### PR TITLE
security: remove hard-coded API key from benchmark scripts

### DIFF
--- a/scripts/benchmark-light.py
+++ b/scripts/benchmark-light.py
@@ -2,11 +2,14 @@
 """Lightweight continuous load test — short requests, 3 in parallel."""
 
 import asyncio
+import os
 import time
 import aiohttp
 
-BASE_URL = "https://api.darkbloom.dev/v1"
-API_KEY = "eigeninference-e47e7299dc7d798ea1bcd706e0f780cb9a98536c7d2124a067f0e40e2b3b5b44"
+BASE_URL = os.environ.get("DARKBLOOM_API_URL", "https://api.darkbloom.dev/v1")
+API_KEY = os.environ.get("DARKBLOOM_API_KEY", "")
+if not API_KEY:
+    raise SystemExit("DARKBLOOM_API_KEY environment variable is required")
 
 MODELS = [
     "mlx-community/gemma-4-26b-a4b-it-8bit",

--- a/scripts/benchmark-models.py
+++ b/scripts/benchmark-models.py
@@ -6,13 +6,16 @@ measures latency and token throughput.
 """
 
 import asyncio
+import os
 import time
 import json
 import aiohttp
 import argparse
 
-BASE_URL = "https://api.darkbloom.dev/v1"
-API_KEY = "eigeninference-e47e7299dc7d798ea1bcd706e0f780cb9a98536c7d2124a067f0e40e2b3b5b44"
+BASE_URL = os.environ.get("DARKBLOOM_API_URL", "https://api.darkbloom.dev/v1")
+API_KEY = os.environ.get("DARKBLOOM_API_KEY", "")
+if not API_KEY:
+    raise SystemExit("DARKBLOOM_API_KEY environment variable is required")
 
 MODELS = [
     "mlx-community/gemma-4-26b-a4b-it-8bit",


### PR DESCRIPTION
## Summary

- Removes live `eigeninference-...` API key hard-coded in `scripts/benchmark-models.py` and `scripts/benchmark-light.py`
- Key is now read from `DARKBLOOM_API_KEY` environment variable; script exits immediately if unset
- `DARKBLOOM_API_URL` can optionally override the base URL

## Impact

Any user with read access to the repo could authenticate as a live service account. The key grants access to backend APIs.

**The committed key should be revoked immediately** regardless of this PR.

## Test plan

- [ ] Revoke the committed key in the Darkbloom dashboard / API key management
- [ ] Run `DARKBLOOM_API_KEY=<new-key> python3 scripts/benchmark-models.py` to verify it works
- [ ] Run `python3 scripts/benchmark-models.py` with no env var set and verify it exits with an error message