### PR TITLE
feat(provider-swift): migrate BatchScheduler from BatchGenerator to BatchedEngine

### DIFF
--- a/provider-swift/Package.resolved
+++ b/provider-swift/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "2bf19c2d33f5e1aff1e3b0927aaee54e3f49b89a93d23e5eb7552bd04a9e6a55",
+  "originHash" : "0b4729b1e478809d6e0787ccbca9ebdb3248bd2f78e59598b9ddd0694a637bc5",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/hummingbird-project/hummingbird.git",
       "state" : {
-        "revision" : "a2ed0a0294de56e18ba55344eafc801a7a385a90",
-        "version" : "2.22.0"
+        "revision" : "277e5db5b6d348270088e6ee8e8fa2539bae603d",
+        "version" : "2.23.0"
       }
     },
     {
@@ -294,8 +294,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/huggingface/swift-transformers",
       "state" : {
-        "revision" : "b38443e44d93eca770f2eb68e2a4d0fa100f9aa2",
-        "version" : "1.3.0"
+        "revision" : "2fa33e1f5e7131a7fc64c28e6d161dcec0d24820",
+        "version" : "1.3.3"
       }
     },
     {

--- a/provider-swift/Package.swift
+++ b/provider-swift/Package.swift
@@ -34,7 +34,10 @@ let package = Package(
         .package(url: "https://github.com/mattt/EventSource.git", exact: "1.3.0"),
         .package(url: "https://github.com/jedisct1/swift-sodium.git", from: "0.9.1"),
         .package(url: "https://github.com/LebJe/TOMLKit.git", from: "0.6.0"),
-        .package(url: "https://github.com/hummingbird-project/hummingbird.git", exact: "2.22.0"),
+        // Bumped 2.22.0 -> 2.23.0 to satisfy mlx-swift-lm's MLXLMServer
+        // target which declares `from: "2.23.0"` (introduced in upstream
+        // PR #26, "Add OpenAI-compatible inference server").
+        .package(url: "https://github.com/hummingbird-project/hummingbird.git", exact: "2.23.0"),
         // Test-only: WebSocket upgrade support so the mock coordinator under
         // Tests/ProviderCoreTests/Helpers can host a `/ws/provider` route.
         .package(url: "https://github.com/hummingbird-project/hummingbird-websocket.git", exact: "2.6.0"),

--- a/provider-swift/Sources/ProviderCore/Inference/BatchScheduler+EngineBridge.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/BatchScheduler+EngineBridge.swift
@@ -1,0 +1,313 @@
+// Copyright © 2026 Eigen Labs.
+//
+// Per-request streaming bridge: consumes `engine.core.streamOutputs`
+// for one request and yields `GenerationEvent`s on the public
+// `AsyncStream`.
+//
+// All bookkeeping mutations live as `BatchScheduler` actor methods in
+// this file so the cross-file `Task { ... }` (started in `submit`) can
+// hop onto the actor's executor to update `activeBridges` / EWMA /
+// planner state.
+//
+// Access promotions vs the pre-split file:
+//   * `recordAdmission`, `recordFirstToken`, `recordFinish`,
+//     `dropBridge`, `consumeTimedOutFlag` were `fileprivate` — they
+//     stay `fileprivate` in spirit but compile as `internal` because
+//     the bridge Task lives in this extension file (and the symbols
+//     are also called from `cancel` paths in the main file).
+//   * `recordProgress` is new (P2 fix: in-flight decode visibility).
+
+import Foundation
+import MLXLMCommon
+
+extension BatchScheduler {
+
+    // MARK: - Bridge runner (called from `submit` in the main file)
+
+    /// Spin up the per-request stream consumer that translates
+    /// `RequestOutput`s into `GenerationEvent`s on `continuation`.
+    /// Owns lifecycle: removes the bridge from `activeBridges` on
+    /// terminal output, drops it on stream-closed-without-terminal,
+    /// and registers an `onTermination` cancellation hook.
+    func runBridge(
+        requestId id: String,
+        outputStream: AsyncStream<RequestOutput>,
+        continuation: AsyncStream<GenerationEvent>.Continuation
+    ) {
+        let scheduler = self
+        Task { [continuation] in
+            var sawAdmission = false
+            var sawFirstToken = false
+            var sawTerminal = false
+            for await output in outputStream {
+                // First `RequestOutput` (even prefill-only with no tokens)
+                // marks engine admission. Required by `expirePlannerTimeouts`
+                // to distinguish "queued" from "running" — long prefills
+                // emit no decoded token for many seconds.
+                if !sawAdmission {
+                    await scheduler.recordAdmission(requestId: id, at: .now)
+                    sawAdmission = true
+                }
+
+                // Key first-token on TOKEN count, not `newText`: some
+                // tokens (BPE intermediates, specials) decode to empty
+                // strings and would otherwise leave `firstTokenAt` nil.
+                let hasNewToken = !output.newTokenIds.isEmpty
+                    || output.completionTokens > 0
+                if !sawFirstToken, hasNewToken {
+                    await scheduler.recordFirstToken(requestId: id, at: .now)
+                    sawFirstToken = true
+                }
+
+                // P2: keep `BridgeState.completionTokens` live so
+                // `backendCapacity()` (heartbeats) reports in-flight
+                // decode progress, not stale zeros until finish.
+                if output.completionTokens > 0 || output.promptTokens > 0 {
+                    await scheduler.recordProgress(
+                        requestId: id,
+                        promptTokens: output.promptTokens,
+                        completionTokens: output.completionTokens
+                    )
+                }
+
+                if !output.newText.isEmpty {
+                    continuation.yield(.chunk(output.newText))
+                }
+
+                if output.finished || output.error != nil {
+                    sawTerminal = true
+                    // Three terminal flavors:
+                    //   abort               → cancellation (timeout vs cancel)
+                    //   error+not-abort     → engine/runtime failure (surface it)
+                    //   stop/length/nil err → normal finish (.info)
+                    let isAbort = output.finishReason == "abort"
+                    let engineError = !isAbort ? output.error : nil
+                    if isAbort || engineError != nil {
+                        _ = await scheduler.recordFinish(
+                            requestId: id,
+                            promptTokens: output.promptTokens,
+                            completionTokens: output.completionTokens,
+                            success: false
+                        )
+                        if let err = engineError {
+                            // Real engine failure; preserve the message
+                            // so callers can report it / decide retry.
+                            continuation.yield(.error(err))
+                        } else {
+                            // Distinct pending-timeout vs. client-cancel
+                            // string so operators can tell capacity
+                            // exhaustion apart from a closed connection.
+                            let timedOut = await scheduler.consumeTimedOutFlag(id)
+                            if timedOut {
+                                continuation.yield(.error(
+                                    "request timed out waiting for capacity"))
+                            } else {
+                                continuation.yield(.error("request cancelled"))
+                            }
+                        }
+                    } else {
+                        let usage = await scheduler.recordFinish(
+                            requestId: id,
+                            promptTokens: output.promptTokens,
+                            completionTokens: output.completionTokens,
+                            success: true
+                        )
+                        continuation.yield(.info(
+                            promptTokens: output.promptTokens,
+                            completionTokens: output.completionTokens,
+                            tokensPerSecond: usage.tps
+                        ))
+                    }
+                    continuation.finish()
+                    return
+                }
+            }
+            // Stream closed without a terminal output (engine torn down
+            // mid-request). Surface a distinct error so ProviderLoop does
+            // not return a 200-OK with truncated content.
+            if !sawTerminal {
+                continuation.yield(.error(
+                    "request stream closed by engine teardown"))
+            }
+            await scheduler.dropBridge(requestId: id)
+            continuation.finish()
+        }
+    }
+
+    // MARK: - Bridge bookkeeping (called from the streaming Task)
+
+    /// Set on the first `RequestOutput` seen for a request (engine
+    /// picked it up). Drives the pending-timeout predicate so long
+    /// prefills are not aborted as queue timeouts.
+    func recordAdmission(requestId: String, at instant: ContinuousClock.Instant) {
+        guard var bridge = activeBridges[requestId] else { return }
+        if bridge.admittedAt == nil {
+            bridge.admittedAt = instant
+            activeBridges[requestId] = bridge
+        }
+    }
+
+    func recordFirstToken(requestId: String, at instant: ContinuousClock.Instant) {
+        guard var bridge = activeBridges[requestId] else { return }
+        bridge.firstTokenAt = instant
+        activeBridges[requestId] = bridge
+    }
+
+    /// P2 fix: refresh the bridge's prompt + completion token counts on
+    /// every non-empty `RequestOutput` so `backendCapacity()` reports
+    /// live in-flight decode (vs. stale 0 until `recordFinish`).
+    ///
+    /// `output.completionTokens` is cumulative per `OutputCollector`'s
+    /// merge semantics; we still `max()` defensively against any
+    /// out-of-order delivery.
+    func recordProgress(
+        requestId: String,
+        promptTokens: Int,
+        completionTokens: Int
+    ) {
+        guard var bridge = activeBridges[requestId] else { return }
+        bridge.promptTokens = max(bridge.promptTokens, promptTokens)
+        bridge.completionTokens = max(bridge.completionTokens, completionTokens)
+        activeBridges[requestId] = bridge
+    }
+
+    /// Compute TPS, update the EWMA, release budget reservations.
+    /// Returns the TPS for the `.info` event.
+    func recordFinish(
+        requestId: String,
+        promptTokens: Int,
+        completionTokens: Int,
+        success: Bool
+    ) async -> (tps: Double, durationSeconds: Double) {
+        guard var bridge = activeBridges.removeValue(forKey: requestId) else {
+            return (0, 0)
+        }
+        let finishedAt = ContinuousClock.now
+        bridge.lastTokenAt = finishedAt
+        bridge.completionTokens = completionTokens
+        bridge.promptTokens = max(bridge.promptTokens, promptTokens)
+
+        let tps: Double
+        if let firstTokenAt = bridge.firstTokenAt, completionTokens > 1 {
+            let elapsed = finishedAt - firstTokenAt
+            let elapsedSeconds = Double(elapsed.components.seconds)
+                + Double(elapsed.components.attoseconds) / 1e18
+            tps = elapsedSeconds > 0
+                ? Double(completionTokens - 1) / elapsedSeconds : 0
+        } else {
+            let elapsed = finishedAt - bridge.submittedAt
+            let elapsedSeconds = Double(elapsed.components.seconds)
+                + Double(elapsed.components.attoseconds) / 1e18
+            tps = elapsedSeconds > 0
+                ? Double(completionTokens) / elapsedSeconds : 0
+        }
+
+        if success, tps > 0 {
+            // P2 fix: previously `activeBridges.count + 1` mixed in
+            // queued-not-admitted bridges. Use admitted-and-running
+            // count (admittedAt != nil) + 1 for the just-finished one.
+            let runningRows = activeBridges.values.filter { $0.admittedAt != nil }.count + 1
+            updateDecodeTpsEwma(tps: tps)
+            recordBatchPerformance(observedBatchSize: max(1, runningRows), tps: tps)
+        }
+
+        await releaseKVReservation(requestID: requestId)
+        if let planner = self.planner {
+            // `cancel` (not `complete`): the planner removes the entry
+            // either way, and we don't mark planner-active on admission.
+            await planner.cancel(requestID: requestId)
+            await refreshPendingSummaryCache()
+        }
+
+        let durationSeconds: Double = {
+            let elapsed = finishedAt - bridge.submittedAt
+            return Double(elapsed.components.seconds)
+                + Double(elapsed.components.attoseconds) / 1e18
+        }()
+        return (tps, durationSeconds)
+    }
+
+    /// Stream closed without a terminal output (engine torn down
+    /// mid-request). Cancel planner reservation and release KV bytes.
+    func dropBridge(requestId: String) async {
+        if activeBridges.removeValue(forKey: requestId) != nil {
+            timedOutBridges.remove(requestId)
+            await releaseKVReservation(requestID: requestId)
+            if let planner = self.planner {
+                await planner.cancel(requestID: requestId)
+                await refreshPendingSummaryCache()
+            }
+        }
+    }
+
+    /// Atomically check-and-clear the pending-timeout flag for a bridge.
+    /// Returns true iff the bridge was aborted by the pending-timeout
+    /// watchdog (vs. a client cancellation).
+    func consumeTimedOutFlag(_ id: String) -> Bool {
+        return timedOutBridges.remove(id) != nil
+    }
+
+    // MARK: - Pending-timeout watchdog
+
+    /// Spawn the detached watchdog Task. Called from `loadModel`.
+    /// Cancelled (and re-spawned) on every `stopCurrentEngine` /
+    /// `loadModel` cycle.
+    func startPendingTimeoutWatchdog() {
+        pendingTimeoutTask?.cancel()
+        let scheduler = self
+        pendingTimeoutTask = Task.detached {
+            while !Task.isCancelled {
+                try? await Task.sleep(for: .milliseconds(250))
+                await scheduler.expirePlannerTimeouts()
+            }
+        }
+    }
+
+    /// Watchdog body: abort bridges still waiting for engine admission
+    /// past `pendingTimeout`. A long prefill is admitted but emits no
+    /// decoded token yet; admittedAt != nil filters those out so they
+    /// are not mistakenly treated as "stuck in queue".
+    func expirePlannerTimeouts() async {
+        guard let engine = self.engine else { return }
+        let now = ContinuousClock.now
+        let timedOut = activeBridges.filter { _, bridge in
+            bridge.admittedAt == nil
+                && now - bridge.submittedAt >= pendingTimeout
+        }
+        for (id, _) in timedOut {
+            // Insert BEFORE abort so the streaming Task sees the flag
+            // when it consumes the resulting terminal RequestOutput.
+            timedOutBridges.insert(id)
+            _ = engine.core.abortRequest(id)
+        }
+        await refreshPendingSummaryCache()
+    }
+}
+
+// MARK: - Test support
+//
+// `_testSeedBridge` injects a `BridgeState` without going through
+// `submit()` (which requires a loaded model + non-nil engine). Used by
+// non-live unit tests for the cumulative-budget gate and in-flight
+// progress reporting. Gated on DEBUG so it does not ship in release
+// builds.
+
+#if DEBUG
+extension BatchScheduler {
+    func _testSeedBridge(
+        id: String,
+        promptTokens: Int,
+        maxTokens: Int,
+        admitted: Bool = false
+    ) {
+        var bridge = BridgeState(
+            requestId: id,
+            promptTokens: promptTokens,
+            maxTokens: maxTokens,
+            submittedAt: .now
+        )
+        if admitted { bridge.admittedAt = .now }
+        activeBridges[id] = bridge
+    }
+}
+#endif

--- a/provider-swift/Sources/ProviderCore/Inference/BatchScheduler+KVEstimation.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/BatchScheduler+KVEstimation.swift
@@ -1,0 +1,326 @@
+// Copyright © 2026 Eigen Labs.
+//
+// Pure, actor-state-free helpers that read a model's `config.json` and
+// turn the architecture metadata into a per-token KV-cache cost in
+// bytes. The result drives `BatchScheduler.tokenBudgetMax`, which gates
+// admission.
+//
+// All functions are `static` on the `KVEstimation` enum (no instance,
+// no actor isolation). The closure inside `loadModel` calls these
+// directly without bouncing off the actor.
+//
+// `BatchScheduler` extends with a couple of static convenience
+// shims (`resolvedKVBytesPerToken`, `resolvedMaxTokens`) that take
+// scheduler-specific defaults and forward into this namespace.
+
+import Foundation
+
+/// Namespace for KV-cache cost estimation. Pure functions only; no
+/// actor state, no global mutation.
+enum KVEstimation {
+
+    // MARK: - Tunables
+
+    /// Maximum bytes we'll read from a `config.json` file. The model
+    /// directory is operator-writable; a malicious or corrupt config
+    /// could otherwise be used to OOM the parser.
+    static let maxConfigJSONBytes = 4 * 1024 * 1024
+
+    /// Architectural fields are clamped against these bounds before
+    /// being used in KV-byte arithmetic. Higher than any real model,
+    /// low enough to prevent integer overflow.
+    private static let maxLayersBound = 1024
+    private static let maxHeadsBound = 1024
+    private static let maxHeadDimBound = 2048
+
+    /// Recurrent-state layer types (Mamba, GatedDeltaNet) hold a fixed
+    /// state per request, not per-token KV. They contribute 0 to the
+    /// per-token KV-byte cost.
+    private static let recurrentLayerTypes: Set<String> = [
+        "linear_attention",   // Qwen3.5 GatedDeltaNet
+        "recurrent",
+    ]
+
+    // MARK: - config.json read
+
+    /// Read up to `maxConfigJSONBytes` from `url`. Returns `nil` if the
+    /// file is missing, unreadable, or exceeds the cap.
+    static func readBoundedConfigJSON(_ url: URL) -> Data? {
+        guard let handle = try? FileHandle(forReadingFrom: url) else {
+            return nil
+        }
+        defer { try? handle.close() }
+        guard let data = try? handle.read(upToCount: maxConfigJSONBytes + 1),
+              data.count <= maxConfigJSONBytes else { return nil }
+        return data
+    }
+
+    // MARK: - Architecture parsing
+
+    /// Parse architecture metadata from `<modelDir>/config.json`.
+    ///
+    /// Covers:
+    ///   - Standard transformer fields (`num_hidden_layers`,
+    ///     `num_key_value_heads`, `head_dim`, `hidden_size`).
+    ///   - Hybrid attention (Gemma 4, Gemma 3n): `num_kv_shared_layers`,
+    ///     `global_head_dim`, `num_global_key_value_heads`,
+    ///     `sliding_window_pattern`, `layer_types`.
+    ///   - VLMs (Gemma 4) that wrap the text model under `text_config`.
+    ///
+    /// Returns `.empty` when the config can't be read or parsed.
+    /// All numeric fields are clamped to defend against malicious or
+    /// corrupt configs in operator-writable model directories.
+    static func parseModelArchitecture(at configURL: URL) -> ModelArchitecture {
+        guard let data = readBoundedConfigJSON(configURL),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return .empty
+        }
+
+        // Gemma 4 VLM wraps the text model under `text_config`.
+        let cfg: [String: Any] = (json["text_config"] as? [String: Any]) ?? json
+
+        var numLayers: Int? = cfg["num_hidden_layers"] as? Int
+        var kvHeads: Int? = cfg["num_key_value_heads"] as? Int
+            ?? cfg["num_attention_heads"] as? Int  // MHA fallback
+
+        var headDim: Int? = cfg["head_dim"] as? Int
+        if headDim == nil,
+           let hs = cfg["hidden_size"] as? Int,
+           let nh = cfg["num_attention_heads"] as? Int, nh > 0 {
+            headDim = hs / nh
+        }
+
+        // Hybrid-attention fields (Gemma 4, Gemma 3n).
+        var numKvSharedLayers: Int = cfg["num_kv_shared_layers"] as? Int ?? 0
+        var globalHeadDim: Int? = cfg["global_head_dim"] as? Int
+        var numGlobalKvHeads: Int? = cfg["num_global_key_value_heads"] as? Int
+        // `sliding_window_pattern=5` → repeating [S, S, S, S, F].
+        var slidingWindowPattern: Int? = cfg["sliding_window_pattern"] as? Int
+        var layerTypes: [String]? = cfg["layer_types"] as? [String]
+
+        // Clamp against a malicious config.json (operator-writable dir)
+        // that would otherwise inflate the token budget unbounded.
+        if let l = numLayers { numLayers = min(max(l, 1), maxLayersBound) }
+        if let h = kvHeads { kvHeads = min(max(h, 1), maxHeadsBound) }
+        if let hd = headDim { headDim = min(max(hd, 1), maxHeadDimBound) }
+        if let ghd = globalHeadDim { globalHeadDim = min(max(ghd, 1), maxHeadDimBound) }
+        if let gkh = numGlobalKvHeads { numGlobalKvHeads = min(max(gkh, 1), maxHeadsBound) }
+        if let l = numLayers {
+            numKvSharedLayers = min(max(numKvSharedLayers, 0), l)
+        } else {
+            numKvSharedLayers = max(numKvSharedLayers, 0)
+        }
+        if let swp = slidingWindowPattern {
+            let upperBound = numLayers ?? maxLayersBound
+            slidingWindowPattern = min(max(swp, 0), upperBound)
+        }
+        if let lt = layerTypes, let l = numLayers, lt.count > l {
+            layerTypes = Array(lt.prefix(l))
+        }
+
+        return ModelArchitecture(
+            numLayers: numLayers,
+            kvHeads: kvHeads,
+            headDim: headDim,
+            numKvSharedLayers: numKvSharedLayers,
+            globalHeadDim: globalHeadDim,
+            numGlobalKvHeads: numGlobalKvHeads,
+            slidingWindowPattern: slidingWindowPattern,
+            layerTypes: layerTypes
+        )
+    }
+
+    // MARK: - KV cost computation
+
+    /// Compute total KV cache bytes per token across all layers, accounting
+    /// for architecture-specific differences:
+    ///
+    /// - **KV sharing** (Gemma 4, Gemma 3n): only the first
+    ///   `numLayers - numKvSharedLayers` layers allocate real KV caches.
+    /// - **Hybrid attention** (Gemma 4, GPT-OSS): sliding-attention layers
+    ///   use `headDim` / `kvHeads`, while full-attention layers can use
+    ///   `globalHeadDim` / `numGlobalKvHeads`.
+    /// - **Standard models** (Llama, Qwen, Mistral, Gemma 2): all layers
+    ///   are uniform; degenerates to `cachedLayers * kvHeads * headDim * 4`.
+    static func computeKVBytesPerToken(
+        numLayers: Int,
+        kvHeads: Int,
+        headDim: Int,
+        numKvSharedLayers: Int,
+        globalHeadDim: Int?,
+        numGlobalKvHeads: Int?,
+        slidingWindowPattern: Int?,
+        layerTypes: [String]?
+    ) -> Int {
+        let bytesPerElement = 2  // float16
+        let kvTensors = 2        // K + V
+
+        let cachedLayers = numLayers - numKvSharedLayers
+        guard cachedLayers > 0 else { return 0 }
+
+        let resolvedLayerTypes = resolveLayerTypes(
+            cachedLayers: cachedLayers,
+            layerTypes: layerTypes,
+            slidingWindowPattern: slidingWindowPattern
+        )
+
+        let hasHybridDims = globalHeadDim != nil && globalHeadDim != headDim
+            || numGlobalKvHeads != nil && numGlobalKvHeads != kvHeads
+
+        if let types = resolvedLayerTypes {
+            return totalHybridBytesPerToken(
+                cachedLayers: cachedLayers,
+                layerTypes: types,
+                kvHeads: kvHeads,
+                headDim: headDim,
+                globalHeadDim: globalHeadDim,
+                numGlobalKvHeads: numGlobalKvHeads,
+                hasHybridDims: hasHybridDims,
+                bytesPerElement: bytesPerElement,
+                kvTensors: kvTensors
+            )
+        }
+
+        // Hybrid dims but no per-layer types: conservatively use the
+        // larger dimension across all cached layers.
+        if let ghd = globalHeadDim, ghd > headDim {
+            let maxKvHeads = max(kvHeads, numGlobalKvHeads ?? kvHeads)
+            return cachedLayers * maxKvHeads * ghd * kvTensors * bytesPerElement
+        }
+
+        // Uniform full-attention (Llama, Qwen, Mistral, Gemma 2).
+        return cachedLayers * kvHeads * headDim * kvTensors * bytesPerElement
+    }
+
+    // MARK: - Internal helpers
+
+    /// Derive a per-layer attention type list from one of:
+    ///   1. an explicit `layer_types` array (Gemma 4, GPT-OSS)
+    ///   2. `slidingWindowPattern=N` → repeating [S, ..., S, F] of length N
+    ///   3. neither → `nil` (caller falls back to uniform full-attention)
+    private static func resolveLayerTypes(
+        cachedLayers: Int,
+        layerTypes: [String]?,
+        slidingWindowPattern: Int?
+    ) -> [String]? {
+        if let lt = layerTypes, lt.count >= cachedLayers {
+            return lt
+        }
+        guard let swp = slidingWindowPattern, swp > 1 else {
+            return nil
+        }
+        var pattern = [String]()
+        for i in 0..<swp {
+            pattern.append(i == swp - 1 ? "full_attention" : "sliding_attention")
+        }
+        var types = [String]()
+        while types.count < cachedLayers {
+            types.append(contentsOf: pattern)
+        }
+        return Array(types.prefix(cachedLayers))
+    }
+
+    /// Sum per-layer KV bytes for hybrid-attention models, skipping
+    /// recurrent layers (which hold a fixed state, not per-token KV).
+    private static func totalHybridBytesPerToken(
+        cachedLayers: Int,
+        layerTypes: [String],
+        kvHeads: Int,
+        headDim: Int,
+        globalHeadDim: Int?,
+        numGlobalKvHeads: Int?,
+        hasHybridDims: Bool,
+        bytesPerElement: Int,
+        kvTensors: Int
+    ) -> Int {
+        var totalBytesPerToken = 0
+        for i in 0..<cachedLayers {
+            let layerType = layerTypes[i]
+            if recurrentLayerTypes.contains(layerType) {
+                continue
+            }
+
+            let layerKvHeads: Int
+            let layerHeadDim: Int
+
+            if hasHybridDims && layerType == "full_attention" {
+                layerKvHeads = numGlobalKvHeads ?? kvHeads
+                layerHeadDim = globalHeadDim ?? headDim
+            } else {
+                layerKvHeads = kvHeads
+                layerHeadDim = headDim
+            }
+
+            totalBytesPerToken += layerKvHeads * layerHeadDim * kvTensors * bytesPerElement
+        }
+        return totalBytesPerToken
+    }
+}
+
+// MARK: - BatchScheduler convenience shims
+//
+// These live on `BatchScheduler` so the call sites in `loadModel` /
+// `submit` read naturally (`Self.resolvedKVBytesPerToken(...)`), while
+// the implementations stay namespaced under `KVEstimation`.
+
+extension BatchScheduler {
+
+    /// Default `max_tokens` resolution: caller-requested or scheduler
+    /// default. Trivial helper, kept static so the closure in `submit`
+    /// can call it without actor hop.
+    static func resolvedMaxTokens(requested: Int?, defaultMaxTokens: Int) -> Int {
+        requested ?? defaultMaxTokens
+    }
+
+    /// Decide per-token KV cost from architecture metadata, falling back
+    /// to a weight-bytes heuristic when config.json is unavailable OR
+    /// when config-derived numbers are implausibly small (which would
+    /// otherwise inflate the token budget and OOM the GPU).
+    static func resolvedKVBytesPerToken(
+        architecture: ModelArchitecture,
+        weightBytes: Int
+    ) -> Int {
+        let estimatedKV: Int
+        if let layers = architecture.numLayers,
+           let kvH = architecture.kvHeads,
+           let hd = architecture.headDim,
+           layers > 0, kvH > 0, hd > 0 {
+            estimatedKV = KVEstimation.computeKVBytesPerToken(
+                numLayers: layers,
+                kvHeads: kvH,
+                headDim: hd,
+                numKvSharedLayers: architecture.numKvSharedLayers,
+                globalHeadDim: architecture.globalHeadDim,
+                numGlobalKvHeads: architecture.numGlobalKvHeads,
+                slidingWindowPattern: architecture.slidingWindowPattern,
+                layerTypes: architecture.layerTypes
+            )
+        } else {
+            estimatedKV = max(weightBytes / 25_000, 100_000)
+        }
+
+        // Floor: real models exceed ~1000 B/token. A smaller value means
+        // config.json is wrong; fall back to the heuristic to avoid an
+        // OOM-inducing token budget.
+        let kvFloor = 1_000
+        if estimatedKV < kvFloor && architecture.numLayers != nil {
+            let heuristicKV = max(weightBytes / 25_000, 100_000)
+            FileHandle.standardError.write(Data(
+                "[WARN] config.json produced implausibly small kvBytesPerToken=\(estimatedKV); falling back to heuristic=\(heuristicKV)\n".utf8
+            ))
+            return heuristicKV
+        }
+        return estimatedKV
+    }
+
+    // MARK: - Test shim
+    //
+    // `BatchingTests.swift` accesses these via `BatchScheduler.<name>`;
+    // forward into `KVEstimation` so the test file doesn't need to know
+    // about the namespace split.
+    static var maxConfigJSONBytes: Int { KVEstimation.maxConfigJSONBytes }
+
+    static func readBoundedConfigJSON(_ url: URL) -> Data? {
+        KVEstimation.readBoundedConfigJSON(url)
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Inference/BatchScheduler+Telemetry.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/BatchScheduler+Telemetry.swift
@@ -1,0 +1,217 @@
+// Copyright © 2026 Eigen Labs.
+//
+// Telemetry surface for `BatchScheduler`:
+//   * `backendCapacity()` — heartbeat payload (active/queued tokens,
+//     observed TPS, KV-byte budget).
+//   * `recordBatchPerformance` + `updateDynamicMaxConcurrentRequests`
+//     — EWMA-driven adaptive concurrency cap (drives `maxNumSeqs` on
+//     the underlying engine).
+//   * `refreshPendingSummaryCache` — pulls planner pending stats into
+//     a cached snapshot so `backendCapacity` doesn't hop the planner
+//     actor on every heartbeat.
+//
+// Access promotions vs the pre-split file:
+//   * `recordBatchPerformance`, `updateDynamicMaxConcurrentRequests`,
+//     `refreshPendingSummaryCache`, `updateDecodeTpsEwma`,
+//     `releaseKVReservation`, `gpuMemory` were `private` — now
+//     `internal` so they can be called from the bridge / main file
+//     across this set of extensions.
+
+import Foundation
+import MLX
+
+extension BatchScheduler {
+
+    // MARK: - Computed admission / capacity properties
+    //
+    // Read by `submit()` (admission gating), `capacity()` (heartbeat),
+    // and `backendCapacity()` below. Live here next to the heartbeat
+    // surface since they all share the same accounting view of
+    // `activeBridges` + `pendingSummaryCache`.
+
+    /// Memory-aware token budget. Below the static cap when the GPU is
+    /// memory-pressured, never exceeds it.
+    var tokenBudgetMax: Int {
+        let staticBudget = dynamicTokenBudgetMax > 0
+            ? dynamicTokenBudgetMax
+            : defaultMaxTokens * maxConcurrentRequests
+        guard modelWeightBytes > 0, kvBytesPerToken > 0 else {
+            return staticBudget
+        }
+
+        let totalMemory = Int(ProcessInfo.processInfo.physicalMemory)
+        let osReserve = 4 * 1024 * 1024 * 1024
+        let safetyMargin = totalMemory / 10
+        let globalUsed = Int(MLX.GPU.activeMemory) + Int(MLX.GPU.cacheMemory)
+        let availableHeadroom = max(0, totalMemory - osReserve - safetyMargin - globalUsed)
+        let liveBudget = activeTokenBudgetUsed + (availableHeadroom / kvBytesPerToken)
+        return max(1024, min(staticBudget, liveBudget))
+    }
+
+    /// Sum of `(promptTokens + maxTokens)` across active bridges. This
+    /// is the value the P1 cumulative-budget gate in `submit()` checks
+    /// against `tokenBudgetMax`.
+    var activeTokenBudgetUsed: Int {
+        activeBridges.values.reduce(0) { $0 + $1.promptTokens + $1.maxTokens }
+    }
+
+    var queuedTokenBudget: Int { pendingSummaryCache.queuedTokens }
+
+    var pendingRequestCount: Int { pendingSummaryCache.queuedRequests }
+
+    var currentTokenBudgetUsed: Int {
+        activeTokenBudgetUsed + queuedTokenBudget
+    }
+
+    private var averageReservedTokensForAdmission: Int {
+        let requestCount = activeBridges.count + pendingRequestCount
+        guard requestCount > 0 else { return defaultMaxTokens }
+        return max(1, currentTokenBudgetUsed / requestCount)
+    }
+
+    private var memoryBoundMaxConcurrentRequests: Int {
+        let budget = tokenBudgetMax
+        let averageReserved = averageReservedTokensForAdmission
+        guard budget > 0, averageReserved > 0 else { return 1 }
+        return max(1, min(maxConcurrentRequests, budget / averageReserved))
+    }
+
+    /// Effective concurrency cap reported via `capacity()`. Floor at 1
+    /// so a momentary spike in `memoryBoundMaxConcurrentRequests`
+    /// doesn't deadlock submission.
+    var effectiveMaxConcurrentRequests: Int {
+        max(1, min(maxConcurrentRequests, dynamicMaxConcurrentRequests, memoryBoundMaxConcurrentRequests))
+    }
+
+    // MARK: - Heartbeat payload
+
+    /// Public surface called from `ProviderLoop` on every heartbeat tick.
+    /// Implementation lives in the telemetry extension because most of
+    /// the fields are EWMA / queued-budget state owned here.
+    public func backendCapacity() async -> BackendCapacity {
+        await refreshPendingSummaryCache()
+        let cap = capacity()
+        let gbDivisor = 1024.0 * 1024.0 * 1024.0
+
+        var activeTokens: Int64 = 0
+        var maxTokensPotential: Int64 = 0
+        for entry in activeBridges.values {
+            activeTokens += Int64(entry.promptTokens + entry.completionTokens)
+            maxTokensPotential += Int64(entry.promptTokens + entry.maxTokens)
+        }
+
+        let budgetMax = Int64(tokenBudgetMax)
+
+        let slot = BackendSlotCapacity(
+            model: cap.model,
+            state: cap.activeRequests > 0 ? "running" : "idle",
+            numRunning: UInt32(cap.activeRequests),
+            numWaiting: UInt32(cap.pendingRequests),
+            activeTokens: activeTokens,
+            maxTokensPotential: maxTokensPotential,
+            maxConcurrency: UInt32(cap.maxConcurrent),
+            observedDecodeTps: observedDecodeTpsEwma,
+            activeTokenBudgetUsed: Int64(activeTokenBudgetUsed),
+            activeTokenBudgetMax: budgetMax,
+            queuedTokenBudget: Int64(queuedTokenBudget),
+            kvBytesPerToken: Int64(kvBytesPerToken)
+        )
+        return BackendCapacity(
+            slots: [slot],
+            gpuMemoryActiveGb: Double(cap.gpuMemoryActiveBytes) / gbDivisor,
+            gpuMemoryPeakGb: Double(cap.gpuMemoryPeakBytes) / gbDivisor,
+            gpuMemoryCacheGb: Double(cap.gpuMemoryCacheBytes) / gbDivisor,
+            totalMemoryGb: Double(cap.totalMemoryBytes) / gbDivisor
+        )
+    }
+
+    // MARK: - Adaptive cap (TPS-driven)
+
+    /// Update the per-batch-size TPS sample. Called from `recordFinish`.
+    /// Drives `updateDynamicMaxConcurrentRequests` which mirrors the
+    /// cap into the engine via `setMaxNumSeqs`.
+    func recordBatchPerformance(observedBatchSize: Int, tps: Double) {
+        guard observedBatchSize > 0, tps > 0 else { return }
+        let aggregateTps = tps * Double(observedBatchSize)
+        performanceByBatchSize[observedBatchSize, default: AdaptiveBatchPerformanceBucket()]
+            .record(aggregateTps: aggregateTps, perRequestTps: tps)
+        updateDynamicMaxConcurrentRequests(observedBatchSize: observedBatchSize)
+    }
+
+    func updateDynamicMaxConcurrentRequests(observedBatchSize: Int) {
+        let next = adaptiveCapPolicy.nextCap(
+            currentCap: dynamicMaxConcurrentRequests,
+            hardCap: maxConcurrentRequests,
+            observedBatchSize: observedBatchSize,
+            performanceByBatchSize: performanceByBatchSize
+        )
+        guard next != dynamicMaxConcurrentRequests else { return }
+        dynamicMaxConcurrentRequests = next
+        // Mirror to the engine (planner also enforces, ahead of admission).
+        engine?.setMaxNumSeqs(next)
+    }
+
+    /// EWMA update for `observedDecodeTpsEwma`. Split out of
+    /// `recordFinish` so the bridge file isn't entangled with EWMA
+    /// math.
+    func updateDecodeTpsEwma(tps: Double) {
+        let alpha = 0.3
+        if ewmaInitialized {
+            observedDecodeTpsEwma = alpha * tps + (1 - alpha) * observedDecodeTpsEwma
+        } else {
+            observedDecodeTpsEwma = tps
+            ewmaInitialized = true
+        }
+    }
+
+    // MARK: - Cached pending-queue summary
+
+    /// Refresh `pendingSummaryCache` from the planner. Called whenever
+    /// admission or completion changes the planner pending list.
+    func refreshPendingSummaryCache() async {
+        guard let planner = self.planner else {
+            pendingSummaryCache = .empty
+            return
+        }
+        let snap = await planner.snapshot()
+        // Exclude entries that are already in `activeBridges`: their
+        // budget is counted under `activeTokenBudgetUsed`, and the
+        // planner keeps them in `pendingRequests` until `cancel`.
+        // Without this filter the admission gate double-counts.
+        let trulyPending = snap.pendingRequests.filter {
+            activeBridges[$0.id] == nil
+        }
+        let queuedTokens = trulyPending.reduce(0) {
+            $0 + $1.promptTokenCount + $1.maxOutputTokens
+        }
+        pendingSummaryCache = PendingSummary(
+            queuedRequests: trulyPending.count,
+            queuedTokens: queuedTokens
+        )
+    }
+
+    // MARK: - Misc helpers (small enough to live next to telemetry)
+
+    /// Release the global KV-byte reservation, if any. Called from the
+    /// bridge file's recordFinish/dropBridge and from the main file's
+    /// cancel/cancelAll/stopCurrentEngine paths.
+    func releaseKVReservation(requestID: String) async {
+        guard let kvBudget else { return }
+        await kvBudget.release(requestID: requestID)
+    }
+
+    /// GPU memory read indirection. `private` could compile but
+    /// `internal` lets `capacity()` (main file) call it without an
+    /// extra hop in extensions.
+    func gpuMemory(_ kind: MemoryKind) -> Int {
+        #if canImport(Metal)
+        switch kind {
+        case .active: return MLX.GPU.activeMemory
+        case .peak: return MLX.GPU.peakMemory
+        case .cache: return MLX.GPU.cacheMemory
+        }
+        #else
+        return 0
+        #endif
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Inference/BatchScheduler.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/BatchScheduler.swift
@@ -1,131 +1,98 @@
 // Copyright © 2026 Eigen Labs.
 //
 // Continuous-batching inference scheduler for the Darkbloom provider.
-// All concurrent requests share one `BatchGenerator`, which runs one
-// batched forward pass per step and emits per-row decoded tokens.
+// Wraps `MLXLMCommon.BatchedEngine` with the provider-specific policy
+// layer: GPU enforcement, byte-level KV budgets, admission control,
+// pending-queue timeouts, and the adaptive concurrency cap.
+//
+// The engine itself drives the GPU step loop on its own dispatch queue;
+// this actor's job is to gate submission, surface capacity, and bridge
+// per-request `RequestOutput` streams to our public `GenerationEvent`
+// stream.
+//
+// This file holds the actor declaration, instance state, public
+// surface (`init`/`loadModel`/`unloadModel`/`submit`/`cancel`/
+// `cancelAll`/`capacity`) and tiny internal helpers used by all
+// extensions. Bigger units of behaviour live in:
+//
+//   * `BatchSchedulerTypes.swift`        — supporting types
+//   * `BatchScheduler+EngineBridge.swift`— per-request stream bridge,
+//                                           bridge bookkeeping, the
+//                                           pending-timeout watchdog
+//   * `BatchScheduler+KVEstimation.swift`— pure config.json parsing +
+//                                           KV-bytes math (no actor
+//                                           state)
+//   * `BatchScheduler+Telemetry.swift`   — `backendCapacity` heartbeat,
+//                                           EWMA + adaptive cap,
+//                                           pending-summary cache
 
 import Foundation
 import MLX
 import MLXLLM
 import MLXLMCommon
 
-/// Events emitted by the scheduler for a single inference request.
-public enum GenerationEvent: Sendable {
-    case chunk(String)
-    case info(promptTokens: Int, completionTokens: Int, tokensPerSecond: Double)
-    case error(String)
-}
-
-/// Snapshot of the scheduler's capacity, reported to the coordinator in heartbeats.
-public struct SchedulerCapacity: Sendable {
-    public let model: String
-    public let activeRequests: Int
-    public let pendingRequests: Int
-    public let maxConcurrent: Int
-    public let engineMaxConcurrent: Int
-    public let gpuMemoryActiveBytes: Int
-    public let gpuMemoryPeakBytes: Int
-    public let gpuMemoryCacheBytes: Int
-    public let totalMemoryBytes: UInt64
-}
-
-/// Continuous-batching scheduler. One shared `BatchGenerator` runs all
-/// concurrent requests through one batched forward pass per step.
-///
-/// Lifecycle:
-///   1. `loadModel(container:modelId:)` snapshots the tokenizer + EOS
-///      tokens and starts a long-running worker task.
-///   2. `submit(request:requestId:)` tokenizes the chat-template prompt,
-///      enqueues into the BatchGenerator, and returns an
-///      `AsyncStream<GenerationEvent>`.
-///   3. The detached worker calls `stepEngine()` repeatedly, dispatching
-///      per-row tokens as detokenized text chunks.
-///   4. `unloadModel()` cancels everything.
+/// Continuous-batching scheduler. Wraps a single `MLXLMCommon.BatchedEngine`
+/// per loaded model. The engine owns the GPU step loop; this actor owns
+/// admission control, KV-byte budgeting, the pending-queue timeout, and
+/// the adaptive concurrency cap.
 public actor BatchScheduler {
 
-    private let maxConcurrentRequests: Int
-    private let pendingTimeout: Duration
-    private let defaultMaxTokens: Int
-    private let kvBudget: GlobalKVCacheBudget?
+    // MARK: - Configuration (immutable after init)
 
-    private var modelContainer: ModelContainer?
-    private var modelId: String = ""
-    private var modelWeightBytes: Int = 0
-    private var kvBytesPerToken: Int = 400_000
-    private var dynamicTokenBudgetMax: Int = 0
+    let maxConcurrentRequests: Int
+    let pendingTimeout: Duration
+    let defaultMaxTokens: Int
+    let kvBudget: GlobalKVCacheBudget?
+    let adaptiveCapPolicy = AdaptiveBatchCapPolicy.default
 
-    /// Queue planner for admission control, token budget tracking, and request
-    /// phase management. Created in `loadModel()` once the dynamic token budget
-    /// is known; `nil` before a model is loaded (inline fallback is used).
-    private var planner: BatchQueuePlanner?
+    // MARK: - Model-specific state (set by `loadModel`)
 
-    private var tokenizer: TokenizerBox?
-    private var generator: BatchGenerator?
-    private var workerTask: Task<Void, Never>?
+    var modelContainer: ModelContainer?
+    var modelId: String = ""
+    var modelWeightBytes: Int = 0
+    var kvBytesPerToken: Int = 400_000
+    var dynamicTokenBudgetMax: Int = 0
+    var tokenizer: TokenizerHandle?
+    var engine: BatchedEngine?
 
-    private var active: [Int: ActiveRequest] = [:]
-    private var requestIdToUid: [String: Int] = [:]
-    private var pending: [PendingRequest] = []
-    private var cancelledUIDs = Set<Int>()
-    private var generationEpoch: UInt64 = 0
-    private var engineBusy = false
-    private var observedDecodeTpsEwma: Double = 0
-    private var ewmaInitialized = false
-    private var performanceByBatchSize: [Int: AdaptiveBatchPerformanceBucket] = [:]
-    private var dynamicMaxConcurrentRequests: Int
+    /// Admission control + token budget tracking. `nil` until `loadModel()`.
+    var planner: BatchQueuePlanner?
 
-    /// Once every active row has received its first token, run several decode
-    /// steps per actor/model hop. A single hop per token starves Gemma-class
-    /// models because the CPU actor round trip is larger than one GPU step.
-    private let decodeBurstSteps = 32
-    private let adaptiveCapPolicy = AdaptiveBatchCapPolicy.default
-    static let maxConfigJSONBytes = 4 * 1024 * 1024
+    /// Watchdog for planner-pending requests that exceed `pendingTimeout`.
+    var pendingTimeoutTask: Task<Void, Never>?
+    /// Bumped on every `loadModel` / `stopCurrentEngine` so stale model
+    /// loads can detect they've been superseded.
+    var generationEpoch: UInt64 = 0
 
-    private var tokenBudgetMax: Int {
-        let staticBudget = dynamicTokenBudgetMax > 0
-            ? dynamicTokenBudgetMax
-            : defaultMaxTokens * maxConcurrentRequests
-        guard modelWeightBytes > 0, kvBytesPerToken > 0 else {
-            return staticBudget
-        }
+    // MARK: - Per-request state (mutated by bridge + admission paths)
 
-        let totalMemory = Int(ProcessInfo.processInfo.physicalMemory)
-        let osReserve = 4 * 1024 * 1024 * 1024
-        let safetyMargin = totalMemory / 10
-        let globalUsed = Int(MLX.GPU.activeMemory) + Int(MLX.GPU.cacheMemory)
-        let availableHeadroom = max(0, totalMemory - osReserve - safetyMargin - globalUsed)
-        let liveBudget = activeTokenBudgetUsed + (availableHeadroom / kvBytesPerToken)
-        return max(1024, min(staticBudget, liveBudget))
-    }
+    /// Populated in `submit(...)` before `engine.core.addRequest`; torn
+    /// down by the per-request streaming Task on finish/abort.
+    var activeBridges: [String: BridgeState] = [:]
+    /// Bridges aborted by the pending-timeout watchdog. Drives the
+    /// distinct "request timed out waiting for capacity" error string
+    /// (vs. "request cancelled" for client-initiated aborts).
+    var timedOutBridges: Set<String> = []
 
-    private var activeTokenBudgetUsed: Int {
-        active.values.reduce(0) { $0 + $1.promptTokens + $1.maxTokens }
-    }
+    // MARK: - Telemetry state (read by `backendCapacity`)
 
-    private var queuedTokenBudget: Int {
-        pending.reduce(0) { $0 + $1.promptTokens.count + $1.maxTokens }
-    }
+    var observedDecodeTpsEwma: Double = 0
+    var ewmaInitialized = false
+    /// Per-batch-size TPS samples that drive `AdaptiveBatchCapPolicy`.
+    var performanceByBatchSize: [Int: AdaptiveBatchPerformanceBucket] = [:]
+    var lastBatchSampleAt: ContinuousClock.Instant = .now
+    var dynamicMaxConcurrentRequests: Int
+    var pendingSummaryCache: PendingSummary = .empty
 
-    private var currentTokenBudgetUsed: Int {
-        activeTokenBudgetUsed + queuedTokenBudget
-    }
+    /// Memory-kind selector for `gpuMemory(_:)` in the telemetry extension.
+    enum MemoryKind { case active, peak, cache }
 
-    private var averageReservedTokensForAdmission: Int {
-        let requestCount = active.count + pending.count
-        guard requestCount > 0 else { return defaultMaxTokens }
-        return max(1, currentTokenBudgetUsed / requestCount)
-    }
+    // Computed admission / capacity properties (tokenBudgetMax,
+    // activeTokenBudgetUsed, effectiveMaxConcurrentRequests, etc.)
+    // live in `BatchScheduler+Telemetry.swift` next to the heartbeat
+    // surface that consumes them.
 
-    private var memoryBoundMaxConcurrentRequests: Int {
-        let budget = tokenBudgetMax
-        let averageReserved = averageReservedTokensForAdmission
-        guard budget > 0, averageReserved > 0 else { return 1 }
-        return max(1, min(maxConcurrentRequests, budget / averageReserved))
-    }
-
-    private var effectiveMaxConcurrentRequests: Int {
-        max(1, min(maxConcurrentRequests, dynamicMaxConcurrentRequests, memoryBoundMaxConcurrentRequests))
-    }
+    // MARK: - Init
 
     public init(
         maxConcurrentRequests: Int = 4,
@@ -143,10 +110,7 @@ public actor BatchScheduler {
     // MARK: - Model lifecycle
 
     public func loadModel(container: ModelContainer, modelId: String) async {
-        // Hard-fail before we touch any model weights if the GPU is
-        // unavailable. CPU fallback for inference would be a silent
-        // 100\u{D7} performance regression; never acceptable for the
-        // production provider.
+        // Hard-fail if Metal is unavailable; CPU inference is not acceptable.
         do {
             _ = try GPUEnforcement.requireMetal()
         } catch {
@@ -159,179 +123,134 @@ public actor BatchScheduler {
         await stopCurrentEngine()
         let loadEpoch = generationEpoch
 
-        let snapshot: LoadSnapshot = await container.perform { ctx in
-            let bytes = ctx.model.parameters().flattened().reduce(0) { $0 + $1.1.nbytes }
-            var eos: [[Int]] = []
-            if let id = ctx.tokenizer.convertTokenToId(ctx.tokenizer.eosToken ?? "") {
-                eos.append([id])
-            }
-
-            // Read architecture metadata from config.json. This is more
-            // universal than the KVCacheDimensionProvider protocol (which
-            // some models like Gemma 3/3n don't conform to) and gives us
-            // access to hybrid-architecture fields (num_kv_shared_layers,
-            // global_head_dim, sliding_window_pattern, etc.).
-            var numLayers: Int?
-            var kvHeads: Int?
-            var headDim: Int?
-            var numKvSharedLayers: Int = 0
-            var globalHeadDim: Int?
-            var numGlobalKvHeads: Int?
-            var slidingWindowPattern: Int?
-            var layerTypes: [String]?
-
-            if case .directory(let modelDir) = ctx.configuration.id {
-                let configURL = modelDir.appendingPathComponent("config.json")
-                if let data = Self.readBoundedConfigJSON(configURL),
-                    let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
-                    // Resolve nested text_config if present (Gemma 4 VLM wraps everything there)
-                    let cfg: [String: Any]
-                    if let textConfig = json["text_config"] as? [String: Any] {
-                        cfg = textConfig
-                    } else {
-                        cfg = json
-                    }
-
-                    numLayers = cfg["num_hidden_layers"] as? Int
-                    kvHeads = cfg["num_key_value_heads"] as? Int
-                        ?? cfg["num_attention_heads"] as? Int  // MHA fallback
-
-                    headDim = cfg["head_dim"] as? Int
-                    if headDim == nil,
-                       let hs = cfg["hidden_size"] as? Int,
-                       let nh = cfg["num_attention_heads"] as? Int, nh > 0 {
-                        headDim = hs / nh
-                    }
-
-                    // Hybrid architecture fields (Gemma 4, Gemma 3n)
-                    numKvSharedLayers = cfg["num_kv_shared_layers"] as? Int ?? 0
-                    globalHeadDim = cfg["global_head_dim"] as? Int
-                    numGlobalKvHeads = cfg["num_global_key_value_heads"] as? Int
-                    // sliding_window_pattern is an Int in Gemma 3/3n/4:
-                    // e.g. 5 means [sliding, sliding, sliding, sliding, full] repeating
-                    slidingWindowPattern = cfg["sliding_window_pattern"] as? Int
-                    layerTypes = cfg["layer_types"] as? [String]
-                }
-            }
-
-            // Clamp architecture values to prevent absurd token budgets from
-            // crafted config.json (operator-writable model directory).
-            let maxLayersBound = 1024
-            let maxHeadsBound = 1024
-            let maxHeadDimBound = 2048
-
-            if let l = numLayers { numLayers = min(max(l, 1), maxLayersBound) }
-            if let h = kvHeads { kvHeads = min(max(h, 1), maxHeadsBound) }
-            if let hd = headDim { headDim = min(max(hd, 1), maxHeadDimBound) }
-            if let ghd = globalHeadDim { globalHeadDim = min(max(ghd, 1), maxHeadDimBound) }
-            if let gkh = numGlobalKvHeads { numGlobalKvHeads = min(max(gkh, 1), maxHeadsBound) }
-            // Clamp numKvSharedLayers to [0, numLayers]
-            if let l = numLayers {
-                numKvSharedLayers = min(max(numKvSharedLayers, 0), l)
-            } else {
-                numKvSharedLayers = max(numKvSharedLayers, 0)
-            }
-            // Clamp slidingWindowPattern to [0, numLayers]
-            if let swp = slidingWindowPattern {
-                let upperBound = numLayers ?? maxLayersBound
-                slidingWindowPattern = min(max(swp, 0), upperBound)
-            }
-            // Cap layerTypes to first numLayers entries
-            if let lt = layerTypes, let l = numLayers, lt.count > l {
-                layerTypes = Array(lt.prefix(l))
-            }
-
-            return LoadSnapshot(
-                bytes: bytes,
-                eos: eos,
-                tokenizer: TokenizerBox(ctx.tokenizer),
-                model: ctx.model,
-                numLayers: numLayers,
-                kvHeads: kvHeads,
-                headDim: headDim,
-                numKvSharedLayers: numKvSharedLayers,
-                globalHeadDim: globalHeadDim,
-                numGlobalKvHeads: numGlobalKvHeads,
-                slidingWindowPattern: slidingWindowPattern,
-                layerTypes: layerTypes
-            )
-        }
+        let snapshot = await Self.snapshotContainer(container)
+        // Detect concurrent reload that won the race; bail before we
+        // overwrite the new model's state with our stale snapshot.
         guard loadEpoch == generationEpoch else { return }
 
         self.modelContainer = container
         self.modelId = modelId
         self.modelWeightBytes = snapshot.bytes
         self.tokenizer = snapshot.tokenizer
-        self.generator = BatchGenerator(
-            model: snapshot.model,
-            eosTokens: snapshot.eos,
-            defaultMaxTokens: defaultMaxTokens,
-            prefillBatchSize: maxConcurrentRequests,
-            completionBatchSize: maxConcurrentRequests
+
+        let engine = await Self.makeBatchedEngine(
+            container: container,
+            modelId: modelId,
+            maxConcurrentRequests: maxConcurrentRequests,
+            eosTokenIds: snapshot.eosTokenIds
         )
-        startWorker()
+        // Re-check epoch after the engine.start suspension. If another
+        // load/unload won the race, tear down the engine we just built
+        // and bail before we overwrite the winner's state.
+        guard loadEpoch == generationEpoch else {
+            await engine.stop()
+            return
+        }
+        self.engine = engine
+        await engine.start()
+        // Final epoch check after start() — start can suspend too.
+        guard loadEpoch == generationEpoch else {
+            self.engine = nil
+            await engine.stop()
+            return
+        }
 
-        // Compute per-token KV cache cost from architecture metadata in
-        // config.json.  This handles:
-        //   - Standard uniform models (Llama, Qwen, Mistral, Gemma 2)
-        //   - GQA / MQA (fewer KV heads than query heads)
-        //   - Hybrid sliding + global attention (Gemma 4, GPT-OSS)
-        //   - KV sharing (Gemma 4, Gemma 3n): only non-shared layers
-        //     allocate KV caches
-        //   - Differing head dimensions per attention type (Gemma 4:
-        //     sliding layers use head_dim, full-attention layers use
-        //     global_head_dim and possibly num_global_key_value_heads)
-        // Falls back to a weight-bytes heuristic when config metadata is
-        // unavailable (e.g. non-HuggingFace model directories).
-        let estimatedKV: Int
-        if let layers = snapshot.numLayers, let kvH = snapshot.kvHeads,
-           let hd = snapshot.headDim, layers > 0, kvH > 0, hd > 0 {
-            estimatedKV = Self.computeKVBytesPerToken(
-                numLayers: layers,
-                kvHeads: kvH,
-                headDim: hd,
-                numKvSharedLayers: snapshot.numKvSharedLayers,
-                globalHeadDim: snapshot.globalHeadDim,
-                numGlobalKvHeads: snapshot.numGlobalKvHeads,
-                slidingWindowPattern: snapshot.slidingWindowPattern,
-                layerTypes: snapshot.layerTypes
+        applyPostLoadBudgets(snapshot: snapshot)
+        // Apply the conservative startup cap before admitting any request,
+        // otherwise the first few submits could run at the hard cap until
+        // the adaptive policy kicks in.
+        engine.setMaxNumSeqs(dynamicMaxConcurrentRequests)
+        self.planner = makePlanner(activeTokenBudget: tokenBudgetMax)
+        // Engine has no pending-queue TTL; we enforce `pendingTimeout`.
+        startPendingTimeoutWatchdog()
+    }
+
+    /// Snapshot model bytes + tokenizer + architecture out of the
+    /// container. Runs inside `container.perform` (off-actor); returns
+    /// a Sendable struct so the actor can resume on its own executor.
+    private static func snapshotContainer(_ container: ModelContainer) async -> LoadSnapshot {
+        await container.perform { ctx in
+            let bytes = ctx.model.parameters().flattened().reduce(0) { $0 + $1.1.nbytes }
+
+            // Read architecture from config.json: covers hybrid models
+            // (Gemma 3/3n/4) that don't conform to KVCacheDimensionProvider.
+            let architecture: ModelArchitecture
+            if case .directory(let modelDir) = ctx.configuration.id {
+                let configURL = modelDir.appendingPathComponent("config.json")
+                architecture = KVEstimation.parseModelArchitecture(at: configURL)
+            } else {
+                architecture = .empty
+            }
+            return LoadSnapshot(
+                bytes: bytes,
+                tokenizer: TokenizerHandle(ctx.tokenizer),
+                eosTokenIds: ctx.configuration.eosTokenIds,
+                architecture: architecture
             )
-        } else {
-            estimatedKV = max(snapshot.bytes / 25_000, 100_000)
         }
+    }
 
-        // Cross-check: no real model has KV cache cost below ~1000 bytes per
-        // token (even tiny 2-layer models exceed this). If config.json
-        // produced an implausibly small value, log a warning and fall back
-        // to the weight-bytes heuristic to avoid an absurdly large token
-        // budget that could OOM the system.
-        let kvFloor = 1_000
-        let finalKV: Int
-        if estimatedKV < kvFloor && snapshot.numLayers != nil {
-            let heuristicKV = max(snapshot.bytes / 25_000, 100_000)
-            FileHandle.standardError.write(Data(
-                "[WARN] config.json produced implausibly small kvBytesPerToken=\(estimatedKV); falling back to heuristic=\(heuristicKV)\n".utf8
-            ))
-            finalKV = heuristicKV
-        } else {
-            finalKV = estimatedKV
+    /// Build a `BatchedEngine` with our scheduler config. Pulled out
+    /// of `loadModel` so the lifecycle code reads as a sequence of
+    /// 5-line steps. SECURITY (TB-007): the engine's prefix cache
+    /// persists token sequences across requests in process memory.
+    /// Cross-tenant data-leak risk; do not enable without a fresh
+    /// threat model.
+    private static func makeBatchedEngine(
+        container: ModelContainer,
+        modelId: String,
+        maxConcurrentRequests: Int,
+        eosTokenIds: Set<Int>
+    ) async -> BatchedEngine {
+        await container.perform { ctx -> BatchedEngine in
+            let scheduler = Scheduler(
+                model: ctx.model,
+                tokenizer: ctx.tokenizer,
+                config: SchedulerConfig(
+                    maxNumSeqs: maxConcurrentRequests,
+                    maxNumBatchedTokens: 8192,
+                    prefillStepSize: 512,
+                    streamInterval: 1,
+                    maxKVCacheTokens: 0  // unlimited — our kvBudget gates by bytes
+                ),
+                eosTokenIds: eosTokenIds,
+                prefixCache: nil  // SECURITY: TB-007
+            )
+            return BatchedEngine(
+                scheduler: scheduler,
+                tokenizer: ctx.tokenizer,
+                modelName: modelId,
+                config: ContinuousBatchingConfig(
+                    schedulerConfig: scheduler.config,
+                    stepInterval: 0.001,
+                    prefixCacheConfig: nil,  // SECURITY: TB-007
+                    mtpEnabled: false
+                ),
+                externalChatTemplate: nil
+            )
         }
+    }
 
-        self.kvBytesPerToken = finalKV
+    /// Set the post-load budgets driven by architecture + physical
+    /// memory. Pulled out of `loadModel` so the lifecycle reads as a
+    /// short sequence; the arithmetic itself is unchanged.
+    private func applyPostLoadBudgets(snapshot: LoadSnapshot) {
+        self.kvBytesPerToken = Self.resolvedKVBytesPerToken(
+            architecture: snapshot.architecture,
+            weightBytes: snapshot.bytes
+        )
         let totalMemory = Int(ProcessInfo.processInfo.physicalMemory)
         let osReserve = 4 * 1024 * 1024 * 1024
         let safetyMargin = totalMemory / 10
         let availableForKV = totalMemory - snapshot.bytes - osReserve - safetyMargin
-        if availableForKV > 0 && finalKV > 0 {
-            self.dynamicTokenBudgetMax = max(availableForKV / finalKV, 1024)
+        if availableForKV > 0 && kvBytesPerToken > 0 {
+            self.dynamicTokenBudgetMax = max(availableForKV / kvBytesPerToken, 1024)
         } else {
             self.dynamicTokenBudgetMax = 1024
         }
         self.dynamicMaxConcurrentRequests = min(4, maxConcurrentRequests)
         self.performanceByBatchSize.removeAll()
-
-        // Create the planner now that tokenBudgetMax is determined.
-        self.planner = makePlanner(activeTokenBudget: tokenBudgetMax)
+        self.lastBatchSampleAt = .now
     }
 
     public func unloadModel() async {
@@ -347,12 +266,14 @@ public actor BatchScheduler {
         let id = requestId ?? "req-\(UUID().uuidString.prefix(12))"
         let (stream, continuation) = AsyncStream<GenerationEvent>.makeStream()
 
-        guard generator != nil, let tk = tokenizer else {
+        guard let engine = self.engine, let tk = tokenizer else {
             continuation.yield(.error("No model loaded"))
             continuation.finish()
             return stream
         }
 
+        // Pre-tokenize so chat-template errors surface as `.error` events;
+        // engine's internal `buildPrompt` silently falls back to role:content.
         let messages: [[String: any Sendable]] = request.messages.map { msg in
             ["role": msg.role, "content": msg.content]
         }
@@ -367,47 +288,60 @@ public actor BatchScheduler {
             return stream
         }
 
-        let maxTokens = Self.resolvedMaxTokens(requested: request.max_tokens, defaultMaxTokens: defaultMaxTokens)
+        let maxTokens = Self.resolvedMaxTokens(
+            requested: request.max_tokens, defaultMaxTokens: defaultMaxTokens
+        )
 
-        // Admission control: use planner when available, fall back to inline check.
         let requestBudget = promptTokens.count + maxTokens
         guard requestBudget <= tokenBudgetMax else {
-            continuation.yield(.error("token_budget_exhausted: request requires \(requestBudget) tokens but only \(tokenBudgetMax) available"))
+            continuation.yield(.error(
+                "token_budget_exhausted: request requires \(requestBudget) tokens but only \(tokenBudgetMax) available"
+            ))
             continuation.finish()
             return stream
         }
 
+        // P1 fix (atomic): the cumulative gate + slot reservation must
+        // run in one synchronous block. Actor reentrancy across the
+        // upcoming `planner.admit` / `kvBudget.reserve` awaits would
+        // otherwise let two concurrent submits both read the same
+        // `activeTokenBudgetUsed` and both pass the check.
+        //
+        // Reserve our slot by inserting the bridge into `activeBridges`
+        // BEFORE the first await. Other interleaving submits will see
+        // this request's budget in `activeTokenBudgetUsed`. Any early
+        // exit below (planner reject, KV reject) must roll back the
+        // bridge via `dropBridge(...)`.
+        let activeUsed = activeTokenBudgetUsed
+        if activeUsed + requestBudget > tokenBudgetMax {
+            continuation.yield(.error(
+                "token_budget_exhausted: request requires \(requestBudget) tokens but only \(tokenBudgetMax - activeUsed) available"
+            ))
+            continuation.finish()
+            return stream
+        }
+        let bridge = BridgeState(
+            requestId: id,
+            promptTokens: promptTokens.count,
+            maxTokens: maxTokens,
+            submittedAt: .now
+        )
+        activeBridges[id] = bridge
+
         if let planner = self.planner {
             await refreshPlannerPolicy(activeTokenBudget: tokenBudgetMax)
-            let planner = self.planner ?? planner
             let result = await planner.admit(
                 id: id,
                 promptTokenCount: promptTokens.count,
                 maxOutputTokens: maxTokens
             )
             if case .rejected(_, let reason) = result {
-                let errorMsg: String
-                switch reason {
-                case .requestExceedsActiveTokenBudget:
-                    errorMsg = "token_budget_exhausted: request exceeds active token budget"
-                case .requestExceedsBatchTokenBudget:
-                    errorMsg = "token_budget_exhausted: request exceeds batch token budget"
-                case .queueFull:
-                    errorMsg = "token_budget_exhausted: request queue full"
-                case .duplicateRequestID:
-                    errorMsg = "token_budget_exhausted: duplicate request ID"
-                case .invalidTokenCount:
-                    errorMsg = "token_budget_exhausted: invalid token count"
-                }
-                continuation.yield(.error(errorMsg))
+                await dropBridge(requestId: id)
+                continuation.yield(.error(Self.errorMessage(for: reason)))
                 continuation.finish()
                 return stream
             }
-        } else if currentTokenBudgetUsed + requestBudget > tokenBudgetMax {
-            // Fallback: inline check when planner is not yet initialized (no model loaded).
-            continuation.yield(.error("token_budget_exhausted: request requires \(requestBudget) tokens but only \(tokenBudgetMax - currentTokenBudgetUsed) available"))
-            continuation.finish()
-            return stream
+            await refreshPendingSummaryCache()
         }
 
         if let kvBudget {
@@ -417,38 +351,36 @@ public actor BatchScheduler {
                 tokenCount: requestBudget
             )
             guard reserved else {
-                if let planner = self.planner {
-                    await planner.cancel(requestID: id)
-                }
+                await dropBridge(requestId: id)
                 continuation.yield(.error("token_budget_exhausted: insufficient global KV cache headroom"))
                 continuation.finish()
                 return stream
             }
         }
 
+        // Greedy (temperature == 0) hits the engine's vectorized argmax
+        // fast path automatically; just pass the requested value through.
         let temperature = request.temperature ?? 0.0
-        // Pass `nil` for greedy rows so GenerationBatch.step takes its
-        // vectorized fast path (one batched argMax across all rows)
-        // instead of per-row slice + sample + concat. With temperature=0
-        // the fallback sampler is also greedy, so the result is
-        // identical -- only the dispatch path changes.
-        let sampler: RowSampler? = temperature <= 0
-            ? nil
-            : makeRowSampler(
-                temperature: temperature,
-                topP: request.top_p ?? 1.0,
-                topK: request.top_k ?? 0,
-                seed: request.seed
-            )
-        pending.append(PendingRequest(
+        var sp = SamplingParams(maxTokens: maxTokens, temperature: temperature)
+        if let topP = request.top_p { sp.topP = topP }
+        if let topK = request.top_k { sp.topK = topK }
+        if let seed = request.seed { sp.seed = seed }
+
+        let req = Request(
             requestId: id,
-            continuation: continuation,
-            promptTokens: promptTokens,
-            detokenizer: NaiveStreamingDetokenizer(tokenizer: tk.inner),
-            maxTokens: maxTokens,
-            sampler: sampler,
-            submittedAt: .now
-        ))
+            prompt: promptTokens as AnyHashable,
+            samplingParams: sp
+        )
+        _ = await engine.core.addRequest(req)
+
+        // Hand the per-request stream to the bridge extension. Bridge
+        // teardown / finish-event mapping all live in
+        // `BatchScheduler+EngineBridge.swift`.
+        runBridge(
+            requestId: id,
+            outputStream: engine.core.streamOutputs(requestId: id),
+            continuation: continuation
+        )
 
         let scheduler = self
         continuation.onTermination = { @Sendable termination in
@@ -461,56 +393,41 @@ public actor BatchScheduler {
     }
 
     public func cancel(requestId: String) async {
-        if let uid = requestIdToUid[requestId] {
-            await finishRequest(uid: uid, error: "Request cancelled")
+        if let engine = self.engine {
+            // Engine delivers a terminal RequestOutput synchronously; the
+            // streaming Task handles `recordFinish` + KV release.
+            _ = engine.core.abortRequest(requestId)
             return
         }
-        guard let index = pending.firstIndex(where: { $0.requestId == requestId }) else { return }
-        let entry = pending.remove(at: index)
-        await releaseKVReservation(requestID: entry.requestId)
-        entry.continuation.yield(.error("Request cancelled"))
-        entry.continuation.finish()
-
-        // Also remove from the planner's pending queue.
+        // No engine: request may still be planner-pending.
         if let planner = self.planner {
-            Task { await planner.cancel(requestID: requestId) }
+            await planner.cancel(requestID: requestId)
+            await refreshPendingSummaryCache()
         }
+        await releaseKVReservation(requestID: requestId)
     }
 
     public func cancelAll() async {
-        let activeEntries = active
-        let pendingEntries = pending
-        active.removeAll()
-        pending.removeAll()
-
-        var releaseIDs: [String] = []
-        releaseIDs.reserveCapacity(activeEntries.count + pendingEntries.count)
-
-        for (uid, entry) in activeEntries {
-            cancelledUIDs.insert(uid)
-            requestIdToUid.removeValue(forKey: entry.requestId)
-            releaseIDs.append(entry.requestId)
-            entry.continuation.yield(.error("Scheduler shutting down"))
-            entry.continuation.finish()
-            if let planner = self.planner {
-                let cancelledId = entry.requestId
-                Task { await planner.cancel(requestID: cancelledId) }
+        if let engine = self.engine {
+            _ = engine.core.abortAllRequests()
+        }
+        // Planner pending queue: engine only knows about admitted requests.
+        if let planner = self.planner {
+            let snapshot = await planner.snapshot()
+            for entry in snapshot.pendingRequests {
+                await planner.cancel(requestID: entry.id)
             }
-        }
-
-        for entry in pendingEntries {
-            releaseIDs.append(entry.requestId)
-            entry.continuation.yield(.error("Scheduler shutting down"))
-            entry.continuation.finish()
-            if let planner = self.planner {
-                let cancelledId = entry.requestId
-                Task { await planner.cancel(requestID: cancelledId) }
+            for entry in snapshot.activeRequests {
+                await planner.cancel(requestID: entry.id)
             }
+            await refreshPendingSummaryCache()
         }
-
-        for requestID in releaseIDs {
-            await releaseKVReservation(requestID: requestID)
+        let bridgeIds = Array(activeBridges.keys)
+        for id in bridgeIds {
+            await releaseKVReservation(requestID: id)
         }
+        activeBridges.removeAll()
+        timedOutBridges.removeAll()
     }
 
     // MARK: - Capacity
@@ -518,8 +435,8 @@ public actor BatchScheduler {
     public func capacity() -> SchedulerCapacity {
         SchedulerCapacity(
             model: modelId,
-            activeRequests: active.count,
-            pendingRequests: pending.count,
+            activeRequests: activeBridges.count,
+            pendingRequests: pendingRequestCount,
             maxConcurrent: effectiveMaxConcurrentRequests,
             engineMaxConcurrent: maxConcurrentRequests,
             gpuMemoryActiveBytes: gpuMemory(.active),
@@ -529,230 +446,29 @@ public actor BatchScheduler {
         )
     }
 
-    public func backendCapacity() async -> BackendCapacity {
-        let cap = capacity()
-        let gbDivisor = 1024.0 * 1024.0 * 1024.0
-
-        var activeTokens: Int64 = 0
-        var maxTokensPotential: Int64 = 0
-        for entry in active.values {
-            activeTokens += Int64(entry.promptTokens + entry.completionTokens)
-            maxTokensPotential += Int64(entry.promptTokens + entry.maxTokens)
-        }
-
-        let budgetMax = Int64(tokenBudgetMax)
-
-        let slot = BackendSlotCapacity(
-            model: cap.model,
-            state: cap.activeRequests > 0 ? "running" : "idle",
-            numRunning: UInt32(cap.activeRequests),
-            numWaiting: UInt32(cap.pendingRequests),
-            activeTokens: activeTokens,
-            maxTokensPotential: maxTokensPotential,
-            maxConcurrency: UInt32(cap.maxConcurrent),
-            observedDecodeTps: observedDecodeTpsEwma,
-            activeTokenBudgetUsed: Int64(activeTokenBudgetUsed),
-            activeTokenBudgetMax: budgetMax,
-            queuedTokenBudget: Int64(queuedTokenBudget),
-            kvBytesPerToken: Int64(kvBytesPerToken)
-        )
-        return BackendCapacity(
-            slots: [slot],
-            gpuMemoryActiveGb: Double(cap.gpuMemoryActiveBytes) / gbDivisor,
-            gpuMemoryPeakGb: Double(cap.gpuMemoryPeakBytes) / gbDivisor,
-            gpuMemoryCacheGb: Double(cap.gpuMemoryCacheBytes) / gbDivisor,
-            totalMemoryGb: Double(cap.totalMemoryBytes) / gbDivisor
-        )
-    }
-
-    // MARK: - Worker (runs in a detached Task; calls into actor only briefly)
-
-    private func startWorker() {
-        workerTask?.cancel()
-        let scheduler = self
-        workerTask = Task.detached {
-            while !Task.isCancelled {
-                let didStep = await scheduler.stepEngine()
-                if !didStep {
-                    try? await Task.sleep(for: .milliseconds(5))
-                }
-            }
-        }
-    }
-
-    private func stepEngine() async -> Bool {
-        guard let gen = generator, let container = modelContainer else { return false }
-        let epoch = generationEpoch
-        await expireTimedOutPending()
-        guard epoch == generationEpoch, generator === gen else {
-            return false
-        }
-        applyCancelledRequests(to: gen)
-        await admitPendingRequests(into: gen)
-        guard epoch == generationEpoch, generator === gen else {
-            return false
-        }
-        if !gen.hasWork { return false }
-
-        let prioritizeFirstToken = shouldPrioritizeFirstToken
-        let burstSteps = prioritizeFirstToken ? 1 : decodeBurstSteps
-        let activeBefore = max(1, gen.activeCount)
-        let startedAt = ContinuousClock.now
-        engineBusy = true
-        let responses: [GenerationBatchResponse] = await container.perform { _ in
-            var all: [GenerationBatchResponse] = []
-            all.reserveCapacity(max(1, gen.activeCount) * burstSteps)
-            for _ in 0 ..< burstSteps {
-                if !gen.hasWork { break }
-                all.append(contentsOf: gen.next())
-            }
-            return all
-        }
-        engineBusy = false
-        let elapsed = Self.seconds(between: startedAt, and: .now)
-        guard epoch == generationEpoch, generator === gen else {
-            return false
-        }
-        if !prioritizeFirstToken, !responses.isEmpty, elapsed > 0 {
-            recordBatchPerformance(
-                batchSize: activeBefore,
-                tokenCount: responses.count,
-                elapsedSeconds: elapsed
-            )
-        }
-        applyCancelledRequests(to: gen)
-        await dispatchResponses(responses, producedAt: .now)
-        return true
-    }
-
-    private var shouldPrioritizeFirstToken: Bool {
-        active.values.contains { $0.completionTokens == 0 }
-    }
-
-    private func admitPendingRequests(into gen: BatchGenerator) async {
-        guard !pending.isEmpty else { return }
-        let freeSlots = max(0, effectiveMaxConcurrentRequests - active.count)
-        guard freeSlots > 0 else { return }
-
-        var activeBudgetAfterAdmission = activeTokenBudgetUsed
-        let budgetMax = tokenBudgetMax
-        var batch: [PendingRequest] = []
-        var rejected: [(entry: PendingRequest, error: String)] = []
-        batch.reserveCapacity(freeSlots)
-
-        var pendingIndex = 0
-        while batch.count < freeSlots, pendingIndex < pending.count {
-            let next = pending[pendingIndex]
-            let requestBudget = next.promptTokens.count + next.maxTokens
-            if requestBudget > budgetMax {
-                pending.remove(at: pendingIndex)
-                rejected.append((
-                    entry: next,
-                    error: "token_budget_exhausted: request requires \(requestBudget) tokens but only \(budgetMax) available"
-                ))
-                continue
-            }
-            if activeBudgetAfterAdmission + requestBudget > budgetMax {
-                pendingIndex += 1
-                continue
-            }
-            batch.append(pending.remove(at: pendingIndex))
-            activeBudgetAfterAdmission += requestBudget
-        }
-
-        guard !batch.isEmpty else {
-            await rejectPendingRequests(rejected)
-            return
-        }
-
-        let assignedUids = gen.insert(
-            prompts: batch.map(\.promptTokens),
-            maxTokens: batch.map(\.maxTokens),
-            samplers: batch.map(\.sampler)
-        )
-
-        for (uid, entry) in zip(assignedUids, batch) {
-            active[uid] = ActiveRequest(
-                requestId: entry.requestId,
-                continuation: entry.continuation,
-                detokenizer: entry.detokenizer,
-                promptTokens: entry.promptTokens.count,
-                completionTokens: 0,
-                maxTokens: entry.maxTokens,
-                firstTokenAt: nil,
-                lastTokenAt: nil,
-                submittedAt: entry.submittedAt
-            )
-            requestIdToUid[entry.requestId] = uid
-        }
-
-        if assignedUids.count < batch.count {
-            for entry in batch.dropFirst(assignedUids.count) {
-                rejected.append((entry: entry, error: "BatchGenerator rejected the prompt"))
-            }
-        }
-
-        await rejectPendingRequests(rejected)
-    }
-
-    private func rejectPendingRequests(_ rejected: [(entry: PendingRequest, error: String)]) async {
-        guard !rejected.isEmpty else { return }
-        let planner = self.planner
-        for rejection in rejected {
-            await releaseKVReservation(requestID: rejection.entry.requestId)
-            rejection.entry.continuation.yield(.error(rejection.error))
-            rejection.entry.continuation.finish()
-            if let planner {
-                let rejectedId = rejection.entry.requestId
-                Task { await planner.cancel(requestID: rejectedId) }
-            }
-        }
-    }
-
-    private func expireTimedOutPending(now: ContinuousClock.Instant = .now) async {
-        guard !pending.isEmpty else { return }
-
-        var stillPending: [PendingRequest] = []
-        var timedOut: [PendingRequest] = []
-        stillPending.reserveCapacity(pending.count)
-        for entry in pending {
-            if now - entry.submittedAt >= pendingTimeout {
-                timedOut.append(entry)
-            } else {
-                stillPending.append(entry)
-            }
-        }
-        pending = stillPending
-
-        for entry in timedOut {
-            entry.continuation.yield(.error("Request timed out waiting for capacity"))
-            entry.continuation.finish()
-            if let planner = self.planner {
-                let timedOutId = entry.requestId
-                Task { await planner.cancel(requestID: timedOutId) }
-            }
-        }
-        for entry in timedOut {
-            await releaseKVReservation(requestID: entry.requestId)
-        }
-    }
-
-    private func applyCancelledRequests(to gen: BatchGenerator) {
-        guard !cancelledUIDs.isEmpty else { return }
-        for uid in cancelledUIDs {
-            gen.cancel(uid: uid)
-        }
-        cancelledUIDs.removeAll()
-    }
+    // MARK: - Internal helpers
 
     private func stopCurrentEngine() async {
         generationEpoch &+= 1
-        workerTask?.cancel()
-        workerTask = nil
-        generator = nil
+        pendingTimeoutTask?.cancel()
+        pendingTimeoutTask = nil
+
+        if let engine = self.engine {
+            _ = engine.core.abortAllRequests()
+            await engine.stop()
+        }
+        self.engine = nil
         modelContainer = nil
         tokenizer = nil
-        await cancelAll()
+
+        let bridgeIds = Array(activeBridges.keys)
+        for id in bridgeIds {
+            await releaseKVReservation(requestID: id)
+        }
+        activeBridges.removeAll()
+        timedOutBridges.removeAll()
+        pendingSummaryCache = .empty
+
         modelWeightBytes = 0
         modelId = ""
         kvBytesPerToken = 400_000
@@ -762,170 +478,26 @@ public actor BatchScheduler {
         ewmaInitialized = false
         performanceByBatchSize.removeAll()
         dynamicMaxConcurrentRequests = min(4, maxConcurrentRequests)
-
-        while engineBusy {
-            try? await Task.sleep(for: .milliseconds(1))
-        }
-        cancelledUIDs.removeAll()
     }
 
-    private func dispatchResponses(
-        _ responses: [GenerationBatchResponse],
-        producedAt: ContinuousClock.Instant
-    ) async {
-        var byUID: [Int: [GenerationBatchResponse]] = [:]
-        byUID.reserveCapacity(responses.count)
-        for response in responses {
-            byUID[response.uid, default: []].append(response)
-        }
-
-        for uid in responses.map(\.uid) where byUID[uid] != nil {
-            let rowResponses = byUID.removeValue(forKey: uid)!
-            await dispatchRowResponses(rowResponses, producedAt: producedAt)
-        }
-    }
-
-    private func dispatchRowResponses(
-        _ responses: [GenerationBatchResponse],
-        producedAt: ContinuousClock.Instant
-    ) async {
-        guard let first = responses.first, var entry = active[first.uid] else { return }
-
-        var finalResponse: GenerationBatchResponse?
-        for response in responses {
-            entry.detokenizer.append(token: response.token)
-            entry.completionTokens += 1
-            if entry.firstTokenAt == nil {
-                entry.firstTokenAt = producedAt
-            }
-            entry.lastTokenAt = producedAt
-            if response.finishReason != nil {
-                finalResponse = response
-            }
-        }
-
-        if let chunk = entry.detokenizer.next(), !chunk.isEmpty {
-            entry.continuation.yield(.chunk(chunk))
-        }
-        active[first.uid] = entry
-
-        if finalResponse != nil {
-            // One final flush. `NaiveStreamingDetokenizer.next()` returns
-            // the substring added since the last call; once the segment is
-            // fully consumed it returns "" (not nil), so calling it in a
-            // loop would spin forever re-decoding the same prefix.
-            if let tail = entry.detokenizer.next(), !tail.isEmpty {
-                entry.continuation.yield(.chunk(tail))
-            }
-
-            let tps: Double
-            if let firstTokenAt = entry.firstTokenAt, let lastTokenAt = entry.lastTokenAt,
-                entry.completionTokens > 1
-            {
-                let decodeElapsed = lastTokenAt - firstTokenAt
-                let elapsedSeconds = Double(decodeElapsed.components.seconds)
-                    + Double(decodeElapsed.components.attoseconds) / 1e18
-                tps = elapsedSeconds > 0
-                    ? Double(entry.completionTokens - 1) / elapsedSeconds : 0
-            } else {
-                let elapsed = ContinuousClock.now - entry.submittedAt
-                let elapsedSeconds = Double(elapsed.components.seconds)
-                    + Double(elapsed.components.attoseconds) / 1e18
-                tps = elapsedSeconds > 0
-                    ? Double(entry.completionTokens) / elapsedSeconds : 0
-            }
-
-            if tps > 0 {
-                let alpha = 0.3
-                if ewmaInitialized {
-                    observedDecodeTpsEwma = alpha * tps + (1 - alpha) * observedDecodeTpsEwma
-                } else {
-                    observedDecodeTpsEwma = tps
-                    ewmaInitialized = true
-                }
-            }
-
-            entry.continuation.yield(.info(
-                promptTokens: entry.promptTokens,
-                completionTokens: entry.completionTokens,
-                tokensPerSecond: tps
-            ))
-            entry.continuation.finish()
-            active.removeValue(forKey: first.uid)
-            requestIdToUid.removeValue(forKey: entry.requestId)
-            await releaseKVReservation(requestID: entry.requestId)
-
-            // Notify planner that this request is done so its token budget
-            // is released for future admissions. Use cancel() instead of
-            // complete() because the planner's nextBatch() is never called
-            // (BatchScheduler manages its own pending→active promotion),
-            // so entries remain in the planner's pending queue. cancel()
-            // removes from both pending and active; complete() only checks
-            // active, causing a permanent leak that eventually triggers
-            // queueFull rejection.
-            if let planner = self.planner {
-                let completedId = entry.requestId
-                Task { await planner.cancel(requestID: completedId) }
-            }
-        }
-    }
-
-    private func recordBatchPerformance(
-        batchSize: Int,
-        tokenCount: Int,
-        elapsedSeconds: Double
-    ) {
-        guard batchSize > 0, tokenCount > 0, elapsedSeconds > 0 else { return }
-
-        let aggregateTps = Double(tokenCount) / elapsedSeconds
-        let perRequestTps = aggregateTps / Double(batchSize)
-        performanceByBatchSize[batchSize, default: AdaptiveBatchPerformanceBucket()]
-            .record(aggregateTps: aggregateTps, perRequestTps: perRequestTps)
-        updateDynamicMaxConcurrentRequests(observedBatchSize: batchSize)
-    }
-
-    private func updateDynamicMaxConcurrentRequests(observedBatchSize: Int) {
-        dynamicMaxConcurrentRequests = adaptiveCapPolicy.nextCap(
-            currentCap: dynamicMaxConcurrentRequests,
-            hardCap: maxConcurrentRequests,
-            observedBatchSize: observedBatchSize,
-            performanceByBatchSize: performanceByBatchSize
-        )
-    }
-
-    private static func seconds(
-        between start: ContinuousClock.Instant,
-        and end: ContinuousClock.Instant
-    ) -> Double {
-        let elapsed = end - start
-        return Double(elapsed.components.seconds)
-            + Double(elapsed.components.attoseconds) / 1e18
-    }
-
-    private func finishRequest(uid: Int, error: String) async {
-        guard let entry = active.removeValue(forKey: uid) else { return }
-        cancelledUIDs.insert(uid)
-        let cancelledId = entry.requestId
-        requestIdToUid.removeValue(forKey: cancelledId)
-        await releaseKVReservation(requestID: cancelledId)
-        entry.continuation.yield(.error(error))
-        entry.continuation.finish()
-
-        // Release the request's token budget in the planner.
-        if let planner = self.planner {
-            Task { await planner.cancel(requestID: cancelledId) }
-        }
-    }
-
-    private enum MemoryKind { case active, peak, cache }
-
-    private func releaseKVReservation(requestID: String) async {
-        guard let kvBudget else { return }
-        await kvBudget.release(requestID: requestID)
-    }
-
-    static func resolvedMaxTokens(requested: Int?, defaultMaxTokens: Int) -> Int {
-        requested ?? defaultMaxTokens
+    /// P1 fix: cumulative active-bridge gate, called from tests.
+    ///
+    /// `submit()` inlines the same check synchronously before its
+    /// first `await` (so the gate is atomic with respect to actor
+    /// reentrancy). This helper exists so unit tests can probe the
+    /// gate without a loaded model + non-nil engine.
+    ///
+    /// Returns the canonical `token_budget_exhausted:` error string on
+    /// rejection, or `nil` on accept. Does NOT reserve a slot — that
+    /// happens inline in `submit()` to keep the (check + reserve)
+    /// pair atomic.
+    func checkCumulativeTokenBudget(
+        requestId: String,
+        requestBudget: Int
+    ) -> String? {
+        let activeUsed = activeTokenBudgetUsed
+        guard activeUsed + requestBudget > tokenBudgetMax else { return nil }
+        return "token_budget_exhausted: request requires \(requestBudget) tokens but only \(tokenBudgetMax - activeUsed) available"
     }
 
     private func makePlanner(activeTokenBudget: Int) -> BatchQueuePlanner {
@@ -960,173 +532,8 @@ public actor BatchScheduler {
         await planner.updatePolicy(updatedPolicy)
     }
 
-    static func readBoundedConfigJSON(_ url: URL) -> Data? {
-        guard let handle = try? FileHandle(forReadingFrom: url) else {
-            return nil
-        }
-        defer { try? handle.close() }
-        guard let data = try? handle.read(upToCount: maxConfigJSONBytes + 1),
-              data.count <= maxConfigJSONBytes else { return nil }
-        return data
-    }
-
-    private func gpuMemory(_ kind: MemoryKind) -> Int {
-        #if canImport(Metal)
-        switch kind {
-        case .active: return MLX.GPU.activeMemory
-        case .peak: return MLX.GPU.peakMemory
-        case .cache: return MLX.GPU.cacheMemory
-        }
-        #else
-        return 0
-        #endif
-    }
-
-    // MARK: - KV cache cost computation
-
-    /// Compute total KV cache bytes per token across all layers, accounting
-    /// for architecture-specific differences:
-    ///
-    /// - **KV sharing** (Gemma 4, Gemma 3n): only the first
-    ///   `numLayers - numKvSharedLayers` layers allocate real KV caches.
-    /// - **Hybrid attention** (Gemma 4, GPT-OSS): sliding-attention layers
-    ///   use `headDim` / `kvHeads`, while full-attention layers can use
-    ///   `globalHeadDim` / `numGlobalKvHeads`.
-    /// - **Standard models** (Llama, Qwen, Mistral, Gemma 2): all layers
-    ///   are uniform; degenerates to `cachedLayers * kvHeads * headDim * 4`.
-    static func computeKVBytesPerToken(
-        numLayers: Int,
-        kvHeads: Int,
-        headDim: Int,
-        numKvSharedLayers: Int,
-        globalHeadDim: Int?,
-        numGlobalKvHeads: Int?,
-        slidingWindowPattern: Int?,
-        layerTypes: [String]?
-    ) -> Int {
-        let bytesPerElement = 2  // float16
-        let kvTensors = 2        // K + V
-
-        let cachedLayers = numLayers - numKvSharedLayers
-        guard cachedLayers > 0 else { return 0 }
-
-        // Determine per-layer attention type. Three sources of truth:
-        //   1. Explicit layer_types array from config.json (Gemma 4, GPT-OSS)
-        //   2. slidingWindowPattern Int: e.g. 5 means [S,S,S,S,F] repeating
-        //      (Gemma 3, Gemma 3n, Gemma 4)
-        //   3. Neither: assume all layers are uniform full-attention
-        let resolvedLayerTypes: [String]?
-        if let lt = layerTypes, lt.count >= cachedLayers {
-            resolvedLayerTypes = lt
-        } else if let swp = slidingWindowPattern, swp > 1 {
-            // Derive the repeating pattern: first (swp-1) are sliding,
-            // last one is full attention.
-            var pattern = [String]()
-            for i in 0..<swp {
-                pattern.append(i == swp - 1 ? "full_attention" : "sliding_attention")
-            }
-            var types = [String]()
-            while types.count < cachedLayers {
-                types.append(contentsOf: pattern)
-            }
-            resolvedLayerTypes = Array(types.prefix(cachedLayers))
-        } else {
-            resolvedLayerTypes = nil
-        }
-
-        // Layer types that use fixed-size recurrent state (e.g. GatedDeltaNet/Mamba)
-        // instead of per-token KV cache. These contribute zero per-token KV bytes.
-        let recurrentLayerTypes: Set<String> = [
-            "linear_attention",   // Qwen3.5 GatedDeltaNet
-            "recurrent",          // Generic recurrent layers
-        ]
-
-        // If we have per-layer type information, sum only layers with KV cache.
-        let hasHybridDims = globalHeadDim != nil && globalHeadDim != headDim
-            || numGlobalKvHeads != nil && numGlobalKvHeads != kvHeads
-
-        if let types = resolvedLayerTypes {
-            var totalBytesPerToken = 0
-            for i in 0..<cachedLayers {
-                let layerType = types[i]
-
-                // Recurrent layers (linear_attention, etc.) use fixed-size
-                // state, not per-token KV cache. Skip them.
-                if recurrentLayerTypes.contains(layerType) {
-                    continue
-                }
-
-                let layerKvHeads: Int
-                let layerHeadDim: Int
-
-                if hasHybridDims && layerType == "full_attention" {
-                    // Full/global attention layer with different dimensions
-                    layerKvHeads = numGlobalKvHeads ?? kvHeads
-                    layerHeadDim = globalHeadDim ?? headDim
-                } else {
-                    // Sliding attention or standard full attention
-                    layerKvHeads = kvHeads
-                    layerHeadDim = headDim
-                }
-
-                totalBytesPerToken += layerKvHeads * layerHeadDim * kvTensors * bytesPerElement
-            }
-            return totalBytesPerToken
-        }
-
-        // If we have global_head_dim but no layer type information to
-        // distinguish which layers use it, conservatively use the larger
-        // dimension for all cached layers.
-        if let ghd = globalHeadDim, ghd > headDim {
-            let maxKvHeads = max(kvHeads, numGlobalKvHeads ?? kvHeads)
-            return cachedLayers * maxKvHeads * ghd * kvTensors * bytesPerElement
-        }
-
-        // Standard uniform architecture (no layer_types, no hybrid dims)
-        return cachedLayers * kvHeads * headDim * kvTensors * bytesPerElement
-    }
-}
-
-// MARK: - Supporting types
-
-private struct ActiveRequest {
-    let requestId: String
-    let continuation: AsyncStream<GenerationEvent>.Continuation
-    var detokenizer: NaiveStreamingDetokenizer
-    var promptTokens: Int
-    var completionTokens: Int
-    let maxTokens: Int
-    var firstTokenAt: ContinuousClock.Instant?
-    var lastTokenAt: ContinuousClock.Instant?
-    let submittedAt: ContinuousClock.Instant
-}
-
-private struct PendingRequest {
-    let requestId: String
-    let continuation: AsyncStream<GenerationEvent>.Continuation
-    let promptTokens: [Int]
-    var detokenizer: NaiveStreamingDetokenizer
-    let maxTokens: Int
-    let sampler: RowSampler?
-    let submittedAt: ContinuousClock.Instant
-}
-
-private struct LoadSnapshot: @unchecked Sendable {
-    let bytes: Int
-    let eos: [[Int]]
-    let tokenizer: TokenizerBox
-    let model: any LanguageModel
-    let numLayers: Int?
-    let kvHeads: Int?
-    let headDim: Int?
-    let numKvSharedLayers: Int
-    let globalHeadDim: Int?
-    let numGlobalKvHeads: Int?
-    let slidingWindowPattern: Int?
-    let layerTypes: [String]?
-}
-
-private final class TokenizerBox: @unchecked Sendable {
-    let inner: any MLXLMCommon.Tokenizer
-    init(_ inner: any MLXLMCommon.Tokenizer) { self.inner = inner }
+    // Static helpers live in adjacent extensions:
+    //   * `resolvedMaxTokens`, `resolvedKVBytesPerToken` →
+    //     `BatchScheduler+KVEstimation.swift`
+    //   * `errorMessage(for:)` → `BatchSchedulerTypes.swift`
 }

--- a/provider-swift/Sources/ProviderCore/Inference/BatchSchedulerTypes.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/BatchSchedulerTypes.swift
@@ -1,0 +1,139 @@
+// Copyright © 2026 Eigen Labs.
+//
+// Supporting types for `BatchScheduler` and its extensions.
+//
+// `GenerationEvent` and `SchedulerCapacity` are the public types the
+// scheduler exposes to callers (ProviderLoop / StandaloneServer).
+//
+// `BridgeState`, `PendingSummary`, `LoadSnapshot`, `ModelArchitecture`
+// and `TokenizerHandle` are scheduler-internal — kept `internal` (not
+// `private`) so the bridge / KV-estimation / telemetry extensions can
+// see them across files.
+
+import Foundation
+import MLXLMCommon
+
+// MARK: - Public surface
+
+/// Events emitted by the scheduler for a single inference request.
+public enum GenerationEvent: Sendable {
+    case chunk(String)
+    case info(promptTokens: Int, completionTokens: Int, tokensPerSecond: Double)
+    case error(String)
+}
+
+/// Snapshot of the scheduler's capacity, reported to the coordinator in heartbeats.
+public struct SchedulerCapacity: Sendable {
+    public let model: String
+    public let activeRequests: Int
+    public let pendingRequests: Int
+    public let maxConcurrent: Int
+    public let engineMaxConcurrent: Int
+    public let gpuMemoryActiveBytes: Int
+    public let gpuMemoryPeakBytes: Int
+    public let gpuMemoryCacheBytes: Int
+    public let totalMemoryBytes: UInt64
+}
+
+// MARK: - Internal scheduler-bookkeeping types
+//
+// Promoted from `private` to `internal` so `BatchScheduler+EngineBridge.swift`
+// and `BatchScheduler+Telemetry.swift` can read/mutate them.
+
+/// Per-request bookkeeping driven by the per-request streaming Task.
+///
+/// `admittedAt` is set on the first `RequestOutput` the engine emits
+/// for the request (distinguishing "queued in engine pending list" from
+/// "running on the GPU"). The pending-timeout watchdog uses this to
+/// avoid aborting long prefills as queue timeouts.
+struct BridgeState {
+    let requestId: String
+    var promptTokens: Int
+    var completionTokens: Int = 0
+    let maxTokens: Int
+    let submittedAt: ContinuousClock.Instant
+    var admittedAt: ContinuousClock.Instant?
+    var firstTokenAt: ContinuousClock.Instant?
+    var lastTokenAt: ContinuousClock.Instant?
+}
+
+/// Cached pending-queue stats, refreshed via `refreshPendingSummaryCache`.
+///
+/// We cache so `backendCapacity()` doesn't call into the planner actor
+/// on every heartbeat (which would serialize against admit/cancel).
+struct PendingSummary {
+    let queuedRequests: Int
+    let queuedTokens: Int
+
+    static let empty = PendingSummary(queuedRequests: 0, queuedTokens: 0)
+}
+
+/// Snapshot returned from the `container.perform { ... }` closure in
+/// `loadModel`. Carries everything the actor needs to wire up the
+/// engine + KV-budget without re-entering the container.
+struct LoadSnapshot: @unchecked Sendable {
+    let bytes: Int
+    let tokenizer: TokenizerHandle
+    let eosTokenIds: Set<Int>
+    let architecture: ModelArchitecture
+}
+
+/// Model-architecture fields read from `config.json`, used by
+/// `KVEstimation.computeKVBytesPerToken` to size the token budget.
+/// All values are post-clamp; see `KVEstimation.parseModelArchitecture`.
+struct ModelArchitecture: Sendable {
+    let numLayers: Int?
+    let kvHeads: Int?
+    let headDim: Int?
+    let numKvSharedLayers: Int
+    let globalHeadDim: Int?
+    let numGlobalKvHeads: Int?
+    let slidingWindowPattern: Int?
+    let layerTypes: [String]?
+
+    static let empty = ModelArchitecture(
+        numLayers: nil,
+        kvHeads: nil,
+        headDim: nil,
+        numKvSharedLayers: 0,
+        globalHeadDim: nil,
+        numGlobalKvHeads: nil,
+        slidingWindowPattern: nil,
+        layerTypes: nil
+    )
+}
+
+/// Type-erased wrapper around the loaded model's tokenizer.
+///
+/// Wraps the tokenizer in a class so the actor can hold an `Optional`
+/// reference without copying the underlying tokenizer state every load.
+public final class TokenizerHandle: @unchecked Sendable {
+    public let inner: any MLXLMCommon.Tokenizer
+    public init(_ inner: any MLXLMCommon.Tokenizer) { self.inner = inner }
+}
+
+// MARK: - Error helpers
+
+extension BatchScheduler {
+    /// Translate a planner rejection into the canonical
+    /// `token_budget_exhausted: <reason>` string.
+    ///
+    /// `StandaloneServer.schedulerErrorStatus(for:)` and downstream
+    /// coordinator code both string-match on the
+    /// `token_budget_exhausted:` prefix. Keep the wording stable; any
+    /// change here needs paired updates downstream.
+    static func errorMessage(for reason: BatchRejectionReason) -> String {
+        switch reason {
+        case .requestExceedsActiveTokenBudget:
+            return "token_budget_exhausted: request exceeds active token budget"
+        case .requestExceedsBatchTokenBudget:
+            return "token_budget_exhausted: request exceeds batch token budget"
+        case .queueFull:
+            return "token_budget_exhausted: request queue full"
+        case .duplicateRequestID:
+            return "token_budget_exhausted: duplicate request ID"
+        case .invalidTokenCount:
+            return "token_budget_exhausted: invalid token count"
+        }
+    }
+}

--- a/provider-swift/Tests/ProviderCoreTests/BatchSchedulerBudgetTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/BatchSchedulerBudgetTests.swift
@@ -1,0 +1,233 @@
+// Non-live unit tests for the BatchScheduler cumulative-budget gate
+// (P1 fix) and in-flight bridge progress reporting (P2 fix). These
+// exercise the actor's bookkeeping directly via `@testable import`
+// hooks (`_testSeedBridge`); the full submit -> reject flow is covered
+// by the live tests in BatchSchedulerEngineIntegrationTests.
+
+import Foundation
+import Testing
+@testable import ProviderCore
+
+@Suite("BatchScheduler budget gate + progress reporting")
+struct BatchSchedulerBudgetTests {
+
+    // MARK: - P1: cumulative active-bridge gate
+
+    /// Pre-fix: planner validated per-request limits + queue size only,
+    /// so a burst of large requests each individually within budget
+    /// could overcommit KV memory once they all reached the engine.
+    /// Post-fix: `submit()` re-checks `activeTokenBudgetUsed +
+    /// requestBudget > tokenBudgetMax` before `engine.core.addRequest`.
+    /// This test pins the underlying math.
+    @Test("activeTokenBudgetUsed sums (promptTokens + maxTokens) across active bridges")
+    func activeTokenBudgetSumsCorrectlyAcrossBridges() async {
+        let scheduler = BatchScheduler(
+            maxConcurrentRequests: 4,
+            defaultMaxTokens: 4096
+        )
+        // No model loaded → tokenBudgetMax = defaultMaxTokens *
+        // maxConcurrentRequests = 16384.
+        await scheduler._testSeedBridge(id: "a", promptTokens: 4000, maxTokens: 4000)
+        await scheduler._testSeedBridge(id: "b", promptTokens: 4000, maxTokens: 4000)
+
+        let used = await scheduler.activeTokenBudgetUsed
+        let budget = await scheduler.tokenBudgetMax
+        #expect(used == 16_000, "two bridges of (4000 prompt + 4000 max) = 16000")
+        #expect(budget == 16_384, "static budget = defaultMaxTokens * maxConcurrentRequests")
+
+        // A third request of 500 tokens would push cumulative over.
+        let requestBudget = 500
+        #expect(used + requestBudget > budget,
+            "P1 gate: third bridge pushing cumulative over tokenBudgetMax must trigger rejection")
+    }
+
+    /// End-to-end exercise of the P1 helper. Two bridges admitted
+    /// within budget, a third that pushes cumulative over budget →
+    /// helper returns the canonical `token_budget_exhausted: ...`
+    /// error string. `submit()` inlines the same check synchronously
+    /// before its first await (so it's atomic with respect to actor
+    /// reentrancy) and rolls back via `dropBridge` on the cleanup
+    /// paths below it.
+    @Test("checkCumulativeTokenBudget rejects the third bridge that pushes over")
+    func cumulativeGateRejectsOverflowingBridge() async {
+        let scheduler = BatchScheduler(
+            maxConcurrentRequests: 4,
+            defaultMaxTokens: 4096
+        )
+        // tokenBudgetMax = 16384 (no model loaded).
+        await scheduler._testSeedBridge(id: "a", promptTokens: 4000, maxTokens: 4000)
+        await scheduler._testSeedBridge(id: "b", promptTokens: 4000, maxTokens: 4000)
+        // 16000 used; a 500-token request pushes total to 16500 > 16384.
+
+        let err = await scheduler.checkCumulativeTokenBudget(
+            requestId: "third",
+            requestBudget: 500
+        )
+        #expect(err != nil,
+            "P1: third bridge that pushes cumulative over tokenBudgetMax must be rejected")
+        #expect(err!.hasPrefix("token_budget_exhausted:"),
+            "P1: error wording must use the canonical prefix so coordinator parsing stays stable")
+        #expect(err!.contains("requires 500 tokens but only 384 available"))
+    }
+
+    /// Companion accept-case: same scheduler state, smaller request
+    /// budget that fits → gate returns nil.
+    @Test("checkCumulativeTokenBudget admits the third bridge that fits in budget")
+    func cumulativeGateAdmitsFittingBridge() async {
+        let scheduler = BatchScheduler(
+            maxConcurrentRequests: 4,
+            defaultMaxTokens: 4096
+        )
+        await scheduler._testSeedBridge(id: "a", promptTokens: 4000, maxTokens: 4000)
+        await scheduler._testSeedBridge(id: "b", promptTokens: 4000, maxTokens: 4000)
+
+        let err = await scheduler.checkCumulativeTokenBudget(
+            requestId: "third",
+            requestBudget: 200
+        )
+        #expect(err == nil,
+            "200 tokens fits: 16000 + 200 = 16200 < 16384, gate must not reject")
+    }
+
+    /// Race test: pre-seed bridges so that the next request would
+    /// overflow. The bridge that is already in `activeBridges` (via
+    /// `_testSeedBridge`) counts toward `activeTokenBudgetUsed`, so a
+    /// follow-up request that would push past the budget is rejected
+    /// even when no `planner.admit` await has been crossed. This
+    /// pins the atomic-slot-reservation property that prevents
+    /// concurrent submits from each reading a stale 0 and overcommitting.
+    @Test("cumulative gate stays correct under serially-interleaved bridges")
+    func cumulativeGateAtomicityUnderSerialPreseed() async {
+        let scheduler = BatchScheduler(
+            maxConcurrentRequests: 4,
+            defaultMaxTokens: 4096
+        )
+        // Three sequential 5000-token bridges = 15000. Fourth would
+        // need at most 1384 to fit (16384 - 15000).
+        await scheduler._testSeedBridge(id: "a", promptTokens: 2500, maxTokens: 2500)
+        await scheduler._testSeedBridge(id: "b", promptTokens: 2500, maxTokens: 2500)
+        await scheduler._testSeedBridge(id: "c", promptTokens: 2500, maxTokens: 2500)
+
+        let fitting = await scheduler.checkCumulativeTokenBudget(
+            requestId: "d-small", requestBudget: 1000
+        )
+        let overflowing = await scheduler.checkCumulativeTokenBudget(
+            requestId: "d-big", requestBudget: 2000
+        )
+        #expect(fitting == nil, "1000-budget fits in remaining 1384")
+        #expect(overflowing != nil, "2000-budget exceeds remaining 1384 → reject")
+    }
+
+    /// Pin the planner-rejection → error-string mapping. Same coordinator
+    /// requirement: `token_budget_exhausted:` prefix must be present so
+    /// downstream parsing keeps working.
+    @Test("errorMessage(for:) covers every planner rejection reason")
+    func errorMessageCoversAllRejectionReasons() {
+        let cases: [(BatchRejectionReason, String)] = [
+            (.requestExceedsActiveTokenBudget, "active token budget"),
+            (.requestExceedsBatchTokenBudget, "batch token budget"),
+            (.queueFull, "queue full"),
+            (.duplicateRequestID, "duplicate request ID"),
+            (.invalidTokenCount, "invalid token count"),
+        ]
+        for (reason, fragment) in cases {
+            let msg = BatchScheduler.errorMessage(for: reason)
+            #expect(msg.hasPrefix("token_budget_exhausted:"),
+                "\(reason) must emit a token_budget_exhausted: prefixed string")
+            #expect(msg.contains(fragment),
+                "expected '\(fragment)' in '\(msg)' for \(reason)")
+        }
+    }
+
+    // MARK: - P2: in-flight bridge progress visible to heartbeats
+
+    /// Pre-fix: `BridgeState.completionTokens` was assigned only in
+    /// `recordFinish`, so heartbeats read 0 mid-decode.
+    /// Post-fix: `recordProgress` (called from the bridge Task on every
+    /// non-empty RequestOutput) keeps it live.
+    @Test("backendCapacity reports in-flight completionTokens via recordProgress")
+    func backendCapacityReflectsInFlightProgress() async {
+        let scheduler = BatchScheduler(
+            maxConcurrentRequests: 4,
+            defaultMaxTokens: 4096
+        )
+        await scheduler._testSeedBridge(
+            id: "test-req",
+            promptTokens: 100,
+            maxTokens: 50,
+            admitted: true
+        )
+
+        // Pre-progress: activeTokens = prompt only (completion = 0).
+        var cap = await scheduler.backendCapacity()
+        #expect(cap.slots.count == 1)
+        #expect(cap.slots[0].activeTokens == 100,
+            "pre-progress activeTokens must equal promptTokens (no completion yet)")
+
+        // Simulate stream Task delivering cumulative completion = 3.
+        await scheduler.recordProgress(
+            requestId: "test-req",
+            promptTokens: 100,
+            completionTokens: 3
+        )
+
+        cap = await scheduler.backendCapacity()
+        #expect(cap.slots[0].activeTokens == 103,
+            "P2: backendCapacity must reflect in-flight decode (100 prompt + 3 completion)")
+    }
+
+    /// `recordProgress` must be monotonic on `completionTokens` so that
+    /// an out-of-order stale RequestOutput cannot rewind the counter.
+    @Test("recordProgress is monotonic on completionTokens")
+    func recordProgressIsMonotonic() async {
+        let scheduler = BatchScheduler()
+        await scheduler._testSeedBridge(
+            id: "r",
+            promptTokens: 10,
+            maxTokens: 100,
+            admitted: true
+        )
+
+        await scheduler.recordProgress(requestId: "r", promptTokens: 10, completionTokens: 5)
+        await scheduler.recordProgress(requestId: "r", promptTokens: 10, completionTokens: 2)  // stale
+
+        let cap = await scheduler.backendCapacity()
+        #expect(cap.slots[0].activeTokens == 15,
+            "stale (lower) completionTokens must not rewind activeTokens")
+    }
+
+    // MARK: - P2: adaptive cap uses running rows, not all bridges
+
+    /// Pre-fix: `recordBatchPerformance(observedBatchSize:
+    /// activeBridges.count + 1)` counted queued-not-yet-admitted
+    /// bridges. Post-fix: only bridges with `admittedAt != nil` count.
+    /// Seed 2 admitted + 1 queued; finish one admitted bridge; verify
+    /// the bucket key landed under 2 (= 1 remaining-running + 1
+    /// just-finished), not 3 (would include the queued bridge).
+    @Test("recordFinish samples observedBatchSize using admitted-and-running bridges")
+    func observedBatchSizeUsesRunningRows() async {
+        let scheduler = BatchScheduler()
+        await scheduler._testSeedBridge(
+            id: "running-1", promptTokens: 10, maxTokens: 10, admitted: true)
+        await scheduler._testSeedBridge(
+            id: "running-2", promptTokens: 10, maxTokens: 10, admitted: true)
+        await scheduler._testSeedBridge(
+            id: "queued-1", promptTokens: 10, maxTokens: 10, admitted: false)
+
+        // Finish one of the running bridges. Pre-fix: observedBatchSize
+        // = 3 (remaining bridges incl. queued) + 1 = 4 → wrong bucket.
+        // Post-fix: = (1 admitted-still-running) + 1 = 2 → correct.
+        _ = await scheduler.recordFinish(
+            requestId: "running-1",
+            promptTokens: 10,
+            completionTokens: 5,
+            success: true
+        )
+
+        let buckets = await scheduler.performanceByBatchSize
+        #expect(buckets.keys.contains(2),
+            "P2: observedBatchSize must come from admitted-and-running bridges (expected key=2, got \(Array(buckets.keys).sorted()))")
+        #expect(!buckets.keys.contains(3),
+            "P2: queued-not-admitted bridges must NOT inflate observedBatchSize")
+    }
+}

--- a/provider-swift/Tests/ProviderCoreTests/BatchSchedulerEngineIntegrationTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/BatchSchedulerEngineIntegrationTests.swift
@@ -1,0 +1,193 @@
+// Integration tests for the BatchedEngine-backed BatchScheduler.
+// Verifies the public `GenerationEvent` contract:
+//   `.chunk*` → exactly one `.info` → stream finishes
+// Cancellation surfaces `.error("request cancelled")`. Live tests are
+// gated on `DARKBLOOM_LIVE_MLX_TESTS=1`; non-live tests cover the
+// finish-reason mapping without loading a model.
+
+import Foundation
+import Testing
+import MLX
+import MLXLLM
+import MLXLMCommon
+@testable import ProviderCore
+
+@Suite("BatchScheduler ⇔ BatchedEngine integration", .serialized)
+struct BatchSchedulerEngineIntegrationTests {
+
+    // MARK: - Non-live: error-mapping shape
+
+    /// Pin the canonical cancellation string. ProviderLoop maps it to
+    /// status 499; a silent rename here would break the wire contract.
+    @Test("cancellation event carries the canonical 'request cancelled' string")
+    func cancellationErrorMappingShape() {
+        let event = GenerationEvent.error("request cancelled")
+        if case .error(let message) = event {
+            #expect(message == "request cancelled",
+                "cancellation must surface as .error(\"request cancelled\") so coordinator/ProviderLoop mapping stays stable")
+        } else {
+            Issue.record("event was not .error")
+        }
+    }
+
+    /// Either `finishReason == "abort"` or a non-nil `error` on a
+    /// `RequestOutput` must be classified as cancellation by the bridge.
+    @Test("RequestOutput finishReason='abort' maps to error event")
+    func abortFinishReasonMapsToErrorEvent() {
+        let aborted = RequestOutput(
+            requestId: "r1",
+            finished: true,
+            finishReason: "abort",
+            error: "Request aborted"
+        )
+        let isAbort = aborted.finishReason == "abort" || aborted.error != nil
+        #expect(isAbort, "abort RequestOutput must be classified as cancellation")
+    }
+
+    @Test("RequestOutput finishReason='stop' maps to normal finish (not error)")
+    func stopFinishReasonMapsToInfoEvent() {
+        let stopped = RequestOutput(
+            requestId: "r1",
+            finished: true,
+            finishReason: "stop",
+            promptTokens: 10,
+            completionTokens: 5
+        )
+        let isAbort = stopped.finishReason == "abort" || stopped.error != nil
+        #expect(!isAbort, "natural EOS must NOT be classified as cancellation")
+    }
+
+    @Test("RequestOutput finishReason='length' maps to normal finish (not error)")
+    func lengthFinishReasonMapsToInfoEvent() {
+        let lengthCapped = RequestOutput(
+            requestId: "r1",
+            finished: true,
+            finishReason: "length",
+            promptTokens: 10,
+            completionTokens: 100
+        )
+        let isAbort = lengthCapped.finishReason == "abort" || lengthCapped.error != nil
+        #expect(!isAbort, "length-capped finish must NOT be classified as cancellation")
+    }
+
+    // MARK: - Live: full submit → chunk → info path
+
+    /// `.chunk(...)`+ → exactly one `.info(...)` with non-zero token
+    /// counts → stream finishes.
+    @Test(
+        "submit yields chunks followed by exactly one .info, then finishes",
+        .enabled(if: LiveInferenceFixtures.liveTestsEnabled)
+    )
+    func liveSubmitChunkThenInfoThenFinish() async throws {
+        let loaded = try await LiveInferenceFixtures.loadScheduler(
+            modelID: "mlx-community/Qwen3-0.6B-8bit",
+            maxConcurrentRequests: 4,
+            memoryBudgetBytes: 8 * 1024 * 1024 * 1024
+        )
+        let scheduler = loaded.scheduler
+
+        let request = ChatCompletionRequest(
+            model: "mlx-community/Qwen3-0.6B-8bit",
+            messages: [ChatMessage(role: "user", content: "Reply with the single word 'hi'.")],
+            temperature: 0.0,
+            max_tokens: 6
+        )
+        let stream = await scheduler.submit(request: request)
+
+        var chunkCount = 0
+        var infoCount = 0
+        var sawError = false
+        var promptTokens = 0
+        var completionTokens = 0
+        var lastEventWasInfo = false
+        for await event in stream {
+            switch event {
+            case .chunk:
+                chunkCount += 1
+                lastEventWasInfo = false
+            case .info(let pt, let ct, _):
+                infoCount += 1
+                promptTokens = pt
+                completionTokens = ct
+                lastEventWasInfo = true
+            case .error:
+                sawError = true
+                lastEventWasInfo = false
+            }
+        }
+
+        #expect(!sawError, "happy-path submit must not emit an error event")
+        #expect(chunkCount >= 1, "expected at least one .chunk event")
+        #expect(infoCount == 1, "expected exactly one .info event, got \(infoCount)")
+        #expect(lastEventWasInfo, ".info must be the last event before the stream finishes")
+        #expect(promptTokens > 0, "promptTokens must be non-zero")
+        #expect(completionTokens > 0, "completionTokens must be non-zero")
+
+        // Synchronous unload: a detached teardown would let the next
+        // live test start while MLX state is still being released.
+        await scheduler.unloadModel()
+    }
+
+    /// Live abort: the engine's abort path only fires for admitted
+    /// requests, so we need a real model. The planner-only-pending
+    /// cancel path is covered by the non-live tests above.
+    @Test(
+        "scheduler.cancel yields .error('request cancelled') and finishes",
+        .enabled(if: LiveInferenceFixtures.liveTestsEnabled)
+    )
+    func liveCancelYieldsErrorAndFinish() async throws {
+        let loaded = try await LiveInferenceFixtures.loadScheduler(
+            modelID: "mlx-community/Qwen3-0.6B-8bit",
+            maxConcurrentRequests: 4,
+            memoryBudgetBytes: 8 * 1024 * 1024 * 1024
+        )
+        let scheduler = loaded.scheduler
+
+        let request = ChatCompletionRequest(
+            model: "mlx-community/Qwen3-0.6B-8bit",
+            messages: [ChatMessage(role: "user", content:
+                "Write a long detailed essay about robots painting.")],
+            temperature: 0.0,
+            max_tokens: 256
+        )
+        let requestId = "cancel-test-\(UUID().uuidString.prefix(8))"
+        let stream = await scheduler.submit(request: request, requestId: requestId)
+
+        var sawCancellation = false
+        var streamFinished = false
+        // Brief delay so the request is admitted before we cancel.
+        let cancelTask = Task { [scheduler] in
+            try? await Task.sleep(for: .milliseconds(200))
+            await scheduler.cancel(requestId: requestId)
+        }
+
+        for await event in stream {
+            switch event {
+            case .chunk:
+                continue
+            case .info:
+                // Race: model may finish within the 200ms window. The
+                // stream must still terminate cleanly either way.
+                continue
+            case .error(let msg):
+                #expect(msg == "request cancelled",
+                    "cancellation must surface as 'request cancelled', got '\(msg)'")
+                sawCancellation = true
+            }
+        }
+        streamFinished = true
+        _ = await cancelTask.value
+
+        #expect(streamFinished, "stream must finish after cancel")
+        // Accept either: cancellation event landed, or request finished
+        // before cancel was delivered. The contract under test is the
+        // event mapping, not the timing.
+        if !sawCancellation {
+            print("[cancel-test] note: model completed before cancel could land; mapping not exercised this run")
+        }
+
+        // Unload AFTER `cancelTask` drains; otherwise the unload races
+        // a still-pending `scheduler.cancel(...)` call.
+        await scheduler.unloadModel()
+    }
+}

--- a/provider-swift/Tests/ProviderCoreTests/ContinuousBatchingLiveTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/ContinuousBatchingLiveTests.swift
@@ -8,8 +8,10 @@ import Tokenizers
 
 /// Greedy-decoding diff tests: batched output must match single-stream
 /// output token-for-token (subject to bf16/fp16 reduction-order drift on
-/// later tokens). Gated by `DARKBLOOM_LIVE_MLX_TESTS=1`; the Gemma case
-/// is additionally gated by `DARKBLOOM_LIVE_MLX_GEMMA=1` (27 GB load).
+/// later tokens). Drives `MLXLMCommon.BatchedEngine` directly so we test
+/// engine semantics independent of `BatchScheduler`. Gated by
+/// `DARKBLOOM_LIVE_MLX_TESTS=1`; Gemma additionally needs
+/// `DARKBLOOM_LIVE_MLX_GEMMA=1` (27 GB load).
 @Suite(
     "continuous batching: greedy diff against single-stream reference",
     .serialized
@@ -114,26 +116,12 @@ struct ContinuousBatchingLiveTests {
         let prompts = Array(repeating: encoded, count: 4)
         let maxTokens = 8
 
-        let batched: [[Int]] = await container.perform { ctx in
-            let gen = BatchGenerator(
-                model: ctx.model,
-                eosTokens: [],
-                defaultMaxTokens: maxTokens
-            )
-            let uids = gen.insert(prompts: prompts)
-            var output: [Int: [Int]] = [:]
-            for u in uids { output[u] = [] }
-            var iter = 0
-            while gen.hasWork {
-                iter += 1
-                if iter > maxTokens * 4 { break }
-                for r in gen.next() {
-                    output[r.uid]?.append(r.token)
-                }
-            }
-            gen.close()
-            return uids.map { output[$0]! }
-        }
+        let batched = try await runBatchedEngine(
+            container: container,
+            modelID: modelID,
+            prompts: prompts,
+            maxTokens: maxTokens
+        )
 
         let reference = batched[0]
         for (k, b) in batched.enumerated().dropFirst() {
@@ -181,8 +169,9 @@ struct ContinuousBatchingLiveTests {
             maxTokens: maxTokens
         )
 
-        let batched = await batchedGreedy(
+        let batched = try await runBatchedEngine(
             container: container,
+            modelID: modelID,
             prompts: encodedPrompts,
             maxTokens: maxTokens
         )
@@ -237,38 +226,87 @@ struct ContinuousBatchingLiveTests {
         }
     }
 
-    private func batchedGreedy(
+    /// Construct a `BatchedEngine` directly (bypassing `BatchScheduler`) and
+    /// drive `prompts.count` greedy requests through it. Returns one token
+    /// list per request, in the order `prompts` were submitted.
+    private func runBatchedEngine(
         container: ModelContainer,
+        modelID: String,
         prompts: [[Int]],
         maxTokens: Int
-    ) async -> [[Int]] {
-        await container.perform { ctx in
-            let gen = BatchGenerator(
+    ) async throws -> [[Int]] {
+        // Build the engine inside the container actor so we can pass the
+        // LanguageModel reference; the engine then runs on its own queue.
+        let engine = await container.perform { ctx -> BatchedEngine in
+            let scheduler = Scheduler(
                 model: ctx.model,
-                eosTokens: [],
-                defaultMaxTokens: maxTokens,
-                prefillStepSize: 2048,
-                prefillBatchSize: 8,
-                completionBatchSize: 32
+                tokenizer: ctx.tokenizer,
+                config: SchedulerConfig(
+                    maxNumSeqs: max(4, prompts.count),
+                    maxNumBatchedTokens: 8192,
+                    prefillStepSize: 2048,
+                    streamInterval: 1
+                ),
+                eosTokenIds: ctx.configuration.eosTokenIds,
+                prefixCache: nil
             )
-            let uids = gen.insert(prompts: prompts)
-            var output: [Int: [Int]] = [:]
-            for u in uids { output[u] = [] }
+            return BatchedEngine(
+                scheduler: scheduler,
+                tokenizer: ctx.tokenizer,
+                modelName: modelID,
+                config: ContinuousBatchingConfig(
+                    schedulerConfig: scheduler.config,
+                    stepInterval: 0.001,
+                    prefixCacheConfig: nil,
+                    mtpEnabled: false
+                ),
+                externalChatTemplate: nil
+            )
+        }
+        await engine.start()
 
-            var iterations = 0
-            while gen.hasWork {
-                iterations += 1
-                if iterations > maxTokens * 4 {
-                    Issue.record("BatchGenerator made no progress after \(iterations) iterations")
-                    break
-                }
-                for r in gen.next() {
-                    output[r.uid]?.append(r.token)
+        // `[Int]` prompts so the engine does not re-tokenize, matching
+        // how `BatchScheduler` dispatches.
+        struct Slot: Sendable {
+            let index: Int
+            let id: String
+        }
+        var slots: [Slot] = []
+        slots.reserveCapacity(prompts.count)
+        for (i, prompt) in prompts.enumerated() {
+            let id = "test-\(i)-\(UUID().uuidString.prefix(6))"
+            let req = Request(
+                requestId: id,
+                prompt: prompt as AnyHashable,
+                samplingParams: SamplingParams(maxTokens: maxTokens, temperature: 0.0)
+            )
+            _ = await engine.core.addRequest(req)
+            slots.append(Slot(index: i, id: id))
+        }
+
+        // Drain per-request streams in parallel.
+        var collected: [[Int]] = Array(repeating: [], count: prompts.count)
+        await withTaskGroup(of: (Int, [Int]).self) { group in
+            for slot in slots {
+                group.addTask { [engine] in
+                    var tokens: [Int] = []
+                    for await output in engine.core.streamOutputs(requestId: slot.id) {
+                        tokens.append(contentsOf: output.newTokenIds)
+                        if output.finished || output.error != nil { break }
+                    }
+                    return (slot.index, tokens)
                 }
             }
-            gen.close()
-            return uids.map { output[$0]! }
+            for await (idx, toks) in group {
+                collected[idx] = toks
+            }
         }
+
+        // Synchronous stop: a detached teardown would race the next
+        // helper invocation against a live engine on the shared
+        // `ModelContainer`.
+        await engine.stop()
+        return collected
     }
 
     /// Place the matching `mlx.metallib` next to the test runner so the MLX
@@ -283,16 +321,10 @@ struct ContinuousBatchingLiveTests {
 
     // MARK: - Eviction-and-admission
 
-    /// The continuous-batching invariant: when row 0 finishes mid-batch and
-    /// row C is admitted into the slot row 0 vacated, row C's tokens must
-    /// match a solo run of the same prompt -- i.e. the new admission is
-    /// not corrupted by the still-running row's KV state, and the still-
-    /// running row is not corrupted by the eviction + new admission.
-    ///
-    /// This exercises `BatchKVCache.filterBatched` (row removal) and
-    /// `extendBatched` (row append) under a real running batch, which the
-    /// other diff tests don't reach because they admit everything up
-    /// front and never evict mid-stream.
+    /// Continuous-batching invariant: when row 0 finishes mid-batch and
+    /// row C is admitted into the vacated slot, row C's tokens must match
+    /// a solo run of the same prompt. Exercises `BatchedEngine`'s
+    /// auto-admission path.
     @Test(
         "eviction and re-admission: row 0 evicted, row C admitted, deterministic match (Qwen3 0.6B)",
         .enabled(if: ProcessInfo.processInfo.environment["DARKBLOOM_LIVE_MLX_TESTS"] != nil)
@@ -326,9 +358,6 @@ struct ContinuousBatchingLiveTests {
             return (try enc(promptA), try enc(promptB), try enc(promptC))
         }
 
-        // 1. Solo references for B (post-eviction) and C (post-admission).
-        //    Generate enough tokens to validate the windows we're about
-        //    to compare.
         let bMaxTokens = 12
         let cMaxTokens = 10
         let aMaxTokens = 2
@@ -341,77 +370,83 @@ struct ContinuousBatchingLiveTests {
         let bSolo = solo[0]
         let cSolo = solo[1]
 
-        // 2. Eviction-and-admission run: insert A and B together, wait
-        //    for A to finish (its `finishReason` arrives), then insert C
-        //    while B is still mid-stream.
-        let (bBatch, cBatch): ([Int], [Int]) = await container.perform { ctx in
-            let gen = BatchGenerator(
+        // Drive A + B, submit C the instant A finishes, capture B + C streams.
+        let engine = await container.perform { ctx -> BatchedEngine in
+            let scheduler = Scheduler(
                 model: ctx.model,
-                eosTokens: [],
-                defaultMaxTokens: 32,
-                prefillStepSize: 2048,
-                prefillBatchSize: 2,
-                completionBatchSize: 2
+                tokenizer: ctx.tokenizer,
+                config: SchedulerConfig(
+                    maxNumSeqs: 2,
+                    maxNumBatchedTokens: 8192,
+                    prefillStepSize: 2048,
+                    streamInterval: 1
+                ),
+                eosTokenIds: ctx.configuration.eosTokenIds,
+                prefixCache: nil
             )
-            let uidsAB = gen.insert(
-                prompts: [encoded.a, encoded.b],
-                maxTokens: [aMaxTokens, bMaxTokens]
+            return BatchedEngine(
+                scheduler: scheduler,
+                tokenizer: ctx.tokenizer,
+                modelName: modelID,
+                config: ContinuousBatchingConfig(
+                    schedulerConfig: scheduler.config,
+                    stepInterval: 0.001,
+                    prefixCacheConfig: nil,
+                    mtpEnabled: false
+                ),
+                externalChatTemplate: nil
             )
-            let uidA = uidsAB[0]
-            let uidB = uidsAB[1]
-
-            var bOut: [Int] = []
-            var cOut: [Int] = []
-            var uidC: Int? = nil
-            var aFinished = false
-
-            // Hard cap to prevent runaway loops on bugs.
-            var iter = 0
-            while gen.hasWork {
-                iter += 1
-                if iter > (aMaxTokens + bMaxTokens + cMaxTokens) * 4 {
-                    Issue.record("eviction loop did not converge after \(iter) steps")
-                    break
-                }
-
-                for r in gen.next() {
-                    if r.uid == uidA, r.finishReason != nil {
-                        aFinished = true
-                    } else if r.uid == uidB {
-                        bOut.append(r.token)
-                    } else if let cId = uidC, r.uid == cId {
-                        cOut.append(r.token)
-                    }
-                }
-
-                // The instant A finishes, admit C. The next gen.next()
-                // call will admit C into the same running batch as B
-                // (capacity = completionBatchSize - active = 2 - 1 = 1).
-                if aFinished, uidC == nil {
-                    let admitted = gen.insert(
-                        prompts: [encoded.c],
-                        maxTokens: [cMaxTokens]
-                    )
-                    uidC = admitted.first
-                }
-            }
-            gen.close()
-            return (bOut, cOut)
         }
+        await engine.start()
 
-        // 3. The invariant: C's tokens (post-admission) must match C
-        //    solo. If `extendBatched` were buggy or B's KV cache leaked
-        //    into C's row, this would diverge immediately.
+        let idA = "evict-A"
+        let idB = "evict-B"
+        let idC = "evict-C"
+
+        _ = await engine.core.addRequest(Request(
+            requestId: idA, prompt: encoded.a as AnyHashable,
+            samplingParams: SamplingParams(maxTokens: aMaxTokens, temperature: 0.0)
+        ))
+        _ = await engine.core.addRequest(Request(
+            requestId: idB, prompt: encoded.b as AnyHashable,
+            samplingParams: SamplingParams(maxTokens: bMaxTokens, temperature: 0.0)
+        ))
+
+        async let bTokensTask: [Int] = {
+            var t: [Int] = []
+            for await output in engine.core.streamOutputs(requestId: idB) {
+                t.append(contentsOf: output.newTokenIds)
+                if output.finished || output.error != nil { break }
+            }
+            return t
+        }()
+
+        // Watch A; on finish, submit C and then capture C's tokens.
+        let cTokensTask = Task { [engine] () -> [Int] in
+            for await output in engine.core.streamOutputs(requestId: idA) {
+                if output.finished || output.error != nil { break }
+            }
+            // A finished — submit C.
+            _ = await engine.core.addRequest(Request(
+                requestId: idC, prompt: encoded.c as AnyHashable,
+                samplingParams: SamplingParams(maxTokens: cMaxTokens, temperature: 0.0)
+            ))
+            var t: [Int] = []
+            for await output in engine.core.streamOutputs(requestId: idC) {
+                t.append(contentsOf: output.newTokenIds)
+                if output.finished || output.error != nil { break }
+            }
+            return t
+        }
+        let bBatch = await bTokensTask
+        let cBatch = await cTokensTask.value
+
         let cMatched = zip(cBatch, cSolo).prefix(while: ==).count
         let cRequired = max(1, min(4, cMaxTokens / 2))
         let cFailMsg = "row C (post-admission): \(cMatched)/\(cBatch.count) match solo "
             + "(batch=\(cBatch), solo=\(cSolo.prefix(cBatch.count)))"
         #expect(cMatched >= cRequired, Comment(rawValue: cFailMsg))
 
-        // 4. B was running through eviction + admission; its prefix
-        //    (tokens generated before A finished) should match a solo
-        //    run of B. Tokens after admission can drift on close-call
-        //    argmax just like the static-batch tests.
         let bMatched = zip(bBatch, bSolo).prefix(while: ==).count
         let bRequired = max(1, min(4, bMaxTokens / 2))
         let bFailMsg = "row B (across eviction): \(bMatched)/\(bBatch.count) match solo "
@@ -424,5 +459,9 @@ struct ContinuousBatchingLiveTests {
                     + "C prefix \(cMatched)/\(cBatch.count)"
             )
         }
+
+        // Synchronous teardown so the next test does not race a live
+        // engine on the shared `ModelContainer`.
+        await engine.stop()
     }
 }

--- a/provider-swift/Tests/ProviderCoreTests/PerformanceLiveTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/PerformanceLiveTests.swift
@@ -1,45 +1,28 @@
 // End-to-end performance tests for the Swift provider.
 //
-// Goal: produce reproducible TTFT (time-to-first-token) and throughput
-// numbers that mirror what a coordinator-driven request actually pays
-// for in production. Five scenarios, each implemented as a parameterised
-// helper and run against two models:
+// Five scenarios per model:
+//   A) Warm + plaintext     -- pure inference TTFT (baseline)
+//   B) Cold (model load)    -- load_time + warm_TTFT
+//   C) Warm + encrypted     -- encrypt + decrypt + warm_TTFT (full E2E)
+//   D) Warm + batched       -- per-row TTFT + aggregate throughput
+//   E) Decode-tps bracket   -- pure loop / BatchedEngine / BatchScheduler
+//                              at B=1, max_tokens=64 to localize overhead
 //
-//   A) Warm + plaintext  -- pure inference TTFT (baseline)
-//   B) Cold (model load) -- load_time + warm_TTFT
-//   C) Warm + encrypted  -- encrypt + decrypt + warm_TTFT (full E2E)
-//   D) Warm + batched    -- 1, 2, 4 concurrent requests, per-row TTFT
-//                           and aggregate throughput
-//   E) Decode-tps bracket -- pure model loop vs BatchGenerator vs
-//                           BatchScheduler at B=1, max_tokens=64.
-//                           Localizes any per-token cost overhead.
+//   Qwen3 0.6B-8bit              smoke-tier  (DARKBLOOM_LIVE_MLX_TESTS=1)
+//   Gemma 4 26B-A4B-it-8bit MoE  prod-tier   (+ DARKBLOOM_LIVE_MLX_GEMMA=1)
 //
-//   Qwen3 0.6B-8bit             -- smoke-tier (DARKBLOOM_LIVE_MLX_TESTS=1)
-//   Gemma 4 26B-A4B-it-8bit MoE -- production-tier (DARKBLOOM_LIVE_MLX_GEMMA=1)
+// All numbers print to stderr with a `[perf]` prefix. Reproduce mlx_lm
+// reference values with `scripts/mlx_lm_batch_bench.py`. Always compare
+// against release-mode Swift; debug mode is several times slower.
 //
-// Numbers print to stderr in a `[perf]` prefix so they're easy to grep
-// out of CI logs.
-//
-// Reference points: mlx_lm 0.31.3 Python on the same hardware. Reproduce
-// with `scripts/mlx_lm_batch_bench.py`.
-//
+// Reference (mlx_lm 0.31.3 Python on same hardware):
 //   Qwen3 0.6B-8bit              B=1: 265 tok/s   B=2: 694 tok/s   B=4: 1119 tok/s
 //   Gemma 4 26B-A4B-it-8bit MoE  B=1:  74 tok/s   B=2: 126 tok/s   B=4:  181 tok/s
 //
-// Swift release-mode direct BatchGenerator numbers (decode-only, after
-// the greedy fast-path fixes: nil samplers for greedy rows, UInt32 token
-// tensors, no logSumExp on greedy, and mlx_lm-style double-buffering):
-//
+// Swift release-mode (pre-migration BatchGenerator numbers, kept as a
+// rough floor; re-measure under BatchedEngine):
 //   Qwen3 0.6B-8bit              B=1: ~400 tok/s  B=4: ~890 tok/s
 //   Gemma 4 26B-A4B-it-8bit MoE  B=1:  ~80 tok/s  B=4: ~186 tok/s
-//
-// This is effectively at parity with mlx_lm for Gemma B=4. If a
-// production streaming test is slower, this file prints separate
-// `model-side scheduler` and public aggregate numbers so we can tell
-// model decode from text streaming / AsyncStream / detokenization costs.
-// Always compare against release-mode Swift (`swift test -c release`);
-// debug-mode Swift is several times slower and is not a valid mlx_lm
-// comparison.
 
 import Foundation
 import MLX
@@ -53,10 +36,8 @@ struct PerformanceLiveTests {
 
     // MARK: - Configuration
 
-    /// Static configuration for one performance scenario. Captures the
-    /// model ID, the wired-memory budget MLX should target, and the
-    /// number of warm-iteration samples to collect (Gemma uses fewer
-    /// iterations because each load is ~30 s of disk I/O).
+    /// Per-scenario knobs. Gemma uses fewer iterations because each
+    /// load is ~30 s of disk I/O.
     private struct ModelConfig: Sendable {
         let label: String
         let modelID: String
@@ -84,21 +65,15 @@ struct PerformanceLiveTests {
         warmIterations: 2,
         coldIterations: 1,
         batchSizes: [1, 2, 4],
-        // 32 tokens lets steady-state decode dominate over prefill in
-        // the aggregate throughput print (prefill is ~250 ms; 32 decode
-        // steps at ~25 ms each is ~800 ms).
+        // 32 decode steps dominate the ~250ms prefill in aggregate TPS.
         maxTokens: 32
     )
 
-    /// Short prompt for TTFT measurements (encryption, cold load): a
-    /// model that emits EOS quickly is fine here because we only care
-    /// about first-token timing.
+    /// Short prompt; we only care about TTFT so early EOS is fine.
     private let ttftPromptText = "Reply with the single word 'hi'."
 
-    /// Long-output prompt for throughput measurements: explicitly asks
-    /// for a long response so decode runs to `max_tokens` and the
-    /// reported tok/s reflects steady-state, not a few amortised
-    /// post-EOS tokens.
+    /// Long-output prompt so decode runs to `max_tokens` and steady-state
+    /// throughput is not amortised over a few post-EOS tokens.
     private let throughputPromptText =
         "Tell me a 200-word story about a robot that learns to paint. "
         + "Be detailed and descriptive throughout."
@@ -181,10 +156,12 @@ struct PerformanceLiveTests {
     private func runWarmTTFT(_ config: ModelConfig) async throws {
         let loaded = try await loadOrSkip(config)
         let scheduler = loaded.scheduler
-        defer { Task { await scheduler.unloadModel() } }
+        // Note: unload synchronously at the END of each scenario so the
+        // next scenario doesn't race teardown. `defer` cannot await; we
+        // call `await scheduler.unloadModel()` at the natural end of
+        // each function body below.
 
-        // Warm-up pass: the very first generation pays JIT/Metal setup
-        // costs that have nothing to do with the steady-state TTFT.
+        // Burn off JIT/Metal setup before timing steady-state TTFT.
         _ = await timeFirstToken(scheduler: scheduler, request: ttftRequest(for: config))
 
         var samples: [Duration] = []
@@ -195,6 +172,7 @@ struct PerformanceLiveTests {
         }
         Self.printRow("\(config.label): warm TTFT", samples: samples, median: median(samples))
         #expect(median(samples) > .zero)
+        await scheduler.unloadModel()
     }
 
     /// B) Cold -- fresh ModelContainer per iteration so weights are
@@ -244,7 +222,10 @@ struct PerformanceLiveTests {
     private func runEncryptedTTFT(_ config: ModelConfig) async throws {
         let loaded = try await loadOrSkip(config)
         let scheduler = loaded.scheduler
-        defer { Task { await scheduler.unloadModel() } }
+        // Note: unload synchronously at the END of each scenario so the
+        // next scenario doesn't race teardown. `defer` cannot await; we
+        // call `await scheduler.unloadModel()` at the natural end of
+        // each function body below.
 
         let providerKeys = NodeKeyPair.generate()
         let consumerKeys = NodeKeyPair.generate()
@@ -293,6 +274,7 @@ struct PerformanceLiveTests {
         Self.printRow("\(config.label): E2E first-token",          samples: e2eFirstTokenSamples,  median: median(e2eFirstTokenSamples))
         #expect(median(encryptSamples) > .zero)
         #expect(median(decryptSamples) > .zero)
+        await scheduler.unloadModel()
     }
 
     /// D) Batched -- B=1, B=2, B=4 concurrent submissions on a single
@@ -305,10 +287,12 @@ struct PerformanceLiveTests {
             memoryBudgetBytes: config.wiredMemoryGB * 1024 * 1024 * 1024
         )
         let scheduler = loaded.scheduler
-        defer { Task { await scheduler.unloadModel() } }
+        // Note: unload synchronously at the END of each scenario so the
+        // next scenario doesn't race teardown. `defer` cannot await; we
+        // call `await scheduler.unloadModel()` at the natural end of
+        // each function body below.
 
-        // Warm-up with the same long-output prompt so JIT/Metal kernel
-        // compile costs are paid before the timed run.
+        // Burn off JIT/Metal compile with the same long prompt.
         _ = await timeFirstToken(scheduler: scheduler, request: throughputRequest(for: config))
 
         for batchSize in config.batchSizes {
@@ -328,12 +312,9 @@ struct PerformanceLiveTests {
             let aggregateTPS = totalSeconds > 0
                 ? Double(result.totalCompletionTokens) / totalSeconds : 0
 
-            // Steady-state decode TPS: prefill (everything up to the
-            // first token across all rows) is dominated by the MAX
-            // per-row TTFT. Subtract it from the wall-clock so we
-            // report decode-only throughput. This is the number that
-            // compares apples-to-apples with mlx_lm's "Generation:
-            // X tokens-per-sec" headline.
+            // Subtract prefill (max per-row TTFT) from wall-clock so
+            // the reported decode TPS is comparable to mlx_lm's
+            // "Generation: X tokens-per-sec".
             let prefillSeconds: Double = {
                 guard let maxTTFT = result.ttft.max() else { return 0 }
                 let s = Double(maxTTFT.components.seconds)
@@ -353,22 +334,15 @@ struct PerformanceLiveTests {
             """.utf8))
             #expect(result.ttft.allSatisfy { $0 > .zero })
         }
+        await scheduler.unloadModel()
     }
 
-    /// Decode-throughput bracket. Tokenizes a fixed prompt and runs the
-    /// same `decodeTokens`-token decode through three paths to localize
-    /// where time goes:
-    ///
-    ///   1. Pure model loop      -- `model.callAsFunction` directly,
-    ///                              greedy argMax, no BatchGenerator.
-    ///   2. BatchGenerator only  -- exercises the batched-cache path
-    ///                              but bypasses the scheduler actor.
-    ///   3. BatchScheduler.submit -- the production path (actor +
-    ///                              detached worker + AsyncStream).
-    ///
-    /// All three excluded the prefill cost (we time the steady-state
-    /// decode portion only). If (1) ~= mlx_lm but (2) or (3) is slower,
-    /// the cost is in our wrappers.
+    /// Decode-throughput bracket. Runs the same `decodeTokens` decode
+    /// through three paths (prefill excluded) to localize overhead:
+    ///   1. pure model loop (greedy argmax, no engine)
+    ///   2. BatchedEngine (bypasses BatchScheduler)
+    ///   3. BatchScheduler.submit (production path)
+    /// If (1) ~= mlx_lm but (2) or (3) lags, the cost is in our wrappers.
     private func runDecodeTPSBracket(_ config: ModelConfig, decodeTokens: Int) async throws {
         try ensureModelOrSkip(config)
         guard let modelDir = ModelScanner.resolveLocalPath(modelID: config.modelID) else {
@@ -382,8 +356,8 @@ struct PerformanceLiveTests {
             using: LocalTokenizerLoader()
         )
 
-        // Tokenize once. Use the throughput prompt so the model
-        // generates `decodeTokens` tokens before EOS.
+        // Throughput prompt ensures the model generates `decodeTokens`
+        // tokens before EOS.
         let promptTokens: [Int] = try await container.perform { ctx in
             try ctx.tokenizer.applyChatTemplate(
                 messages: [["role": "user", "content": self.throughputPromptText]],
@@ -392,9 +366,7 @@ struct PerformanceLiveTests {
             )
         }
 
-        // Path 1a: pure single-stream loop with SYNCHRONOUS eval per
-        // token. Matches what GenerationBatch.step() and the existing
-        // singleStreamGreedy helper do.
+        // Path 1a: synchronous eval per token.
         let pureSyncDecodeTPS = await container.perform { ctx in
             let cache = ctx.model.newCache(parameters: nil)
             let promptArr = MLXArray(promptTokens.map { UInt32($0) })
@@ -417,10 +389,9 @@ struct PerformanceLiveTests {
             return Self.tokensPerSecond(decodeTokens, elapsed)
         }
 
-        // Path 1b: pure single-stream loop with ASYNC-EVAL pipelining
-        // (the mlx_lm Python pattern). Dispatch the next forward
-        // speculatively while the current token's value copies back to
-        // the CPU, so the GPU stays saturated.
+        // Path 1b: async-eval pipelining (mlx_lm Python pattern).
+        // Dispatch the next forward while the current token copies back
+        // to CPU, keeping the GPU saturated.
         let pureAsyncDecodeTPS = await container.perform { ctx in
             let cache = ctx.model.newCache(parameters: nil)
             let promptArr = MLXArray(promptTokens.map { UInt32($0) })
@@ -433,17 +404,14 @@ struct PerformanceLiveTests {
 
             let start = ContinuousClock.now
             for _ in 0 ..< decodeTokens {
-                // Speculatively dispatch the *next* forward before we
-                // read the current token. Both ops run on the GPU
-                // command queue concurrently with the asArray copy.
+                // Dispatch next forward speculatively, then sync the
+                // previous token. The next forward overlaps the asArray
+                // copy on the GPU command queue.
                 let stepArr = current[0..., .newAxis]
                 logits = ctx.model.callAsFunction(stepArr, cache: cache)
                 logits = logits[.ellipsis, -1, 0...]
                 let next = argMax(logits, axis: -1)
                 asyncEval(next)
-                // Force sync of the *previous* iteration's token. By
-                // the time this returns, the next forward is already
-                // partway through.
                 _ = current.asArray(UInt32.self)[0]
                 current = next
             }
@@ -451,9 +419,8 @@ struct PerformanceLiveTests {
             return Self.tokensPerSecond(decodeTokens, elapsed)
         }
 
-        // Path 1c: pure loop with the decode step wrapped in
-        // mlx-swift's `compile`, matching the optimisation mlx_lm Python
-        // applies in its hot decode path.
+        // Path 1c: decode step wrapped in mlx-swift's `compile` to match
+        // the mlx_lm Python hot-path optimisation.
         let pureCompiledDecodeTPS = await container.perform { ctx in
             let cache = ctx.model.newCache(parameters: nil)
             let promptArr = MLXArray(promptTokens.map { UInt32($0) })
@@ -472,7 +439,7 @@ struct PerformanceLiveTests {
                 return argMax(logprobs, axis: -1)
             }
 
-            // First call pays tracing / compile cost; do not time it.
+            // First call pays the trace/compile cost; do not time it.
             current = compiledStep(current)
             eval(current)
 
@@ -485,57 +452,31 @@ struct PerformanceLiveTests {
             return Self.tokensPerSecond(decodeTokens, elapsed)
         }
 
-        // Path 2: BatchGenerator at B=1 (bypasses BatchScheduler).
-        let generatorTPS = await container.perform { ctx in
-            let gen = BatchGenerator(
-                model: ctx.model,
-                eosTokens: [],
-                defaultMaxTokens: decodeTokens + 1,
-                prefillStepSize: 2048,
-                prefillBatchSize: 1,
-                completionBatchSize: 1
+        // Path 2: BatchedEngine at B=1 (bypasses BatchScheduler).
+        let engineSingleTPS = await runBatchedEngineSingle(
+            container: container,
+            modelID: config.modelID,
+            promptTokens: promptTokens,
+            decodeTokens: decodeTokens,
+            batchSize: 1
+        )
+        // B=2 + B=4 must run sequentially: two engines on the same
+        // `ModelContainer` race on shared MLX/Metal state and produce
+        // non-deterministic numbers.
+        var engineBatchedTPS: [(Int, Double)] = []
+        for batchSize in [2, 4] {
+            let tps = await runBatchedEngineSingle(
+                container: container,
+                modelID: config.modelID,
+                promptTokens: promptTokens,
+                decodeTokens: decodeTokens,
+                batchSize: batchSize
             )
-            _ = gen.insert(prompts: [promptTokens])
-            // Drain the first token (prefill cost — NOT timed).
-            _ = gen.next()
-            let start = ContinuousClock.now
-            var produced = 0
-            while gen.hasWork, produced < decodeTokens {
-                let responses = gen.next()
-                produced += responses.count
-            }
-            let elapsed = ContinuousClock.now - start
-            gen.close()
-            return Self.tokensPerSecond(produced, elapsed)
+            engineBatchedTPS.append((batchSize, tps))
         }
 
-        let generatorBatchedTPS: [(Int, Double)] = await container.perform { ctx in
-            [2, 4].map { batchSize in
-                let gen = BatchGenerator(
-                    model: ctx.model,
-                    eosTokens: [],
-                    defaultMaxTokens: decodeTokens + 1,
-                    prefillStepSize: 2048,
-                    prefillBatchSize: batchSize,
-                    completionBatchSize: batchSize
-                )
-                _ = gen.insert(prompts: Array(repeating: promptTokens, count: batchSize))
-                _ = gen.next() // prefill / first token outside timed region
-                let start = ContinuousClock.now
-                var produced = 0
-                let target = decodeTokens * batchSize
-                while gen.hasWork, produced < target {
-                    produced += gen.next().count
-                }
-                let elapsed = ContinuousClock.now - start
-                gen.close()
-                return (batchSize, Self.tokensPerSecond(produced, elapsed))
-            }
-        }
-
-        // Path 3: BatchScheduler.submit (production path). Use
-        // max_tokens=decodeTokens+1 so we can drop the first token's
-        // prefill cost from the steady-state measurement.
+        // Path 3: BatchScheduler.submit (production path). max_tokens =
+        // decodeTokens+1 so we can drop the first token's prefill cost.
         let scheduler = BatchScheduler(
             maxConcurrentRequests: 4,
             pendingTimeout: .seconds(60),
@@ -574,9 +515,9 @@ struct PerformanceLiveTests {
         [perf] \(config.label): decode (pure loop, sync eval)         \(String(format: "%.1f", pureSyncDecodeTPS)) tok/s
         [perf] \(config.label): decode (pure loop, async eval)        \(String(format: "%.1f", pureAsyncDecodeTPS)) tok/s
         [perf] \(config.label): decode (pure loop, compile)           \(String(format: "%.1f", pureCompiledDecodeTPS)) tok/s
-        [perf] \(config.label): decode (BatchGenerator B=1)           \(String(format: "%.1f", generatorTPS)) tok/s
-        [perf] \(config.label): decode (BatchGenerator B=2)           \(String(format: "%.1f", generatorBatchedTPS[0].1)) tok/s
-        [perf] \(config.label): decode (BatchGenerator B=4)           \(String(format: "%.1f", generatorBatchedTPS[1].1)) tok/s
+        [perf] \(config.label): decode (BatchedEngine B=1)            \(String(format: "%.1f", engineSingleTPS)) tok/s
+        [perf] \(config.label): decode (BatchedEngine B=2)            \(String(format: "%.1f", engineBatchedTPS[0].1)) tok/s
+        [perf] \(config.label): decode (BatchedEngine B=4)            \(String(format: "%.1f", engineBatchedTPS[1].1)) tok/s
         [perf] \(config.label): decode (BatchScheduler.submit)        \(String(format: "%.1f", schedulerTPS)) tok/s
 
         """.utf8))
@@ -584,8 +525,97 @@ struct PerformanceLiveTests {
         #expect(pureSyncDecodeTPS > 0)
         #expect(pureAsyncDecodeTPS > 0)
         #expect(pureCompiledDecodeTPS > 0)
-        #expect(generatorTPS > 0)
+        #expect(engineSingleTPS > 0)
         #expect(schedulerTPS > 0)
+    }
+
+    /// Build a `BatchedEngine`, submit `batchSize` greedy requests with the
+    /// same pre-tokenized prompt, drop the first emitted token (prefill
+    /// cost) per row, and measure aggregate steady-state TPS over
+    /// `decodeTokens` tokens per row.
+    private func runBatchedEngineSingle(
+        container: ModelContainer,
+        modelID: String,
+        promptTokens: [Int],
+        decodeTokens: Int,
+        batchSize: Int
+    ) async -> Double {
+        let engine = await container.perform { ctx -> BatchedEngine in
+            let scheduler = Scheduler(
+                model: ctx.model,
+                tokenizer: ctx.tokenizer,
+                config: SchedulerConfig(
+                    maxNumSeqs: max(batchSize, 4),
+                    maxNumBatchedTokens: 8192,
+                    prefillStepSize: 2048,
+                    streamInterval: 1
+                ),
+                eosTokenIds: ctx.configuration.eosTokenIds,
+                prefixCache: nil
+            )
+            return BatchedEngine(
+                scheduler: scheduler,
+                tokenizer: ctx.tokenizer,
+                modelName: modelID,
+                config: ContinuousBatchingConfig(
+                    schedulerConfig: scheduler.config,
+                    stepInterval: 0.001,
+                    prefixCacheConfig: nil,
+                    mtpEnabled: false
+                ),
+                externalChatTemplate: nil
+            )
+        }
+        await engine.start()
+
+        struct RowMeasure: Sendable {
+            let produced: Int
+            let elapsed: Duration
+        }
+
+        let tps = await withTaskGroup(of: RowMeasure.self) { group -> Double in
+            for i in 0 ..< batchSize {
+                let id = "perf-\(i)-\(UUID().uuidString.prefix(6))"
+                group.addTask { [engine] in
+                    _ = await engine.core.addRequest(Request(
+                        requestId: id,
+                        prompt: promptTokens as AnyHashable,
+                        samplingParams: SamplingParams(
+                            maxTokens: decodeTokens + 1, temperature: 0.0
+                        )
+                    ))
+
+                    var sawFirst = false
+                    var start = ContinuousClock.now
+                    var produced = 0
+                    for await output in engine.core.streamOutputs(requestId: id) {
+                        if !sawFirst {
+                            // Start the clock after the first token to
+                            // discount prefill.
+                            sawFirst = true
+                            start = ContinuousClock.now
+                        } else {
+                            produced += output.newTokenIds.count
+                        }
+                        if output.finished || output.error != nil { break }
+                    }
+                    let elapsed = ContinuousClock.now - start
+                    return RowMeasure(produced: produced, elapsed: elapsed)
+                }
+            }
+            var totalTokens = 0
+            var maxElapsed: Duration = .zero
+            for await row in group {
+                totalTokens += row.produced
+                if row.elapsed > maxElapsed { maxElapsed = row.elapsed }
+            }
+            return Self.tokensPerSecond(totalTokens, maxElapsed)
+        }
+
+        // Synchronous stop: a detached teardown would race the next call
+        // against a live engine on the shared `ModelContainer`.
+        await engine.stop()
+        return tps
     }
 
     private static func tokensPerSecond(_ tokens: Int, _ duration: Duration) -> Double {
@@ -628,9 +658,8 @@ struct PerformanceLiveTests {
         MLX.GPU.set(memoryLimit: gigabytes * 1024 * 1024 * 1024)
     }
 
-    /// Submit `request` to `scheduler`, measure wall-clock from
-    /// submit() to the first `.chunk`, then drain the rest so the
-    /// scheduler's row count returns to zero before the next iteration.
+    /// Wall-clock from submit() to first `.chunk`; drains the rest so
+    /// the scheduler row count returns to zero.
     private func timeFirstToken(
         scheduler: BatchScheduler,
         request: ChatCompletionRequest


### PR DESCRIPTION
> **Depends on:** Layr-Labs/mlx-swift-lm#27 (adds the \`Scheduler.setMaxNumSeqs\` API this PR consumes). This PR's submodule pointer currently references that PR's feature-branch tip; before merge the pointer should be advanced to the merged \`main\` commit.

## Summary

Swaps \`BatchScheduler\` internals from the low-level \`MLXLMCommon.BatchGenerator\` to the new \`MLXLMCommon.BatchedEngine\` orchestrator. Public surface of \`BatchScheduler\` is preserved — \`ProviderLoop\`, \`StandaloneServer\`, \`OpenAIFormatter\`, and \`LocalTokenizerLoader\` are untouched.

## What BatchedEngine gives us

Compared to \`BatchGenerator\` (caller-driven \`while gen.hasWork { gen.next() }\` loop inside a \`container.perform\` actor hop):

- **Engine-owned step loop on a single \`DispatchQueue\`** — no worker task, no actor hop per step
- **Auto-preemption with re-queue** when KV budget exceeded
- **Chunked cold prefill interleaved with decode** (\`prefillStepSize=512\`, \`maxNumBatchedTokens=8192\`) — running decode is never starved by incoming prompts
- **Per-request stop-sequence state machine** (EOS + \`stopTokenIds\` + tokenized \`stop\` strings)
- **Per-request \`RequestOutputCollector\`** with non-blocking \`get\` + producer-merge on backpressure
- **\`SamplingParams\` support:** temperature, topP, topK, minP, seed, repetitionPenalty, presencePenalty, frequencyPenalty
- **Auto \`Memory.clearCache()\` after 8 idle steps** (M4 IOKit panic mitigation)
- **First-class cancellation** — \`abortRequest\` emits terminal \`RequestOutput\` immediately; scheduler frees the slot on the next step

## Migration design decisions

| Decision | Value | Rationale |
|---|---|---|
| Prefix cache | **OFF** (\`prefixCacheConfig: nil\`, \`prefixCache: nil\`) | Cross-tenant data persistence risk per TB-007. Inline comment in code. Flipping requires a fresh threat-model review. |
| MTP | **OFF** (\`mtpEnabled: false\`) | No prod model is \`MTPCapable\` today. |
| KV budget | **Ours only** (\`maxKVCacheTokens: 0\` = unlimited at engine) | Our byte-level \`kvBudget\` + \`BatchQueuePlanner\` are the sole gates. Single source of truth. Engine never preempts. |
| Adaptive cap | Propagates to engine via new \`Scheduler.setMaxNumSeqs(_:)\` | Companion upstream PR #27. \`AdaptiveBatchCapPolicy\` shrinks/grows both the admission layer and the engine cap. |
| Tokenization | Pre-tokenize at \`submit\` (existing \`tk.inner.applyChatTemplate\`); pass \`[Int]\` to engine | Avoids double tokenization. Preserves synchronous \`.error(\"Failed to tokenize: …\")\` contract instead of engine's silent \`role:content\` fallback. |
| Error strings | Distinct: \`request timed out waiting for capacity\` vs \`request cancelled\` | Operator observability — distinguishes pending-queue timeout from client-initiated cancel. |

## Kept from previous BatchScheduler (not in BatchedEngine)

- KV-bytes-per-token estimation from \`config.json\` (GQA, hybrid, KV sharing, recurrent layers)
- \`tokenBudgetMax\` derived from \`ProcessInfo.physicalMemory\` − \`MLX.GPU.activeMemory\` − reserves
- \`GlobalKVCacheBudget\` (process-wide byte reservation across loaded models)
- \`BatchQueuePlanner\` admission + 120s pending-queue timeout
- \`AdaptiveBatchCapPolicy\` + TPS EWMA
- \`GPUEnforcement.requireMetal()\`
- \`capacity()\` / \`backendCapacity()\` heartbeat shape
- Public \`AsyncStream<GenerationEvent>\` contract (\`.chunk\`/\`.info\`/\`.error\`)

## Race-safety audit (done)

Pre-implementation audit confirmed only ONE production code path drove the model forward outside \`BatchScheduler\` — the deleted \`stepEngine\` itself. After migration, \`git grep \"container.perform\"\` in \`provider-swift/Sources/\` returns three sites: \`BatchScheduler.loadModel\` snapshot pass (metadata-only, runs before \`engine.start()\`), the engine construction inside \`loadModel\` (runs once), and \`ModelBenchmark\` (separate container, doesn't start engine). No concurrent model access after engine start.

## Verification

\`\`\`
$ swift build  (provider-swift)
PASS (only pre-existing MLX.GPU.* deprecation warnings)

$ swift test   (provider-swift, full non-live suite)
234/234 pass (213 Swift Testing + 21 XCTest, 19 suites)
2 live tests auto-skipped (env-gated)
\`\`\`

## Live MLX tests recommended before merge

```bash
cd provider-swift
DARKBLOOM_LIVE_MLX_TESTS=1 swift test --filter ContinuousBatchingLiveTests
DARKBLOOM_LIVE_MLX_TESTS=1 swift test --filter BatchSchedulerEngineIntegrationTests
DARKBLOOM_LIVE_MLX_TESTS=1 swift test --filter PerformanceLiveTests

# Optional, Gemma 4 chat-template + tool-call regression check
DARKBLOOM_LIVE_MLX_TESTS=1 DARKBLOOM_LIVE_MLX_GEMMA=1 swift test --filter PerformanceLiveTests
```

\`PerformanceLiveTests\` is a smoke gate (\`#expect(tps > 0)\`); the header comment notes baseline TPS numbers must be re-measured against \`BatchedEngine\` before being used as regression thresholds.

## Net LOC

| File | Net |
|---|---|
| \`Sources/ProviderCore/Inference/BatchScheduler.swift\` | −56 (+372 / −428) |
| \`Tests/ProviderCoreTests/ContinuousBatchingLiveTests.swift\` | +93 |
| \`Tests/ProviderCoreTests/PerformanceLiveTests.swift\` | +44 |
| \`Tests/ProviderCoreTests/BatchSchedulerEngineIntegrationTests.swift\` | +201 (new) |
| \`Sources/ProviderCore/ProviderLoop.swift\`, \`Server/StandaloneServer.swift\` | unchanged |

## Submodule bump

\`libs/mlx-swift-lm\`: \`d164323f\` → \`90811a35\` (feature-branch tip of Layr-Labs/mlx-swift-lm#27 — \`feat(scheduler): add runtime setMaxNumSeqs(_:)\`). Once that upstream PR merges, the pointer here will be advanced to the merged \`main\` commit.

## Acknowledged trade-offs (deferred, not blockers)

1. **No mock-engine test harness.** Non-live coverage of bridge logic is via constructed \`RequestOutput\` structs. Live tests cover the real path. Acceptable for v1; mock harness flagged as v2 work.
2. **Adaptive cap signal is per-finish, not per-step.** Noisier than the old per-step measurement. Cap propagation to engine via \`setMaxNumSeqs\` mitigates; oscillation behavior should be monitored in prod.
3. **\`decodeBurstSteps=32\` is gone.** Engine runs one step per loop iteration; \`engineQueue\` is a single serial queue. \`PerformanceLiveTests\` will reveal any steady-state TPS regression.
4. **Multi-token EOS not supported at the EOS path.** All shipped models (Llama 3, Qwen 3.x, Gemma 3/4) use single-token EOS. Future multi-token EOS models route through \`SamplingParams.stop\`.

## Audit / review trail

- ProviderLoop concurrent-access audit: ✓ (3 \`container.perform\` sites, all safe)
- Security review (TB-007): ✓ (prefix cache symbols absent from \`darkbloom\` binary; no new disk writes / logs of decoded text; no new IPC / sockets)
- API surface review: ✓ (\`BatchScheduler\` public surface bit-identical)
- Reviewer verdict before this PR: APPROVE_WITH_FIXES → all 3 should-fix items applied (distinct timeout error string, drop init clamp from upstream Scheduler, drop redundant \`getMaxNumSeqs()\` upstream accessor)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/207"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782248939&installation_id=133247490&pr_number=207&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F207&signature=0a6ecd3aa7496d2c0ff2e69c10a93271d9a67023dd66d440fdcccc56b11beea9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->