### PR TITLE
fix: replace map[string]any with protocol.InferenceRequestMessage in dispatchOneProvider

### DIFF
--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -1088,12 +1088,12 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 				continue
 			}
 			timing.EncryptedAt = time.Now()
-			wireMsg := map[string]any{
-				"type":       protocol.TypeInferenceRequest,
-				"request_id": requestID,
-				"encrypted_body": map[string]string{
-					"ephemeral_public_key": encrypted.EphemeralPublicKey,
-					"ciphertext":           encrypted.Ciphertext,
+			wireMsg := protocol.InferenceRequestMessage{
+				Type:      protocol.TypeInferenceRequest,
+				RequestID: requestID,
+				EncryptedBody: &protocol.EncryptedPayload{
+					EphemeralPublicKey: encrypted.EphemeralPublicKey,
+					Ciphertext:         encrypted.Ciphertext,
 				},
 			}
 			pr.SessionPrivKey = &sessionKeys.PrivateKey
@@ -3419,12 +3419,12 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 		return
 	}
 
-	wireMsg := map[string]any{
-		"type":       protocol.TypeInferenceRequest,
-		"request_id": requestID,
-		"encrypted_body": map[string]string{
-			"ephemeral_public_key": encrypted.EphemeralPublicKey,
-			"ciphertext":           encrypted.Ciphertext,
+	wireMsg := protocol.InferenceRequestMessage{
+		Type:      protocol.TypeInferenceRequest,
+		RequestID: requestID,
+		EncryptedBody: &protocol.EncryptedPayload{
+			EphemeralPublicKey: encrypted.EphemeralPublicKey,
+			Ciphertext:         encrypted.Ciphertext,
 		},
 	}
 

--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -227,12 +227,12 @@ func (s *Server) dispatchOneProvider(
 		return nil, nil, decision, "failed to encrypt request", http.StatusInternalServerError
 	}
 
-	wireMsg := map[string]any{
-		"type":       protocol.TypeInferenceRequest,
-		"request_id": requestID,
-		"encrypted_body": map[string]string{
-			"ephemeral_public_key": encrypted.EphemeralPublicKey,
-			"ciphertext":           encrypted.Ciphertext,
+	wireMsg := protocol.InferenceRequestMessage{
+		Type:      protocol.TypeInferenceRequest,
+		RequestID: requestID,
+		EncryptedBody: &protocol.EncryptedPayload{
+			EphemeralPublicKey: encrypted.EphemeralPublicKey,
+			Ciphertext:         encrypted.Ciphertext,
 		},
 	}
 


### PR DESCRIPTION
Use the existing typed struct from `coordinator/protocol/messages.go` instead of an ad-hoc `map[string]any` for the inference request wire message in `dispatchOneProvider`.

**Before:** `wireMsg := map[string]any{...}` with string-keyed fields and a nested `map[string]string` for `encrypted_body`.

**After:** `wireMsg := protocol.InferenceRequestMessage{...}` with `EncryptedBody: &protocol.EncryptedPayload{...}`.

Both types already exist in the protocol package alongside all other wire message types — no new types needed.

- [x] Build passes
- [x] Tests pass (`go test -race ./api/...`)
- [x] Gofmt clean
- [x] Lint passes (0 issues)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/189"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->