### PR TITLE
feat(coordinator): admin-gated /data state-export for EigenCloud→GCP migration (DAR-70)

### DIFF
--- a/coordinator/api/admin_state_export.go
+++ b/coordinator/api/admin_state_export.go
@@ -1,7 +1,7 @@
 package api
 
 import (
-	"fmt"
+	"crypto/subtle"
 	"io"
 	"net/http"
 	"os"
@@ -37,26 +37,39 @@ func resolveStateExportRoot() string {
 	)
 }
 
+// envTrue reports whether the named env var is set to "true" (case-insensitive,
+// trimmed). Used for the boolean state-export gates.
+func envTrue(name string) bool {
+	return strings.EqualFold(strings.TrimSpace(os.Getenv(name)), "true")
+}
+
 // handleAdminStateExport handles GET /v1/admin/state-export — it streams a
 // consistent (and, by default, encrypted) archive of the coordinator's sealed
 // on-disk state under /data for migration off EigenCloud (DAR-70).
 //
 // Triple gate, fail-closed, in order:
 //  1. master switch (404 when off — route stays invisible/inert),
-//  2. admin auth (s.isAdminAuthorized writes its own 403),
+//  2. admin auth (admin-key only; Privy admin is intentionally NOT accepted),
 //  3. output protection (encrypt to recipient, else 412 unless plaintext allowed).
 func (s *Server) handleAdminStateExport(w http.ResponseWriter, r *http.Request) {
 	start := time.Now()
 
 	// (a) Master switch — 404 when disabled so the route is indistinguishable
 	// from an unregistered path.
-	if !strings.EqualFold(strings.TrimSpace(os.Getenv(envStateExportEnabled)), "true") {
+	if !envTrue(envStateExportEnabled) {
 		http.NotFound(w, r)
 		return
 	}
 
-	// (b) Admin auth — writes 403 itself on failure.
-	if !s.isAdminAuthorized(w, r) {
+	// (b) Admin auth — ADMIN KEY ONLY (constant-time), modeled on
+	// requireAdminKey's bearer-token check. This endpoint exfils the CA private
+	// key, so we deliberately do NOT accept the Privy-admin path: a compromised
+	// Privy admin email must not be able to pull the CA key. (The route is also
+	// not wrapped in Privy auth middleware, so auth.UserFromContext is nil here
+	// regardless.)
+	token := extractBearerToken(r)
+	if !(s.adminKey != "" && subtle.ConstantTimeCompare([]byte(token), []byte(s.adminKey)) == 1) {
+		writeJSON(w, http.StatusForbidden, errorResponse("forbidden", "admin access required"))
 		s.logger.Warn("state-export: unauthorized access attempt",
 			"remote_addr", r.RemoteAddr, "authorized", false)
 		return
@@ -64,7 +77,7 @@ func (s *Server) handleAdminStateExport(w http.ResponseWriter, r *http.Request) 
 
 	// (c) Output protection. Encrypted by default.
 	recipientStr := strings.TrimSpace(os.Getenv(envStateExportRecipient))
-	allowPlaintext := strings.EqualFold(strings.TrimSpace(os.Getenv(envStateExportAllowPlaintext)), "true")
+	allowPlaintext := envTrue(envStateExportAllowPlaintext)
 	encrypted := recipientStr != ""
 
 	if !encrypted && !allowPlaintext {
@@ -76,15 +89,9 @@ func (s *Server) handleAdminStateExport(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
+	// Stage (below) resolves (EvalSymlinks) + stats the root and returns a clean
+	// error mapped to a pre-stream 500, so no separate os.Stat pre-check here.
 	root := resolveStateExportRoot()
-	if info, err := os.Stat(root); err != nil || !info.IsDir() {
-		writeJSON(w, http.StatusInternalServerError, errorResponse("export_error",
-			"state export root is unavailable"))
-		s.logger.Error("state-export: root unavailable",
-			"remote_addr", r.RemoteAddr, "authorized", true, "encrypted", encrypted,
-			"root", root, "error", fmt.Sprint(err))
-		return
-	}
 
 	// Compute the download filename / content-type BEFORE writing headers.
 	epoch := strconv.FormatInt(time.Now().Unix(), 10)
@@ -118,7 +125,10 @@ func (s *Server) handleAdminStateExport(w http.ResponseWriter, r *http.Request) 
 	// the whole export up front.
 	arch := stateexport.NewArchiver()
 	arch.Logger = s.logger
-	staged, stageErr := arch.Stage(root)
+	// Propagate the request context (no artificial deadline — a legit large
+	// export must not be truncated by a timer) so a client disconnect cancels the
+	// snapshot/walk cleanly.
+	staged, stageErr := arch.Stage(r.Context(), root)
 	if stageErr != nil {
 		writeJSON(w, http.StatusInternalServerError, errorResponse("export_error",
 			"state export could not produce a consistent snapshot"))
@@ -156,7 +166,7 @@ func (s *Server) handleAdminStateExport(w http.ResponseWriter, r *http.Request) 
 		sink = aw
 	}
 
-	res, archErr := arch.Write(staged, sink)
+	res, archErr := arch.Write(r.Context(), staged, sink)
 
 	// For encrypted streams, MUST close the age writer to flush the final chunk.
 	if ageWriter != nil {

--- a/coordinator/api/admin_state_export.go
+++ b/coordinator/api/admin_state_export.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"crypto/sha256"
 	"crypto/subtle"
 	"io"
 	"net/http"
@@ -69,7 +70,14 @@ func (s *Server) handleAdminStateExport(w http.ResponseWriter, r *http.Request) 
 	// not wrapped in Privy auth middleware, so auth.UserFromContext is nil here
 	// regardless.)
 	token := extractBearerToken(r)
-	if !(s.adminKey != "" && subtle.ConstantTimeCompare([]byte(token), []byte(s.adminKey)) == 1) {
+	// Hash both sides to a fixed 32 bytes before the constant-time compare so the
+	// check leaks neither the admin key's contents nor its length. (A bare
+	// ConstantTimeCompare returns early when the two byte slices differ in
+	// length — a minor timing side-channel on key length. This is the CA-key
+	// exfil endpoint, so close it.)
+	providedDigest := sha256.Sum256([]byte(token))
+	expectedDigest := sha256.Sum256([]byte(s.adminKey))
+	if s.adminKey == "" || subtle.ConstantTimeCompare(providedDigest[:], expectedDigest[:]) != 1 {
 		writeJSON(w, http.StatusForbidden, errorResponse("forbidden", "admin access required"))
 		s.logger.Warn("state-export: unauthorized access attempt",
 			"remote_addr", r.RemoteAddr, "authorized", false)

--- a/coordinator/api/admin_state_export.go
+++ b/coordinator/api/admin_state_export.go
@@ -40,7 +40,8 @@ func resolveStateExportRoot() string {
 // envTrue reports whether the named env var is set to "true" (case-insensitive,
 // trimmed). Used for the boolean state-export gates.
 func envTrue(name string) bool {
-	return strings.EqualFold(strings.TrimSpace(os.Getenv(name)), "true")
+	b, _ := strconv.ParseBool(strings.TrimSpace(os.Getenv(name)))
+	return b
 }
 
 // handleAdminStateExport handles GET /v1/admin/state-export — it streams a

--- a/coordinator/api/admin_state_export.go
+++ b/coordinator/api/admin_state_export.go
@@ -1,0 +1,199 @@
+package api
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/env"
+	"github.com/eigeninference/d-inference/coordinator/stateexport"
+)
+
+// State-export env vars (all namespaced under env.EnvPrefix == "EIGENINFERENCE").
+const (
+	// envStateExportEnabled is the master switch. When != "true" the route 404s.
+	envStateExportEnabled = env.EnvPrefix + "_STATE_EXPORT_ENABLED"
+	// envStateExportRecipient is an age recipient ("age1..."). When set, output is
+	// encrypted to it; this is the default-secure path.
+	envStateExportRecipient = env.EnvPrefix + "_STATE_EXPORT_RECIPIENT"
+	// envStateExportAllowPlaintext permits a raw (unencrypted) zip ONLY when no
+	// recipient is configured. Must be explicitly "true".
+	envStateExportAllowPlaintext = env.EnvPrefix + "_STATE_EXPORT_ALLOW_PLAINTEXT"
+	// envStateExportRoot overrides the export root (primarily for tests).
+	envStateExportRoot = env.EnvPrefix + "_STATE_EXPORT_ROOT"
+)
+
+// resolveStateExportRoot picks the directory to archive:
+// EIGENINFERENCE_STATE_EXPORT_ROOT -> USER_PERSISTENT_DATA_PATH -> /mnt/disks/userdata.
+func resolveStateExportRoot() string {
+	return env.FirstNonEmpty(
+		os.Getenv(envStateExportRoot),
+		os.Getenv("USER_PERSISTENT_DATA_PATH"),
+		"/mnt/disks/userdata",
+	)
+}
+
+// handleAdminStateExport handles GET /v1/admin/state-export — it streams a
+// consistent (and, by default, encrypted) archive of the coordinator's sealed
+// on-disk state under /data for migration off EigenCloud (DAR-70).
+//
+// Triple gate, fail-closed, in order:
+//  1. master switch (404 when off — route stays invisible/inert),
+//  2. admin auth (s.isAdminAuthorized writes its own 403),
+//  3. output protection (encrypt to recipient, else 412 unless plaintext allowed).
+func (s *Server) handleAdminStateExport(w http.ResponseWriter, r *http.Request) {
+	start := time.Now()
+
+	// (a) Master switch — 404 when disabled so the route is indistinguishable
+	// from an unregistered path.
+	if !strings.EqualFold(strings.TrimSpace(os.Getenv(envStateExportEnabled)), "true") {
+		http.NotFound(w, r)
+		return
+	}
+
+	// (b) Admin auth — writes 403 itself on failure.
+	if !s.isAdminAuthorized(w, r) {
+		s.logger.Warn("state-export: unauthorized access attempt",
+			"remote_addr", r.RemoteAddr, "authorized", false)
+		return
+	}
+
+	// (c) Output protection. Encrypted by default.
+	recipientStr := strings.TrimSpace(os.Getenv(envStateExportRecipient))
+	allowPlaintext := strings.EqualFold(strings.TrimSpace(os.Getenv(envStateExportAllowPlaintext)), "true")
+	encrypted := recipientStr != ""
+
+	if !encrypted && !allowPlaintext {
+		writeJSON(w, http.StatusPreconditionFailed, errorResponse("precondition_failed",
+			"set "+envStateExportRecipient+" to an age recipient, or set "+
+				envStateExportAllowPlaintext+"=true to download unencrypted"))
+		s.logger.Warn("state-export: refused (no recipient, plaintext not allowed)",
+			"remote_addr", r.RemoteAddr, "authorized", true, "encrypted", false)
+		return
+	}
+
+	root := resolveStateExportRoot()
+	if info, err := os.Stat(root); err != nil || !info.IsDir() {
+		writeJSON(w, http.StatusInternalServerError, errorResponse("export_error",
+			"state export root is unavailable"))
+		s.logger.Error("state-export: root unavailable",
+			"remote_addr", r.RemoteAddr, "authorized", true, "encrypted", encrypted,
+			"root", root, "error", fmt.Sprint(err))
+		return
+	}
+
+	// Compute the download filename / content-type BEFORE writing headers.
+	epoch := strconv.FormatInt(time.Now().Unix(), 10)
+	var filename, contentType string
+	if encrypted {
+		filename = "darkbloom-state-" + epoch + ".zip.age"
+		contentType = "application/octet-stream"
+	} else {
+		filename = "darkbloom-state-" + epoch + ".zip"
+		contentType = "application/zip"
+	}
+
+	// Validate the recipient up front (before any header is written) so a parse
+	// failure is a clean 500 rather than a half-written stream.
+	if encrypted {
+		if err := stateexport.ValidateRecipient(recipientStr); err != nil {
+			writeJSON(w, http.StatusInternalServerError, errorResponse("export_error",
+				"state export recipient is misconfigured"))
+			// Do not log the recipient material; log only that parsing failed.
+			s.logger.Error("state-export: recipient parse failed",
+				"remote_addr", r.RemoteAddr, "authorized", true, "encrypted", true)
+			return
+		}
+	}
+
+	// PHASE A — snapshot+validate every *.db into a controlled staging dir BEFORE
+	// writing any response status/bytes. Any failure here is fail-clean: we emit a
+	// real 500 and the client gets ZERO archive bytes. This is what closes the
+	// "partial archive after 200" + "/tmp leak" findings: copies live in one
+	// staging dir we always RemoveAll, and a torn db that can't snapshot aborts
+	// the whole export up front.
+	arch := stateexport.NewArchiver()
+	arch.Logger = s.logger
+	staged, stageErr := arch.Stage(root)
+	if stageErr != nil {
+		writeJSON(w, http.StatusInternalServerError, errorResponse("export_error",
+			"state export could not produce a consistent snapshot"))
+		s.logger.Error("state-export: staging failed (no bytes written)",
+			"remote_addr", r.RemoteAddr, "authorized", true, "encrypted", encrypted,
+			"root", root, "error", stageErr.Error())
+		return
+	}
+	// Always release the staging dir + validated db copies, even on a mid-stream
+	// failure or panic.
+	defer staged.Cleanup()
+
+	// PHASE B — only now commit to a 200 and stream the zip.
+	w.Header().Set("Content-Type", contentType)
+	w.Header().Set("Content-Disposition", `attachment; filename="`+filename+`"`)
+	w.WriteHeader(http.StatusOK)
+
+	// Writer chain (streamed, never buffered):
+	//   archiver -> [age encrypt] -> countingWriter -> http.ResponseWriter
+	// The counter wraps the response so it tallies the actual bytes sent to the
+	// client (ciphertext when encrypted).
+	counter := &countingWriter{w: w}
+
+	var sink io.Writer = counter
+	var ageWriter io.WriteCloser
+	if encrypted {
+		aw, err := stateexport.EncryptWriter(counter, recipientStr)
+		if err != nil {
+			// Headers already sent; we can only abort the stream.
+			s.logger.Error("state-export: age writer init failed after headers",
+				"remote_addr", r.RemoteAddr, "error", err.Error())
+			return
+		}
+		ageWriter = aw
+		sink = aw
+	}
+
+	res, archErr := arch.Write(staged, sink)
+
+	// For encrypted streams, MUST close the age writer to flush the final chunk.
+	if ageWriter != nil {
+		if cerr := ageWriter.Close(); cerr != nil && archErr == nil {
+			archErr = cerr
+		}
+	}
+
+	if archErr != nil {
+		// Headers/body already in flight — cannot change status. Log the failure;
+		// the truncated stream signals the error to the client.
+		s.logger.Error("state-export: archive failed mid-stream",
+			"remote_addr", r.RemoteAddr, "authorized", true, "encrypted", encrypted,
+			"bytes", counter.n, "files", res.Files, "error", archErr.Error())
+		return
+	}
+
+	s.logger.Info("state-export: completed",
+		"remote_addr", r.RemoteAddr,
+		"authorized", true,
+		"encrypted", encrypted,
+		"files", res.Files,
+		"snapshotted_dbs", res.SnapshottedDBs,
+		"bytes", counter.n,
+		"duration_ms", time.Since(start).Milliseconds(),
+		"outcome", "ok",
+	)
+}
+
+// countingWriter tallies bytes written for the audit log without buffering.
+type countingWriter struct {
+	w io.Writer
+	n int64
+}
+
+func (c *countingWriter) Write(p []byte) (int, error) {
+	n, err := c.w.Write(p)
+	c.n += int64(n)
+	return n, err
+}

--- a/coordinator/api/admin_state_export_test.go
+++ b/coordinator/api/admin_state_export_test.go
@@ -1,0 +1,505 @@
+package api
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"filippo.io/age"
+	bolt "go.etcd.io/bbolt"
+
+	"github.com/eigeninference/d-inference/coordinator/registry"
+	"github.com/eigeninference/d-inference/coordinator/store"
+)
+
+// notZip reports whether b is NOT a zip (no PK\x03\x04 magic). A negative-path
+// response (401/403/404/412/500) must contain ZERO archive bytes.
+func notZip(b []byte) bool {
+	return !bytes.HasPrefix(b, []byte("PK\x03\x04"))
+}
+
+const stateExportAdminKey = "dar70-admin-key"
+
+// newStateExportServer builds a real Server with the admin key set, wired to a
+// fresh export root. It returns the httptest server URL and the export root.
+func newStateExportServer(t *testing.T) (*httptest.Server, string) {
+	t.Helper()
+	logger := quietLogger()
+	srv := NewServer(registry.New(logger), store.NewMemory(store.Config{}), ServerConfig{}, logger)
+	srv.SetAdminKey(stateExportAdminKey)
+
+	root := buildStateExportRoot(t)
+	t.Setenv(envStateExportRoot, root)
+
+	ts := httptest.NewServer(srv.Handler())
+	t.Cleanup(ts.Close)
+	return ts, root
+}
+
+// buildStateExportRoot lays down a representative /data tree with a real bbolt db.
+func buildStateExportRoot(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+
+	writeFile(t, filepath.Join(root, "step-ca", "config", "ca.json"), `{"authority":{}}`)
+	writeFile(t, filepath.Join(root, "step-ca", "secrets", "password"), "eigeninference-step-ca")
+	writeFile(t, filepath.Join(root, "step-ca", "certs", "root_ca.crt"), "ROOT")
+	writeFile(t, filepath.Join(root, "step-ca", "certs", "intermediate_ca.crt"), "INT")
+	writeFile(t, filepath.Join(root, "step-ca", "certs", "intermediate_ca_key"), "INTKEY")
+
+	writeFile(t, filepath.Join(root, "micromdm", "push.crt"), "PUSH")
+	writeFile(t, filepath.Join(root, "micromdm", "push.key"), "PUSHKEY")
+	writeFile(t, filepath.Join(root, "micromdm", "config"), "CFG")
+	writeFile(t, filepath.Join(root, "micromdm", ".push_imported"), "")
+	seedBolt(t, filepath.Join(root, "micromdm", "micromdm.db"))
+
+	writeFile(t, filepath.Join(root, "step-ca.log"), "log")
+	writeFile(t, filepath.Join(root, "micromdm", "micromdm.log"), "log")
+
+	return root
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func seedBolt(t *testing.T, path string) {
+	t.Helper()
+	db, err := bolt.Open(path, 0o600, &bolt.Options{Timeout: time.Second})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	if err := db.Update(func(tx *bolt.Tx) error {
+		b, err := tx.CreateBucketIfNotExists([]byte("Devices"))
+		if err != nil {
+			return err
+		}
+		return b.Put([]byte("serial-1"), []byte("payload-1"))
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func getExport(t *testing.T, url, bearer string) *http.Response {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodGet, url+"/v1/admin/state-export", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bearer != "" {
+		req.Header.Set("Authorization", "Bearer "+bearer)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return resp
+}
+
+func zipEntries(t *testing.T, b []byte) map[string][]byte {
+	t.Helper()
+	zr, err := zip.NewReader(bytes.NewReader(b), int64(len(b)))
+	if err != nil {
+		t.Fatalf("open zip: %v", err)
+	}
+	out := map[string][]byte{}
+	for _, f := range zr.File {
+		if f.FileInfo().IsDir() {
+			continue
+		}
+		rc, _ := f.Open()
+		data, _ := io.ReadAll(rc)
+		rc.Close()
+		out[f.Name] = data
+	}
+	return out
+}
+
+// assertNoArchiveBytes reads the whole body and fails if it looks like a zip.
+func assertNoArchiveBytes(t *testing.T, resp *http.Response) {
+	t.Helper()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	if !notZip(body) {
+		t.Fatalf("negative response (%d) leaked archive bytes (%d bytes, zip magic present)",
+			resp.StatusCode, len(body))
+	}
+}
+
+// (a) 404 when the master switch is unset — and no archive bytes.
+func TestStateExport_DisabledReturns404_DAR70(t *testing.T) {
+	ts, _ := newStateExportServer(t)
+	// envStateExportEnabled deliberately not set.
+	resp := getExport(t, ts.URL, stateExportAdminKey)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("disabled: got %d, want 404", resp.StatusCode)
+	}
+	assertNoArchiveBytes(t, resp)
+}
+
+// Disabled + missing/wrong admin key still 404 — the route is invisible
+// regardless of auth (master switch precedes auth).
+func TestStateExport_DisabledMasksAuth404_DAR70(t *testing.T) {
+	ts, _ := newStateExportServer(t)
+	// envStateExportEnabled deliberately not set.
+	for _, key := range []string{"", "wrong-key"} {
+		resp := getExport(t, ts.URL, key)
+		if resp.StatusCode != http.StatusNotFound {
+			resp.Body.Close()
+			t.Fatalf("disabled with key=%q: got %d, want 404", key, resp.StatusCode)
+		}
+		assertNoArchiveBytes(t, resp)
+		resp.Body.Close()
+	}
+}
+
+// (b) 403 with missing/wrong admin key; success with the correct key. Negative
+// responses must contain zero archive bytes.
+func TestStateExport_AdminAuth_DAR70(t *testing.T) {
+	ts, _ := newStateExportServer(t)
+	t.Setenv(envStateExportEnabled, "true")
+	t.Setenv(envStateExportAllowPlaintext, "true")
+
+	// Missing key.
+	resp := getExport(t, ts.URL, "")
+	if resp.StatusCode != http.StatusForbidden {
+		resp.Body.Close()
+		t.Fatalf("missing key: got %d, want 403", resp.StatusCode)
+	}
+	assertNoArchiveBytes(t, resp)
+	resp.Body.Close()
+
+	// Wrong key.
+	resp = getExport(t, ts.URL, "wrong-key")
+	if resp.StatusCode != http.StatusForbidden {
+		resp.Body.Close()
+		t.Fatalf("wrong key: got %d, want 403", resp.StatusCode)
+	}
+	assertNoArchiveBytes(t, resp)
+	resp.Body.Close()
+
+	// Correct key.
+	resp = getExport(t, ts.URL, stateExportAdminKey)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("correct key: got %d, want 200", resp.StatusCode)
+	}
+}
+
+// (c) 412 when no recipient and plaintext not allowed — and no archive bytes.
+func TestStateExport_PreconditionFailed_DAR70(t *testing.T) {
+	ts, _ := newStateExportServer(t)
+	t.Setenv(envStateExportEnabled, "true")
+	// No recipient, no plaintext allowance.
+	resp := getExport(t, ts.URL, stateExportAdminKey)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusPreconditionFailed {
+		t.Fatalf("got %d, want 412", resp.StatusCode)
+	}
+	assertNoArchiveBytes(t, resp)
+}
+
+// HTTP-level root-missing -> 500 with no archive bytes (root resolves to a path
+// that does not exist).
+func TestStateExport_RootMissing500_DAR70(t *testing.T) {
+	logger := quietLogger()
+	srv := NewServer(registry.New(logger), store.NewMemory(store.Config{}), ServerConfig{}, logger)
+	srv.SetAdminKey(stateExportAdminKey)
+	ts := httptest.NewServer(srv.Handler())
+	t.Cleanup(ts.Close)
+
+	t.Setenv(envStateExportRoot, filepath.Join(t.TempDir(), "does-not-exist"))
+	t.Setenv(envStateExportEnabled, "true")
+	t.Setenv(envStateExportAllowPlaintext, "true")
+
+	resp := getExport(t, ts.URL, stateExportAdminKey)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("missing root: got %d, want 500", resp.StatusCode)
+	}
+	assertNoArchiveBytes(t, resp)
+}
+
+// resolveStateExportRoot precedence:
+// EIGENINFERENCE_STATE_EXPORT_ROOT -> USER_PERSISTENT_DATA_PATH -> /mnt/disks/userdata.
+func TestResolveStateExportRootPrecedence_DAR70(t *testing.T) {
+	// Default when nothing is set.
+	t.Setenv(envStateExportRoot, "")
+	t.Setenv("USER_PERSISTENT_DATA_PATH", "")
+	if got := resolveStateExportRoot(); got != "/mnt/disks/userdata" {
+		t.Fatalf("default = %q, want /mnt/disks/userdata", got)
+	}
+	// USER_PERSISTENT_DATA_PATH wins over the hardcoded default.
+	t.Setenv("USER_PERSISTENT_DATA_PATH", "/persist")
+	if got := resolveStateExportRoot(); got != "/persist" {
+		t.Fatalf("with USER_PERSISTENT_DATA_PATH = %q, want /persist", got)
+	}
+	// Explicit override wins over everything.
+	t.Setenv(envStateExportRoot, "/explicit")
+	if got := resolveStateExportRoot(); got != "/explicit" {
+		t.Fatalf("with override = %q, want /explicit", got)
+	}
+}
+
+// HTTP-level encrypted export through a SYMLINKED root still captures children
+// (mirrors prod start.sh `ln -sfn $PERSIST /data`).
+func TestStateExport_SymlinkedRoot_DAR70(t *testing.T) {
+	logger := quietLogger()
+	srv := NewServer(registry.New(logger), store.NewMemory(store.Config{}), ServerConfig{}, logger)
+	srv.SetAdminKey(stateExportAdminKey)
+	ts := httptest.NewServer(srv.Handler())
+	t.Cleanup(ts.Close)
+
+	real := buildStateExportRoot(t)
+	link := filepath.Join(t.TempDir(), "data-link")
+	if err := os.Symlink(real, link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+	t.Setenv(envStateExportRoot, link)
+	t.Setenv(envStateExportEnabled, "true")
+	t.Setenv(envStateExportAllowPlaintext, "true")
+
+	resp := getExport(t, ts.URL, stateExportAdminKey)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("symlinked root: got %d, want 200", resp.StatusCode)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	files := zipEntries(t, body)
+	if _, ok := files["micromdm/micromdm.db"]; !ok {
+		t.Fatal("symlinked-root archive missing micromdm.db (EvalSymlinks not applied)")
+	}
+}
+
+// (d) plaintext allowed -> valid zip; tree matches, *.log excluded,
+// .push_imported included, bolt db opens ReadOnly with intact buckets/keys.
+func TestStateExport_PlaintextZip_DAR70(t *testing.T) {
+	ts, _ := newStateExportServer(t)
+	t.Setenv(envStateExportEnabled, "true")
+	t.Setenv(envStateExportAllowPlaintext, "true")
+
+	resp := getExport(t, ts.URL, stateExportAdminKey)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("got %d, want 200", resp.StatusCode)
+	}
+	if ct := resp.Header.Get("Content-Type"); ct != "application/zip" {
+		t.Fatalf("content-type = %q, want application/zip", ct)
+	}
+	if cd := resp.Header.Get("Content-Disposition"); !bytes.Contains([]byte(cd), []byte(".zip\"")) {
+		t.Fatalf("content-disposition = %q, want a .zip filename", cd)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	files := zipEntries(t, body)
+
+	for _, name := range []string{
+		"step-ca/config/ca.json",
+		"step-ca/secrets/password",
+		"micromdm/push.crt",
+		"micromdm/.push_imported",
+		"micromdm/micromdm.db",
+	} {
+		if _, ok := files[name]; !ok {
+			t.Errorf("missing %q in archive", name)
+		}
+	}
+	for _, name := range []string{"step-ca.log", "micromdm/micromdm.log"} {
+		if _, ok := files[name]; ok {
+			t.Errorf("%q should be excluded", name)
+		}
+	}
+
+	// The bolt db in the zip opens ReadOnly with intact data.
+	dbBytes := files["micromdm/micromdm.db"]
+	tmp := filepath.Join(t.TempDir(), "out.db")
+	if err := os.WriteFile(tmp, dbBytes, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	db, err := bolt.Open(tmp, 0o400, &bolt.Options{ReadOnly: true, Timeout: 2 * time.Second})
+	if err != nil {
+		t.Fatalf("open extracted db: %v", err)
+	}
+	defer db.Close()
+	if err := db.View(func(tx *bolt.Tx) error {
+		b := tx.Bucket([]byte("Devices"))
+		if b == nil {
+			t.Fatal("Devices bucket missing")
+		}
+		if got := b.Get([]byte("serial-1")); !bytes.Equal(got, []byte("payload-1")) {
+			t.Fatalf("serial-1 = %q, want payload-1", got)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// (e) recipient set -> output is an age stream that decrypts to a valid zip.
+func TestStateExport_EncryptedToRecipient_DAR70(t *testing.T) {
+	ts, _ := newStateExportServer(t)
+	id, err := age.GenerateX25519Identity()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(envStateExportEnabled, "true")
+	t.Setenv(envStateExportRecipient, id.Recipient().String())
+
+	resp := getExport(t, ts.URL, stateExportAdminKey)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("got %d, want 200", resp.StatusCode)
+	}
+	if ct := resp.Header.Get("Content-Type"); ct != "application/octet-stream" {
+		t.Fatalf("content-type = %q, want application/octet-stream", ct)
+	}
+	if cd := resp.Header.Get("Content-Disposition"); !bytes.Contains([]byte(cd), []byte(".zip.age\"")) {
+		t.Fatalf("content-disposition = %q, want a .zip.age filename", cd)
+	}
+
+	cipher, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Must NOT be a plain zip (PK\x03\x04 magic).
+	if bytes.HasPrefix(cipher, []byte("PK\x03\x04")) {
+		t.Fatal("output looks like a plain zip — encryption did not happen")
+	}
+
+	dr, err := age.Decrypt(bytes.NewReader(cipher), id)
+	if err != nil {
+		t.Fatalf("decrypt: %v", err)
+	}
+	plain, err := io.ReadAll(dr)
+	if err != nil {
+		t.Fatalf("read decrypted: %v", err)
+	}
+	files := zipEntries(t, plain)
+	if _, ok := files["micromdm/micromdm.db"]; !ok {
+		t.Fatal("decrypted archive missing micromdm.db")
+	}
+	if _, ok := files["step-ca/config/ca.json"]; !ok {
+		t.Fatal("decrypted archive missing ca.json")
+	}
+}
+
+// (f) consistency: continuous writes to the LIVE db during export; the snapshot
+// in the (decrypted) zip must open and pass Check().
+func TestStateExport_ConsistencyUnderWrites_DAR70(t *testing.T) {
+	ts, root := newStateExportServer(t)
+	id, err := age.GenerateX25519Identity()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(envStateExportEnabled, "true")
+	t.Setenv(envStateExportRecipient, id.Recipient().String())
+
+	// Open the live db RW and hammer it with writes (mirrors MicroMDM).
+	dbPath := filepath.Join(root, "micromdm", "micromdm.db")
+	live, err := bolt.Open(dbPath, 0o600, &bolt.Options{Timeout: time.Second})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer live.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
+			_ = live.Update(func(tx *bolt.Tx) error {
+				b, err := tx.CreateBucketIfNotExists([]byte("Churn"))
+				if err != nil {
+					return err
+				}
+				return b.Put([]byte("k"), []byte(time.Now().String()))
+			})
+		}
+	}()
+
+	resp := getExport(t, ts.URL, stateExportAdminKey)
+	cipher, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	cancel()
+	wg.Wait()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("got %d, want 200", resp.StatusCode)
+	}
+	dr, err := age.Decrypt(bytes.NewReader(cipher), id)
+	if err != nil {
+		t.Fatalf("decrypt: %v", err)
+	}
+	plain, err := io.ReadAll(dr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	files := zipEntries(t, plain)
+	dbBytes, ok := files["micromdm/micromdm.db"]
+	if !ok {
+		t.Fatal("snapshot db missing from archive")
+	}
+	tmp := filepath.Join(t.TempDir(), "snap.db")
+	if err := os.WriteFile(tmp, dbBytes, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// Validate with a recover-wrapped walk, NOT tx.Check(): on a genuinely torn
+	// copy Check() panics in an internal goroutine and would crash the whole
+	// `go test` binary instead of failing this test.
+	if err := validateBoltCopy(tmp); err != nil {
+		t.Fatalf("snapshot in archive failed validation: %v", err)
+	}
+}
+
+// validateBoltCopy opens a bolt copy ReadOnly and walks every bucket, recovering
+// from any panic (a torn copy can fault the mmap walk). It mirrors the
+// production validator in package stateexport but lives here because that
+// validator is unexported.
+func validateBoltCopy(path string) (retErr error) {
+	defer func() {
+		if rec := recover(); rec != nil {
+			retErr = fmt.Errorf("bolt validation panicked (torn/corrupt copy): %v", rec)
+		}
+	}()
+	db, err := bolt.Open(path, 0o400, &bolt.Options{ReadOnly: true, Timeout: 2 * time.Second})
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+	return db.View(func(tx *bolt.Tx) error {
+		return tx.ForEach(func(_ []byte, b *bolt.Bucket) error {
+			return b.ForEach(func(_, _ []byte) error { return nil })
+		})
+	})
+}

--- a/coordinator/api/server.go
+++ b/coordinator/api/server.go
@@ -1453,6 +1453,13 @@ func (s *Server) routes() {
 	s.mux.HandleFunc("GET /v1/admin/releases", s.handleAdminListReleases)     // admin key or Privy admin
 	s.mux.HandleFunc("DELETE /v1/admin/releases", s.handleAdminDeleteRelease) // admin key or Privy admin
 
+	// Admin state export (DAR-70) — streams the TEE-sealed /data archive
+	// (step-ca + MicroMDM) for migration off EigenCloud. Always registered, but
+	// inert (404) unless EIGENINFERENCE_STATE_EXPORT_ENABLED=true; admin-gated;
+	// encrypted to an age recipient by default. Auth + output protection are
+	// enforced inside the handler.
+	s.mux.HandleFunc("GET /v1/admin/state-export", s.handleAdminStateExport)
+
 	// Admin CLI auth — Privy email OTP for getting admin tokens without a browser.
 	s.mux.HandleFunc("POST /v1/admin/auth/init", s.handleAdminAuthInit)     // no auth (sends OTP)
 	s.mux.HandleFunc("POST /v1/admin/auth/verify", s.handleAdminAuthVerify) // no auth (returns token)

--- a/coordinator/stateexport/archive.go
+++ b/coordinator/stateexport/archive.go
@@ -72,15 +72,16 @@ func (s *StagedExport) Cleanup() {
 	s.stagingDir = ""
 }
 
-// isLog reports whether the file should be excluded as a log file.
-func isLog(name string) bool {
-	return strings.EqualFold(filepath.Ext(name), ".log")
+// hasExtension reports whether name has the given extension (case-insensitive).
+func hasExtension(name, ext string) bool {
+	return strings.EqualFold(filepath.Ext(name), ext)
 }
 
+// isLog reports whether the file should be excluded as a log file.
+func isLog(name string) bool { return hasExtension(name, ".log") }
+
 // isBoltDB reports whether the file is a BoltDB database (by extension).
-func isBoltDB(name string) bool {
-	return strings.EqualFold(filepath.Ext(name), ".db")
-}
+func isBoltDB(name string) bool { return hasExtension(name, ".db") }
 
 // Stage performs Phase A: it resolves the (possibly symlinked) root, snapshots
 // and validates every *.db under it into a freshly-created 0700 staging dir, and
@@ -140,7 +141,8 @@ func (a *Archiver) Stage(ctx context.Context, root string) (*StagedExport, error
 	// entry that Phase B would WRITE — regular files AND *.db (dirs, symlinks, and
 	// *.log are not written and not counted).
 	fileCount := 0
-	micromdmDirSeen := false
+	micromdmDir := ""    // resolved path of the micromdm dir, if present
+	micromdmDBCount := 0 // *.db snapshots taken INSIDE micromdm/
 
 	walkErr := filepath.WalkDir(resolved, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
@@ -156,7 +158,7 @@ func (a *Archiver) Stage(ctx context.Context, root string) (*StagedExport, error
 		}
 		if d.IsDir() {
 			if d.Name() == "micromdm" {
-				micromdmDirSeen = true
+				micromdmDir = path
 			}
 			// step-ca's default standalone DB is a Badger DIRECTORY at
 			// step-ca/db/, NOT a *.db file. We deliberately do NOT snapshot it:
@@ -186,6 +188,13 @@ func (a *Archiver) Stage(ctx context.Context, root string) (*StagedExport, error
 		}
 		staged.dbSnapshots[path] = tmpPath
 		fileCount++ // *.db is written in Phase B from its staging snapshot
+		// Count *.db snapshots taken INSIDE the micromdm dir specifically. The
+		// fail-loud guard below must require MicroMDM's OWN database — a stray db
+		// elsewhere under the root must not mask a missing MicroMDM db and let us
+		// ship an archive without it.
+		if micromdmDir != "" && strings.HasPrefix(path, micromdmDir+string(filepath.Separator)) {
+			micromdmDBCount++
+		}
 		return nil
 	})
 	if walkErr != nil {
@@ -204,13 +213,13 @@ func (a *Archiver) Stage(ctx context.Context, root string) (*StagedExport, error
 		staged.Cleanup()
 		return nil, fmt.Errorf("export captured 0 files under %q (empty or unreadable root)", resolved)
 	}
-	if micromdmDirSeen && len(staged.dbSnapshots) == 0 {
+	if micromdmDir != "" && micromdmDBCount == 0 {
 		if staged.logger != nil {
-			staged.logger.Warn("state-export: micromdm dir present but ZERO db snapshots captured — refusing to stage",
-				"root", resolved)
+			staged.logger.Warn("state-export: micromdm dir present but its BoltDB was not snapshotted — refusing to stage",
+				"root", resolved, "micromdm_dir", micromdmDir)
 		}
 		staged.Cleanup()
-		return nil, fmt.Errorf("micromdm dir present under %q but 0 db snapshots captured", resolved)
+		return nil, fmt.Errorf("micromdm dir present under %q but its BoltDB (*.db inside micromdm/) was not snapshotted", resolved)
 	}
 
 	return staged, nil

--- a/coordinator/stateexport/archive.go
+++ b/coordinator/stateexport/archive.go
@@ -2,9 +2,11 @@ package stateexport
 
 import (
 	"archive/zip"
+	"context"
 	"fmt"
 	"io"
 	"io/fs"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -18,13 +20,6 @@ type ArchiveResult struct {
 	// SnapshottedDBs is the number of *.db files that went through the
 	// hot-copy+validate bolt snapshotter.
 	SnapshottedDBs int
-}
-
-// Logger is the minimal logging surface the archiver needs. It matches the
-// shape of *slog.Logger's WARN method so the handler can pass its logger
-// directly without coupling this package to a concrete logger.
-type Logger interface {
-	Warn(msg string, args ...any)
 }
 
 // Archiver builds a zip of the export root in two phases:
@@ -45,7 +40,7 @@ type Archiver struct {
 	TmpDir string
 	// Logger receives WARN logs (empty archive, step-ca Badger db present). May
 	// be nil.
-	Logger Logger
+	Logger *slog.Logger
 }
 
 // NewArchiver returns an Archiver using the production bolt snapshotter.
@@ -64,7 +59,7 @@ type StagedExport struct {
 	// dbSnapshots maps the resolved absolute path of each live *.db to the path
 	// of its validated staging copy.
 	dbSnapshots map[string]string
-	logger      Logger
+	logger      *slog.Logger
 }
 
 // Cleanup removes the staging directory and all validated db copies. Safe to
@@ -91,10 +86,13 @@ func isBoltDB(name string) bool {
 // and validates every *.db under it into a freshly-created 0700 staging dir, and
 // returns a StagedExport. The caller MUST call Cleanup() on the returned value.
 //
-// Any failure here — bad root, or a db that won't yield a consistent snapshot
-// after retries — returns an error with nothing else mutated, so the HTTP
-// handler can still emit a clean 500.
-func (a *Archiver) Stage(root string) (*StagedExport, error) {
+// Any failure here — bad root, a db that won't yield a consistent snapshot after
+// retries, OR an empty/degenerate export (0 files, or a micromdm dir with 0 db
+// snapshots) — returns an error with nothing else mutated, so the HTTP handler
+// can still emit a clean 500 BEFORE any response byte is written. Catching the
+// empty/0-db case here (rather than in Write) is what prevents a truncated but
+// successful-looking 200 download. ctx cancellation aborts the walk.
+func (a *Archiver) Stage(ctx context.Context, root string) (*StagedExport, error) {
 	// Prod start.sh does `ln -sfn $PERSIST /data`, so the export root is itself a
 	// symlink. filepath.WalkDir does NOT follow a symlinked root — it would walk
 	// zero children and silently produce an EMPTY archive. Resolve the link first.
@@ -137,8 +135,18 @@ func (a *Archiver) Stage(root string) (*StagedExport, error) {
 		logger:      a.Logger,
 	}
 
+	// Precondition tracking, computed during the same walk so the empty/0-db
+	// guard fires in Phase A (before any response byte). fileCount counts every
+	// entry that Phase B would WRITE — regular files AND *.db (dirs, symlinks, and
+	// *.log are not written and not counted).
+	fileCount := 0
+	micromdmDirSeen := false
+
 	walkErr := filepath.WalkDir(resolved, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
+			return err
+		}
+		if err := ctx.Err(); err != nil {
 			return err
 		}
 		// Skip symlinks under the root — only the root itself is intentionally a
@@ -147,6 +155,9 @@ func (a *Archiver) Stage(root string) (*StagedExport, error) {
 			return nil
 		}
 		if d.IsDir() {
+			if d.Name() == "micromdm" {
+				micromdmDirSeen = true
+			}
 			// step-ca's default standalone DB is a Badger DIRECTORY at
 			// step-ca/db/, NOT a *.db file. We deliberately do NOT snapshot it:
 			// step-ca writes are rare (cert issuance) and the CA private keys live
@@ -161,20 +172,45 @@ func (a *Archiver) Stage(root string) (*StagedExport, error) {
 			}
 			return nil
 		}
-		if isLog(d.Name()) || !isBoltDB(d.Name()) {
-			return nil // *.db handled below; everything else is streamed in Phase B
+		if isLog(d.Name()) {
+			return nil // excluded from the archive; not a written file
+		}
+		if !isBoltDB(d.Name()) {
+			fileCount++ // regular file streamed in Phase B
+			return nil
 		}
 
-		tmpPath, serr := snap.Snapshot(path, stagingDir)
+		tmpPath, serr := snap.Snapshot(ctx, path, stagingDir)
 		if serr != nil {
 			return fmt.Errorf("snapshot bolt db %q: %w", path, serr)
 		}
 		staged.dbSnapshots[path] = tmpPath
+		fileCount++ // *.db is written in Phase B from its staging snapshot
 		return nil
 	})
 	if walkErr != nil {
 		staged.Cleanup()
 		return nil, walkErr
+	}
+
+	// Fail loud on an empty/degenerate export BEFORE returning — this is a
+	// one-way migration tool, so a 0-file or 0-db export is a disaster, and the
+	// handler maps a Stage error to a clean pre-stream 500 (zero bytes sent).
+	if fileCount == 0 {
+		if staged.logger != nil {
+			staged.logger.Warn("state-export: archive would capture ZERO files — refusing to stage empty export",
+				"root", resolved)
+		}
+		staged.Cleanup()
+		return nil, fmt.Errorf("export captured 0 files under %q (empty or unreadable root)", resolved)
+	}
+	if micromdmDirSeen && len(staged.dbSnapshots) == 0 {
+		if staged.logger != nil {
+			staged.logger.Warn("state-export: micromdm dir present but ZERO db snapshots captured — refusing to stage",
+				"root", resolved)
+		}
+		staged.Cleanup()
+		return nil, fmt.Errorf("micromdm dir present under %q but 0 db snapshots captured", resolved)
 	}
 
 	return staged, nil
@@ -185,25 +221,25 @@ func (a *Archiver) Stage(root string) (*StagedExport, error) {
 // files are excluded. *.db files are replaced with their validated staging
 // snapshot (taken in Phase A).
 //
-// Fail-loud: this is a one-way migration tool, so an empty export is a disaster.
-// If the archive captures 0 files, or 0 db snapshots while a micromdm dir
-// exists, Write returns an error (and WARN-logs) rather than finalizing a clean
-// but empty zip.
+// The empty/0-db fail-loud guard lives in Stage (Phase A), so by the time Write
+// runs the export is known non-degenerate; Write is a pure streamer that returns
+// the counts. ctx cancellation aborts the walk.
 //
 // On a mid-stream error the zip writer is NOT Close()d, so the client receives a
 // truncated, clearly-broken download instead of a structurally valid partial
 // archive.
-func (a *Archiver) Write(staged *StagedExport, w io.Writer) (ArchiveResult, error) {
+func (a *Archiver) Write(ctx context.Context, staged *StagedExport, w io.Writer) (ArchiveResult, error) {
 	var res ArchiveResult
 	if staged == nil {
 		return res, fmt.Errorf("nil staged export")
 	}
 
-	micromdmDirSeen := false
-
 	zw := zip.NewWriter(w)
 	walkErr := filepath.WalkDir(staged.root, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
+			return err
+		}
+		if err := ctx.Err(); err != nil {
 			return err
 		}
 
@@ -222,9 +258,6 @@ func (a *Archiver) Write(staged *StagedExport, w io.Writer) (ArchiveResult, erro
 		}
 
 		if d.IsDir() {
-			if d.Name() == "micromdm" {
-				micromdmDirSeen = true
-			}
 			return addDirEntry(zw, rel, d)
 		}
 
@@ -256,22 +289,6 @@ func (a *Archiver) Write(staged *StagedExport, w io.Writer) (ArchiveResult, erro
 		// yields a truncated (clearly-broken) download rather than a
 		// structurally-valid partial zip.
 		return res, walkErr
-	}
-
-	// Fail loud on an empty/degenerate export BEFORE finalizing the zip.
-	if res.Files == 0 {
-		if a.Logger != nil {
-			a.Logger.Warn("state-export: archive captured ZERO files — refusing to finalize empty export",
-				"root", staged.root)
-		}
-		return res, fmt.Errorf("export captured 0 files under %q (empty or unreadable root)", staged.root)
-	}
-	if micromdmDirSeen && res.SnapshottedDBs == 0 {
-		if a.Logger != nil {
-			a.Logger.Warn("state-export: micromdm dir present but ZERO db snapshots captured — refusing to finalize",
-				"root", staged.root)
-		}
-		return res, fmt.Errorf("micromdm dir present under %q but 0 db snapshots captured", staged.root)
 	}
 
 	if err := zw.Close(); err != nil {

--- a/coordinator/stateexport/archive.go
+++ b/coordinator/stateexport/archive.go
@@ -1,0 +1,361 @@
+package stateexport
+
+import (
+	"archive/zip"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// ArchiveResult summarizes a completed archive build.
+type ArchiveResult struct {
+	// Files is the number of entries (regular files + db snapshots) written into
+	// the zip. Directory entries are not counted.
+	Files int
+	// SnapshottedDBs is the number of *.db files that went through the
+	// hot-copy+validate bolt snapshotter.
+	SnapshottedDBs int
+}
+
+// Logger is the minimal logging surface the archiver needs. It matches the
+// shape of *slog.Logger's WARN method so the handler can pass its logger
+// directly without coupling this package to a concrete logger.
+type Logger interface {
+	Warn(msg string, args ...any)
+}
+
+// Archiver builds a zip of the export root in two phases:
+//
+//	Phase A (Stage):  snapshot+validate every *.db under the root into a
+//	                  controlled staging dir. Any failure here is fail-clean —
+//	                  the caller has not written any response bytes yet.
+//	Phase B (Write):  stream the zip from disk + the validated staging copies.
+//
+// Splitting the phases is what makes the HTTP handler able to return a real 500
+// (nothing written) when a db cannot be snapshotted, instead of a structurally
+// valid but silently-partial archive after a 200.
+type Archiver struct {
+	// Snapshotter produces a consistent copy of each *.db file. Injectable so
+	// tests can exercise the walk/zip logic with a fake.
+	Snapshotter Snapshotter
+	// TmpDir is where db snapshots are staged. Empty => os.MkdirTemp default.
+	TmpDir string
+	// Logger receives WARN logs (empty archive, step-ca Badger db present). May
+	// be nil.
+	Logger Logger
+}
+
+// NewArchiver returns an Archiver using the production bolt snapshotter.
+func NewArchiver() *Archiver {
+	return &Archiver{Snapshotter: NewBoltSnapshotter()}
+}
+
+// StagedExport is the validated, pre-staged result of Phase A. It owns a
+// temporary staging directory that the caller MUST release with Cleanup() once
+// the archive has been streamed (or on any error).
+type StagedExport struct {
+	// root is the symlink-resolved export root that Phase B walks.
+	root string
+	// stagingDir is the 0700 temp dir holding validated db copies.
+	stagingDir string
+	// dbSnapshots maps the resolved absolute path of each live *.db to the path
+	// of its validated staging copy.
+	dbSnapshots map[string]string
+	logger      Logger
+}
+
+// Cleanup removes the staging directory and all validated db copies. Safe to
+// call multiple times and on a nil receiver.
+func (s *StagedExport) Cleanup() {
+	if s == nil || s.stagingDir == "" {
+		return
+	}
+	_ = os.RemoveAll(s.stagingDir)
+	s.stagingDir = ""
+}
+
+// isLog reports whether the file should be excluded as a log file.
+func isLog(name string) bool {
+	return strings.EqualFold(filepath.Ext(name), ".log")
+}
+
+// isBoltDB reports whether the file is a BoltDB database (by extension).
+func isBoltDB(name string) bool {
+	return strings.EqualFold(filepath.Ext(name), ".db")
+}
+
+// Stage performs Phase A: it resolves the (possibly symlinked) root, snapshots
+// and validates every *.db under it into a freshly-created 0700 staging dir, and
+// returns a StagedExport. The caller MUST call Cleanup() on the returned value.
+//
+// Any failure here — bad root, or a db that won't yield a consistent snapshot
+// after retries — returns an error with nothing else mutated, so the HTTP
+// handler can still emit a clean 500.
+func (a *Archiver) Stage(root string) (*StagedExport, error) {
+	// Prod start.sh does `ln -sfn $PERSIST /data`, so the export root is itself a
+	// symlink. filepath.WalkDir does NOT follow a symlinked root — it would walk
+	// zero children and silently produce an EMPTY archive. Resolve the link first.
+	resolved, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		return nil, fmt.Errorf("resolve export root %q: %w", root, err)
+	}
+
+	info, err := os.Stat(resolved)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("export root %q does not exist", root)
+		}
+		return nil, fmt.Errorf("stat export root %q: %w", root, err)
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("export root %q is not a directory", root)
+	}
+
+	snap := a.Snapshotter
+	if snap == nil {
+		snap = NewBoltSnapshotter()
+	}
+
+	// One controlled staging dir (0700) so validated copies never leak into
+	// os.TempDir() and survive a crash. The caller's Cleanup() removes it.
+	stagingDir, err := os.MkdirTemp(a.TmpDir, "stateexport-stage-")
+	if err != nil {
+		return nil, fmt.Errorf("create staging dir: %w", err)
+	}
+	if err := os.Chmod(stagingDir, 0o700); err != nil {
+		_ = os.RemoveAll(stagingDir)
+		return nil, fmt.Errorf("chmod staging dir: %w", err)
+	}
+
+	staged := &StagedExport{
+		root:        resolved,
+		stagingDir:  stagingDir,
+		dbSnapshots: map[string]string{},
+		logger:      a.Logger,
+	}
+
+	walkErr := filepath.WalkDir(resolved, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		// Skip symlinks under the root — only the root itself is intentionally a
+		// link; interior links could escape the root or duplicate content.
+		if d.Type()&fs.ModeSymlink != 0 {
+			return nil
+		}
+		if d.IsDir() {
+			// step-ca's default standalone DB is a Badger DIRECTORY at
+			// step-ca/db/, NOT a *.db file. We deliberately do NOT snapshot it:
+			// step-ca writes are rare (cert issuance) and the CA private keys live
+			// in secrets/+certs/ as copy-safe PEM, so a torn db/ index is
+			// recoverable. Warn the operator so they can quiesce enrollments
+			// during the one-time export.
+			if d.Name() == "db" && filepath.Base(filepath.Dir(path)) == "step-ca" {
+				if staged.logger != nil {
+					staged.logger.Warn("state-export: step-ca Badger db present and is copied file-by-file (no snapshot); quiesce certificate enrollments during the export to avoid a torn index",
+						"path", path)
+				}
+			}
+			return nil
+		}
+		if isLog(d.Name()) || !isBoltDB(d.Name()) {
+			return nil // *.db handled below; everything else is streamed in Phase B
+		}
+
+		tmpPath, serr := snap.Snapshot(path, stagingDir)
+		if serr != nil {
+			return fmt.Errorf("snapshot bolt db %q: %w", path, serr)
+		}
+		staged.dbSnapshots[path] = tmpPath
+		return nil
+	})
+	if walkErr != nil {
+		staged.Cleanup()
+		return nil, walkErr
+	}
+
+	return staged, nil
+}
+
+// Write performs Phase B: it streams the zip for an already-staged export to w.
+// Relative paths under the resolved root and file modes are preserved. *.log
+// files are excluded. *.db files are replaced with their validated staging
+// snapshot (taken in Phase A).
+//
+// Fail-loud: this is a one-way migration tool, so an empty export is a disaster.
+// If the archive captures 0 files, or 0 db snapshots while a micromdm dir
+// exists, Write returns an error (and WARN-logs) rather than finalizing a clean
+// but empty zip.
+//
+// On a mid-stream error the zip writer is NOT Close()d, so the client receives a
+// truncated, clearly-broken download instead of a structurally valid partial
+// archive.
+func (a *Archiver) Write(staged *StagedExport, w io.Writer) (ArchiveResult, error) {
+	var res ArchiveResult
+	if staged == nil {
+		return res, fmt.Errorf("nil staged export")
+	}
+
+	micromdmDirSeen := false
+
+	zw := zip.NewWriter(w)
+	walkErr := filepath.WalkDir(staged.root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		rel, relErr := filepath.Rel(staged.root, path)
+		if relErr != nil {
+			return relErr
+		}
+		if rel == "." {
+			return nil
+		}
+
+		// Skip symlinks entirely — following links could escape the root or
+		// duplicate content.
+		if d.Type()&fs.ModeSymlink != 0 {
+			return nil
+		}
+
+		if d.IsDir() {
+			if d.Name() == "micromdm" {
+				micromdmDirSeen = true
+			}
+			return addDirEntry(zw, rel, d)
+		}
+
+		if isLog(d.Name()) {
+			return nil // excluded
+		}
+
+		if isBoltDB(d.Name()) {
+			snapPath, ok := staged.dbSnapshots[path]
+			if !ok {
+				return fmt.Errorf("missing staged snapshot for %q", rel)
+			}
+			if err := addStagedDB(zw, snapPath, rel, d); err != nil {
+				return err
+			}
+			res.SnapshottedDBs++
+			res.Files++
+			return nil
+		}
+
+		if err := addRegularFile(zw, path, rel, d); err != nil {
+			return err
+		}
+		res.Files++
+		return nil
+	})
+	if walkErr != nil {
+		// Do NOT Close() the zip writer: leaving the central directory unwritten
+		// yields a truncated (clearly-broken) download rather than a
+		// structurally-valid partial zip.
+		return res, walkErr
+	}
+
+	// Fail loud on an empty/degenerate export BEFORE finalizing the zip.
+	if res.Files == 0 {
+		if a.Logger != nil {
+			a.Logger.Warn("state-export: archive captured ZERO files — refusing to finalize empty export",
+				"root", staged.root)
+		}
+		return res, fmt.Errorf("export captured 0 files under %q (empty or unreadable root)", staged.root)
+	}
+	if micromdmDirSeen && res.SnapshottedDBs == 0 {
+		if a.Logger != nil {
+			a.Logger.Warn("state-export: micromdm dir present but ZERO db snapshots captured — refusing to finalize",
+				"root", staged.root)
+		}
+		return res, fmt.Errorf("micromdm dir present under %q but 0 db snapshots captured", staged.root)
+	}
+
+	if err := zw.Close(); err != nil {
+		return res, fmt.Errorf("finalize zip: %w", err)
+	}
+	return res, nil
+}
+
+// zipName converts an OS-specific relative path to a forward-slash zip name.
+func zipName(rel string) string {
+	return filepath.ToSlash(rel)
+}
+
+// addDirEntry writes an explicit directory entry so empty dirs are preserved.
+func addDirEntry(zw *zip.Writer, rel string, d fs.DirEntry) error {
+	info, err := d.Info()
+	if err != nil {
+		return err
+	}
+	hdr, err := zip.FileInfoHeader(info)
+	if err != nil {
+		return err
+	}
+	hdr.Name = zipName(rel) + "/"
+	hdr.Method = zip.Store
+	_, err = zw.CreateHeader(hdr)
+	return err
+}
+
+// addRegularFile streams a regular file into the zip, preserving its mode.
+func addRegularFile(zw *zip.Writer, path, rel string, d fs.DirEntry) error {
+	info, err := d.Info()
+	if err != nil {
+		return err
+	}
+	hdr, err := zip.FileInfoHeader(info)
+	if err != nil {
+		return err
+	}
+	hdr.Name = zipName(rel)
+	hdr.Method = zip.Deflate
+
+	wtr, err := zw.CreateHeader(hdr)
+	if err != nil {
+		return err
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	if _, err := io.Copy(wtr, f); err != nil {
+		return fmt.Errorf("copy %q into archive: %w", rel, err)
+	}
+	return nil
+}
+
+// addStagedDB streams the pre-validated staging copy of a bolt db into the zip
+// under the original relative path, preserving the live file's mode and name.
+func addStagedDB(zw *zip.Writer, snapPath, rel string, d fs.DirEntry) error {
+	// Preserve the live db's mode/name in the header, but stream the validated
+	// staging copy.
+	info, err := d.Info()
+	if err != nil {
+		return err
+	}
+	hdr, err := zip.FileInfoHeader(info)
+	if err != nil {
+		return err
+	}
+	hdr.Name = zipName(rel)
+	hdr.Method = zip.Deflate
+
+	wtr, err := zw.CreateHeader(hdr)
+	if err != nil {
+		return err
+	}
+	snapFile, err := os.Open(snapPath)
+	if err != nil {
+		return err
+	}
+	defer snapFile.Close()
+	if _, err := io.Copy(wtr, snapFile); err != nil {
+		return fmt.Errorf("copy bolt snapshot %q into archive: %w", rel, err)
+	}
+	return nil
+}

--- a/coordinator/stateexport/encrypt.go
+++ b/coordinator/stateexport/encrypt.go
@@ -21,6 +21,11 @@ func parseRecipient(recipient string) (age.Recipient, error) {
 	if recipient == "" {
 		return nil, fmt.Errorf("empty age recipient")
 	}
+	// A bech32 age X25519 recipient is ~62 chars; cap well above that to reject
+	// absurd input before handing it to the parser.
+	if len(recipient) > 512 {
+		return nil, fmt.Errorf("age recipient too long")
+	}
 	r, err := age.ParseX25519Recipient(recipient)
 	if err != nil {
 		return nil, fmt.Errorf("invalid age recipient (expected an age1... X25519 recipient): %w", err)

--- a/coordinator/stateexport/encrypt.go
+++ b/coordinator/stateexport/encrypt.go
@@ -1,0 +1,48 @@
+package stateexport
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"filippo.io/age"
+)
+
+// ValidateRecipient parses an age recipient string (e.g. "age1...") and returns
+// a clear error rather than leaking the raw value. Used to fail fast before any
+// response header is written.
+func ValidateRecipient(recipient string) error {
+	_, err := parseRecipient(recipient)
+	return err
+}
+
+func parseRecipient(recipient string) (age.Recipient, error) {
+	recipient = strings.TrimSpace(recipient)
+	if recipient == "" {
+		return nil, fmt.Errorf("empty age recipient")
+	}
+	r, err := age.ParseX25519Recipient(recipient)
+	if err != nil {
+		return nil, fmt.Errorf("invalid age recipient (expected an age1... X25519 recipient): %w", err)
+	}
+	return r, nil
+}
+
+// EncryptWriter wraps dst with age streaming encryption for the given recipient
+// string. The returned WriteCloser MUST be closed to flush age's final chunk and
+// write a valid stream — the caller is responsible for closing it (and should do
+// so before treating the encrypted output as complete).
+//
+// age performs streaming (chunked) encryption, so the archive is never buffered
+// whole in memory: zip writer -> age writer -> http.ResponseWriter.
+func EncryptWriter(dst io.Writer, recipient string) (io.WriteCloser, error) {
+	r, err := parseRecipient(recipient)
+	if err != nil {
+		return nil, err
+	}
+	wc, err := age.Encrypt(dst, r)
+	if err != nil {
+		return nil, fmt.Errorf("init age encryption: %w", err)
+	}
+	return wc, nil
+}

--- a/coordinator/stateexport/snapshot.go
+++ b/coordinator/stateexport/snapshot.go
@@ -1,0 +1,329 @@
+// Package stateexport produces a consistent, optionally-encrypted archive of the
+// coordinator's TEE-sealed on-disk state (step-ca + MicroMDM) under /data so it
+// can be migrated off EigenCloud onto a GCP Confidential VM (DAR-70).
+//
+// The crux is BoltDB consistency: MicroMDM runs as a sibling process that holds
+// an exclusive bbolt file lock for its lifetime, so the live db cannot be opened
+// in-process and a naive byte copy can capture a torn write. snapshot.go
+// implements hot-copy + validate + retry to obtain a clean snapshot.
+//
+// Torn-copy safety: a torn hot-copy can have a meta page with a VALID checksum
+// whose pgid points past the end of the file (the write that grew the file had
+// not been flushed when we copied). bbolt indexes the mmap with no bounds check,
+// so walking such a copy can PANIC rather than return an error. Worse, tx.Check()
+// runs its work in an internal goroutine, so a panic there is unrecoverable by
+// the caller and crashes the process. We therefore (a) NEVER use tx.Check() in
+// the production validation path, and (b) wrap copy-open-validate in a recover so
+// ANY panic becomes a retry-able error.
+package stateexport
+
+import (
+	"encoding/binary"
+	"fmt"
+	"hash/fnv"
+	"io"
+	"os"
+	"time"
+
+	bolt "go.etcd.io/bbolt"
+)
+
+// bbolt on-disk constants (mirrored from go.etcd.io/bbolt/internal/common; they
+// are part of the stable v2 file format). We read the meta pages by hand so we
+// can reject a torn copy WITHOUT mmap-walking it — an mmap walk of a torn file
+// can SIGSEGV (an out-of-bounds mmap read), which is a fatal runtime fault that
+// recover() cannot catch.
+const (
+	boltMagic   uint32 = 0xED0CDAED
+	boltVersion uint32 = 2
+	// Page header is {id u64, flags u16, count u16, overflow u32} = 16 bytes.
+	boltPageHeaderSize = 16
+	// Offsets WITHIN the Meta struct (which begins right after the page header):
+	//   magic u32 | version u32 | pageSize u32 | flags u32 |
+	//   root{rootPgid u64, seq u64} | freelist u64 | pgid u64 | txid u64 | checksum u64
+	metaOffMagic    = 0
+	metaOffVersion  = 4
+	metaOffPageSize = 8
+	metaOffPgid     = 40 // high-water mark: total pages the db claims to use
+	metaOffTxid     = 48
+	metaOffChecksum = 56 // FNV-1a is computed over meta bytes [0:56)
+	metaStructLen   = 64
+)
+
+// Snapshotter produces a consistent copy of a BoltDB file. It is injectable so
+// archive-building tests can exercise the walk/zip logic without a live db.
+type Snapshotter interface {
+	// Snapshot writes a consistent copy of the bbolt database at srcPath into a
+	// freshly-created temp file and returns that file's path. The caller owns the
+	// returned file and must remove it when done. tmpDir, when non-empty, is the
+	// directory the temp file is created in (defaults to os.TempDir()).
+	Snapshot(srcPath, tmpDir string) (string, error)
+}
+
+// SnapshotConfig tunes the hot-copy + validate + retry loop.
+type SnapshotConfig struct {
+	// MaxAttempts is how many times to retry the copy+validate cycle. MicroMDM
+	// write txns are sub-millisecond, so a clean snapshot is obtained quickly.
+	MaxAttempts int
+	// Backoff is the pause between attempts.
+	Backoff time.Duration
+	// OpenTimeout bounds bbolt.Open on the copy (it should never block — the copy
+	// is unlocked — but a short timeout fails fast on a genuinely bad file).
+	OpenTimeout time.Duration
+}
+
+// DefaultSnapshotConfig is the production tuning.
+func DefaultSnapshotConfig() SnapshotConfig {
+	return SnapshotConfig{
+		MaxAttempts: 5,
+		Backoff:     25 * time.Millisecond,
+		OpenTimeout: 2 * time.Second,
+	}
+}
+
+// BoltSnapshotter is the production Snapshotter: hot-copy the live db bytes to a
+// temp file, open the COPY read-only (no lock contention), validate integrity,
+// and retry on failure. It never opens or modifies the live db read-write.
+type BoltSnapshotter struct {
+	Config SnapshotConfig
+}
+
+// NewBoltSnapshotter returns a BoltSnapshotter with default tuning.
+func NewBoltSnapshotter() *BoltSnapshotter {
+	return &BoltSnapshotter{Config: DefaultSnapshotConfig()}
+}
+
+// Snapshot implements Snapshotter.
+func (b *BoltSnapshotter) Snapshot(srcPath, tmpDir string) (string, error) {
+	cfg := b.Config
+	if cfg.MaxAttempts <= 0 {
+		cfg.MaxAttempts = 1
+	}
+	if cfg.OpenTimeout <= 0 {
+		cfg.OpenTimeout = 2 * time.Second
+	}
+
+	var lastErr error
+	for attempt := 1; attempt <= cfg.MaxAttempts; attempt++ {
+		tmpPath, err := copyFileToTemp(srcPath, tmpDir)
+		if err != nil {
+			// A copy error is unlikely to self-heal across retries (bad path,
+			// perms) — fail fast.
+			return "", fmt.Errorf("hot-copy bolt db %q: %w", srcPath, err)
+		}
+
+		if err := validateBolt(tmpPath, cfg.OpenTimeout); err != nil {
+			lastErr = err
+			_ = os.Remove(tmpPath)
+			if attempt < cfg.MaxAttempts && cfg.Backoff > 0 {
+				time.Sleep(cfg.Backoff)
+			}
+			continue
+		}
+
+		// Validated copy — caller owns it.
+		return tmpPath, nil
+	}
+
+	return "", fmt.Errorf("bolt db %q did not yield a consistent snapshot after %d attempts: %w",
+		srcPath, cfg.MaxAttempts, lastErr)
+}
+
+// copyFileToTemp copies the bytes of srcPath into a new temp file (preserving the
+// source's base name pattern) and returns the temp path. The destination is a
+// brand-new file, so the writer never touches the live db's bytes.
+func copyFileToTemp(srcPath, tmpDir string) (string, error) {
+	src, err := os.Open(srcPath)
+	if err != nil {
+		return "", err
+	}
+	defer src.Close()
+
+	if tmpDir == "" {
+		tmpDir = os.TempDir()
+	}
+	dst, err := os.CreateTemp(tmpDir, "stateexport-bolt-*.db")
+	if err != nil {
+		return "", err
+	}
+	tmpPath := dst.Name()
+
+	if _, err := io.Copy(dst, src); err != nil {
+		dst.Close()
+		_ = os.Remove(tmpPath)
+		return "", err
+	}
+	if err := dst.Close(); err != nil {
+		_ = os.Remove(tmpPath)
+		return "", err
+	}
+	return tmpPath, nil
+}
+
+// validateBolt confirms the (already-copied) db is a complete, non-torn snapshot.
+//
+// Two layers, both crash-safe:
+//
+//  1. A pure byte-level meta check (mmap-free): read both meta pages, validate
+//     magic/version/FNV checksum, pick the active meta (highest valid txid), and
+//     confirm its high-water-mark pgid fits inside the file. THIS is the layer
+//     that catches the dangerous torn copy — a meta whose pgid points past EOF —
+//     because the subsequent mmap walk of such a file SIGSEGVs (a fatal runtime
+//     fault, NOT a Go panic; recover() cannot catch it).
+//
+//  2. A recover-wrapped read-only bucket walk. With layer 1 guaranteeing the
+//     high-water mark fits, this is safe; the recover is belt-and-suspenders for
+//     any other internal inconsistency that surfaces as a panic. We deliberately
+//     do NOT use tx.Check(): it runs in an internal goroutine, so a panic there
+//     would crash the process regardless of any recover here.
+func validateBolt(path string, openTimeout time.Duration) (retErr error) {
+	defer func() {
+		if rec := recover(); rec != nil {
+			retErr = fmt.Errorf("bolt validation panicked (torn/corrupt copy): %v", rec)
+		}
+	}()
+
+	// Layer 1: byte-level meta validation. Rejects torn copies before any mmap.
+	if err := validateBoltMeta(path); err != nil {
+		return err
+	}
+
+	// Layer 2: recover-wrapped structural walk on the now-known-bounded copy.
+	db, err := bolt.Open(path, 0o400, &bolt.Options{
+		ReadOnly: true,
+		Timeout:  openTimeout,
+	})
+	if err != nil {
+		return fmt.Errorf("open copy read-only: %w", err)
+	}
+	defer db.Close()
+
+	if err := db.View(walkAllBuckets); err != nil {
+		return fmt.Errorf("walk buckets: %w", err)
+	}
+	return nil
+}
+
+// validateBoltMeta reads the two meta pages straight from the file bytes (no
+// mmap, fully bounds-checked) and confirms the snapshot is complete:
+//   - page size is plausible (power of two, >= 512);
+//   - file size is a whole number of pages and >= 2 pages;
+//   - at least one meta page is valid (correct magic/version/FNV checksum);
+//   - the active meta's high-water-mark pgid fits inside the file.
+//
+// The last condition is the torn-copy signature: a hot-copy taken mid-grow can
+// have a valid-checksum meta claiming N pages while the file holds fewer — the
+// write that extended the file had not reached disk when we copied it.
+func validateBoltMeta(path string) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	info, err := f.Stat()
+	if err != nil {
+		return err
+	}
+	size := info.Size()
+
+	// Page size lives at file offset boltPageHeaderSize+metaOffPageSize in meta
+	// page 0. Read enough of page 0 to cover the whole meta struct.
+	page0 := make([]byte, boltPageHeaderSize+metaStructLen)
+	if _, err := io.ReadFull(f, page0); err != nil {
+		return fmt.Errorf("read bolt meta page 0: %w", err)
+	}
+	pageSize := int64(binary.LittleEndian.Uint32(page0[boltPageHeaderSize+metaOffPageSize:]))
+	if pageSize < 512 || pageSize&(pageSize-1) != 0 {
+		return fmt.Errorf("implausible bolt page size %d (torn/corrupt copy)", pageSize)
+	}
+	if size < 2*pageSize {
+		return fmt.Errorf("bolt copy too small: %d bytes < 2 pages (%d) — torn copy", size, 2*pageSize)
+	}
+	if size%pageSize != 0 {
+		return fmt.Errorf("bolt copy size %d is not a multiple of page size %d — torn copy", size, pageSize)
+	}
+
+	// Read meta page 1 (the second copy of the meta).
+	page1 := make([]byte, boltPageHeaderSize+metaStructLen)
+	if _, err := f.ReadAt(page1, pageSize); err != nil {
+		return fmt.Errorf("read bolt meta page 1: %w", err)
+	}
+
+	totalPages := size / pageSize
+	pgid0, ok0 := parseBoltMeta(page0)
+	pgid1, ok1 := parseBoltMeta(page1)
+	txid0 := binary.LittleEndian.Uint64(page0[boltPageHeaderSize+metaOffTxid:])
+	txid1 := binary.LittleEndian.Uint64(page1[boltPageHeaderSize+metaOffTxid:])
+
+	// Pick the active meta: the valid one with the highest txid (bbolt's rule).
+	var activePgid uint64
+	switch {
+	case ok0 && ok1:
+		if txid0 >= txid1 {
+			activePgid = pgid0
+		} else {
+			activePgid = pgid1
+		}
+	case ok0:
+		activePgid = pgid0
+	case ok1:
+		activePgid = pgid1
+	default:
+		return fmt.Errorf("no valid bolt meta page (both failed magic/version/checksum) — torn/corrupt copy")
+	}
+
+	// High-water mark must fit inside the file. If the meta claims more pages
+	// than the file holds, the copy is torn — reject WITHOUT walking the mmap.
+	// Compare in uint64 space: a pgid with the high bit set would become a
+	// negative int64 and silently pass the bounds check (the exact torn-copy
+	// signature this guard exists to catch). totalPages = size/pageSize ≥ 0.
+	if totalPages < 0 || activePgid > uint64(totalPages) {
+		return fmt.Errorf("bolt high-water mark pgid %d exceeds file pages %d — torn copy", activePgid, totalPages)
+	}
+	return nil
+}
+
+// parseBoltMeta validates a meta page's magic, version, and FNV-1a checksum, and
+// returns its high-water-mark pgid. ok is false if the meta is not valid.
+func parseBoltMeta(page []byte) (pgid uint64, ok bool) {
+	meta := page[boltPageHeaderSize:]
+	if len(meta) < metaStructLen {
+		return 0, false
+	}
+	if binary.LittleEndian.Uint32(meta[metaOffMagic:]) != boltMagic {
+		return 0, false
+	}
+	if binary.LittleEndian.Uint32(meta[metaOffVersion:]) != boltVersion {
+		return 0, false
+	}
+	// FNV-1a 64-bit over meta bytes [0:checksumOffset).
+	h := fnv.New64a()
+	_, _ = h.Write(meta[:metaOffChecksum])
+	want := binary.LittleEndian.Uint64(meta[metaOffChecksum:])
+	if h.Sum64() != want {
+		return 0, false
+	}
+	return binary.LittleEndian.Uint64(meta[metaOffPgid:]), true
+}
+
+// walkAllBuckets recursively iterates every bucket and key in the transaction.
+func walkAllBuckets(tx *bolt.Tx) error {
+	return tx.ForEach(func(name []byte, b *bolt.Bucket) error {
+		return walkBucket(b)
+	})
+}
+
+// walkBucket recursively touches every key/value and descends into nested
+// buckets. Bucket.ForEach yields v==nil for a nested bucket; we re-fetch the
+// sub-bucket via Bucket(name) and recurse so deep structures are validated too.
+func walkBucket(b *bolt.Bucket) error {
+	return b.ForEach(func(k, v []byte) error {
+		if v == nil {
+			if sub := b.Bucket(k); sub != nil {
+				return walkBucket(sub)
+			}
+		}
+		return nil
+	})
+}

--- a/coordinator/stateexport/snapshot.go
+++ b/coordinator/stateexport/snapshot.go
@@ -18,6 +18,7 @@
 package stateexport
 
 import (
+	"context"
 	"encoding/binary"
 	"fmt"
 	"hash/fnv"
@@ -56,55 +57,41 @@ type Snapshotter interface {
 	// Snapshot writes a consistent copy of the bbolt database at srcPath into a
 	// freshly-created temp file and returns that file's path. The caller owns the
 	// returned file and must remove it when done. tmpDir, when non-empty, is the
-	// directory the temp file is created in (defaults to os.TempDir()).
-	Snapshot(srcPath, tmpDir string) (string, error)
+	// directory the temp file is created in (defaults to os.TempDir()). ctx
+	// cancellation aborts the retry loop between attempts.
+	Snapshot(ctx context.Context, srcPath, tmpDir string) (string, error)
 }
 
-// SnapshotConfig tunes the hot-copy + validate + retry loop.
-type SnapshotConfig struct {
-	// MaxAttempts is how many times to retry the copy+validate cycle. MicroMDM
-	// write txns are sub-millisecond, so a clean snapshot is obtained quickly.
-	MaxAttempts int
-	// Backoff is the pause between attempts.
-	Backoff time.Duration
-	// OpenTimeout bounds bbolt.Open on the copy (it should never block — the copy
-	// is unlocked — but a short timeout fails fast on a genuinely bad file).
-	OpenTimeout time.Duration
-}
-
-// DefaultSnapshotConfig is the production tuning.
-func DefaultSnapshotConfig() SnapshotConfig {
-	return SnapshotConfig{
-		MaxAttempts: 5,
-		Backoff:     25 * time.Millisecond,
-		OpenTimeout: 2 * time.Second,
-	}
-}
+// Hot-copy + validate + retry tuning. MicroMDM write txns are sub-millisecond,
+// so a clean snapshot is obtained within a few attempts.
+const (
+	// maxSnapshotAttempts is how many times to retry the copy+validate cycle.
+	maxSnapshotAttempts = 5
+	// snapshotBackoff is the pause between attempts.
+	snapshotBackoff = 25 * time.Millisecond
+	// snapshotOpenTimeout bounds bbolt.Open on the copy (it should never block —
+	// the copy is unlocked — but a short timeout fails fast on a bad file).
+	snapshotOpenTimeout = 2 * time.Second
+)
 
 // BoltSnapshotter is the production Snapshotter: hot-copy the live db bytes to a
 // temp file, open the COPY read-only (no lock contention), validate integrity,
 // and retry on failure. It never opens or modifies the live db read-write.
-type BoltSnapshotter struct {
-	Config SnapshotConfig
-}
+type BoltSnapshotter struct{}
 
-// NewBoltSnapshotter returns a BoltSnapshotter with default tuning.
+// NewBoltSnapshotter returns a BoltSnapshotter.
 func NewBoltSnapshotter() *BoltSnapshotter {
-	return &BoltSnapshotter{Config: DefaultSnapshotConfig()}
+	return &BoltSnapshotter{}
 }
 
 // Snapshot implements Snapshotter.
-func (b *BoltSnapshotter) Snapshot(srcPath, tmpDir string) (string, error) {
-	cfg := b.Config
-	if cfg.MaxAttempts <= 0 {
-		cfg.MaxAttempts = 1
-	}
-	if cfg.OpenTimeout <= 0 {
-		cfg.OpenTimeout = 2 * time.Second
-	}
-
+func (b *BoltSnapshotter) Snapshot(ctx context.Context, srcPath, tmpDir string) (string, error) {
 	var lastErr error
-	for attempt := 1; attempt <= cfg.MaxAttempts; attempt++ {
+	for attempt := 1; attempt <= maxSnapshotAttempts; attempt++ {
+		if err := ctx.Err(); err != nil {
+			return "", err
+		}
+
 		tmpPath, err := copyFileToTemp(srcPath, tmpDir)
 		if err != nil {
 			// A copy error is unlikely to self-heal across retries (bad path,
@@ -112,11 +99,17 @@ func (b *BoltSnapshotter) Snapshot(srcPath, tmpDir string) (string, error) {
 			return "", fmt.Errorf("hot-copy bolt db %q: %w", srcPath, err)
 		}
 
-		if err := validateBolt(tmpPath, cfg.OpenTimeout); err != nil {
+		if err := validateBolt(tmpPath, snapshotOpenTimeout); err != nil {
 			lastErr = err
 			_ = os.Remove(tmpPath)
-			if attempt < cfg.MaxAttempts && cfg.Backoff > 0 {
-				time.Sleep(cfg.Backoff)
+			if attempt < maxSnapshotAttempts {
+				// Cancellable wait so a client disconnect aborts the retry loop
+				// instead of sleeping out the full backoff.
+				select {
+				case <-ctx.Done():
+					return "", ctx.Err()
+				case <-time.After(snapshotBackoff):
+				}
 			}
 			continue
 		}
@@ -126,7 +119,7 @@ func (b *BoltSnapshotter) Snapshot(srcPath, tmpDir string) (string, error) {
 	}
 
 	return "", fmt.Errorf("bolt db %q did not yield a consistent snapshot after %d attempts: %w",
-		srcPath, cfg.MaxAttempts, lastErr)
+		srcPath, maxSnapshotAttempts, lastErr)
 }
 
 // copyFileToTemp copies the bytes of srcPath into a new temp file (preserving the

--- a/coordinator/stateexport/snapshot.go
+++ b/coordinator/stateexport/snapshot.go
@@ -172,7 +172,13 @@ func copyFileToTemp(srcPath, tmpDir string) (string, error) {
 func validateBolt(path string, openTimeout time.Duration) (retErr error) {
 	defer func() {
 		if rec := recover(); rec != nil {
-			retErr = fmt.Errorf("bolt validation panicked (torn/corrupt copy): %v", rec)
+			// Preserve the underlying error type (and chain) when the recovered
+			// value is itself an error; otherwise stringify it.
+			if e, ok := rec.(error); ok {
+				retErr = fmt.Errorf("bolt validation panicked (torn/corrupt copy): %w", e)
+			} else {
+				retErr = fmt.Errorf("bolt validation panicked (torn/corrupt copy): %v", rec)
+			}
 		}
 	}()
 

--- a/coordinator/stateexport/stateexport_test.go
+++ b/coordinator/stateexport/stateexport_test.go
@@ -221,6 +221,26 @@ func TestArchiveEmptyRootErrors(t *testing.T) {
 	}
 }
 
+// TestArchiveMicromdmDirWithoutItsDB_DAR70 is the regression for the Codex PR
+// finding: the fail-loud "micromdm present but no DB" guard must scope to a *.db
+// INSIDE the micromdm dir, not the global snapshot count. A stray db elsewhere
+// under the root (e.g. step-ca/) must not mask a missing MicroMDM database and
+// let Stage succeed — that would ship a 200 archive without the MDM device DB.
+func TestArchiveMicromdmDirWithoutItsDB_DAR70(t *testing.T) {
+	root := t.TempDir()
+	// micromdm dir exists but has NO *.db (only a regular file).
+	mustWrite(t, filepath.Join(root, "micromdm", "config"), "CONFIG")
+	// A stray bolt db elsewhere that WILL be snapshotted (global db count > 0).
+	// mustWrite first so step-ca/ exists before bolt.Open (makeBolt doesn't mkdir).
+	mustWrite(t, filepath.Join(root, "step-ca", "ca.json"), "{}")
+	makeBolt(t, filepath.Join(root, "step-ca", "stray.db"))
+
+	_, err := archiveRoot(t, NewArchiver(), root, io.Discard)
+	if err == nil {
+		t.Fatal("expected error: micromdm dir present but its BoltDB missing, masked by a stray db elsewhere")
+	}
+}
+
 // TestArchiveSymlinkedRoot: prod start.sh symlinks /data -> persistent storage.
 // WalkDir on a symlinked root would walk zero children; the archiver must
 // EvalSymlinks first so the archive still captures children.

--- a/coordinator/stateexport/stateexport_test.go
+++ b/coordinator/stateexport/stateexport_test.go
@@ -50,12 +50,12 @@ func makeBolt(t *testing.T, path string) {
 // root and returns the zip bytes + result. It always cleans up staging.
 func archiveRoot(t *testing.T, a *Archiver, root string, w io.Writer) (ArchiveResult, error) {
 	t.Helper()
-	staged, err := a.Stage(root)
+	staged, err := a.Stage(context.Background(), root)
 	if err != nil {
 		return ArchiveResult{}, err
 	}
 	defer staged.Cleanup()
-	return a.Write(staged, w)
+	return a.Write(context.Background(), staged, w)
 }
 
 // unzipToMap reads a zip from r and returns name -> contents (files only).
@@ -356,7 +356,7 @@ func TestSnapshotConsistencyUnderConcurrentWrites_DAR70(t *testing.T) {
 	snap := NewBoltSnapshotter()
 	// Take several snapshots while writes are in-flight; each must be consistent.
 	for n := 0; n < 8; n++ {
-		tmp, err := snap.Snapshot(dbPath, root)
+		tmp, err := snap.Snapshot(context.Background(), dbPath, root)
 		if err != nil {
 			cancel()
 			wg.Wait()
@@ -513,8 +513,8 @@ func TestSnapshotRetriesThenErrorsOnPersistentTear(t *testing.T) {
 		t.Fatalf("write torn: %v", err)
 	}
 
-	snap := &BoltSnapshotter{Config: SnapshotConfig{MaxAttempts: 3, Backoff: time.Millisecond, OpenTimeout: time.Second}}
-	out, err := snap.Snapshot(torn, root)
+	snap := NewBoltSnapshotter()
+	out, err := snap.Snapshot(context.Background(), torn, root)
 	if err == nil {
 		t.Fatalf("expected Snapshot to error on a persistently torn source; got path %q", out)
 	}
@@ -544,7 +544,7 @@ func zeroInterior(raw []byte) []byte {
 // errors during Phase A (Stage).
 type failingSnapshotter struct{}
 
-func (failingSnapshotter) Snapshot(string, string) (string, error) {
+func (failingSnapshotter) Snapshot(context.Context, string, string) (string, error) {
 	return "", io.ErrUnexpectedEOF
 }
 
@@ -553,7 +553,7 @@ func TestArchivePropagatesSnapshotError(t *testing.T) {
 	makeBolt(t, filepath.Join(root, "x.db"))
 	a := &Archiver{Snapshotter: failingSnapshotter{}}
 	// Stage (Phase A) must fail; nothing is written.
-	_, err := a.Stage(root)
+	_, err := a.Stage(context.Background(), root)
 	if err == nil {
 		t.Fatal("expected Stage to fail when snapshotter errors")
 	}

--- a/coordinator/stateexport/stateexport_test.go
+++ b/coordinator/stateexport/stateexport_test.go
@@ -1,0 +1,560 @@
+package stateexport
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"encoding/binary"
+	"hash/fnv"
+	"io"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"filippo.io/age"
+	bolt "go.etcd.io/bbolt"
+)
+
+// makeBolt creates a real bbolt db at path with a couple of buckets + keys.
+func makeBolt(t *testing.T, path string) {
+	t.Helper()
+	db, err := bolt.Open(path, 0o600, &bolt.Options{Timeout: time.Second})
+	if err != nil {
+		t.Fatalf("open bolt: %v", err)
+	}
+	defer db.Close()
+	if err := db.Update(func(tx *bolt.Tx) error {
+		dev, err := tx.CreateBucketIfNotExists([]byte("Devices"))
+		if err != nil {
+			return err
+		}
+		if err := dev.Put([]byte("serial-1"), []byte("payload-1")); err != nil {
+			return err
+		}
+		if err := dev.Put([]byte("serial-2"), []byte("payload-2")); err != nil {
+			return err
+		}
+		cmd, err := tx.CreateBucketIfNotExists([]byte("Commands"))
+		if err != nil {
+			return err
+		}
+		return cmd.Put([]byte("cmd-1"), []byte("InstallProfile"))
+	}); err != nil {
+		t.Fatalf("seed bolt: %v", err)
+	}
+}
+
+// archiveRoot runs the two-phase Archiver (Stage then Write) end-to-end against
+// root and returns the zip bytes + result. It always cleans up staging.
+func archiveRoot(t *testing.T, a *Archiver, root string, w io.Writer) (ArchiveResult, error) {
+	t.Helper()
+	staged, err := a.Stage(root)
+	if err != nil {
+		return ArchiveResult{}, err
+	}
+	defer staged.Cleanup()
+	return a.Write(staged, w)
+}
+
+// unzipToMap reads a zip from r and returns name -> contents (files only).
+func unzipToMap(t *testing.T, r io.ReaderAt, size int64) map[string][]byte {
+	t.Helper()
+	zr, err := zip.NewReader(r, size)
+	if err != nil {
+		t.Fatalf("open zip: %v", err)
+	}
+	out := map[string][]byte{}
+	for _, f := range zr.File {
+		if f.FileInfo().IsDir() {
+			continue
+		}
+		rc, err := f.Open()
+		if err != nil {
+			t.Fatalf("open zip entry %q: %v", f.Name, err)
+		}
+		b, err := io.ReadAll(rc)
+		rc.Close()
+		if err != nil {
+			t.Fatalf("read zip entry %q: %v", f.Name, err)
+		}
+		out[f.Name] = b
+	}
+	return out
+}
+
+// buildExportRoot lays down a representative /data tree and returns its path.
+func buildExportRoot(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+
+	mustWrite(t, filepath.Join(root, "step-ca", "config", "ca.json"), `{"authority":{}}`)
+	mustWrite(t, filepath.Join(root, "step-ca", "secrets", "password"), "eigeninference-step-ca")
+	mustWrite(t, filepath.Join(root, "step-ca", "certs", "root_ca.crt"), "ROOT-CERT")
+	mustWrite(t, filepath.Join(root, "step-ca", "certs", "intermediate_ca.crt"), "INT-CERT")
+	mustWrite(t, filepath.Join(root, "step-ca", "certs", "intermediate_ca_key"), "INT-KEY")
+
+	mustWrite(t, filepath.Join(root, "micromdm", "push.crt"), "PUSH-CERT")
+	mustWrite(t, filepath.Join(root, "micromdm", "push.key"), "PUSH-KEY")
+	mustWrite(t, filepath.Join(root, "micromdm", "config"), "CONFIG")
+	mustWrite(t, filepath.Join(root, "micromdm", ".push_imported"), "") // sentinel
+	makeBolt(t, filepath.Join(root, "micromdm", "micromdm.db"))
+
+	// Log files that MUST be excluded.
+	mustWrite(t, filepath.Join(root, "step-ca.log"), "step log")
+	mustWrite(t, filepath.Join(root, "micromdm", "micromdm.log"), "mdm log")
+
+	return root
+}
+
+func mustWrite(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %q: %v", path, err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write %q: %v", path, err)
+	}
+}
+
+// TestArchiveWritesExpectedTree verifies the walk/zip logic: correct paths,
+// *.log excluded, .push_imported sentinel included, bolt db snapshotted.
+func TestArchiveWritesExpectedTree(t *testing.T) {
+	root := buildExportRoot(t)
+
+	var buf bytes.Buffer
+	res, err := archiveRoot(t, NewArchiver(), root, &buf)
+	if err != nil {
+		t.Fatalf("archive: %v", err)
+	}
+	if res.SnapshottedDBs != 1 {
+		t.Fatalf("expected 1 snapshotted db, got %d", res.SnapshottedDBs)
+	}
+
+	files := unzipToMap(t, bytes.NewReader(buf.Bytes()), int64(buf.Len()))
+
+	wantPresent := []string{
+		"step-ca/config/ca.json",
+		"step-ca/secrets/password",
+		"step-ca/certs/root_ca.crt",
+		"step-ca/certs/intermediate_ca.crt",
+		"step-ca/certs/intermediate_ca_key",
+		"micromdm/push.crt",
+		"micromdm/push.key",
+		"micromdm/config",
+		"micromdm/.push_imported",
+		"micromdm/micromdm.db",
+	}
+	for _, name := range wantPresent {
+		if _, ok := files[name]; !ok {
+			t.Errorf("expected %q in archive, missing", name)
+		}
+	}
+
+	wantAbsent := []string{"step-ca.log", "micromdm/micromdm.log"}
+	for _, name := range wantAbsent {
+		if _, ok := files[name]; ok {
+			t.Errorf("expected %q to be EXCLUDED, but present", name)
+		}
+	}
+
+	// The snapshotted db inside the zip must open ReadOnly with intact data.
+	dbBytes, ok := files["micromdm/micromdm.db"]
+	if !ok {
+		t.Fatal("micromdm.db missing from archive")
+	}
+	assertBoltIntact(t, dbBytes)
+}
+
+// assertBoltIntact writes dbBytes to a temp file, validates it with the
+// production recover-wrapped validator (NOT tx.Check(), which panics in a
+// goroutine on a torn copy), and verifies the seeded buckets/keys are present.
+func assertBoltIntact(t *testing.T, dbBytes []byte) {
+	t.Helper()
+	tmp := filepath.Join(t.TempDir(), "extracted.db")
+	if err := os.WriteFile(tmp, dbBytes, 0o600); err != nil {
+		t.Fatalf("write extracted db: %v", err)
+	}
+	if err := validateBolt(tmp, 2*time.Second); err != nil {
+		t.Fatalf("extracted db failed validation: %v", err)
+	}
+
+	db, err := bolt.Open(tmp, 0o400, &bolt.Options{ReadOnly: true, Timeout: 2 * time.Second})
+	if err != nil {
+		t.Fatalf("open extracted db ReadOnly: %v", err)
+	}
+	defer db.Close()
+	if err := db.View(func(tx *bolt.Tx) error {
+		dev := tx.Bucket([]byte("Devices"))
+		if dev == nil {
+			t.Fatal("Devices bucket missing in extracted db")
+		}
+		if got := dev.Get([]byte("serial-1")); !bytes.Equal(got, []byte("payload-1")) {
+			t.Fatalf("serial-1 = %q, want payload-1", got)
+		}
+		if tx.Bucket([]byte("Commands")) == nil {
+			t.Fatal("Commands bucket missing in extracted db")
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("verify buckets: %v", err)
+	}
+}
+
+// TestArchiveMissingRoot returns a clear error when the root doesn't exist.
+func TestArchiveMissingRoot(t *testing.T) {
+	_, err := archiveRoot(t, NewArchiver(), filepath.Join(t.TempDir(), "nope"), io.Discard)
+	if err == nil {
+		t.Fatal("expected error for missing root")
+	}
+}
+
+// TestArchiveEmptyRootErrors: a childless root is a degenerate (disastrous)
+// export — Stage succeeds but Write must fail loud rather than finalize an empty
+// zip.
+func TestArchiveEmptyRootErrors(t *testing.T) {
+	root := t.TempDir() // no children
+	_, err := archiveRoot(t, NewArchiver(), root, io.Discard)
+	if err == nil {
+		t.Fatal("expected error for empty root, got nil")
+	}
+}
+
+// TestArchiveSymlinkedRoot: prod start.sh symlinks /data -> persistent storage.
+// WalkDir on a symlinked root would walk zero children; the archiver must
+// EvalSymlinks first so the archive still captures children.
+func TestArchiveSymlinkedRoot(t *testing.T) {
+	real := buildExportRoot(t)
+	link := filepath.Join(t.TempDir(), "data-link")
+	if err := os.Symlink(real, link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	var buf bytes.Buffer
+	res, err := archiveRoot(t, NewArchiver(), link, &buf)
+	if err != nil {
+		t.Fatalf("archive via symlinked root: %v", err)
+	}
+	if res.Files == 0 {
+		t.Fatal("symlinked root produced an EMPTY archive (EvalSymlinks not applied)")
+	}
+	files := unzipToMap(t, bytes.NewReader(buf.Bytes()), int64(buf.Len()))
+	if _, ok := files["micromdm/micromdm.db"]; !ok {
+		t.Fatal("micromdm.db missing from symlinked-root archive")
+	}
+}
+
+// TestArchiveMultipleDBs: every *.db under the root must be snapshotted.
+func TestArchiveMultipleDBs(t *testing.T) {
+	root := buildExportRoot(t)
+	makeBolt(t, filepath.Join(root, "step-ca", "extra.db"))
+	makeBolt(t, filepath.Join(root, "another.db"))
+
+	var buf bytes.Buffer
+	res, err := archiveRoot(t, NewArchiver(), root, &buf)
+	if err != nil {
+		t.Fatalf("archive: %v", err)
+	}
+	if res.SnapshottedDBs < 2 {
+		t.Fatalf("expected >1 snapshotted db, got %d", res.SnapshottedDBs)
+	}
+	files := unzipToMap(t, bytes.NewReader(buf.Bytes()), int64(buf.Len()))
+	for _, name := range []string{"micromdm/micromdm.db", "step-ca/extra.db", "another.db"} {
+		if _, ok := files[name]; !ok {
+			t.Errorf("expected %q in archive, missing", name)
+		}
+	}
+}
+
+// TestEncryptRoundTrip encrypts a payload to a generated identity and decrypts.
+func TestEncryptRoundTrip(t *testing.T) {
+	id, err := age.GenerateX25519Identity()
+	if err != nil {
+		t.Fatalf("gen identity: %v", err)
+	}
+
+	var enc bytes.Buffer
+	w, err := EncryptWriter(&enc, id.Recipient().String())
+	if err != nil {
+		t.Fatalf("encrypt writer: %v", err)
+	}
+	plaintext := []byte("darkbloom-state-bytes")
+	if _, err := w.Write(plaintext); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("close age writer: %v", err)
+	}
+
+	dr, err := age.Decrypt(bytes.NewReader(enc.Bytes()), id)
+	if err != nil {
+		t.Fatalf("decrypt: %v", err)
+	}
+	got, err := io.ReadAll(dr)
+	if err != nil {
+		t.Fatalf("read decrypted: %v", err)
+	}
+	if !bytes.Equal(got, plaintext) {
+		t.Fatalf("decrypted = %q, want %q", got, plaintext)
+	}
+}
+
+func TestValidateRecipient(t *testing.T) {
+	id, _ := age.GenerateX25519Identity()
+	if err := ValidateRecipient(id.Recipient().String()); err != nil {
+		t.Fatalf("valid recipient rejected: %v", err)
+	}
+	if err := ValidateRecipient(""); err == nil {
+		t.Fatal("empty recipient should error")
+	}
+	if err := ValidateRecipient("not-an-age-key"); err == nil {
+		t.Fatal("garbage recipient should error")
+	}
+}
+
+// TestSnapshotConsistencyUnderConcurrentWrites is the crux check for DAR-70: a
+// goroutine hammers the LIVE source db with continuous Update writes while the
+// snapshotter hot-copies it. The resulting snapshot must validate (via the
+// recover-wrapped production validator) — i.e. never capture a torn write.
+func TestSnapshotConsistencyUnderConcurrentWrites_DAR70(t *testing.T) {
+	root := t.TempDir()
+	dbPath := filepath.Join(root, "micromdm.db")
+	makeBolt(t, dbPath)
+
+	// Open the live db RW and keep it open for the duration (mirrors MicroMDM
+	// holding the exclusive lock while we hot-copy the file bytes).
+	live, err := bolt.Open(dbPath, 0o600, &bolt.Options{Timeout: time.Second})
+	if err != nil {
+		t.Fatalf("open live db: %v", err)
+	}
+	defer live.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		i := 0
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
+			_ = live.Update(func(tx *bolt.Tx) error {
+				b, err := tx.CreateBucketIfNotExists([]byte("Churn"))
+				if err != nil {
+					return err
+				}
+				i++
+				return b.Put([]byte("k"), []byte(time.Now().String()))
+			})
+		}
+	}()
+
+	snap := NewBoltSnapshotter()
+	// Take several snapshots while writes are in-flight; each must be consistent.
+	for n := 0; n < 8; n++ {
+		tmp, err := snap.Snapshot(dbPath, root)
+		if err != nil {
+			cancel()
+			wg.Wait()
+			t.Fatalf("snapshot %d failed: %v", n, err)
+		}
+		verifySnapshotChecks(t, tmp)
+		os.Remove(tmp)
+	}
+
+	cancel()
+	wg.Wait()
+}
+
+// verifySnapshotChecks validates a snapshot with the production recover-wrapped
+// validator. We deliberately do NOT use tx.Check(): on a genuinely torn copy
+// Check() runs in an internal goroutine and a panic there would crash the whole
+// `go test` binary rather than fail this test.
+func verifySnapshotChecks(t *testing.T, path string) {
+	t.Helper()
+	if err := validateBolt(path, 2*time.Second); err != nil {
+		t.Fatalf("snapshot failed validation: %v", err)
+	}
+}
+
+// TestValidateBoltTornCopyFailsSafe is the regression for the CRITICAL finding:
+// a hand-corrupted db file (valid header byte count but zeroed/truncated
+// interior) must make validateBolt return an error WITHOUT panicking — never
+// crash the process, never report a torn copy as clean.
+func TestValidateBoltTornCopyFailsSafe(t *testing.T) {
+	root := t.TempDir()
+	good := filepath.Join(root, "good.db")
+	makeBolt(t, good)
+	// Grow the db so it has interior pages worth corrupting.
+	live, err := bolt.Open(good, 0o600, &bolt.Options{Timeout: time.Second})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if err := live.Update(func(tx *bolt.Tx) error {
+		b, _ := tx.CreateBucketIfNotExists([]byte("Big"))
+		for i := 0; i < 500; i++ {
+			if err := b.Put([]byte{byte(i), byte(i >> 8)}, bytes.Repeat([]byte("x"), 256)); err != nil {
+				return err
+			}
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("grow: %v", err)
+	}
+	live.Close()
+
+	raw, err := os.ReadFile(good)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+
+	cases := map[string][]byte{
+		// Truncated mid-file: keep the two meta pages + a bit, drop the rest so
+		// pgid in the meta points past EOF.
+		"truncated": raw[:len(raw)/2],
+		// Size not a multiple of the page size: append a stray byte.
+		"misaligned": append(append([]byte{}, raw...), 0x00),
+		// Interior pages zeroed: meta pages intact (so checksum may pass) but the
+		// referenced data/branch pages are garbage.
+		"zeroed-interior": zeroInterior(raw),
+	}
+
+	for name, corrupt := range cases {
+		t.Run(name, func(t *testing.T) {
+			p := filepath.Join(t.TempDir(), "torn.db")
+			if err := os.WriteFile(p, corrupt, 0o600); err != nil {
+				t.Fatalf("write torn: %v", err)
+			}
+			// MUST NOT panic; MUST return an error. The recover in validateBolt
+			// turns any internal bbolt panic into this error.
+			err := validateBolt(p, time.Second)
+			if err == nil {
+				t.Fatalf("validateBolt accepted a torn copy (%s) as clean", name)
+			}
+		})
+	}
+}
+
+// TestValidateBoltHighBitPgidRejected_DAR70 is the regression for the integer-
+// safety bug Codex caught in the high-water-mark guard: a torn copy whose active
+// meta carries a VALID checksum but a pgid with the high bit set would, under a
+// naive int64(pgid) cast, become negative and silently PASS the bounds check —
+// then get mmap-walked and accepted as clean. The fix compares in uint64 space.
+// The other torn cases all use normal (small) pgids, so only this one exercises
+// the signed-overflow path.
+func TestValidateBoltHighBitPgidRejected_DAR70(t *testing.T) {
+	root := t.TempDir()
+	good := filepath.Join(root, "good.db")
+	makeBolt(t, good)
+	// Grow so the file spans several real pages and stays a clean multiple of the
+	// page size (no truncation/misalignment that an earlier guard would catch).
+	live, err := bolt.Open(good, 0o600, &bolt.Options{Timeout: time.Second})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if err := live.Update(func(tx *bolt.Tx) error {
+		b, _ := tx.CreateBucketIfNotExists([]byte("Big"))
+		return b.Put([]byte("k"), bytes.Repeat([]byte("x"), 4096))
+	}); err != nil {
+		t.Fatalf("grow: %v", err)
+	}
+	live.Close()
+
+	raw, err := os.ReadFile(good)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	pageSize := int(binary.LittleEndian.Uint32(raw[boltPageHeaderSize+metaOffPageSize:]))
+	if pageSize < 512 {
+		t.Fatalf("implausible page size %d", pageSize)
+	}
+
+	// Tamper BOTH meta pages: set the high-water pgid to a value with the high bit
+	// set (negative as int64) and recompute the FNV-1a checksum so the meta still
+	// parses as valid — forcing the bounds check (not the checksum check) to be the
+	// line of defense.
+	const highBitPgid uint64 = 1 << 63 // 0x8000000000000000
+	for _, pageOff := range []int{0, pageSize} {
+		metaStart := pageOff + boltPageHeaderSize
+		binary.LittleEndian.PutUint64(raw[metaStart+metaOffPgid:], highBitPgid)
+		h := fnv.New64a()
+		_, _ = h.Write(raw[metaStart : metaStart+metaOffChecksum])
+		binary.LittleEndian.PutUint64(raw[metaStart+metaOffChecksum:], h.Sum64())
+	}
+
+	p := filepath.Join(t.TempDir(), "highbit.db")
+	if err := os.WriteFile(p, raw, 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	// Without the uint64 comparison this returns nil (accepts the torn copy) — the
+	// bug. With the fix it rejects via the high-water-mark guard.
+	if err := validateBolt(p, time.Second); err == nil {
+		t.Fatalf("validateBolt accepted a high-bit-pgid torn copy as clean")
+	}
+}
+
+// TestSnapshotRetriesThenErrorsOnPersistentTear: hand Snapshot a source that is
+// always torn (a static corrupt file); it must retry then error cleanly without
+// panicking, leaving no validated temp file behind.
+func TestSnapshotRetriesThenErrorsOnPersistentTear(t *testing.T) {
+	root := t.TempDir()
+	good := filepath.Join(root, "good.db")
+	makeBolt(t, good)
+	raw, err := os.ReadFile(good)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	torn := filepath.Join(root, "torn.db")
+	if err := os.WriteFile(torn, raw[:len(raw)/3], 0o600); err != nil { // truncated => always torn
+		t.Fatalf("write torn: %v", err)
+	}
+
+	snap := &BoltSnapshotter{Config: SnapshotConfig{MaxAttempts: 3, Backoff: time.Millisecond, OpenTimeout: time.Second}}
+	out, err := snap.Snapshot(torn, root)
+	if err == nil {
+		t.Fatalf("expected Snapshot to error on a persistently torn source; got path %q", out)
+	}
+	if out != "" {
+		t.Fatalf("Snapshot returned a path on failure: %q", out)
+	}
+}
+
+// zeroInterior zeroes every page after the two meta pages, leaving the meta
+// pages (and thus the page-size header + meta checksum) intact.
+func zeroInterior(raw []byte) []byte {
+	out := append([]byte{}, raw...)
+	if len(out) < 28 {
+		return out
+	}
+	pageSize := int(out[24]) | int(out[25])<<8 | int(out[26])<<16 | int(out[27])<<24
+	if pageSize <= 0 || 2*pageSize >= len(out) {
+		return out
+	}
+	for i := 2 * pageSize; i < len(out); i++ {
+		out[i] = 0
+	}
+	return out
+}
+
+// failingSnapshotter is injected to confirm the archiver surfaces snapshot
+// errors during Phase A (Stage).
+type failingSnapshotter struct{}
+
+func (failingSnapshotter) Snapshot(string, string) (string, error) {
+	return "", io.ErrUnexpectedEOF
+}
+
+func TestArchivePropagatesSnapshotError(t *testing.T) {
+	root := t.TempDir()
+	makeBolt(t, filepath.Join(root, "x.db"))
+	a := &Archiver{Snapshotter: failingSnapshotter{}}
+	// Stage (Phase A) must fail; nothing is written.
+	_, err := a.Stage(root)
+	if err == nil {
+		t.Fatal("expected Stage to fail when snapshotter errors")
+	}
+}

--- a/docs/dar70-state-export-runbook.md
+++ b/docs/dar70-state-export-runbook.md
@@ -1,0 +1,255 @@
+# DAR-70 — State Export Runbook (EigenCloud → GCP migration)
+
+How the admin-gated `/data` state export works end-to-end, and the exact operator
+flow to extract the TEE-sealed coordinator state and rehydrate it on a GCP
+Confidential VM.
+
+> **AI agents must NOT run this against prod.** Enabling the endpoint, deploying
+> the export build to EigenCloud, and running the extraction are **human-only**
+> actions (prod EigenCloud + KMS are human-only — see CLAUDE.md). This doc
+> prepares the commands; a human executes them.
+
+---
+
+## What this solves
+
+The prod coordinator's trust state is **born inside the EigenCloud TEE** and has
+never left it:
+
+- `/data/step-ca/` — the **root + intermediate CA private keys** that sign
+  provider device-attest / SCEP certs.
+- `/data/micromdm/` — the **MicroMDM BoltDB** (the enrolled-device database that
+  the operative hardware-trust check, SecurityInfo, reads against), plus the push
+  cert and the `.push_imported` sentinel.
+
+EigenCloud gives no shell into `/mnt/disks/userdata`, so the only way to carry
+this state to a GCP Confidential VM **without re-enrolling the whole fleet** is to
+ship a coordinator build that can read it and emit it — encrypted to a key the
+operator holds offline. That is `GET /v1/admin/state-export`.
+
+Everything else the new coordinator needs is already portable: the env/KMS
+secrets (operator has the `.env`), the `MNEMONIC` (carried byte-identical), and
+the database (the same AWS RDS, cross-cloud).
+
+---
+
+## Before / After
+
+### Before — prod on EigenCloud (sealed state never leaves the TEE)
+
+```mermaid
+flowchart LR
+  CON["Consumer<br/>(sealed request)"]
+  PRV["Provider Mac<br/>(Secure Enclave)"]
+  DNS["api.darkbloom.dev"]
+  RDS[("AWS RDS<br/>Postgres")]
+
+  subgraph EC["EigenCloud TEE (SEV-SNP class)"]
+    direction TB
+    CAD["Caddy (TLS, injected)"]
+    CO["coordinator :8080"]
+    SC["step-ca :9000"]
+    MM["MicroMDM :9002"]
+    DATA[("/mnt/disks/userdata<br/>step-ca CA keys<br/>MicroMDM BoltDB<br/>SEALED — never extracted")]
+    CAD --> CO
+    CO --- SC
+    CO --- MM
+    SC --> DATA
+    MM --> DATA
+    CO --> DATA
+  end
+
+  CON --> DNS --> CAD
+  PRV -. wss .-> DNS
+  CO --> RDS
+```
+
+### After — prod on GCP Confidential VM (same domain, same DB, rehydrated state)
+
+```mermaid
+flowchart LR
+  CON2["Consumer<br/>(sealed request)"]
+  PRV2["Provider Mac<br/>(Secure Enclave)"]
+  DNS2["api.darkbloom.dev<br/>(DNS repointed)"]
+  RDS2[("AWS RDS<br/>Postgres — same")]
+
+  subgraph GCP["GCP Confidential VM (n2d, SEV-SNP)"]
+    direction TB
+    CAD2["Caddy (TLS, Let's Encrypt)"]
+    CO2["coordinator :8080"]
+    SC2["step-ca :9000"]
+    MM2["MicroMDM :9002"]
+    DATA2[("/mnt/disks/userdata<br/>REHYDRATED:<br/>SAME step-ca CA keys<br/>SAME MicroMDM BoltDB")]
+    CAD2 --> CO2
+    CO2 --- SC2
+    CO2 --- MM2
+    SC2 --> DATA2
+    MM2 --> DATA2
+    CO2 --> DATA2
+  end
+
+  CON2 --> DNS2 --> CAD2
+  PRV2 -. wss .-> DNS2
+  CO2 --> RDS2
+```
+
+The fleet sees no change: same `api.darkbloom.dev`, same CA that signed their
+certs, same MicroMDM DB that holds their enrollment, same deposit/E2E `kid`
+(`MNEMONIC` carried over).
+
+---
+
+## The extraction + rehydration flow
+
+```mermaid
+sequenceDiagram
+  actor Op as Admin (human)
+  participant Off as Offline machine<br/>(age identity)
+  participant EC as EigenCloud coordinator
+  participant GCP as GCP Confidential VM
+
+  Note over Op,Off: 0. Prep (offline, once)
+  Op->>Off: age-keygen -o identity.txt
+  Off-->>Op: public recipient age1...
+
+  Note over Op,EC: 1. Enable on prod (human-only KMS + deploy)
+  Op->>EC: KMS set STATE_EXPORT_ENABLED=true,<br/>STATE_EXPORT_RECIPIENT=age1... + redeploy
+
+  Note over Op,EC: 2. Extract (one request)
+  Op->>EC: GET /v1/admin/state-export<br/>Authorization: Bearer ADMIN_KEY
+  EC->>EC: gate: 404 if disabled / 403 if bad key
+  EC->>EC: Phase A — snapshot+validate BoltDB,<br/>stage step-ca + micromdm (clean 500 on failure)
+  EC->>EC: Phase B — zip, then age-encrypt to recipient
+  EC-->>Op: darkbloom-state-<ts>.zip.age (encrypted stream)
+
+  Note over Op,Off: 3. Decrypt + verify (offline)
+  Op->>Off: age -d -i identity.txt -> .zip
+  Off->>Off: unzip -l; open BoltDB read-only; check CA certs
+
+  Note over Op,GCP: 4. Rehydrate BEFORE first coordinator boot
+  Op->>GCP: unzip into /mnt/disks/userdata
+  Op->>GCP: inject MNEMONIC + secrets; start coordinator
+  GCP->>GCP: start.sh sees /data/step-ca/config -> PRESERVES (no re-init)
+  GCP-->>Op: verify /v1/encryption-key kid matches;<br/>a known enrolled Mac reaches hardware trust
+
+  Note over Op,EC: 5. Disable (human-only)
+  Op->>EC: KMS set STATE_EXPORT_ENABLED=false + redeploy (endpoint -> 404)
+```
+
+---
+
+## Exact operator commands
+
+### 0. Generate the offline recipient keypair (once)
+
+On a trusted, ideally offline machine:
+
+```bash
+age-keygen -o dar70-export-identity.txt
+# prints: Public key: age1qz...   <-- this is the RECIPIENT
+```
+
+Keep `dar70-export-identity.txt` (the private identity) offline. Only the
+`age1...` **public** recipient goes to the coordinator.
+
+### 1. Enable the endpoint on prod EigenCloud (human-only)
+
+Set via EigenCloud KMS and redeploy the coordinator build that contains the
+endpoint:
+
+```
+EIGENINFERENCE_STATE_EXPORT_ENABLED=true
+EIGENINFERENCE_STATE_EXPORT_RECIPIENT=age1qz...      # the offline public key
+# EIGENINFERENCE_ADMIN_KEY is already set
+```
+
+Defaults are fail-closed: with `ENABLED` unset the route returns **404**; with no
+recipient set and `ALLOW_PLAINTEXT` unset it returns **412** (encrypted-by-default).
+
+### 2. Extract (one authenticated request)
+
+```bash
+curl -fSL https://api.darkbloom.dev/v1/admin/state-export \
+  -H "Authorization: Bearer $EIGENINFERENCE_ADMIN_KEY" \
+  -o darkbloom-state.zip.age
+```
+
+The coordinator snapshots the BoltDB consistently (hot-copy + validate + retry —
+MicroMDM keeps the live DB locked), zips `step-ca/**` + `micromdm/**` (excluding
+`*.log`, including `.push_imported`), and **age-encrypts the stream to your
+recipient**. No plaintext is ever written to the coordinator's disk or logs.
+
+### 3. Decrypt + verify (offline)
+
+```bash
+age --decrypt -i dar70-export-identity.txt -o darkbloom-state.zip darkbloom-state.zip.age
+
+unzip -l darkbloom-state.zip            # expect step-ca/..., micromdm/micromdm.db, micromdm/.push_imported
+unzip -d /tmp/verify darkbloom-state.zip
+# sanity-check the BoltDB opens read-only and the CA certs are present:
+ls -l /tmp/verify/step-ca/certs/        # root_ca.crt, intermediate_ca.crt (+ keys)
+```
+
+### 4. Rehydrate on the GCP Confidential VM — BEFORE first coordinator boot
+
+The container's `start.sh` only initializes a fresh CA when `/data/step-ca/config`
+is absent. Land the extracted tree at `/mnt/disks/userdata` **before** the
+coordinator first runs, so the guard preserves it:
+
+```bash
+# copy the decrypted zip to the CVM, then on the CVM:
+sudo mkdir -p /mnt/disks/userdata
+sudo unzip -o darkbloom-state.zip -d /mnt/disks/userdata
+# modes are preserved by the zip; confirm secrets stay tight:
+sudo chmod 600 /mnt/disks/userdata/micromdm/push.key /mnt/disks/userdata/step-ca/secrets/password
+```
+
+Inject `MNEMONIC` (byte-identical) and the rest of the secret set into GCP Secret
+Manager, then start the coordinator. **Verify before any DNS cutover:**
+
+```bash
+# kid must match prod EigenCloud (proves MNEMONIC continuity)
+curl -s https://<cvm-staging-host>/v1/encryption-key | jq .kid
+# then point one known-enrolled Mac at the CVM and confirm it reaches hardware trust
+```
+
+### 5. Disable the endpoint (human-only)
+
+Immediately after a successful extraction:
+
+```
+EIGENINFERENCE_STATE_EXPORT_ENABLED=false   # (or unset) + redeploy → route returns 404 again
+```
+
+Then handle the artifacts per policy: the `.zip.age` is only decryptable with the
+offline identity; destroy the decrypted `.zip` and `/tmp/verify` once rehydration
+is verified.
+
+---
+
+## Security properties (why this is safe to ship)
+
+- **Off by default** — the route is 404 unless `STATE_EXPORT_ENABLED=true`.
+- **Admin-key only** — constant-time, length-leak-free (SHA-256 digests compared);
+  the Privy-admin path is intentionally **not** accepted for this endpoint.
+- **Encrypted by default** — the archive is age-encrypted to an offline recipient;
+  a raw zip requires an explicit `STATE_EXPORT_ALLOW_PLAINTEXT=true`.
+- **Consistent + fail-loud** — BoltDB is snapshotted with hot-copy + byte-level
+  validation + retry; a torn copy or a degenerate (empty / missing MicroMDM DB)
+  export fails as a clean pre-stream **500**, never a truncated 200.
+- **No plaintext residue** — staged snapshots live in one `0700` temp dir that is
+  always removed; nothing sensitive is logged (only counts, addr, outcome).
+
+> The step-ca intermediate key is encrypted at rest under a password that is
+> public in `deploy/start.sh`, so the transit encryption (age, to your offline
+> key) is the real protection for the exported bytes. Treat the `.zip.age` and the
+> offline identity accordingly.
+
+---
+
+## Where this sits in the migration
+
+`DAR-69` (build the GCP CVM target) → **`DAR-70` (this — extract + rehydrate)** →
+`DAR-105` (security review of the exfil path) → `DAR-71` (DNS cutover to the CVM,
+rollback = revert DNS). The domain stays `api.darkbloom.dev` throughout; the
+`.dev → .ai` move (`DAR-243`) is a separate, later project.

--- a/docs/eigencloud-to-gcp-migration-runbook.md
+++ b/docs/eigencloud-to-gcp-migration-runbook.md
@@ -1,0 +1,161 @@
+# EigenCloud → GCP Confidential VM — Migration Runbook
+
+How to move the prod coordinator off EigenCloud onto a GCP Confidential VM with
+**no fleet disruption**, and how to handle the `darkbloom.dev → darkbloom.ai`
+domain change (separately).
+
+Tickets: `DAR-69` (build CVM target) → `DAR-70` (extract + rehydrate sealed
+state — see [dar70-state-export-runbook.md](dar70-state-export-runbook.md)) →
+`DAR-105` (security review) → `DAR-71` (cutover). `DAR-243` (`.ai`) is **decoupled**.
+
+> **Prod EigenCloud, GCP prod deploys, KMS, and DNS are human-only.** AI agents
+> prepare PRs/commands; a human runs anything that mutates prod.
+
+---
+
+## The core idea: this is a state move, not a rebuild
+
+The **dev environment already is the GCP target shape** (`deploy/gcp/*`: GCE VM +
+Docker + systemd + host Caddy + Secret Manager + the same `/mnt/disks/userdata`
+path, so the container's `start.sh` runs unchanged). So the migration is **not**
+an infra-build problem — it's a **state-continuity** problem with three deltas:
+
+1. **Confidential-compute** flags on the VM (preserve the TEE memory-encryption property).
+2. The **prod secret set** in GCP Secret Manager.
+3. The **sealed-state lift** (`DAR-70`) — the only thing that can't otherwise leave EigenCloud.
+
+## What makes it smooth (five invariants)
+
+| Invariant | Why it keeps the fleet/consumers unaware |
+|---|---|
+| **Keep `api.darkbloom.dev`** — repoint DNS only | The MDM `ServerURL` is baked into every enrolled device's profile, and the provider binary self-heals to `wss://api.darkbloom.dev`. Same host = nothing to re-enroll or re-release. |
+| **Keep the same AWS RDS** (cross-cloud) | The store is DSN-portable → zero data migration; users/balances/releases/providers all just work. |
+| **Lift the sealed state faithfully** (`DAR-70`) | Same step-ca CA that signed device certs + same MicroMDM BoltDB → providers re-earn hardware trust normally. |
+| **Carry `MNEMONIC` byte-identical** | Same X25519 `kid` on `/v1/encryption-key` → sealed senders don't break. |
+| **Stage + verify everything before the DNS flip; roll back by reverting DNS** | The cutover is a single, reversible DNS change with EigenCloud kept warm. |
+
+---
+
+## Phase 0 — Pre-flight decisions (lock these first; read-only)
+
+1. **RDS reachability.** Is prod RDS publicly reachable (security-group allowlist) or private-VPC? Private-VPC ⇒ you need VPC peering / PrivateLink / VPN GCP↔AWS — a **multi-day networking task**, decide now. Fallback: Cloud SQL via dump/restore in the maintenance window. (Recommended: keep RDS cross-cloud; add the GCP static egress IP to the RDS SG; `sslmode=require`.)
+2. **Confidential platform.** AMD **SEV-SNP (`n2d`)** recommended (matches the SEV-SNP language in `ARCHITECTURE.md`/`threat-model.yaml`). Reconcile what EigenCloud's TEE actually is vs the docs before asserting "privacy-claim continuity."
+3. **Single CVM vs HA.** CVMs can't live-migrate (`--maintenance-policy=TERMINATE` ⇒ host maintenance reboots the box). With local-disk state (CA keys + BoltDB) there's **no clean multi-instance HA** — accept a single-CVM availability regression vs blue-green, or plan a maintenance-window posture.
+4. **`DAR-105` policy.** Is a one-shot in-TEE export of the CA key to an offline-held key acceptable (this plan), or must the CA never leave the TEE (⇒ re-key on GCP + full fleet re-enroll)? This plan assumes the former.
+5. **Secret custody.** Who holds the offline age identity (DAR-70) and how `MNEMONIC` is moved KMS→Secret Manager without touching a workstation in cleartext.
+6. **Confirm domain stays `api.darkbloom.dev`** for this move (scopes `DAR-243` out).
+
+---
+
+## Phase 1 — Build the prod GCP Confidential VM (`DAR-69`)
+
+Parameterize the dev scripts into a **separate prod GCP project** and add
+confidential-compute. Stand up an **empty** CVM that boots the unchanged
+container; verify; then discard its throwaway `/data`.
+
+- `bootstrap.sh`: `MACHINE_TYPE e2-small → n2d-standard-2` (e2 can't run confidential), and add to the instance create:
+  `--confidential-compute-type=SEV_SNP --maintenance-policy=TERMINATE --shielded-secure-boot --shielded-vtpm --shielded-integrity-monitoring`.
+- **Boot-time confidential assertion** (new, Phase-1 blocker): the coordinator (or vm-startup) must verify it's actually on a confidential VM and refuse to serve if not. *Omitting the flag silently produces a non-confidential VM where the host can read decrypted prompts, with zero error today.*
+- Host **Caddy** for `api.darkbloom.dev` (Let's Encrypt). The in-container `coordinator/Caddyfile` (EigenCloud-injected `/run/tls/`) is dead on the VM.
+- Point at the **same RDS** (drop the dev `cloud-sql-proxy` unit; `sslmode=require`).
+- **Secret Manager parity** — include what the dev wiring is missing: `APNS_*` and `EIGENINFERENCE_MDM_WEBHOOK_SECRET` (confirm prod even has them), and **add `MNEMONIC` + `MICROMDM_API_KEY` to `CRITICAL_VARS`** in `refresh-env.sh` (today an empty value boots a broken coordinator with no abort — empty `MICROMDM_API_KEY` skips MicroMDM entirely → fleet outage).
+- Set **`DD_ENV=production`** + prod hostname (vm-startup hardcodes `development`) so prod dashboards/monitors aren't polluted/blinded.
+
+*Rollback: delete the VM. Prod is untouched on EigenCloud.*
+
+## Phase 2 — Extract the sealed state (`DAR-70`)
+
+Human ships the export build to EigenCloud and runs the one-shot extraction, per
+[dar70-state-export-runbook.md](dar70-state-export-runbook.md). Output: an
+age-encrypted archive of `step-ca/**` + `micromdm/**`, decrypted offline.
+
+*Rollback: code-only / read-only on prod; nothing mutated.*
+
+## Phase 3 — Rehydrate + verify on the CVM (no prod traffic yet)
+
+- Land the decrypted `/data` at `/mnt/disks/userdata` **before** the coordinator's first boot (so `start.sh`'s `if [ ! -d /data/step-ca/config ]` guard preserves the real CA).
+- Inject `MNEMONIC` (byte-identical) + the full secret set. Boot the CVM on a **staging hostname**.
+- **Verification gates (all must pass before any DNS change):**
+  - `GET /v1/encryption-key` `kid` == prod EigenCloud's (proves `MNEMONIC` continuity).
+  - A **known-enrolled Mac** pointed at the CVM completes a MicroMDM SecurityInfo round-trip and reaches **hardware trust** (proves BoltDB + push-cert continuity).
+  - SCEP re-enroll + ACME cert renewal chain to the carried step-ca.
+  - APNs attestor logs **ENABLED**; MDM webhook returns **200** (not 403).
+
+*Rollback: don't flip DNS. Prod stays on EigenCloud.*
+
+## Phase 4 — Cutover + rollback (`DAR-71`)
+
+```mermaid
+flowchart TD
+  A[CVM staged + all Phase-3 gates green] --> B[Pre-lower api.darkbloom.dev DNS TTL]
+  B --> C[Pre-provision TLS cert on CVM via DNS-01<br/>avoids HTTPS cold-start at flip]
+  C --> D[FREEZE: pause provider releases + new enrollments]
+  D --> E[Final consistent re-export + rehydrate<br/>if devices enrolled since Phase 3]
+  E --> F[Flip api.darkbloom.dev A-record -> CVM IP]
+  F --> G{Healthy?<br/>providers reconnect, re-earn hardware trust,<br/>billing OK, capacity returns}
+  G -- yes --> H[Soak; keep EigenCloud warm]
+  H --> I[Unfreeze; decommission EigenCloud after clean soak]
+  G -- no --> R[ROLLBACK: revert A-record -> EigenCloud IP]
+  R --> S[Fleet reconnects to EigenCloud<br/>same RDS, original /data — full trust]
+```
+
+**Smoothness details that bite if skipped:**
+- **TLS cold-start:** at the flip the CVM's Caddy needs a valid `api.darkbloom.dev` cert *before* traffic arrives — pre-provision via **DNS-01** (HTTP-01 needs DNS already pointing at the CVM → brief all-HTTPS outage otherwise).
+- **Freeze enrollment + releases:** otherwise (a) a device enrolled during the window is stranded if you roll back to EigenCloud's older BoltDB, and (b) a `POST /v1/releases` could register on the soon-dead instance.
+- **Shared-RDS overlap:** both coordinators briefly share one RDS — keep exactly **one active Stripe webhook target** (no `ON CONFLICT` on `ledger_entries`); drain EigenCloud first to shrink the window.
+- **Rollback is just the DNS revert** — fast, bounded by the pre-lowered TTL, EigenCloud retains the original `/data` + same RDS.
+
+**After a clean soak (optional, additive):** add `GET /v1/attestation` (vTPM/GCE confidential attestation token) — the coordinator has no self-attestation surface today, so this is the one change that actually *improves* verifiability over the implicit "trust EigenCloud." Update `ARCHITECTURE.md`/`threat-model.yaml`/runbook to "GCP Confidential VM + Secret Manager" (and **redact the prod RDS endpoint** currently hardcoded in `docs/coordinator-deploy-runbook.md:16`).
+
+---
+
+## Changing the domain (`darkbloom.dev → darkbloom.ai`) — DECOUPLE it
+
+Do the substrate move first on the stable domain. The `.ai` rename is its **own
+later project**, because two bindings make a simultaneous switch dangerous:
+
+1. **MDM `ServerURL`** is baked into every already-enrolled device's installed
+   `.mobileconfig` (`micromdm serve -server-url https://${DOMAIN}`). If
+   `api.darkbloom.dev` stops serving, devices can't answer SecurityInfo → the
+   operative hardware-trust path fails → fleet de-routes under `MIN_TRUST=hardware`.
+2. The **provider binary self-heals** to `wss://api.darkbloom.dev/ws/provider` on
+   every startup, so a config-only domain switch is silently reverted.
+
+### How to do `.ai` additively (when you choose to)
+
+```mermaid
+flowchart LR
+  P1[Register darkbloom.ai DNS + TLS] --> P2[Parallel-serve BOTH hosts<br/>Caddy accepts .dev and .ai]
+  P2 --> P3[New signed/notarized provider release<br/>default -> .ai, .dev fallback]
+  P3 --> P4[New .ai enroll profiles<br/>reuse Payload UUIDs so SE key isn't orphaned]
+  P4 --> P5[Re-enroll + fleet auto-update campaign]
+  P5 --> P6[Update Privy callbacks, Stripe webhooks,<br/>console CSP + hardcoded ATTESTATION_API, emails]
+  P6 --> P7[Telemetry: zero devices/providers on .dev?]
+  P7 --> P8[Retire .dev — keep as permanent redirect until then]
+```
+
+- **Keep `api.darkbloom.dev` alive as a permanent alias** as long as *any* device
+  is enrolled against it. It can't be hard-cut.
+- Already domain-independent (no change): the model CDN `models.darkbloom.ai` and
+  the APNs topic (Apple bundle ID `io.darkbloom.provider`).
+- Code touch-points for `.ai`: `coordinator/Caddyfile` (single `{$DOMAIN}` block →
+  accept two names), `coordinator/api/{server,consumer,device_auth,enroll}.go` +
+  `install.sh`, the console-ui `darkbloom.dev` references + the hardcoded
+  `ATTESTATION_API`/CSP `connect-src`, and the `prod.env` URLs.
+
+---
+
+## One-screen blast-radius checklist
+
+- [ ] `MNEMONIC` byte-identical (kid match verified) — **in `CRITICAL_VARS`**
+- [ ] `MICROMDM_API_KEY` present — **in `CRITICAL_VARS`** (empty ⇒ MicroMDM skipped ⇒ outage)
+- [ ] step-ca CA keys + MicroMDM BoltDB rehydrated (consistent snapshot; a real device reaches hardware trust)
+- [ ] `APNS_*` + `EIGENINFERENCE_MDM_WEBHOOK_SECRET` in Secret Manager (confirm prod has them)
+- [ ] RDS network path proven from GCP; `sslmode=require`
+- [ ] `--confidential-compute-type=SEV_SNP` + boot-time confidential assertion
+- [ ] Caddy cert pre-provisioned (DNS-01) before flip; port 80/443 open
+- [ ] `DD_ENV=production` + prod hostname; monitors re-pointed
+- [ ] Enrollment + provider releases frozen during the window
+- [ ] Single Stripe webhook target during overlap
+- [ ] EigenCloud kept warm; DNS TTL pre-lowered; rollback = revert A-record
+- [ ] `DOMAIN=api.darkbloom.dev` unchanged (DAR-243 out of scope)

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/eigeninference/d-inference
 go 1.25.0
 
 require (
+	filippo.io/age v1.3.1
 	github.com/DataDog/datadog-go/v5 v5.8.3
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/google/uuid v1.6.0
@@ -10,6 +11,7 @@ require (
 	github.com/openai/openai-go v1.12.0
 	github.com/smallstep/pkcs7 v0.2.1
 	github.com/stretchr/testify v1.11.1
+	go.etcd.io/bbolt v1.4.3
 	golang.org/x/crypto v0.49.0
 	golang.org/x/time v0.15.0
 	gopkg.in/DataDog/dd-trace-go.v1 v1.74.8
@@ -18,6 +20,7 @@ require (
 )
 
 require (
+	filippo.io/hpke v0.4.0 // indirect
 	github.com/DataDog/datadog-agent/comp/core/tagger/origindetection v0.67.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/obfuscate v0.67.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/proto v0.67.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,9 @@
+c2sp.org/CCTV/age v0.0.0-20251208015420-e9274a7bdbfd h1:ZLsPO6WdZ5zatV4UfVpr7oAwLGRZ+sebTUruuM4Ra3M=
+c2sp.org/CCTV/age v0.0.0-20251208015420-e9274a7bdbfd/go.mod h1:SrHC2C7r5GkDk8R+NFVzYy/sdj0Ypg9htaPXQq5Cqeo=
+filippo.io/age v1.3.1 h1:hbzdQOJkuaMEpRCLSN1/C5DX74RPcNCk6oqhKMXmZi0=
+filippo.io/age v1.3.1/go.mod h1:EZorDTYUxt836i3zdori5IJX/v2Lj6kWFU0cfh6C0D4=
+filippo.io/hpke v0.4.0 h1:p575VVQ6ted4pL+it6M00V/f2qTZITO0zgmdKCkd5+A=
+filippo.io/hpke v0.4.0/go.mod h1:EmAN849/P3qdeK+PCMkDpDm83vRHM5cDipBJ8xbQLVY=
 github.com/DataDog/datadog-agent/comp/core/tagger/origindetection v0.67.0 h1:2mEwRWvhIPHMPK4CMD8iKbsrYBxeMBSuuCXumQAwShU=
 github.com/DataDog/datadog-agent/comp/core/tagger/origindetection v0.67.0/go.mod h1:ejJHsyJTG7NU6c6TDbF7dmckD3g+AUGSdiSXy+ZyaCE=
 github.com/DataDog/datadog-agent/pkg/obfuscate v0.67.0 h1:NcvyDVIUA0NbBDbp7QJnsYhoBv548g8bXq886795mCQ=
@@ -190,6 +196,8 @@ github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
+go.etcd.io/bbolt v1.4.3 h1:dEadXpI6G79deX5prL3QRNP6JB8UxVkqo4UPnHaNXJo=
+go.etcd.io/bbolt v1.4.3/go.mod h1:tKQlpPaYCVFctUIgFKFnAlvbmB3tpy1vkTnDWohtc0E=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
 go.opentelemetry.io/collector/component v1.31.0 h1:9LzU8X1RhV3h8/QsAoTX23aFUfoJ3EUc9O/vK+hFpSI=


### PR DESCRIPTION
## Summary

Adds an **admin-gated endpoint to export the coordinator's TEE-sealed on-disk state (`/data`)** as a downloadable archive, so the prod coordinator can be migrated off the EigenCloud TEE onto a GCP Confidential VM **without re-enrolling the provider fleet**.

This is the **DAR-70** piece of the EigenCloud→GCP migration: the step-ca root + intermediate **CA private keys** and the MicroMDM **BoltDB device database** are born inside the TEE on first boot and have never been exfiltrated — this endpoint is the only way to lift them out so the existing fleet keeps authenticating after the move.

## Endpoint

`GET /v1/admin/state-export` — triple-gated, fail-closed:

1. **`EIGENINFERENCE_STATE_EXPORT_ENABLED`** (default `false`) → returns **404** when off (route inert until toggled + restart).
2. **`isAdminAuthorized`** — reuses the existing constant-time admin-key / Privy-admin check.
3. **Encrypted by default** — if `EIGENINFERENCE_STATE_EXPORT_RECIPIENT` (an `age1…` recipient) is set, output is age-encrypted (`darkbloom-state-<ts>.zip.age`); a raw zip requires `EIGENINFERENCE_STATE_EXPORT_ALLOW_PLAINTEXT=true`, otherwise **412**.

Root resolution: `EIGENINFERENCE_STATE_EXPORT_ROOT` → `USER_PERSISTENT_DATA_PATH` → `/mnt/disks/userdata`.

## What it captures

Zips `step-ca/**` (config, secrets incl. password, certs) and `micromdm/**` (BoltDB, push/server certs, the hidden **`.push_imported`** sentinel), excluding `*.log`. Resolves the symlinked `/data` root. Streams the archive (no full-archive buffering).

## Consistency — the hard part

MicroMDM holds an exclusive bbolt lock on its live DB, so a naive copy can capture a torn write → a corrupt snapshot would silently de-route the fleet on restore. The export is **two-phase**:

- **Phase A** (before any `200`): hot-copy each `*.db` into a `0700` staging dir, then **validate** — byte-level bolt-meta check (magic / version / FNV checksum + **uint64 high-water-mark `pgid` bounds**, *before* any mmap), then a `recover`-wrapped bucket walk; retry on a torn copy; error out if no clean snapshot can be obtained. `tx.Check()` is deliberately **not** used (it panics in an unrecoverable goroutine).
- **Phase B**: only then write `200` + stream the zip from the validated copies. A mid-stream error does **not** finalize the zip (truncated download instead of a structurally-valid partial one). The staging dir is always cleaned up.

**Fail-loud:** 0 files (or 0 DB snapshots when a `micromdm/` dir exists) → error, never a silent empty archive.

## Security

This is a deliberate exfiltration primitive for the CA private key (the step-ca intermediate key is encrypted under a password that is public in `deploy/start.sh`), so the admin gate + transit encryption are the only protections. No key material, file bytes, or tokens are logged; each access is audit-logged (remote addr, authorized, encrypted, counts, outcome).

## Testing

`coordinator/stateexport` unit tests + `coordinator/api` HTTP-path tests via `httptest.NewServer`: all gates, plaintext + encrypted round-trip, multiple/nested DBs, symlinked root, root-missing → 500, disabled + bad-auth → 404, negative responses assert zero bytes, snapshot consistency under concurrent writes, and torn-DB regressions — including `TestValidateBoltHighBitPgidRejected_DAR70`, verified to fail without the `uint64` pgid fix. `go build`, `go vet`, `gofmt`, the full suites, and the Linux cross-compile are all green.

## Review

Dual review (Codex + Claude). Round 1 flagged a torn-copy SIGSEGV that defeated the retry loop and a possible partial-archive-after-`200` → fixed via the two-phase restructure. Round 2 caught an `int64(pgid)` signed cast that let a high-bit pgid slip past the bounds guard → fixed (`uint64` compare) + regression added.

## Operational notes / follow-ups (not in this PR)

- Shipping this build to EigenCloud and **running** the export is a **human-only** action.
- After exporting with `_ENABLED`, set it back to `false` (redeploy) — the env flag is the off-switch.
- Follow-ups: the **restore/rehydrate** counterpart on the GCP side; bundling `MNEMONIC` into the export; step-ca's Badger `db/` is WARN-logged only (rare writes — quiesce enrollments during the one-time export).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/294"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783620293&installation_id=133247490&pr_number=294&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F294&signature=99abd7da8a8fea2f0c7eb998d00036ae3ceef6d9fa8f0b1fee4e06ac7c670b0f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->