### PR TITLE
fix(mdm): provider MDM read-only + close webhook trust-injection (T-021/SEC-004)

### DIFF
--- a/coordinator/api/mdm_webhook_test.go
+++ b/coordinator/api/mdm_webhook_test.go
@@ -1,0 +1,74 @@
+package api
+
+import (
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/eigeninference/d-inference/coordinator/registry"
+	"github.com/eigeninference/d-inference/coordinator/store"
+)
+
+func mdmTestServer(t *testing.T) *Server {
+	t.Helper()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	st := store.NewMemory(store.Config{AdminKey: "test-key"})
+	reg := registry.New(logger)
+	return NewServer(reg, st, ServerConfig{}, logger)
+}
+
+// TestMDMWebhookSecretGate verifies the optional shared-secret layer: when a
+// secret is configured, callers without it are rejected before the body is read;
+// with it, the request is accepted.
+func TestMDMWebhookSecretGate(t *testing.T) {
+	srv := mdmTestServer(t)
+	srv.SetMDMWebhookSecret("s3cret")
+
+	// No token → forbidden.
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/mdm/webhook", strings.NewReader("{}"))
+	srv.HandleMDMWebhook(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("missing token: want 403, got %d", rec.Code)
+	}
+
+	// Wrong token → forbidden.
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodPost, "/v1/mdm/webhook?token=wrong", strings.NewReader("{}"))
+	srv.HandleMDMWebhook(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("wrong token: want 403, got %d", rec.Code)
+	}
+
+	// Correct token (query param) → accepted (200; body is empty JSON, no-op).
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodPost, "/v1/mdm/webhook?token=s3cret", strings.NewReader("{}"))
+	srv.HandleMDMWebhook(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("correct token (query): want 200, got %d", rec.Code)
+	}
+
+	// Correct token (header) → accepted.
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodPost, "/v1/mdm/webhook", strings.NewReader("{}"))
+	req.Header.Set("X-Webhook-Token", "s3cret")
+	srv.HandleMDMWebhook(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("correct token (header): want 200, got %d", rec.Code)
+	}
+}
+
+// TestMDMWebhookNoSecretConfigured verifies that when no secret is set, the
+// endpoint does not 403 (it relies on the solicited-command gate instead).
+func TestMDMWebhookNoSecretConfigured(t *testing.T) {
+	srv := mdmTestServer(t)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/mdm/webhook", strings.NewReader("{}"))
+	srv.HandleMDMWebhook(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("no secret configured: want 200, got %d", rec.Code)
+	}
+}

--- a/coordinator/api/server.go
+++ b/coordinator/api/server.go
@@ -168,6 +168,7 @@ type Server struct {
 	adminEmails            map[string]bool   // emails that have admin access
 	adminKey               string            // EIGENINFERENCE_ADMIN_KEY for admin endpoints
 	mdmClient              *mdm.Client       // MicroMDM client for provider security verification
+	mdmWebhookSecret       string            // optional shared secret MicroMDM must present on the webhook
 	stepCARootCert         *x509.Certificate // step-ca root CA for ACME cert verification
 	stepCAIntermediateCert *x509.Certificate // step-ca intermediate CA
 
@@ -702,6 +703,16 @@ func (s *Server) SetMDMClient(client *mdm.Client) {
 	s.mdmClient = client
 }
 
+// SetMDMWebhookSecret configures an optional shared secret that MicroMDM must
+// present (as ?token= or the X-Webhook-Token header) when calling the webhook.
+// When empty, the webhook relies solely on the solicited-command (CommandUUID)
+// gate in the MDM client; when set, callers lacking the secret are rejected
+// before the body is read. MicroMDM is co-located with the coordinator, so this
+// secret never traverses the public network.
+func (s *Server) SetMDMWebhookSecret(secret string) {
+	s.mdmWebhookSecret = secret
+}
+
 // SyncModelCatalog reads active models from the store and updates the
 // registry's model catalog. Call this at startup and after admin catalog changes.
 func (s *Server) SyncModelCatalog() {
@@ -1187,9 +1198,29 @@ func (s *Server) handleRuntimeManifest(w http.ResponseWriter, r *http.Request) {
 	writeCachedJSON(w, body)
 }
 
+// maxMDMWebhookBodyBytes caps the MicroMDM webhook body. SecurityInfo /
+// DevicePropertiesAttestation responses are a few KB; 1 MiB is generous headroom
+// while preventing an unauthenticated caller from exhausting memory via an
+// unbounded body.
+const maxMDMWebhookBodyBytes = 1 << 20 // 1 MiB
+
 // HandleMDMWebhook processes a MicroMDM webhook callback.
 // Mount this on the webhook URL configured in MicroMDM.
+//
+// Defense layers (the endpoint is reachable but cannot forge trust):
+//  1. Body cap — bounds memory for the unauthenticated path.
+//  2. Optional shared secret — when configured, rejects callers without it
+//     before reading the body.
+//  3. Solicited-command gate (in mdm.Client.HandleWebhook) — only responses
+//     whose CommandUUID matches a command the coordinator actually issued are
+//     acted on, so a forged SecurityInfo can never drive a trust upgrade.
 func (s *Server) HandleMDMWebhook(w http.ResponseWriter, r *http.Request) {
+	if s.mdmWebhookSecret != "" && !s.mdmWebhookTokenValid(r) {
+		s.logger.Warn("mdm webhook rejected: missing/invalid shared secret", "remote_addr", r.RemoteAddr)
+		http.Error(w, "forbidden", http.StatusForbidden)
+		return
+	}
+	r.Body = http.MaxBytesReader(w, r.Body, maxMDMWebhookBodyBytes)
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		http.Error(w, "bad request", http.StatusBadRequest)
@@ -1200,6 +1231,18 @@ func (s *Server) HandleMDMWebhook(w http.ResponseWriter, r *http.Request) {
 		s.mdmClient.HandleWebhook(body)
 	}
 	w.WriteHeader(http.StatusOK)
+}
+
+// mdmWebhookTokenValid reports whether the request carries the configured MDM
+// webhook secret, via either the X-Webhook-Token header or a ?token= query
+// param. Comparison is constant-time. Only called when a secret is configured.
+func (s *Server) mdmWebhookTokenValid(r *http.Request) bool {
+	token := r.Header.Get("X-Webhook-Token")
+	if token == "" {
+		token = r.URL.Query().Get("token")
+	}
+	return token != "" &&
+		subtle.ConstantTimeCompare([]byte(token), []byte(s.mdmWebhookSecret)) == 1
 }
 
 //go:embed install.sh

--- a/coordinator/cmd/coordinator/main.go
+++ b/coordinator/cmd/coordinator/main.go
@@ -391,6 +391,11 @@ func main() {
 		if webhookSecret := os.Getenv("EIGENINFERENCE_MDM_WEBHOOK_SECRET"); webhookSecret != "" {
 			srv.SetMDMWebhookSecret(webhookSecret)
 			logger.Info("MDM webhook shared-secret auth enabled")
+		} else {
+			// The solicited-command (CommandUUID) gate still protects the
+			// webhook, but the shared secret is the recommended extra layer.
+			// Warn so a misconfigured deployment is visible at startup.
+			logger.Warn("EIGENINFERENCE_MDM_WEBHOOK_SECRET not set — MDM webhook relies solely on the CommandUUID gate; set it + keep MicroMDM bound to localhost for defense in depth")
 		}
 		logger.Info("MDM verification enabled", "url", mdmCfg.URL)
 	}

--- a/coordinator/cmd/coordinator/main.go
+++ b/coordinator/cmd/coordinator/main.go
@@ -384,6 +384,14 @@ func main() {
 		})
 
 		srv.SetMDMClient(mdmClient)
+		// Optional shared secret for the MicroMDM webhook. Defense-in-depth on
+		// top of the mandatory solicited-command (CommandUUID) gate: configure
+		// MicroMDM's command-webhook-url with ?token=<secret> and set this to
+		// the same value to reject any caller that lacks it.
+		if webhookSecret := os.Getenv("EIGENINFERENCE_MDM_WEBHOOK_SECRET"); webhookSecret != "" {
+			srv.SetMDMWebhookSecret(webhookSecret)
+			logger.Info("MDM webhook shared-secret auth enabled")
+		}
 		logger.Info("MDM verification enabled", "url", mdmCfg.URL)
 	}
 

--- a/coordinator/deploy/start.sh
+++ b/coordinator/deploy/start.sh
@@ -79,6 +79,18 @@ if [ -n "$MICROMDM_API_KEY" ]; then
             -days 3650 -subj "/CN=localhost" 2>/dev/null
     fi
 
+    # If the coordinator is configured with EIGENINFERENCE_MDM_WEBHOOK_SECRET it
+    # rejects any MDM callback that doesn't present that secret. MicroMDM has no
+    # option to set a header on the command webhook, so the shared secret rides
+    # as a ?token= query param (the coordinator also accepts the X-Webhook-Token
+    # header — see HandleMDMWebhook). These MUST stay in sync: setting the secret
+    # on the coordinator without this token would 403 every legitimate
+    # SecurityInfo/MDA callback and stall provider hardware-trust verification.
+    MDM_WEBHOOK_URL="http://localhost:8080/v1/mdm/webhook"
+    if [ -n "${EIGENINFERENCE_MDM_WEBHOOK_SECRET:-}" ]; then
+        MDM_WEBHOOK_URL="${MDM_WEBHOOK_URL}?token=${EIGENINFERENCE_MDM_WEBHOOK_SECRET}"
+    fi
+
     echo "Starting MicroMDM..."
     micromdm serve \
         -server-url "https://${DOMAIN:-localhost}" \
@@ -89,7 +101,7 @@ if [ -n "$MICROMDM_API_KEY" ]; then
         -tls-key /data/micromdm/server.key \
         -http-addr :9002 \
         -http-proxy-headers \
-        -command-webhook-url http://localhost:8080/v1/mdm/webhook \
+        -command-webhook-url "${MDM_WEBHOOK_URL}" \
         >> /data/micromdm.log 2>&1 &
 
     # Wait for MicroMDM to be ready, then import push cert if needed

--- a/coordinator/mdm/mdm.go
+++ b/coordinator/mdm/mdm.go
@@ -98,10 +98,14 @@ type outstandingCommand struct {
 }
 
 // outstandingCommandTTL bounds how long an issued command UUID stays valid for
-// matching a webhook response. Comfortably longer than the 90s SecurityInfo
-// wait to allow for late (Power Nap / APN) delivery, short enough to bound the
-// forge window if a UUID ever leaked.
-const outstandingCommandTTL = 10 * time.Minute
+// matching a webhook response. It must comfortably exceed the worst-case APN /
+// Power Nap delivery delay (a sleeping Mac wakes on roughly a ~15-minute Power
+// Nap cadence — see the late-SecurityInfo callback in cmd/coordinator/main.go),
+// otherwise the UUID expires before a genuine SecurityInfo response arrives,
+// consumeCommand drops it as stale, and the self_signed→hardware recovery path
+// never fires. 30 minutes covers that delay while still bounding the forge
+// window if a (random, localhost-only) UUID ever leaked.
+const outstandingCommandTTL = 30 * time.Minute
 
 // NewClient creates an MDM client.
 func NewClient(baseURL, apiKey string, logger *slog.Logger) *Client {

--- a/coordinator/mdm/mdm.go
+++ b/coordinator/mdm/mdm.go
@@ -488,15 +488,19 @@ func (c *Client) HandleWebhook(body []byte) {
 		return
 	}
 
-	// Log what the plist contains for debugging
+	// Log what the plist contains. The raw preview is kept at Debug only: it
+	// echoes the device response verbatim, which includes the CommandUUID — and
+	// UUID secrecy is what the solicited-command gate relies on, so it must not
+	// be emitted at Info where it could leak the gate's secret to anyone with
+	// log access.
 	hasSecInfo := bytes.Contains(plistData, []byte("SecurityInfo"))
 	hasDeviceAttest := bytes.Contains(plistData, []byte("DevicePropertiesAttestation"))
 	c.logger.Info("mdm webhook plist content",
 		"size", len(plistData),
 		"has_security_info", hasSecInfo,
 		"has_device_attestation", hasDeviceAttest,
-		"preview", string(plistData[:min(len(plistData), 2000)]),
 	)
+	c.logger.Debug("mdm webhook plist preview", "preview", string(plistData[:min(len(plistData), 2000)]))
 
 	// Parse the plist for SecurityInfo
 	secInfo := parseSecurityInfoPlist(plistData)

--- a/coordinator/mdm/mdm.go
+++ b/coordinator/mdm/mdm.go
@@ -23,12 +23,27 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/google/uuid"
 )
+
+// commandUUIDRe extracts the CommandUUID from a MicroMDM device response plist
+// (<key>CommandUUID</key><string>…</string>), tolerating whitespace/newlines.
+var commandUUIDRe = regexp.MustCompile(`<key>CommandUUID</key>\s*<string>([^<]+)</string>`)
+
+// parseCommandUUID returns the CommandUUID embedded in a device response plist,
+// or "" if absent.
+func parseCommandUUID(plistData []byte) string {
+	m := commandUUIDRe.FindSubmatch(plistData)
+	if len(m) < 2 {
+		return ""
+	}
+	return string(bytes.TrimSpace(m[1]))
+}
 
 // DeviceAttestationResponse contains the DER-encoded certificate chain
 // from Apple's DevicePropertiesAttestation response.
@@ -64,7 +79,29 @@ type Client struct {
 	onMDA OnMDACallback
 	// Callback for SecurityInfo responses that arrive after the waiter timed out.
 	onLateSecInfo OnLateSecurityInfoCallback
+
+	// outstanding tracks command UUIDs the coordinator has issued but not yet
+	// matched to a response. The webhook only honors a response whose
+	// CommandUUID is here — this is what makes the (unauthenticated) MicroMDM
+	// callback safe: a caller can only ANSWER a command we actually issued, it
+	// can never volunteer an unsolicited "SIP=true" to forge a trust upgrade.
+	// Keyed by command UUID (a random, non-public identifier).
+	outstandingMu sync.Mutex
+	outstanding   map[string]outstandingCommand
 }
+
+// outstandingCommand records a command UUID the coordinator issued, so the
+// webhook can verify an inbound response was solicited.
+type outstandingCommand struct {
+	udid     string
+	issuedAt time.Time
+}
+
+// outstandingCommandTTL bounds how long an issued command UUID stays valid for
+// matching a webhook response. Comfortably longer than the 90s SecurityInfo
+// wait to allow for late (Power Nap / APN) delivery, short enough to bound the
+// forge window if a UUID ever leaked.
+const outstandingCommandTTL = 10 * time.Minute
 
 // NewClient creates an MDM client.
 func NewClient(baseURL, apiKey string, logger *slog.Logger) *Client {
@@ -85,7 +122,79 @@ func NewClient(baseURL, apiKey string, logger *slog.Logger) *Client {
 		logger:         logger,
 		secInfoWaiters: make(map[string]chan *SecurityInfoResponse),
 		attestWaiters:  make(map[string]chan *DeviceAttestationResponse),
+		outstanding:    make(map[string]outstandingCommand),
 	}
+}
+
+// readOnlyMDMRequestTypes is the EXHAUSTIVE allowlist of MDM command request
+// types the coordinator is permitted to send to a provider's Mac. Both are pure
+// queries — they read security posture and never mutate the device:
+//
+//	SecurityInfo      → SIP / Secure Boot / FileVault status
+//	DeviceInformation → DevicePropertiesAttestation (Apple-signed cert chain)
+//
+// Every command that could act ON a provider's machine — DeviceLock,
+// EraseDevice, RestartDevice, ShutDownDevice, InstallProfile, RemoveProfile,
+// InstallApplication, ClearPasscode, EnableRemoteDesktop, ScheduleOSUpdate, … —
+// is intentionally absent. Enrolling a provider grants the coordinator
+// read-only visibility into hardware trust, NEVER control. assertReadOnlyCommand
+// is the single chokepoint that enforces this: a future code path (or a
+// compromised coordinator) that tries to issue a mutating command fails closed
+// here instead of reaching the device. To add a command type, it must be a
+// read-only query AND added here in review.
+var readOnlyMDMRequestTypes = map[string]struct{}{
+	"SecurityInfo":      {},
+	"DeviceInformation": {},
+}
+
+// ErrMutatingCommandBlocked is returned when something attempts to send an MDM
+// command that is not on the read-only allowlist.
+var ErrMutatingCommandBlocked = fmt.Errorf("mdm: refusing to send non-read-only command (provider machines are read-only)")
+
+// assertReadOnlyCommand fails closed unless requestType is a known read-only
+// query. This is the guarantee that the coordinator can never "do something" to
+// a provider's Mac via MDM.
+func assertReadOnlyCommand(requestType string) error {
+	if _, ok := readOnlyMDMRequestTypes[requestType]; !ok {
+		return fmt.Errorf("%w: %q", ErrMutatingCommandBlocked, requestType)
+	}
+	return nil
+}
+
+// trackCommand records an issued command UUID so the webhook can confirm a
+// later response was solicited. Prunes expired entries opportunistically.
+func (c *Client) trackCommand(commandUUID, udid string, now time.Time) {
+	if commandUUID == "" {
+		return
+	}
+	c.outstandingMu.Lock()
+	defer c.outstandingMu.Unlock()
+	for id, cmd := range c.outstanding {
+		if now.Sub(cmd.issuedAt) > outstandingCommandTTL {
+			delete(c.outstanding, id)
+		}
+	}
+	c.outstanding[commandUUID] = outstandingCommand{udid: udid, issuedAt: now}
+}
+
+// consumeCommand checks whether commandUUID corresponds to a command the
+// coordinator issued (and has not yet expired), removing it (one-shot). It
+// returns the UDID the command was sent to and whether the match succeeded.
+func (c *Client) consumeCommand(commandUUID string, now time.Time) (string, bool) {
+	if commandUUID == "" {
+		return "", false
+	}
+	c.outstandingMu.Lock()
+	defer c.outstandingMu.Unlock()
+	cmd, ok := c.outstanding[commandUUID]
+	if !ok {
+		return "", false
+	}
+	delete(c.outstanding, commandUUID)
+	if now.Sub(cmd.issuedAt) > outstandingCommandTTL {
+		return "", false
+	}
+	return cmd.udid, true
 }
 
 // SetOnMDA registers a callback for late-arriving MDA attestation certs.
@@ -173,9 +282,13 @@ func (c *Client) LookupDevice(serialNumber string) (*DeviceInfo, error) {
 // SendSecurityInfoCommand sends a SecurityInfo command to a device by UDID.
 // Returns the command UUID for tracking the response.
 func (c *Client) SendSecurityInfoCommand(udid string) (string, error) {
+	const requestType = "SecurityInfo"
+	if err := assertReadOnlyCommand(requestType); err != nil {
+		return "", err
+	}
 	body, _ := json.Marshal(map[string]string{
 		"udid":         udid,
-		"request_type": "SecurityInfo",
+		"request_type": requestType,
 	})
 	req, err := http.NewRequest(http.MethodPost, c.baseURL+"/v1/commands", bytes.NewReader(body))
 	if err != nil {
@@ -199,6 +312,7 @@ func (c *Client) SendSecurityInfoCommand(udid string) (string, error) {
 		return "", fmt.Errorf("mdm command response decode failed: %w", err)
 	}
 
+	c.trackCommand(result.Payload.CommandUUID, udid, time.Now())
 	return result.Payload.CommandUUID, nil
 }
 
@@ -227,6 +341,10 @@ func (c *Client) SendDeviceAttestationCommand(udid string, nonce ...string) (str
 // with DeviceAttestationNonce. MicroMDM's structured API doesn't support this
 // field, so we bypass it with the raw command endpoint: POST /v1/commands/{udid}.
 func (c *Client) sendDeviceAttestationWithNonce(udid, nonce string) (string, error) {
+	// DevicePropertiesAttestation is requested via a DeviceInformation command.
+	if err := assertReadOnlyCommand("DeviceInformation"); err != nil {
+		return "", err
+	}
 	cmdUUID := uuid.New().String()
 
 	// Build nonce XML if provided
@@ -272,6 +390,8 @@ func (c *Client) sendDeviceAttestationWithNonce(udid, nonce string) (string, err
 		respBody, _ := io.ReadAll(resp.Body)
 		return "", fmt.Errorf("mdm raw command failed (status %d): %s", resp.StatusCode, string(respBody))
 	}
+
+	c.trackCommand(cmdUUID, udid, time.Now())
 
 	// Push to trigger device check-in
 	pushReq, err := http.NewRequest(http.MethodGet, c.baseURL+"/push/"+udid, nil)
@@ -338,6 +458,33 @@ func (c *Client) HandleWebhook(body []byte) {
 	plistData, err := base64.StdEncoding.DecodeString(webhook.Event.RawPayload)
 	if err != nil {
 		c.logger.Debug("mdm webhook base64 decode failed", "error", err)
+		return
+	}
+
+	// SOLICITED-RESPONSE GATE. Only honor a response whose CommandUUID matches a
+	// command the coordinator actually issued. The webhook endpoint is otherwise
+	// unauthenticated; without this, anyone who can reach it could POST a forged
+	// "SIP=true" SecurityInfo (or an attestation) and drive a self_signed
+	// provider to hardware trust. Because command UUIDs are random and never
+	// exposed, an attacker cannot match an in-flight command. Unsolicited or
+	// stale responses are dropped here, before any waiter or trust-upgrade
+	// callback runs.
+	cmdUUID := parseCommandUUID(plistData)
+	trackedUDID, solicited := c.consumeCommand(cmdUUID, time.Now())
+	if !solicited {
+		c.logger.Warn("mdm webhook dropped: unsolicited or unknown CommandUUID",
+			"udid", webhook.Event.UDID,
+			"command_uuid", cmdUUID,
+		)
+		return
+	}
+	// Defense in depth: the response's device must be the one we addressed.
+	if trackedUDID != "" && webhook.Event.UDID != "" && trackedUDID != webhook.Event.UDID {
+		c.logger.Warn("mdm webhook dropped: CommandUUID/UDID mismatch",
+			"command_uuid", cmdUUID,
+			"webhook_udid", webhook.Event.UDID,
+			"command_udid", trackedUDID,
+		)
 		return
 	}
 

--- a/coordinator/mdm/mdm_security_test.go
+++ b/coordinator/mdm/mdm_security_test.go
@@ -1,0 +1,149 @@
+package mdm
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+)
+
+func testClient() *Client {
+	return NewClient("https://localhost:9002", "test-key",
+		slog.New(slog.NewTextHandler(io.Discard, nil)))
+}
+
+// TestAssertReadOnlyCommand is the guarantee that the coordinator can only ever
+// QUERY a provider's Mac via MDM, never act on it. Read-only queries pass;
+// every mutating/destructive command is refused.
+func TestAssertReadOnlyCommand(t *testing.T) {
+	readOnly := []string{"SecurityInfo", "DeviceInformation"}
+	for _, rt := range readOnly {
+		if err := assertReadOnlyCommand(rt); err != nil {
+			t.Errorf("read-only command %q should be allowed, got %v", rt, err)
+		}
+	}
+
+	mutating := []string{
+		"DeviceLock", "EraseDevice", "RestartDevice", "ShutDownDevice",
+		"InstallProfile", "RemoveProfile", "InstallApplication",
+		"ClearPasscode", "EnableRemoteDesktop", "ScheduleOSUpdate", "",
+	}
+	for _, rt := range mutating {
+		err := assertReadOnlyCommand(rt)
+		if err == nil {
+			t.Errorf("mutating command %q MUST be blocked, but was allowed", rt)
+		}
+		if !errors.Is(err, ErrMutatingCommandBlocked) {
+			t.Errorf("command %q: expected ErrMutatingCommandBlocked, got %v", rt, err)
+		}
+	}
+}
+
+func TestParseCommandUUID(t *testing.T) {
+	cases := map[string]string{
+		`<key>CommandUUID</key><string>abc-123</string>`:     "abc-123",
+		"<key>CommandUUID</key>\n\t<string>def-456</string>": "def-456",
+		`<dict><key>Other</key><string>x</string></dict>`:    "",
+		`<key>CommandUUID</key><string>  spaced  </string>`:  "spaced",
+	}
+	for plist, want := range cases {
+		if got := parseCommandUUID([]byte(plist)); got != want {
+			t.Errorf("parseCommandUUID(%q) = %q, want %q", plist, got, want)
+		}
+	}
+}
+
+// TestCommandTrackingLifecycle covers track → consume (one-shot), unknown-UUID
+// rejection, and TTL expiry.
+func TestCommandTrackingLifecycle(t *testing.T) {
+	c := testClient()
+	now := time.Now()
+
+	c.trackCommand("uuid-1", "UDID-A", now)
+
+	// Unknown UUID is never solicited.
+	if _, ok := c.consumeCommand("nope", now); ok {
+		t.Error("unknown command UUID must not be consumable")
+	}
+
+	// Known UUID resolves to its UDID, exactly once.
+	udid, ok := c.consumeCommand("uuid-1", now)
+	if !ok || udid != "UDID-A" {
+		t.Fatalf("consumeCommand(uuid-1) = (%q,%v), want (UDID-A,true)", udid, ok)
+	}
+	if _, ok := c.consumeCommand("uuid-1", now); ok {
+		t.Error("command UUID must be one-shot (already consumed)")
+	}
+
+	// Expired UUID is rejected.
+	c.trackCommand("uuid-2", "UDID-B", now)
+	if _, ok := c.consumeCommand("uuid-2", now.Add(outstandingCommandTTL+time.Second)); ok {
+		t.Error("expired command UUID must not be consumable")
+	}
+}
+
+// buildSecurityInfoWebhook builds a MicroMDM acknowledge webhook body carrying a
+// SecurityInfo response plist with the given CommandUUID.
+func buildSecurityInfoWebhook(udid, commandUUID string) []byte {
+	plist := fmt.Sprintf(`<?xml version="1.0"?><plist version="1.0"><dict>`+
+		`<key>CommandUUID</key><string>%s</string>`+
+		`<key>Status</key><string>Acknowledged</string>`+
+		`<key>SecurityInfo</key><dict>`+
+		`<key>SystemIntegrityProtectionEnabled</key><true/>`+
+		`<key>SecureBootLevel</key><string>full</string>`+
+		`</dict></dict></plist>`, commandUUID)
+	body, _ := json.Marshal(map[string]any{
+		"topic": "mdm.Acknowledge",
+		"acknowledge_event": map[string]string{
+			"udid":        udid,
+			"status":      "Acknowledged",
+			"raw_payload": base64.StdEncoding.EncodeToString([]byte(plist)),
+		},
+	})
+	return body
+}
+
+// TestWebhookDropsUnsolicitedSecurityInfo is the core anti-forgery guarantee: a
+// SecurityInfo webhook whose CommandUUID was never issued by the coordinator is
+// dropped before any trust-upgrade callback runs. This is what stops an
+// attacker who reaches the (unauthenticated) webhook from forging "SIP=true" to
+// elevate a provider to hardware trust.
+func TestWebhookDropsUnsolicitedSecurityInfo(t *testing.T) {
+	c := testClient()
+	var lateFired bool
+	c.SetOnLateSecurityInfo(func(udid string, info *SecurityInfoResponse) {
+		lateFired = true
+	})
+
+	// Forged: no command was ever issued for this UUID.
+	c.HandleWebhook(buildSecurityInfoWebhook("UDID-A", "forged-uuid"))
+	if lateFired {
+		t.Fatal("unsolicited SecurityInfo must NOT trigger the trust-upgrade callback")
+	}
+
+	// Solicited: coordinator issued this command UUID for this UDID.
+	c.trackCommand("real-uuid", "UDID-A", time.Now())
+	c.HandleWebhook(buildSecurityInfoWebhook("UDID-A", "real-uuid"))
+	if !lateFired {
+		t.Fatal("solicited SecurityInfo response should be honored")
+	}
+}
+
+// TestWebhookDropsUUIDForDifferentDevice ensures a solicited UUID can't be
+// replayed against a different device's webhook event.
+func TestWebhookDropsUUIDForDifferentDevice(t *testing.T) {
+	c := testClient()
+	var fired bool
+	c.SetOnLateSecurityInfo(func(udid string, info *SecurityInfoResponse) { fired = true })
+
+	c.trackCommand("uuid-x", "UDID-REAL", time.Now())
+	// Same UUID but the webhook claims a different device.
+	c.HandleWebhook(buildSecurityInfoWebhook("UDID-EVIL", "uuid-x"))
+	if fired {
+		t.Fatal("CommandUUID/UDID mismatch must be dropped")
+	}
+}


### PR DESCRIPTION
## Summary

Closes the MicroMDM webhook trust-injection gap (threat-model **T-021 / SEC-004**) and adds a hard guarantee that the coordinator's MDM capability over a provider's Mac is **read-only**.

The MDM `SecurityInfo` callback is the coordinator's *independent* check that a provider isn't lying about SIP/Secure Boot. That callback arrived over `POST /v1/mdm/webhook` with **no auth, no body cap, and no check that the coordinator asked for it** — and the late-arrival path (`main.go`) upgraded a `self_signed` provider straight to **hardware trust** from attacker-controlled SIP/SecureBoot values. A malicious-but-enrolled operator could disable SIP (to read plaintext prompts / run a modified binary / serve manipulated models), then POST a forged `SIP=true` webhook for their own UDID and be promoted to hardware trust — defeating the core attestation guarantee.

## What changed

**1. Read-only MDM (you can't do anything *to* a provider's machine)**
- `assertReadOnlyCommand` — a single chokepoint with an exhaustive allowlist `{SecurityInfo, DeviceInformation}` (both pure queries). Both command senders route through it, so any mutating command (`DeviceLock`, `EraseDevice`, `InstallProfile`, `RestartDevice`, `ShutDownDevice`, …) **fails closed** before reaching MicroMDM. Adding a command type now requires an explicit, reviewable allowlist change.

**2. Solicited-response gate (the real anti-forgery fix)**
- Every issued command UUID is tracked (TTL-bounded, one-shot). `HandleWebhook` parses the response's `CommandUUID` and **drops any webhook whose UUID the coordinator didn't issue**, before any waiter or trust-upgrade callback runs. UUIDs are random and never exposed, so a reachable attacker can't match an in-flight command. Also rejects a solicited UUID replayed against a different device's UDID. This closes both the waiter path and the late-callback path.

**3. HTTP hardening**
- 1 MiB `MaxBytesReader` body cap — kills the unbounded-body memory DoS.
- Optional shared secret (`EIGENINFERENCE_MDM_WEBHOOK_SECRET`, via `?token=` or `X-Webhook-Token`, constant-time) — rejects unauthorized callers before the body is read. MicroMDM is co-located, so the secret never crosses the public network.

## Defense-in-depth, layered

| Layer | Config required | Stops |
|---|---|---|
| Solicited-command (CommandUUID) gate | none — always on | Forged/unsolicited trust upgrades |
| Read-only allowlist | none — always on | Any mutating command to a provider Mac |
| Body cap | none — always on | Unbounded-body DoS |
| Shared secret | optional env | Unauthorized callers reaching the endpoint at all |

## Testing
`go test ./...` green (12 packages). New tests:
- `TestAssertReadOnlyCommand` — reads allowed, every mutating command blocked.
- `TestParseCommandUUID`, `TestCommandTrackingLifecycle` — parse + track→consume (one-shot, TTL, unknown-UUID).
- `TestWebhookDropsUnsolicitedSecurityInfo` — forged SIP=true is dropped; solicited is honored.
- `TestWebhookDropsUUIDForDifferentDevice` — UUID/UDID replay dropped.
- `TestMDMWebhookSecretGate` / `...NoSecretConfigured` — HTTP secret layer.

## Deployment notes (not code)
- MicroMDM already listens on `localhost:9002` (coordinator-only); keep it bound to loopback.
- To enable the optional secret: set `EIGENINFERENCE_MDM_WEBHOOK_SECRET` on the coordinator and append `?token=<same>` to MicroMDM's command-webhook-url. Safe to roll out without it — the CommandUUID gate is the mandatory protection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/270"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783109052&installation_id=133247490&pr_number=270&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F270&signature=86a00da61e85c863b80bb0ac10d2da9898a6ad7f8c0196c75f893b133a3f3875"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->