### PR TITLE
fix: handle two streaming-usage edge cases from Codex review (follow-up to #304)

### DIFF
--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -2499,29 +2499,38 @@ func (s *Server) handleStreamingResponseWithFirstChunk(w http.ResponseWriter, r 
 	// termination events (SE signature chunk + [DONE]).
 	sawResponsesAPI := false
 
+	// The terminal include_usage chunk lacks the reasoning breakdown; we hold its
+	// parsed object and re-emit it at stream end with the provider's authoritative
+	// reasoning count (CompleteCh) spliced in — matching the non-streaming/Responses
+	// paths. Held as a parsed map so it is decoded exactly once. Declared before the
+	// first-chunk write because a zero-delta completion (empty/filtered output) can
+	// make the include_usage frame the very first chunk.
+	var pendingUsage map[string]any
+
 	// Write the first chunk that was already consumed during dispatch.
 	if firstChunk != "" {
 		if strings.Contains(firstChunk, `"response.created"`) || strings.Contains(firstChunk, `"response.output_text.delta"`) {
 			sawResponsesAPI = true
 		}
-		if !sawResponsesAPI {
-			firstChunk = normalizeSSEChunk(firstChunk)
+		// A usage-only first chunk (no content/reasoning deltas streamed before it)
+		// is still terminal usage — hold it so the reasoning breakdown is spliced in
+		// at stream end instead of being emitted raw without reasoning_tokens.
+		if obj, isUsage := parseUsageOnlyStreamChunk(firstChunk); !sawResponsesAPI && isUsage {
+			pendingUsage = obj
+		} else {
+			if !sawResponsesAPI {
+				firstChunk = normalizeSSEChunk(firstChunk)
+			}
+			firstChunk = rewriteChunkModel(firstChunk, pr)
+			fmt.Fprintf(w, "%s\n\n", firstChunk)
+			flusher.Flush()
 		}
-		firstChunk = rewriteChunkModel(firstChunk, pr)
-		fmt.Fprintf(w, "%s\n\n", firstChunk)
-		flusher.Flush()
 	}
 
 	// Use a timer that resets on each chunk so long-running generations
 	// (e.g. chain-of-thought models) don't hit a global timeout.
 	timer := time.NewTimer(inferenceTimeout)
 	defer timer.Stop()
-
-	// The terminal include_usage chunk lacks the reasoning breakdown; we hold its
-	// parsed object and re-emit it at stream end with the provider's authoritative
-	// reasoning count (CompleteCh) spliced in — matching the non-streaming/Responses
-	// paths. Held as a parsed map so it is decoded exactly once.
-	var pendingUsage map[string]any
 
 	for {
 		select {
@@ -2590,6 +2599,19 @@ func (s *Server) handleStreamingResponseWithFirstChunk(w http.ResponseWriter, r 
 				}
 				return
 			}
+			// Every chunk is a liveness signal — re-arm the idle timeout up front,
+			// before deciding whether to forward or hold it, so holding the terminal
+			// usage chunk still resets the window that bounds the wait for the
+			// provider's inference_complete (which closes ChunkCh after billing).
+			// One reset covers both the forward and hold paths.
+			if !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
+			timer.Reset(inferenceTimeout)
+
 			if !sawResponsesAPI {
 				if strings.Contains(chunk, `"response.created"`) || strings.Contains(chunk, `"response.output_text.delta"`) {
 					sawResponsesAPI = true
@@ -2597,8 +2619,7 @@ func (s *Server) handleStreamingResponseWithFirstChunk(w http.ResponseWriter, r 
 			}
 			// Hold the terminal usage chunk (chat completions only) so we can splice
 			// in the reasoning breakdown at stream end; forwarding it inline would
-			// emit it without reasoning_tokens. The stream closes right after, so the
-			// running timer still guards a post-usage hang.
+			// emit it without reasoning_tokens.
 			if !sawResponsesAPI {
 				if obj, isUsage := parseUsageOnlyStreamChunk(chunk); isUsage {
 					pendingUsage = obj
@@ -2611,14 +2632,6 @@ func (s *Server) handleStreamingResponseWithFirstChunk(w http.ResponseWriter, r 
 			chunk = rewriteChunkModel(chunk, pr)
 			fmt.Fprintf(w, "%s\n\n", chunk)
 			flusher.Flush()
-
-			if !timer.Stop() {
-				select {
-				case <-timer.C:
-				default:
-				}
-			}
-			timer.Reset(inferenceTimeout)
 
 		case errMsg, ok := <-pr.ErrorCh:
 			if !ok {

--- a/coordinator/api/consumer_test.go
+++ b/coordinator/api/consumer_test.go
@@ -1741,3 +1741,44 @@ func TestStreamingChatReasoningTokensInUsage(t *testing.T) {
 		t.Fatalf("expected exactly one usage chunk (held + augmented, not doubled); body=\n%s", body)
 	}
 }
+
+// TestStreamingChatUsageOnlyFirstChunk covers the zero-delta case: a completion
+// that streams no content/reasoning deltas, so the include_usage frame is the very
+// FIRST chunk handed to the handler. It must still be held and have the reasoning
+// breakdown spliced in (not emitted raw), and must not be doubled.
+func TestStreamingChatUsageOnlyFirstChunk(t *testing.T) {
+	logger := quietLogger()
+	srv := NewServer(registry.New(logger), store.NewMemory(store.Config{}), ServerConfig{}, logger)
+
+	pr := &registry.PendingRequest{
+		RequestID:  "job-1",
+		Model:      "gpt-oss-20b",
+		ChunkCh:    make(chan string, 1),
+		ErrorCh:    make(chan protocol.InferenceErrorMessage, 1),
+		CompleteCh: make(chan protocol.UsageInfo, 1),
+	}
+	// No deltas at all — the stream closes immediately; the authoritative split
+	// arrives on CompleteCh.
+	close(pr.ChunkCh)
+	pr.CompleteCh <- protocol.UsageInfo{PromptTokens: 10, CompletionTokens: 50, ReasoningTokens: 8}
+
+	firstChunk := `data: {"id":"c1","object":"chat.completion.chunk","model":"gpt-oss-20b","choices":[],"usage":{"prompt_tokens":10,"completion_tokens":50,"total_tokens":60}}`
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	rec := httptest.NewRecorder()
+	srv.handleStreamingResponseWithFirstChunk(rec, req, pr, firstChunk)
+
+	body := rec.Body.String()
+	if !strings.Contains(body, `"reasoning_tokens":8`) {
+		t.Fatalf("usage-only first chunk must still get reasoning_tokens spliced; body=\n%s", body)
+	}
+	if !strings.Contains(body, `"completion_tokens":50`) {
+		t.Fatalf("completion_tokens should stay 50; body=\n%s", body)
+	}
+	if strings.Count(body, `"usage":{`) != 1 {
+		t.Fatalf("expected exactly one usage chunk (held + augmented, not raw + doubled); body=\n%s", body)
+	}
+	if !strings.Contains(body, "data: [DONE]") {
+		t.Fatalf("expected [DONE] terminator; body=\n%s", body)
+	}
+}


### PR DESCRIPTION
Follow-up to #304 (reasoning_tokens in chat-completions streaming). Codex flagged two edge cases after merge. **Neither affects normal streaming** — content deltas followed by a terminal \`include_usage\` frame within the 600s idle window already splices \`reasoning_tokens\` correctly — but both are real tail cases worth closing.

### 1. Usage-only first chunk (P2)
A zero-delta completion (empty/filtered output, or a backend that emits no content/reasoning deltas before usage) makes the \`include_usage\` frame the **very first chunk** handed to the handler. It was written raw, skipping the reasoning splice. Now \`firstChunk\` is routed through \`parseUsageOnlyStreamChunk\` and held like any terminal usage frame.

> Practical impact is ~nil (no reasoning text streamed ⇒ \`reasoning_tokens\` is 0 anyway), but it closes the gap relative to the stated guarantee.

Regression test: \`TestStreamingChatUsageOnlyFirstChunk\` (passes the usage frame as \`firstChunk\`, asserts reasoning spliced + single usage chunk + \`[DONE]\`).

### 2. Idle timer not re-armed on the hold path (P2)
#304 deduplicated the duplicated timer \`Stop()\`/\`Reset()\` (an earlier review note), but the two copies guarded different paths — the dedup dropped the reset on the usage-hold \`continue\`. So the wait for the provider's \`inference_complete\` (which closes \`ChunkCh\` after attestation/billing) was bounded from the **last content delta** instead of the **usage frame**. Harmless at \`inferenceTimeout = 600s\` (billing would have to stall 10 min to spuriously time out), but incorrect.

Fix: a **single** timer reset at the top of the chunk-received branch covering both the forward and hold paths — also resolves the original "duplicate timer" note properly.

## Verification
- \`go test ./api/\` green; \`gofmt\` clean.
- New + existing reasoning/streaming tests pass: \`TestStreamingChatUsageOnlyFirstChunk\`, \`TestStreamingChatReasoningTokensInUsage\`, \`TestUsageChunkParseAndFinalize\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/305"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783705354&installation_id=133247490&pr_number=305&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F305&signature=0a45e806d9fe9771ec275f7255e9bbd17236dc74d0d43c8441fce62927c71a0a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->