### PR TITLE
Fix STT-only model selection in darkbloom start

### DIFF
--- a/provider/src/crypto.rs
+++ b/provider/src/crypto.rs
@@ -150,13 +150,10 @@ pub fn legacy_enclave_e2e_key_paths() -> Vec<std::path::PathBuf> {
 }
 
 fn purge_legacy_e2e_files() {
-    for path in [
-        legacy_node_key_paths(),
-        legacy_enclave_e2e_key_paths(),
-    ]
-    .into_iter()
-    .flatten()
-    .filter(|path| path.exists())
+    for path in [legacy_node_key_paths(), legacy_enclave_e2e_key_paths()]
+        .into_iter()
+        .flatten()
+        .filter(|path| path.exists())
     {
         match std::fs::remove_file(&path) {
             Ok(()) => tracing::info!("Removed legacy E2E secret file: {}", path.display()),

--- a/provider/src/main.rs
+++ b/provider/src/main.rs
@@ -3465,6 +3465,7 @@ async fn cmd_serve(
                                         .map(|s| (s.model_id.clone(), s.model_path.clone(), s.port, s.pid, s.healthy, s.restarting))
                                 };
 
+                                #[cfg(feature = "python")]
                                 let mut inprocess_engine = None;
                                 if let Some((slot_model_id, slot_model_path, slot_port, slot_pid, slot_healthy, slot_restarting)) = slot_info {
                                     if is_inprocess {
@@ -6014,6 +6015,15 @@ fn run_model_picker(entries: &[PickerEntry], memory_gb: f64) -> Result<Vec<usize
         .collect())
 }
 
+fn has_start_selection(
+    text_models: &[String],
+    image_model: Option<&str>,
+    stt_model: Option<&str>,
+) -> bool {
+    // This is hardware-independent: Mac model/RAM only affects picker availability.
+    !text_models.is_empty() || image_model.is_some() || stt_model.is_some()
+}
+
 async fn cmd_start(
     coordinator_url: String,
     model_override: Option<String>,
@@ -6231,7 +6241,11 @@ async fn cmd_start(
             .and_then(|id| models::resolve_local_path(id).map(|p| p.to_string_lossy().to_string()))
     });
 
-    if selected_models.is_empty() && final_image_model.is_none() {
+    if !has_start_selection(
+        &selected_models,
+        final_image_model.as_deref(),
+        picked_stt.as_deref(),
+    ) {
         anyhow::bail!("No models selected");
     }
 
@@ -6259,6 +6273,9 @@ async fn cmd_start(
     }
     if let Some(ref im) = final_image_model {
         println!("  Image:   {}", im);
+    }
+    if let Some(ref stt) = picked_stt {
+        println!("  STT:     {}", stt);
     }
     println!("  Logs:    {}", log_path.display());
     println!("  Service: io.darkbloom.provider (launchd)");
@@ -7238,6 +7255,42 @@ mod tests {
             std::env::remove_var("EIGENINFERENCE_INFERENCE_BACKEND");
         }
         assert!(validate_private_text_runtime(true).is_err());
+    }
+
+    #[test]
+    fn test_start_selection_accepts_text_model() {
+        let text_models = vec!["mlx-community/Qwen3.5-4B-4bit".to_string()];
+
+        assert!(has_start_selection(&text_models, None, None));
+    }
+
+    #[test]
+    fn test_start_selection_accepts_image_model() {
+        let text_models = Vec::new();
+
+        assert!(has_start_selection(
+            &text_models,
+            Some("flux-klein-4b-q8"),
+            None
+        ));
+    }
+
+    #[test]
+    fn test_start_selection_accepts_stt_model() {
+        let text_models = Vec::new();
+
+        assert!(has_start_selection(
+            &text_models,
+            None,
+            Some("CohereLabs/cohere-transcribe-03-2026")
+        ));
+    }
+
+    #[test]
+    fn test_start_selection_rejects_empty_selection() {
+        let text_models = Vec::new();
+
+        assert!(!has_start_selection(&text_models, None, None));
     }
 
     /// Verify that spawn_backend_log_forwarder captures stdout/stderr from a child

--- a/provider/src/secure_enclave_key.rs
+++ b/provider/src/secure_enclave_key.rs
@@ -17,10 +17,9 @@ use security_framework::{
 use security_framework_sys::{
     base::errSecItemNotFound,
     item::{
-        kSecAttrAccessControl, kSecAttrAccessGroup, kSecAttrIsPermanent,
-        kSecAttrKeySizeInBits, kSecAttrKeyType, kSecAttrKeyTypeECSECPrimeRandom,
-        kSecAttrLabel, kSecAttrTokenID, kSecAttrTokenIDSecureEnclave,
-        kSecPrivateKeyAttrs, kSecPublicKeyAttrs,
+        kSecAttrAccessControl, kSecAttrAccessGroup, kSecAttrIsPermanent, kSecAttrKeySizeInBits,
+        kSecAttrKeyType, kSecAttrKeyTypeECSECPrimeRandom, kSecAttrLabel, kSecAttrTokenID,
+        kSecAttrTokenIDSecureEnclave, kSecPrivateKeyAttrs, kSecPublicKeyAttrs,
     },
     key::SecKeyCreateRandomKey,
 };
@@ -36,9 +35,8 @@ pub(crate) fn load_existing_x25519_secret() -> Result<Option<[u8; 32]>> {
     let private_key = find_secure_enclave_key()?.ok_or_else(|| {
         anyhow!("wrapped text E2E secret exists but the Secure Enclave key is missing")
     })?;
-    let secret = unwrap_secret_with_private_key(&private_key, &sealed).context(
-        "wrapped text E2E secret is unreadable; refusing silent key rotation",
-    )?;
+    let secret = unwrap_secret_with_private_key(&private_key, &sealed)
+        .context("wrapped text E2E secret is unreadable; refusing silent key rotation")?;
     Ok(Some(secret))
 }
 
@@ -191,7 +189,9 @@ fn wrap_secret_with_public_key(private_key: &SecKey, secret: &[u8; 32]) -> Resul
     })?;
     public_key
         .encrypt_data(Algorithm::ECIESEncryptionStandardX963SHA256AESGCM, secret)
-        .map_err(|err| anyhow!("failed to seal X25519 secret with Secure Enclave public key: {err}"))
+        .map_err(|err| {
+            anyhow!("failed to seal X25519 secret with Secure Enclave public key: {err}")
+        })
 }
 
 fn unwrap_secret_with_private_key(private_key: &SecKey, sealed: &[u8]) -> Result<[u8; 32]> {
@@ -248,7 +248,8 @@ fn delete_wrapped_secret_file() -> Result<()> {
 }
 
 fn wrapped_secret_path() -> Result<std::path::PathBuf> {
-    let home = dirs::home_dir().context("could not determine home directory for wrapped E2E key")?;
+    let home =
+        dirs::home_dir().context("could not determine home directory for wrapped E2E key")?;
     Ok(home.join(".darkbloom").join(E2E_WRAPPED_SECRET_FILENAME))
 }
 


### PR DESCRIPTION
## Summary

Fixes #42 for the `No models selected` loop when selecting only `Cohere Transcribe [transcription]`.

The issue was reproduced on a Mac Mini, but the root cause is not Mac Mini-specific. `hardware::detect()` only controls which catalog entries fit the machine's RAM; the failure happens later in generic startup selection validation after the picker has already returned selected entries. Any Mac provider that selects only an STT/transcription model can hit the same error.

The separate `ModuleNotFoundError: No module named 'mlx_audio.stt.cohere_asr'` symptom mentioned in #42 is a runtime/package issue and is not covered by this PR.

## Root Cause

`cmd_start` already split selected picker entries into:

- text models for `--model`
- image models for `--image-model`
- transcription/STT models for `EIGENINFERENCE_STT_MODEL`

However, the final validation only checked text and image selections:

```rust
if selected_models.is_empty() && final_image_model.is_none() {
    anyhow::bail!("No models selected");
}
```

So `picked_stt` could be populated correctly, but STT-only startup still failed before launchd service installation.

## Changes

- Adds a small `has_start_selection` helper that treats text, image, and STT selections as valid startup workloads.
- Updates the final `darkbloom start` guard to include `picked_stt`.
- Prints the selected STT model in the startup summary.
- Adds focused unit tests for text-only, image-only, STT-only, and empty selections.
- Keeps the branch on current upstream `master`; while validating that base, also applies formatter-only cleanup in `crypto.rs` / `secure_enclave_key.rs` and gates the in-process engine scratch variable behind the existing `python` feature so `--no-default-features` compiles.

## Validation

- `cd provider && cargo fmt --check`
- `cd provider && cargo test --no-default-features`

Note: an initial sandboxed test run failed because local mock-server socket binding was denied with `Operation not permitted`; the same test command passed when rerun outside the sandbox.