### PR TITLE
feat: trust_status message, auto-report, and MDM re-verification

### DIFF
--- a/coordinator/api/consumer_test.go
+++ b/coordinator/api/consumer_test.go
@@ -368,7 +368,7 @@ func TestStreamingE2E(t *testing.T) {
 					conn.Write(ctx, websocket.MessageText, respData)
 					continue
 				}
-				if msgType == protocol.TypeRuntimeStatus {
+				if msgType == protocol.TypeRuntimeStatus || msgType == protocol.TypeTrustStatus {
 					continue
 				}
 			}

--- a/coordinator/api/provider.go
+++ b/coordinator/api/provider.go
@@ -402,6 +402,7 @@ func (s *Server) applyACMETrust(providerID string, provider *registry.Provider, 
 	}
 
 	provider.SetAttested(true, registry.TrustHardware)
+	s.sendTrustStatus(provider, registry.TrustHardware, "online", "ACME device attestation verified")
 	s.logger.Info("ACME client cert verified — hardware trust via Apple SE attestation",
 		"provider_id", providerID,
 		"acme_serial", acmeResult.SerialNumber,
@@ -930,6 +931,22 @@ func (s *Server) verifyChallengeResponse(providerID string, provider *registry.P
 			"weight_hash", hash,
 		)
 	}
+
+	// Re-attempt MDM verification for self_signed providers. This handles
+	// providers that installed the MDM enrollment profile after their initial
+	// registration — they would otherwise stay at self_signed trust forever
+	// since verifyProviderViaMDM only ran once at registration time.
+	provider.Mu().Lock()
+	trustLevel := provider.TrustLevel
+	attestResult := provider.AttestationResult
+	provider.Mu().Unlock()
+
+	if trustLevel == registry.TrustSelfSigned && s.mdmClient != nil && attestResult != nil {
+		result := *attestResult
+		saferun.Go(s.logger, "retryMDMVerification", func() {
+			s.verifyProviderViaMDM(providerID, provider, result)
+		})
+	}
 }
 
 // handleChallengeFailure records a failed challenge and marks the provider
@@ -948,6 +965,9 @@ func (s *Server) handleChallengeFailure(providerID string, reason string) {
 	if failures >= registry.MaxFailedChallenges {
 		severity = protocol.SeverityError
 		s.registry.MarkUntrusted(providerID)
+		if p := s.registry.GetProvider(providerID); p != nil {
+			s.sendTrustStatus(p, p.TrustLevel, string(registry.StatusUntrusted), reason)
+		}
 	}
 	s.emit(context.Background(), severity, protocol.KindAttestationFailure,
 		"attestation challenge failed",
@@ -1443,6 +1463,7 @@ func (s *Server) verifyProviderAttestation(providerID string, provider *registry
 	}
 
 	provider.SetAttested(true, registry.TrustSelfSigned)
+	s.sendTrustStatus(provider, registry.TrustSelfSigned, "online", "SE attestation verified, awaiting MDM/ACME upgrade")
 
 	// The SE attestation already proves SIP, Secure Boot, and binary hash —
 	// the same checks a challenge re-verifies. Set LastChallengeVerified so
@@ -1559,6 +1580,7 @@ func (s *Server) verifyProviderViaMDM(providerID string, provider *registry.Prov
 
 	// MDM SecurityInfo verification passed — upgrade to hardware trust.
 	provider.SetAttested(true, registry.TrustHardware)
+	s.sendTrustStatus(provider, registry.TrustHardware, "online", "MDM verification passed")
 	s.logger.Info("MDM verification passed — upgraded to hardware trust",
 		"provider_id", providerID,
 		"serial_number", attestResult.SerialNumber,
@@ -1810,4 +1832,27 @@ func (s *Server) handleProviderAttestation(w http.ResponseWriter, r *http.Reques
 			"If verification passes, Apple has confirmed this is a real Apple device with the attested properties.",
 	}
 	writeJSON(w, http.StatusOK, resp)
+}
+
+// sendTrustStatus sends the provider its current trust level and status over
+// the WebSocket connection. This allows the provider to react — e.g. by
+// auto-reporting unified logs when it learns it is self_signed or untrusted.
+func (s *Server) sendTrustStatus(provider *registry.Provider, trustLevel registry.TrustLevel, status string, reason string) {
+	conn := provider.Conn
+	if conn == nil {
+		return
+	}
+	msg := protocol.TrustStatusMessage{
+		Type:       protocol.TypeTrustStatus,
+		TrustLevel: string(trustLevel),
+		Status:     status,
+		Reason:     reason,
+	}
+	data, err := json.Marshal(msg)
+	if err != nil {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_ = conn.Write(ctx, websocket.MessageText, data)
 }

--- a/coordinator/api/provider_test.go
+++ b/coordinator/api/provider_test.go
@@ -1908,7 +1908,7 @@ func TestTrustLevelInResponseHeaders(t *testing.T) {
 					conn.Write(ctx, websocket.MessageText, respData)
 					continue
 				}
-				if msgType == protocol.TypeRuntimeStatus {
+				if msgType == protocol.TypeRuntimeStatus || msgType == protocol.TypeTrustStatus {
 					continue
 				}
 			}

--- a/coordinator/protocol/messages.go
+++ b/coordinator/protocol/messages.go
@@ -44,6 +44,7 @@ const (
 	TypeAttestationChallenge = "attestation_challenge"
 	TypeRuntimeStatus        = "runtime_status"
 	TypeLoadModel            = "load_model"
+	TypeTrustStatus          = "trust_status"
 )
 
 // LoadModelStatus is the lifecycle state reported by a provider in response
@@ -350,6 +351,16 @@ type RuntimeMismatch struct {
 	Component string `json:"component"`
 	Expected  string `json:"expected"`
 	Got       string `json:"got"`
+}
+
+// TrustStatusMessage is sent by the coordinator to inform a provider of its
+// current trust level. Providers that learn they are "self_signed" or
+// "untrusted" can auto-report unified logs for troubleshooting.
+type TrustStatusMessage struct {
+	Type       string `json:"type"`
+	TrustLevel string `json:"trust_level"` // "none", "self_signed", "hardware"
+	Status     string `json:"status"`      // "online", "untrusted", etc.
+	Reason     string `json:"reason,omitempty"`
 }
 
 // ---------------------------------------------------------------------------

--- a/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClient.swift
+++ b/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClient.swift
@@ -21,6 +21,8 @@ public enum CoordinatorEvent: Sendable {
     /// (off-thread) and reply with a `loadModelStatus` outbound message
     /// when the load completes or fails.
     case loadModel(modelId: String)
+    /// Coordinator informs the provider of its current trust level and status.
+    case trustStatus(trustLevel: String, status: String, reason: String)
 }
 
 // MARK: - Shared State
@@ -568,6 +570,14 @@ public actor CoordinatorClient {
         case .loadModel(let load):
             logger.info("Received coordinator-driven preload for: \(load.modelId)")
             eventContinuation?.yield(.loadModel(modelId: load.modelId))
+
+        case .trustStatus(let ts):
+            logger.info("Trust status from coordinator: level=\(ts.trustLevel) status=\(ts.status) reason=\(ts.reason)")
+            eventContinuation?.yield(.trustStatus(
+                trustLevel: ts.trustLevel,
+                status: ts.status,
+                reason: ts.reason
+            ))
         }
     }
 

--- a/provider-swift/Sources/ProviderCore/Protocol/Messages.swift
+++ b/provider-swift/Sources/ProviderCore/Protocol/Messages.swift
@@ -461,6 +461,7 @@ public enum CoordinatorMessage: Sendable, Equatable {
     case attestationChallenge(AttestationChallenge)
     case runtimeStatus(RuntimeStatus)
     case loadModel(LoadModel)
+    case trustStatus(TrustStatus)
 
     public struct InferenceRequest: Sendable, Equatable {
         public var requestId: String
@@ -505,6 +506,20 @@ public enum CoordinatorMessage: Sendable, Equatable {
         public var modelId: String
         public init(modelId: String) { self.modelId = modelId }
     }
+
+    /// Coordinator informs the provider of its current trust level and status.
+    /// Providers that learn they are "self_signed" or "untrusted" can
+    /// auto-report unified logs for troubleshooting.
+    public struct TrustStatus: Sendable, Equatable {
+        public var trustLevel: String
+        public var status: String
+        public var reason: String
+        public init(trustLevel: String, status: String, reason: String = "") {
+            self.trustLevel = trustLevel
+            self.status = status
+            self.reason = reason
+        }
+    }
 }
 
 // MARK: - CoordinatorMessage Codable
@@ -516,6 +531,7 @@ extension CoordinatorMessage: Codable {
         case attestationChallenge = "attestation_challenge"
         case runtimeStatus = "runtime_status"
         case loadModel = "load_model"
+        case trustStatus = "trust_status"
     }
 
     enum CodingKeys: String, CodingKey {
@@ -526,6 +542,8 @@ extension CoordinatorMessage: Codable {
         case nonce, timestamp
         case verified, mismatches
         case modelId = "model_id"
+        case trustLevel = "trust_level"
+        case status, reason
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -557,6 +575,14 @@ extension CoordinatorMessage: Codable {
         case .loadModel(let l):
             try container.encode(TypeValue.loadModel, forKey: .type)
             try container.encode(l.modelId, forKey: .modelId)
+
+        case .trustStatus(let t):
+            try container.encode(TypeValue.trustStatus, forKey: .type)
+            try container.encode(t.trustLevel, forKey: .trustLevel)
+            try container.encode(t.status, forKey: .status)
+            if !t.reason.isEmpty {
+                try container.encode(t.reason, forKey: .reason)
+            }
         }
     }
 
@@ -592,6 +618,13 @@ extension CoordinatorMessage: Codable {
         case .loadModel:
             self = .loadModel(LoadModel(
                 modelId: try container.decode(String.self, forKey: .modelId)
+            ))
+
+        case .trustStatus:
+            self = .trustStatus(TrustStatus(
+                trustLevel: try container.decode(String.self, forKey: .trustLevel),
+                status: try container.decode(String.self, forKey: .status),
+                reason: try container.decodeIfPresent(String.self, forKey: .reason) ?? ""
             ))
         }
     }

--- a/provider-swift/Sources/ProviderCore/ProviderLoop.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop.swift
@@ -156,6 +156,13 @@ public actor ProviderLoop {
     /// Cached binary hash for attestation responses.
     private var binaryHash: String?
 
+    /// Whether we've already submitted an auto-report for this session.
+    /// Set to true after the first trust-triggered report to avoid spamming.
+    private var didAutoReport = false
+
+    /// Task for the delayed auto-report (10 minutes after learning trust status).
+    private var autoReportTask: Task<Void, Never>?
+
     /// Background task that periodically checks idle state and unloads
     /// the model when the timeout has elapsed. nil when disabled
     /// (`idleTimeoutMins == 0`) or before `run()` starts it.
@@ -368,6 +375,9 @@ public actor ProviderLoop {
 
                 case .loadModel(let modelId):
                     handleLoadModelRequest(modelId: modelId, send: send)
+
+                case .trustStatus(let trustLevel, let status, let reason):
+                    handleTrustStatus(trustLevel: trustLevel, status: status, reason: reason)
                 }
             }
         } onCancel: {
@@ -382,6 +392,8 @@ public actor ProviderLoop {
         capacityRefreshTask = nil
         autoUpdateTask?.cancel()
         autoUpdateTask = nil
+        autoReportTask?.cancel()
+        autoReportTask = nil
         let preloads = Array(preloadTasks.values)
         for task in preloads { task.cancel() }
         cancelLoadWaiters()
@@ -968,6 +980,113 @@ public actor ProviderLoop {
                 status: status,
                 error: error
             ))
+        }
+    }
+
+    // MARK: - Trust Status & Auto-Report
+
+    /// Handle a trust_status message from the coordinator. If the provider
+    /// learns it is self_signed or untrusted, schedule a one-time auto-report
+    /// of unified logs after 10 minutes.
+    private func handleTrustStatus(trustLevel: String, status: String, reason: String) {
+        logger.info("Trust status update: level=\(trustLevel) status=\(status) reason=\(reason)")
+
+        let needsReport = trustLevel == "self_signed" || status == "untrusted"
+        guard needsReport, !didAutoReport else {
+            // Already reported or trust is fine — cancel any pending report.
+            autoReportTask?.cancel()
+            autoReportTask = nil
+            return
+        }
+
+        // Schedule auto-report after 10 minutes. If the provider gets
+        // upgraded to hardware trust before that, the task is cancelled.
+        logger.warning("Provider is \(trustLevel)/\(status) — will auto-report logs in 10 minutes")
+        autoReportTask?.cancel()
+        autoReportTask = Task {
+            do {
+                try await Task.sleep(for: .seconds(600))
+            } catch {
+                return // cancelled (shutdown or trust upgraded)
+            }
+            guard !self.didAutoReport else { return }
+            self.didAutoReport = true
+            await self.submitAutoReport(trustLevel: trustLevel, status: status, reason: reason)
+        }
+    }
+
+    /// Collect and upload unified logs to the coordinator.
+    private func submitAutoReport(trustLevel: String, status: String, reason: String) async {
+        logger.info("Auto-reporting unified logs (trust=\(trustLevel), status=\(status))")
+
+        guard let serial = macHardwareSerialNumber(), !serial.isEmpty else {
+            logger.warning("Auto-report skipped: serial number unavailable")
+            return
+        }
+
+        // Collect last 24 hours of unified logs for our subsystem.
+        let logData: Data
+        do {
+            let process = Process()
+            process.executableURL = URL(fileURLWithPath: "/usr/bin/log")
+            process.arguments = [
+                "show",
+                "--predicate", "subsystem == \"dev.darkbloom.provider\"",
+                "--style", "ndjson",
+                "--info",
+                "--last", "24h",
+            ]
+            let pipe = Pipe()
+            process.standardOutput = pipe
+            process.standardError = FileHandle.nullDevice
+            try process.run()
+            logData = pipe.fileHandleForReading.readDataToEndOfFile()
+            process.waitUntilExit()
+        } catch {
+            logger.error("Auto-report: failed to collect logs: \(error)")
+            return
+        }
+
+        guard !logData.isEmpty else {
+            logger.warning("Auto-report: no logs found")
+            return
+        }
+
+        // Cap at 10 MB.
+        let cappedData = logData.count > 10 * 1024 * 1024
+            ? logData.prefix(10 * 1024 * 1024)
+            : logData
+
+        // Upload to coordinator.
+        let httpBase = coordinatorHTTPBase(loopConfig.coordinatorURL)
+        let urlString = "\(httpBase)/v1/provider/log-report?serial=\(serial)"
+        guard let url = URL(string: urlString) else {
+            logger.error("Auto-report: invalid URL: \(urlString)")
+            return
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/octet-stream", forHTTPHeaderField: "Content-Type")
+        request.httpBody = Data(cappedData)
+        request.timeoutInterval = 60
+
+        if let token = AuthTokenStore.load() {
+            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
+
+        do {
+            let (_, response) = try await URLSession.shared.data(for: request)
+            if let httpResp = response as? HTTPURLResponse {
+                if httpResp.statusCode == 201 {
+                    let sizeMB = Double(cappedData.count) / 1_048_576.0
+                    logger.info("Auto-report uploaded successfully (\(String(format: "%.1f", sizeMB)) MB)")
+                } else {
+                    logger.warning("Auto-report upload returned HTTP \(httpResp.statusCode)")
+                }
+            }
+        } catch {
+            logger.warning("Auto-report upload failed: \(error)")
         }
     }
 


### PR DESCRIPTION
## Problem

Three issues preventing providers from being routable:

1. **Providers are blind to their trust status.** The coordinator never tells a provider if it's `self_signed` or `untrusted`. The provider just silently stops receiving requests with no way to diagnose why.

2. **MDM verification only runs once at registration.** If a provider installs the MDM enrollment profile after connecting, it stays at `self_signed` forever until it disconnects and reconnects.

3. **No automatic log collection for stuck providers.** When providers are stuck at degraded trust, the only way to debug is to manually SSH in and run `log show`.

## Changes

### 1. `trust_status` WebSocket message (coordinator → provider)

New protocol message sent at three decision points:
- After SE attestation verifies → `self_signed`
- After MDM/ACME upgrades → `hardware`
- After `MarkUntrusted` (challenge failure threshold)

The provider now knows its own trust level and can react.

### 2. Provider auto-report on degraded trust

When the provider receives `trust_status` with `self_signed` or `untrusted`:
- Logs a warning
- Schedules a one-time auto-report after **10 minutes**
- Collects 24h of `dev.darkbloom.provider` unified logs
- Uploads to `POST /v1/provider/log-report`
- Cancelled if trust is upgraded before the 10-min window
- `didAutoReport` flag ensures it only fires **once per session**

### 3. MDM re-verification in the challenge loop

After a successful attestation challenge, if the provider is still `self_signed` and MDM is configured, re-attempt `verifyProviderViaMDM`. This means providers that install MDM after registration get upgraded to `hardware` trust on the next challenge cycle (~5 minutes) instead of being stuck forever.

## Files Changed

| File | Changes |
|------|---------|
| `coordinator/protocol/messages.go` | `TypeTrustStatus` + `TrustStatusMessage` struct |
| `coordinator/api/provider.go` | `sendTrustStatus` helper, calls at attestation/MDM/untrusted points, MDM re-verify in challenge success |
| `coordinator/api/provider_test.go` | Handle `trust_status` in test provider goroutine |
| `coordinator/api/consumer_test.go` | Same |
| `provider-swift/.../Messages.swift` | `TrustStatus` struct + Codable |
| `provider-swift/.../CoordinatorClient.swift` | `.trustStatus` event |
| `provider-swift/.../ProviderLoop.swift` | `handleTrustStatus`, 10-min delayed auto-report |

## Testing

- `go test ./...` — 12/12 packages pass
- `swift test` — 257/257 tests pass
- `gofmt` — clean

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/233"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782520027&installation_id=133247490&pr_number=233&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F233&signature=f4667fb2877dcdce21be75933dad4482bfddc9250ba10325d1a4ffaffa712030"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->