### PR TITLE
[codex] fix provider telemetry URL and retire provider catalog models

### DIFF
--- a/coordinator/cmd/coordinator/main.go
+++ b/coordinator/cmd/coordinator/main.go
@@ -556,11 +556,21 @@ func envInt(key string, fallback int) int {
 
 // seedModelCatalog ensures all hardcoded models exist in the catalog.
 // On first startup it populates everything; on subsequent starts it adds
-// any new models that were added to the code but not yet in the DB.
+// any new models that were added to the code but not yet in the DB and removes
+// catalog entries that should no longer be provider-selectable.
 func seedModelCatalog(st store.Store, logger *slog.Logger) {
 	existing := st.ListSupportedModels()
 	existingIDs := make(map[string]bool, len(existing))
+	removed := 0
 	for _, m := range existing {
+		if api.IsRetiredProviderModel(m) {
+			if err := st.DeleteSupportedModel(m.ID); err != nil {
+				logger.Warn("failed to remove retired model", "id", m.ID, "error", err)
+			} else {
+				removed++
+			}
+			continue
+		}
 		existingIDs[m.ID] = true
 	}
 
@@ -575,6 +585,9 @@ func seedModelCatalog(st store.Store, logger *slog.Logger) {
 
 	added := 0
 	for i := range models {
+		if api.IsRetiredProviderModel(models[i]) {
+			continue
+		}
 		if existingIDs[models[i].ID] {
 			continue
 		}
@@ -584,8 +597,8 @@ func seedModelCatalog(st store.Store, logger *slog.Logger) {
 			added++
 		}
 	}
-	if added > 0 {
-		logger.Info("new models added to catalog", "added", added, "total", len(existing)+added)
+	if added > 0 || removed > 0 {
+		logger.Info("model catalog reconciled", "added", added, "removed", removed, "total", len(existing)+added-removed)
 	} else {
 		logger.Info("model catalog loaded", "count", len(existing))
 	}

--- a/coordinator/cmd/coordinator/main_test.go
+++ b/coordinator/cmd/coordinator/main_test.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/eigeninference/coordinator/internal/store"
+)
+
+func TestSeedModelCatalogRemovesRetiredProviderModels(t *testing.T) {
+	st := store.NewMemory("")
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	retired := []store.SupportedModel{
+		{
+			ID:          "black-forest-labs/FLUX.1-schnell",
+			S3Name:      "flux-4b",
+			DisplayName: "Flux 4B",
+			ModelType:   "image",
+			Active:      true,
+		},
+		{
+			ID:          "cohere/command-audio-stt",
+			S3Name:      "cohere-stt",
+			DisplayName: "Cohere STT",
+			ModelType:   "transcription",
+			Active:      true,
+		},
+	}
+	for _, model := range retired {
+		if err := st.SetSupportedModel(&model); err != nil {
+			t.Fatalf("SetSupportedModel(%q): %v", model.ID, err)
+		}
+	}
+
+	keep := store.SupportedModel{
+		ID:          "mlx-community/gemma-4-26b-a4b-it-8bit",
+		S3Name:      "gemma-4-26b-a4b-it-8bit",
+		DisplayName: "Gemma 4 26B",
+		ModelType:   "text",
+		Active:      true,
+	}
+	if err := st.SetSupportedModel(&keep); err != nil {
+		t.Fatalf("SetSupportedModel(%q): %v", keep.ID, err)
+	}
+
+	seedModelCatalog(st, logger)
+
+	models := st.ListSupportedModels()
+	byID := make(map[string]store.SupportedModel, len(models))
+	for _, model := range models {
+		byID[model.ID] = model
+	}
+	for _, model := range retired {
+		if _, ok := byID[model.ID]; ok {
+			t.Fatalf("retired model %q remained in catalog", model.ID)
+		}
+	}
+	if _, ok := byID[keep.ID]; !ok {
+		t.Fatalf("supported model %q was removed", keep.ID)
+	}
+	if _, ok := byID["qwen3.5-27b-claude-opus-8bit"]; !ok {
+		t.Fatalf("seeded text model missing")
+	}
+}

--- a/coordinator/internal/api/billing_handlers.go
+++ b/coordinator/internal/api/billing_handlers.go
@@ -644,7 +644,7 @@ func (s *Server) handleModelCatalog(w http.ResponseWriter, r *http.Request) {
 	// Filter to active models only (and by type if specified)
 	var active []store.SupportedModel
 	for _, m := range allModels {
-		if !m.Active {
+		if !m.Active || IsRetiredProviderModel(m) {
 			continue
 		}
 		if typeFilter != "" && m.ModelType != typeFilter {

--- a/coordinator/internal/api/consumer.go
+++ b/coordinator/internal/api/consumer.go
@@ -1234,7 +1234,7 @@ func (s *Server) handleListModels(w http.ResponseWriter, r *http.Request) {
 	catalogModels := s.store.ListSupportedModels()
 	catalogByID := make(map[string]store.SupportedModel, len(catalogModels))
 	for _, cm := range catalogModels {
-		if cm.Active {
+		if cm.Active && !IsRetiredProviderModel(cm) {
 			catalogByID[cm.ID] = cm
 		}
 	}

--- a/coordinator/internal/api/edge_case_test.go
+++ b/coordinator/internal/api/edge_case_test.go
@@ -633,6 +633,60 @@ func TestEdge_ModelsEndpointNoProviders(t *testing.T) {
 	// This verifies the endpoint doesn't crash with no providers
 }
 
+func TestEdge_ModelCatalogHidesRetiredProviderModels(t *testing.T) {
+	srv, st := testServer(t)
+
+	models := []store.SupportedModel{
+		{
+			ID:          "black-forest-labs/FLUX.1-schnell",
+			S3Name:      "flux-4b",
+			DisplayName: "Flux 4B",
+			ModelType:   "image",
+			Active:      true,
+		},
+		{
+			ID:          "cohere/command-audio-stt",
+			S3Name:      "cohere-stt",
+			DisplayName: "Cohere STT",
+			ModelType:   "transcription",
+			Active:      true,
+		},
+		{
+			ID:          "qwen3.5-27b-claude-opus-8bit",
+			S3Name:      "qwen35-27b-claude-opus-8bit",
+			DisplayName: "Qwen3.5 27B Claude Opus",
+			ModelType:   "text",
+			Active:      true,
+		},
+	}
+	for _, model := range models {
+		if err := st.SetSupportedModel(&model); err != nil {
+			t.Fatalf("SetSupportedModel(%q): %v", model.ID, err)
+		}
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/models/catalog", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("models catalog: status = %d, want 200", w.Code)
+	}
+
+	var resp struct {
+		Models []store.SupportedModel `json:"models"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(resp.Models) != 1 {
+		t.Fatalf("models len = %d, want 1: %#v", len(resp.Models), resp.Models)
+	}
+	if resp.Models[0].ID != "qwen3.5-27b-claude-opus-8bit" {
+		t.Fatalf("model = %q, want qwen text model", resp.Models[0].ID)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Release API edge cases
 // ---------------------------------------------------------------------------

--- a/coordinator/internal/api/model_catalog_filter.go
+++ b/coordinator/internal/api/model_catalog_filter.go
@@ -1,0 +1,35 @@
+package api
+
+import (
+	"strings"
+
+	"github.com/eigeninference/coordinator/internal/store"
+)
+
+// IsRetiredProviderModel returns true for catalog entries that should never be
+// provider-selectable, even if a stale row is still present in the store.
+func IsRetiredProviderModel(model store.SupportedModel) bool {
+	fields := []string{
+		model.ID,
+		model.S3Name,
+		model.DisplayName,
+	}
+	for _, field := range fields {
+		if containsRetiredProviderModelToken(field) {
+			return true
+		}
+	}
+	return false
+}
+
+func containsRetiredProviderModelToken(value string) bool {
+	tokens := strings.FieldsFunc(strings.ToLower(value), func(r rune) bool {
+		return (r < 'a' || r > 'z') && (r < '0' || r > '9')
+	})
+	for _, token := range tokens {
+		if token == "cohere" || token == "coherelabs" || token == "flux" || strings.HasPrefix(token, "flux") {
+			return true
+		}
+	}
+	return false
+}

--- a/coordinator/internal/api/server.go
+++ b/coordinator/internal/api/server.go
@@ -397,7 +397,7 @@ func (s *Server) SyncModelCatalog() {
 	models := s.store.ListSupportedModels()
 	entries := make([]registry.CatalogEntry, 0, len(models))
 	for _, m := range models {
-		if m.Active {
+		if m.Active && !IsRetiredProviderModel(m) {
 			entries = append(entries, registry.CatalogEntry{
 				ID:         m.ID,
 				WeightHash: m.WeightHash,

--- a/provider/src/main.rs
+++ b/provider/src/main.rs
@@ -102,7 +102,7 @@ fn default_model_type() -> String {
 
 /// Hardcoded fallback catalog used when the coordinator is unreachable.
 fn fallback_catalog() -> Vec<CatalogModel> {
-    vec![
+    filter_provider_catalog(vec![
         CatalogModel {
             id: "qwen3.5-27b-claude-opus-8bit".into(),
             s3_name: "qwen35-27b-claude-opus-8bit".into(),
@@ -153,7 +153,36 @@ fn fallback_catalog() -> Vec<CatalogModel> {
             description: "SOTA coding, 100 tok/s".into(),
             min_ram_gb: 256,
         },
+    ])
+}
+
+fn is_retired_provider_model(model: &CatalogModel) -> bool {
+    [
+        model.id.as_str(),
+        model.s3_name.as_str(),
+        model.display_name.as_str(),
     ]
+    .iter()
+    .any(|field| contains_retired_provider_model_token(field))
+}
+
+fn contains_retired_provider_model_token(value: &str) -> bool {
+    value
+        .to_ascii_lowercase()
+        .split(|c: char| !c.is_ascii_alphanumeric())
+        .any(|token| {
+            token == "cohere"
+                || token == "coherelabs"
+                || token == "flux"
+                || token.starts_with("flux")
+        })
+}
+
+fn filter_provider_catalog(models: Vec<CatalogModel>) -> Vec<CatalogModel> {
+    models
+        .into_iter()
+        .filter(|model| !is_retired_provider_model(model))
+        .collect()
 }
 
 /// Get available disk space in GB for the home directory.
@@ -1329,7 +1358,15 @@ async fn fetch_catalog(coordinator_url: &str) -> Vec<CatalogModel> {
                 models: Vec<CatalogModel>,
             }
             match resp.json::<CatalogResponse>().await {
-                Ok(cr) if !cr.models.is_empty() => cr.models,
+                Ok(cr) => {
+                    let models = filter_provider_catalog(cr.models);
+                    if !models.is_empty() {
+                        models
+                    } else {
+                        eprintln!("  ⚠ Empty catalog from coordinator, using defaults");
+                        fallback_catalog()
+                    }
+                }
                 _ => {
                     eprintln!("  ⚠ Empty catalog from coordinator, using defaults");
                     fallback_catalog()
@@ -6528,6 +6565,47 @@ mod tests {
         perms.set_mode(0o755);
         std::fs::set_permissions(&path, perms).expect("failed to chmod temp script");
         path
+    }
+
+    #[test]
+    fn test_filter_provider_catalog_removes_retired_flux_and_cohere_models() {
+        let models = vec![
+            CatalogModel {
+                id: "black-forest-labs/FLUX.1-schnell".into(),
+                s3_name: "flux-4b".into(),
+                display_name: "Flux 4B".into(),
+                model_type: "image".into(),
+                size_gb: 4.0,
+                architecture: "diffusion".into(),
+                description: "Retired image model".into(),
+                min_ram_gb: 32,
+            },
+            CatalogModel {
+                id: "cohere/command-audio-stt".into(),
+                s3_name: "cohere-stt".into(),
+                display_name: "Cohere STT".into(),
+                model_type: "transcription".into(),
+                size_gb: 8.0,
+                architecture: "speech".into(),
+                description: "Retired audio model".into(),
+                min_ram_gb: 16,
+            },
+            CatalogModel {
+                id: "qwen3.5-27b-claude-opus-8bit".into(),
+                s3_name: "qwen35-27b-claude-opus-8bit".into(),
+                display_name: "Qwen3.5 27B Claude Opus".into(),
+                model_type: "text".into(),
+                size_gb: 27.0,
+                architecture: "27B dense".into(),
+                description: "Frontier quality reasoning".into(),
+                min_ram_gb: 36,
+            },
+        ];
+
+        let filtered = filter_provider_catalog(models);
+
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].id, "qwen3.5-27b-claude-opus-8bit");
     }
 
     #[test]

--- a/provider/src/telemetry/client.rs
+++ b/provider/src/telemetry/client.rs
@@ -13,7 +13,8 @@ use tokio::sync::mpsc;
 /// Configuration for the telemetry client.
 #[derive(Debug, Clone)]
 pub struct TelemetryConfig {
-    /// Coordinator base URL (e.g. "https://inference-test.openinnovation.dev").
+    /// Coordinator base URL. HTTP(S) bases are used as-is; provider WebSocket
+    /// URLs are normalized to the coordinator's HTTPS ingest base.
     pub coordinator_url: String,
     /// Device-linked auth token for `Authorization: Bearer ...`. Optional —
     /// when absent, the client sends events anonymously and accepts stricter
@@ -154,10 +155,7 @@ async fn run_worker(mut rx: mpsc::Receiver<TelemetryEvent>, cfg: Arc<TelemetryCo
         .build()
         .expect("telemetry: failed to build HTTP client");
 
-    let endpoint = format!(
-        "{}/v1/telemetry/events",
-        cfg.coordinator_url.trim_end_matches('/')
-    );
+    let endpoint = telemetry_ingest_endpoint(&cfg.coordinator_url);
 
     let mut buffer: Vec<TelemetryEvent> = Vec::with_capacity(cfg.max_batch);
     let mut ticker = tokio::time::interval(cfg.flush_interval);
@@ -247,5 +245,46 @@ async fn drain_disk(http: &reqwest::Client, endpoint: &str, cfg: &TelemetryConfi
         for ev in batch.events {
             let _ = q.push(&ev);
         }
+    }
+}
+
+fn telemetry_ingest_endpoint(coordinator_url: &str) -> String {
+    let base = coordinator_url.trim_end_matches('/');
+    let base = if let Some(rest) = base.strip_prefix("wss://") {
+        format!("https://{rest}")
+    } else if let Some(rest) = base.strip_prefix("ws://") {
+        format!("http://{rest}")
+    } else {
+        base.to_string()
+    };
+    let base = base
+        .strip_suffix("/ws/provider")
+        .unwrap_or(&base)
+        .trim_end_matches('/');
+    format!("{base}/v1/telemetry/events")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::telemetry_ingest_endpoint;
+
+    #[test]
+    fn telemetry_endpoint_uses_https_base_for_provider_wss_url() {
+        assert_eq!(
+            telemetry_ingest_endpoint("wss://api.darkbloom.dev/ws/provider"),
+            "https://api.darkbloom.dev/v1/telemetry/events"
+        );
+    }
+
+    #[test]
+    fn telemetry_endpoint_preserves_http_base_urls() {
+        assert_eq!(
+            telemetry_ingest_endpoint("http://localhost:8080"),
+            "http://localhost:8080/v1/telemetry/events"
+        );
+        assert_eq!(
+            telemetry_ingest_endpoint("https://api.darkbloom.dev/"),
+            "https://api.darkbloom.dev/v1/telemetry/events"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Normalize provider telemetry coordinator URLs so WebSocket provider URLs resolve to the HTTPS telemetry ingest endpoint.
- Filter retired Flux/Cohere provider models out of coordinator catalog surfaces and provider catalog fetch/fallback handling.
- Add coverage for telemetry URL normalization and retired model catalog filtering.

## Root Cause

Provider telemetry was initialized with the provider WebSocket URL, then the telemetry client appended `/v1/telemetry/events`, producing an invalid `wss://.../ws/provider/v1/telemetry/events` URL for an HTTP POST.

## Validation

- `cargo fmt --check`
- `PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 cargo test telemetry_endpoint --no-default-features`
- `go test -count=1 ./...` from `coordinator/`
- pre-push hook: all checks passed