### PR TITLE
Add provider scheduling for time-based availability

### DIFF
--- a/app/DGInf/Sources/DGInf/SettingsView.swift
+++ b/app/DGInf/Sources/DGInf/SettingsView.swift
@@ -134,11 +134,99 @@ private struct AvailabilityTab: View {
                 Text("Idle Detection")
                     .font(.headline)
             }
+
+            Section {
+                Toggle("Enable schedule", isOn: $viewModel.scheduleEnabled)
+
+                if viewModel.scheduleEnabled {
+                    ForEach($viewModel.scheduleWindows) { $window in
+                        ScheduleWindowRow(window: $window)
+                    }
+                    .onDelete { indices in
+                        viewModel.scheduleWindows.remove(atOffsets: indices)
+                    }
+
+                    Button {
+                        viewModel.scheduleWindows.append(ScheduleWindowModel.defaultWindow())
+                    } label: {
+                        Label("Add Window", systemImage: "plus")
+                    }
+                    .buttonStyle(.borderless)
+                }
+
+                Text("Set when your machine serves inference. Outside these windows, the provider disconnects and frees GPU memory. Requires provider restart to take effect.")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            } header: {
+                Text("Schedule")
+                    .font(.headline)
+            }
         }
         .padding()
         .onAppear {
             selectedTimeout = viewModel.idleTimeoutSeconds
         }
+    }
+}
+
+// MARK: - Schedule Window Row
+
+private struct ScheduleWindowRow: View {
+    @Binding var window: ScheduleWindowModel
+
+    private let hours: [String] = (0..<24).map { String(format: "%02d:00", $0) }
+        + (0..<24).map { String(format: "%02d:30", $0) }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            // Day selector
+            HStack(spacing: 4) {
+                ForEach(ScheduleWindowModel.allDays, id: \.self) { day in
+                    let isActive = window.activeDays.contains(day)
+                    Button {
+                        if isActive {
+                            window.activeDays.removeAll { $0 == day }
+                        } else {
+                            window.activeDays.append(day)
+                        }
+                    } label: {
+                        Text(ScheduleWindowModel.dayLabels[day] ?? day)
+                            .font(.caption2)
+                            .frame(width: 32, height: 24)
+                    }
+                    .buttonStyle(.bordered)
+                    .tint(isActive ? .accentColor : .secondary)
+                }
+            }
+
+            // Time range
+            HStack {
+                Picker("From", selection: $window.startTime) {
+                    ForEach(sortedHours, id: \.self) { time in
+                        Text(time).tag(time)
+                    }
+                }
+                .frame(width: 120)
+
+                Picker("To", selection: $window.endTime) {
+                    ForEach(sortedHours, id: \.self) { time in
+                        Text(time).tag(time)
+                    }
+                }
+                .frame(width: 120)
+
+                if window.isOvernight {
+                    Text("(overnight)")
+                        .font(.caption2)
+                        .foregroundColor(.orange)
+                }
+            }
+        }
+        .padding(.vertical, 4)
+    }
+
+    private var sortedHours: [String] {
+        hours.sorted()
     }
 }
 

--- a/app/DGInf/Sources/DGInf/StatusViewModel.swift
+++ b/app/DGInf/Sources/DGInf/StatusViewModel.swift
@@ -74,6 +74,24 @@ final class StatusViewModel: ObservableObject {
         }
     }
 
+    // MARK: - Schedule Settings (persisted via UserDefaults, synced to provider config)
+
+    @Published var scheduleEnabled: Bool {
+        didSet {
+            UserDefaults.standard.set(scheduleEnabled, forKey: "scheduleEnabled")
+            syncScheduleToConfig()
+        }
+    }
+
+    @Published var scheduleWindows: [ScheduleWindowModel] {
+        didSet {
+            if let data = try? JSONEncoder().encode(scheduleWindows) {
+                UserDefaults.standard.set(data, forKey: "scheduleWindows")
+            }
+            syncScheduleToConfig()
+        }
+    }
+
     // MARK: - Managers
 
     let providerManager = ProviderManager()
@@ -99,6 +117,13 @@ final class StatusViewModel: ObservableObject {
         self.autoStart = UserDefaults.standard.bool(forKey: "autoStart")
         self.idleTimeoutSeconds = UserDefaults.standard.double(forKey: "idleTimeoutSeconds")
         self.hasCompletedSetup = UserDefaults.standard.bool(forKey: "hasCompletedSetup")
+        self.scheduleEnabled = UserDefaults.standard.bool(forKey: "scheduleEnabled")
+        if let data = UserDefaults.standard.data(forKey: "scheduleWindows"),
+           let windows = try? JSONDecoder().decode([ScheduleWindowModel].self, from: data) {
+            self.scheduleWindows = windows
+        } else {
+            self.scheduleWindows = [ScheduleWindowModel.defaultWindow()]
+        }
 
         if idleTimeoutSeconds == 0 {
             idleTimeoutSeconds = 300
@@ -500,5 +525,80 @@ final class StatusViewModel: ObservableObject {
         ]
         SecItemDelete(query as CFDictionary)
         SecItemAdd(query as CFDictionary, nil)
+    }
+
+    // MARK: - Schedule Config Sync
+
+    /// Write schedule settings to the provider TOML config so the CLI respects them.
+    func syncScheduleToConfig() {
+        guard let configDir = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first?
+            .deletingLastPathComponent()
+            .appendingPathComponent(".config/dginf") else { return }
+
+        let configPath = configDir.appendingPathComponent("provider.toml")
+
+        // Read existing config (if any)
+        var tomlContent = (try? String(contentsOf: configPath, encoding: .utf8)) ?? ""
+
+        // Remove existing [schedule] section (everything from [schedule] to next section or EOF)
+        if let range = tomlContent.range(of: #"\[schedule\][\s\S]*?(?=\n\[|$)"#, options: .regularExpression) {
+            tomlContent.removeSubrange(range)
+        }
+
+        // Build schedule TOML
+        var scheduleToml = "\n[schedule]\nenabled = \(scheduleEnabled)\n"
+
+        for window in scheduleWindows {
+            let days = window.activeDays.map { "\"\($0)\"" }.joined(separator: ", ")
+            scheduleToml += "\n[[schedule.windows]]\ndays = [\(days)]\nstart = \"\(window.startTime)\"\nend = \"\(window.endTime)\"\n"
+        }
+
+        tomlContent = tomlContent.trimmingCharacters(in: .whitespacesAndNewlines)
+        tomlContent += scheduleToml
+
+        try? FileManager.default.createDirectory(at: configDir, withIntermediateDirectories: true)
+        try? tomlContent.write(to: configPath, atomically: true, encoding: .utf8)
+    }
+}
+
+// MARK: - Schedule Window Model
+
+/// A single time window for provider availability scheduling.
+struct ScheduleWindowModel: Identifiable, Codable, Equatable {
+    let id: UUID
+    var activeDays: [String]   // e.g., ["mon", "tue", "wed"]
+    var startTime: String      // "HH:MM" 24h format
+    var endTime: String        // "HH:MM" 24h format
+
+    static let allDays = ["mon", "tue", "wed", "thu", "fri", "sat", "sun"]
+    static let dayLabels: [String: String] = [
+        "mon": "Mon", "tue": "Tue", "wed": "Wed", "thu": "Thu",
+        "fri": "Fri", "sat": "Sat", "sun": "Sun"
+    ]
+
+    static func defaultWindow() -> ScheduleWindowModel {
+        ScheduleWindowModel(
+            id: UUID(),
+            activeDays: ["mon", "tue", "wed", "thu", "fri", "sat", "sun"],
+            startTime: "22:00",
+            endTime: "08:00"
+        )
+    }
+
+    var isOvernight: Bool {
+        guard let start = timeMinutes(startTime), let end = timeMinutes(endTime) else { return false }
+        return end <= start
+    }
+
+    var description: String {
+        let dayStr = activeDays.compactMap { Self.dayLabels[$0] }.joined(separator: ", ")
+        let overnight = isOvernight ? " (overnight)" : ""
+        return "\(dayStr): \(startTime)–\(endTime)\(overnight)"
+    }
+
+    private func timeMinutes(_ s: String) -> Int? {
+        let parts = s.split(separator: ":").compactMap { Int($0) }
+        guard parts.count == 2 else { return nil }
+        return parts[0] * 60 + parts[1]
     }
 }

--- a/provider/Cargo.toml
+++ b/provider/Cargo.toml
@@ -56,6 +56,9 @@ libc = "0.2"
 # Misc
 dirs = "6"
 
+# Time/date handling for scheduling
+chrono = { version = "0.4", features = ["serde"] }
+
 # Crypto — NaCl-compatible X25519 + XSalsa20-Poly1305
 crypto_box = "0.9"
 base64 = "0.22"

--- a/provider/src/backend/mod.rs
+++ b/provider/src/backend/mod.rs
@@ -197,6 +197,57 @@ pub async fn check_health(base_url: &str) -> bool {
     }
 }
 
+/// Check if the backend has fully loaded its model into GPU memory.
+/// Returns true only when the /health endpoint reports model_loaded: true.
+pub async fn check_model_loaded(base_url: &str) -> bool {
+    let url = format!("{base_url}/health");
+    let client = health_client();
+    match client.get(&url).send().await {
+        Ok(resp) if resp.status().is_success() => {
+            if let Ok(body) = resp.json::<serde_json::Value>().await {
+                body.get("model_loaded")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false)
+            } else {
+                // If we can't parse the body, fall back to status-only check
+                true
+            }
+        }
+        _ => false,
+    }
+}
+
+/// Send a minimal warmup request to prime the model's GPU caches.
+/// This avoids the 30-50s first-token penalty on real user requests.
+pub async fn warmup_backend(base_url: &str) -> bool {
+    let url = format!("{base_url}/v1/chat/completions");
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(120))
+        .build()
+        .unwrap_or_default();
+
+    let body = serde_json::json!({
+        "messages": [{"role": "user", "content": "hi"}],
+        "max_tokens": 1,
+        "stream": false,
+    });
+
+    match client.post(&url).json(&body).send().await {
+        Ok(resp) if resp.status().is_success() => {
+            tracing::info!("Backend warmup complete — GPU caches primed");
+            true
+        }
+        Ok(resp) => {
+            tracing::warn!("Backend warmup got status {}", resp.status());
+            false
+        }
+        Err(e) => {
+            tracing::warn!("Backend warmup request failed: {e}");
+            false
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -242,7 +293,7 @@ mod tests {
     #[tokio::test]
     async fn test_health_check_with_mock_server() {
         // Start a minimal axum server for health check
-        use axum::{routing::get, Router};
+        use axum::{Router, routing::get};
 
         let app = Router::new().route("/health", get(|| async { "ok" }));
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();

--- a/provider/src/backend/vllm_mlx.rs
+++ b/provider/src/backend/vllm_mlx.rs
@@ -15,7 +15,7 @@ use std::process::Stdio;
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::{Child, Command};
 
-use super::{binary_exists, check_health, Backend};
+use super::{Backend, binary_exists, check_health};
 
 /// Backend that runs `vllm-mlx serve <model>`.
 ///
@@ -55,10 +55,7 @@ impl VllmMlxBackend {
 
     /// Build the command arguments for spawning vllm-mlx.
     pub fn build_args(&self) -> Vec<String> {
-        let mut args = vec![
-            "serve".to_string(),
-            self.model.clone(),
-        ];
+        let mut args = vec!["serve".to_string(), self.model.clone()];
 
         // If Unix socket is configured, vllm-mlx needs to listen on it.
         // Note: vllm-mlx may not support --unix-socket natively yet.
@@ -78,7 +75,10 @@ impl VllmMlxBackend {
         args
     }
 
-    fn spawn_log_forwarder(stream: impl tokio::io::AsyncRead + Unpin + Send + 'static, label: &'static str) {
+    fn spawn_log_forwarder(
+        stream: impl tokio::io::AsyncRead + Unpin + Send + 'static,
+        label: &'static str,
+    ) {
         tokio::spawn(async move {
             let reader = BufReader::new(stream);
             let mut lines = reader.lines();
@@ -143,11 +143,8 @@ impl Backend for VllmMlxBackend {
                     }
 
                     // Wait up to 10 seconds for graceful shutdown
-                    match tokio::time::timeout(
-                        std::time::Duration::from_secs(10),
-                        child.wait(),
-                    )
-                    .await
+                    match tokio::time::timeout(std::time::Duration::from_secs(10), child.wait())
+                        .await
                     {
                         Ok(Ok(status)) => {
                             tracing::info!("vllm-mlx exited with status: {status}");
@@ -157,9 +154,7 @@ impl Backend for VllmMlxBackend {
                             tracing::warn!("Error waiting for vllm-mlx: {e}");
                         }
                         Err(_) => {
-                            tracing::warn!(
-                                "vllm-mlx did not exit within 10s, sending SIGKILL"
-                            );
+                            tracing::warn!("vllm-mlx did not exit within 10s, sending SIGKILL");
                         }
                     }
                 }
@@ -207,12 +202,7 @@ mod tests {
         let args = backend.build_args();
         assert_eq!(
             args,
-            vec![
-                "serve",
-                "mlx-community/Qwen2.5-7B-4bit",
-                "--port",
-                "8100"
-            ]
+            vec!["serve", "mlx-community/Qwen2.5-7B-4bit", "--port", "8100"]
         );
     }
 

--- a/provider/src/config.rs
+++ b/provider/src/config.rs
@@ -11,6 +11,7 @@
 //! config values at runtime.
 
 use crate::hardware::HardwareInfo;
+use crate::scheduling::ScheduleConfig;
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
@@ -20,6 +21,8 @@ pub struct ProviderConfig {
     pub provider: ProviderSettings,
     pub backend: BackendSettings,
     pub coordinator: CoordinatorSettings,
+    #[serde(default)]
+    pub schedule: Option<ScheduleConfig>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -43,7 +46,10 @@ pub struct CoordinatorSettings {
 
 impl ProviderConfig {
     pub fn default_for_hardware(hw: &HardwareInfo) -> Self {
-        let name = format!("dginf-{}", &hw.machine_model.replace(',', "-").to_lowercase());
+        let name = format!(
+            "dginf-{}",
+            &hw.machine_model.replace(',', "-").to_lowercase()
+        );
 
         Self {
             provider: ProviderSettings {
@@ -59,6 +65,7 @@ impl ProviderConfig {
                 url: "ws://localhost:8080/ws/provider".to_string(),
                 heartbeat_interval_secs: 30,
             },
+            schedule: None,
         }
     }
 }
@@ -76,8 +83,7 @@ pub fn save(path: &Path, config: &ProviderConfig) -> Result<()> {
             .with_context(|| format!("failed to create config directory {}", parent.display()))?;
     }
 
-    let toml_str =
-        toml::to_string_pretty(config).context("failed to serialize config to TOML")?;
+    let toml_str = toml::to_string_pretty(config).context("failed to serialize config to TOML")?;
     std::fs::write(path, &toml_str)
         .with_context(|| format!("failed to write config to {}", path.display()))?;
 
@@ -87,8 +93,7 @@ pub fn save(path: &Path, config: &ProviderConfig) -> Result<()> {
 pub fn load(path: &Path) -> Result<ProviderConfig> {
     let content = std::fs::read_to_string(path)
         .with_context(|| format!("failed to read config from {}", path.display()))?;
-    let config: ProviderConfig =
-        toml::from_str(&content).context("failed to parse config TOML")?;
+    let config: ProviderConfig = toml::from_str(&content).context("failed to parse config TOML")?;
     Ok(config)
 }
 

--- a/provider/src/coordinator.rs
+++ b/provider/src/coordinator.rs
@@ -15,6 +15,8 @@
 
 use anyhow::{Context, Result};
 use futures_util::{SinkExt, StreamExt};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::Duration;
 use tokio::sync::mpsc;
 use tokio_tungstenite::tungstenite::Message;
@@ -23,9 +25,25 @@ use crate::backend::ExponentialBackoff;
 use crate::hardware::HardwareInfo;
 use crate::models::ModelInfo;
 use crate::protocol::{
-    CoordinatorMessage, ImageGenerationRequestBody, ProviderMessage, ProviderStats,
-    ProviderStatus, TranscriptionRequestBody,
+    CoordinatorMessage, ImageGenerationRequestBody, ProviderMessage, ProviderStats, ProviderStatus,
+    TranscriptionRequestBody,
 };
+
+/// Thread-safe counters for provider statistics, shared between the main
+/// event loop (which increments them) and the heartbeat sender (which reads them).
+pub struct AtomicProviderStats {
+    pub requests_served: AtomicU64,
+    pub tokens_generated: AtomicU64,
+}
+
+impl AtomicProviderStats {
+    pub fn new() -> Self {
+        Self {
+            requests_served: AtomicU64::new(0),
+            tokens_generated: AtomicU64::new(0),
+        }
+    }
+}
 
 /// Messages from coordinator connection to the main loop.
 #[derive(Debug)]
@@ -65,6 +83,12 @@ pub struct CoordinatorClient {
     wallet_address: Option<String>,
     attestation: Option<Box<serde_json::value::RawValue>>,
     auth_token: Option<String>,
+    /// Shared atomic counters — incremented by proxy tasks, read by heartbeats.
+    stats: Arc<AtomicProviderStats>,
+    /// True while at least one inference request is in flight.
+    inference_active: Arc<AtomicBool>,
+    /// The model currently loaded / being served (set by the main event loop).
+    current_model: Arc<std::sync::Mutex<Option<String>>>,
 }
 
 impl CoordinatorClient {
@@ -86,6 +110,9 @@ impl CoordinatorClient {
             wallet_address: None,
             attestation: None,
             auth_token: None,
+            stats: Arc::new(AtomicProviderStats::new()),
+            inference_active: Arc::new(AtomicBool::new(false)),
+            current_model: Arc::new(std::sync::Mutex::new(None)),
         }
     }
 
@@ -96,7 +123,10 @@ impl CoordinatorClient {
     }
 
     /// Set the signed Secure Enclave attestation blob (raw JSON bytes preserved).
-    pub fn with_attestation(mut self, attestation: Option<Box<serde_json::value::RawValue>>) -> Self {
+    pub fn with_attestation(
+        mut self,
+        attestation: Option<Box<serde_json::value::RawValue>>,
+    ) -> Self {
         self.attestation = attestation;
         self
     }
@@ -104,6 +134,24 @@ impl CoordinatorClient {
     /// Set the device-linked auth token (from `dginf-provider login`).
     pub fn with_auth_token(mut self, auth_token: Option<String>) -> Self {
         self.auth_token = auth_token;
+        self
+    }
+
+    /// Set the shared atomic stats counters (requests served, tokens generated).
+    pub fn with_stats(mut self, stats: Arc<AtomicProviderStats>) -> Self {
+        self.stats = stats;
+        self
+    }
+
+    /// Set the shared inference-active flag (true while requests are in flight).
+    pub fn with_inference_active(mut self, flag: Arc<AtomicBool>) -> Self {
+        self.inference_active = flag;
+        self
+    }
+
+    /// Set the shared current-model name (model currently loaded on this provider).
+    pub fn with_current_model(mut self, model: Arc<std::sync::Mutex<Option<String>>>) -> Self {
+        self.current_model = model;
         self
     }
 
@@ -127,7 +175,10 @@ impl CoordinatorClient {
 
             tracing::info!("Connecting to coordinator: {}", self.url);
 
-            match self.connect_and_run(&event_tx, &mut outbound_rx, &mut shutdown_rx).await {
+            match self
+                .connect_and_run(&event_tx, &mut outbound_rx, &mut shutdown_rx)
+                .await
+            {
                 Ok(()) => {
                     tracing::info!("Coordinator connection closed, reconnecting...");
                     backoff.reset();
@@ -220,10 +271,15 @@ impl CoordinatorClient {
                     let metrics = crate::hardware::collect_system_metrics(
                         self.hardware.cpu_cores.total,
                     );
+                    let is_active = self.inference_active.load(Ordering::Relaxed);
+                    let active_model = self.current_model.lock().unwrap().clone();
                     let heartbeat = ProviderMessage::Heartbeat {
-                        status: ProviderStatus::Idle,
-                        active_model: None,
-                        stats: ProviderStats::default(),
+                        status: if is_active { ProviderStatus::Serving } else { ProviderStatus::Idle },
+                        active_model,
+                        stats: ProviderStats {
+                            requests_served: self.stats.requests_served.load(Ordering::Relaxed),
+                            tokens_generated: self.stats.tokens_generated.load(Ordering::Relaxed),
+                        },
                         system_metrics: metrics,
                     };
                     let json = serde_json::to_string(&heartbeat)?;
@@ -385,7 +441,6 @@ impl CoordinatorClient {
             }
         }
     }
-
 }
 
 /// Decrypt an E2E encrypted request body using the provider's X25519 private key.
@@ -409,7 +464,10 @@ fn decrypt_request_body(
         .map_err(|e| anyhow::anyhow!("invalid ephemeral public key: {e}"))?;
 
     if ephemeral_pub_bytes.len() != 32 {
-        anyhow::bail!("invalid ephemeral key length: {}", ephemeral_pub_bytes.len());
+        anyhow::bail!(
+            "invalid ephemeral key length: {}",
+            ephemeral_pub_bytes.len()
+        );
     }
 
     let mut ephemeral_pub = [0u8; 32];
@@ -466,7 +524,9 @@ pub fn handle_attestation_challenge(
     let hypervisor_active = crate::security::check_hypervisor_active();
 
     if !sip_enabled {
-        tracing::error!("SIP is disabled during attestation challenge — coordinator will reject us");
+        tracing::error!(
+            "SIP is disabled during attestation challenge — coordinator will reject us"
+        );
     }
     if !rdma_disabled && !hypervisor_active {
         tracing::error!(
@@ -654,7 +714,10 @@ mod tests {
                 ProviderMessage::AttestationResponse { signature: s1, .. },
                 ProviderMessage::AttestationResponse { signature: s2, .. },
             ) => {
-                assert_ne!(s1, s2, "different nonces should produce different signatures");
+                assert_ne!(
+                    s1, s2,
+                    "different nonces should produce different signatures"
+                );
             }
             _ => panic!("Expected AttestationResponse"),
         }
@@ -662,7 +725,8 @@ mod tests {
 
     #[test]
     fn test_handle_attestation_challenge_serialization() {
-        let response = handle_attestation_challenge("dGVzdA==", "2025-06-01T00:00:00Z", Some("a2V5"));
+        let response =
+            handle_attestation_challenge("dGVzdA==", "2025-06-01T00:00:00Z", Some("a2V5"));
         let json = serde_json::to_string(&response).unwrap();
         assert!(json.contains("\"type\":\"attestation_response\""));
         assert!(json.contains("\"nonce\":\"dGVzdA==\""));
@@ -701,7 +765,9 @@ mod tests {
                 }
             });
             write
-                .send(Message::Text(serde_json::to_string(&request).unwrap().into()))
+                .send(Message::Text(
+                    serde_json::to_string(&request).unwrap().into(),
+                ))
                 .await
                 .unwrap();
 
@@ -716,7 +782,9 @@ mod tests {
                 "request_id": "test-req-1"
             });
             write
-                .send(Message::Text(serde_json::to_string(&cancel).unwrap().into()))
+                .send(Message::Text(
+                    serde_json::to_string(&cancel).unwrap().into(),
+                ))
                 .await
                 .unwrap();
 

--- a/provider/src/crypto.rs
+++ b/provider/src/crypto.rs
@@ -17,8 +17,8 @@
 
 use anyhow::{Context, Result};
 use crypto_box::{
-    aead::{Aead, AeadCore, OsRng},
     PublicKey, SalsaBox, SecretKey,
+    aead::{Aead, AeadCore, OsRng},
 };
 use std::path::Path;
 
@@ -107,7 +107,6 @@ impl NodeKeyPair {
     pub fn public_key_bytes(&self) -> [u8; 32] {
         self.public.to_bytes()
     }
-
 
     /// Decrypt a message from a consumer given their ephemeral public key.
     ///
@@ -230,7 +229,12 @@ mod tests {
 
         let result = NodeKeyPair::load(&path);
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("expected 32 bytes"));
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("expected 32 bytes")
+        );
     }
 
     #[test]
@@ -242,12 +246,9 @@ mod tests {
         let plaintext = b"Hello, encrypted world!";
 
         // Consumer encrypts with provider's public key
-        let ciphertext = encrypt_with_keypair(
-            &consumer.secret,
-            &provider.public_key_bytes(),
-            plaintext,
-        )
-        .unwrap();
+        let ciphertext =
+            encrypt_with_keypair(&consumer.secret, &provider.public_key_bytes(), plaintext)
+                .unwrap();
 
         // Provider decrypts with consumer's public key
         let decrypted = provider
@@ -270,12 +271,9 @@ mod tests {
             .unwrap();
 
         // Consumer decrypts
-        let decrypted = decrypt_with_keypair(
-            &consumer.secret,
-            &provider.public_key_bytes(),
-            &ciphertext,
-        )
-        .unwrap();
+        let decrypted =
+            decrypt_with_keypair(&consumer.secret, &provider.public_key_bytes(), &ciphertext)
+                .unwrap();
 
         assert_eq!(decrypted, plaintext);
     }
@@ -288,12 +286,9 @@ mod tests {
 
         let plaintext = b"Secret message";
 
-        let ciphertext = encrypt_with_keypair(
-            &consumer.secret,
-            &provider.public_key_bytes(),
-            plaintext,
-        )
-        .unwrap();
+        let ciphertext =
+            encrypt_with_keypair(&consumer.secret, &provider.public_key_bytes(), plaintext)
+                .unwrap();
 
         // Trying to decrypt with wrong consumer public key should fail
         let result = provider.decrypt(&wrong_key.public_key_bytes(), &ciphertext);
@@ -317,12 +312,9 @@ mod tests {
 
         let plaintext = b"";
 
-        let ciphertext = encrypt_with_keypair(
-            &consumer.secret,
-            &provider.public_key_bytes(),
-            plaintext,
-        )
-        .unwrap();
+        let ciphertext =
+            encrypt_with_keypair(&consumer.secret, &provider.public_key_bytes(), plaintext)
+                .unwrap();
 
         let decrypted = provider
             .decrypt(&consumer.public_key_bytes(), &ciphertext)
@@ -339,12 +331,9 @@ mod tests {
         // Simulate a large prompt
         let plaintext: Vec<u8> = (0..10_000).map(|i| (i % 256) as u8).collect();
 
-        let ciphertext = encrypt_with_keypair(
-            &consumer.secret,
-            &provider.public_key_bytes(),
-            &plaintext,
-        )
-        .unwrap();
+        let ciphertext =
+            encrypt_with_keypair(&consumer.secret, &provider.public_key_bytes(), &plaintext)
+                .unwrap();
 
         let decrypted = provider
             .decrypt(&consumer.public_key_bytes(), &ciphertext)
@@ -360,26 +349,22 @@ mod tests {
 
         let plaintext = b"Same message";
 
-        let ct1 = encrypt_with_keypair(
-            &consumer.secret,
-            &provider.public_key_bytes(),
-            plaintext,
-        )
-        .unwrap();
+        let ct1 = encrypt_with_keypair(&consumer.secret, &provider.public_key_bytes(), plaintext)
+            .unwrap();
 
-        let ct2 = encrypt_with_keypair(
-            &consumer.secret,
-            &provider.public_key_bytes(),
-            plaintext,
-        )
-        .unwrap();
+        let ct2 = encrypt_with_keypair(&consumer.secret, &provider.public_key_bytes(), plaintext)
+            .unwrap();
 
         // Different nonces should produce different ciphertext
         assert_ne!(ct1, ct2);
 
         // But both should decrypt to the same plaintext
-        let d1 = provider.decrypt(&consumer.public_key_bytes(), &ct1).unwrap();
-        let d2 = provider.decrypt(&consumer.public_key_bytes(), &ct2).unwrap();
+        let d1 = provider
+            .decrypt(&consumer.public_key_bytes(), &ct1)
+            .unwrap();
+        let d2 = provider
+            .decrypt(&consumer.public_key_bytes(), &ct2)
+            .unwrap();
         assert_eq!(d1, plaintext);
         assert_eq!(d2, plaintext);
     }

--- a/provider/src/hardware.rs
+++ b/provider/src/hardware.rs
@@ -254,7 +254,10 @@ fn sysctl_string(key: &str) -> Result<String> {
         .with_context(|| format!("failed to run sysctl -n {key}"))?;
 
     if !output.status.success() {
-        anyhow::bail!("sysctl -n {key} failed: {}", String::from_utf8_lossy(&output.stderr));
+        anyhow::bail!(
+            "sysctl -n {key} failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
     }
 
     Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
@@ -289,8 +292,8 @@ fn detect_gpu_info() -> Result<(String, u32)> {
         );
     }
 
-    let json: serde_json::Value = serde_json::from_slice(&output.stdout)
-        .context("failed to parse system_profiler JSON")?;
+    let json: serde_json::Value =
+        serde_json::from_slice(&output.stdout).context("failed to parse system_profiler JSON")?;
 
     let displays = json
         .get("SPDisplaysDataType")

--- a/provider/src/hypervisor.rs
+++ b/provider/src/hypervisor.rs
@@ -32,8 +32,8 @@
 //! └──────────────────────────────────────────────────┘
 //! ```
 
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Mutex;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 /// macOS 26 Hypervisor.framework requires 16 MB alignment for
 /// `hv_vm_map` host virtual addresses and sizes.
@@ -176,7 +176,12 @@ pub fn allocate_pool(pool_bytes: usize) -> Result<(), String> {
         for i in 0..num_chunks {
             let chunk_ptr = unsafe { aligned_base.add(i * CHUNK_SIZE) };
             let r = unsafe {
-                ffi::hv_vm_map(chunk_ptr as *const std::os::raw::c_void, gpa, CHUNK_SIZE, flags)
+                ffi::hv_vm_map(
+                    chunk_ptr as *const std::os::raw::c_void,
+                    gpa,
+                    CHUNK_SIZE,
+                    flags,
+                )
             };
             if r == ffi::HV_SUCCESS {
                 mapped_chunks += 1;

--- a/provider/src/inference.rs
+++ b/provider/src/inference.rs
@@ -84,8 +84,7 @@ impl InProcessEngine {
     ///   - The bundle is code-signed; any modification breaks the signature
     ///   - SIP enforces the signature
     fn lock_python_path(py: Python<'_>) -> Result<()> {
-        let exe = std::env::current_exe()
-            .context("cannot find executable path")?;
+        let exe = std::env::current_exe().context("cannot find executable path")?;
 
         // Find the app bundle's Frameworks/python directory
         let mut search = exe.as_path();
@@ -113,7 +112,8 @@ impl InProcessEngine {
                  import importlib\n\
                  importlib.invalidate_caches()\n",
                 bundled = path_str
-            )).unwrap();
+            ))
+            .unwrap();
             py.run(code.as_c_str(), None, None)
                 .context("failed to lock Python import path")?;
             tracing::info!("Python path locked to bundled packages: {}", path_str);
@@ -162,11 +162,9 @@ impl InProcessEngine {
     pub fn load(&mut self) -> Result<()> {
         self.engine_type = Self::detect_engine()?;
 
-        Python::with_gil(|py| {
-            match self.engine_type {
-                EngineType::VllmMlx => self.load_vllm_mlx(py),
-                EngineType::MlxLm => self.load_mlx_lm(py),
-            }
+        Python::with_gil(|py| match self.engine_type {
+            EngineType::VllmMlx => self.load_vllm_mlx(py),
+            EngineType::MlxLm => self.load_mlx_lm(py),
         })?;
 
         self.loaded = true;
@@ -238,8 +236,9 @@ impl InProcessEngine {
              outputs = _dginf_engine.generate([prompt], params)\n\
              _result_text = outputs[0].outputs[0].text\n\
              _result_prompt_tokens = len(outputs[0].prompt_token_ids)\n\
-             _result_completion_tokens = len(outputs[0].outputs[0].token_ids)\n"
-        ).unwrap();
+             _result_completion_tokens = len(outputs[0].outputs[0].token_ids)\n",
+        )
+        .unwrap();
         py.run(code.as_c_str(), None, Some(&locals))
             .context("vllm-mlx generate failed")?;
 
@@ -276,16 +275,19 @@ impl InProcessEngine {
         let mlx_lm = py.import("mlx_lm").context("failed to import mlx_lm")?;
         let builtins = py.import("builtins").context("failed to import builtins")?;
 
-        let model = builtins.getattr("_dginf_model")
+        let model = builtins
+            .getattr("_dginf_model")
             .context("model not loaded in builtins")?;
-        let tokenizer = builtins.getattr("_dginf_tokenizer")
+        let tokenizer = builtins
+            .getattr("_dginf_tokenizer")
             .context("tokenizer not loaded in builtins")?;
 
         let kwargs = PyDict::new(py);
         kwargs.set_item("prompt", prompt.as_str())?;
         kwargs.set_item("max_tokens", max_tokens)?;
 
-        let result = mlx_lm.call_method("generate", (model, tokenizer), Some(&kwargs))
+        let result = mlx_lm
+            .call_method("generate", (model, tokenizer), Some(&kwargs))
             .context("mlx-lm generate call failed")?;
 
         let text: String = result.extract().context("failed to extract result text")?;
@@ -385,10 +387,7 @@ fn format_chat_prompt(messages: &[serde_json::Value]) -> String {
     let mut prompt = String::new();
     for msg in messages {
         let role = msg.get("role").and_then(|r| r.as_str()).unwrap_or("user");
-        let content = msg
-            .get("content")
-            .and_then(|c| c.as_str())
-            .unwrap_or("");
+        let content = msg.get("content").and_then(|c| c.as_str()).unwrap_or("");
         prompt.push_str(&format!("<|im_start|>{role}\n{content}<|im_end|>\n"));
     }
     prompt.push_str("<|im_start|>assistant\n");

--- a/provider/src/main.rs
+++ b/provider/src/main.rs
@@ -33,6 +33,7 @@ mod inference;
 mod models;
 mod protocol;
 mod proxy;
+mod scheduling;
 mod security;
 mod server;
 mod service;
@@ -56,18 +57,83 @@ struct CatalogModel {
     min_ram_gb: i32,
 }
 
-fn default_model_type() -> String { "text".into() }
+fn default_model_type() -> String {
+    "text".into()
+}
 
 /// Hardcoded fallback catalog used when the coordinator is unreachable.
 fn fallback_catalog() -> Vec<CatalogModel> {
     vec![
-        CatalogModel { id: "CohereLabs/cohere-transcribe-03-2026".into(), s3_name: "cohere-transcribe-03-2026".into(), display_name: "Cohere Transcribe".into(), model_type: "transcription".into(), size_gb: 4.2, architecture: "2B conformer".into(), description: "Best-in-class STT".into(), min_ram_gb: 8 },
-        CatalogModel { id: "flux_2_klein_4b_q8p.ckpt".into(), s3_name: "flux-klein-4b-q8".into(), display_name: "FLUX.2 Klein 4B".into(), model_type: "image".into(), size_gb: 8.1, architecture: "4B diffusion".into(), description: "Fast image gen".into(), min_ram_gb: 16 },
-        CatalogModel { id: "flux_2_klein_9b_q8p.ckpt".into(), s3_name: "flux-klein-9b-q8".into(), display_name: "FLUX.2 Klein 9B".into(), model_type: "image".into(), size_gb: 13.0, architecture: "9B diffusion".into(), description: "Higher quality image gen".into(), min_ram_gb: 24 },
-        CatalogModel { id: "mlx-community/qwen3.5-27b-claude-opus-8bit-text-only".into(), s3_name: "qwen35-27b-claude-opus-8bit".into(), display_name: "Qwen3.5 27B Claude Opus".into(), model_type: "text".into(), size_gb: 27.0, architecture: "27B dense, Claude Opus distilled".into(), description: "Frontier quality reasoning".into(), min_ram_gb: 36 },
-        CatalogModel { id: "mlx-community/Trinity-Mini-8bit".into(), s3_name: "Trinity-Mini-8bit".into(), display_name: "Trinity Mini".into(), model_type: "text".into(), size_gb: 26.0, architecture: "27B Adaptive MoE".into(), description: "Fast agentic inference".into(), min_ram_gb: 48 },
-        CatalogModel { id: "mlx-community/Qwen3.5-122B-A10B-8bit".into(), s3_name: "Qwen3.5-122B-A10B-8bit".into(), display_name: "Qwen3.5 122B".into(), model_type: "text".into(), size_gb: 122.0, architecture: "122B MoE, 10B active".into(), description: "Best quality".into(), min_ram_gb: 128 },
-        CatalogModel { id: "mlx-community/MiniMax-M2.5-8bit".into(), s3_name: "MiniMax-M2.5-8bit".into(), display_name: "MiniMax M2.5".into(), model_type: "text".into(), size_gb: 243.0, architecture: "239B MoE, 11B active".into(), description: "SOTA coding, 100 tok/s".into(), min_ram_gb: 256 },
+        CatalogModel {
+            id: "CohereLabs/cohere-transcribe-03-2026".into(),
+            s3_name: "cohere-transcribe-03-2026".into(),
+            display_name: "Cohere Transcribe".into(),
+            model_type: "transcription".into(),
+            size_gb: 4.2,
+            architecture: "2B conformer".into(),
+            description: "Best-in-class STT".into(),
+            min_ram_gb: 8,
+        },
+        CatalogModel {
+            id: "flux_2_klein_4b_q8p.ckpt".into(),
+            s3_name: "flux-klein-4b-q8".into(),
+            display_name: "FLUX.2 Klein 4B".into(),
+            model_type: "image".into(),
+            size_gb: 8.1,
+            architecture: "4B diffusion".into(),
+            description: "Fast image gen".into(),
+            min_ram_gb: 16,
+        },
+        CatalogModel {
+            id: "flux_2_klein_9b_q8p.ckpt".into(),
+            s3_name: "flux-klein-9b-q8".into(),
+            display_name: "FLUX.2 Klein 9B".into(),
+            model_type: "image".into(),
+            size_gb: 13.0,
+            architecture: "9B diffusion".into(),
+            description: "Higher quality image gen".into(),
+            min_ram_gb: 24,
+        },
+        CatalogModel {
+            id: "mlx-community/qwen3.5-27b-claude-opus-8bit-text-only".into(),
+            s3_name: "qwen35-27b-claude-opus-8bit".into(),
+            display_name: "Qwen3.5 27B Claude Opus".into(),
+            model_type: "text".into(),
+            size_gb: 27.0,
+            architecture: "27B dense, Claude Opus distilled".into(),
+            description: "Frontier quality reasoning".into(),
+            min_ram_gb: 36,
+        },
+        CatalogModel {
+            id: "mlx-community/Trinity-Mini-8bit".into(),
+            s3_name: "Trinity-Mini-8bit".into(),
+            display_name: "Trinity Mini".into(),
+            model_type: "text".into(),
+            size_gb: 26.0,
+            architecture: "27B Adaptive MoE".into(),
+            description: "Fast agentic inference".into(),
+            min_ram_gb: 48,
+        },
+        CatalogModel {
+            id: "mlx-community/Qwen3.5-122B-A10B-8bit".into(),
+            s3_name: "Qwen3.5-122B-A10B-8bit".into(),
+            display_name: "Qwen3.5 122B".into(),
+            model_type: "text".into(),
+            size_gb: 122.0,
+            architecture: "122B MoE, 10B active".into(),
+            description: "Best quality".into(),
+            min_ram_gb: 128,
+        },
+        CatalogModel {
+            id: "mlx-community/MiniMax-M2.5-8bit".into(),
+            s3_name: "MiniMax-M2.5-8bit".into(),
+            display_name: "MiniMax M2.5".into(),
+            model_type: "text".into(),
+            size_gb: 243.0,
+            architecture: "239B MoE, 11B active".into(),
+            description: "SOTA coding, 100 tok/s".into(),
+            min_ram_gb: 256,
+        },
     ]
 }
 
@@ -92,12 +158,19 @@ fn get_available_disk_gb() -> f64 {
 /// Handles both single-file and sharded safetensors models by checking
 /// for `model.safetensors.index.json` and downloading each shard.
 fn download_model_from_cdn(s3_name: &str, cache_dir: &std::path::Path, display_name: &str) -> bool {
-    let base = format!("https://pub-7cbee059c80c46ec9c071dbee2726f8a.r2.dev/{}", s3_name);
+    let base = format!(
+        "https://pub-7cbee059c80c46ec9c071dbee2726f8a.r2.dev/{}",
+        s3_name
+    );
 
     // 1. Download config.json to verify the model exists on CDN
     let config_ok = std::process::Command::new("curl")
-        .args(["-fsSL", &format!("{}/config.json", base),
-               "-o", &cache_dir.join("config.json").to_string_lossy()])
+        .args([
+            "-fsSL",
+            &format!("{}/config.json", base),
+            "-o",
+            &cache_dir.join("config.json").to_string_lossy(),
+        ])
         .status()
         .map(|s| s.success())
         .unwrap_or(false);
@@ -108,10 +181,18 @@ fn download_model_from_cdn(s3_name: &str, cache_dir: &std::path::Path, display_n
     }
 
     // 2. Download tokenizer files
-    for f in &["tokenizer.json", "tokenizer_config.json", "special_tokens_map.json"] {
+    for f in &[
+        "tokenizer.json",
+        "tokenizer_config.json",
+        "special_tokens_map.json",
+    ] {
         let _ = std::process::Command::new("curl")
-            .args(["-fsSL", &format!("{}/{}", base, f),
-                   "-o", &cache_dir.join(f).to_string_lossy()])
+            .args([
+                "-fsSL",
+                &format!("{}/{}", base, f),
+                "-o",
+                &cache_dir.join(f).to_string_lossy(),
+            ])
             .status();
     }
 
@@ -127,8 +208,12 @@ fn download_model_from_cdn(s3_name: &str, cache_dir: &std::path::Path, display_n
     if single_ok {
         println!("  Downloading {} weights...", display_name);
         let ok = std::process::Command::new("curl")
-            .args(["-f#L", &format!("{}/model.safetensors", base),
-                   "-o", &cache_dir.join("model.safetensors").to_string_lossy()])
+            .args([
+                "-f#L",
+                &format!("{}/model.safetensors", base),
+                "-o",
+                &cache_dir.join("model.safetensors").to_string_lossy(),
+            ])
             .status()
             .map(|s| s.success())
             .unwrap_or(false);
@@ -141,8 +226,12 @@ fn download_model_from_cdn(s3_name: &str, cache_dir: &std::path::Path, display_n
     // 4. Sharded model: download index, parse shard names, download each
     let index_path = cache_dir.join("model.safetensors.index.json");
     let index_ok = std::process::Command::new("curl")
-        .args(["-fsSL", &format!("{}/model.safetensors.index.json", base),
-               "-o", &index_path.to_string_lossy()])
+        .args([
+            "-fsSL",
+            &format!("{}/model.safetensors.index.json", base),
+            "-o",
+            &index_path.to_string_lossy(),
+        ])
         .status()
         .map(|s| s.success())
         .unwrap_or(false);
@@ -155,11 +244,17 @@ fn download_model_from_cdn(s3_name: &str, cache_dir: &std::path::Path, display_n
     // Parse the index to get unique shard filenames
     let index_data = match std::fs::read_to_string(&index_path) {
         Ok(d) => d,
-        Err(_) => { println!("  ⚠ Could not read weight index"); return false; }
+        Err(_) => {
+            println!("  ⚠ Could not read weight index");
+            return false;
+        }
     };
     let index_json: serde_json::Value = match serde_json::from_str(&index_data) {
         Ok(v) => v,
-        Err(_) => { println!("  ⚠ Could not parse weight index"); return false; }
+        Err(_) => {
+            println!("  ⚠ Could not parse weight index");
+            return false;
+        }
     };
 
     let mut shards: Vec<String> = Vec::new();
@@ -179,13 +274,21 @@ fn download_model_from_cdn(s3_name: &str, cache_dir: &std::path::Path, display_n
         return false;
     }
 
-    println!("  Downloading {} ({} shards)...", display_name, shards.len());
+    println!(
+        "  Downloading {} ({} shards)...",
+        display_name,
+        shards.len()
+    );
     let mut all_ok = true;
     for (i, shard) in shards.iter().enumerate() {
         println!("  [{}/{}] {}", i + 1, shards.len(), shard);
         let ok = std::process::Command::new("curl")
-            .args(["-f#L", &format!("{}/{}", base, shard),
-                   "-o", &cache_dir.join(shard).to_string_lossy()])
+            .args([
+                "-f#L",
+                &format!("{}/{}", base, shard),
+                "-o",
+                &cache_dir.join(shard).to_string_lossy(),
+            ])
             .status()
             .map(|s| s.success())
             .unwrap_or(false);
@@ -259,7 +362,10 @@ enum Command {
         local: bool,
 
         /// Coordinator WebSocket URL
-        #[arg(long, default_value = "wss://inference-test.openinnovation.dev/ws/provider")]
+        #[arg(
+            long,
+            default_value = "wss://inference-test.openinnovation.dev/ws/provider"
+        )]
         coordinator: String,
 
         /// Port for local API server
@@ -283,11 +389,17 @@ enum Command {
     /// One-command setup: enroll in MDM, download model, start serving
     Install {
         /// Coordinator URL (WebSocket for serving, HTTPS for API)
-        #[arg(long, default_value = "wss://inference-test.openinnovation.dev/ws/provider")]
+        #[arg(
+            long,
+            default_value = "wss://inference-test.openinnovation.dev/ws/provider"
+        )]
         coordinator: String,
 
         /// MDM enrollment profile URL
-        #[arg(long, default_value = "https://inference-test.openinnovation.dev/enroll.mobileconfig")]
+        #[arg(
+            long,
+            default_value = "https://inference-test.openinnovation.dev/enroll.mobileconfig"
+        )]
         profile_url: String,
 
         /// Model to serve (auto-selects if not specified)
@@ -339,7 +451,10 @@ enum Command {
     /// Start the provider in the background (uses existing config)
     Start {
         /// Coordinator WebSocket URL
-        #[arg(long, default_value = "wss://inference-test.openinnovation.dev/ws/provider")]
+        #[arg(
+            long,
+            default_value = "wss://inference-test.openinnovation.dev/ws/provider"
+        )]
         coordinator: String,
 
         /// Model to serve
@@ -424,7 +539,10 @@ async fn main() -> Result<()> {
         Command::Unenroll => cmd_unenroll().await,
         Command::Benchmark => cmd_benchmark().await,
         Command::Status => cmd_status().await,
-        Command::Models { action, coordinator } => cmd_models(action, coordinator).await,
+        Command::Models {
+            action,
+            coordinator,
+        } => cmd_models(action, coordinator).await,
         Command::Earnings { coordinator } => cmd_earnings(coordinator).await,
         Command::Doctor { coordinator } => cmd_doctor(coordinator).await,
         Command::Start { coordinator, model } => cmd_start(coordinator, model).await,
@@ -473,8 +591,10 @@ async fn cmd_install(
     // Step 1: Detect hardware
     println!("Step 1/6: Detecting hardware...");
     let hw = hardware::detect()?;
-    println!("  ✓ {} ({} GB RAM, {} GPU cores, {} GB/s bandwidth)",
-        hw.chip_name, hw.memory_gb, hw.gpu_cores, hw.memory_bandwidth_gbs);
+    println!(
+        "  ✓ {} ({} GB RAM, {} GPU cores, {} GB/s bandwidth)",
+        hw.chip_name, hw.memory_gb, hw.gpu_cores, hw.memory_bandwidth_gbs
+    );
     println!();
 
     // Step 2: Initialize config, keys, and wallet
@@ -505,7 +625,10 @@ async fn cmd_install(
         let client = reqwest::Client::new();
         let resp = client.get(&profile_url).send().await?;
         if !resp.status().is_success() {
-            println!("  ⚠ Could not download profile (HTTP {}). Skipping MDM enrollment.", resp.status());
+            println!(
+                "  ⚠ Could not download profile (HTTP {}). Skipping MDM enrollment.",
+                resp.status()
+            );
             println!("    You can enroll later: dginf-provider enroll");
         } else {
             let profile_bytes = resp.bytes().await?;
@@ -517,7 +640,9 @@ async fn cmd_install(
                 println!("  Install it in System Settings → General → Device Management");
                 println!("  (Only queries security status — no access to personal data)");
                 println!();
-                let _ = std::process::Command::new("open").arg(&profile_path).status();
+                let _ = std::process::Command::new("open")
+                    .arg(&profile_path)
+                    .status();
             }
 
             println!("  Press Enter after installing (or to skip)...");
@@ -554,24 +679,39 @@ async fn cmd_install(
     };
 
     if ram >= 256 {
-        if let Some(m) = find_model("MiniMax-M2.5") { defaults.push(m); }
+        if let Some(m) = find_model("MiniMax-M2.5") {
+            defaults.push(m);
+        }
     } else if ram >= 128 {
-        if let Some(m) = find_model("Qwen3.5-122B") { defaults.push(m); }
+        if let Some(m) = find_model("Qwen3.5-122B") {
+            defaults.push(m);
+        }
     } else if ram >= 48 {
-        if let Some(m) = find_model("qwen3.5-27b-claude-opus") { defaults.push(m); }
+        if let Some(m) = find_model("qwen3.5-27b-claude-opus") {
+            defaults.push(m);
+        }
     } else if ram >= 36 {
-        if let Some(m) = find_model("qwen3.5-27b-claude-opus") { defaults.push(m); }
+        if let Some(m) = find_model("qwen3.5-27b-claude-opus") {
+            defaults.push(m);
+        }
     } else if ram >= 24 {
-        if let Some(m) = find_model("flux_2_klein_9b") { defaults.push(m); }
+        if let Some(m) = find_model("flux_2_klein_9b") {
+            defaults.push(m);
+        }
     } else if ram >= 16 {
-        if let Some(m) = find_model("flux_2_klein_4b") { defaults.push(m); }
+        if let Some(m) = find_model("flux_2_klein_4b") {
+            defaults.push(m);
+        }
     } else {
-        if let Some(m) = find_model("cohere-transcribe") { defaults.push(m); }
+        if let Some(m) = find_model("cohere-transcribe") {
+            defaults.push(m);
+        }
     }
 
     // Optionals: every catalog model that fits in RAM but isn't already a default
     let default_ids: Vec<&str> = defaults.iter().map(|m| m.id.as_str()).collect();
-    let optionals: Vec<&CatalogModel> = catalog.iter()
+    let optionals: Vec<&CatalogModel> = catalog
+        .iter()
         .filter(|m| m.min_ram_gb <= ram as i32)
         .filter(|m| !default_ids.contains(&m.id.as_str()))
         .collect();
@@ -586,8 +726,13 @@ async fn cmd_install(
         for m in &defaults {
             let downloaded = available.iter().any(|a| a.id == m.id);
             let status = if downloaded { "✓ ready" } else { "  " };
-            println!("    {} {:30} {:>5.1} GB  {:6}  {}", status, m.display_name, m.size_gb, m.model_type, m.description);
-            if !downloaded { total_default_size += m.size_gb; }
+            println!(
+                "    {} {:30} {:>5.1} GB  {:6}  {}",
+                status, m.display_name, m.size_gb, m.model_type, m.description
+            );
+            if !downloaded {
+                total_default_size += m.size_gb;
+            }
         }
         println!();
 
@@ -596,11 +741,17 @@ async fn cmd_install(
 
         if total_default_size > 0.0 {
             if total_default_size > disk_available_gb {
-                println!("  ⚠ Not enough disk space ({:.0} GB needed, {:.0} GB available)", total_default_size, disk_available_gb);
+                println!(
+                    "  ⚠ Not enough disk space ({:.0} GB needed, {:.0} GB available)",
+                    total_default_size, disk_available_gb
+                );
                 println!("  Free up disk space and retry: dginf-provider install");
             } else {
                 use std::io::Write;
-                print!("  Download default models? ({:.0} GB) [Y/n]: ", total_default_size);
+                print!(
+                    "  Download default models? ({:.0} GB) [Y/n]: ",
+                    total_default_size
+                );
                 std::io::stdout().flush()?;
                 let mut input = String::new();
                 std::io::stdin().read_line(&mut input)?;
@@ -625,7 +776,15 @@ async fn cmd_install(
             for (i, m) in optionals.iter().enumerate() {
                 let downloaded = available.iter().any(|a| a.id == m.id);
                 let status = if downloaded { "✓" } else { " " };
-                println!("    [{}] {} {:30} {:>5.1} GB  {:6}  {}", i + 1, status, m.display_name, m.size_gb, m.model_type, m.description);
+                println!(
+                    "    [{}] {} {:30} {:>5.1} GB  {:6}  {}",
+                    i + 1,
+                    status,
+                    m.display_name,
+                    m.size_gb,
+                    m.model_type,
+                    m.description
+                );
             }
             println!();
             use std::io::Write;
@@ -656,12 +815,14 @@ async fn cmd_install(
             .replace("/ws/provider", "");
 
         for model_id in &models_to_download {
-            let s3_name = catalog.iter()
+            let s3_name = catalog
+                .iter()
                 .find(|cm| cm.id == *model_id)
                 .map(|cm| cm.s3_name.as_str())
                 .unwrap_or_else(|| model_id.split('/').last().unwrap_or(model_id));
 
-            let display = catalog.iter()
+            let display = catalog
+                .iter()
                 .find(|cm| cm.id == *model_id)
                 .map(|cm| cm.display_name.as_str())
                 .unwrap_or(model_id);
@@ -669,7 +830,8 @@ async fn cmd_install(
             println!();
             println!("  Downloading {}...", display);
 
-            let cache_dir = dirs::home_dir().unwrap_or_default()
+            let cache_dir = dirs::home_dir()
+                .unwrap_or_default()
                 .join(".cache/huggingface/hub")
                 .join(format!("models--{}", model_id.replace('/', "--")))
                 .join("snapshots/main");
@@ -678,10 +840,14 @@ async fn cmd_install(
             // Try pre-packaged tarball first (fastest)
             let tarball_url = format!("{}/dl/models/{}.tar.gz", base_url, s3_name);
             let tar_status = std::process::Command::new("bash")
-                .args(["-c", &format!(
-                    "set -o pipefail; curl -f#L '{}' | tar xz -C '{}'",
-                    tarball_url, cache_dir.display()
-                )])
+                .args([
+                    "-c",
+                    &format!(
+                        "set -o pipefail; curl -f#L '{}' | tar xz -C '{}'",
+                        tarball_url,
+                        cache_dir.display()
+                    ),
+                ])
                 .status();
 
             match tar_status {
@@ -696,7 +862,8 @@ async fn cmd_install(
         if !defaults.is_empty() {
             defaults[0].id.clone()
         } else {
-            catalog.iter()
+            catalog
+                .iter()
                 .filter(|m| hw.memory_available_gb as f64 >= m.size_gb)
                 .last()
                 .map(|m| m.id.clone())
@@ -774,8 +941,12 @@ async fn cmd_serve(
     // Kill any existing provider/mlx_lm processes to avoid "address already in use"
     #[cfg(unix)]
     {
-        let _ = std::process::Command::new("pkill").args(["-f", "mlx_lm.server"]).status();
-        let _ = std::process::Command::new("pkill").args(["-f", "vllm_mlx"]).status();
+        let _ = std::process::Command::new("pkill")
+            .args(["-f", "mlx_lm.server"])
+            .status();
+        let _ = std::process::Command::new("pkill")
+            .args(["-f", "vllm_mlx"])
+            .status();
         // Small delay to let ports free up
         tokio::time::sleep(std::time::Duration::from_secs(1)).await;
     }
@@ -807,7 +978,10 @@ async fn cmd_serve(
             .stderr(std::process::Stdio::null())
             .spawn()
         {
-            Ok(_) => tracing::info!("Sleep prevention active (caffeinate watching PID {})", our_pid),
+            Ok(_) => tracing::info!(
+                "Sleep prevention active (caffeinate watching PID {})",
+                our_pid
+            ),
             Err(e) => tracing::warn!("Could not prevent sleep: {e}"),
         }
     }
@@ -900,7 +1074,11 @@ async fn cmd_serve(
         for pid in pids.split_whitespace() {
             if let Ok(pid_num) = pid.parse::<u32>() {
                 if pid_num != std::process::id() {
-                    tracing::info!("Killing existing process on port {}: PID {}", be_port, pid_num);
+                    tracing::info!(
+                        "Killing existing process on port {}: PID {}",
+                        be_port,
+                        pid_num
+                    );
                     let _ = std::process::Command::new("kill").arg(pid).output();
                 }
             }
@@ -917,11 +1095,13 @@ async fn cmd_serve(
         // Only set PYTHONHOME if this is a real standalone Python install
         // (not a symlink to uv/pyenv/system Python). Wrong PYTHONHOME causes
         // Python to fail to find its stdlib and crash silently.
-        let is_standalone = !bundled_python.is_symlink()
-            && dginf_dir.join("python/lib/python3.12/os.py").exists();
+        let is_standalone =
+            !bundled_python.is_symlink() && dginf_dir.join("python/lib/python3.12/os.py").exists();
         if is_standalone {
             tracing::info!("Using bundled Python: {}", bundled_python.display());
-            unsafe { std::env::set_var("PYTHONHOME", dginf_dir.join("python")); }
+            unsafe {
+                std::env::set_var("PYTHONHOME", dginf_dir.join("python"));
+            }
         } else {
             tracing::info!("Using Python at: {}", bundled_python.display());
         }
@@ -939,26 +1119,48 @@ async fn cmd_serve(
     // level, which would expose user prompts to the provider operator.
     // Health/crash detection uses HTTP health checks, not log parsing.
     let serve_result = std::process::Command::new(&python_cmd)
-        .args(["-m", "vllm_mlx.server", "--model", &model, "--port", &be_port.to_string()])
+        .args([
+            "-m",
+            "vllm_mlx.server",
+            "--model",
+            &model,
+            "--port",
+            &be_port.to_string(),
+        ])
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null())
         .spawn();
 
     let backend_name = match serve_result {
         Ok(child) => {
-            tracing::info!("vllm-mlx started (PID: {:?}) on port {}", child.id(), be_port);
+            tracing::info!(
+                "vllm-mlx started (PID: {:?}) on port {}",
+                child.id(),
+                be_port
+            );
             "vllm-mlx"
         }
         Err(e) => {
             tracing::info!("vllm-mlx CLI failed ({e}), falling back to mlx_lm.server");
             let mlx_serve = std::process::Command::new(&python_cmd)
-                .args(["-m", "mlx_lm.server", "--model", &model, "--port", &be_port.to_string()])
+                .args([
+                    "-m",
+                    "mlx_lm.server",
+                    "--model",
+                    &model,
+                    "--port",
+                    &be_port.to_string(),
+                ])
                 .stdout(std::process::Stdio::null())
                 .stderr(std::process::Stdio::null())
                 .spawn();
             match mlx_serve {
                 Ok(child) => {
-                    tracing::info!("mlx_lm.server started (PID: {:?}) on port {}", child.id(), be_port);
+                    tracing::info!(
+                        "mlx_lm.server started (PID: {:?}) on port {}",
+                        child.id(),
+                        be_port
+                    );
                     "mlx_lm"
                 }
                 Err(e) => anyhow::bail!(
@@ -988,17 +1190,30 @@ async fn cmd_serve(
         tracing::warn!("vllm_mlx backend did not become healthy — falling back to mlx_lm.server");
         #[cfg(unix)]
         {
-            let _ = std::process::Command::new("pkill").args(["-f", "vllm_mlx"]).status();
+            let _ = std::process::Command::new("pkill")
+                .args(["-f", "vllm_mlx"])
+                .status();
         }
         tokio::time::sleep(std::time::Duration::from_secs(1)).await;
         let mlx_serve = std::process::Command::new(&python_cmd)
-            .args(["-m", "mlx_lm.server", "--model", &model, "--port", &be_port.to_string()])
+            .args([
+                "-m",
+                "mlx_lm.server",
+                "--model",
+                &model,
+                "--port",
+                &be_port.to_string(),
+            ])
             .stdout(std::process::Stdio::null())
             .stderr(std::process::Stdio::null())
             .spawn();
         match mlx_serve {
             Ok(child) => {
-                tracing::info!("mlx_lm.server started (PID: {:?}) on port {}", child.id(), be_port);
+                tracing::info!(
+                    "mlx_lm.server started (PID: {:?}) on port {}",
+                    child.id(),
+                    be_port
+                );
                 // Wait for mlx_lm to load
                 for i in 0..30 {
                     tokio::time::sleep(std::time::Duration::from_secs(2)).await;
@@ -1025,8 +1240,7 @@ async fn cmd_serve(
     // DGINF_STT_MODEL_ID: clean model name for coordinator registration (optional,
     //   defaults to "CohereLabs/cohere-transcribe-03-2026").
     let stt_port = be_port + 1;
-    let stt_model_path = std::env::var("DGINF_STT_MODEL")
-        .unwrap_or_default();
+    let stt_model_path = std::env::var("DGINF_STT_MODEL").unwrap_or_default();
     let stt_model_id = std::env::var("DGINF_STT_MODEL_ID")
         .unwrap_or_else(|_| "CohereLabs/cohere-transcribe-03-2026".to_string());
     let stt_available = if !stt_model_path.is_empty() {
@@ -1042,18 +1256,26 @@ async fn cmd_serve(
             let stt_result = std::process::Command::new(&python_cmd)
                 .args([
                     &script,
-                    "--model", &stt_model_path,
-                    "--port", &stt_port.to_string(),
-                    "--host", "127.0.0.1",
-                    "--max-batch-size", "16",
-                    "--max-wait-ms", "100",
+                    "--model",
+                    &stt_model_path,
+                    "--port",
+                    &stt_port.to_string(),
+                    "--host",
+                    "127.0.0.1",
+                    "--max-batch-size",
+                    "16",
+                    "--max-wait-ms",
+                    "100",
                 ])
                 .stdout(std::process::Stdio::null())
                 .stderr(std::process::Stdio::null())
                 .spawn();
             match stt_result {
                 Ok(child) => {
-                    tracing::info!("STT server started (PID: {:?}) on port {stt_port}", child.id());
+                    tracing::info!(
+                        "STT server started (PID: {:?}) on port {stt_port}",
+                        child.id()
+                    );
                     // Wait for STT backend to be ready (model loading can take a few seconds)
                     let stt_url = format!("http://127.0.0.1:{stt_port}");
                     for i in 0..30 {
@@ -1084,8 +1306,8 @@ async fn cmd_serve(
     // DGINF_IMAGE_MODEL_PATH: model directory for gRPCServerCLI (optional).
     let image_port = be_port + 2;
     let image_model = std::env::var("DGINF_IMAGE_MODEL").unwrap_or_default();
-    let image_model_id = std::env::var("DGINF_IMAGE_MODEL_ID")
-        .unwrap_or_else(|_| image_model.clone());
+    let image_model_id =
+        std::env::var("DGINF_IMAGE_MODEL_ID").unwrap_or_else(|_| image_model.clone());
     let image_model_path = std::env::var("DGINF_IMAGE_MODEL_PATH").unwrap_or_default();
     let image_available = if !image_model.is_empty() {
         tracing::info!("Starting image bridge on port {image_port} for model: {image_model}");
@@ -1095,9 +1317,10 @@ async fn cmd_serve(
         // Set PYTHONPATH so the image bridge package is importable.
         // Look for it next to the binary, in ~/.dginf, or in the source tree.
         let bridge_paths: Vec<String> = [
-            std::env::current_exe()
-                .ok()
-                .and_then(|p| p.parent().map(|d| d.join("image-bridge").to_string_lossy().to_string())),
+            std::env::current_exe().ok().and_then(|p| {
+                p.parent()
+                    .map(|d| d.join("image-bridge").to_string_lossy().to_string())
+            }),
             dirs::home_dir().map(|d| d.join(".dginf/image-bridge").to_string_lossy().to_string()),
         ]
         .iter()
@@ -1113,9 +1336,12 @@ async fn cmd_serve(
         }
 
         bridge_cmd.args([
-            "-m", "dginf_image_bridge",
-            "--port", &image_port.to_string(),
-            "--model", &image_model,
+            "-m",
+            "dginf_image_bridge",
+            "--port",
+            &image_port.to_string(),
+            "--model",
+            &image_model,
         ]);
         if !image_model_path.is_empty() {
             bridge_cmd.args(["--model-path", &image_model_path]);
@@ -1162,172 +1388,220 @@ async fn cmd_serve(
         tracing::info!("Local-only mode on port {port}");
         server::start_server(port, backend_url).await?;
     } else {
-        // Coordinator mode: connect WebSocket + proxy
-        tracing::info!("Connecting to coordinator: {coordinator_url}");
+        // Parse schedule from config
+        let schedule = cfg
+            .schedule
+            .as_ref()
+            .and_then(scheduling::Schedule::from_config);
 
-        // Only advertise the model we're actually serving. The provider
-        // can only serve one model at a time (the one loaded in vllm-mlx).
-        // Advertising all cached models causes routing failures when the
-        // coordinator sends requests for a model that isn't loaded.
-        let all_models = models::scan_models(&hw);
-        let mut available_models: Vec<_> = all_models
-            .into_iter()
-            .filter(|m| m.id == model)
-            .collect();
-        if available_models.is_empty() {
-            tracing::warn!("Active model {model} not found in scanned models — registering with ID only");
+        if let Some(ref sched) = schedule {
+            tracing::info!("Schedule enabled: {}", sched.describe());
         }
 
-        // Advertise STT model if available
-        if stt_available && !stt_model_id.is_empty() {
-            available_models.push(models::ModelInfo {
-                id: stt_model_id.clone(),
-                model_type: Some("stt".to_string()),
-                parameters: None,
-                quantization: None,
-                size_bytes: 0,
-                estimated_memory_gb: 4.0,
-            });
-            tracing::info!("Advertising STT model: {stt_model_id}");
-        }
-
-        // Advertise image model if available
-        if image_available && !image_model_id.is_empty() {
-            available_models.push(models::ModelInfo {
-                id: image_model_id.clone(),
-                model_type: Some("image".to_string()),
-                parameters: None,
-                quantization: None,
-                size_bytes: 0,
-                estimated_memory_gb: 8.0,
-            });
-            tracing::info!("Advertising image model: {image_model_id}");
-        }
-        let (event_tx, mut event_rx) = tokio::sync::mpsc::channel(64);
-        let (outbound_tx, outbound_rx) = tokio::sync::mpsc::channel(64);
-        let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
-
-        let backend_name = "vllm_mlx";
-
-        let public_key_b64 = node_keypair.public_key_base64();
-
-        // Compute SHA-256 of our own binary for integrity attestation.
-        let binary_hash = security::self_binary_hash();
-
-        // Generate Secure Enclave attestation, binding the X25519 encryption key
-        // and our binary hash (so coordinator can verify we're running blessed code).
-        let attestation = generate_attestation(&public_key_b64, binary_hash.as_deref());
-
-        // Load device auth token if the provider has been linked to an account.
-        let auth_token = load_auth_token();
-        if auth_token.is_some() {
-            tracing::info!("Provider linked to account (auth token loaded)");
-        }
-
-        // Shared flag: true when inference is in progress. Health monitor
-        // skips crash detection while the backend is busy generating tokens,
-        // because the Python GIL blocks /health during inference.
-        let inference_active = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
-        let health_inference_active = inference_active.clone();
-
-        // Shared atomic counters for stats reported in heartbeats.
-        let provider_stats = std::sync::Arc::new(coordinator::AtomicProviderStats::new());
-
-        // Shared current model name for heartbeat reporting.
-        let current_model: std::sync::Arc<std::sync::Mutex<Option<String>>> =
-            std::sync::Arc::new(std::sync::Mutex::new(Some(model.clone())));
-
-        let client = coordinator::CoordinatorClient::new(
-            coordinator_url,
-            hw.clone(),
-            available_models,
-            backend_name.to_string(),
-            std::time::Duration::from_secs(cfg.coordinator.heartbeat_interval_secs),
-            Some(public_key_b64),
-        )
-        .with_attestation(attestation)
-        .with_wallet_address(
-            wallet::Wallet::load_or_create()
-                .ok()
-                .map(|w| w.address.clone())
-        )
-        .with_auth_token(auth_token)
-        .with_stats(provider_stats.clone())
-        .with_inference_active(inference_active.clone())
-        .with_current_model(current_model);
-
-        // Spawn coordinator connection
-        let coordinator_handle = tokio::spawn(async move {
-            if let Err(e) = client.run(event_tx, outbound_rx, shutdown_rx).await {
-                tracing::error!("Coordinator connection error: {e}");
-            }
-        });
-
-        // Spawn backend health monitor — detects crashes and auto-restarts.
-        let health_url = backend_url_str.clone();
-        let health_python = python_cmd.clone();
-        let health_backend = backend_name.to_string();
-        let health_model = model.clone();
-        let health_port = be_port;
-        tokio::spawn(async move {
-            let mut interval = tokio::time::interval(std::time::Duration::from_secs(15));
-            let mut consecutive_failures = 0u32;
-            loop {
-                interval.tick().await;
-
-                // Skip crash detection while inference is active — the Python
-                // GIL blocks /health while generating tokens, causing false
-                // positives that trigger unnecessary restarts.
-                if health_inference_active.load(std::sync::atomic::Ordering::Relaxed) {
-                    consecutive_failures = 0;
-                    continue;
+        // Coordinator mode — schedule-aware loop. When scheduling is enabled,
+        // the provider waits for the next window before connecting, and
+        // disconnects when the window closes. Without scheduling, this loop
+        // runs exactly once and blocks on Ctrl+C.
+        'schedule_loop: loop {
+            // Wait for schedule window if needed
+            if let Some(ref sched) = schedule {
+                while !sched.is_active_now() {
+                    let wait = sched.duration_until_next_active();
+                    tracing::info!(
+                        "Outside schedule window — sleeping for {}",
+                        scheduling::format_duration(wait)
+                    );
+                    tokio::select! {
+                        _ = tokio::time::sleep(wait) => continue,
+                        _ = tokio::signal::ctrl_c() => break 'schedule_loop,
+                    }
                 }
+                tracing::info!("Schedule window active — coming online");
+            }
 
-                if backend::check_health(&health_url).await {
-                    if consecutive_failures > 0 {
-                        tracing::info!("Backend recovered after {} failed health checks", consecutive_failures);
+            // Coordinator mode: connect WebSocket + proxy
+            tracing::info!("Connecting to coordinator: {coordinator_url}");
+
+            // Only advertise the model we're actually serving. The provider
+            // can only serve one model at a time (the one loaded in vllm-mlx).
+            // Advertising all cached models causes routing failures when the
+            // coordinator sends requests for a model that isn't loaded.
+            let all_models = models::scan_models(&hw);
+            let mut available_models: Vec<_> =
+                all_models.into_iter().filter(|m| m.id == model).collect();
+            if available_models.is_empty() {
+                tracing::warn!(
+                    "Active model {model} not found in scanned models — registering with ID only"
+                );
+            }
+
+            // Advertise STT model if available
+            if stt_available && !stt_model_id.is_empty() {
+                available_models.push(models::ModelInfo {
+                    id: stt_model_id.clone(),
+                    model_type: Some("stt".to_string()),
+                    parameters: None,
+                    quantization: None,
+                    size_bytes: 0,
+                    estimated_memory_gb: 4.0,
+                });
+                tracing::info!("Advertising STT model: {stt_model_id}");
+            }
+
+            // Advertise image model if available
+            if image_available && !image_model_id.is_empty() {
+                available_models.push(models::ModelInfo {
+                    id: image_model_id.clone(),
+                    model_type: Some("image".to_string()),
+                    parameters: None,
+                    quantization: None,
+                    size_bytes: 0,
+                    estimated_memory_gb: 8.0,
+                });
+                tracing::info!("Advertising image model: {image_model_id}");
+            }
+            let (event_tx, mut event_rx) = tokio::sync::mpsc::channel(64);
+            let (outbound_tx, outbound_rx) = tokio::sync::mpsc::channel(64);
+            let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+
+            let backend_name = "vllm_mlx";
+
+            let public_key_b64 = node_keypair.public_key_base64();
+
+            // Compute SHA-256 of our own binary for integrity attestation.
+            let binary_hash = security::self_binary_hash();
+
+            // Generate Secure Enclave attestation, binding the X25519 encryption key
+            // and our binary hash (so coordinator can verify we're running blessed code).
+            let attestation = generate_attestation(&public_key_b64, binary_hash.as_deref());
+
+            // Load device auth token if the provider has been linked to an account.
+            let auth_token = load_auth_token();
+            if auth_token.is_some() {
+                tracing::info!("Provider linked to account (auth token loaded)");
+            }
+
+            // Shared flag: true when inference is in progress. Health monitor
+            // skips crash detection while the backend is busy generating tokens,
+            // because the Python GIL blocks /health during inference.
+            let inference_active = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+            let health_inference_active = inference_active.clone();
+
+            // Shared atomic counters for stats reported in heartbeats.
+            let provider_stats = std::sync::Arc::new(coordinator::AtomicProviderStats::new());
+
+            // Shared current model name for heartbeat reporting.
+            let current_model: std::sync::Arc<std::sync::Mutex<Option<String>>> =
+                std::sync::Arc::new(std::sync::Mutex::new(Some(model.clone())));
+
+            let client = coordinator::CoordinatorClient::new(
+                coordinator_url.clone(),
+                hw.clone(),
+                available_models,
+                backend_name.to_string(),
+                std::time::Duration::from_secs(cfg.coordinator.heartbeat_interval_secs),
+                Some(public_key_b64),
+            )
+            .with_attestation(attestation)
+            .with_wallet_address(
+                wallet::Wallet::load_or_create()
+                    .ok()
+                    .map(|w| w.address.clone()),
+            )
+            .with_auth_token(auth_token)
+            .with_stats(provider_stats.clone())
+            .with_inference_active(inference_active.clone())
+            .with_current_model(current_model);
+
+            // Spawn coordinator connection
+            let coordinator_handle = tokio::spawn(async move {
+                if let Err(e) = client.run(event_tx, outbound_rx, shutdown_rx).await {
+                    tracing::error!("Coordinator connection error: {e}");
+                }
+            });
+
+            // Spawn backend health monitor — detects crashes and auto-restarts.
+            let health_url = backend_url_str.clone();
+            let health_python = python_cmd.clone();
+            let health_backend = backend_name.to_string();
+            let health_model = model.clone();
+            let health_port = be_port;
+            tokio::spawn(async move {
+                let mut interval = tokio::time::interval(std::time::Duration::from_secs(15));
+                let mut consecutive_failures = 0u32;
+                loop {
+                    interval.tick().await;
+
+                    // Skip crash detection while inference is active — the Python
+                    // GIL blocks /health while generating tokens, causing false
+                    // positives that trigger unnecessary restarts.
+                    if health_inference_active.load(std::sync::atomic::Ordering::Relaxed) {
                         consecutive_failures = 0;
+                        continue;
                     }
-                } else {
-                    consecutive_failures += 1;
-                    tracing::warn!("Backend health check failed ({consecutive_failures} consecutive)");
-                    if consecutive_failures >= 8 {
-                        tracing::error!("Backend appears crashed — restarting...");
-                        // Kill any zombie processes
-                        #[cfg(unix)]
-                        {
-                            let _ = std::process::Command::new("pkill").args(["-f", "vllm_mlx"]).status();
-                            let _ = std::process::Command::new("pkill").args(["-f", "mlx_lm.server"]).status();
-                        }
-                        tokio::time::sleep(std::time::Duration::from_secs(2)).await;
 
-                        match reload_backend(&health_python, &health_backend, &health_model, health_port).await {
-                            Ok(()) => {
-                                tracing::info!("Backend auto-restarted successfully");
-                                consecutive_failures = 0;
+                    if backend::check_health(&health_url).await {
+                        if consecutive_failures > 0 {
+                            tracing::info!(
+                                "Backend recovered after {} failed health checks",
+                                consecutive_failures
+                            );
+                            consecutive_failures = 0;
+                        }
+                    } else {
+                        consecutive_failures += 1;
+                        tracing::warn!(
+                            "Backend health check failed ({consecutive_failures} consecutive)"
+                        );
+                        if consecutive_failures >= 8 {
+                            tracing::error!("Backend appears crashed — restarting...");
+                            // Kill any zombie processes
+                            #[cfg(unix)]
+                            {
+                                let _ = std::process::Command::new("pkill")
+                                    .args(["-f", "vllm_mlx"])
+                                    .status();
+                                let _ = std::process::Command::new("pkill")
+                                    .args(["-f", "mlx_lm.server"])
+                                    .status();
                             }
-                            Err(e) => {
-                                tracing::error!("Backend auto-restart failed: {e}");
+                            tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+
+                            match reload_backend(
+                                &health_python,
+                                &health_backend,
+                                &health_model,
+                                health_port,
+                            )
+                            .await
+                            {
+                                Ok(()) => {
+                                    tracing::info!("Backend auto-restarted successfully");
+                                    consecutive_failures = 0;
+                                }
+                                Err(e) => {
+                                    tracing::error!("Backend auto-restart failed: {e}");
+                                }
                             }
                         }
                     }
                 }
-            }
-        });
+            });
 
-        // Process coordinator events
-        let proxy_backend_url = backend_url.clone();
-        let proxy_keypair = node_keypair.clone();
-        let is_inprocess = proxy_backend_url.starts_with("inprocess://");
-        let idle_model = model.clone();
-        let idle_python_cmd = python_cmd.clone();
-        let idle_be_port = be_port;
-        let idle_backend_name = backend_name.to_string();
-        let proxy_stats = provider_stats.clone();
+            // Process coordinator events
+            let proxy_backend_url = backend_url.clone();
+            let proxy_keypair = node_keypair.clone();
+            let is_inprocess = proxy_backend_url.starts_with("inprocess://");
+            let idle_model = model.clone();
+            let idle_python_cmd = python_cmd.clone();
+            let idle_be_port = be_port;
+            let idle_backend_name = backend_name.to_string();
+            let proxy_stats = provider_stats.clone();
 
-        #[cfg(feature = "python")]
-        let shared_engine: Option<std::sync::Arc<tokio::sync::Mutex<inference::InProcessEngine>>> =
-            if is_inprocess {
+            #[cfg(feature = "python")]
+            let shared_engine: Option<
+                std::sync::Arc<tokio::sync::Mutex<inference::InProcessEngine>>,
+            > = if is_inprocess {
                 let mut engine = inference::InProcessEngine::new(model.clone());
                 if let Err(e) = engine.load() {
                     tracing::error!("Failed to load in-process engine for event loop: {e}");
@@ -1338,228 +1612,263 @@ async fn cmd_serve(
                 None
             };
 
-        let event_handle = tokio::spawn(async move {
-            use std::collections::HashMap;
-            use tokio_util::sync::CancellationToken;
+            let event_handle = tokio::spawn(async move {
+                use std::collections::HashMap;
+                use tokio_util::sync::CancellationToken;
 
-            // Track in-flight inference tasks so we can cancel them on
-            // coordinator disconnect or explicit cancel messages.
-            let mut inflight: HashMap<String, (CancellationToken, tokio::task::JoinHandle<()>)> =
-                HashMap::new();
-            let (done_tx, mut done_rx) = tokio::sync::mpsc::channel::<String>(64);
+                // Track in-flight inference tasks so we can cancel them on
+                // coordinator disconnect or explicit cancel messages.
+                let mut inflight: HashMap<
+                    String,
+                    (CancellationToken, tokio::task::JoinHandle<()>),
+                > = HashMap::new();
+                let (done_tx, mut done_rx) = tokio::sync::mpsc::channel::<String>(64);
 
-            // Idle timeout: shut down the backend after 10 minutes of no
-            // requests to free GPU memory. Lazy-reload on next request.
-            const IDLE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10 * 60);
-            let mut last_request_time = tokio::time::Instant::now();
-            let mut backend_running = true;
+                // Idle timeout: shut down the backend after 10 minutes of no
+                // requests to free GPU memory. Lazy-reload on next request.
+                const IDLE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10 * 60);
+                let mut last_request_time = tokio::time::Instant::now();
+                let mut backend_running = true;
 
-            loop {
-                let idle_sleep = async {
-                    if backend_running && inflight.is_empty() {
-                        tokio::time::sleep_until(last_request_time + IDLE_TIMEOUT).await;
-                    } else {
-                        std::future::pending::<()>().await;
-                    }
-                };
+                loop {
+                    let idle_sleep = async {
+                        if backend_running && inflight.is_empty() {
+                            tokio::time::sleep_until(last_request_time + IDLE_TIMEOUT).await;
+                        } else {
+                            std::future::pending::<()>().await;
+                        }
+                    };
 
-                tokio::select! {
-                    event = event_rx.recv() => {
-                        let Some(event) = event else { break };
-                        match event {
-                            coordinator::CoordinatorEvent::Connected => {
-                                tracing::info!("Connected to coordinator");
-                            }
-                            coordinator::CoordinatorEvent::Disconnected => {
-                                let count = inflight.len();
-                                if count > 0 {
-                                    tracing::warn!(
-                                        "Disconnected from coordinator — aborting {count} in-flight request(s)"
-                                    );
-                                    for (rid, (token, handle)) in inflight.drain() {
-                                        tracing::info!("Aborting request {rid} (coordinator disconnected)");
-                                        token.cancel();
-                                        handle.abort();
-                                    }
-                                    inference_active.store(false, std::sync::atomic::Ordering::Relaxed);
-                                } else {
-                                    tracing::warn!("Disconnected from coordinator");
+                    tokio::select! {
+                        event = event_rx.recv() => {
+                            let Some(event) = event else { break };
+                            match event {
+                                coordinator::CoordinatorEvent::Connected => {
+                                    tracing::info!("Connected to coordinator");
                                 }
-                            }
-                            coordinator::CoordinatorEvent::InferenceRequest { request_id, body } => {
-                                last_request_time = tokio::time::Instant::now();
-                                inference_active.store(true, std::sync::atomic::Ordering::Relaxed);
-
-                                // Reload backend if it was idle-shutdown
-                                if !backend_running {
-                                    tracing::info!("Backend idle-shutdown — reloading for incoming request");
-                                    match reload_backend(
-                                        &idle_python_cmd,
-                                        &idle_backend_name,
-                                        &idle_model,
-                                        idle_be_port,
-                                    ).await {
-                                        Ok(()) => {
-                                            backend_running = true;
+                                coordinator::CoordinatorEvent::Disconnected => {
+                                    let count = inflight.len();
+                                    if count > 0 {
+                                        tracing::warn!(
+                                            "Disconnected from coordinator — aborting {count} in-flight request(s)"
+                                        );
+                                        for (rid, (token, handle)) in inflight.drain() {
+                                            tracing::info!("Aborting request {rid} (coordinator disconnected)");
+                                            token.cancel();
+                                            handle.abort();
                                         }
-                                        Err(e) => {
-                                            tracing::error!("Failed to reload backend: {e}");
-                                            let _ = outbound_tx.send(
-                                                protocol::ProviderMessage::InferenceError {
-                                                    request_id,
-                                                    error: format!("backend reload failed: {e}"),
-                                                    status_code: 503,
-                                                }
-                                            ).await;
-                                            continue;
-                                        }
-                                    }
-                                }
-
-                                let tx = outbound_tx.clone();
-                                let cancel_token = CancellationToken::new();
-                                let token_clone = cancel_token.clone();
-                                let done_tx = done_tx.clone();
-                                let rid = request_id.clone();
-
-                                let handle = {
-                                    #[cfg(feature = "python")]
-                                    if let Some(ref engine) = shared_engine {
-                                        let engine = engine.clone();
-                                        let rid2 = rid.clone();
-                                        let stats = proxy_stats.clone();
-                                        tokio::spawn(async move {
-                                            handle_inprocess_request(rid2, body, engine, tx, Some(stats)).await;
-                                            let _ = done_tx.send(rid).await;
-                                        })
-                                    } else {
-                                        let url = proxy_backend_url.clone();
-                                        let kp = proxy_keypair.clone();
-                                        let rid2 = rid.clone();
-                                        let stats = proxy_stats.clone();
-                                        tokio::spawn(async move {
-                                            proxy::handle_inference_request(rid2, body, url, tx, Some(kp), token_clone, Some(stats)).await;
-                                            let _ = done_tx.send(rid).await;
-                                        })
-                                    }
-
-                                    #[cfg(not(feature = "python"))]
-                                    {
-                                        let url = proxy_backend_url.clone();
-                                        let kp = proxy_keypair.clone();
-                                        let rid2 = rid.clone();
-                                        let stats = proxy_stats.clone();
-                                        tokio::spawn(async move {
-                                            proxy::handle_inference_request(rid2, body, url, tx, Some(kp), token_clone, Some(stats)).await;
-                                            let _ = done_tx.send(rid).await;
-                                        })
-                                    }
-                                };
-
-                                inflight.insert(request_id, (cancel_token, handle));
-                            }
-                            coordinator::CoordinatorEvent::TranscriptionRequest { request_id, body } => {
-                                last_request_time = tokio::time::Instant::now();
-                                inference_active.store(true, std::sync::atomic::Ordering::Relaxed);
-
-                                let tx = outbound_tx.clone();
-                                let cancel_token = CancellationToken::new();
-                                let token_clone = cancel_token.clone();
-                                let done_tx = done_tx.clone();
-                                let rid = request_id.clone();
-                                let stt_url = proxy_backend_url.clone().replace(
-                                    &format!(":{}", be_port),
-                                    &format!(":{}", be_port + 1),
-                                );
-
-                                let handle = tokio::spawn(async move {
-                                    proxy::handle_transcription_request(
-                                        rid.clone(), body, stt_url, tx, token_clone,
-                                    ).await;
-                                    let _ = done_tx.send(rid).await;
-                                });
-
-                                inflight.insert(request_id, (cancel_token, handle));
-                            }
-                            coordinator::CoordinatorEvent::ImageGenerationRequest { request_id, body, upload_url } => {
-                                last_request_time = tokio::time::Instant::now();
-
-                                let tx = outbound_tx.clone();
-                                let cancel_token = CancellationToken::new();
-                                let token_clone = cancel_token.clone();
-                                let done_tx = done_tx.clone();
-                                let rid = request_id.clone();
-                                let image_url = proxy_backend_url.clone().replace(
-                                    &format!(":{}", be_port),
-                                    &format!(":{}", be_port + 2),
-                                );
-
-                                let handle = tokio::spawn(async move {
-                                    proxy::handle_image_generation_request(
-                                        rid.clone(), body, image_url, upload_url, tx, token_clone,
-                                    ).await;
-                                    let _ = done_tx.send(rid).await;
-                                });
-
-                                inflight.insert(request_id, (cancel_token, handle));
-                            }
-                            coordinator::CoordinatorEvent::Cancel { request_id } => {
-                                if let Some((token, _handle)) = inflight.remove(&request_id) {
-                                    tracing::info!("Cancelling request {request_id}");
-                                    token.cancel();
-                                    if inflight.is_empty() {
                                         inference_active.store(false, std::sync::atomic::Ordering::Relaxed);
+                                    } else {
+                                        tracing::warn!("Disconnected from coordinator");
                                     }
-                                } else {
-                                    tracing::warn!("Cancel for unknown request {request_id}");
+                                }
+                                coordinator::CoordinatorEvent::InferenceRequest { request_id, body } => {
+                                    last_request_time = tokio::time::Instant::now();
+                                    inference_active.store(true, std::sync::atomic::Ordering::Relaxed);
+
+                                    // Reload backend if it was idle-shutdown
+                                    if !backend_running {
+                                        tracing::info!("Backend idle-shutdown — reloading for incoming request");
+                                        match reload_backend(
+                                            &idle_python_cmd,
+                                            &idle_backend_name,
+                                            &idle_model,
+                                            idle_be_port,
+                                        ).await {
+                                            Ok(()) => {
+                                                backend_running = true;
+                                            }
+                                            Err(e) => {
+                                                tracing::error!("Failed to reload backend: {e}");
+                                                let _ = outbound_tx.send(
+                                                    protocol::ProviderMessage::InferenceError {
+                                                        request_id,
+                                                        error: format!("backend reload failed: {e}"),
+                                                        status_code: 503,
+                                                    }
+                                                ).await;
+                                                continue;
+                                            }
+                                        }
+                                    }
+
+                                    let tx = outbound_tx.clone();
+                                    let cancel_token = CancellationToken::new();
+                                    let token_clone = cancel_token.clone();
+                                    let done_tx = done_tx.clone();
+                                    let rid = request_id.clone();
+
+                                    let handle = {
+                                        #[cfg(feature = "python")]
+                                        if let Some(ref engine) = shared_engine {
+                                            let engine = engine.clone();
+                                            let rid2 = rid.clone();
+                                            let stats = proxy_stats.clone();
+                                            tokio::spawn(async move {
+                                                handle_inprocess_request(rid2, body, engine, tx, Some(stats)).await;
+                                                let _ = done_tx.send(rid).await;
+                                            })
+                                        } else {
+                                            let url = proxy_backend_url.clone();
+                                            let kp = proxy_keypair.clone();
+                                            let rid2 = rid.clone();
+                                            let stats = proxy_stats.clone();
+                                            tokio::spawn(async move {
+                                                proxy::handle_inference_request(rid2, body, url, tx, Some(kp), token_clone, Some(stats)).await;
+                                                let _ = done_tx.send(rid).await;
+                                            })
+                                        }
+
+                                        #[cfg(not(feature = "python"))]
+                                        {
+                                            let url = proxy_backend_url.clone();
+                                            let kp = proxy_keypair.clone();
+                                            let rid2 = rid.clone();
+                                            let stats = proxy_stats.clone();
+                                            tokio::spawn(async move {
+                                                proxy::handle_inference_request(rid2, body, url, tx, Some(kp), token_clone, Some(stats)).await;
+                                                let _ = done_tx.send(rid).await;
+                                            })
+                                        }
+                                    };
+
+                                    inflight.insert(request_id, (cancel_token, handle));
+                                }
+                                coordinator::CoordinatorEvent::TranscriptionRequest { request_id, body } => {
+                                    last_request_time = tokio::time::Instant::now();
+                                    inference_active.store(true, std::sync::atomic::Ordering::Relaxed);
+
+                                    let tx = outbound_tx.clone();
+                                    let cancel_token = CancellationToken::new();
+                                    let token_clone = cancel_token.clone();
+                                    let done_tx = done_tx.clone();
+                                    let rid = request_id.clone();
+                                    let stt_url = proxy_backend_url.clone().replace(
+                                        &format!(":{}", be_port),
+                                        &format!(":{}", be_port + 1),
+                                    );
+
+                                    let handle = tokio::spawn(async move {
+                                        proxy::handle_transcription_request(
+                                            rid.clone(), body, stt_url, tx, token_clone,
+                                        ).await;
+                                        let _ = done_tx.send(rid).await;
+                                    });
+
+                                    inflight.insert(request_id, (cancel_token, handle));
+                                }
+                                coordinator::CoordinatorEvent::ImageGenerationRequest { request_id, body, upload_url } => {
+                                    last_request_time = tokio::time::Instant::now();
+
+                                    let tx = outbound_tx.clone();
+                                    let cancel_token = CancellationToken::new();
+                                    let token_clone = cancel_token.clone();
+                                    let done_tx = done_tx.clone();
+                                    let rid = request_id.clone();
+                                    let image_url = proxy_backend_url.clone().replace(
+                                        &format!(":{}", be_port),
+                                        &format!(":{}", be_port + 2),
+                                    );
+
+                                    let handle = tokio::spawn(async move {
+                                        proxy::handle_image_generation_request(
+                                            rid.clone(), body, image_url, upload_url, tx, token_clone,
+                                        ).await;
+                                        let _ = done_tx.send(rid).await;
+                                    });
+
+                                    inflight.insert(request_id, (cancel_token, handle));
+                                }
+                                coordinator::CoordinatorEvent::Cancel { request_id } => {
+                                    if let Some((token, _handle)) = inflight.remove(&request_id) {
+                                        tracing::info!("Cancelling request {request_id}");
+                                        token.cancel();
+                                        if inflight.is_empty() {
+                                            inference_active.store(false, std::sync::atomic::Ordering::Relaxed);
+                                        }
+                                    } else {
+                                        tracing::warn!("Cancel for unknown request {request_id}");
+                                    }
+                                }
+                                coordinator::CoordinatorEvent::AttestationChallenge { nonce, timestamp } => {
+                                    tracing::debug!(
+                                        "Attestation challenge event received (nonce={}, ts={})",
+                                        &nonce[..8.min(nonce.len())],
+                                        timestamp
+                                    );
                                 }
                             }
-                            coordinator::CoordinatorEvent::AttestationChallenge { nonce, timestamp } => {
-                                tracing::debug!(
-                                    "Attestation challenge event received (nonce={}, ts={})",
-                                    &nonce[..8.min(nonce.len())],
-                                    timestamp
-                                );
+                        }
+                        Some(rid) = done_rx.recv() => {
+                            if inflight.remove(&rid).is_some() {
+                                tracing::debug!("Request {rid} completed, removed from tracker ({} in-flight)", inflight.len());
+                                if inflight.is_empty() {
+                                    inference_active.store(false, std::sync::atomic::Ordering::Relaxed);
+                                }
                             }
                         }
-                    }
-                    Some(rid) = done_rx.recv() => {
-                        if inflight.remove(&rid).is_some() {
-                            tracing::debug!("Request {rid} completed, removed from tracker ({} in-flight)", inflight.len());
-                            if inflight.is_empty() {
-                                inference_active.store(false, std::sync::atomic::Ordering::Relaxed);
-                            }
+                        _ = idle_sleep => {
+                            tracing::info!(
+                                "No requests for 10 minutes — shutting down backend to free GPU memory. \
+                                 Next request will reload and warmup the model (~30-60s cold start)."
+                            );
+                            shutdown_backend().await;
+                            backend_running = false;
                         }
-                    }
-                    _ = idle_sleep => {
-                        tracing::info!(
-                            "No requests for 10 minutes — shutting down backend to free GPU memory. \
-                             Next request will reload and warmup the model (~30-60s cold start)."
-                        );
-                        shutdown_backend().await;
-                        backend_running = false;
                     }
                 }
+            });
+
+            // Wait for Ctrl+C or schedule window end
+            let schedule_end_duration = schedule
+                .as_ref()
+                .and_then(|s| s.duration_until_inactive())
+                .unwrap_or(std::time::Duration::from_secs(u64::MAX / 2));
+
+            let schedule_triggered = if schedule.is_some() {
+                tokio::select! {
+                    _ = tokio::signal::ctrl_c() => false,
+                    _ = tokio::time::sleep(schedule_end_duration) => true,
+                }
+            } else {
+                tokio::signal::ctrl_c().await?;
+                false
+            };
+
+            if schedule_triggered {
+                tracing::info!("Schedule window closed — going offline");
+            } else {
+                tracing::info!("Shutting down...");
             }
-        });
 
-        // Wait for Ctrl+C
-        tokio::signal::ctrl_c().await?;
-        tracing::info!("Shutting down...");
-        let _ = shutdown_tx.send(true);
+            let _ = shutdown_tx.send(true);
 
-        let _ = tokio::time::timeout(
-            std::time::Duration::from_secs(5),
-            coordinator_handle,
-        )
-        .await;
-        event_handle.abort();
+            let _ =
+                tokio::time::timeout(std::time::Duration::from_secs(5), coordinator_handle).await;
+            event_handle.abort();
+
+            // If schedule triggered, loop back to wait for next window.
+            // If Ctrl+C, break out of the schedule loop.
+            if !schedule_triggered {
+                break 'schedule_loop;
+            }
+
+            // Shut down backend between schedule windows to free GPU memory
+            shutdown_backend().await;
+            tracing::info!("Backend stopped — waiting for next schedule window");
+        } // end 'schedule_loop
     }
 
     // Clean up mlx_lm.server
     #[cfg(unix)]
-    { let _ = std::process::Command::new("pkill").args(["-f", "mlx_lm.server"]).status();
-        let _ = std::process::Command::new("pkill").args(["-f", "vllm_mlx"]).status(); }
+    {
+        let _ = std::process::Command::new("pkill")
+            .args(["-f", "mlx_lm.server"])
+            .status();
+        let _ = std::process::Command::new("pkill")
+            .args(["-f", "vllm_mlx"])
+            .status();
+    }
 
     Ok(())
 }
@@ -1568,8 +1877,12 @@ async fn cmd_serve(
 async fn shutdown_backend() {
     #[cfg(unix)]
     {
-        let _ = std::process::Command::new("pkill").args(["-f", "vllm_mlx"]).status();
-        let _ = std::process::Command::new("pkill").args(["-f", "mlx_lm.server"]).status();
+        let _ = std::process::Command::new("pkill")
+            .args(["-f", "vllm_mlx"])
+            .status();
+        let _ = std::process::Command::new("pkill")
+            .args(["-f", "mlx_lm.server"])
+            .status();
     }
     // Give processes time to exit and release GPU memory
     tokio::time::sleep(std::time::Duration::from_secs(2)).await;
@@ -1598,7 +1911,10 @@ async fn reload_backend(
         .spawn()
         .map_err(|e| anyhow::anyhow!("failed to spawn backend: {e}"))?;
 
-    tracing::info!("Backend process started (PID: {:?}), waiting for model to load...", child.id());
+    tracing::info!(
+        "Backend process started (PID: {:?}), waiting for model to load...",
+        child.id()
+    );
 
     let backend_url = format!("http://127.0.0.1:{}", port);
 
@@ -1607,7 +1923,10 @@ async fn reload_backend(
     for i in 0..30 {
         tokio::time::sleep(std::time::Duration::from_secs(2)).await;
         if backend::check_health(&backend_url).await {
-            tracing::info!("Backend HTTP server ready after {}s, waiting for model load...", (i + 1) * 2);
+            tracing::info!(
+                "Backend HTTP server ready after {}s, waiting for model load...",
+                (i + 1) * 2
+            );
             server_up = true;
             break;
         }
@@ -1629,7 +1948,10 @@ async fn reload_backend(
     tracing::info!("Running warmup inference to prime GPU caches...");
     let warmup_start = std::time::Instant::now();
     backend::warmup_backend(&backend_url).await;
-    tracing::info!("Backend fully warm and ready (warmup took {:?})", warmup_start.elapsed());
+    tracing::info!(
+        "Backend fully warm and ready (warmup took {:?})",
+        warmup_start.elapsed()
+    );
 
     Ok(())
 }
@@ -1645,22 +1967,34 @@ async fn handle_inprocess_request(
 ) {
     // Pre-request SIP check
     if !security::check_sip_enabled() {
-        let _ = outbound_tx.send(protocol::ProviderMessage::InferenceError {
-            request_id,
-            error: "SIP disabled".to_string(),
-            status_code: 503,
-        }).await;
+        let _ = outbound_tx
+            .send(protocol::ProviderMessage::InferenceError {
+                request_id,
+                error: "SIP disabled".to_string(),
+                status_code: 503,
+            })
+            .await;
         return;
     }
 
     // Extract parameters from OpenAI-format body
-    let messages: Vec<serde_json::Value> = body.get("messages")
+    let messages: Vec<serde_json::Value> = body
+        .get("messages")
         .and_then(|m| m.as_array())
         .cloned()
         .unwrap_or_default();
-    let max_tokens = body.get("max_tokens").and_then(|v| v.as_u64()).unwrap_or(256);
-    let temperature = body.get("temperature").and_then(|v| v.as_f64()).unwrap_or(0.7);
-    let is_streaming = body.get("stream").and_then(|v| v.as_bool()).unwrap_or(false);
+    let max_tokens = body
+        .get("max_tokens")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(256);
+    let temperature = body
+        .get("temperature")
+        .and_then(|v| v.as_f64())
+        .unwrap_or(0.7);
+    let is_streaming = body
+        .get("stream")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
 
     // Run inference in blocking task (Python GIL)
     let engine_clone = engine.clone();
@@ -1668,7 +2002,8 @@ async fn handle_inprocess_request(
     let result = tokio::task::spawn_blocking(move || {
         let e = engine_clone.blocking_lock();
         e.generate(&messages, max_tokens, temperature)
-    }).await;
+    })
+    .await;
 
     match result {
         Ok(Ok(inference_result)) => {
@@ -1679,51 +2014,69 @@ async fn handle_inprocess_request(
                     "object": "chat.completion.chunk",
                     "choices": [{"delta": {"content": inference_result.text}, "index": 0, "finish_reason": "stop"}]
                 });
-                let _ = outbound_tx.send(protocol::ProviderMessage::InferenceResponseChunk {
-                    request_id: request_id.clone(),
-                    data: format!("data: {}", serde_json::to_string(&chunk).unwrap_or_default()),
-                }).await;
-                let _ = outbound_tx.send(protocol::ProviderMessage::InferenceResponseChunk {
-                    request_id: request_id.clone(),
-                    data: "data: [DONE]".to_string(),
-                }).await;
+                let _ = outbound_tx
+                    .send(protocol::ProviderMessage::InferenceResponseChunk {
+                        request_id: request_id.clone(),
+                        data: format!(
+                            "data: {}",
+                            serde_json::to_string(&chunk).unwrap_or_default()
+                        ),
+                    })
+                    .await;
+                let _ = outbound_tx
+                    .send(protocol::ProviderMessage::InferenceResponseChunk {
+                        request_id: request_id.clone(),
+                        data: "data: [DONE]".to_string(),
+                    })
+                    .await;
             }
 
-            let sign_data = format!("{}:{}:{}", request_id, inference_result.completion_tokens, "inprocess");
+            let sign_data = format!(
+                "{}:{}:{}",
+                request_id, inference_result.completion_tokens, "inprocess"
+            );
             let response_hash = security::sha256_hex(sign_data.as_bytes());
             let se_signature = security::se_sign(response_hash.as_bytes());
 
             let completion_tokens = inference_result.completion_tokens;
-            let _ = outbound_tx.send(protocol::ProviderMessage::InferenceComplete {
-                request_id,
-                usage: protocol::UsageInfo {
-                    prompt_tokens: inference_result.prompt_tokens,
-                    completion_tokens,
-                },
-                se_signature,
-                response_hash: Some(response_hash),
-            }).await;
+            let _ = outbound_tx
+                .send(protocol::ProviderMessage::InferenceComplete {
+                    request_id,
+                    usage: protocol::UsageInfo {
+                        prompt_tokens: inference_result.prompt_tokens,
+                        completion_tokens,
+                    },
+                    se_signature,
+                    response_hash: Some(response_hash),
+                })
+                .await;
             // Increment shared stats counters for heartbeat reporting.
             if let Some(s) = &stats {
-                s.requests_served.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                s.tokens_generated.fetch_add(completion_tokens, std::sync::atomic::Ordering::Relaxed);
+                s.requests_served
+                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                s.tokens_generated
+                    .fetch_add(completion_tokens, std::sync::atomic::Ordering::Relaxed);
             }
         }
         Ok(Err(e)) => {
             tracing::error!("In-process inference failed: {e}");
-            let _ = outbound_tx.send(protocol::ProviderMessage::InferenceError {
-                request_id,
-                error: e.to_string(),
-                status_code: 500,
-            }).await;
+            let _ = outbound_tx
+                .send(protocol::ProviderMessage::InferenceError {
+                    request_id,
+                    error: e.to_string(),
+                    status_code: 500,
+                })
+                .await;
         }
         Err(e) => {
             tracing::error!("Inference task panicked: {e}");
-            let _ = outbound_tx.send(protocol::ProviderMessage::InferenceError {
-                request_id,
-                error: "inference task failed".to_string(),
-                status_code: 500,
-            }).await;
+            let _ = outbound_tx
+                .send(protocol::ProviderMessage::InferenceError {
+                    request_id,
+                    error: "inference task failed".to_string(),
+                    status_code: 500,
+                })
+                .await;
         }
     }
 
@@ -1754,7 +2107,9 @@ fn find_stt_server_script() -> Option<String> {
         // In the provider source directory (development)
         std::path::PathBuf::from("stt_server.py"),
         // In ~/.dginf
-        dirs::home_dir().unwrap_or_default().join(".dginf/stt_server.py"),
+        dirs::home_dir()
+            .unwrap_or_default()
+            .join(".dginf/stt_server.py"),
     ];
 
     for path in &candidates {
@@ -1765,7 +2120,10 @@ fn find_stt_server_script() -> Option<String> {
     None
 }
 
-fn generate_attestation(encryption_key_base64: &str, binary_hash: Option<&str>) -> Option<Box<serde_json::value::RawValue>> {
+fn generate_attestation(
+    encryption_key_base64: &str,
+    binary_hash: Option<&str>,
+) -> Option<Box<serde_json::value::RawValue>> {
     // Look for the enclave CLI binary in common locations
     // Check ~/.dginf/bin first (standard install location)
     let home_bin = dirs::home_dir()
@@ -1830,7 +2188,11 @@ fn generate_attestation(encryption_key_base64: &str, binary_hash: Option<&str>) 
             }
         }
 
-        tracing::info!("Generating Secure Enclave attestation via {} (attempt {})", binary.display(), attempt + 1);
+        tracing::info!(
+            "Generating Secure Enclave attestation via {} (attempt {})",
+            binary.display(),
+            attempt + 1
+        );
 
         let mut args = vec!["attest", "--encryption-key", encryption_key_base64];
         let hash_string;
@@ -1885,7 +2247,9 @@ fn generate_attestation(encryption_key_base64: &str, binary_hash: Option<&str>) 
         // changes the bytes and breaks signature verification.
         match serde_json::value::RawValue::from_string(stdout) {
             Ok(raw) => {
-                tracing::info!("Secure Enclave attestation generated successfully (raw bytes preserved)");
+                tracing::info!(
+                    "Secure Enclave attestation generated successfully (raw bytes preserved)"
+                );
                 return Some(raw);
             }
             Err(e) => {
@@ -1941,16 +2305,22 @@ fn self_verify_attestation(attestation_json: &serde_json::Value) -> bool {
     let pubkey_path = tmp_dir.join("dginf-verify-pubkey.der");
 
     // Write signature and raw data (openssl dgst will hash it)
-    if std::fs::write(&sig_path, &sig_bytes).is_err() { return false; }
-    if std::fs::write(&data_path, blob_json.as_bytes()).is_err() { return false; }
+    if std::fs::write(&sig_path, &sig_bytes).is_err() {
+        return false;
+    }
+    if std::fs::write(&data_path, blob_json.as_bytes()).is_err() {
+        return false;
+    }
 
     // Build DER-encoded SubjectPublicKeyInfo for P-256
     // ASN.1: SEQUENCE { SEQUENCE { OID ecPublicKey, OID prime256v1 }, BIT STRING { pubkey } }
     let mut spki = vec![
         0x30, 0x59, // SEQUENCE, length 89
         0x30, 0x13, // SEQUENCE, length 19
-        0x06, 0x07, 0x2a, 0x86, 0x48, 0xce, 0x3d, 0x02, 0x01, // OID 1.2.840.10045.2.1 (ecPublicKey)
-        0x06, 0x08, 0x2a, 0x86, 0x48, 0xce, 0x3d, 0x03, 0x01, 0x07, // OID 1.2.840.10045.3.1.7 (prime256v1)
+        0x06, 0x07, 0x2a, 0x86, 0x48, 0xce, 0x3d, 0x02,
+        0x01, // OID 1.2.840.10045.2.1 (ecPublicKey)
+        0x06, 0x08, 0x2a, 0x86, 0x48, 0xce, 0x3d, 0x03, 0x01,
+        0x07, // OID 1.2.840.10045.3.1.7 (prime256v1)
         0x03, 0x42, 0x00, // BIT STRING, length 66, no unused bits
     ];
     // pubkey_bytes should be 65 bytes (0x04 + 32 X + 32 Y) or 64 bytes (raw X||Y)
@@ -1964,14 +2334,21 @@ fn self_verify_attestation(attestation_json: &serde_json::Value) -> bool {
         spki[24] = 0x43; // BIT STRING length = 67
     }
 
-    if std::fs::write(&pubkey_path, &spki).is_err() { return false; }
+    if std::fs::write(&pubkey_path, &spki).is_err() {
+        return false;
+    }
 
     // Verify with openssl
     let result = std::process::Command::new("/usr/bin/openssl")
         .args([
-            "dgst", "-sha256", "-verify", &pubkey_path.to_string_lossy(),
-            "-signature", &sig_path.to_string_lossy(),
-            "-keyform", "DER",
+            "dgst",
+            "-sha256",
+            "-verify",
+            &pubkey_path.to_string_lossy(),
+            "-signature",
+            &sig_path.to_string_lossy(),
+            "-keyform",
+            "DER",
             &data_path.to_string_lossy().into_owned(),
         ])
         .output();
@@ -2037,7 +2414,9 @@ async fn cmd_enroll(coordinator_url: String) -> Result<()> {
         println!("    3. Apple verifies your device is genuine hardware");
         println!("    4. A certificate is issued binding the SE key to your device");
         println!();
-        let _ = std::process::Command::new("open").arg(&profile_path).status();
+        let _ = std::process::Command::new("open")
+            .arg(&profile_path)
+            .status();
     }
 
     println!("After installing, verify with: dginf-provider doctor");
@@ -2134,7 +2513,10 @@ async fn cmd_benchmark() -> Result<()> {
 
     // Benchmark each available model
     for model in &models {
-        println!("Benchmarking: {} ({:.1} GB)", model.id, model.estimated_memory_gb);
+        println!(
+            "Benchmarking: {} ({:.1} GB)",
+            model.id, model.estimated_memory_gb
+        );
         let output = std::process::Command::new("python3")
             .args(["-c", &format!(
                 "import mlx_lm, time\n\
@@ -2168,7 +2550,10 @@ async fn cmd_status() -> Result<()> {
     // Hardware
     println!("Hardware:");
     println!("  Chip:       {}", hw.chip_name);
-    println!("  Memory:     {} GB total, {} GB available", hw.memory_gb, hw.memory_available_gb);
+    println!(
+        "  Memory:     {} GB total, {} GB available",
+        hw.memory_gb, hw.memory_available_gb
+    );
     println!("  GPU:        {} cores", hw.gpu_cores);
     println!("  Bandwidth:  {} GB/s", hw.memory_bandwidth_gbs);
     println!();
@@ -2176,22 +2561,53 @@ async fn cmd_status() -> Result<()> {
     // Security
     println!("Security:");
     let sip = security::check_sip_enabled();
-    println!("  SIP:              {}", if sip { "✓ Enabled" } else { "✗ DISABLED" });
+    println!(
+        "  SIP:              {}",
+        if sip { "✓ Enabled" } else { "✗ DISABLED" }
+    );
     println!("  Secure Enclave:   ✓ Available (Apple Silicon)");
 
-    println!("  MDM enrolled:     {}", if security::check_mdm_enrolled() { "✓ Yes" } else { "✗ No" });
+    println!(
+        "  MDM enrolled:     {}",
+        if security::check_mdm_enrolled() {
+            "✓ Yes"
+        } else {
+            "✗ No"
+        }
+    );
     println!();
 
     // Config
     let config_path = config::default_config_path()?;
     println!("Config:");
-    println!("  Config file:  {}", if config_path.exists() { config_path.display().to_string() } else { "Not created (run: dginf-provider init)".to_string() });
+    println!(
+        "  Config file:  {}",
+        if config_path.exists() {
+            config_path.display().to_string()
+        } else {
+            "Not created (run: dginf-provider init)".to_string()
+        }
+    );
     let key_path = crypto::default_key_path()?;
-    println!("  Node key:     {}", if key_path.exists() { "✓ Generated" } else { "✗ Not generated" });
+    println!(
+        "  Node key:     {}",
+        if key_path.exists() {
+            "✓ Generated"
+        } else {
+            "✗ Not generated"
+        }
+    );
 
     let home = dirs::home_dir().unwrap_or_default();
     let enclave_key = home.join(".dginf/enclave_key.data");
-    println!("  Enclave key:  {}", if enclave_key.exists() { "✓ Generated" } else { "✗ Not generated" });
+    println!(
+        "  Enclave key:  {}",
+        if enclave_key.exists() {
+            "✓ Generated"
+        } else {
+            "✗ Not generated"
+        }
+    );
     println!();
 
     // Models
@@ -2213,26 +2629,50 @@ async fn cmd_models(action: String, coordinator_url: String) -> Result<()> {
 
     match action.as_str() {
         "list" | "ls" => {
-            println!("Models for {} ({} GB available):", hw.chip_name, hw.memory_available_gb);
+            println!(
+                "Models for {} ({} GB available):",
+                hw.chip_name, hw.memory_available_gb
+            );
             println!();
             for cm in &catalog {
                 let fits = hw.memory_available_gb as f64 >= cm.size_gb;
                 let is_downloaded = downloaded.iter().any(|m| m.id == cm.id);
-                let status = if is_downloaded { "✓" } else if fits { " " } else { "✗" };
-                let label = if is_downloaded { "downloaded" } else if fits { "available" } else { "too large" };
-                println!("  {} {:>5.1} GB  {:15} {:10} {}", status, cm.size_gb, cm.display_name, label, cm.id);
+                let status = if is_downloaded {
+                    "✓"
+                } else if fits {
+                    " "
+                } else {
+                    "✗"
+                };
+                let label = if is_downloaded {
+                    "downloaded"
+                } else if fits {
+                    "available"
+                } else {
+                    "too large"
+                };
+                println!(
+                    "  {} {:>5.1} GB  {:15} {:10} {}",
+                    status, cm.size_gb, cm.display_name, label, cm.id
+                );
             }
             // Show any downloaded models not in catalog
             for m in &downloaded {
                 let in_catalog = catalog.iter().any(|cm| cm.id == m.id);
                 if !in_catalog {
-                    println!("  ✓ {:>5.1} GB  {:15} {:10} {}", m.estimated_memory_gb, "", "downloaded", m.id);
+                    println!(
+                        "  ✓ {:>5.1} GB  {:15} {:10} {}",
+                        m.estimated_memory_gb, "", "downloaded", m.id
+                    );
                 }
             }
         }
 
         "download" | "add" => {
-            println!("Select models to download ({} GB available):", hw.memory_available_gb);
+            println!(
+                "Select models to download ({} GB available):",
+                hw.memory_available_gb
+            );
             println!();
 
             let mut downloadable: Vec<(usize, &CatalogModel)> = Vec::new();
@@ -2240,12 +2680,23 @@ async fn cmd_models(action: String, coordinator_url: String) -> Result<()> {
                 let fits = hw.memory_available_gb as f64 >= cm.size_gb;
                 let is_downloaded = downloaded.iter().any(|m| m.id == cm.id);
                 if is_downloaded {
-                    println!("  [✓] {:>5.1} GB  {} (already downloaded)", cm.size_gb, cm.display_name);
+                    println!(
+                        "  [✓] {:>5.1} GB  {} (already downloaded)",
+                        cm.size_gb, cm.display_name
+                    );
                 } else if fits {
                     downloadable.push((downloadable.len() + 1, cm));
-                    println!("  [{}] {:>5.1} GB  {}", downloadable.len(), cm.size_gb, cm.display_name);
+                    println!(
+                        "  [{}] {:>5.1} GB  {}",
+                        downloadable.len(),
+                        cm.size_gb,
+                        cm.display_name
+                    );
                 } else {
-                    println!("  [✗] {:>5.1} GB  {} (too large)", cm.size_gb, cm.display_name);
+                    println!(
+                        "  [✗] {:>5.1} GB  {} (too large)",
+                        cm.size_gb, cm.display_name
+                    );
                 }
             }
 
@@ -2260,7 +2711,8 @@ async fn cmd_models(action: String, coordinator_url: String) -> Result<()> {
             let mut input = String::new();
             std::io::stdin().read_line(&mut input)?;
 
-            let selections: Vec<usize> = input.trim()
+            let selections: Vec<usize> = input
+                .trim()
                 .split(',')
                 .filter_map(|s| s.trim().parse::<usize>().ok())
                 .collect();
@@ -2277,7 +2729,8 @@ async fn cmd_models(action: String, coordinator_url: String) -> Result<()> {
                     println!("  Downloading {}...", cm.display_name);
 
                     let s3_name = &cm.s3_name;
-                    let cache_dir = dirs::home_dir().unwrap_or_default()
+                    let cache_dir = dirs::home_dir()
+                        .unwrap_or_default()
                         .join(".cache/huggingface/hub")
                         .join(format!("models--{}", cm.id.replace('/', "--")))
                         .join("snapshots/main");
@@ -2286,10 +2739,14 @@ async fn cmd_models(action: String, coordinator_url: String) -> Result<()> {
                     // Try pre-packaged tarball from CDN first
                     let tarball_url = format!("{}/dl/models/{}.tar.gz", base_url, s3_name);
                     let tar_status = std::process::Command::new("bash")
-                        .args(["-c", &format!(
-                            "set -o pipefail; curl -f#L '{}' | tar xz -C '{}'",
-                            tarball_url, cache_dir.display()
-                        )])
+                        .args([
+                            "-c",
+                            &format!(
+                                "set -o pipefail; curl -f#L '{}' | tar xz -C '{}'",
+                                tarball_url,
+                                cache_dir.display()
+                            ),
+                        ])
                         .status();
 
                     match tar_status {
@@ -2319,14 +2776,16 @@ async fn cmd_models(action: String, coordinator_url: String) -> Result<()> {
             let mut input = String::new();
             std::io::stdin().read_line(&mut input)?;
 
-            let selections: Vec<usize> = input.trim()
+            let selections: Vec<usize> = input
+                .trim()
                 .split(',')
                 .filter_map(|s| s.trim().parse::<usize>().ok())
                 .collect();
 
             for sel in selections {
                 if let Some(m) = downloaded.get(sel.saturating_sub(1)) {
-                    let cache_dir = dirs::home_dir().unwrap_or_default()
+                    let cache_dir = dirs::home_dir()
+                        .unwrap_or_default()
                         .join(".cache/huggingface/hub")
                         .join(format!("models--{}", m.id.replace('/', "--")));
                     if cache_dir.exists() {
@@ -2359,11 +2818,17 @@ async fn cmd_earnings(coordinator_url: String) -> Result<()> {
         .timeout(std::time::Duration::from_secs(5))
         .build()?;
 
-    let health = client.get(format!("{}/health", coordinator_url)).send().await;
+    let health = client
+        .get(format!("{}/health", coordinator_url))
+        .send()
+        .await;
     match health {
         Ok(resp) if resp.status().is_success() => {
             let body: serde_json::Value = resp.json().await?;
-            println!("Coordinator: online ({} providers connected)", body["providers"]);
+            println!(
+                "Coordinator: online ({} providers connected)",
+                body["providers"]
+            );
         }
         _ => {
             println!("Coordinator: offline or unreachable ({})", coordinator_url);
@@ -2375,7 +2840,11 @@ async fn cmd_earnings(coordinator_url: String) -> Result<()> {
 
     // Query provider earnings from the coordinator's ledger
     // Uses the provider-specific endpoint that looks up by wallet address
-    let earnings_url = format!("{}/v1/provider/earnings?wallet={}", coordinator_url, w.address());
+    let earnings_url = format!(
+        "{}/v1/provider/earnings?wallet={}",
+        coordinator_url,
+        w.address()
+    );
     let earnings_resp = client.get(&earnings_url).send().await;
 
     println!();
@@ -2439,7 +2908,10 @@ async fn cmd_doctor(coordinator_url: String) -> Result<()> {
     print!("1. Hardware detection........... ");
     match hardware::detect() {
         Ok(hw) => {
-            println!("✓ {} ({} GB, {} GPU cores)", hw.chip_name, hw.memory_gb, hw.gpu_cores);
+            println!(
+                "✓ {} ({} GB, {} GPU cores)",
+                hw.chip_name, hw.memory_gb, hw.gpu_cores
+            );
             passed += 1;
         }
         Err(e) => {
@@ -2518,13 +2990,19 @@ async fn cmd_doctor(coordinator_url: String) -> Result<()> {
     let dginf_dir = dirs::home_dir().unwrap_or_default().join(".dginf");
     let bundled_python = dginf_dir.join("python/bin/python3.12");
     let (python_cmd, python_home) = if bundled_python.exists() {
-        (bundled_python.to_string_lossy().to_string(), Some(dginf_dir.join("python")))
+        (
+            bundled_python.to_string_lossy().to_string(),
+            Some(dginf_dir.join("python")),
+        )
     } else {
         ("python3".to_string(), None)
     };
 
     let mut mlx_check = std::process::Command::new(&python_cmd);
-    mlx_check.args(["-c", "import vllm_mlx; print(f'vllm-mlx {vllm_mlx.__version__}')"]);
+    mlx_check.args([
+        "-c",
+        "import vllm_mlx; print(f'vllm-mlx {vllm_mlx.__version__}')",
+    ]);
     if let Some(ref home) = python_home {
         mlx_check.env("PYTHONHOME", home);
     }
@@ -2563,11 +3041,19 @@ async fn cmd_doctor(coordinator_url: String) -> Result<()> {
     // 6. Models
     print!("6. Downloaded models........... ");
     let hw = hardware::detect().unwrap_or_else(|_| hardware::HardwareInfo {
-        machine_model: "unknown".into(), chip_name: "unknown".into(),
-        chip_family: hardware::ChipFamily::Unknown, chip_tier: hardware::ChipTier::Unknown,
-        memory_gb: 0, memory_available_gb: 0,
-        cpu_cores: hardware::CpuCores { total: 0, performance: 0, efficiency: 0 },
-        gpu_cores: 0, memory_bandwidth_gbs: 0,
+        machine_model: "unknown".into(),
+        chip_name: "unknown".into(),
+        chip_family: hardware::ChipFamily::Unknown,
+        chip_tier: hardware::ChipTier::Unknown,
+        memory_gb: 0,
+        memory_available_gb: 0,
+        cpu_cores: hardware::CpuCores {
+            total: 0,
+            performance: 0,
+            efficiency: 0,
+        },
+        gpu_cores: 0,
+        memory_bandwidth_gbs: 0,
     });
     let model_count = models::scan_models(&hw).len();
     if model_count > 0 {
@@ -2594,7 +3080,11 @@ async fn cmd_doctor(coordinator_url: String) -> Result<()> {
     let client = reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(5))
         .build()?;
-    match client.get(format!("{}/health", coordinator_url)).send().await {
+    match client
+        .get(format!("{}/health", coordinator_url))
+        .send()
+        .await
+    {
         Ok(resp) if resp.status().is_success() => {
             let body: serde_json::Value = resp.json().await.unwrap_or_default();
             println!("✓ Online ({} providers)", body["providers"]);
@@ -2642,19 +3132,31 @@ async fn cmd_start(coordinator_url: String, model_override: Option<String>) -> R
     let model = if let Some(m) = model_override {
         m
     } else {
-        println!("Select a model to serve (available memory: {} GB):", hw.memory_available_gb);
+        println!(
+            "Select a model to serve (available memory: {} GB):",
+            hw.memory_available_gb
+        );
         println!();
 
         let mut total_mem = 0.0_f64;
         for (i, m) in downloaded.iter().enumerate() {
             let fits = (total_mem + m.estimated_memory_gb) <= hw.memory_available_gb as f64;
             let marker = if fits { "  " } else { "✗ " };
-            println!("  {}[{}] {} ({:.1} GB)", marker, i + 1, m.id, m.estimated_memory_gb);
+            println!(
+                "  {}[{}] {} ({:.1} GB)",
+                marker,
+                i + 1,
+                m.id,
+                m.estimated_memory_gb
+            );
         }
 
         println!();
-        println!("  Enter number [1-{}] (or press Enter for [{}] - largest):",
-            downloaded.len(), downloaded.len());
+        println!(
+            "  Enter number [1-{}] (or press Enter for [{}] - largest):",
+            downloaded.len(),
+            downloaded.len()
+        );
 
         let mut input = String::new();
         std::io::stdin().read_line(&mut input)?;
@@ -2663,7 +3165,10 @@ async fn cmd_start(coordinator_url: String, model_override: Option<String>) -> R
         let idx = if input.is_empty() {
             downloaded.len() - 1
         } else {
-            input.parse::<usize>().unwrap_or(downloaded.len()).saturating_sub(1)
+            input
+                .parse::<usize>()
+                .unwrap_or(downloaded.len())
+                .saturating_sub(1)
         };
 
         let idx = idx.min(downloaded.len() - 1);
@@ -2672,7 +3177,9 @@ async fn cmd_start(coordinator_url: String, model_override: Option<String>) -> R
         selected.id.clone()
     };
 
-    let log_path = dirs::home_dir().unwrap_or_default().join(".dginf/provider.log");
+    let log_path = dirs::home_dir()
+        .unwrap_or_default()
+        .join(".dginf/provider.log");
 
     // Install as launchd user agent (auto-restarts on crash)
     service::install_and_start(&coordinator_url, &model)?;
@@ -2706,7 +3213,9 @@ async fn cmd_stop() -> Result<()> {
         if let Ok(pid_str) = std::fs::read_to_string(&caffeinate_pid_path) {
             if let Ok(pid) = pid_str.trim().parse::<i32>() {
                 #[cfg(unix)]
-                unsafe { libc::kill(pid, libc::SIGTERM); }
+                unsafe {
+                    libc::kill(pid, libc::SIGTERM);
+                }
             }
         }
         let _ = std::fs::remove_file(&caffeinate_pid_path);
@@ -2735,8 +3244,12 @@ async fn cmd_stop() -> Result<()> {
     // Kill any lingering backend processes
     #[cfg(unix)]
     {
-        let _ = std::process::Command::new("pkill").args(["-f", "mlx_lm.server"]).status();
-        let _ = std::process::Command::new("pkill").args(["-f", "vllm_mlx"]).status();
+        let _ = std::process::Command::new("pkill")
+            .args(["-f", "mlx_lm.server"])
+            .status();
+        let _ = std::process::Command::new("pkill")
+            .args(["-f", "vllm_mlx"])
+            .status();
     }
 
     println!("Provider stopped.");
@@ -2844,8 +3357,14 @@ async fn cmd_update(coordinator: String) -> Result<()> {
     }
 
     // Move binaries to bin dir
-    let _ = std::fs::rename(dginf_dir.join("dginf-provider"), bin_dir.join("dginf-provider"));
-    let _ = std::fs::rename(dginf_dir.join("dginf-enclave"), bin_dir.join("dginf-enclave"));
+    let _ = std::fs::rename(
+        dginf_dir.join("dginf-provider"),
+        bin_dir.join("dginf-provider"),
+    );
+    let _ = std::fs::rename(
+        dginf_dir.join("dginf-enclave"),
+        bin_dir.join("dginf-enclave"),
+    );
 
     // Make executable
     #[cfg(unix)]
@@ -2964,7 +3483,10 @@ fn delete_auth_token() -> Result<()> {
 async fn cmd_login(coordinator_url: String) -> Result<()> {
     // Check if already logged in.
     if let Some(token) = load_auth_token() {
-        println!("Already logged in (token: {}...)", &token[..std::cmp::min(20, token.len())]);
+        println!(
+            "Already logged in (token: {}...)",
+            &token[..std::cmp::min(20, token.len())]
+        );
         println!("Run 'dginf-provider logout' first to unlink.");
         return Ok(());
     }
@@ -3011,7 +3533,10 @@ async fn cmd_login(coordinator_url: String) -> Result<()> {
     println!("    │  {}  │", dc.user_code);
     println!("    └──────────────┘");
     println!();
-    println!("  Waiting for approval (expires in {} minutes)...", dc.expires_in / 60);
+    println!(
+        "  Waiting for approval (expires in {} minutes)...",
+        dc.expires_in / 60
+    );
 
     // Try to open the browser automatically.
     let _ = std::process::Command::new("open")

--- a/provider/src/models.rs
+++ b/provider/src/models.rs
@@ -71,7 +71,10 @@ pub fn scan_models_in_dir(cache_dir: &Path, available_memory_gb: u64) -> Vec<Mod
     let entries = match std::fs::read_dir(cache_dir) {
         Ok(e) => e,
         Err(err) => {
-            tracing::warn!("Failed to read cache directory {}: {err}", cache_dir.display());
+            tracing::warn!(
+                "Failed to read cache directory {}: {err}",
+                cache_dir.display()
+            );
             return models;
         }
     };
@@ -415,14 +418,7 @@ mod tests {
 
         let config = r#"{"model_type": "gpt2"}"#;
         // No "mlx" in name and no quantization hint
-        let cache = create_mock_cache(
-            &tmp,
-            &[(
-                "models--openai--gpt2",
-                config,
-                500_000,
-            )],
-        );
+        let cache = create_mock_cache(&tmp, &[("models--openai--gpt2", config, 500_000)]);
 
         // This model has config.json and safetensors, and is_mlx_model will detect it
         // because it has model.safetensors + config.json.
@@ -494,8 +490,7 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let config_path = tmp.path().join("config.json");
 
-        let config =
-            r#"{"model_type": "qwen2", "hidden_size": 4096, "num_hidden_layers": 32, "vocab_size": 152064}"#;
+        let config = r#"{"model_type": "qwen2", "hidden_size": 4096, "num_hidden_layers": 32, "vocab_size": 152064}"#;
         fs::write(&config_path, config).unwrap();
 
         let (model_type, params) = parse_config_json(&config_path);

--- a/provider/src/protocol.rs
+++ b/provider/src/protocol.rs
@@ -536,7 +536,9 @@ mod tests {
         let raw = r#"{"type":"inference_request","request_id":"abc-123","body":{"model":"test","messages":[{"role":"user","content":"hi"}],"stream":false}}"#;
         let msg: CoordinatorMessage = serde_json::from_str(raw).unwrap();
         match msg {
-            CoordinatorMessage::InferenceRequest { request_id, body, .. } => {
+            CoordinatorMessage::InferenceRequest {
+                request_id, body, ..
+            } => {
                 assert_eq!(request_id, "abc-123");
                 assert_eq!(body["model"], "test");
                 assert_eq!(body["stream"], false);
@@ -684,7 +686,11 @@ mod tests {
         let raw = r#"{"type":"transcription_request","request_id":"go-req-1","body":{"model":"cohere-transcribe","audio":"dGVzdA==","language":"en","format":"mp3"}}"#;
         let msg: CoordinatorMessage = serde_json::from_str(raw).unwrap();
         match msg {
-            CoordinatorMessage::TranscriptionRequest { request_id, body, encrypted_body } => {
+            CoordinatorMessage::TranscriptionRequest {
+                request_id,
+                body,
+                encrypted_body,
+            } => {
                 assert_eq!(request_id, "go-req-1");
                 assert_eq!(body["model"], "cohere-transcribe");
                 assert_eq!(body["audio"], "dGVzdA==");
@@ -700,7 +706,11 @@ mod tests {
         let raw = r#"{"type":"transcription_request","request_id":"enc-1","encrypted_body":{"ephemeral_public_key":"a2V5","ciphertext":"Y2lwaGVy"}}"#;
         let msg: CoordinatorMessage = serde_json::from_str(raw).unwrap();
         match msg {
-            CoordinatorMessage::TranscriptionRequest { request_id, encrypted_body, .. } => {
+            CoordinatorMessage::TranscriptionRequest {
+                request_id,
+                encrypted_body,
+                ..
+            } => {
                 assert_eq!(request_id, "enc-1");
                 let enc = encrypted_body.unwrap();
                 assert_eq!(enc.ephemeral_public_key, "a2V5");
@@ -720,7 +730,8 @@ mod tests {
         });
         let msg = CoordinatorMessage::ImageGenerationRequest {
             request_id: "img-123".to_string(),
-            upload_url: "https://example.com/v1/provider/image-upload?request_id=img-123".to_string(),
+            upload_url: "https://example.com/v1/provider/image-upload?request_id=img-123"
+                .to_string(),
             body,
             encrypted_body: None,
         };
@@ -764,7 +775,12 @@ mod tests {
         let raw = r#"{"type":"image_generation_request","request_id":"go-img-1","upload_url":"https://example.com/upload","body":{"model":"flux-klein-4b","prompt":"sunset over mountains","n":2,"size":"512x512"}}"#;
         let msg: CoordinatorMessage = serde_json::from_str(raw).unwrap();
         match msg {
-            CoordinatorMessage::ImageGenerationRequest { request_id, upload_url, body, encrypted_body } => {
+            CoordinatorMessage::ImageGenerationRequest {
+                request_id,
+                upload_url,
+                body,
+                encrypted_body,
+            } => {
                 assert_eq!(request_id, "go-img-1");
                 assert_eq!(upload_url, "https://example.com/upload");
                 assert_eq!(body["model"], "flux-klein-4b");
@@ -781,7 +797,11 @@ mod tests {
         let raw = r#"{"type":"image_generation_request","request_id":"enc-img-1","upload_url":"https://example.com/upload","encrypted_body":{"ephemeral_public_key":"a2V5","ciphertext":"Y2lwaGVy"}}"#;
         let msg: CoordinatorMessage = serde_json::from_str(raw).unwrap();
         match msg {
-            CoordinatorMessage::ImageGenerationRequest { request_id, encrypted_body, .. } => {
+            CoordinatorMessage::ImageGenerationRequest {
+                request_id,
+                encrypted_body,
+                ..
+            } => {
                 assert_eq!(request_id, "enc-img-1");
                 let enc = encrypted_body.unwrap();
                 assert_eq!(enc.ephemeral_public_key, "a2V5");

--- a/provider/src/proxy.rs
+++ b/provider/src/proxy.rs
@@ -19,10 +19,11 @@ use std::sync::Arc;
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 
+use crate::coordinator::AtomicProviderStats;
 use crate::crypto::NodeKeyPair;
 use crate::protocol::{
-    ImageGenerationRequestBody, ImageGenerationUsage, ProviderMessage,
-    TranscriptionRequestBody, TranscriptionSegment, TranscriptionUsage, UsageInfo,
+    ImageGenerationRequestBody, ImageGenerationUsage, ProviderMessage, TranscriptionRequestBody,
+    TranscriptionSegment, TranscriptionUsage, UsageInfo,
 };
 use crate::security;
 
@@ -42,6 +43,7 @@ pub async fn handle_inference_request(
     outbound_tx: mpsc::Sender<ProviderMessage>,
     _node_keypair: Option<Arc<NodeKeyPair>>,
     cancel_token: CancellationToken,
+    stats: Option<Arc<AtomicProviderStats>>,
 ) {
     // Pre-request SIP check: verify SIP is still enabled before processing
     // any consumer data. SIP can't be disabled at runtime (requires reboot),
@@ -58,12 +60,31 @@ pub async fn handle_inference_request(
         return;
     }
 
-    let is_streaming = body.get("stream").and_then(|v| v.as_bool()).unwrap_or(false);
+    let is_streaming = body
+        .get("stream")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
 
     let result = if is_streaming {
-        handle_streaming_request(&request_id, &body, &backend_url, &outbound_tx, &cancel_token).await
+        handle_streaming_request(
+            &request_id,
+            &body,
+            &backend_url,
+            &outbound_tx,
+            &cancel_token,
+            &stats,
+        )
+        .await
     } else {
-        handle_non_streaming_request(&request_id, &body, &backend_url, &outbound_tx, &cancel_token).await
+        handle_non_streaming_request(
+            &request_id,
+            &body,
+            &backend_url,
+            &outbound_tx,
+            &cancel_token,
+            &stats,
+        )
+        .await
     };
 
     if let Err(e) = result {
@@ -100,6 +121,7 @@ async fn handle_non_streaming_request(
     backend_url: &str,
     outbound_tx: &mpsc::Sender<ProviderMessage>,
     cancel_token: &CancellationToken,
+    stats: &Option<Arc<AtomicProviderStats>>,
 ) -> Result<()> {
     let url = format!("{backend_url}/v1/chat/completions");
     let client = reqwest::Client::new();
@@ -138,6 +160,7 @@ async fn handle_non_streaming_request(
 
     // Extract token usage info for billing
     let usage = extract_usage(&response_json);
+    let completion_tokens = usage.completion_tokens;
 
     // Sign the actual response content with the Secure Enclave key
     let content = response_json
@@ -161,6 +184,14 @@ async fn handle_non_streaming_request(
         })
         .await
         .ok();
+
+    // Increment shared stats counters for heartbeat reporting.
+    if let Some(s) = stats {
+        use std::sync::atomic::Ordering;
+        s.requests_served.fetch_add(1, Ordering::Relaxed);
+        s.tokens_generated
+            .fetch_add(completion_tokens, Ordering::Relaxed);
+    }
 
     // Wipe response data from memory — contains consumer's inference output.
     if let Ok(mut resp_bytes) = serde_json::to_vec(&response_json) {
@@ -186,6 +217,7 @@ async fn handle_streaming_request(
     backend_url: &str,
     outbound_tx: &mpsc::Sender<ProviderMessage>,
     cancel_token: &CancellationToken,
+    stats: &Option<Arc<AtomicProviderStats>>,
 ) -> Result<()> {
     let url = format!("{backend_url}/v1/chat/completions");
     let client = reqwest::Client::new();
@@ -254,7 +286,10 @@ async fn handle_streaming_request(
 
                 if data == "[DONE]" {
                     // Stream complete — sign the actual response content
-                    let sign_data = format!("{}:{}:{}", request_id, total_completion_tokens, response_content);
+                    let sign_data = format!(
+                        "{}:{}:{}",
+                        request_id, total_completion_tokens, response_content
+                    );
                     let response_hash = security::sha256_hex(sign_data.as_bytes());
                     let se_signature = security::se_sign(response_hash.as_bytes());
 
@@ -270,6 +305,13 @@ async fn handle_streaming_request(
                         })
                         .await
                         .ok();
+                    // Increment shared stats counters for heartbeat reporting.
+                    if let Some(s) = stats {
+                        use std::sync::atomic::Ordering;
+                        s.requests_served.fetch_add(1, Ordering::Relaxed);
+                        s.tokens_generated
+                            .fetch_add(total_completion_tokens, Ordering::Relaxed);
+                    }
                     return Ok(());
                 }
 
@@ -279,9 +321,7 @@ async fn handle_streaming_request(
                         if let Some(pt) = usage.get("prompt_tokens").and_then(|v| v.as_u64()) {
                             prompt_tokens = pt;
                         }
-                        if let Some(ct) =
-                            usage.get("completion_tokens").and_then(|v| v.as_u64())
-                        {
+                        if let Some(ct) = usage.get("completion_tokens").and_then(|v| v.as_u64()) {
                             total_completion_tokens = ct;
                         }
                     }
@@ -323,7 +363,10 @@ async fn handle_streaming_request(
 
     // If we get here without [DONE], send completion with what we have
     // Sign the actual accumulated response content
-    let sign_data = format!("{}:{}:{}", request_id, total_completion_tokens, response_content);
+    let sign_data = format!(
+        "{}:{}:{}",
+        request_id, total_completion_tokens, response_content
+    );
     let response_hash = security::sha256_hex(sign_data.as_bytes());
     let se_signature = security::se_sign(response_hash.as_bytes());
 
@@ -339,6 +382,14 @@ async fn handle_streaming_request(
         })
         .await
         .ok();
+
+    // Increment shared stats counters for heartbeat reporting.
+    if let Some(s) = stats {
+        use std::sync::atomic::Ordering;
+        s.requests_served.fetch_add(1, Ordering::Relaxed);
+        s.tokens_generated
+            .fetch_add(total_completion_tokens, Ordering::Relaxed);
+    }
 
     Ok(())
 }
@@ -357,8 +408,15 @@ pub async fn handle_transcription_request(
 ) {
     let start = std::time::Instant::now();
 
-    let result =
-        do_transcription(&request_id, &body, &stt_backend_url, &outbound_tx, &cancel_token, start).await;
+    let result = do_transcription(
+        &request_id,
+        &body,
+        &stt_backend_url,
+        &outbound_tx,
+        &cancel_token,
+        start,
+    )
+    .await;
 
     if let Err(e) = result {
         if cancel_token.is_cancelled() {
@@ -399,7 +457,11 @@ async fn do_transcription(
     let audio_seconds = estimate_audio_duration(&audio_bytes, &body.format);
 
     // Determine file extension from format hint
-    let ext = if body.format.is_empty() { "wav" } else { &body.format };
+    let ext = if body.format.is_empty() {
+        "wav"
+    } else {
+        &body.format
+    };
 
     // Write to temp file for multipart upload
     let tmp_path = format!("/tmp/dginf-stt-{request_id}.{ext}");
@@ -415,10 +477,7 @@ async fn do_transcription(
     let file_part = reqwest::multipart::Part::bytes(file_bytes)
         .file_name(format!("audio.{ext}"))
         .mime_str(&format!("audio/{ext}"))
-        .unwrap_or_else(|_| {
-            reqwest::multipart::Part::bytes(vec![])
-                .file_name("audio.wav")
-        });
+        .unwrap_or_else(|_| reqwest::multipart::Part::bytes(vec![]).file_name("audio.wav"));
 
     let mut form = reqwest::multipart::Form::new()
         .part("file", file_part)
@@ -459,7 +518,10 @@ async fn do_transcription(
     }
 
     // mlx-audio returns NDJSON; read the full response
-    let response_text = response.text().await.context("failed to read STT response")?;
+    let response_text = response
+        .text()
+        .await
+        .context("failed to read STT response")?;
 
     // Parse the NDJSON response (may have multiple lines)
     let mut text = String::new();
@@ -504,7 +566,11 @@ async fn do_transcription(
         .send(ProviderMessage::TranscriptionComplete {
             request_id: request_id.to_string(),
             text,
-            segments: if segments.is_empty() { None } else { Some(segments) },
+            segments: if segments.is_empty() {
+                None
+            } else {
+                Some(segments)
+            },
             language,
             usage: TranscriptionUsage {
                 audio_seconds,
@@ -525,15 +591,11 @@ fn estimate_audio_duration(bytes: &[u8], format: &str) -> f64 {
         "wav" => {
             // WAV: sample_rate at offset 24, bits_per_sample at 34, data starts at 44
             if bytes.len() > 44 {
-                let sample_rate = u32::from_le_bytes(
-                    bytes[24..28].try_into().unwrap_or([0; 4]),
-                ) as f64;
-                let bits = u16::from_le_bytes(
-                    bytes[34..36].try_into().unwrap_or([0; 2]),
-                ) as f64;
-                let channels = u16::from_le_bytes(
-                    bytes[22..24].try_into().unwrap_or([0; 2]),
-                ) as f64;
+                let sample_rate =
+                    u32::from_le_bytes(bytes[24..28].try_into().unwrap_or([0; 4])) as f64;
+                let bits = u16::from_le_bytes(bytes[34..36].try_into().unwrap_or([0; 2])) as f64;
+                let channels =
+                    u16::from_le_bytes(bytes[22..24].try_into().unwrap_or([0; 2])) as f64;
                 if sample_rate > 0.0 && bits > 0.0 && channels > 0.0 {
                     let data_bytes = (bytes.len() - 44) as f64;
                     return data_bytes / (sample_rate * channels * bits / 8.0);
@@ -565,7 +627,13 @@ pub async fn handle_image_generation_request(
     let start = std::time::Instant::now();
 
     let result = do_image_generation(
-        &request_id, &body, &image_bridge_url, &upload_url, &outbound_tx, &cancel_token, start,
+        &request_id,
+        &body,
+        &image_bridge_url,
+        &upload_url,
+        &outbound_tx,
+        &cancel_token,
+        start,
     )
     .await;
 
@@ -836,7 +904,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_handle_non_streaming_mock() {
-        use axum::{routing::post, Json, Router};
+        use axum::{Json, Router, routing::post};
 
         // Start a mock backend server
         let app = Router::new().route(
@@ -870,12 +938,15 @@ mod tests {
             tx,
             None,
             CancellationToken::new(),
+            None,
         )
         .await;
 
         let msg = rx.recv().await.unwrap();
         match msg {
-            ProviderMessage::InferenceComplete { request_id, usage, .. } => {
+            ProviderMessage::InferenceComplete {
+                request_id, usage, ..
+            } => {
                 assert_eq!(request_id, "req-1");
                 assert_eq!(usage.prompt_tokens, 10);
                 assert_eq!(usage.completion_tokens, 5);
@@ -886,7 +957,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_handle_error_response() {
-        use axum::{http::StatusCode, routing::post, Router};
+        use axum::{Router, http::StatusCode, routing::post};
 
         let app = Router::new().route(
             "/v1/chat/completions",
@@ -910,6 +981,7 @@ mod tests {
             tx,
             None,
             CancellationToken::new(),
+            None,
         )
         .await;
 
@@ -930,13 +1002,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_handle_streaming_mock() {
-        use axum::{
-            body::Body,
-            http::StatusCode,
-            response::Response,
-            routing::post,
-            Router,
-        };
+        use axum::{Router, body::Body, http::StatusCode, response::Response, routing::post};
 
         let app = Router::new().route(
             "/v1/chat/completions",
@@ -977,6 +1043,7 @@ mod tests {
             tx,
             None,
             CancellationToken::new(),
+            None,
         )
         .await;
 
@@ -989,7 +1056,11 @@ mod tests {
         }
 
         // Should have chunks + final complete
-        assert!(messages.len() >= 2, "Expected at least 2 messages, got {}", messages.len());
+        assert!(
+            messages.len() >= 2,
+            "Expected at least 2 messages, got {}",
+            messages.len()
+        );
 
         // Last message should be InferenceComplete
         let last = messages.last().unwrap();
@@ -1002,13 +1073,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_streaming_cancel_stops_early() {
-        use axum::{
-            body::Body,
-            http::StatusCode,
-            response::Response,
-            routing::post,
-            Router,
-        };
+        use axum::{Router, body::Body, http::StatusCode, response::Response, routing::post};
 
         // Slow SSE backend: sends chunks with delays
         let app = Router::new().route(
@@ -1059,6 +1124,7 @@ mod tests {
                 tx,
                 None,
                 token_clone,
+                None,
             )
             .await;
         });
@@ -1082,13 +1148,19 @@ mod tests {
             }
         }
 
-        assert!(chunks < 50, "Expected early stop, got {chunks} chunks (should be << 100)");
-        assert!(!got_error, "Cancelled request should not send InferenceError");
+        assert!(
+            chunks < 50,
+            "Expected early stop, got {chunks} chunks (should be << 100)"
+        );
+        assert!(
+            !got_error,
+            "Cancelled request should not send InferenceError"
+        );
     }
 
     #[tokio::test]
     async fn test_handle_image_generation_mock() {
-        use axum::{body::Bytes, routing::post, Json, Router};
+        use axum::{Json, Router, body::Bytes, routing::post};
         use std::sync::{Arc, Mutex};
 
         // Track what gets uploaded
@@ -1178,7 +1250,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_handle_image_generation_error() {
-        use axum::{http::StatusCode, routing::post, Router};
+        use axum::{Router, http::StatusCode, routing::post};
 
         let app = Router::new().route(
             "/v1/images/generations",
@@ -1231,7 +1303,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_handle_image_generation_cancel() {
-        use axum::{routing::post, Router};
+        use axum::{Router, routing::post};
 
         // Slow backend that takes 10 seconds
         let app = Router::new().route(
@@ -1284,6 +1356,9 @@ mod tests {
 
         // Should NOT get an error message (cancelled requests are silent)
         let msg = tokio::time::timeout(std::time::Duration::from_millis(100), rx.recv()).await;
-        assert!(msg.is_err() || msg.unwrap().is_none(), "Cancelled request should not send messages");
+        assert!(
+            msg.is_err() || msg.unwrap().is_none(),
+            "Cancelled request should not send messages"
+        );
     }
 }

--- a/provider/src/scheduling.rs
+++ b/provider/src/scheduling.rs
@@ -1,0 +1,439 @@
+//! Provider scheduling — time-based availability windows.
+//!
+//! Users configure when their machine should serve inference requests.
+//! Outside scheduled windows, the provider disconnects from the coordinator
+//! and shuts down the backend to free GPU memory.
+//!
+//! Schedule windows support:
+//!   - Day-of-week selection (Mon-Sun)
+//!   - Start/end times in 24h local time
+//!   - Overnight windows (e.g., 22:00-08:00 = serve overnight)
+//!   - Multiple windows (e.g., weekday evenings + all weekend)
+//!
+//! When no schedule is configured or scheduling is disabled, the provider
+//! is always available (current default behavior).
+
+use chrono::{Datelike, Local, NaiveTime, Timelike, Weekday};
+use serde::{Deserialize, Serialize};
+use std::time::Duration;
+
+/// A single availability window.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ScheduleWindow {
+    /// Days this window applies to (e.g., ["mon", "tue", "wed"]).
+    pub days: Vec<String>,
+    /// Start time in HH:MM 24h format.
+    pub start: String,
+    /// End time in HH:MM 24h format. If end < start, wraps overnight.
+    pub end: String,
+}
+
+/// Schedule configuration.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ScheduleConfig {
+    pub enabled: bool,
+    #[serde(default)]
+    pub windows: Vec<ScheduleWindow>,
+}
+
+impl Default for ScheduleConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            windows: Vec::new(),
+        }
+    }
+}
+
+/// Parsed schedule ready for evaluation.
+pub struct Schedule {
+    windows: Vec<ParsedWindow>,
+}
+
+struct ParsedWindow {
+    days: Vec<Weekday>,
+    start: NaiveTime,
+    end: NaiveTime,
+    overnight: bool, // true when end < start (e.g., 22:00-08:00)
+}
+
+fn parse_day(s: &str) -> Option<Weekday> {
+    match s.to_lowercase().as_str() {
+        "mon" | "monday" => Some(Weekday::Mon),
+        "tue" | "tuesday" => Some(Weekday::Tue),
+        "wed" | "wednesday" => Some(Weekday::Wed),
+        "thu" | "thursday" => Some(Weekday::Thu),
+        "fri" | "friday" => Some(Weekday::Fri),
+        "sat" | "saturday" => Some(Weekday::Sat),
+        "sun" | "sunday" => Some(Weekday::Sun),
+        _ => None,
+    }
+}
+
+fn parse_time(s: &str) -> Option<NaiveTime> {
+    NaiveTime::parse_from_str(s, "%H:%M").ok()
+}
+
+impl Schedule {
+    /// Parse a ScheduleConfig into a Schedule ready for evaluation.
+    pub fn from_config(config: &ScheduleConfig) -> Option<Self> {
+        if !config.enabled || config.windows.is_empty() {
+            return None;
+        }
+
+        let mut windows = Vec::new();
+        for w in &config.windows {
+            let days: Vec<Weekday> = w.days.iter().filter_map(|d| parse_day(d)).collect();
+            if days.is_empty() {
+                continue;
+            }
+            let start = match parse_time(&w.start) {
+                Some(t) => t,
+                None => continue,
+            };
+            let end = match parse_time(&w.end) {
+                Some(t) => t,
+                None => continue,
+            };
+            let overnight = end <= start;
+            windows.push(ParsedWindow {
+                days,
+                start,
+                end,
+                overnight,
+            });
+        }
+
+        if windows.is_empty() {
+            return None;
+        }
+
+        Some(Self { windows })
+    }
+
+    /// Check if the current local time is within any scheduled window.
+    pub fn is_active_now(&self) -> bool {
+        let now = Local::now();
+        let today = now.weekday();
+        let time = now.time();
+
+        for w in &self.windows {
+            if w.overnight {
+                // Overnight window (e.g., 22:00-08:00):
+                // Active if: (today is in days AND time >= start)
+                //         OR (yesterday is in days AND time < end)
+                let yesterday = prev_weekday(today);
+                if w.days.contains(&today) && time >= w.start {
+                    return true;
+                }
+                if w.days.contains(&yesterday) && time < w.end {
+                    return true;
+                }
+            } else {
+                // Same-day window (e.g., 09:00-17:00):
+                if w.days.contains(&today) && time >= w.start && time < w.end {
+                    return true;
+                }
+            }
+        }
+
+        false
+    }
+
+    /// How long until the current active window ends.
+    /// Returns None if not currently active.
+    pub fn duration_until_inactive(&self) -> Option<Duration> {
+        let now = Local::now();
+        let today = now.weekday();
+        let time = now.time();
+
+        for w in &self.windows {
+            if w.overnight {
+                let yesterday = prev_weekday(today);
+                if w.days.contains(&today) && time >= w.start {
+                    // Window ends tomorrow at w.end
+                    let remaining_today = secs_until_midnight(time);
+                    let into_tomorrow = time_to_secs(w.end);
+                    return Some(Duration::from_secs(remaining_today + into_tomorrow));
+                }
+                if w.days.contains(&yesterday) && time < w.end {
+                    // Window ends today at w.end
+                    let diff = time_to_secs(w.end) - time_to_secs(time);
+                    return Some(Duration::from_secs(diff));
+                }
+            } else if w.days.contains(&today) && time >= w.start && time < w.end {
+                let diff = time_to_secs(w.end) - time_to_secs(time);
+                return Some(Duration::from_secs(diff));
+            }
+        }
+
+        None
+    }
+
+    /// How long until the next window opens.
+    /// Returns Duration::ZERO if already active.
+    pub fn duration_until_next_active(&self) -> Duration {
+        if self.is_active_now() {
+            return Duration::ZERO;
+        }
+
+        let now = Local::now();
+        let today = now.weekday();
+        let time = now.time();
+
+        let mut min_wait = u64::MAX;
+
+        // Check each window across the next 7 days
+        for w in &self.windows {
+            for day_offset in 0u64..7 {
+                let check_day = weekday_plus(today, day_offset as usize);
+                if !w.days.contains(&check_day) {
+                    continue;
+                }
+
+                let wait = if day_offset == 0 && time < w.start {
+                    // Today, window hasn't started yet
+                    time_to_secs(w.start) - time_to_secs(time)
+                } else if day_offset > 0 {
+                    // Future day
+                    let remaining_today = secs_until_midnight(time);
+                    let full_days = (day_offset - 1) * 86400;
+                    let into_target = time_to_secs(w.start);
+                    remaining_today + full_days + into_target
+                } else {
+                    continue; // Today but window already passed
+                };
+
+                if wait < min_wait {
+                    min_wait = wait;
+                }
+            }
+        }
+
+        if min_wait == u64::MAX {
+            Duration::from_secs(3600) // fallback: check again in 1 hour
+        } else {
+            Duration::from_secs(min_wait)
+        }
+    }
+
+    /// Human-readable description of the schedule.
+    pub fn describe(&self) -> String {
+        let mut parts = Vec::new();
+        for w in &self.windows {
+            let days: Vec<&str> = w.days.iter().map(|d| weekday_abbrev(d)).collect();
+            parts.push(format!("{} {}-{}", days.join(","), w.start, w.end));
+        }
+        parts.join(" | ")
+    }
+}
+
+fn prev_weekday(day: Weekday) -> Weekday {
+    match day {
+        Weekday::Mon => Weekday::Sun,
+        Weekday::Tue => Weekday::Mon,
+        Weekday::Wed => Weekday::Tue,
+        Weekday::Thu => Weekday::Wed,
+        Weekday::Fri => Weekday::Thu,
+        Weekday::Sat => Weekday::Fri,
+        Weekday::Sun => Weekday::Sat,
+    }
+}
+
+fn weekday_plus(day: Weekday, n: usize) -> Weekday {
+    let days = [
+        Weekday::Mon,
+        Weekday::Tue,
+        Weekday::Wed,
+        Weekday::Thu,
+        Weekday::Fri,
+        Weekday::Sat,
+        Weekday::Sun,
+    ];
+    let idx = day.num_days_from_monday() as usize;
+    days[(idx + n) % 7]
+}
+
+fn weekday_abbrev(day: &Weekday) -> &'static str {
+    match day {
+        Weekday::Mon => "Mon",
+        Weekday::Tue => "Tue",
+        Weekday::Wed => "Wed",
+        Weekday::Thu => "Thu",
+        Weekday::Fri => "Fri",
+        Weekday::Sat => "Sat",
+        Weekday::Sun => "Sun",
+    }
+}
+
+fn time_to_secs(t: NaiveTime) -> u64 {
+    t.hour() as u64 * 3600 + t.minute() as u64 * 60 + t.second() as u64
+}
+
+fn secs_until_midnight(t: NaiveTime) -> u64 {
+    86400 - time_to_secs(t)
+}
+
+/// Format a Duration as a human-readable string (e.g., "2h 30m").
+pub fn format_duration(d: Duration) -> String {
+    let secs = d.as_secs();
+    if secs < 60 {
+        format!("{secs}s")
+    } else if secs < 3600 {
+        format!("{}m", secs / 60)
+    } else {
+        let h = secs / 3600;
+        let m = (secs % 3600) / 60;
+        if m > 0 {
+            format!("{h}h {m}m")
+        } else {
+            format!("{h}h")
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn weekday_config(days: Vec<&str>, start: &str, end: &str) -> ScheduleConfig {
+        ScheduleConfig {
+            enabled: true,
+            windows: vec![ScheduleWindow {
+                days: days.into_iter().map(String::from).collect(),
+                start: start.to_string(),
+                end: end.to_string(),
+            }],
+        }
+    }
+
+    #[test]
+    fn test_disabled_schedule_returns_none() {
+        let config = ScheduleConfig {
+            enabled: false,
+            windows: vec![],
+        };
+        assert!(Schedule::from_config(&config).is_none());
+    }
+
+    #[test]
+    fn test_empty_windows_returns_none() {
+        let config = ScheduleConfig {
+            enabled: true,
+            windows: vec![],
+        };
+        assert!(Schedule::from_config(&config).is_none());
+    }
+
+    #[test]
+    fn test_parse_days() {
+        assert_eq!(parse_day("mon"), Some(Weekday::Mon));
+        assert_eq!(parse_day("Monday"), Some(Weekday::Mon));
+        assert_eq!(parse_day("FRI"), Some(Weekday::Fri));
+        assert_eq!(parse_day("invalid"), None);
+    }
+
+    #[test]
+    fn test_all_days_schedule_is_always_active() {
+        let config = weekday_config(
+            vec!["mon", "tue", "wed", "thu", "fri", "sat", "sun"],
+            "00:00",
+            "23:59",
+        );
+        let schedule = Schedule::from_config(&config).unwrap();
+        assert!(schedule.is_active_now());
+    }
+
+    #[test]
+    fn test_overnight_window_detection() {
+        let config = weekday_config(
+            vec!["mon", "tue", "wed", "thu", "fri", "sat", "sun"],
+            "22:00",
+            "08:00",
+        );
+        let schedule = Schedule::from_config(&config).unwrap();
+        // This window is overnight — verify it parsed correctly
+        assert!(schedule.windows[0].overnight);
+    }
+
+    #[test]
+    fn test_same_day_window_detection() {
+        let config = weekday_config(vec!["mon", "tue", "wed", "thu", "fri"], "09:00", "17:00");
+        let schedule = Schedule::from_config(&config).unwrap();
+        assert!(!schedule.windows[0].overnight);
+    }
+
+    #[test]
+    fn test_duration_until_next_active_when_active() {
+        let config = weekday_config(
+            vec!["mon", "tue", "wed", "thu", "fri", "sat", "sun"],
+            "00:00",
+            "23:59",
+        );
+        let schedule = Schedule::from_config(&config).unwrap();
+        assert_eq!(schedule.duration_until_next_active(), Duration::ZERO);
+    }
+
+    #[test]
+    fn test_describe() {
+        let config = ScheduleConfig {
+            enabled: true,
+            windows: vec![
+                ScheduleWindow {
+                    days: vec!["mon".into(), "tue".into(), "wed".into()],
+                    start: "09:00".into(),
+                    end: "17:00".into(),
+                },
+                ScheduleWindow {
+                    days: vec!["sat".into(), "sun".into()],
+                    start: "00:00".into(),
+                    end: "23:59".into(),
+                },
+            ],
+        };
+        let schedule = Schedule::from_config(&config).unwrap();
+        let desc = schedule.describe();
+        assert!(desc.contains("Mon"));
+        assert!(desc.contains("09:00"));
+        assert!(desc.contains("Sat"));
+    }
+
+    #[test]
+    fn test_format_duration() {
+        assert_eq!(format_duration(Duration::from_secs(30)), "30s");
+        assert_eq!(format_duration(Duration::from_secs(90)), "1m");
+        assert_eq!(format_duration(Duration::from_secs(3600)), "1h");
+        assert_eq!(format_duration(Duration::from_secs(5400)), "1h 30m");
+    }
+
+    #[test]
+    fn test_prev_weekday() {
+        assert_eq!(prev_weekday(Weekday::Mon), Weekday::Sun);
+        assert_eq!(prev_weekday(Weekday::Wed), Weekday::Tue);
+        assert_eq!(prev_weekday(Weekday::Sun), Weekday::Sat);
+    }
+
+    #[test]
+    fn test_weekday_plus() {
+        assert_eq!(weekday_plus(Weekday::Mon, 0), Weekday::Mon);
+        assert_eq!(weekday_plus(Weekday::Mon, 4), Weekday::Fri);
+        assert_eq!(weekday_plus(Weekday::Fri, 3), Weekday::Mon);
+        assert_eq!(weekday_plus(Weekday::Sun, 1), Weekday::Mon);
+    }
+
+    #[test]
+    fn test_config_roundtrip() {
+        let config = ScheduleConfig {
+            enabled: true,
+            windows: vec![ScheduleWindow {
+                days: vec!["mon".into(), "fri".into()],
+                start: "22:00".into(),
+                end: "08:00".into(),
+            }],
+        };
+
+        let toml_str = toml::to_string_pretty(&config).unwrap();
+        let parsed: ScheduleConfig = toml::from_str(&toml_str).unwrap();
+        assert_eq!(config, parsed);
+    }
+}

--- a/provider/src/security.rs
+++ b/provider/src/security.rs
@@ -32,7 +32,8 @@ pub fn deny_debugger_attachment() {
     {
         // PT_DENY_ATTACH = 31 on macOS
         const PT_DENY_ATTACH: libc::c_int = 31;
-        let result = unsafe { libc::ptrace(PT_DENY_ATTACH, 0, std::ptr::null_mut::<libc::c_char>(), 0) };
+        let result =
+            unsafe { libc::ptrace(PT_DENY_ATTACH, 0, std::ptr::null_mut::<libc::c_char>(), 0) };
         if result == 0 {
             tracing::info!("Anti-debug: PT_DENY_ATTACH enabled — debugger attachment blocked");
         } else {
@@ -69,7 +70,9 @@ pub fn check_sip_enabled() -> bool {
                 if enabled {
                     tracing::info!("SIP check: System Integrity Protection is enabled");
                 } else {
-                    tracing::error!("SIP check: System Integrity Protection is DISABLED — refusing to serve");
+                    tracing::error!(
+                        "SIP check: System Integrity Protection is DISABLED — refusing to serve"
+                    );
                 }
                 enabled
             }
@@ -169,15 +172,13 @@ pub fn verify_security_posture() -> Result<(), String> {
                  inference memory is hardware-protected"
             );
         } else {
-            return Err(
-                "RDMA is enabled without hypervisor memory isolation — \
+            return Err("RDMA is enabled without hypervisor memory isolation — \
                  remote memory access possible, refusing to serve.\n\n\
                  To disable RDMA:\n\
                  1. Open System Settings → Sharing\n\
                  2. Disable Remote Direct Memory Access\n\n\
                  Then retry: dginf-provider serve"
-                    .to_string(),
-            );
+                .to_string());
         }
     }
 
@@ -200,7 +201,9 @@ pub fn check_mdm_enrolled() -> bool {
         // Method 1: Check if the system profiles marker file exists.
         // This file is created when any configuration profile is installed
         // at the system level, even if `profiles list` can't show it without sudo.
-        if std::path::Path::new("/var/db/ConfigurationProfiles/Settings/.profilesAreInstalled").exists() {
+        if std::path::Path::new("/var/db/ConfigurationProfiles/Settings/.profilesAreInstalled")
+            .exists()
+        {
             tracing::debug!("MDM check: profiles marker file exists");
             return true;
         }
@@ -215,12 +218,13 @@ pub fn check_mdm_enrolled() -> bool {
                         "{}{}",
                         String::from_utf8_lossy(&o.stdout),
                         String::from_utf8_lossy(&o.stderr)
-                    ).to_lowercase();
+                    )
+                    .to_lowercase();
                     // Positive signals
-                    let has_profile = combined.contains("micromdm") ||
-                        combined.contains("com.github.micromdm") ||
-                        combined.contains("dginf") ||
-                        combined.contains("attribute: profileidentifier");
+                    let has_profile = combined.contains("micromdm")
+                        || combined.contains("com.github.micromdm")
+                        || combined.contains("dginf")
+                        || combined.contains("attribute: profileidentifier");
                     // Negative signal
                     let no_profiles = combined.contains("no configuration profiles");
                     has_profile || (!no_profiles && combined.contains("profileidentifier"))
@@ -597,7 +601,9 @@ impl Sha256Hasher {
             let hash_hex = hex.split_whitespace().next().unwrap_or("");
             let mut result = [0u8; 32];
             for (i, chunk) in hash_hex.as_bytes().chunks(2).enumerate() {
-                if i >= 32 { break; }
+                if i >= 32 {
+                    break;
+                }
                 let byte_str = std::str::from_utf8(chunk).unwrap_or("00");
                 result[i] = u8::from_str_radix(byte_str, 16).unwrap_or(0);
             }

--- a/provider/src/server.rs
+++ b/provider/src/server.rs
@@ -15,12 +15,12 @@
 
 use anyhow::Result;
 use axum::{
+    Json, Router,
     body::Body,
     extract::State,
     http::StatusCode,
     response::{IntoResponse, Response},
     routing::{get, post},
-    Json, Router,
 };
 use std::sync::Arc;
 
@@ -51,9 +51,7 @@ async fn health_handler(State(state): State<Arc<AppState>>) -> impl IntoResponse
     tracing::debug!("Health check -> {url}");
 
     match state.client.get(&url).send().await {
-        Ok(resp) if resp.status().is_success() => {
-            (StatusCode::OK, "ok").into_response()
-        }
+        Ok(resp) if resp.status().is_success() => (StatusCode::OK, "ok").into_response(),
         Ok(resp) => {
             let status = resp.status();
             tracing::warn!("Backend health check returned {status}");
@@ -101,16 +99,20 @@ async fn chat_completions_handler(
 
     // Log the request (summary)
     if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(&body) {
-        let model = parsed.get("model").and_then(|v| v.as_str()).unwrap_or("unknown");
-        let stream = parsed.get("stream").and_then(|v| v.as_bool()).unwrap_or(false);
+        let model = parsed
+            .get("model")
+            .and_then(|v| v.as_str())
+            .unwrap_or("unknown");
+        let stream = parsed
+            .get("stream")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
         let msg_count = parsed
             .get("messages")
             .and_then(|v| v.as_array())
             .map(|a| a.len())
             .unwrap_or(0);
-        tracing::info!(
-            "Chat completion: model={model}, stream={stream}, messages={msg_count}"
-        );
+        tracing::info!("Chat completion: model={model}, stream={stream}, messages={msg_count}");
     }
 
     match state
@@ -148,7 +150,8 @@ async fn chat_completions_handler(
 
 /// Proxy a non-streaming response from the backend.
 async fn proxy_response(resp: reqwest::Response) -> Response {
-    let status = StatusCode::from_u16(resp.status().as_u16()).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
+    let status =
+        StatusCode::from_u16(resp.status().as_u16()).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
 
     // Forward relevant headers
     let mut builder = Response::builder().status(status);
@@ -172,7 +175,8 @@ async fn proxy_response(resp: reqwest::Response) -> Response {
 
 /// Proxy a streaming (SSE) response from the backend.
 async fn proxy_streaming_response(resp: reqwest::Response) -> Response {
-    let status = StatusCode::from_u16(resp.status().as_u16()).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
+    let status =
+        StatusCode::from_u16(resp.status().as_u16()).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
 
     let stream = resp.bytes_stream();
 

--- a/provider/src/service.rs
+++ b/provider/src/service.rs
@@ -157,12 +157,11 @@ pub fn is_installed() -> bool {
 /// Writes the plist and loads it into launchd. If the service is already
 /// loaded, it is unloaded first (to pick up any config changes).
 pub fn install_and_start(coordinator_url: &str, model: &str) -> Result<()> {
-    let binary_path = std::env::current_exe()
-        .unwrap_or_else(|_| {
-            dirs::home_dir()
-                .unwrap_or_default()
-                .join(".dginf/bin/dginf-provider")
-        });
+    let binary_path = std::env::current_exe().unwrap_or_else(|_| {
+        dirs::home_dir()
+            .unwrap_or_default()
+            .join(".dginf/bin/dginf-provider")
+    });
 
     // Unload first if already loaded (picks up plist changes)
     if is_loaded() {

--- a/provider/src/wallet.rs
+++ b/provider/src/wallet.rs
@@ -47,7 +47,10 @@ impl Wallet {
 
             // Migrate to Keychain if possible
             save_to_keychain(&key_hex);
-            tracing::info!("Wallet loaded from file (migrated to Keychain): {}", &address);
+            tracing::info!(
+                "Wallet loaded from file (migrated to Keychain): {}",
+                &address
+            );
             return Ok(Self {
                 private_key_hex: key_hex,
                 address,
@@ -123,7 +126,10 @@ fn generate_private_key() -> String {
 /// For the DGInf internal ledger, this simplified address is sufficient.
 fn address_from_private_key(key_hex: &str) -> Result<String> {
     if key_hex.len() != 64 {
-        anyhow::bail!("invalid private key length: expected 64 hex chars, got {}", key_hex.len());
+        anyhow::bail!(
+            "invalid private key length: expected 64 hex chars, got {}",
+            key_hex.len()
+        );
     }
 
     // Simplified address derivation using SHA-256
@@ -170,8 +176,10 @@ fn load_from_keychain() -> Option<String> {
     let output = std::process::Command::new("/usr/bin/security")
         .args([
             "find-generic-password",
-            "-s", KEYCHAIN_SERVICE,
-            "-a", KEYCHAIN_ACCOUNT,
+            "-s",
+            KEYCHAIN_SERVICE,
+            "-a",
+            KEYCHAIN_ACCOUNT,
             "-w", // output password only
         ])
         .output()
@@ -179,11 +187,7 @@ fn load_from_keychain() -> Option<String> {
 
     if output.status.success() {
         let key = String::from_utf8_lossy(&output.stdout).trim().to_string();
-        if key.len() == 64 {
-            Some(key)
-        } else {
-            None
-        }
+        if key.len() == 64 { Some(key) } else { None }
     } else {
         None
     }
@@ -195,18 +199,24 @@ fn save_to_keychain(key_hex: &str) -> bool {
     let _ = std::process::Command::new("/usr/bin/security")
         .args([
             "delete-generic-password",
-            "-s", KEYCHAIN_SERVICE,
-            "-a", KEYCHAIN_ACCOUNT,
+            "-s",
+            KEYCHAIN_SERVICE,
+            "-a",
+            KEYCHAIN_ACCOUNT,
         ])
         .output();
 
     let status = std::process::Command::new("/usr/bin/security")
         .args([
             "add-generic-password",
-            "-s", KEYCHAIN_SERVICE,
-            "-a", KEYCHAIN_ACCOUNT,
-            "-w", key_hex,
-            "-T", "", // no app access (require user approval)
+            "-s",
+            KEYCHAIN_SERVICE,
+            "-a",
+            KEYCHAIN_ACCOUNT,
+            "-w",
+            key_hex,
+            "-T",
+            "", // no app access (require user approval)
         ])
         .status()
         .map(|s| s.success())
@@ -220,17 +230,23 @@ fn delete_from_keychain() {
     let _ = std::process::Command::new("/usr/bin/security")
         .args([
             "delete-generic-password",
-            "-s", KEYCHAIN_SERVICE,
-            "-a", KEYCHAIN_ACCOUNT,
+            "-s",
+            KEYCHAIN_SERVICE,
+            "-a",
+            KEYCHAIN_ACCOUNT,
         ])
         .output();
 }
 
 #[cfg(not(target_os = "macos"))]
-fn load_from_keychain() -> Option<String> { None }
+fn load_from_keychain() -> Option<String> {
+    None
+}
 
 #[cfg(not(target_os = "macos"))]
-fn save_to_keychain(_key_hex: &str) -> bool { false }
+fn save_to_keychain(_key_hex: &str) -> bool {
+    false
+}
 
 #[cfg(not(target_os = "macos"))]
 fn delete_from_keychain() {}


### PR DESCRIPTION
## Summary
- Providers can configure time windows when their machine serves inference (e.g., "weekday nights 10pm-8am", "all weekend")
- New `[schedule]` section in `provider.toml` with day-of-week, start/end time, overnight support
- Provider disconnects from coordinator and frees GPU memory outside schedule windows, reconnects automatically when the next window opens
- macOS app gets schedule editor UI in Settings > Availability tab with day toggles and time pickers

### Config example
```toml
[schedule]
enabled = true

[[schedule.windows]]
days = ["mon", "tue", "wed", "thu", "fri"]
start = "22:00"
end = "08:00"

[[schedule.windows]]
days = ["sat", "sun"]
start = "00:00"
end = "23:59"
```

### Files
- `provider/src/scheduling.rs` — New module: schedule parsing, `is_active_now()`, `duration_until_next_active()`, overnight window support
- `provider/src/config.rs` — Added `schedule: Option<ScheduleConfig>` to provider config
- `provider/src/main.rs` — Schedule-aware outer loop wrapping coordinator lifecycle
- `app/DGInf/Sources/DGInf/SettingsView.swift` — Schedule UI in Availability tab
- `app/DGInf/Sources/DGInf/StatusViewModel.swift` — Schedule state + config sync to TOML

## Test plan
- [x] All 131 provider tests pass (`cargo test`)
- [x] macOS app compiles (`swift build`)
- [x] Rust formatting clean (`cargo fmt`)
- [ ] Manual: set schedule, verify provider goes offline/online at window boundaries
- [ ] Manual: overnight window (22:00-08:00) crosses midnight correctly
- [ ] Manual: app schedule UI persists settings and writes to provider.toml

🤖 Generated with [Claude Code](https://claude.com/claude-code)