### PR TITLE
fix(provider-swift): darkbloom logs --debug flag + --last/--follow tailing

### DIFF
--- a/provider-swift/Package.swift
+++ b/provider-swift/Package.swift
@@ -162,5 +162,18 @@ let package = Package(
             dependencies: ["ProviderCoreFoundation"],
             path: "Tests/ProviderCoreFoundationTests"
         ),
+
+        // ----------------------------------------------------------------
+        // DarkbloomCLITests — unit tests for the `darkbloom` executable
+        // target's pure helpers. The CLI's command types live in the
+        // executable target (which uses `@main`, so it is importable via
+        // `@testable import darkbloom`). Currently covers the `log` argv
+        // builders in LogsCommand.
+        // ----------------------------------------------------------------
+        .testTarget(
+            name: "DarkbloomCLITests",
+            dependencies: ["darkbloom"],
+            path: "Tests/DarkbloomCLITests"
+        ),
     ]
 )

--- a/provider-swift/Sources/darkbloom/LogsCommand.swift
+++ b/provider-swift/Sources/darkbloom/LogsCommand.swift
@@ -9,8 +9,12 @@ struct Logs: AsyncParsableCommand {
         Streams live logs from macOS unified logging \
         (subsystem: \(subsystem)) by default.
 
-        Use --last to show historical logs, or --file to read the \
-        legacy log file at \(LaunchAgent.logPath().path).
+        Use --last to show a historical window (e.g. 1h, 30m, 24h). Combine \
+        --last with --follow to print that history first and then keep \
+        tailing live output.
+
+        Use --debug to include debug-level messages (excluded by default), \
+        or --file to read the legacy log file at \(LaunchAgent.logPath().path).
         """
     )
 
@@ -22,6 +26,9 @@ struct Logs: AsyncParsableCommand {
 
     @Option(name: [.long], help: "Show historical logs for the given duration (e.g. 1h, 30m, 24h).")
     var last: String?
+
+    @Flag(name: [.long], help: "Include debug-level log messages (unified logging only).")
+    var debug = false
 
     @Option(name: [.short, .long], help: "Number of lines to show (only applies with --file).")
     var lines: Int = 50
@@ -35,31 +42,104 @@ struct Logs: AsyncParsableCommand {
         if file {
             try runFileMode()
         } else if let duration = last {
-            try execLogShow(duration: duration)
+            if follow {
+                try execLogShowThenStream(duration: duration)
+            } else {
+                try execLogShow(duration: duration)
+            }
         } else {
             try execLogStream()
         }
     }
 
-    // MARK: - Unified Logging
+    // MARK: - Unified Logging argv (pure, testable)
 
-    private func execLogStream() throws {
-        try execLog(argv: [
-            "log", "stream",
-            "--predicate", Self.predicate,
-            "--style", "ndjson",
-            "--level", "info",
-        ])
-    }
-
-    private func execLogShow(duration: String) throws {
-        try execLog(argv: [
+    /// Builds the argv for a historical `log show` invocation. Pure with no
+    /// side effects so it can be unit tested. argv[0] is the program name
+    /// (`log`) as required by `execv`. Passing `debug: true` appends `--debug`
+    /// so debug-level messages are included alongside `--info`.
+    static func showArgv(predicate: String, duration: String, debug: Bool) -> [String] {
+        var argv = [
             "log", "show",
-            "--predicate", Self.predicate,
+            "--predicate", predicate,
             "--style", "ndjson",
             "--info",
             "--last", duration,
-        ])
+        ]
+        if debug {
+            argv.append("--debug")
+        }
+        return argv
+    }
+
+    /// Builds the argv for a live `log stream` invocation. Pure with no side
+    /// effects so it can be unit tested. `log stream` has no `--last`; the
+    /// level gates verbosity instead — `--level debug` includes info+debug,
+    /// `--level info` is the non-debug default. argv[0] is the program name
+    /// (`log`) as required by `execv`.
+    static func streamArgv(predicate: String, debug: Bool) -> [String] {
+        [
+            "log", "stream",
+            "--predicate", predicate,
+            "--style", "ndjson",
+            "--level", debug ? "debug" : "info",
+        ]
+    }
+
+    // MARK: - Unified Logging exec
+
+    private func execLogStream() throws {
+        try execLog(argv: Self.streamArgv(predicate: Self.predicate, debug: debug))
+    }
+
+    private func execLogShow(duration: String) throws {
+        try execLog(
+            argv: Self.showArgv(predicate: Self.predicate, duration: duration, debug: debug)
+        )
+    }
+
+    /// `--last` + `--follow`: emit the historical window first (a finite
+    /// `log show`), then exec into a live `log stream`. `log stream` does not
+    /// support `--last`, so the two phases must run as separate processes.
+    ///
+    /// Default signal handling is restored up front: SIG_IGN (set by
+    /// ArgumentParser's async runtime) is inherited across spawn and exec,
+    /// which would otherwise make both the historical `log show` child and the
+    /// final streamed exec ignore Ctrl-C.
+    private func execLogShowThenStream(duration: String) throws {
+        restoreDefaultSignalHandling()
+        try runLogToCompletion(
+            argv: Self.showArgv(predicate: Self.predicate, duration: duration, debug: debug)
+        )
+        try execLogStream()
+    }
+
+    /// Runs `/usr/bin/log` to completion with stdout/stderr/stdin inherited so
+    /// the user sees output directly. Used for the historical phase of
+    /// `--last --follow` before switching to the live stream.
+    private func runLogToCompletion(argv: [String]) throws {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/log")
+        // argv[0] is the program name; Process wants only the trailing args.
+        process.arguments = Array(argv.dropFirst())
+        process.standardOutput = FileHandle.standardOutput
+        process.standardError = FileHandle.standardError
+        process.standardInput = FileHandle.standardInput
+
+        do {
+            try process.run()
+        } catch {
+            printError("failed to run log: \(error.localizedDescription)")
+            throw ExitCode.failure
+        }
+        process.waitUntilExit()
+
+        // Mirror `--last` alone: if the historical `log show` failed (e.g. a
+        // malformed duration), surface its exit status instead of silently
+        // proceeding to the live stream.
+        if process.terminationStatus != 0 {
+            throw ExitCode(process.terminationStatus)
+        }
     }
 
     /// Replace the current process with `/usr/bin/log`. Restores default

--- a/provider-swift/Tests/DarkbloomCLITests/LogsCommandArgvTests.swift
+++ b/provider-swift/Tests/DarkbloomCLITests/LogsCommandArgvTests.swift
@@ -1,0 +1,93 @@
+import Testing
+
+@testable import darkbloom
+
+/// Unit tests for the pure `log` argv builders used by `darkbloom logs`.
+///
+/// These assert the two bug fixes:
+///   1. `--debug` is forwarded to the underlying `log` tool.
+///   2. `--last` + `--follow` reuses the same predicate/style for both the
+///      historical (`showArgv`) and live (`streamArgv`) phases.
+@Suite("Logs argv builders")
+struct LogsCommandArgvTests {
+    /// Matches the subsystem predicate the command builds internally.
+    static let predicate = #"subsystem == "dev.darkbloom.provider""#
+
+    // MARK: - streamArgv
+
+    @Test("streamArgv(debug:false) uses --level info and no --debug")
+    func streamArgvDefault() {
+        let argv = Logs.streamArgv(predicate: Self.predicate, debug: false)
+
+        // Shared base argv.
+        #expect(argv.contains("log"))
+        #expect(argv.contains("stream"))
+        #expect(argv.contains("--predicate"))
+        #expect(argv.contains(Self.predicate))
+        #expect(argv.contains("--style"))
+        #expect(argv.contains("ndjson"))
+
+        // Non-debug => `--level info`, and never the bare `--debug` flag.
+        #expect(argv.contains("--level"))
+        #expect(argv.contains("info"))
+        #expect(argvHasPair(argv, "--level", "info"))
+        #expect(!argv.contains("--debug"))
+    }
+
+    @Test("streamArgv(debug:true) uses --level debug")
+    func streamArgvDebug() {
+        let argv = Logs.streamArgv(predicate: Self.predicate, debug: true)
+
+        #expect(argv.contains("--level"))
+        #expect(argv.contains("debug"))
+        #expect(argvHasPair(argv, "--level", "debug"))
+
+        // debug stream is `--level debug`, not the bare `--debug` flag, and the
+        // default `info` level must not also be present.
+        #expect(!argv.contains("info"))
+        #expect(!argv.contains("--debug"))
+    }
+
+    // MARK: - showArgv
+
+    @Test("showArgv(debug:false) has --info, --last, duration, no --debug")
+    func showArgvDefault() {
+        let argv = Logs.showArgv(predicate: Self.predicate, duration: "10m", debug: false)
+
+        // Shared base argv.
+        #expect(argv.contains("log"))
+        #expect(argv.contains("show"))
+        #expect(argv.contains("--predicate"))
+        #expect(argv.contains(Self.predicate))
+        #expect(argv.contains("--style"))
+        #expect(argv.contains("ndjson"))
+
+        // Historical window: `--info --last 10m`, no debug.
+        #expect(argv.contains("--info"))
+        #expect(argv.contains("--last"))
+        #expect(argv.contains("10m"))
+        #expect(argvHasPair(argv, "--last", "10m"))
+        #expect(!argv.contains("--debug"))
+    }
+
+    @Test("showArgv(debug:true) also appends --debug")
+    func showArgvDebug() {
+        let argv = Logs.showArgv(predicate: Self.predicate, duration: "1h", debug: true)
+
+        // `--info` is kept and `--debug` is added alongside it.
+        #expect(argv.contains("--info"))
+        #expect(argv.contains("--last"))
+        #expect(argv.contains("1h"))
+        #expect(argvHasPair(argv, "--last", "1h"))
+        #expect(argv.contains("--debug"))
+    }
+}
+
+/// Returns true if `first` appears immediately before `second` in `argv`.
+/// Used to assert option/value adjacency (e.g. `--level debug`).
+private func argvHasPair(_ argv: [String], _ first: String, _ second: String) -> Bool {
+    guard let index = argv.firstIndex(of: first), index + 1 < argv.count else {
+        return false
+    }
+    return argv[index + 1] == second
+}


### PR DESCRIPTION
## Problem
Reported by a provider operator (`fire`): the `darkbloom logs` CLI has two bugs.

1. **`--debug` advertised but rejected.** `darkbloom logs` execs `/usr/bin/log`, which prints `Skipping debug messages, pass --debug to include.` — but the subcommand defined no `--debug` flag, so following that advice fails:
   ```
   ; darkbloom logs --last 10m --debug
   Error: Unknown option '--debug'
   ```
2. **`--last` + `--follow` doesn't tail.** `darkbloom logs --last 10m --follow` rendered the historical window and exited instead of printing history and then continuing to tail. `--follow` was silently ignored whenever `--last` was set (it was only honored in `--file` mode).

Both shipped in 0.5.14.

## Fix
`provider-swift/Sources/darkbloom/LogsCommand.swift`:
- Add a `--debug` flag, forwarded to the underlying `log` tool:
  - `log show` gets `--debug` (alongside the existing `--info`).
  - `log stream` uses `--level debug` (it has no standalone `--debug`; `--level` gates verbosity). A bare `--debug` there would just reproduce the original error.
- `--last` + `--follow` now runs `log show --last <dur>` to completion (history, stdout/stderr inherited so the user sees it) and **then** execs `log stream` to tail live. `log stream` has no `--last`, so the two-process split is required. If the history phase exits non-zero (e.g. a malformed duration), that status is surfaced instead of streaming — mirroring `--last` alone.
- Extracted pure, testable argv builders (`showArgv` / `streamArgv`); Ctrl-C handling preserved (default signal dispositions restored before both the `Process` spawn and the final `execv`).

`--follow` alone, `--last` alone, and `--file` mode are unchanged.

## Tests
New `DarkbloomCLITests` target (the CLI types live in the `darkbloom` executable, which is `@main` and thus `@testable`-importable). 4 tests pin:
- `streamArgv` uses `--level info` by default and `--level debug` with `--debug` (never a bare `--debug`).
- `showArgv` carries `--info --last <dur>` and appends `--debug` only when requested.

```
swift build           # Build complete!
swift test --filter LogsCommandArgvTests   # 4 tests, 0 failures
```

## Verification
Implemented by a subagent and independently reviewed by an adversarial verifier agent (verdict: PASS). The verifier confirmed the macOS `log` semantics against the actual tool (`log show` has `--debug`; `log stream` only has `--level`), confirmed no Ctrl-C hang window across both phases, and confirmed no regressions in the unchanged branches. The one actionable finding (history-phase exit status was ignored) was applied in this PR.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/251"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782688215&installation_id=133247490&pr_number=251&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F251&signature=fed5f8aaa4bcc88bd09ec91a918af578a2c7d2df25faf364b88af0ea072bf3f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->