### PR TITLE
fix(coordinator): close provider WebSocket on registry removal (kill zombie connections)

### DIFF
--- a/coordinator/api/provider_eviction_test.go
+++ b/coordinator/api/provider_eviction_test.go
@@ -1,0 +1,140 @@
+package api
+
+// Regression tests for the "zombie connection" bug: removing a provider from
+// the registry must also close its WebSocket. Previously Disconnect left the
+// socket open, so the provider never detected the drop and never reconnected.
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+	"github.com/eigeninference/d-inference/coordinator/registry"
+	"github.com/eigeninference/d-inference/coordinator/store"
+	"nhooyr.io/websocket"
+)
+
+// dialAndRegisterProvider connects + registers a provider and returns the client
+// conn and server-assigned ID. Fails the test if registration doesn't land.
+func dialAndRegisterProvider(t *testing.T, ctx context.Context, ts *httptest.Server, reg *registry.Registry) (*websocket.Conn, string) {
+	t.Helper()
+	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http") + "/ws/provider"
+	conn, _, err := websocket.Dial(ctx, wsURL, nil)
+	if err != nil {
+		t.Fatalf("websocket dial: %v", err)
+	}
+
+	regMsg := protocol.RegisterMessage{
+		Type: protocol.TypeRegister,
+		Hardware: protocol.Hardware{
+			MachineModel: "Mac15,8",
+			ChipName:     "Apple M3 Max",
+			MemoryGB:     64,
+		},
+		Models: []protocol.ModelInfo{
+			{ID: "test-model", SizeBytes: 1000, ModelType: "chat", Quantization: "4bit"},
+		},
+		Backend: "mlx-swift",
+	}
+	regData, _ := json.Marshal(regMsg)
+	if err := conn.Write(ctx, websocket.MessageText, regData); err != nil {
+		t.Fatalf("write register: %v", err)
+	}
+
+	// Wait for the server-side registration to land.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if ids := reg.ProviderIDs(); len(ids) == 1 {
+			return conn, ids[0]
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("provider did not register within deadline (count=%d)", reg.ProviderCount())
+	return nil, ""
+}
+
+// assertSocketClosed fails unless the server tears down the client connection
+// shortly after the provider leaves the registry (the zombie regression). The
+// Read uses a background context, NOT a deadline: nhooyr closes the conn when a
+// Read context expires, which would mask the bug. A wall-clock timer bounds the
+// wait; pre-teardown messages (e.g. trust-status) are drained.
+func assertSocketClosed(t *testing.T, conn *websocket.Conn) {
+	t.Helper()
+	closed := make(chan struct{})
+	go func() {
+		defer close(closed)
+		for {
+			if _, _, err := conn.Read(context.Background()); err != nil {
+				return
+			}
+		}
+	}()
+	select {
+	case <-closed: // Read errored => server tore the socket down. Pass.
+	case <-time.After(2 * time.Second):
+		t.Fatal("provider socket stayed open after registry removal (zombie connection): " +
+			"Read did not unblock within 2s")
+	}
+}
+
+func newEvictionTestServer(t *testing.T) (*Server, *registry.Registry, *httptest.Server) {
+	t.Helper()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	st := store.NewMemory(store.Config{AdminKey: "test-key"})
+	reg := registry.New(logger)
+	srv := NewServer(reg, st, ServerConfig{}, logger)
+	srv.skipChallenge = true // keep the wire quiet apart from registration
+	ts := httptest.NewServer(srv.Handler())
+	t.Cleanup(ts.Close)
+	return srv, reg, ts
+}
+
+// TestDisconnectClosesProviderSocket: Disconnect must close the socket, not just
+// drop the map entry. Without the fix the client Read never unblocks (zombie).
+func TestDisconnectClosesProviderSocket(t *testing.T) {
+	_, reg, ts := newEvictionTestServer(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	conn, id := dialAndRegisterProvider(t, ctx, ts, reg)
+	defer conn.Close(websocket.StatusNormalClosure, "")
+
+	reg.Disconnect(id)
+
+	assertSocketClosed(t, conn)
+
+	if reg.ProviderCount() != 0 {
+		t.Errorf("provider count after disconnect = %d, want 0", reg.ProviderCount())
+	}
+}
+
+// TestStaleEvictionClosesProviderSocket: a provider that stops heartbeating is
+// evicted, and that eviction must close the socket so it detects the drop and
+// reconnects. The reported scenario.
+func TestStaleEvictionClosesProviderSocket(t *testing.T) {
+	_, reg, ts := newEvictionTestServer(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	conn, _ := dialAndRegisterProvider(t, ctx, ts, reg)
+	defer conn.Close(websocket.StatusNormalClosure, "")
+
+	// Short timeout + no heartbeats: provider goes stale and is evicted (ticker = timeout/3).
+	evictCtx, evictCancel := context.WithCancel(context.Background())
+	defer evictCancel()
+	reg.StartEvictionLoop(evictCtx, 100*time.Millisecond)
+
+	assertSocketClosed(t, conn)
+
+	if reg.ProviderCount() != 0 {
+		t.Errorf("provider count after eviction = %d, want 0", reg.ProviderCount())
+	}
+}

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -1313,20 +1313,13 @@ func (r *Registry) DisconnectDuplicatesBySerial(keepID string, serial string) {
 	r.mu.RUnlock()
 
 	for _, id := range toEvict {
-		r.mu.RLock()
-		p := r.providers[id]
-		r.mu.RUnlock()
-
 		r.logger.Warn("evicting duplicate provider from same device",
 			"evicted_id", id,
 			"kept_id", keepID,
 			"serial", serial,
 		)
+		// Disconnect closes the socket itself.
 		r.Disconnect(id)
-
-		if p != nil && p.Conn != nil {
-			p.Conn.Close(websocket.StatusNormalClosure, "replaced by new connection from same device")
-		}
 	}
 }
 
@@ -1859,6 +1852,19 @@ func (r *Registry) Disconnect(id string) {
 	}
 	p.pendingReqs = make(map[string]*PendingRequest)
 	p.mu.Unlock()
+
+	// Tear down the socket. Deleting the map entry only makes the provider
+	// unroutable; its read loop and challenge loop keep running on the open
+	// socket and the coordinator keeps auto-ponging it, so the provider never
+	// detects the drop and never reconnects — a "zombie" that's unroutable yet
+	// still reports stale trust locally. CloseNow unblocks the read loop, which
+	// unwinds the rest, and re-arms the provider's reconnect. CloseNow not Close:
+	// Disconnect runs serially in the eviction loop and Close would block ~5s
+	// waiting for a handshake the stale peer won't send. No-op if already closed;
+	// outside r.mu so it can't stall the registry.
+	if p.Conn != nil {
+		_ = p.Conn.CloseNow()
+	}
 
 	// Close this connection's session row (async; durable uptime history).
 	// Covers both graceful disconnects and evictStale (which calls Disconnect).

--- a/coordinator/registry/registry_test.go
+++ b/coordinator/registry/registry_test.go
@@ -616,6 +616,42 @@ func TestEvictionKeepsFreshProviders(t *testing.T) {
 	}
 }
 
+// TestDisconnectDuplicatesBySerial: providers sharing the kept connection's
+// serial must be removed (the path now relies on Disconnect for teardown).
+func TestDisconnectDuplicatesBySerial(t *testing.T) {
+	reg := New(testLogger())
+	msg := testRegisterMessage()
+
+	const serial = "SERIAL-DUP-1"
+	keep := reg.Register("keep", nil, msg)
+	keep.AttestationResult = &attestation.VerificationResult{SerialNumber: serial}
+	dupA := reg.Register("dupA", nil, msg)
+	dupA.AttestationResult = &attestation.VerificationResult{SerialNumber: serial}
+	dupB := reg.Register("dupB", nil, msg)
+	dupB.AttestationResult = &attestation.VerificationResult{SerialNumber: serial}
+	// A provider from a different device must be left untouched.
+	other := reg.Register("other", nil, msg)
+	other.AttestationResult = &attestation.VerificationResult{SerialNumber: "SERIAL-OTHER"}
+
+	reg.DisconnectDuplicatesBySerial("keep", serial)
+
+	if reg.GetProvider("keep") == nil {
+		t.Error("kept provider should remain registered")
+	}
+	if reg.GetProvider("other") == nil {
+		t.Error("provider with a different serial should not be evicted")
+	}
+	if reg.GetProvider("dupA") != nil {
+		t.Error("duplicate dupA should have been disconnected")
+	}
+	if reg.GetProvider("dupB") != nil {
+		t.Error("duplicate dupB should have been disconnected")
+	}
+	if reg.ProviderCount() != 2 {
+		t.Errorf("provider count = %d, want 2 (keep + other)", reg.ProviderCount())
+	}
+}
+
 func TestEvictionLoopStopsOnCancel(t *testing.T) {
 	reg := New(testLogger())
 	ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
## Problem

A provider can end up a **zombie**: invisible to the coordinator (not routable, absent from `GET /v1/providers/attestation`) while its own daemon keeps reporting a stale `hardware/online` trust. The operator sees `darkbloom status`/`doctor` confidently say "hardware-trusted" while the detailed check says *"no live provider record for this serial yet"* — and the node earns nothing.

### Root cause

`registry.Registry.Disconnect(id)` removed the provider from the routing map and cleaned up pending requests **but never closed the underlying WebSocket** (`p.Conn`). `Disconnect` is the teardown path for the heartbeat-eviction loop (`evictStale`, 90s) and the per-connection read loop's `defer`.

When the eviction loop dropped a provider after a heartbeat gap (a network blip / brief sleep — common on home-network providers):

1. The socket stayed open, so the per-connection **read loop** (`conn.Read`, which has no read deadline) and **`challengeLoop`** kept running on the orphaned connection.
2. While that read loop lived, the coordinator's WebSocket stack kept **auto-answering the provider's pings**, so the provider's own liveness check (ping 10s / pong-timeout 30s) never tripped — it never detected the disconnect and never reconnected.
3. The coordinator never pings providers and sets no read deadline, so eviction was the *only* liveness mechanism — and it didn't tear the socket down.

Net: a permanent half-open zombie until the TCP actually broke (provider restart / coordinator redeploy). This was diagnosed from a real provider's uploaded log reports + prod coordinator logs (eviction churn, `attestation challenge failed: timeout`).

## Fix

`Disconnect` now closes the socket at the single chokepoint every removal path flows through:

```go
if p.Conn != nil {
    _ = p.Conn.CloseNow()
}
```

- **`CloseNow` (not `Close`) is deliberate.** `Disconnect` runs serially in the eviction loop; `Close` performs a 5s close-handshake wait that an already-unresponsive peer won't answer, which would stall eviction of the rest of the fleet. `CloseNow` skips the handshake.
- Closing the socket unblocks the read loop's `conn.Read` → the read loop exits → its `defer` cancels `loopCtx` → `challengeLoop` unwinds. It also stops the coordinator auto-ponging, so the provider's **own pong-timeout re-arms and it reconnects**.
- Consolidated `DisconnectDuplicatesBySerial` onto this chokepoint (removed its now-redundant explicit `Conn.Close`).

## Tests

- `coordinator/api/provider_eviction_test.go` (new) — real WS client via `httptest`: `TestStaleEvictionClosesProviderSocket` (the reported scenario) and `TestDisconnectClosesProviderSocket`. **Both fail without the fix** (the assertion uses a background-context read + independent wall-clock timer so it can't be confounded by nhooyr closing the conn on read-context expiry).
- `coordinator/registry/registry_test.go` — `TestDisconnectDuplicatesBySerial` covering the consolidated duplicate-device path.

## Verification

- `go test -race` green on `./registry/...` and `./api/...`; full `go test ./...` green (14 packages).
- Cross-compiles for EigenCloud (`GOOS=linux GOARCH=amd64`).
- Regression delta proven: with the teardown disabled, both api tests fail with the zombie message — run alone *and* together (no order-fragility).
- Reviewed by two independent reviewers (Codex + a second pass): both PASS; the second reviewer independently reproduced the red/green delta and mutation-tested the new duplicate test.

## Follow-up (not in this PR)

Defense-in-depth — a server-side WS ping / read deadline so the coordinator detects half-open sockets faster than the 90s eviction window. Deliberately scoped out: this fix already resolves the bug and re-arms the provider's own liveness detection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/289"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783558556&installation_id=133247490&pr_number=289&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F289&signature=6246da2fa920e3c4af92f4bbaed29a15ffa4e045964f35abddebac963346b850"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->