### PR TITLE
chore: add changelog and update project docs to Darkbloom branding

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
-# EigenInference - Decentralized Private Inference
+# Darkbloom - Decentralized Private Inference
 
-EigenInference is a decentralized/private inference stack for Apple Silicon Macs. Consumers use OpenAI-compatible APIs, the coordinator handles routing/auth/billing/attestation, and providers run local text, transcription, and image workloads on macOS hardware.
+Darkbloom is a decentralized private inference network for Apple Silicon Macs. Consumers use OpenAI-compatible APIs, the coordinator handles routing, auth, billing, attestation, and capacity management, and providers run local inference workloads on macOS hardware using MLX-Swift. All inference is end-to-end encrypted -- the coordinator never sees plaintext prompts.
 
 ## Project Structure
 
@@ -27,36 +27,43 @@ coordinator/          Go control plane (packages live at top level, not internal
 ├── mdm/              MicroMDM client + webhook handling
 ├── payments/         ledger + pricing
 ├── protocol/         WebSocket message types shared with provider
-├── registry/         provider registry, queueing, routing, reputation
-└── store/            in-memory or Postgres persistence
+├── ratelimit/        rate limiting
+├── registry/         provider registry, queueing, routing, reputation, token-budget admission
+├── saferun/          panic-safe goroutine runners
+├── store/            in-memory or Postgres persistence
+├── telemetry/        Datadog DogStatsD metrics
+├── datadog/          dev dashboard JSON definitions
+└── internal/e2e/     coordinator-scoped integration tests
 
-testbed/              System-level testing framework (shared Go module with coordinator)
-├── coordinator.go    Coordinator lifecycle (start/stop, Postgres helpers)
-├── provider.go       Provider lifecycle (binary discovery, start/stop)
-├── config.go         Test configuration (model, provider, request settings)
-├── events.go         Event system (segments, buffers, fan-out)
-├── instrument.go     Request-level instrumentation
-├── assert/           Assertion framework
-│   ├── assert.go           Latency threshold assertions
-│   └── accounting.go       Postgres-backed accounting integrity checks
-├── deps/             External dependency lifecycle
-│   └── postgres.go         Ephemeral Docker Postgres
-├── profile/          Profiling and regression detection
-│   └── profile.go          Segment stats aggregation, diffing, JSON export
-└── integration/      Integration test suite (Docker Postgres + real coordinator)
+e2e/                  System-level E2E testing framework
+├── integration_test.go  12 E2E tests (streaming, billing, encryption, attestation, etc.)
+├── profile_test.go      latency profiling tests
+├── benchmark_test.go    load benchmarks (posts markdown to PR comments)
+└── testbed/             shared test harness
+    ├── coordinator.go       Coordinator lifecycle (start/stop, Postgres helpers)
+    ├── provider.go          Provider lifecycle (binary discovery, start/stop)
+    ├── config.go            Test configuration (model, provider, request settings)
+    ├── suite.go             Suite orchestration (multi-provider, user pools)
+    ├── events.go            Event system (segments, buffers, fan-out)
+    ├── instrument.go        Request-level instrumentation
+    ├── load.go              Load generator (concurrency, streaming, metrics)
+    ├── assert/              Latency threshold + accounting integrity assertions
+    ├── deps/                External dependency lifecycle (ephemeral Postgres)
+    └── profile/             Segment stats aggregation, diffing, JSON export
 
-provider-swift/       Current Swift provider CLI for Apple Silicon Macs
+provider-swift/       Swift provider CLI for Apple Silicon Macs
 ├── Sources/ProviderCore/             coordinator client, protocol, hardware, security, inference, server, telemetry, model downloads
 ├── Sources/ProviderCoreFoundation/   model manifests, scanner, hashing, publish-safe foundation code
 ├── Sources/darkbloom/                CLI (`serve`, `start`, `stop`, `models`, `benchmark`, `status`, `doctor`, `login`, etc.)
 ├── Sources/darkbloom-publish/        registry manifest builder used by publish workflow
+├── Sources/darkbloom-enclave-cli/    Secure Enclave attestation/sign helper
 └── Tests/                            ProviderCore and ProviderCoreFoundation tests
 
-provider/             Deprecated Rust provider retained for historical/reference work only
+provider/             Deprecated Rust provider (bridge auto-update to Swift bundles only)
 
-enclave/              Swift Secure Enclave helper + bridge binary
+enclave/              Standalone Secure Enclave helper (legacy naming)
 ├── Sources/EigenInferenceEnclave/      enclave key + attestation library + FFI bridge
-├── Sources/EigenInferenceEnclaveCLI/   `eigeninference-enclave` CLI (attest, sign, info)
+├── Sources/EigenInferenceEnclaveCLI/   CLI (attest, sign, info)
 ├── Tests/EigenInferenceEnclaveTests/
 └── include/eigeninference_enclave.h
 
@@ -72,25 +79,28 @@ console-ui/           Next.js 16 / React 19 frontend
 └── proxy.ts          Next.js 16 proxy (replaces middleware.ts)
 
 scripts/              build, signing, install, and deploy helpers
-├── build-bundle.sh   provider/enclave bundle builder (+ optional upload)
 ├── install.sh        end-user installer served from coordinator (hash + codesign verification)
-├── sign-hardened.sh  hardened runtime signing helper
 ├── admin.sh          admin CLI (Privy auth, release mgmt, API calls)
+├── publish-model.sh  model registry publish workflow
 ├── deploy-acme.sh    nginx/step-ca helper
-├── test-stt-e2e.sh   speech-to-text smoke test
+├── fetch-metallib.sh MLX metallib fetcher
 └── entitlements.plist hardened runtime entitlements (hypervisor, network)
 
-docs/                 architecture, deploy runbooks, MDM/ACME notes, image/video research
-.github/workflows/    CI (ci.yml) and release automation (release.yml) with code signing + notarization
+docs/                 architecture, deploy runbooks, MDM/ACME notes, threat model
+.github/workflows/    CI (ci.yml), integration tests (integration.yml), Swift release (release-swift.yml),
+                      Rust bridge release (release-rust-bridge.yml), model registration (register-model.yml),
+                      threat model review (threat-model-review.yml)
 ```
 
 ## Current Surface Area
 
-- Coordinator HTTP routes include `POST /v1/chat/completions`, `POST /v1/completions`, `POST /v1/messages`, `POST /v1/audio/transcriptions`, `POST /v1/images/generations`, `GET /v1/models`, billing/pricing endpoints, invite flows, stats, enrollment, device authorization, and release registration endpoints.
+- Coordinator HTTP routes include `POST /v1/chat/completions`, `POST /v1/completions`, `POST /v1/messages`, `POST /v1/audio/transcriptions`, `POST /v1/images/generations`, `GET /v1/models`, `GET /v1/models/capacity`, billing/pricing endpoints, invite flows, stats, enrollment, device authorization, and release registration endpoints.
 - Coordinator auth is split between Privy JWTs, API keys, and device-code login (RFC 8628) for provider machines.
-- Billing logic is split between `coordinator/payments` (ledger + pricing) and `coordinator/billing` (Stripe, Solana USDC, referrals). Coordinator wallet derived from BIP39 mnemonic via SLIP-0010.
-- Providers currently serve text inference through the Swift `darkbloom` CLI.
+- Routing uses token-budget admission with engine-reported capacity, speculative TTFT dispatch, EWMA TPS tracking, and early 429 with Retry-After for OpenRouter compatibility.
+- Billing logic is split between `coordinator/payments` (ledger + pricing) and `coordinator/billing` (Stripe, Solana USDC, referrals).
+- Providers serve text inference through the Swift `darkbloom` CLI with continuous batching via MLX-Swift.
 - Model registry data is DB-backed in the coordinator and points to R2 manifests under `https://models.darkbloom.ai`; model bytes are not hardcoded in the provider or UI.
+- Observability: Datadog metrics (DogStatsD) for attestation, routing, billing, fleet version, and provider capacity. X-Timing header decomposes per-request latency.
 
 ## Building And Testing
 
@@ -102,7 +112,7 @@ go build ./cmd/coordinator
 go build ./cmd/verify-attestation
 
 # Linux deployment build
-GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o eigeninference-coordinator-linux ./cmd/coordinator
+GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o coordinator-linux ./cmd/coordinator
 ```
 
 ### Provider (Swift)
@@ -128,6 +138,13 @@ npx eslint src/       # lint check
 npm test              # vitest
 ```
 
+### E2E Integration Tests
+```bash
+# Requires Postgres + Swift provider binary + MLX model downloaded
+go test ./e2e/... -run TestIntegration -v
+go test ./e2e/... -run TestBenchmark -v    # load benchmarks
+```
+
 ### Root Python Tests
 ```bash
 python3 -m pytest tests/test_crypto_interop.py
@@ -144,7 +161,7 @@ Current release-sensitive pieces:
 - App bundle + DMG creation lives in `scripts/bundle-app.sh`.
 - Installer flow lives in `scripts/install.sh`.
 - Provider update checks use `LatestProviderVersion` in `coordinator/api/server.go`, so bundle uploads and version bumps need to stay coordinated.
-- CI release workflow (`release.yml`) signs binaries with Developer ID Application cert, notarizes with Apple, computes SHA-256 hashes after signing.
+- CI release workflow (`release-swift.yml`) signs binaries with Developer ID Application cert, notarizes with Apple, computes SHA-256 hashes after signing, embeds provisioning profile in .app bundle.
 
 Quick coordinator deploy (prod, EigenCloud):
 
@@ -176,11 +193,10 @@ Dev coordinator deploy (Google Cloud): see `docs/dev-environment.md`.
 
 ## Common Pitfalls
 
-- The repo contains mixed payment language: current coordinator code implements Privy + Stripe + Solana + referrals, but some provider comments/strings still mention Tempo/pathUSD.
 - `coordinator/coordinator` is a built binary checked into the tree. Do not model changes from it, and do not commit more built artifacts.
 - CI release workflow must compute binary SHA-256 hashes AFTER code signing, not before. Providers verify hashes of the signed binary.
 - Model scan uses fast discovery (no hashing) at startup. Weight hashing is on-demand via `compute_weight_hash()` only for the served model. Don't add hashing back to the scan path.
-- Provider auto-injects ChatML template for models missing `chat_template` field. This is intentional — Qwen3.5 base models ship without it.
+- Provider auto-injects ChatML template for models missing `chat_template` field. This is intentional -- Qwen3.5 base models ship without it.
 - The coordinator uses in-memory store by default. Provider state is lost on restart. Postgres store exists but is not used in production yet.
 - Request queue timeout is 120 seconds. Initial attestation challenge is sent immediately on registration, then every 5 minutes.
 - Backend idle timeout is 1 hour (not 10 minutes as some comments may say).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,111 @@
+# Changelog
+
+## Unreleased (Apr 26 - May 25, 2026)
+
+26 commits since `aa74499`.
+
+### Coordinator
+
+#### Features
+
+- **DB-backed model registry** (#203) -- Model catalog is now stored in Postgres with R2-hosted manifests. Includes readable prefixes, runtime limits, runtime parameters, hardened validation, and provider inventory preservation across catalog updates. `50e8887b`
+- **Token-budget routing with engine-level admission** (#171) -- Replaces heuristic-based routing with engine-reported capacity signals. Providers report real `activeTokens`, `maxTokensPotential`, and token budget usage. Coordinator uses EWMA observed TPS, fleet median fallback, and token-budget admission. 5 new fields on `BackendSlotCapacity` (backward-compatible). 25+ new tests. `78314b4e`
+- **Speculative TTFT dispatch** (#171) -- Parallel dispatch to a backup provider at 50% of the TTFT deadline. First provider to deliver a token wins; loser is cancelled. No double-billing. OpenRouter TTFT SLA enforcement (5s base + 1ms/input token). `78314b4e`
+- **Early 429 with Retry-After for capacity signaling** (#171) -- Returns 429 instead of 503 when fleet is at capacity (no uptime penalty on OpenRouter). `GET /v1/models/capacity` endpoint for observability. `ModelCapacitySnapshot` with per-model routable/warm/cold providers, aggregate TPS, estimated TTFT, and token budget headroom. `78314b4e`
+- **Coordinator-driven model preload protocol** (#110) -- New `load_model` / `load_model_status` WebSocket messages allow the coordinator to push model warm-up requests to providers ahead of demand. `56b050b4`
+- **Datadog observability stack** (#143) -- DogStatsD, APM, journald log collection on dev GCE VM. Structured metrics: attestation counters, model_type tags, provider-count gauges, completion-tokens counter, fleet version/binary hash observability, billing histograms (reservation, settlement, provider credits, platform fees), store latency, input token metrics. `56b050b4`
+- **X-Timing latency decomposition header** (#136) -- Single JSON header with per-phase microsecond breakdown: `parse_us`, `reserve_us`, `route_us`, `queue_us`, `encrypt_us`, `dispatch_us`, `provider_us`. `56b050b4`
+
+#### Bug Fixes
+
+- **Structured JSON 404 for unimplemented /v1/* endpoints** (#168) -- Catch-all handler returns `application/json` errors instead of Go's default `text/plain` 404. Prevents OpenAI SDK parse failures on `/v1/embeddings`, `/v1/moderations`, etc. Added openai-go SDK compatibility tests. `e108da5f`
+- **OpenAI error response `code` and `param` fields** (#144) -- `errorResponse` now populates `code` and `param` per the OpenAI API spec. `insufficient_quota` canonical code, `param="model"` on model errors. All 202 existing call sites backward-compatible. `e108da5f`
+- **Require country for Stripe payout onboarding** (#179) -- `2e262b73`
+- **Stripe dashboard metadata** -- `35582c82`
+- **Prevent double-decrement on untrusted provider disconnect** (#143) -- `MarkUntrusted` race fix: hold write lock through counter decrement. Heartbeat no longer revives untrusted providers. `56b050b4`
+- **Skip Python/dangerous-modules check for Swift runtime** (#143) -- Private text routing gate correctly bypasses Python-specific checks for Swift providers. `56b050b4`
+- **Fix planner pending leak** (#171) -- Changed `planner.complete()` to `planner.cancel()` in request completion path. Without this, pending entries accumulated until `maxQueuedRequests` (128), permanently bricking the provider. `78314b4e`
+- **Refund provider-specific extra on generic dispatch** (#171) -- All 14 failure paths after `reserveAdditionalForProvider` now refund the delta in `handleGenericInference`. `78314b4e`
+- **activeRequests counted per-model, not per-provider** (#171) -- `ModelCapacitySnapshot` now counts only pending requests matching the specific model. `78314b4e`
+- **Link test providers to user account** (#174) -- Ensures payout destination check passes for test providers. `f4219c4f`
+
+#### Breaking / Protocol Changes
+
+- **Go module path changed** -- `github.com/eigeninference/coordinator/internal/X` -> `github.com/eigeninference/d-inference/coordinator/X`. Module path is now `github.com/eigeninference/d-inference`. `coordinator/internal/` flattened to `coordinator/`. `56b050b4`
+- **Bundle filename changed** -- Coordinator now accepts `darkbloom-bundle-<platform>.tar.gz` (was `eigeninference-bundle-`). `56b050b4`
+
+---
+
+### Provider (Swift)
+
+#### Features
+
+- **Swift provider runtime shipped** (#110) -- Full `darkbloom` CLI with `serve`, `start`, `stop`, `status`, `doctor`, `models`, `benchmark`, `login`, `logout`, `enroll`, `update`, `verify` subcommands. Production inference via MLX-Swift on Apple Silicon. GPU-only enforcement. Rename from `eigeninference` to `darkbloom` with backward compatibility. `56b050b4`
+- **Continuous batching** (#110) -- All concurrent requests merged into one batched forward pass per step via `BatchGenerator`. Bit-identical against single-stream greedy. Near-linear throughput scaling (B=4/B=1 = 3.8x on Qwen, 2.9x on Gemma MoE). `56b050b4`
+- **Multi-model concurrent serving** (#167) -- `953b8f02`
+- **MLXLMServer adoption for OpenAI protocol** (#208) -- `ca8983c4`
+- **BatchedEngine migration** (#207) -- `BatchScheduler` migrated from `BatchGenerator` to `BatchedEngine`. `80fc0ee7`
+- **Idle-timeout model unload** (#110) -- Provider unloads model after 60 minutes idle (configurable). Next request lazy-reloads. `56b050b4`
+- **Persistent Secure Enclave key** (#146) -- Replaces ephemeral CryptoKit SE keys with persistent Security framework keys in the macOS data protection keychain. Bound to signing team's keychain access group. .app bundle with embedded provisioning profile. `56b050b4`
+- **Token budget engine-level admission** (#171) -- `BatchScheduler` reports real token budget usage. EWMA decode TPS tracker. Engine-level admission gate rejects with `token_budget_exhausted`. Dynamic token budget sized from model weight bytes and available memory. `78314b4e`
+- **Architecture-aware kvBytesPerToken** (#171) -- Computed from config.json metadata (layer count, KV heads, head dim) instead of weight-bytes heuristic. Handles hybrid attention (Gemma 4), GQA/MQA, recurrent layers (Qwen3.5), and VLM wrappers. 4x reduction on Qwen3.5 models. `78314b4e`
+- **Rust-to-Swift bridge auto-update** (#110) -- Rust provider auto-updates to Swift bundles, rewrites launchd plist, handles .app bundle layout. `56b050b4`
+
+#### Performance
+
+- Greedy fast-path optimization: `nil` sampler for temperature=0 uses vectorized fallback (+6-13% decode TPS). `56b050b4`
+- mlx-swift-lm double buffering, UInt32 token tensors. `56b050b4`
+- Release-mode BatchGenerator B=4 matches mlx_lm Python reference (Qwen: ~1130 vs 1119 tok/s; Gemma: ~186 vs 181 tok/s). `56b050b4`
+
+---
+
+### Console UI
+
+- **Refresh earn calculator and landing page** (#185) -- `ed6d655e`
+- **Fix Next.js version vulnerability** (#172) -- `2f65bb41`
+- **Analytics tracking fix** -- `f7dab6fa`
+
+---
+
+### Testbed / E2E
+
+- **Integration test suite** (#136) -- 12 E2E tests with real Swift provider (Postgres + coordinator + provider per test). Tests: NonStreaming, Streaming, Concurrent, Encryption, Billing, Payout, Referral, InsufficientBalance, InvalidModel, AttestationHeaders. `56b050b4`
+- **Load generator and profiling** (#136) -- Configurable concurrency, streaming, benchmark CI with PR comment posting. Heavy-load 100-concurrent 10KB benchmark. Latency regression assertions. `56b050b4`
+- **Performance test suite** (#110) -- Warm/cold TTFT, encrypted E2E, batched throughput, decode-TPS bracket tests for Qwen 0.6B and Gemma 26B MoE. `56b050b4`
+
+---
+
+### Security
+
+- **Harden release registration and binary hash policy** (#99) -- Release download URL derived from allowlist. `b5dd0488`
+- **Harden release workflow protections** (#103) -- `e515244f`
+- **Rust-to-Swift cutover hardening** (#110) -- Post-codesign verification of entitlements, provisioning profile validation (team ID, access group, expiration), MLX wheel pinning, prod hard-fail on Swift tests. `56b050b4`
+- **STRIDE threat model** (#110) -- 40 threats across 9 trust boundaries. Automated PR review workflow via Claude API. `56b050b4`
+- **Typed response structs for OpenAI endpoints** (#166) -- `7fbfa9fc`
+
+---
+
+### Billing
+
+- **Remove deprecated Solana/wallet-based provider payouts** (#178) -- `fe994fc9`
+
+---
+
+### CI / Infrastructure
+
+- **Migrate CI workflows to Blacksmith** (#182) -- `ff8527a4`
+- **CI runs on any PR** (#119) -- Not just master/main. `98a3a024`
+- **Remove racing deploy-dev-coordinator workflow** (#137) -- Eliminates race condition with Cloud Build. `cf4c0efa`
+- **DEV_/PROD_ prefixed repo secrets** -- Environment-scoped R2 + coordinator secrets for release isolation. `56b050b4`
+- **Native Postgres fallback for CI** -- Docker/colima replaced with `initdb + postgres` on macOS runners. `56b050b4`
+- **Correct version comments for SHA-pinned actions** (#160) -- `85cedc7e`
+
+---
+
+### Housekeeping
+
+- **Remove unused dependencies** (#112) -- `7ccc592f`
+- **Remove stale Python integration test** (#109) -- `e6d63a86`
+- **Bump mlx-swift and mlx-swift-lm submodules** (#206) -- Re-homed to Layr-Labs forks. `5919dac1`
+- **Darkbloom license agreement** (#173) -- `dde67b28`
+- **Update README** (#176) -- `7451a473`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,27 +1,36 @@
-# EigenInference - Decentralized GPU Inference
+# Darkbloom - Decentralized Private Inference
 
-Decentralized inference network for Apple Silicon Macs. Providers offer GPU compute, consumers send OpenAI-compatible requests, the coordinator matches them.
+Darkbloom is a decentralized private inference network for Apple Silicon Macs. Consumers use OpenAI-compatible APIs, the coordinator handles routing, auth, billing, attestation, and capacity management, and providers run local inference workloads on macOS hardware using MLX-Swift. All inference is end-to-end encrypted -- the coordinator never sees plaintext prompts.
 
 ## Project Structure
 
 ```
-coordinator/          Go — central matchmaking server (runs on EigenCloud in prod)
-├── cmd/coordinator/  entrypoint
+coordinator/          Go control plane (packages live at top level, not internal/)
+├── cmd/coordinator/  main service entrypoint
 ├── cmd/verify-attestation/  attestation blob verification utility
-├── internal/
-│   ├── api/          HTTP + WebSocket handlers (consumer.go, provider.go, billing_handlers.go, device_auth.go, invite_handlers.go, release_handlers.go, enroll.go, stats.go, server.go)
-│   ├── attestation/  Secure Enclave + MDA attestation verification
-│   ├── auth/         Privy JWT verification + user provisioning
-│   ├── billing/      Stripe, Solana USDC deposits, referral system
-│   ├── e2e/          End-to-end encryption (X25519 key exchange)
-│   ├── mdm/          MicroMDM integration for device attestation
-│   ├── payments/     Internal ledger, pricing tables, payout tracking
-│   ├── protocol/     WebSocket message types shared with provider
-│   ├── registry/     Provider registry, scoring, reputation, request queue
-│   └── store/        Persistence (in-memory or Postgres)
+├── api/              HTTP + WebSocket handlers (consumer.go, provider.go, billing_handlers.go, device_auth.go, invite_handlers.go, release_handlers.go, enroll.go, stats.go, server.go)
+├── attestation/      Secure Enclave + MDA attestation verification
+├── auth/             Privy JWT verification + user provisioning
+├── billing/          Stripe, Solana USDC deposits, referral system
+├── e2e/              End-to-end encryption (X25519 key exchange)
+├── mdm/              MicroMDM integration for device attestation
+├── payments/         Internal ledger, pricing tables, payout tracking
+├── protocol/         WebSocket message types shared with provider
+├── ratelimit/        Rate limiting
+├── registry/         Provider registry, queueing, routing, reputation, token-budget admission
+├── saferun/          Panic-safe goroutine runners
+├── store/            Persistence (in-memory or Postgres)
+├── telemetry/        Datadog DogStatsD metrics
+├── datadog/          Dev dashboard JSON definitions
+└── internal/e2e/     Coordinator-scoped integration tests
 
-provider-swift/       Swift — current provider CLI for Apple Silicon Macs
-├── Package.swift     SwiftPM manifest, depends on libs/mlx-swift{,-lm}
+e2e/                  System-level E2E testing framework
+├── integration_test.go  12 E2E tests (streaming, billing, encryption, attestation, etc.)
+├── profile_test.go      latency profiling tests
+├── benchmark_test.go    load benchmarks (posts markdown to PR comments)
+└── testbed/             shared test harness (coordinator/provider lifecycle, load generator, assertions)
+
+provider-swift/       Swift provider CLI for Apple Silicon Macs
 ├── Sources/
 │   ├── ProviderCore/                  shared library (protocol, hardware, crypto, security, inference, coordinator client, scheduling, server, telemetry, model downloads, attestation)
 │   ├── ProviderCoreFoundation/        Linux-buildable model manifests, scanner, hashing, publish-safe code
@@ -30,11 +39,17 @@ provider-swift/       Swift — current provider CLI for Apple Silicon Macs
 │   └── darkbloom-enclave-cli/         Secure Enclave attestation/sign helper
 └── Tests/
 
-provider/             Deprecated Rust provider retained for historical/reference work only
+provider/             Deprecated Rust provider (bridge auto-update to Swift bundles only)
+
+enclave/              Standalone Secure Enclave helper (legacy naming)
+├── Sources/EigenInferenceEnclave/      enclave key + attestation library + FFI bridge
+├── Sources/EigenInferenceEnclaveCLI/   CLI (attest, sign, info)
+├── Tests/EigenInferenceEnclaveTests/
+└── include/eigeninference_enclave.h
 
 console-ui/           Next.js 16 / React 19 frontend (chat, billing, models)
 ├── src/app/          Pages: chat (/), billing, models, stats, providers, settings, link, api-console, earn
-├── src/app/api/      Proxy routes: chat, models, auth/keys, payments/*, invite, health, pricing
+├── src/app/api/      Proxy routes: chat, images, transcribe, auth/keys, payments/*, invite, models, health, pricing
 ├── src/components/   Chat UI, sidebar, top bar, trust badges, invite banner, verification panel
 ├── src/lib/          API client (api.ts), Zustand store (store.ts)
 ├── src/hooks/        Auth (useAuth.ts), toast notifications (useToast.ts)
@@ -43,16 +58,16 @@ console-ui/           Next.js 16 / React 19 frontend (chat, billing, models)
 scripts/
 ├── install.sh        curl one-liner installer (fetches release, verifies SHA-256 + code signature)
 ├── admin.sh          Admin CLI (Privy auth, release mgmt, API calls)
+├── publish-model.sh  Model registry publish workflow
 ├── deploy-acme.sh    nginx/step-ca helper
+├── fetch-metallib.sh MLX metallib fetcher
 ├── smoke-dev.sh      Dev-coordinator smoke test
-├── benchmark-*.py    Benchmark utilities
 └── entitlements.plist Hardened Runtime entitlements (hypervisor, network)
 
-docs/                 Architecture docs, deploy runbook, MDM/ACME notes
-landing/              Static landing page (index.html)
-.github/workflows/    CI (ci.yml) and Swift release automation (release-swift.yml)
-
-.external/            Git-ignored; holds external forks used by historical experiments (NOT part of this repo)
+docs/                 Architecture docs, deploy runbook, MDM/ACME notes, threat model
+.github/workflows/    CI (ci.yml), integration tests (integration.yml), Swift release (release-swift.yml),
+                      Rust bridge release (release-rust-bridge.yml), model registration (register-model.yml),
+                      threat model review (threat-model-review.yml)
 ```
 
 ### External Dependencies (`.external/`)
@@ -66,7 +81,7 @@ The `.external/` directory is reserved for local external checkouts and **must n
 cd coordinator
 go test ./...
 # Cross-compile for the EigenCloud container (Linux amd64):
-GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o eigeninference-coordinator-linux ./cmd/coordinator
+GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o coordinator-linux ./cmd/coordinator
 ```
 
 ### Provider, Swift
@@ -89,6 +104,13 @@ npx eslint src/       # lint check
 npm test              # vitest
 ```
 
+### E2E Integration Tests
+```bash
+# Requires Postgres + Swift provider binary + MLX model downloaded
+go test ./e2e/... -run TestIntegration -v
+go test ./e2e/... -run TestBenchmark -v    # load benchmarks
+```
+
 ## Releases
 
 **Never create a release unless explicitly asked by the user.** When asked:
@@ -104,7 +126,7 @@ npm test              # vitest
    - ..."
    ```
 4. **Push** the commit and tag: `git push origin master --tags`
-5. The Swift release workflow (`.github/workflows/release-swift.yml`) is triggered by tags shaped `vX.Y.Z-swift[.N]`. While the Rust provider is still in production, ship Rust releases via a separate workflow re-introduced from git history.
+5. The Swift release workflow (`.github/workflows/release-swift.yml`) is triggered by tags shaped `vX.Y.Z-swift[.N]`. The Rust bridge release workflow (`release-rust-bridge.yml`) handles legacy provider auto-update to Swift bundles.
 
 ## Deploying
 
@@ -142,7 +164,7 @@ Shape: GCE Ubuntu VM + Docker + systemd (coordinator + step-ca + MicroMDM need p
 
 ### Provider bundle
 
-CI (`.github/workflows/release-swift.yml`) builds, signs, notarizes, and uploads the Swift CLI bundle to Cloudflare R2 (`s3://d-inf-app/releases/v{VERSION}/eigeninference-bundle-macos-arm64.tar.gz`), then registers the release with the coordinator via `POST /v1/releases`. Providers fetch via `install.sh` served by the coordinator. There is no SSH-to-a-VM step.
+CI (`.github/workflows/release-swift.yml`) builds, signs, notarizes, and uploads the Swift CLI bundle to Cloudflare R2 (`s3://d-inf-app/releases/v{VERSION}/darkbloom-bundle-macos-arm64.tar.gz`), then registers the release with the coordinator via `POST /v1/releases`. Providers fetch via `install.sh` served by the coordinator. There is no SSH-to-a-VM step.
 
 ## Infrastructure
 
@@ -161,21 +183,24 @@ CI (`.github/workflows/release-swift.yml`) builds, signs, notarizes, and uploads
 
 ## Key Design Decisions
 
+- **Token-budget routing**: Providers report real token budget usage (active tokens, max potential, EWMA decode TPS) in heartbeats. Coordinator uses engine-reported capacity for admission, with fleet median TPS as fallback. Speculative TTFT dispatch sends to a backup provider at 50% of the deadline; first token wins, loser is cancelled. Early 429 with Retry-After for OpenRouter compatibility.
 - **Provider scoring**: decode TPS × trust multiplier × reputation × warm model bonus × health factor. Health factor uses live system metrics (memory pressure, CPU usage, thermal state) reported in heartbeats.
+- **Continuous batching**: All concurrent requests merged into one batched forward pass per step via MLX-Swift BatchedEngine. Near-linear throughput scaling (B=4/B=1 = 3.8x on Qwen, 2.9x on Gemma MoE). Temperature=0 uses vectorized greedy fast path.
 - **Request cancellation**: In-flight inference requests are tracked by request_id with cancellation state. On coordinator disconnect, in-flight requests are cancelled so generation stops promptly.
-- **Idle GPU timeout**: Loaded model state is released after 1 hour of no requests to free GPU memory. Lazy-reloaded when the next request arrives (cold-start penalty depends on model size).
+- **Idle GPU timeout**: Loaded model state is released after 1 hour of no requests to free GPU memory. Lazy-reloaded when the next request arrives. Coordinator can also push `load_model` messages to pre-warm providers.
 - **E2E encryption**: Consumer requests encrypted with provider's X25519 public key (NaCl box). Coordinator never sees plaintext prompts. Decryption only inside the hardened provider process.
-- **Attestation chain**: Secure Enclave P-256 key → signs attestation blob → coordinator verifies signature (self_signed) → MDM SecurityInfo cross-check (hardware trust) → Apple Enterprise Attestation Root CA signs device cert chain via MDA (mda_verified). Full chain exposed at `GET /v1/providers/attestation` for user-side verification.
+- **Attestation chain**: Secure Enclave P-256 key (persistent, keychain access group bound) → signs attestation blob → coordinator verifies signature (self_signed) → MDM SecurityInfo cross-check (hardware trust) → Apple Enterprise Attestation Root CA signs device cert chain via MDA (mda_verified). Full chain exposed at `GET /v1/providers/attestation` for user-side verification.
 - **Protocol symmetry**: `provider-swift/Sources/ProviderCore/Protocol/` and `coordinator/protocol/messages.go` define the same WebSocket message types. Changes to one must be mirrored in the other.
 - **Model registry**: Coordinator registry data is DB-backed and points to R2 manifests. The Swift provider downloads the files listed in the manifest from `https://models.darkbloom.ai` and verifies per-file plus aggregate SHA-256. Do not reintroduce hardcoded model catalog lists.
-- **Billing**: Solana USDC deposits verified on-chain. Coordinator wallet derived from BIP39 mnemonic via SLIP-0010 (m/44'/501'/0'/0'). Stripe wired but inactive. Referral system gives referrers a share of platform fees.
-- **Request queue**: When all providers are busy, requests queue with 120s timeout. Frontend shows "providers are busy" on 503.
+- **Billing**: Solana USDC deposits verified on-chain. Coordinator wallet derived from BIP39 mnemonic via SLIP-0010 (m/44'/501'/0'/0'). Stripe wired for payouts. Referral system gives referrers a share of platform fees.
+- **Request queue**: When all providers are busy, requests queue with 120s timeout. Frontend shows "providers are busy" on 503. 429 with Retry-After returned when fleet is at capacity.
 - **Challenge timing**: Initial attestation challenge sent immediately on provider registration, then every 5 minutes via ticker.
 - **Model scan performance**: `scan_models()` does fast discovery without hashing. Weight hash computed on-demand only for the model being served via `compute_weight_hash()`.
 - **Chat template injection**: Provider auto-injects ChatML template for models missing `chat_template` field (e.g., Qwen3.5 base models).
 - **Hypervisor memory isolation**: Apple Hypervisor.framework creates Stage 2 page tables to protect inference memory from RDMA/DMA attacks. Requires `com.apple.security.hypervisor` entitlement.
 - **Device auth**: RFC 8628 device code flow for linking provider machines to user accounts. Provider runs `login`, gets a code, user enters it on the web.
-- **CI code signing**: GitHub Actions release workflow signs provider binary with Developer ID Application cert, notarizes with Apple, computes SHA-256 hashes after signing.
+- **CI code signing**: GitHub Actions release workflow signs provider binary with Developer ID Application cert, notarizes with Apple, computes SHA-256 hashes after signing. Provisioning profile embedded in .app bundle for persistent SE key.
+- **Observability**: Datadog DogStatsD metrics for attestation, routing, billing, fleet version, provider capacity. X-Timing JSON header decomposes per-request latency (parse, reserve, route, queue, encrypt, dispatch, provider).
 
 ## Problem-Solving Approach
 
@@ -199,12 +224,11 @@ Always think from first principles. When fixing a bug or designing a feature:
 - Telemetry wire types are mirrored in three places: `coordinator/protocol/telemetry.go`, `provider-swift/Sources/ProviderCore/Telemetry/`, and `console-ui/src/lib/telemetry-types.ts`. The field allowlist (`coordinator/api/telemetry_handlers.go`) is the privacy backstop — never add prompt/completion fields. See `docs/telemetry.md`.
 - Attestation tests need `AuthenticatedRootEnabled: true` in test blobs or the ARV check fails and overwrites earlier error messages (the checks run sequentially, last failure wins).
 - The coordinator uses in-memory store by default. Provider state is lost on restart. Postgres store exists but is not used in production yet.
-- Binary files like `coordinator/eigeninference-coordinator` and `coordinator/eigeninference-coordinator-linux` should NOT be committed to git (15MB+ each).
+- Binary files like `coordinator/coordinator` should NOT be committed to git. Do not model changes from this built artifact.
 - CI release workflow must compute binary SHA-256 hashes AFTER code signing, not before. Providers verify hashes of the signed binary.
 - Provider bundle semantics span multiple files: `.github/workflows/release-swift.yml`, `scripts/install.sh`, and `LatestProviderVersion` in `coordinator/api/server.go`. Keep them in sync.
 - Model registry changes span coordinator registry schema/endpoints, `provider-swift` manifest download/publish code, `scripts/publish-model.sh`, and the console UI.
 - Device linking changes span coordinator device auth endpoints and provider `login`/`logout` commands.
-- The repo contains mixed payment language: current code implements Privy + Solana + Stripe, but some provider comments still reference Tempo/pathUSD.
 
 ## Testing New Features
 


### PR DESCRIPTION
## Summary

Add a changelog covering the 26 commits since the last coordinator release (`aa74499`, Apr 26) and update AGENTS.md / CLAUDE.md to use Darkbloom branding with accurate project context.

## Changes

### CHANGELOG.md (new)
Structured changelog covering all changes since the last release, organized by component:
- **Coordinator**: DB-backed model registry, token-budget routing, speculative TTFT dispatch, early 429 signaling, model preload protocol, Datadog observability, X-Timing header, OpenAI error spec compliance, structured JSON 404s, race fixes
- **Provider (Swift)**: Swift runtime shipped, continuous batching, multi-model serving, MLXLMServer adoption, BatchedEngine migration, persistent SE key, idle-timeout unload, architecture-aware kvBytesPerToken
- **Console UI**: Earn calculator refresh, Next.js vulnerability fix, analytics fix
- **E2E Testbed**: Integration test suite, load generator, performance benchmarks
- **Security**: Release hardening, STRIDE threat model, provisioning profile validation
- **CI**: Blacksmith migration, any-PR CI, env-scoped secrets, native Postgres fallback

### AGENTS.md + CLAUDE.md
- Title and description updated from EigenInference to Darkbloom
- Project structure updated to match current repo layout (flattened coordinator packages, new packages, e2e/ testbed, updated workflow listings)
- Current surface area updated with token-budget routing, Datadog observability, capacity endpoint
- Key Design Decisions updated with continuous batching, persistent SE key, observability
- All operational principles, rules, and guidelines preserved unchanged
- Remaining `EigenInference` references are actual filesystem paths (enclave directory names)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/209"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782328481&installation_id=133247490&pr_number=209&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F209&signature=24c595ef9252b8b7693a22804b63517208c05a1862aa06de2775110839f9a199"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->