### PR TITLE
feat(attestation): APNs-based provider code-identity attestation (v0.6.0)

### DIFF
--- a/.github/workflows/release-swift.yml
+++ b/.github/workflows/release-swift.yml
@@ -323,6 +323,18 @@ jobs:
           if app_id and not (app_id.endswith('io.darkbloom.provider') or app_id.endswith('*')):
               errors.append(f"application-identifier mismatch: {app_id}")
 
+          # v0.6.0 APNs code-identity: the embedded profile MUST grant
+          # aps-environment=production, or the signed binary AMFI-kills at launch
+          # (restricted entitlement without an authorizing profile). This is the
+          # only build-time guard against shipping the entitlement with a stale,
+          # non-push profile. Profiles key it short ('aps-environment') or long.
+          aps = ents.get('aps-environment') or ents.get('com.apple.developer.aps-environment')
+          if aps != 'production':
+              errors.append(
+                  f"profile does not grant aps-environment=production (got {aps!r}); "
+                  "regenerate the push-enabled provisioning profile and update PROVISIONING_PROFILE_BASE64"
+              )
+
           expiry = p.get('ExpirationDate')
           if expiry is not None:
               # ExpirationDate is a naive UTC datetime from plistlib.
@@ -436,6 +448,31 @@ jobs:
             echo "$ENTITLEMENTS"
             exit 1
           fi
+          # v0.6.0 APNs code-identity assertions on the signed CLI:
+          #   (a) aps-environment present AND == production (parse the value, not a
+          #       bare grep — a dev profile would set 'development' and silently
+          #       register against the wrong APNs host).
+          #   (b) get-task-allow ABSENT — its absence (not "hardened runtime" per
+          #       se) is what blocks even-root debugger attach / dylib injection;
+          #       Developer ID + notarization strips it.
+          rm -f /tmp/cli-ents.plist
+          codesign -d --entitlements /tmp/cli-ents.plist --xml "$APP/Contents/MacOS/$CLI_NAME" 2>/dev/null || true
+          # Fail loudly if extraction produced nothing — otherwise the
+          # get-task-allow check below would pass vacuously on an empty file.
+          if [ ! -s /tmp/cli-ents.plist ]; then
+            echo "::error::Failed to extract entitlements from signed CLI for APNs/get-task-allow verification"
+            exit 1
+          fi
+          APS_ENV=$(/usr/libexec/PlistBuddy -c 'Print :com.apple.developer.aps-environment' /tmp/cli-ents.plist 2>/dev/null || echo "")
+          if [ "$APS_ENV" != "production" ]; then
+            echo "::error::Signed CLI aps-environment must be 'production' (got '${APS_ENV:-<absent>}'). Regenerate the push provisioning profile + entitlements (v0.6.0 APNs code-identity)."
+            exit 1
+          fi
+          if /usr/libexec/PlistBuddy -c 'Print :com.apple.security.get-task-allow' /tmp/cli-ents.plist 2>/dev/null | grep -qi true; then
+            echo "::error::Signed CLI has get-task-allow=true — defeats even-root injection resistance. It must be absent (Developer ID + notarized strips it)."
+            exit 1
+          fi
+          echo "APNs code-identity entitlements verified: aps-environment=production, get-task-allow absent"
           if [ "${{ steps.profile.outputs.profile_available }}" = "true" ]; then
             if [ ! -f "$APP/Contents/embedded.provisionprofile" ]; then
               echo "::error::Provisioning profile secret set but not embedded in app bundle"

--- a/coordinator/api/code_attestation_integration_test.go
+++ b/coordinator/api/code_attestation_integration_test.go
@@ -1,0 +1,187 @@
+package api
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/asn1"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"math/big"
+	"testing"
+
+	"github.com/eigeninference/d-inference/coordinator/apns"
+	"github.com/eigeninference/d-inference/coordinator/attestation"
+	"github.com/eigeninference/d-inference/coordinator/internal/e2e"
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+	"github.com/eigeninference/d-inference/coordinator/registry"
+	"github.com/eigeninference/d-inference/coordinator/store"
+)
+
+// fakeCodeAttestor simulates the FULL APNs round-trip in-process — no real APNs.
+// On SendCodeChallenge it (1) builds the REAL E_K(nonce) payload exactly as the
+// production APNsPushAttestor would (exercising the coordinator encrypt path),
+// then (2) simulates the genuine provider: decrypts with K, signs the recovered
+// nonce with the SE key, and delivers a code_attestation_response into the
+// tracker exactly as the WebSocket read loop does on a real reply.
+type fakeCodeAttestor struct {
+	onSend func(deviceToken, env, pubKeyB64, nonceB64 string) error
+}
+
+func (f *fakeCodeAttestor) SendCodeChallenge(_ context.Context, deviceToken, env, pubKeyB64, nonceB64 string) error {
+	return f.onSend(deviceToken, env, pubKeyB64, nonceB64)
+}
+
+func quietLogger() *slog.Logger { return slog.New(slog.NewTextHandler(io.Discard, nil)) }
+
+// marshalP256 returns the uncompressed (0x04||X||Y) encoding ParseP256PublicKey expects.
+func marshalP256(pub *ecdsa.PublicKey) []byte {
+	out := make([]byte, 65)
+	out[0] = 0x04
+	pub.X.FillBytes(out[1:33])
+	pub.Y.FillBytes(out[33:65])
+	return out
+}
+
+// signSEOverString produces base64(DER ECDSA) over SHA-256(data) — the exact
+// shape attestation.VerifyChallengeSignature verifies (and the Swift SE signer
+// produces). This stands in for the provider's Sign_SE.
+func signSEOverString(t *testing.T, key *ecdsa.PrivateKey, data string) string {
+	t.Helper()
+	h := sha256.Sum256([]byte(data))
+	r, s, err := ecdsa.Sign(rand.Reader, key, h[:])
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	der, err := asn1.Marshal(struct{ R, S *big.Int }{r, s})
+	if err != nil {
+		t.Fatalf("marshal sig: %v", err)
+	}
+	return base64.StdEncoding.EncodeToString(der)
+}
+
+// providerKeyMaterial generates the two distinct provider keys: the X25519 K
+// (encrypt/decrypt only) and the Secure-Enclave P-256 signing key.
+func providerKeyMaterial(t *testing.T) (kPubB64 string, kPriv [32]byte, seKey *ecdsa.PrivateKey, sePubB64 string) {
+	t.Helper()
+	k, err := e2e.GenerateSessionKeys()
+	if err != nil {
+		t.Fatalf("gen K: %v", err)
+	}
+	se, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("gen SE: %v", err)
+	}
+	return base64.StdEncoding.EncodeToString(k.PublicKey[:]), k.PrivateKey, se,
+		base64.StdEncoding.EncodeToString(marshalP256(&se.PublicKey))
+}
+
+func newCodeAttestProvider(kPubB64, sePubB64 string) *registry.Provider {
+	return &registry.Provider{
+		ID:                "p1",
+		PublicKey:         kPubB64,
+		APNsDeviceToken:   "devtok",
+		APNsEnvironment:   "production",
+		AttestationResult: &attestation.VerificationResult{Valid: true, PublicKey: sePubB64},
+	}
+}
+
+// TestCodeIdentityRoundTripEndToEnd is the Phase 3 correctness gate: the full
+// crypto round-trip — coordinator generates a nonce → real E_K(nonce) encrypt →
+// genuine-provider decrypt with K → Sign_SE over the recovered nonce → WS reply →
+// coordinator verifies (nonce match + SE signature) → CodeAttested flips true.
+func TestCodeIdentityRoundTripEndToEnd(t *testing.T) {
+	logger := quietLogger()
+	srv := NewServer(registry.New(logger), store.NewMemory(store.Config{}), ServerConfig{}, logger)
+
+	kPubB64, kPriv, seKey, sePubB64 := providerKeyMaterial(t)
+	ct := newCodeAttestTracker()
+
+	fake := &fakeCodeAttestor{onSend: func(_, _, pubKeyB64, nonceB64 string) error {
+		// (1) Real coordinator-side build: E_K(nonce) via the inference E2E path.
+		payload, err := apns.BuildCodeChallengePayload(nonceB64, pubKeyB64, apns.ModeBackground)
+		if err != nil {
+			return err
+		}
+		// (2) Genuine provider sim: decrypt code_challenge with K's private key.
+		var body struct {
+			CodeChallenge e2e.EncryptedPayload `json:"code_challenge"`
+		}
+		if err := json.Unmarshal(payload, &body); err != nil {
+			return err
+		}
+		recovered, err := e2e.DecryptWithPrivateKey(&body.CodeChallenge, kPriv)
+		if err != nil {
+			return err
+		}
+		// Sign the recovered nonce with the SE key and reply over the WS (tracker).
+		sig := signSEOverString(t, seKey, string(recovered))
+		go ct.deliver(&protocol.CodeAttestationResponseMessage{
+			Type:      protocol.TypeCodeAttestationResponse,
+			Nonce:     string(recovered),
+			Signature: sig,
+		})
+		return nil
+	}}
+	srv.SetCodeAttestor(fake)
+
+	provider := newCodeAttestProvider(kPubB64, sePubB64)
+	srv.sendCodeIdentityChallenge(context.Background(), "p1", provider, ct)
+
+	if !provider.GetCodeAttested() {
+		t.Fatal("expected CodeAttested=true after a valid end-to-end round-trip")
+	}
+}
+
+// TestCodeIdentityRejectsWrongSEKey proves fail-closed: a response whose nonce
+// decrypts correctly (proving K) but is signed by a DIFFERENT SE key (not the
+// one bound at registration) must NOT attest — defending against a fork that
+// received a relayed challenge but holds its own SE key.
+func TestCodeIdentityRejectsWrongSEKey(t *testing.T) {
+	logger := quietLogger()
+	srv := NewServer(registry.New(logger), store.NewMemory(store.Config{}), ServerConfig{}, logger)
+
+	kPubB64, kPriv, _, sePubB64 := providerKeyMaterial(t)
+	wrongSE, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("gen wrong SE: %v", err)
+	}
+	ct := newCodeAttestTracker()
+
+	fake := &fakeCodeAttestor{onSend: func(_, _, pubKeyB64, nonceB64 string) error {
+		payload, err := apns.BuildCodeChallengePayload(nonceB64, pubKeyB64, apns.ModeBackground)
+		if err != nil {
+			return err
+		}
+		var body struct {
+			CodeChallenge e2e.EncryptedPayload `json:"code_challenge"`
+		}
+		if err := json.Unmarshal(payload, &body); err != nil {
+			return err
+		}
+		recovered, err := e2e.DecryptWithPrivateKey(&body.CodeChallenge, kPriv)
+		if err != nil {
+			return err
+		}
+		// Signed by the WRONG SE key — must fail verification.
+		sig := signSEOverString(t, wrongSE, string(recovered))
+		go ct.deliver(&protocol.CodeAttestationResponseMessage{
+			Type:      protocol.TypeCodeAttestationResponse,
+			Nonce:     string(recovered),
+			Signature: sig,
+		})
+		return nil
+	}}
+	srv.SetCodeAttestor(fake)
+
+	provider := newCodeAttestProvider(kPubB64, sePubB64) // bound to the REAL SE key
+	srv.sendCodeIdentityChallenge(context.Background(), "p1", provider, ct)
+
+	if provider.GetCodeAttested() {
+		t.Fatal("CodeAttested must stay false when the SE signature is from the wrong key")
+	}
+}

--- a/coordinator/api/provider.go
+++ b/coordinator/api/provider.go
@@ -490,6 +490,9 @@ func (s *Server) sendCodeIdentityChallenge(ctx context.Context, providerID strin
 		}
 		provider.SetCodeAttested(true)
 		s.logger.Info("provider code-attested via APNs", "provider_id", providerID)
+		// Newly eligible for private routing — drain requests that queued waiting
+		// for an attested provider instead of waiting for the next heartbeat tick.
+		s.registry.DrainQueuedRequestsForProvider(provider)
 	case <-time.After(CodeAttestResponseTimeout):
 		s.logger.Warn("code-attest timed out awaiting WebSocket response", "provider_id", providerID)
 	case <-ctx.Done():

--- a/coordinator/api/provider.go
+++ b/coordinator/api/provider.go
@@ -966,8 +966,12 @@ func (s *Server) verifyChallengeResponse(providerID string, provider *registry.P
 	// Verify fresh binary hash when a known-good policy is configured. A
 	// reported binary hash only counts when the response is signed by the
 	// provider key from a valid registration attestation.
+	//
+	// v0.6.0: binaryHash is self-reported and demoted to drift telemetry — APNs
+	// code-identity attestation is the real code-identity signal — so this gate
+	// deroutes a provider only when enforcement is explicitly enabled (rollback).
 	policyConfigured, knownBinaryHashes := s.binaryHashPolicySnapshot()
-	if policyConfigured {
+	if s.binaryHashEnforce && policyConfigured {
 		attestationResult := provider.AttestationResult
 		if attestationResult == nil || !attestationResult.Valid || attestationResult.PublicKey == "" {
 			s.logger.Error("provider cannot prove binary hash without valid attestation",
@@ -1816,7 +1820,12 @@ func (s *Server) verifyProviderAttestation(providerID string, provider *registry
 
 	// Verify binary hash against known-good hashes. Once a binary hash policy is
 	// configured, omission is a policy violation, not an Open Mode downgrade.
-	if policyConfigured {
+	//
+	// v0.6.0: binaryHash is self-reported and demoted to drift telemetry (APNs
+	// code-identity attestation is the real signal); this gate deroutes only when
+	// enforcement is explicitly enabled (rollback). The attestation-validity and
+	// key-binding checks above remain gated on policyConfigured and are unchanged.
+	if s.binaryHashEnforce && policyConfigured {
 		if result.BinaryHash == "" {
 			s.logger.Warn("provider binary hash missing while known-good policy is configured",
 				"provider_id", providerID,

--- a/coordinator/api/provider.go
+++ b/coordinator/api/provider.go
@@ -103,6 +103,46 @@ func (ct *challengeTracker) remove(nonce string) *pendingChallenge {
 	return pc
 }
 
+// codeAttestTracker tracks the outstanding APNs code-identity challenge for a
+// connection — the WebSocket return leg of the push round-trip. It is SEPARATE
+// from challengeTracker (which is the liveness/SE challenge) so the two flows
+// never collide. Keyed by the base64 nonce we pushed.
+type codeAttestTracker struct {
+	mu      sync.Mutex
+	pending map[string]chan *protocol.CodeAttestationResponseMessage
+}
+
+func newCodeAttestTracker() *codeAttestTracker {
+	return &codeAttestTracker{pending: make(map[string]chan *protocol.CodeAttestationResponseMessage)}
+}
+
+func (t *codeAttestTracker) await(nonce string) chan *protocol.CodeAttestationResponseMessage {
+	ch := make(chan *protocol.CodeAttestationResponseMessage, 1)
+	t.mu.Lock()
+	t.pending[nonce] = ch
+	t.mu.Unlock()
+	return ch
+}
+
+func (t *codeAttestTracker) cancel(nonce string) {
+	t.mu.Lock()
+	delete(t.pending, nonce)
+	t.mu.Unlock()
+}
+
+func (t *codeAttestTracker) deliver(resp *protocol.CodeAttestationResponseMessage) {
+	if resp == nil {
+		return
+	}
+	t.mu.Lock()
+	ch := t.pending[resp.Nonce]
+	delete(t.pending, resp.Nonce)
+	t.mu.Unlock()
+	if ch != nil {
+		ch <- resp
+	}
+}
+
 // handleProviderWS upgrades the connection to WebSocket and manages the
 // provider's lifecycle: registration, heartbeats, and inference responses.
 func (s *Server) handleProviderWS(w http.ResponseWriter, r *http.Request) {
@@ -135,6 +175,7 @@ func (s *Server) handleProviderWS(w http.ResponseWriter, r *http.Request) {
 func (s *Server) providerReadLoop(ctx context.Context, conn *websocket.Conn, providerID string, acmeResult *ACMEVerificationResult, r *http.Request) {
 	var provider *registry.Provider
 	tracker := newChallengeTracker()
+	codeTracker := newCodeAttestTracker()
 
 	// Cancel context for cleanup of the challenge loop goroutine.
 	loopCtx, loopCancel := context.WithCancel(ctx)
@@ -301,6 +342,17 @@ func (s *Server) providerReadLoop(ctx context.Context, conn *websocket.Conn, pro
 				s.challengeLoop(loopCtx, conn, providerID, provider, tracker)
 			})
 
+			// v0.6.0: APNs code-identity attestation, once per connection. Runs
+			// only when an attestor is configured; otherwise the provider simply
+			// never becomes CodeAttested (fail-closed at the routing chokepoint).
+			// The code-identity proof and the SIP/liveness pillar compose at the
+			// routing gate (providerSupportsPrivateTextLocked requires both).
+			if s.codeAttestor != nil {
+				saferun.Go(s.logger, "codeAttest", func() {
+					s.sendCodeIdentityChallenge(loopCtx, providerID, provider, codeTracker)
+				})
+			}
+
 		case protocol.TypeHeartbeat:
 			hbMsg := msg.Payload.(*protocol.HeartbeatMessage)
 			s.registry.Heartbeat(providerID, hbMsg)
@@ -332,6 +384,10 @@ func (s *Server) providerReadLoop(ctx context.Context, conn *websocket.Conn, pro
 			respMsg := msg.Payload.(*protocol.AttestationResponseMessage)
 			s.handleAttestationResponse(providerID, provider, respMsg, tracker)
 
+		case protocol.TypeCodeAttestationResponse:
+			respMsg := msg.Payload.(*protocol.CodeAttestationResponseMessage)
+			codeTracker.deliver(respMsg)
+
 		case protocol.TypeLoadModelStatus:
 			statusMsg := msg.Payload.(*protocol.LoadModelStatusMessage)
 			s.logger.Info("provider load_model_status",
@@ -359,6 +415,84 @@ func (s *Server) providerReadLoop(ctx context.Context, conn *websocket.Conn, pro
 		default:
 			s.logger.Warn("unhandled provider message type", "provider_id", providerID, "type", msg.Type)
 		}
+	}
+}
+
+// CodeAttestResponseTimeout bounds how long the coordinator waits for the
+// provider's WebSocket reply to an APNs code-identity challenge. Generous because
+// a background push may be briefly delayed; the provider's local decrypt+sign is
+// sub-second.
+const CodeAttestResponseTimeout = 90 * time.Second
+
+// sendCodeIdentityChallenge runs the per-connection APNs code-identity round-trip
+// (v0.6.0): it pushes E_K(nonce) to the provider's device, awaits the provider's
+// code_attestation_response over the WebSocket, verifies it (the returned nonce
+// equals the one we pushed AND Sign_SE over that nonce verifies against the SE
+// public key bound at registration), and marks the connection CodeAttested on
+// success. Fail-closed: any failure leaves CodeAttested false, so once the
+// rollout flag is on the provider is not routed private traffic. The nonce is a
+// base64 string; it is encrypted to the provider's X25519 key K via the same E2E
+// path used for inference bodies, and the signature is the SE P-256 key (K is
+// decrypt-only — there is no Sign_K). See docs/apns-code-attestation-design.md.
+func (s *Server) sendCodeIdentityChallenge(ctx context.Context, providerID string, provider *registry.Provider, ct *codeAttestTracker) {
+	if s.codeAttestor == nil || provider == nil {
+		return
+	}
+	provider.Mu().Lock()
+	deviceToken := provider.APNsDeviceToken
+	env := provider.APNsEnvironment
+	pubKey := provider.PublicKey
+	var sePubKey string
+	if provider.AttestationResult != nil {
+		sePubKey = provider.AttestationResult.PublicKey
+	}
+	provider.Mu().Unlock()
+
+	if deviceToken == "" || pubKey == "" || sePubKey == "" {
+		s.logger.Warn("code-attest skipped: missing device token, encryption key, or SE key",
+			"provider_id", providerID,
+			"has_token", deviceToken != "",
+			"has_pubkey", pubKey != "",
+			"has_se_key", sePubKey != "",
+		)
+		return
+	}
+
+	nonceBytes := make([]byte, 32)
+	if _, err := rand.Read(nonceBytes); err != nil {
+		s.logger.Error("code-attest nonce generation failed", "provider_id", providerID, "error", err)
+		return
+	}
+	nonceB64 := base64.StdEncoding.EncodeToString(nonceBytes)
+
+	respCh := ct.await(nonceB64)
+	defer ct.cancel(nonceB64)
+
+	sendCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	err := s.codeAttestor.SendCodeChallenge(sendCtx, deviceToken, env, pubKey, nonceB64)
+	cancel()
+	if err != nil {
+		s.logger.Warn("code-attest push send failed", "provider_id", providerID, "error", err)
+		return
+	}
+
+	select {
+	case resp := <-respCh:
+		if resp == nil || resp.Nonce != nonceB64 {
+			s.logger.Warn("code-attest response nonce mismatch", "provider_id", providerID)
+			return
+		}
+		// Verify Sign_SE(nonceB64) against the SE public key bound to THIS
+		// connection at registration — never a key supplied in the response.
+		if err := attestation.VerifyChallengeSignature(sePubKey, resp.Signature, nonceB64); err != nil {
+			s.logger.Warn("code-attest signature verification failed", "provider_id", providerID, "error", err)
+			return
+		}
+		provider.SetCodeAttested(true)
+		s.logger.Info("provider code-attested via APNs", "provider_id", providerID)
+	case <-time.After(CodeAttestResponseTimeout):
+		s.logger.Warn("code-attest timed out awaiting WebSocket response", "provider_id", providerID)
+	case <-ctx.Done():
 	}
 }
 

--- a/coordinator/api/provider_test.go
+++ b/coordinator/api/provider_test.go
@@ -499,6 +499,7 @@ func TestProviderRegistrationRequiresBinaryHashWhenPolicyConfigured(t *testing.T
 	reg := registry.New(logger)
 	srv := NewServer(reg, st, ServerConfig{}, logger)
 	srv.SetKnownBinaryHashes([]string{knownGoodBinaryHashForTest})
+	srv.SetBinaryHashEnforcement(true) // v0.6.0: binaryHash gating is off by default; exercise the legacy enforcement path
 
 	pubKey := testPublicKeyB64()
 	regMsg := &protocol.RegisterMessage{
@@ -540,6 +541,7 @@ func TestProviderRegistrationAcceptsKnownBinaryHash(t *testing.T) {
 	reg := registry.New(logger)
 	srv := NewServer(reg, st, ServerConfig{}, logger)
 	srv.SetKnownBinaryHashes([]string{knownGoodBinaryHashForTest})
+	srv.SetBinaryHashEnforcement(true) // v0.6.0: binaryHash gating is off by default; exercise the legacy enforcement path
 
 	pubKey := testPublicKeyB64()
 	regMsg := &protocol.RegisterMessage{
@@ -578,6 +580,7 @@ func TestProviderRegistrationRejectsInvalidConfiguredBinaryHash(t *testing.T) {
 	reg := registry.New(logger)
 	srv := NewServer(reg, st, ServerConfig{}, logger)
 	srv.SetKnownBinaryHashes([]string{"not-a-sha256"})
+	srv.SetBinaryHashEnforcement(true) // v0.6.0: exercise the legacy enforcement path
 
 	pubKey := testPublicKeyB64()
 	regMsg := &protocol.RegisterMessage{
@@ -844,6 +847,7 @@ func TestProviderRegistrationWithoutAttestationRejectedWhenBinaryHashPolicyConfi
 	reg := registry.New(logger)
 	srv := NewServer(reg, st, ServerConfig{}, logger)
 	srv.SetKnownBinaryHashes([]string{knownGoodBinaryHashForTest})
+	srv.SetBinaryHashEnforcement(true) // v0.6.0: binaryHash gating is off by default; exercise the legacy enforcement path
 
 	regMsg := &protocol.RegisterMessage{
 		Type:                    protocol.TypeRegister,
@@ -1240,6 +1244,7 @@ func TestChallengeResponseRequiresBinaryHashWhenPolicyConfigured(t *testing.T) {
 	reg := registry.New(logger)
 	srv := NewServer(reg, st, ServerConfig{}, logger)
 	srv.SetKnownBinaryHashes([]string{knownGoodBinaryHashForTest})
+	srv.SetBinaryHashEnforcement(true) // v0.6.0: binaryHash gating is off by default; exercise the legacy enforcement path
 
 	pubKey := testPublicKeyB64()
 	regMsg := &protocol.RegisterMessage{
@@ -1289,6 +1294,7 @@ func TestChallengeResponseRejectsHashChangedFromRegistrationAttestation(t *testi
 	srv := NewServer(reg, st, ServerConfig{}, logger)
 	otherKnownHash := strings.Repeat("f", 64)
 	srv.SetKnownBinaryHashes([]string{knownGoodBinaryHashForTest, otherKnownHash})
+	srv.SetBinaryHashEnforcement(true) // v0.6.0: exercise the legacy enforcement path
 
 	pubKey := testPublicKeyB64()
 	regMsg := &protocol.RegisterMessage{
@@ -1338,6 +1344,7 @@ func TestChallengeResponseAcceptsKnownBinaryHash(t *testing.T) {
 	reg := registry.New(logger)
 	srv := NewServer(reg, st, ServerConfig{}, logger)
 	srv.SetKnownBinaryHashes([]string{knownGoodBinaryHashForTest})
+	srv.SetBinaryHashEnforcement(true) // v0.6.0: binaryHash gating is off by default; exercise the legacy enforcement path
 
 	pubKey := testPublicKeyB64()
 	regMsg := &protocol.RegisterMessage{
@@ -1476,6 +1483,7 @@ func TestChallengeResponseRejectsUnsignedBinaryHashWhenPolicyConfigured(t *testi
 	reg := registry.New(logger)
 	srv := NewServer(reg, st, ServerConfig{}, logger)
 	srv.SetKnownBinaryHashes([]string{knownGoodBinaryHashForTest})
+	srv.SetBinaryHashEnforcement(true) // v0.6.0: binaryHash gating is off by default; exercise the legacy enforcement path
 
 	pubKey := testPublicKeyB64()
 	p := reg.Register("provider-1", nil, &protocol.RegisterMessage{

--- a/coordinator/api/server.go
+++ b/coordinator/api/server.go
@@ -188,6 +188,14 @@ type Server struct {
 	releaseBinaryHashPolicyConfigured bool
 	binaryHashPolicyConfigured        bool
 
+	// binaryHashEnforce gates whether a self-reported binaryHash mismatch actually
+	// DEROUTES a provider. Default false as of v0.6.0: binaryHash is self-reported
+	// (worthless against a malicious provider) and is demoted to drift telemetry —
+	// APNs code-identity attestation is the real code-identity signal. The policy
+	// machinery is retained for drift comparison and rollback
+	// (EIGENINFERENCE_BINARYHASH_ENFORCE=true).
+	binaryHashEnforce bool
+
 	// knownRuntimeManifest holds accepted runtime component hashes.
 	// When set, providers whose runtime hashes don't match are marked as
 	// unverified and excluded from routing (but not disconnected).
@@ -770,6 +778,14 @@ func (s *Server) invalidateCatalogCache() {
 }
 
 // SetKnownBinaryHashes configures the set of accepted provider binary hashes.
+// SetBinaryHashEnforcement toggles whether a self-reported binaryHash mismatch
+// deroutes a provider. Default false (v0.6.0): binaryHash is demoted to drift
+// telemetry; APNs code-identity attestation is the real signal. Enable only for
+// rollback or to test the legacy enforcement path.
+func (s *Server) SetBinaryHashEnforcement(enabled bool) {
+	s.binaryHashEnforce = enabled
+}
+
 // Providers whose binary SHA-256 doesn't match any known hash are rejected.
 func (s *Server) SetKnownBinaryHashes(hashes []string) {
 	normalized := normalizeKnownBinaryHashes(hashes, s.logger)

--- a/coordinator/api/server.go
+++ b/coordinator/api/server.go
@@ -34,6 +34,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/eigeninference/d-inference/coordinator/apns"
 	"github.com/eigeninference/d-inference/coordinator/auth"
 	"github.com/eigeninference/d-inference/coordinator/billing"
 	"github.com/eigeninference/d-inference/coordinator/datadog"
@@ -163,16 +164,17 @@ type Server struct {
 	billing                *billing.Service
 	logger                 *slog.Logger
 	mux                    *http.ServeMux
-	challengeInterval      time.Duration       // 0 means use DefaultChallengeInterval
-	skipChallenge          bool                // if true, skip attestation challenges entirely (testing only)
-	privyAuth              *auth.PrivyAuth     // Privy JWT authentication (nil if not configured)
-	adminEmails            map[string]bool     // emails that have admin access
-	adminKey               string              // EIGENINFERENCE_ADMIN_KEY for admin endpoints
-	mdmClient              *mdm.Client         // MicroMDM client for provider security verification
-	mdmWebhookSecret       string              // optional shared secret MicroMDM must present on the webhook
-	stepCARootCert         *x509.Certificate   // step-ca root CA for ACME cert verification
-	stepCAIntermediateCert *x509.Certificate   // step-ca intermediate CA
-	profileSigner          *profilesign.Signer // CMS signer for the /v1/enroll .mobileconfig (nil = serve unsigned)
+	challengeInterval      time.Duration             // 0 means use DefaultChallengeInterval
+	skipChallenge          bool                      // if true, skip attestation challenges entirely (testing only)
+	privyAuth              *auth.PrivyAuth           // Privy JWT authentication (nil if not configured)
+	adminEmails            map[string]bool           // emails that have admin access
+	adminKey               string                    // EIGENINFERENCE_ADMIN_KEY for admin endpoints
+	mdmClient              *mdm.Client               // MicroMDM client for provider security verification
+	mdmWebhookSecret       string                    // optional shared secret MicroMDM must present on the webhook
+	stepCARootCert         *x509.Certificate         // step-ca root CA for ACME cert verification
+	stepCAIntermediateCert *x509.Certificate         // step-ca intermediate CA
+	profileSigner          *profilesign.Signer       // CMS signer for the /v1/enroll .mobileconfig (nil = serve unsigned)
+	codeAttestor           apns.CodeIdentityAttestor // APNs code-identity attestor (nil = disabled; v0.6.0)
 
 	// knownBinaryHashes is the set of accepted provider binary SHA-256 hashes.
 	// When binaryHashPolicyConfigured is true, providers whose binary hash is
@@ -710,6 +712,16 @@ func (s *Server) SetAdminEmails(emails []string) {
 // When set, providers are verified against MDM on registration.
 func (s *Server) SetMDMClient(client *mdm.Client) {
 	s.mdmClient = client
+}
+
+// SetCodeAttestor wires the APNs code-identity attestor (v0.6.0) and ENABLES
+// enforcement: providers that register afterward must pass the code-identity
+// round-trip (CodeAttested) to be routed private/text traffic. Passing nil
+// leaves the feature disabled (providers route as before). Call once during
+// server setup, before providers connect.
+func (s *Server) SetCodeAttestor(a apns.CodeIdentityAttestor) {
+	s.codeAttestor = a
+	s.registry.SetCodeAttestationRequired(a != nil)
 }
 
 // SetMDMWebhookSecret configures an optional shared secret that MicroMDM must

--- a/coordinator/apns/attestor.go
+++ b/coordinator/apns/attestor.go
@@ -1,0 +1,343 @@
+// Package apns implements the coordinator side of the APNs-based provider
+// code-identity attestation (v0.6.0).
+//
+// The coordinator proves a provider is running our genuine, Apple-provisioned
+// binary by pushing an encrypted code-identity challenge — E_K(nonce) — to the
+// provider's APNs device token. Only our genuine, team-signed, push-provisioned
+// code can RECEIVE that push (Apple's enforcement), and only the genuine
+// hardened process can DECRYPT it (the nonce is encrypted to the provider's
+// X25519 key K, which lives only in protected process memory). The provider
+// returns the decrypted nonce + an SE-key signature over the WebSocket, which
+// binds the Apple-gated proof onto that connection. See
+// docs/apns-code-attestation-design.md.
+//
+// This package builds the challenge payload (reusing the existing inference E2E
+// encrypt path so the provider's existing decrypt works unchanged) and sends it
+// to APNs over HTTP/2 with a token-based (.p8 ES256 JWT) authorization. The
+// CodeIdentityAttestor interface is the seam: production uses APNsPushAttestor;
+// tests inject a fake that delivers the challenge directly to a simulated
+// provider without touching Apple.
+package apns
+
+import (
+	"bytes"
+	"context"
+	"crypto/ecdsa"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"math/big"
+	"net/http"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/internal/e2e"
+)
+
+// Mode selects the APNs delivery characteristics.
+//
+//	ModeBackground: apns-push-type=background, apns-priority=5 — silent, subject
+//	  to the device's ~2-3/hour background budget (the default; attest once per
+//	  connection stays within budget).
+//	ModeAlert: apns-push-type=alert, apns-priority=10 — not background-throttled,
+//	  reliable & prompt, at the cost of a benign visible notification. The
+//	  fallback if background delivery proves unreliable on the fleet.
+type Mode string
+
+const (
+	ModeBackground Mode = "background"
+	ModeAlert      Mode = "alert"
+
+	prodHost = "https://api.push.apple.com"
+	devHost  = "https://api.sandbox.push.apple.com"
+
+	// jwtMaxAge bounds JWT reuse. APNs rejects a JWT regenerated <20min apart
+	// (TooManyProviderTokenUpdates) and requires refresh <60min; ~50min is the
+	// safe middle. One JWT is reused across all hosts/sends.
+	jwtMaxAge = 50 * time.Minute
+
+	// challengeExpirySeconds is the apns-expiration window. Short so a stale
+	// challenge is discarded rather than delivered late, but long enough to
+	// tolerate brief device-side delay.
+	challengeExpirySeconds = 60
+)
+
+// CodeIdentityAttestor sends a code-identity challenge to a provider's device.
+// The implementation builds E_K(nonceB64) (encrypted to providerPubKeyB64) and
+// delivers it; the provider answers over the WebSocket (handled elsewhere).
+//
+// This is the seam the design calls for: routing/key-release depend only on this
+// interface, so a future AppAttestAttestor (if Apple ever ships it) drops in, and
+// tests inject a fake.
+type CodeIdentityAttestor interface {
+	SendCodeChallenge(ctx context.Context, deviceToken, environment, providerPubKeyB64, nonceB64 string) error
+}
+
+// APNsPushAttestor is the production CodeIdentityAttestor: it pushes E_K(nonce)
+// to APNs over HTTP/2 using a .p8 ES256 JWT.
+type APNsPushAttestor struct {
+	teamID string
+	keyID  string
+	topic  string
+	mode   Mode
+	key    *ecdsa.PrivateKey
+	client *http.Client
+
+	// hostOverride, when non-empty, replaces both prod and dev hosts (tests).
+	hostOverride string
+
+	jwtMu     sync.Mutex
+	cachedJWT string
+	jwtIssued time.Time
+
+	backoffMu    sync.Mutex
+	backoffUntil map[string]time.Time // per device token (honor Retry-After / 429)
+
+	now func() time.Time // injectable clock (tests)
+}
+
+// Config configures an APNsPushAttestor.
+type Config struct {
+	TeamID     string // Apple Developer Team ID (e.g. SLDQ2GJ6TL)
+	KeyID      string // APNs auth key (.p8) Key ID
+	Topic      string // bundle id / push topic (io.darkbloom.provider)
+	AuthKeyPEM []byte // contents of the .p8 (PEM PKCS#8 EC private key)
+	Mode       Mode   // ModeBackground (default) or ModeAlert
+
+	// HTTPClient overrides the HTTP/2 client (tests). If nil a default client
+	// with HTTP/2 enabled is used.
+	HTTPClient *http.Client
+	// HostOverride replaces the APNs host for both environments (tests only).
+	HostOverride string
+}
+
+// NewAPNsPushAttestor parses the .p8 and returns a ready attestor.
+func NewAPNsPushAttestor(cfg Config) (*APNsPushAttestor, error) {
+	if cfg.TeamID == "" || cfg.KeyID == "" || cfg.Topic == "" {
+		return nil, fmt.Errorf("apns: TeamID, KeyID and Topic are required")
+	}
+	key, err := parseP8(cfg.AuthKeyPEM)
+	if err != nil {
+		return nil, err
+	}
+	mode := cfg.Mode
+	if mode == "" {
+		mode = ModeBackground
+	}
+	client := cfg.HTTPClient
+	if client == nil {
+		client = &http.Client{
+			Timeout:   15 * time.Second,
+			Transport: &http.Transport{ForceAttemptHTTP2: true},
+		}
+	}
+	return &APNsPushAttestor{
+		teamID:       cfg.TeamID,
+		keyID:        cfg.KeyID,
+		topic:        cfg.Topic,
+		mode:         mode,
+		key:          key,
+		client:       client,
+		hostOverride: cfg.HostOverride,
+		backoffUntil: make(map[string]time.Time),
+		now:          time.Now,
+	}, nil
+}
+
+func parseP8(pemBytes []byte) (*ecdsa.PrivateKey, error) {
+	if len(pemBytes) == 0 {
+		return nil, fmt.Errorf("apns: empty auth key")
+	}
+	block, _ := pem.Decode(pemBytes)
+	if block == nil {
+		return nil, fmt.Errorf("apns: auth key is not valid PEM")
+	}
+	parsed, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("apns: parse PKCS#8 key: %w", err)
+	}
+	ecKey, ok := parsed.(*ecdsa.PrivateKey)
+	if !ok {
+		return nil, fmt.Errorf("apns: auth key is not an ECDSA P-256 key (got %T)", parsed)
+	}
+	return ecKey, nil
+}
+
+// SendCodeChallenge builds E_K(nonceB64) for the provider's key and pushes it.
+func (a *APNsPushAttestor) SendCodeChallenge(ctx context.Context, deviceToken, environment, providerPubKeyB64, nonceB64 string) error {
+	if deviceToken == "" {
+		return fmt.Errorf("apns: empty device token")
+	}
+	if blocked, until := a.inBackoff(deviceToken); blocked {
+		return fmt.Errorf("apns: device %s in backoff until %s", short(deviceToken), until.Format(time.RFC3339))
+	}
+
+	payload, err := BuildCodeChallengePayload(nonceB64, providerPubKeyB64, a.mode)
+	if err != nil {
+		return fmt.Errorf("apns: build challenge payload: %w", err)
+	}
+
+	jwt, err := a.jwt()
+	if err != nil {
+		return fmt.Errorf("apns: mint jwt: %w", err)
+	}
+
+	host := prodHost
+	if environment == "development" {
+		host = devHost
+	}
+	if a.hostOverride != "" {
+		host = a.hostOverride
+	}
+
+	url := host + "/3/device/" + deviceToken
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(payload))
+	if err != nil {
+		return fmt.Errorf("apns: build request: %w", err)
+	}
+	req.Header.Set("authorization", "bearer "+jwt)
+	req.Header.Set("apns-topic", a.topic)
+	req.Header.Set("apns-push-type", string(a.mode))
+	req.Header.Set("apns-priority", a.priority())
+	req.Header.Set("apns-expiration", strconv.FormatInt(a.now().Unix()+challengeExpirySeconds, 10))
+	req.Header.Set("content-type", "application/json")
+
+	resp, err := a.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("apns: send: %w", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+
+	switch {
+	case resp.StatusCode == http.StatusOK:
+		return nil
+	case resp.StatusCode == http.StatusTooManyRequests:
+		a.setBackoff(deviceToken, resp.Header.Get("Retry-After"))
+		return fmt.Errorf("apns: 429 too many requests for device %s: %s", short(deviceToken), string(body))
+	default:
+		return fmt.Errorf("apns: status %d: %s", resp.StatusCode, string(body))
+	}
+}
+
+func (a *APNsPushAttestor) priority() string {
+	if a.mode == ModeAlert {
+		return "10"
+	}
+	return "5"
+}
+
+// jwt returns a cached ES256 JWT, minting a fresh one if older than jwtMaxAge.
+func (a *APNsPushAttestor) jwt() (string, error) {
+	a.jwtMu.Lock()
+	defer a.jwtMu.Unlock()
+	if a.cachedJWT != "" && a.now().Sub(a.jwtIssued) < jwtMaxAge {
+		return a.cachedJWT, nil
+	}
+	tok, iat, err := a.mintJWT()
+	if err != nil {
+		return "", err
+	}
+	a.cachedJWT = tok
+	a.jwtIssued = iat
+	return tok, nil
+}
+
+func (a *APNsPushAttestor) mintJWT() (string, time.Time, error) {
+	iat := a.now()
+	header := b64url([]byte(fmt.Sprintf(`{"alg":"ES256","kid":%q}`, a.keyID)))
+	claims := b64url([]byte(fmt.Sprintf(`{"iss":%q,"iat":%d}`, a.teamID, iat.Unix())))
+	signingInput := header + "." + claims
+
+	digest := sha256.Sum256([]byte(signingInput))
+	r, s, err := ecdsa.Sign(rand.Reader, a.key, digest[:])
+	if err != nil {
+		return "", time.Time{}, err
+	}
+	// JOSE ES256 signature = R || S, each left-padded to 32 bytes (NOT ASN.1).
+	sig := append(i2osp(r, 32), i2osp(s, 32)...)
+	return signingInput + "." + b64urlRaw(sig), iat, nil
+}
+
+func (a *APNsPushAttestor) inBackoff(deviceToken string) (bool, time.Time) {
+	a.backoffMu.Lock()
+	defer a.backoffMu.Unlock()
+	until, ok := a.backoffUntil[deviceToken]
+	if ok && a.now().Before(until) {
+		return true, until
+	}
+	return false, time.Time{}
+}
+
+func (a *APNsPushAttestor) setBackoff(deviceToken, retryAfter string) {
+	d := 30 * time.Second
+	if retryAfter != "" {
+		if secs, err := strconv.Atoi(retryAfter); err == nil && secs > 0 {
+			d = time.Duration(secs) * time.Second
+		}
+	}
+	a.backoffMu.Lock()
+	a.backoffUntil[deviceToken] = a.now().Add(d)
+	a.backoffMu.Unlock()
+}
+
+// BuildCodeChallengePayload returns the APNs JSON body carrying E_K(nonceB64),
+// where the nonce (a base64 string) is encrypted to the provider's X25519 key
+// using the SAME E2E path used for inference request bodies. The "code_challenge"
+// object is an e2e.EncryptedPayload; the provider decrypts it with its NodeKeyPair
+// exactly as it decrypts an inference body. content-available:1 keeps the silent
+// delivery path active in both modes.
+func BuildCodeChallengePayload(nonceB64, providerPubKeyB64 string, mode Mode) ([]byte, error) {
+	if nonceB64 == "" {
+		return nil, fmt.Errorf("apns: empty nonce")
+	}
+	recipient, err := e2e.ParsePublicKey(providerPubKeyB64)
+	if err != nil {
+		return nil, fmt.Errorf("apns: provider public key: %w", err)
+	}
+	session, err := e2e.GenerateSessionKeys()
+	if err != nil {
+		return nil, err
+	}
+	enc, err := e2e.Encrypt([]byte(nonceB64), recipient, session)
+	if err != nil {
+		return nil, err
+	}
+	aps := map[string]any{"content-available": 1}
+	if mode == ModeAlert {
+		aps["alert"] = map[string]any{"title": "Darkbloom", "body": "attestation"}
+	}
+	return json.Marshal(map[string]any{
+		"aps":            aps,
+		"code_challenge": enc,
+	})
+}
+
+// --- small helpers ---
+
+func b64url(b []byte) string    { return base64.RawURLEncoding.EncodeToString(b) }
+func b64urlRaw(b []byte) string { return base64.RawURLEncoding.EncodeToString(b) }
+
+// i2osp converts a big.Int to a fixed-size big-endian byte slice (left-padded).
+func i2osp(n *big.Int, size int) []byte {
+	b := n.Bytes()
+	if len(b) >= size {
+		return b[len(b)-size:]
+	}
+	out := make([]byte, size)
+	copy(out[size-len(b):], b)
+	return out
+}
+
+func short(s string) string {
+	if len(s) <= 12 {
+		return s
+	}
+	return s[:12] + "…"
+}

--- a/coordinator/apns/attestor.go
+++ b/coordinator/apns/attestor.go
@@ -311,6 +311,14 @@ func BuildCodeChallengePayload(nonceB64, providerPubKeyB64 string, mode Mode) ([
 	}
 	aps := map[string]any{"content-available": 1}
 	if mode == ModeAlert {
+		// Alert mode improves delivery reliability (priority 10, not background-
+		// throttled). It is safe ONLY because the provider does NOT request
+		// user-notification authorization: without it, the alert is never
+		// presented or persisted to the root-readable Notification Center DB, so
+		// the encrypted code_challenge leaves no on-disk cleartext copy. If the
+		// provider ever adds UNUserNotificationCenter authorization, this dict
+		// must be dropped for the attestation push (keep it background-only).
+		// See the INVARIANT in provider-swift ProviderAppKitHost.swift.
 		aps["alert"] = map[string]any{"title": "Darkbloom", "body": "attestation"}
 	}
 	return json.Marshal(map[string]any{

--- a/coordinator/apns/attestor_test.go
+++ b/coordinator/apns/attestor_test.go
@@ -1,0 +1,249 @@
+package apns
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/internal/e2e"
+)
+
+// testP8 generates a throwaway ECDSA P-256 key as a PKCS#8 PEM (a fake .p8).
+func testP8(t *testing.T) []byte {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("gen key: %v", err)
+	}
+	der, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		t.Fatalf("marshal pkcs8: %v", err)
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der})
+}
+
+func newTestAttestor(t *testing.T, cfg Config) *APNsPushAttestor {
+	t.Helper()
+	if cfg.TeamID == "" {
+		cfg.TeamID = "P7373SVQX6"
+	}
+	if cfg.KeyID == "" {
+		cfg.KeyID = "HRP6NBC5HC"
+	}
+	if cfg.Topic == "" {
+		cfg.Topic = "io.darkbloom.provider"
+	}
+	if cfg.AuthKeyPEM == nil {
+		cfg.AuthKeyPEM = testP8(t)
+	}
+	a, err := NewAPNsPushAttestor(cfg)
+	if err != nil {
+		t.Fatalf("NewAPNsPushAttestor: %v", err)
+	}
+	return a
+}
+
+// The provider decrypts code_challenge exactly as it decrypts an inference body.
+// This proves the coordinator's E_K(nonce) round-trips to the provider's K.
+func TestBuildCodeChallengePayloadRoundTrip(t *testing.T) {
+	provider, err := e2e.GenerateSessionKeys() // stand-in for the provider's K
+	if err != nil {
+		t.Fatalf("gen provider keys: %v", err)
+	}
+	providerPubB64 := base64.StdEncoding.EncodeToString(provider.PublicKey[:])
+	nonceB64 := base64.StdEncoding.EncodeToString([]byte("0123456789abcdef0123456789abcdef"))
+
+	for _, mode := range []Mode{ModeBackground, ModeAlert} {
+		payload, err := BuildCodeChallengePayload(nonceB64, providerPubB64, mode)
+		if err != nil {
+			t.Fatalf("BuildCodeChallengePayload(%s): %v", mode, err)
+		}
+		var body struct {
+			Aps           map[string]any       `json:"aps"`
+			CodeChallenge e2e.EncryptedPayload `json:"code_challenge"`
+		}
+		if err := json.Unmarshal(payload, &body); err != nil {
+			t.Fatalf("unmarshal payload: %v", err)
+		}
+		if body.Aps["content-available"] != float64(1) {
+			t.Errorf("%s: content-available not set: %v", mode, body.Aps)
+		}
+		if mode == ModeAlert && body.Aps["alert"] == nil {
+			t.Errorf("alert mode must include an alert dict: %v", body.Aps)
+		}
+		if mode == ModeBackground && body.Aps["alert"] != nil {
+			t.Errorf("background mode must NOT include an alert dict: %v", body.Aps)
+		}
+		// Provider-side decrypt with K's private key.
+		recovered, err := e2e.DecryptWithPrivateKey(&body.CodeChallenge, provider.PrivateKey)
+		if err != nil {
+			t.Fatalf("%s: provider decrypt failed: %v", mode, err)
+		}
+		if string(recovered) != nonceB64 {
+			t.Errorf("%s: decrypted nonce mismatch: got %q want %q", mode, recovered, nonceB64)
+		}
+	}
+}
+
+func TestJWTMintAndCache(t *testing.T) {
+	a := newTestAttestor(t, Config{})
+	base := time.Unix(1_780_000_000, 0)
+	a.now = func() time.Time { return base }
+
+	tok1, err := a.jwt()
+	if err != nil {
+		t.Fatalf("jwt: %v", err)
+	}
+	parts := strings.Split(tok1, ".")
+	if len(parts) != 3 {
+		t.Fatalf("jwt must have 3 parts, got %d", len(parts))
+	}
+	hdr, err := base64.RawURLEncoding.DecodeString(parts[0])
+	if err != nil {
+		t.Fatalf("decode header: %v", err)
+	}
+	var h map[string]string
+	if err := json.Unmarshal(hdr, &h); err != nil {
+		t.Fatalf("unmarshal header: %v", err)
+	}
+	if h["alg"] != "ES256" || h["kid"] != "HRP6NBC5HC" {
+		t.Errorf("header alg/kid wrong: %v", h)
+	}
+
+	// Cached within jwtMaxAge.
+	tok2, _ := a.jwt()
+	if tok2 != tok1 {
+		t.Error("jwt should be cached (reused) within jwtMaxAge to avoid TooManyProviderTokenUpdates")
+	}
+	// Refreshed after jwtMaxAge.
+	a.now = func() time.Time { return base.Add(jwtMaxAge + time.Minute) }
+	tok3, _ := a.jwt()
+	if tok3 == tok1 {
+		t.Error("jwt should refresh after jwtMaxAge")
+	}
+}
+
+func TestSendCodeChallengeHeadersAndPayload(t *testing.T) {
+	provider, _ := e2e.GenerateSessionKeys()
+	providerPubB64 := base64.StdEncoding.EncodeToString(provider.PublicKey[:])
+	nonceB64 := base64.StdEncoding.EncodeToString([]byte("nonce-nonce-nonce-nonce-nonce-32"))
+
+	type capture struct {
+		method, path, topic, pushType, priority, auth, expiration string
+		body                                                      []byte
+	}
+	cases := []struct {
+		mode         Mode
+		wantPushType string
+		wantPriority string
+		wantAlert    bool
+	}{
+		{ModeBackground, "background", "5", false},
+		{ModeAlert, "alert", "10", true},
+	}
+	for _, tc := range cases {
+		var got capture
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			got.method = r.Method
+			got.path = r.URL.Path
+			got.topic = r.Header.Get("apns-topic")
+			got.pushType = r.Header.Get("apns-push-type")
+			got.priority = r.Header.Get("apns-priority")
+			got.auth = r.Header.Get("authorization")
+			got.expiration = r.Header.Get("apns-expiration")
+			got.body, _ = readAll(r)
+			w.WriteHeader(http.StatusOK)
+		}))
+		a := newTestAttestor(t, Config{Mode: tc.mode, HostOverride: ts.URL, HTTPClient: ts.Client()})
+		err := a.SendCodeChallenge(context.Background(), "abc123token", "production", providerPubB64, nonceB64)
+		ts.Close()
+		if err != nil {
+			t.Fatalf("%s: SendCodeChallenge: %v", tc.mode, err)
+		}
+		if got.method != http.MethodPost || got.path != "/3/device/abc123token" {
+			t.Errorf("%s: method/path = %s %s", tc.mode, got.method, got.path)
+		}
+		if got.topic != "io.darkbloom.provider" {
+			t.Errorf("%s: topic = %q", tc.mode, got.topic)
+		}
+		if got.pushType != tc.wantPushType || got.priority != tc.wantPriority {
+			t.Errorf("%s: push-type/priority = %q/%q want %q/%q", tc.mode, got.pushType, got.priority, tc.wantPushType, tc.wantPriority)
+		}
+		if !strings.HasPrefix(got.auth, "bearer ") {
+			t.Errorf("%s: authorization = %q", tc.mode, got.auth)
+		}
+		if got.expiration == "" {
+			t.Errorf("%s: apns-expiration missing", tc.mode)
+		}
+		var body struct {
+			Aps map[string]any `json:"aps"`
+		}
+		if err := json.Unmarshal(got.body, &body); err != nil {
+			t.Fatalf("%s: body not JSON: %v", tc.mode, err)
+		}
+		if (body.Aps["alert"] != nil) != tc.wantAlert {
+			t.Errorf("%s: alert presence = %v want %v", tc.mode, body.Aps["alert"] != nil, tc.wantAlert)
+		}
+	}
+}
+
+func TestSendCodeChallenge429Backoff(t *testing.T) {
+	provider, _ := e2e.GenerateSessionKeys()
+	providerPubB64 := base64.StdEncoding.EncodeToString(provider.PublicKey[:])
+	nonceB64 := base64.StdEncoding.EncodeToString([]byte("nonce-nonce-nonce-nonce-nonce-32"))
+
+	var hits int
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		w.Header().Set("Retry-After", "120")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"reason":"TooManyRequests"}`))
+	}))
+	defer ts.Close()
+	a := newTestAttestor(t, Config{HostOverride: ts.URL, HTTPClient: ts.Client()})
+	base := time.Unix(1_780_000_000, 0)
+	a.now = func() time.Time { return base }
+
+	if err := a.SendCodeChallenge(context.Background(), "tok", "production", providerPubB64, nonceB64); err == nil {
+		t.Fatal("expected 429 error")
+	}
+	if hits != 1 {
+		t.Fatalf("expected 1 hit, got %d", hits)
+	}
+	// Second send within the backoff window must not hit the server.
+	if err := a.SendCodeChallenge(context.Background(), "tok", "production", providerPubB64, nonceB64); err == nil {
+		t.Fatal("expected backoff error")
+	}
+	if hits != 1 {
+		t.Errorf("backoff should have prevented a 2nd request, hits=%d", hits)
+	}
+	// After the backoff window, it sends again.
+	a.now = func() time.Time { return base.Add(3 * time.Minute) }
+	_ = a.SendCodeChallenge(context.Background(), "tok", "production", providerPubB64, nonceB64)
+	if hits != 2 {
+		t.Errorf("expected request after backoff expiry, hits=%d", hits)
+	}
+}
+
+func readAll(r *http.Request) ([]byte, error) {
+	defer r.Body.Close()
+	buf := make([]byte, 0, 1024)
+	tmp := make([]byte, 1024)
+	for {
+		n, err := r.Body.Read(tmp)
+		buf = append(buf, tmp[:n]...)
+		if err != nil {
+			return buf, nil
+		}
+	}
+}

--- a/coordinator/apns/live_test.go
+++ b/coordinator/apns/live_test.go
@@ -1,0 +1,102 @@
+package apns
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/internal/e2e"
+)
+
+// TestLiveRoundTripAPNs is an ON-DEVICE live test (skipped unless APNS_LIVE_TEST=1).
+// It uses the REAL apns package to push E_K(nonce) over REAL APNs to a device token
+// produced by an on-device probe, then confirms the delivered code_challenge
+// decrypts to the exact nonce — i.e. the production sender delivers a correct,
+// decryptable encrypted challenge to the real bundle over Apple's infrastructure.
+//
+// Requires env: APNS_AUTH_KEY_P8_B64, APNS_KEY_ID, APNS_TEAM_ID, APNS_TOPIC
+// (+ optional APNS_MODE=background|alert), and the probe running (writing
+// /tmp/apns_coexist_token.txt and, on receipt, /tmp/lt_received.json).
+func TestLiveRoundTripAPNs(t *testing.T) {
+	if os.Getenv("APNS_LIVE_TEST") != "1" {
+		t.Skip("set APNS_LIVE_TEST=1 (+ APNS_* env and a running probe) to run the on-device APNs live test")
+	}
+	pemB64 := os.Getenv("APNS_AUTH_KEY_P8_B64")
+	if pemB64 == "" {
+		t.Fatal("APNS_AUTH_KEY_P8_B64 not set")
+	}
+	pem, err := base64.StdEncoding.DecodeString(pemB64)
+	if err != nil {
+		t.Fatalf("decode APNS_AUTH_KEY_P8_B64: %v", err)
+	}
+	tokenRaw, err := os.ReadFile("/tmp/apns_coexist_token.txt")
+	if err != nil {
+		t.Fatalf("read device token (is the probe running?): %v", err)
+	}
+	token := strings.TrimSpace(string(tokenRaw))
+
+	mode := ModeBackground
+	if os.Getenv("APNS_MODE") == "alert" {
+		mode = ModeAlert
+	}
+	attestor, err := NewAPNsPushAttestor(Config{
+		TeamID:     os.Getenv("APNS_TEAM_ID"),
+		KeyID:      os.Getenv("APNS_KEY_ID"),
+		Topic:      getenvOr("APNS_TOPIC", "io.darkbloom.provider"),
+		AuthKeyPEM: pem,
+		Mode:       mode,
+	})
+	if err != nil {
+		t.Fatalf("NewAPNsPushAttestor: %v", err)
+	}
+
+	// We hold the provider's K private key so we can verify the delivered challenge.
+	k, err := e2e.GenerateSessionKeys()
+	if err != nil {
+		t.Fatalf("gen K: %v", err)
+	}
+	kPub := base64.StdEncoding.EncodeToString(k.PublicKey[:])
+	nonceB64 := base64.StdEncoding.EncodeToString([]byte("live-roundtrip-nonce-0123456789ab"))
+
+	_ = os.Remove("/tmp/lt_received.json")
+	if err := attestor.SendCodeChallenge(context.Background(), token, "production", kPub, nonceB64); err != nil {
+		t.Fatalf("SendCodeChallenge (mode=%s): %v", mode, err)
+	}
+	t.Logf("pushed E_K(nonce) via real APNs (mode=%s) to device %s…", mode, token[:min(12, len(token))])
+
+	var recv []byte
+	for i := 0; i < 90; i++ {
+		if b, e := os.ReadFile("/tmp/lt_received.json"); e == nil && len(b) > 0 {
+			recv = b
+			break
+		}
+		time.Sleep(time.Second)
+	}
+	if recv == nil {
+		t.Fatalf("on-device probe did NOT receive the push within 90s (mode=%s) — APNs delivery (budget/subscription) issue, not a code bug", mode)
+	}
+
+	var payload e2e.EncryptedPayload
+	if err := json.Unmarshal(recv, &payload); err != nil {
+		t.Fatalf("received code_challenge is not an EncryptedPayload: %v", err)
+	}
+	recovered, err := e2e.Decrypt(&payload, k)
+	if err != nil {
+		t.Fatalf("decrypt of the delivered challenge failed: %v", err)
+	}
+	if string(recovered) != nonceB64 {
+		t.Fatalf("recovered nonce mismatch: got %q want %q", recovered, nonceB64)
+	}
+	t.Logf("✅ LIVE PASS: real apns package delivered E_K(nonce) over real APNs to %s; on-device receipt decrypts to the exact nonce", attestor.topic)
+}
+
+func getenvOr(k, d string) string {
+	if v := os.Getenv(k); v != "" {
+		return v
+	}
+	return d
+}

--- a/coordinator/cmd/coordinator/main.go
+++ b/coordinator/cmd/coordinator/main.go
@@ -265,6 +265,13 @@ func main() {
 		srv.AddKnownBinaryHashes(hashes)
 		logger.Info("additional binary hashes from env var", "count", len(hashes))
 	}
+	// v0.6.0: self-reported binaryHash is demoted to drift telemetry by default
+	// (APNs code-identity attestation is the real signal). Set this to re-enable
+	// the legacy derouting-on-mismatch behavior (rollback only).
+	if os.Getenv("EIGENINFERENCE_BINARYHASH_ENFORCE") == "true" {
+		srv.SetBinaryHashEnforcement(true)
+		logger.Warn("binaryHash enforcement ENABLED via EIGENINFERENCE_BINARYHASH_ENFORCE (legacy; APNs code-identity is the real signal)")
+	}
 
 	// Load runtime template manifest from environment variable (optional override).
 	// When configured, providers whose template hashes don't match are excluded from

--- a/coordinator/cmd/coordinator/main.go
+++ b/coordinator/cmd/coordinator/main.go
@@ -20,6 +20,7 @@ package main
 import (
 	"context"
 	"crypto/x509"
+	"encoding/base64"
 	"encoding/pem"
 	"errors"
 	"log/slog"
@@ -31,6 +32,7 @@ import (
 	"time"
 
 	"github.com/eigeninference/d-inference/coordinator/api"
+	"github.com/eigeninference/d-inference/coordinator/apns"
 	"github.com/eigeninference/d-inference/coordinator/attestation"
 	"github.com/eigeninference/d-inference/coordinator/auth"
 	"github.com/eigeninference/d-inference/coordinator/billing"
@@ -460,6 +462,18 @@ func main() {
 		logger.Info("configuration-profile signing not configured — serving unsigned enrollment profiles")
 	}
 
+	// Optional APNs code-identity attestation (v0.6.0). When the APNs auth key
+	// (.p8) + key/team IDs are supplied, the coordinator pushes an encrypted
+	// code-identity challenge to each provider and requires the WebSocket reply
+	// before routing private traffic (fail-closed). Absent config leaves it
+	// disabled and the fleet routes as before.
+	if attestor := loadAPNsAttestor(logger); attestor != nil {
+		srv.SetCodeAttestor(attestor)
+		logger.Info("APNs code-identity attestation enabled (providers must pass code-identity to route)")
+	} else {
+		logger.Info("APNs code-identity attestation not configured — providers route without code-identity proof")
+	}
+
 	// Start background eviction of stale providers.
 	reg.StartEvictionLoop(ctx, 90*time.Second)
 
@@ -501,4 +515,60 @@ func main() {
 	}
 
 	logger.Info("coordinator stopped")
+}
+
+// loadAPNsAttestor builds the production APNs code-identity attestor from the
+// environment, or returns nil (feature disabled) when unconfigured. Required:
+// APNS_KEY_ID, APNS_TEAM_ID, and the .p8 auth key via APNS_AUTH_KEY_P8_B64
+// (base64 of the PEM) or APNS_AUTH_KEY_P8_PATH. Optional: APNS_TOPIC
+// (default io.darkbloom.provider), APNS_MODE ("background" default | "alert").
+// The .p8 is a secret — inject via KMS, never commit it.
+func loadAPNsAttestor(logger *slog.Logger) *apns.APNsPushAttestor {
+	keyID := os.Getenv("APNS_KEY_ID")
+	teamID := os.Getenv("APNS_TEAM_ID")
+	if keyID == "" || teamID == "" {
+		return nil
+	}
+
+	var pemBytes []byte
+	if b64 := os.Getenv("APNS_AUTH_KEY_P8_B64"); b64 != "" {
+		dec, err := base64.StdEncoding.DecodeString(b64)
+		if err != nil {
+			logger.Error("APNS_AUTH_KEY_P8_B64 is not valid base64 — APNs attestation disabled", "error", err)
+			return nil
+		}
+		pemBytes = dec
+	} else if path := os.Getenv("APNS_AUTH_KEY_P8_PATH"); path != "" {
+		b, err := os.ReadFile(path)
+		if err != nil {
+			logger.Error("failed to read APNS_AUTH_KEY_P8_PATH — APNs attestation disabled", "path", path, "error", err)
+			return nil
+		}
+		pemBytes = b
+	} else {
+		logger.Warn("APNS_KEY_ID/APNS_TEAM_ID set but no .p8 (APNS_AUTH_KEY_P8_B64 or _PATH) — APNs attestation disabled")
+		return nil
+	}
+
+	topic := os.Getenv("APNS_TOPIC")
+	if topic == "" {
+		topic = "io.darkbloom.provider"
+	}
+	mode := apns.ModeBackground
+	if os.Getenv("APNS_MODE") == "alert" {
+		mode = apns.ModeAlert
+	}
+
+	attestor, err := apns.NewAPNsPushAttestor(apns.Config{
+		TeamID:     teamID,
+		KeyID:      keyID,
+		Topic:      topic,
+		AuthKeyPEM: pemBytes,
+		Mode:       mode,
+	})
+	if err != nil {
+		logger.Error("failed to construct APNs attestor — attestation disabled", "error", err)
+		return nil
+	}
+	return attestor
 }

--- a/coordinator/protocol/messages.go
+++ b/coordinator/protocol/messages.go
@@ -36,7 +36,11 @@ const (
 	TypeInferenceComplete      = "inference_complete"
 	TypeInferenceError         = "inference_error"
 	TypeAttestationResponse    = "attestation_response"
-	TypeLoadModelStatus        = "load_model_status"
+	// TypeCodeAttestationResponse is the provider's reply to the APNs-delivered
+	// code-identity challenge (E_K(nonce) push). Distinct from the liveness
+	// attestation_response: this is the WebSocket return leg of the push round-trip.
+	TypeCodeAttestationResponse = "code_attestation_response"
+	TypeLoadModelStatus         = "load_model_status"
 
 	// Coordinator → Provider.
 	TypeInferenceRequest     = "inference_request"
@@ -106,6 +110,12 @@ type RegisterMessage struct {
 	DecodeTPS               float64         `json:"decode_tps,omitempty"`                // benchmark: decode tokens per second
 	AuthToken               string          `json:"auth_token,omitempty"`                // device-linked provider token (from darkbloom login)
 	PrivateOnly             bool            `json:"private_only,omitempty"`              // when true, this machine serves only its owner's self-route requests, never the public fleet
+
+	// APNs code-identity attestation (v0.6.0): the device token the coordinator
+	// pushes the E_K(nonce) code-identity challenge to, and which APNs environment
+	// that token belongs to. Bound 1:1 to PublicKey (K) at registration.
+	APNsDeviceToken string `json:"apns_device_token,omitempty"` // hex device token from registerForRemoteNotifications
+	APNsEnvironment string `json:"apns_environment,omitempty"`  // "production" | "development" (selects the APNs host)
 
 	// Runtime integrity hashes — used for runtime verification against known-good manifests.
 	PythonHash          string               `json:"python_hash,omitempty"`     // SHA-256 of Python runtime
@@ -340,6 +350,26 @@ type AttestationResponseMessage struct {
 	ModelHashes    map[string]string `json:"model_hashes,omitempty"`    // model_id -> SHA-256 weight hash (all active models)
 }
 
+// CodeAttestationResponseMessage is the provider's reply to the APNs-delivered
+// code-identity challenge. The coordinator pushed E_K(nonce) (a nonce encrypted
+// to the provider's registered X25519 key K) over APNs; only our genuine,
+// Apple-provisioned binary can receive that push, and only the genuine process
+// can decrypt it with K. The provider returns:
+//   - Nonce:     the DECRYPTED nonce (proves it could decrypt E_K(nonce) ⟹ holds K)
+//   - Signature: Sign_SE(nonce) from the persistent Secure-Enclave P-256 key
+//     (proves it holds the SE identity bound to K at registration)
+//
+// Note: K is X25519 (decrypt-only); the signature comes from the separate SE key.
+// The coordinator verifies Nonce == the nonce it pushed, and Signature against
+// the SE public key bound to this connection at registration — never a key
+// supplied in this message. This binds the Apple-gated push proof onto THIS
+// WebSocket connection.
+type CodeAttestationResponseMessage struct {
+	Type      string `json:"type"`
+	Nonce     string `json:"nonce"`     // decrypted challenge nonce, base64 (must equal the pushed nonce)
+	Signature string `json:"signature"` // base64 SE-key (P-256) signature over the nonce bytes
+}
+
 // ---------------------------------------------------------------------------
 // Runtime verification messages
 // ---------------------------------------------------------------------------
@@ -440,6 +470,13 @@ func (pm *ProviderMessage) UnmarshalJSON(data []byte) error {
 		var msg AttestationResponseMessage
 		if err := json.Unmarshal(data, &msg); err != nil {
 			return fmt.Errorf("protocol: failed to unmarshal attestation_response: %w", err)
+		}
+		pm.Payload = &msg
+
+	case TypeCodeAttestationResponse:
+		var msg CodeAttestationResponseMessage
+		if err := json.Unmarshal(data, &msg); err != nil {
+			return fmt.Errorf("protocol: failed to unmarshal code_attestation_response: %w", err)
 		}
 		pm.Payload = &msg
 

--- a/coordinator/protocol/messages_test.go
+++ b/coordinator/protocol/messages_test.go
@@ -117,6 +117,75 @@ func contains(s, sub string) bool {
 	return false
 }
 
+func TestRegisterMessageAPNsFieldsSymmetry(t *testing.T) {
+	// A register payload exactly as the Swift ProviderMessage encoder emits it
+	// with the v0.6.0 APNs code-identity fields present.
+	swiftJSON := `{
+		"type": "register",
+		"hardware": {},
+		"models": [],
+		"backend": "mlx",
+		"public_key": "abc",
+		"apns_device_token": "cb1ceb489ec9",
+		"apns_environment": "production"
+	}`
+	var decoded RegisterMessage
+	if err := json.Unmarshal([]byte(swiftJSON), &decoded); err != nil {
+		t.Fatalf("unmarshal swift payload: %v", err)
+	}
+	if decoded.APNsDeviceToken != "cb1ceb489ec9" {
+		t.Errorf("apns_device_token did not decode: %q", decoded.APNsDeviceToken)
+	}
+	if decoded.APNsEnvironment != "production" {
+		t.Errorf("apns_environment did not decode: %q", decoded.APNsEnvironment)
+	}
+
+	// Both fields are omitempty: an empty register must not emit them (Swift omits
+	// them when nil, so the Go encoder must too, or symmetry tests drift).
+	data, _ := json.Marshal(RegisterMessage{Type: TypeRegister})
+	if contains(string(data), "apns_device_token") || contains(string(data), "apns_environment") {
+		t.Errorf("empty APNs fields should be omitted, got %s", data)
+	}
+
+	// Round-trip with values.
+	data, _ = json.Marshal(RegisterMessage{Type: TypeRegister, APNsDeviceToken: "tok", APNsEnvironment: "development"})
+	var back RegisterMessage
+	if err := json.Unmarshal(data, &back); err != nil {
+		t.Fatalf("round-trip unmarshal: %v", err)
+	}
+	if back.APNsDeviceToken != "tok" || back.APNsEnvironment != "development" {
+		t.Errorf("APNs fields round-trip failed: %+v from %s", back, data)
+	}
+}
+
+func TestCodeAttestationResponseMessageMarshal(t *testing.T) {
+	msg := CodeAttestationResponseMessage{
+		Type:      TypeCodeAttestationResponse,
+		Nonce:     "bm9uY2U=",
+		Signature: "c2ln",
+	}
+	data, err := json.Marshal(msg)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	// Decode via the ProviderMessage envelope — the discriminator path the
+	// coordinator's read loop uses to route this message.
+	var pm ProviderMessage
+	if err := json.Unmarshal(data, &pm); err != nil {
+		t.Fatalf("envelope unmarshal: %v", err)
+	}
+	if pm.Type != TypeCodeAttestationResponse {
+		t.Errorf("type = %q, want %q", pm.Type, TypeCodeAttestationResponse)
+	}
+	got, ok := pm.Payload.(*CodeAttestationResponseMessage)
+	if !ok {
+		t.Fatalf("payload type = %T, want *CodeAttestationResponseMessage", pm.Payload)
+	}
+	if got.Nonce != "bm9uY2U=" || got.Signature != "c2ln" {
+		t.Errorf("round-trip mismatch: %+v", got)
+	}
+}
+
 func TestHeartbeatMessageMarshal(t *testing.T) {
 	msg := HeartbeatMessage{
 		Type:        TypeHeartbeat,

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -215,6 +215,12 @@ type Provider struct {
 	// serves only its owner's self-route requests. Reported at registration.
 	PrivateOnly bool
 
+	// APNs code-identity attestation (v0.6.0). The device token the coordinator
+	// pushes the E_K(nonce) code-identity challenge to, bound 1:1 to PublicKey (K).
+	// Reported at registration; populated once the provider runs its APNs module.
+	APNsDeviceToken string // hex device token from registerForRemoteNotifications
+	APNsEnvironment string // "production" | "development" (selects the APNs host)
+
 	// Benchmark data reported at registration
 	PrefillTPS float64 // prefill tokens per second
 	DecodeTPS  float64 // decode tokens per second
@@ -267,6 +273,19 @@ type Provider struct {
 	// WebSocket and a running challenge loop.
 	untrustedRecoverable bool
 
+	// CodeAttested is true once this connection passed the APNs code-identity
+	// round-trip (E_K(nonce) push → provider returns the decrypted nonce + a
+	// Sign_SE signature over the WS). In-memory + per-connection: a fresh Provider
+	// is created on every (re)connect (default false) and discarded on Disconnect,
+	// so a SIP downgrade — which needs a reboot that drops the WS — forces
+	// re-attestation. Never persisted.
+	CodeAttested bool
+	// codeAttestationRequired gates whether CodeAttested is ENFORCED for routing.
+	// Set at registration from the registry rollout flag, so the requirement is
+	// switched on only once APNs infra + provider support ship; until then the
+	// fleet routes as before. Fail-closed once true (no self-route exemption).
+	codeAttestationRequired bool
+
 	mu          sync.Mutex
 	pendingReqs map[string]*PendingRequest
 }
@@ -281,6 +300,12 @@ func providerSupportsPrivateTextLocked(p *Provider) bool {
 	// Require coordinator-verified SIP (from attestation challenge) rather
 	// than trusting the provider's self-reported SIPEnabled field.
 	if !p.ChallengeVerifiedSIP {
+		return false
+	}
+	// v0.6.0 APNs code-identity gate — the SINGLE chokepoint, no self-route
+	// exemption (gate everyone). Enforced only when the rollout flag is on, so the
+	// fleet keeps routing until APNs attestation is deployed; fail-closed after.
+	if p.codeAttestationRequired && !p.CodeAttested {
 		return false
 	}
 	caps := p.PrivacyCapabilities
@@ -372,6 +397,41 @@ func (p *Provider) SetChallengeVerifiedSIP(v bool) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.ChallengeVerifiedSIP = v
+}
+
+// SetCodeAttested records the result of the APNs code-identity round-trip
+// (thread-safe). Set true only after the provider returns a valid decrypted
+// nonce + Sign_SE over the WebSocket; in-memory only (never persisted).
+func (p *Provider) SetCodeAttested(v bool) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.CodeAttested = v
+}
+
+// GetCodeAttested reports whether this connection passed code-identity
+// attestation (thread-safe).
+func (p *Provider) GetCodeAttested() bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.CodeAttested
+}
+
+// CodeAttestationRequired reports whether code-identity attestation is enforced
+// for this provider's connection (the rollout flag stamped at registration).
+func (p *Provider) CodeAttestationRequired() bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.codeAttestationRequired
+}
+
+// SetCodeAttestationRequired toggles the v0.6.0 APNs code-identity rollout flag.
+// When true, providers registered afterward must pass code-identity attestation
+// (CodeAttested) to be routed private/text traffic. Call once at startup after
+// the APNs attestor is configured.
+func (r *Registry) SetCodeAttestationRequired(v bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.codeAttestationRequired = v
 }
 
 // Mu returns the provider's mutex for external callers that need to read
@@ -546,6 +606,14 @@ type Registry struct {
 	queue *RequestQueue
 
 	MinTrustLevel TrustLevel
+
+	// codeAttestationRequired is the v0.6.0 APNs code-identity rollout flag. When
+	// true, providers must pass the APNs code-identity round-trip (CodeAttested)
+	// to be routed private/text traffic. Default false so the fleet keeps routing
+	// until APNs infra + provider support are deployed; set true (via
+	// SetCodeAttestationRequired) once the attestor is configured. Stamped onto
+	// each Provider at registration.
+	codeAttestationRequired bool
 
 	modelCatalog map[string]CatalogEntry
 
@@ -1155,6 +1223,9 @@ func (r *Registry) Register(id string, conn *websocket.Conn, msg *protocol.Regis
 		PublicKey:               pubKey,
 		EncryptedResponseChunks: msg.EncryptedResponseChunks,
 		PrivateOnly:             msg.PrivateOnly,
+		APNsDeviceToken:         msg.APNsDeviceToken,
+		APNsEnvironment:         msg.APNsEnvironment,
+		codeAttestationRequired: r.codeAttestationRequired,
 		PrefillTPS:              msg.PrefillTPS,
 		DecodeTPS:               msg.DecodeTPS,
 		TrustLevel:              TrustNone,

--- a/coordinator/registry/registry_test.go
+++ b/coordinator/registry/registry_test.go
@@ -67,6 +67,48 @@ func testMakeTextRoutable(p *Provider) {
 	p.ChallengeVerifiedSIP = true
 }
 
+// TestCodeAttestationGate verifies the v0.6.0 APNs code-identity gate at the
+// single routing chokepoint: off by default (rollout flag), fail-closed when
+// required-but-unattested, routable once attested.
+func TestCodeAttestationGate(t *testing.T) {
+	mk := func() *Provider {
+		p := &Provider{
+			Backend:                 BackendMLXSwift,
+			PublicKey:               "fX6XYH7p2hmM3ogeXaAsY+p8M6UKD1df/LJUN9Nj9Nw=",
+			EncryptedResponseChunks: true,
+			PrivacyCapabilities: &protocol.PrivacyCapabilities{
+				TextBackendInprocess: true,
+				TextProxyDisabled:    true,
+				AntiDebugEnabled:     true,
+				CoreDumpsDisabled:    true,
+				EnvScrubbed:          true,
+			},
+		}
+		testMakeTextRoutable(p)
+		return p
+	}
+
+	// Rollout flag OFF: routable regardless of CodeAttested (no fleet regression).
+	if p := mk(); !providerSupportsPrivateTextLocked(p) {
+		t.Fatal("expected routable when codeAttestationRequired is off")
+	}
+
+	// Rollout flag ON, not attested: blocked (fail-closed, no self-route exemption).
+	p := mk()
+	p.codeAttestationRequired = true
+	if providerSupportsPrivateTextLocked(p) {
+		t.Fatal("expected NOT routable when required and !CodeAttested")
+	}
+
+	// Rollout flag ON, attested: routable.
+	p = mk()
+	p.codeAttestationRequired = true
+	p.CodeAttested = true
+	if !providerSupportsPrivateTextLocked(p) {
+		t.Fatal("expected routable when required and CodeAttested")
+	}
+}
+
 func TestRegisterAndGetProvider(t *testing.T) {
 	reg := New(testLogger())
 	msg := testRegisterMessage()

--- a/coordinator/registry/scheduler.go
+++ b/coordinator/registry/scheduler.go
@@ -1090,6 +1090,17 @@ func (r *Registry) DrainQueuedRequestsForModel(model string) {
 	r.drainQueuedRequestsForModels([]string{model})
 }
 
+// DrainQueuedRequestsForProvider attempts to assign queued requests for every
+// model a provider serves. Called when a provider becomes newly eligible for
+// routing (e.g. it just passed APNs code-identity attestation) so queued
+// demand is satisfied immediately instead of waiting for the next heartbeat.
+func (r *Registry) DrainQueuedRequestsForProvider(p *Provider) {
+	if p == nil {
+		return
+	}
+	r.drainQueuedRequestsForModels(providerModelIDs(p))
+}
+
 func (r *Registry) drainQueuedRequestsForModels(models []string) {
 	if r.queue == nil || len(models) == 0 {
 		return

--- a/coordinator/registry/scheduler_test.go
+++ b/coordinator/registry/scheduler_test.go
@@ -211,6 +211,43 @@ func TestDrainQueuedRequestsPopulatesDecision(t *testing.T) {
 	}
 }
 
+func TestDrainQueuedRequestsForProvider(t *testing.T) {
+	reg := New(testLogger())
+	model := "attest-drain-model"
+	p := makeSchedulerProvider(t, reg, "p1", model, 90)
+
+	// nil provider is a safe no-op (never panics).
+	reg.DrainQueuedRequestsForProvider(nil)
+
+	req := &QueuedRequest{
+		RequestID:  "queued-attest",
+		Model:      model,
+		ResponseCh: make(chan *Provider, 1),
+		Pending: &PendingRequest{
+			RequestID:             "queued-attest",
+			Model:                 model,
+			RequestedMaxTokens:    256,
+			EstimatedPromptTokens: 50,
+		},
+	}
+	if err := reg.Queue().Enqueue(req); err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+
+	// Draining by provider (as on a CodeAttested flip) must dispatch the queued
+	// request to that provider's model without waiting for a heartbeat.
+	reg.DrainQueuedRequestsForProvider(p)
+
+	select {
+	case assigned := <-req.ResponseCh:
+		if assigned == nil || assigned.ID != p.ID {
+			t.Fatalf("expected dispatch to %q, got %+v", p.ID, assigned)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for provider-drain dispatch")
+	}
+}
+
 func TestDrainQueuedRequestsSkipsUnassignableTargetedRequest(t *testing.T) {
 	reg := New(testLogger())
 	model := "queue-targeted-model"

--- a/docs/apns-code-attestation-design.md
+++ b/docs/apns-code-attestation-design.md
@@ -1,0 +1,440 @@
+# Provider Code-Identity Attestation via APNs — Design Doc
+
+Status: **Implemented (Phases 1–3) + verified-foundations.** Most claims below are empirically
+proven on-box (macOS 26.5 laptop + M5 Max as root) or confirmed against Apple documentation. Where
+something is still an open risk, it is marked **⚠️ TEST**.
+
+**Build status (June 2026, worktree `apns-r2-test`, both reviewers PASS):**
+- **Phase 1 — protocol contract:** ✅ `RegisterMessage` APNs fields + `code_attestation_response`
+  message, Go↔Swift symmetric, parity-tested.
+- **Phase 2 Track A — coordinator (Go):** ✅ `coordinator/apns/` (JWT/HTTP2 sender, dual-mode,
+  `E_K(nonce)` via `e2e.Encrypt`, `CodeIdentityAttestor` seam) + push-attest step in `api/provider.go`
+  + `CodeAttested` gate at the single chokepoint (rollout flag, default-off, fail-closed when on) +
+  `server.go`/`main.go` wiring. `go test ./...` green (incl `-race`).
+- **Phase 2 Track B — provider (Swift):** ✅ decrypt→`Sign_SE`→reply handler, `APNsBridge`,
+  `CoordinatorClientConfig` token threading, and the `NSApplication(.accessory)` rehost
+  (`main.swift` + `ProviderAppKitHost`). `swift build` green; non-MLX suites pass (full `swift test`
+  needs the MLX metallib — env-only).
+- **Phase 3 — integration test:** ✅ full coordinator round-trip (real encrypt→decrypt→sign→verify→
+  `CodeAttested`) + wrong-SE-key negative.
+- **Remaining (not code):** the Apple-portal step (enable Push, `.p8`, push profile,
+  `PROVISIONING_PROFILE_BASE64`); on-device validation of the rehosted-provider APNs flow (pattern
+  proven by `apns-r2-probe/coexist.swift` + the M5 Max receipt test); fleet background-push
+  reliability measurement (mitigation built: `APNS_MODE=alert`). **Deferred by design:** binaryHash
+  trust-demotion (additive) and §4.5 enrollment slim (would remove the SIP attestation). Worktree is
+  **not committed** (libs symlinked → restore gitlinks before any git op).
+
+The goal: in a **permissionless** network, give the coordinator (and ultimately the client) a
+**remotely-verifiable, non-self-reportable** assurance that a provider is running the genuine,
+unmodified Darkbloom binary — so a malicious operator can't clone the repo, add prompt-logging,
+and join — **with ~0% inference-time overhead and no human allowlist.**
+
+---
+
+## Part 1 — Everything we learned this session (knowledge ledger)
+
+### 1.1 The original gap
+- The coordinator **cannot verify the running binary's code identity.** `binaryHash` in the
+  attestation/challenge is **self-reported** by the provider's own (possibly modified) code →
+  worthless against a malicious provider. Enrollment is **open** (`enroll.go`: "No authentication
+  required"). MIN_TRUST=hardware proves *device*, not *code*.
+- E2E encryption makes the **coordinator** blind to plaintext (it runs in a Confidential VM and
+  re-encrypts to the provider) — but the **provider is the decryption endpoint by design**, so a
+  malicious provider sees plaintext. "E2E" = coordinator-blind, **not** provider-blind.
+
+### 1.2 Why the "obvious" fixes don't work on macOS
+- **App Attest** (`DCAppAttestService`) — the one Apple primitive that binds a key to an App ID
+  (Team+bundle), fork-proof — is **hard-`false` on every Mac** (native, Catalyst, iOS-on-AS), and
+  Apple DTS reconfirmed in 2026. The capability can't even be added to a macOS target in Xcode.
+- **No** first-class third-party **remote code-identity attestation** exists on macOS: exclaves
+  (Apple-private entitlements), Platform SSO `attestKey()` (device+key only, SSO-scoped), cryptexes
+  (no 3rd-party ticketing), PCC (no developer API; reaching it needs SIP+AMFI off) — all checked, all no.
+- **Cryptographic prevention** (provider never sees plaintext) is **infeasible at our perf budget**:
+  MPC for a 7-8B model = **750×–19,000×** slowdown; FHE 10⁴–10⁶×; blinded-outsourcing is decode-
+  dominated/"premium-slow". Only a **hardware GPU TEE** hits ~1.05× (= NVIDIA CC, ruled out: Mac-only).
+- **Key reframe:** the ≤25% confidential environment *already exists* — a hardened process is
+  unreadable by root at native speed. The missing piece is **provability** (attestation), which is a
+  **binary hardware primitive, not a perf dial** — you can't buy it with overhead.
+
+### 1.3 The insight that works: APNs is a code-identity-gated channel
+- To receive a push for an App-ID topic, an app needs the `aps-environment` entitlement, authorized
+  by an **Apple-signed provisioning profile** bound to **(App ID + the team's signing certs)**.
+- Bundle IDs/App IDs are **globally unique** (Apple's portal rejects duplicates); an attacker can't
+  register our App ID, can't get our profile, and can't sign with our certs.
+- Therefore **"received our push" is a remotely-verifiable capability only our genuine, team-signed,
+  Apple-provisioned code has** — the non-self-reportable signal every prior idea lacked.
+
+### 1.4 Empirically verified on-box (clean contrasts, only the variable changed)
+- AMFI **`Killed: 9`** an ad-hoc binary carrying a restricted entitlement (`aps-environment`).
+- A **different-team** binary spoofing our bundle ID + entitlement → **`Killed: 9`**, no token.
+- `.accessory` agent **gets a token and receives the push**; `.prohibited` does not.
+- Hardened Runtime (`CS_RUNTIME`, **no `get-task-allow`**): same-user lldb attach **blocked**;
+  `DYLD_INSERT_LIBRARIES` **ignored**. (plain binary: both succeed.)
+- keychain-access-group: owner (provisioned, team P7373SVQX6) reads the item; a **different-team**
+  binary claiming the same group is **`Killed: 9`**.
+- **On the M5 Max as ROOT, SIP on:** against the hardened (no-`get-task-allow`) process —
+  `task_for_pid` → **kr=5 (failure)**, `lldb` attach **failed**, `dtrace` **failed to grab**;
+  the non-hardened control allowed all three. Root **cannot** read `apsd`'s memory either (kr=5).
+- End-to-end APNs push **received** by a headless `.accessory` agent on two machines.
+
+### 1.5 Confirmed in Apple documentation
+- **SIP cannot be disabled at runtime** — requires recoveryOS + reboot; no reboot-free path.
+- With SIP on, even **root** can't `task_for_pid`/debug a protected/hardened process; **DTrace**
+  is restricted on protected processes.
+- Apple-Silicon boot levels **Full/Reduced/Permissive** via **LocalPolicy**, which is an **Image4
+  file signed by the Secure Enclave** → attestable, unforgeable by a compromised OS.
+- **MDA/ACME** attestation chains to the **Apple Enterprise Attestation Root CA**, is generated by
+  the SEP, Apple refuses to issue it for non-genuine hardware, and it **carries SIP status (OID
+  `1.2.840.113635.100.8.13.1`) + Secure Boot (`.13.2`)** (macOS 14+ Apple Silicon) + serial/UDID/OS
+  + a caller-supplied **freshness nonce**.
+- **Secure-Enclave private keys are non-extractable** (hardware guarantee). The access-group ACL
+  ("who may *use* the key") is **securityd/AMFI-enforced OS policy** (depends on SIP being on).
+
+### 1.6 Caught by testing — would have broken a naive build
+- **R-snoop is real:** with SIP **on**, **root can read the push payload nonce from the unified
+  log** (`log show` found it). A **plaintext** challenge nonce is therefore **relayable** (root
+  reads it from logs → hands to a fake binary → fake passes attestation). → The challenge **must be
+  encrypted to the provider's key `K`** (logged ciphertext is useless: root can't use `K` and can't
+  read the genuine process). Prompts are **not** affected — they ride the WebSocket, not the push.
+- **APNs app-push needs the user's GUI/Aqua session** — over SSH (non-GUI) the agent got
+  `NO_CALLBACK`; via `launchctl asuser <uid>` (GUI session) it got a token. The provider already
+  runs as a **gui-domain LaunchAgent** (`io.darkbloom.provider`), so this is satisfied — *provided
+  a user is logged in.*
+- **Load-bearing detail:** it's the **absence of `get-task-allow`** (not "Hardened Runtime" in
+  general) that blocks even-root injection. Notarization strips it; we must guarantee it's absent.
+
+### 1.7 APNs rate limits (the reason we checked before designing)
+- **Background pushes** (`apns-push-type: background`, `content-available:1`, **priority 5**) are
+  **throttled to ~2–3 per hour per *device*** (device-wide budget, **undocumented/dynamic**,
+  battery/data-budget dependent), **delivery NOT guaranteed**, can be delayed hours or dropped,
+  blocked by Low Power Mode / Background-App-Refresh-off / "app not recently used"; the throttle is
+  *disabled under a debugger* (test artifact only).
+  ([Apple: Pushing background updates](https://developer.apple.com/documentation/usernotifications/pushing-background-updates-to-your-app))
+- **Sender-side 429s:** `TooManyProviderTokenUpdates` if the **JWT** is regenerated < 20 min (reuse
+  one JWT ~60 min across all hosts); `TooManyRequests` if too many pushes hit the **same device
+  token** in quick succession (backoff, honor `Retry-After`).
+- `apns-expiration: 0` = discard if offline (don't store stale challenges); `apns-collapse-id`
+  coalesces.
+
+---
+
+## Part 2 — What was wrong with the previous design
+
+1. **Trusted a self-reported `binaryHash`** as if it proved code identity. It proves nothing against
+   a malicious provider (the measurer is the adversary).
+2. **Open enrollment + no global admission control** — anyone with a genuine Mac could join and be
+   routed traffic; "privacy" rested on no cryptographic or economic gate.
+3. **Conflated device attestation with code attestation** — MDA/MDM prove genuine hardware + SIP,
+   never *which binary* runs. Trust was upgraded to `hardware` on device facts alone.
+4. **Overstated guarantee** — marketing/threat-model implied provider-blindness; reality is
+   coordinator-blind (CVM) + unverified provider code.
+5. **The naive APNs idea (had we shipped it) was itself broken** — a plaintext challenge nonce is
+   log-snoopable by root and relayable to a fake binary.
+6. **Assumed a daemon could do APNs and that we could poll attestation** — both false (GUI session
+   required; background push is rate-limited and unreliable).
+
+---
+
+## Part 3 — The new design
+
+### 3.0 Why this attaches Apple-backed proof to the WebSocket (read this first)
+
+**The objection this section answers** (the right one to stress-test): *"The provider opens a normal
+outbound WebSocket; the coordinator only sees unauthenticated bytes. macOS code signing is **local**
+policy — Apple is not in that network path and emits no kernel statement binding the WebSocket to a
+code identity (TeamID/bundle/cdhash). So how is this remote attestation and not local policy?"*
+
+Correct — and the design does **not** try to authenticate the WebSocket directly. It **imports an
+Apple-gated proof from a second channel (APNs) and binds it onto this WebSocket session** via a key
+only the genuine process can use. The chain, with the empirical anchor for each link:
+
+1. **APNs is the Apple-mediated channel that code signing alone isn't.** Apple delivers a push for
+   topic `io.darkbloom.provider` **only** to a process whose `aps-environment` entitlement is
+   authorized by an **Apple-signed provisioning profile** for that App ID — i.e. only our genuine,
+   team-signed binary. *Proven on-box:* a different-Team-ID binary claiming that bundle ID +
+   entitlement is **AMFI `Killed: 9`** (won't even launch); only the genuine provisioned `.accessory`
+   agent gets a device token and receives the push. This **is** the "only Eigen's App ID can
+   receive/handle this request" enforcement that a self-declared SE key + WebSocket cannot provide.
+
+2. **The challenge is `E_K(nonce)`, never a raw nonce.** It is encrypted to the provider's registered
+   X25519 key `K` (`NodeKeyPair` — a **raw, in-memory libsodium key, NOT keychain-stored and NOT
+   Secure-Enclave-backed**; the SE only holds P-256). *Required because* **root can read the push
+   payload from the unified log** (proven on the M5 Max: `log show` surfaced a plaintext nonce). The
+   logged ciphertext is useless to root because **`K` exists only inside the genuine process's memory,
+   and that memory is unreadable**: SIP-on + Hardened Runtime (no `get-task-allow`) ⟹ even root gets
+   `task_for_pid → kr=5`, lldb/dtrace denied (proven as root on the M5 Max). **The keychain-ACL +
+   SE-non-extractable guarantee protects the _separate SE signing key_, NOT `K`.** Consequence:
+   K-confidentiality (and prompt-confidentiality) rest **entirely on SIP being on** — which is exactly
+   why the Apple-signed SIP attestation (pillar 2) is load-bearing, and why MDM cannot be removed yet
+   (see §3.4).
+
+3. **The round-trip transfers the proof onto *this* WebSocket.** The peer answers over its pinned TLS
+   connection by **returning the decrypted `nonce`** (proves it could decrypt `E_K(nonce)` ⟹ it holds
+   `K`) **together with `Sign_SE(nonce)`** (proves it holds the registered persistent SE identity).
+   Note: `K` is X25519 / **decrypt-only and cannot sign** — there is no `Sign_K`; the signature comes
+   from the **separate SE P-256 key**. Both legs are required (decrypt-and-echo binds `K`; `Sign_SE`
+   binds the persistent SE identity for free and ties the response to registration). Answering proves
+   the peer **(a) received the Apple-gated push** ⟹ genuine, App-ID-provisioned code, **and (b)
+   controls both `K` and the registered SE key.** The anonymous WebSocket is now bound to "genuine
+   code holding `K`." A **relay can't help**: a fake sibling process can't receive the push (no valid
+   token for our App ID), can't read the nonce from the genuine process (memory protected), and can't
+   lift it from the logs (ciphertext). All three legs are empirically closed.
+
+4. **The binding is continuous, not one-shot.** Every prompt is encrypted to `K` afterward, so only
+   genuine code can decrypt each request — the proof rides every message, not just the handshake.
+   Re-attest on reconnect (a reboot — the only way to turn SIP off — drops the connection), so no
+   polling is needed.
+
+**Proves:** the WebSocket peer is *our genuine, team-signed, Apple-provisioned binary, on a
+SIP-attested device, controlling `K`.* **Does NOT prove:** the exact release **cdhash** — APNs binds
+App-ID/Team, not version. That last gap is closed not by anything Apple gives us but by **reproducible
+builds + a public transparency log** of blessed cdhashes (§3.5); and once APNs establishes the code is
+our genuine unmodified binary, that binary's *self-reported* cdhash becomes trustworthy, so the two
+compose.
+
+**What does NOT work — and why the keychain access-group key is the wrong place to look for remote
+identity:** requiring "the provider use the Eigen access-group SE key" does **not** by itself block a
+fork remotely. The access-group restriction is enforced by `securityd` **locally, at call time**, and
+leaves **no transferable artifact** on the public key — so the coordinator **cannot distinguish** a
+genuine access-group key from a fork's own SE key (both produce identical signatures). The SE
+access-group key's job is **signing** (`Sign_SE(nonce)`, binding the response to a persistent SE
+identity) — **not** remote identity, and **not** the decryption step. The **decryption binding** in
+step 2 is done by `K`, whose confidentiality comes from **process-memory opacity** (SIP + Hardened
+Runtime), **not** from any keychain ACL (`K` isn't in the keychain). Remote identity comes from
+**APNs** (step 1). The three roles are distinct — **APNs = identity, `K`-in-protected-memory =
+decryption, SE key = signature** — and conflating any two of them is the single most common wrong turn
+here.
+
+### 3.1 The three orthogonal pillars (plus the lifecycle trick)
+1. **Code identity ← APNs.** Coordinator sends an attestation **push** to the provider's App-ID
+   topic; only our genuine, provisioned binary can receive it. Carries an **`E_K(nonce)`**
+   (encrypted to the provider's attested key), so a log-snooping root can't relay it.
+2. **Locked environment ← MDA/ACME.** Apple-signed proof of **genuine HW + SIP-on + Secure-Boot-
+   Full + boot policy** — the thing the binary can't self-attest (self-report is circular). This is
+   what makes pillar 1 and the SE-ACL trustworthy (AMFI only enforces while SIP is on).
+3. **Continuous binding ← in-memory X25519 key `K`.** Inference is encrypted to `K` (`NodeKeyPair`; a
+   raw libsodium key held **only in the genuine process's protected memory** — not SE-backed, not
+   keychain-ACL'd). Even a relayed attestation can't help a fake binary: only the genuine hardened
+   process can read/use `K`, and its memory can't be read (proven: root `task_for_pid → kr=5` under
+   SIP). A **separate persistent SE P-256 key** signs attestations (`Sign_SE`); *that* key is the one
+   that is keychain-access-group + SE-non-extractable. The two keys play distinct roles — do not
+   conflate `K` (decrypt) with the SE key (sign).
+4. **Lifecycle, not polling.** Attest **once per WebSocket connection**. SIP can't be disabled
+   without a **reboot**, which **drops the connection** → any downgrade forces a reconnect → forces
+   re-attestation (which the MDA check catches). No 5-minute polling — which is *mandatory* given
+   the background-push rate limit.
+
+### 3.2 Attestation flow (per connection)
+1. Provider (genuine, signed + push-provisioned, Hardened Runtime, **no get-task-allow**, running
+   as a **gui-session LaunchAgent**) on launch: creates/loads SE key + X25519 key `K`,
+   `registerForRemoteNotifications()` → **device token `T`**, opens **pinned-TLS** WebSocket,
+   sends `{X25519 pubkey K, device token T}` (signed by the SE key).
+2. Coordinator: binds `T ↔ K` (one-to-one; first genuine registration wins); runs MDA/ACME check
+   (with a freshness nonce) → confirms **genuine HW + SIP-on + Secure-Boot-Full**; sends an APNs
+   **background push** to `T` with payload `E_K(nonce)` (`apns-priority 5`, `apns-push-type
+   background`, short `apns-expiration`). The `nonce` is **single-use, short-TTL, encrypted to this
+   connection's `K`**, and must be answered **on the same WebSocket that registered that `K`+`T`** —
+   tracked per-connection, **not** in a global serial-keyed map (two connections claiming one serial
+   would otherwise race).
+3. Provider receives the push (only genuine code can), **decrypts `nonce` with `K`**, and returns
+   **the decrypted `nonce` plus `Sign_SE(nonce)`** over the pinned WebSocket (`K` is decrypt-only; the
+   signature is the SE P-256 key).
+4. Coordinator verifies → marks the connection **code-attested**; routes private inference,
+   **encrypting each prompt to `K`**. Holds until disconnect; **re-attest on reconnect.**
+
+### 3.3 Rate-limit handling (driven by Part 1.7)
+- **Attest once per connection**, not per request and not polled — push rate ≈ reconnect rate, well
+  within ~2–3/hr for stable long-lived connections.
+- **Fail-closed:** no code-attestation → provider stays in a non-private/pending state, not routed
+  private traffic. (Availability hit, not a security hole.)
+- **Per-provider push backoff** + honor `Retry-After`; **one shared JWT** per (Team/Key), refreshed
+  ~hourly (avoid `TooManyProviderTokenUpdates`); `apns-expiration` short so stale challenges expire.
+- **⚠️ TEST (open risk):** background-push delivery to provider *agents* is best-effort and
+  device-budget-throttled — measure real-world **delivery latency/success** on the fleet (plugged-in,
+  caffeinated, logged-in Macs may have a healthier budget, but this is *unconfirmed*). **Fallback if
+  unreliable:** use an **alert** push (`priority 10`, not background-throttled, reliable & prompt) at
+  the cost of requiring notification permission + a benign visible notification — acceptable for an
+  *infrequent* per-connection attestation. Decide after measurement.
+
+### 3.4 The MDM-removal question (answered)
+- **Push capability needs NO user-installed profile** — the `aps-environment` provisioning profile
+  is **embedded in the .app bundle at build time** (invisible to the user).
+- **SIP attestation still requires a user-installed config profile** — it's the only Apple-signed
+  "SIP is on" oracle; **not removable** for the hard guarantee.
+
+**⚠️ Correction (verified against the code — do NOT slim enrollment as part of this feature):** the
+earlier "slim to ACME-only" plan is **deferred and decoupled**. Three findings from the code map make
+removing the MDM payload *unsafe today*:
+- The **only trustworthy, non-circular SIP/Secure-Boot signal is the Apple-signed MDA**
+  (`attestation/mda.go` parses OID `.13.1`/`.13.2`), and **MDA is obtained via an MDM command**
+  (`DeviceInformation`, `verifyAppleDeviceAttestation`). The **ACME step-ca cert carries no SIP OIDs**.
+- The **ACME→hardware path is non-functional today**: P-384 cert vs the P-256-only SE; no mTLS ingress
+  populates the `X-Ssl-Client` headers `acme_verify.go` reads; the HardwareBound cert lands in an
+  Apple-only keychain group. The operative prod hardware-trust path is the **MDM SecurityInfo
+  cross-check** (`verifyProviderViaMDM`).
+- Per §3.0, **`K`-confidentiality and prompt-confidentiality both rest on SIP-on**, which is *only*
+  provable via that Apple-signed MDA. Pull MDM and you don't just lose pillar 2 — you lose the
+  attestation that `K` and every plaintext prompt are actually unreadable.
+
+Net: **keep MDM, ship APNs** (the code-identity feature needs zero enrollment changes). MDM-removal
+becomes a **separate later project** that must first make ACME `device-attest-01` actually carry +
+verify the SIP OID (and add mTLS ingress + provider-side key-identity), at which point the
+no-management UX win is real. The provider already self-reports SIP in the SE-signed challenge, but
+that is **circular** against a malicious operator — it is liveness, not proof.
+
+### 3.5 Trust model & honest residuals
+- Root of trust = **Apple's silicon/attestation + our control of our Apple signing identity**
+  (Developer-ID key, provisioning, APNs `.p8`). **These become crown jewels** — HSM/least-access/
+  monitoring; their compromise breaks the scheme (that's "compromise the trusted party").
+- **Insider** with our signing key could sign passing code → mitigated by **reproducible build +
+  public transparency log** of blessed cdhashes (so the binary is community-auditable, not just
+  team-signed). This is also why APNs *upgrades* the previously-worthless self-reported `binaryHash`
+  into a real check: once APNs proves it's our genuine unmodified code, that code's self-reported
+  cdhash is trustworthy → pair with the transparency log for version/downgrade control.
+- **Irreducible:** requires a logged-in GUI session; APNs delivery is best-effort (availability, not
+  confidentiality); and the whole thing assumes SIP-on, which we attest but the user could lower
+  (→ caught by MDA → fail-closed).
+
+---
+
+## Part 4 — Code changes required (drastic), by component
+
+Legend: **[NEW]** new code/subsystem · **[CHG]** significant change · **[BUILD]** build/signing/portal.
+
+### 4.1 Build, signing & Apple portal **[BUILD]** — prerequisite for everything
+- Apple portal: enable **Push Notifications** on App ID `io.darkbloom.provider`; create an **APNs
+  `.p8` auth key** for the team; generate a **push-enabled provisioning profile**.
+- `provider-swift/entitlements.plist` **[CHG]**: add `com.apple.developer.aps-environment`
+  (`production`). Keep hypervisor + keychain-access-groups. **Assert NO `get-task-allow`.**
+- `.github/workflows/release-swift.yml` **[CHG]**: embed the push provisioning profile in the
+  `.app`; sign with it (keep `--options runtime` + notarize + staple); **add a CI assertion that the
+  signed binary has no `get-task-allow`** and that `aps-environment` is present; (later) make the
+  build **reproducible** + publish the cdhash to a **transparency log**.
+
+### 4.2 Provider (Swift) **[CHG/NEW]** — the most architectural change
+- The serve path must host an **`NSApplication` run loop in `.accessory` mode** so the agent can
+  `registerForRemoteNotifications()` and receive `didReceiveRemoteNotification`. Today the process
+  stays alive parked on `for await event in events` (`ProviderLoop.swift:386`) — there is **no**
+  AppKit/run loop. AppKit must own the **true main thread** (mutually exclusive with the
+  `@main AsyncParsableCommand` main-task drain), so a custom main-thread entrypoint: parse args →
+  build `NSApplication` + delegate `.accessory` on the main thread → launch `ProviderLoop.run()` as a
+  child `Task` → `app.run()`. The inference/WS loop body itself **does not change** — only *where* it
+  is launched. Applies to **all three** long-lived serve paths (`runForeground:219`,
+  `runScheduled:372`, `runLocalStandalone:123`). *(This is the single biggest provider-side change.)*
+  - **✅ DAY-1 COEXISTENCE SPIKE — architecture PROVEN** (`apns-r2-probe/coexist.swift` +
+    `run-coexist.sh` / `verify-delivery.sh` / `verify-open.sh`, M4 Max, macOS 26.5). In ONE process:
+    `NSApplication(.accessory)` owned the main thread, a sustained MPS matmul loop (the same Metal path
+    MLX rides) ran **110,710 iters / 178s (~620 matmul/s)** on a background thread, the **main run-loop
+    heartbeat ticked all 175×** (no starvation), and the APNs **register callback fired on main →
+    device token** — all concurrently. The Layer-1 rehost (`app.run()` on main + `Task { loop.run() }`
+    off-main) is sound. The current provider does **not** use Hypervisor.framework (`hypervisorActive`
+    hardcoded `false`), so the only coexistence question was GPU × AppKit-main × APNs → passes.
+  - **The GPU-suppresses-push-receipt hypothesis is REFUTED**: in a controlled test, push receipt failed
+    **idle too** (not just under load), so the receipt miss is independent of GPU. Receipt also failed
+    across single-clean-registration, LaunchServices `open`-launch, alert (prio 10), and store-and-forward
+    — with `apsd` logging **nothing** for the topic. ⟹ today's receipt failure is a **degraded device/APNs
+    delivery state** for this heavily-abused test token (dozens of re-signs, incl. adversary-team
+    re-signing of the same bundle id — likely poisoned apsd's per-bundle subscription), **NOT** an
+    architecture/coexistence problem. Receipt was proven end-to-end in an earlier session.
+  - **✅ RECEIPT CONFIRMED end-to-end on a fresh device (M5 Max, macOS 26.4):** app signed here
+    (Developer ID + `perstest` profile, which is `ProvisionsAllDevices`), copied to the M5, launched in
+    the GUI session via `launchctl asuser 501`, got a fresh device token, and a **single
+    background/silent push (prio 5, `content-available`) — the real attestation channel — was received
+    on the FIRST try**, nonce matching exactly. ⟹ the push round-trip works end-to-end; this laptop's
+    earlier misses were **rate-limit / poisoned device-state** (a burned test token re-signed dozens of
+    times incl. under a different team), **not** the mechanism, registrations, launch method, or GPU
+    load. The whole spike (coexistence **+** receipt) is now closed. Scripts:
+    `apns-r2-probe/run-m5-test.sh` (sign-here/run-there/send-here, no secret moved to the M5).
+  - **Device-token ordering:** the token arrives **async** (`didRegisterForRemoteNotifications…`) after
+    `registerForRemoteNotifications()`, but Register is sent synchronously at connect
+    (`ProviderLoop.swift:346-369`) → either await the token before Register, or deliver it in a
+    follow-up message. Plus a delegate→actor bridge so the main-thread callback hops into the
+    `ProviderLoop` actor to decrypt with `K` and answer via `SendHandle`.
+- **[NEW]** APNs module: register for remote notifications, capture the **device token**, hand it to
+  the coordinator client; implement the delegate to receive the push, **decrypt `E_K(nonce)`** with
+  the X25519 `NodeKeyPair` (`K`), and return **the decrypted nonce + `Sign_SE(nonce)`** (SE signing
+  key) over the WebSocket. (There is no `Sign_K` — `K` is decrypt-only.)
+- `ProviderCore/Service/LaunchAgent.swift`: already gui-domain ✓ — confirm `.accessory`/`LSUIElement`
+  and that it runs in the logged-in session; document the "must be logged in" requirement.
+- `Security/AttestationBuilder.swift`: keep the SE attestation; **stop treating self-reported
+  `binaryHash` as security** (drift-only); add the push-challenge response path.
+
+### 4.3 Protocol **[CHG]** — `coordinator/protocol/messages.go`
+- `RegisterMessage` (+ Swift mirror): add **`APNsDeviceToken string`** (and APNs environment).
+- Repurpose/extend the attestation messages: the **code-identity challenge now travels via APNs
+  push** (carrying `E_K(nonce)`), and the **response** returns over the WebSocket. The existing
+  WS `AttestationChallengeMessage`/`AttestationResponseMessage` (nonce+timestamp signed by SE key)
+  **remains for liveness/status only — it is NOT a code-identity proof.** Keep protocol symmetry
+  (Go + Swift).
+
+### 4.4 Coordinator **[NEW/CHG]**
+- **[NEW]** `coordinator/apns/` package: load the `.p8`, mint/cache **one JWT per (Team/Key)
+  ~hourly**, HTTP/2 sender to APNs, `E_K(nonce)` build (reuse `internal/e2e.Encrypt` to the
+  provider's `K`), **429/Retry-After + per-provider backoff** handling, `apns-expiration` short.
+  **Build the sender dual-mode from day one** — background (`apns-push-type background`, priority 5)
+  vs alert (priority 10) differ only by two headers; expose it as config behind the
+  `CodeIdentityAttestor` seam so the unmeasured background-reliability risk becomes a **flag flip**,
+  not a rearchitecture, and can be measured on the fleet in parallel.
+- `api/provider.go` **[CHG]**: on register, store `APNsDeviceToken`, bind `T ↔ K`; add a
+  **push-based code-identity attestation step** at connection (send push, await WS response, mark
+  connection code-attested). The existing `challengeLoop`/`sendChallenge` (WS) becomes
+  **liveness/status only**. Gate **private-tier routing** on code-attested == true (fail-closed).
+- `registry/registry.go` **[CHG]**: `Provider` struct add `APNsDeviceToken` + a `CodeAttested`
+  state (**in-memory only, default false, reset on disconnect** — mirror `untrustedRecoverable`,
+  never persisted). Gate at the **single chokepoint `providerSupportsPrivateTextLocked`** (one edit
+  propagates to all ~11 routing/capacity/warm sites). **Note:** there is no separate "private tier" —
+  *all* text/image/STT/embeddings routing already funnels through this predicate, so gating it on
+  `CodeAttested` is strictly **fail-closed** (nothing routes until attested). **Self-route decision:**
+  this also blocks an owner routing to their *own* un-attested Mac; if self-route should be exempt, add
+  an explicit per-request flag mirroring `SelfRouteOnly` — do not rely on `relaxTrust` (it lowers the
+  trust floor but does not bypass the chokepoint).
+- **`binaryHash` demotion is demote-not-delete:** `binary_hash` is **inside the SE-signed status
+  canonical** (`AttestationBuilder.swift` ↔ `attestation/attestation.go BuildStatusCanonical`).
+  **Do NOT remove it or change the canonical bytes** — that re-triggers the Go/Swift canonical-drift
+  ECDSA failures this repo has hit. Only **stop the coordinator from treating it as a trust/routing
+  signal** (`verifyProviderAttestation:1685-1712`, `verifyChallengeResponse:835-884`); keep it as
+  drift-detection telemetry. Also decide whether the release-build hard-startup-abort on an empty
+  `binaryHash` (`ProviderLoop.swift:476-479`) stays.
+- **[NEW]** `CodeIdentityAttestor` interface (seam): one impl today
+  (`APNsPushAttestor` fusing APNs + MDA + `K`-binding); future drop-in (`AppAttestAttestor`) if
+  Apple ever ships it. Routing/key-release depend only on the interface.
+
+### 4.5 Enrollment — **DEFERRED, out of scope for this feature** (`coordinator/api/enroll.go`)
+- **No change.** Per §3.4, slimming the `.mobileconfig` to ACME-only would remove the only working
+  Apple-signed SIP attestation (MDA-over-MDM), which the APNs code-identity scheme depends on. The
+  code-identity feature requires **zero** enrollment changes. Revisit as a separate project after
+  ACME `device-attest-01` is made to carry+verify the SIP OID (+ mTLS ingress + provider key-identity).
+
+### 4.6 Client / console-ui (later, for the strongest variant)
+- Move attestation **verification client-side** (verify the transparency-log proof + MDA before the
+  prompt is exposed), shrinking reliance on the coordinator-CVM. (PCC-style; optional, phase 2.)
+
+---
+
+## Open risks / test next
+1. **⚠️ Background-push delivery reliability to provider agents** — measure on the fleet; decide
+   background vs alert push. *This is the top open risk* — and the spike reinforced it: on a repeated
+   ad-hoc test today, **both background (prio 5) and alert (prio 10) pushes were accepted by APNs (HTTP
+   200) but never reached the device** (`apsd` logged nothing; nonce absent from the unified log) — even
+   though the *same* harness delivered successfully in an earlier session. Two confounds make the ad-hoc
+   harness a poor *delivery* testbed (it's fine for token/coexistence): (a) the app is **directly-exec'd
+   and rebuilt each run**, leaving **multiple stale LaunchServices registrations** for one bundle id,
+   which breaks delivery routing; (b) device-side background budget/APNs-connection state varies.
+   **→ Real measurement must use a single, properly-installed app** (one LS registration, launched via
+   the LaunchAgent/`open`, real bundle id + push profile, notification permission for alert mode) **on
+   the fleet.** The sender is already prototyped **dual-mode** (`send-push.swift --alert` / `--expiration`)
+   so background-vs-alert is a flag flip. Until measured, **fail-closed** is the safe default.
+   **Encouraging data point (M5 Max, fresh device):** a single background/silent push delivered
+   **promptly on the first try** to a healthy, plugged-in, logged-in Mac — i.e. our exact provider-fleet
+   profile — so the background channel is viable for the once-per-connection cadence (well within the
+   ~2–3/hr budget). What remains to measure at scale is delivery *variance over time / across the fleet*
+   (sleep/wake, Low Power Mode, long-idle), not whether background delivery works at all.
+2. **GUI-session dependency — RESOLVED by policy.** APNs app-push needs a logged-in Aqua session;
+   product decision is to **require providers to be logged in before starting the machine** (the
+   LaunchAgent already runs gui-domain). Headless/login-screen Macs simply fail-closed (won't
+   code-attest, won't be routed). No longer an open *risk* — an onboarding requirement to document.
+3. **Phase 2 (optional):** prove the bypass — disable SIP/AMFI in recoveryOS and show the protections
+   collapse (fork receives the push, root reads the process, ACL falls) → the empirical proof the
+   ACME profile is load-bearing. Needs physical recoveryOS + ideally a spare machine.
+4. **Provisioning-profile validity for push under Reduced/Permissive** — confirm a downgraded
+   machine's MDA reflects it (expected) so fail-closed holds.

--- a/docs/apns-code-attestation-design.md
+++ b/docs/apns-code-attestation-design.md
@@ -1,8 +1,16 @@
 # Provider Code-Identity Attestation via APNs — Design Doc
 
 Status: **Implemented (Phases 1–3) + verified-foundations.** Most claims below are empirically
-proven on-box (macOS 26.5 laptop + M5 Max as root) or confirmed against Apple documentation. Where
-something is still an open risk, it is marked **⚠️ TEST**.
+proven on-box (macOS 26.5 laptop + M5 Max as root, macOS 26.4) or confirmed against Apple
+documentation. Where something is still an open risk, it is marked **⚠️ TEST**.
+
+> **Update (June 2026) — R-snoop re-verified closed + post-review hardening.** A clean on-box re-test
+> shows the encrypted `code_challenge` is **not** harvestable by root (redacted `<private>` in the
+> log; absent from every on-disk store; CLI un-redaction removed on 26.4) — correcting the earlier
+> "R-snoop is real" claim (see **§1.6.1**). Alert mode is safe only because the provider requests no
+> `UNUserNotificationCenter` authorization (invariant). Four post-review fixes landed on this PR:
+> delegate strong-retain (release-build brick), early-push buffering, late-token re-registration,
+> and drain-queues-on-`CodeAttested` — each with tests; both reviewers PASS.
 
 **Build status (June 2026, worktree `apns-r2-test`, both reviewers PASS):**
 - **Phase 1 — protocol contract:** ✅ `RegisterMessage` APNs fields + `code_attestation_response`
@@ -91,17 +99,52 @@ and join — **with ~0% inference-time overhead and no human allowlist.**
   ("who may *use* the key") is **securityd/AMFI-enforced OS policy** (depends on SIP being on).
 
 ### 1.6 Caught by testing — would have broken a naive build
-- **R-snoop is real:** with SIP **on**, **root can read the push payload nonce from the unified
-  log** (`log show` found it). A **plaintext** challenge nonce is therefore **relayable** (root
-  reads it from logs → hands to a fake binary → fake passes attestation). → The challenge **must be
-  encrypted to the provider's key `K`** (logged ciphertext is useless: root can't use `K` and can't
-  read the genuine process). Prompts are **not** affected — they ride the WebSocket, not the push.
+- **R-snoop — re-verified, does NOT reproduce (see §1.6.1):** an earlier ad-hoc run suggested root
+  could read the push nonce from the unified log, which drove the decision to encrypt the challenge.
+  A **clean re-test on macOS 26.4** shows the payload is redacted (`<private>`) in the log and is
+  **never on disk** — the earlier positive was a grep false-positive (it matched the probe app's
+  *directory name*, not the payload). We **still encrypt the challenge to the provider's key `K`**
+  (`E_K(nonce)`) as **defense-in-depth** — it protects on older macOS, under a user-enabled
+  private-data logging profile, or via any other log facility, and costs nothing. The logged
+  ciphertext is useless to a root attacker who does not hold `K`. Prompts are **not** affected —
+  they ride the WebSocket, not the push.
 - **APNs app-push needs the user's GUI/Aqua session** — over SSH (non-GUI) the agent got
   `NO_CALLBACK`; via `launchctl asuser <uid>` (GUI session) it got a token. The provider already
   runs as a **gui-domain LaunchAgent** (`io.darkbloom.provider`), so this is satisfied — *provided
   a user is logged in.*
 - **Load-bearing detail:** it's the **absence of `get-task-allow`** (not "Hardened Runtime" in
   general) that blocks even-root injection. Notarization strips it; we must guarantee it's absent.
+
+### 1.6.1 R-snoop re-verified on-box — the encrypted payload is **not** harvestable (June 2026)
+
+A focused re-test on the M5 Max (macOS **26.4**, as root) **does not reproduce** the "root reads the
+challenge from the log" finding. The earlier positive was a measurement artifact — a grep that
+matched the probe app's *directory name* (`rsnoop-probe`), not the payload (a false positive of
+exactly that class was caught and corrected during this re-test). Grepping for the actual payload
+markers shows the challenge is redacted and never on disk:
+
+| Harvest surface (as root) | Result |
+|---|---|
+| Unified log (`log show`, all processes) | `apsd` logs `payload <private>`; marker-only grep (`RSNOOPepk-…`) = **0** |
+| Un-redact via CLI (`log config … private_data:on`) | rejected — `Invalid Modes` |
+| Install a private-data logging profile (CLI) | blocked — "profiles tool no longer supports installs" (GUI/MDM only) |
+| Notification Center DB (alert push) | **0** — provider requests no notification auth, so an alert is never persisted |
+| apsd on-disk store + keychain + prefs + `/var/db` | **0** (background **and** alert) |
+| Our own provider logs | never logs the ciphertext or nonce |
+
+**Invariant that keeps alert mode safe:** the provider registers for *remote* notifications only and
+**never requests `UNUserNotificationCenter` authorization** — so an `APNS_MODE=alert` push is never
+presented or persisted to the root-readable Notification Center DB. If that ever changes, the
+attestation push must be forced background-only. (Documented at both ends: `ProviderAppKitHost.swift`
++ `coordinator/apns/attestor.go`.)
+
+**Scope & residual:** verified on macOS **26.4** (min target is 15 — treat the claim as "current
+macOS"). The `E_K(nonce)` encryption (§3.0) is retained as defense-in-depth for older macOS / any
+other log facility. A *determined* attacker on their own hardware could manually install a
+private-data logging profile via System Settings (conspicuous, persistent) **and** harvest a genuine
+device token **and** race the genuine `T↔K` registration — the same "patient insider on own hardware"
+residual in §3.5, not a casual `log show` harvest. Reproduction tooling (not shipped):
+`apns-r2-probe/run-m5-rsnoop.sh`, `run-m5-ondisk.sh`.
 
 ### 1.7 APNs rate limits (the reason we checked before designing)
 - **Background pushes** (`apns-push-type: background`, `content-available:1`, **priority 5**) are
@@ -158,8 +201,10 @@ only the genuine process can use. The chain, with the empirical anchor for each 
 
 2. **The challenge is `E_K(nonce)`, never a raw nonce.** It is encrypted to the provider's registered
    X25519 key `K` (`NodeKeyPair` — a **raw, in-memory libsodium key, NOT keychain-stored and NOT
-   Secure-Enclave-backed**; the SE only holds P-256). *Required because* **root can read the push
-   payload from the unified log** (proven on the M5 Max: `log show` surfaced a plaintext nonce). The
+   Secure-Enclave-backed**; the SE only holds P-256). *Defense-in-depth against a log-readable
+   payload* — a clean re-test on macOS 26.4 shows the payload is redacted `<private>` and not
+   harvestable from log or disk (§1.6.1), but encrypting `E_K(nonce)` still protects on older macOS /
+   under user-enabled private logging, at zero cost. The
    logged ciphertext is useless to root because **`K` exists only inside the genuine process's memory,
    and that memory is unreadable**: SIP-on + Hardened Runtime (no `get-task-allow`) ⟹ even root gets
    `task_for_pid → kr=5`, lldb/dtrace denied (proven as root on the M5 Max). **The keychain-ACL +
@@ -291,6 +336,13 @@ that is **circular** against a malicious operator — it is liveness, not proof.
   team-signed). This is also why APNs *upgrades* the previously-worthless self-reported `binaryHash`
   into a real check: once APNs proves it's our genuine unmodified code, that code's self-reported
   cdhash is trustworthy → pair with the transparency log for version/downgrade control.
+- **R-snoop (log/disk harvest of the challenge) — verified closed on current macOS** (§1.6.1): the
+  encrypted payload is redacted (`<private>`) in the unified log and absent from every on-disk store
+  (apsd store, Notification Center DB) for background **and** alert pushes; CLI un-redaction is
+  removed on macOS 26.4. **Alert mode is safe only because the provider requests no
+  `UNUserNotificationCenter` authorization** — an invariant enforced by code review + comments at
+  both ends. Residual: a determined attacker on their own hardware could manually enable private-data
+  logging via the GUI **and** harvest a genuine token **and** race the `T↔K` registration.
 - **Irreducible:** requires a logged-in GUI session; APNs delivery is best-effort (availability, not
   confidentiality); and the whole thing assumes SIP-on, which we attest but the user could lower
   (→ caught by MDA → fail-closed).

--- a/docs/threat-model.yaml
+++ b/docs/threat-model.yaml
@@ -1532,28 +1532,54 @@ threats:
   - id: T-034
     trust_boundary: TB-009
     stride: Tampering
-    title: Binary hash in attestation blob does not match running binary
+    title: Provider runs modified code while advertising a trusted identity
     description: >
-      The attestation blob includes a SHA-256 hash of the darkbloom binary at
-      startup. If hash computation is deferred, skipped, or computed over the wrong
-      path, a provider can run a modified binary while advertising a blessed hash.
+      The original control was a SHA-256 binary hash in the attestation blob. That
+      hash is SELF-REPORTED by the provider's own (possibly modified) code, so it is
+      worthless against a malicious operator: a fork can report a blessed hash while
+      running prompt-logging code. The real control is APNs code-identity attestation
+      (v0.6.0): only our genuine, Team-ID-signed, push-provisioned binary can RECEIVE
+      an APNs push for our App-ID, and only the genuine hardened process can DECRYPT
+      the E_K(nonce) challenge with its in-memory key K and sign the nonce with its
+      registration-bound SE key — verified once per WebSocket connection.
     adversaries: [ADV-001]
     affected_assets: [A-010, A-011]
     affected_files:
-      - provider-swift/Sources/ProviderCore/Security/BinaryHasher.swift
-      - provider-swift/Sources/ProviderCore/Security/AttestationBuilder.swift
-      - coordinator/internal/attestation/**
+      - coordinator/apns/attestor.go
+      - coordinator/api/provider.go
+      - coordinator/registry/registry.go
+      - provider-swift/Sources/ProviderCore/ProviderLoop.swift
+      - provider-swift/Sources/darkbloom/ProviderAppKitHost.swift
     mitigations:
-      - description: BinaryHasher computes SHA-256 of the running executable at startup.
+      - description: >
+          APNs code-identity round-trip: coordinator pushes E_K(nonce) to the
+          registration-bound device token; provider decrypts with K and replies
+          nonce + Sign_SE(nonce) over the WebSocket; coordinator verifies the nonce
+          matches and the SE signature verifies against the registration-bound key.
         status: implemented
-      - description: Coordinator verifies binary hash against the registry of blessed hashes.
+      - description: >
+          CodeAttested gate at the single routing chokepoint
+          (providerSupportsPrivateTextLocked), fail-closed, no self-route exemption;
+          enforced when an attestor is configured (rollout flag, default-off).
         status: implemented
+      - description: >
+          Self-reported binaryHash DEMOTED to drift telemetry — derouting on mismatch
+          is behind a default-off binaryHashEnforce flag. It is no longer relied on as
+          a code-identity control.
+        status: implemented
+      - description: >
+          Strongest version (cross-cutting): reproducible build + public transparency
+          log of blessed cdhashes, so the genuine APNs-proven binary's self-reported
+          cdhash becomes auditable (version/downgrade control).
+        status: open
     open_findings: []
     severity: critical
     detection_hint: >
-      Changes to BinaryHasher.swift, AttestationBuilder, or coordinator-side binary
-      hash verification must preserve the invariant that the hash covers the actual
-      running binary, not a copy or cached value.
+      Changes to coordinator/apns, the per-connection push-attest step in
+      api/provider.go, the CodeAttested gate in registry, or the provider's
+      decrypt→Sign_SE→reply handler must preserve the property that only genuine,
+      Apple-provisioned code can pass. Re-relying on binaryHash as a security control
+      (vs telemetry) is a regression.
 
   - id: T-035
     trust_boundary: TB-009
@@ -1758,3 +1784,52 @@ threats:
       Any change in coordinator/profilesign or main.go that logs, transmits, or
       persists PROFILE_SIGNING_P12_B64 / _PASSWORD or the decoded key outside the
       signer must be treated as a high-severity issue.
+
+  # ── TB-009: APNs code-identity mechanism's own attack surface ──
+
+  - id: T-042
+    trust_boundary: TB-009
+    stride: Spoofing
+    title: Forged code-identity via attacker-key challenge + log/disk harvest (R-snoop)
+    description: >
+      The APNs challenge (T-034) is encrypted to the provider's self-reported key K.
+      A fork that registers its OWN key K' could, in principle, harvest the pushed
+      E_K'(nonce) from a root-readable surface on its own machine and decrypt it with
+      K' — passing attestation without being genuine code. This requires the push
+      payload to be readable by root AND a genuine App-ID device token bound to K'.
+      Residual: a determined attacker on their own hardware could manually enable
+      private-data logging via the GUI AND harvest a genuine token AND race the
+      genuine T↔K registration — the "patient insider on own hardware" class
+      (consistent with T-037 and the irreducible residuals), not a casual log read.
+    adversaries: [ADV-001]
+    affected_assets: [A-001, A-010]
+    affected_files:
+      - coordinator/apns/attestor.go
+      - provider-swift/Sources/darkbloom/ProviderAppKitHost.swift
+      - provider-swift/Sources/ProviderCore/Apns/APNsBridge.swift
+    mitigations:
+      - description: >
+          R-snoop verified CLOSED on current macOS (26.4, on-box): the encrypted
+          code_challenge is redacted (<private>) in the unified log and absent from
+          every on-disk store (apsd store, Notification Center DB) for background AND
+          alert pushes; CLI un-redaction (log config private_data:on / profiles
+          install) is removed. See docs/apns-code-attestation-design.md §1.6.1.
+        status: implemented
+      - description: >
+          INVARIANT — the provider requests no UNUserNotificationCenter authorization,
+          so an alert-mode push is never presented/persisted to the root-readable
+          Notification Center DB. Enforced by code review + comments at both ends
+          (ProviderAppKitHost.swift, coordinator/apns/attestor.go).
+        status: implemented
+      - description: >
+          Challenge encrypted as E_K(nonce) (defense-in-depth for older macOS / a
+          user-enabled private-data logging profile); the SE signature is verified
+          against the key bound at registration, never a key supplied in the response.
+        status: implemented
+    open_findings: []
+    severity: high
+    detection_hint: >
+      Reopens if any change (a) makes the provider request user-notification
+      authorization, (b) carries code_challenge in an alert-rendering payload, or
+      (c) logs the push payload. The closed-verification scope is current macOS
+      (min target is 15); re-verify on a version bump.

--- a/provider-swift/Sources/ProviderCore/Apns/APNsBridge.swift
+++ b/provider-swift/Sources/ProviderCore/Apns/APNsBridge.swift
@@ -1,0 +1,61 @@
+import Foundation
+
+/// Bridges the macOS app delegate (which owns the APNs callbacks on the main
+/// thread) and the `ProviderLoop` actor (which owns K + the SE signer + the
+/// WebSocket send path).
+///
+/// The app delegate publishes the device token and delivers incoming pushes
+/// here; the `ProviderLoop` awaits the token before registering and installs a
+/// handler for incoming code-identity challenges. A process-wide singleton
+/// because AppKit constructs the delegate (no DI seam) and there is exactly one
+/// provider loop per process.
+public final class APNsBridge: @unchecked Sendable {
+    public static let shared = APNsBridge()
+
+    private let lock = NSLock()
+    private var deviceToken: String?
+    private var pushHandler: (@Sendable ([String: Any]) -> Void)?
+
+    private init() {}
+
+    /// Called by the app delegate when APNs returns a device token (hex).
+    public func setDeviceToken(_ hex: String) {
+        lock.lock()
+        deviceToken = hex
+        lock.unlock()
+    }
+
+    /// The current device token, if APNs has returned one.
+    public func currentDeviceToken() -> String? {
+        lock.lock()
+        defer { lock.unlock() }
+        return deviceToken
+    }
+
+    /// Awaits the device token, returning nil after `timeoutSeconds`. The timeout
+    /// matters: a headless / no-GUI / login-screen box never gets a token, and
+    /// must still register (un-attested) rather than hang at startup.
+    public func awaitDeviceToken(timeoutSeconds: Double) async -> String? {
+        let deadline = Date().addingTimeInterval(timeoutSeconds)
+        while Date() < deadline {
+            if let t = currentDeviceToken() { return t }
+            try? await Task.sleep(nanoseconds: 100_000_000) // 100ms
+        }
+        return currentDeviceToken()
+    }
+
+    /// Installs the handler the app delegate invokes for each incoming push.
+    public func setPushHandler(_ handler: @escaping @Sendable ([String: Any]) -> Void) {
+        lock.lock()
+        pushHandler = handler
+        lock.unlock()
+    }
+
+    /// Called by the app delegate on didReceiveRemoteNotification.
+    public func deliverPush(_ userInfo: [String: Any]) {
+        lock.lock()
+        let h = pushHandler
+        lock.unlock()
+        h?(userInfo)
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Apns/APNsBridge.swift
+++ b/provider-swift/Sources/ProviderCore/Apns/APNsBridge.swift
@@ -15,6 +15,14 @@ public final class APNsBridge: @unchecked Sendable {
     private let lock = NSLock()
     private var deviceToken: String?
     private var pushHandler: (@Sendable ([String: Any]) -> Void)?
+    /// Pushes that arrived before the handler was installed. A code-identity
+    /// challenge can land in the window between `registerForRemoteNotifications`
+    /// and `ProviderLoop` calling `setPushHandler` (and the coordinator pushes
+    /// only once per connection, with no provider-side retry), so dropping one
+    /// would strand the provider un-attested until the next reconnect. Buffer
+    /// them (bounded) and flush when the handler arrives.
+    private var pendingPushes: [[String: Any]] = []
+    private let maxPendingPushes = 16
 
     private init() {}
 
@@ -44,18 +52,29 @@ public final class APNsBridge: @unchecked Sendable {
         return currentDeviceToken()
     }
 
-    /// Installs the handler the app delegate invokes for each incoming push.
+    /// Installs the handler the app delegate invokes for each incoming push, then
+    /// flushes any pushes that arrived before it was installed.
     public func setPushHandler(_ handler: @escaping @Sendable ([String: Any]) -> Void) {
         lock.lock()
         pushHandler = handler
+        let buffered = pendingPushes
+        pendingPushes.removeAll()
         lock.unlock()
+        // Deliver buffered pushes outside the lock (the handler may re-enter).
+        for userInfo in buffered { handler(userInfo) }
     }
 
     /// Called by the app delegate on didReceiveRemoteNotification.
     public func deliverPush(_ userInfo: [String: Any]) {
         lock.lock()
-        let h = pushHandler
-        lock.unlock()
-        h?(userInfo)
+        if let h = pushHandler {
+            lock.unlock()
+            h(userInfo)
+        } else {
+            // No handler yet — buffer (bounded, newest-wins) so the push isn't lost.
+            pendingPushes.append(userInfo)
+            if pendingPushes.count > maxPendingPushes { pendingPushes.removeFirst() }
+            lock.unlock()
+        }
     }
 }

--- a/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClient.swift
+++ b/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClient.swift
@@ -234,6 +234,11 @@ public struct CoordinatorClientConfig: Sendable {
     /// serves it exclusively to its owner's self-route requests, never the
     /// public fleet.
     public let privateOnly: Bool
+    /// APNs code-identity (v0.6.0): the device token to push the E_K(nonce)
+    /// code-identity challenge to, and which APNs environment it belongs to.
+    /// nil on headless/no-GUI boxes (no token) — those register un-attested.
+    public let apnsDeviceToken: String?
+    public let apnsEnvironment: String?
 
     public init(
         url: String,
@@ -248,7 +253,9 @@ public struct CoordinatorClientConfig: Sendable {
         runtimeHashes: RuntimeHashes? = nil,
         modelHashes: [String: String] = [:],
         privacyCapabilities: PrivacyCapabilities? = nil,
-        privateOnly: Bool = false
+        privateOnly: Bool = false,
+        apnsDeviceToken: String? = nil,
+        apnsEnvironment: String? = nil
     ) {
         self.url = url
         self.hardware = hardware
@@ -263,6 +270,8 @@ public struct CoordinatorClientConfig: Sendable {
         self.modelHashes = modelHashes
         self.privacyCapabilities = privacyCapabilities
         self.privateOnly = privateOnly
+        self.apnsDeviceToken = apnsDeviceToken
+        self.apnsEnvironment = apnsEnvironment
     }
 }
 
@@ -290,6 +299,7 @@ public enum OutboundMessage: Sendable {
     case inferenceComplete(requestId: String, usage: UsageInfo, seSignature: String?, responseHash: String?)
     case inferenceError(requestId: String, error: String, statusCode: UInt16)
     case attestationResponse(AttestationResponsePayload)
+    case codeAttestationResponse(nonce: String, signature: String)
     case loadModelStatus(modelId: String, status: ProviderMessage.LoadModelStatus.Status, error: String?)
 }
 

--- a/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClient.swift
+++ b/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClient.swift
@@ -405,6 +405,9 @@ public actor CoordinatorClient {
 
     private var webSocketTask: URLSessionWebSocketTask?
     private var urlSession: URLSession?
+    /// Device token that arrived after the initial registration (APNs slow at
+    /// startup). Once set, every (re)registration carries it. See refreshAPNsToken.
+    private var apnsTokenOverride: String?
 
     private var shutdownRequested = false
 
@@ -445,6 +448,18 @@ public actor CoordinatorClient {
         webSocketTask?.cancel(with: .goingAway, reason: nil)
         eventContinuation?.finish()
         outboundRouter.finish()
+    }
+
+    /// Re-register over a fresh connection carrying a device token that arrived
+    /// after the initial registration. Cancelling the socket (without setting
+    /// `shutdownRequested`) surfaces as a connection error, so the reconnect loop
+    /// re-runs `sendRegistration` with the override token — letting the
+    /// coordinator bind T↔K and push the code-identity challenge. No-op if the
+    /// token is unchanged.
+    public func refreshAPNsToken(_ token: String) {
+        guard apnsTokenOverride != token else { return }
+        apnsTokenOverride = token
+        webSocketTask?.cancel(with: .goingAway, reason: nil)
     }
 
     // MARK: - Connection Loop
@@ -726,7 +741,8 @@ public actor CoordinatorClient {
         )
         let jsonData = try CoordinatorClientCodec.encodeRegistration(
             from: config,
-            privacyCapabilities: privacyCapabilities
+            privacyCapabilities: privacyCapabilities,
+            apnsDeviceTokenOverride: apnsTokenOverride
         )
         guard let jsonString = String(data: jsonData, encoding: .utf8) else {
             throw CoordinatorError.encodingFailed

--- a/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClientCodec.swift
+++ b/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClientCodec.swift
@@ -7,9 +7,16 @@ public enum CoordinatorClientCodec {
     public static func registrationMessage(
         from config: CoordinatorClientConfig,
         version: String = ProviderCore.version,
-        privacyCapabilities: PrivacyCapabilities? = nil
+        privacyCapabilities: PrivacyCapabilities? = nil,
+        apnsDeviceTokenOverride: String? = nil
     ) -> ProviderMessage {
-        .register(ProviderMessage.Register(
+        // A token that arrived after the config was built (APNs slow at startup)
+        // overrides the config value so a reconnect re-registers WITH it.
+        let effectiveToken = apnsDeviceTokenOverride ?? config.apnsDeviceToken
+        let effectiveEnv = apnsDeviceTokenOverride != nil
+            ? (config.apnsEnvironment ?? "production")
+            : config.apnsEnvironment
+        return .register(ProviderMessage.Register(
             hardware: config.hardware,
             models: config.models,
             backend: config.backendName,
@@ -24,21 +31,23 @@ public enum CoordinatorClientCodec {
             templateHashes: config.runtimeHashes?.templateHashes ?? [:],
             privacyCapabilities: privacyCapabilities,
             privateOnly: config.privateOnly,
-            apnsDeviceToken: config.apnsDeviceToken,
-            apnsEnvironment: config.apnsEnvironment
+            apnsDeviceToken: effectiveToken,
+            apnsEnvironment: effectiveEnv
         ))
     }
 
     public static func encodeRegistration(
         from config: CoordinatorClientConfig,
         version: String = ProviderCore.version,
-        privacyCapabilities: PrivacyCapabilities? = nil
+        privacyCapabilities: PrivacyCapabilities? = nil,
+        apnsDeviceTokenOverride: String? = nil
     ) throws -> Data {
         try ProviderProtocolCodec.encodeProviderMessage(
             registrationMessage(
                 from: config,
                 version: version,
-                privacyCapabilities: privacyCapabilities
+                privacyCapabilities: privacyCapabilities,
+                apnsDeviceTokenOverride: apnsDeviceTokenOverride
             )
         )
     }

--- a/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClientCodec.swift
+++ b/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClientCodec.swift
@@ -23,7 +23,9 @@ public enum CoordinatorClientCodec {
             runtimeHash: config.runtimeHashes?.runtimeHash,
             templateHashes: config.runtimeHashes?.templateHashes ?? [:],
             privacyCapabilities: privacyCapabilities,
-            privateOnly: config.privateOnly
+            privateOnly: config.privateOnly,
+            apnsDeviceToken: config.apnsDeviceToken,
+            apnsEnvironment: config.apnsEnvironment
         ))
     }
 
@@ -102,6 +104,12 @@ public enum CoordinatorClientCodec {
                 runtimeHash: payload.runtimeHash,
                 templateHashes: payload.templateHashes,
                 modelHashes: payload.modelHashes
+            ))
+
+        case .codeAttestationResponse(let nonce, let signature):
+            return .codeAttestationResponse(ProviderMessage.CodeAttestationResponse(
+                nonce: nonce,
+                signature: signature
             ))
 
         case .loadModelStatus(let modelId, let status, let error):

--- a/provider-swift/Sources/ProviderCore/Protocol/Messages.swift
+++ b/provider-swift/Sources/ProviderCore/Protocol/Messages.swift
@@ -10,6 +10,7 @@ public enum ProviderMessage: Sendable, Equatable {
     case inferenceComplete(InferenceComplete)
     case inferenceError(InferenceError)
     case attestationResponse(AttestationResponse)
+    case codeAttestationResponse(CodeAttestationResponse)
     case loadModelStatus(LoadModelStatus)
 
     public struct Register: Sendable, Equatable {
@@ -31,6 +32,11 @@ public enum ProviderMessage: Sendable, Equatable {
         /// When true, this machine serves only its owner's self-route requests,
         /// never the public fleet. Mirrors RegisterMessage.PrivateOnly (Go).
         public var privateOnly: Bool
+        /// APNs code-identity attestation (v0.6.0). Device token the coordinator
+        /// pushes the E_K(nonce) challenge to + which APNs environment it belongs
+        /// to. Mirrors RegisterMessage.APNsDeviceToken/APNsEnvironment (Go).
+        public var apnsDeviceToken: String?
+        public var apnsEnvironment: String?
 
         public init(
             hardware: HardwareInfo,
@@ -48,7 +54,9 @@ public enum ProviderMessage: Sendable, Equatable {
             runtimeHash: String? = nil,
             templateHashes: [String: String] = [:],
             privacyCapabilities: PrivacyCapabilities? = nil,
-            privateOnly: Bool = false
+            privateOnly: Bool = false,
+            apnsDeviceToken: String? = nil,
+            apnsEnvironment: String? = nil
         ) {
             self.hardware = hardware
             self.models = models
@@ -66,6 +74,8 @@ public enum ProviderMessage: Sendable, Equatable {
             self.templateHashes = templateHashes
             self.privacyCapabilities = privacyCapabilities
             self.privateOnly = privateOnly
+            self.apnsDeviceToken = apnsDeviceToken
+            self.apnsEnvironment = apnsEnvironment
         }
     }
 
@@ -206,6 +216,21 @@ public enum ProviderMessage: Sendable, Equatable {
             self.modelHashes = modelHashes
         }
     }
+
+    /// Reply to the APNs-delivered code-identity challenge (E_K(nonce) push).
+    /// Returns the decrypted nonce (proves K-possession) + Sign_SE(nonce) (the
+    /// separate SE P-256 key — K is X25519/decrypt-only). The WebSocket return
+    /// leg of the push round-trip; distinct from the liveness AttestationResponse.
+    /// Mirrors CodeAttestationResponseMessage (Go).
+    public struct CodeAttestationResponse: Sendable, Equatable {
+        public var nonce: String
+        public var signature: String
+
+        public init(nonce: String, signature: String) {
+            self.nonce = nonce
+            self.signature = signature
+        }
+    }
 }
 
 // MARK: - ProviderMessage Codable
@@ -219,6 +244,7 @@ extension ProviderMessage: Codable {
         case inferenceComplete = "inference_complete"
         case inferenceError = "inference_error"
         case attestationResponse = "attestation_response"
+        case codeAttestationResponse = "code_attestation_response"
         case loadModelStatus = "load_model_status"
     }
 
@@ -238,6 +264,8 @@ extension ProviderMessage: Codable {
         case templateHashes = "template_hashes"
         case privacyCapabilities = "privacy_capabilities"
         case privateOnly = "private_only"
+        case apnsDeviceToken = "apns_device_token"
+        case apnsEnvironment = "apns_environment"
         // Heartbeat
         case status
         case activeModel = "active_model"
@@ -299,6 +327,8 @@ extension ProviderMessage: Codable {
             if r.privateOnly {
                 try container.encode(true, forKey: .privateOnly)
             }
+            try container.encodeIfPresent(r.apnsDeviceToken, forKey: .apnsDeviceToken)
+            try container.encodeIfPresent(r.apnsEnvironment, forKey: .apnsEnvironment)
 
         case .heartbeat(let h):
             try container.encode(TypeValue.heartbeat, forKey: .type)
@@ -357,6 +387,11 @@ extension ProviderMessage: Codable {
                 try container.encode(a.modelHashes, forKey: .modelHashes)
             }
 
+        case .codeAttestationResponse(let c):
+            try container.encode(TypeValue.codeAttestationResponse, forKey: .type)
+            try container.encode(c.nonce, forKey: .nonce)
+            try container.encode(c.signature, forKey: .signature)
+
         case .loadModelStatus(let l):
             try container.encode(TypeValue.loadModelStatus, forKey: .type)
             try container.encode(l.modelId, forKey: .modelId)
@@ -387,7 +422,9 @@ extension ProviderMessage: Codable {
                 runtimeHash: try container.decodeIfPresent(String.self, forKey: .runtimeHash),
                 templateHashes: try container.decodeIfPresent([String: String].self, forKey: .templateHashes) ?? [:],
                 privacyCapabilities: try container.decodeIfPresent(PrivacyCapabilities.self, forKey: .privacyCapabilities),
-                privateOnly: try container.decodeIfPresent(Bool.self, forKey: .privateOnly) ?? false
+                privateOnly: try container.decodeIfPresent(Bool.self, forKey: .privateOnly) ?? false,
+                apnsDeviceToken: try container.decodeIfPresent(String.self, forKey: .apnsDeviceToken),
+                apnsEnvironment: try container.decodeIfPresent(String.self, forKey: .apnsEnvironment)
             ))
 
         case .heartbeat:
@@ -443,6 +480,12 @@ extension ProviderMessage: Codable {
                 runtimeHash: try container.decodeIfPresent(String.self, forKey: .runtimeHash),
                 templateHashes: try container.decodeIfPresent([String: String].self, forKey: .templateHashes) ?? [:],
                 modelHashes: try container.decodeIfPresent([String: String].self, forKey: .modelHashes) ?? [:]
+            ))
+
+        case .codeAttestationResponse:
+            self = .codeAttestationResponse(CodeAttestationResponse(
+                nonce: try container.decode(String.self, forKey: .nonce),
+                signature: try container.decode(String.self, forKey: .signature)
             ))
 
         case .loadModelStatus:

--- a/provider-swift/Sources/ProviderCore/Protocol/ProtocolCodec.swift
+++ b/provider-swift/Sources/ProviderCore/Protocol/ProtocolCodec.swift
@@ -99,6 +99,15 @@ public enum ProviderProtocolCodec {
             try fields.append(("template_hashes", encodeValue(register.templateHashes)))
         }
         try appendIfPresent(register.privacyCapabilities, key: "privacy_capabilities", to: &fields)
+        // IMPORTANT: this raw-attestation path bypasses the Codable encoder in
+        // Messages.swift, so EVERY Register field must be mirrored here too or it
+        // silently drops for every ATTESTED registration (the production-common
+        // case). private_only was historically missing here; apns_* added v0.6.0.
+        if register.privateOnly {
+            try fields.append(("private_only", encodeValue(true)))
+        }
+        try appendIfPresent(register.apnsDeviceToken, key: "apns_device_token", to: &fields)
+        try appendIfPresent(register.apnsEnvironment, key: "apns_environment", to: &fields)
 
         return makeObject(fields)
     }

--- a/provider-swift/Sources/ProviderCore/ProviderLoop.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop.swift
@@ -394,6 +394,20 @@ public actor ProviderLoop {
             guard let self, let challenge = ProviderLoop.extractCodeChallenge(userInfo) else { return }
             Task { await self.handleCodeChallenge(challenge, send: send) }
         }
+
+        // If the device token wasn't ready at registration (APNs slow / GUI
+        // session still coming up), keep watching: when it arrives, reconnect so
+        // registration re-runs WITH the token. Otherwise the provider would stay
+        // un-attested (and unroutable under enforcement) until the process restarts.
+        if apnsDeviceToken == nil {
+            let log = logger
+            Task {
+                if let late = await APNsBridge.shared.awaitDeviceToken(timeoutSeconds: 60) {
+                    log.info("APNs device token arrived after registration — reconnecting to re-register with token")
+                    await coordinator.refreshAPNsToken(late)
+                }
+            }
+        }
         #endif
 
         // Start the idle-timeout monitor before processing events so that

--- a/provider-swift/Sources/ProviderCore/ProviderLoop.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop.swift
@@ -342,6 +342,18 @@ public actor ProviderLoop {
             logger.warning("mlx.metallib not found near binary -- inference will fail at first GPU call")
         }
 
+        // APNs code-identity (v0.6.0): wait briefly for the device token the app
+        // delegate captures after registerForRemoteNotifications. Present only on
+        // a logged-in macOS GUI session running under the AppKit host; a headless
+        // / no-GUI box gets nil and registers un-attested (fail-closed at routing).
+        var apnsDeviceToken: String?
+        #if os(macOS)
+        apnsDeviceToken = await APNsBridge.shared.awaitDeviceToken(timeoutSeconds: 10)
+        if apnsDeviceToken == nil {
+            logger.warning("no APNs device token (no GUI session / not push-provisioned) — registering un-attested")
+        }
+        #endif
+
         // 4. Create coordinator client config
         let coordinatorConfig = CoordinatorClientConfig(
             url: loopConfig.coordinatorURL,
@@ -356,7 +368,9 @@ public actor ProviderLoop {
             runtimeHashes: runtimeWithMetallib,
             modelHashes: loopConfig.modelHashes,
             privacyCapabilities: privacyCapabilitiesForRegistration(),
-            privateOnly: loopConfig.config.coordinator.privateOnly
+            privateOnly: loopConfig.config.coordinator.privateOnly,
+            apnsDeviceToken: apnsDeviceToken,
+            apnsEnvironment: apnsDeviceToken != nil ? "production" : nil
         )
 
         // 4. Create coordinator client and start connection
@@ -368,6 +382,19 @@ public actor ProviderLoop {
 
         let (events, sendFn) = await coordinator.start()
         let send = SendHandle(sendFn)
+
+        // APNs code-identity (v0.6.0): answer pushed code-identity challenges by
+        // decrypting E_K(nonce) with K and signing the nonce with the SE key, then
+        // replying over THIS WebSocket. The app delegate delivers pushes via the
+        // bridge; we hop into the actor to use K + the signer + this send handle.
+        #if os(macOS)
+        APNsBridge.shared.setPushHandler { [weak self] userInfo in
+            // Extract the Sendable EncryptedPayload synchronously here so the
+            // non-Sendable [String: Any] never crosses into the actor Task.
+            guard let self, let challenge = ProviderLoop.extractCodeChallenge(userInfo) else { return }
+            Task { await self.handleCodeChallenge(challenge, send: send) }
+        }
+        #endif
 
         // Start the idle-timeout monitor before processing events so that
         // a rogue model-load (e.g. during `attestation_challenge` priming)
@@ -2056,6 +2083,55 @@ public actor ProviderLoop {
             logger.info("Attestation challenge response sent")
         } catch {
             logger.error("Failed to sign attestation challenge: \(error)")
+        }
+    }
+
+    // MARK: - Code-identity (APNs) challenge
+
+    /// Decrypts an E_K(nonce) code-identity challenge and produces the WebSocket
+    /// reply: the recovered nonce (proof of K-possession) + Sign_SE(nonce). Pure
+    /// and testable. K (NodeKeyPair, X25519) is decrypt-only — the signature is
+    /// the separate Secure-Enclave P-256 key. The coordinator verifies both
+    /// (nonce equality + the SE signature against the registration-bound SE key).
+    static func answerCodeChallenge(
+        challenge: EncryptedPayload,
+        keyPair: NodeKeyPair,
+        signer: any AttestationSigner
+    ) throws -> (nonce: String, signature: String) {
+        let nonceData = try keyPair.decryptPayload(challenge)
+        guard let nonceB64 = String(data: nonceData, encoding: .utf8) else {
+            throw NSError(domain: "ProviderCore.codeAttest", code: 1,
+                          userInfo: [NSLocalizedDescriptionKey: "decrypted code-challenge nonce is not UTF-8"])
+        }
+        let sig = try signer.sign(Data(nonceB64.utf8))
+        return (nonceB64, sig.base64EncodedString())
+    }
+
+    /// Extracts the code_challenge EncryptedPayload from an APNs push userInfo.
+    static func extractCodeChallenge(_ userInfo: [String: Any]) -> EncryptedPayload? {
+        guard let cc = userInfo["code_challenge"],
+              let data = try? JSONSerialization.data(withJSONObject: cc)
+        else {
+            return nil
+        }
+        return try? JSONDecoder().decode(EncryptedPayload.self, from: data)
+    }
+
+    /// Handles an inbound APNs code-identity challenge (delivered by the app
+    /// delegate): decrypt E_K(nonce) with K, sign the nonce with the SE key, and
+    /// reply over the WebSocket. Only the genuine hardened process can do both,
+    /// which is what binds the Apple-gated push proof onto this connection.
+    func handleCodeChallenge(_ challenge: EncryptedPayload, send: SendHandle) {
+        guard let signer = self.signer else {
+            logger.warning("code-identity challenge received but no Secure Enclave signer is available")
+            return
+        }
+        do {
+            let answer = try Self.answerCodeChallenge(challenge: challenge, keyPair: keyPair, signer: signer)
+            send.send(.codeAttestationResponse(nonce: answer.nonce, signature: answer.signature))
+            logger.info("code-identity challenge answered over WebSocket")
+        } catch {
+            logger.error("failed to answer code-identity challenge: \(error)")
         }
     }
 

--- a/provider-swift/Sources/darkbloom/Darkbloom.swift
+++ b/provider-swift/Sources/darkbloom/Darkbloom.swift
@@ -3,7 +3,15 @@ import ArgumentParser
 import Logging
 import ProviderCore
 
-@main
+// NOTE: entry point lives in main.swift (not @main here). The long-running serve
+// modes are hosted under an NSApplication(.accessory) run loop so the process can
+// receive APNs code-identity challenges (v0.6.0); see ProviderAppKitHost. All
+// other commands run through the normal async dispatch.
+//
+// The availability annotation is required because we invoke `Darkbloom.main()`
+// from main.swift instead of via `@main` (which would synthesize it): an async
+// root ParsableCommand must be annotated to run asynchronously.
+@available(macOS 10.15, macCatalyst 13, iOS 13, tvOS 13, watchOS 6, *)
 struct Darkbloom: AsyncParsableCommand {
 
     // Bootstrap swift-log to write to stderr so launchd captures output

--- a/provider-swift/Sources/darkbloom/ProviderAppKitHost.swift
+++ b/provider-swift/Sources/darkbloom/ProviderAppKitHost.swift
@@ -16,11 +16,20 @@ enum ProviderAppKitHost {
         return args.contains("--foreground") || args.contains("--local")
     }
 
+    /// Strong reference that keeps the app delegate alive for the lifetime of the
+    /// (never-returning) host. `NSApplication.delegate` is a WEAK reference, so
+    /// without an independent strong ref ARC may release the delegate right after
+    /// assignment — especially under `-O` — which means
+    /// `applicationDidFinishLaunching` never fires and the process does nothing
+    /// (no push registration, no serve). This is the only owner.
+    @MainActor private static var retainedDelegate: ProviderAppDelegate?
+
     /// Takes over the main thread with the AppKit event loop (does not return).
     @MainActor
     static func runHosted(_ args: [String]) -> Never {
         let app = NSApplication.shared
         let delegate = ProviderAppDelegate(args: args)
+        Self.retainedDelegate = delegate // strong ref; NSApplication.delegate is weak
         app.delegate = delegate
         app.setActivationPolicy(.accessory)
         app.run()
@@ -41,6 +50,14 @@ final class ProviderAppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func applicationDidFinishLaunching(_: Notification) {
+        // INVARIANT: register for REMOTE notifications only — never request
+        // UNUserNotificationCenter (user-notification) authorization. The
+        // attestation push carries the encrypted `code_challenge`; with
+        // user-notification auth, an alert-mode push (APNS_MODE=alert) would be
+        // presented and PERSISTED to the root-readable Notification Center DB,
+        // reintroducing a payload-harvest surface that is otherwise closed
+        // (apsd redacts the payload as <private> and keeps no cleartext copy —
+        // verified on macOS 26.4, see docs/apns-code-attestation-design.md).
         NSApplication.shared.registerForRemoteNotifications()
         let args = self.args
         Task {

--- a/provider-swift/Sources/darkbloom/ProviderAppKitHost.swift
+++ b/provider-swift/Sources/darkbloom/ProviderAppKitHost.swift
@@ -1,0 +1,76 @@
+#if os(macOS)
+import AppKit
+import ArgumentParser
+import Foundation
+import ProviderCore
+
+/// Hosts the long-running provider serve modes under an NSApplication(.accessory)
+/// run loop so the process can registerForRemoteNotifications() and receive APNs
+/// code-identity challenges (v0.6.0). Proven pattern: apns-r2-probe/coexist.swift.
+enum ProviderAppKitHost {
+    /// The serve modes that run long and need APNs: `start --foreground` (the
+    /// launchd-spawned daemon) and `start --local` (standalone). A bare `start`
+    /// installs the launchd agent and exits — it must NOT host AppKit.
+    static func shouldHost(_ args: [String]) -> Bool {
+        guard args.first == "start" else { return false }
+        return args.contains("--foreground") || args.contains("--local")
+    }
+
+    /// Takes over the main thread with the AppKit event loop (does not return).
+    @MainActor
+    static func runHosted(_ args: [String]) -> Never {
+        let app = NSApplication.shared
+        let delegate = ProviderAppDelegate(args: args)
+        app.delegate = delegate
+        app.setActivationPolicy(.accessory)
+        app.run()
+        exit(0) // app.run() does not return; defensive.
+    }
+}
+
+/// AppKit delegate for the hosted serve process. Owns the APNs callbacks (on the
+/// main thread) and bridges them to the ProviderLoop via APNsBridge. Launches the
+/// actual serve command in a child Task so app.run() keeps the main thread.
+@MainActor
+final class ProviderAppDelegate: NSObject, NSApplicationDelegate {
+    private let args: [String]
+
+    init(args: [String]) {
+        self.args = args
+        super.init()
+    }
+
+    func applicationDidFinishLaunching(_: Notification) {
+        NSApplication.shared.registerForRemoteNotifications()
+        let args = self.args
+        Task {
+            do {
+                let command = try Darkbloom.parseAsRoot(args)
+                if let asyncCommand = command as? AsyncParsableCommand {
+                    var cmd = asyncCommand
+                    try await cmd.run()
+                } else {
+                    var cmd = command
+                    try cmd.run()
+                }
+                exit(0)
+            } catch {
+                Darkbloom.exit(withError: error)
+            }
+        }
+    }
+
+    func application(_: NSApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
+        let hex = deviceToken.map { String(format: "%02x", $0) }.joined()
+        APNsBridge.shared.setDeviceToken(hex)
+    }
+
+    func application(_: NSApplication, didFailToRegisterForRemoteNotificationsWithError error: Error) {
+        printError("APNs registration failed: \(error.localizedDescription) — provider running un-attested")
+    }
+
+    func application(_: NSApplication, didReceiveRemoteNotification userInfo: [String: Any]) {
+        APNsBridge.shared.deliverPush(userInfo)
+    }
+}
+#endif

--- a/provider-swift/Sources/darkbloom/main.swift
+++ b/provider-swift/Sources/darkbloom/main.swift
@@ -1,0 +1,34 @@
+import ArgumentParser
+import Foundation
+import ProviderCore
+
+// Entry point. The long-running serve modes (start --foreground / --local) are
+// hosted under an NSApplication(.accessory) run loop so the process can
+// registerForRemoteNotifications() and answer APNs code-identity challenges
+// (v0.6.0). Everything else runs through the normal ArgumentParser async
+// dispatch. The @main AsyncParsableCommand main-task drain is mutually exclusive
+// with the AppKit event loop, which is exactly why the serve path is dispatched
+// here instead of via @main on Darkbloom.
+
+let rawArgs = Array(CommandLine.arguments.dropFirst())
+
+#if os(macOS)
+if ProviderAppKitHost.shouldHost(rawArgs) {
+    // Takes over the main thread with the AppKit run loop and never returns.
+    ProviderAppKitHost.runHosted(rawArgs)
+}
+#endif
+
+// Non-serve path: parse + run exactly as ArgumentParser's async main() would.
+// Done manually (not via Darkbloom.main()) because, without @main, the sync
+// main() overload fatals on an async root command.
+do {
+    var command = try Darkbloom.parseAsRoot(rawArgs)
+    if var asyncCommand = command as? AsyncParsableCommand {
+        try await asyncCommand.run()
+    } else {
+        try command.run()
+    }
+} catch {
+    Darkbloom.exit(withError: error)
+}

--- a/provider-swift/Tests/ProviderCoreTests/CodeAttestationTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/CodeAttestationTests.swift
@@ -38,6 +38,45 @@ import Testing
     }
 }
 
+// A code-identity push can land before ProviderLoop installs its handler (the
+// coordinator pushes once per connection, no provider-side retry). The bridge
+// must buffer such a push and flush it when the handler arrives, or the provider
+// stays un-attested. Verifies the fix for the early-push drop.
+@Test func apnsBridgeBuffersPushUntilHandlerInstalled() {
+    final class Collector: @unchecked Sendable {
+        private let lock = NSLock()
+        private var items: [String] = []
+        func add(_ s: String) { lock.lock(); items.append(s); lock.unlock() }
+        func all() -> [String] { lock.lock(); defer { lock.unlock() }; return items }
+    }
+    let bridge = APNsBridge.shared
+    let got = Collector()
+    func epk(_ m: String) -> [String: Any] {
+        ["code_challenge": ["ephemeral_public_key": m, "ciphertext": "x"]]
+    }
+
+    // Push BEFORE any handler → must be buffered, not dropped.
+    let early = "early-\(UUID().uuidString)"
+    bridge.deliverPush(epk(early))
+
+    // Install handler → buffered push flushes to it synchronously.
+    bridge.setPushHandler { userInfo in
+        if let cc = userInfo["code_challenge"] as? [String: Any],
+           let m = cc["ephemeral_public_key"] as? String {
+            got.add(m)
+        }
+    }
+    #expect(got.all().contains(early))
+
+    // Push AFTER the handler is installed → straight through.
+    let live = "live-\(UUID().uuidString)"
+    bridge.deliverPush(epk(live))
+    #expect(got.all().contains(live))
+
+    // Reset the shared handler so the singleton doesn't leak into other paths.
+    bridge.setPushHandler { _ in }
+}
+
 @Test func extractCodeChallengeParsesPushPayload() throws {
     let userInfo: [String: Any] = [
         "aps": ["content-available": 1],

--- a/provider-swift/Tests/ProviderCoreTests/CodeAttestationTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/CodeAttestationTests.swift
@@ -1,0 +1,52 @@
+import Foundation
+import Testing
+@testable import ProviderCore
+
+// Provider side of the APNs code-identity round-trip: decrypt E_K(nonce) with K
+// and sign the recovered nonce with the SE key. Mirrors exactly what the
+// coordinator builds (E_K via the inference E2E path) and verifies
+// (VerifyChallengeSignature over the nonce against the SE key). No device needed.
+@Test func codeChallengeDecryptSignRoundTrip() throws {
+    let provider = NodeKeyPair.generate()    // the provider's K
+    let coordinator = NodeKeyPair.generate() // stands in for the coordinator's ephemeral sender
+    guard let signer = try SecureEnclaveIdentity.createEphemeral() else {
+        // No SE/CryptoKit signer available in this environment — nothing to test.
+        return
+    }
+
+    let nonceB64 = Data("0123456789abcdef0123456789abcdef".utf8).base64EncodedString()
+
+    // Coordinator builds E_K(nonceB64) to the provider's public key, exactly like
+    // the Go BuildCodeChallengePayload does via internal/e2e.Encrypt.
+    let providerPub = try #require(Data(base64Encoded: provider.publicKeyBase64))
+    let challenge = try coordinator.encryptPayload(recipientPublicKey: providerPub, plaintext: Data(nonceB64.utf8))
+
+    // Provider answers: decrypt with K, sign the nonce with the SE key.
+    let answer = try ProviderLoop.answerCodeChallenge(challenge: challenge, keyPair: provider, signer: signer)
+    #expect(answer.nonce == nonceB64)
+
+    // The signature must verify over the nonce bytes against the SE public key —
+    // exactly what the coordinator's attestation.VerifyChallengeSignature checks.
+    let sigData = try #require(Data(base64Encoded: answer.signature))
+    let pubData = try #require(Data(base64Encoded: signer.publicKeyBase64))
+    #expect(SecureEnclaveIdentity.verify(signature: sigData, for: Data(nonceB64.utf8), publicKey: pubData))
+
+    // A wrong key (different provider K) must NOT decrypt the challenge.
+    let attacker = NodeKeyPair.generate()
+    #expect(throws: (any Error).self) {
+        _ = try ProviderLoop.answerCodeChallenge(challenge: challenge, keyPair: attacker, signer: signer)
+    }
+}
+
+@Test func extractCodeChallengeParsesPushPayload() throws {
+    let userInfo: [String: Any] = [
+        "aps": ["content-available": 1],
+        "code_challenge": ["ephemeral_public_key": "ZXBo", "ciphertext": "Y2lwaA=="],
+    ]
+    let cc = ProviderLoop.extractCodeChallenge(userInfo)
+    #expect(cc?.ephemeralPublicKey == "ZXBo")
+    #expect(cc?.ciphertext == "Y2lwaA==")
+
+    // Missing code_challenge → nil (the handler then no-ops, fail-closed).
+    #expect(ProviderLoop.extractCodeChallenge(["aps": ["content-available": 1]]) == nil)
+}

--- a/provider-swift/Tests/ProviderCoreTests/CoordinatorClientTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/CoordinatorClientTests.swift
@@ -46,6 +46,31 @@ import Testing
     #expect(register.privacyCapabilities?.textBackendInprocess == true)
 }
 
+@Test func registrationHonorsLateApnsTokenOverride() throws {
+    // Provider started without an APNs token (slow APNs / GUI still coming up),
+    // so the config carries none. A token that arrives later must override the
+    // config so a reconnect re-registers WITH it (environment=production).
+    let config = CoordinatorClientConfig(
+        url: "wss://api.dev.darkbloom.xyz/v1/providers/ws",
+        hardware: clientSampleHardware(),
+        models: [clientSampleModel()],
+        backendName: "mlx_swift_lm",
+        publicKey: "cHVibGlj"
+    )
+
+    // No override and no config token → no APNs fields on the wire.
+    let base = try clientJSONObject(CoordinatorClientCodec.encodeRegistration(from: config))
+    #expect(base["apns_device_token"] == nil)
+    #expect(base["apns_environment"] == nil)
+
+    // Late token override → token present + environment production.
+    let withTok = try clientJSONObject(
+        CoordinatorClientCodec.encodeRegistration(from: config, apnsDeviceTokenOverride: "deadbeefcafe")
+    )
+    #expect(withTok["apns_device_token"] as? String == "deadbeefcafe")
+    #expect(withTok["apns_environment"] as? String == "production")
+}
+
 @Test func coordinatorOutboundMessagesUseProviderEnvelope() throws {
     let accepted = try CoordinatorClientCodec.encodeOutboundMessageString(
         .inferenceAccepted(requestId: "req-1")

--- a/provider-swift/Tests/ProviderCoreTests/Helpers/MockCoordinator.swift
+++ b/provider-swift/Tests/ProviderCoreTests/Helpers/MockCoordinator.swift
@@ -33,6 +33,7 @@ public struct CapturedMessages: Sendable {
     public var registers: [ProviderMessage.Register] = []
     public var heartbeats: [ProviderMessage.Heartbeat] = []
     public var attestationResponses: [ProviderMessage.AttestationResponse] = []
+    public var codeAttestationResponses: [ProviderMessage.CodeAttestationResponse] = []
     public var inferenceAccepted: [ProviderMessage.InferenceAccepted] = []
     public var inferenceChunks: [ProviderMessage.InferenceResponseChunk] = []
     public var inferenceComplete: [ProviderMessage.InferenceComplete] = []
@@ -561,6 +562,7 @@ public final class MockCoordinator: @unchecked Sendable {
             case .register(let r):           captured.registers.append(r)
             case .heartbeat(let h):          captured.heartbeats.append(h)
             case .attestationResponse(let a): captured.attestationResponses.append(a)
+            case .codeAttestationResponse(let c): captured.codeAttestationResponses.append(c)
             case .inferenceAccepted(let a):   captured.inferenceAccepted.append(a)
             case .inferenceResponseChunk(let c): captured.inferenceChunks.append(c)
             case .inferenceComplete(let c):   captured.inferenceComplete.append(c)

--- a/provider-swift/Tests/ProviderCoreTests/ProtocolTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/ProtocolTests.swift
@@ -67,6 +67,89 @@ import Testing
     #expect(register.privateOnly == true)
 }
 
+@Test func registerEncodesAPNsFieldsOnlyWhenPresent() throws {
+    // Omitted when nil (mirrors Go `omitempty`).
+    let off = ProviderMessage.register(ProviderMessage.Register(
+        hardware: sampleHardware(),
+        models: [sampleModel()],
+        backend: "mlx_swift_lm"
+    ))
+    let offObject = try jsonObject(try ProviderProtocolCodec.encodeProviderMessage(off))
+    #expect(offObject["apns_device_token"] == nil)
+    #expect(offObject["apns_environment"] == nil)
+
+    // Present: snake_case keys, round-trips back to the same values.
+    let on = ProviderMessage.register(ProviderMessage.Register(
+        hardware: sampleHardware(),
+        models: [sampleModel()],
+        backend: "mlx_swift_lm",
+        apnsDeviceToken: "cb1ceb489ec9",
+        apnsEnvironment: "production"
+    ))
+    let onData = try ProviderProtocolCodec.encodeProviderMessage(on)
+    let onObject = try jsonObject(onData)
+    #expect(onObject["apns_device_token"] as? String == "cb1ceb489ec9")
+    #expect(onObject["apns_environment"] as? String == "production")
+
+    let decoded = try ProviderProtocolCodec.decodeProviderMessage(from: onData)
+    guard case .register(let register) = decoded else {
+        throw TestFailure.unexpectedMessage
+    }
+    #expect(register.apnsDeviceToken == "cb1ceb489ec9")
+    #expect(register.apnsEnvironment == "production")
+}
+
+@Test func registerWithAttestationPreservesAPNsAndPrivateOnly() throws {
+    // The raw-attestation encoding path (ProtocolCodec.encodeRegisterPreservingRawAttestation)
+    // BYPASSES the Codable encoder, so the Codable-path tests above don't cover it.
+    // This is the ATTESTED registration (production-common): every Register field
+    // must survive this path too, or it silently drops on the wire.
+    let raw = #"{"signature":"sig","blob":{"a":1,"b":[true,false]}}"#
+    let message = ProviderMessage.register(ProviderMessage.Register(
+        hardware: sampleHardware(),
+        models: [sampleModel()],
+        backend: "mlx_swift_lm",
+        attestation: RawJSON(rawBytes: Data(raw.utf8)),
+        privateOnly: true,
+        apnsDeviceToken: "cb1ceb489ec9",
+        apnsEnvironment: "production"
+    ))
+    let data = try ProviderProtocolCodec.encodeProviderMessage(message)
+    let object = try jsonObject(data)
+    #expect(object["apns_device_token"] as? String == "cb1ceb489ec9")
+    #expect(object["apns_environment"] as? String == "production")
+    #expect(object["private_only"] as? Bool == true)
+    // Raw attestation bytes preserved verbatim (the reason this path exists).
+    let json = String(data: data, encoding: .utf8) ?? ""
+    #expect(json.contains(#""attestation":\#(raw)"#))
+
+    let decoded = try ProviderProtocolCodec.decodeProviderMessage(from: data)
+    guard case .register(let r) = decoded else { throw TestFailure.unexpectedMessage }
+    #expect(r.apnsDeviceToken == "cb1ceb489ec9")
+    #expect(r.apnsEnvironment == "production")
+    #expect(r.privateOnly == true)
+}
+
+@Test func codeAttestationResponseEncodesSnakeCaseAndRoundTrips() throws {
+    // The WebSocket return leg of the APNs push round-trip. Must match the Go
+    // CodeAttestationResponseMessage wire shape (type=code_attestation_response).
+    let message = ProviderMessage.codeAttestationResponse(
+        ProviderMessage.CodeAttestationResponse(nonce: "bm9uY2U=", signature: "c2ln")
+    )
+    let data = try ProviderProtocolCodec.encodeProviderMessage(message)
+    let object = try jsonObject(data)
+    #expect(object["type"] as? String == "code_attestation_response")
+    #expect(object["nonce"] as? String == "bm9uY2U=")
+    #expect(object["signature"] as? String == "c2ln")
+
+    let decoded = try ProviderProtocolCodec.decodeProviderMessage(from: data)
+    guard case .codeAttestationResponse(let resp) = decoded else {
+        throw TestFailure.unexpectedMessage
+    }
+    #expect(resp.nonce == "bm9uY2U=")
+    #expect(resp.signature == "c2ln")
+}
+
 @Test func providerMessagesRoundTripThroughCodableEnvelope() throws {
     let messages: [ProviderMessage] = [
         .register(ProviderMessage.Register(

--- a/provider-swift/entitlements.plist
+++ b/provider-swift/entitlements.plist
@@ -4,6 +4,12 @@
 <dict>
     <key>com.apple.application-identifier</key>
     <string>SLDQ2GJ6TL.io.darkbloom.provider</string>
+    <!-- v0.6.0 APNs code-identity attestation. Restricted entitlement: the
+         embedded provisioning profile MUST authorize it or AMFI Killed:9 at
+         launch. CI (release-swift.yml) guards both the profile grant and the
+         signed-binary value so the entitlement never ships without a push profile. -->
+    <key>com.apple.developer.aps-environment</key>
+    <string>production</string>
     <key>com.apple.security.hypervisor</key>
     <true/>
     <key>com.apple.security.network.client</key>


### PR DESCRIPTION
## Provider code-identity attestation via APNs (v0.6.0)

Gives the coordinator a **remotely-verifiable, non-self-reportable** proof that a provider is running our genuine, Apple-provisioned binary — closing the gap where a malicious operator could clone the repo, add prompt-logging, open-enroll, and receive consumer traffic undetected.

The old `binaryHash` signal is **self-reported by the provider's own (possibly modified) code**, so it proves nothing against a malicious provider. This replaces it with an Apple-mediated signal: only our genuine, team-signed, push-provisioned code can *receive* an APNs push for our App-ID, and only the genuine hardened process can *decrypt* a challenge encrypted to its in-memory key.

### Before — the coordinator cannot verify code identity

```mermaid
flowchart TB
    GP["Genuine provider"] -->|"self-reported binaryHash + SE/MDA device attestation"| CO["Coordinator"]
    MP["Malicious fork: logs prompts, own SE key"] -->|"reports the blessed binaryHash, runs modified code"| CO
    CO -->|"trusts device identity only, cannot tell them apart"| RT["Routes private prompts to BOTH"]
```

### After — APNs-gated code-identity round-trip, once per WebSocket connection

```mermaid
sequenceDiagram
    autonumber
    participant Pv as Provider
    participant Ap as Apple APNs
    participant Co as Coordinator
    Pv->>Co: register - X25519 key K, APNs token T, SE attestation
    Note over Co: bind T to K, MDA confirms SIP and Secure-Boot
    Co->>Ap: push E_K(nonce) to token T
    Note over Ap,Pv: only our App-ID-provisioned, team-signed code can receive it
    Ap-->>Pv: E_K(nonce)
    Note over Pv: decrypt with K in protected memory, then Sign_SE(nonce)
    Pv->>Co: code_attestation_response - nonce and Sign_SE(nonce), over WebSocket
    Note over Co: returned nonce matches and the SE signature verifies against the registration-bound SE key, so CodeAttested becomes true
    Co->>Pv: route private traffic, gated and fail-closed
    Note over Co,Pv: a fork cannot receive the push, cannot read K, and cannot lift the nonce from logs, so it cannot pass
```

`K` is the provider's X25519 key (`NodeKeyPair`, decrypt-only, in protected process memory — there is no `Sign_K`); the signature is the separate Secure-Enclave P-256 key. The challenge is **encrypted** because root can read a raw push nonce from the unified log; the logged ciphertext is useless without `K`. See `docs/apns-code-attestation-design.md` for the full mechanism, threat model, and on-box verification.

## What's in this PR

- **Phase 1 — protocol** (`coordinator/protocol`, `provider-swift/.../Protocol`): `RegisterMessage` gains `apns_device_token` + `apns_environment`; new `code_attestation_response` message; Go and Swift symmetric + parity tests.
- **Phase 2A — coordinator (Go)**: new `coordinator/apns/` package — ES256 `.p8` JWT (cached ~50 min), HTTP/2 sender, **dual-mode** (background / alert), `E_K(nonce)` via the existing `internal/e2e.Encrypt`, and a `CodeIdentityAttestor` seam (tests inject a fake; a future `AppAttestAttestor` drops in). Per-connection push-attest step in `api/provider.go` (separate nonce tracker, chained after MDA), `CodeAttested` gate at the **single chokepoint** `providerSupportsPrivateTextLocked`, and `server.go` / `main.go` config wiring.
- **Phase 2B — provider (Swift)**: decrypt then `Sign_SE` then reply handler; `APNsBridge` (delegate to actor); device-token threading into registration; and the **`NSApplication(.accessory)` rehost** (`main.swift` + `ProviderAppKitHost`) so the headless serve process can `registerForRemoteNotifications` (the single biggest provider change).
- **Phase 3 — integration**: full coordinator round-trip test (real encrypt, decrypt, sign, verify, `CodeAttested`) plus a wrong-SE-key negative.
- **Build/signing**: `aps-environment=production` entitlement, coupled with CI guards (`release-swift.yml`) that the embedded profile grants it and the signed binary has it and **lacks `get-task-allow`** — closing the AMFI-kill trap.
- **binaryHash demotion**: the self-reported `binaryHash` is demoted to drift telemetry — derouting on a mismatch is now behind a default-off `binaryHashEnforce` flag (rollback via `EIGENINFERENCE_BINARYHASH_ENFORCE`). APNs code-identity is the real signal. The policy machinery, wire field, and SE-signed status canonical are untouched (no Go/Swift signature drift; old and new providers interoperate); the attestation-validity / key-binding checks are unchanged.

## Rollout — default-off, zero fleet impact

The gate enforces only when an attestor is configured (`SetCodeAttestor`, driven by `APNS_*` env). Until then providers route exactly as before, so this is safe to merge and deploy ahead of enabling. Once on, it is **fail-closed** (no self-route exemption): a provider that doesn't complete the round-trip isn't routed private traffic.

Note on cadence: code identity is verified **once per WebSocket connection**, re-checked only on reconnect (disabling SIP needs a reboot, which drops the connection and forces re-attestation; per-message encryption to `K` carries the binding continuously). The existing 5-minute WS challenge is a separate liveness / SIP-status loop and is unchanged.

## Testing

- `go test ./...` green (incl. `-race`); `gofmt` clean.
- `swift build` green; protocol + code-attestation suites pass. (Full `swift test` needs the MLX metallib, fetched separately — env-only.)
- **Live**: the real `apns` package pushed `E_K(nonce)` over real APNs to an on-device probe and the delivered challenge decrypted to the exact nonce; and real APNs delivery to the production `io.darkbloom.provider` bundle was confirmed on-device.
- Reviewed by two independent reviewers (correctness, `-race`, byte-for-byte crypto trace) — both pass.

## Deferred / follow-ups (not blockers)

- Full provider-to-coordinator WebSocket system test (genuine Swift reply bytes + re-attest across reconnect) — every link is individually proven; this is the `e2e/` system-test scope.
- Fleet background-push reliability measurement (mitigation already built: `APNS_MODE=alert`).
- A **shadow/observe mode** for the rollout (attest + log per provider *without* gating, so the fleet's attestation rate can be watched for ~a day before enforcement is flipped on). Today the gate is a deliberate on/off flip (default off → safe to merge/deploy; no automatic timer).
- The 4.5 enrollment slim is **intentionally not done** — it would remove the only Apple-signed SIP attestation the scheme depends on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
