### PR TITLE
fix: verify model registry artifact bytes

### DIFF
--- a/coordinator/api/model_registry_handlers.go
+++ b/coordinator/api/model_registry_handlers.go
@@ -99,8 +99,8 @@ func (s *Server) handleRegisterModel(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusBadRequest, errorResponse("invalid_request_error", err.Error()))
 		return
 	}
-	if err := verifyManifestFiles(r.Context(), registryCDNBaseURL(), manifest, s.logger); err != nil {
-		writeJSON(w, http.StatusBadRequest, errorResponse("invalid_request_error", "manifest file verification failed: "+err.Error()))
+	if err := verifyManifestArtifacts(r.Context(), registryCDNBaseURL(), manifest, s.logger); err != nil {
+		writeJSON(w, http.StatusBadRequest, errorResponse("invalid_request_error", "manifest artifact verification failed: "+err.Error()))
 		return
 	}
 
@@ -477,8 +477,10 @@ func fetchModelManifest(ctx context.Context, baseURL, r2Prefix string) (*store.M
 	return &manifest, nil
 }
 
-func verifyManifestFiles(ctx context.Context, baseURL string, manifest *store.ModelManifest, logger interface{ Warn(string, ...any) }) error {
-	client := &http.Client{Timeout: 30 * time.Second}
+func verifyManifestArtifacts(ctx context.Context, baseURL string, manifest *store.ModelManifest, logger interface{ Warn(string, ...any) }) error {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.ResponseHeaderTimeout = 30 * time.Second
+	client := &http.Client{Transport: transport}
 	errCh := make(chan error, len(manifest.Files))
 	fileCh := make(chan store.ManifestFile)
 	var wg sync.WaitGroup
@@ -491,7 +493,7 @@ func verifyManifestFiles(ctx context.Context, baseURL string, manifest *store.Mo
 		go func() {
 			defer wg.Done()
 			for file := range fileCh {
-				if err := verifyManifestFileHEAD(ctx, client, baseURL, manifest.R2Prefix, file, logger); err != nil {
+				if err := verifyManifestFileArtifact(ctx, client, baseURL, manifest.R2Prefix, file, logger); err != nil {
 					errCh <- err
 				}
 			}
@@ -518,28 +520,41 @@ func verifyManifestFiles(ctx context.Context, baseURL string, manifest *store.Mo
 	return nil
 }
 
-func verifyManifestFileHEAD(ctx context.Context, client *http.Client, baseURL, r2Prefix string, file store.ManifestFile, logger interface{ Warn(string, ...any) }) error {
+func verifyManifestFileArtifact(ctx context.Context, client *http.Client, baseURL, r2Prefix string, file store.ManifestFile, logger interface{ Warn(string, ...any) }) error {
 	fileURL, err := url.JoinPath(baseURL, r2Prefix, file.Path)
 	if err != nil {
 		return err
 	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodHead, fileURL, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fileURL, nil)
 	if err != nil {
 		return err
 	}
 	resp, err := client.Do(req)
 	if err != nil {
-		return fmt.Errorf("HEAD %s: %w", file.Path, err)
+		return fmt.Errorf("GET %s: %w", file.Path, err)
 	}
-	resp.Body.Close()
+	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return fmt.Errorf("HEAD %s returned %s", file.Path, resp.Status)
+		return fmt.Errorf("GET %s returned %s", file.Path, resp.Status)
 	}
 	if resp.ContentLength >= 0 && resp.ContentLength != file.SizeBytes {
-		return fmt.Errorf("HEAD %s content length %d != manifest size %d", file.Path, resp.ContentLength, file.SizeBytes)
+		return fmt.Errorf("GET %s content length %d != manifest size %d", file.Path, resp.ContentLength, file.SizeBytes)
 	}
 	if resp.ContentLength < 0 && logger != nil {
-		logger.Warn("model registry: HEAD missing Content-Length", "path", file.Path)
+		logger.Warn("model registry: artifact GET missing Content-Length", "path", file.Path)
+	}
+
+	h := sha256.New()
+	n, err := io.Copy(h, resp.Body)
+	if err != nil {
+		return fmt.Errorf("GET %s body: %w", file.Path, err)
+	}
+	if n != file.SizeBytes {
+		return fmt.Errorf("GET %s read %d bytes != manifest size %d", file.Path, n, file.SizeBytes)
+	}
+	actualSHA256 := hex.EncodeToString(h.Sum(nil))
+	if subtle.ConstantTimeCompare([]byte(actualSHA256), []byte(file.SHA256)) != 1 {
+		return fmt.Errorf("GET %s sha256 %s != manifest sha256 %s", file.Path, actualSHA256, file.SHA256)
 	}
 	return nil
 }

--- a/coordinator/api/model_registry_handlers_test.go
+++ b/coordinator/api/model_registry_handlers_test.go
@@ -139,11 +139,12 @@ func TestRegisterModelHandlerPromotesActiveRecord(t *testing.T) {
 			}
 			writeJSON(w, http.StatusOK, manifest)
 		case "/" + prefix + "/config.json":
-			if r.Method != http.MethodHead {
+			if r.Method != http.MethodGet {
 				t.Fatalf("file method = %s", r.Method)
 			}
-			w.Header().Set("Content-Length", "123")
+			w.Header().Set("Content-Length", fmt.Sprint(len(testManifestFileBytes())))
 			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(testManifestFileBytes())
 		default:
 			http.NotFound(w, r)
 		}
@@ -209,6 +210,61 @@ func TestRegisterModelHandlerPromotesActiveRecord(t *testing.T) {
 	}
 	if len(catalog.Models) != 1 || catalog.Models[0]["id"] != "mlx-community/test" || catalog.Models[0]["version"] != "v1" {
 		t.Fatalf("unexpected catalog response: %#v", catalog.Models)
+	}
+}
+
+func TestRegisterModelHandlerVerifiesArtifactBytes(t *testing.T) {
+	tests := []struct {
+		name       string
+		body       []byte
+		wantStatus int
+	}{
+		{name: "same size wrong bytes", body: bytes.Repeat([]byte{'x'}, len(testManifestFileBytes())), wantStatus: http.StatusBadRequest},
+		{name: "correct bytes", body: testManifestFileBytes(), wantStatus: http.StatusOK},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			manifest := validTestManifest()
+			prefix := modelR2Prefix("mlx-community/test", "v1")
+			cdn := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/" + prefix + "/manifest.json":
+					writeJSON(w, http.StatusOK, manifest)
+				case "/" + prefix + "/config.json":
+					if r.Method != http.MethodGet {
+						t.Fatalf("file method = %s", r.Method)
+					}
+					w.Header().Set("Content-Length", fmt.Sprint(len(tt.body)))
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write(tt.body)
+				default:
+					http.NotFound(w, r)
+				}
+			}))
+			defer cdn.Close()
+			t.Setenv("MODEL_REGISTRY_CDN_BASE_URL", cdn.URL)
+			t.Setenv("MODEL_REGISTRY_PUBLISHING_KEY", "publish-secret")
+
+			logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+			st := store.NewMemory("")
+			srv := NewServer(registry.New(logger), st, logger)
+			payload := map[string]any{
+				"model_id":           "mlx-community/test",
+				"version":            "v1",
+				"quantization":       "4bit",
+				"max_context_length": 32768,
+				"max_output_length":  8192,
+				"min_ram_gb":         16,
+			}
+			body, _ := json.Marshal(payload)
+			req := httptest.NewRequest(http.MethodPost, "/v1/admin/models/register", bytes.NewReader(body))
+			req.Header.Set("Authorization", "Bearer publish-secret")
+			rec := httptest.NewRecorder()
+			srv.Handler().ServeHTTP(rec, req)
+			if rec.Code != tt.wantStatus {
+				t.Fatalf("register status = %d body = %s", rec.Code, rec.Body.String())
+			}
+		})
 	}
 }
 
@@ -384,10 +440,11 @@ func TestModelRegistryNotFoundClassification(t *testing.T) {
 }
 
 func validTestManifest() *store.ModelManifest {
+	body := testManifestFileBytes()
 	files := []store.ManifestFile{{
 		Path:      "config.json",
-		SizeBytes: 123,
-		SHA256:    testHash,
+		SizeBytes: int64(len(body)),
+		SHA256:    sha256Hex(string(body)),
 		Role:      "config",
 	}}
 	return &store.ModelManifest{
@@ -396,9 +453,13 @@ func validTestManifest() *store.ModelManifest {
 		Version:         "v1",
 		R2Prefix:        modelR2Prefix("mlx-community/test", "v1"),
 		AggregateSHA256: aggregateManifestFileHashes(files),
-		TotalSizeBytes:  123,
+		TotalSizeBytes:  int64(len(body)),
 		FileCount:       1,
 		Files:           files,
 		CreatedAt:       time.Now(),
 	}
+}
+
+func testManifestFileBytes() []byte {
+	return []byte(`{"architectures":["TestForCausalLM"],"model_type":"test"}`)
 }


### PR DESCRIPTION
## Summary

Fixes model registry registration accepting same-size corrupted R2 artifacts.

Previously registration only verified each manifest file with `HEAD` status and `Content-Length`. That could accept an object whose bytes did not match `manifest.files[].sha256`, leaving a promotable `ready` model version that providers would later reject during download.

This PR changes registration-time artifact verification to:

- `GET` each manifest file with bounded 8-worker concurrency.
- Stream the response body through SHA-256 without loading full artifacts into memory.
- Compare streamed SHA-256 against `manifest.files[].sha256`.
- Keep `Content-Length` and actual-byte-count checks.
- Use a response-header timeout instead of a whole-request timeout so large model artifacts can stream for longer than 30 seconds.

## Validation

- `go test ./coordinator/...`
- `git diff --check`

## Notes

This intentionally increases model registration cost because the coordinator now reads all artifact bytes once. Registration is an operator/admin path, and the benefit is catching corrupt or overwritten R2 objects before a model version can be stored/promoted as ready.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/205"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782243062&installation_id=133247490&pr_number=205&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F205&signature=7dd40358dc9931bd67b8a0064922d8d7e022aadbbbb42c32f4a7eb9628d075d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->