### PR TITLE
fix(coordinator): cap request body size globally + tighten unauth endpoints

### DIFF
--- a/coordinator/api/body_cap_test.go
+++ b/coordinator/api/body_cap_test.go
@@ -1,0 +1,104 @@
+package api
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// infiniteReader yields 'a' forever; with io.LimitReader it streams an
+// over-cap body without allocating it, so the cap surfaces as a read error.
+type infiniteReader struct{}
+
+func (infiniteReader) Read(p []byte) (int, error) {
+	for i := range p {
+		p[i] = 'a'
+	}
+	return len(p), nil
+}
+
+// The global middleware caps an oversized body on a normal route, so an
+// unbounded POST can't OOM the coordinator. io.Copy(io.Discard, …) drains
+// without buffering, so the cap shows up as a *http.MaxBytesError.
+func TestBodyLimitMiddlewareCapsOversizedBody(t *testing.T) {
+	s := &Server{}
+	var readErr error
+	h := s.bodyLimitMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, readErr = io.Copy(io.Discard, r.Body)
+	}))
+	req := httptest.NewRequest(http.MethodPost, "/v1/enroll",
+		io.LimitReader(infiniteReader{}, int64(maxRequestBodyBytes)+1))
+	h.ServeHTTP(httptest.NewRecorder(), req)
+
+	var maxErr *http.MaxBytesError
+	if !errors.As(readErr, &maxErr) {
+		t.Fatalf("expected the body to be capped (*http.MaxBytesError), got %v", readErr)
+	}
+}
+
+// The provider WebSocket upgrade is exempt — it hijacks the connection and
+// reads framed messages, not r.Body — so the global cap must not apply.
+func TestBodyLimitMiddlewareExemptsProviderWS(t *testing.T) {
+	s := &Server{}
+	var readErr error
+	h := s.bodyLimitMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, readErr = io.Copy(io.Discard, r.Body)
+	}))
+	req := httptest.NewRequest(http.MethodGet, "/ws/provider",
+		io.LimitReader(infiniteReader{}, int64(maxRequestBodyBytes)+1))
+	h.ServeHTTP(httptest.NewRecorder(), req)
+
+	if readErr != nil {
+		t.Fatalf("/ws/provider must be exempt from the body cap, got read error: %v", readErr)
+	}
+}
+
+// decodeCappedJSON: over-cap (but valid-JSON-shaped) -> 413; small invalid JSON
+// -> 400; valid -> ok with the value decoded.
+func TestDecodeCappedJSON(t *testing.T) {
+	type payload struct {
+		X string `json:"x"`
+	}
+
+	t.Run("oversized->413", func(t *testing.T) {
+		// Valid JSON shape that runs past the cap mid-string, so the decoder
+		// hits the MaxBytesReader limit rather than a JSON syntax error.
+		big := `{"x":"` + strings.Repeat("a", maxControlPlaneBodyBytes) + `"}`
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodPost, "/x", strings.NewReader(big))
+		var dst payload
+		if decodeCappedJSON(w, r, maxControlPlaneBodyBytes, &dst) {
+			t.Fatal("expected ok=false for an over-cap body")
+		}
+		if w.Code != http.StatusRequestEntityTooLarge {
+			t.Fatalf("oversized: got %d, want 413", w.Code)
+		}
+	})
+
+	t.Run("invalidJSON->400", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodPost, "/x", strings.NewReader("not json"))
+		var dst payload
+		if decodeCappedJSON(w, r, maxControlPlaneBodyBytes, &dst) {
+			t.Fatal("expected ok=false for invalid JSON")
+		}
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("invalid JSON: got %d, want 400", w.Code)
+		}
+	})
+
+	t.Run("valid->ok", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodPost, "/x", strings.NewReader(`{"x":"hi"}`))
+		var dst payload
+		if !decodeCappedJSON(w, r, maxControlPlaneBodyBytes, &dst) {
+			t.Fatalf("expected ok=true for valid JSON (status %d)", w.Code)
+		}
+		if dst.X != "hi" {
+			t.Fatalf("decoded X=%q, want %q", dst.X, "hi")
+		}
+	})
+}

--- a/coordinator/api/device_auth.go
+++ b/coordinator/api/device_auth.go
@@ -101,7 +101,10 @@ func (s *Server) handleDeviceToken(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		DeviceCode string `json:"device_code"`
 	}
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.DeviceCode == "" {
+	if !decodeCappedJSON(w, r, maxControlPlaneBodyBytes, &req) {
+		return
+	}
+	if req.DeviceCode == "" {
 		writeJSON(w, http.StatusBadRequest, errorResponse("invalid_request", "device_code is required"))
 		return
 	}

--- a/coordinator/api/enroll.go
+++ b/coordinator/api/enroll.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"regexp"
@@ -24,8 +23,7 @@ var serialRegex = regexp.MustCompile(`^[A-Z0-9]{8,14}$`)
 // Security comes from Apple's attestation during the ACME challenge.
 func (s *Server) handleEnroll(w http.ResponseWriter, r *http.Request) {
 	var req enrollRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeJSON(w, http.StatusBadRequest, errorResponse("invalid_request_error", "invalid JSON: "+err.Error()))
+	if !decodeCappedJSON(w, r, maxControlPlaneBodyBytes, &req) {
 		return
 	}
 

--- a/coordinator/api/release_handlers.go
+++ b/coordinator/api/release_handlers.go
@@ -586,8 +586,7 @@ func (s *Server) handleAdminAuthInit(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		Email string `json:"email"`
 	}
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeJSON(w, http.StatusBadRequest, errorResponse("invalid_request_error", "invalid JSON"))
+	if !decodeCappedJSON(w, r, maxControlPlaneBodyBytes, &req) {
 		return
 	}
 	if req.Email == "" {
@@ -620,8 +619,7 @@ func (s *Server) handleAdminAuthVerify(w http.ResponseWriter, r *http.Request) {
 		Email string `json:"email"`
 		Code  string `json:"code"`
 	}
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeJSON(w, http.StatusBadRequest, errorResponse("invalid_request_error", "invalid JSON"))
+	if !decodeCappedJSON(w, r, maxControlPlaneBodyBytes, &req) {
 		return
 	}
 	if req.Email == "" || req.Code == "" {

--- a/coordinator/api/server.go
+++ b/coordinator/api/server.go
@@ -1299,6 +1299,17 @@ func (s *Server) handleRuntimeManifest(w http.ResponseWriter, r *http.Request) {
 // unbounded body.
 const maxMDMWebhookBodyBytes = 1 << 20 // 1 MiB
 
+// maxRequestBodyBytes is the global ceiling bodyLimitMiddleware applies to every
+// request body so no endpoint can be OOM'd by an unbounded POST. It clears the
+// largest legitimate body (the 64 MiB plaintext-inference image path); handlers
+// needing less wrap r.Body in a tighter MaxBytesReader on top.
+const maxRequestBodyBytes = 64 << 20 // 64 MiB
+
+// maxControlPlaneBodyBytes is the tight cap for small unauthenticated
+// control-plane JSON (enroll, device token, admin auth) — far below the global
+// ceiling so these exposed endpoints buffer at most a few KiB.
+const maxControlPlaneBodyBytes = 64 << 10 // 64 KiB
+
 // HandleMDMWebhook processes a MicroMDM webhook callback.
 // Mount this on the webhook URL configured in MicroMDM.
 //
@@ -1673,7 +1684,40 @@ func (s *Server) handleUnimplementedEndpoint(w http.ResponseWriter, r *http.Requ
 //
 // Recover must sit outside logging so a panic during logging doesn't leak.
 func (s *Server) Handler() http.Handler {
-	return s.corsMiddleware(s.recoverMiddleware(s.loggingMiddleware(s.mux)))
+	return s.corsMiddleware(s.recoverMiddleware(s.loggingMiddleware(s.bodyLimitMiddleware(s.mux))))
+}
+
+// bodyLimitMiddleware caps every request body at maxRequestBodyBytes so an
+// unbounded POST can't OOM the coordinator (the trusted TEE component).
+// Per-handler MaxBytesReader caps (tighter) layer on top. The provider
+// WebSocket upgrade is exempt: it hijacks the connection and reads framed
+// messages (bounded separately), not r.Body.
+func (s *Server) bodyLimitMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Body != nil && r.URL.Path != "/ws/provider" {
+			r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+// decodeCappedJSON JSON-decodes the request body under a hard size cap, writing
+// a 413 (too large) or 400 (bad JSON) and returning false on failure. For small
+// unauthenticated control-plane endpoints that must not buffer an unbounded body.
+func decodeCappedJSON(w http.ResponseWriter, r *http.Request, maxBytes int64, dst any) bool {
+	r.Body = http.MaxBytesReader(w, r.Body, maxBytes)
+	if err := json.NewDecoder(r.Body).Decode(dst); err != nil {
+		var maxErr *http.MaxBytesError
+		if errors.As(err, &maxErr) {
+			writeJSON(w, http.StatusRequestEntityTooLarge,
+				errorResponse("invalid_request_error", "request body too large"))
+			return false
+		}
+		writeJSON(w, http.StatusBadRequest,
+			errorResponse("invalid_request_error", "invalid JSON"))
+		return false
+	}
+	return true
 }
 
 // recoverMiddleware catches panics in any handler, emits a telemetry event


### PR DESCRIPTION
## Summary

Caps the size of every consumer request body so an unbounded POST can't OOM the coordinator (the trusted TEE component). Several endpoints decoded `r.Body` with no limit — worst on the **unauthenticated** control-plane endpoints, which need no credential at all.

## The problem

`json.Decoder.Decode` / `io.ReadAll` buffer the request body with no cap on many routes. A multi-GB POST is allocated in full before the handler can validate or reject it. The most exposed are unauthenticated:

| Endpoint | Auth |
|---|---|
| `POST /v1/enroll` | none |
| `POST /v1/device/token` | none |
| `POST /v1/admin/auth/init` | none (sends OTP) |
| `POST /v1/admin/auth/verify` | none (returns token) |

…and the same uncapped pattern exists on API-key (`invite/redeem`) and authed (`billing`, `model`, `release`) decoders.

## The fix — one ceiling + tight caps where it counts

- **`bodyLimitMiddleware`** (added to `Handler()`: `cors(recover(logging(bodyLimit(mux))))`) wraps every request body in `http.MaxBytesReader` at a **64 MiB global ceiling**, so *every* route is bounded in one place. The ceiling clears the largest legitimate body (the 64 MiB plaintext-inference image path). **`/ws/provider` is exempt** — it hijacks the connection and reads framed messages (bounded separately by `SetReadLimit`), not `r.Body`.
- **`decodeCappedJSON`** applies a tight **64 KiB** cap on the four unauthenticated control-plane endpoints (they carry small fixed structs): over-cap → **413**, malformed → **400**.
- **Nothing loosens:** existing tighter per-handler caps (sealed 16 MiB, telemetry/release 64 KiB, MDM 1 MiB) are inner `MaxBytesReader`s, so they still fire first.

## Test plan

`go test ./coordinator/api/` — full package green (no regression from the handler changes). New tests in `coordinator/api/body_cap_test.go`:
- `TestBodyLimitMiddlewareCapsOversizedBody` — an over-ceiling body on a normal route is capped (`*http.MaxBytesError`).
- `TestBodyLimitMiddlewareExemptsProviderWS` — `/ws/provider` is *not* capped.
- `TestDecodeCappedJSON` — over-cap → 413, malformed → 400, valid → decoded.

**Verified the load-bearing test fails without the fix:** removing the middleware's `MaxBytesReader` makes the caps test read the full stream (`nil` instead of `*http.MaxBytesError`).

## Context

Pre-existing on `master`; fixed here so all branches inherit it. Completes the consumer-side body bounding (the inference-body cap is in #338; this global middleware also covers that path) and is the ingress sibling of the provider-side chunk-accumulation issue (#337).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/339"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784006807&installation_id=133247490&pr_number=339&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F339&signature=b6955bbed70ec1e339782b130642f41d0a8f5f33a5d0361070198ebc1f6138f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->