### PR TITLE
feat: per-model context window and max output tokens in catalog

### DIFF
--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -230,7 +230,7 @@ func stripProviderRoutingFields(parsed map[string]any) bool {
 // post-inference charge would fail silently (see GitHub issue #33). Consumers
 // who need longer generations must set max_tokens explicitly and carry the
 // balance to cover it.
-const defaultMaxOutputTokens = 8192
+const defaultMaxOutputTokens = 32768
 
 // explicitMaxTokens returns the consumer-specified max output tokens from any
 // of the recognized field names, or 0 if none were set.
@@ -256,20 +256,26 @@ func (s *Server) reservationCost(model string, promptTokens, maxTokens int) int6
 	return payments.CalculateCostWithOverrides(model, promptTokens, maxTokens, customIn, customOut, hasCustom)
 }
 
-// ensureMaxTokensBound injects defaultMaxOutputTokens into parsed when the
+// ensureMaxTokensBound injects a max-tokens bound into parsed when the
 // consumer didn't specify any max-tokens field, so the outgoing request to
-// the provider is bounded by the amount we reserve upfront. The injected
-// field name depends on the API flavor: Responses API uses max_output_tokens,
-// everything else uses max_tokens. Returns true when an injection occurred,
-// so the caller can re-marshal the outgoing body if needed.
-func ensureMaxTokensBound(parsed map[string]any, isResponsesAPI bool) bool {
+// the provider is bounded by the amount we reserve upfront. Uses the
+// per-model limit from the catalog when available, otherwise falls back to
+// defaultMaxOutputTokens. The injected field name depends on the API flavor:
+// Responses API uses max_output_tokens, everything else uses max_tokens.
+// Returns true when an injection occurred, so the caller can re-marshal the
+// outgoing body if needed.
+func ensureMaxTokensBound(parsed map[string]any, isResponsesAPI bool, modelMaxTokens int) bool {
 	if explicitMaxTokens(parsed) > 0 {
 		return false
 	}
+	limit := defaultMaxOutputTokens
+	if modelMaxTokens > 0 {
+		limit = modelMaxTokens
+	}
 	if isResponsesAPI {
-		parsed["max_output_tokens"] = defaultMaxOutputTokens
+		parsed["max_output_tokens"] = limit
 	} else {
-		parsed["max_tokens"] = defaultMaxOutputTokens
+		parsed["max_tokens"] = limit
 	}
 	return true
 }
@@ -568,7 +574,8 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 	// outgoing body. Without this bound the provider could return more tokens
 	// than we reserved for, and the silent post-inference charge failure would
 	// hand the consumer free inference (GitHub issue #33).
-	if ensureMaxTokensBound(parsed, isResponsesAPI) {
+	modelMaxOutputTokens := s.registry.CatalogMaxOutputTokens(model)
+	if ensureMaxTokensBound(parsed, isResponsesAPI, modelMaxOutputTokens) {
 		rawBody, _ = json.Marshal(parsed)
 	}
 
@@ -2143,6 +2150,16 @@ func (s *Server) handleListModels(w http.ResponseWriter, r *http.Request) {
 		if inCatalog && cm.DisplayName != "" {
 			metadata["display_name"] = cm.DisplayName
 		}
+		contextLength := registry.DefaultContextLength
+		maxOutput := registry.DefaultMaxOutputTokens
+		if inCatalog && cm.ContextLength > 0 {
+			contextLength = cm.ContextLength
+		}
+		if inCatalog && cm.MaxOutputTokens > 0 {
+			maxOutput = cm.MaxOutputTokens
+		}
+		metadata["context_length"] = contextLength
+		metadata["max_output_tokens"] = maxOutput
 		data = append(data, map[string]any{
 			"id":       m.ID,
 			"object":   "model",
@@ -2446,7 +2463,7 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 	// Completions and Anthropic messages both use the max_tokens field (never
 	// max_output_tokens, which is Responses API only). Inject a default if
 	// unset so the pre-flight reservation bounds the generation.
-	ensureMaxTokensBound(parsed, false)
+	ensureMaxTokensBound(parsed, false, s.registry.CatalogMaxOutputTokens(model))
 
 	stream, _ := parsed["stream"].(bool)
 	estimatedPromptTokens := estimatePromptTokens(parsed)

--- a/coordinator/api/server.go
+++ b/coordinator/api/server.go
@@ -422,9 +422,11 @@ func (s *Server) SyncModelCatalog() {
 	for _, m := range models {
 		if m.Active && !IsRetiredProviderModel(m) {
 			entries = append(entries, registry.CatalogEntry{
-				ID:         m.ID,
-				WeightHash: m.WeightHash,
-				SizeGB:     m.SizeGB,
+				ID:              m.ID,
+				WeightHash:      m.WeightHash,
+				SizeGB:          m.SizeGB,
+				ContextLength:   m.ContextLength,
+				MaxOutputTokens: m.MaxOutputTokens,
 			})
 		}
 	}

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -608,9 +608,11 @@ func TruncHash(h string) string {
 
 // CatalogEntry holds metadata about an active model in the catalog.
 type CatalogEntry struct {
-	ID         string
-	WeightHash string  // expected SHA-256 weight fingerprint (empty = not enforced)
-	SizeGB     float64 // disk/GPU footprint of the model weights (zero = unknown, gate disabled)
+	ID              string
+	WeightHash      string  // expected SHA-256 weight fingerprint (empty = not enforced)
+	SizeGB          float64 // disk/GPU footprint of the model weights (zero = unknown, gate disabled)
+	ContextLength   int     // max context window in tokens (0 = default 131072)
+	MaxOutputTokens int     // max output tokens per request (0 = default 32768)
 }
 
 // SetModelCatalog updates the set of active models. Only models in this
@@ -681,6 +683,35 @@ func (r *Registry) catalogSizeGBLocked(model string) float64 {
 		return e.SizeGB
 	}
 	return 0
+}
+
+const (
+	DefaultContextLength   = 131072 // 128k tokens
+	DefaultMaxOutputTokens = 32768  // 32k tokens
+)
+
+// CatalogContextLength returns the context window for a model. Returns
+// DefaultContextLength (128k) if the model is not in the catalog or the
+// field is unset.
+func (r *Registry) CatalogContextLength(model string) int {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if e, ok := r.modelCatalog[model]; ok && e.ContextLength > 0 {
+		return e.ContextLength
+	}
+	return DefaultContextLength
+}
+
+// CatalogMaxOutputTokens returns the max output tokens for a model. Returns
+// DefaultMaxOutputTokens (32k) if the model is not in the catalog or the
+// field is unset.
+func (r *Registry) CatalogMaxOutputTokens(model string) int {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if e, ok := r.modelCatalog[model]; ok && e.MaxOutputTokens > 0 {
+		return e.MaxOutputTokens
+	}
+	return DefaultMaxOutputTokens
 }
 
 // trustMeetsMinimum returns true if the given trust level meets the minimum.

--- a/coordinator/store/interface.go
+++ b/coordinator/store/interface.go
@@ -545,16 +545,18 @@ type StripeWithdrawal struct {
 // small chat models (< 7B) are not useful, but small specialized models
 // (embeddings) can be best-in-class.
 type SupportedModel struct {
-	ID           string  `json:"id"`           // HuggingFace path (e.g. "mlx-community/Qwen3.5-9B-MLX-4bit")
-	S3Name       string  `json:"s3_name"`      // CDN key for download (e.g. "Qwen3.5-9B-MLX-4bit")
-	DisplayName  string  `json:"display_name"` // Human-readable (e.g. "Qwen3.5 9B")
-	ModelType    string  `json:"model_type"`   // "text", "embedding", "tts"
-	SizeGB       float64 `json:"size_gb"`      // Disk/memory size in GB
-	Architecture string  `json:"architecture"` // e.g. "9B dense", "2B conformer"
-	Description  string  `json:"description"`  // e.g. "Balanced", "Fast reasoning"
-	MinRAMGB     int     `json:"min_ram_gb"`   // Minimum system RAM for auto-selection
-	Active       bool    `json:"active"`       // Whether available for use
-	WeightHash   string  `json:"weight_hash"`  // Expected SHA-256 fingerprint of model weight files
+	ID              string  `json:"id"`               // HuggingFace path (e.g. "mlx-community/Qwen3.5-9B-MLX-4bit")
+	S3Name          string  `json:"s3_name"`          // CDN key for download (e.g. "Qwen3.5-9B-MLX-4bit")
+	DisplayName     string  `json:"display_name"`     // Human-readable (e.g. "Qwen3.5 9B")
+	ModelType       string  `json:"model_type"`       // "text", "embedding", "tts"
+	SizeGB          float64 `json:"size_gb"`          // Disk/memory size in GB
+	Architecture    string  `json:"architecture"`     // e.g. "9B dense", "2B conformer"
+	Description     string  `json:"description"`      // e.g. "Balanced", "Fast reasoning"
+	MinRAMGB        int     `json:"min_ram_gb"`       // Minimum system RAM for auto-selection
+	Active          bool    `json:"active"`           // Whether available for use
+	WeightHash      string  `json:"weight_hash"`      // Expected SHA-256 fingerprint of model weight files
+	ContextLength   int     `json:"context_length"`   // Maximum context window in tokens (0 = use default 131072)
+	MaxOutputTokens int     `json:"max_output_tokens"` // Maximum output tokens per request (0 = use default 32768)
 }
 
 // Release represents a versioned provider binary release.

--- a/coordinator/store/interface.go
+++ b/coordinator/store/interface.go
@@ -545,17 +545,17 @@ type StripeWithdrawal struct {
 // small chat models (< 7B) are not useful, but small specialized models
 // (embeddings) can be best-in-class.
 type SupportedModel struct {
-	ID              string  `json:"id"`               // HuggingFace path (e.g. "mlx-community/Qwen3.5-9B-MLX-4bit")
-	S3Name          string  `json:"s3_name"`          // CDN key for download (e.g. "Qwen3.5-9B-MLX-4bit")
-	DisplayName     string  `json:"display_name"`     // Human-readable (e.g. "Qwen3.5 9B")
-	ModelType       string  `json:"model_type"`       // "text", "embedding", "tts"
-	SizeGB          float64 `json:"size_gb"`          // Disk/memory size in GB
-	Architecture    string  `json:"architecture"`     // e.g. "9B dense", "2B conformer"
-	Description     string  `json:"description"`      // e.g. "Balanced", "Fast reasoning"
-	MinRAMGB        int     `json:"min_ram_gb"`       // Minimum system RAM for auto-selection
-	Active          bool    `json:"active"`           // Whether available for use
-	WeightHash      string  `json:"weight_hash"`      // Expected SHA-256 fingerprint of model weight files
-	ContextLength   int     `json:"context_length"`   // Maximum context window in tokens (0 = use default 131072)
+	ID              string  `json:"id"`                // HuggingFace path (e.g. "mlx-community/Qwen3.5-9B-MLX-4bit")
+	S3Name          string  `json:"s3_name"`           // CDN key for download (e.g. "Qwen3.5-9B-MLX-4bit")
+	DisplayName     string  `json:"display_name"`      // Human-readable (e.g. "Qwen3.5 9B")
+	ModelType       string  `json:"model_type"`        // "text", "embedding", "tts"
+	SizeGB          float64 `json:"size_gb"`           // Disk/memory size in GB
+	Architecture    string  `json:"architecture"`      // e.g. "9B dense", "2B conformer"
+	Description     string  `json:"description"`       // e.g. "Balanced", "Fast reasoning"
+	MinRAMGB        int     `json:"min_ram_gb"`        // Minimum system RAM for auto-selection
+	Active          bool    `json:"active"`            // Whether available for use
+	WeightHash      string  `json:"weight_hash"`       // Expected SHA-256 fingerprint of model weight files
+	ContextLength   int     `json:"context_length"`    // Maximum context window in tokens (0 = use default 131072)
 	MaxOutputTokens int     `json:"max_output_tokens"` // Maximum output tokens per request (0 = use default 32768)
 }
 

--- a/coordinator/store/postgres.go
+++ b/coordinator/store/postgres.go
@@ -275,6 +275,15 @@ func (s *PostgresStore) migrate(ctx context.Context) error {
 			ALTER TABLE supported_models ADD COLUMN IF NOT EXISTS weight_hash TEXT NOT NULL DEFAULT '';
 		EXCEPTION WHEN others THEN NULL;
 		END $$`,
+		// Add context_length and max_output_tokens columns for per-model token limits
+		`DO $$ BEGIN
+			ALTER TABLE supported_models ADD COLUMN IF NOT EXISTS context_length INTEGER NOT NULL DEFAULT 0;
+		EXCEPTION WHEN others THEN NULL;
+		END $$`,
+		`DO $$ BEGIN
+			ALTER TABLE supported_models ADD COLUMN IF NOT EXISTS max_output_tokens INTEGER NOT NULL DEFAULT 0;
+		EXCEPTION WHEN others THEN NULL;
+		END $$`,
 
 		// Releases (provider binary versioning)
 		`CREATE TABLE IF NOT EXISTS releases (
@@ -1619,13 +1628,14 @@ func (s *PostgresStore) SetSupportedModel(model *SupportedModel) error {
 	defer cancel()
 
 	_, err := s.pool.Exec(ctx,
-		`INSERT INTO supported_models (id, s3_name, display_name, model_type, size_gb, architecture, description, min_ram_gb, active, weight_hash, updated_at)
-		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, NOW())
+		`INSERT INTO supported_models (id, s3_name, display_name, model_type, size_gb, architecture, description, min_ram_gb, active, weight_hash, context_length, max_output_tokens, updated_at)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, NOW())
 		 ON CONFLICT (id) DO UPDATE SET
 		   s3_name = $2, display_name = $3, model_type = $4, size_gb = $5, architecture = $6,
-		   description = $7, min_ram_gb = $8, active = $9, weight_hash = $10, updated_at = NOW()`,
+		   description = $7, min_ram_gb = $8, active = $9, weight_hash = $10, context_length = $11, max_output_tokens = $12, updated_at = NOW()`,
 		model.ID, model.S3Name, model.DisplayName, model.ModelType, model.SizeGB,
 		model.Architecture, model.Description, model.MinRAMGB, model.Active, model.WeightHash,
+		model.ContextLength, model.MaxOutputTokens,
 	)
 	if err != nil {
 		return fmt.Errorf("store: set supported model: %w", err)
@@ -1638,7 +1648,7 @@ func (s *PostgresStore) ListSupportedModels() []SupportedModel {
 	defer cancel()
 
 	rows, err := s.pool.Query(ctx,
-		`SELECT id, s3_name, display_name, model_type, size_gb, architecture, description, min_ram_gb, active, weight_hash
+		`SELECT id, s3_name, display_name, model_type, size_gb, architecture, description, min_ram_gb, active, weight_hash, context_length, max_output_tokens
 		 FROM supported_models ORDER BY model_type ASC, min_ram_gb ASC, size_gb ASC`,
 	)
 	if err != nil {
@@ -1650,7 +1660,8 @@ func (s *PostgresStore) ListSupportedModels() []SupportedModel {
 	for rows.Next() {
 		var m SupportedModel
 		if err := rows.Scan(&m.ID, &m.S3Name, &m.DisplayName, &m.ModelType, &m.SizeGB,
-			&m.Architecture, &m.Description, &m.MinRAMGB, &m.Active, &m.WeightHash); err != nil {
+			&m.Architecture, &m.Description, &m.MinRAMGB, &m.Active, &m.WeightHash,
+			&m.ContextLength, &m.MaxOutputTokens); err != nil {
 			continue
 		}
 		models = append(models, m)

--- a/provider-swift/Sources/ProviderCore/ProviderLoop.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop.swift
@@ -142,7 +142,7 @@ public actor ProviderLoop {
 
     private static let schedulerMaxConcurrent = 4
     private static let schedulerPendingTimeout: Duration = .seconds(120)
-    private static let schedulerDefaultMaxTokens = 4096
+    private static let schedulerDefaultMaxTokens = 32_768
 
     private struct ModelSlot {
         let scheduler: BatchScheduler

--- a/provider-swift/Sources/ProviderCore/Server/StandaloneServer.swift
+++ b/provider-swift/Sources/ProviderCore/Server/StandaloneServer.swift
@@ -62,7 +62,7 @@ public actor StandaloneServer {
 
     private static let schedulerMaxConcurrent = 4
     private static let schedulerPendingTimeout: Duration = .seconds(120)
-    private static let schedulerDefaultMaxTokens = 4096
+    private static let schedulerDefaultMaxTokens = 32_768
 
     public func loadModel(_ modelId: String, container: MLXLMCommon.ModelContainer) async {
         let scheduler = BatchScheduler(


### PR DESCRIPTION
## Summary

- Add `context_length` and `max_output_tokens` fields to the model catalog
- Default: 128k context window, 32k max output tokens
- Provider scheduler uses 32k max tokens (up from 4096) to support full context generation

## Changes

**Coordinator (Go):**
- `store.SupportedModel` + `registry.CatalogEntry`: new `ContextLength` and `MaxOutputTokens` fields
- Postgres migration adds columns with 0 defaults (0 = use hardcoded defaults)
- `registry.DefaultContextLength = 131072`, `registry.DefaultMaxOutputTokens = 32768`
- `ensureMaxTokensBound()` now uses per-model `MaxOutputTokens` from catalog
- `GET /v1/models` response includes `context_length` and `max_output_tokens` in metadata
- `defaultMaxOutputTokens` raised from 8192 → 32768

**Provider (Swift):**
- `schedulerDefaultMaxTokens` raised from 4096 → 32768

## Stacked on

PR #167 (multi-model concurrent serving)

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` — all coordinator tests pass
- [x] `swift build` passes
- [x] `swift test` — 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)