### PR TITLE
Add internal contributor models for speculative compute

### DIFF
--- a/app/EigenInference/Sources/EigenInference/ModelCatalog.swift
+++ b/app/EigenInference/Sources/EigenInference/ModelCatalog.swift
@@ -33,6 +33,7 @@ enum ModelCatalog {
         Entry(id: "flux_2_klein_9b_q8p.ckpt", name: "FLUX.2 Klein 9B", modelType: "image", sizeGB: 13.0, architecture: "9B diffusion", description: "Higher quality image gen", minRAMGB: 24),
 
         // Text generation
+        Entry(id: "mlx-community/Qwen3.5-4B-4bit", name: "Qwen3.5 4B Contributor", modelType: "text", sizeGB: 4.0, architecture: "4B dense, draft contributor", description: "Internal draft model for disaggregated compute", minRAMGB: 16),
         Entry(id: "qwen3.5-27b-claude-opus-8bit", name: "Qwen3.5 27B Claude Opus", modelType: "text", sizeGB: 27.0, architecture: "27B dense, Claude Opus distilled", description: "Frontier quality reasoning", minRAMGB: 36),
         Entry(id: "mlx-community/Trinity-Mini-8bit", name: "Trinity Mini", modelType: "text", sizeGB: 26.0, architecture: "27B Adaptive MoE", description: "Fast agentic inference", minRAMGB: 48),
         Entry(id: "mlx-community/Qwen3.5-122B-A10B-8bit", name: "Qwen3.5 122B", modelType: "text", sizeGB: 122.0, architecture: "122B MoE, 10B active", description: "Best quality", minRAMGB: 128),
@@ -44,8 +45,7 @@ enum ModelCatalog {
         if ramGB >= 256 { return models.first { $0.id.contains("MiniMax") } }
         if ramGB >= 128 { return models.first { $0.id.contains("Qwen3.5-122B") } }
         if ramGB >= 36  { return models.first { $0.id.contains("qwen3.5-27b-claude-opus") } }
-        if ramGB >= 24  { return models.first { $0.id.contains("flux_2_klein_9b") } }
-        if ramGB >= 16  { return models.first { $0.id.contains("flux_2_klein_4b") } }
+        if ramGB >= 16  { return models.first { $0.id.contains("Qwen3.5-4B-4bit") } }
         return models.first { $0.id.contains("cohere-transcribe") }
     }
 

--- a/coordinator/cmd/coordinator/main.go
+++ b/coordinator/cmd/coordinator/main.go
@@ -397,14 +397,15 @@ func envOr(key, fallback string) string {
 	return fallback
 }
 
-// seedModelCatalog ensures all hardcoded models exist in the catalog.
-// On first startup it populates everything; on subsequent starts it adds
-// any new models that were added to the code but not yet in the DB.
+// seedModelCatalog syncs the built-in model catalog into the store.
+// Existing admin toggles like Active and previously registered weight hashes are
+// preserved, but built-in metadata such as contributor/speculation wiring is
+// refreshed so new routing features become active on upgrade.
 func seedModelCatalog(st store.Store, logger *slog.Logger) {
 	existing := st.ListSupportedModels()
-	existingIDs := make(map[string]bool, len(existing))
+	existingByID := make(map[string]store.SupportedModel, len(existing))
 	for _, m := range existing {
-		existingIDs[m.ID] = true
+		existingByID[m.ID] = m
 	}
 
 	models := []store.SupportedModel{
@@ -416,27 +417,29 @@ func seedModelCatalog(st store.Store, logger *slog.Logger) {
 		{ID: "flux_2_klein_9b_q8p.ckpt", S3Name: "flux-klein-9b-q8", DisplayName: "FLUX.2 Klein 9B", ModelType: "image", SizeGB: 17.4, Architecture: "9B diffusion + Qwen 8B encoder", Description: "Higher quality image gen", MinRAMGB: 32, Active: true},
 
 		// --- Text generation (8-bit quantization) ---
-		{ID: "qwen3.5-27b-claude-opus-8bit", S3Name: "qwen35-27b-claude-opus-8bit", DisplayName: "Qwen3.5 27B Claude Opus Distilled", ModelType: "text", SizeGB: 27.0, Architecture: "27B dense, Claude Opus distilled", Description: "Frontier quality reasoning", MinRAMGB: 36, Active: true},
+		{ID: "mlx-community/Qwen3.5-4B-4bit", S3Name: "Qwen3.5-4B-4bit", DisplayName: "Qwen3.5 4B Contributor", ModelType: "text", SizeGB: 4.0, Architecture: "4B dense", Description: "Internal draft model for disaggregated speculation", MinRAMGB: 16, Active: true, InternalOnly: true, SpeculationFamily: "qwen-chatml"},
+		{ID: "qwen3.5-27b-claude-opus-8bit", S3Name: "qwen35-27b-claude-opus-8bit", DisplayName: "Qwen3.5 27B Claude Opus Distilled", ModelType: "text", SizeGB: 27.0, Architecture: "27B dense, Claude Opus distilled", Description: "Frontier quality reasoning", MinRAMGB: 36, Active: true, SpeculationFamily: "qwen-chatml"},
 		{ID: "mlx-community/Trinity-Mini-8bit", S3Name: "Trinity-Mini-8bit", DisplayName: "Trinity Mini", ModelType: "text", SizeGB: 26.0, Architecture: "27B Adaptive MoE", Description: "Fast agentic inference", MinRAMGB: 48, Active: true},
 		{ID: "mlx-community/gemma-4-26b-a4b-it-8bit", S3Name: "gemma-4-26b-a4b-it-8bit", DisplayName: "Gemma 4 26B", ModelType: "text", SizeGB: 28.0, Architecture: "26B MoE, 4B active", Description: "Fast multimodal MoE", MinRAMGB: 36, Active: true},
-		{ID: "mlx-community/Qwen3.5-122B-A10B-8bit", S3Name: "Qwen3.5-122B-A10B-8bit", DisplayName: "Qwen3.5 122B", ModelType: "text", SizeGB: 122.0, Architecture: "122B MoE, 10B active", Description: "Best quality", MinRAMGB: 128, Active: true},
+		{ID: "mlx-community/Qwen3.5-122B-A10B-8bit", S3Name: "Qwen3.5-122B-A10B-8bit", DisplayName: "Qwen3.5 122B", ModelType: "text", SizeGB: 122.0, Architecture: "122B MoE, 10B active", Description: "Best quality", MinRAMGB: 128, Active: true, SpeculationFamily: "qwen-chatml"},
 		{ID: "mlx-community/MiniMax-M2.5-8bit", S3Name: "MiniMax-M2.5-8bit", DisplayName: "MiniMax M2.5", ModelType: "text", SizeGB: 243.0, Architecture: "239B MoE, 11B active", Description: "SOTA coding, 100 tok/s", MinRAMGB: 256, Active: true},
 	}
 
-	added := 0
+	synced := 0
 	for i := range models {
-		if existingIDs[models[i].ID] {
-			continue
+		if existing, ok := existingByID[models[i].ID]; ok {
+			// Preserve admin activation choice and any previously registered
+			// weight hash while refreshing built-in metadata.
+			models[i].Active = existing.Active
+			if models[i].WeightHash == "" {
+				models[i].WeightHash = existing.WeightHash
+			}
 		}
 		if err := st.SetSupportedModel(&models[i]); err != nil {
 			logger.Warn("failed to seed model", "id", models[i].ID, "error", err)
 		} else {
-			added++
+			synced++
 		}
 	}
-	if added > 0 {
-		logger.Info("new models added to catalog", "added", added, "total", len(existing)+added)
-	} else {
-		logger.Info("model catalog loaded", "count", len(existing))
-	}
+	logger.Info("model catalog synced", "synced", synced, "existing_before", len(existing))
 }

--- a/coordinator/internal/api/billing_handlers.go
+++ b/coordinator/internal/api/billing_handlers.go
@@ -900,6 +900,8 @@ func (s *Server) handleAdminDeleteModel(w http.ResponseWriter, r *http.Request) 
 
 // handleModelCatalog handles GET /v1/models/catalog.
 // Public endpoint — returns active models for providers and the install script.
+// Internal-only contributor models are included here so providers can download
+// and advertise them, but consumer-facing model lists hide them.
 func (s *Server) handleModelCatalog(w http.ResponseWriter, r *http.Request) {
 	allModels := s.store.ListSupportedModels()
 

--- a/coordinator/internal/api/consumer.go
+++ b/coordinator/internal/api/consumer.go
@@ -60,6 +60,11 @@ const (
 	firstChunkTimeout = 10 * time.Second
 )
 
+const (
+	speculationDraftTokenCount      = 8
+	speculationContributorPayoutBps = 2000 // 20% of normal provider payout
+)
+
 // chatCompletionRequest is the incoming OpenAI-compatible request body.
 // The consumer sends plain JSON — no encryption fields are needed because
 // TLS to the Confidential VM is the trust boundary.
@@ -181,6 +186,70 @@ func explicitMaxTokens(parsed map[string]any) int {
 	return 0
 }
 
+func isDeterministicSpeculationEligible(parsed map[string]any) bool {
+	if stream, ok := parsed["stream"].(bool); ok && stream {
+		return false
+	}
+	if _, ok := parsed["input"]; ok {
+		// Responses API has different output framing and tool semantics.
+		return false
+	}
+	if copies, ok := intFromRequestValue(parsed["n"]); ok && copies > 1 {
+		return false
+	}
+	if tools, ok := parsed["tools"]; ok {
+		if arr, ok := tools.([]any); ok && len(arr) > 0 {
+			return false
+		}
+	}
+	if toolChoice, ok := parsed["tool_choice"]; ok && toolChoice != nil {
+		return false
+	}
+	if responseFormat, ok := parsed["response_format"]; ok && responseFormat != nil {
+		return false
+	}
+	temperature, ok := parsed["temperature"].(float64)
+	if !ok || temperature != 0 {
+		return false
+	}
+	if topP, ok := parsed["top_p"].(float64); ok && topP != 1 {
+		return false
+	}
+	if stop, ok := parsed["stop"]; ok && stop != nil {
+		switch x := stop.(type) {
+		case string:
+			if x != "" {
+				return false
+			}
+		case []any:
+			if len(x) > 0 {
+				return false
+			}
+		default:
+			return false
+		}
+	}
+	for _, key := range []string{"presence_penalty", "frequency_penalty", "logit_bias"} {
+		if v, ok := parsed[key]; ok && v != nil {
+			return false
+		}
+	}
+	for _, key := range []string{"logprobs", "top_logprobs"} {
+		if v, ok := parsed[key]; ok && v != nil {
+			return false
+		}
+	}
+	if _, ok := parsed["seed"]; ok {
+		// vllm-mlx already supports deterministic temperature=0 without seed.
+		// Seeded requests can stay on the current direct path until verified.
+		return false
+	}
+	if messages, ok := parsed["messages"].([]any); ok && len(messages) > 0 {
+		return true
+	}
+	return false
+}
+
 // reservationCost is the pre-flight worst-case cost for a text inference
 // request. It mirrors the platform-price branch of handleComplete's billing
 // so the reservation covers any platform-level custom price for the model;
@@ -210,6 +279,762 @@ func ensureMaxTokensBound(parsed map[string]any, isResponsesAPI bool) bool {
 		parsed["max_tokens"] = defaultMaxOutputTokens
 	}
 	return true
+}
+
+type internalDispatchOptions struct {
+	providerID      string
+	model           string
+	rawBody         []byte
+	estimatedPrompt int
+	requestedMax    int
+	firstChunkWait  time.Duration
+	contextTimeout  time.Duration
+	internalOnly    bool
+}
+
+type internalDispatchResult struct {
+	provider   *registry.Provider
+	pending    *registry.PendingRequest
+	requestID  string
+	firstChunk string
+}
+
+type internalCompletionLogprobs struct {
+	Tokens      []string
+	TopLogprobs []map[string]float64
+	TextOffsets []int
+}
+
+type internalCompletionResponse struct {
+	Text         string
+	FinishReason string
+	Logprobs     internalCompletionLogprobs
+	Usage        protocol.UsageInfo
+}
+
+type internalTokenSpan struct {
+	Token       string
+	Offset      int
+	TopLogprobs map[string]float64
+}
+
+type speculativeContributorShare struct {
+	ProviderID     string
+	ProviderKey    string
+	AccountID      string
+	WalletAddress  string
+	AcceptedTokens int
+}
+
+type speculativeChatResult struct {
+	RequestID      string
+	TargetProvider *registry.Provider
+	Message        extractedMessage
+	Usage          protocol.UsageInfo
+	FinishReason   string
+}
+
+func (s *Server) dispatchInternalInference(ctx context.Context, opts internalDispatchOptions) (*internalDispatchResult, error) {
+	if opts.providerID == "" {
+		return nil, fmt.Errorf("provider_id is required")
+	}
+	if opts.model == "" {
+		return nil, fmt.Errorf("model is required")
+	}
+	if len(opts.rawBody) == 0 {
+		return nil, fmt.Errorf("raw body is required")
+	}
+	if opts.firstChunkWait <= 0 {
+		opts.firstChunkWait = firstChunkTimeout
+	}
+	if opts.contextTimeout <= 0 {
+		opts.contextTimeout = inferenceTimeout
+	}
+
+	provider := s.registry.GetProvider(opts.providerID)
+	if provider == nil {
+		return nil, fmt.Errorf("provider %q not found", opts.providerID)
+	}
+	if provider.PublicKey == "" {
+		return nil, fmt.Errorf("provider %q has no E2E public key", opts.providerID)
+	}
+
+	providerPubKey, err := e2e.ParsePublicKey(provider.PublicKey)
+	if err != nil {
+		return nil, fmt.Errorf("provider %q public key invalid: %w", opts.providerID, err)
+	}
+
+	sessionKeys, err := e2e.GenerateSessionKeys()
+	if err != nil {
+		return nil, fmt.Errorf("generate session keys: %w", err)
+	}
+	encrypted, err := e2e.Encrypt(opts.rawBody, providerPubKey, sessionKeys)
+	if err != nil {
+		return nil, fmt.Errorf("encrypt request: %w", err)
+	}
+
+	requestID := uuid.New().String()
+	pr := &registry.PendingRequest{
+		RequestID:             requestID,
+		Model:                 opts.model,
+		ConsumerKey:           "",
+		InternalOnly:          opts.internalOnly,
+		EstimatedPromptTokens: opts.estimatedPrompt,
+		RequestedMaxTokens:    opts.requestedMax,
+		AcceptedCh:            make(chan struct{}, 1),
+		ChunkCh:               make(chan string, chunkBufferSize),
+		CompleteCh:            make(chan protocol.UsageInfo, 1),
+		ErrorCh:               make(chan protocol.InferenceErrorMessage, 1),
+		SessionPrivKey:        &sessionKeys.PrivateKey,
+	}
+
+	reserved := s.registry.ReserveSpecificInternalProvider(opts.providerID, opts.model, pr)
+	if reserved == nil {
+		return nil, fmt.Errorf("provider %q cannot admit model %q", opts.providerID, opts.model)
+	}
+
+	wireMsg := map[string]any{
+		"type":       protocol.TypeInferenceRequest,
+		"request_id": requestID,
+		"encrypted_body": map[string]string{
+			"ephemeral_public_key": encrypted.EphemeralPublicKey,
+			"ciphertext":           encrypted.Ciphertext,
+		},
+	}
+	data, err := json.Marshal(wireMsg)
+	if err != nil {
+		reserved.RemovePending(requestID)
+		s.registry.SetProviderIdle(reserved.ID)
+		return nil, fmt.Errorf("marshal internal request: %w", err)
+	}
+	if err := reserved.Conn.Write(ctx, websocket.MessageText, data); err != nil {
+		reserved.RemovePending(requestID)
+		s.registry.SetProviderIdle(reserved.ID)
+		return nil, fmt.Errorf("write internal request: %w", err)
+	}
+
+	timer := time.NewTimer(opts.firstChunkWait)
+	defer timer.Stop()
+
+	result := &internalDispatchResult{
+		provider:  reserved,
+		pending:   pr,
+		requestID: requestID,
+	}
+
+	select {
+	case <-pr.AcceptedCh:
+		chunkTimer := time.NewTimer(opts.contextTimeout)
+		defer chunkTimer.Stop()
+		select {
+		case chunk, ok := <-pr.ChunkCh:
+			if ok {
+				result.firstChunk = chunk
+				return result, nil
+			}
+			select {
+			case errMsg, ok := <-pr.ErrorCh:
+				if ok {
+					reserved.RemovePending(requestID)
+					s.registry.SetProviderIdle(reserved.ID)
+					return nil, fmt.Errorf("internal provider error: %s", errMsg.Error)
+				}
+			default:
+			}
+			return result, nil
+		case errMsg, ok := <-pr.ErrorCh:
+			reserved.RemovePending(requestID)
+			s.registry.SetProviderIdle(reserved.ID)
+			if ok {
+				return nil, fmt.Errorf("internal provider error: %s", errMsg.Error)
+			}
+			return nil, fmt.Errorf("internal provider error")
+		case <-chunkTimer.C:
+			cancelMsg := protocol.CancelMessage{Type: protocol.TypeCancel, RequestID: requestID}
+			cancelData, _ := json.Marshal(cancelMsg)
+			_ = reserved.Conn.Write(context.Background(), websocket.MessageText, cancelData)
+			reserved.RemovePending(requestID)
+			s.registry.SetProviderIdle(reserved.ID)
+			return nil, fmt.Errorf("timeout waiting for internal provider chunk")
+		case <-ctx.Done():
+			reserved.RemovePending(requestID)
+			s.registry.SetProviderIdle(reserved.ID)
+			return nil, ctx.Err()
+		}
+	case chunk, ok := <-pr.ChunkCh:
+		if ok {
+			result.firstChunk = chunk
+			return result, nil
+		}
+		select {
+		case errMsg, ok := <-pr.ErrorCh:
+			if ok {
+				reserved.RemovePending(requestID)
+				s.registry.SetProviderIdle(reserved.ID)
+				return nil, fmt.Errorf("internal provider error: %s", errMsg.Error)
+			}
+		default:
+		}
+		return result, nil
+	case errMsg, ok := <-pr.ErrorCh:
+		reserved.RemovePending(requestID)
+		s.registry.SetProviderIdle(reserved.ID)
+		if ok {
+			return nil, fmt.Errorf("internal provider error: %s", errMsg.Error)
+		}
+		return nil, fmt.Errorf("internal provider error")
+	case <-timer.C:
+		cancelMsg := protocol.CancelMessage{Type: protocol.TypeCancel, RequestID: requestID}
+		cancelData, _ := json.Marshal(cancelMsg)
+		_ = reserved.Conn.Write(context.Background(), websocket.MessageText, cancelData)
+		reserved.RemovePending(requestID)
+		s.registry.SetProviderIdle(reserved.ID)
+		return nil, fmt.Errorf("timeout waiting for internal provider response")
+	case <-ctx.Done():
+		reserved.RemovePending(requestID)
+		s.registry.SetProviderIdle(reserved.ID)
+		return nil, ctx.Err()
+	}
+}
+
+func awaitInternalCompletion(ctx context.Context, result *internalDispatchResult) (*internalCompletionResponse, error) {
+	if result == nil || result.pending == nil {
+		return nil, fmt.Errorf("internal result is nil")
+	}
+	if result.firstChunk == "" {
+		return nil, fmt.Errorf("internal provider returned no response chunk")
+	}
+
+	select {
+	case usage, ok := <-result.pending.CompleteCh:
+		if !ok {
+			return nil, fmt.Errorf("internal provider closed completion channel")
+		}
+		return parseInternalCompletionChunk(result.firstChunk, usage)
+	case errMsg, ok := <-result.pending.ErrorCh:
+		if ok {
+			return nil, fmt.Errorf("internal provider error: %s", errMsg.Error)
+		}
+		return nil, fmt.Errorf("internal provider error")
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+func parseInternalCompletionChunk(chunk string, usage protocol.UsageInfo) (*internalCompletionResponse, error) {
+	raw := strings.TrimSpace(strings.TrimPrefix(chunk, "data: "))
+	if raw == "" {
+		return nil, fmt.Errorf("internal completion chunk is empty")
+	}
+
+	var parsed struct {
+		Choices []struct {
+			Text         string `json:"text"`
+			FinishReason string `json:"finish_reason"`
+			Logprobs     *struct {
+				Tokens      []string             `json:"tokens"`
+				TopLogprobs []map[string]float64 `json:"top_logprobs"`
+				TextOffsets []int                `json:"text_offset"`
+			} `json:"logprobs"`
+		} `json:"choices"`
+	}
+	if err := json.Unmarshal([]byte(raw), &parsed); err != nil {
+		return nil, fmt.Errorf("decode internal completion response: %w", err)
+	}
+	if len(parsed.Choices) == 0 {
+		return nil, fmt.Errorf("internal completion response had no choices")
+	}
+
+	resp := &internalCompletionResponse{
+		Text:         parsed.Choices[0].Text,
+		FinishReason: parsed.Choices[0].FinishReason,
+		Usage:        usage,
+	}
+	if parsed.Choices[0].Logprobs != nil {
+		resp.Logprobs = internalCompletionLogprobs{
+			Tokens:      parsed.Choices[0].Logprobs.Tokens,
+			TopLogprobs: parsed.Choices[0].Logprobs.TopLogprobs,
+			TextOffsets: parsed.Choices[0].Logprobs.TextOffsets,
+		}
+	}
+	return resp, nil
+}
+
+func internalCompletionRequestBody(model, prompt string, maxTokens int, extras map[string]any) []byte {
+	body := map[string]any{
+		"model":           model,
+		"prompt":          prompt,
+		"max_tokens":      maxTokens,
+		"temperature":     0.0,
+		"stream":          false,
+		"logprobs":        1,
+		"endpoint":        "/v1/completions",
+		"_eigen_internal": true,
+	}
+	for k, v := range extras {
+		body[k] = v
+	}
+	raw, _ := json.Marshal(body)
+	return raw
+}
+
+func messageStringContent(content any) (string, bool) {
+	switch x := content.(type) {
+	case string:
+		return x, true
+	default:
+		return "", false
+	}
+}
+
+func formatQwenChatMLPrompt(messages []any) (string, error) {
+	var b strings.Builder
+	for _, raw := range messages {
+		msg, ok := raw.(map[string]any)
+		if !ok {
+			return "", fmt.Errorf("message must be an object")
+		}
+		role, _ := msg["role"].(string)
+		if role == "" {
+			return "", fmt.Errorf("message role is required")
+		}
+		content, ok := messageStringContent(msg["content"])
+		if !ok {
+			return "", fmt.Errorf("message content for role %q must be a string", role)
+		}
+		b.WriteString("<|im_start|>")
+		b.WriteString(role)
+		b.WriteString("\n")
+		b.WriteString(content)
+		b.WriteString("<|im_end|>\n")
+	}
+	b.WriteString("<|im_start|>assistant\n")
+	return b.String(), nil
+}
+
+func spansWithinOffsets(logprobs internalCompletionLogprobs, startOffset, endOffset int) []internalTokenSpan {
+	limit := len(logprobs.Tokens)
+	if len(logprobs.TextOffsets) < limit {
+		limit = len(logprobs.TextOffsets)
+	}
+	if len(logprobs.TopLogprobs) < limit {
+		limit = len(logprobs.TopLogprobs)
+	}
+	spans := make([]internalTokenSpan, 0, limit)
+	for i := 0; i < limit; i++ {
+		offset := logprobs.TextOffsets[i]
+		if offset < startOffset || offset >= endOffset {
+			continue
+		}
+		spans = append(spans, internalTokenSpan{
+			Token:       logprobs.Tokens[i],
+			Offset:      offset,
+			TopLogprobs: logprobs.TopLogprobs[i],
+		})
+	}
+	return spans
+}
+
+func countAcceptedDraftTokens(draftTokens []string, verifySpans []internalTokenSpan) int {
+	limit := len(draftTokens)
+	if len(verifySpans) < limit {
+		limit = len(verifySpans)
+	}
+	accepted := 0
+	for i := 0; i < limit; i++ {
+		if draftTokens[i] != verifySpans[i].Token {
+			break
+		}
+		if len(verifySpans[i].TopLogprobs) == 0 {
+			break
+		}
+		bestToken := ""
+		bestLogprob := 0.0
+		haveBest := false
+		for tok, lp := range verifySpans[i].TopLogprobs {
+			if !haveBest || lp > bestLogprob {
+				bestToken = tok
+				bestLogprob = lp
+				haveBest = true
+			}
+		}
+		if !haveBest || bestToken != verifySpans[i].Token {
+			break
+		}
+		accepted++
+	}
+	return accepted
+}
+
+func providerModelID(p *registry.Provider) string {
+	if p == nil {
+		return ""
+	}
+	p.Mu().Lock()
+	defer p.Mu().Unlock()
+	if len(p.Models) == 0 {
+		return ""
+	}
+	return p.Models[0].ID
+}
+
+func minInt(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func (s *Server) pickContributorProvider(targetModel string, excludeProviderIDs ...string) (registry.CatalogEntry, *registry.Provider) {
+	for _, entry := range s.registry.ContributorModelsForTarget(targetModel) {
+		provider := s.registry.FindInternalProviderWithTrust(entry.ID, "", excludeProviderIDs...)
+		if provider == nil {
+			continue
+		}
+		return entry, provider
+	}
+	return registry.CatalogEntry{}, nil
+}
+
+func writeProviderResponseHeaders(w http.ResponseWriter, provider *registry.Provider) {
+	if provider == nil {
+		return
+	}
+	provider.Mu().Lock()
+	pubKey := provider.PublicKey
+	attested := provider.Attested
+	trustLevel := provider.TrustLevel
+	attestResult := provider.AttestationResult
+	mdaVerified := provider.MDAVerified
+	providerID := provider.ID
+	chipName := provider.Hardware.ChipName
+	machineModel := provider.Hardware.MachineModel
+	provider.Mu().Unlock()
+
+	if pubKey != "" {
+		w.Header().Set("X-Provider-Public-Key", pubKey)
+	}
+	if attested {
+		w.Header().Set("X-Provider-Attested", "true")
+	} else {
+		w.Header().Set("X-Provider-Attested", "false")
+	}
+	w.Header().Set("X-Provider-Trust-Level", string(trustLevel))
+	w.Header().Set("X-Provider-ID", providerID)
+	w.Header().Set("X-Provider-Chip", chipName)
+	w.Header().Set("X-Provider-Model", machineModel)
+	if attestResult != nil {
+		w.Header().Set("X-Provider-Serial", attestResult.SerialNumber)
+		if attestResult.SecureEnclaveAvailable {
+			w.Header().Set("X-Provider-Secure-Enclave", "true")
+		} else {
+			w.Header().Set("X-Provider-Secure-Enclave", "false")
+		}
+	}
+	if mdaVerified {
+		w.Header().Set("X-Provider-MDA-Verified", "true")
+	}
+	if attestResult != nil && attestResult.PublicKey != "" {
+		w.Header().Set("X-Attestation-SE-Public-Key", attestResult.PublicKey)
+		w.Header().Set("X-Attestation-Device-Serial", attestResult.SerialNumber)
+	}
+}
+
+func creditProviderShare(storeBackend store.Store, ledger *payments.Ledger, provider *registry.Provider, requestID, model string, amountMicroUSD int64, promptTokens, completionTokens int) error {
+	if provider == nil || amountMicroUSD <= 0 {
+		return nil
+	}
+	provider.Mu().Lock()
+	accountID := provider.AccountID
+	walletAddress := provider.WalletAddress
+	providerKey := provider.PublicKey
+	providerID := provider.ID
+	provider.Mu().Unlock()
+
+	if accountID != "" {
+		return storeBackend.CreditProviderAccount(&store.ProviderEarning{
+			AccountID:        accountID,
+			ProviderID:       providerID,
+			ProviderKey:      providerKey,
+			JobID:            requestID,
+			Model:            model,
+			AmountMicroUSD:   amountMicroUSD,
+			PromptTokens:     promptTokens,
+			CompletionTokens: completionTokens,
+			CreatedAt:        time.Now(),
+		})
+	}
+	if walletAddress != "" {
+		return ledger.CreditProvider(walletAddress, amountMicroUSD, model, requestID)
+	}
+	return fmt.Errorf("provider %q has no payout destination", providerID)
+}
+
+func (s *Server) trySpeculativeChatCompletion(ctx context.Context, model string, parsed map[string]any, estimatedPromptTokens, requestedMaxTokens int, consumerKey string, reservedMicroUSD int64) (*speculativeChatResult, bool) {
+	if requestedMaxTokens <= 0 || !isDeterministicSpeculationEligible(parsed) {
+		return nil, false
+	}
+	entry, ok := s.registry.PublicCatalogEntry(model)
+	if !ok || entry.SpeculationFamily != "qwen-chatml" {
+		return nil, false
+	}
+
+	messages, _ := parsed["messages"].([]any)
+	prompt, err := formatQwenChatMLPrompt(messages)
+	if err != nil {
+		return nil, false
+	}
+
+	targetProvider := s.registry.FindProvider(model)
+	if targetProvider == nil {
+		return nil, false
+	}
+	defer s.registry.SetProviderIdle(targetProvider.ID)
+	targetReservationID := uuid.New().String()
+	targetPinned := s.registry.ReserveSpecificInternalProvider(targetProvider.ID, model, &registry.PendingRequest{
+		RequestID:          targetReservationID,
+		Model:              model,
+		ConsumerKey:        consumerKey,
+		InternalOnly:       true,
+		RequestedMaxTokens: requestedMaxTokens,
+		CompleteCh:         make(chan protocol.UsageInfo, 1),
+		ErrorCh:            make(chan protocol.InferenceErrorMessage, 1),
+	})
+	if targetPinned == nil {
+		return nil, false
+	}
+	defer func() {
+		targetProvider.RemovePending(targetReservationID)
+	}()
+
+	var (
+		completionText   strings.Builder
+		completionTokens int
+		promptTokens     int
+		gotPromptUsage   bool
+	)
+	contributorAccepted := make(map[string]int)
+	stopNow := false
+	progressMade := false
+
+	for completionTokens < requestedMaxTokens {
+		contributorEntry, contributorProvider := s.pickContributorProvider(model, targetProvider.ID)
+		if contributorProvider == nil {
+			return nil, false
+		}
+		draftPrompt := prompt + completionText.String()
+		draftMaxTokens := minInt(speculationDraftTokenCount, requestedMaxTokens-completionTokens)
+		draftResp, err := func() (*internalCompletionResponse, error) {
+			defer s.registry.SetProviderIdle(contributorProvider.ID)
+			dispatchResult, err := s.dispatchInternalInference(ctx, internalDispatchOptions{
+				providerID:      contributorProvider.ID,
+				model:           contributorEntry.ID,
+				rawBody:         internalCompletionRequestBody(contributorEntry.ID, draftPrompt, draftMaxTokens, nil),
+				estimatedPrompt: estimatedPromptTokens + completionTokens,
+				requestedMax:    draftMaxTokens,
+				internalOnly:    true,
+			})
+			if err != nil {
+				return nil, err
+			}
+			return awaitInternalCompletion(ctx, dispatchResult)
+		}()
+		if err != nil || len(draftResp.Logprobs.Tokens) == 0 {
+			return nil, false
+		}
+
+		verifyPrompt := draftPrompt + draftResp.Text
+		verifyResp, err := func() (*internalCompletionResponse, error) {
+			dispatchResult, err := s.dispatchInternalInference(ctx, internalDispatchOptions{
+				providerID:      targetProvider.ID,
+				model:           model,
+				rawBody:         internalCompletionRequestBody(model, verifyPrompt, 1, map[string]any{"echo": true}),
+				estimatedPrompt: estimatedPromptTokens + completionTokens + len(draftResp.Logprobs.Tokens),
+				requestedMax:    1,
+				internalOnly:    true,
+			})
+			if err != nil {
+				return nil, err
+			}
+			return awaitInternalCompletion(ctx, dispatchResult)
+		}()
+		if err != nil {
+			return nil, false
+		}
+
+		draftStart := len(draftPrompt)
+		draftEnd := len(verifyPrompt)
+		verifyDraftSpans := spansWithinOffsets(verifyResp.Logprobs, draftStart, draftEnd)
+		if !gotPromptUsage {
+			promptTokens = verifyResp.Usage.PromptTokens - len(verifyDraftSpans)
+			if promptTokens < 0 {
+				promptTokens = estimatedPromptTokens
+			}
+			gotPromptUsage = true
+		}
+
+		accepted := countAcceptedDraftTokens(draftResp.Logprobs.Tokens, verifyDraftSpans)
+		if accepted > 0 {
+			progressMade = true
+			acceptedText := strings.Join(draftResp.Logprobs.Tokens[:accepted], "")
+			completionText.WriteString(acceptedText)
+			completionTokens += accepted
+			contributorAccepted[contributorProvider.ID] += accepted
+		}
+
+		if completionTokens >= requestedMaxTokens {
+			break
+		}
+
+		if accepted == len(draftResp.Logprobs.Tokens) {
+			bonusSpans := spansWithinOffsets(verifyResp.Logprobs, draftEnd, len(verifyPrompt)+1_000_000)
+			if len(bonusSpans) > 0 {
+				progressMade = true
+				completionText.WriteString(bonusSpans[0].Token)
+				completionTokens++
+			}
+			if verifyResp.FinishReason == "stop" && len(bonusSpans) == 0 {
+				stopNow = true
+				break
+			}
+			continue
+		}
+
+		nextResp, err := func() (*internalCompletionResponse, error) {
+			dispatchResult, err := s.dispatchInternalInference(ctx, internalDispatchOptions{
+				providerID:      targetProvider.ID,
+				model:           model,
+				rawBody:         internalCompletionRequestBody(model, prompt+completionText.String(), 1, nil),
+				estimatedPrompt: estimatedPromptTokens + completionTokens,
+				requestedMax:    1,
+				internalOnly:    true,
+			})
+			if err != nil {
+				return nil, err
+			}
+			return awaitInternalCompletion(ctx, dispatchResult)
+		}()
+		if err != nil {
+			return nil, false
+		}
+		if len(nextResp.Logprobs.Tokens) == 0 {
+			if nextResp.FinishReason == "stop" {
+				stopNow = true
+				break
+			}
+			return nil, false
+		}
+		progressMade = true
+		completionText.WriteString(nextResp.Logprobs.Tokens[0])
+		completionTokens++
+		if nextResp.FinishReason == "stop" {
+			stopNow = true
+			break
+		}
+	}
+
+	if !progressMade {
+		return nil, false
+	}
+	if !gotPromptUsage {
+		promptTokens = estimatedPromptTokens
+	}
+
+	usage := protocol.UsageInfo{
+		PromptTokens:     promptTokens,
+		CompletionTokens: completionTokens,
+	}
+	requestID := uuid.New().String()
+	targetProvider.Mu().Lock()
+	targetAccountID := targetProvider.AccountID
+	targetWallet := targetProvider.WalletAddress
+	targetProvider.Mu().Unlock()
+	customIn, customOut, hasCustom := s.store.GetModelPrice(targetAccountID, model)
+	if !hasCustom && targetWallet != "" {
+		customIn, customOut, hasCustom = s.store.GetModelPrice(targetWallet, model)
+	}
+	if !hasCustom {
+		customIn, customOut, hasCustom = s.store.GetModelPrice("platform", model)
+	}
+	totalCost := payments.CalculateCostWithOverrides(model, usage.PromptTokens, usage.CompletionTokens, customIn, customOut, hasCustom)
+	if reservedMicroUSD > 0 && totalCost > reservedMicroUSD {
+		totalCost = reservedMicroUSD
+	}
+	if reservedMicroUSD > 0 && totalCost < reservedMicroUSD {
+		_ = s.store.Credit(consumerKey, reservedMicroUSD-totalCost, store.LedgerRefund, requestID)
+	} else if reservedMicroUSD == 0 {
+		_ = s.ledger.Charge(consumerKey, totalCost, requestID)
+	}
+
+	s.ledger.RecordUsage(consumerKey, payments.UsageEntry{
+		JobID:            requestID,
+		Model:            model,
+		PromptTokens:     usage.PromptTokens,
+		CompletionTokens: usage.CompletionTokens,
+		CostMicroUSD:     totalCost,
+		Timestamp:        time.Now(),
+	})
+	s.store.RecordUsageWithCost(targetProvider.ID, consumerKey, model, requestID, usage.PromptTokens, usage.CompletionTokens, totalCost)
+
+	providerPayout := payments.ProviderPayout(totalCost)
+	contributorBudget := providerPayout * speculationContributorPayoutBps / 10_000
+	totalAccepted := 0
+	for _, accepted := range contributorAccepted {
+		totalAccepted += accepted
+	}
+	allocatedContributor := int64(0)
+	for providerID, accepted := range contributorAccepted {
+		if totalAccepted == 0 || accepted == 0 {
+			continue
+		}
+		share := contributorBudget * int64(accepted) / int64(totalAccepted)
+		if share <= 0 {
+			continue
+		}
+		if err := creditProviderShare(s.store, s.ledger, s.registry.GetProvider(providerID), requestID+":contributor:"+providerID, model, share, 0, accepted); err == nil {
+			allocatedContributor += share
+		}
+	}
+	targetPayout := providerPayout - allocatedContributor
+	if targetPayout < 0 {
+		targetPayout = 0
+	}
+	_ = creditProviderShare(s.store, s.ledger, targetProvider, requestID, model, targetPayout, usage.PromptTokens, usage.CompletionTokens)
+
+	platformFee := payments.PlatformFee(totalCost)
+	if platformFee > 0 {
+		if s.billing != nil && s.billing.Referral() != nil {
+			platformFee = s.billing.Referral().DistributeReferralReward(consumerKey, platformFee, requestID)
+		}
+		_ = s.store.Credit("platform", platformFee, store.LedgerPlatformFee, requestID)
+	}
+
+	responseTime := time.Duration(usage.CompletionTokens) * time.Millisecond * 10
+	s.registry.RecordJobSuccess(targetProvider.ID, responseTime)
+	for providerID, accepted := range contributorAccepted {
+		if accepted > 0 {
+			s.registry.RecordJobSuccess(providerID, responseTime)
+		}
+	}
+
+	if stopNow {
+		_ = stopNow
+	}
+
+	finishReason := "stop"
+	if completionTokens >= requestedMaxTokens && !stopNow {
+		finishReason = "length"
+	}
+
+	return &speculativeChatResult{
+		RequestID:      requestID,
+		TargetProvider: targetProvider,
+		Message: extractedMessage{
+			Content: completionText.String(),
+		},
+		Usage:        usage,
+		FinishReason: finishReason,
+	}, true
 }
 
 // handleChatCompletions handles POST /v1/chat/completions.
@@ -296,11 +1121,24 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Reject requests for models not in the catalog.
-	if !s.registry.IsModelInCatalog(model) {
+	// Reject requests for models not in the public catalog. Internal-only
+	// contributor models are reserved for coordinator-orchestrated work.
+	if _, ok := s.registry.PublicCatalogEntry(model); !ok && !s.registry.IsModelInCatalog(model) {
 		refundReservation()
 		writeJSON(w, http.StatusNotFound, errorResponse("model_not_found",
 			fmt.Sprintf("model %q is not available — see /v1/models for supported models", model)))
+		return
+	}
+	if entry, ok := s.registry.CatalogEntry(model); ok && entry.InternalOnly {
+		refundReservation()
+		writeJSON(w, http.StatusNotFound, errorResponse("model_not_found",
+			fmt.Sprintf("model %q is not available — see /v1/models for supported models", model)))
+		return
+	}
+	if specResult, ok := s.trySpeculativeChatCompletion(r.Context(), model, parsed, estimatedPromptTokens, requestedMaxTokens, consumerKeyFromContext(r.Context()), reservedMicroUSD); ok {
+		writeProviderResponseHeaders(w, specResult.TargetProvider)
+		w.Header().Set("X-Request-ID", specResult.RequestID)
+		writeJSON(w, http.StatusOK, buildNonStreamingResponse(specResult.RequestID, model, specResult.Message, specResult.Usage, specResult.FinishReason, "", ""))
 		return
 	}
 
@@ -310,13 +1148,14 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 	// first chunk before committing — no HTTP response is written until a
 	// provider starts generating, so retries are invisible to the consumer.
 	var (
-		provider    *registry.Provider
-		pr          *registry.PendingRequest
-		requestID   string
-		firstChunk  string
-		lastErr     string
-		lastErrCode int
-		committed   bool
+		provider         *registry.Provider
+		pr               *registry.PendingRequest
+		requestID        string
+		firstChunk       string
+		lastErr          string
+		lastErrCode      int
+		committed        bool
+		completedSuccess bool
 	)
 
 	consumerKey := consumerKeyFromContext(r.Context())
@@ -386,6 +1225,7 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 
 		// E2E encryption — must be done per provider (different keys).
 		if provider.PublicKey == "" {
+			provider.RemovePending(requestID)
 			s.registry.SetProviderIdle(provider.ID)
 			excludeProviders[provider.ID] = struct{}{}
 			lastErr = "no provider with E2E encryption"
@@ -394,6 +1234,7 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 
 		providerPubKey, err := e2e.ParsePublicKey(provider.PublicKey)
 		if err != nil {
+			provider.RemovePending(requestID)
 			s.registry.SetProviderIdle(provider.ID)
 			excludeProviders[provider.ID] = struct{}{}
 			lastErr = "provider public key invalid"
@@ -402,6 +1243,7 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 
 		sessionKeys, err := e2e.GenerateSessionKeys()
 		if err != nil {
+			provider.RemovePending(requestID)
 			s.registry.SetProviderIdle(provider.ID)
 			lastErr = "failed to generate session keys"
 			continue
@@ -409,6 +1251,7 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 
 		encrypted, err := e2e.Encrypt(rawBody, providerPubKey, sessionKeys)
 		if err != nil {
+			provider.RemovePending(requestID)
 			s.registry.SetProviderIdle(provider.ID)
 			lastErr = "failed to encrypt request"
 			continue
@@ -640,6 +1483,9 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 	defer func() {
 		provider.RemovePending(requestID)
 		s.registry.SetProviderIdle(provider.ID)
+		if pr != nil && pr.ReservedMicroUSD > 0 && !completedSuccess {
+			_ = s.store.Credit(pr.ConsumerKey, pr.ReservedMicroUSD, store.LedgerRefund, requestID)
+		}
 
 		cancelMsg := protocol.CancelMessage{
 			Type:      protocol.TypeCancel,
@@ -654,9 +1500,9 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 	}()
 
 	if stream {
-		s.handleStreamingResponseWithFirstChunk(w, r, pr, firstChunk)
+		completedSuccess = s.handleStreamingResponseWithFirstChunk(w, r, pr, firstChunk)
 	} else {
-		s.handleNonStreamingResponseWithFirstChunk(w, r, pr, firstChunk)
+		completedSuccess = s.handleNonStreamingResponseWithFirstChunk(w, r, pr, firstChunk)
 	}
 }
 
@@ -685,7 +1531,12 @@ func (s *Server) handleTranscriptions(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !s.registry.IsModelInCatalog(model) {
+	if _, ok := s.registry.PublicCatalogEntry(model); !ok && !s.registry.IsModelInCatalog(model) {
+		writeJSON(w, http.StatusNotFound, errorResponse("model_not_found",
+			fmt.Sprintf("model %q is not available — see /v1/models for supported models", model)))
+		return
+	}
+	if entry, ok := s.registry.CatalogEntry(model); ok && entry.InternalOnly {
 		writeJSON(w, http.StatusNotFound, errorResponse("model_not_found",
 			fmt.Sprintf("model %q is not available — see /v1/models for supported models", model)))
 		return
@@ -874,7 +1725,12 @@ func (s *Server) handleImageGenerations(w http.ResponseWriter, r *http.Request) 
 		writeJSON(w, http.StatusBadRequest, errorResponse("invalid_request_error", "n must be between 1 and 4"))
 		return
 	}
-	if !s.registry.IsModelInCatalog(req.Model) {
+	if _, ok := s.registry.PublicCatalogEntry(req.Model); !ok && !s.registry.IsModelInCatalog(req.Model) {
+		writeJSON(w, http.StatusNotFound, errorResponse("model_not_found",
+			fmt.Sprintf("model %q is not available — see /v1/models for supported models", req.Model)))
+		return
+	}
+	if entry, ok := s.registry.CatalogEntry(req.Model); ok && entry.InternalOnly {
 		writeJSON(w, http.StatusNotFound, errorResponse("model_not_found",
 			fmt.Sprintf("model %q is not available — see /v1/models for supported models", req.Model)))
 		return
@@ -1042,19 +1898,19 @@ func (s *Server) handleImageGenerations(w http.ResponseWriter, r *http.Request) 
 // from the provider. Each chunk is forwarded in real time, providing
 // token-by-token streaming to the consumer.
 // handleStreamingResponse is kept for callers that don't have a first chunk.
-func (s *Server) handleStreamingResponse(w http.ResponseWriter, r *http.Request, pr *registry.PendingRequest) {
-	s.handleStreamingResponseWithFirstChunk(w, r, pr, "")
+func (s *Server) handleStreamingResponse(w http.ResponseWriter, r *http.Request, pr *registry.PendingRequest) bool {
+	return s.handleStreamingResponseWithFirstChunk(w, r, pr, "")
 }
 
 // handleStreamingResponseWithFirstChunk streams SSE chunks to the consumer.
 // If firstChunk is non-empty, it is written before reading further chunks
 // from the channel. This allows the dispatch loop to "peek" at the first
 // chunk for retry decisions without losing it.
-func (s *Server) handleStreamingResponseWithFirstChunk(w http.ResponseWriter, r *http.Request, pr *registry.PendingRequest, firstChunk string) {
+func (s *Server) handleStreamingResponseWithFirstChunk(w http.ResponseWriter, r *http.Request, pr *registry.PendingRequest, firstChunk string) bool {
 	flusher, ok := w.(http.Flusher)
 	if !ok {
 		writeJSON(w, http.StatusInternalServerError, errorResponse("internal_error", "streaming not supported"))
-		return
+		return false
 	}
 
 	w.Header().Set("Content-Type", "text/event-stream")
@@ -1107,7 +1963,7 @@ func (s *Server) handleStreamingResponseWithFirstChunk(w http.ResponseWriter, r 
 					fmt.Fprint(w, "data: [DONE]\n\n")
 					flusher.Flush()
 				}
-				return
+				return true
 			}
 			if !sawResponsesAPI {
 				if strings.Contains(chunk, `"response.created"`) || strings.Contains(chunk, `"response.output_text.delta"`) {
@@ -1137,28 +1993,28 @@ func (s *Server) handleStreamingResponseWithFirstChunk(w http.ResponseWriter, r 
 			})
 			fmt.Fprintf(w, "data: %s\n\n", errData)
 			flusher.Flush()
-			return
+			return false
 
 		case <-timer.C:
 			fmt.Fprintf(w, "data: {\"error\":{\"message\":\"request timed out\",\"type\":\"timeout\"}}\n\n")
 			flusher.Flush()
-			return
+			return false
 
 		case <-r.Context().Done():
-			return
+			return false
 		}
 	}
 }
 
 // handleNonStreamingResponse is kept for callers that don't have a first chunk.
-func (s *Server) handleNonStreamingResponse(w http.ResponseWriter, r *http.Request, pr *registry.PendingRequest) {
-	s.handleNonStreamingResponseWithFirstChunk(w, r, pr, "")
+func (s *Server) handleNonStreamingResponse(w http.ResponseWriter, r *http.Request, pr *registry.PendingRequest) bool {
+	return s.handleNonStreamingResponseWithFirstChunk(w, r, pr, "")
 }
 
 // handleNonStreamingResponseWithFirstChunk collects all chunks from the
 // provider and assembles them into a single OpenAI-compatible JSON response.
 // If firstChunk is non-empty, it is prepended to the collected chunks.
-func (s *Server) handleNonStreamingResponseWithFirstChunk(w http.ResponseWriter, r *http.Request, pr *registry.PendingRequest, firstChunk string) {
+func (s *Server) handleNonStreamingResponseWithFirstChunk(w http.ResponseWriter, r *http.Request, pr *registry.PendingRequest, firstChunk string) bool {
 	ctx, cancel := context.WithTimeout(r.Context(), inferenceTimeout)
 	defer cancel()
 
@@ -1172,18 +2028,16 @@ func (s *Server) handleNonStreamingResponseWithFirstChunk(w http.ResponseWriter,
 		case chunk, ok := <-pr.ChunkCh:
 			if !ok {
 				// The provider forwards the raw backend response as a single
-				// chunk. Detect complete responses (object=chat.completion
-				// or object=response) and pass through directly — this is
-				// format-agnostic and works for chat completions, Responses
-				// API, or any future endpoint without parsing.
+				// chunk for non-streaming requests. Pass that payload through
+				// unchanged instead of trying to reconstruct endpoint-specific
+				// formats (chat/completions/messages) from SSE delta logic.
 				if len(chunks) == 1 {
 					raw := strings.TrimPrefix(chunks[0], "data: ")
 					var obj map[string]any
 					if json.Unmarshal([]byte(raw), &obj) == nil {
 						objType, _ := obj["object"].(string)
-						// Complete responses have object=chat.completion or
-						// object=response. Delta chunks have object=chat.completion.chunk.
-						if objType == "chat.completion" || objType == "response" {
+						msgType, _ := obj["type"].(string)
+						if objType != "" || msgType == "message" {
 							select {
 							case <-pr.CompleteCh:
 							case <-ctx.Done():
@@ -1193,21 +2047,26 @@ func (s *Server) handleNonStreamingResponseWithFirstChunk(w http.ResponseWriter,
 								obj["response_hash"] = pr.ResponseHash
 							}
 							writeJSON(w, http.StatusOK, obj)
-							return
+							return true
 						}
 					}
 				}
 
-				// Fallback: SSE delta chunks — reconstruct into response.
+				// Fallback: SSE delta chunks — reconstruct into chat-completion response.
 				msg := extractMessage(chunks)
 				select {
-				case usage := <-pr.CompleteCh:
-					resp := buildNonStreamingResponse(pr.RequestID, pr.Model, msg, usage, pr.SESignature, pr.ResponseHash)
+				case usage, ok := <-pr.CompleteCh:
+					if !ok {
+						writeJSON(w, http.StatusBadGateway, errorResponse("provider_error", "provider completed without usage info"))
+						return false
+					}
+					resp := buildNonStreamingResponse(pr.RequestID, pr.Model, msg, usage, "", pr.SESignature, pr.ResponseHash)
 					writeJSON(w, http.StatusOK, resp)
+					return true
 				case <-ctx.Done():
 					writeJSON(w, http.StatusGatewayTimeout, errorResponse("timeout", "timed out waiting for usage info"))
+					return false
 				}
-				return
 			}
 			chunks = append(chunks, chunk)
 
@@ -1217,11 +2076,11 @@ func (s *Server) handleNonStreamingResponseWithFirstChunk(w http.ResponseWriter,
 				statusCode = http.StatusBadGateway
 			}
 			writeJSON(w, statusCode, errorResponse("provider_error", errMsg.Error))
-			return
+			return false
 
 		case <-ctx.Done():
 			writeJSON(w, http.StatusGatewayTimeout, errorResponse("timeout", "request timed out"))
-			return
+			return false
 		}
 	}
 }
@@ -1414,7 +2273,7 @@ func extractMessage(chunks []string) extractedMessage {
 
 // buildNonStreamingResponse constructs a complete OpenAI-compatible chat
 // completion response from the aggregated message and usage info.
-func buildNonStreamingResponse(requestID, model string, msg extractedMessage, usage protocol.UsageInfo, seSignature, responseHash string) map[string]any {
+func buildNonStreamingResponse(requestID, model string, msg extractedMessage, usage protocol.UsageInfo, finishReason, seSignature, responseHash string) map[string]any {
 	message := map[string]any{
 		"role":    "assistant",
 		"content": msg.Content,
@@ -1423,7 +2282,9 @@ func buildNonStreamingResponse(requestID, model string, msg extractedMessage, us
 		message["reasoning"] = msg.Reasoning
 	}
 
-	finishReason := "stop"
+	if finishReason == "" {
+		finishReason = "stop"
+	}
 	if len(msg.ToolCalls) > 0 {
 		message["tool_calls"] = msg.ToolCalls
 		finishReason = "tool_calls"
@@ -1469,7 +2330,7 @@ func (s *Server) handleListModels(w http.ResponseWriter, r *http.Request) {
 	catalogModels := s.store.ListSupportedModels()
 	catalogByID := make(map[string]store.SupportedModel, len(catalogModels))
 	for _, cm := range catalogModels {
-		if cm.Active {
+		if cm.Active && !cm.InternalOnly {
 			catalogByID[cm.ID] = cm
 		}
 	}
@@ -1731,7 +2592,12 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 		writeJSON(w, http.StatusBadRequest, errorResponse("invalid_request_error", "model is required"))
 		return
 	}
-	if !s.registry.IsModelInCatalog(model) {
+	if _, ok := s.registry.PublicCatalogEntry(model); !ok && !s.registry.IsModelInCatalog(model) {
+		writeJSON(w, http.StatusNotFound, errorResponse("model_not_found",
+			fmt.Sprintf("model %q is not available — see /v1/models for supported models", model)))
+		return
+	}
+	if entry, ok := s.registry.CatalogEntry(model); ok && entry.InternalOnly {
 		writeJSON(w, http.StatusNotFound, errorResponse("model_not_found",
 			fmt.Sprintf("model %q is not available — see /v1/models for supported models", model)))
 		return
@@ -1872,10 +2738,26 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 		"stream", stream,
 	)
 
+	completedSuccess := false
+	defer func() {
+		provider.RemovePending(requestID)
+		s.registry.SetProviderIdle(provider.ID)
+		if pr.ReservedMicroUSD > 0 && !completedSuccess {
+			_ = s.store.Credit(pr.ConsumerKey, pr.ReservedMicroUSD, store.LedgerRefund, requestID)
+		}
+
+		cancelMsg := protocol.CancelMessage{
+			Type:      protocol.TypeCancel,
+			RequestID: requestID,
+		}
+		cancelData, _ := json.Marshal(cancelMsg)
+		_ = provider.Conn.Write(context.Background(), websocket.MessageText, cancelData)
+	}()
+
 	if stream {
-		s.handleStreamingResponse(w, r, pr)
+		completedSuccess = s.handleStreamingResponse(w, r, pr)
 	} else {
-		s.handleNonStreamingResponse(w, r, pr)
+		completedSuccess = s.handleNonStreamingResponse(w, r, pr)
 	}
 }
 

--- a/coordinator/internal/api/provider.go
+++ b/coordinator/internal/api/provider.go
@@ -662,6 +662,24 @@ func (s *Server) handleComplete(providerID string, provider *registry.Provider, 
 	pr.SESignature = msg.SESignature
 	pr.ResponseHash = msg.ResponseHash
 
+	if pr.InternalOnly {
+		// Coordinator-generated internal control traffic (for example,
+		// speculative draft / verification sub-requests) should not affect
+		// provider reputation, consumer billing, or payout accounting.
+		pr.CompleteCh <- msg.Usage
+		close(pr.ChunkCh)
+		close(pr.CompleteCh)
+		s.registry.SetProviderIdle(providerID)
+		s.logger.Debug("internal inference complete",
+			"request_id", msg.RequestID,
+			"provider_id", providerID,
+			"model", pr.Model,
+			"prompt_tokens", msg.Usage.PromptTokens,
+			"completion_tokens", msg.Usage.CompletionTokens,
+		)
+		return
+	}
+
 	// Record job success and usage BEFORE closing ChunkCh. Closing
 	// ChunkCh unblocks the consumer response handler, and callers may
 	// check usage immediately after the HTTP response completes.
@@ -670,11 +688,15 @@ func (s *Server) handleComplete(providerID string, provider *registry.Provider, 
 
 	// Calculate cost — check provider's custom price, then platform DB price,
 	// then hardcoded defaults.
-	providerWalletForPricing := ""
+	providerPricingKey := ""
 	if p := s.registry.GetProvider(providerID); p != nil {
-		providerWalletForPricing = p.WalletAddress
+		if p.AccountID != "" {
+			providerPricingKey = p.AccountID
+		} else {
+			providerPricingKey = p.WalletAddress
+		}
 	}
-	customIn, customOut, hasCustom := s.store.GetModelPrice(providerWalletForPricing, pr.Model)
+	customIn, customOut, hasCustom := s.store.GetModelPrice(providerPricingKey, pr.Model)
 	if !hasCustom {
 		customIn, customOut, hasCustom = s.store.GetModelPrice("platform", pr.Model)
 	}
@@ -813,15 +835,20 @@ func (s *Server) handleInferenceError(providerID string, provider *registry.Prov
 		return
 	}
 
-	pr.ErrorCh <- *msg
-	close(pr.ChunkCh)
-	close(pr.CompleteCh)
-	close(pr.ErrorCh)
-	if pr.TranscriptionCh != nil {
-		close(pr.TranscriptionCh)
+	if pr.ErrorCh != nil {
+		pr.ErrorCh <- *msg
 	}
-	if pr.ImageGenerationCh != nil {
-		close(pr.ImageGenerationCh)
+
+	if pr.InternalOnly {
+		s.registry.SetProviderIdle(providerID)
+		s.logger.Debug("internal inference error",
+			"request_id", msg.RequestID,
+			"provider_id", providerID,
+			"model", pr.Model,
+			"error", msg.Error,
+			"status_code", msg.StatusCode,
+		)
+		return
 	}
 
 	// Record job failure for reputation tracking.

--- a/coordinator/internal/api/server.go
+++ b/coordinator/internal/api/server.go
@@ -213,8 +213,11 @@ func (s *Server) SyncModelCatalog() {
 	for _, m := range models {
 		if m.Active {
 			entries = append(entries, registry.CatalogEntry{
-				ID:         m.ID,
-				WeightHash: m.WeightHash,
+				ID:                m.ID,
+				WeightHash:        m.WeightHash,
+				InternalOnly:      m.InternalOnly,
+				ContributorFor:    m.ContributorFor,
+				SpeculationFamily: m.SpeculationFamily,
 			})
 		}
 	}

--- a/coordinator/internal/registry/registry.go
+++ b/coordinator/internal/registry/registry.go
@@ -24,6 +24,7 @@ import (
 	"log/slog"
 	"math"
 	"math/rand"
+	"sort"
 	"sync"
 	"time"
 
@@ -58,6 +59,10 @@ type PendingRequest struct {
 	ProviderID  string
 	Model       string
 	ConsumerKey string
+	// InternalOnly marks coordinator-generated control traffic such as
+	// speculative draft/verify requests. These requests should not affect
+	// billing, payouts, or provider reputation.
+	InternalOnly bool
 	// EstimatedPromptTokens is a coordinator-side heuristic used only for
 	// routing and queue admission. It does not need tokenizer-perfect accuracy.
 	EstimatedPromptTokens int
@@ -313,11 +318,16 @@ func (r *Registry) LoadStoredProviders() map[string]*store.ProviderRecord {
 		rec := records[i]
 		// Index by serial number for matching reconnecting providers
 		if rec.SerialNumber != "" {
-			lookup[rec.SerialNumber] = &rec
+			if _, exists := lookup[rec.SerialNumber]; !exists {
+				lookup[rec.SerialNumber] = &rec
+			}
 		}
 		// Also index by SE public key
 		if rec.SEPublicKey != "" {
-			lookup["sekey:"+rec.SEPublicKey] = &rec
+			key := "sekey:" + rec.SEPublicKey
+			if _, exists := lookup[key]; !exists {
+				lookup[key] = &rec
+			}
 		}
 	}
 
@@ -335,18 +345,6 @@ func (r *Registry) RestoreProviderState(p *Provider, rec *store.ProviderRecord) 
 
 	p.mu.Lock()
 	defer p.mu.Unlock()
-
-	// Restore trust level (will be re-verified via fresh attestation)
-	p.TrustLevel = TrustLevel(rec.TrustLevel)
-	p.Attested = rec.Attested
-	p.MDAVerified = rec.MDAVerified
-	p.ACMEVerified = rec.ACMEVerified
-
-	// Restore challenge state
-	if rec.LastChallengeVerified != nil {
-		p.LastChallengeVerified = *rec.LastChallengeVerified
-	}
-	p.FailedChallenges = rec.FailedChallenges
 
 	// Restore account linkage
 	if rec.AccountID != "" && p.AccountID == "" {
@@ -501,8 +499,11 @@ func TruncHash(h string) string {
 
 // CatalogEntry holds metadata about an active model in the catalog.
 type CatalogEntry struct {
-	ID         string
-	WeightHash string // expected SHA-256 weight fingerprint (empty = not enforced)
+	ID                string
+	WeightHash        string // expected SHA-256 weight fingerprint (empty = not enforced)
+	InternalOnly      bool
+	ContributorFor    string
+	SpeculationFamily string
 }
 
 // SetModelCatalog updates the set of active models. Only models in this
@@ -532,6 +533,75 @@ func (r *Registry) IsModelInCatalog(model string) bool {
 	}
 	_, ok := r.modelCatalog[model]
 	return ok
+}
+
+// CatalogEntry returns the catalog metadata for a model, if configured.
+func (r *Registry) CatalogEntry(model string) (CatalogEntry, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if len(r.modelCatalog) == 0 {
+		return CatalogEntry{}, false
+	}
+	entry, ok := r.modelCatalog[model]
+	return entry, ok
+}
+
+// PublicCatalogEntry returns the catalog metadata for a consumer-routable model.
+// Internal-only contributor models are hidden from direct consumer access.
+func (r *Registry) PublicCatalogEntry(model string) (CatalogEntry, bool) {
+	entry, ok := r.CatalogEntry(model)
+	if !ok {
+		r.mu.RLock()
+		noCatalog := len(r.modelCatalog) == 0
+		r.mu.RUnlock()
+		if noCatalog {
+			return CatalogEntry{ID: model}, true
+		}
+		return CatalogEntry{}, false
+	}
+	if entry.InternalOnly {
+		return CatalogEntry{}, false
+	}
+	return entry, true
+}
+
+// ContributorModelsForTarget returns internal contributor models that are
+// configured to accelerate the given public target model.
+func (r *Registry) ContributorModelsForTarget(target string) []CatalogEntry {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if len(r.modelCatalog) == 0 {
+		return nil
+	}
+	targetEntry, ok := r.modelCatalog[target]
+	if !ok {
+		return nil
+	}
+	entries := make([]CatalogEntry, 0, 4)
+	for _, entry := range r.modelCatalog {
+		if !entry.InternalOnly {
+			continue
+		}
+		if entry.ContributorFor == target {
+			entries = append(entries, entry)
+			continue
+		}
+		if entry.ContributorFor == "" &&
+			entry.SpeculationFamily != "" &&
+			entry.SpeculationFamily == targetEntry.SpeculationFamily {
+			entries = append(entries, entry)
+		}
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].ContributorFor == target && entries[j].ContributorFor != target {
+			return true
+		}
+		if entries[j].ContributorFor == target && entries[i].ContributorFor != target {
+			return false
+		}
+		return entries[i].ID < entries[j].ID
+	})
+	return entries
 }
 
 // CatalogWeightHash returns the expected weight hash for a model, or empty
@@ -760,15 +830,27 @@ func (r *Registry) Disconnect(id string) {
 	// Close all pending request channels so consumers get errors.
 	p.mu.Lock()
 	for reqID, pr := range p.pendingReqs {
-		pr.ErrorCh <- protocol.InferenceErrorMessage{
-			Type:       protocol.TypeInferenceError,
-			RequestID:  reqID,
-			Error:      "provider disconnected",
-			StatusCode: 502,
+		if pr.ErrorCh != nil {
+			pr.ErrorCh <- protocol.InferenceErrorMessage{
+				Type:       protocol.TypeInferenceError,
+				RequestID:  reqID,
+				Error:      "provider disconnected",
+				StatusCode: 502,
+			}
+			close(pr.ErrorCh)
 		}
-		close(pr.ChunkCh)
-		close(pr.CompleteCh)
-		close(pr.ErrorCh)
+		if pr.ChunkCh != nil {
+			close(pr.ChunkCh)
+		}
+		if pr.CompleteCh != nil {
+			close(pr.CompleteCh)
+		}
+		if pr.TranscriptionCh != nil {
+			close(pr.TranscriptionCh)
+		}
+		if pr.ImageGenerationCh != nil {
+			close(pr.ImageGenerationCh)
+		}
 	}
 	p.pendingReqs = make(map[string]*PendingRequest)
 	p.mu.Unlock()
@@ -1032,6 +1114,93 @@ func (r *Registry) FindProvider(model string, excludeIDs ...string) *Provider {
 	return r.FindProviderWithTrust(model, "", excludeIDs...)
 }
 
+// FindInternalProviderWithTrust selects a provider for coordinator-generated
+// internal work, including internal-only contributor models. Unlike
+// FindProviderWithTrust it does not mutate provider status; callers must still
+// reserve capacity explicitly before dispatch.
+func (r *Registry) FindInternalProviderWithTrust(model string, minTrust TrustLevel, excludeIDs ...string) *Provider {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	excludeSet := make(map[string]struct{}, len(excludeIDs))
+	for _, id := range excludeIDs {
+		excludeSet[id] = struct{}{}
+	}
+
+	effectiveMin := r.MinTrustLevel
+	if minTrust != "" && trustRank(minTrust) > trustRank(effectiveMin) {
+		effectiveMin = minTrust
+	}
+
+	challengeMaxAge := 6 * time.Minute
+	now := time.Now()
+
+	if entry, ok := r.modelCatalog[model]; ok && !entry.InternalOnly {
+		return nil
+	}
+
+	var candidates []*Provider
+	for _, p := range r.providers {
+		if _, excluded := excludeSet[p.ID]; excluded {
+			continue
+		}
+
+		p.mu.Lock()
+		status := p.Status
+		trust := p.TrustLevel
+		lastChallenge := p.LastChallengeVerified
+		runtimeVerified := p.RuntimeVerified
+		p.mu.Unlock()
+
+		if status == StatusOffline || status == StatusUntrusted {
+			continue
+		}
+		if trustRank(trust) < trustRank(effectiveMin) {
+			continue
+		}
+		if !runtimeVerified {
+			continue
+		}
+		if lastChallenge.IsZero() || now.Sub(lastChallenge) > challengeMaxAge {
+			continue
+		}
+		if p.PendingCount() >= p.MaxConcurrency() {
+			continue
+		}
+		for _, m := range p.Models {
+			if m.ID == model {
+				candidates = append(candidates, p)
+				break
+			}
+		}
+	}
+
+	if len(candidates) == 0 {
+		return nil
+	}
+
+	bestIdx := 0
+	bestScore := ScoreProvider(candidates[0], model)
+	for i := 1; i < len(candidates); i++ {
+		s := ScoreProvider(candidates[i], model)
+		if s > bestScore {
+			bestScore = s
+			bestIdx = i
+		}
+	}
+
+	var ties []*Provider
+	for _, c := range candidates {
+		if ScoreProvider(c, model) >= bestScore-0.001 {
+			ties = append(ties, c)
+		}
+	}
+	if len(ties) > 1 {
+		return ties[rand.Intn(len(ties))]
+	}
+	return candidates[bestIdx]
+}
+
 // FindProviderWithTrust selects a provider with an optional per-request
 // minimum trust level. If minTrust is empty, the registry's default
 // MinTrustLevel is used. Consumers can request a specific trust level
@@ -1040,6 +1209,10 @@ func (r *Registry) FindProvider(model string, excludeIDs ...string) *Provider {
 func (r *Registry) FindProviderWithTrust(model string, minTrust TrustLevel, excludeIDs ...string) *Provider {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+
+	if entry, ok := r.modelCatalog[model]; ok && entry.InternalOnly {
+		return nil
+	}
 
 	// Build a set of excluded provider IDs for O(1) lookup.
 	excludeSet := make(map[string]struct{}, len(excludeIDs))

--- a/coordinator/internal/registry/scheduler.go
+++ b/coordinator/internal/registry/scheduler.go
@@ -68,6 +68,9 @@ func (r *Registry) ReserveProvider(model string, pr *PendingRequest, excludeIDs 
 	if pr.RequestedMaxTokens <= 0 {
 		pr.RequestedMaxTokens = defaultRequestedMaxTokens
 	}
+	if entry, ok := r.CatalogEntry(model); ok && entry.InternalOnly {
+		return nil
+	}
 
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -87,6 +90,79 @@ func (r *Registry) ReserveProvider(model string, pr *PendingRequest, excludeIDs 
 		return nil
 	}
 
+	pr.ProviderID = p.ID
+	p.addPendingLocked(pr)
+	if p.Status != StatusUntrusted && p.Status != StatusOffline {
+		p.Status = StatusServing
+	}
+	return p
+}
+
+// ReserveSpecificProvider reserves capacity on a specific provider. This is used
+// when a higher-level orchestration flow needs to keep routing pinned to the
+// same provider across multiple internal sub-requests (for example, verifier-
+// gated speculation against a fixed target model host).
+func (r *Registry) ReserveSpecificProvider(providerID, model string, pr *PendingRequest) *Provider {
+	if pr == nil || pr.RequestID == "" {
+		return nil
+	}
+	if pr.Model == "" {
+		pr.Model = model
+	}
+	if pr.RequestedMaxTokens <= 0 {
+		pr.RequestedMaxTokens = defaultRequestedMaxTokens
+	}
+	if entry, ok := r.CatalogEntry(model); ok && entry.InternalOnly {
+		return nil
+	}
+
+	r.mu.RLock()
+	p := r.providers[providerID]
+	r.mu.RUnlock()
+	if p == nil {
+		return nil
+	}
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if !r.providerCanAdmitLocked(p, model) {
+		return nil
+	}
+	pr.ProviderID = p.ID
+	p.addPendingLocked(pr)
+	if p.Status != StatusUntrusted && p.Status != StatusOffline {
+		p.Status = StatusServing
+	}
+	return p
+}
+
+// ReserveSpecificInternalProvider reserves capacity on a specific provider for
+// an internal-only model. Unlike ReserveSpecificProvider, this allows routing
+// to catalog entries marked InternalOnly because those are reserved for
+// coordinator-orchestrated control traffic rather than direct consumer access.
+func (r *Registry) ReserveSpecificInternalProvider(providerID, model string, pr *PendingRequest) *Provider {
+	if pr == nil || pr.RequestID == "" {
+		return nil
+	}
+	if pr.Model == "" {
+		pr.Model = model
+	}
+	if pr.RequestedMaxTokens <= 0 {
+		pr.RequestedMaxTokens = defaultRequestedMaxTokens
+	}
+
+	r.mu.RLock()
+	p := r.providers[providerID]
+	r.mu.RUnlock()
+	if p == nil {
+		return nil
+	}
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if !r.providerCanAdmitInternalLocked(p, model) {
+		return nil
+	}
 	pr.ProviderID = p.ID
 	p.addPendingLocked(pr)
 	if p.Status != StatusUntrusted && p.Status != StatusOffline {
@@ -360,6 +436,10 @@ func providerModelIDs(p *Provider) []string {
 }
 
 func (r *Registry) providerCanAdmitLocked(p *Provider, model string) bool {
+	return r.providerCanAdmitInternalLocked(p, model)
+}
+
+func (r *Registry) providerCanAdmitInternalLocked(p *Provider, model string) bool {
 	if p.Status == StatusOffline || p.Status == StatusUntrusted {
 		return false
 	}

--- a/coordinator/internal/registry/scheduler_test.go
+++ b/coordinator/internal/registry/scheduler_test.go
@@ -267,6 +267,85 @@ func TestReserveProviderUsesModelSpecificSlotState(t *testing.T) {
 	}
 }
 
+func TestReserveProviderSkipsInternalContributorModels(t *testing.T) {
+	reg := New(testLogger())
+	targetModel := "qwen3.5-27b-claude-opus-8bit"
+	contributorModel := "mlx-community/Qwen3.5-4B-4bit"
+
+	reg.SetModelCatalog([]CatalogEntry{
+		{
+			ID:                targetModel,
+			SpeculationFamily: "qwen-chatml",
+		},
+		{
+			ID:                contributorModel,
+			InternalOnly:      true,
+			ContributorFor:    targetModel,
+			SpeculationFamily: "qwen-chatml",
+		},
+	})
+
+	target := makeSchedulerProvider(t, reg, "target", targetModel, 80)
+	contributor := makeSchedulerProvider(t, reg, "contrib", contributorModel, 300)
+
+	req := &PendingRequest{
+		RequestID:          "req-target",
+		Model:              targetModel,
+		RequestedMaxTokens: 128,
+	}
+	selected := reg.ReserveProvider(targetModel, req)
+	if selected == nil {
+		t.Fatal("ReserveProvider returned nil")
+	}
+	if selected.ID != target.ID {
+		t.Fatalf("selected %q, want target provider %q", selected.ID, target.ID)
+	}
+
+	contributor.mu.Lock()
+	contribPending := contributor.pendingCount()
+	contributor.mu.Unlock()
+	if contribPending != 0 {
+		t.Fatalf("contributor provider should remain unused, pending=%d", contribPending)
+	}
+}
+
+func TestReserveSpecificProviderAllowsInternalContributorModels(t *testing.T) {
+	reg := New(testLogger())
+	targetModel := "qwen3.5-27b-claude-opus-8bit"
+	contributorModel := "mlx-community/Qwen3.5-4B-4bit"
+
+	reg.SetModelCatalog([]CatalogEntry{
+		{
+			ID:                targetModel,
+			SpeculationFamily: "qwen-chatml",
+		},
+		{
+			ID:                contributorModel,
+			InternalOnly:      true,
+			ContributorFor:    targetModel,
+			SpeculationFamily: "qwen-chatml",
+		},
+	})
+
+	contributor := makeSchedulerProvider(t, reg, "contrib", contributorModel, 300)
+	req := &PendingRequest{
+		RequestID:          "req-contrib",
+		Model:              contributorModel,
+		RequestedMaxTokens: 32,
+		InternalOnly:       true,
+	}
+	selected := reg.ReserveSpecificInternalProvider(contributor.ID, contributorModel, req)
+	if selected == nil {
+		t.Fatal("ReserveSpecificInternalProvider returned nil for internal contributor")
+	}
+	if selected.ID != contributor.ID {
+		t.Fatalf("selected %q, want contributor provider %q", selected.ID, contributor.ID)
+	}
+	if got := contributor.PendingCount(); got != 1 {
+		t.Fatalf("pending count = %d, want 1", got)
+	}
+}
+
 func TestHeartbeatDrainsQueueAfterSlotRecovery(t *testing.T) {
 	reg := New(testLogger())
 	model := "recovery-model"

--- a/coordinator/internal/store/interface.go
+++ b/coordinator/internal/store/interface.go
@@ -367,16 +367,19 @@ type User struct {
 // output worth paying for — small chat models (< 7B) are not useful, but small
 // specialized models (transcription, embeddings) can be best-in-class.
 type SupportedModel struct {
-	ID           string  `json:"id"`           // HuggingFace path (e.g. "mlx-community/Qwen3.5-9B-MLX-4bit")
-	S3Name       string  `json:"s3_name"`      // CDN key for download (e.g. "Qwen3.5-9B-MLX-4bit")
-	DisplayName  string  `json:"display_name"` // Human-readable (e.g. "Qwen3.5 9B")
-	ModelType    string  `json:"model_type"`   // "text", "transcription", "embedding", "tts", "image"
-	SizeGB       float64 `json:"size_gb"`      // Disk/memory size in GB
-	Architecture string  `json:"architecture"` // e.g. "9B dense", "2B conformer"
-	Description  string  `json:"description"`  // e.g. "Balanced", "Best-in-class STT"
-	MinRAMGB     int     `json:"min_ram_gb"`   // Minimum system RAM for auto-selection
-	Active       bool    `json:"active"`       // Whether available for use
-	WeightHash   string  `json:"weight_hash"`  // Expected SHA-256 fingerprint of model weight files
+	ID                string  `json:"id"`                           // HuggingFace path (e.g. "mlx-community/Qwen3.5-9B-MLX-4bit")
+	S3Name            string  `json:"s3_name"`                      // CDN key for download (e.g. "Qwen3.5-9B-MLX-4bit")
+	DisplayName       string  `json:"display_name"`                 // Human-readable (e.g. "Qwen3.5 9B")
+	ModelType         string  `json:"model_type"`                   // "text", "transcription", "embedding", "tts", "image"
+	SizeGB            float64 `json:"size_gb"`                      // Disk/memory size in GB
+	Architecture      string  `json:"architecture"`                 // e.g. "9B dense", "2B conformer"
+	Description       string  `json:"description"`                  // e.g. "Balanced", "Best-in-class STT"
+	MinRAMGB          int     `json:"min_ram_gb"`                   // Minimum system RAM for auto-selection
+	Active            bool    `json:"active"`                       // Whether available for use
+	InternalOnly      bool    `json:"internal_only,omitempty"`      // Hidden from consumer-facing /v1/models and direct routing
+	ContributorFor    string  `json:"contributor_for,omitempty"`    // Exact public target model this internal contributor accelerates (empty = family-wide)
+	SpeculationFamily string  `json:"speculation_family,omitempty"` // Exact prompt/token compatibility family (e.g. "qwen-chatml")
+	WeightHash        string  `json:"weight_hash"`                  // Expected SHA-256 fingerprint of model weight files
 }
 
 // Release represents a versioned provider binary release.

--- a/coordinator/internal/store/memory.go
+++ b/coordinator/internal/store/memory.go
@@ -568,10 +568,12 @@ func (s *MemoryStore) ListSupportedModels() []SupportedModel {
 	for _, m := range s.supportedModels {
 		models = append(models, *m)
 	}
-	// Sort by MinRAMGB ascending
+	// Sort by MinRAMGB ascending, then public models before internal helpers.
 	for i := 0; i < len(models); i++ {
 		for j := i + 1; j < len(models); j++ {
-			if models[j].MinRAMGB < models[i].MinRAMGB {
+			if models[j].MinRAMGB < models[i].MinRAMGB ||
+				(models[j].MinRAMGB == models[i].MinRAMGB &&
+					models[i].InternalOnly && !models[j].InternalOnly) {
 				models[i], models[j] = models[j], models[i]
 			}
 		}

--- a/coordinator/internal/store/postgres.go
+++ b/coordinator/internal/store/postgres.go
@@ -247,6 +247,9 @@ func (s *PostgresStore) migrate(ctx context.Context) error {
 			description TEXT NOT NULL DEFAULT '',
 			min_ram_gb INTEGER NOT NULL DEFAULT 0,
 			active BOOLEAN NOT NULL DEFAULT TRUE,
+			internal_only BOOLEAN NOT NULL DEFAULT FALSE,
+			contributor_for TEXT NOT NULL DEFAULT '',
+			speculation_family TEXT NOT NULL DEFAULT '',
 			updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 		)`,
 		// Add model_type column if upgrading from previous schema
@@ -257,6 +260,18 @@ func (s *PostgresStore) migrate(ctx context.Context) error {
 		// Add weight_hash column for model integrity verification
 		`DO $$ BEGIN
 			ALTER TABLE supported_models ADD COLUMN IF NOT EXISTS weight_hash TEXT NOT NULL DEFAULT '';
+		EXCEPTION WHEN others THEN NULL;
+		END $$`,
+		`DO $$ BEGIN
+			ALTER TABLE supported_models ADD COLUMN IF NOT EXISTS internal_only BOOLEAN NOT NULL DEFAULT FALSE;
+		EXCEPTION WHEN others THEN NULL;
+		END $$`,
+		`DO $$ BEGIN
+			ALTER TABLE supported_models ADD COLUMN IF NOT EXISTS contributor_for TEXT NOT NULL DEFAULT '';
+		EXCEPTION WHEN others THEN NULL;
+		END $$`,
+		`DO $$ BEGIN
+			ALTER TABLE supported_models ADD COLUMN IF NOT EXISTS speculation_family TEXT NOT NULL DEFAULT '';
 		EXCEPTION WHEN others THEN NULL;
 		END $$`,
 
@@ -1078,13 +1093,15 @@ func (s *PostgresStore) SetSupportedModel(model *SupportedModel) error {
 	defer cancel()
 
 	_, err := s.pool.Exec(ctx,
-		`INSERT INTO supported_models (id, s3_name, display_name, model_type, size_gb, architecture, description, min_ram_gb, active, weight_hash, updated_at)
-		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, NOW())
+		`INSERT INTO supported_models (id, s3_name, display_name, model_type, size_gb, architecture, description, min_ram_gb, active, internal_only, contributor_for, speculation_family, weight_hash, updated_at)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, NOW())
 		 ON CONFLICT (id) DO UPDATE SET
 		   s3_name = $2, display_name = $3, model_type = $4, size_gb = $5, architecture = $6,
-		   description = $7, min_ram_gb = $8, active = $9, weight_hash = $10, updated_at = NOW()`,
+		   description = $7, min_ram_gb = $8, active = $9, internal_only = $10,
+		   contributor_for = $11, speculation_family = $12, weight_hash = $13, updated_at = NOW()`,
 		model.ID, model.S3Name, model.DisplayName, model.ModelType, model.SizeGB,
-		model.Architecture, model.Description, model.MinRAMGB, model.Active, model.WeightHash,
+		model.Architecture, model.Description, model.MinRAMGB, model.Active,
+		model.InternalOnly, model.ContributorFor, model.SpeculationFamily, model.WeightHash,
 	)
 	if err != nil {
 		return fmt.Errorf("store: set supported model: %w", err)
@@ -1097,7 +1114,7 @@ func (s *PostgresStore) ListSupportedModels() []SupportedModel {
 	defer cancel()
 
 	rows, err := s.pool.Query(ctx,
-		`SELECT id, s3_name, display_name, model_type, size_gb, architecture, description, min_ram_gb, active, weight_hash
+		`SELECT id, s3_name, display_name, model_type, size_gb, architecture, description, min_ram_gb, active, internal_only, contributor_for, speculation_family, weight_hash
 		 FROM supported_models ORDER BY model_type ASC, min_ram_gb ASC, size_gb ASC`,
 	)
 	if err != nil {
@@ -1109,7 +1126,8 @@ func (s *PostgresStore) ListSupportedModels() []SupportedModel {
 	for rows.Next() {
 		var m SupportedModel
 		if err := rows.Scan(&m.ID, &m.S3Name, &m.DisplayName, &m.ModelType, &m.SizeGB,
-			&m.Architecture, &m.Description, &m.MinRAMGB, &m.Active, &m.WeightHash); err != nil {
+			&m.Architecture, &m.Description, &m.MinRAMGB, &m.Active, &m.InternalOnly,
+			&m.ContributorFor, &m.SpeculationFamily, &m.WeightHash); err != nil {
 			continue
 		}
 		models = append(models, m)

--- a/coordinator/internal/store/store_test.go
+++ b/coordinator/internal/store/store_test.go
@@ -195,15 +195,18 @@ func TestSupportedModels(t *testing.T) {
 		Active:       true,
 	}
 	m2 := &SupportedModel{
-		ID:           "mlx-community/Qwen3.5-9B-MLX-4bit",
-		S3Name:       "Qwen3.5-9B-MLX-4bit",
-		DisplayName:  "Qwen3.5 9B",
-		ModelType:    "text",
-		SizeGB:       6.0,
-		Architecture: "9B dense",
-		Description:  "Balanced",
-		MinRAMGB:     16,
-		Active:       true,
+		ID:                "mlx-community/Qwen3.5-9B-MLX-4bit",
+		S3Name:            "Qwen3.5-9B-MLX-4bit",
+		DisplayName:       "Qwen3.5 9B",
+		ModelType:         "text",
+		SizeGB:            6.0,
+		Architecture:      "9B dense",
+		Description:       "Balanced",
+		MinRAMGB:          16,
+		Active:            true,
+		InternalOnly:      true,
+		ContributorFor:    "qwen3.5-27b-claude-opus-8bit",
+		SpeculationFamily: "qwen-chatml",
 	}
 
 	if err := s.SetSupportedModel(m1); err != nil {
@@ -253,6 +256,25 @@ func TestSupportedModels(t *testing.T) {
 				t.Error("model should be inactive after update")
 			}
 		}
+	}
+
+	var foundContributor bool
+	for _, m := range models {
+		if m.ID == m2.ID {
+			foundContributor = true
+			if !m.InternalOnly {
+				t.Error("expected internal_only model metadata to round-trip")
+			}
+			if m.ContributorFor != "qwen3.5-27b-claude-opus-8bit" {
+				t.Errorf("contributor_for = %q", m.ContributorFor)
+			}
+			if m.SpeculationFamily != "qwen-chatml" {
+				t.Errorf("speculation_family = %q", m.SpeculationFamily)
+			}
+		}
+	}
+	if !foundContributor {
+		t.Fatalf("contributor model %q missing from store listing", m2.ID)
 	}
 
 	// Delete model

--- a/provider/src/inference.rs
+++ b/provider/src/inference.rs
@@ -53,6 +53,14 @@ pub struct InferenceResult {
     pub completion_tokens: u64,
 }
 
+/// A raw completions-style response produced by the in-process engine.
+#[derive(Debug)]
+pub struct CompletionJsonResult {
+    pub response_json: serde_json::Value,
+    pub prompt_tokens: u64,
+    pub completion_tokens: u64,
+}
+
 /// A streaming token from the inference engine.
 #[derive(Debug)]
 pub struct StreamToken {
@@ -328,6 +336,36 @@ impl InProcessEngine {
         })
     }
 
+    /// Run a raw completions-style request, preserving prompt/echo/logprobs.
+    pub fn generate_completion_json(
+        &self,
+        model_name: &str,
+        prompt: &str,
+        max_tokens: u64,
+        temperature: f64,
+        echo: bool,
+        logprobs: u64,
+    ) -> Result<CompletionJsonResult> {
+        if !self.loaded {
+            anyhow::bail!("Model not loaded — call load() first");
+        }
+
+        Python::with_gil(|py| match self.engine_type {
+            EngineType::VllmMlx => self.generate_completion_json_vllm_mlx(
+                py,
+                model_name,
+                prompt,
+                max_tokens,
+                temperature,
+                echo,
+                logprobs,
+            ),
+            EngineType::MlxLm => anyhow::bail!(
+                "mlx-lm backend does not support raw completions logprobs/echo"
+            ),
+        })
+    }
+
     fn generate_vllm_mlx(
         &self,
         py: Python<'_>,
@@ -372,6 +410,148 @@ impl InProcessEngine {
 
         Ok(InferenceResult {
             text,
+            prompt_tokens,
+            completion_tokens,
+        })
+    }
+
+    fn generate_completion_json_vllm_mlx(
+        &self,
+        py: Python<'_>,
+        model_name: &str,
+        prompt: &str,
+        max_tokens: u64,
+        temperature: f64,
+        echo: bool,
+        logprobs: u64,
+    ) -> Result<CompletionJsonResult> {
+        let locals = PyDict::new(py);
+        locals.set_item("engine_key", &self.cache_key)?;
+        locals.set_item("model_name", model_name)?;
+        locals.set_item("prompt", prompt)?;
+        locals.set_item("max_tokens", max_tokens)?;
+        locals.set_item(
+            "engine_max_tokens",
+            if echo && max_tokens == 0 { 1 } else { max_tokens },
+        )?;
+        locals.set_item("temperature", temperature)?;
+        locals.set_item("echo", echo)?;
+        locals.set_item("logprobs_k", logprobs)?;
+
+        let code = CString::new(
+            "import builtins\n\
+             import json\n\
+             from vllm import SamplingParams\n\
+             engine = builtins._eigeninference_vllm_engines[engine_key]\n\
+             tokenizer = engine.get_tokenizer()\n\
+             num_logprobs = int(logprobs_k)\n\
+             params = SamplingParams(\n\
+                 max_tokens=int(engine_max_tokens),\n\
+                 temperature=float(temperature),\n\
+                 logprobs=(num_logprobs if num_logprobs > 0 else None),\n\
+                 prompt_logprobs=(num_logprobs if bool(echo) and num_logprobs > 0 else None),\n\
+             )\n\
+             outputs = engine.generate([prompt], params, use_tqdm=False)\n\
+             if not outputs or not outputs[0].outputs:\n\
+                 raise RuntimeError('no completion outputs')\n\
+             request_output = outputs[0]\n\
+             completion = request_output.outputs[0]\n\
+             prompt_ids = list(request_output.prompt_token_ids or [])\n\
+             prompt_logprobs = list(request_output.prompt_logprobs) if request_output.prompt_logprobs is not None else []\n\
+             completion_ids = list(completion.token_ids or [])\n\
+             completion_logprobs = list(completion.logprobs) if completion.logprobs is not None else []\n\
+             trim_completion_tokens = 0 if bool(echo) and int(max_tokens) == 0 else len(completion_ids)\n\
+             completion_text = completion.text if trim_completion_tokens == len(completion_ids) else ''\n\
+             def decode_token(token_id, position):\n\
+                 if position is not None and token_id in position:\n\
+                     decoded = getattr(position[token_id], 'decoded_token', None)\n\
+                     if decoded is not None:\n\
+                         return decoded\n\
+                 return tokenizer.decode([token_id])\n\
+             def serialize_position(token_id, position):\n\
+                 token = decode_token(token_id, position)\n\
+                 chosen_logprob = None\n\
+                 top_logprobs = None\n\
+                 if position is not None:\n\
+                     top_logprobs = {}\n\
+                     for cand_id, cand_lp in position.items():\n\
+                         decoded = getattr(cand_lp, 'decoded_token', None)\n\
+                         if decoded is None:\n\
+                             decoded = tokenizer.decode([cand_id])\n\
+                         top_logprobs[decoded] = cand_lp.logprob\n\
+                         if cand_id == token_id:\n\
+                             chosen_logprob = cand_lp.logprob\n\
+                 return token, chosen_logprob, top_logprobs\n\
+             tokens = []\n\
+             token_logprobs = []\n\
+             top_logprobs = []\n\
+             text_offset = []\n\
+             offset = 0\n\
+             if bool(echo):\n\
+                 for idx, token_id in enumerate(prompt_ids):\n\
+                     position = prompt_logprobs[idx] if idx < len(prompt_logprobs) else None\n\
+                     token, chosen, top = serialize_position(token_id, position)\n\
+                     tokens.append(token)\n\
+                     token_logprobs.append(chosen)\n\
+                     top_logprobs.append(top)\n\
+                     text_offset.append(offset)\n\
+                     offset += len(token.encode('utf-8'))\n\
+             for idx, token_id in enumerate(completion_ids[:trim_completion_tokens]):\n\
+                 position = completion_logprobs[idx] if idx < len(completion_logprobs) else None\n\
+                 token, chosen, top = serialize_position(token_id, position)\n\
+                 tokens.append(token)\n\
+                 token_logprobs.append(chosen)\n\
+                 top_logprobs.append(top)\n\
+                 text_offset.append(offset)\n\
+                 offset += len(token.encode('utf-8'))\n\
+             finish_reason = completion.finish_reason or 'stop'\n\
+             if bool(echo) and int(max_tokens) == 0:\n\
+                 finish_reason = 'stop'\n\
+             response = {\n\
+                 'id': f'cmpl-{engine_key[:12]}',\n\
+                 'object': 'text_completion',\n\
+                 'model': model_name,\n\
+                 'choices': [{\n\
+                     'index': 0,\n\
+                     'text': (prompt + completion_text) if bool(echo) else completion_text,\n\
+                     'finish_reason': finish_reason,\n\
+                     'logprobs': {\n\
+                         'tokens': tokens,\n\
+                         'token_logprobs': token_logprobs,\n\
+                         'top_logprobs': top_logprobs,\n\
+                         'text_offset': text_offset,\n\
+                     } if num_logprobs > 0 else None,\n\
+                 }],\n\
+                 'usage': {\n\
+                     'prompt_tokens': len(prompt_ids),\n\
+                     'completion_tokens': trim_completion_tokens,\n\
+                     'total_tokens': len(prompt_ids) + trim_completion_tokens,\n\
+                 },\n\
+             }\n\
+             _result_json = json.dumps(response)\n",
+        )
+        .unwrap();
+        py.run(code.as_c_str(), None, Some(&locals))
+            .context("vllm-mlx raw completion failed")?;
+
+        let raw_json: String = locals
+            .get_item("_result_json")?
+            .ok_or_else(|| anyhow::anyhow!("no completion json"))?
+            .extract()?;
+        let response_json: serde_json::Value =
+            serde_json::from_str(&raw_json).context("failed to parse completion json")?;
+        let prompt_tokens = response_json
+            .get("usage")
+            .and_then(|u| u.get("prompt_tokens"))
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0);
+        let completion_tokens = response_json
+            .get("usage")
+            .and_then(|u| u.get("completion_tokens"))
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0);
+        Ok(CompletionJsonResult {
+            response_json,
             prompt_tokens,
             completion_tokens,
         })
@@ -552,6 +732,31 @@ impl SharedEngine {
         tokio::task::spawn_blocking(move || {
             let e = engine.blocking_lock();
             e.generate(&messages, max_tokens, temperature)
+        })
+        .await?
+    }
+
+    /// Run a raw completions-style request preserving prompt/echo/logprobs.
+    pub async fn generate_completion_json(
+        &self,
+        model_name: String,
+        prompt: String,
+        max_tokens: u64,
+        temperature: f64,
+        echo: bool,
+        logprobs: u64,
+    ) -> Result<CompletionJsonResult> {
+        let engine = self.inner.clone();
+        tokio::task::spawn_blocking(move || {
+            let e = engine.blocking_lock();
+            e.generate_completion_json(
+                model_name.as_str(),
+                prompt.as_str(),
+                max_tokens,
+                temperature,
+                echo,
+                logprobs,
+            )
         })
         .await?
     }

--- a/provider/src/main.rs
+++ b/provider/src/main.rs
@@ -4439,8 +4439,6 @@ async fn handle_inprocess_request(
         return;
     }
 
-    // Extract parameters from OpenAI-format body
-    let messages = extract_inprocess_messages(&body);
     let max_tokens = body
         .get("max_tokens")
         .and_then(|v| v.as_u64())
@@ -4454,7 +4452,48 @@ async fn handle_inprocess_request(
         .and_then(|v| v.as_bool())
         .unwrap_or(false);
 
-    let result = if is_streaming {
+    let endpoint = body
+        .get("endpoint")
+        .and_then(|v| v.as_str())
+        .unwrap_or("/v1/chat/completions");
+    let raw_completion_request = !is_streaming
+        && endpoint == "/v1/completions"
+        && (body.get("prompt").is_some() || body.get("echo").is_some() || body.get("logprobs").is_some());
+
+    // Extract parameters from OpenAI-format body
+    let messages = extract_inprocess_messages(&body);
+
+    let result = if raw_completion_request {
+        let prompt = body
+            .get("prompt")
+            .map(extract_inprocess_input_text)
+            .unwrap_or_default();
+        let echo = body.get("echo").and_then(|v| v.as_bool()).unwrap_or(false);
+        let logprobs = body
+            .get("logprobs")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0);
+        match engine
+            .generate_completion_json(&prompt, max_tokens, temperature, echo, logprobs)
+            .await
+        {
+            Ok(completion) => {
+                let raw_json = serde_json::to_string(&completion.response_json).unwrap_or_default();
+                let _ = outbound_tx
+                    .send(protocol::ProviderMessage::InferenceResponseChunk {
+                        request_id: request_id.clone(),
+                        data: format!("data: {}", raw_json),
+                    })
+                    .await;
+                Ok(inference::InferenceResult {
+                    text: String::new(),
+                    prompt_tokens: completion.prompt_tokens,
+                    completion_tokens: completion.completion_tokens,
+                })
+            }
+            Err(e) => Err(e),
+        }
+    } else if is_streaming {
         match engine
             .stream_generate(messages.clone(), max_tokens, temperature)
             .await
@@ -4501,7 +4540,7 @@ async fn handle_inprocess_request(
 
     match result {
         Ok(inference_result) => {
-            if !is_streaming {
+            if !is_streaming && !raw_completion_request {
                 let response_json = build_inprocess_response_json(
                     &body,
                     &inference_result.text,

--- a/provider/src/main.rs
+++ b/provider/src/main.rs
@@ -1937,10 +1937,6 @@ async fn cmd_install(
         if let Some(m) = find_model("qwen3.5-27b-claude-opus") {
             defaults.push(m);
         }
-    } else if ram >= 24 {
-        if let Some(m) = find_model("flux_2_klein_9b") {
-            defaults.push(m);
-        }
     } else if ram >= 16 {
         if let Some(m) = find_model("Qwen3.5-4B-4bit") {
             defaults.push(m);

--- a/provider/src/main.rs
+++ b/provider/src/main.rs
@@ -92,6 +92,8 @@ struct CatalogModel {
     architecture: String,
     description: String,
     min_ram_gb: i32,
+    #[serde(default)]
+    internal_only: bool,
 }
 
 fn default_model_type() -> String {
@@ -132,6 +134,17 @@ fn fallback_catalog() -> Vec<CatalogModel> {
             min_ram_gb: 24,
         },
         CatalogModel {
+            id: "mlx-community/Qwen3.5-4B-4bit".into(),
+            s3_name: "Qwen3.5-4B-4bit".into(),
+            display_name: "Qwen3.5 4B Contributor".into(),
+            model_type: "text".into(),
+            size_gb: 4.0,
+            architecture: "4B dense".into(),
+            description: "Internal contributor model for Qwen speculative decoding".into(),
+            min_ram_gb: 16,
+            internal_only: true,
+        },
+        CatalogModel {
             id: "qwen3.5-27b-claude-opus-8bit".into(),
             s3_name: "qwen35-27b-claude-opus-8bit".into(),
             display_name: "Qwen3.5 27B Claude Opus".into(),
@@ -140,6 +153,7 @@ fn fallback_catalog() -> Vec<CatalogModel> {
             architecture: "27B dense, Claude Opus distilled".into(),
             description: "Frontier quality reasoning".into(),
             min_ram_gb: 36,
+            internal_only: false,
         },
         CatalogModel {
             id: "mlx-community/Trinity-Mini-8bit".into(),
@@ -150,6 +164,7 @@ fn fallback_catalog() -> Vec<CatalogModel> {
             architecture: "27B Adaptive MoE".into(),
             description: "Fast agentic inference".into(),
             min_ram_gb: 48,
+            internal_only: false,
         },
         CatalogModel {
             id: "mlx-community/gemma-4-26b-a4b-it-8bit".into(),
@@ -160,6 +175,7 @@ fn fallback_catalog() -> Vec<CatalogModel> {
             architecture: "26B MoE, 4B active".into(),
             description: "Fast multimodal MoE".into(),
             min_ram_gb: 36,
+            internal_only: false,
         },
         CatalogModel {
             id: "mlx-community/Qwen3.5-122B-A10B-8bit".into(),
@@ -170,6 +186,7 @@ fn fallback_catalog() -> Vec<CatalogModel> {
             architecture: "122B MoE, 10B active".into(),
             description: "Best quality".into(),
             min_ram_gb: 128,
+            internal_only: false,
         },
         CatalogModel {
             id: "mlx-community/MiniMax-M2.5-8bit".into(),
@@ -180,6 +197,7 @@ fn fallback_catalog() -> Vec<CatalogModel> {
             architecture: "239B MoE, 11B active".into(),
             description: "SOTA coding, 100 tok/s".into(),
             min_ram_gb: 256,
+            internal_only: false,
         },
     ]
 }
@@ -1924,7 +1942,7 @@ async fn cmd_install(
             defaults.push(m);
         }
     } else if ram >= 16 {
-        if let Some(m) = find_model("flux_2_klein_4b") {
+        if let Some(m) = find_model("Qwen3.5-4B-4bit") {
             defaults.push(m);
         }
     } else {

--- a/provider/src/proxy.rs
+++ b/provider/src/proxy.rs
@@ -352,7 +352,9 @@ async fn handle_streaming_request(
                         }
                     }
 
-                    // Extract content from delta chunks for token counting and signing
+                    // Extract content from streaming chunks for token counting and
+                    // signing. Chat streams use choices[].delta.content while
+                    // completions streams use choices[].text.
                     if let Some(choices) = chunk_json.get("choices").and_then(|v| v.as_array()) {
                         for choice in choices {
                             if let Some(content) = choice
@@ -362,6 +364,10 @@ async fn handle_streaming_request(
                             {
                                 total_completion_tokens += 1;
                                 response_content.push_str(content);
+                            }
+                            if let Some(text) = choice.get("text").and_then(|c| c.as_str()) {
+                                total_completion_tokens += 1;
+                                response_content.push_str(text);
                             }
                             // Also capture reasoning/thinking content
                             if let Some(reasoning) = choice
@@ -376,6 +382,16 @@ async fn handle_streaming_request(
                 }
 
                 // Forward the SSE line to coordinator
+                outbound_tx
+                    .send(ProviderMessage::InferenceResponseChunk {
+                        request_id: request_id.to_string(),
+                        data: line.clone(),
+                    })
+                    .await
+                    .ok();
+            } else {
+                // Preserve non-data SSE lines (for example Anthropic event: ... lines)
+                // so the coordinator can relay raw streaming protocols unchanged.
                 outbound_tx
                     .send(ProviderMessage::InferenceResponseChunk {
                         request_id: request_id.to_string(),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Add an internal-only contributor model tier plus coordinator-driven deterministic speculative execution so smaller Macs can contribute draft text compute without changing the authoritative target-model output. This also wires the contributor model through the coordinator/provider/app catalogs, tightens routing so internal models are never consumer-routable, and fixes generic inference cleanup/passthrough paths touched by the new control flow.

## Linked issue

Closes #

## Test plan

- [x] `cd coordinator && go test ./internal/registry ./internal/store ./internal/api -count=1`
- [x] `cd coordinator && go test ./internal/api -run 'TestChatCompletionsNoProvider|TestStreamingE2E' -count=1 -v -timeout 30s`
- [x] `cd coordinator && go test ./internal/registry -run 'TestReserveProviderSkipsInternalContributorModels|TestReserveSpecificProviderAllowsInternalContributorModels' -count=1 -v -timeout 20s`
- [ ] `cd provider && cargo test ...` could not be run in this environment because the installed Cargo toolchain is too old for the repo's Edition 2024 manifest

## Components touched

- [x] coordinator (Go)
- [x] provider (Rust)
- [ ] console-ui (Next.js)
- [ ] image-bridge (Python)
- [x] app (macOS Swift)
- [ ] enclave (Swift)
- [ ] infra / CI / release
- [ ] docs

## Protocol / interface changes

- [x] No protocol/interface changes
- [ ] Yes — described above and matching side updated

## Notes for reviewers

- Internal contributor models are present in the provider-facing catalog but hidden from consumer-facing model lists and direct routing.
- The speculative path is intentionally narrow: deterministic non-streaming Qwen ChatML requests only.
- The provider default in-process path was extended so raw `/v1/completions` requests used by internal speculation can return the `echo`/`logprobs` shape the coordinator verifier expects.
- `seedModelCatalog` now refreshes built-in contributor/speculation metadata on upgrade while preserving existing operator activation choices and stored weight hashes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2ab5814d-4ced-4541-b6c0-91210f8726bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2ab5814d-4ced-4541-b6c0-91210f8726bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

