### PR TITLE
Add provider discounts and cost routing

### DIFF
--- a/console-ui/__tests__/api-routes.test.ts
+++ b/console-ui/__tests__/api-routes.test.ts
@@ -108,6 +108,40 @@ describe("GET /api/me/summary", () => {
 });
 
 // =========================================================================
+// POST /api/chat
+// =========================================================================
+
+describe("POST /api/chat", () => {
+  it("forwards routing preference header and query param to coordinator", async () => {
+    upstreamFetch.mockResolvedValueOnce(
+      new Response("ok", {
+        status: 200,
+        headers: { "Content-Type": "text/plain" },
+      })
+    );
+
+    const { POST } = await import("@/app/api/chat/route");
+    const req = makeRequest("/api/chat?routing_preference=cost", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-api-key": "key123",
+        "x-darkbloom-routing-preference": "cost",
+      },
+      body: JSON.stringify({ model: "model-a", messages: [] }),
+    });
+    const res = await POST(req);
+
+    expect(res.status).toBe(200);
+    const [upstreamUrl, upstreamOpts] = upstreamFetch.mock.calls[0];
+    expect(String(upstreamUrl)).toBe(`${DEFAULT_COORD}/v1/chat/completions?routing_preference=cost`);
+    expect(upstreamOpts.headers.Authorization).toBe("Bearer key123");
+    expect(upstreamOpts.headers["X-Darkbloom-Routing-Preference"]).toBe("cost");
+    expect(JSON.parse(upstreamOpts.body)).toEqual({ model: "model-a", messages: [] });
+  });
+});
+
+// =========================================================================
 // GET /api/payments/balance
 // =========================================================================
 

--- a/console-ui/__tests__/api.test.ts
+++ b/console-ui/__tests__/api.test.ts
@@ -7,6 +7,7 @@ import {
   fetchModels,
   fetchPricing,
   healthCheck,
+  streamChat,
 } from "@/lib/api";
 
 // ---------------------------------------------------------------------------
@@ -57,6 +58,7 @@ afterEach(() => {
 
 describe("fetchBalance", () => {
   it("calls /api/payments/balance with correct headers", async () => {
+    localStorage.setItem("darkbloom_api_key", "test-key");
     const payload = { balance_micro_usd: 5_000_000, balance_usd: 5.0 };
     fetchMock.mockResolvedValueOnce(jsonResponse(payload));
 
@@ -73,6 +75,74 @@ describe("fetchBalance", () => {
   it("throws on non-ok response", async () => {
     fetchMock.mockResolvedValueOnce(jsonResponse({}, 500));
     await expect(fetchBalance()).rejects.toThrow("Failed to fetch balance: 500");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// streamChat routing preference
+// ---------------------------------------------------------------------------
+
+function sseDoneResponse(): Response {
+  const bytes = new TextEncoder().encode("data: [DONE]\n\n");
+  return new Response(
+    new ReadableStream({
+      start(controller) {
+        controller.enqueue(bytes);
+        controller.close();
+      },
+    }),
+    {
+      status: 200,
+      headers: { "Content-Type": "text/event-stream" },
+    }
+  );
+}
+
+function streamCallbacks() {
+  return {
+    onToken: vi.fn(),
+    onThinking: vi.fn(),
+    onMetrics: vi.fn(),
+    onDone: vi.fn(),
+    onError: vi.fn(),
+  };
+}
+
+describe("streamChat routing preference", () => {
+  it("sends lowest-cost preference in body and header", async () => {
+    fetchMock.mockResolvedValueOnce(sseDoneResponse());
+    const callbacks = streamCallbacks();
+
+    await streamChat(
+      [{ role: "user", content: "hi" }],
+      "model-a",
+      callbacks,
+      undefined,
+      { routingPreference: "cost" }
+    );
+
+    const [url, opts] = fetchMock.mock.calls[0];
+    expect(url).toBe("/api/chat");
+    expect(opts.headers["X-Darkbloom-Routing-Preference"]).toBe("cost");
+    expect(JSON.parse(opts.body)).toMatchObject({
+      model: "model-a",
+      routing_preference: "cost",
+    });
+    expect(callbacks.onDone).toHaveBeenCalledOnce();
+  });
+
+  it("keeps performance default wire-compatible", async () => {
+    fetchMock.mockResolvedValueOnce(sseDoneResponse());
+
+    await streamChat(
+      [{ role: "user", content: "hi" }],
+      "model-a",
+      streamCallbacks()
+    );
+
+    const [, opts] = fetchMock.mock.calls[0];
+    expect(opts.headers["X-Darkbloom-Routing-Preference"]).toBeUndefined();
+    expect(JSON.parse(opts.body).routing_preference).toBeUndefined();
   });
 });
 

--- a/console-ui/__tests__/chat-routing.test.tsx
+++ b/console-ui/__tests__/chat-routing.test.tsx
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { ChatInput } from "@/components/ChatInput";
+
+vi.mock("@/lib/store", () => ({
+  useStore: () => ({
+    selectedModel: "model-a",
+    models: [{ id: "model-a", display_name: "Model A" }],
+    setSelectedModel: vi.fn(),
+  }),
+}));
+
+vi.mock("@/lib/google-analytics", () => ({
+  trackEvent: vi.fn(),
+}));
+
+describe("ChatInput routing selector", () => {
+  it("emits cost preference when Lowest cost is selected", () => {
+    const onRoutingPreferenceChange = vi.fn();
+    render(
+      <ChatInput
+        onSend={vi.fn()}
+        onStop={vi.fn()}
+        isStreaming={false}
+        routingPreference="performance"
+        onRoutingPreferenceChange={onRoutingPreferenceChange}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Lowest cost/i }));
+
+    expect(onRoutingPreferenceChange).toHaveBeenCalledWith("cost");
+  });
+});

--- a/console-ui/__tests__/pages.test.tsx
+++ b/console-ui/__tests__/pages.test.tsx
@@ -1,6 +1,12 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen } from "@testing-library/react";
 
+const authMocks = vi.hoisted(() => ({
+  getAccessToken: vi.fn().mockResolvedValue("mock-token"),
+  login: vi.fn(),
+  logout: vi.fn(),
+}));
+
 // ---------------------------------------------------------------------------
 // Mock modules used by page components. We mock at the module level so the
 // pages can import them without hitting Privy, Zustand persistence, etc.
@@ -29,9 +35,9 @@ vi.mock("@/hooks/useAuth", () => ({
     ready: true,
     authenticated: true,
     user: null,
-    login: vi.fn(),
-    logout: vi.fn(),
-    getAccessToken: vi.fn().mockResolvedValue("mock-token"),
+    login: authMocks.login,
+    logout: authMocks.logout,
+    getAccessToken: authMocks.getAccessToken,
     email: null,
     walletAddress: null,
     displayName: null,
@@ -44,9 +50,9 @@ vi.mock("@/components/providers/PrivyClientProvider", () => ({
     ready: true,
     authenticated: true,
     user: null,
-    login: vi.fn(),
-    logout: vi.fn(),
-    getAccessToken: vi.fn().mockResolvedValue("mock-token"),
+    login: authMocks.login,
+    logout: authMocks.logout,
+    getAccessToken: authMocks.getAccessToken,
   }),
 }));
 
@@ -180,8 +186,8 @@ describe("BillingPage", () => {
     // TopBar is mocked and should show "Billing"
     expect(screen.getByTestId("topbar")).toHaveTextContent("Billing");
 
-    // Research preview banner — purchases disabled, Buy Credits button present
-    expect(screen.getByText("Available Credits")).toBeInTheDocument();
+    // Balance card and Buy Credits button present
+    expect(screen.getByText("Balance")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Buy Credits/i })).toBeInTheDocument();
 
     // Invite code section
@@ -231,6 +237,23 @@ describe("LinkPage", () => {
 });
 
 // =========================================================================
+// API Console page
+// =========================================================================
+
+describe("ApiConsolePage", () => {
+  it("renders routing preference examples", async () => {
+    const ApiConsolePage = (await import("@/app/api-console/page")).default;
+    render(<ApiConsolePage />);
+
+    expect(screen.getByText("Routing Preference")).toBeInTheDocument();
+    expect(screen.getByText("JSON Body")).toBeInTheDocument();
+    expect(screen.getByText("Header")).toBeInTheDocument();
+    expect(screen.getByText("Query Param")).toBeInTheDocument();
+    expect(screen.getAllByText(/routing_preference/).length).toBeGreaterThan(0);
+  });
+});
+
+// =========================================================================
 // Providers page
 // =========================================================================
 
@@ -240,17 +263,15 @@ describe("ProvidersPage", () => {
     render(<ProvidersPage />);
 
     await screen.findByRole("heading", { name: "Provider Dashboard" });
-    expect(screen.getByText(/Earnings, device health/)).toBeInTheDocument();
+    expect(screen.getByText("Your linked provider machines.")).toBeInTheDocument();
   });
 
-  it("shows provider summary stats", async () => {
+  it("shows the rebuild notice", async () => {
     const ProvidersPage = (await import("@/app/providers/page")).default;
     render(<ProvidersPage />);
 
-    await screen.findByText("Devices online");
-    expect(screen.getByText("Needs attention")).toBeInTheDocument();
-    expect(screen.getByText("Available earnings")).toBeInTheDocument();
-    expect(screen.getByText("Lifetime earnings")).toBeInTheDocument();
+    await screen.findByText("We're rebuilding this page");
+    expect(screen.getByText(/Detailed machine stats/)).toBeInTheDocument();
   });
 
   it("shows onboarding actions when no devices are linked", async () => {

--- a/console-ui/__tests__/provider-pricing-page.test.tsx
+++ b/console-ui/__tests__/provider-pricing-page.test.tsx
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+
+const authMocks = vi.hoisted(() => ({
+  getAccessToken: vi.fn().mockResolvedValue("privy-token"),
+  login: vi.fn(),
+}));
+
+vi.mock("@/hooks/useAuth", () => ({
+  useAuth: () => ({
+    ready: true,
+    authenticated: true,
+    login: authMocks.login,
+    getAccessToken: authMocks.getAccessToken,
+  }),
+}));
+
+describe("ProviderPricingPage", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.endsWith("/v1/pricing/me")) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              account_id: "acct-1",
+              max_discount_percent: 90,
+              discounts: [
+                {
+                  scope: "account_global",
+                  discount_bps: 2000,
+                  discount_percent: 20,
+                },
+              ],
+              prices: [
+                {
+                  model: "model-a",
+                  base_input_price: 100000,
+                  base_output_price: 200000,
+                  input_price: 80000,
+                  output_price: 160000,
+                  discount_bps: 2000,
+                  discount_percent: 20,
+                  discount_scope: "account_global",
+                  input_usd: "$0.0800",
+                  output_usd: "$0.1600",
+                },
+              ],
+            }),
+            { status: 200 }
+          )
+        );
+      }
+      if (url.endsWith("/v1/me/providers")) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              providers: [
+                {
+                  id: "provider-1",
+                  serial_number: "SERIAL-1",
+                  hardware: { chip_name: "M4 Max" },
+                  models: [],
+                  reputation: {},
+                },
+              ],
+            }),
+            { status: 200 }
+          )
+        );
+      }
+      return Promise.resolve(new Response("not found", { status: 404 }));
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    vi.stubGlobal("localStorage", {
+      getItem: vi.fn().mockReturnValue(null),
+      setItem: vi.fn(),
+      removeItem: vi.fn(),
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders discount forms and effective price preview", async () => {
+    const ProviderPricingPage = (await import("@/app/providers/pricing/page")).default;
+    render(<ProviderPricingPage />);
+
+    expect(await screen.findByText("Account Default")).toBeInTheDocument();
+    expect(screen.getByText("Account Model")).toBeInTheDocument();
+    expect(screen.getByText("Machine Model")).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.getAllByText("model-a").length).toBeGreaterThan(0);
+    });
+    expect(screen.getByText("$0.0800")).toBeInTheDocument();
+    expect(screen.getByText("$0.1600")).toBeInTheDocument();
+    expect(screen.getAllByText("20.00%").length).toBeGreaterThan(0);
+  });
+});

--- a/console-ui/src/app/api-console/page.tsx
+++ b/console-ui/src/app/api-console/page.tsx
@@ -47,7 +47,8 @@ const ENDPOINTS = [
     {"role": "user", "content": "Hello!"}
   ],
   "stream": true,
-  "max_tokens": 1024
+  "max_tokens": 1024,
+  "routing_preference": "performance"
 }`,
     response: `{
   "id": "chatcmpl-...",
@@ -59,7 +60,7 @@ const ENDPOINTS = [
     "finish_reason": null
   }]
 }`,
-    notes: "Supports streaming (SSE) and non-streaming responses. All prompts are end-to-end encrypted. Response headers include provider attestation metadata (x-provider-attested, x-provider-trust-level, x-provider-chip).",
+    notes: "Supports streaming (SSE) and non-streaming responses. routing_preference defaults to performance; set cost to route to the lowest estimated provider price. Response headers include provider attestation metadata (x-provider-attested, x-provider-trust-level, x-provider-chip).",
   },
   {
     method: "POST",
@@ -450,6 +451,44 @@ console.log(text);`,
     },
   ];
 
+  const routingExample = [
+    {
+      label: "JSON Body",
+      language: "bash",
+      code: `curl -X POST ${u}/v1/chat/completions \\
+  -H "Authorization: Bearer ${k}" \\
+  -H "Content-Type: application/json" \\
+  -d '{
+    "model": "mlx-community/gemma-4-26b-a4b-it-8bit",
+    "messages": [{"role": "user", "content": "Summarize this"}],
+    "routing_preference": "cost"
+  }'`,
+    },
+    {
+      label: "Header",
+      language: "bash",
+      code: `curl -X POST ${u}/v1/chat/completions \\
+  -H "Authorization: Bearer ${k}" \\
+  -H "Content-Type: application/json" \\
+  -H "X-Darkbloom-Routing-Preference: cost" \\
+  -d '{
+    "model": "mlx-community/gemma-4-26b-a4b-it-8bit",
+    "messages": [{"role": "user", "content": "Summarize this"}]
+  }'`,
+    },
+    {
+      label: "Query Param",
+      language: "bash",
+      code: `curl -X POST "${u}/v1/chat/completions?routing_preference=cost" \\
+  -H "Authorization: Bearer ${k}" \\
+  -H "Content-Type: application/json" \\
+  -d '{
+    "model": "mlx-community/gemma-4-26b-a4b-it-8bit",
+    "messages": [{"role": "user", "content": "Summarize this"}]
+  }'`,
+    },
+  ];
+
   const modelsExample = [
     {
       label: "Python",
@@ -502,7 +541,7 @@ for model in models.data:
               <h3 className="text-sm font-semibold text-text-primary mb-2">Base URL</h3>
               <p className="text-sm font-mono text-accent-brand">{coordinatorUrl}/v1</p>
               <p className="text-xs text-text-tertiary mt-2">
-                All endpoints are relative to this base URL. Provider attestation and pricing endpoints are publicly accessible without authentication.
+                All endpoints are relative to this base URL. Provider attestation and base pricing endpoints are publicly accessible without authentication.
               </p>
             </div>
           </section>
@@ -599,6 +638,14 @@ for model in models.data:
               Stream chat completions with any supported model. Supports system messages, multi-turn conversations, and thinking/reasoning output.
             </p>
             <CodeExample examples={chatExample} />
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-text-primary mb-2">Routing Preference</h2>
+            <p className="text-sm text-text-secondary mb-4">
+              Use <code className="text-accent-brand">performance</code> or <code className="text-accent-brand">perf</code> for the default scheduler, or <code className="text-accent-brand">cost</code> for lowest estimated provider price.
+            </p>
+            <CodeExample examples={routingExample} />
           </section>
 
           {/* List Models */}

--- a/console-ui/src/app/api/chat/route.ts
+++ b/console-ui/src/app/api/chat/route.ts
@@ -13,6 +13,12 @@ export async function POST(req: NextRequest) {
   const apiKey = req.headers.get("x-api-key") || "";
   const incomingCt = req.headers.get("content-type") || "application/json";
   const isSealed = incomingCt.toLowerCase().startsWith(SEALED_CT);
+  const routingPreference = req.headers.get("x-darkbloom-routing-preference") || "";
+  const upstreamUrl = new URL(`${coordUrl}/v1/chat/completions`);
+  const routingQuery = req.nextUrl.searchParams.get("routing_preference");
+  if (routingQuery) {
+    upstreamUrl.searchParams.set("routing_preference", routingQuery);
+  }
 
   // Forward the body bytes verbatim. For plaintext we keep the existing
   // JSON-roundtrip behavior (preserves the existing tests); for sealed we
@@ -30,11 +36,12 @@ export async function POST(req: NextRequest) {
     headers: {
       "Content-Type": isSealed ? SEALED_CT : "application/json",
       ...(apiKey ? { Authorization: `Bearer ${apiKey}` } : {}),
+      ...(routingPreference ? { "X-Darkbloom-Routing-Preference": routingPreference } : {}),
     },
     body: isSealed ? bodyBytes : JSON.stringify(await req.json()),
   };
 
-  const upstream = await fetch(`${coordUrl}/v1/chat/completions`, fetchInit);
+  const upstream = await fetch(upstreamUrl, fetchInit);
 
   const respHeaders = new Headers();
   // Pass-through content type so sealed responses keep their advertised type.

--- a/console-ui/src/app/page.tsx
+++ b/console-ui/src/app/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useCallback, useState } from "react";
 import { useStore } from "@/lib/store";
 import { streamChat, fetchModels } from "@/lib/api";
+import type { RoutingPreference } from "@/lib/api";
 import { useToastStore } from "@/hooks/useToast";
 import { useAuth } from "@/hooks/useAuth";
 import { ChatMessage } from "@/components/ChatMessage";
@@ -38,6 +39,13 @@ const SUGGESTED_PROMPTS = [
   { label: "Explain zero-knowledge proofs", prompt: "What are zero-knowledge proofs and how are they used in blockchain?" },
 ];
 
+const ROUTING_PREF_STORAGE = "darkbloom_routing_preference";
+
+function readRoutingPreference(): RoutingPreference {
+  if (typeof window === "undefined") return "performance";
+  return localStorage.getItem(ROUTING_PREF_STORAGE) === "cost" ? "cost" : "performance";
+}
+
 export default function ChatPage() {
   const {
     chats,
@@ -57,6 +65,7 @@ export default function ChatPage() {
   const abortRef = useRef<AbortController | null>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
   const [isStreaming, setIsStreaming] = useState(false);
+  const [routingPreference, setRoutingPreference] = useState<RoutingPreference>("performance");
 
   const activeChat = chats.find((c) => c.id === activeChatId);
 
@@ -74,6 +83,20 @@ export default function ChatPage() {
     }
     bootstrap();
   }, [setModels, authenticated, apiKeyReady]);
+
+  useEffect(() => {
+    setRoutingPreference(readRoutingPreference());
+  }, []);
+
+  const updateRoutingPreference = useCallback((preference: RoutingPreference) => {
+    setRoutingPreference(preference);
+    if (typeof window !== "undefined") {
+      localStorage.setItem(ROUTING_PREF_STORAGE, preference);
+    }
+    trackEvent("chat_routing_preference_changed", {
+      routing_preference: preference,
+    });
+  }, []);
 
   useEffect(() => {
     if (scrollRef.current) {
@@ -198,7 +221,8 @@ export default function ChatPage() {
               setIsStreaming(false);
             },
           },
-          abort.signal
+          abort.signal,
+          { routingPreference }
         );
       } catch (err) {
         if ((err as Error).name !== "AbortError") {
@@ -226,6 +250,7 @@ export default function ChatPage() {
       appendToThinking,
       updateChatTitle,
       selectedModel,
+      routingPreference,
       addToast,
     ]
   );
@@ -306,7 +331,8 @@ export default function ChatPage() {
             setIsStreaming(false);
           },
         },
-        abort.signal
+        abort.signal,
+        { routingPreference }
       ).catch((err) => {
         if ((err as Error).name !== "AbortError") {
           trackEvent("chat_error", {
@@ -321,7 +347,7 @@ export default function ChatPage() {
         setIsStreaming(false);
       });
     },
-    [activeChat, isStreaming, authenticated, apiKeyReady, selectedModel, updateMessage, appendToMessage, appendToThinking, addToast]
+    [activeChat, isStreaming, authenticated, apiKeyReady, selectedModel, routingPreference, updateMessage, appendToMessage, appendToThinking, addToast]
   );
 
   return (
@@ -438,6 +464,8 @@ export default function ChatPage() {
         isStreaming={isStreaming}
         authenticated={authenticated}
         onLogin={login}
+        routingPreference={routingPreference}
+        onRoutingPreferenceChange={updateRoutingPreference}
       />
     </div>
   );

--- a/console-ui/src/app/providers/layout.tsx
+++ b/console-ui/src/app/providers/layout.tsx
@@ -7,6 +7,7 @@ import { usePathname } from "next/navigation";
 const TABS = [
   { href: "/providers", label: "Dashboard" },
   { href: "/providers/setup", label: "Setup" },
+  { href: "/providers/pricing", label: "Pricing" },
   { href: "/providers/earnings", label: "Earnings" },
 ];
 

--- a/console-ui/src/app/providers/pricing/page.tsx
+++ b/console-ui/src/app/providers/pricing/page.tsx
@@ -1,0 +1,574 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  CheckCircle2,
+  Layers,
+  Loader2,
+  Mail,
+  Monitor,
+  RefreshCw,
+  Save,
+  Tag,
+  Trash2,
+} from "lucide-react";
+import { useAuth } from "@/hooks/useAuth";
+import type { MyProvider, MyProvidersResponse } from "../types";
+
+interface ProviderDiscount {
+  account_id?: string;
+  provider_key?: string;
+  model?: string;
+  scope: string;
+  discount_bps: number;
+  discount_percent: number;
+}
+
+interface ProviderEffectivePrice {
+  model: string;
+  base_input_price: number;
+  base_output_price: number;
+  input_price: number;
+  output_price: number;
+  discount_bps: number;
+  discount_percent: number;
+  discount_scope?: string;
+  input_usd: string;
+  output_usd: string;
+}
+
+interface MyPricingResponse {
+  account_id: string;
+  discounts: ProviderDiscount[];
+  prices: ProviderEffectivePrice[];
+  max_discount_percent: number;
+}
+
+const SAVE_GLOBAL = "global";
+const SAVE_ACCOUNT_MODEL = "account-model";
+const SAVE_MACHINE_GLOBAL = "machine-global";
+const SAVE_MACHINE_MODEL = "machine-model";
+const MACHINE_SET_ERROR = "Link a provider machine before setting a machine discount.";
+const MACHINE_CLEAR_ERROR = "Link a provider machine before clearing a machine discount.";
+
+function coordinatorUrl() {
+  if (typeof window === "undefined") {
+    return process.env.NEXT_PUBLIC_COORDINATOR_URL || "https://api.darkbloom.dev";
+  }
+  return (
+    localStorage.getItem("darkbloom_coordinator_url") ||
+    process.env.NEXT_PUBLIC_COORDINATOR_URL ||
+    "https://api.darkbloom.dev"
+  );
+}
+
+function machineKey(provider: MyProvider) {
+  return provider.serial_number || provider.se_public_key || provider.id;
+}
+
+function machineLabel(provider: MyProvider) {
+  const chip = provider.hardware?.chip_name || "Mac";
+  const serial = provider.serial_number || provider.id.slice(0, 8);
+  return `${chip} · ${serial}`;
+}
+
+function scopeLabel(scope: string) {
+  switch (scope) {
+    case "machine_model":
+      return "Machine model";
+    case "machine_global":
+      return "Machine default";
+    case "account_model":
+      return "Account model";
+    case "account_global":
+      return "Account default";
+    default:
+      return scope.replaceAll("_", " ");
+  }
+}
+
+function formatMicroUSD(microUSD: number) {
+  return `$${(microUSD / 1_000_000).toFixed(4)}`;
+}
+
+function resolveDiscount(discounts: ProviderDiscount[], model: string, providerKey: string) {
+  const accountGlobal = discounts.find((d) => !d.provider_key && !d.model);
+  const accountModel = discounts.find((d) => !d.provider_key && d.model === model);
+  if (!providerKey) return accountModel || accountGlobal || null;
+  const machineGlobal = discounts.find((d) => d.provider_key === providerKey && !d.model);
+  const machineModel = discounts.find((d) => d.provider_key === providerKey && d.model === model);
+  return machineModel || machineGlobal || accountModel || accountGlobal || null;
+}
+
+function discountedPrice(base: number, discountBPS: number) {
+  if (base <= 0 || discountBPS <= 0) return base;
+  return Math.max(1, Math.floor((base * (10_000 - discountBPS)) / 10_000));
+}
+
+function DiscountEditor({
+  title,
+  icon: Icon,
+  value,
+  onChange,
+  onSave,
+  onClear,
+  saving,
+  children,
+}: {
+  title: string;
+  icon: React.ComponentType<{ size?: number; className?: string }>;
+  value: string;
+  onChange: (value: string) => void;
+  onSave: () => void;
+  onClear: () => void;
+  saving: boolean;
+  children?: React.ReactNode;
+}) {
+  return (
+    <div className="rounded-lg bg-bg-secondary p-5 space-y-4">
+      <div className="flex items-center gap-2">
+        <Icon size={16} className="text-accent-brand" />
+        <h2 className="text-sm font-semibold text-text-primary">{title}</h2>
+      </div>
+      {children}
+      <div className="flex flex-col sm:flex-row gap-2">
+        <label className="flex-1">
+          <span className="block text-xs text-text-tertiary mb-1">Discount percent</span>
+          <input
+            type="number"
+            min={0}
+            max={90}
+            step={0.01}
+            value={value}
+            onChange={(e) => onChange(e.target.value)}
+            className="w-full rounded-lg border border-border-dim bg-bg-white px-3 py-2 text-sm text-text-primary outline-none focus:border-accent-brand"
+          />
+        </label>
+        <div className="flex gap-2 sm:items-end">
+          <button
+            onClick={onSave}
+            disabled={saving}
+            className="inline-flex items-center justify-center gap-1.5 rounded-lg bg-coral px-4 py-2 text-sm font-medium text-white hover:opacity-90 disabled:opacity-50"
+          >
+            <Save size={14} />
+            Save
+          </button>
+          <button
+            onClick={onClear}
+            disabled={saving}
+            className="inline-flex items-center justify-center gap-1.5 rounded-lg border border-border-dim px-3 py-2 text-sm font-medium text-text-secondary hover:bg-bg-hover disabled:opacity-50"
+          >
+            <Trash2 size={14} />
+            Clear
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function ProviderPricingPage() {
+  const { ready, authenticated, login, getAccessToken } = useAuth();
+  const [data, setData] = useState<MyPricingResponse | null>(null);
+  const [providers, setProviders] = useState<MyProvider[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [saving, setSaving] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+  const [globalDiscount, setGlobalDiscount] = useState("");
+  const [accountModel, setAccountModel] = useState("");
+  const [accountModelDiscount, setAccountModelDiscount] = useState("");
+  const [machineGlobalKey, setMachineGlobalKey] = useState("");
+  const [machineGlobalDiscount, setMachineGlobalDiscount] = useState("");
+  const [machineModelKey, setMachineModelKey] = useState("");
+  const [machineModel, setMachineModel] = useState("");
+  const [machineModelDiscount, setMachineModelDiscount] = useState("");
+  const [previewMachineKey, setPreviewMachineKey] = useState("");
+
+  const modelOptions = useMemo(() => data?.prices.map((p) => p.model).sort() ?? [], [data]);
+
+  const loadPricing = useCallback(async () => {
+    setRefreshing(true);
+    setError(null);
+    try {
+      const token = await getAccessToken().catch(() => null);
+      if (!token) {
+        setError("Not authenticated");
+        return;
+      }
+      const headers = { Authorization: `Bearer ${token}` };
+      const [pricingRes, providersRes] = await Promise.all([
+        fetch(`${coordinatorUrl()}/v1/pricing/me`, { headers, cache: "no-store" }),
+        fetch(`${coordinatorUrl()}/v1/me/providers`, { headers, cache: "no-store" }).catch(() => null),
+      ]);
+      if (!pricingRes.ok) throw new Error(`pricing: HTTP ${pricingRes.status}`);
+      const pricing = (await pricingRes.json()) as MyPricingResponse;
+      setData(pricing);
+      const accountGlobal = pricing.discounts.find((d) => !d.provider_key && !d.model);
+      setGlobalDiscount(accountGlobal ? String(accountGlobal.discount_percent) : "");
+
+      if (providersRes?.ok) {
+        const providerData = (await providersRes.json()) as MyProvidersResponse;
+        setProviders(providerData.providers || []);
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  }, [getAccessToken]);
+
+  useEffect(() => {
+    if (!authenticated) {
+      setLoading(false);
+      return;
+    }
+    loadPricing();
+  }, [authenticated, loadPricing]);
+
+  useEffect(() => {
+    if (modelOptions.length > 0) {
+      setAccountModel((current) => current || modelOptions[0]);
+      setMachineModel((current) => current || modelOptions[0]);
+    }
+  }, [modelOptions]);
+
+  useEffect(() => {
+    if (providers.length > 0) {
+      const first = machineKey(providers[0]);
+      setMachineGlobalKey((current) => current || first);
+      setMachineModelKey((current) => current || first);
+    }
+  }, [providers]);
+
+  async function saveDiscount(
+    selector: { provider_key?: string; model?: string },
+    percentText: string,
+    key: string,
+  ) {
+    const percent = Number(percentText);
+    const max = data?.max_discount_percent ?? 90;
+    if (!Number.isFinite(percent) || percent < 0 || percent > max) {
+      setError(`Discount must be between 0 and ${max}`);
+      return;
+    }
+    setSaving(key);
+    setError(null);
+    setNotice(null);
+    try {
+      const token = await getAccessToken();
+      const res = await fetch(`${coordinatorUrl()}/v1/pricing/discount`, {
+        method: "PUT",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ ...selector, discount_percent: percent }),
+      });
+      if (!res.ok) throw new Error(await res.text());
+      setNotice("Discount saved.");
+      await loadPricing();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setSaving("");
+    }
+  }
+
+  async function clearDiscount(selector: { provider_key?: string; model?: string }, key: string) {
+    setSaving(key);
+    setError(null);
+    setNotice(null);
+    try {
+      const token = await getAccessToken();
+      const res = await fetch(`${coordinatorUrl()}/v1/pricing/discount`, {
+        method: "DELETE",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(selector),
+      });
+      if (!res.ok) throw new Error(await res.text());
+      setNotice("Discount cleared.");
+      await loadPricing();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setSaving("");
+    }
+  }
+
+  if (!ready || (loading && authenticated)) {
+    return (
+      <div className="flex items-center justify-center h-64">
+        <Loader2 size={24} className="animate-spin text-accent-brand" />
+      </div>
+    );
+  }
+
+  if (!authenticated) {
+    return (
+      <div className="max-w-5xl mx-auto p-6">
+        <div className="bg-bg-secondary rounded-lg p-6">
+          <h1 className="text-2xl font-bold text-text-primary mb-2">Provider Pricing</h1>
+          <p className="text-sm text-text-secondary mb-5 max-w-2xl">
+            Sign in to set provider discounts and preview effective model prices.
+          </p>
+          <button
+            onClick={login}
+            className="inline-flex items-center gap-2 px-6 py-2.5 rounded-lg bg-coral text-white font-medium text-sm hover:opacity-90"
+          >
+            <Mail size={14} />
+            Sign In
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-6xl mx-auto p-6 space-y-6">
+      <div className="flex items-center justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-bold text-text-primary">Provider Pricing</h1>
+          <p className="text-sm text-text-tertiary mt-0.5">
+            Account defaults, model overrides, and machine-specific discounts.
+          </p>
+        </div>
+        <button
+          onClick={loadPricing}
+          disabled={refreshing}
+          className="inline-flex items-center gap-1.5 text-sm text-text-tertiary hover:text-text-primary disabled:opacity-50"
+        >
+          <RefreshCw size={14} className={refreshing ? "animate-spin" : ""} />
+          Refresh
+        </button>
+      </div>
+
+      {error ? (
+        <div className="rounded-lg border border-accent-red/30 bg-accent-red/5 px-4 py-3 text-sm text-accent-red">
+          {error}
+        </div>
+      ) : null}
+      {notice ? (
+        <div className="rounded-lg border border-accent-green/30 bg-accent-green/5 px-4 py-3 text-sm text-accent-green flex items-center gap-2">
+          <CheckCircle2 size={15} />
+          {notice}
+        </div>
+      ) : null}
+
+      <DiscountEditor
+        title="Account Default"
+        icon={Tag}
+        value={globalDiscount}
+        onChange={setGlobalDiscount}
+        saving={saving === SAVE_GLOBAL}
+        onSave={() => saveDiscount({}, globalDiscount, SAVE_GLOBAL)}
+        onClear={() => clearDiscount({}, SAVE_GLOBAL)}
+      />
+
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
+        <DiscountEditor
+          title="Account Model"
+          icon={Layers}
+          value={accountModelDiscount}
+          onChange={setAccountModelDiscount}
+          saving={saving === SAVE_ACCOUNT_MODEL}
+          onSave={() => saveDiscount({ model: accountModel }, accountModelDiscount, SAVE_ACCOUNT_MODEL)}
+          onClear={() => clearDiscount({ model: accountModel }, SAVE_ACCOUNT_MODEL)}
+        >
+          <label>
+            <span className="block text-xs text-text-tertiary mb-1">Model</span>
+            <select
+              value={accountModel}
+              onChange={(e) => setAccountModel(e.target.value)}
+              className="w-full rounded-lg border border-border-dim bg-bg-white px-3 py-2 text-sm text-text-primary outline-none focus:border-accent-brand"
+            >
+              {modelOptions.map((model) => (
+                <option key={model} value={model}>
+                  {model}
+                </option>
+              ))}
+            </select>
+          </label>
+        </DiscountEditor>
+
+        <DiscountEditor
+          title="Machine Default"
+          icon={Monitor}
+          value={machineGlobalDiscount}
+          onChange={setMachineGlobalDiscount}
+          saving={saving === SAVE_MACHINE_GLOBAL}
+          onSave={() => {
+            if (!machineGlobalKey) {
+              setError(MACHINE_SET_ERROR);
+              return;
+            }
+            saveDiscount({ provider_key: machineGlobalKey }, machineGlobalDiscount, SAVE_MACHINE_GLOBAL);
+          }}
+          onClear={() => {
+            if (!machineGlobalKey) {
+              setError(MACHINE_CLEAR_ERROR);
+              return;
+            }
+            clearDiscount({ provider_key: machineGlobalKey }, SAVE_MACHINE_GLOBAL);
+          }}
+        >
+          <label>
+            <span className="block text-xs text-text-tertiary mb-1">Machine</span>
+            <select
+              value={machineGlobalKey}
+              onChange={(e) => setMachineGlobalKey(e.target.value)}
+              className="w-full rounded-lg border border-border-dim bg-bg-white px-3 py-2 text-sm text-text-primary outline-none focus:border-accent-brand"
+            >
+              {providers.map((provider) => (
+                <option key={provider.id} value={machineKey(provider)}>
+                  {machineLabel(provider)}
+                </option>
+              ))}
+            </select>
+          </label>
+        </DiscountEditor>
+
+        <DiscountEditor
+          title="Machine Model"
+          icon={Monitor}
+          value={machineModelDiscount}
+          onChange={setMachineModelDiscount}
+          saving={saving === SAVE_MACHINE_MODEL}
+          onSave={() => {
+            if (!machineModelKey) {
+              setError(MACHINE_SET_ERROR);
+              return;
+            }
+            saveDiscount(
+              { provider_key: machineModelKey, model: machineModel },
+              machineModelDiscount,
+              SAVE_MACHINE_MODEL,
+            );
+          }}
+          onClear={() => {
+            if (!machineModelKey) {
+              setError(MACHINE_CLEAR_ERROR);
+              return;
+            }
+            clearDiscount({ provider_key: machineModelKey, model: machineModel }, SAVE_MACHINE_MODEL);
+          }}
+        >
+          <div className="grid grid-cols-1 gap-3">
+            <label>
+              <span className="block text-xs text-text-tertiary mb-1">Machine</span>
+              <select
+                value={machineModelKey}
+                onChange={(e) => setMachineModelKey(e.target.value)}
+                className="w-full rounded-lg border border-border-dim bg-bg-white px-3 py-2 text-sm text-text-primary outline-none focus:border-accent-brand"
+              >
+                {providers.map((provider) => (
+                  <option key={provider.id} value={machineKey(provider)}>
+                    {machineLabel(provider)}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label>
+              <span className="block text-xs text-text-tertiary mb-1">Model</span>
+              <select
+                value={machineModel}
+                onChange={(e) => setMachineModel(e.target.value)}
+                className="w-full rounded-lg border border-border-dim bg-bg-white px-3 py-2 text-sm text-text-primary outline-none focus:border-accent-brand"
+              >
+                {modelOptions.map((model) => (
+                  <option key={model} value={model}>
+                    {model}
+                  </option>
+                ))}
+              </select>
+            </label>
+          </div>
+        </DiscountEditor>
+      </div>
+
+      <section className="rounded-lg bg-bg-secondary p-5">
+        <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3 mb-4">
+          <h2 className="text-sm font-semibold text-text-primary">Effective Price Preview</h2>
+          <select
+            value={previewMachineKey}
+            onChange={(e) => setPreviewMachineKey(e.target.value)}
+            className="rounded-lg border border-border-dim bg-bg-white px-3 py-2 text-sm text-text-primary outline-none focus:border-accent-brand"
+          >
+            <option value="">Account pricing</option>
+            {providers.map((provider) => (
+              <option key={provider.id} value={machineKey(provider)}>
+                {machineLabel(provider)}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div className="overflow-x-auto">
+          <table className="w-full min-w-[720px]">
+            <thead>
+              <tr className="border-b border-border-dim">
+                <th className="px-3 py-2 text-left text-xs font-medium text-text-tertiary">Model</th>
+                <th className="px-3 py-2 text-right text-xs font-medium text-text-tertiary">Input</th>
+                <th className="px-3 py-2 text-right text-xs font-medium text-text-tertiary">Output</th>
+                <th className="px-3 py-2 text-right text-xs font-medium text-text-tertiary">Discount</th>
+                <th className="px-3 py-2 text-left text-xs font-medium text-text-tertiary">Source</th>
+              </tr>
+            </thead>
+            <tbody>
+              {(data?.prices ?? []).map((price) => {
+                const discount = resolveDiscount(data?.discounts ?? [], price.model, previewMachineKey);
+                const discountBPS =
+                  discount?.discount_bps ?? Math.round((discount?.discount_percent ?? 0) * 100);
+                const input = discountedPrice(price.base_input_price || price.input_price, discountBPS);
+                const output = discountedPrice(price.base_output_price || price.output_price, discountBPS);
+                return (
+                  <tr key={price.model} className="border-b border-border-dim/50 last:border-0">
+                    <td className="px-3 py-2.5 text-xs font-mono text-text-primary">{price.model}</td>
+                    <td className="px-3 py-2.5 text-right text-sm text-text-primary">{formatMicroUSD(input)}</td>
+                    <td className="px-3 py-2.5 text-right text-sm text-text-primary">{formatMicroUSD(output)}</td>
+                    <td className="px-3 py-2.5 text-right text-sm text-text-secondary">
+                      {discount ? `${discount.discount_percent.toFixed(2)}%` : "0%"}
+                    </td>
+                    <td className="px-3 py-2.5 text-xs text-text-tertiary">
+                      {discount ? scopeLabel(discount.scope) : "Platform price"}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section className="rounded-lg bg-bg-secondary p-5">
+        <h2 className="text-sm font-semibold text-text-primary mb-3">Configured Discounts</h2>
+        {(data?.discounts.length ?? 0) === 0 ? (
+          <p className="text-sm text-text-tertiary">No provider discounts configured.</p>
+        ) : (
+          <div className="space-y-2">
+            {data?.discounts.map((discount) => (
+              <div
+                key={`${discount.provider_key || "account"}:${discount.model || "all"}`}
+                className="flex flex-col sm:flex-row sm:items-center justify-between gap-2 rounded-lg border border-border-dim bg-bg-white px-3 py-2"
+              >
+                <div>
+                  <p className="text-sm font-medium text-text-primary">{scopeLabel(discount.scope)}</p>
+                  <p className="text-xs text-text-tertiary font-mono">
+                    {discount.provider_key || "account"} · {discount.model || "all models"}
+                  </p>
+                </div>
+                <p className="text-sm font-semibold text-accent-brand">
+                  {discount.discount_percent.toFixed(2)}%
+                </p>
+              </div>
+            ))}
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/console-ui/src/components/ChatInput.tsx
+++ b/console-ui/src/components/ChatInput.tsx
@@ -1,9 +1,10 @@
 "use client";
 
 import { useState, useRef, useCallback, useEffect } from "react";
-import { Send, Square, ChevronDown, LogIn } from "lucide-react";
+import { Send, Square, ChevronDown, LogIn, Zap, DollarSign } from "lucide-react";
 import { useStore } from "@/lib/store";
 import { trackEvent } from "@/lib/google-analytics";
+import type { RoutingPreference } from "@/lib/api";
 
 interface ChatInputProps {
   onSend: (content: string) => void;
@@ -11,9 +12,19 @@ interface ChatInputProps {
   isStreaming: boolean;
   authenticated?: boolean;
   onLogin?: () => void;
+  routingPreference?: RoutingPreference;
+  onRoutingPreferenceChange?: (preference: RoutingPreference) => void;
 }
 
-export function ChatInput({ onSend, onStop, isStreaming, authenticated = true, onLogin }: ChatInputProps) {
+export function ChatInput({
+  onSend,
+  onStop,
+  isStreaming,
+  authenticated = true,
+  onLogin,
+  routingPreference = "performance",
+  onRoutingPreferenceChange,
+}: ChatInputProps) {
   const [input, setInput] = useState("");
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const { selectedModel, models, setSelectedModel } = useStore();
@@ -100,7 +111,7 @@ export function ChatInput({ onSend, onStop, isStreaming, authenticated = true, o
           {/* Bottom bar */}
           <div className="flex items-center justify-between px-3 pb-3">
             {/* Left: model selector */}
-            <div className="flex items-center gap-1">
+            <div className="flex items-center gap-1 flex-wrap">
               <div className="relative">
                 <button
                   onClick={(e) => {
@@ -148,6 +159,30 @@ export function ChatInput({ onSend, onStop, isStreaming, authenticated = true, o
                     })}
                   </div>
                 )}
+              </div>
+              <div className="flex items-center rounded-lg border border-border-dim bg-bg-tertiary p-0.5">
+                {([
+                  { value: "performance" as const, label: "Performance", icon: Zap },
+                  { value: "cost" as const, label: "Lowest cost", icon: DollarSign },
+                ]).map(({ value, label, icon: Icon }) => {
+                  const active = routingPreference === value;
+                  return (
+                    <button
+                      key={value}
+                      type="button"
+                      onClick={() => onRoutingPreferenceChange?.(value)}
+                      title={label}
+                      className={`flex items-center gap-1 px-2 py-1 rounded-md text-[11px] font-medium transition-colors ${
+                        active
+                          ? "bg-bg-white text-text-primary shadow-sm"
+                          : "text-text-tertiary hover:text-text-secondary"
+                      }`}
+                    >
+                      <Icon size={11} />
+                      <span className="hidden sm:inline">{label}</span>
+                    </button>
+                  );
+                })}
               </div>
             </div>
 

--- a/console-ui/src/lib/api.ts
+++ b/console-ui/src/lib/api.ts
@@ -61,6 +61,8 @@ export interface ChatMessage {
   content: string;
 }
 
+export type RoutingPreference = "performance" | "cost";
+
 export interface TrustMetadata {
   attested: boolean;
   trustLevel: "none" | "hardware";
@@ -88,6 +90,10 @@ export interface StreamCallbacks {
   onMetrics: (metrics: StreamMetrics) => void;
   onDone: (trustMeta: TrustMetadata, metrics: StreamMetrics) => void;
   onError: (error: string) => void;
+}
+
+export interface StreamChatOptions {
+  routingPreference?: RoutingPreference;
 }
 
 export async function fetchModels(): Promise<Model[]> {
@@ -300,15 +306,26 @@ export async function streamChat(
   messages: ChatMessage[],
   model: string,
   callbacks: StreamCallbacks,
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  options?: StreamChatOptions
 ): Promise<void> {
   // Optional sender→coordinator encryption. Defaults off so plaintext SDK
   // and curl flows keep working unchanged. When enabled we NaCl-Box-seal the
   // outgoing body to the coordinator's published X25519 pubkey, then decrypt
   // each SSE event on the way back.
-  const requestBody = { model, messages, stream: true };
+  const routingPreference = options?.routingPreference || "performance";
+  const requestBody = {
+    model,
+    messages,
+    stream: true,
+    ...(routingPreference === "cost" ? { routing_preference: "cost" } : {}),
+  };
   let sealCtx: { ephemPriv: Uint8Array; coordPub: Uint8Array } | null = null;
-  let fetchHeaders = proxyHeaders();
+  let fetchHeaders = proxyHeaders(
+    routingPreference === "cost"
+      ? { "X-Darkbloom-Routing-Preference": "cost" }
+      : undefined,
+  );
   let fetchBody: string;
 
   if (isEncryptionEnabled()) {
@@ -316,7 +333,12 @@ export async function streamChat(
       const coordKey = await getCoordinatorKey();
       const sealed = sealRequest(requestBody, coordKey);
       fetchBody = sealed.envelopeJson;
-      fetchHeaders = proxyHeaders({ "Content-Type": SEALED_CONTENT_TYPE });
+      fetchHeaders = proxyHeaders({
+        "Content-Type": SEALED_CONTENT_TYPE,
+        ...(routingPreference === "cost"
+          ? { "X-Darkbloom-Routing-Preference": "cost" }
+          : {}),
+      });
       sealCtx = {
         ephemPriv: sealed.ephemeralPrivateKey,
         coordPub: coordKey.publicKey,

--- a/coordinator/internal/api/billing_handlers.go
+++ b/coordinator/internal/api/billing_handlers.go
@@ -14,10 +14,13 @@ package api
 // read-only endpoints and inference.
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -25,6 +28,8 @@ import (
 	"github.com/eigeninference/coordinator/internal/auth"
 	"github.com/eigeninference/coordinator/internal/billing"
 	"github.com/eigeninference/coordinator/internal/payments"
+	providerpricing "github.com/eigeninference/coordinator/internal/pricing"
+	"github.com/eigeninference/coordinator/internal/registry"
 	"github.com/eigeninference/coordinator/internal/store"
 	"github.com/google/uuid"
 )
@@ -369,6 +374,254 @@ func (s *Server) handleGetPricing(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]any{
 		"prices": prices,
 	})
+}
+
+type providerPricingActor struct {
+	AccountID string
+}
+
+func (s *Server) providerPricingActor(w http.ResponseWriter, r *http.Request) (*providerPricingActor, bool) {
+	token := extractBearerToken(r)
+	if token == "" {
+		writeJSON(w, http.StatusUnauthorized, errorResponse("authentication_error", "missing credentials — use Authorization: Bearer <token>"))
+		return nil, false
+	}
+
+	if pt, err := s.store.GetProviderToken(token); err == nil && pt != nil && pt.Active {
+		return &providerPricingActor{AccountID: pt.AccountID}, true
+	}
+
+	if s.privyAuth != nil && strings.HasPrefix(token, "eyJ") {
+		privyUserID, err := s.privyAuth.VerifyToken(token)
+		if err != nil {
+			writeJSON(w, http.StatusUnauthorized, errorResponse("authentication_error", "invalid Privy token"))
+			return nil, false
+		}
+		user, err := s.privyAuth.GetOrCreateUser(privyUserID)
+		if err != nil {
+			s.logger.Error("privy: user resolution failed", "error", err)
+			writeJSON(w, http.StatusInternalServerError, errorResponse("auth_error", "failed to resolve user"))
+			return nil, false
+		}
+		return &providerPricingActor{AccountID: user.AccountID}, true
+	}
+
+	if s.store.ValidateKey(token) {
+		writeJSON(w, http.StatusForbidden, errorResponse("forbidden", "provider pricing requires a Privy session or provider device token"))
+		return nil, false
+	}
+
+	writeJSON(w, http.StatusUnauthorized, errorResponse("authentication_error", "invalid credentials"))
+	return nil, false
+}
+
+type providerDiscountResponse struct {
+	AccountID       string  `json:"account_id,omitempty"`
+	ProviderKey     string  `json:"provider_key,omitempty"`
+	Model           string  `json:"model,omitempty"`
+	Scope           string  `json:"scope"`
+	DiscountBPS     int     `json:"discount_bps"`
+	DiscountPercent float64 `json:"discount_percent"`
+}
+
+type providerEffectivePriceResponse struct {
+	Model           string  `json:"model"`
+	BaseInputPrice  int64   `json:"base_input_price"`
+	BaseOutputPrice int64   `json:"base_output_price"`
+	InputPrice      int64   `json:"input_price"`
+	OutputPrice     int64   `json:"output_price"`
+	DiscountBPS     int     `json:"discount_bps"`
+	DiscountPercent float64 `json:"discount_percent"`
+	DiscountScope   string  `json:"discount_scope,omitempty"`
+	InputUSD        string  `json:"input_usd"`
+	OutputUSD       string  `json:"output_usd"`
+}
+
+func providerDiscountToResponse(d store.ProviderDiscount) providerDiscountResponse {
+	return providerDiscountResponse{
+		AccountID:       d.AccountID,
+		ProviderKey:     d.ProviderKey,
+		Model:           d.Model,
+		Scope:           d.Scope(),
+		DiscountBPS:     d.DiscountBPS,
+		DiscountPercent: providerpricing.DiscountPercentFromBPS(d.DiscountBPS),
+	}
+}
+
+func effectivePriceToResponse(ep providerpricing.EffectivePrice) providerEffectivePriceResponse {
+	return providerEffectivePriceResponse{
+		Model:           ep.Model,
+		BaseInputPrice:  ep.BaseInputPrice,
+		BaseOutputPrice: ep.BaseOutputPrice,
+		InputPrice:      ep.InputPrice,
+		OutputPrice:     ep.OutputPrice,
+		DiscountBPS:     ep.DiscountBPS,
+		DiscountPercent: ep.DiscountPercent,
+		DiscountScope:   ep.DiscountScope,
+		InputUSD:        fmt.Sprintf("$%.4f", float64(ep.InputPrice)/1_000_000),
+		OutputUSD:       fmt.Sprintf("$%.4f", float64(ep.OutputPrice)/1_000_000),
+	}
+}
+
+func (s *Server) handleMyPricing(w http.ResponseWriter, r *http.Request) {
+	actor, ok := s.providerPricingActor(w, r)
+	if !ok {
+		return
+	}
+
+	discounts := s.store.ListProviderDiscounts(actor.AccountID)
+	sort.Slice(discounts, func(i, j int) bool {
+		if discounts[i].ProviderKey != discounts[j].ProviderKey {
+			return discounts[i].ProviderKey < discounts[j].ProviderKey
+		}
+		return discounts[i].Model < discounts[j].Model
+	})
+	discountResp := make([]providerDiscountResponse, 0, len(discounts))
+	for _, d := range discounts {
+		discountResp = append(discountResp, providerDiscountToResponse(d))
+	}
+
+	priceModels := make(map[string]struct{})
+	for model := range payments.DefaultPrices() {
+		priceModels[model] = struct{}{}
+	}
+	for _, mp := range s.store.ListModelPrices("platform") {
+		priceModels[mp.Model] = struct{}{}
+	}
+	models := make([]string, 0, len(priceModels))
+	for model := range priceModels {
+		models = append(models, model)
+	}
+	sort.Strings(models)
+
+	prices := make([]providerEffectivePriceResponse, 0, len(models))
+	for _, model := range models {
+		prices = append(prices, effectivePriceToResponse(providerpricing.EffectiveModelPrice(s.store, actor.AccountID, "", model)))
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"account_id":           actor.AccountID,
+		"discounts":            discountResp,
+		"prices":               prices,
+		"max_discount_percent": providerpricing.DiscountPercentFromBPS(providerpricing.MaxProviderDiscountBPS),
+	})
+}
+
+func (s *Server) handleSetProviderDiscount(w http.ResponseWriter, r *http.Request) {
+	actor, ok := s.providerPricingActor(w, r)
+	if !ok {
+		return
+	}
+
+	var req struct {
+		ProviderKey     string  `json:"provider_key"`
+		Model           string  `json:"model"`
+		DiscountPercent float64 `json:"discount_percent"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, errorResponse("invalid_request_error", "invalid JSON: "+err.Error()))
+		return
+	}
+	req.ProviderKey = strings.TrimSpace(req.ProviderKey)
+	req.Model = strings.TrimSpace(req.Model)
+
+	discountBPS, err := providerpricing.DiscountBPSFromPercent(req.DiscountPercent)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, errorResponse("invalid_request_error", err.Error()))
+		return
+	}
+	if req.ProviderKey != "" && !s.providerKeyBelongsToAccount(r.Context(), actor.AccountID, req.ProviderKey) {
+		writeJSON(w, http.StatusForbidden, errorResponse("forbidden", "provider_key does not belong to this account"))
+		return
+	}
+
+	if err := s.store.SetProviderDiscount(actor.AccountID, req.ProviderKey, req.Model, discountBPS); err != nil {
+		s.logger.Error("provider discount: set failed", "error", err)
+		writeJSON(w, http.StatusInternalServerError, errorResponse("internal_error", "failed to set discount"))
+		return
+	}
+	d, _ := s.store.GetProviderDiscount(actor.AccountID, req.ProviderKey, req.Model)
+	writeJSON(w, http.StatusOK, map[string]any{
+		"status":   "updated",
+		"discount": providerDiscountToResponse(d),
+	})
+}
+
+func (s *Server) handleDeleteProviderDiscount(w http.ResponseWriter, r *http.Request) {
+	actor, ok := s.providerPricingActor(w, r)
+	if !ok {
+		return
+	}
+
+	var req struct {
+		ProviderKey string `json:"provider_key"`
+		Model       string `json:"model"`
+	}
+	if r.Body != nil {
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil && !errors.Is(err, io.EOF) {
+			writeJSON(w, http.StatusBadRequest, errorResponse("invalid_request_error", "invalid JSON: "+err.Error()))
+			return
+		}
+	}
+	q := r.URL.Query()
+	if q.Has("provider_key") {
+		req.ProviderKey = q.Get("provider_key")
+	}
+	if q.Has("model") {
+		req.Model = q.Get("model")
+	}
+	req.ProviderKey = strings.TrimSpace(req.ProviderKey)
+	req.Model = strings.TrimSpace(req.Model)
+
+	if req.ProviderKey != "" && !s.providerKeyBelongsToAccount(r.Context(), actor.AccountID, req.ProviderKey) {
+		writeJSON(w, http.StatusForbidden, errorResponse("forbidden", "provider_key does not belong to this account"))
+		return
+	}
+
+	if err := s.store.DeleteProviderDiscount(actor.AccountID, req.ProviderKey, req.Model); err != nil {
+		writeJSON(w, http.StatusNotFound, errorResponse("not_found", err.Error()))
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"status":       "deleted",
+		"provider_key": req.ProviderKey,
+		"model":        req.Model,
+	})
+}
+
+func (s *Server) providerKeyBelongsToAccount(ctx context.Context, accountID, providerKey string) bool {
+	if strings.TrimSpace(providerKey) == "" {
+		return true
+	}
+	records, err := s.store.ListProvidersByAccount(ctx, accountID)
+	if err == nil {
+		for _, rec := range records {
+			if rec.ID == providerKey || rec.SerialNumber == providerKey || rec.SEPublicKey == providerKey {
+				return true
+			}
+		}
+	}
+	found := false
+	s.registry.ForEachProvider(func(p *registry.Provider) {
+		if found {
+			return
+		}
+		p.Mu().Lock()
+		defer p.Mu().Unlock()
+		if p.AccountID != accountID {
+			return
+		}
+		if p.ID == providerKey || p.PublicKey == providerKey {
+			found = true
+			return
+		}
+		if p.AttestationResult != nil {
+			if p.AttestationResult.SerialNumber == providerKey || p.AttestationResult.PublicKey == providerKey {
+				found = true
+			}
+		}
+	})
+	return found
 }
 
 // handleAdminPricing handles PUT /v1/admin/pricing.

--- a/coordinator/internal/api/billing_integration_test.go
+++ b/coordinator/internal/api/billing_integration_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/eigeninference/coordinator/internal/billing"
 	"github.com/eigeninference/coordinator/internal/payments"
+	providerpricing "github.com/eigeninference/coordinator/internal/pricing"
 	"github.com/eigeninference/coordinator/internal/protocol"
 	"github.com/eigeninference/coordinator/internal/registry"
 	"github.com/eigeninference/coordinator/internal/store"
@@ -204,6 +205,86 @@ func TestIntegration_ConsumerBillingCharge(t *testing.T) {
 	}
 	if usageEntries[0].CompletionTokens != usage.CompletionTokens {
 		t.Errorf("usage entry completion_tokens = %d, want %d", usageEntries[0].CompletionTokens, usage.CompletionTokens)
+	}
+}
+
+func TestIntegration_ProviderDiscountFinalBilling(t *testing.T) {
+	srv, st, ledger := billingTestServer(t)
+
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	const (
+		accountID = "acct-discounted-provider"
+		rawToken  = "discounted-provider-auth-token"
+		model     = "discounted-final-billing-model"
+	)
+	pubKey := testPublicKeyB64()
+	if err := st.CreateProviderToken(&store.ProviderToken{
+		TokenHash: sha256HexStr(rawToken),
+		AccountID: accountID,
+		Label:     "discounted-billing",
+		Active:    true,
+		CreatedAt: time.Now(),
+	}); err != nil {
+		t.Fatalf("create provider token: %v", err)
+	}
+	if err := st.SetModelPrice("platform", model, 1_000_000, 1_000_000); err != nil {
+		t.Fatalf("SetModelPrice: %v", err)
+	}
+	if err := st.SetProviderDiscount(accountID, pubKey, model, 5000); err != nil {
+		t.Fatalf("SetProviderDiscount: %v", err)
+	}
+
+	conn := connectProviderWithToken(t, ctx, ts.URL,
+		[]protocol.ModelInfo{{ID: model, ModelType: "chat", Quantization: "4bit"}},
+		pubKey, rawToken, "0xDiscountedProvider")
+	defer conn.Close(websocket.StatusNormalClosure, "")
+
+	for _, id := range srv.registry.ProviderIDs() {
+		srv.registry.SetTrustLevel(id, registry.TrustHardware)
+		srv.registry.RecordChallengeSuccess(id)
+	}
+
+	consumerID := "test-key"
+	initialConsumerBalance := ledger.Balance(consumerID)
+	usage := protocol.UsageInfo{PromptTokens: 1000, CompletionTokens: 1000}
+	providerDone := serveOneInference(ctx, t, conn, pubKey, usage)
+
+	status := sendInferenceRequest(t, ctx, ts.URL, model, "test-key")
+	if status != http.StatusOK {
+		t.Fatalf("inference status = %d, want 200", status)
+	}
+	<-providerDone
+	time.Sleep(300 * time.Millisecond)
+
+	expectedCost := providerpricing.CalculateCost(st, accountID, pubKey, model, usage.PromptTokens, usage.CompletionTokens)
+	if expectedCost != 1000 {
+		t.Fatalf("expected discounted cost = %d, want 1000", expectedCost)
+	}
+	if got := ledger.Balance(consumerID); got != initialConsumerBalance-expectedCost {
+		t.Fatalf("consumer balance = %d, want %d", got, initialConsumerBalance-expectedCost)
+	}
+	expectedPayout := payments.ProviderPayout(expectedCost)
+	if got := st.GetBalance(accountID); got != expectedPayout {
+		t.Fatalf("provider account balance = %d, want payout %d", got, expectedPayout)
+	}
+
+	earnings, err := st.GetAccountEarnings(accountID, 10)
+	if err != nil {
+		t.Fatalf("GetAccountEarnings: %v", err)
+	}
+	if len(earnings) != 1 {
+		t.Fatalf("earnings count = %d, want 1", len(earnings))
+	}
+	if earnings[0].ProviderKey != pubKey {
+		t.Fatalf("earning provider_key = %q, want registered pubkey", earnings[0].ProviderKey)
+	}
+	if earnings[0].AmountMicroUSD != expectedPayout {
+		t.Fatalf("earning amount = %d, want %d", earnings[0].AmountMicroUSD, expectedPayout)
 	}
 }
 

--- a/coordinator/internal/api/consumer.go
+++ b/coordinator/internal/api/consumer.go
@@ -214,13 +214,37 @@ func parseProviderSerialAllowlist(parsed map[string]any) ([]string, bool, error)
 
 func stripProviderRoutingFields(parsed map[string]any) bool {
 	changed := false
-	for _, key := range []string{"provider_serial", "provider_serials"} {
+	for _, key := range []string{"provider_serial", "provider_serials", "routing_preference"} {
 		if _, ok := parsed[key]; ok {
 			delete(parsed, key)
 			changed = true
 		}
 	}
 	return changed
+}
+
+func parseRoutingPreference(r *http.Request, parsed map[string]any) (string, error) {
+	raw := strings.TrimSpace(r.URL.Query().Get("routing_preference"))
+	if raw == "" {
+		raw = strings.TrimSpace(r.Header.Get("X-Darkbloom-Routing-Preference"))
+	}
+	if raw == "" {
+		if v, ok := parsed["routing_preference"]; ok {
+			s, ok := v.(string)
+			if !ok {
+				return "", fmt.Errorf("routing_preference must be a string")
+			}
+			raw = strings.TrimSpace(s)
+		}
+	}
+	switch strings.ToLower(raw) {
+	case "", "performance", "perf":
+		return "performance", nil
+	case "cost":
+		return "cost", nil
+	default:
+		return "", fmt.Errorf("routing_preference must be one of: performance, perf, cost")
+	}
 }
 
 // defaultMaxOutputTokens is the ceiling injected into requests that don't set
@@ -555,7 +579,13 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusBadRequest, errorResponse("invalid_request_error", err.Error()))
 		return
 	}
-	if hasProviderAllowlist && stripProviderRoutingFields(parsed) {
+	routingPreference, err := parseRoutingPreference(r, parsed)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, errorResponse("invalid_request_error", err.Error()))
+		return
+	}
+	_, hasRoutingPreferenceBody := parsed["routing_preference"]
+	if (hasProviderAllowlist || hasRoutingPreferenceBody) && stripProviderRoutingFields(parsed) {
 		rawBody, _ = json.Marshal(parsed)
 	}
 
@@ -648,6 +678,7 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 			RequestID:              requestID,
 			Model:                  model,
 			ConsumerKey:            consumerKey,
+			RoutingPreference:      routingPreference,
 			IsResponsesAPI:         isResponsesAPI,
 			EstimatedPromptTokens:  estimatedPromptTokens,
 			RequestedMaxTokens:     requestedMaxTokens,
@@ -2380,7 +2411,13 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 		writeJSON(w, http.StatusBadRequest, errorResponse("invalid_request_error", err.Error()))
 		return
 	}
-	if hasProviderAllowlist {
+	routingPreference, err := parseRoutingPreference(r, parsed)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, errorResponse("invalid_request_error", err.Error()))
+		return
+	}
+	_, hasRoutingPreferenceBody := parsed["routing_preference"]
+	if hasProviderAllowlist || hasRoutingPreferenceBody {
 		stripProviderRoutingFields(parsed)
 	}
 
@@ -2422,6 +2459,7 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 		RequestID:              requestID,
 		Model:                  model,
 		ConsumerKey:            consumerKey,
+		RoutingPreference:      routingPreference,
 		AllowedProviderSerials: allowedProviderSerials,
 		EstimatedPromptTokens:  estimatedPromptTokens,
 		RequestedMaxTokens:     requestedMaxTokens,

--- a/coordinator/internal/api/pricing_discount_test.go
+++ b/coordinator/internal/api/pricing_discount_test.go
@@ -1,0 +1,106 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/coordinator/internal/store"
+)
+
+func pricingDiscountRequest(t *testing.T, srv *Server, method, path, token, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(method, path, strings.NewReader(body))
+	if body != "" {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+	return w
+}
+
+func TestProviderPricingEndpointsAuthValidationAndOwnership(t *testing.T) {
+	srv, st := testServer(t)
+	const (
+		accountID = "acct-pricing"
+		rawToken  = "darkbloom-provider-pricing-token"
+	)
+	if err := st.CreateProviderToken(&store.ProviderToken{
+		TokenHash: sha256HexStr(rawToken),
+		AccountID: accountID,
+		Label:     "pricing-test",
+		Active:    true,
+		CreatedAt: time.Now(),
+	}); err != nil {
+		t.Fatalf("CreateProviderToken: %v", err)
+	}
+	if err := st.UpsertProvider(context.Background(), store.ProviderRecord{
+		ID:           "provider-1",
+		AccountID:    accountID,
+		SerialNumber: "SERIAL-1",
+		SEPublicKey:  "SE-PUB-1",
+		LastSeen:     time.Now(),
+	}); err != nil {
+		t.Fatalf("UpsertProvider: %v", err)
+	}
+
+	w := pricingDiscountRequest(t, srv, http.MethodGet, "/v1/pricing/me", rawToken, "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET /v1/pricing/me status = %d body=%s", w.Code, w.Body.String())
+	}
+	var me struct {
+		AccountID string `json:"account_id"`
+		Prices    []any  `json:"prices"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &me); err != nil {
+		t.Fatalf("unmarshal /pricing/me: %v", err)
+	}
+	if me.AccountID != accountID {
+		t.Fatalf("account_id = %q, want %q", me.AccountID, accountID)
+	}
+	if len(me.Prices) == 0 {
+		t.Fatal("/pricing/me returned no price preview rows")
+	}
+
+	w = pricingDiscountRequest(t, srv, http.MethodPut, "/v1/pricing/discount", "test-key", `{"discount_percent":10}`)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("API key status = %d, want 403 body=%s", w.Code, w.Body.String())
+	}
+
+	w = pricingDiscountRequest(t, srv, http.MethodPut, "/v1/pricing/discount", rawToken, `{"discount_percent":91}`)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("91%% status = %d, want 400 body=%s", w.Code, w.Body.String())
+	}
+
+	w = pricingDiscountRequest(t, srv, http.MethodPut, "/v1/pricing/discount", rawToken, `{"provider_key":"SERIAL-OTHER","discount_percent":10}`)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("foreign machine status = %d, want 403 body=%s", w.Code, w.Body.String())
+	}
+
+	w = pricingDiscountRequest(t, srv, http.MethodPut, "/v1/pricing/discount", rawToken, `{"provider_key":"SERIAL-1","model":"model-a","discount_percent":25}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("owned machine set status = %d body=%s", w.Code, w.Body.String())
+	}
+	d, ok := st.GetProviderDiscount(accountID, "SERIAL-1", "model-a")
+	if !ok {
+		t.Fatal("owned machine discount was not stored")
+	}
+	if d.DiscountBPS != 2500 {
+		t.Fatalf("DiscountBPS = %d, want 2500", d.DiscountBPS)
+	}
+
+	w = pricingDiscountRequest(t, srv, http.MethodDelete, "/v1/pricing/discount?provider_key=SERIAL-1&model=model-a", rawToken, "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("delete status = %d body=%s", w.Code, w.Body.String())
+	}
+	if _, ok := st.GetProviderDiscount(accountID, "SERIAL-1", "model-a"); ok {
+		t.Fatal("discount still present after delete")
+	}
+}

--- a/coordinator/internal/api/provider.go
+++ b/coordinator/internal/api/provider.go
@@ -36,6 +36,7 @@ import (
 	"github.com/eigeninference/coordinator/internal/attestation"
 	"github.com/eigeninference/coordinator/internal/e2e"
 	"github.com/eigeninference/coordinator/internal/payments"
+	providerpricing "github.com/eigeninference/coordinator/internal/pricing"
 	"github.com/eigeninference/coordinator/internal/protocol"
 	"github.com/eigeninference/coordinator/internal/registry"
 	"github.com/eigeninference/coordinator/internal/saferun"
@@ -960,17 +961,10 @@ func (s *Server) handleComplete(providerID string, provider *registry.Provider, 
 	responseTime := time.Duration(msg.Usage.CompletionTokens) * time.Millisecond * 10
 	s.registry.RecordJobSuccess(providerID, responseTime)
 
-	// Calculate cost — check provider's custom price, then platform DB price,
-	// then hardcoded defaults.
-	providerWalletForPricing := ""
-	if p := s.registry.GetProvider(providerID); p != nil {
-		providerWalletForPricing = p.WalletAddress
-	}
-	customIn, customOut, hasCustom := s.store.GetModelPrice(providerWalletForPricing, pr.Model)
-	if !hasCustom {
-		customIn, customOut, hasCustom = s.store.GetModelPrice("platform", pr.Model)
-	}
-	totalCost := payments.CalculateCostWithOverrides(pr.Model, msg.Usage.PromptTokens, msg.Usage.CompletionTokens, customIn, customOut, hasCustom)
+	// Calculate cost from the provider's linked account and stable machine
+	// identity so account/model and machine/model discounts apply consistently.
+	accountID, providerKey := s.providerPricingSubject(providerID)
+	totalCost := providerpricing.CalculateCost(s.store, accountID, providerKey, pr.Model, msg.Usage.PromptTokens, msg.Usage.CompletionTokens)
 
 	// Clamp reported cost at the pre-flight reservation. The reservation
 	// uses platform-default and platform-override pricing; a provider that
@@ -1094,6 +1088,27 @@ func (s *Server) handleComplete(providerID string, provider *registry.Provider, 
 		"cost_micro_usd", totalCost,
 		"provider_payout_micro_usd", providerPayout,
 	)
+}
+
+func (s *Server) providerPricingSubject(providerID string) (string, string) {
+	p := s.registry.GetProvider(providerID)
+	if p == nil {
+		return "", ""
+	}
+	p.Mu().Lock()
+	defer p.Mu().Unlock()
+
+	providerKey := p.ID
+	if p.AttestationResult != nil {
+		if p.AttestationResult.SerialNumber != "" {
+			providerKey = p.AttestationResult.SerialNumber
+		} else if p.AttestationResult.PublicKey != "" {
+			providerKey = p.AttestationResult.PublicKey
+		}
+	} else if p.PublicKey != "" {
+		providerKey = p.PublicKey
+	}
+	return p.AccountID, providerKey
 }
 
 func (s *Server) handleInferenceError(providerID string, provider *registry.Provider, msg *protocol.InferenceErrorMessage) {

--- a/coordinator/internal/api/provider_serial_allowlist_test.go
+++ b/coordinator/internal/api/provider_serial_allowlist_test.go
@@ -1,13 +1,15 @@
 package api
 
 import (
+	"net/http/httptest"
 	"reflect"
 	"testing"
 )
 
 func TestParseProviderSerialAllowlist(t *testing.T) {
 	parsed := map[string]any{
-		"provider_serial": " SERIAL-A ",
+		"routing_preference": "cost",
+		"provider_serial":    " SERIAL-A ",
 		"provider_serials": []any{
 			"SERIAL-B",
 			"SERIAL-A",
@@ -37,6 +39,9 @@ func TestParseProviderSerialAllowlist(t *testing.T) {
 	if _, ok := parsed["provider_serials"]; ok {
 		t.Fatal("provider_serials was not stripped")
 	}
+	if _, ok := parsed["routing_preference"]; ok {
+		t.Fatal("routing_preference was not stripped")
+	}
 }
 
 func TestParseProviderSerialAllowlistRejectsInvalidValues(t *testing.T) {
@@ -50,5 +55,46 @@ func TestParseProviderSerialAllowlistRejectsInvalidValues(t *testing.T) {
 		if _, _, err := parseProviderSerialAllowlist(tc); err == nil {
 			t.Fatalf("parseProviderSerialAllowlist(%v) returned nil error", tc)
 		}
+	}
+}
+
+func TestParseRoutingPreference(t *testing.T) {
+	tests := []struct {
+		name   string
+		target string
+		header string
+		body   map[string]any
+		want   string
+	}{
+		{name: "default", target: "/v1/chat/completions", body: map[string]any{}, want: "performance"},
+		{name: "query perf", target: "/v1/chat/completions?routing_preference=perf", body: map[string]any{"routing_preference": "cost"}, want: "performance"},
+		{name: "header cost", target: "/v1/chat/completions", header: "cost", body: map[string]any{}, want: "cost"},
+		{name: "body cost", target: "/v1/chat/completions", body: map[string]any{"routing_preference": "cost"}, want: "cost"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest("POST", tc.target, nil)
+			if tc.header != "" {
+				req.Header.Set("X-Darkbloom-Routing-Preference", tc.header)
+			}
+			got, err := parseRoutingPreference(req, tc.body)
+			if err != nil {
+				t.Fatalf("parseRoutingPreference: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("routing preference = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestParseRoutingPreferenceRejectsInvalidValues(t *testing.T) {
+	req := httptest.NewRequest("POST", "/v1/chat/completions", nil)
+	if _, err := parseRoutingPreference(req, map[string]any{"routing_preference": 42}); err == nil {
+		t.Fatal("expected non-string body value to fail")
+	}
+	req = httptest.NewRequest("POST", "/v1/chat/completions?routing_preference=cheap", nil)
+	if _, err := parseRoutingPreference(req, map[string]any{}); err == nil {
+		t.Fatal("expected unknown query value to fail")
 	}
 }

--- a/coordinator/internal/api/server.go
+++ b/coordinator/internal/api/server.go
@@ -877,10 +877,13 @@ func (s *Server) routes() {
 	s.mux.HandleFunc("POST /v1/billing/stripe/connect/webhook", s.handleStripeConnectWebhook) // no auth — Stripe signs it
 
 	// Pricing — GET is public, PUT/DELETE require auth
-	s.mux.HandleFunc("GET /v1/pricing", s.handleGetPricing)                        // public
-	s.mux.HandleFunc("PUT /v1/pricing", s.requireAuth(s.handleSetPricing))         // provider sets own prices
-	s.mux.HandleFunc("DELETE /v1/pricing", s.requireAuth(s.handleDeletePricing))   // revert to default
-	s.mux.HandleFunc("PUT /v1/admin/pricing", s.requireAuth(s.handleAdminPricing)) // platform sets defaults
+	s.mux.HandleFunc("GET /v1/pricing", s.handleGetPricing)                         // public
+	s.mux.HandleFunc("GET /v1/pricing/me", s.handleMyPricing)                       // provider discount view
+	s.mux.HandleFunc("PUT /v1/pricing/discount", s.handleSetProviderDiscount)       // provider sets discounts
+	s.mux.HandleFunc("DELETE /v1/pricing/discount", s.handleDeleteProviderDiscount) // provider clears discounts
+	s.mux.HandleFunc("PUT /v1/pricing", s.requireAuth(s.handleSetPricing))          // provider sets own prices
+	s.mux.HandleFunc("DELETE /v1/pricing", s.requireAuth(s.handleDeletePricing))    // revert to default
+	s.mux.HandleFunc("PUT /v1/admin/pricing", s.requireAuth(s.handleAdminPricing))  // platform sets defaults
 
 	// Admin model catalog
 	s.mux.HandleFunc("GET /v1/admin/models", s.requireAuth(s.handleAdminListModels))

--- a/coordinator/internal/pricing/discounts.go
+++ b/coordinator/internal/pricing/discounts.go
@@ -1,0 +1,118 @@
+package pricing
+
+import (
+	"fmt"
+	"math"
+	"strings"
+
+	"github.com/eigeninference/coordinator/internal/payments"
+	"github.com/eigeninference/coordinator/internal/store"
+)
+
+const (
+	MaxProviderDiscountBPS = 9000
+	basisPointsPerPercent  = 100
+	fullPriceBPS           = 10000
+)
+
+type EffectivePrice struct {
+	Model             string
+	BaseInputPrice    int64
+	BaseOutputPrice   int64
+	InputPrice        int64
+	OutputPrice       int64
+	DiscountBPS       int
+	DiscountPercent   float64
+	DiscountScope     string
+	DiscountModel     string
+	DiscountProvider  string
+	DiscountAccountID string
+}
+
+func DiscountBPSFromPercent(percent float64) (int, error) {
+	if math.IsNaN(percent) || math.IsInf(percent, 0) {
+		return 0, fmt.Errorf("discount_percent must be a finite number")
+	}
+	if percent < 0 || percent > float64(MaxProviderDiscountBPS)/basisPointsPerPercent {
+		return 0, fmt.Errorf("discount_percent must be between 0 and 90")
+	}
+	return int(math.Round(percent * basisPointsPerPercent)), nil
+}
+
+func DiscountPercentFromBPS(bps int) float64 {
+	return float64(bps) / basisPointsPerPercent
+}
+
+func PlatformPrice(st store.Store, model string) (int64, int64) {
+	model = strings.TrimSpace(model)
+	if st != nil {
+		if input, output, ok := st.GetModelPrice("platform", model); ok {
+			return input, output
+		}
+	}
+	return payments.InputPricePerMillion(model), payments.OutputPricePerMillion(model)
+}
+
+func ResolveDiscount(st store.Store, accountID, providerKey, model string) (store.ProviderDiscount, bool) {
+	if st == nil || strings.TrimSpace(accountID) == "" {
+		return store.ProviderDiscount{}, false
+	}
+	accountID = strings.TrimSpace(accountID)
+	providerKey = strings.TrimSpace(providerKey)
+	model = strings.TrimSpace(model)
+
+	if providerKey != "" {
+		if model != "" {
+			if d, ok := st.GetProviderDiscount(accountID, providerKey, model); ok {
+				return d, true
+			}
+		}
+		if d, ok := st.GetProviderDiscount(accountID, providerKey, ""); ok {
+			return d, true
+		}
+	}
+	if model != "" {
+		if d, ok := st.GetProviderDiscount(accountID, "", model); ok {
+			return d, true
+		}
+	}
+	return st.GetProviderDiscount(accountID, "", "")
+}
+
+func EffectiveModelPrice(st store.Store, accountID, providerKey, model string) EffectivePrice {
+	baseInput, baseOutput := PlatformPrice(st, model)
+	ep := EffectivePrice{
+		Model:           model,
+		BaseInputPrice:  baseInput,
+		BaseOutputPrice: baseOutput,
+		InputPrice:      baseInput,
+		OutputPrice:     baseOutput,
+	}
+	if d, ok := ResolveDiscount(st, accountID, providerKey, model); ok {
+		ep.DiscountBPS = d.DiscountBPS
+		ep.DiscountPercent = DiscountPercentFromBPS(d.DiscountBPS)
+		ep.DiscountAccountID = d.AccountID
+		ep.DiscountProvider = d.ProviderKey
+		ep.DiscountModel = d.Model
+		ep.DiscountScope = d.Scope()
+		ep.InputPrice = applyDiscount(baseInput, d.DiscountBPS)
+		ep.OutputPrice = applyDiscount(baseOutput, d.DiscountBPS)
+	}
+	return ep
+}
+
+func CalculateCost(st store.Store, accountID, providerKey, model string, promptTokens, completionTokens int) int64 {
+	ep := EffectiveModelPrice(st, accountID, providerKey, model)
+	return payments.CalculateCostWithOverrides(model, promptTokens, completionTokens, ep.InputPrice, ep.OutputPrice, true)
+}
+
+func applyDiscount(price int64, discountBPS int) int64 {
+	if discountBPS <= 0 {
+		return price
+	}
+	discounted := price * int64(fullPriceBPS-discountBPS) / fullPriceBPS
+	if price > 0 && discounted < 1 {
+		return 1
+	}
+	return discounted
+}

--- a/coordinator/internal/pricing/discounts_test.go
+++ b/coordinator/internal/pricing/discounts_test.go
@@ -1,0 +1,145 @@
+package pricing
+
+import (
+	"testing"
+
+	"github.com/eigeninference/coordinator/internal/payments"
+	"github.com/eigeninference/coordinator/internal/store"
+)
+
+func TestDiscountBPSFromPercentValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		percent float64
+		want    int
+		wantErr bool
+	}{
+		{name: "zero", percent: 0, want: 0},
+		{name: "fractional", percent: 12.34, want: 1234},
+		{name: "cap", percent: 90, want: 9000},
+		{name: "negative", percent: -0.01, wantErr: true},
+		{name: "above cap", percent: 90.01, wantErr: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := DiscountBPSFromPercent(tc.percent)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("DiscountBPSFromPercent: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("bps = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestEffectiveModelPriceDiscountPrecedence(t *testing.T) {
+	st := store.NewMemory("")
+	const model = "discount-model"
+	if err := st.SetModelPrice("platform", model, 1_000_000, 2_000_000); err != nil {
+		t.Fatalf("SetModelPrice: %v", err)
+	}
+	mustSet := func(providerKey, model string, bps int) {
+		t.Helper()
+		if err := st.SetProviderDiscount("acct-1", providerKey, model, bps); err != nil {
+			t.Fatalf("SetProviderDiscount(%q,%q): %v", providerKey, model, err)
+		}
+	}
+	mustSet("", "", 1000)
+	mustSet("", model, 2000)
+	mustSet("serial-1", "", 3000)
+	mustSet("serial-1", model, 4000)
+
+	tests := []struct {
+		name        string
+		accountID   string
+		providerKey string
+		model       string
+		wantScope   string
+		wantInput   int64
+		wantOutput  int64
+	}{
+		{
+			name:        "machine model wins",
+			accountID:   "acct-1",
+			providerKey: "serial-1",
+			model:       model,
+			wantScope:   "machine_model",
+			wantInput:   600_000,
+			wantOutput:  1_200_000,
+		},
+		{
+			name:        "machine global beats account model",
+			accountID:   "acct-1",
+			providerKey: "serial-1",
+			model:       "other-model",
+			wantScope:   "machine_global",
+		},
+		{
+			name:      "account model beats account global",
+			accountID: "acct-1",
+			model:     model,
+			wantScope: "account_model",
+			wantInput: 800_000,
+		},
+		{
+			name:      "account global fallback",
+			accountID: "acct-1",
+			model:     "other-model",
+			wantScope: "account_global",
+		},
+		{
+			name:      "platform when account missing",
+			accountID: "acct-2",
+			model:     model,
+			wantScope: "",
+			wantInput: 1_000_000,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ep := EffectiveModelPrice(st, tc.accountID, tc.providerKey, tc.model)
+			if ep.DiscountScope != tc.wantScope {
+				t.Fatalf("scope = %q, want %q", ep.DiscountScope, tc.wantScope)
+			}
+			if tc.wantInput != 0 && ep.InputPrice != tc.wantInput {
+				t.Fatalf("input price = %d, want %d", ep.InputPrice, tc.wantInput)
+			}
+			if tc.wantOutput != 0 && ep.OutputPrice != tc.wantOutput {
+				t.Fatalf("output price = %d, want %d", ep.OutputPrice, tc.wantOutput)
+			}
+		})
+	}
+}
+
+func TestCalculateCostDiscountAndMinimumCharge(t *testing.T) {
+	st := store.NewMemory("")
+	const model = "billing-discount-model"
+	if err := st.SetModelPrice("platform", model, 1_000_000, 2_000_000); err != nil {
+		t.Fatalf("SetModelPrice: %v", err)
+	}
+	if err := st.SetProviderDiscount("acct-1", "", model, 5000); err != nil {
+		t.Fatalf("SetProviderDiscount: %v", err)
+	}
+
+	got := CalculateCost(st, "acct-1", "", model, 1_000, 1_000)
+	want := int64(1_500)
+	if got != want {
+		t.Fatalf("CalculateCost = %d, want %d", got, want)
+	}
+	if payout := payments.ProviderPayout(got); payout != 1425 {
+		t.Fatalf("ProviderPayout(discounted charge) = %d, want 1425", payout)
+	}
+
+	min := CalculateCost(st, "acct-1", "", model, 1, 1)
+	if min != payments.MinimumCharge() {
+		t.Fatalf("minimum discounted charge = %d, want %d", min, payments.MinimumCharge())
+	}
+}

--- a/coordinator/internal/registry/registry.go
+++ b/coordinator/internal/registry/registry.go
@@ -59,6 +59,10 @@ type PendingRequest struct {
 	ProviderID  string
 	Model       string
 	ConsumerKey string
+	// RoutingPreference controls candidate selection. Empty and "performance"
+	// use the latency/performance cost model; "cost" prefers lower effective
+	// provider price, then breaks ties by latency/performance cost.
+	RoutingPreference string
 	// IsResponsesAPI tracks requests received through /v1/responses so the
 	// coordinator can translate provider chat-completions output back into
 	// Responses API objects for SDK clients.

--- a/coordinator/internal/registry/scheduler.go
+++ b/coordinator/internal/registry/scheduler.go
@@ -5,6 +5,7 @@ import (
 	"math/rand"
 	"time"
 
+	providerpricing "github.com/eigeninference/coordinator/internal/pricing"
 	"github.com/eigeninference/coordinator/internal/protocol"
 )
 
@@ -81,6 +82,8 @@ type routingSnapshot struct {
 	totalMemoryGB      float64
 	modelSizeGB        float64 // catalog-reported weight footprint (0 = unknown, gate disabled)
 	modelLoaded        bool    // true when the requested model is the currently-running slot
+	accountID          string
+	providerKey        string
 }
 
 type routingCandidate struct {
@@ -90,6 +93,7 @@ type routingCandidate struct {
 	effectiveQueue int
 	breakdown      costBreakdown
 	effectiveTPS   float64 // Phase 4 load-scaled TPS used in this candidate's cost
+	priceMicroUSD  int64
 }
 
 // candidateRejection enumerates why a provider that passed structural
@@ -136,6 +140,8 @@ type RoutingDecision struct {
 	CapacityRejections int     // candidates rejected by the free-memory admission gate
 	EffectiveTPS       float64 // load-scaled decode TPS used in cost (Phase 4)
 	StaticTPS          float64 // benchmarked decode TPS before load scaling
+	RoutingPreference  string  // "performance" or "cost"
+	EstimatedPrice     int64   // estimated request cost used for cost routing
 }
 
 // ReserveProvider selects a hardware-routable provider for the request and
@@ -159,6 +165,7 @@ func (r *Registry) ReserveProviderEx(model string, pr *PendingRequest, excludeID
 	if pr.Model == "" {
 		pr.Model = model
 	}
+	pr.RoutingPreference = normalizeRoutingPreference(pr.RoutingPreference)
 	if pr.RequestedMaxTokens <= 0 {
 		pr.RequestedMaxTokens = defaultRequestedMaxTokens
 	}
@@ -170,6 +177,7 @@ func (r *Registry) ReserveProviderEx(model string, pr *PendingRequest, excludeID
 	if selected == nil {
 		return nil, RoutingDecision{
 			Model:              model,
+			RoutingPreference:  pr.RoutingPreference,
 			CandidateCount:     candidateCount,
 			CapacityRejections: capacityRejections,
 		}
@@ -184,6 +192,7 @@ func (r *Registry) ReserveProviderEx(model string, pr *PendingRequest, excludeID
 	if !r.providerCanAdmitLocked(p, model, pr) {
 		return nil, RoutingDecision{
 			Model:              model,
+			RoutingPreference:  pr.RoutingPreference,
 			CandidateCount:     candidateCount,
 			CapacityRejections: capacityRejections,
 		}
@@ -199,6 +208,7 @@ func (r *Registry) ReserveProviderEx(model string, pr *PendingRequest, excludeID
 	decision := RoutingDecision{
 		ProviderID:         p.ID,
 		Model:              model,
+		RoutingPreference:  pr.RoutingPreference,
 		CostMs:             bd.Total,
 		StateMs:            bd.StateMs,
 		QueueMs:            bd.QueueMs,
@@ -211,6 +221,7 @@ func (r *Registry) ReserveProviderEx(model string, pr *PendingRequest, excludeID
 		CapacityRejections: capacityRejections,
 		EffectiveTPS:       selected.effectiveTPS,
 		StaticTPS:          selected.snapshot.decodeTPS,
+		EstimatedPrice:     selected.priceMicroUSD,
 	}
 	return p, decision
 }
@@ -270,13 +281,13 @@ func (r *Registry) selectBestCandidateLockedFull(model string, pr *PendingReques
 
 	var best *routingCandidate
 	for _, c := range candidates {
-		if best == nil || c.costMs < best.costMs {
+		if best == nil || candidateLess(c, best, pr.RoutingPreference) {
 			best = c
 		}
 	}
 	nearTies := make([]*routingCandidate, 0, len(candidates))
 	for _, c := range candidates {
-		if math.Abs(c.costMs-best.costMs) <= nearTieCostWindowMs {
+		if nearTie(c, best, pr.RoutingPreference) {
 			nearTies = append(nearTies, c)
 		}
 	}
@@ -299,7 +310,7 @@ func (r *Registry) selectBestCandidateLockedFull(model string, pr *PendingReques
 		for _, c := range nearTies {
 			if c.effectiveQueue == winner.effectiveQueue &&
 				c.snapshot.totalPending == winner.snapshot.totalPending &&
-				math.Abs(c.costMs-winner.costMs) <= nearTieCostWindowMs {
+				nearTie(c, winner, pr.RoutingPreference) {
 				equivalent = append(equivalent, c)
 			}
 		}
@@ -309,6 +320,31 @@ func (r *Registry) selectBestCandidateLockedFull(model string, pr *PendingReques
 	}
 	r.logRoutingDecision(model, pr, winner, candidateCount)
 	return winner, candidateCount, capacityRejections
+}
+
+func normalizeRoutingPreference(pref string) string {
+	switch pref {
+	case "cost":
+		return "cost"
+	default:
+		return "performance"
+	}
+}
+
+func candidateLess(a, b *routingCandidate, pref string) bool {
+	if pref == "cost" {
+		if a.priceMicroUSD != b.priceMicroUSD {
+			return a.priceMicroUSD < b.priceMicroUSD
+		}
+	}
+	return a.costMs < b.costMs
+}
+
+func nearTie(a, b *routingCandidate, pref string) bool {
+	if pref == "cost" && a.priceMicroUSD != b.priceMicroUSD {
+		return false
+	}
+	return math.Abs(a.costMs-b.costMs) <= nearTieCostWindowMs
 }
 
 func providerMatchesAllowedSerial(p *Provider, allowed map[string]struct{}) bool {
@@ -341,8 +377,10 @@ func (r *Registry) logRoutingDecision(model string, pr *PendingRequest, winner *
 	r.logger.Debug("routing_decision",
 		"request_id", pr.RequestID,
 		"model", model,
+		"routing_preference", pr.RoutingPreference,
 		"winner", winner.provider.ID,
 		"cost_ms", bd.Total,
+		"estimated_price_micro_usd", winner.priceMicroUSD,
 		"state_ms", bd.StateMs,
 		"queue_ms", bd.QueueMs,
 		"pending_ms", bd.PendingMs,
@@ -393,6 +431,8 @@ func (r *Registry) snapshotProviderLocked(p *Provider, model string, pr *Pending
 		prefillTPS:    resolvedPrefillTPS(p),
 		totalMemoryGB: float64(p.Hardware.MemoryGB),
 		modelSizeGB:   r.catalogSizeGBLocked(model),
+		accountID:     p.AccountID,
+		providerKey:   pricingProviderKeyLocked(p),
 	}
 
 	for _, pr := range p.pendingReqs {
@@ -514,6 +554,7 @@ func (r *Registry) buildCandidateWithReason(snap routingSnapshot, pr *PendingReq
 	thisReqMs := float64(reqPrompt)/snap.prefillTPS*1000.0 + float64(reqMax)/effectiveTPS*1000.0
 	healthMs := healthPenaltyMs(snap.systemMetrics, snap.gpuMemoryActiveGB, snap.totalMemoryGB)
 	cost := statePenalty + queueMs + pendingMs + backlogMs + thisReqMs + healthMs
+	priceMicroUSD := providerpricing.CalculateCost(r.store, snap.accountID, snap.providerKey, snap.model, reqPrompt, reqMax)
 
 	return &routingCandidate{
 		provider:       snap.provider,
@@ -521,6 +562,7 @@ func (r *Registry) buildCandidateWithReason(snap routingSnapshot, pr *PendingReq
 		costMs:         cost,
 		effectiveQueue: effectiveQueue,
 		effectiveTPS:   effectiveTPS,
+		priceMicroUSD:  priceMicroUSD,
 		breakdown: costBreakdown{
 			StateMs:   statePenalty,
 			QueueMs:   queueMs,
@@ -630,6 +672,21 @@ func providerServesModelLocked(p *Provider, model string) bool {
 		}
 	}
 	return false
+}
+
+func pricingProviderKeyLocked(p *Provider) string {
+	if p.AttestationResult != nil {
+		if p.AttestationResult.SerialNumber != "" {
+			return p.AttestationResult.SerialNumber
+		}
+		if p.AttestationResult.PublicKey != "" {
+			return p.AttestationResult.PublicKey
+		}
+	}
+	if p.PublicKey != "" {
+		return p.PublicKey
+	}
+	return p.ID
 }
 
 func providerModelIDs(p *Provider) []string {

--- a/coordinator/internal/registry/scheduler_test.go
+++ b/coordinator/internal/registry/scheduler_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/eigeninference/coordinator/internal/attestation"
 	"github.com/eigeninference/coordinator/internal/protocol"
+	"github.com/eigeninference/coordinator/internal/store"
 )
 
 func makeSchedulerProvider(t *testing.T, reg *Registry, id, model string, decodeTPS float64) *Provider {
@@ -45,6 +46,13 @@ func makeSchedulerProvider(t *testing.T, reg *Registry, id, model string, decode
 func setSchedulerProviderSerial(p *Provider, serial string) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
+	p.AttestationResult = &attestation.VerificationResult{SerialNumber: serial}
+}
+
+func setSchedulerProviderAccountSerial(p *Provider, accountID, serial string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.AccountID = accountID
 	p.AttestationResult = &attestation.VerificationResult{SerialNumber: serial}
 }
 
@@ -113,6 +121,65 @@ func TestReserveProviderExReturnsCostBreakdown(t *testing.T) {
 	}
 }
 
+func TestReserveProviderCostRoutingUsesDiscountedPrice(t *testing.T) {
+	model := "cost-routing-model"
+	makeRegistry := func(t *testing.T) *Registry {
+		t.Helper()
+		st := store.NewMemory("")
+		if err := st.SetModelPrice("platform", model, 1_000_000, 1_000_000); err != nil {
+			t.Fatalf("SetModelPrice: %v", err)
+		}
+		if err := st.SetProviderDiscount("acct-slow", "SLOW-SERIAL", model, 8000); err != nil {
+			t.Fatalf("SetProviderDiscount: %v", err)
+		}
+		reg := New(testLogger())
+		reg.SetStore(st)
+		fast := makeSchedulerProvider(t, reg, "fast-expensive", model, 200)
+		slow := makeSchedulerProvider(t, reg, "slow-cheap", model, 40)
+		setSchedulerProviderAccountSerial(fast, "acct-fast", "FAST-SERIAL")
+		setSchedulerProviderAccountSerial(slow, "acct-slow", "SLOW-SERIAL")
+		return reg
+	}
+
+	perfReq := &PendingRequest{
+		RequestID:             "req-performance",
+		Model:                 model,
+		EstimatedPromptTokens: 1_000,
+		RequestedMaxTokens:    1_000,
+	}
+	perfProvider, perfDecision := makeRegistry(t).ReserveProviderEx(model, perfReq)
+	if perfProvider == nil {
+		t.Fatal("performance reservation returned nil")
+	}
+	if perfProvider.ID != "fast-expensive" {
+		t.Fatalf("performance selected %q, want fast-expensive", perfProvider.ID)
+	}
+	if perfDecision.RoutingPreference != "performance" {
+		t.Fatalf("performance decision preference = %q", perfDecision.RoutingPreference)
+	}
+
+	costReq := &PendingRequest{
+		RequestID:             "req-cost",
+		Model:                 model,
+		RoutingPreference:     "cost",
+		EstimatedPromptTokens: 1_000,
+		RequestedMaxTokens:    1_000,
+	}
+	costProvider, costDecision := makeRegistry(t).ReserveProviderEx(model, costReq)
+	if costProvider == nil {
+		t.Fatal("cost reservation returned nil")
+	}
+	if costProvider.ID != "slow-cheap" {
+		t.Fatalf("cost selected %q, want slow-cheap", costProvider.ID)
+	}
+	if costDecision.RoutingPreference != "cost" {
+		t.Fatalf("cost decision preference = %q", costDecision.RoutingPreference)
+	}
+	if costDecision.EstimatedPrice != 400 {
+		t.Fatalf("cost decision EstimatedPrice = %d, want 400", costDecision.EstimatedPrice)
+	}
+}
+
 func TestReserveProviderHonorsAllowedProviderSerials(t *testing.T) {
 	reg := New(testLogger())
 	model := "targeted-model"
@@ -178,6 +245,7 @@ func TestDrainQueuedRequestsPopulatesDecision(t *testing.T) {
 		Pending: &PendingRequest{
 			RequestID:             "queued-decision",
 			Model:                 model,
+			RoutingPreference:     "cost",
 			RequestedMaxTokens:    256,
 			EstimatedPromptTokens: 50,
 		},
@@ -204,6 +272,12 @@ func TestDrainQueuedRequestsPopulatesDecision(t *testing.T) {
 	}
 	if req.Decision.CostMs <= 0 {
 		t.Fatalf("Decision.CostMs=%f, want > 0", req.Decision.CostMs)
+	}
+	if req.Decision.RoutingPreference != "cost" {
+		t.Fatalf("Decision.RoutingPreference=%q, want cost", req.Decision.RoutingPreference)
+	}
+	if req.Pending.RoutingPreference != "cost" {
+		t.Fatalf("Pending.RoutingPreference=%q, want cost", req.Pending.RoutingPreference)
 	}
 	if req.Decision.CandidateCount != 1 {
 		t.Fatalf("Decision.CandidateCount=%d, want 1", req.Decision.CandidateCount)

--- a/coordinator/internal/store/interface.go
+++ b/coordinator/internal/store/interface.go
@@ -149,6 +149,19 @@ type Store interface {
 	// DeleteModelPrice removes a custom price override.
 	DeleteModelPrice(accountID, model string) error
 
+	// SetProviderDiscount sets a provider discount override. Empty providerKey
+	// means account-wide; empty model means all models.
+	SetProviderDiscount(accountID, providerKey, model string, discountBPS int) error
+
+	// GetProviderDiscount returns one exact provider discount override.
+	GetProviderDiscount(accountID, providerKey, model string) (ProviderDiscount, bool)
+
+	// ListProviderDiscounts returns all discount overrides for an account.
+	ListProviderDiscounts(accountID string) []ProviderDiscount
+
+	// DeleteProviderDiscount removes one exact provider discount override.
+	DeleteProviderDiscount(accountID, providerKey, model string) error
+
 	// --- Supported Models (admin-managed catalog) ---
 
 	// SetSupportedModel adds or updates a supported model in the catalog.
@@ -490,6 +503,28 @@ type ModelPrice struct {
 	Model       string `json:"model"`
 	InputPrice  int64  `json:"input_price"`  // micro-USD per 1M tokens
 	OutputPrice int64  `json:"output_price"` // micro-USD per 1M tokens
+}
+
+// ProviderDiscount represents a provider-side percentage discount. ProviderKey
+// and Model are optional selectors; empty values mean account-wide/all-models.
+type ProviderDiscount struct {
+	AccountID   string `json:"account_id"`
+	ProviderKey string `json:"provider_key,omitempty"`
+	Model       string `json:"model,omitempty"`
+	DiscountBPS int    `json:"discount_bps"`
+}
+
+func (d ProviderDiscount) Scope() string {
+	switch {
+	case d.ProviderKey != "" && d.Model != "":
+		return "machine_model"
+	case d.ProviderKey != "":
+		return "machine_global"
+	case d.Model != "":
+		return "account_model"
+	default:
+		return "account_global"
+	}
 }
 
 // User represents a consumer account linked to a Privy identity.

--- a/coordinator/internal/store/memory.go
+++ b/coordinator/internal/store/memory.go
@@ -49,7 +49,8 @@ type MemoryStore struct {
 	billingSessions map[string]*BillingSession // sessionID → session
 
 	// Custom pricing
-	modelPrices map[string]ModelPrice // "accountID:model" → price
+	modelPrices       map[string]ModelPrice       // "accountID:model" → price
+	providerDiscounts map[string]ProviderDiscount // "accountID:providerKey:model" → discount
 
 	// Supported models (admin-managed catalog)
 	supportedModels map[string]*SupportedModel // modelID → model
@@ -114,6 +115,7 @@ func NewMemory(adminKey string) *MemoryStore {
 		referralCounts:                make(map[string]int),
 		billingSessions:               make(map[string]*BillingSession),
 		modelPrices:                   make(map[string]ModelPrice),
+		providerDiscounts:             make(map[string]ProviderDiscount),
 		supportedModels:               make(map[string]*SupportedModel),
 		usersByPrivyID:                make(map[string]*User),
 		usersByAccountID:              make(map[string]*User),
@@ -772,6 +774,64 @@ func (s *MemoryStore) DeleteModelPrice(accountID, model string) error {
 		return fmt.Errorf("no custom price for model %q", model)
 	}
 	delete(s.modelPrices, key)
+	return nil
+}
+
+func providerDiscountKey(accountID, providerKey, model string) string {
+	accountID = strings.TrimSpace(accountID)
+	providerKey = strings.TrimSpace(providerKey)
+	model = strings.TrimSpace(model)
+	return accountID + ":" + providerKey + ":" + model
+}
+
+func (s *MemoryStore) SetProviderDiscount(accountID, providerKey, model string, discountBPS int) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	accountID = strings.TrimSpace(accountID)
+	providerKey = strings.TrimSpace(providerKey)
+	model = strings.TrimSpace(model)
+	key := providerDiscountKey(accountID, providerKey, model)
+	s.providerDiscounts[key] = ProviderDiscount{
+		AccountID:   accountID,
+		ProviderKey: providerKey,
+		Model:       model,
+		DiscountBPS: discountBPS,
+	}
+	return nil
+}
+
+func (s *MemoryStore) GetProviderDiscount(accountID, providerKey, model string) (ProviderDiscount, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	d, ok := s.providerDiscounts[providerDiscountKey(accountID, providerKey, model)]
+	return d, ok
+}
+
+func (s *MemoryStore) ListProviderDiscounts(accountID string) []ProviderDiscount {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	accountID = strings.TrimSpace(accountID)
+	discounts := make([]ProviderDiscount, 0)
+	for _, d := range s.providerDiscounts {
+		if d.AccountID == accountID {
+			discounts = append(discounts, d)
+		}
+	}
+	return discounts
+}
+
+func (s *MemoryStore) DeleteProviderDiscount(accountID, providerKey, model string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	key := providerDiscountKey(accountID, providerKey, model)
+	if _, ok := s.providerDiscounts[key]; !ok {
+		return fmt.Errorf("no provider discount for selector")
+	}
+	delete(s.providerDiscounts, key)
 	return nil
 }
 

--- a/coordinator/internal/store/postgres.go
+++ b/coordinator/internal/store/postgres.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -235,6 +236,14 @@ func (s *PostgresStore) migrate(ctx context.Context) error {
 			output_price BIGINT NOT NULL,
 			updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
 			PRIMARY KEY (account_id, model)
+		)`,
+		`CREATE TABLE IF NOT EXISTS provider_discounts (
+			account_id TEXT NOT NULL,
+			provider_key TEXT NOT NULL DEFAULT '',
+			model TEXT NOT NULL DEFAULT '',
+			discount_bps INT NOT NULL,
+			updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			PRIMARY KEY (account_id, provider_key, model)
 		)`,
 
 		// Users — Privy identity → internal account mapping
@@ -1342,6 +1351,95 @@ func (s *PostgresStore) DeleteModelPrice(accountID, model string) error {
 	}
 	if tag.RowsAffected() == 0 {
 		return fmt.Errorf("no custom price for model %q", model)
+	}
+	return nil
+}
+
+func (s *PostgresStore) SetProviderDiscount(accountID, providerKey, model string, discountBPS int) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	accountID = strings.TrimSpace(accountID)
+	providerKey = strings.TrimSpace(providerKey)
+	model = strings.TrimSpace(model)
+
+	_, err := s.pool.Exec(ctx,
+		`INSERT INTO provider_discounts (account_id, provider_key, model, discount_bps, updated_at)
+		 VALUES ($1, $2, $3, $4, NOW())
+		 ON CONFLICT (account_id, provider_key, model) DO UPDATE SET
+		   discount_bps = $4, updated_at = NOW()`,
+		accountID, providerKey, model, discountBPS,
+	)
+	if err != nil {
+		return fmt.Errorf("store: set provider discount: %w", err)
+	}
+	return nil
+}
+
+func (s *PostgresStore) GetProviderDiscount(accountID, providerKey, model string) (ProviderDiscount, bool) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	accountID = strings.TrimSpace(accountID)
+	providerKey = strings.TrimSpace(providerKey)
+	model = strings.TrimSpace(model)
+
+	var d ProviderDiscount
+	err := s.pool.QueryRow(ctx,
+		`SELECT account_id, provider_key, model, discount_bps
+		   FROM provider_discounts
+		  WHERE account_id = $1 AND provider_key = $2 AND model = $3`,
+		accountID, providerKey, model,
+	).Scan(&d.AccountID, &d.ProviderKey, &d.Model, &d.DiscountBPS)
+	if err != nil {
+		return ProviderDiscount{}, false
+	}
+	return d, true
+}
+
+func (s *PostgresStore) ListProviderDiscounts(accountID string) []ProviderDiscount {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	accountID = strings.TrimSpace(accountID)
+
+	rows, err := s.pool.Query(ctx,
+		`SELECT account_id, provider_key, model, discount_bps
+		   FROM provider_discounts
+		  WHERE account_id = $1
+		  ORDER BY provider_key, model`,
+		accountID,
+	)
+	if err != nil {
+		return nil
+	}
+	defer rows.Close()
+
+	var discounts []ProviderDiscount
+	for rows.Next() {
+		var d ProviderDiscount
+		if err := rows.Scan(&d.AccountID, &d.ProviderKey, &d.Model, &d.DiscountBPS); err != nil {
+			continue
+		}
+		discounts = append(discounts, d)
+	}
+	return discounts
+}
+
+func (s *PostgresStore) DeleteProviderDiscount(accountID, providerKey, model string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	accountID = strings.TrimSpace(accountID)
+	providerKey = strings.TrimSpace(providerKey)
+	model = strings.TrimSpace(model)
+
+	tag, err := s.pool.Exec(ctx,
+		`DELETE FROM provider_discounts
+		  WHERE account_id = $1 AND provider_key = $2 AND model = $3`,
+		accountID, providerKey, model,
+	)
+	if err != nil {
+		return fmt.Errorf("store: delete provider discount: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return fmt.Errorf("no provider discount for selector")
 	}
 	return nil
 }

--- a/coordinator/internal/store/store_test.go
+++ b/coordinator/internal/store/store_test.go
@@ -389,6 +389,50 @@ func TestProviderToken(t *testing.T) {
 	}
 }
 
+func TestProviderDiscountCRUD(t *testing.T) {
+	s := NewMemory("")
+
+	if err := s.SetProviderDiscount(" acct-1 ", " serial-1 ", " model-a ", 1250); err != nil {
+		t.Fatalf("SetProviderDiscount: %v", err)
+	}
+	got, ok := s.GetProviderDiscount("acct-1", "serial-1", "model-a")
+	if !ok {
+		t.Fatal("GetProviderDiscount returned ok=false")
+	}
+	if got.AccountID != "acct-1" || got.ProviderKey != "serial-1" || got.Model != "model-a" || got.DiscountBPS != 1250 {
+		t.Fatalf("discount = %#v", got)
+	}
+	if got.Scope() != "machine_model" {
+		t.Fatalf("Scope() = %q, want machine_model", got.Scope())
+	}
+
+	if err := s.SetProviderDiscount("acct-1", "", "", 500); err != nil {
+		t.Fatalf("SetProviderDiscount global: %v", err)
+	}
+	list := s.ListProviderDiscounts("acct-1")
+	if len(list) != 2 {
+		t.Fatalf("ListProviderDiscounts len = %d, want 2", len(list))
+	}
+	list[0].DiscountBPS = 9000
+	again, ok := s.GetProviderDiscount("acct-1", "serial-1", "model-a")
+	if !ok {
+		t.Fatal("discount disappeared")
+	}
+	if again.DiscountBPS != 1250 {
+		t.Fatalf("ListProviderDiscounts did not return a copy; bps = %d", again.DiscountBPS)
+	}
+
+	if err := s.DeleteProviderDiscount("acct-1", "serial-1", "model-a"); err != nil {
+		t.Fatalf("DeleteProviderDiscount: %v", err)
+	}
+	if _, ok := s.GetProviderDiscount("acct-1", "serial-1", "model-a"); ok {
+		t.Fatal("discount still exists after delete")
+	}
+	if err := s.DeleteProviderDiscount("acct-1", "serial-1", "model-a"); err == nil {
+		t.Fatal("expected error deleting missing discount")
+	}
+}
+
 func TestProviderEarnings_RecordAndGetByAccount(t *testing.T) {
 	s := NewMemory("")
 

--- a/provider/src/main.rs
+++ b/provider/src/main.rs
@@ -1547,6 +1547,33 @@ enum Command {
         coordinator: String,
     },
 
+    /// Show or edit provider pricing discounts
+    Pricing {
+        /// Action: show, set, or clear
+        #[arg(default_value = "show")]
+        action: String,
+
+        /// Coordinator API URL
+        #[arg(long, default_value = DEFAULT_COORDINATOR_HTTP_URL)]
+        coordinator: String,
+
+        /// Model ID for a model-specific discount
+        #[arg(long)]
+        model: Option<String>,
+
+        /// Stable provider key for a machine-specific discount
+        #[arg(long)]
+        provider_key: Option<String>,
+
+        /// Apply the discount to this Mac using its hardware serial
+        #[arg(long)]
+        this_machine: bool,
+
+        /// Discount percentage, 0 through 90
+        #[arg(long)]
+        discount: Option<f64>,
+    },
+
     /// Diagnose issues: check SIP, Secure Enclave, MDM, models, connectivity
     Doctor {
         /// Coordinator URL to test connectivity
@@ -1685,6 +1712,24 @@ async fn main() -> Result<()> {
             coordinator,
         } => cmd_models(action, coordinator, model).await,
         Command::Earnings { coordinator } => cmd_earnings(coordinator).await,
+        Command::Pricing {
+            action,
+            coordinator,
+            model,
+            provider_key,
+            this_machine,
+            discount,
+        } => {
+            cmd_pricing(
+                action,
+                coordinator,
+                model,
+                provider_key,
+                this_machine,
+                discount,
+            )
+            .await
+        }
         Command::Doctor { coordinator } => cmd_doctor(coordinator).await,
         Command::Start {
             coordinator,
@@ -5121,6 +5166,161 @@ async fn cmd_earnings(coordinator_url: String) -> Result<()> {
     Ok(())
 }
 
+async fn cmd_pricing(
+    action: String,
+    coordinator_url: String,
+    model: Option<String>,
+    provider_key: Option<String>,
+    this_machine: bool,
+    discount: Option<f64>,
+) -> Result<()> {
+    let token = load_auth_token().ok_or_else(|| {
+        anyhow::anyhow!("Not logged in. Run `darkbloom login` before editing provider pricing.")
+    })?;
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(10))
+        .build()?;
+    let base = coordinator_url.trim_end_matches('/');
+    let provider_key = resolve_pricing_provider_key(provider_key, this_machine)?;
+
+    match action.as_str() {
+        "show" | "list" => {
+            let resp = client
+                .get(format!("{base}/v1/pricing/me"))
+                .bearer_auth(&token)
+                .send()
+                .await?;
+            if !resp.status().is_success() {
+                let status = resp.status();
+                let body = resp.text().await.unwrap_or_default();
+                anyhow::bail!("Failed to fetch pricing (HTTP {status}): {body}");
+            }
+            let body: serde_json::Value = resp.json().await?;
+
+            println!("Darkbloom Provider Pricing");
+            println!();
+
+            if let Some(discounts) = body["discounts"].as_array() {
+                if discounts.is_empty() {
+                    println!("Discounts: none configured");
+                } else {
+                    println!("Discounts:");
+                    for d in discounts {
+                        let pct = d["discount_percent"].as_f64().unwrap_or(0.0);
+                        let scope = d["scope"].as_str().unwrap_or("account_global");
+                        let model = d["model"].as_str().unwrap_or("");
+                        let machine = d["provider_key"].as_str().unwrap_or("");
+                        let selector = match (machine.is_empty(), model.is_empty()) {
+                            (true, true) => "account default".to_string(),
+                            (true, false) => format!("account model {model}"),
+                            (false, true) => format!("machine {machine}"),
+                            (false, false) => format!("machine {machine} model {model}"),
+                        };
+                        println!("  {:>5.2}%  {:<14} {}", pct, scope, selector);
+                    }
+                }
+            }
+
+            if let Some(prices) = body["prices"].as_array() {
+                if !prices.is_empty() {
+                    println!();
+                    println!("Effective prices per 1M tokens:");
+                    for p in prices {
+                        let model = p["model"].as_str().unwrap_or("unknown");
+                        let input = p["input_usd"].as_str().unwrap_or("$0.0000");
+                        let output = p["output_usd"].as_str().unwrap_or("$0.0000");
+                        let discount = p["discount_percent"].as_f64().unwrap_or(0.0);
+                        println!(
+                            "  {:<36} in {:>9}  out {:>9}  discount {:>5.2}%",
+                            model, input, output, discount
+                        );
+                    }
+                }
+            }
+        }
+        "set" => {
+            let discount = discount.ok_or_else(|| {
+                anyhow::anyhow!("Missing --discount. Example: darkbloom pricing set --discount 10")
+            })?;
+            if !discount.is_finite() || !(0.0..=90.0).contains(&discount) {
+                anyhow::bail!("--discount must be between 0 and 90");
+            }
+            let mut payload = serde_json::json!({
+                "discount_percent": discount,
+            });
+            if let Some(obj) = payload.as_object_mut() {
+                if !provider_key.is_empty() {
+                    obj.insert("provider_key".to_string(), serde_json::json!(provider_key));
+                }
+                if let Some(model) = model.as_ref().filter(|m| !m.trim().is_empty()) {
+                    obj.insert("model".to_string(), serde_json::json!(model));
+                }
+            }
+
+            let resp = client
+                .put(format!("{base}/v1/pricing/discount"))
+                .bearer_auth(&token)
+                .json(&payload)
+                .send()
+                .await?;
+            if !resp.status().is_success() {
+                let status = resp.status();
+                let body = resp.text().await.unwrap_or_default();
+                anyhow::bail!("Failed to set discount (HTTP {status}): {body}");
+            }
+            let body: serde_json::Value = resp.json().await?;
+            let d = &body["discount"];
+            println!(
+                "Set {} discount to {:.2}%",
+                d["scope"].as_str().unwrap_or("provider"),
+                d["discount_percent"].as_f64().unwrap_or(discount)
+            );
+        }
+        "clear" | "delete" | "reset" => {
+            let mut payload = serde_json::json!({});
+            if let Some(obj) = payload.as_object_mut() {
+                if !provider_key.is_empty() {
+                    obj.insert("provider_key".to_string(), serde_json::json!(provider_key));
+                }
+                if let Some(model) = model.as_ref().filter(|m| !m.trim().is_empty()) {
+                    obj.insert("model".to_string(), serde_json::json!(model));
+                }
+            }
+            let resp = client
+                .delete(format!("{base}/v1/pricing/discount"))
+                .bearer_auth(&token)
+                .json(&payload)
+                .send()
+                .await?;
+            if !resp.status().is_success() {
+                let status = resp.status();
+                let body = resp.text().await.unwrap_or_default();
+                anyhow::bail!("Failed to clear discount (HTTP {status}): {body}");
+            }
+            println!("Cleared discount.");
+        }
+        _ => {
+            anyhow::bail!(
+                "Usage: darkbloom pricing [show|set|clear] [--discount N] [--model MODEL] [--this-machine]"
+            );
+        }
+    }
+
+    Ok(())
+}
+
+fn resolve_pricing_provider_key(
+    provider_key: Option<String>,
+    this_machine: bool,
+) -> Result<String> {
+    match (provider_key, this_machine) {
+        (Some(_), true) => anyhow::bail!("use either --provider-key or --this-machine, not both"),
+        (Some(key), false) => Ok(key.trim().to_string()),
+        (None, true) => get_serial_number(),
+        (None, false) => Ok(String::new()),
+    }
+}
+
 async fn cmd_doctor(coordinator_url: String) -> Result<()> {
     println!("Darkbloom Doctor — System Diagnostics");
     println!();
@@ -6609,6 +6809,68 @@ mod tests {
         perms.set_mode(0o755);
         std::fs::set_permissions(&path, perms).expect("failed to chmod temp script");
         path
+    }
+
+    #[test]
+    fn test_pricing_cli_parses_account_model_discount() {
+        let cli = Cli::parse_from([
+            "darkbloom",
+            "pricing",
+            "set",
+            "--model",
+            "model-a",
+            "--discount",
+            "15",
+        ]);
+        match cli.command {
+            Command::Pricing {
+                action,
+                model,
+                discount,
+                this_machine,
+                ..
+            } => {
+                assert_eq!(action, "set");
+                assert_eq!(model.as_deref(), Some("model-a"));
+                assert_eq!(discount, Some(15.0));
+                assert!(!this_machine);
+            }
+            _ => panic!("expected pricing command"),
+        }
+    }
+
+    #[test]
+    fn test_pricing_cli_parses_this_machine_discount() {
+        let cli = Cli::parse_from([
+            "darkbloom",
+            "pricing",
+            "set",
+            "--this-machine",
+            "--discount",
+            "20",
+        ]);
+        match cli.command {
+            Command::Pricing {
+                action,
+                this_machine,
+                discount,
+                ..
+            } => {
+                assert_eq!(action, "set");
+                assert!(this_machine);
+                assert_eq!(discount, Some(20.0));
+            }
+            _ => panic!("expected pricing command"),
+        }
+    }
+
+    #[test]
+    fn test_pricing_provider_key_validation() {
+        assert_eq!(
+            resolve_pricing_provider_key(Some(" SERIAL-1 ".to_string()), false).unwrap(),
+            "SERIAL-1"
+        );
+        assert!(resolve_pricing_provider_key(Some("SERIAL-1".to_string()), true).is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add provider discount storage/resolution with account-global, account/model, machine-global, and machine/model precedence
- expose authenticated provider pricing endpoints and wire discounted billing/payout math through coordinator paths
- add consumer routing preference parsing for body/header/query, preserve it through queues, and support lowest-cost routing
- add darkbloom pricing CLI commands plus provider pricing and chat routing UI updates

## Validation
- PASS: `cd coordinator && GOCACHE=/tmp/go-build go test ./internal/pricing ./internal/store ./internal/registry ./internal/api`
- PASS: `cd console-ui && npm test`
- PASS: `cd console-ui && npx eslint src/` (97 existing warnings, 0 errors)
- PASS: `cd console-ui && npm run build`
- PASS: `cd provider && cargo fmt --check`
- PASS: `cd provider && PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 cargo test pricing_cli -- --nocapture`
- PASS: `cd provider && PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 cargo test test_pricing_provider_key_validation -- --nocapture`
- PASS: focused rerun of `coordinator::tests::test_coordinator_connect_register_and_receive`
- FAIL: full `cd provider && PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 cargo test -- --nocapture` hit `coordinator::tests::test_coordinator_connect_register_and_receive` in the full suite; first run failed with `expected at least register and error messages, got 1`, second run failed with `expected an inference_error message` and then hung in `secure_enclave_key::tests::test_ephemeral_handle_attestation_without_binary_hash`, so I killed the stuck process
- BLOCKED/EXISTING: `cd console-ui && npx tsc --noEmit` still fails on pre-existing unrelated type errors in `EarningsContent.tsx`, `DatadogRUM.tsx`, `telemetry.ts`, and `vitest.config.ts`

## Notes
- Discounts are clamped to 0-90% and are stored internally as basis points while exposing `discount_percent` externally.
- Provider pricing writes accept provider auth surfaces but reject consumer API keys; machine-scoped writes verify ownership.
- Cost routing optimizes estimated consumer charge and leaves the default performance path unchanged.