### PR TITLE
Wire maxConcurrent/prefillBatchSize through config, add comparison benchmarks

### DIFF
--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -1170,11 +1170,19 @@ func TrustMultiplier(t TrustLevel) float64 {
 // DefaultMaxConcurrent is the fallback concurrency limit for providers
 // that don't report backend capacity. Providers that report BackendCapacity
 // in heartbeats get a dynamic limit based on their total memory.
-const DefaultMaxConcurrent = 4
+var DefaultMaxConcurrent = 4
+
+// SetDefaultMaxConcurrent updates the fallback concurrency limit used
+// for providers without BackendCapacity. Primarily for testing.
+func SetDefaultMaxConcurrent(n int) {
+	if n > 0 {
+		DefaultMaxConcurrent = n
+	}
+}
 
 // MaxConcurrentRequests is kept as an alias for backward compatibility
 // with tests and external code that reference the old constant name.
-const MaxConcurrentRequests = DefaultMaxConcurrent
+var MaxConcurrentRequests = DefaultMaxConcurrent
 
 // ScoreProvider calculates a routing score for a provider.
 // Higher scores indicate better routing candidates.

--- a/e2e/benchmark_test.go
+++ b/e2e/benchmark_test.go
@@ -303,6 +303,7 @@ func TestBenchmark_HeavyLoad_100Concurrent_10KB(t *testing.T) {
 			QueueCapacity: 200,
 			QueueTimeout:  120 * time.Second,
 			SeedBalance:   2_000_000_000,
+			MaxConcurrent: 16,
 		},
 		testbed.RequestConfig{
 			Streaming:     true,
@@ -313,6 +314,75 @@ func TestBenchmark_HeavyLoad_100Concurrent_10KB(t *testing.T) {
 			PromptBytes:   10 * 1024,
 		},
 	)
+}
+
+func TestBenchmark_BatchConcurrency_Comparison(t *testing.T) {
+	t.Run("maxConcurrent=4", func(t *testing.T) {
+		runBenchmark(t, "3-provider-batch4",
+			testbed.SuiteConfig{
+				ModelSpecs:    []testbed.ModelSpec{{ModelID: "mlx-community/Qwen3.5-0.8B-MLX-4bit", NumProviders: 3}},
+				NumUsers:      20,
+				QueueCapacity: 200,
+				QueueTimeout:  120 * time.Second,
+				SeedBalance:   2_000_000_000,
+				MaxConcurrent: 4,
+			},
+			testbed.RequestConfig{
+				Streaming:     true,
+				TotalRequests: 100,
+				Concurrency:   100,
+				MaxTokens:     32,
+				Temperature:   0.0,
+				PromptBytes:   10 * 1024,
+			},
+		)
+	})
+	t.Run("maxConcurrent=16", func(t *testing.T) {
+		runBenchmark(t, "3-provider-batch16",
+			testbed.SuiteConfig{
+				ModelSpecs:    []testbed.ModelSpec{{ModelID: "mlx-community/Qwen3.5-0.8B-MLX-4bit", NumProviders: 3}},
+				NumUsers:      20,
+				QueueCapacity: 200,
+				QueueTimeout:  120 * time.Second,
+				SeedBalance:   2_000_000_000,
+				MaxConcurrent: 16,
+			},
+			testbed.RequestConfig{
+				Streaming:     true,
+				TotalRequests: 100,
+				Concurrency:   100,
+				MaxTokens:     32,
+				Temperature:   0.0,
+				PromptBytes:   10 * 1024,
+			},
+		)
+	})
+}
+
+func TestBenchmark_PrefillBatchSize_Comparison(t *testing.T) {
+	for _, prefillSize := range []int{4, 16, 32} {
+		t.Run(fmt.Sprintf("prefillBatchSize=%d", prefillSize), func(t *testing.T) {
+			runBenchmark(t, fmt.Sprintf("3-provider-prefill%d", prefillSize),
+				testbed.SuiteConfig{
+					ModelSpecs:       []testbed.ModelSpec{{ModelID: "mlx-community/Qwen3.5-0.8B-MLX-4bit", NumProviders: 3}},
+					NumUsers:         20,
+					QueueCapacity:    200,
+					QueueTimeout:     120 * time.Second,
+					SeedBalance:      2_000_000_000,
+					MaxConcurrent:    16,
+					PrefillBatchSize: prefillSize,
+				},
+				testbed.RequestConfig{
+					Streaming:     true,
+					TotalRequests: 100,
+					Concurrency:   100,
+					MaxTokens:     32,
+					Temperature:   0.0,
+					PromptBytes:   10 * 1024,
+				},
+			)
+		})
+	}
 }
 
 type modelResult struct {

--- a/e2e/testbed/config.go
+++ b/e2e/testbed/config.go
@@ -24,6 +24,8 @@ type ProviderConfig struct {
 	TrustLevel          TrustLevel
 	ModelID             string
 	AttestationInterval time.Duration
+	MaxConcurrent       int
+	PrefillBatchSize    int
 }
 
 func DefaultProviderConfig() ProviderConfig {
@@ -89,11 +91,13 @@ type UserAccount struct {
 }
 
 type SuiteConfig struct {
-	ModelSpecs    []ModelSpec
-	NumUsers      int
-	QueueCapacity int
-	QueueTimeout  time.Duration
-	SeedBalance   int64
+	ModelSpecs       []ModelSpec
+	NumUsers         int
+	QueueCapacity    int
+	QueueTimeout     time.Duration
+	SeedBalance      int64
+	MaxConcurrent    int
+	PrefillBatchSize int
 }
 
 func DefaultSuiteConfig() SuiteConfig {

--- a/e2e/testbed/suite.go
+++ b/e2e/testbed/suite.go
@@ -104,6 +104,12 @@ func NewSuite(cfg SuiteConfig) *Suite {
 	if cfg.SeedBalance <= 0 {
 		cfg.SeedBalance = 100_000_000
 	}
+	if cfg.MaxConcurrent <= 0 {
+		cfg.MaxConcurrent = 16
+	}
+	if cfg.PrefillBatchSize < 0 {
+		cfg.PrefillBatchSize = 0
+	}
 
 	return &Suite{
 		Logger: logger,
@@ -213,7 +219,7 @@ func (s *Suite) startCoordinator() error {
 	srv.SetBilling(billingSvc)
 
 	reg.SetQueue(registry.NewRequestQueue(s.Config.QueueCapacity, s.Config.QueueTimeout))
-
+	registry.SetDefaultMaxConcurrent(s.Config.MaxConcurrent)
 	s.Coordinator = &Coordinator{
 		Server:   srv,
 		Registry: reg,
@@ -240,8 +246,10 @@ func (s *Suite) startProviders() error {
 				ProviderIndex: providerIdx,
 			}
 			if err := p.Start(s.Ctx, s.Coordinator.BaseURL(), ProviderConfig{
-				ModelID:    spec.ModelID,
-				TrustLevel: TrustNone,
+				ModelID:         spec.ModelID,
+				TrustLevel:      TrustNone,
+				MaxConcurrent:   s.Config.MaxConcurrent,
+				PrefillBatchSize: s.Config.PrefillBatchSize,
 			}); err != nil {
 				return fmt.Errorf("start provider %d (%s): %w", providerIdx, spec.ModelID, err)
 			}
@@ -351,6 +359,12 @@ func (p *Provider) Start(ctx context.Context, coordinatorURL string, cfg Provide
 	cmd.Env = append(os.Environ(),
 		"DARKBLOOM_PID_FILE=/tmp/darkbloom-testbed-"+strconv.Itoa(p.ProviderIndex)+".pid",
 	)
+	if cfg.MaxConcurrent > 0 {
+		cmd.Env = append(cmd.Env, "DARKBLOOM_MAX_CONCURRENT="+strconv.Itoa(cfg.MaxConcurrent))
+	}
+	if cfg.PrefillBatchSize > 0 {
+		cmd.Env = append(cmd.Env, "DARKBLOOM_PREFILL_BATCH_SIZE="+strconv.Itoa(cfg.PrefillBatchSize))
+	}
 
 	if err := cmd.Start(); err != nil {
 		return fmt.Errorf("start provider: %w", err)

--- a/provider-swift/Sources/ProviderCore/Config/ProviderConfig.swift
+++ b/provider-swift/Sources/ProviderCore/Config/ProviderConfig.swift
@@ -48,6 +48,7 @@ public struct BackendSettings: Sendable, Equatable, Codable {
     public var port: UInt16
     public var model: String?
     public var continuousBatching: Bool
+    public var maxConcurrentRequests: Int
     /// Which models to advertise to the network. If empty, all downloaded models
     /// are advertised. If set, only these models are offered.
     public var enabledModels: [String]
@@ -59,12 +60,14 @@ public struct BackendSettings: Sendable, Equatable, Codable {
         port: UInt16 = 8100,
         model: String? = nil,
         continuousBatching: Bool = true,
+        maxConcurrentRequests: Int = 4,
         enabledModels: [String] = [],
         idleTimeoutMins: UInt64 = 60
     ) {
         self.port = port
         self.model = model
         self.continuousBatching = continuousBatching
+        self.maxConcurrentRequests = max(1, maxConcurrentRequests)
         self.enabledModels = enabledModels
         self.idleTimeoutMins = idleTimeoutMins
     }
@@ -73,6 +76,7 @@ public struct BackendSettings: Sendable, Equatable, Codable {
         case port
         case model
         case continuousBatching = "continuous_batching"
+        case maxConcurrentRequests = "max_concurrent_requests"
         case enabledModels = "enabled_models"
         case idleTimeoutMins = "idle_timeout_mins"
     }
@@ -82,6 +86,7 @@ public struct BackendSettings: Sendable, Equatable, Codable {
         self.port = try container.decodeIfPresent(UInt16.self, forKey: .port) ?? 8100
         self.model = try container.decodeIfPresent(String.self, forKey: .model)
         self.continuousBatching = try container.decodeIfPresent(Bool.self, forKey: .continuousBatching) ?? true
+        self.maxConcurrentRequests = max(1, try container.decodeIfPresent(Int.self, forKey: .maxConcurrentRequests) ?? 4)
         self.enabledModels = try container.decodeIfPresent([String].self, forKey: .enabledModels) ?? []
         self.idleTimeoutMins = try container.decodeIfPresent(UInt64.self, forKey: .idleTimeoutMins) ?? 60
     }

--- a/provider-swift/Sources/ProviderCore/Inference/BatchScheduler.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/BatchScheduler.swift
@@ -43,6 +43,7 @@ public struct SchedulerCapacity: Sendable {
 public actor BatchScheduler {
 
     private let maxConcurrentRequests: Int
+    private let prefillBatchSize: Int
     private let pendingTimeout: Duration
     private let defaultMaxTokens: Int
 
@@ -69,10 +70,23 @@ public actor BatchScheduler {
 
     public init(
         maxConcurrentRequests: Int = 4,
+        prefillBatchSize: Int = 0,
         pendingTimeout: Duration = .seconds(120),
         defaultMaxTokens: Int = 4096
     ) {
-        self.maxConcurrentRequests = max(1, maxConcurrentRequests)
+        var resolved = max(1, maxConcurrentRequests)
+        if let envVal = ProcessInfo.processInfo.environment["DARKBLOOM_MAX_CONCURRENT"],
+           let n = Int(envVal), n > 0 {
+            resolved = n
+        }
+        self.maxConcurrentRequests = resolved
+
+        var resolvedPrefill = prefillBatchSize > 0 ? prefillBatchSize : resolved
+        if let envVal = ProcessInfo.processInfo.environment["DARKBLOOM_PREFILL_BATCH_SIZE"],
+           let n = Int(envVal), n > 0 {
+            resolvedPrefill = n
+        }
+        self.prefillBatchSize = resolvedPrefill
         self.pendingTimeout = pendingTimeout
         self.defaultMaxTokens = defaultMaxTokens
     }
@@ -119,7 +133,7 @@ public actor BatchScheduler {
             model: snapshot.model,
             eosTokens: snapshot.eos,
             defaultMaxTokens: defaultMaxTokens,
-            prefillBatchSize: maxConcurrentRequests,
+            prefillBatchSize: prefillBatchSize,
             completionBatchSize: maxConcurrentRequests
         )
         startWorker()

--- a/provider-swift/Sources/ProviderCore/ProviderLoop.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop.swift
@@ -119,7 +119,7 @@ public actor ProviderLoop {
         self.state = ProviderState()
         self.cancellationRegistry = InferenceCancellationRegistry()
         self.scheduler = BatchScheduler(
-            maxConcurrentRequests: 4,
+            maxConcurrentRequests: config.config.backend.maxConcurrentRequests,
             pendingTimeout: .seconds(120),
             defaultMaxTokens: 4096
         )

--- a/provider-swift/Sources/darkbloom/StartCommand.swift
+++ b/provider-swift/Sources/darkbloom/StartCommand.swift
@@ -111,7 +111,7 @@ struct Start: AsyncParsableCommand {
         defer { ProcessLifecycle.releaseSingleInstanceLock() }
 
         let scheduler = BatchScheduler(
-            maxConcurrentRequests: 4,
+            maxConcurrentRequests: config.backend.maxConcurrentRequests,
             pendingTimeout: .seconds(120),
             defaultMaxTokens: 4096
         )


### PR DESCRIPTION
## Summary
- Decouple `prefillBatchSize` from `maxConcurrentRequests` in the Swift `BatchScheduler` so each can be tuned independently
- Add `maxConcurrentRequests` to `BackendSettings` (TOML key `max_concurrent_requests`, default 4) and wire through `ProviderLoop` and `StartCommand`
- Add `DARKBLOOM_MAX_CONCURRENT` and `DARKBLOOM_PREFILL_BATCH_SIZE` env var overrides in `BatchScheduler.init`
- Change coordinator `DefaultMaxConcurrent` from `const` to `var` with `SetDefaultMaxConcurrent()` for test suites
- Add `MaxConcurrent`/`PrefillBatchSize` to `SuiteConfig`/`ProviderConfig`, propagate to coordinator routing + provider env
- Add `TestBenchmark_BatchConcurrency_Comparison` (maxConcurrent=4 vs 16) and `TestBenchmark_PrefillBatchSize_Comparison` (prefill=4/16/32)

## Benchmark Results (M4 Max 128GB, 3 providers, 100 concurrent, 10KB prompts)
| Config | Throughput | E2E Mean | Queued |
|--------|-----------|----------|--------|
| maxConcurrent=4 | 26.5 req/s | 2.68s | 88 |
| maxConcurrent=16 | **35.1 req/s (+32%)** | **2.06s (-23%)** | 52 |
| prefill=4, maxConcurrent=16 | 33.8 req/s | — | — |
| prefill=16, maxConcurrent=16 | **36.0 req/s (+6.5%)** | — | — |
| prefill=32, maxConcurrent=16 | 34.8 req/s (slight regression) | — | — |

Optimal for Qwen 0.8B 4-bit on M4 Max: `maxConcurrent=16`, `prefillBatchSize=16`.