### PR TITLE
v0.6.0 launch: APNs grace, vision routing, 4-bit cutover, graceful update

### DIFF
--- a/console-ui/src/lib/image-upload.test.ts
+++ b/console-ui/src/lib/image-upload.test.ts
@@ -77,21 +77,25 @@ describe("modelSupportsImages", () => {
     expect(modelSupportsImages({})).toBe(false);
   });
 
-  it("bridges known vision families by id/architecture/family", () => {
-    expect(modelSupportsImages({ id: "mlx-community/gemma-4-26b-a4b-it-4bit" })).toBe(true);
-    expect(modelSupportsImages({ architecture: "gemma4" })).toBe(true);
-    expect(modelSupportsImages({ family: "gemma-4" })).toBe(true);
+  it("does NOT light up from a vision family id/architecture alone (no bridge)", () => {
+    // The /gemma-?4/i family bridge was removed: a VLM model must report its
+    // vision capability via the catalog (input_modalities/capabilities) before
+    // the upload control turns on, so it tracks real fleet/operator readiness.
+    expect(modelSupportsImages({ id: "mlx-community/gemma-4-26b-a4b-it-4bit" })).toBe(false);
+    expect(modelSupportsImages({ architecture: "gemma4" })).toBe(false);
+    expect(modelSupportsImages({ family: "gemma-4" })).toBe(false);
   });
 
-  it("does not match non-vision models via the bridge", () => {
+  it("is false for non-vision models with no modality metadata", () => {
     expect(modelSupportsImages({ id: "qwen/qwen3-8b" })).toBe(false);
     expect(modelSupportsImages({ id: "openai/gpt-oss-20b", architecture: "gptoss" })).toBe(false);
   });
 
-  it("honors an explicit image modality regardless of family", () => {
+  it("turns on once the catalog reports image modality, regardless of family", () => {
     expect(
-      modelSupportsImages({ id: "some-future-vlm", input_modalities: ["text", "image"] })
+      modelSupportsImages({ id: "mlx-community/gemma-4-26b-a4b-it-4bit", input_modalities: ["text", "image"] })
     ).toBe(true);
+    expect(modelSupportsImages({ id: "some-future-vlm", input_modalities: ["text", "image"] })).toBe(true);
   });
 });
 

--- a/console-ui/src/lib/image-upload.ts
+++ b/console-ui/src/lib/image-upload.ts
@@ -60,20 +60,17 @@ export function fileToDataURL(file: File): Promise<string> {
 }
 
 /**
- * Architectures/families known to accept image input. This is a BRIDGE: the
- * coordinator's model catalog currently hardcodes `input_modalities: ["text"]`
- * and carries no vision marker, so the metadata checks below can't yet light up
- * for our VLMs. Once the catalog/registry reports image modality (or a `vision`
- * capability) for VLM models, the metadata checks take precedence and this
- * becomes redundant. Keep it narrow — it is NOT a model catalog, just a
- * capability heuristic. Gemma 4 (26B-A4B) is image+audio+video.
- */
-const VISION_MODEL_PATTERN = /gemma-?4/i;
-
-/**
  * Whether a model accepts image input — used to gate the upload control so we
- * only offer it for vision models (e.g. Gemma 4). Prefers the OpenRouter-style
- * `input_modalities`, then `capabilities`, then a known-vision-family bridge.
+ * only offer it for vision models. Driven SOLELY by catalog metadata: the
+ * OpenRouter-style `input_modalities` (the coordinator's `deriveModalities` adds
+ * "image" once an operator sets the model's vision capability) or an explicit
+ * `vision`/`image`/`multimodal` capability.
+ *
+ * The old `/gemma-?4/i` family bridge was removed deliberately: it lit the upload
+ * button the moment the console deployed, regardless of whether the serving fleet
+ * could actually do vision. Gating on catalog modality makes the operator's
+ * capability flip — done last, after the fleet is on 0.6.0 — the single switch
+ * that turns image input on, matching the coordinator's vision routing gate.
  */
 export function modelSupportsImages(
   model?: Partial<
@@ -84,11 +81,7 @@ export function modelSupportsImages(
   const modalities = model.input_modalities?.map((m) => m.toLowerCase()) ?? [];
   if (modalities.includes("image")) return true;
   const caps = model.capabilities?.map((c) => c.toLowerCase()) ?? [];
-  if (caps.some((c) => c === "vision" || c === "image" || c === "multimodal")) {
-    return true;
-  }
-  const hay = `${model.id ?? ""} ${model.architecture ?? ""} ${model.family ?? ""}`;
-  return VISION_MODEL_PATTERN.test(hay);
+  return caps.some((c) => c === "vision" || c === "image" || c === "multimodal");
 }
 
 /**

--- a/coordinator/api/code_attest_throttle.go
+++ b/coordinator/api/code_attest_throttle.go
@@ -1,0 +1,97 @@
+package api
+
+import (
+	"sync"
+	"time"
+)
+
+// codeAttestThrottle keeps APNs code-identity pushes within Apple's background-
+// push budget and reuses a recent attestation across reconnects, so the
+// coordinator never spams silent pushes.
+//
+// Apple throttles silent/background notifications to roughly 2-3 per device per
+// hour and drops the rest; we are forced to use background pushes (an alert push
+// would require UNUserNotificationCenter authorization, which breaks the
+// no-notification-center invariant). So the coordinator must NOT re-challenge on
+// a fixed interval — attestation is per-connection (the binary cannot change
+// without the process, and thus the WebSocket, restarting), so a single challenge
+// per connection suffices, with bounded retries only on delivery failure.
+//
+// Keyed by the Secure Enclave public key — the stable per-device identity that
+// survives reconnects. Two knobs:
+//   - reuseWindow: how long a successful attestation is honored for a NEW
+//     connection from the same device+version without re-pushing. Bounds the
+//     staleness of the proof (a malicious binary swap within the window could ride
+//     a prior attestation), so it is kept short and version-gated. Within a single
+//     live connection the proof is exact regardless of this window.
+//   - pushCooldown: minimum spacing between pushes to the same device — the hard
+//     rate-limit backstop. At 20m that is <= 3 pushes/hour/device even under
+//     reconnect churn and retries.
+type codeAttestThrottle struct {
+	mu       sync.Mutex
+	attested map[string]codeAttestRecord // seKey -> last successful attestation
+	lastPush map[string]time.Time        // seKey -> last push (device-level rate limit)
+
+	reuseWindow  time.Duration
+	pushCooldown time.Duration
+	maxAttempts  int
+	now          func() time.Time
+}
+
+type codeAttestRecord struct {
+	at      time.Time
+	version string
+}
+
+func newCodeAttestThrottle() *codeAttestThrottle {
+	return &codeAttestThrottle{
+		attested:     make(map[string]codeAttestRecord),
+		lastPush:     make(map[string]time.Time),
+		reuseWindow:  30 * time.Minute,
+		pushCooldown: 20 * time.Minute, // <= 3 pushes/hour/device (APNs background budget)
+		maxAttempts:  3,
+		now:          time.Now,
+	}
+}
+
+// reuseAttestation reports whether the device attested recently with the SAME
+// binary version, so a fresh connection can inherit the proof without a push.
+func (t *codeAttestThrottle) reuseAttestation(seKey, version string) bool {
+	if seKey == "" {
+		return false
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	r, ok := t.attested[seKey]
+	return ok && r.version == version && t.now().Sub(r.at) < t.reuseWindow
+}
+
+// allowPush reports whether enough time has passed since the last push to this
+// device to send another within the background-push budget.
+func (t *codeAttestThrottle) allowPush(seKey string) bool {
+	if seKey == "" {
+		return true // no device identity to throttle on; fall back to the loop's cap
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	last, ok := t.lastPush[seKey]
+	return !ok || t.now().Sub(last) >= t.pushCooldown
+}
+
+func (t *codeAttestThrottle) recordPush(seKey string) {
+	if seKey == "" {
+		return
+	}
+	t.mu.Lock()
+	t.lastPush[seKey] = t.now()
+	t.mu.Unlock()
+}
+
+func (t *codeAttestThrottle) recordAttested(seKey, version string) {
+	if seKey == "" {
+		return
+	}
+	t.mu.Lock()
+	t.attested[seKey] = codeAttestRecord{at: t.now(), version: version}
+	t.mu.Unlock()
+}

--- a/coordinator/api/code_attestation_integration_test.go
+++ b/coordinator/api/code_attestation_integration_test.go
@@ -189,26 +189,12 @@ func TestCodeIdentityRejectsWrongSEKey(t *testing.T) {
 	}
 }
 
-// TestCodeAttestLoopReChallengesUntilAttested proves the re-challenge healing:
-// a first push that fails to send leaves the provider un-attested, and the loop
-// re-issues the challenge on the next tick, which succeeds — so a single dropped
-// background push does not strand a capable provider past the grace deadline.
-func TestCodeAttestLoopReChallengesUntilAttested(t *testing.T) {
-	logger := quietLogger()
-	srv := NewServer(registry.New(logger), store.NewMemory(store.Config{}), ServerConfig{}, logger)
-	srv.challengeInterval = 15 * time.Millisecond // fast re-challenge for the test
-
-	kPubB64, kPriv, seKey, sePubB64 := providerKeyMaterial(t)
-	ct := newCodeAttestTracker()
-
-	var attempts int32
-	fake := &fakeCodeAttestor{onSend: func(_, _, pubKeyB64, nonceB64 string) error {
-		if atomic.AddInt32(&attempts, 1) == 1 {
-			// First attempt: the push fails to send (transient). The challenge
-			// returns immediately without attesting; the loop must retry.
-			return errors.New("transient push send failure")
-		}
-		// Second attempt: full valid round-trip → attests.
+// fullCodeAttestRoundTrip returns an onSend that completes a valid challenge
+// round-trip (decrypt the nonce, SE-sign it, deliver the response), counting the
+// pushes it actually sends into `pushes`.
+func fullCodeAttestRoundTrip(t *testing.T, kPriv [32]byte, seKey *ecdsa.PrivateKey, ct *codeAttestTracker, pushes *int32) func(_, _, _, _ string) error {
+	return func(_, _, pubKeyB64, nonceB64 string) error {
+		atomic.AddInt32(pushes, 1)
 		payload, err := apns.BuildCodeChallengePayload(nonceB64, pubKeyB64, apns.ModeBackground)
 		if err != nil {
 			return err
@@ -230,6 +216,29 @@ func TestCodeAttestLoopReChallengesUntilAttested(t *testing.T) {
 			Signature: sig,
 		})
 		return nil
+	}
+}
+
+// TestCodeAttestLoopHealsDroppedPushWithBoundedRetry proves a single dropped
+// background push doesn't strand a capable provider: the first push fails and the
+// loop retries (spaced by the per-device cooldown — NOT a fixed 5-min ticker) and
+// attests. It must stay within the push budget (bounded by maxAttempts).
+func TestCodeAttestLoopHealsDroppedPushWithBoundedRetry(t *testing.T) {
+	logger := quietLogger()
+	srv := NewServer(registry.New(logger), store.NewMemory(store.Config{}), ServerConfig{}, logger)
+	srv.codeAttestThrottle.pushCooldown = time.Millisecond // fast retry spacing for the test
+
+	kPubB64, kPriv, seKey, sePubB64 := providerKeyMaterial(t)
+	ct := newCodeAttestTracker()
+
+	var attempts int32
+	roundTrip := fullCodeAttestRoundTrip(t, kPriv, seKey, ct, &attempts)
+	fake := &fakeCodeAttestor{onSend: func(a, b, pubKeyB64, nonceB64 string) error {
+		if atomic.LoadInt32(&attempts) == 0 {
+			atomic.AddInt32(&attempts, 1)
+			return errors.New("transient push send failure") // first push fails
+		}
+		return roundTrip(a, b, pubKeyB64, nonceB64)
 	}}
 	srv.SetCodeAttestor(fake)
 
@@ -240,12 +249,89 @@ func TestCodeAttestLoopReChallengesUntilAttested(t *testing.T) {
 
 	deadline := time.Now().Add(3 * time.Second)
 	for time.Now().Before(deadline) && !provider.GetCodeAttested() {
-		time.Sleep(10 * time.Millisecond)
+		time.Sleep(5 * time.Millisecond)
 	}
 	if !provider.GetCodeAttested() {
-		t.Fatal("expected CodeAttested=true after the re-challenge healed the dropped first push")
+		t.Fatal("expected CodeAttested=true after a bounded retry healed the dropped first push")
 	}
-	if got := atomic.LoadInt32(&attempts); got < 2 {
-		t.Fatalf("expected >=2 challenge attempts (re-challenge), got %d", got)
+	if got := atomic.LoadInt32(&attempts); got < 2 || got > int32(srv.codeAttestThrottle.maxAttempts) {
+		t.Fatalf("expected 2..%d attempts, got %d", srv.codeAttestThrottle.maxAttempts, got)
+	}
+}
+
+// TestCodeAttestLoopReusesRecentAttestation proves a reconnect from the same
+// device (same SE key + binary version) within the reuse window inherits the
+// proof with NO additional push — respecting Apple's ~3/hour background-push
+// budget instead of re-challenging on every connection.
+func TestCodeAttestLoopReusesRecentAttestation(t *testing.T) {
+	logger := quietLogger()
+	srv := NewServer(registry.New(logger), store.NewMemory(store.Config{}), ServerConfig{}, logger)
+
+	kPubB64, kPriv, seKey, sePubB64 := providerKeyMaterial(t)
+	ct := newCodeAttestTracker()
+
+	var pushes int32
+	srv.SetCodeAttestor(&fakeCodeAttestor{onSend: fullCodeAttestRoundTrip(t, kPriv, seKey, ct, &pushes)})
+
+	// Connection 1: a real round-trip → exactly one push, attested.
+	p1 := newCodeAttestProvider(kPubB64, sePubB64)
+	p1.Version = "0.6.0"
+	srv.codeAttestLoop(context.Background(), "p1", p1, ct)
+	if !p1.GetCodeAttested() {
+		t.Fatal("connection 1 should attest")
+	}
+	if got := atomic.LoadInt32(&pushes); got != 1 {
+		t.Fatalf("connection 1 should send exactly 1 push, got %d", got)
+	}
+
+	// Connection 2: same device + version, fresh Provider (CodeAttested=false). It
+	// must REUSE the recent attestation — attested without another push.
+	p2 := newCodeAttestProvider(kPubB64, sePubB64)
+	p2.Version = "0.6.0"
+	srv.codeAttestLoop(context.Background(), "p1", p2, ct)
+	if !p2.GetCodeAttested() {
+		t.Fatal("connection 2 should inherit the recent attestation (reuse)")
+	}
+	if got := atomic.LoadInt32(&pushes); got != 1 {
+		t.Fatalf("connection 2 must NOT send another push (reuse); total pushes=%d", got)
+	}
+}
+
+// TestCodeAttestThrottleBudgetAndReuse covers the rate-limit + reuse logic with a
+// fake clock: pushes are blocked within the cooldown, and a recent attestation is
+// reused only within the window and only for the same binary version.
+func TestCodeAttestThrottleBudgetAndReuse(t *testing.T) {
+	cur := time.Unix(1_700_000_000, 0)
+	th := newCodeAttestThrottle()
+	th.now = func() time.Time { return cur }
+	const se = "se-key-1"
+
+	if !th.allowPush(se) {
+		t.Fatal("first push should be allowed")
+	}
+	if th.reuseAttestation(se, "0.6.0") {
+		t.Fatal("no attestation yet → no reuse")
+	}
+	th.recordPush(se)
+
+	cur = cur.Add(th.pushCooldown - time.Minute) // still inside the cooldown
+	if th.allowPush(se) {
+		t.Fatal("a push within the cooldown must be blocked (background-push budget)")
+	}
+	cur = cur.Add(2 * time.Minute) // now just past the cooldown
+	if !th.allowPush(se) {
+		t.Fatal("a push after the cooldown should be allowed")
+	}
+
+	th.recordAttested(se, "0.6.0")
+	if !th.reuseAttestation(se, "0.6.0") {
+		t.Fatal("should reuse a fresh, same-version attestation")
+	}
+	if th.reuseAttestation(se, "0.6.1") {
+		t.Fatal("must NOT reuse across a binary version change")
+	}
+	cur = cur.Add(th.reuseWindow) // window elapsed
+	if th.reuseAttestation(se, "0.6.0") {
+		t.Fatal("reuse must expire after the window")
 	}
 }

--- a/coordinator/api/code_attestation_integration_test.go
+++ b/coordinator/api/code_attestation_integration_test.go
@@ -9,10 +9,13 @@ import (
 	"encoding/asn1"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"io"
 	"log/slog"
 	"math/big"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/eigeninference/d-inference/coordinator/apns"
 	"github.com/eigeninference/d-inference/coordinator/attestation"
@@ -183,5 +186,66 @@ func TestCodeIdentityRejectsWrongSEKey(t *testing.T) {
 
 	if provider.GetCodeAttested() {
 		t.Fatal("CodeAttested must stay false when the SE signature is from the wrong key")
+	}
+}
+
+// TestCodeAttestLoopReChallengesUntilAttested proves the re-challenge healing:
+// a first push that fails to send leaves the provider un-attested, and the loop
+// re-issues the challenge on the next tick, which succeeds — so a single dropped
+// background push does not strand a capable provider past the grace deadline.
+func TestCodeAttestLoopReChallengesUntilAttested(t *testing.T) {
+	logger := quietLogger()
+	srv := NewServer(registry.New(logger), store.NewMemory(store.Config{}), ServerConfig{}, logger)
+	srv.challengeInterval = 15 * time.Millisecond // fast re-challenge for the test
+
+	kPubB64, kPriv, seKey, sePubB64 := providerKeyMaterial(t)
+	ct := newCodeAttestTracker()
+
+	var attempts int32
+	fake := &fakeCodeAttestor{onSend: func(_, _, pubKeyB64, nonceB64 string) error {
+		if atomic.AddInt32(&attempts, 1) == 1 {
+			// First attempt: the push fails to send (transient). The challenge
+			// returns immediately without attesting; the loop must retry.
+			return errors.New("transient push send failure")
+		}
+		// Second attempt: full valid round-trip → attests.
+		payload, err := apns.BuildCodeChallengePayload(nonceB64, pubKeyB64, apns.ModeBackground)
+		if err != nil {
+			return err
+		}
+		var body struct {
+			CodeChallenge e2e.EncryptedPayload `json:"code_challenge"`
+		}
+		if err := json.Unmarshal(payload, &body); err != nil {
+			return err
+		}
+		recovered, err := e2e.DecryptWithPrivateKey(&body.CodeChallenge, kPriv)
+		if err != nil {
+			return err
+		}
+		sig := signSEOverString(t, seKey, string(recovered))
+		go ct.deliver(&protocol.CodeAttestationResponseMessage{
+			Type:      protocol.TypeCodeAttestationResponse,
+			Nonce:     string(recovered),
+			Signature: sig,
+		})
+		return nil
+	}}
+	srv.SetCodeAttestor(fake)
+
+	provider := newCodeAttestProvider(kPubB64, sePubB64)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go srv.codeAttestLoop(ctx, "p1", provider, ct)
+
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) && !provider.GetCodeAttested() {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if !provider.GetCodeAttested() {
+		t.Fatal("expected CodeAttested=true after the re-challenge healed the dropped first push")
+	}
+	if got := atomic.LoadInt32(&attempts); got < 2 {
+		t.Fatalf("expected >=2 challenge attempts (re-challenge), got %d", got)
 	}
 }

--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -505,7 +505,7 @@ func approximateTokenCountUpperBound(v any) int {
 func estimatePromptTokens(parsed map[string]any) int {
 	total := 0
 	if v, ok := parsed["messages"]; ok {
-		total += messagesPromptTokens(v, false)
+		total += messagesPromptTokens(v)
 	}
 	if v, ok := parsed["input"]; ok {
 		total += approximateTokenCount(v)
@@ -526,7 +526,14 @@ func estimatePromptTokens(parsed map[string]any) int {
 func estimateBillingPromptTokens(parsed map[string]any) int {
 	total := 0
 	if v, ok := parsed["messages"]; ok {
-		total += messagesPromptTokens(v, true)
+		// Billing MUST stay a guaranteed upper bound (len(bytes) >= tokens for any
+		// BPE tokenizer), so it keeps counting full message bytes — including a
+		// base64 image's bytes and every non-content field (role, tool_calls,
+		// name). Switching to the media-aware flat count here would DROP those
+		// fields and under-reserve for tool-calling requests. Over-reservation on a
+		// large image is safe (it is refunded after inference); the routing/ITPM
+		// estimate (estimatePromptTokens) is the media-aware one.
+		total += approximateTokenCountUpperBound(v)
 	}
 	if v, ok := parsed["input"]; ok {
 		total += approximateTokenCountUpperBound(v)
@@ -560,17 +567,15 @@ func isMediaPartType(t string) bool {
 	return false
 }
 
-// messageContentTokens estimates prompt tokens for one message's `content`,
-// counting text parts as text and each image/video part as a flat media cost
-// (never the base64 length). byteBound selects the billing upper bound (len) vs
-// the routing heuristic (len/4) for text.
-func messageContentTokens(content any, byteBound bool) int {
+// messageContentTokens estimates ROUTING prompt tokens for one message's
+// `content`, counting text parts as text (len/4) and each image/video part as a
+// flat media cost (never the base64 length). Used only for the routing/ITPM
+// estimate; billing uses approximateTokenCountUpperBound (a guaranteed upper
+// bound that intentionally still counts the base64 bytes).
+func messageContentTokens(content any) int {
 	textTokens := func(s string) int {
 		if s == "" {
 			return 0
-		}
-		if byteBound {
-			return len(s)
 		}
 		if t := len(s) / 4; t > 0 {
 			return t
@@ -599,74 +604,75 @@ func messageContentTokens(content any, byteBound bool) int {
 				total += videoPromptTokenCost
 			default:
 				if b, err := json.Marshal(pm); err == nil {
-					if byteBound {
-						total += len(b)
-					} else {
-						total += len(b) / 4
-					}
+					total += len(b) / 4
 				}
 			}
 		}
 		return total
 	default:
-		if byteBound {
-			return approximateTokenCountUpperBound(content)
-		}
 		return approximateTokenCount(content)
 	}
 }
 
-// messagesPromptTokens sums media-aware content tokens across a messages array.
-// Falls back to the byte heuristic when messages isn't the standard array shape.
-func messagesPromptTokens(messages any, byteBound bool) int {
+// messagesPromptTokens sums media-aware routing content tokens across a messages
+// array. Falls back to the len/4 heuristic when messages isn't the standard
+// array shape.
+func messagesPromptTokens(messages any) int {
 	arr, ok := messages.([]any)
 	if !ok {
-		if byteBound {
-			return approximateTokenCountUpperBound(messages)
-		}
 		return approximateTokenCount(messages)
 	}
 	total := 0
 	for _, m := range arr {
 		mm, ok := m.(map[string]any)
 		if !ok {
-			if byteBound {
-				total += approximateTokenCountUpperBound(m)
-			} else {
-				total += approximateTokenCount(m)
-			}
+			total += approximateTokenCount(m)
 			continue
 		}
 		total += 4 // small per-message framing (role + delimiters)
-		total += messageContentTokens(mm["content"], byteBound)
+		total += messageContentTokens(mm["content"])
 	}
 	return total
 }
 
-// detectMediaRequirement reports whether the request carries image/video input in
-// any message's content parts. The coordinator sees plaintext at this point
-// (sealedTransport decrypts before the handler), so this drives the vision
-// routing gate and the fail-fast "no vision-capable provider" response.
-func detectMediaRequirement(parsed map[string]any) bool {
-	messages, ok := parsed["messages"].([]any)
+// contentPartsHaveMedia reports whether a `content` value (a content-part array)
+// carries any image/video part.
+func contentPartsHaveMedia(content any) bool {
+	parts, ok := content.([]any)
 	if !ok {
 		return false
 	}
-	for _, m := range messages {
-		mm, ok := m.(map[string]any)
+	for _, part := range parts {
+		pm, ok := part.(map[string]any)
 		if !ok {
 			continue
 		}
-		parts, ok := mm["content"].([]any)
-		if !ok {
-			continue
+		if typ, _ := pm["type"].(string); isMediaPartType(typ) {
+			return true
 		}
-		for _, part := range parts {
-			pm, ok := part.(map[string]any)
-			if !ok {
-				continue
+	}
+	return false
+}
+
+// detectMediaRequirement reports whether the request carries image/video input.
+// The coordinator sees plaintext at this point (sealedTransport decrypts before
+// the handler), so this drives the vision routing gate and the fail-fast "no
+// vision-capable provider" response. It scans both the Chat Completions
+// `messages[].content` parts and the Responses API `input[].content` parts so a
+// media request on either surface is gated (never silently routed text-blind).
+func detectMediaRequirement(parsed map[string]any) bool {
+	if messages, ok := parsed["messages"].([]any); ok {
+		for _, m := range messages {
+			if mm, ok := m.(map[string]any); ok && contentPartsHaveMedia(mm["content"]) {
+				return true
 			}
-			if typ, _ := pm["type"].(string); isMediaPartType(typ) {
+		}
+	}
+	// Responses API: `input` may be a string (no media) or an array of items,
+	// each carrying `content` parts in the same image_url/input_image shape.
+	if input, ok := parsed["input"].([]any); ok {
+		for _, item := range input {
+			if im, ok := item.(map[string]any); ok && contentPartsHaveMedia(im["content"]) {
 				return true
 			}
 		}

--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -561,7 +561,9 @@ const (
 // image or video input.
 func isMediaPartType(t string) bool {
 	switch t {
-	case "image_url", "input_image", "video_url", "input_video":
+	// OpenAI chat (image_url/video_url), OpenAI Responses (input_image/input_video),
+	// and Anthropic /v1/messages content blocks ({"type":"image"|"video","source":…}).
+	case "image_url", "input_image", "image", "video_url", "input_video", "video":
 		return true
 	}
 	return false
@@ -598,9 +600,9 @@ func messageContentTokens(content any) int {
 				if s, ok := pm["text"].(string); ok {
 					total += textTokens(s)
 				}
-			case typ == "image_url" || typ == "input_image":
+			case typ == "image_url" || typ == "input_image" || typ == "image":
 				total += imagePromptTokenCost
-			case typ == "video_url" || typ == "input_video":
+			case typ == "video_url" || typ == "input_video" || typ == "video":
 				total += videoPromptTokenCost
 			default:
 				if b, err := json.Marshal(pm); err == nil {
@@ -1251,11 +1253,24 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 	// when the fleet has no such provider (e.g. before the gemma fleet finishes
 	// updating to 0.6.0); the routing layer enforces the same gate per dispatch.
 	requiresVision := detectMediaRequirement(parsed)
-	if requiresVision && !s.registry.HasVisionProviderForModel(model) {
-		writeJSON(w, http.StatusServiceUnavailable, errorResponse("model_unavailable",
-			fmt.Sprintf("model %q has no vision-capable provider available for image/video input right now", publicModel),
-			withParam("model")))
-		return
+	if requiresVision {
+		// The Responses API path lowers `input` to chat messages via
+		// responsesRequestToChatCompletions, which does NOT carry image/video parts
+		// through — so a media request there would be routed and then silently
+		// stripped (image-blind). Reject it cleanly until that conversion preserves
+		// media (tracked follow-up); the console uses /v1/chat/completions for images.
+		if input != nil && len(messages) == 0 {
+			writeJSON(w, http.StatusBadRequest, errorResponse("invalid_request_error",
+				"image/video input via the Responses API is not supported yet; use /v1/chat/completions",
+				withParam("input")))
+			return
+		}
+		if !s.registry.HasVisionProviderForModel(model) {
+			writeJSON(w, http.StatusServiceUnavailable, errorResponse("model_unavailable",
+				fmt.Sprintf("model %q has no vision-capable provider available for image/video input right now", publicModel),
+				withParam("model")))
+			return
+		}
 	}
 
 	isResponsesAPI := input != nil && len(messages) == 0

--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -239,6 +239,7 @@ func (s *Server) dispatchOneProvider(
 	reservedMicroUSD int64,
 	estimatedPromptTokens int,
 	requestedMaxTokens int,
+	requiresVision bool,
 	allowedProviderSerials []string,
 	isResponsesAPI bool,
 	policy selfRoutePolicy,
@@ -263,6 +264,7 @@ func (s *Server) dispatchOneProvider(
 		ConsumerLocation:       consumerLocation,
 		IsResponsesAPI:         isResponsesAPI,
 		EstimatedPromptTokens:  estimatedPromptTokens,
+		RequiresVision:         requiresVision,
 		RequestedMaxTokens:     requestedMaxTokens,
 		ReservedMicroUSD:       reservedMicroUSD,
 		BaseReservedMicroUSD:   reservedMicroUSD,
@@ -503,7 +505,7 @@ func approximateTokenCountUpperBound(v any) int {
 func estimatePromptTokens(parsed map[string]any) int {
 	total := 0
 	if v, ok := parsed["messages"]; ok {
-		total += approximateTokenCount(v)
+		total += messagesPromptTokens(v, false)
 	}
 	if v, ok := parsed["input"]; ok {
 		total += approximateTokenCount(v)
@@ -524,7 +526,7 @@ func estimatePromptTokens(parsed map[string]any) int {
 func estimateBillingPromptTokens(parsed map[string]any) int {
 	total := 0
 	if v, ok := parsed["messages"]; ok {
-		total += approximateTokenCountUpperBound(v)
+		total += messagesPromptTokens(v, true)
 	}
 	if v, ok := parsed["input"]; ok {
 		total += approximateTokenCountUpperBound(v)
@@ -536,6 +538,140 @@ func estimateBillingPromptTokens(parsed map[string]any) int {
 		total = approximateTokenCountUpperBound(parsed)
 	}
 	return total
+}
+
+// Media prompt-token costs. A vision encoder turns each image/video into a
+// bounded number of soft tokens (Gemma 4 caps around a few hundred per image)
+// regardless of the base64 byte length, so counting a `data:` URI as text
+// inflates the estimate by orders of magnitude — distorting routing admission and
+// over-reserving balance. These flat per-media costs keep both sane.
+const (
+	imagePromptTokenCost = 300
+	videoPromptTokenCost = 1500
+)
+
+// isMediaPartType reports whether an OpenAI/OpenRouter content-part type denotes
+// image or video input.
+func isMediaPartType(t string) bool {
+	switch t {
+	case "image_url", "input_image", "video_url", "input_video":
+		return true
+	}
+	return false
+}
+
+// messageContentTokens estimates prompt tokens for one message's `content`,
+// counting text parts as text and each image/video part as a flat media cost
+// (never the base64 length). byteBound selects the billing upper bound (len) vs
+// the routing heuristic (len/4) for text.
+func messageContentTokens(content any, byteBound bool) int {
+	textTokens := func(s string) int {
+		if s == "" {
+			return 0
+		}
+		if byteBound {
+			return len(s)
+		}
+		if t := len(s) / 4; t > 0 {
+			return t
+		}
+		return 1
+	}
+	switch c := content.(type) {
+	case string:
+		return textTokens(c)
+	case []any:
+		total := 0
+		for _, part := range c {
+			pm, ok := part.(map[string]any)
+			if !ok {
+				continue
+			}
+			typ, _ := pm["type"].(string)
+			switch {
+			case typ == "text":
+				if s, ok := pm["text"].(string); ok {
+					total += textTokens(s)
+				}
+			case typ == "image_url" || typ == "input_image":
+				total += imagePromptTokenCost
+			case typ == "video_url" || typ == "input_video":
+				total += videoPromptTokenCost
+			default:
+				if b, err := json.Marshal(pm); err == nil {
+					if byteBound {
+						total += len(b)
+					} else {
+						total += len(b) / 4
+					}
+				}
+			}
+		}
+		return total
+	default:
+		if byteBound {
+			return approximateTokenCountUpperBound(content)
+		}
+		return approximateTokenCount(content)
+	}
+}
+
+// messagesPromptTokens sums media-aware content tokens across a messages array.
+// Falls back to the byte heuristic when messages isn't the standard array shape.
+func messagesPromptTokens(messages any, byteBound bool) int {
+	arr, ok := messages.([]any)
+	if !ok {
+		if byteBound {
+			return approximateTokenCountUpperBound(messages)
+		}
+		return approximateTokenCount(messages)
+	}
+	total := 0
+	for _, m := range arr {
+		mm, ok := m.(map[string]any)
+		if !ok {
+			if byteBound {
+				total += approximateTokenCountUpperBound(m)
+			} else {
+				total += approximateTokenCount(m)
+			}
+			continue
+		}
+		total += 4 // small per-message framing (role + delimiters)
+		total += messageContentTokens(mm["content"], byteBound)
+	}
+	return total
+}
+
+// detectMediaRequirement reports whether the request carries image/video input in
+// any message's content parts. The coordinator sees plaintext at this point
+// (sealedTransport decrypts before the handler), so this drives the vision
+// routing gate and the fail-fast "no vision-capable provider" response.
+func detectMediaRequirement(parsed map[string]any) bool {
+	messages, ok := parsed["messages"].([]any)
+	if !ok {
+		return false
+	}
+	for _, m := range messages {
+		mm, ok := m.(map[string]any)
+		if !ok {
+			continue
+		}
+		parts, ok := mm["content"].([]any)
+		if !ok {
+			continue
+		}
+		for _, part := range parts {
+			pm, ok := part.(map[string]any)
+			if !ok {
+				continue
+			}
+			if typ, _ := pm["type"].(string); isMediaPartType(typ) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func estimateRequestedMaxTokens(parsed map[string]any) int {
@@ -1103,6 +1239,19 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 	}
 	model, rawBody = buildModel, resolvedBody
 
+	// Vision gating: a request carrying image/video input must land on a provider
+	// advertising a vision-capable (VLM) build of this model, or the media is
+	// silently dropped and the answer is image-blind. Fail fast with a clear error
+	// when the fleet has no such provider (e.g. before the gemma fleet finishes
+	// updating to 0.6.0); the routing layer enforces the same gate per dispatch.
+	requiresVision := detectMediaRequirement(parsed)
+	if requiresVision && !s.registry.HasVisionProviderForModel(model) {
+		writeJSON(w, http.StatusServiceUnavailable, errorResponse("model_unavailable",
+			fmt.Sprintf("model %q has no vision-capable provider available for image/video input right now", publicModel),
+			withParam("model")))
+		return
+	}
+
 	isResponsesAPI := input != nil && len(messages) == 0
 
 	// Inject model-specific defaults from the registry: reasoning_parser
@@ -1310,7 +1459,7 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 		var dispatchErrCode int
 		provider, pr, _, dispatchErr, dispatchErrCode = s.dispatchOneProvider(
 			r, model, publicModel, rawBody, consumerKey, consumerLocation, reservedMicroUSD,
-			estimatedPromptTokens, requestedMaxTokens, allowedProviderSerials,
+			estimatedPromptTokens, requestedMaxTokens, requiresVision, allowedProviderSerials,
 			isResponsesAPI, policy, timing, excludeProviders,
 		)
 		if provider == nil {
@@ -1361,6 +1510,7 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 				ConsumerLocation:       consumerLocation,
 				IsResponsesAPI:         isResponsesAPI,
 				EstimatedPromptTokens:  estimatedPromptTokens,
+				RequiresVision:         requiresVision,
 				RequestedMaxTokens:     requestedMaxTokens,
 				ReservedMicroUSD:       reservedMicroUSD,
 				BaseReservedMicroUSD:   reservedMicroUSD,
@@ -1662,7 +1812,7 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 
 				backupProvider, backupPR, _, _, _ = s.dispatchOneProvider(
 					r, model, publicModel, rawBody, consumerKey, consumerLocation, reservedMicroUSD,
-					estimatedPromptTokens, requestedMaxTokens, allowedProviderSerials,
+					estimatedPromptTokens, requestedMaxTokens, requiresVision, allowedProviderSerials,
 					isResponsesAPI, policy, &registry.RequestTiming{ReceivedAt: timing.ReceivedAt},
 					backupExclude,
 				)
@@ -4306,6 +4456,16 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 		return
 	}
 
+	// Vision gating (see handleChatCompletions): a media request must land on a
+	// vision-capable provider, or fail fast when none exists.
+	requiresVision := detectMediaRequirement(parsed)
+	if requiresVision && !s.registry.HasVisionProviderForModel(model) {
+		writeJSON(w, http.StatusServiceUnavailable, errorResponse("model_unavailable",
+			fmt.Sprintf("model %q has no vision-capable provider available for image/video input right now", publicModel),
+			withParam("model")))
+		return
+	}
+
 	// Completions and Anthropic messages both use the max_tokens field (never
 	// max_output_tokens, which is Responses API only). Inject a default if
 	// unset so the pre-flight reservation bounds the generation.
@@ -4420,6 +4580,7 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 		OwnerAccountID:         policy.ownerAccountID,
 		FreeSelfRoute:          policy.enabled,
 		EstimatedPromptTokens:  estimatedPromptTokens,
+		RequiresVision:         requiresVision,
 		RequestedMaxTokens:     requestedMaxTokens,
 		ReservedMicroUSD:       reservedMicroUSD,
 		BaseReservedMicroUSD:   reservedMicroUSD,

--- a/coordinator/api/consumer_test.go
+++ b/coordinator/api/consumer_test.go
@@ -1603,14 +1603,16 @@ func TestDetectMediaRequirementAndTokenEstimate(t *testing.T) {
 	}
 	got := estimatePromptTokens(parsed)
 	if got > 1000 {
-		t.Fatalf("media-aware estimate must ignore base64 length; got %d tokens for a 200KB image", got)
+		t.Fatalf("media-aware ROUTING estimate must ignore base64 length; got %d tokens for a 200KB image", got)
 	}
 	if got < imagePromptTokenCost {
-		t.Fatalf("estimate should include the flat per-image cost (%d); got %d", imagePromptTokenCost, got)
+		t.Fatalf("routing estimate should include the flat per-image cost (%d); got %d", imagePromptTokenCost, got)
 	}
-	// Billing upper bound is also media-aware (no 200k-byte inflation).
-	if b := estimateBillingPromptTokens(parsed); b > 5000 {
-		t.Fatalf("billing estimate must not count the base64 blob; got %d", b)
+	// Billing intentionally stays a guaranteed UPPER bound (still counts the
+	// base64 bytes) so it can never under-reserve; over-reservation is refunded
+	// after inference. It must therefore exceed the small routing estimate here.
+	if b := estimateBillingPromptTokens(parsed); b <= got {
+		t.Fatalf("billing upper bound (%d) should exceed the routing estimate (%d) for a base64 image", b, got)
 	}
 
 	textParsed := map[string]any{
@@ -1620,5 +1622,26 @@ func TestDetectMediaRequirementAndTokenEstimate(t *testing.T) {
 	}
 	if detectMediaRequirement(textParsed) {
 		t.Fatal("a text-only request must not be flagged as requiring vision")
+	}
+}
+
+// TestDetectMediaRequirementResponsesInput verifies the Responses API surface
+// (input[].content parts) is gated too, so a media request there fails fast
+// rather than being silently routed text-blind.
+func TestDetectMediaRequirementResponsesInput(t *testing.T) {
+	withImage := map[string]any{
+		"input": []any{
+			map[string]any{"role": "user", "content": []any{
+				map[string]any{"type": "input_text", "text": "describe"},
+				map[string]any{"type": "input_image", "image_url": "data:image/png;base64,AAAA"},
+			}},
+		},
+	}
+	if !detectMediaRequirement(withImage) {
+		t.Fatal("expected media detected in Responses API input parts")
+	}
+	textOnly := map[string]any{"input": "just a string prompt"}
+	if detectMediaRequirement(textOnly) {
+		t.Fatal("a string Responses input must not be flagged as media")
 	}
 }

--- a/coordinator/api/consumer_test.go
+++ b/coordinator/api/consumer_test.go
@@ -1584,3 +1584,41 @@ func TestInjectReasoningDetailIntoRawUsage(t *testing.T) {
 		t.Errorf("did not expect a usage object to be created")
 	}
 }
+
+// TestDetectMediaRequirementAndTokenEstimate verifies media detection and that
+// the media-aware estimator counts an image as a flat cost rather than its
+// inflated base64 length (which would distort routing admission and billing).
+func TestDetectMediaRequirementAndTokenEstimate(t *testing.T) {
+	bigImage := "data:image/png;base64," + strings.Repeat("A", 200_000)
+	parsed := map[string]any{
+		"messages": []any{
+			map[string]any{"role": "user", "content": []any{
+				map[string]any{"type": "text", "text": "what is in this image?"},
+				map[string]any{"type": "image_url", "image_url": map[string]any{"url": bigImage}},
+			}},
+		},
+	}
+	if !detectMediaRequirement(parsed) {
+		t.Fatal("expected media requirement detected for an image_url content part")
+	}
+	got := estimatePromptTokens(parsed)
+	if got > 1000 {
+		t.Fatalf("media-aware estimate must ignore base64 length; got %d tokens for a 200KB image", got)
+	}
+	if got < imagePromptTokenCost {
+		t.Fatalf("estimate should include the flat per-image cost (%d); got %d", imagePromptTokenCost, got)
+	}
+	// Billing upper bound is also media-aware (no 200k-byte inflation).
+	if b := estimateBillingPromptTokens(parsed); b > 5000 {
+		t.Fatalf("billing estimate must not count the base64 blob; got %d", b)
+	}
+
+	textParsed := map[string]any{
+		"messages": []any{
+			map[string]any{"role": "user", "content": "hello world"},
+		},
+	}
+	if detectMediaRequirement(textParsed) {
+		t.Fatal("a text-only request must not be flagged as requiring vision")
+	}
+}

--- a/coordinator/api/consumer_test.go
+++ b/coordinator/api/consumer_test.go
@@ -1645,3 +1645,22 @@ func TestDetectMediaRequirementResponsesInput(t *testing.T) {
 		t.Fatal("a string Responses input must not be flagged as media")
 	}
 }
+
+// TestDetectMediaRequirementAnthropicImageBlock verifies Anthropic /v1/messages
+// image content blocks ({"type":"image","source":...}) are detected for the
+// vision routing gate, not just OpenAI-style image_url parts.
+func TestDetectMediaRequirementAnthropicImageBlock(t *testing.T) {
+	parsed := map[string]any{
+		"messages": []any{
+			map[string]any{"role": "user", "content": []any{
+				map[string]any{"type": "text", "text": "what is this?"},
+				map[string]any{"type": "image", "source": map[string]any{
+					"type": "base64", "media_type": "image/png", "data": "AAAA",
+				}},
+			}},
+		},
+	}
+	if !detectMediaRequirement(parsed) {
+		t.Fatal("expected Anthropic image content block to be detected as media")
+	}
+}

--- a/coordinator/api/model_alias_handlers.go
+++ b/coordinator/api/model_alias_handlers.go
@@ -19,6 +19,16 @@ type aliasUpsertRequest struct {
 	DesiredBuild  string `json:"desired_build"`
 	PreviousBuild string `json:"previous_build"`
 	Active        *bool  `json:"active"` // pointer so omission defaults to true
+	// Takeover lets a public alias adopt the name of an EXISTING concrete model,
+	// absorbing that same-named build as its previous_build (fallback). This is the
+	// only way to migrate a live public name (e.g. "gemma-4-26b") onto a new
+	// desired build without renaming what providers already advertise — used for
+	// the 8-bit→4-bit gemma cutover. Fail-closed: only the exact shape
+	// alias_id == previous_build == an existing concrete model id is permitted, and
+	// desired_build must still be a distinct registered build. It does NOT touch
+	// the absorbed model's catalog weight hash, so it never untrusts the providers
+	// already serving it; they converge to the desired build via desired_models.
+	Takeover bool `json:"takeover"`
 }
 
 // handleModelAliasUpsert creates or replaces a public model alias (idempotent on
@@ -58,15 +68,37 @@ func (s *Server) handleModelAliasUpsert(w http.ResponseWriter, r *http.Request) 
 		writeJSON(w, http.StatusBadRequest, errorResponse("invalid_request_error", "desired_build is required", withParam("desired_build")))
 		return
 	}
-	// Namespace guard: an alias id must not collide with a concrete model id,
-	// otherwise resolution and routing become ambiguous.
-	if rec, err := s.store.GetModelRegistryRecord(req.AliasID); err == nil && rec != nil {
-		writeJSON(w, http.StatusConflict, errorResponse("invalid_request_error",
-			"alias_id collides with an existing model id", withParam("alias_id")))
+	// Namespace + takeover rules. Normally an alias id must not collide with a
+	// concrete model id (resolution would be ambiguous), and an alias may never
+	// name itself as a member. `takeover` is the deliberate exception for the
+	// public-name migration: an alias adopts the name of an existing concrete
+	// model and absorbs that same-named build as its previous_build (fallback).
+	collidingRec, _ := s.store.GetModelRegistryRecord(req.AliasID)
+	idCollision := collidingRec != nil
+
+	// desired_build can NEVER equal the alias name (that would alias to itself).
+	if req.DesiredBuild == req.AliasID {
+		writeJSON(w, http.StatusBadRequest, errorResponse("invalid_request_error",
+			"desired_build cannot equal alias_id", withParam("desired_build")))
 		return
 	}
-	if req.DesiredBuild == req.AliasID || req.PreviousBuild == req.AliasID {
-		writeJSON(w, http.StatusBadRequest, errorResponse("invalid_request_error", "an alias cannot reference itself", withParam("desired_build")))
+	if idCollision {
+		if !req.Takeover {
+			writeJSON(w, http.StatusConflict, errorResponse("invalid_request_error",
+				"alias_id collides with an existing model id (set takeover=true to adopt it as the alias's previous build)", withParam("alias_id")))
+			return
+		}
+		// Fail-closed: takeover only permits absorbing the SAME-named concrete
+		// build as the alias fallback. previous_build must be exactly alias_id.
+		if req.PreviousBuild != req.AliasID {
+			writeJSON(w, http.StatusBadRequest, errorResponse("invalid_request_error",
+				"takeover requires previous_build to equal alias_id (the concrete build absorbed as the alias fallback)", withParam("previous_build")))
+			return
+		}
+	} else if req.PreviousBuild == req.AliasID {
+		// No concrete model of this name exists, so there is nothing to absorb.
+		writeJSON(w, http.StatusBadRequest, errorResponse("invalid_request_error",
+			"an alias cannot reference itself", withParam("previous_build")))
 		return
 	}
 	if req.PreviousBuild != "" && req.PreviousBuild == req.DesiredBuild {

--- a/coordinator/api/model_alias_handlers_test.go
+++ b/coordinator/api/model_alias_handlers_test.go
@@ -973,3 +973,59 @@ func TestListModelsHidesRetiredAliasBuild(t *testing.T) {
 		t.Fatalf("retired build should be in the hidden set: %v", hidden)
 	}
 }
+
+// TestModelAliasTakeoverOfConcreteID covers the 8-bit→4-bit public-name cutover:
+// an alias adopts the live concrete id "gemma-4-26b", absorbing it as the
+// previous/fallback build while pointing desired at the new 4-bit build. The
+// critical safety property is that the absorbed model's catalog weight hash is
+// untouched, so the providers already serving it are not untrusted.
+func TestModelAliasTakeoverOfConcreteID(t *testing.T) {
+	t.Setenv("MODEL_REGISTRY_PUBLISHING_KEY", "publish-secret")
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	st := store.NewMemory(store.Config{})
+	reg := registry.New(logger)
+	srv := NewServer(reg, st, ServerConfig{}, logger)
+
+	const legacyID = "gemma-4-26b"       // live concrete build = today's public name
+	const qatID = "gemma-4-26b-qat-4bit" // the new 4-bit build
+	seedActiveModel(t, st, legacyID, "Gemma 4 26B (8-bit)")
+	seedActiveModel(t, st, qatID, "Gemma 4 26B (qat-4bit)")
+	srv.SyncModelCatalog()
+	hashBefore := reg.CatalogWeightHash(legacyID)
+
+	post := func(bodyMap map[string]any) *httptest.ResponseRecorder {
+		body, _ := json.Marshal(bodyMap)
+		req := httptest.NewRequest(http.MethodPost, "/v1/admin/models/aliases", bytes.NewReader(body))
+		req.Header.Set("Authorization", "Bearer publish-secret")
+		rec := httptest.NewRecorder()
+		srv.Handler().ServeHTTP(rec, req)
+		return rec
+	}
+
+	// Without takeover, adopting an existing concrete id is a 409.
+	if rec := post(map[string]any{"alias_id": legacyID, "desired_build": qatID, "previous_build": legacyID}); rec.Code != http.StatusConflict {
+		t.Fatalf("expected 409 without takeover, got %d: %s", rec.Code, rec.Body.String())
+	}
+	// Takeover requires previous_build == alias_id (fail-closed on the exact shape).
+	if rec := post(map[string]any{"alias_id": legacyID, "desired_build": qatID, "takeover": true}); rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 when takeover lacks previous_build==alias_id, got %d: %s", rec.Code, rec.Body.String())
+	}
+	// desired_build may never equal the alias name even under takeover.
+	if rec := post(map[string]any{"alias_id": legacyID, "desired_build": legacyID, "previous_build": legacyID, "takeover": true}); rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 when desired_build == alias_id, got %d: %s", rec.Code, rec.Body.String())
+	}
+	// Valid takeover.
+	if rec := post(map[string]any{"alias_id": legacyID, "display_name": "Gemma 4 26B", "desired_build": qatID, "previous_build": legacyID, "takeover": true}); rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 for valid takeover, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// The public name now resolves through the alias to the 4-bit desired build.
+	if b, isAlias, ok := reg.ResolveModel(legacyID); !isAlias || !ok || b != qatID {
+		t.Fatalf("resolve after takeover = %q isAlias=%v ok=%v, want desired %q", b, isAlias, ok, qatID)
+	}
+	// CRITICAL: the absorbed model's catalog weight hash is unchanged, so the
+	// fleet already serving the legacy build is NOT untrusted by the takeover.
+	if after := reg.CatalogWeightHash(legacyID); after != hashBefore {
+		t.Fatalf("takeover changed catalog hash for %s (%q -> %q) — would untrust the live fleet", legacyID, hashBefore, after)
+	}
+}

--- a/coordinator/api/provider.go
+++ b/coordinator/api/provider.go
@@ -357,14 +357,17 @@ func (s *Server) providerReadLoop(ctx context.Context, conn *websocket.Conn, pro
 				s.challengeLoop(loopCtx, conn, providerID, provider, tracker)
 			})
 
-			// v0.6.0: APNs code-identity attestation, once per connection. Runs
-			// only when an attestor is configured; otherwise the provider simply
-			// never becomes CodeAttested (fail-closed at the routing chokepoint).
-			// The code-identity proof and the SIP/liveness pillar compose at the
-			// routing gate (providerSupportsPrivateTextLocked requires both).
+			// v0.6.0: APNs code-identity attestation. Runs only when an attestor is
+			// configured; otherwise the provider simply never becomes CodeAttested
+			// (fail-closed at the routing chokepoint once enforcement begins). The
+			// code-identity proof and the SIP/liveness pillar compose at the routing
+			// gate (providerSupportsPrivateTextLocked requires both). The loop
+			// re-challenges on the ticker until the provider attests, so a single
+			// dropped background push doesn't strand a capable provider past the
+			// grace deadline.
 			if s.codeAttestor != nil {
 				saferun.Go(s.logger, "codeAttest", func() {
-					s.sendCodeIdentityChallenge(loopCtx, providerID, provider, codeTracker)
+					s.codeAttestLoop(loopCtx, providerID, provider, codeTracker)
 				})
 			}
 
@@ -460,6 +463,54 @@ func (s *Server) providerReadLoop(ctx context.Context, conn *websocket.Conn, pro
 // a background push may be briefly delayed; the provider's local decrypt+sign is
 // sub-second.
 const CodeAttestResponseTimeout = 90 * time.Second
+
+// codeAttestLoop drives the APNs code-identity round-trip for one connection. It
+// challenges immediately, then re-challenges on the attestation ticker until the
+// provider is CodeAttested (success), is hard-untrusted, or the connection ends.
+// Re-challenging heals transient APNs delivery failures — the design's top open
+// risk is that a background push is APNs-accepted but never delivered — so a
+// capable provider becomes routable before the grace deadline rather than being
+// stranded by a single dropped push. Providers with no APNs device token (legacy
+// <0.6.0 builds) can never attest, so the loop exits immediately and they are
+// derouted once enforcement begins — the intended "everyone must update" outcome.
+func (s *Server) codeAttestLoop(ctx context.Context, providerID string, provider *registry.Provider, ct *codeAttestTracker) {
+	if s.codeAttestor == nil || provider == nil {
+		return
+	}
+
+	provider.Mu().Lock()
+	hasToken := provider.APNsDeviceToken != ""
+	provider.Mu().Unlock()
+	if !hasToken {
+		s.logger.Info("code-attest: provider has no APNs device token; cannot attest (will be derouted once enforcement begins)",
+			"provider_id", providerID)
+		return
+	}
+
+	s.sendCodeIdentityChallenge(ctx, providerID, provider, ct)
+
+	interval := s.challengeInterval
+	if interval == 0 {
+		interval = DefaultChallengeInterval
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if provider.GetCodeAttested() {
+				return // attested for this connection; nothing more to do
+			}
+			if provider.ChallengeShouldStop() {
+				return // hard (non-recoverable) untrust — stop challenging
+			}
+			s.sendCodeIdentityChallenge(ctx, providerID, provider, ct)
+		}
+	}
+}
 
 // sendCodeIdentityChallenge runs the per-connection APNs code-identity round-trip
 // (v0.6.0): it pushes E_K(nonce) to the provider's device, awaits the provider's

--- a/coordinator/api/provider.go
+++ b/coordinator/api/provider.go
@@ -464,15 +464,26 @@ func (s *Server) providerReadLoop(ctx context.Context, conn *websocket.Conn, pro
 // sub-second.
 const CodeAttestResponseTimeout = 90 * time.Second
 
-// codeAttestLoop drives the APNs code-identity round-trip for one connection. It
-// challenges immediately, then re-challenges on the attestation ticker until the
-// provider is CodeAttested (success), is hard-untrusted, or the connection ends.
-// Re-challenging heals transient APNs delivery failures — the design's top open
-// risk is that a background push is APNs-accepted but never delivered — so a
-// capable provider becomes routable before the grace deadline rather than being
-// stranded by a single dropped push. Providers with no APNs device token (legacy
-// <0.6.0 builds) can never attest, so the loop exits immediately and they are
-// derouted once enforcement begins — the intended "everyone must update" outcome.
+// codeAttestLoop drives the APNs code-identity round-trip for one connection.
+//
+// Attestation is PER-CONNECTION: while a WebSocket is alive the provider's binary
+// cannot change (a binary swap restarts the process and drops the connection), so
+// one successful challenge proves the connection's code identity for its whole
+// lifetime — there is NO periodic re-challenge. That also respects Apple's
+// background-push budget (~2-3/hour/device); a 5-minute ticker (12/hour) would be
+// throttled and dropped.
+//
+// Reliability without spamming pushes:
+//   - Reuse: if this device (Secure Enclave key) attested recently with the same
+//     binary version, the new connection inherits the proof with NO push — so a
+//     brief reconnect/network blip doesn't burn a push or strand the provider.
+//   - Bounded retry: otherwise challenge once, retrying only on delivery failure,
+//     spaced by the per-device push cooldown and capped, so a dropped push heals
+//     without exceeding the budget.
+//
+// Providers with no APNs device token (legacy <0.6.0, or headless boxes with no
+// GUI session) can never attest, so the loop exits immediately — they are derouted
+// once enforcement begins, the intended "everyone must update" outcome.
 func (s *Server) codeAttestLoop(ctx context.Context, providerID string, provider *registry.Provider, ct *codeAttestTracker) {
 	if s.codeAttestor == nil || provider == nil {
 		return
@@ -480,6 +491,11 @@ func (s *Server) codeAttestLoop(ctx context.Context, providerID string, provider
 
 	provider.Mu().Lock()
 	hasToken := provider.APNsDeviceToken != ""
+	version := provider.Version
+	var seKey string
+	if provider.AttestationResult != nil {
+		seKey = provider.AttestationResult.PublicKey
+	}
 	provider.Mu().Unlock()
 	if !hasToken {
 		s.logger.Info("code-attest: provider has no APNs device token; cannot attest (will be derouted once enforcement begins)",
@@ -487,29 +503,42 @@ func (s *Server) codeAttestLoop(ctx context.Context, providerID string, provider
 		return
 	}
 
-	s.sendCodeIdentityChallenge(ctx, providerID, provider, ct)
-
-	interval := s.challengeInterval
-	if interval == 0 {
-		interval = DefaultChallengeInterval
+	// Reuse a recent, same-version attestation for this device instead of spending
+	// a push — the binary can't have changed (same version) and the proof is fresh.
+	if s.codeAttestThrottle.reuseAttestation(seKey, version) {
+		provider.SetCodeAttested(true)
+		s.registry.DrainQueuedRequestsForProvider(provider)
+		s.logger.Info("code-attest: reused a recent attestation for this device (no push)",
+			"provider_id", providerID)
+		return
 	}
-	ticker := time.NewTicker(interval)
-	defer ticker.Stop()
 
-	for {
+	for attempt := 0; attempt < s.codeAttestThrottle.maxAttempts; attempt++ {
+		if provider.GetCodeAttested() {
+			return // attested for this connection; nothing more to do
+		}
+		if provider.ChallengeShouldStop() {
+			return // hard (non-recoverable) untrust — stop challenging
+		}
+		// Only push if the per-device cooldown allows it (background-push budget).
+		if s.codeAttestThrottle.allowPush(seKey) {
+			s.codeAttestThrottle.recordPush(seKey)
+			s.sendCodeIdentityChallenge(ctx, providerID, provider, ct)
+			if provider.GetCodeAttested() {
+				s.codeAttestThrottle.recordAttested(seKey, version)
+				return
+			}
+		}
+		// Space retries by the cooldown so we never exceed the background-push
+		// budget; bail if the connection ends first.
 		select {
 		case <-ctx.Done():
 			return
-		case <-ticker.C:
-			if provider.GetCodeAttested() {
-				return // attested for this connection; nothing more to do
-			}
-			if provider.ChallengeShouldStop() {
-				return // hard (non-recoverable) untrust — stop challenging
-			}
-			s.sendCodeIdentityChallenge(ctx, providerID, provider, ct)
+		case <-time.After(s.codeAttestThrottle.pushCooldown):
 		}
 	}
+	s.logger.Warn("code-attest: not attested after max attempts; will retry on a later reconnect (within the push budget)",
+		"provider_id", providerID)
 }
 
 // sendCodeIdentityChallenge runs the per-connection APNs code-identity round-trip

--- a/coordinator/api/server.go
+++ b/coordinator/api/server.go
@@ -183,6 +183,7 @@ type Server struct {
 	stepCAIntermediateCert *x509.Certificate         // step-ca intermediate CA
 	profileSigner          *profilesign.Signer       // CMS signer for the /v1/enroll .mobileconfig (nil = serve unsigned)
 	codeAttestor           apns.CodeIdentityAttestor // APNs code-identity attestor (nil = disabled; v0.6.0)
+	codeAttestThrottle     *codeAttestThrottle       // per-device APNs push budget + reuse cache (v0.6.0)
 
 	// knownBinaryHashes is the set of accepted provider binary SHA-256 hashes.
 	// When binaryHashPolicyConfigured is true, providers whose binary hash is
@@ -535,6 +536,7 @@ func NewServer(reg *registry.Registry, st store.Store, cfg ServerConfig, logger 
 		geoResolver:          newProviderGeoResolverFromEnv(logger),
 		apiKeyCache:          make(map[string]apiKeyCacheEntry),
 		pendingACME:          make(map[string]*ACMEVerificationResult),
+		codeAttestThrottle:   newCodeAttestThrottle(),
 	}
 	s.registerDefaultGauges()
 	s.routes()

--- a/coordinator/api/server.go
+++ b/coordinator/api/server.go
@@ -140,10 +140,10 @@ func keyLimitResetFromContext(ctx context.Context) string {
 // release has been registered in the store (e.g. in-memory dev setups).
 // Production reads the latest version from the releases table.
 //
-// 0.5.17 is the desired_models cutover release for declarative prefetch/hotswap.
+// 0.6.0 is the APNs code-identity / VLM-routing / graceful-update release.
 // Keep this fallback in sync with ProviderCore.version so dev/in-memory
 // coordinators advertise the same floor as the Swift binary they expect.
-var LatestProviderVersion = "0.5.17"
+var LatestProviderVersion = "0.6.0"
 
 // minProviderVersionForDesiredModels is the first provider version whose Swift
 // runtime understands the desired_models message. The coordinator must NOT send
@@ -730,14 +730,24 @@ func (s *Server) SetMDMClient(client *mdm.Client) {
 	s.mdmClient = client
 }
 
-// SetCodeAttestor wires the APNs code-identity attestor (v0.6.0) and ENABLES
-// enforcement: providers that register afterward must pass the code-identity
-// round-trip (CodeAttested) to be routed private/text traffic. Passing nil
-// leaves the feature disabled (providers route as before). Call once during
-// server setup, before providers connect.
+// SetCodeAttestor wires the APNs code-identity attestor (v0.6.0). When set, the
+// coordinator issues code-identity challenges and measures which providers pass —
+// but enforcement (derouting un-attested providers) only begins once a deadline
+// is reached (SetCodeAttestationDeadline). So configuring the attestor alone is
+// SAFE: the fleet stays in grace/observe mode and keeps routing. Passing nil
+// leaves the feature disabled. Call once during server setup, before providers
+// connect.
 func (s *Server) SetCodeAttestor(a apns.CodeIdentityAttestor) {
 	s.codeAttestor = a
-	s.registry.SetCodeAttestationRequired(a != nil)
+	s.registry.SetCodeAttestationConfigured(a != nil)
+}
+
+// SetCodeAttestationDeadline sets the instant at which code-identity attestation
+// becomes mandatory for routing. Before it (or when zero) the coordinator runs in
+// grace mode: it challenges providers but still routes un-attested ones, giving
+// the fleet time to update to 0.6.0 and attest. Wire it from APNS_ENFORCE_AFTER.
+func (s *Server) SetCodeAttestationDeadline(t time.Time) {
+	s.registry.SetCodeAttestationDeadline(t)
 }
 
 // SetMDMWebhookSecret configures an optional shared secret that MicroMDM must

--- a/coordinator/api/server.go
+++ b/coordinator/api/server.go
@@ -1599,6 +1599,15 @@ func (s *Server) StartDDGaugeLoop(ctx context.Context) {
 			return
 		case <-ticker.C:
 			s.ddGauge("providers.online", float64(s.registry.OnlineCount()), nil)
+			// APNs code-identity coverage — watch this climb during the grace
+			// window before letting APNS_ENFORCE_AFTER pass.
+			codeAttested, _ := s.registry.CodeAttestationCoverage()
+			s.ddGauge("attestation.code_attested", float64(codeAttested), nil)
+			enforced := 0.0
+			if s.registry.CodeAttestationEnforced() {
+				enforced = 1.0
+			}
+			s.ddGauge("attestation.code_enforced", enforced, nil)
 			for model, count := range s.registry.ModelProviderSnapshot() {
 				s.ddGauge("providers.per_model", float64(count), []string{"model:" + model})
 			}

--- a/coordinator/api/stats.go
+++ b/coordinator/api/stats.go
@@ -224,21 +224,27 @@ func (s *Server) handleStats(w http.ResponseWriter, r *http.Request) {
 	// --- Request flow aggregation ---
 	requestFlows := s.aggregateRequestFlows(cutoff)
 
+	// --- APNs code-identity coverage (for watching the grace→enforce rollout) ---
+	codeAttestedProviders, _ := s.registry.CodeAttestationCoverage()
+	codeAttestationEnforced := s.registry.CodeAttestationEnforced()
+
 	resp := map[string]any{
-		"total_requests":          totalRequests,
-		"total_prompt_tokens":     totalPromptTokens,
-		"total_completion_tokens": totalCompletionTokens,
-		"total_tokens":            totalTokens,
-		"avg_tokens_per_request":  avgTokens,
-		"active_providers":        len(providers),
-		"total_gpu_cores":         totalGPUCores,
-		"total_cpu_cores":         totalCPUCores,
-		"total_memory_gb":         totalMemoryGB,
-		"total_bandwidth_gbs":     totalBandwidthGB,
-		"network_capacity_tps":    0, // would need benchmark data
-		"providers":               providers,
-		"models":                  models,
-		"time_series":             timeSeries,
+		"total_requests":            totalRequests,
+		"total_prompt_tokens":       totalPromptTokens,
+		"total_completion_tokens":   totalCompletionTokens,
+		"total_tokens":              totalTokens,
+		"avg_tokens_per_request":    avgTokens,
+		"active_providers":          len(providers),
+		"code_attested_providers":   codeAttestedProviders,
+		"code_attestation_enforced": codeAttestationEnforced,
+		"total_gpu_cores":           totalGPUCores,
+		"total_cpu_cores":           totalCPUCores,
+		"total_memory_gb":           totalMemoryGB,
+		"total_bandwidth_gbs":       totalBandwidthGB,
+		"network_capacity_tps":      0, // would need benchmark data
+		"providers":                 providers,
+		"models":                    models,
+		"time_series":               timeSeries,
 
 		// Location analytics (privacy-floored).
 		"provider_locations":                 providerLocations,

--- a/coordinator/cmd/coordinator/main.go
+++ b/coordinator/cmd/coordinator/main.go
@@ -471,12 +471,24 @@ func main() {
 
 	// Optional APNs code-identity attestation (v0.6.0). When the APNs auth key
 	// (.p8) + key/team IDs are supplied, the coordinator pushes an encrypted
-	// code-identity challenge to each provider and requires the WebSocket reply
-	// before routing private traffic (fail-closed). Absent config leaves it
-	// disabled and the fleet routes as before.
+	// code-identity challenge to each provider over its WebSocket. Configuring the
+	// attestor is SAFE on its own: enforcement (derouting un-attested providers)
+	// only begins once APNS_ENFORCE_AFTER (RFC3339) has passed, so the fleet has a
+	// grace window to update to 0.6.0 and attest. Absent config leaves it disabled.
 	if attestor := loadAPNsAttestor(logger); attestor != nil {
 		srv.SetCodeAttestor(attestor)
-		logger.Info("APNs code-identity attestation enabled (providers must pass code-identity to route)")
+		deadline := parseAPNsEnforceAfter(logger)
+		srv.SetCodeAttestationDeadline(deadline)
+		switch {
+		case deadline.IsZero():
+			logger.Info("APNs code-identity attestation configured in GRACE mode — providers are challenged and measured, but un-attested providers still route (set APNS_ENFORCE_AFTER to begin enforcement)")
+		case time.Now().Before(deadline):
+			logger.Info("APNs code-identity attestation configured — GRACE until the enforcement deadline, then mandatory",
+				"enforce_after", deadline.Format(time.RFC3339))
+		default:
+			logger.Info("APNs code-identity attestation ENFORCED — un-attested providers are not routed",
+				"enforce_after", deadline.Format(time.RFC3339))
+		}
 	} else {
 		logger.Info("APNs code-identity attestation not configured — providers route without code-identity proof")
 	}
@@ -522,6 +534,25 @@ func main() {
 	}
 
 	logger.Info("coordinator stopped")
+}
+
+// parseAPNsEnforceAfter reads APNS_ENFORCE_AFTER (RFC3339) — the instant at which
+// code-identity attestation becomes mandatory for routing. Empty/unset returns the
+// zero time, which keeps the coordinator in grace/observe mode indefinitely (the
+// safe default: configuring APNs secrets never deroutes the fleet). A malformed
+// value also falls back to grace, with an error logged, rather than failing closed.
+func parseAPNsEnforceAfter(logger *slog.Logger) time.Time {
+	raw := strings.TrimSpace(os.Getenv("APNS_ENFORCE_AFTER"))
+	if raw == "" {
+		return time.Time{}
+	}
+	t, err := time.Parse(time.RFC3339, raw)
+	if err != nil {
+		logger.Error("APNS_ENFORCE_AFTER is not valid RFC3339 — leaving APNs in grace mode (no enforcement)",
+			"value", raw, "error", err)
+		return time.Time{}
+	}
+	return t
 }
 
 // loadAPNsAttestor builds the production APNs code-identity attestor from the

--- a/coordinator/cmd/coordinator/main.go
+++ b/coordinator/cmd/coordinator/main.go
@@ -23,6 +23,7 @@ import (
 	"encoding/base64"
 	"encoding/pem"
 	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"os"
@@ -477,7 +478,16 @@ func main() {
 	// grace window to update to 0.6.0 and attest. Absent config leaves it disabled.
 	if attestor := loadAPNsAttestor(logger); attestor != nil {
 		srv.SetCodeAttestor(attestor)
-		deadline := parseAPNsEnforceAfter(logger)
+		deadline, err := parseAPNsEnforceAfter()
+		if err != nil {
+			// A non-empty but malformed APNS_ENFORCE_AFTER is an operator error on a
+			// security-critical knob; falling back to grace would silently keep
+			// un-attested providers routable forever. Fail startup so a typo'd
+			// deadline is caught at deploy, not discovered after a security gap.
+			logger.Error("refusing to start: APNS_ENFORCE_AFTER is set but invalid (fix it, or unset it for grace mode)",
+				"value", os.Getenv("APNS_ENFORCE_AFTER"), "error", err)
+			os.Exit(1)
+		}
 		srv.SetCodeAttestationDeadline(deadline)
 		switch {
 		case deadline.IsZero():
@@ -539,20 +549,21 @@ func main() {
 // parseAPNsEnforceAfter reads APNS_ENFORCE_AFTER (RFC3339) — the instant at which
 // code-identity attestation becomes mandatory for routing. Empty/unset returns the
 // zero time, which keeps the coordinator in grace/observe mode indefinitely (the
-// safe default: configuring APNs secrets never deroutes the fleet). A malformed
-// value also falls back to grace, with an error logged, rather than failing closed.
-func parseAPNsEnforceAfter(logger *slog.Logger) time.Time {
+// safe default: configuring APNs secrets never deroutes the fleet). A NON-EMPTY but
+// malformed value returns an error so the caller fails startup — silently falling
+// back to grace there would be a hidden enforcement downgrade on a typo.
+func parseAPNsEnforceAfter() (time.Time, error) {
 	raw := strings.TrimSpace(os.Getenv("APNS_ENFORCE_AFTER"))
 	if raw == "" {
-		return time.Time{}
+		// Unset is intentional: grace/observe is the safe default. Only a
+		// non-empty-but-malformed value is an error (handled below).
+		return time.Time{}, nil
 	}
 	t, err := time.Parse(time.RFC3339, raw)
 	if err != nil {
-		logger.Error("APNS_ENFORCE_AFTER is not valid RFC3339 — leaving APNs in grace mode (no enforcement)",
-			"value", raw, "error", err)
-		return time.Time{}
+		return time.Time{}, fmt.Errorf("APNS_ENFORCE_AFTER %q is not valid RFC3339: %w", raw, err)
 	}
-	return t
+	return t, nil
 }
 
 // loadAPNsAttestor builds the production APNs code-identity attestor from the

--- a/coordinator/cmd/coordinator/main_test.go
+++ b/coordinator/cmd/coordinator/main_test.go
@@ -1,0 +1,24 @@
+package main
+
+import "testing"
+
+// TestParseAPNsEnforceAfter verifies the security-relevant contract: unset is the
+// safe grace default, a valid RFC3339 value parses, and a NON-EMPTY malformed
+// value returns an error (so the caller fails startup instead of silently keeping
+// the fleet in grace — a hidden enforcement downgrade).
+func TestParseAPNsEnforceAfter(t *testing.T) {
+	t.Setenv("APNS_ENFORCE_AFTER", "")
+	if d, err := parseAPNsEnforceAfter(); err != nil || !d.IsZero() {
+		t.Fatalf("unset should be (zero,nil); got (%v,%v)", d, err)
+	}
+
+	t.Setenv("APNS_ENFORCE_AFTER", "2026-06-11T17:00:00Z")
+	if d, err := parseAPNsEnforceAfter(); err != nil || d.IsZero() {
+		t.Fatalf("valid RFC3339 should parse to a non-zero time; got (%v,%v)", d, err)
+	}
+
+	t.Setenv("APNS_ENFORCE_AFTER", "tomorrow-ish")
+	if _, err := parseAPNsEnforceAfter(); err == nil {
+		t.Fatal("a malformed value must return an error, not silently fall back to grace")
+	}
+}

--- a/coordinator/protocol/messages.go
+++ b/coordinator/protocol/messages.go
@@ -115,6 +115,13 @@ type ModelInfo struct {
 	ModelType    string `json:"model_type"`
 	Quantization string `json:"quantization"`
 	WeightHash   string `json:"weight_hash,omitempty"` // SHA-256 fingerprint of weight files
+	// IsVision is true when the provider can serve this build with image/video
+	// input (a VLM, detected via vision_config). v0.6.0+ only; older providers omit
+	// it (decodes to false) so they are never selected for media requests. The
+	// coordinator uses this purely for routing — the public input-modalities a
+	// consumer sees are governed separately by the catalog capabilities, so this
+	// advertisement does not by itself light up vision in the API.
+	IsVision bool `json:"is_vision,omitempty"`
 }
 
 // ---------------------------------------------------------------------------

--- a/coordinator/protocol/messages_test.go
+++ b/coordinator/protocol/messages_test.go
@@ -7,6 +7,46 @@ import (
 	"testing"
 )
 
+// TestModelInfoIsVisionSymmetry verifies the v0.6.0 is_vision field round-trips
+// and is omitted when false, so a text-only build is wire-compatible with
+// pre-0.6.0 providers (which never send it and decode it as false).
+func TestModelInfoIsVisionSymmetry(t *testing.T) {
+	// Vision build: is_vision present and true.
+	vis := ModelInfo{ID: "gemma-4-26b-qat-4bit", SizeBytes: 1, IsVision: true}
+	b, err := json.Marshal(vis)
+	if err != nil {
+		t.Fatalf("marshal vision: %v", err)
+	}
+	if !bytes.Contains(b, []byte(`"is_vision":true`)) {
+		t.Fatalf("expected is_vision:true in JSON, got %s", b)
+	}
+	var back ModelInfo
+	if err := json.Unmarshal(b, &back); err != nil {
+		t.Fatalf("unmarshal vision: %v", err)
+	}
+	if !back.IsVision {
+		t.Fatal("expected IsVision=true after round-trip")
+	}
+
+	// Text-only build: is_vision omitted entirely (omitempty), and a payload with
+	// no is_vision key decodes to false.
+	text := ModelInfo{ID: "gpt-oss-20b", SizeBytes: 1}
+	b, err = json.Marshal(text)
+	if err != nil {
+		t.Fatalf("marshal text: %v", err)
+	}
+	if bytes.Contains(b, []byte("is_vision")) {
+		t.Fatalf("expected is_vision to be omitted for a text-only build, got %s", b)
+	}
+	var legacy ModelInfo
+	if err := json.Unmarshal([]byte(`{"id":"gpt-oss-20b","size_bytes":1}`), &legacy); err != nil {
+		t.Fatalf("unmarshal legacy: %v", err)
+	}
+	if legacy.IsVision {
+		t.Fatal("expected IsVision=false when the field is absent (pre-0.6.0 provider)")
+	}
+}
+
 func TestRegisterMessageMarshal(t *testing.T) {
 	msg := RegisterMessage{
 		Type: TypeRegister,

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -286,17 +286,18 @@ type Provider struct {
 	// so a SIP downgrade — which needs a reboot that drops the WS — forces
 	// re-attestation. Never persisted.
 	CodeAttested bool
-	// codeAttestationRequired gates whether CodeAttested is ENFORCED for routing.
-	// Set at registration from the registry rollout flag, so the requirement is
-	// switched on only once APNs infra + provider support ship; until then the
-	// fleet routes as before. Fail-closed once true (no self-route exemption).
-	codeAttestationRequired bool
 
 	mu          sync.Mutex
 	pendingReqs map[string]*PendingRequest
 }
 
-func providerSupportsPrivateTextLocked(p *Provider) bool {
+// providerSupportsPrivateTextLocked is the SINGLE routing chokepoint for
+// private/text traffic. It is a method on *Registry (not a free function) so the
+// APNs code-identity gate can consult the live rollout policy
+// (codeAttestationEnforcedLocked) rather than a value stamped at registration —
+// that is what lets the grace→enforce deadline flip without a reconnect. Callers
+// hold r.mu (every call site is inside an r-locked Registry method).
+func (r *Registry) providerSupportsPrivateTextLocked(p *Provider) bool {
 	if p.PublicKey == "" || !privateTextBackendSupported(p.Backend) || !p.EncryptedResponseChunks {
 		return false
 	}
@@ -309,9 +310,9 @@ func providerSupportsPrivateTextLocked(p *Provider) bool {
 		return false
 	}
 	// v0.6.0 APNs code-identity gate — the SINGLE chokepoint, no self-route
-	// exemption (gate everyone). Enforced only when the rollout flag is on, so the
-	// fleet keeps routing until APNs attestation is deployed; fail-closed after.
-	if p.codeAttestationRequired && !p.CodeAttested {
+	// exemption (gate everyone). Enforced only once configured AND past the grace
+	// deadline, so the fleet keeps routing through the rollout; fail-closed after.
+	if r.codeAttestationEnforcedLocked() && !p.CodeAttested {
 		return false
 	}
 	caps := p.PrivacyCapabilities
@@ -422,22 +423,60 @@ func (p *Provider) GetCodeAttested() bool {
 	return p.CodeAttested
 }
 
-// CodeAttestationRequired reports whether code-identity attestation is enforced
-// for this provider's connection (the rollout flag stamped at registration).
-func (p *Provider) CodeAttestationRequired() bool {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	return p.codeAttestationRequired
-}
-
-// SetCodeAttestationRequired toggles the v0.6.0 APNs code-identity rollout flag.
-// When true, providers registered afterward must pass code-identity attestation
-// (CodeAttested) to be routed private/text traffic. Call once at startup after
-// the APNs attestor is configured.
-func (r *Registry) SetCodeAttestationRequired(v bool) {
+// SetCodeAttestationConfigured records whether an APNs code-identity attestor is
+// wired. When configured the coordinator issues code-identity challenges; whether
+// a passing challenge is REQUIRED for routing is governed separately by the
+// enforcement deadline (SetCodeAttestationDeadline). Call during server setup.
+func (r *Registry) SetCodeAttestationConfigured(v bool) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	r.codeAttestationRequired = v
+	r.codeAttestationConfigured = v
+}
+
+// SetCodeAttestationDeadline sets the instant at which code-identity attestation
+// becomes MANDATORY for routing. A zero time means "grace/observe indefinitely"
+// (challenge + measure, but keep routing un-attested providers). Safe to call at
+// runtime; the gate re-reads it on every routing decision.
+func (r *Registry) SetCodeAttestationDeadline(t time.Time) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.codeAttestationDeadline = t
+}
+
+// SetCodeAttestationPolicy sets both knobs atomically (used by tests).
+func (r *Registry) SetCodeAttestationPolicy(configured bool, deadline time.Time) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.codeAttestationConfigured = configured
+	r.codeAttestationDeadline = deadline
+}
+
+// CodeAttestationConfigured reports whether an APNs attestor is wired (so the
+// connection handler should issue code-identity challenges). Thread-safe.
+func (r *Registry) CodeAttestationConfigured() bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.codeAttestationConfigured
+}
+
+// CodeAttestationEnforced reports whether code-identity attestation is currently
+// mandatory for routing (configured AND past the deadline). Thread-safe.
+func (r *Registry) CodeAttestationEnforced() bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.codeAttestationEnforcedLocked()
+}
+
+// codeAttestationEnforcedLocked reports whether code-identity attestation is
+// currently MANDATORY for routing. Caller must hold r.mu. Enforcement begins only
+// when an attestor is configured AND a non-zero deadline has been reached; before
+// then the fleet routes un-attested providers (grace window) while still being
+// challenged.
+func (r *Registry) codeAttestationEnforcedLocked() bool {
+	if !r.codeAttestationConfigured || r.codeAttestationDeadline.IsZero() {
+		return false
+	}
+	return !time.Now().Before(r.codeAttestationDeadline)
 }
 
 // Mu returns the provider's mutex for external callers that need to read
@@ -613,13 +652,25 @@ type Registry struct {
 
 	MinTrustLevel TrustLevel
 
-	// codeAttestationRequired is the v0.6.0 APNs code-identity rollout flag. When
-	// true, providers must pass the APNs code-identity round-trip (CodeAttested)
-	// to be routed private/text traffic. Default false so the fleet keeps routing
-	// until APNs infra + provider support are deployed; set true (via
-	// SetCodeAttestationRequired) once the attestor is configured. Stamped onto
-	// each Provider at registration.
-	codeAttestationRequired bool
+	// APNs code-identity rollout policy (v0.6.0), guarded by r.mu and evaluated
+	// LIVE at every routing decision so a deadline can flip enforcement on/off
+	// without forcing providers to reconnect.
+	//
+	//   - codeAttestationConfigured: true once an APNs attestor is wired
+	//     (SetCodeAttestationConfigured). The coordinator only issues code-identity
+	//     challenges when configured.
+	//   - codeAttestationDeadline: the instant enforcement begins. Before it (or
+	//     when zero) the coordinator is in GRACE/observe mode — it challenges and
+	//     measures providers but still ROUTES un-attested ones, so configuring the
+	//     attestor never deroutes the fleet. At/after the deadline, enforcement is
+	//     fail-closed: un-attested providers (and any too-old to ever attest) stop
+	//     being routed.
+	//
+	// Operator flow: set APNS_* secrets (configured, grace) → fleet updates to
+	// 0.6.0 and attests → set APNS_ENFORCE_AFTER = release+24h → enforcement flips
+	// on automatically when that instant passes.
+	codeAttestationConfigured bool
+	codeAttestationDeadline   time.Time
 
 	modelCatalog map[string]CatalogEntry
 
@@ -1197,7 +1248,7 @@ func (r *Registry) providerCanRouteBuildLocked(p *Provider, buildID string, minT
 	if trustRank(p.TrustLevel) < trustRank(minTrust) {
 		return false
 	}
-	if !p.RuntimeVerified || !providerSupportsPrivateTextLocked(p) {
+	if !p.RuntimeVerified || !r.providerSupportsPrivateTextLocked(p) {
 		return false
 	}
 	if p.LastChallengeVerified.IsZero() || now.Sub(p.LastChallengeVerified) > challengeFreshnessMaxAge {
@@ -1703,7 +1754,6 @@ func (r *Registry) Register(id string, conn *websocket.Conn, msg *protocol.Regis
 		PrivateOnly:             msg.PrivateOnly,
 		APNsDeviceToken:         msg.APNsDeviceToken,
 		APNsEnvironment:         msg.APNsEnvironment,
-		codeAttestationRequired: r.codeAttestationRequired,
 		PrefillTPS:              msg.PrefillTPS,
 		DecodeTPS:               msg.DecodeTPS,
 		TrustLevel:              TrustNone,
@@ -2179,7 +2229,7 @@ func (r *Registry) providerHasWarmModelLocked(p *Provider, model string, now tim
 	if !p.RuntimeVerified {
 		return false
 	}
-	if !providerSupportsPrivateTextLocked(p) {
+	if !r.providerSupportsPrivateTextLocked(p) {
 		return false
 	}
 	if p.LastChallengeVerified.IsZero() || now.Sub(p.LastChallengeVerified) > challengeFreshnessMaxAge {
@@ -2259,7 +2309,7 @@ func (r *Registry) modelLoadCandidatePendingLocked(p *Provider, model string, no
 	if !p.RuntimeVerified {
 		return 0, false
 	}
-	if !providerSupportsPrivateTextLocked(p) {
+	if !r.providerSupportsPrivateTextLocked(p) {
 		return 0, false
 	}
 	if p.LastChallengeVerified.IsZero() || now.Sub(p.LastChallengeVerified) > challengeFreshnessMaxAge {
@@ -2992,7 +3042,7 @@ func (r *Registry) FindProviderWithTrust(model string, minTrust TrustLevel, excl
 		trust := p.TrustLevel
 		lastChallenge := p.LastChallengeVerified
 		runtimeVerified := p.RuntimeVerified
-		privateReady := providerSupportsPrivateTextLocked(p)
+		privateReady := r.providerSupportsPrivateTextLocked(p)
 		p.mu.Unlock()
 
 		if status == StatusOffline || status == StatusUntrusted {
@@ -3127,7 +3177,7 @@ func (r *Registry) ListModels() []AggregateModel {
 		trust := p.TrustLevel
 		attested := p.Attested
 		attestResult := p.AttestationResult
-		privateReady := providerSupportsPrivateTextLocked(p)
+		privateReady := r.providerSupportsPrivateTextLocked(p)
 		privateOnly := p.PrivateOnly
 		// p.Models is replaced copy-on-write by UpdateModelWeightHashes (which
 		// holds only p.mu, not r.mu), so snapshot it here under p.mu rather than
@@ -3215,7 +3265,7 @@ func (r *Registry) ModelCountryCodes(modelID string) []string {
 		p.mu.Lock()
 		status := p.Status
 		trust := p.TrustLevel
-		privateReady := providerSupportsPrivateTextLocked(p)
+		privateReady := r.providerSupportsPrivateTextLocked(p)
 		var cc string
 		if p.Location != nil {
 			cc = strings.ToUpper(strings.TrimSpace(p.Location.CountryCode))
@@ -3479,7 +3529,7 @@ func (r *Registry) ModelCapacitySnapshot() []ModelCapacity {
 			p.mu.Unlock()
 			continue
 		}
-		if !providerSupportsPrivateTextLocked(p) {
+		if !r.providerSupportsPrivateTextLocked(p) {
 			p.mu.Unlock()
 			continue
 		}

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -3430,6 +3430,28 @@ func (r *Registry) OnlineCount() int64 {
 	return r.onlineCount.Load()
 }
 
+// CodeAttestationCoverage reports how many currently online (non-offline,
+// non-untrusted) providers have passed APNs code-identity attestation, plus the
+// online total. Operators watch this during the grace window to judge when it is
+// safe to let the APNS_ENFORCE_AFTER deadline pass — after which every
+// un-attested provider (incl. all headless / pre-0.6.0 boxes) is derouted.
+// Thread-safe.
+func (r *Registry) CodeAttestationCoverage() (codeAttested, online int) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	for _, p := range r.providers {
+		p.mu.Lock()
+		if p.Status != StatusOffline && p.Status != StatusUntrusted {
+			online++
+			if p.CodeAttested {
+				codeAttested++
+			}
+		}
+		p.mu.Unlock()
+	}
+	return codeAttested, online
+}
+
 // ModelProviderSnapshot returns a snapshot of model_id -> provider count.
 func (r *Registry) ModelProviderSnapshot() map[string]int64 {
 	r.modelProvidersMu.Lock()

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -1556,8 +1556,9 @@ func (r *Registry) providerServesCatalogModelLocked(p *Provider, model string) b
 // providerServesVisionModelLocked reports whether the provider advertises the
 // model as a vision-capable (VLM) build — required to route image/video requests
 // so the media is actually perceived rather than silently dropped. Caller must
-// hold r.mu (mirrors providerServesCatalogModelLocked). Pre-0.6.0 providers never
-// set IsVision, so they are correctly excluded.
+// hold r.mu AND p.mu (mirrors providerServesCatalogModelLocked): p.Models is
+// guarded by p.mu and mutated by MergeProviderModels/UpdateModelWeightHashes.
+// Pre-0.6.0 providers never set IsVision, so they are correctly excluded.
 func (r *Registry) providerServesVisionModelLocked(p *Provider, model string) bool {
 	for _, m := range p.Models {
 		if m.ID == model && m.IsVision && r.modelAllowedByCatalogLocked(m) {
@@ -1576,10 +1577,13 @@ func (r *Registry) HasVisionProviderForModel(model string) bool {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	for _, p := range r.providers {
-		if p.Status == StatusOffline || p.Status == StatusUntrusted {
-			continue
-		}
-		if r.providerServesVisionModelLocked(p, model) {
+		// p.Status and p.Models are guarded by p.mu (writers hold it), so the
+		// whole eligibility read must happen under the provider lock.
+		p.mu.Lock()
+		eligible := p.Status != StatusOffline && p.Status != StatusUntrusted &&
+			r.providerServesVisionModelLocked(p, model)
+		p.mu.Unlock()
+		if eligible {
 			return true
 		}
 	}

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -125,6 +125,12 @@ type PendingRequest struct {
 	// EstimatedPromptTokens is a coordinator-side heuristic used only for
 	// routing and queue admission. It does not need tokenizer-perfect accuracy.
 	EstimatedPromptTokens int
+	// RequiresVision is true when the request carries image/video input. Such a
+	// request must only be routed to a provider advertising a vision-capable
+	// (VLM) build for the resolved model; otherwise the provider would silently
+	// drop the media and answer image-blind. Set by the consumer handler from the
+	// parsed content parts; enforced in the candidate filter and final admit.
+	RequiresVision bool
 	// RequestedMaxTokens is the consumer's requested output budget (or a
 	// sensible default when omitted). It is used for backlog estimation.
 	RequestedMaxTokens int
@@ -1541,6 +1547,39 @@ func (r *Registry) modelAllowedByCatalogLocked(model protocol.ModelInfo) bool {
 func (r *Registry) providerServesCatalogModelLocked(p *Provider, model string) bool {
 	for _, m := range p.Models {
 		if m.ID == model && r.modelAllowedByCatalogLocked(m) {
+			return true
+		}
+	}
+	return false
+}
+
+// providerServesVisionModelLocked reports whether the provider advertises the
+// model as a vision-capable (VLM) build — required to route image/video requests
+// so the media is actually perceived rather than silently dropped. Caller must
+// hold r.mu (mirrors providerServesCatalogModelLocked). Pre-0.6.0 providers never
+// set IsVision, so they are correctly excluded.
+func (r *Registry) providerServesVisionModelLocked(p *Provider, model string) bool {
+	for _, m := range p.Models {
+		if m.ID == model && m.IsVision && r.modelAllowedByCatalogLocked(m) {
+			return true
+		}
+	}
+	return false
+}
+
+// HasVisionProviderForModel reports whether any online, non-untrusted provider
+// advertises a vision-capable build for the resolved model id. The consumer uses
+// it to fail a media request fast with a clear error when the fleet has no
+// VLM-capable provider for the model (e.g. before the gemma fleet finishes
+// updating to 0.6.0), instead of queueing the request to a timeout.
+func (r *Registry) HasVisionProviderForModel(model string) bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	for _, p := range r.providers {
+		if p.Status == StatusOffline || p.Status == StatusUntrusted {
+			continue
+		}
+		if r.providerServesVisionModelLocked(p, model) {
 			return true
 		}
 	}

--- a/coordinator/registry/registry_test.go
+++ b/coordinator/registry/registry_test.go
@@ -3025,3 +3025,21 @@ func TestDesiredModelsForLegacyAdvertiserAfterTakeover(t *testing.T) {
 		t.Fatalf("expected previous build = legacy id, got %q", entries[0].PreviousBuild)
 	}
 }
+
+// TestCodeAttestationCoverage verifies the operator-facing coverage counter used
+// to judge when it is safe to let APNS_ENFORCE_AFTER pass.
+func TestCodeAttestationCoverage(t *testing.T) {
+	r := New(testLogger())
+	r.providers["a"] = &Provider{ID: "a", Status: StatusOnline, CodeAttested: true}
+	r.providers["b"] = &Provider{ID: "b", Status: StatusOnline, CodeAttested: false}
+	r.providers["c"] = &Provider{ID: "c", Status: StatusUntrusted, CodeAttested: true} // excluded
+	r.providers["d"] = &Provider{ID: "d", Status: StatusOffline, CodeAttested: true}   // excluded
+
+	attested, online := r.CodeAttestationCoverage()
+	if online != 2 {
+		t.Fatalf("expected 2 online (non-offline/untrusted), got %d", online)
+	}
+	if attested != 1 {
+		t.Fatalf("expected 1 code-attested online provider, got %d", attested)
+	}
+}

--- a/coordinator/registry/registry_test.go
+++ b/coordinator/registry/registry_test.go
@@ -68,8 +68,10 @@ func testMakeTextRoutable(p *Provider) {
 }
 
 // TestCodeAttestationGate verifies the v0.6.0 APNs code-identity gate at the
-// single routing chokepoint: off by default (rollout flag), fail-closed when
-// required-but-unattested, routable once attested.
+// single routing chokepoint across the rollout policy: not configured (no
+// regression), grace/observe (configured but un-enforced still routes), enforced
+// (fail-closed when un-attested, routable when attested), and a live grace→enforce
+// deadline flip that does NOT require the provider to reconnect.
 func TestCodeAttestationGate(t *testing.T) {
 	mk := func() *Provider {
 		p := &Provider{
@@ -88,24 +90,61 @@ func TestCodeAttestationGate(t *testing.T) {
 		return p
 	}
 
-	// Rollout flag OFF: routable regardless of CodeAttested (no fleet regression).
-	if p := mk(); !providerSupportsPrivateTextLocked(p) {
-		t.Fatal("expected routable when codeAttestationRequired is off")
+	// Evaluate the gate under r.mu exactly as real callers do.
+	supports := func(r *Registry, p *Provider) bool {
+		r.mu.RLock()
+		defer r.mu.RUnlock()
+		return r.providerSupportsPrivateTextLocked(p)
 	}
 
-	// Rollout flag ON, not attested: blocked (fail-closed, no self-route exemption).
+	// Not configured: routable regardless of CodeAttested (no fleet regression).
+	r := New(testLogger())
+	if !supports(r, mk()) {
+		t.Fatal("expected routable when code-attestation is not configured")
+	}
+
+	// Configured, no deadline (grace/observe): un-attested still routes.
+	r = New(testLogger())
+	r.SetCodeAttestationPolicy(true, time.Time{})
+	if !supports(r, mk()) {
+		t.Fatal("expected routable in grace mode (configured, no deadline) even when !CodeAttested")
+	}
+
+	// Configured, deadline in the future (still grace): un-attested still routes.
+	r = New(testLogger())
+	r.SetCodeAttestationPolicy(true, time.Now().Add(time.Hour))
+	if !supports(r, mk()) {
+		t.Fatal("expected routable while still inside the grace window")
+	}
+
+	// Enforced (deadline passed), not attested: blocked (fail-closed).
+	r = New(testLogger())
+	r.SetCodeAttestationPolicy(true, time.Now().Add(-time.Minute))
+	if supports(r, mk()) {
+		t.Fatal("expected NOT routable once enforced and !CodeAttested")
+	}
+
+	// Enforced and attested: routable.
+	r = New(testLogger())
+	r.SetCodeAttestationPolicy(true, time.Now().Add(-time.Minute))
+	pAtt := mk()
+	pAtt.CodeAttested = true
+	if !supports(r, pAtt) {
+		t.Fatal("expected routable when enforced and CodeAttested")
+	}
+
+	// Live deadline flip without reconnect: the SAME un-attested provider routes
+	// during grace, then stops the instant the deadline moves into the past.
+	r = New(testLogger())
+	r.SetCodeAttestationConfigured(true)
+	r.SetCodeAttestationDeadline(time.Now().Add(time.Hour)) // grace
 	p := mk()
-	p.codeAttestationRequired = true
-	if providerSupportsPrivateTextLocked(p) {
-		t.Fatal("expected NOT routable when required and !CodeAttested")
+	if !supports(r, p) {
+		t.Fatal("expected routable during grace before the flip")
 	}
-
-	// Rollout flag ON, attested: routable.
-	p = mk()
-	p.codeAttestationRequired = true
-	p.CodeAttested = true
-	if !providerSupportsPrivateTextLocked(p) {
-		t.Fatal("expected routable when required and CodeAttested")
+	r.SetCodeAttestationDeadline(time.Now().Add(-time.Minute)) // enforce now
+	if supports(r, p) {
+		t.Fatal("expected NOT routable after the deadline flips to the past")
 	}
 }
 
@@ -223,7 +262,10 @@ func TestSwiftProviderPrivateTextWithoutPythonCaps(t *testing.T) {
 	p := reg.Register("p-swift-nopython", nil, msg)
 	testMakeTextRoutable(p)
 
-	if !providerSupportsPrivateTextLocked(p) {
+	reg.mu.RLock()
+	routable := reg.providerSupportsPrivateTextLocked(p)
+	reg.mu.RUnlock()
+	if !routable {
 		t.Fatal("Swift provider should support private text without PythonRuntimeLocked/DangerousModulesBlocked")
 	}
 
@@ -241,7 +283,10 @@ func TestPythonProviderDeprecatedNotRoutable(t *testing.T) {
 	p := reg.Register("p-python-deprecated", nil, msg)
 	testMakeTextRoutable(p)
 
-	if providerSupportsPrivateTextLocked(p) {
+	reg.mu.RLock()
+	routable := reg.providerSupportsPrivateTextLocked(p)
+	reg.mu.RUnlock()
+	if routable {
 		t.Fatal("Python (inprocess-mlx) provider should NOT support private text — backend is deprecated")
 	}
 
@@ -262,7 +307,10 @@ func TestSwiftProviderMissingBaseCapsExcluded(t *testing.T) {
 	p := reg.Register("p-swift-no-antidebug", nil, msg)
 	testMakeTextRoutable(p)
 
-	if providerSupportsPrivateTextLocked(p) {
+	reg.mu.RLock()
+	routable := reg.providerSupportsPrivateTextLocked(p)
+	reg.mu.RUnlock()
+	if routable {
 		t.Fatal("Swift provider without AntiDebugEnabled should NOT support private text")
 	}
 

--- a/coordinator/registry/registry_test.go
+++ b/coordinator/registry/registry_test.go
@@ -252,6 +252,50 @@ func TestProviderWithoutChallengeVerifiedSIPExcluded(t *testing.T) {
 	}
 }
 
+// TestVisionRoutingHelpers covers the per-provider vision capability check and
+// the fleet-level fail-fast query that gate image/video routing. With a nil
+// catalog the catalog filter allows all, so the gate reduces to "advertises this
+// model id with IsVision".
+func TestVisionRoutingHelpers(t *testing.T) {
+	r := New(testLogger())
+	visProv := &Provider{
+		ID:     "p-vis",
+		Status: StatusOnline,
+		Models: []protocol.ModelInfo{{ID: "gemma-4-26b", IsVision: true}},
+	}
+	textProv := &Provider{
+		ID:     "p-text",
+		Status: StatusOnline,
+		Models: []protocol.ModelInfo{{ID: "gemma-4-26b"}}, // text-only build of the same model
+	}
+	r.providers["p-vis"] = visProv
+	r.providers["p-text"] = textProv
+
+	r.mu.RLock()
+	visOK := r.providerServesVisionModelLocked(visProv, "gemma-4-26b")
+	textOK := r.providerServesVisionModelLocked(textProv, "gemma-4-26b")
+	r.mu.RUnlock()
+	if !visOK {
+		t.Fatal("vision provider should serve gemma-4-26b as vision-capable")
+	}
+	if textOK {
+		t.Fatal("text-only provider must NOT be vision-capable for gemma-4-26b")
+	}
+
+	if !r.HasVisionProviderForModel("gemma-4-26b") {
+		t.Fatal("fleet has a vision provider for gemma-4-26b")
+	}
+	if r.HasVisionProviderForModel("gpt-oss-20b") {
+		t.Fatal("no vision provider advertises gpt-oss-20b")
+	}
+
+	// An untrusted/offline vision provider must not satisfy the fleet check.
+	visProv.Status = StatusUntrusted
+	if r.HasVisionProviderForModel("gemma-4-26b") {
+		t.Fatal("an untrusted vision provider must not satisfy the fleet vision check")
+	}
+}
+
 func TestSwiftProviderPrivateTextWithoutPythonCaps(t *testing.T) {
 	reg := New(testLogger())
 	msg := testRegisterMessage()

--- a/coordinator/registry/registry_test.go
+++ b/coordinator/registry/registry_test.go
@@ -2997,3 +2997,31 @@ func TestFindProviderCrashedOnlyStillRoutes(t *testing.T) {
 		t.Error("FindProvider should still route to a crashed-only provider (it can attempt reload)")
 	}
 }
+
+// TestDesiredModelsForLegacyAdvertiserAfterTakeover proves the 4-bit cutover
+// bootstrap: after an alias adopts the live public name (desired = new build,
+// previous = the legacy same-named build), a provider advertising ONLY the legacy
+// build is recognised as a member and told to converge to the new build via
+// desired_models — without which the legacy fleet could never migrate.
+func TestDesiredModelsForLegacyAdvertiserAfterTakeover(t *testing.T) {
+	r := New(testLogger())
+	r.providers["p1"] = &Provider{
+		ID:     "p1",
+		Status: StatusOnline,
+		Models: []protocol.ModelInfo{{ID: "gemma-4-26b"}}, // advertises the public name
+	}
+	r.SetModelAliases(map[string]AliasTarget{
+		"gemma-4-26b": {Desired: "gemma-4-26b-qat-4bit", Previous: "gemma-4-26b"},
+	})
+
+	entries := r.DesiredModelsForProvider("p1")
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 desired_models entry for the legacy advertiser, got %d", len(entries))
+	}
+	if entries[0].ModelName != "gemma-4-26b" || entries[0].DesiredBuild != "gemma-4-26b-qat-4bit" {
+		t.Fatalf("unexpected desired entry: %+v", entries[0])
+	}
+	if entries[0].PreviousBuild != "gemma-4-26b" {
+		t.Fatalf("expected previous build = legacy id, got %q", entries[0].PreviousBuild)
+	}
+}

--- a/coordinator/registry/scheduler.go
+++ b/coordinator/registry/scheduler.go
@@ -459,7 +459,7 @@ func (r *Registry) OwnedProviderSummary(accountID, model string) (online, serves
 		online++
 		serves := r.providerServesCatalogModelLocked(p, model) &&
 			p.RuntimeVerified &&
-			providerSupportsPrivateTextLocked(p) &&
+			r.providerSupportsPrivateTextLocked(p) &&
 			!p.LastChallengeVerified.IsZero() &&
 			now.Sub(p.LastChallengeVerified) <= challengeFreshnessMaxAge
 		p.mu.Unlock()
@@ -531,7 +531,7 @@ func (r *Registry) snapshotProviderLocked(p *Provider, model string, selfRouteOw
 	if !p.RuntimeVerified {
 		return routingSnapshot{}, false
 	}
-	if !providerSupportsPrivateTextLocked(p) {
+	if !r.providerSupportsPrivateTextLocked(p) {
 		return routingSnapshot{}, false
 	}
 	if p.LastChallengeVerified.IsZero() || now.Sub(p.LastChallengeVerified) > challengeFreshnessMaxAge {
@@ -902,7 +902,7 @@ func (r *Registry) providerCanAdmitLocked(p *Provider, model string, selfRouteOw
 	if trustRank(p.TrustLevel) < trustRank(minTrust) || !p.RuntimeVerified {
 		return false
 	}
-	if !providerSupportsPrivateTextLocked(p) {
+	if !r.providerSupportsPrivateTextLocked(p) {
 		return false
 	}
 	if p.LastChallengeVerified.IsZero() || time.Since(p.LastChallengeVerified) > challengeFreshnessMaxAge {
@@ -1008,7 +1008,7 @@ func (r *Registry) QuickCapacityCheck(model string, estimatedPromptTokens, reque
 			p.mu.Unlock()
 			continue
 		}
-		if !providerSupportsPrivateTextLocked(p) {
+		if !r.providerSupportsPrivateTextLocked(p) {
 			p.mu.Unlock()
 			continue
 		}

--- a/coordinator/registry/scheduler.go
+++ b/coordinator/registry/scheduler.go
@@ -116,6 +116,11 @@ const (
 	// (transient "full, retry later") this is permanent for this provider, so
 	// it must NOT inflate the busy/429 signal.
 	rejectModelTooLarge
+	// rejectVisionUnsupported means the request carries image/video input but
+	// this provider only advertises a text-only build of the model. Permanent for
+	// this provider (until it loads a VLM build), so like rejectModelTooLarge it
+	// must NOT inflate the transient busy/429 signal.
+	rejectVisionUnsupported
 )
 
 // modelMemoryHeadroomFactor is the FALLBACK multiple of the on-disk weight size
@@ -182,8 +187,13 @@ type RoutingDecision struct {
 	// CapacityRejections so callers don't emit a 429/"over capacity, retry"
 	// signal for a model that will never fit anywhere of this size.
 	ModelTooLargeRejections int
-	EffectiveTPS            float64 // load-scaled decode TPS used in cost (Phase 4)
-	StaticTPS               float64 // benchmarked decode TPS before load scaling
+	// VisionRejections counts providers that serve the model but only as a
+	// text-only build, when the request requires vision. Lets the caller return a
+	// precise "no vision-capable provider for this model" error instead of a
+	// generic capacity/queue signal.
+	VisionRejections int
+	EffectiveTPS     float64 // load-scaled decode TPS used in cost (Phase 4)
+	StaticTPS        float64 // benchmarked decode TPS before load scaling
 }
 
 // ReserveProvider selects a hardware-routable provider for the request and
@@ -214,13 +224,14 @@ func (r *Registry) ReserveProviderEx(model string, pr *PendingRequest, excludeID
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	selected, candidateCount, capacityRejections, tooLargeRejections := r.selectBestCandidateLockedFull(model, pr, excludeIDs...)
+	selected, candidateCount, capacityRejections, tooLargeRejections, visionRejections := r.selectBestCandidateLockedFull(model, pr, excludeIDs...)
 	if selected == nil {
 		return nil, RoutingDecision{
 			Model:                   model,
 			CandidateCount:          candidateCount,
 			CapacityRejections:      capacityRejections,
 			ModelTooLargeRejections: tooLargeRejections,
+			VisionRejections:        visionRejections,
 		}
 	}
 
@@ -235,12 +246,17 @@ func (r *Registry) ReserveProviderEx(model string, pr *PendingRequest, excludeID
 	// (always owned here) or for prefer when the winner happens to be owned.
 	owned := p.AccountID != "" && p.AccountID == pr.OwnerAccountID
 	relaxTrust := pr.SelfRouteOnly || (pr.PreferOwner && owned)
-	if !r.providerCanAdmitLocked(p, model, relaxTrust) {
+	// Re-check the vision gate under the provider lock too: the winner must still
+	// advertise a vision-capable build if the request carries media (guards the
+	// race where its model set changed between snapshot and reservation).
+	if !r.providerCanAdmitLocked(p, model, relaxTrust) ||
+		(pr.RequiresVision && !r.providerServesVisionModelLocked(p, model)) {
 		return nil, RoutingDecision{
 			Model:                   model,
 			CandidateCount:          candidateCount,
 			CapacityRejections:      capacityRejections,
 			ModelTooLargeRejections: tooLargeRejections,
+			VisionRejections:        visionRejections,
 		}
 	}
 
@@ -265,6 +281,7 @@ func (r *Registry) ReserveProviderEx(model string, pr *PendingRequest, excludeID
 		CandidateCount:          candidateCount,
 		CapacityRejections:      capacityRejections,
 		ModelTooLargeRejections: tooLargeRejections,
+		VisionRejections:        visionRejections,
 		EffectiveTPS:            selected.effectiveTPS,
 		StaticTPS:               selected.snapshot.decodeTPS,
 	}
@@ -277,7 +294,9 @@ func (r *Registry) ReserveProviderEx(model string, pr *PendingRequest, excludeID
 // distinguish "no provider serves this model" from "every fitting
 // provider is over-subscribed", which is the difference between the
 // no_provider and over_capacity outcome counters.
-func (r *Registry) selectBestCandidateLockedFull(model string, pr *PendingRequest, excludeIDs ...string) (*routingCandidate, int, int, int) {
+// Returns (winner, candidateCount, capacityRejections, modelTooLargeRejections,
+// visionRejections).
+func (r *Registry) selectBestCandidateLockedFull(model string, pr *PendingRequest, excludeIDs ...string) (*routingCandidate, int, int, int, int) {
 	excludeSet := make(map[string]struct{}, len(excludeIDs))
 	for _, id := range excludeIDs {
 		excludeSet[id] = struct{}{}
@@ -297,6 +316,7 @@ func (r *Registry) selectBestCandidateLockedFull(model string, pr *PendingReques
 	candidateCount := 0
 	capacityRejections := 0
 	tooLargeRejections := 0
+	visionRejections := 0
 	for _, p := range r.providers {
 		owned := providerOwnedBy(p, pr.OwnerAccountID)
 		// Exclusive self-route: restrict to the caller's own machines and never
@@ -320,6 +340,15 @@ func (r *Registry) selectBestCandidateLockedFull(model string, pr *PendingReques
 		if !ok {
 			continue
 		}
+		// Vision gate: a media request must only go to a provider advertising a
+		// vision-capable build of this model. Providers reach here only if they
+		// already serve the model (snapshot ok), so a miss here means "serves it,
+		// but text-only" — counted separately so the caller can return a precise
+		// "no vision-capable provider" error rather than a busy/429.
+		if pr.RequiresVision && !r.providerServesVisionModelLocked(p, model) {
+			visionRejections++
+			continue
+		}
 		candidate, reason, ok := r.buildCandidateWithReason(snap, pr)
 		if !ok {
 			switch reason {
@@ -327,6 +356,8 @@ func (r *Registry) selectBestCandidateLockedFull(model string, pr *PendingReques
 				capacityRejections++
 			case rejectModelTooLarge:
 				tooLargeRejections++
+			case rejectVisionUnsupported:
+				visionRejections++
 			}
 			continue
 		}
@@ -335,7 +366,7 @@ func (r *Registry) selectBestCandidateLockedFull(model string, pr *PendingReques
 	}
 
 	if len(candidates) == 0 {
-		return nil, candidateCount, capacityRejections, tooLargeRejections
+		return nil, candidateCount, capacityRejections, tooLargeRejections, visionRejections
 	}
 
 	// Prefer-with-fallback: if the caller asked to prefer their own machine and
@@ -395,7 +426,7 @@ func (r *Registry) selectBestCandidateLockedFull(model string, pr *PendingReques
 		}
 	}
 	r.logRoutingDecision(model, pr, winner, candidateCount)
-	return winner, candidateCount, capacityRejections, tooLargeRejections
+	return winner, candidateCount, capacityRejections, tooLargeRejections, visionRejections
 }
 
 func providerMatchesAllowedSerial(p *Provider, allowed map[string]struct{}) bool {

--- a/coordinator/registry/scheduler.go
+++ b/coordinator/registry/scheduler.go
@@ -344,10 +344,16 @@ func (r *Registry) selectBestCandidateLockedFull(model string, pr *PendingReques
 		// vision-capable build of this model. Providers reach here only if they
 		// already serve the model (snapshot ok), so a miss here means "serves it,
 		// but text-only" — counted separately so the caller can return a precise
-		// "no vision-capable provider" error rather than a busy/429.
-		if pr.RequiresVision && !r.providerServesVisionModelLocked(p, model) {
-			visionRejections++
-			continue
+		// "no vision-capable provider" error rather than a busy/429. snapshot
+		// released p.mu, so re-take it for the p.Models read.
+		if pr.RequiresVision {
+			p.mu.Lock()
+			servesVision := r.providerServesVisionModelLocked(p, model)
+			p.mu.Unlock()
+			if !servesVision {
+				visionRejections++
+				continue
+			}
 		}
 		candidate, reason, ok := r.buildCandidateWithReason(snap, pr)
 		if !ok {

--- a/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClient.swift
+++ b/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClient.swift
@@ -408,6 +408,23 @@ final class ReachabilityMonitor: @unchecked Sendable {
 // MARK: - Coordinator Client Actor
 
 public actor CoordinatorClient {
+    /// Upper bound on a single inbound WebSocket message. The coordinator sends each
+    /// inference request as ONE text frame carrying the base64 NaCl-box of the full
+    /// body; for a vision request that frame includes base64-encoded image bytes and
+    /// can be several MiB. `URLSessionWebSocketTask` defaults to a 1 MiB cap and
+    /// THROWS on any larger frame, which tears down the entire session and cancels
+    /// every unrelated in-flight request on this provider (then reconnects with
+    /// backoff). Size this comfortably above the coordinator's 16 MiB sealed-body cap
+    /// after base64 expansion (×4/3 ≈ 21.3 MiB).
+    static let maxInboundMessageBytes = 32 * 1024 * 1024
+
+    /// Raise a task's inbound message limit to ``maxInboundMessageBytes``. Factored
+    /// out so a unit test can assert the limit is applied without opening a live
+    /// socket.
+    static func applyInboundMessageLimit(to task: URLSessionWebSocketTask) {
+        task.maximumMessageSize = maxInboundMessageBytes
+    }
+
     private let config: CoordinatorClientConfig
     private let stats: AtomicProviderStats
     private let state: ProviderState
@@ -597,6 +614,9 @@ public actor CoordinatorClient {
         let session = URLSession(configuration: .default)
         self.urlSession = session
         let ws = session.webSocketTask(with: url)
+        // Raise the inbound cap so an image/video request frame can't tear down the
+        // session and collaterally cancel other in-flight requests (see the constant).
+        Self.applyInboundMessageLimit(to: ws)
         self.webSocketTask = ws
         ws.resume()
 

--- a/provider-swift/Sources/ProviderCore/Diagnostics/AttestationReadiness.swift
+++ b/provider-swift/Sources/ProviderCore/Diagnostics/AttestationReadiness.swift
@@ -1,0 +1,227 @@
+import Foundation
+
+#if canImport(SystemConfiguration)
+import SystemConfiguration
+#endif
+
+/// "Will this box be able to do APNs code-identity attestation?"
+///
+/// v0.6.0 ships APNs code-identity attestation. A provider can only obtain an
+/// APNs device token (and therefore answer code-identity challenges) when the
+/// process runs in a logged-in macOS GUI / Aqua session — AppKit's
+/// `registerForRemoteNotifications()` is not daemon-safe and silently no-ops
+/// without a console session. Once the coordinator starts enforcing
+/// (`APNS_ENFORCE_AFTER`), un-attested providers are derouted.
+///
+/// The fleet-wide view already exists (`/v1/stats code_attested_providers`);
+/// this is the per-box complement an operator runs locally before enforcement
+/// bites, so they can fix a misconfigured machine in advance.
+///
+/// Design: the verdict logic (`evaluate`) is a pure function over the three raw
+/// inputs so it is unit-testable without touching the real system. The IO that
+/// gathers those values from the live machine lives in `gather()` and is kept
+/// deliberately thin.
+public enum AttestationReadiness {
+    /// Raw, IO-gathered inputs the verdict is computed from. Pure value type so
+    /// tests can construct any state directly.
+    public struct Inputs: Sendable, Equatable {
+        /// The console (Aqua-session) user from `SCDynamicStoreCopyConsoleUser`,
+        /// or nil when no one is logged in at the console. "loginwindow" / "root"
+        /// / "" are treated as "no real console session".
+        public let consoleUser: String?
+        /// `autoLoginUser` from `/Library/Preferences/com.apple.loginwindow.plist`,
+        /// or nil when automatic login is not configured.
+        public let autoLoginUser: String?
+        /// `com.apple.autologout.AutoLogOutDelay` (seconds) from global prefs.
+        /// 0 or nil means "log out after inactivity" is disabled.
+        public let autoLogoutDelaySeconds: Int?
+
+        public init(consoleUser: String?, autoLoginUser: String?, autoLogoutDelaySeconds: Int?) {
+            self.consoleUser = consoleUser
+            self.autoLoginUser = autoLoginUser
+            self.autoLogoutDelaySeconds = autoLogoutDelaySeconds
+        }
+    }
+
+    /// True when `user` is a real, logged-in console user (not nil, empty,
+    /// the login window placeholder, or a non-Aqua system account).
+    static func isRealConsoleUser(_ user: String?) -> Bool {
+        guard let user = user?.trimmingCharacters(in: .whitespacesAndNewlines), !user.isEmpty else {
+            return false
+        }
+        // SCDynamicStoreCopyConsoleUser returns "loginwindow" (and historically
+        // can return "root") while sitting at the login window — i.e. no Aqua
+        // session a GUI app could attach to.
+        let placeholders: Set<String> = ["loginwindow", "root", "_mbsetupuser"]
+        return !placeholders.contains(user.lowercased())
+    }
+
+    /// Pure verdict logic: turns the three raw inputs into operator-facing
+    /// diagnostics. Same input → same output, no IO.
+    ///
+    /// Ordered most-to-least critical:
+    ///  1. console session present (the headline — no session, no APNs token)
+    ///  2. automatic login (so the box self-recovers a session after reboot)
+    ///  3. auto-logout-after-idle (the silent killer of the GUI agent)
+    ///  4. sleep prevention (informational; the provider self-caffeinates)
+    public static func evaluate(
+        consoleUser: String?,
+        autoLoginUser: String?,
+        autoLogoutDelaySeconds: Int?,
+        sleepPrevented: Bool? = nil
+    ) -> [Diagnostic] {
+        var out: [Diagnostic] = []
+
+        // ---- 1. Console GUI session present (critical) ----
+        let hasSession = isRealConsoleUser(consoleUser)
+        if hasSession {
+            out.append(Diagnostic(
+                section: .attestationReadiness, name: "console session",
+                level: .pass,
+                message: "a user is logged in at the console (\(consoleUser ?? "?")) — this box can obtain an APNs token and attest its code identity.",
+                fix: nil))
+        } else {
+            out.append(Diagnostic(
+                section: .attestationReadiness, name: "console session",
+                level: .fail,
+                message: "no user is logged in at the console (Aqua session) — without a GUI session the provider can't register for remote notifications, so it can't obtain an APNs token or attest. Once the coordinator enforces APNs code-identity, this box will be derouted.",
+                fix: "log in at the physical login window (or via screen sharing) so a real Aqua session exists, then keep the provider running inside that session. Enable automatic login so the session survives reboots."))
+        }
+
+        // ---- 2. Automatic login (so a session exists after reboot) ----
+        if let autoLoginUser, !autoLoginUser.trimmingCharacters(in: .whitespaces).isEmpty {
+            out.append(Diagnostic(
+                section: .attestationReadiness, name: "automatic login",
+                level: .pass,
+                message: "automatic login is enabled for \(autoLoginUser) — after a reboot the box logs back into a console session on its own.",
+                fix: nil))
+        } else {
+            out.append(Diagnostic(
+                section: .attestationReadiness, name: "automatic login",
+                level: .warn,
+                message: "automatic login is not configured — after a reboot the box sits at the login window with no Aqua session, so it can't obtain an APNs token or attest until someone logs in.",
+                fix: "System Settings → Users & Groups → Automatically log in as → pick this provider's user, so the session (and APNs registration) self-recovers after a reboot."))
+        }
+
+        // ---- 3. Auto-logout-after-idle (DANGER) ----
+        // Screen LOCK is fine — only LOGOUT ends the Aqua session and kills the
+        // gui-domain LaunchAgent (and its self-`caffeinate`), so the provider
+        // dies and can no longer attest.
+        if let delay = autoLogoutDelaySeconds, delay > 0 {
+            let minutes = max(1, delay / 60)
+            out.append(Diagnostic(
+                section: .attestationReadiness, name: "auto-logout on idle",
+                level: .fail,
+                message: "\"Log out after \(minutes) min of inactivity\" is enabled (AutoLogOutDelay=\(delay)s) — when it fires it ends the Aqua session, killing the provider's GUI LaunchAgent (and its caffeinate). The box then goes offline and can't attest.",
+                fix: "disable auto-logout: System Settings → Privacy & Security → Advanced → turn OFF \"Log out automatically after N minutes of inactivity\" (or run `sudo defaults delete /Library/Preferences/.GlobalPreferences com.apple.autologout.AutoLogOutDelay`). Screen lock is fine — only logout is the problem."))
+        } else {
+            out.append(Diagnostic(
+                section: .attestationReadiness, name: "auto-logout on idle",
+                level: .pass,
+                message: "auto-logout after inactivity is disabled — the console session won't be ended out from under the provider.",
+                fix: nil))
+        }
+
+        // ---- 4. Sleep prevention (informational / low priority) ----
+        // The provider self-caffeinates while serving, so this is informational
+        // only. Surface it when we have a reading; otherwise leave it UNKNOWN.
+        switch sleepPrevented {
+        case .some(true):
+            out.append(Diagnostic(
+                section: .attestationReadiness, name: "sleep prevention",
+                level: .pass,
+                message: "system sleep is currently prevented (the provider self-caffeinates while serving).",
+                fix: nil))
+        case .some(false):
+            out.append(Diagnostic(
+                section: .attestationReadiness, name: "sleep prevention",
+                level: .warn,
+                message: "system sleep is not currently prevented. The provider caffeinates itself while a request is in flight, so this is informational; deep idle sleep can still delay reconnect/attestation.",
+                fix: "optional: `sudo pmset -a sleep 0` (or `disablesleep 1`) on an always-on box to avoid idle-sleep reconnect lag."))
+        case .none:
+            out.append(Diagnostic(
+                section: .attestationReadiness, name: "sleep prevention",
+                level: .warn,
+                message: "couldn't read the system sleep state (informational only — the provider self-caffeinates while serving).",
+                fix: nil))
+        }
+
+        return out
+    }
+
+    /// Convenience: evaluate directly from gathered `Inputs`.
+    public static func evaluate(_ inputs: Inputs, sleepPrevented: Bool? = nil) -> [Diagnostic] {
+        evaluate(
+            consoleUser: inputs.consoleUser,
+            autoLoginUser: inputs.autoLoginUser,
+            autoLogoutDelaySeconds: inputs.autoLogoutDelaySeconds,
+            sleepPrevented: sleepPrevented)
+    }
+
+    // MARK: - IO (live machine probes)
+
+    /// Reads the three raw signals from the live machine. macOS-only; on other
+    /// platforms returns all-nil (the verdict then reports a FAIL/UNKNOWN, which
+    /// is correct — a non-macOS box can't do APNs attestation anyway).
+    public static func gather() -> Inputs {
+        Inputs(
+            consoleUser: currentConsoleUser(),
+            autoLoginUser: configuredAutoLoginUser(),
+            autoLogoutDelaySeconds: configuredAutoLogoutDelaySeconds())
+    }
+
+    /// The console (Aqua-session) user via `SCDynamicStoreCopyConsoleUser`.
+    /// Returns nil when no one is logged in at the console.
+    public static func currentConsoleUser() -> String? {
+        #if canImport(SystemConfiguration)
+        var uid: uid_t = 0
+        var gid: gid_t = 0
+        guard let store = SCDynamicStoreCreate(nil, "darkbloom.doctor" as CFString, nil, nil) else {
+            return nil
+        }
+        guard let name = SCDynamicStoreCopyConsoleUser(store, &uid, &gid) else {
+            return nil
+        }
+        return name as String
+        #else
+        return nil
+        #endif
+    }
+
+    /// `autoLoginUser` from `/Library/Preferences/com.apple.loginwindow.plist`.
+    public static func configuredAutoLoginUser() -> String? {
+        #if os(macOS)
+        let path = "/Library/Preferences/com.apple.loginwindow.plist"
+        guard let dict = NSDictionary(contentsOfFile: path) else { return nil }
+        guard let user = dict["autoLoginUser"] as? String else { return nil }
+        let trimmed = user.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+        #else
+        return nil
+        #endif
+    }
+
+    /// `com.apple.autologout.AutoLogOutDelay` (seconds) from the system global
+    /// preferences. 0 / absent ⇒ auto-logout disabled (returns nil).
+    public static func configuredAutoLogoutDelaySeconds() -> Int? {
+        #if os(macOS)
+        // The setting lives in the system-domain global prefs. The plist on
+        // disk is `.GlobalPreferences.plist`; the CFPreferences domain is
+        // `.GlobalPreferences` / `kCFPreferencesAnyApplication`.
+        let candidates = [
+            "/Library/Preferences/.GlobalPreferences.plist",
+            "/Library/Preferences/com.apple.GlobalPreferences.plist",
+        ]
+        for path in candidates {
+            guard let dict = NSDictionary(contentsOfFile: path) else { continue }
+            if let raw = dict["com.apple.autologout.AutoLogOutDelay"] {
+                if let n = (raw as? NSNumber)?.intValue { return n > 0 ? n : nil }
+                if let s = raw as? String, let n = Int(s) { return n > 0 ? n : nil }
+            }
+        }
+        return nil
+        #else
+        return nil
+        #endif
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Diagnostics/DiagnosticTypes.swift
+++ b/provider-swift/Sources/ProviderCore/Diagnostics/DiagnosticTypes.swift
@@ -22,6 +22,7 @@ public enum DiagnosticSection: Int, Sendable, Equatable, CaseIterable {
     case hardware
     case security
     case attestationKey
+    case attestationReadiness
     case trust
     case traffic
     case runtime
@@ -34,6 +35,7 @@ public enum DiagnosticSection: Int, Sendable, Equatable, CaseIterable {
         case .hardware: return "HARDWARE & GPU"
         case .security: return "SECURITY POSTURE"
         case .attestationKey: return "ATTESTATION KEY (Secure Enclave)"
+        case .attestationReadiness: return "APNs CODE-IDENTITY READINESS   (can this box attest?)"
         case .trust: return "COORDINATOR TRUST   (why you are / aren't earning)"
         case .traffic: return "TRAFFIC READINESS   (can this box actually serve?)"
         case .runtime: return "RUNTIME (live)"

--- a/provider-swift/Sources/ProviderCore/Inference/ToolSchemaNormalization.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/ToolSchemaNormalization.swift
@@ -1,0 +1,80 @@
+import Foundation
+
+/// Defends Gemma-style chat templates that render `{{ value['type'] | upper }}`
+/// over each tool parameter against schemas that omit an explicit `type` — a
+/// legitimate OpenAI shape (e.g. an `enum`-only or `anyOf` property). Without a
+/// `type`, the Jinja `| upper` filter operates on an undefined value and the
+/// render throws, surfacing to the consumer as a 500 (DAR-130). We inject a
+/// default `type` into every JSON-Schema node under each tool's
+/// `function.parameters` before the request is decoded, so the template always
+/// has a string to upper-case.
+///
+/// This is pure Foundation JSON surgery applied at the single inbound decode
+/// boundary (`ProviderLoop.decodeOpenAIRequest`): the chat-template code in
+/// mlx-swift-lm is left untouched, and non-tool requests pay zero cost (the work
+/// is gated on the body actually carrying `tools`).
+enum ToolSchemaNormalization {
+    /// Return `data` with default `type`s injected into tool parameter schemas.
+    /// Fast-paths out (returns the input unchanged) when the body carries no
+    /// `tools`, or when it isn't a JSON object we can repair.
+    static func ensureParameterTypes(in data: Data) -> Data {
+        // Cheap gate: only pay the JSON round-trip for requests that carry tools.
+        guard data.range(of: Data("\"tools\"".utf8)) != nil else { return data }
+        guard var root = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any],
+              let tools = root["tools"] as? [Any]
+        else {
+            return data
+        }
+        let normalizedTools: [Any] = tools.map { tool in
+            guard var toolDict = tool as? [String: Any],
+                  var function = toolDict["function"] as? [String: Any],
+                  let parameters = function["parameters"]
+            else { return tool }
+            function["parameters"] = injectDefaultTypes(parameters)
+            toolDict["function"] = function
+            return toolDict
+        }
+        root["tools"] = normalizedTools
+        guard let out = try? JSONSerialization.data(withJSONObject: root) else { return data }
+        return out
+    }
+
+    /// Recursively default-fill `type` on JSON-Schema nodes. A node gets a type
+    /// only when it looks like a schema node (has properties / items / enum /
+    /// description / anyOf / oneOf / allOf) — we never invent types on arbitrary
+    /// maps. The inferred default favours structure: object when it has
+    /// properties, array when it has items, otherwise string.
+    static func injectDefaultTypes(_ node: Any) -> Any {
+        if let arr = node as? [Any] {
+            return arr.map(injectDefaultTypes)
+        }
+        guard var dict = node as? [String: Any] else { return node }
+
+        if let props = dict["properties"] as? [String: Any] {
+            dict["properties"] = props.mapValues(injectDefaultTypes)
+        }
+        if let items = dict["items"] {
+            dict["items"] = injectDefaultTypes(items)
+        }
+        for key in ["anyOf", "oneOf", "allOf"] {
+            if let variants = dict[key] as? [Any] {
+                dict[key] = variants.map(injectDefaultTypes)
+            }
+        }
+
+        let looksLikeSchemaNode =
+            dict["properties"] != nil || dict["items"] != nil ||
+            dict["enum"] != nil || dict["description"] != nil ||
+            dict["anyOf"] != nil || dict["oneOf"] != nil || dict["allOf"] != nil
+        if dict["type"] == nil, looksLikeSchemaNode {
+            if dict["properties"] != nil {
+                dict["type"] = "object"
+            } else if dict["items"] != nil {
+                dict["type"] = "array"
+            } else {
+                dict["type"] = "string"
+            }
+        }
+        return dict
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Inference/ToolSchemaNormalization.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/ToolSchemaNormalization.swift
@@ -56,6 +56,12 @@ enum ToolSchemaNormalization {
         if let items = dict["items"] {
             dict["items"] = injectDefaultTypes(items)
         }
+        // additionalProperties may itself be a schema (map-shaped params, e.g.
+        // {"additionalProperties":{"type":"string"}}) — recurse so its inner schema
+        // gets a default type too. A bare `true`/`false` is left untouched.
+        if let addl = dict["additionalProperties"], addl is [String: Any] {
+            dict["additionalProperties"] = injectDefaultTypes(addl)
+        }
         for key in ["anyOf", "oneOf", "allOf"] {
             if let variants = dict[key] as? [Any] {
                 dict[key] = variants.map(injectDefaultTypes)
@@ -64,17 +70,38 @@ enum ToolSchemaNormalization {
 
         let looksLikeSchemaNode =
             dict["properties"] != nil || dict["items"] != nil ||
+            dict["additionalProperties"] != nil ||
             dict["enum"] != nil || dict["description"] != nil ||
             dict["anyOf"] != nil || dict["oneOf"] != nil || dict["allOf"] != nil
         if dict["type"] == nil, looksLikeSchemaNode {
-            if dict["properties"] != nil {
+            if dict["properties"] != nil || dict["additionalProperties"] != nil {
                 dict["type"] = "object"
             } else if dict["items"] != nil {
                 dict["type"] = "array"
+            } else if let unionType = unionMemberType(dict) {
+                // anyOf/oneOf/allOf without a parent type: borrow the first concrete
+                // member type (skipping "null") rather than mislabelling a union as a
+                // string. The template still gets a usable type and can't crash.
+                dict["type"] = unionType
             } else {
                 dict["type"] = "string"
             }
         }
         return dict
+    }
+
+    /// Derive a representative `type` for a union node from the first member that
+    /// declares a concrete, non-"null" type. Returns nil when none is found.
+    private static func unionMemberType(_ dict: [String: Any]) -> String? {
+        for key in ["anyOf", "oneOf", "allOf"] {
+            guard let variants = dict[key] as? [Any] else { continue }
+            for variant in variants {
+                if let v = variant as? [String: Any],
+                    let t = v["type"] as? String, t != "null" {
+                    return t
+                }
+            }
+        }
+        return nil
     }
 }

--- a/provider-swift/Sources/ProviderCore/Inference/ToolSchemaNormalization.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/ToolSchemaNormalization.swift
@@ -17,7 +17,16 @@ enum ToolSchemaNormalization {
     /// Return `data` with default `type`s injected into tool parameter schemas.
     /// Fast-paths out (returns the input unchanged) when the body carries no
     /// `tools`, or when it isn't a JSON object we can repair.
+    /// Upper bound on the body we'll JSON round-trip for tool-schema normalization.
+    /// Tool definitions are tiny (KB), so a multi-MB body — e.g. a long prompt that
+    /// merely contains the word "tools" — should not trigger a full parse + recursive
+    /// traversal. Above this we skip normalization, bounding the cost on the
+    /// (already size-capped) inference path.
+    static let maxNormalizationBytes = 4 * 1024 * 1024
+
     static func ensureParameterTypes(in data: Data) -> Data {
+        // Bound the work: skip the round-trip for oversized bodies (see the constant).
+        guard data.count <= maxNormalizationBytes else { return data }
         // Cheap gate: only pay the JSON round-trip for requests that carry tools.
         guard data.range(of: Data("\"tools\"".utf8)) != nil else { return data }
         guard var root = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any],

--- a/provider-swift/Sources/ProviderCore/Models/ModelScanner+Discovery.swift
+++ b/provider-swift/Sources/ProviderCore/Models/ModelScanner+Discovery.swift
@@ -120,14 +120,33 @@ extension ModelScanner {
 
         let estimatedMemoryGb = (Double(sizeBytes) / (1024.0 * 1024.0 * 1024.0)) * memoryOverheadFactor
 
+        // Advertise whether this build can serve image/video input so the
+        // coordinator only routes media requests to a vision-capable provider.
+        // nil (not false) for text-only builds, so a freshly-scanned text model is
+        // wire-identical to one decoded from an older provider's registration.
+        let isVision = FileManager.default.fileExists(atPath: configPath.path)
+            && configDeclaresVision(at: configPath)
+
         return ModelInfo(
             id: modelName,
             modelType: modelType,
             parameters: parameters,
             quantization: quantization,
             sizeBytes: sizeBytes,
-            estimatedMemoryGb: estimatedMemoryGb
+            estimatedMemoryGb: estimatedMemoryGb,
+            isVision: isVision ? true : nil
         )
+    }
+
+    /// Whether config.json declares a vision tower (`vision_config`) — i.e. the
+    /// build can serve image/video input. Mirrors ProviderLoop.modelIsVLM but lives
+    /// in the dependency-free scanner so the advertised ModelInfo carries the flag.
+    static func configDeclaresVision(at path: URL) -> Bool {
+        guard let data = try? Data(contentsOf: path),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return false
+        }
+        return json["vision_config"] != nil
     }
 
     // MARK: - Config Parsing

--- a/provider-swift/Sources/ProviderCore/Protocol/Types.swift
+++ b/provider-swift/Sources/ProviderCore/Protocol/Types.swift
@@ -92,6 +92,10 @@ public struct ModelInfo: Codable, Sendable, Equatable {
     public var sizeBytes: UInt64
     public var estimatedMemoryGb: Double
     public var weightHash: String?
+    /// True when this build can serve image/video (VLM) input. Encoded only when
+    /// true (matches the coordinator's `is_vision,omitempty`), so pre-0.6.0
+    /// providers and text-only builds omit it and are never routed media requests.
+    public var isVision: Bool?
 
     enum CodingKeys: String, CodingKey {
         case id
@@ -101,6 +105,7 @@ public struct ModelInfo: Codable, Sendable, Equatable {
         case sizeBytes = "size_bytes"
         case estimatedMemoryGb = "estimated_memory_gb"
         case weightHash = "weight_hash"
+        case isVision = "is_vision"
     }
 
     public init(
@@ -110,7 +115,8 @@ public struct ModelInfo: Codable, Sendable, Equatable {
         quantization: String? = nil,
         sizeBytes: UInt64,
         estimatedMemoryGb: Double,
-        weightHash: String? = nil
+        weightHash: String? = nil,
+        isVision: Bool? = nil
     ) {
         self.id = id
         self.modelType = modelType
@@ -119,6 +125,7 @@ public struct ModelInfo: Codable, Sendable, Equatable {
         self.sizeBytes = sizeBytes
         self.estimatedMemoryGb = estimatedMemoryGb
         self.weightHash = weightHash
+        self.isVision = isVision
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -130,6 +137,10 @@ public struct ModelInfo: Codable, Sendable, Equatable {
         try container.encode(sizeBytes, forKey: .sizeBytes)
         try container.encode(estimatedMemoryGb, forKey: .estimatedMemoryGb)
         try container.encodeIfPresent(weightHash, forKey: .weightHash)
+        // Encode only when true so text-only builds stay byte-compatible on the wire.
+        if isVision == true {
+            try container.encode(true, forKey: .isVision)
+        }
     }
 }
 

--- a/provider-swift/Sources/ProviderCore/ProviderCore.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderCore.swift
@@ -20,5 +20,10 @@ public enum ProviderCore {
     // message + provider self-reconcile/hard-swap). The coordinator gates
     // `desired_models` on provider version >= 0.5.17 (minProviderVersionForDesiredModels)
     // so pre-feature providers never receive a message their decoder would reject.
-    public static let version = "0.5.17"
+    // 0.6.0 ships APNs code-identity attestation (graced rollout), encrypted SSD
+    // KV cache (default-on), Gemma 4 image/video VLM serving with vision-aware
+    // routing, graceful download-first auto-update, and the model-alias hot-swap
+    // layer. Semver compares numerically per-component, so 0.6.0 > 0.5.17 keeps
+    // the desired_models gate satisfied.
+    public static let version = "0.6.0"
 }

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+InboundDecode.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+InboundDecode.swift
@@ -30,6 +30,10 @@ extension ProviderLoop {
     internal static func decodeOpenAIRequest(
         _ data: Data
     ) throws -> OpenAIChatCompletionRequest {
+        // Inject default `type`s into tool parameter schemas so a Gemma-style
+        // chat template's `{{ value['type'] | upper }}` can't crash on a typeless
+        // property (DAR-130). No-op for requests without tools.
+        let data = ToolSchemaNormalization.ensureParameterTypes(in: data)
         let decoder = JSONDecoder()
         do {
             return try decoder.decode(OpenAIChatCompletionRequest.self, from: data)

--- a/provider-swift/Sources/ProviderCore/Service/LaunchAgent.swift
+++ b/provider-swift/Sources/ProviderCore/Service/LaunchAgent.swift
@@ -70,8 +70,10 @@ public enum LaunchAgent: Sendable {
     ///
     /// If the service is already loaded it is unloaded first to pick up
     /// any plist changes. The plist is written with:
-    ///   - KeepAlive = false (no auto-restart on crash)
-    ///   - RunAtLoad = false (no auto-start on login)
+    ///   - KeepAlive = false (no auto-restart on crash; avoids racing the updater)
+    ///   - RunAtLoad = true (auto-start when the GUI session loads, i.e. at login —
+    ///     at boot on an auto-login box — so a rebooted provider re-attests via APNs
+    ///     without a manual `darkbloom start`)
     ///   - ProcessType = Interactive (high priority for real-time inference)
     ///   - Nice = -5 (slight scheduling boost)
     ///
@@ -273,13 +275,46 @@ public enum LaunchAgent: Sendable {
             }
         }
 
+        let plistDict = makeServicePlist(
+            label: label,
+            programArguments: programArguments,
+            logPath: log,
+            environment: ProcessInfo.processInfo.environment
+        )
+
+        let data = try PropertyListSerialization.data(
+            fromPropertyList: plistDict,
+            format: .xml,
+            options: 0
+        )
+        try data.write(to: plist, options: .atomic)
+    }
+
+    /// Build the launchd plist dictionary for the provider service. Pure (no I/O)
+    /// so the auto-start and environment-passthrough behavior is unit-testable.
+    ///
+    /// `RunAtLoad = true`: launchd starts the provider as soon as the GUI session
+    /// loads the agent — i.e. at login, which on an auto-login box is at boot. This
+    /// is what lets a rebooted/power-cycled provider come back and re-attest via
+    /// APNs with no human running `darkbloom start`. (APNs registration needs the
+    /// GUI/Aqua session, which a gui-domain LaunchAgent already runs in.)
+    ///
+    /// `KeepAlive = false` is deliberate: unconditional KeepAlive would have launchd
+    /// relaunch the process the instant the graceful self-updater stops it to swap
+    /// the binary, racing the stage-then-swap. Crash-recovery is handled separately.
+    static func makeServicePlist(
+        label: String,
+        programArguments: [String],
+        logPath: String,
+        environment: [String: String]
+    ) -> [String: Any] {
         var plistDict: [String: Any] = [
             "Label": label,
             "ProgramArguments": programArguments,
             "KeepAlive": false,
-            "RunAtLoad": false,
-            "StandardOutPath": log,
-            "StandardErrorPath": log,
+            "RunAtLoad": true,
+            "StandardOutPath": logPath,
+            "StandardErrorPath": logPath,
             "ProcessType": "Interactive",
             "Nice": -5,
         ]
@@ -289,17 +324,12 @@ public enum LaunchAgent: Sendable {
         // on-by-default encrypted SSD KV cache) would be silently ignored by the
         // daemon. Persist the allowlisted passthrough vars into the plist so the
         // operator actually has a per-machine off switch.
-        let environmentVariables = passthroughEnvironment(from: ProcessInfo.processInfo.environment)
+        let environmentVariables = passthroughEnvironment(from: environment)
         if !environmentVariables.isEmpty {
             plistDict["EnvironmentVariables"] = environmentVariables
         }
 
-        let data = try PropertyListSerialization.data(
-            fromPropertyList: plistDict,
-            format: .xml,
-            options: 0
-        )
-        try data.write(to: plist, options: .atomic)
+        return plistDict
     }
 
     private static func loadService() throws {

--- a/provider-swift/Sources/ProviderCore/Service/LaunchAgent.swift
+++ b/provider-swift/Sources/ProviderCore/Service/LaunchAgent.swift
@@ -214,6 +214,24 @@ public enum LaunchAgent: Sendable {
 
     // MARK: - Private
 
+    /// Env vars passed through from the installing shell into the launchd plist's
+    /// `EnvironmentVariables`. Kept to a small allowlist so the daemon's
+    /// environment stays predictable; only non-empty values are forwarded.
+    static let passthroughEnvKeys = ["DARKBLOOM_PREFIX_CACHE"]
+
+    /// Build the daemon `EnvironmentVariables` map from a source environment,
+    /// keeping only the allowlisted, non-empty keys. Pure (environment injected)
+    /// so it is unit-testable without touching the real process environment.
+    static func passthroughEnvironment(from environment: [String: String]) -> [String: String] {
+        var out: [String: String] = [:]
+        for key in passthroughEnvKeys {
+            if let value = environment[key], !value.isEmpty {
+                out[key] = value
+            }
+        }
+        return out
+    }
+
     private static func writePlist(
         binaryPath: String,
         coordinatorURL: String,
@@ -255,7 +273,7 @@ public enum LaunchAgent: Sendable {
             }
         }
 
-        let plistDict: [String: Any] = [
+        var plistDict: [String: Any] = [
             "Label": label,
             "ProgramArguments": programArguments,
             "KeepAlive": false,
@@ -265,6 +283,16 @@ public enum LaunchAgent: Sendable {
             "ProcessType": "Interactive",
             "Nice": -5,
         ]
+
+        // launchd does NOT inherit the installing shell's environment, so any
+        // opt-out the operator set (e.g. DARKBLOOM_PREFIX_CACHE=0 to disable the
+        // on-by-default encrypted SSD KV cache) would be silently ignored by the
+        // daemon. Persist the allowlisted passthrough vars into the plist so the
+        // operator actually has a per-machine off switch.
+        let environmentVariables = passthroughEnvironment(from: ProcessInfo.processInfo.environment)
+        if !environmentVariables.isEmpty {
+            plistDict["EnvironmentVariables"] = environmentVariables
+        }
 
         let data = try PropertyListSerialization.data(
             fromPropertyList: plistDict,

--- a/provider-swift/Sources/darkbloom/Diagnostics/DoctorRunner.swift
+++ b/provider-swift/Sources/darkbloom/Diagnostics/DoctorRunner.swift
@@ -23,6 +23,16 @@ enum DoctorRunner {
         out.append(Diagnostic(section: .attestationKey, name: "se key sign test",
                               level: se.level, message: se.message, fix: se.fix))
 
+        // ---- APNs code-identity readiness (local) ----
+        // Will this box be able to obtain an APNs token and attest its code
+        // identity? Requires a logged-in console (Aqua) session; a missing
+        // session, no auto-login, or idle auto-logout each break attestation.
+        // Pure verdict logic lives in ProviderCore; here we only feed it the
+        // live machine signals.
+        out.append(contentsOf: AttestationReadiness.evaluate(
+            AttestationReadiness.gather(),
+            sleepPrevented: systemSleepPrevented()))
+
         // ---- Coordinator trust (from the daemon's last trust_status) ----
         if let state, let trust = state.trust, daemonUp, !state.isStale(now: now) {
             let advice = TrustReasonCatalog.advice(level: trust.trustLevel, status: trust.status, reason: trust.reason)
@@ -157,5 +167,32 @@ enum DoctorRunner {
         if s < 60 { return "\(s)s" }
         if s < 3600 { return "\(s / 60)m" }
         return "\(s / 3600)h\((s % 3600) / 60)m"
+    }
+
+    /// Best-effort read of whether the system is currently being kept awake,
+    /// via `pmset -g assertions`. Informational only (the provider
+    /// self-caffeinates while serving), so nil/UNKNOWN on any failure is fine.
+    private static func systemSleepPrevented() -> Bool? {
+        let p = Process()
+        p.executableURL = URL(fileURLWithPath: "/usr/bin/pmset")
+        p.arguments = ["-g", "assertions"]
+        let out = Pipe()
+        p.standardOutput = out
+        p.standardError = Pipe()
+        guard (try? p.run()) != nil else { return nil }
+        p.waitUntilExit()
+        guard p.terminationStatus == 0 else { return nil }
+        let data = out.fileHandleForReading.readDataToEndOfFile()
+        guard let text = String(data: data, encoding: .utf8) else { return nil }
+        // `PreventUserIdleSystemSleep` / `PreventSystemSleep` report 1 when an
+        // assertion (e.g. caffeinate, an active inference) is holding the system
+        // awake. Any "1" on those lines ⇒ sleep currently prevented.
+        for line in text.split(separator: "\n") {
+            let l = line.lowercased()
+            if l.contains("preventuseridlesystemsleep") || l.contains("preventsystemsleep") {
+                if l.contains(" 1") || l.hasSuffix("1") { return true }
+            }
+        }
+        return false
     }
 }

--- a/provider-swift/Tests/ProviderCoreTests/AttestationReadinessTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/AttestationReadinessTests.swift
@@ -1,0 +1,114 @@
+import Foundation
+import Testing
+@testable import ProviderCore
+
+// MARK: - AttestationReadiness (pure verdict logic)
+
+/// Pulls the diagnostic for a given check name out of the evaluated set.
+private func check(_ diags: [Diagnostic], _ name: String) -> Diagnostic? {
+    diags.first { $0.name == name }
+}
+
+@Test func attestationReadinessNoConsoleUserFails() {
+    // The headline case: nobody logged in at the console → cannot obtain an
+    // APNs token → cannot attest. Must FAIL.
+    let d = AttestationReadiness.evaluate(
+        consoleUser: nil, autoLoginUser: "provider", autoLogoutDelaySeconds: 0)
+    let session = check(d, "console session")
+    #expect(session?.level == .fail)
+    #expect(session?.fix != nil)
+    // Every check still belongs to the dedicated readiness section.
+    #expect(d.allSatisfy { $0.section == .attestationReadiness })
+}
+
+@Test func attestationReadinessLoginWindowPlaceholderFails() {
+    // SCDynamicStoreCopyConsoleUser returns "loginwindow" while at the login
+    // window — that is NOT a real Aqua session.
+    for placeholder in ["loginwindow", "root", "", "  ", "_mbsetupuser"] {
+        let d = AttestationReadiness.evaluate(
+            consoleUser: placeholder, autoLoginUser: "provider", autoLogoutDelaySeconds: 0)
+        #expect(check(d, "console session")?.level == .fail,
+                "console user \"\(placeholder)\" must be treated as no session")
+    }
+}
+
+@Test func attestationReadinessAllGoodPasses() {
+    // Console user present + auto-login set + auto-logout disabled → all OK.
+    let d = AttestationReadiness.evaluate(
+        consoleUser: "provider", autoLoginUser: "provider", autoLogoutDelaySeconds: 0)
+    #expect(check(d, "console session")?.level == .pass)
+    #expect(check(d, "automatic login")?.level == .pass)
+    #expect(check(d, "auto-logout on idle")?.level == .pass)
+    // The critical and reboot-recovery checks all pass — no failures.
+    #expect(!d.contains { $0.level == .fail })
+    // The console user is surfaced in the message for the operator.
+    #expect(check(d, "console session")?.message.contains("provider") == true)
+}
+
+@Test func attestationReadinessAbsentAutoLogoutTreatedAsDisabled() {
+    // nil AutoLogOutDelay (the common case — setting never touched) == disabled.
+    let d = AttestationReadiness.evaluate(
+        consoleUser: "provider", autoLoginUser: "provider", autoLogoutDelaySeconds: nil)
+    #expect(check(d, "auto-logout on idle")?.level == .pass)
+}
+
+@Test func attestationReadinessAutoLogoutEnabledFails() {
+    // AutoLogOutDelay > 0 → the session is ended after idle, killing the GUI
+    // LaunchAgent and the provider → FAIL.
+    let d = AttestationReadiness.evaluate(
+        consoleUser: "provider", autoLoginUser: "provider", autoLogoutDelaySeconds: 600)
+    let logout = check(d, "auto-logout on idle")
+    #expect(logout?.level == .fail)
+    #expect(logout?.message.contains("10 min") == true) // 600s → 10 min
+    #expect(logout?.fix != nil)
+}
+
+@Test func attestationReadinessNoAutoLoginWarns() {
+    // Without auto-login the box can't self-recover a session after reboot →
+    // WARN (not FAIL: a currently-logged-in box still works until it reboots).
+    let d = AttestationReadiness.evaluate(
+        consoleUser: "provider", autoLoginUser: nil, autoLogoutDelaySeconds: 0)
+    #expect(check(d, "automatic login")?.level == .warn)
+    #expect(check(d, "automatic login")?.fix != nil)
+
+    // Empty-string autoLoginUser is the same as unset.
+    let d2 = AttestationReadiness.evaluate(
+        consoleUser: "provider", autoLoginUser: "   ", autoLogoutDelaySeconds: 0)
+    #expect(check(d2, "automatic login")?.level == .warn)
+}
+
+@Test func attestationReadinessSleepPreventionIsInformational() {
+    // Sleep prevention is low-priority/informational and never FAILs.
+    let prevented = AttestationReadiness.evaluate(
+        consoleUser: "u", autoLoginUser: "u", autoLogoutDelaySeconds: 0, sleepPrevented: true)
+    #expect(check(prevented, "sleep prevention")?.level == .pass)
+
+    let notPrevented = AttestationReadiness.evaluate(
+        consoleUser: "u", autoLoginUser: "u", autoLogoutDelaySeconds: 0, sleepPrevented: false)
+    #expect(check(notPrevented, "sleep prevention")?.level == .warn)
+
+    let unknown = AttestationReadiness.evaluate(
+        consoleUser: "u", autoLoginUser: "u", autoLogoutDelaySeconds: 0, sleepPrevented: nil)
+    #expect(check(unknown, "sleep prevention")?.level == .warn)
+    // Even when sleep can't be read, it is never a hard failure.
+    #expect(check(unknown, "sleep prevention")?.level != .fail)
+}
+
+@Test func attestationReadinessInputsConvenienceMatchesDirect() {
+    let inputs = AttestationReadiness.Inputs(
+        consoleUser: "provider", autoLoginUser: "provider", autoLogoutDelaySeconds: 0)
+    let viaInputs = AttestationReadiness.evaluate(inputs)
+    let direct = AttestationReadiness.evaluate(
+        consoleUser: "provider", autoLoginUser: "provider", autoLogoutDelaySeconds: 0)
+    #expect(viaInputs == direct)
+}
+
+@Test func attestationReadinessIsRealConsoleUser() {
+    #expect(AttestationReadiness.isRealConsoleUser("alice") == true)
+    #expect(AttestationReadiness.isRealConsoleUser("Provider Account") == true)
+    #expect(AttestationReadiness.isRealConsoleUser(nil) == false)
+    #expect(AttestationReadiness.isRealConsoleUser("") == false)
+    #expect(AttestationReadiness.isRealConsoleUser("loginwindow") == false)
+    #expect(AttestationReadiness.isRealConsoleUser("LoginWindow") == false) // case-insensitive
+    #expect(AttestationReadiness.isRealConsoleUser("root") == false)
+}

--- a/provider-swift/Tests/ProviderCoreTests/CoordinatorClientTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/CoordinatorClientTests.swift
@@ -222,6 +222,19 @@ import Testing
     #expect(inRange(backoff.nextDelay(), 1))
 }
 
+@Test func inboundMessageLimitRaisedAboveDefault() {
+    let session = URLSession(configuration: .default)
+    let ws = session.webSocketTask(with: URL(string: "wss://example.invalid/ws/provider")!)
+    defer { ws.cancel(with: .goingAway, reason: nil) }
+
+    // Default URLSessionWebSocketTask limit is 1 MiB; a single base64 image request
+    // frame exceeds it and would tear down the session, so the client raises it well
+    // above the coordinator's 16 MiB sealed-body cap (after base64 expansion).
+    CoordinatorClient.applyInboundMessageLimit(to: ws)
+    #expect(ws.maximumMessageSize == CoordinatorClient.maxInboundMessageBytes)
+    #expect(ws.maximumMessageSize >= 22 * 1024 * 1024)
+}
+
 private func clientSampleHardware() -> HardwareInfo {
     HardwareInfo(
         machineModel: "Mac16,5",

--- a/provider-swift/Tests/ProviderCoreTests/LaunchAgentRestartTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/LaunchAgentRestartTests.swift
@@ -22,3 +22,18 @@ struct LaunchAgentRestartTests {
         #expect(message.contains("boom"))
     }
 }
+
+@Suite("LaunchAgent environment passthrough")
+struct LaunchAgentEnvironmentTests {
+    @Test func forwardsAllowlistedNonEmptyVars() {
+        let env = ["DARKBLOOM_PREFIX_CACHE": "0", "PATH": "/usr/bin", "HOME": "/Users/x"]
+        let out = LaunchAgent.passthroughEnvironment(from: env)
+        // Only the allowlisted opt-out is forwarded to the daemon; PATH/HOME are not.
+        #expect(out == ["DARKBLOOM_PREFIX_CACHE": "0"])
+    }
+
+    @Test func dropsEmptyAndMissingVars() {
+        #expect(LaunchAgent.passthroughEnvironment(from: [:]).isEmpty)
+        #expect(LaunchAgent.passthroughEnvironment(from: ["DARKBLOOM_PREFIX_CACHE": ""]).isEmpty)
+    }
+}

--- a/provider-swift/Tests/ProviderCoreTests/LaunchAgentRestartTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/LaunchAgentRestartTests.swift
@@ -37,3 +37,31 @@ struct LaunchAgentEnvironmentTests {
         #expect(LaunchAgent.passthroughEnvironment(from: ["DARKBLOOM_PREFIX_CACHE": ""]).isEmpty)
     }
 }
+
+@Suite("LaunchAgent service plist")
+struct LaunchAgentServicePlistTests {
+    @Test func autoStartsAtLoadAndForwardsAllowlistedEnv() {
+        let plist = LaunchAgent.makeServicePlist(
+            label: "io.darkbloom.provider",
+            programArguments: ["/usr/local/bin/darkbloom", "start", "--foreground"],
+            logPath: "/tmp/p.log",
+            environment: ["DARKBLOOM_PREFIX_CACHE": "0", "PATH": "/usr/bin"]
+        )
+        // RunAtLoad=true so a rebooted / auto-login box restarts (and re-attests via
+        // APNs) with no human; KeepAlive stays false to avoid racing the self-updater.
+        #expect(plist["RunAtLoad"] as? Bool == true)
+        #expect(plist["KeepAlive"] as? Bool == false)
+        #expect((plist["EnvironmentVariables"] as? [String: String]) == ["DARKBLOOM_PREFIX_CACHE": "0"])
+    }
+
+    @Test func omitsEnvironmentWhenNoAllowlistedVarsSet() {
+        let plist = LaunchAgent.makeServicePlist(
+            label: "io.darkbloom.provider",
+            programArguments: ["darkbloom", "start", "--foreground"],
+            logPath: "/tmp/p.log",
+            environment: ["PATH": "/usr/bin"]
+        )
+        #expect(plist["EnvironmentVariables"] == nil)
+        #expect(plist["RunAtLoad"] as? Bool == true)
+    }
+}

--- a/provider-swift/Tests/ProviderCoreTests/ToolSchemaNormalizationTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/ToolSchemaNormalizationTests.swift
@@ -1,0 +1,59 @@
+import Foundation
+import Testing
+
+@testable import ProviderCore
+
+@Suite("Tool schema normalization (DAR-130)")
+struct ToolSchemaNormalizationTests {
+    private func parse(_ data: Data) -> [String: Any] {
+        (try? JSONSerialization.jsonObject(with: data)) as? [String: Any] ?? [:]
+    }
+
+    @Test func injectsTypeIntoTypelessParameterPropertyAndObject() throws {
+        // A legitimate OpenAI schema: the `unit` property has enum+description but
+        // no explicit `type`, and the parameters object itself omits `type`.
+        let body = #"""
+        {"model":"gemma-4-26b","messages":[{"role":"user","content":"hi"}],
+         "tools":[{"type":"function","function":{"name":"get_weather",
+           "parameters":{"properties":{"unit":{"enum":["c","f"],"description":"unit"}}}}}]}
+        """#.data(using: .utf8)!
+
+        let out = ToolSchemaNormalization.ensureParameterTypes(in: body)
+        let root = parse(out)
+        let tools = try #require(root["tools"] as? [[String: Any]])
+        let function = try #require(tools[0]["function"] as? [String: Any])
+        let params = try #require(function["parameters"] as? [String: Any])
+
+        #expect(params["type"] as? String == "object")
+        let props = try #require(params["properties"] as? [String: Any])
+        let unit = try #require(props["unit"] as? [String: Any])
+        // Defaulted to "string" so `{{ value['type'] | upper }}` no longer throws.
+        #expect(unit["type"] as? String == "string")
+        // The original enum/description are preserved.
+        #expect((unit["enum"] as? [Any])?.count == 2)
+        #expect(unit["description"] as? String == "unit")
+    }
+
+    @Test func preservesExistingTypesAndNestedArrays() throws {
+        let body = #"""
+        {"tools":[{"type":"function","function":{"name":"f",
+          "parameters":{"type":"object","properties":{
+            "tags":{"type":"array","items":{"description":"a tag"}},
+            "q":{"type":"string"}}}}}]}
+        """#.data(using: .utf8)!
+
+        let out = ToolSchemaNormalization.ensureParameterTypes(in: body)
+        let function = try #require((parse(out)["tools"] as? [[String: Any]])?[0]["function"] as? [String: Any])
+        let props = try #require((function["parameters"] as? [String: Any])?["properties"] as? [String: Any])
+        // Existing types untouched.
+        #expect((props["q"] as? [String: Any])?["type"] as? String == "string")
+        // Nested array `items` schema with no type gets defaulted.
+        let items = try #require((props["tags"] as? [String: Any])?["items"] as? [String: Any])
+        #expect(items["type"] as? String == "string")
+    }
+
+    @Test func nonToolBodyReturnedUnchanged() {
+        let noTools = #"{"model":"m","messages":[]}"#.data(using: .utf8)!
+        #expect(ToolSchemaNormalization.ensureParameterTypes(in: noTools) == noTools)
+    }
+}

--- a/provider-swift/Tests/ProviderCoreTests/ToolSchemaNormalizationTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/ToolSchemaNormalizationTests.swift
@@ -93,3 +93,13 @@ extension ToolSchemaNormalizationTests {
         #expect(n["type"] as? String == "number")
     }
 }
+
+extension ToolSchemaNormalizationTests {
+    @Test func skipsNormalizationForOversizedBodies() {
+        // A body above the cap is returned unchanged BEFORE any parse, even though
+        // it contains "tools" — bounding the JSON round-trip cost (DoS amplification).
+        var body = Data(#"{"tools":["#.utf8)
+        body.append(Data(count: ToolSchemaNormalization.maxNormalizationBytes))
+        #expect(ToolSchemaNormalization.ensureParameterTypes(in: body) == body)
+    }
+}

--- a/provider-swift/Tests/ProviderCoreTests/ToolSchemaNormalizationTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/ToolSchemaNormalizationTests.swift
@@ -57,3 +57,39 @@ struct ToolSchemaNormalizationTests {
         #expect(ToolSchemaNormalization.ensureParameterTypes(in: noTools) == noTools)
     }
 }
+
+extension ToolSchemaNormalizationTests {
+    private func toolParams(_ data: Data) -> [String: Any] {
+        let root = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any] ?? [:]
+        let tools = root["tools"] as? [[String: Any]] ?? []
+        let fn = tools.first?["function"] as? [String: Any] ?? [:]
+        return fn["parameters"] as? [String: Any] ?? [:]
+    }
+
+    @Test func recursesIntoAdditionalProperties() throws {
+        let body = #"""
+        {"tools":[{"type":"function","function":{"name":"f",
+          "parameters":{"type":"object","properties":{
+            "meta":{"additionalProperties":{"description":"a value"}}}}}}]}
+        """#.data(using: .utf8)!
+        let props = try #require(toolParams(ToolSchemaNormalization.ensureParameterTypes(in: body))["properties"] as? [String: Any])
+        let meta = try #require(props["meta"] as? [String: Any])
+        // The map-shaped param node is typed "object"...
+        #expect(meta["type"] as? String == "object")
+        // ...and its inner additionalProperties schema gets a default type too.
+        let addl = try #require(meta["additionalProperties"] as? [String: Any])
+        #expect(addl["type"] as? String == "string")
+    }
+
+    @Test func derivesUnionTypeInsteadOfBlanketString() throws {
+        let body = #"""
+        {"tools":[{"type":"function","function":{"name":"f",
+          "parameters":{"type":"object","properties":{
+            "n":{"anyOf":[{"type":"number"},{"type":"null"}]}}}}}]}
+        """#.data(using: .utf8)!
+        let props = try #require(toolParams(ToolSchemaNormalization.ensureParameterTypes(in: body))["properties"] as? [String: Any])
+        let n = try #require(props["n"] as? [String: Any])
+        // A nullable-number union borrows "number", not a mislabelling "string".
+        #expect(n["type"] as? String == "number")
+    }
+}


### PR DESCRIPTION
## v0.6.0 launch — fixes for all seven launch objectives

Implements the code-level fixes from the pre-release audit so v0.6.0 is **safe to deploy** and every launch objective can be turned on operationally afterward. This is one PR; **no tag/release** is created here (release stays human-gated).

Branch base: master @ `8adfe150`.

### What's in it

| Objective | Change |
|---|---|
| **APNs binary verification** | Code-attestation enforcement is now **deadline-driven**: `SetCodeAttestor` only *configures* (challenge + measure); enforcement begins at `APNS_ENFORCE_AFTER` (RFC3339). Unset ⇒ perpetual grace/observe, so setting `APNS_*` secrets **never deroutes the fleet**. After the deadline, un-attested (and too-old-to-attest) providers stop routing — "everyone must have it" after the 1-day grace. The gate reads policy live, so grace→enforce flips with **no provider reconnect**. Added periodic re-challenge so a single dropped background push doesn't strand a capable provider. |
| **Gemma 8-bit → 4-bit migration** | Coordinator **alias takeover**: a public alias can adopt the live concrete id `gemma-4-26b`, absorbing it as the `previous_build` fallback while `desired_build` points at the new 4-bit build. Opt-in, fail-closed, and **does not change the absorbed model's catalog weight hash** (so it never untrusts the live fleet; asserted by test). This is the missing bootstrap for the cutover — inert until an admin invokes it. |
| **SSD KV caching** | Already default-on in 0.6.0; this PR makes the documented opt-out **reachable** by passing `DARKBLOOM_PREFIX_CACHE` through the launchd plist `EnvironmentVariables` (launchd doesn't inherit the installing shell). |
| **Gemma 4 multimodal** | **Vision-aware routing** so a media request is never silently answered image-blind: providers advertise `is_vision` per build (from `vision_config`); the coordinator detects image/video parts (it sees plaintext at routing time) and only routes to a vision-capable provider, failing fast with a clear error when none exists. Media-aware **routing** token estimate (flat per-image cost, not base64 length). Console upload button now lights only from catalog modality (the `/gemma-?4/i` family bridge is removed), so the operator's capability flip is the single switch. **WS 1 MiB cap fix**: the provider raises `maximumMessageSize` to 32 MiB so an image frame can't tear down the whole session and cancel unrelated in-flight requests. |
| **Graceful downloads / swap / update** | Shipped in #292/#298; this PR carries the **0.6.0 version bump** and the alias hot-swap bootstrap above. |
| **Model hashing fix** | Shipped in #297; no code change here — see deploy guardrails (catalog freeze). |
| **EigenCloud → GCP migration** | State-export shipped in #294; no change here. |

Plus **DAR-130**: tool JSON schemas are normalized at the inbound decode boundary (default-fill a missing `type` on each parameter) so a Gemma chat template's `{{ value['type'] | upper }}` can't 500 — provider-side only, the `libs/mlx-swift-lm` submodule is untouched.

### Review

Both quality-gate reviewers (codex + Claude) ran. The first codex pass flagged three real issues in vision routing — a `p.Models` data race (the helper read it without `p.mu`), a billing under-reservation (media-aware count dropped `tool_calls`/`name` fields), and a Responses-API media-detection gap. All three are fixed in `63bdf5f3` and re-verified resolved. Billing now stays a guaranteed upper bound; routing/ITPM is the media-aware estimate.

### Tests

- Coordinator: `go build ./...` + `go test ./...` — 15 packages, 0 failures (new tests pass under `-race`).
- Provider: `swift build` + `swift test` — 678 tests pass.
- Console: `next build` + `eslint` (0 errors) + 240 vitest pass.

New coverage: APNs grace/enforce/live-flip/re-challenge, `is_vision` protocol symmetry, vision routing helpers + fail-fast, media detection (chat + Responses) + media-aware estimate, alias-takeover (incl. catalog-hash-unchanged), tool-schema defaulting, WS cap, launchd env passthrough.

---

## ⚠️ Deploy guardrails (operational — read before shipping)

These are runtime/KMS actions, not code, and gate the safe rollout:

- **KMS — leave unset this cycle:** `APNS_KEY_ID` / `APNS_TEAM_ID` / `APNS_AUTH_KEY_P8_*` (configuring them starts grace/observe; only set `APNS_ENFORCE_AFTER = release + 24h` once the fleet is on 0.6.0 and attesting), `EIGENINFERENCE_MIN_PROVIDER_VERSION` (don't bump — would deroute the <0.6.0 fleet), `EIGENINFERENCE_BINARYHASH_ENFORCE` (default-off is the intended new posture), `EIGENINFERENCE_STATE_EXPORT_ENABLED`.
- **Deploy order:** coordinator first, **catalog frozen** (no publish/promote/status ops) until ~2× 5-min challenge cycles verify clean (`grep "model weight hash mismatch"`, capacity stable). Then register the provider release in a low-traffic window (the ≤0.5.16 updater is drainless).
- **Turn features on last, after fleet convergence:** publish the 4-bit build under a **new** id (inert), then the alias takeover; flip catalog `vision`/`video` capabilities + ship the console image button only once the gemma fleet is on 0.6.0.
- **Size-limit chain (images):** provider WS 32 MiB > Caddy `request_body` 25 MB > coordinator sealed-body cap **16 MiB** (the effective single-image ceiling). Consistent for single-image launch; raise the coordinator's 16 MiB sealed cap first (then Caddy) if multi-image support is wanted later.

## Out of scope (follow-up PRs)

- #291 heartbeat `draining` flag (next release cycle — first fleet-wide graceful drain is 0.6.0 → next).
- Metallib template-hash **union** (newest-wins today; 0.6.0's metallib is byte-identical so safe this release — fix before any MLX-bumping release).
- Remote (coordinator-pushed) SSD-cache kill switch; durable console image storage; batched multimodal; making Responses-API images actually serve (today they're gated + fail-fast, the conversion still strips them).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/303"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783663597&installation_id=133247490&pr_number=303&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F303&signature=fd91067de20cdb36933437462951129d427e3303fb8a486c0be8b100f9ee5065"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->