### PR TITLE
fix(coordinator): cap plaintext inference request body

### DIFF
--- a/console-ui/src/lib/chat-messages.test.ts
+++ b/console-ui/src/lib/chat-messages.test.ts
@@ -2,6 +2,10 @@ import { describe, it, expect } from "vitest";
 import { toApiMessages } from "./chat-messages";
 import type { Message } from "./store";
 
+const PNG_IMAGE = "data:image/png;base64,AAA";
+const JPEG_IMAGE = "data:image/jpeg;base64,BBB";
+const OLD_ANSWER = "old answer";
+
 function msg(partial: Pick<Message, "role" | "content"> & Partial<Message>): Message {
   return { id: "x", timestamp: 0, ...partial };
 }
@@ -24,14 +28,14 @@ describe("toApiMessages", () => {
 
   it("inlines attached images as text-first image_url parts", () => {
     const out = toApiMessages([
-      msg({ role: "user", content: "what is this", images: ["data:image/png;base64,AAA"] }),
+      msg({ role: "user", content: "what is this", images: [PNG_IMAGE] }),
     ]);
     expect(out).toEqual([
       {
         role: "user",
         content: [
           { type: "text", text: "what is this" },
-          { type: "image_url", image_url: { url: "data:image/png;base64,AAA" } },
+          { type: "image_url", image_url: { url: PNG_IMAGE } },
         ],
       },
     ]);
@@ -41,13 +45,49 @@ describe("toApiMessages", () => {
     const out = toApiMessages([
       msg({ role: "user", content: "earlier text" }),
       msg({ role: "assistant", content: "reply" }),
-      msg({ role: "user", content: "", images: ["data:image/jpeg;base64,BBB"] }),
+      msg({ role: "user", content: "", images: [JPEG_IMAGE] }),
     ]);
     expect(out[0]).toEqual({ role: "user", content: "earlier text" });
     expect(out[1]).toEqual({ role: "assistant", content: "reply" });
     expect(out[2]).toEqual({
       role: "user",
-      content: [{ type: "image_url", image_url: { url: "data:image/jpeg;base64,BBB" } }],
+      content: [{ type: "image_url", image_url: { url: JPEG_IMAGE } }],
     });
+  });
+
+  it("keeps only the newest image-bearing turn to stay under the coordinator body cap", () => {
+    const out = toApiMessages([
+      msg({ role: "user", content: "old image", images: [PNG_IMAGE] }),
+      msg({ role: "assistant", content: OLD_ANSWER }),
+      msg({ role: "user", content: "new image", images: [JPEG_IMAGE] }),
+    ]);
+
+    expect(out).toEqual([
+      { role: "user", content: "old image" },
+      { role: "assistant", content: OLD_ANSWER },
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "new image" },
+          { type: "image_url", image_url: { url: JPEG_IMAGE } },
+        ],
+      },
+    ]);
+  });
+
+  it("drops older image-only turns after pruning their image data", () => {
+    const out = toApiMessages([
+      msg({ role: "user", content: "", images: [PNG_IMAGE] }),
+      msg({ role: "assistant", content: OLD_ANSWER }),
+      msg({ role: "user", content: "", images: [JPEG_IMAGE] }),
+    ]);
+
+    expect(out).toEqual([
+      { role: "assistant", content: OLD_ANSWER },
+      {
+        role: "user",
+        content: [{ type: "image_url", image_url: { url: JPEG_IMAGE } }],
+      },
+    ]);
   });
 });

--- a/console-ui/src/lib/chat-messages.ts
+++ b/console-ui/src/lib/chat-messages.ts
@@ -4,9 +4,14 @@ import { buildApiContent } from "./image-upload";
 
 /**
  * Convert stored chat messages into the OpenAI/OpenRouter wire shape, inlining
- * any attached images as `image_url` content parts (text-only turns stay plain
- * strings). Shared by the send and retry paths so the transformation lives in
- * one place.
+ * attached images from the most recent image-bearing turn as `image_url`
+ * content parts (text-only turns stay plain strings). Shared by the send and
+ * retry paths so the transformation lives in one place.
+ *
+ * The coordinator caps plaintext inference bodies at 64 MiB. One UI turn may
+ * carry four 10 MB images (~53 MiB after base64), so resending multiple image
+ * turns from live chat history would breach that cap. Older images remain in
+ * the visible chat state, but only the newest image turn is sent upstream.
  *
  * NOTE: `m.images` is undefined for turns restored from persistence (images are
  * stripped from localStorage to protect the quota — see store.ts `partialize`),
@@ -16,8 +21,29 @@ import { buildApiContent } from "./image-upload";
 export function toApiMessages(
   messages: Pick<Message, "role" | "content" | "images">[]
 ): ChatMessage[] {
-  return messages.map((m) => ({
-    role: m.role,
-    content: buildApiContent(m.content, m.images),
-  }));
+  const newestImageIndex = findNewestImageMessageIndex(messages);
+
+  return messages.flatMap((m, i) => {
+    const images = i === newestImageIndex ? m.images : undefined;
+    if ((!images || images.length === 0) && m.content.length === 0) {
+      return [];
+    }
+    return [{
+      role: m.role,
+      content: buildApiContent(m.content, images),
+    }];
+  });
+}
+
+function findNewestImageMessageIndex(
+  messages: Pick<Message, "images">[]
+): number {
+  let index = messages.length;
+  for (const message of [...messages].reverse()) {
+    index -= 1;
+    if (message.images && message.images.length > 0) {
+      return index;
+    }
+  }
+  return -1;
 }

--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -279,7 +279,7 @@ func (s *Server) resolveRequestedModel(parsed map[string]any, rawBody []byte, re
 		return requested, requested, rawBody, true
 	}
 	parsed["model"] = buildID
-	rb, err := json.Marshal(parsed)
+	rb, err := marshalForwardBody(parsed)
 	if err != nil {
 		rb = rawBody
 	}
@@ -1332,7 +1332,7 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if hasProviderAllowlist && stripProviderRoutingFields(parsed) {
-		rawBody, _ = json.Marshal(parsed)
+		rawBody, _ = marshalForwardBody(parsed)
 	}
 
 	// "Use my own machine, for free" opt-in. The signal is the
@@ -1384,7 +1384,7 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 		if _, hasRP := parsed["reasoning_parser"]; !hasRP && rec.RuntimeParameters != nil {
 			if rp, ok := rec.RuntimeParameters["reasoning_parser"]; ok {
 				parsed["reasoning_parser"] = rp
-				rawBody, _ = json.Marshal(parsed)
+				rawBody, _ = marshalForwardBody(parsed)
 			}
 		}
 		// Use the registry's max_output_length as the default max_tokens
@@ -1419,20 +1419,6 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		rawBody, _ = marshalForwardBody(providerParsed)
-	}
-
-	// Re-check the cap on the FINAL body we'll seal. The read cap bounded the
-	// input, but the body above was re-marshaled after mutation (max_tokens
-	// injection, Responses→chat lowering); the coordinator seals it and sends it
-	// as ONE WebSocket frame, and a body over the cap produces a frame the
-	// provider rejects by tearing down its session (see maxInferenceBodyBytes /
-	// CoordinatorClient.maxInboundMessageBytes). Fail fast with a clean 413 here —
-	// before the balance reservation, so there's nothing to refund — rather than
-	// disconnecting a provider mid-flight.
-	if len(rawBody) > maxInferenceBodyBytes {
-		writeJSON(w, http.StatusRequestEntityTooLarge, errorResponse("invalid_request_error",
-			fmt.Sprintf("request body exceeds the %d-byte limit", maxInferenceBodyBytes)))
-		return
 	}
 
 	// Per-account token rate limiting (ITPM/OTPM) — the industry-standard
@@ -1529,9 +1515,9 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 						writeJSON(w, http.StatusBadRequest, errorResponse("invalid_request_error", err.Error()))
 						return
 					}
-					rawBody, _ = json.Marshal(providerParsed)
+					rawBody, _ = marshalForwardBody(providerParsed)
 				} else {
-					rawBody, _ = json.Marshal(parsed)
+					rawBody, _ = marshalForwardBody(parsed)
 				}
 				candidateCount, capacityRejections, modelTooLarge = s.registry.QuickCapacityCheck(model, estimatedPromptTokens, requestedMaxTokens, registry.RequestTraits{HasTools: hasTools}, allowedProviderSerials...)
 			}
@@ -1596,6 +1582,25 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 	consumerKey := consumerKeyFromContext(r.Context())
 	consumerLocation := s.requestLocation(r)
 	deadline := ttftDeadline(estimatedPromptTokens)
+
+	// Final cap on the body we'll seal. The read cap (parseInferencePrelude)
+	// bounded the request as received, but rawBody has since been re-marshaled at
+	// several points — alias resolution, allowlist/routing-field stripping,
+	// reasoning_parser + max_tokens injection, Responses→chat lowering, and the
+	// alias-capacity fallback above. The coordinator seals this body and sends it
+	// as ONE WebSocket frame; a body over the cap produces a frame the provider
+	// rejects by tearing down its session and cancelling every unrelated in-flight
+	// request (see maxInferenceBodyBytes / CoordinatorClient.maxInboundMessageBytes).
+	// This is the single point where rawBody is frozen into dispatchState, so the
+	// check here covers every upstream mutation; an oversized request gets a clean
+	// 413 instead of disconnecting a provider mid-flight. The reservation is held
+	// at this point, so refund before returning.
+	if len(rawBody) > maxInferenceBodyBytes {
+		refundReservation()
+		writeJSON(w, http.StatusRequestEntityTooLarge, errorResponse("invalid_request_error",
+			fmt.Sprintf("request body exceeds the %d-byte limit", maxInferenceBodyBytes)))
+		return
+	}
 
 	d := &dispatchState{
 		s:                      s,

--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -1403,7 +1403,7 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 	// silent post-inference charge failure would hand the consumer free
 	// inference (GitHub issue #33).
 	if ensureMaxTokensBound(parsed, isResponsesAPI, maxOutputBound) {
-		rawBody, _ = json.Marshal(parsed)
+		rawBody, _ = marshalForwardBody(parsed)
 	}
 
 	stream, _ := parsed["stream"].(bool)
@@ -1418,7 +1418,21 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 			writeJSON(w, http.StatusBadRequest, errorResponse("invalid_request_error", err.Error()))
 			return
 		}
-		rawBody, _ = json.Marshal(providerParsed)
+		rawBody, _ = marshalForwardBody(providerParsed)
+	}
+
+	// Re-check the cap on the FINAL body we'll seal. The read cap bounded the
+	// input, but the body above was re-marshaled after mutation (max_tokens
+	// injection, Responses→chat lowering); the coordinator seals it and sends it
+	// as ONE WebSocket frame, and a body over the cap produces a frame the
+	// provider rejects by tearing down its session (see maxInferenceBodyBytes /
+	// CoordinatorClient.maxInboundMessageBytes). Fail fast with a clean 413 here —
+	// before the balance reservation, so there's nothing to refund — rather than
+	// disconnecting a provider mid-flight.
+	if len(rawBody) > maxInferenceBodyBytes {
+		writeJSON(w, http.StatusRequestEntityTooLarge, errorResponse("invalid_request_error",
+			fmt.Sprintf("request body exceeds the %d-byte limit", maxInferenceBodyBytes)))
+		return
 	}
 
 	// Per-account token rate limiting (ITPM/OTPM) — the industry-standard
@@ -4198,7 +4212,21 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 		}
 	}
 
-	inferenceBody, _ := json.Marshal(parsed)
+	inferenceBody, _ := marshalForwardBody(parsed)
+
+	// Re-check the cap on the FINAL body we'll seal (the input cap bounded the
+	// read; this body was re-marshaled after mutation). A body over the cap seals
+	// into a frame the provider rejects by tearing down its session — return a
+	// clean 413 instead (see maxInferenceBodyBytes). Billing is already reserved
+	// at this point, so refund before returning.
+	if len(inferenceBody) > maxInferenceBodyBytes {
+		cleanupPending()
+		refundExtra()
+		refundReservation()
+		writeJSON(w, http.StatusRequestEntityTooLarge, errorResponse("invalid_request_error",
+			fmt.Sprintf("request body exceeds the %d-byte limit", maxInferenceBodyBytes)))
+		return
+	}
 
 	if provider.PublicKey == "" {
 		cleanupPending()

--- a/coordinator/api/inference_body_cap_test.go
+++ b/coordinator/api/inference_body_cap_test.go
@@ -2,9 +2,11 @@ package api
 
 import (
 	"bytes"
+	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -50,5 +52,49 @@ func TestParseInferencePreludeUnderCapNotSizeRejected(t *testing.T) {
 	}
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("invalid JSON: got status %d, want 400", w.Code)
+	}
+}
+
+// Regression for the re-marshal inflation that the read cap alone didn't catch:
+// the handlers re-marshal the parsed body before sealing it, and encoding/json's
+// default HTML escaping turns each '<' '>' '&' into a 6-byte \uXXXX escape. A
+// benign body that fit the read cap could thus re-marshal ~6× larger and produce
+// a WebSocket frame the provider rejects (tearing down its session). The forward
+// marshaler disables HTML escaping; this asserts the angle brackets survive raw
+// and the output tracks the input size instead of exploding.
+func TestMarshalForwardBodyDoesNotHTMLEscape(t *testing.T) {
+	const n = 1 << 20 // 1 MiB of '<'
+	body := map[string]any{
+		"model":    "m",
+		"messages": []any{map[string]any{"role": "user", "content": strings.Repeat("<", n)}},
+	}
+
+	got, err := marshalForwardBody(body)
+	if err != nil {
+		t.Fatalf("marshalForwardBody: %v", err)
+	}
+	// The 6-byte JSON escape for '<' is the ASCII run \ u 0 0 3 c.
+	escapedAngle := []byte{'\\', 'u', '0', '0', '3', 'c'}
+	if bytes.Contains(got, escapedAngle) {
+		t.Fatal(`marshalForwardBody HTML-escaped '<' to < — expected raw bytes`)
+	}
+	if !bytes.Contains(got, bytes.Repeat([]byte("<"), 8)) {
+		t.Fatal("marshalForwardBody dropped the raw '<' run")
+	}
+	if got[len(got)-1] == '\n' {
+		t.Fatal("marshalForwardBody left the encoder's trailing newline")
+	}
+
+	// The unescaped body must track the input (~1 MiB + small envelope); the
+	// default escaping marshaler inflates the same body ~6×. Prove the gap.
+	escaped, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+	if len(escaped) <= len(got) {
+		t.Fatalf("expected default Marshal (%d) larger than unescaped (%d)", len(escaped), len(got))
+	}
+	if len(got) > n+4096 {
+		t.Fatalf("unescaped body unexpectedly large: %d bytes (input ~%d)", len(got), n)
 	}
 }

--- a/coordinator/api/inference_body_cap_test.go
+++ b/coordinator/api/inference_body_cap_test.go
@@ -8,22 +8,12 @@ import (
 	"testing"
 )
 
-// Regression for OOM-M1: the plaintext inference path read the request body with
-// an unbounded io.ReadAll, so any API-key holder could POST a multi-GB body and
-// OOM the coordinator (the trusted TEE component). parseInferencePrelude now caps
-// it with http.MaxBytesReader. These exercise the prelude directly — the size
-// check returns before any auth/store access, so a zero-value Server suffices.
-
-// infiniteReader yields 'a' forever; used with io.LimitReader so the oversized
-// test streams cap+1 bytes instead of allocating the whole over-cap body.
-type infiniteReader struct{}
-
-func (infiniteReader) Read(p []byte) (int, error) {
-	for i := range p {
-		p[i] = 'a'
-	}
-	return len(p), nil
-}
+// Regression for the plaintext inference body cap: the path read the request
+// body with an unbounded io.ReadAll, so any API-key holder could POST a multi-GB
+// body and OOM the coordinator (the trusted TEE component). parseInferencePrelude
+// now caps it with http.MaxBytesReader. These exercise the prelude directly — the
+// size check returns before any auth/store access, so a zero-value Server
+// suffices. (infiniteReader is shared from body_cap_test.go in this package.)
 
 // Load-bearing regression: without the cap, io.ReadAll consumes the whole
 // oversized body and the request falls through to a 400 (invalid JSON) — this

--- a/coordinator/api/inference_body_cap_test.go
+++ b/coordinator/api/inference_body_cap_test.go
@@ -1,0 +1,64 @@
+package api
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// Regression for OOM-M1: the plaintext inference path read the request body with
+// an unbounded io.ReadAll, so any API-key holder could POST a multi-GB body and
+// OOM the coordinator (the trusted TEE component). parseInferencePrelude now caps
+// it with http.MaxBytesReader. These exercise the prelude directly — the size
+// check returns before any auth/store access, so a zero-value Server suffices.
+
+// infiniteReader yields 'a' forever; used with io.LimitReader so the oversized
+// test streams cap+1 bytes instead of allocating the whole over-cap body.
+type infiniteReader struct{}
+
+func (infiniteReader) Read(p []byte) (int, error) {
+	for i := range p {
+		p[i] = 'a'
+	}
+	return len(p), nil
+}
+
+// Load-bearing regression: without the cap, io.ReadAll consumes the whole
+// oversized body and the request falls through to a 400 (invalid JSON) — this
+// asserts 413, so it fails on the unpatched code.
+func TestParseInferencePreludeRejectsOversizedBody(t *testing.T) {
+	s := &Server{}
+	body := io.LimitReader(infiniteReader{}, int64(maxInferenceBodyBytes)+1)
+	r := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", body)
+	w := httptest.NewRecorder()
+
+	if _, ok := s.parseInferencePrelude(w, r); ok {
+		t.Fatal("expected parseInferencePrelude to reject the oversized body")
+	}
+	if w.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("oversized body: got status %d, want 413", w.Code)
+	}
+}
+
+// False-trigger guard (NOT a fail-without-fix regression — an 8-byte body never
+// hits the cap, so this passes with or without the fix): a small invalid-JSON
+// body must fail JSON parsing (400), not the size cap (413), proving the cap
+// doesn't reject normal-sized requests.
+func TestParseInferencePreludeUnderCapNotSizeRejected(t *testing.T) {
+	s := &Server{}
+	r := httptest.NewRequest(http.MethodPost, "/v1/chat/completions",
+		bytes.NewReader([]byte("not json")))
+	w := httptest.NewRecorder()
+
+	if _, ok := s.parseInferencePrelude(w, r); ok {
+		t.Fatal("expected invalid JSON to be rejected")
+	}
+	if w.Code == http.StatusRequestEntityTooLarge {
+		t.Fatal("under-cap body was wrongly rejected as too large (413)")
+	}
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("invalid JSON: got status %d, want 400", w.Code)
+	}
+}

--- a/coordinator/api/inference_body_remarshal_integration_test.go
+++ b/coordinator/api/inference_body_remarshal_integration_test.go
@@ -1,0 +1,130 @@
+package api
+
+// Regression guard for the forward-body re-marshal inflation gap.
+//
+// The chat handler re-marshals the parsed request body at several points before
+// sealing it to a provider — including the alias-capacity fallback, which
+// switches a saturated desired build to its previous build and re-serializes the
+// body. If that re-marshal uses encoding/json's default Marshal, the bytes '<'
+// '>' '&' are HTML-escaped into 6-byte \uXXXX forms (a ~6x inflation), so a
+// benign request that fit the read cap can balloon past the provider's
+// single-frame WebSocket limit and tear down its session. marshalForwardBody
+// disables that escaping at every forward-marshal site; this test drives a real
+// request through the alias-capacity fallback and asserts the body the provider
+// actually receives is unescaped — failing if any fallback marshal site
+// regresses to json.Marshal.
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/registry"
+	"github.com/eigeninference/d-inference/coordinator/store"
+)
+
+func TestAliasCapacityFallbackForwardsUnescapedBody(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	st := store.NewMemory(store.Config{AdminKey: "test-key"})
+	reg := registry.New(logger)
+	srv := NewServer(reg, st, ServerConfig{}, logger)
+	// Keep the challenge ticker quiet for the test window: the saturated desired
+	// provider is registered with a nil conn (it never receives a dispatch) and
+	// shouldn't be challenged over the wire.
+	srv.challengeInterval = 30 * time.Second
+	ts := httptest.NewServer(srv.Handler())
+	t.Cleanup(ts.Close)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	const (
+		alias        = "gemma-4-fallback"
+		desiredBuild = "build-desired-saturated"
+		prevBuild    = "build-previous-routable"
+	)
+
+	// Desired build: a registered, trusted, SATURATED provider. The alias
+	// resolves to desired (structural), but QuickCapacityCheck(desired) returns
+	// 0 candidates / >0 rejections — the exact condition that fires
+	// maybeFallbackAliasCapacity. nil conn is fine: it never receives a dispatch.
+	registerBuildsProvider(srv, "p-desired", desiredBuild)
+	pd := reg.GetProvider("p-desired")
+	pd.Mu().Lock()
+	pd.BackendCapacity.Slots[0].ActiveTokenBudgetUsed = 1_000
+	pd.BackendCapacity.Slots[0].ActiveTokenBudgetMax = 1_000
+	pd.Mu().Unlock()
+
+	// Previous build: a real failover provider that decrypts and captures the
+	// forwarded body, then serves the request so the HTTP call completes cleanly.
+	prev := startFailoverProvider(t, ctx, ts, reg, failoverProviderConfig{
+		Name: "p-prev", Version: "0.6.4", DecodeTPS: 100,
+		Models: []failoverModelSpec{{ID: prevBuild}},
+		Script: fullServeScript(prevBuild),
+	})
+
+	reg.SetModelAliases(map[string]registry.AliasTarget{
+		alias: {Desired: desiredBuild, Previous: prevBuild},
+	})
+
+	// Sanity: desired is saturated, previous is routable — so the request must
+	// take the fallback to reach a provider at all.
+	if c, rej, _ := reg.QuickCapacityCheck(desiredBuild, 10, 64, registry.RequestTraits{}); c != 0 || rej == 0 {
+		t.Fatalf("desired capacity = %d candidates / %d rejections, want 0 / >0 (saturated)", c, rej)
+	}
+	if c, _, _ := reg.QuickCapacityCheck(prevBuild, 10, 64, registry.RequestTraits{}); c == 0 {
+		t.Fatal("previous build has no routable capacity (candidates=0); fallback would have nothing to switch to")
+	}
+
+	// A '<'-heavy prompt: each '<' is a benign 1 byte unescaped but a 6-byte
+	// < under default HTML escaping. The run is sized so that EVEN THE
+	// ESCAPED body (~6x) still fits the test WebSocket's 32 KiB default read
+	// limit — so on the buggy (escaping) path the body reaches the provider WITH
+	// < in it and the content assertion below is the clean discriminator,
+	// rather than a frame-too-large disconnect. (In production the provider limit
+	// is 32 MiB; the freeze-point cap covers genuinely oversized bodies.)
+	const angleRun = 2048 // 2 KiB of '<'; ~12 KiB escaped, ~16 KiB sealed frame
+	content := strings.Repeat("<", angleRun)
+	chatBody := fmt.Sprintf(
+		`{"model":%q,"messages":[{"role":"user","content":%q}],"stream":true,"max_tokens":64}`,
+		alias, content)
+
+	status, respBody, err := postChat(ctx, ts.URL, "test-key", chatBody)
+	if err != nil {
+		t.Fatalf("chat request: %v", err)
+	}
+	if status != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (fallback should route to the previous build); body = %s", status, respBody)
+	}
+
+	// Inspect the body the provider actually received post-fallback.
+	var got []byte
+	select {
+	case got = <-prev.bodies:
+	case <-time.After(5 * time.Second):
+		t.Fatal("previous provider never received a dispatch — the fallback did not route here")
+	}
+	if got == nil {
+		t.Fatal("previous provider could not decrypt the forwarded body")
+	}
+
+	// The 6-byte JSON escape for '<' is the ASCII run \ u 0 0 3 c. Its presence
+	// means a fallback marshal site regressed to the HTML-escaping json.Marshal.
+	if bytes.Contains(got, []byte{'\\', 'u', '0', '0', '3', 'c'}) {
+		t.Fatal("forwarded body HTML-escaped '<' to \\u003c — an alias-capacity fallback re-marshal regressed to json.Marshal")
+	}
+	if !bytes.Contains(got, bytes.Repeat([]byte("<"), 64)) {
+		t.Fatalf("forwarded body is missing the raw '<' run (len=%d)", len(got))
+	}
+	// The unescaped body tracks the input; the escaped form would be ~6x larger.
+	if len(got) > angleRun+8192 {
+		t.Fatalf("forwarded body unexpectedly large: %d bytes (input ~%d) — inflation suggests escaping crept back in", len(got), angleRun)
+	}
+}

--- a/coordinator/api/inference_preprocess.go
+++ b/coordinator/api/inference_preprocess.go
@@ -12,6 +12,7 @@ package api
 // caller to return via ok=false / handled=true.
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -38,7 +39,34 @@ import (
 // (chat-messages.ts), but a single 4×10 MB turn (~53 MiB) still exceeds this and
 // is undeliverable to any provider — aligning the per-turn UI image budget with
 // the frame cap is tracked separately.
+//
+// This caps the body we READ. The body we actually SEAL can differ: the handlers
+// re-marshal the parsed request after mutating it (max_tokens injection, tool
+// normalization). The cap is therefore re-checked on that final body before
+// encryption (see handleChatCompletions / handleGenericInference) using
+// marshalForwardBody, which also disables HTML escaping so the re-marshal can't
+// silently inflate a benign body past this limit.
 const maxInferenceBodyBytes = 16 << 20 // 16 MiB
+
+// marshalForwardBody serializes a parsed request body for forwarding to a
+// provider WITHOUT HTML escaping. encoding/json's default Marshal escapes the
+// bytes '<', '>', and '&' into their 6-byte \uXXXX forms — a 6× per-character
+// inflation that is meaningless on this path (the body is sealed and parsed as
+// JSON by the provider, never embedded in HTML) yet can balloon a benign request
+// — e.g. a prompt containing a long run of '<' — past the provider's
+// single-frame WebSocket limit, tearing down its session. Disabling escaping
+// keeps the re-marshaled body within a small constant of the (already
+// size-capped) input. Mirrors NormalizeToolSchemas's own non-escaping round-trip.
+func marshalForwardBody(v any) ([]byte, error) {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(v); err != nil {
+		return nil, err
+	}
+	// Encoder.Encode appends a trailing newline the encrypted body shouldn't carry.
+	return bytes.TrimSuffix(buf.Bytes(), []byte{'\n'}), nil
+}
 
 // inferencePrelude carries the parsed request shape produced by the shared
 // prelude: the (tool-schema-normalized) raw body and its parsed map, plus the

--- a/coordinator/api/inference_preprocess.go
+++ b/coordinator/api/inference_preprocess.go
@@ -24,13 +24,21 @@ import (
 // API-key holder could POST a multi-GB body and OOM the coordinator (the trusted
 // TEE component).
 //
-// Sized to one first-party UI image-bearing turn: MAX_IMAGES_PER_MESSAGE (4) ×
-// MAX_IMAGE_BYTES (10 MB) = 40 MB raw ≈ 53 MiB after base64 inflation, plus
-// JSON/text overhead. The console preserves text history but only resends images
-// from the newest image turn, so normal UI multimodal requests stay below this
-// fixed DoS cap. (The sealed E2E path enforces its own 16 MiB cap in
-// sender_encryption.go; this is the plaintext image path.)
-const maxInferenceBodyBytes = 64 << 20 // 64 MiB
+// Sized to the PROVIDER WebSocket frame budget, not just OOM-safety: the
+// coordinator encrypts rawBody and sends the base64 NaCl-box as ONE WS frame
+// (consumer.go), and the Swift provider rejects frames over 32 MiB by tearing
+// down the whole session + cancelling every unrelated in-flight request
+// (CoordinatorClient.maxInboundMessageBytes). base64 adds ×4/3, so a 16 MiB body
+// → ~21.3 MiB frame, comfortably under 32 MiB — the budget that provider cap was
+// sized against, and identical to the sealed path (sender_encryption.go). A
+// larger cap would let a request pass here only to disconnect the provider
+// instead of returning a clean 413.
+//
+// The console already trims image history to the newest image turn
+// (chat-messages.ts), but a single 4×10 MB turn (~53 MiB) still exceeds this and
+// is undeliverable to any provider — aligning the per-turn UI image budget with
+// the frame cap is tracked separately.
+const maxInferenceBodyBytes = 16 << 20 // 16 MiB
 
 // inferencePrelude carries the parsed request shape produced by the shared
 // prelude: the (tool-schema-normalized) raw body and its parsed map, plus the

--- a/coordinator/api/inference_preprocess.go
+++ b/coordinator/api/inference_preprocess.go
@@ -13,10 +13,23 @@ package api
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 )
+
+// maxInferenceBodyBytes caps the plaintext inference request body. Without it
+// the common (non-sealed) path does io.ReadAll(r.Body) with no limit, so any
+// API-key holder could POST a multi-GB body and OOM the coordinator (the trusted
+// TEE component).
+//
+// Sized to the first-party UI's per-message image limit so legitimate multimodal
+// requests aren't rejected: MAX_IMAGES_PER_MESSAGE (4) × MAX_IMAGE_BYTES (10 MB)
+// = 40 MB raw ≈ 53 MiB after base64 inflation, plus JSON/text overhead — see
+// console-ui/src/lib/image-upload.ts. (The sealed E2E path enforces its own
+// 16 MiB cap in sender_encryption.go; this is the plaintext image path.)
+const maxInferenceBodyBytes = 64 << 20 // 64 MiB
 
 // inferencePrelude carries the parsed request shape produced by the shared
 // prelude: the (tool-schema-normalized) raw body and its parsed map, plus the
@@ -36,8 +49,17 @@ type inferencePrelude struct {
 func (s *Server) parseInferencePrelude(w http.ResponseWriter, r *http.Request) (inferencePrelude, bool) {
 	// Read the raw request body so we can forward it as-is to the provider.
 	// We only parse minimally to extract model/stream/messages for routing.
+	// Cap it first: io.ReadAll would otherwise buffer an unbounded body and a
+	// multi-GB POST would OOM the coordinator.
+	r.Body = http.MaxBytesReader(w, r.Body, maxInferenceBodyBytes)
 	rawBody, err := io.ReadAll(r.Body)
 	if err != nil {
+		var maxBytesErr *http.MaxBytesError
+		if errors.As(err, &maxBytesErr) {
+			writeJSON(w, http.StatusRequestEntityTooLarge, errorResponse("invalid_request_error",
+				fmt.Sprintf("request body exceeds the %d-byte limit", maxInferenceBodyBytes)))
+			return inferencePrelude{}, false
+		}
 		writeJSON(w, http.StatusBadRequest, errorResponse("invalid_request_error", "failed to read request body"))
 		return inferencePrelude{}, false
 	}

--- a/coordinator/api/inference_preprocess.go
+++ b/coordinator/api/inference_preprocess.go
@@ -24,11 +24,12 @@ import (
 // API-key holder could POST a multi-GB body and OOM the coordinator (the trusted
 // TEE component).
 //
-// Sized to the first-party UI's per-message image limit so legitimate multimodal
-// requests aren't rejected: MAX_IMAGES_PER_MESSAGE (4) × MAX_IMAGE_BYTES (10 MB)
-// = 40 MB raw ≈ 53 MiB after base64 inflation, plus JSON/text overhead — see
-// console-ui/src/lib/image-upload.ts. (The sealed E2E path enforces its own
-// 16 MiB cap in sender_encryption.go; this is the plaintext image path.)
+// Sized to one first-party UI image-bearing turn: MAX_IMAGES_PER_MESSAGE (4) ×
+// MAX_IMAGE_BYTES (10 MB) = 40 MB raw ≈ 53 MiB after base64 inflation, plus
+// JSON/text overhead. The console preserves text history but only resends images
+// from the newest image turn, so normal UI multimodal requests stay below this
+// fixed DoS cap. (The sealed E2E path enforces its own 16 MiB cap in
+// sender_encryption.go; this is the plaintext image path.)
 const maxInferenceBodyBytes = 64 << 20 // 64 MiB
 
 // inferencePrelude carries the parsed request shape produced by the shared

--- a/coordinator/api/server.go
+++ b/coordinator/api/server.go
@@ -1300,9 +1300,10 @@ func (s *Server) handleRuntimeManifest(w http.ResponseWriter, r *http.Request) {
 const maxMDMWebhookBodyBytes = 1 << 20 // 1 MiB
 
 // maxRequestBodyBytes is the global ceiling bodyLimitMiddleware applies to every
-// request body so no endpoint can be OOM'd by an unbounded POST. It clears the
-// largest legitimate body (the 64 MiB plaintext-inference image path); handlers
-// needing less wrap r.Body in a tighter MaxBytesReader on top.
+// request body so no endpoint can be OOM'd by an unbounded POST. It's a coarse
+// outer bound that clears every legitimate body with headroom; the hot paths
+// self-cap tighter on top (the plaintext-inference path at 16 MiB, sized to the
+// provider WS frame budget — see maxInferenceBodyBytes).
 const maxRequestBodyBytes = 64 << 20 // 64 MiB
 
 // maxControlPlaneBodyBytes is the tight cap for small unauthenticated


### PR DESCRIPTION
## Summary

Caps the plaintext inference request body. The common (non-sealed) path read the body with an unbounded `io.ReadAll(r.Body)`, so any API-key holder could POST a multi-GB JSON body and **OOM the coordinator** — the trusted TEE component.

## The asymmetry

| Path | Body read | Cap |
|---|---|---|
| **Sealed** (E2E ciphertext) | `io.ReadAll(http.MaxBytesReader(w, r.Body, 16<<20))` — `sender_encryption.go:132` | **16 MiB** ✅ |
| **Plaintext** (`/v1/chat/completions`, `/v1/completions`) | `io.ReadAll(r.Body)` — `inference_preprocess.go` (`parseInferencePrelude`) | **none** ❌ |

Both plaintext handlers funnel through `parseInferencePrelude`, and `io.ReadAll` buffers the whole body up front (then `NormalizeToolSchemas` + `parseJSONBody` make further copies). Authenticated, but an API key is cheap and the victim is the trusted coordinator — model-independent (the read is in the shared prelude, before routing).

## Fix

`parseInferencePrelude` now wraps `r.Body` in `http.MaxBytesReader` before reading and maps an over-cap read to **HTTP 413**:

```go
r.Body = http.MaxBytesReader(w, r.Body, maxInferenceBodyBytes) // 16 MiB
rawBody, err := io.ReadAll(r.Body)
if err != nil {
    var maxBytesErr *http.MaxBytesError
    if errors.As(err, &maxBytesErr) { /* 413 */ }
    /* 400 */
}
```

The cap is **64 MiB**, sized to the **first-party UI's per-message image limit** so legitimate multimodal requests aren't rejected: `MAX_IMAGES_PER_MESSAGE` (4) × `MAX_IMAGE_BYTES` (10 MB) = 40 MB raw ≈ 53 MiB after base64, plus JSON/text overhead (see `console-ui/src/lib/image-upload.ts`). A 16 MiB cap (the sealed-path value) would 413 two max-size images; this is the plaintext image path, so it's sized for that. The sealed E2E path keeps its own 16 MiB cap (`sender_encryption.go`).

## Test plan

`go test ./coordinator/api/` — pass (full package, no regression). New tests in `coordinator/api/inference_body_cap_test.go`:
- **`TestParseInferencePreludeRejectsOversizedBody`** — a body one byte over the cap → 413.
- **`TestParseInferencePreludeUnderCapNotSizeRejected`** — a small invalid-JSON body → 400 (not 413), proving the cap fires only on size and never false-triggers.

**Verified the tests fail without the fix:** removing the `MaxBytesReader` makes the oversized test get 400 instead of 413.

## Known related, NOT in this PR

Review flagged that the same OOM class is reachable via other consumer endpoints that decode `r.Body` with no cap — `POST /v1/invite/redeem` (`invite_handlers.go`, API-key authed), and the unauthenticated `enroll.go` / `device_auth.go` sinks (`json.NewDecoder` still buffers a giant body to find a parse error). This PR is scoped to the reported plaintext inference-path body OOM. The sibling endpoints want their own fix — most cleanly a small global request-body `MaxBytesReader` middleware (none exists today; caps are per-handler). Tracking separately.

## Context

Pre-existing on `master`; fixed here so all branches inherit it. Sibling of #337 (provider-side unbounded chunk accumulation) — both let a caller OOM the trusted TEE coordinator via unbounded buffering: this one on consumer *ingress*, #337 on provider *egress*.
