### PR TITLE
feat: multi-model swap — download multiple models, serve one at a time

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -198,6 +198,28 @@ Dev coordinator deploy (Google Cloud): see `docs/dev-environment.md`.
 - Request queue timeout is 120 seconds. Initial attestation challenge is sent immediately on registration, then every 5 minutes.
 - Backend idle timeout is 1 hour (not 10 minutes as some comments may say).
 
+### Coordinator State Model — Multiple Overlapping Views
+
+Provider state lives in several fields that are read by different code paths with different precedence rules. When mutating any of these, trace every reader:
+
+- `BackendCapacity.Slots` is **authoritative** for the scheduler when present (Swift providers). The scheduler derives `slotState`, `modelLoaded`, token budgets, and observed TPS from it. `WarmModels` is only a fallback for legacy providers without `BackendCapacity`.
+- `WarmModels` is updated by heartbeats. It is NOT consulted by `snapshotProviderLocked` or `buildCandidateWithReason` when `BackendCapacity` is non-nil. Only `TriggerModelSwaps` / `hasWarmProviderLocked` checks it as a fallback.
+- `CurrentModel` is set from heartbeat `active_model`. A nil/omitted `active_model` means no model is loaded. Stale `CurrentModel` can cause attestation hash mismatches.
+- `pendingModelLoads` is only checked by `TriggerModelSwaps` planning. It is NOT checked by `QuickCapacityCheck`, `ReserveProviderEx`, or `freeMemoryAdmits`. Do not assume pending-load state affects routing decisions.
+- Provider-reported slot states include `"running"` (active requests), `"idle"` (loaded, no requests), `"crashed"`, `"reloading"`, and `"idle_shutdown"`. The `"idle"` state means the model IS loaded — treat it the same as `"running"` for warm detection, not as `"unknown"`.
+- Providers can hold up to `maxModelSlots` models simultaneously (default 3). Do not assume a model swap evicts all other models.
+- The provider's `ensureModelLoaded` requires `estimatedMemoryGb * 3.0` headroom. The coordinator's `freeMemoryAdmits` uses a different (less conservative) check. A model the coordinator admits can still fail on the provider side.
+
+### Coordinator Mutation Checklist
+
+When adding code that mutates provider state or sends commands (`load_model`, etc.):
+
+1. Enumerate every reader of the fields you're mutating (`BackendCapacity.Slots`, `WarmModels`, `CurrentModel`, `pendingModelLoads`).
+2. Check what happens on the failure path — does state get cleaned up on disconnect, timeout, and load failure?
+3. Check concurrent access — heartbeats arrive per-provider on separate goroutines; `TriggerModelSwaps` can race with `drainQueuedRequestsForModels`.
+4. Check the cleanup path — `Disconnect()` must clear any per-provider state you add.
+5. Verify pre-existing invariants: `maxModelSlots`, heartbeat field omission semantics (`nil` vs empty), and the 3x memory gate on the provider side.
+
 ## Formatting
 
 A pre-commit hook in `.githooks/pre-commit` checks staged files only. It is enabled via:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -203,7 +203,7 @@ Dev coordinator deploy (Google Cloud): see `docs/dev-environment.md`.
 Provider state lives in several fields that are read by different code paths with different precedence rules. When mutating any of these, trace every reader:
 
 - `BackendCapacity.Slots` is **authoritative** for the scheduler when present (Swift providers). The scheduler derives `slotState`, `modelLoaded`, token budgets, and observed TPS from it. `WarmModels` is only a fallback for legacy providers without `BackendCapacity`.
-- `WarmModels` is updated by heartbeats. It is NOT consulted by `snapshotProviderLocked` or `buildCandidateWithReason` when `BackendCapacity` is non-nil. Only `TriggerModelSwaps` / `hasWarmProviderLocked` checks it as a fallback.
+- `WarmModels` is updated by heartbeats. It is NOT consulted by `snapshotProviderLocked` or `buildCandidateWithReason` when `BackendCapacity` is non-nil. `TriggerModelSwaps` / `hasWarmProviderLocked` checks it as a fallback. Legacy `ScoreProvider` also reads it for warm bonus, and `/v1/me/providers` copies it into API responses.
 - `CurrentModel` is set from heartbeat `active_model`. A nil/omitted `active_model` means no model is loaded. Stale `CurrentModel` can cause attestation hash mismatches.
 - `pendingModelLoads` is only checked by `TriggerModelSwaps` planning. It is NOT checked by `QuickCapacityCheck`, `ReserveProviderEx`, or `freeMemoryAdmits`. Do not assume pending-load state affects routing decisions.
 - Provider-reported slot states include `"running"` (active requests), `"idle"` (loaded, no requests), `"crashed"`, `"reloading"`, and `"idle_shutdown"`. The `"idle"` state means the model IS loaded — treat it the same as `"running"` for warm detection, not as `"unknown"`.

--- a/coordinator/api/billing_handlers.go
+++ b/coordinator/api/billing_handlers.go
@@ -349,7 +349,7 @@ func (s *Server) handleGetPricing(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, http.StatusOK, map[string]any{
-		"prices": prices,
+		"prices":                prices,
 		"fallback_input_price":  payments.DefaultInputPricePerMillion,
 		"fallback_output_price": payments.DefaultOutputPricePerMillion,
 		"fallback_input_usd":    fmt.Sprintf("$%.4f", float64(payments.DefaultInputPricePerMillion)/1_000_000),

--- a/coordinator/api/provider.go
+++ b/coordinator/api/provider.go
@@ -315,8 +315,10 @@ func (s *Server) providerReadLoop(ctx context.Context, conn *websocket.Conn, pro
 			)
 			switch statusMsg.Status {
 			case protocol.LoadModelStatusSucceeded:
-				// Clear pending entry and drain queued requests immediately
-				// so consumers don't wait for the next heartbeat (up to 5s).
+				// Mark the model warm on this provider BEFORE draining so
+				// the scheduler sees it as a candidate. Without this, the
+				// provider still looks cold until the next heartbeat.
+				s.registry.MarkModelWarm(providerID, statusMsg.ModelID)
 				s.registry.ClearPendingModelLoad(providerID, statusMsg.ModelID)
 				s.registry.DrainQueuedRequestsForModel(statusMsg.ModelID)
 			case protocol.LoadModelStatusFailed:

--- a/coordinator/api/provider.go
+++ b/coordinator/api/provider.go
@@ -313,6 +313,12 @@ func (s *Server) providerReadLoop(ctx context.Context, conn *websocket.Conn, pro
 				"status", statusMsg.Status,
 				"error", statusMsg.Error,
 			)
+			// Clear the pending load entry so TriggerModelSwaps stops
+			// suppressing new load requests for this (provider, model) pair.
+			if statusMsg.Status == protocol.LoadModelStatusSucceeded ||
+				statusMsg.Status == protocol.LoadModelStatusFailed {
+				s.registry.ClearPendingModelLoad(providerID, statusMsg.ModelID)
+			}
 
 		default:
 			s.logger.Warn("unhandled provider message type", "provider_id", providerID, "type", msg.Type)

--- a/coordinator/api/provider.go
+++ b/coordinator/api/provider.go
@@ -313,10 +313,9 @@ func (s *Server) providerReadLoop(ctx context.Context, conn *websocket.Conn, pro
 				"status", statusMsg.Status,
 				"error", statusMsg.Error,
 			)
-			// Clear the pending load entry so TriggerModelSwaps stops
-			// suppressing new load requests for this (provider, model) pair.
-			if statusMsg.Status == protocol.LoadModelStatusSucceeded ||
-				statusMsg.Status == protocol.LoadModelStatusFailed {
+			// Clear the pending load entry only on success. On failure, leave
+			// the entry in place so the TTL cooldown suppresses retry storms.
+			if statusMsg.Status == protocol.LoadModelStatusSucceeded {
 				s.registry.ClearPendingModelLoad(providerID, statusMsg.ModelID)
 			}
 			// On success, drain queued requests immediately rather than

--- a/coordinator/api/provider.go
+++ b/coordinator/api/provider.go
@@ -319,6 +319,13 @@ func (s *Server) providerReadLoop(ctx context.Context, conn *websocket.Conn, pro
 				statusMsg.Status == protocol.LoadModelStatusFailed {
 				s.registry.ClearPendingModelLoad(providerID, statusMsg.ModelID)
 			}
+			// On success, drain queued requests immediately rather than
+			// waiting for the next heartbeat (up to 5s). The model is
+			// warm now and requests near their queue timeout would
+			// otherwise expire unnecessarily.
+			if statusMsg.Status == protocol.LoadModelStatusSucceeded {
+				s.registry.DrainQueuedRequestsForModel(statusMsg.ModelID)
+			}
 
 		default:
 			s.logger.Warn("unhandled provider message type", "provider_id", providerID, "type", msg.Type)

--- a/coordinator/api/provider.go
+++ b/coordinator/api/provider.go
@@ -313,18 +313,19 @@ func (s *Server) providerReadLoop(ctx context.Context, conn *websocket.Conn, pro
 				"status", statusMsg.Status,
 				"error", statusMsg.Error,
 			)
-			// Clear the pending load entry only on success. On failure, leave
-			// the entry in place so the TTL cooldown suppresses retry storms.
-			if statusMsg.Status == protocol.LoadModelStatusSucceeded {
+			switch statusMsg.Status {
+			case protocol.LoadModelStatusSucceeded:
+				// Clear pending entry and drain queued requests immediately
+				// so consumers don't wait for the next heartbeat (up to 5s).
 				s.registry.ClearPendingModelLoad(providerID, statusMsg.ModelID)
-			}
-			// On success, drain queued requests immediately rather than
-			// waiting for the next heartbeat (up to 5s). The model is
-			// warm now and requests near their queue timeout would
-			// otherwise expire unnecessarily.
-			if statusMsg.Status == protocol.LoadModelStatusSucceeded {
 				s.registry.DrainQueuedRequestsForModel(statusMsg.ModelID)
+			case protocol.LoadModelStatusFailed:
+				// Keep the pending entry (TTL cooldown suppresses retry storms).
+				// If no other provider can serve this model, reject queued
+				// requests immediately rather than making them wait 120s.
+				s.registry.RejectUnservableQueuedRequests(statusMsg.ModelID)
 			}
+			// "started" status: no action — load is in progress.
 
 		default:
 			s.logger.Warn("unhandled provider message type", "provider_id", providerID, "type", msg.Type)

--- a/coordinator/payments/pricing_test.go
+++ b/coordinator/payments/pricing_test.go
@@ -96,8 +96,8 @@ func TestCalculateCostWithOverrides(t *testing.T) {
 	}{
 		{
 			name:             "custom prices override fallback",
-			customInput:      15_000,  // $0.015
-			customOutput:     70_000,  // $0.070
+			customInput:      15_000, // $0.015
+			customOutput:     70_000, // $0.070
 			hasCustom:        true,
 			promptTokens:     1_000_000,
 			completionTokens: 1_000_000,

--- a/coordinator/registry/queue.go
+++ b/coordinator/registry/queue.go
@@ -268,6 +268,22 @@ func (q *RequestQueue) CleanStale() {
 	}
 }
 
+// QueuedModels returns the set of model IDs that currently have at least
+// one request waiting in the queue.
+func (q *RequestQueue) QueuedModels() []string {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	var models []string
+	for model := range q.queues {
+		q.cleanStaleLocked(model)
+		if len(q.queues[model]) > 0 {
+			models = append(models, model)
+		}
+	}
+	return models
+}
+
 // cleanStaleLocked removes stale requests for a specific model.
 // Caller must hold q.mu.
 func (q *RequestQueue) cleanStaleLocked(model string) {

--- a/coordinator/registry/queue.go
+++ b/coordinator/registry/queue.go
@@ -268,6 +268,28 @@ func (q *RequestQueue) CleanStale() {
 	}
 }
 
+// FailQueuedRequestsForModel rejects all queued requests for a model by
+// sending nil on their ResponseCh. Waiters receive ErrQueueTimeout.
+// Called when the coordinator determines no provider can serve the model
+// (e.g. all load_model attempts failed with no alternative provider).
+func (q *RequestQueue) FailQueuedRequestsForModel(model string) int {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	queue := q.queues[model]
+	failed := 0
+	for _, req := range queue {
+		req.markDone()
+		select {
+		case req.ResponseCh <- nil:
+			failed++
+		default:
+		}
+	}
+	delete(q.queues, model)
+	return failed
+}
+
 // QueuedModels returns the set of model IDs that currently have at least
 // one request waiting in the queue.
 func (q *RequestQueue) QueuedModels() []string {

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -1491,6 +1491,28 @@ func (r *Registry) MarkModelWarm(providerID, modelID string) {
 	}
 	p.WarmModels = append(p.WarmModels, modelID)
 	p.CurrentModel = modelID
+
+	// Inject a synthetic "idle" slot into BackendCapacity so the scheduler
+	// sees the model as warm. Without this, the scheduler only checks
+	// BackendCapacity.Slots (not WarmModels) for Swift providers, and a
+	// stale snapshot without the new model's slot would treat it as cold
+	// until the next heartbeat arrives.
+	if p.BackendCapacity != nil {
+		found := false
+		for i, slot := range p.BackendCapacity.Slots {
+			if slot.Model == modelID {
+				p.BackendCapacity.Slots[i].State = "idle"
+				found = true
+				break
+			}
+		}
+		if !found {
+			p.BackendCapacity.Slots = append(p.BackendCapacity.Slots, protocol.BackendSlotCapacity{
+				Model: modelID,
+				State: "idle",
+			})
+		}
+	}
 }
 
 // ClearPendingModelLoad removes a pending model load entry after a terminal

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -1338,11 +1338,16 @@ func (r *Registry) providerHasWarmModelLocked(p *Provider, model string, now tim
 	}
 	if p.BackendCapacity != nil {
 		for _, slot := range p.BackendCapacity.Slots {
-			if slot.Model == model && slot.State == "running" {
-				return true
+			if slot.Model == model {
+				// BackendCapacity is authoritative when present.
+				// Only "running" and "idle" mean the model is warm.
+				return slot.State == "running" || slot.State == "idle"
 			}
 		}
+		// Model has no slot in BackendCapacity -- it's not loaded.
+		return false
 	}
+	// Legacy provider without BackendCapacity: fall back to WarmModels.
 	for _, warmModel := range p.WarmModels {
 		if warmModel == model {
 			return true
@@ -1487,6 +1492,12 @@ func (r *Registry) Disconnect(id string) {
 	p, ok := r.providers[id]
 	if ok {
 		delete(r.providers, id)
+		// Clear any pending model load entries for this provider.
+		for key := range r.pendingModelLoads {
+			if len(key) > len(id)+1 && key[:len(id)+1] == id+":" {
+				delete(r.pendingModelLoads, key)
+			}
+		}
 		p.mu.Lock()
 		if p.Status != StatusUntrusted {
 			r.onlineCount.Add(-1)

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -1497,21 +1497,27 @@ func (r *Registry) MarkModelWarm(providerID, modelID string) {
 	// BackendCapacity.Slots (not WarmModels) for Swift providers, and a
 	// stale snapshot without the new model's slot would treat it as cold
 	// until the next heartbeat arrives.
+	//
+	// Also remove stale slots for models that were evicted to make room
+	// for the new model. The provider only has one active slot after a
+	// swap, so any other "running"/"idle" slots are stale until the next
+	// heartbeat corrects them.
 	if p.BackendCapacity != nil {
-		found := false
-		for i, slot := range p.BackendCapacity.Slots {
+		fresh := p.BackendCapacity.Slots[:0]
+		for _, slot := range p.BackendCapacity.Slots {
 			if slot.Model == modelID {
-				p.BackendCapacity.Slots[i].State = "idle"
-				found = true
-				break
+				continue // will be replaced below
 			}
+			if slot.State == "running" || slot.State == "idle" {
+				continue // evicted — drop stale warm slot
+			}
+			fresh = append(fresh, slot) // keep crashed/reloading/other states
 		}
-		if !found {
-			p.BackendCapacity.Slots = append(p.BackendCapacity.Slots, protocol.BackendSlotCapacity{
-				Model: modelID,
-				State: "idle",
-			})
-		}
+		fresh = append(fresh, protocol.BackendSlotCapacity{
+			Model: modelID,
+			State: "idle",
+		})
+		p.BackendCapacity.Slots = fresh
 	}
 }
 

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -1168,6 +1168,10 @@ func (r *Registry) Heartbeat(id string, msg *protocol.HeartbeatMessage) {
 	p.WarmModels = msg.WarmModels
 	if msg.ActiveModel != nil {
 		p.CurrentModel = *msg.ActiveModel
+	} else {
+		// nil active_model means no model is loaded — clear stale state
+		// so attestation challenges don't compare against an unloaded model.
+		p.CurrentModel = ""
 	}
 	// Only update status from heartbeat if provider is not actively serving
 	// (serving status is managed by request lifecycle). Crucially, an
@@ -1465,6 +1469,28 @@ func (r *Registry) providerHasPendingLoad(providerID string) bool {
 		}
 	}
 	return false
+}
+
+// MarkModelWarm adds a model to the provider's WarmModels list if not already
+// present. Called when load_model_status:succeeded arrives before the next
+// heartbeat, so the scheduler sees the provider as warm during queue drain.
+func (r *Registry) MarkModelWarm(providerID, modelID string) {
+	r.mu.RLock()
+	p, ok := r.providers[providerID]
+	r.mu.RUnlock()
+	if !ok {
+		return
+	}
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	for _, wm := range p.WarmModels {
+		if wm == modelID {
+			return // already warm
+		}
+	}
+	p.WarmModels = append(p.WarmModels, modelID)
+	p.CurrentModel = modelID
 }
 
 // ClearPendingModelLoad removes a pending model load entry after a terminal

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -1162,10 +1162,10 @@ func (r *Registry) Heartbeat(id string, msg *protocol.HeartbeatMessage) {
 			}
 		}
 	}
-	// Update warm models from heartbeat
-	if len(msg.WarmModels) > 0 {
-		p.WarmModels = msg.WarmModels
-	}
+	// Update warm models from heartbeat. Always overwrite -- an empty list
+	// means the provider has no models loaded, and stale entries must be
+	// cleared to prevent TriggerModelSwaps from suppressing needed swaps.
+	p.WarmModels = msg.WarmModels
 	if msg.ActiveModel != nil {
 		p.CurrentModel = *msg.ActiveModel
 	}
@@ -1285,7 +1285,7 @@ func (r *Registry) planModelLoadActions(queuedModels []string, now time.Time) []
 	selectedProviders := make(map[string]struct{})
 	actions := make([]modelLoadAction, 0, len(queuedModels))
 	for _, model := range queuedModels {
-		if r.hasWarmProviderLocked(model) {
+		if r.hasWarmProviderLocked(model, now) {
 			continue
 		}
 
@@ -1301,10 +1301,10 @@ func (r *Registry) planModelLoadActions(queuedModels []string, now time.Time) []
 
 // hasWarmProviderLocked reports whether a connected provider already has the
 // model warm. Caller must hold r.mu (read or write).
-func (r *Registry) hasWarmProviderLocked(model string) bool {
+func (r *Registry) hasWarmProviderLocked(model string, now time.Time) bool {
 	for _, p := range r.providers {
 		p.mu.Lock()
-		warm := providerHasWarmModelLocked(p, model)
+		warm := r.providerHasWarmModelLocked(p, model, now)
 		p.mu.Unlock()
 		if warm {
 			return true
@@ -1313,10 +1313,24 @@ func (r *Registry) hasWarmProviderLocked(model string) bool {
 	return false
 }
 
-// providerHasWarmModelLocked checks heartbeat-reported warm state. Caller must
-// hold p.mu.
-func providerHasWarmModelLocked(p *Provider, model string) bool {
+// providerHasWarmModelLocked checks whether the provider has the model warm
+// AND passes the same routing safety gates used by the scheduler. A provider
+// with stale attestation or failed privacy checks should not suppress swap
+// planning. Caller must hold p.mu. Caller must hold r.mu (read or write).
+func (r *Registry) providerHasWarmModelLocked(p *Provider, model string, now time.Time) bool {
 	if p.Status == StatusOffline || p.Status == StatusUntrusted {
+		return false
+	}
+	if trustRank(p.TrustLevel) < trustRank(r.MinTrustLevel) {
+		return false
+	}
+	if !p.RuntimeVerified {
+		return false
+	}
+	if !providerSupportsPrivateTextLocked(p) {
+		return false
+	}
+	if p.LastChallengeVerified.IsZero() || now.Sub(p.LastChallengeVerified) > challengeFreshnessMaxAge {
 		return false
 	}
 	if p.BackendCapacity != nil {
@@ -1338,7 +1352,6 @@ func providerHasWarmModelLocked(p *Provider, model string) bool {
 // pending requests. Caller must hold r.mu (read or write).
 func (r *Registry) bestModelLoadProviderLocked(model string, now time.Time, selectedProviders map[string]struct{}) string {
 	bestProviderID := ""
-	bestPendingCount := -1
 	for id, p := range r.providers {
 		if _, selected := selectedProviders[id]; selected {
 			continue
@@ -1351,11 +1364,11 @@ func (r *Registry) bestModelLoadProviderLocked(model string, now time.Time, sele
 		if !ok {
 			continue
 		}
-		if bestPendingCount < 0 || pendingCount < bestPendingCount {
-			bestProviderID = id
-			bestPendingCount = pendingCount
-		}
+		// Only consider idle providers (no in-flight requests). Sending
+		// load_model to a provider that is actively serving another model
+		// will fail because the active slot cannot be evicted.
 		if pendingCount == 0 {
+			bestProviderID = id
 			break
 		}
 	}

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -1475,6 +1475,33 @@ func (r *Registry) ClearPendingModelLoad(providerID, modelID string) {
 	r.mu.Unlock()
 }
 
+// RejectUnservableQueuedRequests checks whether any eligible provider can
+// serve the given model. If not, all queued requests for the model are
+// rejected immediately rather than waiting for the 120s queue timeout.
+// Called after a load_model failure to give consumers a fast error.
+func (r *Registry) RejectUnservableQueuedRequests(modelID string) {
+	if r.queue == nil {
+		return
+	}
+	if r.queue.QueueSize(modelID) == 0 {
+		return
+	}
+
+	// Check if any provider can still serve this model.
+	candidates, _ := r.QuickCapacityCheck(modelID, 500, defaultRequestedMaxTokens)
+	if candidates > 0 {
+		return
+	}
+
+	failed := r.queue.FailQueuedRequestsForModel(modelID)
+	if failed > 0 {
+		r.logger.Warn("rejected queued requests for unservable model",
+			"model_id", modelID,
+			"rejected", failed,
+		)
+	}
+}
+
 func cumulativeDelta(previous, current int64) int64 {
 	if current <= 0 {
 		return 0

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -1333,6 +1333,9 @@ func (r *Registry) providerHasWarmModelLocked(p *Provider, model string, now tim
 	if p.LastChallengeVerified.IsZero() || now.Sub(p.LastChallengeVerified) > challengeFreshnessMaxAge {
 		return false
 	}
+	if !r.providerServesCatalogModelLocked(p, model) {
+		return false
+	}
 	if p.BackendCapacity != nil {
 		for _, slot := range p.BackendCapacity.Slots {
 			if slot.Model == model && slot.State == "running" {
@@ -1356,7 +1359,10 @@ func (r *Registry) bestModelLoadProviderLocked(model string, now time.Time, sele
 		if _, selected := selectedProviders[id]; selected {
 			continue
 		}
-		if _, pending := r.pendingModelLoads[modelLoadKey(id, model)]; pending {
+		// Skip providers that have any pending model load -- sending a
+		// second load_model while the first is in progress can cause
+		// swap oscillation on single-slot providers.
+		if r.providerHasPendingLoad(id) {
 			continue
 		}
 
@@ -1440,6 +1446,18 @@ func (r *Registry) sendModelLoadActions(actions []modelLoadAction) {
 
 func modelLoadKey(providerID, modelID string) string {
 	return providerID + ":" + modelID
+}
+
+// providerHasPendingLoad reports whether the provider has any pending
+// load_model command. Caller must hold r.mu (read or write).
+func (r *Registry) providerHasPendingLoad(providerID string) bool {
+	prefix := providerID + ":"
+	for key := range r.pendingModelLoads {
+		if len(key) > len(prefix) && key[:len(prefix)] == prefix {
+			return true
+		}
+	}
+	return false
 }
 
 // ClearPendingModelLoad removes a pending model load entry after a terminal

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -1421,11 +1421,13 @@ func (r *Registry) reservePendingModelLoads(actions []modelLoadAction, now time.
 
 	reserved := actions[:0]
 	for _, action := range actions {
-		key := modelLoadKey(action.providerID, action.modelID)
-		if _, pending := r.pendingModelLoads[key]; pending {
+		// Check per-provider (not just per-key) to prevent concurrent
+		// heartbeat goroutines from reserving the same idle provider
+		// for different models.
+		if r.providerHasPendingLoad(action.providerID) {
 			continue
 		}
-		r.pendingModelLoads[key] = now
+		r.pendingModelLoads[modelLoadKey(action.providerID, action.modelID)] = now
 		reserved = append(reserved, action)
 	}
 	return reserved

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"math"
 	"math/rand"
@@ -489,17 +490,30 @@ type Registry struct {
 	onlineCount      atomic.Int64
 	modelProviders   map[string]*atomic.Int64
 	modelProvidersMu sync.Mutex
+
+	// pendingModelLoads tracks provider-model pairs that have been sent a
+	// load_model command and are awaiting completion. Prevents duplicate
+	// sends across heartbeat cycles.
+	pendingModelLoads map[string]time.Time // key: "providerID:modelID"
+}
+
+const pendingModelLoadTTL = 2 * time.Minute
+
+type modelLoadAction struct {
+	providerID string
+	modelID    string
 }
 
 // New creates a new Registry.
 func New(logger *slog.Logger) *Registry {
 	return &Registry{
-		providers:      make(map[string]*Provider),
-		queue:          NewRequestQueue(10, 120*time.Second),
-		MinTrustLevel:  TrustHardware,
-		tpsRegistry:    NewTPSRegistry(),
-		modelProviders: make(map[string]*atomic.Int64),
-		logger:         logger,
+		providers:         make(map[string]*Provider),
+		queue:             NewRequestQueue(10, 120*time.Second),
+		MinTrustLevel:     TrustHardware,
+		tpsRegistry:       NewTPSRegistry(),
+		modelProviders:    make(map[string]*atomic.Int64),
+		pendingModelLoads: make(map[string]time.Time),
+		logger:            logger,
 	}
 }
 
@@ -1178,6 +1192,249 @@ func (r *Registry) Heartbeat(id string, msg *protocol.HeartbeatMessage) {
 	// crash auto-restart). Drain matching queues using the canonical scheduler
 	// rather than the legacy direct queue assignment path.
 	r.drainQueuedRequestsForModels(providerModelIDs(p))
+
+	// If queue drain didn't satisfy all pending requests (no warm provider),
+	// check if a cold provider should swap models to serve queued demand.
+	r.TriggerModelSwaps()
+}
+
+// SendLoadModel instructs a provider to eagerly load a model so it becomes
+// warm for incoming requests. The provider will autonomously evict idle
+// models to make room. This is a fire-and-forget call — the coordinator
+// does not block waiting for the load to complete. The provider replies
+// asynchronously with a load_model_status message.
+func (r *Registry) SendLoadModel(providerID, modelID string) error {
+	r.mu.RLock()
+	p, ok := r.providers[providerID]
+	r.mu.RUnlock()
+	if !ok {
+		return fmt.Errorf("provider %q not found", providerID)
+	}
+
+	msg := protocol.LoadModelMessage{
+		Type:    protocol.TypeLoadModel,
+		ModelID: modelID,
+	}
+	data, err := json.Marshal(msg)
+	if err != nil {
+		return fmt.Errorf("failed to marshal load_model message: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	p.mu.Lock()
+	conn := p.Conn
+	p.mu.Unlock()
+
+	if conn == nil {
+		return fmt.Errorf("provider %q has no active connection", providerID)
+	}
+
+	if err := conn.Write(ctx, websocket.MessageText, data); err != nil {
+		return fmt.Errorf("failed to send load_model to provider %q: %w", providerID, err)
+	}
+
+	r.logger.Info("sent load_model to provider",
+		"provider_id", providerID,
+		"model_id", modelID,
+	)
+	return nil
+}
+
+// TriggerModelSwaps checks for queued requests that have no warm provider
+// and sends load_model to cold providers that have the model available on
+// disk. This enables demand-driven model swapping: when requests queue for
+// a model that no provider has warm, the coordinator proactively triggers
+// a swap on an idle provider.
+//
+// Called after heartbeat processing and queue drain to catch demand that
+// can't be satisfied by warm providers alone.
+func (r *Registry) TriggerModelSwaps() {
+	if r.queue == nil {
+		return
+	}
+
+	queuedModels := r.queue.QueuedModels()
+	if len(queuedModels) == 0 {
+		return
+	}
+
+	now := time.Now()
+	r.expirePendingModelLoads(now)
+
+	actions := r.planModelLoadActions(queuedModels, now)
+	actions = r.reservePendingModelLoads(actions, now)
+	r.sendModelLoadActions(actions)
+}
+
+func (r *Registry) expirePendingModelLoads(now time.Time) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for key, sentAt := range r.pendingModelLoads {
+		if now.Sub(sentAt) > pendingModelLoadTTL {
+			delete(r.pendingModelLoads, key)
+		}
+	}
+}
+
+func (r *Registry) planModelLoadActions(queuedModels []string, now time.Time) []modelLoadAction {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	selectedProviders := make(map[string]struct{})
+	actions := make([]modelLoadAction, 0, len(queuedModels))
+	for _, model := range queuedModels {
+		if r.hasWarmProviderLocked(model) {
+			continue
+		}
+
+		providerID := r.bestModelLoadProviderLocked(model, now, selectedProviders)
+		if providerID == "" {
+			continue
+		}
+		selectedProviders[providerID] = struct{}{}
+		actions = append(actions, modelLoadAction{providerID: providerID, modelID: model})
+	}
+	return actions
+}
+
+// hasWarmProviderLocked reports whether a connected provider already has the
+// model warm. Caller must hold r.mu (read or write).
+func (r *Registry) hasWarmProviderLocked(model string) bool {
+	for _, p := range r.providers {
+		p.mu.Lock()
+		warm := providerHasWarmModelLocked(p, model)
+		p.mu.Unlock()
+		if warm {
+			return true
+		}
+	}
+	return false
+}
+
+// providerHasWarmModelLocked checks heartbeat-reported warm state. Caller must
+// hold p.mu.
+func providerHasWarmModelLocked(p *Provider, model string) bool {
+	if p.Status == StatusOffline || p.Status == StatusUntrusted {
+		return false
+	}
+	if p.BackendCapacity != nil {
+		for _, slot := range p.BackendCapacity.Slots {
+			if slot.Model == model && slot.State == "running" {
+				return true
+			}
+		}
+	}
+	for _, warmModel := range p.WarmModels {
+		if warmModel == model {
+			return true
+		}
+	}
+	return false
+}
+
+// bestModelLoadProviderLocked selects the eligible provider with the fewest
+// pending requests. Caller must hold r.mu (read or write).
+func (r *Registry) bestModelLoadProviderLocked(model string, now time.Time, selectedProviders map[string]struct{}) string {
+	bestProviderID := ""
+	bestPendingCount := -1
+	for id, p := range r.providers {
+		if _, selected := selectedProviders[id]; selected {
+			continue
+		}
+		if _, pending := r.pendingModelLoads[modelLoadKey(id, model)]; pending {
+			continue
+		}
+
+		pendingCount, ok := r.modelLoadCandidatePendingLocked(p, model, now)
+		if !ok {
+			continue
+		}
+		if bestPendingCount < 0 || pendingCount < bestPendingCount {
+			bestProviderID = id
+			bestPendingCount = pendingCount
+		}
+		if pendingCount == 0 {
+			break
+		}
+	}
+	return bestProviderID
+}
+
+// modelLoadCandidatePendingLocked applies the same routing safety gates used by
+// the scheduler, then returns the provider's current pending request count.
+// Caller must hold r.mu (read or write).
+func (r *Registry) modelLoadCandidatePendingLocked(p *Provider, model string, now time.Time) (int, bool) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.Status == StatusOffline || p.Status == StatusUntrusted {
+		return 0, false
+	}
+	if trustRank(p.TrustLevel) < trustRank(r.MinTrustLevel) {
+		return 0, false
+	}
+	if !p.RuntimeVerified {
+		return 0, false
+	}
+	if !providerSupportsPrivateTextLocked(p) {
+		return 0, false
+	}
+	if p.LastChallengeVerified.IsZero() || now.Sub(p.LastChallengeVerified) > challengeFreshnessMaxAge {
+		return 0, false
+	}
+	if !r.providerServesCatalogModelLocked(p, model) {
+		return 0, false
+	}
+	return p.pendingCount(), true
+}
+
+func (r *Registry) reservePendingModelLoads(actions []modelLoadAction, now time.Time) []modelLoadAction {
+	if len(actions) == 0 {
+		return nil
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.pendingModelLoads == nil {
+		r.pendingModelLoads = make(map[string]time.Time)
+	}
+
+	reserved := actions[:0]
+	for _, action := range actions {
+		key := modelLoadKey(action.providerID, action.modelID)
+		if _, pending := r.pendingModelLoads[key]; pending {
+			continue
+		}
+		r.pendingModelLoads[key] = now
+		reserved = append(reserved, action)
+	}
+	return reserved
+}
+
+func (r *Registry) sendModelLoadActions(actions []modelLoadAction) {
+	for _, action := range actions {
+		if err := r.SendLoadModel(action.providerID, action.modelID); err != nil {
+			r.logger.Warn("failed to trigger model swap",
+				"provider_id", action.providerID,
+				"model_id", action.modelID,
+				"error", err,
+			)
+			r.ClearPendingModelLoad(action.providerID, action.modelID)
+		}
+	}
+}
+
+func modelLoadKey(providerID, modelID string) string {
+	return providerID + ":" + modelID
+}
+
+// ClearPendingModelLoad removes a pending model load entry after a terminal
+// load_model_status response.
+func (r *Registry) ClearPendingModelLoad(providerID, modelID string) {
+	r.mu.Lock()
+	delete(r.pendingModelLoads, modelLoadKey(providerID, modelID))
+	r.mu.Unlock()
 }
 
 func cumulativeDelta(previous, current int64) int64 {

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -1513,9 +1513,13 @@ func (r *Registry) RejectUnservableQueuedRequests(modelID string) {
 		return
 	}
 
-	// Check if any provider can still serve this model.
-	candidates, _ := r.QuickCapacityCheck(modelID, 500, defaultRequestedMaxTokens)
-	if candidates > 0 {
+	// Check if any provider can still serve this model. Only reject when
+	// NO provider serves the model at all. If providers exist but are
+	// temporarily at capacity (capacityRejections > 0), the requests
+	// should wait — those providers may finish current work and become
+	// available.
+	candidates, capacityRejections := r.QuickCapacityCheck(modelID, 500, defaultRequestedMaxTokens)
+	if candidates > 0 || capacityRejections > 0 {
 		return
 	}
 

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -1498,26 +1498,25 @@ func (r *Registry) MarkModelWarm(providerID, modelID string) {
 	// stale snapshot without the new model's slot would treat it as cold
 	// until the next heartbeat arrives.
 	//
-	// Also remove stale slots for models that were evicted to make room
-	// for the new model. The provider only has one active slot after a
-	// swap, so any other "running"/"idle" slots are stale until the next
-	// heartbeat corrects them.
+	// We only add/update the new model's slot and leave existing slots
+	// untouched — the provider may have multiple model slots loaded
+	// simultaneously (maxModelSlots defaults to 3). The next heartbeat
+	// will provide the authoritative slot list.
 	if p.BackendCapacity != nil {
-		fresh := p.BackendCapacity.Slots[:0]
-		for _, slot := range p.BackendCapacity.Slots {
+		found := false
+		for i, slot := range p.BackendCapacity.Slots {
 			if slot.Model == modelID {
-				continue // will be replaced below
+				p.BackendCapacity.Slots[i].State = "idle"
+				found = true
+				break
 			}
-			if slot.State == "running" || slot.State == "idle" {
-				continue // evicted — drop stale warm slot
-			}
-			fresh = append(fresh, slot) // keep crashed/reloading/other states
 		}
-		fresh = append(fresh, protocol.BackendSlotCapacity{
-			Model: modelID,
-			State: "idle",
-		})
-		p.BackendCapacity.Slots = fresh
+		if !found {
+			p.BackendCapacity.Slots = append(p.BackendCapacity.Slots, protocol.BackendSlotCapacity{
+				Model: modelID,
+				State: "idle",
+			})
+		}
 	}
 }
 

--- a/coordinator/registry/scheduler.go
+++ b/coordinator/registry/scheduler.go
@@ -594,7 +594,7 @@ func (r *Registry) buildCandidateWithReason(snap routingSnapshot, pr *PendingReq
 
 func slotStatePenalty(state string) (float64, bool) {
 	switch state {
-	case "", "running":
+	case "", "running", "idle":
 		return slotStatePenaltyRunning, true
 	case "unknown":
 		// Model is available but not loaded. The provider must evict the

--- a/coordinator/registry/scheduler.go
+++ b/coordinator/registry/scheduler.go
@@ -882,6 +882,13 @@ func (r *Registry) QuickCapacityCheck(model string, estimatedPromptTokens, reque
 	return candidateCount, capacityRejections
 }
 
+// DrainQueuedRequestsForModel attempts to assign queued requests for a
+// single model to available providers. Called when a load_model completes
+// so requests don't have to wait for the next heartbeat cycle.
+func (r *Registry) DrainQueuedRequestsForModel(model string) {
+	r.drainQueuedRequestsForModels([]string{model})
+}
+
 func (r *Registry) drainQueuedRequestsForModels(models []string) {
 	if r.queue == nil || len(models) == 0 {
 		return

--- a/coordinator/registry/scheduler.go
+++ b/coordinator/registry/scheduler.go
@@ -14,7 +14,7 @@ const (
 	defaultRequestedMaxTokens = 256
 
 	slotStatePenaltyRunning      = 0.0
-	slotStatePenaltyUnknown      = 2_500.0
+	slotStatePenaltyUnknown      = 30_000.0
 	slotStatePenaltyIdleShutdown = 20_000.0
 
 	// Penalty constants. Phase 3 raised queueDepthPenaltyMs (1000→3000),
@@ -82,6 +82,7 @@ type routingSnapshot struct {
 	totalMemoryGB      float64
 	modelSizeGB        float64 // catalog-reported weight footprint (0 = unknown, gate disabled)
 	modelLoaded        bool    // true when the requested model is the currently-running slot
+	availableOnDisk    bool    // model is in provider's Models list but not currently loaded
 
 	observedDecodeTPS     float64
 	activeTokenBudgetUsed int64
@@ -429,6 +430,7 @@ func (r *Registry) snapshotProviderLocked(p *Provider, model string) (routingSna
 		}
 	}
 	snap.modelLoaded = snap.slotState == "running"
+	snap.availableOnDisk = !snap.modelLoaded
 	snap.fleetMedianTPS = r.tpsRegistry.Median(model, p.Hardware.ChipFamily)
 
 	return snap, true
@@ -466,7 +468,24 @@ func freeMemoryAdmits(snap routingSnapshot, reqPromptTokens, reqMaxTokens int) b
 	if tokens > maxTokensForCalc {
 		tokens = maxTokensForCalc
 	}
-	required += float64(tokens*kvCacheBytesPerToken) / float64(bytesPerGB)
+	kvCacheGB := float64(tokens*kvCacheBytesPerToken) / float64(bytesPerGB)
+	required += kvCacheGB
+
+	// When the model is available on disk but not currently loaded, the
+	// provider will evict idle models to make room (LRU eviction). Check
+	// whether the model individually fits in total memory (with OS/KV
+	// overhead) rather than requiring it to fit alongside existing loaded
+	// models. The provider handles the swap autonomously.
+	//
+	// However, if the provider has in-flight requests (totalPending > 0),
+	// it cannot evict the currently-serving model. In that case, fall
+	// through to the standard free-memory check which requires room
+	// alongside active models.
+	if snap.availableOnDisk && !snap.modelLoaded && snap.totalPending == 0 {
+		const osReserveGB = 4.0
+		return snap.modelSizeGB+kvCacheGB+osReserveGB <= snap.totalMemoryGB
+	}
+
 	free := snap.totalMemoryGB - snap.gpuMemoryActiveGB
 	return free >= required
 }
@@ -578,6 +597,11 @@ func slotStatePenalty(state string) (float64, bool) {
 	case "", "running":
 		return slotStatePenaltyRunning, true
 	case "unknown":
+		// Model is available but not loaded. The provider must evict the
+		// current model and load this one — typically 15–60 seconds for
+		// large models (depends on model size and disk speed). Warm
+		// providers are strongly preferred but cold providers are still
+		// eligible when no warm alternative exists.
 		return slotStatePenaltyUnknown, true
 	case "idle_shutdown":
 		return slotStatePenaltyIdleShutdown, true
@@ -838,6 +862,7 @@ func (r *Registry) QuickCapacityCheck(model string, estimatedPromptTokens, reque
 			}
 		}
 		snap.modelLoaded = snap.slotState == "running"
+		snap.availableOnDisk = !snap.modelLoaded
 
 		p.mu.Unlock()
 

--- a/provider-swift/Sources/ProviderCore/Models/ModelCatalog.swift
+++ b/provider-swift/Sources/ProviderCore/Models/ModelCatalog.swift
@@ -1070,12 +1070,7 @@ public struct ModelDownloader: Sendable {
 
             do {
                 let (tempFile, response) = try await urlSession.download(for: request)
-
-                // URLSession.download(for:) returns a temp file that the system
-                // may reclaim after this call returns. Move it to a stable
-                // location immediately before doing anything else.
-                try? fm.removeItem(at: partial)
-                try fm.moveItem(at: tempFile, to: partial)
+                defer { try? fm.removeItem(at: tempFile) }
 
                 guard let http = response as? HTTPURLResponse else {
                     try? fm.removeItem(at: partial)
@@ -1092,6 +1087,16 @@ public struct ModelDownloader: Sendable {
                 guard (200..<300).contains(http.statusCode) else {
                     try? fm.removeItem(at: partial)
                     throw ModelCatalogError.downloadFailed("\(label): HTTP \(http.statusCode)")
+                }
+
+                // URLSession.download(for:) returns a temp file that the
+                // system may reclaim after this call returns. Promote it to a
+                // stable .part file before hashing or moving to the final path.
+                if http.statusCode == 206 {
+                    try Self.appendDownloadedRange(tempFile, to: partial, label: label)
+                } else {
+                    try? fm.removeItem(at: partial)
+                    try fm.moveItem(at: tempFile, to: partial)
                 }
 
                 if let expectedSHA256 {
@@ -1135,22 +1140,23 @@ public struct ModelDownloader: Sendable {
         return false
     }
 
-    private static func appendFile(_ source: URL, to destination: URL) throws {
-        guard let reader = try? FileHandle(forReadingFrom: source) else {
-            throw ModelCatalogError.downloadFailed("could not open downloaded file")
-        }
-        defer { try? reader.close() }
+    private static func appendDownloadedRange(_ source: URL, to destination: URL, label: String) throws {
+        do {
+            let reader = try FileHandle(forReadingFrom: source)
+            defer { try? reader.close() }
 
-        guard let writer = try? FileHandle(forWritingTo: destination) else {
-            throw ModelCatalogError.downloadFailed("could not open partial destination")
-        }
-        defer { try? writer.close() }
+            let writer = try FileHandle(forWritingTo: destination)
+            defer { try? writer.close() }
 
-        try writer.seekToEnd()
-        while true {
-            guard let chunk = try reader.read(upToCount: 4 * 1_048_576) else { break }
-            if chunk.isEmpty { break }
-            try writer.write(contentsOf: chunk)
+            try writer.seekToEnd()
+            while true {
+                guard let chunk = try reader.read(upToCount: 4 * 1_048_576), !chunk.isEmpty else {
+                    break
+                }
+                try writer.write(contentsOf: chunk)
+            }
+        } catch {
+            throw ModelCatalogError.downloadFailed("\(label): could not append resumed download (\(error.localizedDescription))")
         }
     }
 

--- a/provider-swift/Sources/ProviderCore/Models/ModelCatalog.swift
+++ b/provider-swift/Sources/ProviderCore/Models/ModelCatalog.swift
@@ -1093,7 +1093,22 @@ public struct ModelDownloader: Sendable {
                 // system may reclaim after this call returns. Promote it to a
                 // stable .part file before hashing or moving to the final path.
                 if http.statusCode == 206 {
-                    try Self.appendDownloadedRange(tempFile, to: partial, label: label)
+                    // Validate Content-Range to ensure the server resumed at
+                    // the correct offset. Expected format: "bytes <start>-<end>/<total>".
+                    let expectedStart = UInt64(existingBytes)
+                    if let contentRange = http.value(forHTTPHeaderField: "Content-Range") {
+                        if let rangeStart = Self.parseContentRangeStart(contentRange),
+                           rangeStart != expectedStart {
+                            // Range mismatch: discard partial and re-download fully.
+                            try? fm.removeItem(at: partial)
+                            try fm.moveItem(at: tempFile, to: partial)
+                        } else {
+                            try Self.appendDownloadedRange(tempFile, to: partial, label: label)
+                        }
+                    } else {
+                        // No Content-Range header: cannot verify, append optimistically.
+                        try Self.appendDownloadedRange(tempFile, to: partial, label: label)
+                    }
                 } else {
                     try? fm.removeItem(at: partial)
                     try fm.moveItem(at: tempFile, to: partial)
@@ -1158,6 +1173,15 @@ public struct ModelDownloader: Sendable {
         } catch {
             throw ModelCatalogError.downloadFailed("\(label): could not append resumed download (\(error.localizedDescription))")
         }
+    }
+
+    /// Parse the start offset from a Content-Range header value.
+    /// Expected format: "bytes 12345-67890/123456".
+    private static func parseContentRangeStart(_ value: String) -> UInt64? {
+        guard value.hasPrefix("bytes ") else { return nil }
+        let afterBytes = value.dropFirst("bytes ".count)
+        guard let dashIndex = afterBytes.firstIndex(of: "-") else { return nil }
+        return UInt64(afterBytes[afterBytes.startIndex..<dashIndex])
     }
 
     private static func downloadFailureMessage(label: String, error: Error?) -> String {

--- a/provider-swift/Sources/ProviderCore/Models/ModelCatalog.swift
+++ b/provider-swift/Sources/ProviderCore/Models/ModelCatalog.swift
@@ -1094,20 +1094,28 @@ public struct ModelDownloader: Sendable {
                 // stable .part file before hashing or moving to the final path.
                 if http.statusCode == 206 {
                     // Validate Content-Range to ensure the server resumed at
-                    // the correct offset. Expected format: "bytes <start>-<end>/<total>".
+                    // the correct offset. Expected: "bytes <start>-<end>/<total>".
                     let expectedStart = UInt64(existingBytes)
-                    if let contentRange = http.value(forHTTPHeaderField: "Content-Range") {
-                        if let rangeStart = Self.parseContentRangeStart(contentRange),
-                           rangeStart != expectedStart {
-                            // Range mismatch: discard partial and re-download fully.
-                            try? fm.removeItem(at: partial)
-                            try fm.moveItem(at: tempFile, to: partial)
-                        } else {
-                            try Self.appendDownloadedRange(tempFile, to: partial, label: label)
-                        }
+                    let rangeVerified: Bool
+                    if let contentRange = http.value(forHTTPHeaderField: "Content-Range"),
+                       let rangeStart = Self.parseContentRangeStart(contentRange) {
+                        rangeVerified = (rangeStart == expectedStart)
                     } else {
-                        // No Content-Range header: cannot verify, append optimistically.
+                        // Missing or unparseable Content-Range -- cannot verify
+                        // the server resumed at the correct offset.
+                        rangeVerified = false
+                    }
+
+                    if rangeVerified {
                         try Self.appendDownloadedRange(tempFile, to: partial, label: label)
+                    } else {
+                        // Range unverifiable or mismatched -- discard the stale
+                        // partial and replace it with the server's fresh response.
+                        // The next download attempt (if needed) will resume from
+                        // this new position, or the SHA check below will detect
+                        // a truncated file.
+                        try? fm.removeItem(at: partial)
+                        try fm.moveItem(at: tempFile, to: partial)
                     }
                 } else {
                     try? fm.removeItem(at: partial)

--- a/provider-swift/Sources/darkbloom/StartCommand.swift
+++ b/provider-swift/Sources/darkbloom/StartCommand.swift
@@ -629,11 +629,6 @@ struct Start: AsyncParsableCommand {
         var cursorPos = 0
         var selected = [Bool](repeating: false, count: entries.count)
 
-        // Pre-select the largest downloaded model.
-        if let idx = entries.firstIndex(where: { $0.downloaded }) {
-            selected[idx] = true
-        }
-
         let downloadedCount = entries.filter(\.downloaded).count
         let availableCount = entries.count - downloadedCount
 
@@ -668,6 +663,11 @@ struct Start: AsyncParsableCommand {
 
         func canFitIndividually(_ entry: PickerEntry) -> Bool {
             entry.sizeGb <= budget
+        }
+
+        // Pre-select the largest downloaded model that can fit on this machine.
+        if let idx = entries.firstIndex(where: { $0.downloaded && canFitIndividually($0) }) {
+            selected[idx] = true
         }
 
         /// Render the picker UI, returning the number of lines written.

--- a/provider-swift/Sources/darkbloom/StartCommand.swift
+++ b/provider-swift/Sources/darkbloom/StartCommand.swift
@@ -658,6 +658,18 @@ struct Start: AsyncParsableCommand {
 
         var lastLineCount: Int = 0
 
+        let ansiReset = "\u{1B}[0m"
+        let ansiDim = "\u{1B}[2m"
+        let ansiYellow = "\u{1B}[33m"
+
+        func formattedGB(_ value: Double) -> String {
+            String(format: "%.1f", value)
+        }
+
+        func canFitIndividually(_ entry: PickerEntry) -> Bool {
+            entry.sizeGb <= budget
+        }
+
         /// Render the picker UI, returning the number of lines written.
         func render(pos: Int, sel: [Bool], prevLines: Int) -> Int {
             var output = ""
@@ -673,15 +685,19 @@ struct Start: AsyncParsableCommand {
                 .filter { sel[$0.offset] }
                 .map(\.element.sizeGb)
                 .reduce(0, +)
-            let remaining = budget - used
             let count = sel.filter { $0 }.count
+            let fitsSimultaneously = used <= budget
 
             var lines = 0
 
             output += "  Select models (RAM: \(Int(memoryGb)) GB)  \u{2191}\u{2193} navigate \u{00B7} Space toggle \u{00B7} Enter confirm\r\n"
             lines += 1
 
-            output += "  \u{1B}[2m\(count) selected \u{00B7} \(String(format: "%.1f", used)) GB used \u{00B7} \(String(format: "%.1f", remaining)) GB remaining\u{1B}[0m\r\n\r\n"
+            if fitsSimultaneously {
+                output += "  \(ansiDim)\(count) selected \u{00B7} \(formattedGB(used)) GB total \u{00B7} all models can be served simultaneously\(ansiReset)\r\n\r\n"
+            } else {
+                output += "  \(ansiDim)\(count) selected \u{00B7} \(formattedGB(used)) GB on disk \u{00B7} \(ansiReset)\(ansiYellow)one model active at a time (swap on demand)\(ansiReset)\r\n\r\n"
+            }
             lines += 2
 
             var idx = 0
@@ -695,7 +711,7 @@ struct Start: AsyncParsableCommand {
                     let check = sel[idx] ? "\u{2713}" : " "
                     let highlight = idx == pos ? "\u{1B}[36m" : ""
                     let reset = highlight.isEmpty ? "" : "\u{1B}[0m"
-                    output += "    \(highlight)\(arrow) [\(check)] \(entry.displayName) (\(String(format: "%.1f", entry.sizeGb)) GB)\(reset)\r\n"
+                    output += "    \(highlight)\(arrow) [\(check)] \(entry.displayName) (\(formattedGB(entry.sizeGb)) GB)\(reset)\r\n"
                     lines += 1
                     idx += 1
                 }
@@ -712,17 +728,17 @@ struct Start: AsyncParsableCommand {
                 for entry in entries where !entry.downloaded {
                     let arrow = idx == pos ? "\u{25B8}" : " "
                     let check = sel[idx] ? "\u{2713}" : " "
-                    let fits = !sel[idx] && entry.sizeGb > remaining
+                    let tooLargeForMachine = !canFitIndividually(entry)
                     let highlight: String
                     if idx == pos {
                         highlight = "\u{1B}[33m"
-                    } else if fits {
+                    } else if tooLargeForMachine {
                         highlight = "\u{1B}[2;31m"
                     } else {
                         highlight = "\u{1B}[2m"
                     }
-                    let warn = fits ? " \u{26A0} won't fit" : ""
-                    output += "    \(highlight)\(arrow) [\(check)] \u{2193} \(entry.displayName) (\(String(format: "%.1f", entry.sizeGb)) GB)\(warn)\u{1B}[0m\r\n"
+                    let warn = tooLargeForMachine ? " \u{26A0} exceeds RAM" : ""
+                    output += "    \(highlight)\(arrow) [\(check)] \u{2193} \(entry.displayName) (\(formattedGB(entry.sizeGb)) GB)\(warn)\u{1B}[0m\r\n"
                     lines += 1
                     idx += 1
                 }
@@ -758,11 +774,11 @@ struct Start: AsyncParsableCommand {
                     if selected[cursorPos] {
                         selected[cursorPos] = false
                     } else {
-                        let used: Double = entries.enumerated()
-                            .filter { selected[$0.offset] }
-                            .map(\.element.sizeGb)
-                            .reduce(0, +)
-                        if used + entries[cursorPos].sizeGb <= budget {
+                        // Allow selection if the model individually fits in memory.
+                        // Multiple models can be selected even if their total exceeds
+                        // available RAM — only one will be warm (loaded) at a time;
+                        // the coordinator manages model swaps on demand.
+                        if canFitIndividually(entries[cursorPos]) {
                             selected[cursorPos] = true
                         }
                     }

--- a/provider-swift/Tests/ProviderCoreTests/ModelCatalogTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/ModelCatalogTests.swift
@@ -288,11 +288,15 @@ private final class RangeURLProtocol: URLProtocol, @unchecked Sendable {
         }
         let body = Self.payload.dropFirst(start)
         let status = start > 0 ? 206 : 200
+        var headers = ["Content-Length": "\(body.count)"]
+        if status == 206 {
+            headers["Content-Range"] = "bytes \(start)-\(Self.payload.count - 1)/\(Self.payload.count)"
+        }
         let response = HTTPURLResponse(
             url: request.url!,
             statusCode: status,
             httpVersion: "HTTP/1.1",
-            headerFields: ["Content-Length": "\(body.count)"]
+            headerFields: headers
         )!
         client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
         client?.urlProtocol(self, didLoad: Data(body))


### PR DESCRIPTION
## Summary

Providers can now select and download multiple models even when their combined size exceeds available RAM. Only one model is warm (loaded in GPU memory) at a time; the coordinator manages demand-driven model swaps via the existing `load_model` protocol.

### Example
A machine with 36 GB RAM can now select both a 12 GB and a 26 GB model. Whichever model is warm is the one being served. When the warm model goes idle and demand arrives for the cold model, the coordinator triggers a swap.

---

## Before / After Flow

### Before: Request for cold model (no swap support)

```mermaid
sequenceDiagram
    participant C as Consumer
    participant Co as Coordinator
    participant P as Provider (12GB warm)

    C->>Co: POST /v1/chat/completions (model: 26GB)
    Co->>Co: QuickCapacityCheck
    Note over Co: freeMemoryAdmits: GPU memory<br/>occupied by 12GB model<br/>→ REJECT (no room for 26GB)
    Co-->>C: 429 Too Many Requests
    Note over C: Consumer retries forever<br/>or gives up. 26GB model<br/>is never served.
```

### After: Request for cold model (demand-driven swap)

```mermaid
sequenceDiagram
    participant C as Consumer
    participant Co as Coordinator
    participant P as Provider (12GB warm, 26GB on disk)

    C->>Co: POST /v1/chat/completions (model: 26GB)
    Co->>Co: QuickCapacityCheck
    Note over Co: availableOnDisk=true<br/>provider idle (pending=0)<br/>26GB + KV + 4GB ≤ 36GB → ADMIT<br/>penalty: +30s (cold)
    Co->>Co: ReserveProviderEx (30s cost penalty)
    Co->>P: inference_request (26GB model)
    P->>P: ensureModelLoaded(26GB)
    P->>P: evict 12GB (LRU, idle)
    P->>P: load 26GB from disk
    P-->>Co: inference_accepted
    P-->>Co: inference_response_chunk (streaming)
    Co-->>C: 200 OK (streaming SSE)
```

### Before: No warm provider, request queues

```mermaid
sequenceDiagram
    participant C as Consumer
    participant Co as Coordinator
    participant P as Provider (model A warm)

    C->>Co: POST /v1/chat/completions (model: B)
    Co->>Co: No warm provider for B
    Co->>Co: Queue request (120s timeout)
    Note over Co: No proactive action.<br/>Request waits until timeout.
    Co-->>C: 429 queue timeout (after 120s)
```

### After: No warm provider, proactive swap + fast reject

```mermaid
sequenceDiagram
    participant C as Consumer
    participant Co as Coordinator
    participant P as Provider (model A warm, B on disk)

    C->>Co: POST /v1/chat/completions (model: B)
    Co->>Co: No warm provider for B → queue request
    Co->>Co: Heartbeat arrives
    Co->>Co: TriggerModelSwaps: B queued, no warm provider
    Co->>P: load_model(B)
    P->>P: evict A, load B
    P-->>Co: load_model_status: succeeded
    Co->>Co: MarkModelWarm(P, B)
    Co->>Co: DrainQueuedRequestsForModel(B)
    Co->>P: inference_request (model B)
    P-->>Co: inference_response_chunk
    Co-->>C: 200 OK (streaming SSE)

    Note over Co: If load fails instead:
    Note over Co: RejectUnservableQueuedRequests<br/>→ immediate 429 (not 120s wait)
```

### Before: TUI model picker

```mermaid
flowchart TD
    A[User selects 12GB model ✓] --> B{Select 26GB model?}
    B -->|12 + 26 = 38 > 32 budget| C[❌ Blocked - won't fit]
    C --> D[User can only serve 1 model]
```

### After: TUI model picker

```mermaid
flowchart TD
    A[User selects 12GB model ✓] --> B{Select 26GB model?}
    B -->|26 ≤ 32 individually| C[✓ Selected]
    C --> D[Status: one model active at a time - swap on demand]
    D --> E[Both models registered with coordinator]
    E --> F[Coordinator manages warm/cold swaps]
```

---

## Before / After Table

### Model Selection (TUI Picker)

| | Before | After |
|---|--------|-------|
| Budget enforcement | All selected models must fit in memory **simultaneously** | Each model must **individually** fit; total can exceed RAM |
| 36GB machine, 12GB + 26GB | Blocked — `12 + 26 = 38 > 32` budget | Allowed — shows "one model active at a time (swap on demand)" |
| Status line | `"X GB used · Y GB remaining"` | `"X GB on disk · one model active at a time"` or `"all models can be served simultaneously"` |
| "Won't fit" warning | Based on remaining budget after other selections | Based on whether model individually exceeds machine RAM |
| Pre-selection | Largest downloaded model (even if exceeds RAM) | Largest downloaded model **that fits individually** |

### Coordinator Routing

| | Before | After |
|---|--------|-------|
| Cold provider admission | Rejected — `freeMemoryAdmits` saw GPU memory occupied by warm model | Admitted — checks if model individually fits in total RAM when provider is idle |
| Cold-start penalty | 2.5 seconds (unrealistic) | 30 seconds (matches real 15–60s swap time) |
| Idle warm slot penalty | `"idle"` fell through to `"unknown"` → 30s | `"idle"` treated as `"running"` → 0ms |
| Proactive model swap | None — cold models only loaded on direct request | `TriggerModelSwaps` sends `load_model` to idle cold providers when requests queue |
| Load deduplication | N/A | 2-min cooldown per `(provider, model)`, one provider per pass, per-provider pending check |
| Load failure handling | N/A | Keep cooldown (no retry storm), reject queued requests if no alternative provider |
| Load success handling | Wait up to 5s for next heartbeat | `MarkModelWarm` + `DrainQueuedRequestsForModel` immediately |
| Unservable model | Requests wait 120s queue timeout | `RejectUnservableQueuedRequests` — immediate 429 if no provider can serve |

### Provider State Tracking

| | Before | After |
|---|--------|-------|
| `WarmModels` on empty heartbeat | Never cleared (stale entries persist) | Always overwritten, including empty list |
| `CurrentModel` on nil heartbeat | Never cleared (stale model ID) | Cleared — prevents attestation hash mismatch |
| Warm detection for swap planning | Only checked status (offline/untrusted) | Full routing gates: trust, runtime, privacy, challenge freshness, catalog |
| BackendCapacity vs WarmModels | WarmModels could override crashed slots | BackendCapacity authoritative when present; WarmModels fallback for legacy only |
| Disconnect cleanup | `pendingModelLoads` leaked | Entries cleared by provider prefix on disconnect |

### Model Download Resume

| | Before | After |
|---|--------|-------|
| HTTP 206 handling | Deleted partial file, replaced with resumed bytes (corruption) | Appends resumed bytes to existing partial via `appendDownloadedRange` |
| Content-Range validation | None | Validates start offset matches partial file size |
| Missing/malformed Content-Range | N/A | Discards stale partial, replaces with server response |
| Test mock | No Content-Range header | Sends proper `Content-Range: bytes start-end/total` |

---

## Files changed (9)

| File | Lines | Change |
|------|-------|--------|
| `provider-swift/.../StartCommand.swift` | +50/-10 | TUI picker budget, status line, warnings, preselect guard |
| `provider-swift/.../ModelCatalog.swift` | +78/-22 | Download resume fix, Content-Range validation, `appendDownloadedRange` |
| `provider-swift/.../ModelCatalogTests.swift` | +6/-1 | Test mock sends Content-Range header |
| `coordinator/registry/registry.go` | +380/-7 | `SendLoadModel`, `TriggerModelSwaps`, `MarkModelWarm`, `RejectUnservableQueuedRequests`, `ClearPendingModelLoad`, `providerHasPendingLoad`, `pendingModelLoads`, heartbeat state fixes |
| `coordinator/registry/scheduler.go` | +38/-5 | `availableOnDisk`, `freeMemoryAdmits` cold path, `slotStatePenalty` idle/unknown, `DrainQueuedRequestsForModel` |
| `coordinator/registry/queue.go` | +38/-0 | `QueuedModels`, `FailQueuedRequestsForModel` |
| `coordinator/api/provider.go` | +15/-0 | `load_model_status` handler: success/failure paths |
| `coordinator/api/billing_handlers.go` | +2/-2 | gofmt (pre-existing) |
| `coordinator/payments/pricing_test.go` | +4/-4 | gofmt (pre-existing) |

## Testing
- All 13 Go coordinator test packages pass (0 failures)
- All 257 Swift provider tests pass across 20 suites
- E2E integration tests pass
- E2E benchmarks pass
- 3 adversarial review rounds + 2 verification rounds completed

## Deploy Order
1. **Coordinator first** — backward compatible with old providers (they already handle `load_model`)
2. **Provider second** — new TUI picker needs coordinator routing support to be useful