### PR TITLE
fix(provider): decode Gemma tool-call arguments before chat-template rendering (#249)

### DIFF
--- a/provider-swift/Sources/ProviderCore/Inference/MultiModelBatchSchedulerEngine+Translation.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/MultiModelBatchSchedulerEngine+Translation.swift
@@ -90,7 +90,11 @@ extension OpenAIChatMessage {
                     "type": call.type,
                     "function": [
                         "name": call.function.name,
-                        "arguments": call.function.arguments,
+                        // Decode the JSON-string arguments into an object so the
+                        // chat template renders the `is mapping` branch. See
+                        // `decodeToolCallArguments` for why a raw string corrupts
+                        // Gemma multi-turn tool calls (double-brace rendering).
+                        "arguments": decodeToolCallArguments(call.function.arguments),
                     ] as [String: any Sendable],
                 ]
             }

--- a/provider-swift/Sources/ProviderCore/Inference/MultiModelBatchSchedulerEngine+Translation.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/MultiModelBatchSchedulerEngine+Translation.swift
@@ -90,10 +90,7 @@ extension OpenAIChatMessage {
                     "type": call.type,
                     "function": [
                         "name": call.function.name,
-                        // Decode the JSON-string arguments into an object so the
-                        // chat template renders the `is mapping` branch. See
-                        // `decodeToolCallArguments` for why a raw string corrupts
-                        // Gemma multi-turn tool calls (double-brace rendering).
+                        // Decode to an object so the chat template renders tool calls correctly (#249).
                         "arguments": decodeToolCallArguments(call.function.arguments),
                     ] as [String: any Sendable],
                 ]

--- a/provider-swift/Tests/ProviderCoreTests/GemmaToolCallLiveTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/GemmaToolCallLiveTests.swift
@@ -1,0 +1,218 @@
+// Copyright © 2026 Eigen Labs Inc.
+//
+// Live, end-to-end proof for issue #249 against the real
+// `mlx-community/gemma-4-26b-a4b-it-8bit` model + its real downloaded
+// `chat_template.jinja` (rendered by swift-jinja).
+//
+// Gated:
+//   DARKBLOOM_LIVE_MLX_TESTS=1 DARKBLOOM_LIVE_MLX_GEMMA=1
+//   (generation additionally needs mlx.metallib — set MLX_METALLIB_SOURCE
+//    or have it under .build; see LiveInferenceFixtures).
+
+import Foundation
+import MLX
+import MLXLLM
+import MLXLMCommon
+import MLXLMServer
+import Testing
+import Tokenizers
+
+@testable import ProviderCore
+
+@Suite("issue #249: Gemma multi-turn tool-calling against the real model", .serialized)
+struct GemmaToolCallLiveTests {
+
+    // MARK: - Scenario
+
+    /// run_terminal tool spec in the shape the chat template + parser expect.
+    private var toolSpecs: [[String: any Sendable]] {
+        [[
+            "type": "function",
+            "function": [
+                "name": "run_terminal",
+                "description": "Run a shell command and return its stdout.",
+                "parameters": [
+                    "type": "object",
+                    "properties": [
+                        "command": [
+                            "type": "string",
+                            "description": "The shell command to run.",
+                        ] as [String: any Sendable]
+                    ] as [String: any Sendable],
+                    "required": ["command"],
+                ] as [String: any Sendable],
+            ] as [String: any Sendable],
+        ]]
+    }
+
+    private let systemPrompt =
+        "You are a terminal assistant. You have one tool, run_terminal(command), "
+        + "which runs a shell command and returns its stdout. Always call the tool "
+        + "to inspect files; never guess file contents."
+
+    /// The multi-turn history that triggers the bug: a prior, well-formed
+    /// assistant `tool_calls` step (OpenAI shape — arguments is a JSON string),
+    /// its `tool` result, then a fresh user turn that should produce a second
+    /// tool call.
+    private func conversation() -> [OpenAIChatMessage] {
+        [
+            OpenAIChatMessage(role: .system, content: .text(systemPrompt)),
+            OpenAIChatMessage(role: .user, content: .text("List the files here.")),
+            OpenAIChatMessage(
+                role: .assistant,
+                content: .text(""),
+                toolCalls: [
+                    OpenAIToolCall(
+                        id: "call_1",
+                        function: .init(name: "run_terminal", arguments: #"{"command":"ls -la"}"#)
+                    )
+                ]
+            ),
+            OpenAIChatMessage(
+                role: .tool,
+                content: .text("total 8\n-rw-r--r--  1 user  staff  12 hello.txt"),
+                toolCallID: "call_1"
+            ),
+            OpenAIChatMessage(role: .user, content: .text("Print the contents of hello.txt")),
+        ]
+    }
+
+    /// Hand-built message dicts identical to `templateMessageDict()` output but
+    /// with the prior tool call's arguments left as the raw OpenAI JSON *string*
+    /// — i.e. the pre-fix behavior, used to demonstrate the double brace.
+    private func rawStringDicts() -> [[String: any Sendable]] {
+        let assistant: [String: any Sendable] = [
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                [
+                    "id": "call_1",
+                    "type": "function",
+                    "function": [
+                        "name": "run_terminal",
+                        "arguments": #"{"command":"ls -la"}"#,  // raw string == pre-fix
+                    ] as [String: any Sendable],
+                ] as [String: any Sendable]
+            ] as [[String: any Sendable]],
+        ]
+        return [
+            ["role": "system", "content": systemPrompt],
+            ["role": "user", "content": "List the files here."],
+            assistant,
+            [
+                "role": "tool", "content": "total 8\n-rw-r--r--  1 user  staff  12 hello.txt",
+                "tool_call_id": "call_1",
+            ],
+            ["role": "user", "content": "Print the contents of hello.txt"],
+        ]
+    }
+
+    // MARK: - A. Prompt rendering against the REAL template (no GPU needed)
+
+    @Test(
+        "real Gemma template: fixed translation renders single brace, raw string double-braces",
+        .enabled(if: LiveInferenceFixtures.gemmaTestsEnabled)
+    )
+    func realTemplateRendersSingleBrace() async throws {
+        guard let dir = ModelScanner.resolveLocalPath(modelID: LiveInferenceFixtures.gemmaModelID)
+        else {
+            Issue.record("gemma model not in local cache")
+            return
+        }
+        let tokenizer = try await LocalTokenizerLoader().load(from: dir)
+
+        // FIXED path: the production code under test.
+        let fixedDicts = conversation().map { $0.templateMessageDict() }
+        let fixedIDs = try tokenizer.applyChatTemplate(
+            messages: fixedDicts, tools: toolSpecs, additionalContext: nil)
+        let fixedPrompt = tokenizer.decode(tokenIds: fixedIDs, skipSpecialTokens: false)
+
+        // PRE-FIX path: arguments forwarded as the raw JSON string.
+        let buggyIDs = try tokenizer.applyChatTemplate(
+            messages: rawStringDicts(), tools: toolSpecs, additionalContext: nil)
+        let buggyPrompt = tokenizer.decode(tokenIds: buggyIDs, skipSpecialTokens: false)
+
+        print("\n=== issue #249: rendered prior tool_call (FIXED) ===")
+        print(snippet(fixedPrompt, around: "call:run_terminal"))
+        print("=== rendered prior tool_call (RAW STRING / pre-fix) ===")
+        print(snippet(buggyPrompt, around: "call:run_terminal"))
+        print("====================================================\n")
+
+        // Pre-fix double brace is present...
+        #expect(buggyPrompt.contains(#"{{"command""#))
+        // ...and the fix removes it, emitting the mapping branch instead.
+        #expect(!fixedPrompt.contains(#"{{"command""#))
+        #expect(fixedPrompt.contains("call:run_terminal{command:"))
+    }
+
+    // MARK: - B. Real generation on the real model (needs metallib + ~28 GB)
+
+    @Test(
+        "real Gemma generation: multi-turn tool call comes back clean",
+        .enabled(if: LiveInferenceFixtures.gemmaTestsEnabled)
+    )
+    func realModelEmitsCleanToolCall() async throws {
+        let loaded: (scheduler: BatchScheduler, container: ModelContainer, modelDirectory: URL)
+        do {
+            loaded = try await LiveInferenceFixtures.loadScheduler(
+                modelID: LiveInferenceFixtures.gemmaModelID,
+                maxConcurrentRequests: 2,
+                memoryBudgetBytes: 64 * 1024 * 1024 * 1024
+            )
+        } catch let skip as LiveFixtureSkip {
+            Issue.record("skipping: \(skip)")
+            return
+        }
+        let scheduler = loaded.scheduler
+        defer { Task { await scheduler.unloadModel() } }
+
+        // Build the prompt via the production translation (templateMessageDict).
+        let dicts = conversation().map { $0.templateMessageDict() }
+        let promptTokens: [Int] = try await loaded.container.perform { ctx in
+            try ctx.tokenizer.applyChatTemplate(
+                messages: dicts, tools: toolSpecs, additionalContext: nil)
+        }
+
+        var text = ""
+        let stream = await scheduler.submitTokenized(
+            promptTokens: promptTokens, maxTokens: 96, temperature: 0.0)
+        for await event in stream {
+            switch event {
+            case .chunk(let t): text += t
+            case .info, .error: break
+            }
+        }
+
+        print("\n=== issue #249: real Gemma generation (raw) ===\n\(text)\n===========================\n")
+
+        // No double-brace poison in the generated tool call.
+        #expect(!text.contains("{{"))
+
+        // Parse the tool call the same way the server does.
+        let parsed = GemmaFunctionParser().parse(content: text, tools: toolSpecs)
+        let call = try #require(parsed, "model did not emit a parseable Gemma tool call")
+        #expect(call.function.name == "run_terminal")
+
+        // The corruption symptom is a key like `{"command"` (object split at the
+        // first colon). Assert every key is clean.
+        for key in call.function.arguments.keys {
+            #expect(!key.hasPrefix("{"), "corrupted key: \(key)")
+            #expect(!key.contains("\""), "corrupted key: \(key)")
+        }
+        #expect(call.function.arguments["command"] != nil, "expected a clean `command` argument")
+        if case .string(let cmd)? = call.function.arguments["command"] {
+            print("=== parsed tool call: run_terminal(command: \(cmd)) ===")
+            #expect(cmd.contains("hello.txt"))
+        }
+    }
+
+    // MARK: - helpers
+
+    /// A readable window of `text` centered on the first occurrence of `needle`.
+    private func snippet(_ text: String, around needle: String, pad: Int = 60) -> String {
+        guard let r = text.range(of: needle) else { return "(\(needle) not found)" }
+        let lo = text.index(r.lowerBound, offsetBy: -pad, limitedBy: text.startIndex) ?? text.startIndex
+        let hi = text.index(r.upperBound, offsetBy: pad, limitedBy: text.endIndex) ?? text.endIndex
+        return String(text[lo..<hi])
+    }
+}

--- a/provider-swift/Tests/ProviderCoreTests/GemmaToolCallLiveTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/GemmaToolCallLiveTests.swift
@@ -1,13 +1,7 @@
 // Copyright © 2026 Eigen Labs Inc.
 //
-// Live, end-to-end proof for issue #249 against the real
-// `mlx-community/gemma-4-26b-a4b-it-8bit` model + its real downloaded
-// `chat_template.jinja` (rendered by swift-jinja).
-//
-// Gated:
-//   DARKBLOOM_LIVE_MLX_TESTS=1 DARKBLOOM_LIVE_MLX_GEMMA=1
-//   (generation additionally needs mlx.metallib — set MLX_METALLIB_SOURCE
-//    or have it under .build; see LiveInferenceFixtures).
+// Live end-to-end coverage for #249 against the real gemma-4-26b model.
+// Gated by DARKBLOOM_LIVE_MLX_TESTS=1 + DARKBLOOM_LIVE_MLX_GEMMA=1.
 
 import Foundation
 import MLX
@@ -24,7 +18,6 @@ struct GemmaToolCallLiveTests {
 
     // MARK: - Scenario
 
-    /// run_terminal tool spec in the shape the chat template + parser expect.
     private var toolSpecs: [[String: any Sendable]] {
         [[
             "type": "function",
@@ -50,10 +43,7 @@ struct GemmaToolCallLiveTests {
         + "which runs a shell command and returns its stdout. Always call the tool "
         + "to inspect files; never guess file contents."
 
-    /// The multi-turn history that triggers the bug: a prior, well-formed
-    /// assistant `tool_calls` step (OpenAI shape — arguments is a JSON string),
-    /// its `tool` result, then a fresh user turn that should produce a second
-    /// tool call.
+    /// Multi-turn history with a prior tool call, its result, and a new user turn.
     private func conversation() -> [OpenAIChatMessage] {
         [
             OpenAIChatMessage(role: .system, content: .text(systemPrompt)),
@@ -77,9 +67,8 @@ struct GemmaToolCallLiveTests {
         ]
     }
 
-    /// Hand-built message dicts identical to `templateMessageDict()` output but
-    /// with the prior tool call's arguments left as the raw OpenAI JSON *string*
-    /// — i.e. the pre-fix behavior, used to demonstrate the double brace.
+    /// Same history but with the prior tool call's arguments left as a raw JSON
+    /// string (the pre-fix shape).
     private func rawStringDicts() -> [[String: any Sendable]] {
         let assistant: [String: any Sendable] = [
             "role": "assistant",
@@ -107,7 +96,7 @@ struct GemmaToolCallLiveTests {
         ]
     }
 
-    // MARK: - A. Prompt rendering against the REAL template (no GPU needed)
+    // MARK: - Prompt rendering
 
     @Test(
         "real Gemma template: fixed translation renders single brace, raw string double-braces",
@@ -121,13 +110,11 @@ struct GemmaToolCallLiveTests {
         }
         let tokenizer = try await LocalTokenizerLoader().load(from: dir)
 
-        // FIXED path: the production code under test.
         let fixedDicts = conversation().map { $0.templateMessageDict() }
         let fixedIDs = try tokenizer.applyChatTemplate(
             messages: fixedDicts, tools: toolSpecs, additionalContext: nil)
         let fixedPrompt = tokenizer.decode(tokenIds: fixedIDs, skipSpecialTokens: false)
 
-        // PRE-FIX path: arguments forwarded as the raw JSON string.
         let buggyIDs = try tokenizer.applyChatTemplate(
             messages: rawStringDicts(), tools: toolSpecs, additionalContext: nil)
         let buggyPrompt = tokenizer.decode(tokenIds: buggyIDs, skipSpecialTokens: false)
@@ -138,14 +125,12 @@ struct GemmaToolCallLiveTests {
         print(snippet(buggyPrompt, around: "call:run_terminal"))
         print("====================================================\n")
 
-        // Pre-fix double brace is present...
         #expect(buggyPrompt.contains(#"{{"command""#))
-        // ...and the fix removes it, emitting the mapping branch instead.
         #expect(!fixedPrompt.contains(#"{{"command""#))
         #expect(fixedPrompt.contains("call:run_terminal{command:"))
     }
 
-    // MARK: - B. Real generation on the real model (needs metallib + ~28 GB)
+    // MARK: - Generation
 
     @Test(
         "real Gemma generation: multi-turn tool call comes back clean",
@@ -166,7 +151,6 @@ struct GemmaToolCallLiveTests {
         let scheduler = loaded.scheduler
         defer { Task { await scheduler.unloadModel() } }
 
-        // Build the prompt via the production translation (templateMessageDict).
         let dicts = conversation().map { $0.templateMessageDict() }
         let promptTokens: [Int] = try await loaded.container.perform { ctx in
             try ctx.tokenizer.applyChatTemplate(
@@ -185,16 +169,13 @@ struct GemmaToolCallLiveTests {
 
         print("\n=== issue #249: real Gemma generation (raw) ===\n\(text)\n===========================\n")
 
-        // No double-brace poison in the generated tool call.
         #expect(!text.contains("{{"))
 
-        // Parse the tool call the same way the server does.
         let parsed = GemmaFunctionParser().parse(content: text, tools: toolSpecs)
         let call = try #require(parsed, "model did not emit a parseable Gemma tool call")
         #expect(call.function.name == "run_terminal")
 
-        // The corruption symptom is a key like `{"command"` (object split at the
-        // first colon). Assert every key is clean.
+        // Keys must be clean (the bug produced keys like `{"command"`).
         for key in call.function.arguments.keys {
             #expect(!key.hasPrefix("{"), "corrupted key: \(key)")
             #expect(!key.contains("\""), "corrupted key: \(key)")

--- a/provider-swift/Tests/ProviderCoreTests/ToolCallTemplateArgumentsTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/ToolCallTemplateArgumentsTests.swift
@@ -6,13 +6,8 @@ import Testing
 
 @testable import ProviderCore
 
-/// Regression tests for issue #249 at the live provider translation boundary.
-///
-/// `templateMessageDict()` feeds `MLXLMCommon.Tokenizer.applyChatTemplate`,
-/// which renders the model's downloaded Gemma `chat_template.jinja`. A tool
-/// call's `arguments` must arrive as a *mapping* so the template takes the
-/// `is mapping` branch (single brace) instead of the `is string` branch that
-/// double-braces and corrupts multi-turn tool calls.
+/// Regression tests for #249: `templateMessageDict()` must hand the chat
+/// template a tool-call `arguments` mapping, not a JSON string.
 struct ToolCallTemplateArgumentsTests {
     private func assistantWithToolCall(arguments: String) -> OpenAIChatMessage {
         OpenAIChatMessage(
@@ -40,7 +35,6 @@ struct ToolCallTemplateArgumentsTests {
             assistantWithToolCall(arguments: #"{"command":"ls -la"}"#))
         let mapping = try #require(arguments as? [String: any Sendable])
         #expect(mapping["command"] as? String == "ls -la")
-        // Guards the regression: a String here re-enables the double-brace bug.
         #expect(!(arguments is String))
     }
 

--- a/provider-swift/Tests/ProviderCoreTests/ToolCallTemplateArgumentsTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/ToolCallTemplateArgumentsTests.swift
@@ -1,0 +1,53 @@
+// Copyright © 2026 Eigen Labs Inc.
+
+import Foundation
+import MLXLMServer
+import Testing
+
+@testable import ProviderCore
+
+/// Regression tests for issue #249 at the live provider translation boundary.
+///
+/// `templateMessageDict()` feeds `MLXLMCommon.Tokenizer.applyChatTemplate`,
+/// which renders the model's downloaded Gemma `chat_template.jinja`. A tool
+/// call's `arguments` must arrive as a *mapping* so the template takes the
+/// `is mapping` branch (single brace) instead of the `is string` branch that
+/// double-braces and corrupts multi-turn tool calls.
+struct ToolCallTemplateArgumentsTests {
+    private func assistantWithToolCall(arguments: String) -> OpenAIChatMessage {
+        OpenAIChatMessage(
+            role: .assistant,
+            content: .text(""),
+            toolCalls: [
+                OpenAIToolCall(
+                    id: "call_1",
+                    function: .init(name: "run_terminal", arguments: arguments)
+                )
+            ]
+        )
+    }
+
+    private func renderedArguments(_ message: OpenAIChatMessage) throws -> any Sendable {
+        let dict = message.templateMessageDict()
+        let toolCalls = try #require(dict["tool_calls"] as? [[String: any Sendable]])
+        let function = try #require(toolCalls.first?["function"] as? [String: any Sendable])
+        return try #require(function["arguments"])
+    }
+
+    @Test("templateMessageDict decodes JSON-string arguments into a mapping")
+    func decodesArgumentsIntoMapping() throws {
+        let arguments = try renderedArguments(
+            assistantWithToolCall(arguments: #"{"command":"ls -la"}"#))
+        let mapping = try #require(arguments as? [String: any Sendable])
+        #expect(mapping["command"] as? String == "ls -la")
+        // Guards the regression: a String here re-enables the double-brace bug.
+        #expect(!(arguments is String))
+    }
+
+    @Test("templateMessageDict keeps non-JSON arguments as a string")
+    func keepsNonJSONArgumentsAsString() throws {
+        let arguments = try renderedArguments(
+            assistantWithToolCall(arguments: "not json"))
+        #expect(arguments as? String == "not json")
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #249 — multi-turn tool calling with Gemma (`gemma-4-26b`) corrupts
`function.arguments` after the first turn for every OpenAI-shaped tool-calling
SDK (Claude Code, Codex, AI SDK, OpenAI SDK, …).

OpenAI delivers `function.arguments` as a JSON **string**. When the provider
renders a prior assistant `tool_calls` message into the prompt, that string is
forwarded verbatim into the model's downloaded `chat_template.jinja`, which
takes the `is string` branch and dumps it inside its own `{ … }` block →
**double brace**:

```
<|tool_call>call:run_terminal{{"command":"ls -la"}}<tool_call|>
```

The model imitates that double-brace example on the next turn, and the Gemma
output parser then splits the inner object at its first colon, corrupting the
arguments (`{"command":"ls -la"}` → `{"{\"command\"":"\"ls -la\"}"}`) and
compounding turn over turn.

Confirmed against the exact template the fleet runs: the prod runtime manifest
pins the `gemma4` chat template to hash `2dfbfc7d…`, which matches the downloaded
`gemma-4-26b-a4b-it-8bit` `chat_template.jinja` (lines 200-203 = the buggy
`is string` branch). Note the bug is template-family-wide (the 4bit template has
the same branch) — the root cause is ours, not the quant.

## Fix

Decode the JSON-string `arguments` into an object at the translation boundary so
the template takes the `is mapping` branch (`command:<|"|>ls -la<|"|>`). The
OpenAI wire contract is unchanged — `arguments` stays a `String` to/from
clients; only the *template-input* shape is normalized. Non-JSON / non-object
arguments fall back to the raw string. The chat template and the output parser
are intentionally left untouched.

- **Provider (this repo):** `MultiModelBatchSchedulerEngine+Translation.swift`
  `templateMessageDict()` — the live `applyChatTemplate` path — now calls
  `MLXLMCommon.decodeToolCallArguments`.
- **Submodule bump:** `libs/mlx-swift-lm` → the shared `decodeToolCallArguments`
  helper + the `MLXLMServer` mirror fix (**Layr-Labs/mlx-swift-lm#33**).

## Tests

`provider-swift/Tests/ProviderCoreTests/ToolCallTemplateArgumentsTests.swift`:
asserts `templateMessageDict()` yields a mapping (double-brace regression guard)
and keeps non-JSON args as a string. `swift test` green locally; verified with a
negative control (reverting the one-line change makes the test fail with the raw
`{"command":"ls -la"}` string).

## Merge order ⚠️

1. Merge **Layr-Labs/mlx-swift-lm#33** first.
2. Then re-point the `libs/mlx-swift-lm` gitlink here to the merged `main` SHA
   (this PR currently pins the PR-33 branch commit `2ebc20f` so CI can build).
   If #33 is squash-merged, update the submodule pointer before merging this PR.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/250"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782686949&installation_id=133247490&pr_number=250&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F250&signature=c39847d56125eb6bda4efaab851fcdb73a18ceae2b449d373b4ed84245f14329"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->