### PR TITLE
Add Stripe Connect Express payouts (bank + instant debit card)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,24 @@
 name: Release Provider Bundle
 
+# Two release paths share this workflow:
+#   1. tag push `vX.Y.Z`       -> prod   (reviewer approval required)
+#   2. tag push `vX.Y.Z-dev.N` -> dev    (auto)
+#   3. manual workflow_dispatch with environment input (either)
+# The `environment:` on the job selects which GitHub Environment's secrets
+# and vars get injected, so prod and dev use disjoint R2 buckets, release
+# keys, and coordinator URLs.
+
 on:
   push:
     tags: ['v*']
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Target environment'
+        required: true
+        type: choice
+        options: [dev, prod]
+        default: dev
 
 env:
   CARGO_TERM_COLOR: always
@@ -12,8 +28,27 @@ env:
   PBS_PYTHON_VERSION: "3.12.13"
 
 jobs:
+  # Resolve target environment from either workflow_dispatch input or tag shape.
+  # Dev tags look like `v0.3.6-dev.2`; prod tags are strict `v0.3.6`.
+  resolve-env:
+    runs-on: ubuntu-latest
+    outputs:
+      environment: ${{ steps.pick.outputs.environment }}
+    steps:
+      - id: pick
+        run: |
+          if [ -n "${{ inputs.environment }}" ]; then
+            echo "environment=${{ inputs.environment }}" >> $GITHUB_OUTPUT
+          elif [[ "${{ github.ref_name }}" == *-dev.* ]]; then
+            echo "environment=dev" >> $GITHUB_OUTPUT
+          else
+            echo "environment=prod" >> $GITHUB_OUTPUT
+          fi
+
   build-and-release:
     name: Build, Sign, Upload, Register
+    needs: resolve-env
+    environment: ${{ needs.resolve-env.outputs.environment }}
     runs-on: macos-26-xlarge  # Apple Silicon, 16 cores
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -73,6 +108,11 @@ jobs:
           LIBRARY_PATH: /tmp/eigeninference-build-python/lib
           DYLD_LIBRARY_PATH: /tmp/eigeninference-build-python/lib
           RUSTFLAGS: -L native=/tmp/eigeninference-build-python/lib
+          # Bake the target environment's coordinator URL + R2 CDN into the
+          # binary via provider/build.rs. A dev bundle physically cannot reach
+          # prod R2 or the prod coordinator.
+          DARKBLOOM_COORDINATOR_URL: ${{ secrets.COORDINATOR_URL }}
+          DARKBLOOM_R2_CDN_URL: ${{ vars.R2_CDN }}
         run: |
           cd provider
           cargo build --release
@@ -253,6 +293,8 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
           R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
+          R2_BUCKET: ${{ vars.R2_BUCKET }}
+          R2_CDN: ${{ vars.R2_CDN }}
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
 
@@ -361,24 +403,24 @@ jobs:
 
           # Upload Python runtime to R2 (providers download this)
           aws s3 cp /tmp/eigeninference-python-macos-arm64.tar.gz \
-            "s3://d-inf-app/releases/v${VERSION}/eigeninference-python-macos-arm64.tar.gz" \
+            "s3://${R2_BUCKET}/releases/v${VERSION}/eigeninference-python-macos-arm64.tar.gz" \
             --endpoint-url "$R2_ENDPOINT"
           echo "Python runtime uploaded to R2"
 
           # Upload site-packages tarball — providers use this for self-heal
           aws s3 cp /tmp/eigeninference-site-packages.tar.gz \
-            "s3://d-inf-app/releases/v${VERSION}/eigeninference-site-packages.tar.gz" \
+            "s3://${R2_BUCKET}/releases/v${VERSION}/eigeninference-site-packages.tar.gz" \
             --endpoint-url "$R2_ENDPOINT"
           echo "Site-packages uploaded to R2"
 
           # Upload the vllm-mlx source zip as fallback for older providers.
           aws s3 cp /tmp/vllm-mlx-source.zip \
-            "s3://d-inf-app/releases/v${VERSION}/vllm-mlx-source.zip" \
+            "s3://${R2_BUCKET}/releases/v${VERSION}/vllm-mlx-source.zip" \
             --endpoint-url "$R2_ENDPOINT"
           echo "vllm-mlx source zip uploaded to R2"
 
-          # Compute template hashes from R2 CDN
-          R2_CDN="https://pub-7cbee059c80c46ec9c071dbee2726f8a.r2.dev"
+          # Compute template hashes from R2 CDN (per-environment public bucket URL)
+          R2_CDN="${R2_CDN:-https://pub-7cbee059c80c46ec9c071dbee2726f8a.r2.dev}"
           TEMPLATE_HASHES=""
           for name in qwen3.5 trinity gemma4 minimax; do
             HASH=$(curl -fsSL "$R2_CDN/templates/${name}.jinja" 2>/dev/null | shasum -a 256 | cut -d' ' -f1)
@@ -404,10 +446,11 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
           R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
+          R2_BUCKET: ${{ vars.R2_BUCKET }}
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
           aws s3 cp /tmp/eigeninference-bundle-macos-arm64.tar.gz \
-            "s3://d-inf-app/releases/v${VERSION}/eigeninference-bundle-macos-arm64.tar.gz" \
+            "s3://${R2_BUCKET}/releases/v${VERSION}/eigeninference-bundle-macos-arm64.tar.gz" \
             --endpoint-url "$R2_ENDPOINT"
           echo "Uploaded to R2: releases/v${VERSION}/eigeninference-bundle-macos-arm64.tar.gz"
 
@@ -505,15 +548,16 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
           R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
+          R2_BUCKET: ${{ vars.R2_BUCKET }}
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
           # Versioned
           aws s3 cp /tmp/Darkbloom.dmg \
-            "s3://d-inf-app/releases/v${VERSION}/Darkbloom.dmg" \
+            "s3://${R2_BUCKET}/releases/v${VERSION}/Darkbloom.dmg" \
             --endpoint-url "$R2_ENDPOINT"
           # Latest (stable URL for website download button)
           aws s3 cp /tmp/Darkbloom.dmg \
-            "s3://d-inf-app/releases/latest/Darkbloom.dmg" \
+            "s3://${R2_BUCKET}/releases/latest/Darkbloom.dmg" \
             --endpoint-url "$R2_ENDPOINT"
           echo "DMG uploaded to R2: releases/v${VERSION}/Darkbloom.dmg + releases/latest/Darkbloom.dmg"
 
@@ -522,7 +566,7 @@ jobs:
       - name: Register release with coordinator
         env:
           COORDINATOR_URL: ${{ secrets.COORDINATOR_URL }}
-          RELEASE_KEY: ${{ secrets.DGINF_RELEASE_KEY }}
+          RELEASE_KEY: ${{ secrets.RELEASE_KEY }}
           R2_PUBLIC_URL: ${{ secrets.R2_PUBLIC_URL }}
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
@@ -590,5 +634,5 @@ jobs:
 
             ### Install
             ```bash
-            curl -fsSL https://api.darkbloom.dev/install.sh | bash
+            curl -fsSL ${{ secrets.COORDINATOR_URL }}/install.sh | bash
             ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -188,25 +188,24 @@ Canonical runbook: `docs/coordinator-deploy-runbook.md`
 
 Current release-sensitive pieces:
 
-- Coordinator deploy target in the runbook is AWS EC2 `34.197.17.112` (`api.darkbloom.dev`).
+- Prod coordinator runs on EigenCloud (TEE) as app `d-inference` at `api.darkbloom.dev`. Build target: `coordinator/Dockerfile`. Dev coordinator runs on Google Cloud (see `docs/dev-environment.md`).
 - Provider bundle creation lives in `scripts/build-bundle.sh`.
 - App bundle + DMG creation lives in `scripts/bundle-app.sh`.
 - Installer flow lives in `scripts/install.sh`.
 - Provider update checks use `LatestProviderVersion` in `coordinator/internal/api/server.go`, so bundle uploads and version bumps need to stay coordinated.
 - CI release workflow (`release.yml`) signs binaries with Developer ID Application cert, notarizes with Apple, computes SHA-256 hashes after signing.
 
-Quick coordinator deploy:
+Quick coordinator deploy (prod, EigenCloud):
 
 ```bash
-cd coordinator && \
-GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o eigeninference-coordinator-linux ./cmd/coordinator && \
-scp -i ~/.ssh/eigeninference-infra eigeninference-coordinator-linux ubuntu@34.197.17.112:/tmp/eigeninference-coordinator && \
-ssh -i ~/.ssh/eigeninference-infra ubuntu@34.197.17.112 \
-  'sudo systemctl stop eigeninference-coordinator && \
-   sudo mv /tmp/eigeninference-coordinator /usr/local/bin/eigeninference-coordinator && \
-   sudo chmod +x /usr/local/bin/eigeninference-coordinator && \
-   sudo systemctl start eigeninference-coordinator'
+# EigenCloud builds from the repo via coordinator/Dockerfile and blue-green deploys.
+git push origin master
+ecloud compute app deploy d-inference
+curl https://api.darkbloom.dev/health
+ecloud compute app logs d-inference
 ```
+
+Dev coordinator deploy (Google Cloud): see `docs/dev-environment.md`.
 
 ## Important Sync Points
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ Decentralized inference network for Apple Silicon Macs. Providers offer GPU comp
 ## Project Structure
 
 ```
-coordinator/          Go — central matchmaking server (runs on AWS)
+coordinator/          Go — central matchmaking server (runs on EigenCloud in prod)
 ├── cmd/coordinator/  entrypoint
 ├── cmd/verify-attestation/  attestation blob verification utility
 ├── internal/
@@ -116,7 +116,7 @@ The `.external/` directory contains our fork of [vllm-mlx](https://github.com/Ga
 ```bash
 cd coordinator
 go test ./...
-# Cross-compile for AWS (Linux amd64):
+# Cross-compile for the EigenCloud container (Linux amd64):
 GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o eigeninference-coordinator-linux ./cmd/coordinator
 ```
 
@@ -187,49 +187,52 @@ Full deploy runbook: **[docs/coordinator-deploy-runbook.md](docs/coordinator-dep
 
 Covers coordinator deploy, provider CLI bundling, macOS app distribution, and install.sh updates.
 
-### Coordinator (quick deploy)
-```bash
-cd coordinator && \
-GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o eigeninference-coordinator-linux ./cmd/coordinator && \
-scp -i ~/.ssh/eigeninference-infra eigeninference-coordinator-linux ubuntu@34.197.17.112:/tmp/eigeninference-coordinator && \
-ssh -i ~/.ssh/eigeninference-infra ubuntu@34.197.17.112 \
-  'sudo systemctl stop eigeninference-coordinator && \
-   sudo mv /tmp/eigeninference-coordinator /usr/local/bin/eigeninference-coordinator && \
-   sudo chmod +x /usr/local/bin/eigeninference-coordinator && \
-   sudo systemctl start eigeninference-coordinator'
-```
+### Coordinator (prod, EigenCloud)
 
-### Provider bundle (quick upload)
-```bash
-# After building provider + enclave:
-scp -i ~/.ssh/eigeninference-infra /tmp/eigeninference-bundle/eigeninference-bundle-macos-arm64.tar.gz \
-  ubuntu@34.197.17.112:/var/www/html/dl/
-```
+> **AI agents must NOT deploy to EigenCloud.** Prod deploys (`ecloud compute app deploy …`, any mutation of the `d-inference` EigenCloud app, any write to EigenCloud KMS or prod secrets) are a human-only action. If asked to ship to prod, stop and hand off — prepare the PR, the tag, or the exact commands, but do not execute them. This applies even when the user says "deploy"; confirm they mean *they* will run it, not you. Read-only commands like `ecloud compute app logs d-inference` or `curl https://api.darkbloom.dev/health` are fine.
 
-## SSH
+The prod coordinator runs on EigenCloud (TEE). Build target is `coordinator/Dockerfile`; EigenCloud builds from the repo and injects Caddy + TLS. Deploy is blue-green with persistent disk transfer (`/mnt/disks/userdata`).
 
-Use persistent SSH control sockets to avoid rate limits when running multiple commands against the same host:
+Human-only deploy flow (for reference — do not run this as the agent):
 
 ```bash
-# First connection opens the socket (add to first SSH/SCP call):
-ssh -o ControlMaster=auto -o ControlPath=/tmp/ssh-%r@%h -o ControlPersist=600 -i ~/.ssh/eigeninference-infra ubuntu@34.197.17.112 "..."
+# 1. Push your changes (agent may do this if explicitly asked)
+git push origin master
 
-# Subsequent calls reuse it automatically (same ControlPath):
-ssh -o ControlPath=/tmp/ssh-%r@%h ubuntu@34.197.17.112 "..."
-scp -o ControlPath=/tmp/ssh-%r@%h file ubuntu@34.197.17.112:/path
+# 2. Trigger EigenCloud deploy — HUMAN ONLY
+ecloud compute app deploy d-inference
+
+# 3. Verify (agent may do this)
+curl https://api.darkbloom.dev/health
+ecloud compute app logs d-inference
 ```
 
-Always use control sockets when running multiple SSH/SCP commands to the same host in a session.
+Deploy time: ~5-7 minutes. Env vars/secrets are managed via EigenCloud KMS — see `docs/coordinator-deploy-runbook.md` for the full list.
+
+### Coordinator (dev, Google Cloud)
+
+The dev coordinator runs on GCP (project `sepolia-ai`) — separate domain (`api.dev.darkbloom.dev`), separate R2 bucket (`d-inf-app-dev`), **same** trust level as prod (`MIN_TRUST=hardware`, full MDM + step-ca stack). Mainnet Solana with a dev-only BIP39 mnemonic. **Never** used for prod traffic. Full wiring in [docs/dev-environment.md](docs/dev-environment.md).
+
+Shape: GCE Ubuntu VM + Docker + systemd (coordinator + step-ca + MicroMDM need persistent disk state), Cloud SQL Postgres via cloud-sql-proxy, **Vercel**-hosted console UI, Cloud Build auto-deploys on master push. ~2–4 min coordinator upgrades.
+
+### Provider bundle
+
+CI (`.github/workflows/release.yml`) builds, signs, notarizes, and uploads bundles to Cloudflare R2 (`s3://d-inf-app/releases/v{VERSION}/`), then registers the release with the coordinator via `POST /v1/releases`. Providers fetch via `install.sh` served by the coordinator. There is no SSH-to-a-VM step.
 
 ## Infrastructure
 
-| Component | Location | Details |
-|-----------|----------|---------|
-| Coordinator | AWS EC2 `eigeninference-mdm` | t3.small, `34.197.17.112` (Elastic IP), systemd service |
-| Domain | `inference-test.openinnovation.dev` | nginx → localhost:8080, Let's Encrypt TLS |
-| SSH | `ssh -i ~/.ssh/eigeninference-infra ubuntu@34.197.17.112` | Key name: `eigeninference-infra` |
-| AWS Profile | `admin` | Account 084828557146 |
-| Provider install | `curl -fsSL https://inference-test.openinnovation.dev/install.sh \| bash` | Downloads tarball from `/dl/` |
+| Component | Prod | Dev |
+|-----------|------|-----|
+| Coordinator host | EigenCloud app `d-inference` | GCE VM `d-inference-dev` (us-central1-a, Ubuntu + Docker + systemd) |
+| Console UI | EigenCloud app | Vercel (separate dev project, `NEXT_PUBLIC_COORDINATOR_URL=https://api.dev.darkbloom.dev`) |
+| Domain | `api.darkbloom.dev` | `api.dev.darkbloom.dev` |
+| TLS | Caddy + EigenCloud-injected certs | Caddy in-container (step-ca or Let's Encrypt ACME, VM :443) |
+| Database | AWS RDS PostgreSQL (managed) | Cloud SQL Postgres 16 `d-inference-dev-db` via cloud-sql-proxy sidecar |
+| Persistent storage | `/mnt/disks/userdata` (EigenCloud blue-green) | GCE persistent disk `d-inference-dev-data`, 30 GB, mounted at `/mnt/disks/userdata` |
+| Logs | `ecloud compute app logs d-inference` | `gcloud logging read ...` (VM + Cloud SQL in Cloud Logging) |
+| Release bucket | R2 `d-inf-app` | R2 `d-inf-app-dev` |
+| Trust level | `hardware` (MDM enrollment required) | `hardware` (same — full MDM + step-ca stack) |
+| Provider install | `curl -fsSL https://api.darkbloom.dev/install.sh \| bash` | `curl -fsSL https://api.dev.darkbloom.dev/install.sh \| bash` |
 
 ## Key Design Decisions
 
@@ -277,6 +280,19 @@ Always think from first principles. When fixing a bug or designing a feature:
 - Image generation changes span three places: coordinator consumer/provider handlers, provider proxying, and `image-bridge/`.
 - Device linking changes span coordinator device auth endpoints and provider `login`/`logout` commands.
 - The repo contains mixed payment language: current code implements Privy + Solana + Stripe, but some provider comments still reference Tempo/pathUSD.
+
+## Testing New Features
+
+Every new feature or non-trivial change must ship with tests. Don't rely on "the reviewer will catch it" or "I'll test it manually once" — write tests that a future change can run.
+
+- **Prefer live-isolated tests over mocks.** Spin up a real instance of the dependency in the test process or a throwaway local container (test Postgres via `pgx` + a temp database, a real in-process HTTP server via `httptest.NewServer`, a real in-memory store). Do NOT mock the thing you're actually trying to exercise — mocks hide real bugs (wrong SQL, stale schema, protocol drift). The lesson from past incidents: mocked tests passed while the prod migration failed.
+- **Never point tests at production.** No live coordinator, no prod DB, no real wallets, no real Privy tenants. Each test harness builds its own isolated coordinator, its own in-memory or ephemeral store, its own seed data. If a test needs credentials, they're fake fixtures, not the real ones.
+- **Cover both impls when a feature spans backends.** If a `store.Store` method gets a memory impl AND a postgres impl, both need coverage (memory in the default test suite; postgres behind a build tag or a local-only integration test that uses a throwaway DB).
+- **Test the real HTTP path when possible.** For new endpoints, exercise them through `httptest.NewServer(srv.Handler())` (or the equivalent) — not by calling the handler function directly. That catches routing mistakes, middleware gaps, and path-parameter bugs.
+- **Frontend features need frontend tests.** When adding a page or form, add at minimum a vitest for the component's validation + state. For UI that can't be easily unit-tested, boot the dev server and walk through the flow in a browser before declaring done — and say so in the handoff.
+- **Regression: every bug fix gets a test that fails without the fix.** Otherwise the bug can come back silently.
+
+The goal is "next engineer can change this and CI tells them if they broke it," not "it worked on my machine today."
 
 ## Quality Gate
 

--- a/console-ui/__tests__/stripe-payouts.test.ts
+++ b/console-ui/__tests__/stripe-payouts.test.ts
@@ -1,0 +1,208 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  computeStripeFeeUsd,
+  fetchStripeStatus,
+  startStripeOnboarding,
+  withdrawStripe,
+  fetchStripeWithdrawals,
+} from "@/lib/api";
+
+// Stripe Payouts client tests. These cover:
+//   * Fee math (must mirror billing.FeeForMethodMicroUSD on the server side)
+//   * Each API client function calls the right proxy URL with the right body
+//   * Error responses are surfaced cleanly so the UI can show a toast
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(body),
+    text: () => Promise.resolve(JSON.stringify(body)),
+    headers: new Headers(),
+  } as unknown as Response;
+}
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  fetchMock = vi.fn();
+  vi.stubGlobal("fetch", fetchMock);
+
+  const store: Record<string, string> = {};
+  vi.stubGlobal("localStorage", {
+    getItem: (k: string) => store[k] ?? null,
+    setItem: (k: string, v: string) => {
+      store[k] = v;
+    },
+    removeItem: (k: string) => {
+      delete store[k];
+    },
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// computeStripeFeeUsd
+//
+// This formula MUST stay in lockstep with billing.FeeForMethodMicroUSD on the
+// server side. If you change one, change the other and update both test
+// suites. Source of truth: coordinator/internal/billing/stripe_connect.go.
+// ---------------------------------------------------------------------------
+
+describe("computeStripeFeeUsd", () => {
+  it("returns 0 for standard payouts", () => {
+    expect(computeStripeFeeUsd(100, "standard")).toBe(0);
+    expect(computeStripeFeeUsd(0.01, "standard")).toBe(0);
+  });
+
+  it("returns 0 for zero or negative amounts", () => {
+    expect(computeStripeFeeUsd(0, "instant")).toBe(0);
+    expect(computeStripeFeeUsd(-5, "instant")).toBe(0);
+  });
+
+  it("snaps to the $0.50 floor for small instant payouts", () => {
+    // 1.5% of $5 = $0.075 → snaps to $0.50.
+    expect(computeStripeFeeUsd(5, "instant")).toBe(0.5);
+    // Right at the threshold ($33.33 → 1.5% = $0.499 → snaps to $0.50).
+    expect(computeStripeFeeUsd(33, "instant")).toBe(0.5);
+  });
+
+  it("applies 1.5% above the floor", () => {
+    expect(computeStripeFeeUsd(50, "instant")).toBe(0.75);
+    expect(computeStripeFeeUsd(100, "instant")).toBe(1.5);
+    expect(computeStripeFeeUsd(1000, "instant")).toBe(15);
+  });
+
+  it("respects custom bps and floor passed in via status", () => {
+    // 2% with $1 floor
+    expect(computeStripeFeeUsd(10, "instant", 200, 1)).toBe(1);   // 2% of $10 = $0.20 → snaps to $1
+    expect(computeStripeFeeUsd(100, "instant", 200, 1)).toBe(2);  // 2% of $100 = $2 (above floor)
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fetchStripeStatus
+// ---------------------------------------------------------------------------
+
+describe("fetchStripeStatus", () => {
+  it("calls /api/payments/stripe/status without refresh by default", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({
+      configured: true, has_account: true, status: "ready",
+    }));
+    const s = await fetchStripeStatus();
+    expect(fetchMock).toHaveBeenCalledWith("/api/payments/stripe/status", expect.any(Object));
+    expect(s.status).toBe("ready");
+  });
+
+  it("appends ?refresh=1 when called with refresh=true", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ configured: true, has_account: true, status: "ready" }));
+    await fetchStripeStatus(true);
+    expect(fetchMock).toHaveBeenCalledWith("/api/payments/stripe/status?refresh=1", expect.any(Object));
+  });
+
+  it("throws on non-2xx responses", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({}, 500));
+    await expect(fetchStripeStatus()).rejects.toThrow(/500/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// startStripeOnboarding
+// ---------------------------------------------------------------------------
+
+describe("startStripeOnboarding", () => {
+  it("POSTs return_url to /api/payments/stripe/onboard", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({
+      url: "https://connect.stripe.com/setup/abc",
+      stripe_account_id: "acct_x",
+      status: "pending",
+    }));
+
+    const resp = await startStripeOnboarding("https://app.test/billing?stripe_return=1");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [, opts] = fetchMock.mock.calls[0];
+    expect(opts.method).toBe("POST");
+    expect(JSON.parse(opts.body)).toEqual({ return_url: "https://app.test/billing?stripe_return=1" });
+    expect(resp.url).toContain("connect.stripe.com");
+  });
+
+  it("surfaces server error message when present", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ error: { message: "Stripe is down" } }, 502));
+    await expect(startStripeOnboarding()).rejects.toThrow(/Stripe is down/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// withdrawStripe
+// ---------------------------------------------------------------------------
+
+describe("withdrawStripe", () => {
+  it("POSTs amount and method to /api/payments/withdraw/stripe", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({
+      status: "submitted",
+      withdrawal_id: "wd-1",
+      transfer_id: "tr_1",
+      payout_id: "po_1",
+      amount_usd: "10.00",
+      fee_usd: "0.50",
+      net_usd: "9.50",
+      method: "instant",
+      eta: "~30 minutes",
+      balance_micro_usd: 0,
+    }));
+    const resp = await withdrawStripe("10.00", "instant");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, opts] = fetchMock.mock.calls[0];
+    expect(url).toBe("/api/payments/withdraw/stripe");
+    expect(JSON.parse(opts.body)).toEqual({ amount_usd: "10.00", method: "instant" });
+    expect(resp.fee_usd).toBe("0.50");
+    expect(resp.net_usd).toBe("9.50");
+  });
+
+  it("surfaces insufficient_funds error", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({
+      error: { type: "insufficient_funds", message: "insufficient balance" },
+    }, 400));
+    await expect(withdrawStripe("10.00", "standard")).rejects.toThrow(/insufficient balance/);
+  });
+
+  it("surfaces instant_unavailable error", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({
+      error: { type: "instant_unavailable", message: "instant payouts require a debit card destination" },
+    }, 400));
+    await expect(withdrawStripe("10.00", "instant")).rejects.toThrow(/debit card/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fetchStripeWithdrawals
+// ---------------------------------------------------------------------------
+
+describe("fetchStripeWithdrawals", () => {
+  it("returns the withdrawals array, default limit=20", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({
+      withdrawals: [
+        { id: "wd-1", account_id: "a", stripe_account_id: "acct_x", amount_micro_usd: 5_000_000, fee_micro_usd: 0, net_micro_usd: 5_000_000, method: "standard", status: "paid", created_at: "", updated_at: "" },
+      ],
+    }));
+    const wds = await fetchStripeWithdrawals();
+    expect(fetchMock).toHaveBeenCalledWith("/api/payments/stripe/withdrawals?limit=20", expect.any(Object));
+    expect(wds).toHaveLength(1);
+    expect(wds[0].id).toBe("wd-1");
+  });
+
+  it("returns [] when the response has no withdrawals key", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({}));
+    const wds = await fetchStripeWithdrawals();
+    expect(wds).toEqual([]);
+  });
+
+  it("respects custom limit", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ withdrawals: [] }));
+    await fetchStripeWithdrawals(5);
+    expect(fetchMock).toHaveBeenCalledWith("/api/payments/stripe/withdrawals?limit=5", expect.any(Object));
+  });
+});

--- a/console-ui/src/app/api/payments/stripe/onboard/route.ts
+++ b/console-ui/src/app/api/payments/stripe/onboard/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from "next/server";
+
+// Proxy for POST /v1/billing/stripe/onboard. Stripe Payouts is Privy-only
+// (no API-key access), so we forward the Privy session token via the cookie
+// fallback when no Authorization header is present.
+
+const DEFAULT_COORD = process.env.NEXT_PUBLIC_COORDINATOR_URL || "https://api.darkbloom.dev";
+
+export async function POST(req: NextRequest) {
+  const coordUrl = req.headers.get("x-coordinator-url") || DEFAULT_COORD;
+
+  let authHeader = req.headers.get("authorization") || "";
+  if (!authHeader) {
+    const privyToken = req.cookies.get("privy-token")?.value;
+    if (privyToken) authHeader = `Bearer ${privyToken}`;
+  }
+
+  const body = await req.json().catch(() => ({}));
+
+  const res = await fetch(`${coordUrl}/v1/billing/stripe/onboard`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...(authHeader ? { Authorization: authHeader } : {}),
+    },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    return NextResponse.json({ error: text }, { status: res.status });
+  }
+  return NextResponse.json(await res.json().catch(() => ({})));
+}

--- a/console-ui/src/app/api/payments/stripe/status/route.ts
+++ b/console-ui/src/app/api/payments/stripe/status/route.ts
@@ -1,0 +1,29 @@
+import { NextRequest, NextResponse } from "next/server";
+
+// Proxy for GET /v1/billing/stripe/status. Forwards `?refresh=1` so the
+// Billing page can request a live Stripe refresh after onboarding redirect.
+
+const DEFAULT_COORD = process.env.NEXT_PUBLIC_COORDINATOR_URL || "https://api.darkbloom.dev";
+
+export async function GET(req: NextRequest) {
+  const coordUrl = req.headers.get("x-coordinator-url") || DEFAULT_COORD;
+
+  let authHeader = req.headers.get("authorization") || "";
+  if (!authHeader) {
+    const privyToken = req.cookies.get("privy-token")?.value;
+    if (privyToken) authHeader = `Bearer ${privyToken}`;
+  }
+
+  const url = new URL(req.url);
+  const refresh = url.searchParams.get("refresh");
+  const upstream = `${coordUrl}/v1/billing/stripe/status${refresh ? `?refresh=${refresh}` : ""}`;
+
+  const res = await fetch(upstream, {
+    headers: { ...(authHeader ? { Authorization: authHeader } : {}) },
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    return NextResponse.json({ error: text }, { status: res.status });
+  }
+  return NextResponse.json(await res.json().catch(() => ({})));
+}

--- a/console-ui/src/app/api/payments/stripe/withdrawals/route.ts
+++ b/console-ui/src/app/api/payments/stripe/withdrawals/route.ts
@@ -1,0 +1,29 @@
+import { NextRequest, NextResponse } from "next/server";
+
+// Proxy for GET /v1/billing/stripe/withdrawals — recent payout history for
+// the Billing page.
+
+const DEFAULT_COORD = process.env.NEXT_PUBLIC_COORDINATOR_URL || "https://api.darkbloom.dev";
+
+export async function GET(req: NextRequest) {
+  const coordUrl = req.headers.get("x-coordinator-url") || DEFAULT_COORD;
+
+  let authHeader = req.headers.get("authorization") || "";
+  if (!authHeader) {
+    const privyToken = req.cookies.get("privy-token")?.value;
+    if (privyToken) authHeader = `Bearer ${privyToken}`;
+  }
+
+  const url = new URL(req.url);
+  const limit = url.searchParams.get("limit");
+  const upstream = `${coordUrl}/v1/billing/stripe/withdrawals${limit ? `?limit=${limit}` : ""}`;
+
+  const res = await fetch(upstream, {
+    headers: { ...(authHeader ? { Authorization: authHeader } : {}) },
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    return NextResponse.json({ error: text }, { status: res.status });
+  }
+  return NextResponse.json(await res.json().catch(() => ({})));
+}

--- a/console-ui/src/app/api/payments/withdraw/stripe/route.ts
+++ b/console-ui/src/app/api/payments/withdraw/stripe/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from "next/server";
+
+// Proxy for POST /v1/billing/withdraw/stripe. Mirrors the Solana withdraw
+// proxy shape but forwards the Privy session token via cookie fallback so
+// the Billing page can call it with no API key configured.
+
+const DEFAULT_COORD = process.env.NEXT_PUBLIC_COORDINATOR_URL || "https://api.darkbloom.dev";
+
+export async function POST(req: NextRequest) {
+  const coordUrl = req.headers.get("x-coordinator-url") || DEFAULT_COORD;
+
+  let authHeader = req.headers.get("authorization") || "";
+  if (!authHeader) {
+    const privyToken = req.cookies.get("privy-token")?.value;
+    if (privyToken) authHeader = `Bearer ${privyToken}`;
+  }
+
+  const body = await req.json().catch(() => ({}));
+
+  const res = await fetch(`${coordUrl}/v1/billing/withdraw/stripe`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...(authHeader ? { Authorization: authHeader } : {}),
+    },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    return NextResponse.json({ error: text }, { status: res.status });
+  }
+  return NextResponse.json(await res.json().catch(() => ({})));
+}

--- a/console-ui/src/app/billing/BillingContent.tsx
+++ b/console-ui/src/app/billing/BillingContent.tsx
@@ -17,9 +17,16 @@ import {
   fetchWalletInfo,
   submitDepositTx,
   redeemInviteCode,
+  fetchStripeStatus,
+  startStripeOnboarding,
+  withdrawStripe,
+  fetchStripeWithdrawals,
+  computeStripeFeeUsd,
   type BalanceResponse,
   type UsageEntry,
   type WalletInfo,
+  type StripeStatus,
+  type StripeWithdrawal,
 } from "@/lib/api";
 import {
   Clock,
@@ -33,6 +40,10 @@ import {
   Wallet,
   Copy,
   Info,
+  Building2,
+  Zap,
+  AlertCircle,
+  ArrowDownToLine,
 } from "lucide-react";
 import { UsageChart } from "@/components/UsageChart";
 
@@ -105,6 +116,15 @@ export default function BillingContent() {
   );
   const [sortAsc, setSortAsc] = useState(false);
 
+  // Stripe Payouts state.
+  const [stripeStatus, setStripeStatus] = useState<StripeStatus | null>(null);
+  const [stripeWithdrawals, setStripeWithdrawals] = useState<StripeWithdrawal[]>([]);
+  const [stripeOnboardLoading, setStripeOnboardLoading] = useState(false);
+  const [withdrawOpen, setWithdrawOpen] = useState(false);
+  const [withdrawAmount, setWithdrawAmount] = useState("10");
+  const [withdrawMethod, setWithdrawMethod] = useState<"standard" | "instant">("standard");
+  const [withdrawLoading, setWithdrawLoading] = useState(false);
+
   const loadData = useCallback(async () => {
     setLoading(true);
     try {
@@ -122,9 +142,72 @@ export default function BillingContent() {
     setLoading(false);
   }, [addToast]);
 
+  // Stripe payouts data loads independently — we don't want a misconfigured
+  // coordinator to block the rest of the billing page.
+  const loadStripe = useCallback(async (refresh = false) => {
+    try {
+      const [s, wds] = await Promise.all([
+        fetchStripeStatus(refresh),
+        fetchStripeWithdrawals(20).catch(() => [] as StripeWithdrawal[]),
+      ]);
+      setStripeStatus(s);
+      setStripeWithdrawals(wds);
+    } catch (e) {
+      // Silent — Stripe Payouts is optional infrastructure.
+      console.warn("stripe status fetch failed:", (e as Error).message);
+    }
+  }, []);
+
   useEffect(() => {
     loadData();
   }, [loadData]);
+
+  // Refresh Stripe status on mount; if the user just came back from the
+  // Stripe-hosted onboarding flow (return URL adds ?stripe_return=1) we hit
+  // ?refresh=1 so the coordinator pulls the latest snapshot from Stripe
+  // before the webhook arrives.
+  useEffect(() => {
+    const params = typeof window !== "undefined" ? new URLSearchParams(window.location.search) : null;
+    const justReturned = params?.get("stripe_return") === "1";
+    loadStripe(justReturned);
+    if (justReturned) {
+      addToast("Stripe onboarding complete — verifying...", "success");
+      // Strip the query param so a refresh doesn't re-trigger the toast.
+      const url = new URL(window.location.href);
+      url.searchParams.delete("stripe_return");
+      window.history.replaceState({}, "", url.toString());
+    }
+  }, [loadStripe, addToast]);
+
+  const handleStripeOnboard = async () => {
+    setStripeOnboardLoading(true);
+    try {
+      // We pass the current page (with ?stripe_return=1) as the return URL so
+      // the user lands back on Billing after KYC.
+      const returnURL = typeof window !== "undefined"
+        ? `${window.location.origin}${window.location.pathname}?stripe_return=1`
+        : undefined;
+      const resp = await startStripeOnboarding(returnURL);
+      window.location.href = resp.url;
+    } catch (e) {
+      addToast(`Stripe onboarding failed: ${(e as Error).message}`);
+      setStripeOnboardLoading(false);
+    }
+  };
+
+  const handleStripeWithdraw = async () => {
+    setWithdrawLoading(true);
+    try {
+      const resp = await withdrawStripe(withdrawAmount, withdrawMethod);
+      addToast(`Withdrawal submitted — ${resp.eta || "processing"}`, "success");
+      setWithdrawOpen(false);
+      // Reload balance + history.
+      await Promise.all([loadData(), loadStripe(false)]);
+    } catch (e) {
+      addToast(`${(e as Error).message}`);
+    }
+    setWithdrawLoading(false);
+  };
 
   const handleBuyCredits = async () => {
     const embeddedWallet = wallets.find((w) => w.address === walletAddress);
@@ -341,6 +424,20 @@ export default function BillingContent() {
             )}
           </div>
 
+          {/* Withdraw to Bank (Stripe Connect Express) */}
+          <StripePayoutsCard
+            status={stripeStatus}
+            withdrawals={stripeWithdrawals}
+            balanceMicroUsd={balance?.balance_micro_usd ?? 0}
+            onboardLoading={stripeOnboardLoading}
+            onOnboard={handleStripeOnboard}
+            onOpenWithdraw={() => {
+              setWithdrawAmount("10");
+              setWithdrawMethod(stripeStatus?.instant_eligible ? "instant" : "standard");
+              setWithdrawOpen(true);
+            }}
+          />
+
           {/* Stats row */}
           <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 sm:gap-4">
             {[
@@ -540,6 +637,21 @@ export default function BillingContent() {
         </div>
       </Modal>
 
+      {/* Stripe Withdraw Modal */}
+      <Modal open={withdrawOpen} onClose={() => !withdrawLoading && setWithdrawOpen(false)}>
+        <StripeWithdrawModal
+          status={stripeStatus}
+          balanceMicroUsd={balance?.balance_micro_usd ?? 0}
+          amount={withdrawAmount}
+          method={withdrawMethod}
+          loading={withdrawLoading}
+          onAmountChange={setWithdrawAmount}
+          onMethodChange={setWithdrawMethod}
+          onConfirm={handleStripeWithdraw}
+          onCancel={() => setWithdrawOpen(false)}
+        />
+      </Modal>
+
       {/* Confirmation Modal */}
       <Modal open={confirmOpen} onClose={() => !actionLoading && setConfirmOpen(false)}>
         <div className="px-6 pb-6">
@@ -586,5 +698,337 @@ export default function BillingContent() {
         </div>
       </Modal>
     </div>
+  );
+}
+
+// --- Stripe Payouts components ---
+
+function StripePayoutsCard({
+  status,
+  withdrawals,
+  balanceMicroUsd,
+  onboardLoading,
+  onOnboard,
+  onOpenWithdraw,
+}: {
+  status: StripeStatus | null;
+  withdrawals: StripeWithdrawal[];
+  balanceMicroUsd: number;
+  onboardLoading: boolean;
+  onOnboard: () => void;
+  onOpenWithdraw: () => void;
+}) {
+  // Stripe payouts not configured on this coordinator — hide the card entirely.
+  if (status && !status.configured) return null;
+
+  const ready = status?.status === "ready";
+  const restricted = status?.status === "restricted";
+  const rejected = status?.status === "rejected";
+  const pending = status?.status === "pending";
+  const balanceUsd = balanceMicroUsd / 1_000_000;
+  const minWithdrawUsd = (status?.min_withdraw_micro_usd ?? 1_000_000) / 1_000_000;
+  const canWithdraw = ready && balanceUsd >= minWithdrawUsd;
+
+  return (
+    <div className="rounded-2xl border border-border-dim bg-bg-white p-6 shadow-md">
+      <div className="flex items-center gap-2 mb-4">
+        <Building2 size={16} className="text-teal" />
+        <h3 className="text-sm font-semibold text-text-primary">Withdraw to Bank</h3>
+        {ready && (
+          <span className="ml-auto text-[10px] font-mono uppercase tracking-widest text-teal bg-teal/10 border border-teal/30 rounded px-2 py-0.5">
+            Ready
+          </span>
+        )}
+        {pending && (
+          <span className="ml-auto text-[10px] font-mono uppercase tracking-widest text-gold bg-gold/10 border border-gold/30 rounded px-2 py-0.5">
+            Pending
+          </span>
+        )}
+        {(restricted || rejected) && (
+          <span className="ml-auto text-[10px] font-mono uppercase tracking-widest text-coral bg-coral/10 border border-coral/30 rounded px-2 py-0.5">
+            Action needed
+          </span>
+        )}
+      </div>
+
+      {!status?.has_account ? (
+        <>
+          <p className="text-sm text-text-secondary mb-4 leading-relaxed">
+            Link a bank account or debit card via Stripe to withdraw your credits.
+            Stripe handles identity verification — onboarding takes about 2 minutes.
+          </p>
+          <button
+            onClick={onOnboard}
+            disabled={onboardLoading}
+            className="flex items-center gap-2 px-5 py-2.5 rounded-lg bg-teal border-2 border-ink text-white text-sm font-bold hover:opacity-90 disabled:opacity-50 transition-all"
+          >
+            {onboardLoading ? <Loader2 size={14} className="animate-spin" /> : <Building2 size={14} />}
+            {onboardLoading ? "Redirecting..." : "Link bank via Stripe"}
+          </button>
+        </>
+      ) : ready ? (
+        <>
+          <div className="rounded-lg bg-bg-primary border border-border-dim p-3 mb-4 flex items-center justify-between">
+            <div className="flex items-center gap-2 text-sm text-text-secondary">
+              {status.destination_type === "card" ? (
+                <CreditCard size={14} className="text-teal" />
+              ) : (
+                <Building2 size={14} className="text-teal" />
+              )}
+              <span className="font-mono">
+                {status.destination_type === "card" ? "Debit card" : "Bank"} ••{status.destination_last4}
+              </span>
+              {status.instant_eligible && (
+                <span className="text-[10px] font-mono uppercase text-gold bg-gold/10 border border-gold/30 rounded px-1.5 py-0.5">
+                  Instant
+                </span>
+              )}
+            </div>
+          </div>
+          <button
+            onClick={onOpenWithdraw}
+            disabled={!canWithdraw}
+            className="flex items-center gap-2 px-5 py-2.5 rounded-lg bg-teal border-2 border-ink text-white text-sm font-bold hover:opacity-90 disabled:opacity-50 disabled:cursor-not-allowed transition-all"
+          >
+            <ArrowDownToLine size={14} />
+            Withdraw
+          </button>
+          {!canWithdraw && balanceUsd < minWithdrawUsd && (
+            <p className="text-xs text-text-tertiary mt-2">
+              Minimum withdrawal is ${minWithdrawUsd.toFixed(2)} — your balance is ${balanceUsd.toFixed(2)}.
+            </p>
+          )}
+        </>
+      ) : (
+        <>
+          <p className="text-sm text-text-secondary mb-4 leading-relaxed flex items-start gap-2">
+            <AlertCircle size={14} className="text-coral mt-0.5 flex-shrink-0" />
+            {restricted
+              ? "Stripe needs more information to enable payouts on your account."
+              : rejected
+              ? "Stripe has disabled payouts on this account. Contact support."
+              : "Finish linking your account on Stripe to enable withdrawals."}
+          </p>
+          {!rejected && (
+            <button
+              onClick={onOnboard}
+              disabled={onboardLoading}
+              className="flex items-center gap-2 px-5 py-2.5 rounded-lg bg-teal border-2 border-ink text-white text-sm font-bold hover:opacity-90 disabled:opacity-50 transition-all"
+            >
+              {onboardLoading ? <Loader2 size={14} className="animate-spin" /> : <Building2 size={14} />}
+              {onboardLoading ? "Redirecting..." : restricted ? "Provide more info" : "Continue setup"}
+            </button>
+          )}
+        </>
+      )}
+
+      {withdrawals.length > 0 && (
+        <div className="mt-5 pt-5 border-t border-border-subtle">
+          <p className="text-xs font-mono text-text-tertiary uppercase tracking-wider mb-3">
+            Recent withdrawals
+          </p>
+          <div className="space-y-2">
+            {withdrawals.slice(0, 5).map((w) => (
+              <div key={w.id} className="flex items-center justify-between text-sm">
+                <div className="flex items-center gap-2">
+                  {w.status === "paid" ? (
+                    <Check size={12} className="text-teal" />
+                  ) : w.status === "failed" ? (
+                    <X size={12} className="text-coral" />
+                  ) : (
+                    <Clock size={12} className="text-gold" />
+                  )}
+                  <span className="font-mono text-text-secondary">
+                    ${(w.net_micro_usd / 1_000_000).toFixed(2)}
+                  </span>
+                  <span className="text-[10px] font-mono uppercase text-text-tertiary">
+                    {w.method}
+                  </span>
+                </div>
+                <span className={`text-xs font-mono ${
+                  w.status === "paid" ? "text-teal" :
+                  w.status === "failed" ? "text-coral" :
+                  "text-text-tertiary"
+                }`}>
+                  {w.status}
+                  {w.refunded ? " (refunded)" : ""}
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function StripeWithdrawModal({
+  status,
+  balanceMicroUsd,
+  amount,
+  method,
+  loading,
+  onAmountChange,
+  onMethodChange,
+  onConfirm,
+  onCancel,
+}: {
+  status: StripeStatus | null;
+  balanceMicroUsd: number;
+  amount: string;
+  method: "standard" | "instant";
+  loading: boolean;
+  onAmountChange: (v: string) => void;
+  onMethodChange: (m: "standard" | "instant") => void;
+  onConfirm: () => void;
+  onCancel: () => void;
+}) {
+  const amountNum = parseFloat(amount) || 0;
+  const balanceUsd = balanceMicroUsd / 1_000_000;
+  const minWithdrawUsd = (status?.min_withdraw_micro_usd ?? 1_000_000) / 1_000_000;
+  const instantBps = status?.instant_fee_bps ?? 150;
+  const instantMinUsd = status?.instant_fee_min_usd ?? 0.5;
+  const fee = computeStripeFeeUsd(amountNum, method, instantBps, instantMinUsd);
+  const net = Math.max(0, amountNum - fee);
+
+  const tooSmall = amountNum > 0 && amountNum < minWithdrawUsd;
+  const tooLarge = amountNum > balanceUsd;
+  const valid = amountNum >= minWithdrawUsd && !tooLarge;
+
+  return (
+    <div className="px-6 pb-6">
+      <h3 className="text-2xl font-semibold text-ink mb-2">Withdraw to {status?.destination_type === "card" ? "card" : "bank"}</h3>
+      <p className="text-sm text-text-secondary mb-4">
+        Funds go to {status?.destination_type === "card" ? "your linked card" : "your linked bank account"} ••{status?.destination_last4}.
+      </p>
+
+      <label className="block text-xs font-mono text-text-tertiary uppercase tracking-wider mb-2">
+        Amount (USD)
+      </label>
+      <div className="flex items-center gap-2 mb-3">
+        <span className="text-text-tertiary text-lg">$</span>
+        <input
+          type="number"
+          value={amount}
+          onChange={(e) => onAmountChange(e.target.value)}
+          className="flex-1 bg-bg-primary border border-border-dim rounded-lg px-4 py-3 text-text-primary font-mono text-lg outline-none focus:border-teal transition-colors"
+          min={minWithdrawUsd}
+          max={balanceUsd}
+          step="0.01"
+        />
+      </div>
+      <p className="text-xs text-text-tertiary mb-4">
+        Available: ${balanceUsd.toFixed(2)} · Min: ${minWithdrawUsd.toFixed(2)}
+      </p>
+      {tooSmall && (
+        <p className="text-xs text-coral mb-3">Minimum withdrawal is ${minWithdrawUsd.toFixed(2)}.</p>
+      )}
+      {tooLarge && (
+        <p className="text-xs text-coral mb-3">Insufficient balance.</p>
+      )}
+
+      {/* Method picker */}
+      <label className="block text-xs font-mono text-text-tertiary uppercase tracking-wider mb-2">
+        Speed
+      </label>
+      <div className="grid grid-cols-1 gap-2 mb-4">
+        <MethodOption
+          selected={method === "standard"}
+          onClick={() => onMethodChange("standard")}
+          icon={<Clock size={14} />}
+          label="Standard"
+          eta="1-2 business days"
+          fee="Free"
+        />
+        <MethodOption
+          selected={method === "instant"}
+          onClick={() => status?.instant_eligible && onMethodChange("instant")}
+          disabled={!status?.instant_eligible}
+          icon={<Zap size={14} />}
+          label="Instant"
+          eta="~30 minutes"
+          fee={`${(instantBps / 100).toFixed(2)}% (min $${instantMinUsd.toFixed(2)})`}
+          tooltip={!status?.instant_eligible ? "Link a debit card via Stripe to enable Instant Payouts" : undefined}
+        />
+      </div>
+
+      {/* Fee breakdown */}
+      <div className="rounded-lg bg-bg-primary border border-border-dim p-3 mb-5 text-xs space-y-1">
+        <div className="flex justify-between text-text-tertiary">
+          <span>Withdrawal</span>
+          <span className="font-mono">${amountNum.toFixed(2)}</span>
+        </div>
+        <div className="flex justify-between text-text-tertiary">
+          <span>Fee</span>
+          <span className="font-mono">${fee.toFixed(2)}</span>
+        </div>
+        <div className="flex justify-between text-text-primary font-bold pt-1 border-t border-border-subtle">
+          <span>You receive</span>
+          <span className="font-mono text-teal">${net.toFixed(2)}</span>
+        </div>
+      </div>
+
+      <div className="flex gap-3">
+        <button
+          onClick={onCancel}
+          disabled={loading}
+          className="flex-1 py-3 rounded-lg border-2 border-border-dim text-text-secondary text-sm font-bold hover:bg-bg-hover transition-all"
+        >
+          Cancel
+        </button>
+        <button
+          onClick={onConfirm}
+          disabled={loading || !valid}
+          className="flex-1 py-3 rounded-lg bg-teal border border-border-dim text-white font-bold text-sm hover:opacity-90 disabled:opacity-50 disabled:cursor-not-allowed transition-all flex items-center justify-center gap-2"
+        >
+          {loading && <Loader2 size={14} className="animate-spin" />}
+          {loading ? "Processing..." : `Withdraw $${amountNum.toFixed(2)}`}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function MethodOption({
+  selected,
+  onClick,
+  disabled,
+  icon,
+  label,
+  eta,
+  fee,
+  tooltip,
+}: {
+  selected: boolean;
+  onClick: () => void;
+  disabled?: boolean;
+  icon: React.ReactNode;
+  label: string;
+  eta: string;
+  fee: string;
+  tooltip?: string;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      disabled={disabled}
+      title={tooltip}
+      className={`flex items-center justify-between gap-3 px-3 py-3 rounded-lg border-2 transition-all text-left ${
+        selected
+          ? "bg-teal/10 border-teal text-teal"
+          : disabled
+          ? "bg-bg-primary border-border-dim text-text-tertiary cursor-not-allowed opacity-60"
+          : "bg-bg-primary border-border-dim text-text-secondary hover:border-teal/30 hover:text-teal"
+      }`}
+    >
+      <div className="flex items-center gap-3">
+        {icon}
+        <div>
+          <div className="text-sm font-semibold">{label}</div>
+          <div className="text-xs font-mono text-text-tertiary">{eta}</div>
+        </div>
+      </div>
+      <div className="text-xs font-mono">{fee}</div>
+    </button>
   );
 }

--- a/console-ui/src/lib/api.ts
+++ b/console-ui/src/lib/api.ts
@@ -295,6 +295,118 @@ export async function redeemInviteCode(code: string): Promise<InviteRedeemRespon
   return data;
 }
 
+// --- Stripe Payouts (Connect Express) ---
+//
+// All Stripe Payouts endpoints require a Privy session — no API-key access.
+// The proxy routes fall back to the privy-token cookie when no Authorization
+// header is present, so the browser-side fetch needs no extra plumbing.
+
+export interface StripeStatus {
+  configured: boolean;
+  has_account: boolean;
+  stripe_account_id?: string;
+  status: "" | "pending" | "ready" | "restricted" | "rejected";
+  destination_type?: "" | "bank" | "card";
+  destination_last4?: string;
+  instant_eligible?: boolean;
+  min_withdraw_micro_usd?: number;
+  instant_fee_bps?: number;
+  instant_fee_min_usd?: number;
+  currently_due?: string[];
+}
+
+export async function fetchStripeStatus(refresh = false): Promise<StripeStatus> {
+  const url = refresh ? "/api/payments/stripe/status?refresh=1" : "/api/payments/stripe/status";
+  const res = await fetch(url, { headers: proxyHeaders() });
+  if (!res.ok) throw new Error(`Failed to fetch Stripe status: ${res.status}`);
+  return res.json();
+}
+
+export interface StripeOnboardResponse {
+  url: string;
+  stripe_account_id: string;
+  status: string;
+}
+
+export async function startStripeOnboarding(returnURL?: string): Promise<StripeOnboardResponse> {
+  const res = await fetch("/api/payments/stripe/onboard", {
+    method: "POST",
+    headers: proxyHeaders(),
+    body: JSON.stringify({ return_url: returnURL }),
+  });
+  if (!res.ok) {
+    const data = await res.json().catch(() => ({}));
+    throw new Error(data?.error?.message || data?.error || `Stripe onboarding failed (${res.status})`);
+  }
+  return res.json();
+}
+
+export interface StripeWithdrawResponse {
+  status: string;
+  withdrawal_id: string;
+  transfer_id?: string;
+  payout_id?: string;
+  amount_usd: string;
+  fee_usd: string;
+  net_usd: string;
+  method: "standard" | "instant";
+  eta?: string;
+  arrival_unix?: number;
+  balance_micro_usd: number;
+}
+
+export async function withdrawStripe(amountUsd: string, method: "standard" | "instant"): Promise<StripeWithdrawResponse> {
+  const res = await fetch("/api/payments/withdraw/stripe", {
+    method: "POST",
+    headers: proxyHeaders(),
+    body: JSON.stringify({ amount_usd: amountUsd, method }),
+  });
+  if (!res.ok) {
+    const data = await res.json().catch(() => ({}));
+    throw new Error(data?.error?.message || data?.error || `Withdrawal failed (${res.status})`);
+  }
+  return res.json();
+}
+
+export interface StripeWithdrawal {
+  id: string;
+  account_id: string;
+  stripe_account_id: string;
+  transfer_id?: string;
+  payout_id?: string;
+  amount_micro_usd: number;
+  fee_micro_usd: number;
+  net_micro_usd: number;
+  method: "standard" | "instant";
+  status: "pending" | "transferred" | "paid" | "failed";
+  failure_reason?: string;
+  refunded?: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+export async function fetchStripeWithdrawals(limit = 20): Promise<StripeWithdrawal[]> {
+  const res = await fetch(`/api/payments/stripe/withdrawals?limit=${limit}`, { headers: proxyHeaders() });
+  if (!res.ok) throw new Error(`Failed to fetch withdrawals: ${res.status}`);
+  const data = await res.json();
+  return data.withdrawals || [];
+}
+
+// computeStripeFeeUsd mirrors billing.FeeForMethodMicroUSD on the server so
+// the UI can preview the fee without a round-trip. Keep these formulas in
+// lockstep — see coordinator/internal/billing/stripe_connect.go.
+//
+// All math is done in integer micro-USD (matching the server) to avoid
+// floating-point drift on amounts near the floor boundary; only the final
+// result is converted back to USD for display.
+export function computeStripeFeeUsd(amountUsd: number, method: "standard" | "instant", instantFeeBps = 150, instantFeeMinUsd = 0.5): number {
+  if (method !== "instant" || amountUsd <= 0) return 0;
+  const grossMicro = Math.round(amountUsd * 1_000_000);
+  const minMicro = Math.round(instantFeeMinUsd * 1_000_000);
+  const pctMicro = Math.floor((grossMicro * instantFeeBps) / 10_000);
+  return Math.max(pctMicro, minMicro) / 1_000_000;
+}
+
 export async function healthCheck(): Promise<{ status: string; providers: number }> {
   const res = await fetch("/api/health", { headers: proxyHeaders() });
   if (!res.ok) throw new Error(`Health check failed: ${res.status}`);

--- a/coordinator/cmd/coordinator/main.go
+++ b/coordinator/cmd/coordinator/main.go
@@ -110,6 +110,26 @@ func main() {
 		logger.Info("console URL configured", "url", consoleURL)
 	}
 
+	// Base URL — this coordinator's public origin (e.g. https://api.dev.darkbloom.dev).
+	// Templated into the embedded install.sh at serve time so a single binary
+	// can serve both prod and dev. Falls back to the request's Host header if unset.
+	if baseURL := os.Getenv("EIGENINFERENCE_BASE_URL"); baseURL != "" {
+		srv.SetBaseURL(baseURL)
+		logger.Info("base URL configured", "url", baseURL)
+	}
+
+	// R2 CDN URLs — substituted into install.sh at serve time. Each env has its
+	// own R2 bucket (prod: d-inf-app; dev: d-inf-app-dev). Dev can set only the
+	// primary CDN and the site-packages one defaults to the same bucket.
+	if cdn := os.Getenv("EIGENINFERENCE_R2_CDN_URL"); cdn != "" {
+		srv.SetR2CDNURL(cdn)
+		logger.Info("R2 CDN URL configured", "url", cdn)
+	}
+	if cdn := os.Getenv("EIGENINFERENCE_R2_SITE_PACKAGES_CDN_URL"); cdn != "" {
+		srv.SetR2SitePackagesCDNURL(cdn)
+		logger.Info("R2 site-packages CDN URL configured", "url", cdn)
+	}
+
 	// Scoped release key — GitHub Actions uses this to register new releases.
 	// Separate from admin key: can only POST /v1/releases, nothing else.
 	if releaseKey := os.Getenv("EIGENINFERENCE_RELEASE_KEY"); releaseKey != "" {

--- a/coordinator/cmd/coordinator/main.go
+++ b/coordinator/cmd/coordinator/main.go
@@ -213,6 +213,15 @@ func main() {
 		StripeWebhookSecret: os.Getenv("EIGENINFERENCE_STRIPE_WEBHOOK_SECRET"),
 		StripeSuccessURL:    os.Getenv("EIGENINFERENCE_STRIPE_SUCCESS_URL"),
 		StripeCancelURL:     os.Getenv("EIGENINFERENCE_STRIPE_CANCEL_URL"),
+
+		// Stripe Connect Express — bank/card payouts. Reuses StripeSecretKey
+		// for API auth; the Connect webhook endpoint has its own signing
+		// secret. Return/refresh URLs are where Stripe sends users back to
+		// after the hosted onboarding flow.
+		StripeConnectWebhookSecret:   os.Getenv("EIGENINFERENCE_STRIPE_CONNECT_WEBHOOK_SECRET"),
+		StripeConnectPlatformCountry: envOr("EIGENINFERENCE_STRIPE_CONNECT_COUNTRY", "US"),
+		StripeConnectReturnURL:       os.Getenv("EIGENINFERENCE_STRIPE_CONNECT_RETURN_URL"),
+		StripeConnectRefreshURL:      os.Getenv("EIGENINFERENCE_STRIPE_CONNECT_REFRESH_URL"),
 	}
 
 	// Mock billing mode — skips on-chain verification, auto-credits test balance.

--- a/coordinator/internal/api/install.sh
+++ b/coordinator/internal/api/install.sh
@@ -17,7 +17,11 @@ set -euo pipefail
 #
 # Zero prerequisites — just macOS + Apple Silicon.
 
-COORD_URL="https://api.darkbloom.dev"
+# Coordinator host. The coordinator substitutes __DARKBLOOM_COORD_URL__ at
+# serve time (see coordinator/internal/api/server.go). Users can override by
+# exporting COORD_URL before running the installer — useful when testing
+# against a dev coordinator without re-fetching the script.
+COORD_URL="${COORD_URL:-__DARKBLOOM_COORD_URL__}"
 INSTALL_DIR="$HOME/.darkbloom"
 BIN_DIR="$INSTALL_DIR/bin"
 PYTHON_BIN="$INSTALL_DIR/python/bin/python3.12"
@@ -227,7 +231,7 @@ if [ -f "$PYTHON_BIN" ] && ! "$PYTHON_BIN" -c "print('ok')" 2>/dev/null; then
             echo "  Portable Python installed ✓"
             # Install packages from R2 site-packages tarball (same verified artifacts as CI)
             SITE_DIR="$INSTALL_DIR/python/lib/python3.12/site-packages"
-            R2_CDN="https://pub-3d1cb668259340eeb2276e1d375c846d.r2.dev"
+            R2_CDN="${R2_CDN:-__DARKBLOOM_R2_SITE_PACKAGES_CDN_URL__}"
             if [ -n "$VERSION" ] && curl -fsSL "$R2_CDN/releases/v${VERSION}/eigeninference-site-packages.tar.gz" -o "/tmp/eigen-site-packages.tar.gz" 2>/dev/null; then
                 rm -rf "$SITE_DIR"
                 mkdir -p "$SITE_DIR"
@@ -415,7 +419,7 @@ if [ -n "$MODEL" ]; then
             echo "  $MODEL_NAME downloaded ✓"
         else
             echo "  Tarball not available, downloading from R2..."
-            R2_BASE="https://pub-7cbee059c80c46ec9c071dbee2726f8a.r2.dev/$S3_NAME"
+            R2_BASE="${R2_CDN_URL:-__DARKBLOOM_R2_CDN_URL__}/$S3_NAME"
             for f in config.json tokenizer.json tokenizer_config.json special_tokens_map.json model.safetensors.index.json; do
                 curl -fsSL "$R2_BASE/$f" -o "$CACHE_DIR/$f" 2>/dev/null || true
             done

--- a/coordinator/internal/api/install_sh_test.go
+++ b/coordinator/internal/api/install_sh_test.go
@@ -1,0 +1,139 @@
+package api
+
+import (
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/eigeninference/coordinator/internal/registry"
+	"github.com/eigeninference/coordinator/internal/store"
+)
+
+// TestInstallScriptTemplating verifies the coordinator substitutes
+// __DARKBLOOM_COORD_URL__ with its configured baseURL at serve time.
+// This test exists so dev and prod coordinators can serve the same embedded
+// install.sh source while providers end up talking to the right environment.
+func TestInstallScriptTemplating(t *testing.T) {
+	t.Run("uses baseURL when set", func(t *testing.T) {
+		srv := newTestServerWithBaseURL(t, "https://api.dev.darkbloom.dev")
+		defer srv.Close()
+
+		body := fetchInstallScript(t, srv.URL)
+
+		if strings.Contains(body, "__DARKBLOOM_COORD_URL__") {
+			t.Error("install.sh still contains placeholder after serve-time substitution")
+		}
+		if !strings.Contains(body, `COORD_URL:-https://api.dev.darkbloom.dev`) {
+			t.Errorf("install.sh does not reference configured baseURL; got first 400 chars:\n%s", headOf(body, 400))
+		}
+	})
+
+	t.Run("derives from request host when baseURL unset", func(t *testing.T) {
+		srv := newTestServerWithBaseURL(t, "")
+		defer srv.Close()
+
+		body := fetchInstallScript(t, srv.URL)
+
+		if strings.Contains(body, "__DARKBLOOM_COORD_URL__") {
+			t.Error("install.sh placeholder left unsubstituted when baseURL empty")
+		}
+		if !strings.Contains(body, srv.URL) {
+			t.Errorf("install.sh does not reference request host %q; got first 400 chars:\n%s", srv.URL, headOf(body, 400))
+		}
+	})
+
+	t.Run("trailing slash in baseURL is stripped", func(t *testing.T) {
+		srv := newTestServerWithBaseURL(t, "https://api.dev.darkbloom.dev/")
+		defer srv.Close()
+
+		body := fetchInstallScript(t, srv.URL)
+
+		if strings.Contains(body, "darkbloom.dev//") {
+			t.Error("trailing slash in baseURL was not stripped; would produce double-slash URLs")
+		}
+	})
+
+	t.Run("R2 CDN URL substituted when set", func(t *testing.T) {
+		srv := newTestServerWithR2(t, "https://pub-devxxx.r2.dev", "https://pub-devpkg.r2.dev")
+		defer srv.Close()
+
+		body := fetchInstallScript(t, srv.URL)
+
+		if strings.Contains(body, "__DARKBLOOM_R2_CDN_URL__") {
+			t.Error("R2 CDN placeholder not substituted")
+		}
+		if strings.Contains(body, "__DARKBLOOM_R2_SITE_PACKAGES_CDN_URL__") {
+			t.Error("R2 site-packages CDN placeholder not substituted")
+		}
+		if !strings.Contains(body, "https://pub-devxxx.r2.dev") {
+			t.Error("dev R2 CDN URL not present after substitution")
+		}
+		if !strings.Contains(body, "https://pub-devpkg.r2.dev") {
+			t.Error("dev R2 site-packages URL not present after substitution")
+		}
+	})
+
+	t.Run("R2 site-packages CDN defaults to R2 CDN when unset", func(t *testing.T) {
+		srv := newTestServerWithR2(t, "https://pub-devxxx.r2.dev", "")
+		defer srv.Close()
+
+		body := fetchInstallScript(t, srv.URL)
+
+		if strings.Contains(body, "__DARKBLOOM_R2_SITE_PACKAGES_CDN_URL__") {
+			t.Error("R2 site-packages placeholder left unsubstituted when R2 CDN is set")
+		}
+	})
+}
+
+func newTestServerWithR2(t *testing.T, cdnURL, sitePackagesURL string) *httptest.Server {
+	t.Helper()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	st := store.NewMemory("")
+	reg := registry.New(logger)
+	s := NewServer(reg, st, logger)
+	s.SetBaseURL("https://api.dev.darkbloom.dev")
+	s.SetR2CDNURL(cdnURL)
+	if sitePackagesURL != "" {
+		s.SetR2SitePackagesCDNURL(sitePackagesURL)
+	}
+	return httptest.NewServer(s.Handler())
+}
+
+func newTestServerWithBaseURL(t *testing.T, baseURL string) *httptest.Server {
+	t.Helper()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	st := store.NewMemory("")
+	reg := registry.New(logger)
+	s := NewServer(reg, st, logger)
+	if baseURL != "" {
+		s.SetBaseURL(baseURL)
+	}
+	return httptest.NewServer(s.Handler())
+}
+
+func fetchInstallScript(t *testing.T, base string) string {
+	t.Helper()
+	resp, err := http.Get(base + "/install.sh")
+	if err != nil {
+		t.Fatalf("GET /install.sh: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET /install.sh: status %d", resp.StatusCode)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	return string(body)
+}
+
+func headOf(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n]
+}

--- a/coordinator/internal/api/server.go
+++ b/coordinator/internal/api/server.go
@@ -620,6 +620,13 @@ func (s *Server) routes() {
 	s.mux.HandleFunc("POST /v1/billing/withdraw/solana", s.requireAuth(s.handleSolanaWithdraw))
 	s.mux.HandleFunc("GET /v1/billing/wallet/balance", s.requireAuth(s.handleWalletBalance))
 
+	// Stripe Payouts (Connect Express) — bank/card withdrawals.
+	s.mux.HandleFunc("POST /v1/billing/stripe/onboard", s.requireAuth(s.handleStripeOnboard))
+	s.mux.HandleFunc("GET /v1/billing/stripe/status", s.requireAuth(s.handleStripeStatus))
+	s.mux.HandleFunc("POST /v1/billing/withdraw/stripe", s.requireAuth(s.handleStripeWithdraw))
+	s.mux.HandleFunc("GET /v1/billing/stripe/withdrawals", s.requireAuth(s.handleStripeWithdrawals))
+	s.mux.HandleFunc("POST /v1/billing/stripe/connect/webhook", s.handleStripeConnectWebhook) // no auth — Stripe signs it
+
 	// Pricing — GET is public, PUT/DELETE require auth
 	s.mux.HandleFunc("GET /v1/pricing", s.handleGetPricing)                        // public
 	s.mux.HandleFunc("PUT /v1/pricing", s.requireAuth(s.handleSetPricing))         // provider sets own prices

--- a/coordinator/internal/api/server.go
+++ b/coordinator/internal/api/server.go
@@ -99,6 +99,21 @@ type Server struct {
 	// Used for device auth verification_uri so the browser opens the console, not the coordinator.
 	consoleURL string
 
+	// baseURL is the public URL clients reach this coordinator at
+	// (e.g. "https://api.darkbloom.dev" for prod, "https://api.dev.darkbloom.dev" for dev).
+	// Substituted into the embedded install.sh at serve time so the same binary
+	// can serve both environments. Falls back to "https://" + request.Host when empty.
+	baseURL string
+
+	// r2CDNURL is the public R2 bucket URL that providers pull release artifacts
+	// and model weights from. Prod bucket is distinct from dev bucket, so the
+	// coordinator substitutes it into install.sh at serve time.
+	r2CDNURL string
+
+	// r2SitePackagesCDNURL is the R2 URL for the Python site-packages tarball.
+	// Prod historically uses a second bucket; dev can reuse r2CDNURL.
+	r2SitePackagesCDNURL string
+
 	// imageUploads stores generated images keyed by request_id.
 	// Providers upload images via HTTP POST, then send a small WebSocket
 	// completion message. The consumer handler retrieves images from here.
@@ -137,6 +152,27 @@ func NewServer(reg *registry.Registry, st store.Store, logger *slog.Logger) *Ser
 // SetAdminKey configures the admin API key for admin-only endpoints.
 func (s *Server) SetAdminKey(key string) {
 	s.adminKey = key
+}
+
+// SetBaseURL sets the coordinator's public URL (used to template install.sh).
+// Pass the canonical origin with no trailing slash, e.g. "https://api.darkbloom.dev".
+// If unset, the install.sh handler derives a URL from the request's Host header.
+func (s *Server) SetBaseURL(url string) {
+	s.baseURL = strings.TrimRight(url, "/")
+}
+
+// SetR2CDNURL sets the public R2 bucket URL that install.sh substitutes as
+// the model/template/release download origin. If unset, install.sh keeps the
+// placeholder — providers will fail to pull artifacts, making the misconfig
+// loud instead of silent.
+func (s *Server) SetR2CDNURL(url string) {
+	s.r2CDNURL = strings.TrimRight(url, "/")
+}
+
+// SetR2SitePackagesCDNURL sets the R2 URL for the Python site-packages
+// tarball. Defaults to r2CDNURL when unset.
+func (s *Server) SetR2SitePackagesCDNURL(url string) {
+	s.r2SitePackagesCDNURL = strings.TrimRight(url, "/")
 }
 
 // SetStepCACerts configures the step-ca CA certificates for ACME client cert verification.
@@ -468,13 +504,49 @@ func (s *Server) HandleMDMWebhook(w http.ResponseWriter, r *http.Request) {
 //go:embed install.sh
 var installScript []byte
 
+// installScriptPlaceholder is substituted with the coordinator's public URL at
+// serve time. Keep in sync with coordinator/internal/api/install.sh.
+const installScriptPlaceholder = "__DARKBLOOM_COORD_URL__"
+
+// installScriptR2Placeholder is substituted with the public R2 CDN URL for
+// release artifacts + model weights. Keep in sync with install.sh.
+const installScriptR2Placeholder = "__DARKBLOOM_R2_CDN_URL__"
+
+// installScriptR2SitePackagesPlaceholder is substituted with the R2 URL for
+// the Python site-packages tarball (historically a separate prod bucket).
+const installScriptR2SitePackagesPlaceholder = "__DARKBLOOM_R2_SITE_PACKAGES_CDN_URL__"
+
+// resolveBaseURL returns the configured baseURL, or derives one from the
+// request's Host header when baseURL is unset. TLS-terminating proxies pass
+// through the original scheme via X-Forwarded-Proto; default to https.
+func (s *Server) resolveBaseURL(r *http.Request) string {
+	if s.baseURL != "" {
+		return s.baseURL
+	}
+	scheme := "https"
+	if proto := r.Header.Get("X-Forwarded-Proto"); proto != "" {
+		scheme = proto
+	} else if r.TLS == nil {
+		scheme = "http"
+	}
+	return scheme + "://" + r.Host
+}
+
 // routes mounts all HTTP and WebSocket handlers.
 func (s *Server) routes() {
-	// Install script — served directly from embedded binary.
+	// Install script — served from embedded binary with coordinator URL +
+	// R2 CDN URLs substituted per environment.
 	s.mux.HandleFunc("GET /install.sh", func(w http.ResponseWriter, r *http.Request) {
+		rendered := strings.ReplaceAll(string(installScript), installScriptPlaceholder, s.resolveBaseURL(r))
+		rendered = strings.ReplaceAll(rendered, installScriptR2Placeholder, s.r2CDNURL)
+		sitePackagesURL := s.r2SitePackagesCDNURL
+		if sitePackagesURL == "" {
+			sitePackagesURL = s.r2CDNURL
+		}
+		rendered = strings.ReplaceAll(rendered, installScriptR2SitePackagesPlaceholder, sitePackagesURL)
 		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 		w.Header().Set("Cache-Control", "no-cache")
-		w.Write(installScript)
+		io.WriteString(w, rendered)
 	})
 
 	// Health check — no auth required.

--- a/coordinator/internal/api/stripe_payouts.go
+++ b/coordinator/internal/api/stripe_payouts.go
@@ -1,0 +1,679 @@
+package api
+
+// Stripe Payouts handlers — bank/card withdrawals via Stripe Connect Express.
+//
+// Flow (mirrors handleSolanaWithdraw, but for fiat):
+//
+//  1. Onboard. POST /v1/billing/stripe/onboard creates a Stripe Express
+//     connected account for the Privy user (idempotent — reuses an existing
+//     stripe_account_id if one is on file), then returns a hosted onboarding
+//     URL the frontend redirects them to.
+//  2. Status. GET /v1/billing/stripe/status returns the user's current
+//     readiness state. Called both on the billing page load and when the user
+//     comes back from the hosted onboarding flow so we can refresh from
+//     Stripe before the webhook arrives.
+//  3. Withdraw. POST /v1/billing/withdraw/stripe debits the ledger by
+//     amount_usd, computes the Instant fee (1.5% / $0.50 min) if requested,
+//     calls transfers.create then payouts.create, and persists the local
+//     withdrawal row. On any Stripe error we re-credit the ledger.
+//  4. Webhook. POST /v1/billing/stripe/connect/webhook drives the local state
+//     machine via account.updated, payout.paid, payout.failed, transfer.failed.
+//     payout.failed and transfer.failed re-credit the user's ledger via
+//     LedgerRefund.
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/eigeninference/coordinator/internal/auth"
+	"github.com/eigeninference/coordinator/internal/billing"
+	"github.com/eigeninference/coordinator/internal/store"
+	"github.com/google/uuid"
+)
+
+// stripeStatusReady is the value of User.StripeAccountStatus when payouts are
+// enabled on the Stripe side. The set of statuses tracks the StripeAccount
+// lifecycle: "" (not onboarded) → "pending" (link created, not finished) →
+// "ready" | "restricted" | "rejected".
+const (
+	stripeStatusPending    = "pending"
+	stripeStatusReady      = "ready"
+	stripeStatusRestricted = "restricted"
+	stripeStatusRejected   = "rejected"
+)
+
+// handleStripeOnboard handles POST /v1/billing/stripe/onboard.
+// Creates a Stripe Express connected account on first call (or reuses the one
+// on file) and returns a hosted onboarding URL.
+func (s *Server) handleStripeOnboard(w http.ResponseWriter, r *http.Request) {
+	user := s.requirePrivyUser(w, r)
+	if user == nil {
+		return
+	}
+	if s.billing == nil || s.billing.StripeConnect() == nil {
+		writeJSON(w, http.StatusServiceUnavailable, errorResponse("billing_error", "Stripe Payouts not configured"))
+		return
+	}
+
+	// Allow the frontend to override the return URL (handy for staged envs)
+	// but fall back to the coordinator-configured default.
+	var req struct {
+		ReturnURL  string `json:"return_url,omitempty"`
+		RefreshURL string `json:"refresh_url,omitempty"`
+	}
+	_ = json.NewDecoder(r.Body).Decode(&req)
+
+	returnURL := strings.TrimSpace(req.ReturnURL)
+	if returnURL == "" {
+		returnURL = s.billing.StripeConnectReturnURL()
+	}
+	refreshURL := strings.TrimSpace(req.RefreshURL)
+	if refreshURL == "" {
+		refreshURL = s.billing.StripeConnectRefreshURL()
+	}
+	if refreshURL == "" {
+		// Sensible fallback so the link doesn't 500 if only return_url is set.
+		refreshURL = returnURL
+	}
+	if returnURL == "" {
+		writeJSON(w, http.StatusBadRequest, errorResponse("invalid_request_error",
+			"return_url is required (configure EIGENINFERENCE_STRIPE_CONNECT_RETURN_URL or pass it in the request)"))
+		return
+	}
+
+	// Validate the return/refresh URLs against the configured default's
+	// origin to prevent open-redirect: a phisher could otherwise hand the
+	// user a /stripe/onboard link with their own domain as return_url and
+	// hijack the post-KYC flow. The allowlist is the host of the configured
+	// default; localhost is also allowed for dev.
+	if err := validateRedirectURL(returnURL, s.billing.StripeConnectReturnURL()); err != nil {
+		writeJSON(w, http.StatusBadRequest, errorResponse("invalid_request_error",
+			"return_url is not allowed: "+err.Error()))
+		return
+	}
+	if err := validateRedirectURL(refreshURL, s.billing.StripeConnectReturnURL()); err != nil {
+		writeJSON(w, http.StatusBadRequest, errorResponse("invalid_request_error",
+			"refresh_url is not allowed: "+err.Error()))
+		return
+	}
+
+	// Reuse the user's existing Stripe account if we have one. If we don't,
+	// create a fresh Express account and persist the ID before we ever hand
+	// the user a link — otherwise a webhook arriving before our DB write
+	// could reference an unknown account.
+	stripeAcctID := user.StripeAccountID
+	if stripeAcctID == "" {
+		acct, err := s.billing.StripeConnect().CreateExpressAccount(billing.CreateExpressAccountParams{
+			Email: user.Email,
+		})
+		if err != nil {
+			s.logger.Error("stripe connect: create account failed", "error", err)
+			writeJSON(w, http.StatusBadGateway, errorResponse("stripe_error", err.Error()))
+			return
+		}
+		stripeAcctID = acct.ID
+		if err := s.billing.Store().SetUserStripeAccount(user.AccountID, stripeAcctID, stripeStatusPending, "", "", false); err != nil {
+			s.logger.Error("stripe connect: persist account id failed", "error", err)
+			writeJSON(w, http.StatusInternalServerError, errorResponse("internal_error", "failed to persist Stripe account"))
+			return
+		}
+	}
+
+	link, err := s.billing.StripeConnect().CreateAccountLink(stripeAcctID, returnURL, refreshURL)
+	if err != nil {
+		s.logger.Error("stripe connect: create account link failed", "error", err)
+		writeJSON(w, http.StatusBadGateway, errorResponse("stripe_error", err.Error()))
+		return
+	}
+
+	// Re-read the user — the SetUserStripeAccount above may have updated the
+	// status from "" to "pending"; we want the response to reflect that.
+	refreshed, err := s.billing.Store().GetUserByAccountID(user.AccountID)
+	if err == nil {
+		user = refreshed
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"url":               link,
+		"stripe_account_id": stripeAcctID,
+		"status":            user.StripeAccountStatus,
+	})
+}
+
+// handleStripeStatus handles GET /v1/billing/stripe/status.
+// Returns the full readiness/destination snapshot used by the billing UI to
+// render the Withdraw → Bank panel.
+func (s *Server) handleStripeStatus(w http.ResponseWriter, r *http.Request) {
+	user := s.requirePrivyUser(w, r)
+	if user == nil {
+		return
+	}
+	if s.billing == nil || s.billing.StripeConnect() == nil {
+		writeJSON(w, http.StatusOK, map[string]any{"has_account": false, "configured": false})
+		return
+	}
+
+	resp := map[string]any{
+		"has_account":           user.StripeAccountID != "",
+		"configured":            true,
+		"stripe_account_id":     user.StripeAccountID,
+		"status":                user.StripeAccountStatus,
+		"destination_type":      user.StripeDestinationType,
+		"destination_last4":     user.StripeDestinationLast4,
+		"instant_eligible":      user.StripeInstantEligible,
+		"min_withdraw_micro_usd": billing.MinWithdrawMicroUSD,
+		"instant_fee_bps":       billing.InstantFeeBps,
+		"instant_fee_min_usd":   float64(billing.InstantFeeMinMicroUSD) / 1_000_000,
+	}
+
+	// Optional refresh=1 query param fetches the latest snapshot from Stripe
+	// and rewrites our local state. The frontend hits this on return from the
+	// onboarding flow so the UI doesn't lag behind the webhook.
+	if user.StripeAccountID != "" && r.URL.Query().Get("refresh") == "1" {
+		acct, err := s.billing.StripeConnect().GetAccount(user.StripeAccountID)
+		if err != nil {
+			s.logger.Warn("stripe connect: status refresh failed", "error", err)
+		} else {
+			status := stripeStatusForAccount(acct)
+			if err := s.billing.Store().SetUserStripeAccount(user.AccountID, user.StripeAccountID,
+				status, acct.DestinationType, acct.DestinationLast4, acct.InstantEligible); err != nil {
+				s.logger.Warn("stripe connect: status persist failed", "error", err)
+			} else {
+				resp["status"] = status
+				resp["destination_type"] = acct.DestinationType
+				resp["destination_last4"] = acct.DestinationLast4
+				resp["instant_eligible"] = acct.InstantEligible
+				resp["currently_due"] = acct.CurrentlyDue
+			}
+		}
+	}
+
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// handleStripeWithdraw handles POST /v1/billing/withdraw/stripe.
+//
+// Body: { amount_usd: "10.00", method: "standard"|"instant" }
+//
+// Behavior:
+//  1. Validate method, amount, and that the user's account is ready.
+//  2. Compute fee (Instant: 1.5%, $0.50 min; Standard: free).
+//  3. Debit the ledger by the GROSS amount.
+//  4. transfers.create → payouts.create. Any failure re-credits the ledger.
+//  5. Persist a stripe_withdrawals row in "transferred" or "paid"-leaning
+//     state; the webhook will eventually drive it to a terminal state.
+func (s *Server) handleStripeWithdraw(w http.ResponseWriter, r *http.Request) {
+	user := s.requirePrivyUser(w, r)
+	if user == nil {
+		return
+	}
+	if s.billing == nil || s.billing.StripeConnect() == nil {
+		writeJSON(w, http.StatusServiceUnavailable, errorResponse("billing_error", "Stripe Payouts not configured"))
+		return
+	}
+	if user.StripeAccountID == "" || user.StripeAccountStatus != stripeStatusReady {
+		writeJSON(w, http.StatusForbidden, errorResponse("not_onboarded",
+			"link your bank or debit card via Stripe before withdrawing"))
+		return
+	}
+
+	var req struct {
+		AmountUSD string `json:"amount_usd"`
+		Method    string `json:"method"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, errorResponse("invalid_request_error", "invalid JSON: "+err.Error()))
+		return
+	}
+
+	method := strings.ToLower(strings.TrimSpace(req.Method))
+	if method == "" {
+		method = "standard"
+	}
+	if method != "standard" && method != "instant" {
+		writeJSON(w, http.StatusBadRequest, errorResponse("invalid_request_error",
+			"method must be 'standard' or 'instant'"))
+		return
+	}
+	if method == "instant" && !user.StripeInstantEligible {
+		writeJSON(w, http.StatusBadRequest, errorResponse("instant_unavailable",
+			"instant payouts require a debit card destination — link one in Stripe to enable"))
+		return
+	}
+
+	amountFloat, err := strconv.ParseFloat(req.AmountUSD, 64)
+	if err != nil || amountFloat <= 0 {
+		writeJSON(w, http.StatusBadRequest, errorResponse("invalid_request_error",
+			"amount_usd must be a positive number"))
+		return
+	}
+	grossMicroUSD := int64(amountFloat * 1_000_000)
+	if grossMicroUSD < billing.MinWithdrawMicroUSD {
+		writeJSON(w, http.StatusBadRequest, errorResponse("invalid_request_error",
+			fmt.Sprintf("minimum withdrawal is $%.2f", float64(billing.MinWithdrawMicroUSD)/1_000_000)))
+		return
+	}
+
+	feeMicroUSD := billing.FeeForMethodMicroUSD(method, grossMicroUSD)
+	netMicroUSD := grossMicroUSD - feeMicroUSD
+	if netMicroUSD <= 0 {
+		writeJSON(w, http.StatusBadRequest, errorResponse("invalid_request_error",
+			fmt.Sprintf("amount after fees must be > $0 (fee is $%.2f)", float64(feeMicroUSD)/1_000_000)))
+		return
+	}
+
+	// Cents-rounded amounts crossing the Stripe boundary. We never refund
+	// sub-cent dust to the user — the gross debit absorbs any rounding so
+	// the platform's books stay balanced.
+	netCents := microUSDToCents(netMicroUSD)
+	if netCents <= 0 {
+		writeJSON(w, http.StatusBadRequest, errorResponse("invalid_request_error",
+			"net amount rounds to less than 1 cent"))
+		return
+	}
+
+	// State machine:
+	//
+	//   pending     → row persisted, ledger debited, no Stripe call yet.
+	//   transferred → transfer succeeded; payout may or may not be created.
+	//   paid        → payout.paid webhook delivered.
+	//   failed      → terminal failure; ledger refunded if Refunded=true.
+	//
+	// We persist the row BEFORE any Stripe call so a DB write failure can
+	// never coexist with a successful money movement (no double-spend window).
+	withdrawalID := uuid.New().String()
+	debitRef := "stripe_withdraw:" + withdrawalID
+
+	if err := s.billing.Ledger().Charge(user.AccountID, grossMicroUSD, debitRef); err != nil {
+		writeJSON(w, http.StatusBadRequest, errorResponse("insufficient_funds", err.Error()))
+		return
+	}
+
+	wd := &store.StripeWithdrawal{
+		ID:              withdrawalID,
+		AccountID:       user.AccountID,
+		StripeAccountID: user.StripeAccountID,
+		AmountMicroUSD:  grossMicroUSD,
+		FeeMicroUSD:     feeMicroUSD,
+		NetMicroUSD:     netMicroUSD,
+		Method:          method,
+		Status:          "pending",
+	}
+	if err := s.billing.Store().CreateStripeWithdrawal(wd); err != nil {
+		// No Stripe calls yet — refund and bail.
+		if rerr := s.billing.Store().Credit(user.AccountID, grossMicroUSD, store.LedgerRefund, debitRef); rerr != nil {
+			s.logger.Error("stripe payout: refund after persist failure failed",
+				"error", rerr, "withdrawal_id", withdrawalID)
+		}
+		s.logger.Error("stripe payout: persist withdrawal failed", "error", err)
+		writeJSON(w, http.StatusInternalServerError, errorResponse("internal_error",
+			"failed to record withdrawal — refunded to your balance"))
+		return
+	}
+
+	markFailedRefund := func(reason string) {
+		// Refund the ledger and mark the row failed atomically (best-effort —
+		// neither store call has rollback). Refunded flag prevents webhook
+		// replay from double-crediting.
+		if rerr := s.billing.Store().Credit(user.AccountID, grossMicroUSD, store.LedgerRefund, debitRef); rerr != nil {
+			s.logger.Error("stripe payout: refund failed", "error", rerr, "withdrawal_id", withdrawalID)
+		} else {
+			wd.Refunded = true
+		}
+		wd.Status = "failed"
+		wd.FailureReason = reason
+		if uerr := s.billing.Store().UpdateStripeWithdrawal(wd); uerr != nil {
+			s.logger.Error("stripe payout: mark failed failed", "error", uerr, "withdrawal_id", withdrawalID)
+		}
+	}
+
+	// Step 2: transfer USD from platform balance to the connected account.
+	transfer, err := s.billing.StripeConnect().CreateTransfer(billing.CreateTransferParams{
+		DestinationAccountID: user.StripeAccountID,
+		AmountCents:          netCents,
+		IdempotencyKey:       "wd-tr-" + withdrawalID,
+		Description:          "Darkbloom credit withdrawal",
+	})
+	if err != nil {
+		markFailedRefund("transfer_create_failed: " + err.Error())
+		s.logger.Error("stripe payout: transfer failed", "error", err, "withdrawal_id", withdrawalID)
+		writeJSON(w, http.StatusBadGateway, errorResponse("stripe_error",
+			"failed to transfer funds: "+err.Error()))
+		return
+	}
+	wd.TransferID = transfer.ID
+	wd.Status = "transferred"
+	if err := s.billing.Store().UpdateStripeWithdrawal(wd); err != nil {
+		// Transfer succeeded but we lost track of it. Money is in the
+		// connected account; auto-payout will move it. Don't refund — that
+		// would double-credit the user.
+		s.logger.Error("stripe payout: persist transfer_id failed",
+			"error", err, "withdrawal_id", withdrawalID, "transfer_id", transfer.ID)
+	}
+
+	// Step 3: create the Stripe payout from the connected account → bank/card.
+	payout, err := s.billing.StripeConnect().CreatePayout(billing.CreatePayoutParams{
+		OnBehalfOfAccountID: user.StripeAccountID,
+		AmountCents:         netCents,
+		Method:              method,
+		IdempotencyKey:      "wd-po-" + withdrawalID,
+		Description:         "Darkbloom credit withdrawal",
+	})
+	if err != nil {
+		// Transfer succeeded — funds are in the connected account. Stripe's
+		// default daily auto-payout schedule will move them to the bank. We
+		// do NOT refund (that would double-credit) and we do NOT mark the row
+		// failed (the user will eventually get the money). Leave status at
+		// "transferred" with FailureReason populated for ops visibility.
+		wd.FailureReason = "payout_create_failed: " + err.Error()
+		if uerr := s.billing.Store().UpdateStripeWithdrawal(wd); uerr != nil {
+			s.logger.Error("stripe payout: persist payout failure failed",
+				"error", uerr, "withdrawal_id", withdrawalID)
+		}
+		s.logger.Error("stripe payout: create payout failed", "error", err,
+			"withdrawal_id", withdrawalID, "transfer_id", transfer.ID)
+		writeJSON(w, http.StatusAccepted, map[string]any{
+			"status":           "transferred",
+			"withdrawal_id":    withdrawalID,
+			"transfer_id":      transfer.ID,
+			"amount_usd":       formatUSD(grossMicroUSD),
+			"fee_usd":          formatUSD(feeMicroUSD),
+			"net_usd":          formatUSD(netMicroUSD),
+			"method":           method,
+			"message":          "transfer succeeded but payout failed; funds will arrive on Stripe's default schedule",
+			"balance_micro_usd": s.billing.Ledger().Balance(user.AccountID),
+		})
+		return
+	}
+	wd.PayoutID = payout.ID
+	if err := s.billing.Store().UpdateStripeWithdrawal(wd); err != nil {
+		// Payout succeeded but we couldn't persist the ID. Webhook will
+		// arrive with the payout ID — without the index entry we'll silently
+		// drop it. Log loudly so ops can manually reconcile via the Stripe
+		// dashboard. Do NOT refund — the user is getting the money.
+		s.logger.Error("stripe payout: persist payout_id failed — webhook will be lost",
+			"error", err, "withdrawal_id", withdrawalID,
+			"transfer_id", transfer.ID, "payout_id", payout.ID)
+	}
+
+	s.logger.Info("stripe payout: created",
+		"withdrawal_id", withdrawalID,
+		"account", user.AccountID[:min(8, len(user.AccountID))]+"...",
+		"method", method,
+		"gross_micro_usd", grossMicroUSD,
+		"fee_micro_usd", feeMicroUSD,
+		"net_micro_usd", netMicroUSD,
+	)
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"status":            "submitted",
+		"withdrawal_id":     withdrawalID,
+		"transfer_id":       transfer.ID,
+		"payout_id":         payout.ID,
+		"amount_usd":        formatUSD(grossMicroUSD),
+		"fee_usd":           formatUSD(feeMicroUSD),
+		"net_usd":           formatUSD(netMicroUSD),
+		"method":            method,
+		"eta":               etaForMethod(method),
+		"arrival_unix":      payout.ArrivalDate,
+		"balance_micro_usd": s.billing.Ledger().Balance(user.AccountID),
+	})
+}
+
+// handleStripeWithdrawals handles GET /v1/billing/stripe/withdrawals.
+// Returns the user's recent Stripe withdrawals for display in the UI.
+func (s *Server) handleStripeWithdrawals(w http.ResponseWriter, r *http.Request) {
+	user := s.requirePrivyUser(w, r)
+	if user == nil {
+		return
+	}
+	limit := 50
+	if l := r.URL.Query().Get("limit"); l != "" {
+		if v, err := strconv.Atoi(l); err == nil && v > 0 && v <= 200 {
+			limit = v
+		}
+	}
+	withdrawals, err := s.billing.Store().ListStripeWithdrawals(user.AccountID, limit)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, errorResponse("internal_error", err.Error()))
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"withdrawals": withdrawals})
+}
+
+// handleStripeConnectWebhook handles POST /v1/billing/stripe/connect/webhook.
+// Drives the local state machine for Connect events. This is a separate
+// endpoint from the Checkout webhook because Stripe lets you configure
+// per-endpoint signing secrets.
+func (s *Server) handleStripeConnectWebhook(w http.ResponseWriter, r *http.Request) {
+	if s.billing == nil || s.billing.StripeConnect() == nil {
+		http.Error(w, "Stripe Connect not configured", http.StatusServiceUnavailable)
+		return
+	}
+
+	payload, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+	if err != nil {
+		http.Error(w, "read body", http.StatusBadRequest)
+		return
+	}
+	sig := r.Header.Get("Stripe-Signature")
+	event, err := s.billing.StripeConnect().VerifyConnectWebhookSignature(payload, sig)
+	if err != nil {
+		s.logger.Warn("stripe connect webhook: signature verification failed", "error", err)
+		http.Error(w, "invalid signature", http.StatusBadRequest)
+		return
+	}
+
+	// Connect webhooks include the connected account ID at the top level
+	// (event.account in Stripe's payload). We re-parse the raw payload to
+	// pull it out; the WebhookEvent struct only exposes Type + Data.
+	var envelope struct {
+		Account string `json:"account"`
+	}
+	_ = json.Unmarshal(payload, &envelope)
+
+	switch event.Type {
+	case "account.updated":
+		s.handleAccountUpdated(event)
+	case "payout.paid":
+		s.handlePayoutTerminal(event, envelope.Account, true)
+	case "payout.failed", "payout.canceled":
+		s.handlePayoutTerminal(event, envelope.Account, false)
+	case "transfer.failed":
+		s.handleTransferFailed(event)
+	default:
+		// Ignore everything else — we just ack.
+	}
+	w.WriteHeader(http.StatusOK)
+}
+
+// handleAccountUpdated mirrors Stripe's view of the connected account into our
+// User row. This is what flips a user from "pending" → "ready".
+func (s *Server) handleAccountUpdated(event *billing.WebhookEvent) {
+	acct, err := s.billing.StripeConnect().AccountUpdatedFromEvent(event)
+	if err != nil {
+		s.logger.Warn("stripe connect webhook: account.updated parse failed", "error", err)
+		return
+	}
+	user, err := s.billing.Store().GetUserByStripeAccount(acct.ID)
+	if err != nil {
+		s.logger.Warn("stripe connect webhook: account.updated user lookup failed",
+			"stripe_account_id", acct.ID, "error", err)
+		return
+	}
+	status := stripeStatusForAccount(acct)
+	if err := s.billing.Store().SetUserStripeAccount(user.AccountID, acct.ID,
+		status, acct.DestinationType, acct.DestinationLast4, acct.InstantEligible); err != nil {
+		s.logger.Error("stripe connect webhook: persist account state failed", "error", err)
+	}
+}
+
+// handlePayoutTerminal handles payout.paid / payout.failed / payout.canceled.
+// On success we mark the row "paid". On failure we mark "failed" and re-credit
+// the user's ledger via LedgerRefund.
+func (s *Server) handlePayoutTerminal(event *billing.WebhookEvent, _ string, success bool) {
+	pe, err := s.billing.StripeConnect().PayoutFromEvent(event, "")
+	if err != nil {
+		s.logger.Warn("stripe connect webhook: payout parse failed", "error", err)
+		return
+	}
+	wd, err := s.billing.Store().GetStripeWithdrawalByPayoutID(pe.ID)
+	if err != nil {
+		// Stripe may emit payout events for payouts created outside our flow
+		// (e.g. directly in the dashboard) — silently ignore those.
+		s.logger.Debug("stripe connect webhook: unknown payout", "payout_id", pe.ID)
+		return
+	}
+	if success {
+		// payout.paid is idempotent: nothing changes the ledger, so a
+		// repeated delivery just rewrites the row to "paid" again.
+		if wd.Status == "paid" {
+			return
+		}
+		wd.Status = "paid"
+		if err := s.billing.Store().UpdateStripeWithdrawal(wd); err != nil {
+			s.logger.Error("stripe connect webhook: mark paid failed", "error", err)
+		}
+		return
+	}
+
+	// payout.failed: refund the ledger if we haven't already, then mark
+	// failed. We key idempotency on the Refunded flag (not Status) so a
+	// previously-failed-but-refund-failed row gets retried on webhook
+	// redelivery.
+	if wd.Refunded {
+		// Already refunded — make sure status is terminal and bail.
+		if wd.Status != "failed" {
+			wd.Status = "failed"
+			if err := s.billing.Store().UpdateStripeWithdrawal(wd); err != nil {
+				s.logger.Error("stripe connect webhook: status flip failed", "error", err)
+			}
+		}
+		return
+	}
+	wd.FailureReason = pe.FailureCode + ": " + pe.FailureReason
+	if err := s.billing.Store().Credit(wd.AccountID, wd.AmountMicroUSD, store.LedgerRefund,
+		"stripe_withdraw:"+wd.ID); err != nil {
+		s.logger.Error("stripe connect webhook: refund failed", "error", err, "withdrawal_id", wd.ID)
+		// Still update the row so we know about the failure even if the
+		// refund needs manual intervention.
+		wd.Status = "failed"
+		_ = s.billing.Store().UpdateStripeWithdrawal(wd)
+		return
+	}
+	wd.Refunded = true
+	wd.Status = "failed"
+	if err := s.billing.Store().UpdateStripeWithdrawal(wd); err != nil {
+		s.logger.Error("stripe connect webhook: mark failed failed", "error", err)
+	}
+}
+
+// handleTransferFailed handles the rare case where Stripe rolls back a transfer
+// after we've considered it successful. Same refund logic as a failed payout.
+func (s *Server) handleTransferFailed(event *billing.WebhookEvent) {
+	te, err := s.billing.StripeConnect().TransferFromEvent(event)
+	if err != nil {
+		s.logger.Warn("stripe connect webhook: transfer parse failed", "error", err)
+		return
+	}
+	wd, err := s.billing.Store().GetStripeWithdrawalByTransferID(te.ID)
+	if err != nil {
+		return
+	}
+	// Idempotency keyed on Refunded so a redelivery after a transient credit
+	// failure can still retry the refund.
+	if wd.Refunded {
+		if wd.Status != "failed" {
+			wd.Status = "failed"
+			_ = s.billing.Store().UpdateStripeWithdrawal(wd)
+		}
+		return
+	}
+	wd.FailureReason = "transfer_reversed"
+	if err := s.billing.Store().Credit(wd.AccountID, wd.AmountMicroUSD, store.LedgerRefund,
+		"stripe_withdraw:"+wd.ID); err != nil {
+		s.logger.Error("stripe connect webhook: refund failed", "error", err, "withdrawal_id", wd.ID)
+		wd.Status = "failed"
+		_ = s.billing.Store().UpdateStripeWithdrawal(wd)
+		return
+	}
+	wd.Refunded = true
+	wd.Status = "failed"
+	if err := s.billing.Store().UpdateStripeWithdrawal(wd); err != nil {
+		s.logger.Error("stripe connect webhook: mark failed failed", "error", err)
+	}
+}
+
+// validateRedirectURL ensures the user-supplied URL is on the same host as
+// the operator-configured default. localhost is always allowed (dev). If no
+// default is configured, the URL must be https and the call rejects http.
+func validateRedirectURL(candidate, defaultURL string) error {
+	cu, err := url.Parse(candidate)
+	if err != nil {
+		return fmt.Errorf("invalid URL")
+	}
+	if cu.Scheme != "https" && cu.Scheme != "http" {
+		return fmt.Errorf("scheme must be http or https")
+	}
+	host := strings.ToLower(cu.Hostname())
+	if host == "localhost" || host == "127.0.0.1" || host == "::1" {
+		return nil
+	}
+	if defaultURL == "" {
+		// No allowlist configured → require https + non-empty host.
+		if cu.Scheme != "https" || host == "" {
+			return fmt.Errorf("must be https with a hostname when no default is configured")
+		}
+		return nil
+	}
+	du, err := url.Parse(defaultURL)
+	if err != nil {
+		return nil // defaults are operator-configured; if malformed, fall back to allow https
+	}
+	if !strings.EqualFold(cu.Hostname(), du.Hostname()) {
+		return fmt.Errorf("host %q does not match allowed host %q", cu.Hostname(), du.Hostname())
+	}
+	return nil
+}
+
+// stripeStatusForAccount maps a fresh Stripe account snapshot onto our local
+// status enum.
+func stripeStatusForAccount(acct *billing.ExpressAccount) string {
+	switch {
+	case acct.DisabledReason != "" && strings.HasPrefix(acct.DisabledReason, "rejected"):
+		return stripeStatusRejected
+	case acct.PayoutsEnabled:
+		return stripeStatusReady
+	case acct.DetailsSubmitted && len(acct.CurrentlyDue) > 0:
+		return stripeStatusRestricted
+	default:
+		return stripeStatusPending
+	}
+}
+
+// microUSDToCents truncates to integer cents (1¢ = 10,000 micro-USD).
+func microUSDToCents(microUSD int64) int64 { return microUSD / 10_000 }
+
+func formatUSD(microUSD int64) string {
+	return fmt.Sprintf("%.2f", float64(microUSD)/1_000_000)
+}
+
+func etaForMethod(method string) string {
+	if method == "instant" {
+		return "~30 minutes"
+	}
+	return "1-2 business days"
+}
+
+// Compile-time check we don't accidentally drop the auth import; the Privy
+// helpers stay in scope via requirePrivyUser.
+var _ = auth.UserFromContext
+
+// Compile-time check on time import staying live.
+var _ = time.Now

--- a/coordinator/internal/api/stripe_payouts_test.go
+++ b/coordinator/internal/api/stripe_payouts_test.go
@@ -1,0 +1,856 @@
+package api
+
+// Stripe Payouts handler tests. These exercise the onboard → status →
+// withdraw → webhook lifecycle end-to-end with:
+//   * the real handlers (no mocks of our own code)
+//   * an in-memory store
+//   * a Stripe-API HTTP mock (so transfer/payout calls return deterministic
+//     IDs and we can assert on requests)
+//   * mock-mode billing for the happy path tests, real-HTTP for failure-path
+//     tests.
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/coordinator/internal/billing"
+	"github.com/eigeninference/coordinator/internal/payments"
+	"github.com/eigeninference/coordinator/internal/registry"
+	"github.com/eigeninference/coordinator/internal/store"
+)
+
+// stripePayoutsTestServer wires up a Server with an in-memory store and a
+// billing service whose Stripe Connect client points at the supplied fake
+// Stripe HTTP server. Pass mockMode=true to bypass Stripe entirely.
+func stripePayoutsTestServer(t *testing.T, mockMode bool, fakeStripe *httptest.Server, opts ...billing.Config) (*Server, *store.MemoryStore) {
+	t.Helper()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	st := store.NewMemory("test-key")
+	reg := registry.New(logger)
+	srv := NewServer(reg, st, logger)
+
+	cfg := billing.Config{
+		MockMode:                     mockMode,
+		StripeConnectReturnURL:       "https://app.test/billing?return=1",
+		StripeConnectRefreshURL:      "https://app.test/billing?refresh=1",
+		StripeConnectPlatformCountry: "US",
+	}
+	if !mockMode {
+		cfg.StripeSecretKey = "sk_test_fake"
+		cfg.StripeConnectWebhookSecret = "whsec_test"
+	}
+	if len(opts) > 0 {
+		// Allow tests to override individual fields by merging.
+		o := opts[0]
+		if o.StripeSecretKey != "" {
+			cfg.StripeSecretKey = o.StripeSecretKey
+		}
+		if o.StripeConnectWebhookSecret != "" {
+			cfg.StripeConnectWebhookSecret = o.StripeConnectWebhookSecret
+		}
+	}
+
+	if fakeStripe != nil {
+		// Repoint the Stripe API base URL for the duration of the test.
+		t.Cleanup(setStripeAPIBase(fakeStripe.URL))
+	}
+
+	ledger := payments.NewLedger(st)
+	srv.SetBilling(billing.NewService(st, ledger, logger, cfg))
+	return srv, st
+}
+
+// setStripeAPIBase swaps billing.stripeAPIBase to point at our fake server,
+// returning a cleanup func to restore it.
+func setStripeAPIBase(url string) func() {
+	prev := billing.SetStripeAPIBaseForTest(url)
+	return func() { billing.SetStripeAPIBaseForTest(prev) }
+}
+
+// seedUser inserts a Privy-linked user into the store and returns it.
+func seedUser(t *testing.T, st *store.MemoryStore, accountID, email string) *store.User {
+	t.Helper()
+	u := &store.User{
+		AccountID:   accountID,
+		PrivyUserID: "did:privy:" + accountID,
+		Email:       email,
+	}
+	if err := st.CreateUser(u); err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+	got, _ := st.GetUserByAccountID(accountID)
+	return got
+}
+
+// --- Onboard ---
+
+func TestStripeOnboardRequiresAuth(t *testing.T) {
+	srv, _ := stripePayoutsTestServer(t, true, nil)
+	req := httptest.NewRequest(http.MethodPost, "/v1/billing/stripe/onboard", strings.NewReader(`{}`))
+	w := httptest.NewRecorder()
+	srv.handleStripeOnboard(w, req)
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("got %d, want 401", w.Code)
+	}
+}
+
+func TestStripeOnboardCreatesAccountAndPersistsID(t *testing.T) {
+	srv, st := stripePayoutsTestServer(t, true, nil)
+	user := seedUser(t, st, "acct-onboard-1", "alice@example.com")
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/billing/stripe/onboard", strings.NewReader(`{}`))
+	req = withPrivyUser(req, user)
+	w := httptest.NewRecorder()
+	srv.handleStripeOnboard(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("got %d: %s", w.Code, w.Body.String())
+	}
+	var resp map[string]any
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp["url"] == nil || !strings.Contains(resp["url"].(string), "/setup/mock/") {
+		t.Errorf("expected mock setup URL, got %v", resp["url"])
+	}
+
+	// Confirm the user was persisted with an account ID + pending status.
+	refreshed, _ := st.GetUserByAccountID(user.AccountID)
+	if refreshed.StripeAccountID == "" {
+		t.Error("StripeAccountID was not persisted")
+	}
+	if refreshed.StripeAccountStatus != "pending" {
+		t.Errorf("status = %q, want pending", refreshed.StripeAccountStatus)
+	}
+}
+
+func TestStripeOnboardReusesExistingAccount(t *testing.T) {
+	srv, st := stripePayoutsTestServer(t, true, nil)
+	user := seedUser(t, st, "acct-reuse-1", "bob@example.com")
+
+	// Pre-seed an existing Stripe account ID.
+	_ = st.SetUserStripeAccount(user.AccountID, "acct_existing_123", "ready", "bank", "1234", false)
+	user, _ = st.GetUserByAccountID(user.AccountID)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/billing/stripe/onboard", strings.NewReader(`{}`))
+	req = withPrivyUser(req, user)
+	w := httptest.NewRecorder()
+	srv.handleStripeOnboard(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("got %d: %s", w.Code, w.Body.String())
+	}
+	var resp map[string]any
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp["stripe_account_id"] != "acct_existing_123" {
+		t.Errorf("expected reuse of acct_existing_123, got %v", resp["stripe_account_id"])
+	}
+}
+
+// --- Status ---
+
+func TestStripeStatusReportsCurrentState(t *testing.T) {
+	srv, st := stripePayoutsTestServer(t, true, nil)
+	user := seedUser(t, st, "acct-status-1", "alice@example.com")
+	_ = st.SetUserStripeAccount(user.AccountID, "acct_x", "ready", "card", "4242", true)
+	user, _ = st.GetUserByAccountID(user.AccountID)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/billing/stripe/status", nil)
+	req = withPrivyUser(req, user)
+	w := httptest.NewRecorder()
+	srv.handleStripeStatus(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("got %d: %s", w.Code, w.Body.String())
+	}
+	var resp map[string]any
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp["status"] != "ready" {
+		t.Errorf("status = %v", resp["status"])
+	}
+	if resp["destination_type"] != "card" {
+		t.Errorf("destination_type = %v", resp["destination_type"])
+	}
+	if resp["destination_last4"] != "4242" {
+		t.Errorf("destination_last4 = %v", resp["destination_last4"])
+	}
+	if resp["instant_eligible"] != true {
+		t.Errorf("instant_eligible = %v", resp["instant_eligible"])
+	}
+}
+
+// --- Withdraw ---
+
+func TestStripeWithdrawRejectsWithoutOnboarding(t *testing.T) {
+	srv, st := stripePayoutsTestServer(t, true, nil)
+	user := seedUser(t, st, "acct-w-1", "alice@example.com")
+	st.Credit(user.AccountID, 10_000_000, store.LedgerDeposit, "seed")
+
+	body := `{"amount_usd":"5.00","method":"standard"}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/billing/withdraw/stripe", strings.NewReader(body))
+	req = withPrivyUser(req, user)
+	w := httptest.NewRecorder()
+	srv.handleStripeWithdraw(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Errorf("got %d, want 403", w.Code)
+	}
+}
+
+func TestStripeWithdrawRejectsBelowMinimum(t *testing.T) {
+	srv, st := stripePayoutsTestServer(t, true, nil)
+	user := readyUser(t, st, "acct-w-min", "alice@example.com", false)
+	st.Credit(user.AccountID, 10_000_000, store.LedgerDeposit, "seed")
+
+	body := `{"amount_usd":"0.50","method":"standard"}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/billing/withdraw/stripe", strings.NewReader(body))
+	req = withPrivyUser(req, user)
+	w := httptest.NewRecorder()
+	srv.handleStripeWithdraw(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("got %d, want 400", w.Code)
+	}
+}
+
+func TestStripeWithdrawRejectsInstantWithoutDebitCard(t *testing.T) {
+	srv, st := stripePayoutsTestServer(t, true, nil)
+	user := readyUser(t, st, "acct-w-inst-1", "alice@example.com", false /* instant_eligible */)
+	st.Credit(user.AccountID, 10_000_000, store.LedgerDeposit, "seed")
+
+	body := `{"amount_usd":"5.00","method":"instant"}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/billing/withdraw/stripe", strings.NewReader(body))
+	req = withPrivyUser(req, user)
+	w := httptest.NewRecorder()
+	srv.handleStripeWithdraw(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("got %d, want 400: %s", w.Code, w.Body.String())
+	}
+	var resp map[string]any
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	errObj, _ := resp["error"].(map[string]any)
+	if errObj["type"] != "instant_unavailable" {
+		t.Errorf("error type = %v", errObj["type"])
+	}
+}
+
+func TestStripeWithdrawStandardSuccess(t *testing.T) {
+	srv, st := stripePayoutsTestServer(t, true, nil)
+	user := readyUser(t, st, "acct-w-std", "alice@example.com", false)
+	st.Credit(user.AccountID, 10_000_000, store.LedgerDeposit, "seed")
+
+	body := `{"amount_usd":"5.00","method":"standard"}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/billing/withdraw/stripe", strings.NewReader(body))
+	req = withPrivyUser(req, user)
+	w := httptest.NewRecorder()
+	srv.handleStripeWithdraw(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("got %d: %s", w.Code, w.Body.String())
+	}
+	var resp map[string]any
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp["fee_usd"] != "0.00" {
+		t.Errorf("standard fee should be 0, got %v", resp["fee_usd"])
+	}
+	if resp["net_usd"] != "5.00" {
+		t.Errorf("net should equal gross for standard, got %v", resp["net_usd"])
+	}
+	if resp["amount_usd"] != "5.00" {
+		t.Errorf("amount = %v", resp["amount_usd"])
+	}
+	if balance, _ := resp["balance_micro_usd"].(float64); int64(balance) != 5_000_000 {
+		t.Errorf("balance = %v, want 5_000_000", resp["balance_micro_usd"])
+	}
+
+	// Confirm a withdrawal row was persisted.
+	wds, _ := st.ListStripeWithdrawals(user.AccountID, 0)
+	if len(wds) != 1 {
+		t.Fatalf("expected 1 withdrawal row, got %d", len(wds))
+	}
+	if wds[0].Method != "standard" {
+		t.Errorf("method = %q", wds[0].Method)
+	}
+	if wds[0].FeeMicroUSD != 0 {
+		t.Errorf("persisted fee = %d", wds[0].FeeMicroUSD)
+	}
+	if wds[0].NetMicroUSD != 5_000_000 {
+		t.Errorf("persisted net = %d", wds[0].NetMicroUSD)
+	}
+}
+
+func TestStripeWithdrawInstantAppliesFee(t *testing.T) {
+	srv, st := stripePayoutsTestServer(t, true, nil)
+	user := readyUser(t, st, "acct-w-inst", "alice@example.com", true)
+	st.Credit(user.AccountID, 100_000_000, store.LedgerDeposit, "seed")
+
+	// $50 instant → 1.5% fee = $0.75 → net $49.25 → balance after = $50
+	body := `{"amount_usd":"50.00","method":"instant"}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/billing/withdraw/stripe", strings.NewReader(body))
+	req = withPrivyUser(req, user)
+	w := httptest.NewRecorder()
+	srv.handleStripeWithdraw(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("got %d: %s", w.Code, w.Body.String())
+	}
+	var resp map[string]any
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp["fee_usd"] != "0.75" {
+		t.Errorf("fee_usd = %v, want 0.75", resp["fee_usd"])
+	}
+	if resp["net_usd"] != "49.25" {
+		t.Errorf("net_usd = %v, want 49.25", resp["net_usd"])
+	}
+	if resp["amount_usd"] != "50.00" {
+		t.Errorf("amount_usd = %v", resp["amount_usd"])
+	}
+	if resp["eta"] != "~30 minutes" {
+		t.Errorf("eta = %v", resp["eta"])
+	}
+	if balance, _ := resp["balance_micro_usd"].(float64); int64(balance) != 50_000_000 {
+		t.Errorf("balance = %v, want 50_000_000", resp["balance_micro_usd"])
+	}
+}
+
+func TestStripeWithdrawSmallInstantHitsFloor(t *testing.T) {
+	srv, st := stripePayoutsTestServer(t, true, nil)
+	user := readyUser(t, st, "acct-w-small", "alice@example.com", true)
+	st.Credit(user.AccountID, 10_000_000, store.LedgerDeposit, "seed")
+
+	// $5 instant → 1.5% = $0.075 < $0.50 → fee snaps to $0.50 → net $4.50
+	body := `{"amount_usd":"5.00","method":"instant"}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/billing/withdraw/stripe", strings.NewReader(body))
+	req = withPrivyUser(req, user)
+	w := httptest.NewRecorder()
+	srv.handleStripeWithdraw(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("got %d: %s", w.Code, w.Body.String())
+	}
+	var resp map[string]any
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp["fee_usd"] != "0.50" {
+		t.Errorf("fee_usd = %v, want 0.50 (floor)", resp["fee_usd"])
+	}
+	if resp["net_usd"] != "4.50" {
+		t.Errorf("net_usd = %v", resp["net_usd"])
+	}
+}
+
+func TestStripeWithdrawInsufficientBalance(t *testing.T) {
+	srv, st := stripePayoutsTestServer(t, true, nil)
+	user := readyUser(t, st, "acct-w-poor", "alice@example.com", false)
+	// No credit seeded.
+
+	body := `{"amount_usd":"5.00","method":"standard"}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/billing/withdraw/stripe", strings.NewReader(body))
+	req = withPrivyUser(req, user)
+	w := httptest.NewRecorder()
+	srv.handleStripeWithdraw(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("got %d, want 400", w.Code)
+	}
+	var resp map[string]any
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	errObj, _ := resp["error"].(map[string]any)
+	if errObj["type"] != "insufficient_funds" {
+		t.Errorf("error type = %v", errObj["type"])
+	}
+}
+
+// TestStripeWithdrawTransferFailureRefunds exercises the ledger-refund branch
+// when Stripe rejects transfers.create. We use a real-HTTP Stripe Connect
+// client backed by a fake Stripe server that returns 400 on /v1/transfers.
+func TestStripeWithdrawTransferFailureRefunds(t *testing.T) {
+	fakeStripe := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v1/transfers" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"error":{"message":"insufficient platform funds","type":"invalid_request_error"}}`))
+			return
+		}
+		t.Errorf("unexpected Stripe call: %s %s", r.Method, r.URL.Path)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer fakeStripe.Close()
+
+	srv, st := stripePayoutsTestServer(t, false, fakeStripe)
+	user := readyUser(t, st, "acct-w-fail", "alice@example.com", false)
+	st.Credit(user.AccountID, 10_000_000, store.LedgerDeposit, "seed")
+
+	body := `{"amount_usd":"5.00","method":"standard"}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/billing/withdraw/stripe", strings.NewReader(body))
+	req = withPrivyUser(req, user)
+	w := httptest.NewRecorder()
+	srv.handleStripeWithdraw(w, req)
+
+	if w.Code != http.StatusBadGateway {
+		t.Fatalf("got %d, want 502: %s", w.Code, w.Body.String())
+	}
+	if bal := st.GetBalance(user.AccountID); bal != 10_000_000 {
+		t.Errorf("balance after refund = %d, want 10_000_000 (full original)", bal)
+	}
+	// Ledger should now have: deposit (+10), charge (-5), refund (+5).
+	entries := st.LedgerHistory(user.AccountID)
+	if len(entries) != 3 {
+		t.Fatalf("expected 3 ledger entries, got %d", len(entries))
+	}
+	// Newest first: refund, charge, deposit.
+	if entries[0].Type != store.LedgerRefund {
+		t.Errorf("entries[0].Type = %q, want refund", entries[0].Type)
+	}
+}
+
+func TestStripeWithdrawPersistsRowAsPendingFirst(t *testing.T) {
+	// Verify the row exists before any Stripe call returns. We use a fake
+	// Stripe that records when CreateTransfer is called and the test then
+	// asserts that the DB had a "pending" row at that moment.
+	var rowSeenAtTransferTime *store.StripeWithdrawal
+	st := store.NewMemory("test-key")
+
+	fakeStripe := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v1/transfers" {
+			// Snapshot the only withdrawal in the store at the moment of the
+			// transfer call; should already be persisted with status=pending.
+			wds, _ := st.ListStripeWithdrawals("acct-pers-1", 0)
+			if len(wds) == 1 {
+				cp := wds[0]
+				rowSeenAtTransferTime = &cp
+			}
+			_, _ = w.Write([]byte(`{"id":"tr_pers","amount":500,"destination":"acct_x","created":1700000000}`))
+			return
+		}
+		if r.URL.Path == "/v1/payouts" {
+			_, _ = w.Write([]byte(`{"id":"po_pers","amount":500,"method":"standard","status":"in_transit","arrival_date":1700000300}`))
+			return
+		}
+		t.Errorf("unexpected Stripe call: %s", r.URL.Path)
+	}))
+	defer fakeStripe.Close()
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	reg := registry.New(logger)
+	srv := NewServer(reg, st, logger)
+	t.Cleanup(setStripeAPIBase(fakeStripe.URL))
+	ledger := payments.NewLedger(st)
+	srv.SetBilling(billing.NewService(st, ledger, logger, billing.Config{
+		StripeSecretKey:              "sk_test_fake",
+		StripeConnectWebhookSecret:   "whsec_test",
+		StripeConnectReturnURL:       "https://app.test/billing",
+		StripeConnectRefreshURL:      "https://app.test/billing",
+		StripeConnectPlatformCountry: "US",
+	}))
+
+	user := readyUser(t, st, "acct-pers-1", "alice@example.com", false)
+	st.Credit(user.AccountID, 10_000_000, store.LedgerDeposit, "seed")
+
+	body := `{"amount_usd":"5.00","method":"standard"}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/billing/withdraw/stripe", strings.NewReader(body))
+	req = withPrivyUser(req, user)
+	w := httptest.NewRecorder()
+	srv.handleStripeWithdraw(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("got %d: %s", w.Code, w.Body.String())
+	}
+	if rowSeenAtTransferTime == nil {
+		t.Fatal("withdrawal row should have been persisted before the transfer call")
+	}
+	if rowSeenAtTransferTime.Status != "pending" {
+		t.Errorf("at transfer-time status was %q, want pending", rowSeenAtTransferTime.Status)
+	}
+
+	// Final state.
+	wds, _ := st.ListStripeWithdrawals(user.AccountID, 0)
+	if len(wds) != 1 {
+		t.Fatalf("expected 1 withdrawal row, got %d", len(wds))
+	}
+	if wds[0].Status != "transferred" {
+		t.Errorf("final status = %q, want transferred", wds[0].Status)
+	}
+	if wds[0].TransferID != "tr_pers" || wds[0].PayoutID != "po_pers" {
+		t.Errorf("transfer/payout ids not persisted: %+v", wds[0])
+	}
+}
+
+func TestStripeWithdrawTransferFailureMarksRowFailedAndRefunded(t *testing.T) {
+	fakeStripe := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":{"message":"boom","type":"invalid_request_error"}}`))
+	}))
+	defer fakeStripe.Close()
+
+	srv, st := stripePayoutsTestServer(t, false, fakeStripe)
+	user := readyUser(t, st, "acct-w-marked", "alice@example.com", false)
+	st.Credit(user.AccountID, 10_000_000, store.LedgerDeposit, "seed")
+
+	body := `{"amount_usd":"5.00","method":"standard"}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/billing/withdraw/stripe", strings.NewReader(body))
+	req = withPrivyUser(req, user)
+	w := httptest.NewRecorder()
+	srv.handleStripeWithdraw(w, req)
+
+	if w.Code != http.StatusBadGateway {
+		t.Fatalf("got %d, want 502", w.Code)
+	}
+	wds, _ := st.ListStripeWithdrawals(user.AccountID, 0)
+	if len(wds) != 1 {
+		t.Fatalf("expected 1 withdrawal row, got %d", len(wds))
+	}
+	if wds[0].Status != "failed" {
+		t.Errorf("status = %q, want failed", wds[0].Status)
+	}
+	if !wds[0].Refunded {
+		t.Error("refunded flag should be set")
+	}
+	if !strings.Contains(wds[0].FailureReason, "transfer_create_failed") {
+		t.Errorf("failure_reason = %q", wds[0].FailureReason)
+	}
+}
+
+func TestStripeWithdrawTransferOkPayoutFailLeavesRowTransferred(t *testing.T) {
+	// Transfer succeeds, payout fails — we keep the funds in the connected
+	// account (Stripe's auto-payout schedule will move them) and DON'T
+	// refund the user. Row stays at "transferred" with FailureReason set.
+	fakeStripe := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/transfers":
+			_, _ = w.Write([]byte(`{"id":"tr_ok","amount":500,"destination":"acct_x","created":1700000000}`))
+		case "/v1/payouts":
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"error":{"message":"insufficient connected balance"}}`))
+		default:
+			t.Errorf("unexpected: %s", r.URL.Path)
+		}
+	}))
+	defer fakeStripe.Close()
+
+	srv, st := stripePayoutsTestServer(t, false, fakeStripe)
+	user := readyUser(t, st, "acct-tr-only", "alice@example.com", false)
+	st.Credit(user.AccountID, 10_000_000, store.LedgerDeposit, "seed")
+
+	body := `{"amount_usd":"5.00","method":"standard"}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/billing/withdraw/stripe", strings.NewReader(body))
+	req = withPrivyUser(req, user)
+	w := httptest.NewRecorder()
+	srv.handleStripeWithdraw(w, req)
+
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("got %d, want 202: %s", w.Code, w.Body.String())
+	}
+	if bal := st.GetBalance(user.AccountID); bal != 5_000_000 {
+		t.Errorf("balance = %d, want 5_000_000 (no refund — funds in connected acct)", bal)
+	}
+	wds, _ := st.ListStripeWithdrawals(user.AccountID, 0)
+	if wds[0].Status != "transferred" {
+		t.Errorf("status = %q, want transferred", wds[0].Status)
+	}
+	if wds[0].Refunded {
+		t.Error("refunded flag should NOT be set")
+	}
+	if wds[0].TransferID != "tr_ok" {
+		t.Errorf("transfer_id = %q", wds[0].TransferID)
+	}
+	if !strings.Contains(wds[0].FailureReason, "payout_create_failed") {
+		t.Errorf("failure_reason = %q", wds[0].FailureReason)
+	}
+}
+
+// --- Open-redirect protection ---
+
+func TestStripeOnboardRejectsForeignReturnURL(t *testing.T) {
+	srv, st := stripePayoutsTestServer(t, true, nil)
+	user := seedUser(t, st, "acct-onboard-redir", "alice@example.com")
+
+	// Default return URL is https://app.test/...; passing attacker.example
+	// must be rejected before any Stripe call is made.
+	body := `{"return_url":"https://attacker.example/billing"}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/billing/stripe/onboard", strings.NewReader(body))
+	req = withPrivyUser(req, user)
+	w := httptest.NewRecorder()
+	srv.handleStripeOnboard(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("got %d, want 400 on foreign host: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestStripeOnboardAllowsLocalhostForDev(t *testing.T) {
+	srv, st := stripePayoutsTestServer(t, true, nil)
+	user := seedUser(t, st, "acct-onboard-local", "alice@example.com")
+
+	body := `{"return_url":"http://localhost:3000/billing"}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/billing/stripe/onboard", strings.NewReader(body))
+	req = withPrivyUser(req, user)
+	w := httptest.NewRecorder()
+	srv.handleStripeOnboard(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("got %d, want 200 for localhost: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestStripeOnboardRejectsJavascriptScheme(t *testing.T) {
+	srv, st := stripePayoutsTestServer(t, true, nil)
+	user := seedUser(t, st, "acct-onboard-js", "alice@example.com")
+
+	body := `{"return_url":"javascript:alert(1)"}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/billing/stripe/onboard", strings.NewReader(body))
+	req = withPrivyUser(req, user)
+	w := httptest.NewRecorder()
+	srv.handleStripeOnboard(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("got %d, want 400 on non-http scheme", w.Code)
+	}
+}
+
+// --- Webhook ---
+
+func TestConnectWebhookAccountUpdatedFlipsStatusToReady(t *testing.T) {
+	// Use a fake Stripe server because account.updated calls don't actually
+	// hit the API — Stripe sends us the object — but we still want the
+	// signature verifier to be enabled.
+	fakeStripe := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		t.Errorf("unexpected Stripe call: %s", r.URL.Path)
+	}))
+	defer fakeStripe.Close()
+
+	srv, st := stripePayoutsTestServer(t, false, fakeStripe)
+	user := seedUser(t, st, "acct-wh-1", "alice@example.com")
+	_ = st.SetUserStripeAccount(user.AccountID, "acct_x_wh", "pending", "", "", false)
+
+	payload := []byte(`{
+		"type": "account.updated",
+		"account": "acct_x_wh",
+		"data": {"object": {
+			"id": "acct_x_wh",
+			"payouts_enabled": true,
+			"details_submitted": true,
+			"external_accounts": {"data":[
+				{"object":"bank_account","last4":"6789","default_for_currency":true}
+			]}
+		}}
+	}`)
+	req := signedConnectRequest(t, payload, "whsec_test")
+	w := httptest.NewRecorder()
+	srv.handleStripeConnectWebhook(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("got %d: %s", w.Code, w.Body.String())
+	}
+
+	refreshed, _ := st.GetUserByAccountID(user.AccountID)
+	if refreshed.StripeAccountStatus != "ready" {
+		t.Errorf("status = %q, want ready", refreshed.StripeAccountStatus)
+	}
+	if refreshed.StripeDestinationType != "bank" {
+		t.Errorf("destination_type = %q, want bank", refreshed.StripeDestinationType)
+	}
+	if refreshed.StripeDestinationLast4 != "6789" {
+		t.Errorf("last4 = %q", refreshed.StripeDestinationLast4)
+	}
+}
+
+func TestConnectWebhookPayoutFailedRefundsLedger(t *testing.T) {
+	fakeStripe := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer fakeStripe.Close()
+
+	srv, st := stripePayoutsTestServer(t, false, fakeStripe)
+	user := readyUser(t, st, "acct-wh-fail", "alice@example.com", false)
+	st.Credit(user.AccountID, 10_000_000, store.LedgerDeposit, "seed")
+
+	// Manually create a withdrawal row mimicking what the handler would have
+	// persisted, then debit the ledger to put us in the post-withdraw state.
+	withdrawalID := "wd-test-1"
+	_ = st.Debit(user.AccountID, 5_000_000, store.LedgerCharge, "stripe_withdraw:"+withdrawalID)
+	_ = st.CreateStripeWithdrawal(&store.StripeWithdrawal{
+		ID:              withdrawalID,
+		AccountID:       user.AccountID,
+		StripeAccountID: user.StripeAccountID,
+		PayoutID:        "po_failtest",
+		AmountMicroUSD:  5_000_000,
+		FeeMicroUSD:     0,
+		NetMicroUSD:     5_000_000,
+		Method:          "standard",
+		Status:          "transferred",
+	})
+
+	payload := []byte(`{
+		"type": "payout.failed",
+		"account": "` + user.StripeAccountID + `",
+		"data": {"object": {
+			"id": "po_failtest",
+			"status": "failed",
+			"amount": 500,
+			"method": "standard",
+			"failure_code": "account_closed",
+			"failure_message": "Bank account closed"
+		}}
+	}`)
+	req := signedConnectRequest(t, payload, "whsec_test")
+	w := httptest.NewRecorder()
+	srv.handleStripeConnectWebhook(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("got %d: %s", w.Code, w.Body.String())
+	}
+
+	if bal := st.GetBalance(user.AccountID); bal != 10_000_000 {
+		t.Errorf("balance after refund = %d, want 10_000_000", bal)
+	}
+	wd, _ := st.GetStripeWithdrawal(withdrawalID)
+	if wd.Status != "failed" {
+		t.Errorf("status = %q, want failed", wd.Status)
+	}
+	if !wd.Refunded {
+		t.Error("refunded flag should be set")
+	}
+	if !strings.Contains(wd.FailureReason, "account_closed") {
+		t.Errorf("failure_reason = %q", wd.FailureReason)
+	}
+}
+
+func TestConnectWebhookPayoutFailedIsIdempotent(t *testing.T) {
+	fakeStripe := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer fakeStripe.Close()
+
+	srv, st := stripePayoutsTestServer(t, false, fakeStripe)
+	user := readyUser(t, st, "acct-wh-idem", "alice@example.com", false)
+	st.Credit(user.AccountID, 10_000_000, store.LedgerDeposit, "seed")
+	withdrawalID := "wd-idem-1"
+	_ = st.Debit(user.AccountID, 5_000_000, store.LedgerCharge, "stripe_withdraw:"+withdrawalID)
+	_ = st.CreateStripeWithdrawal(&store.StripeWithdrawal{
+		ID: withdrawalID, AccountID: user.AccountID, StripeAccountID: user.StripeAccountID,
+		PayoutID: "po_idem", AmountMicroUSD: 5_000_000, NetMicroUSD: 5_000_000,
+		Method: "standard", Status: "transferred",
+	})
+
+	payload := []byte(`{
+		"type":"payout.failed","account":"` + user.StripeAccountID + `",
+		"data":{"object":{"id":"po_idem","status":"failed","amount":500,"method":"standard","failure_code":"x","failure_message":"y"}}
+	}`)
+
+	for i := 0; i < 3; i++ {
+		req := signedConnectRequest(t, payload, "whsec_test")
+		w := httptest.NewRecorder()
+		srv.handleStripeConnectWebhook(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("delivery %d: got %d", i, w.Code)
+		}
+	}
+	if bal := st.GetBalance(user.AccountID); bal != 10_000_000 {
+		t.Errorf("balance after 3x payout.failed = %d, want 10_000_000 (single refund)", bal)
+	}
+}
+
+func TestConnectWebhookPayoutPaidIsIdempotent(t *testing.T) {
+	fakeStripe := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer fakeStripe.Close()
+
+	srv, st := stripePayoutsTestServer(t, false, fakeStripe)
+	user := readyUser(t, st, "acct-wh-paid", "alice@example.com", false)
+	st.Credit(user.AccountID, 10_000_000, store.LedgerDeposit, "seed")
+	withdrawalID := "wd-paid-1"
+	_ = st.Debit(user.AccountID, 5_000_000, store.LedgerCharge, "stripe_withdraw:"+withdrawalID)
+	_ = st.CreateStripeWithdrawal(&store.StripeWithdrawal{
+		ID: withdrawalID, AccountID: user.AccountID, StripeAccountID: user.StripeAccountID,
+		PayoutID: "po_paid", AmountMicroUSD: 5_000_000, NetMicroUSD: 5_000_000,
+		Method: "standard", Status: "transferred",
+	})
+
+	payload := []byte(`{
+		"type":"payout.paid","account":"` + user.StripeAccountID + `",
+		"data":{"object":{"id":"po_paid","status":"paid","amount":500,"method":"standard"}}
+	}`)
+	for i := 0; i < 3; i++ {
+		req := signedConnectRequest(t, payload, "whsec_test")
+		w := httptest.NewRecorder()
+		srv.handleStripeConnectWebhook(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("delivery %d: got %d", i, w.Code)
+		}
+	}
+	if bal := st.GetBalance(user.AccountID); bal != 5_000_000 {
+		t.Errorf("balance shouldn't change on payout.paid; got %d, want 5_000_000", bal)
+	}
+	wd, _ := st.GetStripeWithdrawal(withdrawalID)
+	if wd.Status != "paid" {
+		t.Errorf("status = %q", wd.Status)
+	}
+}
+
+func TestConnectWebhookRejectsBadSignature(t *testing.T) {
+	fakeStripe := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer fakeStripe.Close()
+	srv, _ := stripePayoutsTestServer(t, false, fakeStripe)
+
+	payload := []byte(`{"type":"account.updated","data":{"object":{"id":"x"}}}`)
+	req := httptest.NewRequest(http.MethodPost, "/v1/billing/stripe/connect/webhook", strings.NewReader(string(payload)))
+	req.Header.Set("Stripe-Signature", "t=1,v1=deadbeef")
+	w := httptest.NewRecorder()
+	srv.handleStripeConnectWebhook(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("got %d, want 400 on bad signature", w.Code)
+	}
+}
+
+// --- helpers ---
+
+// readyUser seeds a user that has finished Stripe onboarding. instantEligible
+// controls whether the destination is a debit card (true) or bank (false).
+func readyUser(t *testing.T, st *store.MemoryStore, accountID, email string, instantEligible bool) *store.User {
+	t.Helper()
+	u := seedUser(t, st, accountID, email)
+	dest := "bank"
+	last4 := "6789"
+	if instantEligible {
+		dest = "card"
+		last4 = "4242"
+	}
+	if err := st.SetUserStripeAccount(u.AccountID, "acct_"+accountID, "ready", dest, last4, instantEligible); err != nil {
+		t.Fatal(err)
+	}
+	got, _ := st.GetUserByAccountID(u.AccountID)
+	return got
+}
+
+// signedConnectRequest builds an HTTP request with a valid Stripe-Signature
+// header for the given payload + secret.
+func signedConnectRequest(t *testing.T, payload []byte, secret string) *http.Request {
+	t.Helper()
+	ts := fmt.Sprintf("%d", time.Now().Unix())
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(ts + "." + string(payload)))
+	sig := hex.EncodeToString(mac.Sum(nil))
+	req := httptest.NewRequest(http.MethodPost, "/v1/billing/stripe/connect/webhook",
+		strings.NewReader(string(payload)))
+	req.Header.Set("Stripe-Signature", "t="+ts+",v1="+sig)
+	req.Header.Set("Content-Type", "application/json")
+	return req
+}
+
+// silence unused-import linter when tests are pruned during iteration.
+var (
+	_ = io.Discard
+	_ = url.QueryEscape
+	_ = sync.Mutex{}
+)

--- a/coordinator/internal/billing/billing.go
+++ b/coordinator/internal/billing/billing.go
@@ -44,6 +44,14 @@ type Config struct {
 	StripeSuccessURL    string
 	StripeCancelURL     string
 
+	// Stripe Connect — Express accounts for paying users out to bank/card.
+	// Reuses StripeSecretKey for API auth; Connect events have a separate
+	// webhook signing secret because they're posted to a different endpoint.
+	StripeConnectWebhookSecret   string
+	StripeConnectPlatformCountry string // ISO 3166-1 alpha-2; defaults to "US"
+	StripeConnectReturnURL       string // where Stripe redirects after onboarding completes
+	StripeConnectRefreshURL      string // where Stripe redirects if the link expires
+
 	// Solana — primary payment rail for launch
 	SolanaRPCURL             string
 	SolanaUSDCMint           string
@@ -72,9 +80,10 @@ type Service struct {
 	logger *slog.Logger
 	config Config
 
-	stripe   *StripeProcessor
-	solana   *SolanaProcessor
-	referral *ReferralService
+	stripe        *StripeProcessor
+	stripeConnect *StripeConnect
+	solana        *SolanaProcessor
+	referral      *ReferralService
 }
 
 // NewService creates a new billing service from the given configuration.
@@ -96,6 +105,27 @@ func NewService(st store.Store, ledger *payments.Ledger, logger *slog.Logger, cf
 		svc.stripe = NewStripeProcessor(cfg.StripeSecretKey, cfg.StripeWebhookSecret,
 			cfg.StripeSuccessURL, cfg.StripeCancelURL, logger)
 		logger.Info("billing: Stripe processor enabled")
+
+		// Stripe Connect rides on the same secret key. We always create the
+		// client when Stripe is configured so callers can decide whether to
+		// surface the bank-payout option based on connect-specific config
+		// (return URL, etc.) being present.
+		svc.stripeConnect = NewStripeConnect(
+			cfg.StripeSecretKey,
+			cfg.StripeConnectWebhookSecret,
+			cfg.StripeConnectPlatformCountry,
+			cfg.MockMode,
+			logger,
+		)
+		logger.Info("billing: Stripe Connect (Express) enabled",
+			"platform_country", cfg.StripeConnectPlatformCountry,
+			"connect_webhook_configured", cfg.StripeConnectWebhookSecret != "",
+		)
+	} else if cfg.MockMode {
+		// In mock mode, surface a stub Connect client so dev console can
+		// exercise the full payout flow without real Stripe credentials.
+		svc.stripeConnect = NewStripeConnect("", "", cfg.StripeConnectPlatformCountry, true, logger)
+		logger.Info("billing: Stripe Connect mock-mode enabled")
 	}
 
 	// Initialize Solana processor
@@ -133,6 +163,17 @@ func NewService(st store.Store, ledger *payments.Ledger, logger *slog.Logger, cf
 
 // Stripe returns the Stripe processor, or nil if not configured.
 func (s *Service) Stripe() *StripeProcessor { return s.stripe }
+
+// StripeConnect returns the Stripe Connect Express client, or nil if Stripe
+// payouts are not configured.
+func (s *Service) StripeConnect() *StripeConnect { return s.stripeConnect }
+
+// StripeConnectReturnURL returns the configured return URL the frontend
+// should hand to Stripe in onboarding links.
+func (s *Service) StripeConnectReturnURL() string { return s.config.StripeConnectReturnURL }
+
+// StripeConnectRefreshURL returns the configured link-refresh URL.
+func (s *Service) StripeConnectRefreshURL() string { return s.config.StripeConnectRefreshURL }
 
 // Solana returns the Solana processor, or nil if not configured.
 func (s *Service) Solana() *SolanaProcessor { return s.solana }

--- a/coordinator/internal/billing/stripe_connect.go
+++ b/coordinator/internal/billing/stripe_connect.go
@@ -1,0 +1,654 @@
+package billing
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Stripe Connect Express integration for paying users out to bank accounts and
+// debit cards.
+//
+// Lifecycle:
+//
+//  1. We create an Express connected account (`accounts.create`) for the user
+//     when they click "Withdraw to bank" — `CreateExpressAccount`.
+//  2. We hand them a hosted onboarding link (`account_links.create`) — Stripe
+//     handles KYC, bank/card linking, and tax form collection — `CreateAccountLink`.
+//  3. The `account.updated` webhook tells us when `payouts_enabled=true` — we
+//     parse the event with `ParseAccountFromRaw` and the user's account is then
+//     "ready".
+//  4. To withdraw, we move USD from the platform balance to the connected
+//     account (`transfers.create` — `CreateTransfer`), then trigger a payout
+//     to bank or debit card (`payouts.create` — `CreatePayout`).
+//  5. Webhook events `payout.paid`, `payout.failed`, `transfer.failed` drive
+//     the local withdrawal state machine; on terminal failure we re-credit the
+//     user's ledger.
+//
+// All amounts cross the Stripe boundary in **integer USD cents**. The internal
+// micro-USD ledger has six-decimal precision; we always lose precision below a
+// cent on the way out. Callers must compute the exact debit-vs-fee split in
+// micro-USD and pass cent-rounded values here.
+
+// InstantFeeBps is the fee charged on Instant Payout withdrawals, in basis
+// points (150 bps = 1.5%). Calls to FeeForInstantPayoutMicroUSD use this.
+const InstantFeeBps int64 = 150
+
+// InstantFeeMinMicroUSD is the floor of the Instant Payout fee. With a 1.5%
+// rate this kicks in below ~$33.33.
+const InstantFeeMinMicroUSD int64 = 500_000 // $0.50
+
+// MinWithdrawMicroUSD is the smallest withdrawal accepted on the Stripe rail.
+// $1 lines up with both Stripe's ACH minimum and the Solana withdraw minimum.
+const MinWithdrawMicroUSD int64 = 1_000_000
+
+// FeeForInstantPayoutMicroUSD computes the platform fee for an instant payout
+// of the given gross amount. Standard payouts return 0.
+func FeeForInstantPayoutMicroUSD(grossMicroUSD int64) int64 {
+	if grossMicroUSD <= 0 {
+		return 0
+	}
+	pct := grossMicroUSD * InstantFeeBps / 10_000 // basis points → fraction
+	if pct < InstantFeeMinMicroUSD {
+		return InstantFeeMinMicroUSD
+	}
+	return pct
+}
+
+// FeeForMethodMicroUSD returns the per-withdrawal fee for the given method.
+// Standard ACH is free to the user; Instant uses FeeForInstantPayoutMicroUSD.
+func FeeForMethodMicroUSD(method string, grossMicroUSD int64) int64 {
+	if method == "instant" {
+		return FeeForInstantPayoutMicroUSD(grossMicroUSD)
+	}
+	return 0
+}
+
+// StripeConnect wraps the Stripe Connect Express endpoints. It piggybacks on
+// the same secret key + HTTP client as StripeProcessor.
+type StripeConnect struct {
+	secretKey            string
+	connectWebhookSecret string
+	platformCountry      string // ISO 3166-1 alpha-2 — defaults to "US"
+	mockMode             bool   // skips real Stripe API calls; returns deterministic stub responses
+	httpClient           *http.Client
+	logger               *slog.Logger
+}
+
+// NewStripeConnect builds a Stripe Connect client. If secretKey is empty the
+// client returns errors from every method; the higher-level service treats
+// that as "Stripe Payouts not configured".
+func NewStripeConnect(secretKey, connectWebhookSecret, platformCountry string, mockMode bool, logger *slog.Logger) *StripeConnect {
+	if platformCountry == "" {
+		platformCountry = "US"
+	}
+	return &StripeConnect{
+		secretKey:            secretKey,
+		connectWebhookSecret: connectWebhookSecret,
+		platformCountry:      platformCountry,
+		mockMode:             mockMode,
+		httpClient:           &http.Client{Timeout: 30 * time.Second},
+		logger:               logger,
+	}
+}
+
+// MockMode reports whether the client is short-circuiting Stripe API calls.
+func (c *StripeConnect) MockMode() bool { return c.mockMode }
+
+// stripeAPIBase is overridden by tests to point at httptest.NewServer().
+var stripeAPIBase = "https://api.stripe.com"
+
+// SetStripeAPIBaseForTest swaps the Stripe API base URL and returns the
+// previous value so the caller can restore it. Test-only helper — production
+// code must never call this.
+func SetStripeAPIBaseForTest(url string) string {
+	prev := stripeAPIBase
+	stripeAPIBase = url
+	return prev
+}
+
+// ExpressAccount captures the subset of fields we care about on a Stripe
+// connected account.
+type ExpressAccount struct {
+	ID                string
+	Email             string
+	ChargesEnabled    bool
+	PayoutsEnabled    bool
+	DetailsSubmitted  bool
+	CurrentlyDue      []string // requirements blocking the account from being live
+	DisabledReason    string   // populated when Stripe permanently disables the account
+	DestinationType   string   // "bank" | "card" | ""
+	DestinationLast4  string
+	DestinationCard   string // brand for cards (e.g. "visa")
+	InstantEligible   bool   // debit card destination supports Instant Payouts
+}
+
+// CreateExpressAccountParams gates which prefilled fields we pass to Stripe on
+// account creation. Email/first/last come from Privy; country defaults to US.
+type CreateExpressAccountParams struct {
+	Email     string
+	FirstName string
+	LastName  string
+	Country   string // ISO 3166-1 alpha-2 — empty means "use platform default"
+}
+
+// CreateExpressAccount creates a Stripe Express connected account. We request
+// both `transfers` (to push funds out) and `card_payments` because Stripe's
+// Connect Express flow requires the latter unless the platform has been
+// pre-approved for transfers-only. Requesting `card_payments` doesn't mean
+// we ever charge cards on behalf of the user — the capability just sits
+// enabled on the connected account; we only ever call transfers + payouts.
+// The trade-off is slightly more KYC info collected during onboarding, which
+// the user fills in on Stripe's hosted page anyway.
+func (c *StripeConnect) CreateExpressAccount(params CreateExpressAccountParams) (*ExpressAccount, error) {
+	if c.secretKey == "" && !c.mockMode {
+		return nil, fmt.Errorf("stripe connect: not configured")
+	}
+	country := params.Country
+	if country == "" {
+		country = c.platformCountry
+	}
+
+	if c.mockMode {
+		mockID := "acct_mock_" + strings.ReplaceAll(params.Email, "@", "_at_")
+		return &ExpressAccount{
+			ID:               mockID,
+			Email:            params.Email,
+			ChargesEnabled:   false,
+			PayoutsEnabled:   false,
+			DetailsSubmitted: false,
+		}, nil
+	}
+
+	form := url.Values{}
+	form.Set("type", "express")
+	form.Set("country", country)
+	form.Set("capabilities[transfers][requested]", "true")
+	form.Set("capabilities[card_payments][requested]", "true")
+	form.Set("business_type", "individual")
+	if params.Email != "" {
+		form.Set("email", params.Email)
+		form.Set("individual[email]", params.Email)
+	}
+	if params.FirstName != "" {
+		form.Set("individual[first_name]", params.FirstName)
+	}
+	if params.LastName != "" {
+		form.Set("individual[last_name]", params.LastName)
+	}
+	// We hand off all subsequent collection to Stripe's hosted flow.
+	form.Set("settings[payouts][schedule][interval]", "manual")
+
+	body, err := c.do("POST", "/v1/accounts", form, "")
+	if err != nil {
+		return nil, fmt.Errorf("stripe connect: create account: %w", err)
+	}
+	return parseAccount(body)
+}
+
+// CreateAccountLink returns a hosted onboarding URL the frontend should
+// redirect to. Stripe handles the KYC + bank linking flow.
+func (c *StripeConnect) CreateAccountLink(accountID, returnURL, refreshURL string) (string, error) {
+	if c.secretKey == "" && !c.mockMode {
+		return "", fmt.Errorf("stripe connect: not configured")
+	}
+	if accountID == "" || returnURL == "" || refreshURL == "" {
+		return "", fmt.Errorf("stripe connect: account_id, return_url, refresh_url required")
+	}
+
+	if c.mockMode {
+		return "https://connect.stripe.com/setup/mock/" + accountID + "?return=" + url.QueryEscape(returnURL), nil
+	}
+
+	form := url.Values{}
+	form.Set("account", accountID)
+	form.Set("type", "account_onboarding")
+	form.Set("return_url", returnURL)
+	form.Set("refresh_url", refreshURL)
+	form.Set("collect", "eventually_due")
+
+	body, err := c.do("POST", "/v1/account_links", form, "")
+	if err != nil {
+		return "", fmt.Errorf("stripe connect: create account link: %w", err)
+	}
+	var resp struct {
+		URL string `json:"url"`
+	}
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return "", fmt.Errorf("stripe connect: parse account link: %w", err)
+	}
+	return resp.URL, nil
+}
+
+// GetAccount fetches the latest account state from Stripe. We use this when the
+// user lands back on the billing page after onboarding so we can render the
+// "ready" / "needs more info" state without waiting for the webhook.
+func (c *StripeConnect) GetAccount(accountID string) (*ExpressAccount, error) {
+	if c.secretKey == "" && !c.mockMode {
+		return nil, fmt.Errorf("stripe connect: not configured")
+	}
+	if accountID == "" {
+		return nil, fmt.Errorf("stripe connect: account_id required")
+	}
+
+	if c.mockMode {
+		// Mock-mode account is "ready" so devs can exercise withdrawals.
+		return &ExpressAccount{
+			ID:               accountID,
+			ChargesEnabled:   true,
+			PayoutsEnabled:   true,
+			DetailsSubmitted: true,
+			DestinationType:  "bank",
+			DestinationLast4: "4242",
+		}, nil
+	}
+
+	body, err := c.do("GET", "/v1/accounts/"+accountID, nil, "")
+	if err != nil {
+		return nil, fmt.Errorf("stripe connect: get account: %w", err)
+	}
+	return parseAccount(body)
+}
+
+// CreateTransferParams describes a transfer from the platform balance into a
+// connected account's balance. amountCents is the integer-cent amount net of
+// any user-facing fee.
+type CreateTransferParams struct {
+	DestinationAccountID string
+	AmountCents          int64
+	IdempotencyKey       string
+	Description          string // optional, surfaced in the Stripe dashboard
+}
+
+// Transfer is the small subset of Stripe Transfer fields we need.
+type Transfer struct {
+	ID          string
+	AmountCents int64
+	Destination string
+	Created     int64
+}
+
+// CreateTransfer pushes USD from the platform balance to the connected account.
+// Always wrap the call in an idempotency key so a retry after a network blip
+// can't double-pay the user.
+func (c *StripeConnect) CreateTransfer(params CreateTransferParams) (*Transfer, error) {
+	if c.secretKey == "" && !c.mockMode {
+		return nil, fmt.Errorf("stripe connect: not configured")
+	}
+	if params.DestinationAccountID == "" || params.AmountCents <= 0 || params.IdempotencyKey == "" {
+		return nil, fmt.Errorf("stripe connect: destination, amount_cents>0, idempotency_key required")
+	}
+
+	if c.mockMode {
+		return &Transfer{
+			ID:          "tr_mock_" + params.IdempotencyKey,
+			AmountCents: params.AmountCents,
+			Destination: params.DestinationAccountID,
+			Created:     time.Now().Unix(),
+		}, nil
+	}
+
+	form := url.Values{}
+	form.Set("amount", strconv.FormatInt(params.AmountCents, 10))
+	form.Set("currency", "usd")
+	form.Set("destination", params.DestinationAccountID)
+	if params.Description != "" {
+		form.Set("description", params.Description)
+	}
+
+	body, err := c.do("POST", "/v1/transfers", form, params.IdempotencyKey)
+	if err != nil {
+		return nil, fmt.Errorf("stripe connect: create transfer: %w", err)
+	}
+
+	var resp struct {
+		ID          string `json:"id"`
+		Amount      int64  `json:"amount"`
+		Destination string `json:"destination"`
+		Created     int64  `json:"created"`
+	}
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, fmt.Errorf("stripe connect: parse transfer: %w", err)
+	}
+	return &Transfer{
+		ID:          resp.ID,
+		AmountCents: resp.Amount,
+		Destination: resp.Destination,
+		Created:     resp.Created,
+	}, nil
+}
+
+// CreatePayoutParams describes a payout from a connected account's balance to
+// the user's external bank account or debit card. Method is "standard" or
+// "instant"; instant only works against eligible debit-card destinations.
+type CreatePayoutParams struct {
+	OnBehalfOfAccountID string
+	AmountCents         int64
+	Method              string // "standard" | "instant"
+	IdempotencyKey      string
+	Description         string
+}
+
+// Payout captures the Stripe Payout fields we surface to the user.
+type Payout struct {
+	ID          string
+	AmountCents int64
+	Method      string
+	Status      string
+	ArrivalDate int64 // Unix epoch — when funds are expected to land
+}
+
+// CreatePayout instructs the connected account to pay out to its external
+// destination. The Stripe-Account header authenticates the call as the
+// connected account so the payout draws from their balance, not ours.
+func (c *StripeConnect) CreatePayout(params CreatePayoutParams) (*Payout, error) {
+	if c.secretKey == "" && !c.mockMode {
+		return nil, fmt.Errorf("stripe connect: not configured")
+	}
+	if params.OnBehalfOfAccountID == "" || params.AmountCents <= 0 || params.IdempotencyKey == "" {
+		return nil, fmt.Errorf("stripe connect: account, amount_cents>0, idempotency_key required")
+	}
+	method := params.Method
+	if method == "" {
+		method = "standard"
+	}
+	if method != "standard" && method != "instant" {
+		return nil, fmt.Errorf("stripe connect: invalid payout method %q", method)
+	}
+
+	if c.mockMode {
+		return &Payout{
+			ID:          "po_mock_" + params.IdempotencyKey,
+			AmountCents: params.AmountCents,
+			Method:      method,
+			Status:      "in_transit",
+			ArrivalDate: time.Now().Add(24 * time.Hour).Unix(),
+		}, nil
+	}
+
+	form := url.Values{}
+	form.Set("amount", strconv.FormatInt(params.AmountCents, 10))
+	form.Set("currency", "usd")
+	form.Set("method", method)
+	if params.Description != "" {
+		form.Set("description", params.Description)
+	}
+
+	body, err := c.do("POST", "/v1/payouts", form, params.IdempotencyKey, withStripeAccount(params.OnBehalfOfAccountID))
+	if err != nil {
+		return nil, fmt.Errorf("stripe connect: create payout: %w", err)
+	}
+	var resp struct {
+		ID          string `json:"id"`
+		Amount      int64  `json:"amount"`
+		Method      string `json:"method"`
+		Status      string `json:"status"`
+		ArrivalDate int64  `json:"arrival_date"`
+	}
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, fmt.Errorf("stripe connect: parse payout: %w", err)
+	}
+	return &Payout{
+		ID:          resp.ID,
+		AmountCents: resp.Amount,
+		Method:      resp.Method,
+		Status:      resp.Status,
+		ArrivalDate: resp.ArrivalDate,
+	}, nil
+}
+
+// VerifyConnectWebhookSignature mirrors StripeProcessor.VerifyWebhookSignature
+// but uses the Connect-specific webhook secret. Stripe sends Connect events to
+// a separate endpoint configured in the dashboard with its own signing secret.
+//
+// In production we hard-fail if the secret isn't configured: webhooks drive
+// ledger refunds, so accepting unsigned events would let a stolen payout ID
+// trigger a refund. Mock mode (dev) parses without verification so test
+// scripts can drive the state machine end-to-end.
+func (c *StripeConnect) VerifyConnectWebhookSignature(payload []byte, sigHeader string) (*WebhookEvent, error) {
+	if c.connectWebhookSecret == "" {
+		if !c.mockMode {
+			return nil, fmt.Errorf("stripe connect: webhook secret not configured — refusing to verify")
+		}
+		// Mock-only fallback so dev tooling can post events.
+		var event WebhookEvent
+		if err := json.Unmarshal(payload, &event); err != nil {
+			return nil, fmt.Errorf("stripe connect: parse webhook: %w", err)
+		}
+		return &event, nil
+	}
+
+	// Reuse the StripeProcessor signature path by constructing an ad-hoc one
+	// with the same secret. Keeps the HMAC code in one place.
+	tmp := &StripeProcessor{webhookSecret: c.connectWebhookSecret}
+	return tmp.VerifyWebhookSignature(payload, sigHeader)
+}
+
+// AccountUpdatedFromEvent extracts the Stripe Account fields we mirror locally.
+func (c *StripeConnect) AccountUpdatedFromEvent(event *WebhookEvent) (*ExpressAccount, error) {
+	if event == nil || event.Type != "account.updated" {
+		return nil, fmt.Errorf("stripe connect: expected account.updated, got %q", event.Type)
+	}
+	var data struct {
+		Object json.RawMessage `json:"object"`
+	}
+	if err := json.Unmarshal(event.Data, &data); err != nil {
+		return nil, fmt.Errorf("stripe connect: parse account.updated: %w", err)
+	}
+	return parseAccount(data.Object)
+}
+
+// PayoutEvent captures the subset of payout fields driven by webhooks.
+type PayoutEvent struct {
+	ID            string
+	Status        string // "paid" | "failed" | etc
+	AmountCents   int64
+	Method        string
+	FailureCode   string
+	FailureReason string
+	Destination   string // pm-style ID (ba_… / card_…)
+	ConnectedAcct string // Stripe-Account header value, populated from event.Account
+}
+
+// PayoutFromEvent extracts the Payout fields we need, plus the connected
+// account ID from the event envelope (Stripe sends Connect-account events with
+// an "account" field at the top level).
+func (c *StripeConnect) PayoutFromEvent(event *WebhookEvent, rawAccount string) (*PayoutEvent, error) {
+	if event == nil {
+		return nil, fmt.Errorf("stripe connect: nil event")
+	}
+	var data struct {
+		Object struct {
+			ID            string `json:"id"`
+			Status        string `json:"status"`
+			Amount        int64  `json:"amount"`
+			Method        string `json:"method"`
+			FailureCode   string `json:"failure_code"`
+			FailureMsg    string `json:"failure_message"`
+			Destination   string `json:"destination"`
+		} `json:"object"`
+	}
+	if err := json.Unmarshal(event.Data, &data); err != nil {
+		return nil, fmt.Errorf("stripe connect: parse payout event: %w", err)
+	}
+	return &PayoutEvent{
+		ID:            data.Object.ID,
+		Status:        data.Object.Status,
+		AmountCents:   data.Object.Amount,
+		Method:        data.Object.Method,
+		FailureCode:   data.Object.FailureCode,
+		FailureReason: data.Object.FailureMsg,
+		Destination:   data.Object.Destination,
+		ConnectedAcct: rawAccount,
+	}, nil
+}
+
+// TransferEvent is the slimmed-down view of a transfer-related event.
+type TransferEvent struct {
+	ID          string
+	AmountCents int64
+	Destination string
+	Reversed    bool
+}
+
+// TransferFromEvent extracts the transfer object from a charge/transfer event.
+func (c *StripeConnect) TransferFromEvent(event *WebhookEvent) (*TransferEvent, error) {
+	if event == nil {
+		return nil, fmt.Errorf("stripe connect: nil event")
+	}
+	var data struct {
+		Object struct {
+			ID          string `json:"id"`
+			Amount      int64  `json:"amount"`
+			Destination string `json:"destination"`
+			Reversed    bool   `json:"reversed"`
+		} `json:"object"`
+	}
+	if err := json.Unmarshal(event.Data, &data); err != nil {
+		return nil, fmt.Errorf("stripe connect: parse transfer event: %w", err)
+	}
+	return &TransferEvent{
+		ID:          data.Object.ID,
+		AmountCents: data.Object.Amount,
+		Destination: data.Object.Destination,
+		Reversed:    data.Object.Reversed,
+	}, nil
+}
+
+// --- HTTP plumbing ---
+
+type doOption func(req *http.Request)
+
+func withStripeAccount(acct string) doOption {
+	return func(req *http.Request) {
+		if acct != "" {
+			req.Header.Set("Stripe-Account", acct)
+		}
+	}
+}
+
+func (c *StripeConnect) do(method, path string, form url.Values, idempotencyKey string, opts ...doOption) ([]byte, error) {
+	var body io.Reader
+	if form != nil {
+		body = strings.NewReader(form.Encode())
+	}
+	req, err := http.NewRequest(method, stripeAPIBase+path, body)
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+c.secretKey)
+	if form != nil {
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	}
+	if idempotencyKey != "" {
+		req.Header.Set("Idempotency-Key", idempotencyKey)
+	}
+	for _, opt := range opts {
+		opt(req)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("api request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		// Try to surface Stripe's structured error message verbatim.
+		var errEnvelope struct {
+			Error struct {
+				Message string `json:"message"`
+				Type    string `json:"type"`
+				Code    string `json:"code"`
+			} `json:"error"`
+		}
+		if json.Unmarshal(respBody, &errEnvelope) == nil && errEnvelope.Error.Message != "" {
+			return nil, fmt.Errorf("stripe %d: %s", resp.StatusCode, errEnvelope.Error.Message)
+		}
+		return nil, fmt.Errorf("stripe %d: %s", resp.StatusCode, string(respBody))
+	}
+	return respBody, nil
+}
+
+// parseAccount maps the raw account JSON onto our trimmed ExpressAccount type.
+// It pulls the destination (bank account or debit card) from external_accounts
+// when present so the UI can show "Chase ••4821".
+func parseAccount(body []byte) (*ExpressAccount, error) {
+	var resp struct {
+		ID               string `json:"id"`
+		Email            string `json:"email"`
+		ChargesEnabled   bool   `json:"charges_enabled"`
+		PayoutsEnabled   bool   `json:"payouts_enabled"`
+		DetailsSubmitted bool   `json:"details_submitted"`
+		Requirements     struct {
+			CurrentlyDue   []string `json:"currently_due"`
+			DisabledReason string   `json:"disabled_reason"`
+		} `json:"requirements"`
+		ExternalAccounts struct {
+			Data []struct {
+				Object   string `json:"object"` // "bank_account" | "card"
+				Last4    string `json:"last4"`
+				Brand    string `json:"brand"`
+				Funding  string `json:"funding"`
+				DefaultForCurrency bool `json:"default_for_currency"`
+			} `json:"data"`
+		} `json:"external_accounts"`
+	}
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, fmt.Errorf("parse account: %w", err)
+	}
+
+	acct := &ExpressAccount{
+		ID:               resp.ID,
+		Email:            resp.Email,
+		ChargesEnabled:   resp.ChargesEnabled,
+		PayoutsEnabled:   resp.PayoutsEnabled,
+		DetailsSubmitted: resp.DetailsSubmitted,
+		CurrentlyDue:     resp.Requirements.CurrentlyDue,
+		DisabledReason:   resp.Requirements.DisabledReason,
+	}
+
+	// Pick the default external account (or the first one) as the destination
+	// we display. Instant Payouts only work against debit cards.
+	var pick *struct {
+		Object   string `json:"object"`
+		Last4    string `json:"last4"`
+		Brand    string `json:"brand"`
+		Funding  string `json:"funding"`
+		DefaultForCurrency bool `json:"default_for_currency"`
+	}
+	for i := range resp.ExternalAccounts.Data {
+		ea := &resp.ExternalAccounts.Data[i]
+		if pick == nil || ea.DefaultForCurrency {
+			pick = ea
+		}
+		if ea.DefaultForCurrency {
+			break
+		}
+	}
+	if pick != nil {
+		switch pick.Object {
+		case "bank_account":
+			acct.DestinationType = "bank"
+		case "card":
+			acct.DestinationType = "card"
+			acct.DestinationCard = pick.Brand
+			// Stripe only supports Instant Payouts to debit cards.
+			if strings.EqualFold(pick.Funding, "debit") {
+				acct.InstantEligible = true
+			}
+		}
+		acct.DestinationLast4 = pick.Last4
+	}
+	return acct, nil
+}

--- a/coordinator/internal/billing/stripe_connect_test.go
+++ b/coordinator/internal/billing/stripe_connect_test.go
@@ -1,0 +1,484 @@
+package billing
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+// silentLogger keeps test output clean; switch to TextHandler if you're
+// debugging a failing case.
+func silentLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+}
+
+// signWebhook produces a Stripe-Signature header for the given payload using
+// the processor's webhook secret. Mirrors Stripe's reference implementation:
+// "t=<unix>,v1=<HMAC-SHA256(t + . + payload)>".
+func signWebhook(t *testing.T, p *StripeProcessor, payload []byte) string {
+	t.Helper()
+	ts := fmt.Sprintf("%d", time.Now().Unix())
+	mac := hmac.New(sha256.New, []byte(p.webhookSecret))
+	mac.Write([]byte(ts + "." + string(payload)))
+	sig := hex.EncodeToString(mac.Sum(nil))
+	return "t=" + ts + ",v1=" + sig
+}
+
+func TestFeeForInstantPayoutMicroUSD(t *testing.T) {
+	cases := []struct {
+		name      string
+		grossUSD  int64 // micro-USD
+		wantMicro int64
+	}{
+		// Below the floor — fee snaps to $0.50.
+		{"one_dollar", 1_000_000, 500_000},
+		{"five_dollar", 5_000_000, 500_000},
+		{"thirty_dollar", 30_000_000, 500_000},
+		// 1.5% kicks in above the $0.50 / 1.5% = ~$33.33 threshold.
+		{"fifty_dollar", 50_000_000, 750_000},     // 1.5% of $50 = $0.75
+		{"one_hundred", 100_000_000, 1_500_000},  // $1.50
+		{"one_thousand", 1_000_000_000, 15_000_000}, // $15
+		// Edge cases.
+		{"zero", 0, 0},
+		{"negative", -100, 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := FeeForInstantPayoutMicroUSD(tc.grossUSD)
+			if got != tc.wantMicro {
+				t.Errorf("FeeForInstantPayoutMicroUSD(%d) = %d, want %d", tc.grossUSD, got, tc.wantMicro)
+			}
+		})
+	}
+}
+
+func TestFeeForMethodMicroUSD(t *testing.T) {
+	if got := FeeForMethodMicroUSD("standard", 50_000_000); got != 0 {
+		t.Errorf("standard fee should be 0, got %d", got)
+	}
+	if got := FeeForMethodMicroUSD("instant", 50_000_000); got != 750_000 {
+		t.Errorf("instant fee on $50 should be $0.75, got %d", got)
+	}
+	if got := FeeForMethodMicroUSD("unknown", 50_000_000); got != 0 {
+		t.Errorf("unknown method should default to 0 fee, got %d", got)
+	}
+}
+
+// withTestStripe spins up an httptest server, points stripeAPIBase at it for
+// the duration of the test, and returns the server + a client targeting it.
+func withTestStripe(t *testing.T, handler http.HandlerFunc) (*httptest.Server, *StripeConnect) {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	prev := stripeAPIBase
+	stripeAPIBase = srv.URL
+	t.Cleanup(func() { stripeAPIBase = prev })
+	return srv, NewStripeConnect("sk_test_fake", "whsec_fake", "US", false, silentLogger())
+}
+
+func TestCreateExpressAccountSuccess(t *testing.T) {
+	var captured *http.Request
+	var capturedBody url.Values
+	_, client := withTestStripe(t, func(w http.ResponseWriter, r *http.Request) {
+		captured = r
+		body, _ := io.ReadAll(r.Body)
+		capturedBody, _ = url.ParseQuery(string(body))
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{
+			"id": "acct_test_123",
+			"email": "alice@example.com",
+			"charges_enabled": false,
+			"payouts_enabled": false,
+			"details_submitted": false
+		}`))
+	})
+
+	acct, err := client.CreateExpressAccount(CreateExpressAccountParams{
+		Email: "alice@example.com",
+	})
+	if err != nil {
+		t.Fatalf("create account: %v", err)
+	}
+	if acct.ID != "acct_test_123" {
+		t.Errorf("got ID %q, want acct_test_123", acct.ID)
+	}
+	if captured.URL.Path != "/v1/accounts" {
+		t.Errorf("path = %q, want /v1/accounts", captured.URL.Path)
+	}
+	if got := capturedBody.Get("type"); got != "express" {
+		t.Errorf("type=%q, want express", got)
+	}
+	if got := capturedBody.Get("email"); got != "alice@example.com" {
+		t.Errorf("email=%q, want alice@example.com", got)
+	}
+	if got := capturedBody.Get("country"); got != "US" {
+		t.Errorf("country=%q, want US", got)
+	}
+	if auth := captured.Header.Get("Authorization"); auth != "Bearer sk_test_fake" {
+		t.Errorf("Authorization header = %q", auth)
+	}
+}
+
+func TestCreateExpressAccountStripeError(t *testing.T) {
+	_, client := withTestStripe(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":{"message":"country is invalid","type":"invalid_request_error"}}`))
+	})
+	_, err := client.CreateExpressAccount(CreateExpressAccountParams{Email: "a@b.com"})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "country is invalid") {
+		t.Errorf("error should surface Stripe's message; got %v", err)
+	}
+}
+
+func TestCreateAccountLinkSuccess(t *testing.T) {
+	var capturedBody url.Values
+	_, client := withTestStripe(t, func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		capturedBody, _ = url.ParseQuery(string(body))
+		_, _ = w.Write([]byte(`{"url":"https://connect.stripe.com/setup/abc123"}`))
+	})
+	link, err := client.CreateAccountLink("acct_test_123", "https://app/return", "https://app/refresh")
+	if err != nil {
+		t.Fatalf("create link: %v", err)
+	}
+	if link != "https://connect.stripe.com/setup/abc123" {
+		t.Errorf("got link %q", link)
+	}
+	if capturedBody.Get("account") != "acct_test_123" {
+		t.Errorf("account=%q", capturedBody.Get("account"))
+	}
+	if capturedBody.Get("type") != "account_onboarding" {
+		t.Errorf("type=%q", capturedBody.Get("type"))
+	}
+	if capturedBody.Get("return_url") != "https://app/return" {
+		t.Errorf("return_url=%q", capturedBody.Get("return_url"))
+	}
+}
+
+func TestCreateAccountLinkRequiresAccount(t *testing.T) {
+	_, client := withTestStripe(t, func(w http.ResponseWriter, r *http.Request) { t.Error("should not call Stripe") })
+	_, err := client.CreateAccountLink("", "https://app/return", "https://app/refresh")
+	if err == nil {
+		t.Fatal("expected error for missing account")
+	}
+}
+
+func TestGetAccountParsesDestinationAndInstantEligibility(t *testing.T) {
+	_, client := withTestStripe(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{
+			"id": "acct_x",
+			"charges_enabled": true,
+			"payouts_enabled": true,
+			"details_submitted": true,
+			"requirements": {"currently_due": [], "disabled_reason": ""},
+			"external_accounts": {"data": [
+				{"object":"card","last4":"4242","brand":"visa","funding":"debit","default_for_currency":true}
+			]}
+		}`))
+	})
+	acct, err := client.GetAccount("acct_x")
+	if err != nil {
+		t.Fatalf("get account: %v", err)
+	}
+	if !acct.PayoutsEnabled {
+		t.Error("payouts_enabled should be true")
+	}
+	if acct.DestinationType != "card" {
+		t.Errorf("destination_type=%q, want card", acct.DestinationType)
+	}
+	if acct.DestinationLast4 != "4242" {
+		t.Errorf("last4=%q", acct.DestinationLast4)
+	}
+	if !acct.InstantEligible {
+		t.Error("debit card should be instant-eligible")
+	}
+}
+
+func TestGetAccountCreditCardNotInstantEligible(t *testing.T) {
+	_, client := withTestStripe(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{
+			"id": "acct_x",
+			"payouts_enabled": true,
+			"external_accounts": {"data": [
+				{"object":"card","last4":"4242","brand":"visa","funding":"credit","default_for_currency":true}
+			]}
+		}`))
+	})
+	acct, _ := client.GetAccount("acct_x")
+	if acct.InstantEligible {
+		t.Error("credit card destinations should NOT be instant-eligible")
+	}
+}
+
+func TestGetAccountBankDestination(t *testing.T) {
+	_, client := withTestStripe(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{
+			"id": "acct_x",
+			"payouts_enabled": true,
+			"external_accounts": {"data": [
+				{"object":"bank_account","last4":"6789","default_for_currency":true}
+			]}
+		}`))
+	})
+	acct, _ := client.GetAccount("acct_x")
+	if acct.DestinationType != "bank" {
+		t.Errorf("destination_type=%q, want bank", acct.DestinationType)
+	}
+	if acct.InstantEligible {
+		t.Error("bank destinations are not instant-eligible")
+	}
+}
+
+func TestCreateTransferSendsIdempotencyKey(t *testing.T) {
+	var idemKey string
+	var capturedBody url.Values
+	_, client := withTestStripe(t, func(w http.ResponseWriter, r *http.Request) {
+		idemKey = r.Header.Get("Idempotency-Key")
+		body, _ := io.ReadAll(r.Body)
+		capturedBody, _ = url.ParseQuery(string(body))
+		_, _ = w.Write([]byte(`{"id":"tr_123","amount":1000,"destination":"acct_x","created":1700000000}`))
+	})
+	tr, err := client.CreateTransfer(CreateTransferParams{
+		DestinationAccountID: "acct_x",
+		AmountCents:          1000,
+		IdempotencyKey:       "wd-tr-uuid",
+	})
+	if err != nil {
+		t.Fatalf("transfer: %v", err)
+	}
+	if idemKey != "wd-tr-uuid" {
+		t.Errorf("idempotency-key = %q", idemKey)
+	}
+	if tr.ID != "tr_123" {
+		t.Errorf("id=%q", tr.ID)
+	}
+	if capturedBody.Get("amount") != "1000" {
+		t.Errorf("amount=%q", capturedBody.Get("amount"))
+	}
+	if capturedBody.Get("currency") != "usd" {
+		t.Errorf("currency=%q", capturedBody.Get("currency"))
+	}
+	if capturedBody.Get("destination") != "acct_x" {
+		t.Errorf("destination=%q", capturedBody.Get("destination"))
+	}
+}
+
+func TestCreateTransferRequiresParams(t *testing.T) {
+	_, client := withTestStripe(t, func(w http.ResponseWriter, r *http.Request) { t.Error("should not call Stripe") })
+	_, err := client.CreateTransfer(CreateTransferParams{IdempotencyKey: "x"})
+	if err == nil {
+		t.Error("expected error for missing destination/amount")
+	}
+}
+
+func TestCreatePayoutSetsStripeAccountHeader(t *testing.T) {
+	var stripeAcct string
+	var capturedBody url.Values
+	_, client := withTestStripe(t, func(w http.ResponseWriter, r *http.Request) {
+		stripeAcct = r.Header.Get("Stripe-Account")
+		body, _ := io.ReadAll(r.Body)
+		capturedBody, _ = url.ParseQuery(string(body))
+		_, _ = w.Write([]byte(`{"id":"po_1","amount":900,"method":"instant","status":"in_transit","arrival_date":1700000300}`))
+	})
+	po, err := client.CreatePayout(CreatePayoutParams{
+		OnBehalfOfAccountID: "acct_user",
+		AmountCents:         900,
+		Method:              "instant",
+		IdempotencyKey:      "wd-po-uuid",
+	})
+	if err != nil {
+		t.Fatalf("payout: %v", err)
+	}
+	if stripeAcct != "acct_user" {
+		t.Errorf("Stripe-Account header = %q", stripeAcct)
+	}
+	if po.ID != "po_1" || po.Method != "instant" {
+		t.Errorf("payout = %+v", po)
+	}
+	if capturedBody.Get("method") != "instant" {
+		t.Errorf("method=%q", capturedBody.Get("method"))
+	}
+}
+
+func TestCreatePayoutRejectsInvalidMethod(t *testing.T) {
+	_, client := withTestStripe(t, func(w http.ResponseWriter, r *http.Request) { t.Error("should not call Stripe") })
+	_, err := client.CreatePayout(CreatePayoutParams{
+		OnBehalfOfAccountID: "acct_user",
+		AmountCents:         100,
+		Method:              "ach", // not standard/instant
+		IdempotencyKey:      "x",
+	})
+	if err == nil || !strings.Contains(err.Error(), "invalid payout method") {
+		t.Errorf("expected invalid payout method error, got %v", err)
+	}
+}
+
+func TestMockModeBypassesHTTP(t *testing.T) {
+	// No httptest server — mock mode must not hit the network.
+	c := NewStripeConnect("", "", "US", true, silentLogger())
+	acct, err := c.CreateExpressAccount(CreateExpressAccountParams{Email: "a@b.com"})
+	if err != nil {
+		t.Fatalf("mock create: %v", err)
+	}
+	if !strings.HasPrefix(acct.ID, "acct_mock_") {
+		t.Errorf("expected mock account id, got %q", acct.ID)
+	}
+	link, err := c.CreateAccountLink(acct.ID, "https://app/return", "https://app/refresh")
+	if err != nil {
+		t.Fatalf("mock link: %v", err)
+	}
+	if !strings.Contains(link, "/setup/mock/") {
+		t.Errorf("expected mock link, got %q", link)
+	}
+	tr, err := c.CreateTransfer(CreateTransferParams{
+		DestinationAccountID: acct.ID,
+		AmountCents:          100,
+		IdempotencyKey:       "x",
+	})
+	if err != nil {
+		t.Fatalf("mock transfer: %v", err)
+	}
+	if !strings.HasPrefix(tr.ID, "tr_mock_") {
+		t.Errorf("expected mock transfer id, got %q", tr.ID)
+	}
+	po, err := c.CreatePayout(CreatePayoutParams{
+		OnBehalfOfAccountID: acct.ID,
+		AmountCents:         100,
+		Method:              "standard",
+		IdempotencyKey:      "x",
+	})
+	if err != nil {
+		t.Fatalf("mock payout: %v", err)
+	}
+	if !strings.HasPrefix(po.ID, "po_mock_") {
+		t.Errorf("expected mock payout id, got %q", po.ID)
+	}
+}
+
+func TestVerifyConnectWebhookSignatureRejectsEmptySecretInProd(t *testing.T) {
+	// Production-shaped client (no mock mode, no webhook secret) must refuse
+	// to verify rather than accepting unsigned events.
+	c := NewStripeConnect("sk_test", "" /* secret */, "US", false /* mockMode */, silentLogger())
+	_, err := c.VerifyConnectWebhookSignature([]byte(`{"type":"x"}`), "")
+	if err == nil {
+		t.Fatal("expected refusal to verify with empty secret in non-mock mode")
+	}
+	if !strings.Contains(err.Error(), "webhook secret not configured") {
+		t.Errorf("error should mention missing secret; got %v", err)
+	}
+}
+
+func TestVerifyConnectWebhookSignatureMockModeAllowsUnsigned(t *testing.T) {
+	// Mock mode (dev) must still allow unsigned events for local scripting.
+	c := NewStripeConnect("", "", "US", true /* mockMode */, silentLogger())
+	event, err := c.VerifyConnectWebhookSignature([]byte(`{"type":"account.updated","data":{"object":{"id":"x"}}}`), "")
+	if err != nil {
+		t.Fatalf("mock mode should allow unsigned events: %v", err)
+	}
+	if event.Type != "account.updated" {
+		t.Errorf("event type = %q", event.Type)
+	}
+}
+
+func TestVerifyConnectWebhookSignature(t *testing.T) {
+	c := NewStripeConnect("sk_test", "whsec_test", "US", false, silentLogger())
+
+	// Use the same StripeProcessor signing helper as the production webhook
+	// path uses to verify, so test fixtures stay in lockstep.
+	payload := []byte(`{"type":"account.updated","data":{"object":{"id":"acct_x"}}}`)
+	tmp := NewStripeProcessor("sk_test", "whsec_test", "", "", silentLogger())
+	header := signWebhook(t, tmp, payload)
+
+	event, err := c.VerifyConnectWebhookSignature(payload, header)
+	if err != nil {
+		t.Fatalf("verify: %v", err)
+	}
+	if event.Type != "account.updated" {
+		t.Errorf("event type = %q", event.Type)
+	}
+
+	// Tampered payload should fail.
+	tampered := []byte(`{"type":"account.updated","data":{"object":{"id":"acct_y"}}}`)
+	if _, err := c.VerifyConnectWebhookSignature(tampered, header); err == nil {
+		t.Error("expected signature verification to fail on tampered payload")
+	}
+}
+
+func TestAccountUpdatedFromEventStatusMapping(t *testing.T) {
+	c := NewStripeConnect("sk_test", "", "US", false, silentLogger())
+
+	body := []byte(`{
+		"type": "account.updated",
+		"data": {
+			"object": {
+				"id": "acct_x",
+				"payouts_enabled": true,
+				"details_submitted": true,
+				"external_accounts": {"data":[{"object":"card","last4":"1111","funding":"debit","default_for_currency":true}]}
+			}
+		}
+	}`)
+	var event WebhookEvent
+	if err := json.Unmarshal(body, &event); err != nil {
+		t.Fatal(err)
+	}
+	acct, err := c.AccountUpdatedFromEvent(&event)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if !acct.PayoutsEnabled {
+		t.Error("payouts_enabled should be true")
+	}
+	if !acct.InstantEligible {
+		t.Error("instant_eligible should be true for default debit card")
+	}
+}
+
+func TestPayoutFromEventCapturesFailureFields(t *testing.T) {
+	c := NewStripeConnect("sk_test", "", "US", false, silentLogger())
+	body := []byte(`{
+		"type": "payout.failed",
+		"data": {"object": {
+			"id": "po_1",
+			"status": "failed",
+			"amount": 500,
+			"method": "standard",
+			"failure_code": "account_closed",
+			"failure_message": "The bank account was closed."
+		}}
+	}`)
+	var event WebhookEvent
+	_ = json.Unmarshal(body, &event)
+	pe, err := c.PayoutFromEvent(&event, "acct_x")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if pe.Status != "failed" {
+		t.Errorf("status=%q", pe.Status)
+	}
+	if pe.FailureCode != "account_closed" {
+		t.Errorf("failure_code=%q", pe.FailureCode)
+	}
+	if pe.FailureReason != "The bank account was closed." {
+		t.Errorf("failure_reason=%q", pe.FailureReason)
+	}
+	if pe.ConnectedAcct != "acct_x" {
+		t.Errorf("connected_acct=%q", pe.ConnectedAcct)
+	}
+}

--- a/coordinator/internal/store/interface.go
+++ b/coordinator/internal/store/interface.go
@@ -155,6 +155,38 @@ type Store interface {
 	// GetUserByAccountID returns the user for an internal account ID.
 	GetUserByAccountID(accountID string) (*User, error)
 
+	// SetUserStripeAccount upserts the Stripe Connect fields on a user record.
+	// Pass empty strings to clear the destination (e.g. before re-onboarding).
+	SetUserStripeAccount(accountID, stripeAccountID, status, destinationType, destinationLast4 string, instantEligible bool) error
+
+	// GetUserByStripeAccount finds a user by their Stripe connected account ID.
+	// Used by webhook handlers to route account.updated / payout.* events.
+	GetUserByStripeAccount(stripeAccountID string) (*User, error)
+
+	// --- Stripe Withdrawals (bank/card payouts via Stripe Connect) ---
+
+	// CreateStripeWithdrawal stores a new withdrawal record. The caller is
+	// responsible for debiting the ledger atomically before calling this.
+	CreateStripeWithdrawal(withdrawal *StripeWithdrawal) error
+
+	// GetStripeWithdrawal returns a withdrawal by its internal UUID.
+	GetStripeWithdrawal(id string) (*StripeWithdrawal, error)
+
+	// GetStripeWithdrawalByPayoutID looks up a withdrawal by Stripe payout ID
+	// (po_…). Used in payout.paid / payout.failed webhook handlers.
+	GetStripeWithdrawalByPayoutID(payoutID string) (*StripeWithdrawal, error)
+
+	// GetStripeWithdrawalByTransferID looks up a withdrawal by Stripe transfer
+	// ID (tr_…). Used in transfer.failed webhook handlers.
+	GetStripeWithdrawalByTransferID(transferID string) (*StripeWithdrawal, error)
+
+	// UpdateStripeWithdrawal persists status/transfer/payout/fail-reason changes.
+	UpdateStripeWithdrawal(withdrawal *StripeWithdrawal) error
+
+	// ListStripeWithdrawals returns withdrawals for an account, newest first.
+	// Pass limit <= 0 for no limit.
+	ListStripeWithdrawals(accountID string, limit int) ([]StripeWithdrawal, error)
+
 	// --- Device Authorization (RFC 8628-style) ---
 
 	// CreateDeviceCode stores a new device authorization request.
@@ -297,6 +329,7 @@ const (
 	LedgerWithdrawal     LedgerEntryType = "withdrawal"      // on-chain withdrawal
 	LedgerReferralReward LedgerEntryType = "referral_reward" // referrer earns share of platform fee
 	LedgerStripeDeposit  LedgerEntryType = "stripe_deposit"  // Stripe checkout deposit
+	LedgerStripePayout   LedgerEntryType = "stripe_payout"   // user-initiated bank/card withdrawal via Stripe Connect
 	LedgerInviteCredit   LedgerEntryType = "invite_credit"   // invite code redemption
 	LedgerRefund         LedgerEntryType = "refund"          // reservation refund (request failed before inference)
 )
@@ -355,6 +388,39 @@ type User struct {
 	SolanaWalletAddress string    `json:"solana_wallet_address"` // embedded wallet public address
 	SolanaWalletID      string    `json:"solana_wallet_id"`      // Privy's internal wallet ID (for signing API)
 	CreatedAt           time.Time `json:"created_at"`
+
+	// Stripe Connect Express — for bank/card payouts via Stripe.
+	// StripeAccountStatus mirrors the readiness of payouts on the connected
+	// account: "" (not onboarded), "pending" (link created but not finished),
+	// "ready" (payouts_enabled=true), "restricted" (Stripe needs more info),
+	// "rejected" (Stripe permanently disabled the account).
+	StripeAccountID        string `json:"stripe_account_id,omitempty"`
+	StripeAccountStatus    string `json:"stripe_account_status,omitempty"`
+	StripeDestinationType  string `json:"stripe_destination_type,omitempty"` // "bank" | "card" | ""
+	StripeDestinationLast4 string `json:"stripe_destination_last4,omitempty"`
+	StripeInstantEligible  bool   `json:"stripe_instant_eligible,omitempty"` // debit-card destination supports Instant Payouts
+}
+
+// StripeWithdrawal records a user-initiated payout via Stripe Connect Express.
+// The lifecycle is: pending (debit recorded) → transferred (platform→connected
+// account transfer succeeded) → paid (Stripe payout to bank/card succeeded).
+// On failure at any stage we re-credit the user via LedgerRefund and set the
+// status to "failed".
+type StripeWithdrawal struct {
+	ID              string    `json:"id"`                          // internal UUID, used as Stripe idempotency key prefix
+	AccountID       string    `json:"account_id"`                  // internal account that owns the withdrawal
+	StripeAccountID string    `json:"stripe_account_id"`           // Stripe connected account (acct_…)
+	TransferID      string    `json:"transfer_id,omitempty"`       // Stripe transfer (tr_…)
+	PayoutID        string    `json:"payout_id,omitempty"`         // Stripe payout (po_…)
+	AmountMicroUSD  int64     `json:"amount_micro_usd"`            // gross amount debited from ledger
+	FeeMicroUSD     int64     `json:"fee_micro_usd"`               // fee retained by platform
+	NetMicroUSD     int64     `json:"net_micro_usd"`               // amount transferred to user (gross - fee)
+	Method          string    `json:"method"`                      // "standard" | "instant"
+	Status          string    `json:"status"`                      // "pending" | "transferred" | "paid" | "failed"
+	FailureReason   string    `json:"failure_reason,omitempty"`    // populated when Status="failed"
+	Refunded        bool      `json:"refunded,omitempty"`          // true after the failure refund is credited
+	CreatedAt       time.Time `json:"created_at"`
+	UpdatedAt       time.Time `json:"updated_at"`
 }
 
 // SupportedModel represents a model in the admin-managed catalog.

--- a/coordinator/internal/store/memory.go
+++ b/coordinator/internal/store/memory.go
@@ -52,8 +52,15 @@ type MemoryStore struct {
 	supportedModels map[string]*SupportedModel // modelID → model
 
 	// Users (Privy)
-	usersByPrivyID   map[string]*User // privyUserID → user
-	usersByAccountID map[string]*User // accountID → user
+	usersByPrivyID         map[string]*User // privyUserID → user
+	usersByAccountID       map[string]*User // accountID → user
+	usersByStripeAccountID map[string]*User // stripeAccountID → user (subset of usersByAccountID)
+
+	// Stripe Connect withdrawals
+	stripeWithdrawalsByID         map[string]*StripeWithdrawal
+	stripeWithdrawalsByTransferID map[string]string // transferID → withdrawalID
+	stripeWithdrawalsByPayoutID   map[string]string // payoutID → withdrawalID
+	stripeWithdrawalsByAccount    map[string][]string // accountID → []withdrawalID, newest last
 
 	// Device authorization
 	deviceCodesByCode     map[string]*DeviceCode // deviceCode → DeviceCode
@@ -101,8 +108,13 @@ func NewMemory(adminKey string) *MemoryStore {
 		billingSessions:       make(map[string]*BillingSession),
 		modelPrices:           make(map[string]ModelPrice),
 		supportedModels:       make(map[string]*SupportedModel),
-		usersByPrivyID:        make(map[string]*User),
-		usersByAccountID:      make(map[string]*User),
+		usersByPrivyID:                make(map[string]*User),
+		usersByAccountID:              make(map[string]*User),
+		usersByStripeAccountID:        make(map[string]*User),
+		stripeWithdrawalsByID:         make(map[string]*StripeWithdrawal),
+		stripeWithdrawalsByTransferID: make(map[string]string),
+		stripeWithdrawalsByPayoutID:   make(map[string]string),
+		stripeWithdrawalsByAccount:    make(map[string][]string),
 		deviceCodesByCode:     make(map[string]*DeviceCode),
 		deviceCodesByUserCode: make(map[string]*DeviceCode),
 		providerTokens:        make(map[string]*ProviderToken),
@@ -635,6 +647,165 @@ func (s *MemoryStore) GetUserByAccountID(accountID string) (*User, error) {
 	}
 	copy := *u
 	return &copy, nil
+}
+
+// SetUserStripeAccount upserts the Stripe Connect fields on a user record.
+func (s *MemoryStore) SetUserStripeAccount(accountID, stripeAccountID, status, destinationType, destinationLast4 string, instantEligible bool) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	u, ok := s.usersByAccountID[accountID]
+	if !ok {
+		return fmt.Errorf("user with account ID %q not found", accountID)
+	}
+
+	// Maintain the by-stripe-account index. A user may switch accounts (e.g.
+	// after a manual reset) so we drop the old mapping if it was different.
+	if u.StripeAccountID != "" && u.StripeAccountID != stripeAccountID {
+		delete(s.usersByStripeAccountID, u.StripeAccountID)
+	}
+
+	u.StripeAccountID = stripeAccountID
+	u.StripeAccountStatus = status
+	u.StripeDestinationType = destinationType
+	u.StripeDestinationLast4 = destinationLast4
+	u.StripeInstantEligible = instantEligible
+
+	if stripeAccountID != "" {
+		s.usersByStripeAccountID[stripeAccountID] = u
+	}
+	return nil
+}
+
+// GetUserByStripeAccount finds a user by their Stripe connected account ID.
+func (s *MemoryStore) GetUserByStripeAccount(stripeAccountID string) (*User, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	u, ok := s.usersByStripeAccountID[stripeAccountID]
+	if !ok {
+		return nil, fmt.Errorf("user with Stripe account %q not found", stripeAccountID)
+	}
+	copy := *u
+	return &copy, nil
+}
+
+// --- Stripe Withdrawals ---
+
+func (s *MemoryStore) CreateStripeWithdrawal(w *StripeWithdrawal) error {
+	if w == nil || w.ID == "" {
+		return fmt.Errorf("stripe withdrawal id is required")
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, exists := s.stripeWithdrawalsByID[w.ID]; exists {
+		return fmt.Errorf("stripe withdrawal %q already exists", w.ID)
+	}
+	cp := *w
+	if cp.CreatedAt.IsZero() {
+		cp.CreatedAt = time.Now()
+	}
+	if cp.UpdatedAt.IsZero() {
+		cp.UpdatedAt = cp.CreatedAt
+	}
+	s.stripeWithdrawalsByID[cp.ID] = &cp
+	if cp.TransferID != "" {
+		s.stripeWithdrawalsByTransferID[cp.TransferID] = cp.ID
+	}
+	if cp.PayoutID != "" {
+		s.stripeWithdrawalsByPayoutID[cp.PayoutID] = cp.ID
+	}
+	s.stripeWithdrawalsByAccount[cp.AccountID] = append(s.stripeWithdrawalsByAccount[cp.AccountID], cp.ID)
+	return nil
+}
+
+func (s *MemoryStore) GetStripeWithdrawal(id string) (*StripeWithdrawal, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	w, ok := s.stripeWithdrawalsByID[id]
+	if !ok {
+		return nil, fmt.Errorf("stripe withdrawal %q not found", id)
+	}
+	cp := *w
+	return &cp, nil
+}
+
+func (s *MemoryStore) GetStripeWithdrawalByPayoutID(payoutID string) (*StripeWithdrawal, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	id, ok := s.stripeWithdrawalsByPayoutID[payoutID]
+	if !ok {
+		return nil, fmt.Errorf("stripe withdrawal with payout %q not found", payoutID)
+	}
+	w := s.stripeWithdrawalsByID[id]
+	cp := *w
+	return &cp, nil
+}
+
+func (s *MemoryStore) GetStripeWithdrawalByTransferID(transferID string) (*StripeWithdrawal, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	id, ok := s.stripeWithdrawalsByTransferID[transferID]
+	if !ok {
+		return nil, fmt.Errorf("stripe withdrawal with transfer %q not found", transferID)
+	}
+	w := s.stripeWithdrawalsByID[id]
+	cp := *w
+	return &cp, nil
+}
+
+func (s *MemoryStore) UpdateStripeWithdrawal(w *StripeWithdrawal) error {
+	if w == nil || w.ID == "" {
+		return fmt.Errorf("stripe withdrawal id is required")
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	existing, ok := s.stripeWithdrawalsByID[w.ID]
+	if !ok {
+		return fmt.Errorf("stripe withdrawal %q not found", w.ID)
+	}
+	// Re-index transfer/payout IDs if they changed.
+	if existing.TransferID != w.TransferID {
+		if existing.TransferID != "" {
+			delete(s.stripeWithdrawalsByTransferID, existing.TransferID)
+		}
+		if w.TransferID != "" {
+			s.stripeWithdrawalsByTransferID[w.TransferID] = w.ID
+		}
+	}
+	if existing.PayoutID != w.PayoutID {
+		if existing.PayoutID != "" {
+			delete(s.stripeWithdrawalsByPayoutID, existing.PayoutID)
+		}
+		if w.PayoutID != "" {
+			s.stripeWithdrawalsByPayoutID[w.PayoutID] = w.ID
+		}
+	}
+	cp := *w
+	cp.UpdatedAt = time.Now()
+	s.stripeWithdrawalsByID[w.ID] = &cp
+	return nil
+}
+
+func (s *MemoryStore) ListStripeWithdrawals(accountID string, limit int) ([]StripeWithdrawal, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	ids := s.stripeWithdrawalsByAccount[accountID]
+	if len(ids) == 0 {
+		return []StripeWithdrawal{}, nil
+	}
+	out := make([]StripeWithdrawal, 0, len(ids))
+	for i := len(ids) - 1; i >= 0; i-- {
+		w, ok := s.stripeWithdrawalsByID[ids[i]]
+		if !ok {
+			continue
+		}
+		out = append(out, *w)
+		if limit > 0 && len(out) >= limit {
+			break
+		}
+	}
+	return out, nil
 }
 
 // --- Device Authorization ---

--- a/coordinator/internal/store/postgres.go
+++ b/coordinator/internal/store/postgres.go
@@ -368,6 +368,34 @@ func (s *PostgresStore) migrate(ctx context.Context) error {
 		)`,
 		`CREATE INDEX IF NOT EXISTS idx_provider_payouts_address ON provider_payouts(provider_address, created_at DESC)`,
 		`CREATE INDEX IF NOT EXISTS idx_provider_payouts_settled ON provider_payouts(settled, created_at DESC)`,
+
+		// Stripe Connect — bank/card payouts
+		`DO $$ BEGIN ALTER TABLE users ADD COLUMN IF NOT EXISTS stripe_account_id TEXT NOT NULL DEFAULT ''; EXCEPTION WHEN others THEN NULL; END $$`,
+		`DO $$ BEGIN ALTER TABLE users ADD COLUMN IF NOT EXISTS stripe_account_status TEXT NOT NULL DEFAULT ''; EXCEPTION WHEN others THEN NULL; END $$`,
+		`DO $$ BEGIN ALTER TABLE users ADD COLUMN IF NOT EXISTS stripe_destination_type TEXT NOT NULL DEFAULT ''; EXCEPTION WHEN others THEN NULL; END $$`,
+		`DO $$ BEGIN ALTER TABLE users ADD COLUMN IF NOT EXISTS stripe_destination_last4 TEXT NOT NULL DEFAULT ''; EXCEPTION WHEN others THEN NULL; END $$`,
+		`DO $$ BEGIN ALTER TABLE users ADD COLUMN IF NOT EXISTS stripe_instant_eligible BOOLEAN NOT NULL DEFAULT FALSE; EXCEPTION WHEN others THEN NULL; END $$`,
+		`CREATE UNIQUE INDEX IF NOT EXISTS idx_users_stripe_account ON users(stripe_account_id) WHERE stripe_account_id != ''`,
+
+		`CREATE TABLE IF NOT EXISTS stripe_withdrawals (
+			id TEXT PRIMARY KEY,
+			account_id TEXT NOT NULL,
+			stripe_account_id TEXT NOT NULL,
+			transfer_id TEXT NOT NULL DEFAULT '',
+			payout_id TEXT NOT NULL DEFAULT '',
+			amount_micro_usd BIGINT NOT NULL,
+			fee_micro_usd BIGINT NOT NULL DEFAULT 0,
+			net_micro_usd BIGINT NOT NULL,
+			method TEXT NOT NULL,
+			status TEXT NOT NULL,
+			failure_reason TEXT NOT NULL DEFAULT '',
+			refunded BOOLEAN NOT NULL DEFAULT FALSE,
+			created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_stripe_withdrawals_account ON stripe_withdrawals(account_id, created_at DESC)`,
+		`CREATE UNIQUE INDEX IF NOT EXISTS idx_stripe_withdrawals_transfer ON stripe_withdrawals(transfer_id) WHERE transfer_id != ''`,
+		`CREATE UNIQUE INDEX IF NOT EXISTS idx_stripe_withdrawals_payout ON stripe_withdrawals(payout_id) WHERE payout_id != ''`,
 	}
 
 	for _, m := range migrations {
@@ -1039,20 +1067,35 @@ func (s *PostgresStore) CreateUser(user *User) error {
 	return nil
 }
 
+const userSelectColumns = `account_id, privy_user_id, email, solana_wallet_address, solana_wallet_id,
+	stripe_account_id, stripe_account_status, stripe_destination_type,
+	stripe_destination_last4, stripe_instant_eligible, created_at`
+
+func scanUser(row interface {
+	Scan(...any) error
+}) (*User, error) {
+	var u User
+	if err := row.Scan(&u.AccountID, &u.PrivyUserID, &u.Email, &u.SolanaWalletAddress, &u.SolanaWalletID,
+		&u.StripeAccountID, &u.StripeAccountStatus, &u.StripeDestinationType,
+		&u.StripeDestinationLast4, &u.StripeInstantEligible, &u.CreatedAt); err != nil {
+		return nil, err
+	}
+	return &u, nil
+}
+
 // GetUserByPrivyID returns the user for a Privy DID.
 func (s *PostgresStore) GetUserByPrivyID(privyUserID string) (*User, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	var u User
-	err := s.pool.QueryRow(ctx,
-		`SELECT account_id, privy_user_id, email, solana_wallet_address, solana_wallet_id, created_at
-		 FROM users WHERE privy_user_id = $1`, privyUserID,
-	).Scan(&u.AccountID, &u.PrivyUserID, &u.Email, &u.SolanaWalletAddress, &u.SolanaWalletID, &u.CreatedAt)
+	row := s.pool.QueryRow(ctx,
+		`SELECT `+userSelectColumns+` FROM users WHERE privy_user_id = $1`, privyUserID,
+	)
+	u, err := scanUser(row)
 	if err != nil {
 		return nil, fmt.Errorf("store: user not found: %w", err)
 	}
-	return &u, nil
+	return u, nil
 }
 
 // GetUserByAccountID returns the user for an internal account ID.
@@ -1060,15 +1103,189 @@ func (s *PostgresStore) GetUserByAccountID(accountID string) (*User, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	var u User
-	err := s.pool.QueryRow(ctx,
-		`SELECT account_id, privy_user_id, email, solana_wallet_address, solana_wallet_id, created_at
-		 FROM users WHERE account_id = $1`, accountID,
-	).Scan(&u.AccountID, &u.PrivyUserID, &u.Email, &u.SolanaWalletAddress, &u.SolanaWalletID, &u.CreatedAt)
+	row := s.pool.QueryRow(ctx,
+		`SELECT `+userSelectColumns+` FROM users WHERE account_id = $1`, accountID,
+	)
+	u, err := scanUser(row)
 	if err != nil {
 		return nil, fmt.Errorf("store: user not found: %w", err)
 	}
-	return &u, nil
+	return u, nil
+}
+
+// SetUserStripeAccount upserts the Stripe Connect fields on a user record.
+func (s *PostgresStore) SetUserStripeAccount(accountID, stripeAccountID, status, destinationType, destinationLast4 string, instantEligible bool) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	tag, err := s.pool.Exec(ctx,
+		`UPDATE users SET
+			stripe_account_id = $2,
+			stripe_account_status = $3,
+			stripe_destination_type = $4,
+			stripe_destination_last4 = $5,
+			stripe_instant_eligible = $6
+		 WHERE account_id = $1`,
+		accountID, stripeAccountID, status, destinationType, destinationLast4, instantEligible,
+	)
+	if err != nil {
+		return fmt.Errorf("store: set stripe account: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return fmt.Errorf("user with account ID %q not found", accountID)
+	}
+	return nil
+}
+
+// GetUserByStripeAccount finds a user by their Stripe connected account ID.
+func (s *PostgresStore) GetUserByStripeAccount(stripeAccountID string) (*User, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	row := s.pool.QueryRow(ctx,
+		`SELECT `+userSelectColumns+` FROM users WHERE stripe_account_id = $1`, stripeAccountID,
+	)
+	u, err := scanUser(row)
+	if err != nil {
+		return nil, fmt.Errorf("store: user with Stripe account %q not found: %w", stripeAccountID, err)
+	}
+	return u, nil
+}
+
+// --- Stripe Withdrawals ---
+
+func (s *PostgresStore) CreateStripeWithdrawal(w *StripeWithdrawal) error {
+	if w == nil || w.ID == "" {
+		return fmt.Errorf("stripe withdrawal id is required")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	now := time.Now()
+	if w.CreatedAt.IsZero() {
+		w.CreatedAt = now
+	}
+	if w.UpdatedAt.IsZero() {
+		w.UpdatedAt = w.CreatedAt
+	}
+
+	_, err := s.pool.Exec(ctx,
+		`INSERT INTO stripe_withdrawals
+		 (id, account_id, stripe_account_id, transfer_id, payout_id,
+		  amount_micro_usd, fee_micro_usd, net_micro_usd, method, status,
+		  failure_reason, refunded, created_at, updated_at)
+		 VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14)`,
+		w.ID, w.AccountID, w.StripeAccountID, w.TransferID, w.PayoutID,
+		w.AmountMicroUSD, w.FeeMicroUSD, w.NetMicroUSD, w.Method, w.Status,
+		w.FailureReason, w.Refunded, w.CreatedAt, w.UpdatedAt,
+	)
+	if err != nil {
+		return fmt.Errorf("store: create stripe withdrawal: %w", err)
+	}
+	return nil
+}
+
+const stripeWithdrawalSelectColumns = `id, account_id, stripe_account_id, transfer_id, payout_id,
+	amount_micro_usd, fee_micro_usd, net_micro_usd, method, status,
+	failure_reason, refunded, created_at, updated_at`
+
+func scanStripeWithdrawal(row interface{ Scan(...any) error }) (*StripeWithdrawal, error) {
+	var w StripeWithdrawal
+	if err := row.Scan(&w.ID, &w.AccountID, &w.StripeAccountID, &w.TransferID, &w.PayoutID,
+		&w.AmountMicroUSD, &w.FeeMicroUSD, &w.NetMicroUSD, &w.Method, &w.Status,
+		&w.FailureReason, &w.Refunded, &w.CreatedAt, &w.UpdatedAt); err != nil {
+		return nil, err
+	}
+	return &w, nil
+}
+
+func (s *PostgresStore) GetStripeWithdrawal(id string) (*StripeWithdrawal, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	row := s.pool.QueryRow(ctx,
+		`SELECT `+stripeWithdrawalSelectColumns+` FROM stripe_withdrawals WHERE id = $1`, id)
+	w, err := scanStripeWithdrawal(row)
+	if err != nil {
+		return nil, fmt.Errorf("store: stripe withdrawal %q not found: %w", id, err)
+	}
+	return w, nil
+}
+
+func (s *PostgresStore) GetStripeWithdrawalByPayoutID(payoutID string) (*StripeWithdrawal, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	row := s.pool.QueryRow(ctx,
+		`SELECT `+stripeWithdrawalSelectColumns+` FROM stripe_withdrawals WHERE payout_id = $1`, payoutID)
+	w, err := scanStripeWithdrawal(row)
+	if err != nil {
+		return nil, fmt.Errorf("store: stripe withdrawal with payout %q not found: %w", payoutID, err)
+	}
+	return w, nil
+}
+
+func (s *PostgresStore) GetStripeWithdrawalByTransferID(transferID string) (*StripeWithdrawal, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	row := s.pool.QueryRow(ctx,
+		`SELECT `+stripeWithdrawalSelectColumns+` FROM stripe_withdrawals WHERE transfer_id = $1`, transferID)
+	w, err := scanStripeWithdrawal(row)
+	if err != nil {
+		return nil, fmt.Errorf("store: stripe withdrawal with transfer %q not found: %w", transferID, err)
+	}
+	return w, nil
+}
+
+func (s *PostgresStore) UpdateStripeWithdrawal(w *StripeWithdrawal) error {
+	if w == nil || w.ID == "" {
+		return fmt.Errorf("stripe withdrawal id is required")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	tag, err := s.pool.Exec(ctx,
+		`UPDATE stripe_withdrawals SET
+			transfer_id = $2, payout_id = $3, status = $4,
+			failure_reason = $5, refunded = $6, updated_at = NOW()
+		 WHERE id = $1`,
+		w.ID, w.TransferID, w.PayoutID, w.Status, w.FailureReason, w.Refunded,
+	)
+	if err != nil {
+		return fmt.Errorf("store: update stripe withdrawal: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return fmt.Errorf("stripe withdrawal %q not found", w.ID)
+	}
+	w.UpdatedAt = time.Now()
+	return nil
+}
+
+func (s *PostgresStore) ListStripeWithdrawals(accountID string, limit int) ([]StripeWithdrawal, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	q := `SELECT ` + stripeWithdrawalSelectColumns + ` FROM stripe_withdrawals WHERE account_id = $1 ORDER BY created_at DESC`
+	args := []any{accountID}
+	if limit > 0 {
+		q += ` LIMIT $2`
+		args = append(args, limit)
+	}
+	rows, err := s.pool.Query(ctx, q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("store: list stripe withdrawals: %w", err)
+	}
+	defer rows.Close()
+
+	var out []StripeWithdrawal
+	for rows.Next() {
+		w, err := scanStripeWithdrawal(rows)
+		if err != nil {
+			return nil, fmt.Errorf("store: scan stripe withdrawal: %w", err)
+		}
+		out = append(out, *w)
+	}
+	if out == nil {
+		return []StripeWithdrawal{}, nil
+	}
+	return out, nil
 }
 
 // --- Supported Models ---

--- a/coordinator/internal/store/postgres_test.go
+++ b/coordinator/internal/store/postgres_test.go
@@ -45,6 +45,7 @@ func testPostgresStore(t *testing.T) *PostgresStore {
 		"provider_earnings",
 		"provider_payouts",
 		"providers",
+		"stripe_withdrawals",
 	} {
 		if _, err := s.pool.Exec(ctx, "TRUNCATE "+table+" CASCADE"); err != nil {
 			t.Fatalf("truncate %s: %v", table, err)
@@ -389,5 +390,171 @@ func TestPostgresProviderRecordStatsPersisted(t *testing.T) {
 	}
 	if got.LastSessionTokensGenerated != rec.LastSessionTokensGenerated {
 		t.Errorf("last_session_tokens_generated = %d, want %d", got.LastSessionTokensGenerated, rec.LastSessionTokensGenerated)
+	}
+}
+
+// --- Stripe Connect (postgres-backed) ---
+//
+// The memory store has happy-path coverage; these tests verify the postgres
+// schema migrations + queries match the interface contract. Skipped unless
+// DATABASE_URL is set, so unit-test runs without postgres still pass.
+
+func TestPostgresSetUserStripeAccount(t *testing.T) {
+	s := testPostgresStore(t)
+
+	u := &User{AccountID: "acct-pg-1", PrivyUserID: "did:privy:pg1", Email: "a@b"}
+	if err := s.CreateUser(u); err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+
+	if err := s.SetUserStripeAccount("acct-pg-1", "acct_123", "ready", "card", "4242", true); err != nil {
+		t.Fatalf("set stripe account: %v", err)
+	}
+
+	got, err := s.GetUserByAccountID("acct-pg-1")
+	if err != nil {
+		t.Fatalf("get user: %v", err)
+	}
+	if got.StripeAccountID != "acct_123" {
+		t.Errorf("StripeAccountID = %q, want acct_123", got.StripeAccountID)
+	}
+	if got.StripeAccountStatus != "ready" {
+		t.Errorf("status = %q", got.StripeAccountStatus)
+	}
+	if got.StripeDestinationType != "card" || got.StripeDestinationLast4 != "4242" {
+		t.Errorf("destination = %q ••%q", got.StripeDestinationType, got.StripeDestinationLast4)
+	}
+	if !got.StripeInstantEligible {
+		t.Error("instant_eligible should be true")
+	}
+
+	// Lookup by stripe account ID.
+	got2, err := s.GetUserByStripeAccount("acct_123")
+	if err != nil {
+		t.Fatalf("get by stripe acct: %v", err)
+	}
+	if got2.AccountID != "acct-pg-1" {
+		t.Errorf("AccountID = %q, want acct-pg-1", got2.AccountID)
+	}
+}
+
+func TestPostgresSetUserStripeAccountUserNotFound(t *testing.T) {
+	s := testPostgresStore(t)
+	err := s.SetUserStripeAccount("nope", "acct_x", "pending", "", "", false)
+	if err == nil {
+		t.Fatal("expected error for missing user")
+	}
+}
+
+func TestPostgresStripeWithdrawalCRUD(t *testing.T) {
+	s := testPostgresStore(t)
+
+	u := &User{AccountID: "acct-pg-wd", PrivyUserID: "did:privy:pgwd"}
+	_ = s.CreateUser(u)
+	_ = s.SetUserStripeAccount("acct-pg-wd", "acct_wd", "ready", "bank", "6789", false)
+
+	wd := &StripeWithdrawal{
+		ID:              "wd-pg-1",
+		AccountID:       "acct-pg-wd",
+		StripeAccountID: "acct_wd",
+		AmountMicroUSD:  5_000_000,
+		FeeMicroUSD:     0,
+		NetMicroUSD:     5_000_000,
+		Method:          "standard",
+		Status:          "pending",
+	}
+	if err := s.CreateStripeWithdrawal(wd); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	// Round-trip by id.
+	got, err := s.GetStripeWithdrawal("wd-pg-1")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.AmountMicroUSD != 5_000_000 || got.Status != "pending" || got.Method != "standard" {
+		t.Errorf("got = %+v", got)
+	}
+
+	// Update with transfer + payout IDs and flip to paid.
+	got.TransferID = "tr_pg_1"
+	got.PayoutID = "po_pg_1"
+	got.Status = "paid"
+	if err := s.UpdateStripeWithdrawal(got); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+
+	// Lookups by transfer/payout id.
+	byTr, err := s.GetStripeWithdrawalByTransferID("tr_pg_1")
+	if err != nil {
+		t.Fatalf("get by transfer: %v", err)
+	}
+	if byTr.ID != "wd-pg-1" {
+		t.Errorf("byTr.ID = %q", byTr.ID)
+	}
+	byPo, err := s.GetStripeWithdrawalByPayoutID("po_pg_1")
+	if err != nil {
+		t.Fatalf("get by payout: %v", err)
+	}
+	if byPo.Status != "paid" {
+		t.Errorf("status = %q", byPo.Status)
+	}
+
+	// List for account.
+	list, err := s.ListStripeWithdrawals("acct-pg-wd", 0)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(list) != 1 || list[0].ID != "wd-pg-1" {
+		t.Errorf("list = %+v", list)
+	}
+}
+
+func TestPostgresStripeWithdrawalRefundFlag(t *testing.T) {
+	s := testPostgresStore(t)
+	u := &User{AccountID: "acct-pg-rf", PrivyUserID: "did:privy:pgrf"}
+	_ = s.CreateUser(u)
+	_ = s.SetUserStripeAccount("acct-pg-rf", "acct_rf", "ready", "bank", "1", false)
+
+	wd := &StripeWithdrawal{
+		ID: "wd-pg-rf", AccountID: "acct-pg-rf", StripeAccountID: "acct_rf",
+		AmountMicroUSD: 5_000_000, NetMicroUSD: 5_000_000,
+		Method: "standard", Status: "transferred", PayoutID: "po_rf",
+	}
+	if err := s.CreateStripeWithdrawal(wd); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	wd.Status = "failed"
+	wd.Refunded = true
+	wd.FailureReason = "account_closed: bank closed"
+	if err := s.UpdateStripeWithdrawal(wd); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+
+	got, _ := s.GetStripeWithdrawal("wd-pg-rf")
+	if !got.Refunded {
+		t.Error("refunded should be true after update")
+	}
+	if got.FailureReason != "account_closed: bank closed" {
+		t.Errorf("failure_reason = %q", got.FailureReason)
+	}
+}
+
+func TestPostgresStripeWithdrawalDuplicateIDRejected(t *testing.T) {
+	s := testPostgresStore(t)
+	u := &User{AccountID: "acct-pg-dup", PrivyUserID: "did:privy:pgdup"}
+	_ = s.CreateUser(u)
+	_ = s.SetUserStripeAccount("acct-pg-dup", "acct_dup", "ready", "bank", "1", false)
+
+	wd := &StripeWithdrawal{
+		ID: "wd-dup", AccountID: "acct-pg-dup", StripeAccountID: "acct_dup",
+		AmountMicroUSD: 1_000_000, NetMicroUSD: 1_000_000, Method: "standard", Status: "pending",
+	}
+	if err := s.CreateStripeWithdrawal(wd); err != nil {
+		t.Fatalf("create #1: %v", err)
+	}
+	if err := s.CreateStripeWithdrawal(wd); err == nil {
+		t.Fatal("expected duplicate ID to be rejected")
 	}
 }

--- a/deploy/environments/dev.env
+++ b/deploy/environments/dev.env
@@ -1,0 +1,48 @@
+# Development coordinator — runs on Google Cloud (Cloud Run).
+# GCP project: sepolia-ai. Non-secret configuration only; secrets in
+# Google Secret Manager.
+# Release artifacts and fleet live behind api.dev.darkbloom.dev.
+
+ENVIRONMENT=dev
+COORDINATOR_URL=https://api.dev.darkbloom.dev
+COORDINATOR_WS_URL=wss://api.dev.darkbloom.dev/ws/provider
+CONSOLE_URL=https://console.dev.darkbloom.dev
+BASE_URL=https://api.dev.darkbloom.dev
+
+# Trust & attestation — dev mirrors prod so the full attestation chain is
+# exercised (step-ca ACME device-attest-01 + MicroMDM SecurityInfo + MDA).
+# This is why dev runs on a GCE VM with persistent disk, not Cloud Run:
+# MicroMDM uses BoltDB and step-ca writes CA state to disk.
+MIN_TRUST=hardware
+MDM_ENABLED=true
+MICROMDM_INTERNAL_URL=https://localhost:9002
+
+# Billing — mainnet Solana with a dev-only wallet (separate mnemonic from prod)
+BILLING_MOCK=false
+SOLANA_NETWORK=mainnet
+SOLANA_RPC_URL=https://api.mainnet-beta.solana.com
+SOLANA_USDC_MINT=EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v
+
+# Release distribution — separate R2 bucket, never mixed with prod artifacts
+R2_BUCKET=d-inf-app-dev
+APPLE_TEAM_ID=SLDQ2GJ6TL
+APPLE_SIGNING_IDENTITY=Developer ID Application: Eigen Labs, Inc. (SLDQ2GJ6TL)
+
+# GCP
+GCP_PROJECT=sepolia-ai
+GCP_REGION=us-central1
+GCP_ZONE=us-central1-a
+ARTIFACT_REGISTRY_REPO=us-central1-docker.pkg.dev/sepolia-ai/coordinator
+# Coordinator: GCE VM (needs persistent disk for MicroMDM BoltDB + step-ca state)
+GCE_INSTANCE=d-inference-dev
+GCE_MACHINE_TYPE=e2-small
+GCE_BOOT_DISK_SIZE=20GB
+GCE_DATA_DISK=d-inference-dev-data
+GCE_DATA_DISK_SIZE=30GB
+GCE_DATA_MOUNT=/mnt/disks/userdata
+# Console UI runs on Vercel (separate dev project there).
+CONSOLE_VERCEL_PROJECT=darkbloom-console-dev
+CLOUD_SQL_INSTANCE=d-inference-dev-db
+
+# Fleet
+PROVIDER_VERSION_GATE=latest

--- a/deploy/environments/prod.env
+++ b/deploy/environments/prod.env
@@ -1,0 +1,27 @@
+# Production coordinator — runs on EigenCloud.
+# Non-secret configuration only. Secrets live in EigenCloud KMS.
+# This file is a reference for reviewers diffing prod vs dev behavior.
+
+ENVIRONMENT=prod
+COORDINATOR_URL=https://api.darkbloom.dev
+COORDINATOR_WS_URL=wss://api.darkbloom.dev/ws/provider
+CONSOLE_URL=https://console.darkbloom.dev
+BASE_URL=https://api.darkbloom.dev
+
+# Trust & attestation
+MIN_TRUST=hardware
+MDM_ENABLED=true
+
+# Billing
+BILLING_MOCK=false
+SOLANA_NETWORK=mainnet
+SOLANA_RPC_URL=https://api.mainnet-beta.solana.com
+SOLANA_USDC_MINT=EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v
+
+# Release distribution
+R2_BUCKET=d-inf-app
+APPLE_TEAM_ID=SLDQ2GJ6TL
+APPLE_SIGNING_IDENTITY=Developer ID Application: Eigen Labs, Inc. (SLDQ2GJ6TL)
+
+# Fleet
+PROVIDER_VERSION_GATE=latest

--- a/deploy/gcp/bootstrap.sh
+++ b/deploy/gcp/bootstrap.sh
@@ -1,0 +1,216 @@
+#!/bin/bash
+# One-shot GCP bootstrap for the d-inference DEV environment.
+#
+# Creates: Artifact Registry repos, Cloud SQL (Postgres), a GCE VM running the
+# coordinator container (with a persistent data disk for step-ca/MicroMDM),
+# Cloud Run for console-ui, service accounts, Secret Manager entries
+# (placeholders), firewall rules. Idempotent: safe to re-run.
+#
+# Why GCE VM for the coordinator: step-ca writes CA state and MicroMDM uses
+# BoltDB. Both need reliable local filesystem semantics, so the coordinator
+# mounts a persistent disk at /mnt/disks/userdata (same path as EigenCloud).
+#
+# Prereqs:
+#   - `gcloud` authenticated, project sepolia-ai selected (or pass PROJECT)
+#   - Billing enabled on the project
+#   - Owner/Editor on the project (for initial bootstrap only; downgrade after)
+#
+# After running this, populate Secret Manager:
+#   - eigeninference-admin-key               (openssl rand -hex 32)
+#   - eigeninference-release-key             (openssl rand -hex 32)
+#   - eigeninference-solana-mnemonic         (new BIP39 mnemonic for dev)
+#   - eigeninference-privy-app-id            (dev Privy app)
+#   - eigeninference-privy-app-secret        (dev Privy app)
+#   - eigeninference-privy-verification-key  (dev Privy app)
+#   - eigeninference-micromdm-api-key        (openssl rand -hex 32)
+#   - eigeninference-mdm-push-p12-b64        (base64url-encoded MDM push PKCS#12)
+
+set -euo pipefail
+
+PROJECT="${PROJECT:-sepolia-ai}"
+REGION="${REGION:-us-central1}"
+ZONE="${ZONE:-us-central1-a}"
+INSTANCE="${INSTANCE:-d-inference-dev}"
+MACHINE_TYPE="${MACHINE_TYPE:-e2-small}"
+DATA_DISK="${DATA_DISK:-d-inference-dev-data}"
+DATA_DISK_SIZE="${DATA_DISK_SIZE:-30GB}"
+SQL_INSTANCE="${SQL_INSTANCE:-d-inference-dev-db}"
+SQL_DB="${SQL_DB:-coordinator}"
+SQL_USER="${SQL_USER:-coordinator}"
+COORD_SA="d-inference-dev"
+# Console UI runs on Vercel (not Cloud Run) — no GCP provisioning needed.
+
+echo "==> Using GCP project: $PROJECT (zone: $ZONE)"
+gcloud config set project "$PROJECT"
+
+echo "==> Enabling required APIs"
+gcloud services enable \
+  compute.googleapis.com \
+  cloudbuild.googleapis.com \
+  artifactregistry.googleapis.com \
+  secretmanager.googleapis.com \
+  sqladmin.googleapis.com \
+  logging.googleapis.com \
+  monitoring.googleapis.com \
+  iap.googleapis.com
+
+echo "==> Creating Artifact Registry repos"
+gcloud artifacts repositories describe coordinator --location="$REGION" >/dev/null 2>&1 || \
+  gcloud artifacts repositories create coordinator \
+    --repository-format=docker \
+    --location="$REGION" \
+    --description="Dev coordinator container images"
+
+echo "==> Creating service account"
+gcloud iam service-accounts describe "${COORD_SA}@${PROJECT}.iam.gserviceaccount.com" >/dev/null 2>&1 || \
+  gcloud iam service-accounts create "$COORD_SA" \
+    --display-name="Service account for $COORD_SA"
+
+COORD_SA_EMAIL="${COORD_SA}@${PROJECT}.iam.gserviceaccount.com"
+
+for ROLE in roles/secretmanager.secretAccessor roles/cloudsql.client \
+            roles/logging.logWriter roles/artifactregistry.reader; do
+  gcloud projects add-iam-policy-binding "$PROJECT" \
+    --member="serviceAccount:$COORD_SA_EMAIL" \
+    --role="$ROLE" \
+    --condition=None \
+    --quiet >/dev/null
+done
+
+echo "==> Granting Cloud Build SA permission to SSH via IAP + update instance metadata"
+PROJECT_NUM=$(gcloud projects describe "$PROJECT" --format='value(projectNumber)')
+CB_SA="${PROJECT_NUM}@cloudbuild.gserviceaccount.com"
+for ROLE in roles/iap.tunnelResourceAccessor roles/compute.instanceAdmin.v1 \
+            roles/iam.serviceAccountUser; do
+  gcloud projects add-iam-policy-binding "$PROJECT" \
+    --member="serviceAccount:$CB_SA" \
+    --role="$ROLE" \
+    --condition=None \
+    --quiet >/dev/null
+done
+
+echo "==> Creating Secret Manager entries (empty — fill in next)"
+for SECRET in \
+  eigeninference-admin-key \
+  eigeninference-release-key \
+  eigeninference-solana-mnemonic \
+  eigeninference-privy-app-id \
+  eigeninference-privy-app-secret \
+  eigeninference-privy-verification-key \
+  eigeninference-database-url \
+  eigeninference-micromdm-api-key \
+  eigeninference-mdm-push-p12-b64 \
+  eigeninference-r2-cdn-url; do
+  gcloud secrets describe "$SECRET" >/dev/null 2>&1 || \
+    gcloud secrets create "$SECRET" --replication-policy=automatic
+done
+
+echo "==> Creating Cloud SQL Postgres instance (5-10 min on first run)"
+if ! gcloud sql instances describe "$SQL_INSTANCE" >/dev/null 2>&1; then
+  gcloud sql instances create "$SQL_INSTANCE" \
+    --database-version=POSTGRES_16 \
+    --tier=db-f1-micro \
+    --region="$REGION" \
+    --storage-auto-increase \
+    --backup-start-time=03:00
+fi
+
+gcloud sql databases describe "$SQL_DB" --instance="$SQL_INSTANCE" >/dev/null 2>&1 || \
+  gcloud sql databases create "$SQL_DB" --instance="$SQL_INSTANCE"
+
+if ! gcloud sql users list --instance="$SQL_INSTANCE" --format='value(name)' | grep -qx "$SQL_USER"; then
+  PW=$(openssl rand -hex 16)
+  gcloud sql users create "$SQL_USER" --instance="$SQL_INSTANCE" --password="$PW"
+  CONN_NAME=$(gcloud sql instances describe "$SQL_INSTANCE" --format='value(connectionName)')
+  # Coordinator connects via Cloud SQL Auth Proxy sidecar on the VM (see below).
+  URL="postgres://${SQL_USER}:${PW}@127.0.0.1:5432/${SQL_DB}?sslmode=disable"
+  echo "$URL" | gcloud secrets versions add eigeninference-database-url --data-file=-
+  echo "==> DB URL stored in Secret Manager eigeninference-database-url"
+fi
+
+echo "==> Creating persistent data disk for step-ca + MicroMDM state"
+gcloud compute disks describe "$DATA_DISK" --zone="$ZONE" >/dev/null 2>&1 || \
+  gcloud compute disks create "$DATA_DISK" \
+    --zone="$ZONE" \
+    --size="$DATA_DISK_SIZE" \
+    --type=pd-balanced
+
+echo "==> Creating firewall rule for :443"
+gcloud compute firewall-rules describe allow-https-dev >/dev/null 2>&1 || \
+  gcloud compute firewall-rules create allow-https-dev \
+    --direction=INGRESS \
+    --action=ALLOW \
+    --rules=tcp:443,tcp:80 \
+    --target-tags=d-inference-dev \
+    --source-ranges=0.0.0.0/0
+
+echo "==> Reserving static external IP"
+gcloud compute addresses describe d-inference-dev-ip --region="$REGION" >/dev/null 2>&1 || \
+  gcloud compute addresses create d-inference-dev-ip --region="$REGION"
+EXTERNAL_IP=$(gcloud compute addresses describe d-inference-dev-ip --region="$REGION" --format='value(address)')
+echo "External IP: $EXTERNAL_IP  (point api.dev.darkbloom.dev here in Vercel DNS)"
+
+if ! gcloud compute instances describe "$INSTANCE" --zone="$ZONE" >/dev/null 2>&1; then
+  echo "==> Creating GCE VM (Ubuntu + Docker + systemd)"
+  # Ubuntu (not COS) because we need to inject secrets from Secret Manager
+  # into the container's env file at boot — COS's declarative container model
+  # doesn't support reading an SM-fetched env file. The startup script handles
+  # Docker install, disk mount, secret fetch, and systemd unit creation.
+  gcloud compute instances create "$INSTANCE" \
+    --zone="$ZONE" \
+    --machine-type="$MACHINE_TYPE" \
+    --service-account="$COORD_SA_EMAIL" \
+    --scopes=cloud-platform \
+    --tags=d-inference-dev \
+    --address="$EXTERNAL_IP" \
+    --image-family=ubuntu-2404-lts-amd64 \
+    --image-project=ubuntu-os-cloud \
+    --boot-disk-size=20GB \
+    --create-disk="name=${DATA_DISK},mode=rw,boot=no,auto-delete=no,device-name=${DATA_DISK}" \
+    --metadata-from-file=startup-script="$(dirname "$0")/vm-startup.sh"
+  echo "==> VM created. Startup script will run on first boot (~2-3 min)."
+  echo "    Tail progress:"
+  echo "      gcloud compute ssh $INSTANCE --zone=$ZONE -- 'sudo tail -f /var/log/d-inference-startup.log'"
+else
+  echo "==> VM $INSTANCE already exists (skipping create)"
+  echo "    To refresh startup-script metadata after edits:"
+  echo "      gcloud compute instances add-metadata $INSTANCE --zone=$ZONE \\"
+  echo "        --metadata-from-file=startup-script=$(dirname "$0")/vm-startup.sh"
+fi
+
+cat <<EOF
+
+==> Bootstrap complete.
+
+Next steps:
+  1. Populate secrets:
+       for S in eigeninference-admin-key eigeninference-release-key \\
+                eigeninference-micromdm-api-key; do
+         echo -n "\$(openssl rand -hex 32)" | gcloud secrets versions add \$S --data-file=-
+       done
+     Then add Privy values, Solana mnemonic (NEW — never reuse prod), the MDM
+     push PKCS#12 (base64url-encoded), and the dev R2 CDN URL
+     (eigeninference-r2-cdn-url — the public URL of the d-inf-app-dev bucket).
+
+  2. Add DNS records on Vercel Domains:
+       api.dev.darkbloom.dev      A     $EXTERNAL_IP
+       console.dev.darkbloom.dev  CNAME cname.vercel-dns.com   (after step 4)
+
+  3. Push the first coordinator image (triggers startup-script to come to life):
+       gcloud builds submit --config=deploy/gcp/cloudbuild.yaml --project=$PROJECT
+
+  4. Deploy the console UI on **Vercel** (NOT on GCP):
+       - In the Vercel dashboard, import the d-inference repo as a separate
+         project (e.g. "darkbloom-console-dev"), set the root to console-ui/.
+       - Configure environment variables:
+           NEXT_PUBLIC_COORDINATOR_URL = https://api.dev.darkbloom.dev
+       - Add the custom domain console.dev.darkbloom.dev — Vercel will show
+         the CNAME target (usually cname.vercel-dns.com); add it at step 2.
+
+  5. Connect this repo to Cloud Build (one-time, in Cloud Console) so future
+     master pushes auto-deploy the coordinator:
+       - Trigger: coordinator/** + deploy/gcp/** -> cloudbuild.yaml
+
+  6. Upload the MDM enrollment profile and link it to the dev Privy app.
+     (Same process as prod; uses the MDM push cert from step 1.)
+EOF

--- a/deploy/gcp/cloudbuild.yaml
+++ b/deploy/gcp/cloudbuild.yaml
@@ -1,0 +1,81 @@
+# Cloud Build config for the d-inference DEV coordinator on Google Cloud.
+#
+# Triggered on push to master (path filter: coordinator/** | deploy/gcp/**).
+# Builds coordinator/Dockerfile (same image EigenCloud prod uses), pushes to
+# Artifact Registry, then pins the VM's container image tag and restarts the
+# systemd unit so it picks up the new image.
+#
+# Why GCE VM instead of Cloud Run: the coordinator runs step-ca (ACME CA) and
+# MicroMDM (BoltDB). Both need reliable local filesystem semantics, which
+# Cloud Run's ephemeral FS + gcsfuse can't provide. The VM has a persistent
+# disk at /mnt/disks/userdata — same path prod uses on EigenCloud.
+#
+# Upgrade time: ~2-4 minutes end-to-end (build + push + SSH restart).
+
+timeout: 1800s
+
+substitutions:
+  _INSTANCE: d-inference-dev
+  _ZONE: us-central1-a
+  _IMAGE: us-central1-docker.pkg.dev/$PROJECT_ID/coordinator/coordinator
+  _HEALTH_URL: https://api.dev.darkbloom.dev/health
+
+options:
+  logging: CLOUD_LOGGING_ONLY
+  machineType: E2_HIGHCPU_8
+
+steps:
+  - id: build
+    name: gcr.io/cloud-builders/docker
+    dir: coordinator
+    args:
+      - build
+      - --tag=${_IMAGE}:$SHORT_SHA
+      - --tag=${_IMAGE}:latest
+      - --file=Dockerfile
+      - .
+
+  - id: push-sha
+    name: gcr.io/cloud-builders/docker
+    args: [push, '${_IMAGE}:$SHORT_SHA']
+
+  - id: push-latest
+    name: gcr.io/cloud-builders/docker
+    args: [push, '${_IMAGE}:latest']
+
+  # Pin the container image on the VM and restart the systemd unit. We SSH
+  # via IAP so no public SSH ingress is required. The unit's ExecStartPre
+  # does `docker pull`, so restarting is all we need to do here.
+  - id: deploy
+    name: gcr.io/google.com/cloudsdktool/cloud-sdk
+    entrypoint: bash
+    args:
+      - -c
+      - |
+        set -euo pipefail
+
+        # Write the new image tag to instance metadata so the systemd unit
+        # picks it up. The unit reads IMAGE_TAG at ExecStartPre time.
+        gcloud compute instances add-metadata ${_INSTANCE} \
+          --zone=${_ZONE} \
+          --metadata=DINF_IMAGE_TAG=$SHORT_SHA
+
+        gcloud compute ssh ${_INSTANCE} --zone=${_ZONE} --tunnel-through-iap -- \
+          "sudo systemctl restart d-inference-coordinator"
+
+        echo "Restart requested; polling /health..."
+        for i in $(seq 1 48); do
+          code=$(curl -sk -o /dev/null -w '%{http_code}' "${_HEALTH_URL}" || true)
+          if [ "$code" = "200" ]; then
+            echo "health check passed after $((i*5))s"
+            exit 0
+          fi
+          echo "attempt $i: got $code"
+          sleep 5
+        done
+        echo "health check failed after 4 minutes"
+        exit 1
+
+images:
+  - '${_IMAGE}:$SHORT_SHA'
+  - '${_IMAGE}:latest'

--- a/deploy/gcp/vm-startup.sh
+++ b/deploy/gcp/vm-startup.sh
@@ -1,0 +1,179 @@
+#!/bin/bash
+# Startup script for the dev coordinator GCE VM (Ubuntu 24.04 LTS + Docker).
+# Runs on every boot via the instance's `startup-script` metadata. Idempotent.
+#
+# Responsibilities on first boot:
+#   1. Install Docker, gcloud, cloud-sql-proxy
+#   2. Format + mount the attached persistent data disk at /mnt/disks/userdata
+#      (same path as EigenCloud prod, so the container's start.sh works unchanged)
+#   3. Install a systemd unit for cloud-sql-proxy (Cloud SQL on 127.0.0.1:5432)
+#   4. Install a systemd unit for the coordinator container
+#   5. Fetch secrets from Secret Manager, write /etc/d-inference/env
+#
+# On subsequent boots:
+#   - Re-fetch secrets (picks up rotations)
+#   - Re-pull latest container image
+#   - Restart systemd units
+#
+# Redeploys from Cloud Build do NOT go through this script — they SSH in and
+# `systemctl restart d-inference-coordinator`, which re-pulls the pinned image.
+
+set -euo pipefail
+exec > >(tee /var/log/d-inference-startup.log) 2>&1
+echo "==> Startup at $(date -Iseconds)"
+
+REGISTRY_HOST="us-central1-docker.pkg.dev"
+IMAGE_REPO="${REGISTRY_HOST}/sepolia-ai/coordinator/coordinator"
+
+DATA_DEV="/dev/disk/by-id/google-d-inference-dev-data"
+DATA_MOUNT="/mnt/disks/userdata"
+ENV_DIR="/etc/d-inference"
+ENV_FILE="${ENV_DIR}/env"
+
+# ---- 1. Packages ----
+# Install gcloud + Docker + cloud-sql-proxy FIRST. Nothing later in this script
+# can call `gcloud` before this block completes (Ubuntu 24.04 ships no gcloud
+# by default — it would fail silently and break secret fetching).
+export DEBIAN_FRONTEND=noninteractive
+apt-get update
+apt-get install -y ca-certificates curl gnupg jq apt-transport-https
+
+if ! command -v gcloud >/dev/null; then
+  curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | \
+    gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg
+  echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" \
+    > /etc/apt/sources.list.d/google-cloud-sdk.list
+  apt-get update
+  apt-get install -y google-cloud-cli
+fi
+
+if ! command -v docker >/dev/null; then
+  install -m 0755 -d /etc/apt/keyrings
+  curl -fsSL https://download.docker.com/linux/ubuntu/gpg | \
+    gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+  echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" \
+    > /etc/apt/sources.list.d/docker.list
+  apt-get update
+  apt-get install -y docker-ce docker-ce-cli containerd.io
+fi
+
+if ! command -v cloud-sql-proxy >/dev/null; then
+  curl -fsSL -o /usr/local/bin/cloud-sql-proxy \
+    https://storage.googleapis.com/cloud-sql-connectors/cloud-sql-proxy/v2.11.0/cloud-sql-proxy.linux.amd64
+  chmod +x /usr/local/bin/cloud-sql-proxy
+fi
+
+# Now it is safe to invoke gcloud.
+SQL_CONN=$(gcloud sql instances describe d-inference-dev-db --format='value(connectionName)')
+if [ -z "$SQL_CONN" ]; then
+  echo "!! failed to resolve Cloud SQL connection name — aborting"
+  exit 1
+fi
+
+# ---- 2. Persistent data disk ----
+mkdir -p "$DATA_MOUNT"
+if ! blkid "$DATA_DEV" >/dev/null 2>&1; then
+  mkfs.ext4 -F "$DATA_DEV"
+fi
+mountpoint -q "$DATA_MOUNT" || mount -o noatime,discard "$DATA_DEV" "$DATA_MOUNT"
+grep -q "$DATA_DEV" /etc/fstab || \
+  echo "$DATA_DEV $DATA_MOUNT ext4 noatime,discard 0 2" >> /etc/fstab
+
+# ---- 3. Fetch secrets ----
+mkdir -p "$ENV_DIR"
+chmod 700 "$ENV_DIR"
+
+fetch() {
+  gcloud --quiet secrets versions access latest --secret="$1" 2>/dev/null || true
+}
+
+cat > "$ENV_FILE" <<EOF
+EIGENINFERENCE_PORT=8080
+EIGENINFERENCE_MIN_TRUST=hardware
+EIGENINFERENCE_BILLING_MOCK=false
+EIGENINFERENCE_BASE_URL=https://api.dev.darkbloom.dev
+EIGENINFERENCE_CONSOLE_URL=https://console.dev.darkbloom.dev
+EIGENINFERENCE_R2_CDN_URL=$(fetch eigeninference-r2-cdn-url)
+EIGENINFERENCE_SOLANA_RPC_URL=https://api.mainnet-beta.solana.com
+EIGENINFERENCE_SOLANA_USDC_MINT=EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v
+EIGENINFERENCE_ADMIN_EMAILS=gajesh@eigenlabs.org
+EIGENINFERENCE_REFERRAL_SHARE_PCT=15
+DOMAIN=api.dev.darkbloom.dev
+APP_PORT=8080
+EIGENINFERENCE_MDM_URL=https://localhost:9002
+EIGENINFERENCE_STEP_CA_ROOT=/data/step-ca/certs/root_ca.crt
+EIGENINFERENCE_STEP_CA_INTERMEDIATE=/data/step-ca/certs/intermediate_ca.crt
+EIGENINFERENCE_ADMIN_KEY=$(fetch eigeninference-admin-key)
+EIGENINFERENCE_RELEASE_KEY=$(fetch eigeninference-release-key)
+EIGENINFERENCE_PRIVY_APP_ID=$(fetch eigeninference-privy-app-id)
+EIGENINFERENCE_PRIVY_APP_SECRET=$(fetch eigeninference-privy-app-secret)
+EIGENINFERENCE_PRIVY_VERIFICATION_KEY=$(fetch eigeninference-privy-verification-key)
+EIGENINFERENCE_DATABASE_URL=$(fetch eigeninference-database-url)
+MNEMONIC=$(fetch eigeninference-solana-mnemonic)
+MICROMDM_API_KEY=$(fetch eigeninference-micromdm-api-key)
+EIGENINFERENCE_MDM_API_KEY=$(fetch eigeninference-micromdm-api-key)
+MDM_PUSH_P12_B64=$(fetch eigeninference-mdm-push-p12-b64)
+EOF
+chmod 600 "$ENV_FILE"
+
+# ---- 4. cloud-sql-proxy systemd unit ----
+cat > /etc/systemd/system/cloud-sql-proxy.service <<EOF
+[Unit]
+Description=Cloud SQL Auth Proxy
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+ExecStart=/usr/local/bin/cloud-sql-proxy --address 127.0.0.1 --port 5432 ${SQL_CONN}
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+# ---- 5. Coordinator startup wrapper + systemd unit ----
+# Wrapper resolves the image tag from instance metadata at each start so
+# Cloud Build can pin a specific SHA by writing DINF_IMAGE_TAG.
+cat > /usr/local/bin/d-inference-run.sh <<'WRAPPER'
+#!/bin/bash
+set -euo pipefail
+META="http://metadata.google.internal/computeMetadata/v1/instance/attributes/DINF_IMAGE_TAG"
+TAG=$(curl -fsSL -H "Metadata-Flavor: Google" "$META" 2>/dev/null || echo latest)
+IMAGE="us-central1-docker.pkg.dev/sepolia-ai/coordinator/coordinator:${TAG}"
+echo "Starting coordinator with image $IMAGE"
+/usr/bin/gcloud auth configure-docker us-central1-docker.pkg.dev --quiet
+/usr/bin/docker pull "$IMAGE"
+exec /usr/bin/docker run --rm --name d-inference-coordinator \
+  --network host \
+  --env-file /etc/d-inference/env \
+  --mount type=bind,source=/mnt/disks/userdata,target=/mnt/disks/userdata \
+  "$IMAGE"
+WRAPPER
+chmod +x /usr/local/bin/d-inference-run.sh
+
+cat > /etc/systemd/system/d-inference-coordinator.service <<EOF
+[Unit]
+Description=d-inference dev coordinator
+After=docker.service cloud-sql-proxy.service
+Requires=docker.service cloud-sql-proxy.service
+
+[Service]
+Restart=always
+RestartSec=5
+TimeoutStopSec=45
+ExecStartPre=-/usr/bin/docker stop d-inference-coordinator
+ExecStartPre=-/usr/bin/docker rm d-inference-coordinator
+ExecStart=/usr/local/bin/d-inference-run.sh
+ExecStop=/usr/bin/docker stop -t 30 d-inference-coordinator
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+systemctl daemon-reload
+systemctl enable cloud-sql-proxy.service d-inference-coordinator.service
+systemctl restart cloud-sql-proxy.service
+systemctl restart d-inference-coordinator.service
+
+echo "==> Startup complete at $(date -Iseconds)"

--- a/deploy/provider-fleet/dev-inventory.txt
+++ b/deploy/provider-fleet/dev-inventory.txt
@@ -1,0 +1,13 @@
+# Dev provider fleet — one SSH target per line.
+# Format: <ssh-host-alias>    <notes>
+# Lines starting with # and blank lines are ignored.
+#
+# Prereqs: your public key in ~/.ssh/authorized_keys on each machine, and a
+# corresponding Host entry in ~/.ssh/config so aliases resolve.
+#
+# Machines with "connected" in the hostname are tensor-parallel testbench
+# systems — do NOT add them here (see memory/feedback_no_update_connected_machines).
+
+# dev-mba-1    M4 MBA, 24 GB, owned by gajesh
+# dev-mbp-1    M4 Max MBP, 64 GB, owned by gajesh
+# dev-mini-1   M4 Pro mini, 48 GB

--- a/deploy/provider-fleet/prod-inventory.txt
+++ b/deploy/provider-fleet/prod-inventory.txt
@@ -1,0 +1,6 @@
+# Prod provider fleet — one SSH target per line.
+# Format: <ssh-host-alias>    <notes>
+#
+# Real prod hostnames are kept out of the repo (see memory/feedback_no_ips_in_public).
+# Maintain this list locally or in a private vault; this file exists as a
+# placeholder so the fleet-update workflow path is consistent between envs.

--- a/deploy/provider-fleet/update-fleet.sh
+++ b/deploy/provider-fleet/update-fleet.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# Reinstall / refresh the provider on every machine in a fleet inventory.
+#
+# Usage:
+#   deploy/provider-fleet/update-fleet.sh dev
+#   deploy/provider-fleet/update-fleet.sh prod    # requires explicit --force-prod
+#
+# Each machine runs the coordinator-served install.sh, which fetches the
+# latest release registered against that coordinator. Dev machines can only
+# ever talk to dev coordinator because the install.sh is served from there.
+
+set -euo pipefail
+
+ENV_NAME="${1:-}"
+if [ -z "$ENV_NAME" ]; then
+  echo "usage: $0 <dev|prod> [--force-prod]" >&2
+  exit 1
+fi
+
+case "$ENV_NAME" in
+  dev)
+    COORD_URL="https://api.dev.darkbloom.dev"
+    INVENTORY="$(dirname "$0")/dev-inventory.txt"
+    ;;
+  prod)
+    if [ "${2:-}" != "--force-prod" ]; then
+      echo "refusing to touch prod fleet without --force-prod" >&2
+      exit 2
+    fi
+    COORD_URL="https://api.darkbloom.dev"
+    INVENTORY="$(dirname "$0")/prod-inventory.txt"
+    ;;
+  *)
+    echo "unknown env: $ENV_NAME (expected dev or prod)" >&2
+    exit 1
+    ;;
+esac
+
+if [ ! -f "$INVENTORY" ]; then
+  echo "inventory file not found: $INVENTORY" >&2
+  exit 1
+fi
+
+HOSTS=$(grep -v '^[[:space:]]*#' "$INVENTORY" | awk 'NF {print $1}')
+
+if [ -z "$HOSTS" ]; then
+  echo "no hosts in $INVENTORY" >&2
+  exit 1
+fi
+
+echo "==> Updating $ENV_NAME fleet against $COORD_URL"
+for HOST in $HOSTS; do
+  echo "---- $HOST ----"
+  ssh "$HOST" "curl -fsSL $COORD_URL/install.sh | bash" || {
+    echo "!!! $HOST failed — continuing" >&2
+  }
+done
+
+echo "==> Fleet update complete"

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -171,7 +171,7 @@ EigenInference uses Apple MDM (MicroMDM) to independently verify provider securi
   - `FDE_Enabled`: FileVault disk encryption
   - `IsRecoveryLockEnabled`: Recovery Mode lock status
 - **Push notifications:** APNs for on-demand attestation queries
-- **Infrastructure:** MicroMDM + SCEP + step-ca on AWS
+- **Infrastructure:** MicroMDM + SCEP + step-ca co-located in the coordinator container on EigenCloud (prod). Dev runs on Google Cloud with MDM disabled.
 
 ### Apple Device Attestation (MDA)
 

--- a/docs/dev-environment.md
+++ b/docs/dev-environment.md
@@ -1,0 +1,161 @@
+# Dev Environment Runbook
+
+The d-inference dev environment runs on Google Cloud (GCP project `sepolia-ai`, region `us-central1`). It exists so we can test every code path — coordinator, provider bundle, console-ui, Mac fleet, release pipeline — end-to-end without touching prod.
+
+**Prod runs on EigenCloud and is human-deploy-only (see CLAUDE.md).** Nothing in this runbook deploys to prod.
+
+## What dev looks like
+
+| Component | Location | URL / identifier |
+|---|---|---|
+| Coordinator | GCE VM `d-inference-dev` (us-central1-a, Ubuntu 24.04 + Docker + systemd) | `https://api.dev.darkbloom.dev` (static IP) |
+| Persistent disk | GCE persistent disk `d-inference-dev-data` mounted at `/mnt/disks/userdata` (same path as EigenCloud prod) — holds step-ca state + MicroMDM BoltDB | 30 GB, pd-balanced |
+| Console UI | Vercel (separate "darkbloom-console-dev" project, built from `console-ui/`) | `https://console.dev.darkbloom.dev` |
+| Database | Cloud SQL Postgres 16, instance `d-inference-dev-db`, `db-f1-micro`, accessed via cloud-sql-proxy sidecar on the VM | 127.0.0.1:5432 from inside the container |
+| Release bucket | Cloudflare R2 `d-inf-app-dev` | R2 CDN URL in env vars |
+| Secrets | Google Secret Manager, prefix `eigeninference-*`. Fetched at VM boot into `/etc/d-inference/env` | see §Secrets |
+| Mac fleet | 2–4 Macs with hostnames `dev-*` | listed in `deploy/provider-fleet/dev-inventory.txt` |
+| DNS | Vercel Domains: `api.dev.darkbloom.dev` A → VM static IP; `console.dev.darkbloom.dev` CNAME → Cloud Run | — |
+| Privy | Separate dev Privy app (not the prod one) | values in Secret Manager |
+| Solana | Mainnet, but with a dev-only BIP39 mnemonic (new wallet) | `EIGENINFERENCE_BILLING_MOCK=false` |
+| MDM / attestation | Full stack — MicroMDM + step-ca run inside the coordinator container on the VM. `MIN_TRUST=hardware`, same as prod. | |
+
+**Why GCE VM, not Cloud Run:** the coordinator container runs step-ca (writes CA keys to disk) and MicroMDM (BoltDB). Both need reliable local filesystem semantics. Cloud Run's ephemeral FS doesn't survive revisions, and gcsfuse is unsafe for BoltDB. The VM's persistent disk lives at `/mnt/disks/userdata` — the same path EigenCloud prod uses, so the container's `start.sh` works unchanged.
+
+**Upgrade time:** ~2–4 minutes end-to-end for the coordinator (build + push + `systemctl restart`). ~30–60 sec for the console UI on Vercel (auto-builds on git push). During a coordinator restart there is a ~10s blip when the container comes down and back up — providers auto-reconnect.
+
+## Standing up dev from scratch
+
+1. **Bootstrap GCP.** From a workstation with `gcloud` authenticated against `sepolia-ai`:
+   ```bash
+   deploy/gcp/bootstrap.sh
+   ```
+   This creates Artifact Registry repos, service accounts, empty Secret Manager entries, and a Cloud SQL instance. Idempotent — re-run as needed.
+
+2. **Populate secrets.** For each entry created by the bootstrap script:
+   ```bash
+   echo -n '<value>' | gcloud secrets versions add <secret-name> --data-file=-
+   ```
+   Values:
+   - `eigeninference-admin-key` — `openssl rand -hex 32`
+   - `eigeninference-release-key` — `openssl rand -hex 32`
+   - `eigeninference-solana-mnemonic` — generate a **new** BIP39 mnemonic (never reuse prod). Derive the Solana public key, fund it with a small amount of USDC on mainnet for end-to-end testing.
+   - `eigeninference-privy-app-id` — from the dev Privy app dashboard
+   - `eigeninference-privy-app-secret` — same
+   - `eigeninference-privy-verification-key` — same (JWKS JSON or PEM)
+   - `eigeninference-database-url` — already set by bootstrap if Cloud SQL was just created
+   - `eigeninference-micromdm-api-key` — `openssl rand -hex 32` (used by both MicroMDM and the coordinator's MDM client; they must match)
+   - `eigeninference-mdm-push-p12-b64` — base64url-encoded MDM push PKCS#12. Same Apple push cert prod uses (one cert per Apple Developer account). To encode: `base64 < push.p12 | tr '/+' '_-' | tr -d '\n='`
+   - `eigeninference-r2-cdn-url` — the public URL of the `d-inf-app-dev` R2 bucket (e.g. `https://pub-<randomid>.r2.dev`). Used by the coordinator to template install.sh so dev providers pull artifacts from the dev bucket.
+
+3. **DNS.** The bootstrap reserves a static external IP and prints it. On Vercel Domains:
+   - `api.dev.darkbloom.dev`      A     `<VM_STATIC_IP>`
+   - `console.dev.darkbloom.dev`  CNAME `cname.vercel-dns.com` (Vercel shows the exact target when you add the custom domain in step 5)
+
+4. **First coordinator deploy.** From the repo root:
+   ```bash
+   gcloud builds submit --config=deploy/gcp/cloudbuild.yaml --project=sepolia-ai
+   ```
+   This builds the image, pushes to Artifact Registry, writes the SHA to VM metadata, and `systemctl restart`s the unit on the VM via IAP SSH. First build is ~4 min; subsequent deploys are ~2–3 min.
+
+5. **Console UI on Vercel.** In the Vercel dashboard:
+   - Import the `d-inference` repo as a new project named `darkbloom-console-dev`. Set root directory to `console-ui/`.
+   - Environment variables: `NEXT_PUBLIC_COORDINATOR_URL=https://api.dev.darkbloom.dev`.
+   - Add custom domain `console.dev.darkbloom.dev`. Vercel provisions the cert; copy the CNAME target it shows and add it in step 3.
+   - Every push to `master` auto-builds. For isolated preview branches Vercel gives preview URLs that still hit dev coordinator.
+
+6. **Connect GitHub → Cloud Build.** One-time, from the Cloud Console: install the Google Cloud Build GitHub App on `Gajesh2007/d-inference`, authorize the repo, create a trigger targeting `deploy/gcp/cloudbuild.yaml` on push to `master` with path filter `coordinator/**` and `deploy/gcp/**`. (Console UI on Vercel handles its own CI — no second Cloud Build trigger needed.)
+
+7. **First dev release.** From GitHub Actions UI: run `Release Provider Bundle` with `environment=dev`. It builds, signs, notarizes, uploads to R2 `d-inf-app-dev`, registers with the dev coordinator. (Alternative: push a tag like `v0.3.6-dev.1` — the workflow routes dev/prod by tag shape.)
+
+8. **Onboard the Mac fleet.** On each dev Mac:
+   ```bash
+   curl -fsSL https://api.dev.darkbloom.dev/install.sh | bash
+   ```
+   The install script is served by the dev coordinator with its URL templated in, so the installed provider only talks to dev. Add the Mac's SSH host alias to `deploy/provider-fleet/dev-inventory.txt`.
+
+9. **Smoke test.** `scripts/smoke-dev.sh` hits `/health`, `/v1/stats`, `/v1/models/catalog`, verifies install.sh templating, and optionally runs an authenticated chat round-trip if `API_KEY` is set.
+
+## Day-to-day flow
+
+- **Push to `master`** → Cloud Build auto-deploys coordinator + console-ui to dev. No approval step.
+- **Need a new provider release on dev?** Run the `Release Provider Bundle` workflow with `environment=dev` (or push a `-dev.N` tag).
+- **Prod release after dev bake?** Same commit SHA, run the workflow with `environment=prod`. The prod GitHub Environment requires reviewer approval. The provider binary gets rebuilt with the prod coordinator URL baked in — dev and prod never share artifacts.
+- **Fleet refresh.** `deploy/provider-fleet/update-fleet.sh dev` reinstalls via SSH + `install.sh`.
+
+## Secrets mapping
+
+| Env var in coordinator | Secret Manager name | Source |
+|---|---|---|
+| `EIGENINFERENCE_ADMIN_KEY` | `eigeninference-admin-key` | generated once, stored |
+| `EIGENINFERENCE_RELEASE_KEY` | `eigeninference-release-key` | generated once, also set in GH env `dev`→`RELEASE_KEY` |
+| `EIGENINFERENCE_PRIVY_APP_ID` | `eigeninference-privy-app-id` | Privy dashboard (dev app) |
+| `EIGENINFERENCE_PRIVY_APP_SECRET` | `eigeninference-privy-app-secret` | Privy dashboard |
+| `EIGENINFERENCE_PRIVY_VERIFICATION_KEY` | `eigeninference-privy-verification-key` | Privy dashboard |
+| `MNEMONIC` | `eigeninference-solana-mnemonic` | generated fresh for dev |
+| `EIGENINFERENCE_DATABASE_URL` | `eigeninference-database-url` | bootstrap writes Cloud SQL conn string (via cloud-sql-proxy on 127.0.0.1:5432) |
+| `MICROMDM_API_KEY` / `EIGENINFERENCE_MDM_API_KEY` | `eigeninference-micromdm-api-key` | same value for both — keep in sync |
+| `MDM_PUSH_P12_B64` | `eigeninference-mdm-push-p12-b64` | Apple push cert (base64url-encoded PKCS#12) |
+
+Non-secret configuration is baked into `deploy/gcp/cloudbuild.yaml` via `--set-env-vars`. If you need to change one (e.g. flip `MIN_TRUST`), edit that file — the next deploy picks it up.
+
+## GitHub Environments
+
+Two environments exist: `dev` and `prod`. Each holds its own copy of:
+
+| Key | Type | Dev value | Prod value |
+|---|---|---|---|
+| `COORDINATOR_URL` | secret | `https://api.dev.darkbloom.dev` | `https://api.darkbloom.dev` |
+| `RELEASE_KEY` | secret | dev release key | prod release key |
+| `R2_ACCESS_KEY_ID` | secret | R2 token scoped to `d-inf-app-dev` | R2 token for `d-inf-app` |
+| `R2_SECRET_ACCESS_KEY` | secret | same | same |
+| `R2_ENDPOINT` | secret | Cloudflare R2 endpoint | same endpoint (bucket-scoped token) |
+| `R2_PUBLIC_URL` | secret | dev public R2 URL | prod public R2 URL |
+| `APPLE_CERTIFICATE_P12` | secret | shared (one Developer ID cert) | same |
+| `APPLE_CERTIFICATE_PASSWORD` | secret | shared | same |
+| `APPLE_ID` | secret | shared | same |
+| `APPLE_APP_PASSWORD` | secret | shared | same |
+| `R2_BUCKET` | variable | `d-inf-app-dev` | `d-inf-app` |
+| `R2_CDN` | variable | dev public R2 CDN URL | prod public R2 CDN URL |
+
+Prod environment: enable **required reviewers** under Settings → Environments → prod.
+
+## Rollback
+
+- **Dev coordinator.** Images are tagged by `$SHORT_SHA` in Artifact Registry. Point the VM at an older tag and restart:
+  ```bash
+  gcloud compute instances add-metadata d-inference-dev --zone=us-central1-a \
+    --metadata=DINF_IMAGE_TAG=<older-short-sha>
+  gcloud compute ssh d-inference-dev --zone=us-central1-a --tunnel-through-iap -- \
+    'sudo systemctl restart d-inference-coordinator'
+  ```
+  Rollback time: ~1 min (image already in registry + VM already running — just a container swap).
+- **Dev provider bundle.** Releases are immutable in R2; to roll back, reregister an older bundle as "active" via the coordinator admin API, or run the dev release workflow against an older tag.
+
+## What dev does *not* cover
+
+- **EigenCloud blue-green semantics.** The VM + systemd restart model is close but not identical to EigenCloud's blue-green disk transfer. Prod-only deploy paths still need a final smoke on prod (reviewer-approved).
+- **External user traffic.** Dev is team-only; admin emails are gated to `gajesh@eigenlabs.org`.
+
+## Seeding after a redeploy (if using in-memory mode)
+
+If `EIGENINFERENCE_DATABASE_URL` is unset, the coordinator resets state on every deploy. To re-register the current release and grant test credits after a redeploy, run:
+
+```bash
+scripts/admin.sh EIGENINFERENCE_COORDINATOR_URL=https://api.dev.darkbloom.dev releases latest
+```
+
+(Wire a `seed-dev.sh` here when we converge on a pattern.)
+
+## Cost
+
+- GCE `e2-small` 24/7 (coordinator VM): ~$13/mo
+- Cloud SQL `db-f1-micro` Postgres: ~$8/mo
+- GCE static IP (attached): ~$1.50/mo
+- 30 GB persistent disk (pd-balanced): ~$3/mo
+- Artifact Registry + Cloud Build + Logging: free tier
+- R2 `d-inf-app-dev`: free tier
+- Vercel console UI: free/hobby tier
+- DNS: Vercel Domains (existing plan)
+
+Total: ~$25–30/month. Not optimizing for cost — correctness + realism-vs-prod take priority.

--- a/provider/build.rs
+++ b/provider/build.rs
@@ -1,0 +1,53 @@
+// Emits coordinator URL defaults at compile time.
+//
+// CI passes DARKBLOOM_COORDINATOR_URL (e.g. https://api.darkbloom.dev) per
+// environment; this script derives the WebSocket and enroll-profile forms and
+// re-exports them as individual env vars that `option_env!` picks up in code.
+//
+// If DARKBLOOM_COORDINATOR_URL is not set, the env vars are not emitted and the
+// source-level fallbacks (prod URLs) apply. Local dev builds therefore behave
+// identically to today.
+
+use std::env;
+
+fn main() {
+    println!("cargo:rerun-if-env-changed=DARKBLOOM_COORDINATOR_URL");
+    println!("cargo:rerun-if-env-changed=DARKBLOOM_R2_CDN_URL");
+    println!("cargo:rerun-if-env-changed=DARKBLOOM_R2_SITE_PACKAGES_CDN_URL");
+
+    if let Ok(base) = env::var("DARKBLOOM_COORDINATOR_URL") {
+        let base = base.trim_end_matches('/').to_string();
+
+        let ws_base = if let Some(rest) = base.strip_prefix("https://") {
+            format!("wss://{rest}")
+        } else if let Some(rest) = base.strip_prefix("http://") {
+            format!("ws://{rest}")
+        } else {
+            panic!("DARKBLOOM_COORDINATOR_URL must start with http:// or https://");
+        };
+
+        let ws_url = format!("{ws_base}/ws/provider");
+        let enroll_url = format!("{base}/enroll.mobileconfig");
+        let install_url = format!("{base}/install.sh");
+
+        println!("cargo:rustc-env=DARKBLOOM_COORDINATOR_HTTP_URL={base}");
+        println!("cargo:rustc-env=DARKBLOOM_COORDINATOR_WS_URL={ws_url}");
+        println!("cargo:rustc-env=DARKBLOOM_ENROLL_PROFILE_URL={enroll_url}");
+        println!("cargo:rustc-env=DARKBLOOM_INSTALL_URL={install_url}");
+    }
+
+    // R2 CDN URL baked in per environment. If DARKBLOOM_R2_CDN_URL is set and
+    // DARKBLOOM_R2_SITE_PACKAGES_CDN_URL is not, default the site-packages CDN
+    // to the same bucket (dev co-locates them; prod historically uses two).
+    if let Ok(cdn) = env::var("DARKBLOOM_R2_CDN_URL") {
+        let cdn = cdn.trim_end_matches('/').to_string();
+        println!("cargo:rustc-env=DARKBLOOM_R2_CDN_URL={cdn}");
+        if env::var("DARKBLOOM_R2_SITE_PACKAGES_CDN_URL").is_err() {
+            println!("cargo:rustc-env=DARKBLOOM_R2_SITE_PACKAGES_CDN_URL={cdn}");
+        }
+    }
+    if let Ok(spk) = env::var("DARKBLOOM_R2_SITE_PACKAGES_CDN_URL") {
+        let spk = spk.trim_end_matches('/').to_string();
+        println!("cargo:rustc-env=DARKBLOOM_R2_SITE_PACKAGES_CDN_URL={spk}");
+    }
+}

--- a/provider/src/main.rs
+++ b/provider/src/main.rs
@@ -45,6 +45,41 @@ use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
 use tracing_subscriber::EnvFilter;
 
+// Compile-time coordinator URL defaults. CI bakes the right environment via
+// `DARKBLOOM_COORDINATOR_URL` — see `provider/build.rs`. Unset means local
+// build: use prod URLs so dev-on-a-laptop still hits prod when users override
+// via --coordinator flags and config files.
+const DEFAULT_COORDINATOR_HTTP_URL: &str = match option_env!("DARKBLOOM_COORDINATOR_HTTP_URL") {
+    Some(v) => v,
+    None => "https://api.darkbloom.dev",
+};
+const DEFAULT_COORDINATOR_WS_URL: &str = match option_env!("DARKBLOOM_COORDINATOR_WS_URL") {
+    Some(v) => v,
+    None => "wss://api.darkbloom.dev/ws/provider",
+};
+const DEFAULT_ENROLL_PROFILE_URL: &str = match option_env!("DARKBLOOM_ENROLL_PROFILE_URL") {
+    Some(v) => v,
+    None => "https://api.darkbloom.dev/enroll.mobileconfig",
+};
+const DEFAULT_INSTALL_URL: &str = match option_env!("DARKBLOOM_INSTALL_URL") {
+    Some(v) => v,
+    None => "https://api.darkbloom.dev/install.sh",
+};
+// Public R2 CDN URL for releases/templates/models. Dev uses a different bucket
+// (d-inf-app-dev) with its own public URL — build.rs wires DARKBLOOM_R2_CDN_URL
+// from CI. When unset, we fall back to the prod R2 CDN.
+const DEFAULT_R2_CDN_URL: &str = match option_env!("DARKBLOOM_R2_CDN_URL") {
+    Some(v) => v,
+    None => "https://pub-7cbee059c80c46ec9c071dbee2726f8a.r2.dev",
+};
+// Site-packages tarball CDN (separate prod bucket historically, co-located for
+// dev). Falls back to the long-used prod bucket when unset.
+const DEFAULT_R2_SITE_PACKAGES_CDN_URL: &str =
+    match option_env!("DARKBLOOM_R2_SITE_PACKAGES_CDN_URL") {
+        Some(v) => v,
+        None => "https://pub-3d1cb668259340eeb2276e1d375c846d.r2.dev",
+    };
+
 /// A model from the coordinator's supported model catalog.
 #[derive(Debug, Clone, serde::Deserialize)]
 struct CatalogModel {
@@ -364,10 +399,7 @@ fn curl_download(url: &str, dest: &std::path::Path) -> bool {
 ///
 /// Handles text models (safetensors) and image models (.ckpt) from R2.
 fn download_model_from_cdn(s3_name: &str, cache_dir: &std::path::Path, display_name: &str) -> bool {
-    let base = format!(
-        "https://pub-7cbee059c80c46ec9c071dbee2726f8a.r2.dev/{}",
-        s3_name
-    );
+    let base = format!("{}/{}", DEFAULT_R2_CDN_URL, s3_name);
 
     // Check if this is an image model (.ckpt files, no config.json)
     let is_image_model = s3_name.contains("flux") || s3_name.contains("klein");
@@ -707,8 +739,7 @@ fn ensure_chat_template(
     };
 
     // Download from our R2 CDN (primary) or HuggingFace (fallback)
-    const R2_BASE: &str = "https://pub-7cbee059c80c46ec9c071dbee2726f8a.r2.dev";
-    let r2_url = format!("{R2_BASE}/templates/{template_name}.jinja");
+    let r2_url = format!("{}/templates/{template_name}.jinja", DEFAULT_R2_CDN_URL);
 
     tracing::info!("Downloading {template_name} chat template...");
 
@@ -1089,7 +1120,7 @@ fn runtime_smoke_test(python_cmd: &str) -> std::result::Result<String, String> {
 /// the hash against the coordinator's runtime manifest before installing.
 /// This prevents MITM attacks on the update channel.
 fn ensure_runtime_updated(python_cmd: &str, coordinator_base: &str) -> bool {
-    const R2_CDN: &str = "https://pub-3d1cb668259340eeb2276e1d375c846d.r2.dev";
+    let r2_cdn: &str = DEFAULT_R2_SITE_PACKAGES_CDN_URL;
     const GITHUB_FALLBACK: &str =
         "https://github.com/Gajesh2007/vllm-mlx/archive/refs/heads/main.zip";
 
@@ -1135,7 +1166,7 @@ fn ensure_runtime_updated(python_cmd: &str, coordinator_base: &str) -> bool {
     let mut downloaded = false;
     if !release_version.is_empty() {
         let r2_url =
-            format!("{R2_CDN}/releases/v{release_version}/eigeninference-site-packages.tar.gz");
+            format!("{r2_cdn}/releases/v{release_version}/eigeninference-site-packages.tar.gz");
         tracing::info!("Downloading site-packages from R2 (release v{release_version})...");
         downloaded = std::process::Command::new("curl")
             .args([
@@ -1238,7 +1269,7 @@ fn ensure_runtime_updated(python_cmd: &str, coordinator_base: &str) -> bool {
     let tmp_zip = "/tmp/eigeninference-vllm-mlx-update.zip";
     let mut zip_downloaded = false;
     if !release_version.is_empty() {
-        let r2_url = format!("{R2_CDN}/releases/v{release_version}/vllm-mlx-source.zip");
+        let r2_url = format!("{r2_cdn}/releases/v{release_version}/vllm-mlx-source.zip");
         zip_downloaded = std::process::Command::new("curl")
             .args(["-fsSL", "--connect-timeout", "10", &r2_url, "-o", tmp_zip])
             .output()
@@ -1427,7 +1458,7 @@ enum Command {
         local: bool,
 
         /// Coordinator WebSocket URL
-        #[arg(long, default_value = "wss://api.darkbloom.dev/ws/provider")]
+        #[arg(long, default_value = DEFAULT_COORDINATOR_WS_URL)]
         coordinator: String,
 
         /// Port for local API server
@@ -1467,11 +1498,11 @@ enum Command {
     /// One-command setup: enroll in MDM, download model, start serving
     Install {
         /// Coordinator URL (WebSocket for serving, HTTPS for API)
-        #[arg(long, default_value = "wss://api.darkbloom.dev/ws/provider")]
+        #[arg(long, default_value = DEFAULT_COORDINATOR_WS_URL)]
         coordinator: String,
 
         /// MDM enrollment profile URL
-        #[arg(long, default_value = "https://api.darkbloom.dev/enroll.mobileconfig")]
+        #[arg(long, default_value = DEFAULT_ENROLL_PROFILE_URL)]
         profile_url: String,
 
         /// Model to serve (auto-selects if not specified)
@@ -1482,7 +1513,7 @@ enum Command {
     /// Enroll this Mac in Darkbloom MDM (without starting to serve)
     Enroll {
         /// Coordinator URL for device attestation enrollment
-        #[arg(long, default_value = "https://api.darkbloom.dev")]
+        #[arg(long, default_value = DEFAULT_COORDINATOR_HTTP_URL)]
         coordinator: String,
     },
 
@@ -1505,28 +1536,28 @@ enum Command {
         action: String,
 
         /// Coordinator URL to fetch model catalog
-        #[arg(long, default_value = "https://api.darkbloom.dev")]
+        #[arg(long, default_value = DEFAULT_COORDINATOR_HTTP_URL)]
         coordinator: String,
     },
 
     /// Show earnings and usage history
     Earnings {
         /// Coordinator API URL
-        #[arg(long, default_value = "https://api.darkbloom.dev")]
+        #[arg(long, default_value = DEFAULT_COORDINATOR_HTTP_URL)]
         coordinator: String,
     },
 
     /// Diagnose issues: check SIP, Secure Enclave, MDM, models, connectivity
     Doctor {
         /// Coordinator URL to test connectivity
-        #[arg(long, default_value = "https://api.darkbloom.dev")]
+        #[arg(long, default_value = DEFAULT_COORDINATOR_HTTP_URL)]
         coordinator: String,
     },
 
     /// Start the provider in the background (uses existing config)
     Start {
         /// Coordinator WebSocket URL
-        #[arg(long, default_value = "wss://api.darkbloom.dev/ws/provider")]
+        #[arg(long, default_value = DEFAULT_COORDINATOR_WS_URL)]
         coordinator: String,
 
         /// Model to serve
@@ -1563,7 +1594,7 @@ enum Command {
     /// Check for updates and install the latest version
     Update {
         /// Coordinator URL to check for latest version
-        #[arg(long, default_value = "https://api.darkbloom.dev")]
+        #[arg(long, default_value = DEFAULT_COORDINATOR_HTTP_URL)]
         coordinator: String,
         /// Force re-download even if already on the latest version
         #[arg(long)]
@@ -1573,7 +1604,7 @@ enum Command {
     /// Link this machine to your Darkbloom account
     Login {
         /// Coordinator URL
-        #[arg(long, default_value = "https://api.darkbloom.dev")]
+        #[arg(long, default_value = DEFAULT_COORDINATOR_HTTP_URL)]
         coordinator: String,
     },
 
@@ -1694,7 +1725,7 @@ async fn check_for_update_alert() {
                 .replace("wss://", "https://")
                 .replace("/ws/provider", "")
         })
-        .unwrap_or_else(|| "https://api.darkbloom.dev".to_string());
+        .unwrap_or_else(|| DEFAULT_COORDINATOR_HTTP_URL.to_string());
 
     let client = match reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(2))
@@ -2450,7 +2481,8 @@ async fn cmd_serve(
     if !ensure_python_verified(&python_cmd, &coordinator_http_base) {
         anyhow::bail!(
             "Python runtime is broken and could not be recovered. \
-             Please run: curl -fsSL https://api.darkbloom.dev/install.sh | bash"
+             Please run: curl -fsSL {} | bash",
+            DEFAULT_INSTALL_URL
         );
     }
     ensure_runtime_updated(&python_cmd, &coordinator_http_base);
@@ -4974,7 +5006,7 @@ async fn cmd_benchmark() -> Result<()> {
 
     // Scan downloaded models and filter by catalog
     let downloaded = models::scan_models(&hw);
-    let catalog = fetch_catalog("https://api.darkbloom.dev").await;
+    let catalog = fetch_catalog(DEFAULT_COORDINATOR_HTTP_URL).await;
     let catalog_ids: std::collections::HashSet<String> =
         catalog.iter().map(|c| c.id.clone()).collect();
 
@@ -5251,7 +5283,7 @@ async fn cmd_status() -> Result<()> {
 
     // Models (catalog-filtered)
     let models = models::scan_models(&hw);
-    let catalog = fetch_catalog("https://api.darkbloom.dev").await;
+    let catalog = fetch_catalog(DEFAULT_COORDINATOR_HTTP_URL).await;
     let catalog_ids: std::collections::HashSet<String> =
         catalog.iter().map(|c| c.id.clone()).collect();
 
@@ -5730,11 +5762,10 @@ async fn cmd_doctor(coordinator_url: String) -> Result<()> {
                 }
                 _ => {
                     println!("✗ Not installed");
-                    issues.push(
-                        "Inference runtime not found. Reinstall:\n\
-                         \x20    curl -fsSL https://api.darkbloom.dev/install.sh | bash"
-                            .to_string(),
-                    );
+                    issues.push(format!(
+                        "Inference runtime not found. Reinstall:\n     curl -fsSL {} | bash",
+                        DEFAULT_INSTALL_URL
+                    ));
                 }
             }
         }
@@ -6056,7 +6087,7 @@ async fn cmd_start(
             }
 
             // Fetch expected file sizes from CDN via HEAD requests to detect partial downloads.
-            let cdn_base = "https://pub-7cbee059c80c46ec9c071dbee2726f8a.r2.dev";
+            let cdn_base = DEFAULT_R2_CDN_URL;
             let cdn_sizes: std::collections::HashMap<String, u64> = {
                 let client = reqwest::Client::new();
                 let mut sizes = std::collections::HashMap::new();

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -17,7 +17,10 @@ set -euo pipefail
 #
 # Zero prerequisites — just macOS + Apple Silicon.
 
-COORD_URL="https://api.darkbloom.dev"
+# Direct-fetch copy: no serve-time templating applied. Override with
+#   curl ... | COORD_URL=https://api.dev.darkbloom.dev bash
+# Or fetch the coordinator-served copy at $COORD_URL/install.sh for templating.
+COORD_URL="${COORD_URL:-https://api.darkbloom.dev}"
 INSTALL_DIR="$HOME/.darkbloom"
 BIN_DIR="$INSTALL_DIR/bin"
 PYTHON_BIN="$INSTALL_DIR/python/bin/python3.12"
@@ -227,7 +230,9 @@ if [ -f "$PYTHON_BIN" ] && ! "$PYTHON_BIN" -c "print('ok')" 2>/dev/null; then
             echo "  Portable Python installed ✓"
             # Install packages from R2 site-packages tarball (same verified artifacts as CI)
             SITE_DIR="$INSTALL_DIR/python/lib/python3.12/site-packages"
-            R2_CDN="https://pub-3d1cb668259340eeb2276e1d375c846d.r2.dev"
+            # Prefer the coordinator-served install.sh (templated) — this copy is
+            # a direct-fetch fallback and stays pinned to the prod CDN defaults.
+            R2_CDN="${R2_CDN:-https://pub-3d1cb668259340eeb2276e1d375c846d.r2.dev}"
             if [ -n "$VERSION" ] && curl -fsSL "$R2_CDN/releases/v${VERSION}/eigeninference-site-packages.tar.gz" -o "/tmp/eigen-site-packages.tar.gz" 2>/dev/null; then
                 rm -rf "$SITE_DIR"
                 mkdir -p "$SITE_DIR"
@@ -419,7 +424,7 @@ if [ -n "$MODEL" ]; then
             echo "  $MODEL_NAME downloaded ✓"
         else
             echo "  Tarball not available, downloading from R2..."
-            R2_BASE="https://pub-7cbee059c80c46ec9c071dbee2726f8a.r2.dev/$S3_NAME"
+            R2_BASE="${R2_CDN_URL:-https://pub-7cbee059c80c46ec9c071dbee2726f8a.r2.dev}/$S3_NAME"
             for f in config.json tokenizer.json tokenizer_config.json special_tokens_map.json model.safetensors.index.json; do
                 curl -fsSL "$R2_BASE/$f" -o "$CACHE_DIR/$f" 2>/dev/null || true
             done

--- a/scripts/smoke-dev.sh
+++ b/scripts/smoke-dev.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+# End-to-end smoke test for the dev coordinator. Intended to run post-deploy
+# (Cloud Build step) and on a cron (GH Actions). Any failure non-zero-exits
+# so the calling job can alert.
+#
+# Usage:
+#   COORD=https://api.dev.darkbloom.dev \
+#   API_KEY=$DEV_API_KEY \
+#   scripts/smoke-dev.sh
+#
+# API_KEY must be a test account's Darkbloom API key with non-zero credits.
+# No prod API keys. No real prompts — all test inputs are synthetic.
+
+set -euo pipefail
+
+COORD="${COORD:-https://api.dev.darkbloom.dev}"
+API_KEY="${API_KEY:-}"
+FAIL=0
+
+red()   { printf '\033[31m%s\033[0m\n' "$*"; }
+green() { printf '\033[32m%s\033[0m\n' "$*"; }
+step()  { printf '\n--- %s ---\n' "$*"; }
+
+require() {
+  local name="$1"; local val="$2"
+  if [ -z "$val" ]; then
+    red "missing $name — set it and retry"
+    exit 2
+  fi
+}
+
+fail() {
+  red "FAIL: $*"
+  FAIL=$((FAIL+1))
+}
+
+step "health"
+if curl -fsS "$COORD/health" >/dev/null; then
+  green "health OK"
+else
+  fail "health endpoint not responding"
+fi
+
+step "stats (public)"
+PROVIDER_COUNT=$(curl -fsS "$COORD/v1/stats" | python3 -c 'import sys,json; d=json.load(sys.stdin); print(d.get("providers_online", d.get("providers", 0)))' 2>/dev/null || echo 0)
+if [ "$PROVIDER_COUNT" -gt 0 ]; then
+  green "providers online: $PROVIDER_COUNT"
+else
+  fail "no providers visible in /v1/stats (dev fleet offline?)"
+fi
+
+step "model catalog"
+MODEL_COUNT=$(curl -fsS "$COORD/v1/models/catalog" | python3 -c 'import sys,json; d=json.load(sys.stdin); print(len(d.get("models", d if isinstance(d,list) else [])))' 2>/dev/null || echo 0)
+if [ "$MODEL_COUNT" -gt 0 ]; then
+  green "catalog has $MODEL_COUNT models"
+else
+  fail "model catalog empty"
+fi
+
+step "install.sh templating"
+if curl -fsS "$COORD/install.sh" | grep -q 'https://api.dev.darkbloom.dev'; then
+  green "install.sh references dev coordinator"
+else
+  fail "install.sh does not reference dev coordinator (templating broken?)"
+fi
+
+# Authenticated tests only run if an API key is supplied.
+if [ -n "$API_KEY" ]; then
+  step "chat completions (authenticated)"
+  HTTP_CODE=$(curl -sS -o /tmp/smoke-chat.json -w '%{http_code}' \
+    -H "Authorization: Bearer $API_KEY" \
+    -H "Content-Type: application/json" \
+    -d '{"model":"auto","messages":[{"role":"user","content":"ping"}],"max_tokens":8,"stream":false}' \
+    "$COORD/v1/chat/completions" || echo 000)
+  if [ "$HTTP_CODE" = "200" ]; then
+    green "chat OK"
+  else
+    fail "chat returned $HTTP_CODE: $(head -c 400 /tmp/smoke-chat.json)"
+  fi
+else
+  echo "(skipping authenticated tests — set API_KEY to enable)"
+fi
+
+echo
+if [ "$FAIL" -gt 0 ]; then
+  red "$FAIL check(s) failed"
+  exit 1
+fi
+green "all checks passed"


### PR DESCRIPTION
## Summary

- New withdrawal rail: users can link a bank account or debit card via Stripe-hosted onboarding and withdraw their internal credit balance — Standard ACH (1-2 business days, free) or Instant to debit card (~30 min, 1.5% fee, $0.50 min). Fees are deducted from the gross.
- Coordinator gains a Stripe Connect Express client, persist-first state machine for withdrawals (pending → transferred → paid), idempotent webhook handling, and Postgres schema for the new `stripe_withdrawals` table + Stripe fields on `users`.
- Console UI gains a `StripePayoutsCard` + `StripeWithdrawModal` on the Billing page, four proxy routes, and an integer-cent fee helper that mirrors the server formula exactly.

## Why this design

- **Persist before any Stripe call.** Eliminates the failure mode where a DB write could fail after Stripe already moved money. State transitions only update an existing row.
- **Refund idempotency keyed on `Refunded` flag, not `Status`.** A partial-refund failure can be retried on webhook redelivery without manually clearing state.
- **Webhook secret required in non-mock mode.** Refusing to verify (rather than parse-without-verify) closes a vector where a stolen `po_…` ID could trigger an unsigned `payout.failed` and inject a ledger refund.
- **`return_url` allowlist anchored on operator-configured default.** Blocks open-redirect via crafted onboard requests.
- **Express requests both `transfers` and `card_payments` capabilities.** Caught in live test-mode validation: Stripe rejects transfers-only without pre-approval. Adding `card_payments` is cosmetic — we never call charges.

## Validation

- 33 new Go tests (handler lifecycle, fee math, signature verification rejecting empty secrets in prod, redirect allowlist, persist-first ordering, idempotent webhooks, Postgres CRUD).
- 16 new vitest cases (fee helper parity with the server formula, proxy URL shape, error surfacing).
- Full coordinator suite (~600 cases) and console-ui build still pass.
- **Live test-mode validation via `stripe listen` + `stripe trigger`:** real signed `account.updated` webhook delivered through to the handler, signature verified, event parsed, 200 returned. Direct `accounts.create` and `account_links.create` calls against live test-mode Stripe both succeed.
- Independent code review (general-purpose subagent) caught 6 issues pre-merge; all fixed before commit.

## New env vars (all optional — feature activates when `EIGENINFERENCE_STRIPE_SECRET_KEY` is set)

- `EIGENINFERENCE_STRIPE_CONNECT_WEBHOOK_SECRET` — required in non-mock prod
- `EIGENINFERENCE_STRIPE_CONNECT_COUNTRY` (default: `US`)
- `EIGENINFERENCE_STRIPE_CONNECT_RETURN_URL`
- `EIGENINFERENCE_STRIPE_CONNECT_REFRESH_URL`

## Test plan

- [ ] Confirm Stripe Connect is enabled on the production account before merging
- [ ] Set the four new env vars in EigenCloud (test secret key first, then live)
- [ ] Create the production webhook endpoint pointing at `/v1/billing/stripe/connect/webhook` with events: `account.updated`, `payout.paid`, `payout.failed`, `payout.canceled`
- [ ] Run a real round-trip in test mode: onboard a fake user, withdraw $1 to a test bank account, verify webhook flips status to `paid`
- [ ] Verify the withdraw row gets refunded when a real `payout.failed` is triggered
- [ ] Confirm the Stripe USD float strategy (Stripe Checkout deposits as float) is in place before high-volume launch