### PR TITLE
feat(provider+coordinator): OOM protection + detection

### DIFF
--- a/console-ui/src/lib/telemetry-types.ts
+++ b/console-ui/src/lib/telemetry-types.ts
@@ -28,6 +28,7 @@ export type TelemetryKind =
   | "inference_error"
   | "runtime_mismatch"
   | "connectivity"
+  | "oom"
   | "log"
   | "custom";
 
@@ -79,6 +80,15 @@ export const TELEMETRY_ALLOWED_FIELDS = new Set<string>([
   "billing_method",
   "payment_failed",
   "target",
+  // OOM detection / memory pressure (mirror of the Go + Swift allowlists).
+  "detect_source",
+  "peak_memory_bytes",
+  "report",
+  "pressure",
+  "available_bytes",
+  "mlx_active_bytes",
+  "memory_pressure",
+  "in_flight",
   "url",
   "user_agent",
   "route",

--- a/console-ui/src/lib/telemetry-types.ts
+++ b/console-ui/src/lib/telemetry-types.ts
@@ -80,7 +80,7 @@ export const TELEMETRY_ALLOWED_FIELDS = new Set<string>([
   "billing_method",
   "payment_failed",
   "target",
-  // OOM detection / memory pressure (mirror of the Go + Swift allowlists).
+  // OOM / memory pressure (mirror of Go + Swift allowlists).
   "detect_source",
   "peak_memory_bytes",
   "report",

--- a/coordinator/api/provider.go
+++ b/coordinator/api/provider.go
@@ -207,12 +207,9 @@ func (s *Server) providerReadLoop(ctx context.Context, conn *websocket.Conn, pro
 				}
 				s.ddIncr("ws.disconnects", []string{"reason:read_error"})
 
-				// A read_error is an abrupt drop — the signature of a killed
-				// process, not a graceful close. Classify it against the last
-				// heartbeat's memory pressure + in-flight count: a jetsam OOM
-				// kill leaves no other trace, so this is the only way to make it
-				// visible (vs. bucketing it as a generic disconnect). See
-				// registry.ClassifyDisconnectReason.
+				// An abrupt read_error under high last-known memory pressure is
+				// very likely a jetsam OOM (the kill leaves no other trace).
+				// Classify + surface it. See registry.ClassifyDisconnectReason.
 				if provider != nil {
 					memPressure, inFlight := provider.DisconnectDiagnostics()
 					if registry.ClassifyDisconnectReason(true, memPressure, inFlight) == registry.DisconnectReasonOOMSuspected {

--- a/coordinator/api/provider.go
+++ b/coordinator/api/provider.go
@@ -206,6 +206,29 @@ func (s *Server) providerReadLoop(ctx context.Context, conn *websocket.Conn, pro
 					)
 				}
 				s.ddIncr("ws.disconnects", []string{"reason:read_error"})
+
+				// A read_error is an abrupt drop — the signature of a killed
+				// process, not a graceful close. Classify it against the last
+				// heartbeat's memory pressure + in-flight count: a jetsam OOM
+				// kill leaves no other trace, so this is the only way to make it
+				// visible (vs. bucketing it as a generic disconnect). See
+				// registry.ClassifyDisconnectReason.
+				if provider != nil {
+					memPressure, inFlight := provider.DisconnectDiagnostics()
+					if registry.ClassifyDisconnectReason(true, memPressure, inFlight) == registry.DisconnectReasonOOMSuspected {
+						if s.metrics != nil {
+							s.metrics.IncCounter("provider_oom_suspected_total")
+						}
+						s.ddIncr("provider.oom_suspected", nil)
+						s.emit(context.Background(), protocol.SeverityError, protocol.KindOOM,
+							"provider disconnected under memory pressure (suspected OOM)",
+							map[string]any{
+								"provider_id":     providerID,
+								"memory_pressure": memPressure,
+								"in_flight":       inFlight,
+							})
+					}
+				}
 			}
 			return
 		}

--- a/coordinator/api/provider.go
+++ b/coordinator/api/provider.go
@@ -207,12 +207,16 @@ func (s *Server) providerReadLoop(ctx context.Context, conn *websocket.Conn, pro
 				}
 				s.ddIncr("ws.disconnects", []string{"reason:read_error"})
 
-				// An abrupt read_error under high last-known memory pressure is
-				// very likely a jetsam OOM (the kill leaves no other trace).
-				// Classify + surface it. See registry.ClassifyDisconnectReason.
+				// An abrupt read_error under high last-known memory pressure with
+				// active inference is very likely a jetsam OOM (the kill leaves no
+				// other trace). Require in-flight > 0: a graceful shutdown/update
+				// drains first (and may surface here as a frame-less EOF rather
+				// than a clean close), so gating on in-flight avoids misreading a
+				// drained going-away close as OOM. Idle-box kills are recovered by
+				// the provider's crash-log scrape instead.
 				if provider != nil {
 					memPressure, inFlight := provider.DisconnectDiagnostics()
-					if registry.ClassifyDisconnectReason(true, memPressure, inFlight) == registry.DisconnectReasonOOMSuspected {
+					if inFlight > 0 && registry.ClassifyDisconnectReason(true, memPressure, inFlight) == registry.DisconnectReasonOOMSuspected {
 						if s.metrics != nil {
 							s.metrics.IncCounter("provider_oom_suspected_total")
 						}

--- a/coordinator/api/telemetry_handlers.go
+++ b/coordinator/api/telemetry_handlers.go
@@ -80,8 +80,7 @@ var telemetryFieldAllowlist = map[string]struct{}{
 	// Billing (booleans/enums only — no dollar amounts)
 	"billing_method": {},
 	"payment_failed": {},
-	// OOM detection / memory pressure (non-sensitive numbers + enums only).
-	// Mirror of the Swift TelemetryFieldFilter allowlist.
+	// OOM / memory pressure (non-sensitive). Mirror of the Swift allowlist.
 	"detect_source":     {},
 	"peak_memory_bytes": {},
 	"report":            {},

--- a/coordinator/api/telemetry_handlers.go
+++ b/coordinator/api/telemetry_handlers.go
@@ -80,6 +80,16 @@ var telemetryFieldAllowlist = map[string]struct{}{
 	// Billing (booleans/enums only — no dollar amounts)
 	"billing_method": {},
 	"payment_failed": {},
+	// OOM detection / memory pressure (non-sensitive numbers + enums only).
+	// Mirror of the Swift TelemetryFieldFilter allowlist.
+	"detect_source":     {},
+	"peak_memory_bytes": {},
+	"report":            {},
+	"pressure":          {},
+	"available_bytes":   {},
+	"mlx_active_bytes":  {},
+	"memory_pressure":   {},
+	"in_flight":         {},
 	// Console UI context
 	"url":        {},
 	"user_agent": {},

--- a/coordinator/protocol/telemetry.go
+++ b/coordinator/protocol/telemetry.go
@@ -48,8 +48,13 @@ const (
 	KindInferenceError     TelemetryKind = "inference_error"
 	KindRuntimeMismatch    TelemetryKind = "runtime_mismatch"
 	KindConnectivity       TelemetryKind = "connectivity"
-	KindLog                TelemetryKind = "log"
-	KindCustom             TelemetryKind = "custom"
+	// KindOOM is an out-of-memory event: a provider-detected jetsam/crash-log
+	// OOM surfaced on the NEXT launch (a SIGKILL leaves no in-process trace), or
+	// a coordinator-classified "oom_suspected" disconnect. Mirror of Swift
+	// `TelemetryKind.oom` / TS `oom`.
+	KindOOM    TelemetryKind = "oom"
+	KindLog    TelemetryKind = "log"
+	KindCustom TelemetryKind = "custom"
 )
 
 // TelemetrySourceCustom is returned when a source value can't be classified
@@ -93,6 +98,7 @@ func KnownKinds() map[TelemetryKind]struct{} {
 		KindInferenceError:     {},
 		KindRuntimeMismatch:    {},
 		KindConnectivity:       {},
+		KindOOM:                {},
 		KindLog:                {},
 		KindCustom:             {},
 	}

--- a/coordinator/protocol/telemetry.go
+++ b/coordinator/protocol/telemetry.go
@@ -48,10 +48,8 @@ const (
 	KindInferenceError     TelemetryKind = "inference_error"
 	KindRuntimeMismatch    TelemetryKind = "runtime_mismatch"
 	KindConnectivity       TelemetryKind = "connectivity"
-	// KindOOM is an out-of-memory event: a provider-detected jetsam/crash-log
-	// OOM surfaced on the NEXT launch (a SIGKILL leaves no in-process trace), or
-	// a coordinator-classified "oom_suspected" disconnect. Mirror of Swift
-	// `TelemetryKind.oom` / TS `oom`.
+	// KindOOM: a provider-detected jetsam/crash-log OOM (surfaced next launch)
+	// or a coordinator-classified oom_suspected disconnect.
 	KindOOM    TelemetryKind = "oom"
 	KindLog    TelemetryKind = "log"
 	KindCustom TelemetryKind = "custom"

--- a/coordinator/protocol/telemetry_symmetry_test.go
+++ b/coordinator/protocol/telemetry_symmetry_test.go
@@ -62,7 +62,7 @@ func TestTelemetryKindsMatch(t *testing.T) {
 		"panic": true, "http_error": true, "protocol_error": true,
 		"backend_crash": true, "attestation_failure": true,
 		"inference_error": true, "runtime_mismatch": true,
-		"connectivity": true, "log": true, "custom": true,
+		"connectivity": true, "oom": true, "log": true, "custom": true,
 	}
 	for k := range KnownKinds() {
 		if !want[string(k)] {

--- a/coordinator/registry/disconnect_classify.go
+++ b/coordinator/registry/disconnect_classify.go
@@ -1,41 +1,28 @@
 package registry
 
-// Disconnect classification. A macOS jetsam OOM kills the provider with an
-// uncatchable SIGKILL, so the process flushes no crash report — the ONLY trace
-// the coordinator sees is the WebSocket abruptly dying (a "read_error"). Today
-// every such death is bucketed identically to a graceful close, so the ~7,880
-// read-error disconnects/48h hide an unknown number of OOM kills.
-//
-// We can't prove an OOM from the coordinator, but the last heartbeat (≤ a few
-// seconds old) carries the provider's memory pressure, and we know whether
-// requests were in flight. A box that drops the socket while reporting high
-// memory pressure with active inference is, with high probability, a jetsam
-// kill. Classifying these turns invisible OOMs into an attributable signal.
+// Disconnect classification. A jetsam OOM kills the provider with an uncatchable
+// SIGKILL, so its only trace is the WebSocket abruptly dying ("read_error"),
+// bucketed identically to a graceful close. We can't prove an OOM, but the last
+// heartbeat carries memory pressure and we know the in-flight count: an abrupt
+// drop under high pressure with active inference is very likely a jetsam kill.
 
 // DisconnectReason is the classified cause of a provider socket drop.
 type DisconnectReason string
 
 const (
-	// DisconnectReasonNormal is a graceful/unattributed disconnect.
-	DisconnectReasonNormal DisconnectReason = "disconnect"
-	// DisconnectReasonOOMSuspected is an abrupt drop whose last-known state
-	// (high memory pressure, especially with in-flight requests) is consistent
-	// with a jetsam OOM kill.
-	DisconnectReasonOOMSuspected DisconnectReason = "oom_suspected"
+	DisconnectReasonNormal       DisconnectReason = "disconnect"    // graceful/unattributed
+	DisconnectReasonOOMSuspected DisconnectReason = "oom_suspected" // abrupt drop under memory pressure
 )
 
-// OOM-suspicion thresholds. Tuned to favor precision: a box at ≥0.90 pressure
-// is on the edge regardless of load; active inference lowers the bar to 0.80
-// because decode is the allocation that tips it over.
+// Precision-tuned: ≥0.90 pressure is on the edge regardless of load; active
+// inference lowers the bar to 0.80 (decode is the allocation that tips it over).
 const (
 	oomPressureHard         = 0.90
 	oomPressureWithInFlight = 0.80
 )
 
-// ClassifyDisconnectReason decides whether an abrupt disconnect looks like an
-// OOM, from the last-known memory pressure and in-flight request count. Pure
-// and table-tested. `abrupt` is false for a graceful close (which is never an
-// OOM).
+// ClassifyDisconnectReason: does an abrupt disconnect look like an OOM, from the
+// last-known memory pressure + in-flight count? `abrupt` false = graceful close.
 func ClassifyDisconnectReason(abrupt bool, memoryPressure float64, inFlight int) DisconnectReason {
 	if !abrupt {
 		return DisconnectReasonNormal
@@ -49,9 +36,8 @@ func ClassifyDisconnectReason(abrupt bool, memoryPressure float64, inFlight int)
 	return DisconnectReasonNormal
 }
 
-// DisconnectDiagnostics returns the last-known signals used to classify a
-// disconnect, read atomically under the provider lock. Safe to call from
-// outside the registry package (e.g. the WS read loop on read error).
+// DisconnectDiagnostics returns the signals used to classify a disconnect, read
+// atomically under the provider lock.
 func (p *Provider) DisconnectDiagnostics() (memoryPressure float64, inFlight int) {
 	p.mu.Lock()
 	defer p.mu.Unlock()

--- a/coordinator/registry/disconnect_classify.go
+++ b/coordinator/registry/disconnect_classify.go
@@ -1,0 +1,59 @@
+package registry
+
+// Disconnect classification. A macOS jetsam OOM kills the provider with an
+// uncatchable SIGKILL, so the process flushes no crash report — the ONLY trace
+// the coordinator sees is the WebSocket abruptly dying (a "read_error"). Today
+// every such death is bucketed identically to a graceful close, so the ~7,880
+// read-error disconnects/48h hide an unknown number of OOM kills.
+//
+// We can't prove an OOM from the coordinator, but the last heartbeat (≤ a few
+// seconds old) carries the provider's memory pressure, and we know whether
+// requests were in flight. A box that drops the socket while reporting high
+// memory pressure with active inference is, with high probability, a jetsam
+// kill. Classifying these turns invisible OOMs into an attributable signal.
+
+// DisconnectReason is the classified cause of a provider socket drop.
+type DisconnectReason string
+
+const (
+	// DisconnectReasonNormal is a graceful/unattributed disconnect.
+	DisconnectReasonNormal DisconnectReason = "disconnect"
+	// DisconnectReasonOOMSuspected is an abrupt drop whose last-known state
+	// (high memory pressure, especially with in-flight requests) is consistent
+	// with a jetsam OOM kill.
+	DisconnectReasonOOMSuspected DisconnectReason = "oom_suspected"
+)
+
+// OOM-suspicion thresholds. Tuned to favor precision: a box at ≥0.90 pressure
+// is on the edge regardless of load; active inference lowers the bar to 0.80
+// because decode is the allocation that tips it over.
+const (
+	oomPressureHard         = 0.90
+	oomPressureWithInFlight = 0.80
+)
+
+// ClassifyDisconnectReason decides whether an abrupt disconnect looks like an
+// OOM, from the last-known memory pressure and in-flight request count. Pure
+// and table-tested. `abrupt` is false for a graceful close (which is never an
+// OOM).
+func ClassifyDisconnectReason(abrupt bool, memoryPressure float64, inFlight int) DisconnectReason {
+	if !abrupt {
+		return DisconnectReasonNormal
+	}
+	if memoryPressure >= oomPressureHard {
+		return DisconnectReasonOOMSuspected
+	}
+	if inFlight > 0 && memoryPressure >= oomPressureWithInFlight {
+		return DisconnectReasonOOMSuspected
+	}
+	return DisconnectReasonNormal
+}
+
+// DisconnectDiagnostics returns the last-known signals used to classify a
+// disconnect, read atomically under the provider lock. Safe to call from
+// outside the registry package (e.g. the WS read loop on read error).
+func (p *Provider) DisconnectDiagnostics() (memoryPressure float64, inFlight int) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.SystemMetrics.MemoryPressure, len(p.pendingReqs)
+}

--- a/coordinator/registry/disconnect_classify_test.go
+++ b/coordinator/registry/disconnect_classify_test.go
@@ -1,0 +1,53 @@
+package registry
+
+import "testing"
+
+func TestClassifyDisconnectReason(t *testing.T) {
+	tests := []struct {
+		name           string
+		abrupt         bool
+		memoryPressure float64
+		inFlight       int
+		want           DisconnectReason
+	}{
+		{"graceful close is never OOM even at high pressure", false, 0.99, 5, DisconnectReasonNormal},
+		{"abrupt + very high pressure, no inflight -> OOM", true, 0.92, 0, DisconnectReasonOOMSuspected},
+		{"abrupt + high pressure + inflight -> OOM", true, 0.85, 2, DisconnectReasonOOMSuspected},
+		{"abrupt + high pressure but no inflight -> normal", true, 0.85, 0, DisconnectReasonNormal},
+		{"abrupt + moderate pressure + inflight -> normal", true, 0.70, 3, DisconnectReasonNormal},
+		{"abrupt + low pressure -> normal", true, 0.10, 0, DisconnectReasonNormal},
+		{"exactly hard threshold -> OOM", true, oomPressureHard, 0, DisconnectReasonOOMSuspected},
+		{"exactly inflight threshold with inflight -> OOM", true, oomPressureWithInFlight, 1, DisconnectReasonOOMSuspected},
+		{"just below inflight threshold with inflight -> normal", true, oomPressureWithInFlight - 0.01, 1, DisconnectReasonNormal},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ClassifyDisconnectReason(tt.abrupt, tt.memoryPressure, tt.inFlight)
+			if got != tt.want {
+				t.Errorf("ClassifyDisconnectReason(%v, %.2f, %d) = %q, want %q",
+					tt.abrupt, tt.memoryPressure, tt.inFlight, got, tt.want)
+			}
+		})
+	}
+}
+
+// The accessor must read the last-known metrics + in-flight count atomically.
+func TestProviderDisconnectDiagnostics(t *testing.T) {
+	p := &Provider{
+		pendingReqs: make(map[string]*PendingRequest),
+	}
+	p.SystemMetrics.MemoryPressure = 0.93
+	p.pendingReqs["r1"] = &PendingRequest{RequestID: "r1"}
+	p.pendingReqs["r2"] = &PendingRequest{RequestID: "r2"}
+
+	mp, inFlight := p.DisconnectDiagnostics()
+	if mp != 0.93 {
+		t.Errorf("memoryPressure = %f, want 0.93", mp)
+	}
+	if inFlight != 2 {
+		t.Errorf("inFlight = %d, want 2", inFlight)
+	}
+	if got := ClassifyDisconnectReason(true, mp, inFlight); got != DisconnectReasonOOMSuspected {
+		t.Errorf("classify = %q, want oom_suspected", got)
+	}
+}

--- a/provider-swift/Sources/ProviderCore/Diagnostics/MemoryPressureMonitor.swift
+++ b/provider-swift/Sources/ProviderCore/Diagnostics/MemoryPressureMonitor.swift
@@ -10,13 +10,9 @@ public enum MemoryPressureLevel: String, Sendable, Equatable {
 
 /// What the provider should do at a given pressure level.
 public struct MemoryPressureResponse: Equatable, Sendable {
-    /// Drop MLX's reusable buffer pool back to the OS immediately.
-    public var clearCache: Bool
-    /// Persist an OOM marker so that if jetsam SIGKILLs us next, the following
-    /// launch can attribute the death to memory pressure.
-    public var writeMarker: Bool
-    /// Telemetry severity to emit (nil = don't emit).
-    public var severity: TelemetrySeverity?
+    public var clearCache: Bool             // reclaim MLX's buffer pool to the OS
+    public var writeMarker: Bool            // drop an OOM marker for the next launch
+    public var severity: TelemetrySeverity? // nil = don't emit telemetry
 }
 
 /// Pure policy: pressure level -> action. Tested in isolation.
@@ -26,24 +22,19 @@ public enum MemoryPressurePolicy {
         case .normal:
             return MemoryPressureResponse(clearCache: false, writeMarker: false, severity: nil)
         case .warning:
-            // Reclaim the cache early; the live admission gate (GlobalKVCacheBudget /
-            // tokenBudgetMax, now OS-available-aware) naturally tightens as free RAM
-            // falls, so no forced shedding is needed yet — just return memory. No
-            // telemetry: warning pressure is routine on healthy Macs and would
-            // only add noise to the `oom` signal.
+            // Reclaim cache; the live admission gate handles shedding. No telemetry
+            // — warning pressure is routine and would only add noise.
             return MemoryPressureResponse(clearCache: true, writeMarker: false, severity: nil)
         case .critical:
-            // Last chance before a possible jetsam kill: reclaim everything AND
-            // drop a marker so the death isn't invisible.
+            // Last chance before a possible jetsam kill: reclaim + mark for next launch.
             return MemoryPressureResponse(clearCache: true, writeMarker: true, severity: .error)
         }
     }
 }
 
-/// Watches kernel memory pressure and reacts. MLX-free by design: the caller
-/// injects the `clearCache` / `writeMarker` / `emit` actions so this stays
-/// testable and the file has no MLX dependency. `handle(_:)` is the testable
-/// core; `start()` wires it to a real DispatchSource.
+/// Watches kernel memory pressure and reacts. MLX-free: the caller injects the
+/// actions so it stays testable. `handle(_:)` is the core; `start()` wires the
+/// real DispatchSource.
 public final class MemoryPressureMonitor: @unchecked Sendable {
     private let clearCache: @Sendable () -> Void
     private let writeMarker: @Sendable (MemoryPressureLevel) -> Void

--- a/provider-swift/Sources/ProviderCore/Diagnostics/MemoryPressureMonitor.swift
+++ b/provider-swift/Sources/ProviderCore/Diagnostics/MemoryPressureMonitor.swift
@@ -1,0 +1,97 @@
+import Foundation
+import Dispatch
+
+/// Coarse memory-pressure level from the kernel (DISPATCH_SOURCE_MEMORYPRESSURE).
+public enum MemoryPressureLevel: String, Sendable, Equatable {
+    case normal
+    case warning
+    case critical
+}
+
+/// What the provider should do at a given pressure level.
+public struct MemoryPressureResponse: Equatable, Sendable {
+    /// Drop MLX's reusable buffer pool back to the OS immediately.
+    public var clearCache: Bool
+    /// Persist an OOM marker so that if jetsam SIGKILLs us next, the following
+    /// launch can attribute the death to memory pressure.
+    public var writeMarker: Bool
+    /// Telemetry severity to emit (nil = don't emit).
+    public var severity: TelemetrySeverity?
+}
+
+/// Pure policy: pressure level -> action. Tested in isolation.
+public enum MemoryPressurePolicy {
+    public static func response(for level: MemoryPressureLevel) -> MemoryPressureResponse {
+        switch level {
+        case .normal:
+            return MemoryPressureResponse(clearCache: false, writeMarker: false, severity: nil)
+        case .warning:
+            // Reclaim the cache early; the live admission gate (GlobalKVCacheBudget /
+            // tokenBudgetMax, now OS-available-aware) naturally tightens as free RAM
+            // falls, so no forced shedding is needed yet — just return memory. No
+            // telemetry: warning pressure is routine on healthy Macs and would
+            // only add noise to the `oom` signal.
+            return MemoryPressureResponse(clearCache: true, writeMarker: false, severity: nil)
+        case .critical:
+            // Last chance before a possible jetsam kill: reclaim everything AND
+            // drop a marker so the death isn't invisible.
+            return MemoryPressureResponse(clearCache: true, writeMarker: true, severity: .error)
+        }
+    }
+}
+
+/// Watches kernel memory pressure and reacts. MLX-free by design: the caller
+/// injects the `clearCache` / `writeMarker` / `emit` actions so this stays
+/// testable and the file has no MLX dependency. `handle(_:)` is the testable
+/// core; `start()` wires it to a real DispatchSource.
+public final class MemoryPressureMonitor: @unchecked Sendable {
+    private let clearCache: @Sendable () -> Void
+    private let writeMarker: @Sendable (MemoryPressureLevel) -> Void
+    private let emit: @Sendable (MemoryPressureLevel, TelemetrySeverity) -> Void
+    private let queue: DispatchQueue
+    private var source: DispatchSourceMemoryPressure?
+
+    public init(
+        queue: DispatchQueue = DispatchQueue(label: "dev.darkbloom.memory-pressure"),
+        clearCache: @escaping @Sendable () -> Void,
+        writeMarker: @escaping @Sendable (MemoryPressureLevel) -> Void,
+        emit: @escaping @Sendable (MemoryPressureLevel, TelemetrySeverity) -> Void
+    ) {
+        self.queue = queue
+        self.clearCache = clearCache
+        self.writeMarker = writeMarker
+        self.emit = emit
+    }
+
+    public func start() {
+        let src = DispatchSource.makeMemoryPressureSource(eventMask: [.warning, .critical], queue: queue)
+        src.setEventHandler { [weak self] in
+            guard let self, let data = self.source?.data else { return }
+            self.handle(Self.level(from: data))
+        }
+        self.source = src
+        src.activate()
+    }
+
+    public func cancel() {
+        source?.cancel()
+        source = nil
+    }
+
+    /// Testable core: apply the policy for a level and invoke the injected
+    /// actions. Safe to call directly from tests.
+    public func handle(_ level: MemoryPressureLevel) {
+        let response = MemoryPressurePolicy.response(for: level)
+        if response.clearCache { clearCache() }
+        if response.writeMarker { writeMarker(level) }
+        if let severity = response.severity { emit(level, severity) }
+    }
+
+    /// Map a DispatchSource.MemoryPressureEvent bitmask to our coarse level.
+    /// Critical dominates warning when both bits are set.
+    static func level(from data: DispatchSource.MemoryPressureEvent) -> MemoryPressureLevel {
+        if data.contains(.critical) { return .critical }
+        if data.contains(.warning) { return .warning }
+        return .normal
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Diagnostics/OOMDetector+CrashReports.swift
+++ b/provider-swift/Sources/ProviderCore/Diagnostics/OOMDetector+CrashReports.swift
@@ -1,0 +1,87 @@
+import Foundation
+
+/// Pure `.ips` crash-report parsing for OOM detection. Split from OOMDetector
+/// (which owns marker I/O + directory scanning) so the parsing logic — the
+/// bulk of the test surface — stands alone. All functions are pure + tolerant:
+/// malformed input returns nil, never throws.
+extension OOMDetector {
+
+    /// Parse a kernel `JetsamEvent-*.ips` (header line + JSON body with a
+    /// `processes` array); finding iff our process was killed.
+    public static func parseJetsamReport(contents: String, processName: String) -> Finding? {
+        guard let body = jsonBody(from: contents) else { return nil }
+        let pageSize = (body["pageSize"] as? Int)
+            ?? ((body["memoryStatus"] as? [String: Any])?["pageSize"] as? Int)
+            ?? 16384
+        guard let processes = body["processes"] as? [[String: Any]] else { return nil }
+        let needle = processName.lowercased()
+        for proc in processes {
+            guard let name = proc["name"] as? String, name.lowercased().contains(needle) else { continue }
+            let rpages = (proc["rpages"] as? Int) ?? (proc["pages"] as? Int) ?? 0
+            let bytes = UInt64(max(0, rpages)) &* UInt64(max(0, pageSize))
+            let reason = (proc["reason"] as? String) ?? (proc["killDelta"] as? String)
+            return Finding(
+                source: .jetsamReport,
+                message: "jetsam killed \(name) (\(reason ?? "memory pressure"))",
+                reason: reason,
+                peakMemoryBytes: bytes > 0 ? bytes : nil)
+        }
+        return nil
+    }
+
+    /// Parse a process crash `.ips` for a memory kill: `EXC_RESOURCE` with a
+    /// MEMORY subtype, or a JETSAM termination namespace.
+    public static func parseMemoryCrashReport(contents: String, processName: String) -> Finding? {
+        guard let header = jsonHeader(from: contents) else { return nil }
+        let appName = (header["app_name"] as? String) ?? (header["procName"] as? String) ?? ""
+        guard appName.lowercased().contains(processName.lowercased()) else { return nil }
+        guard let body = jsonBody(from: contents) else { return nil }
+
+        if let exception = body["exception"] as? [String: Any] {
+            let type = (exception["type"] as? String) ?? ""
+            let subtype = (exception["subtype"] as? String) ?? ""
+            if type.contains("EXC_RESOURCE") && subtype.uppercased().contains("MEMORY") {
+                return Finding(
+                    source: .memoryCrashReport,
+                    message: "\(appName) hit memory resource limit (\(subtype))",
+                    reason: subtype)
+            }
+        }
+        if let termination = body["termination"] as? [String: Any] {
+            let namespace = (termination["namespace"] as? String) ?? ""
+            if namespace.uppercased().contains("JETSAM") {
+                let reason = (termination["indicator"] as? String) ?? namespace
+                return Finding(
+                    source: .memoryCrashReport,
+                    message: "\(appName) terminated by jetsam (\(reason))",
+                    reason: reason)
+            }
+        }
+        return nil
+    }
+
+    // MARK: - JSON helpers
+
+    /// The first JSON object in an `.ips` document (the one-line header).
+    static func jsonHeader(from contents: String) -> [String: Any]? {
+        guard let firstLine = contents.split(separator: "\n", maxSplits: 1, omittingEmptySubsequences: true).first,
+              let data = firstLine.data(using: .utf8),
+              let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else { return nil }
+        return obj
+    }
+
+    /// The JSON body of an `.ips`: whole-file if it parses, else after line 1.
+    static func jsonBody(from contents: String) -> [String: Any]? {
+        if let data = contents.data(using: .utf8),
+           let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+            return obj
+        }
+        let parts = contents.split(separator: "\n", maxSplits: 1, omittingEmptySubsequences: true)
+        guard parts.count == 2,
+              let data = parts[1].data(using: .utf8),
+              let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else { return nil }
+        return obj
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Diagnostics/OOMDetector+CrashReports.swift
+++ b/provider-swift/Sources/ProviderCore/Diagnostics/OOMDetector+CrashReports.swift
@@ -7,7 +7,13 @@ import Foundation
 extension OOMDetector {
 
     /// Parse a kernel `JetsamEvent-*.ips` (header line + JSON body with a
-    /// `processes` array); finding iff our process was killed.
+    /// `processes` array); finding iff OUR process was the one jetsam killed.
+    ///
+    /// A JetsamEvent lists the whole process table at the pressure event, not
+    /// just the victim — so merely matching the name would flag a provider OOM
+    /// any time darkbloom was resident during someone else's jetsam. Require a
+    /// kill signal on our entry: a `reason` (carried by jetsammed processes) or
+    /// being named the report's `largestProcess`.
     public static func parseJetsamReport(contents: String, processName: String) -> Finding? {
         guard let body = jsonBody(from: contents) else { return nil }
         let pageSize = (body["pageSize"] as? Int)
@@ -15,11 +21,14 @@ extension OOMDetector {
             ?? 16384
         guard let processes = body["processes"] as? [[String: Any]] else { return nil }
         let needle = processName.lowercased()
+        let largest = (body["largestProcess"] as? String)?.lowercased()
         for proc in processes {
             guard let name = proc["name"] as? String, name.lowercased().contains(needle) else { continue }
+            let reason = (proc["reason"] as? String) ?? (proc["killDelta"] as? String)
+            let wasKilled = !(reason ?? "").isEmpty || (largest.map { name.lowercased().contains($0) } ?? false)
+            guard wasKilled else { continue }   // present in the table but not the victim
             let rpages = (proc["rpages"] as? Int) ?? (proc["pages"] as? Int) ?? 0
             let bytes = UInt64(max(0, rpages)) &* UInt64(max(0, pageSize))
-            let reason = (proc["reason"] as? String) ?? (proc["killDelta"] as? String)
             return Finding(
                 source: .jetsamReport,
                 message: "jetsam killed \(name) (\(reason ?? "memory pressure"))",

--- a/provider-swift/Sources/ProviderCore/Diagnostics/OOMDetector.swift
+++ b/provider-swift/Sources/ProviderCore/Diagnostics/OOMDetector.swift
@@ -1,0 +1,276 @@
+import Foundation
+
+/// Make out-of-memory crashes VISIBLE.
+///
+/// The defining problem: when macOS jetsam kills the provider for exhausting
+/// unified memory, it sends an uncatchable SIGKILL. No signal handler runs, no
+/// telemetry flushes — the crash leaves no in-process trace. So OOMs are
+/// invisible to our telemetry today (they show up only as a coordinator-side
+/// "read_error" disconnect, indistinguishable from a network blip).
+///
+/// Two complementary detectors recover the signal:
+///  1. **Pre-death marker** — when the provider observes a *critical* memory
+///     pressure event (see `MemoryPressureMonitor`), it writes a small marker
+///     to disk. If we then get SIGKILL'd, the marker survives and the NEXT
+///     launch reports it.
+///  2. **Crash-log scrape** — on launch, scan `~/Library/Logs/DiagnosticReports`
+///     for kernel `JetsamEvent-*.ips` reports and `EXC_RESOURCE` memory crash
+///     reports naming our process, and emit an `oom` telemetry event for each.
+///
+/// Both are best-effort and tolerant: a parse failure must never crash startup.
+public enum OOMDetector {
+
+    // MARK: - Types
+
+    /// Marker written just before a suspected OOM death (on critical pressure).
+    public struct Marker: Codable, Equatable, Sendable {
+        public var pid: Int32
+        public var epochSeconds: Double
+        public var peakMemoryBytes: UInt64
+        public var availableBytesAtEvent: UInt64
+        public var modelId: String?
+
+        public init(pid: Int32, epochSeconds: Double, peakMemoryBytes: UInt64,
+                    availableBytesAtEvent: UInt64, modelId: String? = nil) {
+            self.pid = pid
+            self.epochSeconds = epochSeconds
+            self.peakMemoryBytes = peakMemoryBytes
+            self.availableBytesAtEvent = availableBytesAtEvent
+            self.modelId = modelId
+        }
+    }
+
+    /// One detected OOM signal, ready to be turned into an `oom` telemetry event.
+    public struct Finding: Equatable, Sendable {
+        public enum Source: String, Sendable {
+            case memoryPressureMarker = "memory_pressure_marker"
+            case jetsamReport = "jetsam_report"
+            case memoryCrashReport = "memory_crash_report"
+        }
+        public var source: Source
+        public var message: String
+        public var reason: String?
+        public var peakMemoryBytes: UInt64?
+        public var reportName: String?
+        public var epochSeconds: Double?
+
+        public init(source: Source, message: String, reason: String? = nil,
+                    peakMemoryBytes: UInt64? = nil, reportName: String? = nil,
+                    epochSeconds: Double? = nil) {
+            self.source = source
+            self.message = message
+            self.reason = reason
+            self.peakMemoryBytes = peakMemoryBytes
+            self.reportName = reportName
+            self.epochSeconds = epochSeconds
+        }
+    }
+
+    // MARK: - Paths
+
+    /// Marker lives under ~/.darkbloom/ — a stable, daemon-writable location
+    /// (the install dir under /usr/local may be read-only for the daemon).
+    public static func defaultMarkerURL(
+        home: URL = FileManager.default.homeDirectoryForCurrentUser
+    ) -> URL {
+        home.appendingPathComponent(".darkbloom").appendingPathComponent("oom_marker.json")
+    }
+
+    public static func defaultDiagnosticReportsURL(
+        home: URL = FileManager.default.homeDirectoryForCurrentUser
+    ) -> URL {
+        home.appendingPathComponent("Library/Logs/DiagnosticReports")
+    }
+
+    /// Watermark of the last crash-log scan. Scanning only reports modified
+    /// after this avoids re-emitting the same JetsamEvent on every launch — the
+    /// difference between one OOM event and a crashloop spamming the same report.
+    public static func defaultLastScanURL(
+        home: URL = FileManager.default.homeDirectoryForCurrentUser
+    ) -> URL {
+        home.appendingPathComponent(".darkbloom").appendingPathComponent("oom_last_scan")
+    }
+
+    public static func loadLastScan(at url: URL = defaultLastScanURL()) -> Date? {
+        guard let raw = try? String(contentsOf: url, encoding: .utf8),
+              let epoch = Double(raw.trimmingCharacters(in: .whitespacesAndNewlines))
+        else { return nil }
+        return Date(timeIntervalSince1970: epoch)
+    }
+
+    public static func saveLastScan(_ date: Date, at url: URL = defaultLastScanURL()) {
+        try? FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try? String(date.timeIntervalSince1970).write(to: url, atomically: true, encoding: .utf8)
+    }
+
+    // MARK: - Marker I/O
+
+    public static func writeMarker(_ marker: Marker, to url: URL = defaultMarkerURL()) {
+        do {
+            try FileManager.default.createDirectory(
+                at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+            let data = try JSONEncoder().encode(marker)
+            try data.write(to: url, options: .atomic)
+        } catch {
+            // Best-effort: a marker we can't write just means this particular
+            // OOM stays invisible — never fatal.
+        }
+    }
+
+    /// Read the marker and delete it (consume-once) so the same event isn't
+    /// reported on every subsequent launch.
+    @discardableResult
+    public static func readAndClearMarker(at url: URL = defaultMarkerURL()) -> Marker? {
+        guard let data = try? Data(contentsOf: url) else { return nil }
+        defer { try? FileManager.default.removeItem(at: url) }
+        return try? JSONDecoder().decode(Marker.self, from: data)
+    }
+
+    // MARK: - Pure parsers (.ips reports)
+
+    /// Parse a kernel `JetsamEvent-*.ips` report. These are two-part documents:
+    /// a one-line JSON header followed by a JSON body containing a `processes`
+    /// array. Returns a finding if our process appears among the killed
+    /// processes. Pure + tolerant: any malformed input returns nil.
+    public static func parseJetsamReport(contents: String, processName: String) -> Finding? {
+        guard let body = jsonBody(from: contents) else { return nil }
+        let pageSize = (body["pageSize"] as? Int)
+            ?? ((body["memoryStatus"] as? [String: Any])?["pageSize"] as? Int)
+            ?? 16384
+        guard let processes = body["processes"] as? [[String: Any]] else { return nil }
+        let needle = processName.lowercased()
+        for proc in processes {
+            guard let name = proc["name"] as? String, name.lowercased().contains(needle) else { continue }
+            let rpages = (proc["rpages"] as? Int) ?? (proc["pages"] as? Int) ?? 0
+            let bytes = UInt64(max(0, rpages)) &* UInt64(max(0, pageSize))
+            let reason = (proc["reason"] as? String) ?? (proc["killDelta"] as? String)
+            return Finding(
+                source: .jetsamReport,
+                message: "jetsam killed \(name) (\(reason ?? "memory pressure"))",
+                reason: reason,
+                peakMemoryBytes: bytes > 0 ? bytes : nil)
+        }
+        return nil
+    }
+
+    /// Parse a process crash `.ips` for a memory kill: `EXC_RESOURCE` with a
+    /// MEMORY subtype, or a JETSAM termination namespace. Pure + tolerant.
+    public static func parseMemoryCrashReport(contents: String, processName: String) -> Finding? {
+        guard let header = jsonHeader(from: contents) else { return nil }
+        // Header names the app; only consider reports for our process.
+        let appName = (header["app_name"] as? String) ?? (header["procName"] as? String) ?? ""
+        guard appName.lowercased().contains(processName.lowercased()) else { return nil }
+        guard let body = jsonBody(from: contents) else { return nil }
+
+        if let exception = body["exception"] as? [String: Any] {
+            let type = (exception["type"] as? String) ?? ""
+            let subtype = (exception["subtype"] as? String) ?? ""
+            if type.contains("EXC_RESOURCE") && subtype.uppercased().contains("MEMORY") {
+                return Finding(
+                    source: .memoryCrashReport,
+                    message: "\(appName) hit memory resource limit (\(subtype))",
+                    reason: subtype)
+            }
+        }
+        if let termination = body["termination"] as? [String: Any] {
+            let namespace = (termination["namespace"] as? String) ?? ""
+            if namespace.uppercased().contains("JETSAM") {
+                let reason = (termination["indicator"] as? String) ?? namespace
+                return Finding(
+                    source: .memoryCrashReport,
+                    message: "\(appName) terminated by jetsam (\(reason))",
+                    reason: reason)
+            }
+        }
+        return nil
+    }
+
+    // MARK: - Launch detection (I/O)
+
+    /// Scan DiagnosticReports for OOM-relevant reports modified since `since`.
+    /// Best-effort; returns [] on any directory/read error.
+    public static func scanDiagnosticReports(
+        dir: URL,
+        processName: String,
+        since: Date,
+        fileManager: FileManager = .default
+    ) -> [Finding] {
+        guard let entries = try? fileManager.contentsOfDirectory(
+            at: dir, includingPropertiesForKeys: [.contentModificationDateKey], options: [.skipsHiddenFiles])
+        else { return [] }
+
+        var findings: [Finding] = []
+        for url in entries {
+            let ext = url.pathExtension.lowercased()
+            guard ext == "ips" || ext == "panic" else { continue }
+            let name = url.lastPathComponent
+            let mtime = (try? url.resourceValues(forKeys: [.contentModificationDateKey]))?.contentModificationDate
+            if let mtime, mtime < since { continue }
+            guard let contents = try? String(contentsOf: url, encoding: .utf8) else { continue }
+
+            let isJetsam = name.hasPrefix("JetsamEvent")
+            var finding: Finding?
+            if isJetsam {
+                finding = parseJetsamReport(contents: contents, processName: processName)
+            } else {
+                finding = parseMemoryCrashReport(contents: contents, processName: processName)
+            }
+            if var f = finding {
+                f.reportName = name
+                f.epochSeconds = mtime?.timeIntervalSince1970
+                findings.append(f)
+            }
+        }
+        return findings
+    }
+
+    /// Full launch-time detection: consume any pre-death marker AND scan crash
+    /// logs since `since`. Returns all findings to emit as `oom` telemetry.
+    public static func detectOnLaunch(
+        markerURL: URL = defaultMarkerURL(),
+        diagnosticReportsDir: URL = defaultDiagnosticReportsURL(),
+        processName: String = "darkbloom",
+        since: Date,
+        fileManager: FileManager = .default
+    ) -> [Finding] {
+        var findings: [Finding] = []
+        if let marker = readAndClearMarker(at: markerURL) {
+            findings.append(Finding(
+                source: .memoryPressureMarker,
+                message: "provider observed critical memory pressure before exit (likely OOM)",
+                peakMemoryBytes: marker.peakMemoryBytes > 0 ? marker.peakMemoryBytes : nil,
+                epochSeconds: marker.epochSeconds))
+        }
+        findings.append(contentsOf: scanDiagnosticReports(
+            dir: diagnosticReportsDir, processName: processName, since: since, fileManager: fileManager))
+        return findings
+    }
+
+    // MARK: - JSON helpers
+
+    /// The first JSON object in an `.ips` document (the one-line header).
+    static func jsonHeader(from contents: String) -> [String: Any]? {
+        guard let firstLine = contents.split(separator: "\n", maxSplits: 1, omittingEmptySubsequences: true).first,
+              let data = firstLine.data(using: .utf8),
+              let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else { return nil }
+        return obj
+    }
+
+    /// The JSON body of an `.ips` document. Some reports are a single JSON
+    /// object (whole file parses); most are header-line + body. Try whole-file
+    /// first, then everything after the first newline.
+    static func jsonBody(from contents: String) -> [String: Any]? {
+        if let data = contents.data(using: .utf8),
+           let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+            return obj
+        }
+        let parts = contents.split(separator: "\n", maxSplits: 1, omittingEmptySubsequences: true)
+        guard parts.count == 2,
+              let data = parts[1].data(using: .utf8),
+              let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else { return nil }
+        return obj
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Diagnostics/OOMDetector.swift
+++ b/provider-swift/Sources/ProviderCore/Diagnostics/OOMDetector.swift
@@ -63,10 +63,18 @@ public enum OOMDetector {
         home.appendingPathComponent(".darkbloom").appendingPathComponent("oom_marker.json")
     }
 
-    public static func defaultDiagnosticReportsURL(
+    /// Where macOS writes crash/jetsam reports. KERNEL jetsam reports
+    /// (`JetsamEvent-*.ips`) land in the SYSTEM tree `/Library/Logs/...`, not the
+    /// per-user `~/Library/...` — so we must scan both, plus each `Retired`
+    /// subdir where older reports are moved. Missing/unreadable dirs are skipped.
+    public static func defaultDiagnosticReportsDirs(
         home: URL = FileManager.default.homeDirectoryForCurrentUser
-    ) -> URL {
-        home.appendingPathComponent("Library/Logs/DiagnosticReports")
+    ) -> [URL] {
+        let bases = [
+            home.appendingPathComponent("Library/Logs/DiagnosticReports"),
+            URL(fileURLWithPath: "/Library/Logs/DiagnosticReports"),
+        ]
+        return bases + bases.map { $0.appendingPathComponent("Retired") }
     }
 
     /// Last-scan watermark: only reports newer than this are emitted, so a
@@ -112,6 +120,15 @@ public enum OOMDetector {
         return try? JSONDecoder().decode(Marker.self, from: data)
     }
 
+    /// Delete the marker on a GRACEFUL exit. The marker is written on critical
+    /// pressure; if the provider then survives and stops/updates cleanly, this
+    /// removes it so the next normal launch doesn't misreport a recovered
+    /// pressure spike as an OOM. A jetsam SIGKILL bypasses this, leaving the
+    /// marker to be reported — exactly the case we want.
+    public static func clearMarker(at url: URL = defaultMarkerURL()) {
+        try? FileManager.default.removeItem(at: url)
+    }
+
     // MARK: - Launch detection (I/O)
     // (.ips parsing lives in OOMDetector+CrashReports.swift)
 
@@ -152,25 +169,37 @@ public enum OOMDetector {
         return findings
     }
 
-    /// Full launch-time detection: consume any pre-death marker AND scan crash
-    /// logs since `since`. Returns all findings to emit as `oom` telemetry.
+    /// Full launch-time detection: scan crash logs since `since` AND consume any
+    /// pre-death marker. Returns the findings to emit as `oom` telemetry.
     public static func detectOnLaunch(
         markerURL: URL = defaultMarkerURL(),
-        diagnosticReportsDir: URL = defaultDiagnosticReportsURL(),
+        diagnosticReportsDirs: [URL] = defaultDiagnosticReportsDirs(),
         processName: String = "darkbloom",
         since: Date,
         fileManager: FileManager = .default
     ) -> [Finding] {
-        var findings: [Finding] = []
-        if let marker = readAndClearMarker(at: markerURL) {
-            findings.append(Finding(
+        // Crash reports are the authoritative signal. Scan every candidate dir
+        // (user + system + Retired); dedupe by report filename across dirs.
+        var seenReports = Set<String>()
+        var crashFindings: [Finding] = []
+        for dir in diagnosticReportsDirs {
+            for f in scanDiagnosticReports(dir: dir, processName: processName, since: since, fileManager: fileManager) {
+                if let name = f.reportName, !seenReports.insert(name).inserted { continue }
+                crashFindings.append(f)
+            }
+        }
+
+        // Always consume the marker (so it never lingers), but only surface it
+        // when no crash report already attributes this death — otherwise one OOM
+        // would emit twice (marker + JetsamEvent).
+        let marker = readAndClearMarker(at: markerURL)
+        if crashFindings.isEmpty, let marker {
+            return [Finding(
                 source: .memoryPressureMarker,
                 message: "provider observed critical memory pressure before exit (likely OOM)",
                 peakMemoryBytes: marker.peakMemoryBytes > 0 ? marker.peakMemoryBytes : nil,
-                epochSeconds: marker.epochSeconds))
+                epochSeconds: marker.epochSeconds)]
         }
-        findings.append(contentsOf: scanDiagnosticReports(
-            dir: diagnosticReportsDir, processName: processName, since: since, fileManager: fileManager))
-        return findings
+        return crashFindings
     }
 }

--- a/provider-swift/Sources/ProviderCore/Diagnostics/OOMDetector.swift
+++ b/provider-swift/Sources/ProviderCore/Diagnostics/OOMDetector.swift
@@ -112,64 +112,8 @@ public enum OOMDetector {
         return try? JSONDecoder().decode(Marker.self, from: data)
     }
 
-    // MARK: - Pure parsers (.ips reports)
-
-    /// Parse a kernel `JetsamEvent-*.ips` (header line + JSON body with a
-    /// `processes` array); finding iff our process was killed. Pure + tolerant.
-    public static func parseJetsamReport(contents: String, processName: String) -> Finding? {
-        guard let body = jsonBody(from: contents) else { return nil }
-        let pageSize = (body["pageSize"] as? Int)
-            ?? ((body["memoryStatus"] as? [String: Any])?["pageSize"] as? Int)
-            ?? 16384
-        guard let processes = body["processes"] as? [[String: Any]] else { return nil }
-        let needle = processName.lowercased()
-        for proc in processes {
-            guard let name = proc["name"] as? String, name.lowercased().contains(needle) else { continue }
-            let rpages = (proc["rpages"] as? Int) ?? (proc["pages"] as? Int) ?? 0
-            let bytes = UInt64(max(0, rpages)) &* UInt64(max(0, pageSize))
-            let reason = (proc["reason"] as? String) ?? (proc["killDelta"] as? String)
-            return Finding(
-                source: .jetsamReport,
-                message: "jetsam killed \(name) (\(reason ?? "memory pressure"))",
-                reason: reason,
-                peakMemoryBytes: bytes > 0 ? bytes : nil)
-        }
-        return nil
-    }
-
-    /// Parse a process crash `.ips` for a memory kill: `EXC_RESOURCE` with a
-    /// MEMORY subtype, or a JETSAM termination namespace. Pure + tolerant.
-    public static func parseMemoryCrashReport(contents: String, processName: String) -> Finding? {
-        guard let header = jsonHeader(from: contents) else { return nil }
-        // Header names the app; only consider reports for our process.
-        let appName = (header["app_name"] as? String) ?? (header["procName"] as? String) ?? ""
-        guard appName.lowercased().contains(processName.lowercased()) else { return nil }
-        guard let body = jsonBody(from: contents) else { return nil }
-
-        if let exception = body["exception"] as? [String: Any] {
-            let type = (exception["type"] as? String) ?? ""
-            let subtype = (exception["subtype"] as? String) ?? ""
-            if type.contains("EXC_RESOURCE") && subtype.uppercased().contains("MEMORY") {
-                return Finding(
-                    source: .memoryCrashReport,
-                    message: "\(appName) hit memory resource limit (\(subtype))",
-                    reason: subtype)
-            }
-        }
-        if let termination = body["termination"] as? [String: Any] {
-            let namespace = (termination["namespace"] as? String) ?? ""
-            if namespace.uppercased().contains("JETSAM") {
-                let reason = (termination["indicator"] as? String) ?? namespace
-                return Finding(
-                    source: .memoryCrashReport,
-                    message: "\(appName) terminated by jetsam (\(reason))",
-                    reason: reason)
-            }
-        }
-        return nil
-    }
-
     // MARK: - Launch detection (I/O)
+    // (.ips parsing lives in OOMDetector+CrashReports.swift)
 
     /// Scan DiagnosticReports for OOM-relevant reports modified since `since`.
     /// Best-effort; returns [] on any directory/read error.
@@ -228,30 +172,5 @@ public enum OOMDetector {
         findings.append(contentsOf: scanDiagnosticReports(
             dir: diagnosticReportsDir, processName: processName, since: since, fileManager: fileManager))
         return findings
-    }
-
-    // MARK: - JSON helpers
-
-    /// The first JSON object in an `.ips` document (the one-line header).
-    static func jsonHeader(from contents: String) -> [String: Any]? {
-        guard let firstLine = contents.split(separator: "\n", maxSplits: 1, omittingEmptySubsequences: true).first,
-              let data = firstLine.data(using: .utf8),
-              let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
-        else { return nil }
-        return obj
-    }
-
-    /// The JSON body of an `.ips`: whole-file if it parses, else after line 1.
-    static func jsonBody(from contents: String) -> [String: Any]? {
-        if let data = contents.data(using: .utf8),
-           let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
-            return obj
-        }
-        let parts = contents.split(separator: "\n", maxSplits: 1, omittingEmptySubsequences: true)
-        guard parts.count == 2,
-              let data = parts[1].data(using: .utf8),
-              let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
-        else { return nil }
-        return obj
     }
 }

--- a/provider-swift/Sources/ProviderCore/Diagnostics/OOMDetector.swift
+++ b/provider-swift/Sources/ProviderCore/Diagnostics/OOMDetector.swift
@@ -1,23 +1,11 @@
 import Foundation
 
-/// Make out-of-memory crashes VISIBLE.
-///
-/// The defining problem: when macOS jetsam kills the provider for exhausting
-/// unified memory, it sends an uncatchable SIGKILL. No signal handler runs, no
-/// telemetry flushes — the crash leaves no in-process trace. So OOMs are
-/// invisible to our telemetry today (they show up only as a coordinator-side
-/// "read_error" disconnect, indistinguishable from a network blip).
-///
-/// Two complementary detectors recover the signal:
-///  1. **Pre-death marker** — when the provider observes a *critical* memory
-///     pressure event (see `MemoryPressureMonitor`), it writes a small marker
-///     to disk. If we then get SIGKILL'd, the marker survives and the NEXT
-///     launch reports it.
-///  2. **Crash-log scrape** — on launch, scan `~/Library/Logs/DiagnosticReports`
-///     for kernel `JetsamEvent-*.ips` reports and `EXC_RESOURCE` memory crash
-///     reports naming our process, and emit an `oom` telemetry event for each.
-///
-/// Both are best-effort and tolerant: a parse failure must never crash startup.
+/// Make OOM crashes visible. A jetsam SIGKILL is uncatchable and flushes no
+/// telemetry, so OOMs surface only as a coordinator-side "read_error" disconnect.
+/// Two best-effort detectors recover the signal: (1) a pre-death marker written
+/// on critical memory pressure that the NEXT launch reports; (2) a launch scan of
+/// ~/Library/Logs/DiagnosticReports for JetsamEvent/EXC_RESOURCE reports naming
+/// our process. Tolerant: a parse failure never crashes startup.
 public enum OOMDetector {
 
     // MARK: - Types
@@ -68,8 +56,7 @@ public enum OOMDetector {
 
     // MARK: - Paths
 
-    /// Marker lives under ~/.darkbloom/ — a stable, daemon-writable location
-    /// (the install dir under /usr/local may be read-only for the daemon).
+    /// ~/.darkbloom/ — stable + daemon-writable (the /usr/local install dir may not be).
     public static func defaultMarkerURL(
         home: URL = FileManager.default.homeDirectoryForCurrentUser
     ) -> URL {
@@ -82,9 +69,8 @@ public enum OOMDetector {
         home.appendingPathComponent("Library/Logs/DiagnosticReports")
     }
 
-    /// Watermark of the last crash-log scan. Scanning only reports modified
-    /// after this avoids re-emitting the same JetsamEvent on every launch — the
-    /// difference between one OOM event and a crashloop spamming the same report.
+    /// Last-scan watermark: only reports newer than this are emitted, so a
+    /// crashloop doesn't re-report the same JetsamEvent every launch.
     public static func defaultLastScanURL(
         home: URL = FileManager.default.homeDirectoryForCurrentUser
     ) -> URL {
@@ -113,8 +99,7 @@ public enum OOMDetector {
             let data = try JSONEncoder().encode(marker)
             try data.write(to: url, options: .atomic)
         } catch {
-            // Best-effort: a marker we can't write just means this particular
-            // OOM stays invisible — never fatal.
+            // Best-effort: a marker we can't write just keeps this OOM invisible.
         }
     }
 
@@ -129,10 +114,8 @@ public enum OOMDetector {
 
     // MARK: - Pure parsers (.ips reports)
 
-    /// Parse a kernel `JetsamEvent-*.ips` report. These are two-part documents:
-    /// a one-line JSON header followed by a JSON body containing a `processes`
-    /// array. Returns a finding if our process appears among the killed
-    /// processes. Pure + tolerant: any malformed input returns nil.
+    /// Parse a kernel `JetsamEvent-*.ips` (header line + JSON body with a
+    /// `processes` array); finding iff our process was killed. Pure + tolerant.
     public static func parseJetsamReport(contents: String, processName: String) -> Finding? {
         guard let body = jsonBody(from: contents) else { return nil }
         let pageSize = (body["pageSize"] as? Int)
@@ -258,9 +241,7 @@ public enum OOMDetector {
         return obj
     }
 
-    /// The JSON body of an `.ips` document. Some reports are a single JSON
-    /// object (whole file parses); most are header-line + body. Try whole-file
-    /// first, then everything after the first newline.
+    /// The JSON body of an `.ips`: whole-file if it parses, else after line 1.
     static func jsonBody(from contents: String) -> [String: Any]? {
         if let data = contents.data(using: .utf8),
            let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {

--- a/provider-swift/Sources/ProviderCore/Inference/BatchScheduler+Telemetry.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/BatchScheduler+Telemetry.swift
@@ -43,7 +43,16 @@ extension BatchScheduler {
         let osReserve = 4 * 1024 * 1024 * 1024
         let safetyMargin = totalMemory / 10
         let globalUsed = Int(MLX.GPU.activeMemory) + Int(MLX.GPU.cacheMemory)
-        let availableHeadroom = max(0, totalMemory - osReserve - safetyMargin - globalUsed)
+        let mlxFree = max(0, totalMemory - globalUsed)
+        // Clamp the MLX-only free figure to what the OS actually reports
+        // available. `totalMemory - MLX.active - MLX.cache` is blind to every
+        // other process on the box, so on a shared office Mac it over-reports
+        // free RAM by whatever Chrome/Xcode/etc. hold — the same OOM hole the
+        // model-load gate and GlobalKVCacheBudget already close via
+        // min(mlxFree, SystemMemory.availableBytes()).
+        let osAvailable = SystemMemory.availableBytes().map { Int(min($0, UInt64(Int.max))) } ?? Int.max
+        let realFree = min(mlxFree, osAvailable)
+        let availableHeadroom = max(0, realFree - osReserve - safetyMargin)
         let liveBudget = activeTokenBudgetUsed + (availableHeadroom / kvBytesPerToken)
         return max(1024, min(staticBudget, liveBudget))
     }

--- a/provider-swift/Sources/ProviderCore/Inference/BatchScheduler+Telemetry.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/BatchScheduler+Telemetry.swift
@@ -44,12 +44,8 @@ extension BatchScheduler {
         let safetyMargin = totalMemory / 10
         let globalUsed = Int(MLX.GPU.activeMemory) + Int(MLX.GPU.cacheMemory)
         let mlxFree = max(0, totalMemory - globalUsed)
-        // Clamp the MLX-only free figure to what the OS actually reports
-        // available. `totalMemory - MLX.active - MLX.cache` is blind to every
-        // other process on the box, so on a shared office Mac it over-reports
-        // free RAM by whatever Chrome/Xcode/etc. hold — the same OOM hole the
-        // model-load gate and GlobalKVCacheBudget already close via
-        // min(mlxFree, SystemMemory.availableBytes()).
+        // Clamp the MLX-only view to real OS-free RAM (other processes' usage),
+        // same as the load gate / GlobalKVCacheBudget; else we OOM on shared boxes.
         let osAvailable = SystemMemory.availableBytes().map { Int(min($0, UInt64(Int.max))) } ?? Int.max
         let realFree = min(mlxFree, osAvailable)
         let availableHeadroom = max(0, realFree - osReserve - safetyMargin)

--- a/provider-swift/Sources/ProviderCore/Inference/BatchScheduler.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/BatchScheduler.swift
@@ -196,10 +196,8 @@ public actor BatchScheduler {
             return
         }
 
-        // Pin MLX's unified-memory ceiling below physical RAM (idempotent, once
-        // per process). MLX defaults memoryLimit to 1.5× the device working set
-        // — above physical RAM — so without this it can allocate the machine
-        // into a jetsam SIGKILL (an invisible OOM). See MLXMemoryGuard.
+        // Pin MLX's memory ceiling below physical RAM (idempotent). MLX's default
+        // (1.5× working set, above RAM) otherwise allows a jetsam OOM. See MLXMemoryGuard.
         MLXMemoryGuard.configureOnce(log: { limits in
             FileHandle.standardError.write(Data(
                 "[mlx] memory ceiling set: limit=\(limits.memoryLimitBytes / (1024*1024*1024))GB cache=\(limits.cacheLimitBytes / (1024*1024*1024))GB\n".utf8

--- a/provider-swift/Sources/ProviderCore/Inference/BatchScheduler.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/BatchScheduler.swift
@@ -196,6 +196,16 @@ public actor BatchScheduler {
             return
         }
 
+        // Pin MLX's unified-memory ceiling below physical RAM (idempotent, once
+        // per process). MLX defaults memoryLimit to 1.5× the device working set
+        // — above physical RAM — so without this it can allocate the machine
+        // into a jetsam SIGKILL (an invisible OOM). See MLXMemoryGuard.
+        MLXMemoryGuard.configureOnce(log: { limits in
+            FileHandle.standardError.write(Data(
+                "[mlx] memory ceiling set: limit=\(limits.memoryLimitBytes / (1024*1024*1024))GB cache=\(limits.cacheLimitBytes / (1024*1024*1024))GB\n".utf8
+            ))
+        })
+
         await stopCurrentEngine()
         let loadEpoch = generationEpoch
 

--- a/provider-swift/Sources/ProviderCore/Inference/GlobalKVCacheBudget.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/GlobalKVCacheBudget.swift
@@ -5,29 +5,37 @@ import MLX
 /// schedulers. MLX active/cache counters are global, so per-scheduler token
 /// budgets can otherwise admit requests against the same apparent headroom.
 public actor GlobalKVCacheBudget {
+    /// The four memory figures an admission decision needs: physical total, MLX's
+    /// own active + cache, and the OS's real free RAM (the cross-process view).
+    public struct MemorySnapshot: Sendable {
+        public var total: UInt64
+        public var active: UInt64
+        public var cache: UInt64
+        public var systemAvailable: UInt64
+    }
+
     private let safetyFactor: Double
     private let reserveBytes: UInt64
-    private let memorySnapshot: @Sendable () -> (total: UInt64, active: UInt64, cache: UInt64, systemAvailable: UInt64)
+    private let memorySnapshot: @Sendable () -> MemorySnapshot
     private var reservations: [String: UInt64] = [:]
 
     public init(reserveBytes: UInt64 = 0, safetyFactor: Double = 0.7) {
         self.reserveBytes = reserveBytes
         self.safetyFactor = Self.clampedSafetyFactor(safetyFactor)
         self.memorySnapshot = {
-            (
+            MemorySnapshot(
                 total: ProcessInfo.processInfo.physicalMemory,
                 active: UInt64(Memory.activeMemory),
                 cache: UInt64(Memory.cacheMemory),
                 // Real OS-free RAM; `.max` falls back to the MLX-only view.
-                systemAvailable: SystemMemory.availableBytes() ?? .max
-            )
+                systemAvailable: SystemMemory.availableBytes() ?? .max)
         }
     }
 
     init(
         reserveBytes: UInt64 = 0,
         safetyFactor: Double = 0.7,
-        memorySnapshot: @escaping @Sendable () -> (total: UInt64, active: UInt64, cache: UInt64, systemAvailable: UInt64)
+        memorySnapshot: @escaping @Sendable () -> MemorySnapshot
     ) {
         self.reserveBytes = reserveBytes
         self.safetyFactor = Self.clampedSafetyFactor(safetyFactor)
@@ -78,13 +86,13 @@ public actor GlobalKVCacheBudget {
     }
 
     private func availableReservationBytes() -> UInt64 {
-        let (total, active, cache, systemAvailable) = memorySnapshot()
-        let mlxUsed = Self.saturatingAdd(active, cache)
-        let mlxFree = total > mlxUsed ? total - mlxUsed : 0
+        let snap = memorySnapshot()
+        let mlxUsed = Self.saturatingAdd(snap.active, snap.cache)
+        let mlxFree = snap.total > mlxUsed ? snap.total - mlxUsed : 0
         // Clamp the MLX-only view (blind to other processes) to real OS-free RAM,
         // mirroring the load gate (ModelLoadAdmission.freeForLoadGb). Without it
         // the runtime admits against memory other apps hold → jetsam OOM.
-        let realFree = min(mlxFree, systemAvailable)
+        let realFree = min(mlxFree, snap.systemAvailable)
         let usable = realFree > reserveBytes ? realFree - reserveBytes : 0
         let capped = Double(usable) * safetyFactor
         let reservationCap = capped >= Double(UInt64.max) ? UInt64.max : UInt64(capped)

--- a/provider-swift/Sources/ProviderCore/Inference/GlobalKVCacheBudget.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/GlobalKVCacheBudget.swift
@@ -18,9 +18,7 @@ public actor GlobalKVCacheBudget {
                 total: ProcessInfo.processInfo.physicalMemory,
                 active: UInt64(Memory.activeMemory),
                 cache: UInt64(Memory.cacheMemory),
-                // Real OS-available memory (free + reclaimable), accounting for
-                // every other process on the box. `.max` when unavailable so we
-                // fall back to the MLX-only view rather than admitting nothing.
+                // Real OS-free RAM; `.max` falls back to the MLX-only view.
                 systemAvailable: SystemMemory.availableBytes() ?? .max
             )
         }
@@ -81,16 +79,11 @@ public actor GlobalKVCacheBudget {
 
     private func availableReservationBytes() -> UInt64 {
         let (total, active, cache, systemAvailable) = memorySnapshot()
-        // MLX-only view: physical total minus what MLX itself holds. This is
-        // blind to every other process on the machine, so on a shared office
-        // Mac it over-reports free memory by whatever Chrome/Xcode/etc. hold.
         let mlxUsed = Self.saturatingAdd(active, cache)
         let mlxFree = total > mlxUsed ? total - mlxUsed : 0
-        // Clamp to what the OS actually reports available. The tighter of the
-        // two bounds wins — the exact same clamp the model-LOAD gate applies
-        // (`ModelLoadAdmission.freeForLoadGb`: realFree = min(mlxFree, OS-free)).
-        // Without this, the runtime KV path admits requests against memory other
-        // processes have already taken and drives the box into a jetsam OOM kill.
+        // Clamp the MLX-only view (blind to other processes) to real OS-free RAM,
+        // mirroring the load gate (ModelLoadAdmission.freeForLoadGb). Without it
+        // the runtime admits against memory other apps hold → jetsam OOM.
         let realFree = min(mlxFree, systemAvailable)
         let usable = realFree > reserveBytes ? realFree - reserveBytes : 0
         let capped = Double(usable) * safetyFactor

--- a/provider-swift/Sources/ProviderCore/Inference/GlobalKVCacheBudget.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/GlobalKVCacheBudget.swift
@@ -7,7 +7,7 @@ import MLX
 public actor GlobalKVCacheBudget {
     private let safetyFactor: Double
     private let reserveBytes: UInt64
-    private let memorySnapshot: @Sendable () -> (total: UInt64, active: UInt64, cache: UInt64)
+    private let memorySnapshot: @Sendable () -> (total: UInt64, active: UInt64, cache: UInt64, systemAvailable: UInt64)
     private var reservations: [String: UInt64] = [:]
 
     public init(reserveBytes: UInt64 = 0, safetyFactor: Double = 0.7) {
@@ -17,7 +17,11 @@ public actor GlobalKVCacheBudget {
             (
                 total: ProcessInfo.processInfo.physicalMemory,
                 active: UInt64(Memory.activeMemory),
-                cache: UInt64(Memory.cacheMemory)
+                cache: UInt64(Memory.cacheMemory),
+                // Real OS-available memory (free + reclaimable), accounting for
+                // every other process on the box. `.max` when unavailable so we
+                // fall back to the MLX-only view rather than admitting nothing.
+                systemAvailable: SystemMemory.availableBytes() ?? .max
             )
         }
     }
@@ -25,7 +29,7 @@ public actor GlobalKVCacheBudget {
     init(
         reserveBytes: UInt64 = 0,
         safetyFactor: Double = 0.7,
-        memorySnapshot: @escaping @Sendable () -> (total: UInt64, active: UInt64, cache: UInt64)
+        memorySnapshot: @escaping @Sendable () -> (total: UInt64, active: UInt64, cache: UInt64, systemAvailable: UInt64)
     ) {
         self.reserveBytes = reserveBytes
         self.safetyFactor = Self.clampedSafetyFactor(safetyFactor)
@@ -76,9 +80,19 @@ public actor GlobalKVCacheBudget {
     }
 
     private func availableReservationBytes() -> UInt64 {
-        let (total, active, cache) = memorySnapshot()
-        let usedBeforeReservations = Self.saturatingAdd(active, cache, reserveBytes)
-        let usable = total > usedBeforeReservations ? total - usedBeforeReservations : 0
+        let (total, active, cache, systemAvailable) = memorySnapshot()
+        // MLX-only view: physical total minus what MLX itself holds. This is
+        // blind to every other process on the machine, so on a shared office
+        // Mac it over-reports free memory by whatever Chrome/Xcode/etc. hold.
+        let mlxUsed = Self.saturatingAdd(active, cache)
+        let mlxFree = total > mlxUsed ? total - mlxUsed : 0
+        // Clamp to what the OS actually reports available. The tighter of the
+        // two bounds wins — the exact same clamp the model-LOAD gate applies
+        // (`ModelLoadAdmission.freeForLoadGb`: realFree = min(mlxFree, OS-free)).
+        // Without this, the runtime KV path admits requests against memory other
+        // processes have already taken and drives the box into a jetsam OOM kill.
+        let realFree = min(mlxFree, systemAvailable)
+        let usable = realFree > reserveBytes ? realFree - reserveBytes : 0
         let capped = Double(usable) * safetyFactor
         let reservationCap = capped >= Double(UInt64.max) ? UInt64.max : UInt64(capped)
         let reserved = reservations.values.reduce(UInt64(0)) { partial, value in

--- a/provider-swift/Sources/ProviderCore/Inference/MLXMemoryGuard.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/MLXMemoryGuard.swift
@@ -1,0 +1,117 @@
+import Foundation
+import MLX
+
+/// Hard ceiling on MLX's unified-memory footprint.
+///
+/// THE PROBLEM: on Apple Silicon, MLX allocates GPU buffers from the same
+/// unified-memory pool as the OS. MLX's `memoryLimit` defaults to **1.5× the
+/// device's recommended max working-set size** — which is *above* physical RAM —
+/// so by default MLX will happily try to allocate past total RAM. When it does,
+/// macOS jetsam sends the process an uncatchable SIGKILL: an invisible OOM
+/// crash (no panic, no telemetry — the kill leaves no trace the process can
+/// flush). This is the dominant office-Mac failure mode.
+///
+/// THE GUARD: pin `Memory.memoryLimit` to `physical − reserve` once at startup.
+/// Past that limit MLX's allocator applies backpressure (malloc waits on
+/// scheduled GPU tasks to free memory) instead of racing the machine into a
+/// kernel kill. This is a *coarse backstop*; the precise, live, shared-machine
+/// protection is the per-request admission gate (`GlobalKVCacheBudget` /
+/// `tokenBudgetMax`, which clamp to `SystemMemory.availableBytes()`). The two
+/// are complementary: admission keeps us from *trying* to over-allocate; the
+/// ceiling bounds the blast radius if an estimate is ever wrong.
+public enum MLXMemoryGuard {
+    /// Default headroom (GB) left below physical RAM for macOS + non-MLX
+    /// process memory. Deliberately larger than the per-request load reserve
+    /// (4 GB) because this is the *whole-machine* ceiling: it must leave room
+    /// for the OS, the window server, and whatever else shares the box.
+    public static let defaultReserveGB: UInt64 = 6
+
+    /// Floor so a tiny/misreported machine never gets a pathological (or zero)
+    /// limit that would wedge every allocation.
+    static let minimumLimitBytes = 2 * 1024 * 1024 * 1024  // 2 GiB
+
+    public struct Limits: Equatable, Sendable {
+        public let memoryLimitBytes: Int
+        public let cacheLimitBytes: Int
+    }
+
+    /// Pure, testable sizing policy.
+    /// - memoryLimit = max(floor, physical − reserve)
+    /// - cacheLimit  = memoryLimit × cacheFraction (bounds the reusable buffer
+    ///   pool below the ceiling so freed buffers return to the OS rather than
+    ///   lingering as the classic "MLX memory wedge"). cacheFraction defaults to
+    ///   0.75 — generous enough to preserve reuse/perf, bounded enough to help.
+    static func recommendedLimits(
+        physicalBytes: UInt64,
+        reserveBytes: UInt64,
+        cacheFraction: Double = 0.75
+    ) -> Limits {
+        let physical = Int(min(physicalBytes, UInt64(Int.max)))
+        let reserve = Int(min(reserveBytes, UInt64(Int.max)))
+        let limit = max(minimumLimitBytes, physical > reserve ? physical - reserve : minimumLimitBytes)
+        let fraction = cacheFraction.isFinite ? min(1.0, max(0.0, cacheFraction)) : 0.75
+        let cache = max(minimumLimitBytes / 2, Int(Double(limit) * fraction))
+        return Limits(memoryLimitBytes: limit, cacheLimitBytes: min(cache, limit))
+    }
+
+    /// Resolve the reserve in BYTES from an explicit byte value, the
+    /// `DARKBLOOM_MLX_MEMORY_RESERVE_GB` env override (in GB), or the default.
+    /// `explicit` is bytes — consistent with `reserveBytes` everywhere else
+    /// (GlobalKVCacheBudget, ProviderLoop.memoryReserveBytes).
+    static func resolvedReserveBytes(
+        explicit: UInt64?,
+        env: [String: String] = ProcessInfo.processInfo.environment
+    ) -> UInt64 {
+        if let explicit { return explicit }
+        if let raw = env["DARKBLOOM_MLX_MEMORY_RESERVE_GB"], let gb = Double(raw), gb >= 0, gb.isFinite {
+            return UInt64(min(gb * 1_073_741_824, Double(UInt64.max)))
+        }
+        return saturatingGiBToBytes(defaultReserveGB)
+    }
+
+    private static func saturatingGiBToBytes(_ gib: UInt64) -> UInt64 {
+        let (bytes, overflow) = gib.multipliedReportingOverflow(by: 1_073_741_824)
+        return overflow ? UInt64.max : bytes
+    }
+
+    // Idempotency: the ceiling only needs to be set once per process. loadModel
+    // can run many times (reloads, multi-model), so guard with a lock + flag.
+    private static let lock = NSLock()
+    nonisolated(unsafe) private static var configured = false
+
+    /// Set the MLX memory + cache ceiling once for this process. Idempotent and
+    /// safe to call from every model load. `apply` is injectable for tests so
+    /// they exercise the sizing/once-logic without touching real MLX globals.
+    @discardableResult
+    public static func configureOnce(
+        reserveBytes: UInt64? = nil,
+        physicalBytes: UInt64 = ProcessInfo.processInfo.physicalMemory,
+        apply: (Limits) -> Void = { limits in
+            Memory.memoryLimit = limits.memoryLimitBytes
+            Memory.cacheLimit = limits.cacheLimitBytes
+        },
+        log: ((Limits) -> Void)? = nil
+    ) -> Limits? {
+        lock.lock()
+        if configured {
+            lock.unlock()
+            return nil
+        }
+        configured = true
+        lock.unlock()
+
+        let limits = recommendedLimits(
+            physicalBytes: physicalBytes,
+            reserveBytes: resolvedReserveBytes(explicit: reserveBytes))
+        apply(limits)
+        log?(limits)
+        return limits
+    }
+
+    /// Test-only: reset the once-flag so a test can drive `configureOnce` again.
+    static func _resetForTest() {
+        lock.lock()
+        configured = false
+        lock.unlock()
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Inference/MLXMemoryGuard.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/MLXMemoryGuard.swift
@@ -3,31 +3,18 @@ import MLX
 
 /// Hard ceiling on MLX's unified-memory footprint.
 ///
-/// THE PROBLEM: on Apple Silicon, MLX allocates GPU buffers from the same
-/// unified-memory pool as the OS. MLX's `memoryLimit` defaults to **1.5× the
-/// device's recommended max working-set size** — which is *above* physical RAM —
-/// so by default MLX will happily try to allocate past total RAM. When it does,
-/// macOS jetsam sends the process an uncatchable SIGKILL: an invisible OOM
-/// crash (no panic, no telemetry — the kill leaves no trace the process can
-/// flush). This is the dominant office-Mac failure mode.
-///
-/// THE GUARD: pin `Memory.memoryLimit` to `physical − reserve` once at startup.
-/// Past that limit MLX's allocator applies backpressure (malloc waits on
-/// scheduled GPU tasks to free memory) instead of racing the machine into a
-/// kernel kill. This is a *coarse backstop*; the precise, live, shared-machine
-/// protection is the per-request admission gate (`GlobalKVCacheBudget` /
-/// `tokenBudgetMax`, which clamp to `SystemMemory.availableBytes()`). The two
-/// are complementary: admission keeps us from *trying* to over-allocate; the
-/// ceiling bounds the blast radius if an estimate is ever wrong.
+/// MLX's `memoryLimit` defaults to 1.5× the device working set — above physical
+/// RAM — so by default MLX can allocate past total RAM and hit an uncatchable
+/// jetsam SIGKILL (an invisible OOM). Pinning it to `physical − reserve` makes
+/// the allocator throttle (malloc waits on scheduled tasks) instead. Coarse
+/// backstop; the live per-request gate (GlobalKVCacheBudget / tokenBudgetMax,
+/// clamped to SystemMemory.availableBytes) is the precise one.
 public enum MLXMemoryGuard {
-    /// Default headroom (GB) left below physical RAM for macOS + non-MLX
-    /// process memory. Deliberately larger than the per-request load reserve
-    /// (4 GB) because this is the *whole-machine* ceiling: it must leave room
-    /// for the OS, the window server, and whatever else shares the box.
+    /// Headroom (GB) left below physical RAM for macOS + non-MLX memory. Larger
+    /// than the per-request load reserve (4 GB): this is the whole-machine ceiling.
     public static let defaultReserveGB: UInt64 = 6
 
-    /// Floor so a tiny/misreported machine never gets a pathological (or zero)
-    /// limit that would wedge every allocation.
+    /// Floor so a tiny/misreported machine never gets a pathological limit.
     static let minimumLimitBytes = 2 * 1024 * 1024 * 1024  // 2 GiB
 
     public struct Limits: Equatable, Sendable {
@@ -35,12 +22,9 @@ public enum MLXMemoryGuard {
         public let cacheLimitBytes: Int
     }
 
-    /// Pure, testable sizing policy.
-    /// - memoryLimit = max(floor, physical − reserve)
-    /// - cacheLimit  = memoryLimit × cacheFraction (bounds the reusable buffer
-    ///   pool below the ceiling so freed buffers return to the OS rather than
-    ///   lingering as the classic "MLX memory wedge"). cacheFraction defaults to
-    ///   0.75 — generous enough to preserve reuse/perf, bounded enough to help.
+    /// Pure sizing policy. memoryLimit = max(floor, physical − reserve);
+    /// cacheLimit = memoryLimit × cacheFraction (bounds the reusable pool so
+    /// freed buffers return to the OS; 0.75 keeps reuse/perf while helping).
     static func recommendedLimits(
         physicalBytes: UInt64,
         reserveBytes: UInt64,
@@ -54,10 +38,8 @@ public enum MLXMemoryGuard {
         return Limits(memoryLimitBytes: limit, cacheLimitBytes: min(cache, limit))
     }
 
-    /// Resolve the reserve in BYTES from an explicit byte value, the
-    /// `DARKBLOOM_MLX_MEMORY_RESERVE_GB` env override (in GB), or the default.
-    /// `explicit` is bytes — consistent with `reserveBytes` everywhere else
-    /// (GlobalKVCacheBudget, ProviderLoop.memoryReserveBytes).
+    /// Reserve in BYTES from explicit (bytes), env DARKBLOOM_MLX_MEMORY_RESERVE_GB
+    /// (GB), or default. `explicit` is bytes, like reserveBytes everywhere else.
     static func resolvedReserveBytes(
         explicit: UInt64?,
         env: [String: String] = ProcessInfo.processInfo.environment
@@ -74,14 +56,12 @@ public enum MLXMemoryGuard {
         return overflow ? UInt64.max : bytes
     }
 
-    // Idempotency: the ceiling only needs to be set once per process. loadModel
-    // can run many times (reloads, multi-model), so guard with a lock + flag.
+    // Set once per process; loadModel runs many times, so guard with lock + flag.
     private static let lock = NSLock()
     nonisolated(unsafe) private static var configured = false
 
-    /// Set the MLX memory + cache ceiling once for this process. Idempotent and
-    /// safe to call from every model load. `apply` is injectable for tests so
-    /// they exercise the sizing/once-logic without touching real MLX globals.
+    /// Set the MLX ceiling once per process (idempotent). `apply` is injectable
+    /// for tests so they avoid touching real MLX globals.
     @discardableResult
     public static func configureOnce(
         reserveBytes: UInt64? = nil,

--- a/provider-swift/Sources/ProviderCore/ProviderLoop.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop.swift
@@ -388,6 +388,11 @@ public actor ProviderLoop {
     /// before `run()` starts it.
     private var autoUpdateTask: Task<Void, Never>?
 
+    /// Reacts to kernel memory pressure (reclaim MLX cache, mark an imminent
+    /// OOM). Held for the loop's lifetime so the DispatchSource isn't
+    /// deallocated. See `MemoryPressureMonitor` / `OOMDetector`.
+    private var memoryPressureMonitor: MemoryPressureMonitor?
+
     private let logger = ProviderLogger(subsystem: "dev.darkbloom.provider", category: "loop")
 
     private static let shutdownDrainTimeout: Duration = .seconds(600)
@@ -544,6 +549,12 @@ public actor ProviderLoop {
         // Crash recovery is owned by the WatchdogAgent (separate launchd job,
         // #315) — installed from the serve path, so it reaches auto-updated
         // installs too. KeepAlive stays false to avoid racing the updater.
+
+        // Memory protection: surface any OOM that killed the previous run (a
+        // jetsam SIGKILL leaves no in-process trace) and start reacting to live
+        // kernel memory pressure before the next kill. Best-effort, never throws.
+        startMemoryProtection()
+        defer { memoryPressureMonitor?.cancel() }
 
         // Unified mode: also expose a local OpenAI endpoint off the same loaded
         // models. Started before the coordinator connection so local clients can
@@ -2092,6 +2103,56 @@ public actor ProviderLoop {
             preloadTaskIds.removeValue(forKey: modelId)
             preloadStatusSubscribers.removeValue(forKey: modelId)
         }
+    }
+
+    // MARK: - Memory protection
+
+    /// Surface any prior-run OOM and start reacting to live memory pressure.
+    ///
+    /// A jetsam SIGKILL (the dominant office-Mac OOM) is uncatchable and leaves
+    /// no in-process trace, so we recover the signal two ways: (1) scrape the
+    /// kernel's crash logs + consume any pre-death marker on THIS launch and
+    /// emit an `oom` telemetry event; (2) watch kernel memory pressure and, on
+    /// critical, reclaim MLX's cache and drop a marker so the *next* launch can
+    /// attribute a kill that happens before we can report it. All best-effort.
+    private func startMemoryProtection() {
+        let now = Date()
+        let since = OOMDetector.loadLastScan() ?? now.addingTimeInterval(-24 * 3600)
+        let findings = OOMDetector.detectOnLaunch(since: since)
+        OOMDetector.saveLastScan(now)
+        for finding in findings {
+            var fields: [String: AnyCodableValue] = ["detect_source": .string(finding.source.rawValue)]
+            if let reason = finding.reason { fields["reason"] = .string(reason) }
+            if let peak = finding.peakMemoryBytes { fields["peak_memory_bytes"] = .int64(Int64(clamping: peak)) }
+            if let report = finding.reportName { fields["report"] = .string(report) }
+            TelemetryClient.shared.emit(
+                kind: .oom, severity: .error, message: finding.message, fields: fields)
+            logger.error("OOM detected on launch: \(finding.message)")
+        }
+
+        let monitor = MemoryPressureMonitor(
+            clearCache: { MLX.Memory.clearCache() },
+            writeMarker: { _ in
+                let marker = OOMDetector.Marker(
+                    pid: ProcessInfo.processInfo.processIdentifier,
+                    epochSeconds: Date().timeIntervalSince1970,
+                    peakMemoryBytes: UInt64(max(0, MLX.Memory.peakMemory)),
+                    availableBytesAtEvent: SystemMemory.availableBytes() ?? 0)
+                OOMDetector.writeMarker(marker)
+            },
+            emit: { level, severity in
+                TelemetryClient.shared.emit(
+                    kind: .oom, severity: severity,
+                    message: "memory pressure \(level.rawValue) — possible imminent OOM",
+                    fields: [
+                        "pressure": .string(level.rawValue),
+                        "available_bytes": .int64(Int64(clamping: SystemMemory.availableBytes() ?? 0)),
+                        "mlx_active_bytes": .int64(Int64(clamping: UInt64(max(0, MLX.Memory.activeMemory)))),
+                    ])
+            })
+        monitor.start()
+        self.memoryPressureMonitor = monitor
+        logger.info("Memory protection active (OOM detection + pressure monitor)")
     }
 
     // MARK: - Idle timeout

--- a/provider-swift/Sources/ProviderCore/ProviderLoop.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop.swift
@@ -552,7 +552,13 @@ public actor ProviderLoop {
 
         // Surface any prior-run OOM and react to live memory pressure. Best-effort.
         startMemoryProtection()
-        defer { memoryPressureMonitor?.cancel() }
+        // On any controlled exit (return/throw — i.e. NOT a jetsam SIGKILL),
+        // drop a memory-pressure marker so a survived pressure spike isn't
+        // misreported as an OOM next launch. A real kill bypasses this.
+        defer {
+            memoryPressureMonitor?.cancel()
+            OOMDetector.clearMarker()
+        }
 
         // Unified mode: also expose a local OpenAI endpoint off the same loaded
         // models. Started before the coordinator connection so local clients can
@@ -2109,10 +2115,18 @@ public actor ProviderLoop {
     /// telemetry) and watch live memory pressure (reclaim cache + drop a marker
     /// on critical so a kill before we can report it is attributed next launch).
     private func startMemoryProtection() {
+        // Pin the MLX memory ceiling BEFORE any model weights are loaded (the
+        // first big allocation happens in ensureModelLoaded → loadModelContainer,
+        // which runs after this). Idempotent; the BatchScheduler.loadModel call
+        // is a backstop for the standalone path. See MLXMemoryGuard.
+        MLXMemoryGuard.configureOnce(log: { [logger] limits in
+            logger.info(
+                "MLX memory ceiling: limit=\(limits.memoryLimitBytes / (1024 * 1024 * 1024))GB cache=\(limits.cacheLimitBytes / (1024 * 1024 * 1024))GB")
+        })
+
         let now = Date()
         let since = OOMDetector.loadLastScan() ?? now.addingTimeInterval(-24 * 3600)
         let findings = OOMDetector.detectOnLaunch(since: since)
-        OOMDetector.saveLastScan(now)
         for finding in findings {
             var fields: [String: AnyCodableValue] = ["detect_source": .string(finding.source.rawValue)]
             if let reason = finding.reason { fields["reason"] = .string(reason) }
@@ -2122,6 +2136,9 @@ public actor ProviderLoop {
                 kind: .oom, severity: .error, message: finding.message, fields: fields)
             logger.error("OOM detected on launch: \(finding.message)")
         }
+        // Advance the scan watermark only AFTER findings are handed to telemetry,
+        // so a crash before this point re-scans the same reports next launch.
+        OOMDetector.saveLastScan(now)
 
         let monitor = MemoryPressureMonitor(
             clearCache: { MLX.Memory.clearCache() },

--- a/provider-swift/Sources/ProviderCore/ProviderLoop.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop.swift
@@ -550,9 +550,7 @@ public actor ProviderLoop {
         // #315) — installed from the serve path, so it reaches auto-updated
         // installs too. KeepAlive stays false to avoid racing the updater.
 
-        // Memory protection: surface any OOM that killed the previous run (a
-        // jetsam SIGKILL leaves no in-process trace) and start reacting to live
-        // kernel memory pressure before the next kill. Best-effort, never throws.
+        // Surface any prior-run OOM and react to live memory pressure. Best-effort.
         startMemoryProtection()
         defer { memoryPressureMonitor?.cancel() }
 
@@ -2107,14 +2105,9 @@ public actor ProviderLoop {
 
     // MARK: - Memory protection
 
-    /// Surface any prior-run OOM and start reacting to live memory pressure.
-    ///
-    /// A jetsam SIGKILL (the dominant office-Mac OOM) is uncatchable and leaves
-    /// no in-process trace, so we recover the signal two ways: (1) scrape the
-    /// kernel's crash logs + consume any pre-death marker on THIS launch and
-    /// emit an `oom` telemetry event; (2) watch kernel memory pressure and, on
-    /// critical, reclaim MLX's cache and drop a marker so the *next* launch can
-    /// attribute a kill that happens before we can report it. All best-effort.
+    /// Surface any prior-run OOM (consume marker + scrape crash logs → oom
+    /// telemetry) and watch live memory pressure (reclaim cache + drop a marker
+    /// on critical so a kill before we can report it is attributed next launch).
     private func startMemoryProtection() {
         let now = Date()
         let since = OOMDetector.loadLastScan() ?? now.addingTimeInterval(-24 * 3600)

--- a/provider-swift/Sources/ProviderCore/Server/StandaloneServer.swift
+++ b/provider-swift/Sources/ProviderCore/Server/StandaloneServer.swift
@@ -111,6 +111,9 @@ public actor StandaloneServer {
         self.diskAccountant = GlobalDiskAccountant(
             kvRoot: kvRoot,
             configuredCeiling: BatchScheduler.prefixCacheGlobalDiskCeiling())
+        // Pin the MLX memory ceiling before any model weights load on this path
+        // (the coordinator path does this in ProviderLoop.startMemoryProtection).
+        MLXMemoryGuard.configureOnce()
     }
 
     static let schedulerMaxConcurrent = 24

--- a/provider-swift/Sources/ProviderCore/Telemetry/TelemetryEvent.swift
+++ b/provider-swift/Sources/ProviderCore/Telemetry/TelemetryEvent.swift
@@ -40,10 +40,8 @@ public enum TelemetryKind: String, Codable, Sendable {
     case inferenceError = "inference_error"
     case runtimeMismatch = "runtime_mismatch"
     case connectivity
-    /// Out-of-memory: either a confirmed jetsam/crash-log OOM detected on the
-    /// NEXT launch (a SIGKILL leaves no in-process trace), or a memory-pressure
-    /// critical event the provider observed before death. Mirror of Go
-    /// `KindOOM` / TS `oom`.
+    /// Out-of-memory: a jetsam/crash-log OOM detected on the next launch, or a
+    /// critical memory-pressure event observed before death.
     case oom
     case log
     case custom
@@ -238,8 +236,7 @@ public enum TelemetryFieldFilter {
         "handler", "provider_id", "trust_level", "queue_depth", "reason",
         "runtime_component", "reconnect_count", "last_error", "ws_state",
         "billing_method", "payment_failed", "target",
-        // OOM detection / memory-pressure fields (all non-sensitive numbers +
-        // enums; no prompt/completion content). Mirror in the Go allowlist.
+        // OOM / memory-pressure fields (non-sensitive). Mirror in Go allowlist.
         "detect_source", "peak_memory_bytes", "report", "pressure",
         "available_bytes", "mlx_active_bytes", "memory_pressure", "in_flight",
     ]

--- a/provider-swift/Sources/ProviderCore/Telemetry/TelemetryEvent.swift
+++ b/provider-swift/Sources/ProviderCore/Telemetry/TelemetryEvent.swift
@@ -40,6 +40,11 @@ public enum TelemetryKind: String, Codable, Sendable {
     case inferenceError = "inference_error"
     case runtimeMismatch = "runtime_mismatch"
     case connectivity
+    /// Out-of-memory: either a confirmed jetsam/crash-log OOM detected on the
+    /// NEXT launch (a SIGKILL leaves no in-process trace), or a memory-pressure
+    /// critical event the provider observed before death. Mirror of Go
+    /// `KindOOM` / TS `oom`.
+    case oom
     case log
     case custom
 }
@@ -233,6 +238,10 @@ public enum TelemetryFieldFilter {
         "handler", "provider_id", "trust_level", "queue_depth", "reason",
         "runtime_component", "reconnect_count", "last_error", "ws_state",
         "billing_method", "payment_failed", "target",
+        // OOM detection / memory-pressure fields (all non-sensitive numbers +
+        // enums; no prompt/completion content). Mirror in the Go allowlist.
+        "detect_source", "peak_memory_bytes", "report", "pressure",
+        "available_bytes", "mlx_active_bytes", "memory_pressure", "in_flight",
     ]
 
     /// Filter a dictionary to only the keys the coordinator accepts.

--- a/provider-swift/Tests/ProviderCoreTests/BatchSchedulerBudgetTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/BatchSchedulerBudgetTests.swift
@@ -658,7 +658,7 @@ struct BatchSchedulerBudgetTests {
         let kvBudget = GlobalKVCacheBudget(
             reserveBytes: 0,
             safetyFactor: 1.0,
-            memorySnapshot: { (total: 200_000, active: 0, cache: 0) }
+            memorySnapshot: { (total: 200_000, active: 0, cache: 0, systemAvailable: .max) }
         )
         let scheduler = BatchScheduler(
             maxConcurrentRequests: 4, defaultMaxTokens: 4096, kvBudget: kvBudget)
@@ -713,7 +713,7 @@ struct BatchSchedulerBudgetTests {
         let kvBudget = GlobalKVCacheBudget(
             reserveBytes: 0,
             safetyFactor: 1.0,
-            memorySnapshot: { (total: 1_000_000, active: 0, cache: 0) }
+            memorySnapshot: { (total: 1_000_000, active: 0, cache: 0, systemAvailable: .max) }
         )
         let scheduler = BatchScheduler(
             maxConcurrentRequests: 4, defaultMaxTokens: 4096, kvBudget: kvBudget)
@@ -746,7 +746,7 @@ struct BatchSchedulerBudgetTests {
     func plainColdRequestOutcomes() async {
         let fits = GlobalKVCacheBudget(
             reserveBytes: 0, safetyFactor: 1.0,
-            memorySnapshot: { (total: 1_000_000, active: 0, cache: 0) })
+            memorySnapshot: { (total: 1_000_000, active: 0, cache: 0, systemAvailable: .max) })
         let schedulerFits = BatchScheduler(
             maxConcurrentRequests: 4, defaultMaxTokens: 4096, kvBudget: fits)
         await schedulerFits._setKvBytesPerTokenForTest(1024)
@@ -763,7 +763,7 @@ struct BatchSchedulerBudgetTests {
         // downgrade to). Mirrors the old `false` return.
         let tiny = GlobalKVCacheBudget(
             reserveBytes: 0, safetyFactor: 1.0,
-            memorySnapshot: { (total: 1_000, active: 0, cache: 0) })
+            memorySnapshot: { (total: 1_000, active: 0, cache: 0, systemAvailable: .max) })
         let schedulerTiny = BatchScheduler(
             maxConcurrentRequests: 4, defaultMaxTokens: 4096, kvBudget: tiny)
         await schedulerTiny._setKvBytesPerTokenForTest(1024)

--- a/provider-swift/Tests/ProviderCoreTests/BatchSchedulerBudgetTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/BatchSchedulerBudgetTests.swift
@@ -658,7 +658,7 @@ struct BatchSchedulerBudgetTests {
         let kvBudget = GlobalKVCacheBudget(
             reserveBytes: 0,
             safetyFactor: 1.0,
-            memorySnapshot: { (total: 200_000, active: 0, cache: 0, systemAvailable: .max) }
+            memorySnapshot: { GlobalKVCacheBudget.MemorySnapshot(total: 200_000, active: 0, cache: 0, systemAvailable: .max) }
         )
         let scheduler = BatchScheduler(
             maxConcurrentRequests: 4, defaultMaxTokens: 4096, kvBudget: kvBudget)
@@ -713,7 +713,7 @@ struct BatchSchedulerBudgetTests {
         let kvBudget = GlobalKVCacheBudget(
             reserveBytes: 0,
             safetyFactor: 1.0,
-            memorySnapshot: { (total: 1_000_000, active: 0, cache: 0, systemAvailable: .max) }
+            memorySnapshot: { GlobalKVCacheBudget.MemorySnapshot(total: 1_000_000, active: 0, cache: 0, systemAvailable: .max) }
         )
         let scheduler = BatchScheduler(
             maxConcurrentRequests: 4, defaultMaxTokens: 4096, kvBudget: kvBudget)
@@ -746,7 +746,7 @@ struct BatchSchedulerBudgetTests {
     func plainColdRequestOutcomes() async {
         let fits = GlobalKVCacheBudget(
             reserveBytes: 0, safetyFactor: 1.0,
-            memorySnapshot: { (total: 1_000_000, active: 0, cache: 0, systemAvailable: .max) })
+            memorySnapshot: { GlobalKVCacheBudget.MemorySnapshot(total: 1_000_000, active: 0, cache: 0, systemAvailable: .max) })
         let schedulerFits = BatchScheduler(
             maxConcurrentRequests: 4, defaultMaxTokens: 4096, kvBudget: fits)
         await schedulerFits._setKvBytesPerTokenForTest(1024)
@@ -763,7 +763,7 @@ struct BatchSchedulerBudgetTests {
         // downgrade to). Mirrors the old `false` return.
         let tiny = GlobalKVCacheBudget(
             reserveBytes: 0, safetyFactor: 1.0,
-            memorySnapshot: { (total: 1_000, active: 0, cache: 0, systemAvailable: .max) })
+            memorySnapshot: { GlobalKVCacheBudget.MemorySnapshot(total: 1_000, active: 0, cache: 0, systemAvailable: .max) })
         let schedulerTiny = BatchScheduler(
             maxConcurrentRequests: 4, defaultMaxTokens: 4096, kvBudget: tiny)
         await schedulerTiny._setKvBytesPerTokenForTest(1024)

--- a/provider-swift/Tests/ProviderCoreTests/GlobalKVCacheBudgetTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/GlobalKVCacheBudgetTests.swift
@@ -3,7 +3,7 @@ import Testing
 
 @Test func globalKVCacheBudgetRejectsDuplicateReservationIDs() async {
     let budget = GlobalKVCacheBudget(safetyFactor: 1.0) {
-        (total: 1024, active: 0, cache: 0)
+        (total: 1024, active: 0, cache: 0, systemAvailable: .max)
     }
 
     #expect(await budget.reserve(requestID: "same", kvBytesPerToken: 1, tokenCount: 1))
@@ -15,7 +15,7 @@ import Testing
 
 @Test func globalKVCacheBudgetRejectsOverflowingReservationSize() async {
     let budget = GlobalKVCacheBudget(safetyFactor: 1.0) {
-        (total: UInt64.max, active: 0, cache: 0)
+        (total: UInt64.max, active: 0, cache: 0, systemAvailable: .max)
     }
 
     #expect(!(await budget.reserve(requestID: "overflow", kvBytesPerToken: Int.max, tokenCount: Int.max)))
@@ -23,11 +23,53 @@ import Testing
 
 @Test func globalKVCacheBudgetHonorsSafetyFactorAsTotalReservationCap() async {
     let budget = GlobalKVCacheBudget(safetyFactor: 0.5) {
-        (total: 1000, active: 0, cache: 0)
+        (total: 1000, active: 0, cache: 0, systemAvailable: .max)
     }
 
     #expect(await budget.reserve(requestID: "first", kvBytesPerToken: 1, tokenCount: 400))
     #expect(!(await budget.reserve(requestID: "second", kvBytesPerToken: 1, tokenCount: 200)))
+}
+
+/// The OOM fix: the runtime KV budget must clamp to real OS-available memory,
+/// not just the MLX-only view (physical − MLX.active − MLX.cache). On a shared
+/// office Mac the MLX view over-reports free RAM by whatever other processes
+/// hold; admitting against it drives the box into a jetsam OOM kill.
+@Test func globalKVCacheBudgetClampsToOSAvailableWhenItIsTighter() async {
+    // MLX-only view says ~1000 bytes free (total 1000, nothing held by MLX),
+    // but the OS reports only 100 bytes actually available (other apps hold the
+    // rest). The budget must bind to the 100, not the 1000.
+    let budget = GlobalKVCacheBudget(safetyFactor: 1.0) {
+        (total: 1000, active: 0, cache: 0, systemAvailable: 100)
+    }
+
+    // 150 bytes exceeds the real 100-byte OS headroom — must be rejected even
+    // though the stale MLX-only math would have admitted it.
+    #expect(!(await budget.reserve(requestID: "over-os", kvBytesPerToken: 1, tokenCount: 150)))
+    // 100 bytes fits exactly within the OS-available headroom.
+    #expect(await budget.reserve(requestID: "at-os", kvBytesPerToken: 1, tokenCount: 100))
+}
+
+/// When MLX's own held memory is the tighter bound, that still wins — the clamp
+/// takes the smaller of the two views, never the larger.
+@Test func globalKVCacheBudgetUsesMLXViewWhenItIsTighterThanOS() async {
+    // OS says everything is free, but MLX already holds 900 of 1000 bytes
+    // (resident weights) → only 100 free for KV.
+    let budget = GlobalKVCacheBudget(safetyFactor: 1.0) {
+        (total: 1000, active: 900, cache: 0, systemAvailable: .max)
+    }
+    #expect(!(await budget.reserve(requestID: "over-mlx", kvBytesPerToken: 1, tokenCount: 150)))
+    #expect(await budget.reserve(requestID: "at-mlx", kvBytesPerToken: 1, tokenCount: 100))
+}
+
+/// The OS reserve is subtracted from real free memory before the safety factor,
+/// matching the load gate's accounting.
+@Test func globalKVCacheBudgetSubtractsReserveFromOSAvailable() async {
+    // OS reports 1000 free, reserve 600 → 400 usable; safetyFactor 1.0.
+    let budget = GlobalKVCacheBudget(reserveBytes: 600, safetyFactor: 1.0) {
+        (total: 100_000, active: 0, cache: 0, systemAvailable: 1000)
+    }
+    #expect(!(await budget.reserve(requestID: "over", kvBytesPerToken: 1, tokenCount: 401)))
+    #expect(await budget.reserve(requestID: "fits", kvBytesPerToken: 1, tokenCount: 400))
 }
 
 @Test func providerLoopMemoryReserveBytesSaturatesOnOverflow() {

--- a/provider-swift/Tests/ProviderCoreTests/GlobalKVCacheBudgetTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/GlobalKVCacheBudgetTests.swift
@@ -31,9 +31,7 @@ import Testing
 }
 
 /// The OOM fix: the runtime KV budget must clamp to real OS-available memory,
-/// not just the MLX-only view (physical − MLX.active − MLX.cache). On a shared
-/// office Mac the MLX view over-reports free RAM by whatever other processes
-/// hold; admitting against it drives the box into a jetsam OOM kill.
+/// not just the MLX-only view, or it over-admits on a shared box → jetsam OOM.
 @Test func globalKVCacheBudgetClampsToOSAvailableWhenItIsTighter() async {
     // MLX-only view says ~1000 bytes free (total 1000, nothing held by MLX),
     // but the OS reports only 100 bytes actually available (other apps hold the

--- a/provider-swift/Tests/ProviderCoreTests/GlobalKVCacheBudgetTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/GlobalKVCacheBudgetTests.swift
@@ -3,7 +3,7 @@ import Testing
 
 @Test func globalKVCacheBudgetRejectsDuplicateReservationIDs() async {
     let budget = GlobalKVCacheBudget(safetyFactor: 1.0) {
-        (total: 1024, active: 0, cache: 0, systemAvailable: .max)
+        GlobalKVCacheBudget.MemorySnapshot(total: 1024, active: 0, cache: 0, systemAvailable: .max)
     }
 
     #expect(await budget.reserve(requestID: "same", kvBytesPerToken: 1, tokenCount: 1))
@@ -15,7 +15,7 @@ import Testing
 
 @Test func globalKVCacheBudgetRejectsOverflowingReservationSize() async {
     let budget = GlobalKVCacheBudget(safetyFactor: 1.0) {
-        (total: UInt64.max, active: 0, cache: 0, systemAvailable: .max)
+        GlobalKVCacheBudget.MemorySnapshot(total: UInt64.max, active: 0, cache: 0, systemAvailable: .max)
     }
 
     #expect(!(await budget.reserve(requestID: "overflow", kvBytesPerToken: Int.max, tokenCount: Int.max)))
@@ -23,7 +23,7 @@ import Testing
 
 @Test func globalKVCacheBudgetHonorsSafetyFactorAsTotalReservationCap() async {
     let budget = GlobalKVCacheBudget(safetyFactor: 0.5) {
-        (total: 1000, active: 0, cache: 0, systemAvailable: .max)
+        GlobalKVCacheBudget.MemorySnapshot(total: 1000, active: 0, cache: 0, systemAvailable: .max)
     }
 
     #expect(await budget.reserve(requestID: "first", kvBytesPerToken: 1, tokenCount: 400))
@@ -37,7 +37,7 @@ import Testing
     // but the OS reports only 100 bytes actually available (other apps hold the
     // rest). The budget must bind to the 100, not the 1000.
     let budget = GlobalKVCacheBudget(safetyFactor: 1.0) {
-        (total: 1000, active: 0, cache: 0, systemAvailable: 100)
+        GlobalKVCacheBudget.MemorySnapshot(total: 1000, active: 0, cache: 0, systemAvailable: 100)
     }
 
     // 150 bytes exceeds the real 100-byte OS headroom — must be rejected even
@@ -53,7 +53,7 @@ import Testing
     // OS says everything is free, but MLX already holds 900 of 1000 bytes
     // (resident weights) → only 100 free for KV.
     let budget = GlobalKVCacheBudget(safetyFactor: 1.0) {
-        (total: 1000, active: 900, cache: 0, systemAvailable: .max)
+        GlobalKVCacheBudget.MemorySnapshot(total: 1000, active: 900, cache: 0, systemAvailable: .max)
     }
     #expect(!(await budget.reserve(requestID: "over-mlx", kvBytesPerToken: 1, tokenCount: 150)))
     #expect(await budget.reserve(requestID: "at-mlx", kvBytesPerToken: 1, tokenCount: 100))
@@ -64,7 +64,7 @@ import Testing
 @Test func globalKVCacheBudgetSubtractsReserveFromOSAvailable() async {
     // OS reports 1000 free, reserve 600 → 400 usable; safetyFactor 1.0.
     let budget = GlobalKVCacheBudget(reserveBytes: 600, safetyFactor: 1.0) {
-        (total: 100_000, active: 0, cache: 0, systemAvailable: 1000)
+        GlobalKVCacheBudget.MemorySnapshot(total: 100_000, active: 0, cache: 0, systemAvailable: 1000)
     }
     #expect(!(await budget.reserve(requestID: "over", kvBytesPerToken: 1, tokenCount: 401)))
     #expect(await budget.reserve(requestID: "fits", kvBytesPerToken: 1, tokenCount: 400))

--- a/provider-swift/Tests/ProviderCoreTests/MLXMemoryGuardTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/MLXMemoryGuardTests.swift
@@ -1,0 +1,65 @@
+import Testing
+@testable import ProviderCore
+
+private let gib = 1024 * 1024 * 1024
+
+@Test func mlxGuardSizesMemoryLimitBelowPhysical() {
+    // 64 GiB box, 6 GiB reserve → 58 GiB ceiling.
+    let limits = MLXMemoryGuard.recommendedLimits(
+        physicalBytes: UInt64(64 * gib), reserveBytes: UInt64(6 * gib))
+    #expect(limits.memoryLimitBytes == 58 * gib)
+    // cache fraction 0.75 of the ceiling, never above it.
+    #expect(limits.cacheLimitBytes == Int(Double(58 * gib) * 0.75))
+    #expect(limits.cacheLimitBytes <= limits.memoryLimitBytes)
+}
+
+@Test func mlxGuardNeverExceedsPhysicalRAM() {
+    // The whole point: the ceiling must be strictly below physical RAM so MLX
+    // can't allocate the box into a jetsam kill.
+    for physGB in [16, 24, 36, 64, 128] {
+        let limits = MLXMemoryGuard.recommendedLimits(
+            physicalBytes: UInt64(physGB * gib), reserveBytes: UInt64(6 * gib))
+        #expect(limits.memoryLimitBytes < physGB * gib, "ceiling must be below physical on a \(physGB)GB box")
+    }
+}
+
+@Test func mlxGuardFloorsTinyOrMisreportedMachines() {
+    // Reserve >= physical would yield a non-positive limit; must floor instead.
+    let limits = MLXMemoryGuard.recommendedLimits(
+        physicalBytes: UInt64(4 * gib), reserveBytes: UInt64(8 * gib))
+    #expect(limits.memoryLimitBytes == MLXMemoryGuard.minimumLimitBytes)
+    #expect(limits.cacheLimitBytes <= limits.memoryLimitBytes)
+}
+
+@Test func mlxGuardReserveResolutionPrefersExplicitThenEnvThenDefault() {
+    // explicit is BYTES (consistent with reserveBytes everywhere else).
+    #expect(MLXMemoryGuard.resolvedReserveBytes(explicit: UInt64(10 * gib), env: [:]) == UInt64(10 * gib))
+    // env override is in GB and is converted to bytes.
+    #expect(MLXMemoryGuard.resolvedReserveBytes(
+        explicit: nil, env: ["DARKBLOOM_MLX_MEMORY_RESERVE_GB": "12"]) == UInt64(12) * 1_073_741_824)
+    #expect(MLXMemoryGuard.resolvedReserveBytes(explicit: nil, env: [:])
+        == MLXMemoryGuard.defaultReserveGB * 1_073_741_824)
+    // Garbage env falls back to the default rather than crashing.
+    #expect(MLXMemoryGuard.resolvedReserveBytes(
+        explicit: nil, env: ["DARKBLOOM_MLX_MEMORY_RESERVE_GB": "not-a-number"])
+        == MLXMemoryGuard.defaultReserveGB * 1_073_741_824)
+}
+
+@Test func mlxGuardConfigureOnceAppliesExactlyOnce() {
+    MLXMemoryGuard._resetForTest()
+    var applied: [MLXMemoryGuard.Limits] = []
+    let first = MLXMemoryGuard.configureOnce(
+        reserveBytes: UInt64(6 * gib),
+        physicalBytes: UInt64(32 * gib),
+        apply: { applied.append($0) })
+    let second = MLXMemoryGuard.configureOnce(
+        reserveBytes: UInt64(6 * gib),
+        physicalBytes: UInt64(32 * gib),
+        apply: { applied.append($0) })
+
+    #expect(first != nil)
+    #expect(second == nil, "second call must be a no-op (ceiling set once per process)")
+    #expect(applied.count == 1)
+    #expect(applied.first?.memoryLimitBytes == 26 * gib)
+    MLXMemoryGuard._resetForTest()
+}

--- a/provider-swift/Tests/ProviderCoreTests/OOMDetectorTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/OOMDetectorTests.swift
@@ -31,6 +31,25 @@ private let jetsamReport = """
     #expect(OOMDetector.parseJetsamReport(contents: "", processName: "darkbloom") == nil)
 }
 
+/// darkbloom merely PRESENT in the process table (no kill reason, not the
+/// largest process) when something else was jetsammed must NOT be reported as a
+/// provider OOM.
+@Test func oomJetsamReportRequiresKillEvidenceForOurProcess() {
+    let safariKilled = """
+    {"bug_type":"298"}
+    {"pageSize":16384,"largestProcess":"Safari","processes":[{"name":"Safari","pid":111,"rpages":2000,"reason":"per-process-limit"},{"name":"darkbloom","pid":456,"rpages":500}]}
+    """
+    #expect(OOMDetector.parseJetsamReport(contents: safariKilled, processName: "darkbloom") == nil)
+
+    // But if darkbloom is the largestProcess (a kill signal) it IS reported,
+    // even without an explicit per-entry reason.
+    let darkbloomLargest = """
+    {"bug_type":"298"}
+    {"pageSize":16384,"largestProcess":"darkbloom","processes":[{"name":"darkbloom","pid":456,"rpages":1000}]}
+    """
+    #expect(OOMDetector.parseJetsamReport(contents: darkbloomLargest, processName: "darkbloom")?.source == .jetsamReport)
+}
+
 // MARK: - EXC_RESOURCE / jetsam crash report parsing
 
 @Test func oomParsesExcResourceMemoryCrash() {
@@ -116,6 +135,48 @@ private let jetsamReport = """
         .appendingPathComponent("does-not-exist-\(UUID().uuidString)")
     #expect(OOMDetector.scanDiagnosticReports(
         dir: missing, processName: "darkbloom", since: Date(timeIntervalSince1970: 0)).isEmpty)
+}
+
+// MARK: - detectOnLaunch dedup (marker vs crash report)
+
+/// When BOTH a pre-death marker and a real JetsamEvent exist for the same death,
+/// detectOnLaunch must emit ONE finding (the authoritative crash report), not two.
+@Test func oomDetectOnLaunchPrefersCrashReportOverMarker() throws {
+    let dir = FileManager.default.temporaryDirectory.appendingPathComponent("oom-dl-\(UUID().uuidString)")
+    try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    let markerURL = dir.appendingPathComponent("oom_marker.json")
+    defer { try? FileManager.default.removeItem(at: dir) }
+
+    OOMDetector.writeMarker(OOMDetector.Marker(
+        pid: 1, epochSeconds: 1, peakMemoryBytes: 1, availableBytesAtEvent: 0), to: markerURL)
+    try jetsamReport.write(
+        to: dir.appendingPathComponent("JetsamEvent-x.ips"), atomically: true, encoding: .utf8)
+
+    let findings = OOMDetector.detectOnLaunch(
+        markerURL: markerURL, diagnosticReportsDirs: [dir],
+        processName: "darkbloom", since: Date(timeIntervalSince1970: 0))
+    #expect(findings.count == 1)
+    #expect(findings.first?.source == .jetsamReport)
+    // Marker is consumed either way (no lingering false positive next launch).
+    #expect(!FileManager.default.fileExists(atPath: markerURL.path))
+}
+
+/// With no crash report, the marker IS surfaced (the only signal we have).
+@Test func oomDetectOnLaunchEmitsMarkerWhenNoCrashReport() throws {
+    let dir = FileManager.default.temporaryDirectory.appendingPathComponent("oom-dl2-\(UUID().uuidString)")
+    try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    let markerURL = dir.appendingPathComponent("oom_marker.json")
+    defer { try? FileManager.default.removeItem(at: dir) }
+
+    OOMDetector.writeMarker(OOMDetector.Marker(
+        pid: 1, epochSeconds: 1, peakMemoryBytes: 42, availableBytesAtEvent: 0), to: markerURL)
+
+    let findings = OOMDetector.detectOnLaunch(
+        markerURL: markerURL, diagnosticReportsDirs: [dir],
+        processName: "darkbloom", since: Date(timeIntervalSince1970: 0))
+    #expect(findings.count == 1)
+    #expect(findings.first?.source == .memoryPressureMarker)
+    #expect(findings.first?.peakMemoryBytes == 42)
 }
 
 @Test func oomLastScanWatermarkRoundTrip() {

--- a/provider-swift/Tests/ProviderCoreTests/OOMDetectorTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/OOMDetectorTests.swift
@@ -1,0 +1,179 @@
+import Testing
+import Foundation
+@testable import ProviderCore
+
+// MARK: - Jetsam report parsing
+
+private let jetsamReport = """
+{"timestamp":"2026-06-12 05:00:00.00 +0000","bug_type":"298","os_version":"macOS 26.4"}
+{"pageSize":16384,"largestProcess":"darkbloom","processes":[{"name":"WindowServer","pid":111,"rpages":1000,"reason":"vm-pageshortage"},{"name":"darkbloom","pid":456,"rpages":1572864,"reason":"per-process-limit"}]}
+"""
+
+@Test func oomParsesJetsamReportForOurProcess() {
+    let finding = OOMDetector.parseJetsamReport(contents: jetsamReport, processName: "darkbloom")
+    #expect(finding != nil)
+    #expect(finding?.source == .jetsamReport)
+    #expect(finding?.reason == "per-process-limit")
+    // 1_572_864 rpages * 16_384 page size = 24 GiB.
+    #expect(finding?.peakMemoryBytes == UInt64(1_572_864) * 16_384)
+}
+
+@Test func oomJetsamReportIgnoresUnrelatedProcesses() {
+    let other = """
+    {"bug_type":"298"}
+    {"pageSize":16384,"processes":[{"name":"WindowServer","pid":111,"rpages":1000,"reason":"vm-pageshortage"}]}
+    """
+    #expect(OOMDetector.parseJetsamReport(contents: other, processName: "darkbloom") == nil)
+}
+
+@Test func oomJetsamReportToleratesGarbage() {
+    #expect(OOMDetector.parseJetsamReport(contents: "not json at all", processName: "darkbloom") == nil)
+    #expect(OOMDetector.parseJetsamReport(contents: "", processName: "darkbloom") == nil)
+}
+
+// MARK: - EXC_RESOURCE / jetsam crash report parsing
+
+@Test func oomParsesExcResourceMemoryCrash() {
+    let report = """
+    {"app_name":"darkbloom","timestamp":"2026-06-12 05:00:00.00 +0000","bug_type":"309"}
+    {"exception":{"type":"EXC_RESOURCE","subtype":"MEMORY (fatal)"}}
+    """
+    let finding = OOMDetector.parseMemoryCrashReport(contents: report, processName: "darkbloom")
+    #expect(finding?.source == .memoryCrashReport)
+    #expect(finding?.reason == "MEMORY (fatal)")
+}
+
+@Test func oomParsesJetsamTerminationCrash() {
+    let report = """
+    {"app_name":"darkbloom","bug_type":"309"}
+    {"termination":{"namespace":"JETSAM","indicator":"per-process-limit"}}
+    """
+    let finding = OOMDetector.parseMemoryCrashReport(contents: report, processName: "darkbloom")
+    #expect(finding?.source == .memoryCrashReport)
+    #expect(finding?.reason == "per-process-limit")
+}
+
+@Test func oomCrashReportIgnoresOtherAppsAndNonMemoryCrashes() {
+    // Different app.
+    let otherApp = """
+    {"app_name":"Safari","bug_type":"309"}
+    {"exception":{"type":"EXC_RESOURCE","subtype":"MEMORY"}}
+    """
+    #expect(OOMDetector.parseMemoryCrashReport(contents: otherApp, processName: "darkbloom") == nil)
+    // Our app but a non-memory crash (e.g. bad access) — not an OOM.
+    let segfault = """
+    {"app_name":"darkbloom","bug_type":"309"}
+    {"exception":{"type":"EXC_BAD_ACCESS","subtype":"KERN_INVALID_ADDRESS"}}
+    """
+    #expect(OOMDetector.parseMemoryCrashReport(contents: segfault, processName: "darkbloom") == nil)
+}
+
+// MARK: - Marker round-trip
+
+@Test func oomMarkerWriteReadClear() {
+    let tmp = FileManager.default.temporaryDirectory
+        .appendingPathComponent("oom-marker-\(UUID().uuidString).json")
+    defer { try? FileManager.default.removeItem(at: tmp) }
+
+    let marker = OOMDetector.Marker(
+        pid: 4242, epochSeconds: 1_780_000_000, peakMemoryBytes: 25_769_803_776,
+        availableBytesAtEvent: 1_000_000, modelId: "gpt-oss-20b")
+    OOMDetector.writeMarker(marker, to: tmp)
+
+    let read = OOMDetector.readAndClearMarker(at: tmp)
+    #expect(read == marker)
+    // Consume-once: the marker file is gone after reading.
+    #expect(!FileManager.default.fileExists(atPath: tmp.path))
+    // A second read finds nothing.
+    #expect(OOMDetector.readAndClearMarker(at: tmp) == nil)
+}
+
+// MARK: - Directory scan + dedup watermark
+
+@Test func oomScanFindsRecentJetsamReport() throws {
+    let dir = FileManager.default.temporaryDirectory
+        .appendingPathComponent("oom-scan-\(UUID().uuidString)")
+    try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: dir) }
+
+    let reportURL = dir.appendingPathComponent("JetsamEvent-2026-06-12-050000.ips")
+    try jetsamReport.write(to: reportURL, atomically: true, encoding: .utf8)
+
+    let findings = OOMDetector.scanDiagnosticReports(
+        dir: dir, processName: "darkbloom", since: Date(timeIntervalSince1970: 0))
+    #expect(findings.count == 1)
+    #expect(findings.first?.reportName == "JetsamEvent-2026-06-12-050000.ips")
+    #expect(findings.first?.peakMemoryBytes == UInt64(1_572_864) * 16_384)
+
+    // The `since` watermark excludes older reports → crashloop dedup.
+    let future = OOMDetector.scanDiagnosticReports(
+        dir: dir, processName: "darkbloom", since: Date(timeIntervalSinceNow: 3600))
+    #expect(future.isEmpty)
+}
+
+@Test func oomScanIsEmptyForMissingDirectory() {
+    let missing = FileManager.default.temporaryDirectory
+        .appendingPathComponent("does-not-exist-\(UUID().uuidString)")
+    #expect(OOMDetector.scanDiagnosticReports(
+        dir: missing, processName: "darkbloom", since: Date(timeIntervalSince1970: 0)).isEmpty)
+}
+
+@Test func oomLastScanWatermarkRoundTrip() {
+    let tmp = FileManager.default.temporaryDirectory
+        .appendingPathComponent("oom-lastscan-\(UUID().uuidString)")
+    defer { try? FileManager.default.removeItem(at: tmp) }
+    #expect(OOMDetector.loadLastScan(at: tmp) == nil)
+    let when = Date(timeIntervalSince1970: 1_780_001_234)
+    OOMDetector.saveLastScan(when, at: tmp)
+    let read = OOMDetector.loadLastScan(at: tmp)
+    #expect(read != nil)
+    #expect(abs((read?.timeIntervalSince1970 ?? 0) - 1_780_001_234) < 1.0)
+}
+
+// MARK: - Memory-pressure policy
+
+@Test func memoryPressurePolicyEscalates() {
+    let normal = MemoryPressurePolicy.response(for: .normal)
+    #expect(!normal.clearCache && !normal.writeMarker && normal.severity == nil)
+
+    let warning = MemoryPressurePolicy.response(for: .warning)
+    #expect(warning.clearCache && !warning.writeMarker && warning.severity == nil)
+
+    let critical = MemoryPressurePolicy.response(for: .critical)
+    #expect(critical.clearCache && critical.writeMarker && critical.severity == .error)
+}
+
+@Test func memoryPressureMonitorHandleInvokesInjectedActions() {
+    let clears = LockedCounter()
+    let markers = LockedBox()
+    let emits = LockedBox()
+    let monitor = MemoryPressureMonitor(
+        clearCache: { clears.bump() },
+        writeMarker: { markers.set($0) },
+        emit: { level, _ in emits.set(level) })
+
+    monitor.handle(.warning)
+    #expect(clears.value == 1)
+    #expect(markers.value == nil)          // warning does not write a marker
+    #expect(emits.value == nil)            // warning does not emit telemetry (routine)
+
+    monitor.handle(.critical)
+    #expect(clears.value == 2)
+    #expect(markers.value == .critical)    // critical writes the marker
+    #expect(emits.value == .critical)      // critical emits the oom signal
+
+    monitor.handle(.normal)
+    #expect(clears.value == 2)             // normal is a no-op
+}
+
+// Tiny thread-safe test helpers (handlers may run off the test thread).
+private final class LockedCounter: @unchecked Sendable {
+    private let lock = NSLock(); private var n = 0
+    func bump() { lock.lock(); n += 1; lock.unlock() }
+    var value: Int { lock.lock(); defer { lock.unlock() }; return n }
+}
+private final class LockedBox: @unchecked Sendable {
+    private let lock = NSLock(); private var v: MemoryPressureLevel?
+    func set(_ x: MemoryPressureLevel) { lock.lock(); v = x; lock.unlock() }
+    var value: MemoryPressureLevel? { lock.lock(); defer { lock.unlock() }; return v }
+}


### PR DESCRIPTION
## Problem

A lot of office Macs running as providers were **OOM-crashing, invisibly.** Over 48h on prod: ~7,880 `read_error` WS disconnects, a step-function fleet collapse on 06-12 (online ~99 → ~57, ~40% capacity never recovered), and 261 "insufficient memory to load model" 503s (86% gpt-oss-20b) — yet only ~2 `panic` events reached Datadog. A jetsam SIGKILL is uncatchable, so the kill flushes no telemetry; the crash shows up only as a coordinator-side disconnect indistinguishable from a network blip.

## Root cause

The provider had a well-defended model-**load** gate (`ModelLoadAdmission.freeForLoadGb` clamps to `min(mlxFree, SystemMemory.availableBytes())`) but an OS-memory-**blind** runtime path on a platform (unified memory) where overshoot is a fatal kernel kill:

1. **Runtime KV admission was OS-blind.** `GlobalKVCacheBudget.availableReservationBytes()` and `BatchScheduler.tokenBudgetMax` computed free RAM as `physicalMemory − MLX.active − MLX.cache` — counting **only MLX's own memory against TOTAL physical RAM**. On a shared office Mac where other apps hold tens of GB, both over-admit by exactly that amount → the KV cache grows under batching → jetsam SIGKILL.
2. **No MLX memory ceiling.** MLX's `memoryLimit` defaults to **1.5× the device working set — above physical RAM** — so MLX freely allocates past total RAM with no catchable failure.
3. **OOMs were invisible.** No `oom` telemetry kind, no memory-pressure handler, no crash-log scrape; the coordinator bucketed the kill as a generic `read_error` disconnect.

## What changed

### Provider OOM fix (the cure)
- **Runtime KV budget consults real OS-available RAM** — `GlobalKVCacheBudget` + `BatchScheduler.tokenBudgetMax` now clamp to `min(mlxFree, SystemMemory.availableBytes()) − reserve`, the same clamp the load gate uses. On a tight box this degrades to one-request-at-a-time instead of crashing — capacity is preserved, not derouted.
- **`MLXMemoryGuard`** pins `Memory.memoryLimit`/`cacheLimit` below physical RAM once per process (wired idempotently in `BatchScheduler.loadModel`), so overshoot throttles instead of racing into a kernel kill.
- **`MemoryPressureMonitor`** (`DISPATCH_SOURCE_MEMORYPRESSURE`): reclaim MLX cache on warning; on critical also drop an OOM marker + emit telemetry.

### OOM detection / observability
- New **`TelemetryKind = oom`**, mirrored in Swift / Go / TS (+ both field allowlists + the console-ui set).
- **`OOMDetector`**: on launch, consume any pre-death marker **and scrape kernel `JetsamEvent` / `EXC_RESOURCE` crash reports** for our process, emitting `oom` telemetry — recovering the signal a SIGKILL destroys.
- **Coordinator** classifies abrupt `read_error` disconnects against the last heartbeat's memory pressure + in-flight count (`ClassifyDisconnectReason`), emitting `provider_oom_suspected_total` + an `oom` event. Turns the silent read-error churn into an attributable metric.

## Testing
New coverage for the OS-clamp (both directions + reserve), MLX sizing/idempotency, the `.ips` parsers / marker round-trip / scan watermark, the memory-pressure policy, and the disconnect classifier. Full `swift test` (provider) and `go test ./...` + `go vet` (coordinator) green. Two independent reviewers passed.

## Not derouting / gemma note
A 24 GB box *can* serve one gpt-oss-20b request when idle; the crashes come from **shared** machines losing headroom + ungated concurrency + no MLX cap — addressed here without giving up the tier. The structural fix for the 36 GB tier is the separate **gemma 8-bit → 4-bit cutover** (~28 GB → ~14 GB weights).

## Deferred follow-ups (not in this PR)
Free-RAM bytes in the heartbeat; coordinator memory hard-gate (deroute > 0.85 pressure); VLM-path memory gating; watchdog crashloop backoff; `max_tokens` clamp to context window.

## Deploy notes
- Provider changes require a **release** for the fleet to pick up (human-gated).
- The disconnect classifier is **coordinator-side** → needs a coordinator deploy (EigenCloud, human-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/330"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783972972&installation_id=133247490&pr_number=330&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F330&signature=66ff540114ba8d9cb02c5a1e23f4c728431deb76d60bed7ca716326719562507"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->