### PR TITLE
Update Privacy Policy and ToS legal copy (June 2026)

### DIFF
--- a/landing/privacy.html
+++ b/landing/privacy.html
@@ -173,7 +173,7 @@
 
 <div class="legal-content">
   <h1>Privacy Policy</h1>
-  <p class="date">Updated: April 17, 2026</p>
+  <p class="date">Updated: June 10, 2026</p>
 
   <p class="lead">This Privacy Policy explains how Eigen Labs, Inc., operating the Darkbloom platform ("Eigen Labs," "Darkbloom," "we," "us," or "our") collects, uses, discloses, and otherwise processes personal information in connection with Darkbloom's websites, console, APIs, software, provider applications, hosted services, and related products and features (collectively, the "Services").</p>
 
@@ -297,6 +297,7 @@
     <p><strong>5.4 Selected providers.</strong> To fulfill inference requests, we disclose relevant Content to the provider selected to process the request. If you operate provider software, that means customer requests may be routed to your device subject to the Services' security and attestation controls.</p>
     <p><strong>5.5 Images and uploads.</strong> Generated images may be temporarily stored in service memory pending retrieval and delivery to the requesting user. These in-memory image uploads are removed after retrieval, but no system can guarantee perfect deletion or eliminate all risk.</p>
     <p><strong>5.6 Training.</strong> This Privacy Policy does not grant us a right to use your Content for general-purpose model training. If we decide to do so in the future, we will update this Privacy Policy and any related contractual terms before doing so, to the extent required by law.</p>
+    <p><strong>5.7 Third-party routing.</strong> If you access the Services through a third-party API aggregator or routing service such as OpenRouter, your requests may be processed by that third party before reaching our infrastructure. Third-party routing services operate as TLS-terminating proxies and may have technical access to your prompts and outputs in transit. Their handling of your data is governed by their own privacy policies, not ours. Darkbloom's privacy architecture applies only to the portion of the request path within our infrastructure.</p>
   </div>
 
   <div class="legal-section">

--- a/landing/terms.html
+++ b/landing/terms.html
@@ -173,7 +173,7 @@
 
 <div class="legal-content">
   <h1>Terms of Service</h1>
-  <p class="date">Updated: April 17, 2026</p>
+  <p class="date">Updated: June 10, 2026</p>
 
   <p class="lead">These Terms of Service ("Terms") are a legal agreement between you and Eigen Labs, Inc., operating the Darkbloom platform ("Eigen Labs," "Darkbloom," "we," "us," or "our") governing your access to and use of Darkbloom's websites, console, APIs, software, provider applications, downloads, hosted services, and related products and features (collectively, the "Services").</p>
 
@@ -193,7 +193,7 @@
 
   <div class="legal-section">
     <h2>2. The Services</h2>
-    <p>Darkbloom is a privacy-focused decentralized inference platform that enables consumers to submit AI inference requests processed on independently operated Apple hardware. The privacy properties of the Services depend on the security architecture described in our Privacy Policy and are subject to the limitations described therein, including the current absence of end-to-end encryption between consumer and provider. You should review the Privacy Policy carefully before submitting sensitive content to the Services.</p>
+    <p>Darkbloom is a privacy-focused decentralized inference platform that enables consumers to submit AI inference requests processed on independently operated Apple hardware. The privacy properties of the Services depend on the security architecture described in our Privacy Policy and are subject to the limitations described therein, including the current absence of end-to-end encryption between consumer and provider. You can find the Privacy Policy at <a href="https://www.darkbloom.dev/privacy.html">https://www.darkbloom.dev/privacy.html</a>. You should review the Privacy Policy carefully before submitting sensitive content to the Services.</p>
     <p>The Services may include:</p>
     <ul>
       <li>OpenAI-compatible and related API endpoints for text, image, audio, and other inference workloads;</li>
@@ -301,7 +301,7 @@
 
   <div class="legal-section">
     <h2>9. Privacy and Security</h2>
-    <p>Our Privacy Policy explains how we collect, use, disclose, and protect personal information. The Privacy Policy is incorporated into these Terms by reference. You can find the Privacy Policy at <a href="https://www.darkbloom.dev/privacy.html">https://www.darkbloom.dev/privacy.html</a>.</p>
+    <p>Our Privacy Policy explains how we collect, use, disclose, and protect personal information. The Privacy Policy is incorporated into these Terms by reference.</p>
     <p>You understand and agree that:</p>
     <ul>
       <li>the Services involve transmission, processing, and storage of Inputs, Outputs, and service metadata;</li>

--- a/landing/terms.html
+++ b/landing/terms.html
@@ -301,7 +301,7 @@
 
   <div class="legal-section">
     <h2>9. Privacy and Security</h2>
-    <p>Our Privacy Policy explains how we collect, use, disclose, and protect personal information. The Privacy Policy is incorporated into these Terms by reference.</p>
+    <p>Our Privacy Policy explains how we collect, use, disclose, and protect personal information. The Privacy Policy is incorporated into these Terms by reference. You can find the Privacy Policy at <a href="https://www.darkbloom.dev/privacy.html">https://www.darkbloom.dev/privacy.html</a>.</p>
     <p>You understand and agree that:</p>
     <ul>
       <li>the Services involve transmission, processing, and storage of Inputs, Outputs, and service metadata;</li>


### PR DESCRIPTION
Updates the public legal pages in `landing/` to match the canonical final drafts (Privacy Policy + Terms of Service `.docx`). **Verified by diffing each HTML against the source `.docx` — zero text differences remain.**

## Privacy Policy (`landing/privacy.html`)
- **Effective date** → `Updated: June 10, 2026`
- **New § 5.7 Third-party routing** (after § 5.6 Training): discloses that requests routed via third-party aggregators such as OpenRouter pass through TLS-terminating proxies that may have technical access to prompts/outputs in transit, governed by those parties' own privacy policies.

## Terms of Service (`landing/terms.html`)
- **Effective date** → `Updated: June 10, 2026`
- **§ 2 The Services** — adds the public Privacy Policy URL (`https://www.darkbloom.dev/privacy.html`) mid-paragraph, before "You should review the Privacy Policy carefully…" (rendered as a hyperlink; identical visible text to the doc).

## Verification
Reconciled against the canonical `.docx` files provided by the doc owner. A line-by-line diff of each rendered HTML page against its `.docx` now shows **no remaining text differences**. (An earlier revision of this PR placed the ToS URL sentence in § 9 and left the ToS date unchanged — both corrected here to match the source.)