### PR TITLE
Add /providers/me dashboard for account-scoped fleet view

### DIFF
--- a/console-ui/__tests__/providers-me-warnings.test.ts
+++ b/console-ui/__tests__/providers-me-warnings.test.ts
@@ -1,0 +1,345 @@
+import { describe, it, expect } from "vitest";
+import {
+  computeWarnings,
+  highestSeverity,
+  semverLess,
+} from "@/app/providers/me/warnings";
+import type { MyProvider, MyProvidersResponse } from "@/app/providers/me/types";
+
+const ctx: Pick<
+  MyProvidersResponse,
+  "latest_provider_version" | "min_provider_version" | "heartbeat_timeout_seconds" | "challenge_max_age_seconds"
+> = {
+  latest_provider_version: "0.3.10",
+  min_provider_version: "0.3.10",
+  heartbeat_timeout_seconds: 90,
+  challenge_max_age_seconds: 360,
+};
+
+function baseProvider(overrides: Partial<MyProvider> = {}): MyProvider {
+  return {
+    id: "p1",
+    account_id: "acct-1",
+    status: "online",
+    online: true,
+    hardware: { chip_name: "Apple M3 Max", memory_gb: 64 },
+    models: [{ id: "mlx-community/Qwen3.5-9B-MLX-4bit" }],
+    trust_level: "hardware",
+    attested: true,
+    mda_verified: true,
+    acme_verified: true,
+    se_key_bound: true,
+    secure_enclave: true,
+    sip_enabled: true,
+    secure_boot_enabled: true,
+    authenticated_root_enabled: true,
+    runtime_verified: true,
+    failed_challenges: 0,
+    pending_requests: 0,
+    max_concurrency: 8,
+    reputation: {
+      score: 0.85,
+      total_jobs: 0,
+      successful_jobs: 0,
+      failed_jobs: 0,
+      total_uptime_seconds: 0,
+      avg_response_time_ms: 0,
+      challenges_passed: 5,
+      challenges_failed: 0,
+    },
+    lifetime_requests_served: 0,
+    lifetime_tokens_generated: 0,
+    earnings_total_micro_usd: 0,
+    earnings_count: 0,
+    last_challenge_verified: new Date().toISOString(),
+    version: "0.3.10",
+    ...overrides,
+  };
+}
+
+describe("semverLess", () => {
+  it("compares numeric segments", () => {
+    expect(semverLess("0.3.9", "0.3.10")).toBe(true);
+    expect(semverLess("0.3.10", "0.3.9")).toBe(false);
+    expect(semverLess("0.3.10", "0.3.10")).toBe(false);
+    expect(semverLess("0.4.0", "0.3.99")).toBe(false);
+  });
+  it("treats empty version as falsy", () => {
+    expect(semverLess("", "0.3.10")).toBe(true);
+    expect(semverLess("0.3.10", "")).toBe(false);
+    expect(semverLess("", "")).toBe(false);
+  });
+});
+
+describe("computeWarnings", () => {
+  it("returns no warnings for a perfectly healthy machine", () => {
+    const warnings = computeWarnings(baseProvider(), ctx);
+    expect(warnings).toEqual([]);
+  });
+
+  it("flags offline machines as blocking", () => {
+    const warnings = computeWarnings(baseProvider({ status: "offline", online: false }), ctx);
+    expect(warnings.find((w) => w.id === "offline")?.severity).toBe("blocking");
+  });
+
+  it("flags untrusted as blocking and explains failed challenges", () => {
+    const warnings = computeWarnings(
+      baseProvider({ status: "untrusted", failed_challenges: 3 }),
+      ctx
+    );
+    expect(warnings.find((w) => w.id === "untrusted")?.severity).toBe("blocking");
+  });
+
+  it("flags runtime mismatch as blocking", () => {
+    const warnings = computeWarnings(baseProvider({ runtime_verified: false }), ctx);
+    expect(warnings.find((w) => w.id === "runtime_unverified")?.severity).toBe("blocking");
+  });
+
+  it("flags version below min as blocking", () => {
+    const warnings = computeWarnings(
+      baseProvider({ version: "0.3.5" }),
+      { ...ctx, min_provider_version: "0.3.10" }
+    );
+    expect(warnings.find((w) => w.id === "version_below_min")?.severity).toBe("blocking");
+  });
+
+  it("flags self-signed trust as blocking (production min trust = hardware)", () => {
+    const warnings = computeWarnings(baseProvider({ trust_level: "self_signed" }), ctx);
+    expect(warnings.find((w) => w.id === "trust_self_signed")?.severity).toBe("blocking");
+  });
+
+  it("flags trust_level=none as blocking", () => {
+    const warnings = computeWarnings(baseProvider({ trust_level: "none", mda_verified: false }), ctx);
+    expect(warnings.find((w) => w.id === "trust_none")?.severity).toBe("blocking");
+  });
+
+  it("flags hardware trust without MDA as degrading", () => {
+    const warnings = computeWarnings(baseProvider({ mda_verified: false }), ctx);
+    expect(warnings.find((w) => w.id === "mda_missing")?.severity).toBe("degrading");
+  });
+
+  it("flags critical thermal as blocking", () => {
+    const warnings = computeWarnings(
+      baseProvider({
+        system_metrics: { memory_pressure: 0.2, cpu_usage: 0.1, thermal_state: "critical" },
+      }),
+      ctx
+    );
+    expect(warnings.find((w) => w.id === "thermal_critical")?.severity).toBe("blocking");
+  });
+
+  it("flags serious thermal as degrading, fair as degrading", () => {
+    const serious = computeWarnings(
+      baseProvider({
+        system_metrics: { memory_pressure: 0.2, cpu_usage: 0.1, thermal_state: "serious" },
+      }),
+      ctx
+    );
+    expect(serious.find((w) => w.id === "thermal_serious")?.severity).toBe("degrading");
+
+    const fair = computeWarnings(
+      baseProvider({
+        system_metrics: { memory_pressure: 0.2, cpu_usage: 0.1, thermal_state: "fair" },
+      }),
+      ctx
+    );
+    expect(fair.find((w) => w.id === "thermal_fair")?.severity).toBe("degrading");
+  });
+
+  it("flags >90% memory pressure", () => {
+    const warnings = computeWarnings(
+      baseProvider({
+        system_metrics: { memory_pressure: 0.95, cpu_usage: 0.1, thermal_state: "nominal" },
+      }),
+      ctx
+    );
+    expect(warnings.find((w) => w.id === "memory_pressure_high")?.severity).toBe("degrading");
+  });
+
+  it("flags crashed backend slot as degrading (scoring penalty, not exclusion)", () => {
+    const warnings = computeWarnings(
+      baseProvider({
+        backend_capacity: {
+          slots: [
+            {
+              model: "model-a",
+              state: "crashed",
+              num_running: 0,
+              num_waiting: 0,
+              active_tokens: 0,
+              max_tokens_potential: 0,
+            },
+          ],
+          gpu_memory_active_gb: 0,
+          gpu_memory_peak_gb: 0,
+          gpu_memory_cache_gb: 0,
+          total_memory_gb: 64,
+        },
+      }),
+      ctx
+    );
+    expect(warnings.find((w) => w.id === "backend_crashed")?.severity).toBe("degrading");
+  });
+
+  it("flags stale challenge (>6 min) as blocking", () => {
+    const elevenMinAgo = new Date(Date.now() - 11 * 60 * 1000).toISOString();
+    const warnings = computeWarnings(
+      baseProvider({ last_challenge_verified: elevenMinAgo }),
+      ctx
+    );
+    expect(warnings.find((w) => w.id === "challenge_stale")?.severity).toBe("blocking");
+  });
+
+  it("does NOT flag a fresh challenge as stale", () => {
+    const oneMinAgo = new Date(Date.now() - 60 * 1000).toISOString();
+    const warnings = computeWarnings(
+      baseProvider({ last_challenge_verified: oneMinAgo }),
+      ctx
+    );
+    expect(warnings.find((w) => w.id === "challenge_stale")).toBeUndefined();
+  });
+
+  it("flags zero catalog models as blocking when machine is online", () => {
+    const warnings = computeWarnings(baseProvider({ models: [] }), ctx);
+    expect(warnings.find((w) => w.id === "no_catalog_models")?.severity).toBe("blocking");
+  });
+
+  it("does not flag no-models for an offline machine", () => {
+    const warnings = computeWarnings(
+      baseProvider({ models: [], status: "offline", online: false }),
+      ctx
+    );
+    expect(warnings.find((w) => w.id === "no_catalog_models")).toBeUndefined();
+  });
+
+  it("flags idle_shutdown backend as degrading", () => {
+    const warnings = computeWarnings(
+      baseProvider({
+        backend_capacity: {
+          slots: [
+            {
+              model: "model-a",
+              state: "idle_shutdown",
+              num_running: 0,
+              num_waiting: 0,
+              active_tokens: 0,
+              max_tokens_potential: 0,
+            },
+          ],
+          gpu_memory_active_gb: 0,
+          gpu_memory_peak_gb: 0,
+          gpu_memory_cache_gb: 0,
+          total_memory_gb: 64,
+        },
+      }),
+      ctx
+    );
+    expect(warnings.find((w) => w.id === "backend_idle_shutdown")?.severity).toBe("degrading");
+  });
+
+  it("flags low success rate (degrading)", () => {
+    const warnings = computeWarnings(
+      baseProvider({
+        reputation: {
+          score: 0.3,
+          total_jobs: 20,
+          successful_jobs: 10,
+          failed_jobs: 10,
+          total_uptime_seconds: 100,
+          avg_response_time_ms: 500,
+          challenges_passed: 5,
+          challenges_failed: 0,
+        },
+      }),
+      ctx
+    );
+    expect(warnings.find((w) => w.id === "low_success_rate")?.severity).toBe("degrading");
+  });
+
+  it("does NOT flag low success rate when sample size is small", () => {
+    const warnings = computeWarnings(
+      baseProvider({
+        reputation: {
+          score: 0.3,
+          total_jobs: 3,
+          successful_jobs: 1,
+          failed_jobs: 2,
+          total_uptime_seconds: 100,
+          avg_response_time_ms: 500,
+          challenges_passed: 5,
+          challenges_failed: 0,
+        },
+      }),
+      ctx
+    );
+    expect(warnings.find((w) => w.id === "low_success_rate")).toBeUndefined();
+  });
+
+  it("flags no payout configured (info)", () => {
+    const warnings = computeWarnings(
+      baseProvider({ account_id: "", wallet_address: undefined }),
+      ctx
+    );
+    expect(warnings.find((w) => w.id === "no_payout")?.severity).toBe("info");
+  });
+
+  it("flags outdated version when latest is newer (info)", () => {
+    const warnings = computeWarnings(
+      baseProvider({ version: "0.3.9" }),
+      { ...ctx, latest_provider_version: "0.3.10", min_provider_version: "0.3.5" }
+    );
+    expect(warnings.find((w) => w.id === "outdated_version")?.severity).toBe("info");
+  });
+
+  it("does NOT double-warn outdated when version is also below the min", () => {
+    const warnings = computeWarnings(
+      baseProvider({ version: "0.3.5" }),
+      { ...ctx, latest_provider_version: "0.3.10", min_provider_version: "0.3.10" }
+    );
+    expect(warnings.find((w) => w.id === "version_below_min")).toBeDefined();
+    expect(warnings.find((w) => w.id === "outdated_version")).toBeUndefined();
+  });
+
+  it("flags missing first challenge (info) when otherwise eligible", () => {
+    const warnings = computeWarnings(
+      baseProvider({ last_challenge_verified: undefined }),
+      ctx
+    );
+    expect(warnings.find((w) => w.id === "no_challenge_yet")?.severity).toBe("info");
+  });
+
+  it("does not surface trust warnings for offline machines (offline takes precedence)", () => {
+    const warnings = computeWarnings(
+      baseProvider({
+        status: "offline",
+        online: false,
+        trust_level: "self_signed",
+      }),
+      ctx
+    );
+    expect(warnings.find((w) => w.id === "trust_self_signed")).toBeUndefined();
+    expect(warnings.find((w) => w.id === "offline")).toBeDefined();
+  });
+});
+
+describe("highestSeverity", () => {
+  it("returns blocking when present", () => {
+    expect(
+      highestSeverity([
+        { id: "a", severity: "info", title: "", detail: "" },
+        { id: "b", severity: "blocking", title: "", detail: "" },
+      ])
+    ).toBe("blocking");
+  });
+  it("returns degrading when no blocking", () => {
+    expect(
+      highestSeverity([
+        { id: "a", severity: "info", title: "", detail: "" },
+        { id: "b", severity: "degrading", title: "", detail: "" },
+      ])
+    ).toBe("degrading");
+  });
+  it("returns null on empty", () => {
+    expect(highestSeverity([])).toBeNull();
+  });
+});

--- a/console-ui/src/app/api/me/providers/route.ts
+++ b/console-ui/src/app/api/me/providers/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from "next/server";
+
+const DEFAULT_COORD = process.env.NEXT_PUBLIC_COORDINATOR_URL || "https://api.darkbloom.dev";
+
+export async function GET(req: NextRequest) {
+  const coordUrl = req.headers.get("x-coordinator-url") || DEFAULT_COORD;
+
+  let authHeader = req.headers.get("authorization") || "";
+  if (!authHeader) {
+    const privyToken = req.cookies.get("privy-token")?.value;
+    if (privyToken) {
+      authHeader = `Bearer ${privyToken}`;
+    }
+  }
+  if (!authHeader) {
+    return NextResponse.json({ error: "missing privy token" }, { status: 401 });
+  }
+
+  const res = await fetch(`${coordUrl}/v1/me/providers`, {
+    headers: { Authorization: authHeader },
+    cache: "no-store",
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    return NextResponse.json({ error: text || `Upstream ${res.status}` }, { status: res.status });
+  }
+  return NextResponse.json(await res.json());
+}

--- a/console-ui/src/app/api/me/summary/route.ts
+++ b/console-ui/src/app/api/me/summary/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from "next/server";
+
+const DEFAULT_COORD = process.env.NEXT_PUBLIC_COORDINATOR_URL || "https://api.darkbloom.dev";
+
+export async function GET(req: NextRequest) {
+  const coordUrl = req.headers.get("x-coordinator-url") || DEFAULT_COORD;
+
+  let authHeader = req.headers.get("authorization") || "";
+  if (!authHeader) {
+    const privyToken = req.cookies.get("privy-token")?.value;
+    if (privyToken) {
+      authHeader = `Bearer ${privyToken}`;
+    }
+  }
+  if (!authHeader) {
+    return NextResponse.json({ error: "missing privy token" }, { status: 401 });
+  }
+
+  const res = await fetch(`${coordUrl}/v1/me/summary`, {
+    headers: { Authorization: authHeader },
+    cache: "no-store",
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    return NextResponse.json({ error: text || `Upstream ${res.status}` }, { status: res.status });
+  }
+  return NextResponse.json(await res.json());
+}

--- a/console-ui/src/app/providers/me/MyMachinesContent.tsx
+++ b/console-ui/src/app/providers/me/MyMachinesContent.tsx
@@ -1,0 +1,608 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import {
+  Activity,
+  AlertTriangle,
+  ArrowRight,
+  CheckCircle2,
+  ChevronDown,
+  Cpu,
+  ExternalLink,
+  HardDrive,
+  Info,
+  Loader2,
+  Mail,
+  RefreshCw,
+  ShieldCheck,
+  Wallet,
+  XCircle,
+  Zap,
+} from "lucide-react";
+import { useAuth } from "@/hooks/useAuth";
+import type {
+  MyProvider,
+  MyProvidersResponse,
+  MySummaryResponse,
+} from "./types";
+import {
+  computeWarnings,
+  highestSeverity,
+  type Warning,
+  type WarningSeverity,
+} from "./warnings";
+
+const REFRESH_MS = 15_000;
+
+function formatUSD(microUSD: number): string {
+  return `$${(microUSD / 1_000_000).toFixed(microUSD < 10_000 ? 4 : 2)}`;
+}
+
+function formatRelative(iso?: string): string {
+  if (!iso) return "never";
+  const t = new Date(iso).getTime();
+  if (!Number.isFinite(t)) return "never";
+  const seconds = Math.max(0, Math.floor((Date.now() - t) / 1000));
+  if (seconds < 60) return `${seconds}s ago`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 48) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+function maskSerial(serial: string): string {
+  if (!serial) return "";
+  if (serial.length <= 6) return serial;
+  return serial.slice(0, 4) + "\u2022".repeat(serial.length - 6) + serial.slice(-2);
+}
+
+export default function MyMachinesContent() {
+  const { ready, authenticated, login, getAccessToken } = useAuth();
+  const [providersResp, setProvidersResp] = useState<MyProvidersResponse | null>(null);
+  const [summary, setSummary] = useState<MySummaryResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchAll = useCallback(async () => {
+    setRefreshing(true);
+    setError(null);
+    try {
+      const token = await getAccessToken().catch(() => null);
+      if (!token) {
+        setError("Not authenticated");
+        return;
+      }
+      const headers = { Authorization: `Bearer ${token}` };
+      const [pRes, sRes] = await Promise.all([
+        fetch("/api/me/providers", { headers, cache: "no-store" }),
+        fetch("/api/me/summary", { headers, cache: "no-store" }),
+      ]);
+      if (!pRes.ok) throw new Error(`providers: HTTP ${pRes.status}`);
+      if (!sRes.ok) throw new Error(`summary: HTTP ${sRes.status}`);
+      const [p, s] = await Promise.all([
+        pRes.json() as Promise<MyProvidersResponse>,
+        sRes.json() as Promise<MySummaryResponse>,
+      ]);
+      setProvidersResp(p);
+      setSummary(s);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  }, [getAccessToken]);
+
+  useEffect(() => {
+    if (!authenticated) {
+      setLoading(false);
+      return;
+    }
+    fetchAll();
+    const id = setInterval(fetchAll, REFRESH_MS);
+    return () => clearInterval(id);
+  }, [authenticated, fetchAll]);
+
+  if (!ready || (loading && authenticated)) {
+    return (
+      <div className="flex items-center justify-center h-64">
+        <Loader2 size={24} className="animate-spin text-accent-brand" />
+      </div>
+    );
+  }
+
+  if (!authenticated) {
+    return (
+      <div className="max-w-3xl mx-auto p-6">
+        <div className="rounded-xl bg-bg-secondary shadow-sm p-6">
+          <h2 className="text-lg font-semibold text-text-primary mb-2">Sign in to view your machines</h2>
+          <p className="text-sm text-text-secondary mb-4">
+            The My Machines dashboard shows the status, earnings, and warnings for every provider machine
+            linked to your account.
+          </p>
+          <button
+            onClick={login}
+            className="inline-flex items-center gap-2 px-6 py-2.5 rounded-lg bg-coral text-white font-medium text-sm hover:opacity-90"
+          >
+            <Mail size={14} />
+            Sign In
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="max-w-5xl mx-auto p-6">
+        <p className="text-accent-red text-sm">Failed to load: {error}</p>
+        <button
+          onClick={fetchAll}
+          className="mt-3 inline-flex items-center gap-1.5 text-sm text-accent-brand hover:underline"
+        >
+          <RefreshCw size={14} /> Retry
+        </button>
+      </div>
+    );
+  }
+
+  const providers = providersResp?.providers ?? [];
+
+  return (
+    <div className="max-w-5xl mx-auto p-6 space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-text-primary">My Machines</h1>
+          <p className="text-sm text-text-tertiary mt-0.5">
+            Health, earnings, and warnings across every provider linked to your account.
+          </p>
+        </div>
+        <button
+          onClick={fetchAll}
+          disabled={refreshing}
+          className="inline-flex items-center gap-1.5 text-sm text-text-tertiary hover:text-text-primary disabled:opacity-50"
+        >
+          <RefreshCw size={14} className={refreshing ? "animate-spin" : ""} /> Refresh
+        </button>
+      </div>
+
+      {summary && <SummaryHeader summary={summary} />}
+      {summary && <PayoutBanner summary={summary} />}
+
+      {providers.length === 0 ? (
+        <EmptyState />
+      ) : (
+        <div className="space-y-4">
+          {providers.map((p) => (
+            <MachineCard key={p.id} provider={p} ctx={providersResp!} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function SummaryHeader({ summary }: { summary: MySummaryResponse }) {
+  const cards = [
+    {
+      label: "Online",
+      value: `${summary.counts.online + summary.counts.serving} of ${summary.counts.total}`,
+      icon: Activity,
+    },
+    {
+      label: "Lifetime",
+      value: formatUSD(summary.lifetime_micro_usd),
+      sub: `${summary.lifetime_jobs.toLocaleString()} jobs`,
+    },
+    { label: "Last 7d", value: formatUSD(summary.last_7d_micro_usd), sub: `${summary.last_7d_jobs} jobs` },
+    { label: "Last 24h", value: formatUSD(summary.last_24h_micro_usd), sub: `${summary.last_24h_jobs} jobs` },
+    { label: "Available", value: formatUSD(summary.available_balance_micro_usd), icon: Wallet },
+  ];
+  return (
+    <div className="grid grid-cols-2 md:grid-cols-5 gap-3">
+      {cards.map(({ label, value, sub, icon: Icon }) => (
+        <div key={label} className="rounded-xl bg-bg-secondary shadow-sm p-4">
+          <div className="flex items-center gap-1.5 mb-1">
+            {Icon ? <Icon size={12} className="text-text-tertiary" /> : null}
+            <p className="text-xs text-text-tertiary">{label}</p>
+          </div>
+          <p className="text-xl font-bold text-text-primary">{value}</p>
+          {sub && <p className="text-[11px] text-text-tertiary mt-0.5">{sub}</p>}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function PayoutBanner({ summary }: { summary: MySummaryResponse }) {
+  if (summary.counts.total === 0) return null;
+  if (summary.wallet_address) return null;
+  return (
+    <div className="rounded-xl border border-accent-amber/40 bg-accent-amber/5 p-4 flex items-start gap-3">
+      <AlertTriangle size={16} className="text-accent-amber shrink-0 mt-0.5" />
+      <div className="flex-1">
+        <p className="text-sm font-medium text-text-primary">No payout wallet on this account</p>
+        <p className="text-xs text-text-secondary mt-0.5">
+          Earnings are accruing to your account balance, but you can&apos;t withdraw until a Solana wallet is linked.
+        </p>
+      </div>
+      <Link
+        href="/billing"
+        className="text-xs font-medium text-accent-brand hover:underline whitespace-nowrap"
+      >
+        Set up wallet <ArrowRight size={11} className="inline" />
+      </Link>
+    </div>
+  );
+}
+
+function EmptyState() {
+  return (
+    <div className="rounded-xl bg-bg-secondary shadow-sm p-8 text-center">
+      <Cpu size={32} className="mx-auto mb-3 text-text-tertiary" />
+      <h3 className="text-base font-semibold text-text-primary mb-1">No machines linked yet</h3>
+      <p className="text-sm text-text-secondary mb-4">
+        Run <code className="bg-bg-tertiary px-1.5 py-0.5 rounded">darkbloom login</code> on a provider to link it to this account.
+      </p>
+      <Link
+        href="/providers/setup"
+        className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-accent-brand text-white text-sm font-medium hover:bg-accent-brand-hover"
+      >
+        Set up a provider <ArrowRight size={14} />
+      </Link>
+    </div>
+  );
+}
+
+function StatusPill({ status }: { status: string }) {
+  const config: Record<string, { color: string; label: string }> = {
+    serving: { color: "bg-accent-green text-white", label: "Serving" },
+    online: { color: "bg-accent-green/20 text-accent-green", label: "Online" },
+    offline: { color: "bg-text-tertiary/20 text-text-tertiary", label: "Offline" },
+    untrusted: { color: "bg-accent-red/20 text-accent-red", label: "Untrusted" },
+    never_seen: { color: "bg-text-tertiary/20 text-text-tertiary", label: "Never seen" },
+  };
+  const c = config[status] || { color: "bg-text-tertiary/20 text-text-tertiary", label: status };
+  return (
+    <span className={`inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full text-[10px] font-semibold uppercase tracking-wider ${c.color}`}>
+      <span className={`w-1.5 h-1.5 rounded-full ${status === "serving" || status === "online" ? "bg-accent-green" : "bg-current opacity-60"}`} />
+      {c.label}
+    </span>
+  );
+}
+
+function severityChip(sev: WarningSeverity) {
+  switch (sev) {
+    case "blocking":
+      return { color: "text-accent-red bg-accent-red/10", icon: XCircle };
+    case "degrading":
+      return { color: "text-accent-amber bg-accent-amber/10", icon: AlertTriangle };
+    default:
+      return { color: "text-accent-brand bg-accent-brand/10", icon: Info };
+  }
+}
+
+function MachineCard({ provider, ctx }: { provider: MyProvider; ctx: MyProvidersResponse }) {
+  const warnings = useMemo(() => computeWarnings(provider, ctx), [provider, ctx]);
+  const top = highestSeverity(warnings);
+  const [showAttestation, setShowAttestation] = useState(false);
+  const [showBackend, setShowBackend] = useState(false);
+
+  const ringColor =
+    top === "blocking"
+      ? "border-accent-red/40"
+      : top === "degrading"
+        ? "border-accent-amber/40"
+        : "border-transparent";
+
+  const chipName = provider.hardware.chip_name || "Unknown chip";
+  const memoryGB = provider.hardware.memory_gb ?? 0;
+  const gpuCores = provider.hardware.gpu_cores ?? 0;
+
+  return (
+    <div className={`rounded-xl bg-bg-secondary shadow-sm overflow-hidden border ${ringColor}`}>
+      <div className="p-4 flex flex-wrap items-start justify-between gap-3">
+        <div className="flex items-center gap-3 min-w-0">
+          <div className="w-10 h-10 rounded-lg bg-accent-brand/10 flex items-center justify-center shrink-0">
+            <Cpu size={20} className="text-accent-brand" />
+          </div>
+          <div className="min-w-0">
+            <h3 className="text-sm font-semibold text-text-primary truncate">{chipName}</h3>
+            <p className="text-xs text-text-tertiary font-mono truncate">
+              {provider.hardware.machine_model || provider.id}
+              {provider.serial_number ? ` · ${maskSerial(provider.serial_number)}` : ""}
+              {provider.version ? ` · v${provider.version}` : ""}
+            </p>
+          </div>
+        </div>
+        <div className="flex items-center gap-2">
+          <StatusPill status={provider.status} />
+          {provider.trust_level === "hardware" ? (
+            <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-accent-green/10 text-accent-green text-[10px] font-semibold uppercase tracking-wider">
+              <ShieldCheck size={10} /> Hardware
+            </span>
+          ) : provider.trust_level === "self_signed" ? (
+            <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-accent-amber/10 text-accent-amber text-[10px] font-semibold uppercase tracking-wider">
+              Self-signed
+            </span>
+          ) : (
+            <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-text-tertiary/20 text-text-tertiary text-[10px] font-semibold uppercase tracking-wider">
+              Unverified
+            </span>
+          )}
+        </div>
+      </div>
+
+      {warnings.length > 0 && (
+        <div className="px-4 pb-3 space-y-1.5">
+          {warnings.map((w) => (
+            <WarningRow key={w.id} warning={w} />
+          ))}
+        </div>
+      )}
+
+      <div className="px-4 pb-4 grid grid-cols-2 md:grid-cols-4 gap-3 border-t border-border-dim/30 pt-3">
+        <Stat label="Earnings" value={formatUSD(provider.earnings_total_micro_usd)} sub={`${provider.earnings_count} jobs`} />
+        <Stat label="Memory" value={`${memoryGB} GB`} sub={`${gpuCores} GPU cores`} />
+        <Stat
+          label="Last seen"
+          value={
+            provider.last_heartbeat
+              ? formatRelative(provider.last_heartbeat)
+              : provider.last_seen
+                ? formatRelative(provider.last_seen)
+                : "never"
+          }
+        />
+        <Stat
+          label="Reputation"
+          value={provider.reputation.score.toFixed(2)}
+          sub={`${provider.reputation.successful_jobs}/${provider.reputation.total_jobs || 0} ok`}
+        />
+      </div>
+
+      {provider.system_metrics && (
+        <div className="px-4 pb-3 grid grid-cols-3 gap-3">
+          <Stat label="Mem pressure" value={`${(provider.system_metrics.memory_pressure * 100).toFixed(0)}%`} />
+          <Stat label="CPU usage" value={`${(provider.system_metrics.cpu_usage * 100).toFixed(0)}%`} />
+          <Stat label="Thermal" value={provider.system_metrics.thermal_state} capitalize />
+        </div>
+      )}
+
+      {(provider.warm_models?.length || provider.current_model) && (
+        <div className="px-4 pb-3">
+          <p className="text-xs text-text-tertiary mb-1.5">Models loaded</p>
+          <div className="flex flex-wrap gap-1.5">
+            {(provider.warm_models?.length ? provider.warm_models : provider.current_model ? [provider.current_model] : []).map((m) => (
+              <span
+                key={m}
+                className={`px-2 py-0.5 rounded-md text-xs font-mono ${
+                  m === provider.current_model
+                    ? "bg-accent-brand/15 text-accent-brand"
+                    : "bg-bg-tertiary text-text-secondary"
+                }`}
+              >
+                {m.split("/").pop()}
+                {m === provider.current_model ? " ●" : ""}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {provider.models.length > 0 && (
+        <div className="px-4 pb-3">
+          <p className="text-xs text-text-tertiary mb-1.5">Catalog models served ({provider.models.length})</p>
+          <div className="flex flex-wrap gap-1.5">
+            {provider.models.map((m) => (
+              <span key={m.id} className="px-2 py-0.5 rounded-md bg-bg-tertiary text-xs text-text-secondary font-mono">
+                {m.id.split("/").pop()}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+
+      <ExpandSection
+        label="Trust & attestation"
+        icon={ShieldCheck}
+        open={showAttestation}
+        onToggle={() => setShowAttestation(!showAttestation)}
+      >
+        <AttestationDetails p={provider} />
+      </ExpandSection>
+
+      {provider.backend_capacity && (
+        <ExpandSection
+          label="Backend slots"
+          icon={Zap}
+          open={showBackend}
+          onToggle={() => setShowBackend(!showBackend)}
+        >
+          <BackendDetails p={provider} />
+        </ExpandSection>
+      )}
+    </div>
+  );
+}
+
+function Stat({ label, value, sub, capitalize }: { label: string; value: string; sub?: string; capitalize?: boolean }) {
+  return (
+    <div className="rounded-lg bg-bg-primary/50 p-2.5">
+      <p className="text-xs text-text-tertiary mb-0.5">{label}</p>
+      <p className={`text-sm font-semibold text-text-primary ${capitalize ? "capitalize" : ""}`}>{value}</p>
+      {sub && <p className="text-[11px] text-text-tertiary mt-0.5">{sub}</p>}
+    </div>
+  );
+}
+
+function WarningRow({ warning }: { warning: Warning }) {
+  const { color, icon: Icon } = severityChip(warning.severity);
+  return (
+    <div className={`flex items-start gap-2 p-2 rounded-lg ${color}`}>
+      <Icon size={14} className="shrink-0 mt-0.5" />
+      <div className="text-xs">
+        <p className="font-medium">{warning.title}</p>
+        <p className="opacity-80 mt-0.5">{warning.detail}</p>
+      </div>
+    </div>
+  );
+}
+
+function ExpandSection({
+  label,
+  icon: Icon,
+  open,
+  onToggle,
+  children,
+}: {
+  label: string;
+  icon: typeof ShieldCheck;
+  open: boolean;
+  onToggle: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <>
+      <button
+        onClick={onToggle}
+        className="w-full flex items-center gap-2 px-4 py-2.5 border-t border-border-dim text-left hover:bg-bg-hover"
+      >
+        <Icon size={12} className="text-text-tertiary" />
+        <span className="text-xs text-text-secondary">{label}</span>
+        <ChevronDown size={12} className={`ml-auto text-text-tertiary transition-transform ${open ? "rotate-180" : ""}`} />
+      </button>
+      {open && <div className="px-4 py-3 border-t border-border-dim/50 space-y-3">{children}</div>}
+    </>
+  );
+}
+
+function CheckLine({ ok, label }: { ok: boolean; label: string }) {
+  return (
+    <div className="flex items-center gap-2 text-xs">
+      {ok ? (
+        <CheckCircle2 size={12} className="text-accent-green" />
+      ) : (
+        <XCircle size={12} className="text-accent-red" />
+      )}
+      <span className="text-text-secondary">{label}</span>
+    </div>
+  );
+}
+
+function AttestationDetails({ p }: { p: MyProvider }) {
+  return (
+    <>
+      <div>
+        <div className="flex items-center gap-1.5 mb-2">
+          <ShieldCheck size={12} className="text-text-tertiary" />
+          <span className="text-xs text-text-tertiary font-medium">Secure Enclave</span>
+        </div>
+        <div className="space-y-1">
+          <CheckLine ok={p.secure_enclave} label="Hardware-bound P-256 identity" />
+          <CheckLine ok={p.acme_verified} label="ACME device-attest-01" />
+          <CheckLine ok={p.se_key_bound} label="SE key bound to MDA nonce" />
+        </div>
+      </div>
+
+      <div>
+        <div className="flex items-center gap-1.5 mb-2">
+          <HardDrive size={12} className="text-text-tertiary" />
+          <span className="text-xs text-text-tertiary font-medium">OS Security</span>
+        </div>
+        <div className="space-y-1">
+          <CheckLine ok={p.sip_enabled} label="System Integrity Protection" />
+          <CheckLine ok={p.secure_boot_enabled} label="Secure Boot" />
+          <CheckLine ok={p.authenticated_root_enabled} label="Authenticated Root Volume" />
+          <CheckLine ok={p.runtime_verified} label="Runtime hashes match manifest" />
+        </div>
+      </div>
+
+      {p.mda_verified && (
+        <div>
+          <div className="flex items-center gap-1.5 mb-2">
+            <ShieldCheck size={12} className="text-text-tertiary" />
+            <span className="text-xs text-text-tertiary font-medium">Apple Device Attestation</span>
+          </div>
+          <div className="space-y-1 text-xs text-text-secondary">
+            <CheckLine ok label="Apple CA cert chain verified" />
+            {p.mda_serial && <div className="text-[11px] font-mono pl-5">Serial: {maskSerial(p.mda_serial)}</div>}
+            {p.mda_os_version && <div className="text-[11px] pl-5">macOS {p.mda_os_version}</div>}
+            {p.mda_sepos_version && <div className="text-[11px] pl-5">SEPOS {p.mda_sepos_version}</div>}
+          </div>
+        </div>
+      )}
+
+      {p.last_challenge_verified && (
+        <div className="text-xs text-text-tertiary">
+          Last attestation challenge: <span className="text-text-secondary">{formatRelative(p.last_challenge_verified)}</span>
+          {p.failed_challenges > 0 && (
+            <span className="ml-2 text-accent-amber">({p.failed_challenges} failed)</span>
+          )}
+        </div>
+      )}
+
+      {p.system_volume_hash && (
+        <div>
+          <p className="text-xs text-text-tertiary mb-1">System Volume Hash</p>
+          <p className="text-xs font-mono text-text-tertiary break-all bg-bg-tertiary rounded px-2 py-1">
+            {p.system_volume_hash}
+          </p>
+        </div>
+      )}
+
+      {p.mda_cert_chain_b64 && p.mda_cert_chain_b64.length > 0 && (
+        <a
+          href="https://www.apple.com/certificateauthority/private/"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-1 text-xs text-accent-brand hover:underline"
+        >
+          Verify against Apple Root CA <ExternalLink size={10} />
+        </a>
+      )}
+    </>
+  );
+}
+
+function BackendDetails({ p }: { p: MyProvider }) {
+  const cap = p.backend_capacity!;
+  return (
+    <>
+      <div className="grid grid-cols-3 gap-2 text-xs">
+        <Stat label="GPU active" value={`${cap.gpu_memory_active_gb.toFixed(1)} GB`} />
+        <Stat label="GPU peak" value={`${cap.gpu_memory_peak_gb.toFixed(1)} GB`} />
+        <Stat label="Concurrency" value={`${p.pending_requests} / ${p.max_concurrency}`} />
+      </div>
+      {cap.slots.length > 0 && (
+        <div className="space-y-1.5">
+          {cap.slots.map((s) => (
+            <div key={s.model} className="flex items-center justify-between rounded-md bg-bg-tertiary/50 px-2 py-1.5">
+              <span className="text-xs font-mono text-text-secondary truncate">{s.model.split("/").pop()}</span>
+              <div className="flex items-center gap-2 text-[11px]">
+                <span
+                  className={`px-1.5 py-0.5 rounded ${
+                    s.state === "running"
+                      ? "bg-accent-green/15 text-accent-green"
+                      : s.state === "crashed"
+                        ? "bg-accent-red/15 text-accent-red"
+                        : s.state === "idle_shutdown"
+                          ? "bg-accent-amber/15 text-accent-amber"
+                          : "bg-text-tertiary/15 text-text-tertiary"
+                  }`}
+                >
+                  {s.state}
+                </span>
+                <span className="text-text-tertiary">{s.num_running} run / {s.num_waiting} wait</span>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </>
+  );
+}

--- a/console-ui/src/app/providers/me/page.tsx
+++ b/console-ui/src/app/providers/me/page.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import { Loader2 } from "lucide-react";
+
+const MyMachinesContent = dynamic(() => import("./MyMachinesContent"), {
+  ssr: false,
+  loading: () => (
+    <div className="flex items-center justify-center h-64">
+      <Loader2 size={24} className="animate-spin text-accent-brand" />
+    </div>
+  ),
+});
+
+export default function MyMachinesPage() {
+  return <MyMachinesContent />;
+}

--- a/console-ui/src/app/providers/me/types.ts
+++ b/console-ui/src/app/providers/me/types.ts
@@ -1,0 +1,150 @@
+// Wire types for /v1/me/providers and /v1/me/summary, mirroring the Go
+// myProvider / myProvidersResponse / mySummaryResponse structs in
+// coordinator/internal/api/me_handlers.go.
+
+export interface MyHardware {
+  machine_model?: string;
+  chip_name?: string;
+  chip_family?: string;
+  chip_tier?: string;
+  memory_gb?: number;
+  memory_available_gb?: number;
+  cpu_cores?: { performance?: number; efficiency?: number };
+  gpu_cores?: number;
+  memory_bandwidth_gbs?: number;
+}
+
+export interface MyModelInfo {
+  id: string;
+  size_bytes?: number;
+  model_type?: string;
+  quantization?: string;
+  weight_hash?: string;
+}
+
+export interface MySystemMetrics {
+  memory_pressure: number;
+  cpu_usage: number;
+  thermal_state: "nominal" | "fair" | "serious" | "critical" | string;
+}
+
+export interface MyBackendSlot {
+  model: string;
+  state: "running" | "idle_shutdown" | "crashed" | "reloading" | string;
+  num_running: number;
+  num_waiting: number;
+  active_tokens: number;
+  max_tokens_potential: number;
+}
+
+export interface MyBackendCapacity {
+  slots: MyBackendSlot[];
+  gpu_memory_active_gb: number;
+  gpu_memory_peak_gb: number;
+  gpu_memory_cache_gb: number;
+  total_memory_gb: number;
+}
+
+export interface MyReputation {
+  score: number;
+  total_jobs: number;
+  successful_jobs: number;
+  failed_jobs: number;
+  total_uptime_seconds: number;
+  avg_response_time_ms: number;
+  challenges_passed: number;
+  challenges_failed: number;
+}
+
+export interface MyProvider {
+  id: string;
+  account_id: string;
+  status: "online" | "serving" | "offline" | "untrusted" | "never_seen" | string;
+  online: boolean;
+  last_heartbeat?: string;
+
+  hardware: MyHardware;
+  models: MyModelInfo[];
+  backend?: string;
+  version?: string;
+  serial_number?: string;
+
+  trust_level: "hardware" | "self_signed" | "none" | string;
+  attested: boolean;
+  mda_verified: boolean;
+  acme_verified: boolean;
+  se_key_bound: boolean;
+  se_public_key?: string;
+  secure_enclave: boolean;
+  sip_enabled: boolean;
+  secure_boot_enabled: boolean;
+  authenticated_root_enabled: boolean;
+  system_volume_hash?: string;
+  mda_cert_chain_b64?: string[];
+  mda_serial?: string;
+  mda_udid?: string;
+  mda_os_version?: string;
+  mda_sepos_version?: string;
+
+  runtime_verified: boolean;
+  python_hash?: string;
+  runtime_hash?: string;
+
+  last_challenge_verified?: string;
+  failed_challenges: number;
+
+  system_metrics?: MySystemMetrics;
+  backend_capacity?: MyBackendCapacity;
+  warm_models?: string[];
+  current_model?: string;
+  pending_requests: number;
+  max_concurrency: number;
+  prefill_tps?: number;
+  decode_tps?: number;
+
+  reputation: MyReputation;
+
+  lifetime_requests_served: number;
+  lifetime_tokens_generated: number;
+
+  earnings_total_micro_usd: number;
+  earnings_count: number;
+
+  wallet_address?: string;
+
+  registered_at?: string;
+  last_seen?: string;
+}
+
+export interface MyProvidersResponse {
+  providers: MyProvider[];
+  latest_provider_version: string;
+  min_provider_version: string;
+  heartbeat_timeout_seconds: number;
+  challenge_max_age_seconds: number;
+}
+
+export interface MyFleetCounts {
+  total: number;
+  online: number;
+  serving: number;
+  offline: number;
+  untrusted: number;
+  hardware: number;
+  needs_attention: number;
+}
+
+export interface MySummaryResponse {
+  account_id: string;
+  wallet_address?: string;
+  available_balance_micro_usd: number;
+  lifetime_micro_usd: number;
+  lifetime_jobs: number;
+  last_24h_micro_usd: number;
+  last_24h_jobs: number;
+  last_7d_micro_usd: number;
+  last_7d_jobs: number;
+  counts: MyFleetCounts;
+  latest_provider_version: string;
+  min_provider_version: string;
+}

--- a/console-ui/src/app/providers/me/warnings.ts
+++ b/console-ui/src/app/providers/me/warnings.ts
@@ -1,0 +1,311 @@
+// Warning derivation for the /providers/me dashboard.
+//
+// Each warning maps a provider state signal to a user-facing message.
+// Severity:
+//   - blocking: machine receives ZERO requests
+//   - degrading: machine still routable but fewer requests / lower priority
+//   - info: configuration issue worth surfacing (e.g. payout setup)
+//
+// Keep this in sync with coordinator/internal/registry/registry.go scoring
+// rules and FindProviderWithTrust exclusion checks.
+
+import type { MyProvider, MyProvidersResponse } from "./types";
+
+export type WarningSeverity = "blocking" | "degrading" | "info";
+
+export interface Warning {
+  id: string;
+  severity: WarningSeverity;
+  title: string;
+  detail: string;
+}
+
+export function semverLess(a: string, b: string): boolean {
+  if (!a) return Boolean(b);
+  if (!b) return false;
+  const ap = a.split(".").map((n) => parseInt(n, 10) || 0);
+  const bp = b.split(".").map((n) => parseInt(n, 10) || 0);
+  const len = Math.max(ap.length, bp.length);
+  for (let i = 0; i < len; i++) {
+    const av = ap[i] ?? 0;
+    const bv = bp[i] ?? 0;
+    if (av < bv) return true;
+    if (av > bv) return false;
+  }
+  return false;
+}
+
+export function computeWarnings(
+  p: MyProvider,
+  ctx: Pick<
+    MyProvidersResponse,
+    | "latest_provider_version"
+    | "min_provider_version"
+    | "heartbeat_timeout_seconds"
+    | "challenge_max_age_seconds"
+  >
+): Warning[] {
+  const out: Warning[] = [];
+
+  // ── Blocking: machine receives no requests ──
+  if (p.status === "untrusted" || p.failed_challenges >= 3) {
+    out.push({
+      id: "untrusted",
+      severity: "blocking",
+      title: "Blocked: failed attestation challenges",
+      detail: `${p.failed_challenges} consecutive challenge failures — the coordinator marked this machine untrusted and is not routing to it. Restart the provider and re-link the device.`,
+    });
+  } else if (p.status === "offline" || p.status === "never_seen") {
+    out.push({
+      id: "offline",
+      severity: "blocking",
+      title: p.status === "never_seen" ? "Never connected" : "Offline",
+      detail:
+        p.status === "never_seen"
+          ? "This machine has a stored record but hasn't connected since the coordinator restarted. Start the provider with `darkbloom start`."
+          : `No heartbeat in over ${ctx.heartbeat_timeout_seconds || 90} seconds. Start the provider with \`darkbloom start\` to come back online.`,
+    });
+  }
+
+  if (!p.runtime_verified) {
+    out.push({
+      id: "runtime_unverified",
+      severity: "blocking",
+      title: "Runtime hash mismatch",
+      detail:
+        "Provider runtime hashes do not match the known-good manifest. Reinstall with the latest installer to restore eligibility.",
+    });
+  }
+
+  if (
+    ctx.min_provider_version &&
+    p.version &&
+    semverLess(p.version, ctx.min_provider_version)
+  ) {
+    out.push({
+      id: "version_below_min",
+      severity: "blocking",
+      title: "Provider version below the minimum",
+      detail: `Running v${p.version}; the coordinator requires v${ctx.min_provider_version} or newer. Update with the install script before this machine can earn.`,
+    });
+  }
+
+  if (p.system_metrics?.thermal_state === "critical") {
+    out.push({
+      id: "thermal_critical",
+      severity: "blocking",
+      title: "Thermal state critical",
+      detail:
+        "Health factor is zero — the coordinator will not route work. Cool the machine and ensure adequate ventilation.",
+    });
+  }
+
+  // Stale attestation challenge — the coordinator excludes providers whose
+  // last challenge is older than `challenge_max_age_seconds` (typically 6 min).
+  if (
+    p.last_challenge_verified &&
+    p.status !== "offline" &&
+    p.status !== "untrusted" &&
+    p.status !== "never_seen"
+  ) {
+    const ageSec = (Date.now() - new Date(p.last_challenge_verified).getTime()) / 1000;
+    if (Number.isFinite(ageSec) && ageSec > (ctx.challenge_max_age_seconds || 360)) {
+      out.push({
+        id: "challenge_stale",
+        severity: "blocking",
+        title: "Attestation challenge stale",
+        detail: `Last challenge verified ${Math.round(ageSec / 60)} minutes ago. The coordinator drops providers from routing until a fresh handshake completes.`,
+      });
+    }
+  }
+
+  // Trust below the routing threshold. In production the coordinator's
+  // MinTrustLevel is "hardware", so anything below that gets ZERO requests
+  // (not just a reduced multiplier). We surface it as blocking and tell the
+  // user how to upgrade.
+  if (
+    p.trust_level !== "hardware" &&
+    p.status !== "offline" &&
+    p.status !== "untrusted" &&
+    p.status !== "never_seen"
+  ) {
+    if (p.trust_level === "self_signed") {
+      out.push({
+        id: "trust_self_signed",
+        severity: "blocking",
+        title: "Self-signed trust — below routing threshold",
+        detail:
+          "The network requires hardware-attested machines. Complete MDM enrollment + Apple Device Attestation to start receiving requests.",
+      });
+    } else {
+      out.push({
+        id: "trust_none",
+        severity: "blocking",
+        title: "No attestation — below routing threshold",
+        detail:
+          "This machine hasn't supplied a Secure Enclave attestation. Re-run the installer to register an SE-bound identity, then re-link the device.",
+      });
+    }
+  }
+
+  // ── Degrading: routable, but fewer / lower-quality requests ──
+
+  // Backend slot states reported as crashed score 0.05× — the provider can
+  // still be selected if it's the only candidate, but it loses routing
+  // priority sharply. Treat as degrading, not blocking.
+  const crashedSlots =
+    p.backend_capacity?.slots?.filter((s) => s.state === "crashed") ?? [];
+  if (crashedSlots.length > 0) {
+    out.push({
+      id: "backend_crashed",
+      severity: "degrading",
+      title: "Backend crashed (0.05× routing weight)",
+      detail: `Backend(s) for ${crashedSlots
+        .map((s) => s.model)
+        .join(", ")} report a crashed state. The coordinator will prefer healthier machines until you restart the provider.`,
+    });
+  }
+
+  if (
+    p.trust_level === "hardware" &&
+    !p.mda_verified &&
+    p.status !== "offline" &&
+    p.status !== "never_seen"
+  ) {
+    out.push({
+      id: "mda_missing",
+      severity: "degrading",
+      title: "Apple Device Attestation incomplete",
+      detail:
+        "MDA proves to consumers that this is a real Apple device. Without it, some consumers will skip this machine.",
+    });
+  }
+
+  if (p.system_metrics?.thermal_state === "serious") {
+    out.push({
+      id: "thermal_serious",
+      severity: "degrading",
+      title: "Thermal state serious (0.4× health)",
+      detail: "The system is throttling. Improve cooling to recover routing weight.",
+    });
+  } else if (p.system_metrics?.thermal_state === "fair") {
+    out.push({
+      id: "thermal_fair",
+      severity: "degrading",
+      title: "Thermal state fair (0.8× health)",
+      detail: "Mild thermal pressure detected.",
+    });
+  }
+
+  if ((p.system_metrics?.memory_pressure ?? 0) > 0.9) {
+    out.push({
+      id: "memory_pressure_high",
+      severity: "degrading",
+      title: "Memory pressure very high",
+      detail: `${(p.system_metrics!.memory_pressure * 100).toFixed(0)}% memory pressure caps health to 0.1×. Close other apps or upgrade RAM.`,
+    });
+  }
+
+  const idleSlots =
+    p.backend_capacity?.slots?.filter((s) => s.state === "idle_shutdown") ?? [];
+  if (idleSlots.length > 0) {
+    out.push({
+      id: "backend_idle_shutdown",
+      severity: "degrading",
+      title: "Backend cold (0.1× weight on cold start)",
+      detail: `Backend(s) for ${idleSlots
+        .map((s) => s.model)
+        .join(", ")} were unloaded after 1h of idle. Next request will pay a ~10–30s cold-start penalty.`,
+    });
+  }
+
+  if (p.reputation.total_jobs > 0) {
+    const successRate =
+      p.reputation.successful_jobs / p.reputation.total_jobs;
+    if (successRate < 0.8 && p.reputation.total_jobs >= 10) {
+      out.push({
+        id: "low_success_rate",
+        severity: "degrading",
+        title: `Job success rate low (${(successRate * 100).toFixed(0)}%)`,
+        detail: `Reputation score: ${p.reputation.score.toFixed(2)}. Investigate failed jobs in the logs to recover routing priority.`,
+      });
+    }
+  }
+
+  // No catalog models: provider is online and trusted but didn't pass any
+  // models through the coordinator's catalog filter (either none of its
+  // models are in the catalog, or weight hashes mismatched). Routing
+  // requires `model in p.Models`, so this is effectively blocking even
+  // though scoring doesn't zero it out.
+  if (
+    p.models.length === 0 &&
+    p.status !== "offline" &&
+    p.status !== "untrusted" &&
+    p.status !== "never_seen"
+  ) {
+    out.push({
+      id: "no_catalog_models",
+      severity: "blocking",
+      title: "No catalog models served",
+      detail:
+        "None of this machine's local models matched the coordinator catalog (or weight hashes did not match). Download an approved model and restart the provider.",
+    });
+  }
+
+  // ── Info: configuration to fix ──
+  if (
+    !p.account_id &&
+    !p.wallet_address &&
+    p.status !== "offline" &&
+    p.status !== "never_seen"
+  ) {
+    out.push({
+      id: "no_payout",
+      severity: "info",
+      title: "No payout method configured",
+      detail:
+        "This machine has no account link and no wallet address. Earnings cannot be claimed. Run `darkbloom login` to link to your account.",
+    });
+  }
+
+  if (
+    ctx.latest_provider_version &&
+    p.version &&
+    semverLess(p.version, ctx.latest_provider_version) &&
+    !out.some((w) => w.id === "version_below_min")
+  ) {
+    out.push({
+      id: "outdated_version",
+      severity: "info",
+      title: "Newer provider version available",
+      detail: `Running v${p.version}. Latest is v${ctx.latest_provider_version}. Update via the installer when convenient.`,
+    });
+  }
+
+  // Visibility check: if the machine should appear in the public marketplace
+  // (online + hardware trust) but isn't routable due to a stale challenge.
+  if (
+    p.status !== "offline" &&
+    p.status !== "untrusted" &&
+    p.status !== "never_seen" &&
+    p.trust_level === "hardware" &&
+    !p.last_challenge_verified
+  ) {
+    out.push({
+      id: "no_challenge_yet",
+      severity: "info",
+      title: "Awaiting first attestation challenge",
+      detail:
+        "The machine is online but the coordinator has not yet completed a challenge handshake. Routing will start within ~5 minutes.",
+    });
+  }
+
+  return out;
+}
+
+export function highestSeverity(warnings: Warning[]): WarningSeverity | null {
+  if (warnings.some((w) => w.severity === "blocking")) return "blocking";
+  if (warnings.some((w) => w.severity === "degrading")) return "degrading";
+  if (warnings.some((w) => w.severity === "info")) return "info";
+  return null;
+}

--- a/console-ui/src/app/providers/page.tsx
+++ b/console-ui/src/app/providers/page.tsx
@@ -358,38 +358,24 @@ export default function ProvidersPage() {
         </div>
       )}
 
-      {/* My provider dashboard */}
-      {myProvider && (
-        <div className="rounded-xl bg-accent-brand/5 shadow-sm p-6">
-          <h2 className="text-lg font-semibold text-text-primary mb-3">Your Provider Node</h2>
-          <div className="grid grid-cols-2 gap-2 sm:grid-cols-4 sm:gap-4">
+      {/* My machines CTA — visible whenever the user is signed in, since the
+          dashboard now lists all machines linked to their account (not just
+          the one matching the connected wallet). */}
+      {authenticated && (
+        <Link
+          href="/providers/me"
+          className="block rounded-xl bg-accent-brand/5 hover:bg-accent-brand/10 transition-colors shadow-sm p-6"
+        >
+          <div className="flex items-center justify-between gap-4">
             <div>
-              <p className="text-xs text-text-tertiary mb-1">Hardware</p>
-              <p className="text-sm font-semibold text-text-primary">{myProvider.chip_name}</p>
+              <h2 className="text-lg font-semibold text-text-primary mb-1">My Machines</h2>
+              <p className="text-sm text-text-secondary">
+                Status, earnings, and warnings for every provider linked to your account.
+              </p>
             </div>
-            <div>
-              <p className="text-xs text-text-tertiary mb-1">Status</p>
-              <div className="flex items-center gap-1.5">
-                <span className="w-2 h-2 rounded-full bg-accent-green" />
-                <p className="text-sm font-semibold text-text-primary capitalize">{myProvider.status || "online"}</p>
-              </div>
-            </div>
-            <div>
-              <p className="text-xs text-text-tertiary mb-1">Memory</p>
-              <p className="text-sm font-semibold text-text-primary">{myProvider.memory_gb} GB</p>
-            </div>
-            <div>
-              <p className="text-xs text-text-tertiary mb-1">Trust</p>
-              <TrustBadge level={myProvider.trust_level} mdaVerified={myProvider.mda_verified} />
-            </div>
+            <ArrowRight size={18} className="text-accent-brand shrink-0" />
           </div>
-          <Link
-            href="/providers/earnings"
-            className="inline-flex items-center gap-1.5 mt-4 text-sm text-accent-brand font-medium hover:underline"
-          >
-            View Earnings <ArrowRight size={14} />
-          </Link>
-        </div>
+        </Link>
       )}
 
       {/* Network overview */}

--- a/coordinator/internal/api/me_handlers.go
+++ b/coordinator/internal/api/me_handlers.go
@@ -1,0 +1,615 @@
+package api
+
+// Account-scoped "my fleet" endpoints used by the console-ui /providers/me dashboard.
+//
+// These endpoints answer "what machines does THIS user own, and are they earning?"
+// by merging persisted ProviderRecord state (which survives coordinator restarts and
+// includes offline machines) with the live registry.Provider snapshot (status,
+// heartbeat metrics, backend capacity).
+//
+// Authentication is Privy-only — these are user-scoped views, not API key
+// keyspaces. An API key not linked to a Privy account gets a 401.
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/eigeninference/coordinator/internal/attestation"
+	"github.com/eigeninference/coordinator/internal/protocol"
+	"github.com/eigeninference/coordinator/internal/registry"
+	"github.com/eigeninference/coordinator/internal/store"
+)
+
+// myReputation is the wire shape for a provider's reputation snapshot.
+type myReputation struct {
+	Score              float64 `json:"score"`
+	TotalJobs          int     `json:"total_jobs"`
+	SuccessfulJobs     int     `json:"successful_jobs"`
+	FailedJobs         int     `json:"failed_jobs"`
+	TotalUptimeSeconds int64   `json:"total_uptime_seconds"`
+	AvgResponseTimeMs  int64   `json:"avg_response_time_ms"`
+	ChallengesPassed   int     `json:"challenges_passed"`
+	ChallengesFailed   int     `json:"challenges_failed"`
+}
+
+// myProvider is the per-machine payload for /v1/me/providers.
+type myProvider struct {
+	ID        string `json:"id"`
+	AccountID string `json:"account_id"`
+
+	// Live operational state. Status is "offline" when the machine is not
+	// currently connected, "never_seen" when it has a stored record but has
+	// not connected since the coordinator started, otherwise mirrors the
+	// registry status (online|serving|untrusted).
+	Status        string     `json:"status"`
+	Online        bool       `json:"online"`
+	LastHeartbeat *time.Time `json:"last_heartbeat,omitempty"`
+
+	// Identity / hardware
+	Hardware     protocol.Hardware    `json:"hardware"`
+	Models       []protocol.ModelInfo `json:"models"`
+	Backend      string               `json:"backend,omitempty"`
+	Version      string               `json:"version,omitempty"`
+	SerialNumber string               `json:"serial_number,omitempty"`
+
+	// Trust & attestation
+	TrustLevel        string   `json:"trust_level"`
+	Attested          bool     `json:"attested"`
+	MDAVerified       bool     `json:"mda_verified"`
+	ACMEVerified      bool     `json:"acme_verified"`
+	SEKeyBound        bool     `json:"se_key_bound"`
+	SEPublicKey       string   `json:"se_public_key,omitempty"`
+	SecureEnclave     bool     `json:"secure_enclave"`
+	SIPEnabled        bool     `json:"sip_enabled"`
+	SecureBootEnabled bool     `json:"secure_boot_enabled"`
+	AuthenticatedRoot bool     `json:"authenticated_root_enabled"`
+	SystemVolumeHash  string   `json:"system_volume_hash,omitempty"`
+	MDACertChain      []string `json:"mda_cert_chain_b64,omitempty"`
+	MDASerial         string   `json:"mda_serial,omitempty"`
+	MDAUDID           string   `json:"mda_udid,omitempty"`
+	MDAOSVersion      string   `json:"mda_os_version,omitempty"`
+	MDASEPVersion     string   `json:"mda_sepos_version,omitempty"`
+
+	// Runtime integrity
+	RuntimeVerified bool   `json:"runtime_verified"`
+	PythonHash      string `json:"python_hash,omitempty"`
+	RuntimeHash     string `json:"runtime_hash,omitempty"`
+
+	// Challenge state
+	LastChallengeVerified *time.Time `json:"last_challenge_verified,omitempty"`
+	FailedChallenges      int        `json:"failed_challenges"`
+
+	// Live snapshot (only set when the machine is currently connected)
+	SystemMetrics   *protocol.SystemMetrics   `json:"system_metrics,omitempty"`
+	BackendCapacity *protocol.BackendCapacity `json:"backend_capacity,omitempty"`
+	WarmModels      []string                  `json:"warm_models,omitempty"`
+	CurrentModel    string                    `json:"current_model,omitempty"`
+	PendingRequests int                       `json:"pending_requests"`
+	MaxConcurrency  int                       `json:"max_concurrency"`
+	PrefillTPS      float64                   `json:"prefill_tps,omitempty"`
+	DecodeTPS       float64                   `json:"decode_tps,omitempty"`
+
+	// Reputation
+	Reputation myReputation `json:"reputation"`
+
+	// Lifetime stats
+	LifetimeRequestsServed  int64 `json:"lifetime_requests_served"`
+	LifetimeTokensGenerated int64 `json:"lifetime_tokens_generated"`
+
+	// Per-node earnings (lifetime).
+	EarningsTotalMicroUSD int64 `json:"earnings_total_micro_usd"`
+	EarningsCount         int64 `json:"earnings_count"`
+
+	// Payout configuration
+	WalletAddress string `json:"wallet_address,omitempty"`
+
+	// Timestamps
+	RegisteredAt *time.Time `json:"registered_at,omitempty"`
+	LastSeen     *time.Time `json:"last_seen,omitempty"`
+}
+
+type myProvidersResponse struct {
+	Providers             []myProvider `json:"providers"`
+	LatestProviderVersion string       `json:"latest_provider_version"`
+	MinProviderVersion    string       `json:"min_provider_version"`
+	HeartbeatTimeoutSec   int          `json:"heartbeat_timeout_seconds"`
+	ChallengeMaxAgeSec    int          `json:"challenge_max_age_seconds"`
+}
+
+// myFleetCounts aggregates machine counts by status for the dashboard header.
+type myFleetCounts struct {
+	Total     int `json:"total"`
+	Online    int `json:"online"`          // status==online
+	Serving   int `json:"serving"`         // status==serving
+	Offline   int `json:"offline"`         // status==offline OR never_seen
+	Untrusted int `json:"untrusted"`       // status==untrusted
+	Hardware  int `json:"hardware"`        // trust_level==hardware
+	NeedsAttn int `json:"needs_attention"` // any of: !runtime_verified, trust!=hardware, untrusted, version below min
+}
+
+// mySummaryResponse is the page-level dashboard header at /v1/me/summary.
+type mySummaryResponse struct {
+	AccountID                string        `json:"account_id"`
+	WalletAddress            string        `json:"wallet_address,omitempty"`
+	AvailableBalanceMicroUSD int64         `json:"available_balance_micro_usd"`
+	LifetimeMicroUSD         int64         `json:"lifetime_micro_usd"`
+	LifetimeJobs             int64         `json:"lifetime_jobs"`
+	Last24hMicroUSD          int64         `json:"last_24h_micro_usd"`
+	Last24hJobs              int64         `json:"last_24h_jobs"`
+	Last7dMicroUSD           int64         `json:"last_7d_micro_usd"`
+	Last7dJobs               int64         `json:"last_7d_jobs"`
+	Counts                   myFleetCounts `json:"counts"`
+	LatestProviderVersion    string        `json:"latest_provider_version"`
+	MinProviderVersion       string        `json:"min_provider_version"`
+}
+
+// handleMySummary returns aggregate earnings + fleet counts for the dashboard
+// header. Implemented in the same file because it shares the merge logic for
+// counting per-machine status.
+func (s *Server) handleMySummary(w http.ResponseWriter, r *http.Request) {
+	user := s.requirePrivyUser(w, r)
+	if user == nil {
+		return
+	}
+	accountID := user.AccountID
+
+	// Aggregate earnings across all linked nodes.
+	summary, err := s.store.GetAccountEarningsSummary(accountID)
+	if err != nil {
+		s.logger.Error("get account earnings summary failed", "error", err)
+		writeJSON(w, http.StatusInternalServerError, errorResponse("internal_error", "failed to fetch earnings"))
+		return
+	}
+
+	// Time-windowed earnings — pull recent earnings (capped) and bucket them
+	// in-process. The same data backs the dashboard's "last 24h / 7d" cards.
+	recent, err := s.store.GetAccountEarnings(accountID, 5000)
+	if err != nil {
+		s.logger.Error("get account earnings failed", "error", err)
+		writeJSON(w, http.StatusInternalServerError, errorResponse("internal_error", "failed to fetch earnings"))
+		return
+	}
+	now := time.Now()
+	cutoff24h := now.Add(-24 * time.Hour)
+	cutoff7d := now.Add(-7 * 24 * time.Hour)
+	var last24Money, last7dMoney int64
+	var last24Jobs, last7dJobs int64
+	for _, e := range recent {
+		if e.CreatedAt.After(cutoff7d) {
+			last7dMoney += e.AmountMicroUSD
+			last7dJobs++
+			if e.CreatedAt.After(cutoff24h) {
+				last24Money += e.AmountMicroUSD
+				last24Jobs++
+			}
+		}
+	}
+
+	// Compute fleet counts from persisted records, overlayed with live status.
+	records, err := s.store.ListProvidersByAccount(r.Context(), accountID)
+	if err != nil {
+		s.logger.Error("list providers by account failed", "account_id", accountID, "error", err)
+		writeJSON(w, http.StatusInternalServerError, errorResponse("internal_error", "failed to list providers"))
+		return
+	}
+	live := make(map[string]*registry.Provider)
+	s.registry.ForEachProvider(func(p *registry.Provider) {
+		p.Mu().Lock()
+		if p.AccountID == accountID {
+			live[p.ID] = p
+		}
+		p.Mu().Unlock()
+	})
+
+	deduped := dedupeRecordsByIdentity(records)
+	counts := myFleetCounts{}
+	seen := make(map[string]bool, len(deduped))
+	emitted := make([]myProvider, 0, len(deduped))
+	for i := range deduped {
+		mp := buildMyProvider(&deduped[i], live[deduped[i].ID])
+		seen[deduped[i].ID] = true
+		emitted = append(emitted, mp)
+		tallyCounts(&counts, &mp, s.minProviderVersion)
+	}
+	for id, p := range live {
+		if seen[id] {
+			continue
+		}
+		if liveMatchesEmittedIdentity(p, emitted) {
+			continue
+		}
+		mp := buildMyProvider(nil, p)
+		emitted = append(emitted, mp)
+		tallyCounts(&counts, &mp, s.minProviderVersion)
+	}
+
+	resp := mySummaryResponse{
+		AccountID:                accountID,
+		WalletAddress:            user.SolanaWalletAddress,
+		AvailableBalanceMicroUSD: s.store.GetBalance(accountID),
+		LifetimeMicroUSD:         summary.TotalMicroUSD,
+		LifetimeJobs:             summary.Count,
+		Last24hMicroUSD:          last24Money,
+		Last24hJobs:              last24Jobs,
+		Last7dMicroUSD:           last7dMoney,
+		Last7dJobs:               last7dJobs,
+		Counts:                   counts,
+		LatestProviderVersion:    LatestProviderVersion,
+		MinProviderVersion:       s.minProviderVersion,
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// tallyCounts updates the fleet aggregate based on one machine's merged state.
+func tallyCounts(c *myFleetCounts, mp *myProvider, minVersion string) {
+	c.Total++
+	switch mp.Status {
+	case "serving":
+		c.Serving++
+	case string(registry.StatusOnline):
+		c.Online++
+	case string(registry.StatusUntrusted):
+		c.Untrusted++
+	default: // offline, never_seen
+		c.Offline++
+	}
+	if mp.TrustLevel == string(registry.TrustHardware) {
+		c.Hardware++
+	}
+	if needsAttention(mp, minVersion) {
+		c.NeedsAttn++
+	}
+}
+
+// needsAttention is the server-side mirror of the client warning logic — it's
+// only used for the summary count, not for individual warning text. The UI
+// renders detailed warnings from the per-machine payload.
+func needsAttention(mp *myProvider, minVersion string) bool {
+	if mp.Status == string(registry.StatusUntrusted) {
+		return true
+	}
+	if mp.Status == "offline" || mp.Status == "never_seen" {
+		return true
+	}
+	if !mp.RuntimeVerified {
+		return true
+	}
+	if mp.TrustLevel != string(registry.TrustHardware) {
+		return true
+	}
+	if mp.FailedChallenges > 0 {
+		return true
+	}
+	if minVersion != "" && mp.Version != "" && semverLess(mp.Version, minVersion) {
+		return true
+	}
+	return false
+}
+
+// handleMyProviders returns the authenticated user's full provider fleet,
+// merging persisted records (so offline machines still appear) with the
+// live registry snapshot (status, heartbeat metrics, backend capacity).
+func (s *Server) handleMyProviders(w http.ResponseWriter, r *http.Request) {
+	user := s.requirePrivyUser(w, r)
+	if user == nil {
+		return
+	}
+	accountID := user.AccountID
+
+	records, err := s.store.ListProvidersByAccount(r.Context(), accountID)
+	if err != nil {
+		s.logger.Error("list providers by account failed", "account_id", accountID, "error", err)
+		writeJSON(w, http.StatusInternalServerError, errorResponse("internal_error", "failed to list providers"))
+		return
+	}
+
+	// Snapshot every live provider belonging to this account in one pass so
+	// we can merge live state into persisted records and pick up any live
+	// machine that hasn't been persisted yet (fresh registration race).
+	live := make(map[string]*registry.Provider)
+	s.registry.ForEachProvider(func(p *registry.Provider) {
+		p.Mu().Lock()
+		if p.AccountID == accountID {
+			live[p.ID] = p
+		}
+		p.Mu().Unlock()
+	})
+
+	// Build the response, persisted records first (covers offline machines).
+	// Provider.ID is generated per WebSocket session, so a machine that has
+	// reconnected since the coordinator booted accumulates multiple
+	// ProviderRecords with the same SerialNumber / SEPublicKey. Collapse them
+	// by stable identity, keeping the most recent (LastSeen) winner so the
+	// dashboard shows one card per physical machine.
+	deduped := dedupeRecordsByIdentity(records)
+	seen := make(map[string]bool, len(deduped))
+	out := make([]myProvider, 0, len(deduped))
+	for i := range deduped {
+		mp := buildMyProvider(&deduped[i], live[deduped[i].ID])
+		s.attachEarnings(&mp)
+		out = append(out, mp)
+		seen[deduped[i].ID] = true
+	}
+	// Append any live machine not yet persisted (or whose stable identity
+	// matches a stored record we already emitted).
+	for id, p := range live {
+		if seen[id] {
+			continue
+		}
+		if liveMatchesEmittedIdentity(p, out) {
+			continue
+		}
+		mp := buildMyProvider(nil, p)
+		s.attachEarnings(&mp)
+		out = append(out, mp)
+	}
+
+	resp := myProvidersResponse{
+		Providers:             out,
+		LatestProviderVersion: LatestProviderVersion,
+		MinProviderVersion:    s.minProviderVersion,
+		HeartbeatTimeoutSec:   90,
+		ChallengeMaxAgeSec:    int((6 * time.Minute).Seconds()),
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// recordIdentity returns the stable identity for a provider record, preferring
+// SerialNumber, then SEPublicKey, then the per-session ID as a last resort.
+// Two records with the same identity refer to the same physical machine.
+func recordIdentity(rec *store.ProviderRecord) string {
+	if rec.SerialNumber != "" {
+		return "serial:" + rec.SerialNumber
+	}
+	if rec.SEPublicKey != "" {
+		return "sekey:" + rec.SEPublicKey
+	}
+	return "id:" + rec.ID
+}
+
+// liveIdentity computes the same stable identity for a live registry provider
+// using the same serial/SE-key precedence so dedup keys are comparable.
+func liveIdentity(p *registry.Provider) string {
+	p.Mu().Lock()
+	defer p.Mu().Unlock()
+	if p.AttestationResult != nil {
+		if p.AttestationResult.SerialNumber != "" {
+			return "serial:" + p.AttestationResult.SerialNumber
+		}
+		if p.AttestationResult.PublicKey != "" {
+			return "sekey:" + p.AttestationResult.PublicKey
+		}
+	}
+	return "id:" + p.ID
+}
+
+// dedupeRecordsByIdentity collapses ProviderRecord rows that refer to the
+// same physical machine, keeping the most recently seen one. The input order
+// is the store's LastSeen-DESC order; we honour it for ties.
+func dedupeRecordsByIdentity(records []store.ProviderRecord) []store.ProviderRecord {
+	if len(records) <= 1 {
+		return records
+	}
+	picked := make(map[string]int, len(records))
+	for i := range records {
+		key := recordIdentity(&records[i])
+		if existing, ok := picked[key]; !ok || records[i].LastSeen.After(records[existing].LastSeen) {
+			picked[key] = i
+		}
+	}
+	out := make([]store.ProviderRecord, 0, len(picked))
+	for i := range records {
+		if picked[recordIdentity(&records[i])] == i {
+			out = append(out, records[i])
+		}
+	}
+	return out
+}
+
+// liveMatchesEmittedIdentity reports whether the live provider corresponds to
+// a machine we already emitted from the persisted-records pass. This avoids
+// duplicating a card when a stored record's session ID drifted from the live
+// session ID (post-reconnect) but they share a serial/SE key.
+func liveMatchesEmittedIdentity(p *registry.Provider, emitted []myProvider) bool {
+	id := liveIdentity(p)
+	for i := range emitted {
+		if emittedIdentity(&emitted[i]) == id {
+			return true
+		}
+	}
+	return false
+}
+
+func emittedIdentity(mp *myProvider) string {
+	if mp.SerialNumber != "" {
+		return "serial:" + mp.SerialNumber
+	}
+	if mp.SEPublicKey != "" {
+		return "sekey:" + mp.SEPublicKey
+	}
+	return "id:" + mp.ID
+}
+
+// attachEarnings populates the lifetime earnings fields. Lookup is keyed by
+// the SE public key (the stable hardware ID we record on every earning).
+// Wallet is omitted: account-linked machines pay into the account balance,
+// not a per-machine wallet.
+func (s *Server) attachEarnings(mp *myProvider) {
+	if mp.SEPublicKey == "" {
+		return
+	}
+	summary, err := s.store.GetProviderEarningsSummary(mp.SEPublicKey)
+	if err != nil {
+		// Log and continue — earnings shouldn't gate the dashboard.
+		s.logger.Debug("get provider earnings summary failed",
+			"provider_id", mp.ID, "error", err)
+		return
+	}
+	mp.EarningsTotalMicroUSD = summary.TotalMicroUSD
+	mp.EarningsCount = summary.Count
+}
+
+// buildMyProvider merges a persisted record with the live registry snapshot.
+// Either may be nil (a never-connected stored record OR a fresh registration
+// that hasn't been persisted yet), but at least one must be non-nil.
+func buildMyProvider(rec *store.ProviderRecord, live *registry.Provider) myProvider {
+	mp := myProvider{Status: "never_seen"}
+
+	// 1. Start from the persisted record (covers offline machines).
+	if rec != nil {
+		mp.ID = rec.ID
+		mp.AccountID = rec.AccountID
+		mp.Backend = rec.Backend
+		mp.Version = rec.Version
+		mp.SerialNumber = rec.SerialNumber
+		mp.TrustLevel = rec.TrustLevel
+		mp.Attested = rec.Attested
+		mp.MDAVerified = rec.MDAVerified
+		mp.ACMEVerified = rec.ACMEVerified
+		mp.SEPublicKey = rec.SEPublicKey
+		mp.RuntimeVerified = rec.RuntimeVerified
+		mp.PythonHash = rec.PythonHash
+		mp.RuntimeHash = rec.RuntimeHash
+		mp.LastChallengeVerified = rec.LastChallengeVerified
+		mp.FailedChallenges = rec.FailedChallenges
+		mp.LifetimeRequestsServed = rec.LifetimeRequestsServed
+		mp.LifetimeTokensGenerated = rec.LifetimeTokensGenerated
+		if !rec.RegisteredAt.IsZero() {
+			t := rec.RegisteredAt
+			mp.RegisteredAt = &t
+		}
+		if !rec.LastSeen.IsZero() {
+			t := rec.LastSeen
+			mp.LastSeen = &t
+		}
+		// Decode embedded JSON blobs.
+		if len(rec.Hardware) > 0 {
+			_ = json.Unmarshal(rec.Hardware, &mp.Hardware)
+		}
+		if len(rec.Models) > 0 {
+			_ = json.Unmarshal(rec.Models, &mp.Models)
+		}
+		// AttestationResult holds chip name, SE flags, OS security, system
+		// volume hash, etc. Source of truth when we don't have a live snapshot.
+		if len(rec.AttestationResult) > 0 {
+			var ar attestation.VerificationResult
+			if err := json.Unmarshal(rec.AttestationResult, &ar); err == nil {
+				if ar.SerialNumber != "" {
+					mp.SerialNumber = ar.SerialNumber
+				}
+				if ar.PublicKey != "" {
+					mp.SEPublicKey = ar.PublicKey
+				}
+				mp.SecureEnclave = ar.SecureEnclaveAvailable
+				mp.SIPEnabled = ar.SIPEnabled
+				mp.SecureBootEnabled = ar.SecureBootEnabled
+				mp.AuthenticatedRoot = ar.AuthenticatedRootEnabled
+				mp.SystemVolumeHash = ar.SystemVolumeHash
+			}
+		}
+		if len(rec.MDACertChain) > 0 {
+			var ders [][]byte
+			if err := json.Unmarshal(rec.MDACertChain, &ders); err == nil {
+				for _, der := range ders {
+					mp.MDACertChain = append(mp.MDACertChain, base64.StdEncoding.EncodeToString(der))
+				}
+			}
+		}
+		// Default to offline; will be overwritten below if we have a live snapshot.
+		mp.Status = "offline"
+	}
+
+	// 2. Overlay the live snapshot if present.
+	if live != nil {
+		live.Mu().Lock()
+		mp.ID = live.ID
+		if live.AccountID != "" {
+			mp.AccountID = live.AccountID
+		}
+		mp.Status = string(live.Status)
+		mp.Online = live.Status != registry.StatusOffline && live.Status != registry.StatusUntrusted
+		hb := live.LastHeartbeat
+		if !hb.IsZero() {
+			mp.LastHeartbeat = &hb
+		}
+		// Hardware / models from the live snapshot are authoritative because
+		// the provider may have re-registered with new specs.
+		mp.Hardware = live.Hardware
+		mp.Models = append([]protocol.ModelInfo{}, live.Models...)
+		mp.Backend = live.Backend
+		mp.Version = live.Version
+		mp.TrustLevel = string(live.TrustLevel)
+		mp.Attested = live.Attested
+		mp.MDAVerified = live.MDAVerified
+		mp.ACMEVerified = live.ACMEVerified
+		mp.SEKeyBound = live.SEKeyBound
+		mp.RuntimeVerified = live.RuntimeVerified
+		mp.PythonHash = live.PythonHash
+		mp.RuntimeHash = live.RuntimeHash
+		if !live.LastChallengeVerified.IsZero() {
+			t := live.LastChallengeVerified
+			mp.LastChallengeVerified = &t
+		}
+		mp.FailedChallenges = live.FailedChallenges
+		mp.LifetimeRequestsServed = live.Stats.RequestsServed
+		mp.LifetimeTokensGenerated = live.Stats.TokensGenerated
+		mp.PrefillTPS = live.PrefillTPS
+		mp.DecodeTPS = live.DecodeTPS
+		mp.WalletAddress = live.WalletAddress
+
+		if live.AttestationResult != nil {
+			ar := live.AttestationResult
+			if ar.SerialNumber != "" {
+				mp.SerialNumber = ar.SerialNumber
+			}
+			if ar.PublicKey != "" {
+				mp.SEPublicKey = ar.PublicKey
+			}
+			mp.SecureEnclave = ar.SecureEnclaveAvailable
+			mp.SIPEnabled = ar.SIPEnabled
+			mp.SecureBootEnabled = ar.SecureBootEnabled
+			mp.AuthenticatedRoot = ar.AuthenticatedRootEnabled
+			mp.SystemVolumeHash = ar.SystemVolumeHash
+		}
+		if len(live.MDACertChain) > 0 {
+			mp.MDACertChain = mp.MDACertChain[:0]
+			for _, der := range live.MDACertChain {
+				mp.MDACertChain = append(mp.MDACertChain, base64.StdEncoding.EncodeToString(der))
+			}
+		}
+		if live.MDAResult != nil {
+			mp.MDASerial = live.MDAResult.DeviceSerial
+			mp.MDAUDID = live.MDAResult.DeviceUDID
+			mp.MDAOSVersion = live.MDAResult.OSVersion
+			mp.MDASEPVersion = live.MDAResult.SepOSVersion
+		}
+		// Live system metrics & backend capacity.
+		sm := live.SystemMetrics
+		mp.SystemMetrics = &sm
+		if live.BackendCapacity != nil {
+			cap := *live.BackendCapacity
+			mp.BackendCapacity = &cap
+		}
+		mp.WarmModels = append([]string{}, live.WarmModels...)
+		mp.CurrentModel = live.CurrentModel
+		// Reputation snapshot.
+		mp.Reputation = myReputation{
+			Score:              live.Reputation.Score(),
+			TotalJobs:          live.Reputation.TotalJobs,
+			SuccessfulJobs:     live.Reputation.SuccessfulJobs,
+			FailedJobs:         live.Reputation.FailedJobs,
+			TotalUptimeSeconds: int64(live.Reputation.TotalUptime / time.Second),
+			AvgResponseTimeMs:  int64(live.Reputation.AvgResponseTime / time.Millisecond),
+			ChallengesPassed:   live.Reputation.ChallengesPassed,
+			ChallengesFailed:   live.Reputation.ChallengesFailed,
+		}
+		live.Mu().Unlock()
+		// Concurrency limit lookup acquires its own lock.
+		mp.PendingRequests = live.PendingCount()
+		mp.MaxConcurrency = live.MaxConcurrency()
+	}
+
+	return mp
+}

--- a/coordinator/internal/api/me_handlers_test.go
+++ b/coordinator/internal/api/me_handlers_test.go
@@ -1,0 +1,542 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/coordinator/internal/auth"
+	"github.com/eigeninference/coordinator/internal/protocol"
+	"github.com/eigeninference/coordinator/internal/registry"
+	"github.com/eigeninference/coordinator/internal/store"
+)
+
+// testMeServer creates a Server with an in-memory store, registry, and a
+// fake Privy user pre-seeded so handlers can resolve an account ID.
+func testMeServer(t *testing.T) (*Server, *store.MemoryStore, *registry.Registry, *store.User) {
+	t.Helper()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	st := store.NewMemory("admin-key")
+	reg := registry.New(logger)
+	srv := NewServer(reg, st, logger)
+
+	user := &store.User{
+		AccountID:           "acct-alice",
+		PrivyUserID:         "did:privy:alice",
+		Email:               "alice@example.com",
+		SolanaWalletAddress: "AliceWalletAddress11111111111111111111111111",
+	}
+	if err := st.CreateUser(user); err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+	return srv, st, reg, user
+}
+
+// authedReq returns a GET request with the given user in context, simulating
+// what requireAuth installs after Privy verification succeeds.
+func authedReq(method, target string, user *store.User) *http.Request {
+	r := httptest.NewRequest(method, target, nil)
+	ctx := context.WithValue(r.Context(), ctxKeyConsumer, user.AccountID)
+	ctx = context.WithValue(ctx, auth.CtxKeyUser, user)
+	return r.WithContext(ctx)
+}
+
+func TestMyProviders_RequiresPrivyAuth(t *testing.T) {
+	srv, _, _, _ := testMeServer(t)
+
+	// API-key-only auth (no Privy user in context) — should be rejected.
+	r := httptest.NewRequest(http.MethodGet, "/v1/me/providers", nil)
+	r = r.WithContext(context.WithValue(r.Context(), ctxKeyConsumer, "api-key-only"))
+	w := httptest.NewRecorder()
+	srv.handleMyProviders(w, r)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestMyProviders_EmptyFleet(t *testing.T) {
+	srv, _, _, user := testMeServer(t)
+
+	r := authedReq(http.MethodGet, "/v1/me/providers", user)
+	w := httptest.NewRecorder()
+	srv.handleMyProviders(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", w.Code, w.Body.String())
+	}
+	var resp myProvidersResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(resp.Providers) != 0 {
+		t.Fatalf("len = %d, want 0", len(resp.Providers))
+	}
+	if resp.LatestProviderVersion == "" {
+		t.Fatal("latest_provider_version should be populated")
+	}
+	if resp.HeartbeatTimeoutSec == 0 {
+		t.Fatal("heartbeat_timeout_seconds should be populated")
+	}
+}
+
+func TestMyProviders_PersistedOfflineMachineAppears(t *testing.T) {
+	srv, st, _, user := testMeServer(t)
+
+	hwJSON, _ := json.Marshal(protocol.Hardware{
+		MachineModel: "Mac15,8",
+		ChipName:     "Apple M3 Max",
+		MemoryGB:     64,
+		GPUCores:     40,
+	})
+	modelsJSON, _ := json.Marshal([]protocol.ModelInfo{
+		{ID: "mlx-community/Qwen3.5-9B-MLX-4bit", ModelType: "text"},
+	})
+	rec := store.ProviderRecord{
+		ID:                      "alice-machine-1",
+		AccountID:               user.AccountID,
+		Hardware:                hwJSON,
+		Models:                  modelsJSON,
+		Backend:                 "vllm-mlx",
+		TrustLevel:              "hardware",
+		Attested:                true,
+		MDAVerified:             true,
+		ACMEVerified:            true,
+		Version:                 "0.3.10",
+		RuntimeVerified:         true,
+		SerialNumber:            "C02XYZ1234",
+		LifetimeRequestsServed:  5_000,
+		LifetimeTokensGenerated: 1_000_000,
+		RegisteredAt:            time.Now().Add(-24 * time.Hour),
+		LastSeen:                time.Now().Add(-30 * time.Minute),
+	}
+	if err := st.UpsertProvider(context.Background(), rec); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+
+	r := authedReq(http.MethodGet, "/v1/me/providers", user)
+	w := httptest.NewRecorder()
+	srv.handleMyProviders(w, r)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", w.Code, w.Body.String())
+	}
+	var resp myProvidersResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(resp.Providers) != 1 {
+		t.Fatalf("len = %d, want 1", len(resp.Providers))
+	}
+	got := resp.Providers[0]
+	if got.ID != "alice-machine-1" {
+		t.Fatalf("id = %q, want alice-machine-1", got.ID)
+	}
+	if got.Status != "offline" {
+		t.Fatalf("status = %q, want offline", got.Status)
+	}
+	if got.Online {
+		t.Fatal("online should be false for an offline machine")
+	}
+	if got.Hardware.ChipName != "Apple M3 Max" {
+		t.Fatalf("hardware.chip_name = %q, want Apple M3 Max", got.Hardware.ChipName)
+	}
+	if got.LifetimeRequestsServed != 5_000 {
+		t.Fatalf("lifetime requests = %d, want 5000", got.LifetimeRequestsServed)
+	}
+	if !got.MDAVerified {
+		t.Fatal("mda_verified should be true from persisted record")
+	}
+	if got.SystemMetrics != nil {
+		t.Fatal("system_metrics should be nil for offline machine (no live snapshot)")
+	}
+}
+
+func TestMyProviders_AccountIsolation(t *testing.T) {
+	srv, st, _, alice := testMeServer(t)
+
+	bob := &store.User{
+		AccountID:   "acct-bob",
+		PrivyUserID: "did:privy:bob",
+		Email:       "bob@example.com",
+	}
+	if err := st.CreateUser(bob); err != nil {
+		t.Fatalf("create bob: %v", err)
+	}
+
+	for _, rec := range []store.ProviderRecord{
+		{ID: "alice-1", AccountID: alice.AccountID, LastSeen: time.Now()},
+		{ID: "alice-2", AccountID: alice.AccountID, LastSeen: time.Now().Add(-time.Hour)},
+		{ID: "bob-1", AccountID: bob.AccountID, LastSeen: time.Now()},
+		{ID: "anon-1", AccountID: "", LastSeen: time.Now()},
+	} {
+		if err := st.UpsertProvider(context.Background(), rec); err != nil {
+			t.Fatalf("upsert: %v", err)
+		}
+	}
+
+	for _, tc := range []struct {
+		user *store.User
+		want []string
+	}{
+		{alice, []string{"alice-1", "alice-2"}},
+		{bob, []string{"bob-1"}},
+	} {
+		r := authedReq(http.MethodGet, "/v1/me/providers", tc.user)
+		w := httptest.NewRecorder()
+		srv.handleMyProviders(w, r)
+		if w.Code != http.StatusOK {
+			t.Fatalf("%s: status = %d", tc.user.AccountID, w.Code)
+		}
+		var resp myProvidersResponse
+		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("%s: unmarshal: %v", tc.user.AccountID, err)
+		}
+		if len(resp.Providers) != len(tc.want) {
+			t.Fatalf("%s: got %d providers, want %d", tc.user.AccountID, len(resp.Providers), len(tc.want))
+		}
+		for i, want := range tc.want {
+			if resp.Providers[i].ID != want {
+				t.Fatalf("%s: provider[%d].id = %q, want %q",
+					tc.user.AccountID, i, resp.Providers[i].ID, want)
+			}
+		}
+	}
+}
+
+// TestMyProviders_LiveMachineMergedOverPersisted checks that when a machine
+// is both persisted and currently connected, the live snapshot's status,
+// system metrics, and warm models override the stale persisted view.
+func TestMyProviders_LiveMachineMergedOverPersisted(t *testing.T) {
+	srv, st, reg, user := testMeServer(t)
+
+	// Persist a stale "offline" record first.
+	hwJSON, _ := json.Marshal(protocol.Hardware{ChipName: "Apple M3 Max", MemoryGB: 64})
+	modelsJSON, _ := json.Marshal([]protocol.ModelInfo{{ID: "model-a"}})
+	rec := store.ProviderRecord{
+		ID:        "live-machine",
+		AccountID: user.AccountID,
+		Hardware:  hwJSON,
+		Models:    modelsJSON,
+		Version:   "0.3.10",
+		LastSeen:  time.Now().Add(-1 * time.Hour),
+	}
+	if err := st.UpsertProvider(context.Background(), rec); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+
+	// Add a live registry entry with the same ID, attribute it to alice, and
+	// give it warm models + system metrics so we can confirm they leak through.
+	regMsg := &protocol.RegisterMessage{
+		Type:     protocol.TypeRegister,
+		Hardware: protocol.Hardware{ChipName: "Apple M3 Max", MemoryGB: 64},
+		Models:   []protocol.ModelInfo{{ID: "model-a"}},
+		Backend:  "vllm-mlx",
+		Version:  "0.3.10",
+	}
+	live := reg.Register("live-machine", nil, regMsg)
+	live.Mu().Lock()
+	live.AccountID = user.AccountID
+	live.Status = registry.StatusOnline
+	live.WarmModels = []string{"model-a"}
+	live.CurrentModel = "model-a"
+	live.SystemMetrics = protocol.SystemMetrics{
+		MemoryPressure: 0.4,
+		CPUUsage:       0.2,
+		ThermalState:   "nominal",
+	}
+	live.LastChallengeVerified = time.Now()
+	live.RuntimeVerified = true
+	live.TrustLevel = registry.TrustHardware
+	live.Attested = true
+	live.Mu().Unlock()
+
+	r := authedReq(http.MethodGet, "/v1/me/providers", user)
+	w := httptest.NewRecorder()
+	srv.handleMyProviders(w, r)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d", w.Code)
+	}
+	var resp myProvidersResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(resp.Providers) != 1 {
+		t.Fatalf("len = %d, want 1 (live and stored should merge, not duplicate)", len(resp.Providers))
+	}
+	got := resp.Providers[0]
+	if got.Status != string(registry.StatusOnline) {
+		t.Fatalf("status = %q, want online (live overrides persisted offline)", got.Status)
+	}
+	if !got.Online {
+		t.Fatal("online should be true")
+	}
+	if got.LastHeartbeat == nil {
+		t.Fatal("last_heartbeat should be present for live machine")
+	}
+	if got.SystemMetrics == nil || got.SystemMetrics.ThermalState != "nominal" {
+		t.Fatalf("system_metrics not populated correctly: %+v", got.SystemMetrics)
+	}
+	if got.CurrentModel != "model-a" {
+		t.Fatalf("current_model = %q, want model-a", got.CurrentModel)
+	}
+}
+
+// TestMyProviders_ReconnectDoesNotDuplicate covers the case where a physical
+// machine reconnected after the coordinator restarted, leaving an old
+// ProviderRecord with the previous session ID and creating a new one with
+// the current session ID. The dashboard must collapse them by stable identity
+// (serial / SE pubkey) so the user sees one card per machine, not two.
+func TestMyProviders_ReconnectDoesNotDuplicate(t *testing.T) {
+	srv, st, _, user := testMeServer(t)
+
+	const serial = "C02XYZ1234"
+	hwJSON, _ := json.Marshal(protocol.Hardware{ChipName: "Apple M3 Max", MemoryGB: 64})
+	modelsJSON, _ := json.Marshal([]protocol.ModelInfo{{ID: "model-a"}})
+
+	// First session: stale record from before the coordinator restart.
+	old := store.ProviderRecord{
+		ID:           "session-old",
+		AccountID:    user.AccountID,
+		Hardware:     hwJSON,
+		Models:       modelsJSON,
+		SerialNumber: serial,
+		LastSeen:     time.Now().Add(-2 * time.Hour),
+	}
+	// Second session: same physical machine reconnected — new ID, same serial.
+	current := store.ProviderRecord{
+		ID:           "session-new",
+		AccountID:    user.AccountID,
+		Hardware:     hwJSON,
+		Models:       modelsJSON,
+		SerialNumber: serial,
+		LastSeen:     time.Now(),
+	}
+	for _, rec := range []store.ProviderRecord{old, current} {
+		if err := st.UpsertProvider(context.Background(), rec); err != nil {
+			t.Fatalf("upsert: %v", err)
+		}
+	}
+
+	r := authedReq(http.MethodGet, "/v1/me/providers", user)
+	w := httptest.NewRecorder()
+	srv.handleMyProviders(w, r)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d", w.Code)
+	}
+	var resp myProvidersResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(resp.Providers) != 1 {
+		t.Fatalf("got %d providers, want 1 (reconnect duplicates should collapse)", len(resp.Providers))
+	}
+	if resp.Providers[0].ID != "session-new" {
+		t.Fatalf("kept ID = %q, want session-new (most recent LastSeen)", resp.Providers[0].ID)
+	}
+}
+
+// TestMyProviders_LiveOnlyMachineAppears covers the race where a provider has
+// just connected and not yet been persisted: we should still surface it.
+func TestMyProviders_LiveOnlyMachineAppears(t *testing.T) {
+	srv, _, reg, user := testMeServer(t)
+
+	regMsg := &protocol.RegisterMessage{
+		Type:     protocol.TypeRegister,
+		Hardware: protocol.Hardware{ChipName: "Apple M2", MemoryGB: 24},
+	}
+	live := reg.Register("fresh-machine", nil, regMsg)
+	live.Mu().Lock()
+	live.AccountID = user.AccountID
+	live.Mu().Unlock()
+
+	r := authedReq(http.MethodGet, "/v1/me/providers", user)
+	w := httptest.NewRecorder()
+	srv.handleMyProviders(w, r)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d", w.Code)
+	}
+	var resp myProvidersResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(resp.Providers) != 1 || resp.Providers[0].ID != "fresh-machine" {
+		t.Fatalf("expected fresh-machine, got %+v", resp.Providers)
+	}
+}
+
+// TestMyProviders_EarningsAttached covers the SE-public-key earnings join.
+func TestMyProviders_EarningsAttached(t *testing.T) {
+	srv, st, _, user := testMeServer(t)
+
+	const sePub = "se-pubkey-base64-fingerprint"
+	hwJSON, _ := json.Marshal(protocol.Hardware{ChipName: "M3 Max", MemoryGB: 64})
+	modelsJSON, _ := json.Marshal([]protocol.ModelInfo{})
+	rec := store.ProviderRecord{
+		ID:          "alice-earner",
+		AccountID:   user.AccountID,
+		Hardware:    hwJSON,
+		Models:      modelsJSON,
+		SEPublicKey: sePub,
+		LastSeen:    time.Now(),
+	}
+	if err := st.UpsertProvider(context.Background(), rec); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	for i := 0; i < 3; i++ {
+		if err := st.RecordProviderEarning(&store.ProviderEarning{
+			AccountID:      user.AccountID,
+			ProviderID:     "alice-earner",
+			ProviderKey:    sePub,
+			JobID:          "job-x",
+			AmountMicroUSD: 100_000,
+			CreatedAt:      time.Now(),
+		}); err != nil {
+			t.Fatalf("record earning: %v", err)
+		}
+	}
+
+	r := authedReq(http.MethodGet, "/v1/me/providers", user)
+	w := httptest.NewRecorder()
+	srv.handleMyProviders(w, r)
+
+	var resp myProvidersResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(resp.Providers) != 1 {
+		t.Fatalf("len = %d", len(resp.Providers))
+	}
+	got := resp.Providers[0]
+	if got.EarningsCount != 3 {
+		t.Fatalf("earnings_count = %d, want 3", got.EarningsCount)
+	}
+	if got.EarningsTotalMicroUSD != 300_000 {
+		t.Fatalf("earnings_total_micro_usd = %d, want 300000", got.EarningsTotalMicroUSD)
+	}
+}
+
+// --- /v1/me/summary ---
+
+func TestMySummary_RequiresPrivyAuth(t *testing.T) {
+	srv, _, _, _ := testMeServer(t)
+	r := httptest.NewRequest(http.MethodGet, "/v1/me/summary", nil)
+	r = r.WithContext(context.WithValue(r.Context(), ctxKeyConsumer, "api-key-only"))
+	w := httptest.NewRecorder()
+	srv.handleMySummary(w, r)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", w.Code)
+	}
+}
+
+func TestMySummary_EmptyAccount(t *testing.T) {
+	srv, _, _, user := testMeServer(t)
+	r := authedReq(http.MethodGet, "/v1/me/summary", user)
+	w := httptest.NewRecorder()
+	srv.handleMySummary(w, r)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d", w.Code)
+	}
+	var resp mySummaryResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp.AccountID != user.AccountID {
+		t.Fatalf("account_id = %q", resp.AccountID)
+	}
+	if resp.LifetimeMicroUSD != 0 || resp.LifetimeJobs != 0 {
+		t.Fatalf("expected zero earnings, got %+v", resp)
+	}
+	if resp.Counts.Total != 0 {
+		t.Fatalf("counts.total = %d, want 0", resp.Counts.Total)
+	}
+}
+
+func TestMySummary_BucketsEarningsAndCountsFleet(t *testing.T) {
+	srv, st, _, user := testMeServer(t)
+
+	now := time.Now()
+	earnings := []store.ProviderEarning{
+		{AccountID: user.AccountID, ProviderKey: "k", JobID: "old", AmountMicroUSD: 1_000_000, CreatedAt: now.Add(-30 * 24 * time.Hour)},
+		{AccountID: user.AccountID, ProviderKey: "k", JobID: "5d", AmountMicroUSD: 500_000, CreatedAt: now.Add(-5 * 24 * time.Hour)},
+		{AccountID: user.AccountID, ProviderKey: "k", JobID: "12h", AmountMicroUSD: 200_000, CreatedAt: now.Add(-12 * time.Hour)},
+		{AccountID: user.AccountID, ProviderKey: "k", JobID: "1m", AmountMicroUSD: 50_000, CreatedAt: now.Add(-time.Minute)},
+	}
+	for _, e := range earnings {
+		if err := st.CreditProviderAccount(&e); err != nil {
+			t.Fatalf("credit: %v", err)
+		}
+	}
+
+	// Fleet: one healthy hardware-trust online machine, one stale offline,
+	// one untrusted machine. Then check counts.
+	healthy := store.ProviderRecord{
+		ID:              "healthy",
+		AccountID:       user.AccountID,
+		TrustLevel:      "hardware",
+		RuntimeVerified: true,
+		Version:         "0.3.10",
+		LastSeen:        now,
+	}
+	offline := store.ProviderRecord{
+		ID:              "offline",
+		AccountID:       user.AccountID,
+		TrustLevel:      "hardware",
+		RuntimeVerified: true,
+		Version:         "0.3.10",
+		LastSeen:        now.Add(-10 * time.Hour),
+	}
+	selfSigned := store.ProviderRecord{
+		ID:              "self-signed",
+		AccountID:       user.AccountID,
+		TrustLevel:      "self_signed",
+		RuntimeVerified: true,
+		Version:         "0.3.10",
+		LastSeen:        now,
+	}
+	for _, rec := range []store.ProviderRecord{healthy, offline, selfSigned} {
+		if err := st.UpsertProvider(context.Background(), rec); err != nil {
+			t.Fatalf("upsert: %v", err)
+		}
+	}
+
+	r := authedReq(http.MethodGet, "/v1/me/summary", user)
+	w := httptest.NewRecorder()
+	srv.handleMySummary(w, r)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d", w.Code)
+	}
+	var resp mySummaryResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp.LifetimeMicroUSD != 1_750_000 {
+		t.Fatalf("lifetime = %d, want 1750000", resp.LifetimeMicroUSD)
+	}
+	if resp.Last7dMicroUSD != 750_000 {
+		t.Fatalf("last_7d = %d, want 750000 (5d + 12h + 1m)", resp.Last7dMicroUSD)
+	}
+	if resp.Last24hMicroUSD != 250_000 {
+		t.Fatalf("last_24h = %d, want 250000 (12h + 1m)", resp.Last24hMicroUSD)
+	}
+	if resp.AvailableBalanceMicroUSD != 1_750_000 {
+		t.Fatalf("available_balance = %d, want 1750000", resp.AvailableBalanceMicroUSD)
+	}
+	if resp.Counts.Total != 3 {
+		t.Fatalf("counts.total = %d, want 3", resp.Counts.Total)
+	}
+	if resp.Counts.Hardware != 2 {
+		t.Fatalf("counts.hardware = %d, want 2", resp.Counts.Hardware)
+	}
+	if resp.Counts.Offline < 1 {
+		t.Fatalf("counts.offline = %d, want at least 1", resp.Counts.Offline)
+	}
+	if resp.Counts.NeedsAttn < 2 {
+		t.Fatalf("counts.needs_attention = %d, want >= 2 (offline + self_signed)",
+			resp.Counts.NeedsAttn)
+	}
+}

--- a/coordinator/internal/api/server.go
+++ b/coordinator/internal/api/server.go
@@ -513,6 +513,10 @@ func (s *Server) routes() {
 	s.mux.HandleFunc("GET /v1/provider/node-earnings", s.handleNodeEarnings)
 	s.mux.HandleFunc("GET /v1/provider/account-earnings", s.requireAuth(s.handleAccountEarnings))
 
+	// Account-scoped fleet view powering the console-ui /providers/me dashboard.
+	s.mux.HandleFunc("GET /v1/me/providers", s.requireAuth(s.handleMyProviders))
+	s.mux.HandleFunc("GET /v1/me/summary", s.requireAuth(s.handleMySummary))
+
 	// ACME enrollment — generates per-device .mobileconfig for device-attest-01.
 	// No auth needed — security comes from Apple's attestation during ACME challenge.
 	s.mux.HandleFunc("POST /v1/enroll", s.handleEnroll)

--- a/coordinator/internal/store/interface.go
+++ b/coordinator/internal/store/interface.go
@@ -252,6 +252,11 @@ type Store interface {
 	// ListProviders returns all stored provider records.
 	ListProviderRecords(ctx context.Context) ([]ProviderRecord, error)
 
+	// ListProvidersByAccount returns provider records linked to the given account ID.
+	// Used by the /v1/me/providers dashboard. Returns an empty slice (not nil)
+	// when the account owns no providers. An empty accountID returns an empty slice.
+	ListProvidersByAccount(ctx context.Context, accountID string) ([]ProviderRecord, error)
+
 	// UpdateProviderLastSeen updates the last_seen timestamp for a provider.
 	UpdateProviderLastSeen(ctx context.Context, id string) error
 

--- a/coordinator/internal/store/memory.go
+++ b/coordinator/internal/store/memory.go
@@ -1161,6 +1161,25 @@ func (s *MemoryStore) ListProviderRecords(_ context.Context) ([]ProviderRecord, 
 	return records, nil
 }
 
+func (s *MemoryStore) ListProvidersByAccount(_ context.Context, accountID string) ([]ProviderRecord, error) {
+	if accountID == "" {
+		return []ProviderRecord{}, nil
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	records := make([]ProviderRecord, 0)
+	for _, p := range s.providerRecords {
+		if p.AccountID == accountID {
+			records = append(records, *p)
+		}
+	}
+	sort.Slice(records, func(i, j int) bool {
+		return records[i].LastSeen.After(records[j].LastSeen)
+	})
+	return records, nil
+}
+
 func (s *MemoryStore) UpdateProviderLastSeen(_ context.Context, id string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/coordinator/internal/store/postgres.go
+++ b/coordinator/internal/store/postgres.go
@@ -113,6 +113,7 @@ func (s *PostgresStore) migrate(ctx context.Context) error {
 		`DO $$ BEGIN ALTER TABLE providers ADD COLUMN IF NOT EXISTS last_session_requests_served BIGINT NOT NULL DEFAULT 0; EXCEPTION WHEN others THEN NULL; END $$`,
 		`DO $$ BEGIN ALTER TABLE providers ADD COLUMN IF NOT EXISTS last_session_tokens_generated BIGINT NOT NULL DEFAULT 0; EXCEPTION WHEN others THEN NULL; END $$`,
 		`CREATE INDEX IF NOT EXISTS idx_providers_serial ON providers(serial_number) WHERE serial_number != ''`,
+		`CREATE INDEX IF NOT EXISTS idx_providers_account ON providers(account_id, last_seen DESC) WHERE account_id != ''`,
 
 		// Migrate usage table: add request_id and cost columns
 		`DO $$ BEGIN ALTER TABLE usage ADD COLUMN IF NOT EXISTS request_id TEXT NOT NULL DEFAULT ''; EXCEPTION WHEN others THEN NULL; END $$`,
@@ -1928,6 +1929,52 @@ func (s *PostgresStore) ListProviderRecords(ctx context.Context) ([]ProviderReco
 	}
 	if records == nil {
 		return []ProviderRecord{}, nil
+	}
+	return records, nil
+}
+
+func (s *PostgresStore) ListProvidersByAccount(ctx context.Context, accountID string) ([]ProviderRecord, error) {
+	if accountID == "" {
+		return []ProviderRecord{}, nil
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	rows, err := s.pool.Query(ctx,
+		`SELECT id, hardware, models, backend, trust_level, attested,
+			attestation_result, se_public_key, serial_number,
+			mda_verified, mda_cert_chain, acme_verified,
+			version, runtime_verified, python_hash, runtime_hash,
+			last_challenge_verified, failed_challenges, account_id,
+			lifetime_requests_served, lifetime_tokens_generated,
+			last_session_requests_served, last_session_tokens_generated,
+			registered_at, last_seen
+		 FROM providers WHERE account_id = $1 ORDER BY last_seen DESC`,
+		accountID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("store: list providers by account: %w", err)
+	}
+	defer rows.Close()
+
+	records := make([]ProviderRecord, 0)
+	for rows.Next() {
+		var p ProviderRecord
+		if err := rows.Scan(
+			&p.ID, &p.Hardware, &p.Models, &p.Backend,
+			&p.TrustLevel, &p.Attested,
+			&p.AttestationResult, &p.SEPublicKey, &p.SerialNumber,
+			&p.MDAVerified, &p.MDACertChain, &p.ACMEVerified,
+			&p.Version, &p.RuntimeVerified, &p.PythonHash, &p.RuntimeHash,
+			&p.LastChallengeVerified, &p.FailedChallenges, &p.AccountID,
+			&p.LifetimeRequestsServed, &p.LifetimeTokensGenerated,
+			&p.LastSessionRequestsServed, &p.LastSessionTokensGenerated,
+			&p.RegisteredAt, &p.LastSeen,
+		); err != nil {
+			continue
+		}
+		records = append(records, p)
 	}
 	return records, nil
 }

--- a/coordinator/internal/store/provider_records_test.go
+++ b/coordinator/internal/store/provider_records_test.go
@@ -1,0 +1,156 @@
+package store
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestListProvidersByAccount_FiltersByAccount(t *testing.T) {
+	st := NewMemory("")
+	ctx := context.Background()
+
+	now := time.Now()
+	records := []ProviderRecord{
+		{ID: "alice-1", AccountID: "acct-alice", LastSeen: now.Add(-2 * time.Hour)},
+		{ID: "alice-2", AccountID: "acct-alice", LastSeen: now.Add(-1 * time.Hour)},
+		{ID: "bob-1", AccountID: "acct-bob", LastSeen: now},
+		{ID: "anon-1", AccountID: "", LastSeen: now},
+	}
+	for _, r := range records {
+		if err := st.UpsertProvider(ctx, r); err != nil {
+			t.Fatalf("upsert: %v", err)
+		}
+	}
+
+	got, err := st.ListProvidersByAccount(ctx, "acct-alice")
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("len = %d, want 2", len(got))
+	}
+	// Should be ordered by LastSeen DESC.
+	if got[0].ID != "alice-2" || got[1].ID != "alice-1" {
+		t.Fatalf("ordering wrong, got %v", []string{got[0].ID, got[1].ID})
+	}
+	for _, r := range got {
+		if r.AccountID != "acct-alice" {
+			t.Fatalf("leaked record from %q", r.AccountID)
+		}
+	}
+}
+
+func TestListProvidersByAccount_EmptyAccount(t *testing.T) {
+	st := NewMemory("")
+	ctx := context.Background()
+
+	if err := st.UpsertProvider(ctx, ProviderRecord{ID: "p1", AccountID: ""}); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+
+	got, err := st.ListProvidersByAccount(ctx, "")
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if got == nil {
+		t.Fatal("got nil, want empty slice")
+	}
+	if len(got) != 0 {
+		t.Fatalf("len = %d, want 0", len(got))
+	}
+}
+
+func TestListProvidersByAccount_UnknownAccount(t *testing.T) {
+	st := NewMemory("")
+	ctx := context.Background()
+
+	if err := st.UpsertProvider(ctx, ProviderRecord{ID: "p1", AccountID: "acct-real"}); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+
+	got, err := st.ListProvidersByAccount(ctx, "acct-ghost")
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if got == nil || len(got) != 0 {
+		t.Fatalf("got %v, want empty slice", got)
+	}
+}
+
+func TestListProvidersByAccount_AccountReassignment(t *testing.T) {
+	st := NewMemory("")
+	ctx := context.Background()
+
+	// Provider initially linked to alice, then re-linked to bob.
+	if err := st.UpsertProvider(ctx, ProviderRecord{ID: "p1", AccountID: "acct-alice", LastSeen: time.Now()}); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	if err := st.UpsertProvider(ctx, ProviderRecord{ID: "p1", AccountID: "acct-bob", LastSeen: time.Now()}); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+
+	aliceRecs, _ := st.ListProvidersByAccount(ctx, "acct-alice")
+	if len(aliceRecs) != 0 {
+		t.Fatalf("alice still has %d providers after reassignment", len(aliceRecs))
+	}
+	bobRecs, _ := st.ListProvidersByAccount(ctx, "acct-bob")
+	if len(bobRecs) != 1 || bobRecs[0].ID != "p1" {
+		t.Fatalf("bob should own p1, got %v", bobRecs)
+	}
+}
+
+// TestPostgresListProvidersByAccount mirrors the memory-store contract on the
+// real database. Skips when DATABASE_URL is unset (dev / CI without postgres).
+func TestPostgresListProvidersByAccount(t *testing.T) {
+	st := testPostgresStore(t)
+	ctx := context.Background()
+
+	now := time.Now()
+	for _, rec := range []ProviderRecord{
+		{ID: "alice-old", AccountID: "acct-alice", SerialNumber: "AAA1", LastSeen: now.Add(-2 * time.Hour)},
+		{ID: "alice-new", AccountID: "acct-alice", SerialNumber: "AAA2", LastSeen: now.Add(-1 * time.Hour)},
+		{ID: "bob-1", AccountID: "acct-bob", SerialNumber: "BBB1", LastSeen: now},
+		{ID: "anon-1", AccountID: "", SerialNumber: "CCC1", LastSeen: now},
+	} {
+		if err := st.UpsertProvider(ctx, rec); err != nil {
+			t.Fatalf("upsert %s: %v", rec.ID, err)
+		}
+	}
+
+	got, err := st.ListProvidersByAccount(ctx, "acct-alice")
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("len = %d, want 2", len(got))
+	}
+	// Postgres returns ORDER BY last_seen DESC.
+	if got[0].ID != "alice-new" || got[1].ID != "alice-old" {
+		t.Fatalf("ordering wrong, got %v", []string{got[0].ID, got[1].ID})
+	}
+
+	bobRecs, err := st.ListProvidersByAccount(ctx, "acct-bob")
+	if err != nil {
+		t.Fatalf("list bob: %v", err)
+	}
+	if len(bobRecs) != 1 || bobRecs[0].ID != "bob-1" {
+		t.Fatalf("bob should own only bob-1, got %v", bobRecs)
+	}
+
+	emptyRecs, err := st.ListProvidersByAccount(ctx, "")
+	if err != nil {
+		t.Fatalf("list empty: %v", err)
+	}
+	if len(emptyRecs) != 0 {
+		t.Fatalf("empty accountID should not match unlinked rows, got %d", len(emptyRecs))
+	}
+
+	ghostRecs, err := st.ListProvidersByAccount(ctx, "acct-ghost")
+	if err != nil {
+		t.Fatalf("list ghost: %v", err)
+	}
+	if len(ghostRecs) != 0 {
+		t.Fatalf("unknown account should return empty, got %d", len(ghostRecs))
+	}
+}


### PR DESCRIPTION
## Summary

Adds a "My Machines" dashboard at `/providers/me` so logged-in users can see every provider machine linked to their account — status, earnings, and the full list of reasons a machine might not be earning.

## Coordinator

- `Store.ListProvidersByAccount(ctx, accountID)` — memory + postgres impls + partial `idx_providers_account` index
- `GET /v1/me/providers` (Privy auth) — merges persisted `ProviderRecord` with the live `registry.Provider` snapshot, dedupes per-session reconnect rows by `SerialNumber` / `SEPublicKey` so one physical machine surfaces once, attaches per-machine lifetime earnings
- `GET /v1/me/summary` (Privy auth) — lifetime / 7d / 24h earnings, pending balance, fleet counts (online / serving / offline / untrusted / hardware / needs-attention), latest + min provider version
- `httptest`-based handler tests for auth, account isolation, offline/live merge, reconnect dedupe, earnings attach, summary buckets
- Postgres store test for `ListProvidersByAccount` gated on `DATABASE_URL`

## Console-UI

- Proxy routes `/api/me/{providers,summary}` forwarding the Privy bearer
- `/providers/me` page: summary header, payout banner, per-machine card with status, hardware, live metrics, warm models, reputation, and expandable Trust & attestation / Backend slots sections
- Pure `computeWarnings()` derives 17 signals across **blocking / degrading / info** severities mirroring `ScoreProvider` + `FindProviderWithTrust` exclusion rules:
  - **Blocking**: offline, untrusted, runtime mismatch, version below min, stale attestation challenge, trust below routing threshold (self-signed / none), no catalog models, thermal critical
  - **Degrading**: crashed backend (0.05×), idle-shutdown cold start (0.1×), MDA missing, thermal serious/fair, memory pressure >90%, low success rate
  - **Info**: no payout configured, outdated provider version, awaiting first challenge
- 29 vitest assertions covering the warning matrix + semver helper
- Existing `/providers` page's wallet-match card replaced with a CTA linking to the new dashboard

## Test plan

- [x] `cd coordinator && go test ./internal/store/ ./internal/api/ -count=1` passes
- [x] `cd console-ui && npx vitest run providers-me-warnings` → 29/29
- [x] `cd console-ui && npm run build` — `/providers/me`, `/api/me/providers`, `/api/me/summary` register cleanly
- [x] `gofmt -l` clean on all touched Go files
- [x] TypeScript clean for new files (pre-existing errors in `EarningsContent.tsx` / `PrivyClientProvider.tsx` / `vitest.config.ts` are not from this PR)
- [ ] Manual: log in, confirm the dashboard renders with real fleet data and warnings fire for a machine that's offline / self-signed / outdated
- [ ] Manual: sanity-check `/v1/me/providers` and `/v1/me/summary` against a deployed coordinator with real account linkage

## Review

Two independent reviewers (Codex rescue + general-purpose Claude subagent) caught and have been addressed:
- Reconnect duplication (persisted records from old sessions) → dedup by stable identity
- Trust level warnings had wrong severity (production `MinTrustLevel=hardware` excludes sub-hardware entirely)
- `backend_crashed` was overstated as blocking → actually a 0.05× scoring penalty
- Missing stale-challenge warning (the 6-minute freshness window)
- Missing no-catalog-models warning
- TypeScript regression on `challenge_max_age_seconds` in the `Pick<>` shape