### PR TITLE
feat: add adaptive provider batching capacity

### DIFF
--- a/coordinator/api/adaptive_capacity_integration_test.go
+++ b/coordinator/api/adaptive_capacity_integration_test.go
@@ -1,0 +1,292 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+	"github.com/eigeninference/d-inference/coordinator/registry"
+	"github.com/eigeninference/d-inference/coordinator/store"
+	"nhooyr.io/websocket"
+)
+
+func setupAdaptiveCapacityIntegration(t *testing.T) (*httptest.Server, *registry.Registry) {
+	t.Helper()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	st := store.NewMemory("test-key")
+	reg := registry.New(logger)
+	srv := NewServer(reg, st, logger)
+	srv.challengeInterval = time.Hour
+	ts := httptest.NewServer(srv.Handler())
+	return ts, reg
+}
+
+func markOnlyProviderRoutable(t *testing.T, reg *registry.Registry) *registry.Provider {
+	t.Helper()
+	ids := reg.ProviderIDs()
+	if len(ids) != 1 {
+		t.Fatalf("provider count = %d, want 1", len(ids))
+	}
+	reg.SetTrustLevel(ids[0], registry.TrustHardware)
+	reg.RecordChallengeSuccess(ids[0])
+	p := reg.GetProvider(ids[0])
+	if p == nil {
+		t.Fatalf("provider %q not found", ids[0])
+	}
+	p.Mu().Lock()
+	p.RuntimeVerified = true
+	p.RuntimeManifestChecked = true
+	p.ChallengeVerifiedSIP = true
+	p.Mu().Unlock()
+	return p
+}
+
+func writeAdaptiveHeartbeat(t *testing.T, ctx context.Context, conn *websocket.Conn, activeModel string, capacity *protocol.BackendCapacity) {
+	t.Helper()
+	msg := protocol.HeartbeatMessage{
+		Type:            protocol.TypeHeartbeat,
+		Status:          "serving",
+		Stats:           protocol.HeartbeatStats{},
+		WarmModels:      []string{activeModel},
+		SystemMetrics:   protocol.SystemMetrics{MemoryPressure: 0.1, CPUUsage: 0.1, ThermalState: "nominal"},
+		BackendCapacity: capacity,
+	}
+	if activeModel != "" {
+		msg.ActiveModel = &activeModel
+	}
+	data, err := json.Marshal(msg)
+	if err != nil {
+		t.Fatalf("marshal heartbeat: %v", err)
+	}
+	if err := conn.Write(ctx, websocket.MessageText, data); err != nil {
+		t.Fatalf("write heartbeat: %v", err)
+	}
+}
+
+func waitForAdaptiveCondition(t *testing.T, timeout time.Duration, condition func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if condition() {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("condition not met before timeout")
+}
+
+func adaptiveChatRequest(ctx context.Context, baseURL, model string, maxTokens int) (int, string, error) {
+	body := fmt.Sprintf(`{"model":%q,"messages":[{"role":"user","content":"hello"}],"stream":true,"max_tokens":%d}`, model, maxTokens)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, baseURL+"/v1/chat/completions", strings.NewReader(body))
+	if err != nil {
+		return 0, "", err
+	}
+	req.Header.Set("Authorization", "Bearer test-key")
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return 0, "", err
+	}
+	defer resp.Body.Close()
+	data, _ := io.ReadAll(resp.Body)
+	return resp.StatusCode, string(data), nil
+}
+
+func TestAdaptiveCapacityIntegrationHeartbeatMaxConcurrencyDrivesMultiModelRouting(t *testing.T) {
+	ts, reg := setupAdaptiveCapacityIntegration(t)
+	defer ts.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	modelA := "adaptive-heartbeat-a"
+	modelB := "adaptive-heartbeat-b"
+	conn := connectProvider(t, ctx, ts.URL, []protocol.ModelInfo{
+		{ID: modelA, ModelType: "chat", Quantization: "4bit"},
+		{ID: modelB, ModelType: "chat", Quantization: "4bit"},
+	}, testPublicKeyB64())
+	defer conn.Close(websocket.StatusNormalClosure, "done")
+	p := markOnlyProviderRoutable(t, reg)
+
+	writeAdaptiveHeartbeat(t, ctx, conn, modelA, &protocol.BackendCapacity{
+		TotalMemoryGB: 64,
+		Slots: []protocol.BackendSlotCapacity{
+			{Model: modelA, State: "running", MaxConcurrency: 1, ActiveTokenBudgetMax: 32_768},
+			{Model: modelB, State: "running", MaxConcurrency: 2, ActiveTokenBudgetMax: 32_768},
+		},
+	})
+	waitForAdaptiveCondition(t, time.Second, func() bool {
+		return p.MaxConcurrencyForModel(modelA) == 1 && p.MaxConcurrencyForModel(modelB) == 2
+	})
+
+	firstA := &registry.PendingRequest{RequestID: "first-a", Model: modelA, EstimatedPromptTokens: 10, RequestedMaxTokens: 128}
+	if selected := reg.ReserveProvider(modelA, firstA); selected == nil || selected.ID != p.ID {
+		t.Fatalf("first model A request selected %#v, want provider %q", selected, p.ID)
+	}
+
+	secondA := &registry.PendingRequest{RequestID: "second-a", Model: modelA, EstimatedPromptTokens: 10, RequestedMaxTokens: 128}
+	selectedA, decisionA := reg.ReserveProviderEx(modelA, secondA)
+	if selectedA != nil {
+		t.Fatalf("second model A request selected %q, want nil at slot cap", selectedA.ID)
+	}
+	if decisionA.CapacityRejections != 1 {
+		t.Fatalf("model A capacity rejections = %d, want 1", decisionA.CapacityRejections)
+	}
+
+	firstB := &registry.PendingRequest{RequestID: "first-b", Model: modelB, EstimatedPromptTokens: 10, RequestedMaxTokens: 128}
+	if selected := reg.ReserveProvider(modelB, firstB); selected == nil || selected.ID != p.ID {
+		t.Fatalf("model B request selected %#v, want provider %q despite model A saturation", selected, p.ID)
+	}
+}
+
+func TestAdaptiveCapacityIntegrationQueueDrainUsesHeartbeatSlotCaps(t *testing.T) {
+	ts, reg := setupAdaptiveCapacityIntegration(t)
+	defer ts.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	modelA := "adaptive-queue-a"
+	modelB := "adaptive-queue-b"
+	conn := connectProvider(t, ctx, ts.URL, []protocol.ModelInfo{
+		{ID: modelA, ModelType: "chat", Quantization: "4bit"},
+		{ID: modelB, ModelType: "chat", Quantization: "4bit"},
+	}, testPublicKeyB64())
+	defer conn.Close(websocket.StatusNormalClosure, "done")
+	p := markOnlyProviderRoutable(t, reg)
+
+	writeAdaptiveHeartbeat(t, ctx, conn, modelA, &protocol.BackendCapacity{
+		TotalMemoryGB: 64,
+		Slots: []protocol.BackendSlotCapacity{
+			{Model: modelA, State: "running", MaxConcurrency: 1, ActiveTokenBudgetMax: 32_768},
+			{Model: modelB, State: "running", MaxConcurrency: 1, ActiveTokenBudgetMax: 32_768},
+		},
+	})
+	waitForAdaptiveCondition(t, time.Second, func() bool { return p.MaxConcurrencyForModel(modelA) == 1 })
+
+	p.AddPending(&registry.PendingRequest{RequestID: "active-a", ProviderID: p.ID, Model: modelA, RequestedMaxTokens: 128})
+	queuedA := &registry.QueuedRequest{
+		RequestID:  "queued-a",
+		Model:      modelA,
+		ResponseCh: make(chan *registry.Provider, 1),
+		Pending:    &registry.PendingRequest{RequestID: "queued-a", Model: modelA, RequestedMaxTokens: 128},
+	}
+	queuedB := &registry.QueuedRequest{
+		RequestID:  "queued-b",
+		Model:      modelB,
+		ResponseCh: make(chan *registry.Provider, 1),
+		Pending:    &registry.PendingRequest{RequestID: "queued-b", Model: modelB, RequestedMaxTokens: 128},
+	}
+	if err := reg.Queue().Enqueue(queuedA); err != nil {
+		t.Fatalf("enqueue A: %v", err)
+	}
+	if err := reg.Queue().Enqueue(queuedB); err != nil {
+		t.Fatalf("enqueue B: %v", err)
+	}
+
+	reg.SetProviderIdle(p.ID)
+
+	select {
+	case assigned := <-queuedB.ResponseCh:
+		if assigned == nil || assigned.ID != p.ID {
+			t.Fatalf("queued B assigned %#v, want provider %q", assigned, p.ID)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("queued B should drain while model A is saturated")
+	}
+	select {
+	case assigned := <-queuedA.ResponseCh:
+		t.Fatalf("queued A should remain queued at model A slot cap, got %#v", assigned)
+	default:
+	}
+
+	p.RemovePending("active-a")
+	reg.SetProviderIdle(p.ID)
+
+	select {
+	case assigned := <-queuedA.ResponseCh:
+		if assigned == nil || assigned.ID != p.ID {
+			t.Fatalf("queued A assigned %#v after freeing capacity, want provider %q", assigned, p.ID)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("queued A should drain after model A capacity is freed")
+	}
+}
+
+func TestAdaptiveCapacityIntegrationHTTP429WhenTokenBudgetExhausted(t *testing.T) {
+	ts, reg := setupAdaptiveCapacityIntegration(t)
+	defer ts.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	model := "adaptive-budget-http"
+	conn := connectProvider(t, ctx, ts.URL, []protocol.ModelInfo{{ID: model, ModelType: "chat", Quantization: "4bit"}}, testPublicKeyB64())
+	defer conn.Close(websocket.StatusNormalClosure, "done")
+	p := markOnlyProviderRoutable(t, reg)
+
+	writeAdaptiveHeartbeat(t, ctx, conn, model, &protocol.BackendCapacity{
+		TotalMemoryGB: 64,
+		Slots: []protocol.BackendSlotCapacity{{
+			Model:                 model,
+			State:                 "running",
+			MaxConcurrency:        8,
+			ActiveTokenBudgetUsed: 950,
+			ActiveTokenBudgetMax:  1_000,
+		}},
+	})
+	waitForAdaptiveCondition(t, time.Second, func() bool {
+		p.Mu().Lock()
+		defer p.Mu().Unlock()
+		return p.BackendCapacity != nil && p.BackendCapacity.Slots[0].ActiveTokenBudgetMax == 1_000
+	})
+
+	status, body, err := adaptiveChatRequest(ctx, ts.URL, model, 256)
+	if err != nil {
+		t.Fatalf("chat request: %v", err)
+	}
+	if status != http.StatusTooManyRequests {
+		t.Fatalf("status = %d, want 429, body = %s", status, body)
+	}
+	if !strings.Contains(body, "at capacity") {
+		t.Fatalf("body = %s, want capacity error", body)
+	}
+}
+
+func TestAdaptiveCapacityIntegrationOmittedMaxConcurrencyUsesLegacyFallback(t *testing.T) {
+	ts, reg := setupAdaptiveCapacityIntegration(t)
+	defer ts.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	model := "adaptive-legacy-fallback"
+	conn := connectProvider(t, ctx, ts.URL, []protocol.ModelInfo{{ID: model, ModelType: "chat", Quantization: "4bit"}}, testPublicKeyB64())
+	defer conn.Close(websocket.StatusNormalClosure, "done")
+	p := markOnlyProviderRoutable(t, reg)
+
+	writeAdaptiveHeartbeat(t, ctx, conn, model, &protocol.BackendCapacity{
+		TotalMemoryGB: 64,
+		Slots:         []protocol.BackendSlotCapacity{{Model: model, State: "running"}},
+	})
+	waitForAdaptiveCondition(t, time.Second, func() bool {
+		return p.MaxConcurrencyForModel(model) == 6
+	})
+
+	for i := range 4 {
+		p.AddPending(&registry.PendingRequest{RequestID: fmt.Sprintf("legacy-%d", i), ProviderID: p.ID, Model: model, RequestedMaxTokens: 128})
+	}
+	candidates, rejections := reg.QuickCapacityCheck(model, 10, 128)
+	if candidates != 1 || rejections != 0 {
+		t.Fatalf("QuickCapacityCheck candidates=%d rejections=%d, want 1/0 with legacy fallback", candidates, rejections)
+	}
+}

--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -179,6 +179,9 @@ func (s *Server) dispatchOneProvider(
 			return nil, nil, decision, "insufficient funds for provider price", http.StatusPaymentRequired
 		}
 	}
+	if pr.Timing != nil {
+		pr.Timing.RoutedAt = time.Now()
+	}
 
 	// refundExtra credits back the provider-specific surcharge that
 	// reserveAdditionalForProvider may have added. The caller's
@@ -222,6 +225,9 @@ func (s *Server) dispatchOneProvider(
 		refundExtra()
 		s.registry.SetProviderIdle(provider.ID)
 		return nil, nil, decision, "failed to encrypt request", http.StatusInternalServerError
+	}
+	if pr.Timing != nil {
+		pr.Timing.EncryptedAt = time.Now()
 	}
 
 	wireMsg := map[string]any{
@@ -1063,6 +1069,7 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 					continue
 				}
 			}
+			timing.RoutedAt = time.Now()
 
 			// Perform E2E encryption and send the request.
 			if provider.PublicKey == "" {
@@ -1113,7 +1120,9 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 			pr.Timing.DispatchedAt = time.Now()
 		}
 		requestID = pr.RequestID
-		timing.RoutedAt = time.Now()
+		if timing.RoutedAt.IsZero() {
+			timing.RoutedAt = time.Now()
+		}
 		s.ddIncr("routing.decisions", []string{"model:" + model, "outcome:selected"})
 		s.ddIncr("routing.provider_selected", []string{"provider_id:" + provider.ID, "model:" + model})
 

--- a/coordinator/protocol/messages.go
+++ b/coordinator/protocol/messages.go
@@ -140,12 +140,13 @@ type HeartbeatMessage struct {
 // BackendSlotCapacity describes the capacity state of a single backend slot
 // (one vllm-mlx instance serving one model).
 type BackendSlotCapacity struct {
-	Model              string `json:"model"`                // model ID for this slot
-	State              string `json:"state"`                // "running", "idle_shutdown", "crashed", "reloading"
-	NumRunning         int    `json:"num_running"`          // requests actively generating
-	NumWaiting         int    `json:"num_waiting"`          // requests queued in backend scheduler
-	ActiveTokens       int64  `json:"active_tokens"`        // sum of (prompt_tokens + completion_tokens) across running requests
-	MaxTokensPotential int64  `json:"max_tokens_potential"` // sum of max_tokens across running requests (worst-case growth)
+	Model              string `json:"model"`                     // model ID for this slot
+	State              string `json:"state"`                     // "running", "idle_shutdown", "crashed", "reloading"
+	NumRunning         int    `json:"num_running"`               // requests actively generating
+	NumWaiting         int    `json:"num_waiting"`               // requests queued in backend scheduler
+	MaxConcurrency     int    `json:"max_concurrency,omitempty"` // provider-reported concurrent request cap for this slot
+	ActiveTokens       int64  `json:"active_tokens"`             // sum of (prompt_tokens + completion_tokens) across running requests
+	MaxTokensPotential int64  `json:"max_tokens_potential"`      // sum of max_tokens across running requests (worst-case growth)
 
 	ObservedDecodeTPS     float64 `json:"observed_decode_tps,omitempty"`      // EWMA of measured per-request decode TPS
 	ActiveTokenBudgetUsed int64   `json:"active_token_budget_used,omitempty"` // tokens reserved by active requests (prompt + max_output)

--- a/coordinator/protocol/messages_test.go
+++ b/coordinator/protocol/messages_test.go
@@ -127,6 +127,50 @@ func TestBackendSlotCapacityMaxConcurrencyRoundTrip(t *testing.T) {
 	}
 }
 
+func TestBackendSlotCapacityMaxConcurrencyOmittedCompatibility(t *testing.T) {
+	data := []byte(`{
+		"type":"heartbeat",
+		"status":"serving",
+		"active_model":null,
+		"stats":{},
+		"system_metrics":{},
+		"backend_capacity":{"slots":[{"model":"qwen","state":"running"}]}
+	}`)
+
+	var decoded HeartbeatMessage
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if decoded.BackendCapacity == nil || len(decoded.BackendCapacity.Slots) != 1 {
+		t.Fatalf("decoded slots = %+v", decoded.BackendCapacity)
+	}
+	if got := decoded.BackendCapacity.Slots[0].MaxConcurrency; got != 0 {
+		t.Fatalf("omitted MaxConcurrency=%d, want zero compatibility default", got)
+	}
+}
+
+func TestBackendSlotCapacityMaxConcurrencyExplicitZeroCompatibility(t *testing.T) {
+	data := []byte(`{
+		"type":"heartbeat",
+		"status":"serving",
+		"active_model":null,
+		"stats":{},
+		"system_metrics":{},
+		"backend_capacity":{"slots":[{"model":"qwen","state":"running","max_concurrency":0}]}
+	}`)
+
+	var decoded HeartbeatMessage
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if decoded.BackendCapacity == nil || len(decoded.BackendCapacity.Slots) != 1 {
+		t.Fatalf("decoded slots = %+v", decoded.BackendCapacity)
+	}
+	if got := decoded.BackendCapacity.Slots[0].MaxConcurrency; got != 0 {
+		t.Fatalf("explicit zero MaxConcurrency=%d, want preserved zero", got)
+	}
+}
+
 func TestHeartbeatWithActiveModel(t *testing.T) {
 	model := "qwen3.5-9b"
 	msg := HeartbeatMessage{

--- a/coordinator/protocol/messages_test.go
+++ b/coordinator/protocol/messages_test.go
@@ -94,6 +94,39 @@ func TestHeartbeatMessageMarshal(t *testing.T) {
 	}
 }
 
+func TestBackendSlotCapacityMaxConcurrencyRoundTrip(t *testing.T) {
+	msg := HeartbeatMessage{
+		Type:   TypeHeartbeat,
+		Status: "serving",
+		BackendCapacity: &BackendCapacity{
+			Slots: []BackendSlotCapacity{{
+				Model:          "qwen",
+				State:          "running",
+				MaxConcurrency: 3,
+			}},
+		},
+	}
+
+	data, err := json.Marshal(msg)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !json.Valid(data) {
+		t.Fatal("marshaled heartbeat is invalid JSON")
+	}
+
+	var decoded HeartbeatMessage
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if decoded.BackendCapacity == nil || len(decoded.BackendCapacity.Slots) != 1 {
+		t.Fatalf("decoded slots = %+v", decoded.BackendCapacity)
+	}
+	if got := decoded.BackendCapacity.Slots[0].MaxConcurrency; got != 3 {
+		t.Fatalf("MaxConcurrency=%d, want 3", got)
+	}
+}
+
 func TestHeartbeatWithActiveModel(t *testing.T) {
 	model := "qwen3.5-9b"
 	msg := HeartbeatMessage{

--- a/coordinator/registry/clamp_test.go
+++ b/coordinator/registry/clamp_test.go
@@ -51,7 +51,8 @@ func TestClampBackendCapacityMaliciousValues(t *testing.T) {
 		GPUMemoryPeakGB:   math.NaN(),
 		GPUMemoryCacheGB:  2048,
 		Slots: []protocol.BackendSlotCapacity{
-			{Model: "qwen", MaxTokensPotential: 1 << 60, NumRunning: -1, NumWaiting: -1},
+			{Model: "qwen", MaxTokensPotential: 1 << 60, NumRunning: -1, NumWaiting: -1, MaxConcurrency: -3},
+			{Model: "huge", MaxConcurrency: 99},
 		},
 	}
 	clampBackendCapacity(logger, "p1", bc)
@@ -75,6 +76,12 @@ func TestClampBackendCapacityMaliciousValues(t *testing.T) {
 	if s.NumRunning != 0 || s.NumWaiting != 0 {
 		t.Errorf("NumRunning=%d NumWaiting=%d, want both 0", s.NumRunning, s.NumWaiting)
 	}
+	if s.MaxConcurrency != 0 {
+		t.Errorf("negative MaxConcurrency = %d, want 0", s.MaxConcurrency)
+	}
+	if bc.Slots[1].MaxConcurrency != maxReportedMaxConcurrency {
+		t.Errorf("huge MaxConcurrency = %d, want %d", bc.Slots[1].MaxConcurrency, maxReportedMaxConcurrency)
+	}
 }
 
 func TestClampBackendCapacityReasonableValues(t *testing.T) {
@@ -86,7 +93,7 @@ func TestClampBackendCapacityReasonableValues(t *testing.T) {
 		GPUMemoryPeakGB:   50.1,
 		GPUMemoryCacheGB:  5.2,
 		Slots: []protocol.BackendSlotCapacity{
-			{Model: "qwen", MaxTokensPotential: 32000, NumRunning: 2, NumWaiting: 0},
+			{Model: "qwen", MaxTokensPotential: 32000, NumRunning: 2, NumWaiting: 0, MaxConcurrency: 8},
 		},
 	}
 	clampBackendCapacity(logger, "p1", bc)
@@ -96,5 +103,8 @@ func TestClampBackendCapacityReasonableValues(t *testing.T) {
 	}
 	if bc.Slots[0].MaxTokensPotential != 32000 {
 		t.Errorf("MaxTokensPotential mutated: %v", bc.Slots[0].MaxTokensPotential)
+	}
+	if bc.Slots[0].MaxConcurrency != 8 {
+		t.Errorf("MaxConcurrency mutated: %v", bc.Slots[0].MaxConcurrency)
 	}
 }

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -356,6 +356,15 @@ func (p *Provider) MaxConcurrency() int {
 	return p.maxConcurrency()
 }
 
+// MaxConcurrencyForModel returns the concurrency limit for a specific model.
+// A positive provider-reported slot cap wins; zero/missing preserves the
+// legacy provider-level fallback.
+func (p *Provider) MaxConcurrencyForModel(model string) int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.maxConcurrencyForModelLocked(model)
+}
+
 // maxConcurrency is the lock-free version (caller must hold p.mu).
 //
 // Tier values were lowered in Phase 2 of the routing-algorithm rework
@@ -397,6 +406,66 @@ func (p *Provider) maxConcurrency() int {
 		cap = 12
 	}
 	return cap
+}
+
+// maxConcurrencyForModelLocked is the lock-free model-aware concurrency cap.
+// Caller must hold p.mu.
+func (p *Provider) maxConcurrencyForModelLocked(model string) int {
+	if p.BackendCapacity != nil {
+		for _, slot := range p.BackendCapacity.Slots {
+			if slot.Model == model && slot.MaxConcurrency > 0 {
+				return slot.MaxConcurrency
+			}
+		}
+	}
+	return p.maxConcurrency()
+}
+
+func (p *Provider) pendingCountForModelLocked(model string) int {
+	count := 0
+	for _, pr := range p.pendingReqs {
+		if pr.Model == model {
+			count++
+		}
+	}
+	return count
+}
+
+func (p *Provider) hasReportedMaxConcurrencyForModelLocked(model string) bool {
+	if p.BackendCapacity == nil {
+		return false
+	}
+	for _, slot := range p.BackendCapacity.Slots {
+		if slot.Model == model && slot.MaxConcurrency > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func (p *Provider) pendingLoadForModelLocked(model string) int {
+	if !p.hasReportedMaxConcurrencyForModelLocked(model) {
+		return p.pendingCount()
+	}
+	load := p.pendingCountForModelLocked(model)
+	if p.BackendCapacity != nil {
+		for _, slot := range p.BackendCapacity.Slots {
+			if slot.Model != model {
+				continue
+			}
+			backendLoad := slot.NumRunning + slot.NumWaiting
+			if backendLoad > load {
+				load = backendLoad
+			}
+			break
+		}
+	}
+	return load
+}
+
+func (p *Provider) hasConcurrencyHeadroomForModelLocked(model string) bool {
+	return p.pendingLoadForModelLocked(model) < p.maxConcurrencyForModelLocked(model) &&
+		p.pendingCount() < p.maxConcurrency()
 }
 
 // Registry holds all connected providers and provides routing.
@@ -748,13 +817,14 @@ func (r *Registry) SetQueue(q *RequestQueue) {
 // tok/s, max Mac Studio RAM is 512 GB) so legitimate future hardware isn't
 // clamped unnecessarily.
 const (
-	maxDecodeTPS                = 500.0
-	maxPrefillTPS               = 5000.0
-	maxMemoryBandwidthGBs       = 2000.0
-	maxMemoryGB                 = 1024
-	maxMemoryGBFloat            = 1024.0
-	maxTokensPotential          = 1_000_000
-	maxTokenBudgetCap     int64 = 10_000_000_000 // 10 billion — generous safety valve for total token budget capacity
+	maxDecodeTPS                    = 500.0
+	maxPrefillTPS                   = 5000.0
+	maxMemoryBandwidthGBs           = 2000.0
+	maxMemoryGB                     = 1024
+	maxMemoryGBFloat                = 1024.0
+	maxReportedMaxConcurrency       = 24
+	maxTokensPotential              = 1_000_000
+	maxTokenBudgetCap         int64 = 10_000_000_000 // 10 billion — generous safety valve for total token budget capacity
 )
 
 // clampNonNeg returns v clamped into [0, max]; NaN/negative become 0.
@@ -810,6 +880,15 @@ func clampBackendCapacity(logger *slog.Logger, providerID string, bc *protocol.B
 		}
 		if s.NumWaiting < 0 {
 			s.NumWaiting = 0
+		}
+		if s.MaxConcurrency < 0 || s.MaxConcurrency > maxReportedMaxConcurrency {
+			logger.Warn("provider slot max_concurrency out of range, clamping",
+				"provider_id", providerID, "model", s.Model, "reported", s.MaxConcurrency)
+			if s.MaxConcurrency < 0 {
+				s.MaxConcurrency = 0
+			} else {
+				s.MaxConcurrency = maxReportedMaxConcurrency
+			}
 		}
 		if v, changed := clampNonNeg(s.ObservedDecodeTPS, maxDecodeTPS); changed {
 			logger.Warn("provider slot observed_decode_tps out of range, clamping",
@@ -1306,10 +1385,11 @@ func ScoreProvider(p *Provider, model string) float64 {
 	}
 
 	// Load: gradient from 0.0 (idle) to 1.0 (at max concurrency).
-	// Uses dynamic max based on hardware when backend capacity is reported.
-	pending := float64(p.PendingCount())
+	// Uses a positive provider-reported slot cap when present, otherwise the
+	// legacy provider-level dynamic max.
 	p.mu.Lock()
-	maxConc := p.maxConcurrency()
+	maxConc := p.maxConcurrencyForModelLocked(model)
+	pending := float64(p.pendingLoadForModelLocked(model))
 	p.mu.Unlock()
 	load := pending / float64(maxConc)
 	if load > 1.0 {
@@ -1491,7 +1571,10 @@ func (r *Registry) FindProviderWithTrust(model string, minTrust TrustLevel, excl
 		if lastChallenge.IsZero() || now.Sub(lastChallenge) > challengeMaxAge {
 			continue
 		}
-		if p.PendingCount() >= p.MaxConcurrency() {
+		p.mu.Lock()
+		hasHeadroom := p.hasConcurrencyHeadroomForModelLocked(model)
+		p.mu.Unlock()
+		if !hasHeadroom {
 			continue
 		}
 		for _, m := range p.Models {
@@ -1925,12 +2008,12 @@ func (r *Registry) ModelCapacitySnapshot() []ModelCapacity {
 			continue
 		}
 
-		hasHeadroom := p.pendingCount() < p.maxConcurrency()
 		decodeTPS := resolvedDecodeTPS(p)
 		prefillTPS := resolvedPrefillTPS(p)
 
 		// Enumerate every model this provider serves.
 		for _, m := range p.Models {
+			hasHeadroom := p.hasConcurrencyHeadroomForModelLocked(m.ID)
 			// Count only pending requests for this specific model, not the
 			// total across all models. Using the total inflates
 			// activeRequests for multi-model providers.
@@ -2000,7 +2083,6 @@ func (r *Registry) ModelCapacitySnapshot() []ModelCapacity {
 			a = &modelAgg{bestWarmTTFTMs: -1, bestColdTTFTMs: -1}
 			agg[s.model] = a
 		}
-		a.routable++
 		if s.warm {
 			a.warm++
 		} else {
@@ -2016,14 +2098,14 @@ func (r *Registry) ModelCapacitySnapshot() []ModelCapacity {
 			a.budgetRemaining += headroom
 			a.budgetTotal += s.activeTokenBudgetMax
 		}
-		if s.hasHeadroom {
-			// anyImmediateSlot requires both concurrency headroom AND
-			// token budget headroom. A provider with concurrency room
-			// but exhausted token budget should not bypass the queue
-			// check.
-			if s.activeTokenBudgetMax <= 0 || s.activeTokenBudgetUsed+s.queuedTokenBudget < s.activeTokenBudgetMax {
-				a.anyImmediateSlot = true
-			}
+		// Routable providers require both concurrency headroom AND token-budget
+		// headroom. A provider with exhausted token budget should not make the
+		// model appear immediately ready.
+		hasBudgetHeadroom := s.activeTokenBudgetMax <= 0 ||
+			s.activeTokenBudgetUsed+s.queuedTokenBudget < s.activeTokenBudgetMax
+		if s.hasHeadroom && hasBudgetHeadroom {
+			a.routable++
+			a.anyImmediateSlot = true
 		}
 
 		// Estimate TTFT for this provider: prefill 500 tokens + backlog drain.

--- a/coordinator/registry/scheduler.go
+++ b/coordinator/registry/scheduler.go
@@ -68,6 +68,7 @@ type routingSnapshot struct {
 	provider           *Provider
 	model              string
 	slotState          string
+	hasHeadroom        bool
 	totalPending       int
 	pendingForModel    int
 	pendingMaxTokens   int
@@ -385,9 +386,6 @@ func (r *Registry) snapshotProviderLocked(p *Provider, model string) (routingSna
 	if p.LastChallengeVerified.IsZero() || now.Sub(p.LastChallengeVerified) > challengeFreshnessMaxAge {
 		return routingSnapshot{}, false
 	}
-	if p.pendingCount() >= p.maxConcurrency() {
-		return routingSnapshot{}, false
-	}
 
 	snap := routingSnapshot{
 		provider:      p,
@@ -412,6 +410,7 @@ func (r *Registry) snapshotProviderLocked(p *Provider, model string) (routingSna
 		}
 		snap.pendingMaxTokens += maxTok
 	}
+	snap.hasHeadroom = p.hasConcurrencyHeadroomForModelLocked(model)
 
 	if p.BackendCapacity != nil {
 		snap.gpuMemoryActiveGB = p.BackendCapacity.GPUMemoryActiveGB
@@ -482,6 +481,9 @@ func (r *Registry) buildCandidateWithReason(snap routingSnapshot, pr *PendingReq
 	statePenalty, eligible := slotStatePenalty(snap.slotState)
 	if !eligible {
 		return nil, rejectNone, false
+	}
+	if !snap.hasHeadroom {
+		return nil, rejectCapacity, false
 	}
 
 	if snap.systemMetrics.ThermalState == "critical" {
@@ -687,7 +689,7 @@ func (r *Registry) providerCanAdmitLocked(p *Provider, model string) bool {
 	if !providerServesModelLocked(p, model) {
 		return false
 	}
-	if p.pendingCount() >= p.maxConcurrency() {
+	if !p.hasConcurrencyHeadroomForModelLocked(model) {
 		return false
 	}
 	if p.BackendCapacity != nil {
@@ -783,7 +785,7 @@ func (r *Registry) QuickCapacityCheck(model string, estimatedPromptTokens, reque
 		}
 
 		// Concurrency gate.
-		if p.pendingCount() >= p.maxConcurrency() {
+		if !p.hasConcurrencyHeadroomForModelLocked(model) {
 			p.mu.Unlock()
 			capacityRejections++
 			continue

--- a/coordinator/registry/scheduler_test.go
+++ b/coordinator/registry/scheduler_test.go
@@ -1,6 +1,7 @@
 package registry
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -692,6 +693,130 @@ func TestMaxConcurrencyFallsBackWithoutTokenBudget(t *testing.T) {
 
 	if got := p.MaxConcurrency(); got != 4 {
 		t.Fatalf("MaxConcurrency()=%d, want 4 (48GB legacy tier)", got)
+	}
+}
+
+func TestPerSlotMaxConcurrencyLimitsRoutingForModel(t *testing.T) {
+	reg := New(testLogger())
+	model := "slot-capped-model"
+	p := makeSchedulerProvider(t, reg, "capped", model, 100)
+	p.mu.Lock()
+	p.BackendCapacity.Slots[0].MaxConcurrency = 1
+	p.mu.Unlock()
+
+	first := &PendingRequest{RequestID: "req-first", Model: model, RequestedMaxTokens: 128}
+	if selected := reg.ReserveProvider(model, first); selected == nil {
+		t.Fatal("first request should route")
+	}
+
+	second := &PendingRequest{RequestID: "req-second", Model: model, RequestedMaxTokens: 128}
+	selected, decision := reg.ReserveProviderEx(model, second)
+	if selected != nil {
+		t.Fatalf("second request selected %q, want nil at per-slot cap", selected.ID)
+	}
+	if decision.CandidateCount != 0 || decision.CapacityRejections != 1 {
+		t.Fatalf("decision=%+v, want one capacity rejection at per-slot cap", decision)
+	}
+
+	candidates, rejections := reg.QuickCapacityCheck(model, 100, 128)
+	if candidates != 0 || rejections != 1 {
+		t.Fatalf("QuickCapacityCheck candidates=%d rejections=%d, want 0/1", candidates, rejections)
+	}
+	if found := reg.FindProvider(model); found != nil {
+		t.Fatalf("FindProvider selected %q, want nil at per-slot cap", found.ID)
+	}
+	if score := ScoreProvider(p, model); score != 0 {
+		t.Fatalf("ScoreProvider=%f, want 0 at per-slot cap", score)
+	}
+}
+
+func TestPerSlotMaxConcurrencyZeroFallsBack(t *testing.T) {
+	reg := New(testLogger())
+	model := "slot-zero-model"
+	p := makeSchedulerProvider(t, reg, "fallback", model, 100)
+	p.mu.Lock()
+	p.BackendCapacity.TotalMemoryGB = 64
+	p.BackendCapacity.Slots[0].MaxConcurrency = 0
+	p.mu.Unlock()
+
+	if got := p.MaxConcurrencyForModel(model); got != 6 {
+		t.Fatalf("MaxConcurrencyForModel()=%d, want fallback 6", got)
+	}
+	for i := range 4 {
+		p.AddPending(&PendingRequest{RequestID: fmt.Sprintf("existing-%d", i), Model: model})
+	}
+	candidates, rejections := reg.QuickCapacityCheck(model, 100, 128)
+	if candidates != 1 || rejections != 0 {
+		t.Fatalf("QuickCapacityCheck candidates=%d rejections=%d, want 1/0", candidates, rejections)
+	}
+	if found := reg.FindProvider(model); found == nil {
+		t.Fatal("FindProvider should use fallback cap when max_concurrency is zero")
+	}
+}
+
+func TestPerSlotMaxConcurrencyUsesBackendReportedLoad(t *testing.T) {
+	reg := New(testLogger())
+	model := "backend-loaded-model"
+	p := makeSchedulerProvider(t, reg, "backend-loaded", model, 100)
+	p.mu.Lock()
+	p.BackendCapacity.Slots[0].MaxConcurrency = 1
+	p.BackendCapacity.Slots[0].NumRunning = 1
+	p.mu.Unlock()
+
+	selected, decision := reg.ReserveProviderEx(model, &PendingRequest{
+		RequestID:          "req-over-backend-cap",
+		Model:              model,
+		RequestedMaxTokens: 128,
+	})
+	if selected != nil {
+		t.Fatalf("selected %q, want nil at backend-reported slot cap", selected.ID)
+	}
+	if decision.CandidateCount != 0 || decision.CapacityRejections != 1 {
+		t.Fatalf("decision=%+v, want one capacity rejection from backend slot load", decision)
+	}
+
+	candidates, rejections := reg.QuickCapacityCheck(model, 100, 128)
+	if candidates != 0 || rejections != 1 {
+		t.Fatalf("QuickCapacityCheck candidates=%d rejections=%d, want 0/1", candidates, rejections)
+	}
+}
+
+func TestModelCapacitySnapshotRespectsPerSlotMaxConcurrency(t *testing.T) {
+	reg := New(testLogger())
+	modelA := "snapshot-full-model"
+	modelB := "snapshot-open-model"
+	p := makeSchedulerProvider(t, reg, "snapshot-provider", modelA, 100)
+	p.mu.Lock()
+	p.Models = append(p.Models, protocol.ModelInfo{ID: modelB, ModelType: "chat", Quantization: "4bit"})
+	p.BackendCapacity.Slots = []protocol.BackendSlotCapacity{
+		{Model: modelA, State: "running", NumRunning: 1, MaxConcurrency: 1},
+		{Model: modelB, State: "running", NumRunning: 0, MaxConcurrency: 2},
+	}
+	p.mu.Unlock()
+
+	snapshots := reg.ModelCapacitySnapshot()
+	byModel := make(map[string]ModelCapacity, len(snapshots))
+	for _, snap := range snapshots {
+		byModel[snap.ModelID] = snap
+	}
+
+	full, ok := byModel[modelA]
+	if !ok {
+		t.Fatalf("missing snapshot for %s", modelA)
+	}
+	if full.Ready || full.CanAccept || full.RoutableProviders != 0 {
+		t.Fatalf("full model snapshot=%+v, want not ready/routable", full)
+	}
+	if full.ActiveRequests != 1 {
+		t.Fatalf("full model active_requests=%d, want 1", full.ActiveRequests)
+	}
+
+	open, ok := byModel[modelB]
+	if !ok {
+		t.Fatalf("missing snapshot for %s", modelB)
+	}
+	if !open.Ready || !open.CanAccept || open.RoutableProviders != 1 {
+		t.Fatalf("open model snapshot=%+v, want ready with one routable provider", open)
 	}
 }
 

--- a/coordinator/registry/scheduler_test.go
+++ b/coordinator/registry/scheduler_test.go
@@ -458,6 +458,120 @@ func TestDrainQueuedRequestsUsesAllAvailableCapacity(t *testing.T) {
 	}
 }
 
+func TestDrainQueuedRequestsRespectsPerSlotCapsAcrossModels(t *testing.T) {
+	reg := New(testLogger())
+	modelA := "queue-slot-full-a"
+	modelB := "queue-slot-open-b"
+	p := makeSchedulerProvider(t, reg, "multi-slot", modelA, 100)
+	p.mu.Lock()
+	p.Models = append(p.Models, protocol.ModelInfo{ID: modelB, ModelType: "chat", Quantization: "4bit"})
+	p.BackendCapacity.Slots = []protocol.BackendSlotCapacity{
+		{Model: modelA, State: "running", NumRunning: 0, NumWaiting: 0, MaxConcurrency: 1},
+		{Model: modelB, State: "running", NumRunning: 0, NumWaiting: 0, MaxConcurrency: 1},
+	}
+	p.mu.Unlock()
+
+	p.AddPending(&PendingRequest{RequestID: "existing-a", Model: modelA, RequestedMaxTokens: 128})
+	queuedA := &QueuedRequest{
+		RequestID:  "queued-a",
+		Model:      modelA,
+		ResponseCh: make(chan *Provider, 1),
+		Pending:    &PendingRequest{RequestID: "queued-a", Model: modelA, RequestedMaxTokens: 128},
+	}
+	queuedB := &QueuedRequest{
+		RequestID:  "queued-b",
+		Model:      modelB,
+		ResponseCh: make(chan *Provider, 1),
+		Pending:    &PendingRequest{RequestID: "queued-b", Model: modelB, RequestedMaxTokens: 128},
+	}
+	if err := reg.Queue().Enqueue(queuedA); err != nil {
+		t.Fatalf("enqueue A: %v", err)
+	}
+	if err := reg.Queue().Enqueue(queuedB); err != nil {
+		t.Fatalf("enqueue B: %v", err)
+	}
+
+	reg.SetProviderIdle(p.ID)
+
+	select {
+	case assigned := <-queuedB.ResponseCh:
+		if assigned == nil || assigned.ID != p.ID {
+			t.Fatalf("queued B assigned %#v, want provider %q", assigned, p.ID)
+		}
+	default:
+		t.Fatal("queued B should drain while model A is at its per-slot cap")
+	}
+	select {
+	case assigned := <-queuedA.ResponseCh:
+		t.Fatalf("queued A should remain queued at per-slot cap, got %#v", assigned)
+	default:
+	}
+	if got := reg.Queue().QueueSize(modelA); got != 1 {
+		t.Fatalf("model A queue size = %d, want 1", got)
+	}
+	if got := reg.Queue().QueueSize(modelB); got != 0 {
+		t.Fatalf("model B queue size = %d, want 0", got)
+	}
+}
+
+func TestSetProviderIdleDrainsOnlyFreedModelCapacity(t *testing.T) {
+	reg := New(testLogger())
+	modelA := "idle-freed-a"
+	modelB := "idle-unchanged-b"
+	p := makeSchedulerProvider(t, reg, "idle-multi", modelA, 100)
+	p.mu.Lock()
+	p.Models = append(p.Models, protocol.ModelInfo{ID: modelB, ModelType: "chat", Quantization: "4bit"})
+	p.BackendCapacity.Slots = []protocol.BackendSlotCapacity{
+		{Model: modelA, State: "running", NumRunning: 0, NumWaiting: 0, MaxConcurrency: 1},
+		{Model: modelB, State: "running", NumRunning: 0, NumWaiting: 0, MaxConcurrency: 1},
+	}
+	p.mu.Unlock()
+
+	p.AddPending(&PendingRequest{RequestID: "active-a", Model: modelA, RequestedMaxTokens: 128})
+	p.AddPending(&PendingRequest{RequestID: "active-b", Model: modelB, RequestedMaxTokens: 128})
+	queuedA := &QueuedRequest{
+		RequestID:  "queued-a-after-free",
+		Model:      modelA,
+		ResponseCh: make(chan *Provider, 1),
+		Pending:    &PendingRequest{RequestID: "queued-a-after-free", Model: modelA, RequestedMaxTokens: 128},
+	}
+	queuedB := &QueuedRequest{
+		RequestID:  "queued-b-still-full",
+		Model:      modelB,
+		ResponseCh: make(chan *Provider, 1),
+		Pending:    &PendingRequest{RequestID: "queued-b-still-full", Model: modelB, RequestedMaxTokens: 128},
+	}
+	if err := reg.Queue().Enqueue(queuedA); err != nil {
+		t.Fatalf("enqueue A: %v", err)
+	}
+	if err := reg.Queue().Enqueue(queuedB); err != nil {
+		t.Fatalf("enqueue B: %v", err)
+	}
+
+	p.RemovePending("active-a")
+	reg.SetProviderIdle(p.ID)
+
+	select {
+	case assigned := <-queuedA.ResponseCh:
+		if assigned == nil || assigned.ID != p.ID {
+			t.Fatalf("queued A assigned %#v, want provider %q", assigned, p.ID)
+		}
+	default:
+		t.Fatal("queued A should drain after model A capacity is freed")
+	}
+	select {
+	case assigned := <-queuedB.ResponseCh:
+		t.Fatalf("queued B should remain queued because model B capacity was not freed, got %#v", assigned)
+	default:
+	}
+	if got := reg.Queue().QueueSize(modelA); got != 0 {
+		t.Fatalf("model A queue size = %d, want 0", got)
+	}
+	if got := reg.Queue().QueueSize(modelB); got != 1 {
+		t.Fatalf("model B queue size = %d, want 1", got)
+	}
+}
+
 func TestReserveProviderUsesModelSpecificSlotState(t *testing.T) {
 	reg := New(testLogger())
 	modelA := "model-a"
@@ -781,6 +895,53 @@ func TestPerSlotMaxConcurrencyUsesBackendReportedLoad(t *testing.T) {
 	}
 }
 
+func TestManyPerSlotCapsRespectProviderWideAggregateCap(t *testing.T) {
+	reg := New(testLogger())
+	models := make([]string, 0, 8)
+	for i := range 8 {
+		models = append(models, fmt.Sprintf("aggregate-cap-model-%d", i))
+	}
+	p := makeSchedulerProvider(t, reg, "aggregate-cap", models[0], 100)
+	p.mu.Lock()
+	p.Models = p.Models[:0]
+	p.BackendCapacity.Slots = p.BackendCapacity.Slots[:0]
+	for _, model := range models {
+		p.Models = append(p.Models, protocol.ModelInfo{ID: model, ModelType: "chat", Quantization: "4bit"})
+		p.BackendCapacity.Slots = append(p.BackendCapacity.Slots, protocol.BackendSlotCapacity{
+			Model:                model,
+			State:                "running",
+			MaxConcurrency:       8,
+			ActiveTokenBudgetMax: 32_768,
+		})
+	}
+	p.mu.Unlock()
+
+	for i := range 24 {
+		p.AddPending(&PendingRequest{
+			RequestID:          fmt.Sprintf("existing-%d", i),
+			Model:              models[i%len(models)],
+			RequestedMaxTokens: 128,
+		})
+	}
+
+	selected, decision := reg.ReserveProviderEx(models[0], &PendingRequest{
+		RequestID:             "req-over-aggregate-cap",
+		Model:                 models[0],
+		EstimatedPromptTokens: 100,
+		RequestedMaxTokens:    128,
+	})
+	if selected != nil {
+		t.Fatalf("selected %q, want nil at provider-wide aggregate cap", selected.ID)
+	}
+	if decision.CandidateCount != 0 || decision.CapacityRejections != 1 {
+		t.Fatalf("decision=%+v, want one capacity rejection at aggregate cap", decision)
+	}
+	candidates, rejections := reg.QuickCapacityCheck(models[0], 100, 128)
+	if candidates != 0 || rejections != 1 {
+		t.Fatalf("QuickCapacityCheck candidates=%d rejections=%d, want 0/1", candidates, rejections)
+	}
+}
+
 func TestModelCapacitySnapshotRespectsPerSlotMaxConcurrency(t *testing.T) {
 	reg := New(testLogger())
 	modelA := "snapshot-full-model"
@@ -917,5 +1078,31 @@ func TestFreeMemoryAdmitsFallsBackWithoutBudget(t *testing.T) {
 	// Model already loaded, so only KV matters. Lots of free memory.
 	if !freeMemoryAdmits(snap, 100, 256) {
 		t.Fatal("should admit with plenty of free memory in legacy mode")
+	}
+}
+
+func TestSlotHeadroomWithExhaustedTokenBudgetRejectsCapacity(t *testing.T) {
+	reg := New(testLogger())
+	model := "budget-headroom-model"
+	p := makeTokenBudgetProvider(t, reg, "budget-headroom", model, 100, 32_000, 32_768, 80)
+	p.mu.Lock()
+	p.BackendCapacity.Slots[0].MaxConcurrency = 8
+	p.mu.Unlock()
+
+	selected, decision := reg.ReserveProviderEx(model, &PendingRequest{
+		RequestID:             "req-budget-reject",
+		Model:                 model,
+		EstimatedPromptTokens: 256,
+		RequestedMaxTokens:    1024,
+	})
+	if selected != nil {
+		t.Fatalf("selected %q, want nil with exhausted token budget", selected.ID)
+	}
+	if decision.CandidateCount != 0 || decision.CapacityRejections != 1 {
+		t.Fatalf("decision=%+v, want one capacity rejection from token budget", decision)
+	}
+	candidates, rejections := reg.QuickCapacityCheck(model, 256, 1024)
+	if candidates != 0 || rejections != 1 {
+		t.Fatalf("QuickCapacityCheck candidates=%d rejections=%d, want 0/1", candidates, rejections)
 	}
 }

--- a/e2e/testbed/config.go
+++ b/e2e/testbed/config.go
@@ -24,6 +24,7 @@ type ProviderConfig struct {
 	TrustLevel          TrustLevel
 	ModelID             string
 	AttestationInterval time.Duration
+	AuthTokenPath       string
 }
 
 func DefaultProviderConfig() ProviderConfig {

--- a/e2e/testbed/suite.go
+++ b/e2e/testbed/suite.go
@@ -2,12 +2,15 @@ package testbed
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"log/slog"
 	"net"
 	"net/http"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -69,6 +72,7 @@ type Provider struct {
 	BinaryPath    string
 	Logger        *slog.Logger
 	ProviderIndex int
+	AuthDir       string
 
 	cmd    *os.Process
 	cancel context.CancelFunc
@@ -239,10 +243,17 @@ func (s *Suite) startProviders() error {
 				Logger:        s.Logger.With("provider_index", providerIdx, "model", spec.ModelID),
 				ProviderIndex: providerIdx,
 			}
+			authDir, authTokenPath, err := s.prepareProviderAuth(providerIdx)
+			if err != nil {
+				return fmt.Errorf("prepare provider auth %d: %w", providerIdx, err)
+			}
+			p.AuthDir = authDir
 			if err := p.Start(s.Ctx, s.Coordinator.BaseURL(), ProviderConfig{
-				ModelID:    spec.ModelID,
-				TrustLevel: TrustNone,
+				ModelID:       spec.ModelID,
+				TrustLevel:    TrustNone,
+				AuthTokenPath: authTokenPath,
 			}); err != nil {
+				_ = os.RemoveAll(authDir)
 				return fmt.Errorf("start provider %d (%s): %w", providerIdx, spec.ModelID, err)
 			}
 			s.Providers = append(s.Providers, p)
@@ -250,6 +261,37 @@ func (s *Suite) startProviders() error {
 		}
 	}
 	return nil
+}
+
+func (s *Suite) prepareProviderAuth(providerIdx int) (string, string, error) {
+	rawToken := fmt.Sprintf("testbed-provider-token-%d-%d", providerIdx, time.Now().UnixNano())
+	tokenHash := sha256.Sum256([]byte(rawToken))
+	accountID := fmt.Sprintf("testbed-provider-%d", providerIdx)
+	if err := s.PgStore.CreateProviderToken(&store.ProviderToken{
+		TokenHash: hex.EncodeToString(tokenHash[:]),
+		AccountID: accountID,
+		Label:     fmt.Sprintf("testbed-provider-%d", providerIdx),
+		Active:    true,
+		CreatedAt: time.Now(),
+	}); err != nil {
+		return "", "", err
+	}
+
+	authDir, err := os.MkdirTemp("", fmt.Sprintf("darkbloom-testbed-provider-%d-", providerIdx))
+	if err != nil {
+		return "", "", err
+	}
+	tokenDir := filepath.Join(authDir, ".darkbloom")
+	if err := os.MkdirAll(tokenDir, 0700); err != nil {
+		_ = os.RemoveAll(authDir)
+		return "", "", err
+	}
+	authTokenPath := filepath.Join(tokenDir, "auth_token")
+	if err := os.WriteFile(authTokenPath, []byte(rawToken+"\n"), 0600); err != nil {
+		_ = os.RemoveAll(authDir)
+		return "", "", err
+	}
+	return authDir, authTokenPath, nil
 }
 
 func (s *Suite) waitForProviderRegistration(timeout time.Duration) error {
@@ -351,6 +393,9 @@ func (p *Provider) Start(ctx context.Context, coordinatorURL string, cfg Provide
 	cmd.Env = append(os.Environ(),
 		"DARKBLOOM_PID_FILE=/tmp/darkbloom-testbed-"+strconv.Itoa(p.ProviderIndex)+".pid",
 	)
+	if cfg.AuthTokenPath != "" {
+		cmd.Env = append(cmd.Env, "DARKBLOOM_AUTH_TOKEN_PATH="+cfg.AuthTokenPath)
+	}
 
 	if err := cmd.Start(); err != nil {
 		return fmt.Errorf("start provider: %w", err)
@@ -387,6 +432,9 @@ func (p *Provider) Stop() {
 		case <-time.After(10 * time.Second):
 			p.cmd.Kill()
 		}
+	}
+	if p.AuthDir != "" {
+		_ = os.RemoveAll(p.AuthDir)
 	}
 	p.Logger.Info("provider stopped")
 }

--- a/provider-swift/Sources/ProviderCore/Auth/DeviceAuth.swift
+++ b/provider-swift/Sources/ProviderCore/Auth/DeviceAuth.swift
@@ -20,7 +20,7 @@ public enum AuthTokenStore: Sendable {
         if let override = ProcessInfo.processInfo.environment["DARKBLOOM_AUTH_TOKEN_PATH"], !override.isEmpty {
             return URL(fileURLWithPath: override)
         }
-        FileManager.default.homeDirectoryForCurrentUser
+        return FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent(".darkbloom")
             .appendingPathComponent("auth_token")
     }

--- a/provider-swift/Sources/ProviderCore/Auth/DeviceAuth.swift
+++ b/provider-swift/Sources/ProviderCore/Auth/DeviceAuth.swift
@@ -14,8 +14,12 @@ import Foundation
 
 public enum AuthTokenStore: Sendable {
 
-    /// Path to the stored auth token: ~/.darkbloom/auth_token
+    /// Path to the stored auth token. Test harnesses can override this with
+    /// DARKBLOOM_AUTH_TOKEN_PATH to avoid touching the user's login state.
     public static func tokenPath() -> URL {
+        if let override = ProcessInfo.processInfo.environment["DARKBLOOM_AUTH_TOKEN_PATH"], !override.isEmpty {
+            return URL(fileURLWithPath: override)
+        }
         FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent(".darkbloom")
             .appendingPathComponent("auth_token")

--- a/provider-swift/Sources/ProviderCore/Batching/BatchQueuePlanner.swift
+++ b/provider-swift/Sources/ProviderCore/Batching/BatchQueuePlanner.swift
@@ -1,5 +1,90 @@
 import Foundation
 
+public struct AdaptiveBatchPerformanceBucket: Sendable, Equatable {
+    public var aggregateTps: Double
+    public var perRequestTps: Double
+    public var samples: Int
+
+    public init(aggregateTps: Double = 0, perRequestTps: Double = 0, samples: Int = 0) {
+        self.aggregateTps = aggregateTps
+        self.perRequestTps = perRequestTps
+        self.samples = samples
+    }
+
+    public var hasSignal: Bool {
+        samples >= 8
+    }
+
+    public mutating func record(aggregateTps newAggregateTps: Double, perRequestTps newPerRequestTps: Double) {
+        let alpha = 0.25
+        if samples == 0 {
+            aggregateTps = newAggregateTps
+            perRequestTps = newPerRequestTps
+        } else {
+            aggregateTps = alpha * newAggregateTps + (1 - alpha) * aggregateTps
+            perRequestTps = alpha * newPerRequestTps + (1 - alpha) * perRequestTps
+        }
+        samples += 1
+    }
+}
+
+public struct AdaptiveBatchCapPolicy: Sendable, Equatable {
+    public let targetMinPerRequestTps: Double
+    public let expansionHeadroomMultiplier: Double
+
+    public init(
+        targetMinPerRequestTps: Double = 15.0,
+        expansionHeadroomMultiplier: Double = 1.15
+    ) {
+        self.targetMinPerRequestTps = targetMinPerRequestTps
+        self.expansionHeadroomMultiplier = expansionHeadroomMultiplier
+    }
+
+    public static let `default` = AdaptiveBatchCapPolicy()
+
+    public func nextCap(
+        currentCap rawCurrentCap: Int,
+        hardCap rawHardCap: Int,
+        observedBatchSize: Int,
+        performanceByBatchSize: [Int: AdaptiveBatchPerformanceBucket]
+    ) -> Int {
+        let hardCap = max(1, rawHardCap)
+        let currentCap = max(1, min(rawCurrentCap, hardCap))
+
+        let signaled = performanceByBatchSize
+            .filter { $0.value.hasSignal }
+            .sorted { $0.key < $1.key }
+        guard !signaled.isEmpty else { return currentCap }
+
+        if let currentBucket = performanceByBatchSize[observedBatchSize],
+           currentBucket.hasSignal,
+           observedBatchSize >= currentCap,
+           currentBucket.perRequestTps < targetMinPerRequestTps {
+            let sustainableLowerCap = signaled
+                .filter { $0.key < observedBatchSize && $0.value.perRequestTps >= targetMinPerRequestTps }
+                .map(\.key)
+                .max()
+            return max(1, sustainableLowerCap ?? observedBatchSize - 1)
+        }
+
+        guard currentCap < hardCap,
+              observedBatchSize >= currentCap,
+              let currentBucket = performanceByBatchSize[currentCap],
+              currentBucket.hasSignal,
+              currentBucket.perRequestTps >= targetMinPerRequestTps * expansionHeadroomMultiplier else {
+            return currentCap
+        }
+
+        if let nextBucket = performanceByBatchSize[currentCap + 1],
+           nextBucket.hasSignal,
+           nextBucket.perRequestTps < targetMinPerRequestTps {
+            return currentCap
+        }
+
+        return currentCap + 1
+    }
+}
+
 public struct BatchSchedulingPolicy: Sendable, Equatable {
     public let maxConcurrentRequests: Int
     public let maxQueuedRequests: Int

--- a/provider-swift/Sources/ProviderCore/Inference/BatchScheduler.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/BatchScheduler.swift
@@ -22,10 +22,33 @@ public struct SchedulerCapacity: Sendable {
     public let activeRequests: Int
     public let pendingRequests: Int
     public let maxConcurrent: Int
+    public let engineMaxConcurrent: Int
     public let gpuMemoryActiveBytes: Int
     public let gpuMemoryPeakBytes: Int
     public let gpuMemoryCacheBytes: Int
     public let totalMemoryBytes: UInt64
+}
+
+private struct BatchPerformanceBucket: Sendable {
+    var aggregateTps: Double = 0
+    var perRequestTps: Double = 0
+    var samples: Int = 0
+
+    var hasSignal: Bool {
+        samples >= 8
+    }
+
+    mutating func record(aggregateTps newAggregateTps: Double, perRequestTps newPerRequestTps: Double) {
+        let alpha = 0.25
+        if samples == 0 {
+            aggregateTps = newAggregateTps
+            perRequestTps = newPerRequestTps
+        } else {
+            aggregateTps = alpha * newAggregateTps + (1 - alpha) * aggregateTps
+            perRequestTps = alpha * newPerRequestTps + (1 - alpha) * perRequestTps
+        }
+        samples += 1
+    }
 }
 
 /// Continuous-batching scheduler. One shared `BatchGenerator` runs all
@@ -69,23 +92,60 @@ public actor BatchScheduler {
     private var engineBusy = false
     private var observedDecodeTpsEwma: Double = 0
     private var ewmaInitialized = false
+    private var performanceByBatchSize: [Int: BatchPerformanceBucket] = [:]
+    private var dynamicMaxConcurrentRequests: Int
 
     /// Once every active row has received its first token, run several decode
     /// steps per actor/model hop. A single hop per token starves Gemma-class
     /// models because the CPU actor round trip is larger than one GPU step.
     private let decodeBurstSteps = 32
+    private let targetMinPerRequestTps = 15.0
+    private let expansionHeadroomMultiplier = 1.15
 
     private var tokenBudgetMax: Int {
-        if dynamicTokenBudgetMax > 0 {
-            return dynamicTokenBudgetMax
+        let staticBudget = dynamicTokenBudgetMax > 0
+            ? dynamicTokenBudgetMax
+            : defaultMaxTokens * maxConcurrentRequests
+        guard modelWeightBytes > 0, kvBytesPerToken > 0 else {
+            return staticBudget
         }
-        return defaultMaxTokens * maxConcurrentRequests
+
+        let totalMemory = Int(ProcessInfo.processInfo.physicalMemory)
+        let osReserve = 4 * 1024 * 1024 * 1024
+        let safetyMargin = totalMemory / 10
+        let globalUsed = Int(MLX.GPU.activeMemory) + Int(MLX.GPU.cacheMemory)
+        let availableHeadroom = max(0, totalMemory - osReserve - safetyMargin - globalUsed)
+        let liveBudget = activeTokenBudgetUsed + (availableHeadroom / kvBytesPerToken)
+        return max(1024, min(staticBudget, liveBudget))
+    }
+
+    private var activeTokenBudgetUsed: Int {
+        active.values.reduce(0) { $0 + $1.promptTokens + $1.maxTokens }
+    }
+
+    private var queuedTokenBudget: Int {
+        pending.reduce(0) { $0 + $1.promptTokens.count + $1.maxTokens }
     }
 
     private var currentTokenBudgetUsed: Int {
-        let activeBudget = active.values.reduce(0) { $0 + $1.promptTokens + $1.maxTokens }
-        let pendingBudget = pending.reduce(0) { $0 + $1.promptTokens.count + $1.maxTokens }
-        return activeBudget + pendingBudget
+        activeTokenBudgetUsed + queuedTokenBudget
+    }
+
+    private var averageReservedTokensForAdmission: Int {
+        let requestCount = active.count + pending.count
+        guard requestCount > 0 else { return defaultMaxTokens }
+        return max(1, currentTokenBudgetUsed / requestCount)
+    }
+
+    private var memoryBoundMaxConcurrentRequests: Int {
+        let budget = tokenBudgetMax
+        let averageReserved = averageReservedTokensForAdmission
+        guard budget > 0, averageReserved > 0 else { return 1 }
+        return max(1, min(maxConcurrentRequests, budget / averageReserved))
+    }
+
+    private var effectiveMaxConcurrentRequests: Int {
+        max(1, min(maxConcurrentRequests, dynamicMaxConcurrentRequests, memoryBoundMaxConcurrentRequests))
     }
 
     public init(
@@ -96,6 +156,7 @@ public actor BatchScheduler {
         self.maxConcurrentRequests = max(1, maxConcurrentRequests)
         self.pendingTimeout = pendingTimeout
         self.defaultMaxTokens = defaultMaxTokens
+        self.dynamicMaxConcurrentRequests = min(4, max(1, maxConcurrentRequests))
     }
 
     // MARK: - Model lifecycle
@@ -285,6 +346,8 @@ public actor BatchScheduler {
         } else {
             self.dynamicTokenBudgetMax = 1024
         }
+        self.dynamicMaxConcurrentRequests = min(4, maxConcurrentRequests)
+        self.performanceByBatchSize.removeAll()
 
         // Create the planner now that tokenBudgetMax is determined.
         self.planner = BatchQueuePlanner(
@@ -334,6 +397,12 @@ public actor BatchScheduler {
 
         // Admission control: use planner when available, fall back to inline check.
         let requestBudget = promptTokens.count + maxTokens
+        guard requestBudget <= tokenBudgetMax else {
+            continuation.yield(.error("token_budget_exhausted: request requires \(requestBudget) tokens but only \(tokenBudgetMax) available"))
+            continuation.finish()
+            return stream
+        }
+
         if let planner = self.planner {
             let result = await planner.admit(
                 id: id,
@@ -423,6 +492,10 @@ public actor BatchScheduler {
         for entry in pending {
             entry.continuation.yield(.error("Scheduler shutting down"))
             entry.continuation.finish()
+            if let planner = self.planner {
+                let cancelledId = entry.requestId
+                Task { await planner.cancel(requestID: cancelledId) }
+            }
         }
         pending.removeAll()
     }
@@ -434,7 +507,8 @@ public actor BatchScheduler {
             model: modelId,
             activeRequests: active.count + cancelledUIDs.count,
             pendingRequests: pending.count,
-            maxConcurrent: maxConcurrentRequests,
+            maxConcurrent: effectiveMaxConcurrentRequests,
+            engineMaxConcurrent: maxConcurrentRequests,
             gpuMemoryActiveBytes: gpuMemory(.active),
             gpuMemoryPeakBytes: gpuMemory(.peak),
             gpuMemoryCacheBytes: gpuMemory(.cache),
@@ -448,24 +522,9 @@ public actor BatchScheduler {
 
         var activeTokens: Int64 = 0
         var maxTokensPotential: Int64 = 0
-        var activeBudget: Int64 = 0
         for entry in active.values {
             activeTokens += Int64(entry.promptTokens + entry.completionTokens)
             maxTokensPotential += Int64(entry.promptTokens + entry.maxTokens)
-            activeBudget += Int64(entry.promptTokens + entry.maxTokens)
-        }
-
-        var queuedBudget: Int64 = 0
-        for entry in pending {
-            queuedBudget += Int64(entry.promptTokens.count + entry.maxTokens)
-        }
-
-        // When the planner is available, prefer its authoritative snapshot
-        // for budget fields since it tracks the full admission lifecycle.
-        if let planner = self.planner {
-            let snapshot = await planner.snapshot()
-            activeBudget = Int64(snapshot.activeTokenBudgetUsed)
-            queuedBudget = Int64(snapshot.queuedTokenBudget)
         }
 
         let budgetMax = Int64(tokenBudgetMax)
@@ -477,10 +536,11 @@ public actor BatchScheduler {
             numWaiting: UInt32(cap.pendingRequests),
             activeTokens: activeTokens,
             maxTokensPotential: maxTokensPotential,
+            maxConcurrency: UInt32(cap.maxConcurrent),
             observedDecodeTps: observedDecodeTpsEwma,
-            activeTokenBudgetUsed: activeBudget,
+            activeTokenBudgetUsed: Int64(activeTokenBudgetUsed),
             activeTokenBudgetMax: budgetMax,
-            queuedTokenBudget: queuedBudget,
+            queuedTokenBudget: Int64(queuedTokenBudget),
             kvBytesPerToken: Int64(kvBytesPerToken)
         )
         return BackendCapacity(
@@ -515,7 +575,10 @@ public actor BatchScheduler {
         admitPendingRequests(into: gen)
         if !gen.hasWork { return false }
 
-        let burstSteps = shouldPrioritizeFirstToken ? 1 : decodeBurstSteps
+        let prioritizeFirstToken = shouldPrioritizeFirstToken
+        let burstSteps = prioritizeFirstToken ? 1 : decodeBurstSteps
+        let activeBefore = max(1, gen.activeCount)
+        let startedAt = ContinuousClock.now
         engineBusy = true
         let responses: [GenerationBatchResponse] = await container.perform { _ in
             var all: [GenerationBatchResponse] = []
@@ -527,8 +590,16 @@ public actor BatchScheduler {
             return all
         }
         engineBusy = false
+        let elapsed = Self.seconds(between: startedAt, and: .now)
         guard epoch == generationEpoch, generator === gen else {
             return false
+        }
+        if !prioritizeFirstToken, !responses.isEmpty, elapsed > 0 {
+            recordBatchPerformance(
+                batchSize: activeBefore,
+                tokenCount: responses.count,
+                elapsedSeconds: elapsed
+            )
         }
         applyCancelledRequests(to: gen)
         dispatchResponses(responses, producedAt: .now)
@@ -541,11 +612,37 @@ public actor BatchScheduler {
 
     private func admitPendingRequests(into gen: BatchGenerator) {
         guard !pending.isEmpty else { return }
-        let freeSlots = max(0, maxConcurrentRequests - active.count)
+        let freeSlots = max(0, effectiveMaxConcurrentRequests - active.count)
         guard freeSlots > 0 else { return }
 
-        let batch = Array(pending.prefix(freeSlots))
-        pending.removeFirst(batch.count)
+        var activeBudgetAfterAdmission = activeTokenBudgetUsed
+        let budgetMax = tokenBudgetMax
+        var batch: [PendingRequest] = []
+        batch.reserveCapacity(freeSlots)
+
+        var pendingIndex = 0
+        while batch.count < freeSlots, pendingIndex < pending.count {
+            let next = pending[pendingIndex]
+            let requestBudget = next.promptTokens.count + next.maxTokens
+            if requestBudget > budgetMax {
+                pending.remove(at: pendingIndex)
+                next.continuation.yield(.error("token_budget_exhausted: request requires \(requestBudget) tokens but only \(budgetMax) available"))
+                next.continuation.finish()
+                if let planner = self.planner {
+                    let rejectedId = next.requestId
+                    Task { await planner.cancel(requestID: rejectedId) }
+                }
+                continue
+            }
+            if activeBudgetAfterAdmission + requestBudget > budgetMax {
+                pendingIndex += 1
+                continue
+            }
+            batch.append(pending.remove(at: pendingIndex))
+            activeBudgetAfterAdmission += requestBudget
+        }
+
+        guard !batch.isEmpty else { return }
 
         let assignedUids = gen.insert(
             prompts: batch.map(\.promptTokens),
@@ -585,6 +682,10 @@ public actor BatchScheduler {
             if now - entry.submittedAt >= pendingTimeout {
                 entry.continuation.yield(.error("Request timed out waiting for capacity"))
                 entry.continuation.finish()
+                if let planner = self.planner {
+                    let timedOutId = entry.requestId
+                    Task { await planner.cancel(requestID: timedOutId) }
+                }
             } else {
                 stillPending.append(entry)
             }
@@ -615,6 +716,8 @@ public actor BatchScheduler {
         planner = nil
         observedDecodeTpsEwma = 0
         ewmaInitialized = false
+        performanceByBatchSize.removeAll()
+        dynamicMaxConcurrentRequests = min(4, maxConcurrentRequests)
 
         while engineBusy {
             try? await Task.sleep(for: .milliseconds(1))
@@ -720,6 +823,68 @@ public actor BatchScheduler {
                 Task { await planner.cancel(requestID: completedId) }
             }
         }
+    }
+
+    private func recordBatchPerformance(
+        batchSize: Int,
+        tokenCount: Int,
+        elapsedSeconds: Double
+    ) {
+        guard batchSize > 0, tokenCount > 0, elapsedSeconds > 0 else { return }
+
+        let aggregateTps = Double(tokenCount) / elapsedSeconds
+        let perRequestTps = aggregateTps / Double(batchSize)
+        performanceByBatchSize[batchSize, default: BatchPerformanceBucket()]
+            .record(aggregateTps: aggregateTps, perRequestTps: perRequestTps)
+        updateDynamicMaxConcurrentRequests(observedBatchSize: batchSize)
+    }
+
+    private func updateDynamicMaxConcurrentRequests(observedBatchSize: Int) {
+        let hardCap = maxConcurrentRequests
+        let currentCap = max(1, min(dynamicMaxConcurrentRequests, hardCap))
+        dynamicMaxConcurrentRequests = currentCap
+
+        let signaled = performanceByBatchSize
+            .filter { $0.value.hasSignal }
+            .sorted { $0.key < $1.key }
+        guard !signaled.isEmpty else { return }
+
+        if let currentBucket = performanceByBatchSize[observedBatchSize],
+           currentBucket.hasSignal,
+           observedBatchSize >= currentCap,
+           currentBucket.perRequestTps < targetMinPerRequestTps {
+            let sustainableLowerCap = signaled
+                .filter { $0.key < observedBatchSize && $0.value.perRequestTps >= targetMinPerRequestTps }
+                .map(\.key)
+                .max()
+            dynamicMaxConcurrentRequests = max(1, sustainableLowerCap ?? observedBatchSize - 1)
+            return
+        }
+
+        guard currentCap < hardCap,
+              observedBatchSize >= currentCap,
+              let currentBucket = performanceByBatchSize[currentCap],
+              currentBucket.hasSignal,
+              currentBucket.perRequestTps >= targetMinPerRequestTps * expansionHeadroomMultiplier else {
+            return
+        }
+
+        if let nextBucket = performanceByBatchSize[currentCap + 1],
+           nextBucket.hasSignal,
+           nextBucket.perRequestTps < targetMinPerRequestTps {
+            return
+        }
+
+        dynamicMaxConcurrentRequests = currentCap + 1
+    }
+
+    private static func seconds(
+        between start: ContinuousClock.Instant,
+        and end: ContinuousClock.Instant
+    ) -> Double {
+        let elapsed = end - start
+        return Double(elapsed.components.seconds)
+            + Double(elapsed.components.attoseconds) / 1e18
     }
 
     private func finishRequest(uid: Int, error: String) {

--- a/provider-swift/Sources/ProviderCore/Inference/BatchScheduler.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/BatchScheduler.swift
@@ -29,28 +29,6 @@ public struct SchedulerCapacity: Sendable {
     public let totalMemoryBytes: UInt64
 }
 
-private struct BatchPerformanceBucket: Sendable {
-    var aggregateTps: Double = 0
-    var perRequestTps: Double = 0
-    var samples: Int = 0
-
-    var hasSignal: Bool {
-        samples >= 8
-    }
-
-    mutating func record(aggregateTps newAggregateTps: Double, perRequestTps newPerRequestTps: Double) {
-        let alpha = 0.25
-        if samples == 0 {
-            aggregateTps = newAggregateTps
-            perRequestTps = newPerRequestTps
-        } else {
-            aggregateTps = alpha * newAggregateTps + (1 - alpha) * aggregateTps
-            perRequestTps = alpha * newPerRequestTps + (1 - alpha) * perRequestTps
-        }
-        samples += 1
-    }
-}
-
 /// Continuous-batching scheduler. One shared `BatchGenerator` runs all
 /// concurrent requests through one batched forward pass per step.
 ///
@@ -92,15 +70,14 @@ public actor BatchScheduler {
     private var engineBusy = false
     private var observedDecodeTpsEwma: Double = 0
     private var ewmaInitialized = false
-    private var performanceByBatchSize: [Int: BatchPerformanceBucket] = [:]
+    private var performanceByBatchSize: [Int: AdaptiveBatchPerformanceBucket] = [:]
     private var dynamicMaxConcurrentRequests: Int
 
     /// Once every active row has received its first token, run several decode
     /// steps per actor/model hop. A single hop per token starves Gemma-class
     /// models because the CPU actor round trip is larger than one GPU step.
     private let decodeBurstSteps = 32
-    private let targetMinPerRequestTps = 15.0
-    private let expansionHeadroomMultiplier = 1.15
+    private let adaptiveCapPolicy = AdaptiveBatchCapPolicy.default
 
     private var tokenBudgetMax: Int {
         let staticBudget = dynamicTokenBudgetMax > 0
@@ -834,48 +811,18 @@ public actor BatchScheduler {
 
         let aggregateTps = Double(tokenCount) / elapsedSeconds
         let perRequestTps = aggregateTps / Double(batchSize)
-        performanceByBatchSize[batchSize, default: BatchPerformanceBucket()]
+        performanceByBatchSize[batchSize, default: AdaptiveBatchPerformanceBucket()]
             .record(aggregateTps: aggregateTps, perRequestTps: perRequestTps)
         updateDynamicMaxConcurrentRequests(observedBatchSize: batchSize)
     }
 
     private func updateDynamicMaxConcurrentRequests(observedBatchSize: Int) {
-        let hardCap = maxConcurrentRequests
-        let currentCap = max(1, min(dynamicMaxConcurrentRequests, hardCap))
-        dynamicMaxConcurrentRequests = currentCap
-
-        let signaled = performanceByBatchSize
-            .filter { $0.value.hasSignal }
-            .sorted { $0.key < $1.key }
-        guard !signaled.isEmpty else { return }
-
-        if let currentBucket = performanceByBatchSize[observedBatchSize],
-           currentBucket.hasSignal,
-           observedBatchSize >= currentCap,
-           currentBucket.perRequestTps < targetMinPerRequestTps {
-            let sustainableLowerCap = signaled
-                .filter { $0.key < observedBatchSize && $0.value.perRequestTps >= targetMinPerRequestTps }
-                .map(\.key)
-                .max()
-            dynamicMaxConcurrentRequests = max(1, sustainableLowerCap ?? observedBatchSize - 1)
-            return
-        }
-
-        guard currentCap < hardCap,
-              observedBatchSize >= currentCap,
-              let currentBucket = performanceByBatchSize[currentCap],
-              currentBucket.hasSignal,
-              currentBucket.perRequestTps >= targetMinPerRequestTps * expansionHeadroomMultiplier else {
-            return
-        }
-
-        if let nextBucket = performanceByBatchSize[currentCap + 1],
-           nextBucket.hasSignal,
-           nextBucket.perRequestTps < targetMinPerRequestTps {
-            return
-        }
-
-        dynamicMaxConcurrentRequests = currentCap + 1
+        dynamicMaxConcurrentRequests = adaptiveCapPolicy.nextCap(
+            currentCap: dynamicMaxConcurrentRequests,
+            hardCap: maxConcurrentRequests,
+            observedBatchSize: observedBatchSize,
+            performanceByBatchSize: performanceByBatchSize
+        )
     }
 
     private static func seconds(

--- a/provider-swift/Sources/ProviderCore/Protocol/Types.swift
+++ b/provider-swift/Sources/ProviderCore/Protocol/Types.swift
@@ -240,6 +240,7 @@ public struct BackendSlotCapacity: Codable, Sendable, Equatable {
     public var activeTokenBudgetMax: Int64
     public var queuedTokenBudget: Int64
     public var kvBytesPerToken: Int64
+    public var maxConcurrency: UInt32
 
     enum CodingKeys: String, CodingKey {
         case model
@@ -253,6 +254,7 @@ public struct BackendSlotCapacity: Codable, Sendable, Equatable {
         case activeTokenBudgetMax = "active_token_budget_max"
         case queuedTokenBudget = "queued_token_budget"
         case kvBytesPerToken = "kv_bytes_per_token"
+        case maxConcurrency = "max_concurrency"
     }
 
     public init(
@@ -262,6 +264,7 @@ public struct BackendSlotCapacity: Codable, Sendable, Equatable {
         numWaiting: UInt32,
         activeTokens: Int64,
         maxTokensPotential: Int64,
+        maxConcurrency: UInt32 = 0,
         observedDecodeTps: Double = 0,
         activeTokenBudgetUsed: Int64 = 0,
         activeTokenBudgetMax: Int64 = 0,
@@ -274,11 +277,28 @@ public struct BackendSlotCapacity: Codable, Sendable, Equatable {
         self.numWaiting = numWaiting
         self.activeTokens = activeTokens
         self.maxTokensPotential = maxTokensPotential
+        self.maxConcurrency = maxConcurrency
         self.observedDecodeTps = observedDecodeTps
         self.activeTokenBudgetUsed = activeTokenBudgetUsed
         self.activeTokenBudgetMax = activeTokenBudgetMax
         self.queuedTokenBudget = queuedTokenBudget
         self.kvBytesPerToken = kvBytesPerToken
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        model = try container.decode(String.self, forKey: .model)
+        state = try container.decode(String.self, forKey: .state)
+        numRunning = try container.decode(UInt32.self, forKey: .numRunning)
+        numWaiting = try container.decode(UInt32.self, forKey: .numWaiting)
+        activeTokens = try container.decodeIfPresent(Int64.self, forKey: .activeTokens) ?? 0
+        maxTokensPotential = try container.decodeIfPresent(Int64.self, forKey: .maxTokensPotential) ?? 0
+        maxConcurrency = try container.decodeIfPresent(UInt32.self, forKey: .maxConcurrency) ?? 0
+        observedDecodeTps = try container.decodeIfPresent(Double.self, forKey: .observedDecodeTps) ?? 0
+        activeTokenBudgetUsed = try container.decodeIfPresent(Int64.self, forKey: .activeTokenBudgetUsed) ?? 0
+        activeTokenBudgetMax = try container.decodeIfPresent(Int64.self, forKey: .activeTokenBudgetMax) ?? 0
+        queuedTokenBudget = try container.decodeIfPresent(Int64.self, forKey: .queuedTokenBudget) ?? 0
+        kvBytesPerToken = try container.decodeIfPresent(Int64.self, forKey: .kvBytesPerToken) ?? 0
     }
 }
 

--- a/provider-swift/Sources/ProviderCore/ProviderLoop.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop.swift
@@ -108,6 +108,10 @@ public actor ProviderLoop {
     /// Tracks in-flight inference tasks by request ID so they can be cancelled.
     private var inflightTasks: [String: Task<Void, Never>] = [:]
 
+    /// A detached task can finish before the actor stores it in `inflightTasks`.
+    /// Track that edge so the post-spawn registration does not leave a stale task.
+    private var completedBeforeTaskRegistration = Set<String>()
+
     /// Tracks coordinator-driven preload tasks so they can be cancelled on shutdown.
     private var preloadTasks: [String: Task<Void, Never>] = [:]
 
@@ -125,6 +129,11 @@ public actor ProviderLoop {
     /// the model when the timeout has elapsed. nil when disabled
     /// (`idleTimeoutMins == 0`) or before `run()` starts it.
     private var idleMonitorTask: Task<Void, Never>?
+
+    /// Periodically refreshes provider-reported backend capacity so heartbeats
+    /// reflect active/queued requests and adaptive batch-cap changes while
+    /// long-running generations are still in flight.
+    private var capacityRefreshTask: Task<Void, Never>?
 
     private let logger = ProviderLogger(subsystem: "dev.darkbloom.provider", category: "loop")
 
@@ -144,7 +153,7 @@ public actor ProviderLoop {
 
     // MARK: - Model Slot
 
-    private static let schedulerMaxConcurrent = 4
+    private static let schedulerMaxConcurrent = 24
     private static let schedulerPendingTimeout: Duration = .seconds(120)
     private static let schedulerDefaultMaxTokens = 4096
 
@@ -233,6 +242,7 @@ public actor ProviderLoop {
         // followed by a long disconnect is still subject to the unload
         // timer.
         startIdleMonitor()
+        startCapacityRefreshMonitor()
 
         logger.info("Coordinator client started, entering event loop")
 
@@ -286,6 +296,8 @@ public actor ProviderLoop {
         logger.info("Event stream ended, shutting down")
         idleMonitorTask?.cancel()
         idleMonitorTask = nil
+        capacityRefreshTask?.cancel()
+        capacityRefreshTask = nil
         for (_, task) in preloadTasks { task.cancel() }
         preloadTasks.removeAll()
         preloadTaskIds.removeAll()
@@ -541,6 +553,7 @@ public actor ProviderLoop {
                 request: chatRequest,
                 requestId: requestId
             )
+            await me.updateAggregateCapacity()
 
             for await event in generationStream {
                 // Check cancellation
@@ -613,6 +626,9 @@ public actor ProviderLoop {
         }
 
         inflightTasks[requestId] = task
+        if completedBeforeTaskRegistration.remove(requestId) != nil {
+            inflightTasks.removeValue(forKey: requestId)
+        }
         modelSlots[modelId]?.lastInferenceAt = .now
     }
 
@@ -770,6 +786,22 @@ public actor ProviderLoop {
         return remMinutes == 0 ? "\(hours)h" : "\(hours)h\(remMinutes)m"
     }
 
+    // MARK: - Capacity Refresh
+
+    private func startCapacityRefreshMonitor() {
+        capacityRefreshTask?.cancel()
+        let heartbeatInterval = max(1, loopConfig.config.coordinator.heartbeatIntervalSecs)
+        let pollInterval = Duration.seconds(Int64(max(1, heartbeatInterval / 2)))
+        let me = self
+        capacityRefreshTask = Task {
+            while !Task.isCancelled {
+                try? await Task.sleep(for: pollInterval)
+                if Task.isCancelled { break }
+                await me.updateAggregateCapacity()
+            }
+        }
+    }
+
     // MARK: - Model Loading
 
     private func ensureModelLoaded(modelId: String) async throws {
@@ -826,11 +858,10 @@ public actor ProviderLoop {
 
         modelsLoading.insert(modelId)
         do {
-            // Budget: model weights + KV cache for 128k context under continuous
-            // batching (4 concurrent requests). estimatedMemoryGb is weight_bytes × 1.2.
-            // KV cache at 128k with GQA is roughly equal to weight size, and we batch
-            // up to 4 requests, so worst-case KV ≈ weights × 4. Budget weights × 3.0
-            // as a practical middle ground (not all requests hit 128k simultaneously).
+            // Budget enough headroom to warm the model. Per-request KV safety is
+            // enforced later by BatchScheduler's live token budget, so this load
+            // gate should not assume the engine's full adaptive slot ceiling is
+            // simultaneously filled with maximum-context requests.
             let requiredGb = modelInfo.estimatedMemoryGb * 3.0
             try await evictUntilAvailable(requiredGb: requiredGb)
 
@@ -952,6 +983,7 @@ public actor ProviderLoop {
         }
 
         requestToModel.removeValue(forKey: requestId)
+        await updateAggregateCapacity()
 
         if let task = inflightTasks.removeValue(forKey: requestId) {
             task.cancel()
@@ -964,12 +996,17 @@ public actor ProviderLoop {
             await handleCancellation(requestId: requestId)
         }
         inflightTasks.removeAll()
+        completedBeforeTaskRegistration.removeAll()
         requestToModel.removeAll()
     }
 
     private func finishInflightRequest(requestId: String) {
-        inflightTasks.removeValue(forKey: requestId)
-        if let modelId = requestToModel.removeValue(forKey: requestId) {
+        let hadRegisteredTask = inflightTasks.removeValue(forKey: requestId) != nil
+        let modelId = requestToModel.removeValue(forKey: requestId)
+        if !hadRegisteredTask, modelId != nil {
+            completedBeforeTaskRegistration.insert(requestId)
+        }
+        if let modelId {
             modelSlots[modelId]?.lastInferenceAt = .now
             syncWarmModelState()
         }

--- a/provider-swift/Sources/ProviderCore/Server/StandaloneServer.swift
+++ b/provider-swift/Sources/ProviderCore/Server/StandaloneServer.swift
@@ -72,7 +72,7 @@ public actor StandaloneServer {
         self.models = models
     }
 
-    private static let schedulerMaxConcurrent = 4
+    private static let schedulerMaxConcurrent = 24
     private static let schedulerPendingTimeout: Duration = .seconds(120)
     private static let schedulerDefaultMaxTokens = 4096
 

--- a/provider-swift/Tests/ProviderCoreTests/BatchingTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/BatchingTests.swift
@@ -353,3 +353,86 @@ import Testing
     #expect(policy.maxActiveTokenBudget == 8192)
     #expect(policy.maxTokensPerBatch == 4096)
 }
+
+@Test func adaptiveCapDoesNotExpandBeforeEnoughSamples() {
+    let policy = AdaptiveBatchCapPolicy(targetMinPerRequestTps: 15, expansionHeadroomMultiplier: 1.15)
+    let cap = policy.nextCap(
+        currentCap: 2,
+        hardCap: 4,
+        observedBatchSize: 2,
+        performanceByBatchSize: [2: AdaptiveBatchPerformanceBucket(aggregateTps: 80, perRequestTps: 40, samples: 7)]
+    )
+
+    #expect(cap == 2)
+}
+
+@Test func adaptiveCapExpandsWithTpsHeadroom() {
+    let policy = AdaptiveBatchCapPolicy(targetMinPerRequestTps: 15, expansionHeadroomMultiplier: 1.15)
+    let cap = policy.nextCap(
+        currentCap: 2,
+        hardCap: 4,
+        observedBatchSize: 2,
+        performanceByBatchSize: [2: AdaptiveBatchPerformanceBucket(aggregateTps: 80, perRequestTps: 18, samples: 8)]
+    )
+
+    #expect(cap == 3)
+}
+
+@Test func adaptiveCapShrinksBelowTargetTps() {
+    let policy = AdaptiveBatchCapPolicy(targetMinPerRequestTps: 15, expansionHeadroomMultiplier: 1.15)
+    let cap = policy.nextCap(
+        currentCap: 4,
+        hardCap: 4,
+        observedBatchSize: 4,
+        performanceByBatchSize: [
+            2: AdaptiveBatchPerformanceBucket(aggregateTps: 36, perRequestTps: 18, samples: 8),
+            4: AdaptiveBatchPerformanceBucket(aggregateTps: 40, perRequestTps: 10, samples: 8),
+        ]
+    )
+
+    #expect(cap == 2)
+}
+
+@Test func adaptiveCapDoesNotExpandWhenNextBucketHasBadSignal() {
+    let policy = AdaptiveBatchCapPolicy(targetMinPerRequestTps: 15, expansionHeadroomMultiplier: 1.15)
+    let cap = policy.nextCap(
+        currentCap: 2,
+        hardCap: 4,
+        observedBatchSize: 2,
+        performanceByBatchSize: [
+            2: AdaptiveBatchPerformanceBucket(aggregateTps: 80, perRequestTps: 18, samples: 8),
+            3: AdaptiveBatchPerformanceBucket(aggregateTps: 36, perRequestTps: 12, samples: 8),
+        ]
+    )
+
+    #expect(cap == 2)
+}
+
+@Test func adaptiveBucketRecordKeepsEwmaAndSampleCount() {
+    var bucket = AdaptiveBatchPerformanceBucket()
+
+    bucket.record(aggregateTps: 40, perRequestTps: 20)
+    bucket.record(aggregateTps: 20, perRequestTps: 10)
+
+    #expect(bucket.samples == 2)
+    #expect(bucket.aggregateTps == 35)
+    #expect(bucket.perRequestTps == 17.5)
+}
+
+@Test func plannerQueuesFittingRequestEvenWhenActiveBudgetIsCurrentlyFull() async {
+    let planner = BatchQueuePlanner(
+        policy: BatchSchedulingPolicy(
+            maxConcurrentRequests: 2,
+            maxQueuedRequests: 10,
+            maxActiveTokenBudget: 10,
+            maxTokensPerBatch: 10
+        )
+    )
+
+    #expect(await planner.admit(id: "active", promptTokenCount: 5, maxOutputTokens: 5) == .queued(requestID: "active", position: 1))
+    #expect(await planner.nextBatch()?.prefill?.id == "active")
+    #expect(await planner.markPrefillComplete(requestID: "active"))
+
+    #expect(await planner.admit(id: "queued", promptTokenCount: 5, maxOutputTokens: 5) == .queued(requestID: "queued", position: 1))
+    #expect(await planner.admit(id: "oversize", promptTokenCount: 6, maxOutputTokens: 5) == .rejected(requestID: "oversize", reason: .requestExceedsActiveTokenBudget))
+}

--- a/provider-swift/Tests/ProviderCoreTests/ProtocolTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/ProtocolTests.swift
@@ -235,6 +235,13 @@ import Testing
     #expect(decoded == slot)
 }
 
+@Test func backendSlotCapacityDecodesMaxConcurrencyPresentAndNonzero() throws {
+    let raw = #"{"model":"test","state":"running","num_running":2,"num_waiting":1,"active_tokens":3000,"max_tokens_potential":8000,"max_concurrency":4}"#
+    let decoded = try JSONDecoder().decode(BackendSlotCapacity.self, from: Data(raw.utf8))
+
+    #expect(decoded.maxConcurrency == 4)
+}
+
 @Test func backendSlotCapacityDecodesOldPayloadWithoutAdaptiveFields() throws {
     let raw = #"{"model":"test","state":"running","num_running":2,"num_waiting":0,"active_tokens":3000,"max_tokens_potential":8000}"#
     let decoded = try JSONDecoder().decode(BackendSlotCapacity.self, from: Data(raw.utf8))
@@ -247,6 +254,62 @@ import Testing
     #expect(decoded.activeTokenBudgetMax == 0)
     #expect(decoded.queuedTokenBudget == 0)
     #expect(decoded.kvBytesPerToken == 0)
+}
+
+@Test func backendSlotCapacityDecodesMaxConcurrencyZero() throws {
+    let raw = #"{"model":"test","state":"running","num_running":2,"num_waiting":1,"active_tokens":3000,"max_tokens_potential":8000,"max_concurrency":0}"#
+    let decoded = try JSONDecoder().decode(BackendSlotCapacity.self, from: Data(raw.utf8))
+
+    #expect(decoded.maxConcurrency == 0)
+}
+
+@Test func heartbeatBackendCapacityEncodesSnakeCaseFields() throws {
+    let heartbeat = ProviderMessage.heartbeat(ProviderMessage.Heartbeat(
+        status: .serving,
+        activeModel: "mlx-community/Qwen2.5-7B-4bit",
+        stats: ProviderStats(requestsServed: 1, tokensGenerated: 2),
+        systemMetrics: SystemMetrics(memoryPressure: 0.1, cpuUsage: 0.2, thermalState: .nominal),
+        backendCapacity: BackendCapacity(
+            slots: [BackendSlotCapacity(
+                model: "mlx-community/Qwen2.5-7B-4bit",
+                state: "running",
+                numRunning: 1,
+                numWaiting: 2,
+                activeTokens: 3000,
+                maxTokensPotential: 8000,
+                maxConcurrency: 4,
+                observedDecodeTps: 90,
+                activeTokenBudgetUsed: 5000,
+                activeTokenBudgetMax: 12000,
+                queuedTokenBudget: 7000,
+                kvBytesPerToken: 262144
+            )],
+            gpuMemoryActiveGb: 5.5,
+            gpuMemoryPeakGb: 6.5,
+            gpuMemoryCacheGb: 1.5,
+            totalMemoryGb: 36
+        )
+    ))
+
+    let data = try ProviderProtocolCodec.encodeProviderMessage(heartbeat)
+    let object = try jsonObject(data)
+    let capacity = object["backend_capacity"] as? [String: Any]
+    let slot = (capacity?["slots"] as? [[String: Any]])?.first
+
+    #expect(capacity?["gpu_memory_active_gb"] as? Double == 5.5)
+    #expect(capacity?["gpu_memory_peak_gb"] as? Double == 6.5)
+    #expect(capacity?["gpu_memory_cache_gb"] as? Double == 1.5)
+    #expect(capacity?["total_memory_gb"] as? Double == 36)
+    #expect(slot?["num_running"] as? Int == 1)
+    #expect(slot?["num_waiting"] as? Int == 2)
+    #expect(slot?["active_tokens"] as? Int == 3000)
+    #expect(slot?["max_tokens_potential"] as? Int == 8000)
+    #expect(slot?["max_concurrency"] as? Int == 4)
+    #expect(slot?["observed_decode_tps"] as? Double == 90)
+    #expect(slot?["active_token_budget_used"] as? Int == 5000)
+    #expect(slot?["active_token_budget_max"] as? Int == 12000)
+    #expect(slot?["queued_token_budget"] as? Int == 7000)
+    #expect(slot?["kv_bytes_per_token"] as? Int == 262144)
 }
 
 private func sampleHardware() -> HardwareInfo {

--- a/provider-swift/Tests/ProviderCoreTests/ProtocolTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/ProtocolTests.swift
@@ -60,7 +60,8 @@ import Testing
                     numRunning: 1,
                     numWaiting: 0,
                     activeTokens: 512,
-                    maxTokensPotential: 2048
+                    maxTokensPotential: 2048,
+                    maxConcurrency: 4
                 )],
                 gpuMemoryActiveGb: 8.5,
                 gpuMemoryPeakGb: 9.0,
@@ -203,6 +204,49 @@ import Testing
         encoding: .utf8
     ) ?? ""
     #expect(!runtimeJSON.contains("mismatches"))
+}
+
+@Test func backendSlotCapacityRoundTripsAdaptiveBatchingFields() throws {
+    let slot = BackendSlotCapacity(
+        model: "mlx-community/Qwen2.5-7B-4bit",
+        state: "running",
+        numRunning: 3,
+        numWaiting: 2,
+        activeTokens: 5_000,
+        maxTokensPotential: 12_000,
+        maxConcurrency: 6,
+        observedDecodeTps: 85.5,
+        activeTokenBudgetUsed: 28_000,
+        activeTokenBudgetMax: 32_768,
+        queuedTokenBudget: 4_096,
+        kvBytesPerToken: 393_216
+    )
+
+    let data = try JSONEncoder().encode(slot)
+    let object = try jsonObject(data)
+    #expect(object["max_concurrency"] as? Int == 6)
+    #expect(object["observed_decode_tps"] as? Double == 85.5)
+    #expect(object["active_token_budget_used"] as? Int == 28_000)
+    #expect(object["active_token_budget_max"] as? Int == 32_768)
+    #expect(object["queued_token_budget"] as? Int == 4_096)
+    #expect(object["kv_bytes_per_token"] as? Int == 393_216)
+
+    let decoded = try JSONDecoder().decode(BackendSlotCapacity.self, from: data)
+    #expect(decoded == slot)
+}
+
+@Test func backendSlotCapacityDecodesOldPayloadWithoutAdaptiveFields() throws {
+    let raw = #"{"model":"test","state":"running","num_running":2,"num_waiting":0,"active_tokens":3000,"max_tokens_potential":8000}"#
+    let decoded = try JSONDecoder().decode(BackendSlotCapacity.self, from: Data(raw.utf8))
+
+    #expect(decoded.model == "test")
+    #expect(decoded.numRunning == 2)
+    #expect(decoded.maxConcurrency == 0)
+    #expect(decoded.observedDecodeTps == 0)
+    #expect(decoded.activeTokenBudgetUsed == 0)
+    #expect(decoded.activeTokenBudgetMax == 0)
+    #expect(decoded.queuedTokenBudget == 0)
+    #expect(decoded.kvBytesPerToken == 0)
 }
 
 private func sampleHardware() -> HardwareInfo {


### PR DESCRIPTION
## Summary

This PR adds provider-reported adaptive batching capacity on top of the multi-model Swift provider branch.

- Swift `BatchScheduler` keeps a hard engine slot ceiling and learns an effective per-model concurrency cap from observed per-batch decode TPS.
- Swift admission remains KV-aware: a request must fit the model's token budget, and pending-to-active promotion re-checks active reserved tokens before allocating a row.
- Swift heartbeats now report per-slot `max_concurrency`, active/queued token budgets, observed TPS, and KV bytes per token.
- Coordinator routing consumes positive per-slot `max_concurrency` for model-aware headroom checks while preserving legacy fallback for omitted/zero values.
- Coordinator model capacity snapshots and routing gates now treat saturated per-model slots as capacity-limited rather than structurally ineligible.

## Before

```mermaid
flowchart TD
    A[Consumer request] --> B[Coordinator selects provider]
    B --> C{Provider-wide cap}
    C -->|Default or memory tier| D[Route to provider]
    D --> E[Swift ProviderLoop]
    E --> F[BatchScheduler]
    F --> G{Fixed active rows = 4}
    G -->|free row| H[BatchGenerator active batch]
    G -->|no row| I[Provider pending queue]
    H --> J[Decode]
    I --> H

    K[KV/token budget] -. checked at submit .-> F
    L[Actual per-batch TPS] -. not used for cap .-> F
    M[Multi-model slots] -. coordinator sees provider-wide cap .-> C
```

## After

```mermaid
flowchart TD
    A[Consumer request] --> B[Coordinator preflight and routing]
    B --> C{Per-model slot cap reported?}
    C -->|yes| D[Use slot max_concurrency]
    C -->|no or zero| E[Legacy provider-wide fallback]
    D --> F{Provider-wide safety cap also has headroom?}
    E --> F
    F -->|headroom| G[Route to provider]
    F -->|full| Q[Capacity rejection / queue]

    G --> H[Swift ProviderLoop]
    H --> I[BatchScheduler]
    I --> J{Request fits token budget alone?}
    J -->|no| R[token_budget_exhausted]
    J -->|yes| K[Pending queue]

    K --> L{Active rows below dynamic cap?}
    L -->|yes| M{Active reserved tokens + request <= live KV budget?}
    M -->|yes| N[Promote to BatchGenerator]
    M -->|no| K
    L -->|no| K
    N --> O[Decode burst]
    O --> P[Record batch-size TPS EWMA]
    P --> S[Expand or shrink dynamic cap]
    S --> T[Heartbeat backend_capacity slot max_concurrency]
    T --> B
```

## Testing

- `cd coordinator && go test ./...`
- `git diff --check`

Swift verification is blocked in this worktree because local path dependencies are absent:

- `libs/mlx-swift/Package.swift`
- `libs/mlx-swift-lm/Package.swift`

## Review Notes

Focused review passes were run for Swift scheduling, coordinator routing, and test coverage. Follow-up fixes addressed submit-time over-rejection, mixed-size pending promotion, fast detached task completion, model capacity readiness, capacity rejection accounting, backend-reported load saturation, and provider-wide safety headroom.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/181"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->