### PR TITLE
fix: report reasoning_tokens separately in chat-completions streaming usage

### DIFF
--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -2517,10 +2517,11 @@ func (s *Server) handleStreamingResponseWithFirstChunk(w http.ResponseWriter, r 
 	timer := time.NewTimer(inferenceTimeout)
 	defer timer.Stop()
 
-	// The terminal include_usage chunk lacks the reasoning breakdown; we hold it
-	// and re-emit it at stream end augmented with the provider's authoritative
-	// reasoning-token count (CompleteCh) — matching the non-streaming/Responses paths.
-	var pendingUsageChunk string
+	// The terminal include_usage chunk lacks the reasoning breakdown; we hold its
+	// parsed object and re-emit it at stream end with the provider's authoritative
+	// reasoning count (CompleteCh) spliced in — matching the non-streaming/Responses
+	// paths. Held as a parsed map so it is decoded exactly once.
+	var pendingUsage map[string]any
 
 	for {
 		select {
@@ -2555,7 +2556,11 @@ func (s *Server) handleStreamingResponseWithFirstChunk(w http.ResponseWriter, r 
 					// Emit the held usage chunk (stream_options.include_usage) with the
 					// reasoning breakdown spliced in from the provider's authoritative
 					// UsageInfo, so streaming reports reasoning_tokens like the rest.
-					if pendingUsageChunk != "" {
+					// This select runs once, at stream end: the provider's
+					// inferenceComplete (which populates CompleteCh) is what ends the
+					// stream, so it is effectively already buffered — the timeout is a
+					// fallback, not a hot-path wait.
+					if pendingUsage != nil {
 						var usage protocol.UsageInfo
 						select {
 						case u, uok := <-pr.CompleteCh:
@@ -2565,11 +2570,10 @@ func (s *Server) handleStreamingResponseWithFirstChunk(w http.ResponseWriter, r 
 						case <-time.After(2 * time.Second):
 						case <-r.Context().Done():
 						}
-						out := normalizeSSEChunk(pendingUsageChunk)
-						out = injectReasoningIntoStreamUsageChunk(out, usage)
-						out = rewriteChunkModel(out, pr)
-						fmt.Fprintf(w, "%s\n\n", out)
-						flusher.Flush()
+						if out := finalizeUsageChunk(pendingUsage, usage, pr); out != "" {
+							fmt.Fprintf(w, "%s\n\n", out)
+							flusher.Flush()
+						}
 					}
 					// Chat completions format: append SE signature + [DONE].
 					if pr.SESignature != "" {
@@ -2593,17 +2597,13 @@ func (s *Server) handleStreamingResponseWithFirstChunk(w http.ResponseWriter, r 
 			}
 			// Hold the terminal usage chunk (chat completions only) so we can splice
 			// in the reasoning breakdown at stream end; forwarding it inline would
-			// emit it without reasoning_tokens.
-			if !sawResponsesAPI && isUsageOnlyStreamChunk(chunk) {
-				pendingUsageChunk = chunk
-				if !timer.Stop() {
-					select {
-					case <-timer.C:
-					default:
-					}
+			// emit it without reasoning_tokens. The stream closes right after, so the
+			// running timer still guards a post-usage hang.
+			if !sawResponsesAPI {
+				if obj, isUsage := parseUsageOnlyStreamChunk(chunk); isUsage {
+					pendingUsage = obj
+					continue
 				}
-				timer.Reset(inferenceTimeout)
-				continue
 			}
 			if !sawResponsesAPI {
 				chunk = normalizeSSEChunk(chunk)
@@ -3381,43 +3381,44 @@ func injectReasoningDetailIntoRawUsage(obj map[string]any, usage protocol.UsageI
 	obj["usage"] = usageObj
 }
 
-// isUsageOnlyStreamChunk reports whether an SSE data chunk is the terminal usage
-// chunk emitted for stream_options.include_usage: empty choices + a non-null usage
-// object, carrying the final usage and no content delta.
-func isUsageOnlyStreamChunk(chunk string) bool {
+// parseUsageOnlyStreamChunk decodes a terminal include_usage chunk (empty choices
+// + a non-null usage object, carrying the final usage and no content delta) and
+// returns the parsed object. ok is false for any other chunk. Parsing here once
+// lets the caller hold the object and finalize it at stream end without re-parsing.
+func parseUsageOnlyStreamChunk(chunk string) (obj map[string]any, ok bool) {
 	line := strings.TrimPrefix(chunk, "data: ")
+	// Cheap gate: skip the parse for content deltas and usage:null chunks.
 	if !strings.Contains(line, `"usage"`) || strings.Contains(line, `"usage":null`) {
-		return false
+		return nil, false
 	}
-	var obj map[string]any
 	if err := json.Unmarshal([]byte(line), &obj); err != nil {
-		return false
+		return nil, false
 	}
-	if u, ok := obj["usage"].(map[string]any); !ok || u == nil {
-		return false
+	if u, uok := obj["usage"].(map[string]any); !uok || u == nil {
+		return nil, false
 	}
-	choices, _ := obj["choices"].([]any)
-	return len(choices) == 0
+	if choices, _ := obj["choices"].([]any); len(choices) != 0 {
+		return nil, false
+	}
+	return obj, true
 }
 
-// injectReasoningIntoStreamUsageChunk adds completion_tokens_details.reasoning_tokens
-// (from the provider's authoritative UsageInfo) to a streaming chat-completions
-// usage chunk, so streaming reports the reasoning breakdown like the non-streaming
-// and Responses paths. No-op when there is no reasoning count or the chunk isn't
-// parseable.
-func injectReasoningIntoStreamUsageChunk(chunk string, usage protocol.UsageInfo) string {
-	if usage.ReasoningTokens <= 0 {
-		return chunk
-	}
-	line := strings.TrimPrefix(chunk, "data: ")
-	var obj map[string]any
-	if err := json.Unmarshal([]byte(line), &obj); err != nil {
-		return chunk
-	}
+// finalizeUsageChunk renders the held terminal usage chunk for chat-completions
+// streaming: it splices the provider's authoritative reasoning count into
+// completion_tokens_details (no-op when there is none), strips a null
+// system_fingerprint, and rewrites the build id to the public alias — marshalling
+// ONCE (obj is already parsed). Returns "" if it can't be marshalled.
+func finalizeUsageChunk(obj map[string]any, usage protocol.UsageInfo, pr *registry.PendingRequest) string {
 	injectReasoningDetailIntoRawUsage(obj, usage)
+	if v, present := obj["system_fingerprint"]; present && v == nil {
+		delete(obj, "system_fingerprint")
+	}
+	if pr.PublicModel != "" && pr.PublicModel != pr.Model {
+		obj["model"] = pr.PublicModel
+	}
 	b, err := json.Marshal(obj)
 	if err != nil {
-		return chunk
+		return ""
 	}
 	return "data: " + string(b)
 }

--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -2517,6 +2517,11 @@ func (s *Server) handleStreamingResponseWithFirstChunk(w http.ResponseWriter, r 
 	timer := time.NewTimer(inferenceTimeout)
 	defer timer.Stop()
 
+	// The terminal include_usage chunk lacks the reasoning breakdown; we hold it
+	// and re-emit it at stream end augmented with the provider's authoritative
+	// reasoning-token count (CompleteCh) — matching the non-streaming/Responses paths.
+	var pendingUsageChunk string
+
 	for {
 		select {
 		case chunk, ok := <-pr.ChunkCh:
@@ -2547,6 +2552,25 @@ func (s *Server) handleStreamingResponseWithFirstChunk(w http.ResponseWriter, r 
 				// "response.completed" as the terminal event. Adding
 				// extra chunks would break SDK parsers.
 				if !sawResponsesAPI {
+					// Emit the held usage chunk (stream_options.include_usage) with the
+					// reasoning breakdown spliced in from the provider's authoritative
+					// UsageInfo, so streaming reports reasoning_tokens like the rest.
+					if pendingUsageChunk != "" {
+						var usage protocol.UsageInfo
+						select {
+						case u, uok := <-pr.CompleteCh:
+							if uok {
+								usage = u
+							}
+						case <-time.After(2 * time.Second):
+						case <-r.Context().Done():
+						}
+						out := normalizeSSEChunk(pendingUsageChunk)
+						out = injectReasoningIntoStreamUsageChunk(out, usage)
+						out = rewriteChunkModel(out, pr)
+						fmt.Fprintf(w, "%s\n\n", out)
+						flusher.Flush()
+					}
 					// Chat completions format: append SE signature + [DONE].
 					if pr.SESignature != "" {
 						sigEvent, _ := json.Marshal(map[string]any{
@@ -2566,6 +2590,20 @@ func (s *Server) handleStreamingResponseWithFirstChunk(w http.ResponseWriter, r 
 				if strings.Contains(chunk, `"response.created"`) || strings.Contains(chunk, `"response.output_text.delta"`) {
 					sawResponsesAPI = true
 				}
+			}
+			// Hold the terminal usage chunk (chat completions only) so we can splice
+			// in the reasoning breakdown at stream end; forwarding it inline would
+			// emit it without reasoning_tokens.
+			if !sawResponsesAPI && isUsageOnlyStreamChunk(chunk) {
+				pendingUsageChunk = chunk
+				if !timer.Stop() {
+					select {
+					case <-timer.C:
+					default:
+					}
+				}
+				timer.Reset(inferenceTimeout)
+				continue
 			}
 			if !sawResponsesAPI {
 				chunk = normalizeSSEChunk(chunk)
@@ -3341,6 +3379,47 @@ func injectReasoningDetailIntoRawUsage(obj map[string]any, usage protocol.UsageI
 	details["reasoning_tokens"] = usage.ReasoningTokens
 	usageObj["completion_tokens_details"] = details
 	obj["usage"] = usageObj
+}
+
+// isUsageOnlyStreamChunk reports whether an SSE data chunk is the terminal usage
+// chunk emitted for stream_options.include_usage: empty choices + a non-null usage
+// object, carrying the final usage and no content delta.
+func isUsageOnlyStreamChunk(chunk string) bool {
+	line := strings.TrimPrefix(chunk, "data: ")
+	if !strings.Contains(line, `"usage"`) || strings.Contains(line, `"usage":null`) {
+		return false
+	}
+	var obj map[string]any
+	if err := json.Unmarshal([]byte(line), &obj); err != nil {
+		return false
+	}
+	if u, ok := obj["usage"].(map[string]any); !ok || u == nil {
+		return false
+	}
+	choices, _ := obj["choices"].([]any)
+	return len(choices) == 0
+}
+
+// injectReasoningIntoStreamUsageChunk adds completion_tokens_details.reasoning_tokens
+// (from the provider's authoritative UsageInfo) to a streaming chat-completions
+// usage chunk, so streaming reports the reasoning breakdown like the non-streaming
+// and Responses paths. No-op when there is no reasoning count or the chunk isn't
+// parseable.
+func injectReasoningIntoStreamUsageChunk(chunk string, usage protocol.UsageInfo) string {
+	if usage.ReasoningTokens <= 0 {
+		return chunk
+	}
+	line := strings.TrimPrefix(chunk, "data: ")
+	var obj map[string]any
+	if err := json.Unmarshal([]byte(line), &obj); err != nil {
+		return chunk
+	}
+	injectReasoningDetailIntoRawUsage(obj, usage)
+	b, err := json.Marshal(obj)
+	if err != nil {
+		return chunk
+	}
+	return "data: " + string(b)
 }
 
 func resolveReasoningTokens(usage protocol.UsageInfo, reasoning string) uint64 {

--- a/coordinator/api/consumer_test.go
+++ b/coordinator/api/consumer_test.go
@@ -1665,22 +1665,40 @@ func TestDetectMediaRequirementAnthropicImageBlock(t *testing.T) {
 	}
 }
 
-// TestInjectReasoningIntoStreamUsageChunk covers the helper logic directly.
-func TestInjectReasoningIntoStreamUsageChunk(t *testing.T) {
-	usageChunk := `data: {"object":"chat.completion.chunk","choices":[],"usage":{"prompt_tokens":10,"completion_tokens":50,"total_tokens":60}}`
-	if !isUsageOnlyStreamChunk(usageChunk) {
-		t.Fatal("expected the usage-only chunk to be detected")
+// TestUsageChunkParseAndFinalize covers the parse-once + finalize helpers.
+func TestUsageChunkParseAndFinalize(t *testing.T) {
+	usageChunk := `data: {"object":"chat.completion.chunk","model":"gpt-oss-20b","choices":[],"usage":{"prompt_tokens":10,"completion_tokens":50,"total_tokens":60}}`
+	pr := &registry.PendingRequest{Model: "gpt-oss-20b"}
+
+	obj, ok := parseUsageOnlyStreamChunk(usageChunk)
+	if !ok {
+		t.Fatal("expected the usage-only chunk to be detected + parsed")
 	}
-	out := injectReasoningIntoStreamUsageChunk(usageChunk, protocol.UsageInfo{CompletionTokens: 50, ReasoningTokens: 8})
+	out := finalizeUsageChunk(obj, protocol.UsageInfo{CompletionTokens: 50, ReasoningTokens: 8}, pr)
 	if !strings.Contains(out, `"reasoning_tokens":8`) {
-		t.Fatalf("expected reasoning_tokens injected; got %s", out)
+		t.Fatalf("expected reasoning_tokens spliced into usage; got %s", out)
 	}
-	delta := `data: {"object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"x"}}]}`
-	if isUsageOnlyStreamChunk(delta) {
+
+	// A content delta and a usage:null chunk are NOT usage-only chunks.
+	if _, ok := parseUsageOnlyStreamChunk(`data: {"object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"x"}}]}`); ok {
 		t.Fatal("a content delta must NOT be treated as a usage-only chunk")
 	}
-	if got := injectReasoningIntoStreamUsageChunk(usageChunk, protocol.UsageInfo{CompletionTokens: 50}); got != usageChunk {
-		t.Fatalf("expected no-op when there is no reasoning; got %s", got)
+	if _, ok := parseUsageOnlyStreamChunk(`data: {"object":"chat.completion.chunk","choices":[],"usage":null}`); ok {
+		t.Fatal("a usage:null chunk must NOT be treated as a usage-only chunk")
+	}
+
+	// No reasoning → no completion_tokens_details added.
+	obj2, _ := parseUsageOnlyStreamChunk(usageChunk)
+	if plain := finalizeUsageChunk(obj2, protocol.UsageInfo{CompletionTokens: 50}, pr); strings.Contains(plain, "completion_tokens_details") {
+		t.Fatalf("expected no reasoning detail when ReasoningTokens=0; got %s", plain)
+	}
+
+	// Build id rewritten to the public alias.
+	obj3, _ := parseUsageOnlyStreamChunk(usageChunk)
+	prAlias := &registry.PendingRequest{Model: "gpt-oss-20b", PublicModel: "gpt-oss"}
+	aliased := finalizeUsageChunk(obj3, protocol.UsageInfo{CompletionTokens: 50, ReasoningTokens: 8}, prAlias)
+	if !strings.Contains(aliased, `"model":"gpt-oss"`) || strings.Contains(aliased, `"model":"gpt-oss-20b"`) {
+		t.Fatalf("expected build id rewritten to the public alias; got %s", aliased)
 	}
 }
 

--- a/coordinator/api/consumer_test.go
+++ b/coordinator/api/consumer_test.go
@@ -1664,3 +1664,62 @@ func TestDetectMediaRequirementAnthropicImageBlock(t *testing.T) {
 		t.Fatal("expected Anthropic image content block to be detected as media")
 	}
 }
+
+// TestInjectReasoningIntoStreamUsageChunk covers the helper logic directly.
+func TestInjectReasoningIntoStreamUsageChunk(t *testing.T) {
+	usageChunk := `data: {"object":"chat.completion.chunk","choices":[],"usage":{"prompt_tokens":10,"completion_tokens":50,"total_tokens":60}}`
+	if !isUsageOnlyStreamChunk(usageChunk) {
+		t.Fatal("expected the usage-only chunk to be detected")
+	}
+	out := injectReasoningIntoStreamUsageChunk(usageChunk, protocol.UsageInfo{CompletionTokens: 50, ReasoningTokens: 8})
+	if !strings.Contains(out, `"reasoning_tokens":8`) {
+		t.Fatalf("expected reasoning_tokens injected; got %s", out)
+	}
+	delta := `data: {"object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"x"}}]}`
+	if isUsageOnlyStreamChunk(delta) {
+		t.Fatal("a content delta must NOT be treated as a usage-only chunk")
+	}
+	if got := injectReasoningIntoStreamUsageChunk(usageChunk, protocol.UsageInfo{CompletionTokens: 50}); got != usageChunk {
+		t.Fatalf("expected no-op when there is no reasoning; got %s", got)
+	}
+}
+
+// TestStreamingChatReasoningTokensInUsage proves chat-completions STREAMING now
+// reports the reasoning breakdown in the terminal usage chunk (the bug: reasoning
+// was lumped into completion with no completion_tokens_details).
+func TestStreamingChatReasoningTokensInUsage(t *testing.T) {
+	logger := quietLogger()
+	srv := NewServer(registry.New(logger), store.NewMemory(store.Config{}), ServerConfig{}, logger)
+
+	pr := &registry.PendingRequest{
+		RequestID:  "job-1",
+		Model:      "gpt-oss-20b",
+		ChunkCh:    make(chan string, 8),
+		ErrorCh:    make(chan protocol.InferenceErrorMessage, 1),
+		CompleteCh: make(chan protocol.UsageInfo, 1),
+	}
+	// Provider streams a content delta, then the include_usage chunk WITHOUT a
+	// reasoning detail, then closes and reports the authoritative split via CompleteCh.
+	pr.ChunkCh <- `data: {"id":"c1","object":"chat.completion.chunk","model":"gpt-oss-20b","choices":[{"index":0,"delta":{"content":"hi"},"finish_reason":null}]}`
+	pr.ChunkCh <- `data: {"id":"c1","object":"chat.completion.chunk","model":"gpt-oss-20b","choices":[],"usage":{"prompt_tokens":10,"completion_tokens":50,"total_tokens":60}}`
+	close(pr.ChunkCh)
+	pr.CompleteCh <- protocol.UsageInfo{PromptTokens: 10, CompletionTokens: 50, ReasoningTokens: 8}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	rec := httptest.NewRecorder()
+	srv.handleStreamingResponseWithFirstChunk(rec, req, pr, "")
+
+	body := rec.Body.String()
+	if !strings.Contains(body, `"reasoning_tokens":8`) {
+		t.Fatalf("streaming usage missing reasoning_tokens; body=\n%s", body)
+	}
+	if !strings.Contains(body, `"completion_tokens":50`) {
+		t.Fatalf("completion_tokens should stay 50 (reasoning is a subset detail); body=\n%s", body)
+	}
+	if !strings.Contains(body, `"content":"hi"`) || !strings.Contains(body, "data: [DONE]") {
+		t.Fatalf("expected the content delta and [DONE]; body=\n%s", body)
+	}
+	if strings.Count(body, `"usage":{`) != 1 {
+		t.Fatalf("expected exactly one usage chunk (held + augmented, not doubled); body=\n%s", body)
+	}
+}


### PR DESCRIPTION
## Problem
Reasoning tokens were being lumped into `completion_tokens` with **no separate breakdown** for **streaming chat completions** — the most common path (chat UI, OpenAI SDK streaming). Consumers got `completion_tokens` (which includes reasoning) but no `completion_tokens_details.reasoning_tokens`.

## Root cause
The provider already counts reasoning tokens accurately and reports them via `UsageInfo.ReasoningTokens` over the WS (→ `CompleteCh`). The **non-streaming** chat path and **both Responses API** paths already splice that into the usage. But the **chat-completions streaming** handler (`handleStreamingResponseWithFirstChunk`) only forwarded the provider's terminal usage chunk verbatim — which carries `{prompt,completion,total}` but no `completion_tokens_details` — and never read `CompleteCh`. So streaming chat dropped the reasoning breakdown. (Added in #272, wired everywhere except chat streaming.)

## Fix
The streaming handler now **holds** the terminal `include_usage` chunk (empty `choices` + non-null `usage`) and re-emits it at stream end with `completion_tokens_details.reasoning_tokens` spliced in from the authoritative `UsageInfo` (`CompleteCh`) — reusing the existing `injectReasoningDetailIntoRawUsage`. OpenAI semantics preserved: `completion_tokens` stays the full output; `reasoning_tokens` is the subset.

- Single usage chunk (held + augmented, not doubled).
- No-op when there's no reasoning count or `stream_options.include_usage` wasn't requested.
- Backward compatible (an old provider reporting 0 reasoning → no detail).
- Hot-path safe: the per-chunk check early-returns without parsing for content deltas and `usage:null` chunks; only the one real usage chunk is parsed.

## Tests
- Helper unit test (`isUsageOnlyStreamChunk` / `injectReasoningIntoStreamUsageChunk`).
- Handler-level streaming test asserting `reasoning_tokens:8` in the final usage chunk, `completion_tokens` unchanged, exactly one usage chunk, content delta + `[DONE]` preserved.
- Full `api` suite green.

## Out of scope (optional follow-ups, found during investigation)
These are analytics/persistence, not the API output: usage records (`RecordUsage*`) don't persist `reasoning_tokens`; no `inference.reasoning_tokens` Datadog metric; console billing view doesn't show the reasoning split. Billing is already correct (reasoning is billed as completion — they're generated tokens).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/304"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783670352&installation_id=133247490&pr_number=304&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F304&signature=0cb7a19f84ab6fdc44ddb22af87f7fdc50203a87218676e5bdd054ff3f18db11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->