### PR TITLE
feat(kv-cache): sliding 5-minute SSD TTL + per-server --local cache scope

### DIFF
--- a/docs/ssd-kv-cache.md
+++ b/docs/ssd-kv-cache.md
@@ -102,6 +102,7 @@ DARKBLOOM_PREFIX_CACHE=0                     # opt OUT (default = ON); also fals
 DARKBLOOM_PREFIX_CACHE_MAX_GB=8              # optional: in-GPU block-cache budget (default = 1/8 physical RAM)
 DARKBLOOM_PREFIX_CACHE_DISK_GB=50            # optional: GLOBAL on-disk budget across ALL models. Unset / 0 / non-numeric = DERIVE min(10 GiB, 50% of free), re-evaluated each tick (NOT unlimited). For effectively-unbounded, set a very large explicit value.
 DARKBLOOM_PREFIX_CACHE_MIN_PERSIST_TOKENS=0  # optional: 2nd-use admission threshold (default = 16384 for Gemma, 0 otherwise)
+DARKBLOOM_PREFIX_CACHE_TTL_SECONDS=300       # optional: SLIDING TTL for SSD checkpoints (default 300 = 5 min; 0 = infinite)
 ```
 
 `MAX_GB` bounds the in-memory block cache (the number of GPU blocks is
@@ -110,7 +111,13 @@ silently retain hundreds of GB outside admission control). `DISK_GB`
 bounds the encrypted SSD files **globally across all loaded models**
 (value-based eviction — see [§11](#11-on-disk-layout)). `MIN_PERSIST_TOKENS`
 gates SSD writes (checkpoints below this stay RAM-only until a 2nd use promotes
-them — see [§4.2](#42-evict--encrypt-to-ssd)).
+them — see [§4.2](#42-evict--encrypt-to-ssd)). `TTL_SECONDS` bounds how long a
+persisted SSD checkpoint survives: it's a **sliding** window off `lastHitAt`
+(every hit refreshes it, matching Anthropic/OpenAI prompt-cache semantics), so
+a hot prefix stays warm while a cold one is reclaimed — enforced on read
+(expired ⇒ miss + drop) and proactively at load-time reconcile. Default 5 min;
+`0` disables (capacity-driven eviction only). Bounds the window in which
+prompt-derived KV lingers on disk (shrinks the TB-007 cross-tenant TTFT oracle).
 
 Wiring happens in `BatchScheduler.makeBatchedEngine` /
 `makeEncryptedPrefixPersistenceIfEnabled`

--- a/provider-swift/Sources/ProviderCore/Inference/BatchScheduler+EngineBridge.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/BatchScheduler+EngineBridge.swift
@@ -282,6 +282,27 @@ extension BatchScheduler {
     /// the interval is 0 (disabled) or there is no checkpoint manager (engine
     /// tier / cache off). Snapshots are cheap (a struct copy across the manager
     /// actor), so a 2-minute cadence is free.
+    /// Periodic steady-state TTL sweep (PR #290 review). Cadence: half the
+    /// TTL, clamped to [60, 300]s — frequent enough that an expired entry
+    /// outlives its TTL by at most ~cadence, rare enough to be free (the sweep
+    /// is an in-memory index scan; file deletes only when something expired).
+    /// Independent of the stats logger so disabling observability never
+    /// disables the privacy reaper.
+    func startTTLReaper() {
+        ttlReapTask?.cancel()
+        ttlReapTask = nil
+        let ttl = Self.prefixCacheTTLSeconds()
+        guard ttl > 0, let mgr = checkpointManager else { return }
+        let cadence = Swift.max(60, Swift.min(ttl / 2, 300))
+        ttlReapTask = Task.detached { [weak mgr] in
+            while !Task.isCancelled {
+                try? await Task.sleep(for: .seconds(Double(cadence)))
+                if Task.isCancelled { return }
+                await mgr?.reapExpiredTick()
+            }
+        }
+    }
+
     func startPrefixCacheStatsLogger() {
         prefixCacheStatsTask?.cancel()
         prefixCacheStatsTask = nil

--- a/provider-swift/Sources/ProviderCore/Inference/BatchScheduler.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/BatchScheduler.swift
@@ -596,6 +596,9 @@ public actor BatchScheduler {
                         // TB-016 sub-feature B: min persist threshold (16384
                         // for Gemma, 0 otherwise). Env override available.
                         minPersistTokens: Self.prefixCacheMinPersistTokens(arch: modelId),
+                        // Sliding SSD TTL (default 5min; 0 = infinite). Bounds
+                        // how long prompt-derived KV lingers on disk.
+                        ttlSeconds: Self.prefixCacheTTLSeconds(),
                         now: nowFn,
                         accountant: diskAccountant,
                         modelKey: backing.modelKey)
@@ -940,6 +943,23 @@ public actor BatchScheduler {
         }
         // Default: 16384 for Gemma, 0 otherwise.
         return PrefixCachePastWindow.isProven(arch: arch) ? 16384 : 0
+    }
+
+    /// Sliding TTL (seconds) for persisted SSD prefix checkpoints. Default 300
+    /// (5 min, matching Anthropic/OpenAI prompt-cache defaults); `0` disables
+    /// (infinite — capacity-driven eviction only). Operator override:
+    /// `DARKBLOOM_PREFIX_CACHE_TTL_SECONDS`.
+    static let defaultPrefixCacheTTLSeconds: Int64 = 300
+    static func prefixCacheTTLSeconds() -> Int64 {
+        resolveTTLSeconds(env: ProcessInfo.processInfo.environment["DARKBLOOM_PREFIX_CACHE_TTL_SECONDS"])
+    }
+
+    /// Pure TTL policy (testable). Unset / malformed / negative ⇒ default;
+    /// `0` ⇒ disabled (infinite); a positive value sets the sliding window.
+    static func resolveTTLSeconds(env: String?) -> Int64 {
+        guard let v = env else { return defaultPrefixCacheTTLSeconds }
+        guard let n = Int64(v), n >= 0 else { return defaultPrefixCacheTTLSeconds }
+        return n  // 0 ⇒ disabled
     }
 
     /// Set the post-load budgets driven by architecture + physical

--- a/provider-swift/Sources/ProviderCore/Inference/BatchScheduler.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/BatchScheduler.swift
@@ -103,6 +103,12 @@ public actor BatchScheduler {
     /// only — the engine tier (`EncryptedPrefixCachePersistence`) keeps no
     /// hit/miss counters, so pure-attention `.engine` models log nothing here.
     var prefixCacheStatsTask: Task<Void, Never>?
+    /// Steady-state TTL reaper (PR #290 review): reapExpired otherwise runs
+    /// only at load-time reconcile, so entries going cold while the model
+    /// stays loaded would sit on disk until restart (the lazy read-path check
+    /// fires only when the same prefix is looked up again). Started with the
+    /// engine, cancelled in `stopCurrentEngine`.
+    var ttlReapTask: Task<Void, Never>?
     /// Interval (seconds) for the stats logger. Default 120s when a checkpoint
     /// manager is active (one info line every two minutes is negligible even
     /// across a fleet, and gives hit-rate observability out of the box). A
@@ -330,6 +336,9 @@ public actor BatchScheduler {
         // Periodic checkpoint-tier hit/miss logger (no-op if disabled or
         // engine-tier model). Cancelled in stopCurrentEngine.
         startPrefixCacheStatsLogger()
+        // Steady-state TTL sweep for the checkpoint SSD tier (no-op when TTL
+        // disabled or engine-tier model). Cancelled in stopCurrentEngine.
+        startTTLReaper()
     }
 
     /// Snapshot model bytes + tokenizer + architecture out of the
@@ -1371,6 +1380,8 @@ public actor BatchScheduler {
         await logPrefixCacheStats()
         prefixCacheStatsTask?.cancel()
         prefixCacheStatsTask = nil
+        ttlReapTask?.cancel()
+        ttlReapTask = nil
 
         if let engine = self.engine {
             _ = engine.core.abortAllRequests()

--- a/provider-swift/Sources/ProviderCore/Inference/MultiModelBatchSchedulerEngine.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/MultiModelBatchSchedulerEngine.swift
@@ -122,7 +122,8 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
         acquire: @escaping @Sendable (String) async throws -> AcquiredModel,
         tokenizerProvider: @escaping @Sendable (String?) async throws -> TokenizerHandle,
         availableModels: @escaping @Sendable () async -> [String],
-        defaultMaxTokens: Int = 4096
+        defaultMaxTokens: Int = 4096,
+        cacheScope: String = ""
     ) {
         self.acquire = acquire
         self.tokenizerProvider = tokenizerProvider
@@ -133,7 +134,11 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
         self.releaseModel = { _ in }
         self.defaultMaxTokens = defaultMaxTokens
         self.reasoningEffort = nil
-        self.cacheScope = ""
+        // Fixed per-server scope for the standalone (--local) path, which can't
+        // carry a per-request prompt_cache_key through the upstream router. ""
+        // ⇒ unscoped (default). Set via DARKBLOOM_PREFIX_CACHE_SCOPE; used to
+        // exercise/validate cross-tenant isolation on a single box.
+        self.cacheScope = cacheScope
     }
 
     // MARK: - MLXServerEngine

--- a/provider-swift/Sources/ProviderCore/KVCache/PrefixCacheManager.swift
+++ b/provider-swift/Sources/ProviderCore/KVCache/PrefixCacheManager.swift
@@ -468,9 +468,45 @@ public actor PrefixCacheManager: PrefixCacheOwner {
 
     private func loadFromSSD(tokens: [Int], scope: String = "") async -> PrefixLookupResult? {
         guard let index, let kek, let cacheDir else { return nil }
-        guard let entry = index.findLongestCheckpoint(
+
+        // Sliding TTL: an entry is expired when it hasn't been hit within
+        // `ttlSeconds` (lastHitAt is bumped on every hit — SSD loads AND RAM
+        // serves — so hot prefixes stay warm). Checked BEFORE decrypt — an
+        // expired entry is reclaimed (same drop path as a corrupt file) and
+        // the search CONTINUES with the next-longest checkpoint: an expired 8k
+        // checkpoint must not mask a shorter, still-fresh one (e.g. a hot
+        // shared system-prefix). Each drop removes the entry from the index,
+        // so findLongestCheckpoint yields the next candidate; progress is
+        // guaranteed. ttlSeconds == 0 disables (infinite retention). Bounds
+        // how long prompt-derived KV survives on disk (TB-007 window shrink).
+        var selected: PrefixIndexEntry?
+        // Defensive cap: dropUnusableSSDFile no-ops when the manager closed
+        // mid-loop (it must not delete in a handed-off dir), which would
+        // otherwise refetch the same entry forever. The `closed` re-check
+        // breaks that cycle; the cap is belt-and-braces against any future
+        // drop path that leaves the entry behind.
+        var attempts = boundaries.count + 1
+        while attempts > 0, !closed, let candidate = index.findLongestCheckpoint(
             modelHash: binding.modelHash, tokens: tokens, boundaries: boundaries, scope: scope
-        ) else { return nil }
+        ) {
+            attempts -= 1
+            if ttlSeconds > 0 {
+                // Overflow-safe age: index.json is plaintext and can be left
+                // corrupt by a crash — an extreme lastHitAt (e.g. Int64.min)
+                // must be treated as expired/dropped, not trap the provider.
+                let (age, overflow) = now().subtractingReportingOverflow(candidate.lastHitAt)
+                if overflow || age > ttlSeconds {
+                    stats.ttlExpirations += 1
+                    let rel = "\(modelDirComponent)/\(candidate.digestHex).\(EncryptedKVStore.fileExtension)"
+                    await dropUnusableSSDFile(
+                        cacheDir.appendingPathComponent(rel), digestHex: candidate.digestHex, index: index)
+                    continue
+                }
+            }
+            selected = candidate
+            break
+        }
+        guard let entry = selected else { return nil }
 
         // Path safety: the on-disk index JSON is plaintext and NOT
         // authenticated, so a tampered entry.relativePath could contain
@@ -481,18 +517,6 @@ public actor PrefixCacheManager: PrefixCacheOwner {
         // digest) instead of trusting the stored path.
         let relPath = "\(modelDirComponent)/\(entry.digestHex).\(EncryptedKVStore.fileExtension)"
         let fileURL = cacheDir.appendingPathComponent(relPath)
-
-        // Sliding TTL: an entry is expired when it hasn't been hit within
-        // `ttlSeconds` (lastHitAt is bumped on every hit, so hot prefixes stay
-        // warm). Checked BEFORE decrypt — an expired entry is a miss, and its
-        // file + index entry are reclaimed (same drop path as a corrupt file).
-        // ttlSeconds == 0 disables (infinite retention). Bounds how long
-        // prompt-derived KV survives on disk (TB-007 oracle-window shrink).
-        if ttlSeconds > 0, now() - entry.lastHitAt > ttlSeconds {
-            stats.ttlExpirations += 1
-            await dropUnusableSSDFile(fileURL, digestHex: entry.digestHex, index: index)
-            return nil
-        }
 
         // MB-1: validate metadata BEFORE unwrap/decrypt. A wrong-model
         // file decrypts cleanly (AAD is its own metadata), so the cipher

--- a/provider-swift/Sources/ProviderCore/KVCache/PrefixCacheManager.swift
+++ b/provider-swift/Sources/ProviderCore/KVCache/PrefixCacheManager.swift
@@ -308,6 +308,19 @@ public actor PrefixCacheManager: PrefixCacheOwner {
         return overflow ? Int64.max : sum
     }
 
+    /// THE sliding-TTL expiry predicate — single source of truth for the read
+    /// path (loadFromSSD) and the sweeps (reapExpired). Expired when the entry
+    /// hasn't been hit within `ttlSeconds`; `lastHitAt` is bumped on every hit
+    /// (SSD loads AND RAM serves), so hot prefixes stay warm. Overflow-safe:
+    /// index.json is plaintext and can be crash-corrupted — an extreme
+    /// `lastHitAt` (e.g. Int64.min) counts as expired/reapable, never a trap.
+    /// `ttlSeconds == 0` ⇒ never expires (infinite retention).
+    private func isExpired(lastHitAt: Int64) -> Bool {
+        guard ttlSeconds > 0 else { return false }
+        let (age, overflow) = now().subtractingReportingOverflow(lastHitAt)
+        return overflow || age > ttlSeconds
+    }
+
     /// Time-coalesced index save after a hit-recency touch (PR #290 review).
     /// `index.touch` only mutates in memory; if the process dies before a
     /// graceful flush, restart reconcile would reap recently-hot entries off
@@ -535,21 +548,14 @@ public actor PrefixCacheManager: PrefixCacheOwner {
             modelHash: binding.modelHash, tokens: tokens, boundaries: boundaries, scope: scope
         ) {
             attempts -= 1
-            if ttlSeconds > 0 {
-                // Overflow-safe age: index.json is plaintext and can be left
-                // corrupt by a crash — an extreme lastHitAt (e.g. Int64.min)
-                // must be treated as expired/dropped, not trap the provider.
-                let (age, overflow) = now().subtractingReportingOverflow(candidate.lastHitAt)
-                if overflow || age > ttlSeconds {
-                    stats.ttlExpirations += 1
-                    let rel = "\(modelDirComponent)/\(candidate.digestHex).\(EncryptedKVStore.fileExtension)"
-                    await dropUnusableSSDFile(
-                        cacheDir.appendingPathComponent(rel), digestHex: candidate.digestHex, index: index)
-                    continue
-                }
+            guard isExpired(lastHitAt: candidate.lastHitAt) else {
+                selected = candidate
+                break
             }
-            selected = candidate
-            break
+            stats.ttlExpirations += 1
+            let rel = "\(modelDirComponent)/\(candidate.digestHex).\(EncryptedKVStore.fileExtension)"
+            await dropUnusableSSDFile(
+                cacheDir.appendingPathComponent(rel), digestHex: candidate.digestHex, index: index)
         }
         guard let entry = selected else { return nil }
 
@@ -1093,11 +1099,7 @@ public actor PrefixCacheManager: PrefixCacheOwner {
     /// manager is closed (a closed manager must not mutate a handed-off dir).
     private func reapExpired(index: PrefixCacheIndex, cacheDir: URL) {
         guard !closed, ttlSeconds > 0 else { return }
-        // Saturating: an operator-set "effectively infinite" TTL (e.g.
-        // Int64.max) must mean "reap nothing", not trap on underflow.
-        let (diff, underflow) = now().subtractingReportingOverflow(ttlSeconds)
-        let cutoff = underflow ? Int64.min : diff
-        for entry in index.entries(modelHash: binding.modelHash) where entry.lastHitAt < cutoff {
+        for entry in index.entries(modelHash: binding.modelHash) where isExpired(lastHitAt: entry.lastHitAt) {
             let url = cacheDir.appendingPathComponent(
                 "\(modelDirComponent)/\(entry.digestHex).\(EncryptedKVStore.fileExtension)")
             try? FileManager.default.removeItem(at: url)

--- a/provider-swift/Sources/ProviderCore/KVCache/PrefixCacheManager.swift
+++ b/provider-swift/Sources/ProviderCore/KVCache/PrefixCacheManager.swift
@@ -216,6 +216,16 @@ public actor PrefixCacheManager: PrefixCacheOwner {
     private var unsavedWrites = 0
     /// Save the index after this many new writes (or on shutdown/idle flush).
     private static let saveCoalesceThreshold = 8
+    /// Last wall-clock second a touch-driven index save ran (PR #290 review):
+    /// hit-recency (`lastHitAt`) is bumped in memory on every RAM/SSD hit, but
+    /// without periodic persistence a crash loses those bumps and the next
+    /// restart's reconcile reaps recently-hot entries off stale timestamps.
+    /// Saves are time-coalesced (at most one per `touchSaveIntervalSeconds`),
+    /// bounding both the hot-path fsync cost and the crash-loss window.
+    private var lastTouchSaveAt: Int64 = 0
+    /// Max recency staleness a crash can cause (seconds). 60s against the 300s
+    /// default TTL means a crash under-credits an entry's recency by ≤ 20%.
+    static let touchSaveIntervalSeconds: Int64 = 60
     /// TB-016 sub-feature B: pinned digests are always eligible for
     /// persistence regardless of minPersistTokens. Internal-only (no
     /// public pin() API this phase).
@@ -296,6 +306,40 @@ public actor PrefixCacheManager: PrefixCacheOwner {
     private func saturatingExpiry(from base: Int64) -> Int64 {
         let (sum, overflow) = base.addingReportingOverflow(ttlSeconds)
         return overflow ? Int64.max : sum
+    }
+
+    /// Time-coalesced index save after a hit-recency touch (PR #290 review).
+    /// `index.touch` only mutates in memory; if the process dies before a
+    /// graceful flush, restart reconcile would reap recently-hot entries off
+    /// stale persisted timestamps. At most one save per
+    /// `touchSaveIntervalSeconds` bounds the crash-loss window without putting
+    /// an fsync on every warm request. TTL-gated: with TTL off nothing reaps
+    /// on recency, so the persistence urgency disappears.
+    private func persistRecencyIfDue(_ index: PrefixCacheIndex) {
+        guard ttlSeconds > 0, !closed, index.isDirty else { return }
+        let t = now()
+        guard t - lastTouchSaveAt >= Self.touchSaveIntervalSeconds else { return }
+        if (try? index.save()) != nil {
+            lastTouchSaveAt = t
+            unsavedWrites = 0
+        }
+    }
+
+    /// Steady-state TTL sweep (PR #290 review): reconcile-time reaping only
+    /// covers model (re)load, and the lazy read-path check only fires when the
+    /// SAME prefix is looked up again — so entries that go cold while the
+    /// model stays loaded would otherwise sit on disk until restart. Called
+    /// periodically by BatchScheduler while the engine is alive. Persists the
+    /// shrunken index and pushes the corrected footprint to the accountant
+    /// (mirroring dropUnusableSSDFile). No-op when TTL disabled / SSD off /
+    /// closed.
+    public func reapExpiredTick() async {
+        guard ssdEnabled, let index, let cacheDir else { return }
+        let before = stats.ttlExpirations
+        reapExpired(index: index, cacheDir: cacheDir)
+        guard stats.ttlExpirations > before else { return }
+        if index.isDirty { _ = try? index.save() }
+        await notifyAccountant()
     }
 
     public init(
@@ -409,6 +453,7 @@ public actor PrefixCacheManager: PrefixCacheOwner {
                         // enabled so ttl=0 behavior stays byte-identical.
                         if ttlSeconds > 0 {
                             index.touch(modelHash: binding.modelHash, digestHex: digestHex, now: now())
+                            persistRecencyIfDue(index)
                         }
                     } else if hit.tokenCount >= minPersistTokens {
                         // TB-016 sub-feature B: 2nd-use promotion. RAM hit above
@@ -618,6 +663,7 @@ public actor PrefixCacheManager: PrefixCacheOwner {
             )
         }
         index.touch(modelHash: binding.modelHash, digestHex: entry.digestHex, now: now())
+        persistRecencyIfDue(index)
 
         return PrefixLookupResult(caches: caches, tokenCount: entry.tokenCount, tier: .ssd)
     }

--- a/provider-swift/Sources/ProviderCore/KVCache/PrefixCacheManager.swift
+++ b/provider-swift/Sources/ProviderCore/KVCache/PrefixCacheManager.swift
@@ -390,16 +390,27 @@ public actor PrefixCacheManager: PrefixCacheOwner {
         for cp in checkpoints.reversed() {
             if let hit = ram.get(modelHash: binding.modelHash, digest: cp.digest) {
                 stats.ramHits += 1
-                // TB-016 sub-feature B: 2nd-use promotion. If this RAM hit is
-                // above the persist threshold and NOT already on SSD, schedule
-                // a detached promotion (no blocking the lookup actor).
                 let digestHex = cp.digest.dbkvHexString
-                if ssdEnabled,
-                   hit.tokenCount >= minPersistTokens,
-                   index?.entry(modelHash: binding.modelHash, digestHex: digestHex) == nil {
-                    let cpScope = scope
-                    Task.detached { [weak self] in
-                        await self?.persistDigest(cp.digest, scope: cpScope)
+                if ssdEnabled, let index {
+                    if index.entry(modelHash: binding.modelHash, digestHex: digestHex) != nil {
+                        // The prefix is ALSO on SSD. A RAM hit must slide the
+                        // SSD entry's lastHitAt: the sliding TTL is "time since
+                        // last use", and use includes RAM serves. Without this,
+                        // a RAM-hot prefix older than the TTL gets reaped as
+                        // "expired" the moment RAM pressure evicts it and the
+                        // next lookup falls through to SSD. Gated on TTL being
+                        // enabled so ttl=0 behavior stays byte-identical.
+                        if ttlSeconds > 0 {
+                            index.touch(modelHash: binding.modelHash, digestHex: digestHex, now: now())
+                        }
+                    } else if hit.tokenCount >= minPersistTokens {
+                        // TB-016 sub-feature B: 2nd-use promotion. RAM hit above
+                        // the persist threshold and NOT already on SSD — schedule
+                        // a detached promotion (no blocking the lookup actor).
+                        let cpScope = scope
+                        Task.detached { [weak self] in
+                            await self?.persistDigest(cp.digest, scope: cpScope)
+                        }
                     }
                 }
                 return PrefixLookupResult(caches: hit.caches, tokenCount: hit.tokenCount, tier: .ram)

--- a/provider-swift/Sources/ProviderCore/KVCache/PrefixCacheManager.swift
+++ b/provider-swift/Sources/ProviderCore/KVCache/PrefixCacheManager.swift
@@ -1047,7 +1047,10 @@ public actor PrefixCacheManager: PrefixCacheOwner {
     /// manager is closed (a closed manager must not mutate a handed-off dir).
     private func reapExpired(index: PrefixCacheIndex, cacheDir: URL) {
         guard !closed, ttlSeconds > 0 else { return }
-        let cutoff = now() - ttlSeconds
+        // Saturating: an operator-set "effectively infinite" TTL (e.g.
+        // Int64.max) must mean "reap nothing", not trap on underflow.
+        let (diff, underflow) = now().subtractingReportingOverflow(ttlSeconds)
+        let cutoff = underflow ? Int64.min : diff
         for entry in index.entries(modelHash: binding.modelHash) where entry.lastHitAt < cutoff {
             let url = cacheDir.appendingPathComponent(
                 "\(modelDirComponent)/\(entry.digestHex).\(EncryptedKVStore.fileExtension)")

--- a/provider-swift/Sources/ProviderCore/KVCache/PrefixCacheManager.swift
+++ b/provider-swift/Sources/ProviderCore/KVCache/PrefixCacheManager.swift
@@ -124,6 +124,8 @@ public struct PrefixCacheManagerStats: Sendable, Equatable {
     public var prefixHashMismatches = 0
     public var ssdReadErrors = 0
     public var diskEvictions = 0
+    /// SSD entries dropped because they passed the sliding TTL (expired).
+    public var ttlExpirations = 0
 }
 
 // MARK: - Manager
@@ -154,6 +156,14 @@ public actor PrefixCacheManager: PrefixCacheOwner {
     /// Half-life (seconds) for recency decay in benefit-per-byte scoring.
     /// TB-016 sub-feature C: freshly-promoted entries stay hot.
     private let evictionHalfLifeSeconds: Double
+    /// Sliding TTL (seconds) for persisted SSD checkpoints. An entry is expired
+    /// when `now() - lastHitAt > ttlSeconds` (sliding: `lastHitAt` is bumped on
+    /// every hit, so hot prefixes stay warm). 0 ⇒ no TTL (infinite — legacy /
+    /// capacity-driven only). Enforced on read (loadFromSSD) and proactively
+    /// reclaimed in the disk sweep. Privacy: bounds how long KV derived from one
+    /// prompt lingers on disk, shrinking the TB-007 cross-tenant TTFT-oracle
+    /// window. SSD tier only — the RAM tier keeps its deterministic LRU.
+    private let ttlSeconds: Int64
     private let now: @Sendable () -> Int64
 
     /// Phase 3: global disk accountant (process-wide, shared across models).
@@ -270,6 +280,17 @@ public actor PrefixCacheManager: PrefixCacheOwner {
         scopeByDigest[digestHex] ?? ""
     }
 
+    /// Absolute expiry stamped into a freshly-written file's metadata:
+    /// `createdAt + ttl`, or nil when TTL is disabled. This is the EARLIEST
+    /// possible expiry (a never-hit entry, where lastHitAt == createdAt); the
+    /// live check slides off the mutable `lastHitAt` in the index, so a hit
+    /// extends effective lifetime without re-sealing the file. Informational +
+    /// a hard floor for any future offline reaper; the authoritative runtime
+    /// check is the lastHitAt comparison in loadFromSSD/sweep.
+    private func expiresAtForWrite() -> Int64? {
+        ttlSeconds > 0 ? now() + ttlSeconds : nil
+    }
+
     public init(
         binding: PrefixCacheModelBinding,
         ram: PrefixCacheRAM,
@@ -282,6 +303,7 @@ public actor PrefixCacheManager: PrefixCacheOwner {
         minPersistTokens: Int = 0,
         prefillCostPerToken: Double = 1.0,
         evictionHalfLifeSeconds: Double = 86400,
+        ttlSeconds: Int64 = 0,
         now: @escaping @Sendable () -> Int64 = { Int64(Date().timeIntervalSince1970) },
         accountant: GlobalDiskAccountant? = nil,
         modelKey: String = ""
@@ -300,6 +322,7 @@ public actor PrefixCacheManager: PrefixCacheOwner {
         self.minPersistTokens = minPersistTokens
         self.prefillCostPerToken = prefillCostPerToken
         self.evictionHalfLifeSeconds = evictionHalfLifeSeconds
+        self.ttlSeconds = max(0, ttlSeconds)
         self.now = now
         self.accountant = accountant
         self.modelKey = modelKey
@@ -440,6 +463,18 @@ public actor PrefixCacheManager: PrefixCacheOwner {
         // digest) instead of trusting the stored path.
         let relPath = "\(modelDirComponent)/\(entry.digestHex).\(EncryptedKVStore.fileExtension)"
         let fileURL = cacheDir.appendingPathComponent(relPath)
+
+        // Sliding TTL: an entry is expired when it hasn't been hit within
+        // `ttlSeconds` (lastHitAt is bumped on every hit, so hot prefixes stay
+        // warm). Checked BEFORE decrypt — an expired entry is a miss, and its
+        // file + index entry are reclaimed (same drop path as a corrupt file).
+        // ttlSeconds == 0 disables (infinite retention). Bounds how long
+        // prompt-derived KV survives on disk (TB-007 oracle-window shrink).
+        if ttlSeconds > 0, now() - entry.lastHitAt > ttlSeconds {
+            stats.ttlExpirations += 1
+            await dropUnusableSSDFile(fileURL, digestHex: entry.digestHex, index: index)
+            return nil
+        }
 
         // MB-1: validate metadata BEFORE unwrap/decrypt. A wrong-model
         // file decrypts cleanly (AAD is its own metadata), so the cipher
@@ -604,6 +639,7 @@ public actor PrefixCacheManager: PrefixCacheOwner {
                 kvHeads: binding.kvHeads, headDim: binding.headDim, tokenCount: checkpointLength,
                 tokenPrefixHash: digestHex, kvCacheClass: "mixed",
                 metaState: [layoutJSON], chunkPlaintextSizes: chunks.map { $0.count }, createdAt: now(),
+                expiresAt: expiresAtForWrite(),
                 scope: scope
             )
             try await EncryptedKVStore.write(to: fileURL, metadata: meta, chunks: chunks, kek: kek)
@@ -701,6 +737,7 @@ public actor PrefixCacheManager: PrefixCacheOwner {
                     metaState: [layoutJSON],
                     chunkPlaintextSizes: chunks.map { $0.count },
                     createdAt: now(),
+                    expiresAt: expiresAtForWrite(),
                     scope: scopeFor(digestHex)
                 )
                 try await EncryptedKVStore.write(to: fileURL, metadata: meta, chunks: chunks, kek: kek)
@@ -804,6 +841,11 @@ public actor PrefixCacheManager: PrefixCacheOwner {
         let fm = FileManager.default
         let suffix = ".\(EncryptedKVStore.fileExtension)"
 
+        // Proactively reclaim TTL-expired entries before re-indexing, so a
+        // restart doesn't resurrect stale KV (and disk is freed even if the
+        // model is never looked up again this session).
+        reapExpired(index: index, cacheDir: cacheDir)
+
         // Drop index entries whose backing file vanished.
         for entry in index.entries(modelHash: binding.modelHash) {
             let url = modelDir.appendingPathComponent("\(entry.digestHex)\(suffix)")
@@ -834,12 +876,22 @@ public actor PrefixCacheManager: PrefixCacheOwner {
                 try? fm.removeItem(at: url)  // foreign / corrupt / mislabeled
                 continue
             }
+            // TTL: don't resurrect an orphan whose own metadata says it's
+            // already expired (expiresAt = createdAt + ttl at write). Delete it.
+            if ttlSeconds > 0, let exp = meta.expiresAt, now() > exp {
+                try? fm.removeItem(at: url)
+                stats.ttlExpirations += 1
+                continue
+            }
             let bytes = (try? fm.attributesOfItem(atPath: url.path)[.size] as? Int) ?? nil
+            // Seed lastHitAt from the file's own createdAt (NOT now()), so a
+            // re-indexed orphan keeps its real age — re-indexing can't reset the
+            // sliding TTL clock and indefinitely extend a stale entry.
             index.record(PrefixIndexEntry(
                 modelHash: binding.modelHash, digestHex: digestHex,
                 tokenCount: meta.tokenCount,
                 relativePath: "\(modelDirComponent)/\(name)",
-                fileBytes: bytes ?? 0, createdAt: meta.createdAt, lastHitAt: now()))
+                fileBytes: bytes ?? 0, createdAt: meta.createdAt, lastHitAt: meta.createdAt))
         }
         // Apply the budget to the reconciled set, then persist.
         enforceDiskBudget(index: index, cacheDir: cacheDir)
@@ -895,6 +947,7 @@ public actor PrefixCacheManager: PrefixCacheOwner {
                 metaState: [layoutJSON],
                 chunkPlaintextSizes: chunks.map { $0.count },
                 createdAt: now(),
+                expiresAt: expiresAtForWrite(),
                 scope: scope
             )
             try await EncryptedKVStore.write(to: fileURL, metadata: meta, chunks: chunks, kek: kek)
@@ -938,6 +991,23 @@ public actor PrefixCacheManager: PrefixCacheOwner {
     /// index.json without bound and can fill the volume. 0 budget = no cap.
     ///
     /// TB-016 sub-feature C: Uses benefit-per-byte scoring instead of LRU.
+    /// Proactively drop SSD entries past the sliding TTL (file + index entry),
+    /// independent of the disk budget. Runs at load-time reconcile so expired
+    /// KV is reclaimed even for a model that's never looked up again; the
+    /// loadFromSSD check covers steady-state. No-op when TTL is disabled or the
+    /// manager is closed (a closed manager must not mutate a handed-off dir).
+    private func reapExpired(index: PrefixCacheIndex, cacheDir: URL) {
+        guard !closed, ttlSeconds > 0 else { return }
+        let cutoff = now() - ttlSeconds
+        for entry in index.entries(modelHash: binding.modelHash) where entry.lastHitAt < cutoff {
+            let url = cacheDir.appendingPathComponent(
+                "\(modelDirComponent)/\(entry.digestHex).\(EncryptedKVStore.fileExtension)")
+            try? FileManager.default.removeItem(at: url)
+            index.remove(modelHash: binding.modelHash, digestHex: entry.digestHex)
+            stats.ttlExpirations += 1
+        }
+    }
+
     private func enforceDiskBudget(index: PrefixCacheIndex, cacheDir: URL) {
         guard diskBudgetBytes > 0 else { return }
         var total = index.bytes(modelHash: binding.modelHash)

--- a/provider-swift/Sources/ProviderCore/KVCache/PrefixCacheManager.swift
+++ b/provider-swift/Sources/ProviderCore/KVCache/PrefixCacheManager.swift
@@ -288,7 +288,14 @@ public actor PrefixCacheManager: PrefixCacheOwner {
     /// a hard floor for any future offline reaper; the authoritative runtime
     /// check is the lastHitAt comparison in loadFromSSD/sweep.
     private func expiresAtForWrite() -> Int64? {
-        ttlSeconds > 0 ? now() + ttlSeconds : nil
+        ttlSeconds > 0 ? saturatingExpiry(from: now()) : nil
+    }
+
+    /// Saturating `base + ttlSeconds`. An operator-set "effectively infinite"
+    /// TTL (e.g. Int64.max) must clamp to never-expires, not trap on overflow.
+    private func saturatingExpiry(from base: Int64) -> Int64 {
+        let (sum, overflow) = base.addingReportingOverflow(ttlSeconds)
+        return overflow ? Int64.max : sum
     }
 
     public init(
@@ -887,12 +894,19 @@ public actor PrefixCacheManager: PrefixCacheOwner {
                 try? fm.removeItem(at: url)  // foreign / corrupt / mislabeled
                 continue
             }
-            // TTL: don't resurrect an orphan whose own metadata says it's
-            // already expired (expiresAt = createdAt + ttl at write). Delete it.
-            if ttlSeconds > 0, let exp = meta.expiresAt, now() > exp {
-                try? fm.removeItem(at: url)
-                stats.ttlExpirations += 1
-                continue
+            // TTL: don't resurrect an orphan that's already expired. New files
+            // carry expiresAt = createdAt + ttl; LEGACY files (written before
+            // the TTL existed, or while it was disabled) have expiresAt == nil
+            // — treat those as createdAt + ttl too, so old and new files get
+            // identical semantics and a stale legacy orphan can't outlive the
+            // privacy window by being re-indexed (PR #290 review).
+            if ttlSeconds > 0 {
+                let exp = meta.expiresAt ?? saturatingExpiry(from: meta.createdAt)
+                if now() > exp {
+                    try? fm.removeItem(at: url)
+                    stats.ttlExpirations += 1
+                    continue
+                }
             }
             let bytes = (try? fm.attributesOfItem(atPath: url.path)[.size] as? Int) ?? nil
             // Seed lastHitAt from the file's own createdAt (NOT now()), so a

--- a/provider-swift/Sources/ProviderCore/ProviderLoop.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop.swift
@@ -2945,6 +2945,12 @@ extension ProviderLoop {
                 guard let self else { return [] }
                 return await self.advertisedLocalModelIds()
             },
+            // Same per-server scope semantics as the standalone --local path
+            // (PR #290 review): the local HTTP endpoint can't carry a
+            // per-request prompt_cache_key, so honor the fixed
+            // DARKBLOOM_PREFIX_CACHE_SCOPE here too. "" => unscoped. The
+            // coordinator WS path is unaffected (it carries per-request scope).
+            cacheScope: ProcessInfo.processInfo.environment["DARKBLOOM_PREFIX_CACHE_SCOPE"] ?? "",
             // Fires only once OUR server has actually bound the socket — the
             // authoritative bind signal. We publish discovery here (never from a
             // best-effort HTTP probe that a foreign process on the same port

--- a/provider-swift/Sources/ProviderCore/Server/LocalInferenceHTTP.swift
+++ b/provider-swift/Sources/ProviderCore/Server/LocalInferenceHTTP.swift
@@ -60,13 +60,15 @@ func makeLocalInferenceApplication(
     acquire: @escaping @Sendable (String) async throws -> MultiModelBatchSchedulerEngine.AcquiredModel,
     tokenizerProvider: @escaping @Sendable (String?) async throws -> TokenizerHandle,
     availableModels: @escaping @Sendable () async -> [String],
+    cacheScope: String = "",
     onServerRunning: @escaping @Sendable (any Channel) async -> Void = { _ in }
 ) -> LocalInferenceApplication {
     let engine = MultiModelBatchSchedulerEngine(
         acquire: acquire,
         tokenizerProvider: tokenizerProvider,
         availableModels: availableModels,
-        defaultMaxTokens: defaultMaxTokens
+        defaultMaxTokens: defaultMaxTokens,
+        cacheScope: cacheScope
     )
     let service = MLXOpenAIService(engine: engine)
     let router = MLXServerApplication.buildRouter(service: service)

--- a/provider-swift/Sources/ProviderCore/Server/StandaloneServer+HTTP.swift
+++ b/provider-swift/Sources/ProviderCore/Server/StandaloneServer+HTTP.swift
@@ -72,6 +72,11 @@ extension StandaloneServer {
                 guard let self else { return [] }
                 return await self.advertisedModelIds()
             },
+            // The --local path can't carry a per-request prompt_cache_key, so
+            // allow a fixed per-server scope via DARKBLOOM_PREFIX_CACHE_SCOPE.
+            // "" ⇒ unscoped (default). Used to validate cross-tenant isolation
+            // on a single box (two servers, two scopes, one cache dir).
+            cacheScope: ProcessInfo.processInfo.environment["DARKBLOOM_PREFIX_CACHE_SCOPE"] ?? "",
             onServerRunning: { [weak self] _ in
                 await self?.markBound()
             }

--- a/provider-swift/Tests/ProviderCoreTests/BatchSchedulerPrefixCacheConfigTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/BatchSchedulerPrefixCacheConfigTests.swift
@@ -111,4 +111,19 @@ struct BatchSchedulerPrefixCacheConfigTests {
         #expect(BatchScheduler.resolveStatsInterval(env: "30") == 30)         // override
         #expect(BatchScheduler.resolveStatsInterval(env: "120") == 120)
     }
+
+    // The sliding SSD TTL: unset/malformed/negative ⇒ default (300s), `0` ⇒
+    // disabled (infinite), positive ⇒ that window. Pure resolver (no process env).
+    @Test("resolveTTLSeconds: default / disable / override semantics")
+    func ttlSeconds() {
+        let dflt = BatchScheduler.defaultPrefixCacheTTLSeconds
+        #expect(dflt == 300)                                          // 5 min
+        #expect(BatchScheduler.resolveTTLSeconds(env: nil) == dflt)   // unset
+        #expect(BatchScheduler.resolveTTLSeconds(env: "") == dflt)    // empty
+        #expect(BatchScheduler.resolveTTLSeconds(env: "abc") == dflt) // garbage
+        #expect(BatchScheduler.resolveTTLSeconds(env: "-1") == dflt)  // negative
+        #expect(BatchScheduler.resolveTTLSeconds(env: "0") == 0)      // explicit disable (infinite)
+        #expect(BatchScheduler.resolveTTLSeconds(env: "300") == 300)
+        #expect(BatchScheduler.resolveTTLSeconds(env: "3600") == 3600)
+    }
 }

--- a/provider-swift/Tests/ProviderCoreTests/KVCache/PrefixCacheManagerTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/KVCache/PrefixCacheManagerTests.swift
@@ -577,15 +577,16 @@ func managerScopedSSDRoundtripAndIsolation() async throws {
 
 // SSD manager with a controllable clock + TTL. RAM is wiped between writes and
 // reads so every read must consult SSD (where TTL is enforced).
-private func makeTTLManager(ttl: Int64, clock: MonotonicClock, dir: URL? = nil)
+private func makeTTLManager(ttl: Int64, clock: MonotonicClock, dir: URL? = nil,
+                            kek: KVCacheKEK? = nil)
     -> (PrefixCacheManager, URL) {
     let cacheDir = dir ?? tmpDir()
     let mgr = PrefixCacheManager(
         binding: binding(model: "m"),
         ram: PrefixCacheRAM(),
         index: PrefixCacheIndex(fileURL: cacheDir.appendingPathComponent("index.json")),
-        kek: KVCacheKEK(wrapper: InMemoryKeyWrappingService(),
-                        storage: InMemoryWrappedKEKStorage(identifier: UUID().uuidString)),
+        kek: kek ?? KVCacheKEK(wrapper: InMemoryKeyWrappingService(),
+                               storage: InMemoryWrappedKEKStorage(identifier: UUID().uuidString)),
         cacheDir: cacheDir, ssdEnabled: true,
         boundaries: [4, 8],
         ttlSeconds: ttl,
@@ -718,4 +719,61 @@ func ttlRamHitSlidesSSDRecency() async {
     let hit = await mgr.lookup(tokens: tokens)
     #expect(hit?.tier == .ssd, "RAM-hot entry must survive RAM eviction (TTL slid by RAM hits)")
     #expect(await mgr.snapshotStats().ttlExpirations == 0, "nothing should have expired")
+}
+
+@Test
+func ttlReconcileReapsLegacyOrphanWithoutExpiresAt() async throws {
+    // PR #290 review (Codex r3377288876): files written BEFORE the TTL existed
+    // (or while it was disabled) carry expiresAt == nil. Reconcile must treat
+    // them as createdAt + ttl — identical to what expiresAtForWrite stamps on
+    // new files — not resurrect stale prompt-derived KV past the privacy window.
+    let clock = MonotonicClock(start: 1000)
+    let dir = tmpDir()
+    // Writer with TTL DISABLED ⇒ file metadata has expiresAt == nil (the exact
+    // legacy shape). A single flush stays under the index save-coalesce
+    // threshold, so the index is never persisted → the file is an ORPHAN for
+    // the next manager.
+    let (m1, _) = makeTTLManager(ttl: 0, clock: clock, dir: dir)
+    let tokens = prompt(10)
+    await m1.store(tokens: tokens, checkpointLength: 8,
+                   caches: SendableKVCaches(attnCaches(layers: 2, tokens: 8)))
+    _ = await m1.flushToSSD()
+
+    clock.advance(1000)  // 1000s > 300s TTL since createdAt
+    let (m2, _) = makeTTLManager(ttl: 300, clock: clock, dir: dir)
+    await m2.reconcileWithDisk()
+
+    // Assert on the FILE, not a lookup — the lazy read-path check would also
+    // miss on a re-indexed stale entry, masking the resurrect bug.
+    let files = (try? FileManager.default.contentsOfDirectory(atPath: dir.appendingPathComponent("m").path))?
+        .filter { $0.hasSuffix(".\(EncryptedKVStore.fileExtension)") } ?? []
+    #expect(files.isEmpty, "stale legacy nil-expiresAt orphan must be deleted at reconcile, not re-indexed")
+    #expect(await m2.snapshotStats().ttlExpirations >= 1)
+}
+
+@Test
+func ttlReconcileKeepsFreshLegacyOrphan() async throws {
+    // Companion guard: a legacy (nil-expiresAt) orphan that is YOUNGER than
+    // the TTL must still be re-indexed normally — the nil-handling must not
+    // over-delete fresh files.
+    let clock = MonotonicClock(start: 1000)
+    let dir = tmpDir()
+    // Share one KEK across both managers (a restart keeps the persisted KEK;
+    // per-manager random KEKs would make the decrypt fail for harness reasons).
+    let sharedKEK = KVCacheKEK(
+        wrapper: InMemoryKeyWrappingService(key: .init(data: Data(repeating: 7, count: 32)), identifier: "shared"),
+        storage: InMemoryWrappedKEKStorage(identifier: "legacy-orphan-fresh"))
+    let (m1, _) = makeTTLManager(ttl: 0, clock: clock, dir: dir, kek: sharedKEK)
+    let tokens = prompt(10)
+    await m1.store(tokens: tokens, checkpointLength: 8,
+                   caches: SendableKVCaches(attnCaches(layers: 2, tokens: 8)))
+    _ = await m1.flushToSSD()
+
+    clock.advance(100)  // 100s < 300s TTL
+    let (m2, _) = makeTTLManager(ttl: 300, clock: clock, dir: dir, kek: sharedKEK)
+    await m2.reconcileWithDisk()
+    await m2.clearRAM()
+    #expect(await m2.lookup(tokens: tokens)?.tier == .ssd,
+            "fresh legacy orphan must be re-indexed and servable")
+    #expect(await m2.snapshotStats().ttlExpirations == 0)
 }

--- a/provider-swift/Tests/ProviderCoreTests/KVCache/PrefixCacheManagerTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/KVCache/PrefixCacheManagerTests.swift
@@ -807,3 +807,23 @@ func ttlExpiredLongestFallsBackToShorterCheckpoint() async {
     let s = await mgr.snapshotStats()
     #expect(s.ttlExpirations == 1, "exactly the stale cp8 should be reaped")
 }
+
+@Test
+func ttlEffectivelyInfiniteTTLNeverTrapsOrReaps() async {
+    // PR #290 review (Codex r3377288882/85): operators approximate "infinite
+    // retention" with huge TTL values (e.g. Int64.max). Every TTL arithmetic
+    // site must saturate, not trap: expiresAtForWrite (now + ttl), the lookup
+    // age check (now - lastHitAt vs ttl), and reapExpired's cutoff (now - ttl).
+    let clock = MonotonicClock(start: 1_700_000_000)
+    let (mgr, _) = makeTTLManager(ttl: Int64.max, clock: clock)
+    let tokens = prompt(10)
+    await mgr.store(tokens: tokens, checkpointLength: 8,
+                    caches: SendableKVCaches(attnCaches(layers: 2, tokens: 8)))
+    _ = await mgr.flushToSSD()          // expiresAtForWrite: saturates, no trap
+    await mgr.reconcileWithDisk()       // reapExpired cutoff: saturates, no trap
+    await mgr.clearRAM()
+    clock.advance(1_000_000_000)        // ~32 years pass
+    let hit = await mgr.lookup(tokens: tokens)   // age check: no trap
+    #expect(hit?.tier == .ssd, "huge TTL = effectively infinite retention")
+    #expect(await mgr.snapshotStats().ttlExpirations == 0, "nothing may be reaped")
+}

--- a/provider-swift/Tests/ProviderCoreTests/KVCache/PrefixCacheManagerTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/KVCache/PrefixCacheManagerTests.swift
@@ -572,3 +572,121 @@ func managerScopedSSDRoundtripAndIsolation() async throws {
     let stats = await mgr.snapshotStats()
     #expect(stats.ssdReadErrors == 0)
 }
+
+// MARK: - Sliding SSD TTL
+
+// SSD manager with a controllable clock + TTL. RAM is wiped between writes and
+// reads so every read must consult SSD (where TTL is enforced).
+private func makeTTLManager(ttl: Int64, clock: MonotonicClock, dir: URL? = nil)
+    -> (PrefixCacheManager, URL) {
+    let cacheDir = dir ?? tmpDir()
+    let mgr = PrefixCacheManager(
+        binding: binding(model: "m"),
+        ram: PrefixCacheRAM(),
+        index: PrefixCacheIndex(fileURL: cacheDir.appendingPathComponent("index.json")),
+        kek: KVCacheKEK(wrapper: InMemoryKeyWrappingService(),
+                        storage: InMemoryWrappedKEKStorage(identifier: UUID().uuidString)),
+        cacheDir: cacheDir, ssdEnabled: true,
+        boundaries: [4, 8],
+        ttlSeconds: ttl,
+        now: { clock.value },
+        modelKey: "test-model"
+    )
+    return (mgr, cacheDir)
+}
+
+@Test
+func ttlExpiredSSDEntryIsMissAndDropped() async {
+    let clock = MonotonicClock(start: 1000)
+    let (mgr, _) = makeTTLManager(ttl: 300, clock: clock)
+    let tokens = prompt(10)
+    await mgr.store(tokens: tokens, checkpointLength: 8,
+                    caches: SendableKVCaches(attnCaches(layers: 2, tokens: 8)))
+    _ = await mgr.flushToSSD()
+    await mgr.clearRAM()
+    // Within TTL ⇒ SSD hit.
+    clock.advance(299)
+    #expect(await mgr.lookup(tokens: tokens)?.tier == .ssd, "within TTL should hit SSD")
+    // The hit slid lastHitAt to now (=1299). Wipe RAM, advance past TTL ⇒ expired.
+    await mgr.clearRAM()
+    clock.advance(301)  // now 1600; lastHitAt 1299; 301 > 300
+    #expect(await mgr.lookup(tokens: tokens) == nil, "past TTL should miss")
+    let s = await mgr.snapshotStats()
+    #expect(s.ttlExpirations >= 1, "expired entry should be counted + dropped")
+    // Dropped: a subsequent lookup is still a miss (file gone), no read error churn.
+    #expect(await mgr.lookup(tokens: tokens) == nil)
+}
+
+@Test
+func ttlSlidingRefreshKeepsHotEntryAlive() async {
+    let clock = MonotonicClock(start: 1000)
+    let (mgr, _) = makeTTLManager(ttl: 300, clock: clock)
+    let tokens = prompt(10)
+    await mgr.store(tokens: tokens, checkpointLength: 8,
+                    caches: SendableKVCaches(attnCaches(layers: 2, tokens: 8)))
+    _ = await mgr.flushToSSD()
+    // Hit every 200s for 5 windows (total 1000s >> ttl); each hit slides lastHitAt.
+    for _ in 0..<5 {
+        await mgr.clearRAM()
+        clock.advance(200)
+        #expect(await mgr.lookup(tokens: tokens)?.tier == .ssd, "sliding refresh should keep it alive")
+    }
+    let s = await mgr.snapshotStats()
+    #expect(s.ttlExpirations == 0, "a continuously-hit entry must never expire")
+}
+
+@Test
+func ttlDisabledNeverExpires() async {
+    let clock = MonotonicClock(start: 1000)
+    let (mgr, _) = makeTTLManager(ttl: 0, clock: clock)   // 0 = infinite
+    let tokens = prompt(10)
+    await mgr.store(tokens: tokens, checkpointLength: 8,
+                    caches: SendableKVCaches(attnCaches(layers: 2, tokens: 8)))
+    _ = await mgr.flushToSSD()
+    await mgr.clearRAM()
+    clock.advance(10_000_000)  // way past any TTL
+    #expect(await mgr.lookup(tokens: tokens)?.tier == .ssd, "ttl=0 ⇒ never expires")
+    #expect(await mgr.snapshotStats().ttlExpirations == 0)
+}
+
+@Test
+func ttlReconcileReapsExpiredOrphan() async throws {
+    let clock = MonotonicClock(start: 1000)
+    let dir = tmpDir()
+    // Manager 1 writes an entry.
+    let (m1, _) = makeTTLManager(ttl: 300, clock: clock, dir: dir)
+    let tokens = prompt(10)
+    await m1.store(tokens: tokens, checkpointLength: 8,
+                   caches: SendableKVCaches(attnCaches(layers: 2, tokens: 8)))
+    _ = await m1.flushToSSD()
+
+    // Time passes well beyond TTL, then a NEW manager reconciles the dir.
+    clock.advance(1000)  // 1000s > 300 ttl since createdAt=1000
+    let (m2, _) = makeTTLManager(ttl: 300, clock: clock, dir: dir)
+    await m2.reconcileWithDisk()
+    // The expired entry must be reaped, so a lookup misses (no resurrected file).
+    await m2.clearRAM()
+    #expect(await m2.lookup(tokens: tokens) == nil, "reconcile must reap the expired orphan")
+    #expect(await m2.snapshotStats().ttlExpirations >= 1)
+}
+
+@Test
+func ttlReconcileReapsExpiredIndexedEntry() async throws {
+    // INDEX-path reap (vs the orphan-path above): persist the index so the new
+    // manager loads the entry IN its index, then reconcile's reapExpired drops it.
+    let clock = MonotonicClock(start: 1000)
+    let dir = tmpDir()
+    let (m1, _) = makeTTLManager(ttl: 300, clock: clock, dir: dir)
+    let tokens = prompt(10)
+    await m1.store(tokens: tokens, checkpointLength: 8,
+                   caches: SendableKVCaches(attnCaches(layers: 2, tokens: 8)))
+    _ = await m1.flushToSSD()
+    await m1.flushIndexNow()   // persist index.json so m2 loads the entry (not an orphan)
+
+    clock.advance(1000)        // 1000s > 300 ttl
+    let (m2, _) = makeTTLManager(ttl: 300, clock: clock, dir: dir)
+    await m2.reconcileWithDisk()   // reapExpired drops the indexed-but-expired entry
+    await m2.clearRAM()
+    #expect(await m2.lookup(tokens: tokens) == nil, "reconcile must reap the expired indexed entry")
+    #expect(await m2.snapshotStats().ttlExpirations >= 1)
+}

--- a/provider-swift/Tests/ProviderCoreTests/KVCache/PrefixCacheManagerTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/KVCache/PrefixCacheManagerTests.swift
@@ -690,3 +690,32 @@ func ttlReconcileReapsExpiredIndexedEntry() async throws {
     #expect(await m2.lookup(tokens: tokens) == nil, "reconcile must reap the expired indexed entry")
     #expect(await m2.snapshotStats().ttlExpirations >= 1)
 }
+
+@Test
+func ttlRamHitSlidesSSDRecency() async {
+    // PR #290 review (Codex r3377288873): a RAM-resident prefix served past the
+    // TTL must NOT be reaped from SSD when RAM pressure later evicts it — every
+    // RAM hit slides the SSD entry's lastHitAt (use = RAM serves too).
+    let clock = MonotonicClock(start: 1000)
+    let (mgr, _) = makeTTLManager(ttl: 300, clock: clock)
+    let tokens = prompt(10)
+    await mgr.store(tokens: tokens, checkpointLength: 8,
+                    caches: SendableKVCaches(attnCaches(layers: 2, tokens: 8)))
+    _ = await mgr.flushToSSD()   // SSD entry exists, lastHitAt = 1000
+
+    // Serve from RAM 5 times, 200s apart — each gap < TTL, but cumulatively
+    // 1000s past the SSD entry's original lastHitAt.
+    for _ in 0..<5 {
+        clock.advance(200)
+        #expect(await mgr.lookup(tokens: tokens)?.tier == .ram, "stays RAM-hot")
+    }
+
+    // RAM pressure evicts; next lookup falls through to SSD 100s after the
+    // last RAM serve. Without the RAM-hit touch, lastHitAt is still 1000
+    // (1100s stale > 300s TTL) and the hot entry is wrongly reaped.
+    await mgr.clearRAM()
+    clock.advance(100)
+    let hit = await mgr.lookup(tokens: tokens)
+    #expect(hit?.tier == .ssd, "RAM-hot entry must survive RAM eviction (TTL slid by RAM hits)")
+    #expect(await mgr.snapshotStats().ttlExpirations == 0, "nothing should have expired")
+}

--- a/provider-swift/Tests/ProviderCoreTests/KVCache/PrefixCacheManagerTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/KVCache/PrefixCacheManagerTests.swift
@@ -827,3 +827,60 @@ func ttlEffectivelyInfiniteTTLNeverTrapsOrReaps() async {
     #expect(hit?.tier == .ssd, "huge TTL = effectively infinite retention")
     #expect(await mgr.snapshotStats().ttlExpirations == 0, "nothing may be reaped")
 }
+
+@Test
+func ttlTouchRecencyPersistsAcrossCrash() async {
+    // PR #290 review (Codex r3384557425): hit-recency bumps were in-memory
+    // only — a crash after hot hits left stale persisted lastHitAt, and the
+    // restart's reconcile reaped recently-hot entries. Touches now trigger a
+    // time-coalesced index save, bounding the crash-loss window.
+    let clock = MonotonicClock(start: 1000)
+    let dir = tmpDir()
+    let sharedKEK = KVCacheKEK(
+        wrapper: InMemoryKeyWrappingService(key: .init(data: Data(repeating: 7, count: 32)), identifier: "shared"),
+        storage: InMemoryWrappedKEKStorage(identifier: "touch-persist"))
+    let (m1, _) = makeTTLManager(ttl: 300, clock: clock, dir: dir, kek: sharedKEK)
+    let tokens = prompt(10)
+    await m1.store(tokens: tokens, checkpointLength: 8,
+                   caches: SendableKVCaches(attnCaches(layers: 2, tokens: 8)))
+    _ = await m1.flushToSSD()
+    await m1.flushIndexNow()   // persisted lastHitAt = 1000
+
+    // A warm hit at t=1200 slides recency AND (coalesced) persists it.
+    clock.advance(200)
+    await m1.clearRAM()
+    #expect(await m1.lookup(tokens: tokens)?.tier == .ssd)
+
+    // CRASH: m1 abandoned without graceful teardown. Restart at t=1400 —
+    // cutoff is 1100; the persisted lastHitAt must be 1200 (the touch), not
+    // the stale 1000, or reconcile reaps a 200s-hot entry.
+    clock.advance(200)
+    let (m2, _) = makeTTLManager(ttl: 300, clock: clock, dir: dir, kek: sharedKEK)
+    await m2.reconcileWithDisk()
+    let hit = await m2.lookup(tokens: tokens)
+    #expect(hit?.tier == .ssd, "recently-hot entry must survive a crash-restart reconcile")
+    #expect(await m2.snapshotStats().ttlExpirations == 0)
+}
+
+@Test
+func ttlReapExpiredTickReapsWhileModelStaysLoaded() async {
+    // PR #290 review (Codex r3384557423): reconcile-only reaping leaves
+    // cold entries on disk for the whole model-loaded lifetime. The periodic
+    // reapExpiredTick must reclaim them with NO reconcile/restart.
+    let clock = MonotonicClock(start: 1000)
+    let (mgr, dir) = makeTTLManager(ttl: 300, clock: clock)
+    let tokens = prompt(10)
+    await mgr.store(tokens: tokens, checkpointLength: 8,
+                    caches: SendableKVCaches(attnCaches(layers: 2, tokens: 8)))
+    _ = await mgr.flushToSSD()
+
+    clock.advance(1000)  // entry is now 1000s cold (> 300s TTL)
+    await mgr.reapExpiredTick()
+
+    // Assert on the physical file + stats (RAM may still hold the entry; the
+    // tick's contract is the DISK tier).
+    let files = (try? FileManager.default.contentsOfDirectory(atPath: dir.appendingPathComponent("m").path))?
+        .filter { $0.hasSuffix(".\(EncryptedKVStore.fileExtension)") } ?? []
+    #expect(files.isEmpty, "steady-state tick must reap the cold entry without a reconcile")
+    #expect(await mgr.snapshotStats().ttlExpirations >= 1)
+}

--- a/provider-swift/Tests/ProviderCoreTests/KVCache/PrefixCacheManagerTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/KVCache/PrefixCacheManagerTests.swift
@@ -777,3 +777,33 @@ func ttlReconcileKeepsFreshLegacyOrphan() async throws {
             "fresh legacy orphan must be re-indexed and servable")
     #expect(await m2.snapshotStats().ttlExpirations == 0)
 }
+
+@Test
+func ttlExpiredLongestFallsBackToShorterCheckpoint() async {
+    // PR #290 review (Codex r3377288879): an expired LONGEST checkpoint must
+    // not mask a shorter, still-fresh one. Boundaries [4,8]: let the 8-token
+    // checkpoint go stale while the 4-token (shared system-prefix analogue)
+    // stays hot; the SSD search must reap the 8 and serve the 4.
+    let clock = MonotonicClock(start: 1000)
+    let (mgr, _) = makeTTLManager(ttl: 300, clock: clock)
+    let tokens = prompt(10)
+    await mgr.store(tokens: tokens, checkpointLength: 4,
+                    caches: SendableKVCaches(attnCaches(layers: 2, tokens: 4)))
+    await mgr.store(tokens: tokens, checkpointLength: 8,
+                    caches: SendableKVCaches(attnCaches(layers: 2, tokens: 8)))
+    _ = await mgr.flushToSSD()   // both on SSD, lastHitAt = 1000
+
+    // Keep ONLY the 4-token checkpoint warm: a 6-token prompt matches just
+    // cp4 (RAM hit → slides cp4's SSD lastHitAt to 1200 via the RAM-touch).
+    clock.advance(200)
+    #expect(await mgr.lookup(tokens: prompt(6))?.tokenCount == 4)
+
+    // t=1400: cp8 age 400s (expired), cp4 age 200s (fresh).
+    clock.advance(200)
+    await mgr.clearRAM()
+    let hit = await mgr.lookup(tokens: tokens)
+    #expect(hit?.tier == .ssd, "search must continue past the expired longest")
+    #expect(hit?.tokenCount == 4, "the still-fresh shorter checkpoint must serve")
+    let s = await mgr.snapshotStats()
+    #expect(s.ttlExpirations == 1, "exactly the stale cp8 should be reaped")
+}


### PR DESCRIPTION
Two follow-ups to the merged encrypted SSD KV cache (#237), both from @Gajesh2007's review comments. Clean branch off `master` — **8 files, +247/−5** (the prompt_cache_key scoping landed with #237 already; this is the remaining work).

## 1. Sliding 5-minute SSD TTL

`expiresAt` was carried in the metadata but **never enforced** — checkpoint lifetime was purely capacity-driven, so a low-traffic prefix could sit encrypted on SSD indefinitely. This adds a real **sliding** TTL:

- **Sliding off `lastHitAt`** (the mutable, plaintext index field bumped on every SSD hit) — so a hit refreshes the window **without re-sealing** the GCM-AAD-bound file. Rule: expired when `now() - lastHitAt > ttl`.
- **Lazy enforcement**: `loadFromSSD` checks expiry *before* decrypt → expired = miss + drop file & index entry + refresh accountant (`ttlExpirations++`).
- **Proactive reclaim**: `reapExpired()` at load-time `reconcileWithDisk` reclaims expired entries even for a model never looked up again (covers both the indexed-entry and orphan-file paths).
- `expiresAt = createdAt + ttl` is now stamped on write (a conservative hard floor for the orphan check); `nil` when disabled.
- **Config**: `DARKBLOOM_PREFIX_CACHE_TTL_SECONDS` — default **300** (matches Anthropic/OpenAI prompt-cache defaults), `0` = infinite.
- **Scope**: SSD checkpoint tier only — the RAM tier keeps its deterministic LRU.
- **Privacy**: bounds how long prompt-derived KV lingers on disk, shrinking the TB-007 cross-tenant TTFT-oracle window.

## 2. Per-server cache scope for the `--local` path

The standalone HTTP server can't carry a per-request `prompt_cache_key` (the upstream `OpenAIChatCompletionRequest` has no such field), so the per-tenant scoping merged in #237 only flowed on the coordinator WebSocket path. This adds a **fixed per-server** scope via `DARKBLOOM_PREFIX_CACHE_SCOPE` (`""` = unscoped, default) so cross-tenant isolation can be validated on a single box.

## Tests
- Unit (deterministic, injectable clock): TTL expiry → miss+drop; sliding-keeps-hot-alive (5×200s hits over a 300s TTL never expire); `ttl=0` → infinite; reconcile reaps (orphan + indexed paths); pure `resolveTTLSeconds` policy. All cache suites green; build clean on top of current `master`.

## Verified live on an M5 Max
- **TTL**: real 300s default — populate 8 SSD checkpoints, idle 330s, restart → reconcile reaped all 8 (**8 → 0**). **Control** with `TTL=0` over the identical idle kept all 8 (**8 → 8**) — proving the reclamation is TTL-driven, not some other cleanup.
- **Scoping**: two scopes sharing one cache dir, identical prompts → file count **24 → 48** (tenant B could not hit tenant A's cached prefixes; same-scope reuse works).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/290"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783558822&installation_id=133247490&pr_number=290&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F290&signature=4b20ec1b7c8019630a243d29f20c910be122902c5a7cb15f38109d40f75eb9af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->