### PR TITLE
Quick fix: collapse Gemma rollout models in clients

### DIFF
--- a/console-ui/src/app/api/models/route.ts
+++ b/console-ui/src/app/api/models/route.ts
@@ -4,6 +4,11 @@ const DEFAULT_COORD = process.env.NEXT_PUBLIC_COORDINATOR_URL || "https://api.da
 
 type JsonRecord = Record<string, unknown>;
 
+const GEMMA_PUBLIC_ID = "gemma-4-26b";
+const GEMMA_QAT_ID = "gemma-4-26b-qat-4bit";
+const GEMMA_ROLLBACK_ID = "gemma-4-26b-8bit";
+const GEMMA_ROLLOUT_IDS = new Set([GEMMA_PUBLIC_ID, GEMMA_QAT_ID, GEMMA_ROLLBACK_ID]);
+
 function asRecord(value: unknown): JsonRecord {
   return value && typeof value === "object" && !Array.isArray(value)
     ? (value as JsonRecord)
@@ -53,6 +58,61 @@ function toModelEntry(model: JsonRecord, capacity?: JsonRecord) {
   };
 }
 
+function isGemmaRolloutBuild(id: unknown): id is string {
+  return typeof id === "string" && GEMMA_ROLLOUT_IDS.has(id);
+}
+
+function sumCapacity(capacityModels: JsonRecord[]) {
+  const sum = (key: string) => capacityModels.reduce((total, model) => total + (typeof model[key] === "number" ? model[key] as number : 0), 0);
+  const ttfts = capacityModels
+    .map((model) => model.estimated_ttft_ms)
+    .filter((value): value is number => typeof value === "number" && value > 0);
+  return {
+    id: GEMMA_PUBLIC_ID,
+    ready: capacityModels.some((model) => model.ready === true),
+    can_accept: capacityModels.some((model) => model.can_accept === true),
+    routable_providers: sum("routable_providers"),
+    warm_providers: sum("warm_providers"),
+    cold_providers: sum("cold_providers"),
+    active_requests: sum("active_requests"),
+    queued_requests: sum("queued_requests"),
+    queue_limit: Math.max(...capacityModels.map((model) => typeof model.queue_limit === "number" ? model.queue_limit : 0)),
+    aggregate_tps: sum("aggregate_tps"),
+    estimated_ttft_ms: ttfts.length > 0 ? Math.min(...ttfts) : undefined,
+  };
+}
+
+function applyGemmaRolloutQuickFix(catalogModels: unknown[], capacityByID: Map<string, JsonRecord>) {
+  // Temporary Gemma 4 rollout shim. Remove after the coordinator alias catalog
+  // contract is deployed and the console consumes alias metadata.
+  const rows = catalogModels.map(asRecord).filter((model) => typeof model.id === "string");
+  const publicRow = rows.find((model) => model.id === GEMMA_PUBLIC_ID);
+  const qatRow = rows.find((model) => model.id === GEMMA_QAT_ID);
+  const primary = publicRow ?? qatRow;
+  const visible = rows.filter((model) => !isGemmaRolloutBuild(model.id));
+  const capacities = [...GEMMA_ROLLOUT_IDS]
+    .map((id) => capacityByID.get(id))
+    .filter((capacity): capacity is JsonRecord => Boolean(capacity));
+
+  if (capacities.length > 0) {
+    capacityByID.set(GEMMA_PUBLIC_ID, sumCapacity(capacities));
+  }
+  if (!primary) return visible;
+
+  return [{
+    ...primary,
+    id: GEMMA_PUBLIC_ID,
+    name: "Gemma 4 26B",
+    display_name: "Gemma 4 26B",
+    quantization: undefined,
+    metadata: {
+      ...asRecord(primary.metadata),
+      display_name: "Gemma 4 26B",
+      quantization: undefined,
+    },
+  }, ...visible];
+}
+
 async function publicCatalogResponse(coordUrl: string) {
   const [catalogRes, capacityRes] = await Promise.all([
     fetch(`${coordUrl}/v1/models/catalog?type=text`),
@@ -80,9 +140,7 @@ async function publicCatalogResponse(coordUrl: string) {
 
   return NextResponse.json({
     object: "list",
-    data: catalogModels
-      .map(asRecord)
-      .filter((model) => typeof model.id === "string")
+    data: applyGemmaRolloutQuickFix(catalogModels, capacityByID)
       .map((model) => toModelEntry(model, capacityByID.get(model.id as string))),
   });
 }

--- a/console-ui/src/app/stats/page.tsx
+++ b/console-ui/src/app/stats/page.tsx
@@ -198,6 +198,11 @@ type StatsTab = "overview" | "leaderboard";
 type LeaderboardMetric = "earnings" | "tokens" | "jobs";
 type LeaderboardWindow = "24h" | "7d" | "30d" | "all";
 
+const GEMMA_PUBLIC_ID = "gemma-4-26b";
+const GEMMA_QAT_ID = "gemma-4-26b-qat-4bit";
+const GEMMA_ROLLBACK_ID = "gemma-4-26b-8bit";
+const GEMMA_ROLLOUT_IDS = new Set([GEMMA_PUBLIC_ID, GEMMA_QAT_ID, GEMMA_ROLLBACK_ID]);
+
 interface ModelInventory {
   model: ModelStats;
   providers: ProviderStats[];
@@ -460,16 +465,36 @@ function MiniStat({
 // Network Power -- realistic Apple Silicon draw, auto-scaled units
 // ---------------------------------------------------------------------------
 function modelProviders(modelID: string, providers: ProviderStats[]): ProviderStats[] {
+  if (modelID === GEMMA_PUBLIC_ID) return gemmaRolloutProviders(providers);
   return providers.filter((provider) => {
     if (provider.current_model === modelID) return true;
     return provider.models?.includes(modelID) ?? false;
   });
 }
 
-function buildModelInventory(stats: PlatformStats): ModelInventory[] {
-  const totalSlots = stats.models.reduce((sum, model) => sum + model.providers, 0);
+function providerServesGemmaRollout(provider: ProviderStats): boolean {
+  if (provider.current_model && GEMMA_ROLLOUT_IDS.has(provider.current_model)) return true;
+  return provider.models?.some((model) => GEMMA_ROLLOUT_IDS.has(model)) ?? false;
+}
 
-  return stats.models
+function gemmaRolloutProviders(providers: ProviderStats[]): ProviderStats[] {
+  return providers.filter(providerServesGemmaRollout);
+}
+
+function publicModelStats(stats: PlatformStats): ModelStats[] {
+  // Temporary Gemma 4 rollout shim. Remove after the coordinator alias catalog
+  // contract is deployed and the console consumes alias metadata.
+  const raw = stats.models.filter((model) => !GEMMA_ROLLOUT_IDS.has(model.id));
+  const hasGemma = stats.models.some((model) => GEMMA_ROLLOUT_IDS.has(model.id));
+  if (!hasGemma) return raw;
+  return [{ id: GEMMA_PUBLIC_ID, providers: gemmaRolloutProviders(stats.providers).length }, ...raw];
+}
+
+function buildModelInventory(stats: PlatformStats): ModelInventory[] {
+  const models = publicModelStats(stats);
+  const totalSlots = models.reduce((sum, model) => sum + model.providers, 0);
+
+  return models
     .map((model) => {
       const providers = modelProviders(model.id, stats.providers);
       return {
@@ -687,6 +712,53 @@ function ModelHeaderMetric({ label, value }: { label: string; value: string }) {
   );
 }
 
+function publicCatalogModels(catalogModels: CatalogModelSummary[] | null): CatalogModelSummary[] | null {
+  if (!catalogModels) return null;
+  const gemma = catalogModels.find((model) => model.id === GEMMA_PUBLIC_ID) ??
+    catalogModels.find((model) => model.id === GEMMA_QAT_ID);
+  const visible = catalogModels.filter((model) => !GEMMA_ROLLOUT_IDS.has(model.id));
+  if (!gemma) return visible;
+  return [{
+    ...gemma,
+    id: GEMMA_PUBLIC_ID,
+    displayName: "Gemma 4 26B",
+    name: "Gemma 4 26B",
+    quantization: undefined,
+  }, ...visible];
+}
+
+function aggregateGemmaCapacity(capacityModels: CapacityModelSummary[]): CapacityModelSummary | null {
+  const members = capacityModels.filter((model) => GEMMA_ROLLOUT_IDS.has(model.id));
+  if (members.length === 0) return null;
+  const sum = (pick: (capacity: CapacityModelSummary) => number | undefined) =>
+    members.reduce((total, capacity) => total + (pick(capacity) ?? 0), 0);
+  const ttfts = members
+    .map((capacity) => capacity.estimatedTTFTMS)
+    .filter((value): value is number => value !== undefined && value > 0);
+  return {
+    id: GEMMA_PUBLIC_ID,
+    ready: members.some((capacity) => capacity.ready),
+    canAccept: members.some((capacity) => capacity.canAccept),
+    routableProviders: sum((capacity) => capacity.routableProviders),
+    warmProviders: sum((capacity) => capacity.warmProviders),
+    coldProviders: sum((capacity) => capacity.coldProviders),
+    activeRequests: sum((capacity) => capacity.activeRequests),
+    queuedRequests: sum((capacity) => capacity.queuedRequests),
+    queueLimit: Math.max(...members.map((capacity) => capacity.queueLimit ?? 0)),
+    aggregateTPS: sum((capacity) => capacity.aggregateTPS),
+    estimatedTTFTMS: ttfts.length > 0 ? Math.min(...ttfts) : undefined,
+    tokenBudgetRemaining: sum((capacity) => capacity.tokenBudgetRemaining),
+    tokenBudgetTotal: sum((capacity) => capacity.tokenBudgetTotal),
+  };
+}
+
+function publicCapacityModels(capacityModels: CapacityModelSummary[] | null): CapacityModelSummary[] | null {
+  if (!capacityModels) return null;
+  const visible = capacityModels.filter((model) => !GEMMA_ROLLOUT_IDS.has(model.id));
+  const gemma = aggregateGemmaCapacity(capacityModels);
+  return gemma ? [gemma, ...visible] : visible;
+}
+
 function ActiveModelsSection({
   stats,
   catalogModels,
@@ -697,9 +769,11 @@ function ActiveModelsSection({
   capacityModels: CapacityModelSummary[] | null;
 }) {
   const [showDeprecatedModels, setShowDeprecatedModels] = useState(false);
+  const visibleCatalogModels = publicCatalogModels(catalogModels);
+  const visibleCapacityModels = publicCapacityModels(capacityModels);
   const inventory = buildModelInventory(stats);
-  const catalogByID = new Map((catalogModels ?? []).map((model) => [model.id, model]));
-  const capacityByID = new Map((capacityModels ?? []).map((model) => [model.id, model]));
+  const catalogByID = new Map((visibleCatalogModels ?? []).map((model) => [model.id, model]));
+  const capacityByID = new Map((visibleCapacityModels ?? []).map((model) => [model.id, model]));
   const servedInventory = inventory.map((item) => ({
     ...item,
     id: item.model.id,
@@ -707,8 +781,8 @@ function ActiveModelsSection({
     catalogModel: catalogByID.get(item.model.id),
     capacity: capacityByID.get(item.model.id),
   }));
-  const filtered = catalogModels
-    ? filterServedCatalogModels(servedInventory, catalogModels, showDeprecatedModels)
+  const filtered = visibleCatalogModels
+    ? filterServedCatalogModels(servedInventory, visibleCatalogModels, showDeprecatedModels)
     : {
       visible: servedInventory.map((item) => ({ ...item, catalogStatus: "active" })),
       catalogServedCount: servedInventory.length,
@@ -2963,7 +3037,7 @@ export default function StatsPage() {
           />
           <MiniStat
             label="Models"
-            value={stats.models.length.toString()}
+            value={publicModelStats(stats).length.toString()}
             sub="serving now"
           />
         </div>

--- a/provider-swift/Sources/darkbloom/StartCommand.swift
+++ b/provider-swift/Sources/darkbloom/StartCommand.swift
@@ -587,6 +587,21 @@ struct Start: AsyncParsableCommand {
         let downloaded: Bool
     }
 
+    private static let gemmaPublicID = "gemma-4-26b"
+    private static let gemmaQATID = "gemma-4-26b-qat-4bit"
+    private static let gemmaRollbackID = "gemma-4-26b-8bit"
+
+    private func gemmaRolloutDisplayName(for model: CatalogModel) -> String? {
+        // Temporary Gemma 4 rollout shim. Remove after the coordinator alias
+        // catalog contract is deployed and the picker consumes alias metadata.
+        model.id == Self.gemmaQATID ? "Gemma 4 26B" : nil
+    }
+
+    private func shouldHideGemmaRolloutModel(_ model: CatalogModel, qatAvailable: Bool) -> Bool {
+        guard qatAvailable else { return model.id == Self.gemmaRollbackID }
+        return model.id == Self.gemmaPublicID || model.id == Self.gemmaRollbackID
+    }
+
     /// Fetches the model catalog from the coordinator, shows an interactive
     /// terminal picker, downloads any missing models, and returns the
     /// selected model IDs.
@@ -613,10 +628,14 @@ struct Start: AsyncParsableCommand {
 
         let localByID = Dictionary(uniqueKeysWithValues: snapshot.models.map { ($0.id, $0) })
         let memoryGb: Double = Double(snapshot.hardware?.memoryGb ?? 16)
+        let gemmaQATAvailable = catalog.contains { $0.id == Self.gemmaQATID }
 
         // Build picker entries: filter to models that fit, sort downloaded-first
         // then by size descending.
         var entries: [PickerEntry] = catalog.compactMap { entry in
+            if shouldHideGemmaRolloutModel(entry, qatAvailable: gemmaQATAvailable) {
+                return nil
+            }
             if let minRam = entry.minRamGb, Double(minRam) > memoryGb {
                 return nil
             }
@@ -630,7 +649,7 @@ struct Start: AsyncParsableCommand {
             return PickerEntry(
                 id: entry.id,
                 catalogModel: entry,
-                displayName: entry.displayName,
+                displayName: gemmaRolloutDisplayName(for: entry) ?? entry.displayName,
                 sizeGb: size,
                 minRamGb: entry.minRamGb,
                 downloaded: isDownloaded


### PR DESCRIPTION
## Summary
- add a temporary Gemma 4 rollout shim in console public model/stats views so QAT, previous 8-bit, and rollback builds appear as one `gemma-4-26b` row
- aggregate Gemma rollout capacity/provider counts under the public model id
- update `darkbloom start` picker to show QAT as the single `Gemma 4 26B` choice and hide old/rollback rows while the coordinator alias contract is not deployed

## Scope
- client-only quick fix: `console-ui` and provider CLI only
- no coordinator changes
- comments mark the shim for removal after the permanent alias catalog contract deploys

## Verification
- `cd console-ui && npx eslint src/app/stats/page.tsx src/app/api/models/route.ts` (warnings only)
- `cd console-ui && npm test -- --run`
- `cd console-ui && npm run build`
- `cd provider-swift && swift build`

## Related
- Permanent coordinator-backed solution: #356

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/357"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784145335&installation_id=133247490&pr_number=357&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F357&signature=1b2050a124433179d8a2ad29d53ab68aaf84d70fef4350f9c52d979b0f9e500a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->