### PR TITLE
feat(provider): revision-aware model update with background download

### DIFF
--- a/provider-swift/Sources/ProviderCore/Models/ModelCatalog.swift
+++ b/provider-swift/Sources/ProviderCore/Models/ModelCatalog.swift
@@ -558,6 +558,53 @@ public struct ModelCatalogClient: Sendable {
     }
 }
 
+// MARK: - Revision tracking
+
+/// Revision record persisted alongside a downloaded model so a later run can
+/// tell whether the cached copy matches the catalog's current revision without
+/// re-hashing multi-GB weights. Written to
+/// `~/.cache/huggingface/hub/models--{org}--{name}/.darkbloom-revision.json`.
+public struct LocalRevision: Codable, Sendable, Equatable {
+    public let modelID: String
+    public let version: String?
+    public let aggregateSHA256: String?
+
+    public init(modelID: String, version: String?, aggregateSHA256: String?) {
+        self.modelID = modelID
+        self.version = version
+        self.aggregateSHA256 = aggregateSHA256
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case modelID = "model_id"
+        case version
+        case aggregateSHA256 = "aggregate_sha256"
+    }
+}
+
+/// How the cached copy of a model compares to the catalog's current revision.
+public enum RevisionStatus: Sendable, Equatable {
+    /// No copy of the model is present on disk.
+    case notInstalled
+    /// Cached revision matches the catalog.
+    case upToDate
+    /// Installed, but with no recorded revision (predates revision tracking)
+    /// or insufficient revision info on one side to compare.
+    case unknown
+    /// Cached revision differs from the catalog's current revision.
+    case outdated(local: String?, catalog: String?)
+}
+
+/// Result of a revision-aware download (`downloadIfOutdated`).
+public enum UpdateOutcome: Sendable, Equatable {
+    case notInstalled
+    case upToDate
+    /// Installed but with no recorded revision, and `replaceUntracked` was
+    /// false — left untouched.
+    case untracked
+    case replaced(from: String?, to: String?)
+}
+
 // MARK: - Downloader
 
 public struct ModelDownloader: Sendable {
@@ -618,10 +665,66 @@ public struct ModelDownloader: Sendable {
                 manifest = try await fetchManifestFromCDN(model: model)
             }
             try await downloadManifestModel(model: model, manifest: manifest, onProgress: onProgress)
+            try writeInstalledRevision(for: model, manifest: manifest)
             return
         }
 
         try await downloadLegacyModelFromCDN(model: model, onProgress: onProgress)
+        try writeInstalledRevision(for: model, manifest: nil)
+    }
+
+    /// Download `model` only if the locally cached revision differs from the
+    /// catalog's current revision, then atomically replace the cached copy.
+    ///
+    /// - If the model is not installed at all, returns `.notInstalled` without
+    ///   downloading -- this is an *update* operation, not a first install
+    ///   (use `download(model:)` to install).
+    /// - If the cached revision matches the catalog, returns `.upToDate`.
+    /// - If the cached revision is outdated -- or untracked when
+    ///   `replaceUntracked` is true -- the new revision is downloaded into a
+    ///   staging directory and atomically swapped in (the manifest path keeps
+    ///   the old snapshot serving until the swap), returning `.replaced`.
+    ///
+    /// `replaceUntracked` defaults to false so that installs predating revision
+    /// tracking are left in place rather than re-downloaded en masse the first
+    /// time this runs; pass true to force-refresh and record their revision.
+    @discardableResult
+    public func downloadIfOutdated(
+        model: CatalogModel,
+        replaceUntracked: Bool = false,
+        onProgress: (@Sendable (ProgressEvent) -> Void)? = nil
+    ) async throws -> UpdateOutcome {
+        let status = ModelDownloader.revisionStatus(for: model)
+        switch status {
+        case .notInstalled:
+            return .notInstalled
+        case .upToDate:
+            return .upToDate
+        case .unknown where !replaceUntracked:
+            return .untracked
+        case .outdated, .unknown:
+            let previous = ModelDownloader.localRevision(for: model.id)
+            try await download(model: model, onProgress: onProgress)
+            return .replaced(
+                from: previous?.version ?? previous?.aggregateSHA256,
+                to: model.version ?? model.aggregateSHA256
+            )
+        }
+    }
+
+    /// Persist the installed revision next to the model's cache directory.
+    /// Prefers the manifest's values (most precise) and falls back to the
+    /// catalog entry for legacy (manifest-less) downloads.
+    private func writeInstalledRevision(for model: CatalogModel, manifest: ModelManifest?) throws {
+        let revision = LocalRevision(
+            modelID: model.id,
+            version: manifest?.version ?? model.version,
+            aggregateSHA256: manifest?.aggregateSHA256 ?? model.aggregateSHA256
+        )
+        try ModelDownloader.writeRevision(
+            revision,
+            modelDir: ModelDownloader.cacheModelDirectory(for: model.id)
+        )
     }
 
     private func fetchManifestFromCDN(model: CatalogModel) async throws -> ModelManifest {
@@ -953,6 +1056,68 @@ public struct ModelDownloader: Sendable {
         guard FileManager.default.fileExists(atPath: modelDir.path) else { return false }
         try FileManager.default.removeItem(at: modelDir)
         return true
+    }
+
+    // MARK: - Revision tracking
+
+    /// Filename recording the installed revision of a model, written next to
+    /// the HuggingFace `snapshots/` and `refs/` directories.
+    static let revisionFileName = ".darkbloom-revision.json"
+
+    static func revisionFileURL(modelDir: URL) -> URL {
+        modelDir.appendingPathComponent(revisionFileName)
+    }
+
+    /// Read the recorded revision for a model directory, if present.
+    static func readRevision(modelDir: URL) -> LocalRevision? {
+        guard let data = try? Data(contentsOf: revisionFileURL(modelDir: modelDir)) else { return nil }
+        return try? JSONDecoder().decode(LocalRevision.self, from: data)
+    }
+
+    /// Persist the revision for a model directory (atomic write).
+    static func writeRevision(_ revision: LocalRevision, modelDir: URL) throws {
+        try FileManager.default.createDirectory(at: modelDir, withIntermediateDirectories: true)
+        let data = try JSONEncoder().encode(revision)
+        try data.write(to: revisionFileURL(modelDir: modelDir), options: .atomic)
+    }
+
+    /// The recorded revision for a cached model ID, or nil if the model is not
+    /// installed or predates revision tracking.
+    public static func localRevision(for modelID: String) -> LocalRevision? {
+        readRevision(modelDir: cacheModelDirectory(for: modelID))
+    }
+
+    /// Pure comparison of a recorded local revision against a catalog entry.
+    /// Factored out (and `internal`) so it can be unit-tested without touching
+    /// the on-disk cache. Callers should use `revisionStatus(for:)`.
+    ///
+    /// Prefers the content hash (`aggregate_sha256`) when both sides advertise
+    /// one -- it detects re-publishes that reuse the same version string -- and
+    /// falls back to the version string otherwise.
+    static func compareRevision(local: LocalRevision?, installed: Bool, catalog: CatalogModel) -> RevisionStatus {
+        guard installed else { return .notInstalled }
+        guard let local else { return .unknown }
+
+        if let localAgg = local.aggregateSHA256, let catAgg = catalog.aggregateSHA256 {
+            return localAgg == catAgg
+                ? .upToDate
+                : .outdated(local: local.version ?? localAgg, catalog: catalog.version ?? catAgg)
+        }
+        if let localVer = local.version, let catVer = catalog.version {
+            return localVer == catVer
+                ? .upToDate
+                : .outdated(local: localVer, catalog: catVer)
+        }
+        // Not enough revision info on one side to compare.
+        return .unknown
+    }
+
+    /// Determine whether the cached copy of `model` matches the catalog's
+    /// current revision.
+    public static func revisionStatus(for model: CatalogModel) -> RevisionStatus {
+        let modelDir = cacheModelDirectory(for: model.id)
+        let installed = FileManager.default.fileExists(atPath: modelDir.path)
+        return compareRevision(local: readRevision(modelDir: modelDir), installed: installed, catalog: model)
     }
 
     // MARK: - Internals

--- a/provider-swift/Sources/darkbloom/ModelsCommand.swift
+++ b/provider-swift/Sources/darkbloom/ModelsCommand.swift
@@ -10,11 +10,12 @@ struct Models: AsyncParsableCommand {
           catalog   Show available models with download status (default).
           list      Show local models only.
           download  Download a catalog model into ~/.cache/huggingface/hub.
+          update    Re-download installed models whose catalog revision changed.
           remove    Delete a downloaded model.
 
         With no subcommand, shows the full catalog.
         """,
-        subcommands: [Catalog.self, List.self, Download.self, Remove.self],
+        subcommands: [Catalog.self, List.self, Download.self, Update.self, Remove.self],
         defaultSubcommand: Catalog.self
     )
 }
@@ -141,7 +142,13 @@ extension Models {
                 for entry in entries {
                     let mark = downloadedIDs.contains(entry.id) ? "✓" : " "
                     let mem = entry.minRamGb.map { " (≥ \($0) GB RAM)" } ?? ""
-                    print("  \(mark) \(entry.displayName)  [\(entry.id)]  ~\(String(format: "%.1f", entry.sizeGb)) GB\(mem)")
+                    let update: String
+                    if case .outdated = ModelDownloader.revisionStatus(for: entry) {
+                        update = "  ⬆ update available (darkbloom models update \(entry.id))"
+                    } else {
+                        update = ""
+                    }
+                    print("  \(mark) \(entry.displayName)  [\(entry.id)]  ~\(String(format: "%.1f", entry.sizeGb)) GB\(mem)\(update)")
                 }
             }
 
@@ -213,6 +220,183 @@ extension Models {
             }
 
             print("Done. Cached at \(ModelDownloader.cacheModelDirectory(for: entry.id).path)")
+        }
+    }
+}
+
+// MARK: - update
+
+extension Models {
+    struct Update: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            abstract: "Re-download installed models whose catalog revision changed.",
+            discussion: """
+            Compares the recorded revision of each locally installed model
+            against the coordinator catalog. When a model's revision has
+            changed, the new revision is downloaded into a staging directory
+            and atomically swapped in, replacing the old copy.
+
+            Models that are not installed are skipped -- this updates existing
+            copies only; use `darkbloom models download <id>` to install.
+
+            With no <model-id>, every installed catalog model is checked.
+            With --background, the update runs in a detached process and logs
+            to ~/.darkbloom/model-update.log so it survives the shell exiting.
+            """
+        )
+
+        @OptionGroup var configOptions: ConfigOptions
+
+        @Argument(help: "Model ID to update. Omit to check all installed models.")
+        var modelID: String?
+
+        @Option(help: "Override coordinator URL.")
+        var coordinator: String?
+
+        @Option(help: "Override the R2 CDN base URL.")
+        var r2CDN: String?
+
+        @Flag(help: "Also re-download installed models that have no recorded revision (predating revision tracking).")
+        var includeUntracked = false
+
+        @Flag(help: "Run the update in a detached background process.")
+        var background = false
+
+        /// Log file for `--background` runs.
+        static func backgroundLogURL() -> URL {
+            FileManager.default.homeDirectoryForCurrentUser
+                .appendingPathComponent(".darkbloom/model-update.log")
+        }
+
+        mutating func run() async throws {
+            if background {
+                try launchInBackground()
+                return
+            }
+
+            let snapshot = try loadRuntimeSnapshot(configOptions: configOptions)
+            let coordinatorURL = coordinator ?? snapshot.config.coordinator.url
+            let client = ModelCatalogClient(coordinatorURL: coordinatorURL)
+
+            let catalog: [CatalogModel]
+            do {
+                catalog = try await client.fetchCatalog(typeFilter: nil)
+            } catch let error as ModelCatalogError {
+                printError("could not fetch catalog: \(error)")
+                throw ExitCode.failure
+            }
+
+            // Resolve the set of catalog entries to check.
+            let targets: [CatalogModel]
+            if let modelID {
+                guard let entry = catalog.first(where: { $0.id == modelID || $0.s3Name == modelID }) else {
+                    printError("model '\(modelID)' is not in the coordinator catalog")
+                    printError("hint: list available IDs with `darkbloom models catalog`")
+                    throw ExitCode.failure
+                }
+                targets = [entry]
+            } else {
+                // All installed catalog models (skip not-installed silently).
+                targets = catalog.filter {
+                    ModelDownloader.revisionStatus(for: $0) != .notInstalled
+                }
+            }
+
+            if targets.isEmpty {
+                print("No installed models to check.")
+                return
+            }
+
+            let downloader = ModelDownloader(r2CDNURL: r2CDN, catalogClient: client)
+            var replaced = 0
+            var failures = 0
+
+            for entry in targets {
+                let status = ModelDownloader.revisionStatus(for: entry)
+                switch status {
+                case .notInstalled:
+                    // Only reachable for an explicit <model-id>.
+                    print("\(entry.id): not installed — skipping (use `models download`).")
+                case .upToDate:
+                    print("\(entry.id): up to date.")
+                case .unknown where !includeUntracked:
+                    print("\(entry.id): no recorded revision — skipping (pass --include-untracked to re-download).")
+                case .unknown, .outdated:
+                    switch status {
+                    case .outdated(let local, let remote):
+                        print("\(entry.id): outdated (\(local ?? "?") → \(remote ?? "?")) — downloading…")
+                    default:
+                        print("\(entry.id): no recorded revision — re-downloading current revision…")
+                    }
+                    do {
+                        let outcome = try await downloader.downloadIfOutdated(
+                            model: entry,
+                            replaceUntracked: includeUntracked
+                        ) { progress in
+                            let mb = Double(progress.bytesDownloaded) / 1_048_576
+                            print("  ✓ \(progress.file)  \(String(format: "%.1f MB", mb))")
+                        }
+                        if case .replaced(let from, let to) = outcome {
+                            print("\(entry.id): replaced \(from ?? "?") → \(to ?? "?").")
+                            replaced += 1
+                        }
+                    } catch let error as ModelCatalogError {
+                        printError("\(entry.id): \(error)")
+                        failures += 1
+                    }
+                }
+            }
+
+            print("Done. \(replaced) replaced, \(failures) failed, \(targets.count) checked.")
+            if failures > 0 { throw ExitCode.failure }
+        }
+
+        /// Re-exec this command (minus --background) as a detached child whose
+        /// output is appended to `model-update.log`, then return immediately.
+        private func launchInBackground() throws {
+            guard let executable = Bundle.main.executablePath else {
+                printError("could not determine the darkbloom executable path")
+                throw ExitCode.failure
+            }
+
+            var childArgs = ["models", "update"]
+            if let modelID { childArgs.append(modelID) }
+            if let coordinator { childArgs += ["--coordinator", coordinator] }
+            if let r2CDN { childArgs += ["--r2-cdn", r2CDN] }
+            if includeUntracked { childArgs.append("--include-untracked") }
+            if let config = configOptions.config { childArgs += ["--config", config] }
+
+            let logURL = Self.backgroundLogURL()
+            let fm = FileManager.default
+            try fm.createDirectory(at: logURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+            if !fm.fileExists(atPath: logURL.path) {
+                fm.createFile(atPath: logURL.path, contents: nil)
+            }
+            let handle = try FileHandle(forWritingTo: logURL)
+            handle.seekToEndOfFile()
+
+            let process = Process()
+            process.executableURL = URL(fileURLWithPath: executable)
+            process.arguments = childArgs
+            process.standardInput = FileHandle.nullDevice
+            process.standardOutput = handle
+            process.standardError = handle
+            // Suppress the child's startup update banner so logs stay focused.
+            var env = ProcessInfo.processInfo.environment
+            env["DARKBLOOM_NO_UPDATE_CHECK"] = "1"
+            process.environment = env
+
+            do {
+                try process.run()
+            } catch {
+                printError("could not start background update: \(error.localizedDescription)")
+                throw ExitCode.failure
+            }
+
+            // Detach: do not wait. The child is reparented to launchd when we
+            // exit and keeps running.
+            print("Model update running in background (pid \(process.processIdentifier)).")
+            print("Logs: \(logURL.path)")
         }
     }
 }

--- a/provider-swift/Tests/ProviderCoreTests/ModelCatalogTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/ModelCatalogTests.swift
@@ -262,6 +262,100 @@ struct ModelCatalogTests {
         #expect(!snapshotEntries.contains { $0.hasPrefix(".local-staging-") })
     }
 
+    // MARK: - Revision tracking
+
+    private func makeCatalogModel(
+        id: String = "org/model",
+        version: String? = nil,
+        aggregateSHA256: String? = nil
+    ) -> CatalogModel {
+        CatalogModel(
+            id: id,
+            s3Name: "model",
+            displayName: "Model",
+            sizeGb: 1.0,
+            version: version,
+            aggregateSHA256: aggregateSHA256
+        )
+    }
+
+    @Test("compareRevision reports notInstalled when the model is absent")
+    func compareRevisionNotInstalled() {
+        let status = ModelDownloader.compareRevision(
+            local: nil,
+            installed: false,
+            catalog: makeCatalogModel(version: "v2", aggregateSHA256: "bbbb")
+        )
+        #expect(status == .notInstalled)
+    }
+
+    @Test("compareRevision reports unknown when installed without a recorded revision")
+    func compareRevisionUnknownWhenUntracked() {
+        let status = ModelDownloader.compareRevision(
+            local: nil,
+            installed: true,
+            catalog: makeCatalogModel(version: "v2", aggregateSHA256: "bbbb")
+        )
+        #expect(status == .unknown)
+    }
+
+    @Test("compareRevision prefers the aggregate hash over the version string")
+    func compareRevisionPrefersAggregateHash() {
+        // Version strings match but content hashes differ -> outdated.
+        let local = LocalRevision(modelID: "org/model", version: "v1", aggregateSHA256: "aaaa")
+        let outdated = ModelDownloader.compareRevision(
+            local: local,
+            installed: true,
+            catalog: makeCatalogModel(version: "v1", aggregateSHA256: "bbbb")
+        )
+        #expect(outdated == .outdated(local: "v1", catalog: "v1"))
+
+        // Same content hash -> up to date even if version strings differ.
+        let upToDate = ModelDownloader.compareRevision(
+            local: LocalRevision(modelID: "org/model", version: "v1", aggregateSHA256: "aaaa"),
+            installed: true,
+            catalog: makeCatalogModel(version: "v2", aggregateSHA256: "aaaa")
+        )
+        #expect(upToDate == .upToDate)
+    }
+
+    @Test("compareRevision falls back to the version string when no hashes are present")
+    func compareRevisionFallsBackToVersion() {
+        let outdated = ModelDownloader.compareRevision(
+            local: LocalRevision(modelID: "org/model", version: "v1", aggregateSHA256: nil),
+            installed: true,
+            catalog: makeCatalogModel(version: "v2", aggregateSHA256: nil)
+        )
+        #expect(outdated == .outdated(local: "v1", catalog: "v2"))
+
+        let upToDate = ModelDownloader.compareRevision(
+            local: LocalRevision(modelID: "org/model", version: "v2", aggregateSHA256: nil),
+            installed: true,
+            catalog: makeCatalogModel(version: "v2", aggregateSHA256: nil)
+        )
+        #expect(upToDate == .upToDate)
+    }
+
+    @Test("revision file round-trips through write and read")
+    func revisionFileRoundTrips() throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("darkbloom-rev-test-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let revision = LocalRevision(modelID: "org/model", version: "2026-06-01", aggregateSHA256: "feedface")
+        try ModelDownloader.writeRevision(revision, modelDir: dir)
+
+        let readBack = ModelDownloader.readRevision(modelDir: dir)
+        #expect(readBack == revision)
+    }
+
+    @Test("readRevision returns nil for a directory with no revision file")
+    func readRevisionMissingFile() {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("darkbloom-rev-missing-\(UUID().uuidString)", isDirectory: true)
+        #expect(ModelDownloader.readRevision(modelDir: dir) == nil)
+    }
+
 }
 
 // Mirror of the private wrapper used inside ModelCatalog.swift so we can


### PR DESCRIPTION
## What

Adds the ability to **download a newer model revision in the background and replace the cached copy** (Slack request).

### New: `darkbloom models update [<model-id>]`
Compares each installed model's recorded revision against the coordinator catalog; when a model's revision changed, downloads the new revision into a staging dir and **atomically swaps it in** (the manifest path keeps the old snapshot serving until the swap completes). Flags:
- `--background` — runs the update in a detached child process, logging to `~/.darkbloom/model-update.log` so it survives the shell exiting.
- `--include-untracked` — also refresh installed models that predate revision tracking (off by default, so the first run doesn't re-download the whole cache).
- `--coordinator` / `--r2-cdn` overrides, mirroring `models download`.

With no `<model-id>`, every installed catalog model is checked. Not-installed models are skipped (this updates existing copies; use `models download` to install).

### Revision tracking
- After every download, persist a per-model `.darkbloom-revision.json` (`version` + `aggregate_sha256`) next to the HF `snapshots/`/`refs/` dirs.
- `ModelDownloader.revisionStatus(for:)` compares it to the catalog — prefers the content hash (catches re-publishes that reuse a version string), falls back to the version string.
- New reusable API: `localRevision(for:)`, `revisionStatus(for:)`, `downloadIfOutdated(model:replaceUntracked:onProgress:)`.

### UX
- `models catalog` now flags entries that have an update available.

## Tests
- Unit tests for the pure revision comparison (`compareRevision`) and the revision-file read/write round-trip in `ModelCatalogTests`.

## Design notes
- Deliberately scoped to an **operator-initiated CLI**, not an in-process hot-swap inside the running attested provider — swapping attested weights at runtime has attestation implications and was left out of scope.
- `aggregate_sha256` is the primary revision key; `version` is the fallback.

## ⚠️ Not built here
`provider-swift` is macOS-only (Darwin / MLX / Metal) and was **not compiled** in the Linux authoring sandbox (no Swift toolchain). CI / a macOS build must verify compilation and run the tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/280"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783361513&installation_id=133247490&pr_number=280&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F280&signature=e36f292bdf2eddc95c51536591c478bf77723af0f7ce9ba10d46ffc17d942d4b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->