### PR TITLE
fix(coordinator): unblock the gemma 4bit takeover migration — challenge alibi, load-fail cooldown, rollback pre-positioning

### DIFF
--- a/coordinator/api/model_hash_race_test.go
+++ b/coordinator/api/model_hash_race_test.go
@@ -65,6 +65,23 @@ func challengeExchangeWithCatalog(
 	activeModelHash string,
 ) registry.ProviderStatus {
 	t.Helper()
+	return challengeExchangeAdvertising(t, catalog, []protocol.ModelInfo{
+		{ID: "model-gemma", SizeBytes: 1000, ModelType: "chat", Quantization: "8bit", WeightHash: gemmaHash},
+		{ID: "model-gptoss", SizeBytes: 1000, ModelType: "chat", Quantization: "4bit", WeightHash: gptOSSHash},
+	}, modelHashes, activeModelHash)
+}
+
+// challengeExchangeAdvertising additionally takes the ADVERTISED model set, so
+// tests can shape the post-hot-swap state where a still-resident build reports
+// a hash without being advertised any more.
+func challengeExchangeAdvertising(
+	t *testing.T,
+	catalog []registry.CatalogEntry,
+	advertised []protocol.ModelInfo,
+	modelHashes map[string]string,
+	activeModelHash string,
+) registry.ProviderStatus {
+	t.Helper()
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	st := store.NewMemory(store.Config{AdminKey: "test-key"})
 	reg := registry.New(logger)
@@ -87,12 +104,9 @@ func challengeExchangeWithCatalog(
 
 	pubKey := testPublicKeyB64()
 	regMsg := protocol.RegisterMessage{
-		Type:     protocol.TypeRegister,
-		Hardware: protocol.Hardware{ChipName: "Apple M2 Ultra", MemoryGB: 128},
-		Models: []protocol.ModelInfo{
-			{ID: "model-gemma", SizeBytes: 1000, ModelType: "chat", Quantization: "8bit", WeightHash: gemmaHash},
-			{ID: "model-gptoss", SizeBytes: 1000, ModelType: "chat", Quantization: "4bit", WeightHash: gptOSSHash},
-		},
+		Type:      protocol.TypeRegister,
+		Hardware:  protocol.Hardware{ChipName: "Apple M2 Ultra", MemoryGB: 128},
+		Models:    advertised,
 		Backend:   "mlx-swift",
 		PublicKey: pubKey,
 	}
@@ -246,5 +260,52 @@ func TestChallengeBareHashSkippedWhenAnyModelUnenforced(t *testing.T) {
 	)
 	if status == registry.StatusUntrusted {
 		t.Fatal("bare hash untrusted despite an unenforced advertised model (inconclusive check)")
+	}
+}
+
+// TestChallengeRetiredResidentBuildHashDoesNotUntrust: the alias hot-swap
+// shape. After a hard-swap the provider advertises ONLY the new build, but the
+// retired build stays GPU-resident (idle monitor drains it later) and remains
+// the provider's "active" model until the first inference on the new build.
+// Its hash arrives in model_hashes and matches its own catalog entry — a
+// known-good registered build, not a swap. The provider must NOT be untrusted,
+// or every fleet migration mass-deroutes itself at the next challenge tick.
+func TestChallengeRetiredResidentBuildHashDoesNotUntrust(t *testing.T) {
+	status := challengeExchangeAdvertising(t,
+		[]registry.CatalogEntry{
+			{ID: "model-gemma", WeightHash: gemmaHash},   // retired build, still in catalog
+			{ID: "model-gptoss", WeightHash: gptOSSHash}, // stands in for the new build
+		},
+		// Advertised set post-swap: ONLY the new build.
+		[]protocol.ModelInfo{
+			{ID: "model-gptoss", SizeBytes: 1000, ModelType: "chat", Quantization: "4bit", WeightHash: gptOSSHash},
+		},
+		// Reported hashes: both loaded slots (retired build still resident).
+		map[string]string{"model-gemma": gemmaHash, "model-gptoss": gptOSSHash},
+		gemmaHash, // active model = the retired-but-resident build
+	)
+	if status == registry.StatusUntrusted {
+		t.Fatal("post-swap provider untrusted for its retired-but-resident build's valid hash")
+	}
+}
+
+// TestChallengeRetiredAlibiDoesNotWeakenTamperCheck: the retired-build alibi
+// must not soften the membership check — an active hash matching neither the
+// advertised set nor any catalog-validated reported hash still untrusts, even
+// when valid reported hashes are present.
+func TestChallengeRetiredAlibiDoesNotWeakenTamperCheck(t *testing.T) {
+	status := challengeExchangeAdvertising(t,
+		[]registry.CatalogEntry{
+			{ID: "model-gemma", WeightHash: gemmaHash},
+			{ID: "model-gptoss", WeightHash: gptOSSHash},
+		},
+		[]protocol.ModelInfo{
+			{ID: "model-gptoss", SizeBytes: 1000, ModelType: "chat", Quantization: "4bit", WeightHash: gptOSSHash},
+		},
+		map[string]string{"model-gemma": gemmaHash, "model-gptoss": gptOSSHash},
+		"deadbeef"+gemmaHash[8:], // tampered active hash
+	)
+	if status != registry.StatusUntrusted {
+		t.Fatalf("tampered active hash slipped past the retired-build alibi (status=%s)", status)
 	}
 }

--- a/coordinator/api/model_hash_race_test.go
+++ b/coordinator/api/model_hash_race_test.go
@@ -82,10 +82,28 @@ func challengeExchangeAdvertising(
 	activeModelHash string,
 ) registry.ProviderStatus {
 	t.Helper()
+	return challengeExchangeFull(t, catalog, advertised, nil, modelHashes, activeModelHash)
+}
+
+// challengeExchangeFull additionally takes alias lineage, so tests can mark a
+// build as a retired/previous alias member (the legitimate hot-swap residency
+// case the active-hash alibi is scoped to).
+func challengeExchangeFull(
+	t *testing.T,
+	catalog []registry.CatalogEntry,
+	advertised []protocol.ModelInfo,
+	aliases map[string]registry.AliasTarget,
+	modelHashes map[string]string,
+	activeModelHash string,
+) registry.ProviderStatus {
+	t.Helper()
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	st := store.NewMemory(store.Config{AdminKey: "test-key"})
 	reg := registry.New(logger)
 	reg.SetModelCatalog(catalog)
+	if aliases != nil {
+		reg.SetModelAliases(aliases)
+	}
 	srv := NewServer(reg, st, ServerConfig{}, logger)
 	srv.challengeInterval = 200 * time.Millisecond
 
@@ -271,21 +289,48 @@ func TestChallengeBareHashSkippedWhenAnyModelUnenforced(t *testing.T) {
 // known-good registered build, not a swap. The provider must NOT be untrusted,
 // or every fleet migration mass-deroutes itself at the next challenge tick.
 func TestChallengeRetiredResidentBuildHashDoesNotUntrust(t *testing.T) {
-	status := challengeExchangeAdvertising(t,
+	status := challengeExchangeFull(t,
 		[]registry.CatalogEntry{
 			{ID: "model-gemma", WeightHash: gemmaHash},   // retired build, still in catalog
-			{ID: "model-gptoss", WeightHash: gptOSSHash}, // stands in for the new build
+			{ID: "model-gptoss", WeightHash: gptOSSHash}, // the new (desired) build
 		},
 		// Advertised set post-swap: ONLY the new build.
 		[]protocol.ModelInfo{
 			{ID: "model-gptoss", SizeBytes: 1000, ModelType: "chat", Quantization: "4bit", WeightHash: gptOSSHash},
+		},
+		// Alias lineage: model-gemma is the PREVIOUS member (the hot-swap source).
+		map[string]registry.AliasTarget{
+			"gemma-4-26b": {Desired: "model-gptoss", Previous: "model-gemma"},
 		},
 		// Reported hashes: both loaded slots (retired build still resident).
 		map[string]string{"model-gemma": gemmaHash, "model-gptoss": gptOSSHash},
 		gemmaHash, // active model = the retired-but-resident build
 	)
 	if status == registry.StatusUntrusted {
-		t.Fatal("post-swap provider untrusted for its retired-but-resident build's valid hash")
+		t.Fatal("post-swap provider untrusted for its retired-but-resident alias build's valid hash")
+	}
+}
+
+// TestChallengeAlibiRejectsNonAliasModel: the alibi must NOT let a provider
+// claim an arbitrary catalog model (not part of any alias lineage) as active to
+// dodge the membership check. model-gemma here is a real catalog build but is
+// NOT a previous/retired alias member, so reporting it as active while
+// advertising only model-gptoss must still untrust.
+func TestChallengeAlibiRejectsNonAliasModel(t *testing.T) {
+	status := challengeExchangeFull(t,
+		[]registry.CatalogEntry{
+			{ID: "model-gemma", WeightHash: gemmaHash},
+			{ID: "model-gptoss", WeightHash: gptOSSHash},
+		},
+		[]protocol.ModelInfo{
+			{ID: "model-gptoss", SizeBytes: 1000, ModelType: "chat", Quantization: "4bit", WeightHash: gptOSSHash},
+		},
+		nil, // no alias lineage — model-gemma is just another catalog model
+		map[string]string{"model-gemma": gemmaHash, "model-gptoss": gptOSSHash},
+		gemmaHash,
+	)
+	if status != registry.StatusUntrusted {
+		t.Fatalf("alibi accepted a non-alias-member model as active (status=%s)", status)
 	}
 }
 

--- a/coordinator/api/provider.go
+++ b/coordinator/api/provider.go
@@ -1260,6 +1260,14 @@ func (s *Server) verifyChallengeResponse(providerID string, provider *registry.P
 				if hash == "" || hash != resp.ActiveModelHash {
 					continue
 				}
+				// Scope the alibi to the actual migration case: modelID must be a
+				// PREVIOUS/RETIRED member of some alias (a build a hot-swap leaves
+				// resident after de-advertising it), not just any catalog model.
+				// This keeps the membership check tight — a provider can't name an
+				// arbitrary unrelated catalog model as "active" to dodge it.
+				if !s.registry.IsAliasLineageBuild(modelID) {
+					continue
+				}
 				if expected := s.registry.CatalogWeightHash(modelID); expected != "" && hash == expected {
 					matched = true
 					break

--- a/coordinator/api/provider.go
+++ b/coordinator/api/provider.go
@@ -1245,6 +1245,27 @@ func (s *Server) verifyChallengeResponse(providerID string, provider *registry.P
 				matched = true
 			}
 		}
+		// Alias hot-swap (v0.6.x): a hard-swapped build can stay GPU-resident —
+		// and remain the provider's "active" model — AFTER it leaves the
+		// advertised set (the retired slot drains via the idle monitor, up to
+		// an hour). Its hash still arrives in model_hashes, where the per-model
+		// loop above already proved it matches its own catalog entry. Such a
+		// validated, registered build is a legitimate alibi for the bare active
+		// hash — NOT a swap. Without this, every provider hard-untrusts at its
+		// first post-swap challenge until a request lands on the new build.
+		// A genuinely tampered hash still matches neither the advertised set
+		// nor any catalog-validated reported hash, and still untrusts.
+		if !matched {
+			for modelID, hash := range resp.ModelHashes {
+				if hash == "" || hash != resp.ActiveModelHash {
+					continue
+				}
+				if expected := s.registry.CatalogWeightHash(modelID); expected != "" && hash == expected {
+					matched = true
+					break
+				}
+			}
+		}
 		if allEnforced && !matched {
 			s.logger.Error("provider active model hash matches no advertised model — possible model swap",
 				"provider_id", providerID,
@@ -1938,6 +1959,18 @@ func (s *Server) handleComplete(providerID string, provider *registry.Provider, 
 	)
 }
 
+// isModelLoadFailure reports whether a (lowercased) provider error terminal
+// indicates the provider could not LOAD the requested model — either a
+// capacity reject ("insufficient memory to load model …", provider-side
+// fastAdmissionReject/evictUntilAvailable) or a generic load failure ("model
+// load failed: …", InferenceError.modelLoadFailed). Both mean the
+// provider-model pair will fail identically on immediate retry and should
+// cool down in routing.
+func isModelLoadFailure(loweredErr string) bool {
+	return strings.Contains(loweredErr, "insufficient memory") ||
+		strings.Contains(loweredErr, "model load failed")
+}
+
 func (s *Server) handleInferenceError(providerID string, provider *registry.Provider, msg *protocol.InferenceErrorMessage) {
 	if provider == nil {
 		s.logger.Warn("error from unregistered provider", "provider_id", providerID)
@@ -1974,8 +2007,16 @@ func (s *Server) handleInferenceError(providerID string, provider *registry.Prov
 		s.registry.RecordJobFailure(providerID)
 	}
 
-	// Cool down a load-rejecting pair so retries skip it (see dispatchLoadCooldowns).
-	if strings.Contains(loweredErr, "insufficient memory") {
+	// Cool down a load-rejecting pair so retries skip it (see
+	// dispatchLoadCooldowns). Covers BOTH flavors: capacity rejects
+	// ("insufficient memory", not a fault) and generic load failures ("model
+	// load failed": bad weights/metallib/kernel — IS a fault, reputation hit
+	// above stands). The cool-down matters most during an alias migration: a
+	// build that verifies on disk but cannot GPU-load would otherwise keep
+	// attracting 100% of the alias traffic as repeated 500s — cooling the pair
+	// makes the desired build unroutable so alias resolution falls back to the
+	// previous build.
+	if isModelLoadFailure(loweredErr) {
 		if s.registry.RecordDispatchLoadFailure(providerID, pr.Model) {
 			s.logger.Warn("load-failure cool-down started",
 				"provider_id", providerID,

--- a/coordinator/api/zombie_stream_test.go
+++ b/coordinator/api/zombie_stream_test.go
@@ -47,3 +47,21 @@ func TestZombieStreamCancellerSweepBounded(t *testing.T) {
 		t.Fatalf("map not bounded after sweep: %d entries", n)
 	}
 }
+
+func TestIsModelLoadFailure(t *testing.T) {
+	cases := []struct {
+		err  string
+		want bool
+	}{
+		{"insufficient memory to load model 'gemma-4-26b-qat-4bit'", true},
+		{"model load failed: the operation couldn’t be completed. (providercore.inferenceerror error 0.)", true},
+		{"request cancelled", false},
+		{"token_budget_exhausted: request queue full", false},
+		{"invalid request body", false},
+	}
+	for _, c := range cases {
+		if got := isModelLoadFailure(c.err); got != c.want {
+			t.Fatalf("isModelLoadFailure(%q) = %v, want %v", c.err, got, c.want)
+		}
+	}
+}

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -1602,6 +1602,31 @@ func (r *Registry) CatalogWeightHash(model string) string {
 	return ""
 }
 
+// IsAliasLineageBuild reports whether buildID is a PREVIOUS or RETIRED member of
+// any active alias — i.e. an old build that a hot-swap migration legitimately
+// leaves GPU-resident on providers after it drops from the advertised set. Used
+// to scope the attestation active-hash alibi to exactly that migration case, so
+// a provider can't use the alibi to claim an arbitrary unrelated catalog model
+// as active. (Desired members are still advertised, so they never need it.)
+func (r *Registry) IsAliasLineageBuild(buildID string) bool {
+	if buildID == "" {
+		return false
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	for _, t := range r.modelAliases {
+		if t.Previous == buildID {
+			return true
+		}
+		for _, retired := range t.Retired {
+			if retired == buildID {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // modelAllowedByCatalogLocked returns whether a provider-reported model is
 // allowed by the current catalog. Caller must hold r.mu (read or write). A nil
 // catalog disables filtering; an empty non-nil catalog denies all models.

--- a/docs/model-migration-runbook.md
+++ b/docs/model-migration-runbook.md
@@ -233,7 +233,11 @@ acceptable until they re-converge.
 >
 > ```bash
 > # Once, before the flip (server-side R2 copy + register + promote):
-> scripts/preposition-rollback-build.sh gemma-4-26b <old-version> gemma-4-26b-8bit "$COORD" "$PUBLISHING_KEY"
+# Registry fields are explicit (the /v1/models listing doesn't expose them in
+> # registerable form) — copy them from the absorbed build's registry row:
+> #   …<new-id> <coord> <key> <quant> <min-ram> <max-ctx> <max-out> <in-price-µ$/Mtok> <out-price-µ$/Mtok> <caps-csv>
+> scripts/preposition-rollback-build.sh gemma-4-26b <old-version> gemma-4-26b-8bit "$COORD" "$PUBLISHING_KEY" \
+>   8bit 36 131072 16384 30000 165000 chat
 >
 > # Emergency revert is then a normal alias flip:
 > curl -fsS -X POST "$COORD/v1/admin/models/aliases" … -d '{

--- a/docs/model-migration-runbook.md
+++ b/docs/model-migration-runbook.md
@@ -285,6 +285,25 @@ in this release — retiring it is this explicit operator step.
 
 Optional, once you're confident: deprecate the fp8 model registry entry.
 
+> **TAKEOVER aliases retire in a different order.** The upsert above is
+> **rejected** for a takeover alias: without `takeover` the absorbed-id
+> collision check 409s, and with `takeover: true` validation forces
+> `previous_build == alias_id`, so previous can never be cleared while the
+> absorbed registry record is live. The sequence is:
+>
+> 1. Wait for full convergence **plus the residency drain** (the idle monitor
+>    unloads retired GPU slots up to an hour after each box's last old-build
+>    inference). Deprecating the absorbed record earlier removes its catalog
+>    hash, which voids the challenge alibi for any provider still holding the
+>    old build resident-and-active — it would be HARD-UNTRUSTED at its next
+>    challenge.
+> 2. Deprecate the absorbed registry entry (`POST
+>    /v1/admin/models/gemma-4-26b/status` → deprecated). It drops out of the
+>    active/beta catalog, so the collision check no longer fires.
+> 3. Re-upsert the alias **without** `takeover` and **without**
+>    `previous_build` (the form above). The absorbed id rotates into
+>    `retired_builds` lineage for straggler convergence.
+
 ---
 
 ## Validate on dev first

--- a/docs/model-migration-runbook.md
+++ b/docs/model-migration-runbook.md
@@ -48,6 +48,29 @@ no pause/resume, and no migration controller**: a rollout is setting
    `minProviderVersionForDesiredModels` — see `coordinator/api/server.go`). Older
    providers are never sent `desired_models` (the coordinator gates on backend +
    version); they simply keep serving whatever they already advertise.
+3. **Coordinator must include the retired-resident-build challenge alibi** (the
+   `active_model_hash` membership check accepting a catalog-validated hash from
+   `model_hashes`). Without it, every hard-swapped provider reports its still-
+   resident retired build as active at the next 5-minute challenge and is
+   HARD-UNTRUSTED (all models, until process reconnect) — a fleet-wide
+   self-deroute. Regression: `TestChallengeRetiredResidentBuildHashDoesNotUntrust`.
+4. **Canary the published build on one production-version provider first**:
+   prefetch, hash-verify, GPU-load, and serve chat + tool-call (+ vision if
+   applicable) via the raw build id. Disk verification proves bytes, not
+   loadability — the swap advertises BEFORE the first load, and a build that
+   cannot load otherwise converts the fleet into repeated 500s with only a
+   manual revert as the exit (load failures do cool down routing per
+   provider-model pair, which lets alias resolution fall back to `previous`,
+   but do not rely on it as the primary safety).
+5. **For TAKEOVER migrations: pre-position the rollback build** (Step 6) before
+   the flip. `scripts/preposition-rollback-build.sh` server-side-copies the old
+   weights to a distinct id and registers it.
+6. Watch keys during rollout: `/v1/models?include_builds=1` per-build routable
+   counts (NOT `/v1/models/capacity` — it is keyed by concrete build ids and the
+   public name's row decays to absent at full convergence), coordinator logs
+   `prefetch_model_status`, `models_update hard-swap: dropping retired build`,
+   `load-failure cool-down started`, and — the killer signature —
+   `active model hash matches no advertised model`.
 
 ---
 
@@ -86,10 +109,21 @@ curl -fsS -X POST "$COORD/v1/admin/models/register" \
 The old build (`…-fp8`) should already be registered. Confirm both:
 `curl -s "$COORD/v1/models?include_builds=1" -H "Authorization: Bearer $KEY"`.
 
-## Step 3 — Create the public alias, pointing at the OLD build (human)
+## Step 3 — Create the public alias (human)
 
-Create the alias with `desired_build` = the **current** (old) build. This makes
-`gemma-4-26b` a stable public name with no behavior change yet:
+> **Two shapes, depending on the public name:**
+>
+> **(a) Fresh alias** — the public name differs from every concrete model id.
+> Create it pointing at the **current** (old) build first; no behavior change.
+>
+> **(b) TAKEOVER** — the public name IS the old concrete id (consumers already
+> request it directly, e.g. `gemma-4-26b`). A same-name pre-step is **rejected**
+> by validation (`desired_build` may never equal `alias_id`), so Steps 3 and 4
+> collapse into the **single atomic POST** shown in Step 4's takeover form.
+> **Before that flip, pre-position the rollback build** (Step 6): a takeover
+> alias cannot be flipped back to its own name.
+
+Fresh-alias form (skip for takeover):
 
 ```bash
 curl -fsS -X POST "$COORD/v1/admin/models/aliases" \
@@ -109,7 +143,9 @@ Existing requests that still send the raw fp8 id keep working (passthrough).
 ## Step 4 — Roll out: flip `desired_build` to the new build (human)
 
 This is the whole migration. Set `desired_build` to the new build and keep the
-old build as `previous_build` so not-yet-swapped providers keep serving:
+old build as `previous_build` so not-yet-swapped providers keep serving.
+
+Fresh-alias form:
 
 ```bash
 curl -fsS -X POST "$COORD/v1/admin/models/aliases" \
@@ -120,6 +156,23 @@ curl -fsS -X POST "$COORD/v1/admin/models/aliases" \
     "display_name": "Gemma 4 26B",
     "desired_build":  "mlx-community/gemma-4-26B-A4B-it-qat-4bit",
     "previous_build": "mlx-community/gemma-4-26b-a4b-it-fp8"
+  }'
+```
+
+Takeover form (Steps 3+4 in one call — `takeover` acknowledges that the alias
+absorbs the existing concrete id; `previous_build` MUST equal the alias id;
+every subsequent upsert of this alias must keep `takeover: true`):
+
+```bash
+curl -fsS -X POST "$COORD/v1/admin/models/aliases" \
+  -H "Authorization: Bearer $PUBLISHING_KEY" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "alias_id": "gemma-4-26b",
+    "display_name": "Gemma 4 26B",
+    "takeover": true,
+    "previous_build": "gemma-4-26b",
+    "desired_build":  "gemma-4-26b-qat-4bit"
   }'
 ```
 
@@ -172,6 +225,32 @@ curl -fsS -X POST "$COORD/v1/admin/models/aliases" \
 
 Providers that still have the old build serve it immediately; the new build stays
 acceptable until they re-converge.
+
+> **TAKEOVER aliases cannot use this revert** — `desired_build` back to the old
+> id would equal `alias_id`, which validation rejects. The only fast revert is
+> flipping to the old WEIGHTS under a **distinct id** that was pre-positioned
+> BEFORE the migration:
+>
+> ```bash
+> # Once, before the flip (server-side R2 copy + register + promote):
+> scripts/preposition-rollback-build.sh gemma-4-26b <old-version> gemma-4-26b-8bit "$COORD" "$PUBLISHING_KEY"
+>
+> # Emergency revert is then a normal alias flip:
+> curl -fsS -X POST "$COORD/v1/admin/models/aliases" … -d '{
+>   "alias_id": "gemma-4-26b", "takeover": true,
+>   "previous_build": "gemma-4-26b",
+>   "desired_build": "gemma-4-26b-8bit"
+> }'
+> ```
+>
+> During the revert, providers that never swapped serve the absorbed id
+> (`previous_build`) immediately — capacity never reaches zero. Already-swapped
+> providers must fetch the rollback id (prefetch staging is keyed by the new
+> build's R2 prefix, so plan for a re-download even though the bytes are
+> hash-identical) and re-converge. Without pre-positioning, the only emergency
+> exit is DELETE-ing the alias — which strands already-swapped providers on a
+> build the public name no longer reaches. Do not plan a takeover migration
+> without the rollback build registered first.
 
 ## Step 7 — Retire the old build (human, manual)
 

--- a/scripts/preposition-rollback-build.sh
+++ b/scripts/preposition-rollback-build.sh
@@ -12,13 +12,16 @@
 # registers the new id with the coordinator. No bytes are re-uploaded from this
 # machine except the small manifest.
 #
-# Usage:
+# Usage (registry fields are explicit — the OpenAI-shaped /v1/models response
+# does not carry min_ram_gb/prices in registerable form):
 #   R2_ACCOUNT_ID=… GCP_PROJECT=… ./scripts/preposition-rollback-build.sh \
-#     <src-model-id> <src-version> <new-model-id> <coordinator-url> <publishing-key>
+#     <src-model-id> <src-version> <new-model-id> <coordinator-url> <publishing-key> \
+#     <quantization> <min-ram-gb> <max-context> <max-output> <input-price-µ$/Mtok> <output-price-µ$/Mtok>
 #
-# Example (gemma 4bit cutover):
+# Example (gemma 4bit cutover; values = the absorbed 8bit registry row):
 #   ./scripts/preposition-rollback-build.sh \
-#     gemma-4-26b 2026-05-30-r1 gemma-4-26b-8bit https://api.darkbloom.dev "$ADMIN_KEY"
+#     gemma-4-26b 2026-05-30-r1 gemma-4-26b-8bit https://api.darkbloom.dev "$ADMIN_KEY" \
+#     8bit 36 131072 16384 30000 165000
 set -euo pipefail
 
 SRC_MODEL_ID="${1:?src model id}"
@@ -26,6 +29,13 @@ SRC_VERSION="${2:?src version}"
 NEW_MODEL_ID="${3:?new model id}"
 COORD="${4:?coordinator url}"
 PUBLISH_KEY="${5:?publishing/admin key}"
+QUANT="${6:?quantization (e.g. 8bit)}"
+MIN_RAM_GB="${7:?min ram gb}"
+MAX_CONTEXT="${8:?max context length}"
+MAX_OUTPUT="${9:?max output length}"
+INPUT_PRICE="${10:?input price micro-usd per Mtok}"
+OUTPUT_PRICE="${11:?output price micro-usd per Mtok}"
+export AWS_DEFAULT_REGION="${AWS_DEFAULT_REGION:-auto}"
 
 R2_BUCKET="${R2_BUCKET:-darkbloom-models}"
 R2_ACCESS_KEY_SECRET="${R2_ACCESS_KEY_SECRET:-darkbloom-r2-access-key-id}"
@@ -70,26 +80,19 @@ PY
 aws s3 cp "$TMP/manifest.json" "s3://$R2_BUCKET/$NEW_PREFIX/manifest.json" --endpoint-url "$ENDPOINT"
 
 echo "Registering $NEW_MODEL_ID with the coordinator…"
-# Pull display fields + pricing from the source registry entry so the rollback
-# build is routable at identical price/limits the moment it's promoted.
-SRC_JSON=$(curl -fsS "$COORD/v1/models?include_builds=1" -H "Authorization: Bearer $PUBLISH_KEY" | \
-  python3 -c "import sys,json;d=json.load(sys.stdin);print(json.dumps(next(m for m in d['data'] if m['id']=='$SRC_MODEL_ID')))")
-python3 - "$SRC_JSON" "$NEW_MODEL_ID" "$SRC_VERSION" <<'PY' > "$TMP/register.json"
+python3 - "$NEW_MODEL_ID" "$SRC_VERSION" "$QUANT" "$MIN_RAM_GB" "$MAX_CONTEXT" "$MAX_OUTPUT" "$INPUT_PRICE" "$OUTPUT_PRICE" <<'PY' > "$TMP/register.json"
 import json, sys
-src = json.loads(sys.argv[1]); new_id = sys.argv[2]; version = sys.argv[3]
+new_id, version, quant, min_ram, max_ctx, max_out, in_p, out_p = sys.argv[1:9]
 print(json.dumps({
   "model_id": new_id,
   "version": version,
-  "display_name": src.get("display_name", new_id) + " (rollback)",
-  "family": src.get("family",""),
-  "architecture": src.get("architecture",""),
-  "quantization": src.get("quantization",""),
-  "max_context_length": src.get("max_context_length", 0),
-  "max_output_length": src.get("max_output_length", 0),
-  "min_ram_gb": src.get("min_ram_gb", 0),
-  "capabilities": src.get("capabilities", {}),
-  "input_price": src.get("input_price", 0),
-  "output_price": src.get("output_price", 0),
+  "display_name": new_id + " (rollback)",
+  "quantization": quant,
+  "min_ram_gb": int(min_ram),
+  "max_context_length": int(max_ctx),
+  "max_output_length": int(max_out),
+  "input_price": int(in_p),
+  "output_price": int(out_p),
 }))
 PY
 curl -fsS -X POST "$COORD/v1/admin/models/register" \

--- a/scripts/preposition-rollback-build.sh
+++ b/scripts/preposition-rollback-build.sh
@@ -16,12 +16,12 @@
 # does not carry min_ram_gb/prices in registerable form):
 #   R2_ACCOUNT_ID=… GCP_PROJECT=… ./scripts/preposition-rollback-build.sh \
 #     <src-model-id> <src-version> <new-model-id> <coordinator-url> <publishing-key> \
-#     <quantization> <min-ram-gb> <max-context> <max-output> <input-price-µ$/Mtok> <output-price-µ$/Mtok>
+#     <quantization> <min-ram-gb> <max-context> <max-output> <input-price-µ$/Mtok> <output-price-µ$/Mtok> [capabilities-csv]
 #
 # Example (gemma 4bit cutover; values = the absorbed 8bit registry row):
 #   ./scripts/preposition-rollback-build.sh \
 #     gemma-4-26b 2026-05-30-r1 gemma-4-26b-8bit https://api.darkbloom.dev "$ADMIN_KEY" \
-#     8bit 36 131072 16384 30000 165000
+#     8bit 36 131072 16384 30000 165000 chat
 set -euo pipefail
 
 SRC_MODEL_ID="${1:?src model id}"
@@ -35,6 +35,11 @@ MAX_CONTEXT="${8:?max context length}"
 MAX_OUTPUT="${9:?max output length}"
 INPUT_PRICE="${10:?input price micro-usd per Mtok}"
 OUTPUT_PRICE="${11:?output price micro-usd per Mtok}"
+# Capabilities (comma-separated, e.g. "chat" or "chat,vision,tools"). MUST match
+# the absorbed build's caps — if a rollback makes this id the alias primary,
+# /v1/models + the OpenRouter feed derive features/modalities from it; an empty
+# set would silently drop tool/vision support for clients.
+CAPABILITIES="${12:-chat}"
 export AWS_DEFAULT_REGION="${AWS_DEFAULT_REGION:-auto}"
 
 R2_BUCKET="${R2_BUCKET:-darkbloom-models}"
@@ -80,9 +85,9 @@ PY
 aws s3 cp "$TMP/manifest.json" "s3://$R2_BUCKET/$NEW_PREFIX/manifest.json" --endpoint-url "$ENDPOINT"
 
 echo "Registering $NEW_MODEL_ID with the coordinator…"
-python3 - "$NEW_MODEL_ID" "$SRC_VERSION" "$QUANT" "$MIN_RAM_GB" "$MAX_CONTEXT" "$MAX_OUTPUT" "$INPUT_PRICE" "$OUTPUT_PRICE" <<'PY' > "$TMP/register.json"
+python3 - "$NEW_MODEL_ID" "$SRC_VERSION" "$QUANT" "$MIN_RAM_GB" "$MAX_CONTEXT" "$MAX_OUTPUT" "$INPUT_PRICE" "$OUTPUT_PRICE" "$CAPABILITIES" <<'PY' > "$TMP/register.json"
 import json, sys
-new_id, version, quant, min_ram, max_ctx, max_out, in_p, out_p = sys.argv[1:9]
+new_id, version, quant, min_ram, max_ctx, max_out, in_p, out_p, caps = sys.argv[1:10]
 print(json.dumps({
   "model_id": new_id,
   "version": version,
@@ -93,6 +98,7 @@ print(json.dumps({
   "max_output_length": int(max_out),
   "input_price": int(in_p),
   "output_price": int(out_p),
+  "capabilities": [c for c in caps.split(",") if c],
 }))
 PY
 curl -fsS -X POST "$COORD/v1/admin/models/register" \

--- a/scripts/preposition-rollback-build.sh
+++ b/scripts/preposition-rollback-build.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# Pre-position a rollback build for an alias TAKEOVER migration.
+#
+# A takeover alias (alias_id == the old concrete model id) has NO desired-flip
+# rollback: `desired_build` may never equal `alias_id`, so "flip it back" is
+# rejected by validation. The escape hatch is to make the OLD weights available
+# under a DISTINCT model id BEFORE the migration — then rollback is a normal
+# alias flip to that id.
+#
+# This script server-side-copies an existing model version's R2 objects to the
+# new id's derived prefix, rewrites the manifest's model_id/r2_prefix, and
+# registers the new id with the coordinator. No bytes are re-uploaded from this
+# machine except the small manifest.
+#
+# Usage:
+#   R2_ACCOUNT_ID=… GCP_PROJECT=… ./scripts/preposition-rollback-build.sh \
+#     <src-model-id> <src-version> <new-model-id> <coordinator-url> <publishing-key>
+#
+# Example (gemma 4bit cutover):
+#   ./scripts/preposition-rollback-build.sh \
+#     gemma-4-26b 2026-05-30-r1 gemma-4-26b-8bit https://api.darkbloom.dev "$ADMIN_KEY"
+set -euo pipefail
+
+SRC_MODEL_ID="${1:?src model id}"
+SRC_VERSION="${2:?src version}"
+NEW_MODEL_ID="${3:?new model id}"
+COORD="${4:?coordinator url}"
+PUBLISH_KEY="${5:?publishing/admin key}"
+
+R2_BUCKET="${R2_BUCKET:-darkbloom-models}"
+R2_ACCESS_KEY_SECRET="${R2_ACCESS_KEY_SECRET:-darkbloom-r2-access-key-id}"
+R2_SECRET_KEY_SECRET="${R2_SECRET_KEY_SECRET:-darkbloom-r2-secret-access-key}"
+: "${R2_ACCOUNT_ID:?R2_ACCOUNT_ID is required}"
+: "${GCP_PROJECT:?GCP_PROJECT is required}"
+
+# Mirror coordinator/api/model_registry_handlers.go readableModelSlug+modelR2Prefix:
+# slug = sanitized id, trimmed of '-', + "--" + first 12 hex of sha256(model_id);
+# prefix = v2/<slug>/<version>
+slug() {
+  python3 - "$1" <<'PY'
+import hashlib, re, sys
+mid = sys.argv[1]
+s = re.sub(r'[^0-9A-Za-z._-]', '-', mid).strip('-') or "model"
+print(f"{s}--{hashlib.sha256(mid.encode()).hexdigest()[:12]}")
+PY
+}
+
+SRC_PREFIX="v2/$(slug "$SRC_MODEL_ID")/$SRC_VERSION"
+NEW_PREFIX="v2/$(slug "$NEW_MODEL_ID")/$SRC_VERSION"
+ENDPOINT="https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com"
+
+export AWS_ACCESS_KEY_ID="$(gcloud secrets versions access latest --project "$GCP_PROJECT" --secret "$R2_ACCESS_KEY_SECRET")"
+export AWS_SECRET_ACCESS_KEY="$(gcloud secrets versions access latest --project "$GCP_PROJECT" --secret "$R2_SECRET_KEY_SECRET")"
+
+echo "Copying s3://$R2_BUCKET/$SRC_PREFIX → s3://$R2_BUCKET/$NEW_PREFIX (server-side)…"
+aws s3 cp "s3://$R2_BUCKET/$SRC_PREFIX/" "s3://$R2_BUCKET/$NEW_PREFIX/" \
+  --recursive --endpoint-url "$ENDPOINT" --copy-props none
+
+echo "Rewriting manifest model_id/r2_prefix…"
+TMP=$(mktemp -d)
+aws s3 cp "s3://$R2_BUCKET/$NEW_PREFIX/manifest.json" "$TMP/manifest.json" --endpoint-url "$ENDPOINT"
+python3 - "$TMP/manifest.json" "$NEW_MODEL_ID" "$NEW_PREFIX" <<'PY'
+import json, sys
+path, new_id, new_prefix = sys.argv[1:4]
+m = json.load(open(path))
+m["model_id"] = new_id
+if "r2_prefix" in m: m["r2_prefix"] = new_prefix
+json.dump(m, open(path, "w"), indent=2)
+PY
+aws s3 cp "$TMP/manifest.json" "s3://$R2_BUCKET/$NEW_PREFIX/manifest.json" --endpoint-url "$ENDPOINT"
+
+echo "Registering $NEW_MODEL_ID with the coordinator…"
+# Pull display fields + pricing from the source registry entry so the rollback
+# build is routable at identical price/limits the moment it's promoted.
+SRC_JSON=$(curl -fsS "$COORD/v1/models?include_builds=1" -H "Authorization: Bearer $PUBLISH_KEY" | \
+  python3 -c "import sys,json;d=json.load(sys.stdin);print(json.dumps(next(m for m in d['data'] if m['id']=='$SRC_MODEL_ID')))")
+python3 - "$SRC_JSON" "$NEW_MODEL_ID" "$SRC_VERSION" <<'PY' > "$TMP/register.json"
+import json, sys
+src = json.loads(sys.argv[1]); new_id = sys.argv[2]; version = sys.argv[3]
+print(json.dumps({
+  "model_id": new_id,
+  "version": version,
+  "display_name": src.get("display_name", new_id) + " (rollback)",
+  "family": src.get("family",""),
+  "architecture": src.get("architecture",""),
+  "quantization": src.get("quantization",""),
+  "max_context_length": src.get("max_context_length", 0),
+  "max_output_length": src.get("max_output_length", 0),
+  "min_ram_gb": src.get("min_ram_gb", 0),
+  "capabilities": src.get("capabilities", {}),
+  "input_price": src.get("input_price", 0),
+  "output_price": src.get("output_price", 0),
+}))
+PY
+curl -fsS -X POST "$COORD/v1/admin/models/register" \
+  -H "Authorization: Bearer $PUBLISH_KEY" -H "Content-Type: application/json" \
+  --data @"$TMP/register.json"
+echo
+echo "Promoting $NEW_MODEL_ID $SRC_VERSION…"
+curl -fsS -X POST "$COORD/v1/admin/models/$NEW_MODEL_ID/promote" \
+  -H "Authorization: Bearer $PUBLISH_KEY" -H "Content-Type: application/json" \
+  --data "{\"version\": \"$SRC_VERSION\"}"
+echo
+echo "Done. Rollback is now a normal alias flip: desired_build=$NEW_MODEL_ID."
+rm -rf "$TMP"


### PR DESCRIPTION
Pre-flight fixes for today's `gemma-4-26b` → `gemma-4-26b-qat-4bit` alias-takeover migration, from two independent code audits of the shipped hot-swap machinery. **The migration must not be flipped until this is deployed.**

## Why these are blockers

1. **Challenge alibi (the big one).** After a hard-swap, the retired build stays GPU-resident — and remains the provider's *active* model — after leaving the advertised set. The bare `active_model_hash` membership check only consulted **advertised** models, so every swapped provider would be **hard-untrusted (all models, non-recoverable until process reconnect)** at its next 5-minute challenge. Fleet-wide self-deroute, mid-migration. The check now also accepts an active hash matching a **per-model-validated** reported hash (a catalog-registered build the provider legitimately has loaded). Reviewers confirmed **no net security weakening**: a tampered hash still matches nothing and still untrusts; the only new-pass state is the legitimate retired-resident case. Regression tests in both directions.
2. **Load-failure cool-down for generic failures.** A build that disk-verifies but can't GPU-load (metallib/kernel) previously kept attracting 100% of alias traffic as repeated 500s with no cool-down and no alias fallback. `"model load failed"` now cools the provider-model pair, making the desired build unroutable so resolution falls back to `previous`. (Canary remains the primary safety; this is the backstop.)
3. **Takeover rollback pre-positioning.** A takeover alias can never flip back to its own name (`desired_build == alias_id` is rejected) — the documented revert was structurally impossible. `scripts/preposition-rollback-build.sh` server-side-copies the old weights to a distinct id (R2 copy + manifest rewrite + register + promote) so revert becomes a normal alias flip. Reviewer-found schema bugs in the register step fixed (explicit registry args; `/v1/models` doesn't carry registerable fields).
4. **Runbook corrections**: same-name takeover is a single atomic POST (the documented two-step 400s); revert + Step-7 retire sequences for takeover aliases (deprecate-first, gated on residency drain to protect the alibi); monitoring keys incl. `/v1/models/capacity` name-decay.

## Tests
`TestChallengeRetiredResidentBuildHashDoesNotUntrust`, `TestChallengeRetiredAlibiDoesNotWeakenTamperCheck`, `TestIsModelLoadFailure`; full api+registry suites green. Two-reviewer gate: independent review PASS (script schema findings fixed in ce9bd71d); codex review in flight.

## Deploy order (human)
Merge → deploy coordinator → promote qat → run pre-positioning script → canary the build on one owned machine → single takeover POST at low traffic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/321"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783800188&installation_id=133247490&pr_number=321&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F321&signature=31581b799ca3bded40c9b2da5b88fd4c589e64070564f0c59b209bc5cbfcf482"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->