### PR TITLE
fix: update benchmark script for current vllm_mlx API

### DIFF
--- a/provider/src/main.rs
+++ b/provider/src/main.rs
@@ -4395,44 +4395,47 @@ async fn cmd_benchmark() -> Result<()> {
     // Run benchmark via vllm-mlx: load model, measure prefill (TTFT) and decode (tok/s)
     let bench_script = format!(
         r#"
-import time, json, sys
+import time, json, sys, asyncio
 sys.path.insert(0, '.')
-from vllm_mlx.engine import MLXEngine
+from vllm_mlx.engine import SimpleEngine
 
-engine = MLXEngine(model="{model_path}", tokenizer="{model_path}")
+async def main():
+    engine = SimpleEngine(model_name="{model_path}")
 
-prompt = "Write a detailed analysis of the economic impact of artificial intelligence on the global workforce over the next decade."
+    prompt = "Write a detailed analysis of the economic impact of artificial intelligence on the global workforce over the next decade."
 
-# Warmup
-print("  Warming up...", flush=True)
-engine.generate(prompt, max_tokens=10)
+    # Warmup
+    print("  Warming up...", flush=True)
+    await engine.generate(prompt, max_tokens=10)
 
-# Benchmark: 3 runs
-results = []
-for run in range(3):
-    start = time.perf_counter()
-    tokens = []
-    first_token_time = None
-    for tok in engine.generate_stream(prompt, max_tokens=200):
-        if first_token_time is None:
-            first_token_time = time.perf_counter()
-        tokens.append(tok)
-    end = time.perf_counter()
+    # Benchmark: 3 runs
+    results = []
+    for run in range(3):
+        start = time.perf_counter()
+        token_count = 0
+        first_token_time = None
+        async for out in engine.stream_generate(prompt, max_tokens=200):
+            if first_token_time is None:
+                first_token_time = time.perf_counter()
+            token_count = out.completion_tokens
+        end = time.perf_counter()
 
-    ttft_ms = (first_token_time - start) * 1000 if first_token_time else 0
-    decode_time = end - first_token_time if first_token_time else end - start
-    n_tokens = len(tokens)
-    tps = n_tokens / decode_time if decode_time > 0 else 0
+        ttft_ms = (first_token_time - start) * 1000 if first_token_time else 0
+        decode_time = end - first_token_time if first_token_time else end - start
+        n_tokens = token_count
+        tps = n_tokens / decode_time if decode_time > 0 else 0
 
-    results.append({{"ttft_ms": ttft_ms, "tokens": n_tokens, "tps": tps, "total_s": end - start}})
-    print(f"  Run {{run+1}}: {{tps:.1f}} tok/s | TTFT {{ttft_ms:.0f}}ms | {{n_tokens}} tokens in {{end-start:.2f}}s", flush=True)
+        results.append({{"ttft_ms": ttft_ms, "tokens": n_tokens, "tps": tps, "total_s": end - start}})
+        print(f"  Run {{run+1}}: {{tps:.1f}} tok/s | TTFT {{ttft_ms:.0f}}ms | {{n_tokens}} tokens in {{end-start:.2f}}s", flush=True)
 
-# Summary
-avg_tps = sum(r["tps"] for r in results) / len(results)
-avg_ttft = sum(r["ttft_ms"] for r in results) / len(results)
-print()
-print(f"  Average: {{avg_tps:.1f}} tok/s | TTFT {{avg_ttft:.0f}}ms")
-print(json.dumps({{"avg_tps": avg_tps, "avg_ttft_ms": avg_ttft, "runs": results}}))
+    # Summary
+    avg_tps = sum(r["tps"] for r in results) / len(results)
+    avg_ttft = sum(r["ttft_ms"] for r in results) / len(results)
+    print()
+    print(f"  Average: {{avg_tps:.1f}} tok/s | TTFT {{avg_ttft:.0f}}ms")
+    print(json.dumps({{"avg_tps": avg_tps, "avg_ttft_ms": avg_ttft, "runs": results}}))
+
+asyncio.run(main())
 "#,
         model_path = model_path.display()
     );


### PR DESCRIPTION
MLXEngine was replaced by SimpleEngine, generate_stream by async stream_generate. Also fix cfg-gated type for inprocess_engine when building without the python feature.

```
darkbloom benchmark

  Darkbloom Benchmark
  ─────────────────────────────────────
  Apple M3 Ultra · 256 GB RAM · 80 GPU cores · 819 GB/s

  Select a model to benchmark:

    [1] Qwen3.5 27B Claude Opus Distilled (31.9 GB)

  Enter number [1-1] (or press Enter for [1]): 1

  Benchmarking: Qwen3.5 27B Claude Opus Distilled (31.9 GB)

  Loading model...

  Warming up...
  Run 1: 23.3 tok/s | TTFT 336ms | 200 tokens in 8.93s
  Run 2: 23.2 tok/s | TTFT 338ms | 200 tokens in 8.94s
  Run 3: 22.9 tok/s | TTFT 332ms | 200 tokens in 9.05s

  Average: 23.2 tok/s | TTFT 335ms
  ─────────────────────────────────────
  Result: 23.2 tok/s decode | 335ms TTFT
  Theoretical bandwidth utilization: 90%
  ``

## Components touched

<!-- Tick all that apply so reviewers know what to look at. -->

- [ ] coordinator (Go)
- [ ] provider (Rust)
- [ ] console-ui (Next.js)
- [ ] image-bridge (Python)
- [ ] app (macOS Swift)
- [ ] enclave (Swift)
- [ ] infra / CI / release
- [ ] docs

## Protocol / interface changes

<!--
If you changed a WebSocket message, an HTTP endpoint, a config key, or a CLI flag:
- Did you update the matching side? (provider/src/protocol.rs ↔ coordinator/internal/protocol/messages.go)
- Are bundle scripts (build-bundle.sh, install.sh, the Swift app launcher, LatestProviderVersion) still consistent?
- Does this need a version bump or a migration note?
-->

- [ ] No protocol/interface changes
- [ ] Yes — described above and matching side updated

## Notes for reviewers

<!-- Anything non-obvious: tradeoffs taken, edge cases not covered, follow-ups planned. -->
