### PR TITLE
feat(console-ui): public models catalog proxy and earn page resilience

### DIFF
--- a/console-ui/__tests__/api.test.ts
+++ b/console-ui/__tests__/api.test.ts
@@ -218,6 +218,27 @@ describe("fetchModels", () => {
     expect(result[0].attested).toBe(true);
   });
 
+  it("unwraps the public catalog response shape", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({
+      models: [
+        {
+          id: "gpt-oss-20b",
+          display_name: "GPT-OSS 20B",
+          size_gb: 12.1,
+          min_ram_gb: 24,
+          architecture: "MoE",
+        },
+      ],
+    }));
+
+    const result = await fetchModels();
+
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("gpt-oss-20b");
+    expect(result[0].display_name).toBe("GPT-OSS 20B");
+    expect(result[0].min_ram_gb).toBe(24);
+  });
+
   it("throws on non-ok response", async () => {
     fetchMock.mockResolvedValueOnce(jsonResponse({}, 503));
     await expect(fetchModels()).rejects.toThrow("Failed to fetch models: 503");

--- a/console-ui/__tests__/earn-page.test.tsx
+++ b/console-ui/__tests__/earn-page.test.tsx
@@ -1,5 +1,10 @@
 import { fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const apiMocks = vi.hoisted(() => ({
+  fetchModels: vi.fn(),
+  fetchPricing: vi.fn(),
+}));
 
 vi.mock("@/components/TopBar", () => ({
   TopBar: ({ title }: { title?: string }) => (
@@ -19,37 +24,69 @@ vi.mock("@/lib/google-analytics", () => ({
   trackEvent: vi.fn(),
 }));
 
+vi.mock("@/lib/api", () => ({
+  fetchModels: apiMocks.fetchModels,
+  fetchPricing: apiMocks.fetchPricing,
+}));
+
+beforeEach(() => {
+  apiMocks.fetchModels.mockReset();
+  apiMocks.fetchPricing.mockReset();
+  apiMocks.fetchModels.mockResolvedValue([
+    {
+      id: "gpt-oss-20b",
+      object: "model",
+      display_name: "GPT-OSS 20B",
+      size_gb: 12.1,
+      min_ram_gb: 24,
+      architecture: "MoE",
+    },
+    {
+      id: "gemma-4-26b",
+      object: "model",
+      display_name: "Gemma 4 26B",
+      size_gb: 28,
+      min_ram_gb: 36,
+      architecture: "MoE",
+    },
+  ]);
+  apiMocks.fetchPricing.mockResolvedValue({
+    prices: [
+      { model: "gemma-4-26b", input_price: 65_000, output_price: 200_000, input_usd: "$0.0650", output_usd: "$0.2000" },
+    ],
+  });
+});
+
 describe("EarnPage", () => {
   it("keeps rendering when selected hardware has no eligible models", async () => {
     const EarnPage = (await import("@/app/earn/page")).default;
     render(<EarnPage />);
 
     fireEvent.click(screen.getByRole("button", { name: "MacBook Air" }));
+    fireEvent.click(screen.getByRole("button", { name: "16 GB" }));
 
     expect(screen.getByText("Provider Earnings Calculator")).toBeInTheDocument();
-    expect(screen.getByText("No models fit in 32 GB RAM")).toBeInTheDocument();
+    expect(await screen.findByText("No models fit in 16 GB RAM")).toBeInTheDocument();
     expect(screen.getByText("No compatible model for this hardware")).toBeInTheDocument();
   });
 
-  it("allows switching to another solo model even when it cannot fit beside the auto-selected model", async () => {
+  it("allows adding another model when it fits beside the auto-selected model", async () => {
     const EarnPage = (await import("@/app/earn/page")).default;
     render(<EarnPage />);
 
-    const qwenButton = screen.getByRole("button", { name: /Qwen3.5 27B Claude Opus/ });
+    const gptButton = await screen.findByRole("button", { name: /GPT-OSS 20B/ });
 
-    expect(screen.getByText("28 GB weights / 48 GB RAM")).toBeInTheDocument();
-    expect(qwenButton).not.toBeDisabled();
-    fireEvent.click(qwenButton);
+    expect(screen.getByText("12 GB weights / 48 GB RAM")).toBeInTheDocument();
+    expect(gptButton).not.toBeDisabled();
+    fireEvent.click(gptButton);
+
+    const gemmaButton = await screen.findByRole("button", { name: /Gemma 4 26B/ });
+    expect(gemmaButton).not.toBeDisabled();
+    fireEvent.click(gemmaButton);
 
     expect(
       screen.getByText("Selected models share active inference hours, so earnings are not double-counted.")
     ).toBeInTheDocument();
-    expect(screen.getByText("27 GB weights / 48 GB RAM")).toBeInTheDocument();
-
-    const gemmaButton = screen.getByRole("button", { name: /Gemma 4 26B/ });
-    expect(gemmaButton).not.toBeDisabled();
-    fireEvent.click(gemmaButton);
-
-    expect(screen.getByText("28 GB weights / 48 GB RAM")).toBeInTheDocument();
+    expect(screen.getByText("40 GB weights / 48 GB RAM")).toBeInTheDocument();
   });
 });

--- a/console-ui/src/app/api/models/route.ts
+++ b/console-ui/src/app/api/models/route.ts
@@ -2,13 +2,89 @@ import { NextRequest, NextResponse } from "next/server";
 
 const DEFAULT_COORD = process.env.NEXT_PUBLIC_COORDINATOR_URL || "https://api.darkbloom.dev";
 
+type JsonRecord = Record<string, unknown>;
+
+function asRecord(value: unknown): JsonRecord {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as JsonRecord)
+    : {};
+}
+
+function toModelEntry(model: JsonRecord, capacity?: JsonRecord) {
+  const metadata = asRecord(model.metadata);
+  return {
+    id: model.id,
+    object: model.object || "model",
+    created: model.created || 0,
+    owned_by: model.owned_by || "eigeninference",
+    metadata: {
+      ...metadata,
+      model_type: model.model_type ?? metadata.model_type,
+      quantization: model.quantization ?? metadata.quantization,
+      provider_count:
+        model.provider_count ?? metadata.provider_count ?? capacity?.routable_providers ?? 0,
+      routable_providers: capacity?.routable_providers ?? metadata.routable_providers ?? 0,
+      warm_providers: capacity?.warm_providers ?? metadata.warm_providers ?? 0,
+      can_accept: capacity?.can_accept ?? metadata.can_accept ?? false,
+      trust_level: model.trust_level ?? metadata.trust_level,
+      display_name: model.display_name ?? metadata.display_name,
+      size_bytes: model.size_bytes ?? model.total_size_bytes ?? metadata.size_bytes,
+      size_gb: model.size_gb ?? metadata.size_gb,
+      min_ram_gb: model.min_ram_gb ?? metadata.min_ram_gb,
+      max_context_length: model.max_context_length ?? metadata.max_context_length,
+      max_output_length: model.max_output_length ?? metadata.max_output_length,
+      architecture: model.architecture ?? metadata.architecture,
+      family: model.family ?? metadata.family,
+      capabilities: model.capabilities ?? metadata.capabilities,
+    },
+  };
+}
+
+async function publicCatalogResponse(coordUrl: string) {
+  const [catalogRes, capacityRes] = await Promise.all([
+    fetch(`${coordUrl}/v1/models/catalog?type=text`),
+    fetch(`${coordUrl}/v1/models/capacity`).catch(() => null),
+  ]);
+
+  if (!catalogRes.ok) {
+    return NextResponse.json({ error: `Upstream ${catalogRes.status}` }, { status: catalogRes.status });
+  }
+
+  const catalog = asRecord(await catalogRes.json());
+  const catalogModels = Array.isArray(catalog.models) ? catalog.models : [];
+
+  const capacityByID = new Map<string, JsonRecord>();
+  if (capacityRes?.ok) {
+    const capacity = asRecord(await capacityRes.json());
+    const capacityModels = Array.isArray(capacity.models) ? capacity.models : [];
+    for (const model of capacityModels) {
+      const entry = asRecord(model);
+      if (typeof entry.id === "string") {
+        capacityByID.set(entry.id, entry);
+      }
+    }
+  }
+
+  return NextResponse.json({
+    object: "list",
+    data: catalogModels
+      .map(asRecord)
+      .filter((model) => typeof model.id === "string")
+      .map((model) => toModelEntry(model, capacityByID.get(model.id as string))),
+  });
+}
+
 export async function GET(req: NextRequest) {
   const coordUrl = DEFAULT_COORD;
   const apiKey = req.headers.get("x-api-key") || "";
 
+  if (!apiKey) {
+    return publicCatalogResponse(coordUrl);
+  }
+
   const res = await fetch(`${coordUrl}/v1/models`, {
     headers: {
-      ...(apiKey ? { Authorization: `Bearer ${apiKey}` } : {}),
+      Authorization: `Bearer ${apiKey}`,
     },
   });
   if (!res.ok) {

--- a/console-ui/src/app/earn/page.tsx
+++ b/console-ui/src/app/earn/page.tsx
@@ -89,6 +89,8 @@ interface CatalogModel {
   outputPriceMicro: number;
 }
 
+const DEFAULT_OUTPUT_PRICE_MICRO_USD = 200_000;
+
 function buildPricingLookup(pricing: PricingResponse | null): Record<string, number> {
   if (!pricing) return {};
   return Object.fromEntries(pricing.prices.map((p) => [p.model, p.output_price]));
@@ -113,14 +115,13 @@ function buildCatalogModels(models: Model[], pricing: PricingResponse | null): C
   const outputPrices = buildPricingLookup(pricing);
   return models
     .map((model) => {
-      const outputPriceMicro = outputPrices[model.id];
-      if (!outputPriceMicro) return null;
+      const outputPriceMicro = outputPrices[model.id] ?? DEFAULT_OUTPUT_PRICE_MICRO_USD;
       const size = Math.max(1, Math.round(modelSizeGB(model)));
       return {
         id: model.id,
         name: model.display_name || model.id.split("/").pop() || model.id,
         minRAMGB: model.min_ram_gb || Math.ceil(size * 1.35),
-        demandNote: "Uses the live coordinator catalog and current per-token pricing.",
+        demandNote: "Uses the live coordinator catalog and current/default per-token pricing.",
         activeParamsGB: activeParamsGB(model, size),
         modelSizeGB: size,
         outputPriceMicro,

--- a/console-ui/src/lib/api.ts
+++ b/console-ui/src/lib/api.ts
@@ -101,7 +101,13 @@ export async function fetchModels(): Promise<Model[]> {
   const res = await fetch("/api/models", { headers: proxyHeaders() });
   if (!res.ok) throw new Error(`Failed to fetch models: ${res.status}`);
   const data = await res.json();
-  const raw = data.data || data;
+  const raw = Array.isArray(data)
+    ? data
+    : Array.isArray(data.data)
+      ? data.data
+      : Array.isArray(data.models)
+        ? data.models
+        : [];
   // Flatten metadata into top-level fields for the UI
   return raw.map((m: Record<string, unknown>) => {
     const meta = (m.metadata || {}) as Record<string, unknown>;


### PR DESCRIPTION
## Summary

Unauthenticated requests to the console-ui models API now proxy to the public catalog + capacity endpoints instead of the auth-gated `/v1/models`, so the earn page and other public surfaces display the full model catalog without an API key.

### Changes

**`console-ui/src/app/api/models/route.ts`** — Public catalog proxy
- Unauthenticated requests fetch from `/v1/models/catalog` + `/v1/models/capacity` and merge the results.
- `toModelEntry()` normalizes catalog fields (`size_gb`, `min_ram_gb`, `architecture`, capacity stats) into the standard model shape the UI expects.
- Authenticated requests continue through the existing `/v1/models` path.

**`console-ui/src/lib/api.ts`** — Flexible response unwrapping
- `fetchModels()` now handles three response shapes: `data.data` (OpenAI list), `data.models` (catalog), or a raw array.

**`console-ui/src/app/earn/page.tsx`** — Earn page resilience
- Models without explicit pricing fall back to a default output price (`200_000` micro-USD) instead of being filtered out.

**Tests**
- New test for catalog response unwrapping in `fetchModels`.
- Earn page tests now mock `fetchModels`/`fetchPricing` from `@/lib/api` instead of relying on hardcoded model data.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/224"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782431567&installation_id=133247490&pr_number=224&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F224&signature=116761ae757b5d8e5e85180af50133147eb5c968516d6bcbd440d0a842a216f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->