### PR TITLE
fix(provider): interactive CLI subcommands print help instead of running (0.6.1 hotfix)

### DIFF
--- a/coordinator/api/server.go
+++ b/coordinator/api/server.go
@@ -143,7 +143,7 @@ func keyLimitResetFromContext(ctx context.Context) string {
 // 0.6.0 is the APNs code-identity / VLM-routing / graceful-update release.
 // Keep this fallback in sync with ProviderCore.version so dev/in-memory
 // coordinators advertise the same floor as the Swift binary they expect.
-var LatestProviderVersion = "0.6.0"
+var LatestProviderVersion = "0.6.1"
 
 // minProviderVersionForDesiredModels is the first provider version whose Swift
 // runtime understands the desired_models message. The coordinator must NOT send

--- a/provider-swift/Sources/ProviderCore/ProviderCore.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderCore.swift
@@ -25,5 +25,5 @@ public enum ProviderCore {
     // routing, graceful download-first auto-update, and the model-alias hot-swap
     // layer. Semver compares numerically per-component, so 0.6.0 > 0.5.17 keeps
     // the desired_models gate satisfied.
-    public static let version = "0.6.0"
+    public static let version = "0.6.1"
 }

--- a/provider-swift/Sources/darkbloom/main.swift
+++ b/provider-swift/Sources/darkbloom/main.swift
@@ -19,16 +19,24 @@ if ProviderAppKitHost.shouldHost(rawArgs) {
 }
 #endif
 
-// Non-serve path: parse + run exactly as ArgumentParser's async main() would.
-// Done manually (not via Darkbloom.main()) because, without @main, the sync
-// main() overload fatals on an async root command.
+// Non-serve path: parse + dispatch as ArgumentParser's async main() would, done
+// manually because @main is removed (it would fight AppKit for the main thread).
 do {
     var command = try Darkbloom.parseAsRoot(rawArgs)
-    if var asyncCommand = command as? AsyncParsableCommand {
-        try await asyncCommand.run()
+    if var asyncCommand = command as? any AsyncParsableCommand {
+        try await runAsyncCommand(&asyncCommand)
     } else {
         try command.run()
     }
 } catch {
     Darkbloom.exit(withError: error)
+}
+
+// The helper boundary is load-bearing: at top-level scope a bare
+// `asyncCommand.run()` binds to the synchronous ParsableCommand witness, whose
+// AsyncParsableCommand default throws a help request — so every subcommand printed
+// help instead of running (#286). Routing through `inout any AsyncParsableCommand`
+// forces the async witness. Covered by CLIDispatchTests.
+func runAsyncCommand(_ command: inout any AsyncParsableCommand) async throws {
+    try await command.run()
 }

--- a/provider-swift/Tests/DarkbloomCLITests/CLIDispatchTests.swift
+++ b/provider-swift/Tests/DarkbloomCLITests/CLIDispatchTests.swift
@@ -1,0 +1,55 @@
+import Foundation
+import Testing
+
+/// Regression test for the v0.6.0 interactive-CLI dispatch bug (#286): every
+/// AsyncParsableCommand subcommand printed its own help instead of running, because
+/// top-level `main.swift` bound `run()` to the synchronous witness (whose default
+/// throws a help request). The bug only manifests in top-level executable scope, so
+/// this exercises the REAL built binary rather than calling `run()` directly.
+@Suite struct CLIDispatchTests {
+    /// Path to the `darkbloom` executable built alongside this test bundle.
+    private var binary: URL {
+        #if os(macOS)
+        for bundle in Bundle.allBundles where bundle.bundlePath.hasSuffix(".xctest") {
+            return bundle.bundleURL.deletingLastPathComponent().appendingPathComponent("darkbloom")
+        }
+        #endif
+        return Bundle.main.bundleURL.appendingPathComponent("darkbloom")
+    }
+
+    private func run(_ args: [String]) throws -> String {
+        let proc = Process()
+        proc.executableURL = binary
+        proc.arguments = args
+        var env = ProcessInfo.processInfo.environment
+        env["DARKBLOOM_NO_UPDATE_CHECK"] = "1" // keep it offline + deterministic
+        proc.environment = env
+        let pipe = Pipe()
+        proc.standardOutput = pipe
+        proc.standardError = pipe
+        try proc.run()
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        proc.waitUntilExit()
+        return String(decoding: data, as: UTF8.self)
+    }
+
+    /// `darkbloom status` must produce a status report, not degenerate to its help.
+    @Test func statusSubcommandRunsInsteadOfPrintingHelp() throws {
+        let out = try run(["status"])
+        #expect(
+            !out.contains("USAGE: darkbloom status"),
+            "`status` printed its help instead of running — async-dispatch regression (main.swift). Got:\n\(out)"
+        )
+        #expect(
+            out.contains("Coordinator:"),
+            "`status` did not produce a status report. Got:\n\(out)"
+        )
+    }
+
+    /// A bare invocation should still show the root help with the subcommand list.
+    @Test func bareInvocationShowsRootHelp() throws {
+        let out = try run([])
+        #expect(out.contains("SUBCOMMANDS"))
+        #expect(out.contains("status"))
+    }
+}

--- a/provider-swift/Tests/DarkbloomCLITests/CLIDispatchTests.swift
+++ b/provider-swift/Tests/DarkbloomCLITests/CLIDispatchTests.swift
@@ -6,15 +6,19 @@ import Testing
 /// top-level `main.swift` bound `run()` to the synchronous witness (whose default
 /// throws a help request). The bug only manifests in top-level executable scope, so
 /// this exercises the REAL built binary rather than calling `run()` directly.
+/// Anchor for `Bundle(for:)` — under swift-testing the host process is SwiftPM's
+/// testing helper, so `Bundle.main`/`Bundle.allBundles` do not locate the test
+/// bundle; resolving via a class in this image does.
+private final class BundleAnchor {}
+
 @Suite struct CLIDispatchTests {
     /// Path to the `darkbloom` executable built alongside this test bundle.
     private var binary: URL {
-        #if os(macOS)
-        for bundle in Bundle.allBundles where bundle.bundlePath.hasSuffix(".xctest") {
-            return bundle.bundleURL.deletingLastPathComponent().appendingPathComponent("darkbloom")
-        }
-        #endif
-        return Bundle.main.bundleURL.appendingPathComponent("darkbloom")
+        let anchor = Bundle(for: BundleAnchor.self).bundleURL
+        let productsDir = anchor.pathExtension == "xctest"
+            ? anchor.deletingLastPathComponent()
+            : anchor
+        return productsDir.appendingPathComponent("darkbloom")
     }
 
     private func run(_ args: [String]) throws -> String {

--- a/provider-swift/Tests/DarkbloomCLITests/CLIDispatchTests.swift
+++ b/provider-swift/Tests/DarkbloomCLITests/CLIDispatchTests.swift
@@ -21,12 +21,16 @@ private final class BundleAnchor {}
         return productsDir.appendingPathComponent("darkbloom")
     }
 
-    private func run(_ args: [String]) throws -> String {
+    /// Runs the built binary hermetically: HOME points at a throwaway directory so
+    /// the subprocess can never read — or migrate/rewrite — a real provider config
+    /// on the host, and the update banner is disabled to keep the run offline.
+    private func run(_ args: [String], home: URL) throws -> String {
         let proc = Process()
         proc.executableURL = binary
         proc.arguments = args
         var env = ProcessInfo.processInfo.environment
-        env["DARKBLOOM_NO_UPDATE_CHECK"] = "1" // keep it offline + deterministic
+        env["HOME"] = home.path
+        env["DARKBLOOM_NO_UPDATE_CHECK"] = "1"
         proc.environment = env
         let pipe = Pipe()
         proc.standardOutput = pipe
@@ -37,9 +41,20 @@ private final class BundleAnchor {}
         return String(decoding: data, as: UTF8.self)
     }
 
+    private func makeTempHome() throws -> URL {
+        let home = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cli-dispatch-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: home, withIntermediateDirectories: true)
+        return home
+    }
+
     /// `darkbloom status` must produce a status report, not degenerate to its help.
     @Test func statusSubcommandRunsInsteadOfPrintingHelp() throws {
-        let out = try run(["status"])
+        let home = try makeTempHome()
+        defer { try? FileManager.default.removeItem(at: home) }
+        // Explicit --config under the temp home as a second isolation layer.
+        let config = home.appendingPathComponent("provider.toml").path
+        let out = try run(["status", "--config", config], home: home)
         #expect(
             !out.contains("USAGE: darkbloom status"),
             "`status` printed its help instead of running — async-dispatch regression (main.swift). Got:\n\(out)"
@@ -52,7 +67,9 @@ private final class BundleAnchor {}
 
     /// A bare invocation should still show the root help with the subcommand list.
     @Test func bareInvocationShowsRootHelp() throws {
-        let out = try run([])
+        let home = try makeTempHome()
+        defer { try? FileManager.default.removeItem(at: home) }
+        let out = try run([], home: home)
         #expect(out.contains("SUBCOMMANDS"))
         #expect(out.contains("status"))
     }


### PR DESCRIPTION
## The bug
On 0.6.0, **every interactive `darkbloom` subcommand prints its own help and exits 0 instead of running** — `status`, `doctor`, `start`, `login`, `enroll`, `update`, `stop`, `restart`, `models`, etc. Reproduced on two machines (incl. a no-MDM box) with the exact released binary, and distilled to a 30-line standalone repro.

## Root cause
Every darkbloom subcommand is an `AsyncParsableCommand`. In #286, `@main` was removed so AppKit could own the main thread for APNs code-identity attestation, and `main.swift` now dispatches manually. At **top-level scope**, a bare `asyncCommand.run()` binds to the **synchronous** `ParsableCommand` witness (the protocol refines `ParsableCommand`, so both a sync and an async `run()` are visible) — and `AsyncParsableCommand`'s default sync `run()` is literally `throw CleanExit.helpRequest(self)`. So each command "runs" by throwing a help request. The compiler even hints at it: *"no 'async' operations occur within 'await' expression."*

## Why the fleet kept working
The serve path (`start --foreground` / `start --local`) is dispatched via `ProviderAppKitHost` inside a **method/Task**, where the same call correctly binds to **async**. That's the launchd daemon path — so existing providers kept serving, auto-updating, and attesting. **Only the interactive CLI was broken**: new onboarding (`install.sh` → `darkbloom start` / `enroll`) and all diagnostics/management.

## The fix
Route the call through a helper typed `inout any AsyncParsableCommand`, which forces the async witness:
```swift
if var asyncCommand = command as? any AsyncParsableCommand {
    try await runAsyncCommand(&asyncCommand)
} else { try command.run() }
...
func runAsyncCommand(_ command: inout any AsyncParsableCommand) async throws { try await command.run() }
```
The function boundary is load-bearing — just adding `any` inline does **not** fix it (the sync witness still wins at top-level). Verified with a standalone repro: async + sync subcommands run, root help / `--help` / bad-flag errors all still correct.

## Tests
New `CLIDispatchTests` runs the **built binary** (the bug only manifests in top-level executable scope) and asserts `darkbloom status` produces a status report, not its help text — and that bare invocation still shows root help. Fails without this fix, passes with it.

## Version
Bumps provider `ProviderCore.version` + coordinator `LatestProviderVersion` `0.6.0 → 0.6.1`. Intended to ship as the **v0.6.1 hotfix** once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/307"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783713234&installation_id=133247490&pr_number=307&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F307&signature=19667c5a59e7c9ee6aac987ebb03fb93a18a631a5acc0ee4e7ba15222f0572e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->