### PR TITLE
feat: self-route ("use my own machine, free") + direct/local mode

### DIFF
--- a/console-ui/__tests__/local-first.test.ts
+++ b/console-ui/__tests__/local-first.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  buildLocalRequest,
+  buildCoordinatorRequest,
+  chatCompletionWithFallback,
+  type FallbackConfig,
+} from "@/lib/localFirst";
+
+const COORD: Pick<FallbackConfig, "coordinatorURL" | "coordinatorApiKey"> = {
+  coordinatorURL: "/api/chat",
+  coordinatorApiKey: "dk-coord",
+};
+
+describe("buildLocalRequest", () => {
+  it("targets <base>/chat/completions with the local bearer token", () => {
+    const { url, init } = buildLocalRequest({ baseURL: "http://127.0.0.1:8000/v1", apiKey: "dk-local-x" }, { a: 1 });
+    expect(url).toBe("http://127.0.0.1:8000/v1/chat/completions");
+    expect((init.headers as Record<string, string>)["Authorization"]).toBe("Bearer dk-local-x");
+    expect(init.body).toBe(JSON.stringify({ a: 1 }));
+  });
+
+  it("omits Authorization when the local server runs with --no-auth", () => {
+    const { init } = buildLocalRequest({ baseURL: "http://127.0.0.1:8000/v1" }, {});
+    expect((init.headers as Record<string, string>)["Authorization"]).toBeUndefined();
+  });
+});
+
+describe("buildCoordinatorRequest", () => {
+  it("sets the X-Darkbloom-Route: self opt-in and both auth header forms", () => {
+    const { url, init } = buildCoordinatorRequest(COORD, { m: "x" });
+    expect(url).toBe("/api/chat");
+    const h = init.headers as Record<string, string>;
+    expect(h["X-Darkbloom-Route"]).toBe("self");
+    // Authorization for a raw coordinator; x-api-key for the /api/chat proxy.
+    expect(h["Authorization"]).toBe("Bearer dk-coord");
+    expect(h["x-api-key"]).toBe("dk-coord");
+  });
+});
+
+describe("chatCompletionWithFallback", () => {
+  const okResponse = () => new Response("ok", { status: 200 });
+
+  it("uses the local endpoint when it is reachable", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(okResponse());
+    const cfg: FallbackConfig = { local: { baseURL: "http://127.0.0.1:8000/v1", apiKey: "dk-local" }, ...COORD };
+    const { via } = await chatCompletionWithFallback({ x: 1 }, cfg, fetchImpl as unknown as typeof fetch);
+    expect(via).toBe("local");
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(fetchImpl.mock.calls[0][0]).toBe("http://127.0.0.1:8000/v1/chat/completions");
+  });
+
+  it("falls back to the coordinator self-route on a local connection failure", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockRejectedValueOnce(new TypeError("fetch failed")) // local unreachable
+      .mockResolvedValueOnce(okResponse()); // coordinator ok
+    const cfg: FallbackConfig = { local: { baseURL: "http://127.0.0.1:8000/v1", apiKey: "dk-local" }, ...COORD };
+    const { via } = await chatCompletionWithFallback({ x: 1 }, cfg, fetchImpl as unknown as typeof fetch);
+    expect(via).toBe("coordinator");
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    const coordInit = fetchImpl.mock.calls[1][1];
+    expect(coordInit.headers["X-Darkbloom-Route"]).toBe("self");
+  });
+
+  it("goes straight to the coordinator when no local endpoint is configured", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(okResponse());
+    const cfg: FallbackConfig = { local: null, ...COORD };
+    const { via } = await chatCompletionWithFallback({ x: 1 }, cfg, fetchImpl as unknown as typeof fetch);
+    expect(via).toBe("coordinator");
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT reroute when the local server is reachable but returns an error", async () => {
+    // A reachable local server that 500s surfaces its own error — no silent reroute.
+    const fetchImpl = vi.fn().mockResolvedValue(new Response("boom", { status: 500 }));
+    const cfg: FallbackConfig = { local: { baseURL: "http://127.0.0.1:8000/v1" }, ...COORD };
+    const { via, response } = await chatCompletionWithFallback({ x: 1 }, cfg, fetchImpl as unknown as typeof fetch);
+    expect(via).toBe("local");
+    expect(response.status).toBe(500);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+});

--- a/console-ui/__tests__/self-route.test.tsx
+++ b/console-ui/__tests__/self-route.test.tsx
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { NextRequest } from "next/server";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { KeyForm } from "@/components/api-keys/KeyForm";
+import { useStore } from "@/lib/store";
+import type { UpdateKeyBody } from "@/lib/api";
+
+// ===========================================================================
+// Chat proxy: X-Darkbloom-Route forwarding (the "My Machine" wire signal).
+// ===========================================================================
+
+describe("POST /api/chat self-route header forwarding", () => {
+  let upstreamFetch: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    upstreamFetch = vi.fn();
+    vi.stubGlobal("fetch", upstreamFetch);
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  function streamResponse(): Response {
+    return new Response("data: {}\n\n", {
+      status: 200,
+      headers: { "Content-Type": "text/event-stream" },
+    });
+  }
+
+  function chatRequest(headers: Record<string, string>): NextRequest {
+    return new NextRequest(new URL("/api/chat", "http://localhost:3000"), {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ model: "m", messages: [] }),
+    });
+  }
+
+  it("forwards X-Darkbloom-Route: self upstream when the client sets it", async () => {
+    upstreamFetch.mockResolvedValueOnce(streamResponse());
+    const { POST } = await import("@/app/api/chat/route");
+    await POST(
+      chatRequest({
+        "x-api-key": "k1",
+        "content-type": "application/json",
+        "x-darkbloom-route": "self",
+      })
+    );
+    const opts = upstreamFetch.mock.calls[0][1];
+    expect(opts.headers["X-Darkbloom-Route"]).toBe("self");
+    expect(opts.headers.Authorization).toBe("Bearer k1");
+  });
+
+  it("omits the header when the client does not request self-route", async () => {
+    upstreamFetch.mockResolvedValueOnce(streamResponse());
+    const { POST } = await import("@/app/api/chat/route");
+    await POST(
+      chatRequest({ "x-api-key": "k1", "content-type": "application/json" })
+    );
+    const opts = upstreamFetch.mock.calls[0][1];
+    expect(opts.headers["X-Darkbloom-Route"]).toBeUndefined();
+  });
+});
+
+// ===========================================================================
+// Store: useMyMachine toggle (persisted preference).
+// ===========================================================================
+
+describe("store useMyMachine", () => {
+  it("defaults to false and toggles", () => {
+    expect(useStore.getState().useMyMachine).toBe(false);
+    useStore.getState().setUseMyMachine(true);
+    expect(useStore.getState().useMyMachine).toBe(true);
+    useStore.getState().setUseMyMachine(false);
+    expect(useStore.getState().useMyMachine).toBe(false);
+  });
+});
+
+// ===========================================================================
+// KeyForm: self_route_only is included in the submit body and reflects initial.
+// ===========================================================================
+
+describe("KeyForm self_route_only", () => {
+  it("submits self_route_only=true after toggling the option on", () => {
+    let submitted: UpdateKeyBody | null = null;
+    render(
+      <KeyForm
+        models={[]}
+        mode="create"
+        submitting={false}
+        onCancel={() => {}}
+        onSubmit={(b) => {
+          submitted = b;
+        }}
+      />
+    );
+    // Name is required before submit is enabled.
+    fireEvent.change(screen.getByPlaceholderText("e.g. Production server"), {
+      target: { value: "my-machine-key" },
+    });
+    fireEvent.click(screen.getByText("My Machine only — free"));
+    fireEvent.click(screen.getByText("Create key"));
+
+    expect(submitted).not.toBeNull();
+    expect(submitted!.self_route_only).toBe(true);
+  });
+
+  it("defaults self_route_only=false when never toggled", () => {
+    let submitted: UpdateKeyBody | null = null;
+    render(
+      <KeyForm
+        models={[]}
+        mode="create"
+        submitting={false}
+        onCancel={() => {}}
+        onSubmit={(b) => {
+          submitted = b;
+        }}
+      />
+    );
+    fireEvent.change(screen.getByPlaceholderText("e.g. Production server"), {
+      target: { value: "normal-key" },
+    });
+    fireEvent.click(screen.getByText("Create key"));
+
+    expect(submitted!.self_route_only).toBe(false);
+  });
+
+  it("reflects an existing key's self_route_only=true as pre-selected", () => {
+    let submitted: UpdateKeyBody | null = null;
+    render(
+      <KeyForm
+        initial={{
+          id: "key_1",
+          name: "existing",
+          label: "sk-db-…",
+          disabled: false,
+          limit_reset: "none",
+          usage_usd: 0,
+          self_route_only: true,
+          created_at: new Date().toISOString(),
+        }}
+        models={[]}
+        mode="edit"
+        submitting={false}
+        onCancel={() => {}}
+        onSubmit={(b) => {
+          submitted = b;
+        }}
+      />
+    );
+    fireEvent.click(screen.getByText("Save changes"));
+    expect(submitted!.self_route_only).toBe(true);
+  });
+});

--- a/console-ui/src/app/api/chat/route.ts
+++ b/console-ui/src/app/api/chat/route.ts
@@ -13,6 +13,9 @@ export async function POST(req: NextRequest) {
   const apiKey = req.headers.get("x-api-key") || "";
   const incomingCt = req.headers.get("content-type") || "application/json";
   const isSealed = incomingCt.toLowerCase().startsWith(SEALED_CT);
+  // "Use my machine, for free" opt-in. Forwarded verbatim to the coordinator,
+  // which honors it server-side; it never enters the request body.
+  const selfRoute = req.headers.get("x-darkbloom-route") || "";
 
   // Forward the body bytes verbatim. For plaintext we keep the existing
   // JSON-roundtrip behavior (preserves the existing tests); for sealed we
@@ -30,6 +33,7 @@ export async function POST(req: NextRequest) {
     headers: {
       "Content-Type": isSealed ? SEALED_CT : "application/json",
       ...(apiKey ? { Authorization: `Bearer ${apiKey}` } : {}),
+      ...(selfRoute ? { "X-Darkbloom-Route": selfRoute } : {}),
     },
     body: isSealed ? bodyBytes : JSON.stringify(await req.json()),
   };

--- a/console-ui/src/app/page.tsx
+++ b/console-ui/src/app/page.tsx
@@ -50,6 +50,7 @@ export default function ChatPage() {
     updateChatTitle,
     selectedModel,
     setModels,
+    useMyMachine,
   } = useStore();
 
   const { ready, authenticated, apiKeyReady, login } = useAuth();
@@ -198,7 +199,8 @@ export default function ChatPage() {
               setIsStreaming(false);
             },
           },
-          abort.signal
+          abort.signal,
+          { selfRoute: useMyMachine }
         );
       } catch (err) {
         if ((err as Error).name !== "AbortError") {
@@ -227,6 +229,7 @@ export default function ChatPage() {
       updateChatTitle,
       selectedModel,
       addToast,
+      useMyMachine,
     ]
   );
 
@@ -306,7 +309,8 @@ export default function ChatPage() {
             setIsStreaming(false);
           },
         },
-        abort.signal
+        abort.signal,
+        { selfRoute: useMyMachine }
       ).catch((err) => {
         if ((err as Error).name !== "AbortError") {
           trackEvent("chat_error", {
@@ -321,7 +325,7 @@ export default function ChatPage() {
         setIsStreaming(false);
       });
     },
-    [activeChat, isStreaming, authenticated, apiKeyReady, selectedModel, updateMessage, appendToMessage, appendToThinking, addToast]
+    [activeChat, isStreaming, authenticated, apiKeyReady, selectedModel, updateMessage, appendToMessage, appendToThinking, addToast, useMyMachine]
   );
 
   return (

--- a/console-ui/src/components/ChatInput.tsx
+++ b/console-ui/src/components/ChatInput.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useRef, useCallback, useEffect } from "react";
-import { Send, Square, ChevronDown, LogIn } from "lucide-react";
+import { Send, Square, ChevronDown, LogIn, Cpu } from "lucide-react";
 import { useStore } from "@/lib/store";
 import { trackEvent } from "@/lib/google-analytics";
 
@@ -16,7 +16,7 @@ interface ChatInputProps {
 export function ChatInput({ onSend, onStop, isStreaming, authenticated = true, onLogin }: ChatInputProps) {
   const [input, setInput] = useState("");
   const textareaRef = useRef<HTMLTextAreaElement>(null);
-  const { selectedModel, models, setSelectedModel } = useStore();
+  const { selectedModel, models, setSelectedModel, useMyMachine, setUseMyMachine } = useStore();
   const [modelOpen, setModelOpen] = useState(false);
 
   const handleSend = useCallback(() => {
@@ -149,6 +149,31 @@ export function ChatInput({ onSend, onStop, isStreaming, authenticated = true, o
                   </div>
                 )}
               </div>
+
+              {/* My Machine (free self-route) toggle */}
+              <button
+                type="button"
+                onClick={() => {
+                  const next = !useMyMachine;
+                  setUseMyMachine(next);
+                  trackEvent("self_route_toggled", { enabled: next });
+                }}
+                title={
+                  useMyMachine
+                    ? "Routing only to your own machine — free, and never falls back to paid providers"
+                    : "Route this chat only to a Darkbloom node you run (free)"
+                }
+                aria-pressed={useMyMachine}
+                className={`flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-xs border-2 transition-all ${
+                  useMyMachine
+                    ? "text-teal bg-teal/10 border-teal/40 font-semibold"
+                    : "text-text-tertiary border-transparent hover:text-text-secondary hover:bg-bg-hover hover:border-border-subtle"
+                }`}
+              >
+                <Cpu size={12} />
+                <span className="hidden sm:inline">My Machine</span>
+                {useMyMachine && <span className="text-[10px] opacity-80">· Free</span>}
+              </button>
             </div>
 
             {/* Right: Send / Stop */}

--- a/console-ui/src/components/api-keys/KeyCard.tsx
+++ b/console-ui/src/components/api-keys/KeyCard.tsx
@@ -128,6 +128,14 @@ export function KeyCard({
                 Console key
               </span>
             )}
+            {keyData.self_route_only && (
+              <span
+                title="Routes only to a machine you run — free, never the public fleet"
+                className="text-[10px] font-mono uppercase tracking-wide text-teal bg-teal/10 border border-teal/30 rounded px-1.5 py-0.5"
+              >
+                My Machine · Free
+              </span>
+            )}
           </div>
           <p className="mt-1 text-xs font-mono text-text-tertiary truncate">{keyData.label}</p>
         </div>

--- a/console-ui/src/components/api-keys/KeyForm.tsx
+++ b/console-ui/src/components/api-keys/KeyForm.tsx
@@ -34,6 +34,7 @@ export function KeyForm({
   const [allowed, setAllowed] = useState<string[]>(initial?.allowed_models ?? []);
   const [modelQuery, setModelQuery] = useState("");
   const [modelText, setModelText] = useState((initial?.allowed_models ?? []).join(", "));
+  const [selfRouteOnly, setSelfRouteOnly] = useState(initial?.self_route_only ?? false);
 
   const hasModels = models.length > 0;
   const nameTrim = name.trim();
@@ -63,6 +64,7 @@ export function KeyForm({
       otpm_limit: intOrClear(otpm, clear),
       expires_at: expiryOrClear(expiresAt, clear),
       allowed_models: modelsOrClear(selectedModels, clear),
+      self_route_only: selfRouteOnly,
     };
     onSubmit(body);
   };
@@ -216,6 +218,30 @@ export function KeyForm({
             : "Leave empty to allow all models."}
         </p>
       </div>
+
+      <button
+        type="button"
+        onClick={() => setSelfRouteOnly((v) => !v)}
+        aria-pressed={selfRouteOnly}
+        className={`w-full flex items-start gap-3 p-3 rounded-lg border text-left transition-colors ${
+          selfRouteOnly ? "border-teal/50 bg-teal/5" : "border-border-dim hover:bg-bg-hover"
+        }`}
+      >
+        <span
+          className={`mt-0.5 flex items-center justify-center w-4 h-4 rounded border shrink-0 ${
+            selfRouteOnly ? "bg-teal border-teal text-white" : "border-border-subtle"
+          }`}
+        >
+          {selfRouteOnly && <Check size={11} />}
+        </span>
+        <span className="min-w-0">
+          <span className="block text-sm font-medium text-text-primary">My Machine only — free</span>
+          <span className="block text-xs text-text-tertiary mt-0.5">
+            Every request on this key routes only to a Darkbloom node you run, and is free. It never
+            spends balance or reaches the public fleet.
+          </span>
+        </span>
+      </button>
 
       <div className="flex gap-3 pt-1">
         <button

--- a/console-ui/src/lib/api.ts
+++ b/console-ui/src/lib/api.ts
@@ -372,6 +372,7 @@ export interface ApiKey {
   itpm_limit?: number;
   otpm_limit?: number;
   allowed_models?: string[]; // empty/omitted = all models
+  self_route_only?: boolean; // hard ceiling: only routes to the owner's machine, free
   expires_at?: string; // RFC3339 UTC
   created_at: string;
   last_used_at?: string;
@@ -387,6 +388,7 @@ export interface CreateKeyBody {
   itpm_limit?: number | null;
   otpm_limit?: number | null;
   allowed_models?: string[] | null;
+  self_route_only?: boolean;
   expires_at?: string | null; // RFC3339
 }
 
@@ -469,15 +471,21 @@ export async function streamChat(
   messages: ChatMessage[],
   model: string,
   callbacks: StreamCallbacks,
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  opts?: { selfRoute?: boolean }
 ): Promise<void> {
   // Optional sender→coordinator encryption. Defaults off so plaintext SDK
   // and curl flows keep working unchanged. When enabled we NaCl-Box-seal the
   // outgoing body to the coordinator's published X25519 pubkey, then decrypt
   // each SSE event on the way back.
   const requestBody = { model, messages, stream: true };
+  // "Use my machine, for free": opt-in routing to the caller's own provider.
+  // Carried as a header so it never enters the (optionally sealed) body.
+  const selfRouteHeader: Record<string, string> = opts?.selfRoute
+    ? { "X-Darkbloom-Route": "self" }
+    : {};
   let sealCtx: { ephemPriv: Uint8Array; coordPub: Uint8Array } | null = null;
-  let fetchHeaders = proxyHeaders();
+  let fetchHeaders = proxyHeaders(selfRouteHeader);
   let fetchBody: string;
 
   if (isEncryptionEnabled()) {
@@ -485,7 +493,7 @@ export async function streamChat(
       const coordKey = await getCoordinatorKey();
       const sealed = sealRequest(requestBody, coordKey);
       fetchBody = sealed.envelopeJson;
-      fetchHeaders = proxyHeaders({ "Content-Type": SEALED_CONTENT_TYPE });
+      fetchHeaders = proxyHeaders({ "Content-Type": SEALED_CONTENT_TYPE, ...selfRouteHeader });
       sealCtx = {
         ephemPriv: sealed.ephemeralPrivateKey,
         coordPub: coordKey.publicKey,
@@ -551,7 +559,19 @@ export async function streamChat(
     try {
       const errData = JSON.parse(text);
       const msg = errData?.error?.message || text;
-      if (res.status === 503 && msg.includes("queue timeout")) {
+      // Self-route ("My Machine") specific errors map to actionable copy. The
+      // coordinator never falls back to paid providers for these, so the
+      // messaging is explicit rather than a generic retry.
+      const code = errData?.error?.code as string | undefined;
+      if (code === "no_linked_machine") {
+        callbacks.onError("No machine linked to your account — run `darkbloom login` on your Mac, then try again.");
+      } else if (code === "machine_offline") {
+        callbacks.onError("Your machine is offline — start your Darkbloom node and try again. (My Machine never falls back to paid providers.)");
+      } else if (code === "model_not_loaded") {
+        callbacks.onError("This model isn't loaded on your machine — load it on your node, then try again.");
+      } else if (code === "machine_busy") {
+        callbacks.onError("Your machine is busy — try again in a moment.");
+      } else if (res.status === 503 && msg.includes("queue timeout")) {
         callbacks.onError("All providers are busy — please try again in a moment");
       } else if (res.status === 402) {
         callbacks.onError("Insufficient credits — buy credits in Billing to continue");

--- a/console-ui/src/lib/localFirst.ts
+++ b/console-ui/src/lib/localFirst.ts
@@ -1,0 +1,103 @@
+// Local-first chat with coordinator fallback.
+//
+// Direct mode (`darkbloom start --local`) exposes an OpenAI-compatible server on
+// the user's own Mac. When a client can reach it, talking to it directly is
+// lower-latency, works offline, and keeps bytes on the local network. When it
+// can't (the Mac is asleep, you're away, or local mode isn't running), this
+// helper falls back to the coordinator with `X-Darkbloom-Route: self` — the
+// relayed "use my machine, for free" path.
+//
+// Fallback fires ONLY on a connection-level failure (fetch rejects / network
+// unreachable). A reachable-but-erroring local server returns its own error
+// rather than silently rerouting — predictable, and both paths are free anyway.
+//
+// This module is fetch-based and dependency-free so it runs in the browser, in
+// Node, and in tests. Discovering the local endpoint from `~/.darkbloom/local.json`
+// is a Node-only `fs` read (see docs/direct-mode.md); callers pass the resolved
+// endpoint in (or null).
+
+export interface LocalEndpoint {
+  /** e.g. "http://127.0.0.1:8000/v1" (from `darkbloom local`). */
+  baseURL: string;
+  /** Local bearer token; omitted when the server runs with --no-auth. */
+  apiKey?: string;
+}
+
+export interface FallbackConfig {
+  /** Resolved local endpoint, or null when none is known/configured. */
+  local: LocalEndpoint | null;
+  /** Coordinator chat URL — the `/api/chat` proxy or a coordinator `/v1/chat/completions`. */
+  coordinatorURL: string;
+  /** Bearer token for the coordinator (your Darkbloom API key). */
+  coordinatorApiKey: string;
+}
+
+export type RouteVia = "local" | "coordinator";
+
+export interface FallbackResult {
+  response: Response;
+  via: RouteVia;
+}
+
+/** Build the request to the local server. */
+export function buildLocalRequest(
+  local: LocalEndpoint,
+  body: unknown
+): { url: string; init: RequestInit } {
+  const headers: Record<string, string> = { "Content-Type": "application/json" };
+  if (local.apiKey) headers["Authorization"] = `Bearer ${local.apiKey}`;
+  return {
+    url: `${local.baseURL.replace(/\/$/, "")}/chat/completions`,
+    init: { method: "POST", headers, body: JSON.stringify(body) },
+  };
+}
+
+/**
+ * Build the coordinator request with the self-route opt-in. Sends BOTH
+ * `Authorization: Bearer` (for a raw coordinator `/v1/chat/completions`) and
+ * `x-api-key` (for the Next.js `/api/chat` proxy, which reads x-api-key and
+ * re-emits Authorization upstream) so the same call works against either URL.
+ */
+export function buildCoordinatorRequest(
+  cfg: Pick<FallbackConfig, "coordinatorURL" | "coordinatorApiKey">,
+  body: unknown
+): { url: string; init: RequestInit } {
+  return {
+    url: cfg.coordinatorURL,
+    init: {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${cfg.coordinatorApiKey}`,
+        "x-api-key": cfg.coordinatorApiKey,
+        "X-Darkbloom-Route": "self",
+      },
+      body: JSON.stringify(body),
+    },
+  };
+}
+
+/**
+ * POST a chat-completion request, preferring the local endpoint and falling
+ * back to the coordinator self-route on a connection failure. Returns the
+ * Response (stream it as usual) plus which path served it.
+ */
+export async function chatCompletionWithFallback(
+  body: unknown,
+  cfg: FallbackConfig,
+  fetchImpl: typeof fetch = fetch
+): Promise<FallbackResult> {
+  if (cfg.local) {
+    const { url, init } = buildLocalRequest(cfg.local, body);
+    try {
+      const response = await fetchImpl(url, init);
+      // Reachable (even if it returns an HTTP error): use it, don't reroute.
+      return { response, via: "local" };
+    } catch {
+      // Connection-level failure → fall through to the coordinator.
+    }
+  }
+  const { url, init } = buildCoordinatorRequest(cfg, body);
+  const response = await fetchImpl(url, init);
+  return { response, via: "coordinator" };
+}

--- a/console-ui/src/lib/store.ts
+++ b/console-ui/src/lib/store.ts
@@ -30,6 +30,8 @@ interface AppState {
   selectedModel: string;
   models: Model[];
   sidebarOpen: boolean;
+  // "Use my machine, for free" — route chat to the user's own provider only.
+  useMyMachine: boolean;
 
   // Actions
   createChat: () => string;
@@ -42,6 +44,7 @@ interface AppState {
   setSelectedModel: (model: string) => void;
   setModels: (models: Model[]) => void;
   setSidebarOpen: (open: boolean) => void;
+  setUseMyMachine: (on: boolean) => void;
   updateChatTitle: (chatId: string, title: string) => void;
 }
 
@@ -57,6 +60,7 @@ export const useStore = create<AppState>()(
       selectedModel: "",
       models: [],
       sidebarOpen: typeof window !== "undefined" ? window.innerWidth >= 640 : true,
+      useMyMachine: false,
 
       createChat: () => {
         const id = generateId();
@@ -147,6 +151,7 @@ export const useStore = create<AppState>()(
         });
       },
       setSidebarOpen: (open) => set({ sidebarOpen: open }),
+      setUseMyMachine: (on) => set({ useMyMachine: on }),
       updateChatTitle: (chatId, title) =>
         set((s) => ({
           chats: s.chats.map((c) =>
@@ -165,6 +170,7 @@ export const useStore = create<AppState>()(
         activeChatId: state.activeChatId,
         selectedModel: state.selectedModel,
         sidebarOpen: state.sidebarOpen,
+        useMyMachine: state.useMyMachine,
       }),
     }
   )

--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -152,6 +152,8 @@ const errModelTooLarge = "model too large for any available provider"
 // dispatchOneProvider encrypts and sends an inference request to a single
 // provider. It returns the pending request and provider on success, or an
 // error string on failure. The excludeProviders set is updated on failure.
+// selfRoutePolicy and its resolvers live in self_route.go.
+
 func (s *Server) dispatchOneProvider(
 	r *http.Request,
 	model string,
@@ -163,6 +165,7 @@ func (s *Server) dispatchOneProvider(
 	requestedMaxTokens int,
 	allowedProviderSerials []string,
 	isResponsesAPI bool,
+	policy selfRoutePolicy,
 	timing *registry.RequestTiming,
 	excludeProviders map[string]struct{},
 ) (
@@ -187,6 +190,9 @@ func (s *Server) dispatchOneProvider(
 		ReservedMicroUSD:       reservedMicroUSD,
 		BaseReservedMicroUSD:   reservedMicroUSD,
 		AllowedProviderSerials: allowedProviderSerials,
+		SelfRouteOnly:          policy.enabled,
+		OwnerAccountID:         policy.ownerAccountID,
+		FreeSelfRoute:          policy.enabled,
 		AcceptedCh:             make(chan struct{}, 1),
 		ChunkCh:                make(chan string, chunkBufferSize),
 		CompleteCh:             make(chan protocol.UsageInfo, 1),
@@ -224,12 +230,14 @@ func (s *Server) dispatchOneProvider(
 		pr.Timing.RoutedAt = time.Now()
 	}
 
-	if s.billing != nil && !providerHasPayoutDestination(provider) {
+	if s.billing != nil && !policy.enabled && !providerHasPayoutDestination(provider) {
 		s.logger.Warn("provider missing payout destination, crediting to internal ledger",
 			"provider_id", provider.ID)
 	}
 
-	if s.billing != nil {
+	// Free self-route requests are settled at zero cost (handleComplete), so
+	// there is no reservation to top up for a provider's custom price.
+	if s.billing != nil && !policy.enabled {
 		_, err := s.reserveAdditionalForProvider(pr, provider)
 		if err != nil {
 			cleanupPending()
@@ -982,6 +990,13 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 		rawBody, _ = json.Marshal(parsed)
 	}
 
+	// "Use my own machine, for free" opt-in. The signal is the
+	// X-Darkbloom-Route header (OpenAI-client-safe: invisible to the body
+	// schema) OR a per-key hard ceiling. The header can only *request*
+	// self-routing; it cannot name a machine — ownership is matched on the
+	// coordinator-stamped provider AccountID, so nothing here is forgeable.
+	policy := s.resolveSelfRoutePolicy(r)
+
 	isResponsesAPI := input != nil && len(messages) == 0
 
 	// Inject model-specific defaults from the registry: reasoning_parser
@@ -1044,7 +1059,10 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 	// portion. The routing estimate (estimatedPromptTokens, len/4) is kept
 	// separate so scheduler capacity checks aren't over-inflated.
 	var reservedMicroUSD int64
-	if s.billing != nil {
+	// Self-route is free: skip the pre-flight balance reservation and the
+	// per-key spend cap entirely. A zero-balance owner must never be blocked
+	// from running on their own machine, and a self_route_only key never spends.
+	if s.billing != nil && !policy.enabled {
 		consumerKey := consumerKeyFromContext(r.Context())
 		reservedMicroUSD = s.reservationCost(model, billingPromptTokens, requestedMaxTokens)
 		// Per-key spend cap (phase 1) — checked before the reservation so a
@@ -1089,31 +1107,42 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Pre-flight capacity check: can ANY provider serve this model right now?
-	// If not, return 429 immediately rather than queueing for up to 120s.
-	// OpenRouter treats 429 as "rate limited" (no uptime penalty) vs 503
-	// which counts as downtime. Fast 429s also preserve our TTFT metrics.
-	candidateCount, capacityRejections, modelTooLarge := s.registry.QuickCapacityCheck(model, estimatedPromptTokens, requestedMaxTokens, allowedProviderSerials...)
-	if candidateCount == 0 && capacityRejections == 0 && modelTooLarge > 0 {
-		// Providers serve this model but none can ever fit it — non-retryable.
-		// Surface a clear 503 instead of a 429 the client would retry forever.
-		refundReservation()
-		s.ddIncr("routing.decisions", []string{"model:" + model, "model_type:" + s.registry.ModelType(model), "outcome:model_too_large"})
-		writeJSON(w, http.StatusServiceUnavailable, errorResponse("model_unavailable",
-			fmt.Sprintf("model %q is too large for any currently available provider", model),
-			withCode("model_unavailable")))
-		return
-	}
-	if candidateCount == 0 && capacityRejections > 0 {
-		// Providers exist for this model but ALL are at capacity.
-		retryAfter := s.estimateRetryAfter(model)
-		w.Header().Set("Retry-After", strconv.Itoa(retryAfter))
-		refundReservation()
-		s.ddIncr("routing.decisions", []string{"model:" + model, "model_type:" + s.registry.ModelType(model), "outcome:capacity_429"})
-		writeJSON(w, http.StatusTooManyRequests, errorResponse("rate_limit_exceeded",
-			fmt.Sprintf("all providers for model %q are at capacity — retry after %ds", model, retryAfter),
-			withCode("rate_limit_exceeded")))
-		return
+	// Self-route pre-flight: confirm the caller owns an online machine that can
+	// serve this model, with precise errors and no fallback to the paid fleet.
+	if policy.enabled {
+		if s.selfRouteUnavailable(w, r, policy.ownerAccountID, model) {
+			refundReservation()
+			return
+		}
+	} else {
+		// Pre-flight capacity check: can ANY provider serve this model right
+		// now? If not, return 429 immediately rather than queueing for up to
+		// 120s. OpenRouter treats 429 as "rate limited" (no uptime penalty) vs
+		// 503 which counts as downtime. Fast 429s also preserve our TTFT
+		// metrics. Self-route skips this fleet-wide gate — it queues on the
+		// owner's machine instead (handled below).
+		candidateCount, capacityRejections, modelTooLarge := s.registry.QuickCapacityCheck(model, estimatedPromptTokens, requestedMaxTokens, allowedProviderSerials...)
+		if candidateCount == 0 && capacityRejections == 0 && modelTooLarge > 0 {
+			// Providers serve this model but none can ever fit it — non-retryable.
+			// Surface a clear 503 instead of a 429 the client would retry forever.
+			refundReservation()
+			s.ddIncr("routing.decisions", []string{"model:" + model, "model_type:" + s.registry.ModelType(model), "outcome:model_too_large"})
+			writeJSON(w, http.StatusServiceUnavailable, errorResponse("model_unavailable",
+				fmt.Sprintf("model %q is too large for any currently available provider", model),
+				withCode("model_unavailable")))
+			return
+		}
+		if candidateCount == 0 && capacityRejections > 0 {
+			// Providers exist for this model but ALL are at capacity.
+			retryAfter := s.estimateRetryAfter(model)
+			w.Header().Set("Retry-After", strconv.Itoa(retryAfter))
+			refundReservation()
+			s.ddIncr("routing.decisions", []string{"model:" + model, "model_type:" + s.registry.ModelType(model), "outcome:capacity_429"})
+			writeJSON(w, http.StatusTooManyRequests, errorResponse("rate_limit_exceeded",
+				fmt.Sprintf("all providers for model %q are at capacity — retry after %ds", model, retryAfter),
+				withCode("rate_limit_exceeded")))
+			return
+		}
 	}
 
 	// Dispatch to a provider with speculative TTFT-aware dispatch. On the
@@ -1152,7 +1181,7 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 		provider, pr, _, dispatchErr, dispatchErrCode = s.dispatchOneProvider(
 			r, model, rawBody, consumerKey, consumerLocation, reservedMicroUSD,
 			estimatedPromptTokens, requestedMaxTokens, allowedProviderSerials,
-			isResponsesAPI, timing, excludeProviders,
+			isResponsesAPI, policy, timing, excludeProviders,
 		)
 		if provider == nil {
 			// No online provider has enough memory to ever fit this model.
@@ -1205,6 +1234,9 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 				ReservedMicroUSD:       reservedMicroUSD,
 				BaseReservedMicroUSD:   reservedMicroUSD,
 				AllowedProviderSerials: allowedProviderSerials,
+				SelfRouteOnly:          policy.enabled,
+				OwnerAccountID:         policy.ownerAccountID,
+				FreeSelfRoute:          policy.enabled,
 				AcceptedCh:             make(chan struct{}, 1),
 				ChunkCh:                make(chan string, chunkBufferSize),
 				CompleteCh:             make(chan protocol.UsageInfo, 1),
@@ -1223,9 +1255,14 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 				retryAfter := s.estimateRetryAfter(model)
 				w.Header().Set("Retry-After", strconv.Itoa(retryAfter))
 				refundReservation()
-				writeJSON(w, http.StatusTooManyRequests, errorResponse("rate_limit_exceeded",
-					fmt.Sprintf("all providers for model %q are at capacity and queue is full", model),
-					withCode("rate_limit_exceeded")))
+				if policy.enabled {
+					writeJSON(w, http.StatusTooManyRequests, errorResponse("machine_busy",
+						"your machine is at capacity — retry shortly", withCode("machine_busy")))
+				} else {
+					writeJSON(w, http.StatusTooManyRequests, errorResponse("rate_limit_exceeded",
+						fmt.Sprintf("all providers for model %q are at capacity and queue is full", model),
+						withCode("rate_limit_exceeded")))
+				}
 				return
 			}
 			s.ddIncr("routing.decisions", []string{"model:" + model, "model_type:" + s.registry.ModelType(model), "outcome:queued"})
@@ -1246,9 +1283,14 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 				s.ddIncr("request_queue.timeout", []string{"model:" + model, "model_type:" + s.registry.ModelType(model)})
 				retryAfter := s.estimateRetryAfter(model)
 				w.Header().Set("Retry-After", strconv.Itoa(retryAfter))
-				writeJSON(w, http.StatusTooManyRequests, errorResponse("rate_limit_exceeded",
-					fmt.Sprintf("all providers for model %q are at capacity (queue timeout)", model),
-					withCode("rate_limit_exceeded")))
+				if policy.enabled {
+					writeJSON(w, http.StatusTooManyRequests, errorResponse("machine_busy",
+						"your machine is at capacity (timed out waiting for a free slot) — retry shortly", withCode("machine_busy")))
+				} else {
+					writeJSON(w, http.StatusTooManyRequests, errorResponse("rate_limit_exceeded",
+						fmt.Sprintf("all providers for model %q are at capacity (queue timeout)", model),
+						withCode("rate_limit_exceeded")))
+				}
 				return
 			}
 			// Queue assigned a provider; still need to dispatch.
@@ -1260,7 +1302,7 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 			// Log missing payout destination but don't skip — earnings
 			// are credited to the provider's internal ledger and can be
 			// withdrawn once they complete Stripe Connect onboarding.
-			if s.billing != nil && !providerHasPayoutDestination(provider) {
+			if s.billing != nil && !policy.enabled && !providerHasPayoutDestination(provider) {
 				s.logger.Warn("queued provider missing payout destination, crediting to internal ledger",
 					"request_id", requestID,
 					"provider_id", provider.ID,
@@ -1268,8 +1310,9 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 			}
 
 			// Custom pricing check — provider may charge more than the
-			// platform rate. Reserve the additional amount now.
-			if s.billing != nil {
+			// platform rate. Reserve the additional amount now. Skipped for
+			// free self-route, which settles at zero cost.
+			if s.billing != nil && !policy.enabled {
 				if _, err := s.reserveAdditionalForProvider(pr, provider); err != nil {
 					provider.RemovePending(requestID)
 					s.registry.SetProviderIdle(provider.ID)
@@ -1457,7 +1500,7 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 			backupProvider, backupPR, _, _, _ := s.dispatchOneProvider(
 				r, model, rawBody, consumerKey, consumerLocation, reservedMicroUSD,
 				estimatedPromptTokens, requestedMaxTokens, allowedProviderSerials,
-				isResponsesAPI, &registry.RequestTiming{ReceivedAt: timing.ReceivedAt},
+				isResponsesAPI, policy, &registry.RequestTiming{ReceivedAt: timing.ReceivedAt},
 				backupExclude,
 			)
 
@@ -3315,6 +3358,7 @@ type createAPIKeyRequest struct {
 	ITPMLimit     *int64     `json:"itpm_limit"`
 	OTPMLimit     *int64     `json:"otpm_limit"`
 	AllowedModels []string   `json:"allowed_models"`
+	SelfRouteOnly bool       `json:"self_route_only"`
 	ExpiresAt     *time.Time `json:"expires_at"`
 }
 
@@ -3337,6 +3381,7 @@ func (s *Server) apiKeyToResponse(k *store.APIKey) types.APIKeyResponse {
 		ITPMLimit:     k.ITPMLimit,
 		OTPMLimit:     k.OTPMLimit,
 		AllowedModels: k.AllowedModels,
+		SelfRouteOnly: k.SelfRouteOnly,
 		ExpiresAt:     k.ExpiresAt,
 		CreatedAt:     k.CreatedAt,
 		LastUsedAt:    k.LastUsedAt,
@@ -3472,6 +3517,7 @@ func (s *Server) handleCreateAPIKey(w http.ResponseWriter, r *http.Request) {
 		ITPMLimit:     req.ITPMLimit,
 		OTPMLimit:     req.OTPMLimit,
 		AllowedModels: req.AllowedModels,
+		SelfRouteOnly: req.SelfRouteOnly,
 		ExpiresAt:     req.ExpiresAt,
 	}
 	if req.LimitUSD != nil {
@@ -3611,6 +3657,13 @@ func applyKeyPatch(k *store.APIKey, patch map[string]json.RawMessage) string {
 			}
 			k.AllowedModels = models
 		}
+	}
+	if raw, ok := patch["self_route_only"]; ok {
+		var v bool
+		if err := json.Unmarshal(raw, &v); err != nil {
+			return "invalid value for self_route_only"
+		}
+		k.SelfRouteOnly = v
 	}
 	for field, dst := range map[string]**int64{
 		"rpm_limit":  &k.RPMLimit,
@@ -3920,6 +3973,9 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 		stripProviderRoutingFields(parsed)
 	}
 
+	// "Use my own machine, for free" opt-in (see handleChatCompletions).
+	policy := s.resolveSelfRoutePolicy(r)
+
 	// Completions and Anthropic messages both use the max_tokens field (never
 	// max_output_tokens, which is Responses API only). Inject a default if
 	// unset so the pre-flight reservation bounds the generation.
@@ -3948,7 +4004,8 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 	consumerKey := consumerKeyFromContext(r.Context())
 	consumerLocation := s.requestLocation(r)
 	var reservedMicroUSD int64
-	if s.billing != nil {
+	// Self-route is free: skip the reservation and per-key spend cap.
+	if s.billing != nil && !policy.enabled {
 		reservedMicroUSD = s.reservationCost(model, billingPromptTokens, requestedMaxTokens)
 		// Per-key spend cap (phase 1) — checked before the reservation.
 		if msg, ok := s.checkKeySpendCap(r.Context(), reservedMicroUSD); !ok {
@@ -3979,25 +4036,33 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 		}
 	}
 
-	// Pre-flight capacity check (same logic as handleChatCompletions).
-	candidateCount, capacityRejections, modelTooLarge := s.registry.QuickCapacityCheck(model, estimatedPromptTokens, requestedMaxTokens, allowedProviderSerials...)
-	if candidateCount == 0 && capacityRejections == 0 && modelTooLarge > 0 {
-		refundReservation()
-		s.ddIncr("routing.decisions", []string{"model:" + model, "model_type:" + s.registry.ModelType(model), "outcome:model_too_large"})
-		writeJSON(w, http.StatusServiceUnavailable, errorResponse("model_unavailable",
-			fmt.Sprintf("model %q is too large for any currently available provider", model),
-			withCode("model_unavailable")))
-		return
-	}
-	if candidateCount == 0 && capacityRejections > 0 {
-		retryAfter := s.estimateRetryAfter(model)
-		w.Header().Set("Retry-After", strconv.Itoa(retryAfter))
-		refundReservation()
-		s.ddIncr("routing.decisions", []string{"model:" + model, "model_type:" + s.registry.ModelType(model), "outcome:capacity_429"})
-		writeJSON(w, http.StatusTooManyRequests, errorResponse("rate_limit_exceeded",
-			fmt.Sprintf("all providers for model %q are at capacity — retry after %ds", model, retryAfter),
-			withCode("rate_limit_exceeded")))
-		return
+	// Self-route pre-flight (precise errors, no paid fallback); otherwise the
+	// fleet-wide capacity 429 (same logic as handleChatCompletions).
+	if policy.enabled {
+		if s.selfRouteUnavailable(w, r, policy.ownerAccountID, model) {
+			refundReservation()
+			return
+		}
+	} else {
+		candidateCount, capacityRejections, modelTooLarge := s.registry.QuickCapacityCheck(model, estimatedPromptTokens, requestedMaxTokens, allowedProviderSerials...)
+		if candidateCount == 0 && capacityRejections == 0 && modelTooLarge > 0 {
+			refundReservation()
+			s.ddIncr("routing.decisions", []string{"model:" + model, "model_type:" + s.registry.ModelType(model), "outcome:model_too_large"})
+			writeJSON(w, http.StatusServiceUnavailable, errorResponse("model_unavailable",
+				fmt.Sprintf("model %q is too large for any currently available provider", model),
+				withCode("model_unavailable")))
+			return
+		}
+		if candidateCount == 0 && capacityRejections > 0 {
+			retryAfter := s.estimateRetryAfter(model)
+			w.Header().Set("Retry-After", strconv.Itoa(retryAfter))
+			refundReservation()
+			s.ddIncr("routing.decisions", []string{"model:" + model, "model_type:" + s.registry.ModelType(model), "outcome:capacity_429"})
+			writeJSON(w, http.StatusTooManyRequests, errorResponse("rate_limit_exceeded",
+				fmt.Sprintf("all providers for model %q are at capacity — retry after %ds", model, retryAfter),
+				withCode("rate_limit_exceeded")))
+			return
+		}
 	}
 
 	requestID := uuid.New().String()
@@ -4010,6 +4075,9 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 		KeyLimitReset:          keyLimitResetFromContext(r.Context()),
 		ConsumerLocation:       consumerLocation,
 		AllowedProviderSerials: allowedProviderSerials,
+		SelfRouteOnly:          policy.enabled,
+		OwnerAccountID:         policy.ownerAccountID,
+		FreeSelfRoute:          policy.enabled,
 		EstimatedPromptTokens:  estimatedPromptTokens,
 		RequestedMaxTokens:     requestedMaxTokens,
 		ReservedMicroUSD:       reservedMicroUSD,
@@ -4045,13 +4113,14 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 			break
 		}
 
-		if s.billing != nil && !providerHasPayoutDestination(provider) {
+		if s.billing != nil && !policy.enabled && !providerHasPayoutDestination(provider) {
 			s.logger.Warn("provider missing payout destination, crediting to internal ledger",
 				"provider_id", provider.ID)
 		}
 
-		// Custom pricing check — provider may charge more than the platform rate.
-		if s.billing != nil {
+		// Custom pricing check — provider may charge more than the platform
+		// rate. Skipped for free self-route, which settles at zero cost.
+		if s.billing != nil && !policy.enabled {
 			if _, err := s.reserveAdditionalForProvider(pr, provider); err != nil {
 				provider.RemovePending(requestID)
 				s.registry.SetProviderIdle(provider.ID)
@@ -4093,9 +4162,14 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 			w.Header().Set("Retry-After", strconv.Itoa(retryAfter))
 			refundReservation()
 			s.ddIncr("routing.decisions", []string{"model:" + model, "model_type:" + s.registry.ModelType(model), "outcome:over_capacity"})
-			writeJSON(w, http.StatusTooManyRequests, errorResponse("rate_limit_exceeded",
-				fmt.Sprintf("all providers for model %q are at capacity and queue is full", model),
-				withCode("rate_limit_exceeded")))
+			if policy.enabled {
+				writeJSON(w, http.StatusTooManyRequests, errorResponse("machine_busy",
+					"your machine is at capacity — retry shortly", withCode("machine_busy")))
+			} else {
+				writeJSON(w, http.StatusTooManyRequests, errorResponse("rate_limit_exceeded",
+					fmt.Sprintf("all providers for model %q are at capacity and queue is full", model),
+					withCode("rate_limit_exceeded")))
+			}
 			return
 		}
 		s.ddIncr("routing.decisions", []string{"model:" + model, "model_type:" + s.registry.ModelType(model), "outcome:queued"})
@@ -4108,9 +4182,14 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 			retryAfter := s.estimateRetryAfter(model)
 			w.Header().Set("Retry-After", strconv.Itoa(retryAfter))
 			refundReservation()
-			writeJSON(w, http.StatusTooManyRequests, errorResponse("rate_limit_exceeded",
-				fmt.Sprintf("all providers for model %q are at capacity (queue timeout)", model),
-				withCode("rate_limit_exceeded")))
+			if policy.enabled {
+				writeJSON(w, http.StatusTooManyRequests, errorResponse("machine_busy",
+					"your machine is at capacity (timed out waiting for a free slot) — retry shortly", withCode("machine_busy")))
+			} else {
+				writeJSON(w, http.StatusTooManyRequests, errorResponse("rate_limit_exceeded",
+					fmt.Sprintf("all providers for model %q are at capacity (queue timeout)", model),
+					withCode("rate_limit_exceeded")))
+			}
 			return
 		}
 		decision = queuedReq.Decision
@@ -4130,11 +4209,12 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 		}
 	}
 	defer cleanupPending()
-	if s.billing != nil && !providerHasPayoutDestination(provider) {
+	if s.billing != nil && !policy.enabled && !providerHasPayoutDestination(provider) {
 		s.logger.Warn("provider missing payout destination, crediting to internal ledger",
 			"provider_id", provider.ID)
 	}
-	if s.billing != nil {
+	// Free self-route settles at zero cost — no provider-price top-up.
+	if s.billing != nil && !policy.enabled {
 		if _, err := s.reserveAdditionalForProvider(pr, provider); err != nil {
 			cleanupPending()
 			refundExtra()

--- a/coordinator/api/provider.go
+++ b/coordinator/api/provider.go
@@ -1280,6 +1280,46 @@ func (s *Server) handleComplete(providerID string, provider *registry.Provider, 
 	}
 
 	providerPayout := payments.ProviderPayoutWithPercent(totalCost, feePercent)
+
+	// Free self-route settlement. A request marked FreeSelfRoute must be served
+	// by a provider the requesting account owns. Re-verify ownership here as
+	// defense-in-depth — the router already filtered to owned providers, so a
+	// mismatch should be impossible (e.g. the machine was unlinked mid-flight).
+	// Only on a confirmed match do we settle at zero cost; otherwise we fall
+	// back to normal paid settlement rather than grant free inference on a
+	// machine the caller does not own (closes the "mark free, serve elsewhere"
+	// hole).
+	freeSelfRoute := false
+	if pr.FreeSelfRoute {
+		// Read ownership from the provider that actually served this request —
+		// the handleComplete argument — rather than a fresh registry lookup.
+		// The provider may have deregistered between sending this completion and
+		// settlement running; GetProvider would then return nil and we'd wrongly
+		// bill the legitimate owner. The provider struct's AccountID is stable
+		// across deregistration, so the passed-in object is the authoritative,
+		// race-free source. (GetProvider is preferred only as a freshness
+		// refinement; it falls back to the argument when the entry is gone.)
+		serving := s.registry.GetProvider(providerID)
+		if serving == nil {
+			serving = provider
+		}
+		serving.Mu().Lock()
+		servingOwner := serving.AccountID
+		serving.Mu().Unlock()
+		if servingOwner != "" && servingOwner == pr.ConsumerKey {
+			freeSelfRoute = true
+			totalCost = 0
+			providerPayout = 0
+		} else {
+			s.logger.Error("self-route completion served by a non-owned provider — settling as paid (defense-in-depth)",
+				"provider_id", providerID,
+				"request_id", msg.RequestID,
+				"serving_owner", servingOwner,
+				"consumer_key", pr.ConsumerKey,
+			)
+		}
+	}
+
 	billingFinalized := true
 
 	// Settle billing against the pre-flight reservation. All balance
@@ -1355,7 +1395,7 @@ func (s *Server) handleComplete(providerID string, provider *registry.Provider, 
 			s.ddHistogram("billing.settlement_refund_micro_usd", float64(refund), []string{"model:" + pr.Model})
 			s.ddHistogram("store.credit.latency_ms", float64(time.Since(start).Milliseconds()), []string{"op:settlement_refund"})
 		}
-	} else {
+	} else if !freeSelfRoute {
 		start := time.Now()
 		if err := s.ledger.Charge(pr.ConsumerKey, totalCost, msg.RequestID); err != nil {
 			if errors.Is(err, store.ErrInsufficientBalance) {
@@ -1421,7 +1461,8 @@ func (s *Server) handleComplete(providerID string, provider *registry.Provider, 
 			publicKey := p.PublicKey
 			p.Mu().Unlock()
 
-			if accountID != "" {
+			// Free self-route earns no payout (consumer == provider account).
+			if accountID != "" && !freeSelfRoute {
 				settlementWg.Add(1)
 				go func() {
 					defer settlementWg.Done()

--- a/coordinator/api/self_route.go
+++ b/coordinator/api/self_route.go
@@ -1,0 +1,87 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// This file holds the consumer-side "use my own machine, for free" (self-route)
+// helpers: how the opt-in is resolved from the authenticated request, and how
+// pre-flight eligibility maps to precise, no-fallback error responses. The
+// routing/billing wiring that consumes these lives in consumer.go (dispatch)
+// and provider.go (settlement); the owner filter and trust relaxation live in
+// the registry scheduler.
+
+// selfRoutePolicy carries the authenticated "use my own machine, for free"
+// decision through dispatch so that primary, sequential-retry, and
+// speculative-backup PendingRequests all inherit the same owner filter and
+// free-billing flag. It is resolved entirely server-side (from the request's
+// authenticated identity plus the X-Darkbloom-Route header / per-key flag);
+// no field originates from the request body.
+type selfRoutePolicy struct {
+	// enabled restricts routing to providers owned by ownerAccountID and marks
+	// the request free. The zero value is a normal paid request to any provider.
+	enabled bool
+	// ownerAccountID is the account that must own the serving provider.
+	ownerAccountID string
+}
+
+// resolveSelfRoutePolicy derives the self-route decision from the request's
+// authenticated identity and opt-in signals. A per-key SelfRouteOnly flag is a
+// hard ceiling (every request on that key self-routes and is free); otherwise
+// the X-Darkbloom-Route: self header opts in a single request. The owner is the
+// authenticated consumer key, which is the same namespace as Provider.AccountID
+// (both derive from the account that linked the device). An unresolved identity
+// (empty consumer key) disables self-route so it can never match a machine.
+func (s *Server) resolveSelfRoutePolicy(r *http.Request) selfRoutePolicy {
+	headerWants := strings.EqualFold(strings.TrimSpace(r.Header.Get("X-Darkbloom-Route")), "self")
+	keyForces := false
+	if k := apiKeyFromContext(r.Context()); k != nil {
+		keyForces = k.SelfRouteOnly
+	}
+	if !headerWants && !keyForces {
+		return selfRoutePolicy{}
+	}
+	owner := consumerKeyFromContext(r.Context())
+	if owner == "" {
+		return selfRoutePolicy{}
+	}
+	return selfRoutePolicy{enabled: true, ownerAccountID: owner}
+}
+
+// selfRouteUnavailable reports whether a self-route request cannot proceed and,
+// when so, writes the precise terminal error. Self-route never falls back to
+// the paid fleet, so "can't serve" is an explicit failure rather than a
+// silent reroute. Distinguishes: no machine linked (409), machine offline
+// (503), and online-but-can't-serve-this-model (503). Returns false (no write)
+// when at least one owned, online machine can serve the model.
+func (s *Server) selfRouteUnavailable(w http.ResponseWriter, r *http.Request, owner, model string) bool {
+	online, servesModel := s.registry.OwnedProviderSummary(owner, model)
+	if servesModel > 0 {
+		return false
+	}
+	if online == 0 {
+		linked := 0
+		if recs, err := s.store.ListProvidersByAccount(r.Context(), owner); err == nil {
+			linked = len(recs)
+		}
+		if linked == 0 {
+			writeJSON(w, http.StatusConflict, errorResponse("no_linked_machine",
+				"self-route requested but no machine is linked to your account — run `darkbloom login` on your Mac to link it",
+				withCode("no_linked_machine")))
+			return true
+		}
+		w.Header().Set("Retry-After", "30")
+		writeJSON(w, http.StatusServiceUnavailable, errorResponse("machine_offline",
+			"your machine is offline — self-route will not fall back to paid providers; start your Darkbloom node and retry",
+			withCode("machine_offline")))
+		return true
+	}
+	// Online, but no owned machine currently serves this model.
+	w.Header().Set("Retry-After", "15")
+	writeJSON(w, http.StatusServiceUnavailable, errorResponse("model_not_loaded",
+		fmt.Sprintf("model %q is not available on your machine — load it on your node and retry", model),
+		withCode("model_not_loaded")))
+	return true
+}

--- a/coordinator/api/self_route_test.go
+++ b/coordinator/api/self_route_test.go
@@ -1,0 +1,267 @@
+package api
+
+// End-to-end HTTP tests for the "use my own machine, for free" (self-route)
+// feature. They exercise the real handler path (auth → policy → routing →
+// settlement) through httptest.NewServer, with a simulated provider over the
+// WebSocket harness shared with the billing integration tests.
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+	"github.com/eigeninference/d-inference/coordinator/registry"
+	"github.com/eigeninference/d-inference/coordinator/store"
+	"nhooyr.io/websocket"
+)
+
+// sendSelfRouteRequest posts a chat completion. When selfHeader is set it adds
+// X-Darkbloom-Route: self. Returns the HTTP status code.
+func sendSelfRouteRequest(t *testing.T, ctx context.Context, tsURL, model, apiKey string, selfHeader bool) int {
+	t.Helper()
+	body := `{"model":"` + model + `","messages":[{"role":"user","content":"hello"}],"stream":true}`
+	req, _ := http.NewRequestWithContext(ctx, http.MethodPost, tsURL+"/v1/chat/completions", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+	if selfHeader {
+		req.Header.Set("X-Darkbloom-Route", "self")
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("http request: %v", err)
+	}
+	defer resp.Body.Close()
+	io.ReadAll(resp.Body)
+	return resp.StatusCode
+}
+
+// setOwnedProvider points every registered provider's AccountID at accountID,
+// making that account the owner of the machine(s).
+func setOwnedProvider(srv *Server, accountID string) {
+	for _, id := range srv.registry.ProviderIDs() {
+		if p := srv.registry.GetProvider(id); p != nil {
+			p.Mu().Lock()
+			p.AccountID = accountID
+			p.Mu().Unlock()
+		}
+	}
+}
+
+// TestSelfRoute_HeaderFreeHappyPath: a zero-balance account that OWNS the
+// serving machine gets a successful, free inference via the header. Asserts no
+// charge, no provider payout, and a zero-cost usage row.
+func TestSelfRoute_HeaderFreeHappyPath(t *testing.T) {
+	srv, st, ledger := billingTestServer(t)
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	const owner = "owner-acct"
+	raw, _, err := st.CreateAPIKey(owner, store.APIKeyCreate{Name: "mine"})
+	if err != nil {
+		t.Fatalf("CreateAPIKey: %v", err)
+	}
+	// Deliberately do NOT credit the owner: a self-route request must succeed at
+	// zero balance.
+	if bal := ledger.Balance(owner); bal != 0 {
+		t.Fatalf("precondition: owner balance = %d, want 0", bal)
+	}
+
+	model := "self-route-billing-model"
+	conn, providerID, pubKey := setupProviderForBilling(t, ctx, ts, srv.registry, model)
+	defer conn.Close(websocket.StatusNormalClosure, "")
+	setOwnedProvider(srv, owner) // the machine belongs to the caller
+
+	usage := protocol.UsageInfo{PromptTokens: 100, CompletionTokens: 50}
+	providerDone := serveOneInference(ctx, t, conn, pubKey, usage)
+
+	status := sendSelfRouteRequest(t, ctx, ts.URL, model, raw, true)
+	if status != http.StatusOK {
+		t.Fatalf("self-route status = %d, want 200", status)
+	}
+	<-providerDone
+	time.Sleep(300 * time.Millisecond)
+
+	// No charge to the owner.
+	if bal := ledger.Balance(owner); bal != 0 {
+		t.Errorf("owner balance = %d after free self-route, want 0", bal)
+	}
+	// A zero-cost usage row was still recorded for transparency.
+	usageEntries := ledger.Usage(owner)
+	if len(usageEntries) != 1 {
+		t.Fatalf("usage entries = %d, want 1", len(usageEntries))
+	}
+	if usageEntries[0].CostMicroUSD != 0 {
+		t.Errorf("usage cost = %d, want 0 (free)", usageEntries[0].CostMicroUSD)
+	}
+	// No provider payout was accrued (consumer == provider account).
+	earnings, _ := st.GetAccountEarnings(owner, 100)
+	if len(earnings) != 0 {
+		t.Errorf("provider earnings = %d, want 0 for free self-route", len(earnings))
+	}
+	_ = providerID
+}
+
+// TestSelfRoute_PerKeyFlagForcesFree: a key created with self_route_only=true
+// self-routes (and is free) WITHOUT any header.
+func TestSelfRoute_PerKeyFlagForcesFree(t *testing.T) {
+	srv, st, ledger := billingTestServer(t)
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	const owner = "owner-acct-2"
+	raw, _, err := st.CreateAPIKey(owner, store.APIKeyCreate{Name: "private", SelfRouteOnly: true})
+	if err != nil {
+		t.Fatalf("CreateAPIKey: %v", err)
+	}
+
+	model := "self-route-perkey-model"
+	conn, _, pubKey := setupProviderForBilling(t, ctx, ts, srv.registry, model)
+	defer conn.Close(websocket.StatusNormalClosure, "")
+	setOwnedProvider(srv, owner)
+
+	usage := protocol.UsageInfo{PromptTokens: 10, CompletionTokens: 20}
+	providerDone := serveOneInference(ctx, t, conn, pubKey, usage)
+
+	// No header — the key flag alone must force the free self-route.
+	status := sendSelfRouteRequest(t, ctx, ts.URL, model, raw, false)
+	if status != http.StatusOK {
+		t.Fatalf("per-key self-route status = %d, want 200", status)
+	}
+	<-providerDone
+	time.Sleep(300 * time.Millisecond)
+
+	if bal := ledger.Balance(owner); bal != 0 {
+		t.Errorf("owner balance = %d, want 0 (per-key free)", bal)
+	}
+}
+
+// TestSelfRoute_NormalRequestStillBilled is the contrast case: the SAME
+// zero-balance account WITHOUT the self-route signal is gated by billing
+// (402), proving that self-route is what bypasses billing — not some other
+// path.
+func TestSelfRoute_NormalRequestStillBilled(t *testing.T) {
+	srv, st, _ := billingTestServer(t)
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	const owner = "owner-acct-3"
+	raw, _, err := st.CreateAPIKey(owner, store.APIKeyCreate{Name: "mine"})
+	if err != nil {
+		t.Fatalf("CreateAPIKey: %v", err)
+	}
+
+	model := "self-route-contrast-model"
+	conn, _, _ := setupProviderForBilling(t, ctx, ts, srv.registry, model)
+	defer conn.Close(websocket.StatusNormalClosure, "")
+	setOwnedProvider(srv, owner)
+
+	// No header, zero balance → standard billing rejects with 402 before
+	// dispatch (no provider serve needed).
+	status := sendSelfRouteRequest(t, ctx, ts.URL, model, raw, false)
+	if status != http.StatusPaymentRequired {
+		t.Fatalf("normal zero-balance request status = %d, want 402", status)
+	}
+}
+
+// TestSelfRoute_NoLinkedMachineReturns409: a caller who owns no machine gets a
+// clean 409, and is NEVER routed to a provider owned by someone else (no
+// fallback), even though that provider serves the model.
+func TestSelfRoute_NoLinkedMachineReturns409(t *testing.T) {
+	srv, st, _ := billingTestServer(t)
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	const caller = "owns-nothing"
+	raw, _, err := st.CreateAPIKey(caller, store.APIKeyCreate{Name: "mine"})
+	if err != nil {
+		t.Fatalf("CreateAPIKey: %v", err)
+	}
+
+	model := "self-route-409-model"
+	// Register a perfectly good provider, but owned by a DIFFERENT account so
+	// the model is in catalog yet the caller owns nothing.
+	conn, _, _ := setupProviderForBilling(t, ctx, ts, srv.registry, model)
+	defer conn.Close(websocket.StatusNormalClosure, "")
+	setOwnedProvider(srv, "someone-else")
+
+	status := sendSelfRouteRequest(t, ctx, ts.URL, model, raw, true)
+	if status != http.StatusConflict {
+		t.Fatalf("self-route with no linked machine status = %d, want 409", status)
+	}
+}
+
+// TestSelfRoute_SettlementMismatchFallsBackToPaid is the defense-in-depth
+// regression: if a request marked FreeSelfRoute is somehow completed by a
+// provider the consumer does NOT own (e.g. the machine was unlinked/relinked
+// mid-flight), settlement must fall back to PAID rather than grant free
+// inference on a stranger's machine. The router never produces this state, so
+// we construct it directly: reserve on an owned machine, then flip ownership
+// before completion.
+func TestSelfRoute_SettlementMismatchFallsBackToPaid(t *testing.T) {
+	srv, st, ledger := billingTestServer(t)
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	const owner = "owner-mismatch"
+	_ = st.Credit(owner, 100_000_000, store.LedgerDeposit, "test-setup") // fund for the paid fallback
+	initialBalance := ledger.Balance(owner)
+
+	model := "self-route-mismatch-model"
+	conn, providerID, _ := setupProviderForBilling(t, ctx, ts, srv.registry, model)
+	defer conn.Close(websocket.StatusNormalClosure, "")
+	setOwnedProvider(srv, owner)
+
+	// Reserve a self-route request on the owned machine (router-equivalent).
+	pr := &registry.PendingRequest{
+		RequestID:             "mismatch-req",
+		Model:                 model,
+		ConsumerKey:           owner,
+		OwnerAccountID:        owner,
+		SelfRouteOnly:         true,
+		FreeSelfRoute:         true,
+		EstimatedPromptTokens: 50,
+		RequestedMaxTokens:    128,
+		AcceptedCh:            make(chan struct{}, 1),
+		ChunkCh:               make(chan string, 1),
+		CompleteCh:            make(chan protocol.UsageInfo, 1),
+		ErrorCh:               make(chan protocol.InferenceErrorMessage, 1),
+	}
+	selected, _ := srv.registry.ReserveProviderEx(model, pr)
+	if selected == nil {
+		t.Fatal("failed to reserve the owned provider for the self-route request")
+	}
+
+	// Simulate the machine being unlinked / relinked to a different account
+	// after dispatch but before completion.
+	if p := srv.registry.GetProvider(providerID); p != nil {
+		p.Mu().Lock()
+		p.AccountID = "a-stranger"
+		p.Mu().Unlock()
+	}
+
+	srv.handleComplete(providerID, selected, &protocol.InferenceCompleteMessage{
+		Type:      protocol.TypeInferenceComplete,
+		RequestID: pr.RequestID,
+		Usage:     protocol.UsageInfo{PromptTokens: 100, CompletionTokens: 50},
+	})
+
+	// The owner must have been CHARGED (paid fallback), not given free inference.
+	finalBalance := ledger.Balance(owner)
+	if finalBalance >= initialBalance {
+		t.Fatalf("owner balance %d not reduced from %d — mismatch must settle as paid, not free", finalBalance, initialBalance)
+	}
+}

--- a/coordinator/api/types/types.go
+++ b/coordinator/api/types/types.go
@@ -231,6 +231,7 @@ type APIKeyResponse struct {
 	ITPMLimit     *int64     `json:"itpm_limit,omitempty"`
 	OTPMLimit     *int64     `json:"otpm_limit,omitempty"`
 	AllowedModels []string   `json:"allowed_models,omitempty"`
+	SelfRouteOnly bool       `json:"self_route_only"`
 	ExpiresAt     *time.Time `json:"expires_at,omitempty"`
 	CreatedAt     time.Time  `json:"created_at"`
 	LastUsedAt    *time.Time `json:"last_used_at,omitempty"`

--- a/coordinator/protocol/messages.go
+++ b/coordinator/protocol/messages.go
@@ -105,6 +105,7 @@ type RegisterMessage struct {
 	PrefillTPS              float64         `json:"prefill_tps,omitempty"`               // benchmark: prefill tokens per second
 	DecodeTPS               float64         `json:"decode_tps,omitempty"`                // benchmark: decode tokens per second
 	AuthToken               string          `json:"auth_token,omitempty"`                // device-linked provider token (from darkbloom login)
+	PrivateOnly             bool            `json:"private_only,omitempty"`              // when true, this machine serves only its owner's self-route requests, never the public fleet
 
 	// Runtime integrity hashes — used for runtime verification against known-good manifests.
 	PythonHash          string               `json:"python_hash,omitempty"`     // SHA-256 of Python runtime

--- a/coordinator/protocol/messages_test.go
+++ b/coordinator/protocol/messages_test.go
@@ -62,6 +62,61 @@ func TestRegisterMessageMarshal(t *testing.T) {
 	}
 }
 
+// TestRegisterMessagePrivateOnlySymmetry verifies the coordinator decodes the
+// private_only flag the Swift provider emits (snake_case key, only present when
+// true), and that the Go side round-trips it. Protects the Go↔Swift protocol
+// symmetry for the self-route "private machine" mode.
+func TestRegisterMessagePrivateOnlySymmetry(t *testing.T) {
+	// A minimal register payload exactly as the Swift ProviderMessage encoder
+	// emits it (private_only present and true).
+	swiftJSON := `{
+		"type": "register",
+		"hardware": {"chip_name": "Apple M3 Max", "memory_gb": 64},
+		"models": [{"id": "m", "model_type": "qwen3", "quantization": "4bit"}],
+		"backend": "mlx",
+		"public_key": "abc",
+		"auth_token": "tok",
+		"private_only": true
+	}`
+	var decoded RegisterMessage
+	if err := json.Unmarshal([]byte(swiftJSON), &decoded); err != nil {
+		t.Fatalf("unmarshal swift payload: %v", err)
+	}
+	if !decoded.PrivateOnly {
+		t.Fatal("private_only=true from the Swift payload did not decode")
+	}
+
+	// Omitted private_only must default to false (Swift omits it when false).
+	withoutFlag := `{"type":"register","hardware":{},"models":[],"backend":"mlx"}`
+	var d2 RegisterMessage
+	if err := json.Unmarshal([]byte(withoutFlag), &d2); err != nil {
+		t.Fatalf("unmarshal without flag: %v", err)
+	}
+	if d2.PrivateOnly {
+		t.Fatal("private_only should default to false when omitted")
+	}
+
+	// Go round-trip: false is omitted (omitempty), true survives.
+	data, _ := json.Marshal(RegisterMessage{Type: TypeRegister, PrivateOnly: false})
+	if contains(string(data), "private_only") {
+		t.Errorf("private_only=false should be omitted, got %s", data)
+	}
+	data, _ = json.Marshal(RegisterMessage{Type: TypeRegister, PrivateOnly: true})
+	var back RegisterMessage
+	if err := json.Unmarshal(data, &back); err != nil || !back.PrivateOnly {
+		t.Errorf("private_only=true round-trip failed: %v / %s", err, data)
+	}
+}
+
+func contains(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}
+
 func TestHeartbeatMessageMarshal(t *testing.T) {
 	msg := HeartbeatMessage{
 		Type:        TypeHeartbeat,

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -91,6 +91,21 @@ type PendingRequest struct {
 	// one of these attested hardware serials. Empty means the request may
 	// route to any eligible provider.
 	AllowedProviderSerials []string
+	// SelfRouteOnly restricts routing to providers owned by OwnerAccountID
+	// (the "use my own machine" path). When set, the scheduler skips every
+	// provider whose AccountID != OwnerAccountID and never falls back to the
+	// public fleet. The owner-match is on the coordinator-stamped AccountID,
+	// never on any client-supplied value.
+	SelfRouteOnly bool
+	// OwnerAccountID is the authenticated account that must own the serving
+	// provider when SelfRouteOnly is set. Stamped server-side from the
+	// request's authenticated identity.
+	OwnerAccountID string
+	// FreeSelfRoute marks a request that must settle at zero cost (no charge,
+	// no platform fee, no provider payout) because it is served by a machine
+	// the requesting account owns. handleComplete re-verifies ownership of the
+	// serving provider before honoring this flag.
+	FreeSelfRoute bool
 	// EstimatedPromptTokens is a coordinator-side heuristic used only for
 	// routing and queue admission. It does not need tokenizer-perfect accuracy.
 	EstimatedPromptTokens int
@@ -185,6 +200,10 @@ type Provider struct {
 
 	// Account linkage (set when provider authenticates via device auth token)
 	AccountID string // internal account ID (from device auth flow)
+
+	// PrivateOnly excludes this machine from the public fleet entirely: it
+	// serves only its owner's self-route requests. Reported at registration.
+	PrivateOnly bool
 
 	// Benchmark data reported at registration
 	PrefillTPS float64 // prefill tokens per second
@@ -1119,6 +1138,7 @@ func (r *Registry) Register(id string, conn *websocket.Conn, msg *protocol.Regis
 		Backend:                 msg.Backend,
 		PublicKey:               pubKey,
 		EncryptedResponseChunks: msg.EncryptedResponseChunks,
+		PrivateOnly:             msg.PrivateOnly,
 		PrefillTPS:              msg.PrefillTPS,
 		DecodeTPS:               msg.DecodeTPS,
 		TrustLevel:              TrustNone,
@@ -2596,8 +2616,14 @@ func (r *Registry) ModelCapacitySnapshot() []ModelCapacity {
 	for _, p := range r.providers {
 		p.mu.Lock()
 
-		// Apply the same gates as snapshotProviderLocked.
+		// Apply the same gates as snapshotProviderLocked. Private-only machines
+		// never serve the public fleet, so they do not count toward public
+		// model capacity.
 		if p.Status == StatusOffline || p.Status == StatusUntrusted {
+			p.mu.Unlock()
+			continue
+		}
+		if p.PrivateOnly {
 			p.mu.Unlock()
 			continue
 		}

--- a/coordinator/registry/scheduler.go
+++ b/coordinator/registry/scheduler.go
@@ -229,8 +229,11 @@ func (r *Registry) ReserveProviderEx(model string, pr *PendingRequest, excludeID
 	defer p.mu.Unlock()
 
 	// Re-check capacity under the provider lock in case another goroutine
-	// changed the pending set between snapshot and reservation.
-	if !r.providerCanAdmitLocked(p, model) {
+	// changed the pending set between snapshot and reservation. selfRouteOwner
+	// mirrors selection: a self-route request has already been filtered to a
+	// provider the caller owns, so the trust floor is relaxed and a private-only
+	// machine is admitted here too.
+	if !r.providerCanAdmitLocked(p, model, pr.SelfRouteOnly) {
 		return nil, RoutingDecision{
 			Model:                   model,
 			CandidateCount:          candidateCount,
@@ -293,6 +296,15 @@ func (r *Registry) selectBestCandidateLockedFull(model string, pr *PendingReques
 	capacityRejections := 0
 	tooLargeRejections := 0
 	for _, p := range r.providers {
+		// Self-route: restrict to providers owned by the requesting account
+		// and never fall back to the public fleet. Once this passes, the
+		// provider is the caller's own machine, so snapshotProviderLocked may
+		// relax the hardware-trust gate (relaxTrust = pr.SelfRouteOnly).
+		if pr.SelfRouteOnly {
+			if !providerOwnedBy(p, pr.OwnerAccountID) {
+				continue
+			}
+		}
 		if len(allowedSerials) > 0 {
 			if !providerMatchesAllowedSerial(p, allowedSerials) {
 				continue
@@ -301,7 +313,7 @@ func (r *Registry) selectBestCandidateLockedFull(model string, pr *PendingReques
 		if _, excluded := excludeSet[p.ID]; excluded {
 			continue
 		}
-		snap, ok := r.snapshotProviderLocked(p, model)
+		snap, ok := r.snapshotProviderLocked(p, model, pr.SelfRouteOnly)
 		if !ok {
 			continue
 		}
@@ -385,6 +397,59 @@ func providerMatchesAllowedSerial(p *Provider, allowed map[string]struct{}) bool
 	return false
 }
 
+// providerOwnedBy reports whether p is owned by accountID. Ownership is the
+// coordinator-stamped Provider.AccountID (set at registration from the device
+// auth token), never a client-supplied value — so it cannot be forged by a
+// caller. An empty accountID never matches.
+func providerOwnedBy(p *Provider, accountID string) bool {
+	if p == nil || accountID == "" {
+		return false
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.AccountID != "" && p.AccountID == accountID
+}
+
+// OwnedProviderSummary reports, for the given account, how many of its
+// currently-connected providers are online and how many can serve `model`.
+// It powers self-route pre-flight error messaging: distinguishing "your
+// machine is offline" from "your machine can't serve this model". The
+// model-serving check applies the same privacy/runtime/challenge gates as
+// routing but deliberately ignores the hardware-trust gate, which self-route
+// relaxes for a caller's own machine. "Linked but offline" providers are not
+// counted here (they are not in the registry); callers detect zero linked
+// machines via store.ListProvidersByAccount.
+func (r *Registry) OwnedProviderSummary(accountID, model string) (online, servesModel int) {
+	if accountID == "" {
+		return 0, 0
+	}
+	now := time.Now()
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	for _, p := range r.providers {
+		p.mu.Lock()
+		if p.AccountID == "" || p.AccountID != accountID {
+			p.mu.Unlock()
+			continue
+		}
+		if p.Status == StatusOffline || p.Status == StatusUntrusted {
+			p.mu.Unlock()
+			continue
+		}
+		online++
+		serves := r.providerServesCatalogModelLocked(p, model) &&
+			p.RuntimeVerified &&
+			providerSupportsPrivateTextLocked(p) &&
+			!p.LastChallengeVerified.IsZero() &&
+			now.Sub(p.LastChallengeVerified) <= challengeFreshnessMaxAge
+		p.mu.Unlock()
+		if serves {
+			servesModel++
+		}
+	}
+	return online, servesModel
+}
+
 // logRoutingDecision emits a structured debug-level record of the
 // winning candidate and its cost breakdown. Cheap when the level is
 // disabled, since slog short-circuits before formatting.
@@ -410,7 +475,16 @@ func (r *Registry) logRoutingDecision(model string, pr *PendingRequest, winner *
 	)
 }
 
-func (r *Registry) snapshotProviderLocked(p *Provider, model string) (routingSnapshot, bool) {
+// snapshotProviderLocked builds a routing snapshot for p, returning ok=false
+// when p fails any structural/privacy/capacity gate. selfRouteOwner is true
+// when this is a self-route request and p is owned by the requesting account.
+// It (1) drops the hardware-trust floor to TrustNone — a personal Mac will not
+// be MDM/MDA enrolled, so without this it would be unroutable to its own owner
+// — and (2) admits a private-only machine, which is otherwise excluded from
+// the public fleet. Every privacy-critical gate (RuntimeVerified, private-text
+// support, challenge freshness) still applies, so plaintext is never exposed
+// and only the genuinely-signed provider binary serves.
+func (r *Registry) snapshotProviderLocked(p *Provider, model string, selfRouteOwner bool) (routingSnapshot, bool) {
 	now := time.Now()
 
 	p.mu.Lock()
@@ -422,7 +496,16 @@ func (r *Registry) snapshotProviderLocked(p *Provider, model string) (routingSna
 	if p.Status == StatusOffline || p.Status == StatusUntrusted {
 		return routingSnapshot{}, false
 	}
-	if trustRank(p.TrustLevel) < trustRank(r.MinTrustLevel) {
+	// A private-only machine never serves the public fleet — only its owner's
+	// self-route requests.
+	if p.PrivateOnly && !selfRouteOwner {
+		return routingSnapshot{}, false
+	}
+	minTrust := r.MinTrustLevel
+	if selfRouteOwner {
+		minTrust = TrustNone
+	}
+	if trustRank(p.TrustLevel) < trustRank(minTrust) {
 		return routingSnapshot{}, false
 	}
 	if !p.RuntimeVerified {
@@ -778,11 +861,18 @@ func providerModelIDs(p *Provider) []string {
 	return ids
 }
 
-func (r *Registry) providerCanAdmitLocked(p *Provider, model string) bool {
+func (r *Registry) providerCanAdmitLocked(p *Provider, model string, selfRouteOwner bool) bool {
 	if p.Status == StatusOffline || p.Status == StatusUntrusted {
 		return false
 	}
-	if trustRank(p.TrustLevel) < trustRank(r.MinTrustLevel) || !p.RuntimeVerified {
+	if p.PrivateOnly && !selfRouteOwner {
+		return false
+	}
+	minTrust := r.MinTrustLevel
+	if selfRouteOwner {
+		minTrust = TrustNone
+	}
+	if trustRank(p.TrustLevel) < trustRank(minTrust) || !p.RuntimeVerified {
 		return false
 	}
 	if !providerSupportsPrivateTextLocked(p) {
@@ -868,12 +958,18 @@ func (r *Registry) QuickCapacityCheck(model string, estimatedPromptTokens, reque
 
 		p.mu.Lock()
 
-		// Structural gates (same as snapshotProviderLocked).
+		// Structural gates (same as snapshotProviderLocked). This pre-flight
+		// only runs for public (non-self-route) requests, so private-only
+		// machines are excluded unconditionally.
 		if !r.providerServesCatalogModelLocked(p, model) {
 			p.mu.Unlock()
 			continue
 		}
 		if p.Status == StatusOffline || p.Status == StatusUntrusted {
+			p.mu.Unlock()
+			continue
+		}
+		if p.PrivateOnly {
 			p.mu.Unlock()
 			continue
 		}

--- a/coordinator/registry/self_route_test.go
+++ b/coordinator/registry/self_route_test.go
@@ -1,0 +1,218 @@
+package registry
+
+import (
+	"testing"
+)
+
+func setProviderAccount(p *Provider, accountID string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.AccountID = accountID
+}
+
+// TestSelfRouteRoutesOnlyToOwnedProvider verifies that a SelfRouteOnly request
+// is served by a provider the requesting account owns, even when a faster
+// provider owned by someone else is available.
+func TestSelfRouteRoutesOnlyToOwnedProvider(t *testing.T) {
+	reg := New(testLogger())
+	model := "self-route-model"
+
+	owned := makeSchedulerProvider(t, reg, "owned", model, 40)  // slower
+	other := makeSchedulerProvider(t, reg, "other", model, 400) // much faster
+	setProviderAccount(owned, "acct-A")
+	setProviderAccount(other, "acct-B")
+
+	req := &PendingRequest{
+		RequestID:          "req-self",
+		Model:              model,
+		RequestedMaxTokens: 128,
+		SelfRouteOnly:      true,
+		OwnerAccountID:     "acct-A",
+	}
+	selected, decision := reg.ReserveProviderEx(model, req)
+	if selected == nil {
+		t.Fatal("ReserveProviderEx returned nil for an owned, capable provider")
+	}
+	if selected.ID != owned.ID {
+		t.Fatalf("selected %q, want owned provider %q (must not pick the faster non-owned one)", selected.ID, owned.ID)
+	}
+	if decision.CandidateCount != 1 {
+		t.Fatalf("decision.CandidateCount=%d, want 1 (only the owned provider is a candidate)", decision.CandidateCount)
+	}
+}
+
+// TestSelfRouteNeverFallsBackToPaid verifies that when the caller owns no
+// eligible provider, self-route returns no provider rather than routing to the
+// public fleet — the core "free, my machine only, no fallback" guarantee.
+func TestSelfRouteNeverFallsBackToPaid(t *testing.T) {
+	reg := New(testLogger())
+	model := "no-fallback-model"
+
+	// A perfectly good provider exists, but it belongs to a different account.
+	other := makeSchedulerProvider(t, reg, "other", model, 200)
+	setProviderAccount(other, "acct-B")
+
+	req := &PendingRequest{
+		RequestID:          "req-no-fallback",
+		Model:              model,
+		RequestedMaxTokens: 128,
+		SelfRouteOnly:      true,
+		OwnerAccountID:     "acct-A",
+	}
+	selected, decision := reg.ReserveProviderEx(model, req)
+	if selected != nil {
+		t.Fatalf("selected %q — self-route must never fall back to a provider the caller does not own", selected.ID)
+	}
+	if decision.CandidateCount != 0 {
+		t.Fatalf("decision.CandidateCount=%d, want 0", decision.CandidateCount)
+	}
+
+	// Sanity: an unauthenticated (empty) owner must also match nothing.
+	req2 := &PendingRequest{RequestID: "req-empty", Model: model, RequestedMaxTokens: 128, SelfRouteOnly: true, OwnerAccountID: ""}
+	if selected2, _ := reg.ReserveProviderEx(model, req2); selected2 != nil {
+		t.Fatalf("empty owner matched provider %q; want nil", selected2.ID)
+	}
+}
+
+// TestSelfRouteRelaxesHardwareTrust verifies that a caller's own self_signed
+// machine (which a personal Mac would be — no MDM/MDA) is routable to its
+// owner under self-route, while still being unroutable to the public fleet and
+// to other accounts.
+func TestSelfRouteRelaxesHardwareTrust(t *testing.T) {
+	reg := New(testLogger()) // default MinTrustLevel == TrustHardware
+	model := "trust-relax-model"
+
+	mine := makeSchedulerProvider(t, reg, "mine", model, 100)
+	mine.mu.Lock()
+	mine.TrustLevel = TrustSelfSigned
+	mine.mu.Unlock()
+	setProviderAccount(mine, "acct-A")
+
+	// Normal (paid) request: the self_signed provider is below MinTrust and
+	// must not be selected.
+	normal := &PendingRequest{RequestID: "req-normal", Model: model, RequestedMaxTokens: 128}
+	if selected := reg.ReserveProvider(model, normal); selected != nil {
+		t.Fatalf("paid request selected self_signed provider %q; hardware-trust gate must hold for the public fleet", selected.ID)
+	}
+
+	// Self-route by the owner: trust is relaxed, so the owner reaches their own
+	// machine.
+	owner := &PendingRequest{RequestID: "req-owner", Model: model, RequestedMaxTokens: 128, SelfRouteOnly: true, OwnerAccountID: "acct-A"}
+	selected := reg.ReserveProvider(model, owner)
+	if selected == nil {
+		t.Fatal("self-route by owner failed to reach their own self_signed machine (trust relaxation not applied)")
+	}
+	if selected.ID != mine.ID {
+		t.Fatalf("selected %q, want %q", selected.ID, mine.ID)
+	}
+
+	// A different account's self-route must NOT reach this machine.
+	stranger := &PendingRequest{RequestID: "req-stranger", Model: model, RequestedMaxTokens: 128, SelfRouteOnly: true, OwnerAccountID: "acct-B"}
+	if selected := reg.ReserveProvider(model, stranger); selected != nil {
+		t.Fatalf("acct-B self-route reached acct-A's machine %q; ownership filter breached", selected.ID)
+	}
+}
+
+// TestSelfRoutePreservesPrivacyGates verifies that trust relaxation does NOT
+// relax the privacy-critical gates: an owned machine that is not
+// runtime-verified is still unroutable, even to its owner.
+func TestSelfRoutePreservesPrivacyGates(t *testing.T) {
+	reg := New(testLogger())
+	model := "privacy-gate-model"
+
+	mine := makeSchedulerProvider(t, reg, "mine", model, 100)
+	mine.mu.Lock()
+	mine.TrustLevel = TrustSelfSigned
+	mine.RuntimeVerified = false // privacy gate fails
+	mine.mu.Unlock()
+	setProviderAccount(mine, "acct-A")
+
+	owner := &PendingRequest{RequestID: "req-owner", Model: model, RequestedMaxTokens: 128, SelfRouteOnly: true, OwnerAccountID: "acct-A"}
+	if selected := reg.ReserveProvider(model, owner); selected != nil {
+		t.Fatalf("selected non-runtime-verified machine %q; privacy gates must never be relaxed", selected.ID)
+	}
+}
+
+// TestOwnedProviderSummary verifies the pre-flight counters that drive
+// self-route error messaging.
+func TestOwnedProviderSummary(t *testing.T) {
+	reg := New(testLogger())
+	model := "summary-model"
+
+	a1 := makeSchedulerProvider(t, reg, "a1", model, 100)
+	a2 := makeSchedulerProvider(t, reg, "a2", model, 100)
+	b1 := makeSchedulerProvider(t, reg, "b1", model, 100)
+	setProviderAccount(a1, "acct-A")
+	setProviderAccount(a2, "acct-A")
+	setProviderAccount(b1, "acct-B")
+
+	// a2 is offline → counts as linked-but-not-online for acct-A.
+	a2.mu.Lock()
+	a2.Status = StatusOffline
+	a2.mu.Unlock()
+
+	online, serves := reg.OwnedProviderSummary("acct-A", model)
+	if online != 1 {
+		t.Fatalf("acct-A online=%d, want 1 (a1 online, a2 offline)", online)
+	}
+	if serves != 1 {
+		t.Fatalf("acct-A servesModel=%d, want 1", serves)
+	}
+
+	// Unknown model: online still counts, servesModel drops to 0.
+	online, serves = reg.OwnedProviderSummary("acct-A", "model-not-served")
+	if online != 1 {
+		t.Fatalf("acct-A online=%d for unknown model, want 1", online)
+	}
+	if serves != 0 {
+		t.Fatalf("acct-A servesModel=%d for unknown model, want 0", serves)
+	}
+
+	// An account with no providers gets zeros.
+	if online, serves = reg.OwnedProviderSummary("acct-none", model); online != 0 || serves != 0 {
+		t.Fatalf("acct-none summary=(%d,%d), want (0,0)", online, serves)
+	}
+
+	// Empty account never matches.
+	if online, serves = reg.OwnedProviderSummary("", model); online != 0 || serves != 0 {
+		t.Fatalf("empty account summary=(%d,%d), want (0,0)", online, serves)
+	}
+}
+
+func setProviderPrivateOnly(p *Provider) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.PrivateOnly = true
+}
+
+// TestPrivateOnlyProviderExcludedFromPublicFleet verifies that a private-only
+// machine serves ONLY its owner's self-route requests: it is invisible to the
+// public fleet (routing and capacity), but reachable by its owner.
+func TestPrivateOnlyProviderExcludedFromPublicFleet(t *testing.T) {
+	reg := New(testLogger())
+	model := "private-only-model"
+
+	priv := makeSchedulerProvider(t, reg, "private", model, 100) // TrustHardware
+	setProviderAccount(priv, "acct-A")
+	setProviderPrivateOnly(priv)
+
+	// Public request: the private-only machine is the only provider, yet it must
+	// not be selected — and capacity must report zero candidates.
+	publicReq := &PendingRequest{RequestID: "pub", Model: model, RequestedMaxTokens: 128}
+	if selected := reg.ReserveProvider(model, publicReq); selected != nil {
+		t.Fatalf("public request selected private-only machine %q", selected.ID)
+	}
+	if cc, _, _ := reg.QuickCapacityCheck(model, 100, 128); cc != 0 {
+		t.Fatalf("QuickCapacityCheck candidateCount=%d for a private-only-only fleet, want 0", cc)
+	}
+
+	// The owner reaches it via self-route.
+	ownerReq := &PendingRequest{RequestID: "own", Model: model, RequestedMaxTokens: 128, SelfRouteOnly: true, OwnerAccountID: "acct-A"}
+	selected := reg.ReserveProvider(model, ownerReq)
+	if selected == nil {
+		t.Fatal("owner self-route failed to reach their own private-only machine")
+	}
+	if selected.ID != priv.ID {
+		t.Fatalf("selected %q, want %q", selected.ID, priv.ID)
+	}
+}

--- a/coordinator/store/interface.go
+++ b/coordinator/store/interface.go
@@ -687,6 +687,12 @@ type APIKey struct {
 	// AllowedModels restricts which models the key may call. Empty = all.
 	AllowedModels []string `json:"allowed_models,omitempty"`
 
+	// SelfRouteOnly is a hard ceiling: every request on this key is routed
+	// only to a machine the owning account runs, and is free. The key can
+	// never spend balance or reach the public fleet. See the "self-route"
+	// design in the consumer handler.
+	SelfRouteOnly bool `json:"self_route_only"`
+
 	ExpiresAt  *time.Time `json:"expires_at,omitempty"`
 	CreatedAt  time.Time  `json:"created_at"`
 	LastUsedAt *time.Time `json:"last_used_at,omitempty"`
@@ -702,6 +708,7 @@ type APIKeyCreate struct {
 	ITPMLimit     *int64
 	OTPMLimit     *int64
 	AllowedModels []string
+	SelfRouteOnly bool
 	ExpiresAt     *time.Time
 }
 

--- a/coordinator/store/memory.go
+++ b/coordinator/store/memory.go
@@ -253,6 +253,7 @@ func (s *MemoryStore) CreateAPIKey(accountID string, opts APIKeyCreate) (string,
 		ITPMLimit:      cloneInt64Ptr(opts.ITPMLimit),
 		OTPMLimit:      cloneInt64Ptr(opts.OTPMLimit),
 		AllowedModels:  append([]string(nil), opts.AllowedModels...),
+		SelfRouteOnly:  opts.SelfRouteOnly,
 		ExpiresAt:      cloneTimePtr(opts.ExpiresAt),
 		CreatedAt:      time.Now().UTC(),
 	}
@@ -386,6 +387,7 @@ func (s *MemoryStore) UpdateAPIKey(accountID, id string, mutable APIKey) (*APIKe
 	rec.ITPMLimit = cloneInt64Ptr(mutable.ITPMLimit)
 	rec.OTPMLimit = cloneInt64Ptr(mutable.OTPMLimit)
 	rec.AllowedModels = append([]string(nil), mutable.AllowedModels...)
+	rec.SelfRouteOnly = mutable.SelfRouteOnly
 	rec.ExpiresAt = cloneTimePtr(mutable.ExpiresAt)
 	return cloneAPIKey(rec), nil
 }
@@ -440,6 +442,7 @@ func (s *MemoryStore) RotateAPIKey(accountID, id string) (string, *APIKey, error
 		ITPMLimit:      cloneInt64Ptr(old.ITPMLimit),
 		OTPMLimit:      cloneInt64Ptr(old.OTPMLimit),
 		AllowedModels:  append([]string(nil), old.AllowedModels...),
+		SelfRouteOnly:  old.SelfRouteOnly,
 		ExpiresAt:      cloneTimePtr(old.ExpiresAt),
 		CreatedAt:      time.Now().UTC(),
 	}

--- a/coordinator/store/postgres.go
+++ b/coordinator/store/postgres.go
@@ -200,6 +200,7 @@ func (s *PostgresStore) migrate(ctx context.Context) error {
 		`DO $$ BEGIN ALTER TABLE api_keys ADD COLUMN IF NOT EXISTS allowed_models TEXT NOT NULL DEFAULT ''; EXCEPTION WHEN others THEN NULL; END $$`,
 		`DO $$ BEGIN ALTER TABLE api_keys ADD COLUMN IF NOT EXISTS expires_at TIMESTAMPTZ; EXCEPTION WHEN others THEN NULL; END $$`,
 		`DO $$ BEGIN ALTER TABLE api_keys ADD COLUMN IF NOT EXISTS last_used_at TIMESTAMPTZ; EXCEPTION WHEN others THEN NULL; END $$`,
+		`DO $$ BEGIN ALTER TABLE api_keys ADD COLUMN IF NOT EXISTS self_route_only BOOLEAN NOT NULL DEFAULT FALSE; EXCEPTION WHEN others THEN NULL; END $$`,
 		// Backfill stable IDs for legacy rows (deterministic from the hash so
 		// it is stable across restarts and idempotent).
 		`UPDATE api_keys SET id = 'key_' || substr(md5(key_hash), 1, 24) WHERE id IS NULL OR id = ''`,
@@ -678,7 +679,7 @@ func hashKey(key string) string {
 // an APIKey via scanAPIKeyRow.
 const apiKeyColumns = `id, owner_account_id, name, raw_prefix, key_hash, active,
 	limit_micro_usd, limit_reset, rpm_limit, itpm_limit, otpm_limit,
-	allowed_models, expires_at, created_at, last_used_at`
+	allowed_models, expires_at, created_at, last_used_at, self_route_only`
 
 // rowScanner is satisfied by both pgx.Row and pgx.Rows.
 type rowScanner interface {
@@ -700,7 +701,7 @@ func scanAPIKeyRow(row rowScanner) (*APIKey, error) {
 	)
 	if err := row.Scan(&k.ID, &k.OwnerAccountID, &k.Name, &k.Label, &k.KeyHash, &active,
 		&limit, &k.LimitReset, &rpm, &itpm, &otpm,
-		&allowed, &expiresAt, &k.CreatedAt, &lastUsedAt); err != nil {
+		&allowed, &expiresAt, &k.CreatedAt, &lastUsedAt, &k.SelfRouteOnly); err != nil {
 		return nil, err
 	}
 	k.Disabled = !active
@@ -747,15 +748,15 @@ func (s *PostgresStore) insertAPIKey(ctx context.Context, rec *APIKey, onConflic
 	q := `INSERT INTO api_keys
 		(id, key_hash, raw_prefix, owner_account_id, name, active,
 		 limit_micro_usd, limit_reset, rpm_limit, itpm_limit, otpm_limit,
-		 allowed_models, expires_at, created_at)
-		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14)`
+		 allowed_models, expires_at, created_at, self_route_only)
+		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15)`
 	if onConflictDoNothing {
 		q += ` ON CONFLICT (key_hash) DO NOTHING`
 	}
 	_, err := s.pool.Exec(ctx, q,
 		rec.ID, rec.KeyHash, rec.Label, rec.OwnerAccountID, rec.Name, !rec.Disabled,
 		rec.LimitMicroUSD, NormalizeResetWindow(rec.LimitReset), rec.RPMLimit, rec.ITPMLimit, rec.OTPMLimit,
-		encodeModelList(rec.AllowedModels), rec.ExpiresAt, rec.CreatedAt,
+		encodeModelList(rec.AllowedModels), rec.ExpiresAt, rec.CreatedAt, rec.SelfRouteOnly,
 	)
 	return err
 }
@@ -795,6 +796,7 @@ func (s *PostgresStore) CreateAPIKey(accountID string, opts APIKeyCreate) (strin
 		ITPMLimit:      opts.ITPMLimit,
 		OTPMLimit:      opts.OTPMLimit,
 		AllowedModels:  opts.AllowedModels,
+		SelfRouteOnly:  opts.SelfRouteOnly,
 		ExpiresAt:      opts.ExpiresAt,
 		CreatedAt:      time.Now().UTC(),
 	}
@@ -955,11 +957,11 @@ func (s *PostgresStore) UpdateAPIKey(accountID, id string, mutable APIKey) (*API
 		`UPDATE api_keys SET
 			name = $1, active = $2, limit_micro_usd = $3, limit_reset = $4,
 			rpm_limit = $5, itpm_limit = $6, otpm_limit = $7,
-			allowed_models = $8, expires_at = $9
-		 WHERE id = $10 AND owner_account_id = $11`,
+			allowed_models = $8, expires_at = $9, self_route_only = $10
+		 WHERE id = $11 AND owner_account_id = $12`,
 		mutable.Name, !mutable.Disabled, mutable.LimitMicroUSD, NormalizeResetWindow(mutable.LimitReset),
 		mutable.RPMLimit, mutable.ITPMLimit, mutable.OTPMLimit,
-		encodeModelList(mutable.AllowedModels), mutable.ExpiresAt,
+		encodeModelList(mutable.AllowedModels), mutable.ExpiresAt, mutable.SelfRouteOnly,
 		id, accountID,
 	)
 	if err != nil {
@@ -1028,6 +1030,7 @@ func (s *PostgresStore) RotateAPIKey(accountID, id string) (string, *APIKey, err
 		ITPMLimit:      old.ITPMLimit,
 		OTPMLimit:      old.OTPMLimit,
 		AllowedModels:  old.AllowedModels,
+		SelfRouteOnly:  old.SelfRouteOnly,
 		ExpiresAt:      old.ExpiresAt,
 		CreatedAt:      time.Now().UTC(),
 	}
@@ -1035,11 +1038,11 @@ func (s *PostgresStore) RotateAPIKey(accountID, id string) (string, *APIKey, err
 		`INSERT INTO api_keys
 			(id, key_hash, raw_prefix, owner_account_id, name, active,
 			 limit_micro_usd, limit_reset, rpm_limit, itpm_limit, otpm_limit,
-			 allowed_models, expires_at, created_at)
-		 VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14)`,
+			 allowed_models, expires_at, created_at, self_route_only)
+		 VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15)`,
 		rec.ID, rec.KeyHash, rec.Label, rec.OwnerAccountID, rec.Name, !rec.Disabled,
 		rec.LimitMicroUSD, rec.LimitReset, rec.RPMLimit, rec.ITPMLimit, rec.OTPMLimit,
-		encodeModelList(rec.AllowedModels), rec.ExpiresAt, rec.CreatedAt,
+		encodeModelList(rec.AllowedModels), rec.ExpiresAt, rec.CreatedAt, rec.SelfRouteOnly,
 	); err != nil {
 		return "", nil, fmt.Errorf("store: insert rotated key: %w", err)
 	}

--- a/coordinator/store/self_route_key_test.go
+++ b/coordinator/store/self_route_key_test.go
@@ -1,0 +1,77 @@
+package store
+
+import "testing"
+
+// exerciseSelfRouteOnlyRoundTrip runs the full lifecycle of the SelfRouteOnly
+// flag against any Store implementation: create → authenticate → get → update
+// (off then on) → rotate. It is shared by the memory and Postgres suites so a
+// schema/scan/INSERT/UPDATE drift in either backend is caught.
+func exerciseSelfRouteOnlyRoundTrip(t *testing.T, s Store) {
+	t.Helper()
+
+	raw, rec, err := s.CreateAPIKey("acct-self", APIKeyCreate{Name: "my-machine", SelfRouteOnly: true})
+	if err != nil {
+		t.Fatalf("CreateAPIKey: %v", err)
+	}
+	if !rec.SelfRouteOnly {
+		t.Fatalf("create did not persist SelfRouteOnly=true")
+	}
+
+	// The request path reads the flag off the AuthenticateKey result.
+	got, err := s.AuthenticateKey(raw)
+	if err != nil {
+		t.Fatalf("AuthenticateKey: %v", err)
+	}
+	if !got.SelfRouteOnly {
+		t.Fatalf("AuthenticateKey lost SelfRouteOnly")
+	}
+
+	byID, err := s.GetAPIKeyByID("acct-self", rec.ID)
+	if err != nil {
+		t.Fatalf("GetAPIKeyByID: %v", err)
+	}
+	if !byID.SelfRouteOnly {
+		t.Fatalf("GetAPIKeyByID lost SelfRouteOnly")
+	}
+
+	// Toggle off via update.
+	mut := *byID
+	mut.SelfRouteOnly = false
+	upd, err := s.UpdateAPIKey("acct-self", rec.ID, mut)
+	if err != nil {
+		t.Fatalf("UpdateAPIKey(off): %v", err)
+	}
+	if upd.SelfRouteOnly {
+		t.Fatalf("UpdateAPIKey did not clear SelfRouteOnly")
+	}
+
+	// Toggle back on, then confirm rotate preserves it.
+	mut.SelfRouteOnly = true
+	if _, err := s.UpdateAPIKey("acct-self", rec.ID, mut); err != nil {
+		t.Fatalf("UpdateAPIKey(on): %v", err)
+	}
+	_, rotated, err := s.RotateAPIKey("acct-self", rec.ID)
+	if err != nil {
+		t.Fatalf("RotateAPIKey: %v", err)
+	}
+	if !rotated.SelfRouteOnly {
+		t.Fatalf("RotateAPIKey dropped SelfRouteOnly")
+	}
+
+	// A key created without the flag defaults to false.
+	_, plain, err := s.CreateAPIKey("acct-self", APIKeyCreate{Name: "normal"})
+	if err != nil {
+		t.Fatalf("CreateAPIKey(plain): %v", err)
+	}
+	if plain.SelfRouteOnly {
+		t.Fatalf("plain key unexpectedly self_route_only")
+	}
+}
+
+func TestMemorySelfRouteOnlyRoundTrip(t *testing.T) {
+	exerciseSelfRouteOnlyRoundTrip(t, NewMemory(Config{}))
+}
+
+func TestPostgresSelfRouteOnlyRoundTrip(t *testing.T) {
+	exerciseSelfRouteOnlyRoundTrip(t, testPostgresStore(t))
+}

--- a/docs/direct-mode.md
+++ b/docs/direct-mode.md
@@ -1,0 +1,129 @@
+# Direct / local mode — talk to your own Mac, no relay
+
+[Self-route](self-route.md) routes "use my own machine, for free" requests
+through the coordinator (the only rendezvous point, since the provider is an
+outbound-only WebSocket client behind NAT). **Direct mode** removes the relay
+entirely for the case where the client can reach the Mac itself — same machine,
+LAN, or tailnet:
+
+- **Lower latency** — localhost/LAN, no WAN round-trip to the coordinator.
+- **Works offline** — your own inference keeps running with no internet.
+- **Bytes never leave your network** — stronger than E2E-through-relay.
+
+The provider already ships an OpenAI-compatible HTTP server backed by the same
+MLX engine (`StandaloneServer`); direct mode makes it **secure** (a local API
+key) and **discoverable**, and adds a client that prefers it with automatic
+fallback to the relayed self-route.
+
+## Run it
+
+```bash
+darkbloom start --local                 # serve locally on 127.0.0.1:8000
+darkbloom start --local --port 8080     # custom port
+darkbloom start --local --bind 100.x.y.z  # bind a tailnet IP for same-account devices
+darkbloom start --local --no-auth       # disable the API key (trusted/airgapped only)
+```
+
+`--local` runs the OpenAI server **only** (no coordinator connection). It mints a
+persistent bearer token (`~/.darkbloom/local_token`, `0600`) and writes a
+discovery record (`~/.darkbloom/local.json`, `0600`).
+
+## Find the endpoint
+
+```bash
+darkbloom local            # prints base URL + API key + ready-to-paste examples
+darkbloom local --json     # machine-readable discovery record
+```
+
+Point any OpenAI client at it:
+
+```bash
+export OPENAI_BASE_URL=http://127.0.0.1:8000/v1
+export OPENAI_API_KEY=dk-local-…      # from `darkbloom local`
+```
+
+```python
+from openai import OpenAI
+client = OpenAI()  # picks up OPENAI_BASE_URL / OPENAI_API_KEY
+client.chat.completions.create(model="…", messages=[{"role": "user", "content": "hi"}])
+```
+
+## Discover from Node (`~/.darkbloom/local.json`)
+
+```ts
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+export function discoverLocalEndpoint() {
+  try {
+    const info = JSON.parse(readFileSync(join(homedir(), ".darkbloom", "local.json"), "utf8"));
+    return { baseURL: info.base_url as string, apiKey: info.api_key as string | undefined };
+  } catch {
+    return null; // local mode not running
+  }
+}
+```
+
+## Local-first with coordinator fallback
+
+`console-ui/src/lib/localFirst.ts` prefers the local endpoint and falls back to
+the coordinator self-route on a connection failure (the Mac is asleep, you're
+away, or local mode isn't running). Fallback fires **only** on a connection-level
+error — a reachable-but-erroring local server returns its own error rather than
+silently rerouting. Both paths are free.
+
+```ts
+import { chatCompletionWithFallback } from "@/lib/localFirst";
+
+const { response, via } = await chatCompletionWithFallback(
+  { model, messages, stream: true },
+  {
+    local: discoverLocalEndpoint(),        // or null
+    coordinatorURL: "/api/chat",            // proxy, or a coordinator /v1/chat/completions
+    coordinatorApiKey: "dk-…",
+  }
+);
+// `via` is "local" or "coordinator"; stream `response` as usual.
+```
+
+## Security
+
+- **API key, not just loopback.** A loopback server with no auth is reachable by
+  any local process and — because it sends `Access-Control-Allow-Origin: *` — by
+  a hostile web page. The bearer token is the boundary. Every inference route
+  requires `Authorization: Bearer <token>`; `OPTIONS` (CORS preflight) and
+  `GET /health` / `GET /` are exempt. Comparison is constant-time; the 401
+  carries a CORS header so browsers can read it.
+- **`--bind` exposes the server to the network** (still token-gated). Prefer a
+  tailnet IP over `0.0.0.0`. The discovery record always advertises a dialable
+  loopback URL when bound to a wildcard.
+- The token persists across restarts (so existing clients keep working) and is
+  written atomically at `0600` (no umask window). The discovery file is removed
+  on graceful shutdown; because a Ctrl-C/SIGKILL/crash skips that cleanup, the
+  record carries the server `pid` and `darkbloom local` (via `readLiveInfo`)
+  treats a stale file whose process is gone as "not running" rather than
+  advertising a dead endpoint.
+
+## How it relates to self-route
+
+| | Direct (local) | Self-route (relayed) |
+|---|---|---|
+| Path | client → your Mac | client → coordinator → your Mac |
+| Best for | same machine / LAN / tailnet | remote, away from your Mac |
+| Coordinator needed | no | yes |
+| Auth | local API key | your Darkbloom API key + `X-Darkbloom-Route: self` |
+| Cost | free | free |
+
+They are complementary modes a client picks by reachability — `localFirst.ts`
+does exactly that.
+
+## Limitations / future
+
+- `--local` is a distinct serve mode: it does not also connect to the coordinator
+  (coordinator mode builds its own scheduler, so running both would load each
+  model twice). A shared-scheduler "serve publicly **and** locally at once" mode
+  is future work.
+- The hosted browser console can't read `~/.darkbloom/local.json`; a settings
+  field to paste the `darkbloom local` URL + token (then prefer it via
+  `localFirst.ts`) is a natural follow-on.

--- a/docs/self-route.md
+++ b/docs/self-route.md
@@ -1,0 +1,119 @@
+# Self-Route — free private inference on your own Mac
+
+**"Use my own machine, for free."** A consumer hitting the OpenAI-compatible
+inference endpoint can opt in to route **only** to a Darkbloom provider machine
+their own account owns. It is free (no charge, no platform fee, no provider
+payout), end-to-end encrypted as usual, and the coordinator **never falls back
+to a paid public provider** — if the owner's machine can't serve, the request
+fails with an explicit, actionable error.
+
+This turns running a provider node from "earn when idle" into "stop paying for
+your own usage **and** earn when idle," the strongest incentive to keep nodes
+online.
+
+> When the client can reach your Mac directly (same machine / LAN / tailnet),
+> **[direct mode](direct-mode.md)** skips the coordinator relay entirely —
+> lower latency, offline-capable, bytes never leave your network. Self-route is
+> the relayed path for when you're away.
+
+## Opting in
+
+Two signals, both OpenAI-client-safe:
+
+| Signal | Scope | Notes |
+|---|---|---|
+| `X-Darkbloom-Route: self` header | Per request | Invisible to the OpenAI body schema; works with any SDK (`extra_headers`). Never enters the (optionally sealed) request body. |
+| API key `self_route_only: true` | Per key (hard ceiling) | Every request on the key self-routes and is free; the key can never spend balance or reach the public fleet, regardless of header. |
+
+```bash
+curl https://api.darkbloom.dev/v1/chat/completions \
+  -H "Authorization: Bearer dk-..." \
+  -H "X-Darkbloom-Route: self" \
+  -d '{"model":"gpt-oss-20b","messages":[{"role":"user","content":"hi"}]}'
+```
+
+In the console UI: the **My Machine** toggle in the chat composer, or the
+**"My Machine only — free"** checkbox when creating/editing an API key.
+
+## Ownership model (the crux)
+
+"My machine" = a provider where `provider.AccountID == authenticated consumer
+account`. Both sides are **stamped server-side**:
+
+- `provider.AccountID` is set at WebSocket registration from the device-auth
+  token (`darkbloom login`), never from client input.
+- The consumer account id comes from `consumerKeyFromContext` (Privy / API key /
+  provider device token).
+
+The opt-in header only *requests* self-routing; it cannot *name* a machine.
+Forging would require forging both an account token and a provider device token,
+so it is unforgeable.
+
+## Routing behaviour
+
+The owner filter lives in the registry scheduler
+(`selectBestCandidateLockedFull` → `providerOwnedBy`, mirrored in
+`ReserveProviderEx`/`providerCanAdmitLocked`). A self-route request only ever
+considers providers the caller owns — across immediate dispatch, sequential
+retry, speculative backup, and the 120s queue + queue-drain.
+
+**Trust:** a personal Mac is not MDM/MDA-enrolled, so self-route relaxes the
+hardware-trust floor (`MIN_TRUST`) **for the owner's own machine only**. Every
+privacy-critical gate (runtime-verified, encrypted-chunks/SIP private-text
+support, challenge freshness) still applies — plaintext is never exposed and the
+machine remains unroutable to the **public** fleet on low trust.
+
+**Errors (no fallback):**
+
+| State | Status | code |
+|---|---|---|
+| No machine linked | 409 | `no_linked_machine` |
+| Machine(s) offline | 503 + Retry-After | `machine_offline` |
+| Online but model not loaded/in-catalog | 503 + Retry-After | `model_not_loaded` |
+| Owned machine busy (after queue) | 429 + Retry-After | `machine_busy` |
+
+## Billing
+
+Self-route skips the pre-flight reservation, the per-key spend cap, the charge,
+the platform fee, and the provider payout — a zero-balance owner is never
+blocked. A **zero-cost usage row** is still recorded for transparency.
+
+At settlement, `handleComplete` **re-verifies** that the provider which actually
+served the completion is owned by the consumer (read from the serving provider
+object, race-free across deregistration). Only then is it free; on any mismatch
+it falls back to **paid** settlement rather than grant free inference on a
+machine the caller doesn't own.
+
+**Rate limits still apply.** Account-level token (ITPM/OTPM) and request (RPM)
+limits run before the billing skip. For a typical `self_route_only` key with no
+per-key limits this is a no-op, but a configured account-tier limiter can still
+throttle free self-route. This is a deliberate abuse guard.
+
+## `private_only` provider mode (advanced)
+
+A provider can register as **private-only** so the coordinator serves it
+*exclusively* to its owner's self-route requests, never the public fleet (and it
+does not count toward public model capacity). Set it in the provider config:
+
+```toml
+[coordinator]
+private_only = true
+```
+
+This adds a `private_only` field to the registration message, mirrored across
+`coordinator/protocol/messages.go` (Go) and
+`provider-swift/Sources/ProviderCore/Protocol/Messages.swift` (Swift), with
+encode-when-true / decode-default-false symmetry on both sides.
+
+## Where it lives
+
+- **Coordinator:** `api/self_route.go` (policy + eligibility), `api/consumer.go`
+  (dispatch wiring, both handlers), `api/provider.go` (free settlement),
+  `registry/scheduler.go` + `registry/registry.go` (owner filter, trust
+  relaxation, `OwnedProviderSummary`, `private_only` gating),
+  `store/{interface,memory,postgres}.go` (`self_route_only` API-key flag).
+- **Console UI:** `lib/api.ts` (header + error mapping + types), `lib/store.ts`
+  (`useMyMachine`), `app/api/chat/route.ts` (header forwarding),
+  `components/ChatInput.tsx` + `components/api-keys/{KeyForm,KeyCard}.tsx`.
+- **Provider (Swift):** `Protocol/Messages.swift`, `Coordinator/CoordinatorClient*.swift`,
+  `Config/ProviderConfig.swift`, `ProviderLoop.swift`.

--- a/provider-swift/Sources/ProviderCore/Config/ProviderConfig.swift
+++ b/provider-swift/Sources/ProviderCore/Config/ProviderConfig.swift
@@ -98,21 +98,28 @@ public struct BackendSettings: Sendable, Equatable, Codable {
 public struct CoordinatorSettings: Sendable, Equatable, Codable {
     public var url: String
     public var heartbeatIntervalSecs: UInt64
+    /// When true, register this machine as private-only: the coordinator serves
+    /// it exclusively to the owner's own ("My Machine") requests, never the
+    /// public fleet. Set `private_only = true` under `[coordinator]` in config.
+    public var privateOnly: Bool
 
-    public init(url: String = "wss://api.darkbloom.dev/ws/provider", heartbeatIntervalSecs: UInt64 = 5) {
+    public init(url: String = "wss://api.darkbloom.dev/ws/provider", heartbeatIntervalSecs: UInt64 = 5, privateOnly: Bool = false) {
         self.url = url
         self.heartbeatIntervalSecs = heartbeatIntervalSecs
+        self.privateOnly = privateOnly
     }
 
     enum CodingKeys: String, CodingKey {
         case url
         case heartbeatIntervalSecs = "heartbeat_interval_secs"
+        case privateOnly = "private_only"
     }
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.url = try container.decodeIfPresent(String.self, forKey: .url) ?? "wss://api.darkbloom.dev/ws/provider"
         self.heartbeatIntervalSecs = try container.decodeIfPresent(UInt64.self, forKey: .heartbeatIntervalSecs) ?? 5
+        self.privateOnly = try container.decodeIfPresent(Bool.self, forKey: .privateOnly) ?? false
     }
 }
 

--- a/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClient.swift
+++ b/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClient.swift
@@ -230,6 +230,10 @@ public struct CoordinatorClientConfig: Sendable {
     public let runtimeHashes: RuntimeHashes?
     public let modelHashes: [String: String]
     public let privacyCapabilities: PrivacyCapabilities?
+    /// When true, this machine registers as private-only: the coordinator
+    /// serves it exclusively to its owner's self-route requests, never the
+    /// public fleet.
+    public let privateOnly: Bool
 
     public init(
         url: String,
@@ -243,7 +247,8 @@ public struct CoordinatorClientConfig: Sendable {
         authToken: String? = nil,
         runtimeHashes: RuntimeHashes? = nil,
         modelHashes: [String: String] = [:],
-        privacyCapabilities: PrivacyCapabilities? = nil
+        privacyCapabilities: PrivacyCapabilities? = nil,
+        privateOnly: Bool = false
     ) {
         self.url = url
         self.hardware = hardware
@@ -257,6 +262,7 @@ public struct CoordinatorClientConfig: Sendable {
         self.runtimeHashes = runtimeHashes
         self.modelHashes = modelHashes
         self.privacyCapabilities = privacyCapabilities
+        self.privateOnly = privateOnly
     }
 }
 

--- a/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClientCodec.swift
+++ b/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClientCodec.swift
@@ -22,7 +22,8 @@ public enum CoordinatorClientCodec {
             pythonHash: config.runtimeHashes?.pythonHash,
             runtimeHash: config.runtimeHashes?.runtimeHash,
             templateHashes: config.runtimeHashes?.templateHashes ?? [:],
-            privacyCapabilities: privacyCapabilities
+            privacyCapabilities: privacyCapabilities,
+            privateOnly: config.privateOnly
         ))
     }
 

--- a/provider-swift/Sources/ProviderCore/Protocol/Messages.swift
+++ b/provider-swift/Sources/ProviderCore/Protocol/Messages.swift
@@ -28,6 +28,9 @@ public enum ProviderMessage: Sendable, Equatable {
         public var runtimeHash: String?
         public var templateHashes: [String: String]
         public var privacyCapabilities: PrivacyCapabilities?
+        /// When true, this machine serves only its owner's self-route requests,
+        /// never the public fleet. Mirrors RegisterMessage.PrivateOnly (Go).
+        public var privateOnly: Bool
 
         public init(
             hardware: HardwareInfo,
@@ -44,7 +47,8 @@ public enum ProviderMessage: Sendable, Equatable {
             pythonHash: String? = nil,
             runtimeHash: String? = nil,
             templateHashes: [String: String] = [:],
-            privacyCapabilities: PrivacyCapabilities? = nil
+            privacyCapabilities: PrivacyCapabilities? = nil,
+            privateOnly: Bool = false
         ) {
             self.hardware = hardware
             self.models = models
@@ -61,6 +65,7 @@ public enum ProviderMessage: Sendable, Equatable {
             self.runtimeHash = runtimeHash
             self.templateHashes = templateHashes
             self.privacyCapabilities = privacyCapabilities
+            self.privateOnly = privateOnly
         }
     }
 
@@ -232,6 +237,7 @@ extension ProviderMessage: Codable {
         case runtimeHash = "runtime_hash"
         case templateHashes = "template_hashes"
         case privacyCapabilities = "privacy_capabilities"
+        case privateOnly = "private_only"
         // Heartbeat
         case status
         case activeModel = "active_model"
@@ -290,6 +296,9 @@ extension ProviderMessage: Codable {
                 try container.encode(r.templateHashes, forKey: .templateHashes)
             }
             try container.encodeIfPresent(r.privacyCapabilities, forKey: .privacyCapabilities)
+            if r.privateOnly {
+                try container.encode(true, forKey: .privateOnly)
+            }
 
         case .heartbeat(let h):
             try container.encode(TypeValue.heartbeat, forKey: .type)
@@ -377,7 +386,8 @@ extension ProviderMessage: Codable {
                 pythonHash: try container.decodeIfPresent(String.self, forKey: .pythonHash),
                 runtimeHash: try container.decodeIfPresent(String.self, forKey: .runtimeHash),
                 templateHashes: try container.decodeIfPresent([String: String].self, forKey: .templateHashes) ?? [:],
-                privacyCapabilities: try container.decodeIfPresent(PrivacyCapabilities.self, forKey: .privacyCapabilities)
+                privacyCapabilities: try container.decodeIfPresent(PrivacyCapabilities.self, forKey: .privacyCapabilities),
+                privateOnly: try container.decodeIfPresent(Bool.self, forKey: .privateOnly) ?? false
             ))
 
         case .heartbeat:

--- a/provider-swift/Sources/ProviderCore/ProviderLoop.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop.swift
@@ -333,7 +333,8 @@ public actor ProviderLoop {
             authToken: loopConfig.authToken,
             runtimeHashes: runtimeWithMetallib,
             modelHashes: loopConfig.modelHashes,
-            privacyCapabilities: privacyCapabilitiesForRegistration()
+            privacyCapabilities: privacyCapabilitiesForRegistration(),
+            privateOnly: loopConfig.config.coordinator.privateOnly
         )
 
         // 4. Create coordinator client and start connection

--- a/provider-swift/Sources/ProviderCore/Server/LocalAuthResponder.swift
+++ b/provider-swift/Sources/ProviderCore/Server/LocalAuthResponder.swift
@@ -1,0 +1,85 @@
+import Foundation
+import HTTPTypes
+import Hummingbird
+import NIOCore
+
+/// Bearer-token auth for the local (direct-mode) OpenAI server. Wraps the
+/// upstream router so every inference route requires `Authorization: Bearer
+/// <token>`, closing the "any local process / hostile webpage can use my GPU"
+/// hole that an unauthenticated loopback server (with `CORS: *`) has.
+///
+/// Exemptions: `OPTIONS` preflights (so CORS still works) and `GET /health` /
+/// `GET /` (liveness, no secret). When `token` is nil the responder is a
+/// pass-through, preserving the unauthenticated behaviour for explicit
+/// `--no-auth` / trusted-airgapped use and for library callers that don't opt
+/// in. The 401 carries `Access-Control-Allow-Origin: *` so browser clients can
+/// read the error body.
+public struct LocalAuthResponder<Inner: HTTPResponder>: HTTPResponder {
+    public typealias Context = Inner.Context
+
+    public let inner: Inner
+    public let token: String?
+
+    public init(inner: Inner, token: String?) {
+        self.inner = inner
+        self.token = token
+    }
+
+    public func respond(to request: Request, context: Context) async throws -> Response {
+        if LocalAuthPolicy.authorize(
+            method: request.method,
+            path: request.uri.path,
+            authorizationHeader: request.headers[.authorization],
+            token: token
+        ) {
+            return try await inner.respond(to: request, context: context)
+        }
+        return LocalAuthPolicy.unauthorizedResponse()
+    }
+}
+
+/// The pure local-auth policy, factored out of the generic responder so it can
+/// be unit-tested directly (no HTTP stack, no valid `Inner` type required).
+public enum LocalAuthPolicy {
+    /// Authorization decision:
+    ///   * nil/empty token              → open (no auth configured)
+    ///   * OPTIONS                      → allowed (CORS preflight)
+    ///   * GET/HEAD /health, /v1/health, / → allowed (liveness)
+    ///   * else                         → requires `Bearer <token>` (constant-time)
+    static func authorize(
+        method: HTTPRequest.Method,
+        path: String,
+        authorizationHeader: String?,
+        token: String?
+    ) -> Bool {
+        guard let token, !token.isEmpty else { return true }
+        if method == .options { return true }
+        let isLiveness = path == "/health" || path == "/v1/health" || path == "/"
+        if isLiveness, method == .get || method == .head { return true }
+        guard let header = authorizationHeader else { return false }
+        let prefix = "Bearer "
+        guard header.hasPrefix(prefix) else { return false }
+        let provided = String(header.dropFirst(prefix.count))
+        return constantTimeEquals(provided, token)
+    }
+
+    /// Length-checked constant-time comparison. Tokens are fixed-length, so the
+    /// early length check leaks nothing useful.
+    static func constantTimeEquals(_ a: String, _ b: String) -> Bool {
+        let ab = Array(a.utf8)
+        let bb = Array(b.utf8)
+        guard ab.count == bb.count else { return false }
+        var diff: UInt8 = 0
+        for i in ab.indices { diff |= ab[i] ^ bb[i] }
+        return diff == 0
+    }
+
+    static func unauthorizedResponse() -> Response {
+        let body = Data(#"{"error":{"message":"missing or invalid local API key — get it from `darkbloom local`","type":"authentication_error"}}"#.utf8)
+        var headers = HTTPFields()
+        headers[.contentType] = "application/json"
+        headers[.wwwAuthenticate] = "Bearer"
+        headers[.accessControlAllowOrigin] = "*"
+        return Response(status: .unauthorized, headers: headers, body: .init(byteBuffer: ByteBuffer(bytes: body)))
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Server/LocalEndpoint.swift
+++ b/provider-swift/Sources/ProviderCore/Server/LocalEndpoint.swift
@@ -1,0 +1,181 @@
+import Crypto
+import Darwin
+import Foundation
+
+/// Token + discovery-file management for **direct/local mode** — the
+/// `darkbloom start --local` OpenAI-compatible server that a consumer on the
+/// same machine (or LAN/tailnet) talks to directly, bypassing the coordinator.
+///
+/// Two artifacts live under `~/.darkbloom/` (override the directory with
+/// `DARKBLOOM_LOCAL_DIR` in tests), both written `0600`:
+///
+///   * `local_token`  — the bearer token the local server requires. Persisted
+///     so existing clients keep working across restarts. A loopback server
+///     with no auth is reachable by any local process and, because the server
+///     sends `Access-Control-Allow-Origin: *`, by a hostile web page too — so
+///     the token is the security boundary, not the loopback bind.
+///   * `local.json`   — discovery metadata (`base_url` + `api_key`) a client
+///     reads to find and authenticate to the local server.
+public enum LocalEndpoint {
+    public static let tokenPrefix = "dk-local-"
+
+    // MARK: - Directory
+
+    static func directory() -> URL {
+        if let override = ProcessInfo.processInfo.environment["DARKBLOOM_LOCAL_DIR"], !override.isEmpty {
+            return URL(fileURLWithPath: override, isDirectory: true)
+        }
+        return FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".darkbloom", isDirectory: true)
+    }
+
+    static func tokenPath() -> URL { directory().appendingPathComponent("local_token") }
+    static func infoPath() -> URL { directory().appendingPathComponent("local.json") }
+
+    // MARK: - Token
+
+    /// Load the persisted local token, or mint and persist a new one. The token
+    /// is `dk-local-<base64url(32 random bytes)>`; restricted to `0600`.
+    public static func loadOrCreateToken() throws -> String {
+        if let existing = readToken() {
+            return existing
+        }
+        let token = generateToken()
+        try writeFile(token, to: tokenPath())
+        return token
+    }
+
+    static func readToken() -> String? {
+        guard let content = try? String(contentsOf: tokenPath(), encoding: .utf8) else { return nil }
+        let trimmed = content.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    static func generateToken() -> String {
+        let raw = SymmetricKey(size: .bits256).withUnsafeBytes { Data($0) }
+        let b64url = raw.base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+        return tokenPrefix + b64url
+    }
+
+    // MARK: - Discovery file
+
+    /// Discovery metadata written by the running local server and read by
+    /// clients to locate + authenticate to it.
+    public struct Info: Codable, Sendable, Equatable {
+        public var baseURL: String
+        public var apiKey: String
+        public var host: String
+        public var port: UInt16
+        public var pid: Int32
+        public var version: String
+        public var updatedAt: String
+
+        enum CodingKeys: String, CodingKey {
+            case baseURL = "base_url"
+            case apiKey = "api_key"
+            case host
+            case port
+            case pid
+            case version
+            case updatedAt = "updated_at"
+        }
+
+        public init(host: String, port: UInt16, apiKey: String, version: String, pid: Int32, updatedAt: String) {
+            // For a client URL, an unspecified bind (0.0.0.0) is not dialable;
+            // present loopback so same-machine clients always have a usable URL.
+            let dialHost = (host == "0.0.0.0" || host.isEmpty) ? "127.0.0.1" : host
+            self.baseURL = "http://\(dialHost):\(port)/v1"
+            self.apiKey = apiKey
+            self.host = host
+            self.port = port
+            self.pid = pid
+            self.version = version
+            self.updatedAt = updatedAt
+        }
+    }
+
+    /// Write the discovery file (`0600`). Call after the server is listening.
+    public static func writeInfo(_ info: Info) throws {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let data = try encoder.encode(info)
+        let json = String(decoding: data, as: UTF8.self)
+        try writeFile(json, to: infoPath())
+    }
+
+    /// Read the discovery file, if present. Pure read — does not check whether
+    /// the recorded server process is still alive (see ``readLiveInfo()``).
+    public static func readInfo() -> Info? {
+        guard let data = try? Data(contentsOf: infoPath()) else { return nil }
+        return try? JSONDecoder().decode(Info.self, from: data)
+    }
+
+    /// Read the discovery file only if the server process that wrote it is still
+    /// running. Cleanup is best-effort (a Ctrl-C/SIGKILL/crash skips the
+    /// shutdown `defer`), so a stale `local.json` can linger pointing at a dead
+    /// server; the recorded pid is the liveness backstop. Consumers (the
+    /// `darkbloom local` command) use this so they never advertise a dead
+    /// endpoint.
+    public static func readLiveInfo() -> Info? {
+        guard let info = readInfo() else { return nil }
+        return isProcessAlive(info.pid) ? info : nil
+    }
+
+    /// True when a process with `pid` exists and is signalable by this user.
+    static func isProcessAlive(_ pid: Int32) -> Bool {
+        if pid <= 0 { return false }
+        // kill(pid, 0) probes existence without delivering a signal: 0 means
+        // alive; EPERM means alive-but-not-ours (still alive); ESRCH means gone.
+        if kill(pid, 0) == 0 { return true }
+        return errno == EPERM
+    }
+
+    /// Best-effort removal of the discovery file (on shutdown). The token file
+    /// is intentionally retained so the same token survives restarts.
+    public static func removeInfo() {
+        try? FileManager.default.removeItem(at: infoPath())
+    }
+
+    // MARK: - Shared file writer (atomic, 0600)
+
+    enum WriteError: Error { case failed(String) }
+
+    /// Write `contents` to `path` with `0600` and no umask window: create a
+    /// fresh temp file via `O_CREAT|O_EXCL|0600` (perms applied at creation),
+    /// write it fully, then atomically `rename` over the target. Both artifacts
+    /// hold a secret (the token), so neither the file nor any reader should ever
+    /// observe looser permissions or a partial write.
+    private static func writeFile(_ contents: String, to path: URL) throws {
+        let dir = path.deletingLastPathComponent()
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+
+        let tmp = dir.appendingPathComponent(".\(path.lastPathComponent).tmp-\(getpid())-\(UInt32.random(in: .min ... .max))")
+        let fd = open(tmp.path, O_CREAT | O_EXCL | O_WRONLY, 0o600)
+        guard fd >= 0 else { throw WriteError.failed("create \(tmp.lastPathComponent): \(String(cString: strerror(errno)))") }
+
+        var bytes = Array(contents.utf8)
+        var ok = true
+        bytes.withUnsafeBytes { buf in
+            var off = 0
+            while off < buf.count {
+                let n = write(fd, buf.baseAddress!.advanced(by: off), buf.count - off)
+                if n <= 0 { ok = false; break }
+                off += n
+            }
+        }
+        close(fd)
+        bytes.removeAll(keepingCapacity: false)
+
+        guard ok else {
+            unlink(tmp.path)
+            throw WriteError.failed("write \(tmp.lastPathComponent)")
+        }
+        guard rename(tmp.path, path.path) == 0 else {
+            unlink(tmp.path)
+            throw WriteError.failed("rename onto \(path.lastPathComponent): \(String(cString: strerror(errno)))")
+        }
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Server/StandaloneServer+HTTP.swift
+++ b/provider-swift/Sources/ProviderCore/Server/StandaloneServer+HTTP.swift
@@ -39,7 +39,7 @@ extension StandaloneServer {
     /// middleware onto a router returned by
     /// `MLXServerApplication.buildRouter`; wrapping the built
     /// responder is the supported alternative.
-    nonisolated func makeApplication() -> Application<CORSResponder<RouterResponder<BasicRequestContext>>> {
+    nonisolated func makeApplication() -> Application<LocalAuthResponder<CORSResponder<RouterResponder<BasicRequestContext>>>> {
         // I1: route through the single atomic-acquire entry point so a
         // concurrent eviction cannot pick the just-loaded model
         // between `ensureModelLoaded` and the reservation bump.
@@ -75,9 +75,12 @@ extension StandaloneServer {
         let service = MLXOpenAIService(engine: engine)
         let router = MLXServerApplication.buildRouter(service: service)
         let corsResponder = CORSResponder(inner: router.buildResponder())
+        // Auth is the outermost layer so an unauthenticated request is rejected
+        // before reaching the engine. Pass-through when no token is configured.
+        let authedResponder = LocalAuthResponder(inner: corsResponder, token: config.authToken)
 
         return Application(
-            responder: corsResponder,
+            responder: authedResponder,
             configuration: .init(
                 address: .hostname(config.host, port: Int(config.port)),
                 serverName: "darkbloom-provider"

--- a/provider-swift/Sources/ProviderCore/Server/StandaloneServer.swift
+++ b/provider-swift/Sources/ProviderCore/Server/StandaloneServer.swift
@@ -48,11 +48,15 @@ public struct StandaloneServerConfig: Sendable {
     public let port: UInt16
     public let host: String
     public let maxCachedModels: Int
+    /// Bearer token required on every inference route (direct/local mode).
+    /// nil = no auth (library default / explicit `--no-auth`).
+    public let authToken: String?
 
-    public init(port: UInt16 = 8000, host: String = "127.0.0.1", maxCachedModels: Int = 3) {
+    public init(port: UInt16 = 8000, host: String = "127.0.0.1", maxCachedModels: Int = 3, authToken: String? = nil) {
         self.port = port
         self.host = host
         self.maxCachedModels = max(1, maxCachedModels)
+        self.authToken = authToken
     }
 }
 

--- a/provider-swift/Sources/darkbloom/Darkbloom.swift
+++ b/provider-swift/Sources/darkbloom/Darkbloom.swift
@@ -24,6 +24,7 @@ struct Darkbloom: AsyncParsableCommand {
             Status.self,
             Doctor.self,
             Models.self,
+            Local.self,
             Login.self,
             Logout.self,
             Benchmark.self,

--- a/provider-swift/Sources/darkbloom/LocalCommand.swift
+++ b/provider-swift/Sources/darkbloom/LocalCommand.swift
@@ -1,0 +1,69 @@
+import ArgumentParser
+import Foundation
+import ProviderCore
+
+/// `darkbloom local` — print the direct/local-mode endpoint (URL + API key)
+/// for the OpenAI-compatible server started by `darkbloom start --local`, with
+/// ready-to-paste client examples. `--json` emits the raw discovery record for
+/// tooling.
+struct Local: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "local",
+        abstract: "Show the local (direct-mode) OpenAI endpoint and API key.",
+        discussion: """
+        Reads ~/.darkbloom/local.json, written by `darkbloom start --local`.
+        Point any OpenAI client at the base URL with the API key to run
+        inference on this Mac directly — free, and without the coordinator.
+        """
+    )
+
+    @Flag(help: "Emit the raw discovery record as JSON.")
+    var json = false
+
+    mutating func run() async throws {
+        Darkbloom.ensureLogging()
+
+        // readLiveInfo() returns nil when the recorded server process is gone,
+        // so a stale local.json from a Ctrl-C/crash is treated as "not running"
+        // rather than advertising a dead endpoint.
+        guard let info = LocalEndpoint.readLiveInfo() else {
+            if json {
+                print("{}")
+            } else {
+                printError("No local server running.")
+                printError("Start one with:  darkbloom start --local")
+            }
+            throw ExitCode.failure
+        }
+
+        if json {
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+            let data = (try? encoder.encode(info)) ?? Data("{}".utf8)
+            print(String(decoding: data, as: UTF8.self))
+            return
+        }
+
+        print("Local (direct-mode) OpenAI endpoint")
+        print("  base URL: \(info.baseURL)")
+        if info.apiKey.isEmpty {
+            print("  API key:  (auth disabled)")
+        } else {
+            print("  API key:  \(info.apiKey)")
+        }
+        print("  pid:      \(info.pid)")
+        print()
+        print("Use it with any OpenAI client:")
+        print("  export OPENAI_BASE_URL=\(info.baseURL)")
+        if !info.apiKey.isEmpty {
+            print("  export OPENAI_API_KEY=\(info.apiKey)")
+        }
+        print()
+        print("  curl \(info.baseURL)/chat/completions \\")
+        if !info.apiKey.isEmpty {
+            print("    -H 'Authorization: Bearer \(info.apiKey)' \\")
+        }
+        print("    -H 'Content-Type: application/json' \\")
+        print("    -d '{\"model\":\"<id>\",\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}]}'")
+    }
+}

--- a/provider-swift/Sources/darkbloom/StartCommand.swift
+++ b/provider-swift/Sources/darkbloom/StartCommand.swift
@@ -37,6 +37,12 @@ struct Start: AsyncParsableCommand {
     @Option(help: "Local server port (used with --local).")
     var port: UInt16 = 8000
 
+    @Option(help: "Bind address for --local (default 127.0.0.1; a tailnet IP exposes it to same-account devices, still API-key gated).")
+    var bind: String = "127.0.0.1"
+
+    @Flag(help: "Disable local API-key auth for --local (NOT recommended; trusted/airgapped use only).")
+    var noAuth = false
+
     mutating func run() async throws {
         Darkbloom.ensureLogging()
 
@@ -97,13 +103,36 @@ struct Start: AsyncParsableCommand {
             includeDisabled: all
         )
 
-        print("darkbloom \(ProviderCore.version) (standalone)")
-        print("Listening on 127.0.0.1:\(port)")
+        // Direct/local mode: mint (or reuse) a bearer token so the loopback
+        // server isn't open to every local process / hostile webpage. --no-auth
+        // opts out for trusted/airgapped use.
+        let token: String?
+        if noAuth {
+            token = nil
+        } else {
+            token = try LocalEndpoint.loadOrCreateToken()
+        }
+
+        let baseURL = "http://\(bind == "0.0.0.0" ? "127.0.0.1" : bind):\(port)/v1"
+        print("darkbloom \(ProviderCore.version) (local / direct mode)")
+        print("Listening on \(bind):\(port)")
         print("Models: \(advertised.count)")
         for m in advertised {
             print("  \(m.id) (\(String(format: "%.1f", m.estimatedMemoryGb)) GB)")
         }
-        print("OpenAI-compatible: GET /health, GET /v1/models, POST /v1/chat/completions")
+        print()
+        print("OpenAI-compatible endpoint:")
+        print("  base URL: \(baseURL)")
+        if let token {
+            print("  API key:  \(token)")
+            print()
+            print("  export OPENAI_BASE_URL=\(baseURL)")
+            print("  export OPENAI_API_KEY=\(token)")
+        } else {
+            print("  API key:  (auth disabled — --no-auth)")
+        }
+        print()
+        print("  Shareable any time with: darkbloom local")
         print()
 
         // Standalone mode still benefits from the PID lock + sleep prevention.
@@ -114,12 +143,27 @@ struct Start: AsyncParsableCommand {
         let server = StandaloneServer(
             config: StandaloneServerConfig(
                 port: port,
-                host: "127.0.0.1",
-                maxCachedModels: Int(clamping: config.backend.maxModelSlots)
+                host: bind,
+                maxCachedModels: Int(clamping: config.backend.maxModelSlots),
+                authToken: token
             ),
             models: advertised
         )
         try await server.start()
+
+        // Publish discovery metadata so a same-machine client (and
+        // `darkbloom local`) can find + authenticate to this server. Removed on
+        // exit; the token file persists so the token survives restarts.
+        let info = LocalEndpoint.Info(
+            host: bind,
+            port: port,
+            apiKey: token ?? "",
+            version: ProviderCore.version,
+            pid: ProcessInfo.processInfo.processIdentifier,
+            updatedAt: ISO8601DateFormatter().string(from: Date())
+        )
+        try? LocalEndpoint.writeInfo(info)
+        defer { LocalEndpoint.removeInfo() }
 
         // Wait forever (until SIGINT). In standalone mode we don't have a
         // coordinator event stream to drive the loop, so we just block.

--- a/provider-swift/Tests/ProviderCoreTests/LocalModeTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/LocalModeTests.swift
@@ -1,0 +1,145 @@
+import Foundation
+import Testing
+
+@testable import ProviderCore
+
+// A trivial inner responder is not needed: the auth policy is a pure function,
+// tested directly. This keeps the security-critical decision covered without
+// standing up a Hummingbird stack.
+
+@Test func localAuthOpenWhenNoTokenConfigured() {
+    // nil/empty token => no auth (library default / --no-auth).
+    #expect(LocalAuthPolicy.authorize(method: .post, path: "/v1/chat/completions", authorizationHeader: nil, token: nil))
+    #expect(LocalAuthPolicy.authorize(method: .post, path: "/v1/chat/completions", authorizationHeader: nil, token: ""))
+}
+
+@Test func localAuthRequiresBearerTokenForInference() {
+    let token = "dk-local-secret"
+    // No header → rejected.
+    #expect(!LocalAuthPolicy.authorize(method: .post, path: "/v1/chat/completions", authorizationHeader: nil, token: token))
+    // Wrong token → rejected.
+    #expect(!LocalAuthPolicy.authorize(method: .post, path: "/v1/chat/completions", authorizationHeader: "Bearer nope", token: token))
+    // Missing "Bearer " prefix → rejected.
+    #expect(!LocalAuthPolicy.authorize(method: .post, path: "/v1/chat/completions", authorizationHeader: token, token: token))
+    // Correct token → allowed.
+    #expect(LocalAuthPolicy.authorize(method: .post, path: "/v1/chat/completions", authorizationHeader: "Bearer \(token)", token: token))
+}
+
+@Test func localAuthExemptsPreflightAndHealth() {
+    let token = "dk-local-secret"
+    // OPTIONS preflight passes without a token (CORS).
+    #expect(LocalAuthPolicy.authorize(method: .options, path: "/v1/chat/completions", authorizationHeader: nil, token: token))
+    // Liveness endpoints pass without a token.
+    #expect(LocalAuthPolicy.authorize(method: .get, path: "/health", authorizationHeader: nil, token: token))
+    #expect(LocalAuthPolicy.authorize(method: .get, path: "/", authorizationHeader: nil, token: token))
+    // But a model-listing GET still needs the token (it reveals the catalog).
+    #expect(!LocalAuthPolicy.authorize(method: .get, path: "/v1/models", authorizationHeader: nil, token: token))
+}
+
+@Test func localAuthExemptsV1HealthAndHead() {
+    let token = "dk-local-secret"
+    // The upstream router registers /v1/health as a liveness alias too.
+    #expect(LocalAuthPolicy.authorize(method: .get, path: "/v1/health", authorizationHeader: nil, token: token))
+    #expect(LocalAuthPolicy.authorize(method: .head, path: "/health", authorizationHeader: nil, token: token))
+    // A non-liveness HEAD still requires the token.
+    #expect(!LocalAuthPolicy.authorize(method: .head, path: "/v1/models", authorizationHeader: nil, token: token))
+}
+
+@Test func localAuthConstantTimeEquals() {
+    #expect(LocalAuthPolicy.constantTimeEquals("abc", "abc"))
+    #expect(!LocalAuthPolicy.constantTimeEquals("abc", "abd"))
+    #expect(!LocalAuthPolicy.constantTimeEquals("abc", "abcd"))
+    #expect(!LocalAuthPolicy.constantTimeEquals("", "x"))
+    #expect(LocalAuthPolicy.constantTimeEquals("", ""))
+}
+
+// LocalEndpoint touches the filesystem via the DARKBLOOM_LOCAL_DIR override, so
+// these run serialized to avoid racing on the process-global env var.
+@Suite(.serialized)
+struct LocalEndpointFileTests {
+    private func withTempDir(_ body: (URL) throws -> Void) throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("dbloom-local-\(UUID().uuidString)", isDirectory: true)
+        setenv("DARKBLOOM_LOCAL_DIR", dir.path, 1)
+        defer {
+            unsetenv("DARKBLOOM_LOCAL_DIR")
+            try? FileManager.default.removeItem(at: dir)
+        }
+        try body(dir)
+    }
+
+    @Test func tokenIsMintedThenReusedWithPrefixAnd0600() throws {
+        try withTempDir { _ in
+            let first = try LocalEndpoint.loadOrCreateToken()
+            #expect(first.hasPrefix(LocalEndpoint.tokenPrefix))
+            #expect(first.count > LocalEndpoint.tokenPrefix.count + 20)
+
+            // Reused, not regenerated.
+            let second = try LocalEndpoint.loadOrCreateToken()
+            #expect(second == first)
+
+            let perms = try FileManager.default.attributesOfItem(atPath: LocalEndpoint.tokenPath().path)[.posixPermissions] as? NSNumber
+            #expect(perms?.int16Value == 0o600)
+        }
+    }
+
+    @Test func discoveryFileRoundTripsAndIsRemovable() throws {
+        try withTempDir { _ in
+            let info = LocalEndpoint.Info(
+                host: "127.0.0.1",
+                port: 8123,
+                apiKey: "dk-local-abc",
+                version: "9.9.9",
+                pid: 4242,
+                updatedAt: "2026-01-01T00:00:00Z"
+            )
+            #expect(info.baseURL == "http://127.0.0.1:8123/v1")
+            try LocalEndpoint.writeInfo(info)
+
+            let perms = try FileManager.default.attributesOfItem(atPath: LocalEndpoint.infoPath().path)[.posixPermissions] as? NSNumber
+            #expect(perms?.int16Value == 0o600)
+
+            let read = LocalEndpoint.readInfo()
+            #expect(read == info)
+
+            LocalEndpoint.removeInfo()
+            #expect(LocalEndpoint.readInfo() == nil)
+        }
+    }
+
+    @Test func infoBaseURLRewritesWildcardBindToLoopback() throws {
+        // A 0.0.0.0 bind is not dialable; the client URL must be loopback.
+        let info = LocalEndpoint.Info(host: "0.0.0.0", port: 9000, apiKey: "", version: "1", pid: 1, updatedAt: "t")
+        #expect(info.baseURL == "http://127.0.0.1:9000/v1")
+        #expect(info.host == "0.0.0.0")
+    }
+
+    @Test func readLiveInfoHonorsProcessLiveness() throws {
+        try withTempDir { _ in
+            // Our own pid is alive → readLiveInfo returns the record.
+            let live = LocalEndpoint.Info(
+                host: "127.0.0.1", port: 8000, apiKey: "k", version: "1",
+                pid: ProcessInfo.processInfo.processIdentifier, updatedAt: "t"
+            )
+            try LocalEndpoint.writeInfo(live)
+            #expect(LocalEndpoint.readLiveInfo() != nil)
+
+            // A dead pid → the file is present but readLiveInfo treats it as
+            // not-running (stale local.json from a Ctrl-C/crash).
+            let dead = LocalEndpoint.Info(
+                host: "127.0.0.1", port: 8000, apiKey: "k", version: "1",
+                pid: 999_999, updatedAt: "t"
+            )
+            try LocalEndpoint.writeInfo(dead)
+            #expect(LocalEndpoint.readInfo() != nil)
+            #expect(LocalEndpoint.readLiveInfo() == nil)
+        }
+    }
+
+    @Test func isProcessAliveDetectsSelfAndRejectsBogus() {
+        #expect(LocalEndpoint.isProcessAlive(ProcessInfo.processInfo.processIdentifier))
+        #expect(!LocalEndpoint.isProcessAlive(0))
+        #expect(!LocalEndpoint.isProcessAlive(-1))
+        #expect(!LocalEndpoint.isProcessAlive(999_999))
+    }
+}

--- a/provider-swift/Tests/ProviderCoreTests/ProtocolTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/ProtocolTests.swift
@@ -39,6 +39,34 @@ import Testing
     #expect(register.attestation?.rawBytes == rawData)
 }
 
+@Test func registerEncodesPrivateOnlyOnlyWhenTrue() throws {
+    // Default (false): the flag is omitted, mirroring the Go `omitempty` tag.
+    let off = ProviderMessage.register(ProviderMessage.Register(
+        hardware: sampleHardware(),
+        models: [sampleModel()],
+        backend: "mlx_swift_lm"
+    ))
+    let offObject = try jsonObject(try ProviderProtocolCodec.encodeProviderMessage(off))
+    #expect(offObject["private_only"] == nil)
+
+    // Explicit true: encoded as snake_case and round-trips back to true.
+    let on = ProviderMessage.register(ProviderMessage.Register(
+        hardware: sampleHardware(),
+        models: [sampleModel()],
+        backend: "mlx_swift_lm",
+        privateOnly: true
+    ))
+    let onData = try ProviderProtocolCodec.encodeProviderMessage(on)
+    let onObject = try jsonObject(onData)
+    #expect(onObject["private_only"] as? Bool == true)
+
+    let decoded = try ProviderProtocolCodec.decodeProviderMessage(from: onData)
+    guard case .register(let register) = decoded else {
+        throw TestFailure.unexpectedMessage
+    }
+    #expect(register.privateOnly == true)
+}
+
 @Test func providerMessagesRoundTripThroughCodableEnvelope() throws {
     let messages: [ProviderMessage] = [
         .register(ProviderMessage.Register(

--- a/provider-swift/Tests/ProviderCoreTests/StandaloneServerTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/StandaloneServerTests.swift
@@ -149,6 +149,69 @@ import Testing
     await server.stopAndWait()
 }
 
+// MARK: - Direct/local mode: bearer-token auth
+
+@Test func standaloneServerEnforcesBearerTokenOnInferenceRoutes() async throws {
+    let model = ModelInfo(
+        id: "mlx-community/Qwen2.5-7B-4bit",
+        modelType: "qwen2",
+        quantization: "4bit",
+        sizeBytes: 4_000_000_000,
+        estimatedMemoryGb: 4.5
+    )
+    let token = "dk-local-integration-token"
+    let server = StandaloneServer(
+        config: StandaloneServerConfig(authToken: token),
+        models: [model]
+    )
+    let app = server.makeApplication()
+
+    try await app.test(.router) { client in
+        // Health is exempt — liveness probes need no secret.
+        try await client.execute(uri: "/health", method: .get) { response in
+            #expect(response.status == .ok)
+        }
+        // /v1/models without a token → 401, with a CORS header so a browser
+        // client can still read the error body.
+        try await client.execute(uri: "/v1/models", method: .get) { response in
+            #expect(response.status == .unauthorized)
+            #expect(response.headers[.accessControlAllowOrigin] == "*")
+        }
+        // Wrong token → 401.
+        try await client.execute(
+            uri: "/v1/models",
+            method: .get,
+            headers: [.authorization: "Bearer not-the-token"]
+        ) { response in
+            #expect(response.status == .unauthorized)
+        }
+        // Correct token → 200 (advertised catalog).
+        try await client.execute(
+            uri: "/v1/models",
+            method: .get,
+            headers: [.authorization: "Bearer \(token)"]
+        ) { response in
+            #expect(response.status == .ok)
+        }
+        // OPTIONS preflight stays exempt (CORS).
+        try await client.execute(uri: "/v1/chat/completions", method: .options) { response in
+            #expect(response.status == .noContent)
+        }
+    }
+}
+
+@Test func standaloneServerWithoutTokenStaysOpen() async throws {
+    // Backward-compat / explicit --no-auth: nil token => no enforcement.
+    let model = ModelInfo(id: "m", quantization: "4bit", sizeBytes: 1, estimatedMemoryGb: 1)
+    let server = standaloneTestServer(models: [model])
+    let app = server.makeApplication()
+    try await app.test(.router) { client in
+        try await client.execute(uri: "/v1/models", method: .get) { response in
+            #expect(response.status == .ok)
+        }
+    }
+}
+
 private func standaloneTestServer(models: [ModelInfo] = []) -> StandaloneServer {
     StandaloneServer(
         models: models


### PR DESCRIPTION
## Summary

Lets a consumer route inference **only to a provider machine their own account owns** — for free, with **no fallback to paid providers** — and adds a **direct/local mode** that talks to that machine without the coordinator at all.

Running a provider node goes from "earn when idle" to "stop paying for your own usage **and** earn when idle."

## Self-route (relayed, via the coordinator)

- **Opt in** per request (`X-Darkbloom-Route: self`) or per API key (`self_route_only` — a hard ceiling that can never spend balance or reach the public fleet).
- **Ownership** = `provider.AccountID == authenticated consumer account`. Both are server-stamped (provider at registration from the device-auth token; consumer from `consumerKeyFromContext`), so nothing is forgeable — the header only *requests* self-routing, it can't *name* a machine.
- **Owner-only routing** across immediate dispatch, sequential retry, speculative backup, and the 120s queue + queue-drain. Relaxes **only** the hardware-trust floor for the owner's own machine (a personal Mac isn't MDM-enrolled); every privacy gate (runtime-verified, private-text/SIP, challenge freshness) still applies. Precise no-fallback errors: `409 no_linked_machine`, `503 machine_offline` / `model_not_loaded`, `429 machine_busy`.
- **Free settlement**: skips reservation, charge, platform fee, and provider payout; still writes a zero-cost usage row. `handleComplete` re-verifies ownership of the *serving* provider (race-free across deregistration) and falls back to **paid** on any mismatch — closing "free inference on a machine you don't own."
- **`private_only` provider mode** (serves only its owner, excluded from public routing/capacity/stats), mirrored across the Go protocol and the Swift provider.
- Persisted `self_route_only` API-key flag (memory **and** Postgres + migration) and console UI: chat **My Machine** toggle, key checkbox + "My Machine · Free" pill, error mapping, proxy header forwarding.

## Direct / local mode (no coordinator)

The provider already shipped a local OpenAI server (`darkbloom start --local`, MLX-backed) — but with `CORS: *` and **no auth**. This secures + makes it discoverable:

- **Auth**: persistent local bearer token (`~/.darkbloom/local_token`, `0600`, atomic write); `LocalAuthResponder` requires `Authorization: Bearer <token>` on inference routes (CORS preflight + liveness exempt; constant-time compare).
- **Discovery**: `~/.darkbloom/local.json` (`0600`); `darkbloom local` prints the endpoint + key + paste-ready examples, and ignores a stale file whose process is dead (pid-liveness backstop). New `--bind` / `--no-auth` flags.
- **Fallback client** (`localFirst.ts`): prefer the local endpoint, fall back to the coordinator self-route only on a connection failure.

See `docs/self-route.md` and `docs/direct-mode.md`.

## Test plan

- **Go**: registry (owner filter, trust relaxation, `private_only`, `OwnedProviderSummary`), store round-trip (memory **and** Postgres, verified against a throwaway PG16), api httptest (free happy-path, per-key flag, zero-balance success, 409 no-machine, settlement-mismatch→paid), protocol symmetry. `go build/vet` clean, all packages green.
- **Swift**: protocol `private_only` round-trip; local auth policy + real-HTTP auth (401 without token, 200 with, liveness/OPTIONS exempt); token/discovery 0600 + pid-liveness. (Full-suite MLX GPU tests need a metallib that isn't present locally — environmental.)
- **console-ui**: vitest for the key form, chat header forwarding, and local-first fallback; eslint 0 errors; `next build` OK.

Reviewed by two independent reviewers (Codex + Claude); all findings fixed (settlement deregistration race, local-mode auth TOCTOU, `/api/chat` auth header, stale discovery file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/274"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783134662&installation_id=133247490&pr_number=274&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F274&signature=d7e38bfd96fdb9ac75ca19a2df77acb71281692213df66a99ff0c6dbfb80de89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->