### PR TITLE
feat(provider): crash-recovery watchdog (auto-restart ~5 min after a crash)

### DIFF
--- a/provider-swift/Sources/ProviderCore/Config/ProviderConfig.swift
+++ b/provider-swift/Sources/ProviderCore/Config/ProviderConfig.swift
@@ -23,17 +23,24 @@ public struct ProviderSettings: Sendable, Equatable, Codable {
     public var name: String
     public var memoryReserveGB: UInt64
     public var autoUpdate: Bool
+    /// When true (default), the watchdog relaunches the provider ~5 minutes
+    /// after a crash. Set `auto_restart = false` to opt out while keeping the
+    /// provider installed (a plain `darkbloom stop` also disables recovery for
+    /// that session). See `WatchdogAgent` / `WatchdogPolicy`.
+    public var autoRestart: Bool
 
-    public init(name: String, memoryReserveGB: UInt64 = 4, autoUpdate: Bool = true) {
+    public init(name: String, memoryReserveGB: UInt64 = 4, autoUpdate: Bool = true, autoRestart: Bool = true) {
         self.name = name
         self.memoryReserveGB = memoryReserveGB
         self.autoUpdate = autoUpdate
+        self.autoRestart = autoRestart
     }
 
     enum CodingKeys: String, CodingKey {
         case name
         case memoryReserveGB = "memory_reserve_gb"
         case autoUpdate = "auto_update"
+        case autoRestart = "auto_restart"
     }
 
     public init(from decoder: Decoder) throws {
@@ -41,6 +48,7 @@ public struct ProviderSettings: Sendable, Equatable, Codable {
         self.name = try container.decodeIfPresent(String.self, forKey: .name) ?? "darkbloom"
         self.memoryReserveGB = try container.decodeIfPresent(UInt64.self, forKey: .memoryReserveGB) ?? 4
         self.autoUpdate = try container.decodeIfPresent(Bool.self, forKey: .autoUpdate) ?? true
+        self.autoRestart = try container.decodeIfPresent(Bool.self, forKey: .autoRestart) ?? true
     }
 }
 

--- a/provider-swift/Sources/ProviderCore/Config/ProviderConfig.swift
+++ b/provider-swift/Sources/ProviderCore/Config/ProviderConfig.swift
@@ -23,10 +23,8 @@ public struct ProviderSettings: Sendable, Equatable, Codable {
     public var name: String
     public var memoryReserveGB: UInt64
     public var autoUpdate: Bool
-    /// When true (default), the watchdog relaunches the provider ~5 minutes
-    /// after a crash. Set `auto_restart = false` to opt out while keeping the
-    /// provider installed (a plain `darkbloom stop` also disables recovery for
-    /// that session). See `WatchdogAgent` / `WatchdogPolicy`.
+    /// When true (default), the watchdog relaunches the provider ~5 min after a
+    /// crash. `false` opts out while keeping the provider installed.
     public var autoRestart: Bool
 
     public init(name: String, memoryReserveGB: UInt64 = 4, autoUpdate: Bool = true, autoRestart: Bool = true) {

--- a/provider-swift/Sources/ProviderCore/Service/LaunchAgent.swift
+++ b/provider-swift/Sources/ProviderCore/Service/LaunchAgent.swift
@@ -1,9 +1,12 @@
 /// LaunchAgent -- launchd user agent management for the Darkbloom provider.
 ///
-/// The provider only runs when the user explicitly starts it via
-/// `darkbloom start` or the macOS app's "Go Online" toggle.
-/// It does NOT auto-start on login or auto-restart after crashes.
-/// The user is always in control of when their GPU is being used.
+/// The provider runs only after the user explicitly starts it via
+/// `darkbloom start` (or the macOS app's "Go Online" toggle). Once installed the
+/// agent auto-starts at login (RunAtLoad) so a rebooted box re-attests without a
+/// manual start, and crash recovery is delegated to the separate `WatchdogAgent`
+/// (it relaunches a crashed daemon after a grace period). `darkbloom stop`
+/// unloads the agent and keeps it stopped. The user is always in control of when
+/// their GPU is being used.
 
 import Foundation
 
@@ -11,6 +14,11 @@ public enum LaunchAgent: Sendable {
 
     public static let label = "io.darkbloom.provider"
     private static let legacyLabels = ["dev.darkbloom.provider"]
+
+    /// Every launchd label the provider may be registered under (canonical +
+    /// legacy). The watchdog probes all of them so it still recognises a running
+    /// provider on a not-yet-migrated install.
+    public static var supportedLabels: [String] { [label] + legacyLabels }
 
     // MARK: - Paths
 
@@ -172,10 +180,37 @@ public enum LaunchAgent: Sendable {
         throw LaunchAgentError.notInstalled
     }
 
+    /// Restart the provider in place ONLY if it is currently loaded
+    /// (`kickstart -k`). Unlike `restart()`, this never bootstraps an unloaded
+    /// job — so the watchdog can recover a crashed (loaded-but-dead) provider
+    /// without ever reviving one the user intentionally stopped (`bootout`
+    /// unloads the job). Returns `true` if a restart was issued, `false` if the
+    /// provider was not loaded under any supported label.
+    @discardableResult
+    public static func kickstartIfLoaded() throws -> Bool {
+        // `reloadIfMissing: false` is the safety guarantee: if the job vanished
+        // between the isLoaded() check and the kickstart (e.g. a `darkbloom stop`
+        // landed in that window), we do NOT bootstrap it back — reviving a
+        // provider the user just stopped is exactly what the watchdog must avoid.
+        if isLoaded() {
+            try kickstartInPlace(label: label, reloadIfMissing: false)
+            return true
+        }
+        for legacyLabel in legacyLabels where isLoaded(label: legacyLabel) {
+            try kickstartInPlace(label: legacyLabel, reloadIfMissing: false)
+            return true
+        }
+        return false
+    }
+
     /// `launchctl kickstart -k gui/<uid>/<label>` — restart the already-loaded
     /// service in place. The `-k` flag kills the current instance before
     /// relaunching it from the existing plist.
-    private static func kickstartInPlace(label serviceLabel: String) throws {
+    ///
+    /// `reloadIfMissing` controls the "service vanished" recovery: `restart()`
+    /// wants it (an unloaded-but-installed job should be brought up), but the
+    /// watchdog passes `false` so it never loads a job the user stopped.
+    private static func kickstartInPlace(label serviceLabel: String, reloadIfMissing: Bool = true) throws {
         let target = "gui/\(getuid())/\(serviceLabel)"
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/bin/launchctl")
@@ -194,9 +229,13 @@ public enum LaunchAgent: Sendable {
                 encoding: .utf8
             ) ?? ""
             // Error 3 = "could not find service": the service vanished between
-            // the isLoaded() check and here. Fall back to a fresh load.
+            // the isLoaded() check and here.
             if stderr.contains("3:") || stderr.contains("could not find service") {
-                try loadService()
+                // Fall back to a fresh load only when allowed; the watchdog opts
+                // out so it can't resurrect an intentionally-stopped provider.
+                if reloadIfMissing {
+                    try loadService()
+                }
                 return
             }
             throw LaunchAgentError.kickstartFailed(stderr.trimmingCharacters(in: .whitespacesAndNewlines))
@@ -301,7 +340,9 @@ public enum LaunchAgent: Sendable {
     ///
     /// `KeepAlive = false` is deliberate: unconditional KeepAlive would have launchd
     /// relaunch the process the instant the graceful self-updater stops it to swap
-    /// the binary, racing the stage-then-swap. Crash-recovery is handled separately.
+    /// the binary, racing the stage-then-swap. Crash-recovery is instead owned by
+    /// the separate `WatchdogAgent`, which waits out a grace period before
+    /// relaunching (so it never races the updater) and honours `darkbloom stop`.
     static func makeServicePlist(
         label: String,
         programArguments: [String],
@@ -359,11 +400,11 @@ public enum LaunchAgent: Sendable {
             }
         }
 
-        // With RunAtLoad=false, bootstrap registers the service but doesn't
-        // start it. Kickstart actually launches the process. After a successful
-        // bootstrap the service exists, so kickstart should return 0 — surface a
-        // non-zero exit (or a spawn failure) rather than silently reporting
-        // success when launchd never launched the process.
+        // RunAtLoad=true already starts the service on bootstrap; this kickstart
+        // is belt-and-suspenders (a no-op if it's already running). After a
+        // successful bootstrap the service exists, so kickstart should return 0 —
+        // surface a non-zero exit (or a spawn failure) rather than silently
+        // reporting success when launchd never launched the process.
         let target = "gui/\(getuid())/\(label)"
         let kickstart = Process()
         kickstart.executableURL = URL(fileURLWithPath: "/bin/launchctl")
@@ -414,20 +455,9 @@ public enum LaunchAgent: Sendable {
     }
 
     /// Resolve the current executable path. Falls back to ~/.darkbloom/bin/darkbloom.
+    /// Shared with `WatchdogAgent` via `LaunchctlControl`.
     private static func currentExecutablePath() -> String {
-        var buffer = [CChar](repeating: 0, count: Int(MAXPATHLEN))
-        var size = UInt32(MAXPATHLEN)
-        if _NSGetExecutablePath(&buffer, &size) == 0 {
-            if let resolved = realpath(buffer, nil) {
-                defer { free(resolved) }
-                return String(cString: resolved)
-            }
-            return String(cString: buffer)
-        }
-        // Fallback
-        return FileManager.default.homeDirectoryForCurrentUser
-            .appendingPathComponent(".darkbloom/bin/darkbloom")
-            .path
+        LaunchctlControl.currentExecutablePath()
     }
 
 }

--- a/provider-swift/Sources/ProviderCore/Service/LaunchAgent.swift
+++ b/provider-swift/Sources/ProviderCore/Service/LaunchAgent.swift
@@ -1,12 +1,9 @@
 /// LaunchAgent -- launchd user agent management for the Darkbloom provider.
 ///
-/// The provider runs only after the user explicitly starts it via
-/// `darkbloom start` (or the macOS app's "Go Online" toggle). Once installed the
-/// agent auto-starts at login (RunAtLoad) so a rebooted box re-attests without a
-/// manual start, and crash recovery is delegated to the separate `WatchdogAgent`
-/// (it relaunches a crashed daemon after a grace period). `darkbloom stop`
-/// unloads the agent and keeps it stopped. The user is always in control of when
-/// their GPU is being used.
+/// The provider runs only after the user explicitly starts it (`darkbloom start`
+/// or the app's "Go Online"). It auto-starts at login (RunAtLoad) so a rebooted
+/// box re-attests without a manual start; crash recovery is delegated to the
+/// separate `WatchdogAgent`. `darkbloom stop` unloads it and keeps it stopped.
 
 import Foundation
 
@@ -15,9 +12,8 @@ public enum LaunchAgent: Sendable {
     public static let label = "io.darkbloom.provider"
     private static let legacyLabels = ["dev.darkbloom.provider"]
 
-    /// Every launchd label the provider may be registered under (canonical +
-    /// legacy). The watchdog probes all of them so it still recognises a running
-    /// provider on a not-yet-migrated install.
+    /// Canonical + legacy labels the provider may be registered under (the
+    /// watchdog probes all of them).
     public static var supportedLabels: [String] { [label] + legacyLabels }
 
     // MARK: - Paths
@@ -180,18 +176,12 @@ public enum LaunchAgent: Sendable {
         throw LaunchAgentError.notInstalled
     }
 
-    /// Restart the provider in place ONLY if it is currently loaded
-    /// (`kickstart -k`). Unlike `restart()`, this never bootstraps an unloaded
-    /// job — so the watchdog can recover a crashed (loaded-but-dead) provider
-    /// without ever reviving one the user intentionally stopped (`bootout`
-    /// unloads the job). Returns `true` if a restart was issued, `false` if the
-    /// provider was not loaded under any supported label.
+    /// Restart in place ONLY if currently loaded (`reloadIfMissing: false`), so
+    /// the watchdog recovers a crashed (loaded-but-dead) provider but never
+    /// revives one the user stopped (`bootout` unloads it). Returns false if not
+    /// loaded under any supported label.
     @discardableResult
     public static func kickstartIfLoaded() throws -> Bool {
-        // `reloadIfMissing: false` is the safety guarantee: if the job vanished
-        // between the isLoaded() check and the kickstart (e.g. a `darkbloom stop`
-        // landed in that window), we do NOT bootstrap it back — reviving a
-        // provider the user just stopped is exactly what the watchdog must avoid.
         if isLoaded() {
             try kickstartInPlace(label: label, reloadIfMissing: false)
             return true
@@ -203,13 +193,9 @@ public enum LaunchAgent: Sendable {
         return false
     }
 
-    /// `launchctl kickstart -k gui/<uid>/<label>` — restart the already-loaded
-    /// service in place. The `-k` flag kills the current instance before
-    /// relaunching it from the existing plist.
-    ///
-    /// `reloadIfMissing` controls the "service vanished" recovery: `restart()`
-    /// wants it (an unloaded-but-installed job should be brought up), but the
-    /// watchdog passes `false` so it never loads a job the user stopped.
+    /// `launchctl kickstart -k` — kill + relaunch the loaded service in place.
+    /// `reloadIfMissing`: `restart()` wants it (bring up an unloaded-but-installed
+    /// job); the watchdog passes false so it never loads a job the user stopped.
     private static func kickstartInPlace(label serviceLabel: String, reloadIfMissing: Bool = true) throws {
         let target = "gui/\(getuid())/\(serviceLabel)"
         let process = Process()

--- a/provider-swift/Sources/ProviderCore/Service/LaunchctlControl.swift
+++ b/provider-swift/Sources/ProviderCore/Service/LaunchctlControl.swift
@@ -1,0 +1,105 @@
+/// LaunchctlControl -- thin shared wrapper over `/bin/launchctl`.
+///
+/// The provider runs two launchd user agents: the main provider service
+/// (`LaunchAgent`, label `io.darkbloom.provider`) and the crash-recovery
+/// watchdog (`WatchdogAgent`, label `io.darkbloom.watchdog`). Both need the
+/// same low-level plumbing -- build a `gui/<uid>/<label>` target, spawn
+/// launchctl, capture its output, and resolve the current executable path.
+/// This enum centralises that plumbing so the agents only encode policy
+/// (which plist keys to write, which launchctl errors are benign).
+///
+/// NOTE: `LaunchAgent` deliberately keeps its own bootstrap/bootout/kickstart
+/// implementations (proven on the whole fleet) and only borrows
+/// `currentExecutablePath()` from here; the watchdog, which is new, is built
+/// entirely on these helpers.
+
+import Foundation
+#if canImport(Darwin)
+import Darwin
+#endif
+
+enum LaunchctlControl {
+
+    /// The current user's GUI launchd domain, e.g. `gui/501`.
+    static func guiDomain(uid: uid_t = getuid()) -> String {
+        "gui/\(uid)"
+    }
+
+    /// A launchd service target, e.g. `gui/501/io.darkbloom.watchdog`.
+    static func target(label: String, uid: uid_t = getuid()) -> String {
+        "gui/\(uid)/\(label)"
+    }
+
+    /// The result of running launchctl: exit status plus captured streams.
+    /// `status == -1` means the process could not be spawned at all.
+    struct Output: Sendable {
+        let status: Int32
+        let stdout: String
+        let stderr: String
+
+        var succeeded: Bool { status == 0 }
+    }
+
+    /// Run `/bin/launchctl <arguments>`, capturing stdout (optional) and stderr.
+    ///
+    /// Reads the pipes *before* `waitUntilExit()` so a large `launchctl print`
+    /// dump can't deadlock by filling the pipe buffer while we wait.
+    @discardableResult
+    static func run(_ arguments: [String], captureStdout: Bool = false) -> Output {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/launchctl")
+        process.arguments = arguments
+
+        let outPipe = captureStdout ? Pipe() : nil
+        let errPipe = Pipe()
+        process.standardOutput = outPipe ?? FileHandle.nullDevice
+        process.standardError = errPipe
+        process.standardInput = FileHandle.nullDevice
+
+        do {
+            try process.run()
+        } catch {
+            return Output(status: -1, stdout: "", stderr: "could not run launchctl: \(error.localizedDescription)")
+        }
+
+        let outData = outPipe?.fileHandleForReading.readDataToEndOfFile() ?? Data()
+        let errData = errPipe.fileHandleForReading.readDataToEndOfFile()
+        process.waitUntilExit()
+
+        return Output(
+            status: process.terminationStatus,
+            stdout: String(data: outData, encoding: .utf8) ?? "",
+            stderr: String(data: errData, encoding: .utf8) ?? ""
+        )
+    }
+
+    /// Whether `launchctl print <target>` exits 0 — i.e. the job is registered
+    /// (loaded) with launchd, whether or not it is currently running.
+    static func printSucceeds(label: String, uid: uid_t = getuid()) -> Bool {
+        run(["print", target(label: label, uid: uid)]).succeeded
+    }
+
+    /// The full `launchctl print <target>` output (and exit status) for liveness
+    /// parsing. Output is empty when the job is not loaded (non-zero status).
+    static func printOutput(label: String, uid: uid_t = getuid()) -> Output {
+        run(["print", target(label: label, uid: uid)], captureStdout: true)
+    }
+
+    /// Resolve the path of the running executable. Falls back to the canonical
+    /// install location (`~/.darkbloom/bin/darkbloom`) if introspection fails so
+    /// a plist we write always points somewhere plausible.
+    static func currentExecutablePath() -> String {
+        var buffer = [CChar](repeating: 0, count: Int(MAXPATHLEN))
+        var size = UInt32(MAXPATHLEN)
+        if _NSGetExecutablePath(&buffer, &size) == 0 {
+            if let resolved = realpath(buffer, nil) {
+                defer { free(resolved) }
+                return String(cString: resolved)
+            }
+            return String(cString: buffer)
+        }
+        return FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".darkbloom/bin/darkbloom")
+            .path
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Service/LaunchctlControl.swift
+++ b/provider-swift/Sources/ProviderCore/Service/LaunchctlControl.swift
@@ -19,10 +19,11 @@ enum LaunchctlControl {
         var succeeded: Bool { status == 0 }
     }
 
-    /// Run launchctl, capturing at most one stream. Capturing only one keeps the
-    /// single drained pipe from deadlocking against an unread one on large output.
+    /// Run launchctl, capturing at most one stream (enforced): draining two
+    /// pipes sequentially can deadlock once the unread one fills.
     @discardableResult
     static func run(_ arguments: [String], captureStdout: Bool = false, captureStderr: Bool = false) -> Output {
+        precondition(!(captureStdout && captureStderr), "capture at most one stream")
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/bin/launchctl")
         process.arguments = arguments

--- a/provider-swift/Sources/ProviderCore/Service/LaunchctlControl.swift
+++ b/provider-swift/Sources/ProviderCore/Service/LaunchctlControl.swift
@@ -1,17 +1,6 @@
-/// LaunchctlControl -- thin shared wrapper over `/bin/launchctl`.
-///
-/// The provider runs two launchd user agents: the main provider service
-/// (`LaunchAgent`, label `io.darkbloom.provider`) and the crash-recovery
-/// watchdog (`WatchdogAgent`, label `io.darkbloom.watchdog`). Both need the
-/// same low-level plumbing -- build a `gui/<uid>/<label>` target, spawn
-/// launchctl, capture its output, and resolve the current executable path.
-/// This enum centralises that plumbing so the agents only encode policy
-/// (which plist keys to write, which launchctl errors are benign).
-///
-/// NOTE: `LaunchAgent` deliberately keeps its own bootstrap/bootout/kickstart
-/// implementations (proven on the whole fleet) and only borrows
-/// `currentExecutablePath()` from here; the watchdog, which is new, is built
-/// entirely on these helpers.
+/// Shared `/bin/launchctl` plumbing for the provider's launchd agents
+/// (`LaunchAgent`, `WatchdogAgent`) and the watchdog probe: target strings,
+/// process spawn + output capture, and executable-path resolution.
 
 import Foundation
 #if canImport(Darwin)
@@ -20,40 +9,27 @@ import Darwin
 
 enum LaunchctlControl {
 
-    /// The current user's GUI launchd domain, e.g. `gui/501`.
-    static func guiDomain(uid: uid_t = getuid()) -> String {
-        "gui/\(uid)"
-    }
+    static func guiDomain(uid: uid_t = getuid()) -> String { "gui/\(uid)" }
+    static func target(label: String, uid: uid_t = getuid()) -> String { "gui/\(uid)/\(label)" }
 
-    /// A launchd service target, e.g. `gui/501/io.darkbloom.watchdog`.
-    static func target(label: String, uid: uid_t = getuid()) -> String {
-        "gui/\(uid)/\(label)"
-    }
-
-    /// The result of running launchctl: exit status plus captured streams.
-    /// `status == -1` means the process could not be spawned at all.
     struct Output: Sendable {
         let status: Int32
         let stdout: String
         let stderr: String
-
         var succeeded: Bool { status == 0 }
     }
 
-    /// Run `/bin/launchctl <arguments>`, capturing stdout (optional) and stderr.
-    ///
-    /// Reads the pipes *before* `waitUntilExit()` so a large `launchctl print`
-    /// dump can't deadlock by filling the pipe buffer while we wait.
+    /// Run launchctl, capturing at most one stream. Capturing only one keeps the
+    /// single drained pipe from deadlocking against an unread one on large output.
     @discardableResult
-    static func run(_ arguments: [String], captureStdout: Bool = false) -> Output {
+    static func run(_ arguments: [String], captureStdout: Bool = false, captureStderr: Bool = false) -> Output {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/bin/launchctl")
         process.arguments = arguments
-
         let outPipe = captureStdout ? Pipe() : nil
-        let errPipe = Pipe()
+        let errPipe = captureStderr ? Pipe() : nil
         process.standardOutput = outPipe ?? FileHandle.nullDevice
-        process.standardError = errPipe
+        process.standardError = errPipe ?? FileHandle.nullDevice
         process.standardInput = FileHandle.nullDevice
 
         do {
@@ -61,11 +37,9 @@ enum LaunchctlControl {
         } catch {
             return Output(status: -1, stdout: "", stderr: "could not run launchctl: \(error.localizedDescription)")
         }
-
         let outData = outPipe?.fileHandleForReading.readDataToEndOfFile() ?? Data()
-        let errData = errPipe.fileHandleForReading.readDataToEndOfFile()
+        let errData = errPipe?.fileHandleForReading.readDataToEndOfFile() ?? Data()
         process.waitUntilExit()
-
         return Output(
             status: process.terminationStatus,
             stdout: String(data: outData, encoding: .utf8) ?? "",
@@ -73,21 +47,17 @@ enum LaunchctlControl {
         )
     }
 
-    /// Whether `launchctl print <target>` exits 0 — i.e. the job is registered
-    /// (loaded) with launchd, whether or not it is currently running.
+    /// `launchctl print` exit-0 check — i.e. the job is loaded.
     static func printSucceeds(label: String, uid: uid_t = getuid()) -> Bool {
         run(["print", target(label: label, uid: uid)]).succeeded
     }
 
-    /// The full `launchctl print <target>` output (and exit status) for liveness
-    /// parsing. Output is empty when the job is not loaded (non-zero status).
+    /// Full `launchctl print` output for liveness parsing.
     static func printOutput(label: String, uid: uid_t = getuid()) -> Output {
         run(["print", target(label: label, uid: uid)], captureStdout: true)
     }
 
-    /// Resolve the path of the running executable. Falls back to the canonical
-    /// install location (`~/.darkbloom/bin/darkbloom`) if introspection fails so
-    /// a plist we write always points somewhere plausible.
+    /// Path of the running executable; falls back to the canonical install path.
     static func currentExecutablePath() -> String {
         var buffer = [CChar](repeating: 0, count: Int(MAXPATHLEN))
         var size = UInt32(MAXPATHLEN)
@@ -99,7 +69,6 @@ enum LaunchctlControl {
             return String(cString: buffer)
         }
         return FileManager.default.homeDirectoryForCurrentUser
-            .appendingPathComponent(".darkbloom/bin/darkbloom")
-            .path
+            .appendingPathComponent(".darkbloom/bin/darkbloom").path
     }
 }

--- a/provider-swift/Sources/ProviderCore/Service/WatchdogAgent.swift
+++ b/provider-swift/Sources/ProviderCore/Service/WatchdogAgent.swift
@@ -1,0 +1,186 @@
+/// WatchdogAgent -- the crash-recovery watchdog's launchd user agent.
+///
+/// A second, deliberately tiny launchd agent (`io.darkbloom.watchdog`) separate
+/// from the provider service (`LaunchAgent`, `io.darkbloom.provider`). It runs
+/// `darkbloom watchdog` once a minute (`StartInterval`); each run is a quick
+/// check-and-exit (see `WatchdogPolicy`). Running as a periodic one-shot rather
+/// than a long-lived daemon is intentional: if a tick wedges or crashes, launchd
+/// simply runs the next one — the watchdog can't itself get stuck.
+///
+/// Its lifecycle mirrors the provider agent exactly, so the two arm and disarm
+/// together:
+///   - `darkbloom start`     → install + load both.
+///   - `darkbloom stop`      → `bootout` both (plists stay on disk; a reboot
+///                             reloads them via RunAtLoad).
+///   - `darkbloom stop -u`   → `bootout` + delete both plists.
+///
+/// `KeepAlive = false` because relaunch cadence is owned by `StartInterval`, not
+/// by exit status; `RunAtLoad = true` so it begins guarding immediately on load
+/// (and again at login after a reboot); `ProcessType = Background` because it is
+/// a low-priority maintenance task, never on the inference hot path.
+
+import Foundation
+#if canImport(Darwin)
+import Darwin
+#endif
+
+public enum WatchdogAgent: Sendable {
+
+    public static let label = "io.darkbloom.watchdog"
+
+    /// How often launchd runs the watchdog one-shot, in seconds.
+    public static let checkIntervalSeconds = 60
+
+    // MARK: - Paths
+
+    /// `~/Library/LaunchAgents/io.darkbloom.watchdog.plist`.
+    public static func plistPath() -> URL {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/LaunchAgents")
+            .appendingPathComponent("\(label).plist")
+    }
+
+    /// `~/.darkbloom/watchdog.log` — kept separate from `provider.log` so the
+    /// recovery audit trail isn't tangled with serving output.
+    public static func logPath() -> URL {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".darkbloom/watchdog.log")
+    }
+
+    // MARK: - Queries
+
+    public static func isInstalled() -> Bool {
+        FileManager.default.fileExists(atPath: plistPath().path)
+    }
+
+    public static func isLoaded() -> Bool {
+        LaunchctlControl.printSucceeds(label: label)
+    }
+
+    // MARK: - Install & Start
+
+    /// Write the plist and (re)load the watchdog. Idempotent: if already loaded
+    /// it is booted out first so plist changes are picked up.
+    public static func installAndStart() throws {
+        let binaryPath = LaunchctlControl.currentExecutablePath()
+
+        if isLoaded() {
+            try bootout()
+            Thread.sleep(forTimeInterval: 0.2)
+        }
+
+        try writePlist(binaryPath: binaryPath)
+        try loadService()
+    }
+
+    // MARK: - Stop & Uninstall
+
+    /// Unload the watchdog (no-op if not loaded). Leaves the plist on disk.
+    public static func stop() throws {
+        if isLoaded() {
+            try bootout()
+        }
+    }
+
+    /// Unload and delete the plist.
+    public static func uninstall() throws {
+        try stop()
+        let path = plistPath()
+        if FileManager.default.fileExists(atPath: path.path) {
+            try FileManager.default.removeItem(at: path)
+        }
+    }
+
+    // MARK: - Plist
+
+    private static func writePlist(binaryPath: String) throws {
+        let plist = plistPath()
+        try FileManager.default.createDirectory(
+            at: plist.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        let plistDict = makeWatchdogPlist(
+            label: label,
+            programArguments: [binaryPath, "watchdog"],
+            logPath: logPath().path,
+            intervalSeconds: checkIntervalSeconds
+        )
+        let data = try PropertyListSerialization.data(
+            fromPropertyList: plistDict,
+            format: .xml,
+            options: 0
+        )
+        try data.write(to: plist, options: .atomic)
+    }
+
+    /// Build the watchdog plist dictionary. Pure (no I/O) so its shape is
+    /// unit-testable.
+    static func makeWatchdogPlist(
+        label: String,
+        programArguments: [String],
+        logPath: String,
+        intervalSeconds: Int
+    ) -> [String: Any] {
+        [
+            "Label": label,
+            "ProgramArguments": programArguments,
+            "StartInterval": intervalSeconds,
+            "RunAtLoad": true,
+            // Cadence is owned by StartInterval; do not relaunch on exit.
+            "KeepAlive": false,
+            "StandardOutPath": logPath,
+            "StandardErrorPath": logPath,
+            "ProcessType": "Background",
+        ]
+    }
+
+    // MARK: - launchctl
+
+    private static func loadService() throws {
+        let bootstrap = LaunchctlControl.run(
+            ["bootstrap", LaunchctlControl.guiDomain(), plistPath().path]
+        )
+        if !bootstrap.succeeded {
+            // Error 37 = "already loaded" — benign.
+            if !bootstrap.stderr.contains("37:") && !bootstrap.stderr.contains("already loaded") {
+                throw WatchdogAgentError.bootstrapFailed(bootstrap.stderr.trimmingCharacters(in: .whitespacesAndNewlines))
+            }
+        }
+
+        // RunAtLoad starts the first tick on bootstrap, but kickstart is
+        // harmless and makes a freshly-loaded watchdog run immediately.
+        let kickstart = LaunchctlControl.run(["kickstart", LaunchctlControl.target(label: label)])
+        if !kickstart.succeeded {
+            throw WatchdogAgentError.kickstartFailed(kickstart.stderr.trimmingCharacters(in: .whitespacesAndNewlines))
+        }
+    }
+
+    private static func bootout() throws {
+        let result = LaunchctlControl.run(["bootout", LaunchctlControl.target(label: label)])
+        if !result.succeeded {
+            // Error 3 = "could not find service" — already unloaded, benign.
+            if !result.stderr.contains("3:") && !result.stderr.contains("could not find service") {
+                throw WatchdogAgentError.bootoutFailed(result.stderr.trimmingCharacters(in: .whitespacesAndNewlines))
+            }
+        }
+    }
+}
+
+// MARK: - Errors
+
+public enum WatchdogAgentError: Error, CustomStringConvertible, Sendable {
+    case bootstrapFailed(String)
+    case bootoutFailed(String)
+    case kickstartFailed(String)
+
+    public var description: String {
+        switch self {
+        case .bootstrapFailed(let detail):
+            return "watchdog launchctl bootstrap failed: \(detail)"
+        case .bootoutFailed(let detail):
+            return "watchdog launchctl bootout failed: \(detail)"
+        case .kickstartFailed(let detail):
+            return "watchdog launchctl kickstart failed: \(detail)"
+        }
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Service/WatchdogAgent.swift
+++ b/provider-swift/Sources/ProviderCore/Service/WatchdogAgent.swift
@@ -1,53 +1,27 @@
-/// WatchdogAgent -- the crash-recovery watchdog's launchd user agent.
-///
-/// A second, deliberately tiny launchd agent (`io.darkbloom.watchdog`) separate
-/// from the provider service (`LaunchAgent`, `io.darkbloom.provider`). It runs
-/// `darkbloom watchdog` once a minute (`StartInterval`); each run is a quick
-/// check-and-exit (see `WatchdogPolicy`). Running as a periodic one-shot rather
-/// than a long-lived daemon is intentional: if a tick wedges or crashes, launchd
-/// simply runs the next one — the watchdog can't itself get stuck.
-///
-/// Its lifecycle mirrors the provider agent exactly, so the two arm and disarm
-/// together:
-///   - `darkbloom start`     → install + load both.
-///   - `darkbloom stop`      → `bootout` both (plists stay on disk; a reboot
-///                             reloads them via RunAtLoad).
-///   - `darkbloom stop -u`   → `bootout` + delete both plists.
-///
-/// `KeepAlive = false` because relaunch cadence is owned by `StartInterval`, not
-/// by exit status; `RunAtLoad = true` so it begins guarding immediately on load
-/// (and again at login after a reboot); `ProcessType = Background` because it is
-/// a low-priority maintenance task, never on the inference hot path.
+/// The crash-recovery watchdog's launchd agent (`io.darkbloom.watchdog`),
+/// separate from the provider service. Runs `darkbloom watchdog` once a minute
+/// (`StartInterval`) as a check-and-exit one-shot, so a wedged tick can't stall
+/// recovery. Lifecycle mirrors the provider agent: `start` installs+loads it,
+/// `stop` bootouts it (plist stays for reboot), `stop --uninstall` deletes it.
 
 import Foundation
-#if canImport(Darwin)
-import Darwin
-#endif
 
 public enum WatchdogAgent: Sendable {
 
     public static let label = "io.darkbloom.watchdog"
-
-    /// How often launchd runs the watchdog one-shot, in seconds.
     public static let checkIntervalSeconds = 60
 
-    // MARK: - Paths
-
-    /// `~/Library/LaunchAgents/io.darkbloom.watchdog.plist`.
     public static func plistPath() -> URL {
         FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent("Library/LaunchAgents")
             .appendingPathComponent("\(label).plist")
     }
 
-    /// `~/.darkbloom/watchdog.log` — kept separate from `provider.log` so the
-    /// recovery audit trail isn't tangled with serving output.
+    /// `~/.darkbloom/watchdog.log` — kept separate from provider.log.
     public static func logPath() -> URL {
         FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent(".darkbloom/watchdog.log")
     }
-
-    // MARK: - Queries
 
     public static func isInstalled() -> Bool {
         FileManager.default.fileExists(atPath: plistPath().path)
@@ -57,29 +31,19 @@ public enum WatchdogAgent: Sendable {
         LaunchctlControl.printSucceeds(label: label)
     }
 
-    // MARK: - Install & Start
-
-    /// Write the plist and (re)load the watchdog. Idempotent: if already loaded
-    /// it is booted out first so plist changes are picked up.
+    /// Write the plist and (re)load it; idempotent.
     public static func installAndStart() throws {
-        let binaryPath = LaunchctlControl.currentExecutablePath()
-
         if isLoaded() {
             try bootout()
             Thread.sleep(forTimeInterval: 0.2)
         }
-
-        try writePlist(binaryPath: binaryPath)
+        try writePlist(binaryPath: LaunchctlControl.currentExecutablePath())
         try loadService()
     }
 
-    // MARK: - Stop & Uninstall
-
-    /// Unload the watchdog (no-op if not loaded). Leaves the plist on disk.
+    /// Unload (no-op if not loaded); leaves the plist on disk.
     public static func stop() throws {
-        if isLoaded() {
-            try bootout()
-        }
+        if isLoaded() { try bootout() }
     }
 
     /// Unload and delete the plist.
@@ -91,42 +55,27 @@ public enum WatchdogAgent: Sendable {
         }
     }
 
-    // MARK: - Plist
-
     private static func writePlist(binaryPath: String) throws {
         let plist = plistPath()
-        try FileManager.default.createDirectory(
-            at: plist.deletingLastPathComponent(),
-            withIntermediateDirectories: true
-        )
-        let plistDict = makeWatchdogPlist(
+        try FileManager.default.createDirectory(at: plist.deletingLastPathComponent(), withIntermediateDirectories: true)
+        let dict = makeWatchdogPlist(
             label: label,
             programArguments: [binaryPath, "watchdog"],
             logPath: logPath().path,
             intervalSeconds: checkIntervalSeconds
         )
-        let data = try PropertyListSerialization.data(
-            fromPropertyList: plistDict,
-            format: .xml,
-            options: 0
-        )
+        let data = try PropertyListSerialization.data(fromPropertyList: dict, format: .xml, options: 0)
         try data.write(to: plist, options: .atomic)
     }
 
-    /// Build the watchdog plist dictionary. Pure (no I/O) so its shape is
-    /// unit-testable.
-    static func makeWatchdogPlist(
-        label: String,
-        programArguments: [String],
-        logPath: String,
-        intervalSeconds: Int
-    ) -> [String: Any] {
+    /// Pure plist builder (testable). KeepAlive=false (cadence is StartInterval's
+    /// job); RunAtLoad=true (guard immediately + at login); Background priority.
+    static func makeWatchdogPlist(label: String, programArguments: [String], logPath: String, intervalSeconds: Int) -> [String: Any] {
         [
             "Label": label,
             "ProgramArguments": programArguments,
             "StartInterval": intervalSeconds,
             "RunAtLoad": true,
-            // Cadence is owned by StartInterval; do not relaunch on exit.
             "KeepAlive": false,
             "StandardOutPath": logPath,
             "StandardErrorPath": logPath,
@@ -134,39 +83,26 @@ public enum WatchdogAgent: Sendable {
         ]
     }
 
-    // MARK: - launchctl
-
     private static func loadService() throws {
-        let bootstrap = LaunchctlControl.run(
-            ["bootstrap", LaunchctlControl.guiDomain(), plistPath().path]
-        )
-        if !bootstrap.succeeded {
-            // Error 37 = "already loaded" — benign.
-            if !bootstrap.stderr.contains("37:") && !bootstrap.stderr.contains("already loaded") {
-                throw WatchdogAgentError.bootstrapFailed(bootstrap.stderr.trimmingCharacters(in: .whitespacesAndNewlines))
-            }
+        let bootstrap = LaunchctlControl.run(["bootstrap", LaunchctlControl.guiDomain(), plistPath().path], captureStderr: true)
+        if !bootstrap.succeeded, !bootstrap.stderr.contains("37:"), !bootstrap.stderr.contains("already loaded") {
+            throw WatchdogAgentError.bootstrapFailed(bootstrap.stderr.trimmingCharacters(in: .whitespacesAndNewlines))
         }
-
-        // RunAtLoad starts the first tick on bootstrap, but kickstart is
-        // harmless and makes a freshly-loaded watchdog run immediately.
-        let kickstart = LaunchctlControl.run(["kickstart", LaunchctlControl.target(label: label)])
+        // RunAtLoad already started it; this kickstart is belt-and-suspenders.
+        let kickstart = LaunchctlControl.run(["kickstart", LaunchctlControl.target(label: label)], captureStderr: true)
         if !kickstart.succeeded {
             throw WatchdogAgentError.kickstartFailed(kickstart.stderr.trimmingCharacters(in: .whitespacesAndNewlines))
         }
     }
 
     private static func bootout() throws {
-        let result = LaunchctlControl.run(["bootout", LaunchctlControl.target(label: label)])
-        if !result.succeeded {
-            // Error 3 = "could not find service" — already unloaded, benign.
-            if !result.stderr.contains("3:") && !result.stderr.contains("could not find service") {
-                throw WatchdogAgentError.bootoutFailed(result.stderr.trimmingCharacters(in: .whitespacesAndNewlines))
-            }
+        let result = LaunchctlControl.run(["bootout", LaunchctlControl.target(label: label)], captureStderr: true)
+        // Error 3 = "could not find service" — already unloaded, benign.
+        if !result.succeeded, !result.stderr.contains("3:"), !result.stderr.contains("could not find service") {
+            throw WatchdogAgentError.bootoutFailed(result.stderr.trimmingCharacters(in: .whitespacesAndNewlines))
         }
     }
 }
-
-// MARK: - Errors
 
 public enum WatchdogAgentError: Error, CustomStringConvertible, Sendable {
     case bootstrapFailed(String)
@@ -175,12 +111,9 @@ public enum WatchdogAgentError: Error, CustomStringConvertible, Sendable {
 
     public var description: String {
         switch self {
-        case .bootstrapFailed(let detail):
-            return "watchdog launchctl bootstrap failed: \(detail)"
-        case .bootoutFailed(let detail):
-            return "watchdog launchctl bootout failed: \(detail)"
-        case .kickstartFailed(let detail):
-            return "watchdog launchctl kickstart failed: \(detail)"
+        case .bootstrapFailed(let d): return "watchdog launchctl bootstrap failed: \(d)"
+        case .bootoutFailed(let d): return "watchdog launchctl bootout failed: \(d)"
+        case .kickstartFailed(let d): return "watchdog launchctl kickstart failed: \(d)"
         }
     }
 }

--- a/provider-swift/Sources/ProviderCore/Service/WatchdogAgent.swift
+++ b/provider-swift/Sources/ProviderCore/Service/WatchdogAgent.swift
@@ -85,6 +85,7 @@ public enum WatchdogAgent: Sendable {
 
     private static func loadService() throws {
         let bootstrap = LaunchctlControl.run(["bootstrap", LaunchctlControl.guiDomain(), plistPath().path], captureStderr: true)
+        // Error 37 = "already loaded" — benign.
         if !bootstrap.succeeded, !bootstrap.stderr.contains("37:"), !bootstrap.stderr.contains("already loaded") {
             throw WatchdogAgentError.bootstrapFailed(bootstrap.stderr.trimmingCharacters(in: .whitespacesAndNewlines))
         }

--- a/provider-swift/Sources/ProviderCore/Service/WatchdogDecision.swift
+++ b/provider-swift/Sources/ProviderCore/Service/WatchdogDecision.swift
@@ -1,0 +1,116 @@
+/// WatchdogDecision -- the pure crash-recovery policy.
+///
+/// The watchdog (`darkbloom watchdog`, run every minute by `WatchdogAgent`)
+/// answers one question each tick: *should I restart the provider right now?*
+/// All of the I/O — querying launchd, reading the timer state, restarting —
+/// lives in the command; this enum encodes the decision itself so it is
+/// deterministic and exhaustively testable.
+///
+/// The policy distinguishes a **crash** from an **intentional stop** using the
+/// launchd job state, which is exact (no guessing):
+///
+///   - The provider plist sets `KeepAlive = false`, so when the daemon crashes
+///     launchd leaves the job *loaded but not running*. `providerLoaded == true
+///     && providerRunning == false` is therefore the precise crash signal.
+///   - `darkbloom stop` runs `launchctl bootout`, which *unloads* the job, and
+///     `darkbloom stop --uninstall` additionally deletes the plist. Either way
+///     `providerLoaded == false` — the user disabled it, so we never restart.
+///   - `auto_restart = false` in the provider config is an explicit opt-out
+///     that wins over everything (`autoRestartEnabled == false`).
+///
+/// A crashed provider is not restarted immediately: the caller arms a grace
+/// window on first observation and only restarts once the daemon has stayed
+/// down for `graceSeconds` (default 5 minutes). The delay sidesteps the
+/// self-updater (its kill+relaunch completes in seconds) and prevents a
+/// genuinely broken binary from tight-looping.
+
+import Foundation
+
+public enum WatchdogDecision: Equatable, Sendable {
+    /// Auto-restart is disabled by config — clear any pending timer, do nothing.
+    case disabled
+    /// The provider isn't managed by launchd right now (stopped via `bootout`,
+    /// or uninstalled). Not a crash — clear any timer, do nothing.
+    case notManaged
+    /// The provider is running normally — clear any pending timer.
+    case healthy
+    /// First tick that observed the provider down — start the grace window
+    /// (caller persists `downSince = now`).
+    case startGrace
+    /// The provider is down but still inside the grace window; `remaining`
+    /// seconds until it becomes eligible for restart.
+    case waiting(remaining: Double)
+    /// The provider has been down for at least `graceSeconds` — restart it.
+    case restart
+}
+
+public enum WatchdogPolicy {
+
+    /// Default grace period before a crashed provider is restarted: 5 minutes.
+    public static let defaultGraceSeconds: Double = 300
+
+    /// Decide what the watchdog should do this tick.
+    ///
+    /// - Parameters:
+    ///   - autoRestartEnabled: provider config `auto_restart` (false = opt-out).
+    ///   - providerLoaded: launchd has the provider job registered (loaded).
+    ///   - providerRunning: the provider process is actually alive.
+    ///   - downSince: epoch seconds the watchdog first observed the provider
+    ///     down, or nil if it wasn't down on the previous tick.
+    ///   - now: current epoch seconds.
+    ///   - graceSeconds: how long the provider must stay down before a restart.
+    public static func decide(
+        autoRestartEnabled: Bool,
+        providerLoaded: Bool,
+        providerRunning: Bool,
+        downSince: Double?,
+        now: Double,
+        graceSeconds: Double = defaultGraceSeconds
+    ) -> WatchdogDecision {
+        guard autoRestartEnabled else { return .disabled }
+        guard providerLoaded else { return .notManaged }
+        if providerRunning { return .healthy }
+
+        guard let downSince else { return .startGrace }
+
+        let elapsed = now - downSince
+        if elapsed >= graceSeconds { return .restart }
+        return .waiting(remaining: max(0, graceSeconds - elapsed))
+    }
+
+    /// Discard a `downSince` that predates the current boot. A timer armed in a
+    /// previous uptime is meaningless after a reboot — both the provider and the
+    /// watchdog reload via RunAtLoad at login, and we want a *fresh* grace window
+    /// per outage, not an instant restart driven by a days-old timestamp. If
+    /// `bootTime` is unavailable (nil), the value is passed through unchanged.
+    public static func effectiveDownSince(_ downSince: Double?, bootTime: Double?) -> Double? {
+        guard let downSince else { return nil }
+        if let bootTime, downSince < bootTime { return nil }
+        return downSince
+    }
+
+    /// The timer state to persist after acting on `decision`, or nil when no
+    /// write is needed. Pure, so the watchdog's persistence logic is unit-tested
+    /// independently of launchd I/O.
+    public static func nextState(
+        for decision: WatchdogDecision,
+        current: WatchdogState,
+        now: Double
+    ) -> WatchdogState? {
+        switch decision {
+        case .restart:
+            // Window consumed; record the attempt and re-arm fresh next tick.
+            return WatchdogState(downSince: nil, lastRestartAt: now)
+        case .startGrace:
+            return WatchdogState(downSince: now, lastRestartAt: current.lastRestartAt)
+        case .waiting:
+            return nil // leave the armed window untouched
+        case .disabled, .notManaged, .healthy:
+            // Clear an armed window, but skip the write when nothing changes so
+            // quiet ticks don't churn the file.
+            return current.downSince == nil
+                ? nil
+                : WatchdogState(downSince: nil, lastRestartAt: current.lastRestartAt)
+        }
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Service/WatchdogDecision.swift
+++ b/provider-swift/Sources/ProviderCore/Service/WatchdogDecision.swift
@@ -1,64 +1,28 @@
-/// WatchdogDecision -- the pure crash-recovery policy.
+/// The crash-recovery policy (pure, no I/O).
 ///
-/// The watchdog (`darkbloom watchdog`, run every minute by `WatchdogAgent`)
-/// answers one question each tick: *should I restart the provider right now?*
-/// All of the I/O — querying launchd, reading the timer state, restarting —
-/// lives in the command; this enum encodes the decision itself so it is
-/// deterministic and exhaustively testable.
-///
-/// The policy distinguishes a **crash** from an **intentional stop** using the
-/// launchd job state, which is exact (no guessing):
-///
-///   - The provider plist sets `KeepAlive = false`, so when the daemon crashes
-///     launchd leaves the job *loaded but not running*. `providerLoaded == true
-///     && providerRunning == false` is therefore the precise crash signal.
-///   - `darkbloom stop` runs `launchctl bootout`, which *unloads* the job, and
-///     `darkbloom stop --uninstall` additionally deletes the plist. Either way
-///     `providerLoaded == false` — the user disabled it, so we never restart.
-///   - `auto_restart = false` in the provider config is an explicit opt-out
-///     that wins over everything (`autoRestartEnabled == false`).
-///
-/// A crashed provider is not restarted immediately: the caller arms a grace
-/// window on first observation and only restarts once the daemon has stayed
-/// down for `graceSeconds` (default 5 minutes). The delay sidesteps the
-/// self-updater (its kill+relaunch completes in seconds) and prevents a
-/// genuinely broken binary from tight-looping.
+/// A crash = the provider's launchd job is loaded but not running (`KeepAlive=false`
+/// leaves a crashed job loaded). `darkbloom stop` unloads it (`bootout`), so
+/// `providerLoaded == false` means the user disabled it — never restarted.
+/// `auto_restart = false` opts out. A crashed provider is restarted only after it
+/// stays down `graceSeconds` (default 5 min): long enough to clear the
+/// self-updater's kill+relaunch and to avoid tight crash-loops.
 
 import Foundation
 
 public enum WatchdogDecision: Equatable, Sendable {
-    /// Auto-restart is disabled by config — clear any pending timer, do nothing.
-    case disabled
-    /// The provider isn't managed by launchd right now (stopped via `bootout`,
-    /// or uninstalled). Not a crash — clear any timer, do nothing.
-    case notManaged
-    /// The provider is running normally — clear any pending timer.
-    case healthy
-    /// First tick that observed the provider down — start the grace window
-    /// (caller persists `downSince = now`).
-    case startGrace
-    /// The provider is down but still inside the grace window; `remaining`
-    /// seconds until it becomes eligible for restart.
-    case waiting(remaining: Double)
-    /// The provider has been down for at least `graceSeconds` — restart it.
-    case restart
+    case disabled                    // auto_restart = false
+    case notManaged                  // unloaded: stopped/uninstalled, not a crash
+    case healthy                     // running
+    case startGrace                  // first tick down: arm the window
+    case waiting(remaining: Double)  // down, inside the grace window
+    case restart                     // down >= grace
 }
 
 public enum WatchdogPolicy {
 
-    /// Default grace period before a crashed provider is restarted: 5 minutes.
+    /// Grace before a crashed provider is restarted: 5 minutes.
     public static let defaultGraceSeconds: Double = 300
 
-    /// Decide what the watchdog should do this tick.
-    ///
-    /// - Parameters:
-    ///   - autoRestartEnabled: provider config `auto_restart` (false = opt-out).
-    ///   - providerLoaded: launchd has the provider job registered (loaded).
-    ///   - providerRunning: the provider process is actually alive.
-    ///   - downSince: epoch seconds the watchdog first observed the provider
-    ///     down, or nil if it wasn't down on the previous tick.
-    ///   - now: current epoch seconds.
-    ///   - graceSeconds: how long the provider must stay down before a restart.
     public static func decide(
         autoRestartEnabled: Bool,
         providerLoaded: Bool,
@@ -70,47 +34,31 @@ public enum WatchdogPolicy {
         guard autoRestartEnabled else { return .disabled }
         guard providerLoaded else { return .notManaged }
         if providerRunning { return .healthy }
-
         guard let downSince else { return .startGrace }
-
         let elapsed = now - downSince
-        if elapsed >= graceSeconds { return .restart }
-        return .waiting(remaining: max(0, graceSeconds - elapsed))
+        return elapsed >= graceSeconds ? .restart : .waiting(remaining: max(0, graceSeconds - elapsed))
     }
 
-    /// Discard a `downSince` that predates the current boot. A timer armed in a
-    /// previous uptime is meaningless after a reboot — both the provider and the
-    /// watchdog reload via RunAtLoad at login, and we want a *fresh* grace window
-    /// per outage, not an instant restart driven by a days-old timestamp. If
-    /// `bootTime` is unavailable (nil), the value is passed through unchanged.
+    /// Drop a `downSince` from before `bootTime` so a timer armed in a previous
+    /// uptime can't trigger an instant restart after a reboot. Passes through
+    /// when `bootTime` is nil.
     public static func effectiveDownSince(_ downSince: Double?, bootTime: Double?) -> Double? {
         guard let downSince else { return nil }
         if let bootTime, downSince < bootTime { return nil }
         return downSince
     }
 
-    /// The timer state to persist after acting on `decision`, or nil when no
-    /// write is needed. Pure, so the watchdog's persistence logic is unit-tested
-    /// independently of launchd I/O.
-    public static func nextState(
-        for decision: WatchdogDecision,
-        current: WatchdogState,
-        now: Double
-    ) -> WatchdogState? {
+    /// Timer state to persist after `decision`, or nil when no write is needed.
+    public static func nextState(for decision: WatchdogDecision, current: WatchdogState, now: Double) -> WatchdogState? {
         switch decision {
         case .restart:
-            // Window consumed; record the attempt and re-arm fresh next tick.
             return WatchdogState(downSince: nil, lastRestartAt: now)
         case .startGrace:
             return WatchdogState(downSince: now, lastRestartAt: current.lastRestartAt)
         case .waiting:
-            return nil // leave the armed window untouched
+            return nil
         case .disabled, .notManaged, .healthy:
-            // Clear an armed window, but skip the write when nothing changes so
-            // quiet ticks don't churn the file.
-            return current.downSince == nil
-                ? nil
-                : WatchdogState(downSince: nil, lastRestartAt: current.lastRestartAt)
+            return current.downSince == nil ? nil : WatchdogState(downSince: nil, lastRestartAt: current.lastRestartAt)
         }
     }
 }

--- a/provider-swift/Sources/ProviderCore/Service/WatchdogProbe.swift
+++ b/provider-swift/Sources/ProviderCore/Service/WatchdogProbe.swift
@@ -1,0 +1,76 @@
+/// WatchdogProbe -- "is the provider loaded / up?" liveness for the watchdog.
+///
+/// Reports two facts the watchdog policy needs:
+///   - **loaded**: launchd has the provider job registered. `false` means the
+///     user stopped (`bootout`) or uninstalled it — not a crash.
+///   - **running**: the provider process is actually alive.
+///
+/// Liveness uses two independent signals, OR'd so a transient quirk in one never
+/// causes a false restart of a healthy provider:
+///
+///   1. **launchd (authoritative).** `launchctl print gui/<uid>/<label>` shows a
+///      running `pid`/`state = running` whenever the daemon process exists —
+///      including while it is still loading a model (cold loads take a couple of
+///      minutes) — so a slow-to-serve provider never reads as down. A crashed
+///      provider (KeepAlive=false) is loaded but shows `state = not running`.
+///   2. **daemon state file (backup).** If launchctl parsing ever misses, a
+///      *fresh* `~/.darkbloom/daemon-state.json` whose pid is alive also counts
+///      as running. Freshness matters: a crashed daemon leaves a stale file, so
+///      requiring not-stale avoids being fooled by a recycled pid.
+
+import Foundation
+
+public enum WatchdogProbe {
+
+    /// Combined loaded/running snapshot of the provider.
+    public struct ProviderLiveness: Sendable, Equatable {
+        public let loaded: Bool
+        public let running: Bool
+        public init(loaded: Bool, running: Bool) {
+            self.loaded = loaded
+            self.running = running
+        }
+    }
+
+    /// Probe the provider across all supported labels with a single `launchctl
+    /// print` per label, falling back to the daemon state file for liveness.
+    public static func probeProvider(now: Double = Date().timeIntervalSince1970) -> ProviderLiveness {
+        var loaded = false
+        var running = false
+
+        for label in LaunchAgent.supportedLabels {
+            let result = LaunchctlControl.printOutput(label: label)
+            guard result.succeeded else { continue } // not loaded under this label
+            loaded = true
+            if parseRunning(result.stdout) {
+                running = true
+                break
+            }
+        }
+
+        if !running,
+           let state = DaemonStateFile.read(),
+           !state.isStale(now: now),
+           daemonProcessAlive(pid: state.pid) {
+            running = true
+        }
+
+        return ProviderLiveness(loaded: loaded, running: running)
+    }
+
+    /// Parse `launchctl print` output for a live process. Pure, so it can be
+    /// unit-tested against captured samples across macOS versions.
+    ///
+    /// Matches an explicit `state = running` or a non-zero `pid = N`, and is
+    /// careful NOT to match `state = not running`.
+    static func parseRunning(_ output: String) -> Bool {
+        let lower = output.lowercased()
+        if lower.range(of: #"state\s*=\s*running"#, options: .regularExpression) != nil {
+            return true
+        }
+        if lower.range(of: #"\bpid\s*=\s*[1-9][0-9]*"#, options: .regularExpression) != nil {
+            return true
+        }
+        return false
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Service/WatchdogProbe.swift
+++ b/provider-swift/Sources/ProviderCore/Service/WatchdogProbe.swift
@@ -1,28 +1,16 @@
-/// WatchdogProbe -- "is the provider loaded / up?" liveness for the watchdog.
+/// "Is the provider loaded / up?" for the watchdog.
 ///
-/// Reports two facts the watchdog policy needs:
-///   - **loaded**: launchd has the provider job registered. `false` means the
-///     user stopped (`bootout`) or uninstalled it — not a crash.
-///   - **running**: the provider process is actually alive.
-///
-/// Liveness uses two independent signals, OR'd so a transient quirk in one never
-/// causes a false restart of a healthy provider:
-///
-///   1. **launchd (authoritative).** `launchctl print gui/<uid>/<label>` shows a
-///      running `pid`/`state = running` whenever the daemon process exists —
-///      including while it is still loading a model (cold loads take a couple of
-///      minutes) — so a slow-to-serve provider never reads as down. A crashed
-///      provider (KeepAlive=false) is loaded but shows `state = not running`.
-///   2. **daemon state file (backup).** If launchctl parsing ever misses, a
-///      *fresh* `~/.darkbloom/daemon-state.json` whose pid is alive also counts
-///      as running. Freshness matters: a crashed daemon leaves a stale file, so
-///      requiring not-stale avoids being fooled by a recycled pid.
+/// `loaded` = launchd has the job registered (false ⇒ stopped/uninstalled).
+/// `running` = the process is alive, from `launchctl print` (`state = running`
+/// or a live `pid`), with a *fresh* daemon-state file as a fallback. The
+/// fallback can only ADD liveness, never remove it, so it can't cause a false
+/// restart. launchd reports a live pid even during a slow cold model load, so a
+/// busy provider never reads as down.
 
 import Foundation
 
 public enum WatchdogProbe {
 
-    /// Combined loaded/running snapshot of the provider.
     public struct ProviderLiveness: Sendable, Equatable {
         public let loaded: Bool
         public let running: Bool
@@ -32,45 +20,30 @@ public enum WatchdogProbe {
         }
     }
 
-    /// Probe the provider across all supported labels with a single `launchctl
-    /// print` per label, falling back to the daemon state file for liveness.
     public static func probeProvider(now: Double = Date().timeIntervalSince1970) -> ProviderLiveness {
         var loaded = false
         var running = false
-
         for label in LaunchAgent.supportedLabels {
             let result = LaunchctlControl.printOutput(label: label)
-            guard result.succeeded else { continue } // not loaded under this label
+            guard result.succeeded else { continue }
             loaded = true
-            if parseRunning(result.stdout) {
-                running = true
-                break
-            }
+            if parseRunning(result.stdout) { running = true; break }
         }
-
         if !running,
            let state = DaemonStateFile.read(),
            !state.isStale(now: now),
            daemonProcessAlive(pid: state.pid) {
             running = true
         }
-
         return ProviderLiveness(loaded: loaded, running: running)
     }
 
-    /// Parse `launchctl print` output for a live process. Pure, so it can be
-    /// unit-tested against captured samples across macOS versions.
-    ///
-    /// Matches an explicit `state = running` or a non-zero `pid = N`, and is
-    /// careful NOT to match `state = not running`.
+    /// Parse `launchctl print` for a live process: `state = running` or a
+    /// non-zero `pid` (and not `state = not running`). Pure, for testing.
     static func parseRunning(_ output: String) -> Bool {
         let lower = output.lowercased()
-        if lower.range(of: #"state\s*=\s*running"#, options: .regularExpression) != nil {
-            return true
-        }
-        if lower.range(of: #"\bpid\s*=\s*[1-9][0-9]*"#, options: .regularExpression) != nil {
-            return true
-        }
+        if lower.range(of: #"state\s*=\s*running"#, options: .regularExpression) != nil { return true }
+        if lower.range(of: #"\bpid\s*=\s*[1-9][0-9]*"#, options: .regularExpression) != nil { return true }
         return false
     }
 }

--- a/provider-swift/Sources/ProviderCore/Service/WatchdogState.swift
+++ b/provider-swift/Sources/ProviderCore/Service/WatchdogState.swift
@@ -1,19 +1,13 @@
-/// WatchdogState -- the watchdog's small, private cross-tick memory.
-///
-/// The watchdog runs as a one-shot every minute (launchd `StartInterval`), so
-/// it can't hold the "provider has been down since T" timer in process memory.
-/// It persists that here, at `~/.darkbloom/watchdog-state.json` (override with
-/// `DARKBLOOM_WATCHDOG_STATE` for tests). The watchdog is the sole writer —
-/// launchd never runs two ticks of the same job concurrently — so no locking is
-/// needed.
+/// The watchdog's cross-tick timer, persisted at
+/// `~/.darkbloom/watchdog-state.json` (override `DARKBLOOM_WATCHDOG_STATE`).
+/// The watchdog is the only writer — launchd never overlaps ticks.
 
 import Foundation
 
 public struct WatchdogState: Codable, Equatable, Sendable {
-    /// Epoch seconds the watchdog first saw the provider down in the current
-    /// outage, or nil when the provider is up.
+    /// When the watchdog first saw the current outage, or nil when up.
     public var downSince: Double?
-    /// Epoch seconds of the most recent watchdog-initiated restart (diagnostic).
+    /// When the watchdog last restarted the provider (diagnostic).
     public var lastRestartAt: Double?
 
     public init(downSince: Double? = nil, lastRestartAt: Double? = nil) {
@@ -29,8 +23,6 @@ public struct WatchdogState: Codable, Equatable, Sendable {
 
 public enum WatchdogStateStore {
 
-    /// `~/.darkbloom/watchdog-state.json`, or the `DARKBLOOM_WATCHDOG_STATE`
-    /// override.
     public static func path() -> URL {
         if let override = ProcessInfo.processInfo.environment["DARKBLOOM_WATCHDOG_STATE"], !override.isEmpty {
             return URL(fileURLWithPath: override)
@@ -39,31 +31,27 @@ public enum WatchdogStateStore {
             .appendingPathComponent(".darkbloom/watchdog-state.json")
     }
 
-    /// Read the persisted state. Returns an empty (all-nil) state when the file
-    /// is missing or unreadable — a fresh start, never an error.
+    /// Empty state when the file is missing or unreadable (a fresh start).
     public static func read(from url: URL = WatchdogStateStore.path()) -> WatchdogState {
         guard let data = try? Data(contentsOf: url),
               let state = try? JSONDecoder().decode(WatchdogState.self, from: data)
-        else {
-            return WatchdogState()
-        }
+        else { return WatchdogState() }
         return state
     }
 
-    /// Atomically persist `state`. Best-effort: a failure to write must never
-    /// crash the watchdog (worst case it re-arms the grace window next tick).
-    public static func write(_ state: WatchdogState, to url: URL = WatchdogStateStore.path()) {
+    /// Atomically persist `state`. Returns false on failure so the caller can
+    /// log it: a persistent write failure would otherwise keep the grace window
+    /// from ever advancing, silently disabling recovery.
+    @discardableResult
+    public static func write(_ state: WatchdogState, to url: URL = WatchdogStateStore.path()) -> Bool {
         do {
-            try FileManager.default.createDirectory(
-                at: url.deletingLastPathComponent(),
-                withIntermediateDirectories: true
-            )
+            try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
             let encoder = JSONEncoder()
             encoder.outputFormatting = [.sortedKeys]
-            let data = try encoder.encode(state)
-            try data.write(to: url, options: .atomic)
+            try encoder.encode(state).write(to: url, options: .atomic)
+            return true
         } catch {
-            // Intentionally ignored — see doc comment.
+            return false
         }
     }
 }

--- a/provider-swift/Sources/ProviderCore/Service/WatchdogState.swift
+++ b/provider-swift/Sources/ProviderCore/Service/WatchdogState.swift
@@ -1,0 +1,69 @@
+/// WatchdogState -- the watchdog's small, private cross-tick memory.
+///
+/// The watchdog runs as a one-shot every minute (launchd `StartInterval`), so
+/// it can't hold the "provider has been down since T" timer in process memory.
+/// It persists that here, at `~/.darkbloom/watchdog-state.json` (override with
+/// `DARKBLOOM_WATCHDOG_STATE` for tests). The watchdog is the sole writer —
+/// launchd never runs two ticks of the same job concurrently — so no locking is
+/// needed.
+
+import Foundation
+
+public struct WatchdogState: Codable, Equatable, Sendable {
+    /// Epoch seconds the watchdog first saw the provider down in the current
+    /// outage, or nil when the provider is up.
+    public var downSince: Double?
+    /// Epoch seconds of the most recent watchdog-initiated restart (diagnostic).
+    public var lastRestartAt: Double?
+
+    public init(downSince: Double? = nil, lastRestartAt: Double? = nil) {
+        self.downSince = downSince
+        self.lastRestartAt = lastRestartAt
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case downSince = "down_since"
+        case lastRestartAt = "last_restart_at"
+    }
+}
+
+public enum WatchdogStateStore {
+
+    /// `~/.darkbloom/watchdog-state.json`, or the `DARKBLOOM_WATCHDOG_STATE`
+    /// override.
+    public static func path() -> URL {
+        if let override = ProcessInfo.processInfo.environment["DARKBLOOM_WATCHDOG_STATE"], !override.isEmpty {
+            return URL(fileURLWithPath: override)
+        }
+        return FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".darkbloom/watchdog-state.json")
+    }
+
+    /// Read the persisted state. Returns an empty (all-nil) state when the file
+    /// is missing or unreadable — a fresh start, never an error.
+    public static func read(from url: URL = WatchdogStateStore.path()) -> WatchdogState {
+        guard let data = try? Data(contentsOf: url),
+              let state = try? JSONDecoder().decode(WatchdogState.self, from: data)
+        else {
+            return WatchdogState()
+        }
+        return state
+    }
+
+    /// Atomically persist `state`. Best-effort: a failure to write must never
+    /// crash the watchdog (worst case it re-arms the grace window next tick).
+    public static func write(_ state: WatchdogState, to url: URL = WatchdogStateStore.path()) {
+        do {
+            try FileManager.default.createDirectory(
+                at: url.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = [.sortedKeys]
+            let data = try encoder.encode(state)
+            try data.write(to: url, options: .atomic)
+        } catch {
+            // Intentionally ignored — see doc comment.
+        }
+    }
+}

--- a/provider-swift/Sources/darkbloom/Darkbloom.swift
+++ b/provider-swift/Sources/darkbloom/Darkbloom.swift
@@ -44,6 +44,7 @@ struct Darkbloom: AsyncParsableCommand {
             Logs.self,
             Report.self,
             AutoUpdate.self,
+            Watchdog.self,
         ]
     )
 

--- a/provider-swift/Sources/darkbloom/RestartCommand.swift
+++ b/provider-swift/Sources/darkbloom/RestartCommand.swift
@@ -28,6 +28,14 @@ struct Restart: AsyncParsableCommand {
         } else {
             print("Provider started.")
         }
+
+        // Re-arm crash recovery to match `start`: a manual restart should leave
+        // the watchdog watching (and re-enable it if a prior `stop` disarmed it,
+        // or install it on a provider upgraded from a pre-watchdog build).
+        if Watchdog.autoRestartEnabled(configPath: nil) {
+            try? WatchdogAgent.installAndStart()
+        }
+
         print("  darkbloom status  Check status")
     }
 }

--- a/provider-swift/Sources/darkbloom/RestartCommand.swift
+++ b/provider-swift/Sources/darkbloom/RestartCommand.swift
@@ -29,9 +29,8 @@ struct Restart: AsyncParsableCommand {
             print("Provider started.")
         }
 
-        // Re-arm crash recovery to match `start`: a manual restart should leave
-        // the watchdog watching (and re-enable it if a prior `stop` disarmed it,
-        // or install it on a provider upgraded from a pre-watchdog build).
+        // Re-arm the watchdog (re-enables it after a prior `stop`, or installs it
+        // on a provider upgraded from a pre-watchdog build).
         if Watchdog.autoRestartEnabled(configPath: nil) {
             try? WatchdogAgent.installAndStart()
         }

--- a/provider-swift/Sources/darkbloom/StartCommand.swift
+++ b/provider-swift/Sources/darkbloom/StartCommand.swift
@@ -253,12 +253,9 @@ struct Start: AsyncParsableCommand {
         // setup is itself captured.
         PanicHook.install()
 
-        // Ensure crash recovery is armed for THIS running daemon, however it was
-        // launched — manual `start`, login RunAtLoad, or a background auto-update
-        // relaunch (which restarts the daemon without going through the
-        // interactive installer, so it would otherwise never arm the watchdog).
-        // Idempotent + best-effort: only install when not already loaded, so
-        // ordinary watchdog-driven restarts don't churn it.
+        // Arm crash recovery for the running daemon however it was launched
+        // (manual start, login, or auto-update relaunch). Idempotent (skip when
+        // already loaded → no churn on restarts) + best-effort.
         if config.provider.autoRestart, !WatchdogAgent.isLoaded() {
             try? WatchdogAgent.installAndStart()
         }
@@ -547,10 +544,8 @@ struct Start: AsyncParsableCommand {
             )
         )
 
-        // Arm crash recovery: a separate launchd watchdog (`io.darkbloom.watchdog`)
-        // relaunches the provider ~5 minutes after a crash. A plain `darkbloom
-        // stop` disarms it; `auto_restart = false` in the config opts out.
-        // Best-effort — a watchdog failure must never fail `start`.
+        // Arm the crash-recovery watchdog (relaunches ~5 min after a crash;
+        // `stop` disarms, `auto_restart = false` opts out). Best-effort.
         let autoRestartOn = config.provider.autoRestart
         if autoRestartOn {
             do {

--- a/provider-swift/Sources/darkbloom/StartCommand.swift
+++ b/provider-swift/Sources/darkbloom/StartCommand.swift
@@ -253,6 +253,16 @@ struct Start: AsyncParsableCommand {
         // setup is itself captured.
         PanicHook.install()
 
+        // Ensure crash recovery is armed for THIS running daemon, however it was
+        // launched — manual `start`, login RunAtLoad, or a background auto-update
+        // relaunch (which restarts the daemon without going through the
+        // interactive installer, so it would otherwise never arm the watchdog).
+        // Idempotent + best-effort: only install when not already loaded, so
+        // ordinary watchdog-driven restarts don't churn it.
+        if config.provider.autoRestart, !WatchdogAgent.isLoaded() {
+            try? WatchdogAgent.installAndStart()
+        }
+
         // ----- Telemetry: configure now so reconnect/inference/panic events flow. -----
         TelemetryClient.shared.configure(TelemetryClientConfig(
             coordinatorURL: coordinatorURL,
@@ -537,6 +547,19 @@ struct Start: AsyncParsableCommand {
             )
         )
 
+        // Arm crash recovery: a separate launchd watchdog (`io.darkbloom.watchdog`)
+        // relaunches the provider ~5 minutes after a crash. A plain `darkbloom
+        // stop` disarms it; `auto_restart = false` in the config opts out.
+        // Best-effort — a watchdog failure must never fail `start`.
+        let autoRestartOn = config.provider.autoRestart
+        if autoRestartOn {
+            do {
+                try WatchdogAgent.installAndStart()
+            } catch {
+                printError("note: could not install crash-recovery watchdog: \(error)")
+            }
+        }
+
         let logPath = LaunchAgent.logPath().path
         print("Provider started as background service.")
         print("  Models:  \(selectedModelIDs.count)")
@@ -548,6 +571,9 @@ struct Start: AsyncParsableCommand {
             print("  Local:   \(shownURL) (unified mode — run `darkbloom local` for the API key)")
         }
         print("  Logs:    \(logPath)")
+        if autoRestartOn {
+            print("  Recovery: auto-restart on (relaunches ~5 min after a crash)")
+        }
         print()
         print("  darkbloom stop     Stop the provider")
         print("  darkbloom restart  Restart with the current selection")

--- a/provider-swift/Sources/darkbloom/StatusCommand.swift
+++ b/provider-swift/Sources/darkbloom/StatusCommand.swift
@@ -26,6 +26,7 @@ struct Status: AsyncParsableCommand {
         print("Configured model: \(config.backend.model ?? "auto-select")")
         print("Continuous batching: \(config.backend.continuousBatching ? "enabled" : "disabled")")
         print("Idle timeout: \(config.backend.idleTimeoutMins == 0 ? "disabled" : "\(config.backend.idleTimeoutMins)m")")
+        print("Auto-restart: \(autoRestartStatus(config: config))")
 
         if let hardware = snapshot.hardware {
             print("Hardware: \(hardware.chipName), \(hardware.memoryGb) GB RAM, \(hardware.gpuCores) GPU cores")
@@ -50,6 +51,21 @@ struct Status: AsyncParsableCommand {
         // Live daemon state (from the state file the running daemon writes).
         print("")
         printDaemonStatus()
+    }
+
+    /// One-line summary of crash-recovery state: the config opt-out plus whether
+    /// the launchd watchdog agent is actually armed.
+    private func autoRestartStatus(config: ProviderConfig) -> String {
+        guard config.provider.autoRestart else {
+            return "off (auto_restart = false)"
+        }
+        if WatchdogAgent.isLoaded() {
+            return "on (watchdog active; relaunches ~5 min after a crash)"
+        }
+        if WatchdogAgent.isInstalled() {
+            return "on (watchdog installed but not loaded)"
+        }
+        return "on (watchdog not installed — run `darkbloom start` or `restart` to arm)"
     }
 
     /// Prints the running daemon's live state, including the coordinator's last

--- a/provider-swift/Sources/darkbloom/StopCommand.swift
+++ b/provider-swift/Sources/darkbloom/StopCommand.swift
@@ -13,10 +13,8 @@ struct Stop: AsyncParsableCommand {
     mutating func run() async throws {
         let wasLoaded = LaunchAgent.isLoaded()
 
-        // Disarm crash recovery FIRST so the watchdog can't relaunch the daemon
-        // we're about to stop. Tear it down to match the provider agent: plain
-        // stop unloads it (plist stays for reboot); uninstall deletes the plist.
-        // Best-effort — a watchdog hiccup must never block stopping the provider.
+        // Disarm crash recovery FIRST so the watchdog can't relaunch what we're
+        // stopping (uninstall deletes its plist + state). Best-effort.
         if uninstall {
             try? WatchdogAgent.uninstall()
             try? FileManager.default.removeItem(at: WatchdogStateStore.path())

--- a/provider-swift/Sources/darkbloom/StopCommand.swift
+++ b/provider-swift/Sources/darkbloom/StopCommand.swift
@@ -1,4 +1,5 @@
 import ArgumentParser
+import Foundation
 import ProviderCore
 
 struct Stop: AsyncParsableCommand {
@@ -12,13 +13,24 @@ struct Stop: AsyncParsableCommand {
     mutating func run() async throws {
         let wasLoaded = LaunchAgent.isLoaded()
 
+        // Disarm crash recovery FIRST so the watchdog can't relaunch the daemon
+        // we're about to stop. Tear it down to match the provider agent: plain
+        // stop unloads it (plist stays for reboot); uninstall deletes the plist.
+        // Best-effort — a watchdog hiccup must never block stopping the provider.
+        if uninstall {
+            try? WatchdogAgent.uninstall()
+            try? FileManager.default.removeItem(at: WatchdogStateStore.path())
+        } else {
+            try? WatchdogAgent.stop()
+        }
+
         if uninstall {
             try LaunchAgent.uninstall()
             print("Provider service uninstalled.")
         } else {
             try LaunchAgent.stop()
             if wasLoaded {
-                print("Provider service stopped.")
+                print("Provider service stopped. (Auto-restart disabled until you start again.)")
             } else {
                 print("Provider service is not running.")
             }

--- a/provider-swift/Sources/darkbloom/StopCommand.swift
+++ b/provider-swift/Sources/darkbloom/StopCommand.swift
@@ -14,13 +14,14 @@ struct Stop: AsyncParsableCommand {
         let wasLoaded = LaunchAgent.isLoaded()
 
         // Disarm crash recovery FIRST so the watchdog can't relaunch what we're
-        // stopping (uninstall deletes its plist + state). Best-effort.
+        // stopping, and drop its timer so the next start gets a fresh grace
+        // window (uninstall additionally deletes its plist). Best-effort.
         if uninstall {
             try? WatchdogAgent.uninstall()
-            try? FileManager.default.removeItem(at: WatchdogStateStore.path())
         } else {
             try? WatchdogAgent.stop()
         }
+        try? FileManager.default.removeItem(at: WatchdogStateStore.path())
 
         if uninstall {
             try LaunchAgent.uninstall()

--- a/provider-swift/Sources/darkbloom/WatchdogCommand.swift
+++ b/provider-swift/Sources/darkbloom/WatchdogCommand.swift
@@ -1,22 +1,10 @@
 import Foundation
 import ArgumentParser
 import ProviderCore
-#if canImport(Darwin)
-import Darwin
-#endif
 
-/// `darkbloom watchdog` -- one crash-recovery check, then exit.
-///
-/// Run once a minute by `WatchdogAgent` (launchd `StartInterval`). It is the
-/// thin I/O shell around `WatchdogPolicy.decide`: probe launchd, read the
-/// cross-tick timer, decide, act. Hidden from `--help` because it is a
-/// machine-invoked maintenance command, not a user-facing verb.
-///
-/// Why a 5-minute delay instead of an instant relaunch (e.g. launchd
-/// `KeepAlive`): it sidesteps the self-updater's brief kill+relaunch, gives a
-/// transient fault (thermal throttle, a network blip, a wedged GPU clearing)
-/// time to settle, and bounds a crash-looping binary to one attempt per window
-/// instead of a tight respawn storm.
+/// `darkbloom watchdog` — one crash-recovery check, then exit. Run every minute
+/// by `WatchdogAgent` (launchd StartInterval). Hidden: machine-invoked, not a
+/// user verb. The thin I/O shell around `WatchdogPolicy`.
 struct Watchdog: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "watchdog",
@@ -33,9 +21,9 @@ struct Watchdog: AsyncParsableCommand {
         let enabled = Self.autoRestartEnabled(configPath: configOptions.config)
         let liveness = WatchdogProbe.probeProvider(now: now)
         let state = WatchdogStateStore.read()
-        // Ignore a downSince left over from a previous boot so every outage gets
-        // a fresh grace window rather than an instant post-reboot restart.
-        let downSince = WatchdogPolicy.effectiveDownSince(state.downSince, bootTime: Self.systemBootTime())
+        // Ignore a downSince left over from a previous boot (fresh window per outage).
+        let bootTime = now - ProcessInfo.processInfo.systemUptime
+        let downSince = WatchdogPolicy.effectiveDownSince(state.downSince, bootTime: bootTime)
 
         let decision = WatchdogPolicy.decide(
             autoRestartEnabled: enabled,
@@ -46,19 +34,13 @@ struct Watchdog: AsyncParsableCommand {
         )
 
         let grace = Int(WatchdogPolicy.defaultGraceSeconds)
-
-        // Side effects (log + restart). Persistence is computed purely below.
         switch decision {
         case .restart:
-            // `kickstartIfLoaded` re-confirms the job is still loaded right before
-            // acting: if `darkbloom stop` landed since the probe it is a no-op, so
-            // we never revive a provider the user intentionally stopped.
+            // kickstartIfLoaded re-checks loaded, so a `stop` racing the probe is a no-op.
             do {
-                if try LaunchAgent.kickstartIfLoaded() {
-                    log("provider down > \(grace)s — restart issued")
-                } else {
-                    log("provider no longer loaded — skipping restart")
-                }
+                let restarted = try LaunchAgent.kickstartIfLoaded()
+                log(restarted ? "provider down > \(grace)s — restart issued"
+                              : "provider no longer loaded — skipping restart")
             } catch {
                 log("restart failed: \(error)")
             }
@@ -69,34 +51,17 @@ struct Watchdog: AsyncParsableCommand {
         case .healthy:
             if downSince != nil { log("provider recovered — cancelling pending restart") }
         case .disabled, .notManaged:
-            break // opted out, stopped, or uninstalled — nothing to do
+            break
         }
 
-        if let newState = WatchdogPolicy.nextState(for: decision, current: state, now: now) {
-            WatchdogStateStore.write(newState)
+        if let newState = WatchdogPolicy.nextState(for: decision, current: state, now: now),
+           !WatchdogStateStore.write(newState) {
+            log("warning: could not persist watchdog state (check ~/.darkbloom)")
         }
     }
 
-    /// System boot time as epoch seconds, or nil if it can't be read. Used to
-    /// discard a stale `downSince` from a previous uptime (see effectiveDownSince).
-    static func systemBootTime() -> Double? {
-        #if canImport(Darwin)
-        var mib: [Int32] = [CTL_KERN, KERN_BOOTTIME]
-        var boot = timeval()
-        var size = MemoryLayout<timeval>.stride
-        let rc = mib.withUnsafeMutableBufferPointer { ptr in
-            sysctl(ptr.baseAddress, UInt32(ptr.count), &boot, &size, nil, 0)
-        }
-        guard rc == 0, boot.tv_sec > 0 else { return nil }
-        return Double(boot.tv_sec) + Double(boot.tv_usec) / 1_000_000
-        #else
-        return nil
-        #endif
-    }
-
-    /// Read just the `auto_restart` flag, cheaply — no hardware detection or
-    /// model scan (this runs every minute). Fails open to enabled so a missing
-    /// or malformed config never silently disables crash recovery.
+    /// Read just `auto_restart` cheaply; fail open to enabled so a missing or
+    /// malformed config never silently disables recovery.
     static func autoRestartEnabled(configPath: String?) -> Bool {
         let path: URL
         if let configPath {
@@ -107,18 +72,12 @@ struct Watchdog: AsyncParsableCommand {
             return true
         }
         guard FileManager.default.fileExists(atPath: path.path),
-              let config = try? ConfigManager.load(from: path)
-        else {
-            return true
-        }
+              let config = try? ConfigManager.load(from: path) else { return true }
         return config.provider.autoRestart
     }
 
-    /// Append a timestamped line; launchd routes our stdout to
-    /// `~/.darkbloom/watchdog.log`. We log only state transitions and actions,
-    /// so quiet ticks (the overwhelming majority) write nothing.
+    /// launchd routes stdout to ~/.darkbloom/watchdog.log; we log only transitions.
     private func log(_ message: String) {
-        let timestamp = ISO8601DateFormatter().string(from: Date())
-        print("[\(timestamp)] watchdog: \(message)")
+        print("[\(ISO8601DateFormatter().string(from: Date()))] watchdog: \(message)")
     }
 }

--- a/provider-swift/Sources/darkbloom/WatchdogCommand.swift
+++ b/provider-swift/Sources/darkbloom/WatchdogCommand.swift
@@ -1,0 +1,124 @@
+import Foundation
+import ArgumentParser
+import ProviderCore
+#if canImport(Darwin)
+import Darwin
+#endif
+
+/// `darkbloom watchdog` -- one crash-recovery check, then exit.
+///
+/// Run once a minute by `WatchdogAgent` (launchd `StartInterval`). It is the
+/// thin I/O shell around `WatchdogPolicy.decide`: probe launchd, read the
+/// cross-tick timer, decide, act. Hidden from `--help` because it is a
+/// machine-invoked maintenance command, not a user-facing verb.
+///
+/// Why a 5-minute delay instead of an instant relaunch (e.g. launchd
+/// `KeepAlive`): it sidesteps the self-updater's brief kill+relaunch, gives a
+/// transient fault (thermal throttle, a network blip, a wedged GPU clearing)
+/// time to settle, and bounds a crash-looping binary to one attempt per window
+/// instead of a tight respawn storm.
+struct Watchdog: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "watchdog",
+        abstract: "Internal: one provider crash-recovery check (run by launchd).",
+        shouldDisplay: false
+    )
+
+    @OptionGroup var configOptions: ConfigOptions
+
+    mutating func run() async throws {
+        Darkbloom.ensureLogging()
+
+        let now = Date().timeIntervalSince1970
+        let enabled = Self.autoRestartEnabled(configPath: configOptions.config)
+        let liveness = WatchdogProbe.probeProvider(now: now)
+        let state = WatchdogStateStore.read()
+        // Ignore a downSince left over from a previous boot so every outage gets
+        // a fresh grace window rather than an instant post-reboot restart.
+        let downSince = WatchdogPolicy.effectiveDownSince(state.downSince, bootTime: Self.systemBootTime())
+
+        let decision = WatchdogPolicy.decide(
+            autoRestartEnabled: enabled,
+            providerLoaded: liveness.loaded,
+            providerRunning: liveness.running,
+            downSince: downSince,
+            now: now
+        )
+
+        let grace = Int(WatchdogPolicy.defaultGraceSeconds)
+
+        // Side effects (log + restart). Persistence is computed purely below.
+        switch decision {
+        case .restart:
+            // `kickstartIfLoaded` re-confirms the job is still loaded right before
+            // acting: if `darkbloom stop` landed since the probe it is a no-op, so
+            // we never revive a provider the user intentionally stopped.
+            do {
+                if try LaunchAgent.kickstartIfLoaded() {
+                    log("provider down > \(grace)s — restart issued")
+                } else {
+                    log("provider no longer loaded — skipping restart")
+                }
+            } catch {
+                log("restart failed: \(error)")
+            }
+        case .startGrace:
+            log("provider appears down — will restart in \(grace)s if it stays down")
+        case .waiting(let remaining):
+            log("provider still down — restart in ~\(Int(remaining))s")
+        case .healthy:
+            if downSince != nil { log("provider recovered — cancelling pending restart") }
+        case .disabled, .notManaged:
+            break // opted out, stopped, or uninstalled — nothing to do
+        }
+
+        if let newState = WatchdogPolicy.nextState(for: decision, current: state, now: now) {
+            WatchdogStateStore.write(newState)
+        }
+    }
+
+    /// System boot time as epoch seconds, or nil if it can't be read. Used to
+    /// discard a stale `downSince` from a previous uptime (see effectiveDownSince).
+    static func systemBootTime() -> Double? {
+        #if canImport(Darwin)
+        var mib: [Int32] = [CTL_KERN, KERN_BOOTTIME]
+        var boot = timeval()
+        var size = MemoryLayout<timeval>.stride
+        let rc = mib.withUnsafeMutableBufferPointer { ptr in
+            sysctl(ptr.baseAddress, UInt32(ptr.count), &boot, &size, nil, 0)
+        }
+        guard rc == 0, boot.tv_sec > 0 else { return nil }
+        return Double(boot.tv_sec) + Double(boot.tv_usec) / 1_000_000
+        #else
+        return nil
+        #endif
+    }
+
+    /// Read just the `auto_restart` flag, cheaply — no hardware detection or
+    /// model scan (this runs every minute). Fails open to enabled so a missing
+    /// or malformed config never silently disables crash recovery.
+    static func autoRestartEnabled(configPath: String?) -> Bool {
+        let path: URL
+        if let configPath {
+            path = URL(fileURLWithPath: (configPath as NSString).expandingTildeInPath)
+        } else if let resolved = try? ConfigManager.defaultConfigPath() {
+            path = resolved
+        } else {
+            return true
+        }
+        guard FileManager.default.fileExists(atPath: path.path),
+              let config = try? ConfigManager.load(from: path)
+        else {
+            return true
+        }
+        return config.provider.autoRestart
+    }
+
+    /// Append a timestamped line; launchd routes our stdout to
+    /// `~/.darkbloom/watchdog.log`. We log only state transitions and actions,
+    /// so quiet ticks (the overwhelming majority) write nothing.
+    private func log(_ message: String) {
+        let timestamp = ISO8601DateFormatter().string(from: Date())
+        print("[\(timestamp)] watchdog: \(message)")
+    }
+}

--- a/provider-swift/Sources/darkbloom/WatchdogCommand.swift
+++ b/provider-swift/Sources/darkbloom/WatchdogCommand.swift
@@ -76,7 +76,7 @@ struct Watchdog: AsyncParsableCommand {
         return config.provider.autoRestart
     }
 
-    /// launchd routes stdout to ~/.darkbloom/watchdog.log; we log only transitions.
+    /// launchd routes stdout to ~/.darkbloom/watchdog.log; healthy ticks log nothing.
     private func log(_ message: String) {
         print("[\(ISO8601DateFormatter().string(from: Date()))] watchdog: \(message)")
     }

--- a/provider-swift/Tests/DarkbloomCLITests/WatchdogCommandTests.swift
+++ b/provider-swift/Tests/DarkbloomCLITests/WatchdogCommandTests.swift
@@ -1,0 +1,61 @@
+import ArgumentParser
+import Foundation
+import Testing
+
+@testable import darkbloom
+
+/// Unit tests for the `darkbloom watchdog` subcommand wiring + its cheap config
+/// read. The launchctl side effects are environment-dependent (manual /
+/// integration verification); here we pin the deterministic pieces.
+@Suite("Watchdog command")
+struct WatchdogCommandTests {
+
+    @Test("watchdog is registered and parses to a Watchdog command")
+    func watchdogParses() throws {
+        let command = try Darkbloom.parseAsRoot(["watchdog"])
+        #expect(command is Watchdog)
+    }
+
+    @Test("watchdog is hidden from help and named correctly")
+    func watchdogConfiguration() {
+        #expect(Watchdog.configuration.commandName == "watchdog")
+        #expect(Watchdog.configuration.shouldDisplay == false)
+    }
+
+    // MARK: - autoRestartEnabled (cheap config read, fail-open)
+
+    private func writeTempConfig(_ toml: String) -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("watchdog-cfg-\(UUID().uuidString).toml")
+        try? toml.write(to: url, atomically: true, encoding: .utf8)
+        return url
+    }
+
+    @Test("auto_restart = false disables recovery")
+    func honoursDisable() {
+        let url = writeTempConfig("""
+        [provider]
+        name = "x"
+        auto_restart = false
+        """)
+        defer { try? FileManager.default.removeItem(at: url) }
+        #expect(Watchdog.autoRestartEnabled(configPath: url.path) == false)
+    }
+
+    @Test("absent auto_restart defaults to enabled")
+    func defaultsEnabled() {
+        let url = writeTempConfig("""
+        [provider]
+        name = "x"
+        """)
+        defer { try? FileManager.default.removeItem(at: url) }
+        #expect(Watchdog.autoRestartEnabled(configPath: url.path) == true)
+    }
+
+    @Test("a missing config file fails open to enabled")
+    func failsOpen() {
+        let missing = FileManager.default.temporaryDirectory
+            .appendingPathComponent("watchdog-missing-\(UUID().uuidString).toml")
+        #expect(Watchdog.autoRestartEnabled(configPath: missing.path) == true)
+    }
+}

--- a/provider-swift/Tests/ProviderCoreTests/WatchdogTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/WatchdogTests.swift
@@ -228,6 +228,15 @@ struct WatchdogStateTests {
         #expect(read.downSince == nil)
         #expect(read.lastRestartAt == nil)
     }
+
+    @Test("write reports success, and failure on an unwritable path")
+    func writeReportsOutcome() {
+        let url = tempURL()
+        defer { try? FileManager.default.removeItem(at: url) }
+        #expect(WatchdogStateStore.write(WatchdogState(downSince: 1), to: url))
+        // /dev/null is a file, so it can never become a parent directory.
+        #expect(!WatchdogStateStore.write(WatchdogState(), to: URL(fileURLWithPath: "/dev/null/watchdog/state.json")))
+    }
 }
 
 /// The `auto_restart` config flag.

--- a/provider-swift/Tests/ProviderCoreTests/WatchdogTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/WatchdogTests.swift
@@ -1,0 +1,263 @@
+import Foundation
+import Testing
+@testable import ProviderCore
+
+/// The crash-recovery policy: the exact rules that decide whether to relaunch a
+/// downed provider. Pure, so every branch is pinned here.
+@Suite("Watchdog decision")
+struct WatchdogDecisionTests {
+    let now: Double = 1_000_000
+    let grace: Double = 300
+
+    @Test("config opt-out wins over everything")
+    func disabledOptsOut() {
+        let d = WatchdogPolicy.decide(
+            autoRestartEnabled: false, providerLoaded: true, providerRunning: false,
+            downSince: now - 9_999, now: now, graceSeconds: grace
+        )
+        #expect(d == .disabled)
+    }
+
+    @Test("an unloaded provider (stopped / uninstalled) is never restarted")
+    func notManagedWhenUnloaded() {
+        let d = WatchdogPolicy.decide(
+            autoRestartEnabled: true, providerLoaded: false, providerRunning: false,
+            downSince: now - 9_999, now: now, graceSeconds: grace
+        )
+        #expect(d == .notManaged)
+    }
+
+    @Test("a running provider is healthy")
+    func healthyWhenRunning() {
+        let d = WatchdogPolicy.decide(
+            autoRestartEnabled: true, providerLoaded: true, providerRunning: true,
+            downSince: now - 100, now: now, graceSeconds: grace
+        )
+        #expect(d == .healthy)
+    }
+
+    @Test("first observation of a down provider arms the grace window")
+    func startsGraceOnFirstDown() {
+        let d = WatchdogPolicy.decide(
+            autoRestartEnabled: true, providerLoaded: true, providerRunning: false,
+            downSince: nil, now: now, graceSeconds: grace
+        )
+        #expect(d == .startGrace)
+    }
+
+    @Test("within the grace window the watchdog waits")
+    func waitsInsideGrace() {
+        let d = WatchdogPolicy.decide(
+            autoRestartEnabled: true, providerLoaded: true, providerRunning: false,
+            downSince: now - 100, now: now, graceSeconds: grace
+        )
+        #expect(d == .waiting(remaining: 200))
+    }
+
+    @Test("at or past the grace window the watchdog restarts")
+    func restartsAtGraceBoundary() {
+        let exactly = WatchdogPolicy.decide(
+            autoRestartEnabled: true, providerLoaded: true, providerRunning: false,
+            downSince: now - 300, now: now, graceSeconds: grace
+        )
+        #expect(exactly == .restart)
+
+        let past = WatchdogPolicy.decide(
+            autoRestartEnabled: true, providerLoaded: true, providerRunning: false,
+            downSince: now - 600, now: now, graceSeconds: grace
+        )
+        #expect(past == .restart)
+    }
+
+    @Test("default grace period is five minutes")
+    func defaultGraceIsFiveMinutes() {
+        #expect(WatchdogPolicy.defaultGraceSeconds == 300)
+    }
+}
+
+/// The reboot guard: a downSince armed in a previous uptime must not survive to
+/// trigger an instant post-reboot restart.
+@Suite("Watchdog reboot guard")
+struct WatchdogEffectiveDownSinceTests {
+    @Test("a downSince from before boot is discarded")
+    func staleAcrossBootDropped() {
+        #expect(WatchdogPolicy.effectiveDownSince(50, bootTime: 100) == nil)
+    }
+
+    @Test("a downSince after boot is kept")
+    func freshKept() {
+        #expect(WatchdogPolicy.effectiveDownSince(150, bootTime: 100) == 150)
+    }
+
+    @Test("unknown boot time passes the value through unchanged")
+    func unknownBootPassesThrough() {
+        #expect(WatchdogPolicy.effectiveDownSince(150, bootTime: nil) == 150)
+        #expect(WatchdogPolicy.effectiveDownSince(nil, bootTime: 100) == nil)
+    }
+}
+
+/// The pure persistence mapping the watchdog command uses after deciding.
+@Suite("Watchdog persistence")
+struct WatchdogNextStateTests {
+    let now: Double = 1_000_000
+
+    @Test("restart records the attempt and clears the window")
+    func restartState() {
+        let s = WatchdogPolicy.nextState(for: .restart, current: WatchdogState(downSince: now - 400), now: now)
+        #expect(s == WatchdogState(downSince: nil, lastRestartAt: now))
+    }
+
+    @Test("startGrace arms downSince, preserving lastRestartAt")
+    func startGraceState() {
+        let s = WatchdogPolicy.nextState(for: .startGrace, current: WatchdogState(lastRestartAt: 42), now: now)
+        #expect(s == WatchdogState(downSince: now, lastRestartAt: 42))
+    }
+
+    @Test("waiting writes nothing")
+    func waitingState() {
+        let s = WatchdogPolicy.nextState(for: .waiting(remaining: 60), current: WatchdogState(downSince: now - 60), now: now)
+        #expect(s == nil)
+    }
+
+    @Test("healthy clears an armed window but no-ops when already clear")
+    func healthyState() {
+        let cleared = WatchdogPolicy.nextState(for: .healthy, current: WatchdogState(downSince: now - 10, lastRestartAt: 7), now: now)
+        #expect(cleared == WatchdogState(downSince: nil, lastRestartAt: 7))
+        #expect(WatchdogPolicy.nextState(for: .healthy, current: WatchdogState(), now: now) == nil)
+    }
+
+    @Test("disabled / notManaged clear an armed window, else no-op")
+    func disabledNotManagedState() {
+        #expect(WatchdogPolicy.nextState(for: .disabled, current: WatchdogState(downSince: 1), now: now) == WatchdogState(downSince: nil))
+        #expect(WatchdogPolicy.nextState(for: .notManaged, current: WatchdogState(), now: now) == nil)
+    }
+}
+
+/// `launchctl print` parsing — the signal that tells a *crashed* (loaded but
+/// dead) provider apart from a *running* one.
+@Suite("Watchdog launchctl parse")
+struct WatchdogProbeParseTests {
+    @Test("a running job (state + pid) parses as running")
+    func runningJob() {
+        let out = """
+        gui/501/io.darkbloom.provider = {
+        \tactive count = 1
+        \tstate = running
+        \tpid = 4242
+        }
+        """
+        #expect(WatchdogProbe.parseRunning(out))
+    }
+
+    @Test("a crashed job (state = not running) parses as not running")
+    func crashedJob() {
+        let out = """
+        gui/501/io.darkbloom.provider = {
+        \tactive count = 0
+        \tstate = not running
+        \tlast exit code = 1
+        }
+        """
+        #expect(!WatchdogProbe.parseRunning(out))
+    }
+
+    @Test("a bare non-zero pid line counts as running")
+    func barePid() {
+        #expect(WatchdogProbe.parseRunning("\tpid = 1"))
+    }
+
+    @Test("pid = 0 and empty output are not running")
+    func notRunningEdges() {
+        #expect(!WatchdogProbe.parseRunning("\tpid = 0"))
+        #expect(!WatchdogProbe.parseRunning(""))
+    }
+}
+
+/// The watchdog launchd plist shape.
+@Suite("Watchdog agent plist")
+struct WatchdogAgentPlistTests {
+    @Test("plist runs `darkbloom watchdog` on a one-minute interval at load")
+    func plistShape() {
+        let plist = WatchdogAgent.makeWatchdogPlist(
+            label: "io.darkbloom.watchdog",
+            programArguments: ["/usr/local/bin/darkbloom", "watchdog"],
+            logPath: "/tmp/watchdog.log",
+            intervalSeconds: 60
+        )
+        #expect(plist["Label"] as? String == "io.darkbloom.watchdog")
+        #expect(plist["ProgramArguments"] as? [String] == ["/usr/local/bin/darkbloom", "watchdog"])
+        #expect(plist["StartInterval"] as? Int == 60)
+        #expect(plist["RunAtLoad"] as? Bool == true)
+        // Cadence is StartInterval's job; the watchdog must not KeepAlive.
+        #expect(plist["KeepAlive"] as? Bool == false)
+        #expect(plist["ProcessType"] as? String == "Background")
+        #expect(plist["StandardOutPath"] as? String == "/tmp/watchdog.log")
+        #expect(plist["StandardErrorPath"] as? String == "/tmp/watchdog.log")
+    }
+
+    @Test("the watchdog label is distinct from the provider label")
+    func distinctLabel() {
+        #expect(WatchdogAgent.label != LaunchAgent.label)
+        #expect(LaunchAgent.supportedLabels.contains(LaunchAgent.label))
+    }
+}
+
+/// The cross-tick timer state persistence.
+@Suite("Watchdog state")
+struct WatchdogStateTests {
+    private func tempURL() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("watchdog-state-\(UUID().uuidString).json")
+    }
+
+    @Test("state round-trips through disk")
+    func roundTrip() {
+        let url = tempURL()
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let original = WatchdogState(downSince: 123.5, lastRestartAt: 456.75)
+        WatchdogStateStore.write(original, to: url)
+        let read = WatchdogStateStore.read(from: url)
+        #expect(read == original)
+    }
+
+    @Test("reading a missing file yields empty state, not an error")
+    func missingFileIsEmpty() {
+        let read = WatchdogStateStore.read(from: tempURL())
+        #expect(read == WatchdogState())
+        #expect(read.downSince == nil)
+        #expect(read.lastRestartAt == nil)
+    }
+}
+
+/// The `auto_restart` config flag.
+@Suite("Provider auto_restart config")
+struct ProviderAutoRestartConfigTests {
+    @Test("auto_restart defaults to true when absent")
+    func defaultsTrue() {
+        let config = ConfigManager.parse("""
+        [provider]
+        name = "test-provider"
+        """)
+        #expect(config.provider.autoRestart)
+    }
+
+    @Test("auto_restart = false is honoured")
+    func explicitFalse() {
+        let config = ConfigManager.parse("""
+        [provider]
+        name = "test-provider"
+        auto_restart = false
+        """)
+        #expect(!config.provider.autoRestart)
+    }
+
+    @Test("auto_restart survives a serialize round-trip")
+    func roundTrips() {
+        let original = ProviderConfig(
+            provider: ProviderSettings(name: "test-provider", autoRestart: false)
+        )
+        let decoded = ConfigManager.parse(ConfigManager.serialize(original))
+        #expect(!decoded.provider.autoRestart)
+    }
+}


### PR DESCRIPTION
## What

Adds a **separate launchd background agent** (`io.darkbloom.watchdog`) that relaunches the provider **~5 minutes after a crash** — but only when the user hasn't disabled it. Closes the gap where a crashed provider stayed dead until the next manual `darkbloom start` or reboot.

## When it acts (and when it doesn't)

The crash-vs-intentional distinction is exact, read straight from launchd state — no guessing:

| Situation | launchd job state | Watchdog |
|---|---|---|
| **Crash / panic / OOM-kill** | loaded, not running (`KeepAlive=false`) | restart after 5 min ✅ |
| `darkbloom stop` | unloaded (`bootout`) | never restart ✅ |
| `darkbloom stop --uninstall` | unloaded + plist deleted | never restart ✅ |
| `auto_restart = false` (config) | n/a | never restart ✅ |
| Self-update (`kickstart -k`) | sub-second blip, stays loaded | grace window ⇒ no-op ✅ |
| Cold model load (~2 min) | running (pid present) | healthy ✅ |
| Schedule window closed | process alive, sleeping | healthy ✅ |

## Why a separate 5-minute watchdog (not `KeepAlive`)

- **Sidesteps the self-updater race.** The main plist keeps `KeepAlive=false` (its comment already warned that unconditional KeepAlive races the graceful stage-then-swap). The 5-minute grace is far longer than an update's kill+relaunch, so recovery never collides with it.
- **Gentle.** A genuinely broken binary is bounded to one restart per ~5 min, not a tight respawn loop. Transient faults (thermal throttle, network blip, a wedged GPU clearing) get time to settle first.
- **Can't itself wedge.** The watchdog is a check-and-exit one-shot run every 60s by launchd `StartInterval`, not a long-lived daemon.

## How it's wired

- **Arm:** `darkbloom start` and `darkbloom restart` install the watchdog; it is also armed idempotently inside `runForeground` (the code the plist actually runs), so a **background auto-update relaunch** or a **login `RunAtLoad`** start arms it too — important for fleet rollout onto this build.
- **Disarm:** `darkbloom stop` unloads it first (so it can't relaunch the daemon you're stopping); `stop --uninstall` deletes its plist + state file.
- **Observe:** `darkbloom status` shows an `Auto-restart:` line; the watchdog logs only state transitions to `~/.darkbloom/watchdog.log`.
- **Opt out:** `provider.auto_restart = false` in `provider.toml` (default `true`).

## Design (modular)

- `WatchdogPolicy` — pure decision core (`decide`, `nextState`, `effectiveDownSince`); zero I/O, exhaustively unit-tested.
- `WatchdogProbe` — liveness via `launchctl print` (`state = running` / `pid = N`), with a *fresh* daemon-state-file fallback that can only ever **prevent** a restart, never cause one.
- `WatchdogAgent` — the `io.darkbloom.watchdog` launchd job (`StartInterval=60`, `RunAtLoad`, `ProcessType=Background`).
- `WatchdogState` — cross-tick `downSince` timer at `~/.darkbloom/watchdog-state.json`.
- `LaunchctlControl` — shared launchctl plumbing (also de-dupes `currentExecutablePath`).
- `LaunchAgent.kickstartIfLoaded()` — restart in place **only if loaded**; never bootstraps an unloaded job, so a stopped provider is never revived. A reboot guard (`effectiveDownSince` vs `sysctl(KERN_BOOTTIME)`) discards a stale timer from a previous uptime.

## Testing

`swift build` clean; **57 watchdog/launch/config tests pass** (decision table incl. grace boundary, launchctl-parse, plist shape, state round-trip, reboot guard, persistence mapping, config decode, command wiring). The launchctl-parse regex was validated against **real macOS output** (217 stopped + 237 running launchd jobs → 0 false positives/negatives).

## Note for reviewers

This is the deliberate, separate-watchdog approach to crash recovery. It is an **alternative to** the `KeepAlive = { SuccessfulExit = false }` flip explored in the `fleet-stability-hotfix` branch — pick one, not both (this PR keeps `KeepAlive=false`). Two independent reviewers (Codex + Claude) reviewed and passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/315"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783745761&installation_id=133247490&pr_number=315&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F315&signature=3ffa58b10a09aca6f8e9fce214e26e4790d2b3ead9d0b9bed966982478dc836d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->