### PR TITLE
feat(coordinator): predictive model warming with thermal hysteresis

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,7 +85,7 @@ docs/                 architecture, deploy runbooks, MDM/ACME notes, threat mode
 
 - Coordinator HTTP routes include `POST /v1/chat/completions`, `POST /v1/completions`, `POST /v1/messages`, `GET /v1/models`, `GET /v1/models/capacity`, billing/pricing endpoints, invite flows, stats, enrollment, device authorization, and release registration endpoints.
 - Coordinator auth is split between Privy JWTs, API keys, and device-code login (RFC 8628) for provider machines.
-- Routing uses token-budget admission with engine-reported capacity, speculative TTFT dispatch, EWMA TPS tracking, and early 429 with Retry-After for OpenRouter compatibility.
+- Routing uses token-budget admission with engine-reported capacity, speculative TTFT dispatch, EWMA TPS tracking, early 429 with Retry-After for OpenRouter compatibility, and optional predictive model warming.
 - Billing logic is split between `coordinator/payments` (ledger + pricing) and `coordinator/billing` (Stripe, referrals).
 - Providers serve text inference through the Swift `darkbloom` CLI with continuous batching via MLX-Swift.
 - Model registry data is DB-backed in the coordinator and points to R2 manifests under `https://models.darkbloom.ai`; model bytes are not hardcoded in the provider or UI.
@@ -193,6 +193,18 @@ Dev coordinator deploy (Google Cloud): see `docs/dev-environment.md`.
 - Request queue timeout is 120 seconds. Initial attestation challenge is sent immediately on registration, then every 5 minutes.
 - Backend idle timeout is 1 hour (not 10 minutes as some comments may say).
 
+### Predictive Warming
+
+- Predictive warming is opt-in via `EIGENINFERENCE_PREDICTIVE_WARMING_ENABLED=true`. When disabled the registry still records demand but never sends proactive `load_model` commands.
+- `DemandForecaster` mixes three signals per model: EWMA-smoothed recent request rates (10s, 60s, 5m windows), current queue depth converted to an equivalent rate, and an optional historical baseline from `HistoricalDemandSource`.
+- `WarmingPlanner` runs on a 1-second ticker. Each tick it forecasts demand, computes a target warm count (`targetWarmCount`), and sends `load_model` commands to the best idle/cold providers up to `MaxLoadsPerModelPerTick`.
+- Provider selection for warming applies the same trust, runtime-verified, challenge-freshness, private-text, catalog, thermal-hysteresis, and pending-load gates as routing. Private-only providers are never warmed for the public fleet.
+- The planner tracks `lastWarmAt` for sticky assignments: a provider that recently had a model warm is preferred.
+- `Registry.SetMetricsEmitter` wires a `MetricsEmitter` so warming metrics (`warming.forecasted_rps`, `warming.load_commands_sent`, etc.) are emitted.
+- `Registry.EstimatedWaitSeconds` gives a rough queue + pending-load wait estimate used for `Retry-After` headers.
+- `SetAdaptiveQueueLimit` scales per-model queue capacity with the demand forecast so bursts don't immediately 429.
+- The scheduler penalizes providers with a pending model load (`pendingModelLoadPenaltyMs`) and applies multiplicative thermal derating (`fair` 0.8x, `serious` 0.4x, `critical` rejects) with thermal hysteresis (`thermallyRejectedLocked` requires two consecutive critical readings).
+
 ### Coordinator State Model — Multiple Overlapping Views
 
 Provider state lives in several fields that are read by different code paths with different precedence rules. When mutating any of these, trace every reader:
@@ -200,10 +212,10 @@ Provider state lives in several fields that are read by different code paths wit
 - `BackendCapacity.Slots` is **authoritative** for the scheduler when present (Swift providers). The scheduler derives `slotState`, `modelLoaded`, token budgets, and observed TPS from it. `WarmModels` is only a fallback for legacy providers without `BackendCapacity`.
 - `WarmModels` is updated by heartbeats. It is NOT consulted by `snapshotProviderLocked` or `buildCandidateWithReason` when `BackendCapacity` is non-nil. `TriggerModelSwaps` / `hasWarmProviderLocked` checks it as a fallback. Legacy `ScoreProvider` also reads it for warm bonus, and `/v1/me/providers` copies it into API responses.
 - `CurrentModel` is set from heartbeat `active_model`. A nil/omitted `active_model` means no model is loaded. Stale `CurrentModel` can cause attestation hash mismatches.
-- `pendingModelLoads` is only checked by `TriggerModelSwaps` planning. It is NOT checked by `QuickCapacityCheck`, `ReserveProviderEx`, or `freeMemoryAdmits`. Do not assume pending-load state affects routing decisions.
+- `pendingModelLoads` suppresses duplicate `load_model` sends in both `TriggerModelSwaps` and `WarmingPlanner`. The scheduler also sees a provider's pending-load state via `routingSnapshot.hasPendingLoad` and penalizes it heavily, so routing treats a provider that is mid-load as less desirable.
 - Provider-reported slot states include `"running"` (active requests), `"idle"` (loaded, no requests), `"crashed"`, `"reloading"`, and `"idle_shutdown"`. The `"idle"` state means the model IS loaded — treat it the same as `"running"` for warm detection, not as `"unknown"`.
 - Providers can hold up to `maxModelSlots` models simultaneously (default 3). Do not assume a model swap evicts all other models.
-- The provider's `ensureModelLoaded` requires `estimatedMemoryGb * 3.0` headroom. The coordinator's `freeMemoryAdmits` uses a different (less conservative) check. A model the coordinator admits can still fail on the provider side.
+- The provider's `ensureModelLoaded` (via `ModelLoadAdmission`) requires the model's `estimatedMemoryGb` plus a small one-request headroom (`defaultLoadHeadroomGb`, currently 2.0 GB), not a 3x multiplier. The coordinator's hardware-fit gate prefers the catalog's `min_ram_gb` and only falls back to a 2x size multiplier when `min_ram_gb` is unknown. A model the coordinator admits can still fail on the provider side if free memory is tighter than the coordinator's estimate.
 
 ### Coordinator Mutation Checklist
 
@@ -213,7 +225,7 @@ When adding code that mutates provider state or sends commands (`load_model`, et
 2. Check what happens on the failure path — does state get cleaned up on disconnect, timeout, and load failure?
 3. Check concurrent access — heartbeats arrive per-provider on separate goroutines; `TriggerModelSwaps` can race with `drainQueuedRequestsForModels`.
 4. Check the cleanup path — `Disconnect()` must clear any per-provider state you add.
-5. Verify pre-existing invariants: `maxModelSlots`, heartbeat field omission semantics (`nil` vs empty), and the 3x memory gate on the provider side.
+5. Verify pre-existing invariants: `maxModelSlots`, heartbeat field omission semantics (`nil` vs empty), and the provider load-admission model (weights plus one-request headroom, not a 3x multiplier).
 
 ## Code Structure & Modularity
 

--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -916,22 +916,10 @@ func (s *Server) refundReservedBalance(pr *registry.PendingRequest, reference st
 }
 
 // estimateRetryAfter returns a suggested wait time in seconds before retrying
-// a request for the given model. Based on queue depth as a rough proxy for
-// fleet backlog. OpenRouter uses the Retry-After header to schedule retries.
+// a request for the given model. Considers queue depth and any in-flight model
+// loads. OpenRouter uses the Retry-After header to schedule retries.
 func (s *Server) estimateRetryAfter(model string) int {
-	queueDepth := s.registry.Queue().QueueSize(model)
-	if queueDepth == 0 {
-		return 2 // Light load, retry soon
-	}
-	// Rough estimate: each queued request takes ~3 seconds to drain.
-	estimate := queueDepth * 3
-	if estimate < 2 {
-		estimate = 2
-	}
-	if estimate > 30 {
-		estimate = 30
-	}
-	return estimate
+	return s.registry.EstimatedWaitSeconds(model)
 }
 
 // writeServiceUnavailable writes a retryable 503 with a Retry-After header so
@@ -1355,6 +1343,10 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	model, rawBody = buildModel, resolvedBody
+
+	// Record demand for predictive warming. Use the resolved build model so
+	// forecasts align with the model actually routed to providers.
+	s.registry.RecordDemand(model)
 
 	// Vision gating: a request carrying image/video input must land on a provider
 	// advertising a vision-capable (VLM) build of this model, or the media is

--- a/coordinator/api/metrics_test.go
+++ b/coordinator/api/metrics_test.go
@@ -1,8 +1,13 @@
 package api
 
 import (
+	"log/slog"
+	"os"
 	"strings"
 	"testing"
+
+	"github.com/eigeninference/d-inference/coordinator/registry"
+	"github.com/eigeninference/d-inference/coordinator/store"
 )
 
 func TestCounterIncrements(t *testing.T) {
@@ -78,5 +83,27 @@ func TestRenderProm(t *testing.T) {
 		if !strings.Contains(text, want) {
 			t.Errorf("missing %q in prom output:\n%s", want, text)
 		}
+	}
+}
+
+func TestDDTagsToMetricLabels(t *testing.T) {
+	labels := ddTagsToMetricLabels([]string{"model:test-model", "outcome:selected", "badtag"})
+	if len(labels) != 2 {
+		t.Fatalf("expected 2 labels, got %d: %+v", len(labels), labels)
+	}
+	if labels[0].Name != "model" || labels[0].Value != "test-model" {
+		t.Errorf("first label = %+v, want model:test-model", labels[0])
+	}
+}
+
+func TestServerRegistersWarmupETAGauge(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	st := store.NewMemory(store.Config{AdminKey: "test-key"})
+	reg := registry.New(logger)
+
+	srv := NewServer(reg, st, ServerConfig{}, logger)
+	snap := srv.Metrics().Snapshot()
+	if _, ok := snap.Gauges["warming.max_warmup_eta_seconds"]; !ok {
+		t.Fatalf("expected warming.max_warmup_eta_seconds gauge to be registered, got %+v", snap.Gauges)
 	}
 }

--- a/coordinator/api/provider.go
+++ b/coordinator/api/provider.go
@@ -422,6 +422,7 @@ func (s *Server) providerReadLoop(ctx context.Context, conn *websocket.Conn, pro
 				s.registry.MarkModelWarm(providerID, statusMsg.ModelID)
 				s.registry.ClearPendingModelLoad(providerID, statusMsg.ModelID)
 				s.registry.DrainQueuedRequestsForModel(statusMsg.ModelID)
+				s.ddIncr("warming.load_commands_succeeded", []string{"model:" + statusMsg.ModelID})
 			case protocol.LoadModelStatusFailed:
 				if statusMsg.Error == protocol.ProviderDrainingForUpdate {
 					// Transient: the provider refused only because it is
@@ -437,6 +438,7 @@ func (s *Server) providerReadLoop(ctx context.Context, conn *websocket.Conn, pro
 					// requests immediately rather than making them wait 120s.
 					s.registry.RejectUnservableQueuedRequests(statusMsg.ModelID)
 				}
+				s.ddIncr("warming.load_commands_failed", []string{"model:" + statusMsg.ModelID})
 			}
 			// "started" status: no action — load is in progress.
 

--- a/coordinator/api/provider.go
+++ b/coordinator/api/provider.go
@@ -419,7 +419,10 @@ func (s *Server) providerReadLoop(ctx context.Context, conn *websocket.Conn, pro
 				// Mark the model warm on this provider BEFORE draining so
 				// the scheduler sees it as a candidate. Without this, the
 				// provider still looks cold until the next heartbeat.
-				s.registry.MarkModelWarm(providerID, statusMsg.ModelID)
+				alreadyWarm := s.registry.MarkModelWarm(providerID, statusMsg.ModelID)
+				if alreadyWarm {
+					s.metrics.IncCounter("warming.unnecessary_loads", MetricLabel{"model", statusMsg.ModelID})
+				}
 				s.registry.ClearPendingModelLoad(providerID, statusMsg.ModelID)
 				s.registry.DrainQueuedRequestsForModel(statusMsg.ModelID)
 				s.ddIncr("warming.load_commands_succeeded", []string{"model:" + statusMsg.ModelID})

--- a/coordinator/api/routing_metrics_test.go
+++ b/coordinator/api/routing_metrics_test.go
@@ -552,3 +552,50 @@ func TestRoutingMetrics_AllTagsOnSelection(t *testing.T) {
 		}
 	}
 }
+
+// TestServerMetricsEmitterMirrorsRegistryCountersIntoInProcessMetrics verifies
+// that metrics emitted by the registry via MetricsEmitter are also reflected in
+// the in-process /v1/admin/metrics registry.
+func TestServerMetricsEmitterMirrorsRegistryCountersIntoInProcessMetrics(t *testing.T) {
+	collector := newUDPCollector(t)
+	defer collector.Close()
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	st := store.NewMemory(store.Config{AdminKey: "test-key"})
+	reg := registry.New(logger)
+
+	srv := NewServer(reg, st, ServerConfig{}, logger)
+	ddClient := newTestDD(t, collector)
+	defer ddClient.Close()
+	srv.SetDatadog(ddClient)
+
+	model := "mirror-model"
+	p := makeRoutableProvider(t, reg, "mirror-p1", model)
+	p.Mu().Lock()
+	p.BackendCapacity.Slots[0].State = "unknown"
+	p.Mu().Unlock()
+
+	pr := &registry.PendingRequest{
+		RequestID:          "req-mirror",
+		Model:              model,
+		RequestedMaxTokens: 128,
+		ChunkCh:            make(chan string, 1),
+		CompleteCh:         make(chan protocol.UsageInfo, 1),
+		ErrorCh:            make(chan protocol.InferenceErrorMessage, 1),
+	}
+
+	_, _ = reg.ReserveProviderEx(model, pr)
+
+	_ = ddClient.Statsd.Flush()
+	packets := collector.drain()
+
+	if !hasMetric(packets, "warming.missed_warm_starts") {
+		t.Errorf("missing warming.missed_warm_starts in DogStatsD packets; got %v", packets)
+	}
+
+	snap := srv.Metrics().Snapshot()
+	key := "warming.missed_warm_starts{model=" + model + "}"
+	if snap.Counters[key] != 1 {
+		t.Fatalf("expected in-process counter %q = 1, got %+v", key, snap.Counters)
+	}
+}

--- a/coordinator/api/server.go
+++ b/coordinator/api/server.go
@@ -662,6 +662,8 @@ type serverMetricsEmitter struct {
 
 func (e serverMetricsEmitter) Incr(name string, tags []string) {
 	e.s.ddIncr(name, tags)
+	labels := ddTagsToMetricLabels(tags)
+	e.s.metrics.IncCounter(name, labels...)
 }
 
 func (e serverMetricsEmitter) Gauge(name string, value float64, tags []string) {
@@ -670,6 +672,21 @@ func (e serverMetricsEmitter) Gauge(name string, value float64, tags []string) {
 
 func (e serverMetricsEmitter) Histogram(name string, value float64, tags []string) {
 	e.s.ddHistogram(name, value, tags)
+	labels := ddTagsToMetricLabels(tags)
+	e.s.metrics.ObserveHistogram(name, value, labels...)
+}
+
+// ddTagsToMetricLabels converts DogStatsD "key:value" tags into the in-process
+// metrics label type so registry-emitted metrics are also visible via
+// /v1/admin/metrics.
+func ddTagsToMetricLabels(tags []string) []MetricLabel {
+	labels := make([]MetricLabel, 0, len(tags))
+	for _, tag := range tags {
+		if idx := strings.IndexByte(tag, ':'); idx > 0 {
+			labels = append(labels, MetricLabel{Name: tag[:idx], Value: tag[idx+1:]})
+		}
+	}
+	return labels
 }
 
 // ddIncr increments a DogStatsD counter. No-op if DD is not configured.
@@ -1616,6 +1633,15 @@ func (s *Server) registerDefaultGauges() {
 			return 1
 		}
 		return 0
+	})
+	s.metrics.RegisterGauge("warming.max_warmup_eta_seconds", func() float64 {
+		var maxETA int
+		for _, model := range s.registry.ModelsWithDemand() {
+			if eta := s.registry.EstimatedWaitSeconds(model); eta > maxETA {
+				maxETA = eta
+			}
+		}
+		return float64(maxETA)
 	})
 }
 

--- a/coordinator/api/server.go
+++ b/coordinator/api/server.go
@@ -549,6 +549,7 @@ func NewServer(reg *registry.Registry, st store.Store, cfg ServerConfig, logger 
 		settlements:          newSettlementHolder(),
 		zombieCanceller:      newZombieStreamCanceller(),
 	}
+	reg.SetMetricsEmitter(serverMetricsEmitter{s: s})
 	s.registerDefaultGauges()
 	s.routes()
 
@@ -651,6 +652,24 @@ func (s *Server) emitRequest(ctx context.Context, severity protocol.TelemetrySev
 		Fields:    fields,
 		RequestID: requestID,
 	})
+}
+
+// serverMetricsEmitter adapts Server's Datadog helpers to the registry's
+// MetricsEmitter interface.
+type serverMetricsEmitter struct {
+	s *Server
+}
+
+func (e serverMetricsEmitter) Incr(name string, tags []string) {
+	e.s.ddIncr(name, tags)
+}
+
+func (e serverMetricsEmitter) Gauge(name string, value float64, tags []string) {
+	e.s.ddGauge(name, value, tags)
+}
+
+func (e serverMetricsEmitter) Histogram(name string, value float64, tags []string) {
+	e.s.ddHistogram(name, value, tags)
 }
 
 // ddIncr increments a DogStatsD counter. No-op if DD is not configured.

--- a/coordinator/cmd/coordinator/main.go
+++ b/coordinator/cmd/coordinator/main.go
@@ -143,12 +143,21 @@ func main() {
 		}
 	}()
 
-	reg := registry.New(logger)
+	reg := registry.NewWithFullConfig(logger, cfg.RegistryCfg)
 
-	// Set minimum trust level for routing.
+	// Set minimum trust level for routing (also present in config, but keep the
+	// explicit override log here for clarity).
 	if cfg.RegistryCfg.MinTrustLevel != "" {
 		reg.MinTrustLevel = registry.TrustLevel(cfg.RegistryCfg.MinTrustLevel)
 		logger.Info("minimum trust level override", "level", cfg.RegistryCfg.MinTrustLevel)
+	}
+	if cfg.RegistryCfg.Warming.Enabled {
+		reg.StartWarmingPlanner()
+		logger.Info("predictive warming enabled",
+			"interval", cfg.RegistryCfg.Warming.PlannerInterval,
+			"horizon", cfg.RegistryCfg.Warming.ForecastHorizon,
+			"target_utilization", cfg.RegistryCfg.Warming.TargetUtilization,
+		)
 	}
 
 	srv := api.NewServer(reg, st, cfg.ServerConfig, logger)
@@ -538,6 +547,7 @@ func main() {
 	defer shutdownCancel()
 
 	cancel() // Stop the eviction loop.
+	reg.StopWarmingPlanner()
 
 	if err := httpServer.Shutdown(shutdownCtx); err != nil {
 		logger.Error("shutdown error", "error", err)

--- a/coordinator/registry/algorithm_scenarios_test.go
+++ b/coordinator/registry/algorithm_scenarios_test.go
@@ -33,12 +33,18 @@ package registry
 // to see which scenarios currently pass.
 
 import (
+	"context"
 	"fmt"
 	"math"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/eigeninference/d-inference/coordinator/protocol"
+	"nhooyr.io/websocket"
 )
 
 // scenarioProvider builds a fully-attested provider with controllable
@@ -53,6 +59,7 @@ type scenarioProvider struct {
 	backendRun  int    // backend slot's NumRunning
 	backendWait int    // backend slot's NumWaiting
 	slotState   string // running, idle_shutdown, etc.
+	conn        *websocket.Conn
 }
 
 func (sp scenarioProvider) register(t *testing.T, reg *Registry, model string) *Provider {
@@ -61,7 +68,7 @@ func (sp scenarioProvider) register(t *testing.T, reg *Registry, model string) *
 	msg.Models = []protocol.ModelInfo{{ID: model, ModelType: "chat", Quantization: "4bit"}}
 	msg.DecodeTPS = sp.decodeTPS
 	msg.Hardware.MemoryGB = int(sp.totalMemGB)
-	p := reg.Register(sp.id, nil, msg)
+	p := reg.Register(sp.id, sp.conn, msg)
 	p.mu.Lock()
 	p.TrustLevel = TrustHardware
 	p.RuntimeVerified = true
@@ -503,6 +510,267 @@ func TestAlgorithm_Regression_TrustLevelGate(t *testing.T) {
 	}
 	if p.ID != "hardware-slow" {
 		t.Fatalf("got %q, want hardware-slow. Trust gate must reject self-signed.", p.ID)
+	}
+}
+
+// ---------------------------------------------------------------------
+// Predictive warming scenarios
+// ---------------------------------------------------------------------
+
+// testMetricsEmitter captures warming-related metrics for assertions.
+type testMetricsEmitter struct {
+	mu     sync.Mutex
+	counts map[string]int
+}
+
+func (m *testMetricsEmitter) Incr(name string, tags []string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.counts == nil {
+		m.counts = make(map[string]int)
+	}
+	key := name + "|" + strings.Join(tags, "|")
+	m.counts[key]++
+}
+
+func (m *testMetricsEmitter) Gauge(string, float64, []string)     {}
+func (m *testMetricsEmitter) Histogram(string, float64, []string) {}
+
+func (m *testMetricsEmitter) count(name string, tags []string) int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.counts == nil {
+		return 0
+	}
+	key := name + "|" + strings.Join(tags, "|")
+	return m.counts[key]
+}
+
+// fakeHistoricalSource returns a fixed baseline for demand-forecast tests.
+type fakeHistoricalSource struct {
+	rps float64
+}
+
+func (f *fakeHistoricalSource) HistoricalDemand(context.Context, string, time.Duration) (float64, error) {
+	return f.rps, nil
+}
+
+// newWarmingRegistry creates a registry with predictive warming enabled.
+func newWarmingRegistry(t *testing.T) *Registry {
+	t.Helper()
+	cfg := DefaultWarmingConfig()
+	cfg.Enabled = true
+	return NewWithConfig(testLogger(), cfg)
+}
+
+// newWarmingRegistryWithHistorical creates a registry with warming enabled and
+// a custom historical demand source.
+func newWarmingRegistryWithHistorical(t *testing.T, hist HistoricalDemandSource) *Registry {
+	t.Helper()
+	cfg := DefaultWarmingConfig()
+	cfg.Enabled = true
+	r := NewWithConfig(testLogger(), cfg)
+	if hist != nil {
+		f := NewDemandForecaster(hist, cfg)
+		r.forecaster = f
+		r.warmingPlanner.forecaster = f
+	}
+	return r
+}
+
+// newTestWebSocketConn creates an in-process websocket connection for tests.
+// The returned client connection can be passed to Register so SendLoadModel
+// succeeds without a real network round-trip.
+func newTestWebSocketConn(t *testing.T) *websocket.Conn {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			t.Errorf("accept websocket: %v", err)
+			return
+		}
+		defer conn.Close(websocket.StatusNormalClosure, "")
+		for {
+			_, _, err := conn.Read(r.Context())
+			if err != nil {
+				return
+			}
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	conn, _, err := websocket.Dial(ctx, "ws://"+srv.Listener.Addr().String(), nil)
+	if err != nil {
+		t.Fatalf("dial websocket: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close(websocket.StatusNormalClosure, "") })
+	return conn
+}
+
+// addModel advertises an additional model on an already-registered provider.
+func addModel(t *testing.T, p *Provider, model string) {
+	t.Helper()
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	for _, m := range p.Models {
+		if m.ID == model {
+			return
+		}
+	}
+	p.Models = append(p.Models, protocol.ModelInfo{
+		ID:           model,
+		ModelType:    "chat",
+		Quantization: "4bit",
+	})
+}
+
+// pendingLoadForModel returns true if the registry has a pending load_model for
+// (provider, model).
+func pendingLoadForModel(r *Registry, providerID, model string) bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	_, ok := r.pendingModelLoads[providerID+":"+model]
+	return ok
+}
+
+// TestAlgorithm_PW_PreQueueWarm verifies that the warming planner sends a
+// load_model command as soon as demand appears, before any request actually
+// queues. Without predictive warming the request would queue first and only
+// then trigger a reactive swap.
+func TestAlgorithm_PW_PreQueueWarm(t *testing.T) {
+	r := newWarmingRegistry(t)
+	metrics := &testMetricsEmitter{}
+	r.SetMetricsEmitter(metrics)
+
+	model := "pw-prequeue-model"
+	r.SetModelCatalog([]CatalogEntry{{ID: model}})
+
+	scenarioProvider{
+		id: "cold", decodeTPS: 30, totalMemGB: 64, gpuActiveGB: 1,
+		slotState: "idle_shutdown",
+		conn:      newTestWebSocketConn(t),
+	}.register(t, r, model)
+
+	// Simulate requests arriving; no request is actually queued.
+	for i := 0; i < 10; i++ {
+		r.RecordDemand(model)
+		time.Sleep(2 * time.Millisecond)
+	}
+
+	r.warmingPlanner.tick()
+
+	if !r.providerHasPendingLoad("cold") {
+		t.Fatal("expected load_model to be sent pre-queue for demanded model")
+	}
+	if !pendingLoadForModel(r, "cold", model) {
+		t.Fatalf("expected pending load for %q on cold provider", model)
+	}
+	if metrics.count("warming.load_commands_sent", []string{"model:" + model}) < 1 {
+		t.Fatal("expected warming.load_commands_sent metric for the model")
+	}
+}
+
+// TestAlgorithm_PW_RapidModelShift verifies that the planner warms providers
+// for a newly-demanded model even when another model was just warmed. This
+// guards against the planner getting stuck on the previous model and ignoring
+// a sudden shift in demand.
+func TestAlgorithm_PW_RapidModelShift(t *testing.T) {
+	r := newWarmingRegistry(t)
+	metrics := &testMetricsEmitter{}
+	r.SetMetricsEmitter(metrics)
+
+	modelA := "pw-shift-model-a"
+	modelB := "pw-shift-model-b"
+	r.SetModelCatalog([]CatalogEntry{{ID: modelA}, {ID: modelB}})
+
+	p1 := scenarioProvider{
+		id: "p1", decodeTPS: 30, totalMemGB: 128, gpuActiveGB: 1,
+		slotState: "idle_shutdown",
+		conn:      newTestWebSocketConn(t),
+	}.register(t, r, modelA)
+	addModel(t, p1, modelB)
+
+	p2 := scenarioProvider{
+		id: "p2", decodeTPS: 30, totalMemGB: 128, gpuActiveGB: 1,
+		slotState: "idle_shutdown",
+		conn:      newTestWebSocketConn(t),
+	}.register(t, r, modelA)
+	addModel(t, p2, modelB)
+
+	// Demand appears for model A. Only one provider needs to be warm.
+	r.RecordQueueDepth(modelA, 1)
+	r.warmingPlanner.tick()
+
+	var warmedForA string
+	for key := range r.pendingModelLoads {
+		pid, m, ok := splitModelLoadKey(key)
+		if ok && m == modelA {
+			warmedForA = pid
+			break
+		}
+	}
+	if warmedForA == "" {
+		t.Fatal("expected a pending load_model for model A")
+	}
+
+	// Simulate the load completing and model A becoming warm on that provider.
+	r.ClearPendingModelLoad(warmedForA, modelA)
+	r.MarkModelWarm(warmedForA, modelA)
+
+	// Demand now shifts to model B.
+	r.RecordQueueDepth(modelB, 1)
+	r.warmingPlanner.tick()
+
+	if !pendingLoadForModel(r, "p1", modelB) && !pendingLoadForModel(r, "p2", modelB) {
+		t.Fatal("expected a load_model for model B after demand shifted")
+	}
+	if metrics.count("warming.load_commands_sent", []string{"model:" + modelB}) < 1 {
+		t.Fatal("expected warming.load_commands_sent metric for model B")
+	}
+
+	// No extra load for A should be sent: one provider is already warm.
+	aLoads := metrics.count("warming.load_commands_sent", []string{"model:" + modelA})
+	if aLoads != 1 {
+		t.Fatalf("expected exactly 1 load command for model A, got %d", aLoads)
+	}
+}
+
+// TestAlgorithm_PW_NoWarmWhenUncertain verifies that a purely historical
+// baseline (no recent requests, no queued requests) does not trigger eager
+// warming. Historical signals alone have low confidence and the planner must
+// wait for stronger evidence before spending provider resources.
+func TestAlgorithm_PW_NoWarmWhenUncertain(t *testing.T) {
+	hist := &fakeHistoricalSource{rps: 0.5}
+	r := newWarmingRegistryWithHistorical(t, hist)
+	metrics := &testMetricsEmitter{}
+	r.SetMetricsEmitter(metrics)
+
+	model := "pw-uncertain-model"
+	r.SetModelCatalog([]CatalogEntry{{ID: model}})
+
+	scenarioProvider{
+		id: "cold", decodeTPS: 30, totalMemGB: 64, gpuActiveGB: 1,
+		slotState: "idle_shutdown",
+		conn:      newTestWebSocketConn(t),
+	}.register(t, r, model)
+
+	r.warmingPlanner.tick()
+
+	if r.providerHasPendingLoad("cold") {
+		t.Fatal("expected no load_model for uncertain historical-only demand")
+	}
+	if metrics.count("warming.load_commands_sent", []string{"model:" + model}) != 0 {
+		t.Fatal("expected no warming.load_commands_sent metric for uncertain demand")
+	}
+
+	f := r.Forecast(context.Background(), model)
+	if f.Confidence >= 0.5 {
+		t.Fatalf("expected low confidence for historical-only signal, got %.2f", f.Confidence)
+	}
+	if f.RequestsPerSecond <= 0 {
+		t.Fatal("expected positive forecasted RPS from historical baseline")
 	}
 }
 

--- a/coordinator/registry/config.go
+++ b/coordinator/registry/config.go
@@ -3,19 +3,90 @@ package registry
 import (
 	"fmt"
 	"os"
+	"strconv"
+	"time"
 
 	"github.com/eigeninference/d-inference/coordinator/env"
 )
 
+// WarmingConfig holds tuning knobs for predictive model warming.
+// All durations use Go time units when parsed from environment (e.g. "60s", "5m").
+type WarmingConfig struct {
+	// Enabled turns on the predictive warming planner.
+	Enabled bool
+	// PlannerInterval is how often the warming planner re-evaluates demand.
+	PlannerInterval time.Duration
+	// ForecastHorizon is how far ahead demand is predicted.
+	ForecastHorizon time.Duration
+	// TargetUtilization is the desired ratio of a provider's capacity to consume
+	// before warming another provider (e.g., 0.7 for 70%).
+	TargetUtilization float64
+	// MaxLoadsPerModelPerTick limits how many concurrent load_model commands are
+	// sent for a single model in one planner tick (anti-thundering-herd).
+	MaxLoadsPerModelPerTick int
+	// MinWarmTime is the minimum time a provider-model pair stays warm before
+	// the coordinator considers allowing idle unload.
+	MinWarmTime time.Duration
+	// EWMA10sWeight, EWMA60sWeight, EWMA5mWeight tune the recent-demand signal.
+	EWMA10sWeight, EWMA60sWeight, EWMA5mWeight float64
+	// HistoricalWeight tunes the historical baseline signal.
+	HistoricalWeight float64
+}
+
 // Config holds registry-level configuration.
 type Config struct {
 	MinTrustLevel string // overrides default trust level (empty = use default)
+	Warming       WarmingConfig
+}
+
+// DefaultWarmingConfig returns the default predictive warming configuration.
+func DefaultWarmingConfig() WarmingConfig {
+	return WarmingConfig{
+		Enabled:                 false,
+		PlannerInterval:         1 * time.Second,
+		ForecastHorizon:         60 * time.Second,
+		TargetUtilization:       0.7,
+		MaxLoadsPerModelPerTick: 3,
+		MinWarmTime:             5 * time.Minute,
+		EWMA10sWeight:           0.6,
+		EWMA60sWeight:           0.4,
+		EWMA5mWeight:            0.2,
+		HistoricalWeight:        0.5,
+	}
 }
 
 // ReadConfig reads registry configuration from environment variables.
 func ReadConfig() Config {
+	wc := DefaultWarmingConfig()
+	wc.Enabled = os.Getenv(env.EnvPrefix+"_PREDICTIVE_WARMING_ENABLED") == "true"
+	if v := os.Getenv(env.EnvPrefix + "_WARMING_PLANNER_INTERVAL"); v != "" {
+		if d, err := time.ParseDuration(v); err == nil {
+			wc.PlannerInterval = d
+		}
+	}
+	if v := os.Getenv(env.EnvPrefix + "_WARMING_FORECAST_HORIZON"); v != "" {
+		if d, err := time.ParseDuration(v); err == nil {
+			wc.ForecastHorizon = d
+		}
+	}
+	if v := os.Getenv(env.EnvPrefix + "_WARMING_TARGET_UTILIZATION"); v != "" {
+		if f, err := strconv.ParseFloat(v, 64); err == nil {
+			wc.TargetUtilization = f
+		}
+	}
+	if v := os.Getenv(env.EnvPrefix + "_WARMING_MAX_LOADS_PER_TICK"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			wc.MaxLoadsPerModelPerTick = n
+		}
+	}
+	if v := os.Getenv(env.EnvPrefix + "_WARMING_MIN_WARM_TIME"); v != "" {
+		if d, err := time.ParseDuration(v); err == nil {
+			wc.MinWarmTime = d
+		}
+	}
 	return Config{
 		MinTrustLevel: os.Getenv(env.EnvPrefix + "_MIN_TRUST"),
+		Warming:       wc,
 	}
 }
 

--- a/coordinator/registry/config_test.go
+++ b/coordinator/registry/config_test.go
@@ -1,0 +1,46 @@
+package registry
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/env"
+)
+
+// TestDefaultWarmingConfig documents the default predictive-warming tuning
+// values referenced in AGENTS.md.
+func TestDefaultWarmingConfig(t *testing.T) {
+	cfg := DefaultWarmingConfig()
+	if cfg.Enabled {
+		t.Error("predictive warming is disabled by default")
+	}
+	if cfg.PlannerInterval != 1*time.Second {
+		t.Errorf("PlannerInterval=%v, want 1s", cfg.PlannerInterval)
+	}
+	if cfg.ForecastHorizon != 60*time.Second {
+		t.Errorf("ForecastHorizon=%v, want 60s", cfg.ForecastHorizon)
+	}
+	if cfg.TargetUtilization != 0.7 {
+		t.Errorf("TargetUtilization=%v, want 0.7", cfg.TargetUtilization)
+	}
+	if cfg.MaxLoadsPerModelPerTick != 3 {
+		t.Errorf("MaxLoadsPerModelPerTick=%d, want 3", cfg.MaxLoadsPerModelPerTick)
+	}
+	if cfg.MinWarmTime != 5*time.Minute {
+		t.Errorf("MinWarmTime=%v, want 5m", cfg.MinWarmTime)
+	}
+}
+
+// TestReadConfigPredictiveWarmingEnabled documents the feature flag that
+// enables predictive warming.
+func TestReadConfigPredictiveWarmingEnabled(t *testing.T) {
+	key := env.EnvPrefix + "_PREDICTIVE_WARMING_ENABLED"
+	t.Setenv(key, "true")
+	defer os.Unsetenv(key)
+
+	cfg := ReadConfig()
+	if !cfg.Warming.Enabled {
+		t.Error("predictive warming should be enabled when the env var is true")
+	}
+}

--- a/coordinator/registry/forecaster.go
+++ b/coordinator/registry/forecaster.go
@@ -46,11 +46,11 @@ type DemandForecast struct {
 type DemandForecaster struct {
 	historical HistoricalDemandSource
 
-	mu       sync.RWMutex
-	tickers  map[string]*demandTicker // model -> rate tracker
-	queues   map[string]int           // model -> last observed queue depth
-	horizon  time.Duration
-	weights  forecastWeights
+	mu      sync.RWMutex
+	tickers map[string]*demandTicker // model -> rate tracker
+	queues  map[string]int           // model -> last observed queue depth
+	horizon time.Duration
+	weights forecastWeights
 }
 
 type forecastWeights struct {

--- a/coordinator/registry/forecaster.go
+++ b/coordinator/registry/forecaster.go
@@ -1,0 +1,234 @@
+package registry
+
+import (
+	"context"
+	"math"
+	"sync"
+	"time"
+)
+
+// HistoricalDemandSource returns historical request-rate baselines for a model.
+// A nil or no-op implementation is valid; the forecaster falls back to recent
+// demand and queue signals.
+type HistoricalDemandSource interface {
+	// HistoricalDemand returns the expected requests-per-second for the model
+	// over the given look-ahead window, based on comparable past intervals.
+	HistoricalDemand(ctx context.Context, model string, window time.Duration) (float64, error)
+}
+
+// noopHistoricalDemandSource always returns zero demand.
+type noopHistoricalDemandSource struct{}
+
+func (noopHistoricalDemandSource) HistoricalDemand(context.Context, string, time.Duration) (float64, error) {
+	return 0, nil
+}
+
+// DemandForecast is the output of the forecaster for one model.
+type DemandForecast struct {
+	Model string
+	// RequestsPerSecond is the predicted demand over the forecast horizon.
+	RequestsPerSecond float64
+	// RecentRPS is the EWMA-smoothed recent arrival rate.
+	RecentRPS float64
+	// HistoricalRPS is the baseline from historical data.
+	HistoricalRPS float64
+	// QueuedRPS is the queue-depth converted to an equivalent rate.
+	QueuedRPS float64
+	// Confidence is in [0,1]; higher means more of the signal is recent or queued
+	// (strong evidence) versus pure historical baseline.
+	Confidence float64
+	// Rising is true when the short-term trend is increasing.
+	Rising bool
+}
+
+// DemandForecaster combines historical baseline, recent arrival-rate EWMAs, and
+// current queue depth into a short-term demand forecast per model.
+type DemandForecaster struct {
+	historical HistoricalDemandSource
+
+	mu       sync.RWMutex
+	tickers  map[string]*demandTicker // model -> rate tracker
+	queues   map[string]int           // model -> last observed queue depth
+	horizon  time.Duration
+	weights  forecastWeights
+}
+
+type forecastWeights struct {
+	historical float64
+	s10s       float64
+	s60s       float64
+	s5m        float64
+	queue      float64
+}
+
+// demandTicker tracks EWMA demand rates for one model at multiple time scales.
+type demandTicker struct {
+	model string
+	s10s  *ewma
+	s60s  *ewma
+	s5m   *ewma
+	last  time.Time
+}
+
+// ewma is an exponentially weighted moving average for a fixed time constant.
+type ewma struct {
+	alpha float64
+	value float64
+	init  bool
+}
+
+func newEWMA(timeConstant time.Duration) *ewma {
+	return &ewma{alpha: 1 - math.Exp(-1.0/timeConstant.Seconds())}
+}
+
+func (e *ewma) add(v float64) {
+	if !e.init {
+		e.value = v
+		e.init = true
+		return
+	}
+	e.value = e.alpha*v + (1-e.alpha)*e.value
+}
+
+func (e *ewma) valuePerSecond() float64 {
+	if !e.init {
+		return 0
+	}
+	return e.value
+}
+
+// NewDemandForecaster creates a forecaster. If historical is nil, a no-op
+// source is used.
+func NewDemandForecaster(historical HistoricalDemandSource, cfg WarmingConfig) *DemandForecaster {
+	if historical == nil {
+		historical = noopHistoricalDemandSource{}
+	}
+	return &DemandForecaster{
+		historical: historical,
+		tickers:    make(map[string]*demandTicker),
+		queues:     make(map[string]int),
+		horizon:    cfg.ForecastHorizon,
+		weights: forecastWeights{
+			historical: cfg.HistoricalWeight,
+			s10s:       cfg.EWMA10sWeight,
+			s60s:       cfg.EWMA60sWeight,
+			s5m:        cfg.EWMA5mWeight,
+			queue:      1.0,
+		},
+	}
+}
+
+// RecordRequest records that one request arrived for the model.
+func (f *DemandForecaster) RecordRequest(model string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	t := f.tickerForLocked(model)
+	now := time.Now()
+	delta := now.Sub(t.last).Seconds()
+	if delta > 0 {
+		rate := 1.0 / delta
+		t.s10s.add(rate)
+		t.s60s.add(rate)
+		t.s5m.add(rate)
+	}
+	t.last = now
+}
+
+// RecordQueue records the current queue depth for the model.
+func (f *DemandForecaster) RecordQueue(model string, depth int) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.queues[model] = depth
+}
+
+// Forecast returns the current demand forecast for the model.
+func (f *DemandForecaster) Forecast(ctx context.Context, model string) DemandForecast {
+	f.mu.RLock()
+	ticker, ok := f.tickers[model]
+	queueDepth := f.queues[model]
+	f.mu.RUnlock()
+
+	hist, _ := f.historical.HistoricalDemand(ctx, model, f.horizon)
+
+	var recent10s, recent60s, recent5m float64
+	if ok {
+		recent10s = ticker.s10s.valuePerSecond()
+		recent60s = ticker.s60s.valuePerSecond()
+		recent5m = ticker.s5m.valuePerSecond()
+	}
+
+	// Convert queue depth to an equivalent rate. We assume each queued request
+	// represents ~3 seconds of backlog (matches estimateRetryAfter heuristic).
+	queuedRPS := float64(queueDepth) / 3.0
+
+	// Confidence rises with the presence of strong recent/queued signals.
+	confidence := 0.3
+	if recent10s > 0 || recent60s > 0 {
+		confidence += 0.4
+	}
+	if queueDepth > 0 {
+		confidence += 0.3
+	}
+	if confidence > 1.0 {
+		confidence = 1.0
+	}
+
+	// Recent signal uses the highest of the short-term EWMAs, discounted for
+	// longer windows.
+	recent := math.Max(recent10s, math.Max(recent60s*f.weights.s60s, recent5m*f.weights.s5m))
+
+	// Combine signals. Historical baseline is scaled down when confidence is high
+	// so that live demand dominates.
+	histWeight := f.weights.historical * (1.0 - confidence*0.5)
+	score := histWeight*hist +
+		f.weights.s10s*recent10s +
+		f.weights.s60s*recent60s +
+		f.weights.s5m*recent5m +
+		f.weights.queue*queuedRPS
+
+	// Boost when the short-term rate is rising.
+	rising := recent10s > recent60s*1.2
+
+	return DemandForecast{
+		Model:             model,
+		RequestsPerSecond: score,
+		RecentRPS:         recent,
+		HistoricalRPS:     hist,
+		QueuedRPS:         queuedRPS,
+		Confidence:        confidence,
+		Rising:            rising,
+	}
+}
+
+// ModelsWithDemand returns the set of models that have any demand signal.
+func (f *DemandForecaster) ModelsWithDemand() []string {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	models := make([]string, 0, len(f.tickers)+len(f.queues))
+	seen := make(map[string]struct{})
+	for m := range f.tickers {
+		seen[m] = struct{}{}
+		models = append(models, m)
+	}
+	for m := range f.queues {
+		if _, ok := seen[m]; !ok {
+			models = append(models, m)
+		}
+	}
+	return models
+}
+
+func (f *DemandForecaster) tickerForLocked(model string) *demandTicker {
+	t, ok := f.tickers[model]
+	if !ok {
+		t = &demandTicker{
+			model: model,
+			s10s:  newEWMA(10 * time.Second),
+			s60s:  newEWMA(60 * time.Second),
+			s5m:   newEWMA(5 * time.Minute),
+			last:  time.Now(),
+		}
+		f.tickers[model] = t
+	}
+	return t
+}

--- a/coordinator/registry/forecaster_test.go
+++ b/coordinator/registry/forecaster_test.go
@@ -1,0 +1,168 @@
+package registry
+
+import (
+	"context"
+	"math"
+	"testing"
+	"time"
+)
+
+func TestEWMAFirstValue(t *testing.T) {
+	e := newEWMA(10 * time.Second)
+	want := 5.0
+	e.add(want)
+	if got := e.valuePerSecond(); math.Abs(got-want) > 1e-9 {
+		t.Fatalf("first ewma value = %v, want %v", got, want)
+	}
+}
+
+func TestEWMAMixesSubsequentValues(t *testing.T) {
+	tc := 10 * time.Second
+	e := newEWMA(tc)
+	alpha := 1 - math.Exp(-1.0/tc.Seconds())
+
+	e.add(10.0)
+	e.add(20.0)
+	want := alpha*20.0 + (1-alpha)*10.0
+	if got := e.valuePerSecond(); math.Abs(got-want) > 1e-9 {
+		t.Fatalf("ewma value = %v, want %v", got, want)
+	}
+}
+
+func TestEWMAConvergesToMean(t *testing.T) {
+	e := newEWMA(10 * time.Second)
+	for range 100 {
+		e.add(42.0)
+	}
+	if got := e.valuePerSecond(); math.Abs(got-42.0) > 1e-6 {
+		t.Fatalf("ewma value = %v, want ~42", got)
+	}
+}
+
+func TestRecordRequestUpdatesForecast(t *testing.T) {
+	f := NewDemandForecaster(nil, DefaultWarmingConfig())
+	model := "request-signal-model"
+
+	// Record requests at a steady ~10 rps so the short-term EWMAs populate.
+	for range 15 {
+		f.RecordRequest(model)
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	forecast := f.Forecast(context.Background(), model)
+	if forecast.RecentRPS <= 0 {
+		t.Fatalf("RecentRPS = %v, want > 0", forecast.RecentRPS)
+	}
+	if forecast.Confidence < 0.7 {
+		t.Fatalf("Confidence = %v, want >= 0.7 after recent requests", forecast.Confidence)
+	}
+	if forecast.RequestsPerSecond <= 0 {
+		t.Fatalf("RequestsPerSecond = %v, want > 0", forecast.RequestsPerSecond)
+	}
+}
+
+func TestRecordQueueUpdatesForecast(t *testing.T) {
+	f := NewDemandForecaster(nil, DefaultWarmingConfig())
+	model := "queue-signal-model"
+	depth := 9
+
+	f.RecordQueue(model, depth)
+	forecast := f.Forecast(context.Background(), model)
+
+	wantQueuedRPS := float64(depth) / 3.0
+	if math.Abs(forecast.QueuedRPS-wantQueuedRPS) > 1e-9 {
+		t.Fatalf("QueuedRPS = %v, want %v", forecast.QueuedRPS, wantQueuedRPS)
+	}
+	if forecast.RequestsPerSecond != forecast.QueuedRPS {
+		t.Fatalf("RequestsPerSecond = %v, want %v (queue is the only signal)", forecast.RequestsPerSecond, forecast.QueuedRPS)
+	}
+}
+
+func TestForecastConfidenceScenarios(t *testing.T) {
+	cfg := DefaultWarmingConfig()
+	f := NewDemandForecaster(nil, cfg)
+
+	tests := []struct {
+		name       string
+		requests   bool
+		queueDepth int
+		wantConf   float64
+		wantRPSPos bool
+	}{
+		{"no signal", false, 0, 0.3, false},
+		{"recent only", true, 0, 0.7, true},
+		{"queue only", false, 6, 0.6, true},
+		{"recent + queue", true, 6, 1.0, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			model := "conf-" + tt.name
+			if tt.requests {
+				f.RecordRequest(model)
+				f.RecordRequest(model)
+			}
+			if tt.queueDepth > 0 {
+				f.RecordQueue(model, tt.queueDepth)
+			}
+
+			forecast := f.Forecast(context.Background(), model)
+			if math.Abs(forecast.Confidence-tt.wantConf) > 1e-9 {
+				t.Fatalf("Confidence = %v, want %v", forecast.Confidence, tt.wantConf)
+			}
+			if tt.wantRPSPos && forecast.RequestsPerSecond <= 0 {
+				t.Fatalf("RequestsPerSecond = %v, want > 0", forecast.RequestsPerSecond)
+			}
+			if !tt.wantRPSPos && forecast.RequestsPerSecond != 0 {
+				t.Fatalf("RequestsPerSecond = %v, want 0", forecast.RequestsPerSecond)
+			}
+		})
+	}
+}
+
+func TestForecastWithHistoricalBaseline(t *testing.T) {
+	hist := &constantHistoricalSource{rps: 5.0}
+	cfg := DefaultWarmingConfig()
+	f := NewDemandForecaster(hist, cfg)
+	model := "historical-model"
+
+	forecast := f.Forecast(context.Background(), model)
+	if forecast.HistoricalRPS != 5.0 {
+		t.Fatalf("HistoricalRPS = %v, want 5.0", forecast.HistoricalRPS)
+	}
+	if math.Abs(forecast.Confidence-0.3) > 1e-9 {
+		t.Fatalf("Confidence = %v, want 0.3 for historical-only signal", forecast.Confidence)
+	}
+	// With no recent/queued signal, the score is the discounted historical weight.
+	// histWeight = HistoricalWeight * (1 - confidence*0.5) = 0.5 * 0.85 = 0.425.
+	want := 0.425 * 5.0
+	if math.Abs(forecast.RequestsPerSecond-want) > 1e-9 {
+		t.Fatalf("RequestsPerSecond = %v, want %v", forecast.RequestsPerSecond, want)
+	}
+}
+
+func TestModelsWithDemand(t *testing.T) {
+	f := NewDemandForecaster(nil, DefaultWarmingConfig())
+	f.RecordRequest("demand-a")
+	f.RecordQueue("demand-b", 3)
+
+	got := f.ModelsWithDemand()
+	if len(got) != 2 {
+		t.Fatalf("ModelsWithDemand returned %v, want 2 models", got)
+	}
+	seen := make(map[string]bool)
+	for _, m := range got {
+		seen[m] = true
+	}
+	if !seen["demand-a"] || !seen["demand-b"] {
+		t.Fatalf("missing expected model in %v", got)
+	}
+}
+
+type constantHistoricalSource struct {
+	rps float64
+}
+
+func (c *constantHistoricalSource) HistoricalDemand(context.Context, string, time.Duration) (float64, error) {
+	return c.rps, nil
+}

--- a/coordinator/registry/queue.go
+++ b/coordinator/registry/queue.go
@@ -69,10 +69,11 @@ func (r *QueuedRequest) Done() <-chan struct{} {
 
 // RequestQueue manages per-model queues for requests awaiting providers.
 type RequestQueue struct {
-	mu      sync.Mutex
-	queues  map[string][]*QueuedRequest // model -> queue
-	maxSize int                         // max queue size per model
-	maxWait time.Duration               // max time a request waits
+	mu         sync.Mutex
+	queues     map[string][]*QueuedRequest // model -> queue
+	maxSize    int                         // max queue size per model
+	maxWait    time.Duration               // max time a request waits
+	adaptiveFn func(model string) int      // optional per-model dynamic limit
 }
 
 // NewRequestQueue creates a new RequestQueue with the given limits.
@@ -82,6 +83,23 @@ func NewRequestQueue(maxSize int, maxWait time.Duration) *RequestQueue {
 		maxSize: maxSize,
 		maxWait: maxWait,
 	}
+}
+
+// SetAdaptiveLimit sets a function that returns the per-model maximum queue
+// size. If nil or if the function returns 0, the static maxSize is used.
+func (q *RequestQueue) SetAdaptiveLimit(fn func(model string) int) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	q.adaptiveFn = fn
+}
+
+func (q *RequestQueue) effectiveMaxSize(model string) int {
+	if q.adaptiveFn != nil {
+		if n := q.adaptiveFn(model); n > 0 {
+			return n
+		}
+	}
+	return q.maxSize
 }
 
 // Enqueue adds a request to the queue for the given model.
@@ -96,7 +114,7 @@ func (q *RequestQueue) Enqueue(req *QueuedRequest) error {
 	q.cleanStaleLocked(req.Model)
 
 	queue := q.queues[req.Model]
-	if len(queue) >= q.maxSize {
+	if len(queue) >= q.effectiveMaxSize(req.Model) {
 		return ErrQueueFull
 	}
 
@@ -188,6 +206,14 @@ func (q *RequestQueue) RequeueFront(req *QueuedRequest) {
 // MaxSize returns the per-model maximum queue depth.
 func (q *RequestQueue) MaxSize() int {
 	return q.maxSize
+}
+
+// MaxSizeFor returns the effective maximum queue depth for a model, taking
+// any adaptive limit into account.
+func (q *RequestQueue) MaxSizeFor(model string) int {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	return q.effectiveMaxSize(model)
 }
 
 // QueueSize returns the number of queued requests for a model.

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -770,6 +770,15 @@ type Registry struct {
 
 	// metricsEmitter, if set, receives warming-related metrics.
 	metricsEmitter MetricsEmitter
+	// metricsEmitterValue is a lock-free box around metricsEmitter so callers
+	// can emit metrics while holding r.mu without deadlocking.
+	metricsEmitterValue atomic.Value
+}
+
+// metricsEmitterBox wraps a MetricsEmitter so atomic.Value always stores the
+// same concrete pointer type.
+type metricsEmitterBox struct {
+	emitter MetricsEmitter
 }
 
 // MetricsEmitter is the minimal interface the registry uses to emit metrics.
@@ -781,8 +790,8 @@ type MetricsEmitter interface {
 
 type noopMetricsEmitter struct{}
 
-func (noopMetricsEmitter) Incr(string, []string)             {}
-func (noopMetricsEmitter) Gauge(string, float64, []string)   {}
+func (noopMetricsEmitter) Incr(string, []string)               {}
+func (noopMetricsEmitter) Gauge(string, float64, []string)     {}
 func (noopMetricsEmitter) Histogram(string, float64, []string) {}
 
 // pendingModelLoadTTL bounds how long an outstanding (or failed) load_model
@@ -844,6 +853,7 @@ func newRegistryWithConfig(logger *slog.Logger, cfg Config) *Registry {
 	}
 	planner.registry = r
 	r.warmingPlanner = planner
+	r.metricsEmitterValue.Store(&metricsEmitterBox{emitter: noopMetricsEmitter{}})
 	return r
 }
 
@@ -867,13 +877,18 @@ func (r *Registry) SetMetricsEmitter(emitter MetricsEmitter) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.metricsEmitter = emitter
+	if emitter == nil {
+		r.metricsEmitterValue.Store(&metricsEmitterBox{emitter: noopMetricsEmitter{}})
+		return
+	}
+	r.metricsEmitterValue.Store(&metricsEmitterBox{emitter: emitter})
 }
 
 func (r *Registry) metrics() MetricsEmitter {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-	if r.metricsEmitter != nil {
-		return r.metricsEmitter
+	if v := r.metricsEmitterValue.Load(); v != nil {
+		if box, ok := v.(*metricsEmitterBox); ok && box.emitter != nil {
+			return box.emitter
+		}
 	}
 	return noopMetricsEmitter{}
 }
@@ -948,6 +963,34 @@ func (r *Registry) Forecast(ctx context.Context, model string) DemandForecast {
 		return DemandForecast{Model: model}
 	}
 	return r.forecaster.Forecast(ctx, model)
+}
+
+// ModelsWithDemand returns the set of models that have a recent demand signal
+// or queued requests. Used by aggregate warmup-ETA gauges.
+func (r *Registry) ModelsWithDemand() []string {
+	r.mu.RLock()
+	queued := r.queue.QueuedModels()
+	r.mu.RUnlock()
+
+	var forecasted []string
+	if r.forecaster != nil {
+		forecasted = r.forecaster.ModelsWithDemand()
+	}
+
+	seen := make(map[string]struct{}, len(queued)+len(forecasted))
+	models := make([]string, 0, len(queued)+len(forecasted))
+	for _, m := range forecasted {
+		seen[m] = struct{}{}
+		models = append(models, m)
+	}
+	for _, m := range queued {
+		if _, ok := seen[m]; ok {
+			continue
+		}
+		seen[m] = struct{}{}
+		models = append(models, m)
+	}
+	return models
 }
 
 // RecordDispatchLoadFailure puts a provider-model pair on a routing cool-down
@@ -2768,7 +2811,9 @@ func (r *Registry) providerHasPendingLoad(providerID string) bool {
 // MarkModelWarm adds a model to the provider's WarmModels list if not already
 // present. Called when load_model_status:succeeded arrives before the next
 // heartbeat, so the scheduler sees the provider as warm during queue drain.
-func (r *Registry) MarkModelWarm(providerID, modelID string) {
+// Returns true if the provider already had the model warm (the load was
+// redundant).
+func (r *Registry) MarkModelWarm(providerID, modelID string) bool {
 	defer func() {
 		if r.warmingPlanner != nil {
 			r.warmingPlanner.RecordWarm(providerID, modelID)
@@ -2779,14 +2824,18 @@ func (r *Registry) MarkModelWarm(providerID, modelID string) {
 	p, ok := r.providers[providerID]
 	r.mu.RUnlock()
 	if !ok {
-		return
+		return false
 	}
 
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	for _, wm := range p.WarmModels {
 		if wm == modelID {
-			return // already warm
+			// The model was already warm when the load completed. The load
+			// command was redundant — likely a race between multiple warming
+			// actions or a stale planner decision.
+			r.metrics().Incr("warming.unnecessary_loads", []string{"model:" + modelID})
+			return true
 		}
 	}
 	p.WarmModels = append(p.WarmModels, modelID)
@@ -2818,6 +2867,7 @@ func (r *Registry) MarkModelWarm(providerID, modelID string) {
 			})
 		}
 	}
+	return false
 }
 
 // ClearPendingModelLoad removes a pending model load entry after a terminal

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -275,6 +275,12 @@ type Provider struct {
 	// this is set by the coordinator after independently checking the challenge response.
 	ChallengeVerifiedSIP bool `json:"challenge_verified_sip"`
 
+	// thermalHistory tracks the last N thermal states reported by heartbeats for
+	// hysteresis: a provider is only rejected for critical thermal after N
+	// consecutive critical readings, and only re-admitted after M non-critical
+	// readings.
+	thermalHistory []string
+
 	// lastPersisted tracks when this provider was last written to the store.
 	// Used by PersistProviderThrottled to avoid hammering Postgres on every heartbeat.
 	lastPersisted time.Time
@@ -522,6 +528,22 @@ func (p *Provider) GetAttestationResult() *attestation.VerificationResult {
 
 // pendingCount returns the number of in-flight requests.
 // Caller must hold p.mu.
+// thermallyRejectedLocked reports whether the provider should be rejected due to
+// thermal state, using hysteresis. Caller must hold p.mu.
+func (p *Provider) thermallyRejectedLocked() bool {
+	if len(p.thermalHistory) < 2 {
+		return false
+	}
+	critical := 0
+	for _, s := range p.thermalHistory {
+		if s == "critical" {
+			critical++
+		}
+	}
+	// Reject if the two most recent readings are critical.
+	return critical >= 2 && p.thermalHistory[len(p.thermalHistory)-1] == "critical" && p.thermalHistory[len(p.thermalHistory)-2] == "critical"
+}
+
 func (p *Provider) pendingCount() int {
 	return len(p.pendingReqs)
 }
@@ -740,7 +762,28 @@ type Registry struct {
 	// or one missed heartbeat doesn't mass-reap a live fleet. Guarded by r.mu;
 	// rebuilt each sweep so disconnected providers drop out automatically.
 	evictStrikes map[string]int
+
+	// Predictive warming.
+	cfg            Config
+	forecaster     *DemandForecaster
+	warmingPlanner *WarmingPlanner
+
+	// metricsEmitter, if set, receives warming-related metrics.
+	metricsEmitter MetricsEmitter
 }
+
+// MetricsEmitter is the minimal interface the registry uses to emit metrics.
+type MetricsEmitter interface {
+	Incr(name string, tags []string)
+	Gauge(name string, value float64, tags []string)
+	Histogram(name string, value float64, tags []string)
+}
+
+type noopMetricsEmitter struct{}
+
+func (noopMetricsEmitter) Incr(string, []string)             {}
+func (noopMetricsEmitter) Gauge(string, float64, []string)   {}
+func (noopMetricsEmitter) Histogram(string, float64, []string) {}
 
 // pendingModelLoadTTL bounds how long an outstanding (or failed) load_model
 // suppresses re-sends to the same provider.
@@ -765,9 +808,26 @@ type modelLoadAction struct {
 	modelID    string
 }
 
-// New creates a new Registry.
+// New creates a new Registry with default configuration (predictive warming
+// disabled). Use NewWithConfig to enable warming.
 func New(logger *slog.Logger) *Registry {
-	return &Registry{
+	return NewWithConfig(logger, DefaultWarmingConfig())
+}
+
+// NewWithConfig creates a new Registry with the given warming configuration.
+func NewWithConfig(logger *slog.Logger, cfg WarmingConfig) *Registry {
+	return newRegistryWithConfig(logger, Config{Warming: cfg})
+}
+
+// NewWithFullConfig creates a new Registry with the full registry config.
+func NewWithFullConfig(logger *slog.Logger, cfg Config) *Registry {
+	return newRegistryWithConfig(logger, cfg)
+}
+
+func newRegistryWithConfig(logger *slog.Logger, cfg Config) *Registry {
+	forecaster := NewDemandForecaster(nil, cfg.Warming)
+	planner := NewWarmingPlanner(cfg.Warming, forecaster, nil, logger)
+	r := &Registry{
 		providers:               make(map[string]*Provider),
 		queue:                   NewRequestQueue(10, 120*time.Second),
 		MinTrustLevel:           TrustHardware,
@@ -779,7 +839,115 @@ func New(logger *slog.Logger) *Registry {
 		inferenceErrorCooldowns: make(map[inferenceErrorKey]time.Time),
 		evictStrikes:            make(map[string]int),
 		logger:                  logger,
+		cfg:                     cfg,
+		forecaster:              forecaster,
 	}
+	planner.registry = r
+	r.warmingPlanner = planner
+	return r
+}
+
+// StartWarmingPlanner starts the predictive warming planner ticker.
+func (r *Registry) StartWarmingPlanner() {
+	if r.warmingPlanner != nil {
+		r.SetAdaptiveQueueLimit(10, 50)
+		r.warmingPlanner.Start()
+	}
+}
+
+// StopWarmingPlanner stops the predictive warming planner ticker.
+func (r *Registry) StopWarmingPlanner() {
+	if r.warmingPlanner != nil {
+		r.warmingPlanner.Stop()
+	}
+}
+
+// SetMetricsEmitter sets the metrics emitter used by the registry.
+func (r *Registry) SetMetricsEmitter(emitter MetricsEmitter) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.metricsEmitter = emitter
+}
+
+func (r *Registry) metrics() MetricsEmitter {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if r.metricsEmitter != nil {
+		return r.metricsEmitter
+	}
+	return noopMetricsEmitter{}
+}
+
+// RecordDemand records a consumer request for demand forecasting.
+func (r *Registry) RecordDemand(model string) {
+	if r.forecaster != nil {
+		r.forecaster.RecordRequest(model)
+	}
+}
+
+// RecordQueueDepth records the current queue depth for demand forecasting.
+func (r *Registry) RecordQueueDepth(model string, depth int) {
+	if r.forecaster != nil {
+		r.forecaster.RecordQueue(model, depth)
+	}
+}
+
+// EstimatedWaitSeconds returns a rough estimate of how long a request for the
+// model would wait before a warm provider is available. It considers queue
+// depth and any in-flight model loads.
+func (r *Registry) EstimatedWaitSeconds(model string) int {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	queueDepth := r.queue.QueueSize(model)
+	// Each queued request takes ~3 seconds to drain once a provider is warm.
+	estimate := queueDepth * 3
+
+	// If there is a pending load for this model, add an estimate for load time.
+	for key := range r.pendingModelLoads {
+		if _, m, ok := splitModelLoadKey(key); ok && m == model {
+			estimate += 30 // rough model-load seconds
+			break
+		}
+	}
+
+	if estimate < 2 {
+		estimate = 2
+	}
+	if estimate > 120 {
+		estimate = 120
+	}
+	return estimate
+}
+
+// SetAdaptiveQueueLimit enables a per-model queue size that scales with the
+// demand forecast. When predictive warming is enabled, models with positive
+// demand get a larger queue so bursts don't immediately 429.
+func (r *Registry) SetAdaptiveQueueLimit(baseSize, maxSize int) {
+	r.queue.SetAdaptiveLimit(func(model string) int {
+		if r.forecaster == nil {
+			return baseSize
+		}
+		f := r.forecaster.Forecast(context.Background(), model)
+		if f.RequestsPerSecond <= 0 && f.QueuedRPS <= 0 {
+			return baseSize
+		}
+		// Scale linearly with forecast up to maxSize.
+		n := baseSize + int(f.RequestsPerSecond*r.cfg.Warming.ForecastHorizon.Seconds())
+		if n > maxSize {
+			n = maxSize
+		}
+		return n
+	})
+}
+
+// Forecast returns the current demand forecast for a model (mainly for tests
+// and diagnostics).
+func (r *Registry) Forecast(ctx context.Context, model string) DemandForecast {
+	if r.forecaster == nil {
+		return DemandForecast{Model: model}
+	}
+	return r.forecaster.Forecast(ctx, model)
 }
 
 // RecordDispatchLoadFailure puts a provider-model pair on a routing cool-down
@@ -2066,6 +2234,10 @@ func (r *Registry) Heartbeat(id string, msg *protocol.HeartbeatMessage) {
 	p.Stats.TokensGenerated += cumulativeDelta(p.lastSessionStats.TokensGenerated, msg.Stats.TokensGenerated)
 	p.lastSessionStats = msg.Stats
 	p.SystemMetrics = msg.SystemMetrics
+	p.thermalHistory = append(p.thermalHistory, msg.SystemMetrics.ThermalState)
+	if len(p.thermalHistory) > 3 {
+		p.thermalHistory = p.thermalHistory[1:]
+	}
 	// Update backend capacity from heartbeat. A nil report clears prior live
 	// capacity so stale slot state cannot keep influencing routing.
 	p.BackendCapacity = msg.BackendCapacity
@@ -2107,6 +2279,11 @@ func (r *Registry) Heartbeat(id string, msg *protocol.HeartbeatMessage) {
 
 	r.PersistProviderThrottled(p)
 
+	// Refresh the forecaster's view of queue depth for all models.
+	for _, model := range r.queue.QueuedModels() {
+		r.RecordQueueDepth(model, r.queue.QueueSize(model))
+	}
+
 	// Heartbeats can make a recovered slot routable again (for example after a
 	// crash auto-restart). Drain matching queues using the canonical scheduler
 	// rather than the legacy direct queue assignment path.
@@ -2114,6 +2291,8 @@ func (r *Registry) Heartbeat(id string, msg *protocol.HeartbeatMessage) {
 
 	// If queue drain didn't satisfy all pending requests (no warm provider),
 	// check if a cold provider should swap models to serve queued demand.
+	// When the predictive warming planner is enabled, this is a reactive backup;
+	// the planner runs independently on a faster ticker.
 	r.TriggerModelSwaps()
 }
 
@@ -2564,6 +2743,16 @@ func modelLoadKey(providerID, modelID string) string {
 	return providerID + ":" + modelID
 }
 
+// splitModelLoadKey splits a key built by modelLoadKey. ok is false if the key
+// does not contain exactly one colon.
+func splitModelLoadKey(key string) (providerID, modelID string, ok bool) {
+	idx := strings.Index(key, ":")
+	if idx < 0 {
+		return "", "", false
+	}
+	return key[:idx], key[idx+1:], true
+}
+
 // providerHasPendingLoad reports whether the provider has any pending
 // load_model command. Caller must hold r.mu (read or write).
 func (r *Registry) providerHasPendingLoad(providerID string) bool {
@@ -2580,6 +2769,12 @@ func (r *Registry) providerHasPendingLoad(providerID string) bool {
 // present. Called when load_model_status:succeeded arrives before the next
 // heartbeat, so the scheduler sees the provider as warm during queue drain.
 func (r *Registry) MarkModelWarm(providerID, modelID string) {
+	defer func() {
+		if r.warmingPlanner != nil {
+			r.warmingPlanner.RecordWarm(providerID, modelID)
+		}
+	}()
+
 	r.mu.RLock()
 	p, ok := r.providers[providerID]
 	r.mu.RUnlock()

--- a/coordinator/registry/registry_test.go
+++ b/coordinator/registry/registry_test.go
@@ -3051,3 +3051,39 @@ func TestCodeAttestationCoverage(t *testing.T) {
 		t.Fatalf("expected 1 code-attested online provider, got %d", attested)
 	}
 }
+
+// TestMarkModelWarmAlreadyWarmEmitsUnnecessaryLoad verifies that marking a
+// model warm on a provider that already has it warm returns true and emits an
+// unnecessary_load counter.
+func TestMarkModelWarmAlreadyWarmEmitsUnnecessaryLoad(t *testing.T) {
+	r := New(testLogger())
+	metrics := &testMetricsEmitter{}
+	r.SetMetricsEmitter(metrics)
+
+	model := "already-warm-model"
+	msg := testRegisterMessage()
+	msg.Models = []protocol.ModelInfo{{ID: model, ModelType: "chat", Quantization: "4bit"}}
+	p := r.Register("p-warm", nil, msg)
+	p.mu.Lock()
+	p.WarmModels = []string{model}
+	p.mu.Unlock()
+
+	if alreadyWarm := r.MarkModelWarm(p.ID, model); !alreadyWarm {
+		t.Fatal("MarkModelWarm should report already warm")
+	}
+	if got := metrics.count("warming.unnecessary_loads", []string{"model:" + model}); got != 1 {
+		t.Fatalf("warming.unnecessary_loads count = %d, want 1", got)
+	}
+
+	// First-time warm should not emit unnecessary_load.
+	model2 := "first-warm-model"
+	p.mu.Lock()
+	p.WarmModels = []string{model}
+	p.mu.Unlock()
+	if alreadyWarm := r.MarkModelWarm(p.ID, model2); alreadyWarm {
+		t.Fatal("MarkModelWarm should report not already warm for a new model")
+	}
+	if got := metrics.count("warming.unnecessary_loads", []string{"model:" + model2}); got != 0 {
+		t.Fatalf("warming.unnecessary_loads count for new model = %d, want 0", got)
+	}
+}

--- a/coordinator/registry/scheduler.go
+++ b/coordinator/registry/scheduler.go
@@ -31,8 +31,7 @@ const (
 	memoryPressurePenaltyMs  = 4_000.0
 	cpuUsagePenaltyMs        = 1_500.0
 	gpuUtilizationPenaltyMs  = 5_000.0
-	thermalPenaltyFairMs     = 2_000.0
-	thermalPenaltySeriousMs  = 8_000.0
+	pendingModelLoadPenaltyMs = 20_000.0
 	nearTieCostWindowMs      = 3_000.0
 	challengeFreshnessMaxAge = 6 * time.Minute
 
@@ -90,6 +89,9 @@ type routingSnapshot struct {
 	activeTokenBudgetMax  int64
 	queuedTokenBudget     int64
 	fleetMedianTPS        float64
+
+	hasPendingLoad  bool // provider has any pending model load command
+	thermalRejected bool // provider is thermally rejected per hysteresis
 }
 
 type routingCandidate struct {
@@ -121,6 +123,10 @@ const (
 	// this provider (until it loads a VLM build), so like rejectModelTooLarge it
 	// must NOT inflate the transient busy/429 signal.
 	rejectVisionUnsupported
+	// rejectThermal means the provider is thermally throttled (critical state,
+	// or serious with hysteresis). Transient; provider re-enters the pool when
+	// it cools.
+	rejectThermal
 )
 
 // modelMemoryHeadroomFactor is the FALLBACK multiple of the on-disk weight size
@@ -366,7 +372,7 @@ func (r *Registry) selectBestCandidateLockedFull(model string, pr *PendingReques
 		candidate, reason, ok := r.buildCandidateWithReason(snap, pr)
 		if !ok {
 			switch reason {
-			case rejectCapacity:
+			case rejectCapacity, rejectThermal:
 				capacityRejections++
 			case rejectModelTooLarge:
 				tooLargeRejections++
@@ -713,6 +719,8 @@ func (r *Registry) snapshotProviderLocked(p *Provider, model string, traits Requ
 	snap.modelLoaded = snap.slotState == "running"
 	snap.availableOnDisk = !snap.modelLoaded
 	snap.fleetMedianTPS = r.tpsRegistry.Median(model, p.Hardware.ChipFamily)
+	snap.hasPendingLoad = r.providerHasPendingLoad(p.ID)
+	snap.thermalRejected = p.thermallyRejectedLocked()
 
 	return snap, true
 }
@@ -808,8 +816,8 @@ func (r *Registry) buildCandidateWithReason(snap routingSnapshot, pr *PendingReq
 		return nil, rejectCapacity, false
 	}
 
-	if snap.systemMetrics.ThermalState == "critical" {
-		return nil, rejectNone, false
+	if snap.thermalRejected {
+		return nil, rejectThermal, false
 	}
 
 	reqMax := pr.RequestedMaxTokens
@@ -861,9 +869,33 @@ func (r *Registry) buildCandidateWithReason(snap routingSnapshot, pr *PendingReq
 	}
 
 	effectiveTPS := resolveEffectiveTPS(snap)
+	prefillTPS := snap.prefillTPS
+
+	// Apply multiplicative thermal derating. Thermal throttling reduces GPU
+	// throughput, so it increases both backlog and this-request latency.
+	thermalFactor := 1.0
+	switch snap.systemMetrics.ThermalState {
+	case "fair":
+		thermalFactor = 0.8
+	case "serious":
+		thermalFactor = 0.4
+	case "critical":
+		thermalFactor = 0.0
+	}
+	if thermalFactor <= 0 {
+		return nil, rejectThermal, false
+	}
+	effectiveTPS *= thermalFactor
+	prefillTPS *= thermalFactor
 
 	queueMs := float64(effectiveQueue) * queueDepthPenaltyMs
 	pendingMs := float64(snap.totalPending) * totalPendingPenaltyMs
+	if snap.hasPendingLoad {
+		// Provider is in the middle of a model load. Routing a different model
+		// here risks eviction/contention. Penalize heavily but don't reject,
+		// because the pending load may be for this same model.
+		pendingMs += pendingModelLoadPenaltyMs
+	}
 	var backlogMs float64
 	if snap.activeTokenBudgetMax > 0 {
 		tokensAhead := float64(snap.activeTokenBudgetUsed) + float64(snap.queuedTokenBudget)
@@ -871,7 +903,7 @@ func (r *Registry) buildCandidateWithReason(snap routingSnapshot, pr *PendingReq
 	} else {
 		backlogMs = backlogTokenMs(snap.maxTokensPotential, waitingBacklogTokens, unaccountedPendingTokens, effectiveTPS)
 	}
-	thisReqMs := float64(reqPrompt)/snap.prefillTPS*1000.0 + float64(reqMax)/effectiveTPS*1000.0
+	thisReqMs := float64(reqPrompt)/prefillTPS*1000.0 + float64(reqMax)/effectiveTPS*1000.0
 	healthMs := healthPenaltyMs(snap.systemMetrics, snap.gpuMemoryActiveGB, snap.totalMemoryGB)
 	cost := statePenalty + queueMs + pendingMs + backlogMs + thisReqMs + healthMs
 
@@ -926,12 +958,6 @@ func backlogTokenMs(maxTokensPotential int64, waitingTokens, unaccountedPendingT
 
 func healthPenaltyMs(m protocol.SystemMetrics, gpuActiveGB, totalMemGB float64) float64 {
 	penalty := m.MemoryPressure*memoryPressurePenaltyMs + m.CPUUsage*cpuUsagePenaltyMs
-	switch m.ThermalState {
-	case "fair":
-		penalty += thermalPenaltyFairMs
-	case "serious":
-		penalty += thermalPenaltySeriousMs
-	}
 	if totalMemGB > 0 {
 		gpuUtil := gpuActiveGB / totalMemGB
 		if gpuUtil < 0 {

--- a/coordinator/registry/scheduler.go
+++ b/coordinator/registry/scheduler.go
@@ -26,14 +26,14 @@ const (
 	// slow-provider decode, so the cost function actually spreads load
 	// across the fleet. Wider tie window admits more candidates to the
 	// queue-depth tie-break + random distribution.
-	queueDepthPenaltyMs      = 3_000.0
-	totalPendingPenaltyMs    = 750.0
-	memoryPressurePenaltyMs  = 4_000.0
-	cpuUsagePenaltyMs        = 1_500.0
-	gpuUtilizationPenaltyMs  = 5_000.0
+	queueDepthPenaltyMs       = 3_000.0
+	totalPendingPenaltyMs     = 750.0
+	memoryPressurePenaltyMs   = 4_000.0
+	cpuUsagePenaltyMs         = 1_500.0
+	gpuUtilizationPenaltyMs   = 5_000.0
 	pendingModelLoadPenaltyMs = 20_000.0
-	nearTieCostWindowMs      = 3_000.0
-	challengeFreshnessMaxAge = 6 * time.Minute
+	nearTieCostWindowMs       = 3_000.0
+	challengeFreshnessMaxAge  = 6 * time.Minute
 
 	// kvCacheBytesPerToken is a per-token KV-cache size estimate used by
 	// the free-memory admission gate.
@@ -227,10 +227,15 @@ func (r *Registry) ReserveProviderEx(model string, pr *PendingRequest, excludeID
 		pr.RequestedMaxTokens = defaultRequestedMaxTokens
 	}
 
+	// Capture the metrics emitter once for this routing decision. metrics() is
+	// lock-free, but caching the reference avoids repeated atomic.Value loads
+	// while iterating candidates under r.mu.
+	metrics := r.metrics()
+
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	selected, candidateCount, capacityRejections, tooLargeRejections, visionRejections := r.selectBestCandidateLockedFull(model, pr, excludeIDs...)
+	selected, candidateCount, capacityRejections, tooLargeRejections, visionRejections := r.selectBestCandidateLockedFull(model, pr, metrics, excludeIDs...)
 	if selected == nil {
 		return nil, RoutingDecision{
 			Model:                   model,
@@ -275,6 +280,12 @@ func (r *Registry) ReserveProviderEx(model string, pr *PendingRequest, excludeID
 		p.Status = StatusServing
 	}
 
+	// A request routed to a non-warm provider will pay a cold-start load
+	// penalty. Count these so warming effectiveness can be tracked.
+	if selected.snapshot.slotState != "running" && selected.snapshot.slotState != "idle" {
+		metrics.Incr("warming.missed_warm_starts", []string{"model:" + model})
+	}
+
 	bd := selected.breakdown
 	decision := RoutingDecision{
 		ProviderID:              p.ID,
@@ -305,7 +316,7 @@ func (r *Registry) ReserveProviderEx(model string, pr *PendingRequest, excludeID
 // no_provider and over_capacity outcome counters.
 // Returns (winner, candidateCount, capacityRejections, modelTooLargeRejections,
 // visionRejections).
-func (r *Registry) selectBestCandidateLockedFull(model string, pr *PendingRequest, excludeIDs ...string) (*routingCandidate, int, int, int, int) {
+func (r *Registry) selectBestCandidateLockedFull(model string, pr *PendingRequest, metrics MetricsEmitter, excludeIDs ...string) (*routingCandidate, int, int, int, int) {
 	excludeSet := make(map[string]struct{}, len(excludeIDs))
 	for _, id := range excludeIDs {
 		excludeSet[id] = struct{}{}
@@ -369,7 +380,7 @@ func (r *Registry) selectBestCandidateLockedFull(model string, pr *PendingReques
 				continue
 			}
 		}
-		candidate, reason, ok := r.buildCandidateWithReason(snap, pr)
+		candidate, reason, ok := r.buildCandidateWithReason(snap, pr, metrics)
 		if !ok {
 			switch reason {
 			case rejectCapacity, rejectThermal:
@@ -807,7 +818,7 @@ func committedTokenBudget(snap routingSnapshot) int64 {
 
 // buildCandidateWithReason returns the candidate plus, on rejection,
 // the reason so callers can split metrics by failure mode.
-func (r *Registry) buildCandidateWithReason(snap routingSnapshot, pr *PendingRequest) (*routingCandidate, candidateRejection, bool) {
+func (r *Registry) buildCandidateWithReason(snap routingSnapshot, pr *PendingRequest, metrics MetricsEmitter) (*routingCandidate, candidateRejection, bool) {
 	statePenalty, eligible := slotStatePenalty(snap.slotState)
 	if !eligible {
 		return nil, rejectNone, false
@@ -817,6 +828,7 @@ func (r *Registry) buildCandidateWithReason(snap routingSnapshot, pr *PendingReq
 	}
 
 	if snap.thermalRejected {
+		metrics.Incr("routing.thermal_rejections", []string{"model:" + snap.model})
 		return nil, rejectThermal, false
 	}
 
@@ -883,6 +895,7 @@ func (r *Registry) buildCandidateWithReason(snap routingSnapshot, pr *PendingReq
 		thermalFactor = 0.0
 	}
 	if thermalFactor <= 0 {
+		metrics.Incr("routing.thermal_rejections", []string{"model:" + snap.model})
 		return nil, rejectThermal, false
 	}
 	effectiveTPS *= thermalFactor

--- a/coordinator/registry/scheduler_test.go
+++ b/coordinator/registry/scheduler_test.go
@@ -1443,3 +1443,109 @@ func TestCapabilityChecksHonorAllowedSerials(t *testing.T) {
 		t.Fatal("constrained to its own serial, the capable provider must satisfy the vision check")
 	}
 }
+
+// TestModelFitsHardware documents the coordinator-side hardware-fit gate. The
+// catalog's authoritative min_ram_gb wins; only when it is unknown does the
+// gate fall back to a 2x multiplier of the on-disk weight size.
+func TestModelFitsHardware(t *testing.T) {
+	// min_ram_gb takes precedence over the 2x size heuristic.
+	if !modelFitsHardware(64, 100, 64) {
+		t.Error("min_ram_gb=64 should fit 64 GB total memory")
+	}
+	if modelFitsHardware(65, 10, 64) {
+		t.Error("min_ram_gb=65 should not fit 64 GB total memory")
+	}
+
+	// Without min_ram_gb, the 2x size fallback applies.
+	if !modelFitsHardware(0, 30, 60) {
+		t.Error("30 GB weights * 2.0 should fit 60 GB total memory")
+	}
+	if modelFitsHardware(0, 30.1, 60) {
+		t.Error("30.1 GB weights * 2.0 should not fit 60 GB total memory")
+	}
+
+	// Unknown memory always passes (fail-open).
+	if !modelFitsHardware(0, 100, 0) {
+		t.Error("unknown total memory should fail open")
+	}
+}
+
+// TestReserveProviderEx_EmitsThermalRejectionMetric verifies that providers
+// rejected because of critical thermal state increment the thermal rejection
+// counter.
+func TestReserveProviderEx_EmitsThermalRejectionMetric(t *testing.T) {
+	reg := New(testLogger())
+	metrics := &testMetricsEmitter{}
+	reg.SetMetricsEmitter(metrics)
+
+	model := "thermal-rejection-model"
+	p := makeSchedulerProvider(t, reg, "hot", model, 100)
+	p.mu.Lock()
+	p.SystemMetrics.ThermalState = "critical"
+	p.thermalHistory = []string{"serious", "critical", "critical"}
+	p.mu.Unlock()
+
+	req := &PendingRequest{
+		RequestID:          "req-thermal",
+		Model:              model,
+		RequestedMaxTokens: 128,
+	}
+	selected, _ := reg.ReserveProviderEx(model, req)
+	if selected != nil {
+		t.Fatal("expected no provider selected for critical thermal")
+	}
+	if got := metrics.count("routing.thermal_rejections", []string{"model:" + model}); got != 1 {
+		t.Fatalf("routing.thermal_rejections count = %d, want 1", got)
+	}
+}
+
+// TestReserveProviderEx_EmitsMissedWarmStartMetric verifies that routing to a
+// cold provider (slot state not running/idle) increments missed_warm_starts.
+func TestReserveProviderEx_EmitsMissedWarmStartMetric(t *testing.T) {
+	reg := New(testLogger())
+	metrics := &testMetricsEmitter{}
+	reg.SetMetricsEmitter(metrics)
+
+	model := "cold-start-model"
+	p := makeSchedulerProvider(t, reg, "cold", model, 100)
+	p.mu.Lock()
+	p.BackendCapacity.Slots[0].State = "unknown"
+	p.mu.Unlock()
+
+	req := &PendingRequest{
+		RequestID:          "req-cold",
+		Model:              model,
+		RequestedMaxTokens: 128,
+	}
+	selected, _ := reg.ReserveProviderEx(model, req)
+	if selected == nil {
+		t.Fatal("expected cold provider to be selected")
+	}
+	if got := metrics.count("warming.missed_warm_starts", []string{"model:" + model}); got != 1 {
+		t.Fatalf("warming.missed_warm_starts count = %d, want 1", got)
+	}
+}
+
+// TestReserveProviderEx_WarmProviderDoesNotEmitMissedWarmStart verifies that
+// routing to a warm provider does not increment missed_warm_starts.
+func TestReserveProviderEx_WarmProviderDoesNotEmitMissedWarmStart(t *testing.T) {
+	reg := New(testLogger())
+	metrics := &testMetricsEmitter{}
+	reg.SetMetricsEmitter(metrics)
+
+	model := "warm-start-model"
+	makeSchedulerProvider(t, reg, "warm", model, 100)
+
+	req := &PendingRequest{
+		RequestID:          "req-warm",
+		Model:              model,
+		RequestedMaxTokens: 128,
+	}
+	selected, _ := reg.ReserveProviderEx(model, req)
+	if selected == nil {
+		t.Fatal("expected warm provider to be selected")
+	}
+	if got := metrics.count("warming.missed_warm_starts", []string{"model:" + model}); got != 0 {
+		t.Fatalf("warming.missed_warm_starts count = %d, want 0", got)
+	}
+}

--- a/coordinator/registry/warming_planner.go
+++ b/coordinator/registry/warming_planner.go
@@ -1,0 +1,404 @@
+package registry
+
+import (
+	"context"
+	"math"
+	"sort"
+	"sync"
+	"time"
+)
+
+// WarmingPlanner turns demand forecasts into concrete load_model actions.
+// It runs on its own ticker so warming decisions are independent of provider
+// heartbeat timing.
+type WarmingPlanner struct {
+	cfg        WarmingConfig
+	forecaster *DemandForecaster
+	registry   *Registry
+	logger     Logger
+
+	mu sync.Mutex
+	// lastWarmAt tracks when a provider-model pair was last observed warm or
+	// successfully loaded. Used for sticky assignments and minimum warm time.
+	lastWarmAt map[string]time.Time // key: "providerID:modelID"
+	stop       chan struct{}
+	wg         sync.WaitGroup
+}
+
+// Logger is the minimal logging interface used by the planner.
+type Logger interface {
+	Debug(msg string, args ...any)
+	Info(msg string, args ...any)
+	Warn(msg string, args ...any)
+	Error(msg string, args ...any)
+}
+
+// NewWarmingPlanner creates a planner. Call Start to begin the ticker.
+func NewWarmingPlanner(cfg WarmingConfig, forecaster *DemandForecaster, registry *Registry, logger Logger) *WarmingPlanner {
+	if logger == nil {
+		logger = noopLogger{}
+	}
+	return &WarmingPlanner{
+		cfg:        cfg,
+		forecaster: forecaster,
+		registry:   registry,
+		logger:     logger,
+		lastWarmAt: make(map[string]time.Time),
+		stop:       make(chan struct{}),
+	}
+}
+
+// Start begins the planner ticker. Safe to call multiple times; subsequent calls
+// are no-ops.
+func (p *WarmingPlanner) Start() {
+	if !p.cfg.Enabled {
+		return
+	}
+	p.mu.Lock()
+	if p.stop == nil {
+		p.stop = make(chan struct{})
+	}
+	p.mu.Unlock()
+
+	p.wg.Add(1)
+	go func() {
+		defer p.wg.Done()
+		ticker := time.NewTicker(p.cfg.PlannerInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				p.tick()
+			case <-p.stop:
+				return
+			}
+		}
+	}()
+}
+
+// Stop shuts down the planner ticker.
+func (p *WarmingPlanner) Stop() {
+	p.mu.Lock()
+	if p.stop != nil {
+		close(p.stop)
+		p.stop = nil
+	}
+	p.mu.Unlock()
+	p.wg.Wait()
+}
+
+// RecordWarm records that a provider-model pair is currently warm.
+func (p *WarmingPlanner) RecordWarm(providerID, modelID string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.lastWarmAt[providerID+":"+modelID] = time.Now()
+}
+
+func (p *WarmingPlanner) tick() {
+	now := time.Now()
+	ctx := context.Background()
+	metrics := p.registry.metrics()
+
+	p.registry.mu.RLock()
+	queuedModels := p.registry.queue.QueuedModels()
+	p.registry.mu.RUnlock()
+
+	// Include models with any demand signal, not just queued ones.
+	models := p.forecaster.ModelsWithDemand()
+	for _, m := range queuedModels {
+		found := false
+		for _, existing := range models {
+			if existing == m {
+				found = true
+				break
+			}
+		}
+		if !found {
+			models = append(models, m)
+		}
+	}
+
+	if len(models) == 0 {
+		return
+	}
+
+	// Emit per-model forecast and warm-count metrics before planning.
+	for _, model := range models {
+		forecast := p.forecaster.Forecast(ctx, model)
+		metrics.Gauge("warming.forecasted_rps", forecast.RequestsPerSecond, []string{"model:" + model})
+		metrics.Gauge("warming.forecast_confidence", forecast.Confidence, []string{"model:" + model})
+		warmCount := p.countWarmProvidersLocked(model, now)
+		metrics.Gauge("warming.actual_warm_count", float64(warmCount), []string{"model:" + model})
+		p.registry.mu.RLock()
+		queueSize := p.registry.queue.QueueSize(model)
+		p.registry.mu.RUnlock()
+		metrics.Gauge("request_queue.adaptive_max_size", float64(p.registry.queue.MaxSizeFor(model)), []string{"model:" + model})
+		metrics.Gauge("request_queue.depth", float64(queueSize), []string{"model:" + model})
+	}
+
+	actions := p.planLoads(ctx, models, now)
+	if len(actions) == 0 {
+		return
+	}
+
+	p.registry.mu.Lock()
+	for _, action := range actions {
+		key := action.providerID + ":" + action.modelID
+		if _, ok := p.registry.pendingModelLoads[key]; ok {
+			continue
+		}
+		p.registry.pendingModelLoads[key] = now.Add(pendingModelLoadTTL)
+		p.registry.SendLoadModel(action.providerID, action.modelID)
+		metrics.Incr("warming.load_commands_sent", []string{"model:" + action.modelID})
+	}
+	p.registry.mu.Unlock()
+}
+
+// planLoads computes the load_model actions for the given models.
+func (p *WarmingPlanner) planLoads(ctx context.Context, models []string, now time.Time) []modelLoadAction {
+	var actions []modelLoadAction
+	selectedProviders := make(map[string]struct{})
+
+	for _, model := range models {
+		forecast := p.forecaster.Forecast(ctx, model)
+		if forecast.RequestsPerSecond <= 0 && forecast.QueuedRPS <= 0 {
+			continue
+		}
+
+		p.registry.mu.RLock()
+		currentWarm := p.countWarmProvidersLocked(model, now)
+		p.registry.mu.RUnlock()
+
+		target := p.targetWarmCount(forecast)
+		if currentWarm >= target {
+			continue
+		}
+
+		needed := target - currentWarm
+		if needed > p.cfg.MaxLoadsPerModelPerTick {
+			needed = p.cfg.MaxLoadsPerModelPerTick
+		}
+
+		for i := 0; i < needed; i++ {
+			providerID := p.pickProviderForWarmLocked(model, selectedProviders, now)
+			if providerID == "" {
+				break
+			}
+			selectedProviders[providerID] = struct{}{}
+			actions = append(actions, modelLoadAction{providerID: providerID, modelID: model})
+		}
+	}
+
+	return actions
+}
+
+// targetWarmCount converts a demand forecast into a desired number of warm
+// providers for the model.
+func (p *WarmingPlanner) targetWarmCount(f DemandForecast) int {
+	// Use recent rate + queued demand as the load driver. Historical baseline
+	// alone should not create many warm providers.
+	demandRPS := f.RecentRPS + f.QueuedRPS
+	if demandRPS <= 0 {
+		return 0
+	}
+
+	// Each provider is expected to handle utilization * its max concurrency.
+	// For simplicity, assume a nominal concurrency of 6 when token budgets are
+	// not available. Token-budget providers will be handled more precisely in
+	// future iterations.
+	nominalConcurrency := 6.0
+	capacityPerProvider := nominalConcurrency * p.cfg.TargetUtilization
+	target := int(math.Ceil(demandRPS / capacityPerProvider))
+
+	// Keep at least one provider warm if there is any queued demand.
+	if f.QueuedRPS > 0 && target < 1 {
+		target = 1
+	}
+
+	// Cap to avoid warming the entire fleet for a spike.
+	maxWarm := 8
+	if target > maxWarm {
+		target = maxWarm
+	}
+
+	return target
+}
+
+// countWarmProvidersLocked returns how many providers currently have the model
+// warm and routing-eligible. Caller must hold r.mu (read or write).
+func (p *WarmingPlanner) countWarmProvidersLocked(model string, now time.Time) int {
+	count := 0
+	for _, provider := range p.registry.providers {
+		provider.mu.Lock()
+		warm := p.registry.providerHasWarmModelLocked(provider, model, now)
+		provider.mu.Unlock()
+		if warm {
+			count++
+		}
+	}
+	return count
+}
+
+// pickProviderForWarmLocked selects the best provider to warm for the model.
+// Caller must NOT hold r.mu; this method acquires its own locks.
+func (p *WarmingPlanner) pickProviderForWarmLocked(model string, selectedProviders map[string]struct{}, now time.Time) string {
+	p.registry.mu.RLock()
+	defer p.registry.mu.RUnlock()
+
+	type candidate struct {
+		id    string
+		score float64
+	}
+	var candidates []candidate
+
+	for id, provider := range p.registry.providers {
+		if _, selected := selectedProviders[id]; selected {
+			continue
+		}
+		score, ok := p.scoreWarmCandidateLocked(provider, model, now)
+		if !ok {
+			continue
+		}
+		candidates = append(candidates, candidate{id: id, score: score})
+	}
+
+	if len(candidates) == 0 {
+		return ""
+	}
+
+	// Lower score is better.
+	sort.Slice(candidates, func(i, j int) bool {
+		return candidates[i].score < candidates[j].score
+	})
+	return candidates[0].id
+}
+
+// scoreWarmCandidateLocked scores a provider for warming. Returns ok=false if
+// the provider must not be selected. Caller must hold r.mu.
+func (p *WarmingPlanner) scoreWarmCandidateLocked(provider *Provider, model string, now time.Time) (float64, bool) {
+	provider.mu.Lock()
+	defer provider.mu.Unlock()
+
+	// Routing safety gates.
+	if provider.Status == StatusOffline || provider.Status == StatusUntrusted {
+		return 0, false
+	}
+	if provider.PrivateOnly {
+		return 0, false
+	}
+	if trustRank(provider.TrustLevel) < trustRank(p.registry.MinTrustLevel) {
+		return 0, false
+	}
+	if !provider.RuntimeVerified {
+		return 0, false
+	}
+	if !p.registry.providerSupportsPrivateTextLocked(provider) {
+		return 0, false
+	}
+	if provider.LastChallengeVerified.IsZero() || now.Sub(provider.LastChallengeVerified) > challengeFreshnessMaxAge {
+		return 0, false
+	}
+	if !p.registry.providerServesCatalogModelLocked(provider, model) {
+		return 0, false
+	}
+
+	// Already warm for this model?
+	if p.registry.providerHasWarmModelLocked(provider, model, now) {
+		return 0, false
+	}
+
+	// Already loading any model? Avoid swap oscillation.
+	if p.registry.providerHasPendingLoad(provider.ID) {
+		return 0, false
+	}
+
+	// Dispatch-load cooldown for this model.
+	if p.registry.dispatchLoadCooldownActiveLocked(provider.ID, model, now) {
+		return 0, false
+	}
+
+	// Thermal hysteresis: exclude providers that are thermally rejected.
+	if provider.thermallyRejectedLocked() {
+		return 0, false
+	}
+	thermal := provider.SystemMetrics.ThermalState
+
+	// Memory gate: static catalog fit first.
+	if entry, ok := p.registry.modelCatalog[model]; ok && (entry.MinRAMGB > 0 || entry.SizeGB > 0) {
+		if !modelFitsHardware(entry.MinRAMGB, entry.SizeGB, float64(provider.Hardware.MemoryGB)) {
+			return 0, false
+		}
+	}
+
+	var score float64
+
+	// Prefer providers with low current load so the new model can actually serve.
+	loadRatio := float64(provider.pendingCount()) / float64(max(1, provider.maxConcurrency()))
+	score += loadRatio * 10_000.0
+
+	// Prefer providers with more free memory.
+	var totalMem, activeMem float64
+	if provider.BackendCapacity != nil {
+		totalMem = provider.BackendCapacity.TotalMemoryGB
+		activeMem = provider.BackendCapacity.GPUMemoryActiveGB
+	}
+	if totalMem <= 0 {
+		totalMem = float64(provider.Hardware.MemoryGB)
+	}
+	freeMem := totalMem - activeMem
+	if freeMem < 0 {
+		freeMem = 0
+	}
+	if entry, ok := p.registry.modelCatalog[model]; ok && entry.SizeGB > 0 {
+		// Penalize if model size exceeds free memory; still allow if total fits
+		// (provider will evict).
+		if freeMem < entry.SizeGB {
+			score += (entry.SizeGB - freeMem) * 1_000.0
+		}
+	}
+
+	// Penalize thermal stress.
+	if thermal == "serious" {
+		score += 5_000.0
+	} else if thermal == "fair" {
+		score += 1_000.0
+	}
+
+	// Sticky bonus: provider recently had this model warm.
+	p.mu.Lock()
+	lastWarm := p.lastWarmAt[provider.ID+":"+model]
+	p.mu.Unlock()
+	if now.Sub(lastWarm) < 30*time.Minute {
+		score -= 2_000.0
+	}
+
+	// Prefer faster chips.
+	chipScore := chipFamilyRank(provider.Hardware.ChipFamily)
+	score -= float64(chipScore) * 200.0
+
+	return score, true
+}
+
+// chipFamilyRank returns a higher number for newer/faster chips. This is a
+// coarse ordering; the scheduler uses observed TPS when available.
+func chipFamilyRank(family string) int {
+	switch family {
+	case "M3 Max", "M3 Pro", "M3":
+		return 6
+	case "M2 Ultra", "M2 Max", "M2 Pro", "M2":
+		return 5
+	case "M1 Ultra", "M1 Max", "M1 Pro":
+		return 4
+	case "M1":
+		return 3
+	default:
+		return 2
+	}
+}
+
+type noopLogger struct{}
+
+func (noopLogger) Debug(string, ...any) {}
+func (noopLogger) Info(string, ...any)  {}
+func (noopLogger) Warn(string, ...any)  {}
+func (noopLogger) Error(string, ...any) {}

--- a/coordinator/registry/warming_planner.go
+++ b/coordinator/registry/warming_planner.go
@@ -122,7 +122,7 @@ func (p *WarmingPlanner) tick() {
 		return
 	}
 
-	// Emit per-model forecast and warm-count metrics before planning.
+	// Emit per-model forecast, warm-count, and warmup ETA metrics before planning.
 	for _, model := range models {
 		forecast := p.forecaster.Forecast(ctx, model)
 		metrics.Gauge("warming.forecasted_rps", forecast.RequestsPerSecond, []string{"model:" + model})
@@ -134,6 +134,7 @@ func (p *WarmingPlanner) tick() {
 		p.registry.mu.RUnlock()
 		metrics.Gauge("request_queue.adaptive_max_size", float64(p.registry.queue.MaxSizeFor(model)), []string{"model:" + model})
 		metrics.Gauge("request_queue.depth", float64(queueSize), []string{"model:" + model})
+		metrics.Gauge("warming.warmup_eta_seconds", float64(p.registry.EstimatedWaitSeconds(model)), []string{"model:" + model})
 	}
 
 	actions := p.planLoads(ctx, models, now)
@@ -141,6 +142,7 @@ func (p *WarmingPlanner) tick() {
 		return
 	}
 
+	var toSend []modelLoadAction
 	p.registry.mu.Lock()
 	for _, action := range actions {
 		key := action.providerID + ":" + action.modelID
@@ -148,10 +150,17 @@ func (p *WarmingPlanner) tick() {
 			continue
 		}
 		p.registry.pendingModelLoads[key] = now.Add(pendingModelLoadTTL)
-		p.registry.SendLoadModel(action.providerID, action.modelID)
-		metrics.Incr("warming.load_commands_sent", []string{"model:" + action.modelID})
+		toSend = append(toSend, action)
 	}
 	p.registry.mu.Unlock()
+
+	for _, action := range toSend {
+		if err := p.registry.SendLoadModel(action.providerID, action.modelID); err != nil {
+			p.registry.ClearPendingModelLoad(action.providerID, action.modelID)
+			continue
+		}
+		metrics.Incr("warming.load_commands_sent", []string{"model:" + action.modelID})
+	}
 }
 
 // planLoads computes the load_model actions for the given models.

--- a/coordinator/registry/warming_planner_test.go
+++ b/coordinator/registry/warming_planner_test.go
@@ -1,0 +1,255 @@
+package registry
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+)
+
+// newTestWarmingPlanner builds a registry + planner pair for unit tests.
+// The planner is not started; callers invoke planLoads or targetWarmCount directly.
+func newTestWarmingPlanner(t *testing.T, cfg WarmingConfig) (*Registry, *WarmingPlanner, *DemandForecaster) {
+	t.Helper()
+	r := New(testLogger())
+	// Lower the trust floor so test providers do not need live attestation state.
+	r.MinTrustLevel = TrustNone
+	f := NewDemandForecaster(nil, cfg)
+	p := NewWarmingPlanner(cfg, f, r, testLogger())
+	return r, p, f
+}
+
+// newTestProvider returns a minimally routable provider advertising model.
+func newTestProvider(id, model string, memGB int) *Provider {
+	return &Provider{
+		ID:      id,
+		Backend: BackendMLXSwift,
+		Hardware: protocol.Hardware{
+			ChipFamily: "M3",
+			MemoryGB:   memGB,
+		},
+		Models: []protocol.ModelInfo{
+			{ID: model},
+		},
+		TrustLevel:              TrustHardware,
+		Status:                  StatusOnline,
+		PublicKey:               "fX6XYH7p2hmM3ogeXaAsY+p8M6UKD1df/LJUN9Nj9Nw=",
+		EncryptedResponseChunks: true,
+		RuntimeVerified:         true,
+		RuntimeManifestChecked:  true,
+		ChallengeVerifiedSIP:    true,
+		LastChallengeVerified:   time.Now(),
+		PrivacyCapabilities: &protocol.PrivacyCapabilities{
+			TextBackendInprocess: true,
+			TextProxyDisabled:    true,
+			AntiDebugEnabled:     true,
+			CoreDumpsDisabled:    true,
+			EnvScrubbed:          true,
+		},
+		pendingReqs: make(map[string]*PendingRequest),
+	}
+}
+
+func TestTargetWarmCount(t *testing.T) {
+	_, p, _ := newTestWarmingPlanner(t, DefaultWarmingConfig())
+
+	cases := []struct {
+		name      string
+		recentRPS float64
+		queuedRPS float64
+		want      int
+	}{
+		{"no demand", 0, 0, 0},
+		{"recent demand only", 5, 0, 2}, // ceil(5 / (6*0.7))
+		{"queued demand only", 0, 3, 1}, // ceil(3 / 4.2) = 1
+		{"combined demand", 2, 3, 2},    // ceil(5 / 4.2) = 2
+		{"single request worth", 1, 0, 1},
+		{"large spike capped at 8", 100, 0, 8},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := p.targetWarmCount(DemandForecast{
+				RecentRPS: tc.recentRPS,
+				QueuedRPS: tc.queuedRPS,
+			})
+			if got != tc.want {
+				t.Fatalf("targetWarmCount(...) = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPlanLoadsSelectsIdleProvider(t *testing.T) {
+	model := "model-a"
+	cfg := DefaultWarmingConfig()
+	r, planner, f := newTestWarmingPlanner(t, cfg)
+
+	busy := newTestProvider("busy", model, 64)
+	idle := newTestProvider("idle", model, 64)
+
+	// busy has one in-flight request; idle has none.
+	busy.AddPending(&PendingRequest{RequestID: "r1", Model: model})
+
+	r.mu.Lock()
+	r.providers["busy"] = busy
+	r.providers["idle"] = idle
+	r.mu.Unlock()
+
+	f.RecordQueue(model, 3) // queuedRPS = 1.0, target = 1
+
+	actions := planner.planLoads(context.Background(), []string{model}, time.Now())
+	if len(actions) != 1 {
+		t.Fatalf("expected 1 action, got %d", len(actions))
+	}
+	if actions[0].providerID != "idle" {
+		t.Fatalf("expected idle provider, got %s", actions[0].providerID)
+	}
+}
+
+func TestPlanLoadsExcludesAlreadyWarmProvider(t *testing.T) {
+	model := "model-a"
+	cfg := DefaultWarmingConfig()
+	r, planner, f := newTestWarmingPlanner(t, cfg)
+
+	warm := newTestProvider("warm", model, 64)
+	warm.WarmModels = []string{model}
+
+	cold := newTestProvider("cold", model, 64)
+
+	r.mu.Lock()
+	r.providers["warm"] = warm
+	r.providers["cold"] = cold
+	r.mu.Unlock()
+
+	// Demand is low enough that the already-warm provider satisfies the target.
+	f.RecordQueue(model, 3)
+
+	actions := planner.planLoads(context.Background(), []string{model}, time.Now())
+	if len(actions) != 0 {
+		t.Fatalf("expected no actions when target already warm, got %d", len(actions))
+	}
+
+	// Demand is high enough to require a second warm provider.
+	f.RecordQueue(model, 13) // queuedRPS = 4.33, target = 2
+	actions = planner.planLoads(context.Background(), []string{model}, time.Now())
+	if len(actions) != 1 || actions[0].providerID != "cold" {
+		t.Fatalf("expected cold provider action, got %v", actions)
+	}
+}
+
+func TestPlanLoadsRespectsMaxLoadsPerModelPerTick(t *testing.T) {
+	model := "model-a"
+	cfg := DefaultWarmingConfig()
+	cfg.MaxLoadsPerModelPerTick = 2
+	r, planner, f := newTestWarmingPlanner(t, cfg)
+
+	for i := 0; i < 5; i++ {
+		p := newTestProvider("p-"+string(rune('a'+i)), model, 64)
+		r.mu.Lock()
+		r.providers[p.ID] = p
+		r.mu.Unlock()
+	}
+
+	// Large queue makes target well above the per-tick cap.
+	f.RecordQueue(model, 30) // queuedRPS = 10.0, target = 8 (capped)
+
+	actions := planner.planLoads(context.Background(), []string{model}, time.Now())
+	if len(actions) != cfg.MaxLoadsPerModelPerTick {
+		t.Fatalf("expected %d actions, got %d", cfg.MaxLoadsPerModelPerTick, len(actions))
+	}
+}
+
+func TestPlanLoadsAntiThrashingPendingLoad(t *testing.T) {
+	model := "model-a"
+	cfg := DefaultWarmingConfig()
+	r, planner, f := newTestWarmingPlanner(t, cfg)
+
+	busy := newTestProvider("busy", model, 64)
+	idle := newTestProvider("idle", model, 64)
+
+	r.mu.Lock()
+	r.providers["busy"] = busy
+	r.providers["idle"] = idle
+	// busy already has a pending model load for a different model.
+	r.pendingModelLoads["busy:other-model"] = time.Now().Add(pendingModelLoadTTL)
+	r.mu.Unlock()
+
+	f.RecordQueue(model, 9) // queuedRPS = 3.0, target = 2
+
+	actions := planner.planLoads(context.Background(), []string{model}, time.Now())
+	if len(actions) != 1 || actions[0].providerID != "idle" {
+		t.Fatalf("expected only idle provider, got %v", actions)
+	}
+}
+
+func TestPlanLoadsAntiThrashingDispatchCooldown(t *testing.T) {
+	model := "model-a"
+	cfg := DefaultWarmingConfig()
+	r, planner, f := newTestWarmingPlanner(t, cfg)
+
+	cooled := newTestProvider("cooled", model, 64)
+	idle := newTestProvider("idle", model, 64)
+
+	r.mu.Lock()
+	r.providers["cooled"] = cooled
+	r.providers["idle"] = idle
+	r.dispatchLoadCooldowns["cooled:"+model] = time.Now().Add(dispatchLoadCooldownTTL)
+	r.mu.Unlock()
+
+	f.RecordQueue(model, 9)
+
+	actions := planner.planLoads(context.Background(), []string{model}, time.Now())
+	if len(actions) != 1 || actions[0].providerID != "idle" {
+		t.Fatalf("expected only idle provider, got %v", actions)
+	}
+}
+
+func TestPlanLoadsThermalExclusion(t *testing.T) {
+	model := "model-a"
+	cfg := DefaultWarmingConfig()
+	r, planner, f := newTestWarmingPlanner(t, cfg)
+
+	hot := newTestProvider("hot", model, 64)
+	hot.SystemMetrics.ThermalState = "critical"
+	hot.thermalHistory = []string{"critical", "critical"}
+
+	cool := newTestProvider("cool", model, 64)
+	cool.SystemMetrics.ThermalState = "nominal"
+
+	if !hot.thermallyRejectedLocked() {
+		t.Fatal("expected hot provider to be thermally rejected")
+	}
+
+	r.mu.Lock()
+	r.providers["hot"] = hot
+	r.providers["cool"] = cool
+	r.mu.Unlock()
+
+	f.RecordQueue(model, 3)
+
+	actions := planner.planLoads(context.Background(), []string{model}, time.Now())
+	if len(actions) != 1 || actions[0].providerID != "cool" {
+		t.Fatalf("expected cool provider, got %v", actions)
+	}
+}
+
+func TestPlanLoadsNoEligibleProvider(t *testing.T) {
+	model := "model-a"
+	cfg := DefaultWarmingConfig()
+	r, planner, f := newTestWarmingPlanner(t, cfg)
+
+	// Provider exists but does not advertise the requested model.
+	p := newTestProvider("p", "model-b", 64)
+	r.mu.Lock()
+	r.providers["p"] = p
+	r.mu.Unlock()
+
+	f.RecordQueue(model, 9)
+
+	actions := planner.planLoads(context.Background(), []string{model}, time.Now())
+	if len(actions) != 0 {
+		t.Fatalf("expected no actions when no eligible provider, got %d", len(actions))
+	}
+}


### PR DESCRIPTION
# Predictive Model Warming

This change makes the coordinator warm providers **before** traffic queues, instead of only reacting once requests are already waiting. It also tightens thermal-state handling and improves queue/Retry-After behavior.

## Before: purely reactive warming

```mermaid
flowchart LR
    A[Consumer request arrives] --> B{Any warm provider?}
    B -->|Yes| C[Route immediately]
    B -->|No| D[Enqueue or 429]
    D --> E[Wait for next heartbeat]
    E --> F[TriggerModelSwaps]
    F --> G[Pick first idle provider]
    G --> H[Send load_model]
    H --> I[Wait 15-60s for weights]
    I --> C
```

Problems:
- Demand must already be queued before warming starts.
- Planning is gated by provider heartbeat frequency.
- Provider selection is first-idle-provider-wins, not best-fit.
- Providers with in-flight requests are never warmed, even when they have memory headroom.
- Thermal state has no hysteresis and is additive in the cost function.

## After: predictive + reactive warming

```mermaid
flowchart LR
    subgraph Demand signals
        R[Recent request EWMA]
        Q[Queue depth]
        H[Historical baseline]
    end

    A[Consumer request arrives] --> B[RecordDemand]
    B --> C{Warm provider?}
    C -->|Yes| D[Route immediately]
    C -->|No| E[Enqueue with adaptive limit]

    R --> F[DemandForecaster]
    Q --> F
    H --> F
    F -->|forecast rps| G[WarmingPlanner 1s ticker]
    G -->|target warm count| I[Score best provider]
    I --> J[Send load_model]
    J --> K[Provider becomes warm]
    K --> D

    E --> L[EstimatedWaitSeconds]
    L --> M[Honest Retry-After header]
```

Improvements:
- Demand is forecast from recent arrival rates, queue depth, and optional historical baseline.
- `WarmingPlanner` runs every second, independent of heartbeats.
- Best-fit provider selection considers memory headroom, chip family, current load, thermal state, and sticky `lastWarmAt` history.
- Providers with light load can now be warmed concurrently with serving.
- Thermal handling uses hysteresis (two consecutive `critical` readings to reject) and multiplicative TPS derating (`fair` 0.8×, `serious` 0.4×).
- Per-model queue size scales with forecast so bursts don't immediately 429.
- `Retry-After` estimates include queue depth and in-flight model loads.

## Feature flag

Predictive warming is opt-in:

```bash
EIGENINFERENCE_PREDICTIVE_WARMING_ENABLED=true
```

Optional tuning knobs (defaults shown):

```bash
EIGENINFERENCE_WARMING_PLANNER_INTERVAL=1s
EIGENINFERENCE_WARMING_FORECAST_HORIZON=60s
EIGENINFERENCE_WARMING_TARGET_UTILIZATION=0.7
EIGENINFERENCE_WARMING_MAX_LOADS_PER_TICK=3
EIGENINFERENCE_WARMING_MIN_WARM_TIME=5m
```

## New metrics

- `warming.forecasted_rps`
- `warming.forecast_confidence`
- `warming.actual_warm_count`
- `warming.target_warm_count`
- `warming.load_commands_sent`
- `warming.load_commands_succeeded`
- `warming.load_commands_failed`
- `warming.unnecessary_loads`
- `warming.missed_warm_starts`
- `warming.warmup_eta_seconds`
- `warming.max_warmup_eta_seconds`
- `routing.thermal_rejections`
- `request_queue.adaptive_max_size`

## Testing

- Added `coordinator/registry/forecaster_test.go`
- Added `coordinator/registry/warming_planner_test.go`
- Added `coordinator/registry/config_test.go`
- Expanded `coordinator/registry/algorithm_scenarios_test.go` with predictive-warming scenarios
- Added thermal-rejection and unnecessary-load tests in existing files
- Full coordinator test suite passes

## Rollout recommendation

1. Enable in staging with a small provider cohort.
2. Watch `warming.missed_warm_starts` and `warming.unnecessary_loads`.
3. Tune forecast weights and `TargetUtilization` based on observed traffic.
4. Enable fleet-wide once missed warm starts drop and unnecessary loads stay bounded.


---

_This PR was written with Kimi K2.7 Code._