### PR TITLE
Fix alias-aware model rollout UX

### DIFF
--- a/console-ui/src/app/api/models/route.ts
+++ b/console-ui/src/app/api/models/route.ts
@@ -4,6 +4,11 @@ const DEFAULT_COORD = process.env.NEXT_PUBLIC_COORDINATOR_URL || "https://api.da
 
 type JsonRecord = Record<string, unknown>;
 
+const GEMMA_PUBLIC_ID = "gemma-4-26b";
+const GEMMA_QAT_ID = "gemma-4-26b-qat-4bit";
+const GEMMA_ROLLBACK_ID = "gemma-4-26b-8bit";
+const GEMMA_ROLLOUT_IDS = new Set([GEMMA_PUBLIC_ID, GEMMA_QAT_ID, GEMMA_ROLLBACK_ID]);
+
 function asRecord(value: unknown): JsonRecord {
   return value && typeof value === "object" && !Array.isArray(value)
     ? (value as JsonRecord)
@@ -64,14 +69,6 @@ function toModelEntry(model: JsonRecord, capacity?: JsonRecord) {
       capabilities: model.capabilities ?? metadata.capabilities,
     },
   };
-}
-
-function asString(value: unknown) {
-  return typeof value === "string" && value.trim() ? value.trim() : undefined;
-}
-
-function asStringArray(value: unknown) {
-  return Array.isArray(value) ? value.filter((item): item is string => typeof item === "string") : [];
 }
 
 function aliasMemberBuilds(alias: JsonRecord, includeRetired = true) {

--- a/console-ui/src/app/api/models/route.ts
+++ b/console-ui/src/app/api/models/route.ts
@@ -53,9 +53,78 @@ function toModelEntry(model: JsonRecord, capacity?: JsonRecord) {
   };
 }
 
+function asString(value: unknown) {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function asStringArray(value: unknown) {
+  return Array.isArray(value) ? value.filter((item): item is string => typeof item === "string") : [];
+}
+
+function aliasMemberBuilds(alias: JsonRecord, includeRetired = true) {
+  const builds = [asString(alias.desired_build), asString(alias.previous_build)];
+  if (includeRetired) builds.push(...asStringArray(alias.retired_builds));
+  return [...new Set(builds.filter((build): build is string => Boolean(build)))];
+}
+
+function isHiddenStandaloneModel(model: JsonRecord) {
+  const metadata = asRecord(model.metadata);
+  if (metadata.hidden_from_picker === true || metadata.hide_standalone === true) return true;
+  const displayName = asString(model.display_name ?? model.name) ?? "";
+  return displayName.toLowerCase().includes("rollback");
+}
+
+function publicModelRows(catalogModels: unknown[], aliases: unknown[]) {
+  const rawModels = catalogModels.map(asRecord).filter((model) => typeof model.id === "string");
+  const aliasRows = aliases.map(asRecord).filter((alias) => typeof alias.id === "string" && typeof alias.desired_build === "string");
+  const rawByID = new Map(rawModels.map((model) => [model.id as string, model]));
+  const hiddenBuilds = new Set(aliasRows.flatMap((alias) => aliasMemberBuilds(alias)));
+  const publicAliases = aliasRows.flatMap((alias): JsonRecord[] => {
+    const primaryID = asString(alias.primary_build) ?? asString(alias.desired_build) ?? asString(alias.previous_build);
+    const primary = primaryID ? rawByID.get(primaryID) : undefined;
+    if (!primary) return [];
+    return [{
+      ...primary,
+      id: alias.id,
+      display_name: alias.display_name ?? primary.display_name,
+      name: alias.display_name ?? primary.name,
+      quantization: undefined,
+      metadata: {
+        ...asRecord(primary.metadata),
+        display_name: alias.display_name ?? asRecord(primary.metadata).display_name,
+        quantization: undefined,
+      },
+    }];
+  });
+  const visibleRaw = rawModels.filter((model) => !hiddenBuilds.has(model.id as string) && !isHiddenStandaloneModel(model));
+  return [...publicAliases, ...visibleRaw];
+}
+
+function aggregateAliasCapacity(alias: JsonRecord, capacityByID: Map<string, JsonRecord>) {
+  const members = aliasMemberBuilds(alias, false).map((build) => capacityByID.get(build)).filter(Boolean) as JsonRecord[];
+  if (members.length === 0) return undefined;
+  const sum = (key: string) => members.reduce((total, item) => total + (typeof item[key] === "number" ? item[key] as number : 0), 0);
+  const ttfts = members
+    .map((item) => item.estimated_ttft_ms)
+    .filter((value): value is number => typeof value === "number" && value > 0);
+  return {
+    id: alias.id,
+    ready: members.some((item) => item.ready === true),
+    can_accept: members.some((item) => item.can_accept === true),
+    routable_providers: sum("routable_providers"),
+    warm_providers: sum("warm_providers"),
+    cold_providers: sum("cold_providers"),
+    active_requests: sum("active_requests"),
+    queued_requests: sum("queued_requests"),
+    queue_limit: Math.max(...members.map((item) => typeof item.queue_limit === "number" ? item.queue_limit : 0)),
+    aggregate_tps: sum("aggregate_tps"),
+    estimated_ttft_ms: ttfts.length > 0 ? Math.min(...ttfts) : undefined,
+  };
+}
+
 async function publicCatalogResponse(coordUrl: string) {
   const [catalogRes, capacityRes] = await Promise.all([
-    fetch(`${coordUrl}/v1/models/catalog?type=text`),
+    fetch(`${coordUrl}/v1/models/catalog?type=text&include_aliases=1`),
     fetch(`${coordUrl}/v1/models/capacity`).catch(() => null),
   ]);
 
@@ -65,6 +134,7 @@ async function publicCatalogResponse(coordUrl: string) {
 
   const catalog = asRecord(await catalogRes.json());
   const catalogModels = Array.isArray(catalog.models) ? catalog.models : [];
+  const aliases = Array.isArray(catalog.aliases) ? catalog.aliases : [];
 
   const capacityByID = new Map<string, JsonRecord>();
   if (capacityRes?.ok) {
@@ -76,13 +146,18 @@ async function publicCatalogResponse(coordUrl: string) {
         capacityByID.set(entry.id, entry);
       }
     }
+    for (const alias of aliases.map(asRecord)) {
+      const aggregate = aggregateAliasCapacity(alias, capacityByID);
+      if (aggregate && typeof aggregate.id === "string") {
+        capacityByID.set(aggregate.id, aggregate);
+      }
+    }
   }
 
   return NextResponse.json({
     object: "list",
-    data: catalogModels
-      .map(asRecord)
-      .filter((model) => typeof model.id === "string")
+    aliases,
+    data: publicModelRows(catalogModels, aliases)
       .map((model) => toModelEntry(model, capacityByID.get(model.id as string))),
   });
 }

--- a/console-ui/src/app/stats/page.tsx
+++ b/console-ui/src/app/stats/page.tsx
@@ -27,10 +27,12 @@ import {
 } from "lucide-react";
 import { TopBar } from "@/components/TopBar";
 import {
-  catalogModelsFromResponse,
+  catalogDataFromResponse,
   capacityModelsFromResponse,
   filterServedCatalogModels,
   type CapacityModelSummary,
+  type CatalogAliasSummary,
+  type CatalogDataSummary,
   type CatalogModelSummary,
 } from "@/lib/stats-model-filter";
 import {
@@ -290,18 +292,18 @@ function normalizeTimeSeries(data: TimeSeriesBucket[], minutes = 30): TimeSeries
   });
 }
 
-async function fetchModelCatalog(): Promise<CatalogModelSummary[] | null> {
+async function fetchModelCatalog(): Promise<CatalogDataSummary | null> {
   const urls = [
     "/api/models",
-    `${COORDINATOR_URL}/v1/models/catalog?type=text`,
+    `${COORDINATOR_URL}/v1/models/catalog?type=text&include_aliases=1`,
   ];
 
   for (const url of urls) {
     try {
       const res = await fetch(url, { cache: "no-store" });
       if (!res.ok) continue;
-      const catalog = catalogModelsFromResponse(await res.json());
-      if (catalog.length > 0) return catalog;
+      const catalog = catalogDataFromResponse(await res.json());
+      if (catalog.models.length > 0) return catalog;
     } catch {
       // Keep stats usable if catalog lookup fails.
     }
@@ -466,12 +468,102 @@ function modelProviders(modelID: string, providers: ProviderStats[]): ProviderSt
   });
 }
 
-function buildModelInventory(stats: PlatformStats): ModelInventory[] {
-  const totalSlots = stats.models.reduce((sum, model) => sum + model.providers, 0);
+function aliasMemberBuilds(alias: CatalogAliasSummary, includeRetired = true): string[] {
+  const builds = [alias.desiredBuild];
+  if (alias.previousBuild) builds.push(alias.previousBuild);
+  if (includeRetired) builds.push(...(alias.retiredBuilds ?? []));
+  return [...new Set(builds.filter(Boolean))];
+}
 
-  return stats.models
+function hiddenAliasBuilds(aliases: CatalogAliasSummary[]): Set<string> {
+  return new Set(aliases.flatMap((alias) => aliasMemberBuilds(alias)));
+}
+
+function providerServesAnyBuild(provider: ProviderStats, builds: Set<string>): boolean {
+  if (provider.current_model && builds.has(provider.current_model)) return true;
+  return provider.models?.some((model) => builds.has(model)) ?? false;
+}
+
+function modelProvidersForBuilds(buildIDs: string[], providers: ProviderStats[]): ProviderStats[] {
+  const builds = new Set(buildIDs);
+  return providers.filter((provider) => providerServesAnyBuild(provider, builds));
+}
+
+function publicCatalogModels(catalogModels: CatalogModelSummary[], aliases: CatalogAliasSummary[]): CatalogModelSummary[] {
+  const rawByID = new Map(catalogModels.map((model) => [model.id, model]));
+  const hidden = hiddenAliasBuilds(aliases);
+  const aliasModels = aliases.flatMap((alias): CatalogModelSummary[] => {
+    const primary = rawByID.get(alias.primaryBuild ?? alias.desiredBuild) ??
+      (alias.previousBuild ? rawByID.get(alias.previousBuild) : undefined);
+    if (!primary) return [];
+    return [{
+      ...primary,
+      id: alias.id,
+      displayName: alias.displayName ?? primary.displayName,
+      name: alias.displayName ?? primary.name,
+      quantization: undefined,
+    }];
+  });
+  const visibleRaw = catalogModels.filter((model) => !hidden.has(model.id));
+  return [...aliasModels, ...visibleRaw];
+}
+
+function aggregateCapacityForBuilds(alias: CatalogAliasSummary, capacityByID: Map<string, CapacityModelSummary>): CapacityModelSummary | null {
+  const members = aliasMemberBuilds(alias, false)
+    .map((build) => capacityByID.get(build))
+    .filter((capacity): capacity is CapacityModelSummary => Boolean(capacity));
+  if (members.length === 0) return null;
+  const sum = (pick: (capacity: CapacityModelSummary) => number | undefined) =>
+    members.reduce((total, capacity) => total + (pick(capacity) ?? 0), 0);
+  const ttfts = members
+    .map((capacity) => capacity.estimatedTTFTMS)
+    .filter((value): value is number => value !== undefined && value > 0);
+  return {
+    id: alias.id,
+    ready: members.some((capacity) => capacity.ready),
+    canAccept: members.some((capacity) => capacity.canAccept),
+    routableProviders: sum((capacity) => capacity.routableProviders),
+    warmProviders: sum((capacity) => capacity.warmProviders),
+    coldProviders: sum((capacity) => capacity.coldProviders),
+    activeRequests: sum((capacity) => capacity.activeRequests),
+    queuedRequests: sum((capacity) => capacity.queuedRequests),
+    queueLimit: Math.max(...members.map((capacity) => capacity.queueLimit ?? 0)),
+    aggregateTPS: sum((capacity) => capacity.aggregateTPS),
+    estimatedTTFTMS: ttfts.length > 0 ? Math.min(...ttfts) : undefined,
+    tokenBudgetRemaining: sum((capacity) => capacity.tokenBudgetRemaining),
+    tokenBudgetTotal: sum((capacity) => capacity.tokenBudgetTotal),
+  };
+}
+
+function publicCapacityModels(capacityModels: CapacityModelSummary[] | null, aliases: CatalogAliasSummary[]): CapacityModelSummary[] | null {
+  if (!capacityModels) return null;
+  const hidden = hiddenAliasBuilds(aliases);
+  const byID = new Map(capacityModels.map((capacity) => [capacity.id, capacity]));
+  const visible = capacityModels.filter((capacity) => !hidden.has(capacity.id));
+  for (const alias of aliases) {
+    const aggregate = aggregateCapacityForBuilds(alias, byID);
+    if (aggregate) visible.push(aggregate);
+  }
+  return visible;
+}
+
+function buildModelInventory(stats: PlatformStats, aliases: CatalogAliasSummary[] = []): ModelInventory[] {
+  const hidden = hiddenAliasBuilds(aliases);
+  const rawModels = stats.models.filter((model) => !hidden.has(model.id));
+  const aliasModels = aliases.flatMap((alias): ModelStats[] => {
+    const providers = modelProvidersForBuilds(aliasMemberBuilds(alias), stats.providers);
+    if (providers.length === 0) return [];
+    return [{ id: alias.id, providers: providers.length }];
+  });
+  const models = [...rawModels, ...aliasModels];
+  const totalSlots = models.reduce((sum, model) => sum + model.providers, 0);
+
+  return models
     .map((model) => {
-      const providers = modelProviders(model.id, stats.providers);
+      const alias = aliases.find((candidate) => candidate.id === model.id);
+      const providers = alias
+        ? modelProvidersForBuilds(aliasMemberBuilds(alias), stats.providers)
+        : modelProviders(model.id, stats.providers);
       return {
         model,
         providers,
@@ -689,17 +781,20 @@ function ModelHeaderMetric({ label, value }: { label: string; value: string }) {
 
 function ActiveModelsSection({
   stats,
-  catalogModels,
+  catalogData,
   capacityModels,
 }: {
   stats: PlatformStats;
-  catalogModels: CatalogModelSummary[] | null;
+  catalogData: CatalogDataSummary | null;
   capacityModels: CapacityModelSummary[] | null;
 }) {
   const [showDeprecatedModels, setShowDeprecatedModels] = useState(false);
-  const inventory = buildModelInventory(stats);
+  const aliases = catalogData?.aliases ?? [];
+  const catalogModels = catalogData ? publicCatalogModels(catalogData.models, aliases) : null;
+  const publicCapacity = publicCapacityModels(capacityModels, aliases);
+  const inventory = buildModelInventory(stats, aliases);
   const catalogByID = new Map((catalogModels ?? []).map((model) => [model.id, model]));
-  const capacityByID = new Map((capacityModels ?? []).map((model) => [model.id, model]));
+  const capacityByID = new Map((publicCapacity ?? []).map((model) => [model.id, model]));
   const servedInventory = inventory.map((item) => ({
     ...item,
     id: item.model.id,
@@ -2799,7 +2894,7 @@ function NetworkNodes({ providers }: { providers: ProviderStats[] }) {
 // ---------------------------------------------------------------------------
 export default function StatsPage() {
   const [stats, setStats] = useState<PlatformStats | null>(null);
-  const [catalogModels, setCatalogModels] = useState<CatalogModelSummary[] | null>(null);
+  const [catalogData, setCatalogData] = useState<CatalogDataSummary | null>(null);
   const [capacityModels, setCapacityModels] = useState<CapacityModelSummary[] | null>(null);
   const [activeTab, setActiveTab] = useState<StatsTab>("overview");
   const [loading, setLoading] = useState(true);
@@ -2817,7 +2912,7 @@ export default function StatsPage() {
       const data = await res.json();
       setStats(data);
       if (catalog) {
-        setCatalogModels(catalog);
+        setCatalogData(catalog);
       }
       if (capacity) {
         setCapacityModels(capacity);
@@ -3019,7 +3114,7 @@ export default function StatsPage() {
         {stats.models.length > 0 && (
           <ActiveModelsSection
             stats={stats}
-            catalogModels={catalogModels}
+            catalogData={catalogData}
             capacityModels={capacityModels}
           />
         )}

--- a/console-ui/src/app/stats/page.tsx
+++ b/console-ui/src/app/stats/page.tsx
@@ -200,6 +200,11 @@ type StatsTab = "overview" | "leaderboard";
 type LeaderboardMetric = "earnings" | "tokens" | "jobs";
 type LeaderboardWindow = "24h" | "7d" | "30d" | "all";
 
+const GEMMA_PUBLIC_ID = "gemma-4-26b";
+const GEMMA_QAT_ID = "gemma-4-26b-qat-4bit";
+const GEMMA_ROLLBACK_ID = "gemma-4-26b-8bit";
+const GEMMA_ROLLOUT_IDS = new Set([GEMMA_PUBLIC_ID, GEMMA_QAT_ID, GEMMA_ROLLBACK_ID]);
+
 interface ModelInventory {
   model: ModelStats;
   providers: ProviderStats[];
@@ -528,7 +533,8 @@ function publicCatalogModels(catalogModels: CatalogModelSummary[], aliases: Cata
   const hidden = hiddenAliasBuilds(aliases);
   const aliasModels: CatalogModelSummary[] = [];
   for (const alias of aliases) {
-    const primary = rawByID.get(alias.primaryBuild ?? alias.desiredBuild) ??
+    const primary = rawByID.get(alias.id) ??
+      rawByID.get(alias.primaryBuild ?? alias.desiredBuild) ??
       (alias.previousBuild ? rawByID.get(alias.previousBuild) : undefined);
     if (!primary) continue;
     aliasModels.push({

--- a/console-ui/src/lib/stats-model-filter.ts
+++ b/console-ui/src/lib/stats-model-filter.ts
@@ -23,6 +23,20 @@ export interface CatalogModelSummary {
   outputModalities?: string[];
 }
 
+export interface CatalogAliasSummary {
+  id: string;
+  displayName?: string;
+  desiredBuild: string;
+  previousBuild?: string;
+  retiredBuilds?: string[];
+  primaryBuild?: string;
+}
+
+export interface CatalogDataSummary {
+  models: CatalogModelSummary[];
+  aliases: CatalogAliasSummary[];
+}
+
 export interface CapacityModelSummary {
   id: string;
   ready?: boolean;
@@ -89,7 +103,7 @@ function compactObject<T extends Record<string, unknown>>(value: T): T {
   ) as T;
 }
 
-export function catalogModelsFromResponse(payload: unknown): CatalogModelSummary[] {
+export function catalogDataFromResponse(payload: unknown): CatalogDataSummary {
   const body = asRecord(payload);
   let rows: unknown[] = [];
   if (Array.isArray(body.data)) {
@@ -98,7 +112,7 @@ export function catalogModelsFromResponse(payload: unknown): CatalogModelSummary
     rows = body.models;
   }
 
-  return rows
+  const models = rows
     .map(asRecord)
     .filter((model) => typeof model.id === "string" && model.id.trim().length > 0)
     .map((model) => {
@@ -122,6 +136,26 @@ export function catalogModelsFromResponse(payload: unknown): CatalogModelSummary
         outputModalities: asStringArray(model.output_modalities),
       });
     });
+
+  const aliases = Array.isArray(body.aliases)
+    ? body.aliases
+      .map(asRecord)
+      .filter((alias) => typeof alias.id === "string" && typeof alias.desired_build === "string")
+      .map((alias) => compactObject({
+        id: alias.id as string,
+        displayName: asString(alias.display_name),
+        desiredBuild: alias.desired_build as string,
+        previousBuild: asString(alias.previous_build),
+        retiredBuilds: asStringArray(alias.retired_builds),
+        primaryBuild: asString(alias.primary_build),
+      }))
+    : [];
+
+  return { models, aliases };
+}
+
+export function catalogModelsFromResponse(payload: unknown): CatalogModelSummary[] {
+  return catalogDataFromResponse(payload).models;
 }
 
 export function capacityModelsFromResponse(payload: unknown): CapacityModelSummary[] {

--- a/coordinator/api/billing_handlers.go
+++ b/coordinator/api/billing_handlers.go
@@ -615,12 +615,16 @@ func (s *Server) requirePrivyUser(w http.ResponseWriter, r *http.Request) *store
 // Public endpoint — returns active models for providers and the install script.
 // Cached for 60s — the underlying DB query is fast but this endpoint is hit
 // by every provider heartbeat and install script poll.
+func modelCatalogCacheKey(typeFilter string, includeAliases bool) string {
+	return "models:catalog:type=" + typeFilter + ":include_aliases=" + strconv.FormatBool(includeAliases)
+}
+
 func (s *Server) handleModelCatalog(w http.ResponseWriter, r *http.Request) {
 	// Optional filter: ?type=text
 	typeFilter := r.URL.Query().Get("type")
 	includeAliases := r.URL.Query().Get("include_aliases") == "1" || strings.EqualFold(r.URL.Query().Get("include_aliases"), "true")
 
-	cacheKey := "models:catalog:type=" + typeFilter + ":include_aliases=" + strconv.FormatBool(includeAliases)
+	cacheKey := modelCatalogCacheKey(typeFilter, includeAliases)
 	if cached, ok := s.readCache.Get(cacheKey); ok {
 		writeCachedJSON(w, cached)
 		return

--- a/coordinator/api/billing_handlers.go
+++ b/coordinator/api/billing_handlers.go
@@ -618,10 +618,14 @@ func (s *Server) requirePrivyUser(w http.ResponseWriter, r *http.Request) *store
 func (s *Server) handleModelCatalog(w http.ResponseWriter, r *http.Request) {
 	// Optional filter: ?type=text
 	typeFilter := r.URL.Query().Get("type")
+	includeAliases := r.URL.Query().Get("include_aliases") == "1" || strings.EqualFold(r.URL.Query().Get("include_aliases"), "true")
 
 	cacheKey := "models:catalog"
 	if typeFilter != "" {
 		cacheKey = "models:catalog:" + typeFilter
+	}
+	if includeAliases {
+		cacheKey += ":aliases"
 	}
 	if cached, ok := s.readCache.Get(cacheKey); ok {
 		writeCachedJSON(w, cached)
@@ -642,6 +646,14 @@ func (s *Server) handleModelCatalog(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	response := map[string]any{"models": models}
+	if includeAliases {
+		aliases, err := s.store.ListModelAliases()
+		if err != nil {
+			s.logger.Warn("model registry: failed to list aliases for catalog response", "error", err)
+		} else {
+			response["aliases"] = catalogAliasesForResponse(models, aliases)
+		}
+	}
 
 	body, err := json.Marshal(response)
 	if err != nil {

--- a/coordinator/api/model_registry_handlers.go
+++ b/coordinator/api/model_registry_handlers.go
@@ -816,6 +816,51 @@ func catalogModelFromRegistryRecord(rec *store.ModelRegistryRecord) map[string]a
 	return model
 }
 
+func catalogAliasesForResponse(models []map[string]any, aliases []store.ModelAlias) []map[string]any {
+	catalogIDs := make(map[string]struct{}, len(models))
+	for _, model := range models {
+		id, _ := model["id"].(string)
+		if id != "" {
+			catalogIDs[id] = struct{}{}
+		}
+	}
+	response := make([]map[string]any, 0, len(aliases))
+	for _, alias := range aliases {
+		if !alias.Active || alias.DesiredBuild == "" {
+			continue
+		}
+		displayName := alias.DisplayName
+		if displayName == "" {
+			displayName = alias.AliasID
+		}
+		retiredBuilds := alias.RetiredBuilds
+		if retiredBuilds == nil {
+			retiredBuilds = []string{}
+		}
+		entry := map[string]any{
+			"id":             alias.AliasID,
+			"display_name":   displayName,
+			"desired_build":  alias.DesiredBuild,
+			"retired_builds": retiredBuilds,
+		}
+		if alias.PreviousBuild != "" {
+			entry["previous_build"] = alias.PreviousBuild
+		}
+		if _, ok := catalogIDs[alias.DesiredBuild]; ok {
+			entry["primary_build"] = alias.DesiredBuild
+		} else if alias.PreviousBuild != "" {
+			if _, ok := catalogIDs[alias.PreviousBuild]; ok {
+				entry["primary_build"] = alias.PreviousBuild
+			}
+		}
+		if entry["primary_build"] == nil {
+			continue
+		}
+		response = append(response, entry)
+	}
+	return response
+}
+
 func supportedModelFromRegistryRecord(rec *store.ModelRegistryRecord) store.SupportedModel {
 	active := rec.Status == "active" || rec.Status == "beta"
 	model := store.SupportedModel{

--- a/coordinator/api/model_registry_handlers_test.go
+++ b/coordinator/api/model_registry_handlers_test.go
@@ -124,6 +124,43 @@ func TestRegisterValidationAndR2Prefix(t *testing.T) {
 	}
 }
 
+func TestCatalogAliasesForResponse(t *testing.T) {
+	models := []map[string]any{
+		{"id": "gemma-4-26b-qat-4bit"},
+		{"id": "gemma-4-26b"},
+	}
+	aliases := []store.ModelAlias{
+		{
+			AliasID:       "gemma-4-26b",
+			DisplayName:   "Gemma 4 26B",
+			DesiredBuild:  "gemma-4-26b-qat-4bit",
+			PreviousBuild: "gemma-4-26b",
+			RetiredBuilds: []string{"gemma-4-26b-old"},
+			Active:        true,
+		},
+		{AliasID: "inactive", DesiredBuild: "missing", Active: false},
+	}
+
+	got := catalogAliasesForResponse(models, aliases)
+	if len(got) != 1 {
+		t.Fatalf("alias count = %d, want 1", len(got))
+	}
+	alias := got[0]
+	if alias["id"] != "gemma-4-26b" || alias["display_name"] != "Gemma 4 26B" {
+		t.Fatalf("unexpected alias identity: %#v", alias)
+	}
+	if alias["desired_build"] != "gemma-4-26b-qat-4bit" || alias["previous_build"] != "gemma-4-26b" {
+		t.Fatalf("unexpected alias builds: %#v", alias)
+	}
+	if alias["primary_build"] != "gemma-4-26b-qat-4bit" {
+		t.Fatalf("primary_build = %v, want desired", alias["primary_build"])
+	}
+	retired, ok := alias["retired_builds"].([]string)
+	if !ok || len(retired) != 1 || retired[0] != "gemma-4-26b-old" {
+		t.Fatalf("retired_builds = %#v", alias["retired_builds"])
+	}
+}
+
 func TestParseModelCatalogPathsDisambiguatesManifestSuffix(t *testing.T) {
 	modelID, ok := parseModelCatalogPath("/v1/models/catalog/org/manifest")
 	if !ok || modelID != "org/manifest" {

--- a/coordinator/api/server.go
+++ b/coordinator/api/server.go
@@ -914,6 +914,8 @@ func (s *Server) invalidateCatalogCache() {
 	}
 	s.readCache.Invalidate("models:catalog")
 	s.readCache.Invalidate("models:catalog:text")
+	s.readCache.Invalidate("models:catalog:aliases")
+	s.readCache.Invalidate("models:catalog:text:aliases")
 }
 
 // SetKnownBinaryHashes configures the set of accepted provider binary hashes.

--- a/coordinator/api/server.go
+++ b/coordinator/api/server.go
@@ -912,10 +912,11 @@ func (s *Server) invalidateCatalogCache() {
 	if s.readCache == nil {
 		return
 	}
-	s.readCache.Invalidate("models:catalog")
-	s.readCache.Invalidate("models:catalog:text")
-	s.readCache.Invalidate("models:catalog:aliases")
-	s.readCache.Invalidate("models:catalog:text:aliases")
+	for _, typeFilter := range []string{"", "text"} {
+		for _, includeAliases := range []bool{false, true} {
+			s.readCache.Invalidate(modelCatalogCacheKey(typeFilter, includeAliases))
+		}
+	}
 }
 
 // SetKnownBinaryHashes configures the set of accepted provider binary hashes.

--- a/provider-swift/Sources/ProviderCore/Models/ModelCatalog.swift
+++ b/provider-swift/Sources/ProviderCore/Models/ModelCatalog.swift
@@ -438,8 +438,32 @@ public struct CatalogModel: Codable, Sendable, Equatable {
     }
 }
 
+public struct CatalogAlias: Codable, Sendable, Equatable {
+    public let id: String
+    public let displayName: String
+    public let desiredBuild: String
+    public let previousBuild: String?
+    public let retiredBuilds: [String]?
+    public let primaryBuild: String?
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case displayName = "display_name"
+        case desiredBuild = "desired_build"
+        case previousBuild = "previous_build"
+        case retiredBuilds = "retired_builds"
+        case primaryBuild = "primary_build"
+    }
+}
+
+public struct CatalogSnapshot: Sendable, Equatable {
+    public let models: [CatalogModel]
+    public let aliases: [CatalogAlias]
+}
+
 private struct CatalogResponse: Codable {
     let models: [CatalogModel]
+    let aliases: [CatalogAlias]?
 }
 
 // MARK: - Errors
@@ -479,10 +503,19 @@ public struct ModelCatalogClient: Sendable {
     /// Fetch the active catalog from the coordinator. `typeFilter` mirrors
     /// the coordinator's `?type=` query parameter (e.g. "text").
     public func fetchCatalog(typeFilter: String? = nil) async throws -> [CatalogModel] {
+        try await fetchCatalogSnapshot(typeFilter: typeFilter, includeAliases: false).models
+    }
+
+    public func fetchCatalogSnapshot(typeFilter: String? = nil, includeAliases: Bool = false) async throws -> CatalogSnapshot {
         var components = URLComponents(string: "\(coordinatorURL)/v1/models/catalog")!
+        var queryItems: [URLQueryItem] = []
         if let typeFilter, !typeFilter.isEmpty {
-            components.queryItems = [URLQueryItem(name: "type", value: typeFilter)]
+            queryItems.append(URLQueryItem(name: "type", value: typeFilter))
         }
+        if includeAliases {
+            queryItems.append(URLQueryItem(name: "include_aliases", value: "1"))
+        }
+        components.queryItems = queryItems.isEmpty ? nil : queryItems
         guard let url = components.url else {
             throw ModelCatalogError.unreachable("invalid catalog URL")
         }
@@ -506,7 +539,7 @@ public struct ModelCatalogClient: Sendable {
 
         do {
             let decoded = try JSONDecoder().decode(CatalogResponse.self, from: data)
-            return decoded.models
+            return CatalogSnapshot(models: decoded.models, aliases: decoded.aliases ?? [])
         } catch {
             throw ModelCatalogError.decodeFailed(error.localizedDescription)
         }

--- a/provider-swift/Sources/darkbloom/StartCommand.swift
+++ b/provider-swift/Sources/darkbloom/StartCommand.swift
@@ -587,6 +587,42 @@ struct Start: AsyncParsableCommand {
         let downloaded: Bool
     }
 
+    private struct PickerCatalogRow {
+        let model: CatalogModel
+        let displayName: String
+    }
+
+    private func pickerCatalogRows(models: [CatalogModel], aliases: [CatalogAlias]) -> [PickerCatalogRow] {
+        var hiddenBuilds = Set<String>()
+        var aliasDisplayByBuild: [String: String] = [:]
+        for alias in aliases {
+            hiddenBuilds.insert(alias.desiredBuild)
+            if let previous = alias.previousBuild { hiddenBuilds.insert(previous) }
+            for retired in alias.retiredBuilds ?? [] { hiddenBuilds.insert(retired) }
+
+            let primary = alias.primaryBuild ?? alias.desiredBuild
+            aliasDisplayByBuild[primary] = alias.displayName
+        }
+
+        return models.compactMap { model in
+            if let displayName = aliasDisplayByBuild[model.id] {
+                return PickerCatalogRow(model: model, displayName: displayName)
+            }
+            if hiddenBuilds.contains(model.id) || isHiddenPickerModel(model) {
+                return nil
+            }
+            return PickerCatalogRow(model: model, displayName: model.displayName)
+        }
+    }
+
+    private func isHiddenPickerModel(_ model: CatalogModel) -> Bool {
+        if let metadata = model.metadata {
+            if metadata["hidden_from_picker"] == .bool(true) { return true }
+            if metadata["hide_standalone"] == .bool(true) { return true }
+        }
+        return model.displayName.localizedCaseInsensitiveContains("rollback")
+    }
+
     /// Fetches the model catalog from the coordinator, shows an interactive
     /// terminal picker, downloads any missing models, and returns the
     /// selected model IDs.
@@ -597,14 +633,16 @@ struct Start: AsyncParsableCommand {
     ) async throws -> [String] {
         let client = ModelCatalogClient(coordinatorURL: coordinatorURL)
 
-        let catalog: [CatalogModel]
+        let catalogSnapshot: CatalogSnapshot
         do {
-            catalog = try await client.fetchCatalog(typeFilter: "text")
+            catalogSnapshot = try await client.fetchCatalogSnapshot(typeFilter: "text", includeAliases: true)
         } catch {
             printError("Could not fetch model catalog from coordinator: \(error)")
             printError("hint: check your coordinator URL or use --model to specify models directly")
             throw ExitCode.failure
         }
+
+        let catalog = pickerCatalogRows(models: catalogSnapshot.models, aliases: catalogSnapshot.aliases)
 
         guard !catalog.isEmpty else {
             printError("No models in the coordinator catalog.")
@@ -616,7 +654,8 @@ struct Start: AsyncParsableCommand {
 
         // Build picker entries: filter to models that fit, sort downloaded-first
         // then by size descending.
-        var entries: [PickerEntry] = catalog.compactMap { entry in
+        var entries: [PickerEntry] = catalog.compactMap { row -> PickerEntry? in
+            let entry = row.model
             if let minRam = entry.minRamGb, Double(minRam) > memoryGb {
                 return nil
             }
@@ -630,7 +669,7 @@ struct Start: AsyncParsableCommand {
             return PickerEntry(
                 id: entry.id,
                 catalogModel: entry,
-                displayName: entry.displayName,
+                displayName: row.displayName,
                 sizeGb: size,
                 minRamGb: entry.minRamGb,
                 downloaded: isDownloaded


### PR DESCRIPTION
## Summary
- add opt-in alias metadata to the public model catalog via `include_aliases=1` without changing default concrete catalog rows
- consolidate alias desired/previous builds in console model/stats views while preserving raw build-level capacity endpoints
- update `darkbloom start` picker to show the public alias label for the desired build and hide previous/retired/rollback rows

## Verification
- `cd coordinator && go test ./api ./registry`
- `cd provider-swift && swift build`
- `cd console-ui && npx eslint src/app/stats/page.tsx src/app/api/models/route.ts src/lib/stats-model-filter.ts` (warnings only)
- `cd console-ui && npm test -- --run`
- `cd console-ui && npm run build`

## Notes
- Raw/operator surfaces remain available: `/v1/models/catalog`, `/v1/models/capacity`, and authenticated `/v1/models?include_builds=1` still expose concrete builds.
- Existing providers ignore the new opt-in `aliases` field unless they request it.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/356"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784144883&installation_id=133247490&pr_number=356&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F356&signature=789147955b6d2319357e11ccf8e1869dfb9f6874b5b6d4b3552b2fc083c46868"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->