### PR TITLE
fix: allow Swift providers without Python privacy caps

### DIFF
--- a/coordinator/internal/registry/registry.go
+++ b/coordinator/internal/registry/registry.go
@@ -182,11 +182,24 @@ func providerSupportsPrivateTextLocked(p *Provider) bool {
 	if caps == nil {
 		return false
 	}
-	// TextBackendInprocess, TextProxyDisabled, PythonRuntimeLocked,
-	// DangerousModulesBlocked, AntiDebugEnabled, CoreDumpsDisabled, EnvScrubbed
-	// remain provider-attested. They are gated by RuntimeManifestChecked
-	// (coordinator verifies the runtime binary hashes match known-good) and
-	// ChallengeVerifiedSIP (coordinator independently checks SIP status).
+	// TextBackendInprocess, TextProxyDisabled, AntiDebugEnabled,
+	// CoreDumpsDisabled, and EnvScrubbed remain provider-attested. They are
+	// gated by RuntimeManifestChecked (coordinator verifies the runtime/binary
+	// hashes match known-good) and ChallengeVerifiedSIP (coordinator
+	// independently checks SIP status).
+	//
+	// Swift providers do not embed or proxy through a Python runtime, so the
+	// PythonRuntimeLocked and DangerousModulesBlocked invariants are not
+	// meaningful for backend == "mlx-swift". Preserve those checks for the
+	// legacy inprocess-mlx backend, where Python/vllm runtime isolation is part
+	// of the privacy boundary.
+	if BackendUsesSwiftRuntime(p.Backend) {
+		return caps.TextBackendInprocess &&
+			caps.TextProxyDisabled &&
+			caps.AntiDebugEnabled &&
+			caps.CoreDumpsDisabled &&
+			caps.EnvScrubbed
+	}
 	return caps.TextBackendInprocess &&
 		caps.TextProxyDisabled &&
 		caps.PythonRuntimeLocked &&

--- a/coordinator/internal/registry/registry_test.go
+++ b/coordinator/internal/registry/registry_test.go
@@ -156,6 +156,45 @@ func TestSwiftProviderRequiresRuntimeManifestCheck(t *testing.T) {
 	}
 }
 
+func TestSwiftProviderDoesNotRequirePythonPrivacyCaps(t *testing.T) {
+	reg := New(testLogger())
+	msg := testRegisterMessage()
+	msg.Backend = BackendMLXSwift
+	msg.PrivacyCapabilities.PythonRuntimeLocked = false
+	msg.PrivacyCapabilities.DangerousModulesBlocked = false
+
+	p := reg.Register("p-swift-no-python", nil, msg)
+	p.TrustLevel = TrustHardware
+	p.LastChallengeVerified = time.Now()
+	p.ChallengeVerifiedSIP = true
+	p.RuntimeVerified = true
+	p.RuntimeManifestChecked = true
+
+	found := reg.FindProvider("mlx-community/Qwen3.5-9B-Instruct-4bit")
+	if found == nil {
+		t.Fatal("swift provider should not require Python-specific privacy capabilities")
+	}
+}
+
+func TestLegacyMLXProviderRequiresPythonPrivacyCaps(t *testing.T) {
+	reg := New(testLogger())
+	msg := testRegisterMessage()
+	msg.PrivacyCapabilities.PythonRuntimeLocked = false
+	msg.PrivacyCapabilities.DangerousModulesBlocked = false
+
+	p := reg.Register("p-legacy-no-python-caps", nil, msg)
+	p.TrustLevel = TrustHardware
+	p.LastChallengeVerified = time.Now()
+	p.ChallengeVerifiedSIP = true
+	p.RuntimeVerified = true
+	p.RuntimeManifestChecked = true
+
+	found := reg.FindProvider("mlx-community/Qwen3.5-9B-Instruct-4bit")
+	if found != nil {
+		t.Fatal("legacy inprocess-mlx provider should still require Python privacy capabilities")
+	}
+}
+
 func TestProviderWithoutChallengeVerifiedSIPExcluded(t *testing.T) {
 	reg := New(testLogger())
 	msg := testRegisterMessage()


### PR DESCRIPTION
## Summary

Fixes the Swift provider private-text routability gate uncovered during cross-device E2E profiling against #110.

Swift providers report `backend == "mlx-swift"` and correctly set Python-specific privacy capability fields to false because they do not embed a Python runtime:

- `python_runtime_locked=false`
- `dangerous_modules_blocked=false`

The coordinator was still requiring those fields for all private-text backends, which made Swift providers connect, pass runtime manifest verification, pass attestation challenge verification, and appear in `/v1/providers/attestation` — but remain absent from `/v1/models` and unroutable.

This keeps the Python runtime checks for the legacy `inprocess-mlx` backend and uses the Swift-relevant invariants for `mlx-swift`:

- in-process text backend
- no proxy
- anti-debug enabled
- core dumps disabled
- env scrubbed
- runtime manifest checked
- coordinator-verified SIP

## Validation

- `go test ./internal/registry -run 'SwiftProvider|LegacyMLXProviderRequiresPythonPrivacyCaps|ProviderWithoutManifestCheck|ProviderPartialPrivacyCaps' -v`
- `go test ./internal/registry ./internal/api -v`
- `git diff --check`

## Context

This is targeted at PR #110 (`swift-provider`). The issue reproduced on the two-machine rig with the Swift provider on the Mac Mini: `/health` showed a connected provider and attestation/runtime verification passed, but `/v1/models` was empty until the coordinator privacy gate became backend-aware.
