### PR TITLE
feat: disaggregated computation — worker capabilities and prefill offloading

### DIFF
--- a/coordinator/internal/api/provider.go
+++ b/coordinator/internal/api/provider.go
@@ -280,6 +280,10 @@ func (s *Server) providerReadLoop(ctx context.Context, conn *websocket.Conn, pro
 			igMsg := msg.Payload.(*protocol.ImageGenerationCompleteMessage)
 			s.handleImageGenerationComplete(providerID, provider, igMsg)
 
+		case protocol.TypePrefillComplete:
+			pfMsg := msg.Payload.(*protocol.PrefillCompleteMessage)
+			s.handlePrefillComplete(providerID, provider, pfMsg)
+
 		case protocol.TypeAttestationResponse:
 			respMsg := msg.Payload.(*protocol.AttestationResponseMessage)
 			s.handleAttestationResponse(providerID, provider, respMsg, tracker)
@@ -387,6 +391,41 @@ func (s *Server) sendChallenge(ctx context.Context, conn *websocket.Conn, provid
 		tracker.remove(nonce)
 		s.handleChallengeFailure(providerID, "timeout")
 	}
+}
+
+// handlePrefillComplete processes a prefill completion from a prefill worker.
+// The coordinator records the job success and marks the worker idle.
+func (s *Server) handlePrefillComplete(providerID string, provider *registry.Provider, msg *protocol.PrefillCompleteMessage) {
+	if provider == nil {
+		s.logger.Warn("prefill complete from unregistered provider", "provider_id", providerID)
+		return
+	}
+	pr := provider.RemovePending(msg.RequestID)
+	if pr == nil {
+		s.logger.Warn("prefill complete for unknown request", "provider_id", providerID, "request_id", msg.RequestID)
+		return
+	}
+
+	responseTime := time.Duration(msg.DurationSecs * float64(time.Second))
+	s.registry.RecordJobSuccess(providerID, responseTime)
+
+	// Signal the consumer handler that prefill is done so it can
+	// dispatch the decode phase to the full-inference provider.
+	if pr.CompleteCh != nil {
+		select {
+		case pr.CompleteCh <- protocol.UsageInfo{PromptTokens: msg.PromptTokens}:
+		default:
+		}
+	}
+
+	s.registry.SetProviderIdle(providerID)
+
+	s.logger.Info("prefill complete",
+		"request_id", msg.RequestID,
+		"provider_id", providerID,
+		"prompt_tokens", msg.PromptTokens,
+		"duration_secs", msg.DurationSecs,
+	)
 }
 
 // handleAttestationResponse processes an attestation response from a provider.

--- a/coordinator/internal/api/stats.go
+++ b/coordinator/internal/api/stats.go
@@ -166,5 +166,10 @@ func (s *Server) handleStats(w http.ResponseWriter, r *http.Request) {
 		"providers":               providers,
 		"models":                  models,
 		"time_series":             timeSeries,
+		"disaggregated_compute": map[string]any{
+			"prefill_workers":        s.registry.PrefillWorkerCount(),
+			"prefill_only_workers":   s.registry.PrefillOnlyWorkerCount(),
+			"full_inference_workers": s.registry.FullInferenceWorkerCount(),
+		},
 	})
 }

--- a/coordinator/internal/protocol/messages.go
+++ b/coordinator/internal/protocol/messages.go
@@ -37,6 +37,7 @@ const (
 	TypeAttestationResponse     = "attestation_response"
 	TypeTranscriptionComplete   = "transcription_complete"
 	TypeImageGenerationComplete = "image_generation_complete"
+	TypePrefillComplete         = "prefill_complete"
 
 	// Coordinator → Provider
 	TypeInferenceRequest       = "inference_request"
@@ -45,6 +46,7 @@ const (
 	TypeTranscriptionRequest   = "transcription_request"
 	TypeImageGenerationRequest = "image_generation_request"
 	TypeRuntimeStatus          = "runtime_status"
+	TypePrefillRequest         = "prefill_request"
 )
 
 // ---------------------------------------------------------------------------
@@ -81,6 +83,36 @@ type ModelInfo struct {
 }
 
 // ---------------------------------------------------------------------------
+// Worker Capabilities — disaggregated computation
+// ---------------------------------------------------------------------------
+
+// WorkerCapabilities describes what roles a provider can perform. Capabilities
+// are auto-detected from hardware at registration time. Small machines (≤16GB,
+// low bandwidth) can serve as prefill workers for prompt processing without
+// running full decode, giving every machine useful work to do.
+type WorkerCapabilities struct {
+	// CanFullInference is true when the provider can run complete inference
+	// (prefill + decode) for its listed models. All Pro/Max/Ultra chips or
+	// machines with ≥24GB can do this.
+	CanFullInference bool `json:"can_full_inference"`
+
+	// CanPrefill is true when the provider can process prompts and return KV
+	// cache or token logits. Useful for offloading the compute-bound prefill
+	// phase from larger machines. Nearly all Apple Silicon machines can do this.
+	CanPrefill bool `json:"can_prefill"`
+
+	// MaxModelSizeGB is the largest model (in GB) this provider can load, based
+	// on available memory after OS reserve. The coordinator uses this to assign
+	// appropriately-sized models.
+	MaxModelSizeGB float64 `json:"max_model_size_gb"`
+
+	// PrefillModels lists model IDs this provider can prefill for. These are
+	// typically smaller quantized models that fit in the provider's memory.
+	// Empty means the provider can prefill for any model it has downloaded.
+	PrefillModels []string `json:"prefill_models,omitempty"`
+}
+
+// ---------------------------------------------------------------------------
 // Provider → Coordinator messages
 // ---------------------------------------------------------------------------
 
@@ -97,6 +129,9 @@ type RegisterMessage struct {
 	PrefillTPS    float64         `json:"prefill_tps,omitempty"`    // benchmark: prefill tokens per second
 	DecodeTPS     float64         `json:"decode_tps,omitempty"`     // benchmark: decode tokens per second
 	AuthToken     string          `json:"auth_token,omitempty"`     // device-linked provider token (from darkbloom login)
+
+	// Worker capabilities for disaggregated inference.
+	WorkerCapabilities *WorkerCapabilities `json:"worker_capabilities,omitempty"`
 
 	// Runtime integrity hashes — used for runtime verification against known-good manifests.
 	PythonHash      string            `json:"python_hash,omitempty"`       // SHA-256 of Python runtime
@@ -271,6 +306,40 @@ type AttestationResponseMessage struct {
 	GrpcBinaryHash  string            `json:"grpc_binary_hash,omitempty"`  // SHA-256 of gRPCServerCLI binary
 	ImageBridgeHash string            `json:"image_bridge_hash,omitempty"` // SHA-256 of image bridge Python source
 	ModelHashes     map[string]string `json:"model_hashes,omitempty"`      // model_id -> SHA-256 weight hash (all active models)
+}
+
+// ---------------------------------------------------------------------------
+// Disaggregated Inference messages — prefill offloading
+// ---------------------------------------------------------------------------
+
+// PrefillRequestBody describes a prefill-only job. The prefill worker processes
+// the prompt and returns token logits or a KV summary that the decode worker
+// can use to skip the prefill phase.
+type PrefillRequestBody struct {
+	Model       string        `json:"model"`
+	Messages    []ChatMessage `json:"messages"`
+	MaxTokens   *int          `json:"max_tokens,omitempty"`
+	Temperature *float64      `json:"temperature,omitempty"`
+}
+
+// PrefillRequestMessage tells a prefill worker to process a prompt.
+// The coordinator sends this to small machines that can handle the compute-bound
+// prefill phase. Results are relayed to the decode worker for token generation.
+type PrefillRequestMessage struct {
+	Type          string             `json:"type"`
+	RequestID     string             `json:"request_id"`
+	Body          PrefillRequestBody `json:"body,omitempty"`
+	EncryptedBody *EncryptedPayload  `json:"encrypted_body,omitempty"`
+}
+
+// PrefillCompleteMessage is sent by the prefill worker when prompt processing
+// is done. The coordinator can use prompt_tokens for billing and relay metadata
+// to the decode worker.
+type PrefillCompleteMessage struct {
+	Type         string  `json:"type"`
+	RequestID    string  `json:"request_id"`
+	PromptTokens int     `json:"prompt_tokens"`
+	DurationSecs float64 `json:"duration_secs"`
 }
 
 // ---------------------------------------------------------------------------
@@ -469,6 +538,13 @@ func (pm *ProviderMessage) UnmarshalJSON(data []byte) error {
 		var msg ImageGenerationCompleteMessage
 		if err := json.Unmarshal(data, &msg); err != nil {
 			return fmt.Errorf("protocol: failed to unmarshal image_generation_complete: %w", err)
+		}
+		pm.Payload = &msg
+
+	case TypePrefillComplete:
+		var msg PrefillCompleteMessage
+		if err := json.Unmarshal(data, &msg); err != nil {
+			return fmt.Errorf("protocol: failed to unmarshal prefill_complete: %w", err)
 		}
 		pm.Payload = &msg
 

--- a/coordinator/internal/protocol/messages_test.go
+++ b/coordinator/internal/protocol/messages_test.go
@@ -781,3 +781,150 @@ func TestProviderMessageUnmarshalHeartbeatWithoutCapacity(t *testing.T) {
 		t.Error("backend_capacity should be nil for old providers")
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Disaggregated computation message tests
+// ---------------------------------------------------------------------------
+
+func TestWorkerCapabilitiesSerialization(t *testing.T) {
+	caps := WorkerCapabilities{
+		CanFullInference: true,
+		CanPrefill:       true,
+		MaxModelSizeGB:   60.0,
+		PrefillModels:    []string{"model-a", "model-b"},
+	}
+
+	data, err := json.Marshal(caps)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var decoded WorkerCapabilities
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if decoded.CanFullInference != true {
+		t.Error("CanFullInference should be true")
+	}
+	if decoded.MaxModelSizeGB != 60.0 {
+		t.Errorf("MaxModelSizeGB = %f, want 60.0", decoded.MaxModelSizeGB)
+	}
+	if len(decoded.PrefillModels) != 2 {
+		t.Errorf("PrefillModels length = %d, want 2", len(decoded.PrefillModels))
+	}
+}
+
+func TestRegisterMessageWithWorkerCapabilities(t *testing.T) {
+	msg := RegisterMessage{
+		Type: TypeRegister,
+		Hardware: Hardware{
+			ChipName: "Apple M2",
+			MemoryGB: 16,
+		},
+		Models:  []ModelInfo{{ID: "test-model"}},
+		Backend: "vllm_mlx",
+		WorkerCapabilities: &WorkerCapabilities{
+			CanFullInference: false,
+			CanPrefill:       true,
+			MaxModelSizeGB:   12.0,
+		},
+	}
+
+	data, err := json.Marshal(msg)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var pm ProviderMessage
+	if err := json.Unmarshal(data, &pm); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	reg := pm.Payload.(*RegisterMessage)
+	if reg.WorkerCapabilities == nil {
+		t.Fatal("WorkerCapabilities should not be nil")
+	}
+	if reg.WorkerCapabilities.CanFullInference {
+		t.Error("CanFullInference should be false for small machine")
+	}
+	if !reg.WorkerCapabilities.CanPrefill {
+		t.Error("CanPrefill should be true")
+	}
+}
+
+func TestRegisterMessageWithoutWorkerCapabilities(t *testing.T) {
+	msg := RegisterMessage{
+		Type:    TypeRegister,
+		Hardware: Hardware{ChipName: "Apple M4 Max", MemoryGB: 128},
+		Models:  []ModelInfo{{ID: "test-model"}},
+		Backend: "vllm_mlx",
+	}
+
+	data, err := json.Marshal(msg)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var pm ProviderMessage
+	if err := json.Unmarshal(data, &pm); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	reg := pm.Payload.(*RegisterMessage)
+	if reg.WorkerCapabilities != nil {
+		t.Error("WorkerCapabilities should be nil when not set")
+	}
+}
+
+func TestPrefillCompleteUnmarshal(t *testing.T) {
+	raw := `{"type":"prefill_complete","request_id":"req-123","prompt_tokens":512,"duration_secs":1.5}`
+
+	var pm ProviderMessage
+	if err := json.Unmarshal([]byte(raw), &pm); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if pm.Type != TypePrefillComplete {
+		t.Errorf("type = %q, want %q", pm.Type, TypePrefillComplete)
+	}
+
+	msg := pm.Payload.(*PrefillCompleteMessage)
+	if msg.RequestID != "req-123" {
+		t.Errorf("RequestID = %q, want %q", msg.RequestID, "req-123")
+	}
+	if msg.PromptTokens != 512 {
+		t.Errorf("PromptTokens = %d, want 512", msg.PromptTokens)
+	}
+	if msg.DurationSecs != 1.5 {
+		t.Errorf("DurationSecs = %f, want 1.5", msg.DurationSecs)
+	}
+}
+
+func TestPrefillRequestMarshal(t *testing.T) {
+	msg := PrefillRequestMessage{
+		Type:      TypePrefillRequest,
+		RequestID: "prefill-001",
+		Body: PrefillRequestBody{
+			Model: "test-model",
+			Messages: []ChatMessage{
+				{Role: "user", Content: "hello world"},
+			},
+		},
+	}
+
+	data, err := json.Marshal(msg)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var parsed map[string]any
+	json.Unmarshal(data, &parsed)
+
+	if parsed["type"] != TypePrefillRequest {
+		t.Errorf("type = %v, want %v", parsed["type"], TypePrefillRequest)
+	}
+	if parsed["request_id"] != "prefill-001" {
+		t.Errorf("request_id = %v, want prefill-001", parsed["request_id"])
+	}
+}

--- a/coordinator/internal/registry/registry.go
+++ b/coordinator/internal/registry/registry.go
@@ -113,6 +113,9 @@ type Provider struct {
 	PrefillTPS float64 // prefill tokens per second
 	DecodeTPS  float64 // decode tokens per second
 
+	// Disaggregated compute capabilities (auto-detected from hardware)
+	WorkerCapabilities *protocol.WorkerCapabilities
+
 	// Warm model cache tracking
 	WarmModels   []string // models currently loaded in provider's memory
 	CurrentModel string   // model currently being served
@@ -608,27 +611,45 @@ func (r *Registry) Register(id string, conn *websocket.Conn, msg *protocol.Regis
 		}
 	}
 
+	// Derive worker capabilities from hardware if the provider didn't send them.
+	caps := msg.WorkerCapabilities
+	if caps == nil {
+		caps = deriveWorkerCapabilities(msg.Hardware)
+	}
+
 	p := &Provider{
-		ID:              id,
-		Hardware:        msg.Hardware,
-		Models:          models,
-		Backend:         msg.Backend,
-		PublicKey:       pubKey,
-		WalletAddress:   msg.WalletAddress,
-		PrefillTPS:      msg.PrefillTPS,
-		DecodeTPS:       msg.DecodeTPS,
-		TrustLevel:      TrustNone,
-		RuntimeVerified: true, // default to verified; API layer sets false when manifest check fails
-		Status:          StatusOnline,
-		Conn:            conn,
-		LastHeartbeat:   time.Now(),
-		Reputation:      NewReputation(),
-		pendingReqs:     make(map[string]*PendingRequest),
+		ID:                 id,
+		Hardware:           msg.Hardware,
+		Models:             models,
+		Backend:            msg.Backend,
+		PublicKey:          pubKey,
+		WalletAddress:      msg.WalletAddress,
+		PrefillTPS:         msg.PrefillTPS,
+		DecodeTPS:          msg.DecodeTPS,
+		WorkerCapabilities: caps,
+		TrustLevel:         TrustNone,
+		RuntimeVerified:    true, // default to verified; API layer sets false when manifest check fails
+		Status:             StatusOnline,
+		Conn:               conn,
+		LastHeartbeat:      time.Now(),
+		Reputation:         NewReputation(),
+		pendingReqs:        make(map[string]*PendingRequest),
 	}
 
 	r.mu.Lock()
 	r.providers[id] = p
 	r.mu.Unlock()
+
+	capStr := "none"
+	if caps != nil {
+		if caps.CanFullInference && caps.CanPrefill {
+			capStr = "full+prefill"
+		} else if caps.CanFullInference {
+			capStr = "full"
+		} else if caps.CanPrefill {
+			capStr = "prefill-only"
+		}
+	}
 
 	r.logger.Info("provider registered",
 		"provider_id", id,
@@ -638,6 +659,7 @@ func (r *Registry) Register(id string, conn *websocket.Conn, msg *protocol.Regis
 		"backend", msg.Backend,
 		"prefill_tps", msg.PrefillTPS,
 		"decode_tps", msg.DecodeTPS,
+		"capabilities", capStr,
 	)
 
 	// Persist provider record to store (async).
@@ -1374,4 +1396,207 @@ func (r *Registry) evictStale(timeout time.Duration) {
 		r.logger.Warn("evicting stale provider", "provider_id", id, "timeout", timeout)
 		r.Disconnect(id)
 	}
+}
+
+// ---------------------------------------------------------------------------
+// Disaggregated computation — worker capability derivation and routing
+// ---------------------------------------------------------------------------
+
+// deriveWorkerCapabilities computes worker capabilities from hardware info.
+// Small machines (≤16GB, base-tier chips) become prefill-only workers.
+// Larger machines do full inference and can also accept prefill jobs.
+func deriveWorkerCapabilities(hw protocol.Hardware) *protocol.WorkerCapabilities {
+	memGB := hw.MemoryGB
+	availGB := float64(memGB) - 4.0 // OS reserve
+	if availGB < 0 {
+		availGB = 0
+	}
+
+	// All Apple Silicon can prefill (it's just prompt processing).
+	canPrefill := memGB >= 8
+
+	// Full inference requires enough memory for model + KV cache + decode.
+	// ≥24GB can run 7B-class models well; ≥16GB can run smaller quantized models.
+	canFull := memGB >= 16
+
+	// Higher-bandwidth chips are better at decode (memory-bound).
+	// Base-tier M-series (Air-class, 100-120 GB/s) are poor at decode
+	// but acceptable for prefill. For machines with very low bandwidth
+	// and limited memory, prefer prefill-only role.
+	bw := float64(hw.MemoryBandwidthGBs)
+	if memGB <= 16 && bw < 150 {
+		canFull = false
+	}
+
+	return &protocol.WorkerCapabilities{
+		CanFullInference: canFull,
+		CanPrefill:       canPrefill,
+		MaxModelSizeGB:   availGB,
+	}
+}
+
+// ReservePrefillWorker selects a provider capable of prefill work for the given
+// model. Prefers providers that are prefill-only (small machines) to avoid
+// consuming full-inference capacity. Falls back to full-inference providers
+// if no dedicated prefill workers are available.
+func (r *Registry) ReservePrefillWorker(model string, pr *PendingRequest, excludeIDs ...string) *Provider {
+	if pr == nil || pr.RequestID == "" {
+		return nil
+	}
+	if pr.Model == "" {
+		pr.Model = model
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	excludeSet := make(map[string]struct{}, len(excludeIDs))
+	for _, id := range excludeIDs {
+		excludeSet[id] = struct{}{}
+	}
+
+	now := time.Now()
+
+	// Phase 1: prefer prefill-only workers (small machines not used for full inference).
+	var prefillOnly []*Provider
+	var fullCapable []*Provider
+
+	for _, p := range r.providers {
+		if _, excluded := excludeSet[p.ID]; excluded {
+			continue
+		}
+		p.mu.Lock()
+		if p.Status == StatusOffline || p.Status == StatusUntrusted {
+			p.mu.Unlock()
+			continue
+		}
+		if !p.RuntimeVerified {
+			p.mu.Unlock()
+			continue
+		}
+		if p.LastChallengeVerified.IsZero() || now.Sub(p.LastChallengeVerified) > challengeFreshnessMaxAge {
+			p.mu.Unlock()
+			continue
+		}
+		if trustRank(p.TrustLevel) < trustRank(r.MinTrustLevel) {
+			p.mu.Unlock()
+			continue
+		}
+		if p.pendingCount() >= p.maxConcurrency() {
+			p.mu.Unlock()
+			continue
+		}
+
+		caps := p.WorkerCapabilities
+		p.mu.Unlock()
+
+		if caps == nil {
+			continue
+		}
+		if !caps.CanPrefill {
+			continue
+		}
+
+		// Check if provider has this model or can prefill for it.
+		canServe := providerServesModelLocked(p, model)
+		if !canServe && len(caps.PrefillModels) > 0 {
+			for _, pm := range caps.PrefillModels {
+				if pm == model {
+					canServe = true
+					break
+				}
+			}
+		}
+		if !canServe {
+			continue
+		}
+
+		if !caps.CanFullInference {
+			prefillOnly = append(prefillOnly, p)
+		} else {
+			fullCapable = append(fullCapable, p)
+		}
+	}
+
+	// Pick from prefill-only workers first, then full-capable.
+	candidates := prefillOnly
+	if len(candidates) == 0 {
+		candidates = fullCapable
+	}
+	if len(candidates) == 0 {
+		return nil
+	}
+
+	// Among candidates, pick the one with fewest pending requests.
+	best := candidates[0]
+	bestPending := best.PendingCount()
+	for _, c := range candidates[1:] {
+		cp := c.PendingCount()
+		if cp < bestPending {
+			best = c
+			bestPending = cp
+		}
+	}
+
+	best.mu.Lock()
+	defer best.mu.Unlock()
+	pr.ProviderID = best.ID
+	best.addPendingLocked(pr)
+	if best.Status != StatusUntrusted && best.Status != StatusOffline {
+		best.Status = StatusServing
+	}
+	return best
+}
+
+// PrefillWorkerCount returns the number of connected providers that can do prefill work.
+func (r *Registry) PrefillWorkerCount() int {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	count := 0
+	for _, p := range r.providers {
+		p.mu.Lock()
+		caps := p.WorkerCapabilities
+		status := p.Status
+		p.mu.Unlock()
+		if caps != nil && caps.CanPrefill && status != StatusOffline && status != StatusUntrusted {
+			count++
+		}
+	}
+	return count
+}
+
+// PrefillOnlyWorkerCount returns the number of connected providers that can
+// ONLY do prefill (not full inference). These are the small machines.
+func (r *Registry) PrefillOnlyWorkerCount() int {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	count := 0
+	for _, p := range r.providers {
+		p.mu.Lock()
+		caps := p.WorkerCapabilities
+		status := p.Status
+		p.mu.Unlock()
+		if caps != nil && caps.CanPrefill && !caps.CanFullInference && status != StatusOffline && status != StatusUntrusted {
+			count++
+		}
+	}
+	return count
+}
+
+// FullInferenceWorkerCount returns the number of connected providers that
+// can do full inference (prefill + decode).
+func (r *Registry) FullInferenceWorkerCount() int {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	count := 0
+	for _, p := range r.providers {
+		p.mu.Lock()
+		caps := p.WorkerCapabilities
+		status := p.Status
+		p.mu.Unlock()
+		if caps != nil && caps.CanFullInference && status != StatusOffline && status != StatusUntrusted {
+			count++
+		}
+	}
+	return count
 }

--- a/coordinator/internal/registry/registry_test.go
+++ b/coordinator/internal/registry/registry_test.go
@@ -2250,3 +2250,305 @@ func TestFindProviderCrashedOnlyStillRoutes(t *testing.T) {
 		t.Error("FindProvider should still route to a crashed-only provider (it can attempt reload)")
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Disaggregated computation tests
+// ---------------------------------------------------------------------------
+
+func TestDeriveWorkerCapabilities_LargeMachine(t *testing.T) {
+	hw := protocol.Hardware{
+		MemoryGB:           128,
+		MemoryBandwidthGBs: 546,
+	}
+	caps := deriveWorkerCapabilities(hw)
+
+	if !caps.CanFullInference {
+		t.Error("128GB machine should be capable of full inference")
+	}
+	if !caps.CanPrefill {
+		t.Error("128GB machine should be capable of prefill")
+	}
+	if caps.MaxModelSizeGB != 124 {
+		t.Errorf("expected MaxModelSizeGB=124, got %v", caps.MaxModelSizeGB)
+	}
+}
+
+func TestDeriveWorkerCapabilities_SmallAir(t *testing.T) {
+	hw := protocol.Hardware{
+		MemoryGB:           16,
+		MemoryBandwidthGBs: 100,
+	}
+	caps := deriveWorkerCapabilities(hw)
+
+	if caps.CanFullInference {
+		t.Error("16GB Air with 100 GB/s should NOT do full inference")
+	}
+	if !caps.CanPrefill {
+		t.Error("16GB Air should be capable of prefill")
+	}
+	if caps.MaxModelSizeGB != 12 {
+		t.Errorf("expected MaxModelSizeGB=12, got %v", caps.MaxModelSizeGB)
+	}
+}
+
+func TestDeriveWorkerCapabilities_8GBMachine(t *testing.T) {
+	hw := protocol.Hardware{
+		MemoryGB:           8,
+		MemoryBandwidthGBs: 68,
+	}
+	caps := deriveWorkerCapabilities(hw)
+
+	if caps.CanFullInference {
+		t.Error("8GB machine should NOT do full inference")
+	}
+	if !caps.CanPrefill {
+		t.Error("8GB machine should be capable of prefill")
+	}
+}
+
+func TestDeriveWorkerCapabilities_24GBPro(t *testing.T) {
+	hw := protocol.Hardware{
+		MemoryGB:           24,
+		MemoryBandwidthGBs: 200,
+	}
+	caps := deriveWorkerCapabilities(hw)
+
+	if !caps.CanFullInference {
+		t.Error("24GB Pro should be capable of full inference")
+	}
+	if !caps.CanPrefill {
+		t.Error("24GB Pro should be capable of prefill")
+	}
+}
+
+func TestDeriveWorkerCapabilities_TinyMachine(t *testing.T) {
+	hw := protocol.Hardware{
+		MemoryGB:           4,
+		MemoryBandwidthGBs: 50,
+	}
+	caps := deriveWorkerCapabilities(hw)
+
+	if caps.CanPrefill {
+		t.Error("4GB machine too small for prefill")
+	}
+	if caps.CanFullInference {
+		t.Error("4GB machine too small for full inference")
+	}
+}
+
+func TestRegisterAssignsWorkerCapabilities(t *testing.T) {
+	reg := New(testLogger())
+	reg.MinTrustLevel = TrustNone
+
+	msg := &protocol.RegisterMessage{
+		Type: protocol.TypeRegister,
+		Hardware: protocol.Hardware{
+			MemoryGB:           16,
+			MemoryBandwidthGBs: 100,
+		},
+		Models:  []protocol.ModelInfo{{ID: "test-model"}},
+		Backend: "vllm_mlx",
+	}
+
+	p := reg.Register("small-air", nil, msg)
+	if p.WorkerCapabilities == nil {
+		t.Fatal("WorkerCapabilities should be set after registration")
+	}
+	if p.WorkerCapabilities.CanFullInference {
+		t.Error("16GB Air should not have CanFullInference")
+	}
+	if !p.WorkerCapabilities.CanPrefill {
+		t.Error("16GB Air should have CanPrefill")
+	}
+}
+
+func TestRegisterPreservesExplicitCapabilities(t *testing.T) {
+	reg := New(testLogger())
+	reg.MinTrustLevel = TrustNone
+
+	caps := &protocol.WorkerCapabilities{
+		CanFullInference: true,
+		CanPrefill:       true,
+		MaxModelSizeGB:   100,
+	}
+	msg := &protocol.RegisterMessage{
+		Type: protocol.TypeRegister,
+		Hardware: protocol.Hardware{
+			MemoryGB:           16,
+			MemoryBandwidthGBs: 100,
+		},
+		Models:             []protocol.ModelInfo{{ID: "test-model"}},
+		Backend:            "vllm_mlx",
+		WorkerCapabilities: caps,
+	}
+
+	p := reg.Register("explicit", nil, msg)
+	if !p.WorkerCapabilities.CanFullInference {
+		t.Error("explicit capabilities should be preserved")
+	}
+	if p.WorkerCapabilities.MaxModelSizeGB != 100 {
+		t.Errorf("expected MaxModelSizeGB=100, got %v", p.WorkerCapabilities.MaxModelSizeGB)
+	}
+}
+
+func TestPrefillWorkerCount(t *testing.T) {
+	reg := New(testLogger())
+	reg.MinTrustLevel = TrustNone
+
+	// Register a full-capable provider
+	fullMsg := &protocol.RegisterMessage{
+		Hardware: protocol.Hardware{MemoryGB: 64, MemoryBandwidthGBs: 400},
+		Models:   []protocol.ModelInfo{{ID: "model-a"}},
+		Backend:  "vllm_mlx",
+	}
+	reg.Register("full-1", nil, fullMsg)
+
+	// Register a prefill-only provider
+	airMsg := &protocol.RegisterMessage{
+		Hardware: protocol.Hardware{MemoryGB: 16, MemoryBandwidthGBs: 100},
+		Models:   []protocol.ModelInfo{{ID: "model-a"}},
+		Backend:  "vllm_mlx",
+	}
+	reg.Register("air-1", nil, airMsg)
+
+	if got := reg.PrefillWorkerCount(); got != 2 {
+		t.Errorf("PrefillWorkerCount = %d, want 2 (both can prefill)", got)
+	}
+	if got := reg.PrefillOnlyWorkerCount(); got != 1 {
+		t.Errorf("PrefillOnlyWorkerCount = %d, want 1", got)
+	}
+	if got := reg.FullInferenceWorkerCount(); got != 1 {
+		t.Errorf("FullInferenceWorkerCount = %d, want 1", got)
+	}
+}
+
+func TestReservePrefillWorker_PrefersPrefillOnly(t *testing.T) {
+	reg := New(testLogger())
+	reg.MinTrustLevel = TrustNone
+	model := "test-model"
+
+	// Register full-capable provider
+	fullMsg := &protocol.RegisterMessage{
+		Hardware: protocol.Hardware{MemoryGB: 64, MemoryBandwidthGBs: 400},
+		Models:   []protocol.ModelInfo{{ID: model}},
+		Backend:  "vllm_mlx",
+	}
+	fullP := reg.Register("full-1", nil, fullMsg)
+	fullP.TrustLevel = TrustHardware
+	fullP.LastChallengeVerified = time.Now()
+	fullP.RuntimeVerified = true
+
+	// Register prefill-only provider (small air)
+	airMsg := &protocol.RegisterMessage{
+		Hardware: protocol.Hardware{MemoryGB: 16, MemoryBandwidthGBs: 100},
+		Models:   []protocol.ModelInfo{{ID: model}},
+		Backend:  "vllm_mlx",
+	}
+	airP := reg.Register("air-1", nil, airMsg)
+	airP.TrustLevel = TrustHardware
+	airP.LastChallengeVerified = time.Now()
+	airP.RuntimeVerified = true
+
+	pr := &PendingRequest{
+		RequestID: "prefill-req-1",
+		Model:     model,
+		ChunkCh:   make(chan string, 1),
+		CompleteCh: make(chan protocol.UsageInfo, 1),
+		ErrorCh:   make(chan protocol.InferenceErrorMessage, 1),
+	}
+
+	selected := reg.ReservePrefillWorker(model, pr)
+	if selected == nil {
+		t.Fatal("should have selected a prefill worker")
+	}
+	if selected.ID != "air-1" {
+		t.Errorf("should prefer prefill-only worker, got %s", selected.ID)
+	}
+}
+
+func TestReservePrefillWorker_FallsBackToFull(t *testing.T) {
+	reg := New(testLogger())
+	reg.MinTrustLevel = TrustNone
+	model := "test-model"
+
+	// Only register a full-capable provider (no dedicated prefill workers)
+	fullMsg := &protocol.RegisterMessage{
+		Hardware: protocol.Hardware{MemoryGB: 64, MemoryBandwidthGBs: 400},
+		Models:   []protocol.ModelInfo{{ID: model}},
+		Backend:  "vllm_mlx",
+	}
+	fullP := reg.Register("full-1", nil, fullMsg)
+	fullP.TrustLevel = TrustHardware
+	fullP.LastChallengeVerified = time.Now()
+	fullP.RuntimeVerified = true
+
+	pr := &PendingRequest{
+		RequestID: "prefill-req-2",
+		Model:     model,
+		ChunkCh:   make(chan string, 1),
+		CompleteCh: make(chan protocol.UsageInfo, 1),
+		ErrorCh:   make(chan protocol.InferenceErrorMessage, 1),
+	}
+
+	selected := reg.ReservePrefillWorker(model, pr)
+	if selected == nil {
+		t.Fatal("should fall back to full-capable provider")
+	}
+	if selected.ID != "full-1" {
+		t.Errorf("expected full-1, got %s", selected.ID)
+	}
+}
+
+func TestReservePrefillWorker_ReturnsNilWhenNoneAvailable(t *testing.T) {
+	reg := New(testLogger())
+	reg.MinTrustLevel = TrustNone
+
+	pr := &PendingRequest{
+		RequestID: "prefill-req-3",
+		Model:     "model-x",
+		ChunkCh:   make(chan string, 1),
+		CompleteCh: make(chan protocol.UsageInfo, 1),
+		ErrorCh:   make(chan protocol.InferenceErrorMessage, 1),
+	}
+
+	selected := reg.ReservePrefillWorker("model-x", pr)
+	if selected != nil {
+		t.Error("should return nil when no providers available")
+	}
+}
+
+func TestReservePrefillWorker_ExcludesIDs(t *testing.T) {
+	reg := New(testLogger())
+	reg.MinTrustLevel = TrustNone
+	model := "test-model"
+
+	// Register two prefill-capable providers
+	for _, id := range []string{"air-1", "air-2"} {
+		msg := &protocol.RegisterMessage{
+			Hardware: protocol.Hardware{MemoryGB: 16, MemoryBandwidthGBs: 100},
+			Models:   []protocol.ModelInfo{{ID: model}},
+			Backend:  "vllm_mlx",
+		}
+		p := reg.Register(id, nil, msg)
+		p.TrustLevel = TrustHardware
+		p.LastChallengeVerified = time.Now()
+		p.RuntimeVerified = true
+	}
+
+	pr := &PendingRequest{
+		RequestID: "prefill-req-4",
+		Model:     model,
+		ChunkCh:   make(chan string, 1),
+		CompleteCh: make(chan protocol.UsageInfo, 1),
+		ErrorCh:   make(chan protocol.InferenceErrorMessage, 1),
+	}
+
+	// Exclude air-1, should get air-2
+	selected := reg.ReservePrefillWorker(model, pr, "air-1")
+	if selected == nil {
+		t.Fatal("should have selected air-2")
+	}
+	if selected.ID != "air-2" {
+		t.Errorf("expected air-2, got %s", selected.ID)
+	}
+}

--- a/provider/src/coordinator.rs
+++ b/provider/src/coordinator.rs
@@ -26,7 +26,7 @@ use crate::hardware::HardwareInfo;
 use crate::models::ModelInfo;
 use crate::protocol::{
     CoordinatorMessage, ImageGenerationRequestBody, ProviderMessage, ProviderStats, ProviderStatus,
-    TranscriptionRequestBody,
+    TranscriptionRequestBody, WorkerCapabilities,
 };
 use crate::security::RuntimeHashes;
 
@@ -63,6 +63,10 @@ pub enum CoordinatorEvent {
         request_id: String,
         body: ImageGenerationRequestBody,
         upload_url: String,
+    },
+    PrefillRequest {
+        request_id: String,
+        body: serde_json::Value,
     },
     Cancel {
         request_id: String,
@@ -106,6 +110,8 @@ pub struct CoordinatorClient {
     model_hashes: std::collections::HashMap<String, String>,
     /// Live backend capacity data (updated by main loop, read by heartbeat tick).
     backend_capacity: Arc<std::sync::Mutex<Option<crate::protocol::BackendCapacity>>>,
+    /// Worker capabilities for disaggregated inference (auto-detected from hardware).
+    worker_capabilities: Option<WorkerCapabilities>,
 }
 
 impl CoordinatorClient {
@@ -137,6 +143,7 @@ impl CoordinatorClient {
             runtime_hashes: None,
             model_hashes: std::collections::HashMap::new(),
             backend_capacity: Arc::new(std::sync::Mutex::new(None)),
+            worker_capabilities: None,
         }
     }
 
@@ -200,6 +207,12 @@ impl CoordinatorClient {
     /// Set runtime integrity hashes (Python, vllm_mlx, templates) for registration.
     pub fn with_runtime_hashes(mut self, hashes: Option<RuntimeHashes>) -> Self {
         self.runtime_hashes = hashes;
+        self
+    }
+
+    /// Set worker capabilities for disaggregated inference.
+    pub fn with_worker_capabilities(mut self, caps: Option<WorkerCapabilities>) -> Self {
+        self.worker_capabilities = caps;
         self
     }
 
@@ -299,6 +312,7 @@ impl CoordinatorClient {
             prefill_tps: None,
             decode_tps: None,
             auth_token: self.auth_token.clone(),
+            worker_capabilities: self.worker_capabilities.clone(),
             python_hash,
             runtime_hash,
             template_hashes,
@@ -469,6 +483,27 @@ impl CoordinatorClient {
                                             tracing::error!("Failed to parse image generation body: {e}");
                                         }
                                     }
+                                }
+                                Ok(CoordinatorMessage::PrefillRequest { request_id, body, encrypted_body }) => {
+                                    tracing::info!("Received prefill request: {request_id}");
+
+                                    let decrypted_body = if let Some(enc) = encrypted_body {
+                                        tracing::info!("Decrypting E2E encrypted prefill request");
+                                        match decrypt_request_body(&enc, self.node_keypair.as_ref()) {
+                                            Ok(b) => b,
+                                            Err(e) => {
+                                                tracing::error!("Failed to decrypt prefill request: {e}");
+                                                continue;
+                                            }
+                                        }
+                                    } else {
+                                        body
+                                    };
+
+                                    let _ = event_tx.send(CoordinatorEvent::PrefillRequest {
+                                        request_id,
+                                        body: decrypted_body,
+                                    }).await;
                                 }
                                 Ok(CoordinatorMessage::Cancel { request_id }) => {
                                     tracing::info!("Received cancel for: {request_id}");
@@ -712,6 +747,7 @@ pub fn build_register_message_with_wallet(
         prefill_tps: None,
         decode_tps: None,
         auth_token: None,
+        worker_capabilities: None,
         python_hash: None,
         runtime_hash: None,
         template_hashes: std::collections::HashMap::new(),

--- a/provider/src/crypto.rs
+++ b/provider/src/crypto.rs
@@ -150,13 +150,10 @@ pub fn legacy_enclave_e2e_key_paths() -> Vec<std::path::PathBuf> {
 }
 
 fn purge_legacy_e2e_files() {
-    for path in [
-        legacy_node_key_paths(),
-        legacy_enclave_e2e_key_paths(),
-    ]
-    .into_iter()
-    .flatten()
-    .filter(|path| path.exists())
+    for path in [legacy_node_key_paths(), legacy_enclave_e2e_key_paths()]
+        .into_iter()
+        .flatten()
+        .filter(|path| path.exists())
     {
         match std::fs::remove_file(&path) {
             Ok(()) => tracing::info!("Removed legacy E2E secret file: {}", path.display()),

--- a/provider/src/hardware.rs
+++ b/provider/src/hardware.rs
@@ -420,6 +420,34 @@ fn lookup_bandwidth(family: ChipFamily, tier: ChipTier, gpu_cores: u32) -> u32 {
 }
 
 // ---------------------------------------------------------------------------
+// Worker capability detection for disaggregated inference
+// ---------------------------------------------------------------------------
+
+/// Derive worker capabilities from hardware info. Small machines (≤16GB,
+/// base-tier with low bandwidth) serve as prefill-only workers. Larger machines
+/// handle full inference and can also accept prefill jobs.
+pub fn derive_worker_capabilities(hw: &HardwareInfo) -> crate::protocol::WorkerCapabilities {
+    let mem_gb = hw.memory_gb;
+    let avail_gb = if mem_gb > 4 { (mem_gb - 4) as f64 } else { 0.0 };
+
+    let can_prefill = mem_gb >= 8;
+
+    let bw = hw.memory_bandwidth_gbs as f64;
+    let can_full = if mem_gb <= 16 && bw < 150.0 {
+        false
+    } else {
+        mem_gb >= 16
+    };
+
+    crate::protocol::WorkerCapabilities {
+        can_full_inference: can_full,
+        can_prefill,
+        max_model_size_gb: avail_gb,
+        prefill_models: Vec::new(),
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Backend status polling (vllm-mlx /v1/status endpoint)
 // ---------------------------------------------------------------------------
 

--- a/provider/src/protocol.rs
+++ b/provider/src/protocol.rs
@@ -21,6 +21,18 @@ use crate::hardware::{HardwareInfo, SystemMetrics};
 use crate::models::ModelInfo;
 use serde::{Deserialize, Serialize};
 
+/// Worker capabilities for disaggregated inference. Auto-detected from hardware.
+/// Small machines (≤16GB, base-tier) serve as prefill workers; larger machines
+/// handle full inference (prefill + decode).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct WorkerCapabilities {
+    pub can_full_inference: bool,
+    pub can_prefill: bool,
+    pub max_model_size_gb: f64,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub prefill_models: Vec<String>,
+}
+
 /// Messages sent from provider to coordinator.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
@@ -53,6 +65,9 @@ pub enum ProviderMessage {
         /// When present, the coordinator links this provider to the token's account.
         #[serde(skip_serializing_if = "Option::is_none")]
         auth_token: Option<String>,
+        /// Worker capabilities for disaggregated inference.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        worker_capabilities: Option<WorkerCapabilities>,
         /// SHA-256 hash of the Python interpreter binary.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         python_hash: Option<String>,
@@ -122,6 +137,12 @@ pub enum ProviderMessage {
         request_id: String,
         usage: ImageGenerationUsage,
         /// Processing time in seconds.
+        duration_secs: f64,
+    },
+    /// Prefill-only job complete — prompt was processed, tokens counted.
+    PrefillComplete {
+        request_id: String,
+        prompt_tokens: u64,
         duration_secs: f64,
     },
     /// Response to an attestation challenge from the coordinator.
@@ -204,6 +225,15 @@ pub enum CoordinatorMessage {
         /// HTTP URL where the provider should POST generated image bytes.
         #[serde(default)]
         upload_url: String,
+        #[serde(default)]
+        body: serde_json::Value,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        encrypted_body: Option<EncryptedPayload>,
+    },
+    /// Prefill-only request — process the prompt and report token count.
+    /// Used for disaggregated inference where small machines handle prefill.
+    PrefillRequest {
+        request_id: String,
         #[serde(default)]
         body: serde_json::Value,
         #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/provider/src/secure_enclave_key.rs
+++ b/provider/src/secure_enclave_key.rs
@@ -17,10 +17,9 @@ use security_framework::{
 use security_framework_sys::{
     base::errSecItemNotFound,
     item::{
-        kSecAttrAccessControl, kSecAttrAccessGroup, kSecAttrIsPermanent,
-        kSecAttrKeySizeInBits, kSecAttrKeyType, kSecAttrKeyTypeECSECPrimeRandom,
-        kSecAttrLabel, kSecAttrTokenID, kSecAttrTokenIDSecureEnclave,
-        kSecPrivateKeyAttrs, kSecPublicKeyAttrs,
+        kSecAttrAccessControl, kSecAttrAccessGroup, kSecAttrIsPermanent, kSecAttrKeySizeInBits,
+        kSecAttrKeyType, kSecAttrKeyTypeECSECPrimeRandom, kSecAttrLabel, kSecAttrTokenID,
+        kSecAttrTokenIDSecureEnclave, kSecPrivateKeyAttrs, kSecPublicKeyAttrs,
     },
     key::SecKeyCreateRandomKey,
 };
@@ -36,9 +35,8 @@ pub(crate) fn load_existing_x25519_secret() -> Result<Option<[u8; 32]>> {
     let private_key = find_secure_enclave_key()?.ok_or_else(|| {
         anyhow!("wrapped text E2E secret exists but the Secure Enclave key is missing")
     })?;
-    let secret = unwrap_secret_with_private_key(&private_key, &sealed).context(
-        "wrapped text E2E secret is unreadable; refusing silent key rotation",
-    )?;
+    let secret = unwrap_secret_with_private_key(&private_key, &sealed)
+        .context("wrapped text E2E secret is unreadable; refusing silent key rotation")?;
     Ok(Some(secret))
 }
 
@@ -191,7 +189,9 @@ fn wrap_secret_with_public_key(private_key: &SecKey, secret: &[u8; 32]) -> Resul
     })?;
     public_key
         .encrypt_data(Algorithm::ECIESEncryptionStandardX963SHA256AESGCM, secret)
-        .map_err(|err| anyhow!("failed to seal X25519 secret with Secure Enclave public key: {err}"))
+        .map_err(|err| {
+            anyhow!("failed to seal X25519 secret with Secure Enclave public key: {err}")
+        })
 }
 
 fn unwrap_secret_with_private_key(private_key: &SecKey, sealed: &[u8]) -> Result<[u8; 32]> {
@@ -248,7 +248,8 @@ fn delete_wrapped_secret_file() -> Result<()> {
 }
 
 fn wrapped_secret_path() -> Result<std::path::PathBuf> {
-    let home = dirs::home_dir().context("could not determine home directory for wrapped E2E key")?;
+    let home =
+        dirs::home_dir().context("could not determine home directory for wrapped E2E key")?;
     Ok(home.join(".darkbloom").join(E2E_WRAPPED_SECRET_FILENAME))
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implement disaggregated computation so every machine in the network has useful work to do, including small Macs (Air, 16GB) that currently can't run full inference efficiently. Worker capabilities are auto-detected from hardware: small machines become prefill workers (compute-bound prompt processing), while larger machines handle full inference (memory-bandwidth-bound decode). The coordinator routes work based on capabilities, preferring dedicated prefill workers to avoid consuming full-inference capacity.

## Linked issue

N/A — new feature

## Test plan

- [x] `go test ./...` — all existing tests pass (68s API, 0.5s registry, 0s protocol, etc.)
- [x] `go test -run "Disaggregated|WorkerCap|Prefill|DeriveWorker"` — 16 new tests pass
- [x] `gofmt -l` — all modified Go files are properly formatted
- [x] `cargo fmt` — Rust files formatted
- [x] `cargo check` — Rust changes are syntactically correct (full build requires macOS)
- [x] Verified backward compatibility: old providers without `worker_capabilities` get them auto-derived from hardware

## Components touched

- [x] coordinator (Go)
- [x] provider (Rust)
- [ ] console-ui (Next.js)
- [ ] image-bridge (Python)
- [ ] app (macOS Swift)
- [ ] enclave (Swift)
- [ ] infra / CI / release
- [ ] docs

## Protocol / interface changes

- [x] Yes — described above and matching side updated

### New message types:
- `prefill_request` (Coordinator → Provider): tells a prefill worker to process a prompt
- `prefill_complete` (Provider → Coordinator): reports prefill completion with token count

### Extended messages:
- `register`: now includes optional `worker_capabilities` field
- Both Go (`coordinator/internal/protocol/messages.go`) and Rust (`provider/src/protocol.rs`) updated in sync

### New types:
- `WorkerCapabilities`: `can_full_inference`, `can_prefill`, `max_model_size_gb`, `prefill_models`

### API changes:
- `GET /v1/stats` response now includes `disaggregated_compute` section with worker counts

No version bump or migration needed — all changes are additive and backward compatible.

## Notes for reviewers

**First-principles design:**
- Prefill (prompt processing) is compute-bound — GPU cores matter, not memory bandwidth
- Decode (token generation) is memory-bandwidth-bound — needs fast memory (Pro/Max/Ultra chips)
- Small machines (Air, 16GB, 100 GB/s) are terrible at decode but have decent compute cores
- Solution: classify machines by capability and route work accordingly

**Hardware classification logic:**
- `≤16GB + <150 GB/s bandwidth` → prefill-only (Air-class, M1/M2/M3/M4 base)
- `≥16GB + ≥150 GB/s` or `≥24GB` → full inference (Pro/Max/Ultra)
- `≥8GB` → can always do prefill work
- `<8GB` → excluded from all work

**Routing:**
- `ReservePrefillWorker()` prefers prefill-only workers first, falls back to full-inference providers
- This ensures small machines get utilized without stealing capacity from decode-capable machines

**Follow-ups needed:**
- Provider main loop should handle `CoordinatorEvent::PrefillRequest` and run actual prefill via vllm-mlx
- Consumer handler can optionally split long-prompt requests into prefill + decode phases
- Console UI can show disaggregated worker stats on the dashboard
- Billing for prefill work (currently only full inference is billed)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1a06c6e3-b550-4914-bfae-9a35e5da5802"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1a06c6e3-b550-4914-bfae-9a35e5da5802"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

