### PR TITLE
fix: return verification failure when Apple root CA is nil in MDA cert chain

### DIFF
--- a/coordinator/internal/attestation/mda.go
+++ b/coordinator/internal/attestation/mda.go
@@ -202,26 +202,31 @@ func VerifyMDACertChain(certChainPEM []byte, appleRootCA *x509.Certificate) (*MD
 
 	result := &MDAResult{}
 
-	// When a root CA is provided, verify the certificate chain.
-	// When nil, skip chain verification and just parse OIDs.
-	if appleRootCA != nil {
-		roots := x509.NewCertPool()
-		roots.AddCert(appleRootCA)
+	// A nil root means no trust anchor is available — return a parsed-only
+	// result with Valid=false so callers cannot accidentally treat unverified
+	// chains as trusted.
+	if appleRootCA == nil {
+		result.Error = "no root CA provided; chain verification skipped"
+		result.DeviceSerial = leaf.Subject.SerialNumber
+		return result, nil
+	}
 
-		intPool := x509.NewCertPool()
-		for _, ic := range intermediatesCerts {
-			intPool.AddCert(ic)
-		}
+	roots := x509.NewCertPool()
+	roots.AddCert(appleRootCA)
 
-		opts := x509.VerifyOptions{
-			Roots:         roots,
-			Intermediates: intPool,
-		}
+	intPool := x509.NewCertPool()
+	for _, ic := range intermediatesCerts {
+		intPool.AddCert(ic)
+	}
 
-		if _, err := leaf.Verify(opts); err != nil {
-			result.Error = fmt.Sprintf("certificate chain verification failed: %v", err)
-			return result, nil
-		}
+	opts := x509.VerifyOptions{
+		Roots:         roots,
+		Intermediates: intPool,
+	}
+
+	if _, err := leaf.Verify(opts); err != nil {
+		result.Error = fmt.Sprintf("certificate chain verification failed: %v", err)
+		return result, nil
 	}
 
 	result.Valid = true

--- a/coordinator/internal/attestation/mda_test.go
+++ b/coordinator/internal/attestation/mda_test.go
@@ -221,7 +221,8 @@ func TestVerifyMDACertChainWrongRoot(t *testing.T) {
 }
 
 func TestVerifyMDACertChainNilRoot(t *testing.T) {
-	// Without a root CA, the function should still parse OIDs but skip chain verification.
+	// Without a root CA no trust anchor is available; the result must be
+	// invalid so callers cannot treat an unverified chain as trusted.
 	certPEM, _ := createTestMDACert(t, false, true, true)
 
 	result, err := VerifyMDACertChain(certPEM, nil)
@@ -229,18 +230,11 @@ func TestVerifyMDACertChainNilRoot(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if !result.Valid {
-		t.Fatalf("expected valid result without root CA, got error: %s", result.Error)
+	if result.Valid {
+		t.Fatal("expected Valid=false when no root CA is provided")
 	}
-
-	if result.SIPEnabled {
-		t.Error("expected SIPEnabled = false")
-	}
-	if !result.SecureBootEnabled {
-		t.Error("expected SecureBootEnabled = true")
-	}
-	if !result.ThirdPartyKexts {
-		t.Error("expected ThirdPartyKexts = true")
+	if result.Error == "" {
+		t.Error("expected a non-empty Error explaining why validation was skipped")
 	}
 }
 


### PR DESCRIPTION
## Summary
- `mda.go`: when `appleRootCA == nil` (the pool contains no root cert), return `Valid=false` with a descriptive error instead of silently falling through to `Valid=true`
- `mda_test.go`: updated `TestVerifyMDACertChainNilRoot` to assert `Valid=false`

## Security impact
Before this fix an attestation request with a crafted cert chain could pass MDA verification when the Apple root CA pool was empty (e.g., cert file missing or misconfigured), granting `mda_verified` trust to an unattesteddevice. The fix ensures an empty root pool is a hard failure.

## Test plan
- [ ] `go test ./internal/attestation/...`
- [ ] Verify `TestVerifyMDACertChainNilRoot` now passes (was asserting wrong direction)