### PR TITLE
ci: optimize workflows for Blacksmith + swap to gemma4 models

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,9 +34,9 @@ jobs:
         with:
           go-version-file: go.mod
       - name: golangci-lint
-        run: |
-          go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.1.6
-          golangci-lint run
+        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
+        with:
+          version: v2.12
 
   test-provider:
     name: Provider Tests
@@ -45,6 +45,16 @@ jobs:
       PYO3_USE_ABI3_FORWARD_COMPATIBILITY: '1'
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Cache Cargo artifacts
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
+        with:
+          path: |
+            ~/.cargo/registry/cache
+            ~/.cargo/registry/index
+            ~/.cargo/git/db
+            provider/target
+          key: cargo-ci-${{ runner.os }}-${{ hashFiles('provider/Cargo.lock') }}
+          restore-keys: cargo-ci-${{ runner.os }}-
       - name: Run tests
         run: |
           cd provider

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -5,6 +5,10 @@ on:
     branches: [master, main]
   pull_request:
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   integration-tests:
     name: E2E Integration Tests
@@ -22,8 +26,25 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - name: Cache Homebrew packages
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
+        with:
+          path: ~/Library/Caches/Homebrew
+          key: brew-integration-${{ runner.os }}-postgresql16
+          restore-keys: brew-integration-${{ runner.os }}-
+
       - name: Install Postgres
         run: brew install postgresql@16
+
+      - name: Cache Swift build artifacts
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
+        with:
+          path: |
+            provider-swift/.build
+            ~/Library/Caches/org.swift.swiftpm
+            ~/Library/org.swift.swiftpm
+          key: swift-integration-${{ runner.os }}-${{ hashFiles('provider-swift/Package.resolved') }}
+          restore-keys: swift-integration-${{ runner.os }}-
 
       - name: Build provider (Swift)
         run: |
@@ -37,11 +58,17 @@ jobs:
           cp /tmp/mlxvenv/lib/python*/site-packages/mlx/lib/mlx.metallib \
              provider-swift/.build/debug/mlx.metallib
 
-      - name: Download model
+      - name: Cache HuggingFace models
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
+        with:
+          path: ~/.cache/huggingface
+          key: hf-models-integration-${{ runner.os }}-gemma4-e4b
+          restore-keys: hf-models-integration-${{ runner.os }}-
+
+      - name: Download models
         run: |
           /tmp/mlxvenv/bin/pip install huggingface_hub
-          /tmp/mlxvenv/bin/python -c "from huggingface_hub import snapshot_download; snapshot_download('mlx-community/Qwen3.5-0.8B-MLX-4bit')"
-          /tmp/mlxvenv/bin/python -c "from huggingface_hub import snapshot_download; snapshot_download('mlx-community/gemma-3-270m-4bit')"
+          /tmp/mlxvenv/bin/python -c "from huggingface_hub import snapshot_download; snapshot_download('mlx-community/gemma-4-e4b-4bit')"
 
       - name: Run integration + profile tests
         run: |
@@ -58,7 +85,7 @@ jobs:
       DARKBLOOM_REPO_ROOT: ${{ github.workspace }}
       TESTBED_PROVIDER_CONFIG: debug
       BENCHMARK_MD_PATH: /tmp/benchmark-results.md
-      RUNNER_DESC: macos-15 (M1 Virtual)
+      RUNNER_DESC: macos-26 (M4 Blacksmith)
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -68,8 +95,25 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - name: Cache Homebrew packages
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
+        with:
+          path: ~/Library/Caches/Homebrew
+          key: brew-integration-${{ runner.os }}-postgresql16
+          restore-keys: brew-integration-${{ runner.os }}-
+
       - name: Install Postgres
         run: brew install postgresql@16
+
+      - name: Cache Swift build artifacts
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
+        with:
+          path: |
+            provider-swift/.build
+            ~/Library/Caches/org.swift.swiftpm
+            ~/Library/org.swift.swiftpm
+          key: swift-integration-${{ runner.os }}-${{ hashFiles('provider-swift/Package.resolved') }}
+          restore-keys: swift-integration-${{ runner.os }}-
 
       - name: Build provider (Swift)
         run: |
@@ -83,11 +127,17 @@ jobs:
           cp /tmp/mlxvenv/lib/python*/site-packages/mlx/lib/mlx.metallib \
              provider-swift/.build/debug/mlx.metallib
 
-      - name: Download model
+      - name: Cache HuggingFace models
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
+        with:
+          path: ~/.cache/huggingface
+          key: hf-models-integration-${{ runner.os }}-gemma4-e4b
+          restore-keys: hf-models-integration-${{ runner.os }}-
+
+      - name: Download models
         run: |
           /tmp/mlxvenv/bin/pip install huggingface_hub
-          /tmp/mlxvenv/bin/python -c "from huggingface_hub import snapshot_download; snapshot_download('mlx-community/Qwen3.5-0.8B-MLX-4bit')"
-          /tmp/mlxvenv/bin/python -c "from huggingface_hub import snapshot_download; snapshot_download('mlx-community/gemma-3-270m-4bit')"
+          /tmp/mlxvenv/bin/python -c "from huggingface_hub import snapshot_download; snapshot_download('mlx-community/gemma-4-e4b-4bit')"
 
       - name: Run benchmarks
         run: |

--- a/.github/workflows/release-swift.yml
+++ b/.github/workflows/release-swift.yml
@@ -239,15 +239,22 @@ jobs:
 
       # ----------------------------------------------------------------------
       # Download the tiny test model used by InferenceLiveTests. The
-      # `mlx-community/Qwen3-0.6B-8bit` model is ~600 MB and seeds
+      # `mlx-community/gemma-4-e4b-4bit` model is ~5 GB and seeds
       # ~/.cache/huggingface/hub so `ModelScanner.resolveLocalPath` finds
       # it. We pin the snapshot to keep CI deterministic across reruns.
       # ----------------------------------------------------------------------
+      - name: Cache HuggingFace test model
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
+        with:
+          path: ~/.cache/huggingface
+          key: hf-models-release-${{ runner.os }}-gemma4-e4b
+          restore-keys: hf-models-release-${{ runner.os }}-
+
       - name: Download tiny test model for live MLX tests
         run: |
           set -euo pipefail
           /tmp/mlxvenv/bin/pip install --quiet --no-cache-dir 'huggingface_hub[cli]'
-          /tmp/mlxvenv/bin/hf download mlx-community/Qwen3-0.6B-8bit \
+          /tmp/mlxvenv/bin/hf download mlx-community/gemma-4-e4b-4bit \
             --revision main \
             > /dev/null
           ls "${HOME}/.cache/huggingface/hub/" | head -20

--- a/.github/workflows/threat-model-review.yml
+++ b/.github/workflows/threat-model-review.yml
@@ -25,6 +25,13 @@ jobs:
           gh pr diff ${{ github.event.pull_request.number }} > /tmp/pr.diff
           echo "Diff size: $(wc -c < /tmp/pr.diff) bytes"
 
+      - name: Cache pip packages
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
+        with:
+          path: ~/.cache/pip
+          key: pip-threat-model-${{ runner.os }}-anthropic
+          restore-keys: pip-threat-model-${{ runner.os }}-
+
       - name: Install Python dependencies
         run: pip install "anthropic>=0.50.0" pyyaml --quiet
 

--- a/coordinator/api/fullstack_integration_test.go
+++ b/coordinator/api/fullstack_integration_test.go
@@ -10,8 +10,8 @@ package api
 //
 // Requirements:
 //   - Apple Silicon Mac with vllm-mlx installed
-//   - mlx-community/Qwen3.5-0.8B-MLX-4bit downloaded (~0.5GB per instance)
-//   - ~1GB RAM per provider instance
+//   - mlx-community/gemma-4-e4b-4bit downloaded (~5.2GB per instance)
+//   - ~6GB RAM per provider instance
 //
 // Gate: LIVE_FULLSTACK_TEST=1 cargo test (not run in CI)
 //
@@ -48,7 +48,7 @@ import (
 
 const (
 	// testModel is the small model used for full-stack tests.
-	testModel = "mlx-community/Qwen3.5-0.8B-MLX-4bit"
+	testModel = "mlx-community/gemma-4-e4b-4bit"
 
 	// basePort is the starting port for vllm-mlx backends.
 	basePort = 18200

--- a/e2e/benchmark_test.go
+++ b/e2e/benchmark_test.go
@@ -158,7 +158,7 @@ func TestMain(m *testing.M) {
 func TestBenchmark_SingleProviderStreaming(t *testing.T) {
 	runBenchmark(t, "1-provider-streaming",
 		testbed.SuiteConfig{
-			ModelSpecs:    []testbed.ModelSpec{{ModelID: "mlx-community/Qwen3.5-0.8B-MLX-4bit", NumProviders: 1}},
+			ModelSpecs:    []testbed.ModelSpec{{ModelID: "mlx-community/gemma-4-e4b-4bit", NumProviders: 1}},
 			NumUsers:      1,
 			QueueCapacity: 100,
 			QueueTimeout:  120 * time.Second,
@@ -177,7 +177,7 @@ func TestBenchmark_SingleProviderStreaming(t *testing.T) {
 func TestBenchmark_SingleProviderNonStreaming(t *testing.T) {
 	runBenchmark(t, "1-provider-non-streaming",
 		testbed.SuiteConfig{
-			ModelSpecs:    []testbed.ModelSpec{{ModelID: "mlx-community/Qwen3.5-0.8B-MLX-4bit", NumProviders: 1}},
+			ModelSpecs:    []testbed.ModelSpec{{ModelID: "mlx-community/gemma-4-e4b-4bit", NumProviders: 1}},
 			NumUsers:      1,
 			QueueCapacity: 100,
 			QueueTimeout:  120 * time.Second,
@@ -197,8 +197,8 @@ func TestBenchmark_MultiModelMultiProvider(t *testing.T) {
 	runBenchmark(t, "7-provider-multi-model",
 		testbed.SuiteConfig{
 			ModelSpecs: []testbed.ModelSpec{
-				{ModelID: "mlx-community/Qwen3.5-0.8B-MLX-4bit", NumProviders: 4},
-				{ModelID: "mlx-community/gemma-3-270m-4bit", NumProviders: 3},
+				{ModelID: "mlx-community/gemma-4-e4b-4bit", NumProviders: 4},
+				{ModelID: "mlx-community/gemma-4-e4b-4bit", NumProviders: 3},
 			},
 			NumUsers:      5,
 			QueueCapacity: 200,
@@ -218,7 +218,7 @@ func TestBenchmark_MultiModelMultiProvider(t *testing.T) {
 func TestBenchmark_HighConcurrency(t *testing.T) {
 	runBenchmark(t, "3-provider-high-concurrency",
 		testbed.SuiteConfig{
-			ModelSpecs:    []testbed.ModelSpec{{ModelID: "mlx-community/Qwen3.5-0.8B-MLX-4bit", NumProviders: 3}},
+			ModelSpecs:    []testbed.ModelSpec{{ModelID: "mlx-community/gemma-4-e4b-4bit", NumProviders: 3}},
 			NumUsers:      10,
 			QueueCapacity: 200,
 			QueueTimeout:  120 * time.Second,
@@ -237,7 +237,7 @@ func TestBenchmark_HighConcurrency(t *testing.T) {
 func TestBenchmark_QueueSaturation(t *testing.T) {
 	runBenchmark(t, "1-provider-queue-saturation",
 		testbed.SuiteConfig{
-			ModelSpecs:    []testbed.ModelSpec{{ModelID: "mlx-community/Qwen3.5-0.8B-MLX-4bit", NumProviders: 1}},
+			ModelSpecs:    []testbed.ModelSpec{{ModelID: "mlx-community/gemma-4-e4b-4bit", NumProviders: 1}},
 			NumUsers:      10,
 			QueueCapacity: 200,
 			QueueTimeout:  120 * time.Second,
@@ -256,7 +256,7 @@ func TestBenchmark_QueueSaturation(t *testing.T) {
 func TestBenchmark_ManyUsers(t *testing.T) {
 	runBenchmark(t, "3-provider-20-users",
 		testbed.SuiteConfig{
-			ModelSpecs:    []testbed.ModelSpec{{ModelID: "mlx-community/Qwen3.5-0.8B-MLX-4bit", NumProviders: 3}},
+			ModelSpecs:    []testbed.ModelSpec{{ModelID: "mlx-community/gemma-4-e4b-4bit", NumProviders: 3}},
 			NumUsers:      20,
 			QueueCapacity: 200,
 			QueueTimeout:  120 * time.Second,
@@ -277,7 +277,7 @@ func TestBenchmark_SingleModelScaling(t *testing.T) {
 		t.Run(fmt.Sprintf("%d-providers", numProviders), func(t *testing.T) {
 			runBenchmark(t, fmt.Sprintf("%d-provider-scaling", numProviders),
 				testbed.SuiteConfig{
-					ModelSpecs:    []testbed.ModelSpec{{ModelID: "mlx-community/Qwen3.5-0.8B-MLX-4bit", NumProviders: numProviders}},
+					ModelSpecs:    []testbed.ModelSpec{{ModelID: "mlx-community/gemma-4-e4b-4bit", NumProviders: numProviders}},
 					NumUsers:      5,
 					QueueCapacity: 200,
 					QueueTimeout:  120 * time.Second,
@@ -298,7 +298,7 @@ func TestBenchmark_SingleModelScaling(t *testing.T) {
 func TestBenchmark_HeavyLoad_100Concurrent_10KB(t *testing.T) {
 	runBenchmark(t, "3-provider-heavy-100conc-10kb",
 		testbed.SuiteConfig{
-			ModelSpecs:    []testbed.ModelSpec{{ModelID: "mlx-community/Qwen3.5-0.8B-MLX-4bit", NumProviders: 3}},
+			ModelSpecs:    []testbed.ModelSpec{{ModelID: "mlx-community/gemma-4-e4b-4bit", NumProviders: 3}},
 			NumUsers:      20,
 			QueueCapacity: 200,
 			QueueTimeout:  120 * time.Second,

--- a/e2e/testbed/config.go
+++ b/e2e/testbed/config.go
@@ -8,8 +8,7 @@ type ModelSpec struct {
 }
 
 var KnownModelSizes = map[string]string{
-	"mlx-community/Qwen3.5-0.8B-MLX-4bit": "0.5 GB",
-	"mlx-community/gemma-3-270m-4bit":     "0.2 GB",
+	"mlx-community/gemma-4-e4b-4bit": "5.2 GB",
 }
 
 type TrustLevel string
@@ -78,7 +77,7 @@ type ModelConfig struct {
 
 func DefaultModelConfig() ModelConfig {
 	return ModelConfig{
-		ModelID:     "mlx-community/gemma-3-270m",
+		ModelID:     "mlx-community/gemma-4-e4b-4bit",
 		BackendPort: 8000,
 	}
 }
@@ -98,7 +97,7 @@ type SuiteConfig struct {
 
 func DefaultSuiteConfig() SuiteConfig {
 	return SuiteConfig{
-		ModelSpecs:    []ModelSpec{{ModelID: "mlx-community/Qwen3.5-0.8B-MLX-4bit", NumProviders: 1}},
+		ModelSpecs:    []ModelSpec{{ModelID: "mlx-community/gemma-4-e4b-4bit", NumProviders: 1}},
 		NumUsers:      1,
 		QueueCapacity: 100,
 		QueueTimeout:  120 * time.Second,
@@ -130,5 +129,5 @@ func (sc SuiteConfig) PrimaryModelID() string {
 	if len(sc.ModelSpecs) > 0 {
 		return sc.ModelSpecs[0].ModelID
 	}
-	return "mlx-community/Qwen3.5-0.8B-MLX-4bit"
+	return "mlx-community/gemma-4-e4b-4bit"
 }

--- a/e2e/testbed/suite.go
+++ b/e2e/testbed/suite.go
@@ -118,7 +118,7 @@ func resolveModelID(modelID string) string {
 	if env := os.Getenv("TESTBED_MODEL_ID"); env != "" {
 		return env
 	}
-	return "mlx-community/Qwen3.5-0.8B-MLX-4bit"
+	return "mlx-community/gemma-4-e4b-4bit"
 }
 
 func (s *Suite) PrimaryModelID() string {

--- a/e2e/testbed/testbed_test.go
+++ b/e2e/testbed/testbed_test.go
@@ -79,7 +79,7 @@ func TestEventSchemaVersion(t *testing.T) {
 
 func TestDefaultConfigs(t *testing.T) {
 	cfg := DefaultTestConfig()
-	assert.Equal(t, "mlx-community/gemma-3-270m", cfg.Model.ModelID)
+	assert.Equal(t, "mlx-community/gemma-4-e4b-4bit", cfg.Model.ModelID)
 	assert.Equal(t, TrustNone, cfg.Provider.TrustLevel)
 	assert.Equal(t, 64, cfg.Request.PromptTokens)
 	assert.Equal(t, 128, cfg.Request.MaxTokens)
@@ -90,12 +90,12 @@ func TestDefaultConfigs(t *testing.T) {
 
 	sc := DefaultSuiteConfig()
 	assert.Equal(t, 1, len(sc.ModelSpecs))
-	assert.Equal(t, "mlx-community/Qwen3.5-0.8B-MLX-4bit", sc.ModelSpecs[0].ModelID)
+	assert.Equal(t, "mlx-community/gemma-4-e4b-4bit", sc.ModelSpecs[0].ModelID)
 	assert.Equal(t, 1, sc.ModelSpecs[0].NumProviders)
 	assert.Equal(t, 1, sc.NumUsers)
 	assert.Equal(t, 1, sc.TotalProviders())
-	assert.Equal(t, "mlx-community/Qwen3.5-0.8B-MLX-4bit", sc.PrimaryModelID())
-	assert.Equal(t, []string{"mlx-community/Qwen3.5-0.8B-MLX-4bit"}, sc.AllModelIDs())
+	assert.Equal(t, "mlx-community/gemma-4-e4b-4bit", sc.PrimaryModelID())
+	assert.Equal(t, []string{"mlx-community/gemma-4-e4b-4bit"}, sc.AllModelIDs())
 
 	multiSpec := SuiteConfig{
 		ModelSpecs: []ModelSpec{


### PR DESCRIPTION
## Summary

Optimize all CI workflows to leverage Blacksmith's infrastructure and migrate test models from Qwen to Gemma 4.

### Workflow optimizations

| Workflow | Optimization | Expected impact |
|---|---|---|
| `ci.yml` | Cargo artifact cache for provider tests | Save 3-8 min/run |
| `ci.yml` | `golangci-lint-action` v9.2.0 (pre-built binary, analysis cache) | Save ~30s + better annotations |
| `integration.yml` | Cache Homebrew, Swift .build, HuggingFace models | Save 5-10 min/run on warm cache |
| `release-swift.yml` | Cache HuggingFace test model | Save ~2 min/release |
| `threat-model-review.yml` | pip cache | Save ~15s |

All caches use standard `actions/cache` — Blacksmith's transparent proxy intercepts them automatically at ~400 MB/s (vs GitHub's ~90 MB/s) with 25 GB free storage per repo.

Sticky disks (`useblacksmith/stickydisk`) were evaluated but are **Linux-only** (ext4 + block devices). All heavy CI jobs run on macOS Apple Silicon runners, so `actions/cache` with the transparent proxy is the best available option.

### Model migration

- **Primary test model**: `mlx-community/Qwen3.5-0.8B-MLX-4bit` → `mlx-community/gemma-4-e4b-4bit` (5.2 GB)
- **Removed**: `mlx-community/gemma-3-270m-4bit` secondary model
- **Release tests**: `mlx-community/Qwen3-0.6B-8bit` → `mlx-community/gemma-4-e4b-4bit`
- Updated testbed defaults, benchmark configs, fullstack integration test constants, and `KnownModelSizes`
- Updated `RUNNER_DESC` to reflect actual Blacksmith runner (`macos-26 (M4 Blacksmith)`)

### Files changed (9)

- `.github/workflows/ci.yml` — Cargo cache + golangci-lint action
- `.github/workflows/integration.yml` — Homebrew/Swift/HF caches + model swap
- `.github/workflows/release-swift.yml` — HF cache + model swap  
- `.github/workflows/threat-model-review.yml` — pip cache
- `e2e/testbed/config.go` — model defaults + known sizes
- `e2e/testbed/suite.go` — fallback model ID
- `e2e/testbed/testbed_test.go` — assertion updates
- `e2e/benchmark_test.go` — benchmark model configs
- `coordinator/api/fullstack_integration_test.go` — testModel constant

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/184"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->