### PR TITLE
Allow free self-hosted provider use while model is running

### DIFF
--- a/coordinator/internal/api/billing_integration_test.go
+++ b/coordinator/internal/api/billing_integration_test.go
@@ -11,6 +11,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
@@ -212,6 +213,304 @@ func TestIntegration_ConsumerBillingCharge(t *testing.T) {
 	}
 }
 
+func TestIntegration_SelfHostedRunningModelIsFree(t *testing.T) {
+	srv, st, ledger := billingTestServer(t)
+
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	accountID := "acct-self-hosted-free"
+	rawToken := "self-hosted-free-token"
+	tokenHash := sha256HexStr(rawToken)
+	if err := st.CreateProviderToken(&store.ProviderToken{
+		TokenHash: tokenHash,
+		AccountID: accountID,
+		Label:     "self-hosted-free",
+		Active:    true,
+		CreatedAt: time.Now(),
+	}); err != nil {
+		t.Fatalf("create provider token: %v", err)
+	}
+
+	apiKey, err := st.CreateKeyForAccount(accountID)
+	if err != nil {
+		t.Fatalf("create api key: %v", err)
+	}
+	if err := st.Credit(accountID, 5_000_000, store.LedgerDeposit, "self-hosted-seed"); err != nil {
+		t.Fatalf("seed account balance: %v", err)
+	}
+	initialBalance := ledger.Balance(accountID)
+
+	pubKey := testPublicKeyB64()
+	model := "self-hosted-free-model"
+	conn := connectProviderWithToken(t, ctx, ts.URL,
+		[]protocol.ModelInfo{{ID: model, ModelType: "test", Quantization: "4bit"}},
+		pubKey, rawToken, "0xSelfHostedFreeWallet")
+	defer conn.Close(websocket.StatusNormalClosure, "")
+
+	time.Sleep(300 * time.Millisecond)
+	for _, id := range srv.registry.ProviderIDs() {
+		srv.registry.SetTrustLevel(id, registry.TrustHardware)
+		srv.registry.RecordChallengeSuccess(id)
+	}
+
+	p := findProviderByModel(srv.registry, model)
+	if p == nil {
+		t.Fatal("provider not found")
+	}
+	if p.AccountID != accountID {
+		t.Fatalf("provider account_id = %q, want %q", p.AccountID, accountID)
+	}
+	p.Mu().Lock()
+	p.BackendCapacity = &protocol.BackendCapacity{
+		TotalMemoryGB: 64,
+		Slots: []protocol.BackendSlotCapacity{
+			{Model: model, State: "running"},
+		},
+	}
+	p.CurrentModel = model
+	p.WarmModels = []string{model}
+	p.Mu().Unlock()
+	if !srv.registry.HasOwnedRunningProvider(accountID, model) {
+		t.Fatal("expected owned running provider to be detectable")
+	}
+
+	usage := protocol.UsageInfo{PromptTokens: 120, CompletionTokens: 60}
+	providerDone := serveOneInference(ctx, t, conn, pubKey, usage)
+
+	status := sendInferenceRequest(t, ctx, ts.URL, model, apiKey)
+	if status != http.StatusOK {
+		t.Fatalf("inference status = %d, want 200", status)
+	}
+
+	<-providerDone
+	time.Sleep(300 * time.Millisecond)
+
+	if got := ledger.Balance(accountID); got != initialBalance {
+		t.Fatalf("account balance = %d, want %d (self-hosted request should be free)", got, initialBalance)
+	}
+
+	usageEntries := ledger.Usage(accountID)
+	if len(usageEntries) != 1 {
+		t.Fatalf("usage entries = %d, want 1", len(usageEntries))
+	}
+	if usageEntries[0].CostMicroUSD != 0 {
+		t.Fatalf("usage cost = %d, want 0", usageEntries[0].CostMicroUSD)
+	}
+
+	earnings, err := st.GetAccountEarnings(accountID, 10)
+	if err != nil {
+		t.Fatalf("get account earnings: %v", err)
+	}
+	if len(earnings) != 0 {
+		t.Fatalf("account earnings = %d, want 0 for self-hosted request", len(earnings))
+	}
+
+	if got := st.GetBalance("platform"); got != 0 {
+		t.Fatalf("platform balance = %d, want 0 for self-hosted request", got)
+	}
+}
+
+func TestIntegration_SelfHostedRunningModelQueuesBehindOwnerAndStaysFree(t *testing.T) {
+	srv, st, ledger := billingTestServer(t)
+
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	accountID := "acct-self-hosted-queued"
+	rawToken := "self-hosted-queued-token"
+	tokenHash := sha256HexStr(rawToken)
+	if err := st.CreateProviderToken(&store.ProviderToken{
+		TokenHash: tokenHash,
+		AccountID: accountID,
+		Label:     "self-hosted-queued",
+		Active:    true,
+		CreatedAt: time.Now(),
+	}); err != nil {
+		t.Fatalf("create provider token: %v", err)
+	}
+
+	apiKey, err := st.CreateKeyForAccount(accountID)
+	if err != nil {
+		t.Fatalf("create api key: %v", err)
+	}
+	if err := st.Credit(accountID, 5_000_000, store.LedgerDeposit, "self-hosted-queued-seed"); err != nil {
+		t.Fatalf("seed account balance: %v", err)
+	}
+	initialBalance := ledger.Balance(accountID)
+
+	pubKey := testPublicKeyB64()
+	model := "self-hosted-queued-model"
+	conn := connectProviderWithToken(t, ctx, ts.URL,
+		[]protocol.ModelInfo{{ID: model, ModelType: "test", Quantization: "4bit"}},
+		pubKey, rawToken, "0xSelfHostedQueuedWallet")
+	defer conn.Close(websocket.StatusNormalClosure, "")
+
+	time.Sleep(300 * time.Millisecond)
+	var providerID string
+	for _, id := range srv.registry.ProviderIDs() {
+		providerID = id
+		srv.registry.SetTrustLevel(id, registry.TrustHardware)
+		srv.registry.RecordChallengeSuccess(id)
+	}
+	if providerID == "" {
+		t.Fatal("provider not registered")
+	}
+
+	p := srv.registry.GetProvider(providerID)
+	if p == nil {
+		t.Fatal("provider not found")
+	}
+	if p.AccountID != accountID {
+		t.Fatalf("provider account_id = %q, want %q", p.AccountID, accountID)
+	}
+	p.Mu().Lock()
+	p.BackendCapacity = &protocol.BackendCapacity{
+		TotalMemoryGB: 16,
+		Slots: []protocol.BackendSlotCapacity{
+			{Model: model, State: "running"},
+		},
+	}
+	p.CurrentModel = model
+	p.WarmModels = []string{model}
+	p.Status = registry.StatusServing
+	p.Mu().Unlock()
+	if !srv.registry.HasOwnedRunningProvider(accountID, model) {
+		t.Fatal("expected owned running provider to be detectable")
+	}
+	for i := 0; i < registry.DefaultMaxConcurrent; i++ {
+		p.AddPending(&registry.PendingRequest{
+			RequestID:          fmt.Sprintf("busy-%d", i),
+			Model:              model,
+			ConsumerKey:        accountID,
+			RequestedMaxTokens: 128,
+		})
+	}
+
+	httpDone := make(chan int, 1)
+	go func() {
+		httpDone <- sendInferenceRequest(t, ctx, ts.URL, model, apiKey)
+	}()
+
+	// Give the request time to block behind the owner's busy backend. The
+	// self-hosted wait path no longer uses the shared registry queue because
+	// that caused head-of-line blocking for unrelated marketplace traffic.
+	time.Sleep(250 * time.Millisecond)
+
+	usage := protocol.UsageInfo{PromptTokens: 90, CompletionTokens: 30}
+	providerDone := serveOneInference(ctx, t, conn, pubKey, usage)
+
+	p.RemovePending("busy-0")
+	for i := 1; i < registry.DefaultMaxConcurrent; i++ {
+		p.RemovePending(fmt.Sprintf("busy-%d", i))
+	}
+	srv.registry.SetProviderIdle(providerID)
+
+	select {
+	case status := <-httpDone:
+		if status != http.StatusOK {
+			t.Fatalf("inference status = %d, want 200", status)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for queued self-hosted request to complete")
+	}
+
+	<-providerDone
+	time.Sleep(300 * time.Millisecond)
+
+	if got := ledger.Balance(accountID); got != initialBalance {
+		t.Fatalf("account balance = %d, want %d for queued self-hosted request", got, initialBalance)
+	}
+
+	usageEntries := ledger.Usage(accountID)
+	if len(usageEntries) != 1 {
+		t.Fatalf("usage entries = %d, want 1", len(usageEntries))
+	}
+	if usageEntries[0].CostMicroUSD != 0 {
+		t.Fatalf("usage cost = %d, want 0 for queued self-hosted request", usageEntries[0].CostMicroUSD)
+	}
+}
+
+func TestIntegration_SelfHostedFallsBackToPaidWhenModelNotRunning(t *testing.T) {
+	srv, st, ledger := billingTestServer(t)
+
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	accountID := "acct-self-hosted-fallback"
+	rawToken := "self-hosted-fallback-token"
+	tokenHash := sha256HexStr(rawToken)
+	if err := st.CreateProviderToken(&store.ProviderToken{
+		TokenHash: tokenHash,
+		AccountID: accountID,
+		Label:     "self-hosted-fallback",
+		Active:    true,
+		CreatedAt: time.Now(),
+	}); err != nil {
+		t.Fatalf("create provider token: %v", err)
+	}
+
+	apiKey, err := st.CreateKeyForAccount(accountID)
+	if err != nil {
+		t.Fatalf("create api key: %v", err)
+	}
+	if err := st.Credit(accountID, 5_000_000, store.LedgerDeposit, "self-hosted-fallback-seed"); err != nil {
+		t.Fatalf("seed account balance: %v", err)
+	}
+	initialBalance := ledger.Balance(accountID)
+
+	ownedConn := connectProviderWithToken(t, ctx, ts.URL,
+		[]protocol.ModelInfo{{ID: "other-model", ModelType: "test", Quantization: "4bit"}},
+		testPublicKeyB64(), rawToken, "0xOwnedOtherWallet")
+	defer ownedConn.Close(websocket.StatusNormalClosure, "")
+
+	servingPubKey := testPublicKeyB64()
+	model := "self-hosted-fallback-model"
+	servingConn := connectProvider(t, ctx, ts.URL,
+		[]protocol.ModelInfo{{ID: model, ModelType: "test", Quantization: "4bit"}},
+		servingPubKey)
+	defer servingConn.Close(websocket.StatusNormalClosure, "")
+
+	time.Sleep(300 * time.Millisecond)
+	for _, id := range srv.registry.ProviderIDs() {
+		srv.registry.SetTrustLevel(id, registry.TrustHardware)
+		srv.registry.RecordChallengeSuccess(id)
+	}
+
+	usage := protocol.UsageInfo{PromptTokens: 100, CompletionTokens: 40}
+	providerDone := serveOneInference(ctx, t, servingConn, servingPubKey, usage)
+
+	status := sendInferenceRequest(t, ctx, ts.URL, model, apiKey)
+	if status != http.StatusOK {
+		t.Fatalf("inference status = %d, want 200", status)
+	}
+
+	<-providerDone
+	time.Sleep(300 * time.Millisecond)
+
+	expectedCost := payments.CalculateCost(model, usage.PromptTokens, usage.CompletionTokens)
+	if got := ledger.Balance(accountID); got != initialBalance-expectedCost {
+		t.Fatalf("account balance = %d, want %d after paid fallback request", got, initialBalance-expectedCost)
+	}
+
+	usageEntries := ledger.Usage(accountID)
+	if len(usageEntries) != 1 {
+		t.Fatalf("usage entries = %d, want 1", len(usageEntries))
+	}
+	if usageEntries[0].CostMicroUSD != expectedCost {
+		t.Fatalf("usage cost = %d, want %d after paid fallback", usageEntries[0].CostMicroUSD, expectedCost)
+	}
+}
+
 // TestIntegration_ConsumerInsufficientBalance verifies that consumers with zero
 // balance are rejected with 402 before routing to a provider.
 func TestIntegration_ConsumerInsufficientBalance(t *testing.T) {
@@ -362,6 +661,99 @@ func TestIntegration_ReservationRefundedOnCompletion(t *testing.T) {
 	if got := ledger.Balance(consumerID); got != initialBalance-expectedCost {
 		t.Errorf("balance = %d, want %d (initial %d minus cost %d); reservation refund failed",
 			got, initialBalance-expectedCost, initialBalance, expectedCost)
+	}
+}
+
+func TestIntegration_SelfHostedInferenceIsFree(t *testing.T) {
+	srv, st, ledger := billingTestServer(t)
+
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	accountID := "acct-self-hosted-free"
+	rawToken := "self-hosted-free-token"
+	if err := st.CreateProviderToken(&store.ProviderToken{
+		TokenHash: sha256HexStr(rawToken),
+		AccountID: accountID,
+		Label:     "self-hosted-free",
+		Active:    true,
+		CreatedAt: time.Now(),
+	}); err != nil {
+		t.Fatalf("create provider token: %v", err)
+	}
+	apiKey, err := st.CreateKeyForAccount(accountID)
+	if err != nil {
+		t.Fatalf("create key for account: %v", err)
+	}
+	if err := st.Credit(accountID, 2_000_000, store.LedgerDeposit, "self-hosted-seed"); err != nil {
+		t.Fatalf("seed balance: %v", err)
+	}
+
+	model := "self-hosted-free-model"
+	pubKey := testPublicKeyB64()
+	conn := connectProviderWithToken(t, ctx, ts.URL,
+		[]protocol.ModelInfo{{ID: model, ModelType: "test", Quantization: "4bit"}},
+		pubKey, rawToken, "0xSelfHostedWallet")
+	defer conn.Close(websocket.StatusNormalClosure, "")
+	time.Sleep(300 * time.Millisecond)
+
+	for _, id := range srv.registry.ProviderIDs() {
+		srv.registry.SetTrustLevel(id, registry.TrustHardware)
+		srv.registry.RecordChallengeSuccess(id)
+		if p := srv.registry.GetProvider(id); p != nil {
+			p.Mu().Lock()
+			p.BackendCapacity = &protocol.BackendCapacity{
+				TotalMemoryGB: 64,
+				Slots: []protocol.BackendSlotCapacity{{
+					Model:              model,
+					State:              "running",
+					NumRunning:         0,
+					NumWaiting:         0,
+					ActiveTokens:       0,
+					MaxTokensPotential: 0,
+				}},
+			}
+			p.Mu().Unlock()
+		}
+	}
+
+	initialBalance := ledger.Balance(accountID)
+	usage := protocol.UsageInfo{PromptTokens: 120, CompletionTokens: 60}
+	providerDone := serveOneInference(ctx, t, conn, pubKey, usage)
+
+	status := sendInferenceRequest(t, ctx, ts.URL, model, apiKey)
+	if status != http.StatusOK {
+		t.Fatalf("status = %d, want 200", status)
+	}
+
+	<-providerDone
+	time.Sleep(300 * time.Millisecond)
+
+	if got := ledger.Balance(accountID); got != initialBalance {
+		t.Fatalf("self-hosted balance changed: got %d want %d", got, initialBalance)
+	}
+
+	usageEntries := ledger.Usage(accountID)
+	if len(usageEntries) != 1 {
+		t.Fatalf("usage entries = %d, want 1", len(usageEntries))
+	}
+	if usageEntries[0].CostMicroUSD != 0 {
+		t.Errorf("usage cost = %d, want 0", usageEntries[0].CostMicroUSD)
+	}
+
+	earnings, err := st.GetAccountEarnings(accountID, 10)
+	if err != nil {
+		t.Fatalf("get account earnings: %v", err)
+	}
+	if len(earnings) != 0 {
+		t.Fatalf("self-hosted request should not credit provider earnings, got %d rows", len(earnings))
+	}
+
+	if platform := st.GetBalance("platform"); platform != 0 {
+		t.Fatalf("platform balance = %d, want 0", platform)
 	}
 }
 

--- a/coordinator/internal/api/consumer.go
+++ b/coordinator/internal/api/consumer.go
@@ -60,6 +60,12 @@ const (
 	firstChunkTimeout = 10 * time.Second
 )
 
+type providerDispatch struct {
+	provider   *registry.Provider
+	request    *registry.PendingRequest
+	selfHosted bool
+}
+
 // chatCompletionRequest is the incoming OpenAI-compatible request body.
 // The consumer sends plain JSON — no encryption fields are needed because
 // TLS to the Confidential VM is the trust boundary.
@@ -212,6 +218,587 @@ func ensureMaxTokensBound(parsed map[string]any, isResponsesAPI bool) bool {
 	return true
 }
 
+func (s *Server) dispatchSelfHostedTextRequest(ctx context.Context, accountID, model string, estimatedPromptTokens, requestedMaxTokens int) (*providerDispatch, error) {
+	requestID := uuid.New().String()
+	pr := &registry.PendingRequest{
+		RequestID:             requestID,
+		Model:                 model,
+		ConsumerKey:           accountID,
+		SelfHosted:            true,
+		EstimatedPromptTokens: estimatedPromptTokens,
+		RequestedMaxTokens:    requestedMaxTokens,
+		AcceptedCh:            make(chan struct{}, 1),
+		ChunkCh:               make(chan string, chunkBufferSize),
+		CompleteCh:            make(chan protocol.UsageInfo, 1),
+		ErrorCh:               make(chan protocol.InferenceErrorMessage, 1),
+	}
+
+	provider := s.registry.ReserveOwnedProvider(accountID, model, pr)
+	if provider != nil {
+		pr.SelfHosted = true
+		return &providerDispatch{provider: provider, request: pr, selfHosted: true}, nil
+	}
+
+	if !s.registry.HasOwnedRunningProvider(accountID, model) {
+		return nil, fmt.Errorf("no self-hosted provider became available for model %q", model)
+	}
+
+	deadline := time.NewTimer(120 * time.Second)
+	defer deadline.Stop()
+	poll := time.NewTicker(200 * time.Millisecond)
+	defer poll.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-deadline.C:
+			return nil, fmt.Errorf("no self-hosted provider became available for model %q", model)
+		case <-poll.C:
+			provider = s.registry.ReserveOwnedProvider(accountID, model, pr)
+			if provider != nil {
+				pr.SelfHosted = true
+				return &providerDispatch{provider: provider, request: pr, selfHosted: true}, nil
+			}
+			if !s.registry.HasOwnedRunningProvider(accountID, model) {
+				return nil, fmt.Errorf("no self-hosted provider became available for model %q", model)
+			}
+		}
+	}
+}
+
+func (s *Server) dispatchMarketplaceTextRequest(ctx context.Context, accountID, model string, estimatedPromptTokens, requestedMaxTokens int) (*providerDispatch, error) {
+	requestID := uuid.New().String()
+	pr := &registry.PendingRequest{
+		RequestID:             requestID,
+		Model:                 model,
+		ConsumerKey:           accountID,
+		EstimatedPromptTokens: estimatedPromptTokens,
+		RequestedMaxTokens:    requestedMaxTokens,
+		AcceptedCh:            make(chan struct{}, 1),
+		ChunkCh:               make(chan string, chunkBufferSize),
+		CompleteCh:            make(chan protocol.UsageInfo, 1),
+		ErrorCh:               make(chan protocol.InferenceErrorMessage, 1),
+	}
+
+	provider := s.registry.ReserveProvider(model, pr)
+	if provider == nil {
+		queuedReq := &registry.QueuedRequest{
+			RequestID:  requestID,
+			Model:      model,
+			Pending:    pr,
+			ResponseCh: make(chan *registry.Provider, 1),
+		}
+		if err := s.registry.Queue().Enqueue(queuedReq); err != nil {
+			return nil, fmt.Errorf("no provider available for model %q", model)
+		}
+		var err error
+		provider, err = s.registry.Queue().WaitForProviderContext(ctx, queuedReq)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &providerDispatch{provider: provider, request: pr, selfHosted: false}, nil
+}
+
+func (s *Server) dispatchTextRequest(ctx context.Context, accountID, model string, estimatedPromptTokens, requestedMaxTokens int, preferSelfHosted bool) (*providerDispatch, error) {
+	if preferSelfHosted {
+		return s.dispatchSelfHostedTextRequest(ctx, accountID, model, estimatedPromptTokens, requestedMaxTokens)
+	}
+	return s.dispatchMarketplaceTextRequest(ctx, accountID, model, estimatedPromptTokens, requestedMaxTokens)
+}
+
+type textRoutingPlan struct {
+	dispatch          *providerDispatch
+	refundReservation func()
+	reserveBalance    func() error
+}
+
+func (s *Server) prepareTextRoutingPlan(ctx context.Context, consumerKey, model string, estimatedPromptTokens, requestedMaxTokens int) (*textRoutingPlan, errorResponseEnvelope) {
+	var reservedMicroUSD int64
+	preferSelfHosted := s.registry.HasOwnedRunningProvider(consumerKey, model)
+	reserveBalance := func() error {
+		if s.billing == nil || reservedMicroUSD > 0 {
+			return nil
+		}
+		reservedMicroUSD = s.reservationCost(model, estimatedPromptTokens, requestedMaxTokens)
+		if err := s.ledger.Charge(consumerKey, reservedMicroUSD, "reserve:"+consumerKey); err != nil {
+			reservedMicroUSD = 0
+			return err
+		}
+		return nil
+	}
+	if !preferSelfHosted {
+		if err := reserveBalance(); err != nil {
+			return nil, errorResponseEnvelope{
+				status: http.StatusPaymentRequired,
+				body: errorResponse("insufficient_funds",
+					"your balance is too low for this request — add funds at /billing or lower max_tokens"),
+			}
+		}
+	}
+
+	refundReservation := func() {
+		if reservedMicroUSD > 0 {
+			_ = s.store.Credit(consumerKey, reservedMicroUSD, store.LedgerRefund, "reservation_refund")
+		}
+	}
+
+	dispatch, err := s.dispatchTextRequest(ctx, consumerKey, model, estimatedPromptTokens, requestedMaxTokens, preferSelfHosted)
+	if err != nil && preferSelfHosted && err != context.Canceled {
+		preferSelfHosted = false
+		if err := reserveBalance(); err != nil {
+			return nil, errorResponseEnvelope{
+				status: http.StatusPaymentRequired,
+				body: errorResponse("insufficient_funds",
+					"your balance is too low for this request — add funds at /billing or lower max_tokens"),
+			}
+		}
+		dispatch, err = s.dispatchMarketplaceTextRequest(ctx, consumerKey, model, estimatedPromptTokens, requestedMaxTokens)
+	}
+	if err != nil {
+		refundReservation()
+		if err == context.Canceled {
+			return nil, errorResponseEnvelope{status: 0}
+		}
+		return nil, errorResponseEnvelope{
+			status: http.StatusServiceUnavailable,
+			body:   errorResponse("model_not_available", err.Error()),
+		}
+	}
+
+	dispatch.request.ReservedMicroUSD = reservedMicroUSD
+	return &textRoutingPlan{
+		dispatch:          dispatch,
+		refundReservation: refundReservation,
+		reserveBalance:    reserveBalance,
+	}, errorResponseEnvelope{}
+}
+
+type errorResponseEnvelope struct {
+	status int
+	body   map[string]any
+}
+
+func (s *Server) executeTextDispatch(
+	w http.ResponseWriter,
+	r *http.Request,
+	rawBody []byte,
+	model string,
+	stream bool,
+	estimatedPromptTokens int,
+	requestedMaxTokens int,
+	dispatch *providerDispatch,
+	reserveBalance func() error,
+	refundReservation func(),
+) bool {
+	// Dispatch to a provider with automatic retry. If the first provider
+	// fails (backend crashed, timeout, etc.), retry on the same or another
+	// provider before returning an error to the consumer. We wait for the
+	// first chunk before committing — no HTTP response is written until a
+	// provider starts generating, so retries are invisible to the consumer.
+	var (
+		provider     *registry.Provider
+		lastProvider *registry.Provider
+		pr           *registry.PendingRequest
+		requestID    string
+		firstChunk   string
+		lastErr      string
+		lastErrCode  int
+		committed    bool
+	)
+
+	consumerKey := consumerKeyFromContext(r.Context())
+	selfHosted := dispatch.selfHosted
+	allowMarketplaceRetry := !dispatch.selfHosted
+
+	// Track providers that failed during retry so we don't dispatch to them again.
+	excludeProviders := make(map[string]struct{})
+	excludeList := func() []string {
+		ids := make([]string, 0, len(excludeProviders))
+		for id := range excludeProviders {
+			ids = append(ids, id)
+		}
+		return ids
+	}
+
+	requestID = dispatch.request.RequestID
+	pr = dispatch.request
+	provider = dispatch.provider
+	lastProvider = provider
+
+	for attempt := 0; attempt < maxDispatchAttempts; attempt++ {
+		if attempt > 0 {
+			if selfHosted && !allowMarketplaceRetry {
+				pr = newTextPendingRequest(requestID, consumerKey, model, estimatedPromptTokens, requestedMaxTokens, true)
+				pr.ReservedMicroUSD = dispatch.request.ReservedMicroUSD
+				provider = s.registry.ReserveOwnedProvider(consumerKey, model, pr, excludeList()...)
+			} else if selfHosted {
+				selfHosted = false
+				if err := reserveBalance(); err != nil {
+					refundReservation()
+					writeJSON(w, http.StatusPaymentRequired, errorResponse("insufficient_funds",
+						"your balance is too low for this request — add funds at /billing or lower max_tokens"))
+					return true
+				}
+				fallbackDispatch, err := s.dispatchMarketplaceTextRequest(r.Context(), consumerKey, model, estimatedPromptTokens, requestedMaxTokens)
+				if err == nil {
+					provider = fallbackDispatch.provider
+					pr = fallbackDispatch.request
+					pr.ReservedMicroUSD = dispatch.request.ReservedMicroUSD
+				} else {
+					provider = nil
+				}
+			} else {
+				fallbackDispatch, err := s.dispatchMarketplaceTextRequest(r.Context(), consumerKey, model, estimatedPromptTokens, requestedMaxTokens)
+				if err == nil {
+					provider = fallbackDispatch.provider
+					pr = fallbackDispatch.request
+					pr.ReservedMicroUSD = dispatch.request.ReservedMicroUSD
+				} else {
+					provider = nil
+				}
+			}
+			if provider == nil {
+				break
+			}
+			lastProvider = provider
+		}
+
+		// E2E encryption — must be done per provider (different keys).
+		if provider.PublicKey == "" {
+			s.registry.SetProviderIdle(provider.ID)
+			excludeProviders[provider.ID] = struct{}{}
+			lastErr = "no provider with E2E encryption"
+			continue
+		}
+
+		providerPubKey, err := e2e.ParsePublicKey(provider.PublicKey)
+		if err != nil {
+			s.registry.SetProviderIdle(provider.ID)
+			excludeProviders[provider.ID] = struct{}{}
+			lastErr = "provider public key invalid"
+			continue
+		}
+
+		sessionKeys, err := e2e.GenerateSessionKeys()
+		if err != nil {
+			s.registry.SetProviderIdle(provider.ID)
+			lastErr = "failed to generate session keys"
+			continue
+		}
+
+		encrypted, err := e2e.Encrypt(rawBody, providerPubKey, sessionKeys)
+		if err != nil {
+			s.registry.SetProviderIdle(provider.ID)
+			lastErr = "failed to encrypt request"
+			continue
+		}
+
+		wireMsg := map[string]any{
+			"type":       protocol.TypeInferenceRequest,
+			"request_id": requestID,
+			"encrypted_body": map[string]string{
+				"ephemeral_public_key": encrypted.EphemeralPublicKey,
+				"ciphertext":           encrypted.Ciphertext,
+			},
+		}
+
+		pr.SessionPrivKey = &sessionKeys.PrivateKey
+
+		data, err := json.Marshal(wireMsg)
+		if err != nil {
+			provider.RemovePending(requestID)
+			s.registry.SetProviderIdle(provider.ID)
+			lastErr = "failed to marshal request"
+			continue
+		}
+		if err := provider.Conn.Write(r.Context(), websocket.MessageText, data); err != nil {
+			provider.RemovePending(requestID)
+			s.registry.SetProviderIdle(provider.ID)
+			excludeProviders[provider.ID] = struct{}{}
+			s.logger.Error("failed to send inference request", "request_id", requestID, "error", err)
+			lastErr = "failed to send request to provider"
+			allowMarketplaceRetry = true
+			continue
+		}
+
+		s.logger.Info("inference request dispatched",
+			"request_id", requestID,
+			"model", model,
+			"provider_id", provider.ID,
+			"stream", stream,
+			"attempt", attempt+1,
+			"self_hosted", selfHosted,
+		)
+
+		// Wait for an accepted signal, first chunk, or error before committing.
+		// No HTTP response has been written yet, so retries are invisible.
+		timer := time.NewTimer(firstChunkTimeout)
+		accepted := false
+		select {
+		case <-pr.AcceptedCh:
+			timer.Stop()
+			accepted = true
+		case chunk, ok := <-pr.ChunkCh:
+			timer.Stop()
+			if ok {
+				firstChunk = chunk
+				committed = true
+			} else {
+				// Channel closed — check if an error caused it.
+				// handleInferenceError sends to ErrorCh then closes ChunkCh,
+				// so both can be ready simultaneously.
+				select {
+				case errMsg := <-pr.ErrorCh:
+					excludeProviders[provider.ID] = struct{}{}
+					provider.RemovePending(requestID)
+					s.registry.SetProviderIdle(provider.ID)
+					lastErr = errMsg.Error
+					lastErrCode = errMsg.StatusCode
+					provider = nil
+					if !accepted {
+						allowMarketplaceRetry = true
+						continue
+					}
+					continue
+				default:
+					// No error — genuine empty response.
+					committed = true
+				}
+			}
+		case errMsg := <-pr.ErrorCh:
+			timer.Stop()
+			excludeProviders[provider.ID] = struct{}{}
+			provider.RemovePending(requestID)
+			s.registry.SetProviderIdle(provider.ID)
+			lastErr = errMsg.Error
+			lastErrCode = errMsg.StatusCode
+			s.logger.Warn("provider failed, retrying",
+				"request_id", requestID,
+				"provider_id", provider.ID,
+				"attempt", attempt+1,
+				"error", errMsg.Error,
+				"self_hosted", selfHosted,
+			)
+			if !selfHosted {
+				statusCode := errMsg.StatusCode
+				if statusCode == 0 {
+					statusCode = http.StatusBadGateway
+				}
+				writeJSON(w, statusCode, errorResponse("provider_error", errMsg.Error))
+				return true
+			}
+			provider = nil
+			if !accepted {
+				allowMarketplaceRetry = true
+				continue
+			}
+			statusCode := errMsg.StatusCode
+			if statusCode == 0 {
+				statusCode = http.StatusBadGateway
+			}
+			writeJSON(w, statusCode, errorResponse("provider_error", errMsg.Error))
+			return true
+		case <-timer.C:
+			excludeProviders[provider.ID] = struct{}{}
+			provider.RemovePending(requestID)
+			s.registry.SetProviderIdle(provider.ID)
+			cancelMsg := protocol.CancelMessage{Type: protocol.TypeCancel, RequestID: requestID}
+			cancelData, _ := json.Marshal(cancelMsg)
+			_ = provider.Conn.Write(context.Background(), websocket.MessageText, cancelData)
+			lastErr = "timeout waiting for first response"
+			lastErrCode = http.StatusGatewayTimeout
+			s.logger.Warn("provider timeout, retrying",
+				"request_id", requestID,
+				"provider_id", provider.ID,
+				"attempt", attempt+1,
+				"self_hosted", selfHosted,
+			)
+			provider = nil
+			if !accepted {
+				allowMarketplaceRetry = true
+			}
+			continue
+		case <-r.Context().Done():
+			provider.RemovePending(requestID)
+			s.registry.SetProviderIdle(provider.ID)
+			refundReservation()
+			return true
+		}
+
+		// Provider accepted or sent first chunk — commit to this provider.
+		// If only accepted (no chunk yet), wait for the first chunk with
+		// the full inference timeout since the backend may be reloading.
+		if accepted && !committed {
+			chunkTimer := time.NewTimer(inferenceTimeout)
+			select {
+			case chunk, ok := <-pr.ChunkCh:
+				chunkTimer.Stop()
+				if ok {
+					firstChunk = chunk
+					committed = true
+				} else {
+					// Closed — check for error (same race as above).
+					select {
+					case errMsg := <-pr.ErrorCh:
+						excludeProviders[provider.ID] = struct{}{}
+						provider.RemovePending(requestID)
+						s.registry.SetProviderIdle(provider.ID)
+						lastErr = errMsg.Error
+						lastErrCode = errMsg.StatusCode
+						provider = nil
+						if selfHosted {
+							allowMarketplaceRetry = true
+						}
+						continue
+					default:
+						committed = true
+					}
+				}
+			case errMsg := <-pr.ErrorCh:
+				chunkTimer.Stop()
+				excludeProviders[provider.ID] = struct{}{}
+				provider.RemovePending(requestID)
+				s.registry.SetProviderIdle(provider.ID)
+				if selfHosted {
+					lastErr = errMsg.Error
+					lastErrCode = errMsg.StatusCode
+					provider = nil
+					allowMarketplaceRetry = true
+					continue
+				}
+				statusCode := errMsg.StatusCode
+				if statusCode == 0 {
+					statusCode = http.StatusBadGateway
+				}
+				writeJSON(w, statusCode, errorResponse("provider_error", errMsg.Error))
+				return true
+			case <-chunkTimer.C:
+				provider.RemovePending(requestID)
+				s.registry.SetProviderIdle(provider.ID)
+				cancelMsg := protocol.CancelMessage{Type: protocol.TypeCancel, RequestID: requestID}
+				cancelData, _ := json.Marshal(cancelMsg)
+				_ = provider.Conn.Write(context.Background(), websocket.MessageText, cancelData)
+				if selfHosted {
+					lastErr = "provider accepted but timed out"
+					lastErrCode = http.StatusGatewayTimeout
+					provider = nil
+					allowMarketplaceRetry = true
+					continue
+				}
+				writeJSON(w, http.StatusGatewayTimeout, errorResponse("timeout", "provider accepted but timed out"))
+				return true
+			case <-r.Context().Done():
+				provider.RemovePending(requestID)
+				s.registry.SetProviderIdle(provider.ID)
+				refundReservation()
+				return true
+			}
+		}
+
+		break
+	}
+
+	if !committed {
+		refundReservation()
+		statusCode := lastErrCode
+		if statusCode == 0 {
+			statusCode = http.StatusServiceUnavailable
+		}
+		writeJSON(w, statusCode, errorResponse("provider_error",
+			fmt.Sprintf("inference failed after %d attempt(s): %s", maxDispatchAttempts, lastErr)))
+		return true
+	}
+
+	// Write provider attestation headers now that we're committed.
+	provider.Mu().Lock()
+	pubKey := provider.PublicKey
+	attested := provider.Attested
+	trustLevel := provider.TrustLevel
+	attestResult := provider.AttestationResult
+	mdaVerified := provider.MDAVerified
+	provider.Mu().Unlock()
+
+	providerID := provider.ID
+	chipName := provider.Hardware.ChipName
+	machineModel := provider.Hardware.MachineModel
+
+	if pubKey != "" {
+		w.Header().Set("X-Provider-Public-Key", pubKey)
+	}
+	if attested {
+		w.Header().Set("X-Provider-Attested", "true")
+	} else {
+		w.Header().Set("X-Provider-Attested", "false")
+	}
+	w.Header().Set("X-Provider-Trust-Level", string(trustLevel))
+	w.Header().Set("X-Provider-ID", providerID)
+	w.Header().Set("X-Provider-Chip", chipName)
+	w.Header().Set("X-Provider-Model", machineModel)
+	if attestResult != nil {
+		w.Header().Set("X-Provider-Serial", attestResult.SerialNumber)
+		if attestResult.SecureEnclaveAvailable {
+			w.Header().Set("X-Provider-Secure-Enclave", "true")
+		} else {
+			w.Header().Set("X-Provider-Secure-Enclave", "false")
+		}
+	}
+	if mdaVerified {
+		w.Header().Set("X-Provider-MDA-Verified", "true")
+	}
+	// SE public key for attestation receipt verification.
+	// Consumers can use this to verify SE signatures on response hashes.
+	if attestResult != nil && attestResult.PublicKey != "" {
+		w.Header().Set("X-Attestation-SE-Public-Key", attestResult.PublicKey)
+		w.Header().Set("X-Attestation-Device-Serial", attestResult.SerialNumber)
+	}
+
+	// When this function returns (consumer disconnect, timeout, or completion),
+	// send a cancel to the provider so it stops generating tokens.
+	defer func() {
+		if lastProvider == nil {
+			return
+		}
+		lastProvider.RemovePending(requestID)
+		s.registry.SetProviderIdle(lastProvider.ID)
+
+		cancelMsg := protocol.CancelMessage{
+			Type:      protocol.TypeCancel,
+			RequestID: requestID,
+		}
+		cancelData, _ := json.Marshal(cancelMsg)
+		if err := lastProvider.Conn.Write(context.Background(), websocket.MessageText, cancelData); err != nil {
+			s.logger.Debug("failed to send cancel (provider may have disconnected)", "request_id", requestID, "error", err)
+		} else {
+			s.logger.Info("sent cancel to provider", "request_id", requestID)
+		}
+	}()
+
+	if stream {
+		s.handleStreamingResponseWithFirstChunk(w, r, pr, firstChunk)
+	} else {
+		s.handleNonStreamingResponseWithFirstChunk(w, r, pr, firstChunk)
+	}
+	return true
+}
+
+func newTextPendingRequest(requestID, accountID, model string, estimatedPromptTokens, requestedMaxTokens int, selfHosted bool) *registry.PendingRequest {
+	return &registry.PendingRequest{
+		RequestID:             requestID,
+		Model:                 model,
+		ConsumerKey:           accountID,
+		SelfHosted:            selfHosted,
+		EstimatedPromptTokens: estimatedPromptTokens,
+		RequestedMaxTokens:    requestedMaxTokens,
+		AcceptedCh:            make(chan struct{}, 1),
+		ChunkCh:               make(chan string, chunkBufferSize),
+		CompleteCh:            make(chan protocol.UsageInfo, 1),
+		ErrorCh:               make(chan protocol.InferenceErrorMessage, 1),
+	}
+}
+
 // handleChatCompletions handles POST /v1/chat/completions.
 //
 // This is the main inference endpoint. It validates the request, finds an
@@ -272,391 +859,22 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 	estimatedPromptTokens := estimatePromptTokens(parsed)
 	requestedMaxTokens := estimateRequestedMaxTokens(parsed)
 
-	// Pre-flight balance reservation — atomically debit the worst-case cost
-	// (prompt tokens already consumed + max_tokens we just bounded the
-	// generation to) before routing to a provider. The post-inference charge
-	// refunds any unused portion. Reserving only the minimum charge let
-	// consumers receive streamed output far exceeding their actual balance.
-	var reservedMicroUSD int64
-	if s.billing != nil {
-		consumerKey := consumerKeyFromContext(r.Context())
-		reservedMicroUSD = s.reservationCost(model, estimatedPromptTokens, requestedMaxTokens)
-		if err := s.ledger.Charge(consumerKey, reservedMicroUSD, "reserve:"+consumerKey); err != nil {
-			writeJSON(w, http.StatusPaymentRequired, errorResponse("insufficient_funds",
-				"your balance is too low for this request — add funds at /billing or lower max_tokens"))
-			return
-		}
-	}
-
-	// Refund reservation on early errors (before inference starts).
-	refundReservation := func() {
-		if reservedMicroUSD > 0 {
-			consumerKey := consumerKeyFromContext(r.Context())
-			_ = s.store.Credit(consumerKey, reservedMicroUSD, store.LedgerRefund, "reservation_refund")
-		}
-	}
-
 	// Reject requests for models not in the catalog.
 	if !s.registry.IsModelInCatalog(model) {
-		refundReservation()
 		writeJSON(w, http.StatusNotFound, errorResponse("model_not_found",
 			fmt.Sprintf("model %q is not available — see /v1/models for supported models", model)))
 		return
 	}
 
-	// Dispatch to a provider with automatic retry. If the first provider
-	// fails (backend crashed, timeout, etc.), retry on the same or another
-	// provider before returning an error to the consumer. We wait for the
-	// first chunk before committing — no HTTP response is written until a
-	// provider starts generating, so retries are invisible to the consumer.
-	var (
-		provider    *registry.Provider
-		pr          *registry.PendingRequest
-		requestID   string
-		firstChunk  string
-		lastErr     string
-		lastErrCode int
-		committed   bool
-	)
-
 	consumerKey := consumerKeyFromContext(r.Context())
-
-	// Track providers that failed during retry so we don't dispatch to them again.
-	excludeProviders := make(map[string]struct{})
-	excludeList := func() []string {
-		ids := make([]string, 0, len(excludeProviders))
-		for id := range excludeProviders {
-			ids = append(ids, id)
-		}
-		return ids
-	}
-
-	for attempt := 0; attempt < maxDispatchAttempts; attempt++ {
-		requestID = uuid.New().String()
-		pr = &registry.PendingRequest{
-			RequestID:             requestID,
-			Model:                 model,
-			ConsumerKey:           consumerKey,
-			EstimatedPromptTokens: estimatedPromptTokens,
-			RequestedMaxTokens:    requestedMaxTokens,
-			AcceptedCh:            make(chan struct{}, 1),
-			ChunkCh:               make(chan string, chunkBufferSize),
-			CompleteCh:            make(chan protocol.UsageInfo, 1),
-			ErrorCh:               make(chan protocol.InferenceErrorMessage, 1),
-		}
-
-		provider = s.registry.ReserveProvider(model, pr, excludeList()...)
-		if provider == nil {
-			// On retry attempts, don't queue — if the only available
-			// providers already failed, waiting 120s for one of them
-			// to come back won't help. Break and return the last error.
-			if attempt > 0 {
-				break
-			}
-			// No idle provider — try queueing.
-			queuedReq := &registry.QueuedRequest{
-				RequestID:  requestID,
-				Model:      model,
-				Pending:    pr,
-				ResponseCh: make(chan *registry.Provider, 1),
-			}
-			if err := s.registry.Queue().Enqueue(queuedReq); err != nil {
-				refundReservation()
-				writeJSON(w, http.StatusServiceUnavailable, errorResponse("model_not_available", fmt.Sprintf("no hardware-trusted provider available for model %q and queue is full", model)))
-				return
-			}
-
-			s.logger.Info("request queued, waiting for provider",
-				"model", model,
-				"attempt", attempt+1,
-			)
-
-			var err error
-			provider, err = s.registry.Queue().WaitForProviderContext(r.Context(), queuedReq)
-			if err != nil {
-				if err == context.Canceled {
-					refundReservation()
-					return
-				}
-				refundReservation()
-				writeJSON(w, http.StatusServiceUnavailable, errorResponse("model_not_available", fmt.Sprintf("no hardware-trusted provider became available for model %q (queue timeout)", model)))
-				return
-			}
-		}
-
-		// E2E encryption — must be done per provider (different keys).
-		if provider.PublicKey == "" {
-			s.registry.SetProviderIdle(provider.ID)
-			excludeProviders[provider.ID] = struct{}{}
-			lastErr = "no provider with E2E encryption"
-			continue
-		}
-
-		providerPubKey, err := e2e.ParsePublicKey(provider.PublicKey)
-		if err != nil {
-			s.registry.SetProviderIdle(provider.ID)
-			excludeProviders[provider.ID] = struct{}{}
-			lastErr = "provider public key invalid"
-			continue
-		}
-
-		sessionKeys, err := e2e.GenerateSessionKeys()
-		if err != nil {
-			s.registry.SetProviderIdle(provider.ID)
-			lastErr = "failed to generate session keys"
-			continue
-		}
-
-		encrypted, err := e2e.Encrypt(rawBody, providerPubKey, sessionKeys)
-		if err != nil {
-			s.registry.SetProviderIdle(provider.ID)
-			lastErr = "failed to encrypt request"
-			continue
-		}
-
-		wireMsg := map[string]any{
-			"type":       protocol.TypeInferenceRequest,
-			"request_id": requestID,
-			"encrypted_body": map[string]string{
-				"ephemeral_public_key": encrypted.EphemeralPublicKey,
-				"ciphertext":           encrypted.Ciphertext,
-			},
-		}
-
-		pr.SessionPrivKey = &sessionKeys.PrivateKey
-		pr.ReservedMicroUSD = reservedMicroUSD
-
-		data, err := json.Marshal(wireMsg)
-		if err != nil {
-			provider.RemovePending(requestID)
-			s.registry.SetProviderIdle(provider.ID)
-			lastErr = "failed to marshal request"
-			continue
-		}
-		if err := provider.Conn.Write(r.Context(), websocket.MessageText, data); err != nil {
-			provider.RemovePending(requestID)
-			s.registry.SetProviderIdle(provider.ID)
-			excludeProviders[provider.ID] = struct{}{}
-			s.logger.Error("failed to send inference request", "request_id", requestID, "error", err)
-			lastErr = "failed to send request to provider"
-			continue
-		}
-
-		s.logger.Info("inference request dispatched",
-			"request_id", requestID,
-			"model", model,
-			"provider_id", provider.ID,
-			"stream", stream,
-			"attempt", attempt+1,
-		)
-
-		// Wait for an accepted signal, first chunk, or error before committing.
-		// No HTTP response has been written yet, so retries are invisible.
-		timer := time.NewTimer(firstChunkTimeout)
-		accepted := false
-		select {
-		case <-pr.AcceptedCh:
-			timer.Stop()
-			accepted = true
-		case chunk, ok := <-pr.ChunkCh:
-			timer.Stop()
-			if ok {
-				firstChunk = chunk
-				committed = true
-			} else {
-				// Channel closed — check if an error caused it.
-				// handleInferenceError sends to ErrorCh then closes ChunkCh,
-				// so both can be ready simultaneously.
-				select {
-				case errMsg := <-pr.ErrorCh:
-					excludeProviders[provider.ID] = struct{}{}
-					provider.RemovePending(requestID)
-					s.registry.SetProviderIdle(provider.ID)
-					lastErr = errMsg.Error
-					lastErrCode = errMsg.StatusCode
-					provider = nil
-					pr = nil
-					continue
-				default:
-					// No error — genuine empty response.
-					committed = true
-				}
-			}
-		case errMsg := <-pr.ErrorCh:
-			timer.Stop()
-			excludeProviders[provider.ID] = struct{}{}
-			provider.RemovePending(requestID)
-			s.registry.SetProviderIdle(provider.ID)
-			lastErr = errMsg.Error
-			lastErrCode = errMsg.StatusCode
-			s.logger.Warn("provider failed, retrying",
-				"request_id", requestID,
-				"provider_id", provider.ID,
-				"attempt", attempt+1,
-				"error", errMsg.Error,
-			)
-			provider = nil
-			pr = nil
-			continue
-		case <-timer.C:
-			excludeProviders[provider.ID] = struct{}{}
-			provider.RemovePending(requestID)
-			s.registry.SetProviderIdle(provider.ID)
-			cancelMsg := protocol.CancelMessage{Type: protocol.TypeCancel, RequestID: requestID}
-			cancelData, _ := json.Marshal(cancelMsg)
-			_ = provider.Conn.Write(context.Background(), websocket.MessageText, cancelData)
-			lastErr = "timeout waiting for first response"
-			lastErrCode = http.StatusGatewayTimeout
-			s.logger.Warn("provider timeout, retrying",
-				"request_id", requestID,
-				"provider_id", provider.ID,
-				"attempt", attempt+1,
-			)
-			provider = nil
-			pr = nil
-			continue
-		case <-r.Context().Done():
-			provider.RemovePending(requestID)
-			s.registry.SetProviderIdle(provider.ID)
-			refundReservation()
-			return
-		}
-
-		// Provider accepted or sent first chunk — commit to this provider.
-		// If only accepted (no chunk yet), wait for the first chunk with
-		// the full inference timeout since the backend may be reloading.
-		if accepted && !committed {
-			chunkTimer := time.NewTimer(inferenceTimeout)
-			select {
-			case chunk, ok := <-pr.ChunkCh:
-				chunkTimer.Stop()
-				if ok {
-					firstChunk = chunk
-					committed = true
-				} else {
-					// Closed — check for error (same race as above).
-					select {
-					case errMsg := <-pr.ErrorCh:
-						provider.RemovePending(requestID)
-						s.registry.SetProviderIdle(provider.ID)
-						refundReservation()
-						statusCode := errMsg.StatusCode
-						if statusCode == 0 {
-							statusCode = http.StatusBadGateway
-						}
-						writeJSON(w, statusCode, errorResponse("provider_error", errMsg.Error))
-						return
-					default:
-						committed = true
-					}
-				}
-			case errMsg := <-pr.ErrorCh:
-				chunkTimer.Stop()
-				provider.RemovePending(requestID)
-				s.registry.SetProviderIdle(provider.ID)
-				refundReservation()
-				statusCode := errMsg.StatusCode
-				if statusCode == 0 {
-					statusCode = http.StatusBadGateway
-				}
-				writeJSON(w, statusCode, errorResponse("provider_error", errMsg.Error))
-				return
-			case <-chunkTimer.C:
-				provider.RemovePending(requestID)
-				s.registry.SetProviderIdle(provider.ID)
-				cancelMsg := protocol.CancelMessage{Type: protocol.TypeCancel, RequestID: requestID}
-				cancelData, _ := json.Marshal(cancelMsg)
-				_ = provider.Conn.Write(context.Background(), websocket.MessageText, cancelData)
-				refundReservation()
-				writeJSON(w, http.StatusGatewayTimeout, errorResponse("timeout", "provider accepted but timed out"))
-				return
-			case <-r.Context().Done():
-				provider.RemovePending(requestID)
-				s.registry.SetProviderIdle(provider.ID)
-				refundReservation()
-				return
-			}
-		}
-
-		break
-	}
-
-	if !committed {
-		refundReservation()
-		statusCode := lastErrCode
-		if statusCode == 0 {
-			statusCode = http.StatusServiceUnavailable
-		}
-		writeJSON(w, statusCode, errorResponse("provider_error",
-			fmt.Sprintf("inference failed after %d attempt(s): %s", maxDispatchAttempts, lastErr)))
+	plan, errResp := s.prepareTextRoutingPlan(r.Context(), consumerKey, model, estimatedPromptTokens, requestedMaxTokens)
+	if errResp.status != 0 {
+		writeJSON(w, errResp.status, errResp.body)
 		return
 	}
 
-	// Write provider attestation headers now that we're committed.
-	provider.Mu().Lock()
-	pubKey := provider.PublicKey
-	attested := provider.Attested
-	trustLevel := provider.TrustLevel
-	attestResult := provider.AttestationResult
-	mdaVerified := provider.MDAVerified
-	provider.Mu().Unlock()
-
-	providerID := provider.ID
-	chipName := provider.Hardware.ChipName
-	machineModel := provider.Hardware.MachineModel
-
-	if pubKey != "" {
-		w.Header().Set("X-Provider-Public-Key", pubKey)
-	}
-	if attested {
-		w.Header().Set("X-Provider-Attested", "true")
-	} else {
-		w.Header().Set("X-Provider-Attested", "false")
-	}
-	w.Header().Set("X-Provider-Trust-Level", string(trustLevel))
-	w.Header().Set("X-Provider-ID", providerID)
-	w.Header().Set("X-Provider-Chip", chipName)
-	w.Header().Set("X-Provider-Model", machineModel)
-	if attestResult != nil {
-		w.Header().Set("X-Provider-Serial", attestResult.SerialNumber)
-		if attestResult.SecureEnclaveAvailable {
-			w.Header().Set("X-Provider-Secure-Enclave", "true")
-		} else {
-			w.Header().Set("X-Provider-Secure-Enclave", "false")
-		}
-	}
-	if mdaVerified {
-		w.Header().Set("X-Provider-MDA-Verified", "true")
-	}
-	// SE public key for attestation receipt verification.
-	// Consumers can use this to verify SE signatures on response hashes.
-	if attestResult != nil && attestResult.PublicKey != "" {
-		w.Header().Set("X-Attestation-SE-Public-Key", attestResult.PublicKey)
-		w.Header().Set("X-Attestation-Device-Serial", attestResult.SerialNumber)
-	}
-
-	// When this function returns (consumer disconnect, timeout, or completion),
-	// send a cancel to the provider so it stops generating tokens.
-	defer func() {
-		provider.RemovePending(requestID)
-		s.registry.SetProviderIdle(provider.ID)
-
-		cancelMsg := protocol.CancelMessage{
-			Type:      protocol.TypeCancel,
-			RequestID: requestID,
-		}
-		cancelData, _ := json.Marshal(cancelMsg)
-		if err := provider.Conn.Write(context.Background(), websocket.MessageText, cancelData); err != nil {
-			s.logger.Debug("failed to send cancel (provider may have disconnected)", "request_id", requestID, "error", err)
-		} else {
-			s.logger.Info("sent cancel to provider", "request_id", requestID)
-		}
-	}()
-
-	if stream {
-		s.handleStreamingResponseWithFirstChunk(w, r, pr, firstChunk)
-	} else {
-		s.handleNonStreamingResponseWithFirstChunk(w, r, pr, firstChunk)
+	if s.executeTextDispatch(w, r, rawBody, model, stream, estimatedPromptTokens, requestedMaxTokens, plan.dispatch, plan.reserveBalance, plan.refundReservation) {
+		return
 	}
 }
 
@@ -1748,134 +1966,17 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 
 	// Inject the endpoint so the provider knows which local path to forward to.
 	parsed["endpoint"] = endpoint
+	rawBody, _ = json.Marshal(parsed)
 
-	// Pre-flight balance reservation — same worst-case-cost reservation as
-	// handleChatCompletions. Before this fix the completions and Anthropic
-	// paths routed without ANY reservation; the silent post-inference charge
-	// meant a consumer could receive full responses with a zero balance.
 	consumerKey := consumerKeyFromContext(r.Context())
-	var reservedMicroUSD int64
-	if s.billing != nil {
-		reservedMicroUSD = s.reservationCost(model, estimatedPromptTokens, requestedMaxTokens)
-		if err := s.ledger.Charge(consumerKey, reservedMicroUSD, "reserve:"+consumerKey); err != nil {
-			writeJSON(w, http.StatusPaymentRequired, errorResponse("insufficient_funds",
-				"your balance is too low for this request — add funds at /billing or lower max_tokens"))
-			return
-		}
-	}
-	// Refund the reservation on any early failure before dispatch.
-	refundReservation := func() {
-		if reservedMicroUSD > 0 {
-			_ = s.store.Credit(consumerKey, reservedMicroUSD, store.LedgerRefund, "reservation_refund")
-		}
-	}
-
-	requestID := uuid.New().String()
-	pr := &registry.PendingRequest{
-		RequestID:             requestID,
-		Model:                 model,
-		ConsumerKey:           consumerKey,
-		EstimatedPromptTokens: estimatedPromptTokens,
-		RequestedMaxTokens:    requestedMaxTokens,
-		ReservedMicroUSD:      reservedMicroUSD,
-		ChunkCh:               make(chan string, chunkBufferSize),
-		CompleteCh:            make(chan protocol.UsageInfo, 1),
-		ErrorCh:               make(chan protocol.InferenceErrorMessage, 1),
-	}
-
-	provider := s.registry.ReserveProvider(model, pr)
-	if provider == nil {
-		queuedReq := &registry.QueuedRequest{
-			RequestID:  requestID,
-			Model:      model,
-			Pending:    pr,
-			ResponseCh: make(chan *registry.Provider, 1),
-		}
-		if err := s.registry.Queue().Enqueue(queuedReq); err != nil {
-			refundReservation()
-			writeJSON(w, http.StatusServiceUnavailable, errorResponse("model_not_available",
-				fmt.Sprintf("no provider available for model %q", model)))
-			return
-		}
-		provider, err = s.registry.Queue().WaitForProviderContext(r.Context(), queuedReq)
-		if err != nil {
-			if err == context.Canceled {
-				refundReservation()
-				return
-			}
-			refundReservation()
-			writeJSON(w, http.StatusServiceUnavailable, errorResponse("model_not_available",
-				fmt.Sprintf("no provider became available for model %q", model)))
-			return
-		}
-	}
-
-	inferenceBody, _ := json.Marshal(parsed)
-
-	if provider.PublicKey == "" {
-		s.registry.SetProviderIdle(provider.ID)
-		refundReservation()
-		writeJSON(w, http.StatusServiceUnavailable, errorResponse("encryption_required",
-			"no provider with E2E encryption available"))
+	plan, errResp := s.prepareTextRoutingPlan(r.Context(), consumerKey, model, estimatedPromptTokens, requestedMaxTokens)
+	if errResp.status != 0 {
+		writeJSON(w, errResp.status, errResp.body)
 		return
 	}
 
-	providerPubKey, err := e2e.ParsePublicKey(provider.PublicKey)
-	if err != nil {
-		s.registry.SetProviderIdle(provider.ID)
-		refundReservation()
-		writeJSON(w, http.StatusInternalServerError, errorResponse("encryption_error", "provider public key invalid"))
+	if s.executeTextDispatch(w, r, rawBody, model, stream, estimatedPromptTokens, requestedMaxTokens, plan.dispatch, plan.reserveBalance, plan.refundReservation) {
 		return
-	}
-
-	sessionKeys, err := e2e.GenerateSessionKeys()
-	if err != nil {
-		s.registry.SetProviderIdle(provider.ID)
-		refundReservation()
-		writeJSON(w, http.StatusInternalServerError, errorResponse("encryption_error", "failed to generate session keys"))
-		return
-	}
-
-	encrypted, err := e2e.Encrypt(inferenceBody, providerPubKey, sessionKeys)
-	if err != nil {
-		s.registry.SetProviderIdle(provider.ID)
-		refundReservation()
-		writeJSON(w, http.StatusInternalServerError, errorResponse("encryption_error", "failed to encrypt request"))
-		return
-	}
-
-	wireMsg := map[string]any{
-		"type":       protocol.TypeInferenceRequest,
-		"request_id": requestID,
-		"encrypted_body": map[string]string{
-			"ephemeral_public_key": encrypted.EphemeralPublicKey,
-			"ciphertext":           encrypted.Ciphertext,
-		},
-	}
-
-	pr.SessionPrivKey = &sessionKeys.PrivateKey
-
-	data, _ := json.Marshal(wireMsg)
-	if err := provider.Conn.Write(r.Context(), websocket.MessageText, data); err != nil {
-		provider.RemovePending(requestID)
-		s.registry.SetProviderIdle(provider.ID)
-		refundReservation()
-		writeJSON(w, http.StatusBadGateway, errorResponse("provider_error", "failed to send request to provider"))
-		return
-	}
-
-	s.logger.Info("inference request dispatched",
-		"request_id", requestID,
-		"model", model,
-		"provider_id", provider.ID,
-		"endpoint", endpoint,
-		"stream", stream,
-	)
-
-	if stream {
-		s.handleStreamingResponse(w, r, pr)
-	} else {
-		s.handleNonStreamingResponse(w, r, pr)
 	}
 }
 

--- a/coordinator/internal/api/provider.go
+++ b/coordinator/internal/api/provider.go
@@ -668,38 +668,44 @@ func (s *Server) handleComplete(providerID string, provider *registry.Provider, 
 	responseTime := time.Duration(msg.Usage.CompletionTokens) * time.Millisecond * 10
 	s.registry.RecordJobSuccess(providerID, responseTime)
 
-	// Calculate cost — check provider's custom price, then platform DB price,
-	// then hardcoded defaults.
-	providerWalletForPricing := ""
-	if p := s.registry.GetProvider(providerID); p != nil {
-		providerWalletForPricing = p.WalletAddress
-	}
-	customIn, customOut, hasCustom := s.store.GetModelPrice(providerWalletForPricing, pr.Model)
-	if !hasCustom {
-		customIn, customOut, hasCustom = s.store.GetModelPrice("platform", pr.Model)
-	}
-	totalCost := payments.CalculateCostWithOverrides(pr.Model, msg.Usage.PromptTokens, msg.Usage.CompletionTokens, customIn, customOut, hasCustom)
+	totalCost := int64(0)
+	providerPayout := int64(0)
+	platformFee := int64(0)
+	if !pr.SelfHosted {
+		// Calculate cost — check provider's custom price, then platform DB price,
+		// then hardcoded defaults.
+		providerWalletForPricing := ""
+		if p := s.registry.GetProvider(providerID); p != nil {
+			providerWalletForPricing = p.WalletAddress
+		}
+		customIn, customOut, hasCustom := s.store.GetModelPrice(providerWalletForPricing, pr.Model)
+		if !hasCustom {
+			customIn, customOut, hasCustom = s.store.GetModelPrice("platform", pr.Model)
+		}
+		totalCost = payments.CalculateCostWithOverrides(pr.Model, msg.Usage.PromptTokens, msg.Usage.CompletionTokens, customIn, customOut, hasCustom)
 
-	// Clamp reported cost at the pre-flight reservation. The reservation
-	// uses platform-default and platform-override pricing; a provider that
-	// sets a custom price above the platform rate accepts revenue capped at
-	// the reservation (this is documented by reservationCost). The clamp
-	// also neutralizes over-reporting: with max_tokens injected into the
-	// outgoing request a cooperating provider can never legitimately bill
-	// more than the reservation, so excess means miscounting or fraud.
-	// Logged at Error so misbehavior shows in the operator dashboards.
-	if pr.ReservedMicroUSD > 0 && totalCost > pr.ReservedMicroUSD {
-		s.logger.Error("provider reported cost above reservation — clamping",
-			"provider_id", providerID,
-			"request_id", msg.RequestID,
-			"reported_cost_micro_usd", totalCost,
-			"reserved_micro_usd", pr.ReservedMicroUSD,
-			"prompt_tokens", msg.Usage.PromptTokens,
-			"completion_tokens", msg.Usage.CompletionTokens,
-		)
-		totalCost = pr.ReservedMicroUSD
+		// Clamp reported cost at the pre-flight reservation. The reservation
+		// uses platform-default and platform-override pricing; a provider that
+		// sets a custom price above the platform rate accepts revenue capped at
+		// the reservation (this is documented by reservationCost). The clamp
+		// also neutralizes over-reporting: with max_tokens injected into the
+		// outgoing request a cooperating provider can never legitimately bill
+		// more than the reservation, so excess means miscounting or fraud.
+		// Logged at Error so misbehavior shows in the operator dashboards.
+		if pr.ReservedMicroUSD > 0 && totalCost > pr.ReservedMicroUSD {
+			s.logger.Error("provider reported cost above reservation — clamping",
+				"provider_id", providerID,
+				"request_id", msg.RequestID,
+				"reported_cost_micro_usd", totalCost,
+				"reserved_micro_usd", pr.ReservedMicroUSD,
+				"prompt_tokens", msg.Usage.PromptTokens,
+				"completion_tokens", msg.Usage.CompletionTokens,
+			)
+			totalCost = pr.ReservedMicroUSD
+		}
+		providerPayout = payments.ProviderPayout(totalCost)
+		platformFee = payments.PlatformFee(totalCost)
 	}
-	providerPayout := payments.ProviderPayout(totalCost)
 
 	// Adjust billing against the pre-flight reservation. After the clamp above
 	// totalCost <= reserved, so the only path here is a refund of the unused
@@ -733,53 +739,54 @@ func (s *Server) handleComplete(providerID string, provider *registry.Provider, 
 	})
 	s.store.RecordUsageWithCost(providerID, pr.ConsumerKey, pr.Model, msg.RequestID, msg.Usage.PromptTokens, msg.Usage.CompletionTokens, totalCost)
 
-	// Credit the provider's pending payout.
-	// If the provider is linked to an account (via device auth), credit that account.
-	// Otherwise, fall back to the provider's self-reported wallet address.
-	if p := s.registry.GetProvider(providerID); p != nil {
-		if p.AccountID != "" {
-			// Provider is linked to a Privy account — atomically credit the
-			// account and record the per-node earning in one store transaction.
-			if err := s.store.CreditProviderAccount(&store.ProviderEarning{
-				AccountID:        p.AccountID,
-				ProviderID:       providerID,
-				ProviderKey:      p.PublicKey,
-				JobID:            msg.RequestID,
-				Model:            pr.Model,
-				AmountMicroUSD:   providerPayout,
-				PromptTokens:     msg.Usage.PromptTokens,
-				CompletionTokens: msg.Usage.CompletionTokens,
-				CreatedAt:        time.Now(),
-			}); err != nil {
-				s.logger.Error("failed to credit linked provider account",
-					"provider_id", providerID,
-					"account_id", p.AccountID,
-					"request_id", msg.RequestID,
-					"error", err,
-				)
-			}
-		} else if p.WalletAddress != "" {
-			// Unlinked provider — atomically credit the wallet and record payout history.
-			if err := s.ledger.CreditProvider(p.WalletAddress, providerPayout, pr.Model, msg.RequestID); err != nil {
-				s.logger.Error("failed to credit provider wallet payout",
-					"provider_id", providerID,
-					"wallet_address", p.WalletAddress,
-					"request_id", msg.RequestID,
-					"error", err,
-				)
+	if !pr.SelfHosted {
+		// Credit the provider's pending payout.
+		// If the provider is linked to an account (via device auth), credit that account.
+		// Otherwise, fall back to the provider's self-reported wallet address.
+		if p := s.registry.GetProvider(providerID); p != nil {
+			if p.AccountID != "" {
+				// Provider is linked to a Privy account — atomically credit the
+				// account and record the per-node earning in one store transaction.
+				if err := s.store.CreditProviderAccount(&store.ProviderEarning{
+					AccountID:        p.AccountID,
+					ProviderID:       providerID,
+					ProviderKey:      p.PublicKey,
+					JobID:            msg.RequestID,
+					Model:            pr.Model,
+					AmountMicroUSD:   providerPayout,
+					PromptTokens:     msg.Usage.PromptTokens,
+					CompletionTokens: msg.Usage.CompletionTokens,
+					CreatedAt:        time.Now(),
+				}); err != nil {
+					s.logger.Error("failed to credit linked provider account",
+						"provider_id", providerID,
+						"account_id", p.AccountID,
+						"request_id", msg.RequestID,
+						"error", err,
+					)
+				}
+			} else if p.WalletAddress != "" {
+				// Unlinked provider — atomically credit the wallet and record payout history.
+				if err := s.ledger.CreditProvider(p.WalletAddress, providerPayout, pr.Model, msg.RequestID); err != nil {
+					s.logger.Error("failed to credit provider wallet payout",
+						"provider_id", providerID,
+						"wallet_address", p.WalletAddress,
+						"request_id", msg.RequestID,
+						"error", err,
+					)
+				}
 			}
 		}
-	}
 
-	// Record platform fee, distributing referral rewards if applicable.
-	platformFee := payments.PlatformFee(totalCost)
-	if platformFee > 0 {
-		// Check if consumer has a referrer and distribute reward.
-		// The referral service deducts the referrer's share from the platform fee.
-		if s.billing != nil && s.billing.Referral() != nil {
-			platformFee = s.billing.Referral().DistributeReferralReward(pr.ConsumerKey, platformFee, msg.RequestID)
+		// Record platform fee, distributing referral rewards if applicable.
+		if platformFee > 0 {
+			// Check if consumer has a referrer and distribute reward.
+			// The referral service deducts the referrer's share from the platform fee.
+			if s.billing != nil && s.billing.Referral() != nil {
+				platformFee = s.billing.Referral().DistributeReferralReward(pr.ConsumerKey, platformFee, msg.RequestID)
+			}
+			_ = s.store.Credit("platform", platformFee, store.LedgerPlatformFee, msg.RequestID)
 		}
-		_ = s.store.Credit("platform", platformFee, store.LedgerPlatformFee, msg.RequestID)
 	}
 
 	// Signal completion to the consumer response handler. This must happen
@@ -799,6 +806,7 @@ func (s *Server) handleComplete(providerID string, provider *registry.Provider, 
 		"completion_tokens", msg.Usage.CompletionTokens,
 		"cost_micro_usd", totalCost,
 		"provider_payout_micro_usd", providerPayout,
+		"self_hosted", pr.SelfHosted,
 	)
 }
 

--- a/coordinator/internal/registry/registry.go
+++ b/coordinator/internal/registry/registry.go
@@ -58,6 +58,9 @@ type PendingRequest struct {
 	ProviderID  string
 	Model       string
 	ConsumerKey string
+	// SelfHosted marks requests pinned to a provider owned by the same account
+	// as the consumer. These requests bypass marketplace billing and payouts.
+	SelfHosted bool
 	// EstimatedPromptTokens is a coordinator-side heuristic used only for
 	// routing and queue admission. It does not need tokenizer-perfect accuracy.
 	EstimatedPromptTokens int

--- a/coordinator/internal/registry/scheduler.go
+++ b/coordinator/internal/registry/scheduler.go
@@ -31,6 +31,7 @@ const (
 type routingSnapshot struct {
 	provider           *Provider
 	model              string
+	accountID          string
 	slotState          string
 	totalPending       int
 	pendingForModel    int
@@ -95,14 +96,78 @@ func (r *Registry) ReserveProvider(model string, pr *PendingRequest, excludeIDs 
 	return p
 }
 
+// ReserveOwnedProvider reserves capacity on a provider owned by the given
+// account. Self-hosted requests only qualify when the exact model is actively
+// running on that provider; cold or crashed backends are not eligible because
+// "provider self-use is free while running" must never spill over to a paid
+// marketplace route or a cold-started backend that is merely configured.
+func (r *Registry) ReserveOwnedProvider(accountID, model string, pr *PendingRequest, excludeIDs ...string) *Provider {
+	if pr == nil {
+		return nil
+	}
+	if pr.RequestID == "" {
+		return nil
+	}
+	if pr.Model == "" {
+		pr.Model = model
+	}
+	if pr.RequestedMaxTokens <= 0 {
+		pr.RequestedMaxTokens = defaultRequestedMaxTokens
+	}
+	if accountID == "" {
+		return nil
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	selected := r.selectOwnedCandidateLocked(accountID, model, pr, excludeIDs...)
+	if selected == nil {
+		return nil
+	}
+
+	p := selected.provider
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if !r.providerCanSelfHostLocked(p, accountID, model) {
+		return nil
+	}
+
+	pr.ProviderID = p.ID
+	p.addPendingLocked(pr)
+	if p.Status != StatusUntrusted && p.Status != StatusOffline {
+		p.Status = StatusServing
+	}
+	return p
+}
+
+// HasOwnedRunningProvider reports whether the account currently has a routable
+// provider with the requested model already running.
+func (r *Registry) HasOwnedRunningProvider(accountID, model string) bool {
+	if accountID == "" {
+		return false
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	now := time.Now()
+	for _, p := range r.providers {
+		if r.providerHasSelfHostedRouteLocked(p, accountID, model, now) {
+			return true
+		}
+	}
+	return false
+}
+
 func (r *Registry) selectBestCandidateLocked(model string, pr *PendingRequest, excludeIDs ...string) *routingCandidate {
 	excludeSet := make(map[string]struct{}, len(excludeIDs))
 	for _, id := range excludeIDs {
 		excludeSet[id] = struct{}{}
 	}
 
-	var best *routingCandidate
-	var nearTies []*routingCandidate
+	var candidates []*routingCandidate
 	for _, p := range r.providers {
 		if _, excluded := excludeSet[p.ID]; excluded {
 			continue
@@ -115,8 +180,49 @@ func (r *Registry) selectBestCandidateLocked(model string, pr *PendingRequest, e
 		if !ok {
 			continue
 		}
+		candidates = append(candidates, candidate)
+	}
 
-		if best == nil || candidate.costMs < best.costMs {
+	return pickBestCandidate(candidates)
+}
+
+func (r *Registry) selectOwnedCandidateLocked(accountID, model string, pr *PendingRequest, excludeIDs ...string) *routingCandidate {
+	excludeSet := make(map[string]struct{}, len(excludeIDs))
+	for _, id := range excludeIDs {
+		excludeSet[id] = struct{}{}
+	}
+
+	var candidates []*routingCandidate
+	for _, p := range r.providers {
+		if _, excluded := excludeSet[p.ID]; excluded {
+			continue
+		}
+		snap, ok := r.snapshotProviderLocked(p, model)
+		if !ok {
+			continue
+		}
+		if snap.accountID != accountID || snap.slotState != "running" {
+			continue
+		}
+		candidate, ok := r.buildCandidate(snap, pr)
+		if !ok {
+			continue
+		}
+		candidates = append(candidates, candidate)
+	}
+
+	return pickBestCandidate(candidates)
+}
+
+func pickBestCandidate(candidates []*routingCandidate) *routingCandidate {
+	if len(candidates) == 0 {
+		return nil
+	}
+
+	best := candidates[0]
+	nearTies := []*routingCandidate{best}
+	for _, candidate := range candidates[1:] {
+		if candidate.costMs < best.costMs {
 			best = candidate
 			nearTies = []*routingCandidate{candidate}
 			continue
@@ -126,9 +232,6 @@ func (r *Registry) selectBestCandidateLocked(model string, pr *PendingRequest, e
 		}
 	}
 
-	if best == nil {
-		return nil
-	}
 	if len(nearTies) == 1 {
 		return best
 	}
@@ -188,6 +291,7 @@ func (r *Registry) snapshotProviderLocked(p *Provider, model string) (routingSna
 	snap := routingSnapshot{
 		provider:      p,
 		model:         model,
+		accountID:     p.AccountID,
 		slotState:     "unknown",
 		totalPending:  p.pendingCount(),
 		systemMetrics: p.SystemMetrics,
@@ -388,6 +492,59 @@ func (r *Registry) providerCanAdmitLocked(p *Provider, model string) bool {
 		}
 	}
 	return true
+}
+
+func (r *Registry) providerCanSelfHostLocked(p *Provider, accountID, model string) bool {
+	if accountID == "" || p.AccountID != accountID {
+		return false
+	}
+	if p.PublicKey == "" {
+		return false
+	}
+	if !r.providerCanAdmitLocked(p, model) {
+		return false
+	}
+	if p.BackendCapacity == nil {
+		return false
+	}
+	for _, slot := range p.BackendCapacity.Slots {
+		if slot.Model != model {
+			continue
+		}
+		return slot.State == "running"
+	}
+	return false
+}
+
+func (r *Registry) providerHasSelfHostedRouteLocked(p *Provider, accountID, model string, now time.Time) bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if accountID == "" || p.AccountID != accountID {
+		return false
+	}
+	if p.PublicKey == "" {
+		return false
+	}
+	if p.Status == StatusOffline || p.Status == StatusUntrusted {
+		return false
+	}
+	if trustRank(p.TrustLevel) < trustRank(r.MinTrustLevel) || !p.RuntimeVerified {
+		return false
+	}
+	if p.LastChallengeVerified.IsZero() || now.Sub(p.LastChallengeVerified) > challengeFreshnessMaxAge {
+		return false
+	}
+	if !providerServesModelLocked(p, model) || p.BackendCapacity == nil {
+		return false
+	}
+	for _, slot := range p.BackendCapacity.Slots {
+		if slot.Model != model {
+			continue
+		}
+		return slot.State == "running"
+	}
+	return false
 }
 
 func (r *Registry) drainQueuedRequestsForModels(models []string) {

--- a/coordinator/internal/registry/scheduler_test.go
+++ b/coordinator/internal/registry/scheduler_test.go
@@ -320,3 +320,76 @@ func TestHeartbeatDrainsQueueAfterSlotRecovery(t *testing.T) {
 		t.Fatal("timed out waiting for recovered slot assignment")
 	}
 }
+
+func TestReserveOwnedProviderRequiresMatchingAccountAndRunningSlot(t *testing.T) {
+	reg := New(testLogger())
+	model := "owned-model"
+	p := makeSchedulerProvider(t, reg, "owned", model, 100)
+
+	p.mu.Lock()
+	p.AccountID = "acct-owner"
+	p.PublicKey = "ZmFrZS1vd25lZC1wdWJsaWMta2V5LXRlc3Q="
+	p.mu.Unlock()
+
+	req := &PendingRequest{RequestID: "req-owned", Model: model, RequestedMaxTokens: 128}
+	selected := reg.ReserveOwnedProvider("acct-owner", model, req)
+	if selected == nil {
+		t.Fatal("ReserveOwnedProvider returned nil for matching running provider")
+	}
+	if selected.ID != p.ID {
+		t.Fatalf("selected %q, want %q", selected.ID, p.ID)
+	}
+
+	selected.RemovePending(req.RequestID)
+	reg.SetProviderIdle(selected.ID)
+
+	if got := reg.ReserveOwnedProvider("acct-other", model, &PendingRequest{
+		RequestID:          "req-other-account",
+		Model:              model,
+		RequestedMaxTokens: 128,
+	}); got != nil {
+		t.Fatalf("expected nil for non-owner account, got %q", got.ID)
+	}
+
+	p.mu.Lock()
+	p.BackendCapacity.Slots[0].State = "idle_shutdown"
+	p.mu.Unlock()
+
+	if got := reg.ReserveOwnedProvider("acct-owner", model, &PendingRequest{
+		RequestID:          "req-cold",
+		Model:              model,
+		RequestedMaxTokens: 128,
+	}); got != nil {
+		t.Fatalf("expected nil for non-running owned slot, got %q", got.ID)
+	}
+}
+
+func TestHasOwnedRunningProviderIgnoresCapacityButRequiresRunningSlot(t *testing.T) {
+	reg := New(testLogger())
+	model := "owned-running"
+	p := makeSchedulerProvider(t, reg, "owned", model, 90)
+
+	p.mu.Lock()
+	p.AccountID = "acct-owner"
+	p.PublicKey = "ZmFrZS1vd25lZC1wdWJsaWMta2V5LXRlc3Q="
+	for i := 0; i < p.maxConcurrency(); i++ {
+		p.addPendingLocked(&PendingRequest{
+			RequestID:          "pending-" + string(rune('a'+i)),
+			Model:              model,
+			RequestedMaxTokens: 64,
+		})
+	}
+	p.mu.Unlock()
+
+	if !reg.HasOwnedRunningProvider("acct-owner", model) {
+		t.Fatal("expected owned running provider to be detected even at capacity")
+	}
+
+	p.mu.Lock()
+	p.BackendCapacity.Slots[0].State = "crashed"
+	p.mu.Unlock()
+
+	if reg.HasOwnedRunningProvider("acct-owner", model) {
+		t.Fatal("expected crashed owned slot to be ignored")
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add owner-pinned self-hosted routing for text requests when a linked provider already has the requested model actively running and is E2E-ready
- keep self-hosted requests free by recording zero consumer cost, zero provider payout, and zero platform fee while still tracking usage
- preserve normal marketplace behavior by falling back to the paid path when self-hosted routing is unavailable or fails before commit, and add focused registry/api regression coverage

## Testing
- `cd coordinator && go test ./internal/registry ./internal/api`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c9d71705-34c3-4d15-ac56-aaeee0bcfc12"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c9d71705-34c3-4d15-ac56-aaeee0bcfc12"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

