### PR TITLE
feat(provider-swift): background auto-update loop + launchd-aware restart

### DIFF
--- a/provider-swift/Sources/ProviderCore/ProviderLoop.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop.swift
@@ -166,6 +166,11 @@ public actor ProviderLoop {
     /// long-running generations are still in flight.
     private var capacityRefreshTask: Task<Void, Never>?
 
+    /// Background task that periodically checks for provider updates and
+    /// applies them automatically. nil when auto-update is disabled or
+    /// before `run()` starts it.
+    private var autoUpdateTask: Task<Void, Never>?
+
     private let logger = ProviderLogger(subsystem: "dev.darkbloom.provider", category: "loop")
 
     private static let shutdownDrainTimeout: Duration = .seconds(600)
@@ -318,6 +323,7 @@ public actor ProviderLoop {
         // timer.
         startIdleMonitor()
         startCapacityRefreshMonitor()
+        startAutoUpdateMonitor()
 
         logger.info("Coordinator client started, entering event loop")
 
@@ -374,6 +380,8 @@ public actor ProviderLoop {
         idleMonitorTask = nil
         capacityRefreshTask?.cancel()
         capacityRefreshTask = nil
+        autoUpdateTask?.cancel()
+        autoUpdateTask = nil
         let preloads = Array(preloadTasks.values)
         for task in preloads { task.cancel() }
         cancelLoadWaiters()
@@ -1108,6 +1116,88 @@ public actor ProviderLoop {
                 if Task.isCancelled { break }
                 await me.updateAggregateCapacity()
             }
+        }
+    }
+
+    // MARK: - Background Auto-Update
+
+    /// Initial delay before the first background update check (5 minutes).
+    /// Avoids slowing down startup; lets the provider stabilize first.
+    private static let autoUpdateInitialDelay: Duration = .seconds(300)
+
+    /// Interval between subsequent update checks (30 minutes).
+    private static let autoUpdateInterval: Duration = .seconds(1800)
+
+    /// Start the background auto-update monitor. Checks the coordinator
+    /// for a newer release every 30 minutes (after an initial 5-minute
+    /// delay), downloads + verifies + installs the update, then performs
+    /// a launchd-aware restart.
+    ///
+    /// The check is skipped when:
+    ///   - `config.provider.autoUpdate` is false
+    ///   - `DARKBLOOM_NO_UPDATE_CHECK` env var is set
+    ///   - inference requests are currently active (never update mid-inference)
+    ///
+    /// Failures are logged at warning level and never crash the provider.
+    private func startAutoUpdateMonitor() {
+        autoUpdateTask?.cancel()
+
+        guard loopConfig.config.provider.autoUpdate else {
+            logger.info("Background auto-update disabled (auto_update=false)")
+            return
+        }
+        guard ProcessInfo.processInfo.environment["DARKBLOOM_NO_UPDATE_CHECK"] == nil else {
+            logger.info("Background auto-update disabled (DARKBLOOM_NO_UPDATE_CHECK set)")
+            return
+        }
+
+        let coordinatorURL = loopConfig.coordinatorURL
+        let me = self
+        autoUpdateTask = Task.detached {
+            // Wait 5 minutes before first check.
+            try? await Task.sleep(for: Self.autoUpdateInitialDelay)
+
+            while !Task.isCancelled {
+                await me.performAutoUpdateCheck(coordinatorURL: coordinatorURL)
+                // Sleep 30 minutes before next check.
+                try? await Task.sleep(for: Self.autoUpdateInterval)
+            }
+        }
+        logger.info("Background auto-update monitor started (initial delay: 5m, interval: 30m)")
+    }
+
+    /// Perform a single background update check + apply cycle.
+    private func performAutoUpdateCheck(coordinatorURL: String) async {
+        // Skip if inference is active -- never update mid-inference.
+        if !requestToModel.isEmpty {
+            logger.info("Auto-update check skipped: inference requests in flight")
+            return
+        }
+
+        logger.info("Auto-update: checking for provider update...")
+        let updater = SelfUpdater(coordinatorBaseURL: coordinatorURL)
+        let result = await updater.update()
+
+        switch result {
+        case .alreadyUpToDate:
+            logger.info("Auto-update: already running latest version")
+
+        case .updated(let from, let to):
+            logger.info("Auto-update: updated provider v\(from) -> v\(to), restarting...")
+            do {
+                try ProcessLifecycle.restartAfterUpdate()
+            } catch {
+                logger.warning("Auto-update: restart failed: \(error.localizedDescription)")
+            }
+
+        case .downloadFailed(let reason):
+            logger.warning("Auto-update: check failed: \(reason)")
+
+        case .hashMismatch(let expected, let got):
+            logger.warning("Auto-update: bundle hash mismatch (expected \(expected), got \(got))")
+
+        case .replaceFailed(let reason):
+            logger.warning("Auto-update: install failed: \(reason)")
         }
     }
 

--- a/provider-swift/Sources/ProviderCore/Service/ProcessLifecycle.swift
+++ b/provider-swift/Sources/ProviderCore/Service/ProcessLifecycle.swift
@@ -134,6 +134,52 @@ public enum ProcessLifecycle {
         #endif
     }
 
+    // MARK: - Launchd-Aware Restart
+
+    /// Restart the provider process after a background auto-update.
+    ///
+    /// If the process is managed by launchd, performs a stop + bootstrap +
+    /// kickstart cycle so launchd picks up the new binary. Otherwise,
+    /// falls back to `execCurrentProcess()` (execv) which replaces the
+    /// process image in-place.
+    ///
+    /// Mirrors the Rust provider's auto-update restart logic.
+    public static func restartAfterUpdate() throws -> Never {
+        if LaunchAgent.isLoaded() {
+            // Launchd-managed: stop the current service, then re-bootstrap
+            // and kickstart so launchd launches the new binary.
+            let domain = "gui/\(getuid())"
+            let target = "\(domain)/\(LaunchAgent.label)"
+            let plistPath = LaunchAgent.plistPath().path
+
+            // 1. Stop the current process via launchctl bootout.
+            //    This will terminate us, but we schedule the bootstrap
+            //    + kickstart first via a short-lived helper process.
+            let script = """
+            /bin/launchctl bootout \(target) 2>/dev/null; \
+            sleep 1; \
+            /bin/launchctl bootstrap \(domain) \(plistPath) 2>/dev/null; \
+            /bin/launchctl kickstart \(target) 2>/dev/null
+            """
+
+            let helper = Process()
+            helper.executableURL = URL(fileURLWithPath: "/bin/sh")
+            helper.arguments = ["-c", script]
+            helper.standardOutput = FileHandle.nullDevice
+            helper.standardError = FileHandle.nullDevice
+            try helper.run()
+
+            // Give the helper a moment to issue bootout, then exit.
+            // The bootout will terminate us; if it doesn't within 2s,
+            // exit cleanly and let the helper finish the restart.
+            Thread.sleep(forTimeInterval: 2.0)
+            exit(0)
+        } else {
+            // Not under launchd: replace process image with execv.
+            try execCurrentProcess()
+        }
+    }
+
     // MARK: - Internals
 
     private static func readPID(at url: URL) -> Int32? {

--- a/provider-swift/Sources/ProviderCore/Update/SelfUpdater.swift
+++ b/provider-swift/Sources/ProviderCore/Update/SelfUpdater.swift
@@ -329,6 +329,8 @@ public struct SelfUpdater: Sendable {
 
             case .success(let tempFile):
                 let replaceResult = installBundle(from: tempFile, release: release)
+                // Clean up the downloaded tarball regardless of install outcome.
+                try? FileManager.default.removeItem(at: tempFile)
                 switch replaceResult {
                 case .success:
                     return .updated(from: current, to: release.version)

--- a/provider-swift/Sources/darkbloom/LogsCommand.swift
+++ b/provider-swift/Sources/darkbloom/LogsCommand.swift
@@ -18,6 +18,8 @@ struct Logs: AsyncParsableCommand {
     var watch = false
 
     mutating func run() async throws {
+        await runUpdateBannerIfEnabled()
+
         let path = LaunchAgent.logPath()
         let fm = FileManager.default
 

--- a/provider-swift/Sources/darkbloom/ModelsCommand.swift
+++ b/provider-swift/Sources/darkbloom/ModelsCommand.swift
@@ -39,6 +39,8 @@ extension Models {
         var hash: String?
 
         mutating func run() async throws {
+            await runUpdateBannerIfEnabled()
+
             if let hash {
                 let digest = WeightHasher.computeHash(for: hash)
                 guard let digest else {

--- a/provider-swift/Sources/darkbloom/UpdateCommand.swift
+++ b/provider-swift/Sources/darkbloom/UpdateCommand.swift
@@ -66,7 +66,12 @@ struct Update: AsyncParsableCommand {
 
         case .updated(let from, let to):
             print("Updated: v\(from) -> v\(to)")
-            print("Restart the provider for the new version to take effect.")
+            if LaunchAgent.isLoaded() {
+                print("Restarting provider via launchd...")
+                try ProcessLifecycle.restartAfterUpdate()
+            } else {
+                print("Restart the provider for the new version to take effect.")
+            }
 
         case .downloadFailed(let reason):
             printError("download failed: \(reason)")


### PR DESCRIPTION
## Problem

The Swift provider only checked for updates once at startup (`StartCommand.runForeground`). Unlike the Rust provider which checked every 30 minutes during serving, a long-running Swift provider would never self-update. With 67+ providers in the fleet, this means new releases (like 0.5.8 with reasoning parsers and tool call support) require manual restarts.

## Changes

### Background auto-update monitor (`ProviderLoop.swift`)

Adds a periodic update check that runs alongside inference:
- **5-minute delay** after startup before first check (don't slow down initial serving)
- **30-minute interval** between checks (matches Rust provider)
- **Skips if active inference** -- checks `requestToModel.isEmpty` to avoid updating mid-request
- **Respects config** -- disabled by `config.provider.autoUpdate = false` or `DARKBLOOM_NO_UPDATE_CHECK` env var
- **Non-blocking** -- runs in a detached Task, inference continues during download/verify
- **Failure-safe** -- logs warnings on failure, never crashes the provider

### Launchd-aware restart (`ProcessLifecycle.swift`)

New `restartAfterUpdate()` method with two paths:
- **Under launchd**: spawns a background shell that does `launchctl bootout` + `sleep 1` + `launchctl bootstrap` + `launchctl kickstart` (matches Rust `auto_update_restart`)
- **Foreground mode**: uses existing `execCurrentProcess()` (execv)

### Update banner wiring

`runUpdateBannerIfEnabled()` was declared in `Darkbloom.swift` but never called from most subcommands. Now wired into `logs` and `models` commands. (`status` and `doctor` already had it.)

### Temp file cleanup (`SelfUpdater.swift`)

Downloaded tarballs are now deleted after successful install instead of lingering in `/tmp`.

## Test Results

- `swift build`: clean
- `swift test`: all pass (same 1 pre-existing download test failure as master)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/219"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782365534&installation_id=133247490&pr_number=219&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F219&signature=47cb5971e85cbd854eca9ad3b7a365143eab239e8c8fffb2f25505223b5d0f69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->