### PR TITLE
Add Enterprise Stripe invoicing

### DIFF
--- a/console-ui/__tests__/billing-enterprise.test.tsx
+++ b/console-ui/__tests__/billing-enterprise.test.tsx
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+
+const enterpriseMock = vi.hoisted(() => ({ response: {} as Record<string, unknown> }));
+const aprilFirst = "2026-04-01T00:00:00Z";
+
+vi.mock("@/hooks/useToast", () => ({
+  useToastStore: () => vi.fn(),
+}));
+
+vi.mock("@/hooks/useAuth", () => ({
+  useAuth: () => ({ email: "user@example.com" }),
+}));
+
+vi.mock("@/components/TopBar", () => ({
+  TopBar: ({ title }: { title?: string }) => <div>{title}</div>,
+}));
+
+vi.mock("@/components/UsageChart", () => ({
+  UsageChart: () => <div data-testid="usage-chart" />,
+}));
+
+vi.mock("@/lib/api", async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    fetchBalance: vi.fn().mockResolvedValue({
+      balance_micro_usd: 0,
+      balance_usd: 0,
+      withdrawable_micro_usd: 0,
+      withdrawable_usd: 0,
+    }),
+    fetchUsage: vi.fn().mockResolvedValue([]),
+    fetchEnterpriseStatus: vi.fn().mockImplementation(() => Promise.resolve(enterpriseMock.response)),
+    fetchStripeStatus: vi.fn().mockResolvedValue({ configured: false, has_account: false, status: "" }),
+    fetchStripeWithdrawals: vi.fn().mockResolvedValue([]),
+    createStripeCheckout: vi.fn(),
+    redeemInviteCode: vi.fn(),
+  };
+});
+
+beforeEach(() => {
+  enterpriseMock.response = {
+      enabled: true,
+      credit_remaining_micro_usd: 7_500_000,
+      account: {
+        account_id: "acct-ent",
+        status: "active",
+        billing_email: "billing@example.com",
+        cadence: "biweekly",
+        terms_days: 15,
+        credit_limit_micro_usd: 10_000_000,
+        accrued_micro_usd: 2_000_000,
+        reserved_micro_usd: 500_000,
+        open_invoice_micro_usd: 0,
+        rounding_carry_micro_usd: 0,
+        current_period_start: aprilFirst,
+        next_invoice_at: "2026-04-15T00:00:00Z",
+      },
+      recent_invoices: [
+        {
+          id: "inv-1",
+          status: "open",
+          amount_micro_usd: 3_000_000,
+          amount_cents: 300,
+          terms_days: 15,
+          period_start: "2026-03-15T00:00:00Z",
+          period_end: aprilFirst,
+          stripe_hosted_invoice_url: "https://invoice.test/inv-1",
+        },
+      ],
+    };
+  const store = new Map<string, string>();
+  vi.stubGlobal("localStorage", {
+    getItem: (k: string) => store.get(k) ?? null,
+    setItem: (k: string, v: string) => {
+      store.set(k, v);
+    },
+    removeItem: (k: string) => {
+      store.delete(k);
+    },
+  });
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("Billing Enterprise card", () => {
+  it("shows cadence, editable terms, remaining credit, and invoice link", async () => {
+    const BillingContent = (await import("@/app/billing/BillingContent")).default;
+    render(<BillingContent />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Enterprise Invoicing")).toBeInTheDocument();
+    });
+    expect(screen.getByText("Bi-weekly")).toBeInTheDocument();
+    expect(screen.getByText("Net 15")).toBeInTheDocument();
+    expect(screen.getByText("$7.50 / $10.00")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /View invoice/i })).toHaveAttribute(
+      "href",
+      "https://invoice.test/inv-1",
+    );
+  });
+
+  it("shows disabled enterprise accounts with invoice history", async () => {
+    enterpriseMock.response = {
+      enabled: false,
+      credit_remaining_micro_usd: 7_000_000,
+      account: {
+        account_id: "acct-ent",
+        status: "disabled",
+        billing_email: "billing@example.com",
+        stripe_customer_id: "cus_ent",
+        cadence: "monthly",
+        terms_days: 30,
+        credit_limit_micro_usd: 10_000_000,
+        accrued_micro_usd: 1_000_000,
+        reserved_micro_usd: 0,
+        open_invoice_micro_usd: 2_000_000,
+        rounding_carry_micro_usd: 0,
+        current_period_start: aprilFirst,
+        next_invoice_at: "2026-05-01T00:00:00Z",
+      },
+      recent_invoices: [
+        {
+          id: "inv-disabled",
+          status: "open",
+          amount_micro_usd: 2_000_000,
+          amount_cents: 200,
+          terms_days: 30,
+          period_start: "2026-03-01T00:00:00Z",
+          period_end: aprilFirst,
+          stripe_hosted_invoice_url: "https://invoice.test/inv-disabled",
+        },
+      ],
+    };
+    const BillingContent = (await import("@/app/billing/BillingContent")).default;
+    render(<BillingContent />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Enterprise Invoicing")).toBeInTheDocument();
+    });
+    expect(screen.getByText("Disabled")).toBeInTheDocument();
+    expect(screen.getByText("Net 30")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /View invoice/i })).toHaveAttribute(
+      "href",
+      "https://invoice.test/inv-disabled",
+    );
+  });
+});

--- a/console-ui/src/app/api/payments/enterprise/status/route.ts
+++ b/console-ui/src/app/api/payments/enterprise/status/route.ts
@@ -1,0 +1,24 @@
+import { NextRequest, NextResponse } from "next/server";
+
+const DEFAULT_COORD = process.env.NEXT_PUBLIC_COORDINATOR_URL || "https://api.darkbloom.dev";
+
+export async function GET(req: NextRequest) {
+  const coordUrl = DEFAULT_COORD;
+  const apiKey = req.headers.get("x-api-key") || "";
+
+  let authHeader = req.headers.get("authorization") || "";
+  if (!authHeader && apiKey) authHeader = `Bearer ${apiKey}`;
+  if (!authHeader) {
+    const privyToken = req.cookies.get("privy-token")?.value;
+    if (privyToken) authHeader = `Bearer ${privyToken}`;
+  }
+
+  const res = await fetch(`${coordUrl}/v1/billing/enterprise/status`, {
+    headers: { ...(authHeader ? { Authorization: authHeader } : {}) },
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    return NextResponse.json({ error: text }, { status: res.status });
+  }
+  return NextResponse.json(await res.json().catch(() => ({})));
+}

--- a/console-ui/src/app/billing/BillingContent.tsx
+++ b/console-ui/src/app/billing/BillingContent.tsx
@@ -7,6 +7,7 @@ import { TopBar } from "@/components/TopBar";
 import {
   fetchBalance,
   fetchUsage,
+  fetchEnterpriseStatus,
   createStripeCheckout,
   redeemInviteCode,
   fetchStripeStatus,
@@ -16,6 +17,7 @@ import {
   computeStripeFeeUsd,
   type BalanceResponse,
   type UsageEntry,
+  type EnterpriseStatusResponse,
   type StripeStatus,
   type StripeWithdrawal,
 } from "@/lib/api";
@@ -68,6 +70,7 @@ export default function BillingContent() {
   const { email } = useAuth();
   const [balance, setBalance] = useState<BalanceResponse | null>(null);
   const [usage, setUsage] = useState<UsageEntry[]>([]);
+  const [enterprise, setEnterprise] = useState<EnterpriseStatusResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [buyOpen, setBuyOpen] = useState(false);
   const [buyAmount, setBuyAmount] = useState("10");
@@ -98,6 +101,7 @@ export default function BillingContent() {
       ]);
       setBalance(b);
       setUsage(u);
+      fetchEnterpriseStatus().then(setEnterprise).catch(() => setEnterprise({ enabled: false }));
     } catch (e) {
       addToast(`Failed to load billing data: ${(e as Error).message}`);
     }
@@ -285,6 +289,10 @@ export default function BillingContent() {
               </button>
             </div>
           </div>
+
+          {enterprise?.account && (
+            <EnterpriseBillingCard enterprise={enterprise} />
+          )}
 
           {/* Invite Code Redemption */}
           <div className="rounded-2xl border border-border-dim bg-bg-white p-6 shadow-md">
@@ -537,6 +545,80 @@ export default function BillingContent() {
           onCancel={() => setWithdrawOpen(false)}
         />
       </Modal>
+    </div>
+  );
+}
+
+function EnterpriseBillingCard({ enterprise }: { enterprise: EnterpriseStatusResponse }) {
+  const account = enterprise.account;
+  if (!account) return null;
+  const active = enterprise.enabled;
+  const committed =
+    account.open_invoice_micro_usd + account.accrued_micro_usd + account.reserved_micro_usd + (account.rounding_carry_micro_usd ?? 0);
+  const remaining = enterprise.credit_remaining_micro_usd ?? Math.max(account.credit_limit_micro_usd - committed, 0);
+  const limitUsd = account.credit_limit_micro_usd / 1_000_000;
+  const remainingUsd = remaining / 1_000_000;
+  const periodUsageUsd = (account.accrued_micro_usd + account.reserved_micro_usd + (account.rounding_carry_micro_usd ?? 0)) / 1_000_000;
+  const cadence = account.cadence === "biweekly" ? "Bi-weekly" : account.cadence[0].toUpperCase() + account.cadence.slice(1);
+
+  return (
+    <div className="rounded-2xl border border-border-dim bg-bg-white p-6 shadow-md">
+      <div className="flex flex-wrap items-center gap-2 mb-4">
+        <Building2 size={16} className="text-teal" />
+        <h3 className="text-sm font-semibold text-text-primary">Enterprise Invoicing</h3>
+        <span className={`ml-auto text-[10px] font-mono uppercase tracking-widest rounded px-2 py-0.5 ${
+          active
+            ? "text-teal bg-teal/10 border border-teal/30"
+            : "text-text-tertiary bg-bg-primary border border-border-dim"
+        }`}>
+          {active ? "Active" : "Disabled"}
+        </span>
+      </div>
+      <div className="grid grid-cols-1 sm:grid-cols-4 gap-3 mb-4">
+        <div className="rounded-lg bg-bg-primary border border-border-dim p-3">
+          <p className="text-[10px] font-mono uppercase tracking-wider text-text-tertiary mb-1">Cadence</p>
+          <p className="text-sm font-semibold text-text-primary">{cadence}</p>
+        </div>
+        <div className="rounded-lg bg-bg-primary border border-border-dim p-3">
+          <p className="text-[10px] font-mono uppercase tracking-wider text-text-tertiary mb-1">Terms</p>
+          <p className="text-sm font-semibold text-text-primary">Net {account.terms_days}</p>
+        </div>
+        <div className="rounded-lg bg-bg-primary border border-border-dim p-3">
+          <p className="text-[10px] font-mono uppercase tracking-wider text-text-tertiary mb-1">Period Usage</p>
+          <p className="text-sm font-mono font-semibold text-text-primary">${periodUsageUsd.toFixed(2)}</p>
+        </div>
+        <div className="rounded-lg bg-bg-primary border border-border-dim p-3">
+          <p className="text-[10px] font-mono uppercase tracking-wider text-text-tertiary mb-1">Remaining</p>
+          <p className="text-sm font-mono font-semibold text-text-primary">
+            ${remainingUsd.toFixed(2)} / ${limitUsd.toFixed(2)}
+          </p>
+        </div>
+      </div>
+      <div className="flex flex-wrap items-center gap-3 text-xs text-text-tertiary font-mono">
+        <span>Next invoice {new Date(account.next_invoice_at).toLocaleDateString()}</span>
+        <span>{account.billing_email}</span>
+      </div>
+      {(enterprise.recent_invoices?.length ?? 0) > 0 && (
+        <div className="mt-4 border-t border-border-subtle pt-4 space-y-2">
+          {enterprise.recent_invoices!.slice(0, 3).map((invoice) => (
+            <div key={invoice.id} className="flex items-center justify-between gap-3 text-xs">
+              <span className="font-mono text-text-secondary">
+                ${(invoice.amount_micro_usd / 1_000_000).toFixed(2)} · {invoice.status}
+              </span>
+              {invoice.stripe_hosted_invoice_url && (
+                <a
+                  href={invoice.stripe_hosted_invoice_url}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="font-semibold text-coral hover:underline"
+                >
+                  View invoice
+                </a>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/console-ui/src/lib/api.ts
+++ b/console-ui/src/lib/api.ts
@@ -141,6 +141,49 @@ export async function fetchUsage(): Promise<UsageEntry[]> {
   return data.usage || data;
 }
 
+export interface EnterpriseAccount {
+  account_id: string;
+  status: "active" | "disabled";
+  billing_email: string;
+  stripe_customer_id?: string;
+  cadence: "weekly" | "biweekly" | "monthly";
+  terms_days: number;
+  credit_limit_micro_usd: number;
+  accrued_micro_usd: number;
+  reserved_micro_usd: number;
+  open_invoice_micro_usd: number;
+  rounding_carry_micro_usd?: number;
+  current_period_start: string;
+  next_invoice_at: string;
+}
+
+export interface EnterpriseInvoice {
+  id: string;
+  status: string;
+  amount_micro_usd: number;
+  amount_cents: number;
+  terms_days: number;
+  period_start: string;
+  period_end: string;
+  due_at?: string;
+  paid_at?: string;
+  stripe_hosted_invoice_url?: string;
+  stripe_invoice_pdf?: string;
+}
+
+export interface EnterpriseStatusResponse {
+  enabled: boolean;
+  account?: EnterpriseAccount;
+  recent_invoices?: EnterpriseInvoice[];
+  credit_remaining_micro_usd?: number;
+}
+
+export async function fetchEnterpriseStatus(): Promise<EnterpriseStatusResponse> {
+  const res = await fetch("/api/payments/enterprise/status", { headers: proxyHeaders() });
+  if (!res.ok) throw new Error(`Failed to fetch enterprise status: ${res.status}`);
+  return res.json();
+}
+
 export interface StripeCheckoutResponse {
   url: string;
   session_id: string;

--- a/coordinator/cmd/coordinator/main.go
+++ b/coordinator/cmd/coordinator/main.go
@@ -487,6 +487,12 @@ func main() {
 	// Start background eviction of stale providers.
 	reg.StartEvictionLoop(ctx, 90*time.Second)
 
+	// Generate due Enterprise invoices in the background when Stripe is
+	// configured. Manual admin runs use the same code path.
+	saferun.Go(logger, "enterprise_invoice_runner", func() {
+		srv.StartEnterpriseInvoiceLoop(ctx, time.Hour)
+	})
+
 	// Push gauge values to DogStatsD periodically.
 	go srv.StartDDGaugeLoop(ctx)
 

--- a/coordinator/internal/api/billing_handlers.go
+++ b/coordinator/internal/api/billing_handlers.go
@@ -133,6 +133,11 @@ func (s *Server) handleStripeWebhook(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if strings.HasPrefix(event.Type, "invoice.") {
+		s.handleStripeInvoiceWebhook(w, event)
+		return
+	}
+
 	if event.Type != "checkout.session.completed" {
 		w.WriteHeader(http.StatusOK)
 		return
@@ -183,6 +188,57 @@ func (s *Server) handleStripeWebhook(w http.ResponseWriter, r *http.Request) {
 		"consumer_key", consumerKey[:min(8, len(consumerKey))]+"...",
 		"amount_micro_usd", amountMicroUSD,
 	)
+	w.WriteHeader(http.StatusOK)
+}
+
+func (s *Server) handleStripeInvoiceWebhook(w http.ResponseWriter, event *billing.WebhookEvent) {
+	invEvent, err := s.billing.Stripe().ParseInvoice(event)
+	if err != nil {
+		s.logger.Error("stripe: parse invoice webhook failed", "error", err)
+		http.Error(w, "invalid event data", http.StatusBadRequest)
+		return
+	}
+	local, err := s.billing.Store().GetEnterpriseInvoiceByStripeID(invEvent.Object.ID)
+	if err != nil {
+		s.logger.Debug("stripe: invoice webhook for unknown invoice", "stripe_invoice_id", invEvent.Object.ID, "event", event.Type)
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+	local.StripeHostedInvoiceURL = invEvent.Object.HostedInvoiceURL
+	local.StripeInvoicePDF = invEvent.Object.InvoicePDF
+	if invEvent.Object.DueDate > 0 {
+		t := time.Unix(invEvent.Object.DueDate, 0)
+		local.DueAt = &t
+	}
+	if invEvent.Object.StatusTransitions.FinalizedAt > 0 {
+		t := time.Unix(invEvent.Object.StatusTransitions.FinalizedAt, 0)
+		local.SentAt = &t
+	}
+	switch event.Type {
+	case "invoice.paid", "invoice.payment_succeeded":
+		local.Status = store.EnterpriseInvoiceStatusPaid
+		if invEvent.Object.StatusTransitions.PaidAt > 0 {
+			t := time.Unix(invEvent.Object.StatusTransitions.PaidAt, 0)
+			local.PaidAt = &t
+		} else {
+			t := time.Now()
+			local.PaidAt = &t
+		}
+	case "invoice.voided":
+		local.Status = store.EnterpriseInvoiceStatusVoid
+	case "invoice.marked_uncollectible":
+		local.Status = store.EnterpriseInvoiceStatusUncollectible
+	case "invoice.finalized", "invoice.sent":
+		local.Status = store.EnterpriseInvoiceStatusOpen
+	default:
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+	if err := s.billing.Store().UpdateEnterpriseInvoice(local); err != nil {
+		s.logger.Error("stripe: update enterprise invoice failed", "error", err, "stripe_invoice_id", invEvent.Object.ID)
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
 	w.WriteHeader(http.StatusOK)
 }
 

--- a/coordinator/internal/api/consumer.go
+++ b/coordinator/internal/api/consumer.go
@@ -87,6 +87,51 @@ func (s *Server) sendProviderCancel(provider *registry.Provider, requestID strin
 	}
 }
 
+func enterpriseBillingReservationID(pr *registry.PendingRequest) string {
+	if pr.BillingReservationID != "" {
+		return pr.BillingReservationID
+	}
+	return pr.RequestID
+}
+
+func (s *Server) releaseEnterpriseReservation(pr *registry.PendingRequest, reason string) {
+	if pr == nil || !pr.EnterpriseBilling || pr.ReservedMicroUSD <= 0 {
+		return
+	}
+	if err := s.store.ReleaseEnterpriseReservation(pr.ConsumerKey, enterpriseBillingReservationID(pr)); err != nil {
+		s.logger.Warn("enterprise billing release failed",
+			"consumer_key", pr.ConsumerKey,
+			"request_id", pr.RequestID,
+			"reservation_id", enterpriseBillingReservationID(pr),
+			"reason", reason,
+			"error", err,
+		)
+	}
+}
+
+func (s *Server) finalizeEnterpriseReservationEstimate(pr *registry.PendingRequest, reason string) {
+	if pr == nil || !pr.EnterpriseBilling || pr.ReservedMicroUSD <= 0 {
+		return
+	}
+	if err := s.store.FinalizeEnterpriseUsage(pr.ConsumerKey, enterpriseBillingReservationID(pr), pr.ReservedMicroUSD); err != nil {
+		s.logger.Warn("enterprise billing estimated finalize failed",
+			"consumer_key", pr.ConsumerKey,
+			"request_id", pr.RequestID,
+			"reservation_id", enterpriseBillingReservationID(pr),
+			"reason", reason,
+			"reserved_micro_usd", pr.ReservedMicroUSD,
+			"error", err,
+		)
+	}
+}
+
+func streamChunkHasBillableText(chunk string) bool {
+	if strings.Contains(chunk, `"content":""`) || strings.Contains(chunk, `"delta":""`) {
+		return false
+	}
+	return strings.Contains(chunk, `"content":"`) || strings.Contains(chunk, `"delta":"`)
+}
+
 func intFromRequestValue(v any) (int, bool) {
 	switch x := v.(type) {
 	case int:
@@ -589,10 +634,24 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 	// refunds any unused portion. Reserving only the minimum charge let
 	// consumers receive streamed output far exceeding their actual balance.
 	var reservedMicroUSD int64
+	var enterpriseBilling bool
+	var billingReservationID string
 	if s.billing != nil {
 		consumerKey := consumerKeyFromContext(r.Context())
 		reservedMicroUSD = s.reservationCost(model, estimatedPromptTokens, requestedMaxTokens)
-		if err := s.ledger.Charge(consumerKey, reservedMicroUSD, "reserve:"+consumerKey); err != nil {
+		if account, err := s.store.GetEnterpriseAccount(consumerKey); err == nil && account.Status == store.EnterpriseStatusActive {
+			billingReservationID = uuid.New().String()
+			if err := s.store.ReserveEnterpriseUsage(consumerKey, billingReservationID, reservedMicroUSD); err != nil {
+				writeJSON(w, http.StatusPaymentRequired, errorResponse("enterprise_credit_limit",
+					"this Enterprise account has reached its postpaid credit limit"))
+				return
+			}
+			enterpriseBilling = true
+		} else if err != nil && !errors.Is(err, store.ErrEnterpriseAccountNotFound) {
+			s.logger.Error("enterprise billing lookup failed", "consumer_key", consumerKey, "error", err)
+			writeJSON(w, http.StatusInternalServerError, errorResponse("billing_error", "failed to check Enterprise billing status"))
+			return
+		} else if err := s.ledger.Charge(consumerKey, reservedMicroUSD, "reserve:"+consumerKey); err != nil {
 			writeJSON(w, http.StatusPaymentRequired, errorResponse("insufficient_funds",
 				"your balance is too low for this request — add funds at /billing or lower max_tokens"))
 			return
@@ -603,7 +662,11 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 	refundReservation := func() {
 		if reservedMicroUSD > 0 {
 			consumerKey := consumerKeyFromContext(r.Context())
-			_ = s.store.Credit(consumerKey, reservedMicroUSD, store.LedgerRefund, "reservation_refund")
+			if enterpriseBilling {
+				_ = s.store.ReleaseEnterpriseReservation(consumerKey, billingReservationID)
+			} else {
+				_ = s.store.Credit(consumerKey, reservedMicroUSD, store.LedgerRefund, "reservation_refund")
+			}
 		}
 	}
 
@@ -657,6 +720,9 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 			CompleteCh:             make(chan protocol.UsageInfo, 1),
 			ErrorCh:                make(chan protocol.InferenceErrorMessage, 1),
 		}
+		pr.ReservedMicroUSD = reservedMicroUSD
+		pr.EnterpriseBilling = enterpriseBilling
+		pr.BillingReservationID = billingReservationID
 
 		var decision registry.RoutingDecision
 		provider, decision = s.registry.ReserveProviderEx(model, pr, excludeList()...)
@@ -757,7 +823,6 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 		}
 
 		pr.SessionPrivKey = &sessionKeys.PrivateKey
-		pr.ReservedMicroUSD = reservedMicroUSD
 
 		data, err := json.Marshal(wireMsg)
 		if err != nil {
@@ -1122,6 +1187,7 @@ func (s *Server) handleStreamingResponseWithFirstChunk(w http.ResponseWriter, r 
 	// Detect Responses API format to skip appending chat-completions-style
 	// termination events (SE signature chunk + [DONE]).
 	sawResponsesAPI := false
+	wroteProviderChunk := false
 
 	// Write the first chunk that was already consumed during dispatch.
 	if firstChunk != "" {
@@ -1131,8 +1197,9 @@ func (s *Server) handleStreamingResponseWithFirstChunk(w http.ResponseWriter, r 
 		if !sawResponsesAPI {
 			firstChunk = normalizeSSEChunk(firstChunk)
 		}
-		fmt.Fprintf(w, "%s\n\n", firstChunk)
+		_, _ = fmt.Fprintf(w, "%s\n\n", firstChunk)
 		flusher.Flush()
+		wroteProviderChunk = streamChunkHasBillableText(firstChunk)
 	}
 
 	// Use a timer that resets on each chunk so long-running generations
@@ -1149,6 +1216,26 @@ func (s *Server) handleStreamingResponseWithFirstChunk(w http.ResponseWriter, r 
 				// "response.completed" as the terminal event. Adding
 				// extra chunks would break SDK parsers.
 				if !sawResponsesAPI {
+					select {
+					case errMsg, ok := <-pr.ErrorCh:
+						if ok {
+							errData, _ := json.Marshal(map[string]any{
+								"error": map[string]any{
+									"message": errMsg.Error,
+									"type":    "provider_error",
+								},
+							})
+							fmt.Fprintf(w, "data: %s\n\n", errData)
+							flusher.Flush()
+							if wroteProviderChunk {
+								s.finalizeEnterpriseReservationEstimate(pr, "stream_provider_error_after_output")
+							} else {
+								s.releaseEnterpriseReservation(pr, "stream_provider_error_before_output")
+							}
+							return
+						}
+					default:
+					}
 					// Chat completions format: append SE signature + [DONE].
 					if pr.SESignature != "" {
 						sigEvent, _ := json.Marshal(map[string]any{
@@ -1172,8 +1259,9 @@ func (s *Server) handleStreamingResponseWithFirstChunk(w http.ResponseWriter, r 
 			if !sawResponsesAPI {
 				chunk = normalizeSSEChunk(chunk)
 			}
-			fmt.Fprintf(w, "%s\n\n", chunk)
+			_, _ = fmt.Fprintf(w, "%s\n\n", chunk)
 			flusher.Flush()
+			wroteProviderChunk = wroteProviderChunk || streamChunkHasBillableText(chunk)
 
 			if !timer.Stop() {
 				select {
@@ -1192,14 +1280,29 @@ func (s *Server) handleStreamingResponseWithFirstChunk(w http.ResponseWriter, r 
 			})
 			fmt.Fprintf(w, "data: %s\n\n", errData)
 			flusher.Flush()
+			if wroteProviderChunk {
+				s.finalizeEnterpriseReservationEstimate(pr, "stream_provider_error_after_output")
+			} else {
+				s.releaseEnterpriseReservation(pr, "stream_provider_error_before_output")
+			}
 			return
 
 		case <-timer.C:
 			fmt.Fprintf(w, "data: {\"error\":{\"message\":\"request timed out\",\"type\":\"timeout\"}}\n\n")
 			flusher.Flush()
+			if wroteProviderChunk {
+				s.finalizeEnterpriseReservationEstimate(pr, "stream_timeout_after_output")
+			} else {
+				s.releaseEnterpriseReservation(pr, "stream_timeout_before_output")
+			}
 			return
 
 		case <-r.Context().Done():
+			if wroteProviderChunk {
+				s.finalizeEnterpriseReservationEstimate(pr, "stream_context_done_after_output")
+			} else {
+				s.releaseEnterpriseReservation(pr, "stream_context_done_before_output")
+			}
 			return
 		}
 	}
@@ -1240,8 +1343,10 @@ func (s *Server) handleResponsesStreamingResponseWithFirstChunk(w http.ResponseW
 	})
 
 	chunks := make([]string, 0, 16)
+	wroteProviderChunk := false
 	if firstChunk != "" {
 		chunks = append(chunks, firstChunk)
+		wroteProviderChunk = streamChunkHasBillableText(firstChunk)
 	}
 
 	timer := time.NewTimer(inferenceTimeout)
@@ -1253,6 +1358,25 @@ func (s *Server) handleResponsesStreamingResponseWithFirstChunk(w http.ResponseW
 			if !ok {
 				var usage protocol.UsageInfo
 				select {
+				case errMsg, ok := <-pr.ErrorCh:
+					if ok {
+						writeResponsesSSE(w, flusher, map[string]any{
+							"type":            "error",
+							"sequence_number": 0,
+							"error": map[string]any{
+								"type":    "provider_error",
+								"code":    "provider_error",
+								"message": errMsg.Error,
+								"param":   nil,
+							},
+						})
+						if wroteProviderChunk {
+							s.finalizeEnterpriseReservationEstimate(pr, "responses_stream_provider_error_after_output")
+						} else {
+							s.releaseEnterpriseReservation(pr, "responses_stream_provider_error_before_output")
+						}
+						return
+					}
 				case u, ok := <-pr.CompleteCh:
 					if ok {
 						usage = u
@@ -1264,6 +1388,7 @@ func (s *Server) handleResponsesStreamingResponseWithFirstChunk(w http.ResponseW
 				return
 			}
 			chunks = append(chunks, chunk)
+			wroteProviderChunk = wroteProviderChunk || streamChunkHasBillableText(chunk)
 			if !timer.Stop() {
 				select {
 				case <-timer.C:
@@ -1283,6 +1408,11 @@ func (s *Server) handleResponsesStreamingResponseWithFirstChunk(w http.ResponseW
 					"param":   nil,
 				},
 			})
+			if wroteProviderChunk {
+				s.finalizeEnterpriseReservationEstimate(pr, "responses_stream_provider_error_after_output")
+			} else {
+				s.releaseEnterpriseReservation(pr, "responses_stream_provider_error_before_output")
+			}
 			return
 
 		case <-timer.C:
@@ -1296,9 +1426,19 @@ func (s *Server) handleResponsesStreamingResponseWithFirstChunk(w http.ResponseW
 					"param":   nil,
 				},
 			})
+			if wroteProviderChunk {
+				s.finalizeEnterpriseReservationEstimate(pr, "responses_stream_timeout_after_output")
+			} else {
+				s.releaseEnterpriseReservation(pr, "responses_stream_timeout_before_output")
+			}
 			return
 
 		case <-r.Context().Done():
+			if wroteProviderChunk {
+				s.finalizeEnterpriseReservationEstimate(pr, "responses_stream_context_done_after_output")
+			} else {
+				s.releaseEnterpriseReservation(pr, "responses_stream_context_done_before_output")
+			}
 			return
 		}
 	}
@@ -1457,6 +1597,19 @@ func (s *Server) handleNonStreamingResponseWithFirstChunk(w http.ResponseWriter,
 		select {
 		case chunk, ok := <-pr.ChunkCh:
 			if !ok {
+				select {
+				case errMsg, ok := <-pr.ErrorCh:
+					if ok {
+						statusCode := errMsg.StatusCode
+						if statusCode == 0 {
+							statusCode = http.StatusBadGateway
+						}
+						s.releaseEnterpriseReservation(pr, "nonstream_provider_error")
+						writeJSON(w, statusCode, errorResponse("provider_error", errMsg.Error))
+						return
+					}
+				default:
+				}
 				// The provider forwards the raw backend response as a single
 				// chunk. Detect complete responses (object=chat.completion
 				// or object=response) and pass through directly — this is
@@ -1473,6 +1626,11 @@ func (s *Server) handleNonStreamingResponseWithFirstChunk(w http.ResponseWriter,
 							select {
 							case <-pr.CompleteCh:
 							case <-ctx.Done():
+								s.releaseEnterpriseReservation(pr, "nonstream_timeout_waiting_complete")
+							}
+							if ctx.Err() != nil {
+								writeJSON(w, http.StatusGatewayTimeout, errorResponse("timeout", "timed out waiting for usage info"))
+								return
 							}
 							if objType == "chat.completion" {
 								normalizeCompleteChatResponse(obj, pr.Model)
@@ -1504,6 +1662,7 @@ func (s *Server) handleNonStreamingResponseWithFirstChunk(w http.ResponseWriter,
 					}
 					writeJSON(w, http.StatusOK, resp)
 				case <-ctx.Done():
+					s.releaseEnterpriseReservation(pr, "nonstream_timeout_waiting_usage")
 					writeJSON(w, http.StatusGatewayTimeout, errorResponse("timeout", "timed out waiting for usage info"))
 				}
 				return
@@ -1515,10 +1674,12 @@ func (s *Server) handleNonStreamingResponseWithFirstChunk(w http.ResponseWriter,
 			if statusCode == 0 {
 				statusCode = http.StatusBadGateway
 			}
+			s.releaseEnterpriseReservation(pr, "nonstream_provider_error")
 			writeJSON(w, statusCode, errorResponse("provider_error", errMsg.Error))
 			return
 
 		case <-ctx.Done():
+			s.releaseEnterpriseReservation(pr, "nonstream_timeout")
 			writeJSON(w, http.StatusGatewayTimeout, errorResponse("timeout", "request timed out"))
 			return
 		}
@@ -2401,10 +2562,23 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 	// paths routed without ANY reservation; the silent post-inference charge
 	// meant a consumer could receive full responses with a zero balance.
 	consumerKey := consumerKeyFromContext(r.Context())
+	requestID := uuid.New().String()
 	var reservedMicroUSD int64
+	var enterpriseBilling bool
 	if s.billing != nil {
 		reservedMicroUSD = s.reservationCost(model, estimatedPromptTokens, requestedMaxTokens)
-		if err := s.ledger.Charge(consumerKey, reservedMicroUSD, "reserve:"+consumerKey); err != nil {
+		if account, err := s.store.GetEnterpriseAccount(consumerKey); err == nil && account.Status == store.EnterpriseStatusActive {
+			if err := s.store.ReserveEnterpriseUsage(consumerKey, requestID, reservedMicroUSD); err != nil {
+				writeJSON(w, http.StatusPaymentRequired, errorResponse("enterprise_credit_limit",
+					"this Enterprise account has reached its postpaid credit limit"))
+				return
+			}
+			enterpriseBilling = true
+		} else if err != nil && !errors.Is(err, store.ErrEnterpriseAccountNotFound) {
+			s.logger.Error("enterprise billing lookup failed", "consumer_key", consumerKey, "error", err)
+			writeJSON(w, http.StatusInternalServerError, errorResponse("billing_error", "failed to check Enterprise billing status"))
+			return
+		} else if err := s.ledger.Charge(consumerKey, reservedMicroUSD, "reserve:"+consumerKey); err != nil {
 			writeJSON(w, http.StatusPaymentRequired, errorResponse("insufficient_funds",
 				"your balance is too low for this request — add funds at /billing or lower max_tokens"))
 			return
@@ -2413,11 +2587,14 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 	// Refund the reservation on any early failure before dispatch.
 	refundReservation := func() {
 		if reservedMicroUSD > 0 {
-			_ = s.store.Credit(consumerKey, reservedMicroUSD, store.LedgerRefund, "reservation_refund")
+			if enterpriseBilling {
+				_ = s.store.ReleaseEnterpriseReservation(consumerKey, requestID)
+			} else {
+				_ = s.store.Credit(consumerKey, reservedMicroUSD, store.LedgerRefund, "reservation_refund")
+			}
 		}
 	}
 
-	requestID := uuid.New().String()
 	pr := &registry.PendingRequest{
 		RequestID:              requestID,
 		Model:                  model,
@@ -2426,6 +2603,8 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 		EstimatedPromptTokens:  estimatedPromptTokens,
 		RequestedMaxTokens:     requestedMaxTokens,
 		ReservedMicroUSD:       reservedMicroUSD,
+		EnterpriseBilling:      enterpriseBilling,
+		BillingReservationID:   requestID,
 		ChunkCh:                make(chan string, chunkBufferSize),
 		CompleteCh:             make(chan protocol.UsageInfo, 1),
 		ErrorCh:                make(chan protocol.InferenceErrorMessage, 1),

--- a/coordinator/internal/api/enterprise_billing.go
+++ b/coordinator/internal/api/enterprise_billing.go
@@ -1,0 +1,410 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/eigeninference/coordinator/internal/billing"
+	"github.com/eigeninference/coordinator/internal/store"
+	"github.com/google/uuid"
+)
+
+func (s *Server) StartEnterpriseInvoiceLoop(ctx context.Context, interval time.Duration) {
+	if interval <= 0 {
+		interval = time.Hour
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if s.billing == nil || s.billing.Stripe() == nil {
+				continue
+			}
+			accounts, err := s.store.ListDueEnterpriseAccounts(time.Now())
+			if err != nil {
+				s.logger.Error("enterprise invoice loop: list due failed", "error", err)
+				continue
+			}
+			for _, result := range s.runEnterpriseInvoices(accounts, time.Now()) {
+				if result.Error != "" {
+					s.logger.Error("enterprise invoice loop: invoice failed", "account_id", result.AccountID, "error", result.Error)
+				}
+			}
+		}
+	}
+}
+
+type enterpriseAccountRequest struct {
+	AccountID           string     `json:"account_id"`
+	Status              *string    `json:"status"`
+	BillingEmail        string     `json:"billing_email"`
+	StripeCustomerID    string     `json:"stripe_customer_id"`
+	Cadence             *string    `json:"cadence"`
+	TermsDays           *int       `json:"terms_days"`
+	CreditLimitMicroUSD *int64     `json:"credit_limit_micro_usd"`
+	CurrentPeriodStart  *time.Time `json:"current_period_start"`
+	NextInvoiceAt       *time.Time `json:"next_invoice_at"`
+}
+
+func (s *Server) handleAdminUpsertEnterpriseAccount(w http.ResponseWriter, r *http.Request) {
+	if !s.requireAdminKey(w, r) {
+		return
+	}
+
+	var req enterpriseAccountRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, errorResponse("invalid_request_error", "invalid JSON: "+err.Error()))
+		return
+	}
+	account, err := s.enterpriseAccountFromRequest(req)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, errorResponse("invalid_request_error", err.Error()))
+		return
+	}
+	if existing, err := s.store.GetEnterpriseAccount(account.AccountID); err == nil {
+		if req.Status == nil {
+			account.Status = existing.Status
+		}
+		if req.Cadence == nil {
+			account.Cadence = existing.Cadence
+		}
+		if req.CreditLimitMicroUSD == nil {
+			account.CreditLimitMicroUSD = existing.CreditLimitMicroUSD
+		}
+		if strings.TrimSpace(req.StripeCustomerID) == "" {
+			account.StripeCustomerID = existing.StripeCustomerID
+		}
+		account.AccruedMicroUSD = existing.AccruedMicroUSD
+		account.ReservedMicroUSD = existing.ReservedMicroUSD
+		account.OpenInvoiceMicroUSD = existing.OpenInvoiceMicroUSD
+		account.RoundingCarryMicroUSD = existing.RoundingCarryMicroUSD
+		account.CreatedAt = existing.CreatedAt
+		if req.TermsDays == nil {
+			account.TermsDays = existing.TermsDays
+		}
+		if req.CurrentPeriodStart == nil {
+			account.CurrentPeriodStart = existing.CurrentPeriodStart
+		}
+		if req.NextInvoiceAt == nil {
+			account.NextInvoiceAt = existing.NextInvoiceAt
+		}
+	}
+	if err := s.store.UpsertEnterpriseAccount(account); err != nil {
+		s.logger.Error("enterprise: upsert account failed", "error", err)
+		writeJSON(w, http.StatusInternalServerError, errorResponse("internal_error", "failed to save enterprise account"))
+		return
+	}
+	saved, _ := s.store.GetEnterpriseAccount(account.AccountID)
+	writeJSON(w, http.StatusOK, map[string]any{"account": saved})
+}
+
+func (s *Server) enterpriseAccountFromRequest(req enterpriseAccountRequest) (*store.EnterpriseAccount, error) {
+	if strings.TrimSpace(req.AccountID) == "" {
+		return nil, fmt.Errorf("account_id is required")
+	}
+	status := ""
+	if req.Status != nil {
+		status = *req.Status
+	}
+	if status == "" {
+		status = store.EnterpriseStatusActive
+	}
+	if status != store.EnterpriseStatusActive && status != store.EnterpriseStatusDisabled {
+		return nil, fmt.Errorf("status must be active or disabled")
+	}
+	if strings.TrimSpace(req.BillingEmail) == "" {
+		return nil, fmt.Errorf("billing_email is required")
+	}
+	cadence := ""
+	if req.Cadence != nil {
+		cadence = *req.Cadence
+	}
+	if cadence == "" {
+		cadence = store.EnterpriseCadenceMonthly
+	}
+	if cadence != store.EnterpriseCadenceWeekly && cadence != store.EnterpriseCadenceBiweekly && cadence != store.EnterpriseCadenceMonthly {
+		return nil, fmt.Errorf("cadence must be weekly, biweekly, or monthly")
+	}
+	termsDays := 15
+	if req.TermsDays != nil {
+		termsDays = *req.TermsDays
+	}
+	if termsDays < 0 || termsDays > 90 {
+		return nil, fmt.Errorf("terms_days must be between 0 and 90")
+	}
+	creditLimitMicroUSD := int64(0)
+	if req.CreditLimitMicroUSD != nil {
+		creditLimitMicroUSD = *req.CreditLimitMicroUSD
+	}
+	if creditLimitMicroUSD < 0 {
+		return nil, fmt.Errorf("credit_limit_micro_usd cannot be negative")
+	}
+	now := time.Now()
+	periodStart := now
+	if req.CurrentPeriodStart != nil && !req.CurrentPeriodStart.IsZero() {
+		periodStart = *req.CurrentPeriodStart
+	}
+	nextInvoiceAt := enterpriseNextInvoiceAt(periodStart, cadence)
+	if req.NextInvoiceAt != nil && !req.NextInvoiceAt.IsZero() {
+		nextInvoiceAt = *req.NextInvoiceAt
+	}
+	return &store.EnterpriseAccount{
+		AccountID:           strings.TrimSpace(req.AccountID),
+		Status:              status,
+		BillingEmail:        strings.TrimSpace(req.BillingEmail),
+		StripeCustomerID:    strings.TrimSpace(req.StripeCustomerID),
+		Cadence:             cadence,
+		TermsDays:           termsDays,
+		CreditLimitMicroUSD: creditLimitMicroUSD,
+		CurrentPeriodStart:  periodStart,
+		NextInvoiceAt:       nextInvoiceAt,
+	}, nil
+}
+
+func enterpriseNextInvoiceAt(start time.Time, cadence string) time.Time {
+	switch cadence {
+	case store.EnterpriseCadenceWeekly:
+		return start.AddDate(0, 0, 7)
+	case store.EnterpriseCadenceBiweekly:
+		return start.AddDate(0, 0, 14)
+	default:
+		return start.AddDate(0, 1, 0)
+	}
+}
+
+func (s *Server) handleAdminListEnterpriseAccounts(w http.ResponseWriter, r *http.Request) {
+	if !s.requireAdminKey(w, r) {
+		return
+	}
+	accounts, err := s.store.ListEnterpriseAccounts()
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, errorResponse("internal_error", "failed to list enterprise accounts"))
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"accounts": accounts})
+}
+
+func (s *Server) handleEnterpriseStatus(w http.ResponseWriter, r *http.Request) {
+	accountID := s.resolveAccountID(r)
+	account, err := s.store.GetEnterpriseAccount(accountID)
+	if err != nil {
+		writeJSON(w, http.StatusOK, map[string]any{"enabled": false})
+		return
+	}
+	invoices, _ := s.store.ListEnterpriseInvoices(accountID, 10)
+	remaining := account.CreditLimitMicroUSD - account.OpenInvoiceMicroUSD - account.AccruedMicroUSD - account.ReservedMicroUSD - account.RoundingCarryMicroUSD
+	if remaining < 0 {
+		remaining = 0
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"enabled":                    account.Status == store.EnterpriseStatusActive,
+		"account":                    account,
+		"recent_invoices":            invoices,
+		"credit_remaining_micro_usd": remaining,
+	})
+}
+
+func (s *Server) handleAdminRunEnterpriseInvoices(w http.ResponseWriter, r *http.Request) {
+	if !s.requireAdminKey(w, r) {
+		return
+	}
+	if s.billing == nil || s.billing.Stripe() == nil {
+		writeJSON(w, http.StatusServiceUnavailable, errorResponse("billing_error", "Stripe payments not configured"))
+		return
+	}
+	var req struct {
+		AccountID string `json:"account_id,omitempty"`
+		Now       string `json:"now,omitempty"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil && !errors.Is(err, io.EOF) {
+		writeJSON(w, http.StatusBadRequest, errorResponse("invalid_request_error", "invalid JSON: "+err.Error()))
+		return
+	}
+	now := time.Now()
+	if req.Now != "" {
+		if parsed, err := time.Parse(time.RFC3339, req.Now); err == nil {
+			now = parsed
+		}
+	}
+	var accounts []store.EnterpriseAccount
+	if req.AccountID != "" {
+		account, err := s.store.GetEnterpriseAccount(req.AccountID)
+		if err != nil {
+			writeJSON(w, http.StatusNotFound, errorResponse("not_found", "enterprise account not found"))
+			return
+		}
+		accounts = []store.EnterpriseAccount{*account}
+	} else {
+		var err error
+		accounts, err = s.store.ListDueEnterpriseAccounts(now)
+		if err != nil {
+			writeJSON(w, http.StatusInternalServerError, errorResponse("internal_error", "failed to list due accounts"))
+			return
+		}
+	}
+	results := s.runEnterpriseInvoices(accounts, now)
+	writeJSON(w, http.StatusOK, map[string]any{"results": results})
+}
+
+type enterpriseInvoiceRunResult struct {
+	AccountID string `json:"account_id"`
+	Skipped   bool   `json:"skipped,omitempty"`
+	Reason    string `json:"reason,omitempty"`
+	InvoiceID string `json:"invoice_id,omitempty"`
+	Error     string `json:"error,omitempty"`
+}
+
+func (s *Server) runEnterpriseInvoices(accounts []store.EnterpriseAccount, now time.Time) []enterpriseInvoiceRunResult {
+	results := make([]enterpriseInvoiceRunResult, 0, len(accounts))
+	for _, account := range accounts {
+		result := enterpriseInvoiceRunResult{AccountID: account.AccountID}
+		if account.Status != store.EnterpriseStatusActive {
+			result.Skipped = true
+			result.Reason = "account_not_active"
+			results = append(results, result)
+			continue
+		}
+		if account.NextInvoiceAt.After(now) {
+			result.Skipped = true
+			result.Reason = "not_due"
+			results = append(results, result)
+			continue
+		}
+		totalMicro := account.AccruedMicroUSD + account.RoundingCarryMicroUSD
+		amountCents := totalMicro / 10_000
+		if amountCents <= 0 {
+			if err := s.store.AdvanceEnterpriseInvoicePeriod(account.AccountID, account.NextInvoiceAt, enterpriseNextInvoiceAt(account.NextInvoiceAt, account.Cadence)); err != nil {
+				result.Error = err.Error()
+				results = append(results, result)
+				continue
+			}
+			result.Skipped = true
+			result.Reason = "below_cent"
+			results = append(results, result)
+			continue
+		}
+		inv, err := s.createEnterpriseInvoice(account, account.NextInvoiceAt, amountCents)
+		if err != nil {
+			result.Error = err.Error()
+		} else {
+			result.InvoiceID = inv.ID
+		}
+		results = append(results, result)
+	}
+	return results
+}
+
+func (s *Server) createEnterpriseInvoice(account store.EnterpriseAccount, periodEnd time.Time, amountCents int64) (*store.EnterpriseInvoice, error) {
+	stripeCustomerID := account.StripeCustomerID
+	if stripeCustomerID == "" {
+		customerKey := "enterprise-customer-" + enterpriseStableID(account.AccountID)
+		customer, err := s.billing.Stripe().CreateCustomerWithIdempotency(account.BillingEmail, account.AccountID, customerKey)
+		if err != nil {
+			return nil, err
+		}
+		stripeCustomerID = customer.ID
+		if err := s.store.SetEnterpriseStripeCustomerID(account.AccountID, stripeCustomerID); err != nil {
+			return nil, err
+		}
+	}
+
+	internalID := enterpriseInvoiceID(account.AccountID, account.CurrentPeriodStart, periodEnd)
+	billedMicro := amountCents * 10_000
+	draft := &store.EnterpriseInvoice{
+		ID:             internalID,
+		AccountID:      account.AccountID,
+		Status:         store.EnterpriseInvoiceStatusDraft,
+		PeriodStart:    account.CurrentPeriodStart,
+		PeriodEnd:      periodEnd,
+		AmountMicroUSD: billedMicro,
+		AmountCents:    amountCents,
+		TermsDays:      account.TermsDays,
+	}
+	if err := s.store.CreateEnterpriseInvoiceDraft(draft); err != nil {
+		return nil, err
+	}
+	desc := fmt.Sprintf("Darkbloom Enterprise usage %s - %s",
+		account.CurrentPeriodStart.Format("2006-01-02"), periodEnd.Format("2006-01-02"))
+	resp, err := s.billing.Stripe().CreateEnterpriseInvoice(billing.EnterpriseInvoiceRequest{
+		CustomerID:     stripeCustomerID,
+		AccountID:      account.AccountID,
+		AmountCents:    amountCents,
+		Currency:       "usd",
+		Description:    desc,
+		PeriodStart:    account.CurrentPeriodStart,
+		PeriodEnd:      periodEnd,
+		TermsDays:      account.TermsDays,
+		IdempotencyKey: "enterprise-invoice-" + internalID,
+		Metadata: map[string]string{
+			"enterprise_invoice_id": internalID,
+			"account_id":            account.AccountID,
+			"period_start":          account.CurrentPeriodStart.Format(time.RFC3339),
+			"period_end":            periodEnd.Format(time.RFC3339),
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+	if resp.AmountDueCents > 0 && resp.AmountDueCents != amountCents {
+		return nil, fmt.Errorf("stripe invoice amount_due=%d does not match local amount=%d", resp.AmountDueCents, amountCents)
+	}
+	invoice := &store.EnterpriseInvoice{
+		ID:                     internalID,
+		AccountID:              account.AccountID,
+		StripeInvoiceID:        resp.InvoiceID,
+		StripeHostedInvoiceURL: resp.HostedInvoiceURL,
+		StripeInvoicePDF:       resp.InvoicePDF,
+		Status:                 normalizeStripeInvoiceStatus(resp.Status),
+		PeriodStart:            account.CurrentPeriodStart,
+		PeriodEnd:              periodEnd,
+		AmountMicroUSD:         billedMicro,
+		AmountCents:            amountCents,
+		TermsDays:              account.TermsDays,
+		DueAt:                  resp.DueAt,
+		SentAt:                 resp.SentAt,
+	}
+	if err := s.store.CreateEnterpriseInvoice(invoice); err != nil {
+		if existing, lookupErr := s.store.GetEnterpriseInvoiceByStripeID(resp.InvoiceID); lookupErr == nil {
+			return existing, nil
+		}
+		return nil, err
+	}
+	return invoice, nil
+}
+
+func enterpriseInvoiceID(accountID string, periodStart, periodEnd time.Time) string {
+	key := fmt.Sprintf("%s:%s:%s",
+		accountID,
+		periodStart.UTC().Format(time.RFC3339Nano),
+		periodEnd.UTC().Format(time.RFC3339Nano),
+	)
+	return enterpriseStableID(key)
+}
+
+func enterpriseStableID(key string) string {
+	return uuid.NewSHA1(uuid.NameSpaceOID, []byte(key)).String()
+}
+
+func normalizeStripeInvoiceStatus(status string) string {
+	switch status {
+	case "paid":
+		return store.EnterpriseInvoiceStatusPaid
+	case "void":
+		return store.EnterpriseInvoiceStatusVoid
+	case "uncollectible":
+		return store.EnterpriseInvoiceStatusUncollectible
+	case "open":
+		return store.EnterpriseInvoiceStatusOpen
+	default:
+		return store.EnterpriseInvoiceStatusDraft
+	}
+}

--- a/coordinator/internal/api/enterprise_billing_test.go
+++ b/coordinator/internal/api/enterprise_billing_test.go
@@ -1,0 +1,424 @@
+package api
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/coordinator/internal/protocol"
+	"github.com/eigeninference/coordinator/internal/registry"
+	"github.com/eigeninference/coordinator/internal/store"
+)
+
+func enterpriseAdminRequest(method, path, body string) *http.Request {
+	req := httptest.NewRequest(method, path, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	return withPrivyUser(req, &store.User{
+		AccountID:   "acct-admin",
+		PrivyUserID: "did:privy:admin",
+		Email:       "admin@example.com",
+	})
+}
+
+func TestAdminEnterpriseAccountAllowsEditableTermsDays(t *testing.T) {
+	srv, st := testBillingServer(t)
+	srv.SetAdminEmails([]string{"admin@example.com"})
+
+	body := `{"account_id":"acct-ent","billing_email":"billing@example.com","cadence":"weekly","terms_days":0,"credit_limit_micro_usd":5000000}`
+	req := enterpriseAdminRequest(http.MethodPut, "/v1/admin/enterprise/account", body)
+	w := httptest.NewRecorder()
+	srv.handleAdminUpsertEnterpriseAccount(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d: %s", w.Code, w.Body.String())
+	}
+	account, err := st.GetEnterpriseAccount("acct-ent")
+	if err != nil {
+		t.Fatalf("GetEnterpriseAccount: %v", err)
+	}
+	if account.TermsDays != 0 {
+		t.Fatalf("terms_days = %d, want 0", account.TermsDays)
+	}
+
+	updateBody := `{"account_id":"acct-ent","billing_email":"new-billing@example.com","credit_limit_micro_usd":7000000}`
+	req = enterpriseAdminRequest(http.MethodPut, "/v1/admin/enterprise/account", updateBody)
+	w = httptest.NewRecorder()
+	srv.handleAdminUpsertEnterpriseAccount(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("update status = %d: %s", w.Code, w.Body.String())
+	}
+	account, err = st.GetEnterpriseAccount("acct-ent")
+	if err != nil {
+		t.Fatalf("GetEnterpriseAccount after update: %v", err)
+	}
+	if account.TermsDays != 0 {
+		t.Fatalf("terms_days after omitted update = %d, want preserved 0", account.TermsDays)
+	}
+	if account.Cadence != store.EnterpriseCadenceWeekly {
+		t.Fatalf("cadence after omitted update = %q, want preserved weekly", account.Cadence)
+	}
+}
+
+func TestAdminEnterpriseAccountAllowsAdminKey(t *testing.T) {
+	srv, st := testBillingServer(t)
+	srv.SetAdminKey("admin-secret")
+
+	body := `{"account_id":"acct-ent-key","billing_email":"billing@example.com","cadence":"monthly","terms_days":15,"credit_limit_micro_usd":5000000}`
+	req := httptest.NewRequest(http.MethodPut, "/v1/admin/enterprise/account", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer admin-secret")
+	w := httptest.NewRecorder()
+	srv.handleAdminUpsertEnterpriseAccount(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d: %s", w.Code, w.Body.String())
+	}
+	if _, err := st.GetEnterpriseAccount("acct-ent-key"); err != nil {
+		t.Fatalf("GetEnterpriseAccount: %v", err)
+	}
+}
+
+func TestAdminRunEnterpriseInvoicesCreatesStripeInvoice(t *testing.T) {
+	var invoiceForm url.Values
+	var customerIDKey string
+	fakeStripe := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		form, _ := url.ParseQuery(string(body))
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/v1/customers":
+			customerIDKey = r.Header.Get("Idempotency-Key")
+			_, _ = w.Write([]byte(`{"id":"cus_ent","email":"billing@example.com"}`))
+		case "/v1/invoiceitems":
+			_, _ = w.Write([]byte(`{"id":"ii_ent"}`))
+		case "/v1/invoices":
+			invoiceForm = form
+			_, _ = w.Write([]byte(`{"id":"in_ent","status":"draft","amount_due":250}`))
+		case "/v1/invoices/in_ent/finalize":
+			_, _ = w.Write([]byte(`{"id":"in_ent","status":"open","amount_due":250,"due_date":1893456000}`))
+		case "/v1/invoices/in_ent/send":
+			_, _ = w.Write([]byte(`{"id":"in_ent","status":"open","hosted_invoice_url":"https://invoice.test/in_ent","invoice_pdf":"https://invoice.test/in_ent.pdf","amount_due":250}`))
+		default:
+			http.Error(w, "unexpected path", http.StatusNotFound)
+		}
+	}))
+	defer fakeStripe.Close()
+
+	srv, st := stripePayoutsTestServer(t, false, fakeStripe)
+	srv.SetAdminEmails([]string{"admin@example.com"})
+	start := time.Now().Add(-8 * 24 * time.Hour).Truncate(time.Second)
+	if err := st.UpsertEnterpriseAccount(&store.EnterpriseAccount{
+		AccountID:           "acct-ent",
+		Status:              store.EnterpriseStatusActive,
+		BillingEmail:        "billing@example.com",
+		Cadence:             store.EnterpriseCadenceWeekly,
+		TermsDays:           15,
+		CreditLimitMicroUSD: 10_000_000,
+		AccruedMicroUSD:     2_500_000,
+		CurrentPeriodStart:  start,
+		NextInvoiceAt:       start,
+	}); err != nil {
+		t.Fatalf("UpsertEnterpriseAccount: %v", err)
+	}
+
+	req := enterpriseAdminRequest(http.MethodPost, "/v1/admin/enterprise/invoices/run", `{"account_id":"acct-ent"}`)
+	w := httptest.NewRecorder()
+	srv.handleAdminRunEnterpriseInvoices(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d: %s", w.Code, w.Body.String())
+	}
+	if got := invoiceForm.Get("collection_method"); got != "send_invoice" {
+		t.Fatalf("collection_method = %q, want send_invoice", got)
+	}
+	if got := invoiceForm.Get("days_until_due"); got != "15" {
+		t.Fatalf("days_until_due = %q, want 15", got)
+	}
+	if got := invoiceForm.Get("pending_invoice_items_behavior"); got != "include" {
+		t.Fatalf("pending_invoice_items_behavior = %q, want include", got)
+	}
+	if customerIDKey == "" {
+		t.Fatal("missing customer idempotency key")
+	}
+	invoices, err := st.ListEnterpriseInvoices("acct-ent", 10)
+	if err != nil {
+		t.Fatalf("ListEnterpriseInvoices: %v", err)
+	}
+	if len(invoices) != 1 {
+		t.Fatalf("invoice count = %d, want 1", len(invoices))
+	}
+	if invoices[0].StripeInvoiceID != "in_ent" || invoices[0].AmountCents != 250 {
+		t.Fatalf("invoice = %+v", invoices[0])
+	}
+	account, _ := st.GetEnterpriseAccount("acct-ent")
+	if account.OpenInvoiceMicroUSD != 2_500_000 || account.AccruedMicroUSD != 0 {
+		t.Fatalf("open/accrued = %d/%d, want 2500000/0", account.OpenInvoiceMicroUSD, account.AccruedMicroUSD)
+	}
+}
+
+func TestAdminRunEnterpriseInvoicesSkipsBelowCentWithoutMutatingAccrual(t *testing.T) {
+	fakeStripe := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatalf("Stripe should not be called for sub-cent Enterprise invoice run: %s", r.URL.Path)
+	}))
+	defer fakeStripe.Close()
+
+	srv, st := stripePayoutsTestServer(t, false, fakeStripe)
+	srv.SetAdminEmails([]string{"admin@example.com"})
+	start := time.Now().Add(-8 * 24 * time.Hour).Truncate(time.Second)
+	if err := st.UpsertEnterpriseAccount(&store.EnterpriseAccount{
+		AccountID:           "acct-subcent",
+		Status:              store.EnterpriseStatusActive,
+		BillingEmail:        "billing@example.com",
+		Cadence:             store.EnterpriseCadenceWeekly,
+		TermsDays:           15,
+		CreditLimitMicroUSD: 10_000_000,
+		AccruedMicroUSD:     9_999,
+		CurrentPeriodStart:  start,
+		NextInvoiceAt:       start,
+	}); err != nil {
+		t.Fatalf("UpsertEnterpriseAccount: %v", err)
+	}
+
+	req := enterpriseAdminRequest(http.MethodPost, "/v1/admin/enterprise/invoices/run", `{"account_id":"acct-subcent"}`)
+	w := httptest.NewRecorder()
+	srv.handleAdminRunEnterpriseInvoices(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d: %s", w.Code, w.Body.String())
+	}
+	account, _ := st.GetEnterpriseAccount("acct-subcent")
+	if account.AccruedMicroUSD != 9_999 || account.RoundingCarryMicroUSD != 0 || !account.NextInvoiceAt.Equal(start.AddDate(0, 0, 7)) {
+		t.Fatalf("account after sub-cent skip: accrued=%d carry=%d next=%s", account.AccruedMicroUSD, account.RoundingCarryMicroUSD, account.NextInvoiceAt)
+	}
+	invoices, _ := st.ListEnterpriseInvoices("acct-subcent", 10)
+	if len(invoices) != 0 {
+		t.Fatalf("invoice count = %d, want 0", len(invoices))
+	}
+}
+
+func TestAdminRunEnterpriseInvoicesRejectsMalformedJSON(t *testing.T) {
+	fakeStripe := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatalf("Stripe should not be called for malformed invoice run body: %s", r.URL.Path)
+	}))
+	defer fakeStripe.Close()
+
+	srv, st := stripePayoutsTestServer(t, false, fakeStripe)
+	srv.SetAdminEmails([]string{"admin@example.com"})
+	start := time.Now().Add(-8 * 24 * time.Hour).Truncate(time.Second)
+	if err := st.UpsertEnterpriseAccount(&store.EnterpriseAccount{
+		AccountID:           "acct-due",
+		Status:              store.EnterpriseStatusActive,
+		BillingEmail:        "billing@example.com",
+		Cadence:             store.EnterpriseCadenceWeekly,
+		TermsDays:           15,
+		CreditLimitMicroUSD: 10_000_000,
+		AccruedMicroUSD:     2_500_000,
+		CurrentPeriodStart:  start,
+		NextInvoiceAt:       start,
+	}); err != nil {
+		t.Fatalf("UpsertEnterpriseAccount: %v", err)
+	}
+
+	req := enterpriseAdminRequest(http.MethodPost, "/v1/admin/enterprise/invoices/run", `{"account_id":`)
+	w := httptest.NewRecorder()
+	srv.handleAdminRunEnterpriseInvoices(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d: %s", w.Code, w.Body.String())
+	}
+	invoices, _ := st.ListEnterpriseInvoices("acct-due", 10)
+	if len(invoices) != 0 {
+		t.Fatalf("invoice count = %d, want 0", len(invoices))
+	}
+}
+
+func TestCreateEnterpriseInvoiceUsesDeterministicIdempotency(t *testing.T) {
+	var invoiceCalls int
+	var idempotencyKeys []string
+	fakeStripe := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/v1/invoiceitems":
+			_, _ = w.Write([]byte(`{"id":"ii_ent"}`))
+		case "/v1/invoices":
+			invoiceCalls++
+			idempotencyKeys = append(idempotencyKeys, r.Header.Get("Idempotency-Key"))
+			_, _ = w.Write([]byte(`{"id":"in_same","status":"draft","amount_due":250}`))
+		case "/v1/invoices/in_same/finalize":
+			_, _ = w.Write([]byte(`{"id":"in_same","status":"open","amount_due":250}`))
+		case "/v1/invoices/in_same/send":
+			_, _ = w.Write([]byte(`{"id":"in_same","status":"open","hosted_invoice_url":"https://invoice.test/in_same","amount_due":250}`))
+		default:
+			http.Error(w, "unexpected path", http.StatusNotFound)
+		}
+	}))
+	defer fakeStripe.Close()
+
+	srv, st := stripePayoutsTestServer(t, false, fakeStripe)
+	start := time.Now().Add(-8 * 24 * time.Hour).Truncate(time.Second)
+	account := store.EnterpriseAccount{
+		AccountID:           "acct-idem",
+		Status:              store.EnterpriseStatusActive,
+		BillingEmail:        "billing@example.com",
+		StripeCustomerID:    "cus_existing",
+		Cadence:             store.EnterpriseCadenceWeekly,
+		TermsDays:           15,
+		CreditLimitMicroUSD: 10_000_000,
+		AccruedMicroUSD:     2_500_000,
+		CurrentPeriodStart:  start,
+		NextInvoiceAt:       start.AddDate(0, 0, 7),
+	}
+	if err := st.UpsertEnterpriseAccount(&account); err != nil {
+		t.Fatalf("UpsertEnterpriseAccount: %v", err)
+	}
+
+	first, err := srv.createEnterpriseInvoice(account, account.NextInvoiceAt, 250)
+	if err != nil {
+		t.Fatalf("first createEnterpriseInvoice: %v", err)
+	}
+	second, err := srv.createEnterpriseInvoice(account, account.NextInvoiceAt, 250)
+	if err != nil {
+		t.Fatalf("second createEnterpriseInvoice: %v", err)
+	}
+	if first.ID != second.ID {
+		t.Fatalf("invoice IDs = %q/%q, want same", first.ID, second.ID)
+	}
+	if invoiceCalls != 2 || len(idempotencyKeys) != 2 || idempotencyKeys[0] == "" || idempotencyKeys[0] != idempotencyKeys[1] {
+		t.Fatalf("idempotency keys/calls = %v/%d, want same non-empty key across retries", idempotencyKeys, invoiceCalls)
+	}
+	invoices, _ := st.ListEnterpriseInvoices("acct-idem", 10)
+	if len(invoices) != 1 {
+		t.Fatalf("invoice count = %d, want 1", len(invoices))
+	}
+}
+
+func TestEnterpriseFinalizeFailureDoesNotCreditPayouts(t *testing.T) {
+	srv, st := testBillingServer(t)
+	model := "enterprise-finalize-model"
+	wallet := "0xproviderwallet"
+	provider := srv.registry.Register("provider-ent", nil, &protocol.RegisterMessage{
+		WalletAddress: wallet,
+		Models:        []protocol.ModelInfo{{ID: model}},
+	})
+	pr := &registry.PendingRequest{
+		RequestID:            "req-ent-finalize",
+		Model:                model,
+		ConsumerKey:          "acct-ent",
+		ReservedMicroUSD:     1_000_000,
+		EnterpriseBilling:    true,
+		BillingReservationID: "missing-reservation",
+		ChunkCh:              make(chan string, 1),
+		CompleteCh:           make(chan protocol.UsageInfo, 1),
+		ErrorCh:              make(chan protocol.InferenceErrorMessage, 1),
+	}
+	provider.AddPending(pr)
+
+	srv.handleComplete(provider.ID, provider, &protocol.InferenceCompleteMessage{
+		Type:      protocol.TypeInferenceComplete,
+		RequestID: pr.RequestID,
+		Usage:     protocol.UsageInfo{PromptTokens: 1000, CompletionTokens: 500},
+	})
+
+	errMsg, ok := <-pr.ErrorCh
+	if !ok || errMsg.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("error message = %+v, ok=%v; want billing failure", errMsg, ok)
+	}
+	if st.GetBalance(wallet) != 0 {
+		t.Fatalf("provider wallet balance = %d, want 0", st.GetBalance(wallet))
+	}
+	if st.GetBalance("platform") != 0 {
+		t.Fatalf("platform balance = %d, want 0", st.GetBalance("platform"))
+	}
+	if _, ok := <-pr.CompleteCh; ok {
+		t.Fatal("CompleteCh delivered usage despite Enterprise finalize failure")
+	}
+}
+
+func TestEnterpriseCommittedStreamErrorSettlesReservationAtEstimate(t *testing.T) {
+	srv, st := testBillingServer(t)
+	if err := st.UpsertEnterpriseAccount(&store.EnterpriseAccount{
+		AccountID:           "acct-stream",
+		Status:              store.EnterpriseStatusActive,
+		BillingEmail:        "billing@example.com",
+		Cadence:             store.EnterpriseCadenceWeekly,
+		TermsDays:           15,
+		CreditLimitMicroUSD: 10_000_000,
+	}); err != nil {
+		t.Fatalf("UpsertEnterpriseAccount: %v", err)
+	}
+	if err := st.ReserveEnterpriseUsage("acct-stream", "res-stream", 1_000_000); err != nil {
+		t.Fatalf("ReserveEnterpriseUsage: %v", err)
+	}
+	pr := &registry.PendingRequest{
+		RequestID:            "req-stream",
+		Model:                "enterprise-stream-model",
+		ConsumerKey:          "acct-stream",
+		ReservedMicroUSD:     1_000_000,
+		EnterpriseBilling:    true,
+		BillingReservationID: "res-stream",
+		ChunkCh:              make(chan string, 1),
+		CompleteCh:           make(chan protocol.UsageInfo, 1),
+		ErrorCh:              make(chan protocol.InferenceErrorMessage, 1),
+	}
+	pr.ErrorCh <- protocol.InferenceErrorMessage{RequestID: pr.RequestID, Error: "backend stopped", StatusCode: http.StatusBadGateway}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	w := httptest.NewRecorder()
+	srv.handleStreamingResponseWithFirstChunk(w, req, pr, `data: {"choices":[{"delta":{"content":"partial"}}]}`)
+
+	account, _ := st.GetEnterpriseAccount("acct-stream")
+	if account.ReservedMicroUSD != 0 || account.AccruedMicroUSD != 1_000_000 {
+		t.Fatalf("reserved/accrued = %d/%d, want 0/1000000", account.ReservedMicroUSD, account.AccruedMicroUSD)
+	}
+}
+
+func TestEnterpriseStatusShowsRecentInvoices(t *testing.T) {
+	srv, st := testBillingServer(t)
+	now := time.Now().Truncate(time.Second)
+	if err := st.UpsertEnterpriseAccount(&store.EnterpriseAccount{
+		AccountID:           "acct-ent",
+		Status:              store.EnterpriseStatusActive,
+		BillingEmail:        "billing@example.com",
+		Cadence:             store.EnterpriseCadenceMonthly,
+		TermsDays:           30,
+		CreditLimitMicroUSD: 10_000_000,
+		AccruedMicroUSD:     1_000_000,
+		CurrentPeriodStart:  now,
+		NextInvoiceAt:       now.AddDate(0, 1, 0),
+	}); err != nil {
+		t.Fatalf("UpsertEnterpriseAccount: %v", err)
+	}
+	if err := st.CreateEnterpriseInvoice(&store.EnterpriseInvoice{
+		ID:                     "inv-1",
+		AccountID:              "acct-ent",
+		StripeInvoiceID:        "in_1",
+		StripeHostedInvoiceURL: "https://invoice.test/in_1",
+		Status:                 store.EnterpriseInvoiceStatusOpen,
+		PeriodStart:            now.AddDate(0, -1, 0),
+		PeriodEnd:              now,
+		AmountMicroUSD:         2_000_000,
+		AmountCents:            200,
+		TermsDays:              30,
+	}); err != nil {
+		t.Fatalf("CreateEnterpriseInvoice: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/billing/enterprise/status", nil)
+	req = req.WithContext(req.Context())
+	req = withPrivyUser(req, &store.User{AccountID: "acct-ent", PrivyUserID: "did:privy:ent", Email: "user@example.com"})
+	w := httptest.NewRecorder()
+	srv.handleEnterpriseStatus(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d: %s", w.Code, w.Body.String())
+	}
+	var resp struct {
+		Enabled        bool                      `json:"enabled"`
+		RecentInvoices []store.EnterpriseInvoice `json:"recent_invoices"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !resp.Enabled || len(resp.RecentInvoices) != 1 {
+		t.Fatalf("enterprise response = %+v", resp)
+	}
+}

--- a/coordinator/internal/api/provider.go
+++ b/coordinator/internal/api/provider.go
@@ -997,7 +997,32 @@ func (s *Server) handleComplete(providerID string, provider *registry.Provider, 
 	// totalCost <= reserved, so the only path here is a refund of the unused
 	// portion. The old "charge extra" path is retained for the unreserved
 	// code path below (billing disabled / legacy requests).
-	if pr.ReservedMicroUSD > 0 {
+	if pr.EnterpriseBilling {
+		reservationID := pr.BillingReservationID
+		if reservationID == "" {
+			reservationID = msg.RequestID
+		}
+		if err := s.store.FinalizeEnterpriseUsage(pr.ConsumerKey, reservationID, totalCost); err != nil {
+			s.logger.Error("enterprise billing finalize failed",
+				"consumer_key", pr.ConsumerKey,
+				"request_id", msg.RequestID,
+				"reservation_id", reservationID,
+				"cost_micro_usd", totalCost,
+				"error", err,
+			)
+			pr.ErrorCh <- protocol.InferenceErrorMessage{
+				Type:       protocol.TypeInferenceError,
+				RequestID:  msg.RequestID,
+				Error:      "enterprise billing finalization failed",
+				StatusCode: http.StatusInternalServerError,
+			}
+			close(pr.ChunkCh)
+			close(pr.CompleteCh)
+			close(pr.ErrorCh)
+			s.registry.SetProviderIdle(providerID)
+			return
+		}
+	} else if pr.ReservedMicroUSD > 0 {
 		if totalCost < pr.ReservedMicroUSD {
 			refund := pr.ReservedMicroUSD - totalCost
 			_ = s.store.Credit(pr.ConsumerKey, refund, store.LedgerRefund, msg.RequestID)

--- a/coordinator/internal/api/server.go
+++ b/coordinator/internal/api/server.go
@@ -865,6 +865,7 @@ func (s *Server) routes() {
 	s.mux.HandleFunc("POST /v1/billing/stripe/create-session", s.requireAuth(s.rateLimitFinancial(s.handleStripeCreateSession)))
 	s.mux.HandleFunc("POST /v1/billing/stripe/webhook", s.handleStripeWebhook) // no auth — Stripe signs it
 	s.mux.HandleFunc("GET /v1/billing/stripe/session", s.requireAuth(s.handleStripeSessionStatus))
+	s.mux.HandleFunc("GET /v1/billing/enterprise/status", s.requireAuth(s.handleEnterpriseStatus))
 
 	// Wallet balance
 	s.mux.HandleFunc("GET /v1/billing/wallet/balance", s.requireAuth(s.handleWalletBalance))
@@ -881,6 +882,9 @@ func (s *Server) routes() {
 	s.mux.HandleFunc("PUT /v1/pricing", s.requireAuth(s.handleSetPricing))         // provider sets own prices
 	s.mux.HandleFunc("DELETE /v1/pricing", s.requireAuth(s.handleDeletePricing))   // revert to default
 	s.mux.HandleFunc("PUT /v1/admin/pricing", s.requireAuth(s.handleAdminPricing)) // platform sets defaults
+	s.mux.HandleFunc("PUT /v1/admin/enterprise/account", s.requireAuth(s.handleAdminUpsertEnterpriseAccount))
+	s.mux.HandleFunc("GET /v1/admin/enterprise/accounts", s.requireAuth(s.handleAdminListEnterpriseAccounts))
+	s.mux.HandleFunc("POST /v1/admin/enterprise/invoices/run", s.requireAuth(s.rateLimitFinancial(s.handleAdminRunEnterpriseInvoices)))
 
 	// Admin model catalog
 	s.mux.HandleFunc("GET /v1/admin/models", s.requireAuth(s.handleAdminListModels))

--- a/coordinator/internal/billing/stripe.go
+++ b/coordinator/internal/billing/stripe.go
@@ -60,6 +60,34 @@ type CheckoutSessionResponse struct {
 	AmountCents int64  `json:"amount_cents"`
 }
 
+type StripeCustomer struct {
+	ID    string `json:"id"`
+	Email string `json:"email"`
+}
+
+type EnterpriseInvoiceRequest struct {
+	CustomerID     string
+	AccountID      string
+	AmountCents    int64
+	Currency       string
+	Description    string
+	PeriodStart    time.Time
+	PeriodEnd      time.Time
+	TermsDays      int
+	Metadata       map[string]string
+	IdempotencyKey string
+}
+
+type EnterpriseInvoiceResponse struct {
+	InvoiceID        string
+	Status           string
+	HostedInvoiceURL string
+	InvoicePDF       string
+	DueAt            *time.Time
+	SentAt           *time.Time
+	AmountDueCents   int64
+}
+
 // CreateCheckoutSession creates a Stripe Checkout Session via the API.
 func (p *StripeProcessor) CreateCheckoutSession(req CheckoutSessionRequest) (*CheckoutSessionResponse, error) {
 	if req.Currency == "" {
@@ -131,6 +159,165 @@ func (p *StripeProcessor) CreateCheckoutSession(req CheckoutSessionRequest) (*Ch
 	}, nil
 }
 
+func (p *StripeProcessor) CreateCustomer(email, accountID string) (*StripeCustomer, error) {
+	return p.CreateCustomerWithIdempotency(email, accountID, "")
+}
+
+func (p *StripeProcessor) CreateCustomerWithIdempotency(email, accountID, idempotencyKey string) (*StripeCustomer, error) {
+	form := url.Values{}
+	if email != "" {
+		form.Set("email", email)
+	}
+	form.Set("metadata[app]", "darkbloom")
+	form.Set("metadata[platform]", "eigeninference")
+	form.Set("metadata[account_id]", accountID)
+	body, err := p.doStripeForm(http.MethodPost, "/v1/customers", form, idempotencyKey)
+	if err != nil {
+		return nil, fmt.Errorf("stripe: create customer: %w", err)
+	}
+	var customer StripeCustomer
+	if err := json.Unmarshal(body, &customer); err != nil {
+		return nil, fmt.Errorf("stripe: parse customer: %w", err)
+	}
+	if customer.ID == "" {
+		return nil, errors.New("stripe: create customer returned empty id")
+	}
+	return &customer, nil
+}
+
+func (p *StripeProcessor) CreateEnterpriseInvoice(req EnterpriseInvoiceRequest) (*EnterpriseInvoiceResponse, error) {
+	if req.Currency == "" {
+		req.Currency = "usd"
+	}
+	if req.CustomerID == "" || req.AmountCents <= 0 {
+		return nil, errors.New("stripe: customer_id and amount_cents are required")
+	}
+	if req.TermsDays < 0 {
+		req.TermsDays = 0
+	}
+
+	metadata := checkoutMetadata(req.Metadata)
+	metadata["purchase_type"] = "enterprise_invoice"
+	metadata["account_id"] = req.AccountID
+
+	itemForm := url.Values{}
+	itemForm.Set("customer", req.CustomerID)
+	itemForm.Set("amount", strconv.FormatInt(req.AmountCents, 10))
+	itemForm.Set("currency", req.Currency)
+	itemForm.Set("description", req.Description)
+	itemForm.Set("period[start]", strconv.FormatInt(req.PeriodStart.Unix(), 10))
+	itemForm.Set("period[end]", strconv.FormatInt(req.PeriodEnd.Unix(), 10))
+	for k, v := range metadata {
+		itemForm.Set("metadata["+k+"]", v)
+	}
+	if _, err := p.doStripeForm(http.MethodPost, "/v1/invoiceitems", itemForm, req.IdempotencyKey+":item"); err != nil {
+		return nil, fmt.Errorf("stripe: create invoice item: %w", err)
+	}
+
+	invoiceForm := url.Values{}
+	invoiceForm.Set("customer", req.CustomerID)
+	invoiceForm.Set("collection_method", "send_invoice")
+	invoiceForm.Set("pending_invoice_items_behavior", "include")
+	invoiceForm.Set("days_until_due", strconv.Itoa(req.TermsDays))
+	invoiceForm.Set("auto_advance", "false")
+	invoiceForm.Set("currency", req.Currency)
+	for k, v := range metadata {
+		invoiceForm.Set("metadata["+k+"]", v)
+	}
+	body, err := p.doStripeForm(http.MethodPost, "/v1/invoices", invoiceForm, req.IdempotencyKey+":invoice")
+	if err != nil {
+		return nil, fmt.Errorf("stripe: create invoice: %w", err)
+	}
+	invoice, err := parseStripeInvoice(body)
+	if err != nil {
+		return nil, err
+	}
+
+	body, err = p.doStripeForm(http.MethodPost, "/v1/invoices/"+invoice.InvoiceID+"/finalize", url.Values{}, req.IdempotencyKey+":finalize")
+	if err != nil {
+		return nil, fmt.Errorf("stripe: finalize invoice: %w", err)
+	}
+	invoice, err = parseStripeInvoice(body)
+	if err != nil {
+		return nil, err
+	}
+
+	body, err = p.doStripeForm(http.MethodPost, "/v1/invoices/"+invoice.InvoiceID+"/send", url.Values{}, req.IdempotencyKey+":send")
+	if err != nil {
+		return nil, fmt.Errorf("stripe: send invoice: %w", err)
+	}
+	invoice, err = parseStripeInvoice(body)
+	if err != nil {
+		return nil, err
+	}
+	return invoice, nil
+}
+
+func (p *StripeProcessor) doStripeForm(method, path string, form url.Values, idempotencyKey string) ([]byte, error) {
+	httpReq, err := http.NewRequest(method, stripeAPIBase+path, strings.NewReader(form.Encode()))
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	httpReq.Header.Set("Authorization", "Bearer "+p.secretKey)
+	httpReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	if idempotencyKey != "" {
+		httpReq.Header.Set("Idempotency-Key", idempotencyKey)
+	}
+	resp, err := p.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("API request failed: %w", err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("API error (status %d): %s", resp.StatusCode, string(body))
+	}
+	return body, nil
+}
+
+func parseStripeInvoice(body []byte) (*EnterpriseInvoiceResponse, error) {
+	var raw struct {
+		ID                string `json:"id"`
+		Status            string `json:"status"`
+		HostedInvoiceURL  string `json:"hosted_invoice_url"`
+		InvoicePDF        string `json:"invoice_pdf"`
+		DueDate           int64  `json:"due_date"`
+		StatusTransitions struct {
+			FinalizedAt int64 `json:"finalized_at"`
+			PaidAt      int64 `json:"paid_at"`
+		} `json:"status_transitions"`
+		AmountDue int64 `json:"amount_due"`
+	}
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return nil, fmt.Errorf("stripe: parse invoice: %w", err)
+	}
+	if raw.ID == "" {
+		return nil, errors.New("stripe: invoice response missing id")
+	}
+	var dueAt *time.Time
+	if raw.DueDate > 0 {
+		t := time.Unix(raw.DueDate, 0)
+		dueAt = &t
+	}
+	var sentAt *time.Time
+	if raw.StatusTransitions.FinalizedAt > 0 {
+		t := time.Unix(raw.StatusTransitions.FinalizedAt, 0)
+		sentAt = &t
+	}
+	return &EnterpriseInvoiceResponse{
+		InvoiceID:        raw.ID,
+		Status:           raw.Status,
+		HostedInvoiceURL: raw.HostedInvoiceURL,
+		InvoicePDF:       raw.InvoicePDF,
+		DueAt:            dueAt,
+		SentAt:           sentAt,
+		AmountDueCents:   raw.AmountDue,
+	}, nil
+}
+
 func checkoutMetadata(metadata map[string]string) map[string]string {
 	params := map[string]string{
 		"app":           "darkbloom",
@@ -158,6 +345,24 @@ type CheckoutSessionEvent struct {
 		Currency      string            `json:"currency"`
 		PaymentStatus string            `json:"payment_status"` // "paid"
 		Metadata      map[string]string `json:"metadata"`
+	} `json:"object"`
+}
+
+type InvoiceEvent struct {
+	Object struct {
+		ID                string            `json:"id"`
+		Status            string            `json:"status"`
+		HostedInvoiceURL  string            `json:"hosted_invoice_url"`
+		InvoicePDF        string            `json:"invoice_pdf"`
+		DueDate           int64             `json:"due_date"`
+		AmountPaid        int64             `json:"amount_paid"`
+		AmountDue         int64             `json:"amount_due"`
+		Metadata          map[string]string `json:"metadata"`
+		StatusTransitions struct {
+			FinalizedAt int64 `json:"finalized_at"`
+			PaidAt      int64 `json:"paid_at"`
+			VoidedAt    int64 `json:"voided_at"`
+		} `json:"status_transitions"`
 	} `json:"object"`
 }
 
@@ -242,6 +447,20 @@ func (p *StripeProcessor) ParseCheckoutSession(event *WebhookEvent) (*CheckoutSe
 		return nil, fmt.Errorf("stripe: payment not completed (status: %s)", data.Object.PaymentStatus)
 	}
 
+	return &data, nil
+}
+
+func (p *StripeProcessor) ParseInvoice(event *WebhookEvent) (*InvoiceEvent, error) {
+	if event == nil || !strings.HasPrefix(event.Type, "invoice.") {
+		return nil, fmt.Errorf("stripe: unexpected event type %q", event.Type)
+	}
+	var data InvoiceEvent
+	if err := json.Unmarshal(event.Data, &data); err != nil {
+		return nil, fmt.Errorf("stripe: parse invoice: %w", err)
+	}
+	if data.Object.ID == "" {
+		return nil, errors.New("stripe: invoice missing id")
+	}
 	return &data, nil
 }
 

--- a/coordinator/internal/billing/stripe_test.go
+++ b/coordinator/internal/billing/stripe_test.go
@@ -1,11 +1,13 @@
 package billing
 
 import (
+	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"testing"
+	"time"
 )
 
 func TestCreateCheckoutSessionAddsDashboardMetadata(t *testing.T) {
@@ -72,5 +74,84 @@ func TestCreateCheckoutSessionAddsDashboardMetadata(t *testing.T) {
 	}
 	if got := capturedForm.Get("line_items[0][price_data][product_data][name]"); got != "Darkbloom Inference Credits" {
 		t.Errorf("product name = %q", got)
+	}
+}
+
+func TestCreateEnterpriseInvoiceUsesSendInvoiceTerms(t *testing.T) {
+	var forms []url.Values
+	var paths []string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, r.URL.Path)
+		body, _ := io.ReadAll(r.Body)
+		form, _ := url.ParseQuery(string(body))
+		forms = append(forms, form)
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/v1/invoiceitems":
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": "ii_test"})
+		case "/v1/invoices":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":         "in_test",
+				"status":     "draft",
+				"amount_due": 1234,
+			})
+		case "/v1/invoices/in_test/finalize":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":         "in_test",
+				"status":     "open",
+				"amount_due": 1234,
+				"due_date":   time.Now().Add(15 * 24 * time.Hour).Unix(),
+			})
+		case "/v1/invoices/in_test/send":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":                 "in_test",
+				"status":             "open",
+				"hosted_invoice_url": "https://invoice.stripe.test/in_test",
+				"invoice_pdf":        "https://invoice.stripe.test/in_test.pdf",
+				"amount_due":         1234,
+			})
+		default:
+			http.Error(w, "unexpected path", http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	prev := stripeAPIBase
+	stripeAPIBase = srv.URL
+	t.Cleanup(func() { stripeAPIBase = prev })
+
+	proc := NewStripeProcessor("sk_test_invoice", "whsec_test", "", "", silentLogger())
+	resp, err := proc.CreateEnterpriseInvoice(EnterpriseInvoiceRequest{
+		CustomerID:     "cus_test",
+		AccountID:      "acct-ent",
+		AmountCents:    1234,
+		Currency:       "usd",
+		Description:    "Darkbloom Enterprise usage",
+		PeriodStart:    time.Unix(100, 0),
+		PeriodEnd:      time.Unix(200, 0),
+		TermsDays:      15,
+		IdempotencyKey: "enterprise-invoice-test",
+	})
+	if err != nil {
+		t.Fatalf("CreateEnterpriseInvoice: %v", err)
+	}
+	if resp.InvoiceID != "in_test" || resp.HostedInvoiceURL == "" {
+		t.Fatalf("unexpected invoice response: %+v", resp)
+	}
+	if len(paths) != 4 {
+		t.Fatalf("Stripe calls = %v, want 4 calls", paths)
+	}
+	if got := forms[1].Get("collection_method"); got != "send_invoice" {
+		t.Fatalf("collection_method = %q, want send_invoice", got)
+	}
+	if got := forms[1].Get("days_until_due"); got != "15" {
+		t.Fatalf("days_until_due = %q, want 15", got)
+	}
+	if got := forms[1].Get("pending_invoice_items_behavior"); got != "include" {
+		t.Fatalf("pending_invoice_items_behavior = %q, want include", got)
+	}
+	if got := forms[0].Get("period[start]"); got != "100" {
+		t.Fatalf("period[start] = %q, want 100", got)
 	}
 }

--- a/coordinator/internal/registry/registry.go
+++ b/coordinator/internal/registry/registry.go
@@ -85,6 +85,13 @@ type PendingRequest struct {
 	// The post-inference charge adjusts for the difference between the
 	// actual cost and this reservation, preventing billing race conditions.
 	ReservedMicroUSD int64
+
+	// EnterpriseBilling is true when ReservedMicroUSD was reserved against an
+	// Enterprise postpaid credit limit instead of the prepaid ledger balance.
+	EnterpriseBilling bool
+	// BillingReservationID is the store reservation key for Enterprise
+	// postpaid reservations. It can differ from RequestID across retry loops.
+	BillingReservationID string
 }
 
 // Provider represents a connected provider agent.

--- a/coordinator/internal/store/interface.go
+++ b/coordinator/internal/store/interface.go
@@ -16,8 +16,11 @@ package store
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"time"
 )
+
+var ErrEnterpriseAccountNotFound = errors.New("enterprise account not found")
 
 // Store is the interface that all storage backends must implement.
 type Store interface {
@@ -132,6 +135,53 @@ type Store interface {
 	// IsExternalIDProcessed returns true if a billing session with this external ID
 	// has already been completed. Used to prevent double-crediting the same on-chain tx.
 	IsExternalIDProcessed(externalID string) bool
+
+	// --- Enterprise Invoicing ---
+
+	// UpsertEnterpriseAccount creates or updates an admin-managed Enterprise account.
+	UpsertEnterpriseAccount(account *EnterpriseAccount) error
+
+	// GetEnterpriseAccount returns the Enterprise billing record for an account.
+	GetEnterpriseAccount(accountID string) (*EnterpriseAccount, error)
+
+	// ListEnterpriseAccounts returns all Enterprise billing records.
+	ListEnterpriseAccounts() ([]EnterpriseAccount, error)
+
+	// SetEnterpriseStripeCustomerID stores the Stripe customer ID without
+	// overwriting live billing counters.
+	SetEnterpriseStripeCustomerID(accountID, stripeCustomerID string) error
+
+	// AdvanceEnterpriseInvoicePeriod advances a below-cent invoice period
+	// without touching live billing counters.
+	AdvanceEnterpriseInvoicePeriod(accountID string, periodStart, nextInvoiceAt time.Time) error
+
+	// ReserveEnterpriseUsage atomically reserves postpaid Enterprise credit.
+	ReserveEnterpriseUsage(accountID, requestID string, amountMicroUSD int64) error
+
+	// FinalizeEnterpriseUsage moves a reservation into accrued invoiceable usage.
+	FinalizeEnterpriseUsage(accountID, requestID string, actualMicroUSD int64) error
+
+	// ReleaseEnterpriseReservation releases an unused Enterprise reservation.
+	ReleaseEnterpriseReservation(accountID, requestID string) error
+
+	// ListDueEnterpriseAccounts returns active Enterprise accounts whose invoice
+	// cadence is due at or before the supplied time.
+	ListDueEnterpriseAccounts(now time.Time) ([]EnterpriseAccount, error)
+
+	// CreateEnterpriseInvoice stores an Enterprise invoice record.
+	CreateEnterpriseInvoice(invoice *EnterpriseInvoice) error
+
+	// CreateEnterpriseInvoiceDraft stores a local invoice marker before Stripe side effects.
+	CreateEnterpriseInvoiceDraft(invoice *EnterpriseInvoice) error
+
+	// UpdateEnterpriseInvoice stores Stripe/status fields for an invoice.
+	UpdateEnterpriseInvoice(invoice *EnterpriseInvoice) error
+
+	// GetEnterpriseInvoiceByStripeID returns the local invoice for a Stripe invoice ID.
+	GetEnterpriseInvoiceByStripeID(stripeInvoiceID string) (*EnterpriseInvoice, error)
+
+	// ListEnterpriseInvoices returns an account's invoices newest first.
+	ListEnterpriseInvoices(accountID string, limit int) ([]EnterpriseInvoice, error)
 
 	// --- Custom Pricing ---
 
@@ -662,6 +712,60 @@ type BillingSession struct {
 	ReferralCode   string     `json:"referral_code"` // optional
 	CreatedAt      time.Time  `json:"created_at"`
 	CompletedAt    *time.Time `json:"completed_at,omitempty"`
+}
+
+const (
+	EnterpriseStatusActive   = "active"
+	EnterpriseStatusDisabled = "disabled"
+
+	EnterpriseCadenceWeekly   = "weekly"
+	EnterpriseCadenceBiweekly = "biweekly"
+	EnterpriseCadenceMonthly  = "monthly"
+
+	EnterpriseInvoiceStatusDraft         = "draft"
+	EnterpriseInvoiceStatusOpen          = "open"
+	EnterpriseInvoiceStatusPaid          = "paid"
+	EnterpriseInvoiceStatusVoid          = "void"
+	EnterpriseInvoiceStatusUncollectible = "uncollectible"
+)
+
+// EnterpriseAccount is an admin-managed postpaid billing configuration.
+type EnterpriseAccount struct {
+	AccountID             string    `json:"account_id"`
+	Status                string    `json:"status"` // "active" | "disabled"
+	BillingEmail          string    `json:"billing_email"`
+	StripeCustomerID      string    `json:"stripe_customer_id,omitempty"`
+	Cadence               string    `json:"cadence"` // "weekly" | "biweekly" | "monthly"
+	TermsDays             int       `json:"terms_days"`
+	CreditLimitMicroUSD   int64     `json:"credit_limit_micro_usd"`
+	AccruedMicroUSD       int64     `json:"accrued_micro_usd"`
+	ReservedMicroUSD      int64     `json:"reserved_micro_usd"`
+	OpenInvoiceMicroUSD   int64     `json:"open_invoice_micro_usd"`
+	RoundingCarryMicroUSD int64     `json:"rounding_carry_micro_usd"`
+	CurrentPeriodStart    time.Time `json:"current_period_start"`
+	NextInvoiceAt         time.Time `json:"next_invoice_at"`
+	CreatedAt             time.Time `json:"created_at"`
+	UpdatedAt             time.Time `json:"updated_at"`
+}
+
+// EnterpriseInvoice records a Stripe invoice generated for Enterprise usage.
+type EnterpriseInvoice struct {
+	ID                     string     `json:"id"`
+	AccountID              string     `json:"account_id"`
+	StripeInvoiceID        string     `json:"stripe_invoice_id,omitempty"`
+	StripeHostedInvoiceURL string     `json:"stripe_hosted_invoice_url,omitempty"`
+	StripeInvoicePDF       string     `json:"stripe_invoice_pdf,omitempty"`
+	Status                 string     `json:"status"`
+	PeriodStart            time.Time  `json:"period_start"`
+	PeriodEnd              time.Time  `json:"period_end"`
+	AmountMicroUSD         int64      `json:"amount_micro_usd"`
+	AmountCents            int64      `json:"amount_cents"`
+	TermsDays              int        `json:"terms_days"`
+	DueAt                  *time.Time `json:"due_at,omitempty"`
+	SentAt                 *time.Time `json:"sent_at,omitempty"`
+	PaidAt                 *time.Time `json:"paid_at,omitempty"`
+	CreatedAt              time.Time  `json:"created_at"`
+	UpdatedAt              time.Time  `json:"updated_at"`
 }
 
 // ProviderRecord is the persistent representation of a provider for storage.

--- a/coordinator/internal/store/memory.go
+++ b/coordinator/internal/store/memory.go
@@ -48,6 +48,12 @@ type MemoryStore struct {
 	// Billing sessions
 	billingSessions map[string]*BillingSession // sessionID → session
 
+	// Enterprise invoicing
+	enterpriseAccounts     map[string]*EnterpriseAccount
+	enterpriseInvoices     map[string]*EnterpriseInvoice
+	enterpriseByStripeID   map[string]string
+	enterpriseReservations map[string]*enterpriseReservation
+
 	// Custom pricing
 	modelPrices map[string]ModelPrice // "accountID:model" → price
 
@@ -113,6 +119,10 @@ func NewMemory(adminKey string) *MemoryStore {
 		referrals:                     make(map[string]string),
 		referralCounts:                make(map[string]int),
 		billingSessions:               make(map[string]*BillingSession),
+		enterpriseAccounts:            make(map[string]*EnterpriseAccount),
+		enterpriseInvoices:            make(map[string]*EnterpriseInvoice),
+		enterpriseByStripeID:          make(map[string]string),
+		enterpriseReservations:        make(map[string]*enterpriseReservation),
 		modelPrices:                   make(map[string]ModelPrice),
 		supportedModels:               make(map[string]*SupportedModel),
 		usersByPrivyID:                make(map[string]*User),
@@ -721,6 +731,396 @@ func (s *MemoryStore) IsExternalIDProcessed(externalID string) bool {
 		}
 	}
 	return false
+}
+
+type enterpriseReservation struct {
+	RequestID      string
+	AccountID      string
+	AmountMicroUSD int64
+	ActualMicroUSD int64
+	Status         string
+	CreatedAt      time.Time
+	UpdatedAt      time.Time
+}
+
+// --- Enterprise Invoicing ---
+
+func normalizeEnterpriseAccount(account *EnterpriseAccount) EnterpriseAccount {
+	copy := *account
+	now := time.Now()
+	if copy.Status == "" {
+		copy.Status = EnterpriseStatusActive
+	}
+	if copy.Cadence == "" {
+		copy.Cadence = EnterpriseCadenceMonthly
+	}
+	if copy.CurrentPeriodStart.IsZero() {
+		copy.CurrentPeriodStart = now
+	}
+	if copy.NextInvoiceAt.IsZero() {
+		copy.NextInvoiceAt = nextEnterpriseInvoiceAt(copy.CurrentPeriodStart, copy.Cadence)
+	}
+	if copy.CreatedAt.IsZero() {
+		copy.CreatedAt = now
+	}
+	copy.UpdatedAt = now
+	return copy
+}
+
+func nextEnterpriseInvoiceAt(start time.Time, cadence string) time.Time {
+	switch cadence {
+	case EnterpriseCadenceWeekly:
+		return start.AddDate(0, 0, 7)
+	case EnterpriseCadenceBiweekly:
+		return start.AddDate(0, 0, 14)
+	default:
+		return start.AddDate(0, 1, 0)
+	}
+}
+
+func (s *MemoryStore) UpsertEnterpriseAccount(account *EnterpriseAccount) error {
+	if account == nil || account.AccountID == "" {
+		return errors.New("enterprise account_id is required")
+	}
+	if account.CreditLimitMicroUSD < 0 ||
+		account.AccruedMicroUSD < 0 ||
+		account.ReservedMicroUSD < 0 ||
+		account.OpenInvoiceMicroUSD < 0 ||
+		account.RoundingCarryMicroUSD < 0 {
+		return errors.New("enterprise money fields cannot be negative")
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if existing, ok := s.enterpriseAccounts[account.AccountID]; ok && account.CreatedAt.IsZero() {
+		account.CreatedAt = existing.CreatedAt
+	}
+	copy := normalizeEnterpriseAccount(account)
+	s.enterpriseAccounts[copy.AccountID] = &copy
+	return nil
+}
+
+func (s *MemoryStore) GetEnterpriseAccount(accountID string) (*EnterpriseAccount, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	account, ok := s.enterpriseAccounts[accountID]
+	if !ok {
+		return nil, fmt.Errorf("%w: %q", ErrEnterpriseAccountNotFound, accountID)
+	}
+	copy := *account
+	return &copy, nil
+}
+
+func (s *MemoryStore) ListEnterpriseAccounts() ([]EnterpriseAccount, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	out := make([]EnterpriseAccount, 0, len(s.enterpriseAccounts))
+	for _, account := range s.enterpriseAccounts {
+		out = append(out, *account)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].UpdatedAt.After(out[j].UpdatedAt)
+	})
+	return out, nil
+}
+
+func (s *MemoryStore) SetEnterpriseStripeCustomerID(accountID, stripeCustomerID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	account, ok := s.enterpriseAccounts[accountID]
+	if !ok {
+		return fmt.Errorf("enterprise account %q not found", accountID)
+	}
+	account.StripeCustomerID = stripeCustomerID
+	account.UpdatedAt = time.Now()
+	return nil
+}
+
+func (s *MemoryStore) AdvanceEnterpriseInvoicePeriod(accountID string, periodStart, nextInvoiceAt time.Time) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	account, ok := s.enterpriseAccounts[accountID]
+	if !ok {
+		return fmt.Errorf("enterprise account %q not found", accountID)
+	}
+	account.CurrentPeriodStart = periodStart
+	account.NextInvoiceAt = nextInvoiceAt
+	account.UpdatedAt = time.Now()
+	return nil
+}
+
+func (s *MemoryStore) ReserveEnterpriseUsage(accountID, requestID string, amountMicroUSD int64) error {
+	if amountMicroUSD <= 0 {
+		return nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	account, ok := s.enterpriseAccounts[accountID]
+	if !ok || account.Status != EnterpriseStatusActive {
+		return fmt.Errorf("enterprise account %q is not active", accountID)
+	}
+	if existing, ok := s.enterpriseReservations[requestID]; ok {
+		if existing.AccountID == accountID && existing.Status == "reserved" {
+			if existing.AmountMicroUSD != amountMicroUSD {
+				return fmt.Errorf("enterprise reservation %q amount mismatch", requestID)
+			}
+			return nil
+		}
+		if existing.AccountID != accountID {
+			return fmt.Errorf("enterprise reservation %q belongs to another account", requestID)
+		}
+		return fmt.Errorf("enterprise reservation %q already %s", requestID, existing.Status)
+	}
+	exposure := account.OpenInvoiceMicroUSD + account.AccruedMicroUSD + account.ReservedMicroUSD + account.RoundingCarryMicroUSD + amountMicroUSD
+	if exposure > account.CreditLimitMicroUSD {
+		return fmt.Errorf("enterprise credit limit exceeded")
+	}
+	now := time.Now()
+	account.ReservedMicroUSD += amountMicroUSD
+	account.UpdatedAt = now
+	s.enterpriseReservations[requestID] = &enterpriseReservation{
+		RequestID: requestID, AccountID: accountID, AmountMicroUSD: amountMicroUSD,
+		Status: "reserved", CreatedAt: now, UpdatedAt: now,
+	}
+	return nil
+}
+
+func (s *MemoryStore) FinalizeEnterpriseUsage(accountID, requestID string, actualMicroUSD int64) error {
+	if actualMicroUSD < 0 {
+		actualMicroUSD = 0
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	account, ok := s.enterpriseAccounts[accountID]
+	if !ok {
+		return fmt.Errorf("enterprise account %q not found", accountID)
+	}
+	res, ok := s.enterpriseReservations[requestID]
+	if !ok || res.Status != "reserved" {
+		return fmt.Errorf("enterprise reservation %q not found", requestID)
+	}
+	if res.AccountID != accountID {
+		return fmt.Errorf("enterprise reservation %q belongs to another account", requestID)
+	}
+	if actualMicroUSD > res.AmountMicroUSD {
+		actualMicroUSD = res.AmountMicroUSD
+	}
+	now := time.Now()
+	account.ReservedMicroUSD -= res.AmountMicroUSD
+	if account.ReservedMicroUSD < 0 {
+		account.ReservedMicroUSD = 0
+	}
+	account.AccruedMicroUSD += actualMicroUSD
+	account.UpdatedAt = now
+	res.ActualMicroUSD = actualMicroUSD
+	res.Status = "finalized"
+	res.UpdatedAt = now
+	return nil
+}
+
+func (s *MemoryStore) ReleaseEnterpriseReservation(accountID, requestID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	account, ok := s.enterpriseAccounts[accountID]
+	if !ok {
+		return fmt.Errorf("enterprise account %q not found", accountID)
+	}
+	res, ok := s.enterpriseReservations[requestID]
+	if !ok || res.Status != "reserved" {
+		return nil
+	}
+	if res.AccountID != accountID {
+		return fmt.Errorf("enterprise reservation %q belongs to another account", requestID)
+	}
+	now := time.Now()
+	account.ReservedMicroUSD -= res.AmountMicroUSD
+	if account.ReservedMicroUSD < 0 {
+		account.ReservedMicroUSD = 0
+	}
+	account.UpdatedAt = now
+	res.Status = "released"
+	res.UpdatedAt = now
+	return nil
+}
+
+func (s *MemoryStore) ListDueEnterpriseAccounts(now time.Time) ([]EnterpriseAccount, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	var out []EnterpriseAccount
+	for _, account := range s.enterpriseAccounts {
+		if account.Status == EnterpriseStatusActive && !account.NextInvoiceAt.After(now) {
+			out = append(out, *account)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].NextInvoiceAt.Before(out[j].NextInvoiceAt)
+	})
+	return out, nil
+}
+
+func (s *MemoryStore) CreateEnterpriseInvoice(invoice *EnterpriseInvoice) error {
+	if invoice == nil || invoice.ID == "" || invoice.AccountID == "" {
+		return errors.New("enterprise invoice id and account_id are required")
+	}
+	if invoice.AmountMicroUSD < 0 || invoice.AmountCents < 0 {
+		return errors.New("enterprise invoice amount cannot be negative")
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	existing, exists := s.enterpriseInvoices[invoice.ID]
+	if exists && existing.StripeInvoiceID != "" {
+		return fmt.Errorf("enterprise invoice %q already exists", invoice.ID)
+	}
+	if exists {
+		if existing.AccountID != invoice.AccountID || existing.AmountMicroUSD != invoice.AmountMicroUSD || existing.AmountCents != invoice.AmountCents {
+			return fmt.Errorf("enterprise invoice %q draft mismatch", invoice.ID)
+		}
+	}
+	copy := *invoice
+	now := time.Now()
+	if copy.CreatedAt.IsZero() {
+		if exists {
+			copy.CreatedAt = existing.CreatedAt
+		} else {
+			copy.CreatedAt = now
+		}
+	}
+	copy.UpdatedAt = now
+	s.enterpriseInvoices[copy.ID] = &copy
+	if copy.StripeInvoiceID != "" {
+		s.enterpriseByStripeID[copy.StripeInvoiceID] = copy.ID
+	}
+	if account, ok := s.enterpriseAccounts[copy.AccountID]; ok {
+		account.OpenInvoiceMicroUSD += copy.AmountMicroUSD
+		remainder := account.AccruedMicroUSD + account.RoundingCarryMicroUSD - copy.AmountMicroUSD
+		if remainder < 0 {
+			remainder = 0
+		}
+		account.AccruedMicroUSD = 0
+		account.RoundingCarryMicroUSD = remainder
+		account.CurrentPeriodStart = copy.PeriodEnd
+		account.NextInvoiceAt = nextEnterpriseInvoiceAt(copy.PeriodEnd, account.Cadence)
+		account.UpdatedAt = now
+	}
+	return nil
+}
+
+func (s *MemoryStore) CreateEnterpriseInvoiceDraft(invoice *EnterpriseInvoice) error {
+	if invoice == nil || invoice.ID == "" || invoice.AccountID == "" {
+		return errors.New("enterprise invoice id and account_id are required")
+	}
+	if invoice.AmountMicroUSD < 0 || invoice.AmountCents < 0 {
+		return errors.New("enterprise invoice amount cannot be negative")
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if existing, exists := s.enterpriseInvoices[invoice.ID]; exists {
+		if existing.AccountID == invoice.AccountID &&
+			existing.AmountMicroUSD == invoice.AmountMicroUSD &&
+			existing.AmountCents == invoice.AmountCents {
+			return nil
+		}
+		return fmt.Errorf("enterprise invoice %q already exists", invoice.ID)
+	}
+	copy := *invoice
+	now := time.Now()
+	if copy.CreatedAt.IsZero() {
+		copy.CreatedAt = now
+	}
+	copy.UpdatedAt = now
+	s.enterpriseInvoices[copy.ID] = &copy
+	return nil
+}
+
+func (s *MemoryStore) UpdateEnterpriseInvoice(invoice *EnterpriseInvoice) error {
+	if invoice == nil || invoice.ID == "" {
+		return errors.New("enterprise invoice id is required")
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	existing, ok := s.enterpriseInvoices[invoice.ID]
+	if !ok {
+		return fmt.Errorf("enterprise invoice %q not found", invoice.ID)
+	}
+	oldStatus := existing.Status
+	persistedAccountID := existing.AccountID
+	persistedAmount := existing.AmountMicroUSD
+	copy := *invoice
+	copy.CreatedAt = existing.CreatedAt
+	copy.AccountID = persistedAccountID
+	copy.AmountMicroUSD = persistedAmount
+	copy.AmountCents = existing.AmountCents
+	copy.PeriodStart = existing.PeriodStart
+	copy.PeriodEnd = existing.PeriodEnd
+	copy.TermsDays = existing.TermsDays
+	copy.UpdatedAt = time.Now()
+	s.enterpriseInvoices[copy.ID] = &copy
+	if copy.StripeInvoiceID != "" {
+		s.enterpriseByStripeID[copy.StripeInvoiceID] = copy.ID
+	}
+	if isEnterpriseInvoiceTerminal(oldStatus) && !isEnterpriseInvoiceTerminal(copy.Status) {
+		copy.Status = oldStatus
+		s.enterpriseInvoices[copy.ID] = &copy
+	}
+	if !isEnterpriseInvoiceTerminal(oldStatus) && isEnterpriseInvoiceTerminal(copy.Status) {
+		if account, ok := s.enterpriseAccounts[persistedAccountID]; ok {
+			account.OpenInvoiceMicroUSD -= persistedAmount
+			if account.OpenInvoiceMicroUSD < 0 {
+				account.OpenInvoiceMicroUSD = 0
+			}
+			account.UpdatedAt = copy.UpdatedAt
+		}
+	}
+	return nil
+}
+
+func isEnterpriseInvoiceTerminal(status string) bool {
+	return status == EnterpriseInvoiceStatusPaid ||
+		status == EnterpriseInvoiceStatusVoid ||
+		status == EnterpriseInvoiceStatusUncollectible
+}
+
+func (s *MemoryStore) GetEnterpriseInvoiceByStripeID(stripeInvoiceID string) (*EnterpriseInvoice, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	id := s.enterpriseByStripeID[stripeInvoiceID]
+	if id == "" {
+		return nil, fmt.Errorf("enterprise invoice for Stripe ID %q not found", stripeInvoiceID)
+	}
+	invoice := s.enterpriseInvoices[id]
+	copy := *invoice
+	return &copy, nil
+}
+
+func (s *MemoryStore) ListEnterpriseInvoices(accountID string, limit int) ([]EnterpriseInvoice, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	var out []EnterpriseInvoice
+	for _, invoice := range s.enterpriseInvoices {
+		if invoice.AccountID == accountID {
+			out = append(out, *invoice)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].CreatedAt.After(out[j].CreatedAt)
+	})
+	if limit > 0 && len(out) > limit {
+		out = out[:limit]
+	}
+	return out, nil
 }
 
 // --- Custom Pricing ---

--- a/coordinator/internal/store/postgres.go
+++ b/coordinator/internal/store/postgres.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
@@ -226,6 +227,56 @@ func (s *PostgresStore) migrate(ctx context.Context) error {
 		)`,
 		`CREATE INDEX IF NOT EXISTS idx_billing_sessions_account ON billing_sessions(account_id)`,
 		`CREATE INDEX IF NOT EXISTS idx_billing_sessions_external ON billing_sessions(external_id)`,
+
+		// Enterprise invoicing — admin-managed postpaid accounts.
+		`CREATE TABLE IF NOT EXISTS enterprise_accounts (
+			account_id TEXT PRIMARY KEY,
+			status TEXT NOT NULL DEFAULT 'active',
+			billing_email TEXT NOT NULL DEFAULT '',
+			stripe_customer_id TEXT NOT NULL DEFAULT '',
+			cadence TEXT NOT NULL DEFAULT 'monthly',
+			terms_days INTEGER NOT NULL DEFAULT 15,
+			credit_limit_micro_usd BIGINT NOT NULL DEFAULT 0,
+			accrued_micro_usd BIGINT NOT NULL DEFAULT 0,
+			reserved_micro_usd BIGINT NOT NULL DEFAULT 0,
+			open_invoice_micro_usd BIGINT NOT NULL DEFAULT 0,
+			rounding_carry_micro_usd BIGINT NOT NULL DEFAULT 0,
+			current_period_start TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			next_invoice_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_enterprise_due ON enterprise_accounts(status, next_invoice_at)`,
+		`CREATE TABLE IF NOT EXISTS enterprise_reservations (
+			request_id TEXT PRIMARY KEY,
+			account_id TEXT NOT NULL REFERENCES enterprise_accounts(account_id),
+			amount_micro_usd BIGINT NOT NULL,
+			actual_micro_usd BIGINT NOT NULL DEFAULT 0,
+			status TEXT NOT NULL DEFAULT 'reserved',
+			created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_enterprise_reservations_account ON enterprise_reservations(account_id, created_at DESC)`,
+		`CREATE TABLE IF NOT EXISTS enterprise_invoices (
+			id TEXT PRIMARY KEY,
+			account_id TEXT NOT NULL REFERENCES enterprise_accounts(account_id),
+			stripe_invoice_id TEXT NOT NULL DEFAULT '',
+			stripe_hosted_invoice_url TEXT NOT NULL DEFAULT '',
+			stripe_invoice_pdf TEXT NOT NULL DEFAULT '',
+			status TEXT NOT NULL DEFAULT 'draft',
+			period_start TIMESTAMPTZ NOT NULL,
+			period_end TIMESTAMPTZ NOT NULL,
+			amount_micro_usd BIGINT NOT NULL,
+			amount_cents BIGINT NOT NULL,
+			terms_days INTEGER NOT NULL,
+			due_at TIMESTAMPTZ,
+			sent_at TIMESTAMPTZ,
+			paid_at TIMESTAMPTZ,
+			created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+		)`,
+		`CREATE UNIQUE INDEX IF NOT EXISTS idx_enterprise_invoices_stripe ON enterprise_invoices(stripe_invoice_id) WHERE stripe_invoice_id != ''`,
+		`CREATE INDEX IF NOT EXISTS idx_enterprise_invoices_account ON enterprise_invoices(account_id, created_at DESC)`,
 
 		// Custom pricing — per-account model price overrides
 		`CREATE TABLE IF NOT EXISTS model_prices (
@@ -1269,6 +1320,519 @@ func (s *PostgresStore) IsExternalIDProcessed(externalID string) bool {
 		externalID,
 	).Scan(&count)
 	return count > 0
+}
+
+// --- Enterprise Invoicing ---
+
+func (s *PostgresStore) UpsertEnterpriseAccount(account *EnterpriseAccount) error {
+	if account == nil || account.AccountID == "" {
+		return errors.New("enterprise account_id is required")
+	}
+	if account.CreditLimitMicroUSD < 0 ||
+		account.AccruedMicroUSD < 0 ||
+		account.ReservedMicroUSD < 0 ||
+		account.OpenInvoiceMicroUSD < 0 ||
+		account.RoundingCarryMicroUSD < 0 {
+		return errors.New("enterprise money fields cannot be negative")
+	}
+	now := time.Now()
+	if account.Status == "" {
+		account.Status = EnterpriseStatusActive
+	}
+	if account.Cadence == "" {
+		account.Cadence = EnterpriseCadenceMonthly
+	}
+	if account.CurrentPeriodStart.IsZero() {
+		account.CurrentPeriodStart = now
+	}
+	if account.NextInvoiceAt.IsZero() {
+		account.NextInvoiceAt = nextEnterpriseInvoiceAt(account.CurrentPeriodStart, account.Cadence)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, err := s.pool.Exec(ctx, `INSERT INTO enterprise_accounts (
+			account_id, status, billing_email, stripe_customer_id, cadence, terms_days,
+			credit_limit_micro_usd, accrued_micro_usd, reserved_micro_usd,
+			open_invoice_micro_usd, rounding_carry_micro_usd,
+			current_period_start, next_invoice_at, updated_at
+		) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,NOW())
+		ON CONFLICT (account_id) DO UPDATE SET
+			status = EXCLUDED.status,
+			billing_email = EXCLUDED.billing_email,
+			stripe_customer_id = EXCLUDED.stripe_customer_id,
+			cadence = EXCLUDED.cadence,
+			terms_days = EXCLUDED.terms_days,
+			credit_limit_micro_usd = EXCLUDED.credit_limit_micro_usd,
+			accrued_micro_usd = EXCLUDED.accrued_micro_usd,
+			reserved_micro_usd = EXCLUDED.reserved_micro_usd,
+			open_invoice_micro_usd = EXCLUDED.open_invoice_micro_usd,
+			rounding_carry_micro_usd = EXCLUDED.rounding_carry_micro_usd,
+			current_period_start = EXCLUDED.current_period_start,
+			next_invoice_at = EXCLUDED.next_invoice_at,
+			updated_at = NOW()`,
+		account.AccountID, account.Status, account.BillingEmail, account.StripeCustomerID,
+		account.Cadence, account.TermsDays, account.CreditLimitMicroUSD, account.AccruedMicroUSD,
+		account.ReservedMicroUSD, account.OpenInvoiceMicroUSD, account.RoundingCarryMicroUSD,
+		account.CurrentPeriodStart, account.NextInvoiceAt)
+	if err != nil {
+		return fmt.Errorf("store: upsert enterprise account: %w", err)
+	}
+	return nil
+}
+
+const enterpriseAccountColumns = `account_id, status, billing_email, stripe_customer_id,
+	cadence, terms_days, credit_limit_micro_usd, accrued_micro_usd, reserved_micro_usd,
+	open_invoice_micro_usd, rounding_carry_micro_usd, current_period_start,
+	next_invoice_at, created_at, updated_at`
+
+func scanEnterpriseAccount(row interface{ Scan(...any) error }) (*EnterpriseAccount, error) {
+	var a EnterpriseAccount
+	if err := row.Scan(&a.AccountID, &a.Status, &a.BillingEmail, &a.StripeCustomerID,
+		&a.Cadence, &a.TermsDays, &a.CreditLimitMicroUSD, &a.AccruedMicroUSD,
+		&a.ReservedMicroUSD, &a.OpenInvoiceMicroUSD, &a.RoundingCarryMicroUSD,
+		&a.CurrentPeriodStart, &a.NextInvoiceAt, &a.CreatedAt, &a.UpdatedAt); err != nil {
+		return nil, err
+	}
+	return &a, nil
+}
+
+func (s *PostgresStore) GetEnterpriseAccount(accountID string) (*EnterpriseAccount, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	row := s.pool.QueryRow(ctx, `SELECT `+enterpriseAccountColumns+` FROM enterprise_accounts WHERE account_id = $1`, accountID)
+	a, err := scanEnterpriseAccount(row)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, fmt.Errorf("%w: %q", ErrEnterpriseAccountNotFound, accountID)
+		}
+		return nil, fmt.Errorf("store: enterprise account not found: %w", err)
+	}
+	return a, nil
+}
+
+func (s *PostgresStore) ListEnterpriseAccounts() ([]EnterpriseAccount, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	rows, err := s.pool.Query(ctx, `SELECT `+enterpriseAccountColumns+` FROM enterprise_accounts ORDER BY updated_at DESC`)
+	if err != nil {
+		return nil, fmt.Errorf("store: list enterprise accounts: %w", err)
+	}
+	defer rows.Close()
+
+	var out []EnterpriseAccount
+	for rows.Next() {
+		a, err := scanEnterpriseAccount(rows)
+		if err != nil {
+			return nil, fmt.Errorf("store: scan enterprise account: %w", err)
+		}
+		out = append(out, *a)
+	}
+	return out, rows.Err()
+}
+
+func (s *PostgresStore) SetEnterpriseStripeCustomerID(accountID, stripeCustomerID string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	tag, err := s.pool.Exec(ctx, `UPDATE enterprise_accounts
+		SET stripe_customer_id = $2, updated_at = NOW()
+		WHERE account_id = $1`, accountID, stripeCustomerID)
+	if err != nil {
+		return fmt.Errorf("store: set enterprise stripe customer: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return fmt.Errorf("enterprise account %q not found", accountID)
+	}
+	return nil
+}
+
+func (s *PostgresStore) AdvanceEnterpriseInvoicePeriod(accountID string, periodStart, nextInvoiceAt time.Time) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	tag, err := s.pool.Exec(ctx, `UPDATE enterprise_accounts
+		SET current_period_start = $2, next_invoice_at = $3, updated_at = NOW()
+		WHERE account_id = $1`, accountID, periodStart, nextInvoiceAt)
+	if err != nil {
+		return fmt.Errorf("store: advance enterprise invoice period: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return fmt.Errorf("enterprise account %q not found", accountID)
+	}
+	return nil
+}
+
+func (s *PostgresStore) ReserveEnterpriseUsage(accountID, requestID string, amountMicroUSD int64) error {
+	if amountMicroUSD <= 0 {
+		return nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("store: begin enterprise reserve: %w", err)
+	}
+	defer tx.Rollback(ctx)
+
+	var existingAccountID, existingStatus string
+	err = tx.QueryRow(ctx, `SELECT account_id, status FROM enterprise_reservations WHERE request_id = $1 FOR UPDATE`, requestID).Scan(&existingAccountID, &existingStatus)
+	if err == nil {
+		if existingAccountID == accountID && existingStatus == "reserved" {
+			var existingAmount int64
+			if amountErr := tx.QueryRow(ctx, `SELECT amount_micro_usd FROM enterprise_reservations WHERE request_id = $1`, requestID).Scan(&existingAmount); amountErr != nil {
+				return fmt.Errorf("store: check enterprise reservation amount: %w", amountErr)
+			}
+			if existingAmount != amountMicroUSD {
+				return fmt.Errorf("enterprise reservation %q amount mismatch", requestID)
+			}
+			return tx.Commit(ctx)
+		}
+		if existingAccountID != accountID {
+			return fmt.Errorf("enterprise reservation %q belongs to another account", requestID)
+		}
+		return fmt.Errorf("enterprise reservation %q already %s", requestID, existingStatus)
+	}
+	if !errors.Is(err, pgx.ErrNoRows) {
+		return fmt.Errorf("store: check enterprise reservation: %w", err)
+	}
+
+	tag, err := tx.Exec(ctx, `UPDATE enterprise_accounts
+		SET reserved_micro_usd = reserved_micro_usd + $2, updated_at = NOW()
+		WHERE account_id = $1
+			AND status = 'active'
+			AND open_invoice_micro_usd + accrued_micro_usd + reserved_micro_usd + rounding_carry_micro_usd + $2 <= credit_limit_micro_usd`,
+		accountID, amountMicroUSD)
+	if err != nil {
+		return fmt.Errorf("store: reserve enterprise usage: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return fmt.Errorf("enterprise credit limit exceeded")
+	}
+
+	_, err = tx.Exec(ctx, `INSERT INTO enterprise_reservations
+		(request_id, account_id, amount_micro_usd, status)
+		VALUES ($1, $2, $3, 'reserved')`,
+		requestID, accountID, amountMicroUSD)
+	if err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+			_ = tx.Rollback(ctx)
+			var existingAccountID, status string
+			checkErr := s.pool.QueryRow(ctx, `SELECT account_id, status FROM enterprise_reservations WHERE request_id = $1`, requestID).Scan(&existingAccountID, &status)
+			if checkErr == nil && existingAccountID == accountID && status == "reserved" {
+				return nil
+			}
+			if checkErr == nil && existingAccountID != accountID {
+				return fmt.Errorf("enterprise reservation %q belongs to another account", requestID)
+			}
+			if checkErr == nil {
+				return fmt.Errorf("enterprise reservation %q already %s", requestID, status)
+			}
+		}
+		return fmt.Errorf("store: create enterprise reservation: %w", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("store: commit enterprise reserve: %w", err)
+	}
+	return nil
+}
+
+func (s *PostgresStore) FinalizeEnterpriseUsage(accountID, requestID string, actualMicroUSD int64) error {
+	if actualMicroUSD < 0 {
+		actualMicroUSD = 0
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("store: begin enterprise finalize: %w", err)
+	}
+	defer tx.Rollback(ctx)
+
+	var reserved int64
+	err = tx.QueryRow(ctx, `UPDATE enterprise_reservations
+		SET status = 'finalized', actual_micro_usd = LEAST($3, amount_micro_usd), updated_at = NOW()
+		WHERE request_id = $1 AND account_id = $2 AND status = 'reserved'
+		RETURNING amount_micro_usd`, requestID, accountID, actualMicroUSD).Scan(&reserved)
+	if err != nil {
+		return fmt.Errorf("store: finalize enterprise reservation: %w", err)
+	}
+	_, err = tx.Exec(ctx, `UPDATE enterprise_accounts
+		SET reserved_micro_usd = GREATEST(reserved_micro_usd - $2, 0),
+			accrued_micro_usd = accrued_micro_usd + LEAST($3, $2),
+			updated_at = NOW()
+		WHERE account_id = $1`, accountID, reserved, actualMicroUSD)
+	if err != nil {
+		return fmt.Errorf("store: accrue enterprise usage: %w", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("store: commit enterprise finalize: %w", err)
+	}
+	return nil
+}
+
+func (s *PostgresStore) ReleaseEnterpriseReservation(accountID, requestID string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("store: begin enterprise release: %w", err)
+	}
+	defer tx.Rollback(ctx)
+
+	var reserved int64
+	err = tx.QueryRow(ctx, `UPDATE enterprise_reservations
+		SET status = 'released', updated_at = NOW()
+		WHERE request_id = $1 AND account_id = $2 AND status = 'reserved'
+		RETURNING amount_micro_usd`, requestID, accountID).Scan(&reserved)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return tx.Commit(ctx)
+	}
+	if err != nil {
+		return fmt.Errorf("store: release enterprise reservation: %w", err)
+	}
+	_, err = tx.Exec(ctx, `UPDATE enterprise_accounts
+		SET reserved_micro_usd = GREATEST(reserved_micro_usd - $2, 0), updated_at = NOW()
+		WHERE account_id = $1`, accountID, reserved)
+	if err != nil {
+		return fmt.Errorf("store: update enterprise reserved: %w", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("store: commit enterprise release: %w", err)
+	}
+	return nil
+}
+
+func (s *PostgresStore) ListDueEnterpriseAccounts(now time.Time) ([]EnterpriseAccount, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	rows, err := s.pool.Query(ctx, `SELECT `+enterpriseAccountColumns+`
+		FROM enterprise_accounts
+		WHERE status = 'active' AND next_invoice_at <= $1
+		ORDER BY next_invoice_at ASC`, now)
+	if err != nil {
+		return nil, fmt.Errorf("store: list due enterprise accounts: %w", err)
+	}
+	defer rows.Close()
+
+	var out []EnterpriseAccount
+	for rows.Next() {
+		a, err := scanEnterpriseAccount(rows)
+		if err != nil {
+			return nil, fmt.Errorf("store: scan due enterprise account: %w", err)
+		}
+		out = append(out, *a)
+	}
+	return out, rows.Err()
+}
+
+const enterpriseInvoiceColumns = `id, account_id, stripe_invoice_id, stripe_hosted_invoice_url,
+	stripe_invoice_pdf, status, period_start, period_end, amount_micro_usd,
+	amount_cents, terms_days, due_at, sent_at, paid_at, created_at, updated_at`
+
+func scanEnterpriseInvoice(row interface{ Scan(...any) error }) (*EnterpriseInvoice, error) {
+	var inv EnterpriseInvoice
+	if err := row.Scan(&inv.ID, &inv.AccountID, &inv.StripeInvoiceID, &inv.StripeHostedInvoiceURL,
+		&inv.StripeInvoicePDF, &inv.Status, &inv.PeriodStart, &inv.PeriodEnd,
+		&inv.AmountMicroUSD, &inv.AmountCents, &inv.TermsDays, &inv.DueAt,
+		&inv.SentAt, &inv.PaidAt, &inv.CreatedAt, &inv.UpdatedAt); err != nil {
+		return nil, err
+	}
+	return &inv, nil
+}
+
+func (s *PostgresStore) CreateEnterpriseInvoice(invoice *EnterpriseInvoice) error {
+	if invoice == nil || invoice.ID == "" || invoice.AccountID == "" {
+		return errors.New("enterprise invoice id and account_id are required")
+	}
+	if invoice.AmountMicroUSD < 0 || invoice.AmountCents < 0 {
+		return errors.New("enterprise invoice amount cannot be negative")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("store: begin create enterprise invoice: %w", err)
+	}
+	defer tx.Rollback(ctx)
+
+	var existingStripeID string
+	err = tx.QueryRow(ctx, `SELECT stripe_invoice_id FROM enterprise_invoices
+		WHERE id = $1 AND account_id = $2 AND amount_micro_usd = $3 AND amount_cents = $4
+		FOR UPDATE`, invoice.ID, invoice.AccountID, invoice.AmountMicroUSD, invoice.AmountCents).Scan(&existingStripeID)
+	if errors.Is(err, pgx.ErrNoRows) {
+		_, err = tx.Exec(ctx, `INSERT INTO enterprise_invoices (
+				id, account_id, stripe_invoice_id, stripe_hosted_invoice_url,
+				stripe_invoice_pdf, status, period_start, period_end, amount_micro_usd,
+				amount_cents, terms_days, due_at, sent_at, paid_at, updated_at
+			) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,NOW())`,
+			invoice.ID, invoice.AccountID, invoice.StripeInvoiceID, invoice.StripeHostedInvoiceURL,
+			invoice.StripeInvoicePDF, invoice.Status, invoice.PeriodStart, invoice.PeriodEnd,
+			invoice.AmountMicroUSD, invoice.AmountCents, invoice.TermsDays, invoice.DueAt,
+			invoice.SentAt, invoice.PaidAt)
+	} else if err == nil && existingStripeID == "" {
+		_, err = tx.Exec(ctx, `UPDATE enterprise_invoices SET
+				stripe_invoice_id = $2,
+				stripe_hosted_invoice_url = $3,
+				stripe_invoice_pdf = $4,
+				status = $5,
+				due_at = $6,
+				sent_at = $7,
+				paid_at = $8,
+				updated_at = NOW()
+			WHERE id = $1`,
+			invoice.ID, invoice.StripeInvoiceID, invoice.StripeHostedInvoiceURL,
+			invoice.StripeInvoicePDF, invoice.Status, invoice.DueAt, invoice.SentAt, invoice.PaidAt)
+	} else if err == nil {
+		return fmt.Errorf("enterprise invoice %q already exists", invoice.ID)
+	}
+	if err != nil {
+		return fmt.Errorf("store: create enterprise invoice: %w", err)
+	}
+	_, err = tx.Exec(ctx, `UPDATE enterprise_accounts
+		SET open_invoice_micro_usd = open_invoice_micro_usd + $2,
+			rounding_carry_micro_usd = GREATEST(accrued_micro_usd + rounding_carry_micro_usd - $2, 0),
+			accrued_micro_usd = 0,
+			current_period_start = $3,
+			next_invoice_at = CASE cadence
+				WHEN 'weekly' THEN $3::timestamptz + INTERVAL '7 days'
+				WHEN 'biweekly' THEN $3::timestamptz + INTERVAL '14 days'
+				ELSE $3::timestamptz + INTERVAL '1 month'
+			END,
+			updated_at = NOW()
+		WHERE account_id = $1`,
+		invoice.AccountID, invoice.AmountMicroUSD, invoice.PeriodEnd)
+	if err != nil {
+		return fmt.Errorf("store: advance enterprise account invoice period: %w", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("store: commit create enterprise invoice: %w", err)
+	}
+	return nil
+}
+
+func (s *PostgresStore) CreateEnterpriseInvoiceDraft(invoice *EnterpriseInvoice) error {
+	if invoice == nil || invoice.ID == "" || invoice.AccountID == "" {
+		return errors.New("enterprise invoice id and account_id are required")
+	}
+	if invoice.AmountMicroUSD < 0 || invoice.AmountCents < 0 {
+		return errors.New("enterprise invoice amount cannot be negative")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, err := s.pool.Exec(ctx, `INSERT INTO enterprise_invoices (
+			id, account_id, stripe_invoice_id, stripe_hosted_invoice_url,
+			stripe_invoice_pdf, status, period_start, period_end, amount_micro_usd,
+			amount_cents, terms_days, due_at, sent_at, paid_at, updated_at
+		) VALUES ($1,$2,'','','',$3,$4,$5,$6,$7,$8,NULL,NULL,NULL,NOW())
+		ON CONFLICT (id) DO NOTHING`,
+		invoice.ID, invoice.AccountID, EnterpriseInvoiceStatusDraft, invoice.PeriodStart,
+		invoice.PeriodEnd, invoice.AmountMicroUSD, invoice.AmountCents, invoice.TermsDays)
+	if err != nil {
+		return fmt.Errorf("store: create enterprise invoice draft: %w", err)
+	}
+	return nil
+}
+
+func (s *PostgresStore) UpdateEnterpriseInvoice(invoice *EnterpriseInvoice) error {
+	if invoice == nil || invoice.ID == "" {
+		return errors.New("enterprise invoice id is required")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("store: begin update enterprise invoice: %w", err)
+	}
+	defer tx.Rollback(ctx)
+
+	var oldStatus, accountID string
+	var amountMicroUSD int64
+	if err := tx.QueryRow(ctx, `SELECT status, account_id, amount_micro_usd FROM enterprise_invoices WHERE id = $1 FOR UPDATE`, invoice.ID).Scan(&oldStatus, &accountID, &amountMicroUSD); err != nil {
+		return fmt.Errorf("store: enterprise invoice not found: %w", err)
+	}
+	newStatus := invoice.Status
+	if isEnterpriseInvoiceTerminal(oldStatus) && !isEnterpriseInvoiceTerminal(newStatus) {
+		newStatus = oldStatus
+	}
+	_, err = tx.Exec(ctx, `UPDATE enterprise_invoices SET
+			stripe_invoice_id = $2,
+			stripe_hosted_invoice_url = $3,
+			stripe_invoice_pdf = $4,
+			status = $5,
+			due_at = $6,
+			sent_at = $7,
+			paid_at = $8,
+			updated_at = NOW()
+		WHERE id = $1`,
+		invoice.ID, invoice.StripeInvoiceID, invoice.StripeHostedInvoiceURL,
+		invoice.StripeInvoicePDF, newStatus, invoice.DueAt, invoice.SentAt, invoice.PaidAt)
+	if err != nil {
+		return fmt.Errorf("store: update enterprise invoice: %w", err)
+	}
+	if !isEnterpriseInvoiceTerminal(oldStatus) && isEnterpriseInvoiceTerminal(newStatus) {
+		_, err = tx.Exec(ctx, `UPDATE enterprise_accounts
+			SET open_invoice_micro_usd = GREATEST(open_invoice_micro_usd - $2, 0), updated_at = NOW()
+			WHERE account_id = $1`, accountID, amountMicroUSD)
+		if err != nil {
+			return fmt.Errorf("store: reduce enterprise open invoices: %w", err)
+		}
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("store: commit update enterprise invoice: %w", err)
+	}
+	return nil
+}
+
+func (s *PostgresStore) GetEnterpriseInvoiceByStripeID(stripeInvoiceID string) (*EnterpriseInvoice, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	row := s.pool.QueryRow(ctx, `SELECT `+enterpriseInvoiceColumns+`
+		FROM enterprise_invoices WHERE stripe_invoice_id = $1`, stripeInvoiceID)
+	inv, err := scanEnterpriseInvoice(row)
+	if err != nil {
+		return nil, fmt.Errorf("store: enterprise invoice not found: %w", err)
+	}
+	return inv, nil
+}
+
+func (s *PostgresStore) ListEnterpriseInvoices(accountID string, limit int) ([]EnterpriseInvoice, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	query := `SELECT ` + enterpriseInvoiceColumns + ` FROM enterprise_invoices WHERE account_id = $1 ORDER BY created_at DESC`
+	args := []any{accountID}
+	if limit > 0 {
+		query += ` LIMIT $2`
+		args = append(args, limit)
+	}
+	rows, err := s.pool.Query(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("store: list enterprise invoices: %w", err)
+	}
+	defer rows.Close()
+
+	var out []EnterpriseInvoice
+	for rows.Next() {
+		inv, err := scanEnterpriseInvoice(rows)
+		if err != nil {
+			return nil, fmt.Errorf("store: scan enterprise invoice: %w", err)
+		}
+		out = append(out, *inv)
+	}
+	return out, rows.Err()
 }
 
 // --- Custom Pricing ---

--- a/coordinator/internal/store/store_test.go
+++ b/coordinator/internal/store/store_test.go
@@ -828,3 +828,249 @@ func TestGetLatestReleasePrefersHigherSemverOverNewerTimestamp(t *testing.T) {
 		t.Fatalf("latest version = %q, want %q", latest.Version, "0.3.9")
 	}
 }
+
+func TestEnterpriseReservationLifecycleAndTerms(t *testing.T) {
+	s := NewMemory("")
+	start := time.Now().Add(-24 * time.Hour).Truncate(time.Second)
+	if err := s.UpsertEnterpriseAccount(&EnterpriseAccount{
+		AccountID:           "acct-ent",
+		Status:              EnterpriseStatusActive,
+		BillingEmail:        "billing@example.com",
+		Cadence:             EnterpriseCadenceBiweekly,
+		TermsDays:           0,
+		CreditLimitMicroUSD: 1_000_000,
+		CurrentPeriodStart:  start,
+		NextInvoiceAt:       start,
+	}); err != nil {
+		t.Fatalf("UpsertEnterpriseAccount: %v", err)
+	}
+	account, err := s.GetEnterpriseAccount("acct-ent")
+	if err != nil {
+		t.Fatalf("GetEnterpriseAccount: %v", err)
+	}
+	if account.TermsDays != 0 {
+		t.Fatalf("terms_days = %d, want editable zero", account.TermsDays)
+	}
+	if err := s.ReserveEnterpriseUsage("acct-ent", "req-1", 700_000); err != nil {
+		t.Fatalf("ReserveEnterpriseUsage req-1: %v", err)
+	}
+	if err := s.ReserveEnterpriseUsage("acct-ent", "req-1", 700_000); err != nil {
+		t.Fatalf("duplicate ReserveEnterpriseUsage req-1 should be idempotent: %v", err)
+	}
+	account, _ = s.GetEnterpriseAccount("acct-ent")
+	if account.ReservedMicroUSD != 700_000 {
+		t.Fatalf("reserved after duplicate = %d, want 700000", account.ReservedMicroUSD)
+	}
+	if err := s.ReserveEnterpriseUsage("acct-ent", "req-2", 400_000); err == nil {
+		t.Fatal("expected over-limit reservation to fail")
+	}
+	if err := s.FinalizeEnterpriseUsage("acct-ent", "req-1", 250_000); err != nil {
+		t.Fatalf("FinalizeEnterpriseUsage: %v", err)
+	}
+	account, _ = s.GetEnterpriseAccount("acct-ent")
+	if account.ReservedMicroUSD != 0 || account.AccruedMicroUSD != 250_000 {
+		t.Fatalf("reserved/accrued = %d/%d, want 0/250000", account.ReservedMicroUSD, account.AccruedMicroUSD)
+	}
+	if err := s.ReserveEnterpriseUsage("acct-ent", "req-3", 300_000); err != nil {
+		t.Fatalf("ReserveEnterpriseUsage req-3: %v", err)
+	}
+	if err := s.FinalizeEnterpriseUsage("acct-ent", "req-3", 500_000); err != nil {
+		t.Fatalf("FinalizeEnterpriseUsage req-3: %v", err)
+	}
+	account, _ = s.GetEnterpriseAccount("acct-ent")
+	if account.AccruedMicroUSD != 550_000 {
+		t.Fatalf("accrued after over-actual finalize = %d, want capped 550000", account.AccruedMicroUSD)
+	}
+	if err := s.ReserveEnterpriseUsage("acct-ent", "req-4", 300_000); err != nil {
+		t.Fatalf("ReserveEnterpriseUsage req-4: %v", err)
+	}
+	if err := s.UpsertEnterpriseAccount(&EnterpriseAccount{
+		AccountID:           "acct-other",
+		Status:              EnterpriseStatusActive,
+		BillingEmail:        "other@example.com",
+		Cadence:             EnterpriseCadenceWeekly,
+		TermsDays:           15,
+		CreditLimitMicroUSD: 1_000_000,
+		CurrentPeriodStart:  start,
+		NextInvoiceAt:       start,
+	}); err != nil {
+		t.Fatalf("UpsertEnterpriseAccount other: %v", err)
+	}
+	if err := s.FinalizeEnterpriseUsage("acct-other", "req-4", 100_000); err == nil {
+		t.Fatal("expected cross-account finalize to fail")
+	}
+	if err := s.ReleaseEnterpriseReservation("acct-ent", "req-4"); err != nil {
+		t.Fatalf("ReleaseEnterpriseReservation: %v", err)
+	}
+	account, _ = s.GetEnterpriseAccount("acct-ent")
+	if account.ReservedMicroUSD != 0 {
+		t.Fatalf("reserved after release = %d, want 0", account.ReservedMicroUSD)
+	}
+
+	if err := s.UpsertEnterpriseAccount(&EnterpriseAccount{
+		AccountID:           "acct-zero",
+		Status:              EnterpriseStatusActive,
+		BillingEmail:        "zero@example.com",
+		Cadence:             EnterpriseCadenceWeekly,
+		TermsDays:           15,
+		CreditLimitMicroUSD: 0,
+		CurrentPeriodStart:  start,
+		NextInvoiceAt:       start,
+	}); err != nil {
+		t.Fatalf("UpsertEnterpriseAccount zero: %v", err)
+	}
+	if err := s.ReserveEnterpriseUsage("acct-zero", "req-zero", 1); err == nil {
+		t.Fatal("expected zero-limit Enterprise account to reject spend")
+	}
+
+	if err := s.UpsertEnterpriseAccount(&EnterpriseAccount{
+		AccountID:             "acct-carry-limit",
+		Status:                EnterpriseStatusActive,
+		BillingEmail:          "carry@example.com",
+		Cadence:               EnterpriseCadenceWeekly,
+		TermsDays:             15,
+		CreditLimitMicroUSD:   1_000_000,
+		RoundingCarryMicroUSD: 900_000,
+		CurrentPeriodStart:    start,
+		NextInvoiceAt:         start,
+	}); err != nil {
+		t.Fatalf("UpsertEnterpriseAccount carry: %v", err)
+	}
+	if err := s.ReserveEnterpriseUsage("acct-carry-limit", "req-carry", 200_000); err == nil {
+		t.Fatal("expected carry exposure to count toward credit limit")
+	}
+}
+
+func TestEnterpriseInvoiceUpdatesOpenExposureOnPayment(t *testing.T) {
+	s := NewMemory("")
+	start := time.Now().Add(-24 * time.Hour).Truncate(time.Second)
+	if err := s.UpsertEnterpriseAccount(&EnterpriseAccount{
+		AccountID:           "acct-invoice",
+		Status:              EnterpriseStatusActive,
+		BillingEmail:        "billing@example.com",
+		Cadence:             EnterpriseCadenceWeekly,
+		TermsDays:           15,
+		CreditLimitMicroUSD: 10_000_000,
+		AccruedMicroUSD:     1_250_000,
+		CurrentPeriodStart:  start,
+		NextInvoiceAt:       start,
+	}); err != nil {
+		t.Fatalf("UpsertEnterpriseAccount: %v", err)
+	}
+	inv := &EnterpriseInvoice{
+		ID:              "inv-local",
+		AccountID:       "acct-invoice",
+		StripeInvoiceID: "in_test",
+		Status:          EnterpriseInvoiceStatusOpen,
+		PeriodStart:     start,
+		PeriodEnd:       start.AddDate(0, 0, 7),
+		AmountMicroUSD:  1_250_000,
+		AmountCents:     125,
+		TermsDays:       15,
+	}
+	if err := s.CreateEnterpriseInvoice(inv); err != nil {
+		t.Fatalf("CreateEnterpriseInvoice: %v", err)
+	}
+	account, _ := s.GetEnterpriseAccount("acct-invoice")
+	if account.OpenInvoiceMicroUSD != 1_250_000 || account.AccruedMicroUSD != 0 {
+		t.Fatalf("open/accrued = %d/%d, want 1250000/0", account.OpenInvoiceMicroUSD, account.AccruedMicroUSD)
+	}
+	inv.Status = EnterpriseInvoiceStatusPaid
+	now := time.Now()
+	inv.PaidAt = &now
+	if err := s.UpdateEnterpriseInvoice(inv); err != nil {
+		t.Fatalf("UpdateEnterpriseInvoice: %v", err)
+	}
+	account, _ = s.GetEnterpriseAccount("acct-invoice")
+	if account.OpenInvoiceMicroUSD != 0 {
+		t.Fatalf("open exposure after payment = %d, want 0", account.OpenInvoiceMicroUSD)
+	}
+	inv.Status = EnterpriseInvoiceStatusOpen
+	if err := s.UpdateEnterpriseInvoice(inv); err != nil {
+		t.Fatalf("late UpdateEnterpriseInvoice: %v", err)
+	}
+	invoices, err := s.ListEnterpriseInvoices("acct-invoice", 1)
+	if err != nil {
+		t.Fatalf("ListEnterpriseInvoices: %v", err)
+	}
+	if invoices[0].Status != EnterpriseInvoiceStatusPaid {
+		t.Fatalf("late open status downgraded invoice to %q, want paid", invoices[0].Status)
+	}
+}
+
+func TestEnterpriseInvoiceRoundingCarryAndVoidExposure(t *testing.T) {
+	s := NewMemory("")
+	start := time.Now().Add(-24 * time.Hour).Truncate(time.Second)
+	if err := s.UpsertEnterpriseAccount(&EnterpriseAccount{
+		AccountID:             "acct-rounding",
+		Status:                EnterpriseStatusActive,
+		BillingEmail:          "billing@example.com",
+		Cadence:               EnterpriseCadenceWeekly,
+		TermsDays:             15,
+		CreditLimitMicroUSD:   10_000_000,
+		AccruedMicroUSD:       1_234_567,
+		RoundingCarryMicroUSD: 5_432,
+		CurrentPeriodStart:    start,
+		NextInvoiceAt:         start,
+	}); err != nil {
+		t.Fatalf("UpsertEnterpriseAccount: %v", err)
+	}
+	inv := &EnterpriseInvoice{
+		ID:              "inv-rounding",
+		AccountID:       "acct-rounding",
+		StripeInvoiceID: "in_rounding",
+		Status:          EnterpriseInvoiceStatusOpen,
+		PeriodStart:     start,
+		PeriodEnd:       start.AddDate(0, 0, 7),
+		AmountMicroUSD:  1_230_000,
+		AmountCents:     123,
+		TermsDays:       15,
+	}
+	if err := s.CreateEnterpriseInvoice(inv); err != nil {
+		t.Fatalf("CreateEnterpriseInvoice: %v", err)
+	}
+	account, _ := s.GetEnterpriseAccount("acct-rounding")
+	if account.AccruedMicroUSD != 0 || account.RoundingCarryMicroUSD != 9_999 {
+		t.Fatalf("accrued/carry = %d/%d, want 0/9999", account.AccruedMicroUSD, account.RoundingCarryMicroUSD)
+	}
+	inv.Status = EnterpriseInvoiceStatusVoid
+	if err := s.UpdateEnterpriseInvoice(inv); err != nil {
+		t.Fatalf("UpdateEnterpriseInvoice void: %v", err)
+	}
+	account, _ = s.GetEnterpriseAccount("acct-rounding")
+	if account.OpenInvoiceMicroUSD != 0 {
+		t.Fatalf("open exposure after void = %d, want 0", account.OpenInvoiceMicroUSD)
+	}
+}
+
+func TestEnterpriseSetStripeCustomerDoesNotClobberCounters(t *testing.T) {
+	s := NewMemory("")
+	start := time.Now().Add(-24 * time.Hour).Truncate(time.Second)
+	if err := s.UpsertEnterpriseAccount(&EnterpriseAccount{
+		AccountID:             "acct-customer",
+		Status:                EnterpriseStatusActive,
+		BillingEmail:          "billing@example.com",
+		Cadence:               EnterpriseCadenceWeekly,
+		TermsDays:             30,
+		CreditLimitMicroUSD:   10_000_000,
+		AccruedMicroUSD:       1_000_000,
+		ReservedMicroUSD:      2_000_000,
+		OpenInvoiceMicroUSD:   3_000_000,
+		RoundingCarryMicroUSD: 4_000,
+		CurrentPeriodStart:    start,
+		NextInvoiceAt:         start,
+	}); err != nil {
+		t.Fatalf("UpsertEnterpriseAccount: %v", err)
+	}
+	if err := s.SetEnterpriseStripeCustomerID("acct-customer", "cus_123"); err != nil {
+		t.Fatalf("SetEnterpriseStripeCustomerID: %v", err)
+	}
+	account, _ := s.GetEnterpriseAccount("acct-customer")
+	if account.StripeCustomerID != "cus_123" ||
+		account.AccruedMicroUSD != 1_000_000 ||
+		account.ReservedMicroUSD != 2_000_000 ||
+		account.OpenInvoiceMicroUSD != 3_000_000 ||
+		account.RoundingCarryMicroUSD != 4_000 {
+		t.Fatalf("account after customer update = %+v", account)
+	}
+}

--- a/provider/src/main.rs
+++ b/provider/src/main.rs
@@ -59,10 +59,6 @@ const DEFAULT_COORDINATOR_WS_URL: &str = match option_env!("DARKBLOOM_COORDINATO
     Some(v) => v,
     None => "wss://api.darkbloom.dev/ws/provider",
 };
-const DEFAULT_ENROLL_PROFILE_URL: &str = match option_env!("DARKBLOOM_ENROLL_PROFILE_URL") {
-    Some(v) => v,
-    None => "https://api.darkbloom.dev/enroll.mobileconfig",
-};
 const DEFAULT_INSTALL_URL: &str = match option_env!("DARKBLOOM_INSTALL_URL") {
     Some(v) => v,
     None => "https://api.darkbloom.dev/install.sh",
@@ -94,6 +90,52 @@ struct CatalogModel {
     architecture: String,
     description: String,
     min_ram_gb: i32,
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+struct CoordinatorAttestationResponse {
+    #[serde(default)]
+    providers: Vec<CoordinatorProviderTrust>,
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+struct CoordinatorProviderTrust {
+    #[serde(default)]
+    provider_id: String,
+    #[serde(default)]
+    serial_number: String,
+    #[serde(default)]
+    trust_level: String,
+    #[serde(default)]
+    status: String,
+    #[serde(default)]
+    mdm_verified: bool,
+    #[serde(default)]
+    acme_verified: bool,
+    #[serde(default)]
+    mda_verified: bool,
+    #[serde(default)]
+    secure_enclave: bool,
+    #[serde(default)]
+    sip_enabled: bool,
+    #[serde(default)]
+    secure_boot_enabled: bool,
+    #[serde(default)]
+    authenticated_root_enabled: bool,
+}
+
+impl CoordinatorProviderTrust {
+    fn is_online(&self) -> bool {
+        self.status.eq_ignore_ascii_case("online")
+    }
+
+    fn is_hardware_verified(&self) -> bool {
+        self.trust_level.eq_ignore_ascii_case("hardware")
+    }
+
+    fn short_provider_id(&self) -> &str {
+        self.provider_id.get(..8).unwrap_or(&self.provider_id)
+    }
 }
 
 fn default_model_type() -> String {
@@ -403,6 +445,47 @@ fn coordinator_http_base(coordinator_url: &str) -> String {
         .replace("/ws/provider", "")
         .trim_end_matches('/')
         .to_string()
+}
+
+fn prefer_provider_record(
+    a: &CoordinatorProviderTrust,
+    b: &CoordinatorProviderTrust,
+) -> std::cmp::Ordering {
+    b.is_hardware_verified()
+        .cmp(&a.is_hardware_verified())
+        .then_with(|| b.is_online().cmp(&a.is_online()))
+        .then_with(|| a.provider_id.cmp(&b.provider_id))
+}
+
+async fn fetch_coordinator_provider_trust(
+    coordinator_url: &str,
+    serial_number: &str,
+) -> Result<Vec<CoordinatorProviderTrust>> {
+    let base_url = coordinator_http_base(coordinator_url);
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(5))
+        .build()?;
+    let resp = client
+        .get(format!("{base_url}/v1/providers/attestation"))
+        .send()
+        .await
+        .with_context(|| format!("failed to query {base_url}/v1/providers/attestation"))?;
+    let status = resp.status();
+    if !status.is_success() {
+        anyhow::bail!("coordinator returned HTTP {status}");
+    }
+
+    let body: CoordinatorAttestationResponse = resp
+        .json()
+        .await
+        .context("failed to parse coordinator attestation response")?;
+    let mut providers: Vec<_> = body
+        .providers
+        .into_iter()
+        .filter(|p| p.serial_number == serial_number)
+        .collect();
+    providers.sort_by(prefer_provider_record);
+    Ok(providers)
 }
 
 fn model_cache_dir(model_id: &str) -> std::path::PathBuf {
@@ -1497,9 +1580,9 @@ enum Command {
         #[arg(long, default_value = DEFAULT_COORDINATOR_WS_URL)]
         coordinator: String,
 
-        /// MDM enrollment profile URL
-        #[arg(long, default_value = DEFAULT_ENROLL_PROFILE_URL)]
-        profile_url: String,
+        /// Legacy static MDM enrollment profile URL. Prefer the default dynamic enrollment flow.
+        #[arg(long, hide = true)]
+        profile_url: Option<String>,
 
         /// Model to serve (auto-selects if not specified)
         #[arg(long)]
@@ -1552,6 +1635,10 @@ enum Command {
         /// Coordinator URL to test connectivity
         #[arg(long, default_value = DEFAULT_COORDINATOR_HTTP_URL)]
         coordinator: String,
+
+        /// Include provider ID, serial, and coordinator trust details for support
+        #[arg(long)]
+        support: bool,
     },
 
     /// Start the provider in the background (uses existing config)
@@ -1685,7 +1772,10 @@ async fn main() -> Result<()> {
             coordinator,
         } => cmd_models(action, coordinator, model).await,
         Command::Earnings { coordinator } => cmd_earnings(coordinator).await,
-        Command::Doctor { coordinator } => cmd_doctor(coordinator).await,
+        Command::Doctor {
+            coordinator,
+            support,
+        } => cmd_doctor(coordinator, support).await,
         Command::Start {
             coordinator,
             model,
@@ -1817,7 +1907,7 @@ async fn cmd_key_status() -> Result<()> {
 
 async fn cmd_install(
     coordinator_url: String,
-    profile_url: String,
+    profile_url: Option<String>,
     model_override: Option<String>,
 ) -> Result<()> {
     println!("╔══════════════════════════════════════════╗");
@@ -1845,42 +1935,65 @@ async fn cmd_install(
     println!("  ✓ E2E key: ephemeral (generated at startup)");
     println!();
 
-    // Step 3: MDM enrollment (skip if already enrolled)
+    // Step 3: MDM enrollment profile. Local profile presence is not the same
+    // as coordinator hardware trust; doctor checks the network-side state.
     println!("Step 3/6: MDM enrollment...");
 
     let already_enrolled = security::check_mdm_enrolled();
 
     if already_enrolled {
-        println!("  ✓ Already enrolled in MDM — skipping");
+        println!("  ✓ Local MDM profile present");
+        println!("    Coordinator hardware trust will be verified after provider registration.");
     } else {
-        let profile_path = std::env::temp_dir().join("EigenInference-Enroll.mobileconfig");
-        println!("  Downloading enrollment profile...");
-        let client = reqwest::Client::new();
-        let resp = client.get(&profile_url).send().await?;
-        if !resp.status().is_success() {
-            println!(
-                "  ⚠ Could not download profile (HTTP {}). Skipping MDM enrollment.",
-                resp.status()
-            );
-            println!("    You can enroll later: darkbloom enroll");
-        } else {
-            let profile_bytes = resp.bytes().await?;
-            std::fs::write(&profile_path, &profile_bytes)?;
+        match get_serial_number() {
+            Ok(serial) => {
+                let profile_path = std::env::temp_dir()
+                    .join(format!("EigenInference-Enroll-{serial}.mobileconfig"));
+                println!("  Requesting enrollment profile...");
+                let client = reqwest::Client::new();
+                let resp = if let Some(ref legacy_url) = profile_url {
+                    client.get(legacy_url).send().await?
+                } else {
+                    let enroll_url =
+                        format!("{}/v1/enroll", coordinator_http_base(&coordinator_url));
+                    client
+                        .post(&enroll_url)
+                        .json(&serde_json::json!({"serial_number": serial}))
+                        .send()
+                        .await?
+                };
 
-            #[cfg(target_os = "macos")]
-            {
-                println!("  Opening enrollment profile...");
-                println!("  Install it in System Settings → General → Device Management");
-                println!("  (Only queries security status — no access to personal data)");
-                println!();
-                let _ = std::process::Command::new("open")
-                    .arg(&profile_path)
-                    .status();
+                if !resp.status().is_success() {
+                    println!(
+                        "  ⚠ Could not download profile (HTTP {}). Skipping MDM enrollment.",
+                        resp.status()
+                    );
+                    println!("    You can enroll later: darkbloom enroll");
+                } else {
+                    let profile_bytes = resp.bytes().await?;
+                    std::fs::write(&profile_path, &profile_bytes)?;
+
+                    #[cfg(target_os = "macos")]
+                    {
+                        println!("  Opening enrollment profile...");
+                        println!("  Install it in System Settings → General → Device Management");
+                        println!("  (Only queries security status — no access to personal data)");
+                        println!();
+                        let _ = std::process::Command::new("open")
+                            .arg(&profile_path)
+                            .status();
+                    }
+
+                    println!("  Press Enter after installing (or to skip)...");
+                    let mut input = String::new();
+                    std::io::stdin().read_line(&mut input)?;
+                    println!("  Enrollment profile opened; coordinator verification is pending.");
+                }
             }
-
-            println!("  Press Enter after installing (or to skip)...");
-            let mut input = String::new();
-            std::io::stdin().read_line(&mut input)?;
+            Err(e) => {
+                println!("  ⚠ Could not read serial number ({e}). Skipping MDM enrollment.");
+                println!("    You can enroll later: darkbloom enroll");
+            }
         }
     }
     println!();
@@ -4767,11 +4880,11 @@ async fn cmd_status() -> Result<()> {
     println!("    SE signing:     ✓ Ephemeral (per-launch)");
 
     println!(
-        "    MDM enrolled:   {}",
+        "    Local MDM:      {}",
         if security::check_mdm_enrolled() {
-            "✓ Yes (hardware trust)"
+            "✓ Profile present"
         } else {
-            "✗ No — not routable without MDM enrollment"
+            "✗ No profile found"
         }
     );
     println!();
@@ -4787,6 +4900,62 @@ async fn cmd_status() -> Result<()> {
             "✗ No — run: darkbloom login"
         }
     );
+    println!();
+
+    // Coordinator trust is the network-side source of truth for routing.
+    println!("  Coordinator trust:");
+    match get_serial_number() {
+        Ok(serial) => {
+            println!("    Serial:    {serial}");
+            match fetch_coordinator_provider_trust(DEFAULT_COORDINATOR_HTTP_URL, &serial).await {
+                Ok(records) if records.is_empty() => {
+                    println!("    Provider:  ✗ No coordinator record for this serial");
+                    println!("    Trust:     ✗ Not verified");
+                    println!(
+                        "    Next:      Start or restart the provider after installing the MDM profile"
+                    );
+                }
+                Ok(records) => {
+                    let record = &records[0];
+                    println!(
+                        "    Provider:  {} ({})",
+                        record.short_provider_id(),
+                        record.status
+                    );
+                    println!("    Trust:     {}", record.trust_level);
+                    println!(
+                        "    MDM:       {}",
+                        if record.mdm_verified {
+                            "✓ Verified"
+                        } else {
+                            "✗ Not verified"
+                        }
+                    );
+                    println!(
+                        "    MDA/ACME:  {}/{}",
+                        if record.mda_verified { "✓" } else { "✗" },
+                        if record.acme_verified { "✓" } else { "✗" }
+                    );
+                    if record.is_hardware_verified() {
+                        println!("    Trust gate: ✓ Passed");
+                    } else {
+                        println!(
+                            "    Trust gate: ✗ Not routable until coordinator verifies hardware trust"
+                        );
+                        println!(
+                            "    Next:       darkbloom stop && darkbloom start, then darkbloom doctor"
+                        );
+                    }
+                }
+                Err(e) => {
+                    println!("    Trust:     ? Could not check coordinator ({e})");
+                }
+            }
+        }
+        Err(e) => {
+            println!("    Serial:    ? Could not read serial ({e})");
+        }
+    }
     println!();
 
     // Models (catalog-filtered)
@@ -5121,12 +5290,90 @@ async fn cmd_earnings(coordinator_url: String) -> Result<()> {
     Ok(())
 }
 
-async fn cmd_doctor(coordinator_url: String) -> Result<()> {
+#[cfg(target_os = "macos")]
+fn support_command_output(program: &str, args: &[&str]) -> String {
+    match std::process::Command::new(program).args(args).output() {
+        Ok(output) => {
+            let combined = format!(
+                "{}{}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            );
+            let trimmed = combined.trim();
+            if trimmed.is_empty() {
+                "<no output>".to_string()
+            } else {
+                trimmed.lines().take(12).collect::<Vec<_>>().join("\n    ")
+            }
+        }
+        Err(e) => format!("<failed to run: {e}>"),
+    }
+}
+
+fn print_doctor_support_info(
+    coordinator_url: &str,
+    serial_number: Option<&str>,
+    local_mdm_profile: bool,
+    provider_records: &[CoordinatorProviderTrust],
+    coordinator_trust_error: Option<&str>,
+) {
+    println!();
+    println!("Support info");
+    println!("  Coordinator: {}", coordinator_http_base(coordinator_url));
+    println!("  Serial: {}", serial_number.unwrap_or("<unavailable>"));
+    println!(
+        "  Local MDM profile: {}",
+        if local_mdm_profile {
+            "present"
+        } else {
+            "not detected"
+        }
+    );
+
+    if provider_records.is_empty() {
+        println!("  Coordinator provider records: none for this serial");
+    } else {
+        println!("  Coordinator provider records:");
+        for record in provider_records {
+            println!(
+                "    {} status={} trust={} mdm={} mda={} acme={} se={} sip={} secure_boot={} root={}",
+                record.provider_id,
+                record.status,
+                record.trust_level,
+                record.mdm_verified,
+                record.mda_verified,
+                record.acme_verified,
+                record.secure_enclave,
+                record.sip_enabled,
+                record.secure_boot_enabled,
+                record.authenticated_root_enabled
+            );
+        }
+    }
+    if let Some(error) = coordinator_trust_error {
+        println!("  Coordinator trust lookup error: {error}");
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        println!("  profiles status -type enrollment:");
+        println!(
+            "    {}",
+            support_command_output("profiles", &["status", "-type", "enrollment"])
+        );
+    }
+}
+
+async fn cmd_doctor(coordinator_url: String, support: bool) -> Result<()> {
     println!("Darkbloom Doctor — System Diagnostics");
     println!();
 
     let mut issues: Vec<String> = Vec::new();
     let mut passed = 0;
+    let total_checks = 9;
+    let local_serial = get_serial_number().ok();
+    let mut provider_records: Vec<CoordinatorProviderTrust> = Vec::new();
+    let mut coordinator_trust_error: Option<String> = None;
 
     // 1. Hardware
     print!("1. Hardware detection........... ");
@@ -5191,16 +5438,17 @@ async fn cmd_doctor(coordinator_url: String) -> Result<()> {
         passed += 1;
     }
 
-    // 4. MDM enrollment
-    print!("4. MDM enrollment.............. ");
-    if security::check_mdm_enrolled() {
-        println!("✓ Enrolled");
+    // 4. Local MDM profile
+    print!("4. Local MDM profile........... ");
+    let local_mdm_profile = security::check_mdm_enrolled();
+    if local_mdm_profile {
+        println!("✓ Present");
         passed += 1;
     } else {
         #[cfg(target_os = "macos")]
         {
-            println!("✗ Not enrolled");
-            issues.push("Run: darkbloom enroll".to_string());
+            println!("✗ Not detected");
+            issues.push("Install the MDM profile: darkbloom enroll".to_string());
         }
         #[cfg(not(target_os = "macos"))]
         {
@@ -5317,9 +5565,65 @@ async fn cmd_doctor(coordinator_url: String) -> Result<()> {
         }
     }
 
+    // 9. Coordinator hardware trust
+    print!("9. Coordinator hardware trust.. ");
+    match local_serial.as_deref() {
+        Some(serial) => match fetch_coordinator_provider_trust(&coordinator_url, serial).await {
+            Ok(records) if records.is_empty() => {
+                println!("✗ No provider record for serial {serial}");
+                issues.push(
+                    "Coordinator has no provider record for this serial. Start or restart the provider after installing the MDM profile."
+                        .to_string(),
+                );
+            }
+            Ok(records) => {
+                provider_records = records;
+                let record = &provider_records[0];
+                if record.is_hardware_verified() {
+                    println!(
+                        "✓ hardware ({}, provider {})",
+                        record.status,
+                        record.short_provider_id()
+                    );
+                    passed += 1;
+                } else {
+                    println!(
+                        "✗ {} ({}, provider {})",
+                        record.trust_level,
+                        record.status,
+                        record.short_provider_id()
+                    );
+                    if local_mdm_profile {
+                        issues.push(
+                            "Local MDM profile is present, but the coordinator has not verified this serial through MDM. Run: darkbloom stop && darkbloom start, then retry darkbloom doctor."
+                                .to_string(),
+                        );
+                    } else {
+                        issues.push(
+                            "Coordinator trust is self-signed because no local MDM profile is detected. Run: darkbloom enroll."
+                                .to_string(),
+                        );
+                    }
+                }
+            }
+            Err(e) => {
+                println!("? Could not check: {e}");
+                coordinator_trust_error = Some(e.to_string());
+                issues.push(format!(
+                    "Could not check coordinator hardware trust for serial {serial}"
+                ));
+            }
+        },
+        None => {
+            println!("✗ Could not read local serial number");
+            issues
+                .push("Could not read Mac serial number for coordinator trust lookup".to_string());
+        }
+    }
+
     // Summary
     println!();
-    println!("Result: {passed}/8 checks passed");
+    println!("Result: {passed}/{total_checks} checks passed");
     if issues.is_empty() {
         println!();
         println!("All good! Start serving with: darkbloom serve");
@@ -5329,6 +5633,18 @@ async fn cmd_doctor(coordinator_url: String) -> Result<()> {
         for (i, issue) in issues.iter().enumerate() {
             println!("  {}. {}", i + 1, issue);
         }
+        println!();
+        println!("For support details, run: darkbloom doctor --support");
+    }
+
+    if support {
+        print_doctor_support_info(
+            &coordinator_url,
+            local_serial.as_deref(),
+            local_mdm_profile,
+            &provider_records,
+            coordinator_trust_error.as_deref(),
+        );
     }
 
     Ok(())
@@ -6684,6 +7000,57 @@ mod tests {
             coordinator_http_base("https://api.darkbloom.dev/"),
             "https://api.darkbloom.dev"
         );
+    }
+
+    #[test]
+    fn test_provider_trust_sort_prefers_hardware_then_online() {
+        let mut records = vec![
+            CoordinatorProviderTrust {
+                provider_id: "self-online".into(),
+                serial_number: "SERIAL".into(),
+                trust_level: "self_signed".into(),
+                status: "online".into(),
+                mdm_verified: false,
+                acme_verified: false,
+                mda_verified: false,
+                secure_enclave: true,
+                sip_enabled: true,
+                secure_boot_enabled: true,
+                authenticated_root_enabled: true,
+            },
+            CoordinatorProviderTrust {
+                provider_id: "hardware-offline".into(),
+                serial_number: "SERIAL".into(),
+                trust_level: "hardware".into(),
+                status: "offline".into(),
+                mdm_verified: true,
+                acme_verified: false,
+                mda_verified: false,
+                secure_enclave: true,
+                sip_enabled: true,
+                secure_boot_enabled: true,
+                authenticated_root_enabled: true,
+            },
+            CoordinatorProviderTrust {
+                provider_id: "hardware-online".into(),
+                serial_number: "SERIAL".into(),
+                trust_level: "hardware".into(),
+                status: "online".into(),
+                mdm_verified: true,
+                acme_verified: false,
+                mda_verified: false,
+                secure_enclave: true,
+                sip_enabled: true,
+                secure_boot_enabled: true,
+                authenticated_root_enabled: true,
+            },
+        ];
+
+        records.sort_by(prefer_provider_record);
+
+        assert_eq!(records[0].provider_id, "hardware-online");
+        assert_eq!(records[1].provider_id, "hardware-offline");
+        assert_eq!(records[2].provider_id, "self-online");
     }
 
     #[test]

--- a/scripts/admin.sh
+++ b/scripts/admin.sh
@@ -10,6 +10,7 @@ set -euo pipefail
 #   ./scripts/admin.sh releases list            # List all releases
 #   ./scripts/admin.sh releases deactivate 0.2.0  # Deactivate a version
 #   ./scripts/admin.sh models list              # List model catalog
+#   ./scripts/admin.sh enterprise list          # List Enterprise accounts
 #   ./scripts/admin.sh raw GET /v1/admin/releases  # Raw API call
 #
 # The admin token is stored at ~/.darkbloom/admin_token and reused until it expires.
@@ -109,6 +110,83 @@ cmd_models_list() {
     authed_curl "$COORDINATOR_URL/v1/admin/models" | python3 -m json.tool
 }
 
+cmd_enterprise_list() {
+    authed_curl "$COORDINATOR_URL/v1/admin/enterprise/accounts" | python3 -m json.tool
+}
+
+cmd_enterprise_set() {
+    local account_id=""
+    local email=""
+    local cadence=""
+    local terms_days=""
+    local credit_limit_usd=""
+    local status=""
+    local stripe_customer_id=""
+
+    while [ "$#" -gt 0 ]; do
+        case "$1" in
+            --account-id) account_id="${2:-}"; shift 2 ;;
+            --email) email="${2:-}"; shift 2 ;;
+            --cadence) cadence="${2:-}"; shift 2 ;;
+            --terms-days) terms_days="${2:-}"; shift 2 ;;
+            --credit-limit-usd) credit_limit_usd="${2:-}"; shift 2 ;;
+            --status) status="${2:-}"; shift 2 ;;
+            --stripe-customer-id) stripe_customer_id="${2:-}"; shift 2 ;;
+            *) echo "Unknown enterprise set option: $1" >&2; exit 1 ;;
+        esac
+    done
+    if [ -z "$account_id" ] || [ -z "$email" ] || [ -z "$credit_limit_usd" ]; then
+        echo "Usage: $0 enterprise set --account-id <acct> --email <billing@email> --credit-limit-usd <usd> [--cadence weekly|biweekly|monthly] [--terms-days 15] [--status active|disabled] [--stripe-customer-id cus_...]" >&2
+        exit 1
+    fi
+
+    local credit_micro
+    credit_micro=$(python3 - "$credit_limit_usd" <<'PY'
+import decimal, sys
+v = decimal.Decimal(sys.argv[1])
+print(int(v * decimal.Decimal(1000000)))
+PY
+)
+    local body
+    body=$(python3 - "$account_id" "$email" "$cadence" "$terms_days" "$credit_micro" "$status" "$stripe_customer_id" <<'PY'
+import json, sys
+account_id, email, cadence, terms_days, credit_micro, status, stripe_customer_id = sys.argv[1:]
+body = {
+    "account_id": account_id,
+    "billing_email": email,
+    "credit_limit_micro_usd": int(credit_micro),
+}
+if cadence:
+    body["cadence"] = cadence
+if status:
+    body["status"] = status
+if terms_days:
+    body["terms_days"] = int(terms_days)
+if stripe_customer_id:
+    body["stripe_customer_id"] = stripe_customer_id
+print(json.dumps(body))
+PY
+)
+    authed_curl -X PUT "$COORDINATOR_URL/v1/admin/enterprise/account" \
+        -H "Content-Type: application/json" \
+        -d "$body" | python3 -m json.tool
+}
+
+cmd_enterprise_run_invoices() {
+    local account_id="${1:-}"
+    local body="{}"
+    if [ -n "$account_id" ]; then
+        body=$(python3 - "$account_id" <<'PY'
+import json, sys
+print(json.dumps({"account_id": sys.argv[1]}))
+PY
+)
+    fi
+    authed_curl -X POST "$COORDINATOR_URL/v1/admin/enterprise/invoices/run" \
+        -H "Content-Type: application/json" \
+        -d "$body" | python3 -m json.tool
+}
+
 cmd_raw() {
     local method="${1:?Usage: $0 raw <METHOD> <path> [body]}"
     local path="${2:?Usage: $0 raw <METHOD> <path> [body]}"
@@ -147,6 +225,14 @@ case "${1:-help}" in
             *) echo "Usage: $0 models [list]" ;;
         esac
         ;;
+    enterprise)
+        case "${2:-list}" in
+            list) cmd_enterprise_list ;;
+            set) shift 2; cmd_enterprise_set "$@" ;;
+            run-invoices) cmd_enterprise_run_invoices "${3:-}" ;;
+            *) echo "Usage: $0 enterprise [list|set|run-invoices]" ;;
+        esac
+        ;;
     raw)
         cmd_raw "${2:-}" "${3:-}" "${4:-}"
         ;;
@@ -160,6 +246,9 @@ case "${1:-help}" in
         echo "  releases latest [platform]     Show latest active release"
         echo "  releases deactivate <version>  Deactivate a release"
         echo "  models list                    List model catalog"
+        echo "  enterprise list                List Enterprise accounts"
+        echo "  enterprise set --account-id <acct> --email <email> --credit-limit-usd <usd> [--cadence monthly] [--terms-days 15]"
+        echo "  enterprise run-invoices [acct] Generate due Enterprise invoices"
         echo "  raw <METHOD> <path> [body]     Raw API call with auth"
         echo ""
         echo "Environment:"


### PR DESCRIPTION
## Summary
- Add admin-gated Enterprise postpaid billing with cadence, editable Net terms, credit limits, reservations, accrual, rounding carry, and invoice state.
- Wire Enterprise billing through inference paths so active Enterprise accounts bypass prepaid debit while completed usage accrues postpaid and provider/platform/referral accounting still runs.
- Add Stripe invoice/customer support, invoice webhook handling, admin/user APIs, console billing display, and `scripts/admin.sh enterprise` helpers including `--terms-days`.
- Add focused store, billing, API, and console tests for Enterprise setup, reservation/cap behavior, invoice lifecycle, terms validation, and UI/status rendering.

## Review hardening
- Fail closed on Enterprise lookup errors and enforce `open invoices + accrued + reserved + rounding carry + estimate <= credit_limit`.
- Make reservations idempotent by account/amount, cap finalized actuals to reserved amounts, and release exposure exactly once on terminal invoice states.
- Persist local draft invoices before Stripe side effects and include pending invoice items when creating Stripe invoices.
- Preserve omitted admin update fields, reject malformed invoice-run JSON, and keep below-cent accrued usage carried forward.

## Validation
- `cd coordinator && GOCACHE=/tmp/go-build go test ./internal/store ./internal/billing ./internal/api`
- `cd coordinator && GOCACHE=/tmp/go-build go test -count=1 ./cmd/coordinator`
- `cd console-ui && npm test -- billing`
- `cd console-ui && npx eslint src/ __tests__/billing-enterprise.test.tsx` (passes with existing warnings, 0 errors)
- `git diff --check`

## Notes
- Draft PR because this is a broad billing stack change and should get human product/security review before merge.
- Live Postgres integration was not run because `DATABASE_URL` is not configured in this worktree.