### PR TITLE
fix(coordinator): per-connection MDM verification — un-strand the self_signed/untrusted cohort

### DIFF
--- a/coordinator/api/acme_verify.go
+++ b/coordinator/api/acme_verify.go
@@ -40,6 +40,15 @@ func (s *Server) extractAndVerifyClientCert(r *http.Request) *ACMEVerificationRe
 	)
 
 	if certEncoded == "" || verifyStatus == "" {
+		// No client cert reached us — either the provider didn't present one or
+		// the ingress isn't forwarding X-Ssl-Client-* headers. Logged (request-
+		// scoped is fine: provider WS connects are infrequent) so "is ACME even
+		// being attempted?" is answerable without a packet capture.
+		s.ddIncr("acme.client_cert", []string{"outcome:missing"})
+		s.logger.Info("no ACME client cert on provider connection",
+			"verify", verifyStatus,
+			"cert_len", len(certEncoded),
+		)
 		return nil // no client cert presented
 	}
 
@@ -47,6 +56,7 @@ func (s *Server) extractAndVerifyClientCert(r *http.Request) *ACMEVerificationRe
 
 	if verifyStatus != "SUCCESS" {
 		result.Error = "nginx client cert verification failed: " + verifyStatus
+		s.ddIncr("acme.client_cert", []string{"outcome:present_invalid"})
 		return result
 	}
 
@@ -54,6 +64,7 @@ func (s *Server) extractAndVerifyClientCert(r *http.Request) *ACMEVerificationRe
 	certPEM, err := url.QueryUnescape(certEncoded)
 	if err != nil {
 		result.Error = "failed to decode client cert: " + err.Error()
+		s.ddIncr("acme.client_cert", []string{"outcome:present_invalid"})
 		return result
 	}
 
@@ -61,12 +72,14 @@ func (s *Server) extractAndVerifyClientCert(r *http.Request) *ACMEVerificationRe
 	block, _ := pem.Decode([]byte(certPEM))
 	if block == nil {
 		result.Error = "invalid PEM in client cert"
+		s.ddIncr("acme.client_cert", []string{"outcome:present_invalid"})
 		return result
 	}
 
 	cert, err := x509.ParseCertificate(block.Bytes)
 	if err != nil {
 		result.Error = "failed to parse client cert: " + err.Error()
+		s.ddIncr("acme.client_cert", []string{"outcome:present_invalid"})
 		return result
 	}
 
@@ -92,6 +105,7 @@ func (s *Server) extractAndVerifyClientCert(r *http.Request) *ACMEVerificationRe
 
 	if err != nil {
 		result.Error = "client cert chain verification failed: " + err.Error()
+		s.ddIncr("acme.client_cert", []string{"outcome:present_invalid"})
 		return result
 	}
 
@@ -103,9 +117,11 @@ func (s *Server) extractAndVerifyClientCert(r *http.Request) *ACMEVerificationRe
 	if err != nil {
 		result.Valid = false
 		result.Error = err.Error()
+		s.ddIncr("acme.client_cert", []string{"outcome:present_invalid"})
 		return result
 	}
 
+	s.ddIncr("acme.client_cert", []string{"outcome:present_valid"})
 	s.logger.Info("ACME client cert verified",
 		"serial", result.SerialNumber,
 		"issuer", result.Issuer,

--- a/coordinator/api/provider.go
+++ b/coordinator/api/provider.go
@@ -2315,6 +2315,19 @@ const (
 // decide whether to retry. It NEVER marks a provider untrusted for a transient
 // failure (not-enrolled / timeout) — only for a genuine posture mismatch.
 func (s *Server) verifyProviderViaMDM(ctx context.Context, providerID string, provider *registry.Provider, attestResult attestation.VerificationResult) mdmVerifyOutcome {
+	// Never let MDM promote a provider whose Secure Enclave attestation is not
+	// valid. verifyProviderAttestation stores an AttestationResult even for an
+	// invalid attestation (and, in Open Mode, leaves the provider connected), so
+	// without this a later SecurityInfo success could grant hardware to a provider
+	// whose SE attestation / encryption-key binding failed. result.Valid==true
+	// implies both passed (verifyProviderAttestation returns early otherwise). The
+	// per-connection loop also gates on this; this is the authoritative backstop.
+	if !attestResult.Valid {
+		s.logger.Warn("refusing MDM verification — SE attestation not valid",
+			"provider_id", providerID, "serial_number", attestResult.SerialNumber)
+		return mdmVerifyTransient
+	}
+
 	s.logger.Info("starting MDM verification",
 		"provider_id", providerID,
 		"serial_number", attestResult.SerialNumber,
@@ -2337,14 +2350,21 @@ func (s *Server) verifyProviderViaMDM(ctx context.Context, providerID string, pr
 	}
 
 	if !mdmResult.DeviceEnrolled {
-		// Distinguish "MicroMDM has no record of this serial" (profile never
-		// installed / check-in never reached the server) from "record exists but
-		// enrollment didn't complete" — different provider-side fixes.
+		// A MicroMDM lookup/transport failure (500, network error) also returns
+		// DeviceEnrolled=false — but the device may well be enrolled; we just
+		// couldn't ask. Bucket that as "error" (MDM-side outage) so the stuck-cohort
+		// gauge doesn't point operators at provider enrollment during an MDM outage.
+		// Otherwise distinguish "no record of this serial" (profile never installed /
+		// check-in never reached the server) from "record exists but enrollment
+		// didn't complete" — different provider-side fixes.
 		reason := "found-not-enrolled"
-		if strings.Contains(mdmResult.Error, "not found") {
+		switch {
+		case strings.Contains(mdmResult.Error, "lookup failed"):
+			reason = "error"
+		case strings.Contains(mdmResult.Error, "not found"):
 			reason = "device-not-found"
 		}
-		s.logger.Warn("provider device not enrolled in MDM — staying at self_signed trust",
+		s.logger.Warn("provider not MDM-verified — staying at self_signed trust",
 			"provider_id", providerID,
 			"serial_number", attestResult.SerialNumber,
 			"reason", reason,
@@ -2403,6 +2423,19 @@ func (s *Server) verifyProviderViaMDM(ctx context.Context, providerID string, pr
 		return mdmVerifyTransient
 	}
 
+	// Do NOT grant hardware while the provider is currently untrusted. A transient
+	// missed-challenge deroute (StatusUntrusted, recoverable) can race an in-flight
+	// MDM verify; granting here would leave the registry in hardware/untrusted
+	// (routing still rejects it on Status) while telling the provider it is
+	// "online" — cancelling its diagnostics for traffic it won't receive. Defer:
+	// recovery flows through a passing SE challenge that restores Status to online,
+	// after which a later loop iteration grants hardware cleanly. (A hard untrust
+	// already stops the loop via ChallengeShouldStop.)
+	if provider.GetStatus() == registry.StatusUntrusted {
+		s.ddIncr("mdm.verification", []string{"outcome:deferred-untrusted"})
+		return mdmVerifyTransient
+	}
+
 	// MDM SecurityInfo verification passed — upgrade to hardware trust.
 	provider.SetMDMFailureReason("")
 	provider.SetAttested(true, registry.TrustHardware)
@@ -2454,14 +2487,24 @@ func (s *Server) mdmVerificationLoop(ctx context.Context, providerID string, pro
 		result = &r
 	}
 	provider.Mu().Unlock()
-	if result == nil || result.SerialNumber == "" {
-		return // no serial → cannot verify via MDM (warned at registration)
+	// Require a VALID Secure Enclave attestation before MDM can promote to
+	// hardware. verifyProviderAttestation sets AttestationResult even when the SE
+	// attestation is invalid (and, in Open Mode, leaves the provider connected),
+	// so gating only on a serial would let a later MDM SecurityInfo success
+	// promote a provider whose SE attestation / encryption-key binding FAILED.
+	// result.Valid==true implies both the SE attestation and the X25519↔SE binding
+	// passed (verifyProviderAttestation returns early otherwise).
+	if result == nil || !result.Valid || result.SerialNumber == "" {
+		return
 	}
 
-	// Fast first (catch a briefly-asleep device), then a slow cadence that
-	// respects Apple's MDM/APNs push budget while still catching a provider that
-	// completes enrollment later in the same connection.
-	backoff := []time.Duration{30 * time.Second, 2 * time.Minute, 5 * time.Minute}
+	// One attempt up front, then a gentle cadence. The initial push (with the
+	// SecurityInfo waiter registered first) wakes an awake-or-reachable device and
+	// usually lands; retries exist only for genuine APNs/Power-Nap delivery delay,
+	// so they're spaced to stay within Apple's MDM push budget (the throttling this
+	// change exists to avoid) while still catching a provider that finishes
+	// enrollment later in the same connection.
+	backoff := []time.Duration{2 * time.Minute, 6 * time.Minute}
 	const steadyInterval = 15 * time.Minute
 
 	for attempt := 0; ; attempt++ {

--- a/coordinator/api/provider.go
+++ b/coordinator/api/provider.go
@@ -724,6 +724,7 @@ func (s *Server) attachProviderLocation(providerID string, provider *registry.Pr
 
 func (s *Server) applyACMETrust(providerID string, provider *registry.Provider, acmeResult *ACMEVerificationResult) {
 	if acmeResult == nil || !acmeResult.Valid {
+		s.ddIncr("acme.trust", []string{"outcome:nil_or_invalid"})
 		return
 	}
 
@@ -741,6 +742,7 @@ func (s *Server) applyACMETrust(providerID string, provider *registry.Provider, 
 	if !providerHasBoundEncryptionAttestation(provider) {
 		// Expected before the first challenge completes; logged at debug so it
 		// doesn't look like a failure. The retry path resolves it.
+		s.ddIncr("acme.trust", []string{"outcome:not_bound"})
 		s.logger.Debug("ACME cert verified but attestation not yet bound — will retry after challenge",
 			"provider_id", providerID,
 			"acme_serial", acmeResult.SerialNumber,
@@ -748,6 +750,7 @@ func (s *Server) applyACMETrust(providerID string, provider *registry.Provider, 
 		return
 	}
 	if !providerAttestationMatchesACMEKey(provider, acmeResult) {
+		s.ddIncr("acme.trust", []string{"outcome:key_mismatch"})
 		s.logger.Warn("ACME client cert key does not match the attested Secure Enclave key",
 			"provider_id", providerID,
 			"acme_serial", acmeResult.SerialNumber,
@@ -760,6 +763,7 @@ func (s *Server) applyACMETrust(providerID string, provider *registry.Provider, 
 	provider.SetAttested(true, registry.TrustHardware)
 	s.sendTrustStatus(provider, registry.TrustHardware, "online", "ACME device attestation verified")
 	s.clearPendingACME(providerID)
+	s.ddIncr("acme.trust", []string{"outcome:granted"})
 	s.logger.Info("ACME client cert verified — hardware trust via Apple SE attestation",
 		"provider_id", providerID,
 		"acme_serial", acmeResult.SerialNumber,

--- a/coordinator/api/provider.go
+++ b/coordinator/api/provider.go
@@ -381,6 +381,14 @@ func (s *Server) providerReadLoop(ctx context.Context, conn *websocket.Conn, pro
 				s.challengeLoop(loopCtx, conn, providerID, provider, tracker)
 			})
 
+			// Start the per-connection MDM verification loop. It runs the initial
+			// SecurityInfo check + a bounded, push-budget-aware retry, decoupled
+			// from the 5-minute challenge ticker. No-op when no MDM client is
+			// configured or the attestation carried no serial.
+			saferun.Go(s.logger, "mdmVerificationLoop", func() {
+				s.mdmVerificationLoop(loopCtx, providerID, provider)
+			})
+
 			// v0.6.0: APNs code-identity attestation. Runs only when an attestor is
 			// configured; otherwise the provider simply never becomes CodeAttested
 			// (fail-closed at the routing chokepoint once enforcement begins). The
@@ -1434,21 +1442,18 @@ func (s *Server) verifyChallengeResponse(providerID string, provider *registry.P
 		)
 	}
 
-	// Re-attempt MDM verification for self_signed providers. This handles
-	// providers that installed the MDM enrollment profile after their initial
-	// registration — they would otherwise stay at self_signed trust forever
-	// since verifyProviderViaMDM only ran once at registration time.
+	// MDM SecurityInfo re-verification is intentionally NOT driven from the
+	// challenge response anymore. It used to re-run on every 5-minute challenge
+	// for self_signed providers, which fired an MDM/APNs push each time and got
+	// throttled by Apple (~2-3/hr budget) — the throttling itself caused the
+	// SecurityInfo timeouts that stranded providers at self_signed. SIP/Secure
+	// Boot can't change without a reboot, and a reboot drops this WebSocket, so
+	// the per-connection mdmVerificationLoop (spawned alongside challengeLoop)
+	// now owns MDM verification with a push-budget-aware backoff. See
+	// mdmVerificationLoop.
 	provider.Mu().Lock()
 	trustLevel := provider.TrustLevel
-	attestResult := provider.AttestationResult
 	provider.Mu().Unlock()
-
-	if trustLevel == registry.TrustSelfSigned && s.mdmClient != nil && attestResult != nil {
-		result := *attestResult
-		saferun.Go(s.logger, "retryMDMVerification", func() {
-			s.verifyProviderViaMDM(providerID, provider, result)
-		})
-	}
 
 	// Re-attempt ACME (mTLS device-cert) trust for self_signed providers.
 	// applyACMETrust ran at registration before attestation was bound, so a
@@ -2275,23 +2280,37 @@ func (s *Server) verifyProviderAttestation(providerID string, provider *registry
 	// This captures the attestation result, serial number, and trust level.
 	s.registry.PersistProvider(provider)
 
-	// MDM verification: independently verify security posture via MicroMDM.
-	// This upgrades trust from self_signed to hardware if MDM confirms
-	// the device is enrolled and SIP/SecureBoot match.
-	if s.mdmClient != nil && result.SerialNumber != "" {
-		saferun.Go(s.logger, "verifyProviderViaMDM", func() {
-			s.verifyProviderViaMDM(providerID, provider, result)
-		})
-	} else if s.mdmClient != nil && result.SerialNumber == "" {
+	// MDM verification is NOT spawned here. It runs once per connection in
+	// mdmVerificationLoop (started alongside challengeLoop in providerReadLoop),
+	// which owns the initial verify + a bounded, push-budget-aware retry. Doing
+	// it per-connection instead of per-registration-and-every-challenge is
+	// security-equivalent (SIP/Secure Boot can't change without a reboot, which
+	// drops the connection) and stops the APNs push throttling that stranded
+	// providers at self_signed.
+	if s.mdmClient != nil && result.SerialNumber == "" {
 		s.logger.Warn("provider attestation has no serial number — cannot verify via MDM",
 			"provider_id", providerID,
 		)
 	}
 }
 
-// verifyProviderViaMDM runs MDM verification in the background.
-// If MDM confirms the device's security posture, the trust level is upgraded.
-func (s *Server) verifyProviderViaMDM(providerID string, provider *registry.Provider, attestResult attestation.VerificationResult) {
+// mdmVerifyOutcome classifies the result of one MDM verification attempt so the
+// per-connection mdmVerificationLoop can decide whether to retry.
+type mdmVerifyOutcome int
+
+const (
+	mdmVerifyGranted   mdmVerifyOutcome = iota // hardware trust granted — stop
+	mdmVerifyTransient                         // not-enrolled / not-found / timeout / error — retry
+	mdmVerifyTerminal                          // posture mismatch (hard untrust) — stop
+)
+
+// verifyProviderViaMDM runs one MDM SecurityInfo verification attempt for a
+// provider and, on success, upgrades it to hardware trust + records Apple Device
+// Attestation. It records a bucketed MDMFailureReason on the provider and emits
+// an outcome metric, then returns an outcome the per-connection loop uses to
+// decide whether to retry. It NEVER marks a provider untrusted for a transient
+// failure (not-enrolled / timeout) — only for a genuine posture mismatch.
+func (s *Server) verifyProviderViaMDM(providerID string, provider *registry.Provider, attestResult attestation.VerificationResult) mdmVerifyOutcome {
 	s.logger.Info("starting MDM verification",
 		"provider_id", providerID,
 		"serial_number", attestResult.SerialNumber,
@@ -2307,29 +2326,45 @@ func (s *Server) verifyProviderViaMDM(providerID string, provider *registry.Prov
 			"provider_id", providerID,
 			"error", err,
 		)
-		return
+		provider.SetMDMFailureReason("error")
+		s.ddIncr("mdm.verification", []string{"outcome:error"})
+		return mdmVerifyTransient
 	}
 
 	if !mdmResult.DeviceEnrolled {
+		// Distinguish "MicroMDM has no record of this serial" (profile never
+		// installed / check-in never reached the server) from "record exists but
+		// enrollment didn't complete" — different provider-side fixes.
+		reason := "found-not-enrolled"
+		if strings.Contains(mdmResult.Error, "not found") {
+			reason = "device-not-found"
+		}
 		s.logger.Warn("provider device not enrolled in MDM — staying at self_signed trust",
 			"provider_id", providerID,
 			"serial_number", attestResult.SerialNumber,
+			"reason", reason,
 			"error", mdmResult.Error,
 		)
-		return
+		provider.SetMDMFailureReason(reason)
+		s.ddIncr("mdm.verification", []string{"outcome:" + reason})
+		return mdmVerifyTransient
 	}
 
 	if mdmResult.Error != "" {
 		// A timeout means APN latency or device sleep — not evidence of
 		// compromise. Keep the provider at its current trust level (self_signed)
-		// instead of marking it untrusted.
+		// instead of marking it untrusted, and let the loop retry.
 		if strings.Contains(mdmResult.Error, "timeout") {
 			s.logger.Warn("MDM verification timed out — staying at current trust level",
 				"provider_id", providerID,
 				"error", mdmResult.Error,
 			)
-			return
+			provider.SetMDMFailureReason("securityinfo-timeout")
+			s.ddIncr("mdm.verification", []string{"outcome:securityinfo-timeout"})
+			return mdmVerifyTransient
 		}
+		// A real posture mismatch (SIP disabled, Secure Boot not full, attestation
+		// disagrees with MDM) IS evidence of a problem — hard untrust, no retry.
 		s.logger.Warn("MDM verification failed — marking provider untrusted",
 			"provider_id", providerID,
 			"error", mdmResult.Error,
@@ -2338,13 +2373,17 @@ func (s *Server) verifyProviderViaMDM(providerID string, provider *registry.Prov
 			"sip_match", mdmResult.SIPMatch,
 			"secure_boot_match", mdmResult.SecureBootMatch,
 		)
+		provider.SetMDMFailureReason("posture-mismatch")
+		s.ddIncr("mdm.verification", []string{"outcome:posture-mismatch"})
 		s.registry.MarkUntrusted(providerID)
-		return
+		return mdmVerifyTerminal
 	}
 
 	// MDM SecurityInfo verification passed — upgrade to hardware trust.
+	provider.SetMDMFailureReason("")
 	provider.SetAttested(true, registry.TrustHardware)
 	s.sendTrustStatus(provider, registry.TrustHardware, "online", "MDM verification passed")
+	s.ddIncr("mdm.verification", []string{"outcome:granted"})
 	s.logger.Info("MDM verification passed — upgraded to hardware trust",
 		"provider_id", providerID,
 		"serial_number", attestResult.SerialNumber,
@@ -2361,6 +2400,67 @@ func (s *Server) verifyProviderViaMDM(providerID string, provider *registry.Prov
 	// chain can be independently verified by users against Apple's
 	// Enterprise Attestation Root CA.
 	s.verifyAppleDeviceAttestation(providerID, provider, attestResult, mdmResult.UDID)
+	return mdmVerifyGranted
+}
+
+// mdmVerificationLoop owns MDM SecurityInfo verification for one provider
+// connection. It replaces the old model where verification ran at registration
+// and then re-ran on every 5-minute challenge for self_signed providers — which
+// fired an MDM/APNs push each time and got throttled by Apple, so the
+// SecurityInfo checks timed out and stranded providers at self_signed.
+//
+// Why per-connection is sufficient (not weaker than polling): SIP and Secure
+// Boot cannot change at runtime — both require a reboot into Recovery — and a
+// reboot drops this WebSocket, which ends this loop and forces a fresh
+// connection that re-verifies. So we don't need to re-poll; we only need the one
+// check to LAND. The backoff below retries within the connection to survive APNs
+// / Power-Nap delivery delays and to catch a provider that finishes enrollment
+// mid-connection, while staying well under Apple's push budget.
+//
+// It stops as soon as hardware trust is earned (here or via ACME concurrently),
+// on a terminal posture mismatch, or when the connection closes (ctx done).
+func (s *Server) mdmVerificationLoop(ctx context.Context, providerID string, provider *registry.Provider) {
+	if s.mdmClient == nil {
+		return
+	}
+	provider.Mu().Lock()
+	var result *attestation.VerificationResult
+	if provider.AttestationResult != nil {
+		r := *provider.AttestationResult
+		result = &r
+	}
+	provider.Mu().Unlock()
+	if result == nil || result.SerialNumber == "" {
+		return // no serial → cannot verify via MDM (warned at registration)
+	}
+
+	// Fast first (catch a briefly-asleep device), then a slow cadence that
+	// respects Apple's MDM/APNs push budget while still catching a provider that
+	// completes enrollment later in the same connection.
+	backoff := []time.Duration{30 * time.Second, 2 * time.Minute, 5 * time.Minute}
+	const steadyInterval = 15 * time.Minute
+
+	for attempt := 0; ; attempt++ {
+		// Stop if hardware was already earned — by this loop on a prior iteration,
+		// or by the ACME leg (retryACMETrust) concurrently.
+		if provider.GetTrustLevel() == registry.TrustHardware {
+			return
+		}
+		switch s.verifyProviderViaMDM(providerID, provider, *result) {
+		case mdmVerifyGranted, mdmVerifyTerminal:
+			return
+		}
+		// Transient (not-enrolled / not-found / timeout / error) — schedule retry.
+		d := steadyInterval
+		if attempt < len(backoff) {
+			d = backoff[attempt]
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(d):
+		}
+	}
 }
 
 // verifyAppleDeviceAttestation sends a DeviceInformation command requesting
@@ -2552,15 +2652,23 @@ func (s *Server) handleProviderAttestation(w http.ResponseWriter, r *http.Reques
 		}
 		p.Mu().Unlock()
 
+		// The public proofs (mdm/mda/acme) are reported true ONLY for a connection
+		// that currently holds hardware trust. A hardware proof is meaningful for
+		// the connection that earned it live; surfacing mda_verified/acme_verified
+		// on a self_signed connection (e.g. a stored flag, an early-set ACME flag
+		// before binding, or a late-arriving MDA webhook) is the misleading
+		// "mda_verified=true while self_signed" drift. Gating all three on the
+		// live trust level keeps the endpoint internally consistent.
+		isHardware := trustLevel == registry.TrustHardware
 		pa := providerAttestation{
 			ProviderID:   p.ID,
 			TrustLevel:   string(trustLevel),
 			Status:       string(status),
 			MemoryGB:     p.Hardware.MemoryGB,
 			GPUCores:     p.Hardware.GPUCores,
-			MDMVerified:  trustLevel == registry.TrustHardware,
-			MDAVerified:  mdaVerified,
-			ACMEVerified: acmeVerified,
+			MDMVerified:  isHardware,
+			MDAVerified:  mdaVerified && isHardware,
+			ACMEVerified: acmeVerified && isHardware,
 		}
 
 		pa.Models = append(pa.Models, modelIDs...)

--- a/coordinator/api/provider.go
+++ b/coordinator/api/provider.go
@@ -2424,22 +2424,20 @@ func (s *Server) verifyProviderViaMDM(ctx context.Context, providerID string, pr
 		return mdmVerifyTransient
 	}
 
-	// Do NOT grant hardware while the provider is currently untrusted. A transient
-	// missed-challenge deroute (StatusUntrusted, recoverable) can race an in-flight
-	// MDM verify; granting here would leave the registry in hardware/untrusted
-	// (routing still rejects it on Status) while telling the provider it is
-	// "online" — cancelling its diagnostics for traffic it won't receive. Defer:
-	// recovery flows through a passing SE challenge that restores Status to online,
-	// after which a later loop iteration grants hardware cleanly. (A hard untrust
-	// already stops the loop via ChallengeShouldStop.)
-	if provider.GetStatus() == registry.StatusUntrusted {
+	// MDM SecurityInfo verification passed — atomically upgrade to hardware trust,
+	// but NOT while the provider is currently untrusted. A missed-challenge deroute
+	// can race this in-flight MDM verify; granting would leave the registry in
+	// hardware/untrusted (routing still rejects it on Status) while telling the
+	// provider it is "online". The atomic check-and-grant closes the TOCTOU between
+	// the status check and the trust write. Recovery from a transient untrust flows
+	// through a passing SE challenge that restores Status, after which a later loop
+	// iteration grants cleanly. (A hard untrust already stops the loop via
+	// ChallengeShouldStop.)
+	if !provider.GrantHardwareIfNotUntrusted() {
 		s.ddIncr("mdm.verification", []string{"outcome:deferred-untrusted"})
 		return mdmVerifyTransient
 	}
-
-	// MDM SecurityInfo verification passed — upgrade to hardware trust.
 	provider.SetMDMFailureReason("")
-	provider.SetAttested(true, registry.TrustHardware)
 	s.sendTrustStatus(provider, registry.TrustHardware, "online", "MDM verification passed")
 	s.ddIncr("mdm.verification", []string{"outcome:granted"})
 	s.logger.Info("MDM verification passed — upgraded to hardware trust",
@@ -2505,15 +2503,16 @@ func (s *Server) ApplyLateSecurityInfo(udid string, info *mdm.SecurityInfoRespon
 		if dev == nil || dev.UDID != udid {
 			continue
 		}
-		// Skip if the provider became untrusted while the response was in flight —
-		// granting hardware would leave hardware/untrusted (routing rejects on
-		// Status) and falsely tell the provider it's online. Recovery flows through
-		// a passing SE challenge. Mirrors the verifyProviderViaMDM guard.
-		if c.provider.GetStatus() == registry.StatusUntrusted {
+		// Atomically grant unless the provider became untrusted while the response
+		// was in flight — granting then would leave hardware/untrusted (routing
+		// rejects on Status) and falsely tell the provider it's online. The
+		// check-and-grant is a single lock (closes the TOCTOU); recovery from a
+		// transient untrust flows through a passing SE challenge. Mirrors
+		// verifyProviderViaMDM.
+		if !c.provider.GrantHardwareIfNotUntrusted() {
 			continue
 		}
 		c.provider.SetMDMFailureReason("")
-		c.provider.SetAttested(true, registry.TrustHardware)
 		// Notify the connection, exactly like the synchronous success path —
 		// otherwise the daemon stays self_signed and doctor keeps warning
 		// MDM-pending even though the coordinator now routes it as hardware.
@@ -2521,6 +2520,9 @@ func (s *Server) ApplyLateSecurityInfo(udid string, info *mdm.SecurityInfoRespon
 		if s.metrics != nil {
 			s.metrics.IncCounter("mdm_late_securityinfo_upgrade_total")
 		}
+		// Also emit on the shared Datadog grant-rate metric so the late path is
+		// visible alongside synchronous grants (not just the in-process counter).
+		s.ddIncr("mdm.verification", []string{"outcome:granted-late"})
 		s.logger.Info("late SecurityInfo arrival — upgraded provider to hardware trust",
 			"provider_id", c.provider.ID,
 			"serial", c.serial,

--- a/coordinator/api/provider.go
+++ b/coordinator/api/provider.go
@@ -37,6 +37,7 @@ import (
 
 	"github.com/eigeninference/d-inference/coordinator/attestation"
 	"github.com/eigeninference/d-inference/coordinator/internal/e2e"
+	"github.com/eigeninference/d-inference/coordinator/mdm"
 	"github.com/eigeninference/d-inference/coordinator/payments"
 	"github.com/eigeninference/d-inference/coordinator/protocol"
 	"github.com/eigeninference/d-inference/coordinator/registry"
@@ -2458,6 +2459,75 @@ func (s *Server) verifyProviderViaMDM(ctx context.Context, providerID string, pr
 	// Enterprise Attestation Root CA.
 	s.verifyAppleDeviceAttestation(ctx, providerID, provider, attestResult, mdmResult.UDID)
 	return mdmVerifyGranted
+}
+
+// ApplyLateSecurityInfo retroactively upgrades a self_signed provider to hardware
+// when its SecurityInfo arrives AFTER the synchronous verify timed out (slow APNs
+// / Power Nap). It mirrors verifyProviderViaMDM's success path so the late path
+// doesn't drift from it: confirm posture (SIP on + Secure Boot full), match the
+// device by UDID, require a valid SE attestation, skip a provider that has since
+// become untrusted (granting would leave hardware/untrusted), and on success grant
+// hardware, clear the MDM failure reason, send a fresh hardware/online
+// trust_status (so the provider's daemon + doctor stop reporting MDM-pending), and
+// persist. Wired as the mdm.Client late-SecurityInfo callback.
+func (s *Server) ApplyLateSecurityInfo(udid string, info *mdm.SecurityInfoResponse) {
+	if s.mdmClient == nil || info == nil {
+		return
+	}
+	// Posture must be good — a late response that reports SIP off / Secure Boot
+	// not full is not a basis for promotion (and the sync path would have hard-
+	// untrusted it; here we simply don't upgrade).
+	if !info.SystemIntegrityProtectionEnabled || info.SecureBootLevel != "full" {
+		return
+	}
+	// Collect self_signed, valid-attestation candidates under the lock, then do
+	// MDM lookups outside it to avoid blocking heartbeats/routing.
+	type candidate struct {
+		provider *registry.Provider
+		serial   string
+	}
+	var candidates []candidate
+	s.registry.ForEachProvider(func(p *registry.Provider) {
+		p.Mu().Lock()
+		trust := p.TrustLevel
+		valid := p.AttestationResult != nil && p.AttestationResult.Valid
+		serial := ""
+		if p.AttestationResult != nil {
+			serial = p.AttestationResult.SerialNumber
+		}
+		p.Mu().Unlock()
+		if trust == registry.TrustSelfSigned && valid && serial != "" {
+			candidates = append(candidates, candidate{provider: p, serial: serial})
+		}
+	})
+	for _, c := range candidates {
+		dev, _ := s.mdmClient.LookupDevice(c.serial)
+		if dev == nil || dev.UDID != udid {
+			continue
+		}
+		// Skip if the provider became untrusted while the response was in flight —
+		// granting hardware would leave hardware/untrusted (routing rejects on
+		// Status) and falsely tell the provider it's online. Recovery flows through
+		// a passing SE challenge. Mirrors the verifyProviderViaMDM guard.
+		if c.provider.GetStatus() == registry.StatusUntrusted {
+			continue
+		}
+		c.provider.SetMDMFailureReason("")
+		c.provider.SetAttested(true, registry.TrustHardware)
+		// Notify the connection, exactly like the synchronous success path —
+		// otherwise the daemon stays self_signed and doctor keeps warning
+		// MDM-pending even though the coordinator now routes it as hardware.
+		s.sendTrustStatus(c.provider, registry.TrustHardware, "online", "MDM verification passed (late SecurityInfo)")
+		if s.metrics != nil {
+			s.metrics.IncCounter("mdm_late_securityinfo_upgrade_total")
+		}
+		s.logger.Info("late SecurityInfo arrival — upgraded provider to hardware trust",
+			"provider_id", c.provider.ID,
+			"serial", c.serial,
+			"udid", udid,
+		)
+		s.registry.PersistProvider(c.provider)
+	}
 }
 
 // mdmVerificationLoop owns MDM SecurityInfo verification for one provider

--- a/coordinator/api/provider.go
+++ b/coordinator/api/provider.go
@@ -2499,7 +2499,7 @@ func (s *Server) ApplyLateSecurityInfo(udid string, info *mdm.SecurityInfoRespon
 		}
 	})
 	for _, c := range candidates {
-		dev, _ := s.mdmClient.LookupDevice(c.serial)
+		dev, _ := s.mdmClient.LookupDevice(context.Background(), c.serial)
 		if dev == nil || dev.UDID != udid {
 			continue
 		}
@@ -2645,7 +2645,7 @@ func (s *Server) verifyAppleDeviceAttestation(ctx context.Context, providerID st
 
 	// Always send the raw plist command so the nonce reaches Apple's servers.
 	// The structured MicroMDM API doesn't support DeviceAttestationNonce.
-	_, err := s.mdmClient.SendDeviceAttestationCommand(udid, seKeyNonce)
+	_, err := s.mdmClient.SendDeviceAttestationCommand(ctx, udid, seKeyNonce)
 	if err != nil {
 		s.logger.Warn("failed to send DeviceInformation attestation command",
 			"provider_id", providerID,

--- a/coordinator/api/provider.go
+++ b/coordinator/api/provider.go
@@ -2314,13 +2314,14 @@ const (
 // an outcome metric, then returns an outcome the per-connection loop uses to
 // decide whether to retry. It NEVER marks a provider untrusted for a transient
 // failure (not-enrolled / timeout) — only for a genuine posture mismatch.
-func (s *Server) verifyProviderViaMDM(providerID string, provider *registry.Provider, attestResult attestation.VerificationResult) mdmVerifyOutcome {
+func (s *Server) verifyProviderViaMDM(ctx context.Context, providerID string, provider *registry.Provider, attestResult attestation.VerificationResult) mdmVerifyOutcome {
 	s.logger.Info("starting MDM verification",
 		"provider_id", providerID,
 		"serial_number", attestResult.SerialNumber,
 	)
 
 	mdmResult, err := s.mdmClient.VerifyProvider(
+		ctx,
 		attestResult.SerialNumber,
 		attestResult.SIPEnabled,
 		attestResult.SecureBootEnabled,
@@ -2355,16 +2356,26 @@ func (s *Server) verifyProviderViaMDM(providerID string, provider *registry.Prov
 	}
 
 	if mdmResult.Error != "" {
-		// A timeout means APN latency or device sleep — not evidence of
-		// compromise. Keep the provider at its current trust level (self_signed)
-		// instead of marking it untrusted, and let the loop retry.
-		if strings.Contains(mdmResult.Error, "timeout") {
-			s.logger.Warn("MDM verification timed out — staying at current trust level",
+		// Hard untrust ONLY for a genuine posture mismatch proven by a received
+		// SecurityInfo response (SecurityMismatch). Everything else with a non-empty
+		// error — a SecurityInfo timeout, a MicroMDM command-send/transport failure,
+		// a decode error, or a context cancellation on disconnect — is a "could not
+		// complete the check" condition: keep the provider at its current trust
+		// level (self_signed) and let the loop retry. Treating a transient MicroMDM
+		// API hiccup as a posture mismatch would wrongly hard-untrust an enrolled,
+		// genuinely-secure box.
+		if !mdmResult.SecurityMismatch {
+			reason := "error"
+			if strings.Contains(mdmResult.Error, "timeout") {
+				reason = "securityinfo-timeout"
+			}
+			s.logger.Warn("MDM verification did not complete — staying at current trust level",
 				"provider_id", providerID,
+				"reason", reason,
 				"error", mdmResult.Error,
 			)
-			provider.SetMDMFailureReason("securityinfo-timeout")
-			s.ddIncr("mdm.verification", []string{"outcome:securityinfo-timeout"})
+			provider.SetMDMFailureReason(reason)
+			s.ddIncr("mdm.verification", []string{"outcome:" + reason})
 			return mdmVerifyTransient
 		}
 		// A real posture mismatch (SIP disabled, Secure Boot not full, attestation
@@ -2381,6 +2392,15 @@ func (s *Server) verifyProviderViaMDM(providerID string, provider *registry.Prov
 		s.ddIncr("mdm.verification", []string{"outcome:posture-mismatch"})
 		s.registry.MarkUntrusted(providerID)
 		return mdmVerifyTerminal
+	}
+
+	// If the connection went away while we were waiting on SecurityInfo, do NOT
+	// mutate/persist trust for a provider that is no longer here — the next
+	// connection re-verifies from scratch (RestoreProviderState caps to
+	// self_signed). Treat as transient; the loop's ctx.Done will end it.
+	if ctx.Err() != nil {
+		provider.SetMDMFailureReason("securityinfo-timeout")
+		return mdmVerifyTransient
 	}
 
 	// MDM SecurityInfo verification passed — upgrade to hardware trust.
@@ -2403,7 +2423,7 @@ func (s *Server) verifyProviderViaMDM(providerID string, provider *registry.Prov
 	// certificate chain that proves this device's identity. This cert
 	// chain can be independently verified by users against Apple's
 	// Enterprise Attestation Root CA.
-	s.verifyAppleDeviceAttestation(providerID, provider, attestResult, mdmResult.UDID)
+	s.verifyAppleDeviceAttestation(ctx, providerID, provider, attestResult, mdmResult.UDID)
 	return mdmVerifyGranted
 }
 
@@ -2450,7 +2470,17 @@ func (s *Server) mdmVerificationLoop(ctx context.Context, providerID string, pro
 		if provider.GetTrustLevel() == registry.TrustHardware {
 			return
 		}
-		switch s.verifyProviderViaMDM(providerID, provider, *result) {
+		// Stop if the provider was HARD-untrusted out-of-band (e.g. the challenge
+		// loop saw SIP disabled or a binary-hash change). Re-granting hardware to a
+		// hard-untrusted provider would leave TrustLevel=hardware while
+		// Status=untrusted — an inconsistent state. A hard untrust recovers only by
+		// reconnect, which restarts this loop. A *transient* untrust (missed-
+		// challenge timeouts) is intentionally NOT a stop: it can recover on a later
+		// passing challenge, after which MDM should still be able to grant hardware.
+		if provider.ChallengeShouldStop() {
+			return
+		}
+		switch s.verifyProviderViaMDM(ctx, providerID, provider, *result) {
 		case mdmVerifyGranted, mdmVerifyTerminal:
 			return
 		}
@@ -2469,7 +2499,7 @@ func (s *Server) mdmVerificationLoop(ctx context.Context, providerID string, pro
 
 // verifyAppleDeviceAttestation sends a DeviceInformation command requesting
 // DevicePropertiesAttestation and verifies the Apple-signed certificate chain.
-func (s *Server) verifyAppleDeviceAttestation(providerID string, provider *registry.Provider, attestResult attestation.VerificationResult, udid string) {
+func (s *Server) verifyAppleDeviceAttestation(ctx context.Context, providerID string, provider *registry.Provider, attestResult attestation.VerificationResult, udid string) {
 	if udid == "" {
 		s.logger.Warn("no UDID for MDA verification", "provider_id", providerID)
 		return
@@ -2510,7 +2540,7 @@ func (s *Server) verifyAppleDeviceAttestation(providerID string, provider *regis
 	}
 
 	// Wait for Apple's response (device contacts Apple's servers — may take longer)
-	attestResp, err := s.mdmClient.WaitForDeviceAttestation(udid, 60*time.Second)
+	attestResp, err := s.mdmClient.WaitForDeviceAttestation(ctx, udid, 60*time.Second)
 	if err != nil {
 		s.logger.Warn("DevicePropertiesAttestation response timeout",
 			"provider_id", providerID,
@@ -2689,17 +2719,24 @@ func (s *Server) handleProviderAttestation(w http.ResponseWriter, r *http.Reques
 			pa.SEPublicKey = attestResult.PublicKey
 		}
 
-		// Include MDA cert chain for independent verification
-		if len(mdaCertChain) > 0 {
-			for _, der := range mdaCertChain {
-				pa.MDACertChain = append(pa.MDACertChain, base64.StdEncoding.EncodeToString(der))
+		// Include the MDA cert chain + parsed fields for independent verification
+		// ONLY for a connection currently holding hardware trust — same gate as the
+		// mda_verified boolean above. The late-MDA callback (main.go) can attach a
+		// cert chain to a provider that has since reconnected as self_signed; without
+		// this gate the endpoint would emit mda_verified=false alongside a non-empty
+		// mda_cert_chain_b64/serial/udid, which is exactly the drift this fix removes.
+		if isHardware {
+			if len(mdaCertChain) > 0 {
+				for _, der := range mdaCertChain {
+					pa.MDACertChain = append(pa.MDACertChain, base64.StdEncoding.EncodeToString(der))
+				}
 			}
-		}
-		if mdaResult != nil {
-			pa.MDASerial = mdaResult.DeviceSerial
-			pa.MDAUDID = mdaResult.DeviceUDID
-			pa.MDAOSVersion = mdaResult.OSVersion
-			pa.MDASepVersion = mdaResult.SepOSVersion
+			if mdaResult != nil {
+				pa.MDASerial = mdaResult.DeviceSerial
+				pa.MDAUDID = mdaResult.DeviceUDID
+				pa.MDAOSVersion = mdaResult.OSVersion
+				pa.MDASepVersion = mdaResult.SepOSVersion
+			}
 		}
 
 		providers = append(providers, pa)

--- a/coordinator/api/provider_mdm_reliability_test.go
+++ b/coordinator/api/provider_mdm_reliability_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -35,6 +36,11 @@ type fakeMDMServer struct {
 	// blocking 60s waiting for an Apple attestation webhook in the success test.
 	failMDARawCommand bool
 
+	// failSecurityInfoCommand makes POST /v1/commands (the SecurityInfo enqueue)
+	// return a 500 so mdm.SendSecurityInfoCommand errors — simulating a transient
+	// MicroMDM transport failure. This must NOT hard-untrust an enrolled provider.
+	failSecurityInfoCommand bool
+
 	pushedUDIDs []string
 }
 
@@ -59,7 +65,13 @@ func (f *fakeMDMServer) handler() http.Handler {
 		_, _ = io.Copy(io.Discard, r.Body)
 		f.mu.Lock()
 		uuid := f.commandUUID
+		fail := f.failSecurityInfoCommand
 		f.mu.Unlock()
+		if fail {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte("micromdm unavailable"))
+			return
+		}
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"payload":{"command_uuid":"` + uuid + `"}}`))
 	})
@@ -196,7 +208,7 @@ func TestVerifyProviderViaMDM_PostureMismatchTerminal(t *testing.T) {
 	// MDM says SIP=false (mismatch vs attestation SIP=true) → posture mismatch.
 	deliverWebhookWhenPushed(srv, fake, "UDID-1", "cmd-mismatch", false /*sip*/, true)
 
-	outcome := srv.verifyProviderViaMDM("prov-mdm", p, attestResultOf(p))
+	outcome := srv.verifyProviderViaMDM(context.Background(), "prov-mdm", p, attestResultOf(p))
 
 	if outcome != mdmVerifyTerminal {
 		t.Errorf("outcome = %v, want mdmVerifyTerminal", outcome)
@@ -233,7 +245,7 @@ func TestVerifyProviderViaMDM_TimeoutTransient(t *testing.T) {
 	srv, p := mdmReliabilityServer(t, fake)
 
 	// Deliberately never deliver a webhook → WaitForSecurityInfo times out.
-	outcome := srv.verifyProviderViaMDM("prov-mdm", p, attestResultOf(p))
+	outcome := srv.verifyProviderViaMDM(context.Background(), "prov-mdm", p, attestResultOf(p))
 
 	if outcome != mdmVerifyTransient {
 		t.Errorf("outcome = %v, want mdmVerifyTransient", outcome)
@@ -256,7 +268,7 @@ func TestVerifyProviderViaMDM_DeviceNotFoundTransient(t *testing.T) {
 	fake := &fakeMDMServer{device: nil, commandUUID: "unused"}
 	srv, p := mdmReliabilityServer(t, fake)
 
-	outcome := srv.verifyProviderViaMDM("prov-mdm", p, attestResultOf(p))
+	outcome := srv.verifyProviderViaMDM(context.Background(), "prov-mdm", p, attestResultOf(p))
 
 	if outcome != mdmVerifyTransient {
 		t.Errorf("outcome = %v, want mdmVerifyTransient", outcome)
@@ -289,7 +301,7 @@ func TestVerifyProviderViaMDM_SuccessGranted(t *testing.T) {
 
 	deliverWebhookWhenPushed(srv, fake, "UDID-1", "cmd-ok", true /*sip*/, true /*secureboot*/)
 
-	outcome := srv.verifyProviderViaMDM("prov-mdm", p, attestResultOf(p))
+	outcome := srv.verifyProviderViaMDM(context.Background(), "prov-mdm", p, attestResultOf(p))
 
 	if outcome != mdmVerifyGranted {
 		t.Errorf("outcome = %v, want mdmVerifyGranted", outcome)
@@ -385,5 +397,103 @@ func TestProviderAttestationGatesProofsOnHardware(t *testing.T) {
 	}
 	if !hw.mdm || !hw.mda || !hw.acme {
 		t.Errorf("hardware proofs should all be true, got mdm=%v mda=%v acme=%v", hw.mdm, hw.mda, hw.acme)
+	}
+}
+
+// TestVerifyProviderViaMDM_TransportErrorTransient is the regression for the
+// classifier bug where a non-timeout MicroMDM error (e.g. the SecurityInfo
+// command enqueue failing — HTTP 500 / decode error) was treated as a posture
+// mismatch and hard-untrusted an enrolled, genuinely-secure provider. A transport
+// failure proves nothing about posture (SecurityMismatch=false), so it must be
+// transient ("error") and must NOT untrust.
+func TestVerifyProviderViaMDM_TransportErrorTransient(t *testing.T) {
+	fake := &fakeMDMServer{
+		device:                  &mdm.DeviceInfo{SerialNumber: "SERIAL-1", UDID: "UDID-1", EnrollmentStatus: true},
+		commandUUID:             "cmd-unused",
+		failSecurityInfoCommand: true, // POST /v1/commands → 500 → SendSecurityInfoCommand errors
+	}
+	srv, p := mdmReliabilityServer(t, fake)
+
+	outcome := srv.verifyProviderViaMDM(context.Background(), "prov-mdm", p, attestResultOf(p))
+
+	if outcome != mdmVerifyTransient {
+		t.Errorf("outcome = %v, want mdmVerifyTransient (transport error is not a posture mismatch)", outcome)
+	}
+	if got := p.GetMDMFailureReason(); got != "error" {
+		t.Errorf("MDMFailureReason = %q, want %q", got, "error")
+	}
+	if lvl := p.GetTrustLevel(); lvl != registry.TrustSelfSigned {
+		t.Errorf("trust = %q, want %q (transport error must not change trust)", lvl, registry.TrustSelfSigned)
+	}
+	if status := srv.registry.GetProvider("prov-mdm").GetStatus(); status == registry.StatusUntrusted {
+		t.Error("a transient MicroMDM transport error must NOT hard-untrust an enrolled provider")
+	}
+}
+
+// TestProviderAttestationGatesMDAPayloadOnHardware is the regression for the
+// drift where /v1/providers/attestation gated the mda_verified boolean on
+// hardware but still emitted the MDA cert chain + serial/udid payload (which the
+// late-MDA callback can attach to a since-reconnected self_signed provider). The
+// whole MDA payload must be suppressed for non-hardware connections, so the
+// endpoint can never show mda_verified=false alongside a populated cert chain.
+func TestProviderAttestationGatesMDAPayloadOnHardware(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	st := store.NewMemory(store.Config{AdminKey: "test-key"})
+	reg := registry.New(logger)
+	srv := NewServer(reg, st, ServerConfig{}, logger)
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	mk := func(id, model string, trust registry.TrustLevel) {
+		msg := &protocol.RegisterMessage{
+			Type:      protocol.TypeRegister,
+			Hardware:  protocol.Hardware{ChipName: "Apple M3 Max", MemoryGB: 64},
+			Models:    []protocol.ModelInfo{{ID: model, ModelType: "chat", Quantization: "4bit"}},
+			Backend:   "mlx-swift",
+			PublicKey: testPublicKeyB64(),
+		}
+		p := reg.Register(id, nil, msg)
+		p.Mu().Lock()
+		p.TrustLevel = trust
+		p.MDAVerified = true
+		p.MDACertChain = [][]byte{[]byte("der-leaf"), []byte("der-intermediate")}
+		p.MDAResult = &attestation.MDAResult{DeviceSerial: "MDA-" + id, DeviceUDID: "UDID-" + id, OSVersion: "26.5"}
+		p.AttestationResult = &attestation.VerificationResult{SerialNumber: "S-" + id, SIPEnabled: true, SecureBootEnabled: true}
+		p.Mu().Unlock()
+	}
+	mk("ss-payload", "m-ss", registry.TrustSelfSigned)
+	mk("hw-payload", "m-hw", registry.TrustHardware)
+
+	resp, err := http.Get(ts.URL + "/v1/providers/attestation")
+	if err != nil {
+		t.Fatalf("GET attestation: %v", err)
+	}
+	defer resp.Body.Close()
+
+	var parsed struct {
+		Providers []struct {
+			ProviderID   string   `json:"provider_id"`
+			MDAVerified  bool     `json:"mda_verified"`
+			MDACertChain []string `json:"mda_cert_chain_b64"`
+			MDASerial    string   `json:"mda_serial"`
+			MDAUDID      string   `json:"mda_udid"`
+		} `json:"providers"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	for _, pr := range parsed.Providers {
+		switch pr.ProviderID {
+		case "ss-payload":
+			if pr.MDAVerified || len(pr.MDACertChain) != 0 || pr.MDASerial != "" || pr.MDAUDID != "" {
+				t.Errorf("self_signed provider leaked MDA payload: verified=%v chain=%d serial=%q udid=%q",
+					pr.MDAVerified, len(pr.MDACertChain), pr.MDASerial, pr.MDAUDID)
+			}
+		case "hw-payload":
+			if !pr.MDAVerified || len(pr.MDACertChain) != 2 || pr.MDASerial == "" {
+				t.Errorf("hardware provider should expose MDA payload: verified=%v chain=%d serial=%q",
+					pr.MDAVerified, len(pr.MDACertChain), pr.MDASerial)
+			}
+		}
 	}
 }

--- a/coordinator/api/provider_mdm_reliability_test.go
+++ b/coordinator/api/provider_mdm_reliability_test.go
@@ -71,12 +71,22 @@ func (f *fakeMDMServer) handler() http.Handler {
 		_ = json.NewEncoder(w).Encode(resp)
 	})
 
-	// SecurityInfo command (structured endpoint).
+	// SecurityInfo command (structured endpoint). MicroMDM's POST /v1/commands
+	// enqueues AND sends the APNs push itself, so we record a push here to model
+	// that auto-push (the coordinator no longer issues a separate GET /push for
+	// SecurityInfo). pushCount() rising is how deliverWebhookWhenPushed knows the
+	// command went out.
 	mux.HandleFunc("POST /v1/commands", func(w http.ResponseWriter, r *http.Request) {
-		_, _ = io.Copy(io.Discard, r.Body)
+		var body struct {
+			UDID string `json:"udid"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&body)
 		f.mu.Lock()
 		uuid := f.commandUUID
 		fail := f.failSecurityInfoCommand
+		if !fail {
+			f.pushedUDIDs = append(f.pushedUDIDs, body.UDID) // MicroMDM auto-push
+		}
 		f.mu.Unlock()
 		if fail {
 			w.WriteHeader(http.StatusInternalServerError)

--- a/coordinator/api/provider_mdm_reliability_test.go
+++ b/coordinator/api/provider_mdm_reliability_test.go
@@ -601,3 +601,27 @@ func TestApplyLateSecurityInfo_SkipsUntrusted(t *testing.T) {
 		t.Error("must NOT grant hardware to an untrusted provider via the late path")
 	}
 }
+
+// TestVerifyProviderViaMDM_DefersGrantWhenUntrusted covers the atomic
+// GrantHardwareIfNotUntrusted guard: even a fully-passing SecurityInfo must NOT
+// promote a provider that is currently untrusted (a challenge-loop deroute racing
+// the in-flight verify), which would otherwise leave hardware/untrusted.
+func TestVerifyProviderViaMDM_DefersGrantWhenUntrusted(t *testing.T) {
+	fake := &fakeMDMServer{
+		device:            &mdm.DeviceInfo{SerialNumber: "SERIAL-1", UDID: "UDID-1", EnrollmentStatus: true},
+		commandUUID:       "cmd-ok",
+		failMDARawCommand: true,
+	}
+	srv, p := mdmReliabilityServer(t, fake)
+	srv.registry.MarkUntrusted("prov-mdm") // deroute lands while MDM verify is in flight
+	deliverWebhookWhenPushed(srv, fake, "UDID-1", "cmd-ok", true, true)
+
+	outcome := srv.verifyProviderViaMDM(context.Background(), "prov-mdm", p, attestResultOf(p))
+
+	if outcome != mdmVerifyTransient {
+		t.Errorf("outcome = %v, want mdmVerifyTransient (must not grant while untrusted)", outcome)
+	}
+	if lvl := p.GetTrustLevel(); lvl == registry.TrustHardware {
+		t.Error("must NOT grant hardware to an untrusted provider (would leave hardware/untrusted)")
+	}
+}

--- a/coordinator/api/provider_mdm_reliability_test.go
+++ b/coordinator/api/provider_mdm_reliability_test.go
@@ -1,0 +1,389 @@
+package api
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/attestation"
+	"github.com/eigeninference/d-inference/coordinator/mdm"
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+	"github.com/eigeninference/d-inference/coordinator/registry"
+	"github.com/eigeninference/d-inference/coordinator/store"
+)
+
+// fakeMDMServer is a minimal MicroMDM stand-in for exercising
+// verifyProviderViaMDM against a real *mdm.Client over HTTP. The test drives the
+// SecurityInfo response itself by calling mdmClient.HandleWebhook with a webhook
+// body whose CommandUUID matches the one this server hands out.
+type fakeMDMServer struct {
+	mu sync.Mutex
+
+	device      *mdm.DeviceInfo // nil → device-not-found
+	commandUUID string          // returned by POST /v1/commands
+
+	// failMDARawCommand makes POST /v1/commands/{udid} (the raw-plist MDA path)
+	// return 500 so verifyAppleDeviceAttestation aborts immediately instead of
+	// blocking 60s waiting for an Apple attestation webhook in the success test.
+	failMDARawCommand bool
+
+	pushedUDIDs []string
+}
+
+func (f *fakeMDMServer) handler() http.Handler {
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("POST /v1/devices", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.Copy(io.Discard, r.Body)
+		f.mu.Lock()
+		dev := f.device
+		f.mu.Unlock()
+		resp := map[string]any{"devices": []mdm.DeviceInfo{}}
+		if dev != nil {
+			resp["devices"] = []mdm.DeviceInfo{*dev}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	})
+
+	// SecurityInfo command (structured endpoint).
+	mux.HandleFunc("POST /v1/commands", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.Copy(io.Discard, r.Body)
+		f.mu.Lock()
+		uuid := f.commandUUID
+		f.mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"payload":{"command_uuid":"` + uuid + `"}}`))
+	})
+
+	// MDA raw-plist command (POST /v1/commands/{udid}).
+	mux.HandleFunc("POST /v1/commands/{udid}", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.Copy(io.Discard, r.Body)
+		f.mu.Lock()
+		fail := f.failMDARawCommand
+		f.mu.Unlock()
+		if fail {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte("mda unavailable in test"))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	})
+
+	mux.HandleFunc("GET /push/{udid}", func(w http.ResponseWriter, r *http.Request) {
+		f.mu.Lock()
+		f.pushedUDIDs = append(f.pushedUDIDs, r.PathValue("udid"))
+		f.mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	})
+
+	return mux
+}
+
+func (f *fakeMDMServer) pushCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.pushedUDIDs)
+}
+
+// securityInfoWebhook builds a MicroMDM acknowledge webhook body carrying a
+// SecurityInfo plist with the given CommandUUID and SIP/SecureBoot posture.
+func securityInfoWebhook(udid, commandUUID string, sipEnabled bool, secureBootFull bool) []byte {
+	sip := "<false/>"
+	if sipEnabled {
+		sip = "<true/>"
+	}
+	sb := "reduced"
+	if secureBootFull {
+		sb = "full"
+	}
+	plist := fmt.Sprintf(`<?xml version="1.0"?><plist version="1.0"><dict>`+
+		`<key>CommandUUID</key><string>%s</string>`+
+		`<key>Status</key><string>Acknowledged</string>`+
+		`<key>SecurityInfo</key><dict>`+
+		`<key>SystemIntegrityProtectionEnabled</key>%s`+
+		`<key>SecureBootLevel</key><string>%s</string>`+
+		`</dict></dict></plist>`, commandUUID, sip, sb)
+	body, _ := json.Marshal(map[string]any{
+		"topic": "mdm.Acknowledge",
+		"acknowledge_event": map[string]string{
+			"udid":        udid,
+			"status":      "Acknowledged",
+			"raw_payload": base64.StdEncoding.EncodeToString([]byte(plist)),
+		},
+	})
+	return body
+}
+
+// mdmReliabilityServer builds a coordinator Server wired to a fake MicroMDM and
+// registers one provider holding a valid attestation result (serial + SIP +
+// SecureBoot + SE public key), at self_signed trust. It returns the server, the
+// fake, and the live *registry.Provider.
+func mdmReliabilityServer(t *testing.T, fake *fakeMDMServer) (*Server, *registry.Provider) {
+	t.Helper()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	st := store.NewMemory(store.Config{AdminKey: "test-key"})
+	reg := registry.New(logger)
+	srv := NewServer(reg, st, ServerConfig{}, logger)
+
+	ts := httptest.NewServer(fake.handler())
+	t.Cleanup(ts.Close)
+	srv.SetMDMClient(mdm.NewClient(ts.URL, "test-key", slog.New(slog.NewTextHandler(io.Discard, nil))))
+
+	msg := &protocol.RegisterMessage{
+		Type:      protocol.TypeRegister,
+		Hardware:  protocol.Hardware{ChipName: "Apple M3 Max", MemoryGB: 64},
+		Models:    []protocol.ModelInfo{{ID: "mdm-model", ModelType: "chat", Quantization: "4bit"}},
+		Backend:   "mlx-swift",
+		PublicKey: testPublicKeyB64(),
+	}
+	p := reg.Register("prov-mdm", nil, msg)
+	p.Mu().Lock()
+	p.TrustLevel = registry.TrustSelfSigned
+	p.AttestationResult = &attestation.VerificationResult{
+		SerialNumber:      "SERIAL-1",
+		SIPEnabled:        true,
+		SecureBootEnabled: true,
+		PublicKey:         "se-pub-key-bytes",
+	}
+	p.Mu().Unlock()
+	return srv, p
+}
+
+func attestResultOf(p *registry.Provider) attestation.VerificationResult {
+	p.Mu().Lock()
+	defer p.Mu().Unlock()
+	return *p.AttestationResult
+}
+
+// deliverWebhookWhenPushed waits until the fake server records a push (proving
+// SendSecurityInfoCommand ran and the command UUID is tracked + a waiter is
+// registered), then delivers the SecurityInfo webhook. Runs in a goroutine.
+func deliverWebhookWhenPushed(srv *Server, fake *fakeMDMServer, udid, commandUUID string, sip, secureBoot bool) {
+	go func() {
+		deadline := time.Now().Add(3 * time.Second)
+		for time.Now().Before(deadline) {
+			if fake.pushCount() > 0 {
+				break
+			}
+			time.Sleep(5 * time.Millisecond)
+		}
+		time.Sleep(20 * time.Millisecond)
+		srv.mdmClient.HandleWebhook(securityInfoWebhook(udid, commandUUID, sip, secureBoot))
+	}()
+}
+
+// TestVerifyProviderViaMDM_PostureMismatchTerminal: MDM reports SIP disabled,
+// which contradicts the provider's attestation. This is a real posture mismatch
+// → terminal outcome, the provider is hard-untrusted, and the failure reason is
+// bucketed as "posture-mismatch".
+func TestVerifyProviderViaMDM_PostureMismatchTerminal(t *testing.T) {
+	fake := &fakeMDMServer{
+		device:      &mdm.DeviceInfo{SerialNumber: "SERIAL-1", UDID: "UDID-1", EnrollmentStatus: true},
+		commandUUID: "cmd-mismatch",
+	}
+	srv, p := mdmReliabilityServer(t, fake)
+
+	// MDM says SIP=false (mismatch vs attestation SIP=true) → posture mismatch.
+	deliverWebhookWhenPushed(srv, fake, "UDID-1", "cmd-mismatch", false /*sip*/, true)
+
+	outcome := srv.verifyProviderViaMDM("prov-mdm", p, attestResultOf(p))
+
+	if outcome != mdmVerifyTerminal {
+		t.Errorf("outcome = %v, want mdmVerifyTerminal", outcome)
+	}
+	if got := p.GetMDMFailureReason(); got != "posture-mismatch" {
+		t.Errorf("MDMFailureReason = %q, want %q", got, "posture-mismatch")
+	}
+	if status := srv.registry.GetProvider("prov-mdm").GetStatus(); status != registry.StatusUntrusted {
+		t.Errorf("status = %q, want %q (posture mismatch must mark untrusted)", status, registry.StatusUntrusted)
+	}
+}
+
+// TestVerifyProviderViaMDM_TimeoutTransient: device enrolled but no SecurityInfo
+// webhook ever arrives → the waiter times out. A timeout is APN latency / device
+// sleep, NOT evidence of compromise: outcome is transient, the provider is NOT
+// marked untrusted, trust stays self_signed, and the reason is
+// "securityinfo-timeout".
+//
+// VerifyProvider's WaitForSecurityInfo timeout is hardcoded at 90s and cannot be
+// shortened without editing source, so this end-to-end timeout test is OPT-IN
+// (set RUN_MDM_TIMEOUT_TEST=1) to keep the default suite fast and deterministic.
+// The fast, deterministic proof that a "timeout" error string drives the
+// securityinfo-timeout bucket lives in the mdm package
+// (TestVerifyProviderTimeoutErrorString, 50ms) plus the classification logic
+// exercised by the other outcomes here.
+func TestVerifyProviderViaMDM_TimeoutTransient(t *testing.T) {
+	if os.Getenv("RUN_MDM_TIMEOUT_TEST") != "1" {
+		t.Skip("opt-in: set RUN_MDM_TIMEOUT_TEST=1 (exercises the real 90s SecurityInfo wait)")
+	}
+	fake := &fakeMDMServer{
+		device:      &mdm.DeviceInfo{SerialNumber: "SERIAL-1", UDID: "UDID-1", EnrollmentStatus: true},
+		commandUUID: "cmd-timeout",
+	}
+	srv, p := mdmReliabilityServer(t, fake)
+
+	// Deliberately never deliver a webhook → WaitForSecurityInfo times out.
+	outcome := srv.verifyProviderViaMDM("prov-mdm", p, attestResultOf(p))
+
+	if outcome != mdmVerifyTransient {
+		t.Errorf("outcome = %v, want mdmVerifyTransient", outcome)
+	}
+	if got := p.GetMDMFailureReason(); got != "securityinfo-timeout" {
+		t.Errorf("MDMFailureReason = %q, want %q", got, "securityinfo-timeout")
+	}
+	if lvl := p.GetTrustLevel(); lvl != registry.TrustSelfSigned {
+		t.Errorf("trust = %q, want %q (timeout must not change trust)", lvl, registry.TrustSelfSigned)
+	}
+	if status := srv.registry.GetProvider("prov-mdm").GetStatus(); status == registry.StatusUntrusted {
+		t.Error("timeout must NOT mark provider untrusted")
+	}
+}
+
+// TestVerifyProviderViaMDM_DeviceNotFoundTransient: MicroMDM has no record of
+// the serial → transient outcome (provider may simply not have enrolled yet)
+// and the reason buckets as "device-not-found". Trust is untouched.
+func TestVerifyProviderViaMDM_DeviceNotFoundTransient(t *testing.T) {
+	fake := &fakeMDMServer{device: nil, commandUUID: "unused"}
+	srv, p := mdmReliabilityServer(t, fake)
+
+	outcome := srv.verifyProviderViaMDM("prov-mdm", p, attestResultOf(p))
+
+	if outcome != mdmVerifyTransient {
+		t.Errorf("outcome = %v, want mdmVerifyTransient", outcome)
+	}
+	if got := p.GetMDMFailureReason(); got != "device-not-found" {
+		t.Errorf("MDMFailureReason = %q, want %q", got, "device-not-found")
+	}
+	if lvl := p.GetTrustLevel(); lvl != registry.TrustSelfSigned {
+		t.Errorf("trust = %q, want %q (not-found must not change trust)", lvl, registry.TrustSelfSigned)
+	}
+	if status := srv.registry.GetProvider("prov-mdm").GetStatus(); status == registry.StatusUntrusted {
+		t.Error("device-not-found must NOT mark provider untrusted")
+	}
+}
+
+// TestVerifyProviderViaMDM_SuccessGranted: device enrolled + SecurityInfo
+// confirms SIP enabled & Secure Boot full matching attestation → granted
+// outcome, trust upgrades to hardware, and the failure reason is cleared. The
+// fake fails the downstream MDA raw command so verifyAppleDeviceAttestation
+// returns immediately (the upgrade has already happened by then).
+func TestVerifyProviderViaMDM_SuccessGranted(t *testing.T) {
+	fake := &fakeMDMServer{
+		device:            &mdm.DeviceInfo{SerialNumber: "SERIAL-1", UDID: "UDID-1", EnrollmentStatus: true},
+		commandUUID:       "cmd-ok",
+		failMDARawCommand: true,
+	}
+	srv, p := mdmReliabilityServer(t, fake)
+	// Seed a stale failure reason to prove success clears it.
+	p.SetMDMFailureReason("securityinfo-timeout")
+
+	deliverWebhookWhenPushed(srv, fake, "UDID-1", "cmd-ok", true /*sip*/, true /*secureboot*/)
+
+	outcome := srv.verifyProviderViaMDM("prov-mdm", p, attestResultOf(p))
+
+	if outcome != mdmVerifyGranted {
+		t.Errorf("outcome = %v, want mdmVerifyGranted", outcome)
+	}
+	if lvl := p.GetTrustLevel(); lvl != registry.TrustHardware {
+		t.Errorf("trust = %q, want %q after success", lvl, registry.TrustHardware)
+	}
+	if got := p.GetMDMFailureReason(); got != "" {
+		t.Errorf("MDMFailureReason = %q, want empty after success", got)
+	}
+}
+
+// TestProviderAttestationGatesProofsOnHardware is the drift guard for
+// GET /v1/providers/attestation: a self_signed provider that (incorrectly) has
+// MDAVerified/ACMEVerified=true set must report mda_verified=false /
+// acme_verified=false / mdm_verified=false, while a hardware provider with the
+// same flags reports them true. All three are gated on the live trust level.
+func TestProviderAttestationGatesProofsOnHardware(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	st := store.NewMemory(store.Config{AdminKey: "test-key"})
+	reg := registry.New(logger)
+	srv := NewServer(reg, st, ServerConfig{}, logger)
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	mk := func(id, model string, trust registry.TrustLevel) {
+		msg := &protocol.RegisterMessage{
+			Type:      protocol.TypeRegister,
+			Hardware:  protocol.Hardware{ChipName: "Apple M3 Max", MemoryGB: 64},
+			Models:    []protocol.ModelInfo{{ID: model, ModelType: "chat", Quantization: "4bit"}},
+			Backend:   "mlx-swift",
+			PublicKey: testPublicKeyB64(),
+		}
+		p := reg.Register(id, nil, msg)
+		p.Mu().Lock()
+		p.TrustLevel = trust
+		// Drift: set the hardware proof flags true regardless of trust level.
+		p.MDAVerified = true
+		p.ACMEVerified = true
+		p.AttestationResult = &attestation.VerificationResult{SerialNumber: "S-" + id, SIPEnabled: true, SecureBootEnabled: true}
+		p.Mu().Unlock()
+	}
+	mk("self-signed-prov", "model-ss", registry.TrustSelfSigned)
+	mk("hardware-prov", "model-hw", registry.TrustHardware)
+
+	resp, err := http.Get(ts.URL + "/v1/providers/attestation")
+	if err != nil {
+		t.Fatalf("GET attestation: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+
+	var parsed struct {
+		Providers []struct {
+			ProviderID   string `json:"provider_id"`
+			TrustLevel   string `json:"trust_level"`
+			MDMVerified  bool   `json:"mdm_verified"`
+			MDAVerified  bool   `json:"mda_verified"`
+			ACMEVerified bool   `json:"acme_verified"`
+		} `json:"providers"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	byID := map[string]struct {
+		trust          string
+		mdm, mda, acme bool
+	}{}
+	for _, pr := range parsed.Providers {
+		byID[pr.ProviderID] = struct {
+			trust          string
+			mdm, mda, acme bool
+		}{pr.TrustLevel, pr.MDMVerified, pr.MDAVerified, pr.ACMEVerified}
+	}
+
+	ss, ok := byID["self-signed-prov"]
+	if !ok {
+		t.Fatal("self-signed-prov missing from attestation response")
+	}
+	if ss.trust != string(registry.TrustSelfSigned) {
+		t.Errorf("self-signed trust_level = %q, want self_signed", ss.trust)
+	}
+	if ss.mdm || ss.mda || ss.acme {
+		t.Errorf("self_signed proofs must all be false despite drift flags, got mdm=%v mda=%v acme=%v", ss.mdm, ss.mda, ss.acme)
+	}
+
+	hw, ok := byID["hardware-prov"]
+	if !ok {
+		t.Fatal("hardware-prov missing from attestation response")
+	}
+	if !hw.mdm || !hw.mda || !hw.acme {
+		t.Errorf("hardware proofs should all be true, got mdm=%v mda=%v acme=%v", hw.mdm, hw.mda, hw.acme)
+	}
+}

--- a/coordinator/api/provider_mdm_reliability_test.go
+++ b/coordinator/api/provider_mdm_reliability_test.go
@@ -556,3 +556,48 @@ func TestVerifyProviderViaMDM_LookupFailureBucketsAsError(t *testing.T) {
 		t.Errorf("MDMFailureReason = %q, want %q (MDM transport failure is not an enrollment problem)", got, "error")
 	}
 }
+
+// TestApplyLateSecurityInfo_GrantsAndClears: a late SecurityInfo (after the sync
+// wait timed out) for a self_signed, online, valid-attestation provider upgrades
+// it to hardware and clears the failure reason — mirroring the sync success path.
+func TestApplyLateSecurityInfo_GrantsAndClears(t *testing.T) {
+	fake := &fakeMDMServer{
+		device:      &mdm.DeviceInfo{SerialNumber: "SERIAL-1", UDID: "UDID-1", EnrollmentStatus: true},
+		commandUUID: "unused",
+	}
+	srv, p := mdmReliabilityServer(t, fake)
+	p.SetMDMFailureReason("securityinfo-timeout") // left behind by the timed-out sync attempt
+
+	srv.ApplyLateSecurityInfo("UDID-1", &mdm.SecurityInfoResponse{
+		SystemIntegrityProtectionEnabled: true,
+		SecureBootLevel:                  "full",
+	})
+
+	if lvl := p.GetTrustLevel(); lvl != registry.TrustHardware {
+		t.Errorf("trust = %q, want hardware after late SecurityInfo", lvl)
+	}
+	if got := p.GetMDMFailureReason(); got != "" {
+		t.Errorf("MDMFailureReason = %q, want cleared", got)
+	}
+}
+
+// TestApplyLateSecurityInfo_SkipsUntrusted: if the provider became untrusted while
+// the SecurityInfo response was in flight, the late path must NOT grant hardware
+// (that would leave hardware/untrusted). Mirrors the sync-path status guard.
+func TestApplyLateSecurityInfo_SkipsUntrusted(t *testing.T) {
+	fake := &fakeMDMServer{
+		device:      &mdm.DeviceInfo{SerialNumber: "SERIAL-1", UDID: "UDID-1", EnrollmentStatus: true},
+		commandUUID: "unused",
+	}
+	srv, p := mdmReliabilityServer(t, fake)
+	srv.registry.MarkUntrusted("prov-mdm") // hard deroute while MDM was in flight
+
+	srv.ApplyLateSecurityInfo("UDID-1", &mdm.SecurityInfoResponse{
+		SystemIntegrityProtectionEnabled: true,
+		SecureBootLevel:                  "full",
+	})
+
+	if lvl := p.GetTrustLevel(); lvl == registry.TrustHardware {
+		t.Error("must NOT grant hardware to an untrusted provider via the late path")
+	}
+}

--- a/coordinator/api/provider_mdm_reliability_test.go
+++ b/coordinator/api/provider_mdm_reliability_test.go
@@ -41,6 +41,11 @@ type fakeMDMServer struct {
 	// MicroMDM transport failure. This must NOT hard-untrust an enrolled provider.
 	failSecurityInfoCommand bool
 
+	// failDeviceLookup makes POST /v1/devices return 500 so mdm.LookupDevice errors
+	// ("device lookup failed: ...") — simulating a MicroMDM outage. The device may
+	// be enrolled; this must bucket as "error", not an enrollment failure.
+	failDeviceLookup bool
+
 	pushedUDIDs []string
 }
 
@@ -51,7 +56,13 @@ func (f *fakeMDMServer) handler() http.Handler {
 		_, _ = io.Copy(io.Discard, r.Body)
 		f.mu.Lock()
 		dev := f.device
+		failLookup := f.failDeviceLookup
 		f.mu.Unlock()
+		if failLookup {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte("micromdm device lookup unavailable"))
+			return
+		}
 		resp := map[string]any{"devices": []mdm.DeviceInfo{}}
 		if dev != nil {
 			resp["devices"] = []mdm.DeviceInfo{*dev}
@@ -162,6 +173,7 @@ func mdmReliabilityServer(t *testing.T, fake *fakeMDMServer) (*Server, *registry
 	p.Mu().Lock()
 	p.TrustLevel = registry.TrustSelfSigned
 	p.AttestationResult = &attestation.VerificationResult{
+		Valid:             true, // a valid SE attestation earned self_signed
 		SerialNumber:      "SERIAL-1",
 		SIPEnabled:        true,
 		SecureBootEnabled: true,
@@ -495,5 +507,52 @@ func TestProviderAttestationGatesMDAPayloadOnHardware(t *testing.T) {
 					pr.MDAVerified, len(pr.MDACertChain), pr.MDASerial)
 			}
 		}
+	}
+}
+
+// TestVerifyProviderViaMDM_InvalidAttestationNotPromoted is the regression for the
+// P1: a provider whose SE attestation is INVALID (Valid=false) must never be
+// promoted to hardware by a later MDM SecurityInfo success. The verify path
+// refuses up front, so even a fully-passing fake MDM cannot grant hardware.
+func TestVerifyProviderViaMDM_InvalidAttestationNotPromoted(t *testing.T) {
+	fake := &fakeMDMServer{
+		device:            &mdm.DeviceInfo{SerialNumber: "SERIAL-1", UDID: "UDID-1", EnrollmentStatus: true},
+		commandUUID:       "cmd-ok",
+		failMDARawCommand: true,
+	}
+	srv, p := mdmReliabilityServer(t, fake)
+	// Force the attestation invalid (e.g. Open Mode connected a bad attestation).
+	p.Mu().Lock()
+	p.AttestationResult.Valid = false
+	p.Mu().Unlock()
+	// Even if SecurityInfo would pass, the invalid attestation must block promotion.
+	deliverWebhookWhenPushed(srv, fake, "UDID-1", "cmd-ok", true, true)
+
+	outcome := srv.verifyProviderViaMDM(context.Background(), "prov-mdm", p, attestResultOf(p))
+
+	if outcome == mdmVerifyGranted {
+		t.Error("invalid attestation must NOT be granted hardware via MDM")
+	}
+	if lvl := p.GetTrustLevel(); lvl == registry.TrustHardware {
+		t.Errorf("trust = %q, must not be hardware for an invalid attestation", lvl)
+	}
+}
+
+// TestVerifyProviderViaMDM_LookupFailureBucketsAsError is the regression for the
+// mis-classification: a MicroMDM lookup/transport failure (500) returns
+// DeviceEnrolled=false with "device lookup failed: ..." — the device may well be
+// enrolled. It must bucket as "error" (MDM outage), not an enrollment failure, so
+// the stuck-cohort gauge doesn't point operators at provider enrollment.
+func TestVerifyProviderViaMDM_LookupFailureBucketsAsError(t *testing.T) {
+	fake := &fakeMDMServer{failDeviceLookup: true}
+	srv, p := mdmReliabilityServer(t, fake)
+
+	outcome := srv.verifyProviderViaMDM(context.Background(), "prov-mdm", p, attestResultOf(p))
+
+	if outcome != mdmVerifyTransient {
+		t.Errorf("outcome = %v, want mdmVerifyTransient", outcome)
+	}
+	if got := p.GetMDMFailureReason(); got != "error" {
+		t.Errorf("MDMFailureReason = %q, want %q (MDM transport failure is not an enrollment problem)", got, "error")
 	}
 }

--- a/coordinator/api/provider_test.go
+++ b/coordinator/api/provider_test.go
@@ -6,6 +6,8 @@ import (
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/sha256"
+	"crypto/x509"
+	"crypto/x509/pkix"
 	"encoding/asn1"
 	"encoding/base64"
 	"encoding/json"
@@ -1825,6 +1827,170 @@ func TestApplyACMETrustRequiresMatchingAttestedSEKey(t *testing.T) {
 	}
 	if p.TrustLevel == registry.TrustHardware {
 		t.Fatal("ACME should not upgrade hardware trust when the ACME cert key mismatches attestation")
+	}
+}
+
+// TestApplyACMETrustEmitsOutcomeMetric verifies that applyACMETrust emits the
+// acme.trust counter with the correct outcome tag at each distinct exit, without
+// changing the trust decision itself.
+func TestApplyACMETrustEmitsOutcomeMetric(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	// boundProvider returns a provider whose attestation is bound + matches the
+	// given ACME key, plus the matching ACME result (the "granted" shape).
+	makeSrv := func(t *testing.T) (*Server, *udpCollector) {
+		t.Helper()
+		collector := newUDPCollector(t)
+		t.Cleanup(collector.Close)
+		st := store.NewMemory(store.Config{AdminKey: "test-key"})
+		reg := registry.New(logger)
+		srv := NewServer(reg, st, ServerConfig{}, logger)
+		ddClient := newTestDD(t, collector)
+		t.Cleanup(func() { ddClient.Close() })
+		srv.SetDatadog(ddClient)
+		return srv, collector
+	}
+
+	registerProvider := func(t *testing.T, srv *Server) (*registry.Provider, *protocol.RegisterMessage) {
+		t.Helper()
+		msg := &protocol.RegisterMessage{
+			Type:                    protocol.TypeRegister,
+			Hardware:                protocol.Hardware{ChipName: "Apple M3 Max", MemoryGB: 64},
+			Models:                  []protocol.ModelInfo{{ID: "acme-model", ModelType: "chat", Quantization: "4bit"}},
+			Backend:                 "mlx-swift",
+			PublicKey:               testPublicKeyB64(),
+			EncryptedResponseChunks: true,
+			PrivacyCapabilities:     testPrivacyCaps(),
+		}
+		return srv.registry.Register("provider-1", nil, msg), msg
+	}
+
+	t.Run("nil_or_invalid", func(t *testing.T) {
+		srv, collector := makeSrv(t)
+		p, _ := registerProvider(t, srv)
+		srv.applyACMETrust("provider-1", p, nil)
+		_ = srv.dd.Statsd.Flush()
+		packets := collector.drain()
+		if !hasMetric(packets, "outcome:nil_or_invalid") {
+			t.Fatalf("expected acme.trust outcome:nil_or_invalid, got %v", findMetrics(packets, "acme.trust"))
+		}
+	})
+
+	t.Run("not_bound", func(t *testing.T) {
+		srv, collector := makeSrv(t)
+		p, _ := registerProvider(t, srv)
+		p.SetAttestationResult(&attestation.VerificationResult{Valid: true}) // no EncryptionPublicKey
+		srv.applyACMETrust("provider-1", p, &ACMEVerificationResult{Valid: true, PublicKey: "k", SerialNumber: "s"})
+		_ = srv.dd.Statsd.Flush()
+		packets := collector.drain()
+		if !hasMetric(packets, "outcome:not_bound") {
+			t.Fatalf("expected acme.trust outcome:not_bound, got %v", findMetrics(packets, "acme.trust"))
+		}
+	})
+
+	t.Run("key_mismatch", func(t *testing.T) {
+		srv, collector := makeSrv(t)
+		p, msg := registerProvider(t, srv)
+		attestationKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		if err != nil {
+			t.Fatalf("GenerateKey(attestation): %v", err)
+		}
+		acmeKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		if err != nil {
+			t.Fatalf("GenerateKey(acme): %v", err)
+		}
+		acmeKeyB64, err := encodeP256PublicKey(&acmeKey.PublicKey)
+		if err != nil {
+			t.Fatalf("encodeP256PublicKey: %v", err)
+		}
+		p.SetAttestationResult(&attestation.VerificationResult{
+			Valid:               true,
+			PublicKey:           rawP256PublicKeyB64ForTest(t, &attestationKey.PublicKey),
+			EncryptionPublicKey: msg.PublicKey,
+		})
+		srv.applyACMETrust("provider-1", p, &ACMEVerificationResult{Valid: true, PublicKey: acmeKeyB64, SerialNumber: "s"})
+		_ = srv.dd.Statsd.Flush()
+		packets := collector.drain()
+		if !hasMetric(packets, "outcome:key_mismatch") {
+			t.Fatalf("expected acme.trust outcome:key_mismatch, got %v", findMetrics(packets, "acme.trust"))
+		}
+	})
+
+	t.Run("granted", func(t *testing.T) {
+		srv, collector := makeSrv(t)
+		p, msg := registerProvider(t, srv)
+		attestationKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		if err != nil {
+			t.Fatalf("GenerateKey: %v", err)
+		}
+		acmeKeyB64, err := encodeP256PublicKey(&attestationKey.PublicKey)
+		if err != nil {
+			t.Fatalf("encodeP256PublicKey: %v", err)
+		}
+		p.SetAttestationResult(&attestation.VerificationResult{
+			Valid:               true,
+			PublicKey:           rawP256PublicKeyB64ForTest(t, &attestationKey.PublicKey),
+			EncryptionPublicKey: msg.PublicKey,
+		})
+		srv.applyACMETrust("provider-1", p, &ACMEVerificationResult{Valid: true, PublicKey: acmeKeyB64, SerialNumber: "s"})
+		if p.GetTrustLevel() != registry.TrustHardware {
+			t.Fatal("granted path should upgrade to hardware trust")
+		}
+		_ = srv.dd.Statsd.Flush()
+		packets := collector.drain()
+		if !hasMetric(packets, "outcome:granted") {
+			t.Fatalf("expected acme.trust outcome:granted, got %v", findMetrics(packets, "acme.trust"))
+		}
+	})
+}
+
+// TestExtractAndVerifyClientCertMissingMetric verifies that the no-cert path
+// emits acme.client_cert outcome:missing when ACME verification is configured
+// but the request carries no client-cert headers.
+func TestExtractAndVerifyClientCertMissingMetric(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	collector := newUDPCollector(t)
+	defer collector.Close()
+	st := store.NewMemory(store.Config{AdminKey: "test-key"})
+	reg := registry.New(logger)
+	srv := NewServer(reg, st, ServerConfig{}, logger)
+	ddClient := newTestDD(t, collector)
+	defer ddClient.Close()
+	srv.SetDatadog(ddClient)
+
+	// Configure a (dummy) step-ca root so extractAndVerifyClientCert does not
+	// short-circuit on s.stepCARootCert == nil before reaching the header check.
+	caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "test-ca"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageCertSign,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &caKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("CreateCertificate: %v", err)
+	}
+	caCert, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatalf("ParseCertificate: %v", err)
+	}
+	srv.SetStepCACerts(caCert, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/provider", nil)
+	if res := srv.extractAndVerifyClientCert(req); res != nil {
+		t.Fatalf("expected nil result for missing client cert, got %+v", res)
+	}
+	_ = srv.dd.Statsd.Flush()
+	packets := collector.drain()
+	if !hasMetric(packets, "outcome:missing") {
+		t.Fatalf("expected acme.client_cert outcome:missing, got %v", findMetrics(packets, "acme.client_cert"))
 	}
 }
 

--- a/coordinator/api/server.go
+++ b/coordinator/api/server.go
@@ -1642,6 +1642,17 @@ func (s *Server) StartDDGaugeLoop(ctx context.Context) {
 			for ver, count := range s.registry.ProviderCountByVersion() {
 				s.ddGauge("providers.per_version", float64(count), []string{"version:" + ver})
 			}
+			// Trust-state cohort gauges — alert when self_signed/untrusted grows.
+			for _, b := range s.registry.ProviderCountByTrustStatus() {
+				s.ddGauge("providers.by_trust_status", float64(b.Count),
+					[]string{"trust_level:" + b.TrustLevel, "status:" + b.Status})
+			}
+			// Stuck-cohort breakdown — distinguishes never-enrolled from
+			// enrolled-but-SecurityInfo-timing-out so we know if the problem is
+			// provider-side enrollment or APNs/MDM delivery.
+			for reason, count := range s.registry.ProviderCountByMDMFailure() {
+				s.ddGauge("providers.by_mdm_failure", float64(count), []string{"reason:" + reason})
+			}
 			if s.minProviderVersion != "" {
 				s.ddGauge("coordinator.min_provider_version_set", 1, []string{"min_version:" + s.minProviderVersion})
 			}

--- a/coordinator/cmd/coordinator/main.go
+++ b/coordinator/cmd/coordinator/main.go
@@ -461,6 +461,14 @@ func main() {
 				}
 			}
 		}
+	} else {
+		// ACME is the no-live-command leg of the OR-trust model: a provider that
+		// presents a valid, bound device-attest-01 mTLS client cert earns hardware
+		// trust without any MDM SecurityInfo round-trip. Without the step-ca root
+		// that leg is dormant, so every provider must earn hardware trust via the
+		// live MDM SecurityInfo path (subject to APNs delivery). Surface the
+		// dormancy at startup so activation can be planned + validated.
+		logger.Warn("ACME device-cert verification disabled — EIGENINFERENCE_STEP_CA_ROOT not set; providers earn hardware trust via MDM SecurityInfo only")
 	}
 
 	// Optional profile signing: when a code-signing identity (e.g. Developer ID

--- a/coordinator/cmd/coordinator/main.go
+++ b/coordinator/cmd/coordinator/main.go
@@ -357,7 +357,15 @@ func main() {
 					logger.Error("late MDA cert parse error", "udid", udid, "error", err)
 					return
 				}
-				if mdaResult.Valid && (mdaResult.DeviceSerial == p.AttestationResult.SerialNumber) {
+				// Only attach the MDA proof to a connection that currently holds
+				// hardware trust. A late DevicePropertiesAttestation can arrive after
+				// the device reconnected as self_signed (RestoreProviderState caps it),
+				// and storing MDAVerified/cert-chain on a self_signed provider is the
+				// drift this fix removes — MDA is re-earned live once hardware is
+				// re-granted this connection.
+				if mdaResult.Valid &&
+					mdaResult.DeviceSerial == p.AttestationResult.SerialNumber &&
+					p.GetTrustLevel() == registry.TrustHardware {
 					p.MDAVerified = true
 					p.MDACertChain = certChain
 					p.MDAResult = mdaResult

--- a/coordinator/cmd/coordinator/main.go
+++ b/coordinator/cmd/coordinator/main.go
@@ -376,50 +376,13 @@ func main() {
 			})
 		})
 
-		// Register callback for late-arriving SecurityInfo responses.
-		// When APN delivery is slow (device sleeping, Power Nap cycle),
-		// the synchronous 90s wait may time out, but the webhook arrives
-		// later. This callback retroactively upgrades self_signed providers.
-		mdmClient.SetOnLateSecurityInfo(func(udid string, info *mdm.SecurityInfoResponse) {
-			if info == nil || !info.SystemIntegrityProtectionEnabled || info.SecureBootLevel != "full" {
-				return
-			}
-			// Collect self_signed provider candidates under the read lock,
-			// then do HTTP lookups outside the lock to avoid blocking
-			// heartbeats and routing while MicroMDM responds.
-			type candidate struct {
-				provider *registry.Provider
-				serial   string
-			}
-			var candidates []candidate
-			reg.ForEachProvider(func(p *registry.Provider) {
-				p.Mu().Lock()
-				trust := p.TrustLevel
-				serial := ""
-				if p.AttestationResult != nil {
-					serial = p.AttestationResult.SerialNumber
-				}
-				p.Mu().Unlock()
-				if trust == registry.TrustSelfSigned && serial != "" {
-					candidates = append(candidates, candidate{provider: p, serial: serial})
-				}
-			})
-			for _, c := range candidates {
-				dev, _ := mdmClient.LookupDevice(c.serial)
-				if dev == nil || dev.UDID != udid {
-					continue
-				}
-				c.provider.SetAttested(true, registry.TrustHardware)
-				c.provider.SetMDMFailureReason("") // recovered — drop from the stuck-cohort gauge
-				srv.Metrics().IncCounter("mdm_late_securityinfo_upgrade_total")
-				logger.Info("late SecurityInfo arrival — upgraded provider to hardware trust",
-					"provider_id", c.provider.ID,
-					"serial", c.serial,
-					"udid", udid,
-				)
-				reg.PersistProvider(c.provider)
-			}
-		})
+		// Register callback for late-arriving SecurityInfo responses. When APN
+		// delivery is slow (device sleeping, Power Nap cycle), the synchronous 90s
+		// wait may time out but the webhook arrives later. The Server method
+		// retroactively upgrades the matching self_signed provider — mirroring the
+		// synchronous success path (status guard + trust_status notification) so the
+		// two paths can't drift.
+		mdmClient.SetOnLateSecurityInfo(srv.ApplyLateSecurityInfo)
 
 		srv.SetMDMClient(mdmClient)
 		// Optional shared secret for the MicroMDM webhook. Defense-in-depth on

--- a/coordinator/cmd/coordinator/main.go
+++ b/coordinator/cmd/coordinator/main.go
@@ -348,27 +348,24 @@ func main() {
 		mdmClient := mdm.NewClient(mdmCfg.URL, mdmCfg.APIKey, logger)
 
 		mdmClient.SetOnMDA(func(udid string, certChain [][]byte) {
+			// Parse + verify the Apple cert chain once (not per provider).
+			mdaResult, err := attestation.VerifyMDADeviceAttestation(certChain)
+			if err != nil {
+				logger.Error("late MDA cert parse error", "udid", udid, "error", err)
+				return
+			}
+			if !mdaResult.Valid {
+				return
+			}
+			// Attach the proof only to a connection that currently holds hardware
+			// trust, atomically (trust check + writes under one lock). A late
+			// DevicePropertiesAttestation can arrive after the device reconnected as
+			// self_signed (RestoreProviderState caps it); attaching MDA to a
+			// self_signed provider is the drift this fix removes — and a separate
+			// check-then-write would be a TOCTOU. MDA is re-earned live once hardware
+			// is re-granted this connection.
 			reg.ForEachProvider(func(p *registry.Provider) {
-				if p.AttestationResult == nil {
-					return
-				}
-				mdaResult, err := attestation.VerifyMDADeviceAttestation(certChain)
-				if err != nil {
-					logger.Error("late MDA cert parse error", "udid", udid, "error", err)
-					return
-				}
-				// Only attach the MDA proof to a connection that currently holds
-				// hardware trust. A late DevicePropertiesAttestation can arrive after
-				// the device reconnected as self_signed (RestoreProviderState caps it),
-				// and storing MDAVerified/cert-chain on a self_signed provider is the
-				// drift this fix removes — MDA is re-earned live once hardware is
-				// re-granted this connection.
-				if mdaResult.Valid &&
-					mdaResult.DeviceSerial == p.AttestationResult.SerialNumber &&
-					p.GetTrustLevel() == registry.TrustHardware {
-					p.MDAVerified = true
-					p.MDACertChain = certChain
-					p.MDAResult = mdaResult
+				if p.SetMDAProofIfHardware(certChain, mdaResult) {
 					logger.Info("late MDA cert stored on provider",
 						"provider_id", p.ID,
 						"serial", mdaResult.DeviceSerial,

--- a/coordinator/cmd/coordinator/main.go
+++ b/coordinator/cmd/coordinator/main.go
@@ -405,6 +405,8 @@ func main() {
 					continue
 				}
 				c.provider.SetAttested(true, registry.TrustHardware)
+				c.provider.SetMDMFailureReason("") // recovered — drop from the stuck-cohort gauge
+				srv.Metrics().IncCounter("mdm_late_securityinfo_upgrade_total")
 				logger.Info("late SecurityInfo arrival — upgraded provider to hardware trust",
 					"provider_id", c.provider.ID,
 					"serial", c.serial,

--- a/coordinator/mdm/mdm.go
+++ b/coordinator/mdm/mdm.go
@@ -317,7 +317,31 @@ func (c *Client) SendSecurityInfoCommand(udid string) (string, error) {
 	}
 
 	c.trackCommand(result.Payload.CommandUUID, udid, time.Now())
+
+	// Explicitly push to wake the device and trigger an immediate check-in.
+	// MicroMDM's POST /v1/commands enqueues the command, but on a sleeping or
+	// Power-Nap'd Mac the device may not pull it until its next idle wake (up to
+	// ~15 min) — long past our 90s wait. The MDA path (sendDeviceAttestationWithNonce)
+	// already pushes; without parity here the SecurityInfo leg silently relied on
+	// MicroMDM's implicit push and timed out far more often. Best-effort: a failed
+	// push doesn't fail the command (it's queued either way).
+	c.pushDevice(udid)
 	return result.Payload.CommandUUID, nil
+}
+
+// pushDevice sends a best-effort APNs push to a device via MicroMDM to trigger
+// an immediate check-in so a freshly-queued command is pulled promptly rather
+// than at the next idle wake. Errors are intentionally ignored: the command is
+// already enqueued, and the push is only a latency optimization.
+func (c *Client) pushDevice(udid string) {
+	pushReq, err := http.NewRequest(http.MethodGet, c.baseURL+"/push/"+udid, nil)
+	if err != nil {
+		return
+	}
+	pushReq.SetBasicAuth("micromdm", c.apiKey)
+	if resp, err := c.client.Do(pushReq); err == nil {
+		_ = resp.Body.Close()
+	}
 }
 
 // SendDeviceAttestationCommand sends a DeviceInformation command requesting
@@ -397,13 +421,8 @@ func (c *Client) sendDeviceAttestationWithNonce(udid, nonce string) (string, err
 
 	c.trackCommand(cmdUUID, udid, time.Now())
 
-	// Push to trigger device check-in
-	pushReq, err := http.NewRequest(http.MethodGet, c.baseURL+"/push/"+udid, nil)
-	if err != nil {
-		return cmdUUID, nil // command queued, push failed
-	}
-	pushReq.SetBasicAuth("micromdm", c.apiKey)
-	c.client.Do(pushReq)
+	// Push to trigger device check-in (best-effort; command is already queued).
+	c.pushDevice(udid)
 
 	return cmdUUID, nil
 }

--- a/coordinator/mdm/mdm.go
+++ b/coordinator/mdm/mdm.go
@@ -450,7 +450,14 @@ func (c *Client) WaitForDeviceAttestation(ctx context.Context, udid string, time
 
 	defer func() {
 		c.waitMu.Lock()
-		delete(c.attestWaiters, udid)
+		// Identity-guarded delete (parity with registerSecurityInfoWaiter): only
+		// remove our own channel. With two overlapping connections for the same
+		// device (same UDID), an unconditional delete could drop a later waiter's
+		// live channel and route its Apple attestation response to the late
+		// callback instead.
+		if cur, ok := c.attestWaiters[udid]; ok && cur == ch {
+			delete(c.attestWaiters, udid)
+		}
 		c.waitMu.Unlock()
 	}()
 

--- a/coordinator/mdm/mdm.go
+++ b/coordinator/mdm/mdm.go
@@ -329,14 +329,14 @@ func (c *Client) SendSecurityInfoCommand(udid string) (string, error) {
 
 	c.trackCommand(result.Payload.CommandUUID, udid, time.Now())
 
-	// Explicitly push to wake the device and trigger an immediate check-in.
-	// MicroMDM's POST /v1/commands enqueues the command, but on a sleeping or
-	// Power-Nap'd Mac the device may not pull it until its next idle wake (up to
-	// ~15 min) — long past our 90s wait. The MDA path (sendDeviceAttestationWithNonce)
-	// already pushes; without parity here the SecurityInfo leg silently relied on
-	// MicroMDM's implicit push and timed out far more often. Best-effort: a failed
-	// push doesn't fail the command (it's queued either way).
-	c.pushDevice(udid)
+	// Do NOT push explicitly here. MicroMDM's structured POST /v1/commands already
+	// schedules the command AND sends the APNs push to wake the device, so an extra
+	// GET /push/{udid} would be a SECOND push per attempt — wasted MDM/APNs push
+	// budget, the pressure this change exists to reduce. (The MDA path uses the raw
+	// POST /v1/commands/{udid} endpoint, which does NOT auto-push, so it pushes
+	// explicitly — that asymmetry is correct, not a bug.) The fast-device webhook
+	// race is handled by registering the SecurityInfo waiter BEFORE this call in
+	// VerifyProvider, so the auto-push's response always finds a waiter.
 	return result.Payload.CommandUUID, nil
 }
 

--- a/coordinator/mdm/mdm.go
+++ b/coordinator/mdm/mdm.go
@@ -259,9 +259,9 @@ type VerificationResult struct {
 }
 
 // LookupDevice checks if a device with the given serial number is enrolled.
-func (c *Client) LookupDevice(serialNumber string) (*DeviceInfo, error) {
+func (c *Client) LookupDevice(ctx context.Context, serialNumber string) (*DeviceInfo, error) {
 	body, _ := json.Marshal(map[string]string{"serial_number": serialNumber})
-	req, err := http.NewRequest(http.MethodPost, c.baseURL+"/v1/devices", bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/v1/devices", bytes.NewReader(body))
 	if err != nil {
 		return nil, err
 	}
@@ -296,7 +296,7 @@ func (c *Client) LookupDevice(serialNumber string) (*DeviceInfo, error) {
 
 // SendSecurityInfoCommand sends a SecurityInfo command to a device by UDID.
 // Returns the command UUID for tracking the response.
-func (c *Client) SendSecurityInfoCommand(udid string) (string, error) {
+func (c *Client) SendSecurityInfoCommand(ctx context.Context, udid string) (string, error) {
 	const requestType = "SecurityInfo"
 	if err := assertReadOnlyCommand(requestType); err != nil {
 		return "", err
@@ -305,7 +305,7 @@ func (c *Client) SendSecurityInfoCommand(udid string) (string, error) {
 		"udid":         udid,
 		"request_type": requestType,
 	})
-	req, err := http.NewRequest(http.MethodPost, c.baseURL+"/v1/commands", bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/v1/commands", bytes.NewReader(body))
 	if err != nil {
 		return "", err
 	}
@@ -344,8 +344,8 @@ func (c *Client) SendSecurityInfoCommand(udid string) (string, error) {
 // an immediate check-in so a freshly-queued command is pulled promptly rather
 // than at the next idle wake. Errors are intentionally ignored: the command is
 // already enqueued, and the push is only a latency optimization.
-func (c *Client) pushDevice(udid string) {
-	pushReq, err := http.NewRequest(http.MethodGet, c.baseURL+"/push/"+udid, nil)
+func (c *Client) pushDevice(ctx context.Context, udid string) {
+	pushReq, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/push/"+udid, nil)
 	if err != nil {
 		return
 	}
@@ -367,19 +367,19 @@ func (c *Client) pushDevice(udid string) {
 //
 // When a nonce is provided, we send a raw plist command because MicroMDM's
 // DeviceInformation struct doesn't support DeviceAttestationNonce.
-func (c *Client) SendDeviceAttestationCommand(udid string, nonce ...string) (string, error) {
+func (c *Client) SendDeviceAttestationCommand(ctx context.Context, udid string, nonce ...string) (string, error) {
 	// Always use raw plist to support DeviceAttestationNonce
 	nonceStr := ""
 	if len(nonce) > 0 {
 		nonceStr = nonce[0]
 	}
-	return c.sendDeviceAttestationWithNonce(udid, nonceStr)
+	return c.sendDeviceAttestationWithNonce(ctx, udid, nonceStr)
 }
 
 // sendDeviceAttestationWithNonce sends a raw plist DeviceInformation command
 // with DeviceAttestationNonce. MicroMDM's structured API doesn't support this
 // field, so we bypass it with the raw command endpoint: POST /v1/commands/{udid}.
-func (c *Client) sendDeviceAttestationWithNonce(udid, nonce string) (string, error) {
+func (c *Client) sendDeviceAttestationWithNonce(ctx context.Context, udid, nonce string) (string, error) {
 	// DevicePropertiesAttestation is requested via a DeviceInformation command.
 	if err := assertReadOnlyCommand("DeviceInformation"); err != nil {
 		return "", err
@@ -412,7 +412,7 @@ func (c *Client) sendDeviceAttestationWithNonce(udid, nonce string) (string, err
 </dict>
 </plist>`, nonceXML, cmdUUID)
 
-	req, err := http.NewRequest(http.MethodPost, c.baseURL+"/v1/commands/"+udid, bytes.NewReader([]byte(plist)))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/v1/commands/"+udid, bytes.NewReader([]byte(plist)))
 	if err != nil {
 		return "", err
 	}
@@ -433,7 +433,9 @@ func (c *Client) sendDeviceAttestationWithNonce(udid, nonce string) (string, err
 	c.trackCommand(cmdUUID, udid, time.Now())
 
 	// Push to trigger device check-in (best-effort; command is already queued).
-	c.pushDevice(udid)
+	// The raw POST /v1/commands/{udid} endpoint does NOT auto-push (unlike the
+	// structured /v1/commands), so the explicit push is required here.
+	c.pushDevice(ctx, udid)
 
 	return cmdUUID, nil
 }
@@ -661,7 +663,7 @@ func (c *Client) VerifyProvider(ctx context.Context, serialNumber string, attest
 	}
 
 	// Step 1: Look up device
-	device, err := c.LookupDevice(serialNumber)
+	device, err := c.LookupDevice(ctx, serialNumber)
 	if err != nil {
 		result.Error = fmt.Sprintf("device lookup failed: %v", err)
 		return result, nil
@@ -689,7 +691,7 @@ func (c *Client) VerifyProvider(ctx context.Context, serialNumber string, attest
 	defer release()
 
 	// Step 3: Send SecurityInfo command (enqueues + pushes the device).
-	if _, err = c.SendSecurityInfoCommand(device.UDID); err != nil {
+	if _, err = c.SendSecurityInfoCommand(ctx, device.UDID); err != nil {
 		result.Error = fmt.Sprintf("failed to send SecurityInfo command: %v", err)
 		return result, nil
 	}

--- a/coordinator/mdm/mdm.go
+++ b/coordinator/mdm/mdm.go
@@ -15,6 +15,7 @@ package mdm
 
 import (
 	"bytes"
+	"context"
 	"crypto/tls"
 	"encoding/base64"
 	"encoding/json"
@@ -244,7 +245,17 @@ type VerificationResult struct {
 	MDMRecoveryLocked bool // Recovery Lock prevents Recovery OS access (blocks rdma_ctl enable)
 	SIPMatch          bool // MDM SIP matches attestation SIP
 	SecureBootMatch   bool // MDM SecureBoot matches attestation
-	Error             string
+
+	// SecurityMismatch is true ONLY for a genuine posture failure proven by a
+	// received SecurityInfo response: SIP disabled, Secure Boot not full, or the
+	// MDM-reported posture disagreeing with the provider's attestation. It is the
+	// single signal callers use to decide a hard (terminal) untrust. It is FALSE
+	// for every "could not complete the check" condition (device not found / not
+	// enrolled, command send failure, SecurityInfo timeout, context cancellation),
+	// so a transient MicroMDM/APNs problem never hard-untrusts an enrolled box.
+	SecurityMismatch bool
+
+	Error string
 }
 
 // LookupDevice checks if a device with the given serial number is enrolled.
@@ -428,7 +439,9 @@ func (c *Client) sendDeviceAttestationWithNonce(udid, nonce string) (string, err
 }
 
 // WaitForDeviceAttestation waits for a DevicePropertiesAttestation response.
-func (c *Client) WaitForDeviceAttestation(udid string, timeout time.Duration) (*DeviceAttestationResponse, error) {
+// It returns early if ctx is cancelled (e.g. the provider disconnected), so a
+// teardown isn't blocked for the full timeout.
+func (c *Client) WaitForDeviceAttestation(ctx context.Context, udid string, timeout time.Duration) (*DeviceAttestationResponse, error) {
 	ch := make(chan *DeviceAttestationResponse, 1)
 
 	c.waitMu.Lock()
@@ -444,6 +457,8 @@ func (c *Client) WaitForDeviceAttestation(udid string, timeout time.Duration) (*
 	select {
 	case resp := <-ch:
 		return resp, nil
+	case <-ctx.Done():
+		return nil, fmt.Errorf("device attestation wait cancelled for %s: %w", udid, ctx.Err())
 	case <-time.After(timeout):
 		return nil, fmt.Errorf("timeout waiting for DevicePropertiesAttestation from %s", udid)
 	}
@@ -581,8 +596,11 @@ func (c *Client) HandleWebhook(body []byte) {
 	}
 }
 
-// WaitForSecurityInfo waits for a SecurityInfo response for the given UDID.
-func (c *Client) WaitForSecurityInfo(udid string, timeout time.Duration) (*SecurityInfoResponse, error) {
+// WaitForSecurityInfo waits for a SecurityInfo response for the given UDID. It
+// returns early if ctx is cancelled (e.g. the provider disconnected), so the
+// per-connection verification goroutine isn't blocked for the full timeout after
+// the connection is gone.
+func (c *Client) WaitForSecurityInfo(ctx context.Context, udid string, timeout time.Duration) (*SecurityInfoResponse, error) {
 	ch := make(chan *SecurityInfoResponse, 1)
 
 	c.waitMu.Lock()
@@ -598,6 +616,8 @@ func (c *Client) WaitForSecurityInfo(udid string, timeout time.Duration) (*Secur
 	select {
 	case resp := <-ch:
 		return resp, nil
+	case <-ctx.Done():
+		return nil, fmt.Errorf("SecurityInfo wait cancelled for %s: %w", udid, ctx.Err())
 	case <-time.After(timeout):
 		return nil, fmt.Errorf("timeout waiting for SecurityInfo from %s", udid)
 	}
@@ -610,7 +630,7 @@ func (c *Client) WaitForSecurityInfo(udid string, timeout time.Duration) (*Secur
 //  3. Send SecurityInfo command
 //  4. Wait for and parse response
 //  5. Cross-check against attestation
-func (c *Client) VerifyProvider(serialNumber string, attestationSIP, attestationSecureBoot bool) (*VerificationResult, error) {
+func (c *Client) VerifyProvider(ctx context.Context, serialNumber string, attestationSIP, attestationSecureBoot bool) (*VerificationResult, error) {
 	result := &VerificationResult{
 		SerialNumber: serialNumber,
 	}
@@ -643,8 +663,9 @@ func (c *Client) VerifyProvider(serialNumber string, attestationSIP, attestation
 	}
 
 	// Step 3: Wait for response (via webhook). 90 seconds allows for APN
-	// delivery delays during Power Nap cycles (every ~15 minutes on AC).
-	secInfo, err := c.WaitForSecurityInfo(device.UDID, 90*time.Second)
+	// delivery delays during Power Nap cycles (every ~15 minutes on AC). Returns
+	// early if ctx is cancelled (provider disconnected).
+	secInfo, err := c.WaitForSecurityInfo(ctx, device.UDID, 90*time.Second)
 	if err != nil {
 		result.Error = fmt.Sprintf("SecurityInfo response: %v", err)
 		return result, nil
@@ -660,14 +681,22 @@ func (c *Client) VerifyProvider(serialNumber string, attestationSIP, attestation
 	result.SIPMatch = result.MDMSIPEnabled == attestationSIP
 	result.SecureBootMatch = result.MDMSecureBootFull == attestationSecureBoot
 
+	// A non-empty Error set below is a GENUINE posture failure proven by a
+	// received SecurityInfo response — mark SecurityMismatch so the caller hard-
+	// untrusts. (Transport/timeout/not-enrolled errors return above with
+	// SecurityMismatch=false and must NOT untrust.)
 	if !result.MDMSIPEnabled {
 		result.Error = "MDM reports SIP disabled"
+		result.SecurityMismatch = true
 	} else if !result.MDMSecureBootFull {
 		result.Error = "MDM reports Secure Boot not full"
+		result.SecurityMismatch = true
 	} else if !result.SIPMatch {
 		result.Error = "attestation SIP does not match MDM SIP — provider may be lying"
+		result.SecurityMismatch = true
 	} else if !result.SecureBootMatch {
 		result.Error = "attestation SecureBoot does not match MDM — provider may be lying"
+		result.SecurityMismatch = true
 	}
 	// Recovery Lock is recommended but not enforced yet — log a warning.
 	// When enforced, providers without Recovery Lock could enable RDMA via Recovery OS.

--- a/coordinator/mdm/mdm.go
+++ b/coordinator/mdm/mdm.go
@@ -596,23 +596,31 @@ func (c *Client) HandleWebhook(body []byte) {
 	}
 }
 
-// WaitForSecurityInfo waits for a SecurityInfo response for the given UDID. It
-// returns early if ctx is cancelled (e.g. the provider disconnected), so the
-// per-connection verification goroutine isn't blocked for the full timeout after
-// the connection is gone.
-func (c *Client) WaitForSecurityInfo(ctx context.Context, udid string, timeout time.Duration) (*SecurityInfoResponse, error) {
+// registerSecurityInfoWaiter installs a one-shot waiter for a UDID's SecurityInfo
+// response and returns the channel plus a release func to deregister it. Callers
+// that send the command themselves MUST register the waiter BEFORE sending /
+// pushing — otherwise a fast device can have its webhook arrive (and consume the
+// tracked CommandUUID) before the waiter exists, so the response is dropped to the
+// late-callback path and the in-flight verifier waits the full timeout.
+func (c *Client) registerSecurityInfoWaiter(udid string) (<-chan *SecurityInfoResponse, func()) {
 	ch := make(chan *SecurityInfoResponse, 1)
-
 	c.waitMu.Lock()
 	c.secInfoWaiters[udid] = ch
 	c.waitMu.Unlock()
-
-	defer func() {
+	return ch, func() {
 		c.waitMu.Lock()
-		delete(c.secInfoWaiters, udid)
+		// Only delete our own channel — HandleWebhook may already have delivered
+		// and removed it, and a later waiter could have registered a new one.
+		if cur, ok := c.secInfoWaiters[udid]; ok && cur == ch {
+			delete(c.secInfoWaiters, udid)
+		}
 		c.waitMu.Unlock()
-	}()
+	}
+}
 
+// awaitSecurityInfo blocks on a previously-registered waiter channel until the
+// response arrives, ctx is cancelled, or the timeout elapses.
+func awaitSecurityInfo(ctx context.Context, ch <-chan *SecurityInfoResponse, udid string, timeout time.Duration) (*SecurityInfoResponse, error) {
 	select {
 	case resp := <-ch:
 		return resp, nil
@@ -621,6 +629,16 @@ func (c *Client) WaitForSecurityInfo(ctx context.Context, udid string, timeout t
 	case <-time.After(timeout):
 		return nil, fmt.Errorf("timeout waiting for SecurityInfo from %s", udid)
 	}
+}
+
+// WaitForSecurityInfo registers a waiter and blocks for the response. Use this
+// when the SecurityInfo command was (or will be) sent elsewhere. VerifyProvider
+// instead registers the waiter explicitly before sending, to close the
+// fast-device webhook race.
+func (c *Client) WaitForSecurityInfo(ctx context.Context, udid string, timeout time.Duration) (*SecurityInfoResponse, error) {
+	ch, release := c.registerSecurityInfoWaiter(udid)
+	defer release()
+	return awaitSecurityInfo(ctx, ch, udid, timeout)
 }
 
 // VerifyProvider performs the full MDM verification flow for a provider.
@@ -655,17 +673,24 @@ func (c *Client) VerifyProvider(ctx context.Context, serialNumber string, attest
 		return result, nil
 	}
 
-	// Step 2: Send SecurityInfo command
-	_, err = c.SendSecurityInfoCommand(device.UDID)
-	if err != nil {
+	// Step 2: Register the response waiter BEFORE sending/pushing. The send path
+	// pushes the device synchronously, so an awake device can answer before we'd
+	// otherwise install the waiter; registering first guarantees the webhook finds
+	// it and the in-flight verifier sees the response (instead of timing out and
+	// relying on the late callback).
+	ch, release := c.registerSecurityInfoWaiter(device.UDID)
+	defer release()
+
+	// Step 3: Send SecurityInfo command (enqueues + pushes the device).
+	if _, err = c.SendSecurityInfoCommand(device.UDID); err != nil {
 		result.Error = fmt.Sprintf("failed to send SecurityInfo command: %v", err)
 		return result, nil
 	}
 
-	// Step 3: Wait for response (via webhook). 90 seconds allows for APN
+	// Step 4: Wait for the response (via webhook). 90 seconds allows for APN
 	// delivery delays during Power Nap cycles (every ~15 minutes on AC). Returns
 	// early if ctx is cancelled (provider disconnected).
-	secInfo, err := c.WaitForSecurityInfo(ctx, device.UDID, 90*time.Second)
+	secInfo, err := awaitSecurityInfo(ctx, ch, device.UDID, 90*time.Second)
 	if err != nil {
 		result.Error = fmt.Sprintf("SecurityInfo response: %v", err)
 		return result, nil

--- a/coordinator/mdm/mdm_push_test.go
+++ b/coordinator/mdm/mdm_push_test.go
@@ -108,7 +108,7 @@ func TestSendSecurityInfoCommandDoesNotDoublePush(t *testing.T) {
 	fake := &fakeMicroMDM{commandUUID: "cmd-abc-123"}
 	c, _ := newFakeMDM(t, fake)
 
-	gotUUID, err := c.SendSecurityInfoCommand("UDID-PUSH")
+	gotUUID, err := c.SendSecurityInfoCommand(context.Background(), "UDID-PUSH")
 	if err != nil {
 		t.Fatalf("SendSecurityInfoCommand: %v", err)
 	}

--- a/coordinator/mdm/mdm_push_test.go
+++ b/coordinator/mdm/mdm_push_test.go
@@ -1,6 +1,7 @@
 package mdm
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"log/slog"
@@ -178,7 +179,7 @@ func TestVerifyProviderSuccess(t *testing.T) {
 		c.HandleWebhook(buildSecurityInfoWebhook("UDID-OK", "cmd-ok"))
 	}()
 
-	res, err := c.VerifyProvider("SERIAL-OK", true /*sip*/, true /*secureboot*/)
+	res, err := c.VerifyProvider(context.Background(), "SERIAL-OK", true /*sip*/, true /*secureboot*/)
 	if err != nil {
 		t.Fatalf("VerifyProvider returned transport error: %v", err)
 	}
@@ -205,7 +206,7 @@ func TestVerifyProviderSuccess(t *testing.T) {
 // verifyProviderViaMDM buckets as securityinfo-timeout.
 func TestVerifyProviderTimeoutErrorString(t *testing.T) {
 	c := testClient()
-	_, err := c.WaitForSecurityInfo("UDID-NO-REPLY", 50*time.Millisecond)
+	_, err := c.WaitForSecurityInfo(context.Background(), "UDID-NO-REPLY", 50*time.Millisecond)
 	if err == nil {
 		t.Fatal("expected a timeout error when no webhook arrives")
 	}
@@ -221,7 +222,7 @@ func TestVerifyProviderDeviceNotFound(t *testing.T) {
 	fake := &fakeMicroMDM{device: nil, commandUUID: "unused"}
 	c, _ := newFakeMDM(t, fake)
 
-	res, err := c.VerifyProvider("SERIAL-MISSING", true, true)
+	res, err := c.VerifyProvider(context.Background(), "SERIAL-MISSING", true, true)
 	if err != nil {
 		t.Fatalf("VerifyProvider transport error: %v", err)
 	}

--- a/coordinator/mdm/mdm_push_test.go
+++ b/coordinator/mdm/mdm_push_test.go
@@ -28,8 +28,13 @@ type fakeMicroMDM struct {
 	// commandUUID returned by POST /v1/commands.
 	commandUUID string
 
-	// pushedUDIDs records every GET /push/{udid} the client issued, in order.
+	// pushedUDIDs records every EXPLICIT GET /push/{udid} the client issued, in
+	// order. The structured POST /v1/commands does NOT count here — MicroMDM
+	// auto-pushes on that endpoint, so the coordinator must not add a second push.
 	pushedUDIDs []string
+
+	// commandPosts counts POST /v1/commands (SecurityInfo enqueues).
+	commandPosts int
 }
 
 func (f *fakeMicroMDM) handler() http.Handler {
@@ -54,6 +59,7 @@ func (f *fakeMicroMDM) handler() http.Handler {
 		_, _ = io.Copy(io.Discard, r.Body)
 		f.mu.Lock()
 		uuid := f.commandUUID
+		f.commandPosts++
 		f.mu.Unlock()
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"payload":{"command_uuid":"` + uuid + `"}}`))
@@ -79,6 +85,12 @@ func (f *fakeMicroMDM) pushes() []string {
 	return out
 }
 
+func (f *fakeMicroMDM) commandPostCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.commandPosts
+}
+
 func newFakeMDM(t *testing.T, fake *fakeMicroMDM) (*Client, *httptest.Server) {
 	t.Helper()
 	ts := httptest.NewServer(fake.handler())
@@ -87,11 +99,12 @@ func newFakeMDM(t *testing.T, fake *fakeMicroMDM) (*Client, *httptest.Server) {
 	return c, ts
 }
 
-// TestSendSecurityInfoCommandPushesDevice is the core reliability fix: enqueuing
-// a SecurityInfo command must also fire an explicit GET /push/{udid} so a
-// sleeping/Power-Nap'd Mac pulls the command inside our wait window instead of
-// at its next idle wake. It also returns the command_uuid for response tracking.
-func TestSendSecurityInfoCommandPushesDevice(t *testing.T) {
+// TestSendSecurityInfoCommandDoesNotDoublePush: the structured POST /v1/commands
+// already makes MicroMDM send the APNs push, so SendSecurityInfoCommand must NOT
+// issue a second explicit GET /push/{udid} — a double push wastes Apple's MDM push
+// budget (the pressure this whole change reduces). It enqueues exactly one command
+// and returns the command_uuid; zero explicit pushes.
+func TestSendSecurityInfoCommandDoesNotDoublePush(t *testing.T) {
 	fake := &fakeMicroMDM{commandUUID: "cmd-abc-123"}
 	c, _ := newFakeMDM(t, fake)
 
@@ -102,49 +115,11 @@ func TestSendSecurityInfoCommandPushesDevice(t *testing.T) {
 	if gotUUID != "cmd-abc-123" {
 		t.Errorf("command_uuid = %q, want %q", gotUUID, "cmd-abc-123")
 	}
-
-	pushes := fake.pushes()
-	if len(pushes) != 1 {
-		t.Fatalf("push count = %d, want exactly 1 (explicit APNs wake)", len(pushes))
+	if n := fake.commandPostCount(); n != 1 {
+		t.Errorf("command posts = %d, want exactly 1", n)
 	}
-	if pushes[0] != "UDID-PUSH" {
-		t.Errorf("pushed udid = %q, want %q", pushes[0], "UDID-PUSH")
-	}
-}
-
-// TestSendSecurityInfoCommandPushIsBestEffort proves a failed push does NOT fail
-// the command — the command is already enqueued, the push is only a latency
-// optimization. We point the client at a dead push endpoint (the command POST
-// still succeeds) and assert the command_uuid is still returned with no error.
-func TestSendSecurityInfoCommandPushIsBestEffort(t *testing.T) {
-	// A handler that succeeds for /v1/commands but hangs up on /push.
-	mux := http.NewServeMux()
-	mux.HandleFunc("POST /v1/commands", func(w http.ResponseWriter, r *http.Request) {
-		_, _ = io.Copy(io.Discard, r.Body)
-		_, _ = w.Write([]byte(`{"payload":{"command_uuid":"cmd-besteffort"}}`))
-	})
-	mux.HandleFunc("GET /push/{udid}", func(w http.ResponseWriter, r *http.Request) {
-		// Hijack and close without a response to simulate a broken push.
-		hj, ok := w.(http.Hijacker)
-		if !ok {
-			w.WriteHeader(http.StatusInternalServerError)
-			return
-		}
-		conn, _, err := hj.Hijack()
-		if err == nil {
-			_ = conn.Close()
-		}
-	})
-	ts := httptest.NewServer(mux)
-	defer ts.Close()
-	c := NewClient(ts.URL, "test-key", slog.New(slog.NewTextHandler(io.Discard, nil)))
-
-	gotUUID, err := c.SendSecurityInfoCommand("UDID-X")
-	if err != nil {
-		t.Fatalf("a failed push must not fail the command, got err: %v", err)
-	}
-	if gotUUID != "cmd-besteffort" {
-		t.Errorf("command_uuid = %q, want %q", gotUUID, "cmd-besteffort")
+	if pushes := fake.pushes(); len(pushes) != 0 {
+		t.Errorf("explicit GET /push count = %d, want 0 (MicroMDM auto-pushes on /v1/commands)", len(pushes))
 	}
 }
 
@@ -166,11 +141,12 @@ func TestVerifyProviderSuccess(t *testing.T) {
 	// Deliver the SecurityInfo response shortly after the verifier registers its
 	// waiter. buildSecurityInfoWebhook reports SIP=true, SecureBoot=full.
 	go func() {
-		// Wait until the command has been issued (push recorded) so the command
-		// UUID is tracked and a waiter is registered, then deliver the webhook.
+		// Wait until the command has been POSTed (uuid tracked + waiter registered),
+		// then deliver the webhook. (SecurityInfo no longer issues an explicit push,
+		// so gate on the command post, not a push.)
 		deadline := time.Now().Add(3 * time.Second)
 		for time.Now().Before(deadline) {
-			if len(fake.pushes()) > 0 {
+			if fake.commandPostCount() > 0 {
 				break
 			}
 			time.Sleep(5 * time.Millisecond)

--- a/coordinator/mdm/mdm_push_test.go
+++ b/coordinator/mdm/mdm_push_test.go
@@ -1,0 +1,238 @@
+package mdm
+
+import (
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// fakeMicroMDM is a minimal stand-in for MicroMDM driven entirely over HTTP. It
+// records the explicit APNs push (GET /push/{udid}) so tests can prove the
+// SecurityInfo leg now wakes the device, returns a deterministic command_uuid
+// from POST /v1/commands, and serves a configurable device record from POST
+// /v1/devices. The SecurityInfo response itself is delivered out-of-band by the
+// test calling client.HandleWebhook (the webhook path MicroMDM uses in prod).
+type fakeMicroMDM struct {
+	mu sync.Mutex
+
+	// device returned by LookupDevice. nil → "not found" (empty device list).
+	device *DeviceInfo
+
+	// commandUUID returned by POST /v1/commands.
+	commandUUID string
+
+	// pushedUDIDs records every GET /push/{udid} the client issued, in order.
+	pushedUDIDs []string
+}
+
+func (f *fakeMicroMDM) handler() http.Handler {
+	mux := http.NewServeMux()
+
+	// LookupDevice
+	mux.HandleFunc("POST /v1/devices", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.Copy(io.Discard, r.Body)
+		f.mu.Lock()
+		dev := f.device
+		f.mu.Unlock()
+		resp := map[string]any{"devices": []DeviceInfo{}}
+		if dev != nil {
+			resp["devices"] = []DeviceInfo{*dev}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	})
+
+	// SendSecurityInfoCommand
+	mux.HandleFunc("POST /v1/commands", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.Copy(io.Discard, r.Body)
+		f.mu.Lock()
+		uuid := f.commandUUID
+		f.mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"payload":{"command_uuid":"` + uuid + `"}}`))
+	})
+
+	// Explicit APNs push — record that it fired and for which UDID.
+	mux.HandleFunc("GET /push/{udid}", func(w http.ResponseWriter, r *http.Request) {
+		udid := r.PathValue("udid")
+		f.mu.Lock()
+		f.pushedUDIDs = append(f.pushedUDIDs, udid)
+		f.mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	})
+
+	return mux
+}
+
+func (f *fakeMicroMDM) pushes() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]string, len(f.pushedUDIDs))
+	copy(out, f.pushedUDIDs)
+	return out
+}
+
+func newFakeMDM(t *testing.T, fake *fakeMicroMDM) (*Client, *httptest.Server) {
+	t.Helper()
+	ts := httptest.NewServer(fake.handler())
+	t.Cleanup(ts.Close)
+	c := NewClient(ts.URL, "test-key", slog.New(slog.NewTextHandler(io.Discard, nil)))
+	return c, ts
+}
+
+// TestSendSecurityInfoCommandPushesDevice is the core reliability fix: enqueuing
+// a SecurityInfo command must also fire an explicit GET /push/{udid} so a
+// sleeping/Power-Nap'd Mac pulls the command inside our wait window instead of
+// at its next idle wake. It also returns the command_uuid for response tracking.
+func TestSendSecurityInfoCommandPushesDevice(t *testing.T) {
+	fake := &fakeMicroMDM{commandUUID: "cmd-abc-123"}
+	c, _ := newFakeMDM(t, fake)
+
+	gotUUID, err := c.SendSecurityInfoCommand("UDID-PUSH")
+	if err != nil {
+		t.Fatalf("SendSecurityInfoCommand: %v", err)
+	}
+	if gotUUID != "cmd-abc-123" {
+		t.Errorf("command_uuid = %q, want %q", gotUUID, "cmd-abc-123")
+	}
+
+	pushes := fake.pushes()
+	if len(pushes) != 1 {
+		t.Fatalf("push count = %d, want exactly 1 (explicit APNs wake)", len(pushes))
+	}
+	if pushes[0] != "UDID-PUSH" {
+		t.Errorf("pushed udid = %q, want %q", pushes[0], "UDID-PUSH")
+	}
+}
+
+// TestSendSecurityInfoCommandPushIsBestEffort proves a failed push does NOT fail
+// the command — the command is already enqueued, the push is only a latency
+// optimization. We point the client at a dead push endpoint (the command POST
+// still succeeds) and assert the command_uuid is still returned with no error.
+func TestSendSecurityInfoCommandPushIsBestEffort(t *testing.T) {
+	// A handler that succeeds for /v1/commands but hangs up on /push.
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /v1/commands", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.Copy(io.Discard, r.Body)
+		_, _ = w.Write([]byte(`{"payload":{"command_uuid":"cmd-besteffort"}}`))
+	})
+	mux.HandleFunc("GET /push/{udid}", func(w http.ResponseWriter, r *http.Request) {
+		// Hijack and close without a response to simulate a broken push.
+		hj, ok := w.(http.Hijacker)
+		if !ok {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		conn, _, err := hj.Hijack()
+		if err == nil {
+			_ = conn.Close()
+		}
+	})
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+	c := NewClient(ts.URL, "test-key", slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	gotUUID, err := c.SendSecurityInfoCommand("UDID-X")
+	if err != nil {
+		t.Fatalf("a failed push must not fail the command, got err: %v", err)
+	}
+	if gotUUID != "cmd-besteffort" {
+		t.Errorf("command_uuid = %q, want %q", gotUUID, "cmd-besteffort")
+	}
+}
+
+// TestVerifyProviderSuccess walks the full happy path: device enrolled, then a
+// solicited SecurityInfo webhook arrives with SIP enabled + Secure Boot full
+// matching the provider's attestation. VerifyProvider returns DeviceEnrolled
+// with no Error.
+func TestVerifyProviderSuccess(t *testing.T) {
+	fake := &fakeMicroMDM{
+		device: &DeviceInfo{
+			SerialNumber:     "SERIAL-OK",
+			UDID:             "UDID-OK",
+			EnrollmentStatus: true,
+		},
+		commandUUID: "cmd-ok",
+	}
+	c, _ := newFakeMDM(t, fake)
+
+	// Deliver the SecurityInfo response shortly after the verifier registers its
+	// waiter. buildSecurityInfoWebhook reports SIP=true, SecureBoot=full.
+	go func() {
+		// Wait until the command has been issued (push recorded) so the command
+		// UUID is tracked and a waiter is registered, then deliver the webhook.
+		deadline := time.Now().Add(3 * time.Second)
+		for time.Now().Before(deadline) {
+			if len(fake.pushes()) > 0 {
+				break
+			}
+			time.Sleep(5 * time.Millisecond)
+		}
+		time.Sleep(20 * time.Millisecond)
+		c.HandleWebhook(buildSecurityInfoWebhook("UDID-OK", "cmd-ok"))
+	}()
+
+	res, err := c.VerifyProvider("SERIAL-OK", true /*sip*/, true /*secureboot*/)
+	if err != nil {
+		t.Fatalf("VerifyProvider returned transport error: %v", err)
+	}
+	if !res.DeviceEnrolled {
+		t.Errorf("DeviceEnrolled = false, want true")
+	}
+	if res.Error != "" {
+		t.Errorf("Error = %q, want empty on success", res.Error)
+	}
+	if !res.MDMSIPEnabled || !res.MDMSecureBootFull {
+		t.Errorf("SIP=%v SecureBootFull=%v, want both true", res.MDMSIPEnabled, res.MDMSecureBootFull)
+	}
+	if !res.SIPMatch || !res.SecureBootMatch {
+		t.Errorf("SIPMatch=%v SecureBootMatch=%v, want both true", res.SIPMatch, res.SecureBootMatch)
+	}
+}
+
+// TestVerifyProviderTimeout: device is enrolled but no SecurityInfo webhook ever
+// arrives, so the 90s waiter times out. We shrink the wait by NOT delivering a
+// webhook and overriding the client to a short timeout is not possible (the
+// 90s is hardcoded), so instead we assert the timeout-error semantics via the
+// lower-level WaitForSecurityInfo with a short timeout — the same error string
+// ("timeout") that VerifyProvider surfaces into result.Error and that
+// verifyProviderViaMDM buckets as securityinfo-timeout.
+func TestVerifyProviderTimeoutErrorString(t *testing.T) {
+	c := testClient()
+	_, err := c.WaitForSecurityInfo("UDID-NO-REPLY", 50*time.Millisecond)
+	if err == nil {
+		t.Fatal("expected a timeout error when no webhook arrives")
+	}
+	if !strings.Contains(err.Error(), "timeout") {
+		t.Errorf("error = %q, want it to contain %q", err.Error(), "timeout")
+	}
+}
+
+// TestVerifyProviderDeviceNotFound: LookupDevice returns no matching device, so
+// VerifyProvider reports DeviceEnrolled=false and an Error mentioning "not
+// found" — the signal verifyProviderViaMDM buckets as device-not-found.
+func TestVerifyProviderDeviceNotFound(t *testing.T) {
+	fake := &fakeMicroMDM{device: nil, commandUUID: "unused"}
+	c, _ := newFakeMDM(t, fake)
+
+	res, err := c.VerifyProvider("SERIAL-MISSING", true, true)
+	if err != nil {
+		t.Fatalf("VerifyProvider transport error: %v", err)
+	}
+	if res.DeviceEnrolled {
+		t.Errorf("DeviceEnrolled = true, want false for a missing device")
+	}
+	if !strings.Contains(res.Error, "not found") {
+		t.Errorf("Error = %q, want it to contain %q", res.Error, "not found")
+	}
+	// A device that was never found must not have triggered any command/push.
+	if len(fake.pushes()) != 0 {
+		t.Errorf("push count = %d, want 0 (no command for a missing device)", len(fake.pushes()))
+	}
+}

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -955,20 +955,16 @@ func (r *Registry) RestoreProviderState(p *Provider, rec *store.ProviderRecord) 
 	if !p.Attested {
 		p.Attested = rec.Attested
 	}
-	// Do NOT resurrect MDA/ACME proofs as standalone badges when trust was just
-	// capped back to self_signed: a hardware proof is only meaningful for the
-	// connection that earned it live. Restoring MDAVerified=true onto a fresh
-	// self_signed connection produced the misleading "mda_verified=true while
-	// self_signed" drift on /v1/providers/attestation. These flags are re-set by
-	// the live MDM/ACME legs (verifyAppleDeviceAttestation / applyACMETrust) once
-	// hardware is re-earned this connection.
-	if p.TrustLevel == TrustHardware {
-		p.MDAVerified = rec.MDAVerified
-		p.ACMEVerified = rec.ACMEVerified
-	} else {
-		p.MDAVerified = false
-		p.ACMEVerified = false
-	}
+	// Never resurrect MDA/ACME proofs from the store. Trust above self_signed was
+	// just capped away (see above), so a restored connection is always
+	// self_signed or lower — and a hardware proof is only meaningful for the
+	// connection that earned it live. Restoring MDAVerified=true here produced the
+	// misleading "mda_verified=true while self_signed" drift on
+	// /v1/providers/attestation. These flags are re-set by the live MDM/ACME legs
+	// (verifyAppleDeviceAttestation / applyACMETrust) once hardware is re-earned
+	// this connection.
+	p.MDAVerified = false
+	p.ACMEVerified = false
 
 	// Restore challenge state
 	if rec.LastChallengeVerified != nil {

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -429,6 +429,34 @@ func (p *Provider) GetMDMFailureReason() string {
 	return p.MDMFailureReason
 }
 
+// SetMDAProofIfHardware atomically attaches a late-arriving Apple Device
+// Attestation proof to the provider IFF it currently holds hardware trust and
+// the MDA serial matches the attested serial. Returns true if attached.
+//
+// The trust check and the field writes happen under a single p.mu acquisition on
+// purpose: doing them separately (read GetTrustLevel, then write the fields) is a
+// TOCTOU — a concurrent SetAttested demotion between the check and the write
+// would attach MDA proof to a now-self_signed connection, re-creating the
+// "mda_verified while self_signed" drift. The single lock also closes the data
+// race with handleProviderAttestation, which reads these fields under p.mu.
+func (p *Provider) SetMDAProofIfHardware(certChain [][]byte, mdaResult *attestation.MDAResult) bool {
+	if mdaResult == nil {
+		return false
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.TrustLevel != TrustHardware {
+		return false
+	}
+	if p.AttestationResult == nil || mdaResult.DeviceSerial != p.AttestationResult.SerialNumber {
+		return false
+	}
+	p.MDAVerified = true
+	p.MDACertChain = certChain
+	p.MDAResult = mdaResult
+	return true
+}
+
 // SetLastChallengeVerified updates the challenge timestamp (thread-safe).
 func (p *Provider) SetLastChallengeVerified(t time.Time) {
 	p.mu.Lock()

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -219,11 +219,20 @@ type Provider struct {
 	MDAResult         *attestation.MDAResult // parsed OIDs from Apple cert
 	ACMEVerified      bool                   // true if ACME device-attest-01 client cert verified (SE key proven)
 	SEKeyBound        bool                   // true if SE key was bound to device via MDA nonce
-	Status            ProviderStatus
-	Conn              *websocket.Conn
-	LastHeartbeat     time.Time
-	Stats             protocol.HeartbeatStats // lifetime counters shown to users
-	lastSessionStats  protocol.HeartbeatStats // raw counters from the current provider process
+
+	// MDMFailureReason records the last MDM verification outcome for this
+	// connection, bucketed for observability: "" (verified/none),
+	// "device-not-found", "found-not-enrolled", "securityinfo-timeout",
+	// "posture-mismatch", or "error". In-memory + per-connection — it explains
+	// why a provider is (still) self_signed so the stuck-cohort gauge can
+	// distinguish "never enrolled" from "enrolled but unresponsive".
+	MDMFailureReason string
+
+	Status           ProviderStatus
+	Conn             *websocket.Conn
+	LastHeartbeat    time.Time
+	Stats            protocol.HeartbeatStats // lifetime counters shown to users
+	lastSessionStats protocol.HeartbeatStats // raw counters from the current provider process
 
 	// Account linkage (set when provider authenticates via device auth token)
 	AccountID string // internal account ID (from device auth flow)
@@ -388,6 +397,36 @@ func (p *Provider) SetAttested(attested bool, trust TrustLevel) {
 	p.Attested = attested
 	p.TrustLevel = trust
 	p.mu.Unlock()
+}
+
+// GetTrustLevel returns the current trust level (thread-safe).
+func (p *Provider) GetTrustLevel() TrustLevel {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.TrustLevel
+}
+
+// GetStatus returns the current provider status (thread-safe).
+func (p *Provider) GetStatus() ProviderStatus {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.Status
+}
+
+// SetMDMFailureReason records the bucketed reason this connection's MDM
+// verification has not (yet) granted hardware trust (thread-safe). Empty string
+// clears it (verified / no failure).
+func (p *Provider) SetMDMFailureReason(reason string) {
+	p.mu.Lock()
+	p.MDMFailureReason = reason
+	p.mu.Unlock()
+}
+
+// GetMDMFailureReason returns the last bucketed MDM verification reason (thread-safe).
+func (p *Provider) GetMDMFailureReason() string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.MDMFailureReason
 }
 
 // SetLastChallengeVerified updates the challenge timestamp (thread-safe).
@@ -916,8 +955,20 @@ func (r *Registry) RestoreProviderState(p *Provider, rec *store.ProviderRecord) 
 	if !p.Attested {
 		p.Attested = rec.Attested
 	}
-	p.MDAVerified = rec.MDAVerified
-	p.ACMEVerified = rec.ACMEVerified
+	// Do NOT resurrect MDA/ACME proofs as standalone badges when trust was just
+	// capped back to self_signed: a hardware proof is only meaningful for the
+	// connection that earned it live. Restoring MDAVerified=true onto a fresh
+	// self_signed connection produced the misleading "mda_verified=true while
+	// self_signed" drift on /v1/providers/attestation. These flags are re-set by
+	// the live MDM/ACME legs (verifyAppleDeviceAttestation / applyACMETrust) once
+	// hardware is re-earned this connection.
+	if p.TrustLevel == TrustHardware {
+		p.MDAVerified = rec.MDAVerified
+		p.ACMEVerified = rec.ACMEVerified
+	} else {
+		p.MDAVerified = false
+		p.ACMEVerified = false
+	}
 
 	// Restore challenge state
 	if rec.LastChallengeVerified != nil {
@@ -3651,6 +3702,68 @@ func (r *Registry) ProviderCountByVersion() map[string]int {
 			ver = "unknown"
 		}
 		counts[ver]++
+	}
+	return counts
+}
+
+// TrustStatusCount is one bucket of the fleet trust-state gauge.
+type TrustStatusCount struct {
+	TrustLevel string
+	Status     string
+	Count      int
+}
+
+// ProviderCountByTrustStatus buckets every connected provider by
+// (trust_level, status) so the coordinator can alert on a growing
+// self_signed/untrusted cohort. Offline providers are excluded (they are not a
+// live routability problem). Unlike most gauges this includes untrusted, since
+// the untrusted cohort is exactly what we want visibility into.
+func (r *Registry) ProviderCountByTrustStatus() []TrustStatusCount {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	type key struct{ trust, status string }
+	counts := make(map[key]int)
+	for _, p := range r.providers {
+		p.mu.Lock()
+		status := p.Status
+		trust := p.TrustLevel
+		p.mu.Unlock()
+		if status == StatusOffline {
+			continue
+		}
+		counts[key{string(trust), string(status)}]++
+	}
+	out := make([]TrustStatusCount, 0, len(counts))
+	for k, n := range counts {
+		out = append(out, TrustStatusCount{TrustLevel: k.trust, Status: k.status, Count: n})
+	}
+	return out
+}
+
+// ProviderCountByMDMFailure buckets connected, non-hardware providers by their
+// last MDM verification failure reason (device-not-found, found-not-enrolled,
+// securityinfo-timeout, posture-mismatch, error). This is the stuck-cohort
+// breakdown: it distinguishes "never enrolled" from "enrolled but the live
+// SecurityInfo check is timing out" so an operator knows whether the problem is
+// provider-side enrollment or APNs/MDM delivery. Hardware providers (reason
+// cleared) are excluded.
+func (r *Registry) ProviderCountByMDMFailure() map[string]int {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	counts := make(map[string]int)
+	for _, p := range r.providers {
+		p.mu.Lock()
+		status := p.Status
+		trust := p.TrustLevel
+		reason := p.MDMFailureReason
+		p.mu.Unlock()
+		if status == StatusOffline || trust == TrustHardware {
+			continue
+		}
+		if reason == "" {
+			reason = "pending"
+		}
+		counts[reason]++
 	}
 	return counts
 }

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -399,6 +399,26 @@ func (p *Provider) SetAttested(attested bool, trust TrustLevel) {
 	p.mu.Unlock()
 }
 
+// GrantHardwareIfNotUntrusted atomically promotes the provider to hardware trust
+// unless it is currently untrusted, returning whether it granted. The status
+// check and the trust write happen under a SINGLE lock on purpose: a separate
+// GetStatus() check followed by SetAttested(hardware) is a TOCTOU — a concurrent
+// hard untrust from the challenge loop (binary-hash change / SIP disabled /
+// signature failure) landing in the gap would leave the registry in
+// hardware/untrusted and push a false "online" to the provider. Callers must only
+// run the rest of the grant (sendTrustStatus / persist / MDA) when this returns
+// true. Mirrors the SetMDAProofIfHardware single-lock pattern.
+func (p *Provider) GrantHardwareIfNotUntrusted() bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.Status == StatusUntrusted {
+		return false
+	}
+	p.Attested = true
+	p.TrustLevel = TrustHardware
+	return true
+}
+
 // GetTrustLevel returns the current trust level (thread-safe).
 func (p *Provider) GetTrustLevel() TrustLevel {
 	p.mu.Lock()

--- a/coordinator/registry/registry_trust_reliability_test.go
+++ b/coordinator/registry/registry_trust_reliability_test.go
@@ -3,6 +3,7 @@ package registry
 import (
 	"testing"
 
+	"github.com/eigeninference/d-inference/coordinator/attestation"
 	"github.com/eigeninference/d-inference/coordinator/store"
 )
 
@@ -169,5 +170,50 @@ func TestProviderCountByMDMFailure(t *testing.T) {
 	}
 	if total != 4 {
 		t.Errorf("total buckets = %d, want 4 (hardware + offline excluded)", total)
+	}
+}
+
+// TestSetMDAProofIfHardware covers the atomic late-MDA attach that fixes the
+// TOCTOU + data race in the onMDA callback: MDA proof is attached only to a
+// connection currently holding hardware trust, with a matching serial, and the
+// trust check + writes happen under a single lock.
+func TestSetMDAProofIfHardware(t *testing.T) {
+	chain := [][]byte{[]byte("der")}
+	mda := &attestation.MDAResult{DeviceSerial: "S1", DeviceUDID: "U1"}
+
+	// hardware + matching serial → attaches.
+	hw := New(testLogger()).Register("hw", nil, testRegisterMessage())
+	hw.Mu().Lock()
+	hw.TrustLevel = TrustHardware
+	hw.AttestationResult = &attestation.VerificationResult{SerialNumber: "S1"}
+	hw.Mu().Unlock()
+	if !hw.SetMDAProofIfHardware(chain, mda) {
+		t.Fatal("expected attach on hardware provider with matching serial")
+	}
+	if !hw.MDAVerified || len(hw.MDACertChain) != 1 || hw.MDAResult == nil {
+		t.Error("hardware provider should have MDA proof set")
+	}
+
+	// self_signed → must NOT attach (this is the drift/TOCTOU guard).
+	ss := New(testLogger()).Register("ss", nil, testRegisterMessage())
+	ss.Mu().Lock()
+	ss.TrustLevel = TrustSelfSigned
+	ss.AttestationResult = &attestation.VerificationResult{SerialNumber: "S1"}
+	ss.Mu().Unlock()
+	if ss.SetMDAProofIfHardware(chain, mda) {
+		t.Error("must NOT attach MDA proof to a self_signed provider")
+	}
+	if ss.MDAVerified {
+		t.Error("self_signed provider must not have MDAVerified set")
+	}
+
+	// hardware but serial mismatch → must NOT attach (different device).
+	mm := New(testLogger()).Register("mm", nil, testRegisterMessage())
+	mm.Mu().Lock()
+	mm.TrustLevel = TrustHardware
+	mm.AttestationResult = &attestation.VerificationResult{SerialNumber: "OTHER"}
+	mm.Mu().Unlock()
+	if mm.SetMDAProofIfHardware(chain, mda) {
+		t.Error("must NOT attach MDA proof when the MDA serial does not match")
 	}
 }

--- a/coordinator/registry/registry_trust_reliability_test.go
+++ b/coordinator/registry/registry_trust_reliability_test.go
@@ -1,0 +1,173 @@
+package registry
+
+import (
+	"testing"
+
+	"github.com/eigeninference/d-inference/coordinator/store"
+)
+
+// TestRestoreProviderStateDoesNotResurrectMDAWhenSelfSigned is the drift fix:
+// a stored record with hardware trust + MDAVerified/ACMEVerified=true must NOT
+// resurrect those proof badges onto a fresh connection. RestoreProviderState
+// caps restored trust to self_signed (hardware must be re-earned live), and when
+// the live trust is below hardware the MDA/ACME flags are forced false — they
+// are only meaningful for the connection that earned hardware live. This is what
+// kills the misleading "mda_verified=true while self_signed" state on
+// /v1/providers/attestation.
+func TestRestoreProviderStateDoesNotResurrectMDAWhenSelfSigned(t *testing.T) {
+	reg := New(testLogger())
+	p := reg.Register("p1", nil, testRegisterMessage())
+
+	rec := &store.ProviderRecord{
+		ID:           "p1",
+		TrustLevel:   string(TrustHardware), // stored as hardware...
+		Attested:     true,
+		MDAVerified:  true,
+		ACMEVerified: true,
+	}
+
+	reg.RestoreProviderState(p, rec)
+
+	// Trust is capped to self_signed (hardware is never resurrected from store).
+	if p.GetTrustLevel() != TrustSelfSigned {
+		t.Errorf("trust = %q, want %q (restore caps hardware → self_signed)", p.GetTrustLevel(), TrustSelfSigned)
+	}
+	// The drift fix: MDA/ACME proofs must be cleared, not carried over.
+	p.Mu().Lock()
+	mda, acme := p.MDAVerified, p.ACMEVerified
+	p.Mu().Unlock()
+	if mda {
+		t.Error("MDAVerified must be false on a self_signed reconnect (drift guard)")
+	}
+	if acme {
+		t.Error("ACMEVerified must be false on a self_signed reconnect (drift guard)")
+	}
+}
+
+// TestRestoreProviderStateKeepsProofsWhenSelfSignedStored verifies the
+// complementary branch: a record whose stored trust is at/below self_signed is
+// restored verbatim (not capped), and since the live trust is then NOT hardware,
+// MDA/ACME are still forced false. (RestoreProviderState only carries the proof
+// flags through when the post-restore trust level is hardware; because hardware
+// is always capped from a stored record, the practical guarantee is that a
+// restore never produces proofs on a non-hardware connection.)
+func TestRestoreProviderStateClearsProofsForSelfSignedRecord(t *testing.T) {
+	reg := New(testLogger())
+	p := reg.Register("p1", nil, testRegisterMessage())
+
+	rec := &store.ProviderRecord{
+		ID:           "p1",
+		TrustLevel:   string(TrustSelfSigned),
+		MDAVerified:  true,
+		ACMEVerified: true,
+	}
+	reg.RestoreProviderState(p, rec)
+
+	if p.GetTrustLevel() != TrustSelfSigned {
+		t.Errorf("trust = %q, want %q", p.GetTrustLevel(), TrustSelfSigned)
+	}
+	p.Mu().Lock()
+	mda, acme := p.MDAVerified, p.ACMEVerified
+	p.Mu().Unlock()
+	if mda || acme {
+		t.Errorf("proofs must be false for a non-hardware restore, got mda=%v acme=%v", mda, acme)
+	}
+}
+
+// TestProviderCountByTrustStatus buckets connected providers by (trust, status),
+// excluding offline providers (they are not a live routability problem) while
+// including untrusted (the cohort we want visibility into).
+func TestProviderCountByTrustStatus(t *testing.T) {
+	reg := New(testLogger())
+
+	// Two self_signed online, one hardware online, one untrusted, one offline.
+	mk := func(id string, trust TrustLevel, status ProviderStatus) {
+		p := reg.Register(id, nil, testRegisterMessage())
+		p.Mu().Lock()
+		p.TrustLevel = trust
+		p.Status = status
+		p.Mu().Unlock()
+	}
+	mk("ss1", TrustSelfSigned, StatusOnline)
+	mk("ss2", TrustSelfSigned, StatusOnline)
+	mk("hw1", TrustHardware, StatusOnline)
+	mk("un1", TrustSelfSigned, StatusUntrusted)
+	mk("off1", TrustHardware, StatusOffline) // excluded
+
+	counts := reg.ProviderCountByTrustStatus()
+
+	get := func(trust, status string) int {
+		for _, c := range counts {
+			if c.TrustLevel == trust && c.Status == status {
+				return c.Count
+			}
+		}
+		return 0
+	}
+
+	if n := get(string(TrustSelfSigned), string(StatusOnline)); n != 2 {
+		t.Errorf("self_signed/online = %d, want 2", n)
+	}
+	if n := get(string(TrustHardware), string(StatusOnline)); n != 1 {
+		t.Errorf("hardware/online = %d, want 1", n)
+	}
+	if n := get(string(TrustSelfSigned), string(StatusUntrusted)); n != 1 {
+		t.Errorf("self_signed/untrusted = %d, want 1", n)
+	}
+	// Offline must be excluded entirely.
+	for _, c := range counts {
+		if c.Status == string(StatusOffline) {
+			t.Errorf("offline provider must be excluded, found bucket %+v", c)
+		}
+	}
+	// Total counted = 4 (5 registered minus the offline one).
+	total := 0
+	for _, c := range counts {
+		total += c.Count
+	}
+	if total != 4 {
+		t.Errorf("total counted = %d, want 4 (offline excluded)", total)
+	}
+}
+
+// TestProviderCountByMDMFailure buckets connected, non-hardware providers by
+// MDMFailureReason. Hardware providers are excluded (reason cleared), offline
+// excluded, and an empty reason maps to "pending".
+func TestProviderCountByMDMFailure(t *testing.T) {
+	reg := New(testLogger())
+
+	mk := func(id string, trust TrustLevel, status ProviderStatus, reason string) {
+		p := reg.Register(id, nil, testRegisterMessage())
+		p.Mu().Lock()
+		p.TrustLevel = trust
+		p.Status = status
+		p.MDMFailureReason = reason
+		p.Mu().Unlock()
+	}
+	mk("a", TrustSelfSigned, StatusOnline, "securityinfo-timeout")
+	mk("b", TrustSelfSigned, StatusOnline, "securityinfo-timeout")
+	mk("c", TrustSelfSigned, StatusOnline, "device-not-found")
+	mk("d", TrustSelfSigned, StatusOnline, "")                  // → pending
+	mk("e", TrustHardware, StatusOnline, "")                    // excluded (hardware)
+	mk("f", TrustSelfSigned, StatusOffline, "device-not-found") // excluded (offline)
+
+	counts := reg.ProviderCountByMDMFailure()
+
+	if counts["securityinfo-timeout"] != 2 {
+		t.Errorf("securityinfo-timeout = %d, want 2", counts["securityinfo-timeout"])
+	}
+	if counts["device-not-found"] != 1 {
+		t.Errorf("device-not-found = %d, want 1 (offline one excluded)", counts["device-not-found"])
+	}
+	if counts["pending"] != 1 {
+		t.Errorf("pending = %d, want 1 (empty reason buckets as pending)", counts["pending"])
+	}
+	// Hardware provider must not contribute any bucket.
+	total := 0
+	for _, n := range counts {
+		total += n
+	}
+	if total != 4 {
+		t.Errorf("total buckets = %d, want 4 (hardware + offline excluded)", total)
+	}
+}

--- a/coordinator/registry/registry_trust_reliability_test.go
+++ b/coordinator/registry/registry_trust_reliability_test.go
@@ -44,13 +44,13 @@ func TestRestoreProviderStateDoesNotResurrectMDAWhenSelfSigned(t *testing.T) {
 	}
 }
 
-// TestRestoreProviderStateKeepsProofsWhenSelfSignedStored verifies the
+// TestRestoreProviderStateClearsProofsForSelfSignedRecord verifies the
 // complementary branch: a record whose stored trust is at/below self_signed is
-// restored verbatim (not capped), and since the live trust is then NOT hardware,
-// MDA/ACME are still forced false. (RestoreProviderState only carries the proof
-// flags through when the post-restore trust level is hardware; because hardware
-// is always capped from a stored record, the practical guarantee is that a
-// restore never produces proofs on a non-hardware connection.)
+// restored verbatim (not capped), and MDA/ACME proofs are still forced false.
+// RestoreProviderState always clears the proof flags (a restored connection is
+// always <= self_signed since hardware is capped away), so the guarantee is that
+// a restore never produces MDA/ACME proofs on a non-hardware connection — they
+// are re-earned live by the MDM/ACME legs this connection.
 func TestRestoreProviderStateClearsProofsForSelfSignedRecord(t *testing.T) {
 	reg := New(testLogger())
 	p := reg.Register("p1", nil, testRegisterMessage())

--- a/docs/provider-trust-reliability.md
+++ b/docs/provider-trust-reliability.md
@@ -114,6 +114,23 @@ confirmation (is the ingress actually terminating mTLS? is step-ca issuing on
 this path?). This change only makes the dormant-vs-active state observable so
 activation can be validated.
 
+> **SECURITY GATE — do NOT activate ACME without this.** Today `applyACMETrust`
+> grants `hardware` on (a) the cert chaining to the step-ca root and (b) the cert
+> key matching the attested SE key. It does **not** independently verify the
+> device's **SIP / Secure Boot** posture — it implicitly trusts step-ca's
+> issuance policy, and a cert's posture is *issuance-time*, not live. While ACME
+> is dormant this grants nothing, so it is not a live hole. But activating ACME
+> as-is would make `hardware` trust reachable with a *weaker* posture guarantee
+> than MDM SecurityInfo (the exact privacy invariant the gate exists to protect:
+> real traffic only to genuinely SIP-on / Secure-Boot-full hardware). Before
+> activation, `extractAndVerifyClientCert`/`applyACMETrust` MUST **fail closed**
+> unless the cert's Apple device-attest extensions assert SIP enabled + Secure
+> Boot full (OIDs `1.2.840.113635.100.8.13.*`, parsed by `attestation/mda.go`),
+> **and** the certs must be short-lived / re-attested per connection so the
+> posture is fresh (a long-lived cert lets a box that later disables Secure Boot
+> keep presenting an "all good" cert). Implement that OID posture check as step 1
+> of activation, with a test, before wiring step-ca + ingress mTLS.
+
 To validate activation once wired: watch `acme.client_cert{outcome:present_valid}`
 climb (certs are reaching us and verifying) and `acme.trust{outcome:granted}`
 follow (those certs are upgrading providers to hardware). See §6.

--- a/docs/provider-trust-reliability.md
+++ b/docs/provider-trust-reliability.md
@@ -1,0 +1,222 @@
+# Provider Trust Reliability
+
+How a provider earns **hardware** trust, why ~11% of the fleet got stranded at
+`self_signed`/`untrusted`, what the per-connection MDM fix changed, and how to
+observe and activate the (currently dormant) ACME device-cert leg.
+
+This is engineer-facing operational doc, not a spec. It does **not** change
+trust-grant semantics — hardware trust still requires a genuine, Apple-attested
+device. It makes the existing OR-trust model reliable and observable.
+
+---
+
+## 1. The problem
+
+Hardware trust via MDM is established by issuing a live **SecurityInfo** command
+over the MicroMDM → APNs → device channel and reading back the device's SIP /
+Secure Boot posture. The old model ran this verification at registration **and
+re-ran it on every 5-minute challenge** for any provider still at `self_signed`.
+
+Each re-verification fired a fresh MDM/APNs push. Apple throttles MDM pushes
+aggressively, so under steady fleet load most of those pushes were dropped or
+delayed past the SecurityInfo wait timeout. The check never landed, the provider
+stayed `self_signed`, the next 5-minute tick pushed again, and the cycle
+repeated. Net effect: roughly **11% of the fleet was stranded** unroutable at
+`self_signed`/`untrusted` even though the machines were genuine, enrolled Apple
+hardware — the trust path was self-inflicting an APNs throttle.
+
+A separate **drift** bug compounded this: a transient SecurityInfo miss (device
+briefly asleep, push delayed) could *downgrade* an already-trusted provider,
+because the verify path treated "no answer right now" the same as "posture
+failed."
+
+---
+
+## 2. The shipped fix
+
+The verification model moved from **poll-forever-per-challenge** to
+**once-per-connection, retried within the connection**:
+
+- **`mdmVerificationLoop` (per connection).** Spawned alongside the challenge
+  loop when a provider connects (`api/provider.go`). It owns SecurityInfo
+  verification for the lifetime of that one WebSocket and stops the moment
+  hardware is earned (here or via the ACME leg concurrently), on a terminal
+  posture mismatch, or when the connection closes.
+- **Explicit push + bounded backoff.** It sends the SecurityInfo command, then
+  retries on a fast→slow schedule (`30s, 2m, 5m`, then a 15-minute steady
+  cadence) — enough to survive APNs / Power-Nap delivery delay and to catch a
+  device that finishes enrollment mid-connection, while staying well under
+  Apple's push budget. It is **not** re-pushed on every 5-minute challenge.
+- **Transient ≠ untrust.** A miss/timeout/not-enrolled outcome is now treated as
+  *transient* — it schedules a retry and never downgrades a provider that
+  already holds trust. Only a real posture mismatch is terminal. This fixes the
+  drift downgrade.
+- **Observability gauges.** `providers.by_trust_status` and
+  `providers.by_mdm_failure` (see §6) make the stuck cohort and its cause
+  visible.
+
+### Why per-connection is security-equivalent to polling
+
+SIP and Secure Boot posture **cannot change at runtime**. Both require a reboot
+into Recovery to alter. A reboot drops the WebSocket, which ends
+`mdmVerificationLoop` and forces a fresh connection that re-verifies from
+scratch. So there is no window in which a machine flips its security posture
+while keeping a live, already-verified connection. We don't need to re-poll a
+stable property; we only need the one check to *land* — which the bounded
+in-connection retry now reliably achieves without spamming APNs.
+
+---
+
+## 3. The OR-trust model
+
+Hardware trust is granted by **either** path — it is already an OR:
+
+```
+TrustHardware  ==  valid+bound ACME device-attest-01 client cert   (no live MDM command)
+                OR live MDM SecurityInfo posture check passes       (MicroMDM → APNs → device)
+```
+
+- **MDM SecurityInfo** (`verifyProviderViaMDM`): the live-command path described
+  above. Operative in prod today.
+- **ACME device-attest-01** (`applyACMETrust`, `api/acme_verify.go`): the
+  provider presents an mTLS client certificate at WebSocket connect. The cert
+  was issued by step-ca only after Apple's ACME `device-attest-01` challenge
+  proved the CSR key lives in this machine's Secure Enclave. Verifying the cert
+  chain against the step-ca root — plus binding it to the provider's attested SE
+  key — proves genuine Apple hardware **with no live MDM/APNs round-trip at
+  all**. This is the throttle-immune leg.
+
+  `applyACMETrust` runs at connect but the attestation challenge hasn't
+  completed yet, so the binding checks fail on ordering; the result is stashed
+  (`stashPendingACME`) and re-applied by `retryACMETrust` once the SE-key
+  binding lands. Exit outcomes are now counted (`acme.trust`, §6).
+
+### ACME is currently DORMANT
+
+In prod, **zero** ACME verifications are observed. The cert-presentation leg is
+not wired end to end:
+
+1. **step-ca must issue the cert.** `enroll.go` already provisions the ACME
+   `device-attest-01` payload in the enrollment `.mobileconfig` (payload type
+   `com.apple.security.acme`, ACME path `eigeninference-acme`), so the client
+   side is ready — but step-ca must actually be running and issuing on that
+   path.
+2. **The ingress must do mTLS client auth** and forward the client cert to the
+   coordinator as `X-Ssl-Client-Verify` / `X-Ssl-Client-Cert` /
+   `X-Ssl-Client-Dn` headers (the headers `extractAndVerifyClientCert` reads).
+3. **`EIGENINFERENCE_STEP_CA_ROOT` must be set** (and optionally
+   `EIGENINFERENCE_STEP_CA_INTERMEDIATE`). Without the root,
+   `extractAndVerifyClientCert` returns early and the entire leg is off. The
+   coordinator now logs a **WARN at startup** when this is unset.
+
+**Activating ACME is out of scope here** — it needs deploy-architecture
+confirmation (is the ingress actually terminating mTLS? is step-ca issuing on
+this path?). This change only makes the dormant-vs-active state observable so
+activation can be validated.
+
+To validate activation once wired: watch `acme.client_cert{outcome:present_valid}`
+climb (certs are reaching us and verifying) and `acme.trust{outcome:granted}`
+follow (those certs are upgrading providers to hardware). See §6.
+
+---
+
+## 4. MDA is identity, not a reliability path
+
+Apple Device Attestation (MDA / `DevicePropertiesAttestation`,
+`verifyAppleDeviceAttestation`) is sometimes mistaken for a third reliability
+escape hatch. It is not.
+
+- MDA rides the **same live MicroMDM → APNs command channel** as SecurityInfo
+  (it's a `DeviceInformation` command). It is subject to the same APNs delivery
+  constraints, so it cannot bypass an MDM/APNs throttle.
+- Its purpose is **identity + anti-relay**: Apple signs a cert chain binding the
+  device to genuine hardware, and the SE-key hash is carried as the attestation
+  nonce (embedded as FreshnessCode, OID `1.2.840.113635.100.8.11.1`) so the SE
+  key is cryptographically bound to *this* machine. That stops a relay attack
+  where one machine answers attestation on behalf of another.
+
+So MDA strengthens *who* a provider is; it does not make trust *more reliable*
+to obtain. Don't reach for it to solve an APNs-delivery problem — that's what the
+ACME leg (no live command) is for.
+
+**SIP / Secure Boot posture** is available Apple-signed from **either**
+SecurityInfo (live) **or** the ACME device cert's attestation extensions (OIDs
+`1.2.840.113635.100.8.13.*`). The ACME leg therefore carries the same posture
+evidence without a live command, which is exactly why activating it removes the
+APNs dependency for the providers that present a cert.
+
+---
+
+## 5. The enrollment-completion gap
+
+A provider that never reaches hardware trust usually has an incomplete MDM
+enrollment, not a coordinator bug. The two distinct failure shapes (both bucketed
+into `providers.by_mdm_failure`, both surfaced by `darkbloom doctor`):
+
+| Reason (`MDMFailureReason`) | Meaning | Provider-side fix |
+|---|---|---|
+| `device-not-found` | The enrollment profile was never checked in to MicroMDM at all — MicroMDM has no record of this serial. | Re-install / repair the enrollment profile; confirm the `.mobileconfig` from `/v1/enroll` was actually installed and the MDM payload accepted. |
+| `found-not-enrolled` | MicroMDM knows the serial but check-in is incomplete — the device record exists but isn't fully enrolled/responsive. | Finish enrollment (approve MDM in System Settings), then keep the Mac awake and APNs reachable so the check-in completes. |
+| `securityinfo-timeout` | Enrolled, but the SecurityInfo push didn't return in time (APNs/Power-Nap delay). | Keep the Mac awake (disable sleep / Power Nap throttling); confirm APNs reachability. The in-connection retry will catch it once a push lands. |
+| `posture-mismatch` | Terminal — device reported SIP/Secure Boot disabled. | Re-enable SIP and Secure Boot (reboot into Recovery). |
+| `error` | Verification call errored. | Inspect coordinator logs for this provider. |
+
+General provider-side remedies: finish/repair the MDM enrollment profile, keep
+the Mac awake (so APNs pushes are delivered promptly), and ensure outbound APNs
+connectivity. `darkbloom doctor` reports the local view of enrollment + SE key +
+attestation so a provider operator can self-diagnose before the coordinator ever
+has to.
+
+---
+
+## 6. Monitoring
+
+Datadog gauges/counters to watch and alert on.
+
+**Trust-cohort gauges** (emitted on a ticker, `api/server.go`):
+
+- `providers.by_trust_status{trust_level,status}` — providers bucketed by trust
+  level and status. **Alert** when the `self_signed`/`untrusted` cohort grows or
+  fails to shrink — that's the stranded fleet.
+- `providers.by_mdm_failure{reason}` — connected, non-hardware providers bucketed
+  by `MDMFailureReason` (§5). Tells you *why* the stuck cohort is stuck:
+  - rising `device-not-found` / `found-not-enrolled` → provider-side enrollment
+    problem (action is on the operators / onboarding).
+  - rising `securityinfo-timeout` → MDM/APNs delivery problem (the thing the
+    per-connection fix mitigates; sustained growth means APNs is degraded or the
+    push budget is again exhausted).
+  - any `posture-mismatch` → genuinely insecure machines, expected to stay
+    untrusted.
+
+**ACME counters** (new in this change):
+
+- `acme.client_cert{outcome}` — emitted once per provider connect in
+  `extractAndVerifyClientCert`:
+  - `missing` — no client cert reached the coordinator (provider didn't present
+    one, or the ingress isn't forwarding `X-Ssl-Client-*` headers). **While ACME
+    is dormant this is expected to be ~100%.** Once activated, a stuck-high
+    `missing` rate means the ingress mTLS forwarding is broken.
+  - `present_invalid` — a cert was forwarded but failed nginx verify / PEM
+    parse / chain verification / key encoding. Indicates an issuance or
+    chain-of-trust problem.
+  - `present_valid` — cert parsed and verified against the step-ca root.
+- `acme.trust{outcome}` — emitted at each `applyACMETrust` exit:
+  - `nil_or_invalid` — no usable ACME result (the dormant default).
+  - `not_bound` — cert valid but the SE-key attestation hasn't bound yet; the
+    stash/retry path will re-apply after the challenge. Persistent `not_bound`
+    without an eventual `granted` means the retry isn't completing.
+  - `key_mismatch` — terminal: the cert's public key doesn't match the attested
+    Secure Enclave key. **Alert** — this is a relay/mismatch signal.
+  - `granted` — provider upgraded to hardware via ACME.
+
+**Startup signal:** the WARN
+`ACME device-cert verification disabled — EIGENINFERENCE_STEP_CA_ROOT not set; …`
+tells you at boot whether the ACME leg is even configured. Its absence (i.e. the
+companion `step-ca ACME client cert verification enabled` Info log) confirms the
+root is loaded.
+
+**Validation playbook for ACME activation:** after wiring step-ca + ingress mTLS
++ `EIGENINFERENCE_STEP_CA_ROOT`, restart and confirm the startup WARN is gone,
+then watch `acme.client_cert{outcome:present_valid}` rise as providers reconnect,
+followed by `acme.trust{outcome:granted}`, and a corresponding shrink of the
+`self_signed` cohort in `providers.by_trust_status`.

--- a/docs/provider-trust-reliability.md
+++ b/docs/provider-trust-reliability.md
@@ -10,6 +10,57 @@ device. It makes the existing OR-trust model reliable and observable.
 
 ---
 
+## At a glance: before vs after
+
+**Before** — MDM `SecurityInfo` was re-run on the 5-minute challenge for every
+`self_signed` provider. Each run pushed via APNs; Apple throttles those, so the
+checks timed out and the provider never escaped `self_signed`:
+
+```mermaid
+flowchart TD
+    A["Provider connects"] --> B["SE attestation → self_signed"]
+    B --> C{"every 5 min: SE challenge"}
+    C -->|"still self_signed → re-run MDM"| D["MDM SecurityInfo<br/>+ implicit APNs push to device"]
+    D --> E{"Apple APNs push budget<br/>~2-3 / hr / device"}
+    E -->|"5-min poll = 12 / hr → THROTTLED"| F["push dropped<br/>device never wakes"]
+    F --> G["SecurityInfo waiter times out (90s)"]
+    G -->|"any non-timeout error also<br/>treated as posture mismatch"| K["wrongly hard-untrusted"]
+    G -->|"loops every 5 min, forever"| C
+    B -.->|"reconnect"| H["trust capped to self_signed<br/>but MDAVerified restored"]
+    H --> I["mda_verified=true while self_signed<br/>(drift on attestation endpoint)"]
+    G --> J["self_signed / untrusted<br/>UNROUTABLE — ~11% of fleet"]
+    K --> J
+    style J fill:#ffdddd,stroke:#cc0000
+    style F fill:#ffdddd
+    style G fill:#ffdddd
+    style K fill:#ffdddd
+    style I fill:#ffeecc,stroke:#cc8800
+```
+
+**After** — the cheap SE liveness challenge stays on its ticker; MDM
+`SecurityInfo` moves to a per-connection loop with an explicit push and a
+push-budget-aware backoff. The check lands once and trust sticks for the
+connection (a reboot — the only way SIP/Secure Boot can change — drops the
+WebSocket and forces a fresh, re-verified connection):
+
+```mermaid
+flowchart TD
+    A["Provider connects"] --> B["SE attestation → self_signed"]
+    B --> C["challengeLoop: cheap SE liveness<br/>every 5 min, NO push<br/>feeds 6-min routing-freshness gate"]
+    B --> D["mdmVerificationLoop<br/>ONCE per connection"]
+    D --> E["SecurityInfo + explicit GET /push/udid<br/>bounded backoff 30s → 2m → 5m → 15m"]
+    E --> F{"outcome"}
+    F -->|"SecurityInfo confirms<br/>SIP on + Secure Boot full"| G["hardware → ROUTABLE"]
+    F -->|"transient: timeout / not-enrolled /<br/>transport error → retry in-budget, NO untrust"| E
+    F -->|"posture mismatch:<br/>SIP off / Secure Boot not full"| H["untrusted (terminal)"]
+    G --> R{"reboot?<br/>(only way SIP/Secure Boot changes)"}
+    R -->|"reboot drops the WebSocket"| A
+    style G fill:#ddffdd,stroke:#00aa00
+    style H fill:#ffdddd
+```
+
+---
+
 ## 1. The problem
 
 Hardware trust via MDM is established by issuing a live **SecurityInfo** command

--- a/docs/provider-trust-reliability.md
+++ b/docs/provider-trust-reliability.md
@@ -25,10 +25,20 @@ repeated. Net effect: roughly **11% of the fleet was stranded** unroutable at
 `self_signed`/`untrusted` even though the machines were genuine, enrolled Apple
 hardware — the trust path was self-inflicting an APNs throttle.
 
-A separate **drift** bug compounded this: a transient SecurityInfo miss (device
-briefly asleep, push delayed) could *downgrade* an already-trusted provider,
-because the verify path treated "no answer right now" the same as "posture
-failed."
+Two **drift / mis-classification** bugs compounded the noise (neither was a
+trust *downgrade* — a SecurityInfo timeout already stayed `self_signed` without
+untrusting):
+
+1. **Display drift:** on reconnect, trust is capped back to `self_signed` but the
+   stored `MDAVerified`/`ACMEVerified` flags (and the late-MDA cert payload) were
+   resurrected, so `/v1/providers/attestation` showed `mda_verified=true` next to
+   a `self_signed` provider — misleading anyone verifying a provider's hardware.
+2. **Outcome mis-classification:** the verify path treated *any* non-timeout
+   error as a posture mismatch — so a transient MicroMDM transport hiccup (the
+   SecurityInfo command failing to enqueue) would wrongly **hard-untrust** an
+   enrolled, genuinely-secure box. Only a SecurityInfo response that actually
+   reports SIP-off / Secure-Boot-not-full (or disagrees with the attestation) is
+   a real mismatch.
 
 ---
 

--- a/provider-swift/Sources/ProviderCore/Diagnostics/MDMTrustDiagnosis.swift
+++ b/provider-swift/Sources/ProviderCore/Diagnostics/MDMTrustDiagnosis.swift
@@ -25,9 +25,10 @@ public enum MDMTrustDiagnosis {
     /// state.
     ///
     /// - Parameters:
-    ///   - trustLevel: the coordinator's last reported trust level for this box
-    ///     (`"self_signed"`, `"hardware"`, `"mda_verified"`, …) — nil when the
-    ///     daemon hasn't received a trust status yet.
+    ///   - trustLevel: the coordinator's last reported trust level for this box.
+    ///     The coordinator only ever emits `"none"`, `"self_signed"`, or
+    ///     `"hardware"` (mda_verified is a separate boolean *proof*, never a trust
+    ///     level) — nil when the daemon hasn't received a trust status yet.
     ///   - enrollment: this Mac's MDM enrollment state from `checkMDMEnrollment`.
     /// - Returns: a `.trust` diagnostic to surface, or nil when no MDM-enrollment
     ///   hint is warranted (e.g. already enrolled AND hardware-trusted, where the
@@ -35,16 +36,15 @@ public enum MDMTrustDiagnosis {
     ///
     /// Callers should only invoke this when the box is NOT already
     /// hardware-trusted (the enrollment hint is pointless once hardware trust is
-    /// granted — e.g. via ACME, which needs no MDM profile). The `.hardware` /
-    /// `.mda_verified` short-circuit below is a defensive backstop, not the
-    /// primary gate.
+    /// granted — e.g. via ACME, which needs no MDM profile). The `"hardware"`
+    /// short-circuit below is a defensive backstop, not the primary gate.
     public static func diagnose(
         trustLevel: String?,
         enrollment: MDMEnrollmentState
     ) -> Diagnostic? {
         // Defensive: a hardware-trusted box never needs an enrollment nag, even
         // if a caller forgets to gate on it.
-        if let trustLevel, trustLevel == "hardware" || trustLevel == "mda_verified" {
+        if trustLevel == "hardware" {
             return nil
         }
 

--- a/provider-swift/Sources/ProviderCore/Diagnostics/MDMTrustDiagnosis.swift
+++ b/provider-swift/Sources/ProviderCore/Diagnostics/MDMTrustDiagnosis.swift
@@ -1,0 +1,81 @@
+import Foundation
+
+/// Pure decision for the "enrolled but the coordinator's live MDM check hasn't
+/// completed" diagnosis — the silent stall that `darkbloom doctor` used to miss.
+///
+/// The operative hardware-trust path is the coordinator's LIVE MDM SecurityInfo
+/// check, re-earned on every reconnect and polled ~every 5 min. Apple throttles
+/// SecurityInfo, so on a flaky/sleeping box that check can keep timing out: the
+/// device is genuinely enrolled in Darkbloom MDM, yet the coordinator never
+/// upgrades it past `self_signed`, so it stays ONLINE but receives NO traffic.
+///
+/// The coordinator does NOT emit a distinct "MDM timed out" trust reason — at
+/// registration it sends "SE attestation verified, awaiting MDM/ACME upgrade"
+/// and stays there. So this state can only be INFERRED locally, by combining
+/// the daemon's last trust level (`self_signed`) with this Mac's actual MDM
+/// enrollment (`profiles status` says it IS enrolled in Darkbloom). That pair —
+/// "we're enrolled, but trust is still self_signed" — is the unresponsive-MDM
+/// signature, and it must read differently from "not enrolled at all".
+///
+/// Pure value logic so it is unit-testable without spawning `profiles` or
+/// reading the daemon state file.
+public enum MDMTrustDiagnosis {
+    /// Decide the MDM-enrollment trust diagnostic for the operator, given the
+    /// daemon's last-known coordinator trust level and this Mac's MDM enrollment
+    /// state.
+    ///
+    /// - Parameters:
+    ///   - trustLevel: the coordinator's last reported trust level for this box
+    ///     (`"self_signed"`, `"hardware"`, `"mda_verified"`, …) — nil when the
+    ///     daemon hasn't received a trust status yet.
+    ///   - enrollment: this Mac's MDM enrollment state from `checkMDMEnrollment`.
+    /// - Returns: a `.trust` diagnostic to surface, or nil when no MDM-enrollment
+    ///   hint is warranted (e.g. already enrolled AND hardware-trusted, where the
+    ///   trust line above already says "earning").
+    ///
+    /// Callers should only invoke this when the box is NOT already
+    /// hardware-trusted (the enrollment hint is pointless once hardware trust is
+    /// granted — e.g. via ACME, which needs no MDM profile). The `.hardware` /
+    /// `.mda_verified` short-circuit below is a defensive backstop, not the
+    /// primary gate.
+    public static func diagnose(
+        trustLevel: String?,
+        enrollment: MDMEnrollmentState
+    ) -> Diagnostic? {
+        // Defensive: a hardware-trusted box never needs an enrollment nag, even
+        // if a caller forgets to gate on it.
+        if let trustLevel, trustLevel == "hardware" || trustLevel == "mda_verified" {
+            return nil
+        }
+
+        switch enrollment {
+        case .enrolledDarkbloom:
+            // Enrolled in OUR MDM but trust is still self_signed ⇒ the
+            // coordinator's live MDM SecurityInfo check hasn't completed. This is
+            // the case that previously printed nothing, leaving the operator to
+            // think doctor "passed" while they silently earn nothing.
+            //
+            // Only flag it while trust is self_signed (or unknown-but-enrolled):
+            // if trust were already hardware we'd have returned above.
+            return Diagnostic(
+                section: .trust, name: "mdm verification", level: .warn,
+                message: "this Mac IS enrolled in Darkbloom MDM, but the coordinator's live MDM SecurityInfo check hasn't completed — trust is still self_signed, so you're ONLINE but will receive NO traffic until that check passes (this network requires hardware trust). Apple throttles SecurityInfo, so a sleeping or flaky machine can keep this pending.",
+                fix: "keep the Mac awake and APNs reachable (don't let it sleep / drop network), then wait ~5 min for the next SecurityInfo poll. If it's still self_signed after >10 min, open System Settings → General → Device Management (Profiles) and confirm the Darkbloom profile is installed and NOT showing as Pending; if it's pending, approve it, otherwise re-run `darkbloom enroll`.")
+        case .enrolledOtherMDM(let serverURL):
+            return Diagnostic(
+                section: .trust, name: "mdm enrollment", level: .warn,
+                message: "this Mac is managed by another MDM (\(serverURL)) — macOS allows one MDM per device, so Darkbloom hardware trust can't be granted here.",
+                fix: "remove that profile in System Settings → Device Management (if it's yours to remove), then run `darkbloom enroll`.")
+        case .notEnrolled:
+            return Diagnostic(
+                section: .trust, name: "mdm enrollment", level: .warn,
+                message: "this Mac is not enrolled in MDM — hardware trust can't be granted, so you won't receive traffic on a hardware-trust network.",
+                fix: "run `darkbloom enroll` and approve the profile in System Settings → Profiles, then wait ~5 min.")
+        case .checkFailed:
+            // Unknown state — asserting "not enrolled" here would send an
+            // enrolled operator down the wrong flow, so stay silent (the
+            // coordinator-doctor check reports the tool failure separately).
+            return nil
+        }
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Diagnostics/MDMTrustDiagnosis.swift
+++ b/provider-swift/Sources/ProviderCore/Diagnostics/MDMTrustDiagnosis.swift
@@ -55,8 +55,12 @@ public enum MDMTrustDiagnosis {
             // the case that previously printed nothing, leaving the operator to
             // think doctor "passed" while they silently earn nothing.
             //
-            // Only flag it while trust is self_signed (or unknown-but-enrolled):
-            // if trust were already hardware we'd have returned above.
+            // Only flag it when we KNOW trust is self_signed. A nil trustLevel
+            // means the daemon is stopped/stale (no fresh trust status) — doctor's
+            // daemon/trust section already tells the operator to start/fix it, so a
+            // "you're ONLINE but earning nothing" MDM-pending warning here would be
+            // contradictory and point at the wrong fix.
+            guard trustLevel == "self_signed" else { return nil }
             return Diagnostic(
                 section: .trust, name: "mdm verification", level: .warn,
                 message: "this Mac IS enrolled in Darkbloom MDM, but the coordinator's live MDM SecurityInfo check hasn't completed — trust is still self_signed, so you're ONLINE but will receive NO traffic until that check passes (this network requires hardware trust). Apple throttles SecurityInfo, so a sleeping or flaky machine can keep this pending.",

--- a/provider-swift/Sources/ProviderCore/Diagnostics/MDMTrustDiagnosis.swift
+++ b/provider-swift/Sources/ProviderCore/Diagnostics/MDMTrustDiagnosis.swift
@@ -4,8 +4,10 @@ import Foundation
 /// completed" diagnosis — the silent stall that `darkbloom doctor` used to miss.
 ///
 /// The operative hardware-trust path is the coordinator's LIVE MDM SecurityInfo
-/// check, re-earned on every reconnect and polled ~every 5 min. Apple throttles
-/// SecurityInfo, so on a flaky/sleeping box that check can keep timing out: the
+/// check, re-earned per connection (the coordinator retries with a bounded
+/// backoff — roughly the first retry within a couple minutes, then ~every 15 min
+/// — not a fixed 5-min poll). Apple throttles SecurityInfo, so on a flaky/sleeping
+/// box that check can keep timing out: the
 /// device is genuinely enrolled in Darkbloom MDM, yet the coordinator never
 /// upgrades it past `self_signed`, so it stays ONLINE but receives NO traffic.
 ///
@@ -69,7 +71,7 @@ public enum MDMTrustDiagnosis {
             return Diagnostic(
                 section: .trust, name: "mdm verification", level: .warn,
                 message: "this Mac IS enrolled in Darkbloom MDM, but the coordinator's live MDM SecurityInfo check hasn't completed — trust is still self_signed, so you're ONLINE but will receive NO traffic until that check passes (this network requires hardware trust). Apple throttles SecurityInfo, so a sleeping or flaky machine can keep this pending.",
-                fix: "keep the Mac awake and APNs reachable (don't let it sleep / drop network), then wait ~5 min for the next SecurityInfo poll. If it's still self_signed after >10 min, open System Settings → General → Device Management (Profiles) and confirm the Darkbloom profile is installed and NOT showing as Pending; if it's pending, approve it, otherwise re-run `darkbloom enroll`.")
+                fix: "keep the Mac awake and APNs reachable (don't let it sleep / drop network), then wait a few minutes for the coordinator's next SecurityInfo check (it retries within ~2 min, then about every 15 min). If it's still self_signed after >15 min, open System Settings → General → Device Management (Profiles) and confirm the Darkbloom profile is installed and NOT showing as Pending; if it's pending, approve it, otherwise re-run `darkbloom enroll`.")
         case .enrolledOtherMDM(let serverURL):
             return Diagnostic(
                 section: .trust, name: "mdm enrollment", level: .warn,

--- a/provider-swift/Sources/ProviderCore/Diagnostics/MDMTrustDiagnosis.swift
+++ b/provider-swift/Sources/ProviderCore/Diagnostics/MDMTrustDiagnosis.swift
@@ -29,6 +29,9 @@ public enum MDMTrustDiagnosis {
     ///     The coordinator only ever emits `"none"`, `"self_signed"`, or
     ///     `"hardware"` (mda_verified is a separate boolean *proof*, never a trust
     ///     level) — nil when the daemon hasn't received a trust status yet.
+    ///   - status: the coordinator's last reported status (`"online"`,
+    ///     `"untrusted"`, …) — nil when unknown. The MDM-pending hint only applies
+    ///     to a provider that is actually `online`.
     ///   - enrollment: this Mac's MDM enrollment state from `checkMDMEnrollment`.
     /// - Returns: a `.trust` diagnostic to surface, or nil when no MDM-enrollment
     ///   hint is warranted (e.g. already enrolled AND hardware-trusted, where the
@@ -40,6 +43,7 @@ public enum MDMTrustDiagnosis {
     /// short-circuit below is a defensive backstop, not the primary gate.
     public static func diagnose(
         trustLevel: String?,
+        status: String?,
         enrollment: MDMEnrollmentState
     ) -> Diagnostic? {
         // Defensive: a hardware-trusted box never needs an enrollment nag, even
@@ -55,12 +59,13 @@ public enum MDMTrustDiagnosis {
             // the case that previously printed nothing, leaving the operator to
             // think doctor "passed" while they silently earn nothing.
             //
-            // Only flag it when we KNOW trust is self_signed. A nil trustLevel
-            // means the daemon is stopped/stale (no fresh trust status) — doctor's
-            // daemon/trust section already tells the operator to start/fix it, so a
-            // "you're ONLINE but earning nothing" MDM-pending warning here would be
-            // contradictory and point at the wrong fix.
-            guard trustLevel == "self_signed" else { return nil }
+            // Only flag it when we KNOW trust is self_signed AND the provider is
+            // online. A nil trustLevel means the daemon is stopped/stale; a
+            // self_signed/untrusted provider has a different (challenge-failure)
+            // problem the trust-status line already covers. In both cases the
+            // "you're ONLINE but earning nothing, just waiting on MDM" message
+            // would be wrong and point at the wrong fix.
+            guard trustLevel == "self_signed", status == "online" else { return nil }
             return Diagnostic(
                 section: .trust, name: "mdm verification", level: .warn,
                 message: "this Mac IS enrolled in Darkbloom MDM, but the coordinator's live MDM SecurityInfo check hasn't completed — trust is still self_signed, so you're ONLINE but will receive NO traffic until that check passes (this network requires hardware trust). Apple throttles SecurityInfo, so a sleeping or flaky machine can keep this pending.",

--- a/provider-swift/Sources/darkbloom/Diagnostics/DoctorRunner.swift
+++ b/provider-swift/Sources/darkbloom/Diagnostics/DoctorRunner.swift
@@ -66,8 +66,9 @@ enum DoctorRunner {
         let alreadyHardwareTrusted = stateFresh && state?.trust?.trustLevel == "hardware"
         if !alreadyHardwareTrusted {
             let liveTrustLevel = stateFresh ? state?.trust?.trustLevel : nil
+            let liveStatus = stateFresh ? state?.trust?.status : nil
             let enrollment = checkMDMEnrollment(coordinatorURL: snapshot.config.coordinator.url)
-            if let diag = MDMTrustDiagnosis.diagnose(trustLevel: liveTrustLevel, enrollment: enrollment) {
+            if let diag = MDMTrustDiagnosis.diagnose(trustLevel: liveTrustLevel, status: liveStatus, enrollment: enrollment) {
                 out.append(diag)
             }
         }

--- a/provider-swift/Sources/darkbloom/Diagnostics/DoctorRunner.swift
+++ b/provider-swift/Sources/darkbloom/Diagnostics/DoctorRunner.swift
@@ -55,21 +55,20 @@ enum DoctorRunner {
         // which needs no MDM profile). Nagging an already-hardware-trusted box to
         // enroll in MDM is a false warning that sends the operator down the wrong
         // flow and contradicts the trust line printed just above.
+        //
+        // Otherwise, delegate the verdict to the pure MDMTrustDiagnosis helper,
+        // which combines the daemon's last trust level with this Mac's actual MDM
+        // enrollment. This is what lets doctor DISTINGUISH "enrolled in Darkbloom
+        // MDM but the coordinator's live SecurityInfo check is still pending /
+        // timing out" (trust stuck at self_signed) from "not enrolled at all" —
+        // the previously-silent stall that left operators thinking they passed
+        // while earning nothing.
         let alreadyHardwareTrusted = stateFresh && state?.trust?.trustLevel == "hardware"
         if !alreadyHardwareTrusted {
-            switch checkMDMEnrollment(coordinatorURL: snapshot.config.coordinator.url) {
-            case .enrolledDarkbloom, .checkFailed:
-                // checkFailed: unknown state — asserting "not enrolled" here
-                // would send an enrolled operator down the wrong flow.
-                break
-            case .enrolledOtherMDM(let serverURL):
-                out.append(Diagnostic(section: .trust, name: "mdm enrollment", level: .warn,
-                                      message: "this Mac is managed by another MDM (\(serverURL)) — macOS allows one MDM per device, so Darkbloom hardware trust can't be granted here.",
-                                      fix: "remove that profile in System Settings → Device Management (if it's yours to remove), then run `darkbloom enroll`."))
-            case .notEnrolled:
-                out.append(Diagnostic(section: .trust, name: "mdm enrollment", level: .warn,
-                                      message: "this Mac is not enrolled in MDM — hardware trust can't be granted, so you won't receive traffic on a hardware-trust network.",
-                                      fix: "run `darkbloom enroll` and approve the profile in System Settings → Profiles, then wait ~5 min."))
+            let liveTrustLevel = stateFresh ? state?.trust?.trustLevel : nil
+            let enrollment = checkMDMEnrollment(coordinatorURL: snapshot.config.coordinator.url)
+            if let diag = MDMTrustDiagnosis.diagnose(trustLevel: liveTrustLevel, enrollment: enrollment) {
+                out.append(diag)
             }
         }
 

--- a/provider-swift/Sources/darkbloom/DoctorCommand.swift
+++ b/provider-swift/Sources/darkbloom/DoctorCommand.swift
@@ -324,7 +324,12 @@ func buildCoordinatorDoctorChecks(
             provider.acmeVerified ? "acme" : nil,
             provider.mdaVerified ? "mda" : nil,
         ].compactMap { $0 }.joined(separator: ",")
-        let proofText = proofs.isEmpty ? "self-signed only" : proofs
+        // When still self_signed, spell out that the MDM SecurityInfo proof is
+        // PENDING (not failed/absent) so the operator reads "waiting on the
+        // coordinator's live MDM check" rather than "self-signed only".
+        let proofText = proofs.isEmpty
+            ? "self-signed only, mdm=pending (coordinator's live MDM SecurityInfo check not yet passed)"
+            : proofs
         checks.append(.init(
             name: "coordinator trust",
             status: status,

--- a/provider-swift/Tests/ProviderCoreTests/MDMTrustDiagnosisTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/MDMTrustDiagnosisTests.swift
@@ -6,13 +6,14 @@ import Testing
 /// The P1.5 case: a Mac enrolled in Darkbloom MDM whose coordinator-side live
 /// MDM SecurityInfo check keeps timing out stays at trust=self_signed and earns
 /// nothing — but `darkbloom doctor` used to print nothing for it. These tests
-/// pin the inference: self_signed + enrolledDarkbloom ⇒ a clear WARN that is
-/// DISTINCT from the "not enrolled at all" warning.
+/// pin the inference: self_signed + online + enrolledDarkbloom ⇒ a clear WARN
+/// that is DISTINCT from the "not enrolled at all" warning.
 @Suite struct MDMTrustDiagnosisTests {
 
-    @Test func selfSignedEnrolledInDarkbloomWarnsAboutPendingMDMCheck() throws {
+    @Test func selfSignedOnlineEnrolledInDarkbloomWarnsAboutPendingMDMCheck() throws {
         let d = MDMTrustDiagnosis.diagnose(
             trustLevel: "self_signed",
+            status: "online",
             enrollment: .enrolledDarkbloom(serverURL: "https://api.darkbloom.dev/mdm/connect"))
         let diag = try #require(d)
         #expect(diag.section == .trust)
@@ -40,7 +41,19 @@ import Testing
         // MDM-pending warning here would be contradictory — stay silent.
         #expect(MDMTrustDiagnosis.diagnose(
             trustLevel: nil,
+            status: nil,
             enrollment: .enrolledDarkbloom(serverURL: "https://api.dev.darkbloom.xyz/mdm/connect")) == nil)
+    }
+
+    @Test func selfSignedButUntrustedStaysSilent() {
+        // self_signed + untrusted (e.g. after a hard challenge failure) is NOT a
+        // "just waiting on MDM" situation — the provider is untrusted, which the
+        // trust-status line already reports. The MDM-pending message claims the box
+        // is ONLINE, so it must NOT fire here.
+        #expect(MDMTrustDiagnosis.diagnose(
+            trustLevel: "self_signed",
+            status: "untrusted",
+            enrollment: .enrolledDarkbloom(serverURL: "https://api.darkbloom.dev/mdm/connect")) == nil)
     }
 
     @Test func enrolledAndHardwareTrustedEmitsNothing() {
@@ -49,6 +62,7 @@ import Testing
         // if the caller forgets to gate on hardware trust.
         #expect(MDMTrustDiagnosis.diagnose(
             trustLevel: "hardware",
+            status: "online",
             enrollment: .enrolledDarkbloom(serverURL: "https://api.darkbloom.dev/mdm/connect")) == nil)
     }
 
@@ -56,7 +70,8 @@ import Testing
         // The "not enrolled at all" case must read differently from the
         // "enrolled but pending" case (different name + message), so the operator
         // doesn't conflate the two flows.
-        let d = MDMTrustDiagnosis.diagnose(trustLevel: "self_signed", enrollment: .notEnrolled)
+        let d = MDMTrustDiagnosis.diagnose(
+            trustLevel: "self_signed", status: "online", enrollment: .notEnrolled)
         let diag = try #require(d)
         #expect(diag.level == .warn)
         #expect(diag.name == "mdm enrollment")
@@ -66,6 +81,7 @@ import Testing
         // It is genuinely distinct from the enrolled-but-pending diagnosis.
         let enrolled = MDMTrustDiagnosis.diagnose(
             trustLevel: "self_signed",
+            status: "online",
             enrollment: .enrolledDarkbloom(serverURL: "https://api.darkbloom.dev/mdm/connect"))
         #expect(diag.name != enrolled?.name)
         #expect(diag.message != enrolled?.message)
@@ -74,6 +90,7 @@ import Testing
     @Test func foreignMDMWarnsAboutSingleMDMConstraint() throws {
         let d = MDMTrustDiagnosis.diagnose(
             trustLevel: "self_signed",
+            status: "online",
             enrollment: .enrolledOtherMDM(serverURL: "https://corp.kandji.io/mdm/commands"))
         let diag = try #require(d)
         #expect(diag.level == .warn)
@@ -85,8 +102,8 @@ import Testing
     @Test func checkFailedStaysSilent() {
         // Unknown enrollment state must NOT assert non-enrollment; stay silent.
         #expect(MDMTrustDiagnosis.diagnose(
-            trustLevel: "self_signed", enrollment: .checkFailed) == nil)
+            trustLevel: "self_signed", status: "online", enrollment: .checkFailed) == nil)
         #expect(MDMTrustDiagnosis.diagnose(
-            trustLevel: nil, enrollment: .checkFailed) == nil)
+            trustLevel: nil, status: nil, enrollment: .checkFailed) == nil)
     }
 }

--- a/provider-swift/Tests/ProviderCoreTests/MDMTrustDiagnosisTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/MDMTrustDiagnosisTests.swift
@@ -51,9 +51,6 @@ import Testing
         #expect(MDMTrustDiagnosis.diagnose(
             trustLevel: "hardware",
             enrollment: .enrolledDarkbloom(serverURL: "https://api.darkbloom.dev/mdm/connect")) == nil)
-        #expect(MDMTrustDiagnosis.diagnose(
-            trustLevel: "mda_verified",
-            enrollment: .enrolledDarkbloom(serverURL: "https://api.darkbloom.dev/mdm/connect")) == nil)
     }
 
     @Test func notEnrolledIsADistinctWarning() throws {

--- a/provider-swift/Tests/ProviderCoreTests/MDMTrustDiagnosisTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/MDMTrustDiagnosisTests.swift
@@ -29,7 +29,7 @@ import Testing
         let fix = try #require(diag.fix)
         #expect(fix.lowercased().contains("awake"))
         #expect(fix.lowercased().contains("apns"))
-        #expect(fix.lowercased().contains("5 min"))
+        #expect(fix.lowercased().contains("15 min"))
         #expect(fix.contains("Pending"))
         #expect(fix.lowercased().contains("profile"))
     }

--- a/provider-swift/Tests/ProviderCoreTests/MDMTrustDiagnosisTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/MDMTrustDiagnosisTests.swift
@@ -33,15 +33,14 @@ import Testing
         #expect(fix.lowercased().contains("profile"))
     }
 
-    @Test func enrolledButTrustLevelUnknownStillWarnsAsPending() throws {
-        // Daemon hasn't reported a trust level yet (nil) but the Mac IS enrolled:
-        // treat as the same pending-MDM signature rather than staying silent.
-        let d = MDMTrustDiagnosis.diagnose(
+    @Test func enrolledButTrustLevelUnknownStaysSilent() {
+        // nil trustLevel means the daemon is stopped/stale (no fresh trust
+        // status). Doctor's daemon/trust section already tells the operator to
+        // start/fix the daemon, so emitting an "ONLINE but earning nothing"
+        // MDM-pending warning here would be contradictory — stay silent.
+        #expect(MDMTrustDiagnosis.diagnose(
             trustLevel: nil,
-            enrollment: .enrolledDarkbloom(serverURL: "https://api.dev.darkbloom.xyz/mdm/connect"))
-        let diag = try #require(d)
-        #expect(diag.level == .warn)
-        #expect(diag.name == "mdm verification")
+            enrollment: .enrolledDarkbloom(serverURL: "https://api.dev.darkbloom.xyz/mdm/connect")) == nil)
     }
 
     @Test func enrolledAndHardwareTrustedEmitsNothing() {

--- a/provider-swift/Tests/ProviderCoreTests/MDMTrustDiagnosisTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/MDMTrustDiagnosisTests.swift
@@ -1,0 +1,96 @@
+import Testing
+@testable import ProviderCore
+
+// MARK: - MDMTrustDiagnosis (pure verdict logic)
+
+/// The P1.5 case: a Mac enrolled in Darkbloom MDM whose coordinator-side live
+/// MDM SecurityInfo check keeps timing out stays at trust=self_signed and earns
+/// nothing — but `darkbloom doctor` used to print nothing for it. These tests
+/// pin the inference: self_signed + enrolledDarkbloom ⇒ a clear WARN that is
+/// DISTINCT from the "not enrolled at all" warning.
+@Suite struct MDMTrustDiagnosisTests {
+
+    @Test func selfSignedEnrolledInDarkbloomWarnsAboutPendingMDMCheck() throws {
+        let d = MDMTrustDiagnosis.diagnose(
+            trustLevel: "self_signed",
+            enrollment: .enrolledDarkbloom(serverURL: "https://api.darkbloom.dev/mdm/connect"))
+        let diag = try #require(d)
+        #expect(diag.section == .trust)
+        #expect(diag.level == .warn)
+        #expect(diag.name == "mdm verification")
+        // The operator must understand: enrolled, but the coordinator's MDM
+        // check hasn't completed, so no traffic yet.
+        #expect(diag.message.lowercased().contains("enrolled"))
+        #expect(diag.message.lowercased().contains("securityinfo"))
+        #expect(diag.message.contains("self_signed"))
+        #expect(diag.message.lowercased().contains("no traffic"))
+        // Concrete, actionable fix: keep awake / APNs / wait, then check Profiles.
+        let fix = try #require(diag.fix)
+        #expect(fix.lowercased().contains("awake"))
+        #expect(fix.lowercased().contains("apns"))
+        #expect(fix.lowercased().contains("5 min"))
+        #expect(fix.contains("Pending"))
+        #expect(fix.lowercased().contains("profile"))
+    }
+
+    @Test func enrolledButTrustLevelUnknownStillWarnsAsPending() throws {
+        // Daemon hasn't reported a trust level yet (nil) but the Mac IS enrolled:
+        // treat as the same pending-MDM signature rather than staying silent.
+        let d = MDMTrustDiagnosis.diagnose(
+            trustLevel: nil,
+            enrollment: .enrolledDarkbloom(serverURL: "https://api.dev.darkbloom.xyz/mdm/connect"))
+        let diag = try #require(d)
+        #expect(diag.level == .warn)
+        #expect(diag.name == "mdm verification")
+    }
+
+    @Test func enrolledAndHardwareTrustedEmitsNothing() {
+        // Once hardware-trusted, the enrollment hint is pointless — and emitting
+        // it would contradict the "earning" trust line. Defensive backstop even
+        // if the caller forgets to gate on hardware trust.
+        #expect(MDMTrustDiagnosis.diagnose(
+            trustLevel: "hardware",
+            enrollment: .enrolledDarkbloom(serverURL: "https://api.darkbloom.dev/mdm/connect")) == nil)
+        #expect(MDMTrustDiagnosis.diagnose(
+            trustLevel: "mda_verified",
+            enrollment: .enrolledDarkbloom(serverURL: "https://api.darkbloom.dev/mdm/connect")) == nil)
+    }
+
+    @Test func notEnrolledIsADistinctWarning() throws {
+        // The "not enrolled at all" case must read differently from the
+        // "enrolled but pending" case (different name + message), so the operator
+        // doesn't conflate the two flows.
+        let d = MDMTrustDiagnosis.diagnose(trustLevel: "self_signed", enrollment: .notEnrolled)
+        let diag = try #require(d)
+        #expect(diag.level == .warn)
+        #expect(diag.name == "mdm enrollment")
+        #expect(diag.message.lowercased().contains("not enrolled"))
+        #expect(diag.fix?.contains("darkbloom enroll") == true)
+
+        // It is genuinely distinct from the enrolled-but-pending diagnosis.
+        let enrolled = MDMTrustDiagnosis.diagnose(
+            trustLevel: "self_signed",
+            enrollment: .enrolledDarkbloom(serverURL: "https://api.darkbloom.dev/mdm/connect"))
+        #expect(diag.name != enrolled?.name)
+        #expect(diag.message != enrolled?.message)
+    }
+
+    @Test func foreignMDMWarnsAboutSingleMDMConstraint() throws {
+        let d = MDMTrustDiagnosis.diagnose(
+            trustLevel: "self_signed",
+            enrollment: .enrolledOtherMDM(serverURL: "https://corp.kandji.io/mdm/commands"))
+        let diag = try #require(d)
+        #expect(diag.level == .warn)
+        #expect(diag.name == "mdm enrollment")
+        #expect(diag.message.contains("corp.kandji.io"))
+        #expect(diag.message.lowercased().contains("another mdm"))
+    }
+
+    @Test func checkFailedStaysSilent() {
+        // Unknown enrollment state must NOT assert non-enrollment; stay silent.
+        #expect(MDMTrustDiagnosis.diagnose(
+            trustLevel: "self_signed", enrollment: .checkFailed) == nil)
+        #expect(MDMTrustDiagnosis.diagnose(
+            trustLevel: nil, enrollment: .checkFailed) == nil)
+    }
+}


### PR DESCRIPTION
## Before / after

**Before** — MDM `SecurityInfo` re-ran on the 5-min challenge for every `self_signed` provider; each run pushed via APNs, Apple throttled them, the checks timed out, and the provider never escaped `self_signed`:

```mermaid
flowchart TD
    A["Provider connects"] --> B["SE attestation → self_signed"]
    B --> C{"every 5 min: SE challenge"}
    C -->|"still self_signed → re-run MDM"| D["MDM SecurityInfo<br/>+ implicit APNs push to device"]
    D --> E{"Apple APNs push budget<br/>~2-3 / hr / device"}
    E -->|"5-min poll = 12 / hr → THROTTLED"| F["push dropped<br/>device never wakes"]
    F --> G["SecurityInfo waiter times out (90s)"]
    G -->|"any non-timeout error also<br/>treated as posture mismatch"| K["wrongly hard-untrusted"]
    G -->|"loops every 5 min, forever"| C
    B -.->|"reconnect"| H["trust capped to self_signed<br/>but MDAVerified restored"]
    H --> I["mda_verified=true while self_signed<br/>(drift on attestation endpoint)"]
    G --> J["self_signed / untrusted<br/>UNROUTABLE — ~11% of fleet"]
    K --> J
    style J fill:#ffdddd,stroke:#cc0000
    style F fill:#ffdddd
    style G fill:#ffdddd
    style K fill:#ffdddd
    style I fill:#ffeecc,stroke:#cc8800
```

**After** — cheap SE liveness stays on the ticker; MDM `SecurityInfo` is per-connection with an explicit push + budget-aware backoff. The check lands once and trust sticks for the connection (a reboot — the only way SIP/Secure Boot can change — drops the WebSocket and forces a fresh, re-verified connection):

```mermaid
flowchart TD
    A["Provider connects"] --> B["SE attestation → self_signed"]
    B --> C["challengeLoop: cheap SE liveness<br/>every 5 min, NO push<br/>feeds 6-min routing-freshness gate"]
    B --> D["mdmVerificationLoop<br/>ONCE per connection"]
    D --> E["SecurityInfo + explicit GET /push/udid<br/>bounded backoff 30s → 2m → 5m → 15m"]
    E --> F{"outcome"}
    F -->|"SecurityInfo confirms<br/>SIP on + Secure Boot full"| G["hardware → ROUTABLE"]
    F -->|"transient: timeout / not-enrolled /<br/>transport error → retry in-budget, NO untrust"| E
    F -->|"posture mismatch:<br/>SIP off / Secure Boot not full"| H["untrusted (terminal)"]
    G --> R{"reboot?<br/>(only way SIP/Secure Boot changes)"}
    R -->|"reboot drops the WebSocket"| A
    style G fill:#ddffdd,stroke:#00aa00
    style H fill:#ffdddd
```

---

## Problem

~11% of the provider fleet was stranded unroutable at `self_signed`/`untrusted` (prod requires `hardware`), even though the machines were genuine, enrolled Apple Silicon. Root cause: hardware trust is re-earned every reconnect via a live MDM `SecurityInfo` round-trip that **also re-fired every 5 minutes** for self_signed providers. Each fired an MDM/APNs push; Apple throttles those (~2–3/hr/device), so the checks timed out — the trust path was self-inflicting the throttle. (The APNs code-identity path already learned this lesson and is per-connection; MDM verification never got the same treatment.)

## Fix

**Per-connection MDM verification** (`mdmVerificationLoop`), not a 5-min poll. This is security-equivalent to polling: SIP/Secure Boot can't change without a reboot, and a reboot drops the WebSocket → reconnect re-verifies. The loop runs the initial check + a bounded, push-budget-aware backoff (30s→2m→5m→15m), stops on hardware-granted / terminal posture-mismatch / hard-untrust / disconnect.

### P0 — reliability
- Drop the per-challenge MDM re-run + registration spawn; consolidate into the per-connection loop.
- `SendSecurityInfoCommand` now issues an explicit `GET /push/{udid}` (parity with the MDA path) so the device wakes and pulls the command instead of waiting for its next idle check-in past the 90s window.
- Outcome classification via a **typed `VerificationResult.SecurityMismatch`** — a provider is hard-untrusted **only** on a received SecurityInfo proving SIP-off / Secure-Boot-not-full / attestation disagreement. Transient conditions (transport error, timeout, not-enrolled, ctx-cancel) stay `self_signed` and retry — they never untrust.
- `ctx` threaded through `VerifyProvider` → `WaitForSecurityInfo`/`WaitForDeviceAttestation` (prompt teardown on disconnect; no stale-provider mutation).

### P1 — observability + self-service
- Gauges: `providers.by_trust_status`, `providers.by_mdm_failure` (buckets: `device-not-found` / `found-not-enrolled` / `securityinfo-timeout` / `posture-mismatch`), `mdm.verification` outcome counter, `mdm_late_securityinfo_upgrade_total`.
- `darkbloom doctor`: surfaces "enrolled but the coordinator's MDM SecurityInfo check hasn't completed → you won't earn" (was a silent stall), distinct from "not enrolled".
- **Drift fix**: `RestoreProviderState` no longer resurrects `MDA`/`ACME` proofs onto a self_signed reconnect; `GET /v1/providers/attestation` gates the `mdm`/`mda`/`acme` booleans **and** the MDA cert-chain payload on live hardware trust; the late-MDA callback only attaches to a currently-hardware provider.

### P2 — observability + design doc (ACME activation deferred)
- `acme.client_cert` / `acme.trust` counters + startup WARN when `EIGENINFERENCE_STEP_CA_ROOT` is unset, so the (currently dormant) ACME leg's state is visible.
- `docs/provider-trust-reliability.md` documents the model, the OR-trust path, and a **fail-closed SIP/Secure-Boot security gate** that must be implemented before ACME is ever activated (verify Apple device-attest OIDs `100.8.13.*` + short-lived certs) — otherwise ACME would grant hardware with a weaker posture guarantee than SecurityInfo.

## Security / privacy

No consumer-prompt-privacy hole: hardware trust is still granted only at posture-gated sites, the routing gate is unchanged, and every change is deny-direction or display/observability. Reviewed by an independent Claude reviewer (PASS) and codex-rescue (PASS after the fixes above).

## Tests

New: per-connection verify, explicit-push, transport-error→transient (no untrust), posture-mismatch→terminal, MDA-payload-suppressed-for-self_signed, restore-clears-proofs, both gauges, ACME outcome metrics. All pass under `-race`; gofmt/vet clean. The 90s real-timeout case is opt-in (`RUN_MDM_TIMEOUT_TEST=1`). Swift `doctor` has a Swift Testing suite; on-box `swift build` pending (worktree submodules uninitialized; pre-push hook skips Swift).

## Deploy
Coordinator-only (+ provider `doctor`). **Not deployed** — prod is human-only. CI is the authoritative build/test gate (esp. the Swift target).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
