### PR TITLE
fix(fleet): reliability fixes — trust, memory routing, billing, SE keys, connectivity

### DIFF
--- a/coordinator/api/adaptive_capacity_integration_test.go
+++ b/coordinator/api/adaptive_capacity_integration_test.go
@@ -285,7 +285,7 @@ func TestAdaptiveCapacityIntegrationOmittedMaxConcurrencyUsesLegacyFallback(t *t
 	for i := range 4 {
 		p.AddPending(&registry.PendingRequest{RequestID: fmt.Sprintf("legacy-%d", i), ProviderID: p.ID, Model: model, RequestedMaxTokens: 128})
 	}
-	candidates, rejections := reg.QuickCapacityCheck(model, 10, 128)
+	candidates, rejections, _ := reg.QuickCapacityCheck(model, 10, 128)
 	if candidates != 1 || rejections != 0 {
 		t.Fatalf("QuickCapacityCheck candidates=%d rejections=%d, want 1/0 with legacy fallback", candidates, rejections)
 	}

--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -143,6 +143,12 @@ func (s *Server) refundProviderExtra(pr *registry.PendingRequest) {
 	s.ddIncr("billing.reservation_extra_refunds", []string{"model:" + pr.Model})
 }
 
+// errModelTooLarge is the dispatch error returned when providers serve the
+// requested model but none of them has enough total memory to ever load it.
+// Distinct from "no provider available" so the caller rejects fast instead of
+// queuing for 120s — queueing can't help a model that will never fit.
+const errModelTooLarge = "model too large for any available provider"
+
 // dispatchOneProvider encrypts and sends an inference request to a single
 // provider. It returns the pending request and provider on success, or an
 // error string on failure. The excludeProviders set is updated on failure.
@@ -198,6 +204,11 @@ func (s *Server) dispatchOneProvider(
 
 	provider, decision = s.registry.ReserveProviderEx(model, pr, excludeList()...)
 	if provider == nil {
+		// Providers serve this model but none can physically fit it: don't make
+		// the caller queue/retry for something that will never load.
+		if decision.CandidateCount == 0 && decision.CapacityRejections == 0 && decision.ModelTooLargeRejections > 0 {
+			return nil, nil, decision, errModelTooLarge, http.StatusServiceUnavailable
+		}
 		return nil, nil, decision, "no provider available", http.StatusServiceUnavailable
 	}
 	pendingCleanup := true
@@ -1134,6 +1145,16 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 			isResponsesAPI, timing, excludeProviders,
 		)
 		if provider == nil {
+			// No online provider has enough memory to ever fit this model.
+			// Retrying and queueing are both pointless — reject immediately
+			// with a clear, non-retryable error.
+			if dispatchErr == errModelTooLarge {
+				s.ddIncr("routing.decisions", []string{"model:" + model, "model_type:" + s.registry.ModelType(model), "outcome:model_too_large"})
+				lastErr = dispatchErr
+				lastErrCode = dispatchErrCode
+				break
+			}
+
 			// dispatchOneProvider may have found a provider but rejected it
 			// (payout destination missing, insufficient funds, encryption
 			// missing). In that case it already added the provider to

--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -1093,7 +1093,17 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 	// If not, return 429 immediately rather than queueing for up to 120s.
 	// OpenRouter treats 429 as "rate limited" (no uptime penalty) vs 503
 	// which counts as downtime. Fast 429s also preserve our TTFT metrics.
-	candidateCount, capacityRejections := s.registry.QuickCapacityCheck(model, estimatedPromptTokens, requestedMaxTokens, allowedProviderSerials...)
+	candidateCount, capacityRejections, modelTooLarge := s.registry.QuickCapacityCheck(model, estimatedPromptTokens, requestedMaxTokens, allowedProviderSerials...)
+	if candidateCount == 0 && capacityRejections == 0 && modelTooLarge > 0 {
+		// Providers serve this model but none can ever fit it — non-retryable.
+		// Surface a clear 503 instead of a 429 the client would retry forever.
+		refundReservation()
+		s.ddIncr("routing.decisions", []string{"model:" + model, "model_type:" + s.registry.ModelType(model), "outcome:model_too_large"})
+		writeJSON(w, http.StatusServiceUnavailable, errorResponse("model_unavailable",
+			fmt.Sprintf("model %q is too large for any currently available provider", model),
+			withCode("model_unavailable")))
+		return
+	}
 	if candidateCount == 0 && capacityRejections > 0 {
 		// Providers exist for this model but ALL are at capacity.
 		retryAfter := s.estimateRetryAfter(model)
@@ -1947,7 +1957,7 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 		if statusCode == 0 {
 			// Distinguish capacity exhaustion (429) from genuine unavailability (503).
 			// A quick capacity check tells us if providers exist but are full.
-			_, capRej := s.registry.QuickCapacityCheck(model, estimatedPromptTokens, requestedMaxTokens, allowedProviderSerials...)
+			_, capRej, _ := s.registry.QuickCapacityCheck(model, estimatedPromptTokens, requestedMaxTokens, allowedProviderSerials...)
 			if capRej > 0 {
 				statusCode = http.StatusTooManyRequests
 			} else {
@@ -3914,7 +3924,15 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 	}
 
 	// Pre-flight capacity check (same logic as handleChatCompletions).
-	candidateCount, capacityRejections := s.registry.QuickCapacityCheck(model, estimatedPromptTokens, requestedMaxTokens, allowedProviderSerials...)
+	candidateCount, capacityRejections, modelTooLarge := s.registry.QuickCapacityCheck(model, estimatedPromptTokens, requestedMaxTokens, allowedProviderSerials...)
+	if candidateCount == 0 && capacityRejections == 0 && modelTooLarge > 0 {
+		refundReservation()
+		s.ddIncr("routing.decisions", []string{"model:" + model, "model_type:" + s.registry.ModelType(model), "outcome:model_too_large"})
+		writeJSON(w, http.StatusServiceUnavailable, errorResponse("model_unavailable",
+			fmt.Sprintf("model %q is too large for any currently available provider", model),
+			withCode("model_unavailable")))
+		return
+	}
 	if candidateCount == 0 && capacityRejections > 0 {
 		retryAfter := s.estimateRetryAfter(model)
 		w.Header().Set("Retry-After", strconv.Itoa(retryAfter))

--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -3997,6 +3997,17 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 		break
 	}
 	if provider == nil {
+		// No online provider can physically fit this model — queueing/retrying
+		// can't help, so fast-fail with a clear, non-retryable error instead of
+		// blocking for 120s then 503-ing. Mirrors the streaming dispatch path.
+		if decision.CandidateCount == 0 && decision.CapacityRejections == 0 && decision.ModelTooLargeRejections > 0 {
+			refundReservation()
+			s.ddIncr("routing.decisions", []string{"model:" + model, "model_type:" + s.registry.ModelType(model), "outcome:model_too_large"})
+			writeJSON(w, http.StatusServiceUnavailable, errorResponse("model_unavailable",
+				fmt.Sprintf("model %q is too large for any currently available provider", model),
+				withCode("model_unavailable")))
+			return
+		}
 		queuedReq := &registry.QueuedRequest{
 			RequestID:  requestID,
 			Model:      model,

--- a/coordinator/api/provider.go
+++ b/coordinator/api/provider.go
@@ -52,6 +52,21 @@ const (
 
 	// ChallengeResponseTimeout is how long to wait for a challenge response.
 	ChallengeResponseTimeout = 30 * time.Second
+
+	// MaxConsecutiveChallengeTimeoutsBeforeReconnect is the number of consecutive
+	// transient challenge timeouts (no response within ChallengeResponseTimeout)
+	// after which the coordinator force-closes the provider's WebSocket so it must
+	// reconnect and re-register.
+	//
+	// MarkUntrustedTransient keeps challenging a provider in place so it can
+	// self-recover via a later passing challenge — but that only helps if the
+	// provider can actually send a response. A provider whose outbound path is
+	// wedged keeps heartbeating (so it is never evicted by the stale sweeper)
+	// while failing every challenge, leaving it pinned hardware/untrusted forever.
+	// Cycling the connection forces a clean re-registration, which is the only way
+	// back. Must be > MaxFailedChallenges so a brief blip (sleep/network) still
+	// self-recovers without a disconnect.
+	MaxConsecutiveChallengeTimeoutsBeforeReconnect = 6
 )
 
 // pendingChallenge tracks an outstanding challenge sent to a provider.
@@ -126,6 +141,7 @@ func (s *Server) providerReadLoop(ctx context.Context, conn *websocket.Conn, pro
 	defer func() {
 		loopCancel()
 		s.registry.Disconnect(providerID)
+		s.clearPendingACME(providerID)
 		conn.Close(websocket.StatusNormalClosure, "goodbye")
 	}()
 
@@ -382,12 +398,19 @@ func (s *Server) applyACMETrust(providerID string, provider *registry.Provider, 
 	provider.ACMEVerified = true
 	provider.Mu().Unlock()
 
+	// Stash the result so retryACMETrust can re-run this on the first passing
+	// challenge. At registration the attestation challenge/response has not yet
+	// completed, so AttestationResult is nil and the two binding checks below
+	// fail purely on ordering — without a retry the provider would stay
+	// self_signed forever despite presenting a valid device cert.
+	s.stashPendingACME(providerID, acmeResult)
+
 	if !providerHasBoundEncryptionAttestation(provider) {
-		s.logger.Warn("ACME client cert verified but X25519 key was not bound by attestation",
+		// Expected before the first challenge completes; logged at debug so it
+		// doesn't look like a failure. The retry path resolves it.
+		s.logger.Debug("ACME cert verified but attestation not yet bound — will retry after challenge",
 			"provider_id", providerID,
 			"acme_serial", acmeResult.SerialNumber,
-			"acme_issuer", acmeResult.Issuer,
-			"acme_key_alg", acmeResult.PublicKeyAlg,
 		)
 		return
 	}
@@ -403,12 +426,42 @@ func (s *Server) applyACMETrust(providerID string, provider *registry.Provider, 
 
 	provider.SetAttested(true, registry.TrustHardware)
 	s.sendTrustStatus(provider, registry.TrustHardware, "online", "ACME device attestation verified")
+	s.clearPendingACME(providerID)
 	s.logger.Info("ACME client cert verified — hardware trust via Apple SE attestation",
 		"provider_id", providerID,
 		"acme_serial", acmeResult.SerialNumber,
 		"acme_issuer", acmeResult.Issuer,
 		"acme_key_alg", acmeResult.PublicKeyAlg,
 	)
+}
+
+// stashPendingACME records the connect-time ACME result for later retry.
+func (s *Server) stashPendingACME(providerID string, acmeResult *ACMEVerificationResult) {
+	s.pendingACMEMu.Lock()
+	s.pendingACME[providerID] = acmeResult
+	s.pendingACMEMu.Unlock()
+}
+
+// clearPendingACME drops a stashed ACME result (after a successful upgrade or
+// on disconnect).
+func (s *Server) clearPendingACME(providerID string) {
+	s.pendingACMEMu.Lock()
+	delete(s.pendingACME, providerID)
+	s.pendingACMEMu.Unlock()
+}
+
+// retryACMETrust re-applies a stashed ACME result. Called from the
+// challenge-success path so a provider whose device cert was presented at
+// connect — but whose attestation had not yet bound — gets upgraded to
+// hardware once the binding completes. Mirrors the MDM re-verification retry.
+func (s *Server) retryACMETrust(providerID string, provider *registry.Provider) {
+	s.pendingACMEMu.Lock()
+	acmeResult := s.pendingACME[providerID]
+	s.pendingACMEMu.Unlock()
+	if acmeResult == nil {
+		return
+	}
+	s.applyACMETrust(providerID, provider, acmeResult)
 }
 
 func providerHasBoundEncryptionAttestation(provider *registry.Provider) bool {
@@ -555,13 +608,13 @@ func (s *Server) sendChallenge(ctx context.Context, conn *websocket.Conn, provid
 		tracker.remove(nonce)
 		if resp == nil {
 			// Channel closed without response
-			s.handleChallengeFailure(providerID, "no response")
+			s.handleTransientChallengeFailure(conn, providerID, "no response")
 			return
 		}
 		s.verifyChallengeResponse(providerID, provider, pc, resp)
 	case <-time.After(timeout):
 		tracker.remove(nonce)
-		s.handleChallengeFailure(providerID, "timeout")
+		s.handleTransientChallengeFailure(conn, providerID, "timeout")
 	}
 }
 
@@ -667,9 +720,36 @@ func (s *Server) verifyChallengeResponse(providerID string, provider *registry.P
 				"provider_id", providerID,
 			)
 		default:
+			// Instrumentation for the non-recovering status-sig lockout seen on
+			// a couple of nodes (cause unconfirmed). Because the plain challenge
+			// signature already verified above (we returned on its failure),
+			// reaching here isolates the status-sig / canonical path: log
+			// plain_sig_passed plus the Go canonical bytes and per-field lengths
+			// so a field-presence or canonicalization mismatch is diagnosable
+			// from logs alone, without shipping a new build to the affected box.
+			canonical, cerr := attestation.BuildStatusCanonical(statusInput)
+			canonicalB64 := ""
+			if cerr == nil {
+				canonicalB64 = base64.StdEncoding.EncodeToString(canonical)
+			}
+			s.ddIncr("attestation.challenges", []string{"outcome:status_sig_failed"})
+			if s.metrics != nil {
+				s.metrics.IncCounter("attestation_status_sig_failed_total")
+			}
 			s.logger.Error("status signature verification failed — possible tampering or canonical mismatch",
 				"provider_id", providerID,
 				"error", err,
+				"plain_sig_passed", true,
+				"go_canonical_b64", canonicalB64,
+				"go_canonical_len", len(canonical),
+				"canonical_build_err", cerr,
+				"status_sig_len", len(resp.StatusSignature),
+				"binary_hash_len", len(resp.BinaryHash),
+				"active_model_hash_len", len(resp.ActiveModelHash),
+				"python_hash_len", len(resp.PythonHash),
+				"runtime_hash_len", len(resp.RuntimeHash),
+				"template_hashes_count", len(resp.TemplateHashes),
+				"model_hashes_count", len(resp.ModelHashes),
 			)
 			s.handleChallengeFailure(providerID, "status signature verification failed: "+err.Error())
 			return
@@ -957,11 +1037,48 @@ func (s *Server) verifyChallengeResponse(providerID string, provider *registry.P
 			s.verifyProviderViaMDM(providerID, provider, result)
 		})
 	}
+
+	// Re-attempt ACME (mTLS device-cert) trust for self_signed providers.
+	// applyACMETrust ran at registration before attestation was bound, so a
+	// provider that presented a valid device cert can be promoted to hardware
+	// now that the challenge has passed. No-op if nothing was stashed.
+	if trustLevel == registry.TrustSelfSigned {
+		s.retryACMETrust(providerID, provider)
+	}
+}
+
+// handleTransientChallengeFailure records a transient challenge failure
+// (timeout / no response) and, once a provider has missed too many consecutive
+// challenges, force-closes its WebSocket so it must reconnect and re-register.
+//
+// A provider whose outbound path is wedged keeps heartbeating (so the stale
+// sweeper never evicts it) while every challenge times out, pinning it
+// hardware/untrusted forever. MarkUntrustedTransient alone cannot recover it
+// because recovery requires a passing challenge, which requires a working
+// outbound path. Cycling the connection forces a clean re-registration.
+func (s *Server) handleTransientChallengeFailure(conn *websocket.Conn, providerID, reason string) {
+	failures := s.handleChallengeFailure(providerID, reason)
+	if conn == nil || failures < MaxConsecutiveChallengeTimeoutsBeforeReconnect {
+		return
+	}
+	s.logger.Warn("provider exceeded consecutive challenge timeouts — forcing reconnect",
+		"provider_id", providerID,
+		"consecutive_failures", failures,
+		"reason", reason,
+	)
+	s.ddIncr("attestation.force_reconnect", []string{"reason:" + reason})
+	if s.metrics != nil {
+		s.metrics.IncCounter("attestation_force_reconnect_total", MetricLabel{"reason", reason})
+	}
+	// Closing the conn unblocks providerReadLoop's conn.Read, which cancels the
+	// loop context (stopping this challenge loop) and runs registry.Disconnect.
+	_ = conn.Close(websocket.StatusPolicyViolation, "attestation unresponsive — reconnect required")
 }
 
 // handleChallengeFailure records a failed challenge and marks the provider
-// as untrusted if the failure threshold is reached.
-func (s *Server) handleChallengeFailure(providerID string, reason string) {
+// as untrusted if the failure threshold is reached. It returns the running
+// count of consecutive failures.
+func (s *Server) handleChallengeFailure(providerID string, reason string) int {
 	transient := reason == "timeout" || reason == "no response"
 	failures := s.registry.RecordChallengeFailure(providerID, transient)
 	s.ddIncr("attestation.challenges", []string{"outcome:failed"})
@@ -999,6 +1116,7 @@ func (s *Server) handleChallengeFailure(providerID string, reason string) {
 		)
 	}
 	s.ddIncr("attestation.failures", []string{"reason:" + reason})
+	return failures
 }
 
 func (s *Server) handleChunk(providerID string, provider *registry.Provider, msg *protocol.InferenceResponseChunkMessage) {
@@ -1105,6 +1223,20 @@ func (s *Server) handleComplete(providerID string, provider *registry.Provider, 
 	// Store SE signature for the consumer response headers.
 	pr.SESignature = msg.SESignature
 	pr.ResponseHash = msg.ResponseHash
+
+	// Billing-zero observability: a COMPLETED request that reports zero tokens
+	// is billed $0 (and fully refunded). The provider-side fix (EngineBridge
+	// max + content-frame floor) should prevent this, but emit a metric so any
+	// residual leak is visible on the dashboard rather than silent.
+	if msg.Usage.CompletionTokens == 0 {
+		s.ddIncr("billing.zero_usage_complete", []string{"model:" + pr.Model})
+		s.logger.Warn("completed request reported zero completion tokens — billed $0",
+			"provider_id", providerID,
+			"request_id", msg.RequestID,
+			"model", pr.Model,
+			"prompt_tokens", msg.Usage.PromptTokens,
+		)
+	}
 
 	// Record job success and usage BEFORE closing ChunkCh. Closing
 	// ChunkCh unblocks the consumer response handler, and callers may

--- a/coordinator/api/provider_test.go
+++ b/coordinator/api/provider_test.go
@@ -2319,6 +2319,40 @@ func TestHandleChallengeFailureThresholdTransientIsRecoverable(t *testing.T) {
 	}
 }
 
+// handleChallengeFailure returns the running consecutive-failure count, which
+// drives the force-reconnect escalation in handleTransientChallengeFailure.
+// A provider whose outbound path is wedged heartbeats forever (never evicted)
+// while failing every challenge; the count is what lets the coordinator cycle
+// the connection. handleTransientChallengeFailure must also tolerate a nil conn.
+func TestHandleChallengeFailureReturnsConsecutiveCountAndNilConnSafe(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	st := store.NewMemory(store.Config{AdminKey: "test-key"})
+	reg := registry.New(logger)
+	srv := NewServer(reg, st, ServerConfig{}, logger)
+
+	reg.Register("p1", nil, &protocol.RegisterMessage{
+		Type:     protocol.TypeRegister,
+		Hardware: protocol.Hardware{ChipName: "Apple M3 Max", MemoryGB: 64},
+		Models:   []protocol.ModelInfo{{ID: "test-model", ModelType: "chat", Quantization: "4bit"}},
+		Backend:  "mlx-swift",
+	})
+
+	for i := 1; i <= MaxConsecutiveChallengeTimeoutsBeforeReconnect; i++ {
+		got := srv.handleChallengeFailure("p1", "timeout")
+		if got != i {
+			t.Fatalf("handleChallengeFailure call %d returned %d, want %d", i, got, i)
+		}
+	}
+
+	// A nil conn (e.g. provider already torn down) must not panic even though
+	// the count is past the force-reconnect threshold.
+	srv.handleTransientChallengeFailure(nil, "p1", "timeout")
+
+	if got := reg.GetProvider("p1"); got == nil || got.Status != registry.StatusUntrusted {
+		t.Fatalf("provider should be untrusted after repeated timeouts")
+	}
+}
+
 // Issue #239: a non-transient reason at the threshold is a hard deroute — the
 // challenge loop stops and it cannot self-recover.
 func TestHandleChallengeFailureThresholdSecurityIsHard(t *testing.T) {

--- a/coordinator/api/routing_metrics_test.go
+++ b/coordinator/api/routing_metrics_test.go
@@ -309,8 +309,23 @@ func TestRoutingMetrics_OverCapacityOutcome(t *testing.T) {
 		t.Fatal("expected nil — 64GB provider can't fit 128GB model")
 	}
 
+	// A model that can never fit must be classified as model_too_large, NOT
+	// over_capacity. over_capacity emits a 429 + Retry-After telling the client
+	// to retry, which is pointless when the model will never fit on this box —
+	// the client would retry forever. The absolute-fit gate reports it via
+	// ModelTooLargeRejections (permanent), separate from CapacityRejections
+	// (transient: full now, retry later).
+	if decision.ModelTooLargeRejections == 0 {
+		t.Fatalf("expected ModelTooLargeRejections > 0 for a 128GB model on a 64GB provider; decision=%+v", decision)
+	}
+	if decision.CapacityRejections != 0 {
+		t.Fatalf("a too-large model must not count as transient capacity pressure; got CapacityRejections=%d", decision.CapacityRejections)
+	}
+
 	outcome := "no_provider"
-	if decision.CapacityRejections > 0 && decision.CandidateCount == 0 {
+	if decision.ModelTooLargeRejections > 0 && decision.CandidateCount == 0 {
+		outcome = "model_too_large"
+	} else if decision.CapacityRejections > 0 && decision.CandidateCount == 0 {
 		outcome = "over_capacity"
 	}
 	srv.ddIncr("routing.decisions", []string{"model:" + model, "outcome:" + outcome})
@@ -318,8 +333,8 @@ func TestRoutingMetrics_OverCapacityOutcome(t *testing.T) {
 	_ = ddClient.Statsd.Flush()
 	packets := collector.drain()
 
-	if !hasMetric(packets, "outcome:over_capacity") {
-		t.Errorf("expected over_capacity outcome when provider too small; got packets: %v", packets)
+	if !hasMetric(packets, "outcome:model_too_large") {
+		t.Errorf("expected model_too_large outcome when provider too small; got packets: %v", packets)
 	}
 }
 

--- a/coordinator/api/server.go
+++ b/coordinator/api/server.go
@@ -719,6 +719,7 @@ func (s *Server) SyncModelCatalog() {
 			ID:         row.ID,
 			WeightHash: row.ActiveVersion.AggregateSHA256,
 			SizeGB:     float64(row.ActiveVersion.TotalSizeBytes) / 1e9,
+			MinRAMGB:   row.MinRAMGB,
 		})
 	}
 	s.registry.SetModelCatalog(entries)

--- a/coordinator/api/server.go
+++ b/coordinator/api/server.go
@@ -256,6 +256,15 @@ type Server struct {
 	// Logs API event forwarding. Nil when DD is not configured.
 	dd *datadog.Client
 
+	// pendingACME holds the connect-time ACME (mTLS device-cert) verification
+	// result per provider so the trust upgrade can be retried after the first
+	// passing challenge. applyACMETrust runs at registration BEFORE the first
+	// challenge response sets AttestationResult, so its binding checks fail
+	// purely on ordering and the provider stays self_signed forever. Cleared on
+	// successful upgrade or disconnect.
+	pendingACMEMu sync.Mutex
+	pendingACME   map[string]*ACMEVerificationResult
+
 	// apiKeyCache memoizes ValidateKeyFull results so repeated requests
 	// with the same API key skip the DB round trip. Entries expire after
 	// apiKeyCacheTTL. Bounded at apiKeyCacheMaxSize entries.
@@ -504,6 +513,7 @@ func NewServer(reg *registry.Registry, st store.Store, cfg ServerConfig, logger 
 		readCache:            newTTLCache(),
 		geoResolver:          newProviderGeoResolverFromEnv(logger),
 		apiKeyCache:          make(map[string]apiKeyCacheEntry),
+		pendingACME:          make(map[string]*ACMEVerificationResult),
 	}
 	s.registerDefaultGauges()
 	s.routes()

--- a/coordinator/api/telemetry_handlers.go
+++ b/coordinator/api/telemetry_handlers.go
@@ -72,9 +72,11 @@ var telemetryFieldAllowlist = map[string]struct{}{
 	"reason":            {},
 	"runtime_component": {},
 	// Connectivity
-	"reconnect_count": {},
-	"last_error":      {},
-	"ws_state":        {},
+	"reconnect_count":   {},
+	"last_error":        {},
+	"ws_state":          {},
+	"network_reachable": {}, // distinguishes "coordinator down" from "box offline"
+	"coordinator_url":   {},
 	// Billing (booleans/enums only — no dollar amounts)
 	"billing_method": {},
 	"payment_failed": {},

--- a/coordinator/attestation/attestation.go
+++ b/coordinator/attestation/attestation.go
@@ -25,6 +25,7 @@
 package attestation
 
 import (
+	"bytes"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/sha256"
@@ -413,7 +414,22 @@ func BuildStatusCanonical(in StatusCanonicalInput) ([]byte, error) {
 	if len(in.ModelHashes) > 0 {
 		m["model_hashes"] = in.ModelHashes
 	}
-	return json.Marshal(m)
+	// Encode WITHOUT Go's HTML escaping so the bytes match the Swift provider's
+	// JSONEncoder (which never escapes <, >, &). With the default json.Marshal,
+	// any field value containing <, >, or & would serialize as < / > /
+	// & on the Go side but raw on the Swift side, producing a canonical
+	// mismatch and a spurious status-signature failure. For base64/hex values
+	// (the only ones in use today) the output is byte-identical, so this is a
+	// no-op for current providers and a fix for the latent divergence.
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(m); err != nil {
+		return nil, err
+	}
+	// json.Encoder.Encode appends a trailing newline; strip it so the canonical
+	// bytes match Swift's JSONEncoder output exactly.
+	return bytes.TrimRight(buf.Bytes(), "\n"), nil
 }
 
 // VerifyStatusSignature verifies that statusSigB64 is a valid SE P-256

--- a/coordinator/attestation/status_canonical_test.go
+++ b/coordinator/attestation/status_canonical_test.go
@@ -116,6 +116,38 @@ func TestBuildStatusCanonicalUnicodeNonce(t *testing.T) {
 	}
 }
 
+// TestBuildStatusCanonicalDoesNotHTMLEscape guards the SetEscapeHTML(false)
+// fix. Go's default json.Marshal escapes <, >, & as < > &,
+// but the Swift provider's JSONEncoder emits them raw — so any signed field
+// containing one of those characters would produce a canonical mismatch and a
+// spurious status-signature failure. The canonical bytes here MUST match what
+// Swift signs (raw characters, no \u00xx escapes).
+func TestBuildStatusCanonicalDoesNotHTMLEscape(t *testing.T) {
+	got, err := BuildStatusCanonical(StatusCanonicalInput{
+		// Fictional values exercising every HTML-escaped character. Real
+		// hashes/nonces are base64/hex today, which is exactly why this
+		// divergence is latent — this test makes it impossible to regress.
+		Nonce:           "a<b>c&d",
+		Timestamp:       "t",
+		BinaryHash:      "x&y",
+		ActiveModelHash: "p<q>r",
+	})
+	if err != nil {
+		t.Fatalf("BuildStatusCanonical: %v", err)
+	}
+	expected := []byte(`{"active_model_hash":"p<q>r","binary_hash":"x&y","nonce":"a<b>c&d","timestamp":"t"}`)
+	if !bytes.Equal(got, expected) {
+		t.Fatalf("HTML escaping not disabled — canonical will mismatch Swift\nwant: %s\ngot:  %s", expected, got)
+	}
+	// Belt-and-suspenders: Go's HTML escaping would turn these characters into
+	// \u00xx sequences, which introduce a backslash (0x5c). The correct,
+	// un-escaped output for these inputs contains no backslash at all — so any
+	// backslash byte means escaping leaked back in.
+	if bytes.IndexByte(got, '\\') != -1 {
+		t.Fatalf("canonical output contains an escape backslash — HTML escaping not fully disabled: %s", got)
+	}
+}
+
 // TestVerifyStatusSignatureMissingReturnsSentinel ensures legacy
 // providers (no status_signature field) trigger ErrStatusSignatureMissing
 // rather than a generic verification failure — callers gate trust

--- a/coordinator/registry/algorithm_scenarios_test.go
+++ b/coordinator/registry/algorithm_scenarios_test.go
@@ -199,6 +199,33 @@ func TestAlgorithm_P1_DoesNotRejectWarmProviderWithoutWeightsHeadroom(t *testing
 	}
 }
 
+// A model that is RESIDENT-but-idle (loaded, no active requests → provider
+// reports slot state "idle", not "running") must never be rejected by the
+// absolute-fit gate. The model is demonstrably in memory, so the heuristic —
+// which can overestimate via catalog SizeGB — must not exclude it. Regression
+// for the review finding: `snap.modelLoaded` only tracks "running", so an "idle"
+// slot would otherwise be treated as a cold load and gated.
+func TestAlgorithm_P1_IdleResidentModelNotRejectedByFitGate(t *testing.T) {
+	reg := New(testLogger())
+	model := "p1-idle-resident"
+	// Catalog SizeGB=40 → fit gate needs 40*2.0=80 GB, more than the 64 GB box.
+	// If the gate ignored residency it would reject this provider.
+	reg.SetModelCatalog([]CatalogEntry{{ID: model, SizeGB: 40}})
+
+	scenarioProvider{
+		id: "idle-resident", decodeTPS: 60, totalMemGB: 64, gpuActiveGB: 42,
+		slotState: "idle", // loaded, currently no active requests
+	}.register(t, reg, model)
+
+	p := reserveOne(reg, model, 256)
+	if p == nil {
+		t.Fatal("expected idle-resident provider to be admitted (model is loaded), got nil")
+	}
+	if p.ID != "idle-resident" {
+		t.Fatalf("got %q, want idle-resident", p.ID)
+	}
+}
+
 // When the catalog has no SizeGB for a model, the gate must not gate.
 // This preserves backwards compatibility with catalog entries written
 // before the SizeGB field existed.

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -614,11 +614,17 @@ func (r *Registry) RestoreProviderState(p *Provider, rec *store.ProviderRecord) 
 	// the "registry says hardware but the live verdict is self_signed" drift.
 	// The challenge-success path (verifyChallengeResponse) re-upgrades to
 	// hardware once the live legs pass.
-	p.TrustLevel = TrustLevel(rec.TrustLevel)
-	if trustRank(p.TrustLevel) > trustRank(TrustSelfSigned) {
+	if r := trustRank(TrustLevel(rec.TrustLevel)); r > trustRank(TrustSelfSigned) {
 		p.TrustLevel = TrustSelfSigned
-		p.Attested = false
 	} else {
+		p.TrustLevel = TrustLevel(rec.TrustLevel)
+	}
+	// Do NOT clobber a fresh live attestation: verifyProviderAttestation runs
+	// just before this and may have already set Attested=true (self_signed) from
+	// a passing SE attestation. Only fall back to the stored flag when we don't
+	// already have a fresh one — otherwise consumers/stats would see
+	// X-Provider-Attested:false despite a successful live attestation.
+	if !p.Attested {
 		p.Attested = rec.Attested
 	}
 	p.MDAVerified = rec.MDAVerified

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -823,6 +823,10 @@ type CatalogEntry struct {
 	ID         string
 	WeightHash string  // expected SHA-256 weight fingerprint (empty = not enforced)
 	SizeGB     float64 // disk/GPU footprint of the model weights (zero = unknown, gate disabled)
+	// MinRAMGB is the catalog's authoritative minimum unified memory (GB) to run
+	// this model — the operator-published requirement. The hardware-fit gate
+	// prefers this over any heuristic multiple of SizeGB. Zero = unknown.
+	MinRAMGB int
 }
 
 // SetModelCatalog updates the set of active models. Only models in this
@@ -919,6 +923,15 @@ func (r *Registry) providerServesCatalogModelLocked(p *Provider, model string) b
 func (r *Registry) catalogSizeGBLocked(model string) float64 {
 	if e, ok := r.modelCatalog[model]; ok {
 		return e.SizeGB
+	}
+	return 0
+}
+
+// catalogMinRAMGbLocked returns the model's authoritative minimum-RAM
+// requirement (GB) from the catalog, or 0 when unknown. Caller must hold r.mu.
+func (r *Registry) catalogMinRAMGbLocked(model string) int {
+	if e, ok := r.modelCatalog[model]; ok {
+		return e.MinRAMGB
 	}
 	return 0
 }
@@ -1488,13 +1501,15 @@ func (r *Registry) modelLoadCandidatePendingLocked(p *Provider, model string, no
 		return 0, false
 	}
 
-	// Memory gate: reject providers that cannot physically load the model.
-	// Shares modelFitsHardware with the consumer-routing admission gate
-	// (freeMemoryAdmits) so the two heuristics can never drift. This prevents
-	// the coordinator from sending load_model commands to machines that will
-	// always OOM-reject them.
-	if entry, ok := r.modelCatalog[model]; ok && entry.SizeGB > 0 {
-		if !modelFitsHardware(entry.SizeGB, float64(p.Hardware.MemoryGB)) {
+	// Memory gate: reject providers that cannot run the model per the catalog's
+	// authoritative min_ram_gb (falling back to the weight heuristic only when
+	// unknown). Shares modelFitsHardware with the consumer-routing admission
+	// gate so the two can never drift. This prevents the coordinator from
+	// sending load_model commands to machines that clearly cannot fit it, while
+	// trusting the operator-published requirement rather than a synthetic
+	// multiple that would exclude catalog-qualified nodes.
+	if entry, ok := r.modelCatalog[model]; ok && (entry.MinRAMGB > 0 || entry.SizeGB > 0) {
+		if !modelFitsHardware(entry.MinRAMGB, entry.SizeGB, float64(p.Hardware.MemoryGB)) {
 			return 0, false
 		}
 	}

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -1623,7 +1623,10 @@ func (r *Registry) RejectUnservableQueuedRequests(modelID string) {
 	// temporarily at capacity (capacityRejections > 0), the requests
 	// should wait — those providers may finish current work and become
 	// available.
-	candidates, capacityRejections := r.QuickCapacityCheck(modelID, 500, defaultRequestedMaxTokens)
+	// modelTooLarge is intentionally ignored here: a model that can never fit
+	// any provider should NOT keep its queued requests waiting (they'd time out
+	// after 120s) — fall through to fail them fast.
+	candidates, capacityRejections, _ := r.QuickCapacityCheck(modelID, 500, defaultRequestedMaxTokens)
 	if candidates > 0 || capacityRejections > 0 {
 		return
 	}

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -607,9 +607,20 @@ func (r *Registry) RestoreProviderState(p *Provider, rec *store.ProviderRecord) 
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
-	// Restore trust level (will be re-verified via fresh attestation)
+	// Restore trust level, but NEVER above self_signed. Hardware trust must be
+	// re-earned via a fresh live challenge + MDM/ACME on every (re)connection.
+	// Resurrecting a stored "hardware" level would route real traffic to a
+	// provider that has not yet passed a live challenge, and is the source of
+	// the "registry says hardware but the live verdict is self_signed" drift.
+	// The challenge-success path (verifyChallengeResponse) re-upgrades to
+	// hardware once the live legs pass.
 	p.TrustLevel = TrustLevel(rec.TrustLevel)
-	p.Attested = rec.Attested
+	if trustRank(p.TrustLevel) > trustRank(TrustSelfSigned) {
+		p.TrustLevel = TrustSelfSigned
+		p.Attested = false
+	} else {
+		p.Attested = rec.Attested
+	}
 	p.MDAVerified = rec.MDAVerified
 	p.ACMEVerified = rec.ACMEVerified
 
@@ -1472,16 +1483,12 @@ func (r *Registry) modelLoadCandidatePendingLocked(p *Provider, model string, no
 	}
 
 	// Memory gate: reject providers that cannot physically load the model.
-	// The provider applies a 2x multiplier on model weight size when deciding
-	// whether to load (ensureModelLoaded uses estimatedMemoryGb * 2.0 for
-	// headroom). Use the catalog SizeGB * 2.5 as the coordinator-side gate
-	// (slightly less conservative since the provider will reject anyway if
-	// it truly doesn't fit). This prevents the coordinator from sending
-	// load_model commands to machines that will always OOM-reject them.
+	// Shares modelFitsHardware with the consumer-routing admission gate
+	// (freeMemoryAdmits) so the two heuristics can never drift. This prevents
+	// the coordinator from sending load_model commands to machines that will
+	// always OOM-reject them.
 	if entry, ok := r.modelCatalog[model]; ok && entry.SizeGB > 0 {
-		requiredGB := entry.SizeGB * 2.5
-		providerMemGB := float64(p.Hardware.MemoryGB)
-		if providerMemGB > 0 && requiredGB > providerMemGB {
+		if !modelFitsHardware(entry.SizeGB, float64(p.Hardware.MemoryGB)) {
 			return 0, false
 		}
 	}

--- a/coordinator/registry/scheduler.go
+++ b/coordinator/registry/scheduler.go
@@ -117,16 +117,21 @@ const (
 	rejectModelTooLarge
 )
 
-// modelMemoryHeadroomFactor approximates a model's resident GPU footprint
-// (weights + KV cache + activations) as a multiple of its on-disk weight size.
-// It matches the provider's own load threshold (ensureModelLoaded uses
-// estimatedMemoryGb * 2.0), so this is a HARD "could the provider ever load
-// this" floor — NOT a conservative comfort margin. Using a larger factor (e.g.
-// 2.5) would reject models the provider can actually load: e.g. a model already
-// resident-but-idle on a 64 GB box (loaded at 2.0x) would be wrongly excluded
-// once it left the "running" slot state. Let the provider make the final call;
-// only gate the cases it could never accept.
-const modelMemoryHeadroomFactor = 2.0
+// modelMemoryHeadroomFactor approximates a model's resident GPU footprint as a
+// multiple of its CATALOG on-disk weight size (SizeGB = TotalSizeBytes/1e9).
+// It must match what the provider actually requires at load time so the
+// coordinator never dispatches a model the provider will reject:
+//
+//	provider estimatedMemoryGb = weightGiB * 1.2   (ModelScanner overhead)
+//	provider requiredGb        = estimatedMemoryGb * 2.0   (ensureModelLoaded)
+//	                           ≈ weight * 2.4
+//
+// So 2.4, not 2.0: at 2.0 a ~28 GB-weight model passes here (28*2=56 ≤ 64) but
+// the provider needs 28*2.4≈67 GB and rejects it at load on a 64 GB Mac. This
+// gate only runs for COLD loads — a resident ("running"/"idle") model is
+// exempted by the caller, so a slightly conservative factor can't wrongly evict
+// a model that already fit.
+const modelMemoryHeadroomFactor = 2.4
 
 // modelFitsHardware reports whether a model of the given on-disk weight size
 // (GB) can plausibly load on a node with the given total unified memory (GB).

--- a/coordinator/registry/scheduler.go
+++ b/coordinator/registry/scheduler.go
@@ -587,11 +587,17 @@ func (r *Registry) buildCandidateWithReason(snap routingSnapshot, pr *PendingReq
 	// 503s at load time ("Insufficient memory … need Y GB") and the request
 	// bounces. This is the hole that let a 93.7 GB model get dispatched to 48/64
 	// GB boxes: the token-budget admission path below never checked physical fit.
-	// Only applies when the model is NOT already resident — modelFitsHardware
-	// uses a conservative *2.5 cold-load headroom estimate, so a model that is
-	// already loaded and serving (and therefore demonstrably fits) must not be
-	// rejected by it. Reported as rejectModelTooLarge (permanent, not capacity).
-	if !snap.modelLoaded && !modelFitsHardware(snap.modelSizeGB, snap.totalMemoryGB) {
+	//
+	// Skip the gate whenever the model is already RESIDENT — a resident model has
+	// demonstrably fit, so the heuristic must never reject it. The provider
+	// reports "running" while actively serving and "idle" when loaded with no
+	// in-flight requests (BatchScheduler+Telemetry: activeRequests>0 ? running :
+	// idle); BOTH mean the weights are in GPU memory. `snap.modelLoaded` only
+	// tracks "running", so we check the slot state directly here — otherwise an
+	// idle-but-loaded provider would be wrongly excluded. Reported as
+	// rejectModelTooLarge (permanent, not capacity).
+	modelResident := snap.slotState == "running" || snap.slotState == "idle"
+	if !modelResident && !modelFitsHardware(snap.modelSizeGB, snap.totalMemoryGB) {
 		return nil, rejectModelTooLarge, false
 	}
 

--- a/coordinator/registry/scheduler.go
+++ b/coordinator/registry/scheduler.go
@@ -821,7 +821,12 @@ func (r *Registry) providerCanAdmitLocked(p *Provider, model string) bool {
 // capacityRejections > 0, providers exist but are all at capacity (429).
 // If candidateCount == 0 && capacityRejections == 0, no provider serves
 // the model at all (404/503).
-func (r *Registry) QuickCapacityCheck(model string, estimatedPromptTokens, requestedMaxTokens int, allowedSerials ...string) (candidateCount, capacityRejections int) {
+//
+//   - modelTooLarge: providers that serve the model but whose memory can never
+//     fit it. Kept separate from capacityRejections so the caller does NOT 429
+//     a model that will never fit (the client would retry forever) — it should
+//     surface model_too_large / 503 instead.
+func (r *Registry) QuickCapacityCheck(model string, estimatedPromptTokens, requestedMaxTokens int, allowedSerials ...string) (candidateCount, capacityRejections, modelTooLarge int) {
 	// Use a dummy PendingRequest with the caller's actual token estimates
 	// for the admission gate (freeMemoryAdmits).
 	if estimatedPromptTokens <= 0 {
@@ -927,6 +932,17 @@ func (r *Registry) QuickCapacityCheck(model string, estimatedPromptTokens, reque
 
 		p.mu.Unlock()
 
+		// Absolute hardware-fit gate (mirrors buildCandidateWithReason). A model
+		// that can never fit this node is a permanent miss, not transient
+		// capacity pressure — count it separately so the caller never 429s it.
+		// Skipped for a resident ("running"/"idle") model, which has demonstrably
+		// fit.
+		modelResident := snap.slotState == "running" || snap.slotState == "idle"
+		if !modelResident && !modelFitsHardware(snap.modelSizeGB, snap.totalMemoryGB) {
+			modelTooLarge++
+			continue
+		}
+
 		// Slot state gate (crashed/reloading are ineligible).
 		if _, eligible := slotStatePenalty(snap.slotState); !eligible {
 			continue
@@ -940,7 +956,7 @@ func (r *Registry) QuickCapacityCheck(model string, estimatedPromptTokens, reque
 
 		candidateCount++
 	}
-	return candidateCount, capacityRejections
+	return candidateCount, capacityRejections, modelTooLarge
 }
 
 // DrainQueuedRequestsForModel attempts to assign queued requests for a

--- a/coordinator/registry/scheduler.go
+++ b/coordinator/registry/scheduler.go
@@ -118,10 +118,15 @@ const (
 )
 
 // modelMemoryHeadroomFactor approximates a model's resident GPU footprint
-// (weights + KV cache + activations) as a multiple of its on-disk weight
-// size. The provider uses 2.0 (ensureModelLoaded); the coordinator uses a
-// slightly looser 2.5 and lets the provider make the final call.
-const modelMemoryHeadroomFactor = 2.5
+// (weights + KV cache + activations) as a multiple of its on-disk weight size.
+// It matches the provider's own load threshold (ensureModelLoaded uses
+// estimatedMemoryGb * 2.0), so this is a HARD "could the provider ever load
+// this" floor — NOT a conservative comfort margin. Using a larger factor (e.g.
+// 2.5) would reject models the provider can actually load: e.g. a model already
+// resident-but-idle on a 64 GB box (loaded at 2.0x) would be wrongly excluded
+// once it left the "running" slot state. Let the provider make the final call;
+// only gate the cases it could never accept.
+const modelMemoryHeadroomFactor = 2.0
 
 // modelFitsHardware reports whether a model of the given on-disk weight size
 // (GB) can plausibly load on a node with the given total unified memory (GB).

--- a/coordinator/registry/scheduler.go
+++ b/coordinator/registry/scheduler.go
@@ -81,6 +81,7 @@ type routingSnapshot struct {
 	gpuMemoryActiveGB  float64
 	totalMemoryGB      float64
 	modelSizeGB        float64 // catalog-reported weight footprint (0 = unknown, gate disabled)
+	minRAMGb           int     // catalog authoritative min RAM (GB) to run the model (0 = unknown)
 	modelLoaded        bool    // true when the requested model is the currently-running slot
 	availableOnDisk    bool    // model is in provider's Models list but not currently loaded
 
@@ -117,33 +118,33 @@ const (
 	rejectModelTooLarge
 )
 
-// modelMemoryHeadroomFactor approximates a model's resident GPU footprint as a
-// multiple of its CATALOG on-disk weight size (SizeGB = TotalSizeBytes/1e9).
-// It must match what the provider actually requires at load time so the
-// coordinator never dispatches a model the provider will reject:
-//
-//	provider estimatedMemoryGb = weightGiB * 1.2   (ModelScanner overhead)
-//	provider requiredGb        = estimatedMemoryGb * 2.0   (ensureModelLoaded)
-//	                           ≈ weight * 2.4
-//
-// So 2.4, not 2.0: at 2.0 a ~28 GB-weight model passes here (28*2=56 ≤ 64) but
-// the provider needs 28*2.4≈67 GB and rejects it at load on a 64 GB Mac. This
-// gate only runs for COLD loads — a resident ("running"/"idle") model is
-// exempted by the caller, so a slightly conservative factor can't wrongly evict
-// a model that already fit.
-const modelMemoryHeadroomFactor = 2.4
+// modelMemoryHeadroomFactor is the FALLBACK multiple of the on-disk weight size
+// used to estimate a model's resident footprint ONLY when the catalog has no
+// authoritative min_ram_gb. Prefer min_ram_gb (see modelFitsHardware): a
+// synthetic multiple of the raw weight does not match what the operator
+// published or what the provider actually loads, and at 2.x it wrongly rejected
+// catalog-qualified nodes (e.g. gpt-oss-20b min_ram_gb=24 vs 12.1*2.x>24, and
+// gemma-4-26b min_ram_gb=36 vs 28*2.x rejecting the whole 64 GB tier).
+const modelMemoryHeadroomFactor = 2.0
 
-// modelFitsHardware reports whether a model of the given on-disk weight size
-// (GB) can plausibly load on a node with the given total unified memory (GB).
-// It fails OPEN when either input is unknown (<=0): callers that need a hard
-// "definitely cannot fit" signal must check sizeGB>0 themselves. Shared by the
-// consumer-routing admission gate (freeMemoryAdmits) and the pre-warm gate
-// (eligibleProviderPendingCount) so the two can never drift.
-func modelFitsHardware(modelSizeGB, totalMemoryGB float64) bool {
-	if modelSizeGB <= 0 || totalMemoryGB <= 0 {
+// modelFitsHardware reports whether a model can run on a node with the given
+// total unified memory (GB). It prefers the catalog's authoritative min_ram_gb
+// (the operator-published requirement) and only falls back to a heuristic
+// multiple of the on-disk weight size when min_ram_gb is unknown. Fails OPEN
+// when nothing is known. The provider still performs the final precise check at
+// load time; this gate only filters models that clearly cannot fit per the
+// catalog's own contract.
+func modelFitsHardware(minRAMGb int, modelSizeGB, totalMemoryGB float64) bool {
+	if totalMemoryGB <= 0 {
 		return true
 	}
-	return modelSizeGB*modelMemoryHeadroomFactor <= totalMemoryGB
+	if minRAMGb > 0 {
+		return float64(minRAMGb) <= totalMemoryGB
+	}
+	if modelSizeGB > 0 {
+		return modelSizeGB*modelMemoryHeadroomFactor <= totalMemoryGB
+	}
+	return true
 }
 
 // costBreakdown decomposes the routing cost so callers can log or
@@ -444,6 +445,7 @@ func (r *Registry) snapshotProviderLocked(p *Provider, model string) (routingSna
 		prefillTPS:    resolvedPrefillTPS(p),
 		totalMemoryGB: float64(p.Hardware.MemoryGB),
 		modelSizeGB:   r.catalogSizeGBLocked(model),
+		minRAMGb:      r.catalogMinRAMGbLocked(model),
 	}
 
 	for _, pr := range p.pendingReqs {
@@ -602,7 +604,7 @@ func (r *Registry) buildCandidateWithReason(snap routingSnapshot, pr *PendingReq
 	// idle-but-loaded provider would be wrongly excluded. Reported as
 	// rejectModelTooLarge (permanent, not capacity).
 	modelResident := snap.slotState == "running" || snap.slotState == "idle"
-	if !modelResident && !modelFitsHardware(snap.modelSizeGB, snap.totalMemoryGB) {
+	if !modelResident && !modelFitsHardware(snap.minRAMGb, snap.modelSizeGB, snap.totalMemoryGB) {
 		return nil, rejectModelTooLarge, false
 	}
 
@@ -907,6 +909,7 @@ func (r *Registry) QuickCapacityCheck(model string, estimatedPromptTokens, reque
 			totalPending:  p.pendingCount(),
 			totalMemoryGB: float64(p.Hardware.MemoryGB),
 			modelSizeGB:   r.catalogSizeGBLocked(model),
+			minRAMGb:      r.catalogMinRAMGbLocked(model),
 		}
 		for _, pending := range p.pendingReqs {
 			if pending.Model != model {
@@ -943,7 +946,7 @@ func (r *Registry) QuickCapacityCheck(model string, estimatedPromptTokens, reque
 		// Skipped for a resident ("running"/"idle") model, which has demonstrably
 		// fit.
 		modelResident := snap.slotState == "running" || snap.slotState == "idle"
-		if !modelResident && !modelFitsHardware(snap.modelSizeGB, snap.totalMemoryGB) {
+		if !modelResident && !modelFitsHardware(snap.minRAMGb, snap.modelSizeGB, snap.totalMemoryGB) {
 			modelTooLarge++
 			continue
 		}

--- a/coordinator/registry/scheduler.go
+++ b/coordinator/registry/scheduler.go
@@ -110,7 +110,31 @@ type candidateRejection int
 const (
 	rejectNone candidateRejection = iota
 	rejectCapacity
+	// rejectModelTooLarge means the model's resident footprint cannot fit in
+	// this provider's total memory under any load state. Unlike rejectCapacity
+	// (transient "full, retry later") this is permanent for this provider, so
+	// it must NOT inflate the busy/429 signal.
+	rejectModelTooLarge
 )
+
+// modelMemoryHeadroomFactor approximates a model's resident GPU footprint
+// (weights + KV cache + activations) as a multiple of its on-disk weight
+// size. The provider uses 2.0 (ensureModelLoaded); the coordinator uses a
+// slightly looser 2.5 and lets the provider make the final call.
+const modelMemoryHeadroomFactor = 2.5
+
+// modelFitsHardware reports whether a model of the given on-disk weight size
+// (GB) can plausibly load on a node with the given total unified memory (GB).
+// It fails OPEN when either input is unknown (<=0): callers that need a hard
+// "definitely cannot fit" signal must check sizeGB>0 themselves. Shared by the
+// consumer-routing admission gate (freeMemoryAdmits) and the pre-warm gate
+// (eligibleProviderPendingCount) so the two can never drift.
+func modelFitsHardware(modelSizeGB, totalMemoryGB float64) bool {
+	if modelSizeGB <= 0 || totalMemoryGB <= 0 {
+		return true
+	}
+	return modelSizeGB*modelMemoryHeadroomFactor <= totalMemoryGB
+}
 
 // costBreakdown decomposes the routing cost so callers can log or
 // expose individual contributions. The numeric values match the terms
@@ -141,9 +165,14 @@ type RoutingDecision struct {
 	HealthMs           float64 // memory/CPU/thermal/GPU-util contribution
 	EffectiveQueue     int     // max(pendingForModel, backendRunning+backendWaiting)
 	CandidateCount     int     // total candidates that passed all gates
-	CapacityRejections int     // candidates rejected by the free-memory admission gate
-	EffectiveTPS       float64 // load-scaled decode TPS used in cost (Phase 4)
-	StaticTPS          float64 // benchmarked decode TPS before load scaling
+	CapacityRejections int     // candidates rejected by the free-memory admission gate (transient: full)
+	// ModelTooLargeRejections counts providers that serve the model but whose
+	// total memory can never fit it (permanent). Kept separate from
+	// CapacityRejections so callers don't emit a 429/"over capacity, retry"
+	// signal for a model that will never fit anywhere of this size.
+	ModelTooLargeRejections int
+	EffectiveTPS            float64 // load-scaled decode TPS used in cost (Phase 4)
+	StaticTPS               float64 // benchmarked decode TPS before load scaling
 }
 
 // ReserveProvider selects a hardware-routable provider for the request and
@@ -174,12 +203,13 @@ func (r *Registry) ReserveProviderEx(model string, pr *PendingRequest, excludeID
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	selected, candidateCount, capacityRejections := r.selectBestCandidateLockedFull(model, pr, excludeIDs...)
+	selected, candidateCount, capacityRejections, tooLargeRejections := r.selectBestCandidateLockedFull(model, pr, excludeIDs...)
 	if selected == nil {
 		return nil, RoutingDecision{
-			Model:              model,
-			CandidateCount:     candidateCount,
-			CapacityRejections: capacityRejections,
+			Model:                   model,
+			CandidateCount:          candidateCount,
+			CapacityRejections:      capacityRejections,
+			ModelTooLargeRejections: tooLargeRejections,
 		}
 	}
 
@@ -191,9 +221,10 @@ func (r *Registry) ReserveProviderEx(model string, pr *PendingRequest, excludeID
 	// changed the pending set between snapshot and reservation.
 	if !r.providerCanAdmitLocked(p, model) {
 		return nil, RoutingDecision{
-			Model:              model,
-			CandidateCount:     candidateCount,
-			CapacityRejections: capacityRejections,
+			Model:                   model,
+			CandidateCount:          candidateCount,
+			CapacityRejections:      capacityRejections,
+			ModelTooLargeRejections: tooLargeRejections,
 		}
 	}
 
@@ -205,20 +236,21 @@ func (r *Registry) ReserveProviderEx(model string, pr *PendingRequest, excludeID
 
 	bd := selected.breakdown
 	decision := RoutingDecision{
-		ProviderID:         p.ID,
-		Model:              model,
-		CostMs:             bd.Total,
-		StateMs:            bd.StateMs,
-		QueueMs:            bd.QueueMs,
-		PendingMs:          bd.PendingMs,
-		BacklogMs:          bd.BacklogMs,
-		ThisReqMs:          bd.ThisReqMs,
-		HealthMs:           bd.HealthMs,
-		EffectiveQueue:     selected.effectiveQueue,
-		CandidateCount:     candidateCount,
-		CapacityRejections: capacityRejections,
-		EffectiveTPS:       selected.effectiveTPS,
-		StaticTPS:          selected.snapshot.decodeTPS,
+		ProviderID:              p.ID,
+		Model:                   model,
+		CostMs:                  bd.Total,
+		StateMs:                 bd.StateMs,
+		QueueMs:                 bd.QueueMs,
+		PendingMs:               bd.PendingMs,
+		BacklogMs:               bd.BacklogMs,
+		ThisReqMs:               bd.ThisReqMs,
+		HealthMs:                bd.HealthMs,
+		EffectiveQueue:          selected.effectiveQueue,
+		CandidateCount:          candidateCount,
+		CapacityRejections:      capacityRejections,
+		ModelTooLargeRejections: tooLargeRejections,
+		EffectiveTPS:            selected.effectiveTPS,
+		StaticTPS:               selected.snapshot.decodeTPS,
 	}
 	return p, decision
 }
@@ -229,7 +261,7 @@ func (r *Registry) ReserveProviderEx(model string, pr *PendingRequest, excludeID
 // distinguish "no provider serves this model" from "every fitting
 // provider is over-subscribed", which is the difference between the
 // no_provider and over_capacity outcome counters.
-func (r *Registry) selectBestCandidateLockedFull(model string, pr *PendingRequest, excludeIDs ...string) (*routingCandidate, int, int) {
+func (r *Registry) selectBestCandidateLockedFull(model string, pr *PendingRequest, excludeIDs ...string) (*routingCandidate, int, int, int) {
 	excludeSet := make(map[string]struct{}, len(excludeIDs))
 	for _, id := range excludeIDs {
 		excludeSet[id] = struct{}{}
@@ -248,6 +280,7 @@ func (r *Registry) selectBestCandidateLockedFull(model string, pr *PendingReques
 	candidates := make([]*routingCandidate, 0, len(r.providers))
 	candidateCount := 0
 	capacityRejections := 0
+	tooLargeRejections := 0
 	for _, p := range r.providers {
 		if len(allowedSerials) > 0 {
 			if !providerMatchesAllowedSerial(p, allowedSerials) {
@@ -263,8 +296,11 @@ func (r *Registry) selectBestCandidateLockedFull(model string, pr *PendingReques
 		}
 		candidate, reason, ok := r.buildCandidateWithReason(snap, pr)
 		if !ok {
-			if reason == rejectCapacity {
+			switch reason {
+			case rejectCapacity:
 				capacityRejections++
+			case rejectModelTooLarge:
+				tooLargeRejections++
 			}
 			continue
 		}
@@ -273,7 +309,7 @@ func (r *Registry) selectBestCandidateLockedFull(model string, pr *PendingReques
 	}
 
 	if len(candidates) == 0 {
-		return nil, candidateCount, capacityRejections
+		return nil, candidateCount, capacityRejections, tooLargeRejections
 	}
 
 	var best *routingCandidate
@@ -316,7 +352,7 @@ func (r *Registry) selectBestCandidateLockedFull(model string, pr *PendingReques
 		}
 	}
 	r.logRoutingDecision(model, pr, winner, candidateCount)
-	return winner, candidateCount, capacityRejections
+	return winner, candidateCount, capacityRejections, tooLargeRejections
 }
 
 func providerMatchesAllowedSerial(p *Provider, allowed map[string]struct{}) bool {
@@ -538,6 +574,20 @@ func (r *Registry) buildCandidateWithReason(snap routingSnapshot, pr *PendingReq
 	reqPrompt := pr.EstimatedPromptTokens
 	if reqPrompt < 0 {
 		reqPrompt = 0
+	}
+
+	// Absolute hardware-fit gate (cold-load only, both admission modes). A model
+	// whose footprint can never fit in this node's total memory must not be
+	// routed here regardless of advertised token budget — otherwise the provider
+	// 503s at load time ("Insufficient memory … need Y GB") and the request
+	// bounces. This is the hole that let a 93.7 GB model get dispatched to 48/64
+	// GB boxes: the token-budget admission path below never checked physical fit.
+	// Only applies when the model is NOT already resident — modelFitsHardware
+	// uses a conservative *2.5 cold-load headroom estimate, so a model that is
+	// already loaded and serving (and therefore demonstrably fits) must not be
+	// rejected by it. Reported as rejectModelTooLarge (permanent, not capacity).
+	if !snap.modelLoaded && !modelFitsHardware(snap.modelSizeGB, snap.totalMemoryGB) {
+		return nil, rejectModelTooLarge, false
 	}
 
 	// Free-memory admission gate (Phase 1). A provider that claims to

--- a/coordinator/registry/scheduler_test.go
+++ b/coordinator/registry/scheduler_test.go
@@ -767,7 +767,7 @@ func TestQuickCapacityCheckCountsPendingPromptAndMaxTokens(t *testing.T) {
 		RequestedMaxTokens:    1_000,
 	})
 
-	candidates, rejections := reg.QuickCapacityCheck(model, 1_000, 256)
+	candidates, rejections, _ := reg.QuickCapacityCheck(model, 1_000, 256)
 	if candidates != 0 || rejections != 1 {
 		t.Fatalf("QuickCapacityCheck candidates=%d rejections=%d, want 0/1", candidates, rejections)
 	}
@@ -905,7 +905,7 @@ func TestPerSlotMaxConcurrencyLimitsRoutingForModel(t *testing.T) {
 		t.Fatalf("decision=%+v, want one capacity rejection at per-slot cap", decision)
 	}
 
-	candidates, rejections := reg.QuickCapacityCheck(model, 100, 128)
+	candidates, rejections, _ := reg.QuickCapacityCheck(model, 100, 128)
 	if candidates != 0 || rejections != 1 {
 		t.Fatalf("QuickCapacityCheck candidates=%d rejections=%d, want 0/1", candidates, rejections)
 	}
@@ -932,12 +932,33 @@ func TestPerSlotMaxConcurrencyZeroFallsBack(t *testing.T) {
 	for i := range 4 {
 		p.AddPending(&PendingRequest{RequestID: fmt.Sprintf("existing-%d", i), Model: model})
 	}
-	candidates, rejections := reg.QuickCapacityCheck(model, 100, 128)
+	candidates, rejections, _ := reg.QuickCapacityCheck(model, 100, 128)
 	if candidates != 1 || rejections != 0 {
 		t.Fatalf("QuickCapacityCheck candidates=%d rejections=%d, want 1/0", candidates, rejections)
 	}
 	if found := reg.FindProvider(model); found == nil {
 		t.Fatal("FindProvider should use fallback cap when max_concurrency is zero")
+	}
+}
+
+// TestQuickCapacityCheckReportsModelTooLarge is the preflight half of the
+// model_too_large fix: a cold model that can never fit must be reported as
+// modelTooLarge, NOT capacityRejections — otherwise the consumer preflight 429s
+// it and the client retries a model that will never fit. Regression for the
+// Codex review finding on the QuickCapacityCheck preflight.
+func TestQuickCapacityCheckReportsModelTooLarge(t *testing.T) {
+	reg := New(testLogger())
+	model := "preflight-too-large"
+	reg.SetModelCatalog([]CatalogEntry{{ID: model, SizeGB: 128}}) // needs 128*2=256GB
+	p := makeSchedulerProvider(t, reg, "small-box", model, 80)
+	p.mu.Lock()
+	p.BackendCapacity.TotalMemoryGB = 64
+	p.BackendCapacity.Slots[0].State = "idle_shutdown" // cold: model not resident
+	p.mu.Unlock()
+
+	candidates, rejections, tooLarge := reg.QuickCapacityCheck(model, 100, 128)
+	if candidates != 0 || rejections != 0 || tooLarge != 1 {
+		t.Fatalf("QuickCapacityCheck = (cand=%d, rej=%d, tooLarge=%d), want 0/0/1", candidates, rejections, tooLarge)
 	}
 }
 
@@ -962,7 +983,7 @@ func TestPerSlotMaxConcurrencyUsesBackendReportedLoad(t *testing.T) {
 		t.Fatalf("decision=%+v, want one capacity rejection from backend slot load", decision)
 	}
 
-	candidates, rejections := reg.QuickCapacityCheck(model, 100, 128)
+	candidates, rejections, _ := reg.QuickCapacityCheck(model, 100, 128)
 	if candidates != 0 || rejections != 1 {
 		t.Fatalf("QuickCapacityCheck candidates=%d rejections=%d, want 0/1", candidates, rejections)
 	}
@@ -1009,7 +1030,7 @@ func TestManyPerSlotCapsRespectProviderWideAggregateCap(t *testing.T) {
 	if decision.CandidateCount != 0 || decision.CapacityRejections != 1 {
 		t.Fatalf("decision=%+v, want one capacity rejection at aggregate cap", decision)
 	}
-	candidates, rejections := reg.QuickCapacityCheck(models[0], 100, 128)
+	candidates, rejections, _ := reg.QuickCapacityCheck(models[0], 100, 128)
 	if candidates != 0 || rejections != 1 {
 		t.Fatalf("QuickCapacityCheck candidates=%d rejections=%d, want 0/1", candidates, rejections)
 	}
@@ -1174,7 +1195,7 @@ func TestSlotHeadroomWithExhaustedTokenBudgetRejectsCapacity(t *testing.T) {
 	if decision.CandidateCount != 0 || decision.CapacityRejections != 1 {
 		t.Fatalf("decision=%+v, want one capacity rejection from token budget", decision)
 	}
-	candidates, rejections := reg.QuickCapacityCheck(model, 256, 1024)
+	candidates, rejections, _ := reg.QuickCapacityCheck(model, 256, 1024)
 	if candidates != 0 || rejections != 1 {
 		t.Fatalf("QuickCapacityCheck candidates=%d rejections=%d, want 0/1", candidates, rejections)
 	}

--- a/coordinator/registry/scheduler_test.go
+++ b/coordinator/registry/scheduler_test.go
@@ -962,6 +962,26 @@ func TestQuickCapacityCheckReportsModelTooLarge(t *testing.T) {
 	}
 }
 
+// TestModelFitUsesProviderMultiplier guards the 2.4x gate: a 28 GB-weight model
+// passes a naive 2.0x check (56 ≤ 64) but the provider actually needs ~2.4x
+// (≈67 GB) and rejects it at load on a 64 GB box. The coordinator must surface
+// model_too_large rather than dispatch a model the provider can never load.
+func TestModelFitUsesProviderMultiplier(t *testing.T) {
+	reg := New(testLogger())
+	model := "fit-multiplier-model"
+	reg.SetModelCatalog([]CatalogEntry{{ID: model, SizeGB: 28}})
+	p := makeSchedulerProvider(t, reg, "box64", model, 80)
+	p.mu.Lock()
+	p.BackendCapacity.TotalMemoryGB = 64
+	p.BackendCapacity.Slots[0].State = "idle_shutdown" // cold: gate applies
+	p.mu.Unlock()
+
+	_, _, tooLarge := reg.QuickCapacityCheck(model, 100, 128)
+	if tooLarge != 1 {
+		t.Fatalf("28GB model on 64GB box: want modelTooLarge=1 (needs ~67GB at 2.4x), got %d", tooLarge)
+	}
+}
+
 func TestPerSlotMaxConcurrencyUsesBackendReportedLoad(t *testing.T) {
 	reg := New(testLogger())
 	model := "backend-loaded-model"

--- a/coordinator/registry/scheduler_test.go
+++ b/coordinator/registry/scheduler_test.go
@@ -962,23 +962,53 @@ func TestQuickCapacityCheckReportsModelTooLarge(t *testing.T) {
 	}
 }
 
-// TestModelFitUsesProviderMultiplier guards the 2.4x gate: a 28 GB-weight model
-// passes a naive 2.0x check (56 ≤ 64) but the provider actually needs ~2.4x
-// (≈67 GB) and rejects it at load on a 64 GB box. The coordinator must surface
-// model_too_large rather than dispatch a model the provider can never load.
-func TestModelFitUsesProviderMultiplier(t *testing.T) {
+// TestModelFitPrefersCatalogMinRAM is the core fix: the fit gate must use the
+// catalog's authoritative min_ram_gb, NOT a synthetic multiple of the weight.
+// A 28 GB-weight model (gemma-like) with min_ram_gb=36 must be ADMITTED on a
+// 64 GB box (a multiplier of 2.x would have wrongly rejected the whole 64 GB
+// tier), and REJECTED on a 24 GB box (below the published minimum).
+func TestModelFitPrefersCatalogMinRAM(t *testing.T) {
+	model := "gemma-like"
+	// Qualifies on 64 GB (min_ram_gb=36 ≤ 64).
 	reg := New(testLogger())
-	model := "fit-multiplier-model"
-	reg.SetModelCatalog([]CatalogEntry{{ID: model, SizeGB: 28}})
+	reg.SetModelCatalog([]CatalogEntry{{ID: model, SizeGB: 28, MinRAMGB: 36}})
 	p := makeSchedulerProvider(t, reg, "box64", model, 80)
 	p.mu.Lock()
 	p.BackendCapacity.TotalMemoryGB = 64
 	p.BackendCapacity.Slots[0].State = "idle_shutdown" // cold: gate applies
 	p.mu.Unlock()
+	if _, _, tooLarge := reg.QuickCapacityCheck(model, 100, 128); tooLarge != 0 {
+		t.Fatalf("min_ram_gb=36 on 64GB box must be admitted, got modelTooLarge=%d", tooLarge)
+	}
 
-	_, _, tooLarge := reg.QuickCapacityCheck(model, 100, 128)
-	if tooLarge != 1 {
-		t.Fatalf("28GB model on 64GB box: want modelTooLarge=1 (needs ~67GB at 2.4x), got %d", tooLarge)
+	// Rejected on 24 GB (below min_ram_gb=36).
+	reg2 := New(testLogger())
+	reg2.SetModelCatalog([]CatalogEntry{{ID: model, SizeGB: 28, MinRAMGB: 36}})
+	small := makeSchedulerProvider(t, reg2, "box24", model, 80)
+	small.mu.Lock()
+	small.BackendCapacity.TotalMemoryGB = 24
+	small.BackendCapacity.Slots[0].State = "idle_shutdown"
+	small.mu.Unlock()
+	if _, _, tooLarge := reg2.QuickCapacityCheck(model, 100, 128); tooLarge != 1 {
+		t.Fatalf("min_ram_gb=36 on 24GB box must be model_too_large, got %d", tooLarge)
+	}
+}
+
+// TestModelFitGptOssOn24GB is the operator-facing case: gpt-oss-20b
+// (min_ram_gb=24) must be ADMITTED on a 24 GB box — the catalog says it
+// qualifies, and a weight×multiplier gate (12.1×2.x > 24) would wrongly reject
+// it and starve every 24 GB node of traffic.
+func TestModelFitGptOssOn24GB(t *testing.T) {
+	reg := New(testLogger())
+	model := "gpt-oss-20b"
+	reg.SetModelCatalog([]CatalogEntry{{ID: model, SizeGB: 12.1, MinRAMGB: 24}})
+	p := makeSchedulerProvider(t, reg, "box24", model, 80)
+	p.mu.Lock()
+	p.BackendCapacity.TotalMemoryGB = 24
+	p.BackendCapacity.Slots[0].State = "idle_shutdown"
+	p.mu.Unlock()
+	if _, _, tooLarge := reg.QuickCapacityCheck(model, 100, 128); tooLarge != 0 {
+		t.Fatalf("gpt-oss-20b (min_ram_gb=24) on a 24GB box must be admitted, got modelTooLarge=%d", tooLarge)
 	}
 }
 

--- a/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClient.swift
+++ b/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClient.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Network
 #if canImport(os)
 import os
 #endif
@@ -153,6 +154,55 @@ private final class ManagedAtomic<Value: FixedWidthInteger>: @unchecked Sendable
     }
 }
 
+// MARK: - OutboundRouter (per-connection outbound delivery)
+
+/// Routes outbound messages to the *current* connection's stream.
+///
+/// The stable `send` closure handed to callers (ProviderLoop) routes through
+/// this so it always reaches the live session. Crucially, the outbound
+/// `AsyncStream` is recreated for every connection: an `AsyncStream` is
+/// single-shot, so once a session's consuming task is cancelled on disconnect
+/// its iterator is permanently terminated. Reusing one stream across reconnects
+/// silently dropped every outbound message -- including attestation challenge
+/// responses -- after the first reconnect, leaving providers stuck
+/// `hardware/untrusted reason=timeout` on an otherwise-healthy connection
+/// (heartbeats and ping/pong run on separate tasks, so the socket stayed up).
+///
+/// A lock (matching PongTracker/ManagedAtomic) is used instead of actor
+/// isolation so `send` can stay a synchronous, non-async closure.
+private final class OutboundRouter: @unchecked Sendable {
+    private let lock = OSAllocatedUnfairLock()
+    private var continuation: AsyncStream<OutboundMessage>.Continuation?
+
+    /// Install the continuation for a new connection, finishing any prior one.
+    func activate(_ cont: AsyncStream<OutboundMessage>.Continuation) {
+        let previous: AsyncStream<OutboundMessage>.Continuation? = lock.withLock {
+            let prev = continuation
+            continuation = cont
+            return prev
+        }
+        previous?.finish()
+    }
+
+    /// Yield a message to the current connection, if any. Messages produced
+    /// while disconnected are dropped (the caller cannot reach the coordinator
+    /// anyway) rather than buffered into a stream nothing is consuming.
+    func yield(_ msg: OutboundMessage) {
+        let cont = lock.withLock { continuation }
+        cont?.yield(msg)
+    }
+
+    /// Tear down outbound delivery permanently (shutdown).
+    func finish() {
+        let cont: AsyncStream<OutboundMessage>.Continuation? = lock.withLock {
+            let c = continuation
+            continuation = nil
+            return c
+        }
+        cont?.finish()
+    }
+}
+
 // MARK: - Configuration
 
 public struct CoordinatorClientConfig: Sendable {
@@ -274,6 +324,38 @@ public struct AttestationResponsePayload: Sendable {
     }
 }
 
+// MARK: - Reachability
+
+/// Lightweight wrapper over NWPathMonitor that tracks current network
+/// reachability. The reconnect loop uses it to distinguish "the coordinator is
+/// down" from "this box has no internet" — the latter is the dominant cause of
+/// provider flap across the fleet and is an operator/network problem, not a
+/// coordinator one. Surfacing it in reconnect telemetry makes that split
+/// visible instead of every drop looking like a coordinator fault.
+final class ReachabilityMonitor: @unchecked Sendable {
+    private let monitor = NWPathMonitor()
+    private let queue = DispatchQueue(label: "dev.darkbloom.reachability")
+    private let lock = NSLock()
+    private var _reachable = true
+
+    init() {
+        monitor.pathUpdateHandler = { [weak self] path in
+            guard let self else { return }
+            self.lock.lock()
+            self._reachable = (path.status == .satisfied)
+            self.lock.unlock()
+        }
+        monitor.start(queue: queue)
+    }
+
+    var isReachable: Bool {
+        lock.lock(); defer { lock.unlock() }
+        return _reachable
+    }
+
+    func stop() { monitor.cancel() }
+}
+
 // MARK: - Coordinator Client Actor
 
 public actor CoordinatorClient {
@@ -283,8 +365,15 @@ public actor CoordinatorClient {
 
     private let logger = Logger(subsystem: "dev.darkbloom.provider", category: "coordinator")
 
+    /// Tracks whether the box currently has a usable network path, so reconnect
+    /// logs/telemetry can attribute flap to local connectivity vs the coordinator.
+    private let reachability = ReachabilityMonitor()
+
     private var eventContinuation: AsyncStream<CoordinatorEvent>.Continuation?
-    private var outboundContinuation: AsyncStream<OutboundMessage>.Continuation?
+    /// Holds the current connection's outbound continuation. The outbound stream
+    /// is recreated per connection (see OutboundRouter / connectAndRun); reusing
+    /// one AsyncStream across reconnects silently kills outbound delivery.
+    private let outboundRouter = OutboundRouter()
 
     private var webSocketTask: URLSessionWebSocketTask?
     private var urlSession: URLSession?
@@ -307,16 +396,17 @@ public actor CoordinatorClient {
         let (eventStream, eventCont) = AsyncStream<CoordinatorEvent>.makeStream()
         self.eventContinuation = eventCont
 
-        let (outboundStream, outboundCont) = AsyncStream<OutboundMessage>.makeStream()
-        self.outboundContinuation = outboundCont
-
+        // The outbound stream is created per-connection inside connectAndRun and
+        // registered with the router; the stable send closure always routes
+        // through the router to the live session.
+        let router = self.outboundRouter
         let sendFn: @Sendable (OutboundMessage) -> Void = { msg in
-            outboundCont.yield(msg)
+            router.yield(msg)
         }
 
         Task { [weak self] in
             guard let self else { return }
-            await self.runLoop(outboundStream: outboundStream)
+            await self.runLoop()
         }
 
         return (eventStream, sendFn)
@@ -326,12 +416,12 @@ public actor CoordinatorClient {
         shutdownRequested = true
         webSocketTask?.cancel(with: .goingAway, reason: nil)
         eventContinuation?.finish()
-        outboundContinuation?.finish()
+        outboundRouter.finish()
     }
 
     // MARK: - Connection Loop
 
-    private func runLoop(outboundStream: AsyncStream<OutboundMessage>) async {
+    private func runLoop() async {
         var backoff = ExponentialBackoff(base: 1.0, max: 30.0)
         var reconnectCount: UInt64 = 0
 
@@ -339,7 +429,7 @@ public actor CoordinatorClient {
             logger.info("Connecting to coordinator: \(self.config.url)")
 
             do {
-                try await connectAndRun(outboundStream: outboundStream)
+                try await connectAndRun()
                 logger.info("Coordinator connection closed, reconnecting...")
                 backoff.reset()
                 continue
@@ -348,7 +438,8 @@ public actor CoordinatorClient {
 
                 eventContinuation?.yield(.disconnected)
                 let delay = backoff.nextDelay()
-                logger.warning("Coordinator connection error: \(error.localizedDescription). Reconnecting in \(delay)s")
+                let reachable = reachability.isReachable
+                logger.warning("Coordinator connection error: \(error.localizedDescription). network_reachable=\(reachable). Reconnecting in \(delay)s")
 
                 reconnectCount += 1
                 if shouldEmitReconnectTelemetry(count: reconnectCount) {
@@ -370,7 +461,7 @@ public actor CoordinatorClient {
 
     // MARK: - Single Connection Session
 
-    private func connectAndRun(outboundStream: AsyncStream<OutboundMessage>) async throws {
+    private func connectAndRun() async throws {
         guard let url = URL(string: config.url) else {
             throw CoordinatorError.invalidURL(config.url)
         }
@@ -383,6 +474,16 @@ public actor CoordinatorClient {
 
         try await sendRegistration(ws: ws)
         logger.info("Sent registration to coordinator")
+
+        // Fresh outbound stream for THIS connection. AsyncStream is single-shot:
+        // its iterator is terminated when the previous session's consumer task is
+        // cancelled on disconnect, so a reused stream would never deliver another
+        // message. Recreating it per connection (and routing the stable send
+        // closure through outboundRouter) is what keeps attestation responses and
+        // inference replies flowing after a reconnect. Activate before announcing
+        // .connected so any immediate outbound is buffered, not dropped.
+        let (outboundStream, outboundCont) = AsyncStream<OutboundMessage>.makeStream()
+        outboundRouter.activate(outboundCont)
 
         eventContinuation?.yield(.connected)
 
@@ -660,6 +761,7 @@ public actor CoordinatorClient {
     }
 
     private func emitReconnectTelemetry(count: UInt64, error: Error) {
+        let reachable = reachability.isReachable
         TelemetryClient.shared.emit(
             kind: .connectivity,
             severity: .warn,
@@ -668,9 +770,12 @@ public actor CoordinatorClient {
                 "reconnect_count": .int(Int(count)),
                 "last_error": .string(error.localizedDescription),
                 "coordinator_url": .string(config.url),
+                // Distinguishes "coordinator down" from "box lost internet" —
+                // the latter is the dominant, operator-side cause of flap.
+                "network_reachable": .bool(reachable),
             ]
         )
-        logger.warning("Reconnect telemetry: count=\(count) error=\(error.localizedDescription)")
+        logger.warning("Reconnect telemetry: count=\(count) network_reachable=\(reachable) error=\(error.localizedDescription)")
     }
 }
 

--- a/provider-swift/Sources/ProviderCore/Coordinator/ExponentialBackoff.swift
+++ b/provider-swift/Sources/ProviderCore/Coordinator/ExponentialBackoff.swift
@@ -2,20 +2,31 @@ import Foundation
 
 public struct ExponentialBackoff: Sendable {
     private var current: TimeInterval
+    private let base: TimeInterval
     private let max: TimeInterval
 
     public init(base: TimeInterval = 1.0, max: TimeInterval = 30.0) {
+        self.base = base
         self.current = base
         self.max = max
     }
 
+    /// Returns the next backoff delay using "equal jitter": half the
+    /// deterministic exponential delay, plus a random amount up to the other
+    /// half. The deterministic component still doubles (capped at `max`).
+    ///
+    /// Jitter matters at fleet scale: without it, every provider that dropped on
+    /// the same coordinator blip reconnects in lockstep (1s, 2s, 4s, …), and the
+    /// synchronized reconnect herd can knock the coordinator straight back over.
+    /// Spreading reconnects across the window breaks that resonance.
     public mutating func nextDelay() -> TimeInterval {
-        let delay = current
+        let deterministic = current
         current = Swift.min(current * 2, max)
-        return delay
+        let half = deterministic / 2
+        return half + Double.random(in: 0...half)
     }
 
     public mutating func reset() {
-        current = 1.0
+        current = base
     }
 }

--- a/provider-swift/Sources/ProviderCore/Inference/BatchScheduler+EngineBridge.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/BatchScheduler+EngineBridge.swift
@@ -112,9 +112,12 @@ extension BatchScheduler {
                             completionTokens: output.completionTokens,
                             success: true
                         )
+                        // Emit the authoritative (max of observed-vs-terminal)
+                        // counts from recordFinish, not the raw terminal output
+                        // — the terminal can under-report and zero out billing.
                         continuation.yield(.info(
-                            promptTokens: output.promptTokens,
-                            completionTokens: output.completionTokens,
+                            promptTokens: usage.promptTokens,
+                            completionTokens: usage.completionTokens,
                             tokensPerSecond: usage.tps
                         ))
                     }
@@ -178,28 +181,36 @@ extension BatchScheduler {
         promptTokens: Int,
         completionTokens: Int,
         success: Bool
-    ) async -> (tps: Double, durationSeconds: Double) {
+    ) async -> (tps: Double, durationSeconds: Double, promptTokens: Int, completionTokens: Int) {
         guard var bridge = activeBridges.removeValue(forKey: requestId) else {
-            return (0, 0)
+            return (0, 0, 0, 0)
         }
         let finishedAt = ContinuousClock.now
         bridge.lastTokenAt = finishedAt
-        bridge.completionTokens = completionTokens
+        // Billing-zero fix: a terminal RequestOutput sometimes reports fewer
+        // tokens (often 0) than were already observed streaming via
+        // recordProgress. Previously we OVERWROTE the live count with the
+        // terminal value, so a completed request could settle at (0,0) — the
+        // coordinator then bills $0 and fully refunds. max() means the terminal
+        // can only ever raise the count, never zero an observed one.
+        bridge.completionTokens = max(bridge.completionTokens, completionTokens)
         bridge.promptTokens = max(bridge.promptTokens, promptTokens)
+        let finalCompletion = bridge.completionTokens
+        let finalPrompt = bridge.promptTokens
 
         let tps: Double
-        if let firstTokenAt = bridge.firstTokenAt, completionTokens > 1 {
+        if let firstTokenAt = bridge.firstTokenAt, finalCompletion > 1 {
             let elapsed = finishedAt - firstTokenAt
             let elapsedSeconds = Double(elapsed.components.seconds)
                 + Double(elapsed.components.attoseconds) / 1e18
             tps = elapsedSeconds > 0
-                ? Double(completionTokens - 1) / elapsedSeconds : 0
+                ? Double(finalCompletion - 1) / elapsedSeconds : 0
         } else {
             let elapsed = finishedAt - bridge.submittedAt
             let elapsedSeconds = Double(elapsed.components.seconds)
                 + Double(elapsed.components.attoseconds) / 1e18
             tps = elapsedSeconds > 0
-                ? Double(completionTokens) / elapsedSeconds : 0
+                ? Double(finalCompletion) / elapsedSeconds : 0
         }
 
         if success, tps > 0 {
@@ -224,7 +235,7 @@ extension BatchScheduler {
             return Double(elapsed.components.seconds)
                 + Double(elapsed.components.attoseconds) / 1e18
         }()
-        return (tps, durationSeconds)
+        return (tps, durationSeconds, finalPrompt, finalCompletion)
     }
 
     /// Stream closed without a terminal output (engine torn down

--- a/provider-swift/Sources/ProviderCore/ProviderLoop.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop.swift
@@ -843,9 +843,16 @@ public actor ProviderLoop {
                         var frameHadContent = false
                         if let content = parsed.contentDelta {
                             fullResponseText += content
-                            frameHadContent = true
+                            // Count only NON-empty content toward the billing
+                            // floor: parseStreamChunk returns a non-nil but empty
+                            // contentDelta for SSE frames carrying "content":""
+                            // (role/terminal deltas), which produce no visible
+                            // output and must not be billed.
+                            if !content.isEmpty {
+                                frameHadContent = true
+                            }
                         }
-                        if let reasoning = parsed.reasoningDelta {
+                        if let reasoning = parsed.reasoningDelta, !reasoning.isEmpty {
                             fullResponseText += reasoning
                             frameHadContent = true
                         }

--- a/provider-swift/Sources/ProviderCore/ProviderLoop.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop.swift
@@ -261,11 +261,15 @@ public actor ProviderLoop {
 
         if PersistentEnclaveKey.isAvailable {
             do {
-                let key = try PersistentEnclaveKey.loadOrCreate()
+                // loadOrCreateVerified proves the key can actually sign (and
+                // auto-repairs a poisoned/locked key once) before we commit to
+                // it. A key that loads but can't sign would otherwise fail every
+                // attestation challenge silently and pin the box untrusted.
+                let key = try PersistentEnclaveKey.loadOrCreateVerified()
                 log.info("Using persistent keychain-backed Secure Enclave key for attestation")
                 return key
             } catch {
-                log.warning("Persistent SE key unavailable (\(error)), falling back to ephemeral")
+                log.warning("Persistent SE key unavailable or unusable (\(error)), falling back to ephemeral")
             }
         }
 
@@ -794,6 +798,14 @@ public actor ProviderLoop {
             var fullResponseText = ""
             var promptTokens = 0
             var completionTokens = 0
+            // Defense-in-depth for the billing-zero leak: count SSE frames that
+            // carried visible output. If the usage chunk is lost entirely
+            // (parser drift / upstream regression), this is a conservative
+            // lower-bound floor for completion tokens so a request that clearly
+            // produced output never settles at 0 (which the coordinator would
+            // fully refund). MLX streams ~1 token per frame, so this slightly
+            // under-counts vs. true tokenization but never bills $0 for work.
+            var contentFrameCount = 0
 
             do {
                 for try await frame in frames {
@@ -828,14 +840,21 @@ public actor ProviderLoop {
                     //   hash that ignored them would commit to (near-)
                     //   empty bytes instead of the actual output.
                     if let parsed = Self.parseStreamChunk(frame) {
+                        var frameHadContent = false
                         if let content = parsed.contentDelta {
                             fullResponseText += content
+                            frameHadContent = true
                         }
                         if let reasoning = parsed.reasoningDelta {
                             fullResponseText += reasoning
+                            frameHadContent = true
                         }
                         if let toolCalls = parsed.toolCallsDelta, !toolCalls.isEmpty {
                             fullResponseText += Self.encodeToolCallsForHash(toolCalls)
+                            frameHadContent = true
+                        }
+                        if frameHadContent {
+                            contentFrameCount += 1
                         }
                         if let usage = parsed.usage {
                             promptTokens = usage.promptTokens
@@ -882,13 +901,28 @@ public actor ProviderLoop {
             // capacity), so we cannot fall back to engine-authoritative
             // counts here without expanding its public surface.
             if promptTokens == 0 || completionTokens == 0 {
-                log.warning(
-                    "[\(requestId)] CRITICAL: usage chunk missing or zero "
-                    + "(promptTokens=\(promptTokens), "
-                    + "completionTokens=\(completionTokens)). "
-                    + "Billing will be undercounted. Check upstream "
-                    + "MLXOpenAIService.streamChatCompletionFrames behavior."
-                )
+                // Fallback: if completion tokens are missing/zero but we
+                // streamed visible output, bill the observed content-frame
+                // count instead of $0. This caps the revenue leak even if the
+                // usage chunk is lost entirely. Prompt tokens have no in-loop
+                // proxy, so a zero there is still only logged.
+                if completionTokens == 0 && contentFrameCount > 0 {
+                    completionTokens = contentFrameCount
+                    log.warning(
+                        "[\(requestId)] usage chunk missing/zero completion tokens; "
+                        + "billing \(contentFrameCount) observed content frames as a floor. "
+                        + "Check upstream MLXOpenAIService.streamChatCompletionFrames behavior."
+                    )
+                } else {
+                    log.warning(
+                        "[\(requestId)] CRITICAL: usage chunk missing or zero "
+                        + "(promptTokens=\(promptTokens), "
+                        + "completionTokens=\(completionTokens), "
+                        + "contentFrames=\(contentFrameCount)). "
+                        + "Billing will be undercounted. Check upstream "
+                        + "MLXOpenAIService.streamChatCompletionFrames behavior."
+                    )
+                }
             }
 
             // Update stats

--- a/provider-swift/Sources/ProviderCore/Security/PersistentEnclaveKey.swift
+++ b/provider-swift/Sources/ProviderCore/Security/PersistentEnclaveKey.swift
@@ -205,10 +205,9 @@ public final class PersistentEnclaveKey: @unchecked Sendable {
         label: String? = nil
     ) throws -> PersistentEnclaveKey {
         let key = try loadOrCreate(accessGroup: accessGroup, label: label)
-        if key.selfTestSign() == nil {
+        guard let status = key.selfTestSign() else {
             return key
         }
-        let status = key.selfTestSign() ?? errSecInternalError
         logger.warning("Persistent SE key failed self-test sign (OSStatus \(status)) — attempting auto-repair (delete + re-mint)")
 
         let group = resolveAccessGroup(accessGroup)

--- a/provider-swift/Sources/ProviderCore/Security/PersistentEnclaveKey.swift
+++ b/provider-swift/Sources/ProviderCore/Security/PersistentEnclaveKey.swift
@@ -169,6 +169,65 @@ public final class PersistentEnclaveKey: @unchecked Sendable {
         return try createNew(accessGroup: group, label: keyLabel)
     }
 
+    // MARK: - Self-test & verified load
+
+    /// errSecInteractionNotAllowed — the key exists but cannot be used right
+    /// now: the data-protection keychain is locked (headless box never unlocked
+    /// since boot) or the key's access policy is too strict (a leftover
+    /// WhenUnlocked v1 key, or a poisoned v2 key).
+    private static let errInteractionNotAllowed: OSStatus = -25308
+
+    /// Signs a fixed probe to prove the key can actually produce a signature.
+    /// Returns nil on success, or the failing OSStatus. A key that *loads* fine
+    /// but fails here is the silent-killer case: the provider would answer every
+    /// attestation challenge with a signing error and be pinned untrusted while
+    /// still heartbeating "online".
+    public func selfTestSign() -> OSStatus? {
+        let probe = Data("darkbloom-se-selftest".utf8)
+        do {
+            _ = try sign(probe)
+            return nil
+        } catch let PersistentEnclaveKeyError.signingFailed(status, _) {
+            return status
+        } catch {
+            return errSecInternalError
+        }
+    }
+
+    /// Like `loadOrCreate`, but proves the key can sign before returning it.
+    /// If the self-test fails, it makes ONE auto-repair attempt — delete the
+    /// key and re-mint it with the AfterFirstUnlock policy — then re-tests. If
+    /// it still cannot sign, it throws so the caller falls back to an ephemeral
+    /// identity (the provider keeps serving at self_signed instead of being
+    /// silently pinned untrusted, e.g. MF4502MM7P: 9/9 -25308, 0 signatures).
+    public static func loadOrCreateVerified(
+        accessGroup: String? = nil,
+        label: String? = nil
+    ) throws -> PersistentEnclaveKey {
+        let key = try loadOrCreate(accessGroup: accessGroup, label: label)
+        if key.selfTestSign() == nil {
+            return key
+        }
+        let status = key.selfTestSign() ?? errSecInternalError
+        logger.warning("Persistent SE key failed self-test sign (OSStatus \(status)) — attempting auto-repair (delete + re-mint)")
+
+        let group = resolveAccessGroup(accessGroup)
+        let keyLabel = label ?? defaultLabel
+        // Best-effort delete; if the keychain is locked this also fails and the
+        // re-mint below surfaces the same error to the caller's ephemeral
+        // fallback.
+        try? delete(accessGroup: accessGroup, label: label)
+        let fresh = try createNew(accessGroup: group, label: keyLabel)
+        if let reStatus = fresh.selfTestSign() {
+            throw PersistentEnclaveKeyError.signingFailed(
+                status: reStatus,
+                message: "persistent SE key cannot sign after auto-repair (keychain likely locked / headless box not unlocked since boot)"
+            )
+        }
+        logger.info("Persistent SE key auto-repair succeeded — re-minted a working v2 key")
+        return fresh
+    }
+
     // MARK: - Find Existing
 
     private static func findExisting(

--- a/provider-swift/Tests/ProviderCoreTests/BatchSchedulerBudgetTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/BatchSchedulerBudgetTests.swift
@@ -230,4 +230,31 @@ struct BatchSchedulerBudgetTests {
         #expect(!buckets.keys.contains(3),
             "P2: queued-not-admitted bridges must NOT inflate observedBatchSize")
     }
+
+    // MARK: - Billing-zero leak: terminal must not zero observed tokens
+
+    /// Regression for the revenue leak: when the engine's terminal
+    /// `RequestOutput` reports fewer tokens (often 0) than were already observed
+    /// streaming, `recordFinish` must return the MAX of observed-vs-terminal,
+    /// not the terminal value. Pre-fix it overwrote the live count, so a
+    /// completed request settled at (0,0) → coordinator billed $0 and refunded.
+    @Test("recordFinish bills max(observed, terminal) completion tokens")
+    func recordFinishUsesMaxObservedTokens() async {
+        let scheduler = BatchScheduler()
+        await scheduler._testSeedBridge(
+            id: "bill-1", promptTokens: 12, maxTokens: 100, admitted: true)
+
+        // Streaming observed 20 completion tokens (and 12 prompt tokens)...
+        await scheduler.recordProgress(
+            requestId: "bill-1", promptTokens: 12, completionTokens: 20)
+
+        // ...but the terminal output under-reports both as 0 (the bug trigger).
+        let usage = await scheduler.recordFinish(
+            requestId: "bill-1", promptTokens: 0, completionTokens: 0, success: true)
+
+        #expect(usage.completionTokens == 20,
+            "terminal zero must not zero out the 20 observed completion tokens (billing-zero leak)")
+        #expect(usage.promptTokens == 12,
+            "prompt tokens must survive a terminal that under-reports them")
+    }
 }

--- a/provider-swift/Tests/ProviderCoreTests/CoordinatorClientTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/CoordinatorClientTests.swift
@@ -138,16 +138,22 @@ import Testing
     #expect(status.mismatches.first?.component == "runtime")
 }
 
-@Test func exponentialBackoffDoublesUntilMaximumAndResets() {
+@Test func exponentialBackoffDoublesWithJitterUntilMaximumAndResets() {
     var backoff = ExponentialBackoff(base: 1, max: 4)
 
-    #expect(backoff.nextDelay() == 1)
-    #expect(backoff.nextDelay() == 2)
-    #expect(backoff.nextDelay() == 4)
-    #expect(backoff.nextDelay() == 4)
+    // Equal jitter: each delay is in [deterministic/2, deterministic], where the
+    // deterministic component doubles (1, 2, 4, 4) and caps at max. We sample
+    // each step and assert the bounds hold (and the cap is respected).
+    func inRange(_ v: Double, _ det: Double) -> Bool { v >= det / 2 && v <= det }
+
+    #expect(inRange(backoff.nextDelay(), 1))
+    #expect(inRange(backoff.nextDelay(), 2))
+    #expect(inRange(backoff.nextDelay(), 4))
+    let capped = backoff.nextDelay()
+    #expect(capped >= 2 && capped <= 4) // still capped at max even with jitter
 
     backoff.reset()
-    #expect(backoff.nextDelay() == 1)
+    #expect(inRange(backoff.nextDelay(), 1))
 }
 
 private func clientSampleHardware() -> HardwareInfo {

--- a/provider-swift/Tests/ProviderCoreTests/CoordinatorIntegrationTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/CoordinatorIntegrationTests.swift
@@ -274,6 +274,92 @@ struct CoordinatorIntegrationTests {
         #expect(snap.registers.last?.backend == "mlx-swift")
     }
 
+    // MARK: 3b. Outbound delivery survives a reconnect (regression)
+
+    /// Regression test for the outage where ~half the fleet got pinned
+    /// `hardware/untrusted reason=timeout` after a coordinator restart.
+    ///
+    /// The outbound `AsyncStream` used to be created once in `start()` and
+    /// reused across every reconnect. An `AsyncStream` is single-shot: once the
+    /// first session's consumer task is cancelled on disconnect, the iterator is
+    /// terminated, so the next session's forwarder task exited immediately and
+    /// NO outbound message (attestation responses, inference replies) was ever
+    /// sent again. Heartbeats/pings run on their own tasks, so the socket stayed
+    /// up and the provider was never evicted — it just silently stopped
+    /// answering challenges.
+    ///
+    /// Test #3 above only proves the provider *re-registers* after a drop, and
+    /// registration uses `ws.send` directly (not the outbound stream), so it
+    /// passed even with the bug. This test exercises the outbound stream
+    /// specifically: it must still deliver an attestation response on the new
+    /// connection.
+    @Test("CoordinatorClient still delivers outbound messages after a reconnect")
+    func outboundDeliverySurvivesReconnect() async throws {
+        let mock = MockCoordinator()
+        let baseURL = try await mock.start()
+        defer { Task { await mock.shutdown() } }
+
+        let keys = NodeKeyPair.generate()
+        let coordinator = makeClient(
+            url: baseURL.mockProviderWebSocketURL(),
+            publicKey: keys.publicKeyBase64,
+            heartbeatInterval: 60
+        )
+        let (events, sendFn) = await coordinator.start()
+        let send = SendHandle(sendFn)
+        defer { Task { await coordinator.shutdown() } }
+
+        // Background drainer: answer every attestation challenge through the
+        // stable `send` handle — the exact outbound path ProviderLoop uses.
+        let drain = Task {
+            for await event in events {
+                if case .attestationChallenge(let nonce, _) = event {
+                    send.send(.attestationResponse(AttestationResponsePayload(
+                        nonce: nonce,
+                        signature: "fake-sig",
+                        statusSignature: nil,
+                        publicKey: keys.publicKeyBase64,
+                        sipEnabled: true,
+                        binaryHash: String(repeating: "b", count: 64)
+                    )))
+                }
+            }
+        }
+        defer { drain.cancel() }
+
+        // First connection.
+        let first = try await mock.awaitFirstRegister(timeout: .seconds(5))
+        try #require(first != nil)
+        let registersBefore = mock.snapshot().registers.count
+
+        // Force a reconnect — what a coordinator restart / network blip does to
+        // every provider at once.
+        await mock.dropActiveWebSocket()
+
+        // Provider reconnects and re-registers on a brand-new WebSocket.
+        let reRegistered = try await mock.waitForSnapshot(timeout: .seconds(10)) {
+            $0.registers.count > registersBefore
+        }
+        try #require(reRegistered != nil)
+
+        // Push a challenge over the NEW connection. Pre-fix, the outbound
+        // forwarder had already exited, so this response was silently dropped.
+        try await mock.pushAttestationChallenge(
+            nonce: "cmVjb25uZWN0",
+            timestamp: "2026-05-31T08:00:00Z"
+        )
+
+        let after = try await mock.waitForSnapshot(timeout: .seconds(10)) {
+            $0.attestationResponses.contains { $0.nonce == "cmVjb25uZWN0" }
+        }
+        let snap = try #require(
+            after,
+            "no attestation response after reconnect — outbound stream is dead"
+        )
+        let resp = try #require(snap.attestationResponses.first { $0.nonce == "cmVjb25uZWN0" })
+        #expect(resp.publicKey == keys.publicKeyBase64)
+    }
+
     // MARK: 4. EnrollmentService round-trip
 
     @Test("EnrollmentService either fetches the mocked profile or short-circuits as already-enrolled")


### PR DESCRIPTION
## Summary

Fixes the seven systemic root causes behind the fleet's reliability problems, diagnosed from **96 provider log reports across 40 Macs** (at diagnosis time, **45% of registered providers were untrusted / non-serving**, ~3,700 GB of GPU RAM offline). Each fix is verified against source and ships with a regression test.

| # | Issue | Impact | Where |
|---|-------|--------|-------|
| 1 | Outbound stream dies after reconnect → trust-timeout cascade | ~13 machines pinned untrusted | `CoordinatorClient.swift`, `provider.go` |
| 2 | ACME upgrade leg never retried + stale-trust restore | ~9 stuck `self_signed` | `provider.go`, `registry.go` |
| 3 | Memory admission skipped physical-fit on token-budget path | ~6,400 failed loads / request bounces | `scheduler.go`, `registry.go` |
| 4 | Billing zero-usage: terminal output zeroed observed tokens | direct revenue leak | `BatchScheduler+EngineBridge.swift`, `ProviderLoop.swift`, `provider.go` |
| 5 | SE key loads but can't sign (-25308 / poisoned v2) | silent untrust | `PersistentEnclaveKey.swift` |
| 6 | Reconnect herd + no reachability signal | softens #1 availability driver | `ExponentialBackoff.swift`, `CoordinatorClient.swift` |
| 7 | ECDSA status-sig lockout (cause unconfirmed) | 2 non-recovering | `provider.go`, `attestation.go` |

## Details

**1. Trust-timeout cascade.** The Swift provider reused a single-shot `AsyncStream` for outbound frames; after the first reconnect its iterator was finished, so every challenge response was silently dropped while heartbeats/pongs (which call `ws.send` directly) kept the socket "online" — the box looked online but answered no challenges → `MarkUntrustedTransient`. Fix: per-connection `OutboundRouter` + coordinator force-reconnect after `MaxConsecutiveChallengeTimeoutsBeforeReconnect=6`. Regression: `outboundDeliverySurvivesReconnect`.

**2. ACME retry + stale-trust restore.** `applyACMETrust` ran at registration *before* attestation binding completed, so its key-match check failed on ordering and never re-ran. Now the connect-time ACME result is stashed and retried on each passing challenge (mirroring MDM). `RestoreProviderState` is capped at `self_signed` so hardware trust is re-earned via a live challenge.

**3. Memory admission.** `freeMemoryAdmits` did only token-budget math for modern providers and never checked physical fit, so a 93.7 GB model was dispatched to 48/64 GB boxes that 503'd at load. New always-on `modelFitsHardware()` gate (shared with the pre-warm path so they can't drift), cold-load only (a resident/serving model is never rejected). A never-fits model now reports `model_too_large` (distinct counter) instead of `over_capacity` (which would 429-retry forever).

**4. Billing zero-usage.** `recordFinish` overwrote the live observed token count with the terminal `RequestOutput`, which can report 0 → coordinator bills \$0 and refunds. Now `max(observed, terminal)`; provider falls back to a content-frame floor if the usage chunk is lost entirely; coordinator emits `billing.zero_usage_complete`.

**5. SE key self-test/auto-repair.** `loadOrCreateVerified` runs a self-test sign, attempts one delete + re-mint, and otherwise throws so the provider falls back to an ephemeral identity and keeps serving at `self_signed` instead of being silently pinned untrusted.

**6. Connectivity.** Equal-jitter backoff breaks the synchronized reconnect herd; `NWPathMonitor` reachability is surfaced in reconnect logs + telemetry to separate "coordinator down" from "box lost internet" (the dominant, operator-side cause).

**7. ECDSA status-sig.** Instruments the failure path (plain-sig-passed, Go canonical bytes, per-field lengths, `status_sig_failed` metric) so the two stuck boxes are diagnosable from logs, and hardens the latent escaping divergence — `BuildStatusCanonical` now uses `SetEscapeHTML(false)` so `<`,`>`,`&` match the Swift encoder (no-op for current base64/hex values).

## Testing
- **Coordinator:** `go build ./...` + `go test ./...` green (11 packages). New tests: absolute-fit / `model_too_large` routing, `BuildStatusCanonical` no-HTML-escape golden.
- **Provider:** `swift build` green; new tests pass — `outboundDeliverySurvivesReconnect`, `recordFinishUsesMaxObservedTokens` (billing), jitter-backoff bounds. MLX-runtime tests skipped locally (no metallib in worktree).

## Follow-ups (noted, not in this PR)
- Backfill `TotalSizeBytes` for catalog model versions (the fit gate fails open on `SizeGB==0`).
- Coordinator periodic `conn.Ping` for faster half-open detection (90s sweeper + #1 force-reconnect already cover it).
- Same `SetEscapeHTML(false)` hardening for the plain attestation-blob canonical (not currently failing anyone).
- Apply `NWPathMonitor` to *gate* reconnects (await link-up), not just report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/268"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783106773&installation_id=133247490&pr_number=268&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F268&signature=9be57398fbc0c8bf6dc648ddb42818abe4de52f3bf8dbc72780bb8652be3138d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->