### PR TITLE
fix(provider): gemma-4 tool calls 500 on nullable (array-typed) schema fields

### DIFF
--- a/provider-swift/Sources/ProviderCore/Inference/ToolSchemaNormalization.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/ToolSchemaNormalization.swift
@@ -92,7 +92,7 @@ enum ToolSchemaNormalization {
                 dict["nullable"] == nil {
                 dict["nullable"] = true
             }
-            dict["type"] = collapsedType(t, in: dict)
+            dict["type"] = collapsedType(members: members, in: dict)
         }
 
         let looksLikeSchemaNode =
@@ -106,17 +106,16 @@ enum ToolSchemaNormalization {
         return dict
     }
 
-    /// Collapse a non-string `type` value to one renderable string: the first
-    /// concrete (non-"null") member of an array type, the lone "null" when that
-    /// is all the array declares, else fall back to structural inference.
-    private static func collapsedType(_ value: Any, in dict: [String: Any]) -> String {
-        if let members = (value as? [Any])?.compactMap({ $0 as? String }) {
-            if let concrete = members.first(where: { $0 != "null" }) {
-                return concrete
-            }
-            if let nullOnly = members.first {
-                return nullOnly
-            }
+    /// Collapse a non-string `type` value (pre-extracted string members of the
+    /// array form) to one renderable string: the first concrete (non-"null")
+    /// member, the lone "null" when that is all the array declares, else fall
+    /// back to structural inference.
+    private static func collapsedType(members: [String], in dict: [String: Any]) -> String {
+        if let concrete = members.first(where: { $0 != "null" }) {
+            return concrete
+        }
+        if let nullOnly = members.first {
+            return nullOnly
         }
         return inferredType(for: dict)
     }

--- a/provider-swift/Sources/ProviderCore/Inference/ToolSchemaNormalization.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/ToolSchemaNormalization.swift
@@ -83,7 +83,15 @@ enum ToolSchemaNormalization {
         // emits for every Optional[...] tool parameter. Collapse it to a single
         // representative string (never delete the key: a node whose only content
         // is its type would not be refilled below and would crash anyway).
+        // Nullability is preserved losslessly: the gemma template natively
+        // renders the standard `nullable` key, so collapsing away a "null"
+        // member sets it (without clobbering an explicit value).
         if let t = dict["type"], !(t is String) {
+            let members = (t as? [Any])?.compactMap { $0 as? String } ?? []
+            if members.contains("null"), members.contains(where: { $0 != "null" }),
+                dict["nullable"] == nil {
+                dict["nullable"] = true
+            }
             dict["type"] = collapsedType(t, in: dict)
         }
 

--- a/provider-swift/Sources/ProviderCore/Inference/ToolSchemaNormalization.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/ToolSchemaNormalization.swift
@@ -77,26 +77,57 @@ enum ToolSchemaNormalization {
             }
         }
 
+        // A type that is PRESENT but not a string crashes `| upper` just like a
+        // missing one. The common real-world shape is the JSON-Schema array form
+        // for nullable fields — `"type": ["string","null"]` — which Pydantic
+        // emits for every Optional[...] tool parameter. Collapse it to a single
+        // representative string (never delete the key: a node whose only content
+        // is its type would not be refilled below and would crash anyway).
+        if let t = dict["type"], !(t is String) {
+            dict["type"] = collapsedType(t, in: dict)
+        }
+
         let looksLikeSchemaNode =
             dict["properties"] != nil || dict["items"] != nil ||
             dict["additionalProperties"] != nil ||
             dict["enum"] != nil || dict["description"] != nil ||
             dict["anyOf"] != nil || dict["oneOf"] != nil || dict["allOf"] != nil
         if dict["type"] == nil, looksLikeSchemaNode {
-            if dict["properties"] != nil || dict["additionalProperties"] != nil {
-                dict["type"] = "object"
-            } else if dict["items"] != nil {
-                dict["type"] = "array"
-            } else if let unionType = unionMemberType(dict) {
-                // anyOf/oneOf/allOf without a parent type: borrow the first concrete
-                // member type (skipping "null") rather than mislabelling a union as a
-                // string. The template still gets a usable type and can't crash.
-                dict["type"] = unionType
-            } else {
-                dict["type"] = "string"
-            }
+            dict["type"] = inferredType(for: dict)
         }
         return dict
+    }
+
+    /// Collapse a non-string `type` value to one renderable string: the first
+    /// concrete (non-"null") member of an array type, the lone "null" when that
+    /// is all the array declares, else fall back to structural inference.
+    private static func collapsedType(_ value: Any, in dict: [String: Any]) -> String {
+        if let members = (value as? [Any])?.compactMap({ $0 as? String }) {
+            if let concrete = members.first(where: { $0 != "null" }) {
+                return concrete
+            }
+            if let nullOnly = members.first {
+                return nullOnly
+            }
+        }
+        return inferredType(for: dict)
+    }
+
+    /// Structural default for a schema node's `type`: object when it has
+    /// properties, array when it has items, a union member's type when it is an
+    /// anyOf/oneOf/allOf (skipping "null" — mislabelling a union as a string
+    /// would be wrong), otherwise string.
+    private static func inferredType(for dict: [String: Any]) -> String {
+        if dict["properties"] != nil || dict["additionalProperties"] != nil {
+            return "object"
+        }
+        if dict["items"] != nil {
+            return "array"
+        }
+        if let unionType = unionMemberType(dict) {
+            return unionType
+        }
+        return "string"
     }
 
     /// Derive a representative `type` for a union node from the first member that

--- a/provider-swift/Tests/ProviderCoreTests/ToolSchemaNormalizationTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/ToolSchemaNormalizationTests.swift
@@ -118,7 +118,10 @@ extension ToolSchemaNormalizationTests {
         let out = ToolSchemaNormalization.ensureParameterTypes(in: body)
         let function = try #require((parse(out)["tools"] as? [[String: Any]])?[0]["function"] as? [String: Any])
         let props = try #require((function["parameters"] as? [String: Any])?["properties"] as? [String: Any])
-        #expect((props["city"] as? [String: Any])?["type"] as? String == "string")
+        let city = try #require(props["city"] as? [String: Any])
+        #expect(city["type"] as? String == "string")
+        // Nullability preserved losslessly via the template-supported key.
+        #expect(city["nullable"] as? Bool == true)
     }
 
     @Test func collapsesArrayTypeSkippingLeadingNull() throws {
@@ -182,5 +185,49 @@ extension ToolSchemaNormalizationTests {
         let props = try #require((function["parameters"] as? [String: Any])?["properties"] as? [String: Any])
         #expect((props["cfg"] as? [String: Any])?["type"] as? String == "object")
         #expect((props["v"] as? [String: Any])?["type"] as? String == "string")
+    }
+    @Test func unionMemberWithArrayTypeStillDrivesParentInference() throws {
+        // Ordering is load-bearing: members collapse BEFORE the parent's union
+        // inference, so a first member declaring ["string","null"] must yield a
+        // "string" parent type (not fall through to the default).
+        let body = #"""
+        {"tools":[{"type":"function","function":{"name":"f",
+          "parameters":{"type":"object","properties":{
+            "u":{"anyOf":[{"type":["string","null"]},{"type":"integer"}],"description":"u"}}}}}]}
+        """#.data(using: .utf8)!
+
+        let out = ToolSchemaNormalization.ensureParameterTypes(in: body)
+        let function = try #require((parse(out)["tools"] as? [[String: Any]])?[0]["function"] as? [String: Any])
+        let props = try #require((function["parameters"] as? [String: Any])?["properties"] as? [String: Any])
+        #expect((props["u"] as? [String: Any])?["type"] as? String == "string")
+    }
+
+    @Test func collapsesArrayTypeOnTopLevelParametersNode() throws {
+        // The template also renders params['type'] | upper at the top level.
+        let body = #"""
+        {"tools":[{"type":"function","function":{"name":"f",
+          "parameters":{"type":["object","null"],"properties":{"q":{"type":"string"}}}}}]}
+        """#.data(using: .utf8)!
+
+        let out = ToolSchemaNormalization.ensureParameterTypes(in: body)
+        let function = try #require((parse(out)["tools"] as? [[String: Any]])?[0]["function"] as? [String: Any])
+        let params = try #require(function["parameters"] as? [String: Any])
+        #expect(params["type"] as? String == "object")
+        #expect(params["nullable"] as? Bool == true)
+    }
+
+    @Test func collapsesArrayTypeInsideAdditionalPropertiesSchema() throws {
+        let body = #"""
+        {"tools":[{"type":"function","function":{"name":"f",
+          "parameters":{"type":"object","properties":{
+            "kv":{"type":"object","additionalProperties":{"type":["number","null"]}}}}}}]}
+        """#.data(using: .utf8)!
+
+        let out = ToolSchemaNormalization.ensureParameterTypes(in: body)
+        let function = try #require((parse(out)["tools"] as? [[String: Any]])?[0]["function"] as? [String: Any])
+        let props = try #require((function["parameters"] as? [String: Any])?["properties"] as? [String: Any])
+        let addl = try #require((props["kv"] as? [String: Any])?["additionalProperties"] as? [String: Any])
+        #expect(addl["type"] as? String == "number")
+        #expect(addl["nullable"] as? Bool == true)
     }
 }

--- a/provider-swift/Tests/ProviderCoreTests/ToolSchemaNormalizationTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/ToolSchemaNormalizationTests.swift
@@ -102,4 +102,85 @@ extension ToolSchemaNormalizationTests {
         body.append(Data(count: ToolSchemaNormalization.maxNormalizationBytes))
         #expect(ToolSchemaNormalization.ensureParameterTypes(in: body) == body)
     }
+    // MARK: - Array-typed (nullable) `type` values — the second DAR-130 class.
+    // `"type": ["string","null"]` is what Pydantic emits for Optional[...] tool
+    // parameters; the gemma template's `| upper` crashed on the list ("upper
+    // filter requires string", reproduced on prod 2026-06-10).
+
+    @Test func collapsesNullableArrayTypeToConcreteMember() throws {
+        let body = #"""
+        {"tools":[{"type":"function","function":{"name":"get_weather",
+          "parameters":{"type":"object","properties":{
+            "city":{"type":["string","null"],"description":"city"}},
+            "required":["city"]}}}]}
+        """#.data(using: .utf8)!
+
+        let out = ToolSchemaNormalization.ensureParameterTypes(in: body)
+        let function = try #require((parse(out)["tools"] as? [[String: Any]])?[0]["function"] as? [String: Any])
+        let props = try #require((function["parameters"] as? [String: Any])?["properties"] as? [String: Any])
+        #expect((props["city"] as? [String: Any])?["type"] as? String == "string")
+    }
+
+    @Test func collapsesArrayTypeSkippingLeadingNull() throws {
+        let body = #"""
+        {"tools":[{"type":"function","function":{"name":"f",
+          "parameters":{"type":"object","properties":{
+            "n":{"type":["null","integer"]}}}}}]}
+        """#.data(using: .utf8)!
+
+        let out = ToolSchemaNormalization.ensureParameterTypes(in: body)
+        let function = try #require((parse(out)["tools"] as? [[String: Any]])?[0]["function"] as? [String: Any])
+        let props = try #require((function["parameters"] as? [String: Any])?["properties"] as? [String: Any])
+        #expect((props["n"] as? [String: Any])?["type"] as? String == "integer")
+    }
+
+    @Test func collapsesNullOnlyArrayTypeToNullString() throws {
+        // ["null"] has no concrete member — keep the honest "null", which still
+        // renders (it is a string for `| upper`).
+        let body = #"""
+        {"tools":[{"type":"function","function":{"name":"f",
+          "parameters":{"type":"object","properties":{
+            "x":{"type":["null"]}}}}}]}
+        """#.data(using: .utf8)!
+
+        let out = ToolSchemaNormalization.ensureParameterTypes(in: body)
+        let function = try #require((parse(out)["tools"] as? [[String: Any]])?[0]["function"] as? [String: Any])
+        let props = try #require((function["parameters"] as? [String: Any])?["properties"] as? [String: Any])
+        #expect((props["x"] as? [String: Any])?["type"] as? String == "null")
+    }
+
+    @Test func collapsesArrayTypeInNestedObjectAndItems() throws {
+        let body = #"""
+        {"tools":[{"type":"function","function":{"name":"set_alarm",
+          "parameters":{"type":"object","properties":{
+            "opts":{"type":"object","properties":{"snooze":{"type":["integer","null"]}}},
+            "tags":{"type":"array","items":{"type":["string","null"]}}}}}}]}
+        """#.data(using: .utf8)!
+
+        let out = ToolSchemaNormalization.ensureParameterTypes(in: body)
+        let function = try #require((parse(out)["tools"] as? [[String: Any]])?[0]["function"] as? [String: Any])
+        let props = try #require((function["parameters"] as? [String: Any])?["properties"] as? [String: Any])
+        let snooze = try #require(((props["opts"] as? [String: Any])?["properties"] as? [String: Any])?["snooze"] as? [String: Any])
+        #expect(snooze["type"] as? String == "integer")
+        let items = try #require((props["tags"] as? [String: Any])?["items"] as? [String: Any])
+        #expect(items["type"] as? String == "string")
+    }
+
+    @Test func malformedNonStringTypeFallsBackToStructuralInference() throws {
+        // A numeric `type` is invalid JSON Schema; repair it from structure
+        // (properties present → object) instead of leaving the list/number for
+        // the template to choke on.
+        let body = #"""
+        {"tools":[{"type":"function","function":{"name":"f",
+          "parameters":{"type":"object","properties":{
+            "cfg":{"type":42,"properties":{"k":{"type":"string"}}},
+            "v":{"type":7,"description":"v"}}}}}]}
+        """#.data(using: .utf8)!
+
+        let out = ToolSchemaNormalization.ensureParameterTypes(in: body)
+        let function = try #require((parse(out)["tools"] as? [[String: Any]])?[0]["function"] as? [String: Any])
+        let props = try #require((function["parameters"] as? [String: Any])?["properties"] as? [String: Any])
+        #expect((props["cfg"] as? [String: Any])?["type"] as? String == "object")
+        #expect((props["v"] as? [String: Any])?["type"] as? String == "string")
+    }
 }


### PR DESCRIPTION
## Consumer-reported — reproduced on prod
A consumer running a daily tool-call matrix found every **gemma-4 + tool definitions** job failing (`Runtime error: upper filter requires string`, surfacing as 408/500), while gpt-oss and no-tool gemma runs pass.

Reproduced live: any tool parameter using the JSON-Schema **nullable array form** crashes gemma:
```json
"city": { "type": ["string", "null"] }   →  HTTP 500: upper filter requires string
```
This is the standard shape **Pydantic emits for every `Optional[...]` tool parameter**, so any Python agent framework with optional fields hits it. (The coordinator retries 3×, then the consumer sees the failure — sometimes as a 408.)

## Root cause — second class of DAR-130
The gemma template renders `{{ value['type'] | upper }}` per parameter. The DAR-130 normalizer (#303) only fills **missing** types (`dict["type"] == nil`); a type that is **present but not a string** (array form, or malformed values) passes through untouched and the Jinja `upper` filter throws on the non-string. My earlier DAR-130 verification passed because it only covered the missing-type/anyOf/additionalProperties shapes.

## Fix
`ToolSchemaNormalization.injectDefaultTypes` now collapses any non-string `type` to a single renderable string:
- `["string","null"]` → `"string"` (first concrete member, order-independent: `["null","integer"]` → `"integer"`)
- `["null"]` → `"null"` (honest, still renders)
- malformed (e.g. numeric) → structural inference (object/array/union-member/string — extracted into `inferredType(for:)`, shared with the existing missing-type branch)

The key is never deleted — a node whose only content is its `type` wouldn't be refilled by the missing-type branch and would crash anyway.

## Tests
5 new cases (nullable collapse, null-first ordering, null-only, nested object+items, malformed numeric) in `ToolSchemaNormalizationTests`; suite 6 → 11, full provider run 708 green.

## Rollout
Provider-side → ships with the next provider release; fleet picks it up via auto-update. Until then, affected consumers can work around by avoiding nullable types in tool schemas (e.g. Pydantic `Optional` → required-with-default).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/310"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783728856&installation_id=133247490&pr_number=310&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F310&signature=d15f7a8ab715094cfb66153a4ddd0e5f18c16558184664ed3bdb5224bd78f89f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->