### PR TITLE
[codex] Improve stats model catalog display

### DIFF
--- a/console-ui/__tests__/google-analytics.test.ts
+++ b/console-ui/__tests__/google-analytics.test.ts
@@ -53,24 +53,29 @@ describe("google analytics helpers", () => {
   });
 
   it("enables analytics only when the measurement id exists", () => {
+    expect(isGoogleAnalyticsEnabled()).toBe(true);
+
+    vi.stubEnv("NEXT_PUBLIC_GA_MEASUREMENT_ID", "");
+
     expect(isGoogleAnalyticsEnabled()).toBe(false);
   });
 
-  it("requires explicit consent before enabling analytics", () => {
-    expect(getGoogleAnalyticsConsentStatus()).toBe("unset");
-    expect(hasGoogleAnalyticsConsent()).toBe(false);
+  it("enables analytics by default without requiring explicit consent", () => {
+    expect(getGoogleAnalyticsConsentStatus()).toBe("granted");
+    expect(hasGoogleAnalyticsConsent()).toBe(true);
+    expect(isGoogleAnalyticsEnabled()).toBe(true);
     grantGoogleAnalyticsConsent();
     expect(getGoogleAnalyticsConsentStatus()).toBe("granted");
     expect(hasGoogleAnalyticsConsent()).toBe(true);
     expect(isGoogleAnalyticsEnabled()).toBe(true);
     revokeGoogleAnalyticsConsent();
-    expect(getGoogleAnalyticsConsentStatus()).toBe("denied");
-    expect(hasGoogleAnalyticsConsent()).toBe(false);
-    expect(window.__googleAnalyticsInitialized).toBe(false);
+    expect(getGoogleAnalyticsConsentStatus()).toBe("granted");
+    expect(hasGoogleAnalyticsConsent()).toBe(true);
   });
 
-  it("falls back to the shared consent cookie when local storage is unset", () => {
-    document.cookie = "darkbloom_ga_consent=granted; path=/; max-age=60";
+  it("ignores stale local opt-out state from the removed consent prompt", () => {
+    localStorage.setItem("darkbloom_ga_consent", "denied");
+    document.cookie = "darkbloom_ga_consent=denied; path=/; max-age=60";
 
     expect(getGoogleAnalyticsConsentStatus()).toBe("granted");
     expect(hasGoogleAnalyticsConsent()).toBe(true);
@@ -90,15 +95,13 @@ describe("google analytics helpers", () => {
     localStorage.setItem("darkbloom_ga_consent", "denied");
     applyGoogleAnalyticsConsentState();
 
-    expect(getGoogleAnalyticsConsentStatus()).toBe("denied");
-    expect(window.__googleAnalyticsInitialized).toBe(false);
-    expect(window.__googleAnalyticsCurrentPageLocation).toBeUndefined();
-    expect(window.__googleAnalyticsCurrentPageReferrer).toBeUndefined();
+    expect(getGoogleAnalyticsConsentStatus()).toBe("granted");
+    expect(window.__googleAnalyticsInitialized).toBe(true);
     expect(
       (
         window as typeof window & Record<string, boolean | undefined>
       )[`ga-disable-${getGoogleAnalyticsMeasurementId()}`]
-    ).toBe(true);
+    ).toBe(false);
   });
 
   it("keeps only allowed attribution params on the initial page view", () => {

--- a/console-ui/__tests__/stats-model-filter.test.ts
+++ b/console-ui/__tests__/stats-model-filter.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+import {
+  catalogModelsFromResponse,
+  capacityModelsFromResponse,
+  filterServedCatalogModels,
+} from "@/lib/stats-model-filter";
+
+const gptModel = "gpt-oss-20b";
+
+describe("filterServedCatalogModels", () => {
+  const gemmaModel = "gemma-4-26b";
+  const statsModels = [
+    { id: gptModel, providers: 17 },
+    { id: gemmaModel, providers: 14 },
+    { id: "stale-provider-model", providers: 9 },
+  ];
+
+  const catalogModels = [
+    { id: gptModel, status: "active" },
+    { id: gemmaModel, status: "active" },
+  ];
+
+  it("shows only served catalog models by default", () => {
+    const result = filterServedCatalogModels(statsModels, catalogModels, false);
+
+    expect(result.visible.map((model) => model.id)).toEqual([
+      gptModel,
+      gemmaModel,
+    ]);
+    expect(result.deprecatedCount).toBe(1);
+  });
+
+  it("includes served non-catalog models when deprecated models are enabled", () => {
+    const result = filterServedCatalogModels(statsModels, catalogModels, true);
+
+    expect(result.visible.map((model) => [model.id, model.catalogStatus])).toEqual([
+      [gptModel, "active"],
+      [gemmaModel, "active"],
+      ["stale-provider-model", "deprecated"],
+    ]);
+  });
+});
+
+describe("catalogModelsFromResponse", () => {
+  it("normalizes Next proxy and coordinator catalog responses", () => {
+    expect(
+      catalogModelsFromResponse({
+        data: [
+          {
+            id: "proxy-active",
+            metadata: {
+              status: "active",
+              display_name: "Proxy Active",
+              size_gb: 12.5,
+            },
+          },
+          { id: "proxy-deprecated", metadata: { status: "deprecated" } },
+        ],
+      }),
+    ).toEqual([
+      {
+        id: "proxy-active",
+        status: "active",
+        displayName: "Proxy Active",
+        sizeGB: 12.5,
+      },
+      { id: "proxy-deprecated", status: "deprecated" },
+    ]);
+
+    expect(
+      catalogModelsFromResponse({
+        models: [
+          { id: "coordinator-active", status: "active" },
+        ],
+      }),
+    ).toEqual([{ id: "coordinator-active", status: "active" }]);
+  });
+});
+
+describe("capacityModelsFromResponse", () => {
+  it("normalizes model capacity analytics", () => {
+    expect(
+      capacityModelsFromResponse({
+        models: [
+          {
+            id: gptModel,
+            ready: true,
+            can_accept: true,
+            routable_providers: 5,
+            warm_providers: 1,
+            cold_providers: 4,
+            active_requests: 2,
+            queued_requests: 3,
+            queue_limit: 10,
+            aggregate_tps: 137.8,
+            estimated_ttft_ms: 24367,
+            token_budget_remaining: 42,
+            token_budget_total: 100,
+          },
+        ],
+      }),
+    ).toEqual([
+      {
+        id: gptModel,
+        ready: true,
+        canAccept: true,
+        routableProviders: 5,
+        warmProviders: 1,
+        coldProviders: 4,
+        activeRequests: 2,
+        queuedRequests: 3,
+        queueLimit: 10,
+        aggregateTPS: 137.8,
+        estimatedTTFTMS: 24367,
+        tokenBudgetRemaining: 42,
+        tokenBudgetTotal: 100,
+      },
+    ]);
+  });
+});

--- a/console-ui/src/app/api/models/capacity/route.ts
+++ b/console-ui/src/app/api/models/capacity/route.ts
@@ -1,0 +1,11 @@
+import { NextResponse } from "next/server";
+
+const COORD_URL = process.env.NEXT_PUBLIC_COORDINATOR_URL || "https://api.darkbloom.dev";
+
+export async function GET() {
+  const res = await fetch(`${COORD_URL}/v1/models/capacity`, { cache: "no-store" });
+  if (!res.ok) {
+    return NextResponse.json({ error: `Upstream ${res.status}` }, { status: res.status });
+  }
+  return NextResponse.json(await res.json());
+}

--- a/console-ui/src/app/settings/page.tsx
+++ b/console-ui/src/app/settings/page.tsx
@@ -1,14 +1,8 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect } from "react";
 import { TopBar } from "@/components/TopBar";
 import { useToastStore } from "@/hooks/useToast";
-import {
-  getGoogleAnalyticsConsentStorageKey,
-  getGoogleAnalyticsConsentStatus,
-  grantGoogleAnalyticsConsent,
-  revokeGoogleAnalyticsConsent,
-} from "@/lib/google-analytics";
 import {
   Globe,
   Check,
@@ -16,7 +10,6 @@ import {
   Loader2,
   Server,
   Lock,
-  BarChart3,
 } from "lucide-react";
 import { healthCheck } from "@/lib/api";
 import {
@@ -29,9 +22,6 @@ import {
 export default function SettingsPage() {
   const addToast = useToastStore((s) => s.addToast);
   const [coordinatorUrl, setCoordinatorUrl] = useState("");
-  const [analyticsConsent, setAnalyticsConsent] = useState<
-    "granted" | "denied" | "unset"
-  >("unset");
   const [saved, setSaved] = useState(false);
   const [healthStatus, setHealthStatus] = useState<
     "idle" | "checking" | "ok" | "error"
@@ -44,10 +34,6 @@ export default function SettingsPage() {
   >("idle");
   const [encInfo, setEncInfo] = useState("");
 
-  const syncAnalyticsConsent = useCallback(() => {
-    setAnalyticsConsent(getGoogleAnalyticsConsentStatus());
-  }, []);
-
   useEffect(() => {
     if (typeof window !== "undefined") {
       setCoordinatorUrl(
@@ -56,27 +42,8 @@ export default function SettingsPage() {
           "https://api.darkbloom.dev"
       );
       setEncryptToCoord(isEncryptionEnabled());
-      syncAnalyticsConsent();
     }
-  }, [syncAnalyticsConsent]);
-
-  useEffect(() => {
-    window.addEventListener("darkbloom-ga-consent-changed", syncAnalyticsConsent);
-    const handleStorage = (event: StorageEvent) => {
-      if (event.key === getGoogleAnalyticsConsentStorageKey()) {
-        syncAnalyticsConsent();
-      }
-    };
-    window.addEventListener("storage", handleStorage);
-    return () =>
-      {
-        window.removeEventListener(
-          "darkbloom-ga-consent-changed",
-          syncAnalyticsConsent
-        );
-        window.removeEventListener("storage", handleStorage);
-      };
-  }, [syncAnalyticsConsent]);
+  }, []);
 
   // When the user flips the toggle, eagerly fetch the coordinator pubkey so
   // they get an immediate signal if the feature is unavailable on this
@@ -239,56 +206,6 @@ export default function SettingsPage() {
                 </span>
               )}
             </div>
-          </section>
-
-          {/* Analytics */}
-          <section className="rounded-xl bg-bg-white border border-border-dim p-6 shadow-md">
-            <div className="flex items-center gap-2 mb-4">
-              <BarChart3 size={14} className="text-accent-green" />
-              <h3 className="text-sm font-medium text-text-primary">
-                Analytics
-              </h3>
-            </div>
-            <p className="text-xs text-text-tertiary mb-4">
-              Control whether Darkbloom can load privacy-filtered Google
-              Analytics to measure product usage. Query parameters are
-              sanitized before analytics events are sent, except for the small
-              attribution allowlist used to preserve campaign measurement.
-            </p>
-            <div className="flex flex-wrap gap-3">
-              <button
-                onClick={() => {
-                  grantGoogleAnalyticsConsent();
-                  addToast("Analytics enabled", "success");
-                }}
-                className={`rounded-lg px-4 py-2 text-sm font-semibold transition-all ${
-                  analyticsConsent === "granted"
-                    ? "bg-coral text-white"
-                    : "border border-border-dim text-text-secondary hover:bg-bg-hover"
-                }`}
-              >
-                Allow analytics
-              </button>
-              <button
-                onClick={() => {
-                  revokeGoogleAnalyticsConsent();
-                  addToast("Analytics disabled", "success");
-                }}
-                className={`rounded-lg px-4 py-2 text-sm font-semibold transition-all ${
-                  analyticsConsent === "denied"
-                    ? "bg-bg-tertiary text-text-primary"
-                    : "border border-border-dim text-text-secondary hover:bg-bg-hover"
-                }`}
-              >
-                Decline analytics
-              </button>
-            </div>
-            <p className="mt-3 text-xs text-text-tertiary">
-              Current choice:{" "}
-              <span className="font-mono text-text-secondary uppercase">
-                {analyticsConsent}
-              </span>
-            </p>
           </section>
 
           {/* Save */}

--- a/console-ui/src/app/stats/page.tsx
+++ b/console-ui/src/app/stats/page.tsx
@@ -22,10 +22,19 @@ import {
 } from "lucide-react";
 import { TopBar } from "@/components/TopBar";
 import {
+  catalogModelsFromResponse,
+  capacityModelsFromResponse,
+  filterServedCatalogModels,
+  type CapacityModelSummary,
+  type CatalogModelSummary,
+} from "@/lib/stats-model-filter";
+import {
   verifyCertificateChain,
   type CertVerificationResult,
   type VerificationStep,
 } from "@/lib/cert-verify";
+
+const COORDINATOR_URL = process.env.NEXT_PUBLIC_COORDINATOR_URL || "https://api.darkbloom.dev";
 
 interface CPUCores {
   total: number;
@@ -185,9 +194,16 @@ interface ModelInventory {
   hardware: number;
   gpuCores: number;
   memoryGB: number;
-  tokens: number;
   sharePct: number;
 }
+
+type ActiveModelInventory = ModelInventory & {
+  id: string;
+  providers: number;
+  catalogStatus?: string;
+  catalogModel?: CatalogModelSummary;
+  capacity?: CapacityModelSummary;
+};
 
 function formatNumber(n: number): string {
   if (n >= 1_000_000) return (n / 1_000_000).toFixed(1) + "M";
@@ -224,6 +240,69 @@ function normalizeTimeSeries(data: TimeSeriesBucket[], minutes = 30): TimeSeries
       active_providers: 0,
     };
   });
+}
+
+async function fetchModelCatalog(): Promise<CatalogModelSummary[] | null> {
+  const urls = [
+    "/api/models",
+    `${COORDINATOR_URL}/v1/models/catalog?type=text`,
+  ];
+
+  for (const url of urls) {
+    try {
+      const res = await fetch(url, { cache: "no-store" });
+      if (!res.ok) continue;
+      const catalog = catalogModelsFromResponse(await res.json());
+      if (catalog.length > 0) return catalog;
+    } catch {
+      // Keep stats usable if catalog lookup fails.
+    }
+  }
+
+  return null;
+}
+
+async function fetchModelCapacity(): Promise<CapacityModelSummary[] | null> {
+  const urls = [
+    "/api/models/capacity",
+    `${COORDINATOR_URL}/v1/models/capacity`,
+  ];
+
+  for (const url of urls) {
+    try {
+      const res = await fetch(url, { cache: "no-store" });
+      if (!res.ok) continue;
+      const capacity = capacityModelsFromResponse(await res.json());
+      if (capacity.length > 0) return capacity;
+    } catch {
+      // Keep stats usable if capacity lookup fails.
+    }
+  }
+
+  return null;
+}
+
+function formatGB(value?: number): string | null {
+  if (value === undefined) return null;
+  return `${value >= 10 ? value.toFixed(0) : value.toFixed(1)} GB`;
+}
+
+function formatLatency(ms?: number): string {
+  if (ms === undefined) return "--";
+  if (ms >= 1000) return `${(ms / 1000).toFixed(1)}s`;
+  return `${Math.round(ms)}ms`;
+}
+
+function formatDecimal(value?: number): string {
+  if (value === undefined) return "--";
+  return value >= 100 ? value.toFixed(0) : value.toFixed(1);
+}
+
+function formatTokenBudget(capacity?: CapacityModelSummary): string {
+  if (!capacity || capacity.tokenBudgetTotal === undefined) return "--";
+  if (capacity.tokenBudgetTotal <= 0) return "0";
+  const remaining = capacity.tokenBudgetRemaining ?? 0;
+  return `${Math.round((remaining / capacity.tokenBudgetTotal) * 100)}%`;
 }
 
 function StatusDot({ status }: { status: string }) {
@@ -332,11 +411,18 @@ function buildModelInventory(stats: PlatformStats): ModelInventory[] {
         hardware: providers.filter((provider) => provider.trust_level === "hardware").length,
         gpuCores: providers.reduce((sum, provider) => sum + provider.gpu_cores, 0),
         memoryGB: providers.reduce((sum, provider) => sum + provider.memory_gb, 0),
-        tokens: providers.reduce((sum, provider) => sum + provider.tokens_generated, 0),
         sharePct: totalSlots > 0 ? (model.providers / totalSlots) * 100 : 0,
       };
     })
     .sort((a, b) => b.model.providers - a.model.providers || a.model.id.localeCompare(b.model.id));
+}
+
+function deprecatedModelLabel(status?: string): string | null {
+  if (!status) return null;
+  const normalized = status.toLowerCase();
+  if (normalized === "deprecated") return "Deprecated";
+  if (normalized === "retired") return "Retired";
+  return null;
 }
 
 function ModelRow({
@@ -344,7 +430,7 @@ function ModelRow({
   maxProviders,
   rank,
 }: {
-  item: ModelInventory;
+  item: ActiveModelInventory;
   maxProviders: number;
   rank: number;
 }) {
@@ -352,6 +438,18 @@ function ModelRow({
   const pct = maxProviders > 0 ? (model.providers / maxProviders) * 100 : 0;
   const routablePct = model.providers > 0 ? (item.routable / model.providers) * 100 : 0;
   const isLeader = rank === 1;
+  const statusLabel = deprecatedModelLabel(item.catalogStatus);
+  const catalog = item.catalogModel;
+  const capacity = item.capacity;
+  const displayName = catalog?.displayName || shortModelName(model.id);
+  const modelSize = formatGB(catalog?.sizeGB);
+  const minRAM = formatGB(catalog?.minRAMGB);
+  const queueValue = capacity
+    ? `${(capacity.activeRequests ?? 0) + (capacity.queuedRequests ?? 0)}/${capacity.queueLimit ?? "--"}`
+    : "--";
+  const warmColdValue = capacity
+    ? `${capacity.warmProviders ?? 0}/${capacity.coldProviders ?? 0}`
+    : "--";
 
   return (
     <div
@@ -383,15 +481,26 @@ function ModelRow({
           </div>
           <div className="min-w-0 space-y-2">
             <div>
-              <p className="truncate text-base font-mono font-semibold text-text-primary">
-                {shortModelName(model.id)}
-              </p>
+              <div className="flex min-w-0 flex-wrap items-center gap-2">
+                <p className="truncate text-base font-mono font-semibold text-text-primary">
+                  {displayName}
+                </p>
+                {statusLabel && (
+                  <span className="shrink-0 rounded-full border border-accent-amber/30 bg-accent-amber-dim px-2 py-0.5 text-[9px] font-mono uppercase tracking-wider text-accent-amber">
+                    {statusLabel}
+                  </span>
+                )}
+              </div>
               <p className="truncate text-xs font-mono text-text-tertiary">{model.id}</p>
             </div>
             <div className="flex flex-wrap gap-1.5">
+              {catalog?.family && <ModelPill label={catalog.family} />}
+              {catalog?.quantization && <ModelPill label={catalog.quantization} />}
+              {modelSize && <ModelPill label={modelSize} />}
+              {minRAM && <ModelPill label={`${minRAM} min`} />}
+              {catalog?.maxContextLength && <ModelPill label={`${formatNumber(catalog.maxContextLength)} ctx`} />}
               <ModelPill label={`${formatNumber(item.gpuCores)} GPU`} />
               <ModelPill label={`${formatNumber(item.memoryGB)} GB RAM`} />
-              <ModelPill label={`${formatNumber(item.tokens)} tok`} />
             </div>
           </div>
         </div>
@@ -404,9 +513,23 @@ function ModelRow({
         </div>
       </div>
 
+      {capacity && (
+        <div className="mt-4 grid grid-cols-2 gap-2 md:grid-cols-5">
+          <CapacityMetric label="Capacity TPS" value={formatDecimal(capacity.aggregateTPS)} />
+          <CapacityMetric label="TTFT Est." value={formatLatency(capacity.estimatedTTFTMS)} />
+          <CapacityMetric label="Queue" value={queueValue} />
+          <CapacityMetric label="Warm/Cold" value={warmColdValue} />
+          <CapacityMetric
+            label="Token Budget"
+            value={formatTokenBudget(capacity)}
+            tone={capacity.canAccept ? "green" : "amber"}
+          />
+        </div>
+      )}
+
       <div className="mt-4 space-y-2">
         <div className="flex items-center justify-between gap-3 text-[11px] font-mono text-text-tertiary">
-          <span>{item.sharePct.toFixed(0)}% of advertised model slots</span>
+          <span>{item.sharePct.toFixed(0)}% of visible model slots</span>
           <span>{Math.round(routablePct)}% routable coverage</span>
         </div>
         <div className="relative h-2.5 overflow-hidden rounded-full bg-bg-elevated">
@@ -451,6 +574,32 @@ function ModelMiniMetric({
   );
 }
 
+function CapacityMetric({
+  label,
+  value,
+  tone,
+}: {
+  label: string;
+  value: string;
+  tone?: "green" | "amber";
+}) {
+  let toneClass = "text-text-primary";
+  if (tone === "green") {
+    toneClass = "text-accent-green";
+  } else if (tone === "amber") {
+    toneClass = "text-accent-amber";
+  }
+
+  return (
+    <div className="rounded-lg border border-border-dim bg-bg-primary/60 px-2.5 py-2">
+      <p className={`text-sm font-mono font-bold ${toneClass}`}>{value}</p>
+      <p className="mt-0.5 text-[9px] font-mono uppercase tracking-wider text-text-tertiary">
+        {label}
+      </p>
+    </div>
+  );
+}
+
 function ModelPill({ label }: { label: string }) {
   return (
     <span className="rounded-md border border-border-dim bg-bg-primary/70 px-2 py-1 text-[10px] font-mono text-text-tertiary">
@@ -472,14 +621,39 @@ function ModelHeaderMetric({ label, value }: { label: string; value: string }) {
 
 function ActiveModelsSection({
   stats,
-  maxProviders,
+  catalogModels,
+  capacityModels,
 }: {
   stats: PlatformStats;
-  maxProviders: number;
+  catalogModels: CatalogModelSummary[] | null;
+  capacityModels: CapacityModelSummary[] | null;
 }) {
+  const [showDeprecatedModels, setShowDeprecatedModels] = useState(false);
   const inventory = buildModelInventory(stats);
-  const totalSlots = inventory.reduce((sum, item) => sum + item.model.providers, 0);
-  const routableSlots = inventory.reduce((sum, item) => sum + item.routable, 0);
+  const catalogByID = new Map((catalogModels ?? []).map((model) => [model.id, model]));
+  const capacityByID = new Map((capacityModels ?? []).map((model) => [model.id, model]));
+  const servedInventory = inventory.map((item) => ({
+    ...item,
+    id: item.model.id,
+    providers: item.model.providers,
+    catalogModel: catalogByID.get(item.model.id),
+    capacity: capacityByID.get(item.model.id),
+  }));
+  const filtered = catalogModels
+    ? filterServedCatalogModels(servedInventory, catalogModels, showDeprecatedModels)
+    : {
+      visible: servedInventory.map((item) => ({ ...item, catalogStatus: "active" })),
+      catalogServedCount: servedInventory.length,
+      deprecatedCount: 0,
+    };
+  const filteredSlots = filtered.visible.reduce((sum, item) => sum + item.model.providers, 0);
+  const visibleInventory = filtered.visible.map((item) => ({
+    ...item,
+    sharePct: filteredSlots > 0 ? (item.model.providers / filteredSlots) * 100 : 0,
+  }));
+  const maxProviders = Math.max(...visibleInventory.map((item) => item.model.providers), 1);
+  const totalSlots = filteredSlots;
+  const routableSlots = visibleInventory.reduce((sum, item) => sum + item.routable, 0);
 
   return (
     <section className="rounded-xl border border-border-dim bg-bg-primary p-5 shadow-sm">
@@ -493,27 +667,59 @@ function ActiveModelsSection({
               Active Models
             </h3>
             <p className="mt-1 text-xs text-text-tertiary">
-              Capacity by model, routability, and trusted node coverage
+              Catalog metadata, live capacity, and trusted node coverage
             </p>
           </div>
         </div>
-        <div className="grid grid-cols-3 gap-2 text-right sm:min-w-[250px]">
-          <ModelHeaderMetric label="Models" value={inventory.length.toString()} />
-          <ModelHeaderMetric label="Slots" value={totalSlots.toString()} />
-          <ModelHeaderMetric label="Routable" value={routableSlots.toString()} />
+        <div className="flex flex-col items-start gap-3 sm:items-end">
+          {filtered.deprecatedCount > 0 && (
+            <label className="flex cursor-pointer items-center gap-2 rounded-lg border border-border-dim bg-bg-secondary px-3 py-2 text-xs font-mono text-text-secondary transition-colors hover:bg-bg-hover">
+              <input
+                type="checkbox"
+                className="sr-only"
+                checked={showDeprecatedModels}
+                onChange={(event) => setShowDeprecatedModels(event.target.checked)}
+                aria-label="Show deprecated models"
+              />
+              <span
+                className={`relative h-5 w-9 rounded-full transition-colors ${
+                  showDeprecatedModels ? "bg-accent-brand" : "bg-bg-elevated"
+                }`}
+                aria-hidden="true"
+              >
+                <span
+                  className={`absolute top-0.5 h-4 w-4 rounded-full bg-bg-primary shadow-sm transition-transform ${
+                    showDeprecatedModels ? "translate-x-4" : "translate-x-0.5"
+                  }`}
+                />
+              </span>
+              <span>Show deprecated ({filtered.deprecatedCount})</span>
+            </label>
+          )}
+          <div className="grid grid-cols-3 gap-2 text-right sm:min-w-[250px]">
+            <ModelHeaderMetric label="Models" value={visibleInventory.length.toString()} />
+            <ModelHeaderMetric label="Slots" value={totalSlots.toString()} />
+            <ModelHeaderMetric label="Routable Slots" value={routableSlots.toString()} />
+          </div>
         </div>
       </div>
 
       <div className="mt-4 grid grid-cols-1 gap-3 lg:grid-cols-[1.2fr_0.8fr]">
         <div className="space-y-3">
-          {inventory.map((item, index) => (
-            <ModelRow
-              key={item.model.id}
-              item={item}
-              maxProviders={maxProviders}
-              rank={index + 1}
-            />
-          ))}
+          {visibleInventory.length === 0 ? (
+            <div className="rounded-xl border border-dashed border-border-dim bg-bg-secondary px-4 py-5 text-sm text-text-tertiary">
+              No currently served catalog models.
+            </div>
+          ) : (
+            visibleInventory.map((item, index) => (
+              <ModelRow
+                key={item.model.id}
+                item={item}
+                maxProviders={maxProviders}
+                rank={index + 1}
+              />
+            ))
+          )}
         </div>
         <div className="rounded-xl border border-border-dim bg-bg-secondary p-4">
           <div className="flex items-center justify-between gap-3">
@@ -525,24 +731,30 @@ function ActiveModelsSection({
             </p>
           </div>
           <div className="mt-4 space-y-3">
-            {inventory.map((item) => (
-              <div key={`mix-${item.model.id}`}>
-                <div className="flex items-center justify-between gap-3 text-xs">
-                  <p className="truncate font-mono text-text-secondary">
-                    {shortModelName(item.model.id)}
-                  </p>
-                  <p className="shrink-0 font-mono font-semibold text-text-primary">
-                    {item.sharePct.toFixed(0)}%
-                  </p>
+            {visibleInventory.length === 0 ? (
+              <p className="text-sm text-text-tertiary">
+                Deprecated provider-advertised models are hidden.
+              </p>
+            ) : (
+              visibleInventory.map((item) => (
+                <div key={`mix-${item.model.id}`}>
+                  <div className="flex items-center justify-between gap-3 text-xs">
+                    <p className="truncate font-mono text-text-secondary">
+                      {shortModelName(item.model.id)}
+                    </p>
+                    <p className="shrink-0 font-mono font-semibold text-text-primary">
+                      {item.sharePct.toFixed(0)}%
+                    </p>
+                  </div>
+                  <div className="mt-1.5 h-1.5 overflow-hidden rounded-full bg-bg-elevated">
+                    <div
+                      className="h-full rounded-full bg-accent-brand/70"
+                      style={{ width: `${Math.max(3, item.sharePct)}%` }}
+                    />
+                  </div>
                 </div>
-                <div className="mt-1.5 h-1.5 overflow-hidden rounded-full bg-bg-elevated">
-                  <div
-                    className="h-full rounded-full bg-accent-brand/70"
-                    style={{ width: `${Math.max(3, item.sharePct)}%` }}
-                  />
-                </div>
-              </div>
-            ))}
+              ))
+            )}
           </div>
           <div className="mt-5 rounded-lg border border-accent-green/20 bg-accent-green/10 px-3 py-2">
             <div className="flex items-center justify-between gap-3">
@@ -2265,16 +2477,28 @@ function NetworkNodes({ providers }: { providers: ProviderStats[] }) {
 // ---------------------------------------------------------------------------
 export default function StatsPage() {
   const [stats, setStats] = useState<PlatformStats | null>(null);
+  const [catalogModels, setCatalogModels] = useState<CatalogModelSummary[] | null>(null);
+  const [capacityModels, setCapacityModels] = useState<CapacityModelSummary[] | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
   const fetchStats = async () => {
     try {
       const query = typeof window === "undefined" ? "" : window.location.search;
-      const res = await fetch(`/api/stats${query}`);
+      const [res, catalog, capacity] = await Promise.all([
+        fetch(`/api/stats${query}`),
+        fetchModelCatalog(),
+        fetchModelCapacity(),
+      ]);
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const data = await res.json();
       setStats(data);
+      if (catalog) {
+        setCatalogModels(catalog);
+      }
+      if (capacity) {
+        setCapacityModels(capacity);
+      }
       setError(null);
     } catch (e: unknown) {
       setError(e instanceof Error ? e.message : "Failed to fetch stats");
@@ -2318,7 +2542,6 @@ export default function StatsPage() {
   }
 
   const hardwareAttested = stats.providers.filter((p) => p.trust_level === "hardware").length;
-  const maxModelProviders = Math.max(...stats.models.map((m) => m.providers), 1);
 
   return (
     <div className="flex-1 flex flex-col overflow-y-auto">
@@ -2437,7 +2660,11 @@ export default function StatsPage() {
 
         {/* Models */}
         {stats.models.length > 0 && (
-          <ActiveModelsSection stats={stats} maxProviders={maxModelProviders} />
+          <ActiveModelsSection
+            stats={stats}
+            catalogModels={catalogModels}
+            capacityModels={capacityModels}
+          />
         )}
 
         <NetworkNodes providers={stats.providers} />

--- a/console-ui/src/components/GoogleAnalytics.tsx
+++ b/console-ui/src/components/GoogleAnalytics.tsx
@@ -1,109 +1,42 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import Script from "next/script";
 import { usePathname } from "next/navigation";
 import {
-  applyGoogleAnalyticsConsentState,
-  getGoogleAnalyticsConsentStatus,
   getGoogleAnalyticsMeasurementId,
-  getGoogleAnalyticsConsentStorageKey,
-  grantGoogleAnalyticsConsent,
   initializeGoogleAnalytics,
-  revokeGoogleAnalyticsConsent,
   trackRouteChange,
 } from "@/lib/google-analytics";
 
 export function GoogleAnalytics() {
   const pathname = usePathname();
   const measurementId = getGoogleAnalyticsMeasurementId();
-  const [consentState, setConsentState] = useState<"granted" | "denied" | "unset">(
-    () => getGoogleAnalyticsConsentStatus(),
-  );
-  const [hasConsent, setHasConsent] = useState(consentState === "granted");
 
   useEffect(() => {
-    const syncConsentState = () => {
-      const nextConsentState = getGoogleAnalyticsConsentStatus();
-      setConsentState(nextConsentState);
-      setHasConsent(nextConsentState === "granted");
-    };
-
-    syncConsentState();
-    window.addEventListener("darkbloom-ga-consent-changed", syncConsentState);
-    const onStorage = (event: StorageEvent) => {
-      if (event.key === getGoogleAnalyticsConsentStorageKey()) {
-        applyGoogleAnalyticsConsentState();
-        syncConsentState();
-      }
-    };
-    window.addEventListener("storage", onStorage);
-    return () =>
-      {
-        window.removeEventListener("darkbloom-ga-consent-changed", syncConsentState);
-        window.removeEventListener("storage", onStorage);
-      };
-  }, []);
-
-  useEffect(() => {
-    if (!hasConsent) {
+    if (!measurementId) {
       return;
     }
 
     initializeGoogleAnalytics();
-  }, [hasConsent]);
+  }, [measurementId]);
 
   useEffect(() => {
-    if (!hasConsent || !pathname) {
+    if (!measurementId || !pathname) {
       return;
     }
 
     trackRouteChange(pathname);
-  }, [hasConsent, pathname]);
+  }, [measurementId, pathname]);
 
   if (!measurementId) {
     return null;
   }
 
   return (
-    <>
-      {hasConsent && (
-        <Script
-          src={`https://www.googletagmanager.com/gtag/js?id=${measurementId}`}
-          strategy="afterInteractive"
-        />
-      )}
-      {consentState === "unset" && !hasConsent && (
-        <div className="fixed bottom-4 left-4 right-4 z-50 mx-auto max-w-xl rounded-xl border border-border-dim bg-bg-white/95 p-4 shadow-lg backdrop-blur">
-          <p className="text-sm text-text-secondary">
-            Allow privacy-filtered usage analytics to help improve
-            Darkbloom&apos;s product experience.
-          </p>
-          <div className="mt-3 flex flex-wrap gap-2">
-            <button
-              onClick={() => {
-                grantGoogleAnalyticsConsent();
-                setHasConsent(true);
-              }}
-              className="rounded-lg bg-coral px-4 py-2 text-sm font-semibold text-white hover:opacity-90 transition-all"
-            >
-              Allow analytics
-            </button>
-            <button
-              onClick={() => {
-                revokeGoogleAnalyticsConsent();
-                setHasConsent(false);
-              }}
-              className="rounded-lg border border-border-dim px-4 py-2 text-sm font-semibold text-text-secondary hover:bg-bg-hover transition-all"
-            >
-              Decline
-            </button>
-            <span className="self-center text-xs text-text-tertiary">
-              Stored in <code>{getGoogleAnalyticsConsentStorageKey()}</code>
-            </span>
-          </div>
-        </div>
-      )}
-    </>
+    <Script
+      src={`https://www.googletagmanager.com/gtag/js?id=${measurementId}`}
+      strategy="afterInteractive"
+    />
   );
 }

--- a/console-ui/src/lib/google-analytics.ts
+++ b/console-ui/src/lib/google-analytics.ts
@@ -78,21 +78,6 @@ function getCookieDomain() {
   return "";
 }
 
-function getGoogleAnalyticsConsentCookie(): GoogleAnalyticsConsentStatus {
-  if (typeof document === "undefined") {
-    return "unset";
-  }
-
-  const prefix = `${GA_CONSENT_STORAGE_KEY}=`;
-  const cookie = document.cookie
-    .split(";")
-    .map((part) => part.trim())
-    .find((part) => part.startsWith(prefix));
-
-  const value = cookie ? decodeURIComponent(cookie.slice(prefix.length)) : "";
-  return value === "granted" || value === "denied" ? value : "unset";
-}
-
 function setGoogleAnalyticsConsentCookie(status: Exclude<GoogleAnalyticsConsentStatus, "unset">) {
   if (typeof document === "undefined") {
     return;
@@ -109,12 +94,7 @@ export function getGoogleAnalyticsConsentStatus(): GoogleAnalyticsConsentStatus 
     return "unset";
   }
 
-  const stored = window.localStorage.getItem(GA_CONSENT_STORAGE_KEY);
-  if (stored === "granted" || stored === "denied") {
-    return stored;
-  }
-
-  return getGoogleAnalyticsConsentCookie();
+  return "granted";
 }
 
 export function applyGoogleAnalyticsConsentState(): GoogleAnalyticsConsentStatus {
@@ -124,12 +104,6 @@ export function applyGoogleAnalyticsConsentState(): GoogleAnalyticsConsentStatus
   }
 
   setGoogleAnalyticsDisabled(status !== "granted");
-
-  if (status !== "granted") {
-    window.__googleAnalyticsInitialized = false;
-    window.__googleAnalyticsCurrentPageLocation = undefined;
-    window.__googleAnalyticsCurrentPageReferrer = undefined;
-  }
 
   return status;
 }
@@ -154,8 +128,8 @@ export function revokeGoogleAnalyticsConsent() {
     return;
   }
 
-  window.localStorage.setItem(GA_CONSENT_STORAGE_KEY, "denied");
-  setGoogleAnalyticsConsentCookie("denied");
+  window.localStorage.removeItem(GA_CONSENT_STORAGE_KEY);
+  setGoogleAnalyticsConsentCookie("granted");
   applyGoogleAnalyticsConsentState();
   window.dispatchEvent(new Event("darkbloom-ga-consent-changed"));
 }

--- a/console-ui/src/lib/stats-model-filter.ts
+++ b/console-ui/src/lib/stats-model-filter.ts
@@ -1,0 +1,172 @@
+export interface ServedModel {
+  id: string;
+  providers: number;
+}
+
+export interface CatalogModelSummary {
+  id: string;
+  status: string;
+  displayName?: string;
+  sizeGB?: number;
+  minRAMGB?: number;
+  maxContextLength?: number;
+  maxOutputLength?: number;
+  architecture?: string;
+  family?: string;
+  quantization?: string;
+  capabilities?: string[];
+}
+
+export interface CapacityModelSummary {
+  id: string;
+  ready?: boolean;
+  canAccept?: boolean;
+  routableProviders?: number;
+  warmProviders?: number;
+  coldProviders?: number;
+  activeRequests?: number;
+  queuedRequests?: number;
+  queueLimit?: number;
+  aggregateTPS?: number;
+  estimatedTTFTMS?: number;
+  tokenBudgetRemaining?: number;
+  tokenBudgetTotal?: number;
+}
+
+export type VisibleServedModel<T extends ServedModel> = T & {
+  catalogStatus: string;
+};
+
+export interface ServedModelFilterResult<T extends ServedModel> {
+  visible: VisibleServedModel<T>[];
+  catalogServedCount: number;
+  deprecatedCount: number;
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function catalogStatus(model: Record<string, unknown>): string {
+  if (typeof model.status === "string" && model.status.trim()) {
+    return model.status.trim();
+  }
+  const metadata = asRecord(model.metadata);
+  return typeof metadata.status === "string" && metadata.status.trim()
+    ? metadata.status.trim()
+    : "active";
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function asNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function asBoolean(value: unknown): boolean | undefined {
+  return typeof value === "boolean" ? value : undefined;
+}
+
+function asStringArray(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const strings = value.filter((item): item is string => typeof item === "string" && item.length > 0);
+  return strings.length > 0 ? strings : undefined;
+}
+
+function compactObject<T extends Record<string, unknown>>(value: T): T {
+  return Object.fromEntries(
+    Object.entries(value).filter(([, entry]) => entry !== undefined),
+  ) as T;
+}
+
+export function catalogModelsFromResponse(payload: unknown): CatalogModelSummary[] {
+  const body = asRecord(payload);
+  let rows: unknown[] = [];
+  if (Array.isArray(body.data)) {
+    rows = body.data;
+  } else if (Array.isArray(body.models)) {
+    rows = body.models;
+  }
+
+  return rows
+    .map(asRecord)
+    .filter((model) => typeof model.id === "string" && model.id.trim().length > 0)
+    .map((model) => {
+      const metadata = asRecord(model.metadata);
+      return compactObject({
+        id: model.id as string,
+        status: catalogStatus(model),
+        displayName: asString(model.display_name ?? metadata.display_name),
+        sizeGB: asNumber(model.size_gb ?? metadata.size_gb),
+        minRAMGB: asNumber(model.min_ram_gb ?? metadata.min_ram_gb),
+        maxContextLength: asNumber(model.max_context_length ?? metadata.max_context_length),
+        maxOutputLength: asNumber(model.max_output_length ?? metadata.max_output_length),
+        architecture: asString(model.architecture ?? metadata.architecture),
+        family: asString(model.family ?? metadata.family),
+        quantization: asString(model.quantization ?? metadata.quantization),
+        capabilities: asStringArray(model.capabilities ?? metadata.capabilities),
+      });
+    });
+}
+
+export function capacityModelsFromResponse(payload: unknown): CapacityModelSummary[] {
+  const body = asRecord(payload);
+  const rows = Array.isArray(body.models) ? body.models : [];
+
+  return rows
+    .map(asRecord)
+    .filter((model) => typeof model.id === "string" && model.id.trim().length > 0)
+    .map((model) => compactObject({
+      id: model.id as string,
+      ready: asBoolean(model.ready),
+      canAccept: asBoolean(model.can_accept),
+      routableProviders: asNumber(model.routable_providers),
+      warmProviders: asNumber(model.warm_providers),
+      coldProviders: asNumber(model.cold_providers),
+      activeRequests: asNumber(model.active_requests),
+      queuedRequests: asNumber(model.queued_requests),
+      queueLimit: asNumber(model.queue_limit),
+      aggregateTPS: asNumber(model.aggregate_tps),
+      estimatedTTFTMS: asNumber(model.estimated_ttft_ms),
+      tokenBudgetRemaining: asNumber(model.token_budget_remaining),
+      tokenBudgetTotal: asNumber(model.token_budget_total),
+    }));
+}
+
+function isDefaultCatalogStatus(status: string): boolean {
+  const normalized = status.toLowerCase();
+  return normalized !== "deprecated" && normalized !== "retired";
+}
+
+export function filterServedCatalogModels<T extends ServedModel>(
+  models: T[],
+  catalogModels: CatalogModelSummary[],
+  includeDeprecated: boolean,
+): ServedModelFilterResult<T> {
+  const catalogStatusByID = new Map(catalogModels.map((model) => [model.id, model.status]));
+
+  const decorated = models.map((model): VisibleServedModel<T> => ({
+    ...model,
+    catalogStatus: catalogStatusByID.get(model.id) ?? "deprecated",
+  }));
+
+  const catalogServedCount = decorated.filter((model) =>
+    catalogStatusByID.has(model.id) && isDefaultCatalogStatus(model.catalogStatus)
+  ).length;
+  const deprecatedCount = decorated.length - catalogServedCount;
+  const visible = includeDeprecated
+    ? decorated
+    : decorated.filter((model) =>
+      catalogStatusByID.has(model.id) && isDefaultCatalogStatus(model.catalogStatus)
+    );
+
+  return {
+    visible,
+    catalogServedCount,
+    deprecatedCount,
+  };
+}


### PR DESCRIPTION
## Summary

- Filter the stats page Active Models list to model-catalog entries by default, with a Show deprecated toggle for provider-advertised non-catalog models.
- Add catalog metadata and live model-capacity analytics to the model rows through a new `/api/models/capacity` proxy.
- Clarify routable model counts as routable slots and remove the misleading provider-level token pill from model rows.
- Enable analytics by default and remove the analytics consent prompt/settings controls.

## Why

The stats page was mixing provider-advertised/deprecated models into the primary model list and showing provider-level token totals as if they were model-specific. It also displayed routable model slots without making that distinction clear from unique routable nodes.

The analytics consent prompt was still surfacing an opt-in choice; analytics should load by default without exposing that choice in the UI.

## Validation

- `npm run build`
- `npm test -- --run __tests__/google-analytics.test.ts __tests__/stats-model-filter.test.ts`
- `npx eslint src/components/GoogleAnalytics.tsx src/lib/google-analytics.ts src/app/settings/page.tsx src/app/stats/page.tsx src/lib/stats-model-filter.ts src/app/api/models/capacity/route.ts __tests__/google-analytics.test.ts __tests__/stats-model-filter.test.ts` (0 errors, warnings only)
- Browser refresh at `http://localhost:3010/stats` confirmed the analytics prompt is gone and the stats page renders.
- Browser check at `http://localhost:3010/settings` confirmed the analytics controls are gone.