### PR TITLE
feat: provider liveness analytics (DAR-61)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,32 +1,43 @@
-# EigenInference - Decentralized GPU Inference
+# CLAUDE.md
 
-Decentralized inference network for Apple Silicon Macs. Providers offer GPU compute, consumers send OpenAI-compatible requests, the coordinator matches them.
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## EigenInference / Darkbloom
+
+Decentralized inference network for Apple Silicon Macs. Providers offer GPU compute, consumers send OpenAI-compatible requests, the coordinator matches them. End-user-facing brand is **Darkbloom**; repo and internal naming is **EigenInference / d-inference**.
+
+Parallel docs: `README.md` (public overview), `AGENTS.md` (alternate agent guidance — has overlap with this file and may drift; trust this file's paths over AGENTS.md when they conflict), `CONTRIBUTING.md` (contributor flow), `docs/` (deep architecture + runbooks).
 
 ## Project Structure
 
 ```
 coordinator/          Go — central matchmaking server (runs on EigenCloud in prod)
+│                     NOTE: Go packages live at the TOP LEVEL of coordinator/, NOT under internal/.
+│                     coordinator/internal/ only holds an e2e/ subdir; everything else is here.
 ├── cmd/coordinator/  entrypoint
 ├── cmd/verify-attestation/  attestation blob verification utility
-├── internal/
-│   ├── api/          HTTP + WebSocket handlers (consumer.go, provider.go, billing_handlers.go, device_auth.go, invite_handlers.go, release_handlers.go, enroll.go, stats.go, server.go)
-│   ├── attestation/  Secure Enclave + MDA attestation verification
-│   ├── auth/         Privy JWT verification + user provisioning
-│   ├── billing/      Stripe, Solana USDC deposits, referral system
-│   ├── e2e/          End-to-end encryption (X25519 key exchange)
-│   ├── mdm/          MicroMDM integration for device attestation
-│   ├── payments/     Internal ledger, pricing tables, payout tracking
-│   ├── protocol/     WebSocket message types shared with provider
-│   ├── registry/     Provider registry, scoring, reputation, request queue
-│   └── store/        Persistence (in-memory or Postgres)
+├── api/              HTTP + WebSocket handlers (consumer.go, provider.go, billing_handlers.go, device_auth.go, invite_handlers.go, release_handlers.go, enroll.go, stats.go, server.go, install.sh, model_catalog_filter.go, telemetry_handlers.go, …)
+├── attestation/      Secure Enclave + MDA attestation verification
+├── auth/             Privy JWT verification + user provisioning
+├── billing/          Stripe, Solana USDC deposits, referral system
+├── datadog/          Datadog client / tracing wiring
+├── mdm/              MicroMDM integration for device attestation
+├── payments/         Internal ledger, pricing tables, payout tracking
+├── protocol/         WebSocket message types shared with provider (messages.go, telemetry.go)
+├── ratelimit/        Per-user / per-key rate limiting
+├── registry/         Provider registry, scoring, reputation, request queue
+├── saferun/          Panic-safe goroutine helpers
+├── store/            Persistence (in-memory or Postgres)
+├── telemetry/        Telemetry pipeline
+└── internal/e2e/     Server-side end-to-end encryption helpers
 
-provider/             Rust — runs on Apple Silicon Macs
+provider/             Rust — runs on Apple Silicon Macs (legacy, in production)
 ├── src/
 │   ├── main.rs       CLI entry (serve, start, stop, models, benchmark, status, doctor, login, etc.)
 │   ├── coordinator.rs WebSocket client with auto-reconnect
 │   ├── proxy.rs      Forwards text requests to local backends
 │   ├── hardware.rs   Apple Silicon detection, system metrics (memory/CPU/thermal)
-│   ├── protocol.rs   Message types (mirrors coordinator/internal/protocol)
+│   ├── protocol.rs   Message types (mirrors coordinator/protocol)
 │   ├── backend/      Backend process management (vllm_mlx.rs, health checks)
 │   ├── crypto.rs     X25519 key pair (NaCl), E2E decryption
 │   ├── security.rs   SIP checks, binary self-hash, anti-debug (PT_DENY_ATTACH)
@@ -38,23 +49,37 @@ provider/             Rust — runs on Apple Silicon Macs
 │   ├── scheduling.rs Time-based availability windows
 │   ├── service.rs    launchd user agent management
 │   └── wallet.rs     Legacy provider wallet (secp256k1)
-├── stt_server.py     Local speech-to-text server script
+└── tests/
 
-provider-swift/       Swift — CLI replacement for the Rust provider (in progress)
+provider-swift/       Swift — CLI replacement for the Rust provider (cutover in progress)
 ├── Package.swift     SwiftPM manifest, depends on libs/mlx-swift{,-lm}
 ├── Sources/
-│   ├── ProviderCore/                  shared library (protocol, hardware, crypto, security, inference, coordinator client, scheduling, server, telemetry, models, attestation)
-│   ├── darkbloom/                     CLI executable (serve, start, stop, status, doctor, models, login, logout, benchmark, update, verify)
-│   └── darkbloom-enclave-cli/    Secure Enclave attestation/sign helper (replaces the legacy enclave/ FFI bridge)
+│   ├── ProviderCore/            shared library (protocol, hardware, crypto, security, inference, coordinator client, scheduling, server, telemetry, models, attestation)
+│   ├── darkbloom/               CLI executable (serve, start, stop, status, doctor, models, login, logout, benchmark, update, verify)
+│   └── darkbloom-enclave-cli/   Secure Enclave attestation/sign helper (replaces the legacy enclave/ FFI bridge)
 └── Tests/ProviderCoreTests/
+
+enclave/              Swift Secure Enclave helper + FFI bridge (separate SwiftPM project from provider-swift/)
+├── Package.swift
+├── Sources/          enclave key + attestation library + FFI bridge + CLI
+└── Tests/
 
 console-ui/           Next.js 16 / React 19 frontend (chat, billing, models, images)
 ├── src/app/          Pages: chat (/), billing, images, models, stats, providers, settings, link, api-console, earn
 ├── src/app/api/      Proxy routes: chat, models, auth/keys, payments/*, invite, health, pricing
 ├── src/components/   Chat UI, sidebar, top bar, trust badges, invite banner, verification panel
-├── src/lib/          API client (api.ts), Zustand store (store.ts)
+├── src/lib/          API client (api.ts), Zustand store (store.ts), telemetry-types.ts
 ├── src/hooks/        Auth (useAuth.ts), toast notifications (useToast.ts)
 └── proxy.ts          Next.js 16 proxy (replaces middleware.ts)
+
+analytics/            Standalone Go module — analytics ingest/queries (separate go.mod from coordinator)
+deploy/               Deploy configs (datadog, environments, gcp, provider-fleet)
+e2e/                  Root-level end-to-end Go tests + testbed framework (integration_test.go, benchmark_test.go, profile_test.go, testbed/)
+libs/                 Vendored / submoduled deps (mlx-swift, mlx-swift-lm) — used by provider-swift
+tests/                Root cross-language tests (test_crypto_interop.py)
+papers/               Research notes and writeups
+landing/              Static landing page (index.html)
+docs/                 Architecture docs, deploy runbook, MDM/ACME notes, dev-environment.md
 
 scripts/
 ├── install.sh        curl one-liner installer (fetches release, verifies SHA-256 + code signature)
@@ -64,9 +89,8 @@ scripts/
 ├── benchmark-*.py    Benchmark utilities
 └── entitlements.plist Hardened Runtime entitlements (hypervisor, network)
 
-docs/                 Architecture docs, deploy runbook, MDM/ACME notes
-landing/              Static landing page (index.html)
 .github/workflows/    CI (ci.yml) and Swift release automation (release-swift.yml)
+.githooks/            pre-commit (fast format check on staged files) + pre-push (fmt + build + tests)
 
 .external/            Git-ignored; holds external forks used by the project (NOT part of this repo)
 └── vllm-mlx/         Our fork of vllm-mlx (github.com/Gajesh2007/vllm-mlx)
@@ -196,7 +220,7 @@ CI (`.github/workflows/release-swift.yml`) builds, signs, notarizes, and uploads
 - **Idle GPU timeout**: Backend (vllm-mlx) process is killed after 1 hour of no requests to free GPU memory. Lazy-reloaded when the next request arrives (cold-start penalty of ~10-30s for model reload).
 - **E2E encryption**: Consumer requests encrypted with provider's X25519 public key (NaCl box). Coordinator never sees plaintext prompts. Decryption only inside the hardened provider process.
 - **Attestation chain**: Secure Enclave P-256 key → signs attestation blob → coordinator verifies signature (self_signed) → MDM SecurityInfo cross-check (hardware trust) → Apple Enterprise Attestation Root CA signs device cert chain via MDA (mda_verified). Full chain exposed at `GET /v1/providers/attestation` for user-side verification.
-- **Protocol symmetry**: `provider/src/protocol.rs` and `coordinator/internal/protocol/messages.go` define the same WebSocket message types. Changes to one must be mirrored in the other.
+- **Protocol symmetry**: `provider/src/protocol.rs` and `coordinator/protocol/messages.go` define the same WebSocket message types. Changes to one must be mirrored in the other.
 - **Model catalog**: Coordinator maintains a catalog of supported models. Provider CLI filters local models against this catalog for serving and display. Only catalog models are served.
 - **Billing**: Solana USDC deposits verified on-chain. Coordinator wallet derived from BIP39 mnemonic via SLIP-0010 (m/44'/501'/0'/0'). Stripe wired but inactive. Referral system gives referrers a share of platform fees.
 - **Request queue**: When all providers are busy, requests queue with 120s timeout. Frontend shows "providers are busy" on 503.
@@ -225,15 +249,15 @@ Always think from first principles. When fixing a bug or designing a feature:
 
 ## Common Pitfalls
 
-- Protocol changes require updating both `provider/src/protocol.rs` (Rust) AND `coordinator/internal/protocol/messages.go` (Go). They must stay in sync.
-- Telemetry wire types are mirrored in three places: `coordinator/internal/protocol/telemetry.go`, `provider/src/telemetry/event.rs`, and `console-ui/src/lib/telemetry-types.ts`. The field allowlist (`coordinator/internal/api/telemetry_handlers.go`) is the privacy backstop — never add prompt/completion fields. See `docs/telemetry.md`.
+- Protocol changes require updating both `provider/src/protocol.rs` (Rust) AND `coordinator/protocol/messages.go` (Go). They must stay in sync.
+- Telemetry wire types are mirrored in three places: `coordinator/protocol/telemetry.go`, `provider/src/telemetry/event.rs`, and `console-ui/src/lib/telemetry-types.ts`. The field allowlist (`coordinator/api/telemetry_handlers.go`) is the privacy backstop — never add prompt/completion fields. See `docs/telemetry.md`.
 - Attestation tests need `AuthenticatedRootEnabled: true` in test blobs or the ARV check fails and overwrites earlier error messages (the checks run sequentially, last failure wins).
 - The `python` feature flag in the provider Cargo.toml links PyO3. Use `--no-default-features` when building for distribution to avoid Python linking issues.
 - The coordinator uses in-memory store by default. Provider state is lost on restart. Postgres store exists but is not used in production yet.
 - Binary files like `coordinator/eigeninference-coordinator` and `coordinator/eigeninference-coordinator-linux` should NOT be committed to git (15MB+ each).
 - CI release workflow must compute binary SHA-256 hashes AFTER code signing, not before. Providers verify hashes of the signed binary.
-- Provider bundle semantics span multiple files: `.github/workflows/release-swift.yml`, `scripts/install.sh` (and the embedded copy at `coordinator/internal/api/install.sh`), and `LatestProviderVersion` in `coordinator/internal/api/server.go`. Keep them in sync.
-- Image generation and audio transcription are not supported. The platform serves only text inference; the model catalog filter (`coordinator/internal/api/model_catalog_filter.go`) rejects any `ModelType` other than `text`.
+- Provider bundle semantics span multiple files: `.github/workflows/release-swift.yml`, `scripts/install.sh` (and the embedded copy at `coordinator/api/install.sh`), and `LatestProviderVersion` in `coordinator/api/server.go`. Keep them in sync.
+- Image generation and audio transcription are not supported. The platform serves only text inference; the model catalog filter (`coordinator/api/model_catalog_filter.go`) rejects any `ModelType` other than `text`.
 - Device linking changes span coordinator device auth endpoints and provider `login`/`logout` commands.
 - The repo contains mixed payment language: current code implements Privy + Solana + Stripe, but some provider comments still reference Tempo/pathUSD.
 

--- a/analytics/README.md
+++ b/analytics/README.md
@@ -12,12 +12,30 @@ It serves public read models like:
 
 ## Current API
 
+Public-facing:
+
 - `GET /healthz`
 - `GET /v1/overview`
 - `GET /v1/leaderboard/earnings?scope=account|node&window=24h|7d|30d|all&limit=25`
 
-`scope=account` is the default. That is the main public leaderboard shape because
-it ranks operators, not individual nodes.
+Provider liveness (intended for internal / admin dashboards — gate or
+leave un-routed at the public DNS layer):
+
+- `GET /v1/providers/{id}/liveness` — pre-aggregated reliability summary
+  (uptime, MTBF, P10/P50/P90 session length, P(stays ≥4h / ≥8h), hourly
+  availability matrix, disconnect reason histogram).
+- `GET /v1/providers/{id}/sessions?window=24h|7d|30d&limit=N` — recent
+  session intervals with connect/disconnect timestamps and reasons.
+- `GET /v1/providers/{id}/heartbeats?window=24h|7d|30d&limit=N` — recent
+  heartbeat samples (status + memory pressure + CPU + thermal).
+- `GET /v1/providers/reliability?min_uptime=0.95&min_stays_4h=0.8&limit=N` —
+  shortlist of providers meeting a reliability bar, ordered by uptime
+  descending. Foundation for sticky / job-aware scheduling.
+- `GET /v1/network/availability` — fleet-wide distribution
+  (mean / p10 / p50 / p90 uptime + count of highly-reliable providers).
+
+`scope=account` is the default for the earnings leaderboard. That is the main
+public leaderboard shape because it ranks operators, not individual nodes.
 
 Aliases are deterministic and secret-backed:
 
@@ -72,12 +90,28 @@ This service currently reads from:
 
 - `providers`
 - `provider_earnings`
+- `provider_heartbeats` (populated by the coordinator's liveness writer)
+- `provider_sessions` (populated by the coordinator's session tracker)
+- `provider_reliability_features` (populated by the coordinator's rollup worker)
 
-Recommended DB user shape:
+Recommended DB role:
 
-- read-only user
-- `SELECT` on the analytics tables only
-- no write privileges
+```sql
+CREATE ROLE analytics_readonly WITH LOGIN PASSWORD '…' CONNECTION LIMIT 8;
+GRANT CONNECT ON DATABASE <db> TO analytics_readonly;
+GRANT USAGE ON SCHEMA public TO analytics_readonly;
+GRANT SELECT ON providers, provider_earnings,
+                provider_heartbeats, provider_sessions,
+                provider_reliability_features
+      TO analytics_readonly;
+ALTER ROLE analytics_readonly SET statement_timeout = '10s';
+ALTER ROLE analytics_readonly SET idle_in_transaction_session_timeout = '5s';
+```
+
+In prod, point `ANALYTICS_DATABASE_URL` at a Postgres read replica so
+analytics queries never compete with operational queries for I/O. In dev /
+test, the primary is fine. **Do not** grant this role any `INSERT` / `UPDATE`
+/ `DELETE` privileges — the analytics service is read-only by design.
 
 ## Design Notes
 

--- a/analytics/cmd/analytics/main.go
+++ b/analytics/cmd/analytics/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/eigeninference/analytics/internal/config"
 	"github.com/eigeninference/analytics/internal/httpapi"
 	"github.com/eigeninference/analytics/internal/leaderboard"
+	"github.com/eigeninference/analytics/internal/liveness"
 	"github.com/eigeninference/analytics/internal/pseudonym"
 )
 
@@ -44,7 +45,18 @@ func main() {
 	defer store.Close()
 
 	service := leaderboard.NewService(store, aliaser, time.Now)
-	handler := httpapi.NewHandler(logger, service, cfg.AllowOrigin)
+
+	// Liveness service uses the same Postgres pool in postgres mode; in
+	// memory mode it gets an empty MemoryStore (returns 404 / empty lists).
+	livenessStore, err := buildLivenessStore(ctx, cfg)
+	if err != nil {
+		logger.Error("failed to initialize liveness store", "error", err)
+		os.Exit(1)
+	}
+	defer livenessStore.Close()
+	livenessSvc := liveness.NewService(livenessStore, aliaser, time.Now)
+
+	handler := httpapi.NewHandler(logger, service, livenessSvc, cfg.AllowOrigin)
 
 	server := &http.Server{
 		Addr:              cfg.Addr,
@@ -78,6 +90,17 @@ func main() {
 	if err := server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
 		logger.Error("analytics service failed", "error", err)
 		os.Exit(1)
+	}
+}
+
+func buildLivenessStore(ctx context.Context, cfg config.Config) (liveness.Store, error) {
+	switch cfg.Backend {
+	case config.BackendMemory:
+		return liveness.NewMemoryStore(), nil
+	case config.BackendPostgres:
+		return liveness.NewPostgresStore(ctx, cfg.DatabaseURL)
+	default:
+		return nil, errors.New("unsupported backend")
 	}
 }
 

--- a/analytics/internal/httpapi/liveness_routes_test.go
+++ b/analytics/internal/httpapi/liveness_routes_test.go
@@ -1,0 +1,183 @@
+package httpapi
+
+import (
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/analytics/internal/leaderboard"
+	"github.com/eigeninference/analytics/internal/liveness"
+	"github.com/eigeninference/analytics/internal/pseudonym"
+)
+
+// newLivenessTestServer wires the real liveness service against an in-memory
+// store seeded with deterministic data, exposes it via httptest, and returns
+// the URL plus the aliaser so tests can compute expected alias values.
+func newLivenessTestServer(t *testing.T) (string, liveness.Aliaser, *liveness.MemoryStore) {
+	t.Helper()
+	store := liveness.NewMemoryStore()
+
+	aliaser, err := pseudonym.NewGenerator("test-secret")
+	if err != nil {
+		t.Fatalf("NewGenerator: %v", err)
+	}
+	svc := liveness.NewService(store, aliaser, func() time.Time {
+		return time.Date(2026, 5, 22, 12, 0, 0, 0, time.UTC)
+	})
+
+	// Need to satisfy the (unused-for-this-test) leaderboard.Service too;
+	// reuse the memory backend with a wide active-window so /v1/overview
+	// doesn't blow up if a future test calls it.
+	lbStore := leaderboard.NewMemoryStore(2 * time.Minute)
+	lbSvc := leaderboard.NewService(lbStore, aliaser, time.Now)
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	handler := NewHandler(logger, lbSvc, svc, "*")
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	return srv.URL, aliaser, store
+}
+
+func getJSON(t *testing.T, url string, into any) int {
+	t.Helper()
+	resp, err := http.Get(url)
+	if err != nil {
+		t.Fatalf("GET %s: %v", url, err)
+	}
+	defer resp.Body.Close()
+	if into != nil {
+		body, _ := io.ReadAll(resp.Body)
+		if len(body) > 0 {
+			if err := json.Unmarshal(body, into); err != nil {
+				t.Fatalf("decode %s: %v body=%s", url, err, body)
+			}
+		}
+	}
+	return resp.StatusCode
+}
+
+func TestProviderLivenessRouteAliasesID(t *testing.T) {
+	base, aliaser, store := newLivenessTestServer(t)
+
+	store.SeedReliability(liveness.ReliabilityRow{
+		ProviderID: "real-id-A",
+		WindowDays: 14,
+		UptimePct:  0.97,
+	})
+
+	var got liveness.Summary
+	code := getJSON(t, base+"/v1/providers/real-id-A/liveness", &got)
+	if code != http.StatusOK {
+		t.Fatalf("status: want 200, got %d", code)
+	}
+	if got.Alias != aliaser.Alias("provider", "real-id-A") {
+		t.Fatalf("alias mismatch: %q", got.Alias)
+	}
+	if got.UptimePct != 0.97 {
+		t.Fatalf("uptime: want 0.97, got %v", got.UptimePct)
+	}
+}
+
+func TestProviderLivenessRouteMissing404(t *testing.T) {
+	base, _, _ := newLivenessTestServer(t)
+	code := getJSON(t, base+"/v1/providers/nope/liveness", nil)
+	if code != http.StatusNotFound {
+		t.Fatalf("status: want 404, got %d", code)
+	}
+}
+
+func TestProviderSessionsRouteShape(t *testing.T) {
+	base, _, store := newLivenessTestServer(t)
+	now := time.Now()
+	store.SeedSessions("p", liveness.SessionRow{
+		ID:               1,
+		ProviderID:       "p",
+		ConnectedAt:      now.Add(-time.Hour),
+		DisconnectedAt:   now.Add(-30 * time.Minute),
+		DisconnectReason: "clean_close",
+	})
+
+	var body struct {
+		Window  string                  `json:"window"`
+		Entries []liveness.SessionEntry `json:"entries"`
+	}
+	code := getJSON(t, base+"/v1/providers/p/sessions?window=24h", &body)
+	if code != http.StatusOK {
+		t.Fatalf("status: want 200, got %d", code)
+	}
+	if body.Window != "24h" {
+		t.Fatalf("window echo: want 24h, got %q", body.Window)
+	}
+	if len(body.Entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(body.Entries))
+	}
+	if body.Entries[0].DurationSeconds < 1700 || body.Entries[0].DurationSeconds > 1900 {
+		t.Fatalf("duration off: %d", body.Entries[0].DurationSeconds)
+	}
+}
+
+func TestReliabilityRouteFilterParams(t *testing.T) {
+	base, _, store := newLivenessTestServer(t)
+	store.SeedReliability(liveness.ReliabilityRow{ProviderID: "good", UptimePct: 0.99, PStays4h: 0.9})
+	store.SeedReliability(liveness.ReliabilityRow{ProviderID: "bad", UptimePct: 0.4, PStays4h: 0.2})
+
+	var body struct {
+		Entries []liveness.ReliabilityEntry `json:"entries"`
+	}
+	code := getJSON(t, base+"/v1/providers/reliability?min_uptime=0.9&min_stays_4h=0.8", &body)
+	if code != http.StatusOK {
+		t.Fatalf("status: want 200, got %d", code)
+	}
+	if len(body.Entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(body.Entries))
+	}
+}
+
+func TestNetworkAvailabilityRouteAggregates(t *testing.T) {
+	base, _, store := newLivenessTestServer(t)
+	for i, u := range []float64{0.4, 0.7, 0.95, 0.99} {
+		store.SeedReliability(liveness.ReliabilityRow{
+			ProviderID: "p-" + strconv.Itoa(i),
+			WindowDays: 14,
+			UptimePct:  u,
+		})
+	}
+
+	var body liveness.FleetAvailability
+	code := getJSON(t, base+"/v1/network/availability", &body)
+	if code != http.StatusOK {
+		t.Fatalf("status: want 200, got %d", code)
+	}
+	if body.Providers != 4 {
+		t.Fatalf("providers: want 4, got %d", body.Providers)
+	}
+	if body.HighlyReliable != 2 {
+		t.Fatalf("highly_reliable: want 2, got %d", body.HighlyReliable)
+	}
+}
+
+func TestLivenessRoutesNotRegisteredWhenServiceNil(t *testing.T) {
+	// If livenessSvc is nil (memory-mode dev runs that didn't wire it),
+	// the routes should return 404 rather than 500.
+	aliaser, _ := pseudonym.NewGenerator("test-secret")
+	lbStore := leaderboard.NewMemoryStore(2 * time.Minute)
+	lbSvc := leaderboard.NewService(lbStore, aliaser, time.Now)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	handler := NewHandler(logger, lbSvc, nil, "*")
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/v1/providers/anything/liveness")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("expected 404 when liveness not wired, got %d", resp.StatusCode)
+	}
+}

--- a/analytics/internal/httpapi/server.go
+++ b/analytics/internal/httpapi/server.go
@@ -3,6 +3,7 @@ package httpapi
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"log/slog"
 	"net/http"
 	"strconv"
@@ -10,6 +11,7 @@ import (
 	"time"
 
 	"github.com/eigeninference/analytics/internal/leaderboard"
+	"github.com/eigeninference/analytics/internal/liveness"
 )
 
 type Service interface {
@@ -19,7 +21,19 @@ type Service interface {
 	EarningsLeaderboard(ctx context.Context, query leaderboard.Query) (leaderboard.Leaderboard, error)
 }
 
-func NewHandler(logger *slog.Logger, service Service, allowOrigin string) http.Handler {
+// LivenessService is the subset of the liveness package's Service that the
+// HTTP layer needs. Separate interface so the httpapi tests can stub it.
+type LivenessService interface {
+	ProviderSummary(ctx context.Context, providerID string) (*liveness.Summary, error)
+	ProviderSessions(ctx context.Context, providerID string, window liveness.Window, limit int) ([]liveness.SessionEntry, error)
+	ProviderHeartbeats(ctx context.Context, providerID string, window liveness.Window, limit int) ([]liveness.HeartbeatEntry, error)
+	ReliableProviders(ctx context.Context, filter liveness.ReliabilityFilterInput) ([]liveness.ReliabilityEntry, error)
+	FleetAvailability(ctx context.Context) (liveness.FleetAvailability, error)
+}
+
+// NewHandler returns the analytics HTTP handler. livenessSvc may be nil
+// when liveness endpoints aren't wired (e.g., memory-mode dev runs).
+func NewHandler(logger *slog.Logger, service Service, livenessSvc LivenessService, allowOrigin string) http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /healthz", func(w http.ResponseWriter, r *http.Request) {
 		ctx, cancel := context.WithTimeout(r.Context(), 2*time.Second)
@@ -98,7 +112,155 @@ func NewHandler(logger *slog.Logger, service Service, allowOrigin string) http.H
 		writeJSON(w, http.StatusOK, board)
 	})
 
+	if livenessSvc != nil {
+		registerLivenessRoutes(mux, logger, livenessSvc)
+	}
+
 	return withCORS(allowOrigin, mux)
+}
+
+// registerLivenessRoutes wires the provider-liveness endpoints. Split out
+// from NewHandler so it's easy to see what's gated behind livenessSvc != nil.
+func registerLivenessRoutes(mux *http.ServeMux, logger *slog.Logger, svc LivenessService) {
+	mux.HandleFunc("GET /v1/providers/{id}/liveness", func(w http.ResponseWriter, r *http.Request) {
+		ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
+		defer cancel()
+
+		providerID := r.PathValue("id")
+		summary, err := svc.ProviderSummary(ctx, providerID)
+		if err != nil {
+			logger.Error("provider summary failed", "provider_id", providerID, "error", err)
+			writeError(w, http.StatusInternalServerError, "internal_error", "failed to load provider summary")
+			return
+		}
+		if summary == nil {
+			writeError(w, http.StatusNotFound, "not_found", "no reliability data for provider")
+			return
+		}
+		writeJSON(w, http.StatusOK, summary)
+	})
+
+	mux.HandleFunc("GET /v1/providers/{id}/sessions", func(w http.ResponseWriter, r *http.Request) {
+		window, limit, err := parseLivenessQuery(r)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "bad_request", err.Error())
+			return
+		}
+		ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
+		defer cancel()
+
+		entries, err := svc.ProviderSessions(ctx, r.PathValue("id"), window, limit)
+		if err != nil {
+			logger.Error("provider sessions failed", "error", err)
+			writeError(w, http.StatusInternalServerError, "internal_error", "failed to load sessions")
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{
+			"window":  string(window),
+			"entries": entries,
+		})
+	})
+
+	mux.HandleFunc("GET /v1/providers/{id}/heartbeats", func(w http.ResponseWriter, r *http.Request) {
+		window, limit, err := parseLivenessQuery(r)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "bad_request", err.Error())
+			return
+		}
+		ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
+		defer cancel()
+
+		entries, err := svc.ProviderHeartbeats(ctx, r.PathValue("id"), window, limit)
+		if err != nil {
+			logger.Error("provider heartbeats failed", "error", err)
+			writeError(w, http.StatusInternalServerError, "internal_error", "failed to load heartbeats")
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{
+			"window":  string(window),
+			"entries": entries,
+		})
+	})
+
+	mux.HandleFunc("GET /v1/providers/reliability", func(w http.ResponseWriter, r *http.Request) {
+		filter := liveness.ReliabilityFilterInput{
+			MinUptimePct: parseFloat(r.URL.Query().Get("min_uptime"), 0),
+			MinPStays4h:  parseFloat(r.URL.Query().Get("min_stays_4h"), 0),
+			MinPStays8h:  parseFloat(r.URL.Query().Get("min_stays_8h"), 0),
+			Limit:        parseIntDefault(r.URL.Query().Get("limit"), liveness.DefaultLimit),
+		}
+		ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
+		defer cancel()
+
+		entries, err := svc.ReliableProviders(ctx, filter)
+		if err != nil {
+			logger.Error("reliable providers failed", "error", err)
+			writeError(w, http.StatusInternalServerError, "internal_error", "failed to load reliable providers")
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{
+			"min_uptime":   filter.MinUptimePct,
+			"min_stays_4h": filter.MinPStays4h,
+			"min_stays_8h": filter.MinPStays8h,
+			"entries":      entries,
+		})
+	})
+
+	mux.HandleFunc("GET /v1/network/availability", func(w http.ResponseWriter, r *http.Request) {
+		ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
+		defer cancel()
+
+		summary, err := svc.FleetAvailability(ctx)
+		if err != nil {
+			logger.Error("network availability failed", "error", err)
+			writeError(w, http.StatusInternalServerError, "internal_error", "failed to load fleet availability")
+			return
+		}
+		writeJSON(w, http.StatusOK, summary)
+	})
+}
+
+// parseLivenessQuery extracts the shared `window` + `limit` query params
+// used by the per-provider endpoints.
+func parseLivenessQuery(r *http.Request) (liveness.Window, int, error) {
+	window, err := liveness.ParseWindow(r.URL.Query().Get("window"))
+	if err != nil {
+		var pe *liveness.ParseError
+		if errors.As(err, &pe) {
+			return "", 0, err
+		}
+		return "", 0, err
+	}
+	limit := parseIntDefault(r.URL.Query().Get("limit"), liveness.DefaultLimit)
+	return window, limit, nil
+}
+
+func parseFloat(raw string, fallback float64) float64 {
+	if raw == "" {
+		return fallback
+	}
+	v, err := strconv.ParseFloat(raw, 64)
+	if err != nil {
+		return fallback
+	}
+	if v < 0 {
+		return 0
+	}
+	if v > 1 {
+		return 1
+	}
+	return v
+}
+
+func parseIntDefault(raw string, fallback int) int {
+	if strings.TrimSpace(raw) == "" {
+		return fallback
+	}
+	v, err := strconv.Atoi(raw)
+	if err != nil || v <= 0 {
+		return fallback
+	}
+	return v
 }
 
 func withCORS(allowOrigin string, next http.Handler) http.Handler {

--- a/analytics/internal/httpapi/server_test.go
+++ b/analytics/internal/httpapi/server_test.go
@@ -127,5 +127,5 @@ func testHandler(t *testing.T) http.Handler {
 
 	service := leaderboard.NewService(store, aliaser, now)
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	return NewHandler(logger, service, "*")
+	return NewHandler(logger, service, nil, "*")
 }

--- a/analytics/internal/liveness/memory.go
+++ b/analytics/internal/liveness/memory.go
@@ -1,0 +1,110 @@
+package liveness
+
+import (
+	"context"
+	"time"
+)
+
+// MemoryStore is an in-memory liveness store used in dev/test. Returns empty
+// results unless test code calls one of the Seed helpers — there is no
+// background ingestion in memory mode.
+type MemoryStore struct {
+	rows       map[string]*ReliabilityRow
+	sessions   map[string][]SessionRow
+	heartbeats map[string][]HeartbeatRow
+}
+
+func NewMemoryStore() *MemoryStore {
+	return &MemoryStore{
+		rows:       make(map[string]*ReliabilityRow),
+		sessions:   make(map[string][]SessionRow),
+		heartbeats: make(map[string][]HeartbeatRow),
+	}
+}
+
+func (m *MemoryStore) Backend() string                { return "memory" }
+func (m *MemoryStore) Ping(_ context.Context) error    { return nil }
+func (m *MemoryStore) Close()                          {}
+
+// SeedReliability lets tests inject pre-aggregated rows.
+func (m *MemoryStore) SeedReliability(row ReliabilityRow) {
+	cp := row
+	m.rows[row.ProviderID] = &cp
+}
+
+// SeedSessions lets tests inject per-provider session history.
+func (m *MemoryStore) SeedSessions(providerID string, rows ...SessionRow) {
+	m.sessions[providerID] = append(m.sessions[providerID], rows...)
+}
+
+// SeedHeartbeats lets tests inject per-provider heartbeat history.
+func (m *MemoryStore) SeedHeartbeats(providerID string, rows ...HeartbeatRow) {
+	m.heartbeats[providerID] = append(m.heartbeats[providerID], rows...)
+}
+
+func (m *MemoryStore) GetReliabilityFeatures(_ context.Context, providerID string) (*ReliabilityRow, error) {
+	r, ok := m.rows[providerID]
+	if !ok {
+		return nil, nil
+	}
+	cp := *r
+	return &cp, nil
+}
+
+func (m *MemoryStore) ListRecentSessions(_ context.Context, providerID string, since time.Time, limit int) ([]SessionRow, error) {
+	all := m.sessions[providerID]
+	out := make([]SessionRow, 0, len(all))
+	for _, s := range all {
+		if s.ConnectedAt.Before(since) {
+			continue
+		}
+		out = append(out, s)
+	}
+	if len(out) > limit {
+		out = out[:limit]
+	}
+	return out, nil
+}
+
+func (m *MemoryStore) ListRecentHeartbeats(_ context.Context, providerID string, since time.Time, limit int) ([]HeartbeatRow, error) {
+	all := m.heartbeats[providerID]
+	out := make([]HeartbeatRow, 0, len(all))
+	for _, h := range all {
+		if h.At.Before(since) {
+			continue
+		}
+		out = append(out, h)
+	}
+	if len(out) > limit {
+		out = out[:limit]
+	}
+	return out, nil
+}
+
+func (m *MemoryStore) ListReliable(_ context.Context, filter ReliabilityFilterInput) ([]ReliabilityRow, error) {
+	out := make([]ReliabilityRow, 0, len(m.rows))
+	for _, r := range m.rows {
+		if r.UptimePct < filter.MinUptimePct {
+			continue
+		}
+		if r.PStays4h < filter.MinPStays4h {
+			continue
+		}
+		if r.PStays8h < filter.MinPStays8h {
+			continue
+		}
+		out = append(out, *r)
+	}
+	if filter.Limit > 0 && len(out) > filter.Limit {
+		out = out[:filter.Limit]
+	}
+	return out, nil
+}
+
+func (m *MemoryStore) FleetSummary(_ context.Context) (FleetAvailability, error) {
+	rows := make([]ReliabilityRow, 0, len(m.rows))
+	for _, r := range m.rows {
+		rows = append(rows, *r)
+	}
+	return computeFleet(rows), nil
+}

--- a/analytics/internal/liveness/postgres.go
+++ b/analytics/internal/liveness/postgres.go
@@ -1,0 +1,222 @@
+package liveness
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// PostgresStore reads liveness data from the coordinator-managed schema.
+// Connect with a read-only role (see analytics/README.md) — this package
+// never writes. Reads target a replica when ANALYTICS_DATABASE_URL points
+// at one.
+type PostgresStore struct {
+	pool *pgxpool.Pool
+}
+
+func NewPostgresStore(ctx context.Context, databaseURL string) (*PostgresStore, error) {
+	cfg, err := pgxpool.ParseConfig(databaseURL)
+	if err != nil {
+		return nil, fmt.Errorf("liveness: parse postgres config: %w", err)
+	}
+	if cfg.MaxConns <= 0 || cfg.MaxConns > 8 {
+		// Per plan safeguard: cap analytics pool small so a runaway query
+		// can't starve the operational DB's pool.
+		cfg.MaxConns = 8
+	}
+	pool, err := pgxpool.NewWithConfig(ctx, cfg)
+	if err != nil {
+		return nil, fmt.Errorf("liveness: connect postgres: %w", err)
+	}
+	if err := pool.Ping(ctx); err != nil {
+		pool.Close()
+		return nil, fmt.Errorf("liveness: ping postgres: %w", err)
+	}
+	return &PostgresStore{pool: pool}, nil
+}
+
+func (s *PostgresStore) Backend() string               { return "postgres" }
+func (s *PostgresStore) Ping(ctx context.Context) error { return s.pool.Ping(ctx) }
+func (s *PostgresStore) Close()                         { s.pool.Close() }
+
+func (s *PostgresStore) GetReliabilityFeatures(ctx context.Context, providerID string) (*ReliabilityRow, error) {
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	var (
+		row      ReliabilityRow
+		lastDisc *time.Time
+		hourly   []byte
+		reasons  []byte
+	)
+	err := s.pool.QueryRow(ctx,
+		`SELECT provider_id, updated_at, window_days, uptime_pct, sessions_count,
+		        mtbf_seconds, median_session_seconds, p10_session_seconds, p90_session_seconds,
+		        hourly_availability, disconnect_reasons, p_stays_4h, p_stays_8h,
+		        last_disconnect_at, last_session_duration_seconds
+		   FROM provider_reliability_features WHERE provider_id = $1`,
+		providerID,
+	).Scan(
+		&row.ProviderID, &row.UpdatedAt, &row.WindowDays, &row.UptimePct, &row.SessionsCount,
+		&row.MTBFSeconds, &row.MedianSessionSeconds, &row.P10SessionSeconds, &row.P90SessionSeconds,
+		&hourly, &reasons, &row.PStays4h, &row.PStays8h,
+		&lastDisc, &row.LastSessionDurationSeconds,
+	)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("liveness: get reliability features: %w", err)
+	}
+	if lastDisc != nil {
+		row.LastDisconnectAt = *lastDisc
+	}
+	row.HourlyAvailability, row.DisconnectReasons = parseReliabilityJSON(hourly, reasons)
+	return &row, nil
+}
+
+func (s *PostgresStore) ListRecentSessions(ctx context.Context, providerID string, since time.Time, limit int) ([]SessionRow, error) {
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	rows, err := s.pool.Query(ctx,
+		`SELECT id, provider_id, connected_at, disconnected_at,
+		        COALESCE(disconnect_reason,''),
+		        requests_served, tokens_generated
+		   FROM provider_sessions
+		  WHERE provider_id = $1 AND connected_at >= $2
+		  ORDER BY connected_at DESC LIMIT $3`,
+		providerID, since, limit,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("liveness: list recent sessions: %w", err)
+	}
+	defer rows.Close()
+
+	var out []SessionRow
+	for rows.Next() {
+		var (
+			r      SessionRow
+			discAt *time.Time
+		)
+		if err := rows.Scan(
+			&r.ID, &r.ProviderID, &r.ConnectedAt, &discAt,
+			&r.DisconnectReason, &r.RequestsServed, &r.TokensGenerated,
+		); err != nil {
+			return nil, fmt.Errorf("liveness: scan session: %w", err)
+		}
+		if discAt != nil {
+			r.DisconnectedAt = *discAt
+		}
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+func (s *PostgresStore) ListRecentHeartbeats(ctx context.Context, providerID string, since time.Time, limit int) ([]HeartbeatRow, error) {
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	rows, err := s.pool.Query(ctx,
+		`SELECT provider_id, at, status, memory_pressure, cpu_usage, thermal_state
+		   FROM provider_heartbeats
+		  WHERE provider_id = $1 AND at >= $2
+		  ORDER BY at DESC LIMIT $3`,
+		providerID, since, limit,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("liveness: list recent heartbeats: %w", err)
+	}
+	defer rows.Close()
+
+	var out []HeartbeatRow
+	for rows.Next() {
+		var r HeartbeatRow
+		if err := rows.Scan(
+			&r.ProviderID, &r.At, &r.Status, &r.MemoryPressure, &r.CPUUsage, &r.ThermalState,
+		); err != nil {
+			return nil, fmt.Errorf("liveness: scan heartbeat: %w", err)
+		}
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+func (s *PostgresStore) ListReliable(ctx context.Context, filter ReliabilityFilterInput) ([]ReliabilityRow, error) {
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	limit := filter.Limit
+	if limit <= 0 || limit > MaxLimit {
+		limit = DefaultLimit
+	}
+	rows, err := s.pool.Query(ctx,
+		`SELECT provider_id, updated_at, window_days, uptime_pct, sessions_count,
+		        mtbf_seconds, median_session_seconds, p10_session_seconds, p90_session_seconds,
+		        hourly_availability, disconnect_reasons, p_stays_4h, p_stays_8h,
+		        last_disconnect_at, last_session_duration_seconds
+		   FROM provider_reliability_features
+		  WHERE uptime_pct >= $1 AND p_stays_4h >= $2 AND p_stays_8h >= $3
+		  ORDER BY uptime_pct DESC, provider_id ASC
+		  LIMIT $4`,
+		filter.MinUptimePct, filter.MinPStays4h, filter.MinPStays8h, limit,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("liveness: list reliable: %w", err)
+	}
+	defer rows.Close()
+
+	var out []ReliabilityRow
+	for rows.Next() {
+		var (
+			row      ReliabilityRow
+			lastDisc *time.Time
+			hourly   []byte
+			reasons  []byte
+		)
+		if err := rows.Scan(
+			&row.ProviderID, &row.UpdatedAt, &row.WindowDays, &row.UptimePct, &row.SessionsCount,
+			&row.MTBFSeconds, &row.MedianSessionSeconds, &row.P10SessionSeconds, &row.P90SessionSeconds,
+			&hourly, &reasons, &row.PStays4h, &row.PStays8h,
+			&lastDisc, &row.LastSessionDurationSeconds,
+		); err != nil {
+			return nil, fmt.Errorf("liveness: scan reliability features: %w", err)
+		}
+		if lastDisc != nil {
+			row.LastDisconnectAt = *lastDisc
+		}
+		row.HourlyAvailability, row.DisconnectReasons = parseReliabilityJSON(hourly, reasons)
+		out = append(out, row)
+	}
+	return out, rows.Err()
+}
+
+func (s *PostgresStore) FleetSummary(ctx context.Context) (FleetAvailability, error) {
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	rows, err := s.pool.Query(ctx,
+		`SELECT provider_id, uptime_pct, window_days FROM provider_reliability_features`,
+	)
+	if err != nil {
+		return FleetAvailability{}, fmt.Errorf("liveness: fleet summary: %w", err)
+	}
+	defer rows.Close()
+
+	var collected []ReliabilityRow
+	for rows.Next() {
+		var r ReliabilityRow
+		if err := rows.Scan(&r.ProviderID, &r.UptimePct, &r.WindowDays); err != nil {
+			return FleetAvailability{}, fmt.Errorf("liveness: scan fleet row: %w", err)
+		}
+		collected = append(collected, r)
+	}
+	if err := rows.Err(); err != nil {
+		return FleetAvailability{}, err
+	}
+	return computeFleet(collected), nil
+}

--- a/analytics/internal/liveness/service.go
+++ b/analytics/internal/liveness/service.go
@@ -1,0 +1,196 @@
+package liveness
+
+import (
+	"context"
+	"sort"
+	"time"
+)
+
+// Service composes the read store and the pseudonym aliaser. Construct one
+// via NewService and pass it to the httpapi handler. Cheap to copy.
+type Service struct {
+	store   Store
+	aliaser Aliaser
+	now     func() time.Time
+}
+
+func NewService(store Store, aliaser Aliaser, now func() time.Time) *Service {
+	if now == nil {
+		now = time.Now
+	}
+	return &Service{store: store, aliaser: aliaser, now: now}
+}
+
+func (s *Service) Backend() string                 { return s.store.Backend() }
+func (s *Service) Ping(ctx context.Context) error  { return s.store.Ping(ctx) }
+func (s *Service) Close()                          { s.store.Close() }
+
+// ProviderSummary returns the per-provider reliability summary. Returns
+// (nil, nil) when we have no rollup row for this provider yet.
+func (s *Service) ProviderSummary(ctx context.Context, providerID string) (*Summary, error) {
+	row, err := s.store.GetReliabilityFeatures(ctx, providerID)
+	if err != nil {
+		return nil, err
+	}
+	if row == nil {
+		return nil, nil
+	}
+	return s.toSummary(row), nil
+}
+
+// ProviderSessions returns recent sessions for one provider.
+func (s *Service) ProviderSessions(ctx context.Context, providerID string, window Window, limit int) ([]SessionEntry, error) {
+	rows, err := s.store.ListRecentSessions(ctx, providerID, s.windowSince(window), clampLimit(limit))
+	if err != nil {
+		return nil, err
+	}
+	out := make([]SessionEntry, 0, len(rows))
+	now := s.now()
+	for _, r := range rows {
+		end := r.DisconnectedAt
+		if end.IsZero() {
+			end = now
+		}
+		out = append(out, SessionEntry{
+			ID:               r.ID,
+			Alias:            s.aliaser.Alias("provider", r.ProviderID),
+			ConnectedAt:      r.ConnectedAt,
+			DisconnectedAt:   r.DisconnectedAt,
+			DisconnectReason: r.DisconnectReason,
+			DurationSeconds:  int64(end.Sub(r.ConnectedAt).Seconds()),
+			RequestsServed:   r.RequestsServed,
+			TokensGenerated:  r.TokensGenerated,
+		})
+	}
+	return out, nil
+}
+
+// ProviderHeartbeats returns recent heartbeat samples for one provider.
+func (s *Service) ProviderHeartbeats(ctx context.Context, providerID string, window Window, limit int) ([]HeartbeatEntry, error) {
+	rows, err := s.store.ListRecentHeartbeats(ctx, providerID, s.windowSince(window), clampLimit(limit))
+	if err != nil {
+		return nil, err
+	}
+	out := make([]HeartbeatEntry, 0, len(rows))
+	for _, r := range rows {
+		out = append(out, HeartbeatEntry{
+			Alias:          s.aliaser.Alias("provider", r.ProviderID),
+			At:             r.At,
+			Status:         r.Status,
+			MemoryPressure: r.MemoryPressure,
+			CPUUsage:       r.CPUUsage,
+			ThermalState:   r.ThermalState,
+		})
+	}
+	return out, nil
+}
+
+// ReliableProviders returns the providers meeting a reliability bar,
+// ordered by uptime_pct desc.
+func (s *Service) ReliableProviders(ctx context.Context, filter ReliabilityFilterInput) ([]ReliabilityEntry, error) {
+	if filter.Limit <= 0 {
+		filter.Limit = DefaultLimit
+	}
+	if filter.Limit > MaxLimit {
+		filter.Limit = MaxLimit
+	}
+	rows, err := s.store.ListReliable(ctx, filter)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]ReliabilityEntry, 0, len(rows))
+	for _, r := range rows {
+		out = append(out, ReliabilityEntry{
+			Alias:                s.aliaser.Alias("provider", r.ProviderID),
+			UptimePct:            r.UptimePct,
+			SessionsCount:        r.SessionsCount,
+			MedianSessionSeconds: r.MedianSessionSeconds,
+			PStays4h:             r.PStays4h,
+			PStays8h:             r.PStays8h,
+		})
+	}
+	return out, nil
+}
+
+// FleetAvailability returns aggregate distributional stats over all providers
+// with reliability features.
+func (s *Service) FleetAvailability(ctx context.Context) (FleetAvailability, error) {
+	return s.store.FleetSummary(ctx)
+}
+
+// toSummary converts the row into the API response, aliasing the provider id.
+func (s *Service) toSummary(r *ReliabilityRow) *Summary {
+	return &Summary{
+		Alias:                      s.aliaser.Alias("provider", r.ProviderID),
+		WindowDays:                 r.WindowDays,
+		UptimePct:                  r.UptimePct,
+		SessionsCount:              r.SessionsCount,
+		MTBFSeconds:                r.MTBFSeconds,
+		MedianSessionSeconds:       r.MedianSessionSeconds,
+		P10SessionSeconds:          r.P10SessionSeconds,
+		P90SessionSeconds:          r.P90SessionSeconds,
+		PStays4h:                   r.PStays4h,
+		PStays8h:                   r.PStays8h,
+		LastDisconnectAt:           r.LastDisconnectAt,
+		LastSessionDurationSeconds: r.LastSessionDurationSeconds,
+		HourlyAvailability:         r.HourlyAvailability,
+		DisconnectReasons:          r.DisconnectReasons,
+		UpdatedAt:                  r.UpdatedAt,
+	}
+}
+
+func (s *Service) windowSince(w Window) time.Time {
+	return s.now().Add(-w.Duration())
+}
+
+func clampLimit(n int) int {
+	if n <= 0 {
+		return DefaultLimit
+	}
+	if n > MaxLimit {
+		return MaxLimit
+	}
+	return n
+}
+
+// computeFleet derives the FleetAvailability struct from a list of rows.
+// Pulled out so both the memory and postgres impls can share the math.
+func computeFleet(rows []ReliabilityRow) FleetAvailability {
+	if len(rows) == 0 {
+		return FleetAvailability{WindowDays: 14}
+	}
+	uptimes := make([]float64, len(rows))
+	var sum float64
+	highlyReliable := 0
+	for i, r := range rows {
+		uptimes[i] = r.UptimePct
+		sum += r.UptimePct
+		if r.UptimePct >= 0.95 {
+			highlyReliable++
+		}
+	}
+	sort.Float64s(uptimes)
+	return FleetAvailability{
+		WindowDays:     rows[0].WindowDays,
+		Providers:      len(rows),
+		MeanUptimePct:  sum / float64(len(rows)),
+		P10UptimePct:   uptimes[percentileIdx(len(rows), 0.10)],
+		P50UptimePct:   uptimes[percentileIdx(len(rows), 0.50)],
+		P90UptimePct:   uptimes[percentileIdx(len(rows), 0.90)],
+		HighlyReliable: highlyReliable,
+	}
+}
+
+func percentileIdx(n int, p float64) int {
+	if n <= 0 {
+		return 0
+	}
+	idx := int(p * float64(n-1))
+	if idx < 0 {
+		idx = 0
+	}
+	if idx >= n {
+		idx = n - 1
+	}
+	return idx
+}

--- a/analytics/internal/liveness/service_test.go
+++ b/analytics/internal/liveness/service_test.go
@@ -1,0 +1,132 @@
+package liveness
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+type fakeAliaser struct{}
+
+func (fakeAliaser) Alias(kind, stableID string) string { return "alias-" + stableID }
+
+func TestProviderSummaryReturnsAliasedRow(t *testing.T) {
+	store := NewMemoryStore()
+	store.SeedReliability(ReliabilityRow{
+		ProviderID:    "real-id",
+		WindowDays:    14,
+		UptimePct:     0.987,
+		SessionsCount: 12,
+		MedianSessionSeconds: 4200,
+		UpdatedAt:     time.Now(),
+	})
+
+	svc := NewService(store, fakeAliaser{}, time.Now)
+	got, err := svc.ProviderSummary(context.Background(), "real-id")
+	if err != nil {
+		t.Fatalf("ProviderSummary: %v", err)
+	}
+	if got == nil {
+		t.Fatalf("expected summary, got nil")
+	}
+	if got.Alias != "alias-real-id" {
+		t.Fatalf("expected aliased id, got %q", got.Alias)
+	}
+	if got.UptimePct != 0.987 {
+		t.Fatalf("uptime mismatch: %v", got.UptimePct)
+	}
+}
+
+func TestProviderSummaryMissingReturnsNil(t *testing.T) {
+	store := NewMemoryStore()
+	svc := NewService(store, fakeAliaser{}, time.Now)
+	got, err := svc.ProviderSummary(context.Background(), "unknown")
+	if err != nil {
+		t.Fatalf("ProviderSummary: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("expected nil for unknown provider, got %+v", got)
+	}
+}
+
+func TestReliableProvidersHonorsFilters(t *testing.T) {
+	store := NewMemoryStore()
+	store.SeedReliability(ReliabilityRow{ProviderID: "good", UptimePct: 0.99, PStays4h: 0.9, PStays8h: 0.8})
+	store.SeedReliability(ReliabilityRow{ProviderID: "ok", UptimePct: 0.80, PStays4h: 0.6, PStays8h: 0.3})
+	store.SeedReliability(ReliabilityRow{ProviderID: "bad", UptimePct: 0.20, PStays4h: 0.1, PStays8h: 0.0})
+
+	svc := NewService(store, fakeAliaser{}, time.Now)
+	out, err := svc.ReliableProviders(context.Background(), ReliabilityFilterInput{
+		MinUptimePct: 0.95,
+		MinPStays4h:  0.85,
+	})
+	if err != nil {
+		t.Fatalf("ReliableProviders: %v", err)
+	}
+	if len(out) != 1 || out[0].Alias != "alias-good" {
+		t.Fatalf("expected only 'good' provider, got %+v", out)
+	}
+}
+
+func TestFleetAvailabilityPercentiles(t *testing.T) {
+	store := NewMemoryStore()
+	for _, pct := range []float64{0.1, 0.5, 0.9, 0.95, 0.99} {
+		store.SeedReliability(ReliabilityRow{
+			ProviderID: "p-" + formatFloat(pct),
+			WindowDays: 14,
+			UptimePct:  pct,
+		})
+	}
+	svc := NewService(store, fakeAliaser{}, time.Now)
+	fa, err := svc.FleetAvailability(context.Background())
+	if err != nil {
+		t.Fatalf("FleetAvailability: %v", err)
+	}
+	if fa.Providers != 5 {
+		t.Fatalf("expected 5 providers, got %d", fa.Providers)
+	}
+	// Two of five are >= 0.95 → highly_reliable = 2.
+	if fa.HighlyReliable != 2 {
+		t.Fatalf("highly_reliable: want 2, got %d", fa.HighlyReliable)
+	}
+	if fa.MeanUptimePct <= 0 || fa.MeanUptimePct > 1 {
+		t.Fatalf("mean out of range: %v", fa.MeanUptimePct)
+	}
+}
+
+func TestParseWindow(t *testing.T) {
+	cases := map[string]Window{
+		"":    Window7d,
+		"7d":  Window7d,
+		"24h": Window24h,
+		"30d": Window30d,
+	}
+	for raw, expected := range cases {
+		got, err := ParseWindow(raw)
+		if err != nil {
+			t.Fatalf("ParseWindow(%q) returned error: %v", raw, err)
+		}
+		if got != expected {
+			t.Fatalf("ParseWindow(%q): want %q got %q", raw, expected, got)
+		}
+	}
+	if _, err := ParseWindow("90d"); err == nil {
+		t.Fatalf("expected error for unsupported window")
+	}
+}
+
+func formatFloat(f float64) string {
+	switch f {
+	case 0.1:
+		return "0.1"
+	case 0.5:
+		return "0.5"
+	case 0.9:
+		return "0.9"
+	case 0.95:
+		return "0.95"
+	case 0.99:
+		return "0.99"
+	}
+	return "x"
+}

--- a/analytics/internal/liveness/store.go
+++ b/analytics/internal/liveness/store.go
@@ -1,0 +1,215 @@
+// Package liveness exposes the read side of provider liveness analytics:
+// per-provider uptime/sessions/heartbeats, fleet-wide availability, and a
+// reliability shortlist suitable for job-aware scheduling.
+//
+// The data is populated by the coordinator's liveness writer + features
+// rollup worker — this package only reads. It mirrors the leaderboard
+// package's shape (Service over Store with memory + postgres impls).
+package liveness
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+)
+
+// Defaults for endpoint inputs.
+const (
+	DefaultLimit    = 50
+	MaxLimit        = 500
+	DefaultWindow7d = "7d"
+)
+
+// Window is a coarse retrospective period selector reused across endpoints.
+type Window string
+
+const (
+	Window24h Window = "24h"
+	Window7d  Window = "7d"
+	Window30d Window = "30d"
+)
+
+// ParseWindow validates a window string. Empty string defaults to 7d.
+func ParseWindow(raw string) (Window, error) {
+	switch raw {
+	case "", "7d":
+		return Window7d, nil
+	case "24h":
+		return Window24h, nil
+	case "30d":
+		return Window30d, nil
+	}
+	return "", &ParseError{Field: "window", Value: raw, Allowed: "24h, 7d, 30d"}
+}
+
+// Duration converts a Window to a time.Duration.
+func (w Window) Duration() time.Duration {
+	switch w {
+	case Window24h:
+		return 24 * time.Hour
+	case Window30d:
+		return 30 * 24 * time.Hour
+	default:
+		return 7 * 24 * time.Hour
+	}
+}
+
+// ParseError is a structured invalid-input error the httpapi layer surfaces
+// as 400 Bad Request.
+type ParseError struct {
+	Field   string
+	Value   string
+	Allowed string
+}
+
+func (e *ParseError) Error() string {
+	return e.Field + " must be one of: " + e.Allowed + ", got " + e.Value
+}
+
+// Summary is the response shape for GET /v1/providers/:id/liveness.
+type Summary struct {
+	Alias                      string    `json:"alias"`
+	WindowDays                 int       `json:"window_days"`
+	UptimePct                  float64   `json:"uptime_pct"`
+	SessionsCount              int       `json:"sessions_count"`
+	MTBFSeconds                int64     `json:"mtbf_seconds"`
+	MedianSessionSeconds       int64     `json:"median_session_seconds"`
+	P10SessionSeconds          int64     `json:"p10_session_seconds"`
+	P90SessionSeconds          int64     `json:"p90_session_seconds"`
+	PStays4h                   float64   `json:"p_stays_4h"`
+	PStays8h                   float64   `json:"p_stays_8h"`
+	LastDisconnectAt           time.Time `json:"last_disconnect_at,omitempty"`
+	LastSessionDurationSeconds int64     `json:"last_session_duration_seconds"`
+	HourlyAvailability         []float64 `json:"hourly_availability,omitempty"` // 168-element 7×24 row-major
+	DisconnectReasons          map[string]int `json:"disconnect_reasons,omitempty"`
+	UpdatedAt                  time.Time `json:"updated_at"`
+}
+
+// SessionEntry is one row in the /sessions endpoint response. Provider ID is
+// already pseudonymized by the time it reaches the consumer.
+type SessionEntry struct {
+	ID                int64     `json:"id"`
+	Alias             string    `json:"alias"`
+	ConnectedAt       time.Time `json:"connected_at"`
+	DisconnectedAt   time.Time `json:"disconnected_at,omitempty"`
+	DisconnectReason string    `json:"disconnect_reason,omitempty"`
+	DurationSeconds  int64     `json:"duration_seconds"`
+	RequestsServed   int64     `json:"requests_served"`
+	TokensGenerated  int64     `json:"tokens_generated"`
+}
+
+// HeartbeatEntry is one row in the /heartbeats endpoint response.
+type HeartbeatEntry struct {
+	Alias          string    `json:"alias"`
+	At             time.Time `json:"at"`
+	Status         string    `json:"status"`
+	MemoryPressure float32   `json:"memory_pressure"`
+	CPUUsage       float32   `json:"cpu_usage"`
+	ThermalState   string    `json:"thermal_state"`
+}
+
+// ReliabilityEntry is one row in the /providers/reliability shortlist.
+type ReliabilityEntry struct {
+	Alias                string  `json:"alias"`
+	UptimePct            float64 `json:"uptime_pct"`
+	SessionsCount        int     `json:"sessions_count"`
+	MedianSessionSeconds int64   `json:"median_session_seconds"`
+	PStays4h             float64 `json:"p_stays_4h"`
+	PStays8h             float64 `json:"p_stays_8h"`
+}
+
+// FleetAvailability is the response for /v1/network/availability. It returns
+// distributional rather than per-provider info to keep things aggregate.
+type FleetAvailability struct {
+	WindowDays         int     `json:"window_days"`
+	Providers          int     `json:"providers"`
+	MeanUptimePct      float64 `json:"mean_uptime_pct"`
+	P10UptimePct       float64 `json:"p10_uptime_pct"`
+	P50UptimePct       float64 `json:"p50_uptime_pct"`
+	P90UptimePct       float64 `json:"p90_uptime_pct"`
+	HighlyReliable     int     `json:"highly_reliable"` // count of providers with uptime ≥ 0.95
+}
+
+// ReliabilityFilterInput mirrors store.ReliabilityFilter with parsed types.
+type ReliabilityFilterInput struct {
+	MinUptimePct float64
+	MinPStays4h  float64
+	MinPStays8h  float64
+	Limit        int
+}
+
+// Aliaser maps internal IDs to opaque public aliases. Reuses the package the
+// existing leaderboard endpoints use; we never return provider_id directly.
+type Aliaser interface {
+	Alias(kind, stableID string) string
+}
+
+// Store is the data-access surface this package consumes. Implementations
+// (memory, postgres) live alongside.
+type Store interface {
+	Backend() string
+	Ping(ctx context.Context) error
+	Close()
+
+	GetReliabilityFeatures(ctx context.Context, providerID string) (*ReliabilityRow, error)
+	ListRecentSessions(ctx context.Context, providerID string, since time.Time, limit int) ([]SessionRow, error)
+	ListRecentHeartbeats(ctx context.Context, providerID string, since time.Time, limit int) ([]HeartbeatRow, error)
+	ListReliable(ctx context.Context, filter ReliabilityFilterInput) ([]ReliabilityRow, error)
+	FleetSummary(ctx context.Context) (FleetAvailability, error)
+}
+
+// ReliabilityRow mirrors store.ReliabilityFeatures with JSON parsed.
+type ReliabilityRow struct {
+	ProviderID                 string
+	UpdatedAt                  time.Time
+	WindowDays                 int
+	UptimePct                  float64
+	SessionsCount              int
+	MTBFSeconds                int64
+	MedianSessionSeconds       int64
+	P10SessionSeconds          int64
+	P90SessionSeconds          int64
+	HourlyAvailability         []float64
+	DisconnectReasons          map[string]int
+	PStays4h                   float64
+	PStays8h                   float64
+	LastDisconnectAt           time.Time
+	LastSessionDurationSeconds int64
+}
+
+// SessionRow is one provider_sessions row, schema-shaped.
+type SessionRow struct {
+	ID               int64
+	ProviderID       string
+	ConnectedAt      time.Time
+	DisconnectedAt   time.Time
+	DisconnectReason string
+	RequestsServed   int64
+	TokensGenerated  int64
+}
+
+// HeartbeatRow is one provider_heartbeats row.
+type HeartbeatRow struct {
+	ProviderID     string
+	At             time.Time
+	Status         string
+	MemoryPressure float32
+	CPUUsage       float32
+	ThermalState   string
+}
+
+// parseReliabilityJSON safely decodes the two JSONB columns into Go values.
+// Either may be absent / empty.
+func parseReliabilityJSON(hourly, reasons []byte) ([]float64, map[string]int) {
+	var (
+		availability  []float64
+		reasonHist    map[string]int
+	)
+	if len(hourly) > 0 {
+		_ = json.Unmarshal(hourly, &availability)
+	}
+	if len(reasons) > 0 {
+		_ = json.Unmarshal(reasons, &reasonHist)
+	}
+	return availability, reasonHist
+}

--- a/coordinator/api/provider.go
+++ b/coordinator/api/provider.go
@@ -123,11 +123,15 @@ func (s *Server) providerReadLoop(ctx context.Context, conn *websocket.Conn, pro
 	var provider *registry.Provider
 	tracker := newChallengeTracker()
 
+	// Disconnect reason for the liveness session. Defaults to the clean-close
+	// case; flipped to read_error when conn.Read returns a non-CloseStatus error.
+	disconnectReason := store.DisconnectReasonCleanClose
+
 	// Cancel context for cleanup of the challenge loop goroutine.
 	loopCtx, loopCancel := context.WithCancel(ctx)
 	defer func() {
 		loopCancel()
-		s.registry.Disconnect(providerID)
+		s.registry.RecordDisconnect(providerID, disconnectReason)
 		conn.Close(websocket.StatusNormalClosure, "goodbye")
 	}()
 
@@ -137,6 +141,7 @@ func (s *Server) providerReadLoop(ctx context.Context, conn *websocket.Conn, pro
 			if websocket.CloseStatus(err) != -1 {
 				s.logger.Info("provider websocket closed", "provider_id", providerID)
 			} else {
+				disconnectReason = store.DisconnectReasonReadError
 				s.logger.Error("provider websocket read error", "provider_id", providerID, "error", err)
 				s.emit(context.Background(), protocol.SeverityWarn, protocol.KindConnectivity,
 					"provider websocket read error",

--- a/coordinator/cmd/coordinator/main.go
+++ b/coordinator/cmd/coordinator/main.go
@@ -44,6 +44,7 @@ import (
 	"github.com/eigeninference/d-inference/coordinator/billing"
 	"github.com/eigeninference/d-inference/coordinator/datadog"
 	"github.com/eigeninference/d-inference/coordinator/internal/e2e"
+	"github.com/eigeninference/d-inference/coordinator/liveness"
 	"github.com/eigeninference/d-inference/coordinator/mdm"
 	"github.com/eigeninference/d-inference/coordinator/payments"
 	"github.com/eigeninference/d-inference/coordinator/ratelimit"
@@ -140,6 +141,38 @@ func main() {
 	if minTrust := os.Getenv("EIGENINFERENCE_MIN_TRUST"); minTrust != "" {
 		reg.MinTrustLevel = registry.TrustLevel(minTrust)
 		logger.Info("minimum trust level override", "level", minTrust)
+	}
+
+	// Liveness sink — historical heartbeats + session intervals + reliability
+	// features. Optional; defaults to ON when a real store is configured.
+	// Set EIGENINFERENCE_LIVENESS=0 to disable (useful for narrow load tests).
+	var livenessWriter *liveness.Writer
+	if os.Getenv("EIGENINFERENCE_LIVENESS") != "0" {
+		// coordinatorID gets stamped on every session row so a blue-green
+		// deploy can keep the old + new coordinators' sessions distinct. HOSTNAME
+		// is set in containerized environments but not guaranteed in every
+		// runtime, so fall back to os.Hostname() (the syscall).
+		coordinatorID := os.Getenv("HOSTNAME")
+		if coordinatorID == "" {
+			if h, err := os.Hostname(); err == nil {
+				coordinatorID = h
+			}
+		}
+		livenessWriter = liveness.NewWriter(st, logger, nil, liveness.Config{})
+		livenessWriter.Start()
+		tracker := liveness.NewSessionTracker(st, logger, coordinatorID)
+		reg.SetLivenessSink(liveness.NewSink(livenessWriter, tracker))
+
+		// Close any sessions left open by a previous coordinator process.
+		// Stamps reason=coordinator_restart on each.
+		orphanCtx, orphanCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		closed, err := tracker.CloseOrphans(orphanCtx)
+		orphanCancel()
+		if err != nil {
+			logger.Warn("close orphan liveness sessions failed", "error", err)
+		} else if closed > 0 {
+			logger.Info("closed orphan liveness sessions", "count", closed)
+		}
 	}
 
 	srv := api.NewServer(reg, st, logger)
@@ -491,6 +524,27 @@ func main() {
 	// Start background eviction of stale providers.
 	reg.StartEvictionLoop(ctx, 90*time.Second)
 
+	// Retention prune for provider_heartbeats. Defaults to 28d window,
+	// hourly cadence, 10k-row batches. Skipped if liveness sink is off.
+	if livenessWriter != nil {
+		retentionDays := envInt("EIGENINFERENCE_LIVENESS_RETENTION_DAYS", liveness.DefaultRetentionDays())
+		retentionBatch := envInt("EIGENINFERENCE_LIVENESS_RETENTION_BATCH", liveness.DefaultRetentionBatch())
+		retentionInterval := envDuration("EIGENINFERENCE_LIVENESS_RETENTION_INTERVAL", liveness.DefaultRetentionInterval())
+		liveness.StartRetentionLoop(ctx, st, logger, nil, liveness.RetentionConfig{
+			Interval: retentionInterval,
+			Window:   time.Duration(retentionDays) * 24 * time.Hour,
+			Batch:    retentionBatch,
+		})
+
+		// Reliability features rollup. Defaults: 5m cadence, 14d window.
+		featureInterval := envDuration("EIGENINFERENCE_LIVENESS_FEATURES_INTERVAL", liveness.DefaultFeatureInterval())
+		featureWindowDays := envInt("EIGENINFERENCE_LIVENESS_FEATURES_WINDOW_DAYS", liveness.DefaultFeatureWindowDays())
+		liveness.StartFeaturesLoop(ctx, st, logger, nil, liveness.FeaturesConfig{
+			Interval:   featureInterval,
+			WindowDays: featureWindowDays,
+		})
+	}
+
 	// Push gauge values to DogStatsD periodically.
 	go srv.StartDDGaugeLoop(ctx)
 
@@ -530,6 +584,12 @@ func main() {
 		logger.Error("shutdown error", "error", err)
 	}
 
+	// Drain buffered liveness events. Must come after HTTP shutdown so no
+	// new heartbeats arrive while the writer is draining.
+	if livenessWriter != nil {
+		livenessWriter.Close()
+	}
+
 	logger.Info("coordinator stopped")
 }
 
@@ -563,6 +623,15 @@ func envInt(key string, fallback int) int {
 	if v := os.Getenv(key); v != "" {
 		if n, err := strconv.Atoi(v); err == nil {
 			return n
+		}
+	}
+	return fallback
+}
+
+func envDuration(key string, fallback time.Duration) time.Duration {
+	if v := os.Getenv(key); v != "" {
+		if d, err := time.ParseDuration(v); err == nil {
+			return d
 		}
 	}
 	return fallback

--- a/coordinator/liveness/features.go
+++ b/coordinator/liveness/features.go
@@ -1,0 +1,308 @@
+package liveness
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"math"
+	"sort"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/saferun"
+	"github.com/eigeninference/d-inference/coordinator/store"
+)
+
+// Feature rollup defaults — tunable via env in cmd/coordinator/main.go.
+const (
+	defaultFeatureInterval   = 5 * time.Minute
+	defaultFeatureWindowDays = 14
+)
+
+// DefaultFeatureInterval is the default cadence of feature rollup runs.
+func DefaultFeatureInterval() time.Duration { return defaultFeatureInterval }
+
+// DefaultFeatureWindowDays is the default window the rollup considers when
+// computing per-provider behavioral features.
+func DefaultFeatureWindowDays() int { return defaultFeatureWindowDays }
+
+// FeaturesConfig parameterizes the rollup worker.
+type FeaturesConfig struct {
+	Interval   time.Duration
+	WindowDays int
+}
+
+func (c FeaturesConfig) withDefaults() FeaturesConfig {
+	if c.Interval <= 0 {
+		c.Interval = defaultFeatureInterval
+	}
+	if c.WindowDays <= 0 {
+		c.WindowDays = defaultFeatureWindowDays
+	}
+	return c
+}
+
+// FeaturesQuery is the subset of store.Store the rollup needs. Decoupled
+// from the store package so test fakes can implement just these methods.
+type FeaturesQuery interface {
+	ListSessionsSince(ctx context.Context, since time.Time) ([]store.SessionRow, error)
+	UpsertReliabilityFeatures(ctx context.Context, row store.ReliabilityFeatures) error
+}
+
+// StartFeaturesLoop runs the rollup periodically. Like the retention loop,
+// it runs once eagerly on boot, then on cfg.Interval.
+//
+// `count` is the metrics callback (nil-safe). Counters emitted:
+//   - "liveness_features_runs_total"     incremented per scheduled run
+//   - "liveness_features_providers_total" incremented by # of providers updated per run
+//   - "liveness_features_errors_total"   incremented on DB error
+func StartFeaturesLoop(ctx context.Context, q FeaturesQuery, logger *slog.Logger, count CounterFn, cfg FeaturesConfig) {
+	cfg = cfg.withDefaults()
+	if logger == nil {
+		logger = slog.Default()
+	}
+	logger = logger.With("component", "liveness.features")
+
+	saferun.Go(logger, "liveness.featuresLoop", func() {
+		runFeatures(ctx, q, logger, count, cfg)
+
+		ticker := time.NewTicker(cfg.Interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				runFeatures(ctx, q, logger, count, cfg)
+			}
+		}
+	})
+}
+
+func runFeatures(ctx context.Context, q FeaturesQuery, logger *slog.Logger, count CounterFn, cfg FeaturesConfig) {
+	if count != nil {
+		count("liveness_features_runs_total", 1)
+	}
+
+	window := time.Duration(cfg.WindowDays) * 24 * time.Hour
+	now := time.Now()
+	since := now.Add(-window)
+
+	sessions, err := q.ListSessionsSince(ctx, since)
+	if err != nil {
+		if count != nil {
+			count("liveness_features_errors_total", 1)
+		}
+		logger.Warn("list sessions failed", "error", err)
+		return
+	}
+
+	// Bucket by provider.
+	byProvider := make(map[string][]store.SessionRow, 128)
+	for _, s := range sessions {
+		byProvider[s.ProviderID] = append(byProvider[s.ProviderID], s)
+	}
+
+	updated := 0
+	for providerID, rows := range byProvider {
+		features := computeFeatures(providerID, rows, since, now, cfg.WindowDays)
+		if err := q.UpsertReliabilityFeatures(ctx, features); err != nil {
+			if count != nil {
+				count("liveness_features_errors_total", 1)
+			}
+			logger.Warn("upsert features failed",
+				"provider_id", providerID,
+				"error", err)
+			continue
+		}
+		updated++
+	}
+	if count != nil && updated > 0 {
+		count("liveness_features_providers_total", int64(updated))
+	}
+	if updated > 0 {
+		logger.Info("features rollup complete",
+			"providers", updated,
+			"window_days", cfg.WindowDays)
+	}
+}
+
+// computeFeatures derives one ReliabilityFeatures row from a provider's
+// session history within [since, now]. Open sessions (DisconnectedAt zero)
+// are treated as if they end at `now`.
+//
+// The math here is intentionally simple — anything fancier (real Kaplan-Meier
+// survival curves, weekday vs weekend disaggregation) is v2.
+func computeFeatures(providerID string, rows []store.SessionRow, since, now time.Time, windowDays int) store.ReliabilityFeatures {
+	windowSeconds := int64(now.Sub(since).Seconds())
+
+	var (
+		uptimeSeconds  int64
+		durations      = make([]int64, 0, len(rows))
+		hourlyOnline   [168]int64 // hour_of_week → seconds online in that bucket
+		discReasons    = make(map[string]int, 4)
+		stays4h        int
+		stays8h        int
+		lastDisconnect time.Time
+		lastClosedDur  int64
+	)
+
+	for _, s := range rows {
+		// Clip to window.
+		start := s.ConnectedAt
+		if start.Before(since) {
+			start = since
+		}
+		end := s.DisconnectedAt
+		if end.IsZero() || end.After(now) {
+			end = now
+		}
+		if !end.After(start) {
+			continue
+		}
+		dur := int64(end.Sub(start).Seconds())
+		uptimeSeconds += dur
+		durations = append(durations, dur)
+
+		// Hour-of-week buckets: walk by hour from start to end, charge each
+		// bucket the fraction of an hour that overlaps. Bounded loop: ≤ 168
+		// per session per week, with at most 168×N sessions to total in a
+		// 14-day window. Cheap enough.
+		for t := start; t.Before(end); {
+			next := t.Truncate(time.Hour).Add(time.Hour)
+			if next.After(end) {
+				next = end
+			}
+			bucket := int(t.Weekday())*24 + t.Hour()
+			hourlyOnline[bucket] += int64(next.Sub(t).Seconds())
+			t = next
+		}
+
+		// Conditional stays-N stats: count UNCLIPPED session duration. We
+		// want "if they came online, did they stay ≥ 4h" — clipping at the
+		// window edge would artificially shorten long sessions started
+		// before the window.
+		rawEnd := s.DisconnectedAt
+		if rawEnd.IsZero() || rawEnd.After(now) {
+			rawEnd = now
+		}
+		rawStart := s.ConnectedAt
+		rawDur := rawEnd.Sub(rawStart)
+		if rawDur >= 4*time.Hour {
+			stays4h++
+		}
+		if rawDur >= 8*time.Hour {
+			stays8h++
+		}
+
+		// Disconnect reasons: only count CLOSED sessions.
+		if !s.DisconnectedAt.IsZero() {
+			reason := s.DisconnectReason
+			if reason == "" {
+				reason = "unspecified"
+			}
+			discReasons[reason]++
+			if s.DisconnectedAt.After(lastDisconnect) {
+				lastDisconnect = s.DisconnectedAt
+				lastClosedDur = int64(s.DisconnectedAt.Sub(s.ConnectedAt).Seconds())
+			}
+		}
+	}
+
+	uptimePct := 0.0
+	if windowSeconds > 0 {
+		uptimePct = float64(uptimeSeconds) / float64(windowSeconds)
+		if uptimePct > 1 {
+			uptimePct = 1
+		}
+	}
+
+	// Hourly availability matrix as fractions of an hour: divide by 3600.
+	// Stored as a flat 168-element array; consumers reshape to 7×24 if they
+	// want a matrix.
+	hourly := make([]float64, 168)
+	for i, sec := range hourlyOnline {
+		// Each hour-of-week appears `windowDays/7` times in a windowDays
+		// window. Normalize so a perfectly-online provider gets 1.0 in
+		// every bucket.
+		occurrences := float64(windowDays) / 7.0
+		if occurrences <= 0 {
+			occurrences = 1
+		}
+		hourly[i] = math.Min(1.0, float64(sec)/(3600.0*occurrences))
+	}
+
+	hourlyJSON, _ := json.Marshal(hourly)
+	disconnectJSON, _ := json.Marshal(discReasons)
+
+	// MTBF: mean gap between consecutive CLOSED sessions, in seconds.
+	// If we have <2 closed sessions, MTBF is meaningless → 0.
+	var (
+		closed   = make([]store.SessionRow, 0, len(rows))
+		mtbfSecs int64
+	)
+	for _, s := range rows {
+		if !s.DisconnectedAt.IsZero() {
+			closed = append(closed, s)
+		}
+	}
+	sort.Slice(closed, func(i, j int) bool {
+		return closed[i].ConnectedAt.Before(closed[j].ConnectedAt)
+	})
+	if len(closed) >= 2 {
+		var totalGap int64
+		gaps := 0
+		for i := 1; i < len(closed); i++ {
+			gap := closed[i].ConnectedAt.Sub(closed[i-1].DisconnectedAt)
+			if gap > 0 {
+				totalGap += int64(gap.Seconds())
+				gaps++
+			}
+		}
+		if gaps > 0 {
+			mtbfSecs = totalGap / int64(gaps)
+		}
+	}
+
+	sort.Slice(durations, func(i, j int) bool { return durations[i] < durations[j] })
+	p10 := percentile(durations, 0.10)
+	p50 := percentile(durations, 0.50)
+	p90 := percentile(durations, 0.90)
+
+	pStays4h := 0.0
+	pStays8h := 0.0
+	if len(rows) > 0 {
+		pStays4h = float64(stays4h) / float64(len(rows))
+		pStays8h = float64(stays8h) / float64(len(rows))
+	}
+
+	return store.ReliabilityFeatures{
+		ProviderID:                 providerID,
+		WindowDays:                 windowDays,
+		UptimePct:                  uptimePct,
+		SessionsCount:              len(rows),
+		MTBFSeconds:                mtbfSecs,
+		MedianSessionSeconds:       p50,
+		P10SessionSeconds:          p10,
+		P90SessionSeconds:          p90,
+		HourlyAvailability:         hourlyJSON,
+		DisconnectReasons:          disconnectJSON,
+		PStays4h:                   pStays4h,
+		PStays8h:                   pStays8h,
+		LastDisconnectAt:           lastDisconnect,
+		LastSessionDurationSeconds: lastClosedDur,
+	}
+}
+
+func percentile(sorted []int64, p float64) int64 {
+	if len(sorted) == 0 {
+		return 0
+	}
+	idx := int(math.Floor(p * float64(len(sorted)-1)))
+	if idx < 0 {
+		idx = 0
+	}
+	if idx >= len(sorted) {
+		idx = len(sorted) - 1
+	}
+	return sorted[idx]
+}

--- a/coordinator/liveness/features_test.go
+++ b/coordinator/liveness/features_test.go
@@ -1,0 +1,154 @@
+package liveness
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/store"
+)
+
+// Synthetic provider session traces and the features they should produce.
+// Built so each math path (uptime, MTBF, percentiles, P(stays N hours)) is
+// exercised by at least one provider.
+func TestComputeFeaturesBasic(t *testing.T) {
+	// Window: 14 days; "now" anchored for determinism.
+	now := time.Date(2026, 5, 22, 12, 0, 0, 0, time.UTC)
+	windowDays := 14
+	since := now.Add(-time.Duration(windowDays) * 24 * time.Hour)
+
+	// Provider with three completed sessions of 5h, 1h, 9h plus one open.
+	rows := []store.SessionRow{
+		{ProviderID: "p", ConnectedAt: since.Add(1 * time.Hour), DisconnectedAt: since.Add(6 * time.Hour), DisconnectReason: store.DisconnectReasonCleanClose},  // 5h
+		{ProviderID: "p", ConnectedAt: since.Add(48 * time.Hour), DisconnectedAt: since.Add(49 * time.Hour), DisconnectReason: store.DisconnectReasonReadError}, // 1h
+		{ProviderID: "p", ConnectedAt: since.Add(72 * time.Hour), DisconnectedAt: since.Add(81 * time.Hour), DisconnectReason: store.DisconnectReasonCleanClose}, // 9h
+		{ProviderID: "p", ConnectedAt: now.Add(-30 * time.Minute)}, // still open
+	}
+
+	f := computeFeatures("p", rows, since, now, windowDays)
+
+	if f.SessionsCount != 4 {
+		t.Fatalf("sessions_count: want 4, got %d", f.SessionsCount)
+	}
+	// Two of 4 sessions are ≥ 4h → 50%; one is ≥ 8h → 25%.
+	if f.PStays4h != 0.5 {
+		t.Fatalf("p_stays_4h: want 0.5, got %v", f.PStays4h)
+	}
+	if f.PStays8h != 0.25 {
+		t.Fatalf("p_stays_8h: want 0.25, got %v", f.PStays8h)
+	}
+	// Percentile sanity: sorted durations are 1800s (open), 3600s, 18000s, 32400s.
+	if f.MedianSessionSeconds < 3000 || f.MedianSessionSeconds > 20000 {
+		t.Fatalf("median_session_seconds out of plausible range: %d", f.MedianSessionSeconds)
+	}
+	// Uptime: 5+1+9+0.5 = 15.5h on a 14d window = 15.5/336 ≈ 0.046.
+	if f.UptimePct < 0.04 || f.UptimePct > 0.05 {
+		t.Fatalf("uptime_pct off: %v", f.UptimePct)
+	}
+	// Disconnect reasons present in JSON for the 3 closed sessions.
+	var reasons map[string]int
+	if err := json.Unmarshal(f.DisconnectReasons, &reasons); err != nil {
+		t.Fatalf("disconnect_reasons not valid JSON: %v", err)
+	}
+	if reasons[store.DisconnectReasonCleanClose] != 2 {
+		t.Fatalf("expected 2 clean_close, got %v", reasons)
+	}
+	if reasons[store.DisconnectReasonReadError] != 1 {
+		t.Fatalf("expected 1 read_error, got %v", reasons)
+	}
+	// Last disconnect: from the 9h session ending at since+81h.
+	wantLastDisc := since.Add(81 * time.Hour)
+	if !f.LastDisconnectAt.Equal(wantLastDisc) {
+		t.Fatalf("last_disconnect_at: want %v, got %v", wantLastDisc, f.LastDisconnectAt)
+	}
+	// MTBF: gaps between (close → next open) are (48-6)=42h and (72-49)=23h.
+	// Mean = 32.5h = 117000s.
+	if f.MTBFSeconds < 100000 || f.MTBFSeconds > 130000 {
+		t.Fatalf("mtbf_seconds off: %d (want ~117000)", f.MTBFSeconds)
+	}
+}
+
+// featuresFake captures rollup output for verifying the loop wiring.
+type featuresFake struct {
+	mu       sync.Mutex
+	sessions []store.SessionRow
+	failList bool
+	upserts  []store.ReliabilityFeatures
+}
+
+func (f *featuresFake) ListSessionsSince(_ context.Context, _ time.Time) ([]store.SessionRow, error) {
+	if f.failList {
+		return nil, errors.New("simulated list failure")
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]store.SessionRow, len(f.sessions))
+	copy(out, f.sessions)
+	return out, nil
+}
+
+func (f *featuresFake) UpsertReliabilityFeatures(_ context.Context, row store.ReliabilityFeatures) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.upserts = append(f.upserts, row)
+	return nil
+}
+
+// One run of the rollup should upsert one row per provider seen.
+func TestFeaturesRollupOneRowPerProvider(t *testing.T) {
+	now := time.Now()
+	q := &featuresFake{
+		sessions: []store.SessionRow{
+			{ProviderID: "a", ConnectedAt: now.Add(-time.Hour), DisconnectedAt: now.Add(-30 * time.Minute), DisconnectReason: store.DisconnectReasonCleanClose},
+			{ProviderID: "b", ConnectedAt: now.Add(-2 * time.Hour)}, // still open
+			{ProviderID: "b", ConnectedAt: now.Add(-5 * time.Hour), DisconnectedAt: now.Add(-3 * time.Hour), DisconnectReason: store.DisconnectReasonStaleHeartbeat},
+		},
+	}
+	runFeatures(context.Background(), q, quietLogger(), nil, FeaturesConfig{WindowDays: 14})
+
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	if len(q.upserts) != 2 {
+		t.Fatalf("expected 2 upserts (one per provider), got %d", len(q.upserts))
+	}
+	seen := map[string]bool{}
+	for _, r := range q.upserts {
+		seen[r.ProviderID] = true
+	}
+	if !seen["a"] || !seen["b"] {
+		t.Fatalf("missing providers: %v", q.upserts)
+	}
+}
+
+// On query error the loop logs + counts + does not write upserts.
+func TestFeaturesRollupStopsOnListError(t *testing.T) {
+	q := &featuresFake{failList: true}
+	var (
+		mu       sync.Mutex
+		counters []string
+	)
+	count := func(name string, _ int64) {
+		mu.Lock()
+		counters = append(counters, name)
+		mu.Unlock()
+	}
+	runFeatures(context.Background(), q, quietLogger(), count, FeaturesConfig{WindowDays: 14})
+
+	if len(q.upserts) != 0 {
+		t.Fatalf("expected no upserts on list error, got %d", len(q.upserts))
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	found := false
+	for _, c := range counters {
+		if c == "liveness_features_errors_total" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected error counter to fire, got %v", counters)
+	}
+}

--- a/coordinator/liveness/integration_test.go
+++ b/coordinator/liveness/integration_test.go
@@ -1,0 +1,266 @@
+package liveness_test
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/liveness"
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+	"github.com/eigeninference/d-inference/coordinator/registry"
+	"github.com/eigeninference/d-inference/coordinator/store"
+)
+
+// inspectableStore is an in-memory store wrapper that lets the integration
+// test peek at appended heartbeats + session rows without exporting the
+// memory store internals. It satisfies store.Store by delegating everything
+// to a real *store.MemoryStore, but additionally records heartbeats it sees
+// and exposes the latest session row for a provider.
+type inspectableStore struct {
+	*store.MemoryStore
+
+	mu         sync.Mutex
+	heartbeats []store.HeartbeatEvent
+	sessions   []sessionRow
+}
+
+type sessionRow struct {
+	id               int64
+	providerID       string
+	coordinatorID    string
+	connectedAt      time.Time
+	disconnectedAt   time.Time
+	disconnectReason string
+}
+
+func newInspectableStore() *inspectableStore {
+	return &inspectableStore{MemoryStore: store.NewMemory("")}
+}
+
+func (s *inspectableStore) AppendHeartbeats(ctx context.Context, events []store.HeartbeatEvent) error {
+	s.mu.Lock()
+	s.heartbeats = append(s.heartbeats, events...)
+	s.mu.Unlock()
+	return s.MemoryStore.AppendHeartbeats(ctx, events)
+}
+
+func (s *inspectableStore) OpenSession(ctx context.Context, sess store.SessionStart) (int64, error) {
+	id, err := s.MemoryStore.OpenSession(ctx, sess)
+	if err != nil {
+		return 0, err
+	}
+	s.mu.Lock()
+	s.sessions = append(s.sessions, sessionRow{
+		id:            id,
+		providerID:    sess.ProviderID,
+		coordinatorID: sess.CoordinatorID,
+		connectedAt:   sess.ConnectedAt,
+	})
+	s.mu.Unlock()
+	return id, nil
+}
+
+func (s *inspectableStore) CloseSession(ctx context.Context, sessionID int64, reason string, at time.Time, lastHeartbeat time.Time, reqs, toks int64) error {
+	s.mu.Lock()
+	for i := range s.sessions {
+		if s.sessions[i].id == sessionID && s.sessions[i].disconnectedAt.IsZero() {
+			s.sessions[i].disconnectedAt = at
+			s.sessions[i].disconnectReason = reason
+			break
+		}
+	}
+	s.mu.Unlock()
+	return s.MemoryStore.CloseSession(ctx, sessionID, reason, at, lastHeartbeat, reqs, toks)
+}
+
+func (s *inspectableStore) CloseOrphanSessions(ctx context.Context, reason string, at time.Time, coordinatorID string) (int64, error) {
+	s.mu.Lock()
+	for i := range s.sessions {
+		if !s.sessions[i].disconnectedAt.IsZero() {
+			continue
+		}
+		if coordinatorID != "" && s.sessions[i].coordinatorID != coordinatorID {
+			continue
+		}
+		s.sessions[i].disconnectedAt = at
+		s.sessions[i].disconnectReason = reason
+	}
+	s.mu.Unlock()
+	return s.MemoryStore.CloseOrphanSessions(ctx, reason, at, coordinatorID)
+}
+
+func (s *inspectableStore) latestSession(providerID string) sessionRow {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for i := len(s.sessions) - 1; i >= 0; i-- {
+		if s.sessions[i].providerID == providerID {
+			return s.sessions[i]
+		}
+	}
+	return sessionRow{}
+}
+
+func (s *inspectableStore) heartbeatCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.heartbeats)
+}
+
+// quietLog returns a logger that swallows everything below error level so
+// the test output stays readable.
+func quietLog() *slog.Logger {
+	return slog.New(slog.NewTextHandler(devNull{}, &slog.HandlerOptions{Level: slog.LevelError}))
+}
+
+type devNull struct{}
+
+func (devNull) Write(p []byte) (int, error) { return len(p), nil }
+
+// waitFor polls until predicate returns true or the deadline elapses.
+func waitFor(t *testing.T, predicate func() bool, deadline time.Duration, msg string) {
+	t.Helper()
+	end := time.Now().Add(deadline)
+	for time.Now().Before(end) {
+		if predicate() {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if !predicate() {
+		t.Fatalf("timed out waiting: %s", msg)
+	}
+}
+
+// End-to-end test: the registry's Heartbeat path emits heartbeats that the
+// writer flushes into the store. The session lifecycle (Register / clean
+// disconnect / stale eviction) writes the right disconnect reasons.
+func TestLivenessFullCycle(t *testing.T) {
+	st := newInspectableStore()
+	logger := quietLog()
+
+	w := liveness.NewWriter(st, logger, nil, liveness.Config{
+		BufferSize:    32,
+		BatchSize:     2,
+		FlushInterval: 50 * time.Millisecond,
+		DrainTimeout:  2 * time.Second,
+	})
+	w.Start()
+	defer w.Close()
+
+	tracker := liveness.NewSessionTracker(st, logger, "coord-test")
+	sink := liveness.NewSink(w, tracker)
+
+	reg := registry.New(logger)
+	reg.SetStore(st)
+	reg.SetLivenessSink(sink)
+
+	t.Run("Register opens a session", func(t *testing.T) {
+		reg.Register("prov-A", nil, &protocol.RegisterMessage{
+			Hardware: protocol.Hardware{ChipName: "M4 Max", MemoryGB: 64},
+			Backend:  "vllm-mlx",
+		})
+
+		waitFor(t, func() bool {
+			row := st.latestSession("prov-A")
+			return row.id != 0 && row.disconnectedAt.IsZero()
+		}, time.Second, "prov-A session not opened")
+	})
+
+	t.Run("Heartbeat is recorded", func(t *testing.T) {
+		active := "qwen3.5"
+		reg.Heartbeat("prov-A", &protocol.HeartbeatMessage{
+			Status:      "idle",
+			ActiveModel: &active,
+			SystemMetrics: protocol.SystemMetrics{
+				MemoryPressure: 0.4,
+				CPUUsage:       0.1,
+				ThermalState:   "nominal",
+			},
+		})
+
+		waitFor(t, func() bool {
+			return st.heartbeatCount() >= 1
+		}, time.Second, "no heartbeats appended")
+	})
+
+	t.Run("RecordDisconnect(clean) closes the session with reason", func(t *testing.T) {
+		reg.RecordDisconnect("prov-A", store.DisconnectReasonCleanClose)
+
+		// SessionTracker.Close is synchronous against the store, no wait needed.
+		row := st.latestSession("prov-A")
+		if row.disconnectedAt.IsZero() {
+			t.Fatalf("expected session closed, got open row: %+v", row)
+		}
+		if row.disconnectReason != store.DisconnectReasonCleanClose {
+			t.Fatalf("expected reason %q, got %q", store.DisconnectReasonCleanClose, row.disconnectReason)
+		}
+	})
+
+	t.Run("evictStale closes session with stale_heartbeat reason", func(t *testing.T) {
+		reg.Register("prov-B", nil, &protocol.RegisterMessage{
+			Hardware: protocol.Hardware{ChipName: "M3", MemoryGB: 32},
+			Backend:  "vllm-mlx",
+		})
+		// Let prov-B's LastHeartbeat age past the staleness threshold below.
+		time.Sleep(30 * time.Millisecond)
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		reg.StartEvictionLoop(ctx, 5*time.Millisecond)
+
+		waitFor(t, func() bool {
+			row := st.latestSession("prov-B")
+			return !row.disconnectedAt.IsZero() &&
+				row.disconnectReason == store.DisconnectReasonStaleHeartbeat
+		}, 2*time.Second, "prov-B not evicted with stale_heartbeat reason")
+	})
+}
+
+// CloseOrphans on coordinator boot stamps "coordinator_restart" on sessions
+// left open by THIS coordinator's prior incarnation (same coordinatorID).
+// Sessions owned by a sibling coordinator are left alone — important for
+// blue-green deploys where two coordinator processes run concurrently.
+func TestOrphanCloseOnBoot(t *testing.T) {
+	st := newInspectableStore()
+	logger := quietLog()
+
+	// Previous incarnation of "coord-A" opens two sessions, then "crashes"
+	// (we discard the tracker without closing anything).
+	prev := liveness.NewSessionTracker(st, logger, "coord-A")
+	prev.Open("ghost-A1")
+	prev.Open("ghost-A2")
+
+	// A sibling coordinator "coord-B" runs concurrently and has its own
+	// live session. CloseOrphans on coord-A's boot must NOT touch this.
+	siblingTracker := liveness.NewSessionTracker(st, logger, "coord-B")
+	siblingTracker.Open("live-on-B")
+
+	// New incarnation of "coord-A" boots and sweeps.
+	bootTracker := liveness.NewSessionTracker(st, logger, "coord-A")
+	closed, err := bootTracker.CloseOrphans(context.Background())
+	if err != nil {
+		t.Fatalf("CloseOrphans: %v", err)
+	}
+	if closed != 2 {
+		t.Fatalf("expected exactly 2 orphans closed (only coord-A's), got %d", closed)
+	}
+
+	// coord-A's ghosts should now be stamped coordinator_restart.
+	for _, id := range []string{"ghost-A1", "ghost-A2"} {
+		row := st.latestSession(id)
+		if row.disconnectedAt.IsZero() {
+			t.Fatalf("expected %s closed", id)
+		}
+		if !strings.Contains(row.disconnectReason, "coordinator_restart") {
+			t.Fatalf("expected %s reason=coordinator_restart, got %q", id, row.disconnectReason)
+		}
+	}
+
+	// coord-B's session must still be open — it's still live there.
+	siblingRow := st.latestSession("live-on-B")
+	if !siblingRow.disconnectedAt.IsZero() {
+		t.Fatalf("expected live-on-B still open, got closed with reason %q", siblingRow.disconnectReason)
+	}
+}

--- a/coordinator/liveness/retention.go
+++ b/coordinator/liveness/retention.go
@@ -1,0 +1,128 @@
+package liveness
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/saferun"
+	"github.com/eigeninference/d-inference/coordinator/store"
+)
+
+// Retention defaults — tunable via env in cmd/coordinator/main.go.
+const (
+	defaultRetentionInterval = time.Hour
+	defaultRetentionDays     = 28
+	defaultRetentionBatch    = 10000
+)
+
+// DefaultRetentionInterval is the default time between retention prune runs.
+func DefaultRetentionInterval() time.Duration { return defaultRetentionInterval }
+
+// DefaultRetentionDays is the default age threshold (in days) for raw
+// heartbeats. Rows older than this are deleted by the retention loop.
+func DefaultRetentionDays() int { return defaultRetentionDays }
+
+// DefaultRetentionBatch is the default per-DELETE batch size. Tuned to keep
+// WAL pressure / replication lag bounded and allow autovacuum to keep up.
+func DefaultRetentionBatch() int { return defaultRetentionBatch }
+
+// RetentionConfig parameterizes the retention loop.
+type RetentionConfig struct {
+	Interval time.Duration // how often to run the prune loop
+	Window   time.Duration // delete heartbeats older than now-Window
+	Batch    int           // rows deleted per DELETE statement
+}
+
+func (c RetentionConfig) withDefaults() RetentionConfig {
+	if c.Interval <= 0 {
+		c.Interval = defaultRetentionInterval
+	}
+	if c.Window <= 0 {
+		c.Window = defaultRetentionDays * 24 * time.Hour
+	}
+	if c.Batch <= 0 {
+		c.Batch = defaultRetentionBatch
+	}
+	return c
+}
+
+// StartRetentionLoop runs a periodic prune of provider_heartbeats. Mirrors
+// registry.StartEvictionLoop's saferun.Go + ticker pattern so a panic can't
+// take down the coordinator. Exits when ctx is cancelled.
+//
+// The actual DELETE is batched: the loop calls DeleteHeartbeatsBefore in a
+// drain loop until either a single call returns 0 (caught up) or the per-run
+// time budget (cfg.Interval - 5s) is exhausted. This keeps WAL pressure
+// bounded and lets autovacuum keep pace.
+//
+// `count` is the metrics callback (nil-safe). It receives one of:
+//   - "liveness_retention_rows_total"   incremented by rows actually deleted
+//   - "liveness_retention_runs_total"   incremented once per scheduled run
+//   - "liveness_retention_errors_total" incremented on DB error
+func StartRetentionLoop(ctx context.Context, s store.Store, logger *slog.Logger, count CounterFn, cfg RetentionConfig) {
+	cfg = cfg.withDefaults()
+	if logger == nil {
+		logger = slog.Default()
+	}
+	logger = logger.With("component", "liveness.retention")
+
+	saferun.Go(logger, "liveness.retentionLoop", func() {
+		// Run once promptly on boot so a long-stopped coordinator catches up
+		// before waiting for the first tick.
+		runRetention(ctx, s, logger, count, cfg)
+
+		ticker := time.NewTicker(cfg.Interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				runRetention(ctx, s, logger, count, cfg)
+			}
+		}
+	})
+}
+
+func runRetention(ctx context.Context, s store.Store, logger *slog.Logger, count CounterFn, cfg RetentionConfig) {
+	if count != nil {
+		count("liveness_retention_runs_total", 1)
+	}
+
+	// Reserve 5s of headroom before the next tick so a slow DB can't make
+	// retention runs overlap or starve other work.
+	budget := cfg.Interval - 5*time.Second
+	if budget < 5*time.Second {
+		budget = 5 * time.Second
+	}
+	deadline := time.Now().Add(budget)
+	before := time.Now().Add(-cfg.Window)
+
+	var total int64
+	for time.Now().Before(deadline) {
+		if ctx.Err() != nil {
+			return
+		}
+		deleted, err := s.DeleteHeartbeatsBefore(ctx, before, cfg.Batch)
+		if err != nil {
+			if count != nil {
+				count("liveness_retention_errors_total", 1)
+			}
+			logger.Warn("retention delete failed", "error", err, "total_so_far", total)
+			return
+		}
+		if deleted == 0 {
+			break
+		}
+		total += deleted
+		if count != nil {
+			count("liveness_retention_rows_total", deleted)
+		}
+	}
+	if total > 0 {
+		logger.Info("retention prune complete",
+			"rows_deleted", total,
+			"window_days", int(cfg.Window/(24*time.Hour)))
+	}
+}

--- a/coordinator/liveness/retention_test.go
+++ b/coordinator/liveness/retention_test.go
@@ -1,0 +1,148 @@
+package liveness
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/store"
+)
+
+// retentionFakeStore wraps an in-memory store and lets the test count
+// DeleteHeartbeatsBefore invocations + force errors.
+type retentionFakeStore struct {
+	*store.MemoryStore
+	mu      sync.Mutex
+	calls   int
+	failN   int
+	deleted atomic.Int64
+}
+
+func (s *retentionFakeStore) DeleteHeartbeatsBefore(ctx context.Context, before time.Time, limit int) (int64, error) {
+	s.mu.Lock()
+	s.calls++
+	if s.failN > 0 {
+		s.failN--
+		s.mu.Unlock()
+		return 0, errors.New("simulated delete failure")
+	}
+	s.mu.Unlock()
+	n, err := s.MemoryStore.DeleteHeartbeatsBefore(ctx, before, limit)
+	s.deleted.Add(n)
+	return n, err
+}
+
+func (s *retentionFakeStore) callCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.calls
+}
+
+func seedHeartbeats(t *testing.T, s store.Store, providerID string, age time.Duration, n int) {
+	t.Helper()
+	now := time.Now().Add(-age)
+	events := make([]store.HeartbeatEvent, n)
+	for i := range events {
+		events[i] = store.HeartbeatEvent{
+			ProviderID:   providerID,
+			At:           now.Add(time.Duration(i) * time.Millisecond),
+			Status:       "idle",
+			ThermalState: "nominal",
+		}
+	}
+	if err := s.AppendHeartbeats(context.Background(), events); err != nil {
+		t.Fatalf("AppendHeartbeats: %v", err)
+	}
+}
+
+// runRetention drains in batches until 0 or budget elapses.
+func TestRetentionDrainsBacklog(t *testing.T) {
+	fs := &retentionFakeStore{MemoryStore: store.NewMemory("")}
+	seedHeartbeats(t, fs, "p", 48*time.Hour, 25)
+	seedHeartbeats(t, fs, "p", time.Minute, 5) // fresh, must survive
+
+	cfg := RetentionConfig{
+		Interval: time.Hour, // not used directly here; we call runRetention once
+		Window:   24 * time.Hour,
+		Batch:    7,
+	}.withDefaults()
+
+	runRetention(context.Background(), fs, quietLogger(), nil, cfg)
+
+	if got := fs.deleted.Load(); got != 25 {
+		t.Fatalf("expected 25 rows deleted, got %d", got)
+	}
+	// At Batch=7, drains in ceil(25/7)=4 successful calls + 1 zero-return call = 5
+	if calls := fs.callCount(); calls < 4 {
+		t.Fatalf("expected at least 4 DELETE calls to drain backlog, got %d", calls)
+	}
+}
+
+// A delete error should be logged + counted, not crash; loop exits cleanly.
+func TestRetentionStopsOnError(t *testing.T) {
+	fs := &retentionFakeStore{
+		MemoryStore: store.NewMemory(""),
+		failN:       1,
+	}
+	seedHeartbeats(t, fs, "p", 48*time.Hour, 5)
+
+	var (
+		mu       sync.Mutex
+		counters []string
+	)
+	count := func(name string, _ int64) {
+		mu.Lock()
+		counters = append(counters, name)
+		mu.Unlock()
+	}
+
+	cfg := RetentionConfig{Window: 24 * time.Hour, Batch: 100}.withDefaults()
+	runRetention(context.Background(), fs, quietLogger(), count, cfg)
+
+	mu.Lock()
+	defer mu.Unlock()
+	sawErr := false
+	for _, c := range counters {
+		if c == "liveness_retention_errors_total" {
+			sawErr = true
+		}
+	}
+	if !sawErr {
+		t.Fatalf("expected error counter to fire, got %v", counters)
+	}
+}
+
+// StartRetentionLoop spins the goroutine, runs once on boot, then again on
+// the ticker. Cancelling the context exits cleanly.
+func TestStartRetentionLoopRunsAndStops(t *testing.T) {
+	fs := &retentionFakeStore{MemoryStore: store.NewMemory("")}
+	seedHeartbeats(t, fs, "p", 48*time.Hour, 3)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	StartRetentionLoop(ctx, fs, quietLogger(), nil, RetentionConfig{
+		Interval: 50 * time.Millisecond,
+		Window:   24 * time.Hour,
+		Batch:    100,
+	})
+
+	// Wait for the eager-on-boot run + at least one ticker fire.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if fs.callCount() >= 2 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if fs.callCount() < 2 {
+		t.Fatalf("expected ≥2 calls (boot + tick), got %d", fs.callCount())
+	}
+
+	cancel()
+	// Loop should exit without panicking — nothing more to assert; the test
+	// would hang if the goroutine leaked, which `go test -race` would also
+	// surface.
+}

--- a/coordinator/liveness/session.go
+++ b/coordinator/liveness/session.go
@@ -1,0 +1,106 @@
+package liveness
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/store"
+)
+
+// SessionTracker maps live providerID → open session row id so the
+// coordinator's existing Register / Disconnect / evictStale call sites can
+// reference sessions without threading the int64 id through three layers.
+//
+// All store calls are synchronous and short — session open/close are
+// per-connection events, not hot-path. We do NOT batch them.
+type SessionTracker struct {
+	store         store.Store
+	logger        *slog.Logger
+	coordinatorID string
+	timeout       time.Duration
+
+	mu   sync.Mutex
+	open map[string]int64 // providerID → sessionID
+}
+
+// NewSessionTracker constructs a tracker. coordinatorID is stamped into each
+// row so future debugging can distinguish which coordinator instance owned a
+// session (matters during blue/green deploys).
+func NewSessionTracker(s store.Store, logger *slog.Logger, coordinatorID string) *SessionTracker {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &SessionTracker{
+		store:         s,
+		logger:        logger.With("component", "liveness.sessions"),
+		coordinatorID: coordinatorID,
+		timeout:       5 * time.Second,
+		open:          make(map[string]int64),
+	}
+}
+
+// Open records a new session for the given provider. If the provider already
+// has an open session (e.g. a reconnect we never saw closed), the old session
+// is left alone — orphan-close on next coordinator boot will sweep it. We
+// always create a fresh row so the new session has a clean ID.
+func (t *SessionTracker) Open(providerID string) {
+	ctx, cancel := context.WithTimeout(context.Background(), t.timeout)
+	defer cancel()
+
+	id, err := t.store.OpenSession(ctx, store.SessionStart{
+		ProviderID:    providerID,
+		ConnectedAt:   time.Now(),
+		CoordinatorID: t.coordinatorID,
+	})
+	if err != nil {
+		t.logger.Warn("open session failed",
+			"provider_id", providerID,
+			"error", err)
+		return
+	}
+	t.mu.Lock()
+	t.open[providerID] = id
+	t.mu.Unlock()
+}
+
+// Close marks the provider's currently-open session as disconnected.
+// reason should be one of the store.DisconnectReason* constants.
+// lastHeartbeat / requestsServed / tokensGenerated are optional context for
+// post-hoc analysis; pass zero values if not tracked.
+//
+// Idempotent: a second call for the same provider is a no-op.
+func (t *SessionTracker) Close(providerID, reason string, lastHeartbeat time.Time, requestsServed, tokensGenerated int64) {
+	t.mu.Lock()
+	id, ok := t.open[providerID]
+	if ok {
+		delete(t.open, providerID)
+	}
+	t.mu.Unlock()
+	if !ok {
+		// No tracked session — either we missed the Open (eg. coordinator
+		// restart) or this is a duplicate Close. Either way, nothing to
+		// update. CloseOrphanSessions on the next boot will catch the gap.
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), t.timeout)
+	defer cancel()
+	if err := t.store.CloseSession(ctx, id, reason, time.Now(), lastHeartbeat, requestsServed, tokensGenerated); err != nil {
+		t.logger.Warn("close session failed",
+			"provider_id", providerID,
+			"session_id", id,
+			"reason", reason,
+			"error", err)
+	}
+}
+
+// CloseOrphans is called once on coordinator boot to close any sessions left
+// open by a previous coordinator process (crash or unclean shutdown). All
+// matching rows owned by THIS coordinatorID are stamped with
+// reason=coordinator_restart. Sessions owned by a sibling coordinator (e.g.
+// during a blue-green deploy) are left alone — they're still live there.
+func (t *SessionTracker) CloseOrphans(ctx context.Context) (int64, error) {
+	return t.store.CloseOrphanSessions(ctx, store.DisconnectReasonCoordinatorRestart, time.Now(), t.coordinatorID)
+}

--- a/coordinator/liveness/session_test.go
+++ b/coordinator/liveness/session_test.go
@@ -1,0 +1,42 @@
+package liveness
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/store"
+)
+
+func TestSessionTrackerOpenClose(t *testing.T) {
+	s := store.NewMemory("")
+	tr := NewSessionTracker(s, quietLogger(), "coord-A")
+
+	tr.Open("prov-1")
+	tr.Open("prov-2")
+
+	// Close prov-1 cleanly. Both store and tracker should reflect that.
+	tr.Close("prov-1", store.DisconnectReasonCleanClose, time.Now(), 3, 100)
+
+	// prov-2 is still open; orphan-sweep should pick it up.
+	closed, err := tr.CloseOrphans(context.Background())
+	if err != nil {
+		t.Fatalf("CloseOrphans: %v", err)
+	}
+	if closed < 1 {
+		t.Fatalf("expected ≥1 orphan closed, got %d", closed)
+	}
+
+	// Second Close on prov-1 is a no-op (idempotent — tracker dropped the id).
+	tr.Close("prov-1", store.DisconnectReasonReadError, time.Now(), 0, 0)
+}
+
+func TestSessionTrackerCloseWithoutOpen(t *testing.T) {
+	// If we never observed an Open (e.g. coordinator restarted mid-session),
+	// Close should be a silent no-op — orphan sweep on the prior boot handles it.
+	s := store.NewMemory("")
+	tr := NewSessionTracker(s, quietLogger(), "coord-A")
+
+	// Should not panic, should not error-log loudly.
+	tr.Close("unknown-prov", store.DisconnectReasonStaleHeartbeat, time.Time{}, 0, 0)
+}

--- a/coordinator/liveness/sink.go
+++ b/coordinator/liveness/sink.go
@@ -1,0 +1,44 @@
+package liveness
+
+import (
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/store"
+)
+
+// Sink adapts the Writer + SessionTracker pair into a single value the
+// registry can hold via its registry.LivenessSink interface. It exists so
+// the registry package can stay free of an explicit import of this package
+// (we'd otherwise get a cycle through tests that wire everything together).
+type Sink struct {
+	Writer   *Writer
+	Sessions *SessionTracker
+}
+
+// NewSink returns a sink wrapping the provided writer + tracker. Either
+// component may be nil — calls to the nil component become no-ops, so a
+// partial wire-up (e.g. heartbeats only, no session tracking) still works.
+func NewSink(w *Writer, s *SessionTracker) *Sink {
+	return &Sink{Writer: w, Sessions: s}
+}
+
+func (s *Sink) EmitHeartbeat(ev store.HeartbeatEvent) {
+	if s == nil || s.Writer == nil {
+		return
+	}
+	s.Writer.Emit(ev)
+}
+
+func (s *Sink) OpenSession(providerID string) {
+	if s == nil || s.Sessions == nil {
+		return
+	}
+	s.Sessions.Open(providerID)
+}
+
+func (s *Sink) CloseSession(providerID, reason string, lastHeartbeat time.Time, requestsServed, tokensGenerated int64) {
+	if s == nil || s.Sessions == nil {
+		return
+	}
+	s.Sessions.Close(providerID, reason, lastHeartbeat, requestsServed, tokensGenerated)
+}

--- a/coordinator/liveness/writer.go
+++ b/coordinator/liveness/writer.go
@@ -1,0 +1,252 @@
+// Package liveness records historical provider heartbeats and session
+// intervals to the store. It exists so the coordinator's heartbeat hot path
+// can be non-blocking: the WebSocket handler emits an in-memory event, and
+// a background goroutine batches and bulk-INSERTs them via the store.
+//
+// Safeguards (see plan: /plans/what-i-d-extend-given-crispy-rivest.md):
+//   - bounded channel + non-blocking send (drops on overflow, counts drops)
+//   - batched flush every flushInterval OR when buffer reaches batchSize
+//   - per-flush statement timeout via context
+//   - error backoff (skip next tick on failure)
+//   - graceful drain on Close with a configurable deadline
+package liveness
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/saferun"
+	"github.com/eigeninference/d-inference/coordinator/store"
+)
+
+// Defaults — picked from the plan, tunable via Config.
+const (
+	defaultBufferSize    = 8192
+	defaultBatchSize     = 500
+	defaultFlushInterval = 2 * time.Second
+	defaultFlushTimeout  = 5 * time.Second
+	defaultErrorBackoff  = 2 // skip this many ticks after a failure
+	defaultDrainTimeout  = 10 * time.Second
+)
+
+// Config tunes the Writer's batching behavior.
+type Config struct {
+	BufferSize    int           // channel capacity; events emitted when full are dropped
+	BatchSize     int           // flush early when buffer reaches this size
+	FlushInterval time.Duration // periodic flush tick
+	FlushTimeout  time.Duration // statement timeout per flush
+	DrainTimeout  time.Duration // max time to wait on Close()
+}
+
+func (c Config) withDefaults() Config {
+	if c.BufferSize <= 0 {
+		c.BufferSize = defaultBufferSize
+	}
+	if c.BatchSize <= 0 {
+		c.BatchSize = defaultBatchSize
+	}
+	if c.FlushInterval <= 0 {
+		c.FlushInterval = defaultFlushInterval
+	}
+	if c.FlushTimeout <= 0 {
+		c.FlushTimeout = defaultFlushTimeout
+	}
+	if c.DrainTimeout <= 0 {
+		c.DrainTimeout = defaultDrainTimeout
+	}
+	return c
+}
+
+// CounterFn is the interface the Writer uses to publish stats. Implementations
+// typically wrap api.Metrics.IncCounter. Nil counters are silently ignored so
+// callers don't have to wire anything up in tests.
+type CounterFn func(name string, value int64)
+
+// Writer buffers HeartbeatEvents and flushes them to the store in batches.
+// Safe for concurrent Emit() callers.
+type Writer struct {
+	cfg    Config
+	store  store.Store
+	logger *slog.Logger
+	count  CounterFn
+
+	events chan store.HeartbeatEvent
+
+	// Lifecycle.
+	ctx       context.Context
+	cancel    context.CancelFunc
+	wg        sync.WaitGroup
+	closeOnce sync.Once
+
+	// Stats (exported via Stats() for tests + metrics).
+	dropped      atomic.Int64
+	flushed      atomic.Int64
+	flushFailed  atomic.Int64
+	lastFlushErr atomic.Pointer[error]
+}
+
+// NewWriter constructs a Writer but does not start its flush goroutine.
+// Call Start to begin batching.
+func NewWriter(s store.Store, logger *slog.Logger, count CounterFn, cfg Config) *Writer {
+	cfg = cfg.withDefaults()
+	if logger == nil {
+		logger = slog.Default()
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	return &Writer{
+		cfg:    cfg,
+		store:  s,
+		logger: logger.With("component", "liveness.writer"),
+		count:  count,
+		events: make(chan store.HeartbeatEvent, cfg.BufferSize),
+		ctx:    ctx,
+		cancel: cancel,
+	}
+}
+
+// Start launches the background flush goroutine. Safe to call once.
+func (w *Writer) Start() {
+	w.wg.Add(1)
+	saferun.Go(w.logger, "liveness.writer.flush", func() {
+		defer w.wg.Done()
+		w.flushLoop()
+	})
+}
+
+// Emit enqueues a heartbeat event for asynchronous persistence. Never blocks:
+// if the buffer is full the event is dropped and the drop counter is bumped.
+// This is the function called from the heartbeat hot path on every heartbeat.
+func (w *Writer) Emit(ev store.HeartbeatEvent) {
+	select {
+	case w.events <- ev:
+	default:
+		n := w.dropped.Add(1)
+		w.incCounter("liveness_dropped_total", 1)
+		// Rate-limit the log to once every 1024 drops so a flood doesn't drown
+		// out other coordinator logs.
+		if n&1023 == 1 {
+			w.logger.Warn("liveness writer dropping events — buffer full",
+				"dropped_total", n,
+				"buffer_size", w.cfg.BufferSize)
+		}
+	}
+}
+
+// Stats is a snapshot of writer counters for tests and metrics scraping.
+type Stats struct {
+	Dropped     int64
+	Flushed     int64
+	FlushFailed int64
+	Buffered    int
+}
+
+// Stats returns a point-in-time snapshot of the writer counters.
+func (w *Writer) Stats() Stats {
+	return Stats{
+		Dropped:     w.dropped.Load(),
+		Flushed:     w.flushed.Load(),
+		FlushFailed: w.flushFailed.Load(),
+		Buffered:    len(w.events),
+	}
+}
+
+// Close stops the flush loop, draining any buffered events with a deadline
+// of cfg.DrainTimeout. Safe to call multiple times; only the first does work.
+// After Close, Emit() will still accept events but they will never be flushed.
+func (w *Writer) Close() {
+	w.closeOnce.Do(func() {
+		// Signal the flush loop to drain + exit. It owns the channel close.
+		w.cancel()
+		// Wait for the loop to finish, bounded by DrainTimeout.
+		done := make(chan struct{})
+		go func() {
+			w.wg.Wait()
+			close(done)
+		}()
+		select {
+		case <-done:
+		case <-time.After(w.cfg.DrainTimeout):
+			w.logger.Warn("liveness writer drain timed out",
+				"deadline", w.cfg.DrainTimeout,
+				"buffered", len(w.events))
+		}
+	})
+}
+
+// flushLoop is the background goroutine that batches events and writes them
+// to the store. It exits when ctx is cancelled (via Close), draining the
+// channel before returning.
+func (w *Writer) flushLoop() {
+	ticker := time.NewTicker(w.cfg.FlushInterval)
+	defer ticker.Stop()
+
+	batch := make([]store.HeartbeatEvent, 0, w.cfg.BatchSize)
+	backoff := 0 // ticks to skip after an error
+
+	flush := func() {
+		if len(batch) == 0 {
+			return
+		}
+		if backoff > 0 {
+			// Still in error window; defer this batch to the next tick.
+			backoff--
+			return
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), w.cfg.FlushTimeout)
+		defer cancel()
+		if err := w.store.AppendHeartbeats(ctx, batch); err != nil {
+			w.flushFailed.Add(1)
+			w.incCounter("liveness_flush_failed_total", 1)
+			w.lastFlushErr.Store(&err)
+			w.logger.Warn("liveness flush failed",
+				"error", err,
+				"batch_size", len(batch))
+			backoff = defaultErrorBackoff
+			// Keep the batch so a fast catch-up can retry next tick.
+			return
+		}
+		w.flushed.Add(int64(len(batch)))
+		w.incCounter("liveness_flush_rows_total", int64(len(batch)))
+		batch = batch[:0]
+	}
+
+	for {
+		select {
+		case ev := <-w.events:
+			batch = append(batch, ev)
+			if len(batch) >= w.cfg.BatchSize {
+				flush()
+			}
+		case <-ticker.C:
+			flush()
+		case <-w.ctx.Done():
+			// Drain whatever remains in the channel into the batch (bounded
+			// by DrainTimeout via the outer select in Close). Force-clear the
+			// error backoff so we make a best-effort final flush even if the
+			// last steady-state flush failed within the backoff window —
+			// otherwise drain silently drops the buffered tail.
+			backoff = 0
+			for {
+				select {
+				case ev := <-w.events:
+					batch = append(batch, ev)
+				default:
+					flush()
+					return
+				}
+				if len(batch) >= w.cfg.BatchSize {
+					flush()
+				}
+			}
+		}
+	}
+}
+
+func (w *Writer) incCounter(name string, value int64) {
+	if w.count != nil {
+		w.count(name, value)
+	}
+}

--- a/coordinator/liveness/writer_test.go
+++ b/coordinator/liveness/writer_test.go
@@ -1,0 +1,230 @@
+package liveness
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/store"
+)
+
+// fakeStore is a thin store.Store harness used to observe Writer behavior.
+// It records AppendHeartbeats calls and can be configured to fail.
+type fakeStore struct {
+	store.Store // unused methods fall through to embedded nil — panics if hit
+
+	mu     sync.Mutex
+	calls  int
+	rows   []store.HeartbeatEvent
+	failN  int   // fail the next N calls then succeed
+	delay  time.Duration
+	failed atomic.Int64
+}
+
+func (f *fakeStore) AppendHeartbeats(ctx context.Context, events []store.HeartbeatEvent) error {
+	f.mu.Lock()
+	if f.failN > 0 {
+		f.failN--
+		f.failed.Add(1)
+		f.mu.Unlock()
+		return errors.New("simulated flush failure")
+	}
+	f.calls++
+	f.rows = append(f.rows, events...)
+	d := f.delay
+	f.mu.Unlock()
+	if d > 0 {
+		select {
+		case <-time.After(d):
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	return nil
+}
+
+func (f *fakeStore) snapshot() (calls int, rows int) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.calls, len(f.rows)
+}
+
+func quietLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelError}))
+}
+
+func newTestWriter(t *testing.T, fs *fakeStore, cfg Config) *Writer {
+	t.Helper()
+	w := NewWriter(fs, quietLogger(), nil, cfg)
+	w.Start()
+	t.Cleanup(w.Close)
+	return w
+}
+
+// Writer accepts events from many goroutines and flushes them in batches.
+func TestWriterFlushesBatches(t *testing.T) {
+	fs := &fakeStore{}
+	w := newTestWriter(t, fs, Config{
+		BufferSize:    1024,
+		BatchSize:     50,
+		FlushInterval: 200 * time.Millisecond,
+	})
+
+	for i := 0; i < 120; i++ {
+		w.Emit(store.HeartbeatEvent{ProviderID: "p", At: time.Now()})
+	}
+
+	// Wait long enough that a batch-size flush + at least one ticker flush
+	// have had a chance to run.
+	if !waitFor(func() bool {
+		_, rows := fs.snapshot()
+		return rows >= 120
+	}, 2*time.Second) {
+		_, rows := fs.snapshot()
+		t.Fatalf("expected 120 rows persisted, got %d", rows)
+	}
+	if w.Stats().Dropped != 0 {
+		t.Fatalf("expected 0 dropped, got %d", w.Stats().Dropped)
+	}
+}
+
+// Bounded channel + non-blocking send: when the buffer is full Emit must
+// return immediately and the drop counter must advance.
+func TestWriterDropsWhenBufferFull(t *testing.T) {
+	// Use a slow store so the flush goroutine can't keep up.
+	fs := &fakeStore{delay: 50 * time.Millisecond}
+	// Tiny buffer + large batch keeps the channel saturated.
+	w := newTestWriter(t, fs, Config{
+		BufferSize:    4,
+		BatchSize:     4,
+		FlushInterval: 500 * time.Millisecond,
+	})
+
+	// Emit far more than the buffer can hold; Emit must NEVER block.
+	deadline := time.Now().Add(50 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		w.Emit(store.HeartbeatEvent{ProviderID: "p", At: time.Now()})
+	}
+
+	if w.Stats().Dropped == 0 {
+		t.Fatalf("expected at least one drop under saturation; stats=%+v", w.Stats())
+	}
+}
+
+// On flush error, the writer should bump flush_failed and NOT lose the batch
+// permanently. The next successful flush should persist the same rows.
+func TestWriterRetainsBatchOnFlushError(t *testing.T) {
+	fs := &fakeStore{failN: 1}
+	w := newTestWriter(t, fs, Config{
+		BufferSize:    16,
+		BatchSize:     3,
+		FlushInterval: 100 * time.Millisecond,
+	})
+
+	for i := 0; i < 3; i++ {
+		w.Emit(store.HeartbeatEvent{ProviderID: "p"})
+	}
+
+	// Wait for at least one failed flush + one successful retry. The error
+	// backoff is 2 ticks (200ms), so allow ~1s headroom.
+	if !waitFor(func() bool {
+		_, rows := fs.snapshot()
+		return rows == 3 && w.Stats().FlushFailed > 0
+	}, 2*time.Second) {
+		_, rows := fs.snapshot()
+		t.Fatalf("expected 3 rows + ≥1 failed flush; rows=%d stats=%+v", rows, w.Stats())
+	}
+}
+
+// Close drains the buffer before returning (within DrainTimeout).
+func TestWriterDrainsOnClose(t *testing.T) {
+	fs := &fakeStore{}
+	w := NewWriter(fs, quietLogger(), nil, Config{
+		BufferSize:    32,
+		BatchSize:     32,
+		FlushInterval: 10 * time.Second, // never tick during the test
+		DrainTimeout:  2 * time.Second,
+	})
+	w.Start()
+
+	for i := 0; i < 10; i++ {
+		w.Emit(store.HeartbeatEvent{ProviderID: "p"})
+	}
+
+	w.Close()
+
+	_, rows := fs.snapshot()
+	if rows != 10 {
+		t.Fatalf("expected 10 rows persisted after Close, got %d", rows)
+	}
+}
+
+// CounterFn callback is invoked on drops and on successful flushes so metrics
+// wiring observes the right names + values.
+func TestWriterPublishesCounters(t *testing.T) {
+	type counterCall struct {
+		name  string
+		value int64
+	}
+	var (
+		mu    sync.Mutex
+		calls []counterCall
+	)
+	count := func(name string, value int64) {
+		mu.Lock()
+		defer mu.Unlock()
+		calls = append(calls, counterCall{name, value})
+	}
+
+	// Slow store + tiny buffer to force at least one drop.
+	fs := &fakeStore{delay: 30 * time.Millisecond}
+	w := NewWriter(fs, quietLogger(), count, Config{
+		BufferSize:    2,
+		BatchSize:     2,
+		FlushInterval: 200 * time.Millisecond,
+	})
+	w.Start()
+	t.Cleanup(w.Close)
+
+	for i := 0; i < 50; i++ {
+		w.Emit(store.HeartbeatEvent{ProviderID: "p"})
+	}
+
+	// Wait until both kinds of counter have been seen.
+	saw := func() (drop, flush bool) {
+		mu.Lock()
+		defer mu.Unlock()
+		for _, c := range calls {
+			switch c.name {
+			case "liveness_dropped_total":
+				drop = true
+			case "liveness_flush_rows_total":
+				flush = true
+			}
+		}
+		return
+	}
+	if !waitFor(func() bool {
+		d, f := saw()
+		return d && f
+	}, 2*time.Second) {
+		d, f := saw()
+		t.Fatalf("expected both counter kinds; drop=%v flush=%v calls=%v", d, f, calls)
+	}
+}
+
+func waitFor(predicate func() bool, deadline time.Duration) bool {
+	end := time.Now().Add(deadline)
+	for time.Now().Before(end) {
+		if predicate() {
+			return true
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	return predicate()
+}

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -418,6 +418,20 @@ type Registry struct {
 	onlineCount      atomic.Int64
 	modelProviders   map[string]*atomic.Int64
 	modelProvidersMu sync.Mutex
+
+	// Liveness sink — optional; nil-safe at every call site. Wired by
+	// cmd/coordinator/main.go so tests can construct a Registry without
+	// dragging in the liveness package.
+	liveness LivenessSink
+}
+
+// LivenessSink is the minimal interface the registry needs to record provider
+// liveness history. Defined here (rather than imported from the liveness pkg)
+// to avoid a package cycle and to keep tests free of liveness wiring.
+type LivenessSink interface {
+	EmitHeartbeat(event store.HeartbeatEvent)
+	OpenSession(providerID string)
+	CloseSession(providerID, reason string, lastHeartbeat time.Time, requestsServed, tokensGenerated int64)
 }
 
 // New creates a new Registry.
@@ -436,6 +450,13 @@ func New(logger *slog.Logger) *Registry {
 // When set, provider state and reputation are persisted to the store.
 func (r *Registry) SetStore(st store.Store) {
 	r.store = st
+}
+
+// SetLivenessSink wires the historical liveness recorder. Optional — when
+// nil, the registry behaves exactly as before (no per-heartbeat / per-session
+// persistence beyond the in-memory state).
+func (r *Registry) SetLivenessSink(sink LivenessSink) {
+	r.liveness = sink
 }
 
 // LoadStoredProviders loads provider records and reputation from the store
@@ -955,6 +976,12 @@ func (r *Registry) Register(id string, conn *websocket.Conn, msg *protocol.Regis
 	// Persist provider record to store (async).
 	r.persistProvider(p)
 
+	// Open a liveness session for this connection. Disconnect / evictStale
+	// will close it. Nil-safe.
+	if r.liveness != nil {
+		r.liveness.OpenSession(id)
+	}
+
 	return p
 }
 
@@ -1001,7 +1028,7 @@ func (r *Registry) DisconnectDuplicatesBySerial(keepID string, serial string) {
 			"kept_id", keepID,
 			"serial", serial,
 		)
-		r.Disconnect(id)
+		r.RecordDisconnect(id, store.DisconnectReasonDuplicateSerial)
 
 		if p != nil && p.Conn != nil {
 			p.Conn.Close(websocket.StatusNormalClosure, "replaced by new connection from same device")
@@ -1072,10 +1099,52 @@ func (r *Registry) Heartbeat(id string, msg *protocol.HeartbeatMessage) {
 
 	r.PersistProvider(p)
 
+	// Emit a heartbeat event to the liveness sink. Non-blocking — if the
+	// buffer is full the sink drops the event and increments its drop counter.
+	// Nil-safe.
+	if r.liveness != nil {
+		r.liveness.EmitHeartbeat(buildHeartbeatEvent(id, msg))
+	}
+
 	// Heartbeats can make a recovered slot routable again (for example after a
 	// crash auto-restart). Drain matching queues using the canonical scheduler
 	// rather than the legacy direct queue assignment path.
 	r.drainQueuedRequestsForModels(providerModelIDs(p))
+}
+
+// buildHeartbeatEvent converts a protocol HeartbeatMessage into the
+// store-level event row, mapping nullable fields and extracting indexed
+// columns from the optional BackendCapacity blob.
+func buildHeartbeatEvent(id string, msg *protocol.HeartbeatMessage) store.HeartbeatEvent {
+	ev := store.HeartbeatEvent{
+		ProviderID:     id,
+		At:             time.Now(),
+		Status:         msg.Status,
+		MemoryPressure: float32(msg.SystemMetrics.MemoryPressure),
+		CPUUsage:       float32(msg.SystemMetrics.CPUUsage),
+		ThermalState:   msg.SystemMetrics.ThermalState,
+	}
+	if msg.ActiveModel != nil {
+		ev.ActiveModel = *msg.ActiveModel
+	}
+	if msg.BackendCapacity != nil {
+		active := float32(msg.BackendCapacity.GPUMemoryActiveGB)
+		cache := float32(msg.BackendCapacity.GPUMemoryCacheGB)
+		ev.GPUMemoryActiveGB = &active
+		ev.GPUMemoryCacheGB = &cache
+		// Backend state aggregates slot states; "running" wins if any slot
+		// is serving, else first non-empty, else "".
+		for _, slot := range msg.BackendCapacity.Slots {
+			if slot.State == "running" {
+				ev.BackendState = "running"
+				break
+			}
+			if ev.BackendState == "" {
+				ev.BackendState = slot.State
+			}
+		}
+	}
+	return ev
 }
 
 func cumulativeDelta(previous, current int64) int64 {
@@ -1087,6 +1156,35 @@ func cumulativeDelta(previous, current int64) int64 {
 	}
 	// The provider process restarted and reset its in-memory counters.
 	return current
+}
+
+// RecordDisconnect closes the provider's liveness session with the given
+// reason (one of store.DisconnectReason* constants) and then delegates to
+// Disconnect. Use this from call sites that know the reason (clean WS close,
+// read error, stale-heartbeat eviction). Internal callers that don't have a
+// clean reason can keep calling Disconnect directly — those sessions get
+// swept on next coordinator restart.
+func (r *Registry) RecordDisconnect(id, reason string) {
+	if r.liveness != nil {
+		// Snapshot session-end counters and last-heartbeat under the
+		// provider lock so they're consistent with what Disconnect about to
+		// tear down.
+		r.mu.RLock()
+		p, ok := r.providers[id]
+		r.mu.RUnlock()
+
+		var lastHB time.Time
+		var reqs, toks int64
+		if ok {
+			p.mu.Lock()
+			lastHB = p.LastHeartbeat
+			reqs = p.Stats.RequestsServed
+			toks = p.Stats.TokensGenerated
+			p.mu.Unlock()
+		}
+		r.liveness.CloseSession(id, reason, lastHB, reqs, toks)
+	}
+	r.Disconnect(id)
 }
 
 // Disconnect removes a provider from the registry and cleans up pending requests.
@@ -2111,7 +2209,11 @@ func (r *Registry) ProviderIDs() []string {
 // that haven't sent a heartbeat within the given timeout. It stops when
 // the context is cancelled.
 func (r *Registry) StartEvictionLoop(ctx context.Context, timeout time.Duration) {
-	ticker := time.NewTicker(timeout / 3)
+	tickEvery := timeout / 3
+	if tickEvery < time.Millisecond {
+		tickEvery = time.Millisecond
+	}
+	ticker := time.NewTicker(tickEvery)
 	saferun.Go(r.logger, "registry.evictionLoop", func() {
 		defer ticker.Stop()
 		for {
@@ -2138,6 +2240,6 @@ func (r *Registry) evictStale(timeout time.Duration) {
 
 	for _, id := range stale {
 		r.logger.Warn("evicting stale provider", "provider_id", id, "timeout", timeout)
-		r.Disconnect(id)
+		r.RecordDisconnect(id, store.DisconnectReasonStaleHeartbeat)
 	}
 }

--- a/coordinator/store/interface.go
+++ b/coordinator/store/interface.go
@@ -351,6 +351,63 @@ type Store interface {
 	// Used by the ingestion handler and the coordinator emitter. The primary
 	// destination is Datadog; this is secondary for debugging.
 	InsertTelemetryEvents(ctx context.Context, events []TelemetryEventRecord) error
+
+	// --- Provider Liveness Persistence ---
+	//
+	// AppendHeartbeats bulk-inserts buffered heartbeat samples. Caller
+	// (coordinator/liveness.Writer) batches these on a background goroutine
+	// so the heartbeat handler stays non-blocking.
+	AppendHeartbeats(ctx context.Context, events []HeartbeatEvent) error
+
+	// OpenSession records that a provider connected. Returns the session ID
+	// so the caller can later close it.
+	OpenSession(ctx context.Context, s SessionStart) (int64, error)
+
+	// CloseSession marks a session closed with the given reason and timestamp.
+	// If lastHeartbeat is non-zero it is also recorded for clean MTBF math.
+	CloseSession(ctx context.Context, sessionID int64, reason string, at time.Time, lastHeartbeat time.Time, requestsServed, tokensGenerated int64) error
+
+	// CloseOrphanSessions closes any sessions left open (disconnected_at IS NULL),
+	// stamping the given reason and timestamp. Called once on coordinator boot
+	// to clean up sessions that survived a coordinator crash.
+	//
+	// coordinatorID, if non-empty, restricts the close to sessions owned by
+	// that coordinator instance. This is required for blue-green deploys
+	// where multiple coordinator processes run concurrently — without the
+	// filter, a new coordinator's boot would erroneously close the live
+	// sessions owned by the previous coordinator. Pass "" only when there
+	// is exactly one coordinator instance.
+	CloseOrphanSessions(ctx context.Context, reason string, at time.Time, coordinatorID string) (int64, error)
+
+	// DeleteHeartbeatsBefore deletes up to `limit` rows older than `before`.
+	// Returns the number of rows actually deleted. Used by the retention cron.
+	// Loop until 0 is returned to drain a backlog incrementally.
+	DeleteHeartbeatsBefore(ctx context.Context, before time.Time, limit int) (int64, error)
+
+	// ListSessionsSince returns sessions that connected or were open at any
+	// point in [since, now]. Used by the feature rollup. Rows with
+	// disconnected_at IS NULL are still-open sessions.
+	ListSessionsSince(ctx context.Context, since time.Time) ([]SessionRow, error)
+
+	// UpsertReliabilityFeatures writes one pre-aggregated reliability row.
+	UpsertReliabilityFeatures(ctx context.Context, row ReliabilityFeatures) error
+
+	// GetReliabilityFeatures returns the most recent reliability row for
+	// the given provider, or ErrNotFound if none exists yet.
+	GetReliabilityFeatures(ctx context.Context, providerID string) (*ReliabilityFeatures, error)
+
+	// ListReliabilityFeatures returns reliability rows for all providers
+	// meeting the given filter, ordered by uptime_pct DESC then provider_id.
+	ListReliabilityFeatures(ctx context.Context, filter ReliabilityFilter) ([]ReliabilityFeatures, error)
+
+	// ListRecentHeartbeats returns the most recent heartbeat rows for a
+	// provider, newest-first, capped at `limit`. Powers the
+	// /v1/providers/:id/heartbeats analytics endpoint.
+	ListRecentHeartbeats(ctx context.Context, providerID string, since time.Time, limit int) ([]HeartbeatEvent, error)
+
+	// ListRecentSessions is the read-side counterpart to ListSessionsSince
+	// scoped to one provider, newest-first, capped at `limit`.
+	ListRecentSessions(ctx context.Context, providerID string, since time.Time, limit int) ([]SessionRow, error)
 }
 
 // TelemetryEventRecord is the persistence-layer representation of a telemetry
@@ -702,4 +759,84 @@ type ReputationRecord struct {
 	AvgResponseTimeMs  int64 `json:"avg_response_time_ms"`
 	ChallengesPassed   int   `json:"challenges_passed"`
 	ChallengesFailed   int   `json:"challenges_failed"`
+}
+
+// HeartbeatEvent is one row appended to provider_heartbeats. Fields mirror
+// protocol.HeartbeatMessage but live here so the store stays free of protocol
+// imports. Pointer fields are nullable in the column (older providers may not
+// report them).
+type HeartbeatEvent struct {
+	ProviderID        string          `json:"provider_id"`
+	At                time.Time       `json:"at"`
+	Status            string          `json:"status"`
+	MemoryPressure    float32         `json:"memory_pressure"`
+	CPUUsage          float32         `json:"cpu_usage"`
+	ThermalState      string          `json:"thermal_state"`
+	MemoryAvailableGB *float32        `json:"memory_available_gb,omitempty"`
+	GPUMemoryActiveGB *float32        `json:"gpu_memory_active_gb,omitempty"`
+	GPUMemoryCacheGB  *float32        `json:"gpu_memory_cache_gb,omitempty"`
+	BackendState      string          `json:"backend_state"`
+	ActiveModel       string          `json:"active_model"`
+	Capacity          json.RawMessage `json:"capacity,omitempty"`
+}
+
+// SessionStart is the payload for opening a provider session.
+type SessionStart struct {
+	ProviderID    string    `json:"provider_id"`
+	ConnectedAt   time.Time `json:"connected_at"`
+	CoordinatorID string    `json:"coordinator_id"`
+}
+
+// Disconnect reason constants written to provider_sessions.disconnect_reason.
+// Stable, lowercase, snake_case so dashboards can filter on them.
+const (
+	DisconnectReasonCleanClose         = "clean_close"
+	DisconnectReasonReadError          = "read_error"
+	DisconnectReasonStaleHeartbeat     = "stale_heartbeat"
+	DisconnectReasonCoordinatorRestart = "coordinator_restart"
+	DisconnectReasonDuplicateSerial    = "duplicate_serial"
+)
+
+// SessionRow is one provider_sessions row in the shape consumers expect.
+// Open sessions have a zero DisconnectedAt.
+type SessionRow struct {
+	ID               int64     `json:"id"`
+	ProviderID       string    `json:"provider_id"`
+	ConnectedAt      time.Time `json:"connected_at"`
+	DisconnectedAt   time.Time `json:"disconnected_at,omitempty"`
+	DisconnectReason string    `json:"disconnect_reason,omitempty"`
+	LastHeartbeatAt  time.Time `json:"last_heartbeat_at,omitempty"`
+	RequestsServed   int64     `json:"requests_served"`
+	TokensGenerated  int64     `json:"tokens_generated"`
+	CoordinatorID    string    `json:"coordinator_id,omitempty"`
+}
+
+// ReliabilityFeatures is one provider_reliability_features row. The hourly
+// availability and disconnect reason histograms are pre-serialized JSON so
+// the store impls don't need to know the consumer shape.
+type ReliabilityFeatures struct {
+	ProviderID                 string          `json:"provider_id"`
+	UpdatedAt                  time.Time       `json:"updated_at"`
+	WindowDays                 int             `json:"window_days"`
+	UptimePct                  float64         `json:"uptime_pct"`
+	SessionsCount              int             `json:"sessions_count"`
+	MTBFSeconds                int64           `json:"mtbf_seconds"`
+	MedianSessionSeconds       int64           `json:"median_session_seconds"`
+	P10SessionSeconds          int64           `json:"p10_session_seconds"`
+	P90SessionSeconds          int64           `json:"p90_session_seconds"`
+	HourlyAvailability         json.RawMessage `json:"hourly_availability,omitempty"`
+	DisconnectReasons          json.RawMessage `json:"disconnect_reasons,omitempty"`
+	PStays4h                   float64         `json:"p_stays_4h"`
+	PStays8h                   float64         `json:"p_stays_8h"`
+	LastDisconnectAt           time.Time       `json:"last_disconnect_at,omitempty"`
+	LastSessionDurationSeconds int64           `json:"last_session_duration_seconds"`
+}
+
+// ReliabilityFilter narrows the providers returned from
+// ListReliabilityFeatures. Zero values mean "no filter on that field".
+type ReliabilityFilter struct {
+	MinUptimePct float64
+	MinPStays4h  float64
+	MinPStays8h  float64
+	Limit        int
 }

--- a/coordinator/store/liveness_test.go
+++ b/coordinator/store/liveness_test.go
@@ -1,0 +1,197 @@
+package store
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+// runLivenessSuite exercises the liveness methods against an arbitrary Store
+// implementation. Called once per backend (memory + postgres) so both stay
+// in sync. Per CLAUDE.md: prefer live-isolated over mocks — we instantiate
+// each backend directly.
+func runLivenessSuite(t *testing.T, s Store) {
+	t.Helper()
+	ctx := context.Background()
+	provider := "prov-test"
+
+	t.Run("AppendHeartbeats empty is a noop", func(t *testing.T) {
+		if err := s.AppendHeartbeats(ctx, nil); err != nil {
+			t.Fatalf("AppendHeartbeats nil: %v", err)
+		}
+	})
+
+	t.Run("AppendHeartbeats writes rows", func(t *testing.T) {
+		now := time.Now().Truncate(time.Microsecond)
+		mp := float32(0.42)
+		gpu := float32(8.5)
+		events := []HeartbeatEvent{
+			{
+				ProviderID:        provider,
+				At:                now,
+				Status:            "idle",
+				MemoryPressure:    0.4,
+				CPUUsage:          0.2,
+				ThermalState:      "nominal",
+				MemoryAvailableGB: &mp, // arbitrary nullable
+				GPUMemoryActiveGB: &gpu,
+				BackendState:      "running",
+				ActiveModel:       "qwen3.5-27b",
+				Capacity:          json.RawMessage(`{"slots":[]}`),
+			},
+			{
+				ProviderID:     provider,
+				At:             now.Add(5 * time.Second),
+				Status:         "serving",
+				MemoryPressure: 0.6,
+				CPUUsage:       0.3,
+				ThermalState:   "fair",
+				BackendState:   "running",
+				ActiveModel:    "qwen3.5-27b",
+			},
+		}
+		if err := s.AppendHeartbeats(ctx, events); err != nil {
+			t.Fatalf("AppendHeartbeats: %v", err)
+		}
+	})
+
+	t.Run("OpenSession returns id, CloseSession is idempotent", func(t *testing.T) {
+		start := time.Now()
+		id, err := s.OpenSession(ctx, SessionStart{
+			ProviderID:    provider,
+			ConnectedAt:   start,
+			CoordinatorID: "coord-A",
+		})
+		if err != nil {
+			t.Fatalf("OpenSession: %v", err)
+		}
+		if id == 0 {
+			t.Fatalf("expected non-zero session id, got 0")
+		}
+
+		// Close once with reason.
+		closedAt := start.Add(30 * time.Second)
+		lastHB := start.Add(25 * time.Second)
+		if err := s.CloseSession(ctx, id, DisconnectReasonCleanClose, closedAt, lastHB, 7, 1234); err != nil {
+			t.Fatalf("CloseSession: %v", err)
+		}
+
+		// Closing again must NOT error (idempotent) but also must not flip the
+		// reason — the WHERE clause requires disconnected_at IS NULL.
+		if err := s.CloseSession(ctx, id, DisconnectReasonReadError, closedAt.Add(time.Second), lastHB, 99, 99999); err != nil {
+			t.Fatalf("CloseSession second call: %v", err)
+		}
+	})
+
+	t.Run("CloseOrphanSessions only touches open rows", func(t *testing.T) {
+		// Open three sessions; close one cleanly; orphan-close the rest.
+		id1, err := s.OpenSession(ctx, SessionStart{ProviderID: "orphan-A", ConnectedAt: time.Now(), CoordinatorID: "coord-A"})
+		if err != nil {
+			t.Fatalf("OpenSession A: %v", err)
+		}
+		_, err = s.OpenSession(ctx, SessionStart{ProviderID: "orphan-B", ConnectedAt: time.Now(), CoordinatorID: "coord-A"})
+		if err != nil {
+			t.Fatalf("OpenSession B: %v", err)
+		}
+		_, err = s.OpenSession(ctx, SessionStart{ProviderID: "orphan-C", ConnectedAt: time.Now(), CoordinatorID: "coord-A"})
+		if err != nil {
+			t.Fatalf("OpenSession C: %v", err)
+		}
+
+		// Cleanly close A so orphan-sweep should NOT touch it.
+		closedAt := time.Now()
+		if err := s.CloseSession(ctx, id1, DisconnectReasonCleanClose, closedAt, time.Time{}, 0, 0); err != nil {
+			t.Fatalf("CloseSession A: %v", err)
+		}
+
+		closed, err := s.CloseOrphanSessions(ctx, DisconnectReasonCoordinatorRestart, time.Now(), "coord-A")
+		if err != nil {
+			t.Fatalf("CloseOrphanSessions: %v", err)
+		}
+		if closed < 2 {
+			t.Fatalf("expected ≥2 orphan sessions closed, got %d", closed)
+		}
+
+		// Running again should be a no-op (all already closed).
+		closed2, err := s.CloseOrphanSessions(ctx, DisconnectReasonCoordinatorRestart, time.Now(), "coord-A")
+		if err != nil {
+			t.Fatalf("CloseOrphanSessions second call: %v", err)
+		}
+		if closed2 != 0 {
+			t.Fatalf("expected 0 on re-run, got %d", closed2)
+		}
+	})
+
+	t.Run("DeleteHeartbeatsBefore respects limit and cutoff", func(t *testing.T) {
+		// Insert 5 old + 3 fresh.
+		base := time.Now().Add(-48 * time.Hour)
+		old := make([]HeartbeatEvent, 5)
+		for i := range old {
+			old[i] = HeartbeatEvent{
+				ProviderID:   "retention",
+				At:           base.Add(time.Duration(i) * time.Minute),
+				Status:       "idle",
+				ThermalState: "nominal",
+			}
+		}
+		fresh := []HeartbeatEvent{
+			{ProviderID: "retention", At: time.Now(), Status: "idle", ThermalState: "nominal"},
+			{ProviderID: "retention", At: time.Now().Add(-time.Minute), Status: "idle", ThermalState: "nominal"},
+			{ProviderID: "retention", At: time.Now().Add(-2 * time.Minute), Status: "idle", ThermalState: "nominal"},
+		}
+		if err := s.AppendHeartbeats(ctx, append(old, fresh...)); err != nil {
+			t.Fatalf("AppendHeartbeats: %v", err)
+		}
+
+		// Cut off 24h ago, batch-limit 3 → expect 3 deleted on first call,
+		// then 2 remaining old, then 0 once drained.
+		cutoff := time.Now().Add(-24 * time.Hour)
+		deleted, err := s.DeleteHeartbeatsBefore(ctx, cutoff, 3)
+		if err != nil {
+			t.Fatalf("DeleteHeartbeatsBefore: %v", err)
+		}
+		if deleted != 3 {
+			t.Fatalf("first call: expected 3 deleted, got %d", deleted)
+		}
+
+		deleted, err = s.DeleteHeartbeatsBefore(ctx, cutoff, 100)
+		if err != nil {
+			t.Fatalf("DeleteHeartbeatsBefore drain: %v", err)
+		}
+		if deleted != 2 {
+			t.Fatalf("drain call: expected 2 deleted, got %d", deleted)
+		}
+
+		deleted, err = s.DeleteHeartbeatsBefore(ctx, cutoff, 100)
+		if err != nil {
+			t.Fatalf("DeleteHeartbeatsBefore empty: %v", err)
+		}
+		if deleted != 0 {
+			t.Fatalf("empty call: expected 0 deleted, got %d", deleted)
+		}
+	})
+
+	t.Run("DeleteHeartbeatsBefore with non-positive limit is a noop", func(t *testing.T) {
+		deleted, err := s.DeleteHeartbeatsBefore(ctx, time.Now(), 0)
+		if err != nil {
+			t.Fatalf("DeleteHeartbeatsBefore(0): %v", err)
+		}
+		if deleted != 0 {
+			t.Fatalf("expected 0 deleted with limit=0, got %d", deleted)
+		}
+	})
+}
+
+// TestMemoryLiveness exercises the in-memory backend.
+func TestMemoryLiveness(t *testing.T) {
+	s := NewMemory("")
+	runLivenessSuite(t, s)
+}
+
+// TestPostgresLiveness exercises the Postgres backend. Skipped without
+// DATABASE_URL (mirrors the convention in postgres_test.go).
+func TestPostgresLiveness(t *testing.T) {
+	s := testPostgresStore(t)
+	runLivenessSuite(t, s)
+}

--- a/coordinator/store/memory.go
+++ b/coordinator/store/memory.go
@@ -95,6 +95,31 @@ type MemoryStore struct {
 
 	// Telemetry ring buffer (bounded at memTelemetryCap)
 	telemetryEvents []TelemetryEventRecord
+
+	// Provider liveness — historical heartbeats and session intervals.
+	// heartbeats is unbounded in memory mode; callers wanting retention must
+	// run the same DeleteHeartbeatsBefore cron the postgres backend runs.
+	// (Memory store is for dev/test; not expected to accumulate forever.)
+	heartbeats     []HeartbeatEvent
+	sessions       map[int64]*memorySession
+	sessionsByOpen map[string]int64 // providerID → most-recent open sessionID (for fast lookup)
+	sessionSeq     int64
+
+	// Pre-aggregated reliability features (one row per provider).
+	reliability map[string]*ReliabilityFeatures
+}
+
+// memorySession mirrors a row in provider_sessions.
+type memorySession struct {
+	ID               int64
+	ProviderID       string
+	ConnectedAt      time.Time
+	DisconnectedAt   time.Time // zero if open
+	DisconnectReason string
+	LastHeartbeatAt  time.Time
+	RequestsServed   int64
+	TokensGenerated  int64
+	CoordinatorID    string
 }
 
 // NewMemory creates a new MemoryStore. If adminKey is non-empty it is
@@ -135,6 +160,10 @@ func NewMemory(adminKey string) *MemoryStore {
 		reputationRecords:             make(map[string]*ReputationRecord),
 		serialToProviderID:            make(map[string]string),
 		telemetryEvents:               make([]TelemetryEventRecord, 0, memTelemetryCap),
+		heartbeats:                    make([]HeartbeatEvent, 0),
+		sessions:                      make(map[int64]*memorySession),
+		sessionsByOpen:                make(map[string]int64),
+		reliability:                   make(map[string]*ReliabilityFeatures),
 	}
 	if adminKey != "" {
 		s.keys[adminKey] = true
@@ -1666,4 +1695,246 @@ func (s *MemoryStore) GetReputation(_ context.Context, providerID string) (*Repu
 func sha256Hex(s string) string {
 	h := sha256.Sum256([]byte(s))
 	return hex.EncodeToString(h[:])
+}
+
+// --- Provider Liveness ---
+
+func (s *MemoryStore) AppendHeartbeats(_ context.Context, events []HeartbeatEvent) error {
+	if len(events) == 0 {
+		return nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.heartbeats = append(s.heartbeats, events...)
+	return nil
+}
+
+func (s *MemoryStore) OpenSession(_ context.Context, sess SessionStart) (int64, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	connectedAt := sess.ConnectedAt
+	if connectedAt.IsZero() {
+		connectedAt = time.Now()
+	}
+	s.sessionSeq++
+	row := &memorySession{
+		ID:            s.sessionSeq,
+		ProviderID:    sess.ProviderID,
+		ConnectedAt:   connectedAt,
+		CoordinatorID: sess.CoordinatorID,
+	}
+	s.sessions[row.ID] = row
+	s.sessionsByOpen[sess.ProviderID] = row.ID
+	return row.ID, nil
+}
+
+func (s *MemoryStore) CloseSession(_ context.Context, sessionID int64, reason string, at time.Time, lastHeartbeat time.Time, requestsServed, tokensGenerated int64) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	row, ok := s.sessions[sessionID]
+	if !ok {
+		return fmt.Errorf("session %d not found", sessionID)
+	}
+	if !row.DisconnectedAt.IsZero() {
+		return nil // idempotent: already closed
+	}
+	if at.IsZero() {
+		at = time.Now()
+	}
+	row.DisconnectedAt = at
+	row.DisconnectReason = reason
+	if !lastHeartbeat.IsZero() {
+		row.LastHeartbeatAt = lastHeartbeat
+	}
+	row.RequestsServed = requestsServed
+	row.TokensGenerated = tokensGenerated
+	if openID, ok := s.sessionsByOpen[row.ProviderID]; ok && openID == sessionID {
+		delete(s.sessionsByOpen, row.ProviderID)
+	}
+	return nil
+}
+
+func (s *MemoryStore) CloseOrphanSessions(_ context.Context, reason string, at time.Time, coordinatorID string) (int64, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if at.IsZero() {
+		at = time.Now()
+	}
+	var closed int64
+	for _, row := range s.sessions {
+		if !row.DisconnectedAt.IsZero() {
+			continue
+		}
+		if coordinatorID != "" && row.CoordinatorID != coordinatorID {
+			continue
+		}
+		row.DisconnectedAt = at
+		row.DisconnectReason = reason
+		delete(s.sessionsByOpen, row.ProviderID)
+		closed++
+	}
+	return closed, nil
+}
+
+func (s *MemoryStore) DeleteHeartbeatsBefore(_ context.Context, before time.Time, limit int) (int64, error) {
+	if limit <= 0 {
+		return 0, nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Walk the slice and drop rows older than `before`, up to `limit`.
+	// We can't assume chronological order — out-of-order heartbeats can
+	// arrive on coordinator restart or under clock skew.
+	kept := s.heartbeats[:0]
+	var deleted int64
+	for _, hb := range s.heartbeats {
+		if deleted < int64(limit) && hb.At.Before(before) {
+			deleted++
+			continue
+		}
+		kept = append(kept, hb)
+	}
+	s.heartbeats = kept
+	return deleted, nil
+}
+
+func (s *MemoryStore) ListSessionsSince(_ context.Context, since time.Time) ([]SessionRow, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	out := make([]SessionRow, 0, len(s.sessions))
+	for _, sess := range s.sessions {
+		// Include if still open, or closed within window.
+		if !sess.DisconnectedAt.IsZero() && sess.DisconnectedAt.Before(since) {
+			continue
+		}
+		out = append(out, memSessionToRow(sess))
+	}
+	return out, nil
+}
+
+func (s *MemoryStore) ListRecentSessions(_ context.Context, providerID string, since time.Time, limit int) ([]SessionRow, error) {
+	if limit <= 0 {
+		limit = 100
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	matches := make([]*memorySession, 0)
+	for _, sess := range s.sessions {
+		if sess.ProviderID != providerID {
+			continue
+		}
+		if sess.ConnectedAt.Before(since) {
+			continue
+		}
+		matches = append(matches, sess)
+	}
+	sort.Slice(matches, func(i, j int) bool {
+		return matches[i].ConnectedAt.After(matches[j].ConnectedAt)
+	})
+	if len(matches) > limit {
+		matches = matches[:limit]
+	}
+	out := make([]SessionRow, len(matches))
+	for i, sess := range matches {
+		out[i] = memSessionToRow(sess)
+	}
+	return out, nil
+}
+
+func (s *MemoryStore) ListRecentHeartbeats(_ context.Context, providerID string, since time.Time, limit int) ([]HeartbeatEvent, error) {
+	if limit <= 0 {
+		limit = 100
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	var matched []HeartbeatEvent
+	for _, hb := range s.heartbeats {
+		if hb.ProviderID == providerID && !hb.At.Before(since) {
+			matched = append(matched, hb)
+		}
+	}
+	sort.Slice(matched, func(i, j int) bool {
+		return matched[i].At.After(matched[j].At)
+	})
+	if len(matched) > limit {
+		matched = matched[:limit]
+	}
+	return matched, nil
+}
+
+func (s *MemoryStore) UpsertReliabilityFeatures(_ context.Context, row ReliabilityFeatures) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	cp := row
+	cp.UpdatedAt = time.Now()
+	s.reliability[row.ProviderID] = &cp
+	return nil
+}
+
+func (s *MemoryStore) GetReliabilityFeatures(_ context.Context, providerID string) (*ReliabilityFeatures, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	r, ok := s.reliability[providerID]
+	if !ok {
+		return nil, nil
+	}
+	cp := *r
+	return &cp, nil
+}
+
+func (s *MemoryStore) ListReliabilityFeatures(_ context.Context, filter ReliabilityFilter) ([]ReliabilityFeatures, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	limit := filter.Limit
+	if limit <= 0 || limit > 500 {
+		limit = 100
+	}
+
+	out := make([]ReliabilityFeatures, 0, len(s.reliability))
+	for _, r := range s.reliability {
+		if r.UptimePct < filter.MinUptimePct {
+			continue
+		}
+		if r.PStays4h < filter.MinPStays4h {
+			continue
+		}
+		if r.PStays8h < filter.MinPStays8h {
+			continue
+		}
+		out = append(out, *r)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].UptimePct != out[j].UptimePct {
+			return out[i].UptimePct > out[j].UptimePct
+		}
+		return out[i].ProviderID < out[j].ProviderID
+	})
+	if len(out) > limit {
+		out = out[:limit]
+	}
+	return out, nil
+}
+
+// memSessionToRow converts the internal memorySession struct (memory.go) into
+// the exported SessionRow shape used by store consumers.
+func memSessionToRow(sess *memorySession) SessionRow {
+	return SessionRow{
+		ID:               sess.ID,
+		ProviderID:       sess.ProviderID,
+		ConnectedAt:      sess.ConnectedAt,
+		DisconnectedAt:   sess.DisconnectedAt,
+		DisconnectReason: sess.DisconnectReason,
+		LastHeartbeatAt:  sess.LastHeartbeatAt,
+		RequestsServed:   sess.RequestsServed,
+		TokensGenerated:  sess.TokensGenerated,
+		CoordinatorID:    sess.CoordinatorID,
+	}
 }

--- a/coordinator/store/postgres.go
+++ b/coordinator/store/postgres.go
@@ -477,6 +477,71 @@ func (s *PostgresStore) migrate(ctx context.Context) error {
 			WHERE account_id = b.account_id
 			  AND entry_type IN ('payout', 'referral_reward', 'admin_reward', 'stripe_payout')
 		), 0)) WHERE b.withdrawable_micro_usd = 0`,
+
+		// Provider liveness — historical heartbeats, session intervals, and
+		// pre-aggregated reliability features. Powers the analytics service
+		// and future job-aware scheduling. See plan: /plans/what-i-d-extend-given-crispy-rivest.md
+		`CREATE TABLE IF NOT EXISTS provider_heartbeats (
+			id BIGSERIAL PRIMARY KEY,
+			provider_id TEXT NOT NULL,
+			at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			status TEXT NOT NULL DEFAULT '',
+			memory_pressure REAL NOT NULL DEFAULT 0,
+			cpu_usage REAL NOT NULL DEFAULT 0,
+			thermal_state TEXT NOT NULL DEFAULT '',
+			memory_available_gb REAL,
+			gpu_memory_active_gb REAL,
+			gpu_memory_cache_gb REAL,
+			backend_state TEXT NOT NULL DEFAULT '',
+			active_model TEXT NOT NULL DEFAULT '',
+			capacity JSONB
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_provider_heartbeats_provider_at ON provider_heartbeats(provider_id, at DESC)`,
+		`CREATE INDEX IF NOT EXISTS idx_provider_heartbeats_at ON provider_heartbeats(at DESC)`,
+
+		`CREATE TABLE IF NOT EXISTS provider_heartbeats_hourly (
+			provider_id TEXT NOT NULL,
+			hour TIMESTAMPTZ NOT NULL,
+			heartbeat_count INT NOT NULL DEFAULT 0,
+			avg_memory_pressure REAL NOT NULL DEFAULT 0,
+			avg_cpu_usage REAL NOT NULL DEFAULT 0,
+			max_thermal_state TEXT NOT NULL DEFAULT '',
+			avg_memory_available_gb REAL,
+			PRIMARY KEY (provider_id, hour)
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_provider_heartbeats_hourly_hour ON provider_heartbeats_hourly(hour DESC)`,
+
+		`CREATE TABLE IF NOT EXISTS provider_sessions (
+			id BIGSERIAL PRIMARY KEY,
+			provider_id TEXT NOT NULL,
+			connected_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			disconnected_at TIMESTAMPTZ,
+			disconnect_reason TEXT NOT NULL DEFAULT '',
+			last_heartbeat_at TIMESTAMPTZ,
+			requests_served BIGINT NOT NULL DEFAULT 0,
+			tokens_generated BIGINT NOT NULL DEFAULT 0,
+			coordinator_id TEXT NOT NULL DEFAULT ''
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_provider_sessions_provider_connected ON provider_sessions(provider_id, connected_at DESC)`,
+		`CREATE INDEX IF NOT EXISTS idx_provider_sessions_open ON provider_sessions(provider_id) WHERE disconnected_at IS NULL`,
+
+		`CREATE TABLE IF NOT EXISTS provider_reliability_features (
+			provider_id TEXT PRIMARY KEY,
+			updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			window_days INT NOT NULL DEFAULT 14,
+			uptime_pct REAL NOT NULL DEFAULT 0,
+			sessions_count INT NOT NULL DEFAULT 0,
+			mtbf_seconds BIGINT NOT NULL DEFAULT 0,
+			median_session_seconds BIGINT NOT NULL DEFAULT 0,
+			p10_session_seconds BIGINT NOT NULL DEFAULT 0,
+			p90_session_seconds BIGINT NOT NULL DEFAULT 0,
+			hourly_availability JSONB NOT NULL DEFAULT '{}'::jsonb,
+			disconnect_reasons JSONB NOT NULL DEFAULT '{}'::jsonb,
+			p_stays_4h REAL NOT NULL DEFAULT 0,
+			p_stays_8h REAL NOT NULL DEFAULT 0,
+			last_disconnect_at TIMESTAMPTZ,
+			last_session_duration_seconds BIGINT NOT NULL DEFAULT 0
+		)`,
 	}
 
 	for _, m := range migrations {
@@ -2655,4 +2720,413 @@ func (s *PostgresStore) GetReputation(ctx context.Context, providerID string) (*
 		return nil, fmt.Errorf("store: reputation not found: %w", err)
 	}
 	return &rep, nil
+}
+
+// --- Provider Liveness ---
+
+// heartbeatColumns mirrors the column order used by AppendHeartbeats CopyFrom.
+var heartbeatColumns = []string{
+	"provider_id", "at", "status", "memory_pressure", "cpu_usage",
+	"thermal_state", "memory_available_gb", "gpu_memory_active_gb",
+	"gpu_memory_cache_gb", "backend_state", "active_model", "capacity",
+}
+
+func nullableFloat32(p *float32) any {
+	if p == nil {
+		return nil
+	}
+	return *p
+}
+
+func (s *PostgresStore) AppendHeartbeats(ctx context.Context, events []HeartbeatEvent) error {
+	if len(events) == 0 {
+		return nil
+	}
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	rows := make([][]any, len(events))
+	for i, e := range events {
+		var capacity any
+		if len(e.Capacity) > 0 {
+			capacity = []byte(e.Capacity)
+		}
+		rows[i] = []any{
+			e.ProviderID,
+			e.At,
+			e.Status,
+			e.MemoryPressure,
+			e.CPUUsage,
+			e.ThermalState,
+			nullableFloat32(e.MemoryAvailableGB),
+			nullableFloat32(e.GPUMemoryActiveGB),
+			nullableFloat32(e.GPUMemoryCacheGB),
+			e.BackendState,
+			e.ActiveModel,
+			capacity,
+		}
+	}
+
+	if _, err := s.pool.CopyFrom(ctx,
+		pgx.Identifier{"provider_heartbeats"},
+		heartbeatColumns,
+		pgx.CopyFromRows(rows),
+	); err != nil {
+		return fmt.Errorf("store: bulk insert heartbeats: %w", err)
+	}
+	return nil
+}
+
+func (s *PostgresStore) OpenSession(ctx context.Context, sess SessionStart) (int64, error) {
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	connectedAt := sess.ConnectedAt
+	if connectedAt.IsZero() {
+		connectedAt = time.Now()
+	}
+
+	var id int64
+	err := s.pool.QueryRow(ctx,
+		`INSERT INTO provider_sessions (provider_id, connected_at, coordinator_id)
+		 VALUES ($1, $2, $3) RETURNING id`,
+		sess.ProviderID, connectedAt, sess.CoordinatorID,
+	).Scan(&id)
+	if err != nil {
+		return 0, fmt.Errorf("store: open session: %w", err)
+	}
+	return id, nil
+}
+
+func (s *PostgresStore) CloseSession(ctx context.Context, sessionID int64, reason string, at time.Time, lastHeartbeat time.Time, requestsServed, tokensGenerated int64) error {
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	if at.IsZero() {
+		at = time.Now()
+	}
+	var lastHB any
+	if !lastHeartbeat.IsZero() {
+		lastHB = lastHeartbeat
+	}
+
+	_, err := s.pool.Exec(ctx,
+		`UPDATE provider_sessions
+		   SET disconnected_at = $2,
+		       disconnect_reason = $3,
+		       last_heartbeat_at = COALESCE($4, last_heartbeat_at),
+		       requests_served = $5,
+		       tokens_generated = $6
+		 WHERE id = $1 AND disconnected_at IS NULL`,
+		sessionID, at, reason, lastHB, requestsServed, tokensGenerated,
+	)
+	if err != nil {
+		return fmt.Errorf("store: close session: %w", err)
+	}
+	return nil
+}
+
+func (s *PostgresStore) CloseOrphanSessions(ctx context.Context, reason string, at time.Time, coordinatorID string) (int64, error) {
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	if at.IsZero() {
+		at = time.Now()
+	}
+	// The $3 = '' OR clause keeps the old behavior available for callers
+	// running in a single-coordinator deployment (or in tests); production
+	// callers should always pass a non-empty coordinatorID to avoid
+	// stomping on sessions owned by a sibling coordinator process.
+	tag, err := s.pool.Exec(ctx,
+		`UPDATE provider_sessions
+		   SET disconnected_at = $1, disconnect_reason = $2
+		 WHERE disconnected_at IS NULL
+		   AND ($3 = '' OR coordinator_id = $3)`,
+		at, reason, coordinatorID,
+	)
+	if err != nil {
+		return 0, fmt.Errorf("store: close orphan sessions: %w", err)
+	}
+	return tag.RowsAffected(), nil
+}
+
+func (s *PostgresStore) DeleteHeartbeatsBefore(ctx context.Context, before time.Time, limit int) (int64, error) {
+	if limit <= 0 {
+		return 0, nil
+	}
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	// Two-step delete keeps the lock set small: pick rows in an unindexed
+	// subquery (planner uses idx_provider_heartbeats_at), then delete by id.
+	tag, err := s.pool.Exec(ctx,
+		`DELETE FROM provider_heartbeats
+		 WHERE id IN (
+		   SELECT id FROM provider_heartbeats
+		   WHERE at < $1
+		   ORDER BY at ASC
+		   LIMIT $2
+		 )`,
+		before, limit,
+	)
+	if err != nil {
+		return 0, fmt.Errorf("store: delete heartbeats: %w", err)
+	}
+	return tag.RowsAffected(), nil
+}
+
+func (s *PostgresStore) ListSessionsSince(ctx context.Context, since time.Time) ([]SessionRow, error) {
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	rows, err := s.pool.Query(ctx,
+		`SELECT id, provider_id, connected_at, disconnected_at,
+		        disconnect_reason, last_heartbeat_at,
+		        requests_served, tokens_generated, coordinator_id
+		   FROM provider_sessions
+		  WHERE disconnected_at IS NULL OR disconnected_at >= $1`,
+		since,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("store: list sessions since: %w", err)
+	}
+	defer rows.Close()
+	return scanSessionRows(rows)
+}
+
+func (s *PostgresStore) ListRecentSessions(ctx context.Context, providerID string, since time.Time, limit int) ([]SessionRow, error) {
+	if limit <= 0 {
+		limit = 100
+	}
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	rows, err := s.pool.Query(ctx,
+		`SELECT id, provider_id, connected_at, disconnected_at,
+		        disconnect_reason, last_heartbeat_at,
+		        requests_served, tokens_generated, coordinator_id
+		   FROM provider_sessions
+		  WHERE provider_id = $1 AND connected_at >= $2
+		  ORDER BY connected_at DESC
+		  LIMIT $3`,
+		providerID, since, limit,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("store: list recent sessions: %w", err)
+	}
+	defer rows.Close()
+	return scanSessionRows(rows)
+}
+
+func (s *PostgresStore) ListRecentHeartbeats(ctx context.Context, providerID string, since time.Time, limit int) ([]HeartbeatEvent, error) {
+	if limit <= 0 {
+		limit = 100
+	}
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	rows, err := s.pool.Query(ctx,
+		`SELECT provider_id, at, status, memory_pressure, cpu_usage, thermal_state,
+		        memory_available_gb, gpu_memory_active_gb, gpu_memory_cache_gb,
+		        backend_state, active_model, capacity
+		   FROM provider_heartbeats
+		  WHERE provider_id = $1 AND at >= $2
+		  ORDER BY at DESC
+		  LIMIT $3`,
+		providerID, since, limit,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("store: list recent heartbeats: %w", err)
+	}
+	defer rows.Close()
+
+	var out []HeartbeatEvent
+	for rows.Next() {
+		var (
+			hb       HeartbeatEvent
+			memAvail *float32
+			gpuAct   *float32
+			gpuCache *float32
+			capacity []byte
+		)
+		if err := rows.Scan(
+			&hb.ProviderID, &hb.At, &hb.Status, &hb.MemoryPressure, &hb.CPUUsage,
+			&hb.ThermalState, &memAvail, &gpuAct, &gpuCache,
+			&hb.BackendState, &hb.ActiveModel, &capacity,
+		); err != nil {
+			return nil, fmt.Errorf("store: scan heartbeat: %w", err)
+		}
+		hb.MemoryAvailableGB = memAvail
+		hb.GPUMemoryActiveGB = gpuAct
+		hb.GPUMemoryCacheGB = gpuCache
+		if len(capacity) > 0 {
+			hb.Capacity = capacity
+		}
+		out = append(out, hb)
+	}
+	return out, rows.Err()
+}
+
+func (s *PostgresStore) UpsertReliabilityFeatures(ctx context.Context, row ReliabilityFeatures) error {
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	var lastDisc any
+	if !row.LastDisconnectAt.IsZero() {
+		lastDisc = row.LastDisconnectAt
+	}
+	_, err := s.pool.Exec(ctx,
+		`INSERT INTO provider_reliability_features (
+		   provider_id, updated_at, window_days, uptime_pct, sessions_count,
+		   mtbf_seconds, median_session_seconds, p10_session_seconds, p90_session_seconds,
+		   hourly_availability, disconnect_reasons, p_stays_4h, p_stays_8h,
+		   last_disconnect_at, last_session_duration_seconds
+		 ) VALUES ($1, NOW(), $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
+		 ON CONFLICT (provider_id) DO UPDATE SET
+		   updated_at = NOW(),
+		   window_days = EXCLUDED.window_days,
+		   uptime_pct = EXCLUDED.uptime_pct,
+		   sessions_count = EXCLUDED.sessions_count,
+		   mtbf_seconds = EXCLUDED.mtbf_seconds,
+		   median_session_seconds = EXCLUDED.median_session_seconds,
+		   p10_session_seconds = EXCLUDED.p10_session_seconds,
+		   p90_session_seconds = EXCLUDED.p90_session_seconds,
+		   hourly_availability = EXCLUDED.hourly_availability,
+		   disconnect_reasons = EXCLUDED.disconnect_reasons,
+		   p_stays_4h = EXCLUDED.p_stays_4h,
+		   p_stays_8h = EXCLUDED.p_stays_8h,
+		   last_disconnect_at = EXCLUDED.last_disconnect_at,
+		   last_session_duration_seconds = EXCLUDED.last_session_duration_seconds`,
+		row.ProviderID, row.WindowDays, row.UptimePct, row.SessionsCount,
+		row.MTBFSeconds, row.MedianSessionSeconds, row.P10SessionSeconds, row.P90SessionSeconds,
+		[]byte(row.HourlyAvailability), []byte(row.DisconnectReasons),
+		row.PStays4h, row.PStays8h, lastDisc, row.LastSessionDurationSeconds,
+	)
+	if err != nil {
+		return fmt.Errorf("store: upsert reliability features: %w", err)
+	}
+	return nil
+}
+
+func (s *PostgresStore) GetReliabilityFeatures(ctx context.Context, providerID string) (*ReliabilityFeatures, error) {
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	var (
+		row      ReliabilityFeatures
+		lastDisc *time.Time
+		hourly   []byte
+		reasons  []byte
+	)
+	err := s.pool.QueryRow(ctx,
+		`SELECT provider_id, updated_at, window_days, uptime_pct, sessions_count,
+		        mtbf_seconds, median_session_seconds, p10_session_seconds, p90_session_seconds,
+		        hourly_availability, disconnect_reasons, p_stays_4h, p_stays_8h,
+		        last_disconnect_at, last_session_duration_seconds
+		   FROM provider_reliability_features WHERE provider_id = $1`,
+		providerID,
+	).Scan(
+		&row.ProviderID, &row.UpdatedAt, &row.WindowDays, &row.UptimePct, &row.SessionsCount,
+		&row.MTBFSeconds, &row.MedianSessionSeconds, &row.P10SessionSeconds, &row.P90SessionSeconds,
+		&hourly, &reasons, &row.PStays4h, &row.PStays8h,
+		&lastDisc, &row.LastSessionDurationSeconds,
+	)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("store: get reliability features: %w", err)
+	}
+	if lastDisc != nil {
+		row.LastDisconnectAt = *lastDisc
+	}
+	row.HourlyAvailability = hourly
+	row.DisconnectReasons = reasons
+	return &row, nil
+}
+
+func (s *PostgresStore) ListReliabilityFeatures(ctx context.Context, filter ReliabilityFilter) ([]ReliabilityFeatures, error) {
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	limit := filter.Limit
+	if limit <= 0 || limit > 500 {
+		limit = 100
+	}
+
+	rows, err := s.pool.Query(ctx,
+		`SELECT provider_id, updated_at, window_days, uptime_pct, sessions_count,
+		        mtbf_seconds, median_session_seconds, p10_session_seconds, p90_session_seconds,
+		        hourly_availability, disconnect_reasons, p_stays_4h, p_stays_8h,
+		        last_disconnect_at, last_session_duration_seconds
+		   FROM provider_reliability_features
+		  WHERE uptime_pct >= $1 AND p_stays_4h >= $2 AND p_stays_8h >= $3
+		  ORDER BY uptime_pct DESC, provider_id ASC
+		  LIMIT $4`,
+		filter.MinUptimePct, filter.MinPStays4h, filter.MinPStays8h, limit,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("store: list reliability features: %w", err)
+	}
+	defer rows.Close()
+
+	var out []ReliabilityFeatures
+	for rows.Next() {
+		var (
+			row      ReliabilityFeatures
+			lastDisc *time.Time
+			hourly   []byte
+			reasons  []byte
+		)
+		if err := rows.Scan(
+			&row.ProviderID, &row.UpdatedAt, &row.WindowDays, &row.UptimePct, &row.SessionsCount,
+			&row.MTBFSeconds, &row.MedianSessionSeconds, &row.P10SessionSeconds, &row.P90SessionSeconds,
+			&hourly, &reasons, &row.PStays4h, &row.PStays8h,
+			&lastDisc, &row.LastSessionDurationSeconds,
+		); err != nil {
+			return nil, fmt.Errorf("store: scan reliability features: %w", err)
+		}
+		if lastDisc != nil {
+			row.LastDisconnectAt = *lastDisc
+		}
+		row.HourlyAvailability = hourly
+		row.DisconnectReasons = reasons
+		out = append(out, row)
+	}
+	return out, rows.Err()
+}
+
+// scanSessionRows is the shared SessionRow scanner used by ListSessionsSince
+// and ListRecentSessions. Both queries SELECT the same column order.
+func scanSessionRows(rows pgx.Rows) ([]SessionRow, error) {
+	var out []SessionRow
+	for rows.Next() {
+		var (
+			r       SessionRow
+			discAt  *time.Time
+			lastHB  *time.Time
+			reason  *string
+			coordID *string
+		)
+		if err := rows.Scan(
+			&r.ID, &r.ProviderID, &r.ConnectedAt, &discAt,
+			&reason, &lastHB, &r.RequestsServed, &r.TokensGenerated, &coordID,
+		); err != nil {
+			return nil, fmt.Errorf("store: scan session row: %w", err)
+		}
+		if discAt != nil {
+			r.DisconnectedAt = *discAt
+		}
+		if reason != nil {
+			r.DisconnectReason = *reason
+		}
+		if lastHB != nil {
+			r.LastHeartbeatAt = *lastHB
+		}
+		if coordID != nil {
+			r.CoordinatorID = *coordID
+		}
+		out = append(out, r)
+	}
+	return out, rows.Err()
 }

--- a/coordinator/store/postgres_test.go
+++ b/coordinator/store/postgres_test.go
@@ -49,6 +49,10 @@ func testPostgresStore(t *testing.T) *PostgresStore {
 		"provider_earnings",
 		"provider_payouts",
 		"providers",
+		"provider_heartbeats",
+		"provider_heartbeats_hourly",
+		"provider_sessions",
+		"provider_reliability_features",
 		"stripe_withdrawals",
 	} {
 		if _, err := s.pool.Exec(ctx, "TRUNCATE "+table+" CASCADE"); err != nil {


### PR DESCRIPTION
## Summary

- Captures every provider heartbeat + connect/disconnect transition to Postgres without blocking the heartbeat hot path.
- Adds a per-provider reliability rollup (uptime, MTBF, P10/P50/P90 session length, P(stays ≥ 4h / 8h), 7×24 hourly availability matrix, disconnect-reason histogram) recomputed every 5 minutes.
- Exposes five read-only analytics endpoints behind the existing pseudonym layer for internal dashboards and future job-aware scheduling.

Foundation for scheduling long-running scientific workloads (DFT, protein folding) — gives us the data to decide which providers can reliably hold a multi-hour job, and to detect risk before it materializes. Closes DAR-61.

## What changes

| Area | Change |
|---|---|
| Schema (additive only) | 4 new tables: `provider_heartbeats`, `provider_heartbeats_hourly`, `provider_sessions`, `provider_reliability_features` + indexes. No `ALTER` on existing tables. No protocol changes. |
| Coordinator write path | New `coordinator/liveness/` package: bounded-buffer `Writer` (non-blocking emit, batched flush, drop policy, error backoff, graceful drain), `SessionTracker`, retention prune (28d default), 5-min features rollup. |
| Coordinator hooks | `registry.Heartbeat` emits to writer; `Register` opens a session; `evictStale` and the WS read-loop call `RecordDisconnect` with classified reason; `main.go` runs orphan-close on boot and drains on shutdown. |
| Analytics service | New `analytics/internal/liveness/` package + 5 endpoints: `/v1/providers/{id}/{liveness,sessions,heartbeats}`, `/v1/providers/reliability`, `/v1/network/availability`. All outputs aliased through the existing pseudonym layer. |
| Docs | `analytics/README.md` documents new endpoints + `analytics_readonly` role SQL. `CLAUDE.md` path fixes. |

## Safeguards

- Bounded channel + non-blocking send → no OOM on Postgres outage; drops counted via `liveness_dropped_total`.
- 5s statement timeout per flush + error backoff → bad flushes can't stall the writer.
- Drain on shutdown forces backoff = 0 → no silent data loss when graceful-stopping after a transient error.
- `CloseOrphanSessions` is coordinator_id-scoped → blue-green deploys won't stomp the sibling coordinator's live sessions.
- Retention deletes in batches of 10k via subquery + IN → bounded WAL pressure, autovacuum keeps pace, partial progress survives cancellation.
- Analytics service uses capped 8-connection pool + `statement_timeout = 10s` (set on the `analytics_readonly` role) → runaway queries can't starve operational traffic.
- All endpoint queries are pre-aggregated (`provider_reliability_features`) or indexed lookups — no seq scans at request time.

## Test plan

- [ ] `cd coordinator && go build ./...` — clean (verified locally)
- [ ] `cd coordinator && go test ./... -count=1 -timeout 180s` — all packages green (verified locally, ~75s including api integration suite)
- [ ] `cd analytics && go build ./...` — clean (verified locally)
- [ ] `cd analytics && go test ./... -count=1` — all packages green (verified locally)
- [ ] **Postgres-backed store tests** (not yet run; needs a real DB):
      ```
      DATABASE_URL=postgres://… go test ./coordinator/store/ -run TestPostgresLiveness -count=1
      ```
- [ ] 24h soak on dev coordinator: verify `liveness_dropped_total == 0`, flush p99 < 100ms, no connection-pool exhaustion.
- [ ] Confirm `os.Hostname()` is stable across EigenCloud redeploys (blue-green correctness).
- [ ] Hit each new endpoint via curl against dev analytics service and verify response shape + pseudonym aliasing.

## Deploy / infra follow-ups (not in this PR)

1. Create `analytics_readonly` role on prod + dev Postgres (SQL in `analytics/README.md`).
2. Deploy the analytics binary somewhere internal (sidecar on dev VM, or second container in the EigenCloud app).
3. Set `ANALYTICS_DATABASE_URL` to point at primary; swap to a read replica later if/when sustained analytics load justifies it.
4. Wire the `CounterFn` callbacks (`liveness_dropped_total`, `liveness_flush_failed_total`, `liveness_features_runs_total`, etc.) into the existing metrics pipeline so they're visible on dashboards.

## Out of scope for v1

- Real-time risk-signal stream (deferred; the captured data is the training set).
- Job-aware / sticky scheduling (separate workstream — analytics tells you when, but the platform still needs a checkpoint protocol to act).
- Public DNS / Caddy routing for analytics endpoints (internal-only for now).
- Postgres read replica (analytics queries are bounded by `statement_timeout` + connection cap + pre-aggregated features; revisit if you measure operational impact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/200"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782067278&installation_id=133247490&pr_number=200&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F200&signature=c62d4bba290997d919d109f1e4c7cc21f41bba3d50b42f240bfd9b856f6282fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->