### PR TITLE
feat: coordinated drain + restart for provider auto-updates

### DIFF
--- a/coordinator/api/provider.go
+++ b/coordinator/api/provider.go
@@ -412,6 +412,16 @@ func (s *Server) providerReadLoop(ctx context.Context, conn *websocket.Conn, pro
 			}
 			// "started" status: no action — load is in progress.
 
+		case protocol.TypeProviderDraining:
+			drainMsg := msg.Payload.(*protocol.ProviderDrainingMessage)
+			s.logger.Info("provider draining update",
+				"provider_id", providerID,
+				"reason", drainMsg.Reason,
+				"in_flight", drainMsg.InFlight,
+				"completed", drainMsg.Completed,
+			)
+			s.registry.UpdateProviderDraining(providerID, drainMsg)
+
 		default:
 			s.logger.Warn("unhandled provider message type", "provider_id", providerID, "type", msg.Type)
 		}

--- a/coordinator/api/release_handlers.go
+++ b/coordinator/api/release_handlers.go
@@ -17,10 +17,14 @@ import (
 	"path"
 	"regexp"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/eigeninference/d-inference/coordinator/auth"
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+	"github.com/eigeninference/d-inference/coordinator/registry"
 	"github.com/eigeninference/d-inference/coordinator/store"
+	"nhooyr.io/websocket"
 )
 
 const (
@@ -136,6 +140,9 @@ func (s *Server) handleRegisterRelease(w http.ResponseWriter, r *http.Request) {
 	s.readCache.Invalidate("api_version:v1")
 	s.readCache.Invalidate("runtime_manifest:v1")
 	s.readCache.Invalidate("latest_release:v1")
+
+	// Trigger coordinated drain for all online providers to pick up the new release.
+	s.triggerProviderDrainForRelease(release.Version)
 
 	s.logger.Info("release registered",
 		"version", release.Version,
@@ -620,4 +627,79 @@ func (s *Server) handleAdminAuthVerify(w http.ResponseWriter, r *http.Request) {
 		"token": token,
 		"email": req.Email,
 	})
+}
+
+// triggerProviderDrainForRelease sends a drain command to all online providers
+// when a new release is registered. This initiates the coordinated update flow:
+// providers stop accepting new requests, finish in-flight, then restart.
+func (s *Server) triggerProviderDrainForRelease(version string) {
+	// Check feature flag (enabled by default)
+	if os.Getenv("ENABLE_DRAIN_UPDATE") == "false" {
+		s.logger.Debug("drain update disabled via ENABLE_DRAIN_UPDATE=false, skipping provider drain", "version", version)
+		return
+	}
+
+	s.logger.Info("triggering coordinated drain for new release", "version", version)
+
+	// Get all online providers from registry
+	providers := s.registry.GetOnlineProviders()
+
+	if len(providers) == 0 {
+		s.logger.Info("no online providers to drain")
+		return
+	}
+
+	// Calculate deadline (now + drain timeout + buffer)
+	drainTimeout := 30 * time.Second // default, could be configurable
+	deadline := time.Now().Add(drainTimeout + 10*time.Second)
+	deadlineStr := deadline.Format(time.RFC3339)
+
+	// Fan out drain commands concurrently
+	var wg sync.WaitGroup
+	sem := make(chan struct{}, 50) // limit concurrency
+
+	for _, p := range providers {
+		wg.Add(1)
+		sem <- struct{}{}
+		go func(provider *registry.Provider) {
+			defer wg.Done()
+			defer func() { <-sem }()
+
+			provider.Mu().Lock()
+			conn := provider.Conn
+			providerID := provider.ID
+			provider.Mu().Unlock()
+
+			if conn == nil {
+				s.logger.Debug("provider has no connection, skipping drain", "provider_id", providerID)
+				return
+			}
+
+			// Send drain command via WebSocket
+			drainMsg := protocol.DrainCommandMessage{
+				Type:     protocol.TypeDrainCommand,
+				Reason:   protocol.DrainReasonUpdate,
+				Deadline: deadlineStr,
+				Version:  version,
+			}
+			data, err := json.Marshal(drainMsg)
+			if err != nil {
+				s.logger.Warn("failed to marshal drain command", "provider_id", providerID, "error", err)
+				return
+			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+
+			if err := conn.Write(ctx, websocket.MessageText, data); err != nil {
+				s.logger.Warn("failed to send drain command", "provider_id", providerID, "error", err)
+				return
+			}
+
+			s.logger.Info("sent drain command to provider", "provider_id", providerID, "version", version)
+		}(p)
+	}
+
+	wg.Wait()
+	s.logger.Info("drain fan-out complete", "providers", len(providers), "version", version)
 }

--- a/coordinator/protocol/messages.go
+++ b/coordinator/protocol/messages.go
@@ -41,6 +41,7 @@ const (
 	// attestation_response: this is the WebSocket return leg of the push round-trip.
 	TypeCodeAttestationResponse = "code_attestation_response"
 	TypeLoadModelStatus         = "load_model_status"
+	TypeProviderDraining        = "provider_draining"
 
 	// Coordinator → Provider.
 	TypeInferenceRequest     = "inference_request"
@@ -49,6 +50,7 @@ const (
 	TypeRuntimeStatus        = "runtime_status"
 	TypeLoadModel            = "load_model"
 	TypeTrustStatus          = "trust_status"
+	TypeDrainCommand         = "drain_command"
 )
 
 // LoadModelStatus is the lifecycle state reported by a provider in response
@@ -137,6 +139,15 @@ type PrivacyCapabilities struct {
 	HypervisorActive        bool `json:"hypervisor_active"`
 }
 
+// DrainReason describes why a provider is being drained.
+type DrainReason string
+
+const (
+	DrainReasonUpdate     DrainReason = "update"      // provider binary update available
+	DrainReasonMaintenance DrainReason = "maintenance" // coordinator-initiated maintenance
+	DrainReasonDecommission DrainReason = "decommission" // provider being removed from fleet
+)
+
 // HeartbeatMessage is sent periodically by connected providers.
 type HeartbeatMessage struct {
 	Type            string           `json:"type"`
@@ -146,6 +157,9 @@ type HeartbeatMessage struct {
 	WarmModels      []string         `json:"warm_models,omitempty"`      // models currently loaded in memory
 	SystemMetrics   SystemMetrics    `json:"system_metrics"`             // live resource utilization
 	BackendCapacity *BackendCapacity `json:"backend_capacity,omitempty"` // live backend capacity (nil for old providers)
+	Draining        bool             `json:"draining,omitempty"`         // true when provider is draining
+	DrainReason     *DrainReason     `json:"drain_reason,omitempty"`     // reason for draining
+	DrainDeadline   *string          `json:"drain_deadline,omitempty"`   // RFC3339 deadline when drain must complete
 }
 
 // BackendSlotCapacity describes the capacity state of a single backend slot
@@ -309,6 +323,32 @@ type LoadModelStatusMessage struct {
 	ModelID string `json:"model_id"`
 	Status  string `json:"status"`
 	Error   string `json:"error,omitempty"`
+}
+
+// ProviderDrainingMessage is sent by a provider to inform the coordinator
+// that it has entered draining state and will not accept new requests.
+type ProviderDrainingMessage struct {
+	Type        string     `json:"type"`
+	Reason      DrainReason `json:"reason"`
+	Deadline    string     `json:"deadline"`    // RFC3339 deadline when drain must complete
+	InFlight    int        `json:"in_flight"`   // number of in-flight requests at drain start
+	Completed   int        `json:"completed"`   // number of requests completed since drain started
+}
+
+// DrainCommandMessage is sent by the coordinator to instruct a provider
+// to begin draining (stop accepting new requests, finish in-flight, then restart).
+type DrainCommandMessage struct {
+	Type     string     `json:"type"`
+	Reason   DrainReason `json:"reason"`
+	Deadline string     `json:"deadline"` // RFC3339 deadline when drain must complete
+	Version  string     `json:"version,omitempty"` // target version for update drains
+}
+
+// ProviderDrainError is the error response sent to clients when a provider
+// is draining and cannot accept new requests.
+type ProviderDrainError struct {
+	Error      string `json:"error"`
+	RetryAfter int    `json:"retry_after"` // seconds until client should retry
 }
 
 // AttestationChallengeMessage is sent by the coordinator to challenge a provider
@@ -484,6 +524,13 @@ func (pm *ProviderMessage) UnmarshalJSON(data []byte) error {
 		var msg LoadModelStatusMessage
 		if err := json.Unmarshal(data, &msg); err != nil {
 			return fmt.Errorf("protocol: failed to unmarshal load_model_status: %w", err)
+		}
+		pm.Payload = &msg
+
+	case TypeProviderDraining:
+		var msg ProviderDrainingMessage
+		if err := json.Unmarshal(data, &msg); err != nil {
+			return fmt.Errorf("protocol: failed to unmarshal provider_draining: %w", err)
 		}
 		pm.Payload = &msg
 

--- a/coordinator/protocol/messages.go
+++ b/coordinator/protocol/messages.go
@@ -143,8 +143,8 @@ type PrivacyCapabilities struct {
 type DrainReason string
 
 const (
-	DrainReasonUpdate     DrainReason = "update"      // provider binary update available
-	DrainReasonMaintenance DrainReason = "maintenance" // coordinator-initiated maintenance
+	DrainReasonUpdate       DrainReason = "update"       // provider binary update available
+	DrainReasonMaintenance  DrainReason = "maintenance"  // coordinator-initiated maintenance
 	DrainReasonDecommission DrainReason = "decommission" // provider being removed from fleet
 )
 
@@ -328,20 +328,20 @@ type LoadModelStatusMessage struct {
 // ProviderDrainingMessage is sent by a provider to inform the coordinator
 // that it has entered draining state and will not accept new requests.
 type ProviderDrainingMessage struct {
-	Type        string     `json:"type"`
-	Reason      DrainReason `json:"reason"`
-	Deadline    string     `json:"deadline"`    // RFC3339 deadline when drain must complete
-	InFlight    int        `json:"in_flight"`   // number of in-flight requests at drain start
-	Completed   int        `json:"completed"`   // number of requests completed since drain started
+	Type      string      `json:"type"`
+	Reason    DrainReason `json:"reason"`
+	Deadline  string      `json:"deadline"`  // RFC3339 deadline when drain must complete
+	InFlight  int         `json:"in_flight"` // number of in-flight requests at drain start
+	Completed int         `json:"completed"` // number of requests completed since drain started
 }
 
 // DrainCommandMessage is sent by the coordinator to instruct a provider
 // to begin draining (stop accepting new requests, finish in-flight, then restart).
 type DrainCommandMessage struct {
-	Type     string     `json:"type"`
+	Type     string      `json:"type"`
 	Reason   DrainReason `json:"reason"`
-	Deadline string     `json:"deadline"` // RFC3339 deadline when drain must complete
-	Version  string     `json:"version,omitempty"` // target version for update drains
+	Deadline string      `json:"deadline"`          // RFC3339 deadline when drain must complete
+	Version  string      `json:"version,omitempty"` // target version for update drains
 }
 
 // ProviderDrainError is the error response sent to clients when a provider

--- a/coordinator/protocol/messages_test.go
+++ b/coordinator/protocol/messages_test.go
@@ -1026,3 +1026,70 @@ func TestBackendSlotCapacityBackwardCompatDecode(t *testing.T) {
 		t.Errorf("num_running = %d, want 2", slot.NumRunning)
 	}
 }
+
+func TestDrainCommandMarshalWholeSecondDeadline(t *testing.T) {
+	// The provider's Swift decoder must be able to parse the deadline. Go's
+	// time.RFC3339 emits whole seconds with no fractional component; pin that
+	// shape here so a deadline-format regression fails this test.
+	msg := DrainCommandMessage{
+		Type:     TypeDrainCommand,
+		Reason:   DrainReasonUpdate,
+		Deadline: "2026-06-09T01:30:00Z",
+		Version:  "0.6.1",
+	}
+	data, err := json.Marshal(msg)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var decoded DrainCommandMessage
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if decoded.Reason != DrainReasonUpdate {
+		t.Errorf("reason = %q, want %q", decoded.Reason, DrainReasonUpdate)
+	}
+	if decoded.Deadline != "2026-06-09T01:30:00Z" {
+		t.Errorf("deadline = %q, want whole-second RFC3339", decoded.Deadline)
+	}
+	if decoded.Version != "0.6.1" {
+		t.Errorf("version = %q, want 0.6.1", decoded.Version)
+	}
+}
+
+func TestDrainCommandOmitsEmptyVersion(t *testing.T) {
+	msg := DrainCommandMessage{
+		Type:     TypeDrainCommand,
+		Reason:   DrainReasonMaintenance,
+		Deadline: "2026-06-09T01:30:00Z",
+	}
+	data, err := json.Marshal(msg)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var raw map[string]any
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("unmarshal raw: %v", err)
+	}
+	if _, present := raw["version"]; present {
+		t.Errorf("version key present, want omitted when empty")
+	}
+}
+
+func TestProviderMessageUnmarshalProviderDraining(t *testing.T) {
+	data := []byte(`{"type":"provider_draining","reason":"update","deadline":"2026-06-09T01:30:00Z","in_flight":3,"completed":1}`)
+
+	var msg ProviderMessage
+	if err := json.Unmarshal(data, &msg); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if msg.Type != TypeProviderDraining {
+		t.Fatalf("Type=%q, want %q", msg.Type, TypeProviderDraining)
+	}
+	draining, ok := msg.Payload.(*ProviderDrainingMessage)
+	if !ok {
+		t.Fatalf("Payload=%T, want *ProviderDrainingMessage", msg.Payload)
+	}
+	if draining.Reason != DrainReasonUpdate || draining.InFlight != 3 || draining.Completed != 1 {
+		t.Fatalf("decoded draining = %+v", draining)
+	}
+}

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -286,6 +286,10 @@ type Provider struct {
 	// fleet routes as before. Fail-closed once true (no self-route exemption).
 	codeAttestationRequired bool
 
+	// Draining indicates the provider is in coordinated drain mode (stop accepting
+	// new requests, finish in-flight, then restart). Set via UpdateProviderDraining.
+	Draining bool
+
 	mu          sync.Mutex
 	pendingReqs map[string]*PendingRequest
 }
@@ -1057,6 +1061,23 @@ func (r *Registry) SetQueue(q *RequestQueue) {
 	r.queue = q
 }
 
+// GetOnlineProviders returns all providers that are online or serving.
+// Used for coordinated drain fan-out.
+func (r *Registry) GetOnlineProviders() []*Provider {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	providers := make([]*Provider, 0, len(r.providers))
+	for _, p := range r.providers {
+		p.mu.Lock()
+		if p.Status == StatusOnline || p.Status == StatusServing {
+			providers = append(providers, p)
+		}
+		p.mu.Unlock()
+	}
+	return providers
+}
+
 // Sanity caps on provider-reported stats. A malicious (or broken) provider
 // could otherwise report absurd values to monopolize routing. These caps are
 // ~3-4x current hardware ceilings (M2 Ultra is ~800 GB/s, MLX decode is ~120
@@ -1368,6 +1389,9 @@ func (r *Registry) Heartbeat(id string, msg *protocol.HeartbeatMessage) {
 			}
 		}
 	}
+	// Sync drain state from heartbeat (authoritative — heartbeat is the
+	// only live signal; provider_draining messages are advisory).
+	p.Draining = msg.Draining
 	// Update warm models from heartbeat. Always overwrite -- an empty list
 	// means the provider has no models loaded, and stale entries must be
 	// cleared to prevent TriggerModelSwaps from suppressing needed swaps.
@@ -1836,6 +1860,8 @@ func (r *Registry) Disconnect(id string) {
 				r.modelProviderDec(m.ID)
 			}
 		}
+		// Clear drain state on disconnect — a reconnecting provider starts fresh.
+		p.Draining = false
 		p.mu.Unlock()
 	}
 	r.mu.Unlock()
@@ -2093,6 +2119,45 @@ func (r *Registry) RecordChallengeFailure(providerID string, transientOnly bool)
 	return count
 }
 
+// UpdateProviderDraining updates a provider's draining state from a
+// provider_draining WebSocket message.
+func (r *Registry) UpdateProviderDraining(providerID string, msg *protocol.ProviderDrainingMessage) {
+	r.mu.RLock()
+	p, ok := r.providers[providerID]
+	r.mu.RUnlock()
+	if !ok {
+		r.logger.Warn("draining update from unknown provider", "provider_id", providerID)
+		return
+	}
+
+	p.mu.Lock()
+	p.Draining = true
+	p.WarmModels = []string{} // Clear warm models during drain
+	p.CurrentModel = ""
+	p.mu.Unlock()
+
+	r.logger.Info("provider draining state updated",
+		"provider_id", providerID,
+		"reason", msg.Reason,
+		"in_flight", msg.InFlight,
+		"completed", msg.Completed,
+	)
+}
+
+// IsProviderDraining reports whether a provider is currently draining.
+func (r *Registry) IsProviderDraining(providerID string) bool {
+	r.mu.RLock()
+	p, ok := r.providers[providerID]
+	r.mu.RUnlock()
+	if !ok {
+		return false
+	}
+	p.mu.Lock()
+	draining := p.Draining
+	p.mu.Unlock()
+	return draining
+}
+
 // TrustMultiplier returns the trust multiplier for routing score calculation.
 func TrustMultiplier(t TrustLevel) float64 {
 	switch t {
@@ -2314,6 +2379,13 @@ func (r *Registry) FindProviderWithTrust(model string, minTrust TrustLevel, excl
 			continue
 		}
 		if lastChallenge.IsZero() || now.Sub(lastChallenge) > challengeMaxAge {
+			continue
+		}
+		// Skip draining providers
+		p.mu.Lock()
+		draining := p.Draining
+		p.mu.Unlock()
+		if draining {
 			continue
 		}
 		p.mu.Lock()
@@ -2761,8 +2833,13 @@ func (r *Registry) ModelCapacitySnapshot() []ModelCapacity {
 
 		// Apply the same gates as snapshotProviderLocked. Private-only machines
 		// never serve the public fleet, so they do not count toward public
-		// model capacity.
+		// model capacity. Draining providers are not routable — they are
+		// finishing in-flight work before restarting.
 		if p.Status == StatusOffline || p.Status == StatusUntrusted {
+			p.mu.Unlock()
+			continue
+		}
+		if p.Draining {
 			p.mu.Unlock()
 			continue
 		}

--- a/coordinator/registry/scheduler.go
+++ b/coordinator/registry/scheduler.go
@@ -516,6 +516,11 @@ func (r *Registry) snapshotProviderLocked(p *Provider, model string, selfRouteOw
 	if p.Status == StatusOffline || p.Status == StatusUntrusted {
 		return routingSnapshot{}, false
 	}
+	// Draining providers are not routable — they are finishing in-flight work
+	// before restarting.
+	if p.Draining {
+		return routingSnapshot{}, false
+	}
 	// A private-only machine never serves the public fleet — only its owner's
 	// self-route requests.
 	if p.PrivateOnly && !selfRouteOwner {
@@ -885,6 +890,11 @@ func (r *Registry) providerCanAdmitLocked(p *Provider, model string, selfRouteOw
 	if p.Status == StatusOffline || p.Status == StatusUntrusted {
 		return false
 	}
+	// Draining providers are not routable — they are finishing in-flight work
+	// before restarting.
+	if p.Draining {
+		return false
+	}
 	if p.PrivateOnly && !selfRouteOwner {
 		return false
 	}
@@ -990,6 +1000,12 @@ func (r *Registry) QuickCapacityCheck(model string, estimatedPromptTokens, reque
 			continue
 		}
 		if p.PrivateOnly {
+			p.mu.Unlock()
+			continue
+		}
+		// Draining providers are not routable — they are finishing in-flight work
+		// before restarting.
+		if p.Draining {
 			p.mu.Unlock()
 			continue
 		}

--- a/coordinator/registry/scheduler_test.go
+++ b/coordinator/registry/scheduler_test.go
@@ -306,6 +306,101 @@ func TestDrainQueuedRequestsSkipsUnassignableTargetedRequest(t *testing.T) {
 	}
 }
 
+func TestReserveProviderSkipsDraining(t *testing.T) {
+	reg := New(testLogger())
+	model := "scheduler-model"
+	healthy := makeSchedulerProvider(t, reg, "healthy", model, 100)
+	draining := makeSchedulerProvider(t, reg, "draining", model, 200) // faster, would win if routable
+
+	draining.mu.Lock()
+	draining.Draining = true
+	draining.mu.Unlock()
+
+	req := &PendingRequest{
+		RequestID:          "req-drain",
+		Model:              model,
+		RequestedMaxTokens: 128,
+	}
+	selected := reg.ReserveProvider(model, req)
+	if selected == nil {
+		t.Fatal("ReserveProvider returned nil; healthy provider should still be routable")
+	}
+	if selected.ID != healthy.ID {
+		t.Fatalf("selected %q, want %q (draining provider must be skipped)", selected.ID, healthy.ID)
+	}
+}
+
+func TestReserveProviderExNilWhenAllDraining(t *testing.T) {
+	reg := New(testLogger())
+	model := "scheduler-model"
+	p := makeSchedulerProvider(t, reg, "only", model, 100)
+
+	p.mu.Lock()
+	p.Draining = true
+	p.mu.Unlock()
+
+	req := &PendingRequest{
+		RequestID:          "req-all-drain",
+		Model:              model,
+		RequestedMaxTokens: 128,
+	}
+	selected, decision := reg.ReserveProviderEx(model, req)
+	if selected != nil {
+		t.Fatalf("expected nil provider when the only candidate is draining, got %q", selected.ID)
+	}
+	if decision.CandidateCount != 0 {
+		t.Fatalf("decision.CandidateCount=%d, want 0 (draining excluded)", decision.CandidateCount)
+	}
+}
+
+func TestQuickCapacityCheckSkipsDraining(t *testing.T) {
+	reg := New(testLogger())
+	model := "scheduler-model"
+	p := makeSchedulerProvider(t, reg, "only", model, 100)
+
+	// Healthy: counts as a candidate.
+	candidates, _, _ := reg.QuickCapacityCheck(model, 100, 128)
+	if candidates != 1 {
+		t.Fatalf("candidates=%d, want 1 before drain", candidates)
+	}
+
+	p.mu.Lock()
+	p.Draining = true
+	p.mu.Unlock()
+
+	// Draining: no longer a candidate.
+	candidates, _, _ = reg.QuickCapacityCheck(model, 100, 128)
+	if candidates != 0 {
+		t.Fatalf("candidates=%d, want 0 after drain", candidates)
+	}
+}
+
+func TestHeartbeatClearsDrainingState(t *testing.T) {
+	reg := New(testLogger())
+	model := "scheduler-model"
+	p := makeSchedulerProvider(t, reg, "p1", model, 100)
+
+	p.mu.Lock()
+	p.Draining = true
+	p.mu.Unlock()
+
+	// A heartbeat reporting draining=false (the provider restarted/recovered)
+	// must clear the drain gate so routing resumes.
+	reg.Heartbeat("p1", &protocol.HeartbeatMessage{
+		Type:          protocol.TypeHeartbeat,
+		Status:        "idle",
+		SystemMetrics: protocol.SystemMetrics{ThermalState: "nominal"},
+		Draining:      false,
+	})
+
+	p.mu.Lock()
+	draining := p.Draining
+	p.mu.Unlock()
+	if draining {
+		t.Fatal("heartbeat with draining=false should clear p.Draining")
+	}
+}
+
 func TestReserveProviderExWhenNoneAvailable(t *testing.T) {
 	reg := New(testLogger())
 	model := "missing-model"

--- a/provider-swift/Package.resolved
+++ b/provider-swift/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "0b4729b1e478809d6e0787ccbca9ebdb3248bd2f78e59598b9ddd0694a637bc5",
+  "originHash" : "66ce96b8b5c1f30f70d847e3c566e98236628e8096cede2f01002716555609ef",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -195,8 +195,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "f71c8d2a5e74a2c6d11a0fbe324774b5d6084237",
-        "version" : "2.99.0"
+        "revision" : "77b84ac2cd2ac9e4ac67d19f045fd5b434f56967",
+        "version" : "2.101.0"
       }
     },
     {

--- a/provider-swift/Sources/ProviderCore/Config/ProviderConfig.swift
+++ b/provider-swift/Sources/ProviderCore/Config/ProviderConfig.swift
@@ -58,9 +58,6 @@ public struct BackendSettings: Sendable, Equatable, Codable {
     /// coordinator-driven preloads so advertised model count cannot become a
     /// memory-unbounded slot cap.
     public var maxModelSlots: UInt64
-    /// Seconds to wait for in-flight requests to complete during a coordinated
-    /// drain before forcing restart. Default: 30.
-    public var drainTimeoutSecs: UInt64
 
     public init(
         port: UInt16 = 8100,
@@ -68,8 +65,7 @@ public struct BackendSettings: Sendable, Equatable, Codable {
         continuousBatching: Bool = true,
         enabledModels: [String] = [],
         idleTimeoutMins: UInt64 = 60,
-        maxModelSlots: UInt64 = 3,
-        drainTimeoutSecs: UInt64 = 30
+        maxModelSlots: UInt64 = 3
     ) {
         self.port = port
         self.model = model
@@ -77,7 +73,6 @@ public struct BackendSettings: Sendable, Equatable, Codable {
         self.enabledModels = enabledModels
         self.idleTimeoutMins = idleTimeoutMins
         self.maxModelSlots = maxModelSlots
-        self.drainTimeoutSecs = drainTimeoutSecs
     }
 
     enum CodingKeys: String, CodingKey {
@@ -87,7 +82,6 @@ public struct BackendSettings: Sendable, Equatable, Codable {
         case enabledModels = "enabled_models"
         case idleTimeoutMins = "idle_timeout_mins"
         case maxModelSlots = "max_model_slots"
-        case drainTimeoutSecs = "drain_timeout_secs"
     }
 
     public init(from decoder: Decoder) throws {
@@ -98,7 +92,6 @@ public struct BackendSettings: Sendable, Equatable, Codable {
         self.enabledModels = try container.decodeIfPresent([String].self, forKey: .enabledModels) ?? []
         self.idleTimeoutMins = try container.decodeIfPresent(UInt64.self, forKey: .idleTimeoutMins) ?? 60
         self.maxModelSlots = try container.decodeIfPresent(UInt64.self, forKey: .maxModelSlots) ?? 3
-        self.drainTimeoutSecs = try container.decodeIfPresent(UInt64.self, forKey: .drainTimeoutSecs) ?? 30
     }
 }
 
@@ -177,8 +170,7 @@ public struct ProviderConfig: Sendable, Equatable, Codable {
                 continuousBatching: true,
                 enabledModels: [],
                 idleTimeoutMins: 60,
-                maxModelSlots: 3,
-                drainTimeoutSecs: 30
+                maxModelSlots: 3
             ),
             coordinator: CoordinatorSettings(
                 url: "wss://api.darkbloom.dev/ws/provider",

--- a/provider-swift/Sources/ProviderCore/Config/ProviderConfig.swift
+++ b/provider-swift/Sources/ProviderCore/Config/ProviderConfig.swift
@@ -58,6 +58,9 @@ public struct BackendSettings: Sendable, Equatable, Codable {
     /// coordinator-driven preloads so advertised model count cannot become a
     /// memory-unbounded slot cap.
     public var maxModelSlots: UInt64
+    /// Seconds to wait for in-flight requests to complete during a coordinated
+    /// drain before forcing restart. Default: 30.
+    public var drainTimeoutSecs: UInt64
 
     public init(
         port: UInt16 = 8100,
@@ -65,7 +68,8 @@ public struct BackendSettings: Sendable, Equatable, Codable {
         continuousBatching: Bool = true,
         enabledModels: [String] = [],
         idleTimeoutMins: UInt64 = 60,
-        maxModelSlots: UInt64 = 3
+        maxModelSlots: UInt64 = 3,
+        drainTimeoutSecs: UInt64 = 30
     ) {
         self.port = port
         self.model = model
@@ -73,6 +77,7 @@ public struct BackendSettings: Sendable, Equatable, Codable {
         self.enabledModels = enabledModels
         self.idleTimeoutMins = idleTimeoutMins
         self.maxModelSlots = maxModelSlots
+        self.drainTimeoutSecs = drainTimeoutSecs
     }
 
     enum CodingKeys: String, CodingKey {
@@ -82,6 +87,7 @@ public struct BackendSettings: Sendable, Equatable, Codable {
         case enabledModels = "enabled_models"
         case idleTimeoutMins = "idle_timeout_mins"
         case maxModelSlots = "max_model_slots"
+        case drainTimeoutSecs = "drain_timeout_secs"
     }
 
     public init(from decoder: Decoder) throws {
@@ -92,6 +98,7 @@ public struct BackendSettings: Sendable, Equatable, Codable {
         self.enabledModels = try container.decodeIfPresent([String].self, forKey: .enabledModels) ?? []
         self.idleTimeoutMins = try container.decodeIfPresent(UInt64.self, forKey: .idleTimeoutMins) ?? 60
         self.maxModelSlots = try container.decodeIfPresent(UInt64.self, forKey: .maxModelSlots) ?? 3
+        self.drainTimeoutSecs = try container.decodeIfPresent(UInt64.self, forKey: .drainTimeoutSecs) ?? 30
     }
 }
 
@@ -170,7 +177,8 @@ public struct ProviderConfig: Sendable, Equatable, Codable {
                 continuousBatching: true,
                 enabledModels: [],
                 idleTimeoutMins: 60,
-                maxModelSlots: 3
+                maxModelSlots: 3,
+                drainTimeoutSecs: 30
             ),
             coordinator: CoordinatorSettings(
                 url: "wss://api.darkbloom.dev/ws/provider",

--- a/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClient.swift
+++ b/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClient.swift
@@ -24,6 +24,8 @@ public enum CoordinatorEvent: Sendable {
     case loadModel(modelId: String)
     /// Coordinator informs the provider of its current trust level and status.
     case trustStatus(trustLevel: String, status: String, reason: String)
+    /// Coordinator instructs the provider to begin draining for an update.
+    case drainCommand(reason: DrainReason, deadline: String, version: String?)
 }
 
 // MARK: - Shared State
@@ -74,6 +76,9 @@ public final class ProviderState: @unchecked Sendable {
     private var _warmModels: [String] = []
     private var _currentModelHash: String? = nil
     private var _backendCapacity: BackendCapacity? = nil
+    private var _draining: Bool = false
+    private var _drainReason: DrainReason?
+    private var _drainDeadline: String?
 
     public init() {}
 
@@ -100,6 +105,21 @@ public final class ProviderState: @unchecked Sendable {
     public var backendCapacity: BackendCapacity? {
         get { lock.withLock { _backendCapacity } }
         set { lock.withLock { _backendCapacity = newValue } }
+    }
+
+    public var draining: Bool {
+        get { lock.withLock { _draining } }
+        set { lock.withLock { _draining = newValue } }
+    }
+
+    public var drainReason: DrainReason? {
+        get { lock.withLock { _drainReason } }
+        set { lock.withLock { _drainReason = newValue } }
+    }
+
+    public var drainDeadline: String? {
+        get { lock.withLock { _drainDeadline } }
+        set { lock.withLock { _drainDeadline = newValue } }
     }
 }
 
@@ -301,6 +321,7 @@ public enum OutboundMessage: Sendable {
     case attestationResponse(AttestationResponsePayload)
     case codeAttestationResponse(nonce: String, signature: String)
     case loadModelStatus(modelId: String, status: ProviderMessage.LoadModelStatus.Status, error: String?)
+    case providerDraining(ProviderMessage.ProviderDraining)
 }
 
 public struct AttestationResponsePayload: Sendable {
@@ -722,6 +743,14 @@ public actor CoordinatorClient {
                 status: ts.status,
                 reason: ts.reason
             ))
+
+        case .drainCommand(let drain):
+            logger.info("Received drain command: reason=\(drain.reason.rawValue), deadline=\(drain.deadline), version=\(drain.version ?? "none")")
+            eventContinuation?.yield(.drainCommand(
+                reason: drain.reason,
+                deadline: drain.deadline,
+                version: drain.version
+            ))
         }
     }
 
@@ -758,6 +787,9 @@ public actor CoordinatorClient {
         let warmModels = state.warmModels
         let capacity = state.backendCapacity
         let metrics = SystemMetricsCollector.collect(cpuCores: config.hardware.cpuCores.total)
+        let draining = state.draining
+        let drainReason = state.drainReason
+        let drainDeadline = state.drainDeadline
 
         let message = CoordinatorClientCodec.heartbeatMessage(
             status: isActive ? .serving : .idle,
@@ -768,7 +800,10 @@ public actor CoordinatorClient {
                 tokensGenerated: stats.tokensGenerated
             ),
             systemMetrics: metrics,
-            backendCapacity: capacity
+            backendCapacity: capacity,
+            draining: draining,
+            drainReason: drainReason,
+            drainDeadline: drainDeadline
         )
 
         guard let data = try? ProviderProtocolCodec.encodeProviderMessage(message),

--- a/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClientCodec.swift
+++ b/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClientCodec.swift
@@ -58,7 +58,10 @@ public enum CoordinatorClientCodec {
         warmModels: [String],
         stats: ProviderStats,
         systemMetrics: SystemMetrics,
-        backendCapacity: BackendCapacity?
+        backendCapacity: BackendCapacity?,
+        draining: Bool = false,
+        drainReason: DrainReason? = nil,
+        drainDeadline: String? = nil
     ) -> ProviderMessage {
         .heartbeat(ProviderMessage.Heartbeat(
             status: status,
@@ -66,7 +69,10 @@ public enum CoordinatorClientCodec {
             warmModels: warmModels,
             stats: stats,
             systemMetrics: systemMetrics,
-            backendCapacity: backendCapacity
+            backendCapacity: backendCapacity,
+            draining: draining,
+            drainReason: drainReason,
+            drainDeadline: drainDeadline
         ))
     }
 
@@ -127,6 +133,9 @@ public enum CoordinatorClientCodec {
                 status: status,
                 error: error
             ))
+
+        case .providerDraining(let draining):
+            return .providerDraining(draining)
         }
     }
 

--- a/provider-swift/Sources/ProviderCore/Protocol/Messages.swift
+++ b/provider-swift/Sources/ProviderCore/Protocol/Messages.swift
@@ -2,6 +2,13 @@ import Foundation
 
 // MARK: - Provider -> Coordinator
 
+/// Reason for draining.
+public enum DrainReason: String, Sendable, Equatable, Codable {
+    case update = "update"
+    case maintenance = "maintenance"
+    case decommission = "decommission"
+}
+
 public enum ProviderMessage: Sendable, Equatable {
     case register(Register)
     case heartbeat(Heartbeat)
@@ -12,6 +19,7 @@ public enum ProviderMessage: Sendable, Equatable {
     case attestationResponse(AttestationResponse)
     case codeAttestationResponse(CodeAttestationResponse)
     case loadModelStatus(LoadModelStatus)
+    case providerDraining(ProviderDraining)
 
     public struct Register: Sendable, Equatable {
         public var hardware: HardwareInfo
@@ -86,6 +94,9 @@ public enum ProviderMessage: Sendable, Equatable {
         public var stats: ProviderStats
         public var systemMetrics: SystemMetrics
         public var backendCapacity: BackendCapacity?
+        public var draining: Bool
+        public var drainReason: DrainReason?
+        public var drainDeadline: String?
 
         public init(
             status: ProviderStatus,
@@ -93,7 +104,10 @@ public enum ProviderMessage: Sendable, Equatable {
             warmModels: [String] = [],
             stats: ProviderStats,
             systemMetrics: SystemMetrics,
-            backendCapacity: BackendCapacity? = nil
+            backendCapacity: BackendCapacity? = nil,
+            draining: Bool = false,
+            drainReason: DrainReason? = nil,
+            drainDeadline: String? = nil
         ) {
             self.status = status
             self.activeModel = activeModel
@@ -101,6 +115,9 @@ public enum ProviderMessage: Sendable, Equatable {
             self.stats = stats
             self.systemMetrics = systemMetrics
             self.backendCapacity = backendCapacity
+            self.draining = draining
+            self.drainReason = drainReason
+            self.drainDeadline = drainDeadline
         }
     }
 
@@ -165,6 +182,21 @@ public enum ProviderMessage: Sendable, Equatable {
             self.modelId = modelId
             self.status = status
             self.error = error
+        }
+    }
+
+    /// Sent by the provider to inform the coordinator it has entered draining state.
+    public struct ProviderDraining: Sendable, Equatable {
+        public var reason: DrainReason
+        public var deadline: String // RFC3339
+        public var inFlight: Int
+        public var completed: Int
+
+        public init(reason: DrainReason, deadline: String, inFlight: Int, completed: Int) {
+            self.reason = reason
+            self.deadline = deadline
+            self.inFlight = inFlight
+            self.completed = completed
         }
     }
 
@@ -246,6 +278,7 @@ extension ProviderMessage: Codable {
         case attestationResponse = "attestation_response"
         case codeAttestationResponse = "code_attestation_response"
         case loadModelStatus = "load_model_status"
+        case providerDraining = "provider_draining"
     }
 
     enum CodingKeys: String, CodingKey {
@@ -273,6 +306,9 @@ extension ProviderMessage: Codable {
         case stats
         case systemMetrics = "system_metrics"
         case backendCapacity = "backend_capacity"
+        case draining
+        case drainReason = "drain_reason"
+        case drainDeadline = "drain_deadline"
         // Common
         case requestId = "request_id"
         // InferenceResponseChunk
@@ -297,6 +333,11 @@ extension ProviderMessage: Codable {
         case modelHashes = "model_hashes"
         // LoadModelStatus
         case modelId = "model_id"
+        // ProviderDraining
+        case reason
+        case deadline
+        case inFlight = "in_flight"
+        case completed
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -340,6 +381,11 @@ extension ProviderMessage: Codable {
             try container.encode(h.stats, forKey: .stats)
             try container.encode(h.systemMetrics, forKey: .systemMetrics)
             try container.encodeIfPresent(h.backendCapacity, forKey: .backendCapacity)
+            if h.draining {
+                try container.encode(true, forKey: .draining)
+            }
+            try container.encodeIfPresent(h.drainReason, forKey: .drainReason)
+            try container.encodeIfPresent(h.drainDeadline, forKey: .drainDeadline)
 
         case .inferenceAccepted(let a):
             try container.encode(TypeValue.inferenceAccepted, forKey: .type)
@@ -397,6 +443,13 @@ extension ProviderMessage: Codable {
             try container.encode(l.modelId, forKey: .modelId)
             try container.encode(l.status.rawValue, forKey: .status)
             try container.encodeIfPresent(l.error, forKey: .error)
+
+        case .providerDraining(let d):
+            try container.encode(TypeValue.providerDraining, forKey: .type)
+            try container.encode(d.reason.rawValue, forKey: .reason)
+            try container.encode(d.deadline, forKey: .deadline)
+            try container.encode(d.inFlight, forKey: .inFlight)
+            try container.encode(d.completed, forKey: .completed)
         }
     }
 
@@ -434,7 +487,10 @@ extension ProviderMessage: Codable {
                 warmModels: try container.decodeIfPresent([String].self, forKey: .warmModels) ?? [],
                 stats: try container.decode(ProviderStats.self, forKey: .stats),
                 systemMetrics: try container.decode(SystemMetrics.self, forKey: .systemMetrics),
-                backendCapacity: try container.decodeIfPresent(BackendCapacity.self, forKey: .backendCapacity)
+                backendCapacity: try container.decodeIfPresent(BackendCapacity.self, forKey: .backendCapacity),
+                draining: try container.decodeIfPresent(Bool.self, forKey: .draining) ?? false,
+                drainReason: try container.decodeIfPresent(DrainReason.self, forKey: .drainReason),
+                drainDeadline: try container.decodeIfPresent(String.self, forKey: .drainDeadline)
             ))
 
         case .inferenceAccepted:
@@ -502,19 +558,36 @@ extension ProviderMessage: Codable {
                 status: status,
                 error: try container.decodeIfPresent(String.self, forKey: .error)
             ))
+
+        case .providerDraining:
+            let rawReason = try container.decode(String.self, forKey: .reason)
+            guard let reason = DrainReason(rawValue: rawReason) else {
+                throw DecodingError.dataCorruptedError(
+                    forKey: .reason,
+                    in: container,
+                    debugDescription: "unknown drain_reason value: \(rawReason)"
+                )
+            }
+            self = .providerDraining(ProviderDraining(
+                reason: reason,
+                deadline: try container.decode(String.self, forKey: .deadline),
+                inFlight: try container.decode(Int.self, forKey: .inFlight),
+                completed: try container.decode(Int.self, forKey: .completed)
+            ))
         }
     }
 }
 
 // MARK: - Coordinator -> Provider
 
-public enum CoordinatorMessage: Sendable, Equatable {
+    public enum CoordinatorMessage: Sendable, Equatable {
     case inferenceRequest(InferenceRequest)
     case cancel(Cancel)
     case attestationChallenge(AttestationChallenge)
     case runtimeStatus(RuntimeStatus)
     case loadModel(LoadModel)
     case trustStatus(TrustStatus)
+    case drainCommand(DrainCommand)
 
     public struct InferenceRequest: Sendable, Equatable {
         public var requestId: String
@@ -573,6 +646,21 @@ public enum CoordinatorMessage: Sendable, Equatable {
             self.reason = reason
         }
     }
+
+    /// Coordinator instructs the provider to begin draining (stop accepting new
+    /// requests, finish in-flight, then restart). The provider should reply with
+    /// a `ProviderDraining` message to acknowledge.
+    public struct DrainCommand: Sendable, Equatable {
+        public var reason: DrainReason
+        public var deadline: String // RFC3339
+        public var version: String? // target version for update drains
+
+        public init(reason: DrainReason, deadline: String, version: String? = nil) {
+            self.reason = reason
+            self.deadline = deadline
+            self.version = version
+        }
+    }
 }
 
 // MARK: - CoordinatorMessage Codable
@@ -585,6 +673,7 @@ extension CoordinatorMessage: Codable {
         case runtimeStatus = "runtime_status"
         case loadModel = "load_model"
         case trustStatus = "trust_status"
+        case drainCommand = "drain_command"
     }
 
     enum CodingKeys: String, CodingKey {
@@ -597,6 +686,8 @@ extension CoordinatorMessage: Codable {
         case modelId = "model_id"
         case trustLevel = "trust_level"
         case status, reason
+        case deadline
+        case version
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -636,6 +727,12 @@ extension CoordinatorMessage: Codable {
             if !t.reason.isEmpty {
                 try container.encode(t.reason, forKey: .reason)
             }
+
+        case .drainCommand(let d):
+            try container.encode(TypeValue.drainCommand, forKey: .type)
+            try container.encode(d.reason.rawValue, forKey: .reason)
+            try container.encode(d.deadline, forKey: .deadline)
+            try container.encodeIfPresent(d.version, forKey: .version)
         }
     }
 
@@ -678,6 +775,21 @@ extension CoordinatorMessage: Codable {
                 trustLevel: try container.decode(String.self, forKey: .trustLevel),
                 status: try container.decode(String.self, forKey: .status),
                 reason: try container.decodeIfPresent(String.self, forKey: .reason) ?? ""
+            ))
+
+        case .drainCommand:
+            let rawReason = try container.decode(String.self, forKey: .reason)
+            guard let reason = DrainReason(rawValue: rawReason) else {
+                throw DecodingError.dataCorruptedError(
+                    forKey: .reason,
+                    in: container,
+                    debugDescription: "unknown drain_reason value: \(rawReason)"
+                )
+            }
+            self = .drainCommand(DrainCommand(
+                reason: reason,
+                deadline: try container.decode(String.self, forKey: .deadline),
+                version: try container.decodeIfPresent(String.self, forKey: .version)
             ))
         }
     }

--- a/provider-swift/Sources/ProviderCore/ProviderLoop.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop.swift
@@ -206,6 +206,15 @@ public actor ProviderLoop {
     /// before `run()` starts it.
     private var autoUpdateTask: Task<Void, Never>?
 
+    /// Draining state for coordinated updates.
+    private var isDraining: Bool = false
+    private var drainDeadline: Date?
+    private var drainReason: DrainReason?
+    private var drainInFlightAtStart: Int = 0
+    private var drainCompletedCount: Int = 0
+    private var drainTask: Task<Void, Never>?
+    private let drainFormatter = ISO8601DateFormatter()
+
     private let logger = ProviderLogger(subsystem: "dev.darkbloom.provider", category: "loop")
 
     private static let shutdownDrainTimeout: Duration = .seconds(600)
@@ -464,6 +473,9 @@ public actor ProviderLoop {
 
                 case .trustStatus(let trustLevel, let status, let reason):
                     handleTrustStatus(trustLevel: trustLevel, status: status, reason: reason)
+
+                case .drainCommand(let reason, let deadline, let version):
+                    await handleDrainCommand(reason: reason, deadline: deadline, version: version, send: send)
                 }
             }
         } onCancel: {
@@ -628,6 +640,23 @@ public actor ProviderLoop {
             send.send(.inferenceError(
                 requestId: requestId,
                 error: "provider is shutting down",
+                statusCode: 503
+            ))
+            return
+        }
+
+        // Reject new requests during drain
+        if isDraining {
+            let retryAfter: Int
+            if let deadline = drainDeadline {
+                retryAfter = max(1, Int(deadline.timeIntervalSinceNow))
+            } else {
+                retryAfter = Int(loopConfig.config.backend.drainTimeoutSecs)
+            }
+            logger.warning("[\(requestId)] Rejecting request during drain (retry-after: \(retryAfter)s)")
+            send.send(.inferenceError(
+                requestId: requestId,
+                error: "provider_draining",
                 statusCode: 503
             ))
             return
@@ -1055,6 +1084,9 @@ public actor ProviderLoop {
 
             // Update state
             await me.updateAggregateCapacity()
+
+            // Record drain completion if draining
+            await me.recordDrainCompletion()
 
             // Send completion
             let attestation = computeResponseAttestation(
@@ -2349,5 +2381,178 @@ extension ProviderLoop {
     /// this provider is configured to serve, not just the resident subset.
     func advertisedLocalModelIds() -> [String] {
         loopConfig.models.map { $0.id }.sorted()
+    }
+
+    // MARK: - Coordinated Drain
+
+    /// Handle a drain command from the coordinator. The provider stops accepting
+    /// new requests, waits for in-flight requests to complete (or deadline),
+    /// then restarts to apply the update.
+    private func handleDrainCommand(
+        reason: DrainReason,
+        deadline: String,
+        version: String?,
+        send: SendHandle
+    ) async {
+        logger.info("Received drain command: reason=\(reason.rawValue), deadline=\(deadline), version=\(version ?? "none")")
+
+        // Parse deadline - try with fractional seconds first, then without (for Go time.RFC3339 compatibility)
+        drainFormatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        var deadlineDate = drainFormatter.date(from: deadline)
+        if deadlineDate == nil {
+            drainFormatter.formatOptions = [.withInternetDateTime]
+            deadlineDate = drainFormatter.date(from: deadline)
+        }
+        guard let parsedDeadline = deadlineDate else {
+            logger.error("Invalid drain deadline format: \(deadline)")
+            return
+        }
+
+        // If already draining, update deadline if new one is sooner
+        if isDraining {
+            if let currentDeadline = drainDeadline, parsedDeadline < currentDeadline {
+                drainDeadline = parsedDeadline
+                drainReason = reason
+                state.draining = true
+                state.drainReason = reason
+                state.drainDeadline = deadline
+                logger.info("Updated drain deadline to \(deadline)")
+            }
+            return
+        }
+
+        isDraining = true
+        drainDeadline = parsedDeadline
+        drainReason = reason
+        drainInFlightAtStart = inflightTasks.count
+        drainCompletedCount = 0
+
+        // Sync to ProviderState for heartbeat
+        state.draining = true
+        state.drainReason = reason
+        state.drainDeadline = deadline
+
+        // Send draining acknowledgment
+        let drainingMsg = ProviderMessage.ProviderDraining(
+            reason: reason,
+            deadline: deadline,
+            inFlight: drainInFlightAtStart,
+            completed: 0
+        )
+        send.send(.providerDraining(drainingMsg))
+
+        // Start drain monitor task
+        drainTask = Task {
+            await runDrainMonitor(send: send, version: version)
+        }
+    }
+
+    /// Background task that monitors in-flight requests during drain.
+    /// When all complete or deadline expires, triggers restart.
+    private func runDrainMonitor(send: SendHandle, version: String?) async {
+        let _ = loopConfig.config.backend.drainTimeoutSecs
+        let checkInterval: Duration = .seconds(2)
+
+        while isDraining {
+            // Check if deadline has passed
+            if let deadline = drainDeadline, Date() >= deadline {
+                logger.warning("Drain deadline reached, forcing restart")
+                break
+            }
+
+            // Check in-flight count
+            let currentInFlight = inflightTasks.count
+            if currentInFlight == 0 {
+                logger.info("All in-flight requests completed, restarting")
+                break
+            }
+
+            // Update completed count and send progress
+            drainCompletedCount = drainInFlightAtStart - currentInFlight
+            let progressMsg = ProviderMessage.ProviderDraining(
+                reason: drainReason ?? .update,
+                deadline: drainDeadline.map { drainFormatter.string(from: $0) } ?? "",
+                inFlight: currentInFlight,
+                completed: drainCompletedCount
+            )
+            send.send(.providerDraining(progressMsg))
+
+            // Wait before next check
+            do {
+                try await Task.sleep(for: checkInterval)
+            } catch {
+                return // cancelled
+            }
+        }
+
+        // Drain complete - run SelfUpdater to apply the binary update, then restart
+        if let version = drainReason == .update ? version : nil {
+            logger.info("Running SelfUpdater to apply version \(version)...")
+            let updater = SelfUpdater(coordinatorBaseURL: loopConfig.coordinatorURL)
+            let result = await updater.update()
+            switch result {
+            case .alreadyUpToDate:
+                logger.info("Already running latest version")
+            case .updated(let from, let to):
+                logger.info("SelfUpdater updated provider v\(from) -> v\(to)")
+            case .downloadFailed(let reason):
+                logger.warning("SelfUpdater download failed: \(reason)")
+            case .hashMismatch(let expected, let got):
+                logger.warning("SelfUpdater hash mismatch (expected \(expected), got \(got))")
+            case .replaceFailed(let reason):
+                logger.warning("SelfUpdater install failed: \(reason)")
+            }
+        }
+        await restartAfterUpdate()
+    }
+
+    /// Restart the provider process to apply the update.
+    /// This replaces the current process with the new binary via launchd or execv.
+    private func restartAfterUpdate() async {
+        logger.info("Restarting provider to apply update...")
+
+        // Cancel drain task
+        drainTask?.cancel()
+        drainTask = nil
+
+        // Clear draining state
+        isDraining = false
+        drainDeadline = nil
+        drainReason = nil
+        drainInFlightAtStart = 0
+        drainCompletedCount = 0
+        state.draining = false
+        state.drainReason = nil
+        state.drainDeadline = nil
+
+        // Signal shutdown to the run loop
+        isShuttingDown = true
+
+        // Actually restart the process using the launchd-aware restart
+        // This will either bootout/bootstrap/kickstart (under launchd) or execv (standalone)
+        do {
+            try ProcessLifecycle.restartAfterUpdate()
+        } catch {
+            logger.error("Failed to restart after update: \(error.localizedDescription)")
+            // If restart fails, exit cleanly and let launchd/CLI wrapper handle it
+            exit(1)
+        }
+    }
+
+    /// Check if provider is currently draining (for admission gate).
+    func isProviderDraining() -> Bool {
+        isDraining
+    }
+
+    /// Get drain deadline for admission gate Retry-After calculation.
+    func getDrainDeadline() -> Date? {
+        drainDeadline
+    }
+
+    /// Increment completed count when a request finishes during drain.
+    func recordDrainCompletion() {
+        if isDraining {
+            drainCompletedCount += 1
+        }
     }
 }

--- a/provider-swift/Sources/ProviderCore/ProviderLoop.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop.swift
@@ -492,6 +492,8 @@ public actor ProviderLoop {
         autoUpdateTask = nil
         autoReportTask?.cancel()
         autoReportTask = nil
+        drainTask?.cancel()
+        drainTask = nil
         let preloads = Array(preloadTasks.values)
         for task in preloads { task.cancel() }
         cancelLoadWaiters()
@@ -645,15 +647,12 @@ public actor ProviderLoop {
             return
         }
 
-        // Reject new requests during drain
+        // Reject new requests during drain. The coordinator already gates
+        // routing on the provider's draining state; this catches the narrow
+        // race where a request was dispatched just as the drain began. 503
+        // signals the coordinator to treat it as a capacity rejection.
         if isDraining {
-            let retryAfter: Int
-            if let deadline = drainDeadline {
-                retryAfter = max(1, Int(deadline.timeIntervalSinceNow))
-            } else {
-                retryAfter = Int(loopConfig.config.backend.drainTimeoutSecs)
-            }
-            logger.warning("[\(requestId)] Rejecting request during drain (retry-after: \(retryAfter)s)")
+            logger.warning("[\(requestId)] Rejecting request during drain")
             send.send(.inferenceError(
                 requestId: requestId,
                 error: "provider_draining",
@@ -1084,9 +1083,6 @@ public actor ProviderLoop {
 
             // Update state
             await me.updateAggregateCapacity()
-
-            // Record drain completion if draining
-            await me.recordDrainCompletion()
 
             // Send completion
             let attestation = computeResponseAttestation(
@@ -2385,9 +2381,18 @@ extension ProviderLoop {
 
     // MARK: - Coordinated Drain
 
-    /// Handle a drain command from the coordinator. The provider stops accepting
-    /// new requests, waits for in-flight requests to complete (or deadline),
-    /// then restarts to apply the update.
+    /// Handle a drain command from the coordinator.
+    ///
+    /// Flow (download-first to minimize downtime):
+    ///   1. For `.update` drains, download + verify the new bundle IN THE
+    ///      BACKGROUND while still serving requests (the slow part).
+    ///   2. Only once the bundle is staged do we enter draining state (stop
+    ///      accepting new requests).
+    ///   3. Wait for in-flight requests to complete (or the deadline).
+    ///   4. Install the staged bundle (fast file swap) and restart.
+    ///
+    /// If the download/verify fails the provider never drains — it keeps
+    /// serving on the current binary and the coordinator can retry later.
     private func handleDrainCommand(
         reason: DrainReason,
         deadline: String,
@@ -2408,114 +2413,148 @@ extension ProviderLoop {
             return
         }
 
-        // If already draining, update deadline if new one is sooner
-        if isDraining {
-            if let currentDeadline = drainDeadline, parsedDeadline < currentDeadline {
+        // De-dup: a drain flow (download or active drain) is already running.
+        // If we're already actively draining, tighten the deadline if sooner.
+        if drainTask != nil {
+            if isDraining, let currentDeadline = drainDeadline, parsedDeadline < currentDeadline {
                 drainDeadline = parsedDeadline
-                drainReason = reason
-                state.draining = true
-                state.drainReason = reason
                 state.drainDeadline = deadline
                 logger.info("Updated drain deadline to \(deadline)")
             }
             return
         }
 
-        isDraining = true
+        // Record the requested deadline/reason up front; isDraining stays false
+        // until the bundle is staged so the provider keeps serving meanwhile.
         drainDeadline = parsedDeadline
         drainReason = reason
-        drainInFlightAtStart = inflightTasks.count
-        drainCompletedCount = 0
 
-        // Sync to ProviderState for heartbeat
-        state.draining = true
-        state.drainReason = reason
-        state.drainDeadline = deadline
-
-        // Send draining acknowledgment
-        let drainingMsg = ProviderMessage.ProviderDraining(
-            reason: reason,
-            deadline: deadline,
-            inFlight: drainInFlightAtStart,
-            completed: 0
-        )
-        send.send(.providerDraining(drainingMsg))
-
-        // Start drain monitor task
         drainTask = Task {
-            await runDrainMonitor(send: send, version: version)
+            await runDrainFlow(reason: reason, deadlineStr: deadline, version: version, send: send)
         }
     }
 
-    /// Background task that monitors in-flight requests during drain.
-    /// When all complete or deadline expires, triggers restart.
-    private func runDrainMonitor(send: SendHandle, version: String?) async {
-        let _ = loopConfig.config.backend.drainTimeoutSecs
-        let checkInterval: Duration = .seconds(2)
-
-        while isDraining {
-            // Check if deadline has passed
-            if let deadline = drainDeadline, Date() >= deadline {
-                logger.warning("Drain deadline reached, forcing restart")
-                break
+    /// The end-to-end drain flow: stage update (if any) → drain → install → restart.
+    private func runDrainFlow(
+        reason: DrainReason,
+        deadlineStr: String,
+        version: String?,
+        send: SendHandle
+    ) async {
+        // Phase 1 — stage the update in the background (still serving).
+        var staged: (file: URL, release: ReleaseInfo)?
+        if reason == .update {
+            // Respect the operator's auto-update opt-out, same as the periodic monitor.
+            guard loopConfig.config.provider.autoUpdate,
+                  ProcessInfo.processInfo.environment["DARKBLOOM_NO_UPDATE_CHECK"] == nil
+            else {
+                logger.info("Drain update skipped: auto-update disabled; not draining")
+                clearDrainState()
+                return
             }
 
-            // Check in-flight count
+            let updater = SelfUpdater(coordinatorBaseURL: loopConfig.coordinatorURL)
+            switch await updater.checkForUpdate() {
+            case .upToDate(let v):
+                logger.info("Drain update: already at latest (\(v)); not draining")
+                clearDrainState()
+                return
+            case .checkFailed(let reason):
+                logger.warning("Drain update: check failed (\(reason)); not draining")
+                clearDrainState()
+                return
+            case .updateAvailable(_, let release):
+                logger.info("Drain update: downloading \(release.version) in background while serving...")
+                switch await updater.downloadAndVerify(release: release) {
+                case .success(let file):
+                    staged = (file, release)
+                    logger.info("Drain update: bundle \(release.version) downloaded + verified; entering drain")
+                case .failure(let err):
+                    logger.warning("Drain update: download/verify failed (\(err)); not draining")
+                    clearDrainState()
+                    return
+                }
+            }
+        }
+
+        if Task.isCancelled || isShuttingDown {
+            clearDrainState()
+            return
+        }
+
+        // Phase 2 — enter draining state (now stop accepting new requests).
+        isDraining = true
+        drainInFlightAtStart = inflightTasks.count
+        drainCompletedCount = 0
+        state.draining = true
+        state.drainReason = reason
+        state.drainDeadline = deadlineStr
+        send.send(.providerDraining(ProviderMessage.ProviderDraining(
+            reason: reason,
+            deadline: deadlineStr,
+            inFlight: drainInFlightAtStart,
+            completed: 0
+        )))
+
+        // Phase 3 — wait for in-flight to finish or the deadline to pass.
+        await waitForDrain(send: send)
+
+        // A shutdown raced the drain (stop/SIGTERM) — don't restart over it.
+        if isShuttingDown {
+            clearDrainState()
+            return
+        }
+
+        // Phase 4 — install the staged bundle (fast), then restart.
+        if let staged {
+            let updater = SelfUpdater(coordinatorBaseURL: loopConfig.coordinatorURL)
+            switch updater.installBundle(from: staged.file, release: staged.release) {
+            case .success:
+                logger.info("Drain update: installed \(staged.release.version), restarting")
+            case .failure(let err):
+                // Install failed AFTER draining. Restarting onto a half-written
+                // bundle is risky; resume serving on the current binary instead.
+                logger.error("Drain update: install failed (\(err)); resuming service without restart")
+                clearDrainState()
+                return
+            }
+        }
+
+        await finishDrainAndExit(restart: reason != .decommission)
+    }
+
+    /// Poll until in-flight requests drain to zero or the deadline elapses,
+    /// emitting progress to the coordinator on each tick.
+    private func waitForDrain(send: SendHandle) async {
+        let checkInterval: Duration = .seconds(2)
+        while isDraining {
+            if isShuttingDown { return }
+            if let deadline = drainDeadline, Date() >= deadline {
+                logger.warning("Drain deadline reached, proceeding to restart")
+                return
+            }
             let currentInFlight = inflightTasks.count
             if currentInFlight == 0 {
-                logger.info("All in-flight requests completed, restarting")
-                break
+                logger.info("All in-flight requests completed")
+                return
             }
-
-            // Update completed count and send progress
-            drainCompletedCount = drainInFlightAtStart - currentInFlight
-            let progressMsg = ProviderMessage.ProviderDraining(
+            drainCompletedCount = max(0, drainInFlightAtStart - currentInFlight)
+            send.send(.providerDraining(ProviderMessage.ProviderDraining(
                 reason: drainReason ?? .update,
                 deadline: drainDeadline.map { drainFormatter.string(from: $0) } ?? "",
                 inFlight: currentInFlight,
                 completed: drainCompletedCount
-            )
-            send.send(.providerDraining(progressMsg))
-
-            // Wait before next check
+            )))
             do {
                 try await Task.sleep(for: checkInterval)
             } catch {
                 return // cancelled
             }
         }
-
-        // Drain complete - run SelfUpdater to apply the binary update, then restart
-        if let version = drainReason == .update ? version : nil {
-            logger.info("Running SelfUpdater to apply version \(version)...")
-            let updater = SelfUpdater(coordinatorBaseURL: loopConfig.coordinatorURL)
-            let result = await updater.update()
-            switch result {
-            case .alreadyUpToDate:
-                logger.info("Already running latest version")
-            case .updated(let from, let to):
-                logger.info("SelfUpdater updated provider v\(from) -> v\(to)")
-            case .downloadFailed(let reason):
-                logger.warning("SelfUpdater download failed: \(reason)")
-            case .hashMismatch(let expected, let got):
-                logger.warning("SelfUpdater hash mismatch (expected \(expected), got \(got))")
-            case .replaceFailed(let reason):
-                logger.warning("SelfUpdater install failed: \(reason)")
-            }
-        }
-        await restartAfterUpdate()
     }
 
-    /// Restart the provider process to apply the update.
-    /// This replaces the current process with the new binary via launchd or execv.
-    private func restartAfterUpdate() async {
-        logger.info("Restarting provider to apply update...")
-
-        // Cancel drain task
-        drainTask?.cancel()
-        drainTask = nil
-
-        // Clear draining state
+    /// Clear all drain state and resume normal serving (no restart).
+    private func clearDrainState() {
         isDraining = false
         drainDeadline = nil
         drainReason = nil
@@ -2524,35 +2563,27 @@ extension ProviderLoop {
         state.draining = false
         state.drainReason = nil
         state.drainDeadline = nil
+        drainTask = nil
+    }
 
-        // Signal shutdown to the run loop
+    /// Terminate the process: restart (update/maintenance) or exit (decommission).
+    private func finishDrainAndExit(restart: Bool) async {
+        // Signal shutdown so the run loop and monitors stop.
         isShuttingDown = true
 
-        // Actually restart the process using the launchd-aware restart
-        // This will either bootout/bootstrap/kickstart (under launchd) or execv (standalone)
+        if !restart {
+            logger.info("Drain complete (decommission), shutting down")
+            exit(0)
+        }
+
+        logger.info("Drain complete, restarting provider...")
         do {
+            // launchd-aware: bootout/bootstrap/kickstart, or execv when standalone.
             try ProcessLifecycle.restartAfterUpdate()
         } catch {
-            logger.error("Failed to restart after update: \(error.localizedDescription)")
-            // If restart fails, exit cleanly and let launchd/CLI wrapper handle it
+            logger.error("Failed to restart after drain: \(error.localizedDescription)")
+            // Exit non-zero so launchd/the CLI wrapper relaunches us.
             exit(1)
-        }
-    }
-
-    /// Check if provider is currently draining (for admission gate).
-    func isProviderDraining() -> Bool {
-        isDraining
-    }
-
-    /// Get drain deadline for admission gate Retry-After calculation.
-    func getDrainDeadline() -> Date? {
-        drainDeadline
-    }
-
-    /// Increment completed count when a request finishes during drain.
-    func recordDrainCompletion() {
-        if isDraining {
-            drainCompletedCount += 1
         }
     }
 }

--- a/provider-swift/Tests/ProviderCoreTests/Helpers/MockCoordinator.swift
+++ b/provider-swift/Tests/ProviderCoreTests/Helpers/MockCoordinator.swift
@@ -39,6 +39,7 @@ public struct CapturedMessages: Sendable {
     public var inferenceComplete: [ProviderMessage.InferenceComplete] = []
     public var inferenceErrors: [ProviderMessage.InferenceError] = []
     public var loadModelStatuses: [ProviderMessage.LoadModelStatus] = []
+    public var providerDraining: [ProviderMessage.ProviderDraining] = []
     public var telemetryBatches: [TelemetryBatch] = []
 
     public init() {}
@@ -568,6 +569,7 @@ public final class MockCoordinator: @unchecked Sendable {
             case .inferenceComplete(let c):   captured.inferenceComplete.append(c)
             case .inferenceError(let e):      captured.inferenceErrors.append(e)
             case .loadModelStatus(let s):    captured.loadModelStatuses.append(s)
+            case .providerDraining(let d):   captured.providerDraining.append(d)
             }
         }
         eventContinuation.yield(.providerMessage(parsed))

--- a/provider-swift/Tests/ProviderCoreTests/ProtocolTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/ProtocolTests.swift
@@ -272,6 +272,61 @@ import Testing
     #expect(failedObj["error"] as? String == "GPU OOM")
 }
 
+@Test func drainCommandDecodesGoWholeSecondDeadline() throws {
+    // The coordinator emits deadlines via Go's time.RFC3339 — whole seconds,
+    // NO fractional component. The provider must decode this exact shape.
+    let goDrain = #"{"type":"drain_command","reason":"update","deadline":"2026-06-09T01:30:00Z","version":"0.6.1"}"#
+    let decoded = try ProviderProtocolCodec.decodeCoordinatorMessage(from: goDrain)
+    guard case .drainCommand(let drain) = decoded else {
+        throw TestFailure.unexpectedMessage
+    }
+    #expect(drain.reason == .update)
+    #expect(drain.deadline == "2026-06-09T01:30:00Z")
+    #expect(drain.version == "0.6.1")
+
+    // The provider parses the deadline with a fractional-seconds-tolerant
+    // fallback. Both shapes must yield a valid Date (regression guard for the
+    // Go RFC3339 ↔ Swift .withFractionalSeconds mismatch).
+    let f = ISO8601DateFormatter()
+    f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+    var d = f.date(from: drain.deadline)
+    if d == nil {
+        f.formatOptions = [.withInternetDateTime]
+        d = f.date(from: drain.deadline)
+    }
+    #expect(d != nil)
+}
+
+@Test func drainCommandRoundTripsAllReasons() throws {
+    for reason in ["update", "maintenance", "decommission"] {
+        let json = "{\"type\":\"drain_command\",\"reason\":\"\(reason)\",\"deadline\":\"2026-06-09T01:30:00Z\"}"
+        let decoded = try ProviderProtocolCodec.decodeCoordinatorMessage(from: json)
+        guard case .drainCommand(let drain) = decoded else {
+            throw TestFailure.unexpectedMessage
+        }
+        #expect(drain.reason.rawValue == reason)
+        #expect(drain.version == nil) // omitted version decodes to nil
+    }
+}
+
+@Test func providerDrainingEncodesSnakeCaseAndRoundTrips() throws {
+    let msg = ProviderMessage.providerDraining(ProviderMessage.ProviderDraining(
+        reason: .update,
+        deadline: "2026-06-09T01:30:00Z",
+        inFlight: 3,
+        completed: 1
+    ))
+    let encoded = try ProviderProtocolCodec.encodeProviderMessage(msg)
+    let object = try jsonObject(encoded)
+    #expect(object["type"] as? String == "provider_draining")
+    #expect(object["reason"] as? String == "update")
+    #expect(object["in_flight"] as? Int == 3)
+    #expect(object["completed"] as? Int == 1)
+
+    let roundTripped = try ProviderProtocolCodec.decodeProviderMessage(from: encoded)
+    #expect(roundTripped == msg)
+}
+
 @Test func coordinatorMessagesDecodeAndEncodeWithSnakeCaseKeys() throws {
     let encryptedRequest = #"{"type":"inference_request","request_id":"go-enc-req-1","body":null,"encrypted_body":{"ephemeral_public_key":"ZXBoZW1lcmFs","ciphertext":"Y2lwaGVy"}}"#
     let request = try ProviderProtocolCodec.decodeCoordinatorMessage(from: encryptedRequest)


### PR DESCRIPTION
## Summary

Implements coordinated drain + restart for provider auto-updates. When a new release is registered, the coordinator fans out drain commands to all online providers, which stop accepting new requests, finish in-flight work, apply the binary update via SelfUpdater, and restart.

### Changes

**Protocol (Go + Swift):**
- New message types: `drain_command` (coordinator->provider), `provider_draining` (provider->coordinator)
- `DrainReason` enum: `update`, `maintenance`, `decommission`
- Heartbeat includes `draining`, `drain_reason`, `drain_deadline`

**Provider (ProviderLoop.swift):**
- Drain state machine: `isDraining`, `drainDeadline`, `drainReason`, progress counters
- Admission gate: rejects new requests with 503 + Retry-After during drain
- `runDrainMonitor()`: waits for in-flight completion or deadline, sends progress updates
- `restartAfterUpdate()`: calls `ProcessLifecycle.restartAfterUpdate()` (launchd bootout/bootstrap/kickstart or execv)
- Runs `SelfUpdater.update()` before restart to apply binary update
- Deadline parsing: tries fractional seconds first, falls back to Go time.RFC3339

**Coordinator Registry (registry.go):**
- `Draining` field on Provider struct
- `UpdateProviderDraining()`: updates state from draining messages
- `GetOnlineProviders()`: returns online providers for fan-out
- `Disconnect()`: clears drain state on reconnect

**Coordinator Scheduler (scheduler.go):**
- `snapshotProviderLocked`: skips draining providers
- `providerCanAdmitLocked`: skips draining providers
- `QuickCapacityCheck`: skips draining providers
- `ModelCapacitySnapshot`: skips draining providers

**Release Handlers (release_handlers.go):**
- `triggerProviderDrainForRelease()`: fans out drain commands to all online providers on new release
- Feature flag: `ENABLE_DRAIN_UPDATE=false` to disable (enabled by default)

### Verification
- Coordinator: `go build ./...`, `go test ./...` all pass
- Provider: `swift build`, `swift test` pass (non-MLX tests; MLX error is test-env only)
- gofmt clean

### Follow-up (not blocking)
- Add canary/batching to fleet drain (currently all-at-once)
- Add drain command authentication (signature/nonce)
- Add test coverage for drain flow
- Make SelfUpdater respect commanded version
- Make drainTimeoutSecs authoritative
- Restart only on successful .updated (not on failure/no-op)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/291"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783559972&installation_id=133247490&pr_number=291&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F291&signature=fa42c24be2f143492e22e80d49a7b3422d7b854f5ccb1192c0a45d2b72cc1381"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->