### PR TITLE
Add invite code system for coordinator-funded credits

### DIFF
--- a/coordinator/cmd/coordinator/main.go
+++ b/coordinator/cmd/coordinator/main.go
@@ -11,9 +11,10 @@
 // prompt content.
 //
 // Configuration (environment variables):
-//   DGINF_PORT         - HTTP listen port (default: "8080")
-//   DGINF_ADMIN_KEY    - Pre-seeded API key for bootstrapping
-//   DGINF_DATABASE_URL - PostgreSQL connection string (omit for in-memory store)
+//
+//	DGINF_PORT         - HTTP listen port (default: "8080")
+//	DGINF_ADMIN_KEY    - Pre-seeded API key for bootstrapping
+//	DGINF_DATABASE_URL - PostgreSQL connection string (omit for in-memory store)
 //
 // Graceful shutdown: The coordinator handles SIGINT/SIGTERM, stops the
 // eviction loop, and drains active connections with a 15-second deadline.
@@ -97,6 +98,7 @@ func main() {
 	}
 
 	srv := api.NewServer(reg, st, logger)
+	srv.SetAdminKey(adminKey)
 
 	// Configure billing service.
 	//
@@ -108,7 +110,7 @@ func main() {
 		// Solana — primary payment rail
 		SolanaRPCURL:             os.Getenv("DGINF_SOLANA_RPC_URL"),
 		SolanaUSDCMint:           envOr("DGINF_SOLANA_USDC_MINT", "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"), // mainnet USDC
-		SolanaCoordinatorAddress: os.Getenv("DGINF_SOLANA_COORDINATOR_ADDRESS"),                                     // address that receives USDC
+		SolanaCoordinatorAddress: os.Getenv("DGINF_SOLANA_COORDINATOR_ADDRESS"),                                   // address that receives USDC
 
 		// Stripe — present but not activated day-1 (set env vars to enable)
 		StripeSecretKey:     os.Getenv("DGINF_STRIPE_SECRET_KEY"),

--- a/coordinator/internal/api/invite_handlers.go
+++ b/coordinator/internal/api/invite_handlers.go
@@ -1,0 +1,210 @@
+package api
+
+import (
+	"crypto/rand"
+	"crypto/subtle"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/dginf/coordinator/internal/auth"
+	"github.com/dginf/coordinator/internal/store"
+)
+
+// requireAdminKey checks that the request is from an admin (either admin key or Privy admin).
+// Returns true if authorized, false if it wrote an error response.
+func (s *Server) requireAdminKey(w http.ResponseWriter, r *http.Request) bool {
+	// Check 1: Bearer token matches admin key
+	token := extractBearerToken(r)
+	if token != "" && s.adminKey != "" && subtle.ConstantTimeCompare([]byte(token), []byte(s.adminKey)) == 1 {
+		return true
+	}
+
+	// Check 2: Privy admin
+	user := auth.UserFromContext(r.Context())
+	if user != nil && s.isAdmin(user) {
+		return true
+	}
+
+	writeJSON(w, http.StatusForbidden, errorResponse("forbidden", "admin access required"))
+	return false
+}
+
+// handleAdminCreateInviteCode handles POST /v1/admin/invite-codes.
+func (s *Server) handleAdminCreateInviteCode(w http.ResponseWriter, r *http.Request) {
+	if !s.requireAdminKey(w, r) {
+		return
+	}
+
+	var req struct {
+		Code      string  `json:"code"`
+		AmountUSD float64 `json:"amount_usd"`
+		MaxUses   int     `json:"max_uses"`
+		ExpiresAt string  `json:"expires_at,omitempty"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, errorResponse("invalid_request_error", "invalid JSON: "+err.Error()))
+		return
+	}
+
+	if req.AmountUSD <= 0 {
+		writeJSON(w, http.StatusBadRequest, errorResponse("invalid_request_error", "amount_usd must be positive"))
+		return
+	}
+
+	// Auto-generate code if empty
+	code := strings.ToUpper(strings.TrimSpace(req.Code))
+	if code == "" {
+		b := make([]byte, 4)
+		rand.Read(b)
+		code = "INV-" + strings.ToUpper(hex.EncodeToString(b))
+	}
+
+	amountMicroUSD := int64(req.AmountUSD * 1_000_000)
+	if req.MaxUses < 0 {
+		req.MaxUses = 0
+	}
+	if req.MaxUses == 0 {
+		req.MaxUses = 1 // default single-use
+	}
+
+	ic := &store.InviteCode{
+		Code:           code,
+		AmountMicroUSD: amountMicroUSD,
+		MaxUses:        req.MaxUses,
+		Active:         true,
+		CreatedAt:      time.Now(),
+	}
+
+	if req.ExpiresAt != "" {
+		t, err := time.Parse(time.RFC3339, req.ExpiresAt)
+		if err != nil {
+			writeJSON(w, http.StatusBadRequest, errorResponse("invalid_request_error", "invalid expires_at: "+err.Error()))
+			return
+		}
+		ic.ExpiresAt = &t
+	}
+
+	if err := s.store.CreateInviteCode(ic); err != nil {
+		writeJSON(w, http.StatusConflict, errorResponse("conflict", err.Error()))
+		return
+	}
+
+	s.logger.Info("invite code created", "code", code, "amount_usd", req.AmountUSD, "max_uses", req.MaxUses)
+	writeJSON(w, http.StatusCreated, map[string]any{
+		"code":       code,
+		"amount_usd": fmt.Sprintf("%.2f", float64(amountMicroUSD)/1_000_000),
+		"max_uses":   req.MaxUses,
+		"expires_at": ic.ExpiresAt,
+	})
+}
+
+// handleAdminListInviteCodes handles GET /v1/admin/invite-codes.
+func (s *Server) handleAdminListInviteCodes(w http.ResponseWriter, r *http.Request) {
+	if !s.requireAdminKey(w, r) {
+		return
+	}
+
+	codes := s.store.ListInviteCodes()
+	type codeView struct {
+		Code      string     `json:"code"`
+		AmountUSD string     `json:"amount_usd"`
+		MaxUses   int        `json:"max_uses"`
+		UsedCount int        `json:"used_count"`
+		Active    bool       `json:"active"`
+		ExpiresAt *time.Time `json:"expires_at,omitempty"`
+		CreatedAt time.Time  `json:"created_at"`
+	}
+
+	views := make([]codeView, len(codes))
+	for i, c := range codes {
+		views[i] = codeView{
+			Code:      c.Code,
+			AmountUSD: fmt.Sprintf("%.2f", float64(c.AmountMicroUSD)/1_000_000),
+			MaxUses:   c.MaxUses,
+			UsedCount: c.UsedCount,
+			Active:    c.Active,
+			ExpiresAt: c.ExpiresAt,
+			CreatedAt: c.CreatedAt,
+		}
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{"invite_codes": views})
+}
+
+// handleAdminDeactivateInviteCode handles DELETE /v1/admin/invite-codes.
+func (s *Server) handleAdminDeactivateInviteCode(w http.ResponseWriter, r *http.Request) {
+	if !s.requireAdminKey(w, r) {
+		return
+	}
+
+	var req struct {
+		Code string `json:"code"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, errorResponse("invalid_request_error", "invalid JSON"))
+		return
+	}
+	if req.Code == "" {
+		writeJSON(w, http.StatusBadRequest, errorResponse("invalid_request_error", "code is required"))
+		return
+	}
+
+	if err := s.store.DeactivateInviteCode(req.Code); err != nil {
+		writeJSON(w, http.StatusNotFound, errorResponse("not_found", err.Error()))
+		return
+	}
+
+	s.logger.Info("invite code deactivated", "code", req.Code)
+	writeJSON(w, http.StatusOK, map[string]string{"status": "deactivated"})
+}
+
+// handleRedeemInviteCode handles POST /v1/invite/redeem.
+func (s *Server) handleRedeemInviteCode(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		Code string `json:"code"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, errorResponse("invalid_request_error", "invalid JSON"))
+		return
+	}
+
+	code := strings.ToUpper(strings.TrimSpace(req.Code))
+	if code == "" {
+		writeJSON(w, http.StatusBadRequest, errorResponse("invalid_request_error", "code is required"))
+		return
+	}
+
+	accountID := consumerKeyFromContext(r.Context())
+
+	// Get the invite code to know the amount
+	ic, err := s.store.GetInviteCode(code)
+	if err != nil {
+		writeJSON(w, http.StatusNotFound, errorResponse("not_found", "invalid invite code"))
+		return
+	}
+
+	// Redeem atomically (checks active, expiry, max uses, double-redemption)
+	if err := s.store.RedeemInviteCode(code, accountID); err != nil {
+		writeJSON(w, http.StatusBadRequest, errorResponse("invalid_request_error", err.Error()))
+		return
+	}
+
+	// Credit the user's balance
+	if err := s.store.Credit(accountID, ic.AmountMicroUSD, store.LedgerInviteCredit, "invite:"+code); err != nil {
+		s.logger.Error("failed to credit invite balance", "account", accountID, "code", code, "error", err)
+		writeJSON(w, http.StatusInternalServerError, errorResponse("internal_error", "failed to credit balance"))
+		return
+	}
+
+	balance := s.store.GetBalance(accountID)
+	s.logger.Info("invite code redeemed", "code", code, "account", accountID, "amount_micro_usd", ic.AmountMicroUSD)
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"credited_usd": fmt.Sprintf("%.2f", float64(ic.AmountMicroUSD)/1_000_000),
+		"balance_usd":  fmt.Sprintf("%.6f", float64(balance)/1_000_000),
+	})
+}

--- a/coordinator/internal/api/server.go
+++ b/coordinator/internal/api/server.go
@@ -59,24 +59,25 @@ var LatestProviderVersion = "0.2.0"
 // Server is the main HTTP/WS server for the coordinator. It ties together
 // the provider registry, key store, payment ledger, billing service, and HTTP routing.
 type Server struct {
-	registry          *registry.Registry
-	store             store.Store
-	ledger            *payments.Ledger
-	billing           *billing.Service
-	logger            *slog.Logger
-	mux               *http.ServeMux
-	challengeInterval time.Duration // 0 means use DefaultChallengeInterval
+	registry               *registry.Registry
+	store                  store.Store
+	ledger                 *payments.Ledger
+	billing                *billing.Service
+	logger                 *slog.Logger
+	mux                    *http.ServeMux
+	challengeInterval      time.Duration       // 0 means use DefaultChallengeInterval
 	privyAuth              *auth.PrivyAuth     // Privy JWT authentication (nil if not configured)
 	adminEmails            map[string]bool     // emails that have admin access
-	mdmClient              *mdm.Client        // MicroMDM client for provider security verification
-	stepCARootCert         *x509.Certificate  // step-ca root CA for ACME cert verification
-	stepCAIntermediateCert *x509.Certificate  // step-ca intermediate CA
+	adminKey               string              // DGINF_ADMIN_KEY for admin endpoints
+	mdmClient              *mdm.Client         // MicroMDM client for provider security verification
+	stepCARootCert         *x509.Certificate   // step-ca root CA for ACME cert verification
+	stepCAIntermediateCert *x509.Certificate   // step-ca intermediate CA
 
 	// imageUploads stores generated images keyed by request_id.
 	// Providers upload images via HTTP POST, then send a small WebSocket
 	// completion message. The consumer handler retrieves images from here.
-	imageUploads           map[string][][]byte // request_id → list of PNG images
-	imageUploadsMu         sync.Mutex
+	imageUploads   map[string][][]byte // request_id → list of PNG images
+	imageUploadsMu sync.Mutex
 }
 
 // NewServer creates a configured Server with all routes mounted.
@@ -92,6 +93,12 @@ func NewServer(reg *registry.Registry, st store.Store, logger *slog.Logger) *Ser
 	s.routes()
 	return s
 }
+
+// SetAdminKey configures the admin API key for admin-only endpoints.
+func (s *Server) SetAdminKey(key string) {
+	s.adminKey = key
+}
+
 
 // SetStepCACerts configures the step-ca CA certificates for ACME client cert verification.
 func (s *Server) SetStepCACerts(root, intermediate *x509.Certificate) {
@@ -186,8 +193,8 @@ func (s *Server) routes() {
 	s.mux.HandleFunc("GET /api/version", s.handleVersion)
 
 	// Device authorization flow — providers link to user accounts.
-	s.mux.HandleFunc("POST /v1/device/code", s.handleDeviceCode)            // no auth — provider not yet authenticated
-	s.mux.HandleFunc("POST /v1/device/token", s.handleDeviceToken)          // no auth — polls with device_code secret
+	s.mux.HandleFunc("POST /v1/device/code", s.handleDeviceCode)                      // no auth — provider not yet authenticated
+	s.mux.HandleFunc("POST /v1/device/token", s.handleDeviceToken)                    // no auth — polls with device_code secret
 	s.mux.HandleFunc("POST /v1/device/approve", s.requireAuth(s.handleDeviceApprove)) // Privy auth — user approves in browser
 
 	// --- Billing endpoints (multi-chain payments + referrals) ---
@@ -203,9 +210,9 @@ func (s *Server) routes() {
 	s.mux.HandleFunc("GET /v1/billing/wallet/balance", s.requireAuth(s.handleWalletBalance))
 
 	// Pricing — GET is public, PUT/DELETE require auth
-	s.mux.HandleFunc("GET /v1/pricing", s.handleGetPricing)                         // public
-	s.mux.HandleFunc("PUT /v1/pricing", s.requireAuth(s.handleSetPricing))          // provider sets own prices
-	s.mux.HandleFunc("DELETE /v1/pricing", s.requireAuth(s.handleDeletePricing))    // revert to default
+	s.mux.HandleFunc("GET /v1/pricing", s.handleGetPricing)                        // public
+	s.mux.HandleFunc("PUT /v1/pricing", s.requireAuth(s.handleSetPricing))         // provider sets own prices
+	s.mux.HandleFunc("DELETE /v1/pricing", s.requireAuth(s.handleDeletePricing))   // revert to default
 	s.mux.HandleFunc("PUT /v1/admin/pricing", s.requireAuth(s.handleAdminPricing)) // platform sets defaults
 
 	// Admin model catalog
@@ -224,6 +231,14 @@ func (s *Server) routes() {
 	s.mux.HandleFunc("POST /v1/referral/apply", s.requireAuth(s.handleReferralApply))
 	s.mux.HandleFunc("GET /v1/referral/stats", s.requireAuth(s.handleReferralStats))
 	s.mux.HandleFunc("GET /v1/referral/info", s.requireAuth(s.handleReferralInfo))
+
+	// Invite codes (admin)
+	s.mux.HandleFunc("POST /v1/admin/invite-codes", s.requireAuth(s.handleAdminCreateInviteCode))
+	s.mux.HandleFunc("GET /v1/admin/invite-codes", s.requireAuth(s.handleAdminListInviteCodes))
+	s.mux.HandleFunc("DELETE /v1/admin/invite-codes", s.requireAuth(s.handleAdminDeactivateInviteCode))
+
+	// Invite code redemption (user)
+	s.mux.HandleFunc("POST /v1/invite/redeem", s.requireAuth(s.handleRedeemInviteCode))
 }
 
 // Handler returns the root http.Handler with global middleware applied.

--- a/coordinator/internal/store/interface.go
+++ b/coordinator/internal/store/interface.go
@@ -148,6 +148,27 @@ type Store interface {
 	// DeleteExpiredDeviceCodes removes device codes that have passed their expiry.
 	DeleteExpiredDeviceCodes() error
 
+	// --- Invite Codes ---
+
+	// CreateInviteCode stores a new invite code.
+	CreateInviteCode(code *InviteCode) error
+
+	// GetInviteCode returns an invite code by its code string.
+	GetInviteCode(code string) (*InviteCode, error)
+
+	// ListInviteCodes returns all invite codes (admin view).
+	ListInviteCodes() []InviteCode
+
+	// DeactivateInviteCode sets active=false on an invite code.
+	DeactivateInviteCode(code string) error
+
+	// RedeemInviteCode atomically increments used_count and records the redemption.
+	// Returns error if code is inactive, expired, fully used, or already redeemed by this account.
+	RedeemInviteCode(code string, accountID string) error
+
+	// HasRedeemedInviteCode checks if an account has already redeemed a specific code.
+	HasRedeemedInviteCode(code, accountID string) bool
+
 	// --- Provider Tokens (device-linked auth) ---
 
 	// CreateProviderToken stores a long-lived provider auth token linked to an account.
@@ -181,6 +202,7 @@ const (
 	LedgerWithdrawal     LedgerEntryType = "withdrawal"      // on-chain withdrawal
 	LedgerReferralReward LedgerEntryType = "referral_reward" // referrer earns share of platform fee
 	LedgerStripeDeposit  LedgerEntryType = "stripe_deposit"  // Stripe checkout deposit
+	LedgerInviteCredit   LedgerEntryType = "invite_credit"   // invite code redemption
 )
 
 // LedgerEntry is a single balance-changing event.
@@ -196,15 +218,15 @@ type LedgerEntry struct {
 
 // PaymentRecord captures a settled payment.
 type PaymentRecord struct {
-	TxHash          string    `json:"tx_hash"`
-	ConsumerAddress string    `json:"consumer_address"`
-	ProviderAddress string    `json:"provider_address"`
-	AmountUSD       string    `json:"amount_usd"`
-	Model           string    `json:"model"`
-	PromptTokens    int       `json:"prompt_tokens"`
-	CompletionTokens int      `json:"completion_tokens"`
-	Memo            string    `json:"memo"`
-	CreatedAt       time.Time `json:"created_at"`
+	TxHash           string    `json:"tx_hash"`
+	ConsumerAddress  string    `json:"consumer_address"`
+	ProviderAddress  string    `json:"provider_address"`
+	AmountUSD        string    `json:"amount_usd"`
+	Model            string    `json:"model"`
+	PromptTokens     int       `json:"prompt_tokens"`
+	CompletionTokens int       `json:"completion_tokens"`
+	Memo             string    `json:"memo"`
+	CreatedAt        time.Time `json:"created_at"`
 }
 
 // Referrer represents a registered referral partner.
@@ -249,15 +271,15 @@ type User struct {
 // output worth paying for — small chat models (< 7B) are not useful, but small
 // specialized models (transcription, embeddings) can be best-in-class.
 type SupportedModel struct {
-	ID           string  `json:"id"`            // HuggingFace path (e.g. "mlx-community/Qwen3.5-9B-MLX-4bit")
-	S3Name       string  `json:"s3_name"`       // CDN key for download (e.g. "Qwen3.5-9B-MLX-4bit")
-	DisplayName  string  `json:"display_name"`  // Human-readable (e.g. "Qwen3.5 9B")
-	ModelType    string  `json:"model_type"`    // "text", "transcription", "embedding", "tts", "image"
-	SizeGB       float64 `json:"size_gb"`       // Disk/memory size in GB
-	Architecture string  `json:"architecture"`  // e.g. "9B dense", "2B conformer"
-	Description  string  `json:"description"`   // e.g. "Balanced", "Best-in-class STT"
-	MinRAMGB     int     `json:"min_ram_gb"`    // Minimum system RAM for auto-selection
-	Active       bool    `json:"active"`        // Whether available for use
+	ID           string  `json:"id"`           // HuggingFace path (e.g. "mlx-community/Qwen3.5-9B-MLX-4bit")
+	S3Name       string  `json:"s3_name"`      // CDN key for download (e.g. "Qwen3.5-9B-MLX-4bit")
+	DisplayName  string  `json:"display_name"` // Human-readable (e.g. "Qwen3.5 9B")
+	ModelType    string  `json:"model_type"`   // "text", "transcription", "embedding", "tts", "image"
+	SizeGB       float64 `json:"size_gb"`      // Disk/memory size in GB
+	Architecture string  `json:"architecture"` // e.g. "9B dense", "2B conformer"
+	Description  string  `json:"description"`  // e.g. "Balanced", "Best-in-class STT"
+	MinRAMGB     int     `json:"min_ram_gb"`   // Minimum system RAM for auto-selection
+	Active       bool    `json:"active"`       // Whether available for use
 }
 
 // DeviceCode represents a pending device authorization request (RFC 8628-style).
@@ -281,16 +303,34 @@ type ProviderToken struct {
 	CreatedAt time.Time `json:"created_at"`
 }
 
+// InviteCode represents a coordinator-generated invite code that grants credits.
+type InviteCode struct {
+	Code           string     `json:"code"`
+	AmountMicroUSD int64      `json:"amount_micro_usd"`
+	MaxUses        int        `json:"max_uses"` // 0 = unlimited
+	UsedCount      int        `json:"used_count"`
+	Active         bool       `json:"active"`
+	CreatedAt      time.Time  `json:"created_at"`
+	ExpiresAt      *time.Time `json:"expires_at,omitempty"`
+}
+
+// InviteRedemption records a single redemption of an invite code.
+type InviteRedemption struct {
+	Code      string    `json:"code"`
+	AccountID string    `json:"account_id"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
 // BillingSession tracks an in-progress payment via any method (Stripe, EVM, Solana).
 type BillingSession struct {
 	ID             string     `json:"id"`
 	AccountID      string     `json:"account_id"`
 	PaymentMethod  string     `json:"payment_method"` // "stripe", "evm", "solana"
-	Chain          string     `json:"chain"`           // "ethereum", "tempo", "solana", ""
+	Chain          string     `json:"chain"`          // "ethereum", "tempo", "solana", ""
 	AmountMicroUSD int64      `json:"amount_micro_usd"`
-	ExternalID     string     `json:"external_id"`     // Stripe session ID, tx hash, etc.
-	Status         string     `json:"status"`          // "pending", "completed", "expired"
-	ReferralCode   string     `json:"referral_code"`   // optional
+	ExternalID     string     `json:"external_id"`   // Stripe session ID, tx hash, etc.
+	Status         string     `json:"status"`        // "pending", "completed", "expired"
+	ReferralCode   string     `json:"referral_code"` // optional
 	CreatedAt      time.Time  `json:"created_at"`
 	CompletedAt    *time.Time `json:"completed_at,omitempty"`
 }

--- a/coordinator/internal/store/memory.go
+++ b/coordinator/internal/store/memory.go
@@ -25,13 +25,13 @@ var _ Store = (*MemoryStore)(nil)
 // MemoryStore manages API keys, usage records, payments, and balances in memory.
 type MemoryStore struct {
 	mu            sync.RWMutex
-	keys          map[string]bool    // key → valid
-	keyAccounts   map[string]string  // key → accountID (owner)
+	keys          map[string]bool   // key → valid
+	keyAccounts   map[string]string // key → accountID (owner)
 	usage         []UsageRecord
 	payments      []PaymentRecord
-	balances      map[string]int64   // accountID → micro-USD
+	balances      map[string]int64 // accountID → micro-USD
 	ledgerEntries []LedgerEntry
-	ledgerSeq     int64              // auto-increment ID
+	ledgerSeq     int64 // auto-increment ID
 
 	// Referral system
 	referrersByCode    map[string]*Referrer // code → referrer
@@ -58,30 +58,38 @@ type MemoryStore struct {
 
 	// Provider tokens
 	providerTokens map[string]*ProviderToken // tokenHash → ProviderToken
+
+	// Invite codes
+	inviteCodes        map[string]*InviteCode        // code → InviteCode
+	inviteRedemptions  map[string][]InviteRedemption // code → list of redemptions
+	accountRedemptions map[string]map[string]bool    // accountID → set of redeemed codes
 }
 
 // NewMemory creates a new MemoryStore. If adminKey is non-empty it is
 // pre-seeded as a valid API key for bootstrapping.
 func NewMemory(adminKey string) *MemoryStore {
 	s := &MemoryStore{
-		keys:               make(map[string]bool),
-		keyAccounts:        make(map[string]string),
-		usage:              make([]UsageRecord, 0),
-		payments:           make([]PaymentRecord, 0),
-		balances:           make(map[string]int64),
-		ledgerEntries:      make([]LedgerEntry, 0),
-		referrersByCode:    make(map[string]*Referrer),
-		referrersByAccount: make(map[string]*Referrer),
-		referrals:          make(map[string]string),
-		referralCounts:     make(map[string]int),
-		billingSessions:    make(map[string]*BillingSession),
-		modelPrices:      make(map[string]ModelPrice),
-		supportedModels: make(map[string]*SupportedModel),
+		keys:                  make(map[string]bool),
+		keyAccounts:           make(map[string]string),
+		usage:                 make([]UsageRecord, 0),
+		payments:              make([]PaymentRecord, 0),
+		balances:              make(map[string]int64),
+		ledgerEntries:         make([]LedgerEntry, 0),
+		referrersByCode:       make(map[string]*Referrer),
+		referrersByAccount:    make(map[string]*Referrer),
+		referrals:             make(map[string]string),
+		referralCounts:        make(map[string]int),
+		billingSessions:       make(map[string]*BillingSession),
+		modelPrices:           make(map[string]ModelPrice),
+		supportedModels:       make(map[string]*SupportedModel),
 		usersByPrivyID:        make(map[string]*User),
 		usersByAccountID:      make(map[string]*User),
 		deviceCodesByCode:     make(map[string]*DeviceCode),
 		deviceCodesByUserCode: make(map[string]*DeviceCode),
 		providerTokens:        make(map[string]*ProviderToken),
+		inviteCodes:           make(map[string]*InviteCode),
+		inviteRedemptions:     make(map[string][]InviteRedemption),
+		accountRedemptions:    make(map[string]map[string]bool),
 	}
 	if adminKey != "" {
 		s.keys[adminKey] = true
@@ -685,6 +693,99 @@ func (s *MemoryStore) RevokeProviderToken(token string) error {
 	}
 	pt.Active = false
 	return nil
+}
+
+// --- Invite Codes ---
+
+func (s *MemoryStore) CreateInviteCode(code *InviteCode) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, exists := s.inviteCodes[code.Code]; exists {
+		return fmt.Errorf("invite code %q already exists", code.Code)
+	}
+	cp := *code
+	s.inviteCodes[code.Code] = &cp
+	return nil
+}
+
+func (s *MemoryStore) GetInviteCode(code string) (*InviteCode, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	ic, ok := s.inviteCodes[code]
+	if !ok {
+		return nil, fmt.Errorf("invite code %q not found", code)
+	}
+	cp := *ic
+	return &cp, nil
+}
+
+func (s *MemoryStore) ListInviteCodes() []InviteCode {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	codes := make([]InviteCode, 0, len(s.inviteCodes))
+	for _, ic := range s.inviteCodes {
+		codes = append(codes, *ic)
+	}
+	return codes
+}
+
+func (s *MemoryStore) DeactivateInviteCode(code string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	ic, ok := s.inviteCodes[code]
+	if !ok {
+		return fmt.Errorf("invite code %q not found", code)
+	}
+	ic.Active = false
+	return nil
+}
+
+func (s *MemoryStore) RedeemInviteCode(code string, accountID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	ic, ok := s.inviteCodes[code]
+	if !ok {
+		return fmt.Errorf("invite code %q not found", code)
+	}
+	if !ic.Active {
+		return fmt.Errorf("invite code %q is inactive", code)
+	}
+	if ic.ExpiresAt != nil && time.Now().After(*ic.ExpiresAt) {
+		return fmt.Errorf("invite code %q has expired", code)
+	}
+	if ic.MaxUses > 0 && ic.UsedCount >= ic.MaxUses {
+		return fmt.Errorf("invite code %q has reached max uses", code)
+	}
+	if acctCodes, ok := s.accountRedemptions[accountID]; ok && acctCodes[code] {
+		return fmt.Errorf("account has already redeemed code %q", code)
+	}
+
+	ic.UsedCount++
+	s.inviteRedemptions[code] = append(s.inviteRedemptions[code], InviteRedemption{
+		Code:      code,
+		AccountID: accountID,
+		CreatedAt: time.Now(),
+	})
+	if s.accountRedemptions[accountID] == nil {
+		s.accountRedemptions[accountID] = make(map[string]bool)
+	}
+	s.accountRedemptions[accountID][code] = true
+	return nil
+}
+
+func (s *MemoryStore) HasRedeemedInviteCode(code, accountID string) bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if acctCodes, ok := s.accountRedemptions[accountID]; ok {
+		return acctCodes[code]
+	}
+	return false
 }
 
 // sha256Hex returns the hex-encoded SHA-256 digest of s.

--- a/coordinator/internal/store/postgres.go
+++ b/coordinator/internal/store/postgres.go
@@ -214,6 +214,23 @@ func (s *PostgresStore) migrate(ctx context.Context) error {
 			created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 		)`,
 		`CREATE INDEX IF NOT EXISTS idx_provider_tokens_account ON provider_tokens(account_id)`,
+
+		// Invite codes
+		`CREATE TABLE IF NOT EXISTS invite_codes (
+			code TEXT PRIMARY KEY,
+			amount_micro_usd BIGINT NOT NULL,
+			max_uses INTEGER NOT NULL DEFAULT 1,
+			used_count INTEGER NOT NULL DEFAULT 0,
+			active BOOLEAN NOT NULL DEFAULT TRUE,
+			expires_at TIMESTAMPTZ,
+			created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+		)`,
+		`CREATE TABLE IF NOT EXISTS invite_redemptions (
+			code TEXT NOT NULL REFERENCES invite_codes(code),
+			account_id TEXT NOT NULL,
+			created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			PRIMARY KEY (code, account_id)
+		)`,
 	}
 
 	for _, m := range migrations {
@@ -1051,4 +1068,137 @@ func (s *PostgresStore) RevokeProviderToken(token string) error {
 		return fmt.Errorf("provider token not found")
 	}
 	return nil
+}
+
+// --- Invite Codes ---
+
+func (s *PostgresStore) CreateInviteCode(code *InviteCode) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, err := s.pool.Exec(ctx,
+		`INSERT INTO invite_codes (code, amount_micro_usd, max_uses, used_count, active, expires_at)
+		 VALUES ($1, $2, $3, $4, $5, $6)`,
+		code.Code, code.AmountMicroUSD, code.MaxUses, code.UsedCount, code.Active, code.ExpiresAt,
+	)
+	if err != nil {
+		return fmt.Errorf("store: create invite code: %w", err)
+	}
+	return nil
+}
+
+func (s *PostgresStore) GetInviteCode(code string) (*InviteCode, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	var ic InviteCode
+	err := s.pool.QueryRow(ctx,
+		`SELECT code, amount_micro_usd, max_uses, used_count, active, expires_at, created_at
+		 FROM invite_codes WHERE code = $1`, code,
+	).Scan(&ic.Code, &ic.AmountMicroUSD, &ic.MaxUses, &ic.UsedCount, &ic.Active, &ic.ExpiresAt, &ic.CreatedAt)
+	if err != nil {
+		return nil, fmt.Errorf("store: invite code not found: %w", err)
+	}
+	return &ic, nil
+}
+
+func (s *PostgresStore) ListInviteCodes() []InviteCode {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	rows, err := s.pool.Query(ctx,
+		`SELECT code, amount_micro_usd, max_uses, used_count, active, expires_at, created_at
+		 FROM invite_codes ORDER BY created_at DESC`,
+	)
+	if err != nil {
+		return nil
+	}
+	defer rows.Close()
+
+	var codes []InviteCode
+	for rows.Next() {
+		var ic InviteCode
+		if err := rows.Scan(&ic.Code, &ic.AmountMicroUSD, &ic.MaxUses, &ic.UsedCount, &ic.Active, &ic.ExpiresAt, &ic.CreatedAt); err != nil {
+			continue
+		}
+		codes = append(codes, ic)
+	}
+	return codes
+}
+
+func (s *PostgresStore) DeactivateInviteCode(code string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	tag, err := s.pool.Exec(ctx,
+		`UPDATE invite_codes SET active = FALSE WHERE code = $1`, code,
+	)
+	if err != nil {
+		return fmt.Errorf("store: deactivate invite code: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return fmt.Errorf("invite code %q not found", code)
+	}
+	return nil
+}
+
+func (s *PostgresStore) RedeemInviteCode(code string, accountID string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("store: begin tx: %w", err)
+	}
+	defer tx.Rollback(ctx)
+
+	// Lock the invite code row
+	var ic InviteCode
+	err = tx.QueryRow(ctx,
+		`SELECT code, amount_micro_usd, max_uses, used_count, active, expires_at
+		 FROM invite_codes WHERE code = $1 FOR UPDATE`, code,
+	).Scan(&ic.Code, &ic.AmountMicroUSD, &ic.MaxUses, &ic.UsedCount, &ic.Active, &ic.ExpiresAt)
+	if err != nil {
+		return fmt.Errorf("invite code %q not found", code)
+	}
+	if !ic.Active {
+		return fmt.Errorf("invite code %q is inactive", code)
+	}
+	if ic.ExpiresAt != nil && time.Now().After(*ic.ExpiresAt) {
+		return fmt.Errorf("invite code %q has expired", code)
+	}
+	if ic.MaxUses > 0 && ic.UsedCount >= ic.MaxUses {
+		return fmt.Errorf("invite code %q has reached max uses", code)
+	}
+
+	// Insert redemption (PK constraint prevents double-redemption)
+	_, err = tx.Exec(ctx,
+		`INSERT INTO invite_redemptions (code, account_id) VALUES ($1, $2)`,
+		code, accountID,
+	)
+	if err != nil {
+		return fmt.Errorf("account has already redeemed code %q", code)
+	}
+
+	// Increment used_count
+	_, err = tx.Exec(ctx,
+		`UPDATE invite_codes SET used_count = used_count + 1 WHERE code = $1`, code,
+	)
+	if err != nil {
+		return fmt.Errorf("store: update invite code: %w", err)
+	}
+
+	return tx.Commit(ctx)
+}
+
+func (s *PostgresStore) HasRedeemedInviteCode(code, accountID string) bool {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	var count int
+	_ = s.pool.QueryRow(ctx,
+		`SELECT COUNT(*) FROM invite_redemptions WHERE code = $1 AND account_id = $2`,
+		code, accountID,
+	).Scan(&count)
+	return count > 0
 }


### PR DESCRIPTION
## Summary
- Admin-generated invite codes that grant configurable credit amounts to users on redemption
- Credits funded by coordinator, flow to providers through normal billing pipeline
- Supports single-use and multi-use codes with optional expiration
- Admin auth via `DGINF_ADMIN_KEY` or Privy admin emails (constant-time comparison)
- Full store implementations for both MemoryStore and PostgresStore (transactional redemption with `SELECT ... FOR UPDATE`)

### API Endpoints
| Method | Path | Auth | Description |
|--------|------|------|-------------|
| `POST /v1/admin/invite-codes` | Admin | Create invite code |
| `GET /v1/admin/invite-codes` | Admin | List all codes with stats |
| `DELETE /v1/admin/invite-codes` | Admin | Deactivate a code |
| `POST /v1/invite/redeem` | User | Redeem code → credits balance |

## Test plan
- [x] All existing tests pass (`go test ./...`)
- [x] Code formatted (`gofmt`)
- [ ] Manual test: create invite code via admin key, redeem as user, verify balance credited
- [ ] Verify double-redemption prevention
- [ ] Verify max-uses enforcement

🤖 Generated with [Claude Code](https://claude.com/claude-code)