### PR TITLE
fix(coordinator): schedule the read-cache purge janitor

### DIFF
--- a/coordinator/api/cache.go
+++ b/coordinator/api/cache.go
@@ -67,6 +67,14 @@ func (c *ttlCache) PurgeExpired() {
 	c.mu.Unlock()
 }
 
+// Len returns the number of entries currently held (including not-yet-purged
+// expired ones). Used by the janitor's tests to observe reclamation.
+func (c *ttlCache) Len() int {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return len(c.data)
+}
+
 // writeCachedJSON writes pre-serialized JSON bytes with the standard
 // Content-Type header. Used on cache hit to skip json.Marshal.
 func writeCachedJSON(w http.ResponseWriter, body []byte) {

--- a/coordinator/api/cache_test.go
+++ b/coordinator/api/cache_test.go
@@ -1,0 +1,59 @@
+package api
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// PurgeExpired removes expired entries and keeps live ones.
+func TestTTLCachePurgeExpired(t *testing.T) {
+	c := newTTLCache()
+	c.Set("stale", []byte("v"), -time.Second) // already expired
+	c.Set("fresh", []byte("v"), time.Minute)  // live
+
+	c.PurgeExpired()
+
+	if c.Len() != 1 {
+		t.Fatalf("PurgeExpired: got %d entries, want 1", c.Len())
+	}
+	if _, ok := c.Get("stale"); ok {
+		t.Error("expired entry should be gone after PurgeExpired")
+	}
+	if _, ok := c.Get("fresh"); !ok {
+		t.Error("live entry should survive PurgeExpired")
+	}
+}
+
+// The janitor actually reclaims expired entries (PurgeExpired was previously
+// never scheduled, so high-cardinality keys lingered forever) and stops on ctx
+// cancel.
+func TestReadCacheJanitorPurgesExpiredAndStops(t *testing.T) {
+	s := &Server{readCache: newTTLCache()}
+	// An expired entry that nothing will ever re-read — only the janitor frees it.
+	s.readCache.Set("stale", []byte("v"), -time.Second)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		s.runReadCacheJanitor(ctx, time.Millisecond)
+		close(done)
+	}()
+
+	deadline := time.After(2 * time.Second)
+	for s.readCache.Len() != 0 {
+		select {
+		case <-deadline:
+			t.Fatal("janitor did not purge the expired entry")
+		default:
+			time.Sleep(time.Millisecond)
+		}
+	}
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("janitor did not stop on context cancel")
+	}
+}

--- a/coordinator/api/server.go
+++ b/coordinator/api/server.go
@@ -1640,6 +1640,35 @@ func (s *Server) StartDDGaugeLoop(ctx context.Context) {
 	}
 }
 
+// readCacheJanitorInterval is how often expired readCache entries are reclaimed.
+// Get already skips expired entries, so this only frees memory — but without it
+// high-cardinality keys (e.g. the per-account "account-earnings:" entries) are
+// written and never re-read, so they linger forever and the cache grows unbounded.
+const readCacheJanitorInterval = time.Minute
+
+// StartReadCacheJanitor periodically purges expired entries from the read cache
+// so it can't grow unbounded. Call as a goroutine; stops when ctx is cancelled.
+func (s *Server) StartReadCacheJanitor(ctx context.Context) {
+	s.runReadCacheJanitor(ctx, readCacheJanitorInterval)
+}
+
+// runReadCacheJanitor is StartReadCacheJanitor with an injectable interval (tests).
+func (s *Server) runReadCacheJanitor(ctx context.Context, interval time.Duration) {
+	if s.readCache == nil {
+		return
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			s.readCache.PurgeExpired()
+		}
+	}
+}
+
 // handleAdminMetrics returns the metrics snapshot in JSON or Prometheus text.
 func (s *Server) handleAdminMetrics(w http.ResponseWriter, r *http.Request) {
 	if !s.isAdminAuthorized(w, r) {

--- a/coordinator/cmd/coordinator/main.go
+++ b/coordinator/cmd/coordinator/main.go
@@ -509,6 +509,9 @@ func main() {
 	// Push gauge values to DogStatsD periodically.
 	go srv.StartDDGaugeLoop(ctx)
 
+	// Reclaim expired read-cache entries periodically (bounds memory growth).
+	go srv.StartReadCacheJanitor(ctx)
+
 	// HTTP server with graceful shutdown.
 	httpServer := &http.Server{
 		Addr:         ":" + cfg.ServerConfig.Port,


### PR DESCRIPTION
## Summary

Schedules the read-cache purge janitor that was never wired up — dead code that let the cache grow unbounded.

## The bug

`api/cache.go`'s `ttlCache.PurgeExpired()` carries the comment *"Called by a background goroutine — bounded growth even when keys are added but never re-read."* But **nothing ever called it** (grep for callers: none). So expired `readCache` entries were only *skipped* on read (`Get`), never freed.

Most `readCache` keys are fixed/low-cardinality (`models:catalog`, `api_version:v1`, leaderboard combos) and harmless. But `"account-earnings:" + accountID + ":" + limit` (`billing_handlers.go`) is **per-account** — every distinct `(accountID, limit)` that ever hits the earnings endpoint leaves a serialized-JSON entry that expires but is never reclaimed, so the cache grows unbounded as the user base grows.

## The fix

- `Server.StartReadCacheJanitor(ctx)` — mirrors the existing `StartDDGaugeLoop` (`time.NewTicker` + `select` on `ctx.Done()`/`ticker.C` + `defer ticker.Stop()`), calling `readCache.PurgeExpired()` every minute. Launched from `cmd/coordinator/main.go` next to `StartDDGaugeLoop`, on the same shutdown-cancelled `ctx`.
- `runReadCacheJanitor(ctx, interval)` is the injectable-interval inner func (tests use a short interval).
- Added `ttlCache.Len()` as an observation point for the tests.

Get already skipped expired entries, so this is purely memory reclamation — no behavior change for callers.

## Test plan

`go test -race ./coordinator/api/` — green. New tests in `coordinator/api/cache_test.go`:
- `TestTTLCachePurgeExpired` — `PurgeExpired` removes expired entries, keeps live ones.
- `TestReadCacheJanitorPurgesExpiredAndStops` — the janitor reclaims an expired entry and stops promptly on `ctx` cancel (no goroutine leak).

**Verified the janitor test fails without the fix:** removing the `PurgeExpired()` call makes the entry never get reclaimed (`did not purge`).

## Context

Pre-existing on `master`; one of a few coordinator unbounded-growth items surfaced in review. The siblings (the in-memory per-consumer usage log and the never-deleted billing-sessions map) are separate and not in this PR.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/340"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784047278&installation_id=133247490&pr_number=340&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F340&signature=fa7c41d96f36e7befb2762c9a9da4c321cff8ce9bc3ce2cfac847308e55073f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->