### PR TITLE
chore: correct version comments for SHA-pinned workflow actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '22'
           cache: 'npm'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,7 +26,7 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
 

--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -57,7 +57,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Checkout PR merge commit
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: refs/pull/${{ steps.pr.outputs.number }}/merge
           fetch-depth: 0
@@ -73,7 +73,7 @@ jobs:
 
       - name: Run Codex
         id: run_codex
-        uses: openai/codex-action@c25d10f3f498316d4b2496cc4c6dd58057a7b031 # v1
+        uses: openai/codex-action@c25d10f3f498316d4b2496cc4c6dd58057a7b031 # v1.6
         with:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
           sandbox: read-only
@@ -107,7 +107,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Post Codex feedback as PR comment
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         env:
           CODEX_FINAL_MESSAGE: ${{ needs.codex.outputs.final_message }}
           PR_NUMBER: ${{ needs.codex.outputs.pr_number }}


### PR DESCRIPTION
## Summary

All GitHub Actions in the workflow files were already SHA-pinned (good), but several version comments were inaccurate or imprecise. This PR corrects the comments to exactly match the version each pinned SHA corresponds to, verified via the GitHub API.

**Changes:**
- `actions/setup-node`: comment `# v4` → `# v4.4.0` (SHA `49933ea5...` is v4.4.0)
- `actions/checkout`: comment `# v6.0.0` → `# v6.0.2` (SHA `de0fac2e...` is v6.0.2, in claude.yml and codex.yml)
- `openai/codex-action`: comment `# v1` → `# v1.6` (SHA `c25d10f3...` is v1.6)
- `actions/github-script`: comment `# v7` → `# v7.1.0` (SHA `f28e40c7...` is v7.1.0)

No SHA values were changed — all were already correct.

## Test plan

- [ ] Verify all 4 workflow files still reference the same SHA values (only comments changed)
- [ ] Confirm CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)