### PR TITLE
fix: guard nonce slice bounds to prevent panic on short nonce string

### DIFF
--- a/coordinator/internal/api/provider.go
+++ b/coordinator/internal/api/provider.go
@@ -502,7 +502,11 @@ func (s *Server) handleAttestationResponse(providerID string, provider *registry
 
 	pc := tracker.remove(msg.Nonce)
 	if pc == nil {
-		s.logger.Warn("attestation response for unknown challenge", "provider_id", providerID, "nonce", msg.Nonce[:8]+"...")
+		nonce := msg.Nonce
+		if len(nonce) > 8 {
+			nonce = nonce[:8]
+		}
+		s.logger.Warn("attestation response for unknown challenge", "provider_id", providerID, "nonce", nonce+"...")
 		return
 	}
 


### PR DESCRIPTION
## Summary
- `coordinator/internal/api/provider.go`: added a length check before truncating the nonce for logging — `if len(nonce) > 8 { nonce = nonce[:8] }` — to prevent a slice-bounds panic when a short or empty nonce is received

## Security impact
A malicious provider (or fuzzer) could send an empty or single-character nonce string. The previous unconditional `nonce[:8]` slice would panic with an index-out-of-range, crashing the coordinator goroutine and enabling a denial-of-service via any connected provider WebSocket.

## Test plan
- [ ] `go test ./internal/api/...`
- [ ] Send a registration message with an empty nonce and verify the coordinator handles it gracefully