### PR TITLE
feat(coordinator): improve consumer routing controls

### DIFF
--- a/coordinator/api/build.go
+++ b/coordinator/api/build.go
@@ -1,0 +1,9 @@
+package api
+
+// Build metadata is filled by release builds via -ldflags. Safe defaults keep
+// local and test builds identifiable without requiring build-time injection.
+var (
+	BuildVersion = "dev"
+	BuildCommit  = "unknown"
+	BuildDate    = "unknown"
+)

--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -16,6 +16,7 @@ package api
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -292,7 +293,7 @@ func (s *Server) resolveRequestedModel(parsed map[string]any, rawBody []byte, re
 // immediate capacity, route this request to Previous instead of returning a fast
 // 429. Hard constraints and permanent model-too-large failures are handled by the
 // caller and do not use this fallback.
-func (s *Server) maybeFallbackAliasCapacity(parsed map[string]any, publicModel, currentModel string, estimatedPromptTokens, requestedMaxTokens int, traits registry.RequestTraits, allowedProviderSerials []string) (string, bool) {
+func (s *Server) maybeFallbackAliasCapacity(parsed map[string]any, publicModel, currentModel string, estimatedPromptTokens, requestedMaxTokens int, traits registry.RequestTraits, requiresVision bool, allowedProviderSerials []string) (string, bool) {
 	if publicModel == "" || publicModel == currentModel {
 		return currentModel, false
 	}
@@ -303,7 +304,7 @@ func (s *Server) maybeFallbackAliasCapacity(parsed map[string]any, publicModel, 
 	if !s.registry.IsModelInCatalog(target.Previous) {
 		return currentModel, false
 	}
-	candidates, _, _ := s.registry.QuickCapacityCheck(target.Previous, estimatedPromptTokens, requestedMaxTokens, traits, allowedProviderSerials...)
+	candidates, _, _ := s.registry.QuickCapacityCheckForRequest(target.Previous, estimatedPromptTokens, requestedMaxTokens, traits, requiresVision, allowedProviderSerials...)
 	if candidates <= 0 {
 		return currentModel, false
 	}
@@ -326,12 +327,15 @@ func (s *Server) dispatchOneProvider(
 	reservedMicroUSD int64,
 	estimatedPromptTokens int,
 	requestedMaxTokens int,
+	tokenAdmission registry.TokenAdmission,
 	requiresVision bool,
 	traits registry.RequestTraits,
 	allowedProviderSerials []string,
 	isResponsesAPI bool,
 	policy selfRoutePolicy,
 	timing *registry.RequestTiming,
+	serviceReservation bool,
+	cacheAffinityKey string,
 	excludeProviders map[string]struct{},
 ) (
 	provider *registry.Provider,
@@ -355,8 +359,11 @@ func (s *Server) dispatchOneProvider(
 		RequiresVision:         requiresVision,
 		Traits:                 traits,
 		RequestedMaxTokens:     requestedMaxTokens,
+		TokenAdmission:         tokenAdmission,
+		CacheAffinityKey:       cacheAffinityKey,
 		ReservedMicroUSD:       reservedMicroUSD,
 		BaseReservedMicroUSD:   reservedMicroUSD,
+		ServiceReservation:     serviceReservation,
 		AllowedProviderSerials: allowedProviderSerials,
 		SelfRouteOnly:          policy.enabled,
 		PreferOwner:            policy.prefer,
@@ -783,6 +790,15 @@ func requestHasTools(parsed map[string]any) bool {
 	return ok && len(tools) > 0
 }
 
+func requestCacheAffinityKey(parsed map[string]any) string {
+	raw, ok := parsed["prompt_cache_key"].(string)
+	if !ok || raw == "" {
+		return ""
+	}
+	sum := sha256.Sum256([]byte(raw))
+	return fmt.Sprintf("%x", sum[:])
+}
+
 func estimateRequestedMaxTokens(parsed map[string]any) int {
 	for _, key := range []string{"max_tokens", "max_completion_tokens", "max_output_tokens"} {
 		if n, ok := intFromRequestValue(parsed[key]); ok && n > 0 {
@@ -896,6 +912,10 @@ func (s *Server) refundReservedBalance(pr *registry.PendingRequest, reference st
 	}
 	start := time.Now()
 	finalized, err := pr.FinalizeReservation(func() error {
+		if pr.ServiceReservation {
+			s.releaseServiceReservation(pr, "refund")
+			return nil
+		}
 		return s.store.Credit(pr.ConsumerKey, pr.ReservedMicroUSD, store.LedgerRefund, reference)
 	})
 	if err != nil {
@@ -910,8 +930,12 @@ func (s *Server) refundReservedBalance(pr *registry.PendingRequest, reference st
 	if !finalized {
 		return false
 	}
-	s.ddIncr("billing.reservation_refunds", []string{"model:" + pr.Model})
-	s.ddHistogram("store.credit.latency_ms", float64(time.Since(start).Milliseconds()), []string{"op:reservation_refund"})
+	tags := []string{"model:" + pr.Model, "mode:" + reservationMetricMode(pr.ServiceReservation)}
+	s.ddIncr("billing.reservation_refunds", tags)
+	if !pr.ServiceReservation {
+		s.ddIncr("billing.reservation_releases", append(tags, "reason:refund"))
+		s.ddHistogram("store.credit.latency_ms", float64(time.Since(start).Milliseconds()), []string{"op:reservation_refund"})
+	}
 	return true
 }
 
@@ -1366,6 +1390,7 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 	// schemas without crashing (version floor + template_render_ok gate);
 	// detected here, alongside the media gate, while the parsed body is hot.
 	hasTools := requestHasTools(parsed)
+	cacheAffinityKey := requestCacheAffinityKey(parsed)
 	// Shared media/tools fail-fast. Chat completions additionally rejects media
 	// sent via the Responses API surface (input-without-messages), because the
 	// Responses→chat lowering doesn't carry image/video parts through.
@@ -1425,7 +1450,8 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 	// token throttle alongside RPM. Charged upfront from the input estimate
 	// and the bounded max_tokens (OpenAI-style). Runs before the balance
 	// reservation so a throttled request never touches billing.
-	if !s.applyTokenRateLimit(w, r, estimatedPromptTokens, requestedMaxTokens) {
+	tokenAdmission, ok := s.applyTokenRateLimitWithAdmission(w, r, estimatedPromptTokens, requestedMaxTokens)
+	if !ok {
 		return
 	}
 
@@ -1436,6 +1462,7 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 	// portion. The routing estimate (estimatedPromptTokens, len/4) is kept
 	// separate so scheduler capacity checks aren't over-inflated.
 	var reservedMicroUSD int64
+	serviceReservation := false
 	// Self-route is free: skip the pre-flight balance reservation and the
 	// per-key spend cap entirely. A zero-balance owner must never be blocked
 	// from running on their own machine, and a self_route_only key never spends.
@@ -1448,8 +1475,9 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 			writeJSON(w, http.StatusPaymentRequired, errorResponse("insufficient_quota", msg, withCode("insufficient_quota")))
 			return
 		}
-		start := time.Now()
-		if err := s.ledger.Charge(consumerKey, reservedMicroUSD, "reserve:"+consumerKey); err != nil {
+		var err error
+		serviceReservation, err = s.reserveInitialBalance(consumerKey, model, reservedMicroUSD)
+		if err != nil {
 			if errors.Is(err, store.ErrInsufficientBalance) {
 				writeJSON(w, http.StatusPaymentRequired, errorResponse("insufficient_funds",
 					"your balance is too low for this request — add funds at /billing or lower max_tokens", withCode("insufficient_quota")))
@@ -1459,19 +1487,13 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 			}
 			return
 		}
-		s.ddHistogram("billing.reserved_micro_usd", float64(reservedMicroUSD), []string{"model:" + model})
-		s.ddHistogram("store.debit.latency_ms", float64(time.Since(start).Milliseconds()), []string{"op:reserve"})
 	}
 	timing.ReservedAt = time.Now()
 
 	// Refund reservation on early errors (before inference starts).
 	refundReservation := func() {
 		if reservedMicroUSD > 0 {
-			consumerKey := consumerKeyFromContext(r.Context())
-			start := time.Now()
-			_ = s.store.Credit(consumerKey, reservedMicroUSD, store.LedgerRefund, "reservation_refund")
-			s.ddIncr("billing.reservation_refunds", []string{"model:" + model})
-			s.ddHistogram("store.credit.latency_ms", float64(time.Since(start).Milliseconds()), []string{"op:reservation_refund"})
+			s.releaseInitialReservation(consumerKeyFromContext(r.Context()), model, reservedMicroUSD, serviceReservation)
 		}
 	}
 
@@ -1504,9 +1526,9 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 		// 503 which counts as downtime. Fast 429s also preserve our TTFT
 		// metrics. Self-route skips this fleet-wide gate — it queues on the
 		// owner's machine instead (handled below).
-		candidateCount, capacityRejections, modelTooLarge := s.registry.QuickCapacityCheck(model, estimatedPromptTokens, requestedMaxTokens, registry.RequestTraits{HasTools: hasTools}, allowedProviderSerials...)
+		candidateCount, capacityRejections, modelTooLarge := s.registry.QuickCapacityCheckForRequest(model, estimatedPromptTokens, requestedMaxTokens, registry.RequestTraits{HasTools: hasTools}, requiresVision, allowedProviderSerials...)
 		if candidateCount == 0 && capacityRejections > 0 {
-			if fallbackModel, switched := s.maybeFallbackAliasCapacity(parsed, publicModel, model, estimatedPromptTokens, requestedMaxTokens, registry.RequestTraits{HasTools: hasTools}, allowedProviderSerials); switched {
+			if fallbackModel, switched := s.maybeFallbackAliasCapacity(parsed, publicModel, model, estimatedPromptTokens, requestedMaxTokens, registry.RequestTraits{HasTools: hasTools}, requiresVision, allowedProviderSerials); switched {
 				model = fallbackModel
 				if isResponsesAPI {
 					providerParsed, err := responsesRequestToChatCompletions(parsed)
@@ -1519,7 +1541,7 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 				} else {
 					rawBody, _ = marshalForwardBody(parsed)
 				}
-				candidateCount, capacityRejections, modelTooLarge = s.registry.QuickCapacityCheck(model, estimatedPromptTokens, requestedMaxTokens, registry.RequestTraits{HasTools: hasTools}, allowedProviderSerials...)
+				candidateCount, capacityRejections, modelTooLarge = s.registry.QuickCapacityCheckForRequest(model, estimatedPromptTokens, requestedMaxTokens, registry.RequestTraits{HasTools: hasTools}, requiresVision, allowedProviderSerials...)
 			}
 		}
 		if candidateCount == 0 && capacityRejections == 0 && modelTooLarge > 0 {
@@ -1533,6 +1555,7 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if candidateCount == 0 && capacityRejections > 0 {
+			s.registry.RecordWarmPoolCapacityReject(model)
 			// Providers exist for this model but ALL are at capacity.
 			retryAfter := s.estimateRetryAfter(model)
 			w.Header().Set("Retry-After", strconv.Itoa(retryAfter))
@@ -1612,6 +1635,8 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 		consumerKey:            consumerKey,
 		consumerLocation:       consumerLocation,
 		reservedMicroUSD:       reservedMicroUSD,
+		tokenAdmission:         tokenAdmission,
+		serviceReservation:     serviceReservation,
 		estimatedPromptTokens:  estimatedPromptTokens,
 		requestedMaxTokens:     requestedMaxTokens,
 		requiresVision:         requiresVision,
@@ -1620,6 +1645,7 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 		stream:                 stream,
 		policy:                 policy,
 		allowedProviderSerials: allowedProviderSerials,
+		cacheAffinityKey:       cacheAffinityKey,
 		timing:                 timing,
 		deadline:               deadline,
 		speculativeAt:          time.Duration(float64(deadline) * speculativeTimerRatio),
@@ -3668,8 +3694,11 @@ func (s *Server) handleRotateAPIKey(w http.ResponseWriter, r *http.Request) {
 // This endpoint does not require authentication.
 func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, types.HealthResponse{
-		Status:    "ok",
-		Providers: s.registry.ProviderCount(),
+		Status:      "ok",
+		Providers:   s.registry.ProviderCount(),
+		Version:     BuildVersion,
+		BuildCommit: BuildCommit,
+		BuildDate:   BuildDate,
 	})
 }
 
@@ -3899,6 +3928,7 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 		return
 	}
 	model = buildModel
+	cacheAffinityKey := requestCacheAffinityKey(parsed)
 
 	if !s.registry.IsModelInCatalog(model) {
 		writeJSON(w, http.StatusNotFound, errorResponse("model_not_found",
@@ -3934,7 +3964,8 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 	parsed["endpoint"] = endpoint
 
 	// Per-account token rate limiting (ITPM/OTPM), before the reservation.
-	if !s.applyTokenRateLimit(w, r, estimatedPromptTokens, requestedMaxTokens) {
+	tokenAdmission, ok := s.applyTokenRateLimitWithAdmission(w, r, estimatedPromptTokens, requestedMaxTokens)
+	if !ok {
 		return
 	}
 
@@ -3944,6 +3975,7 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 	consumerKey := consumerKeyFromContext(r.Context())
 	consumerLocation := s.requestLocation(r)
 	var reservedMicroUSD int64
+	serviceReservation := false
 	// Self-route is free: skip the reservation and per-key spend cap.
 	if s.billing != nil && !policy.enabled {
 		reservedMicroUSD = s.reservationCost(model, billingPromptTokens, requestedMaxTokens)
@@ -3952,8 +3984,9 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 			writeJSON(w, http.StatusPaymentRequired, errorResponse("insufficient_quota", msg, withCode("insufficient_quota")))
 			return
 		}
-		start := time.Now()
-		if err := s.ledger.Charge(consumerKey, reservedMicroUSD, "reserve:"+consumerKey); err != nil {
+		var err error
+		serviceReservation, err = s.reserveInitialBalance(consumerKey, model, reservedMicroUSD)
+		if err != nil {
 			if errors.Is(err, store.ErrInsufficientBalance) {
 				writeJSON(w, http.StatusPaymentRequired, errorResponse("insufficient_funds",
 					"your balance is too low for this request — add funds at /billing or lower max_tokens", withCode("insufficient_quota")))
@@ -3963,15 +3996,10 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 			}
 			return
 		}
-		s.ddHistogram("billing.reserved_micro_usd", float64(reservedMicroUSD), []string{"model:" + model})
-		s.ddHistogram("store.debit.latency_ms", float64(time.Since(start).Milliseconds()), []string{"op:reserve"})
 	}
 	refundReservation := func() {
 		if reservedMicroUSD > 0 {
-			start := time.Now()
-			_ = s.store.Credit(consumerKey, reservedMicroUSD, store.LedgerRefund, "reservation_refund")
-			s.ddIncr("billing.reservation_refunds", []string{"model:" + model})
-			s.ddHistogram("store.credit.latency_ms", float64(time.Since(start).Milliseconds()), []string{"op:reservation_refund"})
+			s.releaseInitialReservation(consumerKey, model, reservedMicroUSD, serviceReservation)
 		}
 	}
 
@@ -3986,11 +4014,11 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 		// Prefer mode skips the public fleet pre-flight (no owner-trust
 		// relaxation there); owned-first dispatch + paid fallback + queue gate it.
 	} else {
-		candidateCount, capacityRejections, modelTooLarge := s.registry.QuickCapacityCheck(model, estimatedPromptTokens, requestedMaxTokens, registry.RequestTraits{HasTools: hasTools}, allowedProviderSerials...)
+		candidateCount, capacityRejections, modelTooLarge := s.registry.QuickCapacityCheckForRequest(model, estimatedPromptTokens, requestedMaxTokens, registry.RequestTraits{HasTools: hasTools}, requiresVision, allowedProviderSerials...)
 		if candidateCount == 0 && capacityRejections > 0 {
-			if fallbackModel, switched := s.maybeFallbackAliasCapacity(parsed, publicModel, model, estimatedPromptTokens, requestedMaxTokens, registry.RequestTraits{HasTools: hasTools}, allowedProviderSerials); switched {
+			if fallbackModel, switched := s.maybeFallbackAliasCapacity(parsed, publicModel, model, estimatedPromptTokens, requestedMaxTokens, registry.RequestTraits{HasTools: hasTools}, requiresVision, allowedProviderSerials); switched {
 				model = fallbackModel
-				candidateCount, capacityRejections, modelTooLarge = s.registry.QuickCapacityCheck(model, estimatedPromptTokens, requestedMaxTokens, registry.RequestTraits{HasTools: hasTools}, allowedProviderSerials...)
+				candidateCount, capacityRejections, modelTooLarge = s.registry.QuickCapacityCheckForRequest(model, estimatedPromptTokens, requestedMaxTokens, registry.RequestTraits{HasTools: hasTools}, requiresVision, allowedProviderSerials...)
 			}
 		}
 		if candidateCount == 0 && capacityRejections == 0 && modelTooLarge > 0 {
@@ -4002,6 +4030,7 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 			return
 		}
 		if candidateCount == 0 && capacityRejections > 0 {
+			s.registry.RecordWarmPoolCapacityReject(model)
 			retryAfter := s.estimateRetryAfter(model)
 			w.Header().Set("Retry-After", strconv.Itoa(retryAfter))
 			refundReservation()
@@ -4044,11 +4073,14 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 		FreeSelfRoute:          policy.enabled,
 		EstimatedPromptTokens:  estimatedPromptTokens,
 		RequiresVision:         requiresVision,
+		CacheAffinityKey:       cacheAffinityKey,
 		// Single-attempt path: no retry loop, so no AvoidVersion to thread.
 		Traits:               registry.RequestTraits{HasTools: hasTools},
 		RequestedMaxTokens:   requestedMaxTokens,
+		TokenAdmission:       tokenAdmission,
 		ReservedMicroUSD:     reservedMicroUSD,
 		BaseReservedMicroUSD: reservedMicroUSD,
+		ServiceReservation:   serviceReservation,
 		AcceptedCh:           make(chan struct{}, 1),
 		ChunkCh:              make(chan string, chunkBufferSize),
 		CompleteCh:           make(chan protocol.UsageInfo, 1),
@@ -4150,6 +4182,9 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 			}
 			return
 		}
+		if depth, oldest := s.registry.Queue().QueueStats(model); depth > 0 {
+			s.registry.RecordWarmPoolQueueEnqueued(model, depth, oldest)
+		}
 		s.ddIncr("routing.decisions", []string{"model:" + model, "model_type:" + s.registry.ModelType(model), "outcome:queued"})
 		provider, err = s.registry.Queue().WaitForProviderContext(r.Context(), queuedReq)
 		if err != nil {
@@ -4158,6 +4193,7 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 				return
 			}
 			retryAfter := s.estimateRetryAfter(model)
+			s.registry.RecordWarmPoolQueueTimeout(model, time.Since(queuedReq.EnqueuedAt))
 			w.Header().Set("Retry-After", strconv.Itoa(retryAfter))
 			refundReservation()
 			if policy.enabled {

--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -795,6 +795,10 @@ func requestCacheAffinityKey(parsed map[string]any) string {
 	if !ok || raw == "" {
 		return ""
 	}
+	const maxPromptCacheKeyBytes = 512
+	if len(raw) > maxPromptCacheKeyBytes {
+		return ""
+	}
 	sum := sha256.Sum256([]byte(raw))
 	return fmt.Sprintf("%x", sum[:])
 }

--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -293,23 +293,23 @@ func (s *Server) resolveRequestedModel(parsed map[string]any, rawBody []byte, re
 // immediate capacity, route this request to Previous instead of returning a fast
 // 429. Hard constraints and permanent model-too-large failures are handled by the
 // caller and do not use this fallback.
-func (s *Server) maybeFallbackAliasCapacity(parsed map[string]any, publicModel, currentModel string, estimatedPromptTokens, requestedMaxTokens int, traits registry.RequestTraits, requiresVision bool, allowedProviderSerials []string) (string, bool) {
+func (s *Server) maybeFallbackAliasCapacity(parsed map[string]any, publicModel, currentModel string, estimatedPromptTokens, requestedMaxTokens int, traits registry.RequestTraits, requiresVision bool, allowedProviderSerials []string) (string, int, int, int, bool) {
 	if publicModel == "" || publicModel == currentModel {
-		return currentModel, false
+		return currentModel, 0, 0, 0, false
 	}
 	target, ok := s.registry.AliasTarget(publicModel)
 	if !ok || target.Desired != currentModel || target.Previous == "" {
-		return currentModel, false
+		return currentModel, 0, 0, 0, false
 	}
 	if !s.registry.IsModelInCatalog(target.Previous) {
-		return currentModel, false
+		return currentModel, 0, 0, 0, false
 	}
-	candidates, _, _ := s.registry.QuickCapacityCheckForRequest(target.Previous, estimatedPromptTokens, requestedMaxTokens, traits, requiresVision, allowedProviderSerials...)
+	candidates, rejections, tooLarge := s.registry.QuickCapacityCheckForRequest(target.Previous, estimatedPromptTokens, requestedMaxTokens, traits, requiresVision, allowedProviderSerials...)
 	if candidates <= 0 {
-		return currentModel, false
+		return currentModel, candidates, rejections, tooLarge, false
 	}
 	parsed["model"] = target.Previous
-	return target.Previous, true
+	return target.Previous, candidates, rejections, tooLarge, true
 }
 
 // dispatchOneProvider encrypts and sends an inference request to a single
@@ -1528,8 +1528,9 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 		// owner's machine instead (handled below).
 		candidateCount, capacityRejections, modelTooLarge := s.registry.QuickCapacityCheckForRequest(model, estimatedPromptTokens, requestedMaxTokens, registry.RequestTraits{HasTools: hasTools}, requiresVision, allowedProviderSerials...)
 		if candidateCount == 0 && capacityRejections > 0 {
-			if fallbackModel, switched := s.maybeFallbackAliasCapacity(parsed, publicModel, model, estimatedPromptTokens, requestedMaxTokens, registry.RequestTraits{HasTools: hasTools}, requiresVision, allowedProviderSerials); switched {
+			if fallbackModel, fallbackCandidates, fallbackRejections, fallbackTooLarge, switched := s.maybeFallbackAliasCapacity(parsed, publicModel, model, estimatedPromptTokens, requestedMaxTokens, registry.RequestTraits{HasTools: hasTools}, requiresVision, allowedProviderSerials); switched {
 				model = fallbackModel
+				candidateCount, capacityRejections, modelTooLarge = fallbackCandidates, fallbackRejections, fallbackTooLarge
 				if isResponsesAPI {
 					providerParsed, err := responsesRequestToChatCompletions(parsed)
 					if err != nil {
@@ -1541,7 +1542,6 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 				} else {
 					rawBody, _ = marshalForwardBody(parsed)
 				}
-				candidateCount, capacityRejections, modelTooLarge = s.registry.QuickCapacityCheckForRequest(model, estimatedPromptTokens, requestedMaxTokens, registry.RequestTraits{HasTools: hasTools}, requiresVision, allowedProviderSerials...)
 			}
 		}
 		if candidateCount == 0 && capacityRejections == 0 && modelTooLarge > 0 {
@@ -4016,9 +4016,9 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 	} else {
 		candidateCount, capacityRejections, modelTooLarge := s.registry.QuickCapacityCheckForRequest(model, estimatedPromptTokens, requestedMaxTokens, registry.RequestTraits{HasTools: hasTools}, requiresVision, allowedProviderSerials...)
 		if candidateCount == 0 && capacityRejections > 0 {
-			if fallbackModel, switched := s.maybeFallbackAliasCapacity(parsed, publicModel, model, estimatedPromptTokens, requestedMaxTokens, registry.RequestTraits{HasTools: hasTools}, requiresVision, allowedProviderSerials); switched {
+			if fallbackModel, fallbackCandidates, fallbackRejections, fallbackTooLarge, switched := s.maybeFallbackAliasCapacity(parsed, publicModel, model, estimatedPromptTokens, requestedMaxTokens, registry.RequestTraits{HasTools: hasTools}, requiresVision, allowedProviderSerials); switched {
 				model = fallbackModel
-				candidateCount, capacityRejections, modelTooLarge = s.registry.QuickCapacityCheckForRequest(model, estimatedPromptTokens, requestedMaxTokens, registry.RequestTraits{HasTools: hasTools}, requiresVision, allowedProviderSerials...)
+				candidateCount, capacityRejections, modelTooLarge = fallbackCandidates, fallbackRejections, fallbackTooLarge
 			}
 		}
 		if candidateCount == 0 && capacityRejections == 0 && modelTooLarge > 0 {

--- a/coordinator/api/dispatch.go
+++ b/coordinator/api/dispatch.go
@@ -93,14 +93,17 @@ type dispatchState struct {
 	consumerKey            string
 	consumerLocation       *store.ProviderLocation
 	reservedMicroUSD       int64
+	serviceReservation     bool
 	estimatedPromptTokens  int
 	requestedMaxTokens     int
+	tokenAdmission         registry.TokenAdmission
 	requiresVision         bool
 	hasTools               bool
 	isResponsesAPI         bool
 	stream                 bool
 	policy                 selfRoutePolicy
 	allowedProviderSerials []string
+	cacheAffinityKey       string
 	timing                 *registry.RequestTiming
 	deadline               time.Duration
 	speculativeAt          time.Duration
@@ -145,9 +148,9 @@ func (d *dispatchState) dispatchPrimary() dispatchOutcome {
 	var dispatchErrCode int
 	d.provider, d.pr, _, dispatchErr, dispatchErrCode = s.dispatchOneProvider(
 		r, d.model, d.publicModel, d.rawBody, d.consumerKey, d.consumerLocation, d.reservedMicroUSD,
-		d.estimatedPromptTokens, d.requestedMaxTokens, d.requiresVision,
+		d.estimatedPromptTokens, d.requestedMaxTokens, d.tokenAdmission, d.requiresVision,
 		d.traits(),
-		d.allowedProviderSerials, d.isResponsesAPI, d.policy, d.timing, d.excludeProviders,
+		d.allowedProviderSerials, d.isResponsesAPI, d.policy, d.timing, d.serviceReservation, d.cacheAffinityKey, d.excludeProviders,
 	)
 	if d.provider == nil {
 		// No online provider has enough memory to ever fit this model.
@@ -200,9 +203,12 @@ func (d *dispatchState) dispatchPrimary() dispatchOutcome {
 			RequiresVision:         d.requiresVision,
 			Traits:                 d.traits(),
 			RequestedMaxTokens:     d.requestedMaxTokens,
+			TokenAdmission:         d.tokenAdmission,
 			ReservedMicroUSD:       d.reservedMicroUSD,
 			BaseReservedMicroUSD:   d.reservedMicroUSD,
+			ServiceReservation:     d.serviceReservation,
 			AllowedProviderSerials: d.allowedProviderSerials,
+			CacheAffinityKey:       d.cacheAffinityKey,
 			SelfRouteOnly:          d.policy.enabled,
 			PreferOwner:            d.policy.prefer,
 			OwnerAccountID:         d.policy.ownerAccountID,
@@ -235,6 +241,9 @@ func (d *dispatchState) dispatchPrimary() dispatchOutcome {
 			}
 			return outcomeResponseWritten
 		}
+		if depth, oldest := s.registry.Queue().QueueStats(d.model); depth > 0 {
+			s.registry.RecordWarmPoolQueueEnqueued(d.model, depth, oldest)
+		}
 		s.ddIncr("routing.decisions", []string{"model:" + d.model, "model_type:" + s.registry.ModelType(d.model), "outcome:queued"})
 
 		s.logger.Info("request queued, waiting for provider",
@@ -251,6 +260,7 @@ func (d *dispatchState) dispatchPrimary() dispatchOutcome {
 			}
 			d.refundReservation()
 			s.ddIncr("request_queue.timeout", []string{"model:" + d.model, "model_type:" + s.registry.ModelType(d.model)})
+			s.registry.RecordWarmPoolQueueTimeout(d.model, time.Since(queuedReq.EnqueuedAt))
 			retryAfter := s.estimateRetryAfter(d.model)
 			w.Header().Set("Retry-After", strconv.Itoa(retryAfter))
 			if d.policy.enabled {
@@ -500,6 +510,7 @@ func (d *dispatchState) waitFirstChunk() dispatchOutcome {
 				return outcomeAccepted
 			}
 			d.excludeProviders[provider.ID] = struct{}{}
+			s.registry.RecordWarmPoolTTFTMiss(d.model, d.deadline)
 			s.cancelDispatch(provider, pr)
 			d.lastErr = "timeout waiting for first response"
 			d.lastErrCode = http.StatusGatewayTimeout
@@ -545,6 +556,7 @@ func (d *dispatchState) runSpeculative() dispatchOutcome {
 
 	// Primary is slow. Attempt speculative backup dispatch.
 	s.ddIncr("inference.speculative_dispatch", []string{"model:" + d.model})
+	s.registry.RecordWarmPoolSpeculativeStarted(d.model)
 
 	var backupProvider *registry.Provider
 	var backupPR *registry.PendingRequest
@@ -573,10 +585,12 @@ func (d *dispatchState) runSpeculative() dispatchOutcome {
 
 		backupProvider, backupPR, _, _, _ = s.dispatchOneProvider(
 			r, d.model, d.publicModel, d.rawBody, d.consumerKey, d.consumerLocation, d.reservedMicroUSD,
-			d.estimatedPromptTokens, d.requestedMaxTokens, d.requiresVision,
+			d.estimatedPromptTokens, d.requestedMaxTokens, d.tokenAdmission, d.requiresVision,
 			d.traits(),
 			d.allowedProviderSerials, d.isResponsesAPI, d.policy,
 			&registry.RequestTiming{ReceivedAt: d.timing.ReceivedAt},
+			d.serviceReservation,
+			d.cacheAffinityKey,
 			backupExclude,
 		)
 	}
@@ -672,6 +686,7 @@ func (d *dispatchState) waitNoBackup() dispatchOutcome {
 				return outcomeAccepted
 			}
 			d.excludeProviders[provider.ID] = struct{}{}
+			s.registry.RecordWarmPoolTTFTMiss(d.model, d.deadline)
 			s.cancelDispatch(provider, pr)
 			d.lastErr = "timeout waiting for first response"
 			d.lastErrCode = http.StatusGatewayTimeout
@@ -775,6 +790,7 @@ func (d *dispatchState) runRace(backupProvider *registry.Provider, backupPR *reg
 			raceDeadline.Stop()
 			s.cancelDispatch(provider, pr)
 			s.ddIncr("inference.speculative_win", []string{"model:" + d.model})
+			s.registry.RecordWarmPoolSpeculativeWon(d.model)
 			if ok {
 				d.provider = backupProvider
 				d.pr = backupPR
@@ -866,6 +882,7 @@ func (d *dispatchState) runRace(backupProvider *registry.Provider, backupPR *reg
 				s.noteInferenceError(backupProvider.ID, backupPR, http.StatusGatewayTimeout)
 			}
 			s.cancelDispatch(provider, pr)
+			s.registry.RecordWarmPoolTTFTMiss(d.model, d.deadline)
 			s.cancelDispatch(backupProvider, backupPR)
 			d.excludeProviders[provider.ID] = struct{}{}
 			d.excludeProviders[backupProvider.ID] = struct{}{}
@@ -962,6 +979,7 @@ func (d *dispatchState) raceBackupChunkClosedWaitPrimary(provider *registry.Prov
 			// is already recorded); report the timeout, not the
 			// backup's stale error text.
 			d.excludeProviders[provider.ID] = struct{}{}
+			s.registry.RecordWarmPoolTTFTMiss(d.model, d.deadline)
 			s.cancelDispatch(provider, pr)
 			d.lastErr = "timeout waiting for first response"
 			d.lastErrCode = http.StatusGatewayTimeout
@@ -1063,6 +1081,7 @@ func (d *dispatchState) racePrimaryFailedWaitBackup(backupProvider *registry.Pro
 				return outcomeAccepted
 			}
 			d.excludeProviders[backupProvider.ID] = struct{}{}
+			s.registry.RecordWarmPoolTTFTMiss(d.model, d.deadline)
 			s.cancelDispatch(backupProvider, backupPR)
 			d.lastErr = "timeout waiting for first response (backup)"
 			d.lastErrCode = http.StatusGatewayTimeout
@@ -1147,6 +1166,7 @@ func (d *dispatchState) raceBackupErrWaitPrimary(provider *registry.Provider, pr
 				return outcomeAccepted
 			}
 			d.excludeProviders[provider.ID] = struct{}{}
+			s.registry.RecordWarmPoolTTFTMiss(d.model, d.deadline)
 			s.cancelDispatch(provider, pr)
 			d.lastErr = "timeout waiting for first response"
 			d.lastErrCode = http.StatusGatewayTimeout
@@ -1269,6 +1289,7 @@ func (d *dispatchState) waitAccepted() dispatchOutcome {
 			return outcomeRetry
 		case <-chunkTimer.C:
 			d.excludeProviders[provider.ID] = struct{}{}
+			s.registry.RecordWarmPoolTTFTMiss(d.model, firstContentBudget)
 			s.cancelDispatch(provider, pr)
 			// Accepted-then-silent (or preamble-then-stall) is a
 			// provider-at-fault 504 — feed the breaker so a provider
@@ -1380,7 +1401,7 @@ exhausted:
 		if statusCode == 0 {
 			// Distinguish capacity exhaustion (429) from genuine unavailability (503).
 			// A quick capacity check tells us if providers exist but are full.
-			_, capRej, _ := s.registry.QuickCapacityCheck(d.model, d.estimatedPromptTokens, d.requestedMaxTokens, registry.RequestTraits{HasTools: d.hasTools}, d.allowedProviderSerials...)
+			_, capRej, _ := s.registry.QuickCapacityCheckForRequest(d.model, d.estimatedPromptTokens, d.requestedMaxTokens, registry.RequestTraits{HasTools: d.hasTools}, d.requiresVision, d.allowedProviderSerials...)
 			if capRej > 0 {
 				statusCode = http.StatusTooManyRequests
 			} else {
@@ -1441,6 +1462,7 @@ func (d *dispatchState) writeCommittedResponse() {
 	providerID := provider.ID
 	chipName := provider.Hardware.ChipName
 	machineModel := provider.Hardware.MachineModel
+	s.registry.RecordCacheAffinity(pr.ConsumerKey, pr.Model, pr.CacheAffinityKey, providerID)
 
 	if pubKey != "" {
 		w.Header().Set("X-Provider-Encrypted", "true")

--- a/coordinator/api/model_alias_handlers_test.go
+++ b/coordinator/api/model_alias_handlers_test.go
@@ -270,7 +270,7 @@ func TestAliasCapacityFallbackUsesPreviousWhenDesiredFull(t *testing.T) {
 		"model":    aliasQAT,
 		"messages": []any{map[string]any{"role": "user", "content": "hi"}},
 	}
-	fallback, switched := srv.maybeFallbackAliasCapacity(parsed, "gemma-4-26b", aliasQAT, 10, 128, registry.RequestTraits{}, false, nil)
+	fallback, _, _, _, switched := srv.maybeFallbackAliasCapacity(parsed, "gemma-4-26b", aliasQAT, 10, 128, registry.RequestTraits{}, false, nil)
 	if !switched || fallback != aliasFP8 {
 		t.Fatalf("fallback = %q switched=%v, want previous %q", fallback, switched, aliasFP8)
 	}

--- a/coordinator/api/model_alias_handlers_test.go
+++ b/coordinator/api/model_alias_handlers_test.go
@@ -270,7 +270,7 @@ func TestAliasCapacityFallbackUsesPreviousWhenDesiredFull(t *testing.T) {
 		"model":    aliasQAT,
 		"messages": []any{map[string]any{"role": "user", "content": "hi"}},
 	}
-	fallback, switched := srv.maybeFallbackAliasCapacity(parsed, "gemma-4-26b", aliasQAT, 10, 128, registry.RequestTraits{}, nil)
+	fallback, switched := srv.maybeFallbackAliasCapacity(parsed, "gemma-4-26b", aliasQAT, 10, 128, registry.RequestTraits{}, false, nil)
 	if !switched || fallback != aliasFP8 {
 		t.Fatalf("fallback = %q switched=%v, want previous %q", fallback, switched, aliasFP8)
 	}

--- a/coordinator/api/provider.go
+++ b/coordinator/api/provider.go
@@ -453,9 +453,12 @@ func (s *Server) providerReadLoop(ctx context.Context, conn *websocket.Conn, pro
 				// the scheduler sees it as a candidate. Without this, the
 				// provider still looks cold until the next heartbeat.
 				s.registry.MarkModelWarm(providerID, statusMsg.ModelID)
-				s.registry.ClearPendingModelLoad(providerID, statusMsg.ModelID)
+				duration := s.registry.ClearPendingModelLoad(providerID, statusMsg.ModelID)
+				s.registry.RecordWarmPoolLoadResult(statusMsg.ModelID, true, duration)
 				s.registry.DrainQueuedRequestsForModel(statusMsg.ModelID)
 			case protocol.LoadModelStatusFailed:
+				duration := s.registry.PendingModelLoadDuration(providerID, statusMsg.ModelID)
+				s.registry.RecordWarmPoolLoadResult(statusMsg.ModelID, false, duration)
 				if statusMsg.Error == protocol.ProviderDrainingForUpdate {
 					// Transient: the provider refused only because it is
 					// draining ahead of an auto-update restart. Shorten the
@@ -1679,6 +1682,7 @@ func (s *Server) handleComplete(providerID string, provider *registry.Provider, 
 			"prompt_tokens", msg.Usage.PromptTokens,
 		)
 	}
+	s.reconcileOutputAdmission(pr, msg.Usage.CompletionTokens)
 
 	// Record job success and usage BEFORE closing ChunkCh. Closing
 	// ChunkCh unblocks the consumer response handler, and callers may
@@ -1772,7 +1776,44 @@ func (s *Server) handleComplete(providerID string, provider *registry.Provider, 
 	// mutations (overage charge, refund) happen inside the finalization
 	// gate so that a concurrent timeout/error refund path cannot race
 	// with the settlement here.
-	if pr.ReservedMicroUSD > 0 {
+	if pr.ServiceReservation && pr.ReservedMicroUSD > 0 {
+		var chargeErr error
+		finalized, _ := pr.FinalizeReservation(func() error {
+			if totalCost > 0 {
+				start := time.Now()
+				chargeErr = s.ledger.Charge(pr.ConsumerKey, totalCost, msg.RequestID)
+				s.ddHistogram("store.debit.latency_ms", float64(time.Since(start).Milliseconds()), []string{"op:service_reservation_settle"})
+			}
+			s.releaseServiceReservation(pr, "finalize")
+			return nil
+		})
+		if !finalized {
+			billingFinalized = false
+			s.logger.Warn("skipping completion billing for already-finalized service reservation",
+				"provider_id", providerID,
+				"request_id", msg.RequestID,
+			)
+		} else if chargeErr != nil {
+			if errors.Is(chargeErr, store.ErrInsufficientBalance) {
+				s.logger.Warn("service reservation settlement failed (insufficient balance) — zeroing uncollected charge",
+					"consumer_key", pr.ConsumerKey,
+					"cost_micro_usd", totalCost,
+				)
+			} else {
+				s.logger.Error("service reservation settlement failed (DB error) — zeroing uncollected charge",
+					"consumer_key", pr.ConsumerKey,
+					"cost_micro_usd", totalCost,
+					"error", chargeErr,
+				)
+			}
+			totalCost = 0
+			providerPayout = 0
+			s.ddIncr("billing.uncollected_zeroed", []string{"model:" + pr.Model, "mode:service_hold"})
+		} else {
+			s.ddIncr("billing.reservation_finalize", []string{"model:" + pr.Model, "mode:service_hold", "outcome:charged"})
+			s.ddHistogram("billing.service_settlement_micro_usd", float64(totalCost), []string{"model:" + pr.Model})
+		}
+	} else if pr.ReservedMicroUSD > 0 {
 		if !pr.MarkReservationFinalized() {
 			billingFinalized = false
 			s.logger.Warn("skipping completion billing for already-finalized reservation",

--- a/coordinator/api/reservations.go
+++ b/coordinator/api/reservations.go
@@ -28,9 +28,10 @@ func (m *serviceReservationManager) Reserve(accountID string, amount int64) erro
 	if m == nil || !m.enabled || amount <= 0 {
 		return nil
 	}
+	balance := m.store.GetBalance(accountID)
+
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	balance := m.store.GetBalance(accountID)
 	if balance-m.outstanding[accountID] < amount {
 		return store.ErrInsufficientBalance
 	}

--- a/coordinator/api/reservations.go
+++ b/coordinator/api/reservations.go
@@ -1,0 +1,114 @@
+package api
+
+import (
+	"sync"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/registry"
+	"github.com/eigeninference/d-inference/coordinator/store"
+)
+
+type serviceReservationManager struct {
+	store   store.Store
+	enabled bool
+
+	mu          sync.Mutex
+	outstanding map[string]int64
+}
+
+func newServiceReservationManager(st store.Store, enabled bool) *serviceReservationManager {
+	return &serviceReservationManager{store: st, enabled: enabled, outstanding: make(map[string]int64)}
+}
+
+func (m *serviceReservationManager) Enabled() bool {
+	return m != nil && m.enabled
+}
+
+func (m *serviceReservationManager) Reserve(accountID string, amount int64) error {
+	if m == nil || !m.enabled || amount <= 0 {
+		return nil
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	balance := m.store.GetBalance(accountID)
+	if balance-m.outstanding[accountID] < amount {
+		return store.ErrInsufficientBalance
+	}
+	m.outstanding[accountID] += amount
+	return nil
+}
+
+func (m *serviceReservationManager) Release(accountID string, amount int64) {
+	if m == nil || !m.enabled || amount <= 0 {
+		return
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	current := m.outstanding[accountID]
+	if amount >= current {
+		delete(m.outstanding, accountID)
+		return
+	}
+	m.outstanding[accountID] = current - amount
+}
+
+func reservationMetricMode(service bool) string {
+	if service {
+		return "service_hold"
+	}
+	return "ledger"
+}
+
+func (s *Server) useServiceReservation(accountID string) bool {
+	return s.serviceReservations != nil && s.serviceReservations.Enabled() && s.isServiceConsumer(accountID)
+}
+
+func (s *Server) reserveInitialBalance(accountID, model string, amount int64) (bool, error) {
+	serviceMode := s.useServiceReservation(accountID)
+	start := time.Now()
+	if serviceMode {
+		if err := s.serviceReservations.Reserve(accountID, amount); err != nil {
+			s.ddIncr("billing.reservations", []string{"model:" + model, "mode:service_hold", "outcome:rejected"})
+			return true, err
+		}
+		s.ddIncr("billing.reservations", []string{"model:" + model, "mode:service_hold", "outcome:reserved"})
+		s.ddHistogram("billing.reserved_micro_usd", float64(amount), []string{"model:" + model, "mode:service_hold"})
+		return true, nil
+	}
+	if err := s.ledger.Charge(accountID, amount, "reserve:"+accountID); err != nil {
+		s.ddIncr("billing.reservations", []string{"model:" + model, "mode:ledger", "outcome:rejected"})
+		return false, err
+	}
+	s.ddIncr("billing.reservations", []string{"model:" + model, "mode:ledger", "outcome:reserved"})
+	s.ddHistogram("billing.reserved_micro_usd", float64(amount), []string{"model:" + model, "mode:ledger"})
+	s.ddHistogram("store.debit.latency_ms", float64(time.Since(start).Milliseconds()), []string{"op:reserve"})
+	return false, nil
+}
+
+func (s *Server) releaseInitialReservation(accountID, model string, amount int64, serviceMode bool) {
+	if amount <= 0 {
+		return
+	}
+	tags := []string{"model:" + model, "mode:" + reservationMetricMode(serviceMode)}
+	if serviceMode {
+		s.serviceReservations.Release(accountID, amount)
+		s.ddIncr("billing.reservation_releases", append(tags, "reason:early"))
+		return
+	}
+	start := time.Now()
+	_ = s.store.Credit(accountID, amount, store.LedgerRefund, "reservation_refund")
+	s.ddIncr("billing.reservation_refunds", tags)
+	s.ddIncr("billing.reservation_releases", append(tags, "reason:early"))
+	s.ddHistogram("store.credit.latency_ms", float64(time.Since(start).Milliseconds()), []string{"op:reservation_refund"})
+}
+
+func (s *Server) releaseServiceReservation(pr *registry.PendingRequest, reason string) {
+	if pr == nil || !pr.ServiceReservation {
+		return
+	}
+	s.serviceReservations.Release(pr.ConsumerKey, pr.ReservedMicroUSD)
+	if reason == "" {
+		reason = "unknown"
+	}
+	s.ddIncr("billing.reservation_releases", []string{"model:" + pr.Model, "mode:service_hold", "reason:" + reason})
+}

--- a/coordinator/api/reservations_test.go
+++ b/coordinator/api/reservations_test.go
@@ -1,0 +1,197 @@
+package api
+
+import (
+	"errors"
+	"log/slog"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/billing"
+	"github.com/eigeninference/d-inference/coordinator/payments"
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+	"github.com/eigeninference/d-inference/coordinator/registry"
+	"github.com/eigeninference/d-inference/coordinator/store"
+)
+
+type countingStore struct {
+	store.Store
+
+	mu       sync.Mutex
+	debits   int
+	debitErr error
+	delay    time.Duration
+}
+
+func (s *countingStore) Debit(accountID string, amountMicroUSD int64, entryType store.LedgerEntryType, reference string) error {
+	if s.delay > 0 {
+		time.Sleep(s.delay)
+	}
+	s.mu.Lock()
+	s.debits++
+	err := s.debitErr
+	s.mu.Unlock()
+	if err != nil {
+		return err
+	}
+	return s.Store.Debit(accountID, amountMicroUSD, entryType, reference)
+}
+
+func (s *countingStore) DebitCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.debits
+}
+
+func newReservationTestServer(t *testing.T, cfg ServerConfig, debitErr error) (*Server, *countingStore) {
+	t.Helper()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	mem := store.NewMemory(store.Config{AdminKey: "test-key"})
+	st := &countingStore{Store: mem, debitErr: debitErr}
+	srv := NewServer(registry.New(logger), st, cfg, logger)
+	srv.SetBilling(billing.NewService(st, payments.NewLedger(st), logger, billing.Config{MockMode: true}))
+	return srv, st
+}
+
+func createServiceUser(t *testing.T, st store.Store, accountID string) {
+	t.Helper()
+	if err := st.CreateUser(&store.User{AccountID: accountID, PrivyUserID: "did:privy:" + accountID, Role: store.RoleService}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestServiceReservationDisabledUsesLedgerDebit(t *testing.T) {
+	srv, st := newReservationTestServer(t, ServerConfig{}, nil)
+	createServiceUser(t, st, "svc-disabled")
+	if err := st.Credit("svc-disabled", 1_000_000, store.LedgerDeposit, "seed"); err != nil {
+		t.Fatal(err)
+	}
+
+	serviceMode, err := srv.reserveInitialBalance("svc-disabled", "model", 100_000)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if serviceMode {
+		t.Fatal("service reservations should be disabled by default")
+	}
+	if got := st.DebitCount(); got != 1 {
+		t.Fatalf("Debit calls = %d, want 1", got)
+	}
+}
+
+func TestServiceReservationConcurrentAvoidsDebitHotRow(t *testing.T) {
+	srv, st := newReservationTestServer(t, ServerConfig{ServiceReservations: true}, errors.New("hot row unavailable"))
+	createServiceUser(t, st, "svc-hotrow")
+	if err := st.Credit("svc-hotrow", 10_000_000, store.LedgerDeposit, "seed"); err != nil {
+		t.Fatal(err)
+	}
+
+	const workers = 32
+	var wg sync.WaitGroup
+	errs := make(chan error, workers)
+	for range workers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			serviceMode, err := srv.reserveInitialBalance("svc-hotrow", "model", 100_000)
+			if err != nil {
+				errs <- err
+				return
+			}
+			if !serviceMode {
+				errs <- errors.New("expected service reservation mode")
+			}
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	if got := st.DebitCount(); got != 0 {
+		t.Fatalf("Debit calls = %d, want 0", got)
+	}
+}
+
+func TestNormalConsumerStillUsesSynchronousDebit(t *testing.T) {
+	srv, st := newReservationTestServer(t, ServerConfig{ServiceReservations: true}, store.ErrInsufficientBalance)
+	if err := st.Credit("consumer", 1_000_000, store.LedgerDeposit, "seed"); err != nil {
+		t.Fatal(err)
+	}
+
+	serviceMode, err := srv.reserveInitialBalance("consumer", "model", 100_000)
+	if !errors.Is(err, store.ErrInsufficientBalance) {
+		t.Fatalf("err = %v, want ErrInsufficientBalance", err)
+	}
+	if serviceMode {
+		t.Fatal("normal consumer used service reservation mode")
+	}
+	if got := st.DebitCount(); got != 1 {
+		t.Fatalf("Debit calls = %d, want 1", got)
+	}
+}
+
+func TestServiceReservationRefundReleasesHoldWithoutCredit(t *testing.T) {
+	srv, st := newReservationTestServer(t, ServerConfig{ServiceReservations: true}, nil)
+	createServiceUser(t, st, "svc-refund")
+	if err := st.Credit("svc-refund", 1_000_000, store.LedgerDeposit, "seed"); err != nil {
+		t.Fatal(err)
+	}
+	serviceMode, err := srv.reserveInitialBalance("svc-refund", "model", 250_000)
+	if err != nil || !serviceMode {
+		t.Fatalf("reserve serviceMode=%v err=%v", serviceMode, err)
+	}
+
+	pr := &registry.PendingRequest{RequestID: "svc-refund", Model: "model", ConsumerKey: "svc-refund", ReservedMicroUSD: 250_000, ServiceReservation: true}
+	if !srv.refundReservedBalance(pr, "test") {
+		t.Fatal("refundReservedBalance returned false")
+	}
+	if got := st.GetBalance("svc-refund"); got != 1_000_000 {
+		t.Fatalf("balance = %d, want unchanged 1000000", got)
+	}
+	if srv.refundReservedBalance(pr, "test-again") {
+		t.Fatal("second refund should be finalized/no-op")
+	}
+}
+
+func TestServiceReservationCompletionDebitsActualAndReleasesHold(t *testing.T) {
+	srv, st := newReservationTestServer(t, ServerConfig{ServiceReservations: true}, nil)
+	createServiceUser(t, st, "svc-complete")
+	if err := st.Credit("svc-complete", 1_000_000, store.LedgerDeposit, "seed"); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.SetModelPrice("platform", "svc-model", 1_000_000, 2_000_000); err != nil {
+		t.Fatal(err)
+	}
+	serviceMode, err := srv.reserveInitialBalance("svc-complete", "svc-model", 500_000)
+	if err != nil || !serviceMode {
+		t.Fatalf("reserve serviceMode=%v err=%v", serviceMode, err)
+	}
+
+	provider := srv.registry.Register("svc-provider", nil, &protocol.RegisterMessage{Models: []protocol.ModelInfo{{ID: "svc-model", ModelType: "chat", Quantization: "4bit"}}})
+	pr := &registry.PendingRequest{
+		RequestID:          "svc-complete",
+		Model:              "svc-model",
+		ConsumerKey:        "svc-complete",
+		ReservedMicroUSD:   500_000,
+		ServiceReservation: true,
+		ChunkCh:            make(chan string, 1),
+		CompleteCh:         make(chan protocol.UsageInfo, 1),
+		ErrorCh:            make(chan protocol.InferenceErrorMessage, 1),
+	}
+	provider.AddPending(pr)
+
+	usage := protocol.UsageInfo{PromptTokens: 10, CompletionTokens: 20}
+	expected := payments.CalculateCostWithOverridesNoMinimum("svc-model", usage.PromptTokens, usage.CompletionTokens, 1_000_000, 2_000_000, true)
+	srv.handleComplete(provider.ID, provider, &protocol.InferenceCompleteMessage{Type: protocol.TypeInferenceComplete, RequestID: pr.RequestID, Usage: usage})
+
+	if got := st.DebitCount(); got != 1 {
+		t.Fatalf("Debit calls = %d, want 1 completion settlement debit", got)
+	}
+	if got := st.GetBalance("svc-complete"); got != 1_000_000-expected {
+		t.Fatalf("balance = %d, want %d", got, 1_000_000-expected)
+	}
+}

--- a/coordinator/api/server.go
+++ b/coordinator/api/server.go
@@ -324,12 +324,19 @@ type Server struct {
 	// service accounts bypass rate limiting entirely.
 	serviceRateLimiter *ratelimit.Limiter
 
+	// serviceReservations avoids hot-row pre-router ledger debits for trusted
+	// service accounts when enabled. Normal consumers still use ledger debits.
+	serviceReservations *serviceReservationManager
+
 	// consumerTokenLimiter / serviceTokenLimiter enforce per-account input
 	// (ITPM) and output (OTPM) token-per-minute limits on inference endpoints,
 	// the industry-standard token throttle alongside RPM. Nil means no token
 	// limiting for that tier. Service accounts use serviceTokenLimiter.
 	consumerTokenLimiter *ratelimit.TokenLimiter
 	serviceTokenLimiter  *ratelimit.TokenLimiter
+	// outputAdmissionEstimator enables service-account expected-output admission
+	// for OTPM. Nil means disabled and preserves full max_tokens admission.
+	outputAdmissionEstimator *ratelimit.OutputAdmissionEstimator
 
 	// keyRPMLimiter / keyTokenLimiter enforce PER-KEY rate overrides (each key
 	// may carry a different ceiling) on top of the per-account limiters above.
@@ -365,6 +372,10 @@ func (s *Server) SetTokenLimiters(consumer, service *ratelimit.TokenLimiter) {
 	s.serviceTokenLimiter = service
 }
 
+func (s *Server) SetOutputAdmissionEstimator(estimator *ratelimit.OutputAdmissionEstimator) {
+	s.outputAdmissionEstimator = estimator
+}
+
 // SetKeyLimiters configures the per-key (variable-rate) RPM and ITPM/OTPM
 // limiters used for per-key overrides. Pass nil to disable per-key limiting.
 func (s *Server) SetKeyLimiters(rpm *ratelimit.Limiter, tokens *ratelimit.KeyTokenLimiter) {
@@ -379,53 +390,122 @@ func (s *Server) SetKeyLimiters(rpm *ratelimit.Limiter, tokens *ratelimit.KeyTok
 // and returns false. Admin bypasses. Standard x-ratelimit-*-{input,output}-tokens
 // headers are set on both success and rejection.
 func (s *Server) applyTokenRateLimit(w http.ResponseWriter, r *http.Request, inputTokens, outputTokens int) bool {
+	_, ok := s.applyTokenRateLimitWithAdmission(w, r, inputTokens, outputTokens)
+	return ok
+}
+
+func (s *Server) applyTokenRateLimitWithAdmission(w http.ResponseWriter, r *http.Request, inputTokens, outputTokens int) (registry.TokenAdmission, bool) {
+	admission := registry.TokenAdmission{AdmittedOutputTokens: outputTokens}
 	accountID := consumerKeyFromContext(r.Context())
 	if accountID == "admin" {
-		return true
+		return admission, true
 	}
 
 	// Resolve the account-tier token limiter (nil = no account-level token limit
 	// for this caller, e.g. a service account with no service token limiter).
 	tl := s.consumerTokenLimiter
 	tier := "consumer"
+	serviceAccount := false
 	if user := auth.UserFromContext(r.Context()); user != nil && user.Role == store.RoleService {
+		serviceAccount = true
+		tier = "service"
 		if s.serviceTokenLimiter != nil {
 			tl = s.serviceTokenLimiter
-			tier = "service"
 		} else {
 			tl = nil
 		}
 	}
+	admission.AccountTier = tier
+	if serviceAccount {
+		if estimatedOutput, estimated := s.outputAdmissionEstimator.Estimate(outputTokens); estimated {
+			admission.AdmittedOutputTokens = estimatedOutput
+			admission.EstimatedOutput = true
+		}
+	}
 
 	keyID, inRPS, inBurst, outRPS, outBurst, keyEnforced := s.keyTokenParams(r)
+	admission.AccountOutputLimited = tl != nil && tl.HasOutputLimit()
+	admission.KeyOutputLimited = keyEnforced && outRPS > 0 && outBurst > 0
+	admission.KeyOutputRPS = outRPS
+	admission.KeyOutputBurst = outBurst
+	if admission.TracksOutput() {
+		s.ddHistogram("ratelimit.output_admission.estimated_tokens", float64(admission.AdmittedOutputTokens), outputAdmissionTags(tier, admission.EstimatedOutput))
+	}
 
 	// Peek BOTH the per-key override and the account-level limiter before
 	// consuming either. Only commit when both have capacity, so a rejection in
 	// one limiter never debits the other (a per-key request that the account
 	// bucket rejects must not drain the key's quota, and vice-versa).
 	if keyEnforced {
-		if ok, dim, retry := s.keyTokenLimiter.Peek(keyID, inputTokens, outputTokens, inRPS, inBurst, outRPS, outBurst); !ok {
+		if ok, dim, retry := s.keyTokenLimiter.Peek(keyID, inputTokens, admission.AdmittedOutputTokens, inRPS, inBurst, outRPS, outBurst); !ok {
 			s.writeTokenRateLimited(w, "key", dim, retry)
-			return false
+			return admission, false
 		}
 	}
 	if tl != nil {
-		if ok, dim, retry := tl.Peek(accountID, inputTokens, outputTokens); !ok {
+		if ok, dim, retry := tl.Peek(accountID, inputTokens, admission.AdmittedOutputTokens); !ok {
 			setTokenRateLimitHeaders(w, tl, accountID)
 			s.writeTokenRateLimited(w, tier, dim, retry)
-			return false
+			return admission, false
 		}
 	}
 
 	// Both dimensions have capacity — commit to each.
 	if keyEnforced {
-		s.keyTokenLimiter.Commit(keyID, inputTokens, outputTokens, inRPS, inBurst, outRPS, outBurst)
+		s.keyTokenLimiter.Commit(keyID, inputTokens, admission.AdmittedOutputTokens, inRPS, inBurst, outRPS, outBurst)
 	}
 	if tl != nil {
-		tl.Commit(accountID, inputTokens, outputTokens)
+		tl.Commit(accountID, inputTokens, admission.AdmittedOutputTokens)
 		setTokenRateLimitHeaders(w, tl, accountID)
 	}
-	return true
+	return admission, true
+}
+
+func outputAdmissionTags(tier string, estimated bool) []string {
+	if tier == "" {
+		tier = "none"
+	}
+	return []string{"tier:" + tier, "estimated:" + strconv.FormatBool(estimated)}
+}
+
+func (s *Server) reconcileOutputAdmission(pr *registry.PendingRequest, actualOutputTokens int) {
+	if pr == nil || !pr.TokenAdmission.TracksOutput() {
+		return
+	}
+	admission := pr.TokenAdmission
+	if actualOutputTokens < 0 {
+		actualOutputTokens = 0
+	}
+	admittedOutputTokens := admission.AdmittedOutputTokens
+	if admittedOutputTokens < 0 {
+		admittedOutputTokens = 0
+	}
+	delta := actualOutputTokens - admittedOutputTokens
+	if delta < 0 {
+		delta = 0
+	}
+	tags := append(outputAdmissionTags(admission.AccountTier, admission.EstimatedOutput), "model:"+pr.Model)
+	s.ddHistogram("ratelimit.output_admission.actual_tokens", float64(actualOutputTokens), tags)
+	s.ddHistogram("ratelimit.output_admission.delta_tokens", float64(delta), tags)
+	if delta == 0 {
+		return
+	}
+	if admission.AccountOutputLimited {
+		var tl *ratelimit.TokenLimiter
+		switch admission.AccountTier {
+		case "service":
+			tl = s.serviceTokenLimiter
+		default:
+			tl = s.consumerTokenLimiter
+		}
+		if tl != nil {
+			tl.DebitOutput(pr.ConsumerKey, delta)
+		}
+	}
+	if admission.KeyOutputLimited && s.keyTokenLimiter != nil {
+		s.keyTokenLimiter.DebitOutput(pr.KeyID, delta, admission.KeyOutputRPS, admission.KeyOutputBurst)
+	}
+	s.ddCount("ratelimit.output_admission.delta_tokens_total", int64(delta), tags)
 }
 
 // writeTokenRateLimited writes a 429 for a token-dimension rejection with a
@@ -548,6 +628,7 @@ func NewServer(reg *registry.Registry, st store.Store, cfg ServerConfig, logger 
 		codeAttestThrottle:   newCodeAttestThrottle(),
 		settlements:          newSettlementHolder(),
 		zombieCanceller:      newZombieStreamCanceller(),
+		serviceReservations:  newServiceReservationManager(st, cfg.ServiceReservations),
 	}
 	s.registerDefaultGauges()
 	s.routes()

--- a/coordinator/api/server_config.go
+++ b/coordinator/api/server_config.go
@@ -21,6 +21,7 @@ type ServerConfig struct {
 	AdminKey             string
 	AdminEmails          []string
 	ReleaseKey           string
+	ServiceReservations  bool
 }
 
 // ReadServerConfig reads server configuration from environment variables.
@@ -36,6 +37,7 @@ func ReadServerConfig() ServerConfig {
 		AdminKey:             os.Getenv(env.EnvPrefix + "_ADMIN_KEY"),
 		AdminEmails:          ParseCommaList(env.EnvOr(env.EnvPrefix+"_ADMIN_EMAILS", "")),
 		ReleaseKey:           os.Getenv(env.EnvPrefix + "_RELEASE_KEY"),
+		ServiceReservations:  env.EnvBool(env.EnvPrefix+"_SERVICE_RESERVATIONS_ENABLED", false),
 	}
 }
 

--- a/coordinator/api/token_ratelimit_test.go
+++ b/coordinator/api/token_ratelimit_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/eigeninference/d-inference/coordinator/auth"
 	"github.com/eigeninference/d-inference/coordinator/ratelimit"
+	"github.com/eigeninference/d-inference/coordinator/registry"
 	"github.com/eigeninference/d-inference/coordinator/store"
 )
 
@@ -18,6 +19,12 @@ func tokenReq(accountID string, role string) *http.Request {
 		ctx = context.WithValue(ctx, auth.CtxKeyUser, &store.User{AccountID: accountID, Role: role})
 	}
 	return httptest.NewRequest("POST", "/v1/chat/completions", nil).WithContext(ctx)
+}
+
+func tokenReqWithKey(accountID string, role string, key *store.APIKey) *http.Request {
+	req := tokenReq(accountID, role)
+	ctx := context.WithValue(req.Context(), ctxKeyAPIKey, key)
+	return req.WithContext(ctx)
 }
 
 // Consumer output-token budget trips with the output_tokens dimension and emits
@@ -130,5 +137,87 @@ func TestApplyTokenRateLimitNilLimiter(t *testing.T) {
 	rec := httptest.NewRecorder()
 	if !s.applyTokenRateLimit(rec, tokenReq("acct", ""), 1_000_000, 1_000_000) {
 		t.Fatal("nil limiter should pass through")
+	}
+}
+
+func TestTokenExpectedOutputAdmissionServiceEnabledAvoidsUpfrontBurst(t *testing.T) {
+	s := &Server{
+		serviceTokenLimiter: ratelimit.NewTokenLimiter(1_000_000, 10_000_000, 0.000001, 512_000),
+		outputAdmissionEstimator: ratelimit.NewOutputAdmissionEstimator(ratelimit.OutputAdmissionEstimatorConfig{
+			Enabled:  true,
+			Fraction: 0.25,
+		}),
+	}
+
+	for i := 0; i < 16; i++ {
+		rec := httptest.NewRecorder()
+		if !s.applyTokenRateLimit(rec, tokenReq("openrouter", store.RoleService), 10, 32_768) {
+			t.Fatalf("service request %d should pass with estimated-output admission, got %d %s", i, rec.Code, rec.Body.String())
+		}
+	}
+}
+
+func TestTokenExpectedOutputAdmissionDisabledUnchanged(t *testing.T) {
+	s := &Server{serviceTokenLimiter: ratelimit.NewTokenLimiter(1_000_000, 10_000_000, 0.000001, 512_000)}
+
+	for i := 0; i < 15; i++ {
+		rec := httptest.NewRecorder()
+		if !s.applyTokenRateLimit(rec, tokenReq("openrouter", store.RoleService), 10, 32_768) {
+			t.Fatalf("service request %d should pass before burst is exhausted, got %d %s", i, rec.Code, rec.Body.String())
+		}
+	}
+	rec := httptest.NewRecorder()
+	if s.applyTokenRateLimit(rec, tokenReq("openrouter", store.RoleService), 10, 32_768) {
+		t.Fatal("disabled estimator should preserve full max_tokens OTPM admission and reject request 16")
+	}
+	if !strings.Contains(rec.Body.String(), "output_tokens") {
+		t.Fatalf("expected output_tokens rejection, got %s", rec.Body.String())
+	}
+}
+
+func TestTokenExpectedOutputAdmissionDeltaConsumesFutureCapacity(t *testing.T) {
+	s := &Server{
+		serviceTokenLimiter: ratelimit.NewTokenLimiter(1_000_000, 10_000_000, 0.000001, 100),
+		outputAdmissionEstimator: ratelimit.NewOutputAdmissionEstimator(ratelimit.OutputAdmissionEstimatorConfig{
+			Enabled:  true,
+			Fraction: 0.5,
+		}),
+	}
+
+	rec := httptest.NewRecorder()
+	admission, ok := s.applyTokenRateLimitWithAdmission(rec, tokenReq("openrouter", store.RoleService), 10, 80)
+	if !ok {
+		t.Fatalf("request should pass, got %d %s", rec.Code, rec.Body.String())
+	}
+	if admission.AdmittedOutputTokens != 40 {
+		t.Fatalf("admitted output = %d, want 40", admission.AdmittedOutputTokens)
+	}
+	s.reconcileOutputAdmission(&registry.PendingRequest{ConsumerKey: "openrouter", Model: "m", TokenAdmission: admission}, 70)
+	if ok, dim, _ := s.serviceTokenLimiter.Peek("openrouter", 0, 31); ok || dim != "output_tokens" {
+		t.Fatalf("delta should consume future output capacity; peek ok=%v dim=%q", ok, dim)
+	}
+}
+
+func TestTokenExpectedOutputAdmissionPerKeyOverrideStillEnforced(t *testing.T) {
+	otpm := int64(100)
+	s := &Server{
+		serviceTokenLimiter: ratelimit.NewTokenLimiter(1_000_000, 10_000_000, 1_000_000, 10_000_000),
+		keyTokenLimiter:     ratelimit.NewKeyTokenLimiter(),
+		outputAdmissionEstimator: ratelimit.NewOutputAdmissionEstimator(ratelimit.OutputAdmissionEstimatorConfig{
+			Enabled:  true,
+			Fraction: 0.25,
+		}),
+	}
+	key := &store.APIKey{ID: "key_1", OwnerAccountID: "openrouter", OTPMLimit: &otpm}
+
+	for i := 0; i < 2; i++ {
+		rec := httptest.NewRecorder()
+		if !s.applyTokenRateLimit(rec, tokenReqWithKey("openrouter", store.RoleService, key), 10, 200) {
+			t.Fatalf("per-key request %d should pass using output estimate, got %d %s", i, rec.Code, rec.Body.String())
+		}
+	}
+	rec := httptest.NewRecorder()
+	if s.applyTokenRateLimit(rec, tokenReqWithKey("openrouter", store.RoleService, key), 10, 200) {
+		t.Fatal("per-key OTPM override should reject after estimated charges exhaust the key bucket")
 	}
 }

--- a/coordinator/api/types/types.go
+++ b/coordinator/api/types/types.go
@@ -264,8 +264,11 @@ type CreateAPIKeyResponse struct {
 
 // HealthResponse is the GET /health response.
 type HealthResponse struct {
-	Status    string `json:"status"`
-	Providers int    `json:"providers"`
+	Status      string `json:"status"`
+	Providers   int    `json:"providers"`
+	Version     string `json:"version"`
+	BuildCommit string `json:"build_commit"`
+	BuildDate   string `json:"build_date"`
 }
 
 // VersionResponse is the GET /api/version response.

--- a/coordinator/cmd/coordinator/main.go
+++ b/coordinator/cmd/coordinator/main.go
@@ -150,6 +150,9 @@ func main() {
 		reg.MinTrustLevel = registry.TrustLevel(cfg.RegistryCfg.MinTrustLevel)
 		logger.Info("minimum trust level override", "level", cfg.RegistryCfg.MinTrustLevel)
 	}
+	reg.ConfigureCacheAffinity(cfg.RegistryCfg.CacheAffinity)
+	cacheAffinityCfg := reg.CacheAffinityConfigSnapshot()
+	logger.Info("cache affinity configured", "ttl", cacheAffinityCfg.TTL.String(), "bonus_ms", cacheAffinityCfg.BonusMs, "enabled", cacheAffinityCfg.BonusMs > 0)
 	stopWarmPool := reg.StartWarmPoolController(ctx, cfg.RegistryCfg.WarmPool)
 	defer stopWarmPool()
 	if cfg.RegistryCfg.WarmPool.Enabled {

--- a/coordinator/cmd/coordinator/main.go
+++ b/coordinator/cmd/coordinator/main.go
@@ -150,6 +150,11 @@ func main() {
 		reg.MinTrustLevel = registry.TrustLevel(cfg.RegistryCfg.MinTrustLevel)
 		logger.Info("minimum trust level override", "level", cfg.RegistryCfg.MinTrustLevel)
 	}
+	stopWarmPool := reg.StartWarmPoolController(ctx, cfg.RegistryCfg.WarmPool)
+	defer stopWarmPool()
+	if cfg.RegistryCfg.WarmPool.Enabled {
+		logger.Info("warm-pool controller enabled", "observe_only", cfg.RegistryCfg.WarmPool.ObserveOnly, "interval", cfg.RegistryCfg.WarmPool.Interval.String())
+	}
 
 	srv := api.NewServer(reg, st, cfg.ServerConfig, logger)
 
@@ -212,6 +217,11 @@ func main() {
 		logger.Info("service token rate limiter enabled", "itpm", serviceTok.InputPerMinute, "otpm", serviceTok.OutputPerMinute)
 	}
 	srv.SetTokenLimiters(consumerTokenLimiter, serviceTokenLimiter)
+	if outputAdmission := ratelimit.NewOutputAdmissionEstimator(cfg.OutputAdmission); outputAdmission != nil {
+		srv.SetOutputAdmissionEstimator(outputAdmission)
+		estCfg := outputAdmission.Config()
+		logger.Info("service expected-output token admission enabled", "fraction", estCfg.Fraction, "floor", estCfg.Floor, "ceiling", estCfg.Ceiling)
+	}
 
 	// Per-key (variable-rate) limiters for per-key RPM and ITPM/OTPM overrides.
 	// Unlike the per-account limiters above, these only act when an individual

--- a/coordinator/config/app_config.go
+++ b/coordinator/config/app_config.go
@@ -19,21 +19,22 @@ const EnvPrefix = env.EnvPrefix
 
 // AppConfig is the root configuration struct, composing per-package configs.
 type AppConfig struct {
-	StoreConfig    store.Config
-	ServerConfig   api.ServerConfig
-	BillingConfig  billing.Config
-	AuthConfig     auth.Config
-	RateLimitCfg   ratelimit.Config
-	FinancialRL    ratelimit.Config
-	ServiceRL      ratelimit.Config
-	ConsumerTokens ratelimit.TokenConfig
-	ServiceTokens  ratelimit.TokenConfig
-	RegistryCfg    registry.Config
-	MDMConfig      mdm.Config
-	DatadogConfig  datadog.Config
-	AdminKey       string
-	AdminEmails    []string
-	ReleaseKey     string
+	StoreConfig     store.Config
+	ServerConfig    api.ServerConfig
+	BillingConfig   billing.Config
+	AuthConfig      auth.Config
+	RateLimitCfg    ratelimit.Config
+	FinancialRL     ratelimit.Config
+	ServiceRL       ratelimit.Config
+	ConsumerTokens  ratelimit.TokenConfig
+	ServiceTokens   ratelimit.TokenConfig
+	OutputAdmission ratelimit.OutputAdmissionEstimatorConfig
+	RegistryCfg     registry.Config
+	MDMConfig       mdm.Config
+	DatadogConfig   datadog.Config
+	AdminKey        string
+	AdminEmails     []string
+	ReleaseKey      string
 }
 
 // Check runs validation on every per-package config.
@@ -69,20 +70,21 @@ func (c AppConfig) Check() error {
 func ReadAppConfig() AppConfig {
 	rlCfg := ratelimit.ReadConfig()
 	return AppConfig{
-		StoreConfig:    store.ReadConfig(),
-		ServerConfig:   api.ReadServerConfig(),
-		BillingConfig:  billing.ReadConfig(),
-		AuthConfig:     auth.ReadConfig(),
-		RateLimitCfg:   rlCfg.Inference,
-		FinancialRL:    rlCfg.Financial,
-		ServiceRL:      rlCfg.Service,
-		ConsumerTokens: rlCfg.ConsumerTokens,
-		ServiceTokens:  rlCfg.ServiceTokens,
-		RegistryCfg:    registry.ReadConfig(),
-		MDMConfig:      mdm.ReadConfig(),
-		DatadogConfig:  datadog.ConfigFromEnv(),
-		AdminKey:       EnvOr(EnvPrefix+"_ADMIN_KEY", ""),
-		AdminEmails:    api.ParseCommaList(EnvOr(EnvPrefix+"_ADMIN_EMAILS", "")),
-		ReleaseKey:     EnvOr(EnvPrefix+"_RELEASE_KEY", ""),
+		StoreConfig:     store.ReadConfig(),
+		ServerConfig:    api.ReadServerConfig(),
+		BillingConfig:   billing.ReadConfig(),
+		AuthConfig:      auth.ReadConfig(),
+		RateLimitCfg:    rlCfg.Inference,
+		FinancialRL:     rlCfg.Financial,
+		ServiceRL:       rlCfg.Service,
+		ConsumerTokens:  rlCfg.ConsumerTokens,
+		ServiceTokens:   rlCfg.ServiceTokens,
+		OutputAdmission: rlCfg.OutputAdmission,
+		RegistryCfg:     registry.ReadConfig(),
+		MDMConfig:       mdm.ReadConfig(),
+		DatadogConfig:   datadog.ConfigFromEnv(),
+		AdminKey:        EnvOr(EnvPrefix+"_ADMIN_KEY", ""),
+		AdminEmails:     api.ParseCommaList(EnvOr(EnvPrefix+"_ADMIN_EMAILS", "")),
+		ReleaseKey:      EnvOr(EnvPrefix+"_RELEASE_KEY", ""),
 	}
 }

--- a/coordinator/env/env.go
+++ b/coordinator/env/env.go
@@ -7,6 +7,7 @@ package env
 import (
 	"os"
 	"strconv"
+	"strings"
 )
 
 // EnvPrefix is the namespace prefix for all coordinator environment variables.
@@ -48,6 +49,17 @@ func EnvInt(key string, fallback int) int {
 	if v := os.Getenv(key); v != "" {
 		if n, err := strconv.Atoi(v); err == nil {
 			return n
+		}
+	}
+	return fallback
+}
+
+// EnvBool reads key from the environment as a bool, returning fallback when
+// the key is missing, empty, or unparseable.
+func EnvBool(key string, fallback bool) bool {
+	if v := strings.TrimSpace(os.Getenv(key)); v != "" {
+		if b, err := strconv.ParseBool(v); err == nil {
+			return b
 		}
 	}
 	return fallback

--- a/coordinator/ratelimit/config.go
+++ b/coordinator/ratelimit/config.go
@@ -24,15 +24,23 @@ type TokenConfig struct {
 	OutputBurst     int
 }
 
+type OutputAdmissionEstimatorConfig struct {
+	Enabled  bool
+	Fraction float64
+	Floor    int
+	Ceiling  int
+}
+
 // ConfigPair holds the rate-limiter configs for every account tier:
 // inference (consumer), financial, and the elevated service tier, plus the
 // per-tier token-per-minute (ITPM/OTPM) limits.
 type ConfigPair struct {
-	Inference      Config
-	Financial      Config
-	Service        Config
-	ConsumerTokens TokenConfig
-	ServiceTokens  TokenConfig
+	Inference       Config
+	Financial       Config
+	Service         Config
+	ConsumerTokens  TokenConfig
+	ServiceTokens   TokenConfig
+	OutputAdmission OutputAdmissionEstimatorConfig
 }
 
 // ReadConfig reads all rate limiter configs from environment variables.
@@ -66,6 +74,12 @@ func ReadConfig() ConfigPair {
 			InputBurst:      env.EnvInt(env.EnvPrefix+"_SERVICE_RATE_LIMIT_ITPM_BURST", 5_000_000),
 			OutputPerMinute: env.EnvFloat(env.EnvPrefix+"_SERVICE_RATE_LIMIT_OTPM", 5_000_000),
 			OutputBurst:     env.EnvInt(env.EnvPrefix+"_SERVICE_RATE_LIMIT_OTPM_BURST", 512_000),
+		},
+		OutputAdmission: OutputAdmissionEstimatorConfig{
+			Enabled:  env.EnvBool(env.EnvPrefix+"_SERVICE_EXPECTED_OUTPUT_ADMISSION_ENABLED", false),
+			Fraction: env.EnvFloat(env.EnvPrefix+"_SERVICE_EXPECTED_OUTPUT_ADMISSION_FRACTION", 0.25),
+			Floor:    env.EnvInt(env.EnvPrefix+"_SERVICE_EXPECTED_OUTPUT_ADMISSION_FLOOR", 512),
+			Ceiling:  env.EnvInt(env.EnvPrefix+"_SERVICE_EXPECTED_OUTPUT_ADMISSION_CEILING", 8192),
 		},
 	}
 }

--- a/coordinator/ratelimit/key_token_limiter.go
+++ b/coordinator/ratelimit/key_token_limiter.go
@@ -131,3 +131,13 @@ func (t *KeyTokenLimiter) Commit(key string, inputTokens, outputTokens int,
 		t.output.AllowNWithRate(key, outputTokens, outRPS, outBurst)
 	}
 }
+
+func (t *KeyTokenLimiter) DebitOutput(key string, outputTokens int, outRPS float64, outBurst int) {
+	if key == "" || outputTokens <= 0 || outRPS <= 0 || outBurst <= 0 {
+		return
+	}
+	lock := t.lockFor(key)
+	lock.Lock()
+	defer lock.Unlock()
+	t.output.DebitNWithRate(key, outputTokens, outRPS, outBurst)
+}

--- a/coordinator/ratelimit/output_admission.go
+++ b/coordinator/ratelimit/output_admission.go
@@ -1,0 +1,56 @@
+package ratelimit
+
+import "math"
+
+// OutputAdmissionEstimator converts bounded max_tokens into the output-token
+// charge used for service-account admission. Billing still reserves and settles
+// against the full bounded max_tokens path; this only affects OTPM.
+type OutputAdmissionEstimator struct {
+	cfg OutputAdmissionEstimatorConfig
+}
+
+func NewOutputAdmissionEstimator(cfg OutputAdmissionEstimatorConfig) *OutputAdmissionEstimator {
+	if !cfg.Enabled {
+		return nil
+	}
+	if cfg.Fraction <= 0 || cfg.Fraction > 1 {
+		cfg.Fraction = 1
+	}
+	if cfg.Floor < 0 {
+		cfg.Floor = 0
+	}
+	if cfg.Ceiling < 0 {
+		cfg.Ceiling = 0
+	}
+	return &OutputAdmissionEstimator{cfg: cfg}
+}
+
+func (e *OutputAdmissionEstimator) Estimate(boundedMaxTokens int) (int, bool) {
+	if e == nil {
+		return boundedMaxTokens, false
+	}
+	if boundedMaxTokens <= 0 {
+		return 0, true
+	}
+	estimate := int(math.Ceil(float64(boundedMaxTokens) * e.cfg.Fraction))
+	if estimate < e.cfg.Floor {
+		estimate = e.cfg.Floor
+	}
+	if e.cfg.Ceiling > 0 && estimate > e.cfg.Ceiling {
+		estimate = e.cfg.Ceiling
+	}
+	if estimate > boundedMaxTokens {
+		estimate = boundedMaxTokens
+	}
+	if estimate < 0 {
+		return 0, true
+	}
+	return estimate, true
+}
+
+func (e *OutputAdmissionEstimator) Config() OutputAdmissionEstimatorConfig {
+	if e == nil {
+		return OutputAdmissionEstimatorConfig{}
+	}
+	return e.cfg
+}

--- a/coordinator/ratelimit/ratelimit.go
+++ b/coordinator/ratelimit/ratelimit.go
@@ -118,6 +118,24 @@ func (l *Limiter) AllowN(accountID string, n int) (bool, time.Duration) {
 	return false, retryAfter
 }
 
+func (l *Limiter) DebitN(accountID string, n int) {
+	if accountID == "" || n <= 0 {
+		return
+	}
+	now := time.Now()
+	e := l.bucketFor(accountID, now)
+	for remaining := n; remaining > 0; {
+		chunk := remaining
+		if chunk > l.cfg.Burst {
+			chunk = l.cfg.Burst
+		}
+		if chunk <= 0 || !e.limiter.ReserveN(now, chunk).OK() {
+			return
+		}
+		remaining -= chunk
+	}
+}
+
 // CanN reports whether n units are currently available for the account WITHOUT
 // consuming them. Used for cross-bucket peek-then-consume so a rejection in one
 // dimension doesn't debit another. Empty accountID or n <= 0 is always true.
@@ -205,6 +223,24 @@ func (l *Limiter) AllowNWithRate(key string, n int, rps float64, burst int) (boo
 		retryAfter = maxRetryAfter
 	}
 	return false, retryAfter
+}
+
+func (l *Limiter) DebitNWithRate(key string, n int, rps float64, burst int) {
+	if key == "" || n <= 0 || rps <= 0 || burst <= 0 {
+		return
+	}
+	now := time.Now()
+	e := l.bucketForWithRate(key, rps, burst, now)
+	for remaining := n; remaining > 0; {
+		chunk := remaining
+		if chunk > burst {
+			chunk = burst
+		}
+		if chunk <= 0 || !e.limiter.ReserveN(now, chunk).OK() {
+			return
+		}
+		remaining -= chunk
+	}
 }
 
 // CanNWithRate reports whether n units are currently available against a per-key

--- a/coordinator/ratelimit/token_limiter.go
+++ b/coordinator/ratelimit/token_limiter.go
@@ -143,6 +143,20 @@ func (t *TokenLimiter) Commit(accountID string, inputTokens, outputTokens int) {
 	}
 }
 
+func (t *TokenLimiter) DebitOutput(accountID string, outputTokens int) {
+	if accountID == "" || outputTokens <= 0 || t.output == nil {
+		return
+	}
+	lock := t.lockFor(accountID)
+	lock.Lock()
+	defer lock.Unlock()
+	t.output.DebitN(accountID, outputTokens)
+}
+
+func (t *TokenLimiter) HasOutputLimit() bool {
+	return t != nil && t.output != nil
+}
+
 // InputStat returns the input-token bucket snapshot for header emission and
 // whether the dimension is enforced (false when unlimited).
 func (t *TokenLimiter) InputStat(accountID string) (Stat, bool) {

--- a/coordinator/ratelimit/token_limiter_test.go
+++ b/coordinator/ratelimit/token_limiter_test.go
@@ -114,6 +114,33 @@ func TestTokenLimiterNoCrossDimensionDrain(t *testing.T) {
 	}
 }
 
+func TestOutputAdmissionEstimatorBounds(t *testing.T) {
+	if est := NewOutputAdmissionEstimator(OutputAdmissionEstimatorConfig{}); est != nil {
+		t.Fatal("disabled estimator should be nil")
+	}
+	est := NewOutputAdmissionEstimator(OutputAdmissionEstimatorConfig{Enabled: true, Fraction: 0.25, Floor: 100, Ceiling: 500})
+	if got, ok := est.Estimate(10); !ok || got != 10 {
+		t.Fatalf("small max should cap floor at max_tokens, got %d ok=%v", got, ok)
+	}
+	if got, _ := est.Estimate(1000); got != 250 {
+		t.Fatalf("fraction estimate = %d, want 250", got)
+	}
+	if got, _ := est.Estimate(10_000); got != 500 {
+		t.Fatalf("ceiling estimate = %d, want 500", got)
+	}
+}
+
+func TestTokenLimiterDebitOutputCreatesFutureDebt(t *testing.T) {
+	tl := NewTokenLimiter(0, 0, 0.000001, 100)
+	if ok, dim, _ := tl.Allow("acct", 0, 80); !ok {
+		t.Fatalf("initial output charge should pass, got dim=%q", dim)
+	}
+	tl.DebitOutput("acct", 30)
+	if ok, dim, _ := tl.Allow("acct", 0, 1); ok || dim != "output_tokens" {
+		t.Fatalf("future debt should reject subsequent output, got ok=%v dim=%q", ok, dim)
+	}
+}
+
 // Concurrent same-account requests must not over-admit past the bucket: with
 // the per-account lock, exactly burst/charge requests succeed. Run with -race.
 func TestTokenLimiterConcurrentNoOverAdmit(t *testing.T) {

--- a/coordinator/registry/cache_affinity.go
+++ b/coordinator/registry/cache_affinity.go
@@ -1,0 +1,72 @@
+package registry
+
+import (
+	"sync"
+	"time"
+)
+
+const (
+	cacheAffinityTTL     = 10 * time.Minute
+	cacheAffinityBonusMs = 1_500.0
+)
+
+type cacheAffinityKey struct {
+	account string
+	model   string
+	scope   string
+}
+
+type cacheAffinityEntry struct {
+	providerID string
+	expiresAt  time.Time
+}
+
+type cacheAffinityTracker struct {
+	mu      sync.Mutex
+	ttl     time.Duration
+	entries map[cacheAffinityKey]cacheAffinityEntry
+}
+
+func newCacheAffinityTracker(ttl time.Duration) *cacheAffinityTracker {
+	if ttl <= 0 {
+		ttl = cacheAffinityTTL
+	}
+	return &cacheAffinityTracker{ttl: ttl, entries: make(map[cacheAffinityKey]cacheAffinityEntry)}
+}
+
+func (t *cacheAffinityTracker) lookup(account, model, scope string, now time.Time) string {
+	if t == nil || account == "" || model == "" || scope == "" {
+		return ""
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	key := cacheAffinityKey{account: account, model: model, scope: scope}
+	entry, ok := t.entries[key]
+	if !ok {
+		return ""
+	}
+	if now.After(entry.expiresAt) {
+		delete(t.entries, key)
+		return ""
+	}
+	return entry.providerID
+}
+
+func (t *cacheAffinityTracker) record(account, model, scope, providerID string, now time.Time) {
+	if t == nil || account == "" || model == "" || scope == "" || providerID == "" {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.entries[cacheAffinityKey{account: account, model: model, scope: scope}] = cacheAffinityEntry{
+		providerID: providerID,
+		expiresAt:  now.Add(t.ttl),
+	}
+}
+
+func (r *Registry) RecordCacheAffinity(account, model, scope, providerID string) {
+	if r == nil || r.cacheAffinity == nil {
+		return
+	}
+	r.cacheAffinity.record(account, model, scope, providerID, time.Now())
+}

--- a/coordinator/registry/cache_affinity.go
+++ b/coordinator/registry/cache_affinity.go
@@ -8,6 +8,7 @@ import (
 const (
 	cacheAffinityTTL            = 10 * time.Minute
 	defaultCacheAffinityBonusMs = 1_500.0
+	cacheAffinityMaxEntries     = 10_000
 )
 
 type cacheAffinityKey struct {
@@ -22,16 +23,17 @@ type cacheAffinityEntry struct {
 }
 
 type cacheAffinityTracker struct {
-	mu      sync.Mutex
-	ttl     time.Duration
-	entries map[cacheAffinityKey]cacheAffinityEntry
+	mu         sync.Mutex
+	ttl        time.Duration
+	maxEntries int
+	entries    map[cacheAffinityKey]cacheAffinityEntry
 }
 
 func newCacheAffinityTracker(ttl time.Duration) *cacheAffinityTracker {
 	if ttl <= 0 {
 		ttl = cacheAffinityTTL
 	}
-	return &cacheAffinityTracker{ttl: ttl, entries: make(map[cacheAffinityKey]cacheAffinityEntry)}
+	return &cacheAffinityTracker{ttl: ttl, maxEntries: cacheAffinityMaxEntries, entries: make(map[cacheAffinityKey]cacheAffinityEntry)}
 }
 
 func (t *cacheAffinityTracker) lookup(account, model, scope string, now time.Time) string {
@@ -58,9 +60,26 @@ func (t *cacheAffinityTracker) record(account, model, scope, providerID string, 
 	}
 	t.mu.Lock()
 	defer t.mu.Unlock()
+	if len(t.entries) >= t.maxEntries {
+		t.sweepExpiredLocked(now)
+	}
+	if len(t.entries) >= t.maxEntries {
+		for key := range t.entries {
+			delete(t.entries, key)
+			break
+		}
+	}
 	t.entries[cacheAffinityKey{account: account, model: model, scope: scope}] = cacheAffinityEntry{
 		providerID: providerID,
 		expiresAt:  now.Add(t.ttl),
+	}
+}
+
+func (t *cacheAffinityTracker) sweepExpiredLocked(now time.Time) {
+	for key, entry := range t.entries {
+		if now.After(entry.expiresAt) {
+			delete(t.entries, key)
+		}
 	}
 }
 

--- a/coordinator/registry/cache_affinity.go
+++ b/coordinator/registry/cache_affinity.go
@@ -6,8 +6,8 @@ import (
 )
 
 const (
-	cacheAffinityTTL     = 10 * time.Minute
-	cacheAffinityBonusMs = 1_500.0
+	cacheAffinityTTL            = 10 * time.Minute
+	defaultCacheAffinityBonusMs = 1_500.0
 )
 
 type cacheAffinityKey struct {

--- a/coordinator/registry/cache_affinity_test.go
+++ b/coordinator/registry/cache_affinity_test.go
@@ -1,0 +1,104 @@
+package registry
+
+import (
+	"testing"
+	"time"
+)
+
+func TestCacheAffinityPrefersPreviousProviderWhenCostsClose(t *testing.T) {
+	reg := New(testLogger())
+	model := "cache-affinity-close"
+	previous := makeSchedulerProvider(t, reg, "previous", model, 95)
+	fast := makeSchedulerProvider(t, reg, "fast", model, 100)
+	scope := "scope-hash"
+
+	reg.RecordCacheAffinity("acct-a", model, scope, previous.ID)
+	selected, _ := reg.ReserveProviderEx(model, &PendingRequest{
+		RequestID:          "req-affinity",
+		Model:              model,
+		ConsumerKey:        "acct-a",
+		RequestedMaxTokens: 128,
+		CacheAffinityKey:   scope,
+	})
+	if selected == nil {
+		t.Fatal("ReserveProviderEx returned nil")
+	}
+	if selected.ID != previous.ID {
+		t.Fatalf("selected %q, want affinity provider %q over close faster provider %q", selected.ID, previous.ID, fast.ID)
+	}
+}
+
+func TestCacheAffinityDifferentAccountsDoNotShare(t *testing.T) {
+	reg := New(testLogger())
+	model := "cache-affinity-account"
+	previous := makeSchedulerProvider(t, reg, "previous", model, 20)
+	fast := makeSchedulerProvider(t, reg, "fast", model, 200)
+	scope := "scope-hash"
+
+	reg.RecordCacheAffinity("acct-a", model, scope, previous.ID)
+	selected, _ := reg.ReserveProviderEx(model, &PendingRequest{
+		RequestID:          "req-affinity-other-account",
+		Model:              model,
+		ConsumerKey:        "acct-b",
+		RequestedMaxTokens: 4096,
+		CacheAffinityKey:   scope,
+	})
+	if selected == nil {
+		t.Fatal("ReserveProviderEx returned nil")
+	}
+	if selected.ID != fast.ID {
+		t.Fatalf("selected %q, want fast provider %q; affinity from another account must not apply", selected.ID, fast.ID)
+	}
+}
+
+func TestCacheAffinityExpiredIgnored(t *testing.T) {
+	reg := New(testLogger())
+	reg.cacheAffinity = newCacheAffinityTracker(time.Millisecond)
+	model := "cache-affinity-expired"
+	previous := makeSchedulerProvider(t, reg, "previous", model, 20)
+	fast := makeSchedulerProvider(t, reg, "fast", model, 200)
+	scope := "scope-hash"
+
+	reg.RecordCacheAffinity("acct-a", model, scope, previous.ID)
+	time.Sleep(2 * time.Millisecond)
+	selected, _ := reg.ReserveProviderEx(model, &PendingRequest{
+		RequestID:          "req-affinity-expired",
+		Model:              model,
+		ConsumerKey:        "acct-a",
+		RequestedMaxTokens: 4096,
+		CacheAffinityKey:   scope,
+	})
+	if selected == nil {
+		t.Fatal("ReserveProviderEx returned nil")
+	}
+	if selected.ID != fast.ID {
+		t.Fatalf("selected %q, want fast provider %q; expired affinity to %q must be ignored", selected.ID, fast.ID, previous.ID)
+	}
+}
+
+func TestCacheAffinityDoesNotBypassCapacity(t *testing.T) {
+	reg := New(testLogger())
+	model := "cache-affinity-capacity"
+	full := makeSchedulerProvider(t, reg, "full", model, 200)
+	open := makeSchedulerProvider(t, reg, "open", model, 80)
+	full.mu.Lock()
+	full.BackendCapacity.Slots[0].MaxConcurrency = 1
+	full.BackendCapacity.Slots[0].NumRunning = 1
+	full.mu.Unlock()
+	scope := "scope-hash"
+	reg.RecordCacheAffinity("acct-a", model, scope, full.ID)
+
+	selected, decision := reg.ReserveProviderEx(model, &PendingRequest{
+		RequestID:          "req-affinity-full",
+		Model:              model,
+		ConsumerKey:        "acct-a",
+		RequestedMaxTokens: 128,
+		CacheAffinityKey:   scope,
+	})
+	if selected == nil {
+		t.Fatalf("ReserveProviderEx returned nil; decision=%+v", decision)
+	}
+	if selected.ID != open.ID {
+		t.Fatalf("selected %q, want open provider %q; affinity must not bypass capacity", selected.ID, open.ID)
+	}
+}

--- a/coordinator/registry/config.go
+++ b/coordinator/registry/config.go
@@ -3,32 +3,101 @@ package registry
 import (
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/eigeninference/d-inference/coordinator/env"
 )
 
 // Config holds registry-level configuration.
 type Config struct {
-	MinTrustLevel string // overrides default trust level (empty = use default)
+	MinTrustLevel string
+	WarmPool      WarmPoolConfig
+}
+
+type WarmPoolConfig struct {
+	Enabled     bool
+	ObserveOnly bool
+
+	Interval time.Duration
+	MinDwell time.Duration
+
+	QueueAgeThreshold         time.Duration
+	CapacityRejectThreshold   int
+	WarmSaturationThreshold   float64
+	TTFTMissThreshold         int
+	SpeculativeStartThreshold int
+	SpeculativeWinThreshold   int
+	ColdDispatchThreshold     int
+	LoadDurationThreshold     time.Duration
+
+	MaxLoadsPerTick       int
+	MaxGlobalPendingLoads int
 }
 
 // ReadConfig reads registry configuration from environment variables.
 func ReadConfig() Config {
 	return Config{
 		MinTrustLevel: os.Getenv(env.EnvPrefix + "_MIN_TRUST"),
+		WarmPool: WarmPoolConfig{
+			Enabled:                   env.EnvBool(env.EnvPrefix+"_WARM_POOL_ENABLED", false),
+			ObserveOnly:               env.EnvBool(env.EnvPrefix+"_WARM_POOL_OBSERVE_ONLY", true),
+			Interval:                  envDuration(env.EnvPrefix+"_WARM_POOL_INTERVAL", 30*time.Second),
+			MinDwell:                  envDuration(env.EnvPrefix+"_WARM_POOL_MIN_DWELL", 5*time.Minute),
+			QueueAgeThreshold:         envDuration(env.EnvPrefix+"_WARM_POOL_QUEUE_AGE_THRESHOLD", 5*time.Second),
+			CapacityRejectThreshold:   env.EnvInt(env.EnvPrefix+"_WARM_POOL_CAPACITY_REJECT_THRESHOLD", 1),
+			WarmSaturationThreshold:   env.EnvFloat(env.EnvPrefix+"_WARM_POOL_WARM_SATURATION_THRESHOLD", 0.8),
+			TTFTMissThreshold:         env.EnvInt(env.EnvPrefix+"_WARM_POOL_TTFT_MISS_THRESHOLD", 1),
+			SpeculativeStartThreshold: env.EnvInt(env.EnvPrefix+"_WARM_POOL_SPECULATIVE_START_THRESHOLD", 2),
+			SpeculativeWinThreshold:   env.EnvInt(env.EnvPrefix+"_WARM_POOL_SPECULATIVE_WIN_THRESHOLD", 1),
+			ColdDispatchThreshold:     env.EnvInt(env.EnvPrefix+"_WARM_POOL_COLD_DISPATCH_THRESHOLD", 1),
+			LoadDurationThreshold:     envDuration(env.EnvPrefix+"_WARM_POOL_LOAD_DURATION_THRESHOLD", 20*time.Second),
+			MaxLoadsPerTick:           env.EnvInt(env.EnvPrefix+"_WARM_POOL_MAX_LOADS_PER_TICK", 1),
+			MaxGlobalPendingLoads:     env.EnvInt(env.EnvPrefix+"_WARM_POOL_MAX_GLOBAL_PENDING_LOADS", 4),
+		},
 	}
+}
+
+func envDuration(key string, fallback time.Duration) time.Duration {
+	if v := os.Getenv(key); v != "" {
+		if d, err := time.ParseDuration(v); err == nil {
+			return d
+		}
+	}
+	return fallback
 }
 
 // Check validates the configuration.
 // An empty MinTrustLevel is valid and means "use the default".
 func (c Config) Check() error {
 	if c.MinTrustLevel == "" {
-		return nil
+		return c.WarmPool.Check()
 	}
 	// trustRank returns -1 for unrecognized trust levels.
 	if trustRank(TrustLevel(c.MinTrustLevel)) < 0 {
 		return fmt.Errorf("registry: invalid MinTrustLevel %q (valid: %q, %q, %q)",
 			c.MinTrustLevel, TrustNone, TrustSelfSigned, TrustHardware)
+	}
+	return c.WarmPool.Check()
+}
+
+func (c WarmPoolConfig) Check() error {
+	if !c.Enabled && c.Interval == 0 {
+		return nil
+	}
+	if c.Interval <= 0 {
+		return fmt.Errorf("registry: warm pool interval must be > 0")
+	}
+	if c.MinDwell < 0 || c.QueueAgeThreshold < 0 || c.LoadDurationThreshold < 0 {
+		return fmt.Errorf("registry: warm pool durations must be >= 0")
+	}
+	if c.WarmSaturationThreshold < 0 || c.WarmSaturationThreshold > 1 {
+		return fmt.Errorf("registry: warm pool saturation threshold must be in [0,1]")
+	}
+	if c.CapacityRejectThreshold < 1 || c.TTFTMissThreshold < 1 || c.SpeculativeStartThreshold < 1 || c.SpeculativeWinThreshold < 1 || c.ColdDispatchThreshold < 1 {
+		return fmt.Errorf("registry: warm pool pressure thresholds must be >= 1")
+	}
+	if c.MaxLoadsPerTick < 0 || c.MaxGlobalPendingLoads < 0 {
+		return fmt.Errorf("registry: warm pool load limits must be >= 0")
 	}
 	return nil
 }

--- a/coordinator/registry/config.go
+++ b/coordinator/registry/config.go
@@ -12,6 +12,12 @@ import (
 type Config struct {
 	MinTrustLevel string
 	WarmPool      WarmPoolConfig
+	CacheAffinity CacheAffinityConfig
+}
+
+type CacheAffinityConfig struct {
+	TTL     time.Duration
+	BonusMs float64
 }
 
 type WarmPoolConfig struct {
@@ -54,6 +60,10 @@ func ReadConfig() Config {
 			MaxLoadsPerTick:           env.EnvInt(env.EnvPrefix+"_WARM_POOL_MAX_LOADS_PER_TICK", 1),
 			MaxGlobalPendingLoads:     env.EnvInt(env.EnvPrefix+"_WARM_POOL_MAX_GLOBAL_PENDING_LOADS", 4),
 		},
+		CacheAffinity: CacheAffinityConfig{
+			TTL:     envDuration(env.EnvPrefix+"_CACHE_AFFINITY_TTL", cacheAffinityTTL),
+			BonusMs: env.EnvFloat(env.EnvPrefix+"_CACHE_AFFINITY_BONUS_MS", defaultCacheAffinityBonusMs),
+		},
 	}
 }
 
@@ -70,14 +80,33 @@ func envDuration(key string, fallback time.Duration) time.Duration {
 // An empty MinTrustLevel is valid and means "use the default".
 func (c Config) Check() error {
 	if c.MinTrustLevel == "" {
-		return c.WarmPool.Check()
+		if err := c.WarmPool.Check(); err != nil {
+			return err
+		}
+		return c.CacheAffinity.Check()
 	}
 	// trustRank returns -1 for unrecognized trust levels.
 	if trustRank(TrustLevel(c.MinTrustLevel)) < 0 {
 		return fmt.Errorf("registry: invalid MinTrustLevel %q (valid: %q, %q, %q)",
 			c.MinTrustLevel, TrustNone, TrustSelfSigned, TrustHardware)
 	}
-	return c.WarmPool.Check()
+	if err := c.WarmPool.Check(); err != nil {
+		return err
+	}
+	return c.CacheAffinity.Check()
+}
+
+func (c CacheAffinityConfig) Check() error {
+	if c.TTL < 0 {
+		return fmt.Errorf("registry: cache affinity ttl must be >= 0")
+	}
+	if c.BonusMs < 0 {
+		return fmt.Errorf("registry: cache affinity bonus must be >= 0")
+	}
+	if c.BonusMs > 10_000 {
+		return fmt.Errorf("registry: cache affinity bonus must be <= 10000ms")
+	}
+	return nil
 }
 
 func (c WarmPoolConfig) Check() error {

--- a/coordinator/registry/queue.go
+++ b/coordinator/registry/queue.go
@@ -197,6 +197,27 @@ func (q *RequestQueue) QueueSize(model string) int {
 	return len(q.queues[model])
 }
 
+func (q *RequestQueue) QueueStats(model string) (depth int, oldestAge time.Duration) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	queue := q.queues[model]
+	depth = len(queue)
+	if depth == 0 {
+		return 0, 0
+	}
+	now := time.Now()
+	oldest := queue[0].EnqueuedAt
+	for _, req := range queue[1:] {
+		if req.EnqueuedAt.Before(oldest) {
+			oldest = req.EnqueuedAt
+		}
+	}
+	if !oldest.IsZero() {
+		oldestAge = now.Sub(oldest)
+	}
+	return depth, oldestAge
+}
+
 // TotalSize returns the total number of queued requests across all models.
 func (q *RequestQueue) TotalSize() int {
 	q.mu.Lock()

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -139,13 +139,20 @@ type PendingRequest struct {
 	// RequestedMaxTokens is the consumer's requested output budget (or a
 	// sensible default when omitted). It is used for backlog estimation.
 	RequestedMaxTokens int
-	AcceptedCh         chan struct{}           // signalled when provider accepts request
-	ChunkCh            chan string             // SSE data chunks
-	CompleteCh         chan protocol.UsageInfo // closed after usage sent
-	ErrorCh            chan protocol.InferenceErrorMessage
-	SessionPrivKey     *[32]byte // E2E session private key for decrypting responses
-	SESignature        string    // SE signature over response hash
-	ResponseHash       string    // SHA-256 of response data
+	// CacheAffinityKey is SHA256(prompt_cache_key) from the request body. Empty
+	// means no cache-affinity routing. It is scoped again by account and model in
+	// the registry tracker and is never persisted.
+	CacheAffinityKey string
+	// TokenAdmission records the output-token charge admitted at request time so
+	// successful completion can reconcile any positive actual-output delta.
+	TokenAdmission TokenAdmission
+	AcceptedCh     chan struct{}           // signalled when provider accepts request
+	ChunkCh        chan string             // SSE data chunks
+	CompleteCh     chan protocol.UsageInfo // closed after usage sent
+	ErrorCh        chan protocol.InferenceErrorMessage
+	SessionPrivKey *[32]byte // E2E session private key for decrypting responses
+	SESignature    string    // SE signature over response hash
+	ResponseHash   string    // SHA-256 of response data
 
 	// ReservedMicroUSD is the balance atomically debited at pre-flight.
 	// The post-inference charge adjusts for the difference between the
@@ -158,11 +165,28 @@ type PendingRequest struct {
 	// timeout). The base itself is refunded once globally or settled by the
 	// winning attempt.
 	BaseReservedMicroUSD int64
+	// ServiceReservation marks a trusted service account request whose pre-router
+	// admission used an in-memory hold instead of a synchronous ledger debit.
+	ServiceReservation   bool
 	reservationMu        sync.Mutex
 	reservationFinalized bool
 
 	// Timing fields for latency decomposition.
 	Timing *RequestTiming
+}
+
+type TokenAdmission struct {
+	AdmittedOutputTokens int
+	EstimatedOutput      bool
+	AccountOutputLimited bool
+	AccountTier          string
+	KeyOutputLimited     bool
+	KeyOutputRPS         float64
+	KeyOutputBurst       int
+}
+
+func (a TokenAdmission) TracksOutput() bool {
+	return a.AccountOutputLimited || a.KeyOutputLimited
 }
 
 // MarkReservationFinalized returns true only for the first settlement or refund
@@ -804,7 +828,8 @@ type Registry struct {
 	// after a failed one. The value is the entry's expiry time. While an
 	// entry lives, the provider is skipped for new load_model sends
 	// (bestModelLoadProviderLocked / reservePendingModelLoads).
-	pendingModelLoads map[string]time.Time // key: "providerID:modelID", value: expiry
+	pendingModelLoads       map[string]time.Time // key: "providerID:modelID", value: expiry
+	pendingModelLoadStarted map[string]time.Time
 
 	// dispatchLoadCooldowns: provider-model pairs that rejected a dispatch with a
 	// load failure ("insufficient memory"). Routing skips the pair until expiry —
@@ -839,6 +864,11 @@ type Registry struct {
 	// or one missed heartbeat doesn't mass-reap a live fleet. Guarded by r.mu;
 	// rebuilt each sweep so disconnected providers drop out automatically.
 	evictStrikes map[string]int
+
+	cacheAffinity *cacheAffinityTracker
+	warmPool      *warmPoolController
+	// loadModelSender is a test seam for SendLoadModel. Nil uses the provider WebSocket.
+	loadModelSender func(providerID, modelID string) error
 }
 
 // pendingModelLoadTTL bounds how long an outstanding (or failed) load_model
@@ -873,10 +903,12 @@ func New(logger *slog.Logger) *Registry {
 		tpsRegistry:             NewTPSRegistry(),
 		modelProviders:          make(map[string]*atomic.Int64),
 		pendingModelLoads:       make(map[string]time.Time),
+		pendingModelLoadStarted: make(map[string]time.Time),
 		dispatchLoadCooldowns:   make(map[string]time.Time),
 		inferenceErrorStrikes:   make(map[inferenceErrorKey][]time.Time),
 		inferenceErrorCooldowns: make(map[inferenceErrorKey]time.Time),
 		evictStrikes:            make(map[string]int),
+		cacheAffinity:           newCacheAffinityTracker(cacheAffinityTTL),
 		logger:                  logger,
 	}
 }
@@ -2230,6 +2262,14 @@ func (r *Registry) Heartbeat(id string, msg *protocol.HeartbeatMessage) {
 // does not block waiting for the load to complete. The provider replies
 // asynchronously with a load_model_status message.
 func (r *Registry) SendLoadModel(providerID, modelID string) error {
+	if r.loadModelSender != nil {
+		if err := r.loadModelSender(providerID, modelID); err != nil {
+			return err
+		}
+		r.logger.Info("sent load_model to provider", "provider_id", providerID, "model_id", modelID)
+		return nil
+	}
+
 	r.mu.RLock()
 	p, ok := r.providers[providerID]
 	r.mu.RUnlock()
@@ -2463,6 +2503,7 @@ func (r *Registry) expirePendingModelLoads(now time.Time) {
 	for key, expiresAt := range r.pendingModelLoads {
 		if now.After(expiresAt) {
 			delete(r.pendingModelLoads, key)
+			delete(r.pendingModelLoadStarted, key)
 		}
 	}
 }
@@ -2648,7 +2689,9 @@ func (r *Registry) reservePendingModelLoads(actions []modelLoadAction, now time.
 		if r.providerHasPendingLoad(action.providerID) {
 			continue
 		}
-		r.pendingModelLoads[modelLoadKey(action.providerID, action.modelID)] = now.Add(pendingModelLoadTTL)
+		key := modelLoadKey(action.providerID, action.modelID)
+		r.pendingModelLoads[key] = now.Add(pendingModelLoadTTL)
+		r.pendingModelLoadStarted[key] = now
 		reserved = append(reserved, action)
 	}
 	return reserved
@@ -2734,10 +2777,27 @@ func (r *Registry) MarkModelWarm(providerID, modelID string) {
 
 // ClearPendingModelLoad removes a pending model load entry after a terminal
 // load_model_status response.
-func (r *Registry) ClearPendingModelLoad(providerID, modelID string) {
+func (r *Registry) ClearPendingModelLoad(providerID, modelID string) time.Duration {
 	r.mu.Lock()
-	delete(r.pendingModelLoads, modelLoadKey(providerID, modelID))
+	key := modelLoadKey(providerID, modelID)
+	started := r.pendingModelLoadStarted[key]
+	delete(r.pendingModelLoads, key)
+	delete(r.pendingModelLoadStarted, key)
 	r.mu.Unlock()
+	if started.IsZero() {
+		return 0
+	}
+	return time.Since(started)
+}
+
+func (r *Registry) PendingModelLoadDuration(providerID, modelID string) time.Duration {
+	r.mu.RLock()
+	started := r.pendingModelLoadStarted[modelLoadKey(providerID, modelID)]
+	r.mu.RUnlock()
+	if started.IsZero() {
+		return 0
+	}
+	return time.Since(started)
 }
 
 // BackoffPendingModelLoadForDrain re-stamps a pending load entry with the
@@ -2749,7 +2809,14 @@ func (r *Registry) ClearPendingModelLoad(providerID, modelID string) {
 // clears the entry anyway via Disconnect.
 func (r *Registry) BackoffPendingModelLoadForDrain(providerID, modelID string) {
 	r.mu.Lock()
-	r.pendingModelLoads[modelLoadKey(providerID, modelID)] = time.Now().Add(pendingModelLoadDrainBackoff)
+	key := modelLoadKey(providerID, modelID)
+	r.pendingModelLoads[key] = time.Now().Add(pendingModelLoadDrainBackoff)
+	if r.pendingModelLoadStarted == nil {
+		r.pendingModelLoadStarted = make(map[string]time.Time)
+	}
+	if r.pendingModelLoadStarted[key].IsZero() {
+		r.pendingModelLoadStarted[key] = time.Now()
+	}
 	r.mu.Unlock()
 }
 
@@ -2821,6 +2888,7 @@ func (r *Registry) Disconnect(id string) {
 		for key := range r.pendingModelLoads {
 			if len(key) > len(id)+1 && key[:len(id)+1] == id+":" {
 				delete(r.pendingModelLoads, key)
+				delete(r.pendingModelLoadStarted, key)
 			}
 		}
 		p.mu.Lock()
@@ -3856,7 +3924,8 @@ type ModelCapacity struct {
 	Ready                bool    `json:"ready"`                  // at least one routable provider with headroom
 	CanAccept            bool    `json:"can_accept"`             // ready AND queue not full
 	RoutableProviders    int     `json:"routable_providers"`     // passed all gates
-	WarmProviders        int     `json:"warm_providers"`         // model loaded (slot state "running")
+	WarmProviders        int     `json:"warm_providers"`         // model loaded (slot state "running" or "idle")
+	RunningProviders     int     `json:"running_providers"`      // model loaded with active requests (slot state "running")
 	ColdProviders        int     `json:"cold_providers"`         // model available but not loaded
 	ActiveRequests       int     `json:"active_requests"`        // in-flight across fleet
 	QueuedRequests       int     `json:"queued_requests"`        // waiting in coordinator queue
@@ -3872,6 +3941,7 @@ type ModelCapacity struct {
 type providerCapSnap struct {
 	model                 string
 	warm                  bool
+	running               bool
 	hasHeadroom           bool // pending < maxConcurrency
 	effectiveTPS          float64
 	prefillTPS            float64
@@ -3957,7 +4027,8 @@ func (r *Registry) ModelCapacitySnapshot() []ModelCapacity {
 					if slot.Model != m.ID {
 						continue
 					}
-					snap.warm = slot.State == "running"
+					snap.warm = slotStateModelLoaded(slot.State)
+					snap.running = slot.State == "running"
 					slotActive := int(slot.NumRunning) + int(slot.NumWaiting)
 					if slotActive > snap.activeRequests {
 						snap.activeRequests = slotActive
@@ -3986,6 +4057,7 @@ func (r *Registry) ModelCapacitySnapshot() []ModelCapacity {
 	type modelAgg struct {
 		routable         int
 		warm             int
+		running          int
 		cold             int
 		activeRequests   int
 		aggregateTPS     float64
@@ -4004,6 +4076,9 @@ func (r *Registry) ModelCapacitySnapshot() []ModelCapacity {
 		}
 		if s.warm {
 			a.warm++
+			if s.running {
+				a.running++
+			}
 		} else {
 			a.cold++
 		}
@@ -4077,6 +4152,7 @@ func (r *Registry) ModelCapacitySnapshot() []ModelCapacity {
 			CanAccept:            canAccept,
 			RoutableProviders:    a.routable,
 			WarmProviders:        a.warm,
+			RunningProviders:     a.running,
 			ColdProviders:        a.cold,
 			ActiveRequests:       a.activeRequests,
 			QueuedRequests:       queued,

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -865,8 +865,9 @@ type Registry struct {
 	// rebuilt each sweep so disconnected providers drop out automatically.
 	evictStrikes map[string]int
 
-	cacheAffinity *cacheAffinityTracker
-	warmPool      *warmPoolController
+	cacheAffinity        *cacheAffinityTracker
+	cacheAffinityBonusMs float64
+	warmPool             *warmPoolController
 	// loadModelSender is a test seam for SendLoadModel. Nil uses the provider WebSocket.
 	loadModelSender func(providerID, modelID string) error
 }
@@ -909,8 +910,29 @@ func New(logger *slog.Logger) *Registry {
 		inferenceErrorCooldowns: make(map[inferenceErrorKey]time.Time),
 		evictStrikes:            make(map[string]int),
 		cacheAffinity:           newCacheAffinityTracker(cacheAffinityTTL),
+		cacheAffinityBonusMs:    defaultCacheAffinityBonusMs,
 		logger:                  logger,
 	}
+}
+
+func (r *Registry) ConfigureCacheAffinity(cfg CacheAffinityConfig) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if cfg.TTL <= 0 {
+		cfg.TTL = cacheAffinityTTL
+	}
+	r.cacheAffinity = newCacheAffinityTracker(cfg.TTL)
+	r.cacheAffinityBonusMs = cfg.BonusMs
+}
+
+func (r *Registry) CacheAffinityConfigSnapshot() CacheAffinityConfig {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	ttl := cacheAffinityTTL
+	if r.cacheAffinity != nil {
+		ttl = r.cacheAffinity.ttl
+	}
+	return CacheAffinityConfig{TTL: ttl, BonusMs: r.cacheAffinityBonusMs}
 }
 
 // RecordDispatchLoadFailure puts a provider-model pair on a routing cool-down

--- a/coordinator/registry/scheduler.go
+++ b/coordinator/registry/scheduler.go
@@ -82,7 +82,7 @@ type routingSnapshot struct {
 	totalMemoryGB      float64
 	modelSizeGB        float64 // catalog-reported weight footprint (0 = unknown, gate disabled)
 	minRAMGb           int     // catalog authoritative min RAM (GB) to run the model (0 = unknown)
-	modelLoaded        bool    // true when the requested model is the currently-running slot
+	modelLoaded        bool    // true when the requested model is resident (running or idle)
 	availableOnDisk    bool    // model is in provider's Models list but not currently loaded
 
 	observedDecodeTPS     float64
@@ -268,6 +268,9 @@ func (r *Registry) ReserveProviderEx(model string, pr *PendingRequest, excludeID
 	if p.Status != StatusUntrusted && p.Status != StatusOffline {
 		p.Status = StatusServing
 	}
+	if !slotStateModelLoaded(selected.snapshot.slotState) {
+		r.RecordWarmPoolColdDispatch(model)
+	}
 
 	bd := selected.breakdown
 	decision := RoutingDecision{
@@ -320,6 +323,10 @@ func (r *Registry) selectBestCandidateLockedFull(model string, pr *PendingReques
 	capacityRejections := 0
 	tooLargeRejections := 0
 	visionRejections := 0
+	affinityProviderID := ""
+	if pr.CacheAffinityKey != "" && pr.ConsumerKey != "" {
+		affinityProviderID = r.cacheAffinity.lookup(pr.ConsumerKey, model, pr.CacheAffinityKey, time.Now())
+	}
 	for _, p := range r.providers {
 		owned := providerOwnedBy(p, pr.OwnerAccountID)
 		// Exclusive self-route: restrict to the caller's own machines and never
@@ -374,6 +381,10 @@ func (r *Registry) selectBestCandidateLockedFull(model string, pr *PendingReques
 				visionRejections++
 			}
 			continue
+		}
+		if affinityProviderID != "" && p.ID == affinityProviderID {
+			candidate.costMs -= cacheAffinityBonusMs
+			candidate.breakdown.Total = candidate.costMs
 		}
 		candidates = append(candidates, candidate)
 		candidateCount++
@@ -455,6 +466,14 @@ func (r *Registry) selectBestCandidateLockedFull(model string, pr *PendingReques
 		}
 		if len(equivalent) > 1 {
 			winner = equivalent[rand.Intn(len(equivalent))]
+		}
+	}
+	if affinityProviderID != "" {
+		for _, c := range nearTies {
+			if c.provider.ID == affinityProviderID {
+				winner = c
+				break
+			}
 		}
 	}
 	r.logRoutingDecision(model, pr, winner, candidateCount)
@@ -710,7 +729,7 @@ func (r *Registry) snapshotProviderLocked(p *Provider, model string, traits Requ
 			break
 		}
 	}
-	snap.modelLoaded = snap.slotState == "running"
+	snap.modelLoaded = slotStateModelLoaded(snap.slotState)
 	snap.availableOnDisk = !snap.modelLoaded
 	snap.fleetMedianTPS = r.tpsRegistry.Median(model, p.Hardware.ChipFamily)
 
@@ -836,8 +855,7 @@ func (r *Registry) buildCandidateWithReason(snap routingSnapshot, pr *PendingReq
 	// tracks "running", so we check the slot state directly here — otherwise an
 	// idle-but-loaded provider would be wrongly excluded. Reported as
 	// rejectModelTooLarge (permanent, not capacity).
-	modelResident := snap.slotState == "running" || snap.slotState == "idle"
-	if !modelResident && !modelFitsHardware(snap.minRAMGb, snap.modelSizeGB, snap.totalMemoryGB) {
+	if !slotStateModelLoaded(snap.slotState) && !modelFitsHardware(snap.minRAMGb, snap.modelSizeGB, snap.totalMemoryGB) {
 		return nil, rejectModelTooLarge, false
 	}
 
@@ -911,6 +929,10 @@ func slotStatePenalty(state string) (float64, bool) {
 	default:
 		return slotStatePenaltyUnknown, true
 	}
+}
+
+func slotStateModelLoaded(state string) bool {
+	return state == "running" || state == "idle"
 }
 
 func backlogTokenMs(maxTokensPotential int64, waitingTokens, unaccountedPendingTokens, decodeTPS float64) float64 {
@@ -1077,6 +1099,14 @@ func (r *Registry) providerCanAdmitLocked(p *Provider, model string, traits Requ
 //     a model that will never fit (the client would retry forever) — it should
 //     surface model_too_large / 503 instead.
 func (r *Registry) QuickCapacityCheck(model string, estimatedPromptTokens, requestedMaxTokens int, traits RequestTraits, allowedSerials ...string) (candidateCount, capacityRejections, modelTooLarge int) {
+	return r.quickCapacityCheck(model, estimatedPromptTokens, requestedMaxTokens, traits, false, allowedSerials...)
+}
+
+func (r *Registry) QuickCapacityCheckForRequest(model string, estimatedPromptTokens, requestedMaxTokens int, traits RequestTraits, requiresVision bool, allowedSerials ...string) (candidateCount, capacityRejections, modelTooLarge int) {
+	return r.quickCapacityCheck(model, estimatedPromptTokens, requestedMaxTokens, traits, requiresVision, allowedSerials...)
+}
+
+func (r *Registry) quickCapacityCheck(model string, estimatedPromptTokens, requestedMaxTokens int, traits RequestTraits, requiresVision bool, allowedSerials ...string) (candidateCount, capacityRejections, modelTooLarge int) {
 	// Use a dummy PendingRequest with the caller's actual token estimates
 	// for the admission gate (freeMemoryAdmits).
 	if estimatedPromptTokens <= 0 {
@@ -1116,6 +1146,14 @@ func (r *Registry) QuickCapacityCheck(model string, estimatedPromptTokens, reque
 		// (non-self-route) requests, so selfRouteOwner is false — private-only
 		// machines are excluded unconditionally.
 		if !r.providerPassesRoutingGatesLocked(p, model, traits, false, now) {
+			p.mu.Unlock()
+			continue
+		}
+		if p.SystemMetrics.ThermalState == "critical" {
+			p.mu.Unlock()
+			continue
+		}
+		if requiresVision && !r.providerServesVisionModelLocked(p, model) {
 			p.mu.Unlock()
 			continue
 		}
@@ -1161,7 +1199,7 @@ func (r *Registry) QuickCapacityCheck(model string, estimatedPromptTokens, reque
 				break
 			}
 		}
-		snap.modelLoaded = snap.slotState == "running"
+		snap.modelLoaded = slotStateModelLoaded(snap.slotState)
 		snap.availableOnDisk = !snap.modelLoaded
 
 		p.mu.Unlock()
@@ -1171,8 +1209,7 @@ func (r *Registry) QuickCapacityCheck(model string, estimatedPromptTokens, reque
 		// capacity pressure — count it separately so the caller never 429s it.
 		// Skipped for a resident ("running"/"idle") model, which has demonstrably
 		// fit.
-		modelResident := snap.slotState == "running" || snap.slotState == "idle"
-		if !modelResident && !modelFitsHardware(snap.minRAMGb, snap.modelSizeGB, snap.totalMemoryGB) {
+		if !slotStateModelLoaded(snap.slotState) && !modelFitsHardware(snap.minRAMGb, snap.modelSizeGB, snap.totalMemoryGB) {
 			modelTooLarge++
 			continue
 		}

--- a/coordinator/registry/scheduler.go
+++ b/coordinator/registry/scheduler.go
@@ -324,7 +324,8 @@ func (r *Registry) selectBestCandidateLockedFull(model string, pr *PendingReques
 	tooLargeRejections := 0
 	visionRejections := 0
 	affinityProviderID := ""
-	if pr.CacheAffinityKey != "" && pr.ConsumerKey != "" {
+	affinityLookup := pr.CacheAffinityKey != "" && pr.ConsumerKey != ""
+	if affinityLookup && r.cacheAffinityBonusMs > 0 {
 		affinityProviderID = r.cacheAffinity.lookup(pr.ConsumerKey, model, pr.CacheAffinityKey, time.Now())
 	}
 	for _, p := range r.providers {
@@ -383,7 +384,11 @@ func (r *Registry) selectBestCandidateLockedFull(model string, pr *PendingReques
 			continue
 		}
 		if affinityProviderID != "" && p.ID == affinityProviderID {
-			candidate.costMs -= cacheAffinityBonusMs
+			bonus := r.cacheAffinityBonusMs
+			if bonus > candidate.costMs {
+				bonus = candidate.costMs
+			}
+			candidate.costMs -= bonus
 			candidate.breakdown.Total = candidate.costMs
 		}
 		candidates = append(candidates, candidate)

--- a/coordinator/registry/scheduler_test.go
+++ b/coordinator/registry/scheduler_test.go
@@ -1443,3 +1443,61 @@ func TestCapabilityChecksHonorAllowedSerials(t *testing.T) {
 		t.Fatal("constrained to its own serial, the capable provider must satisfy the vision check")
 	}
 }
+
+func TestQuickCapacityCheckForRequestRequiresVision(t *testing.T) {
+	reg := New(testLogger())
+	model := "vision-preflight-model"
+	textOnly := makeSchedulerProvider(t, reg, "text-only", model, 100)
+	textOnly.mu.Lock()
+	textOnly.Models = []protocol.ModelInfo{{ID: model, ModelType: "chat", Quantization: "4bit", IsVision: false}}
+	textOnly.mu.Unlock()
+
+	if candidates, rejections, tooLarge := reg.QuickCapacityCheckForRequest(model, 100, 128, RequestTraits{}, true); candidates != 0 || rejections != 0 || tooLarge != 0 {
+		t.Fatalf("vision preflight with text-only provider = (%d,%d,%d), want 0/0/0", candidates, rejections, tooLarge)
+	}
+
+	vision := makeSchedulerProvider(t, reg, "vision", model, 100)
+	vision.mu.Lock()
+	vision.Models = []protocol.ModelInfo{{ID: model, ModelType: "chat", Quantization: "4bit", IsVision: true}}
+	vision.mu.Unlock()
+
+	if candidates, _, _ := reg.QuickCapacityCheckForRequest(model, 100, 128, RequestTraits{}, true); candidates != 1 {
+		t.Fatalf("vision preflight candidates=%d, want 1", candidates)
+	}
+}
+
+func TestQuickCapacityCheckExcludesCriticalThermal(t *testing.T) {
+	reg := New(testLogger())
+	model := "critical-thermal-preflight"
+	p := makeSchedulerProvider(t, reg, "hot", model, 100)
+	p.mu.Lock()
+	p.SystemMetrics.ThermalState = "critical"
+	p.mu.Unlock()
+
+	if candidates, rejections, tooLarge := reg.QuickCapacityCheckForRequest(model, 100, 128, RequestTraits{}, false); candidates != 0 || rejections != 0 || tooLarge != 0 {
+		t.Fatalf("critical thermal preflight = (%d,%d,%d), want 0/0/0", candidates, rejections, tooLarge)
+	}
+}
+
+func TestIdleResidentAdmittedByFallbackMemoryGate(t *testing.T) {
+	reg := New(testLogger())
+	model := "idle-resident-fallback"
+	reg.SetModelCatalog([]CatalogEntry{{ID: model, SizeGB: 40}})
+	p := makeSchedulerProvider(t, reg, "idle-resident", model, 100)
+	p.mu.Lock()
+	p.BackendCapacity.GPUMemoryActiveGB = 42
+	p.BackendCapacity.TotalMemoryGB = 64
+	p.BackendCapacity.Slots[0].State = "idle"
+	// Force legacy memory admission path; active token budget path would bypass
+	// the bug this test guards.
+	p.BackendCapacity.Slots[0].ActiveTokenBudgetMax = 0
+	p.mu.Unlock()
+
+	selected, decision := reg.ReserveProviderEx(model, &PendingRequest{RequestID: "idle-resident", Model: model, EstimatedPromptTokens: 100, RequestedMaxTokens: 128})
+	if selected == nil {
+		t.Fatalf("idle resident provider rejected; decision=%+v", decision)
+	}
+	if selected.ID != p.ID {
+		t.Fatalf("selected %q, want %q", selected.ID, p.ID)
+	}
+}

--- a/coordinator/registry/warm_pool_controller.go
+++ b/coordinator/registry/warm_pool_controller.go
@@ -232,7 +232,7 @@ func (c *warmPoolController) reserveActions(actions []modelLoadAction, now time.
 func (c *warmPoolController) targetWarm(fleet warmPoolModelSnapshot, pressure warmPoolPressureBucket, queue warmPoolQueuePressure, now time.Time) int {
 	target := fleet.warm
 	add := 0
-	if queue.Depth > 0 {
+	if queue.Depth > 0 && queue.OldestAge >= c.config.QueueAgeThreshold {
 		add++
 		if queue.Depth > 1 {
 			add += int(math.Ceil(float64(queue.Depth-1) / 4.0))

--- a/coordinator/registry/warm_pool_controller.go
+++ b/coordinator/registry/warm_pool_controller.go
@@ -232,7 +232,7 @@ func (c *warmPoolController) reserveActions(actions []modelLoadAction, now time.
 func (c *warmPoolController) targetWarm(fleet warmPoolModelSnapshot, pressure warmPoolPressureBucket, queue warmPoolQueuePressure, now time.Time) int {
 	target := fleet.warm
 	add := 0
-	if queue.Depth > 0 || queue.OldestAge >= c.config.QueueAgeThreshold {
+	if queue.Depth > 0 {
 		add++
 		if queue.Depth > 1 {
 			add += int(math.Ceil(float64(queue.Depth-1) / 4.0))

--- a/coordinator/registry/warm_pool_controller.go
+++ b/coordinator/registry/warm_pool_controller.go
@@ -1,0 +1,414 @@
+package registry
+
+import (
+	"context"
+	"math"
+	"sort"
+	"sync"
+	"time"
+)
+
+type warmPoolController struct {
+	registry *Registry
+	config   WarmPoolConfig
+	state    *warmPoolState
+	queueMu  syncQueuePressure
+}
+
+type syncQueuePressure struct {
+	mu     sync.Mutex
+	models map[string]warmPoolQueuePressure
+}
+
+type warmPoolQueuePressure struct {
+	Depth     int
+	OldestAge time.Duration
+	UpdatedAt time.Time
+}
+
+type WarmPoolSnapshot struct {
+	Model              string
+	TargetWarm         int
+	WarmProviders      int
+	EligibleCold       int
+	QueueDepth         int
+	OldestQueueAge     time.Duration
+	CapacityRejects    int
+	TTFTMisses         int
+	SpeculativeStarted int
+	SpeculativeWon     int
+	ColdDispatches     int
+	LoadDurationEWMA   time.Duration
+	ObserveOnly        bool
+	Actions            []modelLoadAction
+}
+
+type warmPoolModelSnapshot struct {
+	model         string
+	warm          int
+	warmSaturated int
+	eligibleCold  []warmPoolCandidate
+}
+
+type warmPoolCandidate struct {
+	providerID string
+	score      float64
+}
+
+func newWarmPoolController(r *Registry, cfg WarmPoolConfig) *warmPoolController {
+	return &warmPoolController{
+		registry: r,
+		config:   cfg,
+		state:    newWarmPoolState(),
+		queueMu:  syncQueuePressure{models: make(map[string]warmPoolQueuePressure)},
+	}
+}
+
+func (r *Registry) ConfigureWarmPool(cfg WarmPoolConfig) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.warmPool == nil {
+		r.warmPool = newWarmPoolController(r, cfg)
+		return
+	}
+	r.warmPool.config = cfg
+}
+
+func (r *Registry) StartWarmPoolController(ctx context.Context, cfg WarmPoolConfig) func() {
+	if !cfg.Enabled {
+		return func() {}
+	}
+	r.ConfigureWarmPool(cfg)
+	ctx, cancel := context.WithCancel(ctx)
+	r.mu.RLock()
+	controller := r.warmPool
+	r.mu.RUnlock()
+	go controller.run(ctx)
+	return cancel
+}
+
+func (c *warmPoolController) run(ctx context.Context) {
+	interval := c.config.Interval
+	if interval <= 0 {
+		interval = 30 * time.Second
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			c.tick(time.Now())
+		}
+	}
+}
+
+func (c *warmPoolController) tick(now time.Time) []WarmPoolSnapshot {
+	if c == nil || c.registry == nil {
+		return nil
+	}
+	snapshots := c.plan(now)
+	for _, snap := range snapshots {
+		if c.registry.logger != nil {
+			c.registry.logger.Info("warm_pool_tick",
+				"model", snap.Model,
+				"target_warm", snap.TargetWarm,
+				"warm", snap.WarmProviders,
+				"eligible_cold", snap.EligibleCold,
+				"queue_depth", snap.QueueDepth,
+				"oldest_queue_age_ms", snap.OldestQueueAge.Milliseconds(),
+				"capacity_rejects", snap.CapacityRejects,
+				"ttft_misses", snap.TTFTMisses,
+				"speculative_started", snap.SpeculativeStarted,
+				"speculative_won", snap.SpeculativeWon,
+				"cold_dispatches", snap.ColdDispatches,
+				"actions", len(snap.Actions),
+				"observe_only", snap.ObserveOnly,
+			)
+		}
+		if snap.ObserveOnly || len(snap.Actions) == 0 {
+			continue
+		}
+		c.registry.sendModelLoadActions(snap.Actions)
+	}
+	return snapshots
+}
+
+func (c *warmPoolController) plan(now time.Time) []WarmPoolSnapshot {
+	if c.config.MaxLoadsPerTick == 0 || c.config.MaxGlobalPendingLoads == 0 {
+		return c.planObserveOnly(now, nil)
+	}
+	return c.planObserveOnly(now, c.reserveActions)
+}
+
+func (c *warmPoolController) planObserveOnly(now time.Time, reserve func([]modelLoadAction, time.Time) []modelLoadAction) []WarmPoolSnapshot {
+	stateWindow := c.config.Interval * 4
+	if stateWindow < time.Minute {
+		stateWindow = time.Minute
+	}
+	pressure := c.state.snapshot(now, stateWindow)
+	queue := c.queueSnapshot(now, stateWindow)
+	fleet := c.registry.warmPoolFleetSnapshot(now)
+
+	models := make(map[string]struct{})
+	for model := range pressure {
+		models[model] = struct{}{}
+	}
+	for model := range queue {
+		models[model] = struct{}{}
+	}
+	for model := range fleet {
+		models[model] = struct{}{}
+	}
+
+	ordered := make([]string, 0, len(models))
+	for model := range models {
+		ordered = append(ordered, model)
+	}
+	sort.Strings(ordered)
+
+	loadsRemaining := c.config.MaxLoadsPerTick
+	if loadsRemaining < 0 {
+		loadsRemaining = 0
+	}
+	globalPendingRemaining := c.config.MaxGlobalPendingLoads - c.registry.pendingModelLoadCount(now)
+	if globalPendingRemaining < loadsRemaining {
+		loadsRemaining = globalPendingRemaining
+	}
+	if loadsRemaining < 0 {
+		loadsRemaining = 0
+	}
+
+	var out []WarmPoolSnapshot
+	for _, model := range ordered {
+		p := pressure[model]
+		q := queue[model]
+		f := fleet[model]
+		target := c.targetWarm(f, p, q, now)
+		need := target - f.warm
+		if need < 0 {
+			need = 0
+		}
+		if need > len(f.eligibleCold) {
+			need = len(f.eligibleCold)
+		}
+		if need > loadsRemaining {
+			need = loadsRemaining
+		}
+		actions := make([]modelLoadAction, 0, need)
+		for i := 0; i < need; i++ {
+			actions = append(actions, modelLoadAction{providerID: f.eligibleCold[i].providerID, modelID: model})
+		}
+		if reserve != nil && !c.config.ObserveOnly {
+			actions = reserve(actions, now)
+		}
+		loadsRemaining -= len(actions)
+		c.state.rememberTarget(model, target, now)
+		out = append(out, WarmPoolSnapshot{
+			Model:              model,
+			TargetWarm:         target,
+			WarmProviders:      f.warm,
+			EligibleCold:       len(f.eligibleCold),
+			QueueDepth:         q.Depth,
+			OldestQueueAge:     q.OldestAge,
+			CapacityRejects:    p.capacityRejects,
+			TTFTMisses:         p.ttftMisses,
+			SpeculativeStarted: p.speculativeStarted,
+			SpeculativeWon:     p.speculativeWon,
+			ColdDispatches:     p.coldDispatches,
+			LoadDurationEWMA:   p.loadDurationEWMA,
+			ObserveOnly:        c.config.ObserveOnly,
+			Actions:            actions,
+		})
+	}
+	return out
+}
+
+func (c *warmPoolController) reserveActions(actions []modelLoadAction, now time.Time) []modelLoadAction {
+	return c.registry.reservePendingModelLoads(actions, now)
+}
+
+func (c *warmPoolController) targetWarm(fleet warmPoolModelSnapshot, pressure warmPoolPressureBucket, queue warmPoolQueuePressure, now time.Time) int {
+	target := fleet.warm
+	add := 0
+	if queue.Depth > 0 || queue.OldestAge >= c.config.QueueAgeThreshold {
+		add++
+		if queue.Depth > 1 {
+			add += int(math.Ceil(float64(queue.Depth-1) / 4.0))
+		}
+	}
+	if pressure.capacityRejects >= c.config.CapacityRejectThreshold {
+		add++
+	}
+	if pressure.ttftMisses >= c.config.TTFTMissThreshold {
+		add++
+	}
+	if pressure.speculativeStarted >= c.config.SpeculativeStartThreshold {
+		add++
+	}
+	if pressure.speculativeWon >= c.config.SpeculativeWinThreshold {
+		add++
+	}
+	if pressure.coldDispatches >= c.config.ColdDispatchThreshold {
+		add++
+	}
+	if pressure.loadDurationEWMA >= c.config.LoadDurationThreshold && pressure.coldDispatches > 0 {
+		add++
+	}
+	externalPressure := queue.Depth > 0 || pressure.capacityRejects > 0 || pressure.ttftMisses > 0 || pressure.speculativeStarted > 0 || pressure.speculativeWon > 0 || pressure.coldDispatches > 0
+	if fleet.warm > 0 && externalPressure && float64(fleet.warmSaturated)/float64(fleet.warm) >= c.config.WarmSaturationThreshold {
+		add++
+	}
+	target += add
+	if target < 0 {
+		target = 0
+	}
+	if target > fleet.warm+len(fleet.eligibleCold) {
+		target = fleet.warm + len(fleet.eligibleCold)
+	}
+	if c.config.MinDwell > 0 && pressure.lastTarget > target && now.Sub(pressure.lastTargetChangedAt) < c.config.MinDwell {
+		target = pressure.lastTarget
+	}
+	return target
+}
+
+func (c *warmPoolController) recordQueuePressure(model string, depth int, oldestAge time.Duration, now time.Time) {
+	if depth < 0 {
+		depth = 0
+	}
+	if oldestAge < 0 {
+		oldestAge = 0
+	}
+	c.queueMu.mu.Lock()
+	defer c.queueMu.mu.Unlock()
+	c.queueMu.models[model] = warmPoolQueuePressure{Depth: depth, OldestAge: oldestAge, UpdatedAt: now}
+}
+
+func (c *warmPoolController) queueSnapshot(now time.Time, recentWindow time.Duration) map[string]warmPoolQueuePressure {
+	c.queueMu.mu.Lock()
+	defer c.queueMu.mu.Unlock()
+	out := make(map[string]warmPoolQueuePressure, len(c.queueMu.models))
+	for model, p := range c.queueMu.models {
+		if !p.UpdatedAt.IsZero() && now.Sub(p.UpdatedAt) > recentWindow {
+			delete(c.queueMu.models, model)
+			continue
+		}
+		out[model] = p
+	}
+	return out
+}
+
+func (r *Registry) warmPoolFleetSnapshot(now time.Time) map[string]warmPoolModelSnapshot {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make(map[string]warmPoolModelSnapshot)
+	for _, p := range r.providers {
+		p.mu.Lock()
+		models := make([]string, 0, len(p.Models))
+		for _, m := range p.Models {
+			if r.modelAllowedByCatalogLocked(m) {
+				models = append(models, m.ID)
+			}
+		}
+		for _, model := range models {
+			warm := r.providerHasWarmModelLocked(p, model, now)
+			if warm {
+				s := out[model]
+				s.model = model
+				s.warm++
+				if !p.hasConcurrencyHeadroomForModelLocked(model) || warmPoolBackendSlotBusyLocked(p) {
+					s.warmSaturated++
+				}
+				out[model] = s
+				continue
+			}
+			if candidate, ok := r.warmPoolCandidateLocked(p, model, now); ok {
+				s := out[model]
+				s.model = model
+				s.eligibleCold = append(s.eligibleCold, candidate)
+				out[model] = s
+			}
+		}
+		p.mu.Unlock()
+	}
+	for model, s := range out {
+		sort.Slice(s.eligibleCold, func(i, j int) bool { return s.eligibleCold[i].score > s.eligibleCold[j].score })
+		out[model] = s
+	}
+	return out
+}
+
+func (r *Registry) warmPoolCandidateLocked(p *Provider, model string, now time.Time) (warmPoolCandidate, bool) {
+	if p.Status == StatusOffline || p.Status == StatusUntrusted || p.PrivateOnly {
+		return warmPoolCandidate{}, false
+	}
+	if r.providerHasPendingLoad(p.ID) || r.dispatchLoadCooldownActiveLocked(p.ID, model, now) {
+		return warmPoolCandidate{}, false
+	}
+	if p.pendingCount() != 0 || warmPoolBackendSlotBusyLocked(p) {
+		return warmPoolCandidate{}, false
+	}
+	if p.SystemMetrics.ThermalState == "critical" {
+		return warmPoolCandidate{}, false
+	}
+	if trustRank(p.TrustLevel) < trustRank(r.MinTrustLevel) || !p.RuntimeVerified || !r.providerSupportsPrivateTextLocked(p) {
+		return warmPoolCandidate{}, false
+	}
+	if p.LastChallengeVerified.IsZero() || now.Sub(p.LastChallengeVerified) > challengeFreshnessMaxAge {
+		return warmPoolCandidate{}, false
+	}
+	if !r.providerServesCatalogModelLocked(p, model) {
+		return warmPoolCandidate{}, false
+	}
+	totalMemoryGB := float64(p.Hardware.MemoryGB)
+	gpuActiveGB := 0.0
+	if p.BackendCapacity != nil {
+		if p.BackendCapacity.TotalMemoryGB > 0 {
+			totalMemoryGB = p.BackendCapacity.TotalMemoryGB
+		}
+		gpuActiveGB = p.BackendCapacity.GPUMemoryActiveGB
+	}
+	if !modelFitsHardware(r.catalogMinRAMGbLocked(model), r.catalogSizeGBLocked(model), totalMemoryGB) {
+		return warmPoolCandidate{}, false
+	}
+	freeGB := totalMemoryGB - gpuActiveGB
+	if freeGB < 0 {
+		freeGB = 0
+	}
+	thermalPenalty := 0.0
+	switch p.SystemMetrics.ThermalState {
+	case "serious":
+		thermalPenalty = 1000
+	case "fair":
+		thermalPenalty = 250
+	}
+	score := freeGB*100 + resolvedDecodeTPS(p)*10 - p.SystemMetrics.MemoryPressure*500 - p.SystemMetrics.CPUUsage*100 - thermalPenalty
+	return warmPoolCandidate{providerID: p.ID, score: score}, true
+}
+
+func warmPoolBackendSlotBusyLocked(p *Provider) bool {
+	if p.BackendCapacity == nil {
+		return false
+	}
+	for _, slot := range p.BackendCapacity.Slots {
+		if slot.NumRunning > 0 || slot.NumWaiting > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func (r *Registry) pendingModelLoadCount(now time.Time) int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	count := 0
+	for key, expiresAt := range r.pendingModelLoads {
+		if now.After(expiresAt) {
+			delete(r.pendingModelLoads, key)
+			continue
+		}
+		count++
+	}
+	return count
+}

--- a/coordinator/registry/warm_pool_controller_test.go
+++ b/coordinator/registry/warm_pool_controller_test.go
@@ -1,0 +1,194 @@
+package registry
+
+import (
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+)
+
+func testWarmPoolConfig() WarmPoolConfig {
+	return WarmPoolConfig{
+		Enabled:                   true,
+		ObserveOnly:               false,
+		Interval:                  time.Second,
+		MinDwell:                  0,
+		QueueAgeThreshold:         2 * time.Second,
+		CapacityRejectThreshold:   1,
+		WarmSaturationThreshold:   0.8,
+		TTFTMissThreshold:         1,
+		SpeculativeStartThreshold: 1,
+		SpeculativeWinThreshold:   1,
+		ColdDispatchThreshold:     1,
+		LoadDurationThreshold:     time.Second,
+		MaxLoadsPerTick:           1,
+		MaxGlobalPendingLoads:     10,
+	}
+}
+
+func makeWarmPoolColdProvider(t *testing.T, reg *Registry, id, model string, decodeTPS float64, totalMemory, activeMemory float64) *Provider {
+	t.Helper()
+	p := makeSchedulerProvider(t, reg, id, model, decodeTPS)
+	p.mu.Lock()
+	p.BackendCapacity = &protocol.BackendCapacity{
+		TotalMemoryGB:     totalMemory,
+		GPUMemoryActiveGB: activeMemory,
+		Slots: []protocol.BackendSlotCapacity{
+			{Model: "other-model", State: "idle"},
+		},
+	}
+	p.mu.Unlock()
+	return p
+}
+
+func captureWarmPoolLoads(reg *Registry) *[]modelLoadAction {
+	var sent []modelLoadAction
+	reg.loadModelSender = func(providerID, modelID string) error {
+		sent = append(sent, modelLoadAction{providerID: providerID, modelID: modelID})
+		return nil
+	}
+	return &sent
+}
+
+func TestWarmPoolSaturatedWarmProviderRaisesTargetAndSendsBoundedLoad(t *testing.T) {
+	reg := New(testLogger())
+	model := "warm-pool-saturated"
+	warm := makeSchedulerProvider(t, reg, "warm", model, 80)
+	cold := makeWarmPoolColdProvider(t, reg, "cold", model, 80, 64, 8)
+	warm.mu.Lock()
+	warm.BackendCapacity.Slots[0].MaxConcurrency = 1
+	warm.BackendCapacity.Slots[0].NumRunning = 1
+	warm.mu.Unlock()
+
+	reg.ConfigureWarmPool(testWarmPoolConfig())
+	sent := captureWarmPoolLoads(reg)
+	reg.RecordWarmPoolCapacityReject(model)
+
+	snaps := reg.warmPool.tick(time.Now())
+	if len(*sent) != 1 {
+		t.Fatalf("sent loads = %d, want 1", len(*sent))
+	}
+	if (*sent)[0].providerID != cold.ID || (*sent)[0].modelID != model {
+		t.Fatalf("sent %+v, want cold provider/model", (*sent)[0])
+	}
+	if len(snaps) == 0 || snaps[0].TargetWarm < 2 || len(snaps[0].Actions) != 1 {
+		t.Fatalf("snapshot = %+v, want target>=2 with one action", snaps)
+	}
+}
+
+func TestWarmPoolCapacityRejectRaisesTargetWithoutQueue(t *testing.T) {
+	reg := New(testLogger())
+	model := "warm-pool-capacity"
+	makeSchedulerProvider(t, reg, "warm", model, 80)
+	makeWarmPoolColdProvider(t, reg, "cold", model, 80, 64, 8)
+	reg.ConfigureWarmPool(testWarmPoolConfig())
+	sent := captureWarmPoolLoads(reg)
+
+	reg.RecordWarmPoolCapacityReject(model)
+	reg.warmPool.tick(time.Now())
+
+	if len(*sent) != 1 {
+		t.Fatalf("sent loads = %d, want 1", len(*sent))
+	}
+}
+
+func TestWarmPoolQueueAgePressureRaisesTarget(t *testing.T) {
+	reg := New(testLogger())
+	model := "warm-pool-queue-age"
+	makeSchedulerProvider(t, reg, "warm", model, 80)
+	makeWarmPoolColdProvider(t, reg, "cold", model, 80, 64, 8)
+	reg.ConfigureWarmPool(testWarmPoolConfig())
+	sent := captureWarmPoolLoads(reg)
+
+	reg.RecordWarmPoolQueueEnqueued(model, 1, 3*time.Second)
+	reg.warmPool.tick(time.Now())
+
+	if len(*sent) != 1 {
+		t.Fatalf("sent loads = %d, want 1", len(*sent))
+	}
+}
+
+func TestWarmPoolNoPressureForLongActiveDecodeAlone(t *testing.T) {
+	reg := New(testLogger())
+	model := "warm-pool-active-only"
+	warm := makeSchedulerProvider(t, reg, "warm", model, 80)
+	makeWarmPoolColdProvider(t, reg, "cold", model, 80, 64, 8)
+	warm.mu.Lock()
+	warm.BackendCapacity.Slots[0].NumRunning = 1
+	warm.mu.Unlock()
+	reg.ConfigureWarmPool(testWarmPoolConfig())
+	sent := captureWarmPoolLoads(reg)
+
+	snaps := reg.warmPool.tick(time.Now())
+
+	if len(*sent) != 0 {
+		t.Fatalf("sent loads = %d, want 0", len(*sent))
+	}
+	if len(snaps) == 0 || snaps[0].TargetWarm != 1 {
+		t.Fatalf("snapshot = %+v, want target 1", snaps)
+	}
+}
+
+func TestWarmPoolSkipsIneligibleProviders(t *testing.T) {
+	reg := New(testLogger())
+	model := "warm-pool-skip"
+	makeSchedulerProvider(t, reg, "warm", model, 80)
+	priv := makeWarmPoolColdProvider(t, reg, "private", model, 80, 64, 8)
+	untrusted := makeWarmPoolColdProvider(t, reg, "untrusted", model, 80, 64, 8)
+	stale := makeWarmPoolColdProvider(t, reg, "stale", model, 80, 64, 8)
+	critical := makeWarmPoolColdProvider(t, reg, "critical", model, 80, 64, 8)
+	active := makeWarmPoolColdProvider(t, reg, "active", model, 80, 64, 8)
+	pending := makeWarmPoolColdProvider(t, reg, "pending", model, 80, 64, 8)
+	good := makeWarmPoolColdProvider(t, reg, "good", model, 80, 64, 8)
+
+	priv.mu.Lock()
+	priv.PrivateOnly = true
+	priv.mu.Unlock()
+	untrusted.mu.Lock()
+	untrusted.Status = StatusUntrusted
+	untrusted.mu.Unlock()
+	stale.mu.Lock()
+	stale.LastChallengeVerified = time.Now().Add(-10 * time.Minute)
+	stale.mu.Unlock()
+	critical.mu.Lock()
+	critical.SystemMetrics.ThermalState = "critical"
+	critical.mu.Unlock()
+	active.AddPending(&PendingRequest{RequestID: "active-req", Model: "other-model"})
+	reg.reservePendingModelLoads([]modelLoadAction{{providerID: pending.ID, modelID: model}}, time.Now())
+
+	reg.ConfigureWarmPool(testWarmPoolConfig())
+	sent := captureWarmPoolLoads(reg)
+	reg.RecordWarmPoolCapacityReject(model)
+	reg.warmPool.tick(time.Now())
+
+	if len(*sent) != 1 {
+		t.Fatalf("sent loads = %d, want 1", len(*sent))
+	}
+	if (*sent)[0].providerID != good.ID {
+		t.Fatalf("selected provider = %q, want good", (*sent)[0].providerID)
+	}
+}
+
+func TestWarmPoolPicksBetterIdleProvider(t *testing.T) {
+	reg := New(testLogger())
+	model := "warm-pool-score"
+	makeSchedulerProvider(t, reg, "warm", model, 80)
+	bad := makeWarmPoolColdProvider(t, reg, "bad", model, 40, 32, 28)
+	good := makeWarmPoolColdProvider(t, reg, "good", model, 160, 128, 12)
+	bad.mu.Lock()
+	bad.SystemMetrics.ThermalState = "serious"
+	bad.SystemMetrics.MemoryPressure = 0.7
+	bad.mu.Unlock()
+
+	reg.ConfigureWarmPool(testWarmPoolConfig())
+	sent := captureWarmPoolLoads(reg)
+	reg.RecordWarmPoolCapacityReject(model)
+	reg.warmPool.tick(time.Now())
+
+	if len(*sent) != 1 {
+		t.Fatalf("sent loads = %d, want 1", len(*sent))
+	}
+	if (*sent)[0].providerID != good.ID {
+		t.Fatalf("selected provider = %q, want %q", (*sent)[0].providerID, good.ID)
+	}
+}

--- a/coordinator/registry/warm_pool_state.go
+++ b/coordinator/registry/warm_pool_state.go
@@ -1,0 +1,209 @@
+package registry
+
+import (
+	"sync"
+	"time"
+)
+
+type warmPoolPressureEvent string
+
+const (
+	warmPoolEventCapacityReject     warmPoolPressureEvent = "capacity_reject"
+	warmPoolEventTTFTMiss           warmPoolPressureEvent = "ttft_miss"
+	warmPoolEventSpeculativeStarted warmPoolPressureEvent = "speculative_started"
+	warmPoolEventSpeculativeWon     warmPoolPressureEvent = "speculative_won"
+	warmPoolEventColdDispatch       warmPoolPressureEvent = "cold_dispatch"
+)
+
+type warmPoolPressureBucket struct {
+	capacityRejects     int
+	ttftMisses          int
+	speculativeStarted  int
+	speculativeWon      int
+	coldDispatches      int
+	loadSuccesses       int
+	loadFailures        int
+	loadDurationEWMA    time.Duration
+	lastEventAt         time.Time
+	lastTarget          int
+	lastTargetChangedAt time.Time
+}
+
+type warmPoolState struct {
+	mu      sync.Mutex
+	models  map[string]*warmPoolPressureBucket
+	lastNow time.Time
+}
+
+func newWarmPoolState() *warmPoolState {
+	return &warmPoolState{models: make(map[string]*warmPoolPressureBucket)}
+}
+
+func (s *warmPoolState) recordEvent(model string, event warmPoolPressureEvent, now time.Time) {
+	if model == "" {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	b := s.bucketLocked(model)
+	s.recordEventLocked(b, event, now)
+}
+
+func (s *warmPoolState) recordLoad(model string, success bool, duration time.Duration, now time.Time) {
+	if model == "" {
+		return
+	}
+	if duration < 0 {
+		duration = 0
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	b := s.bucketLocked(model)
+	if success {
+		b.loadSuccesses++
+	} else {
+		b.loadFailures++
+	}
+	if duration > 0 {
+		if b.loadDurationEWMA == 0 {
+			b.loadDurationEWMA = duration
+		} else {
+			b.loadDurationEWMA = (b.loadDurationEWMA*3 + duration) / 4
+		}
+	}
+	b.lastEventAt = now
+}
+
+func (s *warmPoolState) snapshot(now time.Time, recentWindow time.Duration) map[string]warmPoolPressureBucket {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if recentWindow <= 0 {
+		recentWindow = time.Minute
+	}
+	out := make(map[string]warmPoolPressureBucket, len(s.models))
+	for model, b := range s.models {
+		if !b.lastEventAt.IsZero() && now.Sub(b.lastEventAt) > recentWindow {
+			b.capacityRejects = 0
+			b.ttftMisses = 0
+			b.speculativeStarted = 0
+			b.speculativeWon = 0
+			b.coldDispatches = 0
+			b.loadSuccesses = 0
+			b.loadFailures = 0
+			b.loadDurationEWMA = 0
+		}
+		out[model] = *b
+	}
+	return out
+}
+
+func (s *warmPoolState) rememberTarget(model string, target int, now time.Time) {
+	if model == "" {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	b := s.bucketLocked(model)
+	if b.lastTarget != target {
+		b.lastTarget = target
+		b.lastTargetChangedAt = now
+	}
+}
+
+func (s *warmPoolState) bucketLocked(model string) *warmPoolPressureBucket {
+	b := s.models[model]
+	if b == nil {
+		b = &warmPoolPressureBucket{}
+		s.models[model] = b
+	}
+	return b
+}
+
+func (s *warmPoolState) recordEventLocked(b *warmPoolPressureBucket, event warmPoolPressureEvent, now time.Time) {
+	s.decayLocked(now)
+	s.lastNow = now
+	switch event {
+	case warmPoolEventCapacityReject:
+		b.capacityRejects++
+	case warmPoolEventTTFTMiss:
+		b.ttftMisses++
+	case warmPoolEventSpeculativeStarted:
+		b.speculativeStarted++
+	case warmPoolEventSpeculativeWon:
+		b.speculativeWon++
+	case warmPoolEventColdDispatch:
+		b.coldDispatches++
+	}
+	b.lastEventAt = now
+}
+
+func (s *warmPoolState) decayLocked(now time.Time) {
+	if s.lastNow.IsZero() || now.Sub(s.lastNow) < time.Minute {
+		return
+	}
+	for _, b := range s.models {
+		b.capacityRejects /= 2
+		b.ttftMisses /= 2
+		b.speculativeStarted /= 2
+		b.speculativeWon /= 2
+		b.coldDispatches /= 2
+		b.loadSuccesses /= 2
+		b.loadFailures /= 2
+	}
+}
+
+func (r *Registry) RecordWarmPoolCapacityReject(model string) {
+	if r.warmPool == nil {
+		return
+	}
+	r.warmPool.state.recordEvent(model, warmPoolEventCapacityReject, time.Now())
+}
+
+func (r *Registry) RecordWarmPoolQueueEnqueued(model string, depth int, oldestAge time.Duration) {
+	if r.warmPool == nil || model == "" {
+		return
+	}
+	r.warmPool.recordQueuePressure(model, depth, oldestAge, time.Now())
+}
+
+func (r *Registry) RecordWarmPoolQueueTimeout(model string, age time.Duration) {
+	if r.warmPool == nil || model == "" {
+		return
+	}
+	r.warmPool.recordQueuePressure(model, 1, age, time.Now())
+}
+
+func (r *Registry) RecordWarmPoolTTFTMiss(model string, duration time.Duration) {
+	if r.warmPool == nil {
+		return
+	}
+	r.warmPool.state.recordEvent(model, warmPoolEventTTFTMiss, time.Now())
+}
+
+func (r *Registry) RecordWarmPoolSpeculativeStarted(model string) {
+	if r.warmPool == nil {
+		return
+	}
+	r.warmPool.state.recordEvent(model, warmPoolEventSpeculativeStarted, time.Now())
+}
+
+func (r *Registry) RecordWarmPoolSpeculativeWon(model string) {
+	if r.warmPool == nil {
+		return
+	}
+	r.warmPool.state.recordEvent(model, warmPoolEventSpeculativeWon, time.Now())
+}
+
+func (r *Registry) RecordWarmPoolColdDispatch(model string) {
+	if r.warmPool == nil {
+		return
+	}
+	r.warmPool.state.recordEvent(model, warmPoolEventColdDispatch, time.Now())
+}
+
+func (r *Registry) RecordWarmPoolLoadResult(model string, success bool, duration time.Duration) {
+	if r.warmPool == nil {
+		return
+	}
+	r.warmPool.state.recordLoad(model, success, duration, time.Now())
+}

--- a/docs/architecture/operations/consumer-latest-routing-plan.md
+++ b/docs/architecture/operations/consumer-latest-routing-plan.md
@@ -1,0 +1,367 @@
+# Consumer-Latest Routing Plan
+
+Date: 2026-06-14
+
+Worktree: `.worktrees/consumer-latest-routing`
+
+Branch: `plan/consumer-latest-routing`
+
+## Objective
+
+Deliver the best consumer experience under burst and sustained load: requests should reach capable providers whenever the fleet can serve them, TTFT should stay low, per-request decode TPS should stay healthy, long-budget requests should not be rejected solely because they requested worst-case output, and the coordinator should widen warm capacity when direct pressure shows the current warm set is insufficient.
+
+## Core Diagnosis
+
+- The largest observed load-test failures are pre-router admission failures, not provider selection failures.
+- Balance reservation debits one hot Postgres balance row before routing; OpenRouter-style service traffic concentrates on one account row.
+- OTPM admission charges full bounded `max_tokens` before routing; long-budget reasoning requests get rejected even when actual output would fit.
+- Current warming is too reactive: it looks at queued demand and only warms when there is no warm provider at all.
+- A single warm provider can soak traffic while many cold-capable providers stay idle because routing correctly prefers warm slots but no separate controller expands the warm pool.
+- Prefix/SSD KV cache has an explicit request-level `prompt_cache_key` scope. It can be used for soft routing affinity, but it must stay separate from warm-pool control.
+- Prod deploy freshness is ambiguous. `/health` does not expose coordinator commit/version, making load-test interpretation harder after several days without redeploy.
+
+## Design Principles
+
+- Use direct pressure signals, not speculative forecasts.
+- Optimize user-visible performance, not provider utilization. The system should optimize two consumer SLOs: time to first content (TTFT/TTFC) and sustained output TPS. The controller should react to consumer pain: queue wait, time-to-first-content, decode TPS degradation, retries/failover, and cold-start exposure.
+- Keep routing and warm-pool control separate. Routing picks the best provider for this request; the controller decides whether to add warm capacity for a model.
+- The warm-pool controller only changes warm targets and sends bounded `load_model` commands. It must not change token budgets, balance admission, or request rate limits.
+- Cache affinity is a routing optimization only. It must not drive the warm-pool controller.
+- Prefer simple hysteresis over complex prediction: require pressure to persist before warming, add capacity in small steps, and stop adding when pressure clears.
+- Do not force-unload in the first pass. Let provider idle timeout handle decay; the coordinator target only controls new load commands.
+- Every warm action must pass the same safety gates as routing: model catalog, trust, private-text support, challenge freshness, runtime verification, cooldowns, memory fit, private-only exclusion, and thermal safety.
+- Warming must be non-interfering. Do not send `load_model` to a provider with active inference, and keep global concurrent loads low so model loading does not hurt active consumers on other machines through fleet-wide resource contention.
+- Routing should prefer providers that preserve both fast first content and good decode TPS. A warm but heavily saturated provider should lose to another eligible provider when the expected per-request TPS or backlog makes consumer experience worse.
+
+## Non-Goals
+
+- Do not port the existing `.worktrees/predictive-warming` branch as the main design. It can be mined for tests or small helpers, but the controller should be simpler.
+- Do not redesign billing ledger semantics for every consumer in the first pass.
+- Do not add prompt content logging or persistent prompt fingerprints.
+- Do not require provider protocol changes for the first cache-affinity implementation.
+- Do not hard-pin public traffic to any provider.
+
+## Code Evidence
+
+- Preflight balance reservation runs before routing in `coordinator/api/consumer.go:1452` and `coordinator/api/consumer.go:3956`.
+- Postgres balance debit updates a single account row in `coordinator/store/postgres.go:1781`.
+- Output-token rate limiting admits on upfront `max_tokens` in `coordinator/api/server.go:375`.
+- Provider-reported KV bytes per token exists in `coordinator/protocol/messages.go:208`.
+- Coordinator fallback KV sizing still uses `kvCacheBytesPerToken` in `coordinator/registry/scheduler.go:39` and `coordinator/registry/scheduler.go:752`.
+- Dispatch selection is `ReserveProviderEx` in `coordinator/registry/scheduler.go:213`.
+- Fast preflight is `QuickCapacityCheck` in `coordinator/registry/scheduler.go:1079`.
+- Queue-driven reactive warming is `TriggerModelSwaps` in `coordinator/registry/registry.go:2339`.
+- Capacity snapshot currently sets warm from a running slot in `coordinator/registry/registry.go:3803`.
+- Provider extracts `prompt_cache_key` or `user` as cache scope in `provider-swift/Sources/ProviderCore/ProviderLoop+InboundDecode.swift:80`.
+- Provider token-level checkpoint digests are computed after tokenization in `provider-swift/Sources/ProviderCore/KVCache/PrefixDigest.swift:25`.
+
+## Current Control Knobs And Feedback Paths
+
+This is the concrete control surface the implementation should use. New code should add to these loops rather than invent separate hidden loops.
+
+Queue loop:
+
+- Knobs: per-model queue size `10`, wait `120s` in `coordinator/registry/registry.go:784`; retry hint from `estimateRetryAfter` in `coordinator/api/consumer.go:918`.
+- Signals: queue depth, oldest queued age, queue timeout, queue full.
+- Actuators: enqueue/reject, drain queued requests, warm-pool target/load commands.
+
+TTFT/speculation loop:
+
+- Knobs: `ttftDeadline = 5s + 1ms/input_token`, speculative backup at `0.5 * deadline`, preamble-content timeout, inference idle timeout in `coordinator/api/consumer.go:44`.
+- Signals: first-content time, speculative backup started, speculative backup won, first-content timeout, accepted-then-stall timeout.
+- Actuators: retry/failover for this request, warm-pool pressure for future requests.
+
+Admission loop:
+
+- Knobs: request RPM/service RPM and ITPM/OTPM defaults in `coordinator/ratelimit/config.go:38`; per-key overrides in API-key records.
+- Signals: token/RPM rejects, service-account balance reservation failures, capacity preflight rejects.
+- Actuators: request reject, expected-output token admission, service-account deferred reservation. Admission changes must stay separate from warm-pool control.
+
+Routing/capacity loop:
+
+- Knobs: queue/pending/backlog/health/cold-load cost terms in `coordinator/registry/scheduler.go:16`; provider token-budget caps from heartbeat; trust and freshness gates.
+- Signals: candidate count, capacity rejection count, effective TPS, token backlog, warm saturation, thermal state.
+- Actuators: provider selection for this request; warm-pool pressure events for future capacity.
+
+Model-load loop:
+
+- Knobs: `pendingModelLoadTTL = 2m`, drain backoff `30s`, dispatch-load cooldown `2m` in `coordinator/registry/registry.go:757`.
+- Signals: `load_model_status` success/failure, load duration, dispatch load failure, pending-load count.
+- Actuators: send bounded `load_model`, clear/backoff pending load, reject unservable queue.
+
+Freshness/safety loop:
+
+- Knobs: challenge freshness `6m` in `coordinator/registry/scheduler.go:37`, heartbeat-derived `BackendCapacity`, thermal gates.
+- Signals: heartbeat slot states, observed decode TPS, active token budget, challenge freshness, provider thermal state.
+- Actuators: deroute, skip warming target, capacity snapshot.
+
+Rollout loop:
+
+- Knobs: new feature flags must default off for service reservation, expected-output OTPM, warm-pool active mode, and cache affinity.
+- Signals: health version, feature mode tags, per-track metrics.
+- Actuators: observe-only mode first, per-service-account enablement, then broader rollout.
+
+## Track A: Pre-Router Admission Reliability
+
+Owner profile: coordinator API + store engineer.
+
+Goal: service-account traffic should not return `503 service_unavailable` because many concurrent requests all pre-debit the same balance row.
+
+Plan:
+
+- Add coordinator build/version metadata to `/health` first so canaries prove what code is deployed.
+- Introduce a trusted service-account reservation mode behind an env flag, initially for `store.RoleService` only.
+- In service-account reservation mode, skip the synchronous preflight `ledger.Charge` hot-row debit and reserve against an in-memory per-account outstanding cap refreshed from the store.
+- Charge actual usage at settlement and keep full immediate debit behavior for normal consumer accounts.
+- Bound exposure with per-account outstanding caps, request TTL cleanup, and fail-closed behavior if cached available balance cannot be refreshed.
+- Keep provider-specific price top-up paths consistent with free self-route and service-account reservation mode.
+
+Files likely touched:
+
+- `coordinator/api/consumer.go`
+- `coordinator/api/dispatch.go`
+- `coordinator/api/server.go`
+- `coordinator/store/postgres.go`
+- new `coordinator/api/reservations.go`
+
+Tests:
+
+- Concurrent service-account preflight does not call `Debit` per request and does not emit `503` under artificial slow store.
+- Normal consumer preflight still debits synchronously and still rejects insufficient balance.
+- Service-account settlement charges exactly once on success and cleans outstanding holds on provider error, client cancel, timeout, and speculative loser.
+- Provider custom price top-up does not reintroduce the hot-row path for service accounts.
+
+## Track B: Expected-Output Token Admission
+
+Owner profile: rate-limit + API engineer.
+
+Goal: OTPM protects the platform without rejecting long-budget requests solely because `max_tokens` is large.
+
+Plan:
+
+- Extend token limiting to admit on estimated output tokens and reconcile actual completion tokens afterward.
+- Start with service accounts enabled by env flag; keep full `max_tokens` charging for normal consumers until validated.
+- Add `OutputAdmissionEstimator` in `coordinator/api`: estimate = bounded fraction of `max_tokens` with floors and model-specific override hooks.
+- Reconcile actual output after completion. If actual output exceeds estimate, consume the delta from the same token limiter so later requests slow down.
+- Keep billing reservation separate; this track changes rate-limit admission, not billable usage.
+
+Files likely touched:
+
+- `coordinator/api/server.go`
+- `coordinator/api/consumer.go`
+- `coordinator/api/dispatch.go`
+- `coordinator/ratelimit/*`
+
+Tests:
+
+- Service account with `max_tokens=32768` no longer immediately exhausts the 512k burst purely from 16 concurrent admissions.
+- Actual completion above estimate reduces future output-token capacity.
+- Reconciliation is idempotent across streaming, non-streaming, provider error, and timeout paths.
+- Per-key OTPM overrides still apply.
+
+## Track C: Pressure-Based Warm-Pool Controller
+
+Owner profile: registry/scheduler engineer.
+
+Goal: if directly observed pressure shows a model's warm pool is too small, warm more eligible providers before users experience queue timeouts or repeated cold starts.
+
+Controller model:
+
+- State is per model: current warm count, current running count, current idle-loaded count, target warm count, oldest queued age, recent capacity-reject count, recent first-content SLO miss count, recent decode-TPS SLO miss count, recent speculative backup win count, and warm saturation count.
+- Signals come from direct events only:
+  - Queue depth and oldest queue age.
+  - Capacity rejects from preflight and dispatch selection.
+  - Warm saturation: warm eligible providers with no concurrency or token-budget headroom.
+  - User-visible time-to-first-content pressure: route+queue+dispatch time before first content.
+  - User-visible decode throughput pressure: recent requests whose post-first-content tokens/sec is below the model/provider floor.
+  - Provider-reported decode TPS degradation: warm slots whose observed TPS falls materially below their own recent baseline while they are running multiple requests.
+  - TTFT deadline misses, speculative backup launches, and speculative backup wins.
+  - Cold dispatches selected by routing.
+  - Measured `load_model` duration and recent request service time, used only to calibrate wait estimates and rollout dashboards.
+- EWMA may smooth noisy counters, but no historical baseline or demand forecast is required.
+- Output is only `targetWarmCount` and bounded `load_model` actions.
+
+Pressure rules:
+
+- Severe pressure: oldest queued age exceeds a small threshold, or capacity rejects occur while cold eligible providers exist. Add one warm target immediately, subject to caps.
+- Sustained pressure: warm saturation, first-content SLO misses, decode-TPS SLO misses caused by loaded-slot saturation, speculative backup wins, or cold dispatches persist for N ticks. Add one warm target.
+- No pressure: keep target stable for a minimum dwell time, then let it decay by one target step. Do not force-unload.
+- Emergency guard: never warm more than the configured per-model step, global step, or eligible idle provider count in one tick.
+
+Warm target selection:
+
+- Candidate must be routing-safe, public-eligible, idle, not private-only, not in pending-load or dispatch-load cooldown, not critical thermal, and must fit the model by catalog/hardware gates.
+- Candidate must have zero active requests across all loaded models. A warm-up action should never compete with an active consumer on that Mac.
+- Prefer candidates with more free memory/headroom, lower GPU memory pressure, better observed/static TPS, lower thermal state, fewer loaded pressured models, and no recent load failures.
+- Do not steal a provider from another model that is currently pressured unless no other option exists.
+- Respect `maxModelSlots`; providers may hold multiple models, but the controller should avoid churn by enforcing a minimum model dwell time.
+
+Consumer-performance guardrails:
+
+- Warm-pool changes should be judged by first-content latency and retry behavior, not just more warm providers.
+- Warm-pool changes should also be judged by sustained output TPS. If adding warm capacity spreads load and improves per-request decode TPS, keep it; if it only adds churn, back off.
+- A load command is a means to reduce future consumer wait or preserve output throughput. If warming raises TTFT misses, decode-TPS misses, speculative wins, provider OOMs, or load failures, the controller should back off.
+- Prefer warming models with active consumer pain over models with merely high request rate.
+- Avoid chasing long generations: a high number of active long decodes is not itself pressure if first-content SLO is healthy, decode TPS is healthy, and the queue is empty.
+
+Files likely touched:
+
+- new `coordinator/registry/warm_pool_controller.go`
+- new `coordinator/registry/warm_pool_state.go`
+- `coordinator/registry/config.go`
+- `coordinator/registry/registry.go`
+- `coordinator/registry/scheduler.go`
+- `coordinator/cmd/coordinator/main.go`
+- `coordinator/api/consumer.go`
+- `coordinator/api/dispatch.go`
+- `coordinator/api/provider.go`
+
+Tests:
+
+- One warm saturated provider plus cold eligible providers raises target and sends one bounded `load_model`.
+- Fast capacity rejects record pressure and can raise target even when no request entered the queue.
+- Queue age pressure raises target; empty queues with no misses do not.
+- First-content SLO miss or speculative backup win contributes pressure without requiring p95 aggregation.
+- Decode-TPS SLO miss contributes pressure only when it coincides with warm saturation or low observed TPS under multi-request load; a slow model/provider baseline alone does not raise target.
+- Active long-running decodes alone do not raise target when queue age, capacity rejects, first-content misses, and decode-TPS misses are zero.
+- Controller skips private-only, untrusted, stale challenge, dispatch-load-cooled, critical thermal, active, and pending-load providers.
+- Controller picks the better idle provider by headroom/TPS/thermal, not map iteration.
+- Target does not oscillate when demand alternates between two models; minimum dwell and no-steal rules hold.
+
+## Track D: Scheduler And Capacity Correctness
+
+Owner profile: registry correctness engineer.
+
+Goal: preflight, capacity snapshot, and actual dispatch should agree, and operators should see true warm/cold state.
+
+Plan:
+
+- Treat slot state `idle` as loaded everywhere, including `freeMemoryAdmits` and `QuickCapacityCheck` snapshots.
+- Fold vision requirement into preflight capacity so media requests do not pass text-only capacity checks.
+- Add thermal-critical exclusion to `QuickCapacityCheck`; preserve serious/fair as cost penalties unless warm target selection skips them.
+- Update `/v1/models/capacity` to count both `running` and `idle` as warm, and optionally expose `running_providers` separately.
+- Emit `routing.cost_ms`, `routing.effective_decode_tps`, and cost breakdown tags for the main chat dispatch path, not only generic paths.
+- Add consumer-visible decode TPS metrics from first content to completion where usage is available. Use these for observability and warm-pool pressure, not for billing.
+- Review candidate cost terms so saturated warm providers are penalized enough to protect both first-content and decode TPS. Keep the cost model explainable: queue/backlog/this-request/health terms should remain decomposable.
+- Replace fixed cold penalties with measured load ETA only if that can be done from direct recent load durations; otherwise keep conservative defaults and rely on the warm-pool controller.
+
+Files likely touched:
+
+- `coordinator/registry/scheduler.go`
+- `coordinator/registry/registry.go`
+- `coordinator/api/consumer.go`
+- `coordinator/api/dispatch.go`
+- capacity handler files
+
+Tests:
+
+- `idle` resident slots are admitted under memory fallback.
+- Vision preflight returns no candidates when only text providers are eligible.
+- Critical thermal provider does not count as preflight capacity.
+- Capacity snapshot warm count includes `idle`; running count remains available if added.
+- Chat dispatch emits route cost metrics for immediate, queued, retry, and speculative backup win paths.
+- Low effective TPS on a saturated warm provider makes another eligible provider win when consumer decode throughput would be materially better.
+
+## Track E: Cache Affinity For Existing Prefix Cache Scope
+
+Owner profile: API + scheduler engineer.
+
+Goal: repeated or conversation-like workloads that explicitly provide `prompt_cache_key` should have a chance to hit provider-local prefix cache without hard-pinning traffic.
+
+Plan:
+
+- Reuse existing request field `prompt_cache_key`; hash it as `SHA256(prompt_cache_key)` to match provider cache scope policy.
+- Do not compute token-level `PrefixDigest` in the coordinator in the first pass. That requires provider-equivalent tokenization and chat-template rendering.
+- Do not use cache affinity as a warm-pool signal.
+- Add an in-memory, TTL-bound `CacheAffinityTracker` keyed by `(accountID, model, cacheScopeHash)`.
+- Record the winning provider after a successful first content or completion.
+- During candidate selection, apply a small cost bonus when the affinity provider is eligible and not materially slower than the best provider.
+- Never bypass normal gates: trust, privacy, serial allowlists, vision/tools, thermal, token budget, cooldowns, and queue/backlog still win.
+- Emit metrics for affinity lookup, eligible hit, selected hit, and skipped-too-busy.
+
+Files likely touched:
+
+- `coordinator/api/consumer.go`
+- `coordinator/api/dispatch.go`
+- `coordinator/registry/scheduler.go`
+- new `coordinator/registry/cache_affinity.go`
+
+Tests:
+
+- Same account/model/`prompt_cache_key` softly prefers previous provider when costs are close.
+- Affinity does not select a provider that is full, cooled down, text-only for media, below trait floor, private-only, thermally bad, or outside allowlist.
+- Different accounts do not share affinity.
+- Expired affinity is ignored.
+- Requests without explicit `prompt_cache_key` do not get cache-affinity routing by default.
+
+## Track F: Verification, Canary, And Load-Test Harness
+
+Owner profile: verifier/load-test engineer.
+
+Goal: prove consumer experience improved before prod-wide rollout.
+
+Plan:
+
+- Add coordinator commit/version to `/health` and include it in load-test reports.
+- Extend load tests to classify pre-router versus router versus provider errors.
+- Add direct recent metrics, not sparse percentile aggregation, for:
+  - `queue.depth` and `queue.oldest_age_ms`
+  - `routing.time_to_first_content_ms`
+  - `routing.output_tps`
+  - `routing.decode_tps_slo_miss`
+  - `routing.capacity_rejects`
+  - `routing.ttft_deadline_miss`
+  - `routing.speculative_backup_started`
+  - `routing.speculative_backup_won`
+  - `warm_pool.pressure`
+  - `warm_pool.target_warm_count`
+  - `warm_pool.actual_warm_count`
+  - `warm_pool.load_commands_sent`
+  - `routing.cache_affinity_selected`
+- Add a gemma mixed-load scenario that asserts warm target and loaded warm count increase under direct pressure.
+- Add service-account burst tests for short-output high concurrency and long-budget reasoning concurrency.
+
+Acceptance targets:
+
+- `512 max_tokens x 64 concurrency` service-account burst has zero pre-router billing `503` with idle fleet.
+- `32768 max_tokens x 16 concurrency` service-account burst is not rejected solely by upfront OTPM when actual output remains below tier budget.
+- Under sustained gemma pressure, warm loaded provider count grows beyond the initial small warm set without queue timeout.
+- TTFT deadline-miss rate and speculative-backup-win rate improve or stay flat; no increase in provider OOM/load-failure rate.
+- First-content latency improves or stays flat for streaming users; output TPS improves or stays flat for long generations; non-streaming total completion latency must not regress for short requests.
+- No privacy regression: no raw prompt logging, no persisted prompt hashes, no cross-account cache affinity.
+
+## Suggested Swarm Split
+
+- Agent A: Track A service-account reservation mode and `/health` version metadata.
+- Agent B: Track B expected-output token admission and reconciliation.
+- Agent C: Track C pressure-based warm-pool controller.
+- Agent D: Track D scheduler/capacity correctness and route-cost observability.
+- Agent E: Track E explicit `prompt_cache_key` cache affinity.
+- Agent F: Track F tests, load-test scripts, dashboards, and final verification.
+
+## Dependency Order
+
+- Track D should land early because it fixes correctness drift used by the warm-pool controller.
+- Track C can start immediately on its own state/controller files, then wire into Track D helpers when available.
+- Track A and Track B are independent from scheduler work and should run in parallel because they address the observed OpenRouter-facing failures.
+- Track E depends lightly on Track D because it must use the same eligibility/cost model, but it must remain independent from Track C.
+- Track F starts immediately with baseline tests and finishes last with integrated load validation.
+
+## Rollout Plan
+
+- Deploy version metadata first or with the first coordinator change.
+- Enable service-account reservation mode only for a known test service account in dev.
+- Enable expected-output OTPM only for service tier in dev, then one production service account.
+- Enable warm-pool controller in observe-only mode first: compute pressure and target, emit metrics, send no `load_model`.
+- Enable warm-pool controller with conservative caps: max one load per model per tick, small global load cap, and no forced unload.
+- Roll out cache affinity last because it is an optimization, not an availability fix.
+- Keep feature flags for service reservation, expected-output OTPM, warm-pool control, adaptive queue behavior, and cache affinity so each can be disabled independently.
+
+## Open Questions For Humans
+
+- What maximum temporary exposure is acceptable for trusted service accounts if preflight debit is deferred?
+- Should OpenRouter/service accounts bypass consumer OTPM entirely until expected-output reconciliation is live?
+- What direct TTFT/SLO miss threshold should trigger warm-pool pressure for public OpenRouter traffic?
+- What minimum recent per-model output TPS should count as consumer-visible decode pressure for public OpenRouter traffic?
+- What production env controls are available for enabling warm-pool control independently of deploy?
+- Is there a preferred canonical coordinator version source: build-time `git_sha`, Docker label, or EigenCloud revision?


### PR DESCRIPTION
## Summary

This PR implements the consumer-latest routing control plan from Issue #342 and the routing review discussion.

It focuses on giving consumers better TTFT and sustained output TPS while keeping rollout conservative and feature-flagged.

### Routing/capacity correctness

- Treats `idle` backend slots as loaded/resident everywhere relevant to dispatch and preflight admission.
- Adds request-aware capacity preflight for vision requests.
- Excludes critical thermal providers from preflight capacity.
- Updates model capacity snapshots so `warm_providers` includes `running` and `idle`, plus adds `running_providers`.
- Emits build metadata from `/health`: `version`, `build_commit`, `build_date`.

### Pre-router admission controls

- Adds disabled-by-default service-account reservation mode via `EIGENINFERENCE_SERVICE_RESERVATIONS_ENABLED`.
- Service accounts can reserve against in-memory outstanding holds instead of synchronously debiting one hot Postgres balance row before routing.
- Normal consumers retain synchronous ledger debit behavior.
- Completion settlement still performs a real debit for actual usage.

### Expected-output OTPM admission

- Adds disabled-by-default service expected-output admission via `EIGENINFERENCE_SERVICE_EXPECTED_OUTPUT_ADMISSION_ENABLED`.
- Adds estimator knobs for fraction/floor/ceiling.
- Reconciles actual successful output above the admitted estimate into future rate-limit debt.

### Pressure-based warm-pool controller

- Adds disabled-by-default warm-pool controller via `EIGENINFERENCE_WARM_POOL_ENABLED`.
- Defaults to observe-only via `EIGENINFERENCE_WARM_POOL_OBSERVE_ONLY=true`.
- Uses only direct pressure signals: queue age/depth, capacity rejects, TTFT misses, speculative starts/wins, cold dispatches, and measured load duration.
- Actuator is only bounded `load_model` commands; it does not mutate token admission, billing, or routing affinity.
- Warming is non-interfering: candidates must be idle, public-eligible, fresh/trusted, not private-only, not thermally critical, not active, and not already loading.

### Explicit prompt cache affinity

- Adds in-memory TTL affinity for explicit `prompt_cache_key` only.
- Stores only SHA-256(prompt_cache_key), scoped by account/model, never raw key and never persisted.
- Applies only a bounded soft routing bonus after normal gates pass.
- Does not drive warm-pool control.

## Red-Team / Control-System Notes

- All new actuators default off. Warm-pool is observe-only even when enabled unless explicitly changed.
- Warm-pool signals are direct recent pressure counters, not historical forecasting.
- Cache affinity is intentionally separated from warming to avoid feedback loops and privacy surprises.
- Service reservations are in-memory and per-process; restart drops holds. Completion still debits actual usage, and failed settlement zeroes uncollected cost/payout.
- Expected-output admission can create future OTPM debt if actual output exceeds estimates; this is intentional but needs production tuning.
- Cache affinity is recorded after committed first content so it can help streaming continuations; it is not limited to fully completed responses.

## Tests

- `cd coordinator && go test ./...`
- `git diff --check`
