### PR TITLE
fix(coordinator): single [DONE] terminator + well-formed SE signature event (0.6.2)

### DIFF
--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -2508,7 +2508,7 @@ func (s *Server) handleStreamingResponseWithFirstChunk(w http.ResponseWriter, r 
 	var pendingUsage map[string]any
 
 	// Write the first chunk that was already consumed during dispatch.
-	if firstChunk != "" {
+	if firstChunk != "" && !isSSEDoneChunk(firstChunk) {
 		if strings.Contains(firstChunk, `"response.created"`) || strings.Contains(firstChunk, `"response.output_text.delta"`) {
 			sawResponsesAPI = true
 		}
@@ -2579,14 +2579,27 @@ func (s *Server) handleStreamingResponseWithFirstChunk(w http.ResponseWriter, r 
 						case <-time.After(2 * time.Second):
 						case <-r.Context().Done():
 						}
+						// Ride the SE signature on the held usage chunk (a complete,
+						// well-formed chat.completion.chunk) instead of emitting a
+						// separate bare event that strict SDK parsers reject.
+						if pr.SESignature != "" {
+							pendingUsage["se_signature"] = pr.SESignature
+							pendingUsage["response_hash"] = pr.ResponseHash
+						}
 						if out := finalizeUsageChunk(pendingUsage, usage, pr); out != "" {
 							fmt.Fprintf(w, "%s\n\n", out)
 							flusher.Flush()
 						}
-					}
-					// Chat completions format: append SE signature + [DONE].
-					if pr.SESignature != "" {
+					} else if pr.SESignature != "" {
+						// No held usage chunk to ride on: emit the signature as a
+						// fully-shaped chat.completion.chunk (id/object/created/model/
+						// choices) so strict decoders parse it; the extra fields are
+						// additive. It precedes the single [DONE] below.
 						sigEvent, _ := json.Marshal(map[string]any{
+							"id":            "chatcmpl-" + pr.RequestID,
+							"object":        "chat.completion.chunk",
+							"created":       time.Now().Unix(),
+							"model":         consumerModel(pr),
 							"choices":       []any{},
 							"se_signature":  pr.SESignature,
 							"response_hash": pr.ResponseHash,
@@ -2594,6 +2607,7 @@ func (s *Server) handleStreamingResponseWithFirstChunk(w http.ResponseWriter, r 
 						fmt.Fprintf(w, "data: %s\n\n", sigEvent)
 						flusher.Flush()
 					}
+					// Exactly one terminator, after every coordinator-appended event.
 					fmt.Fprint(w, "data: [DONE]\n\n")
 					flusher.Flush()
 				}
@@ -2616,6 +2630,16 @@ func (s *Server) handleStreamingResponseWithFirstChunk(w http.ResponseWriter, r 
 				if strings.Contains(chunk, `"response.created"`) || strings.Contains(chunk, `"response.output_text.delta"`) {
 					sawResponsesAPI = true
 				}
+			}
+			// Swallow the provider's own "data: [DONE]" terminator. The
+			// coordinator appends terminal events of its own (held usage with
+			// the reasoning breakdown, SE signature) and then emits exactly ONE
+			// [DONE] — forwarding the provider's produced a stream shaped
+			// `...usage, [DONE], signature, [DONE]`, and third-party SDKs treat
+			// the first [DONE] as final (MacPaw/OpenAI then chokes parsing the
+			// signature event).
+			if !sawResponsesAPI && isSSEDoneChunk(chunk) {
+				continue
 			}
 			// Hold the terminal usage chunk (chat completions only) so we can splice
 			// in the reasoning breakdown at stream end; forwarding it inline would
@@ -3398,6 +3422,16 @@ func injectReasoningDetailIntoRawUsage(obj map[string]any, usage protocol.UsageI
 // + a non-null usage object, carrying the final usage and no content delta) and
 // returns the parsed object. ok is false for any other chunk. Parsing here once
 // lets the caller hold the object and finalize it at stream end without re-parsing.
+// isSSEDoneChunk reports whether a provider stream chunk is the SSE
+// "data: [DONE]" terminator (with or without the data: prefix). The
+// coordinator owns stream termination — provider terminators are swallowed
+// so coordinator-appended events (held usage, SE signature) never trail a
+// [DONE] that SDKs treat as final.
+func isSSEDoneChunk(chunk string) bool {
+	line := strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(chunk), "data:"))
+	return line == "[DONE]"
+}
+
 func parseUsageOnlyStreamChunk(chunk string) (obj map[string]any, ok bool) {
 	line := strings.TrimPrefix(chunk, "data: ")
 	// Cheap gate: skip the parse for content deltas and usage:null chunks.

--- a/coordinator/api/consumer_test.go
+++ b/coordinator/api/consumer_test.go
@@ -1782,3 +1782,115 @@ func TestStreamingChatUsageOnlyFirstChunk(t *testing.T) {
 		t.Fatalf("expected [DONE] terminator; body=\n%s", body)
 	}
 }
+
+// TestStreamingChatSingleDoneSignatureBeforeIt covers the SplittyDev report:
+// the provider's own "data: [DONE]" was forwarded, then the coordinator
+// appended a bare {"choices":[],se_signature,...} event and a SECOND [DONE].
+// SDKs treat the first [DONE] as final and choke on the malformed trailer.
+// Now: provider [DONE] swallowed, the signature rides a fully-shaped chunk,
+// and exactly one [DONE] terminates the stream.
+func TestStreamingChatSingleDoneSignatureBeforeIt(t *testing.T) {
+	logger := quietLogger()
+	srv := NewServer(registry.New(logger), store.NewMemory(store.Config{}), ServerConfig{}, logger)
+
+	pr := &registry.PendingRequest{
+		RequestID:    "job-1",
+		Model:        "gpt-oss-20b",
+		SESignature:  "sig-abc",
+		ResponseHash: "hash-def",
+		ChunkCh:      make(chan string, 8),
+		ErrorCh:      make(chan protocol.InferenceErrorMessage, 1),
+		CompleteCh:   make(chan protocol.UsageInfo, 1),
+	}
+	pr.ChunkCh <- `data: {"id":"c1","object":"chat.completion.chunk","created":1,"model":"gpt-oss-20b","choices":[{"index":0,"delta":{"content":"hi"},"finish_reason":null}]}`
+	pr.ChunkCh <- `data: {"id":"c1","object":"chat.completion.chunk","created":1,"model":"gpt-oss-20b","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}`
+	pr.ChunkCh <- "data: [DONE]" // the provider's own terminator — must be swallowed
+	close(pr.ChunkCh)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	rec := httptest.NewRecorder()
+	srv.handleStreamingResponseWithFirstChunk(rec, req, pr, "")
+
+	body := rec.Body.String()
+	if got := strings.Count(body, "data: [DONE]"); got != 1 {
+		t.Fatalf("expected exactly ONE [DONE]; got %d\nbody:\n%s", got, body)
+	}
+	if !strings.HasSuffix(strings.TrimSpace(body), "data: [DONE]") {
+		t.Fatalf("[DONE] must be the FINAL event — nothing may trail it; body:\n%s", body)
+	}
+	sigIdx := strings.Index(body, `"se_signature":"sig-abc"`)
+	doneIdx := strings.Index(body, "data: [DONE]")
+	if sigIdx == -1 || sigIdx > doneIdx {
+		t.Fatalf("signature event must precede the single [DONE]; body:\n%s", body)
+	}
+	// The signature event must be a fully-shaped chunk for strict decoders.
+	var sigLine string
+	for _, line := range strings.Split(body, "\n") {
+		if strings.Contains(line, "se_signature") {
+			sigLine = strings.TrimPrefix(line, "data: ")
+			break
+		}
+	}
+	var sigObj map[string]any
+	if err := json.Unmarshal([]byte(sigLine), &sigObj); err != nil {
+		t.Fatalf("signature event is not valid JSON: %v", err)
+	}
+	for _, k := range []string{"id", "object", "created", "model", "choices", "response_hash"} {
+		if _, present := sigObj[k]; !present {
+			t.Fatalf("signature event missing required field %q (breaks strict SDKs); got: %s", k, sigLine)
+		}
+	}
+	if sigObj["object"] != "chat.completion.chunk" {
+		t.Fatalf("signature event object must be chat.completion.chunk; got %v", sigObj["object"])
+	}
+}
+
+// TestStreamingChatSignatureRidesUsageChunk: with stream_options.include_usage
+// (a held usage-only chunk), the SE signature is spliced into that final
+// well-formed chunk — no separate signature event, single [DONE].
+func TestStreamingChatSignatureRidesUsageChunk(t *testing.T) {
+	logger := quietLogger()
+	srv := NewServer(registry.New(logger), store.NewMemory(store.Config{}), ServerConfig{}, logger)
+
+	pr := &registry.PendingRequest{
+		RequestID:    "job-1",
+		Model:        "gpt-oss-20b",
+		SESignature:  "sig-abc",
+		ResponseHash: "hash-def",
+		ChunkCh:      make(chan string, 8),
+		ErrorCh:      make(chan protocol.InferenceErrorMessage, 1),
+		CompleteCh:   make(chan protocol.UsageInfo, 1),
+	}
+	pr.ChunkCh <- `data: {"id":"c1","object":"chat.completion.chunk","created":1,"model":"gpt-oss-20b","choices":[{"index":0,"delta":{"content":"hi"},"finish_reason":null}]}`
+	pr.ChunkCh <- `data: {"id":"c1","object":"chat.completion.chunk","created":1,"model":"gpt-oss-20b","choices":[],"usage":{"prompt_tokens":10,"completion_tokens":50,"total_tokens":60}}`
+	pr.ChunkCh <- "data: [DONE]"
+	close(pr.ChunkCh)
+	pr.CompleteCh <- protocol.UsageInfo{PromptTokens: 10, CompletionTokens: 50, ReasoningTokens: 8}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	rec := httptest.NewRecorder()
+	srv.handleStreamingResponseWithFirstChunk(rec, req, pr, "")
+
+	body := rec.Body.String()
+	if got := strings.Count(body, "data: [DONE]"); got != 1 {
+		t.Fatalf("expected exactly ONE [DONE]; got %d\nbody:\n%s", got, body)
+	}
+	if got := strings.Count(body, "se_signature"); got != 1 {
+		t.Fatalf("signature must appear exactly once (on the usage chunk); got %d\nbody:\n%s", got, body)
+	}
+	// One line carries usage + reasoning + signature together.
+	var found bool
+	for _, line := range strings.Split(body, "\n") {
+		if strings.Contains(line, "se_signature") {
+			found = strings.Contains(line, `"reasoning_tokens":8`) &&
+				strings.Contains(line, `"usage"`) &&
+				strings.Contains(line, `"response_hash":"hash-def"`)
+		}
+	}
+	if !found {
+		t.Fatalf("signature must ride the final usage chunk (with reasoning spliced); body:\n%s", body)
+	}
+	if !strings.HasSuffix(strings.TrimSpace(body), "data: [DONE]") {
+		t.Fatalf("[DONE] must be the final event; body:\n%s", body)
+	}
+}

--- a/coordinator/api/server.go
+++ b/coordinator/api/server.go
@@ -143,7 +143,7 @@ func keyLimitResetFromContext(ctx context.Context) string {
 // 0.6.0 is the APNs code-identity / VLM-routing / graceful-update release.
 // Keep this fallback in sync with ProviderCore.version so dev/in-memory
 // coordinators advertise the same floor as the Swift binary they expect.
-var LatestProviderVersion = "0.6.1"
+var LatestProviderVersion = "0.6.2"
 
 // minProviderVersionForDesiredModels is the first provider version whose Swift
 // runtime understands the desired_models message. The coordinator must NOT send

--- a/provider-swift/Sources/ProviderCore/ProviderCore.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderCore.swift
@@ -25,5 +25,5 @@ public enum ProviderCore {
     // routing, graceful download-first auto-update, and the model-alias hot-swap
     // layer. Semver compares numerically per-component, so 0.6.0 > 0.5.17 keeps
     // the desired_models gate satisfied.
-    public static let version = "0.6.1"
+    public static let version = "0.6.2"
 }


### PR DESCRIPTION
## Provider-reported (SplittyDev) — reproduced live on prod
The chat-completions SSE stream ends with **two** `data: [DONE]` events, with a malformed signature event between them:

```
data: {...final chunk with usage...}
data: [DONE]
data: {"choices":[],"response_hash":"...","se_signature":"..."}   ← no id/object/created/model
data: [DONE]
```

Third-party SDKs treat the first `[DONE]` as terminal. Most (OpenAI SDK py/js, LiteLLM, PydanticAI, Langchain, Vercel AI) stop reading and silently lose the signature; MacPaw/OpenAI (Swift) keeps parsing and **throws** (`DecodingError.keyNotFound: 'created'`), breaking the integration.

## Root cause
The provider's engine terminates its own SSE with `[DONE]`. The coordinator forwarded it verbatim, then appended its own terminal events (held reasoning-usage chunk, SE signature) and a second `[DONE]`.

## Fix
1. **The coordinator owns termination**: the provider's `[DONE]` is swallowed (`isSSEDoneChunk`, chat path including the first-chunk edge); exactly one `[DONE]` is emitted after all coordinator-appended events.
2. **Signature rides the last well-formed chunk** (SplittyDev's suggestion): with `stream_options.include_usage`, `se_signature` + `response_hash` are spliced into the held final usage chunk — no separate event at all.
3. **Standalone signature event is now fully shaped** (`id`/`object: chat.completion.chunk`/`created`/`model`/`choices: []` + the two signature fields) so strict decoders parse it, and it precedes the single `[DONE]`.

Resulting stream: `...chunks, {usage+signature}, [DONE]` — nothing after the terminator, every event a valid `chat.completion.chunk`.

## Also
Bumps version `0.6.1 → 0.6.2` (provider + coordinator constants) — this rides the v0.6.2 release together with #308.

## Tests
- `TestStreamingChatSingleDoneSignatureBeforeIt` — provider `[DONE]` swallowed; one terminator; nothing trails it; signature event JSON-parses with all required fields.
- `TestStreamingChatSignatureRidesUsageChunk` — signature + reasoning ride the single final usage chunk.
- Existing reasoning/streaming tests unchanged and green; full `go test ./api/` passes.

> Note for rollout: this is a **coordinator-side** fix — it reaches consumers on the next coordinator deploy, independent of the provider bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/309"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783720217&installation_id=133247490&pr_number=309&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F309&signature=de1178a7cd0066c74aceccd76862dffb1a3479a83db54c2ff2a51ce41e88b983"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->