### PR TITLE
fix(fleet): end the provider churn outage — App Nap/wake, eviction grace, zombie streams, memory wedge, update, billing, DD gauges

### DIFF
--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -2452,32 +2452,16 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// When this function returns (consumer disconnect, timeout, or completion),
-	// free the provider's slot and tell it to stop generating. The pending is
-	// removed from the provider's set immediately so the slot frees and the
-	// concurrency/idle accounting is accurate.
-	//
-	// If the request was still in flight (RemovePending returns non-nil — i.e.
-	// the provider's terminal had NOT already settled it), park its billing
-	// record for settlement: a consumer that disconnected mid-stream still
-	// received the streamed tokens, and the provider's terminal (sent right
-	// after it aborts) carries the real usage. Without this hold the terminal
-	// would hit "complete for unknown request", leaking the consumer's
-	// reservation and paying the provider $0 for delivered work. If no terminal
-	// arrives within the grace, holdForSettlement refunds the reservation.
+	// On return (disconnect/timeout/completion): free the slot, tell the
+	// provider to stop, and preserve billing for a mid-stream disconnect.
+	// Park BEFORE RemovePending so a racing provider terminal always finds the
+	// record in pending or the holder — never neither (which would drop it and
+	// mis-refund). GetPending is nil if a terminal already settled it (normal
+	// completion), so nothing is parked then. Both settle paths are
+	// FinalizeReservation-guarded, so the park-then-remove overlap can't double-bill.
 	defer func() {
-		// Park for settlement BEFORE removing from the pending set, so a
-		// provider terminal racing this defer always finds the billing record
-		// in one place or the other — never in neither (which would drop the
-		// terminal and mis-refund). Parking while still pending is safe: both
-		// settle paths are FinalizeReservation-guarded, so if handleComplete
-		// claims via RemovePending and the grace timer also fires, exactly one
-		// credits. GetPending returns nil if a terminal already settled it
-		// (normal completion), so nothing is parked in that case.
 		s.holdForSettlement(provider.GetPending(requestID))
-		// Then remove from pending so SetProviderIdle (gated on
-		// pendingCount()==0) frees the slot.
-		provider.RemovePending(requestID)
+		provider.RemovePending(requestID) // then remove so SetProviderIdle frees the slot
 		s.registry.SetProviderIdle(provider.ID)
 		s.sendProviderCancel(provider, requestID)
 	}()
@@ -5129,16 +5113,9 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 		return
 	}
 
-	// When this function returns (consumer disconnect, timeout, or
-	// completion), free the provider's slot and tell it to stop generating.
-	// A request still in flight at return (RemovePending non-nil) is parked
-	// for late-terminal settlement so its billing isn't lost — see the
-	// identical defer in the chat-completions path for the full rationale.
+	// Free the slot, stop the provider, and preserve billing on a mid-stream
+	// disconnect (park-before-remove; see the chat-completions path for why).
 	defer func() {
-		// Park for settlement BEFORE removing from pending (see the identical
-		// defer in the chat-completions path) so a racing provider terminal
-		// never sees the record in neither place. GetPending returns nil if a
-		// terminal already settled it, so normal completion parks nothing.
 		s.holdForSettlement(provider.GetPending(requestID))
 		provider.RemovePending(requestID)
 		s.registry.SetProviderIdle(provider.ID)

--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -33,6 +33,7 @@ import (
 	"github.com/eigeninference/d-inference/coordinator/payments"
 	"github.com/eigeninference/d-inference/coordinator/protocol"
 	"github.com/eigeninference/d-inference/coordinator/registry"
+	"github.com/eigeninference/d-inference/coordinator/saferun"
 	"github.com/eigeninference/d-inference/coordinator/store"
 	"github.com/google/uuid"
 	"nhooyr.io/websocket"
@@ -2460,7 +2461,22 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 	// completion), so nothing is parked then. Both settle paths are
 	// FinalizeReservation-guarded, so the park-then-remove overlap can't double-bill.
 	defer func() {
-		s.holdForSettlement(provider.GetPending(requestID))
+		if stale := provider.GetPending(requestID); stale != nil {
+			s.holdForSettlement(stale)
+		} else {
+			// A terminal already claimed the pending. In every normal path the
+			// reservation is finalized by now (completion billed it, the relay
+			// error/timeout branches refunded it) and this is a no-op. The one
+			// exception is a provider error landing in the gap between this
+			// handler abandoning its channels and this defer running: that
+			// terminal pushed into an unread ErrorCh and nobody settled — sweep
+			// it here. Post-commit only, so it can never finalize a reservation
+			// the dispatch loop still needs for a retry attempt.
+			refundPr := pr
+			saferun.Go(s.logger, "api.postTerminalSweep", func() {
+				s.refundReservedBalance(refundPr, "post_terminal_sweep:"+requestID)
+			})
+		}
 		provider.RemovePending(requestID) // then remove so SetProviderIdle frees the slot
 		s.registry.SetProviderIdle(provider.ID)
 		s.sendProviderCancel(provider, requestID)
@@ -5114,9 +5130,17 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 	}
 
 	// Free the slot, stop the provider, and preserve billing on a mid-stream
-	// disconnect (park-before-remove; see the chat-completions path for why).
+	// disconnect (park-before-remove + post-terminal sweep; see the
+	// chat-completions path for the full rationale).
 	defer func() {
-		s.holdForSettlement(provider.GetPending(requestID))
+		if stale := provider.GetPending(requestID); stale != nil {
+			s.holdForSettlement(stale)
+		} else {
+			refundPr := pr
+			saferun.Go(s.logger, "api.postTerminalSweep", func() {
+				s.refundReservedBalance(refundPr, "post_terminal_sweep:"+requestID)
+			})
+		}
 		provider.RemovePending(requestID)
 		s.registry.SetProviderIdle(provider.ID)
 		s.sendProviderCancel(provider, requestID)

--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -2453,8 +2453,30 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// When this function returns (consumer disconnect, timeout, or completion),
-	// send a cancel to the provider so it stops generating tokens.
+	// free the provider's slot and tell it to stop generating. The pending is
+	// removed from the provider's set immediately so the slot frees and the
+	// concurrency/idle accounting is accurate.
+	//
+	// If the request was still in flight (RemovePending returns non-nil — i.e.
+	// the provider's terminal had NOT already settled it), park its billing
+	// record for settlement: a consumer that disconnected mid-stream still
+	// received the streamed tokens, and the provider's terminal (sent right
+	// after it aborts) carries the real usage. Without this hold the terminal
+	// would hit "complete for unknown request", leaking the consumer's
+	// reservation and paying the provider $0 for delivered work. If no terminal
+	// arrives within the grace, holdForSettlement refunds the reservation.
 	defer func() {
+		// Park for settlement BEFORE removing from the pending set, so a
+		// provider terminal racing this defer always finds the billing record
+		// in one place or the other — never in neither (which would drop the
+		// terminal and mis-refund). Parking while still pending is safe: both
+		// settle paths are FinalizeReservation-guarded, so if handleComplete
+		// claims via RemovePending and the grace timer also fires, exactly one
+		// credits. GetPending returns nil if a terminal already settled it
+		// (normal completion), so nothing is parked in that case.
+		s.holdForSettlement(provider.GetPending(requestID))
+		// Then remove from pending so SetProviderIdle (gated on
+		// pendingCount()==0) frees the slot.
 		provider.RemovePending(requestID)
 		s.registry.SetProviderIdle(provider.ID)
 		s.sendProviderCancel(provider, requestID)
@@ -5108,10 +5130,16 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 	}
 
 	// When this function returns (consumer disconnect, timeout, or
-	// completion), tell the provider to stop generating. Without this the
-	// provider keeps producing tokens into a buffered channel until the
-	// buffer fills, wasting GPU cycles.
+	// completion), free the provider's slot and tell it to stop generating.
+	// A request still in flight at return (RemovePending non-nil) is parked
+	// for late-terminal settlement so its billing isn't lost — see the
+	// identical defer in the chat-completions path for the full rationale.
 	defer func() {
+		// Park for settlement BEFORE removing from pending (see the identical
+		// defer in the chat-completions path) so a racing provider terminal
+		// never sees the record in neither place. GetPending returns nil if a
+		// terminal already settled it, so normal completion parks nothing.
+		s.holdForSettlement(provider.GetPending(requestID))
 		provider.RemovePending(requestID)
 		s.registry.SetProviderIdle(provider.ID)
 		s.sendProviderCancel(provider, requestID)

--- a/coordinator/api/provider.go
+++ b/coordinator/api/provider.go
@@ -1987,22 +1987,25 @@ func (s *Server) handleInferenceError(providerID string, provider *registry.Prov
 
 	s.registry.SetProviderIdle(providerID)
 
-	// Settle the reservation server-side for EVERY error terminal, off the read
-	// loop (a store Credit can block for seconds under DB pressure, and this
-	// handler runs on the provider WS read loop — blocking it stalls heartbeats
-	// and challenge responses, feeding the eviction churn). Unconditional so a
-	// spontaneous provider error landing in the gap between the consumer
-	// goroutine abandoning its channels and its defer parking the record can't
-	// leak the reservation. FinalizeReservation is single-winner, so the racing
-	// refunds (relay ErrorCh reader, settlement grace timer) stay idempotent.
-	refundPr := pr
-	refundID := msg.RequestID
-	saferun.Go(s.logger, "api.refundOnInferenceError", func() {
-		s.refundReservedBalance(refundPr, "provider_error:"+refundID)
-	})
-
 	if consumerGone {
-		// Consumer disconnected — no reader for the channels; nothing to push.
+		// Consumer disconnected — no reader for the channels; settle by
+		// refunding, OFF the read loop (a store Credit can block for seconds
+		// under DB pressure, and blocking this loop stalls heartbeats and
+		// challenge responses — the eviction-churn vector). Idempotent vs. the
+		// settlement grace timer via FinalizeReservation.
+		//
+		// Deliberately NOT unconditional: during the dispatch retry window the
+		// consumer handler keeps the base reservation alive for the next
+		// attempt — refunding/finalizing it here would let a later successful
+		// attempt settle against a dead reservation (served for free). Errors
+		// with a live consumer are refunded by their channel readers (relay /
+		// dispatch-exhaustion paths); the relay-return→park gap is swept by
+		// the post-commit defer's last-chance refund in consumer.go.
+		refundPr := pr
+		refundID := msg.RequestID
+		saferun.Go(s.logger, "api.refundAfterDisconnect", func() {
+			s.refundReservedBalance(refundPr, "provider_error_after_disconnect:"+refundID)
+		})
 		return
 	}
 

--- a/coordinator/api/provider.go
+++ b/coordinator/api/provider.go
@@ -1574,6 +1574,13 @@ func (s *Server) handleComplete(providerID string, provider *registry.Provider, 
 		return
 	}
 	pr := provider.RemovePending(msg.RequestID)
+	// Always clear any parked settlement record for this request (consumer
+	// disconnected mid-stream). It's the SAME object as a non-nil pr when the
+	// terminal raced the disconnect defer; claiming it here both settles the
+	// disconnect case and stops the grace timer from later no-op-refunding.
+	if parked := s.claimSettlement(msg.RequestID); parked != nil && pr == nil {
+		pr = parked
+	}
 	if pr == nil {
 		s.logger.Warn("complete for unknown request", "provider_id", providerID, "request_id", msg.RequestID)
 		return
@@ -1602,6 +1609,8 @@ func (s *Server) handleComplete(providerID string, provider *registry.Provider, 
 	// check usage immediately after the HTTP response completes.
 	responseTime := time.Duration(msg.Usage.CompletionTokens) * time.Millisecond * 10
 	s.registry.RecordJobSuccess(providerID, responseTime)
+	// Serving this model proves the pair can load — lift any cool-down early.
+	s.registry.ClearDispatchLoadCooldown(providerID, pr.Model)
 
 	// Resolve the consumer once: platform-fee override (nil = global default)
 	// and whether this is a wholesale/service channel (e.g. OpenRouter). A
@@ -1918,22 +1927,26 @@ func (s *Server) handleInferenceError(providerID string, provider *registry.Prov
 		return
 	}
 	pr := provider.RemovePending(msg.RequestID)
+	// Clear any parked settlement record (consumer disconnected mid-stream).
+	// Same object as a non-nil pr when the terminal raced the disconnect defer.
+	parked := s.claimSettlement(msg.RequestID)
+	if pr == nil {
+		pr = parked
+	}
 	if pr == nil {
 		s.logger.Warn("error for unknown request", "provider_id", providerID, "request_id", msg.RequestID)
 		return
 	}
-
-	pr.ErrorCh <- *msg
-	close(pr.ChunkCh)
-	close(pr.CompleteCh)
-	close(pr.ErrorCh)
+	consumerGone := parked != nil
 
 	// Record job failure for reputation tracking, but carve out capacity
 	// rejections — those are not provider faults, just the provider declining
 	// work it cannot currently serve (the coordinator reroutes these). Counting
 	// them would unfairly penalise healthy providers shedding load. Capacity
 	// signals: HTTP 503 (service unavailable) / 429 (too many requests), an
-	// exhausted token budget, or an out-of-memory model-load reject.
+	// exhausted token budget, or an out-of-memory model-load reject. Done before
+	// the consumer-gone return so a load reject still records its cool-down even
+	// when the consumer already disconnected.
 	loweredErr := strings.ToLower(msg.Error)
 	capacityRejection := msg.StatusCode == http.StatusServiceUnavailable ||
 		msg.StatusCode == http.StatusTooManyRequests ||
@@ -1943,8 +1956,34 @@ func (s *Server) handleInferenceError(providerID string, provider *registry.Prov
 		s.registry.RecordJobFailure(providerID)
 	}
 
-	// Mark provider idle.
+	// A load reject means the provider cannot serve this model RIGHT NOW and
+	// will fail every dispatch for it identically (observed in prod as
+	// hundreds of dispatch→503 loops against memory-wedged boxes). Put the
+	// provider-model pair on a routing cool-down so retries land on real
+	// capacity; cleared on re-registration or a served request for the pair.
+	if strings.Contains(loweredErr, "insufficient memory") {
+		if s.registry.RecordDispatchLoadFailure(providerID, pr.Model) {
+			s.logger.Warn("load-failure cool-down started",
+				"provider_id", providerID,
+				"model", pr.Model,
+			)
+			s.ddIncr("routing.load_failure_cooldowns", []string{"model:" + pr.Model})
+		}
+	}
+
 	s.registry.SetProviderIdle(providerID)
+
+	if consumerGone {
+		// No reader for the consumer channels (they disconnected) — settle by
+		// refunding the reservation instead of pushing onto ErrorCh.
+		s.refundReservedBalance(pr, "provider_error_after_disconnect:"+msg.RequestID)
+		return
+	}
+
+	pr.ErrorCh <- *msg
+	close(pr.ChunkCh)
+	close(pr.CompleteCh)
+	close(pr.ErrorCh)
 
 	s.logger.Error("inference error",
 		"request_id", msg.RequestID,

--- a/coordinator/api/provider.go
+++ b/coordinator/api/provider.go
@@ -1486,6 +1486,14 @@ func (s *Server) handleChunk(providerID string, provider *registry.Provider, msg
 	pr := provider.GetPending(msg.RequestID)
 	if pr == nil {
 		s.logger.Warn("chunk for unknown request", "provider_id", providerID, "request_id", msg.RequestID)
+		// The provider is still generating into a stream we abandoned (consumer
+		// gone / already settled), burning its GPU and token-budget admission.
+		// Nudge it to stop — throttled so a chunk-per-token zombie doesn't flood
+		// the provider with cancels.
+		if s.zombieCanceller.shouldCancel(msg.RequestID, time.Now()) {
+			s.sendProviderCancel(provider, msg.RequestID)
+			s.ddIncr("inference.zombie_stream_cancel", []string{})
+		}
 		return
 	}
 	chunkData, err := decryptTextResponseChunk(provider, pr, msg)

--- a/coordinator/api/provider.go
+++ b/coordinator/api/provider.go
@@ -1584,13 +1584,20 @@ func (s *Server) handleComplete(providerID string, provider *registry.Provider, 
 	pr := provider.RemovePending(msg.RequestID)
 	// Clear any parked settlement record (consumer disconnected mid-stream):
 	// settles the disconnect case and stops the grace timer from no-op-refunding.
-	if parked := s.claimSettlement(msg.RequestID); parked != nil && pr == nil {
+	parked := s.claimSettlement(msg.RequestID)
+	if pr == nil {
 		pr = parked
 	}
 	if pr == nil {
 		s.logger.Warn("complete for unknown request", "provider_id", providerID, "request_id", msg.RequestID)
 		return
 	}
+	// A parked record means the consumer handler already returned: there is no
+	// channel reader, and registry.Disconnect may have already CLOSED the
+	// channels (park-before-remove leaves a window where the record is in both
+	// the pending map and the holder) — sending would panic. Billing still
+	// settles below; only the consumer signaling is skipped.
+	consumerGone := parked != nil
 
 	// Store SE signature for the consumer response headers.
 	pr.SESignature = msg.SESignature
@@ -1910,9 +1917,13 @@ func (s *Server) handleComplete(providerID string, provider *registry.Provider, 
 	// Signal completion to the consumer response handler. This must happen
 	// AFTER usage/billing is recorded because closing ChunkCh immediately
 	// unblocks the HTTP response, and callers may check usage right after.
-	pr.CompleteCh <- msg.Usage
-	close(pr.ChunkCh)
-	close(pr.CompleteCh)
+	// Skipped when the consumer is gone: no reader, and the channels may
+	// already be closed (send would panic).
+	if !consumerGone {
+		pr.CompleteCh <- msg.Usage
+		close(pr.ChunkCh)
+		close(pr.CompleteCh)
+	}
 
 	// Mark provider idle if no more pending requests.
 	s.registry.SetProviderIdle(providerID)
@@ -1945,15 +1956,21 @@ func (s *Server) handleInferenceError(providerID string, provider *registry.Prov
 	}
 	consumerGone := parked != nil
 
-	// Record a job failure, but not for capacity rejections — those aren't
-	// provider faults, just load shedding the coordinator reroutes. Run before
-	// the consumer-gone return so a load reject still starts its cool-down.
+	// Record a job failure, but not for capacity rejections or consumer
+	// cancellations — neither is a provider fault. Capacity = load shedding the
+	// coordinator reroutes. Cancel (499 / "request cancelled") = the CONSUMER
+	// disconnected; before the settlement holder these terminals died on
+	// pr==nil with zero reputation effect, and the old fleet emits one for
+	// every mid-stream disconnect — penalizing them would erode the whole
+	// fleet's reputation for consumer behavior.
 	loweredErr := strings.ToLower(msg.Error)
 	capacityRejection := msg.StatusCode == http.StatusServiceUnavailable ||
 		msg.StatusCode == http.StatusTooManyRequests ||
 		strings.Contains(loweredErr, "token_budget_exhausted") ||
 		strings.Contains(loweredErr, "insufficient memory")
-	if !capacityRejection {
+	cancelTerminal := msg.StatusCode == 499 ||
+		strings.Contains(loweredErr, "request cancelled")
+	if !capacityRejection && !cancelTerminal {
 		s.registry.RecordJobFailure(providerID)
 	}
 
@@ -1970,10 +1987,22 @@ func (s *Server) handleInferenceError(providerID string, provider *registry.Prov
 
 	s.registry.SetProviderIdle(providerID)
 
+	// Settle the reservation server-side for EVERY error terminal, off the read
+	// loop (a store Credit can block for seconds under DB pressure, and this
+	// handler runs on the provider WS read loop — blocking it stalls heartbeats
+	// and challenge responses, feeding the eviction churn). Unconditional so a
+	// spontaneous provider error landing in the gap between the consumer
+	// goroutine abandoning its channels and its defer parking the record can't
+	// leak the reservation. FinalizeReservation is single-winner, so the racing
+	// refunds (relay ErrorCh reader, settlement grace timer) stay idempotent.
+	refundPr := pr
+	refundID := msg.RequestID
+	saferun.Go(s.logger, "api.refundOnInferenceError", func() {
+		s.refundReservedBalance(refundPr, "provider_error:"+refundID)
+	})
+
 	if consumerGone {
-		// No reader for the consumer channels (they disconnected) — settle by
-		// refunding the reservation instead of pushing onto ErrorCh.
-		s.refundReservedBalance(pr, "provider_error_after_disconnect:"+msg.RequestID)
+		// Consumer disconnected — no reader for the channels; nothing to push.
 		return
 	}
 

--- a/coordinator/api/provider.go
+++ b/coordinator/api/provider.go
@@ -1574,10 +1574,8 @@ func (s *Server) handleComplete(providerID string, provider *registry.Provider, 
 		return
 	}
 	pr := provider.RemovePending(msg.RequestID)
-	// Always clear any parked settlement record for this request (consumer
-	// disconnected mid-stream). It's the SAME object as a non-nil pr when the
-	// terminal raced the disconnect defer; claiming it here both settles the
-	// disconnect case and stops the grace timer from later no-op-refunding.
+	// Clear any parked settlement record (consumer disconnected mid-stream):
+	// settles the disconnect case and stops the grace timer from no-op-refunding.
 	if parked := s.claimSettlement(msg.RequestID); parked != nil && pr == nil {
 		pr = parked
 	}
@@ -1939,14 +1937,9 @@ func (s *Server) handleInferenceError(providerID string, provider *registry.Prov
 	}
 	consumerGone := parked != nil
 
-	// Record job failure for reputation tracking, but carve out capacity
-	// rejections — those are not provider faults, just the provider declining
-	// work it cannot currently serve (the coordinator reroutes these). Counting
-	// them would unfairly penalise healthy providers shedding load. Capacity
-	// signals: HTTP 503 (service unavailable) / 429 (too many requests), an
-	// exhausted token budget, or an out-of-memory model-load reject. Done before
-	// the consumer-gone return so a load reject still records its cool-down even
-	// when the consumer already disconnected.
+	// Record a job failure, but not for capacity rejections — those aren't
+	// provider faults, just load shedding the coordinator reroutes. Run before
+	// the consumer-gone return so a load reject still starts its cool-down.
 	loweredErr := strings.ToLower(msg.Error)
 	capacityRejection := msg.StatusCode == http.StatusServiceUnavailable ||
 		msg.StatusCode == http.StatusTooManyRequests ||
@@ -1956,11 +1949,7 @@ func (s *Server) handleInferenceError(providerID string, provider *registry.Prov
 		s.registry.RecordJobFailure(providerID)
 	}
 
-	// A load reject means the provider cannot serve this model RIGHT NOW and
-	// will fail every dispatch for it identically (observed in prod as
-	// hundreds of dispatch→503 loops against memory-wedged boxes). Put the
-	// provider-model pair on a routing cool-down so retries land on real
-	// capacity; cleared on re-registration or a served request for the pair.
+	// Cool down a load-rejecting pair so retries skip it (see dispatchLoadCooldowns).
 	if strings.Contains(loweredErr, "insufficient memory") {
 		if s.registry.RecordDispatchLoadFailure(providerID, pr.Model) {
 			s.logger.Warn("load-failure cool-down started",

--- a/coordinator/api/server.go
+++ b/coordinator/api/server.go
@@ -210,6 +210,13 @@ type Server struct {
 	// unverified and excluded from routing (but not disconnected).
 	knownRuntimeManifest *RuntimeManifest
 
+	// settlements parks billing records for requests whose consumer disconnected
+	// mid-stream, so a late provider terminal can settle them (or the reservation
+	// is refunded on grace expiry). See settlement.go.
+	settlements *settlementHolder
+	// settleGrace overrides defaultTerminalSettleGrace (tests set it small).
+	settleGrace time.Duration
+
 	// minProviderVersion is the minimum provider version accepted for routing.
 	// Providers below this version are excluded and told to update.
 	// Set from EIGENINFERENCE_MIN_PROVIDER_VERSION env var or derived from latest release.
@@ -537,6 +544,7 @@ func NewServer(reg *registry.Registry, st store.Store, cfg ServerConfig, logger 
 		apiKeyCache:          make(map[string]apiKeyCacheEntry),
 		pendingACME:          make(map[string]*ACMEVerificationResult),
 		codeAttestThrottle:   newCodeAttestThrottle(),
+		settlements:          newSettlementHolder(),
 	}
 	s.registerDefaultGauges()
 	s.routes()

--- a/coordinator/api/server.go
+++ b/coordinator/api/server.go
@@ -216,6 +216,8 @@ type Server struct {
 	settlements *settlementHolder
 	// settleGrace overrides defaultTerminalSettleGrace (tests set it small).
 	settleGrace time.Duration
+	// zombieCanceller throttles cancels for chunks on abandoned streams. See zombie_stream.go.
+	zombieCanceller *zombieStreamCanceller
 
 	// minProviderVersion is the minimum provider version accepted for routing.
 	// Providers below this version are excluded and told to update.
@@ -545,6 +547,7 @@ func NewServer(reg *registry.Registry, st store.Store, cfg ServerConfig, logger 
 		pendingACME:          make(map[string]*ACMEVerificationResult),
 		codeAttestThrottle:   newCodeAttestThrottle(),
 		settlements:          newSettlementHolder(),
+		zombieCanceller:      newZombieStreamCanceller(),
 	}
 	s.registerDefaultGauges()
 	s.routes()

--- a/coordinator/api/settlement.go
+++ b/coordinator/api/settlement.go
@@ -7,26 +7,18 @@ import (
 	"github.com/eigeninference/d-inference/coordinator/registry"
 )
 
-// defaultTerminalSettleGrace is how long a mid-stream-disconnected request's
-// billing record is held, waiting for the provider's terminal
-// inference_complete/_error to settle it, before the reservation is refunded.
-//
-// A connected provider aborts and emits its terminal within milliseconds of the
-// cancel; 30s covers WS latency with a wide margin. The record lives OUTSIDE the
-// provider's pending set (registry pendingReqs), so it never counts against the
-// provider's concurrency headroom or idle state during the wait — the slot frees
-// immediately on disconnect, only the billing tail lingers.
+// defaultTerminalSettleGrace bounds how long a disconnected request's billing
+// record waits for the provider's terminal before its reservation is refunded.
+// A connected provider aborts within ms; 30s is a wide WS-latency margin. The
+// record lives outside the provider's pending set, so it doesn't count against
+// concurrency/idle while waiting.
 const defaultTerminalSettleGrace = 30 * time.Second
 
-// settlementHolder parks the billing context of a request whose consumer
-// disconnected mid-stream so a late provider terminal can still settle it
-// (charge for delivered tokens) instead of hitting "complete for unknown
-// request" — which would leak the consumer's reservation and pay the provider
-// nothing for real work. If no terminal arrives within the grace, the reservation
-// is refunded. Claim is single-winner: whichever of the terminal handler or the
-// grace timer claims first gets the record; the other sees nil. Reservation
-// finalization is independently idempotent (FinalizeReservation), so a settle/
-// refund race cannot double-count.
+// settlementHolder parks the billing record of a consumer-disconnected request
+// so a late provider terminal can settle it (charge delivered tokens) instead of
+// hitting "unknown request" — which would leak the reservation and pay $0. No
+// terminal within the grace → refund. Claim is single-winner (terminal handler
+// vs. grace timer); FinalizeReservation independently guards double-counting.
 type settlementHolder struct {
 	mu      sync.Mutex
 	pending map[string]*registry.PendingRequest
@@ -66,8 +58,8 @@ func (h *settlementHolder) claim(requestID string) *registry.PendingRequest {
 	return pr
 }
 
-// terminalSettleGrace returns the configured grace, defaulting when unset (so
-// tests can shrink it via the Server field without every caller threading it).
+// terminalSettleGrace returns the configured grace, defaulting when unset
+// (tests shrink it via s.settleGrace).
 func (s *Server) terminalSettleGrace() time.Duration {
 	if s.settleGrace > 0 {
 		return s.settleGrace
@@ -88,10 +80,8 @@ func (s *Server) holdForSettlement(pr *registry.PendingRequest) {
 		return
 	}
 	s.settlements.hold(pr, s.terminalSettleGrace(), func(expired *registry.PendingRequest) {
-		// Only log a refund if this call actually finalized it. With
-		// park-before-remove, a request settled by handleComplete can leave a
-		// duplicate here; FinalizeReservation makes the refund a no-op in that
-		// case (returns false) — don't claim a refund that didn't happen.
+		// Log only if this actually refunded — a request already settled by
+		// handleComplete leaves a dup here whose refund no-ops (FinalizeReservation).
 		if s.refundReservedBalance(expired, "no_terminal_after_cancel:"+expired.RequestID) {
 			s.logger.Warn("no terminal from provider after cancel — refunded reservation",
 				"request_id", expired.RequestID,

--- a/coordinator/api/settlement.go
+++ b/coordinator/api/settlement.go
@@ -1,0 +1,111 @@
+package api
+
+import (
+	"sync"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/registry"
+)
+
+// defaultTerminalSettleGrace is how long a mid-stream-disconnected request's
+// billing record is held, waiting for the provider's terminal
+// inference_complete/_error to settle it, before the reservation is refunded.
+//
+// A connected provider aborts and emits its terminal within milliseconds of the
+// cancel; 30s covers WS latency with a wide margin. The record lives OUTSIDE the
+// provider's pending set (registry pendingReqs), so it never counts against the
+// provider's concurrency headroom or idle state during the wait — the slot frees
+// immediately on disconnect, only the billing tail lingers.
+const defaultTerminalSettleGrace = 30 * time.Second
+
+// settlementHolder parks the billing context of a request whose consumer
+// disconnected mid-stream so a late provider terminal can still settle it
+// (charge for delivered tokens) instead of hitting "complete for unknown
+// request" — which would leak the consumer's reservation and pay the provider
+// nothing for real work. If no terminal arrives within the grace, the reservation
+// is refunded. Claim is single-winner: whichever of the terminal handler or the
+// grace timer claims first gets the record; the other sees nil. Reservation
+// finalization is independently idempotent (FinalizeReservation), so a settle/
+// refund race cannot double-count.
+type settlementHolder struct {
+	mu      sync.Mutex
+	pending map[string]*registry.PendingRequest
+}
+
+func newSettlementHolder() *settlementHolder {
+	return &settlementHolder{pending: make(map[string]*registry.PendingRequest)}
+}
+
+// hold stores pr under its request id and schedules onExpiry(pr) after grace if
+// it has not been claimed by then. onExpiry runs at most once for a held record.
+func (h *settlementHolder) hold(pr *registry.PendingRequest, grace time.Duration, onExpiry func(*registry.PendingRequest)) {
+	if pr == nil {
+		return
+	}
+	h.mu.Lock()
+	h.pending[pr.RequestID] = pr
+	h.mu.Unlock()
+
+	time.AfterFunc(grace, func() {
+		if expired := h.claim(pr.RequestID); expired != nil {
+			onExpiry(expired)
+		}
+	})
+}
+
+// claim removes and returns the held record for requestID, or nil if none
+// (already claimed, expired, or never held).
+func (h *settlementHolder) claim(requestID string) *registry.PendingRequest {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	pr, ok := h.pending[requestID]
+	if !ok {
+		return nil
+	}
+	delete(h.pending, requestID)
+	return pr
+}
+
+// terminalSettleGrace returns the configured grace, defaulting when unset (so
+// tests can shrink it via the Server field without every caller threading it).
+func (s *Server) terminalSettleGrace() time.Duration {
+	if s.settleGrace > 0 {
+		return s.settleGrace
+	}
+	return defaultTerminalSettleGrace
+}
+
+// holdForSettlement parks a mid-stream-disconnected request for late-terminal
+// settlement, refunding its reservation if no terminal arrives within the grace.
+func (s *Server) holdForSettlement(pr *registry.PendingRequest) {
+	if pr == nil {
+		return
+	}
+	if s.settlements == nil {
+		// Defensive: a Server built without newSettlementHolder still refunds
+		// rather than leaking the reservation.
+		s.refundReservedBalance(pr, "no_terminal_after_cancel:"+pr.RequestID)
+		return
+	}
+	s.settlements.hold(pr, s.terminalSettleGrace(), func(expired *registry.PendingRequest) {
+		// Only log a refund if this call actually finalized it. With
+		// park-before-remove, a request settled by handleComplete can leave a
+		// duplicate here; FinalizeReservation makes the refund a no-op in that
+		// case (returns false) — don't claim a refund that didn't happen.
+		if s.refundReservedBalance(expired, "no_terminal_after_cancel:"+expired.RequestID) {
+			s.logger.Warn("no terminal from provider after cancel — refunded reservation",
+				"request_id", expired.RequestID,
+			)
+		}
+	})
+}
+
+// claimSettlement returns a parked billing record for requestID (consumed), or
+// nil. Used by the terminal handlers when the request is no longer in the
+// provider's pending set because the consumer already disconnected.
+func (s *Server) claimSettlement(requestID string) *registry.PendingRequest {
+	if s.settlements == nil {
+		return nil
+	}
+	return s.settlements.claim(requestID)
+}

--- a/coordinator/api/settlement_test.go
+++ b/coordinator/api/settlement_test.go
@@ -1,0 +1,128 @@
+package api
+
+import (
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/registry"
+)
+
+// settlementHolder: claim before expiry wins and the expiry callback never runs.
+func TestSettlementHolderClaimBeatsExpiry(t *testing.T) {
+	h := newSettlementHolder()
+	pr := &registry.PendingRequest{RequestID: "r1"}
+	expired := make(chan struct{}, 1)
+	h.hold(pr, 100*time.Millisecond, func(*registry.PendingRequest) { expired <- struct{}{} })
+
+	if got := h.claim("r1"); got != pr {
+		t.Fatalf("claim returned %v, want the held pr", got)
+	}
+	if got := h.claim("r1"); got != nil {
+		t.Fatal("second claim should return nil (record consumed)")
+	}
+	select {
+	case <-expired:
+		t.Fatal("expiry callback ran for an already-claimed record")
+	case <-time.After(250 * time.Millisecond):
+	}
+}
+
+// settlementHolder: with no claim, the expiry callback fires exactly once.
+func TestSettlementHolderExpiryFires(t *testing.T) {
+	h := newSettlementHolder()
+	pr := &registry.PendingRequest{RequestID: "r2"}
+	got := make(chan *registry.PendingRequest, 2)
+	h.hold(pr, 30*time.Millisecond, func(p *registry.PendingRequest) { got <- p })
+
+	select {
+	case p := <-got:
+		if p != pr {
+			t.Fatalf("expiry got %v, want held pr", p)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("expiry callback never fired")
+	}
+	if c := h.claim("r2"); c != nil {
+		t.Fatal("record should be gone after expiry claimed it")
+	}
+}
+
+// holdForSettlement refunds the reservation when no terminal arrives — the
+// pre-existing leak (consumer disconnects mid-stream, provider never settles).
+func TestHoldForSettlementRefundsOnExpiry(t *testing.T) {
+	srv, _, ledger := billingTestServer(t)
+	srv.settleGrace = 50 * time.Millisecond
+
+	acct := testConsumerID
+	base := ledger.Balance(acct)
+	const reserved int64 = 2_000_000
+	pr := &registry.PendingRequest{
+		RequestID:            "settle-refund",
+		Model:                "m",
+		ConsumerKey:          acct,
+		BaseReservedMicroUSD: reserved,
+		ReservedMicroUSD:     reserved,
+	}
+
+	srv.holdForSettlement(pr)
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if ledger.Balance(acct) == base+reserved {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if got := ledger.Balance(acct); got != base+reserved {
+		t.Fatalf("balance after grace = %d, want %d (reservation refunded)", got, base+reserved)
+	}
+}
+
+// When a terminal claims the parked record first, the grace timer must NOT also
+// refund — the terminal path settles it. (Single-winner + FinalizeReservation.)
+func TestHoldForSettlementClaimedNotRefunded(t *testing.T) {
+	srv, _, ledger := billingTestServer(t)
+	srv.settleGrace = 50 * time.Millisecond
+
+	acct := testConsumerID
+	base := ledger.Balance(acct)
+	pr := &registry.PendingRequest{
+		RequestID:            "settle-claimed",
+		Model:                "m",
+		ConsumerKey:          acct,
+		BaseReservedMicroUSD: 1_000_000,
+		ReservedMicroUSD:     1_000_000,
+	}
+
+	srv.holdForSettlement(pr)
+	// Simulate the terminal handler claiming the record before grace expiry.
+	if claimed := srv.claimSettlement("settle-claimed"); claimed != pr {
+		t.Fatal("claimSettlement did not return the held record")
+	}
+
+	time.Sleep(200 * time.Millisecond) // let the grace timer fire (it should no-op)
+	if got := ledger.Balance(acct); got != base {
+		t.Fatalf("balance = %d, want %d (claimed record must not be auto-refunded)", got, base)
+	}
+}
+
+// Defensive: a Server without a settlement holder still refunds rather than
+// leaking the reservation.
+func TestHoldForSettlementNilHolderRefunds(t *testing.T) {
+	srv, _, ledger := billingTestServer(t)
+	srv.settlements = nil
+	acct := testConsumerID
+	base := ledger.Balance(acct)
+	const reserved int64 = 500_000
+	pr := &registry.PendingRequest{
+		RequestID:            "nil-holder",
+		Model:                "m",
+		ConsumerKey:          acct,
+		BaseReservedMicroUSD: reserved,
+		ReservedMicroUSD:     reserved,
+	}
+	srv.holdForSettlement(pr)
+	if got := ledger.Balance(acct); got != base+reserved {
+		t.Fatalf("balance = %d, want %d (nil holder must refund immediately)", got, base+reserved)
+	}
+}

--- a/coordinator/api/zombie_stream.go
+++ b/coordinator/api/zombie_stream.go
@@ -11,6 +11,7 @@ import (
 // one cancel per request per this interval is enough to stop a provider that's
 // actually listening, and harmless against one that isn't.
 const zombieCancelThrottle = 10 * time.Second
+const zombieCancelMaxEntries = 4096
 
 // zombieStreamCanceller throttles cancels sent for chunks that arrive for a
 // request the coordinator no longer tracks (consumer gone / already settled).
@@ -32,15 +33,30 @@ func newZombieStreamCanceller() *zombieStreamCanceller {
 func (z *zombieStreamCanceller) shouldCancel(requestID string, now time.Time) bool {
 	z.mu.Lock()
 	defer z.mu.Unlock()
-	if len(z.sent) > 4096 {
+
+	if t, ok := z.sent[requestID]; ok {
+		if now.Sub(t) < zombieCancelThrottle {
+			return false
+		}
+		delete(z.sent, requestID)
+	}
+
+	if len(z.sent) >= zombieCancelMaxEntries {
+		var oldestID string
+		var oldest time.Time
 		for id, t := range z.sent {
 			if now.Sub(t) > zombieCancelThrottle {
 				delete(z.sent, id)
+				continue
+			}
+			if oldestID == "" || t.Before(oldest) {
+				oldestID = id
+				oldest = t
 			}
 		}
-	}
-	if t, ok := z.sent[requestID]; ok && now.Sub(t) < zombieCancelThrottle {
-		return false
+		if len(z.sent) >= zombieCancelMaxEntries && oldestID != "" {
+			delete(z.sent, oldestID)
+		}
 	}
 	z.sent[requestID] = now
 	return true

--- a/coordinator/api/zombie_stream.go
+++ b/coordinator/api/zombie_stream.go
@@ -1,0 +1,47 @@
+package api
+
+import (
+	"sync"
+	"time"
+)
+
+// zombieCancelThrottle bounds how often the coordinator re-sends a cancel for
+// the same abandoned (unknown) request. A zombie stream emits ~1 chunk per
+// token, so cancelling on every chunk would flood the provider with WS writes;
+// one cancel per request per this interval is enough to stop a provider that's
+// actually listening, and harmless against one that isn't.
+const zombieCancelThrottle = 10 * time.Second
+
+// zombieStreamCanceller throttles cancels sent for chunks that arrive for a
+// request the coordinator no longer tracks (consumer gone / already settled).
+// Such a stream burns provider GPU and token-budget admission until max_tokens,
+// so the coordinator nudges the provider to stop — but at most once per
+// throttle window per request.
+type zombieStreamCanceller struct {
+	mu   sync.Mutex
+	sent map[string]time.Time
+}
+
+func newZombieStreamCanceller() *zombieStreamCanceller {
+	return &zombieStreamCanceller{sent: make(map[string]time.Time)}
+}
+
+// shouldCancel reports whether to send a cancel for requestID now, recording
+// the send. Returns false within zombieCancelThrottle of the last send for that
+// id. Opportunistically sweeps expired entries so the map stays bounded.
+func (z *zombieStreamCanceller) shouldCancel(requestID string, now time.Time) bool {
+	z.mu.Lock()
+	defer z.mu.Unlock()
+	if len(z.sent) > 4096 {
+		for id, t := range z.sent {
+			if now.Sub(t) > zombieCancelThrottle {
+				delete(z.sent, id)
+			}
+		}
+	}
+	if t, ok := z.sent[requestID]; ok && now.Sub(t) < zombieCancelThrottle {
+		return false
+	}
+	z.sent[requestID] = now
+	return true
+}

--- a/coordinator/api/zombie_stream_test.go
+++ b/coordinator/api/zombie_stream_test.go
@@ -1,0 +1,42 @@
+package api
+
+import (
+	"testing"
+	"time"
+)
+
+func TestZombieStreamCancellerThrottle(t *testing.T) {
+	z := newZombieStreamCanceller()
+	t0 := time.Now()
+
+	if !z.shouldCancel("req-1", t0) {
+		t.Fatal("first chunk for an unknown request should cancel")
+	}
+	if z.shouldCancel("req-1", t0.Add(time.Second)) {
+		t.Fatal("second chunk within the throttle window should NOT re-cancel")
+	}
+	// A different request is independent.
+	if !z.shouldCancel("req-2", t0.Add(time.Second)) {
+		t.Fatal("a different unknown request should cancel")
+	}
+	// After the throttle window, the same request cancels again.
+	if !z.shouldCancel("req-1", t0.Add(zombieCancelThrottle+time.Second)) {
+		t.Fatal("after the throttle window the same request should cancel again")
+	}
+}
+
+func TestZombieStreamCancellerSweepBounded(t *testing.T) {
+	z := newZombieStreamCanceller()
+	base := time.Now()
+	for i := 0; i < 5000; i++ {
+		z.shouldCancel(string(rune('a'+i%26))+string(rune('0'+i%10))+string(rune(i)), base)
+	}
+	// All those are expired relative to a far-future call, which triggers the sweep.
+	z.shouldCancel("trigger", base.Add(zombieCancelThrottle+time.Hour))
+	z.mu.Lock()
+	n := len(z.sent)
+	z.mu.Unlock()
+	if n > 4096 {
+		t.Fatalf("map not bounded after sweep: %d entries", n)
+	}
+}

--- a/coordinator/api/zombie_stream_test.go
+++ b/coordinator/api/zombie_stream_test.go
@@ -31,12 +31,19 @@ func TestZombieStreamCancellerSweepBounded(t *testing.T) {
 	for i := 0; i < 5000; i++ {
 		z.shouldCancel(string(rune('a'+i%26))+string(rune('0'+i%10))+string(rune(i)), base)
 	}
-	// All those are expired relative to a far-future call, which triggers the sweep.
-	z.shouldCancel("trigger", base.Add(zombieCancelThrottle+time.Hour))
 	z.mu.Lock()
 	n := len(z.sent)
 	z.mu.Unlock()
-	if n > 4096 {
+	if n > zombieCancelMaxEntries {
+		t.Fatalf("map not bounded during fresh burst: %d entries", n)
+	}
+
+	// All those are expired relative to a far-future call, which triggers the sweep.
+	z.shouldCancel("trigger", base.Add(zombieCancelThrottle+time.Hour))
+	z.mu.Lock()
+	n = len(z.sent)
+	z.mu.Unlock()
+	if n > zombieCancelMaxEntries {
 		t.Fatalf("map not bounded after sweep: %d entries", n)
 	}
 }

--- a/coordinator/datadog/datadog.go
+++ b/coordinator/datadog/datadog.go
@@ -43,6 +43,12 @@ type Client struct {
 	logTicker  *time.Ticker
 	logDone    chan struct{}
 	logFlushWg sync.WaitGroup
+
+	// HTTP gauge submission (no agent needed). See metrics_http.go.
+	series      *seriesBuffer
+	seriesURL   string
+	metricsHost string
+	metricsTags []string
 }
 
 // Config holds Datadog configuration. Populated from env vars in NewClient.
@@ -98,6 +104,10 @@ func NewClient(cfg Config, logger *slog.Logger) (*Client, error) {
 	}
 	c.logsURL = fmt.Sprintf("https://http-intake.logs.%s/api/v2/logs", site)
 	c.eventsURL = fmt.Sprintf("https://api.%s/api/v1/events", site)
+	c.seriesURL = fmt.Sprintf("https://api.%s/api/v1/series", site)
+	c.series = newSeriesBuffer()
+	c.metricsTags = []string{"env:" + cfg.Env, "service:" + cfg.Service}
+	c.metricsHost = envOr("DD_HOSTNAME", cfg.Service)
 
 	// DogStatsD client — best effort. If the agent isn't running, metrics
 	// calls become no-ops (the library handles reconnection).
@@ -130,6 +140,7 @@ func (c *Client) Close() {
 	close(c.logDone)
 	c.logFlushWg.Wait()
 	c.flushLogs()
+	c.flushSeries()
 	if c.Statsd != nil {
 		_ = c.Statsd.Close()
 	}
@@ -163,12 +174,19 @@ func (c *Client) Histogram(name string, value float64, tags []string) {
 	_ = c.Statsd.Histogram(name, value, tags, 1)
 }
 
-// Gauge sets a gauge value.
+// Gauge sets a gauge value. Sent via DogStatsD (if an agent is reachable) AND
+// buffered for HTTP submission (if DD_API_KEY is set) so fleet gauges land even
+// without a local agent. See metrics_http.go.
 func (c *Client) Gauge(name string, value float64, tags []string) {
-	if c == nil || c.Statsd == nil {
+	if c == nil {
 		return
 	}
-	_ = c.Statsd.Gauge(name, value, tags, 1)
+	if c.Statsd != nil {
+		_ = c.Statsd.Gauge(name, value, tags, 1)
+	}
+	if c.apiKey != "" && c.series != nil {
+		c.series.setGauge(name, value, tags, time.Now().Unix())
+	}
 }
 
 // ---------------------------------------------------------------------------
@@ -277,6 +295,7 @@ func (c *Client) logFlushLoop() {
 		select {
 		case <-c.logTicker.C:
 			c.flushLogs()
+			c.flushSeries()
 		case <-c.logDone:
 			return
 		}

--- a/coordinator/datadog/datadog.go
+++ b/coordinator/datadog/datadog.go
@@ -44,11 +44,12 @@ type Client struct {
 	logDone    chan struct{}
 	logFlushWg sync.WaitGroup
 
-	// HTTP gauge submission (no agent needed). See metrics_http.go.
-	series      *seriesBuffer
-	seriesURL   string
-	metricsHost string
-	metricsTags []string
+	// HTTP metric submission (no agent needed). See metrics_http.go.
+	series            *seriesBuffer
+	seriesURL         string
+	metricsHost       string
+	metricsTags       []string
+	flushIntervalSecs int64
 }
 
 // Config holds Datadog configuration. Populated from env vars in NewClient.
@@ -108,6 +109,7 @@ func NewClient(cfg Config, logger *slog.Logger) (*Client, error) {
 	c.series = newSeriesBuffer()
 	c.metricsTags = []string{"env:" + cfg.Env, "service:" + cfg.Service}
 	c.metricsHost = envOr("DD_HOSTNAME", cfg.Service)
+	c.flushIntervalSecs = int64(cfg.FlushSecs)
 
 	// DogStatsD client — best effort. If the agent isn't running, metrics
 	// calls become no-ops (the library handles reconnection).
@@ -150,23 +152,35 @@ func (c *Client) Close() {
 // DogStatsD convenience methods
 // ---------------------------------------------------------------------------
 
+// httpMetrics reports whether metrics go via the HTTPS series API. When true,
+// the DogStatsD leg is skipped for gauges/counters — teeing both would
+// double-count if an agent ever appears, with divergent host tags. See
+// metrics_http.go.
+func (c *Client) httpMetrics() bool {
+	return c.apiKey != "" && c.series != nil
+}
+
 // Incr increments a counter.
 func (c *Client) Incr(name string, tags []string) {
-	if c == nil || c.Statsd == nil {
-		return
-	}
-	_ = c.Statsd.Incr(name, tags, 1)
+	c.Count(name, 1, tags)
 }
 
-// Count increments a DogStatsD counter by the given value.
+// Count increments a counter by the given value.
 func (c *Client) Count(name string, value int64, tags []string) {
-	if c == nil || c.Statsd == nil {
+	if c == nil {
 		return
 	}
-	_ = c.Statsd.Count(name, value, tags, 1)
+	if c.httpMetrics() {
+		c.series.addCount(name, float64(value), tags, time.Now().Unix())
+		return
+	}
+	if c.Statsd != nil {
+		_ = c.Statsd.Count(name, value, tags, 1)
+	}
 }
 
-// Histogram records a histogram value.
+// Histogram records a histogram value. DogStatsD-only: percentile aggregation
+// happens agent-side and isn't replicated by the HTTP path.
 func (c *Client) Histogram(name string, value float64, tags []string) {
 	if c == nil || c.Statsd == nil {
 		return
@@ -174,18 +188,17 @@ func (c *Client) Histogram(name string, value float64, tags []string) {
 	_ = c.Statsd.Histogram(name, value, tags, 1)
 }
 
-// Gauge sets a gauge value. Sent via DogStatsD (if an agent is reachable) AND
-// buffered for HTTP submission (if DD_API_KEY is set) so fleet gauges land even
-// without a local agent. See metrics_http.go.
+// Gauge sets a gauge value.
 func (c *Client) Gauge(name string, value float64, tags []string) {
 	if c == nil {
 		return
 	}
+	if c.httpMetrics() {
+		c.series.setGauge(name, value, tags, time.Now().Unix())
+		return
+	}
 	if c.Statsd != nil {
 		_ = c.Statsd.Gauge(name, value, tags, 1)
-	}
-	if c.apiKey != "" && c.series != nil {
-		c.series.setGauge(name, value, tags, time.Now().Unix())
 	}
 }
 

--- a/coordinator/datadog/metrics_http.go
+++ b/coordinator/datadog/metrics_http.go
@@ -1,0 +1,114 @@
+package datadog
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+)
+
+// HTTP gauge submission. DogStatsD sends metrics over UDP to a local agent;
+// the EigenCloud TEE container has no agent, so those metrics are silently
+// dropped (UDP) and fleet gauges like d_inference.providers.online never appear
+// in Datadog. Logs and events already submit directly over the HTTPS API with
+// DD_API_KEY (no agent needed) — this routes GAUGES the same way so fleet-health
+// metrics land. Counters/histograms still go via DogStatsD only (the agent-side
+// aggregation they need isn't replicated here); gauges are the fleet-visibility
+// metrics that were the actual gap.
+
+// seriesBuffer holds the latest value per (metric, tags) gauge until the next
+// flush — gauges are last-write-wins, so one point per series per interval is
+// the correct, agent-equivalent submission.
+type seriesBuffer struct {
+	mu     sync.Mutex
+	points map[string]seriesPoint
+}
+
+type seriesPoint struct {
+	metric string
+	tags   []string
+	value  float64
+	ts     int64
+}
+
+func newSeriesBuffer() *seriesBuffer {
+	return &seriesBuffer{points: make(map[string]seriesPoint)}
+}
+
+func (b *seriesBuffer) setGauge(metric string, value float64, tags []string, ts int64) {
+	key := metric + "|" + strings.Join(tags, ",")
+	b.mu.Lock()
+	b.points[key] = seriesPoint{metric: metric, tags: tags, value: value, ts: ts}
+	b.mu.Unlock()
+}
+
+func (b *seriesBuffer) drain() []seriesPoint {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if len(b.points) == 0 {
+		return nil
+	}
+	out := make([]seriesPoint, 0, len(b.points))
+	for _, p := range b.points {
+		out = append(out, p)
+	}
+	b.points = make(map[string]seriesPoint)
+	return out
+}
+
+// flushSeries POSTs buffered gauges to the Datadog v1 series API. Best-effort:
+// errors are logged, never fatal. No-op without an API key or buffered points.
+func (c *Client) flushSeries() {
+	if c == nil || c.apiKey == "" || c.series == nil {
+		return
+	}
+	pts := c.series.drain()
+	if len(pts) == 0 {
+		return
+	}
+
+	type ddMetric struct {
+		Metric string       `json:"metric"`
+		Points [][2]float64 `json:"points"`
+		Type   string       `json:"type"`
+		Tags   []string     `json:"tags,omitempty"`
+		Host   string       `json:"host,omitempty"`
+	}
+	series := make([]ddMetric, 0, len(pts))
+	for _, p := range pts {
+		tags := append(append([]string{}, c.metricsTags...), p.tags...)
+		series = append(series, ddMetric{
+			Metric: "d_inference." + p.metric, // mirror the DogStatsD WithNamespace prefix
+			Points: [][2]float64{{float64(p.ts), p.value}},
+			Type:   "gauge",
+			Tags:   tags,
+			Host:   c.metricsHost,
+		})
+	}
+
+	body, err := json.Marshal(map[string]any{"series": series})
+	if err != nil {
+		c.logger.Warn("datadog: failed to marshal series batch", "error", err)
+		return
+	}
+	req, err := http.NewRequest(http.MethodPost, c.seriesURL, bytes.NewReader(body))
+	if err != nil {
+		c.logger.Warn("datadog: failed to create series request", "error", err)
+		return
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Dd-Api-Key", c.apiKey)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		c.logger.Warn("datadog: series API request failed", "error", err, "batch_size", len(series))
+		return
+	}
+	_, _ = io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		c.logger.Warn("datadog: series API returned error", "status", resp.StatusCode, "batch_size", len(series))
+	}
+}

--- a/coordinator/datadog/metrics_http.go
+++ b/coordinator/datadog/metrics_http.go
@@ -9,21 +9,24 @@ import (
 	"sync"
 )
 
-// HTTP gauge submission. DogStatsD sends metrics over UDP to a local agent;
+// HTTP metric submission. DogStatsD sends metrics over UDP to a local agent;
 // the EigenCloud TEE container has no agent, so those metrics are silently
-// dropped (UDP) and fleet gauges like d_inference.providers.online never appear
-// in Datadog. Logs and events already submit directly over the HTTPS API with
-// DD_API_KEY (no agent needed) — this routes GAUGES the same way so fleet-health
-// metrics land. Counters/histograms still go via DogStatsD only (the agent-side
-// aggregation they need isn't replicated here); gauges are the fleet-visibility
-// metrics that were the actual gap.
+// dropped (UDP) and fleet metrics like d_inference.providers.online never
+// appear in Datadog. Logs and events already submit directly over the HTTPS
+// API with DD_API_KEY (no agent needed) — this routes GAUGES and COUNTERS the
+// same way. When DD_API_KEY is set the HTTP path is authoritative and the
+// DogStatsD leg is skipped (teeing would double-count if an agent ever
+// appears, with divergent host tags); without an API key, DogStatsD is the
+// only leg. Histograms remain DogStatsD-only: their percentile aggregation
+// happens agent-side and isn't replicated here.
 
-// seriesBuffer holds the latest value per (metric, tags) gauge until the next
-// flush — gauges are last-write-wins, so one point per series per interval is
-// the correct, agent-equivalent submission.
+// seriesBuffer accumulates metric points between flushes: gauges are
+// last-write-wins per (metric, tags) series; counters sum per series over the
+// flush interval — both matching what a local agent would submit.
 type seriesBuffer struct {
 	mu     sync.Mutex
-	points map[string]seriesPoint
+	gauges map[string]seriesPoint
+	counts map[string]seriesPoint
 }
 
 type seriesPoint struct {
@@ -34,58 +37,90 @@ type seriesPoint struct {
 }
 
 func newSeriesBuffer() *seriesBuffer {
-	return &seriesBuffer{points: make(map[string]seriesPoint)}
+	return &seriesBuffer{
+		gauges: make(map[string]seriesPoint),
+		counts: make(map[string]seriesPoint),
+	}
+}
+
+func seriesKey(metric string, tags []string) string {
+	return metric + "|" + strings.Join(tags, ",")
 }
 
 func (b *seriesBuffer) setGauge(metric string, value float64, tags []string, ts int64) {
-	key := metric + "|" + strings.Join(tags, ",")
+	key := seriesKey(metric, tags)
 	b.mu.Lock()
-	b.points[key] = seriesPoint{metric: metric, tags: tags, value: value, ts: ts}
+	b.gauges[key] = seriesPoint{metric: metric, tags: tags, value: value, ts: ts}
 	b.mu.Unlock()
 }
 
-func (b *seriesBuffer) drain() []seriesPoint {
+func (b *seriesBuffer) addCount(metric string, value float64, tags []string, ts int64) {
+	key := seriesKey(metric, tags)
 	b.mu.Lock()
-	defer b.mu.Unlock()
-	if len(b.points) == 0 {
-		return nil
+	p, ok := b.counts[key]
+	if !ok {
+		p = seriesPoint{metric: metric, tags: tags}
 	}
-	out := make([]seriesPoint, 0, len(b.points))
-	for _, p := range b.points {
-		out = append(out, p)
-	}
-	b.points = make(map[string]seriesPoint)
-	return out
+	p.value += value
+	p.ts = ts
+	b.counts[key] = p
+	b.mu.Unlock()
 }
 
-// flushSeries POSTs buffered gauges to the Datadog v1 series API. Best-effort:
-// errors are logged, never fatal. No-op without an API key or buffered points.
+// drain returns and clears the buffered gauges and counts.
+func (b *seriesBuffer) drain() (gauges, counts []seriesPoint) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	for _, p := range b.gauges {
+		gauges = append(gauges, p)
+	}
+	for _, p := range b.counts {
+		counts = append(counts, p)
+	}
+	b.gauges = make(map[string]seriesPoint)
+	b.counts = make(map[string]seriesPoint)
+	return gauges, counts
+}
+
+// ddMetric is the v1 /series payload entry.
+type ddMetric struct {
+	Metric   string       `json:"metric"`
+	Points   [][2]float64 `json:"points"`
+	Type     string       `json:"type"`
+	Interval int64        `json:"interval,omitempty"` // counts: the flush window
+	Tags     []string     `json:"tags,omitempty"`
+	Host     string       `json:"host,omitempty"`
+}
+
+// flushSeries POSTs buffered gauges and counters to the Datadog v1 series API.
+// Best-effort: errors are logged, never fatal. No-op without an API key or
+// buffered points.
 func (c *Client) flushSeries() {
 	if c == nil || c.apiKey == "" || c.series == nil {
 		return
 	}
-	pts := c.series.drain()
-	if len(pts) == 0 {
+	gauges, counts := c.series.drain()
+	if len(gauges)+len(counts) == 0 {
 		return
 	}
 
-	type ddMetric struct {
-		Metric string       `json:"metric"`
-		Points [][2]float64 `json:"points"`
-		Type   string       `json:"type"`
-		Tags   []string     `json:"tags,omitempty"`
-		Host   string       `json:"host,omitempty"`
-	}
-	series := make([]ddMetric, 0, len(pts))
-	for _, p := range pts {
+	series := make([]ddMetric, 0, len(gauges)+len(counts))
+	emit := func(p seriesPoint, typ string, interval int64) {
 		tags := append(append([]string{}, c.metricsTags...), p.tags...)
 		series = append(series, ddMetric{
-			Metric: "d_inference." + p.metric, // mirror the DogStatsD WithNamespace prefix
-			Points: [][2]float64{{float64(p.ts), p.value}},
-			Type:   "gauge",
-			Tags:   tags,
-			Host:   c.metricsHost,
+			Metric:   "d_inference." + p.metric, // mirror the DogStatsD WithNamespace prefix
+			Points:   [][2]float64{{float64(p.ts), p.value}},
+			Type:     typ,
+			Interval: interval,
+			Tags:     tags,
+			Host:     c.metricsHost,
 		})
+	}
+	for _, p := range gauges {
+		emit(p, "gauge", 0)
+	}
+	for _, p := range counts {
+		emit(p, "count", c.flushIntervalSecs)
 	}
 
 	body, err := json.Marshal(map[string]any{"series": series})

--- a/coordinator/datadog/metrics_http_test.go
+++ b/coordinator/datadog/metrics_http_test.go
@@ -1,0 +1,25 @@
+package datadog
+
+import "testing"
+
+func TestSeriesBufferLastWriteWins(t *testing.T) {
+	b := newSeriesBuffer()
+	b.setGauge("providers.online", 10, []string{"env:prod"}, 100)
+	b.setGauge("providers.online", 12, []string{"env:prod"}, 101) // same series → overwrite
+	b.setGauge("providers.online", 3, []string{"version:0.6.3"}, 101)
+
+	pts := b.drain()
+	if len(pts) != 2 {
+		t.Fatalf("expected 2 distinct series, got %d", len(pts))
+	}
+	for _, p := range pts {
+		if p.metric == "providers.online" && len(p.tags) == 1 && p.tags[0] == "env:prod" && p.value != 12 {
+			t.Fatalf("last-write-wins failed: got %v want 12", p.value)
+		}
+	}
+
+	// Drain empties the buffer.
+	if again := b.drain(); again != nil {
+		t.Fatalf("drain should empty the buffer, got %d points", len(again))
+	}
+}

--- a/coordinator/datadog/metrics_http_test.go
+++ b/coordinator/datadog/metrics_http_test.go
@@ -1,25 +1,120 @@
 package datadog
 
-import "testing"
+import (
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+)
 
-func TestSeriesBufferLastWriteWins(t *testing.T) {
+func TestSeriesBufferLastWriteWinsAndCountSums(t *testing.T) {
 	b := newSeriesBuffer()
 	b.setGauge("providers.online", 10, []string{"env:prod"}, 100)
 	b.setGauge("providers.online", 12, []string{"env:prod"}, 101) // same series → overwrite
 	b.setGauge("providers.online", 3, []string{"version:0.6.3"}, 101)
+	b.addCount("routing.load_failure_cooldowns", 1, []string{"model:m"}, 100)
+	b.addCount("routing.load_failure_cooldowns", 1, []string{"model:m"}, 101) // same series → sum
+	b.addCount("inference.zombie_stream_cancel", 1, nil, 101)
 
-	pts := b.drain()
-	if len(pts) != 2 {
-		t.Fatalf("expected 2 distinct series, got %d", len(pts))
+	gauges, counts := b.drain()
+	if len(gauges) != 2 {
+		t.Fatalf("expected 2 distinct gauge series, got %d", len(gauges))
 	}
-	for _, p := range pts {
+	for _, p := range gauges {
 		if p.metric == "providers.online" && len(p.tags) == 1 && p.tags[0] == "env:prod" && p.value != 12 {
-			t.Fatalf("last-write-wins failed: got %v want 12", p.value)
+			t.Fatalf("gauge last-write-wins failed: got %v want 12", p.value)
+		}
+	}
+	if len(counts) != 2 {
+		t.Fatalf("expected 2 distinct count series, got %d", len(counts))
+	}
+	for _, p := range counts {
+		if p.metric == "routing.load_failure_cooldowns" && p.value != 2 {
+			t.Fatalf("count sum failed: got %v want 2", p.value)
 		}
 	}
 
-	// Drain empties the buffer.
-	if again := b.drain(); again != nil {
-		t.Fatalf("drain should empty the buffer, got %d points", len(again))
+	// Drain empties both maps.
+	if g, c := b.drain(); g != nil || c != nil {
+		t.Fatalf("drain should empty the buffer, got %d gauges %d counts", len(g), len(c))
 	}
+}
+
+// Wire-contract test: flushSeries must produce the exact v1 /series shape —
+// a payload regression here silently reproduces the missing-metrics gap this
+// path exists to fix.
+func TestFlushSeriesWireContract(t *testing.T) {
+	type wireMetric struct {
+		Metric   string       `json:"metric"`
+		Points   [][2]float64 `json:"points"`
+		Type     string       `json:"type"`
+		Interval int64        `json:"interval"`
+		Tags     []string     `json:"tags"`
+		Host     string       `json:"host"`
+	}
+	var got struct {
+		Series []wireMetric `json:"series"`
+	}
+	var apiKey string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		apiKey = r.Header.Get("Dd-Api-Key")
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &got)
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer srv.Close()
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	c := &Client{
+		logger:            logger,
+		apiKey:            "test-key",
+		httpClient:        srv.Client(),
+		seriesURL:         srv.URL,
+		series:            newSeriesBuffer(),
+		metricsTags:       []string{"env:test", "service:svc"},
+		metricsHost:       "test-host",
+		flushIntervalSecs: 5,
+	}
+
+	c.Gauge("providers.online", 42, []string{"region:us"})
+	c.Incr("inference.zombie_stream_cancel", []string{"model:m"})
+	c.Incr("inference.zombie_stream_cancel", []string{"model:m"})
+	c.flushSeries()
+
+	if apiKey != "test-key" {
+		t.Fatalf("Dd-Api-Key header = %q, want test-key", apiKey)
+	}
+	if len(got.Series) != 2 {
+		t.Fatalf("series count = %d, want 2", len(got.Series))
+	}
+	for _, m := range got.Series {
+		switch m.Metric {
+		case "d_inference.providers.online":
+			if m.Type != "gauge" || m.Points[0][1] != 42 {
+				t.Fatalf("gauge wire shape wrong: %+v", m)
+			}
+			if m.Points[0][0] < 1e9 {
+				t.Fatalf("gauge timestamp not unix seconds: %v", m.Points[0][0])
+			}
+		case "d_inference.inference.zombie_stream_cancel":
+			if m.Type != "count" || m.Points[0][1] != 2 || m.Interval != 5 {
+				t.Fatalf("count wire shape wrong: %+v", m)
+			}
+		default:
+			t.Fatalf("unexpected metric (prefix wrong?): %q", m.Metric)
+		}
+		if m.Host != "test-host" {
+			t.Fatalf("host = %q, want test-host", m.Host)
+		}
+		// env/service base tags merged before per-point tags.
+		if len(m.Tags) < 3 || m.Tags[0] != "env:test" || m.Tags[1] != "service:svc" {
+			t.Fatalf("tags wrong: %v", m.Tags)
+		}
+	}
+
+	// HTTP-exclusive: nothing should remain buffered, and a second flush is a no-op.
+	c.flushSeries()
 }

--- a/coordinator/registry/dispatch_load_cooldown_test.go
+++ b/coordinator/registry/dispatch_load_cooldown_test.go
@@ -1,0 +1,146 @@
+package registry
+
+import (
+	"testing"
+	"time"
+)
+
+func cooldownActive(r *Registry, providerID, modelID string, now time.Time) bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.dispatchLoadCooldownActiveLocked(providerID, modelID, now)
+}
+
+// Regression for the prod fleet outage: providers wedged on "insufficient
+// memory to load model" kept getting dispatches (hundreds of instant-503
+// retry loops per provider) because nothing excluded the pair from routing.
+func TestDispatchLoadCooldownLifecycle(t *testing.T) {
+	r := New(testLogger())
+	now := time.Now()
+
+	if cooldownActive(r, "p1", "m1", now) {
+		t.Fatal("cool-down active before any failure")
+	}
+
+	if !r.RecordDispatchLoadFailure("p1", "m1") {
+		t.Fatal("first failure should start a NEW cool-down")
+	}
+	if r.RecordDispatchLoadFailure("p1", "m1") {
+		t.Fatal("repeat failure should extend, not report a new cool-down")
+	}
+
+	if !cooldownActive(r, "p1", "m1", now) {
+		t.Fatal("cool-down not active after failure")
+	}
+	// Scoped to the pair: same provider other model, and other provider same
+	// model, still route.
+	if cooldownActive(r, "p1", "m2", now) || cooldownActive(r, "p2", "m1", now) {
+		t.Fatal("cool-down leaked beyond the failing provider-model pair")
+	}
+
+	if cooldownActive(r, "p1", "m1", now.Add(dispatchLoadCooldownTTL+time.Second)) {
+		t.Fatal("cool-down survived past its TTL")
+	}
+
+	// A served request for the pair lifts the cool-down early.
+	r.RecordDispatchLoadFailure("p1", "m1")
+	r.ClearDispatchLoadCooldown("p1", "m1")
+	if cooldownActive(r, "p1", "m1", now) {
+		t.Fatal("cool-down survived ClearDispatchLoadCooldown")
+	}
+}
+
+// End-to-end through the dispatch selector: a cooling-down pair must not be
+// picked, and must return to rotation once cleared.
+func TestFindProviderWithTrustSkipsCoolingPair(t *testing.T) {
+	r := New(testLogger())
+	const model = aliasQAT
+	p := registerProviderWithModel(r, "p1", model)
+	makeProviderRoutable(p)
+
+	if got := r.FindProviderWithTrust(model, ""); got == nil {
+		t.Fatal("healthy provider not selected (fixture broken?)")
+	}
+
+	r.RecordDispatchLoadFailure(p.ID, model)
+	if got := r.FindProviderWithTrust(model, ""); got != nil {
+		t.Fatal("cooling-down provider was selected for dispatch")
+	}
+
+	r.ClearDispatchLoadCooldown(p.ID, model)
+	if got := r.FindProviderWithTrust(model, ""); got == nil {
+		t.Fatal("provider not selected after cool-down cleared")
+	}
+}
+
+// The production dispatch hot path is ReserveProviderEx (not
+// FindProviderWithTrust). A cooling-down pair must be excluded there too,
+// otherwise the cool-down is cosmetic and the retry storm continues.
+func TestReserveProviderExSkipsCoolingPair(t *testing.T) {
+	reg := New(testLogger())
+	model := "cooldown-reserve-model"
+	p := makeSchedulerProvider(t, reg, "p1", model, 200)
+
+	req := func(id string) *PendingRequest {
+		return &PendingRequest{RequestID: id, Model: model, RequestedMaxTokens: 128}
+	}
+
+	selected, _ := reg.ReserveProviderEx(model, req("r1"))
+	if selected == nil {
+		t.Fatal("ReserveProviderEx returned nil for a healthy provider (fixture broken?)")
+	}
+	// Free the slot so the next reservation is gated only by the cool-down.
+	p.RemovePending("r1")
+
+	reg.RecordDispatchLoadFailure(p.ID, model)
+	if selected, _ := reg.ReserveProviderEx(model, req("r2")); selected != nil {
+		t.Fatal("ReserveProviderEx selected a cooling-down provider (cool-down not on the hot path)")
+	}
+
+	reg.ClearDispatchLoadCooldown(p.ID, model)
+	if selected, _ := reg.ReserveProviderEx(model, req("r3")); selected == nil {
+		t.Fatal("ReserveProviderEx returned nil after the cool-down was cleared")
+	}
+}
+
+func TestDispatchLoadCooldownClearedOnRegister(t *testing.T) {
+	r := New(testLogger())
+	r.RecordDispatchLoadFailure("p1", "m1")
+	r.RecordDispatchLoadFailure("p1", "m2")
+
+	r.mu.Lock()
+	r.clearDispatchLoadCooldownsLocked("p1")
+	r.mu.Unlock()
+
+	now := time.Now()
+	if cooldownActive(r, "p1", "m1", now) || cooldownActive(r, "p1", "m2", now) {
+		t.Fatal("re-registration must clear the provider's cool-downs (fresh process, fresh memory)")
+	}
+}
+
+func TestDispatchLoadCooldownSweepBoundsMap(t *testing.T) {
+	r := New(testLogger())
+	// Insert >1024 entries, then force them all past expiry by recording a
+	// fresh failure after the TTL — the opportunistic sweep must drop them.
+	for i := 0; i < 1100; i++ {
+		r.RecordDispatchLoadFailure("dead-provider-"+string(rune('a'+i%26))+string(rune('0'+i%10))+string(rune('0'+(i/10)%10))+string(rune('0'+(i/100)%10)), "m")
+	}
+	r.mu.Lock()
+	for k := range r.dispatchLoadCooldowns {
+		r.dispatchLoadCooldowns[k] = time.Now().Add(-time.Second)
+	}
+	size := len(r.dispatchLoadCooldowns)
+	r.mu.Unlock()
+	if size < 1000 {
+		t.Fatalf("setup produced too few distinct entries: %d", size)
+	}
+
+	r.RecordDispatchLoadFailure("live", "m")
+
+	r.mu.Lock()
+	after := len(r.dispatchLoadCooldowns)
+	r.mu.Unlock()
+	if after != 1 {
+		t.Fatalf("sweep should leave only the live entry, got %d", after)
+	}
+}

--- a/coordinator/registry/eviction_grace_test.go
+++ b/coordinator/registry/eviction_grace_test.go
@@ -1,0 +1,80 @@
+package registry
+
+import (
+	"testing"
+	"time"
+)
+
+func providerPresent(r *Registry, id string) bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	_, ok := r.providers[id]
+	return ok
+}
+
+// A provider stale for only ONE sweep must NOT be evicted (grace), but stale for
+// TWO consecutive sweeps IS — so a transient coordinator stall that ages many
+// LastHeartbeat values at once gives the fleet a sweep to recover.
+func TestEvictStaleTwoStrikeGrace(t *testing.T) {
+	r := New(testLogger())
+	const model = aliasQAT
+	p := registerProviderWithModel(r, "p1", model)
+	p.mu.Lock()
+	p.LastHeartbeat = time.Now().Add(-5 * time.Minute) // well past any timeout
+	p.mu.Unlock()
+
+	timeout := 90 * time.Second
+
+	r.evictStale(timeout) // strike 1 — grace
+	if !providerPresent(r, p.ID) {
+		t.Fatal("provider evicted on the first stale sweep (no grace)")
+	}
+
+	r.evictStale(timeout) // strike 2 — evict
+	if providerPresent(r, p.ID) {
+		t.Fatal("provider survived two consecutive stale sweeps")
+	}
+}
+
+// A provider that recovers (fresh heartbeat) after one stale sweep must have its
+// strike reset, so it's never evicted.
+func TestEvictStaleStrikeResetsOnRecovery(t *testing.T) {
+	r := New(testLogger())
+	const model = aliasQAT
+	p := registerProviderWithModel(r, "p1", model)
+	timeout := 90 * time.Second
+
+	p.mu.Lock()
+	p.LastHeartbeat = time.Now().Add(-5 * time.Minute)
+	p.mu.Unlock()
+	r.evictStale(timeout) // strike 1
+
+	p.mu.Lock()
+	p.LastHeartbeat = time.Now() // heartbeat arrived
+	p.mu.Unlock()
+	r.evictStale(timeout) // not stale — strike reset
+
+	p.mu.Lock()
+	p.LastHeartbeat = time.Now().Add(-5 * time.Minute) // stale again
+	p.mu.Unlock()
+	r.evictStale(timeout) // strike 1 again (reset worked), not evicted
+
+	if !providerPresent(r, p.ID) {
+		t.Fatal("provider evicted despite a recovery resetting its strike count")
+	}
+}
+
+func TestDurationStats(t *testing.T) {
+	if a, b, c, d := durationStats(nil); a|b|c|d != 0 {
+		t.Fatalf("empty slice should be all zeros, got %v %v %v %v", a, b, c, d)
+	}
+	ds := []time.Duration{50 * time.Second, 10 * time.Second, 100 * time.Second, 30 * time.Second}
+	min, med, p90, max := durationStats(ds)
+	if min != 10*time.Second || max != 100*time.Second {
+		t.Fatalf("min/max = %v/%v, want 10s/100s", min, max)
+	}
+	if med <= 0 || med > max {
+		t.Fatalf("median %v out of range", med)
+	}
+	_ = p90
+}

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -702,15 +702,11 @@ type Registry struct {
 	// (bestModelLoadProviderLocked / reservePendingModelLoads).
 	pendingModelLoads map[string]time.Time // key: "providerID:modelID", value: expiry
 
-	// dispatchLoadCooldowns tracks provider-model pairs that rejected a
-	// DISPATCH with a load failure ("insufficient memory to load model").
-	// Routing skips the pair until expiry: a provider in that state fails
-	// every request for the model instantly, and without a cool-down the
-	// scheduler re-picks it (it looks idle and high-scoring) — observed in
-	// prod as hundreds of dispatch→503→retry loops per provider per hour
-	// while real capacity sat behind the retries. Cleared on provider
-	// (re-)registration (a restart frees the memory) and on a served
-	// request for the same pair.
+	// dispatchLoadCooldowns: provider-model pairs that rejected a dispatch with a
+	// load failure ("insufficient memory"). Routing skips the pair until expiry —
+	// it would instant-503 again, and without this the scheduler re-picks it
+	// (looks idle), causing the dispatch→503→retry storms seen in prod. Cleared
+	// on re-registration and on a served request for the pair.
 	dispatchLoadCooldowns map[string]time.Time // key: "providerID:modelID", value: expiry
 }
 
@@ -727,11 +723,9 @@ const pendingModelLoadTTL = 2 * time.Minute
 // re-registration) could serve.
 const pendingModelLoadDrainBackoff = 30 * time.Second
 
-// dispatchLoadCooldownTTL is how long routing skips a provider-model pair
-// after the provider rejected a dispatch with a load failure. Long enough to
-// stop instant-fail retry loops from soaking up dispatch attempts; short
-// enough that a provider that recovers (memory freed, model evicted
-// elsewhere) returns to rotation on its own.
+// dispatchLoadCooldownTTL is how long routing skips a pair after a dispatch
+// load failure — long enough to stop the retry loop, short enough that a
+// recovered provider returns on its own.
 const dispatchLoadCooldownTTL = 2 * time.Minute
 
 type modelLoadAction struct {
@@ -761,9 +755,8 @@ func (r *Registry) RecordDispatchLoadFailure(providerID, modelID string) bool {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	now := time.Now()
-	// Opportunistic sweep: provider ids are per-session UUIDs, so entries for
-	// disconnected providers expire but are never re-keyed. Bound the map by
-	// dropping expired entries once it grows past any plausible live set.
+	// Opportunistic sweep: provider ids are per-session UUIDs, so dead entries
+	// never get re-keyed — bound the map by dropping expired ones when it grows.
 	if len(r.dispatchLoadCooldowns) > 1024 {
 		for key, expiry := range r.dispatchLoadCooldowns {
 			if !now.Before(expiry) {
@@ -786,10 +779,8 @@ func (r *Registry) ClearDispatchLoadCooldown(providerID, modelID string) {
 	delete(r.dispatchLoadCooldowns, providerID+":"+modelID)
 }
 
-// clearDispatchLoadCooldownsLocked drops every cool-down for a provider. Run
-// on (re-)registration: a fresh process has fresh memory accounting, and the
-// provider-side admission self-heal means a restart genuinely clears the
-// wedge the cool-down was protecting against. Caller holds r.mu.
+// clearDispatchLoadCooldownsLocked drops a provider's cool-downs on
+// (re-)registration — a fresh process has fresh memory. Caller holds r.mu.
 func (r *Registry) clearDispatchLoadCooldownsLocked(providerID string) {
 	prefix := providerID + ":"
 	for key := range r.dispatchLoadCooldowns {
@@ -799,12 +790,9 @@ func (r *Registry) clearDispatchLoadCooldownsLocked(providerID string) {
 	}
 }
 
-// dispatchLoadCooldownActiveLocked reports whether routing should skip the
-// pair right now. READ-ONLY: some routing entry points hold only r.mu.RLock,
-// so expired entries are NOT deleted here — they are overwritten on the next
-// failure or dropped by ClearDispatchLoadCooldown / re-registration. The map
-// is bounded by live providers × catalog models. Caller holds r.mu (either
-// mode).
+// dispatchLoadCooldownActiveLocked reports whether routing should skip the pair.
+// READ-ONLY (no lazy delete) — some callers hold only r.mu.RLock. Caller holds
+// r.mu in either mode.
 func (r *Registry) dispatchLoadCooldownActiveLocked(providerID, modelID string, now time.Time) bool {
 	expiry, ok := r.dispatchLoadCooldowns[providerID+":"+modelID]
 	return ok && now.Before(expiry)

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -708,6 +708,13 @@ type Registry struct {
 	// (looks idle), causing the dispatch→503→retry storms seen in prod. Cleared
 	// on re-registration and on a served request for the pair.
 	dispatchLoadCooldowns map[string]time.Time // key: "providerID:modelID", value: expiry
+
+	// evictStrikes counts consecutive eviction sweeps a provider has been stale.
+	// A provider is only evicted after STALE on two sweeps in a row, so a single
+	// transient coordinator stall (which ages many LastHeartbeat values at once)
+	// or one missed heartbeat doesn't mass-reap a live fleet. Guarded by r.mu;
+	// rebuilt each sweep so disconnected providers drop out automatically.
+	evictStrikes map[string]int
 }
 
 // pendingModelLoadTTL bounds how long an outstanding (or failed) load_model
@@ -743,6 +750,7 @@ func New(logger *slog.Logger) *Registry {
 		modelProviders:        make(map[string]*atomic.Int64),
 		pendingModelLoads:     make(map[string]time.Time),
 		dispatchLoadCooldowns: make(map[string]time.Time),
+		evictStrikes:          make(map[string]int),
 		logger:                logger,
 	}
 }
@@ -3883,18 +3891,72 @@ func (r *Registry) StartEvictionLoop(ctx context.Context, timeout time.Duration)
 }
 
 func (r *Registry) evictStale(timeout time.Duration) {
-	r.mu.RLock()
-	var stale []string
 	now := time.Now()
+
+	// Scan under the write lock: we both READ LastHeartbeat and REBUILD
+	// evictStrikes. Collect every provider's heartbeat age for the summary, and
+	// decide who to evict: a provider is reaped only after it is stale on TWO
+	// consecutive sweeps (strike >= 2), so a single transient stall that ages
+	// many timestamps at once gives the fleet a sweep to recover instead of a
+	// mass reap.
+	r.mu.Lock()
+	fleet := len(r.providers)
+	ages := make([]time.Duration, 0, fleet)
+	nextStrikes := make(map[string]int, len(r.evictStrikes))
+	var toEvict []string
+	var evictAges []time.Duration
 	for id, p := range r.providers {
-		if now.Sub(p.LastHeartbeat) > timeout {
-			stale = append(stale, id)
+		age := now.Sub(p.LastHeartbeat)
+		ages = append(ages, age)
+		if age > timeout {
+			strikes := r.evictStrikes[id] + 1
+			if strikes >= evictStrikeThreshold {
+				toEvict = append(toEvict, id)
+				evictAges = append(evictAges, age)
+			} else {
+				nextStrikes[id] = strikes // carry the strike to next sweep
+			}
 		}
 	}
-	r.mu.RUnlock()
+	r.evictStrikes = nextStrikes
+	r.mu.Unlock()
 
-	for _, id := range stale {
+	if len(ages) > 0 {
+		amin, amed, ap90, amax := durationStats(ages)
+		// A tight evicted-age spread (emax-emin small) means many providers went
+		// stale at the same instant — a coordinator-side stall. A broad spread
+		// means independent provider sleeps. The summary makes that diagnosable.
+		emin, _, _, emax := durationStats(evictAges)
+		r.logger.Info("eviction sweep",
+			"fleet", fleet,
+			"evicting", len(toEvict),
+			"hb_age_min_s", int(amin.Seconds()),
+			"hb_age_p50_s", int(amed.Seconds()),
+			"hb_age_p90_s", int(ap90.Seconds()),
+			"hb_age_max_s", int(amax.Seconds()),
+			"evicted_age_min_s", int(emin.Seconds()),
+			"evicted_age_max_s", int(emax.Seconds()),
+		)
+	}
+
+	for _, id := range toEvict {
 		r.logger.Warn("evicting stale provider", "provider_id", id, "timeout", timeout)
 		r.Disconnect(id)
 	}
+}
+
+// evictStrikeThreshold is how many consecutive stale sweeps trigger eviction.
+// With a timeout/3 sweep cadence, 2 strikes ≈ one extra sweep interval of grace.
+const evictStrikeThreshold = 2
+
+// durationStats returns min, median, p90, max of ds (zeros for an empty slice).
+// Sorts a copy; ds is small (fleet-sized) so this is cheap.
+func durationStats(ds []time.Duration) (min, median, p90, max time.Duration) {
+	if len(ds) == 0 {
+		return 0, 0, 0, 0
+	}
+	s := make([]time.Duration, len(ds))
+	copy(s, ds)
+	sort.Slice(s, func(i, j int) bool { return s[i] < s[j] })
+	return s[0], s[len(s)/2], s[(len(s)*9)/10], s[len(s)-1]
 }

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -701,6 +701,17 @@ type Registry struct {
 	// entry lives, the provider is skipped for new load_model sends
 	// (bestModelLoadProviderLocked / reservePendingModelLoads).
 	pendingModelLoads map[string]time.Time // key: "providerID:modelID", value: expiry
+
+	// dispatchLoadCooldowns tracks provider-model pairs that rejected a
+	// DISPATCH with a load failure ("insufficient memory to load model").
+	// Routing skips the pair until expiry: a provider in that state fails
+	// every request for the model instantly, and without a cool-down the
+	// scheduler re-picks it (it looks idle and high-scoring) — observed in
+	// prod as hundreds of dispatch→503→retry loops per provider per hour
+	// while real capacity sat behind the retries. Cleared on provider
+	// (re-)registration (a restart frees the memory) and on a served
+	// request for the same pair.
+	dispatchLoadCooldowns map[string]time.Time // key: "providerID:modelID", value: expiry
 }
 
 // pendingModelLoadTTL bounds how long an outstanding (or failed) load_model
@@ -716,6 +727,13 @@ const pendingModelLoadTTL = 2 * time.Minute
 // re-registration) could serve.
 const pendingModelLoadDrainBackoff = 30 * time.Second
 
+// dispatchLoadCooldownTTL is how long routing skips a provider-model pair
+// after the provider rejected a dispatch with a load failure. Long enough to
+// stop instant-fail retry loops from soaking up dispatch attempts; short
+// enough that a provider that recovers (memory freed, model evicted
+// elsewhere) returns to rotation on its own.
+const dispatchLoadCooldownTTL = 2 * time.Minute
+
 type modelLoadAction struct {
 	providerID string
 	modelID    string
@@ -724,14 +742,72 @@ type modelLoadAction struct {
 // New creates a new Registry.
 func New(logger *slog.Logger) *Registry {
 	return &Registry{
-		providers:         make(map[string]*Provider),
-		queue:             NewRequestQueue(10, 120*time.Second),
-		MinTrustLevel:     TrustHardware,
-		tpsRegistry:       NewTPSRegistry(),
-		modelProviders:    make(map[string]*atomic.Int64),
-		pendingModelLoads: make(map[string]time.Time),
-		logger:            logger,
+		providers:             make(map[string]*Provider),
+		queue:                 NewRequestQueue(10, 120*time.Second),
+		MinTrustLevel:         TrustHardware,
+		tpsRegistry:           NewTPSRegistry(),
+		modelProviders:        make(map[string]*atomic.Int64),
+		pendingModelLoads:     make(map[string]time.Time),
+		dispatchLoadCooldowns: make(map[string]time.Time),
+		logger:                logger,
 	}
+}
+
+// RecordDispatchLoadFailure puts a provider-model pair on a routing cool-down
+// after the provider rejected a dispatch with a load failure. Returns true
+// when this call started a new cool-down (false when one was already live),
+// so callers can emit metrics without double-counting the retry storm.
+func (r *Registry) RecordDispatchLoadFailure(providerID, modelID string) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	now := time.Now()
+	// Opportunistic sweep: provider ids are per-session UUIDs, so entries for
+	// disconnected providers expire but are never re-keyed. Bound the map by
+	// dropping expired entries once it grows past any plausible live set.
+	if len(r.dispatchLoadCooldowns) > 1024 {
+		for key, expiry := range r.dispatchLoadCooldowns {
+			if !now.Before(expiry) {
+				delete(r.dispatchLoadCooldowns, key)
+			}
+		}
+	}
+	key := providerID + ":" + modelID
+	_, active := r.dispatchLoadCooldowns[key]
+	active = active && now.Before(r.dispatchLoadCooldowns[key])
+	r.dispatchLoadCooldowns[key] = now.Add(dispatchLoadCooldownTTL)
+	return !active
+}
+
+// ClearDispatchLoadCooldown removes the cool-down for one provider-model pair
+// (called when the pair serves a request successfully — it can load after all).
+func (r *Registry) ClearDispatchLoadCooldown(providerID, modelID string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.dispatchLoadCooldowns, providerID+":"+modelID)
+}
+
+// clearDispatchLoadCooldownsLocked drops every cool-down for a provider. Run
+// on (re-)registration: a fresh process has fresh memory accounting, and the
+// provider-side admission self-heal means a restart genuinely clears the
+// wedge the cool-down was protecting against. Caller holds r.mu.
+func (r *Registry) clearDispatchLoadCooldownsLocked(providerID string) {
+	prefix := providerID + ":"
+	for key := range r.dispatchLoadCooldowns {
+		if strings.HasPrefix(key, prefix) {
+			delete(r.dispatchLoadCooldowns, key)
+		}
+	}
+}
+
+// dispatchLoadCooldownActiveLocked reports whether routing should skip the
+// pair right now. READ-ONLY: some routing entry points hold only r.mu.RLock,
+// so expired entries are NOT deleted here — they are overwritten on the next
+// failure or dropped by ClearDispatchLoadCooldown / re-registration. The map
+// is bounded by live providers × catalog models. Caller holds r.mu (either
+// mode).
+func (r *Registry) dispatchLoadCooldownActiveLocked(providerID, modelID string, now time.Time) bool {
+	expiry, ok := r.dispatchLoadCooldowns[providerID+":"+modelID]
+	return ok && now.Before(expiry)
 }
 
 // SetStore configures the persistence store for the registry.
@@ -1243,6 +1319,9 @@ func (r *Registry) anyEligibleProviderCanRouteLocked(buildID string, allowedSeri
 // slot required — they load on first demand). Caller holds r.mu (RLock) and p.mu.
 func (r *Registry) providerCanRouteBuildLocked(p *Provider, buildID string, minTrust TrustLevel, now time.Time, allowPrivate bool) bool {
 	if !r.providerServesCatalogModelLocked(p, buildID) {
+		return false
+	}
+	if r.dispatchLoadCooldownActiveLocked(p.ID, buildID, now) {
 		return false
 	}
 	if p.Status == StatusOffline || p.Status == StatusUntrusted {
@@ -1818,6 +1897,9 @@ func (r *Registry) Register(id string, conn *websocket.Conn, msg *protocol.Regis
 	for _, m := range models {
 		r.modelProviderInc(m.ID)
 	}
+	// A (re-)registration means a fresh provider process: any dispatch-time
+	// load-failure cool-downs belonged to the previous process's memory state.
+	r.clearDispatchLoadCooldownsLocked(id)
 	r.mu.Unlock()
 
 	// Open a session row for this connection (async; durable uptime history).
@@ -3077,6 +3159,11 @@ func (r *Registry) FindProviderWithTrust(model string, minTrust TrustLevel, excl
 	for _, p := range r.providers {
 		// Skip explicitly excluded providers (failed on previous retry attempts).
 		if _, excluded := excludeSet[p.ID]; excluded {
+			continue
+		}
+		// Skip pairs cooling down after a dispatch-time load failure —
+		// re-picking them just burns a retry attempt on an instant 503.
+		if r.dispatchLoadCooldownActiveLocked(p.ID, model, now) {
 			continue
 		}
 

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -3906,7 +3906,10 @@ func (r *Registry) evictStale(timeout time.Duration) {
 	var toEvict []string
 	var evictAges []time.Duration
 	for id, p := range r.providers {
-		age := now.Sub(p.LastHeartbeat)
+		p.mu.Lock()
+		lastHeartbeat := p.LastHeartbeat
+		p.mu.Unlock()
+		age := now.Sub(lastHeartbeat)
 		ages = append(ages, age)
 		if age > timeout {
 			strikes := r.evictStrikes[id] + 1

--- a/coordinator/registry/registry_test.go
+++ b/coordinator/registry/registry_test.go
@@ -684,11 +684,17 @@ func TestEviction(t *testing.T) {
 	// Backdate the heartbeat.
 	p.LastHeartbeat = time.Now().Add(-2 * time.Minute)
 
-	// Manually call eviction with a 90-second timeout.
+	// Eviction now requires two consecutive stale sweeps (grace against a
+	// transient coordinator stall mass-reaping a live fleet). First sweep =
+	// strike, second = evict.
+	reg.evictStale(90 * time.Second)
+	if reg.GetProvider("p1") == nil {
+		t.Error("provider should survive the first stale sweep (grace)")
+	}
 	reg.evictStale(90 * time.Second)
 
 	if reg.GetProvider("p1") != nil {
-		t.Error("provider should have been evicted")
+		t.Error("provider should have been evicted after two stale sweeps")
 	}
 	if reg.ProviderCount() != 0 {
 		t.Errorf("count = %d, want 0", reg.ProviderCount())
@@ -1849,8 +1855,10 @@ func TestProviderEviction(t *testing.T) {
 	}
 	reg.SetProviderIdle(found.ID)
 
-	// Backdate heartbeat to 2 minutes ago and evict with 90s timeout.
+	// Backdate heartbeat to 2 minutes ago and evict with 90s timeout. Eviction
+	// takes two consecutive stale sweeps (grace); the second one reaps.
 	p.LastHeartbeat = time.Now().Add(-2 * time.Minute)
+	reg.evictStale(90 * time.Second)
 	reg.evictStale(90 * time.Second)
 
 	// Verify complete removal.

--- a/coordinator/registry/scheduler.go
+++ b/coordinator/registry/scheduler.go
@@ -550,6 +550,14 @@ func (r *Registry) snapshotProviderLocked(p *Provider, model string, selfRouteOw
 	if !r.providerServesCatalogModelLocked(p, model) {
 		return routingSnapshot{}, false
 	}
+	// Skip a provider-model pair cooling down after a dispatch-time load
+	// failure ("insufficient memory") — it would instant-503 again, burning a
+	// dispatch attempt. This is the production dispatch hot path
+	// (ReserveProviderEx), so the cool-down MUST be enforced here, not only in
+	// the FindProviderWithTrust / RoutableProviderIDsForBuild paths.
+	if r.dispatchLoadCooldownActiveLocked(p.ID, model, now) {
+		return routingSnapshot{}, false
+	}
 	if p.Status == StatusOffline || p.Status == StatusUntrusted {
 		return routingSnapshot{}, false
 	}
@@ -946,6 +954,11 @@ func (r *Registry) providerCanAdmitLocked(p *Provider, model string, selfRouteOw
 		return false
 	}
 	if !r.providerServesCatalogModelLocked(p, model) {
+		return false
+	}
+	// Under-lock re-check: don't admit a pair that entered the dispatch
+	// load-failure cool-down between selection and reservation.
+	if r.dispatchLoadCooldownActiveLocked(p.ID, model, time.Now()) {
 		return false
 	}
 	if !p.hasConcurrencyHeadroomForModelLocked(model) {

--- a/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClient.swift
+++ b/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClient.swift
@@ -684,10 +684,24 @@ public actor CoordinatorClient {
                 }
             }
 
-            // Task 4: Ping timer with pong timeout detection
+            // Task 4: Ping timer with pong timeout + suspension detection
             group.addTask {
+                var lastTick = CFAbsoluteTimeGetCurrent()
                 while true {
                     try await Task.sleep(for: .seconds(pingInterval))
+
+                    // If far more wall-clock elapsed than we slept for, the
+                    // process was suspended/throttled (App Nap or sleep). The
+                    // socket is almost certainly dead and the coordinator has
+                    // likely already evicted us, so reconnect NOW instead of
+                    // waiting out the (also-throttled) pong timeout — this is
+                    // what removes the multi-minute post-wake detection lag.
+                    let now = CFAbsoluteTimeGetCurrent()
+                    let gap = now - lastTick
+                    lastTick = now
+                    if gap > pingInterval * 3 {
+                        throw CoordinatorError.suspensionDetected
+                    }
 
                     if pongTracker.elapsed() > pongTimeout {
                         throw CoordinatorError.pongTimeout
@@ -953,6 +967,7 @@ public enum CoordinatorError: Error, CustomStringConvertible {
     case encodingFailed
     case pongTimeout
     case connectionClosed(Error)
+    case suspensionDetected
 
     public var description: String {
         switch self {
@@ -960,6 +975,7 @@ public enum CoordinatorError: Error, CustomStringConvertible {
         case .encodingFailed: return "Failed to encode message"
         case .pongTimeout: return "WebSocket pong timeout (no response in 30s)"
         case .connectionClosed(let err): return "WebSocket connection closed: \(err.localizedDescription)"
+        case .suspensionDetected: return "Process suspension detected (timer gap); forcing reconnect"
         }
     }
 }

--- a/provider-swift/Sources/ProviderCore/Inference/BatchScheduler+EngineBridge.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/BatchScheduler+EngineBridge.swift
@@ -83,7 +83,7 @@ extension BatchScheduler {
                     let isAbort = output.finishReason == "abort"
                     let engineError = !isAbort ? output.error : nil
                     if isAbort || engineError != nil {
-                        _ = await scheduler.recordFinish(
+                        let usage = await scheduler.recordFinish(
                             requestId: id,
                             promptTokens: output.promptTokens,
                             completionTokens: output.completionTokens,
@@ -94,6 +94,18 @@ extension BatchScheduler {
                             // so callers can report it / decide retry.
                             continuation.yield(.error(err))
                         } else {
+                            // An aborted request did real work (prefill +
+                            // partial decode). Emit the authoritative counts
+                            // BEFORE the terminal error so a listener that is
+                            // still attached can settle billing for the
+                            // tokens it already delivered instead of $0.
+                            if usage.promptTokens > 0 || usage.completionTokens > 0 {
+                                continuation.yield(.info(
+                                    promptTokens: usage.promptTokens,
+                                    completionTokens: usage.completionTokens,
+                                    tokensPerSecond: usage.tps
+                                ))
+                            }
                             // Distinct pending-timeout vs. client-cancel
                             // string so operators can tell capacity
                             // exhaustion apart from a closed connection.

--- a/provider-swift/Sources/ProviderCore/Inference/BatchScheduler+EngineBridge.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/BatchScheduler+EngineBridge.swift
@@ -94,11 +94,8 @@ extension BatchScheduler {
                             // so callers can report it / decide retry.
                             continuation.yield(.error(err))
                         } else {
-                            // An aborted request did real work (prefill +
-                            // partial decode). Emit the authoritative counts
-                            // BEFORE the terminal error so a listener that is
-                            // still attached can settle billing for the
-                            // tokens it already delivered instead of $0.
+                            // An abort did real work — emit its usage before the
+                            // error so a listener can still bill delivered tokens.
                             if usage.promptTokens > 0 || usage.completionTokens > 0 {
                                 continuation.yield(.info(
                                     promptTokens: usage.promptTokens,

--- a/provider-swift/Sources/ProviderCore/Inference/BatchScheduler.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/BatchScheduler.swift
@@ -717,10 +717,8 @@ public actor BatchScheduler {
             return nil
         }
 
-        // `.notice`, not `.warning`: os.Logger has no warning type — warning()
-        // emits OSLogType.error, so this routine banner showed as `E`/type=Error
-        // in `log show` and in operator log reports. Notice keeps it visible at
-        // the default log level without reading as a fault.
+        // `.notice` not `.warning`: os.Logger maps warning()->OSLogType.error,
+        // so this routine banner showed as type=Error in log reports.
         prefixCacheLogger.notice(
             "Prefix cache is ON (default; opt out with DARKBLOOM_PREFIX_CACHE=0) — TB-007: cross-tenant sharing / TTFT side-channel; encrypted-at-rest only."
         )

--- a/provider-swift/Sources/ProviderCore/Inference/BatchScheduler.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/BatchScheduler.swift
@@ -717,7 +717,11 @@ public actor BatchScheduler {
             return nil
         }
 
-        prefixCacheLogger.warning(
+        // `.notice`, not `.warning`: os.Logger has no warning type — warning()
+        // emits OSLogType.error, so this routine banner showed as `E`/type=Error
+        // in `log show` and in operator log reports. Notice keeps it visible at
+        // the default log level without reading as a fault.
+        prefixCacheLogger.notice(
             "Prefix cache is ON (default; opt out with DARKBLOOM_PREFIX_CACHE=0) — TB-007: cross-tenant sharing / TTFT side-channel; encrypted-at-rest only."
         )
 

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+InboundDecode.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+InboundDecode.swift
@@ -95,4 +95,30 @@ extension ProviderLoop {
         }
         return ""
     }
+
+    /// Prompt-token recovery for requests whose usage chunk never arrived —
+    /// the NORMAL case for a stream cancelled mid-generation (the engine's
+    /// usage rides the final chunk an aborted request never produces), or an
+    /// upstream regression on a clean finish.
+    ///
+    /// Re-applies the SAME chat-template tokenization the engine prefilled
+    /// with (`templateMessageDict`/`toolSpec` + the slot tokenizer), so the
+    /// count matches the engine's own prompt accounting. Media (VLM) parts
+    /// aren't representable in the text template, so vision prompts
+    /// under-count — an acceptable floor, never an overcharge. Returns 0 when
+    /// templating fails; callers treat that as "no floor available".
+    internal static func promptTokenFloor(
+        request: OpenAIChatCompletionRequest,
+        tokenizer: TokenizerHandle,
+        reasoningEffort: String?
+    ) -> Int {
+        let messages = request.messages.map { $0.templateMessageDict() }
+        let toolSpecs = request.tools?.map { $0.toolSpec() }
+        let additionalContext: [String: any Sendable]? =
+            reasoningEffort.map { ["reasoning_effort": $0] }
+        guard let ids = try? tokenizer.inner.applyChatTemplate(
+            messages: messages, tools: toolSpecs, additionalContext: additionalContext
+        ) else { return 0 }
+        return ids.count
+    }
 }

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+InboundDecode.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+InboundDecode.swift
@@ -96,17 +96,10 @@ extension ProviderLoop {
         return ""
     }
 
-    /// Prompt-token recovery for requests whose usage chunk never arrived —
-    /// the NORMAL case for a stream cancelled mid-generation (the engine's
-    /// usage rides the final chunk an aborted request never produces), or an
-    /// upstream regression on a clean finish.
-    ///
-    /// Re-applies the SAME chat-template tokenization the engine prefilled
-    /// with (`templateMessageDict`/`toolSpec` + the slot tokenizer), so the
-    /// count matches the engine's own prompt accounting. Media (VLM) parts
-    /// aren't representable in the text template, so vision prompts
-    /// under-count — an acceptable floor, never an overcharge. Returns 0 when
-    /// templating fails; callers treat that as "no floor available".
+    /// Prompt-token floor for requests whose usage chunk never arrived (cancelled
+    /// stream / upstream regression). Re-runs the engine's exact applyChatTemplate
+    /// path so the count matches what was prefilled; VLM parts aren't in the text
+    /// template so vision under-counts (a floor, never an overcharge). 0 on failure.
     internal static func promptTokenFloor(
         request: OpenAIChatCompletionRequest,
         tokenizer: TokenizerHandle,

--- a/provider-swift/Sources/ProviderCore/ProviderLoop.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop.swift
@@ -541,6 +541,18 @@ public actor ProviderLoop {
             reason: "Darkbloom provider serving inference / keeping the coordinator link alive")
         defer { ProcessInfo.processInfo.endActivity(napAssertion) }
 
+        // Refresh the launchd KeepAlive policy in the on-disk plist (file-only;
+        // takes effect at the next bootstrap). Auto-update restarts never
+        // re-read the plist, so without this the existing fleet would never
+        // gain crash recovery. Best-effort — a failure must not block serving.
+        do {
+            if try LaunchAgent.syncKeepAlivePolicyOnDisk() {
+                logger.info("launchd plist KeepAlive policy refreshed (applies at next bootstrap)")
+            }
+        } catch {
+            logger.warning("launchd plist KeepAlive refresh failed: \(error)")
+        }
+
         // Unified mode: also expose a local OpenAI endpoint off the same loaded
         // models. Started before the coordinator connection so local clients can
         // serve immediately; torn down on shutdown.

--- a/provider-swift/Sources/ProviderCore/ProviderLoop.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop.swift
@@ -1245,22 +1245,15 @@ public actor ProviderLoop {
             var reasoningText = ""
             var reasoningTokens = 0
 
-            // Set when the request is cancelled mid-stream (consumer
-            // disconnect / speculative-dispatch loser). Cancelled requests
-            // that already streamed output settle through the normal
-            // completion path below with real usage — the consumer received
-            // those tokens and the GPU did that work — instead of a bare 499
-            // that bills (and credits the provider) $0 for it.
+            // A cancelled request that already streamed output settles through
+            // the completion path below with real usage, not a bare 499 ($0).
             var cancelledMidStream = false
             do {
                 for try await frame in frames {
                     if token.isCancelled {
                         log.info("[\(requestId)] Cancelled during generation")
                         cancelledMidStream = true
-                        // Exiting the iteration is what propagates the abort:
-                        // the stream's onTermination cancels the engine-side
-                        // task and `scheduler.cancel` stops generation.
-                        break
+                        break  // exiting propagates the abort via onTermination
                     }
                     // Aggregate the assistant text + usage by parsing each
                     // chunk back from its JSON delta. This is the cost of
@@ -1340,13 +1333,8 @@ public actor ProviderLoop {
                     if !emitSSE(frameToEmit) { return }
                 }
             } catch {
-                // P1 #2: CancellationError raised by `try await
-                // frame in frames` when the inflight task is cancelled
-                // BEFORE the explicit `token.isCancelled` early-exit
-                // branch runs. (Depending on suspension timing a cancelled
-                // task can ALSO surface as a clean nil-end of the stream —
-                // that path falls out of the loop with `token.isCancelled`
-                // true and settles below like this one.)
+                // Cancellation can throw here or end the stream as a clean
+                // nil-end (caught after the loop); both settle as a cancel.
                 if error is CancellationError || token.isCancelled {
                     log.info("[\(requestId)] Cancelled while waiting on next frame")
                     cancelledMidStream = true
@@ -1361,14 +1349,9 @@ public actor ProviderLoop {
                     return
                 }
             }
-            // A cancelled task can also end the iteration as a clean nil-end
-            // (AsyncThrowingStream finishes instead of throwing). Catch that
-            // flavor too so it settles as a cancellation, not a normal finish.
             if token.isCancelled { cancelledMidStream = true }
 
-            // Cancelled before anything was delivered: nothing to bill — send
-            // 499 (Client Closed Request) so the coordinator refunds, exactly
-            // as before.
+            // Cancelled with nothing delivered: 499 so the coordinator refunds.
             if cancelledMidStream && contentFrameCount == 0 && fullResponseText.isEmpty {
                 send.send(.inferenceError(
                     requestId: requestId,
@@ -1378,19 +1361,12 @@ public actor ProviderLoop {
                 return
             }
 
-            // C1 defense-in-depth: if the usage chunk never landed — the
-            // NORMAL case for a cancelled stream (the engine's terminal usage
-            // rides the final chunk, which an aborted request never produces),
-            // or an upstream regression on a clean finish — the coordinator
-            // would bill $0 for this request. Recover both halves:
-            //   completion: floor at the observed content-frame count
-            //               (MLX streams ~1 token per frame).
-            //   prompt:     re-derive via the SAME applyChatTemplate path the
-            //               engine tokenized with (Translation helpers + the
-            //               slot tokenizer), so the count matches what was
-            //               actually prefilled. Media (VLM) requests
-            //               under-count (image tokens aren't in the text
-            //               template) — still a floor, never an overcharge.
+            // No usage chunk (the normal case for a cancelled stream, since the
+            // engine's usage rides the final chunk an abort never sends; also an
+            // upstream regression on clean finish). Recover a billing floor:
+            // completion = content-frame count (~1 token/frame); prompt =
+            // re-template via the engine's exact applyChatTemplate path. VLM
+            // prompts under-count (no image tokens) — a floor, never an overcharge.
             if promptTokens == 0 || completionTokens == 0 {
                 if completionTokens == 0 && contentFrameCount > 0 {
                     completionTokens = contentFrameCount
@@ -1414,9 +1390,8 @@ public actor ProviderLoop {
                         )
                     }
                 }
-                // Cancelled streams end before the final chunk, so the
-                // reasoning re-tokenize that normally rides the usage parse
-                // never ran — recover it here for the completion report.
+                // Re-tokenize reasoning here too — a cancel ends before the
+                // usage parse that normally does it.
                 if reasoningTokens == 0 && !reasoningText.isEmpty && completionTokens > 0 {
                     reasoningTokens = min(
                         tokenizer.inner.encode(
@@ -1435,9 +1410,8 @@ public actor ProviderLoop {
                         + "MLXOpenAIService.streamChatCompletionFrames behavior."
                     )
                 }
-                // Surface the usage-chunk anomaly to the operator via `doctor`
-                // — except for cancellation, where a missing final chunk is
-                // expected behavior, not an upstream anomaly.
+                // Surface to `doctor` — but not for a cancel, where a missing
+                // final chunk is expected, not an upstream anomaly.
                 if !cancelledMidStream {
                     providerStats.incrementUsageGaps()
                 }
@@ -2653,9 +2627,7 @@ public actor ProviderLoop {
         } catch {
             modelsLoading.remove(modelId)
             isLoadingAny = false
-            // A failed/aborted load can leave partially-allocated weight buffers
-            // in MLX's recycling pool; release them so the admission math doesn't
-            // count ghost bytes against the next attempt (same wedge as unload).
+            // Release pool buffers a failed load left behind (same wedge as unload).
             MLX.Memory.clearCache()
             for waiter in loadingWaiters.removeValue(forKey: modelId) ?? [] {
                 waiter.resume(throwing: error)
@@ -2685,11 +2657,9 @@ public actor ProviderLoop {
         await slot.scheduler.unloadModel()
         modelSlots.removeValue(forKey: modelId)
         modelsUnloading.remove(modelId)
-        // Return the freed weight/KV buffers from MLX's recycling pool to the
-        // OS. Without this, `MLX.GPU.cacheMemory` stays ~weights-sized after an
-        // unload, and the admission math (which counts pool bytes as used)
-        // rejects every subsequent load on mid-size machines — the provider
-        // stays registered but 503s all traffic until the process restarts.
+        // Mandatory: freed weights linger in MLX's pool (GPU.cacheMemory), which
+        // load-admission counts as used — without this the box 503s every load
+        // until restart.
         MLX.Memory.clearCache()
         let waiters = unloadingWaiters.removeValue(forKey: modelId) ?? []
         for waiter in waiters { waiter.resume() }
@@ -2785,11 +2755,9 @@ public actor ProviderLoop {
                 .min(by: { $0.value.lastInferenceAt < $1.value.lastInferenceAt })
 
             guard let (modelId, _) = candidate else {
-                // Last resort before failing: MLX's recycling pool counts as
-                // used in the math above but is instantly reclaimable — drop it
-                // and resample so a pool-inflated box (KV churn, crashed unload)
-                // doesn't refuse a load that actually fits. Mirrors the same
-                // self-heal in `fastAdmissionReject`.
+                // Nothing idle to evict — drop the reclaimable pool and resample
+                // before failing, so a pool-inflated box isn't refused a load
+                // that fits. Same self-heal as fastAdmissionReject.
                 MLX.Memory.clearCache()
                 let retried = await availableMemoryGb()
                 if retried >= requiredGb { return }
@@ -2849,18 +2817,12 @@ public actor ProviderLoop {
             !modelsWithInflight.contains($0.key) && !hasLocalReservation($0.key) && !modelsUnloading.contains($0.key)
         }
 
-        // Mirrors evictUntilAvailable's terminal failure: not enough free
-        // memory and nothing idle to free. Before rejecting, return MLX's
-        // recycling pool to the OS and resample once: pool bytes are counted
-        // as used by the admission math but are instantly reclaimable, so a
-        // box that merely churned KV (or missed a clear on a crashed unload)
-        // must not wedge into rejecting all traffic until process restart.
+        // Not enough free memory and nothing idle to evict. Drop the reclaimable
+        // pool and resample once before rejecting (the wedge self-heal).
         if available < requiredGb && !hasEvictable {
             MLX.Memory.clearCache()
             let retried = await availableMemoryGb()
-            // Residency may have changed across the await; a fresh slot for
-            // this model means a concurrent request just loaded it — admit.
-            if modelSlots[modelId] != nil {
+            if modelSlots[modelId] != nil {  // a concurrent load won the race
                 return false
             }
             if retried < requiredGb {

--- a/provider-swift/Sources/ProviderCore/ProviderLoop.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop.swift
@@ -528,6 +528,19 @@ public actor ProviderLoop {
         networkAssertion.acquire()
         defer { networkAssertion.release() }
 
+        // Suppress App Nap for the lifetime of the serve loop. macOS throttles
+        // "napping" background processes — Task.sleep-driven timers (heartbeat,
+        // ping/pong) stop firing on schedule, the coordinator stops receiving
+        // heartbeats and evicts us within 90s, and our own throttled ping takes
+        // minutes to notice the dead socket: the connect→evict→reconnect churn.
+        // .userInitiated suppresses App Nap; .idleSystemSleepDisabled keeps an
+        // idle box awake while serving, on battery too (caffeinate -s is AC-only).
+        let napAssertion = ProcessInfo.processInfo.beginActivity(
+            options: [.userInitiated, .idleSystemSleepDisabled,
+                      .suddenTerminationDisabled, .automaticTerminationDisabled],
+            reason: "Darkbloom provider serving inference / keeping the coordinator link alive")
+        defer { ProcessInfo.processInfo.endActivity(napAssertion) }
+
         // Unified mode: also expose a local OpenAI endpoint off the same loaded
         // models. Started before the coordinator connection so local clients can
         // serve immediately; torn down on shutdown.

--- a/provider-swift/Sources/ProviderCore/ProviderLoop.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop.swift
@@ -1245,16 +1245,22 @@ public actor ProviderLoop {
             var reasoningText = ""
             var reasoningTokens = 0
 
+            // Set when the request is cancelled mid-stream (consumer
+            // disconnect / speculative-dispatch loser). Cancelled requests
+            // that already streamed output settle through the normal
+            // completion path below with real usage — the consumer received
+            // those tokens and the GPU did that work — instead of a bare 499
+            // that bills (and credits the provider) $0 for it.
+            var cancelledMidStream = false
             do {
                 for try await frame in frames {
                     if token.isCancelled {
                         log.info("[\(requestId)] Cancelled during generation")
-                        send.send(.inferenceError(
-                            requestId: requestId,
-                            error: "request cancelled",
-                            statusCode: 499
-                        ))
-                        return
+                        cancelledMidStream = true
+                        // Exiting the iteration is what propagates the abort:
+                        // the stream's onTermination cancels the engine-side
+                        // task and `scheduler.cancel` stops generation.
+                        break
                     }
                     // Aggregate the assistant text + usage by parsing each
                     // chunk back from its JSON delta. This is the cost of
@@ -1337,55 +1343,91 @@ public actor ProviderLoop {
                 // P1 #2: CancellationError raised by `try await
                 // frame in frames` when the inflight task is cancelled
                 // BEFORE the explicit `token.isCancelled` early-exit
-                // branch runs. Map to 499 (Client Closed Request) so
-                // the coordinator forwards an accurate status to the
-                // consumer instead of a spurious 500. Mirrors the
-                // shape of the `token.isCancelled` branch above.
-                if error is CancellationError {
+                // branch runs. (Depending on suspension timing a cancelled
+                // task can ALSO surface as a clean nil-end of the stream —
+                // that path falls out of the loop with `token.isCancelled`
+                // true and settles below like this one.)
+                if error is CancellationError || token.isCancelled {
                     log.info("[\(requestId)] Cancelled while waiting on next frame")
+                    cancelledMidStream = true
+                } else {
+                    log.error("[\(requestId)] Generation error: \(error)")
+                    let statusCode = Self.mapInferenceErrorToStatus(error)
                     send.send(.inferenceError(
                         requestId: requestId,
-                        error: "request cancelled",
-                        statusCode: 499
+                        error: error.localizedDescription,
+                        statusCode: statusCode
                     ))
                     return
                 }
-                log.error("[\(requestId)] Generation error: \(error)")
-                let statusCode = Self.mapInferenceErrorToStatus(error)
+            }
+            // A cancelled task can also end the iteration as a clean nil-end
+            // (AsyncThrowingStream finishes instead of throwing). Catch that
+            // flavor too so it settles as a cancellation, not a normal finish.
+            if token.isCancelled { cancelledMidStream = true }
+
+            // Cancelled before anything was delivered: nothing to bill — send
+            // 499 (Client Closed Request) so the coordinator refunds, exactly
+            // as before.
+            if cancelledMidStream && contentFrameCount == 0 && fullResponseText.isEmpty {
                 send.send(.inferenceError(
                     requestId: requestId,
-                    error: error.localizedDescription,
-                    statusCode: statusCode
+                    error: "request cancelled",
+                    statusCode: 499
                 ))
                 return
             }
 
-            // C1 defense-in-depth: if the usage chunk somehow never landed
-            // (upstream regression, parser drift, etc.) the coordinator
-            // would bill $0 for this request. Log at WARN, emit a
-            // diagnostic line, and continue. The chunk-parse path is the
-            // primary signal; if it ever stops working we want operators
-            // to see the regression in logs before the revenue impact
-            // shows up on the dashboard. `BatchScheduler` does not
-            // currently expose per-request token counts (only aggregate
-            // capacity), so we cannot fall back to engine-authoritative
-            // counts here without expanding its public surface.
+            // C1 defense-in-depth: if the usage chunk never landed — the
+            // NORMAL case for a cancelled stream (the engine's terminal usage
+            // rides the final chunk, which an aborted request never produces),
+            // or an upstream regression on a clean finish — the coordinator
+            // would bill $0 for this request. Recover both halves:
+            //   completion: floor at the observed content-frame count
+            //               (MLX streams ~1 token per frame).
+            //   prompt:     re-derive via the SAME applyChatTemplate path the
+            //               engine tokenized with (Translation helpers + the
+            //               slot tokenizer), so the count matches what was
+            //               actually prefilled. Media (VLM) requests
+            //               under-count (image tokens aren't in the text
+            //               template) — still a floor, never an overcharge.
             if promptTokens == 0 || completionTokens == 0 {
-                // Fallback: if completion tokens are missing/zero but we
-                // streamed visible output, bill the observed content-frame
-                // count instead of $0. This caps the revenue leak even if the
-                // usage chunk is lost entirely. Prompt tokens have no in-loop
-                // proxy, so a zero there is still only logged.
                 if completionTokens == 0 && contentFrameCount > 0 {
                     completionTokens = contentFrameCount
                     log.warning(
-                        "[\(requestId)] usage chunk missing/zero completion tokens; "
-                        + "billing \(contentFrameCount) observed content frames as a floor. "
-                        + "Check upstream MLXOpenAIService.streamChatCompletionFrames behavior."
+                        "[\(requestId)] usage chunk missing/zero completion tokens"
+                        + "\(cancelledMidStream ? " (cancelled mid-stream)" : ""); "
+                        + "billing \(contentFrameCount) observed content frames as a floor."
                     )
-                } else {
+                }
+                if promptTokens == 0 {
+                    promptTokens = Self.promptTokenFloor(
+                        request: streamingRequest,
+                        tokenizer: tokenizer,
+                        reasoningEffort: reasoningEffort
+                    )
+                    if promptTokens > 0 {
+                        log.warning(
+                            "[\(requestId)] usage chunk missing/zero prompt tokens"
+                            + "\(cancelledMidStream ? " (cancelled mid-stream)" : ""); "
+                            + "billing \(promptTokens) re-templated prompt tokens as a floor."
+                        )
+                    }
+                }
+                // Cancelled streams end before the final chunk, so the
+                // reasoning re-tokenize that normally rides the usage parse
+                // never ran — recover it here for the completion report.
+                if reasoningTokens == 0 && !reasoningText.isEmpty && completionTokens > 0 {
+                    reasoningTokens = min(
+                        tokenizer.inner.encode(
+                            text: reasoningText, addSpecialTokens: false
+                        ).count,
+                        completionTokens
+                    )
+                }
+                if promptTokens == 0 || completionTokens == 0 {
                     log.warning(
-                        "[\(requestId)] CRITICAL: usage chunk missing or zero "
+                        "[\(requestId)] CRITICAL: usage missing after recovery "
                         + "(promptTokens=\(promptTokens), "
                         + "completionTokens=\(completionTokens), "
                         + "contentFrames=\(contentFrameCount)). "
@@ -1394,9 +1436,11 @@ public actor ProviderLoop {
                     )
                 }
                 // Surface the usage-chunk anomaly to the operator via `doctor`
-                // (recorded even when the content-frame floor recovered billing,
-                // since a missing/zero usage chunk is itself the signal).
-                providerStats.incrementUsageGaps()
+                // — except for cancellation, where a missing final chunk is
+                // expected behavior, not an upstream anomaly.
+                if !cancelledMidStream {
+                    providerStats.incrementUsageGaps()
+                }
             }
 
             // Update stats
@@ -1425,7 +1469,9 @@ public actor ProviderLoop {
                 responseHash: attestation.hash
             ))
 
-            log.info("[\(requestId)] Complete: \(promptTokens) prompt + \(completionTokens) completion tokens")
+            log.info(
+                "[\(requestId)] Complete\(cancelledMidStream ? " (cancelled mid-stream, partial settle)" : ""): "
+                + "\(promptTokens) prompt + \(completionTokens) completion tokens")
         }
 
         inflightTasks[requestId] = task
@@ -2578,6 +2624,7 @@ public actor ProviderLoop {
             )
             if isShuttingDown || Task.isCancelled {
                 await scheduler.unloadModel()
+                MLX.Memory.clearCache()
                 throw CancellationError()
             }
 
@@ -2606,6 +2653,10 @@ public actor ProviderLoop {
         } catch {
             modelsLoading.remove(modelId)
             isLoadingAny = false
+            // A failed/aborted load can leave partially-allocated weight buffers
+            // in MLX's recycling pool; release them so the admission math doesn't
+            // count ghost bytes against the next attempt (same wedge as unload).
+            MLX.Memory.clearCache()
             for waiter in loadingWaiters.removeValue(forKey: modelId) ?? [] {
                 waiter.resume(throwing: error)
             }
@@ -2634,6 +2685,12 @@ public actor ProviderLoop {
         await slot.scheduler.unloadModel()
         modelSlots.removeValue(forKey: modelId)
         modelsUnloading.remove(modelId)
+        // Return the freed weight/KV buffers from MLX's recycling pool to the
+        // OS. Without this, `MLX.GPU.cacheMemory` stays ~weights-sized after an
+        // unload, and the admission math (which counts pool bytes as used)
+        // rejects every subsequent load on mid-size machines — the provider
+        // stays registered but 503s all traffic until the process restarts.
+        MLX.Memory.clearCache()
         let waiters = unloadingWaiters.removeValue(forKey: modelId) ?? []
         for waiter in waiters { waiter.resume() }
         syncWarmModelState()
@@ -2728,7 +2785,15 @@ public actor ProviderLoop {
                 .min(by: { $0.value.lastInferenceAt < $1.value.lastInferenceAt })
 
             guard let (modelId, _) = candidate else {
-                let available = String(format: "%.1f", await availableMemoryGb())
+                // Last resort before failing: MLX's recycling pool counts as
+                // used in the math above but is instantly reclaimable — drop it
+                // and resample so a pool-inflated box (KV churn, crashed unload)
+                // doesn't refuse a load that actually fits. Mirrors the same
+                // self-heal in `fastAdmissionReject`.
+                MLX.Memory.clearCache()
+                let retried = await availableMemoryGb()
+                if retried >= requiredGb { return }
+                let available = String(format: "%.1f", retried)
                 let required = String(format: "%.1f", requiredGb)
                 throw InferenceError.modelLoadFailed(
                     "Insufficient memory (\(available) GB free, need \(required) GB) and all loaded models are actively serving"
@@ -2785,9 +2850,22 @@ public actor ProviderLoop {
         }
 
         // Mirrors evictUntilAvailable's terminal failure: not enough free
-        // memory and nothing idle to free.
+        // memory and nothing idle to free. Before rejecting, return MLX's
+        // recycling pool to the OS and resample once: pool bytes are counted
+        // as used by the admission math but are instantly reclaimable, so a
+        // box that merely churned KV (or missed a clear on a crashed unload)
+        // must not wedge into rejecting all traffic until process restart.
         if available < requiredGb && !hasEvictable {
-            return true
+            MLX.Memory.clearCache()
+            let retried = await availableMemoryGb()
+            // Residency may have changed across the await; a fresh slot for
+            // this model means a concurrent request just loaded it — admit.
+            if modelSlots[modelId] != nil {
+                return false
+            }
+            if retried < requiredGb {
+                return true
+            }
         }
 
         // Mirrors the slot-cap guard in ensureModelLoaded: all slots full and

--- a/provider-swift/Sources/ProviderCore/Service/LaunchAgent.swift
+++ b/provider-swift/Sources/ProviderCore/Service/LaunchAgent.swift
@@ -299,24 +299,13 @@ public enum LaunchAgent: Sendable {
     /// APNs with no human running `darkbloom start`. (APNs registration needs the
     /// GUI/Aqua session, which a gui-domain LaunchAgent already runs in.)
     ///
-    /// `KeepAlive = { SuccessfulExit = false }` gives crash-recovery WITHOUT
-    /// racing the updater. launchd relaunches the daemon only when it exits
-    /// ABNORMALLY (crash, panic, OOM-kill — exactly the cases that were silently
-    /// removing providers from the fleet for good, since the old `KeepAlive=false`
-    /// never brought a crashed node back until the next login/reboot). The two
-    /// intentional teardown paths are unaffected:
-    ///   - `darkbloom stop` / `update` uninstall → `launchctl bootout` removes the
-    ///     job from launchd entirely, so KeepAlive cannot relaunch it.
-    ///   - graceful self-update → `launchctl kickstart -k` is an atomic
-    ///     kill+relaunch; the binary swap happens while the old process is still
-    ///     running (rename), so launchd never observes an exit mid-swap to race.
-    /// A genuinely broken binary that crashes on launch is bounded by launchd's
-    /// default 10s ThrottleInterval (no tight respawn loop).
-    ///
-    /// NOTE: a plist already on disk is only re-read by launchd on
-    /// bootout+bootstrap (login/reboot/`darkbloom start`), NOT by `kickstart -k`.
-    /// So existing installs pick this up on their next restart cycle, not on the
-    /// in-place auto-update that swaps the binary.
+    /// `KeepAlive = { SuccessfulExit = false }`: relaunch only on ABNORMAL exit
+    /// (crash/panic/OOM-kill) — crash-recovery the old `KeepAlive=false` lacked.
+    /// The intentional teardowns don't race it: `stop`/uninstall is a `bootout`
+    /// (removes the job) and self-update is `kickstart -k` (atomic restart;
+    /// binary is swapped while still running). NOTE: an on-disk plist is re-read
+    /// only on bootout+bootstrap (login/reboot/`darkbloom start`), not by
+    /// `kickstart -k`, so existing installs pick this up on their next restart.
     static func makeServicePlist(
         label: String,
         programArguments: [String],

--- a/provider-swift/Sources/ProviderCore/Service/LaunchAgent.swift
+++ b/provider-swift/Sources/ProviderCore/Service/LaunchAgent.swift
@@ -299,9 +299,24 @@ public enum LaunchAgent: Sendable {
     /// APNs with no human running `darkbloom start`. (APNs registration needs the
     /// GUI/Aqua session, which a gui-domain LaunchAgent already runs in.)
     ///
-    /// `KeepAlive = false` is deliberate: unconditional KeepAlive would have launchd
-    /// relaunch the process the instant the graceful self-updater stops it to swap
-    /// the binary, racing the stage-then-swap. Crash-recovery is handled separately.
+    /// `KeepAlive = { SuccessfulExit = false }` gives crash-recovery WITHOUT
+    /// racing the updater. launchd relaunches the daemon only when it exits
+    /// ABNORMALLY (crash, panic, OOM-kill — exactly the cases that were silently
+    /// removing providers from the fleet for good, since the old `KeepAlive=false`
+    /// never brought a crashed node back until the next login/reboot). The two
+    /// intentional teardown paths are unaffected:
+    ///   - `darkbloom stop` / `update` uninstall → `launchctl bootout` removes the
+    ///     job from launchd entirely, so KeepAlive cannot relaunch it.
+    ///   - graceful self-update → `launchctl kickstart -k` is an atomic
+    ///     kill+relaunch; the binary swap happens while the old process is still
+    ///     running (rename), so launchd never observes an exit mid-swap to race.
+    /// A genuinely broken binary that crashes on launch is bounded by launchd's
+    /// default 10s ThrottleInterval (no tight respawn loop).
+    ///
+    /// NOTE: a plist already on disk is only re-read by launchd on
+    /// bootout+bootstrap (login/reboot/`darkbloom start`), NOT by `kickstart -k`.
+    /// So existing installs pick this up on their next restart cycle, not on the
+    /// in-place auto-update that swaps the binary.
     static func makeServicePlist(
         label: String,
         programArguments: [String],
@@ -311,7 +326,8 @@ public enum LaunchAgent: Sendable {
         var plistDict: [String: Any] = [
             "Label": label,
             "ProgramArguments": programArguments,
-            "KeepAlive": false,
+            // Restart only on abnormal exit; clean bootout (stop) stays stopped.
+            "KeepAlive": ["SuccessfulExit": false],
             "RunAtLoad": true,
             "StandardOutPath": logPath,
             "StandardErrorPath": logPath,

--- a/provider-swift/Sources/ProviderCore/Service/LaunchAgent.swift
+++ b/provider-swift/Sources/ProviderCore/Service/LaunchAgent.swift
@@ -27,6 +27,52 @@ public enum LaunchAgent: Sendable {
             .appendingPathComponent(".darkbloom/provider.log")
     }
 
+    // MARK: - In-place policy refresh
+
+    /// Surgically refresh the KeepAlive policy in the EXISTING on-disk plist.
+    ///
+    /// The crash-recovery KeepAlive={SuccessfulExit:false} only ships in plists
+    /// written by `darkbloom start` — auto-update restarts via `kickstart -k`
+    /// (which never re-reads the file) and login/reboot re-bootstrap whatever
+    /// file is on disk. Without this, the existing fleet would NEVER gain crash
+    /// recovery. Called at serve startup: rewrites ONLY the KeepAlive key in
+    /// place (preserving ProgramArguments/env customizations) so the policy
+    /// takes effect at the next bootstrap. Deliberately does NOT bootout/
+    /// re-bootstrap — that would kill the running provider; the file change is
+    /// inert until launchd next loads it.
+    ///
+    /// Returns true if the file was updated, false if absent/already current.
+    /// Best-effort: failures are logged by the caller, never fatal.
+    @discardableResult
+    public static func syncKeepAlivePolicyOnDisk() throws -> Bool {
+        try syncKeepAlivePolicy(at: plistPath())
+    }
+
+    /// Path-injectable core of `syncKeepAlivePolicyOnDisk` (separated for tests).
+    @discardableResult
+    static func syncKeepAlivePolicy(at path: URL) throws -> Bool {
+        guard FileManager.default.fileExists(atPath: path.path) else {
+            return false // not a launchd install (foreground/terminal serve)
+        }
+        let data = try Data(contentsOf: path)
+        var format = PropertyListSerialization.PropertyListFormat.xml
+        guard var plist = try PropertyListSerialization.propertyList(
+            from: data, options: [], format: &format
+        ) as? [String: Any] else {
+            return false
+        }
+        if let keepAlive = plist["KeepAlive"] as? [String: Bool],
+           keepAlive["SuccessfulExit"] == false {
+            return false // already current
+        }
+        plist["KeepAlive"] = ["SuccessfulExit": false]
+        let updated = try PropertyListSerialization.data(
+            fromPropertyList: plist, format: format, options: 0
+        )
+        try updated.write(to: path, options: .atomic)
+        return true
+    }
+
     // MARK: - Queries
 
     /// Whether the plist file exists on disk.
@@ -303,9 +349,14 @@ public enum LaunchAgent: Sendable {
     /// (crash/panic/OOM-kill) — crash-recovery the old `KeepAlive=false` lacked.
     /// The intentional teardowns don't race it: `stop`/uninstall is a `bootout`
     /// (removes the job) and self-update is `kickstart -k` (atomic restart;
-    /// binary is swapped while still running). NOTE: an on-disk plist is re-read
-    /// only on bootout+bootstrap (login/reboot/`darkbloom start`), not by
-    /// `kickstart -k`, so existing installs pick this up on their next restart.
+    /// binary is swapped while still running).
+    ///
+    /// PROPAGATION: nothing rewrites an existing install's plist by itself —
+    /// self-update is `kickstart -k` (doesn't re-read the file) and login/reboot
+    /// re-bootstrap the OLD on-disk file. `syncKeepAlivePolicyOnDisk` (called at
+    /// serve startup) refreshes the FILE in place so the policy takes effect at
+    /// the next bootstrap; only a fresh `darkbloom start` regenerates the whole
+    /// plist.
     static func makeServicePlist(
         label: String,
         programArguments: [String],

--- a/provider-swift/Sources/ProviderCore/Service/LaunchAgent.swift
+++ b/provider-swift/Sources/ProviderCore/Service/LaunchAgent.swift
@@ -41,11 +41,25 @@ public enum LaunchAgent: Sendable {
     /// re-bootstrap — that would kill the running provider; the file change is
     /// inert until launchd next loads it.
     ///
-    /// Returns true if the file was updated, false if absent/already current.
+    /// Returns true if any file was updated, false if absent/already current.
     /// Best-effort: failures are logged by the caller, never fatal.
+    ///
+    /// Also refreshes plists installed under the supported LEGACY labels:
+    /// `restart()`/`stop()` keep legacy-label installs running, so a machine
+    /// that never re-ran `darkbloom start` since the rename still boots from
+    /// the legacy plist — without this it would never gain crash recovery.
     @discardableResult
     public static func syncKeepAlivePolicyOnDisk() throws -> Bool {
-        try syncKeepAlivePolicy(at: plistPath())
+        var updated = try syncKeepAlivePolicy(at: plistPath())
+        let agentsDir = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/LaunchAgents")
+        for legacyLabel in legacyLabels {
+            let legacyPath = agentsDir.appendingPathComponent("\(legacyLabel).plist")
+            if try syncKeepAlivePolicy(at: legacyPath) {
+                updated = true
+            }
+        }
+        return updated
     }
 
     /// Path-injectable core of `syncKeepAlivePolicyOnDisk` (separated for tests).

--- a/provider-swift/Sources/ProviderCore/Update/SelfUpdater.swift
+++ b/provider-swift/Sources/ProviderCore/Update/SelfUpdater.swift
@@ -449,16 +449,10 @@ public struct SelfUpdater: Sendable {
         return .success(())
     }
 
-    /// The darkbloom root directory (~/.darkbloom/) of the running install.
-    /// The executable could be at either:
-    ///   ~/.darkbloom/bin/darkbloom                           -> root = ../../
-    ///   ~/.darkbloom/Darkbloom.app/Contents/MacOS/darkbloom  -> root = ../../../../
-    ///
-    /// `install.sh` also symlinks /usr/local/bin/darkbloom -> ~/.darkbloom/bin/
-    /// for PATH convenience, and `executablePath` reports the path the process
-    /// was invoked through — the SYMLINK when run as plain `darkbloom`. Resolve
-    /// it first, or the root derives to /usr/local and every stage/commit fails
-    /// with a permission error ("can't save .update-staging-… in 'local'").
+    /// The darkbloom root (~/.darkbloom/) of the running install. Must resolve
+    /// symlinks first: invoked as plain `darkbloom`, `executablePath` is the
+    /// /usr/local/bin/darkbloom PATH symlink, which would derive root=/usr/local
+    /// and fail staging with EPERM ("can't save .update-staging-… in 'local'").
     private func liveInstallDir() -> URL? {
         guard let executablePath = Bundle.main.executablePath else { return nil }
         return Self.installRoot(forExecutablePath: executablePath)

--- a/provider-swift/Sources/ProviderCore/Update/SelfUpdater.swift
+++ b/provider-swift/Sources/ProviderCore/Update/SelfUpdater.swift
@@ -453,9 +453,20 @@ public struct SelfUpdater: Sendable {
     /// The executable could be at either:
     ///   ~/.darkbloom/bin/darkbloom                           -> root = ../../
     ///   ~/.darkbloom/Darkbloom.app/Contents/MacOS/darkbloom  -> root = ../../../../
+    ///
+    /// `install.sh` also symlinks /usr/local/bin/darkbloom -> ~/.darkbloom/bin/
+    /// for PATH convenience, and `executablePath` reports the path the process
+    /// was invoked through — the SYMLINK when run as plain `darkbloom`. Resolve
+    /// it first, or the root derives to /usr/local and every stage/commit fails
+    /// with a permission error ("can't save .update-staging-… in 'local'").
     private func liveInstallDir() -> URL? {
         guard let executablePath = Bundle.main.executablePath else { return nil }
-        let execURL = URL(fileURLWithPath: executablePath)
+        return Self.installRoot(forExecutablePath: executablePath)
+    }
+
+    /// Pure path derivation behind `liveInstallDir` (separated for tests).
+    static func installRoot(forExecutablePath executablePath: String) -> URL {
+        let execURL = URL(fileURLWithPath: executablePath).resolvingSymlinksInPath()
         let parentDir = execURL.deletingLastPathComponent()
         if parentDir.lastPathComponent == "MacOS" {
             // Inside .app bundle: MacOS -> Contents -> Darkbloom.app -> root

--- a/provider-swift/Tests/ProviderCoreTests/LaunchAgentRestartTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/LaunchAgentRestartTests.swift
@@ -48,9 +48,15 @@ struct LaunchAgentServicePlistTests {
             environment: ["DARKBLOOM_PREFIX_CACHE": "0", "PATH": "/usr/bin"]
         )
         // RunAtLoad=true so a rebooted / auto-login box restarts (and re-attests via
-        // APNs) with no human; KeepAlive stays false to avoid racing the self-updater.
+        // APNs) with no human.
         #expect(plist["RunAtLoad"] as? Bool == true)
-        #expect(plist["KeepAlive"] as? Bool == false)
+        // KeepAlive restarts ONLY on abnormal exit (crash/OOM-kill) — crash
+        // recovery without racing the self-updater. Clean bootout (stop) and
+        // kickstart (update) are unaffected. Must be the dict form
+        // {SuccessfulExit: false}, NOT the old unconditional `false`.
+        let keepAlive = plist["KeepAlive"] as? [String: Bool]
+        #expect(keepAlive == ["SuccessfulExit": false])
+        #expect(plist["KeepAlive"] as? Bool == nil)
         #expect((plist["EnvironmentVariables"] as? [String: String]) == ["DARKBLOOM_PREFIX_CACHE": "0"])
     }
 

--- a/provider-swift/Tests/ProviderCoreTests/LaunchAgentRestartTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/LaunchAgentRestartTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 @testable import ProviderCore
 
@@ -69,5 +70,56 @@ struct LaunchAgentServicePlistTests {
         )
         #expect(plist["EnvironmentVariables"] == nil)
         #expect(plist["RunAtLoad"] as? Bool == true)
+    }
+}
+
+@Suite("LaunchAgent KeepAlive policy refresh")
+struct LaunchAgentKeepAliveSyncTests {
+    private func writePlist(_ dict: [String: Any]) throws -> URL {
+        let path = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ka-sync-\(UUID().uuidString).plist")
+        let data = try PropertyListSerialization.data(
+            fromPropertyList: dict, format: .xml, options: 0)
+        try data.write(to: path)
+        return path
+    }
+
+    /// An old-fleet plist (KeepAlive=false bool) is upgraded in place to the
+    /// crash-recovery dict, preserving every other key — this is the only
+    /// channel by which existing installs ever gain crash recovery (auto-update
+    /// restarts never re-read the plist).
+    @Test func upgradesLegacyBoolKeepAlivePreservingOtherKeys() throws {
+        let path = try writePlist([
+            "Label": "io.darkbloom.provider",
+            "ProgramArguments": ["/Users/op/.darkbloom/bin/darkbloom", "start", "--foreground"],
+            "KeepAlive": false,
+            "RunAtLoad": true,
+            "EnvironmentVariables": ["DARKBLOOM_PREFIX_CACHE": "0"],
+        ])
+        defer { try? FileManager.default.removeItem(at: path) }
+
+        #expect(try LaunchAgent.syncKeepAlivePolicy(at: path) == true)
+
+        let data = try Data(contentsOf: path)
+        let plist = try PropertyListSerialization.propertyList(
+            from: data, options: [], format: nil) as? [String: Any]
+        #expect((plist?["KeepAlive"] as? [String: Bool]) == ["SuccessfulExit": false])
+        // Operator customizations survive the surgical rewrite.
+        #expect((plist?["ProgramArguments"] as? [String])?.count == 3)
+        #expect((plist?["EnvironmentVariables"] as? [String: String]) == ["DARKBLOOM_PREFIX_CACHE": "0"])
+        #expect(plist?["RunAtLoad"] as? Bool == true)
+    }
+
+    @Test func alreadyCurrentAndMissingAreNoOps() throws {
+        let current = try writePlist([
+            "Label": "io.darkbloom.provider",
+            "KeepAlive": ["SuccessfulExit": false],
+        ])
+        defer { try? FileManager.default.removeItem(at: current) }
+        #expect(try LaunchAgent.syncKeepAlivePolicy(at: current) == false)
+
+        let missing = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ka-sync-missing-\(UUID().uuidString).plist")
+        #expect(try LaunchAgent.syncKeepAlivePolicy(at: missing) == false)
     }
 }

--- a/provider-swift/Tests/ProviderCoreTests/SelfUpdaterTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/SelfUpdaterTests.swift
@@ -317,3 +317,51 @@ private func runTarCreate(sourceDir: URL, tarball: URL) throws {
     process.waitUntilExit()
     #expect(process.terminationStatus == 0)
 }
+
+// MARK: - installRoot derivation (symlink regression)
+
+@Suite("SelfUpdater.installRoot")
+struct SelfUpdaterInstallRootTests {
+
+    @Test("flat bin layout derives the darkbloom root")
+    func flatLayout() {
+        let root = SelfUpdater.installRoot(
+            forExecutablePath: "/Users/op/.darkbloom/bin/darkbloom")
+        #expect(root.path.hasSuffix("/.darkbloom"))
+    }
+
+    @Test("app bundle layout walks out of Contents/MacOS")
+    func appBundleLayout() {
+        let root = SelfUpdater.installRoot(
+            forExecutablePath:
+                "/Users/op/.darkbloom/Darkbloom.app/Contents/MacOS/darkbloom")
+        #expect(root.path.hasSuffix("/.darkbloom"))
+    }
+
+    /// Regression for the fleet-wide `darkbloom update` failure: install.sh
+    /// symlinks /usr/local/bin/darkbloom -> ~/.darkbloom/bin/darkbloom, and the
+    /// executable path reports the SYMLINK when invoked through PATH. Deriving
+    /// the root from the unresolved path staged updates into /usr/local
+    /// ("You don't have permission to save .update-staging-… in 'local'").
+    @Test("PATH symlink resolves to the real install root")
+    func symlinkedInvocationResolvesRealRoot() throws {
+        let fm = FileManager.default
+        let tmp = fm.temporaryDirectory
+            .appendingPathComponent("installroot-\(UUID().uuidString)")
+        let realBin = tmp.appendingPathComponent("home/.darkbloom/bin")
+        let fakeUsrLocalBin = tmp.appendingPathComponent("usr/local/bin")
+        try fm.createDirectory(at: realBin, withIntermediateDirectories: true)
+        try fm.createDirectory(at: fakeUsrLocalBin, withIntermediateDirectories: true)
+        defer { try? fm.removeItem(at: tmp) }
+
+        let realExec = realBin.appendingPathComponent("darkbloom")
+        #expect(fm.createFile(atPath: realExec.path, contents: Data("x".utf8)))
+        let link = fakeUsrLocalBin.appendingPathComponent("darkbloom")
+        try fm.createSymbolicLink(at: link, withDestinationURL: realExec)
+
+        let root = SelfUpdater.installRoot(forExecutablePath: link.path)
+
+        #expect(root.path.hasSuffix("/.darkbloom"))
+        #expect(!root.path.contains("usr/local"))
+    }
+}


### PR DESCRIPTION
Fleet-stability hotfix for the June 2026 outage where the fleet collapsed (~71→38, "18 live") with most disconnected machines stuck in a connect→evict→reconnect loop. Diagnosed from the RDS replica (`provider_sessions`/`providers`) + `ecloud compute app logs`, and two rounds of code investigation. The "v0.6.2 HOME edit" hypothesis was ruled out.

## Primary cause — the churn loop (verified in data)
Provider processes got **suspended** (macOS App Nap / sleep), which froze their `Task.sleep` heartbeat/ping timers → coordinator stopped receiving heartbeats → **evicted at 90s** → provider took **~15 min** to notice the dead socket (its own ping/pong was also throttled) → reconnect. Confirmed: 99 sessions died in the 90–130s evict window in 12h; top churners ran ~115s avg with 17–21 reconnects/6h; live logs still show `insufficient memory` (92) and `chunk for unknown request` (6).

### Provider fixes (keep providers alive + reconnect fast)
- **App Nap prevention** — `ProcessInfo.beginActivity([.userInitiated, .idleSystemSleepDisabled, …])` for the serve lifetime. Root-cause fix for the timer freeze. (No new battery behavior: `caffeinate -i` already prevented idle sleep on battery; this replaces it with an in-process assertion that *also* stops App Nap.)
- **Suspension-detection reconnect** — the ping task detects an over-long wall-clock gap between ticks (process was suspended) and reconnects immediately instead of waiting out the throttled 30s pong timeout. Removes the ~15-min lag.
- **KeepAlive crash-recovery that actually propagates** — `KeepAlive={SuccessfulExit:false}` in new plists, **plus** a serve-startup `syncKeepAlivePolicyOnDisk()` that surgically refreshes the existing on-disk plist (file-only, no bootout), since auto-update (`kickstart -k`) never re-reads the plist and login/reboot re-bootstrap the old file. Takes effect at each node's next bootstrap.

### Coordinator fixes
- **Eviction 2-strike grace** — reap only after stale on two consecutive sweeps, so a transient coordinator stall (which ages many `LastHeartbeat` values at once → the synchronized mass-eviction signature) can't reap a live fleet. Plus a per-sweep heartbeat-age histogram so "providers slept" vs "coordinator stalled" is diagnosable.
- **Zombie-stream cancel** — chunk for an unknown request → throttled cancel so the provider stops burning GPU + admission.
- **Settlement holder** — consumer mid-stream disconnects no longer drop the provider's terminal ("unknown request"): billing settles from the terminal or the reservation refunds after a 30s grace. Error-terminal refunds run **off the WS read loop** (a blocking RDS credit there would stall heartbeats — the same churn vector). Cancel terminals (499) no longer ding provider reputation (old-fleet providers emit one per consumer disconnect).
- **Dispatch load-failure cool-down** — skip a pair that 503'd `insufficient memory` for 2m (on the `ReserveProviderEx` hot path), ending the dispatch→503→retry storm.

## Also fixed
- **MLX memory wedge** — `MLX.Memory.clearCache()` on unload/failed-load/evict; freed weights stayed in the pool and admission 503'd every load until restart.
- **`darkbloom update` /usr/local EPERM** — resolve the PATH symlink before deriving the install root.
- **Cancelled-request billing $0** — settle cancelled streams with real usage (prompt re-template + content-frame floor).
- **Datadog without an agent** — gauges **and counters** now submit via the HTTPS `/series` API (the TEE has no DogStatsD agent; UDP metrics were silently dropped). Path-exclusive with DogStatsD; wire-contract test pins the payload.
- prefix-cache banner `.notice` not `.warning`.

## Deferred (with rationale — NOT shipped)
- **SE-key minting guard** — verification inconclusive: `install.sh` symlinks resolve *into* the `.app`, contradicting the "outside-bundle mints a new key" hypothesis.
- **`ReserveProviderEx` selection RLock** — the coordinator-stall root cause is the O(fleet) routing selection under the `r.mu` write lock. High-risk lock change; the eviction grace mitigates the blast radius. Focused follow-up.

## Review
Four review rounds: two 2-reviewer quality gates (settlement race, cool-down hot-path, `LastHeartbeat` race, zombie map bound — all fixed) plus a **six-dimension adversarial panel** (20 agents; every finding independently code-verified: 9 confirmed → all fixed above, 5 refuted — including the battery-behavior and wall-clock-suspension concerns). Full coordinator suite green incl. `-race` on api/registry/datadog; Swift build + targeted suites green.

## Rollout (human-only)
1. **Deploy coordinator now** — eviction grace, zombie cancel, settlement, cool-down, DD metrics all help immediately with no provider update.
2. **Cut provider 0.6.4** — the ~54 live 0.6.3 nodes auto-update and pick up App Nap prevention (the big one), wake-reconnect, clearCache, update-symlink, cancelled billing, and the plist KeepAlive refresh (crash-recovery arms at each node's next login/reboot/start).

🤖 Generated with [Claude Code](https://claude.com/claude-code)