### PR TITLE
security: remove client-controlled coordinator URL (SSRF)

### DIFF
--- a/console-ui/src/app/api/payments/stripe/checkout/route.ts
+++ b/console-ui/src/app/api/payments/stripe/checkout/route.ts
@@ -7,7 +7,7 @@ import { NextRequest, NextResponse } from "next/server";
 const DEFAULT_COORD = process.env.NEXT_PUBLIC_COORDINATOR_URL || "https://api.darkbloom.dev";
 
 export async function POST(req: NextRequest) {
-  const coordUrl = req.headers.get("x-coordinator-url") || DEFAULT_COORD;
+  const coordUrl = DEFAULT_COORD;
 
   let authHeader = req.headers.get("authorization") || "";
   if (!authHeader) {

--- a/console-ui/src/app/api/payments/stripe/onboard/route.ts
+++ b/console-ui/src/app/api/payments/stripe/onboard/route.ts
@@ -7,7 +7,7 @@ import { NextRequest, NextResponse } from "next/server";
 const DEFAULT_COORD = process.env.NEXT_PUBLIC_COORDINATOR_URL || "https://api.darkbloom.dev";
 
 export async function POST(req: NextRequest) {
-  const coordUrl = req.headers.get("x-coordinator-url") || DEFAULT_COORD;
+  const coordUrl = DEFAULT_COORD;
 
   let authHeader = req.headers.get("authorization") || "";
   if (!authHeader) {

--- a/console-ui/src/app/api/payments/stripe/status/route.ts
+++ b/console-ui/src/app/api/payments/stripe/status/route.ts
@@ -6,7 +6,7 @@ import { NextRequest, NextResponse } from "next/server";
 const DEFAULT_COORD = process.env.NEXT_PUBLIC_COORDINATOR_URL || "https://api.darkbloom.dev";
 
 export async function GET(req: NextRequest) {
-  const coordUrl = req.headers.get("x-coordinator-url") || DEFAULT_COORD;
+  const coordUrl = DEFAULT_COORD;
 
   let authHeader = req.headers.get("authorization") || "";
   if (!authHeader) {

--- a/console-ui/src/app/api/payments/withdraw/stripe/route.ts
+++ b/console-ui/src/app/api/payments/withdraw/stripe/route.ts
@@ -7,7 +7,7 @@ import { NextRequest, NextResponse } from "next/server";
 const DEFAULT_COORD = process.env.NEXT_PUBLIC_COORDINATOR_URL || "https://api.darkbloom.dev";
 
 export async function POST(req: NextRequest) {
-  const coordUrl = req.headers.get("x-coordinator-url") || DEFAULT_COORD;
+  const coordUrl = DEFAULT_COORD;
 
   let authHeader = req.headers.get("authorization") || "";
   if (!authHeader) {

--- a/console-ui/src/app/api/telemetry/route.ts
+++ b/console-ui/src/app/api/telemetry/route.ts
@@ -11,7 +11,7 @@ const MAX_BODY = 64 * 1024;
 export const runtime = "nodejs";
 
 export async function POST(req: NextRequest) {
-  const coordUrl = req.headers.get("x-coordinator-url") || DEFAULT_COORD;
+  const coordUrl = DEFAULT_COORD;
 
   // Read with explicit size cap.
   const raw = await req.text();


### PR DESCRIPTION
## Summary

- All 5 console-ui API proxy routes read `x-coordinator-url` from the request and forwarded Privy session tokens / cookies to that arbitrary URL
- An attacker sending a crafted request could exfiltrate bearer tokens to any server they control
- Fix: remove the header read entirely; all routes now unconditionally use `DEFAULT_COORD` (server-side env var)

**Affected routes:**
- `POST /api/payments/withdraw/stripe`
- `POST /api/payments/stripe/checkout`
- `POST /api/payments/stripe/onboard`
- `GET /api/payments/stripe/status`
- `POST /api/telemetry`

## Test plan

- [ ] Verify billing flows still work end-to-end (checkout, onboard, status, withdraw)
- [ ] Verify telemetry still reaches the coordinator
- [ ] Confirm that sending `x-coordinator-url: https://evil.example.com` in a request no longer causes auth headers to be forwarded there