### PR TITLE
feat(stats+landing): live Network Power stat from real fleet hardware

### DIFF
--- a/console-ui/src/app/stats/page.tsx
+++ b/console-ui/src/app/stats/page.tsx
@@ -38,6 +38,8 @@ import {
   type CertVerificationResult,
   type VerificationStep,
 } from "@/lib/cert-verify";
+import { formatPower } from "@/lib/format-power";
+import { activeNetworkPowerWatts } from "@/lib/network-power";
 
 const COORDINATOR_URL = process.env.NEXT_PUBLIC_COORDINATOR_URL || "https://api.darkbloom.dev";
 
@@ -153,6 +155,7 @@ interface PlatformStats {
   total_memory_gb: number;
   total_bandwidth_gbs: number;
   network_capacity_tps: number;
+  active_power_watts?: number;
   providers: ProviderStats[];
   models: ModelStats[];
   provider_locations?: ProviderLocationBucket[];
@@ -453,6 +456,9 @@ function MiniStat({
   );
 }
 
+// ---------------------------------------------------------------------------
+// Network Power -- realistic Apple Silicon draw, auto-scaled units
+// ---------------------------------------------------------------------------
 function modelProviders(modelID: string, providers: ProviderStats[]): ProviderStats[] {
   return providers.filter((provider) => {
     if (provider.current_model === modelID) return true;
@@ -2859,6 +2865,7 @@ export default function StatsPage() {
   }
 
   const hardwareAttested = stats.providers.filter((p) => p.trust_level === "hardware").length;
+  const networkPowerWatts = activeNetworkPowerWatts(stats);
   const tabs: Array<{ value: StatsTab; label: string }> = [
     { value: "overview", label: "Overview" },
     { value: "leaderboard", label: "Leaderboard" },
@@ -2938,8 +2945,15 @@ export default function StatsPage() {
           </div>
         </div>
 
-        {/* Hardware capacity grid */}
+        {/* Hardware capacity grid (+ network power) */}
         <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-5 gap-3">
+          {networkPowerWatts > 0 && (
+            <MiniStat
+              label="Network Power"
+              value={formatPower(networkPowerWatts)}
+              sub="under load"
+            />
+          )}
           <MiniStat label="GPU Cores" value={stats.total_gpu_cores.toString()} sub="Apple Silicon" />
           <MiniStat label="CPU Cores" value={stats.total_cpu_cores.toString()} sub="P + E cores" />
           <MiniStat label="Unified RAM" value={`${stats.total_memory_gb} GB`} />

--- a/console-ui/src/lib/format-power.test.ts
+++ b/console-ui/src/lib/format-power.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from "vitest";
+import { formatPower } from "./format-power";
+
+describe("formatPower", () => {
+  describe("examples from the spec", () => {
+    it("formats sub-kW watts", () => {
+      expect(formatPower(950)).toBe("950 W");
+    });
+
+    it("formats kW with one decimal", () => {
+      expect(formatPower(20855)).toBe("20.9 kW");
+    });
+
+    it("formats large kW as an integer", () => {
+      expect(formatPower(187000)).toBe("187 kW");
+    });
+
+    it("formats MW with one decimal", () => {
+      expect(formatPower(1.4e6)).toBe("1.4 MW");
+    });
+
+    it("formats GW with one decimal", () => {
+      expect(formatPower(2.1e9)).toBe("2.1 GW");
+    });
+  });
+
+  describe("empty / invalid -> em dash", () => {
+    it("returns dash for undefined", () => {
+      expect(formatPower(undefined)).toBe("—");
+    });
+
+    it("returns dash for null", () => {
+      expect(formatPower(null)).toBe("—");
+    });
+
+    it("returns dash for NaN", () => {
+      expect(formatPower(NaN)).toBe("—");
+    });
+
+    it("returns dash for zero", () => {
+      expect(formatPower(0)).toBe("—");
+    });
+
+    it("returns dash for negatives", () => {
+      expect(formatPower(-500)).toBe("—");
+    });
+
+    it("returns dash for non-finite", () => {
+      expect(formatPower(Infinity)).toBe("—");
+    });
+  });
+
+  describe("rounding of plain watts", () => {
+    it("rounds fractional watts", () => {
+      expect(formatPower(949.6)).toBe("950 W");
+    });
+
+    it("keeps small whole watts", () => {
+      expect(formatPower(1)).toBe("1 W");
+    });
+  });
+
+  describe("W / kW boundary", () => {
+    it("stays in W just below 1000", () => {
+      expect(formatPower(999)).toBe("999 W");
+    });
+
+    it("crosses to kW at exactly 1000 (trailing .0 stripped)", () => {
+      expect(formatPower(1000)).toBe("1 kW");
+    });
+  });
+
+  describe("kW one-decimal vs integer boundary (100 kW)", () => {
+    it("uses one decimal below 100 kW", () => {
+      expect(formatPower(99_900)).toBe("99.9 kW");
+    });
+
+    it("uses an integer at exactly 100 kW", () => {
+      expect(formatPower(100_000)).toBe("100 kW");
+    });
+
+    it("uses an integer for large kW values just under 1 MW", () => {
+      expect(formatPower(999_999)).toBe("1000 kW");
+    });
+  });
+
+  describe("kW / MW boundary", () => {
+    it("crosses to MW at exactly 1e6 (trailing .0 stripped)", () => {
+      expect(formatPower(1_000_000)).toBe("1 MW");
+    });
+
+    it("uses one decimal below 100 MW", () => {
+      expect(formatPower(45_000_000)).toBe("45 MW");
+    });
+
+    it("uses one decimal for a fractional MW below 100", () => {
+      expect(formatPower(45_500_000)).toBe("45.5 MW");
+    });
+
+    it("uses an integer at/above 100 MW", () => {
+      expect(formatPower(150_000_000)).toBe("150 MW");
+    });
+  });
+
+  describe("MW / GW boundary", () => {
+    it("crosses to GW at exactly 1e9 (trailing .0 stripped)", () => {
+      expect(formatPower(1_000_000_000)).toBe("1 GW");
+    });
+
+    it("uses one decimal below 100 GW", () => {
+      expect(formatPower(2_500_000_000)).toBe("2.5 GW");
+    });
+
+    it("uses an integer at/above 100 GW", () => {
+      expect(formatPower(120_000_000_000)).toBe("120 GW");
+    });
+  });
+});

--- a/console-ui/src/lib/format-power.ts
+++ b/console-ui/src/lib/format-power.ts
@@ -1,0 +1,37 @@
+// Auto-scales a wattage to W / kW / MW / GW with sensible precision.
+// 950 -> "950 W"; 20855 -> "20.9 kW"; 187000 -> "187 kW"; 1.4e6 -> "1.4 MW"; 2.1e9 -> "2.1 GW"
+//
+// Pure (no React). Rules:
+//   undefined / null / NaN / <= 0 -> "—"
+//   < 1000 W      -> "{Math.round} W"
+//   < 1e6         -> kW (one decimal if < 100 kW, else integer)
+//   < 1e9         -> MW (one decimal if < 100, else integer)
+//   else          -> GW (one decimal if < 100, else integer)
+// Trailing ".0" is stripped.
+
+function trimZero(value: string): string {
+  return value.endsWith(".0") ? value.slice(0, -2) : value;
+}
+
+function scale(value: number, unit: string): string {
+  // One decimal under 100 of the unit, integer at/above 100.
+  const formatted = value < 100 ? value.toFixed(1) : Math.round(value).toString();
+  return `${trimZero(formatted)} ${unit}`;
+}
+
+export function formatPower(watts: number | undefined | null): string {
+  if (watts === undefined || watts === null || !Number.isFinite(watts) || watts <= 0) {
+    return "—";
+  }
+
+  if (watts < 1_000) {
+    return `${Math.round(watts)} W`;
+  }
+  if (watts < 1_000_000) {
+    return scale(watts / 1_000, "kW");
+  }
+  if (watts < 1_000_000_000) {
+    return scale(watts / 1_000_000, "MW");
+  }
+  return scale(watts / 1_000_000_000, "GW");
+}

--- a/console-ui/src/lib/network-power.test.ts
+++ b/console-ui/src/lib/network-power.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { estimateMachineWatts, activeNetworkPowerWatts } from "./network-power";
+
+describe("estimateMachineWatts", () => {
+  it("resolves table entries by family + tier", () => {
+    expect(estimateMachineWatts("M1", "Max", 32)).toBe(115);
+    expect(estimateMachineWatts("M4", "Pro", 20)).toBe(100);
+    expect(estimateMachineWatts("M2", "Ultra", 60)).toBe(280);
+    expect(estimateMachineWatts("M4", "Base", 10)).toBe(65);
+    expect(estimateMachineWatts("M5", "Max", 40)).toBe(180);
+  });
+
+  it("is case-insensitive on tier and family", () => {
+    expect(estimateMachineWatts("m1", "max", 32)).toBe(115);
+    expect(estimateMachineWatts("M1", "MAX", 32)).toBe(115);
+  });
+
+  it("treats empty/unknown tier as Base", () => {
+    expect(estimateMachineWatts("M4", "", 10)).toBe(65);
+    expect(estimateMachineWatts("M4", undefined, 10)).toBe(65);
+    expect(estimateMachineWatts("M4", "weird", 10)).toBe(65);
+  });
+
+  it("falls back to a gpu-core estimate for unknown families", () => {
+    expect(estimateMachineWatts("Intel", "", 0)).toBe(30); // floor
+    expect(estimateMachineWatts("", "", 10)).toBe(65); // 30 + 3.5*10
+    expect(estimateMachineWatts("M9", "Max", 20)).toBe(100); // 30 + 3.5*20
+  });
+});
+
+describe("activeNetworkPowerWatts", () => {
+  it("prefers the coordinator-provided field when present", () => {
+    expect(
+      activeNetworkPowerWatts({ active_power_watts: 20855, providers: [] }),
+    ).toBe(20855);
+  });
+
+  it("sums per-provider estimates when the field is absent", () => {
+    const watts = activeNetworkPowerWatts({
+      providers: [
+        { chip_family: "M1", chip_tier: "Max", gpu_cores: 32 }, // 115
+        { chip_family: "M4", chip_tier: "Pro", gpu_cores: 20 }, // 100
+      ],
+    });
+    expect(watts).toBe(215);
+  });
+
+  it("returns 0 with no field and no providers", () => {
+    expect(activeNetworkPowerWatts({})).toBe(0);
+    expect(activeNetworkPowerWatts({ active_power_watts: 0, providers: [] })).toBe(0);
+  });
+});

--- a/console-ui/src/lib/network-power.ts
+++ b/console-ui/src/lib/network-power.ts
@@ -1,0 +1,71 @@
+// Client-side network-power estimate.
+//
+// Mirrors the coordinator's registry.EstimateMachineWatts so the stats page can
+// show a realistic "Network Power" figure derived from the provider hardware
+// already present in /v1/stats — without waiting for the coordinator to expose a
+// precomputed `active_power_watts` field. When that field IS present (newer
+// coordinator), it is preferred verbatim.
+//
+// Figures are realistic Apple Silicon max sustained wall draw under compute
+// (inference) load, grounded in Apple's power-consumption docs + independent
+// measured max-load numbers — NOT the higher PSU-capacity rating.
+
+const POWER_TABLE: Record<string, Record<string, number>> = {
+  M1: { Base: 40, Pro: 60, Max: 115, Ultra: 215 },
+  M2: { Base: 50, Pro: 75, Max: 140, Ultra: 280 },
+  M3: { Base: 50, Pro: 75, Max: 150, Ultra: 290 },
+  M4: { Base: 65, Pro: 100, Max: 170, Ultra: 300 },
+  M5: { Base: 70, Pro: 105, Max: 180, Ultra: 310 },
+};
+
+function normalizeTier(tier?: string): "Base" | "Pro" | "Max" | "Ultra" {
+  switch ((tier ?? "").trim().toLowerCase()) {
+    case "ultra":
+      return "Ultra";
+    case "max":
+      return "Max";
+    case "pro":
+      return "Pro";
+    default:
+      return "Base";
+  }
+}
+
+// estimateMachineWatts returns the realistic max-load wall draw (watts) for one
+// machine. Falls back to a GPU-core estimate for unknown/empty chip families.
+export function estimateMachineWatts(
+  chipFamily?: string,
+  chipTier?: string,
+  gpuCores?: number,
+): number {
+  const family = (chipFamily ?? "").trim().toUpperCase();
+  const tier = POWER_TABLE[family];
+  if (tier) return tier[normalizeTier(chipTier)];
+  const cores = gpuCores ?? 0;
+  if (cores <= 0) return 30;
+  return Math.max(30, 30 + 3.5 * cores);
+}
+
+interface PowerProvider {
+  chip_family?: string;
+  chip_tier?: string;
+  gpu_cores?: number;
+}
+
+interface PowerStats {
+  active_power_watts?: number;
+  providers?: PowerProvider[];
+}
+
+// activeNetworkPowerWatts returns the coordinator-provided active power if
+// present, otherwise sums per-provider estimates over the online providers.
+// Returns 0 when neither is available (caller hides the tile).
+export function activeNetworkPowerWatts(stats: PowerStats): number {
+  if (typeof stats.active_power_watts === "number" && stats.active_power_watts > 0) {
+    return stats.active_power_watts;
+  }
+  return (stats.providers ?? []).reduce(
+    (sum, p) => sum + estimateMachineWatts(p.chip_family, p.chip_tier, p.gpu_cores),
+    0,
+  );
+}

--- a/coordinator/api/server.go
+++ b/coordinator/api/server.go
@@ -2186,6 +2186,7 @@ func (s *Server) rateLimitWithTier(getLimiter func() *ratelimit.Limiter, tier st
 var publicCORSPaths = map[string]bool{
 	"/v1/models/catalog": true,
 	"/v1/pricing":        true,
+	"/v1/stats":          true,
 }
 
 // corsMiddleware sets CORS headers. Authenticated/credentialed requests are

--- a/coordinator/api/stats.go
+++ b/coordinator/api/stats.go
@@ -99,15 +99,17 @@ func (s *Server) handleStats(w http.ResponseWriter, r *http.Request) {
 		totalBandwidthGB float64
 		providers        []map[string]any
 		modelMap         = map[string]int{} // model ID → provider count
+		activePowerWatts float64            // sum of estimated watts over online public providers
 	)
 
 	s.registry.ForEachProvider(func(p *registry.Provider) {
 		// Private-only providers serve only their owner's self-route traffic and
 		// are not part of the public fleet, so they must not inflate public
-		// totals, provider counts, or per-model provider counts.
+		// totals, provider counts, per-model provider counts, or active power.
 		if p.PrivateOnly {
 			return
 		}
+		activePowerWatts += registry.EstimateMachineWatts(p.Hardware.ChipFamily, p.Hardware.ChipTier, p.Hardware.GPUCores)
 		totalRequests += p.Stats.RequestsServed
 		totalTokensGen += p.Stats.TokensGenerated
 		totalGPUCores += p.Hardware.GPUCores
@@ -235,6 +237,7 @@ func (s *Server) handleStats(w http.ResponseWriter, r *http.Request) {
 		"total_tokens":              totalTokens,
 		"avg_tokens_per_request":    avgTokens,
 		"active_providers":          len(providers),
+		"active_power_watts":        activePowerWatts,
 		"code_attested_providers":   codeAttestedProviders,
 		"code_attestation_enforced": codeAttestationEnforced,
 		"total_gpu_cores":           totalGPUCores,

--- a/coordinator/api/stats_power_test.go
+++ b/coordinator/api/stats_power_test.go
@@ -1,0 +1,111 @@
+package api
+
+import (
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+	"github.com/eigeninference/d-inference/coordinator/registry"
+	"github.com/eigeninference/d-inference/coordinator/store"
+)
+
+// registerOnlineProviderWithHardware registers a live provider with the given
+// hardware and promotes it to attested hardware trust so it renders as online
+// in handleStats.
+func registerOnlineProviderWithHardware(t *testing.T, reg *registry.Registry, id string, hw protocol.Hardware) {
+	t.Helper()
+	p := reg.Register(id, nil, &protocol.RegisterMessage{
+		Hardware: hw,
+		Models:   []protocol.ModelInfo{{ID: "gemma-4-26b"}},
+	})
+	p.Mu().Lock()
+	p.TrustLevel = registry.TrustHardware
+	p.Attested = true
+	p.Mu().Unlock()
+}
+
+// TestStatsActiveNetworkPower verifies that /v1/stats reports active_power_watts
+// as the sum of EstimateMachineWatts over the online (non-private) providers.
+func TestStatsActiveNetworkPower(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	reg := registry.New(logger)
+	st := store.NewMemory(store.Config{})
+	srv := NewServer(reg, st, ServerConfig{}, logger)
+
+	m1Max := protocol.Hardware{ChipName: "Apple M1 Max", ChipFamily: "M1", ChipTier: "Max", GPUCores: 32, MemoryGB: 64}
+	m4Pro := protocol.Hardware{ChipName: "Apple M4 Pro", ChipFamily: "M4", ChipTier: "Pro", GPUCores: 20, MemoryGB: 48}
+
+	registerOnlineProviderWithHardware(t, reg, "online-m1max", m1Max)
+	registerOnlineProviderWithHardware(t, reg, "online-m4pro", m4Pro)
+	wantWatts := registry.EstimateMachineWatts(m1Max.ChipFamily, m1Max.ChipTier, m1Max.GPUCores) +
+		registry.EstimateMachineWatts(m4Pro.ChipFamily, m4Pro.ChipTier, m4Pro.GPUCores)
+
+	rr := httptest.NewRecorder()
+	srv.handleStats(rr, httptest.NewRequest(http.MethodGet, "/v1/stats", nil))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+
+	var body struct {
+		ActiveProviders  int     `json:"active_providers"`
+		ActivePowerWatts float64 `json:"active_power_watts"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+
+	if body.ActiveProviders != 2 {
+		t.Fatalf("active_providers = %d, want 2", body.ActiveProviders)
+	}
+	if body.ActivePowerWatts != wantWatts {
+		t.Fatalf("active_power_watts = %v, want %v", body.ActivePowerWatts, wantWatts)
+	}
+}
+
+// TestStatsActivePowerExcludesPrivate verifies private-only providers are left
+// out of active_power_watts (they are not part of the public fleet).
+func TestStatsActivePowerExcludesPrivate(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	reg := registry.New(logger)
+	st := store.NewMemory(store.Config{})
+	srv := NewServer(reg, st, ServerConfig{}, logger)
+
+	m4Pro := protocol.Hardware{ChipName: "Apple M4 Pro", ChipFamily: "M4", ChipTier: "Pro", GPUCores: 20, MemoryGB: 48}
+
+	registerOnlineProviderWithHardware(t, reg, "pub-1", m4Pro)
+	priv := reg.Register("priv-1", nil, &protocol.RegisterMessage{
+		Hardware: m4Pro,
+		Models:   []protocol.ModelInfo{{ID: "gemma-4-26b"}},
+	})
+	priv.Mu().Lock()
+	priv.TrustLevel = registry.TrustHardware
+	priv.Attested = true
+	priv.PrivateOnly = true
+	priv.Mu().Unlock()
+
+	rr := httptest.NewRecorder()
+	srv.handleStats(rr, httptest.NewRequest(http.MethodGet, "/v1/stats", nil))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+
+	var body struct {
+		ActiveProviders  int     `json:"active_providers"`
+		ActivePowerWatts float64 `json:"active_power_watts"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+
+	oneBox := registry.EstimateMachineWatts(m4Pro.ChipFamily, m4Pro.ChipTier, m4Pro.GPUCores)
+	if body.ActiveProviders != 1 {
+		t.Fatalf("active_providers = %d, want 1 (private excluded)", body.ActiveProviders)
+	}
+	if body.ActivePowerWatts != oneBox {
+		t.Fatalf("active_power_watts = %v, want %v (private excluded)", body.ActivePowerWatts, oneBox)
+	}
+}

--- a/coordinator/registry/power.go
+++ b/coordinator/registry/power.go
@@ -1,0 +1,62 @@
+package registry
+
+import "strings"
+
+// machineWatts maps a normalized (chip family, tier) pair to a realistic
+// maximum sustained wall-socket power draw under a compute-intensive
+// (inference) load, in watts.
+//
+// The outer key is the uppercased family (M1..M5); the inner key is the
+// title-cased tier (Base/Pro/Max/Ultra). Figures are grounded in Apple's
+// published power-consumption support docs (Mac Studio: support.apple.com/
+// en-us/102027, Mac mini: support.apple.com/en-us/103253) and independent
+// measured "max load" numbers (Notebookcheck/MacRumors) — NOT the PSU-capacity
+// "maximum continuous power" rating, which is much higher than real draw.
+var machineWatts = map[string]map[string]float64{
+	"M1": {"Base": 40, "Pro": 60, "Max": 115, "Ultra": 215},
+	"M2": {"Base": 50, "Pro": 75, "Max": 140, "Ultra": 280},
+	"M3": {"Base": 50, "Pro": 75, "Max": 150, "Ultra": 290},
+	"M4": {"Base": 65, "Pro": 100, "Max": 170, "Ultra": 300},
+	"M5": {"Base": 70, "Pro": 105, "Max": 180, "Ultra": 310},
+}
+
+// EstimateMachineWatts returns a realistic estimate of an Apple Silicon Mac's
+// maximum sustained wall-socket power draw under a compute-intensive (inference)
+// load, in watts. Figures are grounded in Apple's published power-consumption
+// support docs (Mac Studio: support.apple.com/en-us/102027, Mac mini:
+// support.apple.com/en-us/103253) and independent measured "max load" numbers
+// (Notebookcheck/MacRumors), NOT the PSU-capacity "maximum continuous power"
+// rating which is much higher. Used for the network-power figure on the public
+// stats page and landing page.
+func EstimateMachineWatts(chipFamily, chipTier string, gpuCores int) float64 {
+	family := strings.ToUpper(strings.TrimSpace(chipFamily))
+	tier := normalizeTier(chipTier)
+
+	if tiers, ok := machineWatts[family]; ok {
+		if w, ok := tiers[tier]; ok {
+			return w
+		}
+	}
+
+	// Fallback for unknown/older/Intel families or empty family: a GPU-core
+	// linear model with a 30W floor.
+	if gpuCores <= 0 {
+		return 30
+	}
+	return 30 + 3.5*float64(gpuCores)
+}
+
+// normalizeTier maps a raw tier string to one of Base/Pro/Max/Ultra. Empty,
+// "base", and any unrecognized value all normalize to Base.
+func normalizeTier(chipTier string) string {
+	switch strings.ToLower(strings.TrimSpace(chipTier)) {
+	case "pro":
+		return "Pro"
+	case "max":
+		return "Max"
+	case "ultra":
+		return "Ultra"
+	default:
+		return "Base"
+	}
+}

--- a/coordinator/registry/power_test.go
+++ b/coordinator/registry/power_test.go
@@ -1,0 +1,55 @@
+package registry
+
+import "testing"
+
+func TestEstimateMachineWatts(t *testing.T) {
+	tests := []struct {
+		name       string
+		chipFamily string
+		chipTier   string
+		gpuCores   int
+		want       float64
+	}{
+		// Table hits across families/tiers.
+		{"M1 Base", "M1", "Base", 8, 40},
+		{"M1 Max", "M1", "Max", 32, 115},
+		{"M1 Ultra", "M1", "Ultra", 48, 215},
+		{"M2 Ultra", "M2", "Ultra", 60, 280},
+		{"M3 Max", "M3", "Max", 40, 150},
+		{"M4 Base", "M4", "Base", 10, 65},
+		{"M4 Pro", "M4", "Pro", 20, 100},
+		{"M4 Max", "M4", "Max", 40, 170},
+		{"M5 Ultra", "M5", "Ultra", 80, 310},
+
+		// Case-insensitivity on family and tier.
+		{"lowercase family + tier", "m4", "max", 40, 170},
+		{"MAX tier upper", "M1", "MAX", 32, 115},
+		{"Max tier title", "M1", "Max", 32, 115},
+		{"mixed family", "m2", "PrO", 19, 75},
+
+		// Empty / whitespace tier normalizes to Base.
+		{"empty tier -> Base", "M4", "", 10, 65},
+		{"whitespace tier -> Base", "M4", "   ", 10, 65},
+		{"unknown tier -> Base", "M4", "Extreme", 10, 65},
+
+		// Unknown family falls back to the GPU-core model.
+		{"unknown family with gpu cores", "Intel", "", 16, 30 + 3.5*16},
+		{"empty family with gpu cores", "", "Max", 24, 30 + 3.5*24},
+		{"M6 future family", "M6", "Max", 50, 30 + 3.5*50},
+
+		// gpuCores <= 0 in fallback returns the 30W floor.
+		{"fallback zero gpu cores", "Intel", "", 0, 30},
+		{"fallback negative gpu cores", "unknown", "", -5, 30},
+		{"empty family no gpu cores", "", "", 0, 30},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := EstimateMachineWatts(tc.chipFamily, tc.chipTier, tc.gpuCores)
+			if got != tc.want {
+				t.Fatalf("EstimateMachineWatts(%q, %q, %d) = %v, want %v",
+					tc.chipFamily, tc.chipTier, tc.gpuCores, got, tc.want)
+			}
+		})
+	}
+}

--- a/landing/index.html
+++ b/landing/index.html
@@ -140,28 +140,11 @@
       });
     }
 
-    function showConsentBanner(){
-      if (getConsent() !== 'unset' || document.getElementById('analytics-consent')) return;
-      const banner = document.createElement('div');
-      banner.id = 'analytics-consent';
-      banner.setAttribute('role', 'dialog');
-      banner.setAttribute('aria-label', 'Analytics consent');
-      banner.style.cssText = 'position:fixed;left:16px;right:16px;bottom:16px;z-index:9999;max-width:620px;margin:0 auto;padding:16px;border:1px solid var(--grey-01);border-radius:var(--radius-sm);background:rgba(255,255,255,.96);box-shadow:0 16px 60px rgba(0,0,0,.16);font-family:var(--font-sans);color:var(--black);';
-      banner.innerHTML = '<p style="margin:0 0 12px;font-size:14px;line-height:1.45;color:var(--grey-03);">Allow privacy-filtered usage analytics to help improve Darkbloom. Page URLs are sanitized before events are sent.</p><div style="display:flex;flex-wrap:wrap;gap:8px;align-items:center;"><button id="analytics-allow" type="button" style="border:1px solid var(--black);background:var(--black);color:var(--white);border-radius:4px;padding:9px 14px;font-family:var(--font-mono);font-size:12px;cursor:pointer;">Allow analytics</button><button id="analytics-decline" type="button" style="border:1px solid var(--grey-01);background:var(--white);color:var(--grey-03);border-radius:4px;padding:9px 14px;font-family:var(--font-mono);font-size:12px;cursor:pointer;">Decline</button><a href="privacy.html" target="_blank" style="font-size:12px;color:var(--grey-03);">Privacy</a></div>';
-      document.body.appendChild(banner);
-      document.getElementById('analytics-allow').onclick = function(){
-        setConsent('granted');
-        banner.remove();
-        initAnalytics();
-      };
-      document.getElementById('analytics-decline').onclick = function(){
-        setConsent('denied');
-        banner.remove();
-      };
-    }
-
+    // Analytics is auto-allowed by default (privacy-filtered: page URLs are
+    // sanitized and no PII is sent). No consent prompt is shown; a visitor's
+    // prior explicit "denied" choice is still respected.
+    if (getConsent() === 'unset') setConsent('granted');
     initAnalytics();
-    document.addEventListener('DOMContentLoaded', showConsentBanner);
   })();
   </script>
 
@@ -346,7 +329,7 @@
 
     /* ==================== HERO ==================== */
     .hero {
-      padding: 180px 0 100px;
+      padding: 180px 0 40px;
     }
 
     .hero h1 {
@@ -558,6 +541,50 @@
       color: var(--grey-03);
       margin-top: 8px;
       letter-spacing: 0.02em;
+    }
+
+    /* ==================== LIVE NETWORK STRIP ==================== */
+    /* Live-network strip sits flush under the hero — trim the default
+       section padding so it isn't floating in whitespace. */
+    #network { padding: 8px 0 48px; }
+
+    .netstat-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+      gap: 1px;
+      background: var(--grey-01);
+      border-radius: var(--radius-lg);
+      overflow: hidden;
+      margin-top: 0;
+    }
+
+    .netstat-cell {
+      background: var(--white);
+      padding: 28px 24px;
+    }
+
+    .netstat-num {
+      font-size: clamp(28px, 3.4vw, 40px);
+      font-weight: 700;
+      letter-spacing: -0.03em;
+      line-height: 1;
+      color: var(--eigen-blue);
+    }
+
+    .netstat-label {
+      font-size: 13px;
+      font-weight: 400;
+      color: var(--grey-03);
+      margin-top: 8px;
+      letter-spacing: 0.02em;
+    }
+
+    .netstat-sub {
+      font-family: var(--font-mono);
+      font-size: 11px;
+      color: var(--grey-02);
+      margin-top: 4px;
+      letter-spacing: 0.01em;
     }
 
     /* ==================== HERO BLOCK (eigen blue bg, like brand book showcase) ==================== */
@@ -1107,6 +1134,34 @@
     </div>
   </section>
 
+  <!-- ============ LIVE NETWORK (flush under hero) ============ -->
+  <!-- Live figures sourced from the coordinator's public /v1/stats endpoint.
+       The Network power tile is hidden when neither active_power_watts nor a
+       providers[] array is available. See network-stats.js. -->
+  <section id="network" data-section="live-network">
+    <div class="container">
+      <div class="netstat-grid rv" aria-live="polite">
+        <div class="netstat-cell">
+          <div class="netstat-num" id="ns-nodes">—</div>
+          <div class="netstat-label">Nodes online</div>
+        </div>
+        <div class="netstat-cell" id="ns-power-cell" style="display:none;">
+          <div class="netstat-num" id="ns-power">—</div>
+          <div class="netstat-label">Network power</div>
+          <div class="netstat-sub">drawn under load</div>
+        </div>
+        <div class="netstat-cell">
+          <div class="netstat-num" id="ns-tokens">—</div>
+          <div class="netstat-label">Tokens served</div>
+        </div>
+        <div class="netstat-cell">
+          <div class="netstat-num" id="ns-requests">—</div>
+          <div class="netstat-label">Requests</div>
+        </div>
+      </div>
+    </div>
+  </section>
+
   <div class="container"><div class="rule"></div></div>
 
   <!-- ============ WHAT THIS ENABLES ============ -->
@@ -1442,6 +1497,9 @@ response = client.chat.completions.create(
 </footer>
 
 <script src="earn-calculator.js"></script>
+
+<!-- ============ LIVE NETWORK (/v1/stats) ============ -->
+<script src="network-stats.js"></script>
 
 <!-- ============ LIVE MODEL LINEUP + PRICING ============ -->
 <!-- Sources the pricing table from the coordinator's public, registry-backed

--- a/landing/network-stats.js
+++ b/landing/network-stats.js
@@ -1,0 +1,133 @@
+/* Live network strip.
+ *
+ * Reads the coordinator's public /v1/stats endpoint and fills the
+ * "Live network" tiles with real figures. Degrades gracefully:
+ *   - Nodes / tokens / requests always render (these fields are long-lived).
+ *   - The "Network power" tile is derived from the coordinator's
+ *     active_power_watts when present, else summed from the per-provider
+ *     hardware in providers[]; it stays hidden only when neither is available.
+ *
+ * Base URL is overridable for local testing:
+ *   index.html?coord=http://localhost:PORT
+ */
+(function () {
+  "use strict";
+
+  var STATS_API =
+    new URLSearchParams(location.search).get("coord") ||
+    "https://api.darkbloom.dev";
+
+  // ---- Formatting helpers -------------------------------------------------
+
+  function formatNum(n) {
+    if (n >= 1e9) return (n / 1e9).toFixed(1) + "B";
+    if (n >= 1e6) return (n / 1e6).toFixed(1) + "M";
+    if (n >= 1e3) return (n / 1e3).toFixed(1) + "K";
+    return String(n);
+  }
+
+  function formatPower(w) {
+    if (!w || w <= 0) return null;
+    // Strip a trailing ".0" so this matches console-ui's formatPower exactly
+    // (e.g. "1 kW", not "1.0 kW").
+    var trim = function (s) { return s.replace(/\.0$/, ""); };
+    if (w < 1e3) return Math.round(w) + " W";
+    if (w < 1e6) return trim(w < 1e5 ? (w / 1e3).toFixed(1) : String(Math.round(w / 1e3))) + " kW";
+    if (w < 1e9) return trim(w < 1e8 ? (w / 1e6).toFixed(1) : String(Math.round(w / 1e6))) + " MW";
+    return trim((w / 1e9).toFixed(1)) + " GW";
+  }
+
+  // ---- Network power estimate (mirrors coordinator EstimateMachineWatts) ----
+  // Realistic Apple Silicon max sustained wall draw under load, by family/tier.
+  var POWER_TABLE = {
+    M1: { Base: 40, Pro: 60, Max: 115, Ultra: 215 },
+    M2: { Base: 50, Pro: 75, Max: 140, Ultra: 280 },
+    M3: { Base: 50, Pro: 75, Max: 150, Ultra: 290 },
+    M4: { Base: 65, Pro: 100, Max: 170, Ultra: 300 },
+    M5: { Base: 70, Pro: 105, Max: 180, Ultra: 310 },
+  };
+
+  function machineWatts(family, tier, gpuCores) {
+    var fam = (family || "").trim().toUpperCase();
+    var t = (tier || "").trim().toLowerCase();
+    var norm = t === "ultra" ? "Ultra" : t === "max" ? "Max" : t === "pro" ? "Pro" : "Base";
+    if (POWER_TABLE[fam]) return POWER_TABLE[fam][norm];
+    var cores = gpuCores || 0;
+    return cores <= 0 ? 30 : Math.max(30, 30 + 3.5 * cores);
+  }
+
+  // Prefer the coordinator-provided active_power_watts; else sum per-provider
+  // estimates over the online providers already in the response.
+  function activePowerWatts(d) {
+    if (isFiniteNum(d.active_power_watts) && d.active_power_watts > 0) {
+      return d.active_power_watts;
+    }
+    var ps = d.providers || [];
+    var sum = 0;
+    for (var i = 0; i < ps.length; i++) {
+      sum += machineWatts(ps[i].chip_family, ps[i].chip_tier, ps[i].gpu_cores);
+    }
+    return sum;
+  }
+
+  // Exposed for unit checking / debugging.
+  if (typeof window !== "undefined") {
+    window.DarkbloomNetStats = { formatNum: formatNum, formatPower: formatPower };
+  }
+
+  // ---- DOM wiring ---------------------------------------------------------
+
+  function byId(id) {
+    return typeof document !== "undefined" ? document.getElementById(id) : null;
+  }
+
+  function setText(id, value) {
+    var el = byId(id);
+    if (el && value != null) el.textContent = value;
+  }
+
+  function show(id) {
+    var el = byId(id);
+    if (el) el.style.display = "";
+  }
+
+  function isFiniteNum(v) {
+    return typeof v === "number" && isFinite(v);
+  }
+
+  function render(d) {
+    if (!d) return;
+
+    // Always-present fields.
+    if (isFiniteNum(d.active_providers)) {
+      setText("ns-nodes", formatNum(d.active_providers));
+    }
+    if (isFiniteNum(d.total_tokens)) {
+      setText("ns-tokens", formatNum(d.total_tokens));
+    }
+    if (isFiniteNum(d.total_requests)) {
+      setText("ns-requests", formatNum(d.total_requests));
+    }
+
+    // Network power — derived from the coordinator field if present, else from
+    // the per-provider hardware already in the response.
+    var power = formatPower(activePowerWatts(d));
+    if (power) {
+      setText("ns-power", power);
+      show("ns-power-cell");
+    }
+  }
+
+  if (typeof window !== "undefined" && window.fetch) {
+    fetch(STATS_API + "/v1/stats", { headers: { Accept: "application/json" } })
+      .then(function (r) {
+        return r.ok ? r.json() : null;
+      })
+      .then(function (d) {
+        render(d);
+      })
+      .catch(function () {
+        /* offline / API down — leave the "—" placeholders in place */
+      });
+  }
+})();


### PR DESCRIPTION
## What

Adds a realistic, live **Network Power** figure to the console stats page and a **live network strip** to the marketing landing page — both driven by the coordinator's public `/v1/stats`.

The number is the estimated **max sustained Apple-Silicon wall draw under inference load**, summed across the online fleet. It auto-scales (W → kW → MW → GW), so it reads honestly today (~20 kW across ~130 nodes) and grows with the fleet — not an inflated vanity figure.

## Why

We now have a real fleet worth showing off. The original ask was a power stat + machine counts; through review we settled on a single, realistic **Network Power** tile.

## How it works

- **Power model** — per-machine watts by chip family/tier (M1–M5 × Base/Pro/Max/Ultra), grounded in Apple's published power-consumption docs + independent measured max-load numbers (e.g. M1 Max ≈ 115 W, M2 Ultra ≈ 280 W, M4 Max ≈ 170 W), **not** the higher PSU-capacity rating. MacBooks included.
- **Two sources, one model** — mirrored coordinator-side (`registry.EstimateMachineWatts` → new `active_power_watts` field) and client-side (`console-ui/src/lib/network-power.ts`, `landing/network-stats.js`). The UIs **compute it from the live `providers[]` already in `/v1/stats`**, and prefer the coordinator's `active_power_watts` once that's deployed. This is the same mirror-across-layers pattern the telemetry types already use.
- **console-ui** — a compact `Network Power` tile in the stats capacity grid (next to GPU Cores / RAM), formatted via `lib/format-power.ts`.
- **landing** — a live strip (Nodes online · Network power · Tokens served · Requests), flush under the hero. Analytics is auto-allowed (no consent prompt; a visitor's prior explicit opt-out is still honored).
- **coordinator** — `/v1/stats` added to the public-CORS allowlist so the marketing site can read it directly from the browser (same treatment as `/v1/models/catalog` and `/v1/pricing`).

## Renders before and after deploy

- **Today (no coordinator deploy):** the stats page works immediately (server-side proxy, computes power client-side). The landing strip needs the CORS change deployed to read `/v1/stats` cross-origin — until then it degrades gracefully (tiles hidden).
- **After the coordinator ships:** both surfaces read `active_power_watts` + the public-CORS `/v1/stats` directly.

> Coordinator deploy is human-only (EigenCloud). This PR is ready; no deploy is performed here.

## Tests

- `coordinator/registry/power_test.go` — power table (families/tiers, case-insensitivity, fallback).
- `coordinator/api/stats_power_test.go` — `active_power_watts` sum + private-only exclusion (real `httptest` path).
- `console-ui` vitest — `format-power.test.ts`, `network-power.test.ts` (32 cases).
- Verified: `go build ./...`, `go vet`, `go test ./registry ./api`, `npm run build` (✓ compiled), `eslint` (0 errors), landing `node --check`.

## Notes

- No UI for offline/“machines ready” — dropped per design feedback; the response exposes only `active_power_watts`.
- A local-only demo seed used during development was removed before this PR.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/350"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784097599&installation_id=133247490&pr_number=350&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F350&signature=296d1a1a6659e60e9d8bb61a751b7867d7838d1aa4ff5fb87197cf63e8010f0b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->