### PR TITLE
security: pin coordinator URL in console proxies + installer sync + billing mock-mode guard

### DIFF
--- a/console-ui/__tests__/coordinator-url-pinning.test.ts
+++ b/console-ui/__tests__/coordinator-url-pinning.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// SEC-001 regression: server proxy routes must resolve the coordinator URL
+// from the build-time constant only. A client-supplied `x-coordinator-url`
+// header must never choose the upstream origin — it turns the Next server
+// into an SSRF proxy and forwards Privy session tokens to that origin.
+//
+// Each case sends an attacker-controlled header (plus a privy-token cookie
+// for the routes that forward it) and asserts the upstream fetch went to the
+// pinned coordinator.
+
+const DEFAULT_COORD = "https://api.darkbloom.dev";
+const ATTACKER = "https://attacker.example.com";
+
+let upstreamFetch: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  upstreamFetch = vi.fn().mockResolvedValue(
+    new Response(JSON.stringify({}), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    })
+  );
+  vi.stubGlobal("fetch", upstreamFetch);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.resetModules();
+});
+
+function makeRequest(
+  url: string,
+  init?: { method?: string; body?: string }
+): NextRequest {
+  return new NextRequest(new URL(url, "http://localhost:3000"), {
+    method: init?.method ?? "GET",
+    headers: {
+      "x-coordinator-url": ATTACKER,
+      cookie: "privy-token=privy-tok-123",
+      ...(init?.body ? { "content-type": "application/json" } : {}),
+    },
+    ...(init?.body ? { body: init.body } : {}),
+  });
+}
+
+interface RouteCase {
+  name: string;
+  importPath: () => Promise<{
+    POST?: (req: NextRequest) => Promise<Response>;
+    GET?: (req: NextRequest) => Promise<Response>;
+  }>;
+  method: "GET" | "POST";
+  requestPath: string;
+  upstreamPath: string;
+  body?: string;
+}
+
+const CASES: RouteCase[] = [
+  {
+    name: "POST /api/payments/stripe/checkout",
+    importPath: () => import("@/app/api/payments/stripe/checkout/route"),
+    method: "POST",
+    requestPath: "/api/payments/stripe/checkout",
+    upstreamPath: "/v1/billing/stripe/create-session",
+    body: JSON.stringify({ amount_usd: 10 }),
+  },
+  {
+    name: "GET /api/payments/stripe/status",
+    importPath: () => import("@/app/api/payments/stripe/status/route"),
+    method: "GET",
+    requestPath: "/api/payments/stripe/status",
+    upstreamPath: "/v1/billing/stripe/status",
+  },
+  {
+    name: "POST /api/payments/stripe/onboard",
+    importPath: () => import("@/app/api/payments/stripe/onboard/route"),
+    method: "POST",
+    requestPath: "/api/payments/stripe/onboard",
+    upstreamPath: "/v1/billing/stripe/onboard",
+    body: JSON.stringify({ country: "US" }),
+  },
+  {
+    name: "GET /api/payments/stripe/withdrawals",
+    importPath: () => import("@/app/api/payments/stripe/withdrawals/route"),
+    method: "GET",
+    requestPath: "/api/payments/stripe/withdrawals",
+    upstreamPath: "/v1/billing/stripe/withdrawals",
+  },
+  {
+    name: "POST /api/payments/withdraw/stripe",
+    importPath: () => import("@/app/api/payments/withdraw/stripe/route"),
+    method: "POST",
+    requestPath: "/api/payments/withdraw/stripe",
+    upstreamPath: "/v1/billing/withdraw/stripe",
+    body: JSON.stringify({ amount_usd: 5, method: "standard" }),
+  },
+  {
+    name: "POST /api/telemetry",
+    importPath: () => import("@/app/api/telemetry/route"),
+    method: "POST",
+    requestPath: "/api/telemetry",
+    upstreamPath: "/v1/telemetry/events",
+    body: JSON.stringify({ events: [] }),
+  },
+];
+
+describe("coordinator URL pinning (SEC-001)", () => {
+  for (const c of CASES) {
+    it(`${c.name} ignores x-coordinator-url`, async () => {
+      const mod = await c.importPath();
+      const handler = c.method === "GET" ? mod.GET! : mod.POST!;
+      const res = await handler(
+        makeRequest(c.requestPath, { method: c.method, body: c.body })
+      );
+
+      expect(res.status).toBe(200);
+      expect(upstreamFetch).toHaveBeenCalledTimes(1);
+      const upstreamUrl = String(upstreamFetch.mock.calls[0][0]);
+      expect(upstreamUrl.startsWith(`${DEFAULT_COORD}${c.upstreamPath}`)).toBe(
+        true
+      );
+      expect(upstreamUrl).not.toContain("attacker.example.com");
+    });
+  }
+});

--- a/console-ui/__tests__/coordinator-url-pinning.test.ts
+++ b/console-ui/__tests__/coordinator-url-pinning.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { NextRequest } from "next/server";
 
-// SEC-001 regression: server proxy routes must resolve the coordinator URL
+// Regression: server proxy routes must resolve the coordinator URL
 // from the build-time constant only. A client-supplied `x-coordinator-url`
 // header must never choose the upstream origin — it turns the Next server
 // into an SSRF proxy and forwards Privy session tokens to that origin.
@@ -106,7 +106,7 @@ const CASES: RouteCase[] = [
   },
 ];
 
-describe("coordinator URL pinning (SEC-001)", () => {
+describe("coordinator URL pinning", () => {
   for (const c of CASES) {
     it(`${c.name} ignores x-coordinator-url`, async () => {
       const mod = await c.importPath();

--- a/console-ui/__tests__/earnings-url-pinning.test.tsx
+++ b/console-ui/__tests__/earnings-url-pinning.test.tsx
@@ -1,0 +1,90 @@
+import { render, waitFor } from "@testing-library/react";
+import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
+
+// SEC-002 regression: the Earnings page sends a bearer token with its
+// account-earnings fetch. That fetch must go to the build-time coordinator
+// URL — a localStorage-poisoned `darkbloom_coordinator_url` must never
+// receive the token.
+
+vi.mock("@/hooks/useAuth", () => ({
+  useAuth: () => ({
+    ready: true,
+    authenticated: true,
+    login: vi.fn(),
+    getAccessToken: vi.fn().mockResolvedValue("privy-access-token"),
+  }),
+}));
+
+vi.mock("@/hooks/useToast", () => ({
+  useToastStore: (selector: (s: { addToast: () => void }) => unknown) =>
+    selector({ addToast: vi.fn() }),
+}));
+
+vi.mock("@/lib/google-analytics", () => ({
+  trackEvent: vi.fn(),
+}));
+
+vi.mock("@/lib/api", () => ({
+  fetchStripeStatus: vi.fn().mockResolvedValue({
+    connected: false,
+    payouts_enabled: false,
+    requirements_due: [],
+  }),
+  startStripeOnboarding: vi.fn(),
+  withdrawStripe: vi.fn(),
+  fetchStripeWithdrawals: vi.fn().mockResolvedValue([]),
+  computeStripeFeeUsd: vi.fn().mockReturnValue(0),
+}));
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  fetchMock = vi.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    json: () =>
+      Promise.resolve({
+        account_id: "acct",
+        earnings: [],
+        total_micro_usd: 0,
+        total_usd: "0.00",
+        count: 0,
+        recent_count: 0,
+        history_limit: 100,
+        available_balance_micro_usd: 0,
+        available_balance_usd: "0.00",
+        withdrawable_balance_micro_usd: 0,
+        withdrawable_balance_usd: "0.00",
+      }),
+  });
+  vi.stubGlobal("fetch", fetchMock);
+  localStorage.clear();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("EarningsContent coordinator URL pinning (SEC-002)", () => {
+  it("ignores a poisoned localStorage coordinator URL", async () => {
+    localStorage.setItem(
+      "darkbloom_coordinator_url",
+      "https://attacker.example.com"
+    );
+
+    const { default: EarningsContent } = await import(
+      "@/app/providers/earnings/EarningsContent"
+    );
+    render(<EarningsContent />);
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+
+    const earningsCall = fetchMock.mock.calls.find((c) =>
+      String(c[0]).includes("/v1/provider/account-earnings")
+    );
+    expect(earningsCall).toBeDefined();
+    const url = String(earningsCall![0]);
+    expect(url.startsWith("https://api.darkbloom.dev/")).toBe(true);
+    expect(url).not.toContain("attacker.example.com");
+  });
+});

--- a/console-ui/__tests__/earnings-url-pinning.test.tsx
+++ b/console-ui/__tests__/earnings-url-pinning.test.tsx
@@ -1,7 +1,7 @@
 import { render, waitFor } from "@testing-library/react";
 import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
 
-// SEC-002 regression: the Earnings page sends a bearer token with its
+// Regression: the Earnings page sends a bearer token with its
 // account-earnings fetch. That fetch must go to the build-time coordinator
 // URL — a localStorage-poisoned `darkbloom_coordinator_url` must never
 // receive the token.
@@ -65,7 +65,7 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-describe("EarningsContent coordinator URL pinning (SEC-002)", () => {
+describe("EarningsContent coordinator URL pinning", () => {
   it("ignores a poisoned localStorage coordinator URL", async () => {
     localStorage.setItem(
       "darkbloom_coordinator_url",

--- a/console-ui/__tests__/privy-client-provider.test.tsx
+++ b/console-ui/__tests__/privy-client-provider.test.tsx
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+// ---------------------------------------------------------------------------
+// PrivyClientProvider — production misconfiguration guard
+//
+// IS_PRIVY_CONFIGURED is evaluated at module scope, so we use
+// vi.resetModules() + dynamic import to get a fresh evaluation of the
+// NEXT_PUBLIC_PRIVY_APP_ID env var.  The production check itself (isProductionEnv)
+// reads process.env.NODE_ENV at render time, so vi.stubEnv works for it even
+// without a module reload.
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  vi.resetModules();
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+// ---------------------------------------------------------------------------
+// Case A: production build + missing/placeholder app ID → config-error screen
+// ---------------------------------------------------------------------------
+
+const CONFIG_ERROR_PATTERN = /Authentication is not configured/i;
+
+async function renderProviderProd(appId: string) {
+  vi.stubEnv("NEXT_PUBLIC_PRIVY_APP_ID", appId);
+  vi.stubEnv("NODE_ENV", "production");
+  const { PrivyClientProvider } = await import(
+    "@/components/providers/PrivyClientProvider"
+  );
+  render(
+    <PrivyClientProvider>
+      <span data-testid="child-probe">should not appear</span>
+    </PrivyClientProvider>
+  );
+}
+
+describe("PrivyClientProvider — production with unconfigured app ID", () => {
+  it("shows config-error UI and does NOT render children when NODE_ENV=production and app ID is absent", async () => {
+    // Ensure NEXT_PUBLIC_PRIVY_APP_ID is absent (force module re-evaluation).
+    await renderProviderProd("");
+
+    // Config-error message must be visible.
+    expect(screen.getByText(CONFIG_ERROR_PATTERN)).toBeInTheDocument();
+    expect(
+      screen.getByText(/NEXT_PUBLIC_PRIVY_APP_ID/i)
+    ).toBeInTheDocument();
+    expect(screen.getByText(/misconfigured/i)).toBeInTheDocument();
+
+    // Children must NOT be rendered.
+    expect(screen.queryByTestId("child-probe")).not.toBeInTheDocument();
+  });
+
+  it("shows config-error UI when app ID is the literal 'placeholder' string in production", async () => {
+    await renderProviderProd("placeholder");
+
+    expect(screen.getByText(CONFIG_ERROR_PATTERN)).toBeInTheDocument();
+    expect(screen.queryByTestId("child-probe")).not.toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Case B: non-production (test/dev) + missing app ID → mock fallback renders children
+// ---------------------------------------------------------------------------
+
+describe("PrivyClientProvider — non-production with unconfigured app ID", () => {
+  it("renders children via mock-auth fallback when NODE_ENV is not production", async () => {
+    // Default vitest NODE_ENV is "test"; NEXT_PUBLIC_PRIVY_APP_ID unset.
+    vi.stubEnv("NEXT_PUBLIC_PRIVY_APP_ID", "");
+    // Do NOT stub NODE_ENV — vitest default is "test", which is non-production.
+
+    const { PrivyClientProvider } = await import(
+      "@/components/providers/PrivyClientProvider"
+    );
+
+    render(
+      <PrivyClientProvider>
+        <span data-testid="child-probe">hello</span>
+      </PrivyClientProvider>
+    );
+
+    // Children must render.
+    expect(screen.getByTestId("child-probe")).toBeInTheDocument();
+    expect(screen.getByText("hello")).toBeInTheDocument();
+
+    // Config-error message must NOT be present.
+    expect(
+      screen.queryByText(/Authentication is not configured/i)
+    ).not.toBeInTheDocument();
+  });
+});

--- a/console-ui/src/app/api/payments/stripe/checkout/route.ts
+++ b/console-ui/src/app/api/payments/stripe/checkout/route.ts
@@ -7,7 +7,7 @@ import { NextRequest, NextResponse } from "next/server";
 const DEFAULT_COORD = process.env.NEXT_PUBLIC_COORDINATOR_URL || "https://api.darkbloom.dev";
 
 export async function POST(req: NextRequest) {
-  const coordUrl = req.headers.get("x-coordinator-url") || DEFAULT_COORD;
+  const coordUrl = DEFAULT_COORD;
 
   let authHeader = req.headers.get("authorization") || "";
   if (!authHeader) {

--- a/console-ui/src/app/api/payments/stripe/onboard/route.ts
+++ b/console-ui/src/app/api/payments/stripe/onboard/route.ts
@@ -7,7 +7,7 @@ import { NextRequest, NextResponse } from "next/server";
 const DEFAULT_COORD = process.env.NEXT_PUBLIC_COORDINATOR_URL || "https://api.darkbloom.dev";
 
 export async function POST(req: NextRequest) {
-  const coordUrl = req.headers.get("x-coordinator-url") || DEFAULT_COORD;
+  const coordUrl = DEFAULT_COORD;
 
   let authHeader = req.headers.get("authorization") || "";
   if (!authHeader) {

--- a/console-ui/src/app/api/payments/stripe/status/route.ts
+++ b/console-ui/src/app/api/payments/stripe/status/route.ts
@@ -6,7 +6,7 @@ import { NextRequest, NextResponse } from "next/server";
 const DEFAULT_COORD = process.env.NEXT_PUBLIC_COORDINATOR_URL || "https://api.darkbloom.dev";
 
 export async function GET(req: NextRequest) {
-  const coordUrl = req.headers.get("x-coordinator-url") || DEFAULT_COORD;
+  const coordUrl = DEFAULT_COORD;
 
   let authHeader = req.headers.get("authorization") || "";
   if (!authHeader) {

--- a/console-ui/src/app/api/payments/stripe/withdrawals/route.ts
+++ b/console-ui/src/app/api/payments/stripe/withdrawals/route.ts
@@ -6,7 +6,7 @@ import { NextRequest, NextResponse } from "next/server";
 const DEFAULT_COORD = process.env.NEXT_PUBLIC_COORDINATOR_URL || "https://api.darkbloom.dev";
 
 export async function GET(req: NextRequest) {
-  const coordUrl = req.headers.get("x-coordinator-url") || DEFAULT_COORD;
+  const coordUrl = DEFAULT_COORD;
 
   let authHeader = req.headers.get("authorization") || "";
   if (!authHeader) {

--- a/console-ui/src/app/api/payments/withdraw/stripe/route.ts
+++ b/console-ui/src/app/api/payments/withdraw/stripe/route.ts
@@ -7,7 +7,7 @@ import { NextRequest, NextResponse } from "next/server";
 const DEFAULT_COORD = process.env.NEXT_PUBLIC_COORDINATOR_URL || "https://api.darkbloom.dev";
 
 export async function POST(req: NextRequest) {
-  const coordUrl = req.headers.get("x-coordinator-url") || DEFAULT_COORD;
+  const coordUrl = DEFAULT_COORD;
 
   let authHeader = req.headers.get("authorization") || "";
   if (!authHeader) {

--- a/console-ui/src/app/api/telemetry/route.ts
+++ b/console-ui/src/app/api/telemetry/route.ts
@@ -11,7 +11,7 @@ const MAX_BODY = 64 * 1024;
 export const runtime = "nodejs";
 
 export async function POST(req: NextRequest) {
-  const coordUrl = req.headers.get("x-coordinator-url") || DEFAULT_COORD;
+  const coordUrl = DEFAULT_COORD;
 
   // Read with explicit size cap.
   const raw = await req.text();

--- a/console-ui/src/app/providers/earnings/EarningsContent.tsx
+++ b/console-ui/src/app/providers/earnings/EarningsContent.tsx
@@ -119,10 +119,10 @@ export default function EarningsContent() {
   const fetchEarnings = useCallback(async () => {
     setError(null);
     try {
+      // Coordinator URL is build-time pinned — bearer tokens must never
+      // follow a localStorage-derived origin (session poisoning).
       const coordinatorUrl =
-        localStorage.getItem("darkbloom_coordinator_url") ||
-        process.env.NEXT_PUBLIC_COORDINATOR_URL ||
-        "https://api.darkbloom.dev";
+        process.env.NEXT_PUBLIC_COORDINATOR_URL || "https://api.darkbloom.dev";
       const headers = await getAuthHeaders();
 
       const res = await fetch(

--- a/console-ui/src/components/providers/PrivyClientProvider.tsx
+++ b/console-ui/src/components/providers/PrivyClientProvider.tsx
@@ -6,6 +6,10 @@ import { PrivyProvider, usePrivy } from "@privy-io/react-auth";
 const PRIVY_APP_ID = process.env.NEXT_PUBLIC_PRIVY_APP_ID || "";
 const IS_PRIVY_CONFIGURED = PRIVY_APP_ID && PRIVY_APP_ID !== "placeholder";
 
+function isProductionEnv(): boolean {
+  return process.env.NODE_ENV === "production";
+}
+
 export interface AuthState {
   ready: boolean;
   authenticated: boolean;
@@ -97,6 +101,21 @@ export function PrivyClientProvider({
   children: React.ReactNode;
 }) {
   if (!IS_PRIVY_CONFIGURED) {
+    if (isProductionEnv()) {
+      return (
+        <div className="min-h-screen bg-bg-primary flex items-center justify-center p-4">
+          <div className="max-w-md w-full rounded-lg border border-red-800 bg-red-950/40 p-8 text-center">
+            <h1 className="text-lg font-semibold text-red-400 mb-2">
+              Authentication not configured
+            </h1>
+            <p className="text-sm text-red-300/80">
+              Authentication is not configured (NEXT_PUBLIC_PRIVY_APP_ID
+              missing). This deployment is misconfigured.
+            </p>
+          </div>
+        </div>
+      );
+    }
     return (
       <AuthContext.Provider value={MOCK_AUTH}>
         {children}

--- a/coordinator/api/install.sh
+++ b/coordinator/api/install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # NOTE: This file is also embedded in the coordinator binary via go:embed.
-# The copy at coordinator/internal/api/install.sh must be kept in sync.
+# Keep both installer copies in sync.
 set -euo pipefail
 
 # Darkbloom Provider Installer (Swift CLI release v0.5.0+)
@@ -11,8 +11,7 @@ set -euo pipefail
 #   2. Downloads the provider bundle (darkbloom + darkbloom-enclave + mlx.metallib)
 #   3. Verifies bundle SHA-256 + Apple Developer ID code signature
 #   4. Sets up the Secure Enclave identity
-#   5. Optionally enrolls in MDM (device attestation)
-#   6. Optionally downloads a starter model
+#   5. Kicks off MDM enrollment (non-blocking)
 #
 # Zero prerequisites — just macOS 14+ on Apple Silicon. The Swift CLI
 # links mlx-swift directly and ships a colocated mlx.metallib for Metal
@@ -56,7 +55,7 @@ echo "  $CHIP · ${MEM}GB · macOS $MACOS"
 echo ""
 
 # ─── Step 1: Fetch latest release ────────────────────────────
-echo "→ [1/5] Fetching latest release from $COORD_URL ..."
+echo "→ [1/4] Fetching latest release from $COORD_URL ..."
 
 RELEASE_JSON=$(curl -fsSL "$COORD_URL/v1/releases/latest" 2>/dev/null || echo "")
 if [ -z "$RELEASE_JSON" ]; then
@@ -86,7 +85,7 @@ echo "  Signed by: Developer ID Application: Eigen Labs, Inc."
 echo ""
 
 # ─── Step 2: Download + verify bundle ────────────────────────
-echo "→ [2/5] Downloading Darkbloom v${VERSION}..."
+echo "→ [2/4] Downloading Darkbloom v${VERSION}..."
 mkdir -p "$INSTALL_DIR" "$BIN_DIR"
 
 TARBALL="/tmp/darkbloom-bundle.tar.gz"
@@ -208,7 +207,7 @@ done
 
 # ─── Step 3: Secure Enclave identity ─────────────────────────
 echo ""
-echo "→ [3/5] Provisioning Secure Enclave identity..."
+echo "→ [3/4] Provisioning Secure Enclave identity..."
 if "$BIN_DIR/darkbloom-enclave" info >/dev/null 2>&1; then
     echo "  Secure Enclave ✓ (P-256 key generated)"
 else
@@ -217,7 +216,7 @@ fi
 
 # ─── Step 4: Enrollment + device attestation ─────────────────
 echo ""
-echo "→ [4/5] Enrollment + device attestation..."
+echo "→ [4/4] Enrollment + device attestation..."
 
 ALREADY_ENROLLED=false
 if profiles status -type enrollment 2>&1 | grep -q "MDM enrollment: Yes"; then
@@ -252,45 +251,13 @@ elif [ -n "$SERIAL" ]; then
         open "x-apple.systempreferences:com.apple.Profiles-Settings.extension"
 
         echo "  System Settings opened — click Install and enter your password."
-        if [ "$INTERACTIVE" = true ]; then
-            echo ""
-            read -p "  Press Enter once you have installed the profile..." || true
-        else
-            echo "  After installing, the provider will verify on first start."
-            sleep 3
-        fi
-        echo "  Enrollment ✓"
+        echo "  You can finish this now or later; the provider works either way."
+        sleep 2
     else
         echo "  Enrollment ⚠ (coordinator unreachable — enroll later with: darkbloom enroll)"
     fi
 else
     echo "  Enrollment ⚠ (could not read serial number — enroll later with: darkbloom enroll)"
-fi
-
-# ─── Step 5: Optional starter model ──────────────────────────
-echo ""
-echo "→ [5/5] Inference model..."
-
-CATALOG_JSON=$(curl -fsSL "$COORD_URL/v1/models/catalog?type=text" 2>/dev/null || echo "")
-
-if [ -n "$CATALOG_JSON" ]; then
-    if [ "$INTERACTIVE" = true ]; then
-        echo ""
-        echo "  Available text models:"
-        echo "$CATALOG_JSON" \
-          | tr ',' '\n' \
-          | sed -n 's/.*"id":"\([^"]*\)".*"display_name":"\([^"]*\)".*"size_gb":\([0-9.]*\).*"min_ram_gb":\([0-9]*\).*/  • \2  ~\3 GB  (≥\4 GB RAM)  [\1]/p' \
-          | head -20
-        echo ""
-        echo "  Download a model with:"
-        echo "    darkbloom models download <id>"
-    else
-        echo "  Run interactively to pick a starter model:"
-        echo "    curl -fsSL $COORD_URL/install.sh | bash -s"
-        echo "  Or list the catalog with:  darkbloom models catalog"
-    fi
-else
-    echo "  Could not fetch model catalog (continuing anyway)."
 fi
 
 # ─── Done ────────────────────────────────────────────────────
@@ -299,10 +266,7 @@ echo "╔═══════════════════════�
 echo "║  Install complete                            ║"
 echo "╚══════════════════════════════════════════════╝"
 echo ""
-echo "  Next steps:"
-echo "    darkbloom doctor             # verify the system is ready"
-echo "    darkbloom models catalog     # browse available models"
-echo "    darkbloom models download <id>"
-echo "    darkbloom login              # link this Mac to your account"
-echo "    darkbloom start              # serve inference (interactive picker)"
+echo "  Start serving:"
+echo ""
+echo "    source ~/.zshrc && darkbloom start"
 echo ""

--- a/coordinator/api/install_sh_test.go
+++ b/coordinator/api/install_sh_test.go
@@ -5,6 +5,9 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -107,6 +110,57 @@ func TestInstallScriptTemplating(t *testing.T) {
 			t.Error("install.sh does not install the Secure Enclave helper")
 		}
 	})
+}
+
+// TestInstallScriptNoDrift asserts that coordinator/api/install.sh and
+// scripts/install.sh are byte-for-byte identical after normalizing the single
+// intentional difference: the COORD_URL default line. In coordinator/api/install.sh
+// that line carries __DARKBLOOM_COORD_URL__ (substituted at serve time); in
+// scripts/install.sh it carries https://api.darkbloom.dev (direct-fetch default).
+// If someone edits one copy without the other this test fails.
+func TestInstallScriptNoDrift(t *testing.T) {
+	// Locate scripts/install.sh relative to this source file. runtime.Caller
+	// gives us the absolute path of the test file; walk up two directories to
+	// the repo root, then descend into scripts/.
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller(0) failed — cannot locate test source file")
+	}
+	// thisFile: .../coordinator/api/install_sh_test.go
+	// repoRoot: .../
+	repoRoot := filepath.Join(filepath.Dir(thisFile), "..", "..")
+	scriptsSrc := filepath.Join(repoRoot, "scripts", "install.sh")
+
+	scriptsSrcBytes, err := os.ReadFile(scriptsSrc)
+	if err != nil {
+		if os.IsNotExist(err) {
+			t.Skipf("scripts/install.sh not found at %s (vendored layout?); skipping drift check", scriptsSrc)
+		}
+		t.Fatalf("read scripts/install.sh: %v", err)
+	}
+
+	// installScript is the embedded coordinator/api/install.sh (package-level var).
+	embedded := string(installScript)
+	scriptsRef := string(scriptsSrcBytes)
+
+	// normalizeCoordURL replaces both the placeholder and the prod-URL default
+	// with a fixed token so the one intentional difference is invisible to the
+	// equality check.
+	normalizeCoordURL := func(s string) string {
+		s = strings.ReplaceAll(s, `COORD_URL="${COORD_URL:-__DARKBLOOM_COORD_URL__}"`, `COORD_URL="__NORMALIZED__"`)
+		s = strings.ReplaceAll(s, `COORD_URL="${COORD_URL:-https://api.darkbloom.dev}"`, `COORD_URL="__NORMALIZED__"`)
+		return s
+	}
+
+	embeddedNorm := normalizeCoordURL(embedded)
+	scriptsNorm := normalizeCoordURL(scriptsRef)
+
+	if embeddedNorm != scriptsNorm {
+		t.Errorf("coordinator/api/install.sh has drifted from scripts/install.sh\n" +
+			"Run: diff scripts/install.sh coordinator/api/install.sh\n" +
+			"The only intentional difference is the COORD_URL default line.\n" +
+			"Sync both copies before committing.")
+	}
 }
 
 func newTestServerWithBaseURL(t *testing.T, baseURL string) *httptest.Server {

--- a/coordinator/api/install_sh_test.go
+++ b/coordinator/api/install_sh_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strings"
 	"testing"
@@ -143,17 +144,18 @@ func TestInstallScriptNoDrift(t *testing.T) {
 	embedded := string(installScript)
 	scriptsRef := string(scriptsSrcBytes)
 
-	// normalizeCoordURL replaces both the placeholder and the prod-URL default
-	// with a fixed token so the one intentional difference is invisible to the
-	// equality check.
-	normalizeCoordURL := func(s string) string {
-		s = strings.ReplaceAll(s, `COORD_URL="${COORD_URL:-__DARKBLOOM_COORD_URL__}"`, `COORD_URL="__NORMALIZED__"`)
-		s = strings.ReplaceAll(s, `COORD_URL="${COORD_URL:-https://api.darkbloom.dev}"`, `COORD_URL="__NORMALIZED__"`)
-		return s
+	// The one intentional difference between the two copies is the COORD_URL
+	// default — the placeholder (__DARKBLOOM_COORD_URL__) in the embedded copy
+	// vs. the prod URL in scripts/install.sh. Collapse whatever the default is to
+	// a single token so the equality check ignores it (and so this test won't
+	// silently stop normalizing if the prod default ever changes).
+	coordURLDefault := regexp.MustCompile(`COORD_URL="\$\{COORD_URL:-[^}]*\}"`)
+	normalize := func(s string) string {
+		return coordURLDefault.ReplaceAllString(s, `COORD_URL="__NORMALIZED__"`)
 	}
 
-	embeddedNorm := normalizeCoordURL(embedded)
-	scriptsNorm := normalizeCoordURL(scriptsRef)
+	embeddedNorm := normalize(embedded)
+	scriptsNorm := normalize(scriptsRef)
 
 	if embeddedNorm != scriptsNorm {
 		t.Errorf("coordinator/api/install.sh has drifted from scripts/install.sh\n" +

--- a/coordinator/billing/config.go
+++ b/coordinator/billing/config.go
@@ -35,9 +35,8 @@ type Config struct {
 	// MockMode skips on-chain verification and auto-credits test balances.
 	// Set EIGENINFERENCE_BILLING_MOCK=true for testing without real payments.
 	//
-	// DAR-59: a boot-time tripwire (Config.Check) refuses to start when MockMode
-	// is enabled alongside real payment credentials (mnemonic or Stripe key).
-	// The full audit of remaining MockMode code paths is still tracked in DAR-59.
+	// A boot-time tripwire (Config.Check) refuses to start when MockMode is
+	// enabled alongside real payment credentials (mnemonic or Stripe key).
 	MockMode bool
 }
 
@@ -70,7 +69,7 @@ func ReadConfig() Config {
 
 // Check validates billing configuration invariants.
 //
-// Fail-closed tripwire (DAR-59): MockMode must never coexist with real payment
+// Fail-closed tripwire: MockMode must never coexist with real payment
 // credentials. A production deployment that accidentally sets
 // EIGENINFERENCE_BILLING_MOCK=true would silently skip on-chain Solana
 // verification and Stripe payment checks. By refusing to boot in that state we
@@ -81,14 +80,14 @@ func ReadConfig() Config {
 func (c Config) Check() error {
 	if c.MockMode && c.EncryptionMnemonic != "" {
 		return fmt.Errorf(
-			"billing mock mode is enabled but real payment credentials (Solana mnemonic) are configured — refusing to start (DAR-59); "+
+			"billing mock mode is enabled but real payment credentials (Solana mnemonic) are configured — refusing to start; "+
 				"unset MNEMONIC / %s_MNEMONIC / %s_SOLANA_MNEMONIC or disable %s_BILLING_MOCK",
 			env.EnvPrefix, env.EnvPrefix, env.EnvPrefix,
 		)
 	}
 	if c.MockMode && c.StripeSecretKey != "" {
 		return fmt.Errorf(
-			"billing mock mode is enabled but real payment credentials (Stripe secret key) are configured — refusing to start (DAR-59); "+
+			"billing mock mode is enabled but real payment credentials (Stripe secret key) are configured — refusing to start; "+
 				"unset %s_STRIPE_SECRET_KEY or disable %s_BILLING_MOCK",
 			env.EnvPrefix, env.EnvPrefix,
 		)

--- a/coordinator/billing/config.go
+++ b/coordinator/billing/config.go
@@ -25,8 +25,8 @@ type Config struct {
 	StripeConnectRefreshURL      string // where Stripe redirects if the link expires
 
 	// EncryptionMnemonic is a BIP39 mnemonic phrase used to derive the
-	// coordinator's X25519 encryption key (via HKDF) for sender→coordinator
-	// E2E request encryption (e2e.DeriveCoordinatorKey).
+	// coordinator's X25519 encryption key (via HKDF) for optional
+	// sender→coordinator request sealing (e2e.DeriveCoordinatorKey).
 	EncryptionMnemonic string
 
 	// Referral
@@ -35,8 +35,9 @@ type Config struct {
 	// MockMode skips on-chain verification and auto-credits test balances.
 	// Set EIGENINFERENCE_BILLING_MOCK=true for testing without real payments.
 	//
-	// TODO(linear): audit MockMode code paths — accidental enablement in a real
-	// deployment could silently skip payment verification. Tracked as DAR-59.
+	// DAR-59: a boot-time tripwire (Config.Check) refuses to start when MockMode
+	// is enabled alongside real payment credentials (mnemonic or Stripe key).
+	// The full audit of remaining MockMode code paths is still tracked in DAR-59.
 	MockMode bool
 }
 
@@ -67,13 +68,30 @@ func ReadConfig() Config {
 	return cfg
 }
 
-// Check validates billing configuration invariants. At minimum it prevents
-// MockMode from coexisting with real Stripe credentials — accidental mock
-// enablement in a production deployment with live keys would silently skip
-// payment verification.
+// Check validates billing configuration invariants.
+//
+// Fail-closed tripwire (DAR-59): MockMode must never coexist with real payment
+// credentials. A production deployment that accidentally sets
+// EIGENINFERENCE_BILLING_MOCK=true would silently skip on-chain Solana
+// verification and Stripe payment checks. By refusing to boot in that state we
+// convert a silent exploit path into a loud startup failure.
+//
+// Dev/test environments that legitimately use MockMode have no real credentials,
+// so this check is a no-op for them.
 func (c Config) Check() error {
+	if c.MockMode && c.EncryptionMnemonic != "" {
+		return fmt.Errorf(
+			"billing mock mode is enabled but real payment credentials (Solana mnemonic) are configured — refusing to start (DAR-59); "+
+				"unset MNEMONIC / %s_MNEMONIC / %s_SOLANA_MNEMONIC or disable %s_BILLING_MOCK",
+			env.EnvPrefix, env.EnvPrefix, env.EnvPrefix,
+		)
+	}
 	if c.MockMode && c.StripeSecretKey != "" {
-		return fmt.Errorf("billing mock mode is enabled but a real Stripe secret key is configured — these are mutually exclusive; unset %s_STRIPE_SECRET_KEY or disable %s_BILLING_MOCK", env.EnvPrefix, env.EnvPrefix)
+		return fmt.Errorf(
+			"billing mock mode is enabled but real payment credentials (Stripe secret key) are configured — refusing to start (DAR-59); "+
+				"unset %s_STRIPE_SECRET_KEY or disable %s_BILLING_MOCK",
+			env.EnvPrefix, env.EnvPrefix,
+		)
 	}
 	return nil
 }

--- a/coordinator/billing/config_test.go
+++ b/coordinator/billing/config_test.go
@@ -72,20 +72,7 @@ func TestCheckMockModeTripwire(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			// Isolate env state: clear all billing-related vars, then set the
-			// ones for this case.  t.Setenv restores on cleanup automatically.
-			for _, key := range []string{
-				prefix + "_BILLING_MOCK",
-				prefix + "_SOLANA_MNEMONIC",
-				prefix + "_MNEMONIC",
-				"MNEMONIC",
-				prefix + "_STRIPE_SECRET_KEY",
-			} {
-				t.Setenv(key, "")
-			}
-			for k, v := range tc.envs {
-				t.Setenv(k, v)
-			}
+			setBillingEnv(t, prefix, tc.envs)
 
 			cfg := ReadConfig()
 			err := cfg.Check()
@@ -100,5 +87,24 @@ func TestCheckMockModeTripwire(t *testing.T) {
 				t.Fatalf("error message %q does not contain expected fragment %q", err.Error(), tc.errFrag)
 			}
 		})
+	}
+}
+
+// setBillingEnv isolates env state for one case: it clears every billing-related
+// var (so cases can't leak into each other) and then applies the case's vars.
+// t.Setenv restores all of them on test cleanup.
+func setBillingEnv(t *testing.T, prefix string, envs map[string]string) {
+	t.Helper()
+	for _, key := range []string{
+		prefix + "_BILLING_MOCK",
+		prefix + "_SOLANA_MNEMONIC",
+		prefix + "_MNEMONIC",
+		"MNEMONIC",
+		prefix + "_STRIPE_SECRET_KEY",
+	} {
+		t.Setenv(key, "")
+	}
+	for k, v := range envs {
+		t.Setenv(k, v)
 	}
 }

--- a/coordinator/billing/config_test.go
+++ b/coordinator/billing/config_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/eigeninference/d-inference/coordinator/env"
 )
 
-// TestCheckMockModeTripwire exercises the DAR-59 fail-closed guard in
+// TestCheckMockModeTripwire exercises the fail-closed mock-mode guard in
 // Config.Check via ReadConfig so that the real env-var→Config path is covered
 // (not a hand-built Config struct that could drift from ReadConfig).
 //
@@ -40,7 +40,7 @@ func TestCheckMockModeTripwire(t *testing.T) {
 				prefix + "_SOLANA_MNEMONIC": "word1 word2 word3 word4 word5 word6 word7 word8 word9 word10 word11 word12",
 			},
 			wantErr: true,
-			errFrag: "DAR-59",
+			errFrag: "refusing to start",
 		},
 		{
 			name: "(b2) mock + bare MNEMONIC env — must error",
@@ -49,7 +49,7 @@ func TestCheckMockModeTripwire(t *testing.T) {
 				"MNEMONIC":               "word1 word2 word3 word4 word5 word6 word7 word8 word9 word10 word11 word12",
 			},
 			wantErr: true,
-			errFrag: "DAR-59",
+			errFrag: "refusing to start",
 		},
 		{
 			name: "(c) mock + Stripe secret key — must error",
@@ -58,7 +58,7 @@ func TestCheckMockModeTripwire(t *testing.T) {
 				prefix + "_STRIPE_SECRET_KEY": "sk_live_fakekeyfortest",
 			},
 			wantErr: true,
-			errFrag: "DAR-59",
+			errFrag: "refusing to start",
 		},
 		{
 			name: "(d) no mock + real creds — production baseline — OK",

--- a/coordinator/billing/config_test.go
+++ b/coordinator/billing/config_test.go
@@ -1,0 +1,104 @@
+package billing
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/eigeninference/d-inference/coordinator/env"
+)
+
+// TestCheckMockModeTripwire exercises the DAR-59 fail-closed guard in
+// Config.Check via ReadConfig so that the real env-var→Config path is covered
+// (not a hand-built Config struct that could drift from ReadConfig).
+//
+// Table layout:
+//
+//	(a) mock + no real creds  → loads fine
+//	(b) mock + mnemonic set   → error
+//	(c) mock + stripe key set → error
+//	(d) no mock + real creds  → loads fine (production baseline)
+func TestCheckMockModeTripwire(t *testing.T) {
+	prefix := env.EnvPrefix // "EIGENINFERENCE"
+
+	cases := []struct {
+		name    string
+		envs    map[string]string
+		wantErr bool
+		errFrag string // substring that must appear in the error message
+	}{
+		{
+			name: "(a) mock only — no real creds — OK",
+			envs: map[string]string{
+				prefix + "_BILLING_MOCK": "true",
+			},
+			wantErr: false,
+		},
+		{
+			name: "(b) mock + Solana mnemonic — must error",
+			envs: map[string]string{
+				prefix + "_BILLING_MOCK":    "true",
+				prefix + "_SOLANA_MNEMONIC": "word1 word2 word3 word4 word5 word6 word7 word8 word9 word10 word11 word12",
+			},
+			wantErr: true,
+			errFrag: "DAR-59",
+		},
+		{
+			name: "(b2) mock + bare MNEMONIC env — must error",
+			envs: map[string]string{
+				prefix + "_BILLING_MOCK": "true",
+				"MNEMONIC":               "word1 word2 word3 word4 word5 word6 word7 word8 word9 word10 word11 word12",
+			},
+			wantErr: true,
+			errFrag: "DAR-59",
+		},
+		{
+			name: "(c) mock + Stripe secret key — must error",
+			envs: map[string]string{
+				prefix + "_BILLING_MOCK":      "true",
+				prefix + "_STRIPE_SECRET_KEY": "sk_live_fakekeyfortest",
+			},
+			wantErr: true,
+			errFrag: "DAR-59",
+		},
+		{
+			name: "(d) no mock + real creds — production baseline — OK",
+			envs: map[string]string{
+				prefix + "_SOLANA_MNEMONIC":   "word1 word2 word3 word4 word5 word6 word7 word8 word9 word10 word11 word12",
+				prefix + "_STRIPE_SECRET_KEY": "sk_live_fakekeyfortest",
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Isolate env state: clear all billing-related vars, then set the
+			// ones for this case.  t.Setenv restores on cleanup automatically.
+			for _, key := range []string{
+				prefix + "_BILLING_MOCK",
+				prefix + "_SOLANA_MNEMONIC",
+				prefix + "_MNEMONIC",
+				"MNEMONIC",
+				prefix + "_STRIPE_SECRET_KEY",
+			} {
+				t.Setenv(key, "")
+			}
+			for k, v := range tc.envs {
+				t.Setenv(k, v)
+			}
+
+			cfg := ReadConfig()
+			err := cfg.Check()
+
+			if tc.wantErr && err == nil {
+				t.Fatalf("expected an error but Check() returned nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("expected no error but Check() returned: %v", err)
+			}
+			if tc.wantErr && tc.errFrag != "" && !strings.Contains(err.Error(), tc.errFrag) {
+				t.Fatalf("error message %q does not contain expected fragment %q", err.Error(), tc.errFrag)
+			}
+		})
+	}
+}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # NOTE: This file is also embedded in the coordinator binary via go:embed.
-# The copy at coordinator/internal/api/install.sh must be kept in sync.
+# Keep both installer copies in sync.
 set -euo pipefail
 
 # Darkbloom Provider Installer (Swift CLI release v0.5.0+)


### PR DESCRIPTION
Frontend + ops security hardening, split out from a larger working tree (PR 1 of 2).

## SEC-001 / SEC-002 — SSRF + credential forwarding
The six Next proxy routes (stripe checkout/status/onboard/withdrawals, withdraw/stripe, telemetry) and the provider Earnings page no longer honor the client-supplied `x-coordinator-url` header / localStorage coordinator URL. They pin to the build-time `NEXT_PUBLIC_COORDINATOR_URL`, so Privy session cookies / API bearer tokens can no longer be forwarded to an attacker-supplied origin.

## Privy production guard
A production build missing or carrying a `"placeholder"` `NEXT_PUBLIC_PRIVY_APP_ID` now renders a config-error screen instead of silently serving mock-authenticated UI.

## install.sh drift
`coordinator/api/install.sh` (served to providers via `//go:embed`) is synced with `scripts/install.sh`, and `TestInstallScriptNoDrift` now fails if they diverge.

## DAR-59 — billing MockMode boot guard
The coordinator refuses to boot when billing mock mode is enabled alongside real payment credentials (mnemonic / Stripe key) — a silent payment-bypass becomes a loud startup failure.

## Tests
- vitest: `coordinator-url-pinning`, `earnings-url-pinning`, `privy-client-provider` (250/250 suite green, eslint clean)
- Go: `TestInstallScriptNoDrift`, MockMode boot-guard table test
- All regression tests revert-verified (fail without the fix).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/316"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783746404&installation_id=133247490&pr_number=316&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F316&signature=493cd93a5bca06acfbaa425cc91611b5de1afcbee0fd42bdc3fb75f9d217cedf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->