### PR TITLE
security: add CSP and security headers to console-ui (SEC-014)

### DIFF
--- a/console-ui/next.config.ts
+++ b/console-ui/next.config.ts
@@ -1,11 +1,47 @@
 import type { NextConfig } from "next";
 
+// Content-Security-Policy directives.
+// - 'unsafe-inline' for style-src: required by Next.js for injected styles.
+// - 'unsafe-inline' + 'unsafe-eval' for script-src: required by Privy SDK
+//   and Next.js dev mode. Tighten to nonce-based CSP when feasible.
+// - connect-src: coordinator API, Privy auth, Google Analytics, Stripe.
+// - frame-src: Privy auth iframes, Stripe Checkout iframes.
+const cspDirectives = [
+  "default-src 'self'",
+  "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.googletagmanager.com https://js.stripe.com",
+  "style-src 'self' 'unsafe-inline'",
+  "img-src 'self' data: blob: https:",
+  "font-src 'self' data:",
+  "connect-src 'self' https://api.darkbloom.dev https://*.privy.io wss://*.privy.io https://www.google-analytics.com https://api.stripe.com",
+  "frame-src https://auth.privy.io https://js.stripe.com",
+  "frame-ancestors 'none'",
+  "base-uri 'self'",
+  "form-action 'self'",
+].join("; ");
+
+const securityHeaders = [
+  { key: "Content-Security-Policy", value: cspDirectives },
+  { key: "X-Frame-Options", value: "DENY" },
+  { key: "X-Content-Type-Options", value: "nosniff" },
+  { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+  { key: "Strict-Transport-Security", value: "max-age=63072000; includeSubDomains; preload" },
+  { key: "Permissions-Policy", value: "camera=(), microphone=(), geolocation=()" },
+];
+
 const nextConfig: NextConfig = {
   typescript: {
     // @noble/curves >=1.9 ships raw .ts files with .ts import extensions,
     // which fails Next.js type-checking even with skipLibCheck: true.
     // This is a known upstream issue in viem's dependency tree.
     ignoreBuildErrors: true,
+  },
+  async headers() {
+    return [
+      {
+        source: "/(.*)",
+        headers: securityHeaders,
+      },
+    ];
   },
 };
 


### PR DESCRIPTION
## Summary

Adds six security headers to all console-ui routes via `next.config.ts` `headers()`. Closes the open finding SEC-014 (threat T-019: missing security headers increase XSS blast radius).

## Headers Added

| Header | Value | Purpose |
|--------|-------|---------|
| `Content-Security-Policy` | See below | Restricts script/style/connect/frame origins |
| `X-Frame-Options` | `DENY` | Clickjacking prevention (legacy) |
| `X-Content-Type-Options` | `nosniff` | MIME-type sniffing prevention |
| `Referrer-Policy` | `strict-origin-when-cross-origin` | Controls referrer leakage |
| `Strict-Transport-Security` | `max-age=63072000; includeSubDomains; preload` | Forces HTTPS |
| `Permissions-Policy` | `camera=(), microphone=(), geolocation=()` | Denies device access |

### CSP Directives

| Directive | Value | Why |
|-----------|-------|-----|
| `default-src` | `'self'` | Baseline restriction |
| `script-src` | `'self' 'unsafe-inline' 'unsafe-eval' googletagmanager stripe.js` | Privy SDK + Next.js require unsafe-inline/eval |
| `style-src` | `'self' 'unsafe-inline'` | Next.js injected styles |
| `img-src` | `'self' data: blob: https:` | Data URIs + external images |
| `font-src` | `'self' data:` | Inline fonts |
| `connect-src` | `'self' api.darkbloom.dev *.privy.io google-analytics stripe` | API + auth + analytics |
| `frame-src` | `auth.privy.io js.stripe.com` | Privy auth + Stripe Checkout iframes |
| `frame-ancestors` | `'none'` | Prevents embedding in iframes |
| `base-uri` | `'self'` | Prevents base tag hijacking |
| `form-action` | `'self'` | Restricts form submission targets |

## Verification

- `npm run build` passes
- Headers apply to all routes via `/(.*)` source pattern

## Notes

- `unsafe-inline` and `unsafe-eval` in script-src are required by the Privy SDK and Next.js runtime. A future improvement would be moving to nonce-based CSP.
- The CSP is deliberately tight on `connect-src` and `frame-src` -- if new external services are added, their origins must be allowlisted here.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/213"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782333607&installation_id=133247490&pr_number=213&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F213&signature=6b8a7c56c6759b8a0948bbfa864344d3c43904d063e0322574be7a2acff62dd7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->