### PR TITLE
chore(release): v0.6.9 — Gemma 4 batched-attention NaN fix

### DIFF
--- a/provider-swift/Sources/ProviderCore/ProviderCore.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderCore.swift
@@ -25,5 +25,11 @@ public enum ProviderCore {
     // routing, graceful download-first auto-update, and the model-alias hot-swap
     // layer. Semver compares numerically per-component, so 0.6.0 > 0.5.17 keeps
     // the desired_models gate satisfied.
-    public static let version = "0.6.8"
+    // 0.6.9 fixes a Gemma 4 batched-attention NaN bug: when continuous batching
+    // co-prefills requests of different lengths, short rows are left-padded and
+    // their fully-masked padding queries softmaxed to NaN, which `0 * NaN`
+    // propagated into every row -> token-salad/repetition under concurrent load.
+    // Fixed in mlx-swift-lm#38 (gemma4AttentionFallback NaN-guard); submodule
+    // pin advanced to ee2a921.
+    public static let version = "0.6.9"
 }


### PR DESCRIPTION
## Summary

Cuts **v0.6.9**, advancing the \`libs/mlx-swift-lm\` submodule to **ee2a921** ([mlx-swift-lm#38](https://github.com/Layr-Labs/mlx-swift-lm/pull/38)) and bumping the provider version **0.6.8 → 0.6.9**.

## The bug it fixes

\`gemma-4-26b\` produced token-salad / repetition garbage on **some** responses under **concurrent load** — e.g. *"I's a marathon, but I's a marathon, just a marathon…"* or collapsing into a repeated token. Reproduced on the live fleet (targeted at a busy provider) and isolated to **batched** decoding: it survives greedy, top-k/top-p, and repetition_penalty because the **logits are NaN before sampling**.

**Root cause:** continuous batching co-prefills requests of **different prompt lengths** in one forward pass; the cache left-pads the short rows and the attention mask blocks their padding slots, making those rows' **padding-position queries fully masked**. The hand-rolled \`gemma4AttentionFallback\` softmaxed an all-\`-inf\` row to **NaN**, and \`0 * NaN = NaN\` in the value matmul propagated NaN into every row of the batch → all-NaN logits → garbage. Measured: a left-padded row's prefill logits were **1024/1024 NaN before, 0 after**.

The submodule PR maps post-softmax NaN→0 (matching \`MLXFast.scaledDotProductAttention\`, used by the decode path and mlx-lm). No behavior change for solo / uniform-length batches.

## Verification (in mlx-swift-lm#38)

- New CI regression test (\`raggedBatchGreedyParityTinyModel\`, tiny random-weight model, no download): fails pre-fix (NaN → token 0), passes after; verified to fail when the fix is reverted.
- Real \`gemma-4-26b\`: before = garbage on left-padded rows; after = coherent text, batched rows match solo decode.
- All existing MTP / batched parity suites (B=2/4) pass.

## Notes

- Coordinator-only change is **not** required; this is a provider-side inference fix that takes effect as the fleet rolls to 0.6.9.
- The bug predates #35, so a submodule pin rollback would not have fixed it.

Release: after merge, tag \`v0.6.9\` on master to trigger the Swift release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/354"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784135907&installation_id=133247490&pr_number=354&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F354&signature=a2b0d9b8ca22590d9653672b6d04abf17ea277e48abe10fdb8ad1afad3f63f37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->