### PR TITLE
Fix provider model path leakage in completion responses

### DIFF
--- a/app/EigenInference/Sources/EigenInference/ModelCatalog.swift
+++ b/app/EigenInference/Sources/EigenInference/ModelCatalog.swift
@@ -10,12 +10,17 @@ enum ModelCatalog {
 
     struct Entry: Identifiable {
         let id: String
+        let sourceID: String?
         let name: String
         let modelType: String   // "text", "image", "transcription"
         let sizeGB: Double
         let architecture: String
         let description: String
         let minRAMGB: Int
+
+        var resolvedSourceID: String {
+            sourceID ?? id
+        }
 
         /// Whether this model fits on a machine with the given RAM.
         func fitsInMemory(totalGB: Int) -> Bool {
@@ -26,17 +31,17 @@ enum ModelCatalog {
     /// Known models from the Darkbloom catalog, ordered by min RAM tier.
     static let models: [Entry] = [
         // Transcription
-        Entry(id: "CohereLabs/cohere-transcribe-03-2026", name: "Cohere Transcribe", modelType: "transcription", sizeGB: 4.2, architecture: "2B conformer", description: "Best-in-class STT", minRAMGB: 8),
+        Entry(id: "CohereLabs/cohere-transcribe-03-2026", sourceID: nil, name: "Cohere Transcribe", modelType: "transcription", sizeGB: 4.2, architecture: "2B conformer", description: "Best-in-class STT", minRAMGB: 8),
 
         // Image generation
-        Entry(id: "flux_2_klein_4b_q8p.ckpt", name: "FLUX.2 Klein 4B", modelType: "image", sizeGB: 8.1, architecture: "4B diffusion", description: "Fast image gen", minRAMGB: 16),
-        Entry(id: "flux_2_klein_9b_q8p.ckpt", name: "FLUX.2 Klein 9B", modelType: "image", sizeGB: 13.0, architecture: "9B diffusion", description: "Higher quality image gen", minRAMGB: 24),
+        Entry(id: "flux_2_klein_4b_q8p.ckpt", sourceID: nil, name: "FLUX.2 Klein 4B", modelType: "image", sizeGB: 8.1, architecture: "4B diffusion", description: "Fast image gen", minRAMGB: 16),
+        Entry(id: "flux_2_klein_9b_q8p.ckpt", sourceID: nil, name: "FLUX.2 Klein 9B", modelType: "image", sizeGB: 13.0, architecture: "9B diffusion", description: "Higher quality image gen", minRAMGB: 24),
 
         // Text generation
-        Entry(id: "qwen3.5-27b-claude-opus-8bit", name: "Qwen3.5 27B Claude Opus", modelType: "text", sizeGB: 27.0, architecture: "27B dense, Claude Opus distilled", description: "Frontier quality reasoning", minRAMGB: 36),
-        Entry(id: "mlx-community/Trinity-Mini-8bit", name: "Trinity Mini", modelType: "text", sizeGB: 26.0, architecture: "27B Adaptive MoE", description: "Fast agentic inference", minRAMGB: 48),
-        Entry(id: "mlx-community/Qwen3.5-122B-A10B-8bit", name: "Qwen3.5 122B", modelType: "text", sizeGB: 122.0, architecture: "122B MoE, 10B active", description: "Best quality", minRAMGB: 128),
-        Entry(id: "mlx-community/MiniMax-M2.5-8bit", name: "MiniMax M2.5", modelType: "text", sizeGB: 243.0, architecture: "239B MoE, 11B active", description: "SOTA coding, 100 tok/s", minRAMGB: 256),
+        Entry(id: "qwen3.5-27b-claude-opus-8bit", sourceID: nil, name: "Qwen3.5 27B Claude Opus", modelType: "text", sizeGB: 27.0, architecture: "27B dense, Claude Opus distilled", description: "Frontier quality reasoning", minRAMGB: 36),
+        Entry(id: "Trinity-Mini-8bit", sourceID: "mlx-community/Trinity-Mini-8bit", name: "Trinity Mini", modelType: "text", sizeGB: 26.0, architecture: "27B Adaptive MoE", description: "Fast agentic inference", minRAMGB: 48),
+        Entry(id: "Qwen3.5-122B-A10B-8bit", sourceID: "mlx-community/Qwen3.5-122B-A10B-8bit", name: "Qwen3.5 122B", modelType: "text", sizeGB: 122.0, architecture: "122B MoE, 10B active", description: "Best quality", minRAMGB: 128),
+        Entry(id: "MiniMax-M2.5-8bit", sourceID: "mlx-community/MiniMax-M2.5-8bit", name: "MiniMax M2.5", modelType: "text", sizeGB: 243.0, architecture: "239B MoE, 11B active", description: "SOTA coding, 100 tok/s", minRAMGB: 256),
     ]
 
     /// Returns the default model for a given RAM tier.

--- a/app/EigenInference/Sources/EigenInference/ModelCatalogView.swift
+++ b/app/EigenInference/Sources/EigenInference/ModelCatalogView.swift
@@ -64,7 +64,9 @@ struct ModelCatalogView: View {
     }
 
     private func modelRow(_ entry: ModelCatalog.Entry) -> some View {
-        let isDownloaded = viewModel.modelManager.availableModels.contains { $0.id == entry.id }
+        let isDownloaded = viewModel.modelManager.availableModels.contains {
+            $0.id == entry.id || $0.id == entry.sourceID
+        }
         let fits = entry.fitsInMemory(totalGB: viewModel.memoryGB)
         let isActive = viewModel.currentModel == entry.id
         let isDownloading = downloadingModel == entry.id
@@ -198,7 +200,8 @@ struct ModelCatalogView: View {
     private func removeModel(_ modelId: String) async {
         let home = FileManager.default.homeDirectoryForCurrentUser
         let cacheDir = home.appendingPathComponent(".cache/huggingface/hub")
-        let dirName = "models--" + modelId.replacingOccurrences(of: "/", with: "--")
+        let sourceModelId = ModelCatalog.models.first(where: { $0.id == modelId })?.sourceID ?? modelId
+        let dirName = "models--" + sourceModelId.replacingOccurrences(of: "/", with: "--")
         let modelDir = cacheDir.appendingPathComponent(dirName)
 
         do {

--- a/app/EigenInference/Sources/EigenInference/ModelManager.swift
+++ b/app/EigenInference/Sources/EigenInference/ModelManager.swift
@@ -31,6 +31,12 @@ struct LocalModel: Identifiable, Hashable {
 
     /// Whether this model is an MLX model (contains mlx or MLX in the path).
     let isMLX: Bool
+
+    /// Returns true when this on-disk model matches either the public API ID
+    /// or the source repo ID for a catalog entry.
+    func matches(_ entry: ModelCatalog.Entry) -> Bool {
+        id == entry.id || id == entry.sourceID
+    }
 }
 
 /// Discovers HuggingFace-cached models and manages downloads.

--- a/app/EigenInference/Sources/EigenInference/SetupWizardView.swift
+++ b/app/EigenInference/Sources/EigenInference/SetupWizardView.swift
@@ -632,7 +632,9 @@ struct SetupWizardView: View {
     }
 
     private func downloadModelIfNeeded(_ model: ModelCatalog.Entry) async {
-        let alreadyDownloaded = viewModel.modelManager.availableModels.contains { $0.id == model.id }
+        let alreadyDownloaded = viewModel.modelManager.availableModels.contains {
+            $0.id == model.id || $0.id == model.sourceID
+        }
         if alreadyDownloaded {
             downloadStatus = ""
             return

--- a/console-ui/src/app/api-console/page.tsx
+++ b/console-ui/src/app/api-console/page.tsx
@@ -393,7 +393,7 @@ export DARKBLOOM_BASE_URL="${u}/v1"`,
   -H "Authorization: Bearer ${k}" \\
   -H "Content-Type: application/json" \\
   -d '{
-    "model": "mlx-community/gemma-4-26b-a4b-it-8bit",
+    "model": "gemma-4-26b-a4b-it-8bit",
     "messages": [{"role": "user", "content": "Explain quantum computing"}],
     "stream": true,
     "max_tokens": 1024
@@ -410,7 +410,7 @@ client = OpenAI(
 )
 
 stream = client.chat.completions.create(
-    model="mlx-community/gemma-4-26b-a4b-it-8bit",
+    model="gemma-4-26b-a4b-it-8bit",
     messages=[{"role": "user", "content": "Explain quantum computing"}],
     stream=True,
     max_tokens=1024,
@@ -432,7 +432,7 @@ const client = new OpenAI({
 });
 
 const stream = await client.chat.completions.create({
-  model: "mlx-community/gemma-4-26b-a4b-it-8bit",
+  model: "gemma-4-26b-a4b-it-8bit",
   messages: [{ role: "user", content: "Explain quantum computing" }],
   stream: true,
   max_tokens: 1024,
@@ -457,7 +457,7 @@ const darkbloom = createOpenAICompatible({
 
 // Streaming response
 const { textStream } = streamText({
-  model: darkbloom.chatModel("mlx-community/gemma-4-26b-a4b-it-8bit"),
+  model: darkbloom.chatModel("gemma-4-26b-a4b-it-8bit"),
   prompt: "Explain quantum computing",
 });
 
@@ -467,7 +467,7 @@ for await (const text of textStream) {
 
 // Single response
 const { text } = await generateText({
-  model: darkbloom.chatModel("mlx-community/gemma-4-26b-a4b-it-8bit"),
+  model: darkbloom.chatModel("gemma-4-26b-a4b-it-8bit"),
   prompt: "Write a haiku about Apple Silicon",
 });
 console.log(text);`,
@@ -657,10 +657,10 @@ for model in models.data:
                 </thead>
                 <tbody>
                   {[
-                    { id: "mlx-community/gemma-4-26b-a4b-it-8bit", type: "text", arch: "26B MoE, 4B active — recommended" },
+                    { id: "gemma-4-26b-a4b-it-8bit", type: "text", arch: "26B MoE, 4B active — recommended" },
                     { id: "qwen3.5-27b-claude-opus-8bit", type: "text", arch: "27B dense, Claude Opus distilled" },
-                    { id: "mlx-community/Qwen3.5-122B-A10B-8bit", type: "text", arch: "122B MoE, 10B active" },
-                    { id: "mlx-community/MiniMax-M2.5-8bit", type: "text", arch: "239B MoE, 11B active" },
+                    { id: "Qwen3.5-122B-A10B-8bit", type: "text", arch: "122B MoE, 10B active" },
+                    { id: "MiniMax-M2.5-8bit", type: "text", arch: "239B MoE, 11B active" },
                     { id: "CohereLabs/cohere-transcribe-03-2026", type: "stt", arch: "2B conformer" },
                   ].map((m) => (
                     <tr key={m.id} className="border-b border-border-dim/50 last:border-0">

--- a/console-ui/src/app/models/page.tsx
+++ b/console-ui/src/app/models/page.tsx
@@ -16,10 +16,10 @@ import {
 // Competitor pricing for comparison — static since these are external
 const competitorPricing: Record<string, { output: number; name: string; competitor: string; unit?: string }> = {
   "qwen3.5-27b-claude-opus-8bit": { output: 1_560_000, name: "Qwen3.5 27B Claude Opus", competitor: "OpenRouter" },
-  "mlx-community/Trinity-Mini-8bit": { output: 150_000, name: "Trinity Mini", competitor: "OpenRouter" },
-  "mlx-community/gemma-4-26b-a4b-it-8bit": { output: 400_000, name: "Gemma 4 26B", competitor: "OpenRouter" },
-  "mlx-community/Qwen3.5-122B-A10B-8bit": { output: 2_080_000, name: "Qwen3.5 122B", competitor: "OpenRouter" },
-  "mlx-community/MiniMax-M2.5-8bit": { output: 1_000_000, name: "MiniMax M2.5", competitor: "OpenRouter" },
+  "Trinity-Mini-8bit": { output: 150_000, name: "Trinity Mini", competitor: "OpenRouter" },
+  "gemma-4-26b-a4b-it-8bit": { output: 400_000, name: "Gemma 4 26B", competitor: "OpenRouter" },
+  "Qwen3.5-122B-A10B-8bit": { output: 2_080_000, name: "Qwen3.5 122B", competitor: "OpenRouter" },
+  "MiniMax-M2.5-8bit": { output: 1_000_000, name: "MiniMax M2.5", competitor: "OpenRouter" },
   "CohereLabs/cohere-transcribe-03-2026": { output: 2_000, name: "Cohere Transcribe", competitor: "AssemblyAI", unit: "per audio-min" },
 };
 

--- a/coordinator/cmd/coordinator/main.go
+++ b/coordinator/cmd/coordinator/main.go
@@ -383,28 +383,81 @@ func envOr(key, fallback string) string {
 func seedModelCatalog(st store.Store, logger *slog.Logger) {
 	existing := st.ListSupportedModels()
 	existingIDs := make(map[string]bool, len(existing))
+	existingBySourceID := make(map[string][]store.SupportedModel, len(existing))
 	for _, m := range existing {
 		existingIDs[m.ID] = true
+		sourceID := m.SourceID
+		if sourceID == "" {
+			sourceID = m.ID
+		}
+		existingBySourceID[sourceID] = append(existingBySourceID[sourceID], m)
 	}
 
 	models := []store.SupportedModel{
 		// --- Transcription (speech-to-text) ---
-		{ID: "CohereLabs/cohere-transcribe-03-2026", S3Name: "cohere-transcribe-03-2026", DisplayName: "Cohere Transcribe", ModelType: "transcription", SizeGB: 4.2, Architecture: "2B conformer", Description: "Best-in-class STT", MinRAMGB: 8, Active: true},
+		{ID: "CohereLabs/cohere-transcribe-03-2026", SourceID: "CohereLabs/cohere-transcribe-03-2026", S3Name: "cohere-transcribe-03-2026", DisplayName: "Cohere Transcribe", ModelType: "transcription", SizeGB: 4.2, Architecture: "2B conformer", Description: "Best-in-class STT", MinRAMGB: 8, Active: true},
 
 		// --- Image generation (Draw Things + Metal FlashAttention) ---
-		{ID: "flux_2_klein_4b_q8p.ckpt", S3Name: "flux-klein-4b-q8", DisplayName: "FLUX.2 Klein 4B", ModelType: "image", SizeGB: 8.1, Architecture: "4B diffusion", Description: "Fast image gen", MinRAMGB: 16, Active: true},
-		{ID: "flux_2_klein_9b_q8p.ckpt", S3Name: "flux-klein-9b-q8", DisplayName: "FLUX.2 Klein 9B", ModelType: "image", SizeGB: 17.4, Architecture: "9B diffusion + Qwen 8B encoder", Description: "Higher quality image gen", MinRAMGB: 32, Active: true},
+		{ID: "flux_2_klein_4b_q8p.ckpt", SourceID: "flux_2_klein_4b_q8p.ckpt", S3Name: "flux-klein-4b-q8", DisplayName: "FLUX.2 Klein 4B", ModelType: "image", SizeGB: 8.1, Architecture: "4B diffusion", Description: "Fast image gen", MinRAMGB: 16, Active: true},
+		{ID: "flux_2_klein_9b_q8p.ckpt", SourceID: "flux_2_klein_9b_q8p.ckpt", S3Name: "flux-klein-9b-q8", DisplayName: "FLUX.2 Klein 9B", ModelType: "image", SizeGB: 17.4, Architecture: "9B diffusion + Qwen 8B encoder", Description: "Higher quality image gen", MinRAMGB: 32, Active: true},
 
 		// --- Text generation (8-bit quantization) ---
-		{ID: "qwen3.5-27b-claude-opus-8bit", S3Name: "qwen35-27b-claude-opus-8bit", DisplayName: "Qwen3.5 27B Claude Opus Distilled", ModelType: "text", SizeGB: 27.0, Architecture: "27B dense, Claude Opus distilled", Description: "Frontier quality reasoning", MinRAMGB: 36, Active: true},
-		{ID: "mlx-community/Trinity-Mini-8bit", S3Name: "Trinity-Mini-8bit", DisplayName: "Trinity Mini", ModelType: "text", SizeGB: 26.0, Architecture: "27B Adaptive MoE", Description: "Fast agentic inference", MinRAMGB: 48, Active: true},
-		{ID: "mlx-community/gemma-4-26b-a4b-it-8bit", S3Name: "gemma-4-26b-a4b-it-8bit", DisplayName: "Gemma 4 26B", ModelType: "text", SizeGB: 28.0, Architecture: "26B MoE, 4B active", Description: "Fast multimodal MoE", MinRAMGB: 36, Active: true},
-		{ID: "mlx-community/Qwen3.5-122B-A10B-8bit", S3Name: "Qwen3.5-122B-A10B-8bit", DisplayName: "Qwen3.5 122B", ModelType: "text", SizeGB: 122.0, Architecture: "122B MoE, 10B active", Description: "Best quality", MinRAMGB: 128, Active: true},
-		{ID: "mlx-community/MiniMax-M2.5-8bit", S3Name: "MiniMax-M2.5-8bit", DisplayName: "MiniMax M2.5", ModelType: "text", SizeGB: 243.0, Architecture: "239B MoE, 11B active", Description: "SOTA coding, 100 tok/s", MinRAMGB: 256, Active: true},
+		{ID: "qwen3.5-27b-claude-opus-8bit", SourceID: "qwen3.5-27b-claude-opus-8bit", S3Name: "qwen35-27b-claude-opus-8bit", DisplayName: "Qwen3.5 27B Claude Opus Distilled", ModelType: "text", SizeGB: 27.0, Architecture: "27B dense, Claude Opus distilled", Description: "Frontier quality reasoning", MinRAMGB: 36, Active: true},
+		{ID: "Trinity-Mini-8bit", SourceID: "mlx-community/Trinity-Mini-8bit", S3Name: "Trinity-Mini-8bit", DisplayName: "Trinity Mini", ModelType: "text", SizeGB: 26.0, Architecture: "27B Adaptive MoE", Description: "Fast agentic inference", MinRAMGB: 48, Active: true},
+		{ID: "gemma-4-26b-a4b-it-8bit", SourceID: "mlx-community/gemma-4-26b-a4b-it-8bit", S3Name: "gemma-4-26b-a4b-it-8bit", DisplayName: "Gemma 4 26B", ModelType: "text", SizeGB: 28.0, Architecture: "26B MoE, 4B active", Description: "Fast multimodal MoE", MinRAMGB: 36, Active: true},
+		{ID: "Qwen3.5-122B-A10B-8bit", SourceID: "mlx-community/Qwen3.5-122B-A10B-8bit", S3Name: "Qwen3.5-122B-A10B-8bit", DisplayName: "Qwen3.5 122B", ModelType: "text", SizeGB: 122.0, Architecture: "122B MoE, 10B active", Description: "Best quality", MinRAMGB: 128, Active: true},
+		{ID: "MiniMax-M2.5-8bit", SourceID: "mlx-community/MiniMax-M2.5-8bit", S3Name: "MiniMax-M2.5-8bit", DisplayName: "MiniMax M2.5", ModelType: "text", SizeGB: 243.0, Architecture: "239B MoE, 11B active", Description: "SOTA coding, 100 tok/s", MinRAMGB: 256, Active: true},
 	}
 
 	added := 0
 	for i := range models {
+		if legacyRows, ok := existingBySourceID[models[i].SourceID]; ok {
+			var canonicalPresent bool
+			var legacyRowsToDelete []store.SupportedModel
+			for _, legacy := range legacyRows {
+				if legacy.ID == models[i].ID {
+					canonicalPresent = true
+					continue
+				}
+				legacyRowsToDelete = append(legacyRowsToDelete, legacy)
+			}
+			for _, legacy := range legacyRowsToDelete {
+				migrated := legacy
+				migrated.ID = models[i].ID
+				if migrated.SourceID == "" {
+					migrated.SourceID = models[i].SourceID
+				}
+				migrated.S3Name = models[i].S3Name
+				migrated.DisplayName = models[i].DisplayName
+				migrated.ModelType = models[i].ModelType
+				migrated.SizeGB = models[i].SizeGB
+				migrated.Architecture = models[i].Architecture
+				migrated.Description = models[i].Description
+				migrated.MinRAMGB = models[i].MinRAMGB
+				migrated.Active = models[i].Active
+				if err := st.SetSupportedModel(&migrated); err != nil {
+					logger.Warn("failed to migrate legacy model id",
+						"legacy_id", legacy.ID,
+						"new_id", migrated.ID,
+						"error", err,
+					)
+					continue
+				}
+				if err := st.DeleteSupportedModel(legacy.ID); err != nil {
+					logger.Warn("failed to delete legacy model id after migration",
+						"legacy_id", legacy.ID,
+						"new_id", migrated.ID,
+						"error", err,
+					)
+				}
+				canonicalPresent = true
+				existingIDs[migrated.ID] = true
+				added++
+			}
+			if canonicalPresent {
+				continue
+			}
+		}
 		if existingIDs[models[i].ID] {
 			continue
 		}

--- a/coordinator/internal/api/billing_handlers.go
+++ b/coordinator/internal/api/billing_handlers.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -573,8 +574,9 @@ func (s *Server) handleGetPricing(w http.ResponseWriter, r *http.Request) {
 	// Overlay admin-set platform prices (account_id = "platform").
 	platformPrices := s.store.ListModelPrices("platform")
 	for _, mp := range platformPrices {
-		priceMap[mp.Model] = priceEntry{
-			Model:       mp.Model,
+		modelID := s.canonicalModelID(mp.Model)
+		priceMap[modelID] = priceEntry{
+			Model:       modelID,
 			InputPrice:  mp.InputPrice,
 			OutputPrice: mp.OutputPrice,
 			InputUSD:    fmt.Sprintf("$%.4f", float64(mp.InputPrice)/1_000_000),
@@ -651,6 +653,7 @@ func (s *Server) handleAdminPricing(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusBadRequest, errorResponse("invalid_request_error", "model is required"))
 		return
 	}
+	req.Model = s.canonicalModelID(req.Model)
 	if req.InputPrice <= 0 || req.OutputPrice <= 0 {
 		writeJSON(w, http.StatusBadRequest, errorResponse("invalid_request_error", "input_price and output_price must be positive"))
 		return
@@ -698,6 +701,7 @@ func (s *Server) handleSetPricing(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusBadRequest, errorResponse("invalid_request_error", "model is required"))
 		return
 	}
+	req.Model = s.canonicalModelID(req.Model)
 	if req.InputPrice <= 0 || req.OutputPrice <= 0 {
 		writeJSON(w, http.StatusBadRequest, errorResponse("invalid_request_error", "input_price and output_price must be positive (micro-USD per 1M tokens)"))
 		return
@@ -737,6 +741,7 @@ func (s *Server) handleDeletePricing(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusBadRequest, errorResponse("invalid_request_error", "model is required"))
 		return
 	}
+	req.Model = s.canonicalModelID(req.Model)
 
 	accountID := s.resolveAccountID(r)
 	if err := s.store.DeleteModelPrice(accountID, req.Model); err != nil {
@@ -811,7 +816,7 @@ func (s *Server) handleAdminListModels(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	models := s.store.ListSupportedModels()
+	models := uniqueSupportedModels(s.store.ListSupportedModels())
 	if models == nil {
 		models = []store.SupportedModel{}
 	}
@@ -883,25 +888,43 @@ func (s *Server) handleAdminDeleteModel(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	if err := s.store.DeleteSupportedModel(req.ID); err != nil {
-		writeJSON(w, http.StatusNotFound, errorResponse("not_found", err.Error()))
+	modelID := s.canonicalModelID(req.ID)
+	catalog := s.store.ListSupportedModels()
+	toDelete := []string{modelID}
+	for _, model := range catalog {
+		if canonicalModelID(model.ID, catalog) == modelID && !slices.Contains(toDelete, model.ID) {
+			toDelete = append(toDelete, model.ID)
+		}
+	}
+
+	deleted := 0
+	var lastErr error
+	for _, id := range toDelete {
+		if err := s.store.DeleteSupportedModel(id); err != nil {
+			lastErr = err
+			continue
+		}
+		deleted++
+	}
+	if deleted == 0 {
+		writeJSON(w, http.StatusNotFound, errorResponse("not_found", lastErr.Error()))
 		return
 	}
 
 	// Sync the updated catalog to the registry so routing reflects the change.
 	s.SyncModelCatalog()
 
-	s.logger.Info("admin: model removed from catalog", "model_id", req.ID)
+	s.logger.Info("admin: model removed from catalog", "model_id", modelID, "rows_deleted", deleted)
 	writeJSON(w, http.StatusOK, map[string]any{
 		"status":   "model_deleted",
-		"model_id": req.ID,
+		"model_id": modelID,
 	})
 }
 
 // handleModelCatalog handles GET /v1/models/catalog.
 // Public endpoint — returns active models for providers and the install script.
 func (s *Server) handleModelCatalog(w http.ResponseWriter, r *http.Request) {
-	allModels := s.store.ListSupportedModels()
+	allModels := uniqueSupportedModels(s.store.ListSupportedModels())
 
 	// Optional filter: ?type=text or ?type=transcription
 	typeFilter := r.URL.Query().Get("type")

--- a/coordinator/internal/api/consumer.go
+++ b/coordinator/internal/api/consumer.go
@@ -190,6 +190,8 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusBadRequest, errorResponse("invalid_request_error", "model is required"))
 		return
 	}
+	model = s.canonicalModelID(model)
+	parsed["model"] = model
 
 	// Accept either chat completions format (messages) or Responses API
 	// format (input). The provider's backend handles both natively.
@@ -623,6 +625,7 @@ func (s *Server) handleTranscriptions(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusBadRequest, errorResponse("invalid_request_error", "model is required"))
 		return
 	}
+	model = s.canonicalModelID(model)
 
 	if !s.registry.IsModelInCatalog(model) {
 		writeJSON(w, http.StatusNotFound, errorResponse("model_not_found",
@@ -813,6 +816,7 @@ func (s *Server) handleImageGenerations(w http.ResponseWriter, r *http.Request) 
 		writeJSON(w, http.StatusBadRequest, errorResponse("invalid_request_error", "n must be between 1 and 4"))
 		return
 	}
+	req.Model = s.canonicalModelID(req.Model)
 	if !s.registry.IsModelInCatalog(req.Model) {
 		writeJSON(w, http.StatusNotFound, errorResponse("model_not_found",
 			fmt.Sprintf("model %q is not available — see /v1/models for supported models", req.Model)))
@@ -1404,13 +1408,23 @@ func buildNonStreamingResponse(requestID, model string, msg extractedMessage, us
 func (s *Server) handleListModels(w http.ResponseWriter, r *http.Request) {
 	models := s.registry.ListModels()
 
-	// Filter to only show models from the catalog (active supported models).
+	// Filter to only show models from the active catalog. Deduplicate any
+	// upgraded rows where a legacy source ID and a new public ID both exist.
 	catalogModels := s.store.ListSupportedModels()
 	catalogByID := make(map[string]store.SupportedModel, len(catalogModels))
 	for _, cm := range catalogModels {
-		if cm.Active {
-			catalogByID[cm.ID] = cm
+		if !cm.Active {
+			continue
 		}
+		canonicalID := s.canonicalModelID(cm.ID)
+		if canonicalID == "" {
+			continue
+		}
+		cm.ID = canonicalID
+		if existing, ok := catalogByID[canonicalID]; ok && existing.SourceID != "" {
+			continue
+		}
+		catalogByID[canonicalID] = cm
 	}
 
 	data := make([]map[string]any, 0, len(models))
@@ -1670,6 +1684,8 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 		writeJSON(w, http.StatusBadRequest, errorResponse("invalid_request_error", "model is required"))
 		return
 	}
+	model = s.canonicalModelID(model)
+	parsed["model"] = model
 	if !s.registry.IsModelInCatalog(model) {
 		writeJSON(w, http.StatusNotFound, errorResponse("model_not_found",
 			fmt.Sprintf("model %q is not available — see /v1/models for supported models", model)))

--- a/coordinator/internal/api/provider.go
+++ b/coordinator/internal/api/provider.go
@@ -148,6 +148,9 @@ func (s *Server) providerReadLoop(ctx context.Context, conn *websocket.Conn, pro
 		switch msg.Type {
 		case protocol.TypeRegister:
 			regMsg := msg.Payload.(*protocol.RegisterMessage)
+			for i := range regMsg.Models {
+				regMsg.Models[i].ID = s.canonicalModelID(regMsg.Models[i].ID)
+			}
 			provider = s.registry.Register(providerID, conn, regMsg)
 			s.verifyProviderAttestation(providerID, provider, regMsg)
 
@@ -254,6 +257,17 @@ func (s *Server) providerReadLoop(ctx context.Context, conn *websocket.Conn, pro
 
 		case protocol.TypeHeartbeat:
 			hbMsg := msg.Payload.(*protocol.HeartbeatMessage)
+			hbMsg.WarmModels = s.canonicalModelIDs(hbMsg.WarmModels)
+			if hbMsg.ActiveModel != nil {
+				model := s.canonicalModelID(*hbMsg.ActiveModel)
+				hbMsg.ActiveModel = &model
+			}
+			if hbMsg.BackendCapacity != nil {
+				for i := range hbMsg.BackendCapacity.Slots {
+					hbMsg.BackendCapacity.Slots[i].Model =
+						s.canonicalModelID(hbMsg.BackendCapacity.Slots[i].Model)
+				}
+			}
 			s.registry.Heartbeat(providerID, hbMsg)
 
 		case protocol.TypeInferenceAccepted:

--- a/coordinator/internal/api/server.go
+++ b/coordinator/internal/api/server.go
@@ -24,6 +24,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -112,6 +113,72 @@ type Server struct {
 	storedProviders map[string]*store.ProviderRecord
 }
 
+func canonicalModelID(model string, catalog []store.SupportedModel) string {
+	model = strings.TrimSpace(model)
+	if model == "" {
+		return ""
+	}
+	for _, m := range catalog {
+		if m.SourceID == model && m.ID != model {
+			return m.ID
+		}
+	}
+	for _, m := range catalog {
+		if m.ID == model || m.SourceID == model {
+			return m.ID
+		}
+	}
+	return model
+}
+
+func uniqueSupportedModels(models []store.SupportedModel) []store.SupportedModel {
+	if len(models) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(models))
+	deduped := make([]store.SupportedModel, 0, len(models))
+	for _, model := range models {
+		canonical := canonicalModelID(model.ID, models)
+		if canonical == "" {
+			canonical = model.ID
+		}
+		if _, ok := seen[canonical]; ok {
+			continue
+		}
+		if model.ID != canonical {
+			for _, candidate := range models {
+				if candidate.ID == canonical {
+					model = candidate
+					break
+				}
+			}
+		}
+		seen[canonical] = struct{}{}
+		deduped = append(deduped, model)
+	}
+	return deduped
+}
+
+func (s *Server) canonicalModelID(model string) string {
+	return canonicalModelID(model, s.store.ListSupportedModels())
+}
+
+func (s *Server) canonicalModelIDs(models []string) []string {
+	if len(models) == 0 {
+		return nil
+	}
+	catalog := s.store.ListSupportedModels()
+	normalized := make([]string, 0, len(models))
+	for _, model := range models {
+		id := canonicalModelID(model, catalog)
+		if id == "" || slices.Contains(normalized, id) {
+			continue
+		}
+		normalized = append(normalized, id)
+	}
+	return normalized
+}
+
 // NewServer creates a configured Server with all routes mounted.
 func NewServer(reg *registry.Registry, st store.Store, logger *slog.Logger) *Server {
 	// Wire the store into the registry for provider fleet persistence.
@@ -172,12 +239,13 @@ func (s *Server) SetMDMClient(client *mdm.Client) {
 // SyncModelCatalog reads active models from the store and updates the
 // registry's model catalog. Call this at startup and after admin catalog changes.
 func (s *Server) SyncModelCatalog() {
-	models := s.store.ListSupportedModels()
+	models := uniqueSupportedModels(s.store.ListSupportedModels())
 	entries := make([]registry.CatalogEntry, 0, len(models))
 	for _, m := range models {
 		if m.Active {
 			entries = append(entries, registry.CatalogEntry{
 				ID:         m.ID,
+				SourceID:   m.SourceID,
 				WeightHash: m.WeightHash,
 			})
 		}

--- a/coordinator/internal/payments/pricing.go
+++ b/coordinator/internal/payments/pricing.go
@@ -39,11 +39,11 @@ type modelPrice struct {
 
 var modelPricing = map[string]modelPrice{
 	// Text generation — 50% of OpenRouter rates
-	"qwen3.5-27b-claude-opus-8bit":          {input: 100_000, output: 780_000},   // $0.10 / $0.78
-	"mlx-community/Trinity-Mini-8bit":       {input: 23_000, output: 75_000},     // $0.023 / $0.075 (50% of OpenRouter)
-	"mlx-community/gemma-4-26b-a4b-it-8bit": {input: 65_000, output: 200_000},    // $0.065 / $0.20 (50% of OpenRouter)
-	"mlx-community/Qwen3.5-122B-A10B-8bit":  {input: 130_000, output: 1_040_000}, // $0.13 / $1.04
-	"mlx-community/MiniMax-M2.5-8bit":       {input: 60_000, output: 500_000},    // $0.06 / $0.50
+	"qwen3.5-27b-claude-opus-8bit": {input: 100_000, output: 780_000},   // $0.10 / $0.78
+	"Trinity-Mini-8bit":            {input: 23_000, output: 75_000},     // $0.023 / $0.075 (50% of OpenRouter)
+	"gemma-4-26b-a4b-it-8bit":      {input: 65_000, output: 200_000},    // $0.065 / $0.20 (50% of OpenRouter)
+	"Qwen3.5-122B-A10B-8bit":       {input: 130_000, output: 1_040_000}, // $0.13 / $1.04
+	"MiniMax-M2.5-8bit":            {input: 60_000, output: 500_000},    // $0.06 / $0.50
 }
 
 // transcriptionPricing stores per-audio-minute prices in micro-USD.

--- a/coordinator/internal/payments/pricing_bench_test.go
+++ b/coordinator/internal/payments/pricing_bench_test.go
@@ -7,7 +7,7 @@ import (
 func BenchmarkCalculateCost(b *testing.B) {
 	b.ReportAllocs()
 	// Known model with explicit pricing
-	model := "mlx-community/Qwen3.5-122B-A10B-8bit"
+	model := "Qwen3.5-122B-A10B-8bit"
 	promptTokens := 1500
 	completionTokens := 800
 
@@ -19,7 +19,7 @@ func BenchmarkCalculateCost(b *testing.B) {
 
 func BenchmarkCalculateCostWithOverrides(b *testing.B) {
 	b.ReportAllocs()
-	model := "mlx-community/Qwen3.5-122B-A10B-8bit"
+	model := "Qwen3.5-122B-A10B-8bit"
 	promptTokens := 1500
 	completionTokens := 800
 	// Custom enterprise pricing: $0.05 input, $0.15 output per 1M tokens

--- a/coordinator/internal/payments/pricing_test.go
+++ b/coordinator/internal/payments/pricing_test.go
@@ -10,9 +10,9 @@ func TestOutputPriceKnownModels(t *testing.T) {
 		want  int64
 	}{
 		{"qwen3.5-27b-claude-opus-8bit", 780_000},
-		{"mlx-community/Trinity-Mini-8bit", 75_000},
-		{"mlx-community/Qwen3.5-122B-A10B-8bit", 1_040_000},
-		{"mlx-community/MiniMax-M2.5-8bit", 500_000},
+		{"Trinity-Mini-8bit", 75_000},
+		{"Qwen3.5-122B-A10B-8bit", 1_040_000},
+		{"MiniMax-M2.5-8bit", 500_000},
 	}
 
 	for _, tc := range tests {
@@ -29,9 +29,9 @@ func TestInputPriceKnownModels(t *testing.T) {
 		want  int64
 	}{
 		{"qwen3.5-27b-claude-opus-8bit", 100_000},
-		{"mlx-community/Trinity-Mini-8bit", 23_000},
-		{"mlx-community/Qwen3.5-122B-A10B-8bit", 130_000},
-		{"mlx-community/MiniMax-M2.5-8bit", 60_000},
+		{"Trinity-Mini-8bit", 23_000},
+		{"Qwen3.5-122B-A10B-8bit", 130_000},
+		{"MiniMax-M2.5-8bit", 60_000},
 	}
 
 	for _, tc := range tests {
@@ -74,42 +74,42 @@ func TestCalculateCost(t *testing.T) {
 	}{
 		{
 			name:             "1M output tokens at Trinity Mini rate, no input",
-			model:            "mlx-community/Trinity-Mini-8bit",
+			model:            "Trinity-Mini-8bit",
 			promptTokens:     0,
 			completionTokens: 1_000_000,
 			want:             75_000, // $0.075 output only
 		},
 		{
 			name:             "1M input + 1M output at Trinity Mini rate",
-			model:            "mlx-community/Trinity-Mini-8bit",
+			model:            "Trinity-Mini-8bit",
 			promptTokens:     1_000_000,
 			completionTokens: 1_000_000,
 			want:             98_000, // $0.023 input + $0.075 output = $0.098
 		},
 		{
 			name:             "only input tokens at MiniMax rate",
-			model:            "mlx-community/MiniMax-M2.5-8bit",
+			model:            "MiniMax-M2.5-8bit",
 			promptTokens:     1_000_000,
 			completionTokens: 0,
 			want:             60_000, // $0.06 input, no output
 		},
 		{
 			name:             "122B model 1M each",
-			model:            "mlx-community/Qwen3.5-122B-A10B-8bit",
+			model:            "Qwen3.5-122B-A10B-8bit",
 			promptTokens:     1_000_000,
 			completionTokens: 1_000_000,
 			want:             1_170_000, // $0.13 input + $1.04 output = $1.17
 		},
 		{
 			name:             "small request hits minimum",
-			model:            "mlx-community/Trinity-Mini-8bit",
+			model:            "Trinity-Mini-8bit",
 			promptTokens:     10,
 			completionTokens: 10,
 			want:             100, // minimum $0.0001
 		},
 		{
 			name:             "zero tokens hits minimum",
-			model:            "mlx-community/Trinity-Mini-8bit",
+			model:            "Trinity-Mini-8bit",
 			promptTokens:     0,
 			completionTokens: 0,
 			want:             100, // minimum
@@ -189,9 +189,9 @@ func TestAllModelPricesUndercutCompetitors(t *testing.T) {
 	// Competitor output prices (micro-USD per 1M tokens)
 	competitorOutput := map[string]int64{
 		"qwen3.5-27b-claude-opus-8bit":         1_560_000, // OpenRouter $1.56
-		"mlx-community/Trinity-Mini-8bit":      150_000,   // OpenRouter $0.15
-		"mlx-community/Qwen3.5-122B-A10B-8bit": 2_080_000, // OpenRouter $2.08
-		"mlx-community/MiniMax-M2.5-8bit":      1_000_000, // OpenRouter $1.00
+		"Trinity-Mini-8bit":      150_000,   // OpenRouter $0.15
+		"Qwen3.5-122B-A10B-8bit": 2_080_000, // OpenRouter $2.08
+		"MiniMax-M2.5-8bit":      1_000_000, // OpenRouter $1.00
 	}
 
 	for model, compPrice := range competitorOutput {
@@ -204,9 +204,9 @@ func TestAllModelPricesUndercutCompetitors(t *testing.T) {
 	// Competitor input prices (micro-USD per 1M tokens)
 	competitorInput := map[string]int64{
 		"qwen3.5-27b-claude-opus-8bit":         200_000, // OpenRouter $0.20
-		"mlx-community/Trinity-Mini-8bit":      46_000,  // OpenRouter $0.046
-		"mlx-community/Qwen3.5-122B-A10B-8bit": 260_000, // OpenRouter $0.26
-		"mlx-community/MiniMax-M2.5-8bit":      120_000, // OpenRouter $0.12
+		"Trinity-Mini-8bit":      46_000,  // OpenRouter $0.046
+		"Qwen3.5-122B-A10B-8bit": 260_000, // OpenRouter $0.26
+		"MiniMax-M2.5-8bit":      120_000, // OpenRouter $0.12
 	}
 
 	for model, compPrice := range competitorInput {

--- a/coordinator/internal/registry/registry.go
+++ b/coordinator/internal/registry/registry.go
@@ -502,6 +502,7 @@ func TruncHash(h string) string {
 // CatalogEntry holds metadata about an active model in the catalog.
 type CatalogEntry struct {
 	ID         string
+	SourceID   string
 	WeightHash string // expected SHA-256 weight fingerprint (empty = not enforced)
 }
 

--- a/coordinator/internal/store/interface.go
+++ b/coordinator/internal/store/interface.go
@@ -367,9 +367,10 @@ type User struct {
 // output worth paying for — small chat models (< 7B) are not useful, but small
 // specialized models (transcription, embeddings) can be best-in-class.
 type SupportedModel struct {
-	ID           string  `json:"id"`           // HuggingFace path (e.g. "mlx-community/Qwen3.5-9B-MLX-4bit")
-	S3Name       string  `json:"s3_name"`      // CDN key for download (e.g. "Qwen3.5-9B-MLX-4bit")
-	DisplayName  string  `json:"display_name"` // Human-readable (e.g. "Qwen3.5 9B")
+	ID           string  `json:"id"`           // Stable public API model ID (e.g. "Qwen3.5-122B-A10B-8bit")
+	SourceID     string  `json:"source_id"`    // Source repo / artifact ID used by providers (e.g. "mlx-community/Qwen3.5-122B-A10B-8bit")
+	S3Name       string  `json:"s3_name"`      // CDN key for download (e.g. "Qwen3.5-122B-A10B-8bit")
+	DisplayName  string  `json:"display_name"` // Human-readable (e.g. "Qwen3.5 122B")
 	ModelType    string  `json:"model_type"`   // "text", "transcription", "embedding", "tts", "image"
 	SizeGB       float64 `json:"size_gb"`      // Disk/memory size in GB
 	Architecture string  `json:"architecture"` // e.g. "9B dense", "2B conformer"

--- a/coordinator/internal/store/postgres.go
+++ b/coordinator/internal/store/postgres.go
@@ -239,6 +239,7 @@ func (s *PostgresStore) migrate(ctx context.Context) error {
 		// Supported models — admin-managed catalog
 		`CREATE TABLE IF NOT EXISTS supported_models (
 			id TEXT PRIMARY KEY,
+			source_id TEXT NOT NULL DEFAULT '',
 			s3_name TEXT NOT NULL DEFAULT '',
 			display_name TEXT NOT NULL DEFAULT '',
 			model_type TEXT NOT NULL DEFAULT 'text',
@@ -250,6 +251,10 @@ func (s *PostgresStore) migrate(ctx context.Context) error {
 			updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 		)`,
 		// Add model_type column if upgrading from previous schema
+		`DO $$ BEGIN
+			ALTER TABLE supported_models ADD COLUMN IF NOT EXISTS source_id TEXT NOT NULL DEFAULT '';
+		EXCEPTION WHEN others THEN NULL;
+		END $$`,
 		`DO $$ BEGIN
 			ALTER TABLE supported_models ADD COLUMN IF NOT EXISTS model_type TEXT NOT NULL DEFAULT 'text';
 		EXCEPTION WHEN others THEN NULL;
@@ -1078,12 +1083,12 @@ func (s *PostgresStore) SetSupportedModel(model *SupportedModel) error {
 	defer cancel()
 
 	_, err := s.pool.Exec(ctx,
-		`INSERT INTO supported_models (id, s3_name, display_name, model_type, size_gb, architecture, description, min_ram_gb, active, weight_hash, updated_at)
-		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, NOW())
+		`INSERT INTO supported_models (id, source_id, s3_name, display_name, model_type, size_gb, architecture, description, min_ram_gb, active, weight_hash, updated_at)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, NOW())
 		 ON CONFLICT (id) DO UPDATE SET
-		   s3_name = $2, display_name = $3, model_type = $4, size_gb = $5, architecture = $6,
-		   description = $7, min_ram_gb = $8, active = $9, weight_hash = $10, updated_at = NOW()`,
-		model.ID, model.S3Name, model.DisplayName, model.ModelType, model.SizeGB,
+		   source_id = $2, s3_name = $3, display_name = $4, model_type = $5, size_gb = $6, architecture = $7,
+		   description = $8, min_ram_gb = $9, active = $10, weight_hash = $11, updated_at = NOW()`,
+		model.ID, model.SourceID, model.S3Name, model.DisplayName, model.ModelType, model.SizeGB,
 		model.Architecture, model.Description, model.MinRAMGB, model.Active, model.WeightHash,
 	)
 	if err != nil {
@@ -1097,7 +1102,7 @@ func (s *PostgresStore) ListSupportedModels() []SupportedModel {
 	defer cancel()
 
 	rows, err := s.pool.Query(ctx,
-		`SELECT id, s3_name, display_name, model_type, size_gb, architecture, description, min_ram_gb, active, weight_hash
+		`SELECT id, source_id, s3_name, display_name, model_type, size_gb, architecture, description, min_ram_gb, active, weight_hash
 		 FROM supported_models ORDER BY model_type ASC, min_ram_gb ASC, size_gb ASC`,
 	)
 	if err != nil {
@@ -1108,7 +1113,7 @@ func (s *PostgresStore) ListSupportedModels() []SupportedModel {
 	var models []SupportedModel
 	for rows.Next() {
 		var m SupportedModel
-		if err := rows.Scan(&m.ID, &m.S3Name, &m.DisplayName, &m.ModelType, &m.SizeGB,
+		if err := rows.Scan(&m.ID, &m.SourceID, &m.S3Name, &m.DisplayName, &m.ModelType, &m.SizeGB,
 			&m.Architecture, &m.Description, &m.MinRAMGB, &m.Active, &m.WeightHash); err != nil {
 			continue
 		}

--- a/provider/src/main.rs
+++ b/provider/src/main.rs
@@ -49,6 +49,8 @@ use tracing_subscriber::EnvFilter;
 #[derive(Debug, Clone, serde::Deserialize)]
 struct CatalogModel {
     id: String,
+    #[serde(default)]
+    source_id: String,
     s3_name: String,
     display_name: String,
     #[serde(default = "default_model_type")]
@@ -61,6 +63,46 @@ struct CatalogModel {
 
 fn default_model_type() -> String {
     "text".into()
+}
+
+impl CatalogModel {
+    fn source_id(&self) -> &str {
+        if self.source_id.is_empty() {
+            &self.id
+        } else {
+            &self.source_id
+        }
+    }
+}
+
+fn find_catalog_model_by_public_or_source_id<'a>(
+    catalog: &'a [CatalogModel],
+    model_id: &str,
+) -> Option<&'a CatalogModel> {
+    catalog
+        .iter()
+        .find(|m| m.id == model_id || m.source_id() == model_id)
+}
+
+fn public_model_id_for<'a>(catalog: &'a [CatalogModel], model_id: &'a str) -> &'a str {
+    find_catalog_model_by_public_or_source_id(catalog, model_id)
+        .map(|m| m.id.as_str())
+        .unwrap_or(model_id)
+}
+
+fn source_model_id_for<'a>(catalog: &'a [CatalogModel], model_id: &'a str) -> &'a str {
+    find_catalog_model_by_public_or_source_id(catalog, model_id)
+        .map(|m| m.source_id())
+        .unwrap_or(model_id)
+}
+
+fn is_catalog_model_downloaded(
+    available_models: &[models::ModelInfo],
+    catalog: &[CatalogModel],
+    public_model_id: &str,
+) -> bool {
+    let source_model_id = source_model_id_for(catalog, public_model_id);
+    available_models.iter().any(|m| m.id == source_model_id)
 }
 
 fn sanitize_public_model_error(
@@ -80,6 +122,7 @@ fn fallback_catalog() -> Vec<CatalogModel> {
     vec![
         CatalogModel {
             id: "CohereLabs/cohere-transcribe-03-2026".into(),
+            source_id: String::new(),
             s3_name: "cohere-transcribe-03-2026".into(),
             display_name: "Cohere Transcribe".into(),
             model_type: "transcription".into(),
@@ -90,6 +133,7 @@ fn fallback_catalog() -> Vec<CatalogModel> {
         },
         CatalogModel {
             id: "flux_2_klein_4b_q8p.ckpt".into(),
+            source_id: String::new(),
             s3_name: "flux-klein-4b-q8".into(),
             display_name: "FLUX.2 Klein 4B".into(),
             model_type: "image".into(),
@@ -100,6 +144,7 @@ fn fallback_catalog() -> Vec<CatalogModel> {
         },
         CatalogModel {
             id: "flux_2_klein_9b_q8p.ckpt".into(),
+            source_id: String::new(),
             s3_name: "flux-klein-9b-q8".into(),
             display_name: "FLUX.2 Klein 9B".into(),
             model_type: "image".into(),
@@ -110,6 +155,7 @@ fn fallback_catalog() -> Vec<CatalogModel> {
         },
         CatalogModel {
             id: "qwen3.5-27b-claude-opus-8bit".into(),
+            source_id: String::new(),
             s3_name: "qwen35-27b-claude-opus-8bit".into(),
             display_name: "Qwen3.5 27B Claude Opus".into(),
             model_type: "text".into(),
@@ -119,7 +165,8 @@ fn fallback_catalog() -> Vec<CatalogModel> {
             min_ram_gb: 36,
         },
         CatalogModel {
-            id: "mlx-community/Trinity-Mini-8bit".into(),
+            id: "Trinity-Mini-8bit".into(),
+            source_id: "mlx-community/Trinity-Mini-8bit".into(),
             s3_name: "Trinity-Mini-8bit".into(),
             display_name: "Trinity Mini".into(),
             model_type: "text".into(),
@@ -129,7 +176,8 @@ fn fallback_catalog() -> Vec<CatalogModel> {
             min_ram_gb: 48,
         },
         CatalogModel {
-            id: "mlx-community/gemma-4-26b-a4b-it-8bit".into(),
+            id: "gemma-4-26b-a4b-it-8bit".into(),
+            source_id: "mlx-community/gemma-4-26b-a4b-it-8bit".into(),
             s3_name: "gemma-4-26b-a4b-it-8bit".into(),
             display_name: "Gemma 4 26B".into(),
             model_type: "text".into(),
@@ -139,7 +187,8 @@ fn fallback_catalog() -> Vec<CatalogModel> {
             min_ram_gb: 36,
         },
         CatalogModel {
-            id: "mlx-community/Qwen3.5-122B-A10B-8bit".into(),
+            id: "Qwen3.5-122B-A10B-8bit".into(),
+            source_id: "mlx-community/Qwen3.5-122B-A10B-8bit".into(),
             s3_name: "Qwen3.5-122B-A10B-8bit".into(),
             display_name: "Qwen3.5 122B".into(),
             model_type: "text".into(),
@@ -149,7 +198,8 @@ fn fallback_catalog() -> Vec<CatalogModel> {
             min_ram_gb: 128,
         },
         CatalogModel {
-            id: "mlx-community/MiniMax-M2.5-8bit".into(),
+            id: "MiniMax-M2.5-8bit".into(),
+            source_id: "mlx-community/MiniMax-M2.5-8bit".into(),
             s3_name: "MiniMax-M2.5-8bit".into(),
             display_name: "MiniMax M2.5".into(),
             model_type: "text".into(),
@@ -1930,7 +1980,9 @@ async fn cmd_install(
         println!("  Default models for your hardware:");
         let mut total_default_size = 0.0_f64;
         for m in &defaults {
-            let downloaded = available.iter().any(|a| a.id == m.id);
+            let downloaded = available
+                .iter()
+                .any(|a| a.id == source_model_id_for(&catalog, &m.id));
             let status = if downloaded { "✓ ready" } else { "  " };
             println!(
                 "    {} {:30} {:>5.1} GB  {:6}  {}",
@@ -1964,7 +2016,9 @@ async fn cmd_install(
                 let input = input.trim().to_lowercase();
                 if input.is_empty() || input == "y" || input == "yes" {
                     for m in &defaults {
-                        let downloaded = available.iter().any(|a| a.id == m.id);
+                        let downloaded = available
+                            .iter()
+                            .any(|a| a.id == source_model_id_for(&catalog, &m.id));
                         if !downloaded {
                             models_to_download.push(m.id.clone());
                         }
@@ -1980,7 +2034,9 @@ async fn cmd_install(
             println!();
             println!("  Optional models (your hardware can also run):");
             for (i, m) in optionals.iter().enumerate() {
-                let downloaded = available.iter().any(|a| a.id == m.id);
+                let downloaded = available
+                    .iter()
+                    .any(|a| a.id == source_model_id_for(&catalog, &m.id));
                 let status = if downloaded { "✓" } else { " " };
                 println!(
                     "    [{}] {} {:30} {:>5.1} GB  {:6}  {}",
@@ -2004,7 +2060,9 @@ async fn cmd_install(
                     if let Ok(n) = part.trim().parse::<usize>() {
                         if n >= 1 && n <= optionals.len() {
                             let m = optionals[n - 1];
-                            let downloaded = available.iter().any(|a| a.id == m.id);
+                            let downloaded = available
+                                .iter()
+                                .any(|a| a.id == source_model_id_for(&catalog, &m.id));
                             if !downloaded {
                                 models_to_download.push(m.id.clone());
                             }
@@ -2026,6 +2084,11 @@ async fn cmd_install(
                 .find(|cm| cm.id == *model_id)
                 .map(|cm| cm.s3_name.as_str())
                 .unwrap_or_else(|| model_id.split('/').last().unwrap_or(model_id));
+            let source_model_id = catalog
+                .iter()
+                .find(|cm| cm.id == *model_id)
+                .map(|cm| cm.source_id())
+                .unwrap_or(model_id);
 
             let display = catalog
                 .iter()
@@ -2039,7 +2102,7 @@ async fn cmd_install(
             let cache_dir = dirs::home_dir()
                 .unwrap_or_default()
                 .join(".cache/huggingface/hub")
-                .join(format!("models--{}", model_id.replace('/', "--")))
+                .join(format!("models--{}", source_model_id.replace('/', "--")))
                 .join("snapshots/main");
             std::fs::create_dir_all(&cache_dir)?;
 
@@ -2295,6 +2358,8 @@ async fn cmd_serve(
         tracing::info!("Idle GPU timeout: disabled (backend stays running)");
     }
 
+    let catalog = fetch_catalog(&coordinator_url).await;
+
     let text_backend_mode = preferred_text_backend_mode(local);
     let using_inprocess = matches!(text_backend_mode, TextBackendMode::InProcess);
     let text_backend_name = backend_name_for_mode(text_backend_mode);
@@ -2313,9 +2378,14 @@ async fn cmd_serve(
         model_overrides
             .into_iter()
             .filter(|m| !is_non_text(m))
+            .map(|m| public_model_id_for(&catalog, &m).to_string())
             .collect()
     } else if let Some(m) = cfg.backend.model.clone() {
-        if is_non_text(&m) { vec![] } else { vec![m] }
+        if is_non_text(&m) {
+            vec![]
+        } else {
+            vec![public_model_id_for(&catalog, &m).to_string()]
+        }
     } else {
         // No --model specified — don't auto-pick. The picker in cmd_start
         // explicitly chooses which models to serve. If only image models were
@@ -2343,6 +2413,7 @@ async fn cmd_serve(
     // Shared state struct for per-slot health monitoring and lifecycle management.
     struct BackendSlot {
         model_id: String,
+        source_model_id: String,
         model_path: String,
         port: u16,
         pid: Option<u32>,
@@ -2356,6 +2427,7 @@ async fn cmd_serve(
             let port = be_port + i as u16;
             BackendSlot {
                 model_id: model_id.clone(),
+                source_model_id: source_model_id_for(&catalog, model_id).to_string(),
                 model_path: String::new(), // resolved later during backend startup
                 port,
                 pid: None,
@@ -2369,14 +2441,21 @@ async fn cmd_serve(
         })
         .collect();
 
-    // For backwards compat, keep a "primary model" (first in list)
+    // For backwards compat, keep a "primary model" (first public ID in list)
     let model = selected_models.first().cloned().unwrap_or_default();
+    let primary_source_model = backend_slots
+        .first()
+        .map(|slot| slot.source_model_id.clone())
+        .unwrap_or_else(|| model.clone());
 
     // Hypervisor memory pool: sum of all model sizes × 2
     if hypervisor::is_active() {
         let total_model_bytes: u64 = selected_models
             .iter()
-            .filter_map(|mid| available_models.iter().find(|m| m.id == *mid))
+            .filter_map(|mid| {
+                let source_id = source_model_id_for(&catalog, mid);
+                available_models.iter().find(|m| m.id == source_id)
+            })
             .map(|m| m.size_bytes)
             .sum();
 
@@ -2487,7 +2566,14 @@ async fn cmd_serve(
         selected_models.iter().map(|s| s.as_str()).collect();
     let mut advertised_models: Vec<_> = all_scanned
         .into_iter()
-        .filter(|m| selected_set.contains(m.id.as_str()))
+        .filter_map(|m| {
+            let public_id = selected_models
+                .iter()
+                .find(|selected| m.id == source_model_id_for(&catalog, selected.as_str()))?;
+            let mut advertised = m.clone();
+            advertised.id = public_id.clone();
+            Some(advertised)
+        })
         .collect();
     tracing::info!(
         "Advertising {} model(s) (only loaded models)",
@@ -2542,6 +2628,7 @@ async fn cmd_serve(
     const BACKEND_CRASHED: u8 = 2;
     let backend_running_flag_opt: Option<std::sync::Arc<std::sync::atomic::AtomicU8>>;
     let mut rehash_model_hash_opt: Option<std::sync::Arc<std::sync::Mutex<Option<String>>>> = None;
+    let current_model_handle_opt: Option<std::sync::Arc<std::sync::Mutex<Option<String>>>>;
     // Deferred coordinator spawn state — held until backends are ready.
     let mut deferred_coordinator: Option<(
         coordinator::CoordinatorClient,
@@ -2584,13 +2671,14 @@ async fn cmd_serve(
         // Shared current model name for heartbeat reporting.
         let current_model: std::sync::Arc<std::sync::Mutex<Option<String>>> =
             std::sync::Arc::new(std::sync::Mutex::new(Some(model.clone())));
+        let current_model_handle = current_model.clone();
 
         // All warm models (for multi-model heartbeat reporting).
         let warm_models: std::sync::Arc<std::sync::Mutex<Vec<String>>> =
             std::sync::Arc::new(std::sync::Mutex::new(selected_models.clone()));
 
         // Compute weight hashes for all active models (text, STT, image).
-        let initial_model_hash = models::compute_weight_hash(&model);
+        let initial_model_hash = models::compute_weight_hash(&primary_source_model);
         let current_model_hash: std::sync::Arc<std::sync::Mutex<Option<String>>> =
             std::sync::Arc::new(std::sync::Mutex::new(initial_model_hash.clone()));
         rehash_model_hash_opt = Some(current_model_hash.clone());
@@ -2741,6 +2829,7 @@ async fn cmd_serve(
         inference_active_opt = Some(inference_active);
         health_inference_active_opt = Some(health_inference_active);
         provider_stats_opt = Some(provider_stats);
+        current_model_handle_opt = Some(current_model_handle);
     } else {
         coordinator_handle = None;
         event_rx_opt = None;
@@ -2751,6 +2840,7 @@ async fn cmd_serve(
         provider_stats_opt = None;
         backend_capacity_opt = None;
         backend_running_flag_opt = None;
+        current_model_handle_opt = None;
     }
 
     // =========================================================================
@@ -2779,14 +2869,14 @@ async fn cmd_serve(
     };
 
     for slot in &mut backend_slots {
-        let model_path = models::resolve_local_path(&slot.model_id)
+        let model_path = models::resolve_local_path(&slot.source_model_id)
             .map(|p| p.to_string_lossy().to_string())
             .unwrap_or_else(|| {
                 tracing::warn!(
                     "Could not resolve local path for {} — using ID directly",
-                    slot.model_id
+                    slot.source_model_id
                 );
-                slot.model_id.clone()
+                slot.source_model_id.clone()
             });
         slot.model_path = model_path.clone();
         tracing::info!(
@@ -2885,6 +2975,7 @@ async fn cmd_serve(
     // The event loop reads healthy to know which slots can serve, and updates pid on reload.
     struct SharedSlotState {
         model_id: String,
+        source_model_id: String,
         model_path: String,
         port: u16,
         pid: Option<u32>,
@@ -2897,6 +2988,7 @@ async fn cmd_serve(
                 .iter()
                 .map(|s| SharedSlotState {
                     model_id: s.model_id.clone(),
+                    source_model_id: s.source_model_id.clone(),
                     model_path: s.model_path.clone(),
                     port: s.port,
                     pid: s.pid,
@@ -3355,15 +3447,12 @@ async fn cmd_serve(
         let idle_backend_name = backend_name.to_string();
         let proxy_stats = provider_stats.clone();
         let model_to_url = model_to_url.clone();
+        let current_model_handle =
+            current_model_handle_opt.expect("current_model_handle must be set in non-local mode");
         // Build model→local-path lookup for rewriting the model field in requests
         let model_to_path: std::collections::HashMap<String, String> = backend_slots
             .iter()
-            .map(|s| {
-                let path = models::resolve_local_path(&s.model_id)
-                    .map(|p| p.to_string_lossy().to_string())
-                    .unwrap_or_else(|| s.model_id.clone());
-                (s.model_id.clone(), path)
-            })
+            .map(|s| (s.model_id.clone(), s.model_path.clone()))
             .collect();
         // For idle reload: re-hash weights after reloading to detect tampering
         let rehash_handle = rehash_model_hash_opt.clone();
@@ -3474,7 +3563,7 @@ async fn cmd_serve(
                                         .find(|s| s.model_id == req_model_id
                                             || s.model_id.contains(&req_model_id)
                                             || req_model_id.contains(&s.model_id))
-                                        .map(|s| (s.model_id.clone(), s.model_path.clone(), s.port, s.pid, s.healthy, s.restarting))
+                                        .map(|s| (s.model_id.clone(), s.source_model_id.clone(), s.model_path.clone(), s.port, s.pid, s.healthy, s.restarting))
                                 };
 
                                 #[cfg(feature = "python")]
@@ -3483,7 +3572,7 @@ async fn cmd_serve(
                                 > = None;
                                 let public_model = req_model_id.clone();
 
-                                if let Some((slot_model_id, slot_model_path, slot_port, slot_pid, slot_healthy, slot_restarting)) = slot_info {
+                                if let Some((slot_model_id, slot_source_model_id, slot_model_path, slot_port, slot_pid, slot_healthy, slot_restarting)) = slot_info {
                                     if is_inprocess {
                                         #[cfg(feature = "python")]
                                         {
@@ -3520,10 +3609,12 @@ async fn cmd_serve(
                                                             s.restarting = false;
                                                         }
                                                     }
+                                                    *current_model_handle.lock().unwrap() =
+                                                        Some(slot_model_id.clone());
                                                     if let Some(ref hash_arc) = rehash_handle {
-                                                        if let Some(new_hash) =
-                                                            models::compute_weight_hash(&slot_model_id)
-                                                        {
+                                                        if let Some(new_hash) = models::compute_weight_hash(
+                                                            &slot_source_model_id,
+                                                        ) {
                                                             *hash_arc.lock().unwrap() = Some(new_hash);
                                                             tracing::info!(
                                                                 "Model weight hash refreshed after in-process load"
@@ -3614,8 +3705,12 @@ async fn cmd_serve(
                                                             s.restarting = false;
                                                         }
                                                     }
+                                                    *current_model_handle.lock().unwrap() =
+                                                        Some(slot_model_id.clone());
                                                     if let Some(ref hash_arc) = rehash_handle {
-                                                        if let Some(new_hash) = models::compute_weight_hash(&slot_model_id) {
+                                                        if let Some(new_hash) = models::compute_weight_hash(
+                                                            &slot_source_model_id,
+                                                        ) {
                                                             *hash_arc.lock().unwrap() = Some(new_hash);
                                                             tracing::info!("Model weight hash refreshed after reload");
                                                         }
@@ -5030,12 +5125,12 @@ async fn cmd_benchmark() -> Result<()> {
     // Scan downloaded models and filter by catalog
     let downloaded = models::scan_models(&hw);
     let catalog = fetch_catalog("https://api.darkbloom.dev").await;
-    let catalog_ids: std::collections::HashSet<String> =
-        catalog.iter().map(|c| c.id.clone()).collect();
+    let catalog_source_ids: std::collections::HashSet<String> =
+        catalog.iter().map(|c| c.source_id().to_string()).collect();
 
     let servable: Vec<_> = downloaded
         .iter()
-        .filter(|m| catalog_ids.contains(&m.id))
+        .filter(|m| catalog_source_ids.contains(&m.id))
         .collect();
 
     if servable.is_empty() {
@@ -5048,7 +5143,7 @@ async fn cmd_benchmark() -> Result<()> {
     for (i, m) in servable.iter().enumerate() {
         let display = catalog
             .iter()
-            .find(|c| c.id == m.id)
+            .find(|c| c.source_id() == m.id)
             .map(|c| c.display_name.as_str())
             .unwrap_or(&m.id);
         println!(
@@ -5077,7 +5172,7 @@ async fn cmd_benchmark() -> Result<()> {
 
     let display_name = catalog
         .iter()
-        .find(|c| c.id == selected.id)
+        .find(|c| c.source_id() == selected.id)
         .map(|c| c.display_name.as_str())
         .unwrap_or(&selected.id);
 
@@ -5307,25 +5402,24 @@ async fn cmd_status() -> Result<()> {
     // Models (catalog-filtered)
     let models = models::scan_models(&hw);
     let catalog = fetch_catalog("https://api.darkbloom.dev").await;
-    let catalog_ids: std::collections::HashSet<String> =
-        catalog.iter().map(|c| c.id.clone()).collect();
 
     let servable: Vec<_> = models
         .iter()
-        .filter(|m| catalog_ids.contains(&m.id))
+        .filter(|m| find_catalog_model_by_public_or_source_id(&catalog, &m.id).is_some())
         .collect();
     let extra: Vec<_> = models
         .iter()
-        .filter(|m| !catalog_ids.contains(&m.id))
+        .filter(|m| find_catalog_model_by_public_or_source_id(&catalog, &m.id).is_none())
         .collect();
 
     println!("  Models ({} servable):", servable.len());
     for m in &servable {
-        let active = serving_model.as_deref() == Some(&m.id);
+        let public_id = public_model_id_for(&catalog, &m.id);
+        let active = serving_model.as_deref() == Some(public_id);
         let marker = if active { "●" } else { " " };
         let display = catalog
             .iter()
-            .find(|c| c.id == m.id)
+            .find(|c| c.id == public_id)
             .map(|c| c.display_name.as_str())
             .unwrap_or(&m.id);
         println!(
@@ -5376,7 +5470,7 @@ async fn cmd_models(action: String, coordinator_url: String) -> Result<()> {
         println!("  Catalog:");
         for cm in &catalog {
             let fits = hw.memory_available_gb as f64 >= cm.size_gb;
-            let is_downloaded = downloaded.iter().any(|m| m.id == cm.id);
+            let is_downloaded = downloaded.iter().any(|m| m.id == cm.source_id());
             let (icon, label) = if is_downloaded {
                 ("✓", "downloaded")
             } else if fits {
@@ -5393,7 +5487,7 @@ async fn cmd_models(action: String, coordinator_url: String) -> Result<()> {
         // Non-catalog downloaded models
         let extra: Vec<_> = downloaded
             .iter()
-            .filter(|m| !catalog.iter().any(|cm| cm.id == m.id))
+            .filter(|m| !catalog.iter().any(|cm| cm.source_id() == m.id))
             .collect();
         if !extra.is_empty() {
             println!();
@@ -5437,7 +5531,7 @@ async fn cmd_models(action: String, coordinator_url: String) -> Result<()> {
             let mut downloadable: Vec<(usize, &CatalogModel)> = Vec::new();
             for cm in &catalog {
                 let fits = hw.memory_available_gb as f64 >= cm.size_gb;
-                let is_downloaded = downloaded.iter().any(|m| m.id == cm.id);
+                let is_downloaded = downloaded.iter().any(|m| m.id == cm.source_id());
                 if is_downloaded {
                     println!(
                         "  [✓] {:>5.1} GB  {} (already downloaded)",
@@ -5498,7 +5592,7 @@ async fn cmd_models(action: String, coordinator_url: String) -> Result<()> {
                         dirs::home_dir()
                             .unwrap_or_default()
                             .join(".cache/huggingface/hub")
-                            .join(format!("models--{}", cm.id.replace('/', "--")))
+                            .join(format!("models--{}", cm.source_id().replace('/', "--")))
                             .join("snapshots/main")
                     };
                     let _ = std::fs::create_dir_all(&cache_dir);
@@ -6103,6 +6197,7 @@ async fn cmd_start(
             // Build picker items from catalog: all models that fit in RAM.
             struct PickerItem {
                 id: String,
+                source_id: String,
                 display: String,
                 size_gb: f64,
                 downloaded: bool,
@@ -6116,7 +6211,10 @@ async fn cmd_start(
                 let client = reqwest::Client::new();
                 let mut sizes = std::collections::HashMap::new();
                 for c in &catalog {
-                    if let Some(on_disk) = downloaded.iter().find(|m| m.id == c.id) {
+                    if let Some(on_disk) = downloaded
+                        .iter()
+                        .find(|m| m.id == source_model_id_for(&catalog, &c.id))
+                    {
                         // Only HEAD-check models we have locally (to verify completeness)
                         let url = if c.id.ends_with(".ckpt") {
                             format!("{}/{}/{}", cdn_base, c.s3_name, c.id)
@@ -6147,7 +6245,8 @@ async fn cmd_start(
                     // Check if model is downloaded AND complete.
                     // For image models (.ckpt), also verify companion files exist
                     // (text encoder + VAE) since the pipeline needs all 3.
-                    let on_disk = downloaded.iter().find(|m| m.id == c.id);
+                    let source_id = source_model_id_for(&catalog, &c.id);
+                    let on_disk = downloaded.iter().find(|m| m.id == source_id);
                     let is_downloaded = on_disk.is_some_and(|m| {
                         let main_ok = if let Some(&expected) = cdn_sizes.get(&c.id) {
                             m.size_bytes >= expected
@@ -6159,7 +6258,7 @@ async fn cmd_start(
                         }
                         // For image models, parse models.json and verify all referenced files exist
                         if c.model_type == "image" {
-                            let model_dir = models::resolve_local_path(&c.id);
+                            let model_dir = models::resolve_local_path(source_id);
                             if let Some(dir) = model_dir.as_ref().and_then(|p| p.parent()) {
                                 let meta_path = dir.join("models.json");
                                 if !meta_path.exists() {
@@ -6204,6 +6303,7 @@ async fn cmd_start(
                     };
                     PickerItem {
                         id: c.id.clone(),
+                        source_id: source_id.to_string(),
                         display,
                         size_gb: size,
                         downloaded: is_downloaded,
@@ -6247,7 +6347,7 @@ async fn cmd_start(
                     let cache_dir = dirs::home_dir()
                         .unwrap_or_default()
                         .join(".cache/huggingface/hub")
-                        .join(format!("models--{}", item.id.replace('/', "--")))
+                        .join(format!("models--{}", item.source_id.replace('/', "--")))
                         .join("snapshots/main");
                     std::fs::create_dir_all(&cache_dir)?;
                     if !download_model_from_cdn(&item.s3_name, &cache_dir, &item.display) {
@@ -7302,7 +7402,7 @@ mod tests {
     fn test_build_inprocess_response_json_uses_public_model_id() {
         let leaked_model =
             "/Users/provider/.cache/huggingface/hub/models--mlx-community--Qwen3.5/snapshots/main";
-        let public_model = "mlx-community/Qwen3.5-122B-A10B-8bit";
+        let public_model = "Qwen3.5-122B-A10B-8bit";
         let body = json!({
             "endpoint": "/v1/chat/completions",
             "model": leaked_model,
@@ -7325,7 +7425,7 @@ mod tests {
     fn test_sanitize_public_model_error_rewrites_local_path() {
         let leaked_model =
             "/Users/provider/.cache/huggingface/hub/models--mlx-community--Qwen3.5/snapshots/main";
-        let public_model = "mlx-community/Qwen3.5-122B-A10B-8bit";
+        let public_model = "Qwen3.5-122B-A10B-8bit";
         let message = format!("failed to load model from {leaked_model}");
 
         let sanitized = sanitize_public_model_error(message, leaked_model, public_model);

--- a/provider/src/main.rs
+++ b/provider/src/main.rs
@@ -63,6 +63,18 @@ fn default_model_type() -> String {
     "text".into()
 }
 
+fn sanitize_public_model_error(
+    message: impl Into<String>,
+    local_model: &str,
+    public_model: &str,
+) -> String {
+    let message = message.into();
+    if local_model.is_empty() || public_model.is_empty() || local_model == public_model {
+        return message;
+    }
+    message.replace(local_model, public_model)
+}
+
 /// Hardcoded fallback catalog used when the coordinator is unreachable.
 fn fallback_catalog() -> Vec<CatalogModel> {
     vec![
@@ -3465,7 +3477,12 @@ async fn cmd_serve(
                                         .map(|s| (s.model_id.clone(), s.model_path.clone(), s.port, s.pid, s.healthy, s.restarting))
                                 };
 
-                                let mut inprocess_engine = None;
+                                #[cfg(feature = "python")]
+                                let mut inprocess_engine: Option<
+                                    std::sync::Arc<inference::SharedEngine>,
+                                > = None;
+                                let public_model = req_model_id.clone();
+
                                 if let Some((slot_model_id, slot_model_path, slot_port, slot_pid, slot_healthy, slot_restarting)) = slot_info {
                                     if is_inprocess {
                                         #[cfg(feature = "python")]
@@ -3529,7 +3546,11 @@ async fn cmd_serve(
                                                     let _ = outbound_tx.send(
                                                         protocol::ProviderMessage::InferenceError {
                                                             request_id,
-                                                            error: format!("in-process model load failed: {e}"),
+                                                            error: sanitize_public_model_error(
+                                                                format!("in-process model load failed: {e}"),
+                                                                &slot_model_path,
+                                                                &public_model,
+                                                            ),
                                                             status_code: 503,
                                                         }
                                                     ).await;
@@ -3637,10 +3658,7 @@ async fn cmd_serve(
                                 // (InferenceAccepted already sent above, before reload)
 
                                 // Route to the correct backend based on the requested model.
-                                let requested_model = body.get("model")
-                                    .and_then(|v| v.as_str())
-                                    .unwrap_or("")
-                                    .to_string();
+                                let requested_model = req_model_id.clone();
 
                                 // Find the backend URL for this model
                                 let target_url = model_to_url.get(&requested_model)
@@ -3679,16 +3697,36 @@ async fn cmd_serve(
                                         let engine = engine.clone();
                                         let rid2 = rid.clone();
                                         let stats = proxy_stats.clone();
+                                        let public_model = public_model.clone();
                                         tokio::spawn(async move {
-                                            handle_inprocess_request(rid2, body, engine, tx, Some(stats)).await;
+                                            handle_inprocess_request(
+                                                rid2,
+                                                body,
+                                                public_model,
+                                                engine,
+                                                tx,
+                                                Some(stats),
+                                            )
+                                            .await;
                                             let _ = done_tx.send((rid, false)).await;
                                         })
                                     } else {
                                         let kp = proxy_keypair.clone();
                                         let rid2 = rid.clone();
                                         let stats = proxy_stats.clone();
+                                        let public_model = public_model.clone();
                                         tokio::spawn(async move {
-                                            let dead = proxy::handle_inference_request(rid2, body, target_url, tx, Some(kp), token_clone, Some(stats)).await;
+                                            let dead = proxy::handle_inference_request_with_public_model(
+                                                rid2,
+                                                body,
+                                                target_url,
+                                                Some(public_model),
+                                                tx,
+                                                Some(kp),
+                                                token_clone,
+                                                Some(stats),
+                                            )
+                                            .await;
                                             let _ = done_tx.send((rid, dead)).await;
                                         })
                                     }
@@ -3698,8 +3736,19 @@ async fn cmd_serve(
                                         let kp = proxy_keypair.clone();
                                         let rid2 = rid.clone();
                                         let stats = proxy_stats.clone();
+                                        let public_model = public_model.clone();
                                         tokio::spawn(async move {
-                                            let dead = proxy::handle_inference_request(rid2, body, target_url, tx, Some(kp), token_clone, Some(stats)).await;
+                                            let dead = proxy::handle_inference_request_with_public_model(
+                                                rid2,
+                                                body,
+                                                target_url,
+                                                Some(public_model),
+                                                tx,
+                                                Some(kp),
+                                                token_clone,
+                                                Some(stats),
+                                            )
+                                            .await;
                                             let _ = done_tx.send((rid, dead)).await;
                                         })
                                     }
@@ -4289,6 +4338,7 @@ fn extract_inprocess_messages(body: &serde_json::Value) -> Vec<serde_json::Value
 #[cfg(feature = "python")]
 fn build_inprocess_response_json(
     body: &serde_json::Value,
+    public_model: &str,
     text: &str,
     prompt_tokens: u64,
     completion_tokens: u64,
@@ -4297,10 +4347,6 @@ fn build_inprocess_response_json(
         .get("endpoint")
         .and_then(|v| v.as_str())
         .unwrap_or("/v1/chat/completions");
-    let model = body
-        .get("model")
-        .and_then(|v| v.as_str())
-        .unwrap_or("unknown");
     let usage = serde_json::json!({
         "prompt_tokens": prompt_tokens,
         "completion_tokens": completion_tokens,
@@ -4311,7 +4357,7 @@ fn build_inprocess_response_json(
         "/v1/completions" => serde_json::json!({
             "id": format!("cmpl-{}", uuid::Uuid::new_v4()),
             "object": "text_completion",
-            "model": model,
+            "model": public_model,
             "choices": [{
                 "index": 0,
                 "text": text,
@@ -4323,7 +4369,7 @@ fn build_inprocess_response_json(
             "id": format!("msg_{}", uuid::Uuid::new_v4()),
             "type": "message",
             "role": "assistant",
-            "model": model,
+            "model": public_model,
             "content": [{
                 "type": "text",
                 "text": text,
@@ -4337,7 +4383,7 @@ fn build_inprocess_response_json(
         "/v1/responses" => serde_json::json!({
             "id": format!("resp_{}", uuid::Uuid::new_v4()),
             "object": "response",
-            "model": model,
+            "model": public_model,
             "output": [{
                 "id": format!("msg_{}", uuid::Uuid::new_v4()),
                 "type": "message",
@@ -4358,7 +4404,7 @@ fn build_inprocess_response_json(
         _ => serde_json::json!({
             "id": format!("chatcmpl-{}", uuid::Uuid::new_v4()),
             "object": "chat.completion",
-            "model": model,
+            "model": public_model,
             "choices": [{
                 "index": 0,
                 "message": {
@@ -4377,6 +4423,7 @@ fn build_inprocess_response_json(
 async fn handle_inprocess_request(
     request_id: String,
     body: serde_json::Value,
+    public_model: String,
     engine: std::sync::Arc<inference::SharedEngine>,
     outbound_tx: tokio::sync::mpsc::Sender<protocol::ProviderMessage>,
     stats: Option<std::sync::Arc<coordinator::AtomicProviderStats>>,
@@ -4418,6 +4465,7 @@ async fn handle_inprocess_request(
                     let chunk = serde_json::json!({
                         "id": format!("chatcmpl-{}", uuid::Uuid::new_v4()),
                         "object": "chat.completion.chunk",
+                        "model": public_model.clone(),
                         "choices": [{
                             "delta": {"content": token.text},
                             "index": 0,
@@ -4458,6 +4506,7 @@ async fn handle_inprocess_request(
             if !is_streaming {
                 let response_json = build_inprocess_response_json(
                     &body,
+                    &public_model,
                     &inference_result.text,
                     inference_result.prompt_tokens,
                     inference_result.completion_tokens,
@@ -4502,7 +4551,13 @@ async fn handle_inprocess_request(
             let _ = outbound_tx
                 .send(protocol::ProviderMessage::InferenceError {
                     request_id,
-                    error: e.to_string(),
+                    error: sanitize_public_model_error(
+                        e.to_string(),
+                        body.get("model")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or_default(),
+                        &public_model,
+                    ),
                     status_code: 500,
                 })
                 .await;
@@ -7140,6 +7195,8 @@ async fn cmd_autoupdate(action: &str) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(feature = "python")]
+    use serde_json::json;
     use std::os::unix::fs::PermissionsExt;
 
     fn write_test_command(script: &str) -> std::path::PathBuf {
@@ -7238,6 +7295,43 @@ mod tests {
             std::env::remove_var("EIGENINFERENCE_INFERENCE_BACKEND");
         }
         assert!(validate_private_text_runtime(true).is_err());
+    }
+
+    #[cfg(feature = "python")]
+    #[test]
+    fn test_build_inprocess_response_json_uses_public_model_id() {
+        let leaked_model =
+            "/Users/provider/.cache/huggingface/hub/models--mlx-community--Qwen3.5/snapshots/main";
+        let public_model = "mlx-community/Qwen3.5-122B-A10B-8bit";
+        let body = json!({
+            "endpoint": "/v1/chat/completions",
+            "model": leaked_model,
+        });
+
+        let response = build_inprocess_response_json(&body, public_model, "Hello", 12, 5);
+
+        assert_eq!(
+            response.get("model").and_then(|v| v.as_str()),
+            Some(public_model)
+        );
+        let response_str = serde_json::to_string(&response).expect("response should serialize");
+        assert!(
+            !response_str.contains(leaked_model),
+            "in-process responses should not expose backend model paths"
+        );
+    }
+
+    #[test]
+    fn test_sanitize_public_model_error_rewrites_local_path() {
+        let leaked_model =
+            "/Users/provider/.cache/huggingface/hub/models--mlx-community--Qwen3.5/snapshots/main";
+        let public_model = "mlx-community/Qwen3.5-122B-A10B-8bit";
+        let message = format!("failed to load model from {leaked_model}");
+
+        let sanitized = sanitize_public_model_error(message, leaked_model, public_model);
+
+        assert!(sanitized.contains(public_model));
+        assert!(!sanitized.contains(leaked_model));
     }
 
     /// Verify that spawn_backend_log_forwarder captures stdout/stderr from a child

--- a/provider/src/proxy.rs
+++ b/provider/src/proxy.rs
@@ -27,6 +27,63 @@ use crate::protocol::{
 };
 use crate::security;
 
+fn public_model_value(public_model: Option<&str>) -> Option<String> {
+    public_model
+        .map(str::trim)
+        .filter(|model| !model.is_empty())
+        .map(|model| model.to_string())
+}
+
+fn rewrite_response_model(
+    mut response_json: serde_json::Value,
+    public_model: Option<&str>,
+) -> serde_json::Value {
+    let Some(public_model) = public_model_value(public_model) else {
+        return response_json;
+    };
+
+    if let Some(obj) = response_json.as_object_mut() {
+        if matches!(obj.get("model"), Some(serde_json::Value::String(_))) {
+            obj.insert(
+                "model".to_string(),
+                serde_json::Value::String(public_model.clone()),
+            );
+        }
+        if let Some(response_obj) = obj
+            .get_mut("response")
+            .and_then(|value| value.as_object_mut())
+        {
+            if matches!(
+                response_obj.get("model"),
+                Some(serde_json::Value::String(_))
+            ) {
+                response_obj.insert("model".to_string(), serde_json::Value::String(public_model));
+            }
+        }
+    }
+
+    response_json
+}
+
+fn sanitize_error_body(
+    error_body: String,
+    request_model: Option<&str>,
+    public_model: Option<&str>,
+) -> String {
+    let Some(public_model) = public_model_value(public_model) else {
+        return error_body;
+    };
+
+    let Some(request_model) = request_model
+        .map(str::trim)
+        .filter(|model| !model.is_empty())
+    else {
+        return error_body;
+    };
+
+    error_body.replace(request_model, &public_model)
+}
+
 /// Handle an inference request by forwarding it to the local backend
 /// and streaming responses back via the outbound channel.
 ///
@@ -42,6 +99,34 @@ pub async fn handle_inference_request(
     request_id: String,
     body: serde_json::Value,
     backend_url: String,
+    outbound_tx: mpsc::Sender<ProviderMessage>,
+    _node_keypair: Option<Arc<NodeKeyPair>>,
+    cancel_token: CancellationToken,
+    stats: Option<Arc<AtomicProviderStats>>,
+) -> bool {
+    let public_model = body
+        .get("model")
+        .and_then(|v| v.as_str())
+        .map(|model| model.to_string());
+
+    handle_inference_request_with_public_model(
+        request_id,
+        body,
+        backend_url,
+        public_model,
+        outbound_tx,
+        _node_keypair,
+        cancel_token,
+        stats,
+    )
+    .await
+}
+
+pub(crate) async fn handle_inference_request_with_public_model(
+    request_id: String,
+    body: serde_json::Value,
+    backend_url: String,
+    public_model: Option<String>,
     outbound_tx: mpsc::Sender<ProviderMessage>,
     _node_keypair: Option<Arc<NodeKeyPair>>,
     cancel_token: CancellationToken,
@@ -73,6 +158,7 @@ pub async fn handle_inference_request(
             &body,
             &backend_url,
             &outbound_tx,
+            public_model.as_deref(),
             &cancel_token,
             &stats,
         )
@@ -83,6 +169,7 @@ pub async fn handle_inference_request(
             &body,
             &backend_url,
             &outbound_tx,
+            public_model.as_deref(),
             &cancel_token,
             &stats,
         )
@@ -131,6 +218,7 @@ async fn handle_non_streaming_request(
     body: &serde_json::Value,
     backend_url: &str,
     outbound_tx: &mpsc::Sender<ProviderMessage>,
+    response_model: Option<&str>,
     cancel_token: &CancellationToken,
     stats: &Option<Arc<AtomicProviderStats>>,
 ) -> Result<()> {
@@ -138,6 +226,7 @@ async fn handle_non_streaming_request(
         .get("endpoint")
         .and_then(|v| v.as_str())
         .unwrap_or("/v1/chat/completions");
+    let request_model = body.get("model").and_then(|v| v.as_str());
     let url = format!("{backend_url}{endpoint}");
     let client = reqwest::Client::new();
 
@@ -152,7 +241,11 @@ async fn handle_non_streaming_request(
 
     let status = response.status();
     if !status.is_success() {
-        let error_body = response.text().await.unwrap_or_default();
+        let error_body = sanitize_error_body(
+            response.text().await.unwrap_or_default(),
+            request_model,
+            response_model,
+        );
         outbound_tx
             .send(ProviderMessage::InferenceError {
                 request_id: request_id.to_string(),
@@ -172,6 +265,7 @@ async fn handle_non_streaming_request(
             anyhow::bail!("request cancelled");
         }
     };
+    let response_json = rewrite_response_model(response_json, response_model);
 
     // Extract token usage info for billing (format-agnostic: handles both
     // chat completions prompt_tokens/completion_tokens and Responses API
@@ -238,6 +332,7 @@ async fn handle_streaming_request(
     body: &serde_json::Value,
     backend_url: &str,
     outbound_tx: &mpsc::Sender<ProviderMessage>,
+    response_model: Option<&str>,
     cancel_token: &CancellationToken,
     stats: &Option<Arc<AtomicProviderStats>>,
 ) -> Result<()> {
@@ -245,6 +340,7 @@ async fn handle_streaming_request(
         .get("endpoint")
         .and_then(|v| v.as_str())
         .unwrap_or("/v1/chat/completions");
+    let request_model = body.get("model").and_then(|v| v.as_str());
     let url = format!("{backend_url}{endpoint}");
     let client = reqwest::Client::new();
 
@@ -259,7 +355,11 @@ async fn handle_streaming_request(
 
     let status = response.status();
     if !status.is_success() {
-        let error_body = response.text().await.unwrap_or_default();
+        let error_body = sanitize_error_body(
+            response.text().await.unwrap_or_default(),
+            request_model,
+            response_model,
+        );
         outbound_tx
             .send(ProviderMessage::InferenceError {
                 request_id: request_id.to_string(),
@@ -341,8 +441,12 @@ async fn handle_streaming_request(
                     return Ok(());
                 }
 
+                let mut forwarded_line = line.clone();
+
                 // Try to extract usage from chunk (some backends include it)
                 if let Ok(chunk_json) = serde_json::from_str::<serde_json::Value>(data) {
+                    let chunk_json = rewrite_response_model(chunk_json, response_model);
+
                     if let Some(usage) = chunk_json.get("usage") {
                         if let Some(pt) = usage.get("prompt_tokens").and_then(|v| v.as_u64()) {
                             prompt_tokens = pt;
@@ -373,13 +477,18 @@ async fn handle_streaming_request(
                             }
                         }
                     }
+
+                    forwarded_line = format!(
+                        "data: {}",
+                        serde_json::to_string(&chunk_json).unwrap_or_else(|_| data.to_string())
+                    );
                 }
 
                 // Forward the SSE line to coordinator
                 outbound_tx
                     .send(ProviderMessage::InferenceResponseChunk {
                         request_id: request_id.to_string(),
-                        data: line.clone(),
+                        data: forwarded_line,
                     })
                     .await
                     .ok();
@@ -1003,6 +1112,76 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_non_streaming_response_uses_public_model_id() {
+        use axum::{Json, Router, routing::post};
+
+        let leaked_model =
+            "/Users/provider/.cache/huggingface/hub/models--mlx-community--Qwen3.5/snapshots/main";
+        let public_model = "mlx-community/Qwen3.5-122B-A10B-8bit";
+        let leaked_model_for_server = leaked_model.to_string();
+
+        let app = Router::new().route(
+            "/v1/chat/completions",
+            post(move || {
+                let leaked_model = leaked_model_for_server.clone();
+                async move {
+                    Json(serde_json::json!({
+                        "id": "chatcmpl-test",
+                        "object": "chat.completion",
+                        "model": leaked_model,
+                        "choices": [{"message": {"role": "assistant", "content": "Hello!"}}],
+                        "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15}
+                    }))
+                }
+            }),
+        );
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        let (tx, mut rx) = mpsc::channel(32);
+        let body = serde_json::json!({
+            "model": leaked_model,
+            "messages": [{"role": "user", "content": "hi"}],
+            "stream": false
+        });
+
+        let dead = handle_inference_request_with_public_model(
+            "req-public-model".to_string(),
+            body,
+            format!("http://127.0.0.1:{}", addr.port()),
+            Some(public_model.to_string()),
+            tx,
+            None,
+            CancellationToken::new(),
+            None,
+        )
+        .await;
+        assert!(!dead, "backend should not be reported as dead");
+
+        let chunk_msg = rx.recv().await.unwrap();
+        match chunk_msg {
+            ProviderMessage::InferenceResponseChunk { data, .. } => {
+                let payload = data.trim_start_matches("data: ");
+                let json: serde_json::Value = serde_json::from_str(payload).unwrap();
+                assert_eq!(
+                    json.get("model").and_then(|v| v.as_str()),
+                    Some(public_model)
+                );
+                assert!(
+                    !payload.contains(leaked_model),
+                    "response should not expose backend model path"
+                );
+            }
+            other => panic!("Expected InferenceResponseChunk, got {:?}", other),
+        }
+    }
+
+    #[tokio::test]
     async fn test_handle_error_response() {
         use axum::{Router, http::StatusCode, routing::post};
 
@@ -1119,6 +1298,228 @@ mod tests {
             "Expected InferenceComplete as last message, got {:?}",
             last
         );
+    }
+
+    #[tokio::test]
+    async fn test_streaming_response_uses_public_model_id() {
+        use axum::{Router, body::Body, http::StatusCode, response::Response, routing::post};
+
+        let leaked_model =
+            "/Users/provider/.cache/huggingface/hub/models--mlx-community--Qwen3.5/snapshots/main";
+        let public_model = "mlx-community/Qwen3.5-122B-A10B-8bit";
+        let chunk = serde_json::json!({
+            "id": "chatcmpl-test",
+            "object": "chat.completion.chunk",
+            "model": leaked_model,
+            "choices": [{"delta": {"content": "Hello"}}]
+        });
+        let sse_data = format!(
+            "data: {}\n\ndata: [DONE]\n\n",
+            serde_json::to_string(&chunk).unwrap()
+        );
+
+        let app = Router::new().route(
+            "/v1/chat/completions",
+            post(move || {
+                let sse_data = sse_data.clone();
+                async move {
+                    Response::builder()
+                        .status(StatusCode::OK)
+                        .header("content-type", "text/event-stream")
+                        .body(Body::from(sse_data))
+                        .unwrap()
+                }
+            }),
+        );
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        let (tx, mut rx) = mpsc::channel(32);
+        let body = serde_json::json!({
+            "model": leaked_model,
+            "messages": [{"role": "user", "content": "hi"}],
+            "stream": true
+        });
+
+        let dead = handle_inference_request_with_public_model(
+            "req-stream-public-model".to_string(),
+            body,
+            format!("http://127.0.0.1:{}", addr.port()),
+            Some(public_model.to_string()),
+            tx,
+            None,
+            CancellationToken::new(),
+            None,
+        )
+        .await;
+        assert!(!dead, "backend should not be reported as dead");
+
+        let first_msg = rx.recv().await.unwrap();
+        match first_msg {
+            ProviderMessage::InferenceResponseChunk { data, .. } => {
+                let payload = data.trim_start_matches("data: ");
+                let json: serde_json::Value = serde_json::from_str(payload).unwrap();
+                assert_eq!(
+                    json.get("model").and_then(|v| v.as_str()),
+                    Some(public_model)
+                );
+                assert!(
+                    !payload.contains(leaked_model),
+                    "stream chunk should not expose backend model path"
+                );
+            }
+            other => panic!("Expected InferenceResponseChunk, got {:?}", other),
+        }
+
+        let complete_msg = rx.recv().await.unwrap();
+        assert!(
+            matches!(complete_msg, ProviderMessage::InferenceComplete { .. }),
+            "Expected InferenceComplete, got {:?}",
+            complete_msg
+        );
+    }
+
+    #[tokio::test]
+    async fn test_responses_streaming_event_uses_public_model_id() {
+        use axum::{Router, body::Body, http::StatusCode, response::Response, routing::post};
+
+        let leaked_model =
+            "/Users/provider/.cache/huggingface/hub/models--mlx-community--Qwen3.5/snapshots/main";
+        let public_model = "mlx-community/Qwen3.5-122B-A10B-8bit";
+        let chunk = serde_json::json!({
+            "type": "response.created",
+            "response": {
+                "id": "resp_123",
+                "model": leaked_model
+            }
+        });
+        let sse_data = format!(
+            "data: {}\n\ndata: [DONE]\n\n",
+            serde_json::to_string(&chunk).unwrap()
+        );
+
+        let app = Router::new().route(
+            "/v1/responses",
+            post(move || {
+                let sse_data = sse_data.clone();
+                async move {
+                    Response::builder()
+                        .status(StatusCode::OK)
+                        .header("content-type", "text/event-stream")
+                        .body(Body::from(sse_data))
+                        .unwrap()
+                }
+            }),
+        );
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        let (tx, mut rx) = mpsc::channel(32);
+        let body = serde_json::json!({
+            "model": leaked_model,
+            "input": "hi",
+            "endpoint": "/v1/responses",
+            "stream": true
+        });
+
+        let dead = handle_inference_request_with_public_model(
+            "req-stream-response-model".to_string(),
+            body,
+            format!("http://127.0.0.1:{}", addr.port()),
+            Some(public_model.to_string()),
+            tx,
+            None,
+            CancellationToken::new(),
+            None,
+        )
+        .await;
+        assert!(!dead, "backend should not be reported as dead");
+
+        let first_msg = rx.recv().await.unwrap();
+        match first_msg {
+            ProviderMessage::InferenceResponseChunk { data, .. } => {
+                let payload = data.trim_start_matches("data: ");
+                let json: serde_json::Value = serde_json::from_str(payload).unwrap();
+                assert_eq!(
+                    json.get("response")
+                        .and_then(|v| v.get("model"))
+                        .and_then(|v| v.as_str()),
+                    Some(public_model)
+                );
+                assert!(
+                    !payload.contains(leaked_model),
+                    "responses stream event should not expose backend model path"
+                );
+            }
+            other => panic!("Expected InferenceResponseChunk, got {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_error_response_scrubs_backend_model_path() {
+        use axum::{Router, http::StatusCode, routing::post};
+
+        let leaked_model =
+            "/Users/provider/.cache/huggingface/hub/models--mlx-community--Qwen3.5/snapshots/main";
+        let public_model = "mlx-community/Qwen3.5-122B-A10B-8bit";
+        let leaked_error = format!("unknown model: {leaked_model}");
+
+        let app = Router::new().route(
+            "/v1/chat/completions",
+            post(move || {
+                let leaked_error = leaked_error.clone();
+                async move { (StatusCode::BAD_REQUEST, leaked_error) }
+            }),
+        );
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        let (tx, mut rx) = mpsc::channel(32);
+        let body = serde_json::json!({
+            "model": leaked_model,
+            "messages": [{"role": "user", "content": "hi"}],
+            "stream": false
+        });
+
+        let dead = handle_inference_request_with_public_model(
+            "req-error-public-model".to_string(),
+            body,
+            format!("http://127.0.0.1:{}", addr.port()),
+            Some(public_model.to_string()),
+            tx,
+            None,
+            CancellationToken::new(),
+            None,
+        )
+        .await;
+        assert!(!dead, "backend should not be reported as dead");
+
+        let msg = rx.recv().await.unwrap();
+        match msg {
+            ProviderMessage::InferenceError { error, .. } => {
+                assert!(error.contains(public_model));
+                assert!(
+                    !error.contains(leaked_model),
+                    "error body should not expose backend model path"
+                );
+            }
+            other => panic!("Expected InferenceError, got {:?}", other),
+        }
     }
 
     #[tokio::test]

--- a/provider/src/proxy.rs
+++ b/provider/src/proxy.rs
@@ -1117,7 +1117,7 @@ mod tests {
 
         let leaked_model =
             "/Users/provider/.cache/huggingface/hub/models--mlx-community--Qwen3.5/snapshots/main";
-        let public_model = "mlx-community/Qwen3.5-122B-A10B-8bit";
+        let public_model = "Qwen3.5-122B-A10B-8bit";
         let leaked_model_for_server = leaked_model.to_string();
 
         let app = Router::new().route(
@@ -1306,7 +1306,7 @@ mod tests {
 
         let leaked_model =
             "/Users/provider/.cache/huggingface/hub/models--mlx-community--Qwen3.5/snapshots/main";
-        let public_model = "mlx-community/Qwen3.5-122B-A10B-8bit";
+        let public_model = "Qwen3.5-122B-A10B-8bit";
         let chunk = serde_json::json!({
             "id": "chatcmpl-test",
             "object": "chat.completion.chunk",
@@ -1390,7 +1390,7 @@ mod tests {
 
         let leaked_model =
             "/Users/provider/.cache/huggingface/hub/models--mlx-community--Qwen3.5/snapshots/main";
-        let public_model = "mlx-community/Qwen3.5-122B-A10B-8bit";
+        let public_model = "Qwen3.5-122B-A10B-8bit";
         let chunk = serde_json::json!({
             "type": "response.created",
             "response": {
@@ -1471,7 +1471,7 @@ mod tests {
 
         let leaked_model =
             "/Users/provider/.cache/huggingface/hub/models--mlx-community--Qwen3.5/snapshots/main";
-        let public_model = "mlx-community/Qwen3.5-122B-A10B-8bit";
+        let public_model = "Qwen3.5-122B-A10B-8bit";
         let leaked_error = format!("unknown model: {leaked_model}");
 
         let app = Router::new().route(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- preserve the public requested model ID before provider requests are rewritten to local backend paths, and stop completion responses from leaking local filesystem paths
- split public model IDs from source repo IDs so the external API uses clean model names while providers still resolve and launch backing artifacts from source IDs
- normalize legacy `mlx-community/...` IDs at coordinator/provider edges for backward compatibility, migrate/dedupe legacy catalog rows, and update app/UI/tooling surfaces to the new public ID contract
- merge latest `origin/master` into this branch and resolve the provider-side conflict by combining master's default coordinator URL constant with the source-aware public/source model ID logic

## Verification
- `go test ./...` in `coordinator/`
- `cargo +nightly fmt --check` in `provider/`
- `PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 cargo +nightly check --target aarch64-apple-darwin --no-default-features` in `provider/`
- `PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 cargo +nightly check --target aarch64-apple-darwin --no-default-features --tests` in `provider/`
- merge conflict reviewed and resolved; repeated parallel review passes after fixing runtime/source-ID and catalog-migration edge cases
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5c3d0585-1d0c-451f-8c6e-0c4876d18cd0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5c3d0585-1d0c-451f-8c6e-0c4876d18cd0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

