### PR TITLE
fix(coordinator): strip VLM-crashing penalties for pre-0.6.7 providers

### DIFF
--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -475,7 +475,10 @@ func (s *Server) dispatchOneProvider(
 		return nil, nil, decision, "failed to generate session keys", http.StatusInternalServerError
 	}
 
-	encrypted, err := e2e.Encrypt(rawBody, providerPubKey, sessionKeys)
+	// Pre-fix providers crash on a vision request carrying sampling penalties;
+	// strip them for those providers only (see bodyForProvider).
+	sealedBody := bodyForProvider(rawBody, requiresVision, provider)
+	encrypted, err := e2e.Encrypt(sealedBody, providerPubKey, sessionKeys)
 	if err != nil {
 		refundExtra()
 		cleanupPending()
@@ -872,6 +875,48 @@ func stripProviderRoutingFields(parsed map[string]any) bool {
 		}
 	}
 	return changed
+}
+
+// penaltySafeProviderVersion is the first provider release whose VLM penalty
+// path handles repetition/presence/frequency penalties without crashing (the
+// TokenRing 2D-prompt fix). Providers below it crash on a vision request that
+// carries any of these fields, so the coordinator strips them before sealing
+// for such a provider. Keep in sync with the release that ships the fix.
+const penaltySafeProviderVersion = "0.6.7"
+
+// visionPenaltyFields crash the pre-fix VLM penalty path on image requests.
+var visionPenaltyFields = []string{"repetition_penalty", "presence_penalty", "frequency_penalty"}
+
+// bodyForProvider returns the request body to seal for `provider`. It equals
+// rawBody, except a vision request routed to a pre-fix provider has the
+// crash-inducing penalty fields stripped. Fixed providers receive the penalties
+// unchanged. Per-provider (not pre-routing) so a retry on a fixed provider keeps
+// them. Remove once MIN_PROVIDER_VERSION clears all pre-fix builds.
+func bodyForProvider(rawBody []byte, requiresVision bool, provider *registry.Provider) []byte {
+	if !requiresVision {
+		return rawBody
+	}
+	if provider.Version != "" && !semverLess(provider.Version, penaltySafeProviderVersion) {
+		return rawBody // fixed provider — pass penalties through
+	}
+	var parsed map[string]any
+	if json.Unmarshal(rawBody, &parsed) != nil {
+		return rawBody
+	}
+	changed := false
+	for _, key := range visionPenaltyFields {
+		if _, ok := parsed[key]; ok {
+			delete(parsed, key)
+			changed = true
+		}
+	}
+	if !changed {
+		return rawBody
+	}
+	if stripped, err := marshalForwardBody(parsed); err == nil {
+		return stripped
+	}
+	return rawBody
 }
 
 // defaultMaxOutputTokens is the ceiling injected into requests that don't set
@@ -4300,6 +4345,9 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 		return
 	}
 
+	// Version-gated penalty strip for vision requests (Anthropic /v1/messages
+	// carries image blocks); this handler seals separately from dispatchOneProvider.
+	inferenceBody = bodyForProvider(inferenceBody, requiresVision, provider)
 	encrypted, err := e2e.Encrypt(inferenceBody, providerPubKey, sessionKeys)
 	if err != nil {
 		cleanupPending()

--- a/coordinator/api/consumer_test.go
+++ b/coordinator/api/consumer_test.go
@@ -1666,6 +1666,63 @@ func TestDetectMediaRequirementAnthropicImageBlock(t *testing.T) {
 	}
 }
 
+// TestBodyForProviderPenaltyGating verifies the coordinator strips the penalty
+// fields that crash the pre-fix VLM path, but ONLY for vision requests routed to
+// a provider below penaltySafeProviderVersion. Fixed providers and text requests
+// keep their penalties. See bodyForProvider.
+func TestBodyForProviderPenaltyGating(t *testing.T) {
+	visionBody := []byte(`{"model":"gemma-4-26b","temperature":1.0,"repetition_penalty":1.0,` +
+		`"presence_penalty":0.0,"frequency_penalty":0.0,"messages":[{"role":"user","content":[` +
+		`{"type":"text","text":"what is this?"},` +
+		`{"type":"image_url","image_url":{"url":"data:image/png;base64,AAAA"}}]}]}`)
+	textBody := []byte(`{"model":"gemma-4-26b","repetition_penalty":1.3,` +
+		`"messages":[{"role":"user","content":"hello"}]}`)
+
+	has := func(body []byte, key string) bool {
+		var m map[string]any
+		if err := json.Unmarshal(body, &m); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		_, ok := m[key]
+		return ok
+	}
+	penalties := []string{"repetition_penalty", "presence_penalty", "frequency_penalty"}
+
+	// Vision + pre-fix provider → penalties stripped, other fields kept.
+	out := bodyForProvider(visionBody, true, &registry.Provider{Version: "0.6.6"})
+	for _, k := range penalties {
+		if has(out, k) {
+			t.Fatalf("pre-fix vision provider: expected %q stripped", k)
+		}
+	}
+	if !has(out, "temperature") || !has(out, "messages") {
+		t.Fatal("pre-fix vision provider: non-penalty fields must be preserved")
+	}
+
+	// Vision + provider with unknown version → stripped (conservative).
+	if has(bodyForProvider(visionBody, true, &registry.Provider{Version: ""}), "repetition_penalty") {
+		t.Fatal("unknown-version vision provider: expected penalties stripped")
+	}
+
+	// Vision + fixed provider (== and > floor) → penalties preserved.
+	for _, v := range []string{"0.6.7", "0.7.0"} {
+		if !has(bodyForProvider(visionBody, true, &registry.Provider{Version: v}), "repetition_penalty") {
+			t.Fatalf("fixed provider %s: penalties must pass through", v)
+		}
+	}
+
+	// Text request (any provider) → penalties preserved.
+	if !has(bodyForProvider(textBody, false, &registry.Provider{Version: "0.6.6"}), "repetition_penalty") {
+		t.Fatal("text request: penalties must pass through")
+	}
+
+	// Vision + pre-fix provider but no penalty fields → returns rawBody unchanged.
+	clean := []byte(`{"model":"gemma-4-26b","messages":[{"role":"user","content":[{"type":"image_url","image_url":{"url":"data:image/png;base64,AAAA"}}]}]}`)
+	if out := bodyForProvider(clean, true, &registry.Provider{Version: "0.6.6"}); string(out) != string(clean) {
+		t.Fatal("no-penalty vision body should be returned unchanged")
+	}
+}
+
 // TestUsageChunkParseAndFinalize covers the parse-once + finalize helpers.
 func TestUsageChunkParseAndFinalize(t *testing.T) {
 	usageChunk := `data: {"object":"chat.completion.chunk","model":"gpt-oss-20b","choices":[],"usage":{"prompt_tokens":10,"completion_tokens":50,"total_tokens":60}}`

--- a/coordinator/api/dispatch.go
+++ b/coordinator/api/dispatch.go
@@ -355,7 +355,10 @@ func (d *dispatchState) dispatchPrimary() dispatchOutcome {
 			d.lastErr = "failed to generate session keys"
 			return outcomeRetry
 		}
-		encrypted, err := e2e.Encrypt(d.rawBody, providerPubKey, sessionKeys)
+		// Version-gated penalty strip (see bodyForProvider). The queued path seals
+		// here, separately from dispatchOneProvider.
+		sealedBody := bodyForProvider(d.rawBody, d.requiresVision, d.provider)
+		encrypted, err := e2e.Encrypt(sealedBody, providerPubKey, sessionKeys)
 		if err != nil {
 			d.provider.RemovePending(d.requestID)
 			s.registry.SetProviderIdle(d.provider.ID)


### PR DESCRIPTION
## Problem

A vision (image) request to a VLM (e.g. `gemma-4-26b`) carrying `repetition_penalty` — including the no-op value `1.0` that many OpenAI-compatible clients send by default — crashes the provider process, surfacing to consumers as HTTP 502 "provider disconnected". Root cause is provider-side (penalty ring buffer mis-handles the VLM 2-D prompt) and is fixed in mlx-swift-lm (Layr-Labs/mlx-swift-lm#37), shipping in the 0.6.7 provider release.

## This change (coordinator mitigation)

Until the fleet finishes updating to ≥0.6.7, strip the crash-inducing penalty fields (`repetition_penalty`/`presence_penalty`/`frequency_penalty`) from **vision** requests at seal time — but **only when the chosen provider is below `penaltySafeProviderVersion` (0.6.7)**. Fixed providers and all text requests keep their penalties (`bodyForProvider`). A retry that lands on a fixed provider still gets the penalties (the shared body is never mutated).

Wired into all three encryption seal points:
- `dispatchOneProvider` (chat-completions / Responses, incl. speculative backup) — `consumer.go`
- the queued dispatch path — `dispatch.go`
- `handleGenericInference` (Anthropic `/v1/messages`, `/v1/completions`) — `consumer.go`

Mirrors the existing tool-schema normalization rationale (protect lagging providers from the wire). Remove once `MIN_PROVIDER_VERSION` clears all pre-0.6.7 builds.

## Tests

`TestBodyForProviderPenaltyGating` (api): pre-0.6.7 vision → stripped; `==`/`>` floor → preserved; unknown version → stripped (conservative); text → preserved; no-penalty body → unchanged. Full `go test ./...` green.

## Rollout

Coordinator deploy = immediate fleet protection during the 0.6.7 rollout. The provider fix ships separately via the 0.6.7 release (merge #37 → bump submodule pin + provider version → tag).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/351"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784098912&installation_id=133247490&pr_number=351&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F351&signature=df4d450ec7782e12bbdd5b4f3d7d01035b2dac3d560e86350c82bd0e8ceccae2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->