### PR TITLE
fix(provider): resolve FLUX.2 Klein pipeline by s3_name, not legacy cache path

### DIFF
--- a/provider/src/main.rs
+++ b/provider/src/main.rs
@@ -510,7 +510,11 @@ fn download_ckpt_model_from_cdn(
         name: &'static str,
     }
 
-    let pipeline = if cache_dir.to_string_lossy().contains("flux_2_klein_9b_q8p") {
+    // Match on base_url (contains s3_name) or cache_dir (legacy HF cache layout),
+    // so both `~/.darkbloom/models/flux-klein-9b-q8` and
+    // `~/.cache/huggingface/hub/models--flux_2_klein_9b_q8p.ckpt/...` resolve correctly.
+    let key = format!("{} {}", base_url, cache_dir.to_string_lossy());
+    let pipeline = if key.contains("klein-9b") || key.contains("klein_9b") {
         Some(ImagePipeline {
             model_file: "flux_2_klein_9b_q8p.ckpt",
             text_encoder: "qwen_3_8b_q8p.ckpt",
@@ -518,7 +522,7 @@ fn download_ckpt_model_from_cdn(
             version: "flux2_9b",
             name: "FLUX.2 [klein] 9B",
         })
-    } else if cache_dir.to_string_lossy().contains("flux_2_klein_4b_q8p") {
+    } else if key.contains("klein-4b") || key.contains("klein_4b") {
         Some(ImagePipeline {
             model_file: "flux_2_klein_4b_q8p.ckpt",
             text_encoder: "qwen_3_4b_q8p.ckpt",


### PR DESCRIPTION
## Summary
- `download_ckpt_model_from_cdn` matched the FLUX.2 Klein pipeline against `cache_dir.contains("flux_2_klein_{4,9}b_q8p")`, but `cmd_models` writes image models to `~/.darkbloom/models/<s3_name>` (e.g. `flux-klein-4b-q8`). The match always fell through to the `None` arm, so users saw `⚠ Unknown image model` after the tarball fallback 404'd.
- Match on a combined key of `base_url` (carries `s3_name`) and `cache_dir`, accepting both dashed (`klein-4b`/`klein-9b`) and underscored (`klein_4b`/`klein_9b`) forms so the legacy `~/.cache/huggingface/hub/models--flux_2_klein_4b_q8p.ckpt/...` layout still resolves.

Fixes #23.

## Test plan
- [x] `darkbloom models` → `1` (Download) → `1` (FLUX.2 Klein 4B): VAE completes, diffusion model begins streaming from R2 (`flux-klein-4b-q8`) at ~70+ MB/s on Apple M4 Pro.
- [x] Verified R2 URLs return `200 OK` for `flux_2_klein_4b_q8p.ckpt`, `flux_2_vae_f16.ckpt`, `qwen_3_4b_q8p.ckpt`.
- [ ] Confirm FLUX.2 Klein 9B downloads through the same path.
- [ ] Smoke-check legacy HF-cache layout still resolves (`klein_4b`/`klein_9b` branch).