### PR TITLE
feat(provider): Gemma 4 MTP speculative decoding (engine + VLM image/video)

### DIFF
--- a/provider-swift/Sources/ProviderCore/Inference/BatchScheduler.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/BatchScheduler.swift
@@ -36,6 +36,7 @@ import os
 // `internal` (not `private`) so the BatchScheduler extension files
 // (e.g. +EngineBridge) can log under the same category.
 let prefixCacheLogger = Logger(subsystem: "dev.darkbloom.provider", category: "prefix-cache-wiring")
+let mtpLogger = Logger(subsystem: "dev.darkbloom.provider", category: "mtp-wiring")
 
 /// Continuous-batching scheduler. Wraps a single `MLXLMCommon.BatchedEngine`
 /// per loaded model. The engine owns the GPU step loop; this actor owns
@@ -490,6 +491,36 @@ public actor BatchScheduler {
         let engineTierOwner: EncryptedPrefixCachePersistence?
     }
 
+    // MARK: - MTP (Gemma 4 drafter speculative decoding) config
+
+    /// Whether drafter-based MTP is enabled. Off by default; opt in with
+    /// `DARKBLOOM_ENABLE_MTP=1` (also true/yes/on). Mirrors the
+    /// `DARKBLOOM_PREFIX_CACHE` parsing style but defaults OFF.
+    static func mtpEnabledFlag() -> Bool {
+        let v = ProcessInfo.processInfo.environment["DARKBLOOM_ENABLE_MTP"]?
+            .trimmingCharacters(in: .whitespaces).lowercased() ?? ""
+        return v == "1" || v == "true" || v == "yes" || v == "on"
+    }
+
+    /// Explicit drafter directory for MTP, from `DARKBLOOM_MTP_DRAFTER_PATH`.
+    /// v1 requires an explicit path (operator-controlled); manifest-driven
+    /// auto-discovery is a follow-up. Returns nil if unset/missing.
+    static func mtpDrafterPath() -> URL? {
+        guard let p = ProcessInfo.processInfo.environment["DARKBLOOM_MTP_DRAFTER_PATH"],
+              !p.isEmpty else { return nil }
+        let url = URL(fileURLWithPath: p)
+        return FileManager.default.fileExists(atPath: url.path) ? url : nil
+    }
+
+    /// Max active batch size that still speculates (`DARKBLOOM_MTP_MAX_BATCH`,
+    /// default 2). Above it the engine falls back to plain batched decode —
+    /// the MoE verify tax makes speculation ≈ break-even by B≈4.
+    static func mtpMaxBatch() -> Int {
+        guard let v = ProcessInfo.processInfo.environment["DARKBLOOM_MTP_MAX_BATCH"],
+              let n = Int(v), n >= 1 else { return 2 }
+        return n
+    }
+
     private static func makeBatchedEngine(
         container: ModelContainer,
         modelId: String,
@@ -500,6 +531,30 @@ public actor BatchScheduler {
         architecture: ModelArchitecture,
         diskAccountant: GlobalDiskAccountant? = nil
     ) async -> EngineBuild {
+        // MTP drafter (Gemma 4): load before `container.perform` (which is a
+        // sync, @Sendable closure) so the async weight load can be awaited and
+        // captured immutably. Bound to the target and attached to the scheduler
+        // inside the perform block. Off unless DARKBLOOM_ENABLE_MTP=1 and a
+        // drafter path is provided.
+        let mtpDrafter: Gemma4AssistantDraftModel? = await {
+            guard mtpEnabledFlag() else { return nil }
+            guard let drafterDir = mtpDrafterPath() else {
+                mtpLogger.warning(
+                    "DARKBLOOM_ENABLE_MTP set but DARKBLOOM_MTP_DRAFTER_PATH missing/invalid; using plain decode.")
+                return nil
+            }
+            do {
+                let d = try await Gemma4AssistantDraftModel.load(from: drafterDir)
+                eval(d)
+                mtpLogger.info("MTP enabled — drafter loaded from \(drafterDir.path)")
+                return d
+            } catch {
+                mtpLogger.error(
+                    "MTP enabled but drafter load failed (\(error)); using plain decode.")
+                return nil
+            }
+        }()
+        let mtpMaxBatchCap = mtpMaxBatch()
         // TB-007: the prefix cache is ON by default (operator decision) with an
         // ENCRYPTED-at-rest backend; opt out with DARKBLOOM_PREFIX_CACHE=0.
         // Encryption does NOT close the in-process cross-tenant sharing / TTFT
@@ -632,6 +687,30 @@ public actor BatchScheduler {
                 eosTokenIds: eosTokenIds,
                 prefixCache: enginePrefixCache  // nil unless .engine + flag (TB-007)
             )
+            // Attach the Gemma 4 MTP runtime if a drafter was loaded and the
+            // target is a Gemma 4 model. The scheduler threads it into every
+            // GenerationBatch it builds; eligibility (size ≤ maxBatch, greedy)
+            // is decided per decode step. Non-Gemma-4 or bind failure → plain
+            // decode (runtime stays nil).
+            if let drafter = mtpDrafter {
+                let target: Gemma4TextModel? =
+                    (ctx.model as? Gemma4TextModel)
+                    ?? (ctx.model as? Gemma4Model)?.textModel
+                if let target {
+                    do {
+                        scheduler.mtpRuntime = try Gemma4MTPEngineRuntime(
+                            target: target, drafter: drafter, maxBatch: mtpMaxBatchCap)
+                        mtpLogger.info(
+                            "MTP runtime attached for \(modelId) (maxBatch=\(mtpMaxBatchCap)).")
+                    } catch {
+                        mtpLogger.error("MTP bind failed (\(error)); using plain decode.")
+                    }
+                } else {
+                    mtpLogger.warning(
+                        "MTP enabled but \(modelId) is not a Gemma 4 model; using plain decode.")
+                }
+            }
+
             // Wire the checkpoint capture hook: store snapshots to the manager
             // out-of-band (the hook is sync on the engine queue; storing hops
             // to the manager actor via a detached Task). nil-safe: only set

--- a/provider-swift/Sources/ProviderCore/Inference/BatchScheduler.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/BatchScheduler.swift
@@ -230,6 +230,7 @@ public actor BatchScheduler {
             maxConcurrentRequests: maxConcurrentRequests,
             eosTokenIds: snapshot.eosTokenIds,
             architecture: snapshot.architecture,
+            mtpCapable: snapshot.mtpCapable,
             diskAccountant: diskAccountant
         )
         let engine = build.engine
@@ -380,11 +381,18 @@ public actor BatchScheduler {
             } else {
                 architecture = .empty
             }
+            // MTP-capability by the actual loaded type (not model_type strings
+            // or aliases): the Gemma 4 text towers and the MLXVLM Gemma 4 tower.
+            let mtpCapable =
+                ctx.model is Gemma4TextModel
+                || ctx.model is Gemma4Model
+                || ctx.model is MLXVLM.Gemma4
             return LoadSnapshot(
                 bytes: bytes,
                 tokenizer: TokenizerHandle(ctx.tokenizer),
                 eosTokenIds: ctx.configuration.eosTokenIds,
-                architecture: architecture
+                architecture: architecture,
+                mtpCapable: mtpCapable
             )
         }
     }
@@ -558,6 +566,7 @@ public actor BatchScheduler {
         maxConcurrentRequests: Int,
         eosTokenIds: Set<Int>,
         architecture: ModelArchitecture,
+        mtpCapable: Bool,
         diskAccountant: GlobalDiskAccountant? = nil
     ) async -> EngineBuild {
         // MTP drafter (Gemma 4): load before `container.perform` (which is a
@@ -567,6 +576,15 @@ public actor BatchScheduler {
         // drafter path is provided.
         let mtpDrafter: Gemma4AssistantDraftModel? = await {
             guard mtpEnabledFlag() else { return nil }
+            // Skip the (large) drafter load for non-Gemma models — on a
+            // multi-model provider with MTP globally enabled, the drafter is
+            // unusable for Qwen/Llama/etc. and would only waste load time + GPU
+            // memory before falling back to plain decode.
+            guard mtpCapable else {
+                mtpLogger.info(
+                    "DARKBLOOM_ENABLE_MTP set but \(modelId) is not an MTP-capable Gemma 4 model; skipping drafter load.")
+                return nil
+            }
             guard let drafterDir = mtpDrafterPath() else {
                 mtpLogger.warning(
                     "DARKBLOOM_ENABLE_MTP set but DARKBLOOM_MTP_DRAFTER_PATH missing/invalid; using plain decode.")

--- a/provider-swift/Sources/ProviderCore/Inference/BatchScheduler.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/BatchScheduler.swift
@@ -31,6 +31,7 @@ import Foundation
 import MLX
 import MLXLLM
 import MLXLMCommon
+import MLXVLM
 import os
 
 // `internal` (not `private`) so the BatchScheduler extension files
@@ -89,6 +90,19 @@ public actor BatchScheduler {
     /// deregistered at stopCurrentEngine.
     var engineTierOwner: EncryptedPrefixCachePersistence?
     var engineTierAccountantToken: AccountantToken?
+
+    /// MTP drafter bound to a VLM (image/video) tower. Non-nil only when the
+    /// loaded model is an `MLXVLM.Gemma4` AND MTP is enabled
+    /// (`DARKBLOOM_ENABLE_MTP=1` + `DARKBLOOM_MTP_DRAFTER_PATH`). The
+    /// non-batched vision path (`VLMRequestInference.stream`) reads this to
+    /// route greedy multimodal decode through MTP speculative decoding. nil ⇒
+    /// vision decode uses the plain `container.generate` path. Set by
+    /// `loadModel` from the `EngineBuild` (built by the static
+    /// `makeBatchedEngine`, which can't touch `self`).
+    var vlmMtpDrafter: Gemma4AssistantDraftModel?
+    /// Single-stream MTP speculative block size for the VLM vision path.
+    /// Default 3 (the B=1 default proven for Gemma 4).
+    var vlmMtpBlockSize: Int = 3
 
     /// Admission control + token budget tracking. `nil` until `loadModel()`.
     var planner: BatchQueuePlanner?
@@ -230,6 +244,11 @@ public actor BatchScheduler {
         self.checkpointManager = build.checkpointManager
         self.checkpointBoundaries = build.checkpointBoundaries
         self.engineTierOwner = build.engineTierOwner
+        // MTP drafter for the non-batched VLM vision path. nil for text
+        // models / when MTP is off — the vision stream then uses plain
+        // `container.generate`. (Text models bind the drafter into the
+        // engine runtime inside `makeBatchedEngine` instead.)
+        self.vlmMtpDrafter = build.vlmMtpDrafter
         await engine.start()
         // Final epoch check after start() — start can suspend too.
         // Identity-checked cleanup — only nil self.engine if it's
@@ -240,6 +259,7 @@ public actor BatchScheduler {
             if self.checkpointManager === build.checkpointManager { self.checkpointManager = nil }
             if self.checkpointBoundaries == build.checkpointBoundaries { self.checkpointBoundaries = [] }
             if self.engineTierOwner === build.engineTierOwner { self.engineTierOwner = nil }
+            if self.vlmMtpDrafter === build.vlmMtpDrafter { self.vlmMtpDrafter = nil }
             await engine.stop()
             return
         }
@@ -282,6 +302,7 @@ public actor BatchScheduler {
             if self.checkpointManager === build.checkpointManager { self.checkpointManager = nil }
             if self.checkpointBoundaries == build.checkpointBoundaries { self.checkpointBoundaries = [] }
             if self.engineTierOwner === build.engineTierOwner { self.engineTierOwner = nil }
+            if self.vlmMtpDrafter === build.vlmMtpDrafter { self.vlmMtpDrafter = nil }
             await engine.stop()
             return
         }
@@ -320,6 +341,7 @@ public actor BatchScheduler {
                     if self.checkpointManager === build.checkpointManager { self.checkpointManager = nil }
                     if self.checkpointBoundaries == build.checkpointBoundaries { self.checkpointBoundaries = [] }
                     if self.engineTierOwner === build.engineTierOwner { self.engineTierOwner = nil }
+                    if self.vlmMtpDrafter === build.vlmMtpDrafter { self.vlmMtpDrafter = nil }
                     await engine.stop()
                     return
                 }
@@ -489,6 +511,13 @@ public actor BatchScheduler {
         let checkpointManager: PrefixCacheManager?
         let checkpointBoundaries: [Int]
         let engineTierOwner: EncryptedPrefixCachePersistence?
+        /// The MTP drafter bound to a VLM (image/video) tower, when the
+        /// loaded model is an `MLXVLM.Gemma4` and MTP is enabled. nil for
+        /// text models (those bind the drafter into the engine's
+        /// `Gemma4MTPEngineRuntime` instead) and whenever MTP is off. The
+        /// caller stores this on the `BatchScheduler` so the non-batched VLM
+        /// vision path can route its decode through MTP speculative decoding.
+        let vlmMtpDrafter: Gemma4AssistantDraftModel?
     }
 
     // MARK: - MTP (Gemma 4 drafter speculative decoding) config
@@ -692,6 +721,15 @@ public actor BatchScheduler {
             // GenerationBatch it builds; eligibility (size ≤ maxBatch, greedy)
             // is decided per decode step. Non-Gemma-4 or bind failure → plain
             // decode (runtime stays nil).
+            //
+            // VLM (image/video) models never flow through the batched engine
+            // for multimodal requests — those are served by the non-batched
+            // `VLMRequestInference.stream` vision path. So the text-target cast
+            // below is nil for an `MLXVLM.Gemma4`. In that case we bind the SAME
+            // drafter to the VLM tower and hand it out via `EngineBuild` so the
+            // vision path can route greedy decode through MTP. Carried out of
+            // this static closure on `vlmMtpDrafter`.
+            var vlmMtpDrafter: Gemma4AssistantDraftModel? = nil
             if let drafter = mtpDrafter {
                 let target: Gemma4TextModel? =
                     (ctx.model as? Gemma4TextModel)
@@ -704,6 +742,18 @@ public actor BatchScheduler {
                             "MTP runtime attached for \(modelId) (maxBatch=\(mtpMaxBatchCap)).")
                     } catch {
                         mtpLogger.error("MTP bind failed (\(error)); using plain decode.")
+                    }
+                } else if let vlm = ctx.model as? MLXVLM.Gemma4 {
+                    // VLM tower: bind the drafter to it for the non-batched
+                    // vision path. `bind` is idempotent on the same target.
+                    do {
+                        try drafter.bind(target: vlm)
+                        vlmMtpDrafter = drafter
+                        mtpLogger.info(
+                            "MTP drafter bound to VLM tower for \(modelId); vision decode will speculate.")
+                    } catch {
+                        mtpLogger.error(
+                            "MTP VLM bind failed for \(modelId) (\(error)); vision decode uses plain generate.")
                     }
                 } else {
                     mtpLogger.warning(
@@ -743,7 +793,8 @@ public actor BatchScheduler {
                 ),
                 checkpointManager: checkpointManager,
                 checkpointBoundaries: boundaries,
-                engineTierOwner: engineTierOwner
+                engineTierOwner: engineTierOwner,
+                vlmMtpDrafter: vlmMtpDrafter
             )
         }
     }
@@ -1469,6 +1520,10 @@ public actor BatchScheduler {
         self.engine = nil
         modelContainer = nil
         tokenizer = nil
+        // Drop the VLM MTP drafter so its weights are freed on unload (the next
+        // model's loadModel reinstalls its own, or nil). Without this the
+        // drafter's GPU weights are retained until the field is overwritten.
+        vlmMtpDrafter = nil
         // Persist any coalesced index writes before dropping the manager, so
         // checkpoints written since the last coalesced save survive restart.
         if let mgr = checkpointManager {

--- a/provider-swift/Sources/ProviderCore/Inference/BatchSchedulerTypes.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/BatchSchedulerTypes.swift
@@ -76,6 +76,11 @@ struct LoadSnapshot: @unchecked Sendable {
     let tokenizer: TokenizerHandle
     let eosTokenIds: Set<Int>
     let architecture: ModelArchitecture
+    /// Whether the resident model is an MTP-capable Gemma 4 tower (text or
+    /// VLM). Gates the (potentially large) drafter weight load: with MTP
+    /// globally enabled on a multi-model provider, a non-Gemma model load
+    /// must not allocate the unusable drafter.
+    let mtpCapable: Bool
 }
 
 /// Model-architecture fields read from `config.json`, used by

--- a/provider-swift/Sources/ProviderCore/Inference/MultiModelBatchSchedulerEngine.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/MultiModelBatchSchedulerEngine.swift
@@ -193,8 +193,15 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
         // batched engine. For VLM models, serve them via the container's
         // non-batched prepare/generate vision path.
         if isVLM, let container, VLMRequestInference.hasMedia(request) {
+            // Route greedy multimodal decode through MTP speculative decoding
+            // when the model is an MTP-capable VLM with a bound drafter
+            // (non-nil only with DARKBLOOM_ENABLE_MTP + a drafter path). nil ⇒
+            // the vision path uses the plain prepare/generate path unchanged.
+            let vlmMtpDrafter = await scheduler.vlmMtpDrafter
+            let vlmMtpBlockSize = await scheduler.vlmMtpBlockSize
             let vlmStream = VLMRequestInference.stream(
-                container: container, request: request, defaultMaxTokens: defaultMaxTokens)
+                container: container, request: request, defaultMaxTokens: defaultMaxTokens,
+                mtpDrafter: vlmMtpDrafter, mtpBlockSize: vlmMtpBlockSize)
             return AsyncThrowingStream { continuation in
                 let task = Task {
                     do {

--- a/provider-swift/Sources/ProviderCore/Inference/VLMRequestInference.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/VLMRequestInference.swift
@@ -148,9 +148,16 @@ public enum VLMRequestInference {
                     // to the existing prepare/generate path below, unchanged.
                     let repPenaltyNeutral =
                         params.repetitionPenalty == nil || params.repetitionPenalty == 1.0
+                    // Tool-call requests must stay on the library generate path:
+                    // `streamMTP` only emits `.content`/`.info`, so taking the MTP
+                    // branch would drop the structured `.toolCall` events the plain
+                    // path surfaces — changing the wire response. Gate MTP off when
+                    // the request carries tools.
+                    let noTools = request.tools?.isEmpty ?? true
                     if let drafter = mtpDrafter,
                         params.temperature == 0,
-                        repPenaltyNeutral
+                        repPenaltyNeutral,
+                        noTools
                     {
                         let handled = try await streamMTP(
                             container: container,

--- a/provider-swift/Sources/ProviderCore/Inference/VLMRequestInference.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/VLMRequestInference.swift
@@ -17,8 +17,10 @@
 
 import CoreImage
 import Foundation
+import MLXLLM
 import MLXLMCommon
 import MLXLMServer
+import MLXVLM
 
 /// Namespace for the non-batched VLM (image/video) inference path.
 ///
@@ -98,7 +100,9 @@ public enum VLMRequestInference {
     public static func stream(
         container: ModelContainer,
         request: OpenAIChatCompletionRequest,
-        defaultMaxTokens: Int
+        defaultMaxTokens: Int,
+        mtpDrafter: Gemma4AssistantDraftModel? = nil,
+        mtpBlockSize: Int = 3
     ) -> AsyncThrowingStream<MLXServerGenerationEvent, Error> {
         AsyncThrowingStream { continuation in
             let task = Task {
@@ -135,6 +139,35 @@ public enum VLMRequestInference {
                         topK: request.topK ?? 0,
                         repetitionPenalty: request.repetitionPenalty
                     )
+
+                    // MTP speculative-decode gate. MTP only matches the plain
+                    // decode byte-for-byte under GREEDY sampling (temperature 0)
+                    // with no repetition penalty, so it is gated to exactly that
+                    // case. Any other sampling config (temperature > 0, top-k/p
+                    // tweaks paired with sampling, repetition penalty) falls back
+                    // to the existing prepare/generate path below, unchanged.
+                    let repPenaltyNeutral =
+                        params.repetitionPenalty == nil || params.repetitionPenalty == 1.0
+                    if let drafter = mtpDrafter,
+                        params.temperature == 0,
+                        repPenaltyNeutral
+                    {
+                        let handled = try await streamMTP(
+                            container: container,
+                            lmInput: lmInput,
+                            params: params,
+                            drafter: drafter,
+                            blockSize: mtpBlockSize,
+                            startedAt: startedAt,
+                            continuation: continuation)
+                        // `streamMTP` returns true when it served the request
+                        // (it finished the stream itself). false ⇒ the model was
+                        // not an MTP-capable VLM tower; fall through to plain
+                        // generate so we never drop the request.
+                        if handled { return }
+                        mtpLogger.warning(
+                            "VLM MTP requested but model is not an MLXVLM.Gemma4 tower; using plain generate.")
+                    }
 
                     let genStream = try await container.generate(
                         input: lmInput, parameters: params)
@@ -193,6 +226,132 @@ public enum VLMRequestInference {
             continuation.onTermination = { @Sendable _ in
                 task.cancel()
             }
+        }
+    }
+
+    // MARK: - MTP speculative vision decode
+
+    /// Run the multimodal decode through Gemma 4 MTP speculative decoding.
+    ///
+    /// The whole decode runs inside `container.perform` so model access stays
+    /// single-threaded (the container's contract). We seed the drafter from a
+    /// multimodal prefill (`forwardForMTPMultimodal`, which merges the image /
+    /// video features), then drive `Gemma4MTPTokenIterator` round-by-round.
+    /// Each yielded token id is decoded to text exactly like the library's
+    /// `generateGemma4MTP` (`tokenizer.decode(tokenIds:[tok])`) and streamed.
+    ///
+    /// Returns `true` when it served the request (and finished the stream
+    /// itself); `false` when the loaded model is not an `MLXVLM.Gemma4` tower,
+    /// in which case the caller falls back to the plain generate path.
+    /// Throws on prefill / iterator-init failure so the caller's `catch`
+    /// finishes the stream with the error.
+    private static func streamMTP(
+        container: ModelContainer,
+        lmInput: LMInput,
+        params: GenerateParameters,
+        drafter: Gemma4AssistantDraftModel,
+        blockSize: Int,
+        startedAt: Date,
+        continuation: AsyncThrowingStream<MLXServerGenerationEvent, Error>.Continuation
+    ) async throws -> Bool {
+        // `LMInput` is non-Sendable; hand it across the container's isolation
+        // boundary via the `nonSendable` perform overload rather than capturing
+        // it in the @Sendable closure.
+        try await container.perform(nonSendable: lmInput) { ctx, lmInput in
+            guard let vlm = ctx.model as? MLXVLM.Gemma4 else {
+                return false
+            }
+
+            let promptTokens = lmInput.text.tokens.size
+            // Full stop-token set, mirroring the baseline generate loop
+            // (`buildStopTokenIds`): model EOS ids ∪ the tokenizer's EOS ∪ the
+            // resolved `extraEOSTokens`; the unknown-token id is also treated as
+            // a stop. Using only `configuration.eosTokenIds` could fail to
+            // terminate on a tokenizer/extra EOS not present in that set.
+            var stopTokenIds = ctx.configuration.eosTokenIds
+            if let tokenizerEOS = ctx.tokenizer.eosTokenId {
+                stopTokenIds.insert(tokenizerEOS)
+            }
+            for token in ctx.configuration.extraEOSTokens {
+                if let id = ctx.tokenizer.convertTokenToId(token) {
+                    stopTokenIds.insert(id)
+                }
+            }
+            let unknownId = ctx.tokenizer.unknownTokenId
+            // Cap output length the same way the library default does when the
+            // caller leaves it open-ended.
+            var p = params
+            if p.maxTokens == nil { p.maxTokens = 1024 }
+            let maxTokens = p.maxTokens
+
+            // Seed: multimodal prefill (vision merge + capturing forward),
+            // then a prefilled-state MTP iterator over text-only decode rounds.
+            let cache = vlm.mtpNewCache(parameters: p)
+            let prefill = try vlm.forwardForMTPMultimodal(lmInput, cache: cache)
+            var iter = try Gemma4MTPTokenIterator(
+                prefill: prefill,
+                cache: cache,
+                target: vlm,
+                drafter: drafter,
+                parameters: p,
+                blockSize: blockSize)
+
+            // Streaming detokenizer: buffers a token whose decoded segment ends
+            // mid-codepoint (U+FFFD) and emits only complete text — so CJK /
+            // emoji / accented output is never split into mojibake. Per-token
+            // `decode([id])` (what this replaces) breaks multi-token glyphs.
+            var detokenizer = NaiveStreamingDetokenizer(tokenizer: ctx.tokenizer)
+
+            var completionTokens = 0
+            var firstTokenAt: Date?
+            var lastTokenAt: Date?
+            // Default "length"; flipped to "stop" on an EOS token. Mirrors the
+            // batched + library paths (maxTokens hit ⇒ "length", EOS ⇒ "stop").
+            var stopReason = "length"
+
+            while let tokenId = iter.next() {
+                if Task.isCancelled {
+                    continuation.finish()
+                    return true
+                }
+                // Stop tokens terminate WITHOUT being emitted or counted —
+                // parity with the baseline generate loop (which counts only
+                // non-stop tokens and never emits the EOS text).
+                if tokenId == unknownId || stopTokenIds.contains(tokenId) {
+                    stopReason = "stop"
+                    break
+                }
+                if firstTokenAt == nil { firstTokenAt = Date() }
+                lastTokenAt = Date()
+                completionTokens += 1
+
+                detokenizer.append(token: tokenId)
+                if let chunkText = detokenizer.next(), !chunkText.isEmpty {
+                    continuation.yield(.content(chunkText))
+                }
+
+                if let maxTokens, completionTokens >= maxTokens {
+                    stopReason = "length"
+                    break
+                }
+            }
+
+            let promptTime = (firstTokenAt ?? startedAt).timeIntervalSince(startedAt)
+            let generationTime = (lastTokenAt ?? firstTokenAt ?? startedAt)
+                .timeIntervalSince(firstTokenAt ?? startedAt)
+            continuation.yield(
+                .info(
+                    ServerGenerationInfo(
+                        promptTokens: promptTokens,
+                        completionTokens: completionTokens,
+                        promptTime: max(0, promptTime),
+                        generationTime: max(0, generationTime),
+                        stopReason: stopReason
+                    )
+                )
+            )
+            continuation.finish()
+            return true
         }
     }
 

--- a/provider-swift/Tests/ProviderCoreTests/VLMRequestInferenceMTPLiveTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/VLMRequestInferenceMTPLiveTests.swift
@@ -1,0 +1,300 @@
+// Live, real-image end-to-end coverage for the VLM MTP speculative-decode
+// path (`VLMRequestInference.stream` with `mtpDrafter:`).
+//
+// This is the final proof that multimodal Gemma 4 MTP works against a real
+// image and a real ~14 GB qat-4bit VLM tower + its qat-4bit assistant
+// drafter, through the exact `ModelContainer` / `container.perform` path
+// ProviderLoop serves with. It runs TWO streams over the same request — a
+// plain (mtpDrafter: nil) baseline and an MTP stream — and asserts the MTP
+// output is coherent and broadly similar to the baseline.
+//
+// Gated by VLM_MTP_E2E=1 and requires both checkpoints in the local cache.
+// Skips cleanly (recorded as a warning) when any precondition is unmet, so
+// the default suite on a model-less / GPU-less runner stays green.
+//
+//   cd provider-swift
+//   VLM_MTP_E2E=1 swift test --filter vlmMTPRealImageEndToEnd 2>&1 | tail -60
+//
+// NOTE on byte-identity: MTP and plain are NOT asserted byte-equal. The
+// VLM tower verifies several drafted tokens per round in a single batched
+// forward, and bf16 rounding makes a handful of near-tie logits resolve
+// differently between the width-1 (plain) and width-N (verify) passes. That
+// divergence is known and accepted; we assert a *loose* similarity (shared
+// prefix or strong word overlap) instead of equality.
+
+import CoreImage
+import Foundation
+import Testing
+import MLX
+import MLXLLM
+import MLXLMCommon
+import MLXLMServer
+import MLXVLM
+
+@testable import ProviderCore
+
+private enum VLMMTPLiveFixtures {
+
+    /// Opt-in env var for this (expensive, ~14 GB) live test.
+    static let envVar = "VLM_MTP_E2E"
+
+    static var enabled: Bool {
+        ProcessInfo.processInfo.environment[envVar].map { !$0.isEmpty } ?? false
+    }
+
+    /// Multimodal Gemma 4 target (config declares `vision_config`).
+    /// Overridable via VLM_MTP_TARGET_DIR for a differently-located snapshot.
+    static var targetDir: String {
+        ProcessInfo.processInfo.environment["VLM_MTP_TARGET_DIR"]
+            ?? "/Users/gaj/.cache/huggingface/hub/models--mlx-community--gemma-4-26B-A4B-it-qat-4bit/snapshots/0e3cbab38ce568cf6e23543010d08d03b731910c"
+    }
+
+    /// Matching qat-4bit assistant drafter. Overridable via VLM_MTP_DRAFTER_DIR.
+    static var drafterDir: String {
+        ProcessInfo.processInfo.environment["VLM_MTP_DRAFTER_DIR"]
+            ?? "/Users/gaj/.cache/huggingface/hub/models--mlx-community--gemma-4-26B-A4B-it-qat-assistant-4bit/snapshots/bb94eae1b70a80dac16cbf959bb4b7d56bd1fb8c"
+    }
+
+    /// First existing candidate image, or nil if none are present.
+    static var testImage: URL? {
+        let candidates = [
+            ProcessInfo.processInfo.environment["VLM_MTP_IMAGE"],
+            "/Users/gaj/Downloads/eigen-labs-logo.png",
+            "/Users/gaj/Downloads/exo-logo.png",
+        ].compactMap { $0 }
+        for path in candidates where FileManager.default.fileExists(atPath: path) {
+            return URL(fileURLWithPath: path)
+        }
+        return nil
+    }
+}
+
+/// Outcome of consuming one `VLMRequestInference.stream`.
+private struct StreamRun {
+    var text: String
+    var completionTokens: Int
+    var promptTokens: Int
+    var generationTime: TimeInterval
+    /// Wall-clock seconds around stream consumption.
+    var wallSeconds: Double
+
+    /// Decode tokens/sec from the engine-reported generation time, falling
+    /// back to wall clock when the engine didn't report a positive time.
+    var tokensPerSecond: Double {
+        if generationTime > 0 { return Double(completionTokens) / generationTime }
+        if wallSeconds > 0 { return Double(completionTokens) / wallSeconds }
+        return 0
+    }
+}
+
+@Suite("VLM MTP real-image end-to-end (live)", .serialized)
+struct VLMRequestInferenceMTPLiveTests {
+
+    @Test(
+        "VLM MTP describes a real image, coherent and similar to plain decode",
+        .enabled(if: VLMMTPLiveFixtures.enabled)
+    )
+    func vlmMTPRealImageEndToEnd() async throws {
+        // 0. Preconditions — skip cleanly (recorded warning) if unmet so the
+        //    default suite stays green on a runner without these assets.
+        guard LiveInferenceFixtures.ensureMetallibColocated() != nil else {
+            withKnownIssue("skipped: \(LiveFixtureSkip.missingMetallib)") {
+                Issue.record("\(LiveFixtureSkip.missingMetallib)")
+            }
+            return
+        }
+        let targetURL = URL(fileURLWithPath: VLMMTPLiveFixtures.targetDir)
+        let drafterURL = URL(fileURLWithPath: VLMMTPLiveFixtures.drafterDir)
+        let fm = FileManager.default
+        guard fm.fileExists(atPath: targetURL.appendingPathComponent("config.json").path) else {
+            withKnownIssue("skipped: VLM target not found at \(targetURL.path)") {
+                Issue.record("VLM target not found at \(targetURL.path)")
+            }
+            return
+        }
+        guard fm.fileExists(atPath: drafterURL.appendingPathComponent("config.json").path) else {
+            withKnownIssue("skipped: drafter not found at \(drafterURL.path)") {
+                Issue.record("drafter not found at \(drafterURL.path)")
+            }
+            return
+        }
+        guard let imageURL = VLMMTPLiveFixtures.testImage else {
+            withKnownIssue("skipped: no test image present") {
+                Issue.record("no test image present (set VLM_MTP_IMAGE)")
+            }
+            return
+        }
+
+        // Cap MLX memory the same way ProviderLoop does; this is a big model.
+        LiveInferenceFixtures.applyMemoryBudget(maxBytes: 24 * 1024 * 1024 * 1024)
+
+        // 1. Load the real VLM ModelContainer via the SAME factory path
+        //    ProviderLoop.loadModelContainer uses for a vision_config model.
+        #expect(
+            ProviderLoop.modelIsVLM(at: targetURL),
+            "target must declare vision_config to exercise the VLM path")
+        let container = try await VLMModelFactory.shared.loadContainer(
+            from: targetURL,
+            using: LocalTokenizerLoader()
+        )
+
+        // 2. Load the assistant drafter.
+        let drafter = try await Gemma4AssistantDraftModel.load(from: drafterURL)
+
+        // 3. Build the OpenAI request: one text part + one inline base64 image.
+        let imageBytes = try Data(contentsOf: imageURL)
+        let dataURI = "data:image/png;base64," + imageBytes.base64EncodedString()
+        let request = OpenAIChatCompletionRequest(
+            model: "gemma-4-vlm",
+            messages: [
+                .init(
+                    role: .user,
+                    content: .parts([
+                        .text("Describe this image in one sentence."),
+                        .imageURL(dataURI),
+                    ]))
+            ],
+            temperature: 0,
+            maxTokens: 64
+        )
+        #expect(VLMRequestInference.hasMedia(request), "request must be detected as multimodal")
+
+        // 4. Run TWO streams: plain baseline, then MTP.
+        let plain = try await runStream(
+            container: container, request: request, drafter: nil)
+        let mtp = try await runStream(
+            container: container, request: request, drafter: drafter)
+
+        // 5. Coherence + similarity assertions.
+        let plainTrim = plain.text.trimmingCharacters(in: .whitespacesAndNewlines)
+        let mtpTrim = mtp.text.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        let letterCount = mtpTrim.filter { $0.isLetter }.count
+        let coherent = mtpTrim.count > 0 && letterCount >= 10 && !isDegenerate(mtpTrim)
+
+        let prefix = commonPrefixLength(plainTrim, mtpTrim)
+        let jaccard = wordJaccard(plainTrim, mtpTrim)
+        // "Similar" = a meaningful shared prefix OR strong word overlap. bf16
+        // near-ties in the width-N verify pass can flip a token mid-stream, so
+        // we deliberately do NOT require byte-identity.
+        let similar = prefix >= 8 || jaccard >= 0.4
+
+        let speedup = plain.tokensPerSecond > 0
+            ? mtp.tokensPerSecond / plain.tokensPerSecond : 0
+
+        // 6. Full diagnostic dump for the manual record.
+        print("================ VLM MTP real-image E2E ================")
+        print("image: \(imageURL.lastPathComponent)  (\(imageBytes.count) bytes)")
+        print("target: \(VLMMTPLiveFixtures.targetDir)")
+        print("drafter: \(VLMMTPLiveFixtures.drafterDir)")
+        print("----------------- PLAIN (baseline) --------------------")
+        print(plainTrim)
+        print("[plain] completion_tokens=\(plain.completionTokens) "
+            + "prompt_tokens=\(plain.promptTokens) "
+            + String(format: "tok/s=%.2f wall=%.2fs gen=%.2fs",
+                plain.tokensPerSecond, plain.wallSeconds, plain.generationTime))
+        print("----------------- MTP ---------------------------------")
+        print(mtpTrim)
+        print("[mtp]   completion_tokens=\(mtp.completionTokens) "
+            + "prompt_tokens=\(mtp.promptTokens) "
+            + String(format: "tok/s=%.2f wall=%.2fs gen=%.2fs",
+                mtp.tokensPerSecond, mtp.wallSeconds, mtp.generationTime))
+        print("----------------- SIMILARITY --------------------------")
+        print(String(
+            format: "common_prefix_chars=%d  word_jaccard=%.3f  speedup=%.2fx  coherent=%@  similar=%@",
+            prefix, jaccard, speedup,
+            coherent ? "yes" : "no", similar ? "yes" : "no"))
+        print("=======================================================")
+
+        // Assertions.
+        let coherentMsg = "MTP output must be coherent (>=10 letters, not degenerate): \(mtpTrim.prefix(120))"
+        let similarMsg = "MTP must be loosely similar to plain (prefix=\(prefix) jaccard=\(jaccard)). "
+            + "plain=<\(plainTrim.prefix(120))> mtp=<\(mtpTrim.prefix(120))>"
+        #expect(mtpTrim.count > 0, "MTP output must be non-empty")
+        #expect(coherent, "\(coherentMsg)")
+        #expect(plainTrim.count > 0, "plain baseline must be non-empty")
+        #expect(similar, "\(similarMsg)")
+    }
+
+    // MARK: - Stream consumption
+
+    /// Consume one `VLMRequestInference.stream`, timing the wall clock around
+    /// the iteration and collecting content + the final `.info`.
+    private func runStream(
+        container: ModelContainer,
+        request: OpenAIChatCompletionRequest,
+        drafter: Gemma4AssistantDraftModel?
+    ) async throws -> StreamRun {
+        let stream = VLMRequestInference.stream(
+            container: container,
+            request: request,
+            defaultMaxTokens: 64,
+            mtpDrafter: drafter,
+            mtpBlockSize: 3
+        )
+        var text = ""
+        var completionTokens = 0
+        var promptTokens = 0
+        var generationTime: TimeInterval = 0
+        let start = Date()
+        for try await event in stream {
+            switch event {
+            case .content(let chunk):
+                text += chunk
+            case .info(let info):
+                completionTokens = info.completionTokens
+                promptTokens = info.promptTokens
+                generationTime = info.generationTime
+            case .toolCall:
+                continue
+            }
+        }
+        let wall = Date().timeIntervalSince(start)
+        return StreamRun(
+            text: text,
+            completionTokens: completionTokens,
+            promptTokens: promptTokens,
+            generationTime: generationTime,
+            wallSeconds: wall)
+    }
+
+    // MARK: - Similarity / coherence helpers
+
+    /// Length (in characters) of the common leading prefix of two strings.
+    private func commonPrefixLength(_ a: String, _ b: String) -> Int {
+        var count = 0
+        var ai = a.startIndex
+        var bi = b.startIndex
+        while ai < a.endIndex, bi < b.endIndex, a[ai] == b[bi] {
+            count += 1
+            ai = a.index(after: ai)
+            bi = b.index(after: bi)
+        }
+        return count
+    }
+
+    /// Jaccard similarity over lowercased word sets.
+    private func wordJaccard(_ a: String, _ b: String) -> Double {
+        let wa = Set(words(a))
+        let wb = Set(words(b))
+        if wa.isEmpty && wb.isEmpty { return 1 }
+        let inter = wa.intersection(wb).count
+        let union = wa.union(wb).count
+        return union == 0 ? 0 : Double(inter) / Double(union)
+    }
+
+    private func words(_ s: String) -> [String] {
+        s.lowercased()
+            .components(separatedBy: CharacterSet.alphanumerics.inverted)
+            .filter { !$0.isEmpty }
+    }
+
+    /// Detect obviously-broken output: a single token/word repeated many
+    /// times with almost no lexical variety.
+    private func isDegenerate(_ s: String) -> Bool {
+        let ws = words(s)
+        guard ws.count >= 6 else { return false }
+        let unique = Set(ws).count
+        return Double(unique) / Double(ws.count) < 0.2
+    }
+}


### PR DESCRIPTION
## Provider: Gemma 4 MTP speculative decoding (engine + VLM)

Opt-in drafter-based MTP speculative decoding in the provider. Bumps `mlx-swift-lm` to the MTP engine + vision-tower support (Layr-Labs/mlx-swift-lm#35). **Off by default** — no serving behavior change until an operator sets `DARKBLOOM_ENABLE_MTP=1`.

### Text (batched engine)
- Loads a Gemma 4 drafter (gated on `DARKBLOOM_ENABLE_MTP` + `DARKBLOOM_MTP_DRAFTER_PATH`), binds it to the text target, and attaches the engine MTP runtime. Speculates at `B ≤ DARKBLOOM_MTP_MAX_BATCH` (default 2), plain decode above. Greedy rows only.

### VLM (image/video) — this PR's focus
- When the loaded model is an MLXVLM Gemma 4, the same drafter is bound to the **vision tower** and stashed on the scheduler.
- `VLMRequestInference` gains an MTP branch: when a drafter is bound, the request is greedy (`temperature == 0`, no repetition penalty), and the model is a Gemma 4 VLM, it decodes via multimodal MTP prefill + `Gemma4MTPTokenIterator`. Otherwise the existing `container.generate` path runs **unchanged**.
- Streams via `NaiveStreamingDetokenizer` (correct multi-byte/CJK/emoji), the full stop-token set (model EOS ∪ tokenizer EOS ∪ extra-EOS ∪ unknown), EOS suppressed + not counted, `maxTokens` + cancellation honored. Drafter freed on model unload.

### Gating (all must hold, else plain decode)
`DARKBLOOM_ENABLE_MTP=1` AND a drafter loaded+bound AND model is Gemma 4 VLM AND greedy (temp 0, no penalty). Default off; safe fallback always available.

### Verification
- Real-image E2E live test (`VLM_MTP_E2E=1`): plain vs MTP on `eigen-labs-logo.png` → **identical, coherent output, ~1.9x faster** (43.8 → 73.9 tok/s).
- `swift build` clean; 22 `VLMRequestInference` unit tests pass; default-off path unchanged.
- Two independent reviewers (Codex + Claude) passed; all flagged issues fixed (drafter unload leak, per-token-decode mojibake, incomplete EOS set, EOS over-count).

### Notes
- The VLM tower's multi-token verify is bf16-noisier than the text tower; MTP output diverges from non-MTP decode only at a genuine ~0.14-logit near-tie. Output stays coherent/correct — within the "similar, not bit-identical" tolerance.
- Concurrent VLM requests serialize their decode under the model lock (the VLM path is already non-batched + uncapped) — acceptable, flagged for awareness.

### Test plan
- `swift build` — green.
- `VLM_MTP_E2E=1 swift test --filter vlmMTPRealImageEndToEnd` (needs the qat-4bit VLM + qat-assistant-4bit drafter in the local HF cache).

**Depends on Layr-Labs/mlx-swift-lm#35** (merge that first; this PR pins the submodule to it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/306"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783707840&installation_id=133247490&pr_number=306&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F306&signature=508b98082a5e1adbe5696e8909d8fef7dd3564eb815705854bcc3c91f9b42db2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->