### PR TITLE
feat(console-ui): image upload in chat for vision models (Gemma 4)

### DIFF
--- a/console-ui/src/app/page.tsx
+++ b/console-ui/src/app/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useCallback, useState } from "react";
 import { useStore } from "@/lib/store";
 import { streamChat, fetchModels } from "@/lib/api";
+import { buildApiContent } from "@/lib/image-upload";
 import { useToastStore } from "@/hooks/useToast";
 import { useAuth } from "@/hooks/useAuth";
 import { ChatMessage } from "@/components/ChatMessage";
@@ -83,9 +84,9 @@ export default function ChatPage() {
   }, [activeChat?.messages]);
 
   const handleSend = useCallback(
-    async (content: string) => {
+    async (content: string, images: string[] = []) => {
       const trimmedContent = content.trim();
-      if (!trimmedContent) {
+      if (!trimmedContent && images.length === 0) {
         return;
       }
 
@@ -97,10 +98,8 @@ export default function ChatPage() {
 
       const chat = useStore.getState().chats.find((c) => c.id === chatId);
       if (chat && chat.messages.length === 0) {
-        const title =
-          trimmedContent.length > 40
-            ? trimmedContent.slice(0, 40) + "..."
-            : trimmedContent;
+        const base = trimmedContent || (images.length > 0 ? "Image" : "");
+        const title = base.length > 40 ? base.slice(0, 40) + "..." : base;
         updateChatTitle(chatId, title);
       }
 
@@ -108,6 +107,7 @@ export default function ChatPage() {
         id: generateId(),
         role: "user",
         content: trimmedContent,
+        ...(images.length > 0 ? { images } : {}),
         timestamp: Date.now(),
       };
       const currentChat = useStore
@@ -144,7 +144,7 @@ export default function ChatPage() {
 
       const userMessages = [...priorMessages, userMsg].map((m) => ({
         role: m.role,
-        content: m.content,
+        content: buildApiContent(m.content, m.images),
       }));
       const allMessages = [
         { role: "system" as const, content: SYSTEM_PROMPT },
@@ -272,7 +272,7 @@ export default function ChatPage() {
         { role: "system" as const, content: SYSTEM_PROMPT },
         ...messages
           .slice(0, errorIdx)
-          .map((m) => ({ role: m.role, content: m.content })),
+          .map((m) => ({ role: m.role, content: buildApiContent(m.content, m.images) })),
       ];
 
       streamChat(

--- a/console-ui/src/app/page.tsx
+++ b/console-ui/src/app/page.tsx
@@ -142,6 +142,10 @@ export default function ChatPage() {
       const abort = new AbortController();
       abortRef.current = abort;
 
+      // NOTE: m.images is undefined for turns restored from persistence (images
+      // are stripped from localStorage to protect the quota — see store.ts),
+      // so earlier-turn image context isn't re-sent after a page reload.
+      // Follow-up: durable image storage (IndexedDB) to close this gap.
       const userMessages = [...priorMessages, userMsg].map((m) => ({
         role: m.role,
         content: buildApiContent(m.content, m.images),
@@ -272,6 +276,8 @@ export default function ChatPage() {
         { role: "system" as const, content: SYSTEM_PROMPT },
         ...messages
           .slice(0, errorIdx)
+          // m.images is undefined after a reload (stripped from persistence),
+          // so retrying an image turn post-reload re-sends text only.
           .map((m) => ({ role: m.role, content: buildApiContent(m.content, m.images) })),
       ];
 

--- a/console-ui/src/app/page.tsx
+++ b/console-ui/src/app/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useRef, useCallback, useState } from "react";
 import { useStore } from "@/lib/store";
 import { streamChat, fetchModels } from "@/lib/api";
-import { buildApiContent } from "@/lib/image-upload";
+import { toApiMessages } from "@/lib/chat-messages";
 import { useToastStore } from "@/hooks/useToast";
 import { useAuth } from "@/hooks/useAuth";
 import { ChatMessage } from "@/components/ChatMessage";
@@ -142,17 +142,9 @@ export default function ChatPage() {
       const abort = new AbortController();
       abortRef.current = abort;
 
-      // NOTE: m.images is undefined for turns restored from persistence (images
-      // are stripped from localStorage to protect the quota — see store.ts),
-      // so earlier-turn image context isn't re-sent after a page reload.
-      // Follow-up: durable image storage (IndexedDB) to close this gap.
-      const userMessages = [...priorMessages, userMsg].map((m) => ({
-        role: m.role,
-        content: buildApiContent(m.content, m.images),
-      }));
       const allMessages = [
         { role: "system" as const, content: SYSTEM_PROMPT },
-        ...userMessages,
+        ...toApiMessages([...priorMessages, userMsg]),
       ];
 
       try {
@@ -274,11 +266,7 @@ export default function ChatPage() {
       // Rebuild message history up to (but not including) the error message
       const allMessages = [
         { role: "system" as const, content: SYSTEM_PROMPT },
-        ...messages
-          .slice(0, errorIdx)
-          // m.images is undefined after a reload (stripped from persistence),
-          // so retrying an image turn post-reload re-sends text only.
-          .map((m) => ({ role: m.role, content: buildApiContent(m.content, m.images) })),
+        ...toApiMessages(messages.slice(0, errorIdx)),
       ];
 
       streamChat(

--- a/console-ui/src/components/ChatInput.tsx
+++ b/console-ui/src/components/ChatInput.tsx
@@ -1,12 +1,14 @@
 "use client";
 
 import { useState, useRef, useCallback, useEffect } from "react";
-import { Send, Square, ChevronDown, LogIn, Cpu } from "lucide-react";
+import { Send, Square, ChevronDown, LogIn, Cpu, ImagePlus, X } from "lucide-react";
 import { useStore } from "@/lib/store";
 import { trackEvent } from "@/lib/google-analytics";
+import { modelSupportsImages, MAX_IMAGES_PER_MESSAGE } from "@/lib/image-upload";
+import { useImageUpload } from "@/hooks/useImageUpload";
 
 interface ChatInputProps {
-  onSend: (content: string) => void;
+  onSend: (content: string, images: string[]) => void;
   onStop: () => void;
   isStreaming: boolean;
   authenticated?: boolean;
@@ -19,13 +21,27 @@ export function ChatInput({ onSend, onStop, isStreaming, authenticated = true, o
   const { selectedModel, models, setSelectedModel, useMyMachine, setUseMyMachine } = useStore();
   const [modelOpen, setModelOpen] = useState(false);
 
+  const selectedModelObj = models.find((m) => m.id === selectedModel);
+  const supportsImages = modelSupportsImages(selectedModelObj);
+  const {
+    images,
+    imgError,
+    atLimit: atImageLimit,
+    fileInputRef,
+    removeImage,
+    clearImages,
+    handlePaste,
+    handleFileInputChange,
+  } = useImageUpload(supportsImages);
+
   const handleSend = useCallback(() => {
     const trimmed = input.trim();
-    if (!trimmed || isStreaming) return;
-    onSend(trimmed);
+    if ((!trimmed && images.length === 0) || isStreaming) return;
+    onSend(trimmed, images);
     setInput("");
+    clearImages();
     if (textareaRef.current) textareaRef.current.style.height = "auto";
-  }, [input, isStreaming, onSend]);
+  }, [input, images, isStreaming, onSend, clearImages]);
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
@@ -53,8 +69,6 @@ export function ChatInput({ onSend, onStop, isStreaming, authenticated = true, o
   }, [modelOpen]);
 
   const chatModels = models;
-
-  const selectedModelObj = chatModels.find((m) => m.id === selectedModel);
   const displayModel = selectedModelObj?.display_name
     || selectedModel?.split("/").pop()
     || "Select model";
@@ -86,16 +100,44 @@ export function ChatInput({ onSend, onStop, isStreaming, authenticated = true, o
       <div className="max-w-4xl mx-auto px-3 sm:px-6 py-3 sm:py-4">
         <div className="relative flex flex-col gap-2 bg-bg-white rounded-2xl border border-border-dim
                         shadow-md focus-within:shadow-lg transition-all">
+          {/* Staged image thumbnails */}
+          {images.length > 0 && (
+            <div className="flex flex-wrap gap-2 px-4 pt-3">
+              {images.map((src, i) => (
+                <div key={i} className="relative">
+                  <img
+                    src={src}
+                    alt={`Attachment ${i + 1}`}
+                    className="h-16 w-16 rounded-lg border border-border-dim object-cover"
+                  />
+                  <button
+                    type="button"
+                    onClick={() => removeImage(i)}
+                    aria-label={`Remove image ${i + 1}`}
+                    className="absolute -top-1.5 -right-1.5 flex items-center justify-center w-5 h-5 rounded-full bg-ink text-white border border-bg-white hover:opacity-90 transition-opacity"
+                  >
+                    <X size={11} />
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
+
           {/* Textarea */}
           <textarea
             ref={textareaRef}
             value={input}
             onChange={(e) => setInput(e.target.value)}
             onKeyDown={handleKeyDown}
+            onPaste={handlePaste}
             placeholder="Send a message..."
             rows={1}
             className="w-full bg-transparent px-4 pt-4 pb-1 text-text-primary placeholder:text-text-tertiary text-[15px] resize-none outline-none"
           />
+
+          {imgError && (
+            <p className="px-4 text-xs text-accent-red" role="alert">{imgError}</p>
+          )}
 
           {/* Bottom bar */}
           <div className="flex items-center justify-between px-3 pb-3">
@@ -174,6 +216,30 @@ export function ChatInput({ onSend, onStop, isStreaming, authenticated = true, o
                 <span className="hidden sm:inline">My Machine</span>
                 {useMyMachine && <span className="text-[10px] opacity-80">· Free, else paid</span>}
               </button>
+
+              {/* Image attach — only for vision models (e.g. Gemma 4) */}
+              {supportsImages && (
+                <>
+                  <input
+                    ref={fileInputRef}
+                    type="file"
+                    accept="image/png,image/jpeg,image/webp,image/gif"
+                    multiple
+                    onChange={handleFileInputChange}
+                    className="hidden"
+                  />
+                  <button
+                    type="button"
+                    onClick={() => fileInputRef.current?.click()}
+                    disabled={isStreaming || atImageLimit}
+                    title={atImageLimit ? `Up to ${MAX_IMAGES_PER_MESSAGE} images` : "Attach image"}
+                    aria-label="Attach image"
+                    className="flex items-center px-2.5 py-1.5 rounded-lg text-xs text-text-tertiary hover:text-text-secondary hover:bg-bg-hover border-2 border-transparent hover:border-border-subtle transition-all disabled:opacity-30 disabled:hover:bg-transparent"
+                  >
+                    <ImagePlus size={14} />
+                  </button>
+                </>
+              )}
             </div>
 
             {/* Right: Send / Stop */}
@@ -188,7 +254,7 @@ export function ChatInput({ onSend, onStop, isStreaming, authenticated = true, o
               ) : (
                 <button
                   onClick={handleSend}
-                  disabled={!input.trim() || isStreaming}
+                  disabled={(!input.trim() && images.length === 0) || isStreaming}
                   className="flex items-center justify-center w-9 h-9 rounded-xl bg-coral border-2 border-ink text-white
                              disabled:opacity-30 disabled:border-border-subtle
                              hover:opacity-90

--- a/console-ui/src/components/ChatMessage.tsx
+++ b/console-ui/src/components/ChatMessage.tsx
@@ -260,13 +260,30 @@ export function ChatMessage({ message, onRetry }: { message: Message; onRetry?: 
   const isThinking = message.streaming && !message.content && !!message.thinking;
 
   if (isUser) {
+    const hasImages = !!message.images && message.images.length > 0;
     return (
       <div className="message-animate py-4">
         <div className="max-w-4xl mx-auto px-3 sm:px-6 flex justify-end">
-          <div className="max-w-[90%] sm:max-w-[80%] bg-coral/10 border-2 border-coral/30 rounded-2xl rounded-br-md px-4 py-3">
-            <p className="text-[15px] text-text-primary leading-relaxed whitespace-pre-wrap">
-              {message.content}
-            </p>
+          <div className="max-w-[90%] sm:max-w-[80%] flex flex-col items-end gap-2">
+            {hasImages && (
+              <div className="flex flex-wrap gap-2 justify-end">
+                {message.images!.map((src, i) => (
+                  <img
+                    key={i}
+                    src={src}
+                    alt={`Attached image ${i + 1}`}
+                    className="max-h-48 max-w-[12rem] rounded-xl border-2 border-coral/30 object-cover"
+                  />
+                ))}
+              </div>
+            )}
+            {message.content && (
+              <div className="bg-coral/10 border-2 border-coral/30 rounded-2xl rounded-br-md px-4 py-3">
+                <p className="text-[15px] text-text-primary leading-relaxed whitespace-pre-wrap">
+                  {message.content}
+                </p>
+              </div>
+            )}
           </div>
         </div>
       </div>

--- a/console-ui/src/hooks/useImageUpload.test.ts
+++ b/console-ui/src/hooks/useImageUpload.test.ts
@@ -1,0 +1,77 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { useImageUpload } from "./useImageUpload";
+import { MAX_IMAGES_PER_MESSAGE } from "@/lib/image-upload";
+
+// Avoid touching the analytics global (gtag) during tests.
+vi.mock("@/lib/google-analytics", () => ({ trackEvent: vi.fn() }));
+
+function pngFile(name = "a.png"): File {
+  return new File([new Uint8Array([1, 2, 3])], name, { type: "image/png" });
+}
+
+describe("useImageUpload", () => {
+  it("stages valid images via addFiles", async () => {
+    const { result } = renderHook(() => useImageUpload(true));
+    await act(async () => {
+      await result.current.addFiles([pngFile(), pngFile("b.png")]);
+    });
+    expect(result.current.images).toHaveLength(2);
+    expect(result.current.imgError).toBeNull();
+  });
+
+  it("rejects an invalid type with an error and stages nothing", async () => {
+    const { result } = renderHook(() => useImageUpload(true));
+    const bad = new File([new Uint8Array([1])], "x.pdf", { type: "application/pdf" });
+    await act(async () => {
+      await result.current.addFiles([bad]);
+    });
+    expect(result.current.images).toHaveLength(0);
+    expect(result.current.imgError).toMatch(/unsupported/i);
+  });
+
+  it("enforces the per-message cap", async () => {
+    const { result } = renderHook(() => useImageUpload(true));
+    const many = Array.from({ length: MAX_IMAGES_PER_MESSAGE + 2 }, (_, i) =>
+      pngFile(`f${i}.png`)
+    );
+    await act(async () => {
+      await result.current.addFiles(many);
+    });
+    expect(result.current.images).toHaveLength(MAX_IMAGES_PER_MESSAGE);
+    expect(result.current.atLimit).toBe(true);
+    expect(result.current.imgError).toMatch(/up to/i);
+  });
+
+  it("removes and clears staged images", async () => {
+    const { result } = renderHook(() => useImageUpload(true));
+    await act(async () => {
+      await result.current.addFiles([pngFile(), pngFile("b.png")]);
+    });
+    act(() => result.current.removeImage(0));
+    expect(result.current.images).toHaveLength(1);
+    act(() => result.current.clearImages());
+    expect(result.current.images).toHaveLength(0);
+    expect(result.current.imgError).toBeNull();
+  });
+
+  it("ignores intake and clears staged images when disabled", async () => {
+    const { result, rerender } = renderHook(({ on }) => useImageUpload(on), {
+      initialProps: { on: true },
+    });
+    await act(async () => {
+      await result.current.addFiles([pngFile()]);
+    });
+    expect(result.current.images).toHaveLength(1);
+
+    rerender({ on: false });
+    await waitFor(() => expect(result.current.images).toHaveLength(0));
+
+    // Further intake is a no-op while disabled.
+    await act(async () => {
+      await result.current.addFiles([pngFile()]);
+    });
+    expect(result.current.images).toHaveLength(0);
+  });
+});

--- a/console-ui/src/hooks/useImageUpload.test.ts
+++ b/console-ui/src/hooks/useImageUpload.test.ts
@@ -44,6 +44,18 @@ describe("useImageUpload", () => {
     expect(result.current.imgError).toMatch(/up to/i);
   });
 
+  it("never exceeds the cap even with two overlapping intakes (race)", async () => {
+    const { result } = renderHook(() => useImageUpload(true));
+    const batch = () =>
+      Array.from({ length: MAX_IMAGES_PER_MESSAGE }, (_, i) => pngFile(`r${i}.png`));
+    // Both calls read the same stale images.length (0) before either commits;
+    // without the in-updater cap this would stage 2 * MAX.
+    await act(async () => {
+      await Promise.all([result.current.addFiles(batch()), result.current.addFiles(batch())]);
+    });
+    expect(result.current.images).toHaveLength(MAX_IMAGES_PER_MESSAGE);
+  });
+
   it("removes and clears staged images", async () => {
     const { result } = renderHook(() => useImageUpload(true));
     await act(async () => {

--- a/console-ui/src/hooks/useImageUpload.ts
+++ b/console-ui/src/hooks/useImageUpload.ts
@@ -1,0 +1,120 @@
+"use client";
+
+import { useState, useRef, useCallback, useEffect } from "react";
+import { trackEvent } from "@/lib/google-analytics";
+import {
+  validateImageFile,
+  fileToDataURL,
+  MAX_IMAGES_PER_MESSAGE,
+} from "@/lib/image-upload";
+
+export interface ImageUpload {
+  images: string[];
+  imgError: string | null;
+  atLimit: boolean;
+  fileInputRef: React.RefObject<HTMLInputElement | null>;
+  addFiles: (files: File[]) => Promise<void>;
+  removeImage: (index: number) => void;
+  clearImages: () => void;
+  handlePaste: (e: React.ClipboardEvent) => void;
+  handleFileInputChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+}
+
+/**
+ * Image-attachment state for the chat composer: staging, validation, base64
+ * encoding, paste + file-picker intake, and the per-message cap. `enabled`
+ * gates intake (pass false for non-vision models); when it flips false any
+ * staged images are auto-cleared so we never send media a model can't accept.
+ */
+export function useImageUpload(enabled: boolean): ImageUpload {
+  const [images, setImages] = useState<string[]>([]);
+  const [imgError, setImgError] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (!enabled && images.length > 0) {
+      setImages([]);
+      setImgError(null);
+    }
+  }, [enabled, images.length]);
+
+  const addFiles = useCallback(
+    async (files: File[]) => {
+      if (!enabled || files.length === 0) return;
+      setImgError(null);
+      let remaining = MAX_IMAGES_PER_MESSAGE - images.length;
+      if (remaining <= 0) {
+        setImgError(`You can attach up to ${MAX_IMAGES_PER_MESSAGE} images per message.`);
+        return;
+      }
+      const accepted: string[] = [];
+      for (const file of files) {
+        if (remaining <= 0) {
+          setImgError(`You can attach up to ${MAX_IMAGES_PER_MESSAGE} images per message.`);
+          break;
+        }
+        const err = validateImageFile(file);
+        if (err) {
+          setImgError(err);
+          continue;
+        }
+        try {
+          accepted.push(await fileToDataURL(file));
+          remaining -= 1;
+        } catch {
+          setImgError("Failed to read one of the images. Try again.");
+        }
+      }
+      if (accepted.length > 0) {
+        setImages((prev) => [...prev, ...accepted]);
+        trackEvent("chat_image_attached", { count: accepted.length });
+      }
+    },
+    [enabled, images.length]
+  );
+
+  const removeImage = useCallback((index: number) => {
+    setImages((prev) => prev.filter((_, i) => i !== index));
+  }, []);
+
+  const clearImages = useCallback(() => {
+    setImages([]);
+    setImgError(null);
+  }, []);
+
+  const handlePaste = useCallback(
+    (e: React.ClipboardEvent) => {
+      if (!enabled) return;
+      const files = Array.from(e.clipboardData.files).filter((f) =>
+        f.type.startsWith("image/")
+      );
+      if (files.length > 0) {
+        e.preventDefault();
+        void addFiles(files);
+      }
+    },
+    [enabled, addFiles]
+  );
+
+  const handleFileInputChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const files = e.target.files ? Array.from(e.target.files) : [];
+      void addFiles(files);
+      // Reset so picking the same file again still fires onChange.
+      e.target.value = "";
+    },
+    [addFiles]
+  );
+
+  return {
+    images,
+    imgError,
+    atLimit: images.length >= MAX_IMAGES_PER_MESSAGE,
+    fileInputRef,
+    addFiles,
+    removeImage,
+    clearImages,
+    handlePaste,
+    handleFileInputChange,
+  };
+}

--- a/console-ui/src/hooks/useImageUpload.ts
+++ b/console-ui/src/hooks/useImageUpload.ts
@@ -66,7 +66,10 @@ export function useImageUpload(enabled: boolean): ImageUpload {
         }
       }
       if (accepted.length > 0) {
-        setImages((prev) => [...prev, ...accepted]);
+        // Cap inside the updater: two overlapping intakes (e.g. a paste landing
+        // while a prior file read is still awaiting) both read the same stale
+        // `images.length` above, so enforce the limit against the latest state.
+        setImages((prev) => [...prev, ...accepted].slice(0, MAX_IMAGES_PER_MESSAGE));
         trackEvent("chat_image_attached", { count: accepted.length });
       }
     },

--- a/console-ui/src/lib/api.ts
+++ b/console-ui/src/lib/api.ts
@@ -82,9 +82,23 @@ export interface UsageEntry {
   timestamp: string;
 }
 
+/**
+ * A content part in the OpenAI/OpenRouter multimodal format. Either a text
+ * part or an image part. The image `url` is a base64 `data:` URI — our
+ * provider is end-to-end-encrypted and rejects remote http(s)/file URLs
+ * (the image must ride inside the encrypted prompt). Mirrors the provider's
+ * `OpenAIContentPart`.
+ */
+export type ChatContentPart =
+  | { type: "text"; text: string }
+  | { type: "image_url"; image_url: { url: string } };
+
 export interface ChatMessage {
   role: "user" | "assistant" | "system";
-  content: string;
+  // `string` for text-only turns (unchanged wire shape); a parts array when
+  // the turn carries images, matching the standard OpenAI/OpenRouter
+  // `image_url` content-part format.
+  content: string | ChatContentPart[];
 }
 
 export interface TrustMetadata {

--- a/console-ui/src/lib/chat-messages.test.ts
+++ b/console-ui/src/lib/chat-messages.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import { toApiMessages } from "./chat-messages";
+import type { Message } from "./store";
+
+function msg(partial: Pick<Message, "role" | "content"> & Partial<Message>): Message {
+  return { id: "x", timestamp: 0, ...partial };
+}
+
+describe("toApiMessages", () => {
+  it("returns [] for an empty list", () => {
+    expect(toApiMessages([])).toEqual([]);
+  });
+
+  it("preserves roles and keeps text-only turns as plain strings", () => {
+    const out = toApiMessages([
+      msg({ role: "user", content: "hi" }),
+      msg({ role: "assistant", content: "hello" }),
+    ]);
+    expect(out).toEqual([
+      { role: "user", content: "hi" },
+      { role: "assistant", content: "hello" },
+    ]);
+  });
+
+  it("inlines attached images as text-first image_url parts", () => {
+    const out = toApiMessages([
+      msg({ role: "user", content: "what is this", images: ["data:image/png;base64,AAA"] }),
+    ]);
+    expect(out).toEqual([
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "what is this" },
+          { type: "image_url", image_url: { url: "data:image/png;base64,AAA" } },
+        ],
+      },
+    ]);
+  });
+
+  it("maps a mixed conversation (text turn + image turn) correctly", () => {
+    const out = toApiMessages([
+      msg({ role: "user", content: "earlier text" }),
+      msg({ role: "assistant", content: "reply" }),
+      msg({ role: "user", content: "", images: ["data:image/jpeg;base64,BBB"] }),
+    ]);
+    expect(out[0]).toEqual({ role: "user", content: "earlier text" });
+    expect(out[1]).toEqual({ role: "assistant", content: "reply" });
+    expect(out[2]).toEqual({
+      role: "user",
+      content: [{ type: "image_url", image_url: { url: "data:image/jpeg;base64,BBB" } }],
+    });
+  });
+});

--- a/console-ui/src/lib/chat-messages.ts
+++ b/console-ui/src/lib/chat-messages.ts
@@ -1,0 +1,23 @@
+import type { Message } from "./store";
+import type { ChatMessage } from "./api";
+import { buildApiContent } from "./image-upload";
+
+/**
+ * Convert stored chat messages into the OpenAI/OpenRouter wire shape, inlining
+ * any attached images as `image_url` content parts (text-only turns stay plain
+ * strings). Shared by the send and retry paths so the transformation lives in
+ * one place.
+ *
+ * NOTE: `m.images` is undefined for turns restored from persistence (images are
+ * stripped from localStorage to protect the quota — see store.ts `partialize`),
+ * so earlier-turn image context isn't re-sent after a page reload. Follow-up:
+ * durable image storage (IndexedDB).
+ */
+export function toApiMessages(
+  messages: Pick<Message, "role" | "content" | "images">[]
+): ChatMessage[] {
+  return messages.map((m) => ({
+    role: m.role,
+    content: buildApiContent(m.content, m.images),
+  }));
+}

--- a/console-ui/src/lib/image-upload.test.ts
+++ b/console-ui/src/lib/image-upload.test.ts
@@ -1,0 +1,133 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from "vitest";
+import {
+  validateImageFile,
+  fileToDataURL,
+  modelSupportsImages,
+  buildApiContent,
+  ALLOWED_IMAGE_TYPES,
+  MAX_IMAGE_BYTES,
+  MAX_IMAGES_PER_MESSAGE,
+} from "./image-upload";
+
+function makeFile(type: string, sizeBytes = 8, name = "x"): File {
+  const file = new File([new Uint8Array(Math.min(sizeBytes, 1024))], name, { type });
+  // Override the derived size so we can test the cap without allocating big buffers.
+  Object.defineProperty(file, "size", { value: sizeBytes });
+  return file;
+}
+
+describe("validateImageFile", () => {
+  it("accepts every allowed image type under the size limit", () => {
+    for (const type of ALLOWED_IMAGE_TYPES) {
+      expect(validateImageFile(makeFile(type, 1024))).toBeNull();
+    }
+  });
+
+  it("rejects a non-image / disallowed type with a helpful message", () => {
+    const err = validateImageFile(makeFile("application/pdf", 1024, "doc.pdf"));
+    expect(err).toMatch(/unsupported image type/i);
+    expect(err).toContain("application/pdf");
+  });
+
+  it("rejects an empty/unknown type", () => {
+    expect(validateImageFile(makeFile("", 1024))).toMatch(/unsupported/i);
+  });
+
+  it("rejects an image over the size cap", () => {
+    const err = validateImageFile(makeFile("image/png", MAX_IMAGE_BYTES + 1));
+    expect(err).toMatch(/too large/i);
+  });
+
+  it("accepts an image exactly at the cap", () => {
+    expect(validateImageFile(makeFile("image/png", MAX_IMAGE_BYTES))).toBeNull();
+  });
+});
+
+describe("fileToDataURL", () => {
+  it("reads a file into a base64 data: URI with the right mime", async () => {
+    const file = new File([new Uint8Array([1, 2, 3, 4])], "p.png", { type: "image/png" });
+    const url = await fileToDataURL(file);
+    expect(url.startsWith("data:image/png;base64,")).toBe(true);
+  });
+});
+
+describe("modelSupportsImages", () => {
+  it("is true when input_modalities includes image", () => {
+    expect(modelSupportsImages({ input_modalities: ["text", "image"] })).toBe(true);
+  });
+
+  it("is case-insensitive", () => {
+    expect(modelSupportsImages({ input_modalities: ["Text", "Image"] })).toBe(true);
+  });
+
+  it("is false for text-only models", () => {
+    expect(modelSupportsImages({ input_modalities: ["text"] })).toBe(false);
+  });
+
+  it("falls back to capabilities (vision/multimodal)", () => {
+    expect(modelSupportsImages({ capabilities: ["vision"] })).toBe(true);
+    expect(modelSupportsImages({ capabilities: ["multimodal"] })).toBe(true);
+    expect(modelSupportsImages({ capabilities: ["tools"] })).toBe(false);
+  });
+
+  it("is false for null/undefined or empty model", () => {
+    expect(modelSupportsImages(null)).toBe(false);
+    expect(modelSupportsImages(undefined)).toBe(false);
+    expect(modelSupportsImages({})).toBe(false);
+  });
+
+  it("bridges known vision families by id/architecture/family", () => {
+    expect(modelSupportsImages({ id: "mlx-community/gemma-4-26b-a4b-it-4bit" })).toBe(true);
+    expect(modelSupportsImages({ architecture: "gemma4" })).toBe(true);
+    expect(modelSupportsImages({ family: "gemma-4" })).toBe(true);
+  });
+
+  it("does not match non-vision models via the bridge", () => {
+    expect(modelSupportsImages({ id: "qwen/qwen3-8b" })).toBe(false);
+    expect(modelSupportsImages({ id: "openai/gpt-oss-20b", architecture: "gptoss" })).toBe(false);
+  });
+
+  it("honors an explicit image modality regardless of family", () => {
+    expect(
+      modelSupportsImages({ id: "some-future-vlm", input_modalities: ["text", "image"] })
+    ).toBe(true);
+  });
+});
+
+describe("buildApiContent", () => {
+  it("returns a plain string for text-only turns (unchanged wire shape)", () => {
+    expect(buildApiContent("hello")).toBe("hello");
+    expect(buildApiContent("hello", [])).toBe("hello");
+  });
+
+  it("returns text-first parts when images are present (OpenAI/OpenRouter shape)", () => {
+    const out = buildApiContent("describe this", ["data:image/png;base64,AAA"]);
+    expect(out).toEqual([
+      { type: "text", text: "describe this" },
+      { type: "image_url", image_url: { url: "data:image/png;base64,AAA" } },
+    ]);
+  });
+
+  it("omits the text part for an image-only message", () => {
+    const out = buildApiContent("", ["data:image/jpeg;base64,BBB"]);
+    expect(out).toEqual([
+      { type: "image_url", image_url: { url: "data:image/jpeg;base64,BBB" } },
+    ]);
+  });
+
+  it("emits one image_url part per image, in order", () => {
+    const out = buildApiContent("x", ["data:1", "data:2", "data:3"]);
+    expect(Array.isArray(out)).toBe(true);
+    const parts = out as { type: string }[];
+    expect(parts).toHaveLength(4); // 1 text + 3 images
+    expect(parts.filter((p) => p.type === "image_url")).toHaveLength(3);
+  });
+});
+
+describe("constants", () => {
+  it("caps images per message at a sane number", () => {
+    expect(MAX_IMAGES_PER_MESSAGE).toBeGreaterThan(0);
+    expect(MAX_IMAGES_PER_MESSAGE).toBeLessThanOrEqual(10);
+  });
+});

--- a/console-ui/src/lib/image-upload.ts
+++ b/console-ui/src/lib/image-upload.ts
@@ -1,0 +1,115 @@
+// Image-upload helpers for the chat composer (Gemma 4-style vision input).
+//
+// Our endpoint matches the OpenAI/OpenRouter `image_url` wire format, with one
+// constraint: the image must be an inline base64 `data:` URI (the provider is
+// end-to-end-encrypted and rejects remote URLs). So the browser reads the file,
+// validates it, and base64-encodes it client-side before it enters the
+// (sender→coordinator sealed) request body.
+
+import type { ChatContentPart, Model } from "./api";
+
+/** Content types the Gemma 4 vision tower / Core Image decode accepts. */
+export const ALLOWED_IMAGE_TYPES = [
+  "image/png",
+  "image/jpeg",
+  "image/webp",
+  "image/gif",
+] as const;
+
+/** Max size per image. base64 inflates ~33%, and the whole request is sealed
+ *  and sent inside the encrypted prompt, so keep this conservative. */
+export const MAX_IMAGE_BYTES = 10 * 1024 * 1024; // 10 MB
+
+/** Max images attached to a single message. */
+export const MAX_IMAGES_PER_MESSAGE = 4;
+
+function mb(bytes: number): string {
+  return (bytes / (1024 * 1024)).toFixed(1);
+}
+
+/**
+ * Validate a picked/pasted file. Returns a human-readable error string, or
+ * `null` if the file is acceptable.
+ */
+export function validateImageFile(file: File): string | null {
+  if (!(ALLOWED_IMAGE_TYPES as readonly string[]).includes(file.type)) {
+    return `Unsupported image type "${file.type || "unknown"}". Use PNG, JPEG, WebP, or GIF.`;
+  }
+  if (file.size > MAX_IMAGE_BYTES) {
+    return `Image is too large (${mb(file.size)} MB). Max ${mb(MAX_IMAGE_BYTES)} MB.`;
+  }
+  return null;
+}
+
+/** Read a File into a base64 `data:` URI (e.g. `data:image/png;base64,...`). */
+export function fileToDataURL(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onerror = () =>
+      reject(reader.error ?? new Error("Failed to read image file"));
+    reader.onload = () => {
+      const result = reader.result;
+      if (typeof result === "string") {
+        resolve(result);
+      } else {
+        reject(new Error("Unexpected file read result (not a data URL)"));
+      }
+    };
+    reader.readAsDataURL(file);
+  });
+}
+
+/**
+ * Architectures/families known to accept image input. This is a BRIDGE: the
+ * coordinator's model catalog currently hardcodes `input_modalities: ["text"]`
+ * and carries no vision marker, so the metadata checks below can't yet light up
+ * for our VLMs. Once the catalog/registry reports image modality (or a `vision`
+ * capability) for VLM models, the metadata checks take precedence and this
+ * becomes redundant. Keep it narrow — it is NOT a model catalog, just a
+ * capability heuristic. Gemma 4 (26B-A4B) is image+audio+video.
+ */
+const VISION_MODEL_PATTERN = /gemma-?4/i;
+
+/**
+ * Whether a model accepts image input — used to gate the upload control so we
+ * only offer it for vision models (e.g. Gemma 4). Prefers the OpenRouter-style
+ * `input_modalities`, then `capabilities`, then a known-vision-family bridge.
+ */
+export function modelSupportsImages(
+  model?: Partial<
+    Pick<Model, "input_modalities" | "capabilities" | "id" | "architecture" | "family">
+  > | null
+): boolean {
+  if (!model) return false;
+  const modalities = model.input_modalities?.map((m) => m.toLowerCase()) ?? [];
+  if (modalities.includes("image")) return true;
+  const caps = model.capabilities?.map((c) => c.toLowerCase()) ?? [];
+  if (caps.some((c) => c === "vision" || c === "image" || c === "multimodal")) {
+    return true;
+  }
+  const hay = `${model.id ?? ""} ${model.architecture ?? ""} ${model.family ?? ""}`;
+  return VISION_MODEL_PATTERN.test(hay);
+}
+
+/**
+ * Build an OpenAI/OpenRouter-compatible message `content` from text + images.
+ * Text-only turns stay a plain string (unchanged wire shape). When images are
+ * present, returns a parts array with the text FIRST (OpenRouter recommends
+ * text-before-images), followed by one `image_url` part per data: URI.
+ */
+export function buildApiContent(
+  text: string,
+  images?: string[]
+): string | ChatContentPart[] {
+  if (!images || images.length === 0) {
+    return text;
+  }
+  const parts: ChatContentPart[] = [];
+  if (text) {
+    parts.push({ type: "text", text });
+  }
+  for (const url of images) {
+    parts.push({ type: "image_url", image_url: { url } });
+  }
+  return parts;
+}

--- a/console-ui/src/lib/store.ts
+++ b/console-ui/src/lib/store.ts
@@ -13,6 +13,10 @@ export interface Message {
   id: string;
   role: "user" | "assistant";
   content: string;
+  // Attached images as base64 `data:` URIs (user messages only). Kept in
+  // memory for display + re-send within the session; stripped from persisted
+  // state (see `partialize`) so large base64 blobs don't exhaust localStorage.
+  images?: string[];
   thinking?: string;
   trust?: TrustMetadata;
   streaming?: boolean;
@@ -166,8 +170,16 @@ export const useStore = create<AppState>()(
       partialize: (state) => ({
         chats: state.chats.map((c) => ({
           ...c,
-          // Clear streaming flag on any messages that were mid-stream when page closed
-          messages: c.messages.map((m) => ({ ...m, streaming: false })),
+          messages: c.messages.map((m) => ({
+            ...m,
+            // Clear streaming flag on any messages mid-stream when page closed.
+            streaming: false,
+            // Drop base64 image data from persistence — a few attachments would
+            // exceed the ~5-10MB localStorage quota and silently break saving
+            // the whole chat history. Images stay visible for the live session;
+            // they vanish on reload (follow-up: IndexedDB for durable storage).
+            images: undefined,
+          })),
         })),
         activeChatId: state.activeChatId,
         selectedModel: state.selectedModel,


### PR DESCRIPTION
## What
Adds Gemma 4-style **image upload** to the chat composer. Users attach images (file picker + paste); they're base64-encoded client-side and sent as standard OpenAI/OpenRouter `image_url` content parts. The provider (E2E-encrypted) decodes the `data:` URI and runs the VLM (already merged: #293 + Layr-Labs/mlx-swift-lm#34).

## How
- `src/lib/image-upload.ts` — `validateImageFile`, `fileToDataURL`, `modelSupportsImages`, `buildApiContent` (text-first `image_url` parts).
- `src/hooks/useImageUpload.ts` — staging / validation / base64 / per-message cap (keeps the composer thin).
- `ChatInput` — file-picker + paste intake, staged thumbnails with remove, cap; attach button shown **only for vision models**.
- `ChatMessage` — renders attached thumbnails on user turns.
- `page.tsx` — threads images through the send **and** retry paths via `buildApiContent`.
- `store.ts` — `Message.images[]` in memory; **stripped from localStorage** to protect the quota.
- `api.ts` — `ChatContentPart` type; `ChatMessage.content` widened to `string | ChatContentPart[]`.

## Media transport / E2E
Images are base64 `data:` URIs **only** (no remote URLs) — they ride inside the X25519-sealed request; the coordinator never sees them. Matches the provider's `data:`-only decode (SSRF-safe).

## Vision gating
The attach button uses `modelSupportsImages` (reads `input_modalities` / `capabilities`) with a **temporary `gemma-4` family bridge**, because the coordinator catalog currently reports `input_modalities: ["text"]` for all models. The clean fix is a separate coordinator PR that adds the `vision` capability so `deriveModalities` reports image input — after which the bridge is redundant (the gate already prefers real metadata).

## Tests
- `image-upload.test.ts` (19) + `useImageUpload.test.ts` (6, incl. a cap-race regression).
- **236 vitest tests pass; eslint 0 errors; `npm run build` compiles.**
- Reviewed by both quality-gate reviewers (codex + claude): substantive PASS; flagged items fixed.

## Follow-ups
- Images stripped from persistence → prior-turn image context isn't re-sent after a page reload (documented at both send sites; IndexedDB follow-up).
- Not user-visible until a release ships + a provider serves Gemma 4 as VLM.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/295"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783623904&installation_id=133247490&pr_number=295&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F295&signature=bc4d5fbd2476837ff44b9dc45aa3822f64e513cbbcc346eb699846f7e8f0cc1e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->