### PR TITLE
fix(coordinator+provider): kill false "model swap" untrusts on busy multi-model providers

### DIFF
--- a/coordinator/api/model_hash_data_race_test.go
+++ b/coordinator/api/model_hash_data_race_test.go
@@ -1,0 +1,94 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+)
+
+// TestHandlersDoNotRaceModelHashRefresh is a data-race regression for the
+// stale-model-hash heal path at the HTTP layer. UpdateModelWeightHashes replaces
+// Provider.Models copy-on-write under p.mu only (it holds r.mu just as a read
+// lock to look the provider up), so any handler that ranges p.Models without
+// holding p.mu races on the slice header against the challenge goroutine.
+//
+// The /v1/stats and /v1/providers/attestation handlers both range p.Models
+// inside a ForEachProvider callback. This test drives both handlers concurrently
+// with UpdateModelWeightHashes; run under -race it fails (DATA RACE) before the
+// handler-side locking fix and passes after.
+func TestHandlersDoNotRaceModelHashRefresh(t *testing.T) {
+	const modelID = "data-race-model"
+
+	srv, _ := testServer(t)
+	reg := srv.registry
+
+	regMsg := &protocol.RegisterMessage{
+		Type:                    protocol.TypeRegister,
+		Hardware:                protocol.Hardware{ChipName: "Apple M3 Max", MemoryGB: 64, GPUCores: 40},
+		Models:                  []protocol.ModelInfo{{ID: modelID, ModelType: "chat", Quantization: "4bit", WeightHash: "hash-a"}},
+		Backend:                 "mlx-swift",
+		PublicKey:               testPublicKeyB64(),
+		EncryptedResponseChunks: true,
+		PrivacyCapabilities:     testPrivacyCaps(),
+	}
+	reg.Register("p1", nil, regMsg)
+
+	handler := srv.Handler()
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+
+	// Writer: flip the stored weight hash so each call actually replaces the
+	// Provider.Models slice header (the racy write).
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		toggle := false
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			h := "hash-a"
+			if toggle {
+				h = "hash-b"
+			}
+			toggle = !toggle
+			reg.UpdateModelWeightHashes("p1", map[string]string{modelID: h})
+		}
+	}()
+
+	hit := func(path string) {
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+	}
+
+	for _, path := range []string{"/v1/stats", "/v1/providers/attestation"} {
+		path := path
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				hit(path)
+			}
+		}()
+	}
+
+	// Hammer the writer from this goroutine too, then stop.
+	for i := 0; i < 20000; i++ {
+		reg.UpdateModelWeightHashes("p1", map[string]string{modelID: "hash-c"})
+		reg.UpdateModelWeightHashes("p1", map[string]string{modelID: "hash-a"})
+	}
+	close(stop)
+	wg.Wait()
+}

--- a/coordinator/api/model_hash_data_race_test.go
+++ b/coordinator/api/model_hash_data_race_test.go
@@ -63,6 +63,15 @@ func TestHandlersDoNotRaceModelHashRefresh(t *testing.T) {
 	}()
 
 	hit := func(path string) {
+		// /v1/stats caches its serialized body for 60s, so without this the
+		// handler would range p.Models only on the first (cache-miss) call and
+		// the stats-side race would be exercised exactly once. Invalidate the
+		// key each iteration so every call misses the cache and actually reads
+		// p.Models — otherwise reverting ONLY the stats fix would not reliably
+		// trip -race.
+		if path == "/v1/stats" {
+			srv.readCache.Invalidate("stats:v1")
+		}
 		req := httptest.NewRequest(http.MethodGet, path, nil)
 		w := httptest.NewRecorder()
 		handler.ServeHTTP(w, req)

--- a/coordinator/api/model_hash_race_test.go
+++ b/coordinator/api/model_hash_race_test.go
@@ -1,0 +1,200 @@
+package api
+
+// Regression tests for the active-model-hash RACE that false-untrusted busy
+// dual-model providers in prod.
+//
+// The challenge response used to be validated by comparing
+// resp.ActiveModelHash (the hash of whatever model the PROVIDER considered
+// current when it built the response) against the catalog hash of
+// provider.CurrentModel (the model the COORDINATOR believed current, from the
+// last heartbeat — up to a heartbeat interval stale). On a provider serving
+// two models with interleaved traffic, the current model flips between
+// heartbeats, so a perfectly correct hash of model B was misread as a
+// tampered hash of model A → false "model swap" hard-untrust.
+//
+// The fix validates the model-keyed resp.ModelHashes map against the catalog
+// — exact and race-free — with a membership fallback for legacy responses
+// that carry only active_model_hash.
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+	"github.com/eigeninference/d-inference/coordinator/registry"
+	"github.com/eigeninference/d-inference/coordinator/store"
+	"nhooyr.io/websocket"
+)
+
+const (
+	gemmaHash  = "a4722b6020adb1894c700b45ddcd58bc0e0f033abe7139f86cbbbfe60cba4eb6"
+	gptOSSHash = "61bfc04e4016a7fa487eb10e29f79360047e302487229f298da3681984aec512"
+)
+
+// challengeExchange registers a dual-model provider, makes the coordinator
+// believe "model-gemma" is current (via heartbeat), then answers the first
+// challenge with the given hash payload. Returns the provider's final status.
+func challengeExchange(
+	t *testing.T,
+	modelHashes map[string]string,
+	activeModelHash string,
+) registry.ProviderStatus {
+	t.Helper()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	st := store.NewMemory(store.Config{AdminKey: "test-key"})
+	reg := registry.New(logger)
+	reg.SetModelCatalog([]registry.CatalogEntry{
+		{ID: "model-gemma", WeightHash: gemmaHash},
+		{ID: "model-gptoss", WeightHash: gptOSSHash},
+	})
+	srv := NewServer(reg, st, ServerConfig{}, logger)
+	srv.challengeInterval = 200 * time.Millisecond
+
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http") + "/ws/provider"
+	conn, _, err := websocket.Dial(ctx, wsURL, nil)
+	if err != nil {
+		t.Fatalf("websocket dial: %v", err)
+	}
+	defer conn.Close(websocket.StatusNormalClosure, "")
+
+	pubKey := testPublicKeyB64()
+	regMsg := protocol.RegisterMessage{
+		Type:     protocol.TypeRegister,
+		Hardware: protocol.Hardware{ChipName: "Apple M2 Ultra", MemoryGB: 128},
+		Models: []protocol.ModelInfo{
+			{ID: "model-gemma", SizeBytes: 1000, ModelType: "chat", Quantization: "8bit", WeightHash: gemmaHash},
+			{ID: "model-gptoss", SizeBytes: 1000, ModelType: "chat", Quantization: "4bit", WeightHash: gptOSSHash},
+		},
+		Backend:   "mlx-swift",
+		PublicKey: pubKey,
+	}
+	regData, _ := json.Marshal(regMsg)
+	if err := conn.Write(ctx, websocket.MessageText, regData); err != nil {
+		t.Fatalf("write register: %v", err)
+	}
+
+	// Heartbeat: the coordinator's last word is "model-gemma is current".
+	active := "model-gemma"
+	hb := protocol.HeartbeatMessage{
+		Type:        protocol.TypeHeartbeat,
+		Status:      "serving",
+		ActiveModel: &active,
+	}
+	hbData, _ := json.Marshal(hb)
+	if err := conn.Write(ctx, websocket.MessageText, hbData); err != nil {
+		t.Fatalf("write heartbeat: %v", err)
+	}
+
+	// Answer the first challenge with the supplied hash payload.
+	answered := false
+	for range 30 {
+		readCtx, readCancel := context.WithTimeout(ctx, 500*time.Millisecond)
+		_, data, err := conn.Read(readCtx)
+		readCancel()
+		if err != nil {
+			continue
+		}
+		var envelope struct {
+			Type string `json:"type"`
+		}
+		_ = json.Unmarshal(data, &envelope)
+		if envelope.Type != protocol.TypeAttestationChallenge {
+			continue
+		}
+		var challenge protocol.AttestationChallengeMessage
+		_ = json.Unmarshal(data, &challenge)
+		rdmaDisabled := true
+		sipEnabled := true
+		secureBootEnabled := true
+		resp := protocol.AttestationResponseMessage{
+			Type:              protocol.TypeAttestationResponse,
+			Nonce:             challenge.Nonce,
+			Signature:         testChallengeSignature(challenge.Nonce, challenge.Timestamp, pubKey),
+			PublicKey:         pubKey,
+			RDMADisabled:      &rdmaDisabled,
+			SIPEnabled:        &sipEnabled,
+			SecureBootEnabled: &secureBootEnabled,
+			ActiveModelHash:   activeModelHash,
+			ModelHashes:       modelHashes,
+		}
+		respData, _ := json.Marshal(resp)
+		if err := conn.Write(ctx, websocket.MessageText, respData); err != nil {
+			t.Fatalf("write challenge response: %v", err)
+		}
+		answered = true
+		break
+	}
+	if !answered {
+		t.Fatal("no attestation challenge received")
+	}
+
+	// Give the coordinator time to process, then read the provider's status.
+	time.Sleep(300 * time.Millisecond)
+	ids := reg.ProviderIDs()
+	if len(ids) != 1 {
+		t.Fatalf("expected 1 provider, got %d", len(ids))
+	}
+	p := reg.GetProvider(ids[0])
+	p.Mu().Lock()
+	defer p.Mu().Unlock()
+	return p.Status
+}
+
+// TestChallengeCorrectHashesOfOtherModelDoNotUntrust reproduces the prod race:
+// the coordinator believes model-gemma is current (heartbeat), but the
+// provider's active model flipped to model-gptoss before it answered — so
+// active_model_hash is gptoss's (correct) hash while the coordinator expects
+// gemma's. With correct per-model hashes in model_hashes, the provider must
+// NOT be untrusted. Fails on the old guess-based check.
+func TestChallengeCorrectHashesOfOtherModelDoNotUntrust(t *testing.T) {
+	status := challengeExchange(t,
+		map[string]string{"model-gemma": gemmaHash, "model-gptoss": gptOSSHash},
+		gptOSSHash, // hash of the model the provider ACTUALLY has active
+	)
+	if status == registry.StatusUntrusted {
+		t.Fatal("provider with correct per-model hashes was untrusted (active-model guess race)")
+	}
+}
+
+// TestChallengeWrongModelHashUntrusts: a genuinely wrong hash for an advertised
+// model must still hard-untrust (the security check stays effective).
+func TestChallengeWrongModelHashUntrusts(t *testing.T) {
+	status := challengeExchange(t,
+		map[string]string{"model-gemma": "deadbeef" + gemmaHash[8:], "model-gptoss": gptOSSHash},
+		gptOSSHash,
+	)
+	if status != registry.StatusUntrusted {
+		t.Fatalf("provider with tampered model hash was not untrusted (status=%s)", status)
+	}
+}
+
+// TestChallengeLegacyActiveHashMatchingAnyModelAccepted: legacy responses with
+// no model_hashes map are accepted when active_model_hash matches ANY
+// advertised model's catalog hash (membership, not the racy current-model guess).
+func TestChallengeLegacyActiveHashMatchingAnyModelAccepted(t *testing.T) {
+	status := challengeExchange(t, nil, gptOSSHash)
+	if status == registry.StatusUntrusted {
+		t.Fatal("legacy response with a valid advertised-model hash was untrusted")
+	}
+}
+
+// TestChallengeLegacyActiveHashMatchingNothingUntrusts: a legacy response whose
+// active hash matches no advertised model is still rejected.
+func TestChallengeLegacyActiveHashMatchingNothingUntrusts(t *testing.T) {
+	status := challengeExchange(t, nil, "deadbeef"+gemmaHash[8:])
+	if status != registry.StatusUntrusted {
+		t.Fatalf("legacy response with unknown hash was not untrusted (status=%s)", status)
+	}
+}

--- a/coordinator/api/model_hash_race_test.go
+++ b/coordinator/api/model_hash_race_test.go
@@ -13,8 +13,12 @@ package api
 // tampered hash of model A → false "model swap" hard-untrust.
 //
 // The fix validates the model-keyed resp.ModelHashes map against the catalog
-// — exact and race-free — with a membership fallback for legacy responses
-// that carry only active_model_hash.
+// — exact and race-free. The bare active_model_hash is additionally checked
+// by membership (it must match SOME advertised model's catalog hash), which
+// runs regardless of the map — so a map of only empty/unknown entries cannot
+// suppress it — but only when every advertised model has an enforced catalog
+// hash; otherwise the bare hash could legitimately belong to an unenforced
+// model and proves nothing.
 
 import (
 	"context"
@@ -46,13 +50,25 @@ func challengeExchange(
 	activeModelHash string,
 ) registry.ProviderStatus {
 	t.Helper()
+	return challengeExchangeWithCatalog(t, []registry.CatalogEntry{
+		{ID: "model-gemma", WeightHash: gemmaHash},
+		{ID: "model-gptoss", WeightHash: gptOSSHash},
+	}, modelHashes, activeModelHash)
+}
+
+// challengeExchangeWithCatalog is challengeExchange with a caller-supplied
+// model catalog (to exercise unenforced catalog entries).
+func challengeExchangeWithCatalog(
+	t *testing.T,
+	catalog []registry.CatalogEntry,
+	modelHashes map[string]string,
+	activeModelHash string,
+) registry.ProviderStatus {
+	t.Helper()
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	st := store.NewMemory(store.Config{AdminKey: "test-key"})
 	reg := registry.New(logger)
-	reg.SetModelCatalog([]registry.CatalogEntry{
-		{ID: "model-gemma", WeightHash: gemmaHash},
-		{ID: "model-gptoss", WeightHash: gptOSSHash},
-	})
+	reg.SetModelCatalog(catalog)
 	srv := NewServer(reg, st, ServerConfig{}, logger)
 	srv.challengeInterval = 200 * time.Millisecond
 
@@ -196,5 +212,39 @@ func TestChallengeLegacyActiveHashMatchingNothingUntrusts(t *testing.T) {
 	status := challengeExchange(t, nil, "deadbeef"+gemmaHash[8:])
 	if status != registry.StatusUntrusted {
 		t.Fatalf("legacy response with unknown hash was not untrusted (status=%s)", status)
+	}
+}
+
+// TestChallengeUselessMapDoesNotSuppressActiveHashCheck: a model_hashes map
+// holding only empty or unknown entries must not act as a bypass — the bare
+// active_model_hash membership check still runs and rejects a bogus hash.
+// (Review finding: with the fallback gated on len(resp.ModelHashes) == 0, a
+// malicious provider could send {"model-gemma": ""} plus a bad active hash
+// and skip both checks.)
+func TestChallengeUselessMapDoesNotSuppressActiveHashCheck(t *testing.T) {
+	status := challengeExchange(t,
+		map[string]string{"model-gemma": "", "not-in-catalog": "ffff" + gemmaHash[4:]},
+		"deadbeef"+gemmaHash[8:],
+	)
+	if status != registry.StatusUntrusted {
+		t.Fatalf("useless model_hashes map suppressed the active-hash check (status=%s)", status)
+	}
+}
+
+// TestChallengeBareHashSkippedWhenAnyModelUnenforced: when an advertised model
+// has no enforced catalog hash, a bare active_model_hash matching nothing is
+// inconclusive — it could legitimately be that model's hash — so the provider
+// must NOT be untrusted.
+func TestChallengeBareHashSkippedWhenAnyModelUnenforced(t *testing.T) {
+	status := challengeExchangeWithCatalog(t,
+		[]registry.CatalogEntry{
+			{ID: "model-gemma", WeightHash: gemmaHash},
+			{ID: "model-gptoss", WeightHash: ""}, // unenforced
+		},
+		nil,
+		"deadbeef"+gemmaHash[8:], // plausibly model-gptoss's real hash
+	)
+	if status == registry.StatusUntrusted {
+		t.Fatal("bare hash untrusted despite an unenforced advertised model (inconclusive check)")
 	}
 }

--- a/coordinator/api/model_hash_refresh_test.go
+++ b/coordinator/api/model_hash_refresh_test.go
@@ -1,0 +1,139 @@
+package api
+
+// End-to-end regression for the stale model-hash heal path: a provider whose
+// daemon recomputed a model's weight hash (model re-published while running)
+// reports the fresh hash in its attestation challenge response, and the
+// coordinator must refresh its stored per-model weight hash — otherwise the
+// per-model catalog filter keeps judging the provider by the stale
+// registration-time value until the next reconnect.
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+	"github.com/eigeninference/d-inference/coordinator/registry"
+	"github.com/eigeninference/d-inference/coordinator/store"
+	"nhooyr.io/websocket"
+)
+
+func TestChallengeResponseRefreshesStoredModelWeightHashes(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	st := store.NewMemory(store.Config{AdminKey: "test-key"})
+	reg := registry.New(logger)
+	srv := NewServer(reg, st, ServerConfig{}, logger)
+	srv.challengeInterval = 200 * time.Millisecond
+
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http") + "/ws/provider"
+	conn, _, err := websocket.Dial(ctx, wsURL, nil)
+	if err != nil {
+		t.Fatalf("websocket dial: %v", err)
+	}
+	defer conn.Close(websocket.StatusNormalClosure, "")
+
+	// Register with a daemon-start (stale) weight hash.
+	pubKey := testPublicKeyB64()
+	regMsg := protocol.RegisterMessage{
+		Type:     protocol.TypeRegister,
+		Hardware: protocol.Hardware{ChipName: "Apple M3 Max", MemoryGB: 64},
+		Models: []protocol.ModelInfo{{
+			ID:           "refresh-model",
+			SizeBytes:    1000,
+			ModelType:    "chat",
+			Quantization: "4bit",
+			WeightHash:   "stale-hash-from-registration",
+		}},
+		Backend:   "mlx-swift",
+		PublicKey: pubKey,
+	}
+	regData, _ := json.Marshal(regMsg)
+	if err := conn.Write(ctx, websocket.MessageText, regData); err != nil {
+		t.Fatalf("write register: %v", err)
+	}
+
+	// Answer the first challenge with a valid response carrying a refreshed
+	// model hash (the daemon recomputed it at model (re)load).
+	answered := false
+	for range 30 {
+		readCtx, readCancel := context.WithTimeout(ctx, 500*time.Millisecond)
+		_, data, err := conn.Read(readCtx)
+		readCancel()
+		if err != nil {
+			continue
+		}
+		var envelope struct {
+			Type string `json:"type"`
+		}
+		_ = json.Unmarshal(data, &envelope)
+		if envelope.Type != protocol.TypeAttestationChallenge {
+			continue
+		}
+
+		var challenge protocol.AttestationChallengeMessage
+		_ = json.Unmarshal(data, &challenge)
+		rdmaDisabled := true
+		sipEnabled := true
+		secureBootEnabled := true
+		resp := protocol.AttestationResponseMessage{
+			Type:              protocol.TypeAttestationResponse,
+			Nonce:             challenge.Nonce,
+			Signature:         testChallengeSignature(challenge.Nonce, challenge.Timestamp, pubKey),
+			PublicKey:         pubKey,
+			RDMADisabled:      &rdmaDisabled,
+			SIPEnabled:        &sipEnabled,
+			SecureBootEnabled: &secureBootEnabled,
+			ModelHashes:       map[string]string{"refresh-model": "fresh-hash-after-reload"},
+		}
+		respData, _ := json.Marshal(resp)
+		if err := conn.Write(ctx, websocket.MessageText, respData); err != nil {
+			t.Fatalf("write challenge response: %v", err)
+		}
+		answered = true
+		break
+	}
+	if !answered {
+		t.Fatal("no attestation challenge received")
+	}
+
+	// The verified response must refresh the stored per-model hash. Read
+	// p.Models under the provider lock — it is replaced copy-on-write by
+	// UpdateModelWeightHashes on the challenge goroutine.
+	storedHash := func() string {
+		ids := reg.ProviderIDs()
+		if len(ids) != 1 {
+			return ""
+		}
+		p := reg.GetProvider(ids[0])
+		if p == nil {
+			return ""
+		}
+		p.Mu().Lock()
+		defer p.Mu().Unlock()
+		if len(p.Models) != 1 {
+			return ""
+		}
+		return p.Models[0].WeightHash
+	}
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if storedHash() == "fresh-hash-after-reload" {
+			return // refreshed — pass
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("stored weight hash = %q, want %q (challenge response did not refresh it)",
+		storedHash(), "fresh-hash-after-reload")
+}

--- a/coordinator/api/provider.go
+++ b/coordinator/api/provider.go
@@ -1056,29 +1056,32 @@ func (s *Server) verifyChallengeResponse(providerID string, provider *registry.P
 		}
 	}
 
-	// Legacy fallback for providers that report only active_model_hash with no
-	// model_hashes map: the response does not say WHICH model the hash belongs
-	// to, so accept it if it matches ANY advertised model's catalog hash.
-	// (Comparing against the heartbeat-derived "current model" is inherently
-	// racy — see above.)
-	if len(resp.ModelHashes) == 0 && resp.ActiveModelHash != "" {
+	// The bare active_model_hash names no model, so the strongest race-free
+	// statement it admits is membership: when EVERY advertised model has an
+	// enforced catalog hash, a hash that matches none of them is tampered.
+	// This runs regardless of model_hashes — a map holding only empty or
+	// unknown entries must not suppress it — and stays inconclusive (skipped)
+	// when any advertised model is unenforced, since the bare hash could
+	// legitimately belong to that model. (Comparing against the
+	// heartbeat-derived "current model" instead is inherently racy — see
+	// above.)
+	if resp.ActiveModelHash != "" {
 		provider.Mu().Lock()
 		models := provider.Models
 		provider.Mu().Unlock()
-		enforced := false
+		allEnforced := len(models) > 0
 		matched := false
 		for _, m := range models {
 			expectedHash := s.registry.CatalogWeightHash(m.ID)
 			if expectedHash == "" {
-				continue
-			}
-			enforced = true
-			if resp.ActiveModelHash == expectedHash {
-				matched = true
+				allEnforced = false
 				break
 			}
+			if resp.ActiveModelHash == expectedHash {
+				matched = true
+			}
 		}
-		if enforced && !matched {
+		if allEnforced && !matched {
 			s.logger.Error("provider active model hash matches no advertised model — possible model swap",
 				"provider_id", providerID,
 				"got", registry.TruncHash(resp.ActiveModelHash),

--- a/coordinator/api/provider.go
+++ b/coordinator/api/provider.go
@@ -1024,26 +1024,68 @@ func (s *Server) verifyChallengeResponse(providerID string, provider *registry.P
 		}
 	}
 
-	// Verify active model hash if reported and catalog has expected hash.
-	if resp.ActiveModelHash != "" {
-		// Get the current model from the provider's last heartbeat.
-		provider.Mu().Lock()
-		currentModel := provider.CurrentModel
-		provider.Mu().Unlock()
+	// Verify reported model weight hashes against the catalog. The response's
+	// model_hashes map is keyed by model ID, so each entry is compared against
+	// the catalog hash for exactly that model — race-free, and strictly
+	// stronger than checking only the active model.
+	//
+	// The previous check compared resp.ActiveModelHash (the hash of whatever
+	// model the PROVIDER considered current when it built the response)
+	// against the catalog hash of provider.CurrentModel (the model the
+	// COORDINATOR believed current, from the last heartbeat — up to a full
+	// heartbeat interval stale). On a busy multi-model provider the current
+	// model flips between heartbeats, so the two regularly disagreed and a
+	// perfectly correct hash of model B was misread as a tampered hash of
+	// model A ("possible model swap") → false hard-untrust. Hit in prod by
+	// the two busiest dual-model boxes (gemma-4-26b + gpt-oss-20b interleaved).
+	for modelID, hash := range resp.ModelHashes {
+		if hash == "" {
+			continue
+		}
+		expectedHash := s.registry.CatalogWeightHash(modelID)
+		if expectedHash != "" && hash != expectedHash {
+			s.logger.Error("provider model weight hash mismatch — possible model swap",
+				"provider_id", providerID,
+				"model", modelID,
+				"expected", registry.TruncHash(expectedHash),
+				"got", registry.TruncHash(hash),
+			)
+			s.registry.MarkUntrusted(providerID)
+			s.handleChallengeFailure(providerID, "model weight hash mismatch")
+			return
+		}
+	}
 
-		if currentModel != "" {
-			expectedHash := s.registry.CatalogWeightHash(currentModel)
-			if expectedHash != "" && resp.ActiveModelHash != expectedHash {
-				s.logger.Error("provider active model hash mismatch — possible model swap",
-					"provider_id", providerID,
-					"model", currentModel,
-					"expected", registry.TruncHash(expectedHash),
-					"got", registry.TruncHash(resp.ActiveModelHash),
-				)
-				s.registry.MarkUntrusted(providerID)
-				s.handleChallengeFailure(providerID, "active model weight hash mismatch")
-				return
+	// Legacy fallback for providers that report only active_model_hash with no
+	// model_hashes map: the response does not say WHICH model the hash belongs
+	// to, so accept it if it matches ANY advertised model's catalog hash.
+	// (Comparing against the heartbeat-derived "current model" is inherently
+	// racy — see above.)
+	if len(resp.ModelHashes) == 0 && resp.ActiveModelHash != "" {
+		provider.Mu().Lock()
+		models := provider.Models
+		provider.Mu().Unlock()
+		enforced := false
+		matched := false
+		for _, m := range models {
+			expectedHash := s.registry.CatalogWeightHash(m.ID)
+			if expectedHash == "" {
+				continue
 			}
+			enforced = true
+			if resp.ActiveModelHash == expectedHash {
+				matched = true
+				break
+			}
+		}
+		if enforced && !matched {
+			s.logger.Error("provider active model hash matches no advertised model — possible model swap",
+				"provider_id", providerID,
+				"got", registry.TruncHash(resp.ActiveModelHash),
+			)
+			s.registry.MarkUntrusted(providerID)
+			s.handleChallengeFailure(providerID, "active model weight hash mismatch")
+			return
 		}
 	}
 

--- a/coordinator/api/provider.go
+++ b/coordinator/api/provider.go
@@ -2237,6 +2237,14 @@ func (s *Server) handleProviderAttestation(w http.ResponseWriter, r *http.Reques
 		attestResult := p.AttestationResult
 		mdaCertChain := p.MDACertChain
 		mdaResult := p.MDAResult
+		// p.Models is replaced copy-on-write by UpdateModelWeightHashes on the
+		// challenge goroutine, so its slice header must be read under p.mu. Copy
+		// the IDs out within this same locked section rather than ranging the
+		// field after unlock.
+		modelIDs := make([]string, 0, len(p.Models))
+		for _, m := range p.Models {
+			modelIDs = append(modelIDs, m.ID)
+		}
 		p.Mu().Unlock()
 
 		pa := providerAttestation{
@@ -2250,9 +2258,7 @@ func (s *Server) handleProviderAttestation(w http.ResponseWriter, r *http.Reques
 			ACMEVerified: acmeVerified,
 		}
 
-		for _, m := range p.Models {
-			pa.Models = append(pa.Models, m.ID)
-		}
+		pa.Models = append(pa.Models, modelIDs...)
 
 		if attestResult != nil {
 			pa.ChipName = attestResult.ChipName

--- a/coordinator/api/provider.go
+++ b/coordinator/api/provider.go
@@ -1132,7 +1132,16 @@ func (s *Server) verifyChallengeResponse(providerID string, provider *registry.P
 	provider.ChallengeVerifiedSIP = resp.SIPEnabled != nil && *resp.SIPEnabled
 	provider.Mu().Unlock()
 
-	// Challenge passed.
+	// Challenge passed. Refresh stored per-model weight hashes BEFORE
+	// RecordChallengeSuccess: its queue drain re-enters routing, and queued
+	// requests must be admitted against the hashes this verified response just
+	// proved — not the registration-time snapshot. The provider recomputes
+	// hashes when it (re)loads a model from disk (e.g. after a model
+	// re-publish), so the registration-time value can go stale mid-connection,
+	// which would silently fail the per-model catalog routing filter until the
+	// next reconnect.
+	s.registry.UpdateModelWeightHashes(providerID, resp.ModelHashes)
+
 	recovered := s.registry.RecordChallengeSuccess(providerID)
 	if recovered {
 		// The provider was transiently untrusted and is now back online. It was

--- a/coordinator/api/stats.go
+++ b/coordinator/api/stats.go
@@ -120,11 +120,16 @@ func (s *Server) handleStats(w http.ResponseWriter, r *http.Request) {
 			status = "online"
 		}
 
-		// Collect available model IDs for this provider
+		// Collect available model IDs for this provider. p.Models is replaced
+		// copy-on-write by UpdateModelWeightHashes on the challenge goroutine, so
+		// its slice header must be read under p.mu; copy the IDs out and reuse the
+		// local slice for both the per-provider list and the model histogram below.
+		p.Mu().Lock()
 		provModels := make([]string, 0, len(p.Models))
 		for _, m := range p.Models {
 			provModels = append(provModels, m.ID)
 		}
+		p.Mu().Unlock()
 
 		lastChallengeVerified := ""
 		if last := p.GetLastChallengeVerified(); !last.IsZero() {
@@ -158,8 +163,8 @@ func (s *Server) handleStats(w http.ResponseWriter, r *http.Request) {
 		}
 		providers = append(providers, prov)
 
-		for _, m := range p.Models {
-			modelMap[m.ID]++
+		for _, id := range provModels {
+			modelMap[id]++
 		}
 	})
 

--- a/coordinator/registry/model_hash_race_test.go
+++ b/coordinator/registry/model_hash_race_test.go
@@ -1,0 +1,119 @@
+package registry
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+)
+
+// TestUpdateModelWeightHashesConcurrentReaders is a race regression for the
+// stale-model-hash heal path. UpdateModelWeightHashes replaces p.Models
+// copy-on-write under p.mu only (it takes r.mu as a read lock to look up the
+// provider, then releases it before the write), so p.mu is the sole lock
+// guarding p.Models. Any reader that ranges p.Models without holding p.mu races
+// on the slice header against the challenge goroutine that calls
+// UpdateModelWeightHashes on every verified attestation response carrying
+// refreshed hashes.
+//
+// This test drives UpdateModelWeightHashes concurrently with every reader that
+// reaches p.Models — ForEachProvider (the stats and attestation handlers),
+// ListModels, FindProviderWithTrust (via providerServesCatalogModelLocked), and
+// ModelCapacitySnapshot. Run under -race it fails (DATA RACE on the p.Models
+// slice header) before the reader-side locking fix and passes after.
+func TestUpdateModelWeightHashesConcurrentReaders(t *testing.T) {
+	const modelID = "mlx-community/Qwen3.5-9B-Instruct-4bit"
+
+	reg := New(testLogger())
+	reg.MinTrustLevel = TrustNone
+	// Enforce a catalog hash so providerServesCatalogModelLocked actually
+	// inspects each model's WeightHash while UpdateModelWeightHashes is rewriting
+	// it — exercising the read on the same field being mutated.
+	reg.SetModelCatalog([]CatalogEntry{{ID: modelID}})
+
+	msg := testRegisterMessage()
+	msg.Models = []protocol.ModelInfo{{
+		ID:           modelID,
+		SizeBytes:    5700000000,
+		ModelType:    "qwen3",
+		Quantization: "4bit",
+		WeightHash:   "hash-a",
+	}}
+	p := reg.Register("p1", nil, msg)
+	testMakeTextRoutable(p)
+	// FindProviderWithTrust additionally gates on RuntimeVerified before reaching
+	// providerServesCatalogModelLocked; PrivacyCapabilities is already populated
+	// by Register from the registration message.
+	p.RuntimeVerified = true
+	p.LastChallengeVerified = time.Now()
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+
+	// Writer: flip the stored weight hash back and forth so every call actually
+	// detects a change and replaces the p.Models slice header (the racy write).
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		toggle := false
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			h := "hash-a"
+			if toggle {
+				h = "hash-b"
+			}
+			toggle = !toggle
+			reg.UpdateModelWeightHashes("p1", map[string]string{modelID: h})
+		}
+	}()
+
+	// Readers: each must hold p.mu internally; if any ranges p.Models without it,
+	// -race trips against the writer above.
+	readers := []func(){
+		// Mirrors api/stats.go and api/provider.go handleProviderAttestation,
+		// which range p.Models inside a ForEachProvider callback.
+		func() {
+			reg.ForEachProvider(func(p *Provider) {
+				p.Mu().Lock()
+				for _, m := range p.Models {
+					_ = m.ID
+					_ = m.WeightHash
+				}
+				p.Mu().Unlock()
+			})
+		},
+		func() { _ = reg.ListModels() },
+		func() { _ = reg.FindProviderWithTrust(modelID, "") },
+		func() { _ = reg.ModelCapacitySnapshot() },
+		func() { _ = reg.ModelCountryCodes(modelID) },
+		func() { _ = reg.ModelType(modelID) },
+	}
+	for _, fn := range readers {
+		fn := fn
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				fn()
+			}
+		}()
+	}
+
+	// Let the goroutines hammer for a bit, then stop.
+	for i := 0; i < 50000; i++ {
+		reg.UpdateModelWeightHashes("p1", map[string]string{modelID: "hash-c"})
+		reg.UpdateModelWeightHashes("p1", map[string]string{modelID: "hash-a"})
+	}
+	close(stop)
+	wg.Wait()
+}

--- a/coordinator/registry/model_hash_refresh_test.go
+++ b/coordinator/registry/model_hash_refresh_test.go
@@ -1,0 +1,81 @@
+package registry
+
+// Tests for UpdateModelWeightHashes — the coordinator half of the stale
+// model-hash fix. Providers recompute weight hashes when a model is (re)loaded
+// from disk (e.g. after a model re-publish); the registry must refresh its
+// stored per-model hashes from the verified challenge response or the
+// per-model catalog filter keeps judging the provider by its
+// registration-time snapshot until the next reconnect.
+
+import (
+	"testing"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+)
+
+func registerWithWeightHash(reg *Registry, id, modelID, hash string) *Provider {
+	msg := testRegisterMessage()
+	msg.Models = []protocol.ModelInfo{{
+		ID:           modelID,
+		SizeBytes:    1000,
+		ModelType:    "chat",
+		Quantization: "4bit",
+		WeightHash:   hash,
+	}}
+	return reg.Register(id, nil, msg)
+}
+
+func TestUpdateModelWeightHashesRefreshesStoredHash(t *testing.T) {
+	reg := New(testLogger())
+	registerWithWeightHash(reg, "p1", "gemma-test", "stale-hash")
+
+	reg.UpdateModelWeightHashes("p1", map[string]string{"gemma-test": "fresh-hash"})
+
+	p := reg.GetProvider("p1")
+	if p == nil {
+		t.Fatal("provider not found")
+	}
+	if got := p.Models[0].WeightHash; got != "fresh-hash" {
+		t.Errorf("stored weight hash = %q, want %q", got, "fresh-hash")
+	}
+}
+
+func TestUpdateModelWeightHashesIgnoresUnknownModelAndEmptyHash(t *testing.T) {
+	reg := New(testLogger())
+	registerWithWeightHash(reg, "p1", "gemma-test", "stale-hash")
+
+	// Hash for a model this provider does not advertise: must not be added.
+	reg.UpdateModelWeightHashes("p1", map[string]string{"other-model": "x"})
+	p := reg.GetProvider("p1")
+	if len(p.Models) != 1 || p.Models[0].WeightHash != "stale-hash" {
+		t.Errorf("unknown model must not change stored models: %+v", p.Models)
+	}
+
+	// Empty hash: ignored, stored value kept.
+	reg.UpdateModelWeightHashes("p1", map[string]string{"gemma-test": ""})
+	if got := reg.GetProvider("p1").Models[0].WeightHash; got != "stale-hash" {
+		t.Errorf("empty hash must be ignored, got %q", got)
+	}
+
+	// Unknown provider / empty map: must not panic.
+	reg.UpdateModelWeightHashes("nonexistent", map[string]string{"gemma-test": "x"})
+	reg.UpdateModelWeightHashes("p1", nil)
+}
+
+func TestUpdateModelWeightHashesIsCopyOnWrite(t *testing.T) {
+	reg := New(testLogger())
+	registerWithWeightHash(reg, "p1", "gemma-test", "stale-hash")
+
+	// A reader holding the pre-update slice must keep seeing consistent old
+	// data — the update must swap the slice, never mutate it in place.
+	before := reg.GetProvider("p1").Models
+
+	reg.UpdateModelWeightHashes("p1", map[string]string{"gemma-test": "fresh-hash"})
+
+	if before[0].WeightHash != "stale-hash" {
+		t.Error("pre-update slice was mutated in place (not copy-on-write)")
+	}
+	if got := reg.GetProvider("p1").Models[0].WeightHash; got != "fresh-hash" {
+		t.Errorf("stored weight hash = %q, want %q", got, "fresh-hash")
+	}
+}

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -981,6 +981,42 @@ func (r *Registry) IsModelInCatalog(model string) bool {
 	return ok
 }
 
+// UpdateModelWeightHashes refreshes the stored per-model weight hashes for a
+// provider from a verified attestation challenge response. Providers recompute
+// weight hashes when a model is (re)loaded from disk — e.g. after a model was
+// re-published and re-downloaded while the daemon kept running. Without this,
+// the registry would keep the registration-time snapshot and the per-model
+// catalog filter (modelAllowedByCatalogLocked) would silently stop routing the
+// model to this provider until its next reconnect.
+//
+// The slice is replaced copy-on-write (never mutated in place) so concurrent
+// readers ranging over the old slice always see internally consistent data.
+func (r *Registry) UpdateModelWeightHashes(providerID string, hashes map[string]string) {
+	if len(hashes) == 0 {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	p, ok := r.providers[providerID]
+	if !ok {
+		return
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	changed := false
+	models := make([]protocol.ModelInfo, len(p.Models))
+	copy(models, p.Models)
+	for i := range models {
+		if h, ok := hashes[models[i].ID]; ok && h != "" && models[i].WeightHash != h {
+			models[i].WeightHash = h
+			changed = true
+		}
+	}
+	if changed {
+		p.Models = models
+	}
+}
+
 // CatalogWeightHash returns the expected weight hash for a model, or empty
 // string if not set or not in catalog.
 func (r *Registry) CatalogWeightHash(model string) string {

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -989,15 +989,19 @@ func (r *Registry) IsModelInCatalog(model string) bool {
 // catalog filter (modelAllowedByCatalogLocked) would silently stop routing the
 // model to this provider until its next reconnect.
 //
-// The slice is replaced copy-on-write (never mutated in place) so concurrent
-// readers ranging over the old slice always see internally consistent data.
+// Concurrency: the p.Models slice header is replaced (copy-on-write, never
+// mutated in place) under p.mu — NOT under the registry-wide r.mu, which is held
+// only as a read lock to look the provider up in the map. p.mu is therefore the
+// sole lock guarding p.Models, so every reader that ranges p.Models must hold
+// p.mu (see providerModelIDs and the *Locked helpers). Do not rely on r.mu to
+// serialize reads against this write: it does not.
 func (r *Registry) UpdateModelWeightHashes(providerID string, hashes map[string]string) {
 	if len(hashes) == 0 {
 		return
 	}
-	r.mu.Lock()
-	defer r.mu.Unlock()
+	r.mu.RLock()
 	p, ok := r.providers[providerID]
+	r.mu.RUnlock()
 	if !ok {
 		return
 	}
@@ -2358,13 +2362,18 @@ func (r *Registry) FindProviderWithTrust(model string, minTrust TrustLevel, excl
 		if lastChallenge.IsZero() || now.Sub(lastChallenge) > challengeMaxAge {
 			continue
 		}
+		// providerServesCatalogModelLocked ranges p.Models, which is replaced
+		// copy-on-write by UpdateModelWeightHashes under p.mu (not r.mu), so it
+		// must run under p.mu — fold it into the same locked section as the
+		// headroom check rather than calling it after unlock.
 		p.mu.Lock()
 		hasHeadroom := p.hasConcurrencyHeadroomForModelLocked(model)
+		serves := hasHeadroom && r.providerServesCatalogModelLocked(p, model)
 		p.mu.Unlock()
 		if !hasHeadroom {
 			continue
 		}
-		if r.providerServesCatalogModelLocked(p, model) {
+		if serves {
 			candidates = append(candidates, p)
 		}
 	}
@@ -2475,6 +2484,11 @@ func (r *Registry) ListModels() []AggregateModel {
 		attestResult := p.AttestationResult
 		privateReady := providerSupportsPrivateTextLocked(p)
 		privateOnly := p.PrivateOnly
+		// p.Models is replaced copy-on-write by UpdateModelWeightHashes (which
+		// holds only p.mu, not r.mu), so snapshot it here under p.mu rather than
+		// ranging the field after unlock.
+		models := make([]protocol.ModelInfo, len(p.Models))
+		copy(models, p.Models)
 		p.mu.Unlock()
 
 		if status == StatusOffline || status == StatusUntrusted {
@@ -2488,7 +2502,7 @@ func (r *Registry) ListModels() []AggregateModel {
 		if !r.trustMeetsMinimum(trust) || !privateReady {
 			continue
 		}
-		for _, m := range p.Models {
+		for _, m := range models {
 			if !r.modelAllowedByCatalogLocked(m) {
 				continue
 			}

--- a/coordinator/registry/scheduler.go
+++ b/coordinator/registry/scheduler.go
@@ -874,6 +874,13 @@ func providerModelIDs(p *Provider) []string {
 	if p == nil {
 		return nil
 	}
+	// p.Models is replaced (copy-on-write) by UpdateModelWeightHashes when a
+	// challenge response carries refreshed weight hashes, so the slice header
+	// must be read under p.mu. All callers invoke this helper after releasing
+	// p.mu (verified: Heartbeat, RecordChallengeSuccess, SetProviderIdle,
+	// DrainQueuedRequestsForProvider), so taking the lock here cannot deadlock.
+	p.mu.Lock()
+	defer p.mu.Unlock()
 	ids := make([]string, 0, len(p.Models))
 	for _, m := range p.Models {
 		ids = append(ids, m.ID)

--- a/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClient.swift
+++ b/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClient.swift
@@ -409,6 +409,16 @@ public actor CoordinatorClient {
     /// startup). Once set, every (re)registration carries it. See refreshAPNsToken.
     private var apnsTokenOverride: String?
 
+    /// Live per-model weight hashes pushed by the provider loop when a model
+    /// (re)load discovers the on-disk weights changed (model re-published while
+    /// the daemon runs). Once set, every (re)registration patches
+    /// models[].weight_hash so the coordinator's per-model catalog filter sees
+    /// current values instead of the daemon-start snapshot. Unlike
+    /// refreshAPNsToken this does NOT force a reconnect — challenge responses
+    /// already carry the fresh hashes live; this only keeps future
+    /// registrations consistent.
+    private var modelWeightHashOverrides: [String: String] = [:]
+
     private var shutdownRequested = false
 
     public init(
@@ -460,6 +470,13 @@ public actor CoordinatorClient {
         guard apnsTokenOverride != token else { return }
         apnsTokenOverride = token
         webSocketTask?.cancel(with: .goingAway, reason: nil)
+    }
+
+    /// Record refreshed per-model weight hashes for use in future
+    /// (re)registrations. Called by the provider loop after a model (re)load
+    /// recomputes the on-disk weight hash. See `modelWeightHashOverrides`.
+    public func updateModelWeightHashes(_ hashes: [String: String]) {
+        modelWeightHashOverrides = hashes
     }
 
     // MARK: - Connection Loop
@@ -742,7 +759,8 @@ public actor CoordinatorClient {
         let jsonData = try CoordinatorClientCodec.encodeRegistration(
             from: config,
             privacyCapabilities: privacyCapabilities,
-            apnsDeviceTokenOverride: apnsTokenOverride
+            apnsDeviceTokenOverride: apnsTokenOverride,
+            modelWeightHashOverrides: modelWeightHashOverrides
         )
         guard let jsonString = String(data: jsonData, encoding: .utf8) else {
             throw CoordinatorError.encodingFailed

--- a/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClientCodec.swift
+++ b/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClientCodec.swift
@@ -8,7 +8,8 @@ public enum CoordinatorClientCodec {
         from config: CoordinatorClientConfig,
         version: String = ProviderCore.version,
         privacyCapabilities: PrivacyCapabilities? = nil,
-        apnsDeviceTokenOverride: String? = nil
+        apnsDeviceTokenOverride: String? = nil,
+        modelWeightHashOverrides: [String: String] = [:]
     ) -> ProviderMessage {
         // A token that arrived after the config was built (APNs slow at startup)
         // overrides the config value so a reconnect re-registers WITH it.
@@ -16,9 +17,25 @@ public enum CoordinatorClientCodec {
         let effectiveEnv = apnsDeviceTokenOverride != nil
             ? (config.apnsEnvironment ?? "production")
             : config.apnsEnvironment
+        // Weight hashes refreshed after a model (re)load override the
+        // daemon-start values so a reconnect registers with the hashes of the
+        // weights actually on disk (the coordinator's per-model catalog filter
+        // keys off models[].weight_hash).
+        let effectiveModels: [ModelInfo]
+        if modelWeightHashOverrides.isEmpty {
+            effectiveModels = config.models
+        } else {
+            effectiveModels = config.models.map { model in
+                var patched = model
+                if let fresh = modelWeightHashOverrides[model.id] {
+                    patched.weightHash = fresh
+                }
+                return patched
+            }
+        }
         return .register(ProviderMessage.Register(
             hardware: config.hardware,
-            models: config.models,
+            models: effectiveModels,
             backend: config.backendName,
             version: version,
             publicKey: config.publicKey,
@@ -40,14 +57,16 @@ public enum CoordinatorClientCodec {
         from config: CoordinatorClientConfig,
         version: String = ProviderCore.version,
         privacyCapabilities: PrivacyCapabilities? = nil,
-        apnsDeviceTokenOverride: String? = nil
+        apnsDeviceTokenOverride: String? = nil,
+        modelWeightHashOverrides: [String: String] = [:]
     ) throws -> Data {
         try ProviderProtocolCodec.encodeProviderMessage(
             registrationMessage(
                 from: config,
                 version: version,
                 privacyCapabilities: privacyCapabilities,
-                apnsDeviceTokenOverride: apnsDeviceTokenOverride
+                apnsDeviceTokenOverride: apnsDeviceTokenOverride,
+                modelWeightHashOverrides: modelWeightHashOverrides
             )
         )
     }

--- a/provider-swift/Sources/ProviderCore/ProviderLoop.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop.swift
@@ -1619,6 +1619,78 @@ public actor ProviderLoop {
 
     // MARK: - Model Loading
 
+    /// Outcome of one weight-hash refresh: the snapshot fingerprint the recorded
+    /// hash corresponds to (nil if the dir couldn't be stat'd), and whether the
+    /// `liveModelHashes` entry now reflects bytes on disk. `effectiveFingerprint`
+    /// is what the after-load TOCTOU check compares against to decide whether the
+    /// bytes drifted between hashing and loading.
+    private struct WeightHashRefreshResult {
+        /// Fingerprint that `liveModelHashes[modelId]` now corresponds to, or nil
+        /// if we have no trustworthy fingerprint (stat failed / recompute failed).
+        let effectiveFingerprint: String?
+    }
+
+    /// Re-hash the weights for `modelId` and update `liveModelHashes` /
+    /// `modelHashFingerprints` to match the bytes on disk, pushing any change into
+    /// the coordinator client. The expensive SHA-256 read runs off-actor (hashing
+    /// a large model takes seconds and must not block heartbeats or challenge
+    /// handling). A snapshot fingerprint (paths + sizes + mtimes) skips the full
+    /// re-read when nothing changed since the last hash, so routine idle-reload
+    /// cycles stay cheap.
+    ///
+    /// The model may have been re-published and re-downloaded since the last hash;
+    /// a stale hash would make the coordinator hard-untrust this provider for a
+    /// "model swap" even though the disk is correct. Returns the fingerprint the
+    /// recorded hash now corresponds to so the caller can detect a post-load drift.
+    private func refreshWeightHash(modelId: String, modelPath: URL) async throws -> WeightHashRefreshResult {
+        let priorFingerprint = modelHashFingerprints[modelId]
+        let hasPriorHash = liveModelHashes[modelId] != nil
+        let refresh = await Task.detached(priority: .utility) {
+            () -> (fingerprint: String?, hash: String?, skipped: Bool) in
+            let fingerprint = WeightHasher.snapshotFingerprint(snapshotDir: modelPath)
+            if let fingerprint, fingerprint == priorFingerprint, hasPriorHash {
+                return (fingerprint, nil, true)  // unchanged — keep cached hash
+            }
+            return (fingerprint, WeightHasher.computeHash(snapshotDir: modelPath, modelID: modelId), false)
+        }.value
+        try Task.checkCancellation()
+        if isShuttingDown { throw CancellationError() }
+
+        // Record the fingerprint ONLY when we have a hash that corresponds to it
+        // (fresh or skip-confirmed). Caching it after a FAILED re-hash would make
+        // the next reload fingerprint-match against the stale hash and silently
+        // skip the retry — turning a transient read failure into a persistently
+        // stale report.
+        let haveTrustworthyHash = refresh.hash != nil || refresh.skipped
+        if let fingerprint = refresh.fingerprint, haveTrustworthyHash {
+            modelHashFingerprints[modelId] = fingerprint
+        }
+        if let freshHash = refresh.hash {
+            if liveModelHashes[modelId] != freshHash {
+                let previous = liveModelHashes[modelId]?.prefix(16) ?? "unset"
+                logger.info("Weight hash refreshed for \(modelId): \(freshHash.prefix(16))... (was \(previous))")
+                liveModelHashes[modelId] = freshHash
+                // Push into the client so a later reconnect re-registers with
+                // current models[].weight_hash (the coordinator's per-model
+                // catalog filter uses the register-time value).
+                if let client = coordinatorClient {
+                    await client.updateModelWeightHashes(liveModelHashes)
+                }
+            }
+        } else if !refresh.skipped {
+            // Recompute failed: keep the previous value but say so — a stale hash
+            // here is operator-visible as a model-swap untrust.
+            logger.warning("Weight hash recompute failed for \(modelId) — keeping previous value")
+        }
+
+        // The effective fingerprint is the one the recorded hash corresponds to.
+        // nil when we couldn't establish a trustworthy hash/fingerprint pair, in
+        // which case the after-load check should re-hash (safe direction).
+        return WeightHashRefreshResult(
+            effectiveFingerprint: haveTrustworthyHash ? refresh.fingerprint : nil
+        )
+    }
+
     private func ensureModelLoaded(modelId: String) async throws {
         if isShuttingDown {
             throw CancellationError()
@@ -1727,53 +1799,11 @@ public actor ProviderLoop {
 
             logger.info("Loading model: \(modelId) from \(modelPath.path)")
 
-            // Re-hash the weights about to be loaded (off-actor: hashing a
-            // large model takes seconds and must not block heartbeats or
-            // challenge handling). The model may have been re-published and
-            // re-downloaded since daemon start; the startup hash would then be
-            // stale and the coordinator would hard-untrust this provider for a
-            // "model swap" even though the disk is correct. Refreshing BEFORE
-            // the slot goes active guarantees a challenge arriving mid-serve
-            // reports the hash of the bytes actually loaded. A snapshot
-            // fingerprint (paths + sizes + mtimes) skips the full re-read when
-            // nothing changed, so routine idle-reload cycles stay cheap.
-            let priorFingerprint = modelHashFingerprints[modelId]
-            let hasPriorHash = liveModelHashes[modelId] != nil
-            let refresh = await Task.detached(priority: .utility) {
-                () -> (fingerprint: String?, hash: String?, skipped: Bool) in
-                let fingerprint = WeightHasher.snapshotFingerprint(snapshotDir: modelPath)
-                if let fingerprint, fingerprint == priorFingerprint, hasPriorHash {
-                    return (fingerprint, nil, true)  // unchanged — keep cached hash
-                }
-                return (fingerprint, WeightHasher.computeHash(snapshotDir: modelPath, modelID: modelId), false)
-            }.value
-            try Task.checkCancellation()
-            if isShuttingDown { throw CancellationError() }
-            // Record the fingerprint ONLY when we have a hash that corresponds
-            // to it (fresh or skip-confirmed). Caching it after a FAILED
-            // re-hash would make the next reload fingerprint-match against the
-            // stale hash and silently skip the retry — turning a transient
-            // read failure into a persistently stale report.
-            if let fingerprint = refresh.fingerprint, refresh.hash != nil || refresh.skipped {
-                modelHashFingerprints[modelId] = fingerprint
-            }
-            if let freshHash = refresh.hash {
-                if liveModelHashes[modelId] != freshHash {
-                    let previous = liveModelHashes[modelId]?.prefix(16) ?? "unset"
-                    logger.info("Weight hash refreshed for \(modelId): \(freshHash.prefix(16))... (was \(previous))")
-                    liveModelHashes[modelId] = freshHash
-                    // Push into the client so a later reconnect re-registers
-                    // with current models[].weight_hash (the coordinator's
-                    // per-model catalog filter uses the register-time value).
-                    if let client = coordinatorClient {
-                        await client.updateModelWeightHashes(liveModelHashes)
-                    }
-                }
-            } else if !refresh.skipped {
-                // Recompute failed: keep the previous value but say so — a
-                // stale hash here is operator-visible as a model-swap untrust.
-                logger.warning("Weight hash recompute failed for \(modelId) — keeping previous value")
-            }
+            // Re-hash the weights about to be loaded. Refreshing BEFORE the slot
+            // goes active guarantees a challenge arriving mid-serve reports the
+            // hash of the bytes actually loaded — not the disk state at daemon
+            // start. (See `refreshWeightHash` for the full rationale.)
+            let preLoadRefresh = try await refreshWeightHash(modelId: modelId, modelPath: modelPath)
 
             if let beforeModelLoad {
                 await beforeModelLoad(modelId)
@@ -1783,6 +1813,24 @@ public actor ProviderLoop {
             let container = try await loadModelContainer(from: modelPath)
             try Task.checkCancellation()
             if isShuttingDown { throw CancellationError() }
+
+            // TOCTOU guard: the hash above was computed BEFORE loadModelContainer
+            // read the weights. If a re-download landed in that window,
+            // liveModelHashes would describe different bytes than what was
+            // actually loaded. Re-stat the snapshot fingerprint (cheap) and, only
+            // if it drifted from what the recorded hash corresponds to, recompute
+            // so liveModelHashes/modelHashFingerprints reflect the loaded bytes.
+            // The common case (fingerprint unchanged) costs one stat-based
+            // fingerprint and no re-read. A nil pre-load fingerprint also forces a
+            // re-hash here — we never recorded a trustworthy hash, so re-deriving
+            // it post-load is the safe direction.
+            let postLoadFingerprint = WeightHasher.snapshotFingerprint(snapshotDir: modelPath)
+            if preLoadRefresh.effectiveFingerprint == nil
+                || postLoadFingerprint != preLoadRefresh.effectiveFingerprint {
+                logger.warning(
+                    "Snapshot fingerprint drifted between hash and load for \(modelId) — recomputing weight hash for the bytes actually loaded")
+                _ = try await refreshWeightHash(modelId: modelId, modelPath: modelPath)
+            }
             let scheduler = BatchScheduler(
                 maxConcurrentRequests: Self.schedulerMaxConcurrent,
                 pendingTimeout: Self.schedulerPendingTimeout,
@@ -1856,6 +1904,22 @@ public actor ProviderLoop {
         syncWarmModelState()
         await updateAggregateCapacity()
         logger.info("Unloaded model: \(modelId) (\(modelSlots.count) model(s) remaining)")
+    }
+
+    /// Weight hashes for ONLY the models currently loaded in memory this session.
+    /// A model is "currently loaded" iff it has a live slot (and isn't tearing
+    /// down) AND we have a known live hash for it. Used by the attestation
+    /// challenge response so the coordinator's model-swap hard-untrust check only
+    /// ever sees hashes for weights we are actually serving — idle/unloaded
+    /// advertised models drop out because they have no slot.
+    private func loadedModelHashesSnapshot() -> [String: String] {
+        var result: [String: String] = [:]
+        for modelId in modelSlots.keys where !modelsUnloading.contains(modelId) {
+            if let hash = liveModelHashes[modelId] {
+                result[modelId] = hash
+            }
+        }
+        return result
     }
 
     private func syncWarmModelState() {
@@ -2172,6 +2236,19 @@ public actor ProviderLoop {
                 liveModelHashes[modelId]
             }
 
+            // Report hashes ONLY for models we are CURRENTLY SERVING (a live
+            // slot this session), never for every advertised model. Registration
+            // still advertises all models' startup hashes (the coordinator's
+            // catalog routing filter needs them, and a stale IDLE model there
+            // degrades to a gentle silent deroute). But the challenge response
+            // feeds the coordinator's model-swap *hard-untrust* check: reporting
+            // a hash for an idle, unloaded model would hard-untrust this provider
+            // the moment that model's catalog hash changes (e.g. a re-publish)
+            // before we re-download it — even though we never served stale
+            // weights. A model that has been idle-unloaded drops out
+            // automatically here because it no longer has a slot.
+            let loadedModelHashes = loadedModelHashesSnapshot()
+
             let response = try builder.buildChallengeResponse(
                 nonce: nonce,
                 timestamp: timestamp,
@@ -2179,7 +2256,7 @@ public actor ProviderLoop {
                 binaryHash: binaryHash,
                 activeModelHash: activeModelHash,
                 runtimeHashes: augmentRuntimeHashesWithMetallib(loopConfig.runtimeHashes),
-                modelHashes: liveModelHashes
+                modelHashes: loadedModelHashes
             )
 
             send.send(.attestationResponse(AttestationResponsePayload(

--- a/provider-swift/Sources/ProviderCore/ProviderLoop.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop.swift
@@ -172,6 +172,27 @@ public actor ProviderLoop {
     /// Cached binary hash for attestation responses.
     private var binaryHash: String?
 
+    /// Live per-model weight hashes. Seeded from the startup scan and REFRESHED
+    /// whenever a model is (re)loaded from disk, so attestation challenge
+    /// responses report the weights actually being served — not the state of
+    /// the disk when the daemon started. Previously the startup map was frozen
+    /// for the process lifetime: a model re-published while the daemon ran kept
+    /// the stale hash and tripped the coordinator's model-swap hard-untrust
+    /// even though the disk (and the loaded model) were correct.
+    private var liveModelHashes: [String: String]
+
+    /// Per-model snapshot fingerprints (paths + sizes + mtimes) recorded when a
+    /// weight hash was last computed. A model whose fingerprint is unchanged at
+    /// reload skips the full multi-second re-hash — idle-unload/lazy-reload
+    /// cycles happen hourly, and re-reading ~30 GB of unchanged weights each
+    /// time would tax cold-start TTFT for nothing.
+    private var modelHashFingerprints: [String: String] = [:]
+
+    /// The running coordinator client, kept so weight-hash refreshes can be
+    /// pushed into reconnect registrations (models[].weight_hash drives the
+    /// coordinator's per-model catalog routing filter).
+    private var coordinatorClient: CoordinatorClient?
+
     /// Whether we've already submitted an auto-report for this session.
     /// Set to true after the first trust-triggered report to avoid spamming.
     private var didAutoReport = false
@@ -254,6 +275,7 @@ public actor ProviderLoop {
         self.powerAssertion = InferencePowerAssertion(reason: "Darkbloom inference job active")
         self.preloadTaskStarted = preloadTaskStarted
         self.beforeModelLoad = beforeModelLoad
+        self.liveModelHashes = config.modelHashes
     }
 
     static func memoryReserveBytes(forGiB gb: UInt64) -> UInt64 {
@@ -388,6 +410,11 @@ public actor ProviderLoop {
             stats: stats,
             state: state
         )
+        coordinatorClient = coordinator
+        // Seed the client with the current map: a model loaded before the
+        // client existed (e.g. a local-endpoint request during startup) may
+        // already have refreshed a hash, and registration must carry it.
+        await coordinator.updateModelWeightHashes(liveModelHashes)
 
         let (events, sendFn) = await coordinator.start()
         let send = SendHandle(sendFn)
@@ -1691,6 +1718,54 @@ public actor ProviderLoop {
 
             logger.info("Loading model: \(modelId) from \(modelPath.path)")
 
+            // Re-hash the weights about to be loaded (off-actor: hashing a
+            // large model takes seconds and must not block heartbeats or
+            // challenge handling). The model may have been re-published and
+            // re-downloaded since daemon start; the startup hash would then be
+            // stale and the coordinator would hard-untrust this provider for a
+            // "model swap" even though the disk is correct. Refreshing BEFORE
+            // the slot goes active guarantees a challenge arriving mid-serve
+            // reports the hash of the bytes actually loaded. A snapshot
+            // fingerprint (paths + sizes + mtimes) skips the full re-read when
+            // nothing changed, so routine idle-reload cycles stay cheap.
+            let priorFingerprint = modelHashFingerprints[modelId]
+            let hasPriorHash = liveModelHashes[modelId] != nil
+            let refresh = await Task.detached(priority: .utility) {
+                () -> (fingerprint: String?, hash: String?, skipped: Bool) in
+                let fingerprint = WeightHasher.snapshotFingerprint(snapshotDir: modelPath)
+                if let fingerprint, fingerprint == priorFingerprint, hasPriorHash {
+                    return (fingerprint, nil, true)  // unchanged — keep cached hash
+                }
+                return (fingerprint, WeightHasher.computeHash(snapshotDir: modelPath, modelID: modelId), false)
+            }.value
+            try Task.checkCancellation()
+            if isShuttingDown { throw CancellationError() }
+            // Record the fingerprint ONLY when we have a hash that corresponds
+            // to it (fresh or skip-confirmed). Caching it after a FAILED
+            // re-hash would make the next reload fingerprint-match against the
+            // stale hash and silently skip the retry — turning a transient
+            // read failure into a persistently stale report.
+            if let fingerprint = refresh.fingerprint, refresh.hash != nil || refresh.skipped {
+                modelHashFingerprints[modelId] = fingerprint
+            }
+            if let freshHash = refresh.hash {
+                if liveModelHashes[modelId] != freshHash {
+                    let previous = liveModelHashes[modelId]?.prefix(16) ?? "unset"
+                    logger.info("Weight hash refreshed for \(modelId): \(freshHash.prefix(16))... (was \(previous))")
+                    liveModelHashes[modelId] = freshHash
+                    // Push into the client so a later reconnect re-registers
+                    // with current models[].weight_hash (the coordinator's
+                    // per-model catalog filter uses the register-time value).
+                    if let client = coordinatorClient {
+                        await client.updateModelWeightHashes(liveModelHashes)
+                    }
+                }
+            } else if !refresh.skipped {
+                // Recompute failed: keep the previous value but say so — a
+                // stale hash here is operator-visible as a model-swap untrust.
+                logger.warning("Weight hash recompute failed for \(modelId) — keeping previous value")
+            }
+
             if let beforeModelLoad {
                 await beforeModelLoad(modelId)
                 try Task.checkCancellation()
@@ -1706,7 +1781,11 @@ public actor ProviderLoop {
                 kvBudget: kvBudget,
                 diskAccountant: diskAccountant
             )
-            await scheduler.loadModel(container: container, modelId: modelId, weightHash: modelInfo.weightHash)
+            await scheduler.loadModel(
+                container: container,
+                modelId: modelId,
+                weightHash: liveModelHashes[modelId] ?? modelInfo.weightHash
+            )
             if isShuttingDown || Task.isCancelled {
                 await scheduler.unloadModel()
                 throw CancellationError()
@@ -1779,7 +1858,7 @@ public actor ProviderLoop {
         let candidates = currentCandidates.isEmpty ? activeSlots : currentCandidates
         if let mostRecent = candidates.max(by: { $0.value.lastInferenceAt < $1.value.lastInferenceAt }) {
             state.currentModel = mostRecent.key
-            state.currentModelHash = loopConfig.modelHashes[mostRecent.key]
+            state.currentModelHash = liveModelHashes[mostRecent.key]
         } else {
             state.currentModel = nil
             state.currentModelHash = nil
@@ -2081,7 +2160,7 @@ public actor ProviderLoop {
 
         do {
             let activeModelHash = state.currentModel.flatMap { modelId in
-                loopConfig.modelHashes[modelId]
+                liveModelHashes[modelId]
             }
 
             let response = try builder.buildChallengeResponse(
@@ -2091,7 +2170,7 @@ public actor ProviderLoop {
                 binaryHash: binaryHash,
                 activeModelHash: activeModelHash,
                 runtimeHashes: augmentRuntimeHashesWithMetallib(loopConfig.runtimeHashes),
-                modelHashes: loopConfig.modelHashes
+                modelHashes: liveModelHashes
             )
 
             send.send(.attestationResponse(AttestationResponsePayload(

--- a/provider-swift/Sources/ProviderCore/ProviderLoop.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop.swift
@@ -72,6 +72,11 @@ public struct ProviderLoopConfig: Sendable {
     public let authToken: String?
     public let runtimeHashes: RuntimeHashes?
     public let modelHashes: [String: String]
+    /// Snapshot fingerprints captured at the same time as `modelHashes` (see
+    /// `WeightHasher.snapshotFingerprint`). Seeding these lets the first
+    /// `ensureModelLoaded` skip a full re-read of weights that were already
+    /// hashed at startup; without them the first load re-hashes every byte.
+    public let modelHashFingerprints: [String: String]
     /// When set, the provider also serves a local OpenAI-compatible HTTP
     /// endpoint off the SAME loaded models it serves to the coordinator
     /// (unified mode). nil = coordinator-only (the default).
@@ -85,6 +90,7 @@ public struct ProviderLoopConfig: Sendable {
         authToken: String? = nil,
         runtimeHashes: RuntimeHashes? = nil,
         modelHashes: [String: String] = [:],
+        modelHashFingerprints: [String: String] = [:],
         localEndpoint: LocalInferenceHTTPConfig? = nil
     ) {
         self.coordinatorURL = coordinatorURL
@@ -94,6 +100,7 @@ public struct ProviderLoopConfig: Sendable {
         self.authToken = authToken
         self.runtimeHashes = runtimeHashes
         self.modelHashes = modelHashes
+        self.modelHashFingerprints = modelHashFingerprints
         self.localEndpoint = localEndpoint
     }
 }
@@ -185,8 +192,9 @@ public actor ProviderLoop {
     /// weight hash was last computed. A model whose fingerprint is unchanged at
     /// reload skips the full multi-second re-hash — idle-unload/lazy-reload
     /// cycles happen hourly, and re-reading ~30 GB of unchanged weights each
-    /// time would tax cold-start TTFT for nothing.
-    private var modelHashFingerprints: [String: String] = [:]
+    /// time would tax cold-start TTFT for nothing. Seeded from the config so
+    /// the FIRST load doesn't re-read weights already hashed at startup.
+    private var modelHashFingerprints: [String: String]
 
     /// The running coordinator client, kept so weight-hash refreshes can be
     /// pushed into reconnect registrations (models[].weight_hash drives the
@@ -276,6 +284,7 @@ public actor ProviderLoop {
         self.preloadTaskStarted = preloadTaskStarted
         self.beforeModelLoad = beforeModelLoad
         self.liveModelHashes = config.modelHashes
+        self.modelHashFingerprints = config.modelHashFingerprints
     }
 
     static func memoryReserveBytes(forGiB gb: UInt64) -> UInt64 {

--- a/provider-swift/Sources/ProviderCoreFoundation/WeightHasher.swift
+++ b/provider-swift/Sources/ProviderCoreFoundation/WeightHasher.swift
@@ -53,6 +53,39 @@ public struct WeightHasher: Sendable {
         return hash
     }
 
+    // MARK: - Change Detection
+
+    /// Cheap change-detection fingerprint for a snapshot directory: the sorted
+    /// paths + sizes + mtimes of all integrity files. If the fingerprint is
+    /// unchanged since the last full hash, the weights cannot have drifted
+    /// (threat model: this guards *accidental* drift on honest providers — a
+    /// malicious provider can lie about the reported hash regardless), so the
+    /// expensive full re-read can be skipped on model reload.
+    ///
+    /// Returns nil when the directory has no integrity files or a file cannot
+    /// be stat'ed — callers must treat nil as "unknown" and re-hash.
+    public static func snapshotFingerprint(snapshotDir: URL) -> String? {
+        let (_, paths) = ModelScanner.collectWeightFiles(in: snapshotDir)
+        guard !paths.isEmpty else { return nil }
+        let fm = FileManager.default
+        var parts: [String] = []
+        parts.reserveCapacity(paths.count)
+        for url in paths.sorted(by: { $0.path < $1.path }) {
+            // Stat the TARGET of HF blob-style symlinks, not the link itself —
+            // an in-place blob rewrite behind an unchanged link must still
+            // change the fingerprint. (attributesOfItem does not traverse.)
+            let resolved = url.resolvingSymlinksInPath()
+            guard let attrs = try? fm.attributesOfItem(atPath: resolved.path),
+                let size = attrs[.size] as? UInt64,
+                let mtime = attrs[.modificationDate] as? Date
+            else {
+                return nil
+            }
+            parts.append("\(url.path)|\(size)|\(mtime.timeIntervalSince1970)")
+        }
+        return parts.joined(separator: "\n")
+    }
+
     // MARK: - Hashing Implementation
 
     /// Hash files in sorted filename order, combining per-file digests into a final hash.

--- a/provider-swift/Sources/darkbloom/Darkbloom.swift
+++ b/provider-swift/Sources/darkbloom/Darkbloom.swift
@@ -278,17 +278,31 @@ func advertisedModels(
     return models.filter { enabled.contains($0.id) }
 }
 
-func attachWeightHashes(to models: [ModelInfo]) -> ([ModelInfo], [String: String]) {
+func attachWeightHashes(to models: [ModelInfo]) -> (
+    [ModelInfo], hashes: [String: String], fingerprints: [String: String]
+) {
     var hashes: [String: String] = [:]
+    var fingerprints: [String: String] = [:]
     let withHashes = models.map { model -> ModelInfo in
         var updated = model
-        if let hash = WeightHasher.computeHash(for: model.id) {
+        guard let snapshotDir = ModelScanner.resolveLocalPath(modelID: model.id) else {
+            return updated
+        }
+        // Fingerprint BEFORE hashing: if files change in between, the stale
+        // fingerprint forces a re-hash at first model load (safe direction).
+        // The reverse order could pair a fingerprint of newer bytes with a
+        // hash of older ones and silently skip that re-hash.
+        let fingerprint = WeightHasher.snapshotFingerprint(snapshotDir: snapshotDir)
+        if let hash = WeightHasher.computeHash(snapshotDir: snapshotDir, modelID: model.id) {
             updated.weightHash = hash
             hashes[model.id] = hash
+            if let fingerprint {
+                fingerprints[model.id] = fingerprint
+            }
         }
         return updated
     }
-    return (withHashes, hashes)
+    return (withHashes, hashes, fingerprints)
 }
 
 // MARK: - Output Helpers

--- a/provider-swift/Sources/darkbloom/StartCommand.swift
+++ b/provider-swift/Sources/darkbloom/StartCommand.swift
@@ -236,7 +236,7 @@ struct Start: AsyncParsableCommand {
             throw ExitCode.failure
         }
 
-        let (models, modelHashes) = attachWeightHashes(to: selectedModels)
+        let (models, modelHashes, modelHashFingerprints) = attachWeightHashes(to: selectedModels)
         let runtimeHashes = (try? RuntimeHashReporter().report().coordinatorRuntimeHashes)
         let authToken = AuthTokenStore.load()
 
@@ -321,6 +321,7 @@ struct Start: AsyncParsableCommand {
             authToken: authToken,
             runtimeHashes: runtimeHashes,
             modelHashes: modelHashes,
+            modelHashFingerprints: modelHashFingerprints,
             localEndpoint: localEndpointConfig
         )
 

--- a/provider-swift/Tests/ProviderCoreFoundationTests/StaleHashRecomputeTest.swift
+++ b/provider-swift/Tests/ProviderCoreFoundationTests/StaleHashRecomputeTest.swift
@@ -80,4 +80,56 @@ final class StaleHashRecomputeTest: XCTestCase {
         defer { try? FileManager.default.removeItem(at: empty) }
         XCTAssertNil(WeightHasher.snapshotFingerprint(snapshotDir: empty))
     }
+
+    /// TOCTOU regression: the provider hashes the weights about to be loaded, then
+    /// `loadModelContainer` reads them. If a re-download lands in that window, the
+    /// recorded hash describes the OLD bytes while the loaded model is the NEW
+    /// ones. The fix re-checks the snapshot fingerprint AFTER the load and, on a
+    /// drift, recomputes. This pins the primitives that fix relies on:
+    ///   1. the fingerprint captured at hash time differs from the fingerprint
+    ///      observed after a mid-window rewrite (so the drift check fires), and
+    ///   2. recomputing then yields the hash of the bytes actually on disk.
+    func testFingerprintAfterLoadDetectsMidWindowRewrite() throws {
+        // "Hash time": capture the hash + the fingerprint it corresponds to.
+        let hashAtHashTime = WeightHasher.computeHash(snapshotDir: snapshotDir)
+        let fingerprintAtHashTime = WeightHasher.snapshotFingerprint(snapshotDir: snapshotDir)
+        XCTAssertNotNil(hashAtHashTime)
+        XCTAssertNotNil(fingerprintAtHashTime)
+
+        // A re-download lands BETWEEN hashing and loading: same file name, new
+        // bytes. (Size differs so even a coarse stat-only fingerprint catches it.)
+        try Data("re-downloaded-mid-load-v2".utf8)
+            .write(to: snapshotDir.appendingPathComponent("model.safetensors"))
+
+        // "After load": the post-load fingerprint must NOT equal the one captured
+        // at hash time — this inequality is exactly what triggers the recompute.
+        let fingerprintAfterLoad = WeightHasher.snapshotFingerprint(snapshotDir: snapshotDir)
+        XCTAssertNotNil(fingerprintAfterLoad)
+        XCTAssertNotEqual(
+            fingerprintAfterLoad, fingerprintAtHashTime,
+            "post-load fingerprint must differ after a mid-window rewrite — otherwise the TOCTOU recompute never fires")
+
+        // The triggered recompute must reflect the bytes actually loaded, not the
+        // stale hash captured before the rewrite.
+        let recomputed = WeightHasher.computeHash(snapshotDir: snapshotDir)
+        XCTAssertNotNil(recomputed)
+        XCTAssertNotEqual(
+            recomputed, hashAtHashTime,
+            "recompute after drift must reflect the loaded bytes, not the pre-rewrite hash")
+    }
+
+    /// Negative case: when NO rewrite happens between hash and load, the
+    /// fingerprint is identical, so the after-load check does no extra hashing.
+    func testFingerprintAfterLoadStableWhenNoRewrite() throws {
+        _ = WeightHasher.computeHash(snapshotDir: snapshotDir)
+        let fingerprintAtHashTime = WeightHasher.snapshotFingerprint(snapshotDir: snapshotDir)
+        XCTAssertNotNil(fingerprintAtHashTime)
+
+        // No rewrite occurs (the common case). The post-load fingerprint must
+        // equal the one at hash time so the recompute is skipped.
+        let fingerprintAfterLoad = WeightHasher.snapshotFingerprint(snapshotDir: snapshotDir)
+        XCTAssertEqual(
+            fingerprintAfterLoad, fingerprintAtHashTime,
+            "unchanged weights must yield an identical fingerprint so the after-load recompute is skipped")
+    }
 }

--- a/provider-swift/Tests/ProviderCoreFoundationTests/StaleHashRecomputeTest.swift
+++ b/provider-swift/Tests/ProviderCoreFoundationTests/StaleHashRecomputeTest.swift
@@ -1,0 +1,83 @@
+import XCTest
+
+@testable import ProviderCoreFoundation
+
+/// Regression for the stale-model-hash bug: the provider daemon used to compute
+/// weight hashes ONCE at startup and report that frozen value forever. When a
+/// model was re-published and re-downloaded while the daemon ran, the daemon
+/// kept reporting the old hash and the coordinator hard-untrusted it for a
+/// "model swap" even though the disk was correct.
+///
+/// The fix re-runs `WeightHasher.computeHash(snapshotDir:)` at model (re)load.
+/// This test pins the primitive that fix relies on: re-hashing the same
+/// snapshot directory reflects changed bytes, and is stable when nothing
+/// changed.
+final class StaleHashRecomputeTest: XCTestCase {
+
+    private var snapshotDir: URL!
+
+    override func setUpWithError() throws {
+        snapshotDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("stale-hash-test-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: snapshotDir, withIntermediateDirectories: true)
+        try Data("{\"model_type\":\"test\"}".utf8)
+            .write(to: snapshotDir.appendingPathComponent("config.json"))
+        try Data("original-weights-v1".utf8)
+            .write(to: snapshotDir.appendingPathComponent("model.safetensors"))
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: snapshotDir)
+    }
+
+    func testRecomputeIsStableWhenFilesUnchanged() throws {
+        let first = WeightHasher.computeHash(snapshotDir: snapshotDir)
+        let second = WeightHasher.computeHash(snapshotDir: snapshotDir)
+        XCTAssertNotNil(first)
+        XCTAssertEqual(first, second, "re-hashing unchanged files must be deterministic")
+    }
+
+    func testRecomputeReflectsChangedWeights() throws {
+        let before = WeightHasher.computeHash(snapshotDir: snapshotDir)
+        XCTAssertNotNil(before)
+
+        // Simulate a model re-publish landing on disk: same file name, new bytes.
+        try Data("republished-weights-v2".utf8)
+            .write(to: snapshotDir.appendingPathComponent("model.safetensors"))
+
+        let after = WeightHasher.computeHash(snapshotDir: snapshotDir)
+        XCTAssertNotNil(after)
+        XCTAssertNotEqual(
+            before, after,
+            "recompute must reflect the bytes on disk — a frozen value here is the stale-hash bug")
+
+        // Restoring the original bytes restores the original hash (content-,
+        // not mtime-, addressed).
+        try Data("original-weights-v1".utf8)
+            .write(to: snapshotDir.appendingPathComponent("model.safetensors"))
+        XCTAssertEqual(WeightHasher.computeHash(snapshotDir: snapshotDir), before)
+    }
+
+    func testSnapshotFingerprintDetectsChange() throws {
+        // The fingerprint is the cheap stand-in that lets reloads skip the full
+        // re-hash: it must be stable while files are untouched and change when
+        // a file is rewritten (size or mtime moves).
+        let first = WeightHasher.snapshotFingerprint(snapshotDir: snapshotDir)
+        XCTAssertNotNil(first)
+        XCTAssertEqual(WeightHasher.snapshotFingerprint(snapshotDir: snapshotDir), first)
+
+        // Rewrite with different content (size changes).
+        try Data("republished-weights-v2-longer".utf8)
+            .write(to: snapshotDir.appendingPathComponent("model.safetensors"))
+        let after = WeightHasher.snapshotFingerprint(snapshotDir: snapshotDir)
+        XCTAssertNotNil(after)
+        XCTAssertNotEqual(first, after, "fingerprint must change when a weight file is rewritten")
+
+        // Empty/missing dir → nil (callers must re-hash).
+        let empty = FileManager.default.temporaryDirectory
+            .appendingPathComponent("fp-empty-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: empty, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: empty) }
+        XCTAssertNil(WeightHasher.snapshotFingerprint(snapshotDir: empty))
+    }
+}

--- a/provider-swift/Tests/ProviderCoreTests/CoordinatorClientTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/CoordinatorClientTests.swift
@@ -71,6 +71,47 @@ import Testing
     #expect(withTok["apns_environment"] as? String == "production")
 }
 
+@Test func registrationHonorsModelWeightHashOverrides() throws {
+    // The daemon-start weight hash goes stale when a model is re-published and
+    // re-downloaded while the daemon runs. After the loop refreshes the hash at
+    // model (re)load, reconnect registrations must carry the FRESH hash in
+    // models[].weight_hash — the coordinator's per-model catalog filter keys
+    // off the register-time value.
+    var staleModel = clientSampleModel()
+    staleModel.weightHash = "stale-hash-from-daemon-start"
+    let config = CoordinatorClientConfig(
+        url: "wss://api.dev.darkbloom.xyz/v1/providers/ws",
+        hardware: clientSampleHardware(),
+        models: [staleModel],
+        backendName: "mlx_swift_lm",
+        publicKey: "cHVibGlj"
+    )
+
+    func registeredModels(_ overrides: [String: String]) throws -> [[String: Any]] {
+        let data = try CoordinatorClientCodec.encodeRegistration(
+            from: config,
+            modelWeightHashOverrides: overrides
+        )
+        let object = try clientJSONObject(data)
+        return object["models"] as? [[String: Any]] ?? []
+    }
+
+    // No overrides → the config (daemon-start) hash goes out unchanged.
+    let base = try registeredModels([:])
+    #expect(base.count == 1)
+    #expect(base[0]["weight_hash"] as? String == "stale-hash-from-daemon-start")
+
+    // Override for this model → registration carries the refreshed hash.
+    let refreshed = try registeredModels([staleModel.id: "fresh-hash-after-reload"])
+    #expect(refreshed.count == 1)
+    #expect(refreshed[0]["weight_hash"] as? String == "fresh-hash-after-reload")
+
+    // Override for a DIFFERENT model → this model's hash is untouched.
+    let unrelated = try registeredModels(["some-other-model": "other-hash"])
+    #expect(unrelated.count == 1)
+    #expect(unrelated[0]["weight_hash"] as? String == "stale-hash-from-daemon-start")
+}
+
 @Test func coordinatorOutboundMessagesUseProviderEnvelope() throws {
     let accepted = try CoordinatorClientCodec.encodeOutboundMessageString(
         .inferenceAccepted(requestId: "req-1")


### PR DESCRIPTION
# Fix false "model swap" hard-untrusts on busy multi-model providers

## The incident

Two of our busiest providers (both dual-model: `gemma-4-26b` + `gpt-oss-20b`, both on v0.5.16, both with **bit-perfect weights on disk**) were repeatedly hard-untrusted with `active model hash mismatch — possible model swap`. Restarts didn't help ("untrusted a few minutes after start"), re-downloading didn't help, and a local verifier script run on the box confirmed the disk matched the published manifests exactly.

The "wrong" hash the coordinator kept logging — `61bfc04e…` — turned out to be **the correct, official aggregate hash of gpt-oss-20b**.

## Root cause: a race in the coordinator's active-model check

The challenge response's `active_model_hash` is a bare hash — it does not say which model it describes. To validate it, the coordinator *guessed* the model from the provider's **last heartbeat** (up to a full heartbeat interval stale):

```
16:24:06.3Z  gemma request finishes            ← last heartbeat: "current = gemma"
16:24:06.5Z  gpt-oss request dispatched        ← provider's current model is now gpt-oss
16:24:08.4Z  challenge arrives; provider answers in 190 ms with
             active_model_hash = hash(gpt-oss) = 61bfc04e…   ← correct, for gpt-oss
             coordinator compares against catalog[gemma] = a4722b60…
             mismatch → "model swap" → MarkUntrusted (hard)
```

On a multi-model box both models are loaded and serving simultaneously — "current model" is just *whichever model served the last request*, a label that flips every few seconds under interleaved traffic. The provider answers about its current model *now*; the coordinator validates against the model it heard about *up to 30 s ago*. When traffic flips the model inside that window, a perfectly correct hash of model B is graded against model A's answer key.

The bug only fires on **busy multi-model** providers (31 of 69 fleet providers are dual-model and exposed; the two highest-scored boxes hit it first because routing gives them the densest interleaving). Single-model providers can never hit it — which is why "other machines on the same version have no issues."

A hard untrust also stops the challenge loop, so one race hit sticks until the provider reconnects.

## The fix (coordinator side — deploys without touching the fleet)

v0.5.16 providers **already send the model-keyed map** `model_hashes = {model_id: hash}` in every challenge response. The coordinator now validates that map entry-by-entry against the catalog — exact, race-free, and strictly stronger than checking only one model:

- any advertised model with a tampered hash → hard untrust (security property preserved)
- correct hashes never untrust, regardless of heartbeat staleness (race eliminated)

The bare `active_model_hash` is additionally checked by **membership**: it must match *some* advertised model's catalog hash. This runs regardless of the map (so a map of only empty/unknown entries can't suppress it — review finding) and is conclusive only when every advertised model has an enforced catalog hash, since a bare hash could legitimately belong to an unenforced model. Membership is the strongest race-free check a hash that names no model admits.

Regression test `TestChallengeCorrectHashesOfOtherModelDoNotUntrust` reproduces the prod race over a real WebSocket exchange and **fails on the old code**; companions pin tampered-hash rejection and both legacy branches.

## Also in this PR: provider-side live re-hashing (hardening)

While chasing this we found a real latent bug (not the cause of this incident): the provider computed weight hashes **once at daemon startup** and reported that frozen snapshot forever. If a model is re-published and re-downloaded while the daemon runs, the daemon keeps reporting the old hash and gets untrusted even though the disk is correct.

Now the provider re-verifies at model (re)load — hash the snapshot when loading, skip via a cheap size+mtime fingerprint when nothing changed, push refreshed hashes to the coordinator (`UpdateModelWeightHashes`) so its catalog view tracks reality. This matches the principle that integrity should be established when the model is loaded, not when the process happens to start.

## Changes

**Coordinator**
- `api/provider.go` — validate model-keyed `resp.ModelHashes` against the catalog; legacy any-advertised-model fallback for bare `active_model_hash`
- `registry/registry.go` — `UpdateModelWeightHashes` (copy-on-write under locks)
- `registry/scheduler.go` — `providerModelIDs` now takes `p.mu` (fixes a pre-existing data race)
- tests: `api/model_hash_race_test.go` (race repro + 3 companions), `api/model_hash_refresh_test.go`, `registry/model_hash_refresh_test.go`

**Provider (Swift)**
- `ProviderLoop.swift` — live model-hash cache, re-hash at `ensureModelLoaded` (fingerprint fast-path), push updates to coordinator
- `WeightHasher.swift` — `snapshotFingerprint` (sorted path|size|mtime over integrity files; resolves HF blob symlinks)
- `CoordinatorClient(+Codec)` — `updateModelWeightHashes`, registration honors hash overrides
- tests: `StaleHashRecomputeTest.swift`, `CoordinatorClientTests.swift`

## Ops notes

- Affected providers heal on reconnect/restart; they stay race-prone until this deploys.
- `go test -race ./...` green; Swift tests green.
