### PR TITLE
Skip Vercel preview deployments on PR branches

### DIFF
--- a/console-ui/vercel.json
+++ b/console-ui/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "ignoreCommand": "[ \"$VERCEL_GIT_COMMIT_REF\" = \"master\" ]"
+}

--- a/landing/vercel.json
+++ b/landing/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "ignoreCommand": "[ \"$VERCEL_GIT_COMMIT_REF\" = \"master\" ]"
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "ignoreCommand": "[ \"$VERCEL_GIT_COMMIT_REF\" = \"master\" ]"
+}


### PR DESCRIPTION
## Summary

- Adds `console-ui/vercel.json` with an `ignoreCommand` that only allows Vercel builds on the `main` branch
- PR branches will be skipped, preventing unnecessary preview deployments during CI

The Vercel GitHub App triggers preview deployments on every push by default. The `ignoreCommand` shell test `[ "$VERCEL_GIT_COMMIT_REF" = "main" ]` exits 0 (proceed) only for `main`; all other branches exit 1 (skip).