### PR TITLE
feat(coordinator): report video input modality from a video capability

### DIFF
--- a/coordinator/api/openrouter_models.go
+++ b/coordinator/api/openrouter_models.go
@@ -66,8 +66,9 @@ func mapQuantizationToOpenRouter(q string) string {
 }
 
 // deriveModalities returns the input and output modalities for a model. Text is
-// always present; a vision/multimodal capability adds image input. Embedding
-// models report a text->embedding shape.
+// always present; a vision/multimodal capability adds image input, an audio
+// capability adds audio, and a video capability adds video. Embedding models
+// report a text->embedding shape.
 func deriveModalities(modelType string, capabilities []string) (input, output []string) {
 	mt := strings.ToLower(strings.TrimSpace(modelType))
 	switch mt {
@@ -86,6 +87,10 @@ func deriveModalities(modelType string, capabilities []string) (input, output []
 		case "audio", "audio_input":
 			if !contains(input, "audio") {
 				input = append(input, "audio")
+			}
+		case "video", "video_input":
+			if !contains(input, "video") {
+				input = append(input, "video")
 			}
 		case "file", "pdf":
 			if !contains(input, "file") {

--- a/coordinator/api/openrouter_models_test.go
+++ b/coordinator/api/openrouter_models_test.go
@@ -47,6 +47,22 @@ func TestDeriveModalities(t *testing.T) {
 	if !reflect.DeepEqual(in, []string{"text"}) || !reflect.DeepEqual(out, []string{"embedding"}) {
 		t.Errorf("embedding = (%v,%v), want ([text],[embedding])", in, out)
 	}
+
+	in, _ = deriveModalities("text", []string{"video"})
+	if !reflect.DeepEqual(in, []string{"text", "video"}) {
+		t.Errorf("video input = %v, want [text video]", in)
+	}
+
+	in, _ = deriveModalities("text", []string{"video_input"})
+	if !reflect.DeepEqual(in, []string{"text", "video"}) {
+		t.Errorf("video_input alias = %v, want [text video]", in)
+	}
+
+	// Gemma 4-style: image + audio + video together, order preserved, deduped.
+	in, _ = deriveModalities("text", []string{"vision", "audio", "video", "video"})
+	if !reflect.DeepEqual(in, []string{"text", "image", "audio", "video"}) {
+		t.Errorf("multimodal input = %v, want [text image audio video]", in)
+	}
 }
 
 func TestSupportedFeaturesFromCapabilities(t *testing.T) {


### PR DESCRIPTION
## What
`deriveModalities` now maps a `video` / `video_input` capability to a `video` **input modality**, alongside the existing `vision`→`image`, `audio`→`audio`, `file`→`file` mappings.

## Why
`/v1/models` (`consumer.go`) and the model-registry handler derive `input_modalities` from a model's capabilities via `deriveModalities`. There was **no `video` case**, so a VLM like Gemma 4 (image + audio + video) could never report `video` input — the console-ui and any OpenAI/OpenRouter-style consumer would see text/image at best. This adds the missing case.

## How to enable for a model (no further code needed)
`normalizeCapabilities` already accepts arbitrary capability strings, so set it via the existing admin endpoint:
```
POST /v1/admin/models/{model-id}/capabilities
{"capabilities": ["vision", "audio", "video"]}   # wholesale replace
```
Then `/v1/models` reports `input_modalities: ["text","image","audio","video"]`.

## Tests
- `TestDeriveModalities`: `video`, the `video_input` alias, and a combined image+audio+video case (deduped, order-preserved).
- gofmt clean; `go build ./...` OK; `go test ./api/` passes.

## Related
Pairs with #295 (console-ui image upload). The console-ui gates its upload button on `modelSupportsImages`; once a VLM's capabilities are set here, that gate reads real metadata and the temporary `gemma-4` family bridge in #295 becomes redundant.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/296"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783624025&installation_id=133247490&pr_number=296&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F296&signature=bb2e773895ebb4031a50a0742b5e46b44fb17e47d680dedf6d9b64ddb1c59a17"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->