### PR TITLE
fix: restore Provider Tests CI job targeting Swift provider

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,27 @@ jobs:
           go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.1.6
           golangci-lint run
 
+  test-provider:
+    name: Provider Tests
+    runs-on: blacksmith-12vcpu-macos-26
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          submodules: recursive
+      - name: Restore SwiftPM cache
+        uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
+        with:
+          path: |
+            ~/Library/Caches/org.swift.swiftpm
+            ~/Library/org.swift.swiftpm
+            provider-swift/.build
+          key: spm-v1-${{ runner.os }}-${{ hashFiles('provider-swift/Package.resolved', 'libs/mlx-swift/Package.swift', 'libs/mlx-swift-lm/Package.swift') }}
+          restore-keys: |
+            spm-v1-${{ runner.os }}-
+      - name: Run Swift tests
+        working-directory: provider-swift
+        run: swift test
+
   cache-swift:
     name: Swift Build + Cache
     runs-on: blacksmith-12vcpu-macos-26

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,15 @@ jobs:
           key: spm-v1-${{ runner.os }}-${{ hashFiles('provider-swift/Package.resolved', 'libs/mlx-swift/Package.swift', 'libs/mlx-swift-lm/Package.swift') }}
           restore-keys: |
             spm-v1-${{ runner.os }}-
+      - name: Build provider-swift
+        working-directory: provider-swift
+        run: swift build
+      - name: Extract mlx.metallib
+        run: |
+          python3 -m venv /tmp/mlxvenv
+          /tmp/mlxvenv/bin/pip install 'mlx==0.31.2'
+          cp /tmp/mlxvenv/lib/python*/site-packages/mlx/lib/mlx.metallib \
+             provider-swift/.build/debug/mlx.metallib
       - name: Run Swift tests
         working-directory: provider-swift
         run: swift test


### PR DESCRIPTION
## Problem

PR #255 removed the Rust `provider/` directory and the `test-provider` CI job from `.github/workflows/ci.yml`. However, **"Provider Tests"** is still listed as a required status check in the `master` branch protection rules. Since no workflow produces a check with that name, every PR shows:

> **Provider Tests** — Expected — Waiting for status to be reported

indefinitely, blocking merges.

## Fix

Re-add a `test-provider` / **"Provider Tests"** job that runs on the existing Blacksmith macOS runner (`blacksmith-12vcpu-macos-26`) — the same runner already used by `cache-swift`. Instead of the deleted Rust tests, it runs `swift test` for the Swift provider (`provider-swift/`), reusing the same SwiftPM cache.

### What changed

- **Before (removed in #255):** `cargo test` + `cargo fmt` + `cargo clippy` for the Rust provider
- **After (this PR):** `swift test` for the Swift provider on `blacksmith-12vcpu-macos-26`

### CI job

```yaml
test-provider:
  name: Provider Tests
  runs-on: blacksmith-12vcpu-macos-26
  steps:
    - checkout (submodules: recursive)
    - restore SwiftPM cache (same key as cache-swift)
    - swift test
```

## Verification

- Branch is clean, cut from `origin/master`
- GPG-signed commit (`57E1CCC9E6C07252`)
- CI should now report "Provider Tests" as a passing check once approved

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/263"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782904022&installation_id=133247490&pr_number=263&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F263&signature=5360579a4398c7fca8d271fa130df664b722c488a5a74d56de1b0b29ca6daeb1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->