### PR TITLE
fix(store): use INSERT ON CONFLICT for telemetry to handle duplicate event IDs

### DIFF
--- a/coordinator/store/telemetry_postgres.go
+++ b/coordinator/store/telemetry_postgres.go
@@ -10,20 +10,45 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
-
-	"github.com/jackc/pgx/v5"
 )
 
-// InsertTelemetryEvents writes a batch into telemetry_events.
+// InsertTelemetryEvents writes a batch into telemetry_events using INSERT with
+// ON CONFLICT DO NOTHING so that duplicate event IDs from client retries are
+// silently dropped instead of failing the entire batch.
 func (s *PostgresStore) InsertTelemetryEvents(ctx context.Context, events []TelemetryEventRecord) error {
 	if len(events) == 0 {
 		return nil
 	}
 
-	rows := make([][]any, 0, len(events))
 	now := time.Now().UTC()
-	for _, e := range events {
+
+	// Build a batch INSERT … ON CONFLICT (id) DO NOTHING.
+	// Each row has 14 columns; placeholders are $1..$14, $15..$28, etc.
+	const cols = 14
+	var sb strings.Builder
+	sb.WriteString(`INSERT INTO telemetry_events (
+		id, ts, source, severity, kind, version,
+		machine_id, account_id, request_id, session_id,
+		message, fields, stack, received_at
+	) VALUES `)
+
+	args := make([]any, 0, len(events)*cols)
+	for i, e := range events {
+		if i > 0 {
+			sb.WriteByte(',')
+		}
+		base := i * cols
+		sb.WriteByte('(')
+		for j := 0; j < cols; j++ {
+			if j > 0 {
+				sb.WriteByte(',')
+			}
+			fmt.Fprintf(&sb, "$%d", base+j+1)
+		}
+		sb.WriteByte(')')
+
 		fields := e.Fields
 		if len(fields) == 0 {
 			fields = json.RawMessage(`{}`)
@@ -32,7 +57,7 @@ func (s *PostgresStore) InsertTelemetryEvents(ctx context.Context, events []Tele
 		if received.IsZero() {
 			received = now
 		}
-		rows = append(rows, []any{
+		args = append(args,
 			e.ID,
 			e.Timestamp.UTC(),
 			e.Source,
@@ -47,19 +72,12 @@ func (s *PostgresStore) InsertTelemetryEvents(ctx context.Context, events []Tele
 			fields,
 			e.Stack,
 			received,
-		})
+		)
 	}
 
-	_, err := s.pool.CopyFrom(
-		ctx,
-		pgx.Identifier{"telemetry_events"},
-		[]string{
-			"id", "ts", "source", "severity", "kind", "version",
-			"machine_id", "account_id", "request_id", "session_id",
-			"message", "fields", "stack", "received_at",
-		},
-		pgx.CopyFromRows(rows),
-	)
+	sb.WriteString(` ON CONFLICT (id) DO NOTHING`)
+
+	_, err := s.pool.Exec(ctx, sb.String(), args...)
 	if err != nil {
 		return fmt.Errorf("store: insert telemetry: %w", err)
 	}


### PR DESCRIPTION
## Problem

Telemetry inserts use `pgx.CopyFrom` (raw COPY) which has no duplicate key handling. When clients retry after a 429 or 500, they resend the same event UUIDs, hitting the `telemetry_events_pkey` constraint. This fails the entire batch and returns another 500, creating a retry storm:

```
telemetry: failed to insert events  error="store:insert telemetry: ERROR: duplicate key value violates unique constraint \"telemetry_events_pkey\" (SQLSTATE 23505)"
```

## Fix

Replace `CopyFrom` with `INSERT ... ON CONFLICT (id) DO NOTHING` so duplicate event IDs from client retries are silently dropped instead of failing the batch.

Telemetry is best-effort secondary storage (Datadog is the primary sink via `forwardTelemetryToDatadog`), so silently dropping duplicates is the correct behavior.

## Impact

- Eliminates the retry storm feedback loop
- No schema changes needed
- No impact on inference, routing, billing, or provider connections
- All coordinator tests pass

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/216"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782341566&installation_id=133247490&pr_number=216&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F216&signature=419aebe11b0d70c2c31eb578bc0db61d82530143b10665d4aefcbb4ee4e8494c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->