### PR TITLE
Skip Vercel preview deployments on non-master branches

### DIFF
--- a/console-ui/vercel.json
+++ b/console-ui/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "ignoreCommand": "[ \"$VERCEL_GIT_COMMIT_REF\" = \"master\" ]"
+}

--- a/landing/vercel.json
+++ b/landing/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "ignoreCommand": "[ \"$VERCEL_GIT_COMMIT_REF\" = \"master\" ]"
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "ignoreCommand": "[ \"$VERCEL_GIT_COMMIT_REF\" = \"master\" ]"
+}


### PR DESCRIPTION
## Summary

- Adds `vercel.json` with an `ignoreCommand` at the repo root, `console-ui/`, and `landing/` to cover both Vercel projects (`d-inference` and `d-inference-landing`)
- The ignore command `[ "$VERCEL_GIT_COMMIT_REF" = "master" ]` only allows builds on `master`; all PR/feature branches are skipped
- Prevents unnecessary failed preview deployments during CI