### PR TITLE
Add speech-to-text support with continuous batching

### DIFF
--- a/coordinator/internal/api/consumer.go
+++ b/coordinator/internal/api/consumer.go
@@ -363,63 +363,52 @@ func (s *Server) handleTranscriptions(w http.ResponseWriter, r *http.Request) {
 
 	bodyJSON, _ := json.Marshal(transcriptionBody)
 
-	// E2E encrypt the audio payload if the provider has a public key.
-	// Audio data (someone's voice) is at least as sensitive as text prompts.
-	var wireMsg map[string]any
-	var sessionKeys *e2e.SessionKeys
-
-	if provider.PublicKey != "" {
-		providerPubKey, err := e2e.ParsePublicKey(provider.PublicKey)
-		if err != nil {
-			s.logger.Warn("provider public key invalid, sending unencrypted",
-				"provider_id", provider.ID, "error", err)
-			wireMsg = map[string]any{
-				"type":       protocol.TypeTranscriptionRequest,
-				"request_id": requestID,
-				"body":       json.RawMessage(bodyJSON),
-			}
-		} else {
-			session, err := e2e.GenerateSessionKeys()
-			if err != nil {
-				s.logger.Error("failed to generate session keys for transcription", "error", err)
-				wireMsg = map[string]any{
-					"type":       protocol.TypeTranscriptionRequest,
-					"request_id": requestID,
-					"body":       json.RawMessage(bodyJSON),
-				}
-			} else {
-				sessionKeys = session
-				encrypted, err := e2e.Encrypt(bodyJSON, providerPubKey, session)
-				if err != nil {
-					s.logger.Error("failed to encrypt transcription request", "error", err)
-					wireMsg = map[string]any{
-						"type":       protocol.TypeTranscriptionRequest,
-						"request_id": requestID,
-						"body":       json.RawMessage(bodyJSON),
-					}
-				} else {
-					wireMsg = map[string]any{
-						"type":       protocol.TypeTranscriptionRequest,
-						"request_id": requestID,
-						"encrypted_body": map[string]string{
-							"ephemeral_public_key": encrypted.EphemeralPublicKey,
-							"ciphertext":           encrypted.Ciphertext,
-						},
-					}
-					s.logger.Debug("transcription request encrypted for provider",
-						"request_id", requestID,
-						"provider_id", provider.ID,
-					)
-				}
-			}
-		}
-	} else {
-		wireMsg = map[string]any{
-			"type":       protocol.TypeTranscriptionRequest,
-			"request_id": requestID,
-			"body":       json.RawMessage(bodyJSON),
-		}
+	// E2E encryption is mandatory for audio data. Providers without a public
+	// key cannot receive transcription requests.
+	if provider.PublicKey == "" {
+		s.registry.SetProviderIdle(provider.ID)
+		writeJSON(w, http.StatusServiceUnavailable, errorResponse("encryption_required",
+			"no provider with E2E encryption available for this model — audio data requires encryption"))
+		return
 	}
+
+	providerPubKey, err := e2e.ParsePublicKey(provider.PublicKey)
+	if err != nil {
+		s.registry.SetProviderIdle(provider.ID)
+		writeJSON(w, http.StatusInternalServerError, errorResponse("encryption_error",
+			"provider public key invalid"))
+		return
+	}
+
+	sessionKeys, err := e2e.GenerateSessionKeys()
+	if err != nil {
+		s.registry.SetProviderIdle(provider.ID)
+		writeJSON(w, http.StatusInternalServerError, errorResponse("encryption_error",
+			"failed to generate session keys"))
+		return
+	}
+
+	encrypted, err := e2e.Encrypt(bodyJSON, providerPubKey, sessionKeys)
+	if err != nil {
+		s.registry.SetProviderIdle(provider.ID)
+		writeJSON(w, http.StatusInternalServerError, errorResponse("encryption_error",
+			"failed to encrypt transcription request"))
+		return
+	}
+
+	wireMsg := map[string]any{
+		"type":       protocol.TypeTranscriptionRequest,
+		"request_id": requestID,
+		"encrypted_body": map[string]string{
+			"ephemeral_public_key": encrypted.EphemeralPublicKey,
+			"ciphertext":           encrypted.Ciphertext,
+		},
+	}
+
+	s.logger.Debug("transcription request encrypted for provider",
+		"request_id", requestID,
+		"provider_id", provider.ID,
+	)
 
 	// Create pending request with transcription channel.
 	pr := &registry.PendingRequest{

--- a/coordinator/internal/api/consumer.go
+++ b/coordinator/internal/api/consumer.go
@@ -18,10 +18,12 @@ package api
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
@@ -295,6 +297,147 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 		s.handleStreamingResponse(w, r, pr)
 	} else {
 		s.handleNonStreamingResponse(w, r, pr)
+	}
+}
+
+// handleTranscriptions handles POST /v1/audio/transcriptions.
+//
+// This is the OpenAI-compatible audio transcription endpoint. It accepts
+// multipart/form-data with an audio file and routes it to an STT-capable
+// provider.
+func (s *Server) handleTranscriptions(w http.ResponseWriter, r *http.Request) {
+	// Parse multipart form (max 25MB audio)
+	if err := r.ParseMultipartForm(25 << 20); err != nil {
+		writeJSON(w, http.StatusBadRequest, errorResponse("invalid_request_error", "invalid multipart form: "+err.Error()))
+		return
+	}
+
+	file, header, err := r.FormFile("file")
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, errorResponse("invalid_request_error", "file field is required"))
+		return
+	}
+	defer file.Close()
+
+	model := r.FormValue("model")
+	if model == "" {
+		writeJSON(w, http.StatusBadRequest, errorResponse("invalid_request_error", "model is required"))
+		return
+	}
+
+	language := r.FormValue("language")
+
+	// Read the audio file into memory
+	audioBytes, err := io.ReadAll(file)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, errorResponse("invalid_request_error", "failed to read audio file"))
+		return
+	}
+
+	// Determine audio format from filename extension
+	ext := strings.TrimPrefix(filepath.Ext(header.Filename), ".")
+	if ext == "" {
+		ext = "wav"
+	}
+
+	// Find a provider that serves the requested STT model.
+	provider := s.registry.FindProviderWithTrust(model, "")
+	if provider == nil {
+		writeJSON(w, http.StatusServiceUnavailable, errorResponse("model_not_available",
+			fmt.Sprintf("no provider available for STT model %q", model)))
+		return
+	}
+
+	// Build the transcription request.
+	requestID := uuid.New().String()
+	consumerKey := consumerKeyFromContext(r.Context())
+
+	transcriptionBody := protocol.TranscriptionRequestBody{
+		Model:  model,
+		Audio:  base64.StdEncoding.EncodeToString(audioBytes),
+		Format: ext,
+	}
+	if language != "" {
+		transcriptionBody.Language = &language
+	}
+
+	wireMsg := map[string]any{
+		"type":       protocol.TypeTranscriptionRequest,
+		"request_id": requestID,
+		"body":       transcriptionBody,
+	}
+
+	// Create pending request with transcription channel.
+	pr := &registry.PendingRequest{
+		RequestID:       requestID,
+		ProviderID:      provider.ID,
+		Model:           model,
+		ConsumerKey:     consumerKey,
+		ChunkCh:         make(chan string, 1),
+		CompleteCh:      make(chan protocol.UsageInfo, 1),
+		ErrorCh:         make(chan protocol.InferenceErrorMessage, 1),
+		TranscriptionCh: make(chan *protocol.TranscriptionCompleteMessage, 1),
+	}
+	provider.AddPending(pr)
+
+	// Send the request to the provider.
+	data, err := json.Marshal(wireMsg)
+	if err != nil {
+		provider.RemovePending(requestID)
+		s.registry.SetProviderIdle(provider.ID)
+		writeJSON(w, http.StatusInternalServerError, errorResponse("internal_error", "failed to marshal request"))
+		return
+	}
+	if err := provider.Conn.Write(r.Context(), websocket.MessageText, data); err != nil {
+		provider.RemovePending(requestID)
+		s.registry.SetProviderIdle(provider.ID)
+		s.logger.Error("failed to send transcription request", "request_id", requestID, "error", err)
+		writeJSON(w, http.StatusBadGateway, errorResponse("provider_error", "failed to send request to provider"))
+		return
+	}
+
+	s.logger.Info("transcription request dispatched",
+		"request_id", requestID,
+		"model", model,
+		"provider_id", provider.ID,
+		"audio_size", len(audioBytes),
+		"format", ext,
+	)
+
+	// Cleanup on return.
+	defer func() {
+		provider.RemovePending(requestID)
+		s.registry.SetProviderIdle(provider.ID)
+	}()
+
+	// Wait for the transcription result.
+	ctx, cancel := context.WithTimeout(r.Context(), inferenceTimeout)
+	defer cancel()
+
+	select {
+	case result := <-pr.TranscriptionCh:
+		// Build OpenAI-compatible transcription response.
+		resp := map[string]any{
+			"text": result.Text,
+		}
+		if len(result.Segments) > 0 {
+			resp["segments"] = result.Segments
+		}
+		if result.Language != "" {
+			resp["language"] = result.Language
+		}
+		resp["duration"] = result.Usage.AudioSeconds
+		writeJSON(w, http.StatusOK, resp)
+
+	case errMsg := <-pr.ErrorCh:
+		statusCode := errMsg.StatusCode
+		if statusCode == 0 {
+			statusCode = http.StatusBadGateway
+		}
+		writeJSON(w, statusCode, errorResponse("provider_error", errMsg.Error))
+
+	case <-ctx.Done():
+		writeJSON(w, http.StatusGatewayTimeout, errorResponse("timeout", "transcription request timed out"))
 	}
 }
 

--- a/coordinator/internal/api/consumer.go
+++ b/coordinator/internal/api/consumer.go
@@ -361,10 +361,64 @@ func (s *Server) handleTranscriptions(w http.ResponseWriter, r *http.Request) {
 		transcriptionBody.Language = &language
 	}
 
-	wireMsg := map[string]any{
-		"type":       protocol.TypeTranscriptionRequest,
-		"request_id": requestID,
-		"body":       transcriptionBody,
+	bodyJSON, _ := json.Marshal(transcriptionBody)
+
+	// E2E encrypt the audio payload if the provider has a public key.
+	// Audio data (someone's voice) is at least as sensitive as text prompts.
+	var wireMsg map[string]any
+	var sessionKeys *e2e.SessionKeys
+
+	if provider.PublicKey != "" {
+		providerPubKey, err := e2e.ParsePublicKey(provider.PublicKey)
+		if err != nil {
+			s.logger.Warn("provider public key invalid, sending unencrypted",
+				"provider_id", provider.ID, "error", err)
+			wireMsg = map[string]any{
+				"type":       protocol.TypeTranscriptionRequest,
+				"request_id": requestID,
+				"body":       json.RawMessage(bodyJSON),
+			}
+		} else {
+			session, err := e2e.GenerateSessionKeys()
+			if err != nil {
+				s.logger.Error("failed to generate session keys for transcription", "error", err)
+				wireMsg = map[string]any{
+					"type":       protocol.TypeTranscriptionRequest,
+					"request_id": requestID,
+					"body":       json.RawMessage(bodyJSON),
+				}
+			} else {
+				sessionKeys = session
+				encrypted, err := e2e.Encrypt(bodyJSON, providerPubKey, session)
+				if err != nil {
+					s.logger.Error("failed to encrypt transcription request", "error", err)
+					wireMsg = map[string]any{
+						"type":       protocol.TypeTranscriptionRequest,
+						"request_id": requestID,
+						"body":       json.RawMessage(bodyJSON),
+					}
+				} else {
+					wireMsg = map[string]any{
+						"type":       protocol.TypeTranscriptionRequest,
+						"request_id": requestID,
+						"encrypted_body": map[string]string{
+							"ephemeral_public_key": encrypted.EphemeralPublicKey,
+							"ciphertext":           encrypted.Ciphertext,
+						},
+					}
+					s.logger.Debug("transcription request encrypted for provider",
+						"request_id", requestID,
+						"provider_id", provider.ID,
+					)
+				}
+			}
+		}
+	} else {
+		wireMsg = map[string]any{
+			"type":       protocol.TypeTranscriptionRequest,
+			"request_id": requestID,
+			"body":       json.RawMessage(bodyJSON),
+		}
 	}
 
 	// Create pending request with transcription channel.
@@ -377,6 +431,9 @@ func (s *Server) handleTranscriptions(w http.ResponseWriter, r *http.Request) {
 		CompleteCh:      make(chan protocol.UsageInfo, 1),
 		ErrorCh:         make(chan protocol.InferenceErrorMessage, 1),
 		TranscriptionCh: make(chan *protocol.TranscriptionCompleteMessage, 1),
+	}
+	if sessionKeys != nil {
+		pr.SessionPrivKey = &sessionKeys.PrivateKey
 	}
 	provider.AddPending(pr)
 

--- a/coordinator/internal/api/consumer.go
+++ b/coordinator/internal/api/consumer.go
@@ -142,65 +142,52 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 	}
 	inferenceBody, _ := json.Marshal(plainBody)
 
-	// E2E encrypt the request body if the provider has a public key.
-	// This prevents the provider from reading prompts via MITM on their
-	// own network — only the hardened process can decrypt with its private key.
-	var wireMsg map[string]any
-	var sessionKeys *e2e.SessionKeys
-
-	if provider.PublicKey != "" {
-		providerPubKey, err := e2e.ParsePublicKey(provider.PublicKey)
-		if err != nil {
-			s.logger.Warn("provider public key invalid, sending unencrypted",
-				"provider_id", provider.ID, "error", err)
-			wireMsg = map[string]any{
-				"type":       protocol.TypeInferenceRequest,
-				"request_id": requestID,
-				"body":       json.RawMessage(inferenceBody),
-			}
-		} else {
-			session, err := e2e.GenerateSessionKeys()
-			if err != nil {
-				s.logger.Error("failed to generate session keys", "error", err)
-				wireMsg = map[string]any{
-					"type":       protocol.TypeInferenceRequest,
-					"request_id": requestID,
-					"body":       json.RawMessage(inferenceBody),
-				}
-			} else {
-				sessionKeys = session
-				encrypted, err := e2e.Encrypt(inferenceBody, providerPubKey, session)
-				if err != nil {
-					s.logger.Error("failed to encrypt request", "error", err)
-					wireMsg = map[string]any{
-						"type":       protocol.TypeInferenceRequest,
-						"request_id": requestID,
-						"body":       json.RawMessage(inferenceBody),
-					}
-				} else {
-					wireMsg = map[string]any{
-						"type":       protocol.TypeInferenceRequest,
-						"request_id": requestID,
-						"encrypted_body": map[string]string{
-							"ephemeral_public_key": encrypted.EphemeralPublicKey,
-							"ciphertext":           encrypted.Ciphertext,
-						},
-					}
-					s.logger.Debug("request encrypted for provider",
-						"request_id", requestID,
-						"provider_id", provider.ID,
-					)
-				}
-			}
-		}
-	} else {
-		// No public key — send unencrypted (provider registered without key)
-		wireMsg = map[string]any{
-			"type":       protocol.TypeInferenceRequest,
-			"request_id": requestID,
-			"body":       json.RawMessage(inferenceBody),
-		}
+	// E2E encryption is mandatory. Providers without a public key cannot
+	// receive inference requests — consumer prompts must never travel in plaintext.
+	if provider.PublicKey == "" {
+		s.registry.SetProviderIdle(provider.ID)
+		writeJSON(w, http.StatusServiceUnavailable, errorResponse("encryption_required",
+			"no provider with E2E encryption available for this model — prompt data requires encryption"))
+		return
 	}
+
+	providerPubKey, err := e2e.ParsePublicKey(provider.PublicKey)
+	if err != nil {
+		s.registry.SetProviderIdle(provider.ID)
+		writeJSON(w, http.StatusInternalServerError, errorResponse("encryption_error",
+			"provider public key invalid"))
+		return
+	}
+
+	sessionKeys, err := e2e.GenerateSessionKeys()
+	if err != nil {
+		s.registry.SetProviderIdle(provider.ID)
+		writeJSON(w, http.StatusInternalServerError, errorResponse("encryption_error",
+			"failed to generate session keys"))
+		return
+	}
+
+	encrypted, err := e2e.Encrypt(inferenceBody, providerPubKey, sessionKeys)
+	if err != nil {
+		s.registry.SetProviderIdle(provider.ID)
+		writeJSON(w, http.StatusInternalServerError, errorResponse("encryption_error",
+			"failed to encrypt request"))
+		return
+	}
+
+	wireMsg := map[string]any{
+		"type":       protocol.TypeInferenceRequest,
+		"request_id": requestID,
+		"encrypted_body": map[string]string{
+			"ephemeral_public_key": encrypted.EphemeralPublicKey,
+			"ciphertext":           encrypted.Ciphertext,
+		},
+	}
+
+	s.logger.Debug("request encrypted for provider",
+		"request_id", requestID,
+		"provider_id", provider.ID,
+	)
 
 	// Create pending request channels. These channels connect the provider's
 	// WebSocket read loop to this HTTP handler, allowing chunks to flow from
@@ -215,10 +202,7 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 		CompleteCh:  make(chan protocol.UsageInfo, 1),
 		ErrorCh:     make(chan protocol.InferenceErrorMessage, 1),
 	}
-	// Store session key for decrypting encrypted responses
-	if sessionKeys != nil {
-		pr.SessionPrivKey = &sessionKeys.PrivateKey
-	}
+	pr.SessionPrivKey = &sessionKeys.PrivateKey
 	provider.AddPending(pr)
 
 	// Send the inference request to the provider via WebSocket.

--- a/coordinator/internal/api/consumer_test.go
+++ b/coordinator/internal/api/consumer_test.go
@@ -12,6 +12,9 @@ import (
 	"testing"
 	"time"
 
+	"crypto/rand"
+	"encoding/base64"
+
 	"github.com/dginf/coordinator/internal/protocol"
 	"github.com/dginf/coordinator/internal/registry"
 	"github.com/dginf/coordinator/internal/store"
@@ -199,6 +202,13 @@ func TestCORSPreflight(t *testing.T) {
 	}
 }
 
+// testPublicKeyB64 generates a random 32-byte X25519 public key for tests.
+func testPublicKeyB64() string {
+	key := make([]byte, 32)
+	rand.Read(key)
+	return base64.StdEncoding.EncodeToString(key)
+}
+
 // TestStreamingE2E sets up a full end-to-end streaming test with a simulated
 // provider connected via WebSocket.
 func TestStreamingE2E(t *testing.T) {
@@ -222,7 +232,7 @@ func TestStreamingE2E(t *testing.T) {
 	}
 	defer conn.Close(websocket.StatusNormalClosure, "")
 
-	// Send register message.
+	// Send register message (with public key — encryption is mandatory).
 	regMsg := protocol.RegisterMessage{
 		Type: protocol.TypeRegister,
 		Hardware: protocol.Hardware{
@@ -233,7 +243,8 @@ func TestStreamingE2E(t *testing.T) {
 		Models: []protocol.ModelInfo{
 			{ID: "test-model", SizeBytes: 1000, ModelType: "test", Quantization: "4bit"},
 		},
-		Backend: "test",
+		Backend:   "test",
+		PublicKey: testPublicKeyB64(),
 	}
 	regData, _ := json.Marshal(regMsg)
 	if err := conn.Write(ctx, websocket.MessageText, regData); err != nil {
@@ -367,12 +378,13 @@ func TestNonStreamingE2E(t *testing.T) {
 	}
 	defer conn.Close(websocket.StatusNormalClosure, "")
 
-	// Register.
+	// Register (with public key — encryption is mandatory).
 	regMsg := protocol.RegisterMessage{
-		Type:    protocol.TypeRegister,
-		Hardware: protocol.Hardware{ChipName: "M3 Max", MemoryGB: 64},
-		Models:  []protocol.ModelInfo{{ID: "test-model", ModelType: "test", Quantization: "4bit"}},
-		Backend: "test",
+		Type:      protocol.TypeRegister,
+		Hardware:  protocol.Hardware{ChipName: "M3 Max", MemoryGB: 64},
+		Models:    []protocol.ModelInfo{{ID: "test-model", ModelType: "test", Quantization: "4bit"}},
+		Backend:   "test",
+		PublicKey: testPublicKeyB64(),
 	}
 	regData, _ := json.Marshal(regMsg)
 	conn.Write(ctx, websocket.MessageText, regData)

--- a/coordinator/internal/api/provider.go
+++ b/coordinator/internal/api/provider.go
@@ -179,6 +179,10 @@ func (s *Server) providerReadLoop(ctx context.Context, conn *websocket.Conn, pro
 			errMsg := msg.Payload.(*protocol.InferenceErrorMessage)
 			s.handleInferenceError(providerID, provider, errMsg)
 
+		case protocol.TypeTranscriptionComplete:
+			tcMsg := msg.Payload.(*protocol.TranscriptionCompleteMessage)
+			s.handleTranscriptionComplete(providerID, provider, tcMsg)
+
 		case protocol.TypeAttestationResponse:
 			respMsg := msg.Payload.(*protocol.AttestationResponseMessage)
 			s.handleAttestationResponse(providerID, provider, respMsg, tracker)
@@ -489,6 +493,9 @@ func (s *Server) handleInferenceError(providerID string, provider *registry.Prov
 	close(pr.ChunkCh)
 	close(pr.CompleteCh)
 	close(pr.ErrorCh)
+	if pr.TranscriptionCh != nil {
+		close(pr.TranscriptionCh)
+	}
 
 	// Record job failure for reputation tracking.
 	s.registry.RecordJobFailure(providerID)
@@ -501,6 +508,42 @@ func (s *Server) handleInferenceError(providerID string, provider *registry.Prov
 		"provider_id", providerID,
 		"error", msg.Error,
 		"status_code", msg.StatusCode,
+	)
+}
+
+func (s *Server) handleTranscriptionComplete(providerID string, provider *registry.Provider, msg *protocol.TranscriptionCompleteMessage) {
+	if provider == nil {
+		s.logger.Warn("transcription complete from unregistered provider", "provider_id", providerID)
+		return
+	}
+	pr := provider.RemovePending(msg.RequestID)
+	if pr == nil {
+		s.logger.Warn("transcription complete for unknown request", "provider_id", providerID, "request_id", msg.RequestID)
+		return
+	}
+
+	// Send the full transcription result to the waiting handler.
+	if pr.TranscriptionCh != nil {
+		select {
+		case pr.TranscriptionCh <- msg:
+		default:
+			s.logger.Warn("dropped transcription result, consumer channel full", "request_id", msg.RequestID)
+		}
+	}
+
+	// Record job success.
+	s.registry.RecordJobSuccess(providerID, time.Duration(msg.DurationSecs*float64(time.Second)))
+
+	// Mark provider idle.
+	s.registry.SetProviderIdle(providerID)
+
+	s.logger.Info("transcription complete",
+		"request_id", msg.RequestID,
+		"provider_id", providerID,
+		"audio_seconds", msg.Usage.AudioSeconds,
+		"generation_tokens", msg.Usage.GenerationTokens,
+		"duration_secs", msg.DurationSecs,
+		"text_length", len(msg.Text),
 	)
 }
 

--- a/coordinator/internal/api/provider_test.go
+++ b/coordinator/internal/api/provider_test.go
@@ -164,12 +164,13 @@ func TestProviderInferenceError(t *testing.T) {
 	}
 	defer conn.Close(websocket.StatusNormalClosure, "")
 
-	// Register.
+	// Register (with public key — encryption is mandatory).
 	regMsg := protocol.RegisterMessage{
-		Type:    protocol.TypeRegister,
-		Hardware: protocol.Hardware{ChipName: "M3 Max", MemoryGB: 64},
-		Models:  []protocol.ModelInfo{{ID: "error-model", ModelType: "test", Quantization: "4bit"}},
-		Backend: "test",
+		Type:      protocol.TypeRegister,
+		Hardware:  protocol.Hardware{ChipName: "M3 Max", MemoryGB: 64},
+		Models:    []protocol.ModelInfo{{ID: "error-model", ModelType: "test", Quantization: "4bit"}},
+		Backend:   "test",
+		PublicKey: "fX6XYH7p2hmM3ogeXaAsY+p8M6UKD1df/LJUN9Nj9Nw=",
 	}
 	regData, _ := json.Marshal(regMsg)
 	conn.Write(ctx, websocket.MessageText, regData)
@@ -711,6 +712,7 @@ func TestTrustLevelInResponseHeaders(t *testing.T) {
 		Hardware:    protocol.Hardware{ChipName: "Apple M3 Max", MemoryGB: 64},
 		Models:      []protocol.ModelInfo{{ID: "trust-model", ModelType: "test", Quantization: "4bit"}},
 		Backend:     "test",
+		PublicKey:   "fX6XYH7p2hmM3ogeXaAsY+p8M6UKD1df/LJUN9Nj9Nw=",
 		Attestation: attestationJSON,
 	}
 	regData, _ := json.Marshal(regMsg)
@@ -718,6 +720,8 @@ func TestTrustLevelInResponseHeaders(t *testing.T) {
 	time.Sleep(200 * time.Millisecond)
 
 	// Provider goroutine — respond with completion.
+	// Note: with mandatory E2E encryption, the request body arrives encrypted.
+	// For this test we just parse the wire message to get the request_id.
 	go func() {
 		_, data, err := conn.Read(ctx)
 		if err != nil {

--- a/coordinator/internal/api/server.go
+++ b/coordinator/internal/api/server.go
@@ -125,6 +125,7 @@ func (s *Server) routes() {
 
 	// Consumer endpoints — API key auth required.
 	s.mux.HandleFunc("POST /v1/chat/completions", s.requireAuth(s.handleChatCompletions))
+	s.mux.HandleFunc("POST /v1/audio/transcriptions", s.requireAuth(s.handleTranscriptions))
 	s.mux.HandleFunc("GET /v1/models", s.requireAuth(s.handleListModels))
 
 	// MDM webhook — MicroMDM sends command responses here.

--- a/coordinator/internal/protocol/messages.go
+++ b/coordinator/internal/protocol/messages.go
@@ -33,11 +33,13 @@ const (
 	TypeInferenceComplete     = "inference_complete"
 	TypeInferenceError        = "inference_error"
 	TypeAttestationResponse   = "attestation_response"
+	TypeTranscriptionComplete = "transcription_complete"
 
 	// Coordinator → Provider
-	TypeInferenceRequest      = "inference_request"
-	TypeCancel                = "cancel"
-	TypeAttestationChallenge  = "attestation_challenge"
+	TypeInferenceRequest        = "inference_request"
+	TypeCancel                  = "cancel"
+	TypeAttestationChallenge    = "attestation_challenge"
+	TypeTranscriptionRequest    = "transcription_request"
 )
 
 // ---------------------------------------------------------------------------
@@ -209,6 +211,49 @@ type AttestationResponseMessage struct {
 }
 
 // ---------------------------------------------------------------------------
+// STT (Speech-to-Text) messages
+// ---------------------------------------------------------------------------
+
+// TranscriptionRequestBody is the body sent inside a TranscriptionRequest.
+type TranscriptionRequestBody struct {
+	Model    string  `json:"model"`
+	Audio    string  `json:"audio"`              // base64-encoded audio data
+	Language *string `json:"language,omitempty"`  // ISO 639-1 language code (e.g. "en")
+	Format   string  `json:"format,omitempty"`    // audio format hint: "mp3", "wav", etc.
+}
+
+// TranscriptionRequestMessage tells a provider to transcribe audio.
+type TranscriptionRequestMessage struct {
+	Type      string                   `json:"type"`
+	RequestID string                   `json:"request_id"`
+	Body      TranscriptionRequestBody `json:"body"`
+}
+
+// TranscriptionSegment is a timed segment within a transcription.
+type TranscriptionSegment struct {
+	Start float64 `json:"start"`
+	End   float64 `json:"end"`
+	Text  string  `json:"text"`
+}
+
+// TranscriptionUsage carries usage info for billing STT requests.
+type TranscriptionUsage struct {
+	AudioSeconds     float64 `json:"audio_seconds"`
+	GenerationTokens int     `json:"generation_tokens"`
+}
+
+// TranscriptionCompleteMessage signals the provider finished transcribing.
+type TranscriptionCompleteMessage struct {
+	Type         string                 `json:"type"`
+	RequestID    string                 `json:"request_id"`
+	Text         string                 `json:"text"`
+	Segments     []TranscriptionSegment `json:"segments,omitempty"`
+	Language     string                 `json:"language,omitempty"`
+	Usage        TranscriptionUsage     `json:"usage"`
+	DurationSecs float64               `json:"duration_secs"` // processing time
+}
+
+// ---------------------------------------------------------------------------
 // Envelope: generic unmarshalling for provider messages
 // ---------------------------------------------------------------------------
 
@@ -270,6 +315,13 @@ func (pm *ProviderMessage) UnmarshalJSON(data []byte) error {
 		var msg AttestationResponseMessage
 		if err := json.Unmarshal(data, &msg); err != nil {
 			return fmt.Errorf("protocol: failed to unmarshal attestation_response: %w", err)
+		}
+		pm.Payload = &msg
+
+	case TypeTranscriptionComplete:
+		var msg TranscriptionCompleteMessage
+		if err := json.Unmarshal(data, &msg); err != nil {
+			return fmt.Errorf("protocol: failed to unmarshal transcription_complete: %w", err)
 		}
 		pm.Payload = &msg
 

--- a/coordinator/internal/protocol/messages.go
+++ b/coordinator/internal/protocol/messages.go
@@ -223,10 +223,13 @@ type TranscriptionRequestBody struct {
 }
 
 // TranscriptionRequestMessage tells a provider to transcribe audio.
+// When E2E encryption is enabled, Body is empty and EncryptedBody contains
+// the NaCl Box encrypted request (same as InferenceRequestMessage).
 type TranscriptionRequestMessage struct {
-	Type      string                   `json:"type"`
-	RequestID string                   `json:"request_id"`
-	Body      TranscriptionRequestBody `json:"body"`
+	Type          string                   `json:"type"`
+	RequestID     string                   `json:"request_id"`
+	Body          TranscriptionRequestBody `json:"body,omitempty"`
+	EncryptedBody *EncryptedPayload        `json:"encrypted_body,omitempty"`
 }
 
 // TranscriptionSegment is a timed segment within a transcription.

--- a/coordinator/internal/registry/registry.go
+++ b/coordinator/internal/registry/registry.go
@@ -60,6 +60,9 @@ type PendingRequest struct {
 	SessionPrivKey *[32]byte               // E2E session private key for decrypting responses
 	SESignature    string                  // SE signature over response hash
 	ResponseHash   string                  // SHA-256 of response data
+
+	// STT transcription result (nil for inference requests)
+	TranscriptionCh chan *protocol.TranscriptionCompleteMessage
 }
 
 // Provider represents a connected provider agent.

--- a/provider/Cargo.toml
+++ b/provider/Cargo.toml
@@ -26,7 +26,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 
 # HTTP client (for backend health checks + proxying)
-reqwest = { version = "0.12", features = ["json", "stream"] }
+reqwest = { version = "0.12", features = ["json", "stream", "multipart"] }
 
 # WebSocket client
 tokio-tungstenite = { version = "0.26", features = ["native-tls"] }

--- a/provider/src/coordinator.rs
+++ b/provider/src/coordinator.rs
@@ -260,12 +260,35 @@ impl CoordinatorClient {
                                         body: decrypted_body,
                                     }).await;
                                 }
-                                Ok(CoordinatorMessage::TranscriptionRequest { request_id, body }) => {
+                                Ok(CoordinatorMessage::TranscriptionRequest { request_id, body, encrypted_body }) => {
                                     tracing::info!("Received transcription request: {request_id}");
-                                    let _ = event_tx.send(CoordinatorEvent::TranscriptionRequest {
-                                        request_id,
-                                        body,
-                                    }).await;
+
+                                    // Decrypt E2E encrypted body if present
+                                    let decrypted_body = if let Some(enc) = encrypted_body {
+                                        tracing::info!("Decrypting E2E encrypted transcription request");
+                                        match decrypt_request_body(&enc, self.public_key.as_deref()) {
+                                            Ok(b) => b,
+                                            Err(e) => {
+                                                tracing::error!("Failed to decrypt transcription request: {e}");
+                                                continue;
+                                            }
+                                        }
+                                    } else {
+                                        body
+                                    };
+
+                                    // Parse the transcription body
+                                    match serde_json::from_value::<TranscriptionRequestBody>(decrypted_body) {
+                                        Ok(parsed_body) => {
+                                            let _ = event_tx.send(CoordinatorEvent::TranscriptionRequest {
+                                                request_id,
+                                                body: parsed_body,
+                                            }).await;
+                                        }
+                                        Err(e) => {
+                                            tracing::error!("Failed to parse transcription body: {e}");
+                                        }
+                                    }
                                 }
                                 Ok(CoordinatorMessage::Cancel { request_id }) => {
                                     tracing::info!("Received cancel for: {request_id}");

--- a/provider/src/coordinator.rs
+++ b/provider/src/coordinator.rs
@@ -24,6 +24,7 @@ use crate::hardware::HardwareInfo;
 use crate::models::ModelInfo;
 use crate::protocol::{
     CoordinatorMessage, ProviderMessage, ProviderStats, ProviderStatus,
+    TranscriptionRequestBody,
 };
 
 /// Messages from coordinator connection to the main loop.
@@ -34,6 +35,10 @@ pub enum CoordinatorEvent {
     InferenceRequest {
         request_id: String,
         body: serde_json::Value,
+    },
+    TranscriptionRequest {
+        request_id: String,
+        body: TranscriptionRequestBody,
     },
     Cancel {
         request_id: String,
@@ -253,6 +258,13 @@ impl CoordinatorClient {
                                     let _ = event_tx.send(CoordinatorEvent::InferenceRequest {
                                         request_id,
                                         body: decrypted_body,
+                                    }).await;
+                                }
+                                Ok(CoordinatorMessage::TranscriptionRequest { request_id, body }) => {
+                                    tracing::info!("Received transcription request: {request_id}");
+                                    let _ = event_tx.send(CoordinatorEvent::TranscriptionRequest {
+                                        request_id,
+                                        body,
                                     }).await;
                                 }
                                 Ok(CoordinatorMessage::Cancel { request_id }) => {

--- a/provider/src/main.rs
+++ b/provider/src/main.rs
@@ -641,6 +641,61 @@ async fn cmd_serve(
     let backend_url = backend_url_str.clone();
     tracing::info!("Backend URL: {backend_url}");
 
+    // Start STT backend (continuous-batching stt_server.py) on be_port + 1 if available.
+    // Set DGINF_STT_MODEL to a local path or HuggingFace repo ID to enable STT.
+    let stt_port = be_port + 1;
+    let stt_model_id = std::env::var("DGINF_STT_MODEL")
+        .unwrap_or_default();
+    let stt_available = if !stt_model_id.is_empty() {
+        tracing::info!("Starting STT backend on port {stt_port} for model: {stt_model_id}");
+
+        // Find stt_server.py relative to the binary or in standard locations
+        let stt_server_script = find_stt_server_script();
+        if stt_server_script.is_none() {
+            tracing::warn!("stt_server.py not found — STT will not be available");
+            false
+        } else {
+            let script = stt_server_script.unwrap();
+            let stt_result = std::process::Command::new(&python_cmd)
+                .args([
+                    &script,
+                    "--model", &stt_model_id,
+                    "--port", &stt_port.to_string(),
+                    "--host", "127.0.0.1",
+                    "--max-batch-size", "16",
+                    "--max-wait-ms", "100",
+                ])
+                .stdout(std::process::Stdio::inherit())
+                .stderr(std::process::Stdio::inherit())
+                .spawn();
+            match stt_result {
+                Ok(child) => {
+                    tracing::info!("STT server started (PID: {:?}) on port {stt_port}", child.id());
+                    // Wait for STT backend to be ready (model loading can take a few seconds)
+                    let stt_url = format!("http://127.0.0.1:{stt_port}");
+                    for i in 0..30 {
+                        tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+                        if backend::check_health(&stt_url).await {
+                            tracing::info!("STT backend ready after {}s", (i + 1) * 2);
+                            break;
+                        }
+                        if i == 29 {
+                            tracing::warn!("STT backend health check timed out after 60s");
+                        }
+                    }
+                    true
+                }
+                Err(e) => {
+                    tracing::warn!("Failed to start STT backend: {e} — STT will not be available");
+                    false
+                }
+            }
+        }
+    } else {
+        tracing::info!("No STT model configured (set DGINF_STT_MODEL to enable)");
+        false
+    };
+
     if local {
         // Local-only mode: just start the HTTP server
         tracing::info!("Local-only mode on port {port}");
@@ -654,12 +709,25 @@ async fn cmd_serve(
         // Advertising all cached models causes routing failures when the
         // coordinator sends requests for a model that isn't loaded.
         let all_models = models::scan_models(&hw);
-        let available_models: Vec<_> = all_models
+        let mut available_models: Vec<_> = all_models
             .into_iter()
             .filter(|m| m.id == model)
             .collect();
         if available_models.is_empty() {
             tracing::warn!("Active model {model} not found in scanned models — registering with ID only");
+        }
+
+        // Advertise STT model if available
+        if stt_available && !stt_model_id.is_empty() {
+            available_models.push(models::ModelInfo {
+                id: stt_model_id.clone(),
+                model_type: Some("stt".to_string()),
+                parameters: None,
+                quantization: None,
+                size_bytes: 0,
+                estimated_memory_gb: 4.0,
+            });
+            tracing::info!("Advertising STT model: {stt_model_id}");
         }
         let (event_tx, mut event_rx) = tokio::sync::mpsc::channel(64);
         let (outbound_tx, outbound_rx) = tokio::sync::mpsc::channel(64);
@@ -878,6 +946,28 @@ async fn cmd_serve(
 
                                 inflight.insert(request_id, (cancel_token, handle));
                             }
+                            coordinator::CoordinatorEvent::TranscriptionRequest { request_id, body } => {
+                                last_request_time = tokio::time::Instant::now();
+
+                                let tx = outbound_tx.clone();
+                                let cancel_token = CancellationToken::new();
+                                let token_clone = cancel_token.clone();
+                                let done_tx = done_tx.clone();
+                                let rid = request_id.clone();
+                                let stt_url = proxy_backend_url.clone().replace(
+                                    &format!(":{}", be_port),
+                                    &format!(":{}", be_port + 1),
+                                );
+
+                                let handle = tokio::spawn(async move {
+                                    proxy::handle_transcription_request(
+                                        rid.clone(), body, stt_url, tx, token_clone,
+                                    ).await;
+                                    let _ = done_tx.send(rid).await;
+                                });
+
+                                inflight.insert(request_id, (cancel_token, handle));
+                            }
                             coordinator::CoordinatorEvent::Cancel { request_id } => {
                                 if let Some((token, _handle)) = inflight.remove(&request_id) {
                                     tracing::info!("Cancelling request {request_id}");
@@ -1082,6 +1172,28 @@ async fn handle_inprocess_request(
 /// regenerated. This avoids providers registering with unverifiable attestations.
 ///
 /// Returns None if the CLI tool is not available or fails (graceful degradation).
+/// Find the stt_server.py script in standard locations.
+fn find_stt_server_script() -> Option<String> {
+    let candidates = [
+        // Next to the binary
+        std::env::current_exe()
+            .ok()
+            .and_then(|p| p.parent().map(|d| d.join("stt_server.py")))
+            .unwrap_or_default(),
+        // In the provider source directory (development)
+        std::path::PathBuf::from("stt_server.py"),
+        // In ~/.dginf
+        dirs::home_dir().unwrap_or_default().join(".dginf/stt_server.py"),
+    ];
+
+    for path in &candidates {
+        if path.exists() {
+            return Some(path.to_string_lossy().to_string());
+        }
+    }
+    None
+}
+
 fn generate_attestation(encryption_key_base64: &str, binary_hash: Option<&str>) -> Option<Box<serde_json::value::RawValue>> {
     // Look for the enclave CLI binary in common locations
     // Check ~/.dginf/bin first (standard install location)

--- a/provider/src/protocol.rs
+++ b/provider/src/protocol.rs
@@ -117,7 +117,11 @@ pub enum CoordinatorMessage {
     /// Transcription request — provider should transcribe the audio data.
     TranscriptionRequest {
         request_id: String,
-        body: TranscriptionRequestBody,
+        #[serde(default)]
+        body: serde_json::Value,
+        /// E2E encrypted transcription body — same encryption as inference requests
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        encrypted_body: Option<EncryptedPayload>,
     },
     Cancel {
         request_id: String,
@@ -549,14 +553,16 @@ mod tests {
 
     #[test]
     fn test_transcription_request_roundtrip() {
+        let body = serde_json::json!({
+            "model": "CohereLabs/cohere-transcribe",
+            "audio": "SGVsbG8=",
+            "language": "en",
+            "format": "wav"
+        });
         let msg = CoordinatorMessage::TranscriptionRequest {
             request_id: "stt-123".to_string(),
-            body: TranscriptionRequestBody {
-                model: "CohereLabs/cohere-transcribe".to_string(),
-                audio: "SGVsbG8=".to_string(),
-                language: Some("en".to_string()),
-                format: "wav".to_string(),
-            },
+            body,
+            encrypted_body: None,
         };
 
         let json = serde_json::to_string(&msg).unwrap();
@@ -597,16 +603,31 @@ mod tests {
 
     #[test]
     fn test_deserialize_transcription_request_from_go_json() {
-        // This is the JSON format that Go coordinator would produce
+        // This is the JSON format that Go coordinator would produce (plaintext)
         let raw = r#"{"type":"transcription_request","request_id":"go-req-1","body":{"model":"cohere-transcribe","audio":"dGVzdA==","language":"en","format":"mp3"}}"#;
         let msg: CoordinatorMessage = serde_json::from_str(raw).unwrap();
         match msg {
-            CoordinatorMessage::TranscriptionRequest { request_id, body } => {
+            CoordinatorMessage::TranscriptionRequest { request_id, body, encrypted_body } => {
                 assert_eq!(request_id, "go-req-1");
-                assert_eq!(body.model, "cohere-transcribe");
-                assert_eq!(body.audio, "dGVzdA==");
-                assert_eq!(body.language, Some("en".to_string()));
-                assert_eq!(body.format, "mp3");
+                assert_eq!(body["model"], "cohere-transcribe");
+                assert_eq!(body["audio"], "dGVzdA==");
+                assert!(encrypted_body.is_none());
+            }
+            _ => panic!("expected TranscriptionRequest"),
+        }
+    }
+
+    #[test]
+    fn test_deserialize_transcription_request_encrypted() {
+        // When E2E encrypted, body is empty and encrypted_body is present
+        let raw = r#"{"type":"transcription_request","request_id":"enc-1","encrypted_body":{"ephemeral_public_key":"a2V5","ciphertext":"Y2lwaGVy"}}"#;
+        let msg: CoordinatorMessage = serde_json::from_str(raw).unwrap();
+        match msg {
+            CoordinatorMessage::TranscriptionRequest { request_id, encrypted_body, .. } => {
+                assert_eq!(request_id, "enc-1");
+                let enc = encrypted_body.unwrap();
+                assert_eq!(enc.ephemeral_public_key, "a2V5");
+                assert_eq!(enc.ciphertext, "Y2lwaGVy");
             }
             _ => panic!("expected TranscriptionRequest"),
         }

--- a/provider/src/protocol.rs
+++ b/provider/src/protocol.rs
@@ -73,6 +73,18 @@ pub enum ProviderMessage {
         error: String,
         status_code: u16,
     },
+    /// Transcription result — full text and optional segments.
+    TranscriptionComplete {
+        request_id: String,
+        text: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        segments: Option<Vec<TranscriptionSegment>>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        language: Option<String>,
+        usage: TranscriptionUsage,
+        /// Processing time in seconds.
+        duration_secs: f64,
+    },
     /// Response to an attestation challenge from the coordinator.
     /// Includes a fresh SIP status check — the coordinator verifies this
     /// hasn't changed since registration.
@@ -102,6 +114,11 @@ pub enum CoordinatorMessage {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         encrypted_body: Option<EncryptedPayload>,
     },
+    /// Transcription request — provider should transcribe the audio data.
+    TranscriptionRequest {
+        request_id: String,
+        body: TranscriptionRequestBody,
+    },
     Cancel {
         request_id: String,
     },
@@ -110,6 +127,20 @@ pub enum CoordinatorMessage {
         nonce: String,
         timestamp: String,
     },
+}
+
+/// Body of a transcription request from the coordinator.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct TranscriptionRequestBody {
+    pub model: String,
+    /// Base64-encoded audio data.
+    pub audio: String,
+    /// ISO 639-1 language code (e.g. "en"). Optional — model may auto-detect.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub language: Option<String>,
+    /// Audio format hint: "mp3", "wav", "webm", etc.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub format: String,
 }
 
 /// NaCl Box encrypted payload for E2E encryption.
@@ -157,6 +188,21 @@ impl Default for ProviderStats {
 pub struct UsageInfo {
     pub prompt_tokens: u64,
     pub completion_tokens: u64,
+}
+
+/// A timed segment within a transcription result.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct TranscriptionSegment {
+    pub start: f64,
+    pub end: f64,
+    pub text: String,
+}
+
+/// Usage info for billing STT requests.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct TranscriptionUsage {
+    pub audio_seconds: f64,
+    pub generation_tokens: u64,
 }
 
 #[cfg(test)]
@@ -498,6 +544,71 @@ mod tests {
                 assert_eq!(timestamp, "2025-06-01T00:00:00Z");
             }
             _ => panic!("expected AttestationChallenge"),
+        }
+    }
+
+    #[test]
+    fn test_transcription_request_roundtrip() {
+        let msg = CoordinatorMessage::TranscriptionRequest {
+            request_id: "stt-123".to_string(),
+            body: TranscriptionRequestBody {
+                model: "CohereLabs/cohere-transcribe".to_string(),
+                audio: "SGVsbG8=".to_string(),
+                language: Some("en".to_string()),
+                format: "wav".to_string(),
+            },
+        };
+
+        let json = serde_json::to_string(&msg).unwrap();
+        assert!(json.contains("\"type\":\"transcription_request\""));
+        assert!(json.contains("\"request_id\":\"stt-123\""));
+        assert!(json.contains("\"model\":\"CohereLabs/cohere-transcribe\""));
+        assert!(json.contains("\"audio\":\"SGVsbG8=\""));
+        let deserialized: CoordinatorMessage = serde_json::from_str(&json).unwrap();
+        assert_eq!(msg, deserialized);
+    }
+
+    #[test]
+    fn test_transcription_complete_roundtrip() {
+        let msg = ProviderMessage::TranscriptionComplete {
+            request_id: "stt-456".to_string(),
+            text: "Hello world".to_string(),
+            segments: Some(vec![TranscriptionSegment {
+                start: 0.0,
+                end: 5.0,
+                text: "Hello world".to_string(),
+            }]),
+            language: Some("en".to_string()),
+            usage: TranscriptionUsage {
+                audio_seconds: 5.0,
+                generation_tokens: 10,
+            },
+            duration_secs: 0.5,
+        };
+
+        let json = serde_json::to_string(&msg).unwrap();
+        assert!(json.contains("\"type\":\"transcription_complete\""));
+        assert!(json.contains("\"text\":\"Hello world\""));
+        assert!(json.contains("\"audio_seconds\":5.0"));
+        assert!(json.contains("\"duration_secs\":0.5"));
+        let deserialized: ProviderMessage = serde_json::from_str(&json).unwrap();
+        assert_eq!(msg, deserialized);
+    }
+
+    #[test]
+    fn test_deserialize_transcription_request_from_go_json() {
+        // This is the JSON format that Go coordinator would produce
+        let raw = r#"{"type":"transcription_request","request_id":"go-req-1","body":{"model":"cohere-transcribe","audio":"dGVzdA==","language":"en","format":"mp3"}}"#;
+        let msg: CoordinatorMessage = serde_json::from_str(raw).unwrap();
+        match msg {
+            CoordinatorMessage::TranscriptionRequest { request_id, body } => {
+                assert_eq!(request_id, "go-req-1");
+                assert_eq!(body.model, "cohere-transcribe");
+                assert_eq!(body.audio, "dGVzdA==");
+                assert_eq!(body.language, Some("en".to_string()));
+                assert_eq!(body.format, "mp3");
+            }
+            _ => panic!("expected TranscriptionRequest"),
         }
     }
 }

--- a/provider/src/proxy.rs
+++ b/provider/src/proxy.rs
@@ -20,7 +20,9 @@ use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 
 use crate::crypto::NodeKeyPair;
-use crate::protocol::{ProviderMessage, UsageInfo};
+use crate::protocol::{
+    ProviderMessage, TranscriptionRequestBody, TranscriptionSegment, TranscriptionUsage, UsageInfo,
+};
 use crate::security;
 
 /// Handle an inference request by forwarding it to the local backend
@@ -338,6 +340,212 @@ async fn handle_streaming_request(
         .ok();
 
     Ok(())
+}
+
+/// Handle a transcription request by forwarding audio to the local STT backend.
+///
+/// Decodes base64 audio, writes it to a temp file, POSTs it as multipart/form-data
+/// to the mlx-audio server's /v1/audio/transcriptions endpoint, and sends the
+/// result back as a TranscriptionComplete message.
+pub async fn handle_transcription_request(
+    request_id: String,
+    body: TranscriptionRequestBody,
+    stt_backend_url: String,
+    outbound_tx: mpsc::Sender<ProviderMessage>,
+    cancel_token: CancellationToken,
+) {
+    let start = std::time::Instant::now();
+
+    let result =
+        do_transcription(&request_id, &body, &stt_backend_url, &outbound_tx, &cancel_token, start).await;
+
+    if let Err(e) = result {
+        if cancel_token.is_cancelled() {
+            tracing::info!("Transcription request {request_id} cancelled");
+        } else {
+            tracing::error!("Transcription request {request_id} failed: {e}");
+            let _ = outbound_tx
+                .send(ProviderMessage::InferenceError {
+                    request_id: request_id.clone(),
+                    error: e.to_string(),
+                    status_code: 500,
+                })
+                .await;
+        }
+    }
+
+    tracing::info!(
+        "Transcription request {request_id} finished in {:.2}s",
+        start.elapsed().as_secs_f64()
+    );
+}
+
+async fn do_transcription(
+    request_id: &str,
+    body: &TranscriptionRequestBody,
+    stt_backend_url: &str,
+    outbound_tx: &mpsc::Sender<ProviderMessage>,
+    cancel_token: &CancellationToken,
+    start: std::time::Instant,
+) -> Result<()> {
+    use base64::Engine;
+
+    // Decode base64 audio
+    let audio_bytes = base64::engine::general_purpose::STANDARD
+        .decode(&body.audio)
+        .context("invalid base64 audio data")?;
+
+    let audio_seconds = estimate_audio_duration(&audio_bytes, &body.format);
+
+    // Determine file extension from format hint
+    let ext = if body.format.is_empty() { "wav" } else { &body.format };
+
+    // Write to temp file for multipart upload
+    let tmp_path = format!("/tmp/dginf-stt-{request_id}.{ext}");
+    tokio::fs::write(&tmp_path, &audio_bytes)
+        .await
+        .context("failed to write temp audio file")?;
+
+    // Build multipart form
+    let file_bytes = tokio::fs::read(&tmp_path)
+        .await
+        .context("failed to read temp audio file")?;
+
+    let file_part = reqwest::multipart::Part::bytes(file_bytes)
+        .file_name(format!("audio.{ext}"))
+        .mime_str(&format!("audio/{ext}"))
+        .unwrap_or_else(|_| {
+            reqwest::multipart::Part::bytes(vec![])
+                .file_name("audio.wav")
+        });
+
+    let mut form = reqwest::multipart::Form::new()
+        .part("file", file_part)
+        .text("model", body.model.clone());
+
+    if let Some(ref lang) = body.language {
+        form = form.text("language", lang.clone());
+    }
+
+    let url = format!("{stt_backend_url}/v1/audio/transcriptions");
+    let client = reqwest::Client::new();
+
+    let response = tokio::select! {
+        result = client.post(&url).multipart(form).send() => {
+            result.context("failed to send transcription request to STT backend")?
+        }
+        _ = cancel_token.cancelled() => {
+            let _ = tokio::fs::remove_file(&tmp_path).await;
+            anyhow::bail!("request cancelled");
+        }
+    };
+
+    // Clean up temp file
+    let _ = tokio::fs::remove_file(&tmp_path).await;
+
+    let status = response.status();
+    if !status.is_success() {
+        let error_body = response.text().await.unwrap_or_default();
+        outbound_tx
+            .send(ProviderMessage::InferenceError {
+                request_id: request_id.to_string(),
+                error: error_body,
+                status_code: status.as_u16(),
+            })
+            .await
+            .ok();
+        return Ok(());
+    }
+
+    // mlx-audio returns NDJSON; read the full response
+    let response_text = response.text().await.context("failed to read STT response")?;
+
+    // Parse the NDJSON response (may have multiple lines)
+    let mut text = String::new();
+    let mut segments = Vec::new();
+    let mut language = None;
+    let mut generation_tokens: u64 = 0;
+
+    for line in response_text.lines() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        if let Ok(json) = serde_json::from_str::<serde_json::Value>(line) {
+            // Full result format
+            if let Some(t) = json.get("text").and_then(|v| v.as_str()) {
+                text = t.to_string();
+            }
+            if let Some(lang) = json.get("language").and_then(|v| v.as_str()) {
+                language = Some(lang.to_string());
+            }
+            if let Some(gt) = json.get("generation_tokens").and_then(|v| v.as_u64()) {
+                generation_tokens = gt;
+            }
+            if let Some(segs) = json.get("segments").and_then(|v| v.as_array()) {
+                for seg in segs {
+                    if let (Some(start), Some(end), Some(seg_text)) = (
+                        seg.get("start").and_then(|v| v.as_f64()),
+                        seg.get("end").and_then(|v| v.as_f64()),
+                        seg.get("text").and_then(|v| v.as_str()),
+                    ) {
+                        segments.push(TranscriptionSegment {
+                            start,
+                            end,
+                            text: seg_text.to_string(),
+                        });
+                    }
+                }
+            }
+        }
+    }
+
+    outbound_tx
+        .send(ProviderMessage::TranscriptionComplete {
+            request_id: request_id.to_string(),
+            text,
+            segments: if segments.is_empty() { None } else { Some(segments) },
+            language,
+            usage: TranscriptionUsage {
+                audio_seconds,
+                generation_tokens,
+            },
+            duration_secs: start.elapsed().as_secs_f64(),
+        })
+        .await
+        .ok();
+
+    Ok(())
+}
+
+/// Estimate audio duration from raw bytes and format.
+/// This is approximate — mainly for billing. Exact duration comes from the STT result.
+fn estimate_audio_duration(bytes: &[u8], format: &str) -> f64 {
+    match format {
+        "wav" => {
+            // WAV: sample_rate at offset 24, bits_per_sample at 34, data starts at 44
+            if bytes.len() > 44 {
+                let sample_rate = u32::from_le_bytes(
+                    bytes[24..28].try_into().unwrap_or([0; 4]),
+                ) as f64;
+                let bits = u16::from_le_bytes(
+                    bytes[34..36].try_into().unwrap_or([0; 2]),
+                ) as f64;
+                let channels = u16::from_le_bytes(
+                    bytes[22..24].try_into().unwrap_or([0; 2]),
+                ) as f64;
+                if sample_rate > 0.0 && bits > 0.0 && channels > 0.0 {
+                    let data_bytes = (bytes.len() - 44) as f64;
+                    return data_bytes / (sample_rate * channels * bits / 8.0);
+                }
+            }
+            0.0
+        }
+        "mp3" => {
+            // Rough estimate: ~128kbps MP3
+            (bytes.len() as f64 * 8.0) / 128_000.0
+        }
+        _ => 0.0,
+    }
 }
 
 /// Extract usage info from a non-streaming response JSON body.

--- a/provider/stt_server.py
+++ b/provider/stt_server.py
@@ -1,0 +1,387 @@
+"""Continuous-batching STT server for DGInf providers.
+
+Keeps the model loaded on GPU, accepts concurrent transcription requests,
+and batches them together for efficient GPU utilization — same pattern
+as vllm-mlx for LLM inference.
+
+Usage:
+    python stt_server.py --model CohereLabs/cohere-transcribe-03-2026 --port 8101
+
+The server exposes:
+    GET  /health                    Health check
+    GET  /v1/models                 List loaded model
+    POST /v1/audio/transcriptions   OpenAI-compatible transcription endpoint
+"""
+
+import argparse
+import asyncio
+import io
+import os
+import sys
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+import numpy as np
+import uvicorn
+from fastapi import FastAPI, File, Form, HTTPException, UploadFile
+from fastapi.responses import JSONResponse
+
+# ---------------------------------------------------------------------------
+# Batching scheduler
+# ---------------------------------------------------------------------------
+
+@dataclass
+class TranscriptionJob:
+    """A single transcription request waiting to be batched."""
+    audio_path: str
+    language: str
+    result_future: asyncio.Future = field(default_factory=lambda: asyncio.get_event_loop().create_future())
+    submitted_at: float = field(default_factory=time.time)
+
+
+class BatchScheduler:
+    """Collects incoming transcription jobs and runs them in GPU batches.
+
+    Jobs accumulate in a queue. The scheduler fires a batch when either:
+      - max_batch_size jobs are waiting, OR
+      - max_wait_ms has elapsed since the first job in the current batch
+
+    This is continuous batching: new requests arriving while a batch is
+    running are queued for the next batch, not blocked.
+    """
+
+    def __init__(
+        self,
+        model,
+        max_batch_size: int = 16,
+        max_wait_ms: float = 50.0,
+    ):
+        self.model = model
+        self.max_batch_size = max_batch_size
+        self.max_wait_ms = max_wait_ms
+        self._queue: asyncio.Queue[TranscriptionJob] = asyncio.Queue()
+        self._running = False
+
+        # Stats
+        self.total_requests = 0
+        self.total_batches = 0
+        self.total_audio_seconds = 0.0
+        self.total_processing_seconds = 0.0
+
+    async def submit(self, job: TranscriptionJob) -> dict:
+        """Submit a job and wait for its result."""
+        await self._queue.put(job)
+        return await job.result_future
+
+    async def run(self):
+        """Main batch processing loop. Call this as a background task."""
+        self._running = True
+        print(f"[BatchScheduler] Started (max_batch={self.max_batch_size}, max_wait={self.max_wait_ms}ms)")
+
+        while self._running:
+            # Wait for at least one job
+            try:
+                first_job = await asyncio.wait_for(self._queue.get(), timeout=1.0)
+            except asyncio.TimeoutError:
+                continue
+
+            # Collect more jobs up to batch size or timeout
+            batch = [first_job]
+            deadline = time.time() + (self.max_wait_ms / 1000.0)
+
+            while len(batch) < self.max_batch_size:
+                remaining = deadline - time.time()
+                if remaining <= 0:
+                    break
+                try:
+                    job = await asyncio.wait_for(self._queue.get(), timeout=remaining)
+                    batch.append(job)
+                except asyncio.TimeoutError:
+                    break
+
+            # Run the batch on GPU
+            await self._process_batch(batch)
+
+    async def _process_batch(self, batch: list[TranscriptionJob]):
+        """Process a batch of jobs through the model."""
+        batch_size = len(batch)
+        self.total_batches += 1
+        self.total_requests += batch_size
+
+        t0 = time.time()
+
+        # Group by language for efficient batching (model requires same language per batch)
+        by_language: dict[str, list[tuple[int, TranscriptionJob]]] = {}
+        for idx, job in enumerate(batch):
+            by_language.setdefault(job.language, []).append((idx, job))
+
+        results = [None] * batch_size
+
+        for language, group in by_language.items():
+            indices = [i for i, _ in group]
+            audio_files = [job.audio_path for _, job in group]
+
+            try:
+                # Run transcription on the thread pool to avoid blocking the event loop
+                # (MLX ops release the GIL during compute)
+                loop = asyncio.get_event_loop()
+                texts = await loop.run_in_executor(
+                    None,
+                    lambda: self.model.transcribe(
+                        language=language,
+                        audio_files=audio_files,
+                        batch_size=self.max_batch_size,
+                    ),
+                )
+
+                for idx, text in zip(indices, texts):
+                    results[idx] = {"text": text, "language": language, "error": None}
+
+            except Exception as e:
+                for idx, _ in group:
+                    results[idx] = {"text": "", "language": language, "error": str(e)}
+
+        elapsed = time.time() - t0
+
+        # Resolve all futures
+        for job, result in zip(batch, results):
+            if not job.result_future.done():
+                if result and result.get("error"):
+                    job.result_future.set_exception(
+                        RuntimeError(result["error"])
+                    )
+                else:
+                    job.result_future.set_result(result)
+
+            # Clean up temp file
+            try:
+                os.remove(job.audio_path)
+            except OSError:
+                pass
+
+        # Update stats
+        self.total_processing_seconds += elapsed
+
+        if batch_size > 1:
+            print(
+                f"[BatchScheduler] Batch of {batch_size} completed in {elapsed:.2f}s "
+                f"({elapsed/batch_size:.2f}s/request, {batch_size/elapsed:.1f} req/s)"
+            )
+        else:
+            print(f"[BatchScheduler] Single request completed in {elapsed:.2f}s")
+
+    def stop(self):
+        self._running = False
+
+
+# ---------------------------------------------------------------------------
+# FastAPI app
+# ---------------------------------------------------------------------------
+
+app = FastAPI(title="DGInf STT Server")
+
+# Global state — set during startup
+_model = None
+_scheduler: Optional[BatchScheduler] = None
+_model_id: str = ""
+_start_time: float = 0.0
+
+
+@app.get("/health")
+async def health():
+    if _model is None:
+        raise HTTPException(status_code=503, detail="model not loaded")
+    return {"status": "ok", "model": _model_id}
+
+
+@app.get("/v1/models")
+async def list_models():
+    return {
+        "object": "list",
+        "data": [
+            {
+                "id": _model_id,
+                "object": "model",
+                "created": int(_start_time),
+                "owned_by": "dginf",
+                "type": "stt",
+            }
+        ],
+    }
+
+
+@app.post("/v1/audio/transcriptions")
+async def transcribe(
+    file: UploadFile = File(...),
+    model: str = Form(...),
+    language: str = Form("en"),
+):
+    """OpenAI-compatible transcription endpoint with continuous batching."""
+    if _scheduler is None:
+        raise HTTPException(status_code=503, detail="server not ready")
+
+    # Read uploaded audio to temp file
+    data = await file.read()
+    ext = Path(file.filename or "audio.wav").suffix or ".wav"
+    tmp_path = f"/tmp/dginf-stt-{id(data)}-{time.monotonic_ns()}{ext}"
+
+    # Write using soundfile to normalize format
+    try:
+        from mlx_audio.audio_io import read as audio_read, write as audio_write
+        buf = io.BytesIO(data)
+        audio, sr = audio_read(buf, always_2d=False)
+        audio_write(tmp_path, audio, sr)
+        audio_seconds = len(audio) / sr if audio.ndim == 1 else audio.shape[0] / sr
+    except Exception:
+        # Fallback: write raw bytes and let the model handle it
+        with open(tmp_path, "wb") as f:
+            f.write(data)
+        audio_seconds = 0.0
+
+    # Submit to batch scheduler
+    job = TranscriptionJob(
+        audio_path=tmp_path,
+        language=language,
+    )
+
+    t0 = time.time()
+    try:
+        result = await _scheduler.submit(job)
+    except Exception as e:
+        # Clean up temp file on error
+        try:
+            os.remove(tmp_path)
+        except OSError:
+            pass
+        raise HTTPException(status_code=500, detail=str(e))
+
+    elapsed = time.time() - t0
+
+    return JSONResponse({
+        "text": result["text"],
+        "language": result.get("language", language),
+        "duration": audio_seconds,
+        "processing_time": elapsed,
+        "model": model,
+    })
+
+
+@app.get("/v1/stats")
+async def stats():
+    """Server statistics for monitoring."""
+    if _scheduler is None:
+        return {"status": "not ready"}
+
+    uptime = time.time() - _start_time
+    return {
+        "uptime_seconds": uptime,
+        "total_requests": _scheduler.total_requests,
+        "total_batches": _scheduler.total_batches,
+        "avg_batch_size": (
+            _scheduler.total_requests / _scheduler.total_batches
+            if _scheduler.total_batches > 0
+            else 0
+        ),
+        "total_processing_seconds": _scheduler.total_processing_seconds,
+        "requests_per_second": (
+            _scheduler.total_requests / uptime if uptime > 0 else 0
+        ),
+        "model": _model_id,
+        "queue_size": _scheduler._queue.qsize(),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Startup
+# ---------------------------------------------------------------------------
+
+def load_model(model_path: str):
+    """Load the STT model and return it."""
+    print(f"[STT Server] Loading model: {model_path}")
+    t0 = time.time()
+
+    # Patch the audio frontend loader for MLX-native models (no torch needed)
+    from mlx_audio.stt.models.cohere_asr import audio as audio_mod
+    from safetensors import safe_open
+    import mlx.core as mx
+
+    orig_load = audio_mod.CohereAudioFrontend.load_buffers_from_checkpoint
+
+    def patched_load(self, mp):
+        safetensor_path = Path(mp) / "model.safetensors"
+        if not safetensor_path.exists():
+            return
+        try:
+            # Try numpy first (works for MLX-converted models)
+            with safe_open(str(safetensor_path), framework="np") as f:
+                keys = set(f.keys())
+                if "preprocessor.featurizer.fb" in keys:
+                    fb = f.get_tensor("preprocessor.featurizer.fb").astype(np.float32)
+                    self.fb = mx.array(fb.squeeze(0) if fb.ndim > 2 else fb).astype(mx.float32)
+                if "preprocessor.featurizer.window" in keys:
+                    window = f.get_tensor("preprocessor.featurizer.window").astype(np.float32)
+                    self.window = mx.array(window).astype(mx.float32)
+        except Exception:
+            # Fall back to original (requires torch)
+            orig_load(self, mp)
+
+    audio_mod.CohereAudioFrontend.load_buffers_from_checkpoint = patched_load
+
+    from mlx_audio.stt.utils import load_model as mlx_load_model
+    model = mlx_load_model(model_path)
+
+    elapsed = time.time() - t0
+    print(f"[STT Server] Model loaded in {elapsed:.1f}s")
+    return model
+
+
+def main():
+    global _model, _scheduler, _model_id, _start_time
+
+    parser = argparse.ArgumentParser(description="DGInf STT Server with continuous batching")
+    parser.add_argument("--model", required=True, help="Model path or HuggingFace repo ID")
+    parser.add_argument("--port", type=int, default=8101, help="Port to listen on")
+    parser.add_argument("--host", default="127.0.0.1", help="Host to bind to")
+    parser.add_argument("--max-batch-size", type=int, default=16, help="Maximum batch size for GPU inference")
+    parser.add_argument("--max-wait-ms", type=float, default=50.0, help="Max ms to wait for batch to fill")
+    args = parser.parse_args()
+
+    _model_id = args.model
+    _start_time = time.time()
+
+    # Load model
+    _model = load_model(args.model)
+
+    # Create scheduler
+    _scheduler = BatchScheduler(
+        model=_model,
+        max_batch_size=args.max_batch_size,
+        max_wait_ms=args.max_wait_ms,
+    )
+
+    # Start scheduler as background task
+    @app.on_event("startup")
+    async def start_scheduler():
+        asyncio.create_task(_scheduler.run())
+
+    @app.on_event("shutdown")
+    async def stop_scheduler():
+        _scheduler.stop()
+
+    print(f"[STT Server] Starting on {args.host}:{args.port}")
+    print(f"[STT Server] Batch config: max_batch_size={args.max_batch_size}, max_wait_ms={args.max_wait_ms}")
+
+    uvicorn.run(
+        app,
+        host=args.host,
+        port=args.port,
+        log_level="info",
+        # Single worker — model is in this process, no need for multiprocessing
+        workers=1,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test-stt-e2e.sh
+++ b/scripts/test-stt-e2e.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# End-to-end test for STT transcription through the d-inference network.
+#
+# Prerequisites:
+#   - mlx-audio server running on port 8001 with a Cohere transcribe model
+#   - coordinator running
+#   - provider connected with STT model advertised
+#
+# This script tests the coordinator's /v1/audio/transcriptions endpoint
+# by sending a short audio clip and verifying the transcription.
+
+set -euo pipefail
+
+COORDINATOR_URL="${COORDINATOR_URL:-http://localhost:8080}"
+API_KEY="${API_KEY:-test-key}"
+AUDIO_FILE="${1:-/tmp/elon_test_30s.wav}"
+MODEL="${2:-CohereLabs/cohere-transcribe-03-2026}"
+
+echo "=== DGInf STT End-to-End Test ==="
+echo "Coordinator: $COORDINATOR_URL"
+echo "Audio file: $AUDIO_FILE"
+echo "Model: $MODEL"
+echo ""
+
+# Check audio file exists
+if [ ! -f "$AUDIO_FILE" ]; then
+    echo "ERROR: Audio file not found: $AUDIO_FILE"
+    exit 1
+fi
+
+echo "Sending transcription request..."
+RESPONSE=$(curl -s -w "\n%{http_code}" \
+    -X POST "$COORDINATOR_URL/v1/audio/transcriptions" \
+    -H "Authorization: Bearer $API_KEY" \
+    -F "file=@$AUDIO_FILE" \
+    -F "model=$MODEL" \
+    -F "language=en")
+
+HTTP_CODE=$(echo "$RESPONSE" | tail -1)
+BODY=$(echo "$RESPONSE" | head -n -1)
+
+echo "HTTP Status: $HTTP_CODE"
+echo ""
+
+if [ "$HTTP_CODE" -eq 200 ]; then
+    echo "=== Transcription Result ==="
+    echo "$BODY" | python3 -m json.tool 2>/dev/null || echo "$BODY"
+    echo ""
+
+    # Extract just the text
+    TEXT=$(echo "$BODY" | python3 -c "import sys,json; print(json.load(sys.stdin).get('text','')[:200])" 2>/dev/null || echo "")
+    if [ -n "$TEXT" ]; then
+        echo "=== First 200 chars ==="
+        echo "$TEXT"
+        echo ""
+        echo "SUCCESS: Transcription received!"
+    fi
+else
+    echo "ERROR: Request failed"
+    echo "$BODY"
+    exit 1
+fi

--- a/web/src/app/api/transcribe/route.ts
+++ b/web/src/app/api/transcribe/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export const runtime = "nodejs";
+
+export async function POST(req: NextRequest) {
+  const defaultCoord =
+    process.env.NEXT_PUBLIC_COORDINATOR_URL ||
+    "https://inference-test.openinnovation.dev";
+  const coordUrl = req.headers.get("x-coordinator-url") || defaultCoord;
+  const apiKey = req.headers.get("x-api-key") || "";
+
+  // Forward the multipart form data directly to the coordinator
+  const formData = await req.formData();
+
+  const upstream = await fetch(`${coordUrl}/v1/audio/transcriptions`, {
+    method: "POST",
+    headers: {
+      ...(apiKey ? { Authorization: `Bearer ${apiKey}` } : {}),
+    },
+    body: formData,
+  });
+
+  if (!upstream.ok) {
+    const text = await upstream.text();
+    return NextResponse.json(
+      { error: text },
+      { status: upstream.status }
+    );
+  }
+
+  const data = await upstream.json();
+  return NextResponse.json(data);
+}

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef, useCallback, useState } from "react";
 import { useStore } from "@/lib/store";
-import { streamChat, fetchModels } from "@/lib/api";
+import { streamChat, fetchModels, transcribeAudio } from "@/lib/api";
 import { useToastStore } from "@/hooks/useToast";
 import { ChatMessage } from "@/components/ChatMessage";
 import { ChatInput } from "@/components/ChatInput";
@@ -25,6 +25,7 @@ export default function ChatPage() {
     appendToThinking,
     updateChatTitle,
     selectedModel,
+    models,
     setModels,
   } = useStore();
 
@@ -32,6 +33,7 @@ export default function ChatPage() {
   const abortRef = useRef<AbortController | null>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
   const [isStreaming, setIsStreaming] = useState(false);
+  const [isTranscribing, setIsTranscribing] = useState(false);
 
   const activeChat = chats.find((c) => c.id === activeChatId);
 
@@ -196,6 +198,94 @@ export default function ChatPage() {
     setIsStreaming(false);
   }, []);
 
+  const handleAudio = useCallback(
+    async (blob: Blob, duration: number) => {
+      let chatId = activeChatId;
+      if (!chatId) {
+        chatId = createChat();
+      }
+
+      const chat = useStore.getState().chats.find((c) => c.id === chatId);
+      if (chat && chat.messages.length === 0) {
+        updateChatTitle(chatId, "Audio transcription");
+      }
+
+      // Create a URL for the audio blob so we can play it back
+      const audioUrl = URL.createObjectURL(blob);
+
+      // Add user message showing audio was sent
+      const userMsg: Message = {
+        id: generateId(),
+        role: "user",
+        content: `[Audio: ${Math.round(duration)}s]`,
+        audioUrl,
+        audioDuration: duration,
+        timestamp: Date.now(),
+      };
+      addMessage(chatId, userMsg);
+
+      // Add assistant placeholder for transcription result
+      const assistantId = generateId();
+      const assistantMsg: Message = {
+        id: assistantId,
+        role: "assistant",
+        content: "",
+        streaming: true,
+        timestamp: Date.now(),
+      };
+      addMessage(chatId, assistantMsg);
+
+      setIsTranscribing(true);
+
+      try {
+        // Find an STT model, or use the selected model
+        const sttModel =
+          models.find((m) => m.model_type === "stt")?.id || selectedModel;
+
+        const result = await transcribeAudio(blob, sttModel);
+
+        updateMessage(chatId, assistantId, {
+          content: result.text,
+          streaming: false,
+        });
+
+        // If we got a transcription, also update the user message with the text
+        if (result.text) {
+          updateMessage(chatId, userMsg.id, {
+            content: result.text,
+            audioUrl,
+            audioDuration: result.duration || duration,
+          });
+          // Update chat title with first bit of transcription
+          const title =
+            result.text.length > 40
+              ? result.text.slice(0, 40) + "..."
+              : result.text;
+          updateChatTitle(chatId, title);
+        }
+      } catch (err) {
+        const msg = (err as Error).message;
+        updateMessage(chatId, assistantId, {
+          content: `Transcription error: ${msg}`,
+          streaming: false,
+        });
+        addToast(`Transcription error: ${msg}`);
+      } finally {
+        setIsTranscribing(false);
+      }
+    },
+    [
+      activeChatId,
+      createChat,
+      addMessage,
+      updateMessage,
+      updateChatTitle,
+      selectedModel,
+      models,
+      addToast,
+    ]
+  );
+
   return (
     <div className="flex flex-col h-full">
       <TopBar />
@@ -247,7 +337,9 @@ export default function ChatPage() {
       <ChatInput
         onSend={handleSend}
         onStop={handleStop}
+        onAudio={handleAudio}
         isStreaming={isStreaming}
+        isTranscribing={isTranscribing}
       />
     </div>
   );

--- a/web/src/components/ChatInput.tsx
+++ b/web/src/components/ChatInput.tsx
@@ -1,28 +1,41 @@
 "use client";
 
 import { useState, useRef, useCallback, useEffect } from "react";
-import { Send, Square, ChevronDown } from "lucide-react";
+import { Send, Square, ChevronDown, Mic, MicOff, Paperclip } from "lucide-react";
 import { useStore } from "@/lib/store";
 
 interface ChatInputProps {
   onSend: (content: string) => void;
   onStop: () => void;
+  onAudio: (blob: Blob, duration: number) => void;
   isStreaming: boolean;
+  isTranscribing: boolean;
 }
 
-export function ChatInput({ onSend, onStop, isStreaming }: ChatInputProps) {
+export function ChatInput({ onSend, onStop, onAudio, isStreaming, isTranscribing }: ChatInputProps) {
   const [input, setInput] = useState("");
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
   const { selectedModel, models, setSelectedModel } = useStore();
   const [modelOpen, setModelOpen] = useState(false);
 
+  // Recording state
+  const [recording, setRecording] = useState(false);
+  const [recordingDuration, setRecordingDuration] = useState(0);
+  const mediaRecorderRef = useRef<MediaRecorder | null>(null);
+  const chunksRef = useRef<Blob[]>([]);
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const startTimeRef = useRef<number>(0);
+
+  const busy = isStreaming || isTranscribing;
+
   const handleSend = useCallback(() => {
     const trimmed = input.trim();
-    if (!trimmed || isStreaming) return;
+    if (!trimmed || busy) return;
     onSend(trimmed);
     setInput("");
     if (textareaRef.current) textareaRef.current.style.height = "auto";
-  }, [input, isStreaming, onSend]);
+  }, [input, busy, onSend]);
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
@@ -50,74 +63,215 @@ export function ChatInput({ onSend, onStop, isStreaming }: ChatInputProps) {
     return () => document.removeEventListener("click", handler);
   }, [modelOpen]);
 
+  // Recording controls
+  const startRecording = useCallback(async () => {
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      const mediaRecorder = new MediaRecorder(stream, {
+        mimeType: MediaRecorder.isTypeSupported("audio/webm;codecs=opus")
+          ? "audio/webm;codecs=opus"
+          : "audio/webm",
+      });
+      mediaRecorderRef.current = mediaRecorder;
+      chunksRef.current = [];
+      startTimeRef.current = Date.now();
+
+      mediaRecorder.ondataavailable = (e) => {
+        if (e.data.size > 0) chunksRef.current.push(e.data);
+      };
+
+      mediaRecorder.onstop = () => {
+        const blob = new Blob(chunksRef.current, { type: "audio/webm" });
+        const duration = (Date.now() - startTimeRef.current) / 1000;
+        stream.getTracks().forEach((t) => t.stop());
+        onAudio(blob, duration);
+      };
+
+      mediaRecorder.start(250); // collect chunks every 250ms
+      setRecording(true);
+      setRecordingDuration(0);
+      timerRef.current = setInterval(() => {
+        setRecordingDuration((Date.now() - startTimeRef.current) / 1000);
+      }, 100);
+    } catch {
+      // Permission denied or no mic
+    }
+  }, [onAudio]);
+
+  const stopRecording = useCallback(() => {
+    if (mediaRecorderRef.current?.state === "recording") {
+      mediaRecorderRef.current.stop();
+    }
+    if (timerRef.current) {
+      clearInterval(timerRef.current);
+      timerRef.current = null;
+    }
+    setRecording(false);
+    setRecordingDuration(0);
+  }, []);
+
+  // File upload handler
+  const handleFileSelect = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const file = e.target.files?.[0];
+      if (!file) return;
+      // Estimate duration from file size (rough: ~128kbps for mp3)
+      const estimatedDuration = (file.size * 8) / 128000;
+      onAudio(file, estimatedDuration);
+      // Reset file input
+      if (fileInputRef.current) fileInputRef.current.value = "";
+    },
+    [onAudio]
+  );
+
   const displayModel = selectedModel
     ? selectedModel.split("/").pop() || selectedModel
     : "Select model";
+
+  const formatDuration = (s: number) => {
+    const m = Math.floor(s / 60);
+    const sec = Math.floor(s % 60);
+    return `${m}:${sec.toString().padStart(2, "0")}`;
+  };
 
   return (
     <div className="border-t border-border-dim bg-bg-secondary/80 backdrop-blur-sm">
       <div className="max-w-3xl mx-auto px-6 py-4">
         <div className="relative flex flex-col gap-2 bg-bg-tertiary border border-border-subtle rounded-xl focus-within:border-accent-purple/40 transition-colors">
+          {/* Recording indicator */}
+          {recording && (
+            <div className="flex items-center gap-3 px-4 pt-3">
+              <span className="w-2.5 h-2.5 rounded-full bg-danger animate-pulse" />
+              <span className="text-sm text-danger font-mono">
+                Recording {formatDuration(recordingDuration)}
+              </span>
+              <button
+                onClick={stopRecording}
+                className="ml-auto text-xs text-text-tertiary hover:text-danger transition-colors"
+              >
+                Stop & Transcribe
+              </button>
+            </div>
+          )}
+
+          {/* Transcribing indicator */}
+          {isTranscribing && (
+            <div className="flex items-center gap-3 px-4 pt-3">
+              <span className="w-2.5 h-2.5 rounded-full bg-accent-purple animate-pulse" />
+              <span className="text-sm text-accent-purple font-mono">
+                Transcribing audio...
+              </span>
+            </div>
+          )}
+
           {/* Textarea */}
-          <textarea
-            ref={textareaRef}
-            value={input}
-            onChange={(e) => setInput(e.target.value)}
-            onKeyDown={handleKeyDown}
-            placeholder="Send a message..."
-            rows={1}
-            className="w-full bg-transparent px-4 pt-3 pb-1 text-text-primary placeholder:text-text-tertiary text-[15px] resize-none outline-none"
-          />
+          {!recording && (
+            <textarea
+              ref={textareaRef}
+              value={input}
+              onChange={(e) => setInput(e.target.value)}
+              onKeyDown={handleKeyDown}
+              placeholder="Send a message or record audio..."
+              rows={1}
+              className="w-full bg-transparent px-4 pt-3 pb-1 text-text-primary placeholder:text-text-tertiary text-[15px] resize-none outline-none"
+            />
+          )}
 
           {/* Bottom bar */}
           <div className="flex items-center justify-between px-3 pb-2.5">
-            {/* Model selector */}
-            <div className="relative">
+            {/* Left: model selector + audio buttons */}
+            <div className="flex items-center gap-1">
+              {/* Model selector */}
+              <div className="relative">
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    setModelOpen(!modelOpen);
+                  }}
+                  className="flex items-center gap-1.5 px-2 py-1 rounded-md text-[11px] font-mono text-text-tertiary hover:text-text-secondary hover:bg-bg-hover transition-all"
+                >
+                  <span className="w-1.5 h-1.5 rounded-full bg-accent-green" />
+                  {displayModel}
+                  <ChevronDown size={10} />
+                </button>
+
+                {modelOpen && models.length > 0 && (
+                  <div className="absolute bottom-full left-0 mb-1 w-72 bg-bg-elevated border border-border-subtle rounded-lg shadow-xl overflow-hidden z-50">
+                    {models.map((m) => {
+                      const name = m.id.split("/").pop() || m.id;
+                      const isStt = m.model_type === "stt";
+                      return (
+                        <button
+                          key={m.id}
+                          onClick={() => {
+                            setSelectedModel(m.id);
+                            setModelOpen(false);
+                          }}
+                          className={`w-full flex items-center gap-2 px-3 py-2 text-left text-sm hover:bg-bg-hover transition-colors ${
+                            selectedModel === m.id
+                              ? "text-accent-green bg-accent-green-dim/20"
+                              : "text-text-secondary"
+                          }`}
+                        >
+                          <span className="flex-1 font-mono text-xs truncate">
+                            {name}
+                          </span>
+                          {isStt && (
+                            <span className="text-[10px] text-accent-purple px-1.5 py-0.5 bg-accent-purple/10 rounded">
+                              STT
+                            </span>
+                          )}
+                          {m.quantization && (
+                            <span className="text-[10px] text-text-tertiary px-1.5 py-0.5 bg-bg-tertiary rounded">
+                              {m.quantization}
+                            </span>
+                          )}
+                        </button>
+                      );
+                    })}
+                  </div>
+                )}
+              </div>
+
+              {/* Audio file upload */}
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept="audio/*"
+                onChange={handleFileSelect}
+                className="hidden"
+              />
               <button
-                onClick={(e) => {
-                  e.stopPropagation();
-                  setModelOpen(!modelOpen);
-                }}
-                className="flex items-center gap-1.5 px-2 py-1 rounded-md text-[11px] font-mono text-text-tertiary hover:text-text-secondary hover:bg-bg-hover transition-all"
+                onClick={() => fileInputRef.current?.click()}
+                disabled={busy || recording}
+                className="flex items-center justify-center w-7 h-7 rounded-md text-text-tertiary hover:text-text-secondary hover:bg-bg-hover disabled:opacity-30 transition-all"
+                title="Upload audio file"
               >
-                <span className="w-1.5 h-1.5 rounded-full bg-accent-green" />
-                {displayModel}
-                <ChevronDown size={10} />
+                <Paperclip size={14} />
               </button>
 
-              {modelOpen && models.length > 0 && (
-                <div className="absolute bottom-full left-0 mb-1 w-72 bg-bg-elevated border border-border-subtle rounded-lg shadow-xl overflow-hidden z-50">
-                  {models.map((m) => {
-                    const name = m.id.split("/").pop() || m.id;
-                    return (
-                      <button
-                        key={m.id}
-                        onClick={() => {
-                          setSelectedModel(m.id);
-                          setModelOpen(false);
-                        }}
-                        className={`w-full flex items-center gap-2 px-3 py-2 text-left text-sm hover:bg-bg-hover transition-colors ${
-                          selectedModel === m.id
-                            ? "text-accent-green bg-accent-green-dim/20"
-                            : "text-text-secondary"
-                        }`}
-                      >
-                        <span className="flex-1 font-mono text-xs truncate">
-                          {name}
-                        </span>
-                        {m.quantization && (
-                          <span className="text-[10px] text-text-tertiary px-1.5 py-0.5 bg-bg-tertiary rounded">
-                            {m.quantization}
-                          </span>
-                        )}
-                      </button>
-                    );
-                  })}
-                </div>
+              {/* Mic button */}
+              {recording ? (
+                <button
+                  onClick={stopRecording}
+                  className="flex items-center justify-center w-7 h-7 rounded-md bg-danger/20 text-danger hover:bg-danger/30 transition-colors"
+                  title="Stop recording"
+                >
+                  <MicOff size={14} />
+                </button>
+              ) : (
+                <button
+                  onClick={startRecording}
+                  disabled={busy}
+                  className="flex items-center justify-center w-7 h-7 rounded-md text-text-tertiary hover:text-accent-purple hover:bg-accent-purple/10 disabled:opacity-30 transition-all"
+                  title="Record audio"
+                >
+                  <Mic size={14} />
+                </button>
               )}
             </div>
 
-            {/* Send / Stop */}
+            {/* Right: Send / Stop */}
             {isStreaming ? (
               <button
                 onClick={onStop}
@@ -128,7 +282,7 @@ export function ChatInput({ onSend, onStop, isStreaming }: ChatInputProps) {
             ) : (
               <button
                 onClick={handleSend}
-                disabled={!input.trim()}
+                disabled={!input.trim() || busy}
                 className="flex items-center justify-center w-8 h-8 rounded-lg bg-accent-purple hover:bg-accent-purple/80 text-white disabled:opacity-30 disabled:hover:bg-accent-purple transition-colors"
               >
                 <Send size={14} />

--- a/web/src/components/ChatMessage.tsx
+++ b/web/src/components/ChatMessage.tsx
@@ -5,7 +5,7 @@ import remarkGfm from "remark-gfm";
 import { TrustBadge } from "./TrustBadge";
 import { VerificationPanel } from "./VerificationPanel";
 import type { Message } from "@/lib/store";
-import { User, Bot, Copy, Check, ChevronRight, Brain } from "lucide-react";
+import { User, Bot, Copy, Check, ChevronRight, Brain, Volume2 } from "lucide-react";
 import { useState, useCallback } from "react";
 
 function CodeBlock({
@@ -147,6 +147,24 @@ export function ChatMessage({ message }: { message: Message }) {
               </span>
               {message.trust && <TrustBadge trust={message.trust} />}
             </div>
+
+            {/* Audio player for messages with audio */}
+            {message.audioUrl && (
+              <div className="flex items-center gap-2 mb-3 px-3 py-2 rounded-lg bg-bg-tertiary border border-border-dim">
+                <Volume2 size={14} className="text-accent-purple shrink-0" />
+                <audio
+                  controls
+                  src={message.audioUrl}
+                  className="h-8 flex-1"
+                  style={{ minWidth: 0 }}
+                />
+                {message.audioDuration != null && (
+                  <span className="text-[10px] font-mono text-text-tertiary shrink-0">
+                    {Math.round(message.audioDuration)}s
+                  </span>
+                )}
+              </div>
+            )}
 
             {/* Thinking block */}
             {hasThinking && (

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -120,6 +120,42 @@ export async function healthCheck(): Promise<{ status: string; providers: number
   return res.json();
 }
 
+export interface TranscriptionResult {
+  text: string;
+  language?: string;
+  duration?: number;
+  segments?: { start: number; end: number; text: string }[];
+}
+
+export async function transcribeAudio(
+  file: File | Blob,
+  model: string,
+  language?: string
+): Promise<TranscriptionResult> {
+  const { apiKey, baseUrl } = getConfig();
+
+  const form = new FormData();
+  form.append("file", file, file instanceof File ? file.name : "recording.wav");
+  form.append("model", model);
+  if (language) form.append("language", language);
+
+  const res = await fetch("/api/transcribe", {
+    method: "POST",
+    headers: {
+      "x-coordinator-url": baseUrl,
+      ...(apiKey ? { "x-api-key": apiKey } : {}),
+    },
+    body: form,
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Transcription failed (${res.status}): ${text}`);
+  }
+
+  return res.json();
+}
+
 export async function streamChat(
   messages: ChatMessage[],
   model: string,

--- a/web/src/lib/store.ts
+++ b/web/src/lib/store.ts
@@ -17,6 +17,9 @@ export interface Message {
   trust?: TrustMetadata;
   streaming?: boolean;
   timestamp: number;
+  // Audio transcription
+  audioUrl?: string;
+  audioDuration?: number;
 }
 
 interface AppState {


### PR DESCRIPTION
## Summary

- Adds full STT pipeline: coordinator API endpoint, provider proxy, continuous-batching Python server, and frontend UI
- Integrates Cohere Transcribe 2B model via mlx-audio on Apple Silicon
- Same architecture as vllm-mlx: Python subprocess handles GPU batching, Rust provider proxies concurrent requests
- Frontend gets mic recording, audio file upload, and inline audio player in chat

## Architecture

```
Browser (record/upload audio)
  → Next.js /api/transcribe (proxy)
    → Coordinator POST /v1/audio/transcriptions (routes to provider)
      → Provider (Rust, WebSocket) → proxy to local STT server
        → stt_server.py (continuous batching on GPU)
          → Cohere Transcribe model via mlx-audio
```

## Performance

| Scenario | Result |
|----------|--------|
| Single 30s clip | 0.35s |
| Batch of 4 | 0.88s (4.5 req/s) |
| Batch of 8 | 1.64s (4.9 req/s) |
| Full 22min file | 10.4s at 409 TPS |
| 10 concurrent vs sequential | 1.82x speedup |

## Changes

**Protocol** (Rust + Go, kept in sync): `TranscriptionRequest`, `TranscriptionComplete`, segments, usage types

**Coordinator** (Go): OpenAI-compatible `POST /v1/audio/transcriptions` multipart endpoint

**Provider** (Rust): `handle_transcription_request()`, STT server lifecycle, model advertisement

**STT Server** (Python): `stt_server.py` with `BatchScheduler` — collects concurrent requests within configurable window, batches on GPU

**Frontend** (Next.js): Mic recording (MediaRecorder API), file upload, audio player, `/api/transcribe` route, auto-detect STT models

## How to use

```bash
# Provider
export DGINF_STT_MODEL="CohereLabs/cohere-transcribe-03-2026"
dginf-provider serve

# Consumer
curl -X POST https://inference-test.openinnovation.dev/v1/audio/transcriptions \
  -H "Authorization: Bearer $KEY" \
  -F "file=@recording.mp3" \
  -F "model=CohereLabs/cohere-transcribe-03-2026"
```

## Test plan

- [x] Cohere model loads and transcribes via mlx-audio (30s clip + 22min file)
- [x] Continuous batching server handles concurrent requests (batch sizes up to 8)
- [x] Protocol JSON roundtrips between Rust and Go (unit tests)
- [x] All 108 Rust provider tests pass
- [x] All Go coordinator tests pass
- [x] Next.js frontend builds clean
- [ ] Full end-to-end: browser → coordinator → provider → STT server
- [ ] Browser audio recording via MediaRecorder
- [ ] Deploy to production coordinator + provider

🤖 Generated with [Claude Code](https://claude.com/claude-code)