### PR TITLE
fix(coordinator): never list a build behind a public alias (hide retired builds)

### DIFF
--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -3378,13 +3378,31 @@ func buildNonStreamingResponse(requestID, model string, msg extractedMessage, us
 // including attestation metadata (trust level, Secure Enclave status,
 // provider count) for each model. Capacity fields (routable_providers,
 // warm_providers, can_accept) are included from the live capacity snapshot.
+// hideAliasBuild marks a concrete build id as hidden from the standalone model
+// listing — a build behind a public alias is only ever exposed through that
+// alias. Only builds that are actually in the catalog are hidden: a build absent
+// from the catalog can't appear in the listing anyway, and adding it would
+// pollute the hidden set (e.g. an alias pointing at a not-yet-registered build).
+// Empty ids are ignored.
+func hideAliasBuild(hidden map[string]struct{}, catalogByID map[string]store.SupportedModel, buildID string) {
+	if buildID == "" {
+		return
+	}
+	if _, inCatalog := catalogByID[buildID]; inCatalog {
+		hidden[buildID] = struct{}{}
+	}
+}
+
 // aliasModelEntries builds the consumer-facing /v1/models entries for active
 // public aliases and returns the set of underlying build ids those aliases
-// cover (so the caller can hide them from the default listing). Each alias entry
-// derives its metadata from its primary build — the desired build, or the
-// previous build if the desired one isn't in the catalog yet — and aggregates
-// live capacity across both the desired and previous builds so the alias's
-// routable/warm counts reflect every quant currently serving it.
+// cover (so the caller can hide them from the default listing). The hidden set
+// covers EVERY build an alias references — desired, previous, and the retired
+// lineage — so a concrete quant build never appears as its own entry once it is
+// behind an alias. Each alias entry derives its metadata from its primary build
+// — the desired build, or the previous build if the desired one isn't in the
+// catalog yet — and aggregates live capacity across the desired and previous
+// builds so the alias's routable/warm counts reflect every quant currently
+// serving it (retired builds are hide-only and never contribute capacity).
 func (s *Server) aliasModelEntries(
 	capByModel map[string]*registry.ModelCapacity,
 	catalogByID map[string]store.SupportedModel,
@@ -3401,6 +3419,16 @@ func (s *Server) aliasModelEntries(
 	for _, a := range aliases {
 		if !a.Active || a.DesiredBuild == "" {
 			continue
+		}
+		// A consumer must only ever see the alias, never a concrete build behind
+		// it. Hide EVERY build this alias references — desired, previous, AND the
+		// retired lineage — from the standalone listing, even if the alias itself
+		// isn't advertisable right now. (Capacity below aggregates only the
+		// routable desired/previous members; retired builds are hide-only.)
+		hideAliasBuild(hidden, catalogByID, a.DesiredBuild)
+		hideAliasBuild(hidden, catalogByID, a.PreviousBuild)
+		for _, b := range a.RetiredBuilds {
+			hideAliasBuild(hidden, catalogByID, b)
 		}
 		// Primary build = the desired build when it's in the catalog, else the
 		// previous build (so the alias keeps a real entry while the desired build
@@ -3433,7 +3461,6 @@ func (s *Server) aliasModelEntries(
 		routable, warm := 0, 0
 		canAccept := false
 		for _, b := range members {
-			hidden[b] = struct{}{}
 			if cap, ok := capByModel[b]; ok {
 				routable += cap.RoutableProviders
 				warm += cap.WarmProviders

--- a/coordinator/api/model_alias_handlers_test.go
+++ b/coordinator/api/model_alias_handlers_test.go
@@ -906,3 +906,70 @@ func TestRegisterModelRejectsAliasCollision(t *testing.T) {
 		t.Fatalf("register over alias status = %d, want 409 (body=%s)", rec.Code, rec.Body.String())
 	}
 }
+
+// After full retirement (previous_build cleared, the old build moved into the
+// retired lineage but still a registered/active model), /v1/models must STILL
+// show only the alias — never the raw retired quant. Regression for the
+// retired-build listing leak: a consumer must only ever see the alias.
+func TestListModelsHidesRetiredAliasBuild(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	st := store.NewMemory(store.Config{})
+	srv := NewServer(registry.New(logger), st, ServerConfig{}, logger)
+
+	seedActiveModel(t, st, aliasFP8, "Gemma 4 26B (fp8)")
+	seedActiveModel(t, st, aliasQAT, "Gemma 4 26B (qat-4bit)")
+	// Fully retired: desired=qat, previous cleared, fp8 in the retired lineage
+	// (still registered + active in the catalog — the exact leak condition).
+	if err := st.UpsertModelAlias(&store.ModelAlias{
+		AliasID: "gemma-4-26b", DisplayName: "Gemma 4 26B", Active: true,
+		DesiredBuild: aliasQAT, RetiredBuilds: []string{aliasFP8},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	srv.SyncModelCatalog()
+
+	rec := httptest.NewRecorder()
+	srv.handleListModels(rec, httptest.NewRequest(http.MethodGet, "/v1/models", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	var resp struct {
+		Data []struct {
+			ID string `json:"id"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	sawAlias, leakedFP8, leakedQAT := false, false, false
+	for _, m := range resp.Data {
+		switch m.ID {
+		case "gemma-4-26b":
+			sawAlias = true
+		case aliasFP8:
+			leakedFP8 = true
+		case aliasQAT:
+			leakedQAT = true
+		}
+	}
+	if !sawAlias {
+		t.Fatalf("alias gemma-4-26b missing from /v1/models: %+v", resp.Data)
+	}
+	if leakedFP8 {
+		t.Fatalf("retired build %q leaked into /v1/models — consumers must only ever see the alias", aliasFP8)
+	}
+	if leakedQAT {
+		t.Fatalf("desired build %q leaked into /v1/models", aliasQAT)
+	}
+
+	// The hidden set covers the retired build directly too.
+	_, registryByID, err := srv.activeCatalogLookups()
+	if err != nil {
+		t.Fatal(err)
+	}
+	catalogByID := map[string]store.SupportedModel{aliasFP8: {ID: aliasFP8, Active: true, ModelType: "text"}, aliasQAT: {ID: aliasQAT, Active: true, ModelType: "text"}}
+	_, hidden := srv.aliasModelEntries(map[string]*registry.ModelCapacity{}, catalogByID, registryByID)
+	if _, ok := hidden[aliasFP8]; !ok {
+		t.Fatalf("retired build should be in the hidden set: %v", hidden)
+	}
+}

--- a/coordinator/api/openrouter_endpoint.go
+++ b/coordinator/api/openrouter_endpoint.go
@@ -126,6 +126,16 @@ func (s *Server) openRouterAliasEntries(
 		if !a.Active || a.DesiredBuild == "" {
 			continue
 		}
+		// Never sell a raw build behind a public alias: hide EVERY build the
+		// alias references — desired, previous, AND the retired lineage — from
+		// the marketplace feed, even if the alias itself isn't listable right now
+		// (a retired build left registered would otherwise reappear as a sellable
+		// entry with no providers — a marketplace black-hole).
+		hideAliasBuild(hidden, catalogByID, a.DesiredBuild)
+		hideAliasBuild(hidden, catalogByID, a.PreviousBuild)
+		for _, b := range a.RetiredBuilds {
+			hideAliasBuild(hidden, catalogByID, b)
+		}
 		members := make([]string, 0, 2)
 		if _, ok := catalogByID[a.DesiredBuild]; ok {
 			members = append(members, a.DesiredBuild)
@@ -140,9 +150,6 @@ func (s *Server) openRouterAliasEntries(
 			continue
 		}
 		primary := members[0]
-		for _, b := range members {
-			hidden[b] = struct{}{}
-		}
 
 		cm := catalogByID[primary]
 		modelType := cm.ModelType

--- a/coordinator/api/openrouter_endpoint_test.go
+++ b/coordinator/api/openrouter_endpoint_test.go
@@ -297,3 +297,47 @@ func TestOpenRouterModelsAliasEntriesHideBuilds(t *testing.T) {
 		t.Fatal("unaliased model missing from feed")
 	}
 }
+
+// The OpenRouter marketplace feed must also hide a retired build: once fp8 is
+// retired (moved to the lineage) it must not reappear as a sellable entry —
+// otherwise OpenRouter lists it is_ready:true with zero providers, a black-hole.
+func TestOpenRouterModelsHidesRetiredAliasBuild(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	st := store.NewMemory(store.Config{})
+	srv := NewServer(registry.New(logger), st, ServerConfig{}, logger)
+
+	seedActiveModel(t, st, aliasFP8, "Gemma 4 26B fp8")
+	seedActiveModel(t, st, aliasQAT, "Gemma 4 26B qat")
+	if err := st.UpsertModelAlias(&store.ModelAlias{
+		AliasID: "gemma-4-26b", DisplayName: "Gemma 4 26B", Active: true,
+		DesiredBuild: aliasQAT, RetiredBuilds: []string{aliasFP8},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	srv.SyncModelCatalog()
+
+	rec := httptest.NewRecorder()
+	srv.handleListModelsOpenRouter(rec, httptest.NewRequest(http.MethodGet, "/v1/models/openrouter", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	var resp types.OpenRouterModelsResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	sawAlias := false
+	for _, m := range resp.Data {
+		if m.ID == aliasFP8 {
+			t.Fatalf("retired build %q leaked into the OpenRouter feed", aliasFP8)
+		}
+		if m.ID == aliasQAT {
+			t.Fatalf("desired build %q leaked into the OpenRouter feed", aliasQAT)
+		}
+		if m.ID == "gemma-4-26b" {
+			sawAlias = true
+		}
+	}
+	if !sawAlias {
+		t.Fatalf("alias gemma-4-26b missing from OpenRouter feed: %+v", resp.Data)
+	}
+}


### PR DESCRIPTION
## Never expose a concrete build behind a public alias

A consumer must only ever see the **alias** (e.g. `gemma-4-26b`) — the concrete quant build it resolves to (`…-fp8`, `…-qat-4bit`) is a backend routing detail and must never appear in a public listing.

### The bug
`/v1/models` and `/v1/models/openrouter` built their "hidden builds" set from only the alias's **desired** and **previous** builds. Once a build was **fully retired** — the operator clears `previous_build`, so the old build moves into the alias's `retired_builds` lineage but is left **registered/active** — it was no longer desired-or-previous, so it stopped being hidden and **reappeared as its own raw entry**.

Concretely, after retiring fp8 on the `gemma-4-26b` migration:

```
GET /v1/models →
  gemma-4-26b                                  ← the alias (correct)
  mlx-community/gemma-4-26b-a4b-it-fp8         ← ⚠️ the raw quant, leaked back
```

On the OpenRouter feed it's worse: the retired build is listed `is_ready: true` with **zero providers** → requests to it queue and 429 after the 120s timeout (a marketplace black-hole).

### The fix
Hide **every in-catalog build a public alias references** — desired, previous, **and** the retired lineage — in both listing helpers (`aliasModelEntries`, `openRouterAliasEntries`), regardless of whether the alias itself is advertisable right now.

- Only **in-catalog** builds are hidden — a build absent from the catalog can't appear in the listing anyway, and gating on catalog membership preserves the "desired build not yet registered" case (an alias mid-registration still doesn't hide a phantom id).
- Capacity still aggregates only the routable **desired/previous** members; retired builds are **hide-only** and never contribute capacity.

After the fix, `GET /v1/models` shows only `gemma-4-26b` at every stage — rollout, retirement, and after.

### Tests
- `TestListModelsHidesRetiredAliasBuild` and `TestOpenRouterModelsHidesRetiredAliasBuild` reproduce the exact leak (retired build still registered) and assert only the alias is listed. **Both verified to fail without the fix.**
- Existing alias-listing tests still pass (incl. `TestAliasModelEntriesDesiredNotInCatalog`, which pins the not-yet-registered-desired behavior).
- Full coordinator `go test ./...` + `go vet` clean.

Follow-up to #283 (DAR-225). Coordinator-only; no protocol or provider changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/299"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783643070&installation_id=133247490&pr_number=299&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F299&signature=638bbdc0217b39371a28b821914a8cfbf12492f6d6ca43cf7e41b7eb64ade6bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->