### PR TITLE
feat(provider): apply presence/frequency penalties on VLM (image) requests

### DIFF
--- a/provider-swift/Sources/ProviderCore/Inference/VLMRequestInference.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/VLMRequestInference.swift
@@ -90,6 +90,25 @@ public enum VLMRequestInference {
         return false
     }
 
+    /// Build the engine sampling parameters from an OpenAI request. Forwards all
+    /// sampling penalties — repetition, presence, and frequency — so they take
+    /// effect on image/video (VLM) requests, matching the text/batched engine.
+    /// The penalty processors apply only for non-identity values (repetition ≠ 1,
+    /// presence/frequency ≠ 0); identities are no-ops.
+    static func generateParameters(
+        for request: OpenAIChatCompletionRequest, defaultMaxTokens: Int
+    ) -> GenerateParameters {
+        GenerateParameters(
+            maxTokens: request.maxTokens ?? defaultMaxTokens,
+            temperature: request.temperature ?? 0,
+            topP: request.topP ?? 1.0,
+            topK: request.topK ?? 0,
+            repetitionPenalty: request.repetitionPenalty,
+            presencePenalty: request.presencePenalty,
+            frequencyPenalty: request.frequencyPenalty
+        )
+    }
+
     // MARK: - Streaming
 
     /// Stream a multimodal completion through the container's
@@ -168,13 +187,8 @@ public enum VLMRequestInference {
                     let startedAt = Date()
                     let lmInput = try await container.prepare(input: userInput)
 
-                    let params = GenerateParameters(
-                        maxTokens: request.maxTokens ?? defaultMaxTokens,
-                        temperature: request.temperature ?? 0,
-                        topP: request.topP ?? 1.0,
-                        topK: request.topK ?? 0,
-                        repetitionPenalty: request.repetitionPenalty
-                    )
+                    let params = generateParameters(
+                        for: request, defaultMaxTokens: defaultMaxTokens)
 
                     let genStream = try await container.generate(
                         input: lmInput, parameters: params)

--- a/provider-swift/Sources/vlm-smoke/main.swift
+++ b/provider-swift/Sources/vlm-smoke/main.swift
@@ -81,11 +81,14 @@ struct VLMSmoke {
         let env = ProcessInfo.processInfo.environment
         let temp = Float(env["VLM_TEMP"] ?? "") ?? 0.0
         let repPen: Float? = Float(env["VLM_REPPEN"] ?? "")
+        let presPen: Float? = Float(env["VLM_PRESPEN"] ?? "")
+        let freqPen: Float? = Float(env["VLM_FREQPEN"] ?? "")
         let maxTok = Int(env["VLM_MAXTOK"] ?? "") ?? 220
         let repPenDesc: String = repPen == nil ? "none" : "\(repPen!)"
-        err("[vlm-smoke] sampling: temp=\(temp) repPen=\(repPenDesc) maxTokens=\(maxTok)")
+        err("[vlm-smoke] sampling: temp=\(temp) repPen=\(repPenDesc) presPen=\(presPen.map { "\($0)" } ?? "none") freqPen=\(freqPen.map { "\($0)" } ?? "none") maxTokens=\(maxTok)")
         let params = GenerateParameters(
-            maxTokens: maxTok, temperature: temp, repetitionPenalty: repPen)
+            maxTokens: maxTok, temperature: temp, repetitionPenalty: repPen,
+            presencePenalty: presPen, frequencyPenalty: freqPen)
         let stream = try await container.generate(input: lmInput, parameters: params)
 
         err("---OUTPUT-START---")

--- a/provider-swift/Tests/ProviderCoreTests/VLMRequestInferenceTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/VLMRequestInferenceTests.swift
@@ -660,3 +660,38 @@ func vlmBuildUserInputRejectsVideoFramePixels() async {
     }
     for u in tempFiles { try? FileManager.default.removeItem(at: u) }
 }
+
+// Sampling-penalty wiring: the VLM path must forward repetition, presence, AND
+// frequency penalties into the engine (previously only repetition was wired, so
+// presence/frequency silently had no effect on image/video requests).
+@Test("generateParameters forwards repetition, presence, and frequency penalties")
+func testGenerateParametersForwardsAllPenalties() {
+    let request = OpenAIChatCompletionRequest(
+        model: "gemma-4-26b",
+        messages: [.init(role: .user, content: .text("describe"))],
+        temperature: 0.8,
+        maxTokens: 64,
+        presencePenalty: 0.5,
+        frequencyPenalty: 0.7,
+        repetitionPenalty: 1.3
+    )
+    let p = VLMRequestInference.generateParameters(for: request, defaultMaxTokens: 100)
+    #expect(p.maxTokens == 64)
+    #expect(p.temperature == 0.8)
+    #expect(p.repetitionPenalty == 1.3)
+    #expect(p.presencePenalty == 0.5)
+    #expect(p.frequencyPenalty == 0.7)
+}
+
+@Test("generateParameters leaves penalties unset and applies default max tokens")
+func testGenerateParametersDefaults() {
+    let request = OpenAIChatCompletionRequest(
+        model: "gemma-4-26b",
+        messages: [.init(role: .user, content: .text("describe"))]
+    )
+    let p = VLMRequestInference.generateParameters(for: request, defaultMaxTokens: 100)
+    #expect(p.maxTokens == 100)
+    #expect(p.repetitionPenalty == nil)
+    #expect(p.presencePenalty == nil)
+    #expect(p.frequencyPenalty == nil)
+}


### PR DESCRIPTION
## What

Apply **`presence_penalty`** and **`frequency_penalty`** on VLM (image/video) requests. Previously the VLM inference path forwarded only `repetition_penalty` into `GenerateParameters`, so the other two were **silently ignored** on image requests — even though the text/batched engine applies all three.

## Why it's safe now

The penalty processors (`RepetitionContext`/`PresencePenaltyContext`/`FrequencyPenaltyContext`) share a `TokenRing` that previously crashed on the VLM's 2-D `[1, seq]` prompt — that's fixed in 0.6.7 (mlx-swift-lm `loadPrompt` flatten). Presence/Frequency ride the same fixed path, so forwarding them is now safe.

## Change

- New testable helper `VLMRequestInference.generateParameters(for:defaultMaxTokens:)` that forwards repetition + presence + frequency penalties. Processors apply only for non-identity values (repetition ≠ 1, presence/frequency ≠ 0).
- `vlm-smoke` gains `VLM_PRESPEN` / `VLM_FREQPEN` env knobs for real-model checks.

## Tests / verification

- `VLMRequestInferenceTests`: all three penalties forwarded; omitted penalties stay unset; default max-tokens applied. (`swift test --filter VLMRequestInferenceTests` → 44 passed.)
- Real model (`gemma-4-26b` qat-4bit), greedy (temp=0) so output is deterministic: with `presence=2.0 frequency=2.0` the output **diverges** from baseline (repeated tokens suppressed) — i.e. the penalties take effect — **and no crash**.

Ships in the next provider release (0.6.8).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/352"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784101463&installation_id=133247490&pr_number=352&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F352&signature=841fff781dd546b8bb4eeecb49d8a8e33e770a595493443cc9d46e3d7160abb7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->