### PR TITLE
fix(coordinator): snapshot AttestationResult on store (fix -race data race)

### DIFF
--- a/coordinator/registry/attestation_result_race_test.go
+++ b/coordinator/registry/attestation_result_race_test.go
@@ -1,0 +1,76 @@
+package registry
+
+import (
+	"encoding/json"
+	"sync"
+	"testing"
+
+	"github.com/eigeninference/d-inference/coordinator/attestation"
+)
+
+// Regression for the data race between persistProviderNow's async
+// json.Marshal(p.AttestationResult) and the registration path mutating the
+// same local `result` across validation checks. SetAttestationResult must
+// snapshot the struct so the stored value never aliases caller-mutable memory.
+
+// Deterministic guard: mutating the caller's struct after storing it must not
+// change what the Provider holds. Fails (stored value reflects the mutation)
+// without the copy in SetAttestationResult.
+func TestSetAttestationResultSnapshotsCallerStruct(t *testing.T) {
+	p := &Provider{}
+	r := &attestation.VerificationResult{Valid: true, Error: "orig", SerialNumber: "ABC"}
+	p.SetAttestationResult(r)
+
+	// Mirror the registration handler mutating its single local `result` after
+	// an earlier SetAttestationResult already handed the pointer to the registry.
+	r.Valid = false
+	r.Error = "mutated"
+	r.SerialNumber = "XYZ"
+
+	got := p.GetAttestationResult()
+	if got == nil {
+		t.Fatal("expected stored result, got nil")
+	}
+	if !got.Valid || got.Error != "orig" || got.SerialNumber != "ABC" {
+		t.Fatalf("stored result was not snapshotted: Valid=%v Error=%q Serial=%q",
+			got.Valid, got.Error, got.SerialNumber)
+	}
+}
+
+func TestSetAttestationResultNilClears(t *testing.T) {
+	p := &Provider{}
+	p.SetAttestationResult(&attestation.VerificationResult{Valid: true})
+	p.SetAttestationResult(nil)
+	if p.GetAttestationResult() != nil {
+		t.Fatal("expected nil after SetAttestationResult(nil)")
+	}
+}
+
+// Run under `-race`: a marshal loop (as persistProviderNow does) concurrent with
+// a caller mutating its result and re-storing. Clean with the snapshot copy;
+// races on the shared struct's fields without it.
+func TestSetAttestationResultNoRaceWithConcurrentMarshal(t *testing.T) {
+	p := &Provider{}
+	r := &attestation.VerificationResult{Valid: true, Error: "orig"}
+	p.SetAttestationResult(r)
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() { // reader: persistProviderNow-style marshal of the stored snapshot
+		defer wg.Done()
+		for i := 0; i < 5000; i++ {
+			if got := p.GetAttestationResult(); got != nil {
+				_, _ = json.Marshal(got)
+			}
+		}
+	}()
+	go func() { // writer: registration-style mutate-then-restore of the local result
+		defer wg.Done()
+		for i := 0; i < 5000; i++ {
+			r.Valid = !r.Valid
+			r.Error = "x"
+			p.SetAttestationResult(r)
+		}
+	}()
+	wg.Wait()
+}

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -506,11 +506,23 @@ func (p *Provider) ChallengeShouldStop() bool {
 	return p.Status == StatusUntrusted && !p.untrustedRecoverable
 }
 
-// SetAttestationResult stores the parsed attestation result (thread-safe).
+// SetAttestationResult stores a snapshot of the parsed attestation result
+// (thread-safe). It copies the struct instead of retaining the caller's
+// pointer: the registration path mutates a single local `result` across several
+// validation checks (Valid/Error/...) while `persistProviderNow` asynchronously
+// `json.Marshal`s `p.AttestationResult` under `p.mu`. Aliasing the caller's
+// struct would let those unsynchronized field writes race the marshal (caught by
+// `-race` in coordinator/api). VerificationResult is all value-typed fields, so a
+// shallow copy is a complete, immutable snapshot owned by the Provider.
 func (p *Provider) SetAttestationResult(result *attestation.VerificationResult) {
 	p.mu.Lock()
-	p.AttestationResult = result
-	p.mu.Unlock()
+	defer p.mu.Unlock()
+	if result == nil {
+		p.AttestationResult = nil
+		return
+	}
+	snapshot := *result
+	p.AttestationResult = &snapshot
 }
 
 // GetAttestationResult returns the current attestation result (thread-safe).


### PR DESCRIPTION
## Summary

Fixes a data race (caught intermittently by the `-race` detector in `coordinator/api`, e.g. `TestProviderRegistrationRejectsInvalidConfiguredBinaryHash`) between `registry.persistProviderNow`'s async marshal and the provider-registration path.

## Root cause

`persistProviderNow` spawns a detached goroutine that `json.Marshal`s `p.AttestationResult` under `p.mu`. The registration path (`coordinator/api/provider.go`) builds a single local `result` (`*attestation.VerificationResult`), mutates its fields across several validation checks (`result.Valid`, `result.Error`, …), and hands the **pointer** to the registry via `SetAttestationResult(&result)`. Storing the caller's pointer made `p.AttestationResult` **alias** that still-mutable struct, so the unsynchronized field writes raced the async marshal.

It's nondeterministic because the persist goroutine outlives the test that spawned it and only collides with another test's registration under the wrong interleaving — so the test passes in isolation but trips occasionally on a full-package `-race` run.

This is **pre-existing on `master`** (both `persistProviderNow` and the pointer-storing `SetAttestationResult` are unchanged there); it is not specific to any feature branch.

## Fix

`SetAttestationResult` now stores a **shallow copy** under `p.mu`:

```go
snapshot := *result
p.AttestationResult = &snapshot
```

`attestation.VerificationResult` is all value-typed fields (bools / strings / `time.Time`), so the copy is a complete, immutable, Provider-owned snapshot — the caller can keep mutating its local `result` without ever touching what the registry marshals. `nil` is preserved.

## Test plan

`go test -race ./coordinator/registry/` and `./coordinator/api/` — pass. New regression tests in `coordinator/registry/attestation_result_race_test.go`:
- **`TestSetAttestationResultSnapshotsCallerStruct`** — deterministic: mutating the caller's struct after `SetAttestationResult` must not change the stored value.
- **`TestSetAttestationResultNoRaceWithConcurrentMarshal`** — a marshal loop concurrent with caller mutate-then-restore, clean under `-race`.
- `TestSetAttestationResultNilClears` — nil clears the stored result.

**Verified the tests fail without the fix:** reverting `SetAttestationResult` to the pointer-store makes the snapshot test fail deterministically (`stored result was not snapshotted: Valid=false Error="mutated"`) and the concurrency test report `DATA RACE`. The originally-flaky `TestProviderRegistrationRejectsInvalidConfiguredBinaryHash` ran 15× clean under `-race` with the fix.

## Context

Surfaced as a flaky CI failure on an unrelated PR (#335). Fixed here on `master` so all branches inherit it.

## Follow-up (not in this PR)

Review flagged a separate, pre-existing low-severity item, untouched by this change: `cmd/coordinator/main.go:352,360` reads `p.AttestationResult` without `p.mu` in the `SetOnMDA` callback (the sibling `SetOnLateSecurityInfo` callback locks correctly). This snapshot fix *reduces* its danger — the stored struct is now immutable — but the pointer read should go through `GetAttestationResult()`. Worth a small standalone fix.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/336"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783996851&installation_id=133247490&pr_number=336&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F336&signature=efdf6285307ed1a9b3c752d306c5b8efcdc1aa035f9d64b04608dee79aa069a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->