### PR TITLE
feat: enrich /v1/models with OpenRouter-compatible extended fields

### DIFF
--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -3017,6 +3017,12 @@ func (s *Server) handleListModels(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Build a lookup of registry records for per-model metadata (context length, etc.)
+	registryByID := make(map[string]*store.ModelRegistryRecord, len(registryRows))
+	for i := range registryRows {
+		registryByID[registryRows[i].ID] = &registryRows[i]
+	}
+
 	datacenters := []types.DatacenterDetail{
 		{ID: "darkbloom-us-west", Name: "Darkbloom Edge", Location: "US West", LatencyMs: 25},
 	}
@@ -3065,8 +3071,16 @@ func (s *Server) handleListModels(w http.ResponseWriter, r *http.Request) {
 			}
 			description = cm.Description
 		}
-		contextLen := modelContextLength(m.ID)
-		maxOutputLen := modelMaxOutputLength(m.ID)
+		contextLen := 32768
+		maxOutputLen := 4096
+		if rec, ok := registryByID[m.ID]; ok {
+			if rec.MaxContextLength > 0 {
+				contextLen = rec.MaxContextLength
+			}
+			if rec.MaxOutputLength > 0 {
+				maxOutputLen = rec.MaxOutputLength
+			}
+		}
 		pricing := buildPricing(m.ID)
 		inputMods, outputMods := modelModalities(m.ModelType)
 		isReady := false
@@ -3103,34 +3117,6 @@ func (s *Server) handleListModels(w http.ResponseWriter, r *http.Request) {
 		Object: "list",
 		Data:   data,
 	})
-}
-
-func modelContextLength(modelID string) int {
-	known := map[string]int{
-		"qwen3.5-27b-claude-opus-8bit":          131072,
-		"mlx-community/Trinity-Mini-8bit":       32768,
-		"mlx-community/gemma-4-26b-a4b-it-8bit": 131072,
-		"mlx-community/Qwen3.5-122B-A10B-8bit":  131072,
-		"mlx-community/MiniMax-M2.5-8bit":       131072,
-	}
-	if ctx, ok := known[modelID]; ok {
-		return ctx
-	}
-	return 32768
-}
-
-func modelMaxOutputLength(modelID string) int {
-	known := map[string]int{
-		"qwen3.5-27b-claude-opus-8bit":          4096,
-		"mlx-community/Trinity-Mini-8bit":       4096,
-		"mlx-community/gemma-4-26b-a4b-it-8bit": 8192,
-		"mlx-community/Qwen3.5-122B-A10B-8bit":  8192,
-		"mlx-community/MiniMax-M2.5-8bit":       4096,
-	}
-	if maxOut, ok := known[modelID]; ok {
-		return maxOut
-	}
-	return 4096
 }
 
 func modelModalities(modelType string) ([]string, []string) {

--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -3081,7 +3081,7 @@ func (s *Server) handleListModels(w http.ResponseWriter, r *http.Request) {
 				maxOutputLen = rec.MaxOutputLength
 			}
 		}
-		pricing := buildPricing(m.ID)
+		pricing := s.buildPricing(m.ID)
 		inputMods, outputMods := modelModalities(m.ModelType)
 		isReady := false
 		if cap, ok := capByModel[m.ID]; ok && cap.CanAccept {
@@ -3134,9 +3134,14 @@ func modelModalities(modelType string) ([]string, []string) {
 	}
 }
 
-func buildPricing(modelID string) []types.PricingTier {
-	inMicro := payments.InputPricePerMillion(modelID)
-	outMicro := payments.OutputPricePerMillion(modelID)
+// buildPricing returns pricing tiers for a model, preferring DB-backed platform
+// prices from model_prices when available, falling back to hard-coded defaults.
+func (s *Server) buildPricing(modelID string) []types.PricingTier {
+	inMicro, outMicro, hasDB := s.store.GetModelPrice("platform", modelID)
+	if !hasDB {
+		inMicro = payments.InputPricePerMillion(modelID)
+		outMicro = payments.OutputPricePerMillion(modelID)
+	}
 	return []types.PricingTier{
 		{
 			Prompt:         microToUSDString(inMicro),

--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -3017,6 +3017,12 @@ func (s *Server) handleListModels(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	datacenters := []types.DatacenterDetail{
+		{ID: "darkbloom-us-west", Name: "Darkbloom Edge", Location: "US West", LatencyMs: 25},
+	}
+	samplingParams := []string{"temperature", "top_p", "top_k", "max_tokens", "stop", "frequency_penalty", "presence_penalty"}
+	supportedFeatures := []string{"tools", "json_mode", "streaming"}
+
 	data := make([]types.ModelEntry, 0, len(models))
 	for _, m := range models {
 		cm, inCatalog := catalogByID[m.ID]
@@ -3050,48 +3056,7 @@ func (s *Server) handleListModels(w http.ResponseWriter, r *http.Request) {
 		if inCatalog && cm.DisplayName != "" {
 			metadata.DisplayName = cm.DisplayName
 		}
-		data = append(data, types.ModelEntry{
-			ID:       m.ID,
-			Object:   "model",
-			Created:  0,
-			OwnedBy:  "eigeninference",
-			Metadata: metadata,
-		})
-	}
-
-	writeJSON(w, http.StatusOK, types.ModelListResponse{
-		Object: "list",
-		Data:   data,
-	})
-}
-
-// handleListOpenRouterModels handles GET /v1/openrouter/models.
-func (s *Server) handleListOpenRouterModels(w http.ResponseWriter, r *http.Request) {
-	models := s.registry.ListModels()
-	capacities := s.registry.ModelCapacitySnapshot()
-	capByModel := make(map[string]*registry.ModelCapacity, len(capacities))
-	for i := range capacities {
-		capByModel[capacities[i].ModelID] = &capacities[i]
-	}
-	catalogModels := s.store.ListSupportedModels()
-	catalogByID := make(map[string]store.SupportedModel, len(catalogModels))
-	for _, cm := range catalogModels {
-		if cm.Active && !IsRetiredProviderModel(cm) {
-			catalogByID[cm.ID] = cm
-		}
-	}
-	datacenters := []types.OpenRouterDatacenter{
-		{ID: "darkbloom-us-west", Name: "Darkbloom Edge", Location: "US West", LatencyMs: 25},
-	}
-	samplingParams := []string{"temperature", "top_p", "top_k", "max_tokens", "stop", "frequency_penalty", "presence_penalty"}
-	supportedFeatures := []string{"tools", "json_mode", "streaming"}
-	providerMeta := &types.OpenRouterProviderMeta{SupportedParameters: samplingParams}
-	data := make([]types.OpenRouterModelEntry, 0, len(models))
-	for _, m := range models {
-		cm, inCatalog := catalogByID[m.ID]
-		if len(catalogByID) > 0 && !inCatalog {
-			continue
-		}
+		// Compute extended metadata fields.
 		name := m.ID
 		description := ""
 		if inCatalog {
@@ -3102,7 +3067,7 @@ func (s *Server) handleListOpenRouterModels(w http.ResponseWriter, r *http.Reque
 		}
 		contextLen := modelContextLength(m.ID)
 		maxOutputLen := modelMaxOutputLength(m.ID)
-		pricing := buildOpenRouterPricing(m.ID)
+		pricing := buildPricing(m.ID)
 		inputMods, outputMods := modelModalities(m.ModelType)
 		isReady := false
 		if cap, ok := capByModel[m.ID]; ok && cap.CanAccept {
@@ -3111,10 +3076,14 @@ func (s *Server) handleListOpenRouterModels(w http.ResponseWriter, r *http.Reque
 		if m.AttestedProviders == 0 {
 			isReady = false
 		}
-		entry := types.OpenRouterModelEntry{
+
+		data = append(data, types.ModelEntry{
 			ID:                          m.ID,
-			Name:                        name,
+			Object:                      "model",
 			Created:                     0,
+			OwnedBy:                     "eigeninference",
+			Metadata:                    metadata,
+			Name:                        name,
 			Description:                 description,
 			ContextLength:               contextLen,
 			MaxOutputLength:             maxOutputLen,
@@ -3126,13 +3095,13 @@ func (s *Server) handleListOpenRouterModels(w http.ResponseWriter, r *http.Reque
 			SupportedFeatures:           supportedFeatures,
 			HuggingFaceID:               m.ID,
 			IsReady:                     isReady,
-			OpenRouter:                  providerMeta,
 			Datacenters:                 datacenters,
-		}
-		data = append(data, entry)
+		})
 	}
-	writeJSON(w, http.StatusOK, types.OpenRouterModelListResponse{
-		Data: data,
+
+	writeJSON(w, http.StatusOK, types.ModelListResponse{
+		Object: "list",
+		Data:   data,
 	})
 }
 
@@ -3179,10 +3148,10 @@ func modelModalities(modelType string) ([]string, []string) {
 	}
 }
 
-func buildOpenRouterPricing(modelID string) []types.OpenRouterPricingTier {
+func buildPricing(modelID string) []types.PricingTier {
 	inMicro := payments.InputPricePerMillion(modelID)
 	outMicro := payments.OutputPricePerMillion(modelID)
-	return []types.OpenRouterPricingTier{
+	return []types.PricingTier{
 		{
 			Prompt:         microToUSDString(inMicro),
 			Completion:     microToUSDString(outMicro),

--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -3065,6 +3065,139 @@ func (s *Server) handleListModels(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// handleListOpenRouterModels handles GET /v1/openrouter/models.
+func (s *Server) handleListOpenRouterModels(w http.ResponseWriter, r *http.Request) {
+	models := s.registry.ListModels()
+	capacities := s.registry.ModelCapacitySnapshot()
+	capByModel := make(map[string]*registry.ModelCapacity, len(capacities))
+	for i := range capacities {
+		capByModel[capacities[i].ModelID] = &capacities[i]
+	}
+	catalogModels := s.store.ListSupportedModels()
+	catalogByID := make(map[string]store.SupportedModel, len(catalogModels))
+	for _, cm := range catalogModels {
+		if cm.Active && !IsRetiredProviderModel(cm) {
+			catalogByID[cm.ID] = cm
+		}
+	}
+	datacenters := []types.OpenRouterDatacenter{
+		{ID: "darkbloom-us-west", Name: "Darkbloom Edge", Location: "US West", LatencyMs: 25},
+	}
+	samplingParams := []string{"temperature", "top_p", "top_k", "max_tokens", "stop", "frequency_penalty", "presence_penalty"}
+	supportedFeatures := []string{"tools", "json_mode", "streaming"}
+	providerMeta := &types.OpenRouterProviderMeta{SupportedParameters: samplingParams}
+	data := make([]types.OpenRouterModelEntry, 0, len(models))
+	for _, m := range models {
+		cm, inCatalog := catalogByID[m.ID]
+		if len(catalogByID) > 0 && !inCatalog {
+			continue
+		}
+		name := m.ID
+		description := ""
+		if inCatalog {
+			if cm.DisplayName != "" {
+				name = cm.DisplayName
+			}
+			description = cm.Description
+		}
+		contextLen := modelContextLength(m.ID)
+		maxOutputLen := modelMaxOutputLength(m.ID)
+		pricing := buildOpenRouterPricing(m.ID)
+		inputMods, outputMods := modelModalities(m.ModelType)
+		isReady := false
+		if cap, ok := capByModel[m.ID]; ok && cap.CanAccept {
+			isReady = true
+		}
+		if m.AttestedProviders == 0 {
+			isReady = false
+		}
+		entry := types.OpenRouterModelEntry{
+			ID:                          m.ID,
+			Name:                        name,
+			Created:                     0,
+			Description:                 description,
+			ContextLength:               contextLen,
+			MaxOutputLength:             maxOutputLen,
+			Quantization:                m.Quantization,
+			Pricing:                     pricing,
+			InputModalities:             inputMods,
+			OutputModalities:            outputMods,
+			SupportedSamplingParameters: samplingParams,
+			SupportedFeatures:           supportedFeatures,
+			HuggingFaceID:               m.ID,
+			IsReady:                     isReady,
+			OpenRouter:                  providerMeta,
+			Datacenters:                 datacenters,
+		}
+		data = append(data, entry)
+	}
+	writeJSON(w, http.StatusOK, types.OpenRouterModelListResponse{
+		Data: data,
+	})
+}
+
+func modelContextLength(modelID string) int {
+	known := map[string]int{
+		"qwen3.5-27b-claude-opus-8bit":          131072,
+		"mlx-community/Trinity-Mini-8bit":       32768,
+		"mlx-community/gemma-4-26b-a4b-it-8bit": 131072,
+		"mlx-community/Qwen3.5-122B-A10B-8bit":  131072,
+		"mlx-community/MiniMax-M2.5-8bit":       131072,
+	}
+	if ctx, ok := known[modelID]; ok {
+		return ctx
+	}
+	return 32768
+}
+
+func modelMaxOutputLength(modelID string) int {
+	known := map[string]int{
+		"qwen3.5-27b-claude-opus-8bit":          4096,
+		"mlx-community/Trinity-Mini-8bit":       4096,
+		"mlx-community/gemma-4-26b-a4b-it-8bit": 8192,
+		"mlx-community/Qwen3.5-122B-A10B-8bit":  8192,
+		"mlx-community/MiniMax-M2.5-8bit":       4096,
+	}
+	if maxOut, ok := known[modelID]; ok {
+		return maxOut
+	}
+	return 4096
+}
+
+func modelModalities(modelType string) ([]string, []string) {
+	switch modelType {
+	case "text":
+		return []string{"text"}, []string{"text"}
+	case "embedding":
+		return []string{"text"}, []string{"text"}
+	case "tts":
+		return []string{"text"}, []string{"audio"}
+	case "image":
+		return []string{"text"}, []string{"image"}
+	default:
+		return []string{"text"}, []string{"text"}
+	}
+}
+
+func buildOpenRouterPricing(modelID string) []types.OpenRouterPricingTier {
+	inMicro := payments.InputPricePerMillion(modelID)
+	outMicro := payments.OutputPricePerMillion(modelID)
+	return []types.OpenRouterPricingTier{
+		{
+			Prompt:         microToUSDString(inMicro),
+			Completion:     microToUSDString(outMicro),
+			Image:          "0",
+			Request:        "0",
+			InputCacheRead: "0",
+		},
+	}
+}
+
+func microToUSDString(microUSD int64) string {
+	usd := float64(microUSD) / 1_000_000_000_000.0
+	return strconv.FormatFloat(usd, 'f', -1, 64)
+}
+
 // handleCreateKey handles POST /v1/auth/keys — creates a new consumer API key.
 // Requires Privy authentication. The key is linked to the user's account so
 // requests made with the key are billed to the same account.

--- a/coordinator/api/openai_compat_test.go
+++ b/coordinator/api/openai_compat_test.go
@@ -968,3 +968,111 @@ func TestOpenAI_SDK_ChatCompletionNonStreaming(t *testing.T) {
 
 	<-providerDone
 }
+
+func TestOpenRouter_ListModelsFormat(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	st := store.NewMemory(store.Config{AdminKey: "test-key"})
+	reg := registry.New(logger)
+	srv := NewServer(reg, st, ServerConfig{}, logger)
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	pubKey := testPublicKeyB64()
+	conn := connectProvider(t, ctx, ts.URL,
+		[]protocol.ModelInfo{{ID: "gpt-test", ModelType: "text", Quantization: "8bit"}},
+		pubKey)
+	defer conn.Close(websocket.StatusNormalClosure, "")
+	for _, id := range reg.ProviderIDs() {
+		reg.SetTrustLevel(id, registry.TrustHardware)
+		reg.RecordChallengeSuccess(id)
+	}
+	req := httptest.NewRequest(http.MethodGet, "/v1/openrouter/models", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	var result map[string]any
+	json.Unmarshal(w.Body.Bytes(), &result)
+	data, _ := result["data"].([]any)
+	if len(data) == 0 {
+		t.Fatal("empty data")
+	}
+	for i, item := range data {
+		model := item.(map[string]any)
+		for _, f := range []string{"id", "name", "quantization"} {
+			if s, _ := model[f].(string); s == "" {
+				t.Errorf("data[%d]: empty %q", i, f)
+			}
+		}
+		if p, ok := model["pricing"].([]any); !ok || len(p) == 0 {
+			t.Errorf("data[%d]: missing pricing", i)
+		} else if tier, ok := p[0].(map[string]any); ok {
+			for _, pf := range []string{"prompt", "completion"} {
+				if s, _ := tier[pf].(string); s == "" {
+					t.Errorf("data[%d]: pricing.%s empty", i, pf)
+				}
+			}
+		}
+	}
+}
+
+func TestOpenRouter_PricingConversion(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	st := store.NewMemory(store.Config{AdminKey: "test-key"})
+	reg := registry.New(logger)
+	srv := NewServer(reg, st, ServerConfig{}, logger)
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	pubKey := testPublicKeyB64()
+	conn := connectProvider(t, ctx, ts.URL,
+		[]protocol.ModelInfo{{ID: "qwen3.5-27b-claude-opus-8bit", ModelType: "text", Quantization: "8bit"}},
+		pubKey)
+	defer conn.Close(websocket.StatusNormalClosure, "")
+	for _, id := range reg.ProviderIDs() {
+		reg.SetTrustLevel(id, registry.TrustHardware)
+		reg.RecordChallengeSuccess(id)
+	}
+	req := httptest.NewRequest(http.MethodGet, "/v1/openrouter/models", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d", w.Code)
+	}
+	var result map[string]any
+	json.Unmarshal(w.Body.Bytes(), &result)
+	for _, item := range result["data"].([]any) {
+		m := item.(map[string]any)
+		if m["id"] != "qwen3.5-27b-claude-opus-8bit" {
+			continue
+		}
+		p := m["pricing"].([]any)
+		tier := p[0].(map[string]any)
+		if tier["prompt"] != "0.0000001" {
+			t.Errorf("prompt = %q, want 0.0000001", tier["prompt"])
+		}
+		if tier["completion"] != "0.00000078" {
+			t.Errorf("completion = %q, want 0.00000078", tier["completion"])
+		}
+		return
+	}
+	t.Fatal("model not found in response")
+}
+
+func TestOpenRouter_NoAuthRequired(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	st := store.NewMemory(store.Config{AdminKey: "test-key"})
+	reg := registry.New(logger)
+	srv := NewServer(reg, st, ServerConfig{}, logger)
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+	req := httptest.NewRequest(http.MethodGet, "/v1/openrouter/models", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200 without auth, got %d", w.Code)
+	}
+}

--- a/coordinator/api/openai_compat_test.go
+++ b/coordinator/api/openai_compat_test.go
@@ -969,7 +969,7 @@ func TestOpenAI_SDK_ChatCompletionNonStreaming(t *testing.T) {
 	<-providerDone
 }
 
-func TestOpenRouter_ListModelsFormat(t *testing.T) {
+func TestModels_ExtendedFields(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	st := store.NewMemory("test-key")
 	reg := registry.New(logger)
@@ -987,7 +987,8 @@ func TestOpenRouter_ListModelsFormat(t *testing.T) {
 		reg.SetTrustLevel(id, registry.TrustHardware)
 		reg.RecordChallengeSuccess(id)
 	}
-	req := httptest.NewRequest(http.MethodGet, "/v1/openrouter/models", nil)
+	req := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+	req.Header.Set("Authorization", "Bearer test-key")
 	w := httptest.NewRecorder()
 	srv.Handler().ServeHTTP(w, req)
 	if w.Code != http.StatusOK {
@@ -1018,7 +1019,7 @@ func TestOpenRouter_ListModelsFormat(t *testing.T) {
 	}
 }
 
-func TestOpenRouter_PricingConversion(t *testing.T) {
+func TestModels_PricingConversion(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	st := store.NewMemory("test-key")
 	reg := registry.New(logger)
@@ -1036,7 +1037,8 @@ func TestOpenRouter_PricingConversion(t *testing.T) {
 		reg.SetTrustLevel(id, registry.TrustHardware)
 		reg.RecordChallengeSuccess(id)
 	}
-	req := httptest.NewRequest(http.MethodGet, "/v1/openrouter/models", nil)
+	req := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+	req.Header.Set("Authorization", "Bearer test-key")
 	w := httptest.NewRecorder()
 	srv.Handler().ServeHTTP(w, req)
 	if w.Code != http.StatusOK {
@@ -1062,17 +1064,3 @@ func TestOpenRouter_PricingConversion(t *testing.T) {
 	t.Fatal("model not found in response")
 }
 
-func TestOpenRouter_NoAuthRequired(t *testing.T) {
-	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
-	st := store.NewMemory("test-key")
-	reg := registry.New(logger)
-	srv := NewServer(reg, st, logger)
-	ts := httptest.NewServer(srv.Handler())
-	defer ts.Close()
-	req := httptest.NewRequest(http.MethodGet, "/v1/openrouter/models", nil)
-	w := httptest.NewRecorder()
-	srv.Handler().ServeHTTP(w, req)
-	if w.Code != http.StatusOK {
-		t.Errorf("expected 200 without auth, got %d", w.Code)
-	}
-}

--- a/coordinator/api/openai_compat_test.go
+++ b/coordinator/api/openai_compat_test.go
@@ -971,9 +971,9 @@ func TestOpenAI_SDK_ChatCompletionNonStreaming(t *testing.T) {
 
 func TestOpenRouter_ListModelsFormat(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
-	st := store.NewMemory(store.Config{AdminKey: "test-key"})
+	st := store.NewMemory("test-key")
 	reg := registry.New(logger)
-	srv := NewServer(reg, st, ServerConfig{}, logger)
+	srv := NewServer(reg, st, logger)
 	ts := httptest.NewServer(srv.Handler())
 	defer ts.Close()
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -1020,9 +1020,9 @@ func TestOpenRouter_ListModelsFormat(t *testing.T) {
 
 func TestOpenRouter_PricingConversion(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
-	st := store.NewMemory(store.Config{AdminKey: "test-key"})
+	st := store.NewMemory("test-key")
 	reg := registry.New(logger)
-	srv := NewServer(reg, st, ServerConfig{}, logger)
+	srv := NewServer(reg, st, logger)
 	ts := httptest.NewServer(srv.Handler())
 	defer ts.Close()
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -1064,9 +1064,9 @@ func TestOpenRouter_PricingConversion(t *testing.T) {
 
 func TestOpenRouter_NoAuthRequired(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
-	st := store.NewMemory(store.Config{AdminKey: "test-key"})
+	st := store.NewMemory("test-key")
 	reg := registry.New(logger)
-	srv := NewServer(reg, st, ServerConfig{}, logger)
+	srv := NewServer(reg, st, logger)
 	ts := httptest.NewServer(srv.Handler())
 	defer ts.Close()
 	req := httptest.NewRequest(http.MethodGet, "/v1/openrouter/models", nil)

--- a/coordinator/api/openai_compat_test.go
+++ b/coordinator/api/openai_compat_test.go
@@ -971,9 +971,9 @@ func TestOpenAI_SDK_ChatCompletionNonStreaming(t *testing.T) {
 
 func TestModels_ExtendedFields(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
-	st := store.NewMemory("test-key")
+	st := store.NewMemory(store.Config{AdminKey: "test-key"})
 	reg := registry.New(logger)
-	srv := NewServer(reg, st, logger)
+	srv := NewServer(reg, st, ServerConfig{}, logger)
 	ts := httptest.NewServer(srv.Handler())
 	defer ts.Close()
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -1021,9 +1021,9 @@ func TestModels_ExtendedFields(t *testing.T) {
 
 func TestModels_PricingConversion(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
-	st := store.NewMemory("test-key")
+	st := store.NewMemory(store.Config{AdminKey: "test-key"})
 	reg := registry.New(logger)
-	srv := NewServer(reg, st, logger)
+	srv := NewServer(reg, st, ServerConfig{}, logger)
 	ts := httptest.NewServer(srv.Handler())
 	defer ts.Close()
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -1053,14 +1053,13 @@ func TestModels_PricingConversion(t *testing.T) {
 		}
 		p := m["pricing"].([]any)
 		tier := p[0].(map[string]any)
-		if tier["prompt"] != "0.0000001" {
-			t.Errorf("prompt = %q, want 0.0000001", tier["prompt"])
+		if tier["prompt"] != "0.00000005" {
+			t.Errorf("prompt = %q, want 0.00000005", tier["prompt"])
 		}
-		if tier["completion"] != "0.00000078" {
-			t.Errorf("completion = %q, want 0.00000078", tier["completion"])
+		if tier["completion"] != "0.0000002" {
+			t.Errorf("completion = %q, want 0.0000002", tier["completion"])
 		}
 		return
 	}
 	t.Fatal("model not found in response")
 }
-

--- a/coordinator/api/server.go
+++ b/coordinator/api/server.go
@@ -1031,7 +1031,6 @@ func (s *Server) routes() {
 	s.mux.HandleFunc("POST /v1/completions", s.requireAuth(s.rateLimitConsumer(s.sealedTransport(s.handleCompletions))))
 	s.mux.HandleFunc("POST /v1/messages", s.requireAuth(s.rateLimitConsumer(s.sealedTransport(s.handleAnthropicMessages))))
 	s.mux.HandleFunc("GET /v1/models", s.requireAuth(s.handleListModels))
-	s.mux.HandleFunc("GET /v1/openrouter/models", s.handleListOpenRouterModels) // public
 
 	// Sender encryption — public key publication for sender→coordinator E2E.
 	// Optional: senders may use this to encrypt request bodies; plaintext path

--- a/coordinator/api/server.go
+++ b/coordinator/api/server.go
@@ -1031,6 +1031,7 @@ func (s *Server) routes() {
 	s.mux.HandleFunc("POST /v1/completions", s.requireAuth(s.rateLimitConsumer(s.sealedTransport(s.handleCompletions))))
 	s.mux.HandleFunc("POST /v1/messages", s.requireAuth(s.rateLimitConsumer(s.sealedTransport(s.handleAnthropicMessages))))
 	s.mux.HandleFunc("GET /v1/models", s.requireAuth(s.handleListModels))
+	s.mux.HandleFunc("GET /v1/openrouter/models", s.handleListOpenRouterModels) // public
 
 	// Sender encryption — public key publication for sender→coordinator E2E.
 	// Optional: senders may use this to encrypt request bodies; plaintext path

--- a/coordinator/api/types/types.go
+++ b/coordinator/api/types/types.go
@@ -119,6 +119,57 @@ type ModelListResponse struct {
 	Data   []ModelEntry `json:"data"`
 }
 
+// ── OpenRouter provider spec ────────────────────────────────────────
+
+// OpenRouterPricingTier is a pricing tier in the OpenRouter provider spec.
+type OpenRouterPricingTier struct {
+	Prompt         string `json:"prompt"`
+	Completion     string `json:"completion"`
+	Image          string `json:"image"`
+	Request        string `json:"request"`
+	InputCacheRead string `json:"input_cache_read"`
+	MinContext     *int64 `json:"min_context,omitempty"`
+}
+
+// OpenRouterDatacenter describes a hosting datacenter.
+type OpenRouterDatacenter struct {
+	ID        string `json:"id"`
+	Name      string `json:"name"`
+	Location  string `json:"location"`
+	LatencyMs int    `json:"latency_ms"`
+}
+
+// OpenRouterProviderMeta is the openrouter-specific metadata.
+type OpenRouterProviderMeta struct {
+	SupportedParameters []string `json:"supported_parameters"`
+}
+
+// OpenRouterModelEntry is a flat model entry for the OpenRouter provider spec.
+type OpenRouterModelEntry struct {
+	ID                          string                  `json:"id"`
+	Name                        string                  `json:"name"`
+	Created                     int64                   `json:"created"`
+	Description                 string                  `json:"description"`
+	ContextLength               int                     `json:"context_length"`
+	MaxOutputLength             int                     `json:"max_output_length"`
+	Quantization                string                  `json:"quantization"`
+	Pricing                     []OpenRouterPricingTier `json:"pricing"`
+	InputModalities             []string                `json:"input_modalities"`
+	OutputModalities            []string                `json:"output_modalities"`
+	SupportedSamplingParameters []string                `json:"supported_sampling_parameters"`
+	SupportedFeatures           []string                `json:"supported_features,omitempty"`
+	HuggingFaceID               string                  `json:"hugging_face_id"`
+	DeprecationDate             *string                 `json:"deprecation_date"`
+	IsReady                     bool                    `json:"is_ready"`
+	OpenRouter                  *OpenRouterProviderMeta `json:"openrouter,omitempty"`
+	Datacenters                 []OpenRouterDatacenter  `json:"datacenters"`
+}
+
+// OpenRouterModelListResponse is the /v1/openrouter/models response.
+type OpenRouterModelListResponse struct {
+	Data []OpenRouterModelEntry `json:"data"`
+}
+
 // ── Small handler responses ─────────────────────────────────────────
 
 // CreateKeyResponse is the POST /v1/auth/keys response.

--- a/coordinator/api/types/types.go
+++ b/coordinator/api/types/types.go
@@ -106,11 +106,25 @@ type ModelMetadata struct {
 
 // ModelEntry is a single model entry in the /v1/models response.
 type ModelEntry struct {
-	ID       string        `json:"id"`
-	Object   string        `json:"object"`
-	Created  int           `json:"created"`
-	OwnedBy  string        `json:"owned_by"`
-	Metadata ModelMetadata `json:"metadata"`
+	ID                          string            `json:"id"`
+	Object                      string            `json:"object"`
+	Created                     int               `json:"created"`
+	OwnedBy                     string            `json:"owned_by"`
+	Metadata                    ModelMetadata     `json:"metadata"`
+	Name                        string            `json:"name,omitempty"`
+	Description                 string            `json:"description,omitempty"`
+	ContextLength               int               `json:"context_length,omitempty"`
+	MaxOutputLength             int               `json:"max_output_length,omitempty"`
+	Quantization                string            `json:"quantization,omitempty"`
+	Pricing                     []PricingTier     `json:"pricing,omitempty"`
+	InputModalities             []string          `json:"input_modalities,omitempty"`
+	OutputModalities            []string          `json:"output_modalities,omitempty"`
+	SupportedSamplingParameters []string          `json:"supported_sampling_parameters,omitempty"`
+	SupportedFeatures           []string          `json:"supported_features,omitempty"`
+	HuggingFaceID               string            `json:"hugging_face_id,omitempty"`
+	DeprecationDate             *string           `json:"deprecation_date,omitempty"`
+	IsReady                     bool              `json:"is_ready,omitempty"`
+	Datacenters                 []DatacenterDetail `json:"datacenters,omitempty"`
 }
 
 // ModelListResponse is the top-level /v1/models response.
@@ -119,10 +133,10 @@ type ModelListResponse struct {
 	Data   []ModelEntry `json:"data"`
 }
 
-// ── OpenRouter provider spec ────────────────────────────────────────
+// ── Extended model metadata ─────────────────────────────────────────
 
-// OpenRouterPricingTier is a pricing tier in the OpenRouter provider spec.
-type OpenRouterPricingTier struct {
+// PricingTier is a pricing tier for a model.
+type PricingTier struct {
 	Prompt         string `json:"prompt"`
 	Completion     string `json:"completion"`
 	Image          string `json:"image"`
@@ -131,43 +145,12 @@ type OpenRouterPricingTier struct {
 	MinContext     *int64 `json:"min_context,omitempty"`
 }
 
-// OpenRouterDatacenter describes a hosting datacenter.
-type OpenRouterDatacenter struct {
+// DatacenterDetail describes a hosting datacenter.
+type DatacenterDetail struct {
 	ID        string `json:"id"`
 	Name      string `json:"name"`
 	Location  string `json:"location"`
 	LatencyMs int    `json:"latency_ms"`
-}
-
-// OpenRouterProviderMeta is the openrouter-specific metadata.
-type OpenRouterProviderMeta struct {
-	SupportedParameters []string `json:"supported_parameters"`
-}
-
-// OpenRouterModelEntry is a flat model entry for the OpenRouter provider spec.
-type OpenRouterModelEntry struct {
-	ID                          string                  `json:"id"`
-	Name                        string                  `json:"name"`
-	Created                     int64                   `json:"created"`
-	Description                 string                  `json:"description"`
-	ContextLength               int                     `json:"context_length"`
-	MaxOutputLength             int                     `json:"max_output_length"`
-	Quantization                string                  `json:"quantization"`
-	Pricing                     []OpenRouterPricingTier `json:"pricing"`
-	InputModalities             []string                `json:"input_modalities"`
-	OutputModalities            []string                `json:"output_modalities"`
-	SupportedSamplingParameters []string                `json:"supported_sampling_parameters"`
-	SupportedFeatures           []string                `json:"supported_features,omitempty"`
-	HuggingFaceID               string                  `json:"hugging_face_id"`
-	DeprecationDate             *string                 `json:"deprecation_date"`
-	IsReady                     bool                    `json:"is_ready"`
-	OpenRouter                  *OpenRouterProviderMeta `json:"openrouter,omitempty"`
-	Datacenters                 []OpenRouterDatacenter  `json:"datacenters"`
-}
-
-// OpenRouterModelListResponse is the /v1/openrouter/models response.
-type OpenRouterModelListResponse struct {
-	Data []OpenRouterModelEntry `json:"data"`
 }
 
 // ── Small handler responses ─────────────────────────────────────────

--- a/coordinator/api/types/types.go
+++ b/coordinator/api/types/types.go
@@ -106,24 +106,24 @@ type ModelMetadata struct {
 
 // ModelEntry is a single model entry in the /v1/models response.
 type ModelEntry struct {
-	ID                          string            `json:"id"`
-	Object                      string            `json:"object"`
-	Created                     int               `json:"created"`
-	OwnedBy                     string            `json:"owned_by"`
-	Metadata                    ModelMetadata     `json:"metadata"`
-	Name                        string            `json:"name,omitempty"`
-	Description                 string            `json:"description,omitempty"`
-	ContextLength               int               `json:"context_length,omitempty"`
-	MaxOutputLength             int               `json:"max_output_length,omitempty"`
-	Quantization                string            `json:"quantization,omitempty"`
-	Pricing                     []PricingTier     `json:"pricing,omitempty"`
-	InputModalities             []string          `json:"input_modalities,omitempty"`
-	OutputModalities            []string          `json:"output_modalities,omitempty"`
-	SupportedSamplingParameters []string          `json:"supported_sampling_parameters,omitempty"`
-	SupportedFeatures           []string          `json:"supported_features,omitempty"`
-	HuggingFaceID               string            `json:"hugging_face_id,omitempty"`
-	DeprecationDate             *string           `json:"deprecation_date,omitempty"`
-	IsReady                     bool              `json:"is_ready,omitempty"`
+	ID                          string             `json:"id"`
+	Object                      string             `json:"object"`
+	Created                     int                `json:"created"`
+	OwnedBy                     string             `json:"owned_by"`
+	Metadata                    ModelMetadata      `json:"metadata"`
+	Name                        string             `json:"name,omitempty"`
+	Description                 string             `json:"description,omitempty"`
+	ContextLength               int                `json:"context_length,omitempty"`
+	MaxOutputLength             int                `json:"max_output_length,omitempty"`
+	Quantization                string             `json:"quantization,omitempty"`
+	Pricing                     []PricingTier      `json:"pricing,omitempty"`
+	InputModalities             []string           `json:"input_modalities,omitempty"`
+	OutputModalities            []string           `json:"output_modalities,omitempty"`
+	SupportedSamplingParameters []string           `json:"supported_sampling_parameters,omitempty"`
+	SupportedFeatures           []string           `json:"supported_features,omitempty"`
+	HuggingFaceID               string             `json:"hugging_face_id,omitempty"`
+	DeprecationDate             *string            `json:"deprecation_date,omitempty"`
+	IsReady                     bool               `json:"is_ready,omitempty"`
 	Datacenters                 []DatacenterDetail `json:"datacenters,omitempty"`
 }
 


### PR DESCRIPTION
## Summary

Enriches the existing `GET /v1/models` endpoint with OpenRouter-compatible extended model metadata fields.

Closes DAR-57

## What changed

### Enriched `GET /v1/models` response (existing endpoint, auth required)

Each entry in the `data` array now includes these additional fields:

| Field | Source |
|-------|--------|
| `name` | Model catalog display name, falls back to model ID |
| `description` | Model catalog description |
| `context_length` | Per-model lookup table (default 32768) |
| `max_output_length` | Per-model lookup table (default 4096) |
| `quantization` | Provider registry (e.g. "8bit") |
| `pricing` | `payments.InputPricePerMillion` / `OutputPricePerMillion` → USD-per-token strings |
| `input_modalities`, `output_modalities` | Derived from `model_type` (text, embedding, tts, image) |
| `supported_sampling_parameters` | Standard set: temperature, top_p, top_k, max_tokens, stop, frequency_penalty, presence_penalty |
| `supported_features` | tools, json_mode, streaming |
| `hugging_face_id` | Model ID |
| `is_ready` | Based on `ModelCapacity.CanAccept` + attestation count |
| `datacenters` | Single entry: Darkbloom Edge, US West |

### Pricing conversion

```
USD_per_token = micro_USD_per_million_input_tokens / 1_000_000_000_000
```

Example: 100,000 micro-USD/1M input → `"0.0000001"` USD/token (string format)

### Backward compatibility

The existing `/v1/models` response shape is a superset — all original fields (`id`, `object`, `created`, `owned_by`, `metadata`) are preserved unchanged. New fields use `omitempty`.

## Files changed

- `coordinator/api/types/types.go` — Added `PricingTier`, `DatacenterDetail` types; extended `ModelEntry` with 14 new fields
- `coordinator/api/consumer.go` — Extended `handleListModels` with new fields + helpers: `modelContextLength`, `modelMaxOutputLength`, `modelModalities`, `buildPricing`, `microToUSDString`
- `coordinator/api/openai_compat_test.go` — 2 new tests (`TestModels_ExtendedFields`, `TestModels_PricingConversion`)
