### PR TITLE
Add explicit return type annotation to ProvidersPage

### DIFF
--- a/console-ui/src/app/providers/page.tsx
+++ b/console-ui/src/app/providers/page.tsx
@@ -1,5 +1,5 @@
 import ProviderDashboardContent from "./ProviderDashboardContent";
 
-export default function ProvidersPage() {
+export default function ProvidersPage(): JSX.Element {
   return <ProviderDashboardContent />;
 }


### PR DESCRIPTION
## 问题背景

公共函数 `ProvidersPage` 缺少显式的返回类型注解。在 TypeScript 中，这可能导致类型推断不明确，降低代码的可读性和维护性。显式的类型注解有助于开发者快速理解函数的返回类型，并减少潜在的类型错误。

## 修改内容

- 为 `ProvidersPage` 函数添加了返回类型 `JSX.Element` 的显式注解。

## 验证方式

- 运行 TypeScript 编译器（如 `tsc`）以确保没有引入类型错误。
- 功能保持不变，因为添加类型注解不会改变代码的运行时行为。

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/285"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783390146&installation_id=133247490&pr_number=285&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F285&signature=e83c81414e7b701703e00f95115ea9935c757630062f8b11ca1afb866de02845"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->