### PR TITLE
feat: environment-scoped release secrets (dev/prod R2 isolation)

### DIFF
--- a/.github/workflows/release-rust-bridge.yml
+++ b/.github/workflows/release-rust-bridge.yml
@@ -16,16 +16,16 @@ name: Release Rust Bridge Provider Bundle
 # The tag prefix is intentionally not `v...` so the Swift release workflow
 # cannot accidentally publish a Swift bundle for the bridge tag.
 #
-# Environment-scoped secrets (configure per GitHub environment: dev, prod):
-#   R2_ACCESS_KEY_ID      — Cloudflare R2 API token ID for the target bucket
-#   R2_SECRET_ACCESS_KEY  — Cloudflare R2 API token secret
-#   R2_ENDPOINT           — e.g. https://<account-id>.r2.cloudflarestorage.com
-#   R2_BUCKET             — dev: d-inf-app-dev, prod: d-inf-app-prod
-#   R2_PUBLIC_URL         — public CDN URL for the target bucket
-#   COORDINATOR_URL       — dev: https://api.dev.darkbloom.xyz, prod: https://api.darkbloom.dev
-#   RELEASE_KEY           — scoped release key for the target coordinator
-#   APPLE_CERTIFICATE_P12, APPLE_CERTIFICATE_PASSWORD, APPLE_ID, APPLE_APP_PASSWORD
-#                          — shared across environments
+# Repo secrets use DEV_/PROD_ prefixes so both environments live at repo
+# level without needing GitHub environments:
+#   DEV_R2_ACCESS_KEY_ID  / PROD_R2_ACCESS_KEY_ID
+#   DEV_R2_SECRET_ACCESS_KEY / PROD_R2_SECRET_ACCESS_KEY
+#   DEV_R2_ENDPOINT       / PROD_R2_ENDPOINT
+#   DEV_R2_BUCKET         / PROD_R2_BUCKET
+#   DEV_R2_PUBLIC_URL     / PROD_R2_PUBLIC_URL
+#   DEV_COORDINATOR_URL   / PROD_COORDINATOR_URL
+#   DEV_RELEASE_KEY       / PROD_RELEASE_KEY
+# Apple signing secrets are shared (same cert for both envs).
 
 on:
   push:
@@ -64,6 +64,13 @@ jobs:
     outputs:
       environment: ${{ steps.pick.outputs.environment }}
       version: ${{ steps.pick.outputs.version }}
+      r2_access_key_id: ${{ steps.secrets.outputs.r2_access_key_id }}
+      r2_secret_access_key: ${{ steps.secrets.outputs.r2_secret_access_key }}
+      r2_endpoint: ${{ steps.secrets.outputs.r2_endpoint }}
+      r2_bucket: ${{ steps.secrets.outputs.r2_bucket }}
+      r2_public_url: ${{ steps.secrets.outputs.r2_public_url }}
+      coordinator_url: ${{ steps.secrets.outputs.coordinator_url }}
+      release_key: ${{ steps.secrets.outputs.release_key }}
     steps:
       - id: pick
         run: |
@@ -83,10 +90,36 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Resolved env=$ENV version=$VERSION"
 
+      - id: secrets
+        env:
+          ENV_PREFIX: ${{ steps.pick.outputs.environment }}
+          DEV_R2_ACCESS_KEY_ID: ${{ secrets.DEV_R2_ACCESS_KEY_ID }}
+          PROD_R2_ACCESS_KEY_ID: ${{ secrets.PROD_R2_ACCESS_KEY_ID }}
+          DEV_R2_SECRET_ACCESS_KEY: ${{ secrets.DEV_R2_SECRET_ACCESS_KEY }}
+          PROD_R2_SECRET_ACCESS_KEY: ${{ secrets.PROD_R2_SECRET_ACCESS_KEY }}
+          DEV_R2_ENDPOINT: ${{ secrets.DEV_R2_ENDPOINT }}
+          PROD_R2_ENDPOINT: ${{ secrets.PROD_R2_ENDPOINT }}
+          DEV_R2_BUCKET: ${{ secrets.DEV_R2_BUCKET }}
+          PROD_R2_BUCKET: ${{ secrets.PROD_R2_BUCKET }}
+          DEV_R2_PUBLIC_URL: ${{ secrets.DEV_R2_PUBLIC_URL }}
+          PROD_R2_PUBLIC_URL: ${{ secrets.PROD_R2_PUBLIC_URL }}
+          DEV_COORDINATOR_URL: ${{ secrets.DEV_COORDINATOR_URL }}
+          PROD_COORDINATOR_URL: ${{ secrets.PROD_COORDINATOR_URL }}
+          DEV_RELEASE_KEY: ${{ secrets.DEV_RELEASE_KEY }}
+          PROD_RELEASE_KEY: ${{ secrets.PROD_RELEASE_KEY }}
+        run: |
+          set -euo pipefail
+          PREFIX=$(echo "$ENV_PREFIX" | tr '[:lower:]' '[:upper:]')
+          for key in R2_ACCESS_KEY_ID R2_SECRET_ACCESS_KEY R2_ENDPOINT R2_BUCKET R2_PUBLIC_URL COORDINATOR_URL RELEASE_KEY; do
+            varname="${PREFIX}_${key}"
+            val="${!varname}"
+            outkey=$(echo "$key" | tr '[:upper:]' '[:lower:]')
+            echo "${outkey}=${val}" >> "$GITHUB_OUTPUT"
+          done
+
   build-and-release:
     name: Build, sign, notarize, upload, register
     needs: [resolve-env]
-    environment: ${{ needs.resolve-env.outputs.environment }}
     runs-on: macos-26-xlarge
 
     env:
@@ -317,10 +350,10 @@ jobs:
 
       - name: Upload bridge artifacts to R2
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
-          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
-          R2_BUCKET: ${{ secrets.R2_BUCKET }}
+          AWS_ACCESS_KEY_ID: ${{ needs.resolve-env.outputs.r2_access_key_id }}
+          AWS_SECRET_ACCESS_KEY: ${{ needs.resolve-env.outputs.r2_secret_access_key }}
+          R2_ENDPOINT: ${{ needs.resolve-env.outputs.r2_endpoint }}
+          R2_BUCKET: ${{ needs.resolve-env.outputs.r2_bucket }}
         run: |
           set -euo pipefail
           PREFIX="s3://${R2_BUCKET}/releases/v${VERSION}"
@@ -350,9 +383,9 @@ jobs:
 
       - name: Register bridge release with coordinator
         env:
-          COORDINATOR_URL: ${{ secrets.COORDINATOR_URL }}
-          RELEASE_KEY: ${{ secrets.RELEASE_KEY }}
-          R2_PUBLIC_URL: ${{ secrets.R2_PUBLIC_URL }}
+          COORDINATOR_URL: ${{ needs.resolve-env.outputs.coordinator_url }}
+          RELEASE_KEY: ${{ needs.resolve-env.outputs.release_key }}
+          R2_PUBLIC_URL: ${{ needs.resolve-env.outputs.r2_public_url }}
         run: |
           set -euo pipefail
           BUNDLE_URL="${R2_PUBLIC_URL}/releases/v${VERSION}/eigeninference-bundle-macos-arm64.tar.gz"

--- a/.github/workflows/release-rust-bridge.yml
+++ b/.github/workflows/release-rust-bridge.yml
@@ -24,7 +24,7 @@ name: Release Rust Bridge Provider Bundle
 #   DEV_R2_BUCKET         / PROD_R2_BUCKET
 #   DEV_R2_PUBLIC_URL     / PROD_R2_PUBLIC_URL
 #   DEV_COORDINATOR_URL   / PROD_COORDINATOR_URL
-#   DEV_RELEASE_KEY       / PROD_RELEASE_KEY
+#   RELEASE_KEY           — shared across environments (no prefix)
 # Apple signing secrets are shared (same cert for both envs).
 
 on:
@@ -70,7 +70,6 @@ jobs:
       r2_bucket: ${{ steps.secrets.outputs.r2_bucket }}
       r2_public_url: ${{ steps.secrets.outputs.r2_public_url }}
       coordinator_url: ${{ steps.secrets.outputs.coordinator_url }}
-      release_key: ${{ steps.secrets.outputs.release_key }}
     steps:
       - id: pick
         run: |
@@ -105,12 +104,10 @@ jobs:
           PROD_R2_PUBLIC_URL: ${{ secrets.PROD_R2_PUBLIC_URL }}
           DEV_COORDINATOR_URL: ${{ secrets.DEV_COORDINATOR_URL }}
           PROD_COORDINATOR_URL: ${{ secrets.PROD_COORDINATOR_URL }}
-          DEV_RELEASE_KEY: ${{ secrets.DEV_RELEASE_KEY }}
-          PROD_RELEASE_KEY: ${{ secrets.PROD_RELEASE_KEY }}
         run: |
           set -euo pipefail
           PREFIX=$(echo "$ENV_PREFIX" | tr '[:lower:]' '[:upper:]')
-          for key in R2_ACCESS_KEY_ID R2_SECRET_ACCESS_KEY R2_ENDPOINT R2_BUCKET R2_PUBLIC_URL COORDINATOR_URL RELEASE_KEY; do
+          for key in R2_ACCESS_KEY_ID R2_SECRET_ACCESS_KEY R2_ENDPOINT R2_BUCKET R2_PUBLIC_URL COORDINATOR_URL; do
             varname="${PREFIX}_${key}"
             val="${!varname}"
             outkey=$(echo "$key" | tr '[:upper:]' '[:lower:]')
@@ -384,7 +381,7 @@ jobs:
       - name: Register bridge release with coordinator
         env:
           COORDINATOR_URL: ${{ needs.resolve-env.outputs.coordinator_url }}
-          RELEASE_KEY: ${{ needs.resolve-env.outputs.release_key }}
+          RELEASE_KEY: ${{ secrets.RELEASE_KEY }}
           R2_PUBLIC_URL: ${{ needs.resolve-env.outputs.r2_public_url }}
         run: |
           set -euo pipefail

--- a/.github/workflows/release-rust-bridge.yml
+++ b/.github/workflows/release-rust-bridge.yml
@@ -15,6 +15,17 @@ name: Release Rust Bridge Provider Bundle
 #
 # The tag prefix is intentionally not `v...` so the Swift release workflow
 # cannot accidentally publish a Swift bundle for the bridge tag.
+#
+# Environment-scoped secrets (configure per GitHub environment: dev, prod):
+#   R2_ACCESS_KEY_ID      — Cloudflare R2 API token ID for the target bucket
+#   R2_SECRET_ACCESS_KEY  — Cloudflare R2 API token secret
+#   R2_ENDPOINT           — e.g. https://<account-id>.r2.cloudflarestorage.com
+#   R2_BUCKET             — dev: d-inf-app-dev, prod: d-inf-app-prod
+#   R2_PUBLIC_URL         — public CDN URL for the target bucket
+#   COORDINATOR_URL       — dev: https://api.dev.darkbloom.xyz, prod: https://api.darkbloom.dev
+#   RELEASE_KEY           — scoped release key for the target coordinator
+#   APPLE_CERTIFICATE_P12, APPLE_CERTIFICATE_PASSWORD, APPLE_ID, APPLE_APP_PASSWORD
+#                          — shared across environments
 
 on:
   push:
@@ -309,7 +320,7 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
           R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
-          R2_BUCKET: ${{ vars.R2_BUCKET }}
+          R2_BUCKET: ${{ secrets.R2_BUCKET }}
         run: |
           set -euo pipefail
           PREFIX="s3://${R2_BUCKET}/releases/v${VERSION}"

--- a/.github/workflows/release-swift.yml
+++ b/.github/workflows/release-swift.yml
@@ -23,6 +23,17 @@ name: Release Provider Bundle (Swift)
 #
 # The one-time Rust migration bridge intentionally uses `rust-bridge-vX.Y.Z`
 # so it cannot be confused with the Swift cutover tags above.
+#
+# Environment-scoped secrets (configure per GitHub environment: dev, prod):
+#   R2_ACCESS_KEY_ID      — Cloudflare R2 API token ID for the target bucket
+#   R2_SECRET_ACCESS_KEY  — Cloudflare R2 API token secret
+#   R2_ENDPOINT           — e.g. https://<account-id>.r2.cloudflarestorage.com
+#   R2_BUCKET             — dev: d-inf-app-dev, prod: d-inf-app-prod
+#   R2_PUBLIC_URL         — public CDN URL for the target bucket
+#   COORDINATOR_URL       — dev: https://api.dev.darkbloom.xyz, prod: https://api.darkbloom.dev
+#   RELEASE_KEY           — scoped release key for the target coordinator
+#   APPLE_CERTIFICATE_P12, APPLE_CERTIFICATE_PASSWORD, APPLE_ID, APPLE_APP_PASSWORD
+#                          — shared across environments (Apple signing is the same)
 
 on:
   push:
@@ -298,7 +309,8 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
           R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
-          R2_BUCKET: ${{ vars.R2_BUCKET }}
+          R2_BUCKET: ${{ secrets.R2_BUCKET }}
+          R2_PUBLIC_URL: ${{ secrets.R2_PUBLIC_URL }}
         run: |
           set -euo pipefail
           PREFIX="s3://${R2_BUCKET}/releases/v${VERSION}"

--- a/.github/workflows/release-swift.yml
+++ b/.github/workflows/release-swift.yml
@@ -24,16 +24,16 @@ name: Release Provider Bundle (Swift)
 # The one-time Rust migration bridge intentionally uses `rust-bridge-vX.Y.Z`
 # so it cannot be confused with the Swift cutover tags above.
 #
-# Environment-scoped secrets (configure per GitHub environment: dev, prod):
-#   R2_ACCESS_KEY_ID      — Cloudflare R2 API token ID for the target bucket
-#   R2_SECRET_ACCESS_KEY  — Cloudflare R2 API token secret
-#   R2_ENDPOINT           — e.g. https://<account-id>.r2.cloudflarestorage.com
-#   R2_BUCKET             — dev: d-inf-app-dev, prod: d-inf-app-prod
-#   R2_PUBLIC_URL         — public CDN URL for the target bucket
-#   COORDINATOR_URL       — dev: https://api.dev.darkbloom.xyz, prod: https://api.darkbloom.dev
-#   RELEASE_KEY           — scoped release key for the target coordinator
-#   APPLE_CERTIFICATE_P12, APPLE_CERTIFICATE_PASSWORD, APPLE_ID, APPLE_APP_PASSWORD
-#                          — shared across environments (Apple signing is the same)
+# Repo secrets use DEV_/PROD_ prefixes so both environments live at repo
+# level without needing GitHub environments:
+#   DEV_R2_ACCESS_KEY_ID  / PROD_R2_ACCESS_KEY_ID
+#   DEV_R2_SECRET_ACCESS_KEY / PROD_R2_SECRET_ACCESS_KEY
+#   DEV_R2_ENDPOINT       / PROD_R2_ENDPOINT
+#   DEV_R2_BUCKET         / PROD_R2_BUCKET
+#   DEV_R2_PUBLIC_URL     / PROD_R2_PUBLIC_URL
+#   DEV_COORDINATOR_URL   / PROD_COORDINATOR_URL
+#   DEV_RELEASE_KEY       / PROD_RELEASE_KEY
+# Apple signing secrets are shared (same cert for both envs).
 
 on:
   push:
@@ -73,6 +73,13 @@ jobs:
     outputs:
       environment: ${{ steps.pick.outputs.environment }}
       version: ${{ steps.pick.outputs.version }}
+      r2_access_key_id: ${{ steps.secrets.outputs.r2_access_key_id }}
+      r2_secret_access_key: ${{ steps.secrets.outputs.r2_secret_access_key }}
+      r2_endpoint: ${{ steps.secrets.outputs.r2_endpoint }}
+      r2_bucket: ${{ steps.secrets.outputs.r2_bucket }}
+      r2_public_url: ${{ steps.secrets.outputs.r2_public_url }}
+      coordinator_url: ${{ steps.secrets.outputs.coordinator_url }}
+      release_key: ${{ steps.secrets.outputs.release_key }}
     steps:
       - id: pick
         run: |
@@ -95,10 +102,36 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Resolved env=$ENV version=$VERSION"
 
+      - id: secrets
+        env:
+          ENV_PREFIX: ${{ steps.pick.outputs.environment }}
+          DEV_R2_ACCESS_KEY_ID: ${{ secrets.DEV_R2_ACCESS_KEY_ID }}
+          PROD_R2_ACCESS_KEY_ID: ${{ secrets.PROD_R2_ACCESS_KEY_ID }}
+          DEV_R2_SECRET_ACCESS_KEY: ${{ secrets.DEV_R2_SECRET_ACCESS_KEY }}
+          PROD_R2_SECRET_ACCESS_KEY: ${{ secrets.PROD_R2_SECRET_ACCESS_KEY }}
+          DEV_R2_ENDPOINT: ${{ secrets.DEV_R2_ENDPOINT }}
+          PROD_R2_ENDPOINT: ${{ secrets.PROD_R2_ENDPOINT }}
+          DEV_R2_BUCKET: ${{ secrets.DEV_R2_BUCKET }}
+          PROD_R2_BUCKET: ${{ secrets.PROD_R2_BUCKET }}
+          DEV_R2_PUBLIC_URL: ${{ secrets.DEV_R2_PUBLIC_URL }}
+          PROD_R2_PUBLIC_URL: ${{ secrets.PROD_R2_PUBLIC_URL }}
+          DEV_COORDINATOR_URL: ${{ secrets.DEV_COORDINATOR_URL }}
+          PROD_COORDINATOR_URL: ${{ secrets.PROD_COORDINATOR_URL }}
+          DEV_RELEASE_KEY: ${{ secrets.DEV_RELEASE_KEY }}
+          PROD_RELEASE_KEY: ${{ secrets.PROD_RELEASE_KEY }}
+        run: |
+          set -euo pipefail
+          PREFIX=$(echo "$ENV_PREFIX" | tr '[:lower:]' '[:upper:]')
+          for key in R2_ACCESS_KEY_ID R2_SECRET_ACCESS_KEY R2_ENDPOINT R2_BUCKET R2_PUBLIC_URL COORDINATOR_URL RELEASE_KEY; do
+            varname="${PREFIX}_${key}"
+            val="${!varname}"
+            outkey=$(echo "$key" | tr '[:upper:]' '[:lower:]')
+            echo "${outkey}=${val}" >> "$GITHUB_OUTPUT"
+          done
+
   build-and-release:
     name: Build, sign, notarize, upload, register
     needs: [resolve-env]
-    environment: ${{ needs.resolve-env.outputs.environment }}
     runs-on: macos-26-xlarge
 
     env:
@@ -306,11 +339,11 @@ jobs:
 
       - name: Upload bundle to R2
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
-          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
-          R2_BUCKET: ${{ secrets.R2_BUCKET }}
-          R2_PUBLIC_URL: ${{ secrets.R2_PUBLIC_URL }}
+          AWS_ACCESS_KEY_ID: ${{ needs.resolve-env.outputs.r2_access_key_id }}
+          AWS_SECRET_ACCESS_KEY: ${{ needs.resolve-env.outputs.r2_secret_access_key }}
+          R2_ENDPOINT: ${{ needs.resolve-env.outputs.r2_endpoint }}
+          R2_BUCKET: ${{ needs.resolve-env.outputs.r2_bucket }}
+          R2_PUBLIC_URL: ${{ needs.resolve-env.outputs.r2_public_url }}
         run: |
           set -euo pipefail
           PREFIX="s3://${R2_BUCKET}/releases/v${VERSION}"
@@ -347,9 +380,9 @@ jobs:
 
       - name: Register release with coordinator
         env:
-          COORDINATOR_URL: ${{ secrets.COORDINATOR_URL }}
-          RELEASE_KEY: ${{ secrets.RELEASE_KEY }}
-          R2_PUBLIC_URL: ${{ secrets.R2_PUBLIC_URL }}
+          COORDINATOR_URL: ${{ needs.resolve-env.outputs.coordinator_url }}
+          RELEASE_KEY: ${{ needs.resolve-env.outputs.release_key }}
+          R2_PUBLIC_URL: ${{ needs.resolve-env.outputs.r2_public_url }}
         run: |
           set -euo pipefail
           BUNDLE_URL="${R2_PUBLIC_URL}/releases/v${VERSION}/darkbloom-bundle-macos-arm64.tar.gz"
@@ -402,7 +435,7 @@ jobs:
           ### Install
 
           \`\`\`bash
-          curl -fsSL ${{ secrets.COORDINATOR_URL }}/install.sh | bash
+          curl -fsSL ${{ needs.resolve-env.outputs.coordinator_url }}/install.sh | bash
           \`\`\`
 
           NOTES

--- a/.github/workflows/release-swift.yml
+++ b/.github/workflows/release-swift.yml
@@ -32,7 +32,7 @@ name: Release Provider Bundle (Swift)
 #   DEV_R2_BUCKET         / PROD_R2_BUCKET
 #   DEV_R2_PUBLIC_URL     / PROD_R2_PUBLIC_URL
 #   DEV_COORDINATOR_URL   / PROD_COORDINATOR_URL
-#   DEV_RELEASE_KEY       / PROD_RELEASE_KEY
+#   RELEASE_KEY           — shared across environments (no prefix)
 # Apple signing secrets are shared (same cert for both envs).
 
 on:
@@ -79,7 +79,6 @@ jobs:
       r2_bucket: ${{ steps.secrets.outputs.r2_bucket }}
       r2_public_url: ${{ steps.secrets.outputs.r2_public_url }}
       coordinator_url: ${{ steps.secrets.outputs.coordinator_url }}
-      release_key: ${{ steps.secrets.outputs.release_key }}
     steps:
       - id: pick
         run: |
@@ -117,12 +116,10 @@ jobs:
           PROD_R2_PUBLIC_URL: ${{ secrets.PROD_R2_PUBLIC_URL }}
           DEV_COORDINATOR_URL: ${{ secrets.DEV_COORDINATOR_URL }}
           PROD_COORDINATOR_URL: ${{ secrets.PROD_COORDINATOR_URL }}
-          DEV_RELEASE_KEY: ${{ secrets.DEV_RELEASE_KEY }}
-          PROD_RELEASE_KEY: ${{ secrets.PROD_RELEASE_KEY }}
         run: |
           set -euo pipefail
           PREFIX=$(echo "$ENV_PREFIX" | tr '[:lower:]' '[:upper:]')
-          for key in R2_ACCESS_KEY_ID R2_SECRET_ACCESS_KEY R2_ENDPOINT R2_BUCKET R2_PUBLIC_URL COORDINATOR_URL RELEASE_KEY; do
+          for key in R2_ACCESS_KEY_ID R2_SECRET_ACCESS_KEY R2_ENDPOINT R2_BUCKET R2_PUBLIC_URL COORDINATOR_URL; do
             varname="${PREFIX}_${key}"
             val="${!varname}"
             outkey=$(echo "$key" | tr '[:upper:]' '[:lower:]')
@@ -381,7 +378,7 @@ jobs:
       - name: Register release with coordinator
         env:
           COORDINATOR_URL: ${{ needs.resolve-env.outputs.coordinator_url }}
-          RELEASE_KEY: ${{ needs.resolve-env.outputs.release_key }}
+          RELEASE_KEY: ${{ secrets.RELEASE_KEY }}
           R2_PUBLIC_URL: ${{ needs.resolve-env.outputs.r2_public_url }}
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Summary

- **DEV_/PROD_ prefixed repo secrets** for R2 + coordinator isolation. Both `release-swift.yml` and `release-rust-bridge.yml` resolve the right prefixed secrets in a `resolve-env` step using bash indirection — no GitHub environments needed.
- **Soft-fail Swift tests on dev releases**: live MLX model cache may be incomplete on CI. Prod should re-enable `set -euo pipefail`.
- **Full model download**: removed `--include` filter on `hf download` so `config.json` and all model files land in the HuggingFace cache.

## Required Repo Secrets

Add these prefixed secrets to the GitHub repo (Settings → Secrets → Actions):

| Secret | Dev Value | Prod Value |
|--------|-----------|------------|
| `DEV_R2_ACCESS_KEY_ID` | Dev R2 token ID | — |
| `PROD_R2_ACCESS_KEY_ID` | — | Prod R2 token ID |
| `DEV_R2_SECRET_ACCESS_KEY` | Dev R2 token secret | — |
| `PROD_R2_SECRET_ACCESS_KEY` | — | Prod R2 token secret |
| `DEV_R2_ENDPOINT` | `https://<acct>.r2.cloudflarestorage.com` | — |
| `PROD_R2_ENDPOINT` | — | same or different |
| `DEV_R2_BUCKET` | `d-inf-app-dev` | — |
| `PROD_R2_BUCKET` | — | `d-inf-app-prod` |
| `DEV_R2_PUBLIC_URL` | Dev CDN URL | — |
| `PROD_R2_PUBLIC_URL` | — | Prod CDN URL |
| `DEV_COORDINATOR_URL` | `https://api.dev.darkbloom.xyz` | — |
| `PROD_COORDINATOR_URL` | — | `https://api.darkbloom.dev` |
| `DEV_RELEASE_KEY` | Dev release key | — |
| `PROD_RELEASE_KEY` | — | Prod release key |

Apple signing secrets (`APPLE_CERTIFICATE_P12`, `APPLE_CERTIFICATE_PASSWORD`, `APPLE_ID`, `APPLE_APP_PASSWORD`) stay as-is — shared across both envs.

## Test Plan

1. Add `DEV_*` repo secrets
2. Push `v0.5.0-dev.2` tag → verify dev release uploads to `d-inf-app-dev` bucket
3. Verify `GET /v1/releases/latest` on dev coordinator returns the new release