### PR TITLE
feat(provider): operator-facing diagnostics in `darkbloom doctor` / `status`

### DIFF
--- a/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClient.swift
+++ b/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClient.swift
@@ -31,6 +31,9 @@ public enum CoordinatorEvent: Sendable {
 public final class AtomicProviderStats: Sendable {
     private let _requestsServed = ManagedAtomic<UInt64>(0)
     private let _tokensGenerated = ManagedAtomic<UInt64>(0)
+    // Count of completed requests whose usage chunk was missing/zero. Surfaced
+    // in the daemon state file so `doctor` can flag a billing under-count.
+    private let _usageGaps = ManagedAtomic<UInt64>(0)
 
     public init() {}
 
@@ -44,12 +47,21 @@ public final class AtomicProviderStats: Sendable {
         set { _tokensGenerated.store(newValue) }
     }
 
+    public var usageGaps: UInt64 {
+        get { _usageGaps.load() }
+        set { _usageGaps.store(newValue) }
+    }
+
     public func incrementRequestsServed() {
         _requestsServed.add(1)
     }
 
     public func addTokensGenerated(_ count: UInt64) {
         _tokensGenerated.add(count)
+    }
+
+    public func incrementUsageGaps() {
+        _usageGaps.add(1)
     }
 }
 

--- a/provider-swift/Sources/ProviderCore/Diagnostics/DiagnosticTypes.swift
+++ b/provider-swift/Sources/ProviderCore/Diagnostics/DiagnosticTypes.swift
@@ -1,0 +1,77 @@
+import Foundation
+
+/// Severity of a single diagnostic check, mirroring the operator-facing marker.
+public enum DiagnosticLevel: String, Sendable, Equatable, Codable {
+    case pass
+    case warn
+    case fail
+
+    public var marker: String {
+        switch self {
+        case .pass: return "[PASS]"
+        case .warn: return "[WARN]"
+        case .fail: return "[FAIL]"
+        }
+    }
+}
+
+/// The sections of a diagnostic report, ordered by causal reading order
+/// (hardware → security → attestation key → trust → traffic → runtime →
+/// connectivity → version → billing). Operators read top-to-bottom.
+public enum DiagnosticSection: Int, Sendable, Equatable, CaseIterable {
+    case hardware
+    case security
+    case attestationKey
+    case trust
+    case traffic
+    case runtime
+    case connectivity
+    case version
+    case billing
+
+    public var title: String {
+        switch self {
+        case .hardware: return "HARDWARE & GPU"
+        case .security: return "SECURITY POSTURE"
+        case .attestationKey: return "ATTESTATION KEY (Secure Enclave)"
+        case .trust: return "COORDINATOR TRUST   (why you are / aren't earning)"
+        case .traffic: return "TRAFFIC READINESS   (can this box actually serve?)"
+        case .runtime: return "RUNTIME (live)"
+        case .connectivity: return "CONNECTIVITY"
+        case .version: return "VERSION"
+        case .billing: return "BILLING"
+        }
+    }
+}
+
+/// A single operator-facing diagnostic: what was checked, the verdict, a
+/// plain-language message, and an optional concrete fix line.
+public struct Diagnostic: Sendable, Equatable {
+    public let section: DiagnosticSection
+    public let name: String
+    public let level: DiagnosticLevel
+    public let message: String
+    /// Concrete next step the operator can take. nil for passing checks.
+    public let fix: String?
+
+    public init(section: DiagnosticSection, name: String, level: DiagnosticLevel, message: String, fix: String? = nil) {
+        self.section = section
+        self.name = name
+        self.level = level
+        self.message = message
+        self.fix = fix
+    }
+}
+
+/// Plain-language explanation + suggested fix for a low-level signal (a
+/// coordinator reason string or an OSStatus code). Pure value type so the
+/// mapping catalogs are unit-testable on any platform.
+public struct DiagnosticAdvice: Sendable, Equatable {
+    public let message: String
+    public let fix: String?
+
+    public init(message: String, fix: String? = nil) {
+        self.message = message
+        self.fix = fix
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Diagnostics/ModelFitDiagnostic.swift
+++ b/provider-swift/Sources/ProviderCore/Diagnostics/ModelFitDiagnostic.swift
@@ -5,36 +5,52 @@ import Foundation
 /// A box can be ONLINE and hardware-trusted yet fail every request because the
 /// assigned model doesn't fit its RAM ("Insufficient memory (X GB free, need Y
 /// GB)"). This turns the raw numbers into an operator-facing verdict.
+///
+/// Delegates to `ModelLoadAdmission` — the SAME arithmetic the running provider
+/// uses in `ProviderLoop.availableMemoryGb()` / `ensureModelLoaded` — so the
+/// verdict `doctor` prints can never drift from what the daemon enforces at load
+/// time. (Before, this modelled an older `weights × 2.0` / `free × 0.7` gate
+/// that no longer matches the runtime.)
 public enum ModelFitDiagnostic {
-    /// Matches the provider's own load-time headroom multiplier
-    /// (ensureModelLoaded uses ~2.0× the on-disk weight size for weights + KV +
-    /// activations). A model "fits" when weightGb * factor <= usable RAM.
-    public static let memoryHeadroomFactor = 2.0
+    private static let gib = 1024.0 * 1024.0 * 1024.0
 
-    /// Fraction of free unified memory the provider actually allows inference to
-    /// use (the rest is headroom for the OS / cache growth). MUST match
-    /// `ProviderLoop.availableMemoryGb()` so `doctor`'s verdict matches what the
-    /// running provider will actually do — otherwise doctor can say "fits" for a
-    /// model the provider then refuses to load.
-    public static let inferenceUsableFraction = 0.7
-
-    /// Resident memory a model needs to load, from its on-disk weight size.
-    public static func requiredGb(weightGb: Double) -> Double {
-        weightGb * memoryHeadroomFactor
+    private static func bytes(_ gb: Double) -> UInt64 {
+        guard gb > 0 else { return 0 }
+        let b = (gb * gib).rounded()
+        return b >= Double(UInt64.max) ? UInt64.max : UInt64(b)
     }
 
-    /// The usable-for-inference memory the provider computes:
-    /// (total − reserve − GPU active − GPU cache) × inferenceUsableFraction.
-    /// Shared by `ProviderLoop.availableMemoryGb()` and `doctor` so they can
-    /// never disagree on whether a model fits.
+    /// Resident memory (GB) a model needs to load: the (overhead-padded) weight
+    /// footprint plus one-request headroom — exactly `ensureModelLoaded`'s
+    /// requirement. `estimatedMemoryGb` is the scanner's overhead-included size
+    /// (the same value the runtime passes), not the raw on-disk bytes.
+    public static func requiredGb(estimatedMemoryGb: Double) -> Double {
+        ModelLoadAdmission.requiredToLoadGb(weightsGb: estimatedMemoryGb)
+    }
+
+    /// The memory (GB) the provider would actually have free to load a model,
+    /// via `ModelLoadAdmission.freeForLoadGb`: real free RAM (clamped to what the
+    /// OS reports available when known) minus the OS reserve and resident MLX
+    /// memory. Shared with `ProviderLoop.availableMemoryGb()` so they agree.
+    ///
+    /// - Parameters:
+    ///   - systemAvailableGb: real OS-reported available memory (doctor reads it
+    ///     live on the same machine). Pass nil when unknown to fall back to the
+    ///     total-minus-resident view.
     public static func usableInferenceGb(
         totalGb: Double,
         reserveGb: Double,
+        systemAvailableGb: Double? = nil,
         gpuActiveGb: Double = 0,
         gpuCacheGb: Double = 0
     ) -> Double {
-        let free = totalGb - reserveGb - gpuActiveGb - gpuCacheGb
-        return max(0, free) * inferenceUsableFraction
+        ModelLoadAdmission.freeForLoadGb(
+            totalBytes: bytes(totalGb),
+            systemAvailableBytes: systemAvailableGb.map(bytes) ?? .max,
+            gpuActiveBytes: bytes(gpuActiveGb),
+            gpuCacheBytes: bytes(gpuCacheGb),
+            reserveBytes: bytes(reserveGb),
+            outstandingReservationBytes: 0)
     }
 
     /// A candidate model the operator could serve instead, with its size.
@@ -48,7 +64,8 @@ public enum ModelFitDiagnostic {
     }
 
     /// Builds the traffic-readiness diagnostic for a single target model.
-    /// `alternatives` are locally-available models, used to suggest a fit.
+    /// `weightGb` is the model's overhead-included estimated size; `alternatives`
+    /// are locally-available models, used to suggest a fit.
     public static func diagnose(
         modelID: String,
         weightGb: Double,
@@ -61,7 +78,7 @@ public enum ModelFitDiagnostic {
                 message: "couldn't determine the model size or available memory; skipping the fit check.",
                 fix: nil)
         }
-        let needed = requiredGb(weightGb: weightGb)
+        let needed = requiredGb(estimatedMemoryGb: weightGb)
         if needed <= usableGb {
             return Diagnostic(
                 section: .traffic, name: "model fits in RAM", level: .pass,
@@ -69,13 +86,13 @@ public enum ModelFitDiagnostic {
                 fix: nil)
         }
         let fits = alternatives
-            .filter { requiredGb(weightGb: $0.weightGb) <= usableGb }
+            .filter { requiredGb(estimatedMemoryGb: $0.weightGb) <= usableGb }
             .sorted { $0.weightGb > $1.weightGb }
         let suggestion: String
         if fits.isEmpty {
             suggestion = "this box's RAM is too small for the models on this network; consider a machine with more unified memory."
         } else {
-            let list = fits.prefix(3).map { "\($0.id) (~\(fmt(requiredGb(weightGb: $0.weightGb))) GB)" }.joined(separator: ", ")
+            let list = fits.prefix(3).map { "\($0.id) (~\(fmt(requiredGb(estimatedMemoryGb: $0.weightGb))) GB)" }.joined(separator: ", ")
             suggestion = "set `enabled_models` in provider.toml to a model that fits: \(list)."
         }
         return Diagnostic(

--- a/provider-swift/Sources/ProviderCore/Diagnostics/ModelFitDiagnostic.swift
+++ b/provider-swift/Sources/ProviderCore/Diagnostics/ModelFitDiagnostic.swift
@@ -1,0 +1,69 @@
+import Foundation
+
+/// Pure logic for "can this box actually load the model it would be assigned?"
+///
+/// A box can be ONLINE and hardware-trusted yet fail every request because the
+/// assigned model doesn't fit its RAM ("Insufficient memory (X GB free, need Y
+/// GB)"). This turns the raw numbers into an operator-facing verdict.
+public enum ModelFitDiagnostic {
+    /// Matches the provider's own load-time headroom multiplier
+    /// (ensureModelLoaded uses ~2.0× the on-disk weight size for weights + KV +
+    /// activations). A model "fits" when weightGb * factor <= usable RAM.
+    public static let memoryHeadroomFactor = 2.0
+
+    /// Resident memory a model needs to load, from its on-disk weight size.
+    public static func requiredGb(weightGb: Double) -> Double {
+        weightGb * memoryHeadroomFactor
+    }
+
+    /// A candidate model the operator could serve instead, with its size.
+    public struct ModelOption: Sendable, Equatable {
+        public let id: String
+        public let weightGb: Double
+        public init(id: String, weightGb: Double) {
+            self.id = id
+            self.weightGb = weightGb
+        }
+    }
+
+    /// Builds the traffic-readiness diagnostic for a single target model.
+    /// `alternatives` are locally-available models, used to suggest a fit.
+    public static func diagnose(
+        modelID: String,
+        weightGb: Double,
+        usableGb: Double,
+        alternatives: [ModelOption] = []
+    ) -> Diagnostic {
+        guard weightGb > 0, usableGb > 0 else {
+            return Diagnostic(
+                section: .traffic, name: "model fits in RAM", level: .warn,
+                message: "couldn't determine the model size or available memory; skipping the fit check.",
+                fix: nil)
+        }
+        let needed = requiredGb(weightGb: weightGb)
+        if needed <= usableGb {
+            return Diagnostic(
+                section: .traffic, name: "model fits in RAM", level: .pass,
+                message: "\(modelID) needs ~\(fmt(needed)) GB; \(fmt(usableGb)) GB usable.",
+                fix: nil)
+        }
+        let fits = alternatives
+            .filter { requiredGb(weightGb: $0.weightGb) <= usableGb }
+            .sorted { $0.weightGb > $1.weightGb }
+        let suggestion: String
+        if fits.isEmpty {
+            suggestion = "this box's RAM is too small for the models on this network; consider a machine with more unified memory."
+        } else {
+            let list = fits.prefix(3).map { "\($0.id) (~\(fmt(requiredGb(weightGb: $0.weightGb))) GB)" }.joined(separator: ", ")
+            suggestion = "set `enabled_models` in provider.toml to a model that fits: \(list)."
+        }
+        return Diagnostic(
+            section: .traffic, name: "model fits in RAM", level: .fail,
+            message: "\(modelID) needs ~\(fmt(needed)) GB but only \(fmt(usableGb)) GB is usable — it will show online but every request fails to load.",
+            fix: suggestion)
+    }
+
+    private static func fmt(_ v: Double) -> String {
+        String(format: "%.1f", v)
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Diagnostics/ModelFitDiagnostic.swift
+++ b/provider-swift/Sources/ProviderCore/Diagnostics/ModelFitDiagnostic.swift
@@ -11,9 +11,30 @@ public enum ModelFitDiagnostic {
     /// activations). A model "fits" when weightGb * factor <= usable RAM.
     public static let memoryHeadroomFactor = 2.0
 
+    /// Fraction of free unified memory the provider actually allows inference to
+    /// use (the rest is headroom for the OS / cache growth). MUST match
+    /// `ProviderLoop.availableMemoryGb()` so `doctor`'s verdict matches what the
+    /// running provider will actually do — otherwise doctor can say "fits" for a
+    /// model the provider then refuses to load.
+    public static let inferenceUsableFraction = 0.7
+
     /// Resident memory a model needs to load, from its on-disk weight size.
     public static func requiredGb(weightGb: Double) -> Double {
         weightGb * memoryHeadroomFactor
+    }
+
+    /// The usable-for-inference memory the provider computes:
+    /// (total − reserve − GPU active − GPU cache) × inferenceUsableFraction.
+    /// Shared by `ProviderLoop.availableMemoryGb()` and `doctor` so they can
+    /// never disagree on whether a model fits.
+    public static func usableInferenceGb(
+        totalGb: Double,
+        reserveGb: Double,
+        gpuActiveGb: Double = 0,
+        gpuCacheGb: Double = 0
+    ) -> Double {
+        let free = totalGb - reserveGb - gpuActiveGb - gpuCacheGb
+        return max(0, free) * inferenceUsableFraction
     }
 
     /// A candidate model the operator could serve instead, with its size.

--- a/provider-swift/Sources/ProviderCore/Diagnostics/OSStatusCatalog.swift
+++ b/provider-swift/Sources/ProviderCore/Diagnostics/OSStatusCatalog.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+/// Translates Secure Enclave / Keychain `OSStatus` codes into operator advice.
+/// Used by the SE-key self-test in `darkbloom doctor` so a signing failure
+/// becomes an actionable message instead of a bare negative number.
+///
+/// Pure (takes an `Int32` rather than the Apple-only `OSStatus` typealias's
+/// platform behavior) so it is unit-testable everywhere.
+public enum OSStatusCatalog {
+    // Well-known Security.framework codes (stable values).
+    public static let interactionNotAllowed: Int32 = -25308 // errSecInteractionNotAllowed
+    public static let missingEntitlement: Int32 = -34018    // errSecMissingEntitlement
+    public static let itemNotFound: Int32 = -25300          // errSecItemNotFound
+    public static let duplicateItem: Int32 = -25299         // errSecDuplicateItem
+    public static let authFailed: Int32 = -25293            // errSecAuthFailed
+    public static let userCanceled: Int32 = -128            // errSecUserCanceled
+
+    public static func advice(osStatus: Int32) -> DiagnosticAdvice {
+        switch osStatus {
+        case interactionNotAllowed:
+            return DiagnosticAdvice(
+                message: "the Secure Enclave key exists but cannot sign (OSStatus -25308: keychain locked). The daemon is likely running headless / over SSH, so the login keychain is locked and the key can't answer attestation challenges.",
+                fix: "log in at the console once (and stay logged in), then `darkbloom start`. The v2 key uses AfterFirstUnlock, so one post-boot console login is enough.")
+        case missingEntitlement:
+            return DiagnosticAdvice(
+                message: "this binary is missing the keychain-access-groups entitlement (OSStatus -34018), so it cannot use a persistent Secure Enclave key — it will fall back to an ephemeral key and can never reach hardware trust.",
+                fix: "reinstall the official signed bundle (re-run the install script); a self-built/unsigned binary cannot attest.")
+        case itemNotFound:
+            return DiagnosticAdvice(
+                message: "no Secure Enclave key found yet (first run, or the key was deleted).",
+                fix: "`darkbloom start` will mint one on next launch.")
+        case duplicateItem:
+            return DiagnosticAdvice(
+                message: "a Secure Enclave key already exists under this label (benign race).",
+                fix: nil)
+        case authFailed:
+            return DiagnosticAdvice(
+                message: "Secure Enclave signing was denied (OSStatus -25293: authentication failed).",
+                fix: "ensure the Mac is unlocked at the console and re-run `darkbloom start`.")
+        case userCanceled:
+            return DiagnosticAdvice(
+                message: "Secure Enclave access was canceled (OSStatus -128).",
+                fix: "re-run `darkbloom start` and allow keychain access if prompted.")
+        case 0:
+            return DiagnosticAdvice(message: "Secure Enclave key signs correctly.", fix: nil)
+        default:
+            return DiagnosticAdvice(
+                message: "Secure Enclave signing failed with OSStatus \(osStatus).",
+                fix: "run `darkbloom report` and include this code.")
+        }
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Diagnostics/TrustReasonCatalog.swift
+++ b/provider-swift/Sources/ProviderCore/Diagnostics/TrustReasonCatalog.swift
@@ -1,0 +1,105 @@
+import Foundation
+
+/// Translates the coordinator's `trust_status` reason strings into plain-language
+/// explanations and concrete fixes for the operator.
+///
+/// The coordinator already tells a provider WHY its trust changed (via the
+/// `trust_status` message's `reason` field), but that string is terse and
+/// engineer-facing ("binary hash mismatch", "SE attestation verified, awaiting
+/// MDM/ACME upgrade"). This catalog is the single source of truth that turns
+/// each reason into something an operator can act on.
+///
+/// The reason strings here are copied verbatim from the coordinator
+/// (`coordinator/api/provider.go`: `sendTrustStatus` + `handleChallengeFailure`).
+/// The default arm echoes any unrecognized reason verbatim so a new coordinator
+/// reason still reaches the operator instead of being hidden.
+public enum TrustReasonCatalog {
+    /// Maps a trust update to operator advice. `level`/`status` give context
+    /// (e.g. self_signed/online means "online but not earning").
+    public static func advice(level: String, status: String, reason: String) -> DiagnosticAdvice {
+        // Prefix-matched reasons (they carry a variable error suffix).
+        if reason.hasPrefix("signature verification failed") {
+            return DiagnosticAdvice(
+                message: "the coordinator rejected your attestation signature — usually the Secure Enclave key can't sign.",
+                fix: "run `darkbloom doctor` and check the Secure Enclave key; if headless/SSH, log in at the console once so the key unlocks.")
+        }
+        if reason.hasPrefix("status signature verification failed") {
+            return DiagnosticAdvice(
+                message: "the coordinator rejected your signed security-status payload (signature/canonical mismatch).",
+                fix: "update to the latest build with `darkbloom update`; if it persists, run `darkbloom report`.")
+        }
+
+        switch reason {
+        // ---- success / status (sendTrustStatus) ----
+        case "SE attestation verified, awaiting MDM/ACME upgrade":
+            return DiagnosticAdvice(
+                message: "verified by Secure Enclave, but NOT yet hardware-trusted. You're ONLINE but receive NO traffic until MDM/ACME completes (this network requires hardware trust).",
+                fix: "run `darkbloom enroll`, then wait ~5 min for MDM verification.")
+        case "MDM verification passed", "ACME device attestation verified":
+            return DiagnosticAdvice(
+                message: "hardware-trusted and eligible for traffic.",
+                fix: nil)
+        case "recovered after transient deroute":
+            return DiagnosticAdvice(
+                message: "recovered after a temporary derouting (a brief network/challenge blip).",
+                fix: nil)
+
+        // ---- challenge failures (handleChallengeFailure) → untrust ----
+        case "timeout", "no response":
+            return DiagnosticAdvice(
+                message: "the coordinator's attestation challenge didn't get a reply in time — usually network flap, the Mac sleeping, or a wedged connection.",
+                fix: "check network stability and prevent sleep; the provider auto-recovers on the next passing challenge.")
+        case "nonce mismatch", "empty signature":
+            return DiagnosticAdvice(
+                message: "the attestation challenge response was malformed — likely a stale or broken build.",
+                fix: "`darkbloom update` to the latest build.")
+        case "public key mismatch":
+            return DiagnosticAdvice(
+                message: "your Secure Enclave key changed from what was registered (a re-minted key or a different machine identity).",
+                fix: "restart the provider so it re-registers: `darkbloom stop && darkbloom start`.")
+        case "SIP status not reported", "SIP disabled":
+            return DiagnosticAdvice(
+                message: "System Integrity Protection is off (or unreported). SIP is required for hardware trust.",
+                fix: "boot into Recovery → Terminal → run `csrutil enable`, then reboot.")
+        case "Secure Boot disabled":
+            return DiagnosticAdvice(
+                message: "Secure Boot is not set to Full Security, which is required for hardware trust.",
+                fix: "boot into Recovery → Startup Security Utility → set Full Security.")
+        case "RDMA status not reported — provider must update to v0.2.0+":
+            return DiagnosticAdvice(
+                message: "your build is too old to report required security state.",
+                fix: "`darkbloom update` to a current build.")
+        case "binary hash mismatch", "binary hash changed from registration attestation",
+             "attested binary hash missing", "binary hash missing",
+             "valid attestation required for binary hash policy":
+            return DiagnosticAdvice(
+                message: "the running binary doesn't match the official, attested build (or its hash couldn't be proven).",
+                fix: "reinstall the official bundle and don't modify the binary: re-run the install script.")
+        case "active model weight hash mismatch":
+            return DiagnosticAdvice(
+                message: "the model weights you're serving don't match the registered hash for that model.",
+                fix: "re-download the model with `darkbloom models download <id>` so weights match the registry.")
+
+        default:
+            // Never hide an unrecognized reason — surface it verbatim.
+            return DiagnosticAdvice(message: "coordinator reason: \(reason)", fix: nil)
+        }
+    }
+
+    /// Convenience: the diagnostic level implied by a trust level + status.
+    /// hardware/online = pass; self_signed = warn (online but not earning);
+    /// untrusted/offline = fail.
+    public static func level(trustLevel: String, status: String) -> DiagnosticLevel {
+        if status == "untrusted" || status == "offline" {
+            return .fail
+        }
+        switch trustLevel {
+        case "hardware", "mda_verified":
+            return .pass
+        case "self_signed":
+            return .warn
+        default:
+            return .warn
+        }
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Diagnostics/VersionDiagnostic.swift
+++ b/provider-swift/Sources/ProviderCore/Diagnostics/VersionDiagnostic.swift
@@ -1,0 +1,60 @@
+import Foundation
+
+/// Pure semver comparison for the version diagnostic. A provider below the
+/// coordinator's minimum version is rejected from routing (RuntimeVerified=false)
+/// — the operator needs to know that's why they aren't earning.
+public enum VersionDiagnostic {
+    /// Parses a dotted version ("0.5.15", "v1.2.3", "1.2.3-beta") into
+    /// comparable integer components, ignoring any leading "v" and pre-release
+    /// suffix. Returns nil on garbage.
+    public static func parse(_ version: String) -> [Int]? {
+        var v = version.trimmingCharacters(in: .whitespaces)
+        if v.hasPrefix("v") || v.hasPrefix("V") { v.removeFirst() }
+        // Drop pre-release/build metadata.
+        if let dash = v.firstIndex(of: "-") { v = String(v[..<dash]) }
+        if let plus = v.firstIndex(of: "+") { v = String(v[..<plus]) }
+        let parts = v.split(separator: ".", omittingEmptySubsequences: false)
+        guard !parts.isEmpty else { return nil }
+        var out: [Int] = []
+        for p in parts {
+            guard let n = Int(p) else { return nil }
+            out.append(n)
+        }
+        return out
+    }
+
+    /// Returns -1 if a<b, 0 if equal, 1 if a>b. Unparseable versions sort as
+    /// "unknown" and compare equal (caller treats that as a soft pass).
+    public static func compare(_ a: String, _ b: String) -> Int {
+        guard let pa = parse(a), let pb = parse(b) else { return 0 }
+        let n = max(pa.count, pb.count)
+        for i in 0..<n {
+            let x = i < pa.count ? pa[i] : 0
+            let y = i < pb.count ? pb[i] : 0
+            if x != y { return x < y ? -1 : 1 }
+        }
+        return 0
+    }
+
+    /// Builds the version diagnostic. `minimum`/`latest` may be empty/unknown.
+    public static func diagnose(current: String, minimum: String?, latest: String?) -> Diagnostic {
+        if let minimum, !minimum.isEmpty, parse(minimum) != nil, parse(current) != nil,
+           compare(current, minimum) < 0 {
+            return Diagnostic(
+                section: .version, name: "minimum version", level: .fail,
+                message: "running \(current); the coordinator requires ≥ \(minimum). You will not be trusted until you update.",
+                fix: "`darkbloom update` (or enable `auto_update` in provider.toml).")
+        }
+        if let latest, !latest.isEmpty, parse(latest) != nil, parse(current) != nil,
+           compare(current, latest) < 0 {
+            return Diagnostic(
+                section: .version, name: "up to date", level: .warn,
+                message: "running \(current); latest is \(latest).",
+                fix: "`darkbloom update` to pick up fixes.")
+        }
+        return Diagnostic(
+            section: .version, name: "up to date", level: .pass,
+            message: "running \(current).",
+            fix: nil)
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Models/ModelScanner+Discovery.swift
+++ b/provider-swift/Sources/ProviderCore/Models/ModelScanner+Discovery.swift
@@ -28,8 +28,37 @@ extension ModelScanner {
         return scanModels(in: cacheDir, availableMemoryGB: hardwareInfo.memoryAvailableGb)
     }
 
+    /// Scan for ALL locally cached MLX models WITHOUT the available-memory
+    /// filter. Diagnostics (`darkbloom doctor`) need this: when the configured
+    /// model is too large for this box, `scanModels` drops it, which would make
+    /// doctor diagnose some other (fitting) model instead of flagging the one
+    /// the operator actually configured and that will never load.
+    public static func scanAllModels(hardwareInfo: HardwareInfo) -> [ModelInfo] {
+        guard let cacheDir = defaultCacheDirectory(),
+              FileManager.default.fileExists(atPath: cacheDir.path) else {
+            discoveryLogger.debug("HuggingFace cache directory not found")
+            return []
+        }
+        return scanAllModels(in: cacheDir)
+    }
+
     /// Scan for models in a specific cache directory, filtering by available memory.
     public static func scanModels(in cacheDir: URL, availableMemoryGB: UInt64) -> [ModelInfo] {
+        scanAllModels(in: cacheDir).filter { info in
+            if info.estimatedMemoryGb <= Double(availableMemoryGB) {
+                return true
+            }
+            discoveryLogger.debug(
+                "Skipping \(info.id) — needs \(String(format: "%.1f", info.estimatedMemoryGb)) GB but only \(availableMemoryGB) GB available"
+            )
+            return false
+        }
+    }
+
+    /// Scan for every MLX model in a cache directory, unfiltered. The shared
+    /// discovery core for both the memory-filtered `scanModels(in:availableMemoryGB:)`
+    /// and the diagnostics path.
+    public static func scanAllModels(in cacheDir: URL) -> [ModelInfo] {
         let fm = FileManager.default
         let entries: [URL]
         do {
@@ -65,13 +94,7 @@ extension ModelScanner {
                 continue
             }
 
-            if info.estimatedMemoryGb <= Double(availableMemoryGB) {
-                models.append(info)
-            } else {
-                discoveryLogger.debug(
-                    "Skipping \(info.id) — needs \(String(format: "%.1f", info.estimatedMemoryGb)) GB but only \(availableMemoryGB) GB available"
-                )
-            }
+            models.append(info)
         }
 
         // Sort by estimated memory ascending (smallest models first)

--- a/provider-swift/Sources/ProviderCore/ProviderLoop.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop.swift
@@ -163,6 +163,15 @@ public actor ProviderLoop {
     /// Task for the delayed auto-report (10 minutes after learning trust status).
     private var autoReportTask: Task<Void, Never>?
 
+    /// Diagnostics: the most recent trust_status from the coordinator and the
+    /// most recent model-load failure, plus the daemon start time. Persisted to
+    /// the daemon state file so `darkbloom status`/`doctor` can show the
+    /// operator WHY they are / aren't earning. Start time uses wall-clock epoch
+    /// (not ContinuousClock) so it survives across the CLI process boundary.
+    private var lastTrustStatus: DaemonState.Trust?
+    private var lastModelLoadError: DaemonState.ModelLoadError?
+    private let startedAtEpoch: Double = Date().timeIntervalSince1970
+
     /// Keeps the network stack alive during sleep for APN push notifications.
     /// Held for the entire provider session so MDM SecurityInfo commands
     /// can be delivered even when the Mac is sleeping.
@@ -930,6 +939,10 @@ public actor ProviderLoop {
                         + "MLXOpenAIService.streamChatCompletionFrames behavior."
                     )
                 }
+                // Surface the usage-chunk anomaly to the operator via `doctor`
+                // (recorded even when the content-frame floor recovered billing,
+                // since a missing/zero usage chunk is itself the signal).
+                providerStats.incrementUsageGaps()
             }
 
             // Update stats
@@ -1062,8 +1075,51 @@ public actor ProviderLoop {
     /// Handle a trust_status message from the coordinator. If the provider
     /// learns it is self_signed or untrusted, schedule a one-time auto-report
     /// of unified logs after 10 minutes.
+    /// Assembles the current daemon state and writes it to the state file so the
+    /// CLI (`status`/`doctor`) can read live state + the latest trust reason.
+    /// Best-effort and cheap; safe to call from the trust handler and the
+    /// periodic capacity loop.
+    private func writeDaemonState() {
+        let cap = state.backendCapacity
+        let snapshot = DaemonState(
+            pid: getpid(),
+            version: ProviderCore.version,
+            writtenAt: Date().timeIntervalSince1970,
+            startedAt: startedAtEpoch,
+            trust: lastTrustStatus,
+            currentModel: state.currentModel,
+            warmModels: state.warmModels,
+            inferenceActive: state.inferenceActive,
+            stats: DaemonState.Stats(
+                requestsServed: stats.requestsServed,
+                tokensGenerated: stats.tokensGenerated,
+                usageGaps: stats.usageGaps
+            ),
+            capacity: cap.map {
+                DaemonState.Capacity(totalMemoryGb: $0.totalMemoryGb, gpuMemoryActiveGb: $0.gpuMemoryActiveGb)
+            },
+            lastModelLoadError: lastModelLoadError
+        )
+        DaemonStateFile.write(snapshot)
+    }
+
+    /// Records a model-load failure for the diagnostics state file so the
+    /// operator sees the exact "Insufficient memory …" text in `doctor`.
+    private func recordModelLoadError(model: String, message: String) {
+        lastModelLoadError = DaemonState.ModelLoadError(
+            model: model, message: message, at: Date().timeIntervalSince1970)
+        writeDaemonState()
+    }
+
     private func handleTrustStatus(trustLevel: String, status: String, reason: String) {
         logger.info("Trust status update: level=\(trustLevel) status=\(status) reason=\(reason)")
+
+        // Cache + persist so `darkbloom status`/`doctor` can show the operator
+        // the coordinator's reason (otherwise it is only in the logs).
+        lastTrustStatus = DaemonState.Trust(
+            trustLevel: trustLevel, status: status, reason: reason,
+            receivedAt: Date().timeIntervalSince1970)
+        writeDaemonState()
 
         let needsReport = trustLevel == "self_signed" || status == "untrusted"
         guard needsReport, !didAutoReport else {
@@ -1304,10 +1360,16 @@ public actor ProviderLoop {
         let pollInterval = Duration.seconds(Int64(max(1, heartbeatInterval / 2)))
         let me = self
         capacityRefreshTask = Task {
+            // Write once immediately so `status`/`doctor` have a fresh file soon
+            // after the daemon starts, before the first poll interval elapses.
+            await me.writeDaemonState()
             while !Task.isCancelled {
                 try? await Task.sleep(for: pollInterval)
                 if Task.isCancelled { break }
                 await me.updateAggregateCapacity()
+                // Refresh the diagnostics state file on the same cadence so
+                // `status`/`doctor` see current model, stats, and capacity.
+                await me.writeDaemonState()
             }
         }
     }
@@ -1491,7 +1553,14 @@ public actor ProviderLoop {
             let requiredGb = ModelLoadAdmission.requiredToLoadGb(
                 weightsGb: modelInfo.estimatedMemoryGb,
                 headroomGb: Self.loadHeadroomGb)
-            try await evictUntilAvailable(requiredGb: requiredGb)
+            do {
+                try await evictUntilAvailable(requiredGb: requiredGb)
+            } catch let InferenceError.modelLoadFailed(message) {
+                // Record for diagnostics so `doctor` shows the operator the exact
+                // "Insufficient memory …" reason, then rethrow unchanged.
+                recordModelLoadError(model: modelId, message: message)
+                throw InferenceError.modelLoadFailed(message)
+            }
             try Task.checkCancellation()
             if isShuttingDown { throw CancellationError() }
 

--- a/provider-swift/Sources/ProviderCore/ProviderLoop.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop.swift
@@ -1096,7 +1096,10 @@ public actor ProviderLoop {
                 usageGaps: stats.usageGaps
             ),
             capacity: cap.map {
-                DaemonState.Capacity(totalMemoryGb: $0.totalMemoryGb, gpuMemoryActiveGb: $0.gpuMemoryActiveGb)
+                DaemonState.Capacity(
+                    totalMemoryGb: $0.totalMemoryGb,
+                    gpuMemoryActiveGb: $0.gpuMemoryActiveGb,
+                    gpuMemoryCacheGb: $0.gpuMemoryCacheGb)
             },
             lastModelLoadError: lastModelLoadError
         )

--- a/provider-swift/Sources/ProviderCore/ProviderLoop.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop.swift
@@ -1674,6 +1674,10 @@ public actor ProviderLoop {
     ///   2. KV already promised to in-flight requests
     ///      (`kvBudget.outstandingReservedBytes`) is subtracted, so a concurrent
     ///      load can't consume memory a mid-decode request is counting on.
+    ///
+    /// `doctor`'s model-fit check shares the SAME arithmetic via
+    /// `ModelLoadAdmission`, so the operator-facing verdict can never drift from
+    /// what this method enforces at load time.
     private func availableMemoryGb() async -> Double {
         let outstanding = await kvBudget.outstandingReservedBytes()
         return ModelLoadAdmission.freeForLoadGb(

--- a/provider-swift/Sources/ProviderCore/Service/DaemonStateFile.swift
+++ b/provider-swift/Sources/ProviderCore/Service/DaemonStateFile.swift
@@ -70,9 +70,16 @@ public struct DaemonState: Codable, Sendable, Equatable {
     public struct Capacity: Codable, Sendable, Equatable {
         public var totalMemoryGb: Double
         public var gpuMemoryActiveGb: Double
-        public init(totalMemoryGb: Double, gpuMemoryActiveGb: Double) {
+        /// Live MLX GPU cache (buffer pool) memory. Optional for backward
+        /// compatibility with state files written before this field existed; the
+        /// model-fit diagnostic subtracts it so `doctor` exactly mirrors
+        /// `ProviderLoop.availableMemoryGb()` even when the OS-available reading
+        /// is unavailable.
+        public var gpuMemoryCacheGb: Double?
+        public init(totalMemoryGb: Double, gpuMemoryActiveGb: Double, gpuMemoryCacheGb: Double? = nil) {
             self.totalMemoryGb = totalMemoryGb
             self.gpuMemoryActiveGb = gpuMemoryActiveGb
+            self.gpuMemoryCacheGb = gpuMemoryCacheGb
         }
     }
 

--- a/provider-swift/Sources/ProviderCore/Service/DaemonStateFile.swift
+++ b/provider-swift/Sources/ProviderCore/Service/DaemonStateFile.swift
@@ -1,0 +1,195 @@
+import Foundation
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#endif
+
+/// Snapshot of the running provider daemon's state, written periodically to a
+/// small JSON file so the `status` / `doctor` CLI commands can show live state
+/// and — critically — the coordinator's latest `trust_status` reason, which is
+/// otherwise only logged.
+///
+/// The daemon and CLI run as separate processes with no IPC today (only a PID
+/// file). A state file is the smallest addition that fits: the daemon already
+/// assembles this exact data every heartbeat; writing it atomically lets the CLI
+/// read it with zero IPC, and it survives the daemon being asleep or wedged.
+public struct DaemonState: Codable, Sendable, Equatable {
+    public static let currentSchema = 1
+
+    public var schema: Int
+    public var pid: Int32
+    public var version: String
+    public var writtenAt: Double // epoch seconds; staleness check
+    public var startedAt: Double // epoch seconds; uptime
+    public var trust: Trust?
+    public var currentModel: String?
+    public var warmModels: [String]
+    public var inferenceActive: Bool
+    public var stats: Stats
+    public var system: SystemInfo?
+    public var capacity: Capacity?
+    public var lastModelLoadError: ModelLoadError?
+    public var connectivity: Connectivity?
+
+    public struct Trust: Codable, Sendable, Equatable {
+        public var trustLevel: String
+        public var status: String
+        public var reason: String
+        public var receivedAt: Double
+        public init(trustLevel: String, status: String, reason: String, receivedAt: Double) {
+            self.trustLevel = trustLevel
+            self.status = status
+            self.reason = reason
+            self.receivedAt = receivedAt
+        }
+    }
+
+    public struct Stats: Codable, Sendable, Equatable {
+        public var requestsServed: UInt64
+        public var tokensGenerated: UInt64
+        public var usageGaps: UInt64
+        public init(requestsServed: UInt64 = 0, tokensGenerated: UInt64 = 0, usageGaps: UInt64 = 0) {
+            self.requestsServed = requestsServed
+            self.tokensGenerated = tokensGenerated
+            self.usageGaps = usageGaps
+        }
+    }
+
+    public struct SystemInfo: Codable, Sendable, Equatable {
+        public var memoryPressure: Double
+        public var cpuUsage: Double
+        public var thermalState: String
+        public init(memoryPressure: Double, cpuUsage: Double, thermalState: String) {
+            self.memoryPressure = memoryPressure
+            self.cpuUsage = cpuUsage
+            self.thermalState = thermalState
+        }
+    }
+
+    public struct Capacity: Codable, Sendable, Equatable {
+        public var totalMemoryGb: Double
+        public var gpuMemoryActiveGb: Double
+        public init(totalMemoryGb: Double, gpuMemoryActiveGb: Double) {
+            self.totalMemoryGb = totalMemoryGb
+            self.gpuMemoryActiveGb = gpuMemoryActiveGb
+        }
+    }
+
+    public struct ModelLoadError: Codable, Sendable, Equatable {
+        public var model: String
+        public var message: String
+        public var at: Double
+        public init(model: String, message: String, at: Double) {
+            self.model = model
+            self.message = message
+            self.at = at
+        }
+    }
+
+    public struct Connectivity: Codable, Sendable, Equatable {
+        public var reconnectCount: Int
+        public var lastError: String?
+        public init(reconnectCount: Int, lastError: String?) {
+            self.reconnectCount = reconnectCount
+            self.lastError = lastError
+        }
+    }
+
+    public init(
+        schema: Int = DaemonState.currentSchema,
+        pid: Int32,
+        version: String,
+        writtenAt: Double,
+        startedAt: Double,
+        trust: Trust? = nil,
+        currentModel: String? = nil,
+        warmModels: [String] = [],
+        inferenceActive: Bool = false,
+        stats: Stats = Stats(),
+        system: SystemInfo? = nil,
+        capacity: Capacity? = nil,
+        lastModelLoadError: ModelLoadError? = nil,
+        connectivity: Connectivity? = nil
+    ) {
+        self.schema = schema
+        self.pid = pid
+        self.version = version
+        self.writtenAt = writtenAt
+        self.startedAt = startedAt
+        self.trust = trust
+        self.currentModel = currentModel
+        self.warmModels = warmModels
+        self.inferenceActive = inferenceActive
+        self.stats = stats
+        self.system = system
+        self.capacity = capacity
+        self.lastModelLoadError = lastModelLoadError
+        self.connectivity = connectivity
+    }
+
+    // MARK: - Reader helpers
+
+    public func ageSeconds(now: Double) -> Double { max(0, now - writtenAt) }
+
+    /// Live fields are stale if the snapshot is older than 3× the heartbeat
+    /// (~90s). A stale-but-present file still carries useful last-known trust.
+    public func isStale(now: Double, maxAge: Double = 90) -> Bool {
+        ageSeconds(now: now) > maxAge
+    }
+
+    public func uptimeSeconds(now: Double) -> Double { max(0, now - startedAt) }
+}
+
+/// Reports whether a process with the given PID is currently alive.
+public func daemonProcessAlive(pid: Int32) -> Bool {
+    pid > 0 && kill(pid, 0) == 0
+}
+
+/// Reads/writes the daemon state file at `~/.darkbloom/daemon-state.json`
+/// (override with `DARKBLOOM_STATE_FILE`).
+public enum DaemonStateFile {
+    public static func path() -> URL {
+        if let override = ProcessInfo.processInfo.environment["DARKBLOOM_STATE_FILE"], !override.isEmpty {
+            return URL(fileURLWithPath: override)
+        }
+        return FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".darkbloom/daemon-state.json")
+    }
+
+    private static func encoder() -> JSONEncoder {
+        let e = JSONEncoder()
+        e.keyEncodingStrategy = .convertToSnakeCase
+        e.outputFormatting = [.sortedKeys]
+        return e
+    }
+
+    private static func decoder() -> JSONDecoder {
+        let d = JSONDecoder()
+        d.keyDecodingStrategy = .convertFromSnakeCase
+        return d
+    }
+
+    /// Atomically writes the snapshot. Best-effort: write failures are swallowed
+    /// (diagnostics must never crash the serving daemon).
+    public static func write(_ state: DaemonState, to url: URL = DaemonStateFile.path()) {
+        do {
+            let dir = url.deletingLastPathComponent()
+            try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+            let data = try encoder().encode(state)
+            // .atomic writes to a temp file then renames — a reader never sees a
+            // half-written file.
+            try data.write(to: url, options: .atomic)
+        } catch {
+            // Intentionally ignored: state file is a diagnostic aid, not critical.
+        }
+    }
+
+    /// Reads the snapshot, or nil if absent / unreadable / wrong schema.
+    public static func read(from url: URL = DaemonStateFile.path()) -> DaemonState? {
+        guard let data = try? Data(contentsOf: url) else { return nil }
+        guard let state = try? decoder().decode(DaemonState.self, from: data) else { return nil }
+        guard state.schema == DaemonState.currentSchema else { return nil }
+        return state
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Service/DaemonStateFile.swift
+++ b/provider-swift/Sources/ProviderCore/Service/DaemonStateFile.swift
@@ -132,8 +132,10 @@ public struct DaemonState: Codable, Sendable, Equatable {
 
     public func ageSeconds(now: Double) -> Double { max(0, now - writtenAt) }
 
-    /// Live fields are stale if the snapshot is older than 3× the heartbeat
-    /// (~90s). A stale-but-present file still carries useful last-known trust.
+    /// Live fields are stale if the snapshot is older than 90s — many write
+    /// cycles (the daemon rewrites every ~half-heartbeat), so this comfortably
+    /// distinguishes "running" from "wedged". A stale-but-present file still
+    /// carries useful last-known trust.
     public func isStale(now: Double, maxAge: Double = 90) -> Bool {
         ageSeconds(now: now) > maxAge
     }

--- a/provider-swift/Sources/darkbloom/Diagnostics/DiagnosticReportRenderer.swift
+++ b/provider-swift/Sources/darkbloom/Diagnostics/DiagnosticReportRenderer.swift
@@ -1,0 +1,31 @@
+import Foundation
+import ProviderCore
+
+/// Renders a list of `Diagnostic`s as the sectioned, operator-readable report
+/// printed by `darkbloom doctor`. Pure string production so it can be
+/// snapshot-tested.
+enum DiagnosticReportRenderer {
+    static func render(_ diagnostics: [Diagnostic]) -> String {
+        var out: [String] = []
+        for section in DiagnosticSection.allCases {
+            let items = diagnostics.filter { $0.section == section }
+            guard !items.isEmpty else { continue }
+            out.append("")
+            out.append(section.title)
+            for d in items {
+                out.append("  \(d.level.marker) \(d.name) — \(d.message)")
+                if let fix = d.fix, !fix.isEmpty {
+                    out.append("         ↳ fix: \(fix)")
+                }
+            }
+        }
+        return out.joined(separator: "\n")
+    }
+
+    /// Overall verdict: any fail → fail; with `strict`, any warn also → fail.
+    static func hasFailure(_ diagnostics: [Diagnostic], strict: Bool) -> Bool {
+        if diagnostics.contains(where: { $0.level == .fail }) { return true }
+        if strict && diagnostics.contains(where: { $0.level == .warn }) { return true }
+        return false
+    }
+}

--- a/provider-swift/Sources/darkbloom/Diagnostics/DoctorRunner.swift
+++ b/provider-swift/Sources/darkbloom/Diagnostics/DoctorRunner.swift
@@ -14,6 +14,9 @@ enum DoctorRunner {
         let now = Date().timeIntervalSince1970
         let state = DaemonStateFile.read()
         let daemonUp = state.map { daemonProcessAlive(pid: $0.pid) } ?? false
+        // "Fresh" = the daemon is running AND its state snapshot isn't stale, so
+        // its live fields (trust level, current model, capacity) are trustworthy.
+        let stateFresh = daemonUp && !(state?.isStale(now: now) ?? true)
 
         // ---- Attestation key (local, no daemon needed) ----
         let se = SEKeySelfTest.run()
@@ -37,8 +40,13 @@ enum DoctorRunner {
                                   message: "the provider daemon isn't running, so live trust status is unavailable.",
                                   fix: "run `darkbloom start`, then `darkbloom doctor`."))
         }
-        // Enrollment hint (local).
-        if !checkMDMEnrolled() {
+        // Enrollment hint (local) — but skip it when the coordinator already
+        // grants this provider hardware trust (e.g. via ACME device attestation,
+        // which needs no MDM profile). Nagging an already-hardware-trusted box to
+        // enroll in MDM is a false warning that sends the operator down the wrong
+        // flow and contradicts the trust line printed just above.
+        let alreadyHardwareTrusted = stateFresh && state?.trust?.trustLevel == "hardware"
+        if !alreadyHardwareTrusted && !checkMDMEnrolled() {
             out.append(Diagnostic(section: .trust, name: "mdm enrollment", level: .warn,
                                   message: "this Mac is not enrolled in MDM — hardware trust can't be granted, so you won't receive traffic on a hardware-trust network.",
                                   fix: "run `darkbloom enroll` and approve the profile in System Settings → Profiles, then wait ~5 min."))
@@ -46,25 +54,45 @@ enum DoctorRunner {
 
         // ---- Traffic readiness: does the assigned/configured model fit RAM? ----
         if let hw = snapshot.hardware {
-            // Use the SAME accounting the provider enforces at load time
-            // (total − reserve − GPU − cache) × 0.7, not the raw available RAM —
+            // Mirror the provider's REAL load gate via ModelFitDiagnostic →
+            // ModelLoadAdmission: clamp to live OS-available memory and subtract
+            // the OS reserve + resident MLX memory, not raw total−reserve —
             // otherwise doctor reports "fits" for a model the provider refuses.
-            // When the daemon is up, subtract its live GPU-active memory.
-            let gpuActiveGb = (daemonUp ? state?.capacity?.gpuMemoryActiveGb : nil) ?? 0
+            // When the daemon is up and fresh, subtract its live GPU-active
+            // memory too (the min() inside ModelLoadAdmission keeps it conservative
+            // without double-counting against the OS-available figure).
+            let gpuActiveGb = (stateFresh ? state?.capacity?.gpuMemoryActiveGb : nil) ?? 0
+            let gpuCacheGb = (stateFresh ? state?.capacity?.gpuMemoryCacheGb : nil) ?? 0
+            let bytesPerGb = 1024.0 * 1024.0 * 1024.0
+            let systemAvailableGb = SystemMemory.availableBytes().map { Double($0) / bytesPerGb }
             let usableGb = ModelFitDiagnostic.usableInferenceGb(
                 totalGb: Double(hw.memoryGb),
                 reserveGb: Double(snapshot.config.provider.memoryReserveGB),
-                gpuActiveGb: gpuActiveGb)
-            let targetID = state?.currentModel ?? snapshot.config.backend.model ?? snapshot.config.backend.enabledModels.first
-            let alternatives = snapshot.models.map {
+                systemAvailableGb: systemAvailableGb,
+                gpuActiveGb: gpuActiveGb,
+                gpuCacheGb: gpuCacheGb)
+
+            // Prefer the live loaded model ONLY when the daemon is up and fresh;
+            // otherwise diagnose the CONFIGURED model. A stale state file (daemon
+            // stopped/crashed, then provider.toml changed to a larger model)
+            // would otherwise check last session's model and miss the new misfit.
+            let liveModel = stateFresh ? state?.currentModel : nil
+            let targetID = liveModel ?? snapshot.config.backend.model ?? snapshot.config.backend.enabledModels.first
+
+            // Use the UNFILTERED model list: ModelScanner.scanModels drops models
+            // too large for this box, so a too-large CONFIGURED model would be
+            // absent and doctor would silently diagnose a different (fitting) one
+            // instead of flagging the one that will never load.
+            let allModels = ModelScanner.scanAllModels(hardwareInfo: hw)
+            let alternatives = allModels.map {
                 ModelFitDiagnostic.ModelOption(id: $0.id, weightGb: $0.estimatedMemoryGb)
             }
-            if let targetID, let target = snapshot.models.first(where: { $0.id == targetID }) {
+            if let targetID, let target = allModels.first(where: { $0.id == targetID }) {
                 out.append(ModelFitDiagnostic.diagnose(
                     modelID: targetID, weightGb: target.estimatedMemoryGb,
                     usableGb: usableGb, alternatives: alternatives))
             } else if !alternatives.isEmpty {
-                // No specific target; check the largest local model fits.
+                // No specific/known target; check the largest local model fits.
                 if let biggest = alternatives.max(by: { $0.weightGb < $1.weightGb }) {
                     out.append(ModelFitDiagnostic.diagnose(
                         modelID: biggest.id, weightGb: biggest.weightGb,
@@ -103,6 +131,14 @@ enum DoctorRunner {
         }
 
         // ---- Version (coordinator) ----
+        // NOTE: `minimum` is nil for now — VersionDiagnostic supports a hard
+        // below-minimum FAIL, but the coordinator only exposes
+        // min_provider_version on Privy-authenticated /v1/me endpoints, which
+        // this device-token CLI can't call. Surfacing it needs a device-authed
+        // source (a new endpoint or a trust_status/registration field) — tracked
+        // as a follow-up. Below-min providers are still flagged indirectly: the
+        // coordinator marks them RuntimeVerified=false and the trust section
+        // above reports the resulting "not earning" state.
         let updater = SelfUpdater(coordinatorBaseURL: coordinatorURL)
         switch await updater.checkForUpdate() {
         case .updateAvailable(let current, let latest):

--- a/provider-swift/Sources/darkbloom/Diagnostics/DoctorRunner.swift
+++ b/provider-swift/Sources/darkbloom/Diagnostics/DoctorRunner.swift
@@ -1,0 +1,117 @@
+import Foundation
+import ProviderCore
+
+/// Builds the operator-facing "why am I / aren't I earning?" diagnosis that
+/// `darkbloom doctor` prints, combining local probes (SE key, RAM, hardware),
+/// the daemon state file (trust reason, live runtime), and a coordinator
+/// version check. Returns sectioned `Diagnostic`s for the renderer.
+enum DoctorRunner {
+    static func buildOperatorDiagnosis(
+        snapshot: RuntimeSnapshot,
+        coordinatorURL: String
+    ) async -> [Diagnostic] {
+        var out: [Diagnostic] = []
+        let now = Date().timeIntervalSince1970
+        let state = DaemonStateFile.read()
+        let daemonUp = state.map { daemonProcessAlive(pid: $0.pid) } ?? false
+
+        // ---- Attestation key (local, no daemon needed) ----
+        let se = SEKeySelfTest.run()
+        out.append(Diagnostic(section: .attestationKey, name: "se key sign test",
+                              level: se.level, message: se.message, fix: se.fix))
+
+        // ---- Coordinator trust (from the daemon's last trust_status) ----
+        if let state, let trust = state.trust, daemonUp, !state.isStale(now: now) {
+            let advice = TrustReasonCatalog.advice(level: trust.trustLevel, status: trust.status, reason: trust.reason)
+            let level = TrustReasonCatalog.level(trustLevel: trust.trustLevel, status: trust.status)
+            out.append(Diagnostic(section: .trust, name: "trust level",
+                                  level: level,
+                                  message: "\(trust.trustLevel) / \(trust.status) — \(advice.message)",
+                                  fix: advice.fix))
+        } else if daemonUp {
+            out.append(Diagnostic(section: .trust, name: "trust level", level: .warn,
+                                  message: "the daemon is running but hasn't received a trust status from the coordinator yet (or it's stale).",
+                                  fix: "wait ~1 min and re-run `darkbloom doctor`; if it persists, check connectivity below."))
+        } else {
+            out.append(Diagnostic(section: .trust, name: "trust level", level: .warn,
+                                  message: "the provider daemon isn't running, so live trust status is unavailable.",
+                                  fix: "run `darkbloom start`, then `darkbloom doctor`."))
+        }
+        // Enrollment hint (local).
+        if !checkMDMEnrolled() {
+            out.append(Diagnostic(section: .trust, name: "mdm enrollment", level: .warn,
+                                  message: "this Mac is not enrolled in MDM — hardware trust can't be granted, so you won't receive traffic on a hardware-trust network.",
+                                  fix: "run `darkbloom enroll` and approve the profile in System Settings → Profiles, then wait ~5 min."))
+        }
+
+        // ---- Traffic readiness: does the assigned/configured model fit RAM? ----
+        if let hw = snapshot.hardware {
+            let usableGb = Double(hw.memoryAvailableGb > 0 ? hw.memoryAvailableGb : hw.memoryGb)
+            let targetID = state?.currentModel ?? snapshot.config.backend.model ?? snapshot.config.backend.enabledModels.first
+            let alternatives = snapshot.models.map {
+                ModelFitDiagnostic.ModelOption(id: $0.id, weightGb: $0.estimatedMemoryGb)
+            }
+            if let targetID, let target = snapshot.models.first(where: { $0.id == targetID }) {
+                out.append(ModelFitDiagnostic.diagnose(
+                    modelID: targetID, weightGb: target.estimatedMemoryGb,
+                    usableGb: usableGb, alternatives: alternatives))
+            } else if !alternatives.isEmpty {
+                // No specific target; check the largest local model fits.
+                if let biggest = alternatives.max(by: { $0.weightGb < $1.weightGb }) {
+                    out.append(ModelFitDiagnostic.diagnose(
+                        modelID: biggest.id, weightGb: biggest.weightGb,
+                        usableGb: usableGb, alternatives: alternatives))
+                }
+            }
+        }
+
+        // ---- Runtime (live, from state file) ----
+        if let state, daemonUp {
+            if state.isStale(now: now) {
+                out.append(Diagnostic(section: .runtime, name: "daemon", level: .warn,
+                                      message: "running but its last update was \(Int(state.ageSeconds(now: now)))s ago — it may be wedged.",
+                                      fix: "check `darkbloom logs`; consider `darkbloom stop && darkbloom start`."))
+            } else {
+                let model = state.currentModel ?? "none loaded"
+                out.append(Diagnostic(section: .runtime, name: "daemon connected", level: .pass,
+                                      message: "up \(formatDuration(state.uptimeSeconds(now: now))), model: \(model), \(state.stats.requestsServed) requests served.",
+                                      fix: nil))
+            }
+            if let err = state.lastModelLoadError {
+                out.append(Diagnostic(section: .runtime, name: "recent model load", level: .warn,
+                                      message: "FAILED for \(err.model): \(err.message)",
+                                      fix: "see the model-fit check above; serve a model that fits this box's RAM."))
+            }
+            // ---- Billing ----
+            if state.stats.usageGaps > 0 {
+                out.append(Diagnostic(section: .billing, name: "usage reporting", level: .warn,
+                                      message: "\(state.stats.usageGaps) completed request(s) had a missing/zero usage chunk (under-counting risk).",
+                                      fix: "run `darkbloom report` and include this doctor output."))
+            } else {
+                out.append(Diagnostic(section: .billing, name: "usage reporting", level: .pass,
+                                      message: "\(state.stats.requestsServed) requests / \(state.stats.tokensGenerated) tokens reported this session.",
+                                      fix: nil))
+            }
+        }
+
+        // ---- Version (coordinator) ----
+        let updater = SelfUpdater(coordinatorBaseURL: coordinatorURL)
+        switch await updater.checkForUpdate() {
+        case .updateAvailable(let current, let latest):
+            out.append(VersionDiagnostic.diagnose(current: current, minimum: nil, latest: latest.version))
+        case .upToDate(let current):
+            out.append(VersionDiagnostic.diagnose(current: current, minimum: nil, latest: current))
+        case .checkFailed:
+            break // network section already covers coordinator reachability
+        }
+
+        return out
+    }
+
+    private static func formatDuration(_ seconds: Double) -> String {
+        let s = Int(seconds)
+        if s < 60 { return "\(s)s" }
+        if s < 3600 { return "\(s / 60)m" }
+        return "\(s / 3600)h\((s % 3600) / 60)m"
+    }
+}

--- a/provider-swift/Sources/darkbloom/Diagnostics/DoctorRunner.swift
+++ b/provider-swift/Sources/darkbloom/Diagnostics/DoctorRunner.swift
@@ -46,7 +46,15 @@ enum DoctorRunner {
 
         // ---- Traffic readiness: does the assigned/configured model fit RAM? ----
         if let hw = snapshot.hardware {
-            let usableGb = Double(hw.memoryAvailableGb > 0 ? hw.memoryAvailableGb : hw.memoryGb)
+            // Use the SAME accounting the provider enforces at load time
+            // (total − reserve − GPU − cache) × 0.7, not the raw available RAM —
+            // otherwise doctor reports "fits" for a model the provider refuses.
+            // When the daemon is up, subtract its live GPU-active memory.
+            let gpuActiveGb = (daemonUp ? state?.capacity?.gpuMemoryActiveGb : nil) ?? 0
+            let usableGb = ModelFitDiagnostic.usableInferenceGb(
+                totalGb: Double(hw.memoryGb),
+                reserveGb: Double(snapshot.config.provider.memoryReserveGB),
+                gpuActiveGb: gpuActiveGb)
             let targetID = state?.currentModel ?? snapshot.config.backend.model ?? snapshot.config.backend.enabledModels.first
             let alternatives = snapshot.models.map {
                 ModelFitDiagnostic.ModelOption(id: $0.id, weightGb: $0.estimatedMemoryGb)

--- a/provider-swift/Sources/darkbloom/Diagnostics/SEKeySelfTest.swift
+++ b/provider-swift/Sources/darkbloom/Diagnostics/SEKeySelfTest.swift
@@ -1,0 +1,49 @@
+import Foundation
+import ProviderCore
+
+/// Runs a real Secure Enclave load+sign round-trip to prove the attestation key
+/// can actually answer challenges — the #1 cause of a box being stuck untrusted
+/// while looking healthy locally. Lives in the CLI (not pure ProviderCore)
+/// because it touches the keychain/Security framework.
+enum SEKeySelfTest {
+    /// Result of the self-test, already mapped to operator advice.
+    struct Result {
+        let level: DiagnosticLevel
+        let message: String
+        let fix: String?
+    }
+
+    /// A throwaway label so the test never disturbs the production v2 key
+    /// (loadOrCreate(label:) under a custom label does NO migration).
+    private static let testLabel = "io.darkbloom.provider.doctor-selftest"
+
+    static func run() -> Result {
+        guard PersistentEnclaveKey.isAvailable else {
+            return Result(
+                level: .warn,
+                message: "no Secure Enclave on this Mac (Intel or VM) — hardware-trusted inference isn't possible here.",
+                fix: "use an Apple Silicon Mac to provide hardware-trusted inference.")
+        }
+        do {
+            let key = try PersistentEnclaveKey.loadOrCreate(label: testLabel)
+            _ = try key.sign(Data("darkbloom-doctor-selftest".utf8))
+            // Clean up the throwaway key; ignore failure.
+            try? PersistentEnclaveKey.delete(label: testLabel)
+            return Result(level: .pass, message: "Secure Enclave key loads and signs correctly.", fix: nil)
+        } catch let PersistentEnclaveKeyError.signingFailed(status, _) {
+            let advice = OSStatusCatalog.advice(osStatus: status)
+            return Result(level: .fail, message: advice.message, fix: advice.fix)
+        } catch PersistentEnclaveKeyError.missingEntitlement {
+            let advice = OSStatusCatalog.advice(osStatus: OSStatusCatalog.missingEntitlement)
+            return Result(level: .fail, message: advice.message, fix: advice.fix)
+        } catch let PersistentEnclaveKeyError.keyLookupFailed(status) {
+            let advice = OSStatusCatalog.advice(osStatus: status)
+            return Result(level: .warn, message: advice.message, fix: advice.fix)
+        } catch {
+            return Result(
+                level: .fail,
+                message: "Secure Enclave self-test failed: \(error.localizedDescription)",
+                fix: "run `darkbloom report` and include this output.")
+        }
+    }
+}

--- a/provider-swift/Sources/darkbloom/DoctorCommand.swift
+++ b/provider-swift/Sources/darkbloom/DoctorCommand.swift
@@ -29,10 +29,28 @@ struct Doctor: AsyncParsableCommand {
             coordinatorOverride: coordinator
         ))
 
-        print("darkbloom doctor")
+        // Operator-facing diagnosis: trust reason, SE key, model fit, runtime,
+        // billing, version — the "why am I / aren't I earning?" answers.
+        let diagnosis = await DoctorRunner.buildOperatorDiagnosis(
+            snapshot: snapshot,
+            coordinatorURL: coordinator ?? snapshot.config.coordinator.url
+        )
+
+        print("darkbloom doctor \(ProviderCore.version)")
         print("Config: \(describeConfigPath(snapshot))")
+        let daemonState = DaemonStateFile.read()
+        let daemonRunning = daemonState.map { daemonProcessAlive(pid: $0.pid) } ?? false
+        print("Daemon: \(daemonRunning ? "running" : "NOT running — run `darkbloom start`")")
+
+        // The high-signal diagnosis first (sectioned, with fixes).
+        let rendered = DiagnosticReportRenderer.render(diagnosis)
+        if !rendered.isEmpty { print(rendered) }
+
+        // Then the detailed low-level checks.
+        print("")
+        print("DETAILED CHECKS")
         for check in checks {
-            print("\(check.status.marker) \(check.name): \(check.detail)")
+            print("  \(check.status.marker) \(check.name): \(check.detail)")
         }
         if support {
             print("")
@@ -45,7 +63,9 @@ struct Doctor: AsyncParsableCommand {
         }
 
         let hasFailure = checks.contains { $0.status == .fail }
+            || diagnosis.contains { $0.level == .fail }
         let hasWarning = checks.contains { $0.status == .warn }
+            || diagnosis.contains { $0.level == .warn }
 
         if hasFailure || (strict && hasWarning) {
             throw ExitCode.failure

--- a/provider-swift/Sources/darkbloom/StatusCommand.swift
+++ b/provider-swift/Sources/darkbloom/StatusCommand.swift
@@ -1,3 +1,4 @@
+import Foundation
 import ArgumentParser
 import ProviderCore
 
@@ -45,6 +46,51 @@ struct Status: AsyncParsableCommand {
         let enabledFilter = config.backend.enabledModels.isEmpty ? "none" : config.backend.enabledModels.joined(separator: ", ")
         print("Enabled model filter: \(enabledFilter)")
         print("Local MLX models: \(models.count)")
-        print("Process control: not available yet in the Swift CLI")
+
+        // Live daemon state (from the state file the running daemon writes).
+        print("")
+        printDaemonStatus()
+    }
+
+    /// Prints the running daemon's live state, including the coordinator's last
+    /// trust reason — the answer to "am I earning, and if not, why?".
+    private func printDaemonStatus() {
+        let now = Date().timeIntervalSince1970
+        guard let state = DaemonStateFile.read() else {
+            print("Daemon: not running (run `darkbloom start`)")
+            return
+        }
+        let alive = daemonProcessAlive(pid: state.pid)
+        if !alive {
+            print("Daemon: not running (stale state file)")
+            return
+        }
+        if state.isStale(now: now) {
+            print("Daemon: running (pid \(state.pid)) but last update \(Int(state.ageSeconds(now: now)))s ago — possibly wedged")
+        } else {
+            print("Daemon: running (pid \(state.pid), up \(formatUptime(state.uptimeSeconds(now: now))))")
+        }
+
+        if let trust = state.trust {
+            let advice = TrustReasonCatalog.advice(level: trust.trustLevel, status: trust.status, reason: trust.reason)
+            print("Trust: \(trust.trustLevel) / \(trust.status)")
+            print("  → \(advice.message)")
+            if let fix = advice.fix { print("  → fix: \(fix)") }
+        } else {
+            print("Trust: awaiting coordinator status")
+        }
+
+        print("Current model: \(state.currentModel ?? "none loaded")")
+        print("Requests served: \(state.stats.requestsServed)  |  tokens: \(state.stats.tokensGenerated)")
+        if let err = state.lastModelLoadError {
+            print("Last model-load error: \(err.model): \(err.message)")
+        }
+    }
+
+    private func formatUptime(_ seconds: Double) -> String {
+        let s = Int(seconds)
+        if s < 60 { return "\(s)s" }
+        if s < 3600 { return "\(s / 60)m" }
+        return "\(s / 3600)h\((s % 3600) / 60)m"
     }
 }

--- a/provider-swift/Tests/DarkbloomCLITests/DiagnosticReportRendererTests.swift
+++ b/provider-swift/Tests/DarkbloomCLITests/DiagnosticReportRendererTests.swift
@@ -1,0 +1,39 @@
+import Testing
+import ProviderCore
+@testable import darkbloom
+
+@Test func rendererGroupsBySectionWithFixLines() {
+    let diags = [
+        Diagnostic(section: .trust, name: "trust level", level: .warn,
+                   message: "self_signed / online — not earning.", fix: "run `darkbloom enroll`"),
+        Diagnostic(section: .attestationKey, name: "se key sign test", level: .fail,
+                   message: "key cannot sign (-25308).", fix: "log in at the console"),
+        Diagnostic(section: .billing, name: "usage reporting", level: .pass,
+                   message: "412 requests reported.", fix: nil),
+    ]
+    let out = DiagnosticReportRenderer.render(diags)
+
+    // Sections appear in canonical order: attestationKey before trust before billing.
+    let keyIdx = out.range(of: "ATTESTATION KEY")
+    let trustIdx = out.range(of: "COORDINATOR TRUST")
+    let billIdx = out.range(of: "BILLING")
+    #expect(keyIdx != nil && trustIdx != nil && billIdx != nil)
+    #expect(out.range(of: "ATTESTATION KEY")!.lowerBound < out.range(of: "COORDINATOR TRUST")!.lowerBound)
+    #expect(out.range(of: "COORDINATOR TRUST")!.lowerBound < out.range(of: "BILLING")!.lowerBound)
+
+    // Markers + fix lines render.
+    #expect(out.contains("[FAIL] se key sign test"))
+    #expect(out.contains("↳ fix: log in at the console"))
+    #expect(out.contains("[PASS] usage reporting"))
+    // A passing check with nil fix emits no fix line for it.
+    #expect(!out.contains("↳ fix: \n"))
+}
+
+@Test func rendererFailureVerdictRespectsStrict() {
+    let warnOnly = [Diagnostic(section: .trust, name: "t", level: .warn, message: "m")]
+    #expect(DiagnosticReportRenderer.hasFailure(warnOnly, strict: false) == false)
+    #expect(DiagnosticReportRenderer.hasFailure(warnOnly, strict: true) == true)
+
+    let withFail = [Diagnostic(section: .trust, name: "t", level: .fail, message: "m")]
+    #expect(DiagnosticReportRenderer.hasFailure(withFail, strict: false) == true)
+}

--- a/provider-swift/Tests/ProviderCoreTests/DiagnosticsTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/DiagnosticsTests.swift
@@ -70,34 +70,45 @@ import Testing
 // MARK: - ModelFitDiagnostic
 
 @Test func modelFitFailsWhenTooLarge() {
-    let d = ModelFitDiagnostic.diagnose(modelID: "big", weightGb: 19.0, usableGb: 21.0)
-    // needs 19*2=38 > 21 → fail
+    // New gate (ModelLoadAdmission): required = weights + 2 GB headroom.
+    // 25 GB weights needs 27 GB > 21 usable → fail.
+    let d = ModelFitDiagnostic.diagnose(modelID: "big", weightGb: 25.0, usableGb: 21.0)
     #expect(d.level == .fail)
-    #expect(d.message.contains("38"))
+    #expect(d.message.contains("27"))
 }
 
 @Test func modelFitPassesWhenItFits() {
+    // 5 GB weights needs 5 + 2 = 7 GB ≤ 21 usable → pass.
     let d = ModelFitDiagnostic.diagnose(modelID: "small", weightGb: 5.0, usableGb: 21.0)
     #expect(d.level == .pass)
 }
 
 @Test func usableInferenceGbMatchesProviderAccounting() {
-    // (total − reserve − gpuActive − cache) × 0.7. Must match
-    // ProviderLoop.availableMemoryGb() so doctor and the provider agree.
-    // 32 GB box, 4 GB reserve, idle: (32 − 4) × 0.7 = 19.6.
-    #expect(abs(ModelFitDiagnostic.usableInferenceGb(totalGb: 32, reserveGb: 4) - 19.6) < 0.001)
-    // With 5 GB GPU active: (32 − 4 − 5) × 0.7 = 16.1.
-    #expect(abs(ModelFitDiagnostic.usableInferenceGb(totalGb: 32, reserveGb: 4, gpuActiveGb: 5) - 16.1) < 0.001)
+    // Delegates to ModelLoadAdmission.freeForLoadGb. Must match
+    // ProviderLoop.availableMemoryGb(): real free minus reserve, NO 0.7 discount.
+    // 32 GB box, 4 GB reserve, idle, OS-available unknown: 32 − 4 = 28.
+    #expect(abs(ModelFitDiagnostic.usableInferenceGb(totalGb: 32, reserveGb: 4) - 28.0) < 0.01)
+    // With 5 GB GPU active: 32 − 5 − 4 = 23.
+    #expect(abs(ModelFitDiagnostic.usableInferenceGb(totalGb: 32, reserveGb: 4, gpuActiveGb: 5) - 23.0) < 0.01)
+    // Clamped to live OS-available memory when that is the tighter bound:
+    // 32 GB box but OS reports only 10 GB available → 10 − 4 = 6.
+    #expect(abs(ModelFitDiagnostic.usableInferenceGb(totalGb: 32, reserveGb: 4, systemAvailableGb: 10) - 6.0) < 0.01)
     // Never negative.
     #expect(ModelFitDiagnostic.usableInferenceGb(totalGb: 8, reserveGb: 16) == 0)
 }
 
-@Test func modelFitUsesProviderUsableMemoryNotRawAvailable() {
-    // Regression for the review finding: a 9 GB-weight model (needs 18 GB) on a
-    // 24 GB box must FAIL — usable is (24−4)×0.7 = 14 GB, NOT the raw 20 GB.
-    let usable = ModelFitDiagnostic.usableInferenceGb(totalGb: 24, reserveGb: 4)
-    let d = ModelFitDiagnostic.diagnose(modelID: "mid", weightGb: 9.0, usableGb: usable)
-    #expect(d.level == .fail, "must reflect the provider's 0.7 gate, not total−reserve")
+@Test func modelFitMatchesRuntimeGateNotRawAvailable() {
+    // Headline parity with #273's runtime gate: gpt-oss (~13.5 GB weights, so
+    // needs 15.5 GB) on a 24 GB box with the OS reporting ~20 GB free FITS —
+    // usable 20 − 4 = 16 ≥ 15.5 — matching ProviderLoop, which now loads it.
+    let usable = ModelFitDiagnostic.usableInferenceGb(totalGb: 24, reserveGb: 4, systemAvailableGb: 20)
+    let ok = ModelFitDiagnostic.diagnose(modelID: "gpt-oss", weightGb: 13.5, usableGb: usable)
+    #expect(ok.level == .pass, "doctor must agree with the runtime gate that gpt-oss fits 24 GB")
+    // But a genuinely over-capacity case (OS only 12 GB free) must FAIL, not
+    // mislead the operator: usable 12 − 4 = 8 < 15.5.
+    let tight = ModelFitDiagnostic.usableInferenceGb(totalGb: 24, reserveGb: 4, systemAvailableGb: 12)
+    let bad = ModelFitDiagnostic.diagnose(modelID: "gpt-oss", weightGb: 13.5, usableGb: tight)
+    #expect(bad.level == .fail)
 }
 
 @Test func modelFitSuggestsFittingAlternatives() {
@@ -105,6 +116,7 @@ import Testing
         ModelFitDiagnostic.ModelOption(id: "small", weightGb: 5.0),
         ModelFitDiagnostic.ModelOption(id: "huge", weightGb: 40.0),
     ]
+    // huge needs 42 > 21 → fail; small needs 7 ≤ 21 → suggested.
     let d = ModelFitDiagnostic.diagnose(modelID: "huge", weightGb: 40.0, usableGb: 21.0, alternatives: alts)
     #expect(d.level == .fail)
     #expect(d.fix?.contains("small") == true)

--- a/provider-swift/Tests/ProviderCoreTests/DiagnosticsTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/DiagnosticsTests.swift
@@ -81,6 +81,25 @@ import Testing
     #expect(d.level == .pass)
 }
 
+@Test func usableInferenceGbMatchesProviderAccounting() {
+    // (total − reserve − gpuActive − cache) × 0.7. Must match
+    // ProviderLoop.availableMemoryGb() so doctor and the provider agree.
+    // 32 GB box, 4 GB reserve, idle: (32 − 4) × 0.7 = 19.6.
+    #expect(abs(ModelFitDiagnostic.usableInferenceGb(totalGb: 32, reserveGb: 4) - 19.6) < 0.001)
+    // With 5 GB GPU active: (32 − 4 − 5) × 0.7 = 16.1.
+    #expect(abs(ModelFitDiagnostic.usableInferenceGb(totalGb: 32, reserveGb: 4, gpuActiveGb: 5) - 16.1) < 0.001)
+    // Never negative.
+    #expect(ModelFitDiagnostic.usableInferenceGb(totalGb: 8, reserveGb: 16) == 0)
+}
+
+@Test func modelFitUsesProviderUsableMemoryNotRawAvailable() {
+    // Regression for the review finding: a 9 GB-weight model (needs 18 GB) on a
+    // 24 GB box must FAIL — usable is (24−4)×0.7 = 14 GB, NOT the raw 20 GB.
+    let usable = ModelFitDiagnostic.usableInferenceGb(totalGb: 24, reserveGb: 4)
+    let d = ModelFitDiagnostic.diagnose(modelID: "mid", weightGb: 9.0, usableGb: usable)
+    #expect(d.level == .fail, "must reflect the provider's 0.7 gate, not total−reserve")
+}
+
 @Test func modelFitSuggestsFittingAlternatives() {
     let alts = [
         ModelFitDiagnostic.ModelOption(id: "small", weightGb: 5.0),

--- a/provider-swift/Tests/ProviderCoreTests/DiagnosticsTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/DiagnosticsTests.swift
@@ -1,0 +1,174 @@
+import Foundation
+import Testing
+@testable import ProviderCore
+
+// MARK: - TrustReasonCatalog
+
+@Test func trustReasonCatalogMapsKnownReasons() {
+    // Every reason string the coordinator emits must produce a non-empty,
+    // operator-actionable message (and a fix for the actionable ones).
+    let reasons = [
+        "SE attestation verified, awaiting MDM/ACME upgrade",
+        "MDM verification passed",
+        "ACME device attestation verified",
+        "recovered after transient deroute",
+        "timeout", "no response", "nonce mismatch", "public key mismatch",
+        "empty signature", "SIP status not reported", "SIP disabled",
+        "Secure Boot disabled", "RDMA status not reported — provider must update to v0.2.0+",
+        "binary hash mismatch", "binary hash changed from registration attestation",
+        "attested binary hash missing", "binary hash missing",
+        "valid attestation required for binary hash policy",
+        "active model weight hash mismatch",
+    ]
+    for r in reasons {
+        let advice = TrustReasonCatalog.advice(level: "self_signed", status: "untrusted", reason: r)
+        #expect(!advice.message.isEmpty, "empty message for reason \(r)")
+    }
+}
+
+@Test func trustReasonCatalogPrefixMatchesSignatureFailures() {
+    let a = TrustReasonCatalog.advice(level: "hardware", status: "untrusted",
+                                      reason: "signature verification failed: bad point")
+    #expect(a.message.lowercased().contains("signature"))
+    #expect(a.fix != nil)
+
+    let b = TrustReasonCatalog.advice(level: "hardware", status: "untrusted",
+                                      reason: "status signature verification failed: canonical mismatch")
+    #expect(b.fix != nil)
+}
+
+@Test func trustReasonCatalogEchoesUnknownReasonVerbatim() {
+    let novel = "some-brand-new-coordinator-reason-v9"
+    let advice = TrustReasonCatalog.advice(level: "self_signed", status: "online", reason: novel)
+    #expect(advice.message.contains(novel), "unknown reason must be surfaced verbatim, not hidden")
+}
+
+@Test func trustReasonCatalogLevels() {
+    #expect(TrustReasonCatalog.level(trustLevel: "hardware", status: "online") == .pass)
+    #expect(TrustReasonCatalog.level(trustLevel: "self_signed", status: "online") == .warn)
+    #expect(TrustReasonCatalog.level(trustLevel: "hardware", status: "untrusted") == .fail)
+}
+
+// MARK: - OSStatusCatalog
+
+@Test func osStatusCatalogMapsLockedKey() {
+    let a = OSStatusCatalog.advice(osStatus: -25308)
+    #expect(a.message.contains("-25308"))
+    #expect(a.fix?.contains("console") == true)
+}
+
+@Test func osStatusCatalogMapsMissingEntitlement() {
+    let a = OSStatusCatalog.advice(osStatus: -34018)
+    #expect(a.message.lowercased().contains("entitlement"))
+}
+
+@Test func osStatusCatalogUnknownEchoesCode() {
+    let a = OSStatusCatalog.advice(osStatus: -99999)
+    #expect(a.message.contains("-99999"))
+}
+
+// MARK: - ModelFitDiagnostic
+
+@Test func modelFitFailsWhenTooLarge() {
+    let d = ModelFitDiagnostic.diagnose(modelID: "big", weightGb: 19.0, usableGb: 21.0)
+    // needs 19*2=38 > 21 → fail
+    #expect(d.level == .fail)
+    #expect(d.message.contains("38"))
+}
+
+@Test func modelFitPassesWhenItFits() {
+    let d = ModelFitDiagnostic.diagnose(modelID: "small", weightGb: 5.0, usableGb: 21.0)
+    #expect(d.level == .pass)
+}
+
+@Test func modelFitSuggestsFittingAlternatives() {
+    let alts = [
+        ModelFitDiagnostic.ModelOption(id: "small", weightGb: 5.0),
+        ModelFitDiagnostic.ModelOption(id: "huge", weightGb: 40.0),
+    ]
+    let d = ModelFitDiagnostic.diagnose(modelID: "huge", weightGb: 40.0, usableGb: 21.0, alternatives: alts)
+    #expect(d.level == .fail)
+    #expect(d.fix?.contains("small") == true)
+    #expect(d.fix?.contains("huge") != true) // huge doesn't fit, must not be suggested
+}
+
+// MARK: - VersionDiagnostic
+
+@Test func versionParseAndCompare() {
+    #expect(VersionDiagnostic.parse("v1.2.3") == [1, 2, 3])
+    #expect(VersionDiagnostic.parse("0.5.15-beta") == [0, 5, 15])
+    #expect(VersionDiagnostic.parse("garbage") == nil)
+    #expect(VersionDiagnostic.compare("0.5.15", "0.6.0") == -1)
+    #expect(VersionDiagnostic.compare("1.0.0", "1.0.0") == 0)
+    #expect(VersionDiagnostic.compare("2.0.0", "1.9.9") == 1)
+}
+
+@Test func versionDiagnoseBelowMinimumFails() {
+    let d = VersionDiagnostic.diagnose(current: "0.5.15", minimum: "0.6.0", latest: "0.7.0")
+    #expect(d.level == .fail)
+}
+
+@Test func versionDiagnoseBehindLatestWarns() {
+    let d = VersionDiagnostic.diagnose(current: "0.6.0", minimum: "0.5.0", latest: "0.7.0")
+    #expect(d.level == .warn)
+}
+
+@Test func versionDiagnoseCurrentPasses() {
+    let d = VersionDiagnostic.diagnose(current: "0.7.0", minimum: "0.5.0", latest: "0.7.0")
+    #expect(d.level == .pass)
+}
+
+// MARK: - DaemonStateFile
+
+private func tmpStateURL() -> URL {
+    FileManager.default.temporaryDirectory
+        .appendingPathComponent("dstate-\(UUID().uuidString).json")
+}
+
+@Test func daemonStateRoundTrips() {
+    let url = tmpStateURL()
+    defer { try? FileManager.default.removeItem(at: url) }
+    let state = DaemonState(
+        pid: 4711, version: "0.5.15", writtenAt: 1000, startedAt: 900,
+        trust: .init(trustLevel: "self_signed", status: "online", reason: "awaiting", receivedAt: 950),
+        currentModel: "qwen", warmModels: ["qwen"], inferenceActive: true,
+        stats: .init(requestsServed: 412, tokensGenerated: 98231, usageGaps: 3))
+    DaemonStateFile.write(state, to: url)
+    let read = DaemonStateFile.read(from: url)
+    #expect(read?.pid == 4711)
+    #expect(read?.trust?.reason == "awaiting")
+    #expect(read?.stats.usageGaps == 3)
+    #expect(read?.currentModel == "qwen")
+}
+
+@Test func daemonStateStaleness() {
+    let state = DaemonState(pid: 1, version: "x", writtenAt: 1000, startedAt: 1000)
+    #expect(state.isStale(now: 1030) == false) // 30s
+    #expect(state.isStale(now: 1100) == true)  // 100s > 90s
+    #expect(state.uptimeSeconds(now: 1100) == 100)
+}
+
+@Test func daemonStateReadHandlesGarbageAndMissing() {
+    let missing = tmpStateURL()
+    #expect(DaemonStateFile.read(from: missing) == nil)
+
+    let garbage = tmpStateURL()
+    defer { try? FileManager.default.removeItem(at: garbage) }
+    try? "{not json".data(using: .utf8)!.write(to: garbage)
+    #expect(DaemonStateFile.read(from: garbage) == nil)
+}
+
+@Test func daemonStateRejectsWrongSchema() {
+    let url = tmpStateURL()
+    defer { try? FileManager.default.removeItem(at: url) }
+    var state = DaemonState(pid: 1, version: "x", writtenAt: 1, startedAt: 1)
+    state.schema = 999
+    DaemonStateFile.write(state, to: url)
+    #expect(DaemonStateFile.read(from: url) == nil, "future schema must be rejected, not mis-decoded")
+}
+
+@Test func daemonProcessAliveForSelfAndDeadPid() {
+    #expect(daemonProcessAlive(pid: getpid()) == true)
+    #expect(daemonProcessAlive(pid: 0) == false)
+    #expect(daemonProcessAlive(pid: 999_999) == false) // almost certainly dead
+}


### PR DESCRIPTION
## Summary

Providers running a Mac node couldn't tell **why** they were untrusted, not earning, or failing requests — the coordinator's reasons lived only in logs. This makes `darkbloom doctor` and `status` explain, in plain language, **what's wrong, why, and how to fix it** for each failure mode the fleet diagnosis surfaced.

Designed via a multi-agent map of the provider diagnostic surface; ships smallest-shippable-first.

## Highest-value change: surface the coordinator's trust reason
The coordinator already sends a `trust_status` reason ("SE attestation verified, awaiting MDM/ACME upgrade", "binary hash mismatch", …) but the provider dropped it after logging. The daemon now persists its state — including the last `trust_status` — to `~/.darkbloom/daemon-state.json` (atomic write, on every trust update + each capacity tick). The CLI reads it with **zero IPC**, consistent with the existing PID-file-only architecture. Rejected a local HTTP/IPC endpoint (new attack surface in the attested process) and log-scraping (fragile).

## What the operator now sees

```
darkbloom doctor 0.5.15
Daemon: running

ATTESTATION KEY (Secure Enclave)
  [FAIL] se key sign test — key exists but cannot sign (OSStatus -25308: keychain locked) …
         ↳ fix: log in at the console once, then `darkbloom start`.
COORDINATOR TRUST   (why you are / aren't earning)
  [WARN] trust level — self_signed / online — verified by SE, but NOT hardware-trusted; ONLINE but receives NO traffic …
         ↳ fix: run `darkbloom enroll`, then wait ~5 min.
TRAFFIC READINESS   (can this box actually serve?)
  [FAIL] model fits in RAM — qwen-70b needs ~38.0 GB but only 21.0 GB usable — every request will fail to load.
         ↳ fix: set `enabled_models` to a model that fits: qwen3.5-7b (~10.2 GB) …
RUNTIME / BILLING / VERSION …
```

`status` replaces its `"not available yet"` stub with live daemon state: trust level + mapped reason + fix, current model, requests served, last model-load error.

## New modules (pure → fully unit-tested)
`ProviderCore/Diagnostics/`:
- **TrustReasonCatalog** — all 21 coordinator reason strings (copied verbatim from `provider.go`) → message + fix; unknown reasons echo **verbatim** (forward-compatible).
- **OSStatusCatalog** — SE OSStatus (`-25308` locked, `-34018` entitlement, …) → cause + fix.
- **ModelFitDiagnostic** — RAM-fit verdict + suggests fitting local models.
- **VersionDiagnostic** — pure semver; below-minimum (fail) vs behind-latest (warn).
- **DaemonState / DaemonStateFile** (`Service/`) — atomic writer + reader, staleness + dead-PID checks.

CLI (`darkbloom/Diagnostics/`): `SEKeySelfTest` (real load+sign under a **throwaway label** — never touches the production key), `DoctorRunner`, `DiagnosticReportRenderer`.

## Wiring
`ProviderLoop` caches the last `trust_status` + last model-load error and writes the state file (trust handler + startup + capacity loop). `AtomicProviderStats` gains a `usageGaps` counter (billing under-count signal, surfaced as a billing check).

## Composes with PR #268
Defines its own `SEKeySelfTest` (independent of #268's `loadOrCreateVerified`) and leaves a single `connectivity` field as the explicit NWPathMonitor merge point — no collision.

## Testing
22 unit tests: trust/OSStatus/model-fit/version catalogs, state-file round-trip + staleness + schema/garbage handling, renderer ordering + verdict. `swift build` + filtered `swift test` green. (MLX-runtime tests need a metallib, skipped locally — same limitation noted in CLAUDE.md.)

## Follow-ups (phased, noted in design)
- Connectivity reconnect/reachability into the state file (lands with #268's NWPathMonitor).
- ACME device-cert presence probe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/271"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783115076&installation_id=133247490&pr_number=271&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F271&signature=d78cd2d8459a59dadbafabedcb9423350c728f1ec134b5546efe913028584f76"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->