### PR TITLE
fix(provider-swift): map defective chat-template render to 422, not cascading 500 (#242)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,10 @@
 - mlx-swift-lm double buffering, UInt32 token tensors. `56b050b4`
 - Release-mode BatchGenerator B=4 matches mlx_lm Python reference (Qwen: ~1130 vs 1119 tok/s; Gemma: ~186 vs 181 tok/s). `56b050b4`
 
+#### Bug Fixes
+
+- **Chat-template render failures return 422 instead of cascading 500** (#242) -- A defective `chat_template.jinja` (e.g. `mlx-community/gemma-4-26b-a4b-it-8bit`'s `X | upper` on an `Undefined` value when tool definitions are present) throws `upper filter requires string` under swift-jinja, where CPython's permissive jinja2 silently passes. `MultiModelBatchSchedulerEngine.streamChatCompletion`/`applyTemplate` now wrap the render error into the typed `MultiModelBatchSchedulerEngineError.templateRenderingFailed`, which `mapInferenceErrorToStatus` maps to 422 -- so the provider is no longer misread as faulty and rerouted into a cascading `model load failed`.
+
 ---
 
 ### Console UI

--- a/provider-swift/Sources/ProviderCore/Inference/MultiModelBatchSchedulerEngine.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/MultiModelBatchSchedulerEngine.swift
@@ -168,9 +168,20 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
             promptTokens = try tokenizer.inner.applyChatTemplate(
                 messages: messages, tools: toolSpecs, additionalContext: nil
             )
-        } catch {
+        } catch let error as MultiModelBatchSchedulerEngineError {
             await releaseBox.fire()
             throw error
+        } catch {
+            // #242: a defective `chat_template.jinja` (e.g. gemma-4-26b's
+            // `X | upper` on an Undefined value when tools are present)
+            // throws inside swift-jinja. Wrap it as a typed, request-shaped
+            // 422 instead of letting the raw render error fall through to a
+            // generic 500 that the coordinator misreads as a provider fault
+            // and reroutes into a cascading `model load failed`.
+            await releaseBox.fire()
+            throw MultiModelBatchSchedulerEngineError.templateRenderingFailed(
+                "chat template failed to render request: \(error.localizedDescription)"
+            )
         }
 
         let maxTokens = request.maxTokens ?? defaultMaxTokens
@@ -321,11 +332,23 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
         let tokenizer = try await resolveTokenizer(modelId: request.model)
         let messages = request.messages.map { $0.templateMessageDict() }
         let tools = request.tools?.map { $0.toolSpec() }
-        let tokens = try tokenizer.inner.applyChatTemplate(
-            messages: messages,
-            tools: tools,
-            additionalContext: nil
-        )
+        let tokens: [Int]
+        do {
+            tokens = try tokenizer.inner.applyChatTemplate(
+                messages: messages,
+                tools: tools,
+                additionalContext: nil
+            )
+        } catch let error as MultiModelBatchSchedulerEngineError {
+            throw error
+        } catch {
+            // #242: same defensive wrap as `streamChatCompletion` so a
+            // template that throws on tool definitions surfaces as a clean
+            // 422 from `/apply-template` rather than a generic 500.
+            throw MultiModelBatchSchedulerEngineError.templateRenderingFailed(
+                "chat template failed to render request: \(error.localizedDescription)"
+            )
+        }
         return TokenizeResponse(tokens: tokens)
     }
 

--- a/provider-swift/Sources/ProviderCore/Inference/MultiModelBatchSchedulerEngine.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/MultiModelBatchSchedulerEngine.swift
@@ -168,9 +168,19 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
             promptTokens = try tokenizer.inner.applyChatTemplate(
                 messages: messages, tools: toolSpecs, additionalContext: nil
             )
-        } catch let error as MultiModelBatchSchedulerEngineError {
+        } catch let MultiModelBatchSchedulerEngineError.templateRenderingFailed(message) {
+            // Trust boundary (review #248): only `.templateRenderingFailed`
+            // is passed through unchanged, to avoid double-wrapping its
+            // message. We deliberately do NOT pass through every typed
+            // engine error — the tokenizer is a distinct trust domain from
+            // the scheduler, so scheduler-origin admission errors
+            // (`queueFull`, `tokenBudgetExhausted`, `requestRejected`, ...)
+            // cannot originate here. Any other failure out of this render
+            // block is, by construction, a template problem and is wrapped
+            // below — so a future typed error thrown from the tokenizer
+            // path can't silently slip out with the wrong status code.
             await releaseBox.fire()
-            throw error
+            throw MultiModelBatchSchedulerEngineError.templateRenderingFailed(message)
         } catch {
             // #242: a defective `chat_template.jinja` (e.g. gemma-4-26b's
             // `X | upper` on an Undefined value when tools are present)
@@ -339,8 +349,11 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
                 tools: tools,
                 additionalContext: nil
             )
-        } catch let error as MultiModelBatchSchedulerEngineError {
-            throw error
+        } catch let MultiModelBatchSchedulerEngineError.templateRenderingFailed(message) {
+            // Trust boundary (review #248): only pass `.templateRenderingFailed`
+            // through unchanged; any other failure from this render block is
+            // wrapped below. See the matching note in `streamChatCompletion`.
+            throw MultiModelBatchSchedulerEngineError.templateRenderingFailed(message)
         } catch {
             // #242: same defensive wrap as `streamChatCompletion` so a
             // template that throws on tool definitions surfaces as a clean

--- a/provider-swift/Sources/ProviderCore/Inference/MultiModelBatchSchedulerEngineError.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/MultiModelBatchSchedulerEngineError.swift
@@ -45,6 +45,21 @@ public enum MultiModelBatchSchedulerEngineError: Error, LocalizedError, Equatabl
     /// example a future "request_rejected: ..." path). Surfaces as
     /// 503 — the request was not run and the client may safely retry.
     case requestRejected(String)
+    /// The model's chat template (`chat_template.jinja`) threw while
+    /// rendering the request — e.g. a defective template that fails
+    /// inside a Jinja filter when tool definitions are present.
+    ///
+    /// Issue #242: `mlx-community/gemma-4-26b-a4b-it-8bit` renders
+    /// `X | upper` against an `Undefined` value, which CPython's
+    /// permissive jinja2 swallows but swift-jinja rejects with
+    /// `upper filter requires string`. Without this case the raw render
+    /// error fell through ``ProviderLoop/mapInferenceErrorToStatus(_:)``
+    /// to a generic 500, which the coordinator reads as a provider fault
+    /// and reroutes — turning a deterministic, request-shaped failure
+    /// into a cascading `model load failed` across every provider. This
+    /// is a model/request-shape problem, not a transient capacity fault,
+    /// so it surfaces as 422 and the provider stays healthy.
+    case templateRenderingFailed(String)
 
     public var errorDescription: String? {
         switch self {
@@ -61,6 +76,8 @@ public enum MultiModelBatchSchedulerEngineError: Error, LocalizedError, Equatabl
         case .queueFull(let message):
             return message
         case .requestRejected(let message):
+            return message
+        case .templateRenderingFailed(let message):
             return message
         }
     }

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+ErrorMapping.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+ErrorMapping.swift
@@ -52,6 +52,13 @@ extension ProviderLoop {
                 return 503
             case .requestRejected:
                 return 503
+            case .templateRenderingFailed:
+                // #242: a chat template that throws while rendering the
+                // request (e.g. a defective `X | upper` filter on tool
+                // definitions) is unprocessable for this model, not a
+                // provider fault. 422 keeps the provider healthy instead
+                // of triggering a reroute + cascading `model load failed`.
+                return 422
             case .generationFailed:
                 return 500
             }

--- a/provider-swift/Tests/ProviderCoreTests/MultiModelBatchSchedulerEngineTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/MultiModelBatchSchedulerEngineTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import MLXLMCommon
 import MLXLMServer
 import Testing
 @testable import ProviderCore
@@ -244,9 +245,109 @@ func invalidRoleMapsToBadRequest() {
     #expect(ProviderLoop.mapInferenceErrorToStatus(err) == 400)
 }
 
+// MARK: - Chat-template render failures (#242)
+//
+// A defective `chat_template.jinja` (e.g. gemma-4-26b's `X | upper` on
+// an Undefined value when tool definitions are present) throws inside
+// swift-jinja. Before #242 that raw error fell through
+// `mapInferenceErrorToStatus` to a generic 500, which the coordinator
+// reads as a provider fault and reroutes — cascading into a
+// `model load failed` across every provider. The engine now wraps the
+// render failure into `.templateRenderingFailed` so it surfaces as a
+// clean, request-shaped 422 and the provider stays healthy.
+
+@Test("templateRenderingFailed maps to 422 (#242)")
+func templateRenderingFailedMapsToUnprocessable() {
+    let err = MultiModelBatchSchedulerEngineError.templateRenderingFailed(
+        "chat template failed to render request: upper filter requires string"
+    )
+    #expect(ProviderLoop.mapInferenceErrorToStatus(err) == 422)
+}
+
+@Test("templateRenderingFailed preserves the underlying render message")
+func templateRenderingFailedPreservesMessage() {
+    let err = MultiModelBatchSchedulerEngineError.templateRenderingFailed(
+        "upper filter requires string"
+    )
+    #expect(err.errorDescription == "upper filter requires string",
+        "verbatim render error must be preserved for operator debugging")
+}
+
+@Test("applyTemplate with tool definitions wraps a throwing template into .templateRenderingFailed (422) (#242)")
+func applyTemplateWrapsTemplateRenderFailureAs422() async throws {
+    // Drive the render path through `applyTemplate`'s tokenizer-provider
+    // (no live model / scheduler needed). The fake tokenizer reproduces
+    // the swift-jinja `upper filter requires string` failure that
+    // gemma-4-26b throws when tool definitions are present.
+    let engine = MultiModelBatchSchedulerEngine(
+        acquire: { _ in
+            throw MultiModelBatchSchedulerEngineError.modelNotLoaded("unused-in-this-test")
+        },
+        tokenizerProvider: { _ in TokenizerHandle(ThrowingTemplateTokenizer()) },
+        availableModels: { [] }
+    )
+
+    let request = ApplyTemplateRequest(
+        model: "mlx-community/gemma-4-26b-a4b-it-8bit",
+        messages: [.init(role: .user, content: .text("What's the weather in NYC?"))],
+        tools: [
+            OpenAITool(function: OpenAIFunctionDefinition(
+                name: "get_weather",
+                description: "Look up the current weather for a city",
+                parameters: nil
+            ))
+        ]
+    )
+
+    do {
+        _ = try await engine.applyTemplate(request)
+        Issue.record("expected applyTemplate to throw for a defective chat template")
+    } catch let error as MultiModelBatchSchedulerEngineError {
+        guard case .templateRenderingFailed(let message) = error else {
+            Issue.record("expected .templateRenderingFailed, got \(error)")
+            return
+        }
+        #expect(message.contains("upper filter requires string"),
+            "underlying swift-jinja error must be preserved for operator debugging")
+        #expect(ProviderLoop.mapInferenceErrorToStatus(error) == 422,
+            "#242: a defective chat template is unprocessable (422), not a provider fault (500)")
+    }
+}
+
 // MARK: - Helpers
 
 private actor Counter {
     private(set) var value: Int = 0
     func increment() { value += 1 }
+}
+
+/// Error mirroring the swift-jinja render failure surfaced by a
+/// defective `chat_template.jinja` (issue #242).
+private struct FakeJinjaRenderError: Error, LocalizedError {
+    let message: String
+    var errorDescription: String? { message }
+}
+
+/// Minimal `MLXLMCommon.Tokenizer` whose `applyChatTemplate` always
+/// throws — mirrors `LocalTokenizerBridge`'s conformance surface but
+/// reproduces the gemma-4-26b template render failure. Only the
+/// `applyChatTemplate(messages:tools:additionalContext:)` overload is a
+/// protocol requirement; the `chatTemplate:`-string overloads have
+/// default implementations.
+private struct ThrowingTemplateTokenizer: MLXLMCommon.Tokenizer {
+    func encode(text: String, addSpecialTokens: Bool) -> [Int] { [] }
+    func decode(tokenIds: [Int], skipSpecialTokens: Bool) -> String { "" }
+    func convertTokenToId(_ token: String) -> Int? { nil }
+    func convertIdToToken(_ id: Int) -> String? { nil }
+    var bosToken: String? { nil }
+    var eosToken: String? { nil }
+    var unknownToken: String? { nil }
+
+    func applyChatTemplate(
+        messages: [[String: any Sendable]],
+        tools: [[String: any Sendable]]?,
+        additionalContext: [String: any Sendable]?
+    ) throws -> [Int] {
+        throw FakeJinjaRenderError(message: "upper filter requires string")
+    }
 }


### PR DESCRIPTION
## What

Fixes the `500 upper filter requires string` thrown by `provider-swift` whenever a request carrying **tool definitions** is routed to a model whose `chat_template.jinja` is not portable to swift-jinja — specifically `mlx-community/gemma-4-26b-a4b-it-8bit` (#242).

## Why

The model's `chat_template.jinja` renders `X | upper` against an `Undefined`/`None` value. CPython's jinja2 (used by oMLX and other backends) is permissive and propagates `Undefined`/`""` through the filter, so the template "works" everywhere else. swift-jinja is stricter and raises `upper filter requires string`.

The render happens inside `MultiModelBatchSchedulerEngine.streamChatCompletion` (and `applyTemplate`), which **rethrew the raw error verbatim**. It then fell through `mapInferenceErrorToStatus` to a generic **500**. The coordinator reads a 500 as a provider fault and reroutes the request — so a deterministic, request-shaped failure turns into a cascading `model load failed` across every provider serving the model, impacting all agent harnesses that send tools.

## What this PR changes (provider-side defensive guard — the "should" item in the issue)

- **New typed error** `MultiModelBatchSchedulerEngineError.templateRenderingFailed(String)`.
- **Defensive `try/catch`** around `applyChatTemplate` in both `streamChatCompletion` and `applyTemplate`: any non-typed render failure is wrapped into `.templateRenderingFailed` (the verbatim underlying message is preserved for operator debugging); already-typed engine errors pass through unchanged.
- **Status mapping** `.templateRenderingFailed → 422` in `ProviderLoop+ErrorMapping`. A 422 fails the request cleanly without marking the provider faulty or triggering a reroute.
- **Tests** (`MultiModelBatchSchedulerEngineTests`): the 422 mapping, verbatim-message preservation, and a tokenizer-driven `applyTemplate` test that sends a tool definition and asserts the swift-jinja failure surfaces as `.templateRenderingFailed` → 422 (no live model required).
- CHANGELOG entry under Provider (Swift) → Bug Fixes.

## Remaining items from the issue (NOT in this PR — they are publish/infra, not repo code)

These require artifacts/access outside this repo and the actual re-vended template:

- [ ] **Patch `chat_template.jinja`** — replace `X | upper` with `(X | default('')) | upper` throughout. The template is not in this repo; it ships inside the model snapshot on R2.
- [ ] **Re-vend the patched template from a new R2 prefix.**
- [ ] **Bump `aggregate_sha256` in the coordinator catalog** — this lives in the `model_versions` Postgres table (`r2_prefix` + `aggregate_sha256`), populated at publish time, not in a static repo file. It must be set to the real digest produced by the re-vend.
- [ ] (Optional) Upstream the template patch to `mlx-community/gemma-4-26b-a4b-it-8bit`.

Once the patched template is re-vended, the 422 guard here remains valuable as defense-in-depth against any future non-portable template.

## Verification note

`provider-swift` is a macOS/MLX Swift package and its dependencies (`MLXLMServer`, `mlx-swift-lm`) do not build in this Linux CI sandbox, so I could not run `swift test` here. The new tests are written against the verified upstream type signatures (`ApplyTemplateRequest`, `OpenAITool`, `MLXLMCommon.Tokenizer`) and mirror existing test patterns; please confirm they pass in the macOS test job.

Resolves #242 (provider-side guard).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/248"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782666937&installation_id=133247490&pr_number=248&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F248&signature=f563baf2549a487494101f2a2750cad4064de311a22b582c78c81853d933f379"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->