### PR TITLE
fix: redeem invite code and credit account in a single atomic transaction

### DIFF
--- a/coordinator/internal/api/invite_handlers.go
+++ b/coordinator/internal/api/invite_handlers.go
@@ -190,8 +190,20 @@ func (s *Server) handleRedeemInviteCode(w http.ResponseWriter, r *http.Request) 
 	// Atomically redeem the invite code and credit the balance in one operation.
 	// This prevents the invite being consumed without the credit landing.
 	if err := s.store.RedeemInviteCodeAndCredit(code, accountID, ic.AmountMicroUSD, store.LedgerInviteCredit, "invite:"+code); err != nil {
-		s.logger.Error("failed to redeem invite code", "account", accountID, "code", code, "error", err)
-		writeJSON(w, http.StatusBadRequest, errorResponse("invalid_request_error", err.Error()))
+		msg := err.Error()
+		// Classify user-visible validation errors (400) vs server errors (500).
+		// The store returns these specific messages for invalid/exhausted codes.
+		isUserError := strings.Contains(msg, "already redeemed") ||
+			strings.Contains(msg, "inactive") ||
+			strings.Contains(msg, "expired") ||
+			strings.Contains(msg, "max uses") ||
+			strings.Contains(msg, "not found")
+		if isUserError {
+			writeJSON(w, http.StatusBadRequest, errorResponse("invalid_request_error", msg))
+		} else {
+			s.logger.Error("failed to redeem invite code", "account", accountID, "code", code, "error", err)
+			writeJSON(w, http.StatusInternalServerError, errorResponse("internal_error", "failed to apply invite credit"))
+		}
 		return
 	}
 

--- a/coordinator/internal/api/invite_handlers.go
+++ b/coordinator/internal/api/invite_handlers.go
@@ -180,23 +180,18 @@ func (s *Server) handleRedeemInviteCode(w http.ResponseWriter, r *http.Request) 
 
 	accountID := consumerKeyFromContext(r.Context())
 
-	// Get the invite code to know the amount
+	// Get the invite code to know the amount.
 	ic, err := s.store.GetInviteCode(code)
 	if err != nil {
 		writeJSON(w, http.StatusNotFound, errorResponse("not_found", "invalid invite code"))
 		return
 	}
 
-	// Redeem atomically (checks active, expiry, max uses, double-redemption)
-	if err := s.store.RedeemInviteCode(code, accountID); err != nil {
+	// Atomically redeem the invite code and credit the balance in one operation.
+	// This prevents the invite being consumed without the credit landing.
+	if err := s.store.RedeemInviteCodeAndCredit(code, accountID, ic.AmountMicroUSD, store.LedgerInviteCredit, "invite:"+code); err != nil {
+		s.logger.Error("failed to redeem invite code", "account", accountID, "code", code, "error", err)
 		writeJSON(w, http.StatusBadRequest, errorResponse("invalid_request_error", err.Error()))
-		return
-	}
-
-	// Credit the user's balance
-	if err := s.store.Credit(accountID, ic.AmountMicroUSD, store.LedgerInviteCredit, "invite:"+code); err != nil {
-		s.logger.Error("failed to credit invite balance", "account", accountID, "code", code, "error", err)
-		writeJSON(w, http.StatusInternalServerError, errorResponse("internal_error", "failed to credit balance"))
 		return
 	}
 

--- a/coordinator/internal/store/interface.go
+++ b/coordinator/internal/store/interface.go
@@ -255,6 +255,11 @@ type Store interface {
 	// Returns error if code is inactive, expired, fully used, or already redeemed by this account.
 	RedeemInviteCode(code string, accountID string) error
 
+	// RedeemInviteCodeAndCredit atomically redeems the invite code and credits
+	// the account in a single transaction. Prevents the invite being consumed
+	// without the credit landing when the credit step fails separately.
+	RedeemInviteCodeAndCredit(code string, accountID string, amountMicroUSD int64, entryType LedgerEntryType, reference string) error
+
 	// HasRedeemedInviteCode checks if an account has already redeemed a specific code.
 	HasRedeemedInviteCode(code, accountID string) bool
 

--- a/coordinator/internal/store/memory.go
+++ b/coordinator/internal/store/memory.go
@@ -1235,6 +1235,43 @@ func (s *MemoryStore) RedeemInviteCode(code string, accountID string) error {
 	return nil
 }
 
+func (s *MemoryStore) RedeemInviteCodeAndCredit(code string, accountID string, amountMicroUSD int64, entryType LedgerEntryType, reference string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	ic, ok := s.inviteCodes[code]
+	if !ok {
+		return fmt.Errorf("invite code %q not found", code)
+	}
+	if !ic.Active {
+		return fmt.Errorf("invite code %q is inactive", code)
+	}
+	if ic.ExpiresAt != nil && time.Now().After(*ic.ExpiresAt) {
+		return fmt.Errorf("invite code %q has expired", code)
+	}
+	if ic.MaxUses > 0 && ic.UsedCount >= ic.MaxUses {
+		return fmt.Errorf("invite code %q has reached max uses", code)
+	}
+	if acctCodes, ok := s.accountRedemptions[accountID]; ok && acctCodes[code] {
+		return fmt.Errorf("account has already redeemed code %q", code)
+	}
+
+	ic.UsedCount++
+	s.inviteRedemptions[code] = append(s.inviteRedemptions[code], InviteRedemption{
+		Code:      code,
+		AccountID: accountID,
+		CreatedAt: time.Now(),
+	})
+	if s.accountRedemptions[accountID] == nil {
+		s.accountRedemptions[accountID] = make(map[string]bool)
+	}
+	s.accountRedemptions[accountID][code] = true
+
+	// Credit in the same lock scope so the two operations are atomic.
+	s.creditLocked(accountID, amountMicroUSD, entryType, reference, time.Now())
+	return nil
+}
+
 func (s *MemoryStore) HasRedeemedInviteCode(code, accountID string) bool {
 	s.mu.RLock()
 	defer s.mu.RUnlock()

--- a/coordinator/internal/store/postgres.go
+++ b/coordinator/internal/store/postgres.go
@@ -2011,6 +2011,60 @@ func (s *PostgresStore) RedeemInviteCode(code string, accountID string) error {
 	return tx.Commit(ctx)
 }
 
+func (s *PostgresStore) RedeemInviteCodeAndCredit(code string, accountID string, amountMicroUSD int64, entryType LedgerEntryType, reference string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("store: begin tx: %w", err)
+	}
+	defer tx.Rollback(ctx)
+
+	// Lock and validate the invite code.
+	var ic InviteCode
+	err = tx.QueryRow(ctx,
+		`SELECT code, amount_micro_usd, max_uses, used_count, active, expires_at
+		 FROM invite_codes WHERE code = $1 FOR UPDATE`, code,
+	).Scan(&ic.Code, &ic.AmountMicroUSD, &ic.MaxUses, &ic.UsedCount, &ic.Active, &ic.ExpiresAt)
+	if err != nil {
+		return fmt.Errorf("invite code %q not found", code)
+	}
+	if !ic.Active {
+		return fmt.Errorf("invite code %q is inactive", code)
+	}
+	if ic.ExpiresAt != nil && time.Now().After(*ic.ExpiresAt) {
+		return fmt.Errorf("invite code %q has expired", code)
+	}
+	if ic.MaxUses > 0 && ic.UsedCount >= ic.MaxUses {
+		return fmt.Errorf("invite code %q has reached max uses", code)
+	}
+
+	// Insert redemption (PK constraint prevents double-redemption).
+	_, err = tx.Exec(ctx,
+		`INSERT INTO invite_redemptions (code, account_id) VALUES ($1, $2)`,
+		code, accountID,
+	)
+	if err != nil {
+		return fmt.Errorf("account has already redeemed code %q", code)
+	}
+
+	// Increment used_count.
+	_, err = tx.Exec(ctx,
+		`UPDATE invite_codes SET used_count = used_count + 1 WHERE code = $1`, code,
+	)
+	if err != nil {
+		return fmt.Errorf("store: update invite code: %w", err)
+	}
+
+	// Credit the balance in the same transaction.
+	if err := creditTx(ctx, tx, accountID, amountMicroUSD, entryType, reference, time.Time{}); err != nil {
+		return err
+	}
+
+	return tx.Commit(ctx)
+}
+
 func (s *PostgresStore) HasRedeemedInviteCode(code, accountID string) bool {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()


### PR DESCRIPTION
## Summary
- Adds `RedeemInviteCodeAndCredit` method to `store.Store` interface, with implementations in both memory and postgres stores
- Memory impl holds the store lock for the full redeem + credit operation
- Postgres impl uses `SELECT ... FOR UPDATE` on the invite code row before marking it redeemed, then calls `creditTx` within the same transaction
- `invite_handlers.go`: replaces the separate `RedeemInviteCode` + `Credit` calls with the new atomic method

## Security impact
The previous two-step approach had a TOCTOU race: two concurrent requests for the same invite code could both pass the `RedeemInviteCode` check and both apply the credit. The atomic transaction closes this window — the `FOR UPDATE` lock ensures only one winner, and both redeem + credit either commit together or not at all.

## Test plan
- [ ] `go test ./internal/store/...`
- [ ] `go test ./internal/api/...`
- [ ] Simulate concurrent invite redemption requests with the same code and verify only one credit is applied