### PR TITLE
Fix checkpoint KV restore crash guards

### DIFF
--- a/provider-swift/Sources/ProviderCore/Inference/BatchScheduler+EngineBridge.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/BatchScheduler+EngineBridge.swift
@@ -395,7 +395,8 @@ extension BatchScheduler {
         id: String,
         promptTokens: Int,
         maxTokens: Int,
-        admitted: Bool = false
+        admitted: Bool = false,
+        reservedTokens: Int? = nil
     ) {
         var bridge = BridgeState(
             requestId: id,
@@ -403,6 +404,7 @@ extension BatchScheduler {
             maxTokens: maxTokens,
             submittedAt: .now
         )
+        bridge.reservedTokens = reservedTokens
         if admitted { bridge.admittedAt = .now }
         activeBridges[id] = bridge
     }

--- a/provider-swift/Sources/ProviderCore/Inference/BatchScheduler+Telemetry.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/BatchScheduler+Telemetry.swift
@@ -52,7 +52,9 @@ extension BatchScheduler {
     /// is the value the P1 cumulative-budget gate in `submit()` checks
     /// against `tokenBudgetMax`.
     var activeTokenBudgetUsed: Int {
-        activeBridges.values.reduce(0) { $0 + $1.promptTokens + $1.maxTokens }
+        activeBridges.values.reduce(0) {
+            $0 + ($1.reservedTokens ?? ($1.promptTokens + $1.maxTokens))
+        }
     }
 
     var queuedTokenBudget: Int { pendingSummaryCache.queuedTokens }

--- a/provider-swift/Sources/ProviderCore/Inference/BatchScheduler.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/BatchScheduler.swift
@@ -81,6 +81,8 @@ public actor BatchScheduler {
     var checkpointManager: PrefixCacheManager?
     /// Sliding-window-derived checkpoint boundaries for the current model.
     var checkpointBoundaries: [Int] = []
+    /// Per-layer cache class/window signature for restore validation.
+    var checkpointLayerSignatures: [CheckpointLayerSignature] = []
 
     /// Engine-tier owner (EncryptedPrefixCachePersistence) for pure-
     /// attention models. Non-nil only when the model classifies as `.engine` AND
@@ -228,6 +230,7 @@ public actor BatchScheduler {
         self.engine = engine
         self.checkpointManager = build.checkpointManager
         self.checkpointBoundaries = build.checkpointBoundaries
+        self.checkpointLayerSignatures = build.checkpointLayerSignatures
         self.engineTierOwner = build.engineTierOwner
         await engine.start()
         // Final epoch check after start() — start can suspend too.
@@ -238,6 +241,7 @@ public actor BatchScheduler {
             if self.engine === engine { self.engine = nil }
             if self.checkpointManager === build.checkpointManager { self.checkpointManager = nil }
             if self.checkpointBoundaries == build.checkpointBoundaries { self.checkpointBoundaries = [] }
+            if self.checkpointLayerSignatures == build.checkpointLayerSignatures { self.checkpointLayerSignatures = [] }
             if self.engineTierOwner === build.engineTierOwner { self.engineTierOwner = nil }
             await engine.stop()
             return
@@ -280,6 +284,7 @@ public actor BatchScheduler {
             if self.engine === engine { self.engine = nil }
             if self.checkpointManager === build.checkpointManager { self.checkpointManager = nil }
             if self.checkpointBoundaries == build.checkpointBoundaries { self.checkpointBoundaries = [] }
+            if self.checkpointLayerSignatures == build.checkpointLayerSignatures { self.checkpointLayerSignatures = [] }
             if self.engineTierOwner === build.engineTierOwner { self.engineTierOwner = nil }
             await engine.stop()
             return
@@ -318,6 +323,7 @@ public actor BatchScheduler {
                     if self.engine === engine { self.engine = nil }
                     if self.checkpointManager === build.checkpointManager { self.checkpointManager = nil }
                     if self.checkpointBoundaries == build.checkpointBoundaries { self.checkpointBoundaries = [] }
+                    if self.checkpointLayerSignatures == build.checkpointLayerSignatures { self.checkpointLayerSignatures = [] }
                     if self.engineTierOwner === build.engineTierOwner { self.engineTierOwner = nil }
                     await engine.stop()
                     return
@@ -372,18 +378,215 @@ public actor BatchScheduler {
     /// persists token sequences across requests in process memory.
     /// Cross-tenant data-leak risk; do not enable without a fresh
     /// threat model.
+    private struct RestoredCheckpointAdmission {
+        let reservedTokens: Int
+    }
+
     /// Checkpoint-tier lookup: on a hit, attach the restored per-layer caches
     /// to the request so the scheduler decodes only the suffix. No-op when
     /// the checkpoint manager is nil (engine/none models, or flag off). Done
     /// in the async submit path because the engine step loop can't await the
-    /// manager actor. The tokenCount guard mirrors the scheduler's so a
-    /// degenerate hit (no suffix) is never attached.
-    private func maybeRestoreCheckpoint(_ req: Request, promptTokens: [Int], scope: String) async {
-        guard let mgr = checkpointManager else { return }
+    /// manager actor.
+    ///
+    /// MLX shape/runtime errors are fatal traps, not Swift throws. Validate the
+    /// restored checkpoint before it reaches `EngineCore.addRequest`; any
+    /// uncertainty becomes a cold prefill. The returned token count is the
+    /// memory reservation to charge if the restore is accepted.
+    private func maybeRestoreCheckpoint(
+        _ req: Request,
+        promptTokens: [Int],
+        scope: String
+    ) async -> RestoredCheckpointAdmission? {
+        guard let mgr = checkpointManager else { return nil }
         guard let hit = await mgr.lookup(tokens: promptTokens, scope: scope),
               hit.tokenCount >= 1, hit.tokenCount < promptTokens.count
-        else { return }
+        else { return nil }
+
+        guard Self.restoredCheckpointIsUsable(
+            caches: hit.caches,
+            expected: checkpointLayerSignatures,
+            tokenCount: hit.tokenCount,
+            promptTokenCount: promptTokens.count
+        ) else {
+            prefixCacheLogger.warning(
+                "prefix cache restore rejected: invalid checkpoint geometry; falling back to cold prefill")
+            return nil
+        }
+
         req.restoredCheckpoint = (caches: hit.caches, tokenCount: hit.tokenCount)
+        return RestoredCheckpointAdmission(
+            reservedTokens: restoredCheckpointReservedTokens(
+                caches: hit.caches,
+                promptTokenCount: promptTokens.count,
+                restoredTokenCount: hit.tokenCount,
+                maxTokens: req.maxTokens
+            )
+        )
+    }
+
+    static func restoredCheckpointIsUsable(
+        caches: [any KVCache],
+        expected: [CheckpointLayerSignature],
+        tokenCount: Int,
+        promptTokenCount: Int
+    ) -> Bool {
+        guard tokenCount >= 1, tokenCount < promptTokenCount else { return false }
+        guard caches.count == expected.count, !caches.isEmpty else { return false }
+
+        for (restored, signature) in zip(caches, expected) {
+            guard restoredLayerIsUsable(restored, expected: signature, tokenCount: tokenCount) else {
+                return false
+            }
+        }
+        return true
+    }
+
+    private static func restoredLayerIsUsable(
+        _ restored: any KVCache,
+        expected: CheckpointLayerSignature,
+        tokenCount: Int
+    ) -> Bool {
+        if restored is ArraysCache { return false }
+        if restored is ChunkedKVCache { return false }
+        if restored is QuantizedKVCache { return false }
+
+        guard let shape = restoredKVShape(restored) else { return false }
+
+        switch expected {
+        case .rotating(let window, let expectedShape):
+            guard let rot = restored as? RotatingKVCache, window > 0 else { return false }
+            guard let restoredWindow = rot.maxSize, restoredWindow == window else { return false }
+            guard restoredShapeMatches(shape, expected: expectedShape) else { return false }
+            let storedTokens = shape.tokenCount
+            let expectedStoredTokens = min(tokenCount, window)
+            return storedTokens == expectedStoredTokens
+        case .simple(let expectedShape):
+            guard let simple = restored as? KVCacheSimple, !(restored is RotatingKVCache) else {
+                return false
+            }
+            guard restoredShapeMatches(shape, expected: expectedShape) else { return false }
+            return simple.offset == tokenCount && shape.tokenCount == tokenCount
+        case .unsupported:
+            return false
+        }
+    }
+
+    private struct RestoredKVShape {
+        let tokenCount: Int
+        let kvHeads: Int
+        let headDim: Int
+    }
+
+    private static func restoredKVShape(_ cache: any KVCache) -> RestoredKVShape? {
+        let state = cache.state
+        guard state.count >= 2 else { return nil }
+        let k = state[0]
+        let v = state[1]
+        guard k.shape.count == 4, v.shape.count == 4 else { return nil }
+        guard k.dim(0) == 1, v.dim(0) == 1 else { return nil }
+        guard k.dim(1) == v.dim(1), k.dim(2) == v.dim(2) else { return nil }
+        guard k.dim(3) == v.dim(3) else { return nil }
+        guard k.dim(1) > 0, k.dim(2) > 0, k.dim(3) > 0 else { return nil }
+        return RestoredKVShape(tokenCount: k.dim(2), kvHeads: k.dim(1), headDim: k.dim(3))
+    }
+
+    private static func restoredShapeMatches(_ restored: RestoredKVShape, expected: CheckpointLayerShape?) -> Bool {
+        guard let expected else { return true }
+        return restored.kvHeads == expected.kvHeads && restored.headDim == expected.headDim
+    }
+
+    /// Reserve for the original request plus restored-KV materialization.
+    ///
+    /// A checkpoint hit can hold multiple live copies briefly: the RAM/SSD hit
+    /// copy returned by `PrefixCacheManager`, plus the B==1 batched cache that
+    /// MLX builds for decode. Charge those copies explicitly so a restore that
+    /// would fit as a cold prefill but not as restored KV is skipped before MLX
+    /// can hit a fatal `metal::malloc`.
+    private func restoredCheckpointReservedTokens(
+        caches: [any KVCache],
+        promptTokenCount: Int,
+        restoredTokenCount: Int,
+        maxTokens: Int
+    ) -> Int {
+        let requestTokens = promptTokenCount + maxTokens
+        guard kvBytesPerToken > 0 else { return requestTokens }
+        let restoredBytes = PrefixCacheRAM.byteSize(of: caches)
+        let extraRestoredCopies = 2
+        let chargedBytes = restoredBytes.multipliedReportingOverflow(by: extraRestoredCopies)
+        let restoredEquivalentTokens: Int
+        if chargedBytes.overflow {
+            restoredEquivalentTokens = Int.max
+        } else {
+            let roundedBytes = chargedBytes.partialValue.addingReportingOverflow(kvBytesPerToken - 1)
+            restoredEquivalentTokens = roundedBytes.overflow
+                ? Int.max
+                : roundedBytes.partialValue / kvBytesPerToken
+        }
+        let suffixAndOutputTokens = max(0, promptTokenCount - restoredTokenCount) + maxTokens
+        let restoredTotal = restoredEquivalentTokens.addingReportingOverflow(suffixAndOutputTokens)
+        return max(requestTokens, restoredTotal.overflow ? Int.max : restoredTotal.partialValue)
+    }
+
+    private func acceptRestoredCheckpointBudget(
+        requestId: String,
+        requestTokens: Int,
+        admission: RestoredCheckpointAdmission?,
+        req: Request
+    ) -> Int {
+        guard let admission, admission.reservedTokens > requestTokens else {
+            return requestTokens
+        }
+        let usedWithoutThis = max(0, activeTokenBudgetUsed - requestTokens)
+        let projected = usedWithoutThis.addingReportingOverflow(admission.reservedTokens)
+        guard !projected.overflow, projected.partialValue <= tokenBudgetMax else {
+            req.restoredCheckpoint = nil
+            prefixCacheLogger.warning(
+                "prefix cache restore skipped: restored KV exceeds token budget; falling back to cold prefill")
+            return requestTokens
+        }
+        if var bridge = activeBridges[requestId] {
+            bridge.reservedTokens = admission.reservedTokens
+            activeBridges[requestId] = bridge
+        }
+        return admission.reservedTokens
+    }
+
+    private func reserveKVForRequest(
+        requestId: String,
+        requestTokens: Int,
+        reservationTokens: Int,
+        req: Request
+    ) async -> Bool {
+        guard let kvBudget else { return true }
+        if await kvBudget.reserve(
+            requestID: requestId,
+            kvBytesPerToken: kvBytesPerToken,
+            tokenCount: reservationTokens
+        ) {
+            return true
+        }
+
+        // A restored checkpoint hit can require materially more headroom than
+        // a cold prefill because restored KV is already materialized. If that
+        // larger reservation fails, drop the restore and retry the normal
+        // request reservation so the cache miss is slow, not fatal.
+        guard req.restoredCheckpoint != nil, reservationTokens > requestTokens else {
+            return false
+        }
+
+        req.restoredCheckpoint = nil
+        if var bridge = activeBridges[requestId] {
+            bridge.reservedTokens = nil
+            activeBridges[requestId] = bridge
+        }
+        prefixCacheLogger.warning(
+            "prefix cache restore skipped: insufficient KV headroom; falling back to cold prefill")
+
+        return await kvBudget.reserve(
+            requestID: requestId,
+            kvBytesPerToken: kvBytesPerToken,
+            tokenCount: requestTokens
+        )
     }
 
     /// Stale-engine enqueue guard: `submit`/`submitTokenized` capture
@@ -466,9 +669,15 @@ public actor BatchScheduler {
     /// a manager with an in-memory KEK here to exercise the real
     /// submit→lookup→admit→capture path that the SE gate otherwise blocks.
     /// Must be called after `loadModel`. Not used in production.
-    func _installCheckpointManagerForTest(_ mgr: PrefixCacheManager, boundaries: [Int]) {
+    func _installCheckpointManagerForTest(_ mgr: PrefixCacheManager, boundaries: [Int]) async {
         self.checkpointManager = mgr
         self.checkpointBoundaries = boundaries
+        self.checkpointLayerSignatures = await modelContainer?.perform { ctx in
+            Self.checkpointLayerSignatures(
+                for: ctx.model.newCache(parameters: nil),
+                layerShapes: Self.probeLayerShapes(model: ctx.model)
+            )
+        } ?? []
         engine?.core.scheduler.checkpointBoundaries = boundaries
         engine?.core.scheduler.onCheckpointCapture = { prefixTokens, length, caches in
             let box = SendableKVCaches(caches)
@@ -487,6 +696,7 @@ public actor BatchScheduler {
         let engine: BatchedEngine
         let checkpointManager: PrefixCacheManager?
         let checkpointBoundaries: [Int]
+        let checkpointLayerSignatures: [CheckpointLayerSignature]
         let engineTierOwner: EncryptedPrefixCachePersistence?
     }
 
@@ -525,14 +735,16 @@ public actor BatchScheduler {
         let nowFn: @Sendable () -> Int64 = { Int64(Date().timeIntervalSince1970) }
 
         return await container.perform { ctx -> EngineBuild in
+            let cacheLayout = ctx.model.newCache(parameters: nil)
             // Classify from the model's own cache layout.
             let strategy = backing == nil
                 ? PrefixCacheStrategy.none
-                : PrefixCacheStrategy.classify(ctx.model.newCache(parameters: nil))
+                : PrefixCacheStrategy.classify(cacheLayout)
 
             var enginePrefixCache: PrefixCache? = nil
             var checkpointManager: PrefixCacheManager? = nil
             var boundaries: [Int] = []
+            var checkpointLayerSignatures: [CheckpointLayerSignature] = []
             // Capture the engine-tier owner for accountant registration.
             var engineTierOwner: EncryptedPrefixCachePersistence? = nil
 
@@ -559,7 +771,7 @@ public actor BatchScheduler {
                 case .checkpoint:
                     // Boundaries capped at the smallest sliding window so a
                     // snapshot never claims tokens a window has discarded.
-                    let window = PrefixCacheStrategy.minSlidingWindow(ctx.model.newCache(parameters: nil)) ?? 0
+                    let window = PrefixCacheStrategy.minSlidingWindow(cacheLayout) ?? 0
                     // TB-016 sub-feature A: lift ladder past window for proven
                     // families. Use modelId as the arch string (safe fallback;
                     // proven=false for unmatched families keeps today's ladder).
@@ -576,6 +788,10 @@ public actor BatchScheduler {
                     // (kvHeads, headDim) pair can't describe them and the
                     // load-time shape guard would reject the model's own files.
                     let layerShapes = Self.probeLayerShapes(model: ctx.model)
+                    checkpointLayerSignatures = Self.checkpointLayerSignatures(
+                        for: cacheLayout,
+                        layerShapes: layerShapes
+                    )
                     let checkpointBinding = PrefixCacheModelBinding(
                         modelHash: backing.binding.modelHash,
                         modelDtype: backing.binding.modelDtype,
@@ -664,6 +880,7 @@ public actor BatchScheduler {
                 ),
                 checkpointManager: checkpointManager,
                 checkpointBoundaries: boundaries,
+                checkpointLayerSignatures: checkpointLayerSignatures,
                 engineTierOwner: engineTierOwner
             )
         }
@@ -823,6 +1040,16 @@ public actor BatchScheduler {
             shapes.append([k.dim(1), k.dim(3)])  // [kvHeads, headDim]
         }
         return shapes
+    }
+
+    private static func checkpointLayerSignatures(
+        for caches: [any KVCache],
+        layerShapes: [[Int]]?
+    ) -> [CheckpointLayerSignature] {
+        caches.enumerated().map { idx, cache in
+            let shape = layerShapes.flatMap { idx < $0.count ? $0[idx] : nil }
+            return CheckpointLayerSignature.from(cache, layerShape: shape)
+        }
     }
 
     /// Cache identity: bind to the weight hash so a re-download under the
@@ -1081,20 +1308,6 @@ public actor BatchScheduler {
             await refreshPendingSummaryCache()
         }
 
-        if let kvBudget {
-            let reserved = await kvBudget.reserve(
-                requestID: id,
-                kvBytesPerToken: kvBytesPerToken,
-                tokenCount: requestBudget
-            )
-            guard reserved else {
-                await dropBridge(requestId: id)
-                continuation.yield(.error("token_budget_exhausted: insufficient global KV cache headroom"))
-                continuation.finish()
-                return stream
-            }
-        }
-
         var sp = SamplingParams(maxTokens: maxTokens, temperature: temperature)
         if let topP { sp.topP = topP }
         if let topK { sp.topK = topK }
@@ -1105,7 +1318,24 @@ public actor BatchScheduler {
             prompt: promptTokens as AnyHashable,
             samplingParams: sp
         )
-        await maybeRestoreCheckpoint(req, promptTokens: promptTokens, scope: cacheScope)
+        let restoreAdmission = await maybeRestoreCheckpoint(req, promptTokens: promptTokens, scope: cacheScope)
+        let kvReservationTokens = acceptRestoredCheckpointBudget(
+            requestId: id,
+            requestTokens: requestBudget,
+            admission: restoreAdmission,
+            req: req
+        )
+        guard await reserveKVForRequest(
+            requestId: id,
+            requestTokens: requestBudget,
+            reservationTokens: kvReservationTokens,
+            req: req
+        ) else {
+            await dropBridge(requestId: id)
+            continuation.yield(.error("token_budget_exhausted: insufficient global KV cache headroom"))
+            continuation.finish()
+            return stream
+        }
         // Re-check the engine is still the one we captured (a reload/
         // unload may have run during the awaits above). Enqueuing onto a stopped/
         // superseded engine hangs the request or runs it on the wrong model.
@@ -1234,20 +1464,6 @@ public actor BatchScheduler {
             await refreshPendingSummaryCache()
         }
 
-        if let kvBudget {
-            let reserved = await kvBudget.reserve(
-                requestID: id,
-                kvBytesPerToken: kvBytesPerToken,
-                tokenCount: requestBudget
-            )
-            guard reserved else {
-                await dropBridge(requestId: id)
-                continuation.yield(.error("token_budget_exhausted: insufficient global KV cache headroom"))
-                continuation.finish()
-                return stream
-            }
-        }
-
         // Greedy (temperature == 0) hits the engine's vectorized argmax
         // fast path automatically; just pass the requested value through.
         let temperature = request.temperature ?? 0.0
@@ -1261,7 +1477,24 @@ public actor BatchScheduler {
             prompt: promptTokens as AnyHashable,
             samplingParams: sp
         )
-        await maybeRestoreCheckpoint(req, promptTokens: promptTokens, scope: request.cacheScope)
+        let restoreAdmission = await maybeRestoreCheckpoint(req, promptTokens: promptTokens, scope: request.cacheScope)
+        let kvReservationTokens = acceptRestoredCheckpointBudget(
+            requestId: id,
+            requestTokens: requestBudget,
+            admission: restoreAdmission,
+            req: req
+        )
+        guard await reserveKVForRequest(
+            requestId: id,
+            requestTokens: requestBudget,
+            reservationTokens: kvReservationTokens,
+            req: req
+        ) else {
+            await dropBridge(requestId: id)
+            continuation.yield(.error("token_budget_exhausted: insufficient global KV cache headroom"))
+            continuation.finish()
+            return stream
+        }
         // Re-check the captured engine is still current after the awaits.
         // releaseRequestResources (not bare dropBridge): a cancel/timeout during
         // planner.admit could have dropped the bridge BEFORE we reserved KV, so
@@ -1403,6 +1636,7 @@ public actor BatchScheduler {
         // model (the new model's loadModel reinstalls its own, or nil).
         checkpointManager = nil
         checkpointBoundaries = []
+        checkpointLayerSignatures = []
 
         // Close the engine-tier owner FIRST (before deregister) so no disk
         // mutation slips through between deregistration and the dir being handed

--- a/provider-swift/Sources/ProviderCore/Inference/BatchScheduler.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/BatchScheduler.swift
@@ -1047,7 +1047,12 @@ public actor BatchScheduler {
         layerShapes: [[Int]]?
     ) -> [CheckpointLayerSignature] {
         caches.enumerated().map { idx, cache in
-            let shape = layerShapes.flatMap { idx < $0.count ? $0[idx] : nil }
+            let shape: [Int]? =
+                if let layerShapes, idx < layerShapes.count {
+                    layerShapes[idx]
+                } else {
+                    nil
+                }
             return CheckpointLayerSignature.from(cache, layerShape: shape)
         }
     }

--- a/provider-swift/Sources/ProviderCore/Inference/BatchSchedulerTypes.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/BatchSchedulerTypes.swift
@@ -51,6 +51,11 @@ struct BridgeState {
     var promptTokens: Int
     var completionTokens: Int = 0
     let maxTokens: Int
+    /// Memory-admission budget for this request. Normally this is
+    /// `promptTokens + maxTokens`; restored checkpoint hits can require a larger
+    /// reservation because the provider materializes restored KV before handing
+    /// it to MLX, and MLX then builds a batched copy for decode.
+    var reservedTokens: Int? = nil
     let submittedAt: ContinuousClock.Instant
     var admittedAt: ContinuousClock.Instant?
     var firstTokenAt: ContinuousClock.Instant?
@@ -76,6 +81,48 @@ struct LoadSnapshot: @unchecked Sendable {
     let tokenizer: TokenizerHandle
     let eosTokenIds: Set<Int>
     let architecture: ModelArchitecture
+}
+
+/// Sendable summary of the loaded model's per-layer KV cache class.
+/// The restored checkpoint itself is still validated against live cache
+/// shapes before admission; this signature prevents cross-layer/type restores
+/// without moving non-Sendable MLX cache objects across actor boundaries.
+struct CheckpointLayerShape: Sendable, Equatable {
+    let kvHeads: Int
+    let headDim: Int
+
+    init?(raw: [Int]?) {
+        guard let raw, raw.count == 2, raw[0] > 0, raw[1] > 0 else {
+            return nil
+        }
+        self.kvHeads = raw[0]
+        self.headDim = raw[1]
+    }
+
+    init(kvHeads: Int, headDim: Int) {
+        self.kvHeads = kvHeads
+        self.headDim = headDim
+    }
+}
+
+enum CheckpointLayerSignature: Sendable, Equatable {
+    case simple(shape: CheckpointLayerShape?)
+    case rotating(window: Int, shape: CheckpointLayerShape?)
+    case unsupported
+
+    static func from(_ cache: any KVCache, layerShape: [Int]? = nil) -> CheckpointLayerSignature {
+        let shape = CheckpointLayerShape(raw: layerShape)
+        if cache is ArraysCache { return .unsupported }
+        if cache is ChunkedKVCache { return .unsupported }
+        if cache is QuantizedKVCache { return .unsupported }
+        if let rotating = cache as? RotatingKVCache, let window = rotating.maxSize, window > 0 {
+            return .rotating(window: window, shape: shape)
+        }
+        if cache is KVCacheSimple, !(cache is RotatingKVCache) {
+            return .simple(shape: shape)
+        }
+        return .unsupported
+    }
 }
 
 /// Model-architecture fields read from `config.json`, used by

--- a/provider-swift/Sources/ProviderCore/KVCache/PrefixCacheManager.swift
+++ b/provider-swift/Sources/ProviderCore/KVCache/PrefixCacheManager.swift
@@ -1017,9 +1017,10 @@ public actor PrefixCacheManager: PrefixCacheOwner {
         if index.entry(modelHash: binding.modelHash, digestHex: digestHex) != nil { return false }
         if inFlightWrites.contains(digestHex) { return false }
 
-        // Find the RAM entry (if it still exists).
-        guard let snap = ram.entriesForFlush(modelHash: binding.modelHash)
-            .first(where: { $0.key.digest == digest }) else {
+        // Find only the target RAM entry. Calling entriesForFlush(...).first
+        // copies every checkpoint for the model and can OOM during a single
+        // second-use promotion.
+        guard let snap = ram.entryForFlush(modelHash: binding.modelHash, digest: digest) else {
             return false
         }
 

--- a/provider-swift/Sources/ProviderCore/KVCache/PrefixCacheRAM.swift
+++ b/provider-swift/Sources/ProviderCore/KVCache/PrefixCacheRAM.swift
@@ -198,6 +198,15 @@ public final class PrefixCacheRAM {
             .map { ($0.key, $0.caches.map { c in c.copy() }, $0.tokenCount) }
     }
 
+    /// Snapshot one entry for persistence. Used by second-use promotion; do
+    /// not call `entriesForFlush(...).first(where:)` there, because that copies
+    /// every checkpoint for the model before discarding all but one.
+    public func entryForFlush(modelHash: String, digest: Data) -> (key: PrefixCacheKey, caches: [any KVCache], tokenCount: Int)? {
+        let key = PrefixCacheKey(modelHash: modelHash, digest: digest)
+        guard let entry = entries[key] else { return nil }
+        return (entry.key, entry.caches.map { $0.copy() }, entry.tokenCount)
+    }
+
     // MARK: - Introspection
 
     public func contains(_ key: PrefixCacheKey) -> Bool { entries[key] != nil }

--- a/provider-swift/Tests/ProviderCoreTests/BatchSchedulerBudgetTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/BatchSchedulerBudgetTests.swift
@@ -6,7 +6,38 @@
 
 import Foundation
 import Testing
+@testable import MLX
+@testable import MLXLMCommon
 @testable import ProviderCore
+
+private let restoreB = 1
+private let restoreH = 1
+private let restoreD = 2
+
+private func schedulerSimpleCache(tokens n: Int, heads: Int = restoreH, dim: Int = restoreD) -> KVCacheSimple {
+    let cache = KVCacheSimple()
+    let k = MLXArray.ones([restoreB, heads, n, dim])
+    let v = MLXArray.ones([restoreB, heads, n, dim]) * Float32(2)
+    _ = cache.update(keys: k, values: v)
+    eval(cache.innerState())
+    return cache
+}
+
+private func schedulerRotatingCache(
+    tokens n: Int,
+    maxSize: Int,
+    heads: Int = restoreH,
+    dim: Int = restoreD
+) -> RotatingKVCache {
+    let cache = RotatingKVCache(maxSize: maxSize, keep: 0, step: maxSize)
+    for _ in 0..<n {
+        let k = MLXArray.ones([restoreB, heads, 1, dim])
+        let v = MLXArray.ones([restoreB, heads, 1, dim]) * Float32(2)
+        _ = cache.update(keys: k, values: v)
+        eval(cache.innerState())
+    }
+    return cache
+}
 
 @Suite("BatchScheduler budget gate + progress reporting")
 struct BatchSchedulerBudgetTests {
@@ -39,6 +70,101 @@ struct BatchSchedulerBudgetTests {
         let requestBudget = 500
         #expect(used + requestBudget > budget,
             "P1 gate: third bridge pushing cumulative over tokenBudgetMax must trigger rejection")
+    }
+
+    /// Restored checkpoint hits can hold more live KV than their prompt+decode
+    /// token count because the restored cache is already materialized. The
+    /// scheduler's active-budget view must charge the explicit reservation, not
+    /// the billing prompt count, or concurrent restored hits can overcommit MLX.
+    @Test("activeTokenBudgetUsed uses restored checkpoint reservation when present")
+    func activeTokenBudgetUsesRestoredReservation() async {
+        let scheduler = BatchScheduler(
+            maxConcurrentRequests: 4,
+            defaultMaxTokens: 4096
+        )
+
+        await scheduler._testSeedBridge(
+            id: "restore",
+            promptTokens: 100,
+            maxTokens: 20,
+            reservedTokens: 500
+        )
+
+        #expect(await scheduler.activeTokenBudgetUsed == 500,
+            "restored checkpoint bridges must charge their memory reservation, not prompt+max tokens")
+    }
+
+    /// Guard the pre-MLX restore gate. The crash class here is fatal inside MLX,
+    /// so a bad checkpoint must be rejected before `EngineCore.addRequest`.
+    @Test("restored checkpoint geometry rejects unsafe cache layouts")
+    func restoredCheckpointGeometryRejectsUnsafeLayouts() {
+        let shape = CheckpointLayerShape(kvHeads: restoreH, headDim: restoreD)
+        let expected: [CheckpointLayerSignature] = [
+            .simple(shape: shape),
+            .rotating(window: 4, shape: shape),
+        ]
+        let valid: [any KVCache] = [
+            schedulerSimpleCache(tokens: 6),
+            schedulerRotatingCache(tokens: 6, maxSize: 4),
+        ]
+
+        #expect(BatchScheduler.restoredCheckpointIsUsable(
+            caches: valid,
+            expected: expected,
+            tokenCount: 6,
+            promptTokenCount: 9
+        ))
+
+        let wrongSimpleCount: [any KVCache] = [
+            schedulerSimpleCache(tokens: 5),
+            schedulerRotatingCache(tokens: 6, maxSize: 4),
+        ]
+        #expect(!BatchScheduler.restoredCheckpointIsUsable(
+            caches: wrongSimpleCount,
+            expected: expected,
+            tokenCount: 6,
+            promptTokenCount: 9
+        ))
+
+        let wrongRotatingWindow: [any KVCache] = [
+            schedulerSimpleCache(tokens: 6),
+            schedulerRotatingCache(tokens: 6, maxSize: 8),
+        ]
+        #expect(!BatchScheduler.restoredCheckpointIsUsable(
+            caches: wrongRotatingWindow,
+            expected: expected,
+            tokenCount: 6,
+            promptTokenCount: 9
+        ))
+
+        let wrongHeadShape: [any KVCache] = [
+            schedulerSimpleCache(tokens: 6, heads: 2),
+            schedulerRotatingCache(tokens: 6, maxSize: 4),
+        ]
+        #expect(!BatchScheduler.restoredCheckpointIsUsable(
+            caches: wrongHeadShape,
+            expected: expected,
+            tokenCount: 6,
+            promptTokenCount: 9
+        ))
+
+        let wrongLayerOrder: [any KVCache] = [
+            schedulerRotatingCache(tokens: 6, maxSize: 4),
+            schedulerSimpleCache(tokens: 6),
+        ]
+        #expect(!BatchScheduler.restoredCheckpointIsUsable(
+            caches: wrongLayerOrder,
+            expected: expected,
+            tokenCount: 6,
+            promptTokenCount: 9
+        ))
+
+        #expect(!BatchScheduler.restoredCheckpointIsUsable(
+            caches: valid,
+            expected: expected,
+            tokenCount: 9,
+            promptTokenCount: 9
+        ), "full-prompt restore is not a suffix decode and must be skipped")
     }
 
     /// End-to-end exercise of the P1 helper. Two bridges admitted

--- a/provider-swift/Tests/ProviderCoreTests/KVCache/PrefixCacheRAMTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/KVCache/PrefixCacheRAMTests.swift
@@ -204,3 +204,29 @@ func entriesForFlushReturnsCopiesPerModel() {
     // entriesForFlush does not remove.
     #expect(ram.count == 2)
 }
+
+@Test
+func entryForFlushReturnsOneIndependentCopy() {
+    let ram = PrefixCacheRAM()
+    ram.put(modelHash: "A", digest: digest("p"), caches: [simpleCache(tokens: 4)], tokenCount: 4)
+    ram.put(modelHash: "A", digest: digest("q"), caches: [simpleCache(tokens: 6)], tokenCount: 6)
+    ram.put(modelHash: "B", digest: digest("p"), caches: [simpleCache(tokens: 8)], tokenCount: 8)
+
+    let flush = ram.entryForFlush(modelHash: "A", digest: digest("q"))
+    #expect(flush != nil)
+    #expect(flush?.key.modelHash == "A")
+    #expect(flush?.key.digest == digest("q"))
+    #expect(flush?.tokenCount == 6)
+    #expect(flush?.caches.count == 1)
+    #expect(flush?.caches[0].offset == 6)
+
+    let extra = MLXArray(Array(repeating: Float(999), count: H * 3 * D), [1, H, 3, D])
+    _ = flush!.caches[0].update(keys: extra, values: extra)
+    eval(flush!.caches[0].innerState())
+    #expect(flush!.caches[0].offset == 9)
+
+    #expect(ram.get(modelHash: "A", digest: digest("q"))?.caches[0].offset == 6,
+            "single-entry flush snapshot must be an independent copy")
+    #expect(ram.entryForFlush(modelHash: "A", digest: digest("missing")) == nil)
+    #expect(ram.count == 3, "entryForFlush snapshots without removing entries")
+}


### PR DESCRIPTION
Summary: Adds restore geometry/type/window/shape validation before MLX sees restored checkpoint KV, accounts restored-checkpoint memory in admission, falls back to cold prefill when restored KV does not fit, and avoids RAM promotion copy amplification. Tests: swift test --filter BatchSchedulerBudgetTests; swift test --filter PrefixCacheRAMTests; swift test --filter PrefixCacheManagerTests; git diff --check.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/324"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783813512&installation_id=133247490&pr_number=324&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F324&signature=2d9e3bf25143b20cf31c51f65bacff7e4c28f1ecb8ab7c371f77da61f64af31e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->