### PR TITLE
feat(provider): serve image + video (VLM) inference via Gemma 4

### DIFF
--- a/provider-swift/Package.swift
+++ b/provider-swift/Package.swift
@@ -73,6 +73,7 @@ let package = Package(
                 .product(name: "MLX", package: "mlx-swift"),
                 .product(name: "MLXNN", package: "mlx-swift"),
                 .product(name: "MLXLLM", package: "mlx-swift-lm"),
+                .product(name: "MLXVLM", package: "mlx-swift-lm"),
                 .product(name: "MLXLMCommon", package: "mlx-swift-lm"),
                 .product(name: "MLXLMServer", package: "mlx-swift-lm"),
                 .product(name: "Transformers", package: "swift-transformers"),
@@ -114,6 +115,23 @@ let package = Package(
             name: "kv-se-harness",
             dependencies: ["ProviderCore"],
             path: "Sources/kv-se-harness"
+        ),
+
+        // ----------------------------------------------------------------
+        // vlm-smoke: THROWAWAY harness to test Gemma 4 multimodal (VLM)
+        // inference via the mlx-swift-lm fork's MLXVLM library. NOT a
+        // product. Mirrors the provider's real load path (LocalTokenizerLoader)
+        // but swaps LLMModelFactory -> VLMModelFactory. Safe to delete.
+        // ----------------------------------------------------------------
+        .executableTarget(
+            name: "vlm-smoke",
+            dependencies: [
+                "ProviderCore",
+                .product(name: "MLX", package: "mlx-swift"),
+                .product(name: "MLXLMCommon", package: "mlx-swift-lm"),
+                .product(name: "MLXVLM", package: "mlx-swift-lm"),
+            ],
+            path: "Sources/vlm-smoke"
         ),
 
         // ----------------------------------------------------------------

--- a/provider-swift/Sources/ProviderCore/Inference/MultiModelBatchSchedulerEngine+Registry.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/MultiModelBatchSchedulerEngine+Registry.swift
@@ -9,6 +9,7 @@
 // references.
 
 import Foundation
+import MLXLMCommon
 
 public extension MultiModelBatchSchedulerEngine {
 
@@ -24,11 +25,23 @@ public extension MultiModelBatchSchedulerEngine {
         /// The `model_type` from config.json (e.g. `"gpt_oss"`, `"gemma2"`,
         /// `"qwen3"`). Used to auto-select reasoning and tool call parsers.
         public let modelType: String?
+        /// The loaded model container. Present for VLM models so multimodal
+        /// requests can run the non-batched `prepare`/`generate` vision path.
+        public let container: ModelContainer?
+        /// Whether this model is a vision-language model (config has a
+        /// `vision_config`). When true, requests that carry image/video
+        /// content are routed to the container's vision path.
+        public let isVLM: Bool
 
-        public init(scheduler: BatchScheduler, tokenizer: TokenizerHandle, modelType: String? = nil) {
+        public init(
+            scheduler: BatchScheduler, tokenizer: TokenizerHandle, modelType: String? = nil,
+            container: ModelContainer? = nil, isVLM: Bool = false
+        ) {
             self.scheduler = scheduler
             self.tokenizer = tokenizer
             self.modelType = modelType
+            self.container = container
+            self.isVLM = isVLM
         }
     }
 
@@ -48,17 +61,26 @@ public extension MultiModelBatchSchedulerEngine {
         public let releaseToken: OneShotRelease
         /// The `model_type` from config.json.
         public let modelType: String?
+        /// The loaded model container (present for VLM models — see
+        /// ``ModelRegistryEntry/container``).
+        public let container: ModelContainer?
+        /// Whether this model is a vision-language model.
+        public let isVLM: Bool
 
         public init(
             scheduler: BatchScheduler,
             tokenizer: TokenizerHandle,
             releaseToken: OneShotRelease,
-            modelType: String? = nil
+            modelType: String? = nil,
+            container: ModelContainer? = nil,
+            isVLM: Bool = false
         ) {
             self.scheduler = scheduler
             self.tokenizer = tokenizer
             self.releaseToken = releaseToken
             self.modelType = modelType
+            self.container = container
+            self.isVLM = isVLM
         }
     }
 }

--- a/provider-swift/Sources/ProviderCore/Inference/MultiModelBatchSchedulerEngine.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/MultiModelBatchSchedulerEngine.swift
@@ -158,6 +158,8 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
         let tokenizer: TokenizerHandle
         let modelType: String?
         let releaseBox: OneShotRelease
+        let container: ModelContainer?
+        let isVLM: Bool
         let modelId = request.model
         if let acquire {
             let acquired = try await acquire(modelId)
@@ -165,6 +167,8 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
             tokenizer = acquired.tokenizer
             modelType = acquired.modelType
             releaseBox = acquired.releaseToken
+            container = acquired.container
+            isVLM = acquired.isVLM
         } else {
             try await ensureLoaded(modelId)
             let registry = await (registryProvider?() ?? [:])
@@ -176,6 +180,35 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
             modelType = entry.modelType
             await reserveModel(modelId)
             releaseBox = OneShotRelease(release: releaseModel, modelId: modelId)
+            container = entry.container
+            isVLM = entry.isVLM
+        }
+
+        // Multimodal (image/video) requests can't flow through the token-only
+        // batched engine. For VLM models, serve them via the container's
+        // non-batched prepare/generate vision path.
+        if isVLM, let container, VLMRequestInference.hasMedia(request) {
+            let vlmStream = VLMRequestInference.stream(
+                container: container, request: request, defaultMaxTokens: defaultMaxTokens)
+            return AsyncThrowingStream { continuation in
+                let task = Task {
+                    do {
+                        for try await event in vlmStream {
+                            if Task.isCancelled { break }
+                            continuation.yield(event)
+                        }
+                        await releaseBox.fire()
+                        continuation.finish()
+                    } catch {
+                        await releaseBox.fire()
+                        continuation.finish(throwing: error)
+                    }
+                }
+                continuation.onTermination = { @Sendable _ in
+                    task.cancel()
+                    Task { await releaseBox.fire() }
+                }
+            }
         }
 
         // Tokenize the full OpenAI request (including tools, tool_call_id,

--- a/provider-swift/Sources/ProviderCore/Inference/MultiModelBatchSchedulerEngine.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/MultiModelBatchSchedulerEngine.swift
@@ -211,6 +211,17 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
             }
         }
 
+        // If we reach here with media still present, the resolved model is NOT
+        // a usable VLM (either `!isVLM`, or it is flagged VLM but no container
+        // was handed to us, so the vision prepare/generate path is unavailable).
+        // The batched text path below silently discards image/video parts, so
+        // letting media fall through would answer a vision question from text
+        // alone — a wrong, confusing result. Fail closed with a 4xx instead.
+        if VLMRequestInference.hasMedia(request) {
+            await releaseBox.fire()
+            throw MultiModelBatchSchedulerEngineError.mediaUnsupportedByModel(modelId)
+        }
+
         // Tokenize the full OpenAI request (including tools, tool_call_id,
         // reasoning_content, etc.) ourselves rather than going through the
         // lossy `translate()` → `ChatMessage` path that drops tool fields.

--- a/provider-swift/Sources/ProviderCore/Inference/MultiModelBatchSchedulerEngineError.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/MultiModelBatchSchedulerEngineError.swift
@@ -45,6 +45,12 @@ public enum MultiModelBatchSchedulerEngineError: Error, LocalizedError, Equatabl
     /// example a future "request_rejected: ..." path). Surfaces as
     /// 503 — the request was not run and the client may safely retry.
     case requestRejected(String)
+    /// The request carried image/video media but the resolved model is not
+    /// a usable vision-language model (not VLM-capable, or its container is
+    /// unavailable for the non-batched vision path). A client fault that
+    /// will fail identically on retry, so it surfaces as 400 — never let
+    /// media silently fall through to the text-only path.
+    case mediaUnsupportedByModel(String)
 
     public var errorDescription: String? {
         switch self {
@@ -62,6 +68,9 @@ public enum MultiModelBatchSchedulerEngineError: Error, LocalizedError, Equatabl
             return message
         case .requestRejected(let message):
             return message
+        case .mediaUnsupportedByModel(let id):
+            return
+                "Model '\(id)' does not support image or video input on this provider"
         }
     }
 

--- a/provider-swift/Sources/ProviderCore/Inference/VLMRequestInference.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/VLMRequestInference.swift
@@ -1,0 +1,316 @@
+// Copyright © 2026 Eigen Labs.
+//
+// Non-batched vision-language inference path.
+//
+// The continuous-batching engine (`BatchScheduler` / `BatchedEngine`)
+// carries only `[Int]` token arrays, so it cannot represent image/video
+// pixels. Multimodal requests for a VLM model are served here instead:
+// we build a `UserInput` carrying the decoded media, `prepare` it into an
+// `LMInput`, and stream `container.generate(...)`. This mirrors exactly
+// the prepare → generate path proven by `Sources/vlm-smoke/main.swift`.
+//
+// Text-only requests never reach this file — they stay on the batched
+// engine. Routing lives in
+// `MultiModelBatchSchedulerEngine.streamChatCompletion`, which calls
+// `VLMRequestInference.hasMedia` and, when true for a VLM model,
+// delegates to `VLMRequestInference.stream`.
+
+import CoreImage
+import Foundation
+import MLXLMCommon
+import MLXLMServer
+
+/// Namespace for the non-batched VLM (image/video) inference path.
+///
+/// Pure functions + one streaming entry point; holds no state. The
+/// container is owned by `ProviderLoop`'s `ModelSlot` and passed in.
+public enum VLMRequestInference {
+
+    /// Errors surfaced while decoding inline media from a request. These
+    /// finish the stream via `continuation.finish(throwing:)` so the
+    /// status mapper can turn them into a 4xx for the caller.
+    public enum MediaError: Error, CustomStringConvertible {
+        case malformedDataURI(String)
+        case base64DecodeFailed
+        case percentDecodeFailed
+        case imageDecodeFailed
+        case invalidURL(String)
+        case videoWriteFailed(String)
+
+        public var description: String {
+            switch self {
+            case .malformedDataURI(let detail):
+                return "malformed data: URI (\(detail))"
+            case .base64DecodeFailed:
+                return "failed to base64-decode data: URI payload"
+            case .percentDecodeFailed:
+                return "failed to percent-decode data: URI payload"
+            case .imageDecodeFailed:
+                return "failed to decode image data into a CIImage"
+            case .invalidURL(let uri):
+                return "not a valid media URL: \(uri)"
+            case .videoWriteFailed(let detail):
+                return "failed to write inline video to a temp file (\(detail))"
+            }
+        }
+    }
+
+    // MARK: - Routing
+
+    /// True when any message carries an image or video content part.
+    /// Used by the engine to decide between the batched (text) path and
+    /// this non-batched vision path.
+    public static func hasMedia(_ request: OpenAIChatCompletionRequest) -> Bool {
+        for message in request.messages {
+            guard case .parts(let parts) = message.content else { continue }
+            for part in parts {
+                switch part {
+                case .imageURL, .videoURL:
+                    return true
+                case .text, .unsupported:
+                    continue
+                }
+            }
+        }
+        return false
+    }
+
+    // MARK: - Streaming
+
+    /// Stream a multimodal completion through the container's
+    /// `prepare`/`generate` vision path.
+    ///
+    /// Emits the same `MLXServerGenerationEvent` shape as the batched
+    /// engine so the surrounding HTTP/SSE plumbing is identical:
+    /// `.content` chunks during generation, then a final `.info` carrying
+    /// token counts and timing. Inline-video temp files are removed when
+    /// the stream ends (normal completion, error, or cancellation).
+    public static func stream(
+        container: ModelContainer,
+        request: OpenAIChatCompletionRequest,
+        defaultMaxTokens: Int
+    ) -> AsyncThrowingStream<MLXServerGenerationEvent, Error> {
+        AsyncThrowingStream { continuation in
+            let task = Task {
+                // Inline `data:` videos are materialized to temp files for
+                // AVFoundation; track them so we can clean up on exit.
+                var tempFiles: [URL] = []
+                defer {
+                    for url in tempFiles {
+                        try? FileManager.default.removeItem(at: url)
+                    }
+                }
+
+                let userInput: UserInput
+                do {
+                    userInput = try buildUserInput(from: request, tempFiles: &tempFiles)
+                } catch {
+                    continuation.finish(throwing: error)
+                    return
+                }
+
+                do {
+                    let lmInput = try await container.prepare(input: userInput)
+
+                    let params = GenerateParameters(
+                        maxTokens: request.maxTokens ?? defaultMaxTokens,
+                        temperature: request.temperature ?? 0,
+                        topP: request.topP ?? 1.0,
+                        topK: request.topK ?? 0,
+                        repetitionPenalty: request.repetitionPenalty
+                    )
+
+                    let genStream = try await container.generate(
+                        input: lmInput, parameters: params)
+
+                    var promptTokens = 0
+                    var completionTokens = 0
+                    var firstTokenAt: Date?
+                    var lastTokenAt: Date?
+                    let startedAt = Date()
+
+                    for await gen in genStream {
+                        if Task.isCancelled {
+                            continuation.finish()
+                            return
+                        }
+                        switch gen {
+                        case .chunk(let text):
+                            if firstTokenAt == nil { firstTokenAt = Date() }
+                            lastTokenAt = Date()
+                            if !text.isEmpty {
+                                continuation.yield(.content(text))
+                            }
+                        case .info(let info):
+                            promptTokens = info.promptTokenCount
+                            completionTokens = info.generationTokenCount
+                        case .toolCall(let toolCall):
+                            continuation.yield(.toolCall(toolCall))
+                        }
+                    }
+
+                    let promptTime = (firstTokenAt ?? startedAt)
+                        .timeIntervalSince(startedAt)
+                    let generationTime = (lastTokenAt ?? firstTokenAt ?? startedAt)
+                        .timeIntervalSince(firstTokenAt ?? startedAt)
+                    continuation.yield(
+                        .info(
+                            ServerGenerationInfo(
+                                promptTokens: promptTokens,
+                                completionTokens: completionTokens,
+                                promptTime: max(0, promptTime),
+                                generationTime: max(0, generationTime),
+                                stopReason: "stop"
+                            )
+                        )
+                    )
+                    continuation.finish()
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+            continuation.onTermination = { @Sendable _ in
+                task.cancel()
+            }
+        }
+    }
+
+    // MARK: - UserInput construction
+
+    /// Build a model-agnostic `UserInput` from the OpenAI request,
+    /// decoding any inline image/video content parts. `tempFiles`
+    /// accumulates temp URLs created for inline videos so the caller can
+    /// remove them when the stream ends.
+    static func buildUserInput(
+        from request: OpenAIChatCompletionRequest,
+        tempFiles: inout [URL]
+    ) throws -> UserInput {
+        var chatMessages: [Chat.Message] = []
+        for message in request.messages {
+            let (text, images, videos) = try parts(
+                from: message.content, tempFiles: &tempFiles)
+            switch message.role {
+            case .user:
+                chatMessages.append(.user(text, images: images, videos: videos))
+            case .system:
+                chatMessages.append(.system(text))
+            case .assistant:
+                chatMessages.append(.assistant(text))
+            case .tool:
+                chatMessages.append(.tool(text))
+            }
+        }
+        return UserInput(chat: chatMessages)
+    }
+
+    /// Convenience overload that discards temp-file tracking. Used by
+    /// tests that pass only base64/url images (no inline videos).
+    static func buildUserInput(
+        from request: OpenAIChatCompletionRequest
+    ) throws -> UserInput {
+        var sink: [URL] = []
+        return try buildUserInput(from: request, tempFiles: &sink)
+    }
+
+    /// Split a message's content into the concatenated text plus decoded
+    /// image/video media. Non-user roles drop media at the call site, but
+    /// we still decode here so a malformed inline payload fails loudly
+    /// rather than being silently ignored.
+    private static func parts(
+        from content: OpenAIMessageContent,
+        tempFiles: inout [URL]
+    ) throws -> (text: String, images: [UserInput.Image], videos: [UserInput.Video]) {
+        switch content {
+        case .text(let string):
+            return (string, [], [])
+        case .null:
+            return ("", [], [])
+        case .parts(let parts):
+            var text = ""
+            var images: [UserInput.Image] = []
+            var videos: [UserInput.Video] = []
+            for part in parts {
+                switch part {
+                case .text(let string):
+                    text += string
+                case .imageURL(let uri):
+                    images.append(try decodeImage(uri))
+                case .videoURL(let uri):
+                    videos.append(try decodeVideo(uri, tempFiles: &tempFiles))
+                case .unsupported:
+                    continue
+                }
+            }
+            return (text, images, videos)
+        }
+    }
+
+    // MARK: - Media decode
+
+    /// Decode an image content part. `data:` URIs are decoded in-memory
+    /// into a `CIImage`; everything else is treated as a remote/file URL
+    /// that the model processor loads lazily.
+    static func decodeImage(_ uri: String) throws -> UserInput.Image {
+        if uri.hasPrefix("data:") {
+            let data = try dataFromDataURI(uri)
+            guard let image = CIImage(data: data) else {
+                throw MediaError.imageDecodeFailed
+            }
+            return .ciImage(image)
+        }
+        guard let url = URL(string: uri) else {
+            throw MediaError.invalidURL(uri)
+        }
+        return .url(url)
+    }
+
+    /// Decode a video content part. `data:` URIs are written to a unique
+    /// temp file (tracked for cleanup) because AVFoundation consumes a
+    /// URL; everything else is treated as a remote/file URL.
+    static func decodeVideo(
+        _ uri: String, tempFiles: inout [URL]
+    ) throws -> UserInput.Video {
+        if uri.hasPrefix("data:") {
+            let data = try dataFromDataURI(uri)
+            let tempURL = FileManager.default.temporaryDirectory
+                .appendingPathComponent("vlm-\(UUID().uuidString).mp4")
+            do {
+                try data.write(to: tempURL)
+            } catch {
+                throw MediaError.videoWriteFailed(String(describing: error))
+            }
+            tempFiles.append(tempURL)
+            return .url(tempURL)
+        }
+        guard let url = URL(string: uri) else {
+            throw MediaError.invalidURL(uri)
+        }
+        return .url(url)
+    }
+
+    /// Extract the raw bytes from a `data:` URI. The header before the
+    /// first comma decides the encoding: `;base64` ⇒ base64, otherwise
+    /// the payload is percent-encoded UTF-8 text.
+    static func dataFromDataURI(_ uri: String) throws -> Data {
+        guard let commaIndex = uri.firstIndex(of: ",") else {
+            throw MediaError.malformedDataURI("missing ','")
+        }
+        let header = uri[uri.startIndex..<commaIndex]
+        let payload = String(uri[uri.index(after: commaIndex)...])
+
+        if header.contains(";base64") {
+            let stripped = payload.filter { !$0.isWhitespace }
+            guard let data = Data(base64Encoded: stripped) else {
+                throw MediaError.base64DecodeFailed
+            }
+            return data
+        }
+
+        guard let decoded = payload.removingPercentEncoding,
+            let data = decoded.data(using: .utf8)
+        else {
+            throw MediaError.percentDecodeFailed
+        }
+        return data
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Inference/VLMRequestInference.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/VLMRequestInference.swift
@@ -52,7 +52,11 @@ public enum VLMRequestInference {
             case .imageDecodeFailed:
                 return "failed to decode image data into a CIImage"
             case .invalidURL(let uri):
-                return "not a valid media URL: \(uri)"
+                // Actionable for clients porting from OpenAI/OpenRouter: our wire
+                // format is identical, but media must be an inline base64 data:
+                // URI — remote/file URLs are rejected for E2E + SSRF safety.
+                let shown = uri.count > 200 ? String(uri.prefix(200)) + "…" : uri
+                return "media must be sent as an inline base64 data: URI (e.g. \"data:image/jpeg;base64,…\") on this end-to-end-encrypted endpoint; remote http(s):// and file:// URLs are rejected. Got: \(shown)"
             case .videoWriteFailed(let detail):
                 return "failed to write inline video to a temp file (\(detail))"
             }

--- a/provider-swift/Sources/ProviderCore/Inference/VLMRequestInference.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/VLMRequestInference.swift
@@ -29,7 +29,11 @@ public enum VLMRequestInference {
     /// Errors surfaced while decoding inline media from a request. These
     /// finish the stream via `continuation.finish(throwing:)` so the
     /// status mapper can turn them into a 4xx for the caller.
-    public enum MediaError: Error, CustomStringConvertible {
+    ///
+    /// Conforms to `LocalizedError` so the human-readable `description`
+    /// reaches the client (via `error.localizedDescription`) instead of
+    /// the generic Cocoa "operation couldn't be completed" fallback.
+    public enum MediaError: Error, CustomStringConvertible, LocalizedError {
         case malformedDataURI(String)
         case base64DecodeFailed
         case percentDecodeFailed
@@ -53,6 +57,8 @@ public enum VLMRequestInference {
                 return "failed to write inline video to a temp file (\(detail))"
             }
         }
+
+        public var errorDescription: String? { description }
     }
 
     // MARK: - Routing
@@ -110,6 +116,12 @@ public enum VLMRequestInference {
                 }
 
                 do {
+                    // Capture the prompt-clock origin BEFORE `prepare` so the
+                    // reported `promptTime` includes media decode / resize /
+                    // tokenization, matching the batched + server engines
+                    // (which start their clock before any prep work). Capturing
+                    // it after `prepare` would undercount prompt latency.
+                    let startedAt = Date()
                     let lmInput = try await container.prepare(input: userInput)
 
                     let params = GenerateParameters(
@@ -127,7 +139,11 @@ public enum VLMRequestInference {
                     var completionTokens = 0
                     var firstTokenAt: Date?
                     var lastTokenAt: Date?
-                    let startedAt = Date()
+                    // Default to "stop"; overwritten from the engine's
+                    // GenerateCompletionInfo so we report the real finish
+                    // reason (e.g. "length" when maxTokens is hit) instead of
+                    // a hardcoded value.
+                    var stopReason = "stop"
 
                     for await gen in genStream {
                         if Task.isCancelled {
@@ -144,6 +160,7 @@ public enum VLMRequestInference {
                         case .info(let info):
                             promptTokens = info.promptTokenCount
                             completionTokens = info.generationTokenCount
+                            stopReason = openAIFinishReason(info.stopReason)
                         case .toolCall(let toolCall):
                             continuation.yield(.toolCall(toolCall))
                         }
@@ -160,7 +177,7 @@ public enum VLMRequestInference {
                                 completionTokens: completionTokens,
                                 promptTime: max(0, promptTime),
                                 generationTime: max(0, generationTime),
-                                stopReason: "stop"
+                                stopReason: stopReason
                             )
                         )
                     )
@@ -247,45 +264,48 @@ public enum VLMRequestInference {
 
     // MARK: - Media decode
 
-    /// Decode an image content part. `data:` URIs are decoded in-memory
-    /// into a `CIImage`; everything else is treated as a remote/file URL
-    /// that the model processor loads lazily.
+    /// Decode an image content part. Inline `data:` URIs are decoded
+    /// in-memory into a `CIImage`. Anything else is REJECTED: this is an
+    /// end-to-end-encrypted provider, so the only legitimate transport for
+    /// media is an inline `data:` URI inside the encrypted prompt. Accepting
+    /// an arbitrary `http(s)://`/`file://` URL here would let a crafted
+    /// request drive `CIImage(contentsOf:)` into an SSRF / local-file-read
+    /// primitive (the provider is the fetcher), so a non-`data:` URI fails
+    /// closed with `invalidURL`.
     static func decodeImage(_ uri: String) throws -> UserInput.Image {
-        if uri.hasPrefix("data:") {
-            let data = try dataFromDataURI(uri)
-            guard let image = CIImage(data: data) else {
-                throw MediaError.imageDecodeFailed
-            }
-            return .ciImage(image)
-        }
-        guard let url = URL(string: uri) else {
+        guard uri.hasPrefix("data:") else {
             throw MediaError.invalidURL(uri)
         }
-        return .url(url)
+        let data = try dataFromDataURI(uri)
+        guard let image = CIImage(data: data) else {
+            throw MediaError.imageDecodeFailed
+        }
+        return .ciImage(image)
     }
 
-    /// Decode a video content part. `data:` URIs are written to a unique
-    /// temp file (tracked for cleanup) because AVFoundation consumes a
-    /// URL; everything else is treated as a remote/file URL.
+    /// Decode a video content part. Inline `data:` URIs are written to a
+    /// unique temp file (tracked for cleanup) because AVFoundation consumes
+    /// a URL. Anything else is REJECTED for the same reason as `decodeImage`:
+    /// accepting an arbitrary `http(s)://`/`file://` URL would hand a crafted
+    /// request an SSRF / local-file-read primitive via `AVAsset(url:)`. The
+    /// only legitimate media transport on this E2E-encrypted provider is an
+    /// inline `data:` URI, so a non-`data:` URI fails closed with `invalidURL`.
     static func decodeVideo(
         _ uri: String, tempFiles: inout [URL]
     ) throws -> UserInput.Video {
-        if uri.hasPrefix("data:") {
-            let data = try dataFromDataURI(uri)
-            let tempURL = FileManager.default.temporaryDirectory
-                .appendingPathComponent("vlm-\(UUID().uuidString).mp4")
-            do {
-                try data.write(to: tempURL)
-            } catch {
-                throw MediaError.videoWriteFailed(String(describing: error))
-            }
-            tempFiles.append(tempURL)
-            return .url(tempURL)
-        }
-        guard let url = URL(string: uri) else {
+        guard uri.hasPrefix("data:") else {
             throw MediaError.invalidURL(uri)
         }
-        return .url(url)
+        let data = try dataFromDataURI(uri)
+        let tempURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("vlm-\(UUID().uuidString).mp4")
+        do {
+            try data.write(to: tempURL)
+        } catch {
+            throw MediaError.videoWriteFailed(String(describing: error))
+        }
+        tempFiles.append(tempURL)
+        return .url(tempURL)
     }
 
     /// Extract the raw bytes from a `data:` URI. The header before the
@@ -312,5 +332,22 @@ public enum VLMRequestInference {
             throw MediaError.percentDecodeFailed
         }
         return data
+    }
+
+    // MARK: - Stop-reason mapping
+
+    /// Map a `GenerateStopReason` to the OpenAI `finish_reason` string.
+    ///
+    /// MLXLMServer ships an equivalent `GenerateStopReason.openAIFinishReason`
+    /// but it is `internal` to that module, so we mirror its mapping here to
+    /// keep the same wire contract as the batched + server engines: `.length`
+    /// ⇒ `"length"`, everything else (`.stop`, `.cancelled`) ⇒ `"stop"`.
+    static func openAIFinishReason(_ reason: GenerateStopReason) -> String {
+        switch reason {
+        case .length:
+            return "length"
+        case .stop, .cancelled:
+            return "stop"
+        }
     }
 }

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+ErrorMapping.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+ErrorMapping.swift
@@ -52,7 +52,28 @@ extension ProviderLoop {
                 return 503
             case .requestRejected:
                 return 503
+            case .mediaUnsupportedByModel:
+                // Client fault: media sent to a non-VLM model. Fails
+                // identically on retry, so 400 (not a 5xx/retry signal).
+                return 400
             case .generationFailed:
+                return 500
+            }
+        }
+        // VLM inline-media decode errors. All but the temp-file write are
+        // client faults (a malformed/oversized/non-`data:` payload the caller
+        // controls) → 400. `videoWriteFailed` is a provider-side IO failure
+        // → 500. These propagate up from `VLMRequestInference.stream`'s
+        // `continuation.finish(throwing:)` through the engine wrapper.
+        if let mediaErr = error as? VLMRequestInference.MediaError {
+            switch mediaErr {
+            case .malformedDataURI,
+                .base64DecodeFailed,
+                .percentDecodeFailed,
+                .imageDecodeFailed,
+                .invalidURL:
+                return 400
+            case .videoWriteFailed:
                 return 500
             }
         }

--- a/provider-swift/Sources/ProviderCore/ProviderLoop.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop.swift
@@ -284,6 +284,9 @@ public actor ProviderLoop {
         let scheduler: BatchScheduler
         let container: MLXLMCommon.ModelContainer
         let tokenizer: TokenizerHandle
+        /// Vision-language model (config has `vision_config`). Multimodal
+        /// requests are served from `container` via the non-batched path.
+        let isVLM: Bool
         var lastInferenceAt: ContinuousClock.Instant
     }
 
@@ -781,6 +784,8 @@ public actor ProviderLoop {
         let log = self.logger
         let tokenizer = slot.tokenizer
         let modelType = loopConfig.models.first(where: { $0.id == modelId })?.modelType
+        let slotContainer = slot.container
+        let slotIsVLM = slot.isVLM
 
         // 8. Spawn inference task. The streaming pipeline now flows through
         // the upstream `MLXLMServer` library:
@@ -835,7 +840,9 @@ public actor ProviderLoop {
             // still going through the upstream library for SSE encoding.
             let providerEngine = MultiModelBatchSchedulerEngine(
                 registryProvider: { @Sendable in
-                    [chatRequest.model: .init(scheduler: sched, tokenizer: tokenizer, modelType: modelType)]
+                    [chatRequest.model: .init(
+                        scheduler: sched, tokenizer: tokenizer, modelType: modelType,
+                        container: slotContainer, isVLM: slotIsVLM)]
                 },
                 ensureLoaded: { _ in },
                 reserveModel: { _ in },
@@ -1719,6 +1726,7 @@ public actor ProviderLoop {
                 scheduler: scheduler,
                 container: container,
                 tokenizer: tokenizer,
+                isVLM: Self.modelIsVLM(at: modelPath),
                 lastInferenceAt: .now
             )
 
@@ -1943,10 +1951,31 @@ public actor ProviderLoop {
     }
 
     private func loadModelContainer(from directory: URL) async throws -> MLXLMCommon.ModelContainer {
-        try await LLMModelFactory.shared.loadContainer(
+        // Vision-language models (config declares `vision_config`) load via
+        // VLMModelFactory so image/video requests can run the container's
+        // prepare/generate vision path. Their text path still works through the
+        // batched engine since VLMModel refines LanguageModel.
+        if Self.modelIsVLM(at: directory) {
+            return try await VLMModelFactory.shared.loadContainer(
+                from: directory,
+                using: LocalTokenizerLoader()
+            )
+        }
+        return try await LLMModelFactory.shared.loadContainer(
             from: directory,
             using: LocalTokenizerLoader()
         )
+    }
+
+    /// A model is a vision-language model when its `config.json` declares a
+    /// `vision_config`. Cheap, dependency-free check used to pick the model
+    /// factory and to route multimodal requests.
+    static func modelIsVLM(at directory: URL) -> Bool {
+        let configURL = directory.appendingPathComponent("config.json")
+        guard let data = try? Data(contentsOf: configURL),
+            let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else { return false }
+        return json["vision_config"] != nil
     }
 
     // MARK: - Cancellation
@@ -2224,6 +2253,7 @@ struct ProviderLogger: Sendable {
 import MLX
 import MLXLLM
 import MLXLMCommon
+import MLXVLM
 
 // MARK: - Unified local endpoint
 
@@ -2331,7 +2361,9 @@ extension ProviderLoop {
             scheduler: slot.scheduler,
             tokenizer: slot.tokenizer,
             releaseToken: OneShotRelease(release: release, modelId: modelId),
-            modelType: loopConfig.models.first(where: { $0.id == modelId })?.modelType
+            modelType: loopConfig.models.first(where: { $0.id == modelId })?.modelType,
+            container: slot.container,
+            isVLM: slot.isVLM
         )
     }
 

--- a/provider-swift/Sources/vlm-smoke/main.swift
+++ b/provider-swift/Sources/vlm-smoke/main.swift
@@ -25,75 +25,86 @@ struct VLMSmoke {
             err("usage: vlm-smoke <modelDir> <image-or-video-path[,path2,...]> [prompt]")
             exit(2)
         }
-        let modelDir = URL(fileURLWithPath: args[1])
-        let mediaPaths = args[2].split(separator: ",").map { String($0) }
+        do {
+            try await run(
+                modelDirPath: args[1],
+                mediaArg: args[2],
+                promptArg: args.count >= 4 ? args[3] : nil
+            )
+        } catch {
+            err("[vlm-smoke] ERROR: \(error)")
+            exit(1)
+        }
+    }
+
+    // `nonisolated` so `userInput` is constructed OUTSIDE any actor's region.
+    // `main()` is @MainActor; on older toolchains (CI's macOS-26 Xcode) a
+    // non-Sendable value built in an actor-isolated context cannot be sent
+    // into `container.prepare(input:)` ("sending 'userInput' risks causing
+    // data races"), even with no post-construction reads. In a nonisolated
+    // async function the fresh value is in a disconnected region, which every
+    // Swift 6.x compiler accepts. Same shape as upstream llm-tool's `run()`.
+    nonisolated static func run(
+        modelDirPath: String, mediaArg: String, promptArg: String?
+    ) async throws {
+        let modelDir = URL(fileURLWithPath: modelDirPath)
+        let mediaPaths = mediaArg.split(separator: ",").map { String($0) }
         let isVideo = mediaPaths.count == 1
             && videoExtensions.contains((mediaPaths[0] as NSString).pathExtension.lowercased())
         let defaultPrompt =
             isVideo
             ? "Describe what is happening in this video."
             : "Describe this image in detail. What objects, animals, colors, and any text do you see?"
-        let prompt = args.count >= 4 ? args[3] : defaultPrompt
+        let prompt = promptArg ?? defaultPrompt
 
-        do {
-            let t0 = Date()
-            err("[vlm-smoke] loading VLM from \(modelDir.lastPathComponent) ...")
-            let container = try await VLMModelFactory.shared.loadContainer(
-                from: modelDir,
-                using: LocalTokenizerLoader()
-            )
-            err(String(format: "[vlm-smoke] loaded in %.1fs", Date().timeIntervalSince(t0)))
+        let t0 = Date()
+        err("[vlm-smoke] loading VLM from \(modelDir.lastPathComponent) ...")
+        let container = try await VLMModelFactory.shared.loadContainer(
+            from: modelDir,
+            using: LocalTokenizerLoader()
+        )
+        err(String(format: "[vlm-smoke] loaded in %.1fs", Date().timeIntervalSince(t0)))
 
-            // NOTE: do not read `userInput.images/videos` after building it.
-            // `main()` is `@MainActor`, so any post-construction read binds
-            // `userInput` to the main actor and `container.prepare(input:)`
-            // then fails to compile with "sending 'userInput' risks causing
-            // data races". `mediaPaths` is logged here instead, before the
-            // value is built, so it flows straight into `prepare`.
-            let userInput: UserInput
-            if isVideo {
-                err("[vlm-smoke] preparing input (video: \(mediaPaths[0])) ...")
-                let videoURL = URL(fileURLWithPath: mediaPaths[0])
-                userInput = UserInput(chat: [.user(prompt, videos: [.url(videoURL)])])
-            } else {
-                err("[vlm-smoke] preparing input (\(mediaPaths.count) image(s)) ...")
-                let images = mediaPaths.map { UserInput.Image.url(URL(fileURLWithPath: $0)) }
-                userInput = UserInput(chat: [.user(prompt, images: images)])
-            }
-            let lmInput = try await container.prepare(input: userInput)
-
-            err("[vlm-smoke] generating ...")
-            let env = ProcessInfo.processInfo.environment
-            let temp = Float(env["VLM_TEMP"] ?? "") ?? 0.0
-            let repPen: Float? = Float(env["VLM_REPPEN"] ?? "")
-            let maxTok = Int(env["VLM_MAXTOK"] ?? "") ?? 220
-            let repPenDesc: String = repPen == nil ? "none" : "\(repPen!)"
-            err("[vlm-smoke] sampling: temp=\(temp) repPen=\(repPenDesc) maxTokens=\(maxTok)")
-            let params = GenerateParameters(
-                maxTokens: maxTok, temperature: temp, repetitionPenalty: repPen)
-            let stream = try await container.generate(input: lmInput, parameters: params)
-
-            err("---OUTPUT-START---")
-            var out = ""
-            for await gen in stream {
-                switch gen {
-                case .chunk(let s):
-                    out += s
-                    FileHandle.standardOutput.write(Data(s.utf8))
-                case .info(let info):
-                    err(String(format: "\n[vlm-smoke] %.1f tok/s, %d tokens",
-                               info.tokensPerSecond, info.generationTokenCount))
-                case .toolCall(let c):
-                    err("[vlm-smoke] toolCall: \(c)")
-                @unknown default:
-                    break
-                }
-            }
-            FileHandle.standardOutput.write(Data("\n".utf8))
-            err("---OUTPUT-END--- (\(out.count) chars)")
-        } catch {
-            err("[vlm-smoke] ERROR: \(error)")
-            exit(1)
+        let userInput: UserInput
+        if isVideo {
+            err("[vlm-smoke] preparing input (video: \(mediaPaths[0])) ...")
+            let videoURL = URL(fileURLWithPath: mediaPaths[0])
+            userInput = UserInput(chat: [.user(prompt, videos: [.url(videoURL)])])
+        } else {
+            err("[vlm-smoke] preparing input (\(mediaPaths.count) image(s)) ...")
+            let images = mediaPaths.map { UserInput.Image.url(URL(fileURLWithPath: $0)) }
+            userInput = UserInput(chat: [.user(prompt, images: images)])
         }
+        let lmInput = try await container.prepare(input: userInput)
+
+        err("[vlm-smoke] generating ...")
+        let env = ProcessInfo.processInfo.environment
+        let temp = Float(env["VLM_TEMP"] ?? "") ?? 0.0
+        let repPen: Float? = Float(env["VLM_REPPEN"] ?? "")
+        let maxTok = Int(env["VLM_MAXTOK"] ?? "") ?? 220
+        let repPenDesc: String = repPen == nil ? "none" : "\(repPen!)"
+        err("[vlm-smoke] sampling: temp=\(temp) repPen=\(repPenDesc) maxTokens=\(maxTok)")
+        let params = GenerateParameters(
+            maxTokens: maxTok, temperature: temp, repetitionPenalty: repPen)
+        let stream = try await container.generate(input: lmInput, parameters: params)
+
+        err("---OUTPUT-START---")
+        var out = ""
+        for await gen in stream {
+            switch gen {
+            case .chunk(let s):
+                out += s
+                FileHandle.standardOutput.write(Data(s.utf8))
+            case .info(let info):
+                err(String(format: "\n[vlm-smoke] %.1f tok/s, %d tokens",
+                           info.tokensPerSecond, info.generationTokenCount))
+            case .toolCall(let c):
+                err("[vlm-smoke] toolCall: \(c)")
+            @unknown default:
+                break
+            }
+        }
+        FileHandle.standardOutput.write(Data("\n".utf8))
+        err("---OUTPUT-END--- (\(out.count) chars)")
     }
 }

--- a/provider-swift/Sources/vlm-smoke/main.swift
+++ b/provider-swift/Sources/vlm-smoke/main.swift
@@ -1,0 +1,95 @@
+// vlm-smoke — throwaway harness to test Gemma 4 multimodal (VLM) inference
+// with the mlx-swift-lm fork's MLXVLM library, loading from a LOCAL model
+// directory (no network) and feeding an image OR video + text prompt.
+//
+// usage: vlm-smoke <modelDir> <image-or-video-path> [prompt]
+//   - If the media path has a video extension (mp4/mov/m4v/3gp/webm), it is
+//     fed as a video; otherwise as an image.
+//   - Multiple comma-separated image paths are fed as multiple images.
+
+import Foundation
+import MLX
+import MLXLMCommon
+import MLXVLM
+import ProviderCore  // LocalTokenizerLoader (local, no-network tokenizer)
+
+func err(_ s: String) { FileHandle.standardError.write(Data((s + "\n").utf8)) }
+
+@main
+struct VLMSmoke {
+    static let videoExtensions: Set<String> = ["mp4", "mov", "m4v", "3gp", "webm", "avi", "mkv"]
+
+    static func main() async {
+        let args = CommandLine.arguments
+        guard args.count >= 3 else {
+            err("usage: vlm-smoke <modelDir> <image-or-video-path[,path2,...]> [prompt]")
+            exit(2)
+        }
+        let modelDir = URL(fileURLWithPath: args[1])
+        let mediaPaths = args[2].split(separator: ",").map { String($0) }
+        let isVideo = mediaPaths.count == 1
+            && videoExtensions.contains((mediaPaths[0] as NSString).pathExtension.lowercased())
+        let defaultPrompt =
+            isVideo
+            ? "Describe what is happening in this video."
+            : "Describe this image in detail. What objects, animals, colors, and any text do you see?"
+        let prompt = args.count >= 4 ? args[3] : defaultPrompt
+
+        do {
+            let t0 = Date()
+            err("[vlm-smoke] loading VLM from \(modelDir.lastPathComponent) ...")
+            let container = try await VLMModelFactory.shared.loadContainer(
+                from: modelDir,
+                using: LocalTokenizerLoader()
+            )
+            err(String(format: "[vlm-smoke] loaded in %.1fs", Date().timeIntervalSince(t0)))
+
+            let userInput: UserInput
+            if isVideo {
+                err("[vlm-smoke] preparing input (video: \(mediaPaths[0])) ...")
+                let videoURL = URL(fileURLWithPath: mediaPaths[0])
+                userInput = UserInput(chat: [.user(prompt, videos: [.url(videoURL)])])
+                err("[vlm-smoke] userInput.videos count = \(userInput.videos.count)")
+            } else {
+                err("[vlm-smoke] preparing input (\(mediaPaths.count) image(s)) ...")
+                let images = mediaPaths.map { UserInput.Image.url(URL(fileURLWithPath: $0)) }
+                userInput = UserInput(chat: [.user(prompt, images: images)])
+                err("[vlm-smoke] userInput.images count = \(userInput.images.count)")
+            }
+            let lmInput = try await container.prepare(input: userInput)
+
+            err("[vlm-smoke] generating ...")
+            let env = ProcessInfo.processInfo.environment
+            let temp = Float(env["VLM_TEMP"] ?? "") ?? 0.0
+            let repPen: Float? = Float(env["VLM_REPPEN"] ?? "")
+            let maxTok = Int(env["VLM_MAXTOK"] ?? "") ?? 220
+            let repPenDesc: String = repPen == nil ? "none" : "\(repPen!)"
+            err("[vlm-smoke] sampling: temp=\(temp) repPen=\(repPenDesc) maxTokens=\(maxTok)")
+            let params = GenerateParameters(
+                maxTokens: maxTok, temperature: temp, repetitionPenalty: repPen)
+            let stream = try await container.generate(input: lmInput, parameters: params)
+
+            err("---OUTPUT-START---")
+            var out = ""
+            for await gen in stream {
+                switch gen {
+                case .chunk(let s):
+                    out += s
+                    FileHandle.standardOutput.write(Data(s.utf8))
+                case .info(let info):
+                    err(String(format: "\n[vlm-smoke] %.1f tok/s, %d tokens",
+                               info.tokensPerSecond, info.generationTokenCount))
+                case .toolCall(let c):
+                    err("[vlm-smoke] toolCall: \(c)")
+                @unknown default:
+                    break
+                }
+            }
+            FileHandle.standardOutput.write(Data("\n".utf8))
+            err("---OUTPUT-END--- (\(out.count) chars)")
+        } catch {
+            err("[vlm-smoke] ERROR: \(error)")
+            exit(1)
+        }
+    }
+}

--- a/provider-swift/Sources/vlm-smoke/main.swift
+++ b/provider-swift/Sources/vlm-smoke/main.swift
@@ -44,17 +44,21 @@ struct VLMSmoke {
             )
             err(String(format: "[vlm-smoke] loaded in %.1fs", Date().timeIntervalSince(t0)))
 
+            // NOTE: do not read `userInput.images/videos` after building it.
+            // `main()` is `@MainActor`, so any post-construction read binds
+            // `userInput` to the main actor and `container.prepare(input:)`
+            // then fails to compile with "sending 'userInput' risks causing
+            // data races". `mediaPaths` is logged here instead, before the
+            // value is built, so it flows straight into `prepare`.
             let userInput: UserInput
             if isVideo {
                 err("[vlm-smoke] preparing input (video: \(mediaPaths[0])) ...")
                 let videoURL = URL(fileURLWithPath: mediaPaths[0])
                 userInput = UserInput(chat: [.user(prompt, videos: [.url(videoURL)])])
-                err("[vlm-smoke] userInput.videos count = \(userInput.videos.count)")
             } else {
                 err("[vlm-smoke] preparing input (\(mediaPaths.count) image(s)) ...")
                 let images = mediaPaths.map { UserInput.Image.url(URL(fileURLWithPath: $0)) }
                 userInput = UserInput(chat: [.user(prompt, images: images)])
-                err("[vlm-smoke] userInput.images count = \(userInput.images.count)")
             }
             let lmInput = try await container.prepare(input: userInput)
 

--- a/provider-swift/Tests/ProviderCoreTests/VLMRequestInferenceTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/VLMRequestInferenceTests.swift
@@ -318,6 +318,6 @@ func vlmMediaErrorLocalizedDescription() {
     // (not the generic Cocoa "operation couldn't be completed") reaches the
     // client via error.localizedDescription.
     let err = VLMRequestInference.MediaError.invalidURL("file:///etc/passwd")
-    #expect(err.localizedDescription == "not a valid media URL: file:///etc/passwd")
+    #expect(err.localizedDescription == "media must be sent as an inline base64 data: URI (e.g. \"data:image/jpeg;base64,…\") on this end-to-end-encrypted endpoint; remote http(s):// and file:// URLs are rejected. Got: file:///etc/passwd")
     #expect(!err.localizedDescription.contains("couldn’t be completed"))
 }

--- a/provider-swift/Tests/ProviderCoreTests/VLMRequestInferenceTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/VLMRequestInferenceTests.swift
@@ -22,6 +22,31 @@ private let tinyPNGBase64 =
 
 private let tinyPNGDataURI = "data:image/png;base64,\(tinyPNGBase64)"
 
+// MARK: - Test helpers
+
+/// Run a throwing media-decode body and assert it threw
+/// `MediaError.invalidURL(expectedURI)`. `MediaError` is not `Equatable`, so
+/// we pattern-match the case and compare its associated URI rather than using
+/// the value form of `#expect(throws:)`.
+private func expectInvalidURL(
+    _ expectedURI: String,
+    _ body: () throws -> Void
+) {
+    do {
+        try body()
+        Issue.record(
+            "expected MediaError.invalidURL(\(expectedURI)) but no error was thrown")
+    } catch let error as VLMRequestInference.MediaError {
+        guard case .invalidURL(let uri) = error else {
+            Issue.record("expected .invalidURL, got \(error)")
+            return
+        }
+        #expect(uri == expectedURI)
+    } catch {
+        Issue.record("expected MediaError.invalidURL, got \(error)")
+    }
+}
+
 // MARK: - dataFromDataURI
 
 @Test("dataFromDataURI decodes a base64 image payload")
@@ -75,14 +100,24 @@ func vlmDecodeImageDataURI() throws {
     #expect(ci.extent.height == 1)
 }
 
-@Test("decodeImage treats a non-data URI as a URL")
-func vlmDecodeImageRemoteURL() throws {
-    let image = try VLMRequestInference.decodeImage("https://example.com/cat.png")
-    guard case .url(let url) = image else {
-        Issue.record("expected .url, got \(image)")
-        return
+// SECURITY (SSRF / local-file-read): the provider is the only thing that can
+// enforce media policy on an E2E-encrypted request, so inline media MUST be a
+// `data:` URI. A non-`data:` URL (http(s):// or file://) must be rejected with
+// `invalidURL` and NEVER turned into a `.url(...)` that `CIImage(contentsOf:)`
+// / `AVAsset(url:)` would later fetch. These tests lock that guarantee so it
+// can't silently regress.
+@Test("decodeImage rejects an http:// URI with invalidURL (no SSRF)")
+func vlmDecodeImageHTTPRejected() {
+    expectInvalidURL("https://example.com/cat.png") {
+        _ = try VLMRequestInference.decodeImage("https://example.com/cat.png")
     }
-    #expect(url.absoluteString == "https://example.com/cat.png")
+}
+
+@Test("decodeImage rejects a file:// URI with invalidURL (no local-file read)")
+func vlmDecodeImageFileRejected() {
+    expectInvalidURL("file:///etc/passwd") {
+        _ = try VLMRequestInference.decodeImage("file:///etc/passwd")
+    }
 }
 
 @Test("decodeImage throws when a data: URI holds non-image bytes")
@@ -115,16 +150,24 @@ func vlmDecodeVideoDataURIWritesTempFile() throws {
     try? FileManager.default.removeItem(at: url)
 }
 
-@Test("decodeVideo treats a non-data URI as a URL without writing a temp file")
-func vlmDecodeVideoRemoteURL() throws {
+@Test("decodeVideo rejects an http:// URI with invalidURL (no SSRF)")
+func vlmDecodeVideoHTTPRejected() {
     var tempFiles: [URL] = []
-    let video = try VLMRequestInference.decodeVideo(
-        "https://example.com/clip.mp4", tempFiles: &tempFiles)
-    guard case .url(let url) = video else {
-        Issue.record("expected .url, got \(video)")
-        return
+    expectInvalidURL("https://example.com/clip.mp4") {
+        _ = try VLMRequestInference.decodeVideo(
+            "https://example.com/clip.mp4", tempFiles: &tempFiles)
     }
-    #expect(url.absoluteString == "https://example.com/clip.mp4")
+    // A rejected URI must not have spawned a temp file.
+    #expect(tempFiles.isEmpty)
+}
+
+@Test("decodeVideo rejects a file:// URI with invalidURL (no local-file read)")
+func vlmDecodeVideoFileRejected() {
+    var tempFiles: [URL] = []
+    expectInvalidURL("file:///etc/passwd") {
+        _ = try VLMRequestInference.decodeVideo(
+            "file:///etc/passwd", tempFiles: &tempFiles)
+    }
     #expect(tempFiles.isEmpty)
 }
 
@@ -228,4 +271,53 @@ func vlmBuildUserInputTextOnly() throws {
     }
     #expect(messages.count == 1)
     #expect(messages[0].content == "just text")
+}
+
+// MARK: - error → HTTP status mapping
+
+// These lock the status contract for the VLM-side errors:
+//   - client-fault MediaError cases (bad/oversized/non-`data:` payloads the
+//     caller controls) → 400
+//   - the provider-side temp-file write failure → 500
+//   - media sent to a non-VLM model → 400
+// They also guard the propagation premise behind FIX F: these exact error
+// values are what `VLMRequestInference.stream` / the engine throw upward, and
+// `mapInferenceErrorToStatus` is what ProviderLoop calls on them.
+
+@Test("client-fault MediaError cases map to HTTP 400")
+func vlmMediaErrorMapsTo400() {
+    let clientFaults: [VLMRequestInference.MediaError] = [
+        .invalidURL("file:///etc/passwd"),
+        .malformedDataURI("missing ','"),
+        .base64DecodeFailed,
+        .percentDecodeFailed,
+        .imageDecodeFailed,
+    ]
+    for err in clientFaults {
+        #expect(
+            ProviderLoop.mapInferenceErrorToStatus(err) == 400,
+            "expected 400 for \(err)")
+    }
+}
+
+@Test("videoWriteFailed (provider IO fault) maps to HTTP 500")
+func vlmVideoWriteFailedMapsTo500() {
+    let err = VLMRequestInference.MediaError.videoWriteFailed("disk full")
+    #expect(ProviderLoop.mapInferenceErrorToStatus(err) == 500)
+}
+
+@Test("media-to-non-VLM-model error maps to HTTP 400")
+func vlmMediaUnsupportedByModelMapsTo400() {
+    let err = MultiModelBatchSchedulerEngineError.mediaUnsupportedByModel("text-only")
+    #expect(ProviderLoop.mapInferenceErrorToStatus(err) == 400)
+}
+
+@Test("MediaError surfaces a useful localizedDescription (LocalizedError)")
+func vlmMediaErrorLocalizedDescription() {
+    // FIX B: conforming to LocalizedError means the human-readable message
+    // (not the generic Cocoa "operation couldn't be completed") reaches the
+    // client via error.localizedDescription.
+    let err = VLMRequestInference.MediaError.invalidURL("file:///etc/passwd")
+    #expect(err.localizedDescription == "not a valid media URL: file:///etc/passwd")
+    #expect(!err.localizedDescription.contains("couldn’t be completed"))
 }

--- a/provider-swift/Tests/ProviderCoreTests/VLMRequestInferenceTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/VLMRequestInferenceTests.swift
@@ -1,0 +1,231 @@
+import CoreImage
+import Foundation
+import MLXLMCommon
+import MLXLMServer
+import Testing
+
+@testable import ProviderCore
+
+// Unit tests for the non-batched VLM (image/video) inference path. These
+// cover the pure decode + routing helpers — data: URI parsing, image
+// decode, media detection, and UserInput construction — without loading
+// a model or touching the network. Live generation through a real VLM
+// container is covered by the smoke harness / live suites.
+
+// A real, round-trip-verified 1x1 PNG (red pixel), base64 with no
+// whitespace. Decodes cleanly through CIImage(data:).
+private let tinyPNGBase64 =
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAAAXNSR0IArs4c6QAAAERl"
+    + "WElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAAB"
+    + "AAAAAaADAAQAAAABAAAAAQAAAAD5Ip3+AAAADElEQVQIHWP4z8AAAAMBAQBb2/lEAAAA"
+    + "AElFTkSuQmCC"
+
+private let tinyPNGDataURI = "data:image/png;base64,\(tinyPNGBase64)"
+
+// MARK: - dataFromDataURI
+
+@Test("dataFromDataURI decodes a base64 image payload")
+func vlmDataFromDataURIBase64() throws {
+    let data = try VLMRequestInference.dataFromDataURI(tinyPNGDataURI)
+    // PNG magic number: 89 50 4E 47 0D 0A 1A 0A
+    let magic: [UInt8] = [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]
+    #expect(Array(data.prefix(8)) == magic)
+}
+
+@Test("dataFromDataURI decodes a percent-encoded (non-base64) payload")
+func vlmDataFromDataURIPercentEncoded() throws {
+    let uri = "data:text/plain,hello%20world"
+    let data = try VLMRequestInference.dataFromDataURI(uri)
+    #expect(String(data: data, encoding: .utf8) == "hello world")
+}
+
+@Test("dataFromDataURI tolerates whitespace in base64 payload")
+func vlmDataFromDataURIStripsWhitespace() throws {
+    // Inject newlines/spaces the way some clients line-wrap base64.
+    let wrapped = "data:image/png;base64," + tinyPNGBase64.prefix(40) + "\n  "
+        + tinyPNGBase64.dropFirst(40)
+    let data = try VLMRequestInference.dataFromDataURI(String(wrapped))
+    #expect(data.prefix(4) == Data([0x89, 0x50, 0x4E, 0x47]))
+}
+
+@Test("dataFromDataURI throws on a malformed data: URI (no comma)")
+func vlmDataFromDataURIMalformedThrows() {
+    #expect(throws: VLMRequestInference.MediaError.self) {
+        _ = try VLMRequestInference.dataFromDataURI("data:image/png;base64")
+    }
+}
+
+@Test("dataFromDataURI throws on undecodable base64")
+func vlmDataFromDataURIBadBase64Throws() {
+    #expect(throws: VLMRequestInference.MediaError.self) {
+        _ = try VLMRequestInference.dataFromDataURI("data:image/png;base64,!!!not base64!!!")
+    }
+}
+
+// MARK: - decodeImage
+
+@Test("decodeImage decodes a base64 data: URI into a CIImage")
+func vlmDecodeImageDataURI() throws {
+    let image = try VLMRequestInference.decodeImage(tinyPNGDataURI)
+    guard case .ciImage(let ci) = image else {
+        Issue.record("expected .ciImage, got \(image)")
+        return
+    }
+    #expect(ci.extent.width == 1)
+    #expect(ci.extent.height == 1)
+}
+
+@Test("decodeImage treats a non-data URI as a URL")
+func vlmDecodeImageRemoteURL() throws {
+    let image = try VLMRequestInference.decodeImage("https://example.com/cat.png")
+    guard case .url(let url) = image else {
+        Issue.record("expected .url, got \(image)")
+        return
+    }
+    #expect(url.absoluteString == "https://example.com/cat.png")
+}
+
+@Test("decodeImage throws when a data: URI holds non-image bytes")
+func vlmDecodeImageGarbageThrows() {
+    // Valid base64 but not a decodable image.
+    let garbage = "data:image/png;base64," + Data("not an image".utf8).base64EncodedString()
+    #expect(throws: VLMRequestInference.MediaError.self) {
+        _ = try VLMRequestInference.decodeImage(garbage)
+    }
+}
+
+// MARK: - decodeVideo
+
+@Test("decodeVideo writes an inline data: URI to a tracked temp file")
+func vlmDecodeVideoDataURIWritesTempFile() throws {
+    var tempFiles: [URL] = []
+    let payload = Data("fake mp4 bytes".utf8).base64EncodedString()
+    let uri = "data:video/mp4;base64,\(payload)"
+    let video = try VLMRequestInference.decodeVideo(uri, tempFiles: &tempFiles)
+    guard case .url(let url) = video else {
+        Issue.record("expected .url, got \(video)")
+        return
+    }
+    #expect(tempFiles == [url])
+    #expect(FileManager.default.fileExists(atPath: url.path))
+    #expect(url.pathExtension == "mp4")
+    let written = try Data(contentsOf: url)
+    #expect(String(data: written, encoding: .utf8) == "fake mp4 bytes")
+    // cleanup (production code removes these when the stream ends)
+    try? FileManager.default.removeItem(at: url)
+}
+
+@Test("decodeVideo treats a non-data URI as a URL without writing a temp file")
+func vlmDecodeVideoRemoteURL() throws {
+    var tempFiles: [URL] = []
+    let video = try VLMRequestInference.decodeVideo(
+        "https://example.com/clip.mp4", tempFiles: &tempFiles)
+    guard case .url(let url) = video else {
+        Issue.record("expected .url, got \(video)")
+        return
+    }
+    #expect(url.absoluteString == "https://example.com/clip.mp4")
+    #expect(tempFiles.isEmpty)
+}
+
+// MARK: - hasMedia
+
+@Test("hasMedia is true when a message carries an image_url part")
+func vlmHasMediaImage() {
+    let request = OpenAIChatCompletionRequest(
+        model: "vlm",
+        messages: [
+            .init(
+                role: .user,
+                content: .parts([
+                    .text("What is in this image?"),
+                    .imageURL(tinyPNGDataURI),
+                ]))
+        ])
+    #expect(VLMRequestInference.hasMedia(request))
+}
+
+@Test("hasMedia is true when a message carries a video_url part")
+func vlmHasMediaVideo() {
+    let request = OpenAIChatCompletionRequest(
+        model: "vlm",
+        messages: [
+            .init(
+                role: .user,
+                content: .parts([.videoURL("https://example.com/clip.mp4")]))
+        ])
+    #expect(VLMRequestInference.hasMedia(request))
+}
+
+@Test("hasMedia is false for a plain text request")
+func vlmHasMediaTextFalse() {
+    let request = OpenAIChatCompletionRequest(
+        model: "vlm",
+        messages: [.init(role: .user, content: .text("hello"))])
+    #expect(!VLMRequestInference.hasMedia(request))
+}
+
+@Test("hasMedia is false for parts that are text-only")
+func vlmHasMediaTextPartsFalse() {
+    let request = OpenAIChatCompletionRequest(
+        model: "vlm",
+        messages: [
+            .init(role: .user, content: .parts([.text("hi"), .text(" there")]))
+        ])
+    #expect(!VLMRequestInference.hasMedia(request))
+}
+
+// MARK: - buildUserInput
+
+@Test("buildUserInput collects text + one image into the user message")
+func vlmBuildUserInputTextAndImage() throws {
+    let request = OpenAIChatCompletionRequest(
+        model: "vlm",
+        messages: [
+            .init(role: .system, content: .text("You are a vision assistant.")),
+            .init(
+                role: .user,
+                content: .parts([
+                    .text("Describe "),
+                    .text("this image."),
+                    .imageURL(tinyPNGDataURI),
+                ])),
+        ])
+
+    let userInput = try VLMRequestInference.buildUserInput(from: request)
+
+    // UserInput aggregates media across all chat messages.
+    #expect(userInput.images.count == 1)
+    #expect(userInput.videos.isEmpty)
+
+    guard case .chat(let messages) = userInput.prompt else {
+        Issue.record("expected .chat prompt")
+        return
+    }
+    #expect(messages.count == 2)
+    #expect(messages[0].role == .system)
+    #expect(messages[0].content == "You are a vision assistant.")
+    let user = messages[1]
+    #expect(user.role == .user)
+    // text parts are concatenated in order
+    #expect(user.content == "Describe this image.")
+    #expect(user.images.count == 1)
+    #expect(user.videos.isEmpty)
+}
+
+@Test("buildUserInput keeps a text-only request media-free")
+func vlmBuildUserInputTextOnly() throws {
+    let request = OpenAIChatCompletionRequest(
+        model: "vlm",
+        messages: [.init(role: .user, content: .text("just text"))])
+
+    let userInput = try VLMRequestInference.buildUserInput(from: request)
+    #expect(userInput.images.isEmpty)
+    #expect(userInput.videos.isEmpty)
+    guard case .chat(let messages) = userInput.prompt else {
+        Issue.record("expected .chat prompt")
+        return
+    }
+    #expect(messages.count == 1)
+    #expect(messages[0].content == "just text")
+}


### PR DESCRIPTION
## Summary

Makes the provider serve **image + video (multimodal) inference** through the now-fixed Gemma 4 VLM, **without changing the text path**. Multimodal requests run a separate, non-batched vision path; text-only requests continue through the continuous-batching engine untouched.

Pairs with **Layr-Labs/mlx-swift-lm#34** (the model fix + `video_url` protocol part). This PR bumps the `libs/mlx-swift-lm` submodule to that branch (`98e6ac9`); re-point to the merge commit once #34 lands.

## Why

The provider loaded Gemma 4 as the text-only `MLXLLM.Gemma4Model` and the batching engine carries only `[Int]` token arrays, so image content (already decoded at the protocol layer as `image_url`) was dropped. The fixed `MLXVLM.Gemma4` needs the `container.prepare(UserInput+pixels) → container.generate(LMInput)` path.

## How

- **VLM detection** (`ProviderLoop`): models whose `config.json` declares `vision_config` load via `VLMModelFactory` instead of `LLMModelFactory`. Because `VLMModel: LanguageModel`, the same container still serves **text** through the batched engine — one model copy, no 2× memory, no text-throughput regression. `ModelSlot` + the engine registry/acquire types now carry the `ModelContainer` and an `isVLM` flag.
- **`VLMRequestInference`** (new): builds a `UserInput` from the OpenAI messages — text plus `image_url`/`video_url` parts decoded from `data:` (base64), `http(s)`, or `file:` URIs into `CIImage` / a video URL — then runs `prepare` + `generate` and adapts the `Generation` stream to `MLXServerGenerationEvent`. Routed from `MultiModelBatchSchedulerEngine.streamChatCompletion` **only** when the request carries media **and** the model is a VLM; otherwise the batched path is used verbatim.
- **`video_url` content part** added to the OpenAI chat protocol (in the submodule bump) so clients can attach video.
- **Tests** (`ProviderCoreTests/VLMRequestInferenceTests`): media-URI decoding (base64 / percent / malformed), `hasMedia`, and `buildUserInput`.

## Verification

- `swift build` clean; new tests pass (`swift test --filter VLMRequestInference` → 16 passing); existing scheduler tests unaffected.
- Manually verified end-to-end with the local `gemma-4-26b-a4b-it-4bit`: image (book cover → correct description), the synthetic red-circle/"73" fixture, and a waterfall video clip — all correct (matching the Python `mlx-vlm` reference).

## Notes / follow-ups

- Multimodal requests are non-batched (per-request `prepare`/`generate`); batched multimodal is a deferred optimization.
- Per-frame `MM:SS` timestamp text (present in the Python video prompt) is omitted; video understanding works without it.
- Capacity/memory accounting for the VLM container + per-request pixels, and console-ui image upload, are follow-ups.
- `provider-swift/Sources/vlm-smoke` is a local manual VLM test harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/293"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783614121&installation_id=133247490&pr_number=293&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F293&signature=317f3e3dc4108227082236a210bf60ce9db78e41e10d15988b2093d1e863e6c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->