### PR TITLE
Fix provider attestation reconnect state

### DIFF
--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -1085,8 +1085,12 @@ func (r *Registry) RestoreProviderState(p *Provider, rec *store.ProviderRecord) 
 	p.MDAVerified = false
 	p.ACMEVerified = false
 
-	// Restore challenge state
-	if rec.LastChallengeVerified != nil {
+	// Restore challenge state, but never move a fresh live verification
+	// backwards. Registration attestation sets LastChallengeVerified=now before
+	// RestoreProviderState runs; clobbering it with an old persisted timestamp
+	// can make a just-reconnected provider fail the freshness gate until the
+	// first challenge response lands.
+	if rec.LastChallengeVerified != nil && rec.LastChallengeVerified.After(p.LastChallengeVerified) {
 		p.LastChallengeVerified = *rec.LastChallengeVerified
 	}
 	p.FailedChallenges = rec.FailedChallenges

--- a/coordinator/registry/registry_test.go
+++ b/coordinator/registry/registry_test.go
@@ -507,6 +507,44 @@ func TestHeartbeatAccumulatesAcrossRestarts(t *testing.T) {
 	}
 }
 
+func TestRestoreProviderStateKeepsFreshChallengeVerification(t *testing.T) {
+	reg := New(testLogger())
+	p := reg.Register("p1", nil, testRegisterMessage())
+	fresh := time.Now()
+	stale := fresh.Add(-10 * time.Minute)
+	p.SetLastChallengeVerified(fresh)
+
+	reg.RestoreProviderState(p, &store.ProviderRecord{
+		ID:                    "persisted-p1",
+		TrustLevel:            string(TrustHardware),
+		Attested:              true,
+		LastChallengeVerified: &stale,
+	})
+
+	if !p.LastChallengeVerified.Equal(fresh) {
+		t.Fatalf("LastChallengeVerified = %v, want fresh registration value %v", p.LastChallengeVerified, fresh)
+	}
+}
+
+func TestRestoreProviderStateAcceptsNewerChallengeVerification(t *testing.T) {
+	reg := New(testLogger())
+	p := reg.Register("p1", nil, testRegisterMessage())
+	old := time.Now().Add(-10 * time.Minute)
+	newer := old.Add(5 * time.Minute)
+	p.SetLastChallengeVerified(old)
+
+	reg.RestoreProviderState(p, &store.ProviderRecord{
+		ID:                    "persisted-p1",
+		TrustLevel:            string(TrustSelfSigned),
+		Attested:              true,
+		LastChallengeVerified: &newer,
+	})
+
+	if !p.LastChallengeVerified.Equal(newer) {
+		t.Fatalf("LastChallengeVerified = %v, want newer stored value %v", p.LastChallengeVerified, newer)
+	}
+}
+
 func TestHeartbeatUnknownProvider(t *testing.T) {
 	reg := New(testLogger())
 	hb := &protocol.HeartbeatMessage{

--- a/provider-swift/Sources/ProviderCore/Security/AttestationBuilder.swift
+++ b/provider-swift/Sources/ProviderCore/Security/AttestationBuilder.swift
@@ -378,6 +378,30 @@ private func detectOSVersion() -> String {
 /// The coordinator uses this to look up the device in MicroMDM and
 /// independently verify its security posture via MDM SecurityInfo.
 private func detectSerialNumber() -> String? {
+    if let serial = detectSerialNumberFromIOReg() {
+        return serial
+    }
+    return detectSerialNumberFromSystemProfiler()
+}
+
+private func detectSerialNumberFromIOReg() -> String? {
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: "/usr/sbin/ioreg")
+    process.arguments = ["-c", "IOPlatformExpertDevice", "-d", "2"]
+
+    let pipe = Pipe()
+    process.standardOutput = pipe
+    process.standardError = Pipe()
+
+    guard let _ = try? process.run() else { return nil }
+    process.waitUntilExit()
+
+    let data = pipe.fileHandleForReading.readDataToEndOfFile()
+    let output = String(data: data, encoding: .utf8) ?? ""
+    return parseSerialNumberFromIOReg(output)
+}
+
+private func detectSerialNumberFromSystemProfiler() -> String? {
     let process = Process()
     process.executableURL = URL(fileURLWithPath: "/usr/sbin/system_profiler")
     process.arguments = ["SPHardwareDataType"]
@@ -392,6 +416,24 @@ private func detectSerialNumber() -> String? {
     let data = pipe.fileHandleForReading.readDataToEndOfFile()
     let output = String(data: data, encoding: .utf8) ?? ""
 
+    return parseSerialNumberFromSystemProfiler(output)
+}
+
+func parseSerialNumberFromIOReg(_ output: String) -> String? {
+    for line in output.components(separatedBy: "\n") {
+        guard line.contains("IOPlatformSerialNumber") else { continue }
+        let parts = line.split(separator: "\"", omittingEmptySubsequences: false)
+        if parts.count >= 4 {
+            let candidate = String(parts[3]).trimmingCharacters(in: .whitespacesAndNewlines)
+            if !candidate.isEmpty {
+                return candidate
+            }
+        }
+    }
+    return nil
+}
+
+func parseSerialNumberFromSystemProfiler(_ output: String) -> String? {
     for line in output.components(separatedBy: "\n") {
         if line.contains("Serial Number") {
             return line.components(separatedBy: ":").last?

--- a/provider-swift/Tests/ProviderCoreTests/EnrollmentTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/EnrollmentTests.swift
@@ -19,6 +19,29 @@ struct EnrollmentTests {
         #expect(serial.count >= 8, "serial '\(serial)' looks too short")
     }
 
+    @Test("attestation serial parser reads ioreg output")
+    func attestationSerialParserReadsIOReg() {
+        let output = """
+        +-o IOPlatformExpertDevice  <class IOPlatformExpertDevice, id 0x100000100, registered, matched, active, busy 0 (41 ms), retain 39>
+            "IOPlatformSerialNumber" = "WV0NCDC2TX"
+        """
+        #expect(parseSerialNumberFromIOReg(output) == "WV0NCDC2TX")
+    }
+
+    @Test("attestation serial parser reads system_profiler output")
+    func attestationSerialParserReadsSystemProfiler() {
+        let output = """
+            Hardware:
+
+                Hardware Overview:
+
+                  Model Name: Mac Studio
+                  Chip: Apple M3 Ultra
+                  Serial Number (system): WV0NCDC2TX
+        """
+        #expect(parseSerialNumberFromSystemProfiler(output) == "WV0NCDC2TX")
+    }
+
     @Test("EnrollmentError descriptions are stable")
     func enrollmentErrorDescriptions() {
         let cases: [(EnrollmentError, String)] = [


### PR DESCRIPTION
## Summary
- prefer ioreg for provider attestation serial detection, with system_profiler as fallback
- avoid restoring stale persisted LastChallengeVerified over a fresh registration verification
- add Swift parser coverage and coordinator registry regression tests

## Verification
- cd coordinator && go test ./...
- cd provider-swift && swift test --filter EnrollmentTests
- cd provider-swift && swift test (after installing/copying pinned mlx.metallib test prerequisite)
- git diff --check

## Notes
- Current live attestation for WV0NCDC2TX shows hardware/serving on gpt-oss-20b.
- This addresses two concrete failure modes matching the observed incident: transient missing serial and stale restored challenge freshness after reconnect.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/359"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784147745&installation_id=133247490&pr_number=359&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F359&signature=eefdee414da222ccd0c64e7eb9e752de3e1cd407f5c2f807d9509448e08d2254"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->