### PR TITLE
feat: honor reasoning_effort and return accurate reasoning_tokens

### DIFF
--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -2463,10 +2463,7 @@ func writeResponsesStreamOutput(w http.ResponseWriter, flusher http.Flusher, pr 
 		outputIndex++
 	}
 
-	reasoningTokens := uint64(0)
-	if msg.Reasoning != "" {
-		reasoningTokens = uint64(usage.CompletionTokens)
-	}
+	reasoningTokens := resolveReasoningTokens(usage, msg.Reasoning)
 	writeResponsesSSE(w, flusher, map[string]any{
 		"type": "response.completed",
 		"response": map[string]any{
@@ -2522,13 +2519,15 @@ func (s *Server) handleNonStreamingResponseWithFirstChunk(w http.ResponseWriter,
 						// Complete responses have object=chat.completion or
 						// object=response. Delta chunks have object=chat.completion.chunk.
 						if objType == "chat.completion" || objType == "response" {
+							var completeUsage protocol.UsageInfo
 							select {
-							case _, ok := <-pr.CompleteCh:
+							case u, ok := <-pr.CompleteCh:
 								if !ok {
 									s.refundReservedBalance(pr, "provider_incomplete:"+pr.RequestID)
 									writeJSON(w, http.StatusBadGateway, errorResponse("provider_error", "provider ended without completion"))
 									return
 								}
+								completeUsage = u
 							case <-ctx.Done():
 								s.refundReservedBalance(pr, "provider_timeout:"+pr.RequestID)
 								writeJSON(w, http.StatusGatewayTimeout, errorResponse("timeout", "timed out waiting for usage info"))
@@ -2536,6 +2535,11 @@ func (s *Server) handleNonStreamingResponseWithFirstChunk(w http.ResponseWriter,
 							}
 							if objType == "chat.completion" {
 								normalizeCompleteChatResponse(obj, pr.Model)
+								// Keep the passthrough path consistent with the
+								// SSE-reconstruction path: surface the provider's
+								// accurate reasoning-token count if its raw usage
+								// object didn't already carry one.
+								injectReasoningDetailIntoRawUsage(obj, completeUsage)
 								if pr.IsResponsesAPI {
 									var chatResp types.ChatCompletionResponse
 									b, err := json.Marshal(obj)
@@ -2918,6 +2922,50 @@ func extractMessage(chunks []string) extractedMessage {
 	return msg
 }
 
+// resolveReasoningTokens returns the reasoning-token count to report.
+// It prefers the provider's tokenizer-accurate count
+// (UsageInfo.ReasoningTokens) and falls back to the coarse "all
+// completion tokens" estimate only for older providers that emit
+// reasoning content without a count — so a reasoning response never
+// reports zero reasoning tokens, while up-to-date providers report the
+// real split.
+// injectReasoningDetailIntoRawUsage splices
+// completion_tokens_details.reasoning_tokens into a passthrough
+// chat.completion object when the provider reported an accurate
+// reasoning-token count (UsageInfo.ReasoningTokens) and the raw usage
+// object didn't already carry the detail. It never overrides a value the
+// provider already supplied, and is a no-op when there is no reasoning
+// count or no usage object.
+func injectReasoningDetailIntoRawUsage(obj map[string]any, usage protocol.UsageInfo) {
+	if usage.ReasoningTokens <= 0 {
+		return
+	}
+	usageObj, ok := obj["usage"].(map[string]any)
+	if !ok {
+		return
+	}
+	details, _ := usageObj["completion_tokens_details"].(map[string]any)
+	if details == nil {
+		details = map[string]any{}
+	}
+	if _, exists := details["reasoning_tokens"]; exists {
+		return
+	}
+	details["reasoning_tokens"] = usage.ReasoningTokens
+	usageObj["completion_tokens_details"] = details
+	obj["usage"] = usageObj
+}
+
+func resolveReasoningTokens(usage protocol.UsageInfo, reasoning string) uint64 {
+	if usage.ReasoningTokens > 0 {
+		return uint64(usage.ReasoningTokens)
+	}
+	if reasoning != "" {
+		return uint64(usage.CompletionTokens)
+	}
+	return 0
+}
+
 func buildResponsesUsage(promptTokens, completionTokens uint64, reasoningTokens uint64) types.ResponsesUsage {
 	return types.ResponsesUsage{
 		InputTokens:        int(promptTokens),
@@ -2989,10 +3037,7 @@ func appendResponsesOutputItems(output []any, requestID string, msg extractedMes
 }
 
 func buildResponsesResponse(requestID, model string, msg extractedMessage, usage protocol.UsageInfo, seSignature, responseHash string) types.ResponsesResponse {
-	reasoningTokens := uint64(0)
-	if msg.Reasoning != "" {
-		reasoningTokens = uint64(usage.CompletionTokens)
-	}
+	reasoningTokens := resolveReasoningTokens(usage, msg.Reasoning)
 	resp := types.ResponsesResponse{
 		ID:        "resp_" + strings.ReplaceAll(requestID, "-", ""),
 		Object:    "response",
@@ -3017,7 +3062,9 @@ func firstChoice(resp types.ChatCompletionResponse) *types.ChatCompletionChoice 
 
 func chatUsageToResponsesUsage(resp types.ChatCompletionResponse, reasoning string) types.ResponsesUsage {
 	reasoningTokens := 0
-	if reasoning != "" {
+	if d := resp.Usage.CompletionTokensDetails; d != nil && d.ReasoningTokens > 0 {
+		reasoningTokens = d.ReasoningTokens
+	} else if reasoning != "" {
 		reasoningTokens = resp.Usage.CompletionTokens
 	}
 	return buildResponsesUsage(uint64(resp.Usage.PromptTokens), uint64(resp.Usage.CompletionTokens), uint64(reasoningTokens))
@@ -3090,6 +3137,15 @@ func buildNonStreamingResponse(requestID, model string, msg extractedMessage, us
 			CompletionTokens: usage.CompletionTokens,
 			TotalTokens:      usage.PromptTokens + usage.CompletionTokens,
 		},
+	}
+
+	// Surface the OpenAI-standard reasoning-token breakdown when present
+	// so non-streaming chat-completions consumers can read it (the
+	// streaming path carries it on the provider's verbatim usage chunk).
+	if rt := resolveReasoningTokens(usage, msg.Reasoning); rt > 0 {
+		resp.Usage.CompletionTokensDetails = &types.CompletionTokensDetails{
+			ReasoningTokens: int(rt),
+		}
 	}
 
 	if seSignature != "" {

--- a/coordinator/api/consumer_test.go
+++ b/coordinator/api/consumer_test.go
@@ -1446,3 +1446,141 @@ func TestEstimatePromptTokens(t *testing.T) {
 		})
 	}
 }
+
+// TestResolveReasoningTokens covers the precedence between the provider's
+// tokenizer-accurate count and the legacy completion-tokens fallback.
+func TestResolveReasoningTokens(t *testing.T) {
+	cases := []struct {
+		name      string
+		usage     protocol.UsageInfo
+		reasoning string
+		want      uint64
+	}{
+		{
+			name:      "accurate count preferred",
+			usage:     protocol.UsageInfo{CompletionTokens: 100, ReasoningTokens: 42},
+			reasoning: "thinking...",
+			want:      42,
+		},
+		{
+			name:      "fallback to completion tokens for legacy provider",
+			usage:     protocol.UsageInfo{CompletionTokens: 100, ReasoningTokens: 0},
+			reasoning: "thinking...",
+			want:      100,
+		},
+		{
+			name:      "no reasoning content yields zero",
+			usage:     protocol.UsageInfo{CompletionTokens: 100, ReasoningTokens: 0},
+			reasoning: "",
+			want:      0,
+		},
+		{
+			name:      "accurate count wins even without reasoning text",
+			usage:     protocol.UsageInfo{CompletionTokens: 100, ReasoningTokens: 7},
+			reasoning: "",
+			want:      7,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := resolveReasoningTokens(tc.usage, tc.reasoning); got != tc.want {
+				t.Errorf("resolveReasoningTokens = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestBuildNonStreamingResponseReasoningDetails verifies the chat
+// completion usage object carries completion_tokens_details.reasoning_tokens
+// only when there is a reasoning count to report.
+func TestBuildNonStreamingResponseReasoningDetails(t *testing.T) {
+	msg := extractedMessage{Content: "4", Reasoning: "2+2"}
+	usage := protocol.UsageInfo{PromptTokens: 10, CompletionTokens: 20, ReasoningTokens: 8}
+
+	resp := buildNonStreamingResponse("req-1", "gpt-oss-20b", msg, usage, "", "")
+	if resp.Usage.CompletionTokensDetails == nil {
+		t.Fatalf("expected completion_tokens_details, got nil")
+	}
+	if resp.Usage.CompletionTokensDetails.ReasoningTokens != 8 {
+		t.Errorf("reasoning_tokens = %d, want 8", resp.Usage.CompletionTokensDetails.ReasoningTokens)
+	}
+
+	// Wire format must include the nested detail.
+	b, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(b), `"completion_tokens_details":{"reasoning_tokens":8}`) {
+		t.Errorf("wire missing reasoning detail: %s", b)
+	}
+
+	// No reasoning content => no details object (omitempty).
+	plain := buildNonStreamingResponse("req-2", "gpt-oss-20b",
+		extractedMessage{Content: "hi"},
+		protocol.UsageInfo{PromptTokens: 3, CompletionTokens: 1}, "", "")
+	if plain.Usage.CompletionTokensDetails != nil {
+		t.Errorf("expected no details for non-reasoning response, got %#v", plain.Usage.CompletionTokensDetails)
+	}
+	pb, _ := json.Marshal(plain)
+	if strings.Contains(string(pb), "completion_tokens_details") {
+		t.Errorf("non-reasoning wire should omit details: %s", pb)
+	}
+}
+
+// TestBuildResponsesResponseReasoningTokens verifies the Responses API
+// uses the accurate count when the provider supplies it.
+func TestBuildResponsesResponseReasoningTokens(t *testing.T) {
+	msg := extractedMessage{Content: "4", Reasoning: "2+2"}
+	usage := protocol.UsageInfo{PromptTokens: 10, CompletionTokens: 20, ReasoningTokens: 8}
+
+	resp := buildResponsesResponse("req-1", "gpt-oss-20b", msg, usage, "", "")
+	if resp.Usage.OutputTokensDetail.ReasoningTokens != 8 {
+		t.Errorf("reasoning_tokens = %d, want 8 (accurate count, not %d completion)",
+			resp.Usage.OutputTokensDetail.ReasoningTokens, usage.CompletionTokens)
+	}
+}
+
+// TestInjectReasoningDetailIntoRawUsage covers the passthrough path: a
+// provider-reported accurate reasoning count is spliced into the raw
+// chat.completion usage object, without overriding an existing value.
+func TestInjectReasoningDetailIntoRawUsage(t *testing.T) {
+	// Adds detail when absent.
+	obj := map[string]any{
+		"object": "chat.completion",
+		"usage": map[string]any{
+			"prompt_tokens":     float64(10),
+			"completion_tokens": float64(30),
+		},
+	}
+	injectReasoningDetailIntoRawUsage(obj, protocol.UsageInfo{CompletionTokens: 30, ReasoningTokens: 12})
+	details := obj["usage"].(map[string]any)["completion_tokens_details"].(map[string]any)
+	if details["reasoning_tokens"] != 12 {
+		t.Errorf("reasoning_tokens = %v, want 12", details["reasoning_tokens"])
+	}
+
+	// No-op when the provider reported no reasoning count.
+	plain := map[string]any{"usage": map[string]any{"completion_tokens": float64(5)}}
+	injectReasoningDetailIntoRawUsage(plain, protocol.UsageInfo{CompletionTokens: 5, ReasoningTokens: 0})
+	if _, ok := plain["usage"].(map[string]any)["completion_tokens_details"]; ok {
+		t.Errorf("expected no details injected for zero reasoning count")
+	}
+
+	// Never overrides an existing detail.
+	existing := map[string]any{
+		"usage": map[string]any{
+			"completion_tokens_details": map[string]any{"reasoning_tokens": float64(99)},
+		},
+	}
+	injectReasoningDetailIntoRawUsage(existing, protocol.UsageInfo{ReasoningTokens: 5})
+	got := existing["usage"].(map[string]any)["completion_tokens_details"].(map[string]any)["reasoning_tokens"]
+	if got != float64(99) {
+		t.Errorf("reasoning_tokens = %v, want 99 (must not override)", got)
+	}
+
+	// No-op when there is no usage object at all.
+	noUsage := map[string]any{"object": "chat.completion"}
+	injectReasoningDetailIntoRawUsage(noUsage, protocol.UsageInfo{ReasoningTokens: 7})
+	if _, ok := noUsage["usage"]; ok {
+		t.Errorf("did not expect a usage object to be created")
+	}
+}

--- a/coordinator/api/types/types.go
+++ b/coordinator/api/types/types.go
@@ -32,9 +32,17 @@ type ChatCompletionChoice struct {
 
 // ChatCompletionUsage is token usage in a chat completion response.
 type ChatCompletionUsage struct {
-	PromptTokens     int `json:"prompt_tokens"`
-	CompletionTokens int `json:"completion_tokens"`
-	TotalTokens      int `json:"total_tokens"`
+	PromptTokens            int                      `json:"prompt_tokens"`
+	CompletionTokens        int                      `json:"completion_tokens"`
+	TotalTokens             int                      `json:"total_tokens"`
+	CompletionTokensDetails *CompletionTokensDetails `json:"completion_tokens_details,omitempty"`
+}
+
+// CompletionTokensDetails is the OpenAI-compatible breakdown of
+// completion tokens. Only emitted when there is something to report
+// (e.g. a non-zero reasoning-token count).
+type CompletionTokensDetails struct {
+	ReasoningTokens int `json:"reasoning_tokens"`
 }
 
 // ChatCompletionResponse is an OpenAI-compatible chat completion response.

--- a/coordinator/protocol/messages.go
+++ b/coordinator/protocol/messages.go
@@ -202,6 +202,13 @@ type InferenceResponseChunkMessage struct {
 type UsageInfo struct {
 	PromptTokens     int `json:"prompt_tokens"`
 	CompletionTokens int `json:"completion_tokens"`
+	// ReasoningTokens is the subset of CompletionTokens spent on
+	// reasoning/analysis content (gpt-oss analysis channel, <think>
+	// blocks, etc.), counted with the model tokenizer on the provider.
+	// 0 when the response carried no reasoning content. Mirrors
+	// `reasoningTokens` in the Swift UsageInfo. omitempty keeps the wire
+	// shape unchanged for non-reasoning responses and older providers.
+	ReasoningTokens int `json:"reasoning_tokens,omitempty"`
 }
 
 // InferenceCompleteMessage signals the provider finished generating.

--- a/provider-swift/Sources/ProviderCore/Inference/MultiModelBatchSchedulerEngine.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/MultiModelBatchSchedulerEngine.swift
@@ -71,18 +71,30 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
     private let releaseModel: @Sendable (String) async -> Void
     private let defaultMaxTokens: Int
 
+    /// OpenAI `reasoning_effort` for this request (`low`/`medium`/`high`
+    /// for gpt-oss; model-specific otherwise). Injected verbatim into the
+    /// chat template's render context under the `reasoning_effort` key so
+    /// templates that read it (gpt-oss / Harmony) emit the matching
+    /// `Reasoning: <effort>` system directive. `nil` leaves the template
+    /// at its built-in default. We do not validate the value here — the
+    /// allowed set is model-specific and lives in each model's Jinja
+    /// template, so passing through is the format-agnostic choice.
+    private let reasoningEffort: String?
+
     public init(
         registryProvider: @escaping @Sendable () async -> Registry,
         ensureLoaded: @escaping @Sendable (String) async throws -> Void = { _ in },
         reserveModel: @escaping @Sendable (String) async -> Void = { _ in },
         releaseModel: @escaping @Sendable (String) async -> Void = { _ in },
-        defaultMaxTokens: Int = 4096
+        defaultMaxTokens: Int = 4096,
+        reasoningEffort: String? = nil
     ) {
         self.registryProvider = registryProvider
         self.ensureLoaded = ensureLoaded
         self.reserveModel = reserveModel
         self.releaseModel = releaseModel
         self.defaultMaxTokens = defaultMaxTokens
+        self.reasoningEffort = reasoningEffort
         self.acquire = nil
         self.tokenizerProvider = nil
         self.availableModelsOverride = nil
@@ -114,6 +126,7 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
         self.reserveModel = { _ in }
         self.releaseModel = { _ in }
         self.defaultMaxTokens = defaultMaxTokens
+        self.reasoningEffort = nil
     }
 
     // MARK: - MLXServerEngine
@@ -163,10 +176,19 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
         // lossy `translate()` → `ChatMessage` path that drops tool fields.
         let messages = request.messages.map { $0.templateMessageDict() }
         let toolSpecs = request.tools?.map { $0.toolSpec() }
+        // Surface `reasoning_effort` to the Jinja render context. Templates
+        // that don't reference the key (most models) ignore the extra
+        // variable; gpt-oss / Harmony reads it to emit `Reasoning: <effort>`.
+        let additionalContext: [String: any Sendable]?
+        if let reasoningEffort {
+            additionalContext = ["reasoning_effort": reasoningEffort]
+        } else {
+            additionalContext = nil
+        }
         let promptTokens: [Int]
         do {
             promptTokens = try tokenizer.inner.applyChatTemplate(
-                messages: messages, tools: toolSpecs, additionalContext: nil
+                messages: messages, tools: toolSpecs, additionalContext: additionalContext
             )
         } catch {
             await releaseBox.fire()

--- a/provider-swift/Sources/ProviderCore/Protocol/Types.swift
+++ b/provider-swift/Sources/ProviderCore/Protocol/Types.swift
@@ -143,15 +143,32 @@ public struct ProviderStats: Codable, Sendable, Equatable {
 public struct UsageInfo: Codable, Sendable, Equatable {
     public var promptTokens: UInt64
     public var completionTokens: UInt64
+    /// Subset of `completionTokens` spent on reasoning/analysis content
+    /// (gpt-oss analysis channel, <think> blocks, etc.). Counted with the
+    /// model tokenizer on the provider; 0 when the response carried no
+    /// reasoning content. The coordinator surfaces this as
+    /// `reasoning_tokens` in the Responses API and as
+    /// `completion_tokens_details.reasoning_tokens` in chat completions.
+    public var reasoningTokens: UInt64
 
     enum CodingKeys: String, CodingKey {
         case promptTokens = "prompt_tokens"
         case completionTokens = "completion_tokens"
+        case reasoningTokens = "reasoning_tokens"
     }
 
-    public init(promptTokens: UInt64, completionTokens: UInt64) {
+    public init(promptTokens: UInt64, completionTokens: UInt64, reasoningTokens: UInt64 = 0) {
         self.promptTokens = promptTokens
         self.completionTokens = completionTokens
+        self.reasoningTokens = reasoningTokens
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        self.promptTokens = try c.decode(UInt64.self, forKey: .promptTokens)
+        self.completionTokens = try c.decode(UInt64.self, forKey: .completionTokens)
+        // Optional for backward compatibility with peers that don't send it.
+        self.reasoningTokens = try c.decodeIfPresent(UInt64.self, forKey: .reasoningTokens) ?? 0
     }
 }
 

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+InboundDecode.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+InboundDecode.swift
@@ -55,4 +55,21 @@ extension ProviderLoop {
             return try decoder.decode(OpenAIChatCompletionRequest.self, from: normalized)
         }
     }
+
+    /// Pull the OpenAI `reasoning_effort` field out of a raw request body.
+    ///
+    /// This lives outside `OpenAIChatCompletionRequest` (the upstream type
+    /// doesn't model it), so we decode it directly. Returns a trimmed,
+    /// non-empty string or `nil`. The value is passed through verbatim —
+    /// the valid set (`low`/`medium`/`high` for gpt-oss; other models
+    /// differ) is enforced by each model's chat template, not here, so we
+    /// stay format-agnostic rather than hardcoding a per-model allowlist.
+    internal static func extractReasoningEffort(from data: Data) -> String? {
+        struct Probe: Decodable { let reasoning_effort: String? }
+        guard let probe = try? JSONDecoder().decode(Probe.self, from: data),
+              let raw = probe.reasoning_effort
+        else { return nil }
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
 }

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+SSEParser.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+SSEParser.swift
@@ -143,6 +143,50 @@ extension ProviderLoop {
         )
     }
 
+    /// Inject `usage.completion_tokens_details.reasoning_tokens` into a
+    /// final SSE chunk that already carries a `usage` block.
+    ///
+    /// Upstream's `OpenAIUsage` only models `prompt_tokens` /
+    /// `completion_tokens`, so we can't add the detail by re-encoding a
+    /// typed value. Instead we edit the JSON payload generically: decode
+    /// the `data:` line to a dictionary, splice the OpenAI-standard
+    /// `completion_tokens_details` object onto the existing `usage`, and
+    /// re-serialize. This preserves every other field (id, model, choices,
+    /// finish_reason, the existing token counts) untouched.
+    ///
+    /// The consumer-facing chat-completions usage object is the wire
+    /// surface OpenAI clients read for reasoning-token accounting; the
+    /// coordinator forwards this chunk verbatim, so editing it here is the
+    /// single source of truth for the streaming path. On any parse/encode
+    /// failure we return the original frame unchanged — a missing detail is
+    /// strictly better than a corrupted usage chunk (which would break
+    /// billing extraction downstream).
+    internal static func injectReasoningTokens(
+        into frame: String, reasoningTokens: Int
+    ) -> String {
+        guard reasoningTokens > 0,
+              let payload = joinedDataPayload(frame),
+              let bytes = payload.data(using: .utf8),
+              var obj = (try? JSONSerialization.jsonObject(with: bytes)) as? [String: Any],
+              var usage = obj["usage"] as? [String: Any]
+        else {
+            return frame
+        }
+        // Merge into any existing details object rather than clobbering it.
+        var details = usage["completion_tokens_details"] as? [String: Any] ?? [:]
+        details["reasoning_tokens"] = reasoningTokens
+        usage["completion_tokens_details"] = details
+        obj["usage"] = usage
+        guard let out = try? JSONSerialization.data(
+                withJSONObject: obj, options: [.sortedKeys, .withoutEscapingSlashes]
+              ),
+              let json = String(data: out, encoding: .utf8)
+        else {
+            return frame
+        }
+        return "data: \(json)\n\n"
+    }
+
     /// TB-007 P2 #2: deterministic serialization of a `tool_calls`
     /// delta for inclusion in the response-hash accumulator.
     ///

--- a/provider-swift/Sources/ProviderCore/ProviderLoop.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop.swift
@@ -614,6 +614,14 @@ public actor ProviderLoop {
             return
         }
 
+        // `reasoning_effort` is not part of the upstream
+        // `OpenAIChatCompletionRequest` shape, so decode it directly from
+        // the request body and thread it into the chat template's render
+        // context below (see `MultiModelBatchSchedulerEngine`). gpt-oss /
+        // Harmony reads it to set the reasoning budget; other models
+        // ignore the extra template variable.
+        let reasoningEffort = Self.extractReasoningEffort(from: decryptedData)
+
         // 3. Fast pre-accept admission check. The coordinator accepts fast and
         // then waits for the first chunk with the full inference timeout, so we
         // must REJECT (status 503) any request we are *certain* we cannot serve
@@ -753,7 +761,8 @@ public actor ProviderLoop {
                 ensureLoaded: { _ in },
                 reserveModel: { _ in },
                 releaseModel: { _ in },
-                defaultMaxTokens: Self.schedulerDefaultMaxTokens
+                defaultMaxTokens: Self.schedulerDefaultMaxTokens,
+                reasoningEffort: reasoningEffort
             )
 
             // Force-stream so we get SSE frames even if the original request
@@ -815,6 +824,12 @@ public actor ProviderLoop {
             // fully refund). MLX streams ~1 token per frame, so this slightly
             // under-counts vs. true tokenization but never bills $0 for work.
             var contentFrameCount = 0
+            // Accumulated `reasoning_content` deltas (gpt-oss analysis
+            // channel, Qwen3/DeepSeek <think>, Gemma4 channels). Re-tokenized
+            // at completion to report an accurate `reasoning_tokens` count —
+            // upstream's usage block only carries the total completion count.
+            var reasoningText = ""
+            var reasoningTokens = 0
 
             do {
                 for try await frame in frames {
@@ -848,6 +863,7 @@ public actor ProviderLoop {
                     //   real assistant output on `delta.tool_calls`; a
                     //   hash that ignored them would commit to (near-)
                     //   empty bytes instead of the actual output.
+                    var frameToEmit = frame
                     if let parsed = Self.parseStreamChunk(frame) {
                         var frameHadContent = false
                         if let content = parsed.contentDelta {
@@ -864,6 +880,7 @@ public actor ProviderLoop {
                         if let reasoning = parsed.reasoningDelta, !reasoning.isEmpty {
                             fullResponseText += reasoning
                             frameHadContent = true
+                            reasoningText += reasoning
                         }
                         if let toolCalls = parsed.toolCallsDelta, !toolCalls.isEmpty {
                             fullResponseText += Self.encodeToolCallsForHash(toolCalls)
@@ -875,9 +892,32 @@ public actor ProviderLoop {
                         if let usage = parsed.usage {
                             promptTokens = usage.promptTokens
                             completionTokens = usage.completionTokens
+                            // The usage block rides the final chunk, after all
+                            // reasoning deltas, so `reasoningText` is complete
+                            // here. Re-tokenize it for an accurate count and
+                            // surface it to chat-completions consumers via
+                            // `usage.completion_tokens_details.reasoning_tokens`
+                            // (OpenAI shape). The coordinator forwards this
+                            // chunk verbatim, so no coordinator change is
+                            // needed for the streaming path.
+                            if !reasoningText.isEmpty {
+                                // Re-tokenizing detokenized text isn't a perfect
+                                // identity (whitespace/special-token merges), so
+                                // clamp to the engine's completion count — a
+                                // reasoning subset can never exceed the total.
+                                reasoningTokens = min(
+                                    tokenizer.inner.encode(
+                                        text: reasoningText, addSpecialTokens: false
+                                    ).count,
+                                    max(0, completionTokens)
+                                )
+                                frameToEmit = Self.injectReasoningTokens(
+                                    into: frame, reasoningTokens: reasoningTokens
+                                )
+                            }
                         }
                     }
-                    if !emitSSE(frame) { return }
+                    if !emitSSE(frameToEmit) { return }
                 }
             } catch {
                 // P1 #2: CancellationError raised by `try await
@@ -961,7 +1001,8 @@ public actor ProviderLoop {
             )
             let usageInfo = UsageInfo(
                 promptTokens: UInt64(max(0, promptTokens)),
-                completionTokens: UInt64(max(0, completionTokens))
+                completionTokens: UInt64(max(0, completionTokens)),
+                reasoningTokens: UInt64(max(0, reasoningTokens))
             )
             send.send(.inferenceComplete(
                 requestId: requestId,

--- a/provider-swift/Tests/ProviderCoreTests/InboundDecodeTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/InboundDecodeTests.swift
@@ -195,4 +195,33 @@ struct InboundDecodeTests {
             _ = try decode("[]")
         }
     }
+
+    // MARK: - reasoning_effort extraction
+
+    private func effort(_ json: String) -> String? {
+        ProviderLoop.extractReasoningEffort(from: Data(json.utf8))
+    }
+
+    @Test("reasoning_effort is extracted verbatim")
+    func reasoningEffortExtracted() {
+        #expect(effort(#"{"model":"m","messages":[],"reasoning_effort":"high"}"#) == "high")
+        #expect(effort(#"{"model":"m","messages":[],"reasoning_effort":"low"}"#) == "low")
+    }
+
+    @Test("reasoning_effort absent or blank yields nil")
+    func reasoningEffortAbsentOrBlank() {
+        #expect(effort(#"{"model":"m","messages":[]}"#) == nil)
+        #expect(effort(#"{"model":"m","messages":[],"reasoning_effort":""}"#) == nil)
+        #expect(effort(#"{"model":"m","messages":[],"reasoning_effort":"  "}"#) == nil)
+    }
+
+    @Test("reasoning_effort is trimmed")
+    func reasoningEffortTrimmed() {
+        #expect(effort(#"{"model":"m","messages":[],"reasoning_effort":"  medium  "}"#) == "medium")
+    }
+
+    @Test("non-string reasoning_effort is ignored")
+    func reasoningEffortNonString() {
+        #expect(effort(#"{"model":"m","messages":[],"reasoning_effort":3}"#) == nil)
+    }
 }

--- a/provider-swift/Tests/ProviderCoreTests/ProtocolTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/ProtocolTests.swift
@@ -386,6 +386,28 @@ private func samplePrivacyCapabilities() -> PrivacyCapabilities {
     )
 }
 
+@Test func usageInfoEncodesReasoningTokensAndDecodesLegacyPayload() throws {
+    // Encoding includes the snake_case reasoning_tokens key.
+    let usage = UsageInfo(promptTokens: 10, completionTokens: 30, reasoningTokens: 12)
+    let encoded = try JSONEncoder().encode(usage)
+    let obj = try jsonObject(encoded)
+    #expect((obj["prompt_tokens"] as? Int) == 10)
+    #expect((obj["completion_tokens"] as? Int) == 30)
+    #expect((obj["reasoning_tokens"] as? Int) == 12)
+
+    // Round-trips.
+    let decoded = try JSONDecoder().decode(UsageInfo.self, from: encoded)
+    #expect(decoded == usage)
+
+    // Backward-compat: a legacy payload without reasoning_tokens decodes
+    // with the field defaulting to 0.
+    let legacy = #"{"prompt_tokens":5,"completion_tokens":7}"#
+    let legacyDecoded = try JSONDecoder().decode(UsageInfo.self, from: Data(legacy.utf8))
+    #expect(legacyDecoded.promptTokens == 5)
+    #expect(legacyDecoded.completionTokens == 7)
+    #expect(legacyDecoded.reasoningTokens == 0)
+}
+
 private func jsonObject(_ data: Data) throws -> [String: Any] {
     guard let object = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
         throw TestFailure.notJSONObject

--- a/provider-swift/Tests/ProviderCoreTests/ProviderLoopStreamChunkTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/ProviderLoopStreamChunkTests.swift
@@ -284,3 +284,61 @@ func encodeToolCallsForHashProducesStableEncoding() {
 func encodeToolCallsForHashEmptyInputReturnsEmptyString() {
     #expect(ProviderLoop.encodeToolCallsForHash([]) == "")
 }
+
+// MARK: - injectReasoningTokens
+
+@Test("injectReasoningTokens adds completion_tokens_details to a usage frame")
+func injectReasoningTokensAddsDetails() throws {
+    let frame = try encodeChunk(
+        finishReason: "stop",
+        usage: OpenAIUsage(promptTokens: 10, completionTokens: 30)
+    )
+    let rewritten = ProviderLoop.injectReasoningTokens(into: frame, reasoningTokens: 12)
+
+    // The rewritten frame must still parse and preserve the original counts.
+    let parsed = try #require(ProviderLoop.parseStreamChunk(rewritten))
+    let usage = try #require(parsed.usage)
+    #expect(usage.promptTokens == 10)
+    #expect(usage.completionTokens == 30)
+
+    // And carry the OpenAI-standard reasoning detail on the wire.
+    let payload = try #require(ProviderLoop.joinedDataPayload(rewritten))
+    let obj = try #require(
+        try JSONSerialization.jsonObject(with: Data(payload.utf8)) as? [String: Any]
+    )
+    let usageObj = try #require(obj["usage"] as? [String: Any])
+    let details = try #require(usageObj["completion_tokens_details"] as? [String: Any])
+    #expect((details["reasoning_tokens"] as? Int) == 12)
+}
+
+@Test("injectReasoningTokens is a no-op for zero reasoning tokens")
+func injectReasoningTokensZeroIsNoop() throws {
+    let frame = try encodeChunk(
+        finishReason: "stop",
+        usage: OpenAIUsage(promptTokens: 5, completionTokens: 5)
+    )
+    #expect(ProviderLoop.injectReasoningTokens(into: frame, reasoningTokens: 0) == frame)
+}
+
+@Test("injectReasoningTokens leaves frames without a usage block untouched")
+func injectReasoningTokensNoUsageIsNoop() throws {
+    let frame = try encodeChunk(content: "hello")
+    #expect(ProviderLoop.injectReasoningTokens(into: frame, reasoningTokens: 9) == frame)
+}
+
+@Test("injectReasoningTokens preserves a pre-existing details object")
+func injectReasoningTokensMergesExistingDetails() throws {
+    // Hand-craft a usage frame that already carries an unrelated detail
+    // field; the reasoning_tokens splice must not drop it.
+    let raw = #"data: {"id":"x","model":"m","choices":[],"usage":{"prompt_tokens":1,"completion_tokens":2,"completion_tokens_details":{"audio_tokens":3}}}"# + "\n\n"
+    let rewritten = ProviderLoop.injectReasoningTokens(into: raw, reasoningTokens: 4)
+    let payload = try #require(ProviderLoop.joinedDataPayload(rewritten))
+    let obj = try #require(
+        try JSONSerialization.jsonObject(with: Data(payload.utf8)) as? [String: Any]
+    )
+    let details = try #require(
+        (obj["usage"] as? [String: Any])?["completion_tokens_details"] as? [String: Any]
+    )
+    #expect((details["reasoning_tokens"] as? Int) == 4)
+    #expect((details["audio_tokens"] as? Int) == 3)
+}

--- a/provider-swift/Tests/ProviderCoreTests/ReasoningEffortLiveTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/ReasoningEffortLiveTests.swift
@@ -1,0 +1,174 @@
+// Live end-to-end coverage for the reasoning_effort + reasoning_tokens
+// work, exercised against a REAL gpt-oss model through the same serving
+// path ProviderLoop uses (MLXOpenAIService over
+// MultiModelBatchSchedulerEngine).
+//
+// Gated by DARKBLOOM_LIVE_MLX_TESTS=1 and requires
+// `mlx-community/gpt-oss-20b-MXFP4-Q8` in the local HuggingFace cache.
+// Tests skip cleanly (recorded as a warning) when either precondition is
+// unmet, so CI on a model-less runner stays green.
+
+import Foundation
+import Testing
+import MLX
+import MLXLLM
+import MLXLMCommon
+import MLXLMServer
+@testable import ProviderCore
+
+private let gptOssModelID = "mlx-community/gpt-oss-20b-MXFP4-Q8"
+
+// `.serialized`: both tests load the same multi-GB model and race on the
+// one-time metallib colocation; running them sequentially avoids that and
+// keeps peak memory to a single model.
+@Suite("reasoning_effort + reasoning_tokens (live gpt-oss)", .serialized)
+struct ReasoningEffortLiveTests {
+
+    /// Fix #1, decisive: the REAL gpt-oss harmony template reads the
+    /// `reasoning_effort` value we inject via `additionalContext` and
+    /// renders the matching `Reasoning: <effort>` system directive. This
+    /// is the exact API path `MultiModelBatchSchedulerEngine` uses.
+    @Test(
+        "harmony template renders the injected reasoning_effort",
+        .enabled(if: LiveInferenceFixtures.liveTestsEnabled)
+    )
+    func templateHonorsReasoningEffort() async throws {
+        let loaded: (scheduler: BatchScheduler, container: ModelContainer, modelDirectory: URL)
+        do {
+            loaded = try await LiveInferenceFixtures.loadScheduler(
+                modelID: gptOssModelID,
+                maxConcurrentRequests: 1,
+                memoryBudgetBytes: 24 * 1024 * 1024 * 1024
+            )
+        } catch let skip as LiveFixtureSkip {
+            withKnownIssue("skipped: \(skip)") { Issue.record("\(skip)") }
+            return
+        }
+        let scheduler = loaded.scheduler
+        defer { Task { await scheduler.unloadModel() } }
+        let tokenizer: TokenizerHandle = await loaded.container.perform { ctx in
+            TokenizerHandle(ctx.tokenizer)
+        }
+
+        let messages: [[String: any Sendable]] = [
+            ["role": "user", "content": "What is 2+2?"]
+        ]
+
+        func renderedPrompt(effort: String?) throws -> String {
+            let ctx: [String: any Sendable]? = effort.map { ["reasoning_effort": $0] }
+            let tokens = try tokenizer.inner.applyChatTemplate(
+                messages: messages, tools: nil, additionalContext: ctx
+            )
+            return tokenizer.inner.decode(tokenIds: tokens, skipSpecialTokens: false)
+        }
+
+        let high = try renderedPrompt(effort: "high")
+        let low = try renderedPrompt(effort: "low")
+        let defaulted = try renderedPrompt(effort: nil)
+
+        #expect(high.contains("Reasoning: high"))
+        #expect(low.contains("Reasoning: low"))
+        // No reasoning_effort supplied → template's built-in default.
+        #expect(defaulted.contains("Reasoning: medium"))
+        // And the value actually changes the prompt.
+        #expect(high != low)
+    }
+
+    /// Fix #1 + #2, integration: a real generation through the provider
+    /// serving path with reasoningEffort set produces analysis-channel
+    /// reasoning content, and our token accounting yields a non-zero,
+    /// clamped reasoning_tokens that injects cleanly into the usage frame.
+    @Test(
+        "live generation reports accurate reasoning_tokens",
+        .enabled(if: LiveInferenceFixtures.liveTestsEnabled)
+    )
+    func generationReportsReasoningTokens() async throws {
+        let loaded: (scheduler: BatchScheduler, container: ModelContainer, modelDirectory: URL)
+        do {
+            loaded = try await LiveInferenceFixtures.loadScheduler(
+                modelID: gptOssModelID,
+                maxConcurrentRequests: 1,
+                memoryBudgetBytes: 24 * 1024 * 1024 * 1024
+            )
+        } catch let skip as LiveFixtureSkip {
+            withKnownIssue("skipped: \(skip)") { Issue.record("\(skip)") }
+            return
+        }
+        let scheduler = loaded.scheduler
+        defer { Task { await scheduler.unloadModel() } }
+        let tokenizer: TokenizerHandle = await loaded.container.perform { ctx in
+            TokenizerHandle(ctx.tokenizer)
+        }
+
+        // Wire the engine exactly as ProviderLoop does, with the
+        // reasoning_effort threaded through.
+        let engine = MultiModelBatchSchedulerEngine(
+            registryProvider: { @Sendable in
+                [gptOssModelID: .init(scheduler: scheduler, tokenizer: tokenizer, modelType: "gpt_oss")]
+            },
+            ensureLoaded: { _ in },
+            reserveModel: { _ in },
+            releaseModel: { _ in },
+            defaultMaxTokens: 256,
+            reasoningEffort: "high"
+        )
+        let service = MLXOpenAIService(engine: engine)
+
+        let request = OpenAIChatCompletionRequest(
+            model: gptOssModelID,
+            messages: [
+                .init(role: .user, content: .text("If a train travels 60 miles in 1.5 hours, what is its average speed? Think briefly."))
+            ],
+            reasoningParser: .harmony,
+            stream: true,
+            temperature: 0.0,
+            maxTokens: 200,
+            streamOptions: .init(includeUsage: true, continuousUsageStats: nil)
+        )
+
+        let stream = try await service.streamChatCompletionFrames(request: request)
+
+        // Re-run the exact accounting ProviderLoop performs over the frames.
+        var reasoningText = ""
+        var contentText = ""
+        var completionTokens = 0
+        var usageFrame: String?
+        for try await frame in stream {
+            if frame == ServerSentEventEncoder.done { continue }
+            guard let parsed = ProviderLoop.parseStreamChunk(frame) else { continue }
+            if let r = parsed.reasoningDelta { reasoningText += r }
+            if let c = parsed.contentDelta { contentText += c }
+            if let usage = parsed.usage {
+                completionTokens = usage.completionTokens
+                usageFrame = frame
+            }
+        }
+
+        // The model actually reasoned (analysis channel was parsed out).
+        #expect(!reasoningText.isEmpty)
+        #expect(completionTokens > 0)
+
+        let reasoningTokens = min(
+            tokenizer.inner.encode(text: reasoningText, addSpecialTokens: false).count,
+            max(0, completionTokens)
+        )
+        #expect(reasoningTokens > 0)
+        #expect(reasoningTokens <= completionTokens)
+
+        // The usage frame rewrite carries the detail through to the wire.
+        let rewritten = ProviderLoop.injectReasoningTokens(
+            into: try #require(usageFrame), reasoningTokens: reasoningTokens
+        )
+        let payload = try #require(ProviderLoop.joinedDataPayload(rewritten))
+        let obj = try #require(
+            try JSONSerialization.jsonObject(with: Data(payload.utf8)) as? [String: Any]
+        )
+        let details = try #require(
+            (obj["usage"] as? [String: Any])?["completion_tokens_details"] as? [String: Any]
+        )
+        #expect((details["reasoning_tokens"] as? Int) == reasoningTokens)
+
+        // Surface the real numbers in the test log for the manual record.
+        print("[live] reasoning_tokens=\(reasoningTokens) completion_tokens=\(completionTokens) reasoning_chars=\(reasoningText.count) content=\(contentText.prefix(80))")
+    }
+}


### PR DESCRIPTION
## Summary

Closes two customer-reported gaps on gpt-oss / reasoning models.

### 1. `reasoning_effort` is now honored (gpt-oss low/medium/high)
Previously the param was silently dropped — the provider decoded into the upstream `OpenAIChatCompletionRequest` shape (which doesn't model `reasoning_effort`) and always passed `additionalContext: nil` to the chat template, so the gpt-oss harmony template stayed at its `medium` default. That's why a customer saw no difference between low/high.

The provider now decodes `reasoning_effort` from the raw body (`extractReasoningEffort`) and threads it through `MultiModelBatchSchedulerEngine` into `applyChatTemplate(additionalContext:)`. The swift-transformers renderer injects each `additionalContext` key directly into the Jinja context, so the harmony template reads `reasoning_effort` and emits the matching `Reasoning: <effort>` system directive. Values pass through verbatim — the valid set is model-specific and lives in each template, so there's no hardcoded allowlist. (`minimal`/`xhigh` are GPT-5-family values, not gpt-oss, so they remain no-ops on gpt-oss by design.)

### 2. Accurate `reasoning_tokens`
Chat completions returned no reasoning breakdown; the Responses API reported **all** completion tokens as reasoning (a 2–4× overcount). The provider now tokenizes the actual reasoning content with the model tokenizer (clamped to ≤ `completion_tokens`) and surfaces it as:
- `usage.completion_tokens_details.reasoning_tokens` — chat completions (streaming, non-streaming reconstruction, and raw passthrough)
- `output_tokens_details.reasoning_tokens` — Responses API

The count rides the structured `UsageInfo` and is injected into the streaming usage SSE frame (which the coordinator forwards verbatim).

## Protocol / compatibility
`UsageInfo` gains `reasoning_tokens` in **both** `coordinator/protocol/messages.go` (Go, `omitempty`) and `provider-swift/.../Protocol/Types.swift` (Swift, `decodeIfPresent`). Old↔new provider/coordinator mixes are safe; `resolveReasoningTokens` falls back to the prior estimate for providers that predate accurate counting.

## Not changed (out of scope, deliberately)
- Billing still consumes only `prompt_tokens` + `completion_tokens`.
- Response-hash / attestation domain is unaffected (only the usage frame is rewritten, which carries no content/reasoning deltas).

## Testing
- **Go** (`api` + `protocol` suites pass): `resolveReasoningTokens` precedence, passthrough `injectReasoningDetailIntoRawUsage`, non-streaming + Responses usage shapes.
- **Swift** (63 tests across touched suites pass): `extractReasoningEffort` (verbatim/trim/blank/non-string), `injectReasoningTokens` (add/zero-noop/no-usage-noop/merge-existing), `UsageInfo` codable + legacy decode.
- Reviewed by two independent reviewers; the flagged passthrough-consistency gap is fixed and covered.

⚠️ **Not yet run live end-to-end** against a real gpt-oss MLX model through the full provider→coordinator→consumer path — see PR discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/272"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783117937&installation_id=133247490&pr_number=272&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F272&signature=7b3eac8bc06e4d45d1590e1c196befbe1f959d428293f5a9e6d29132052a1190"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->