### PR TITLE
fix(coordinator): return 429 when TTFT estimate exceeds target

### DIFF
--- a/coordinator/api/alias_helpers_test.go
+++ b/coordinator/api/alias_helpers_test.go
@@ -13,7 +13,7 @@ import (
 // applies. Used by alias/routing tests that need routable capacity without a live
 // WebSocket. Version is set to the desired_models feature floor so version-gated
 // fan-out includes it (the nil conn just means an actual send is a no-op error).
-func registerBuildsProvider(srv *Server, id string, builds ...string) {
+func registerBuildsProvider(srv *Server, id string, builds ...string) *registry.Provider {
 	models := make([]protocol.ModelInfo, 0, len(builds))
 	slots := make([]protocol.BackendSlotCapacity, 0, len(builds))
 	for _, b := range builds {
@@ -48,4 +48,5 @@ func registerBuildsProvider(srv *Server, id string, builds ...string) {
 	p.SystemMetrics = protocol.SystemMetrics{MemoryPressure: 0.1, CPUUsage: 0.1, ThermalState: "nominal"}
 	p.BackendCapacity = &protocol.BackendCapacity{TotalMemoryGB: 64, Slots: slots}
 	p.Mu().Unlock()
+	return p
 }

--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -1696,10 +1696,8 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if ttftTooSlow(bestTTFT, hasTTFT) {
-			if fallbackModel, fallbackCandidates, fallbackRejections, fallbackTooLarge, fallbackTTFT, fallbackHasTTFT, switched := s.maybeFallbackAliasTTFT(parsed, publicModel, model, estimatedPromptTokens, requestedMaxTokens, registry.RequestTraits{HasTools: hasTools}, requiresVision, allowedProviderSerials); switched {
+			if fallbackModel, _, _, _, fallbackTTFT, fallbackHasTTFT, switched := s.maybeFallbackAliasTTFT(parsed, publicModel, model, estimatedPromptTokens, requestedMaxTokens, registry.RequestTraits{HasTools: hasTools}, requiresVision, allowedProviderSerials); switched {
 				model = fallbackModel
-				candidateCount, capacityRejections, modelTooLarge = fallbackCandidates, fallbackRejections, fallbackTooLarge
-				bestTTFT, hasTTFT = fallbackTTFT, fallbackHasTTFT
 				if isResponsesAPI {
 					providerParsed, err := responsesRequestToChatCompletions(parsed)
 					if err != nil {
@@ -4190,7 +4188,6 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 		if ttftTooSlow(bestTTFT, hasTTFT) {
 			if fallbackModel, _, _, _, fallbackTTFT, fallbackHasTTFT, switched := s.maybeFallbackAliasTTFT(parsed, publicModel, model, estimatedPromptTokens, requestedMaxTokens, registry.RequestTraits{HasTools: hasTools}, requiresVision, allowedProviderSerials); switched {
 				model = fallbackModel
-				bestTTFT, hasTTFT = fallbackTTFT, fallbackHasTTFT
 			} else {
 				retryModel, retryTTFT := fasterTTFTEstimate(model, bestTTFT, fallbackModel, fallbackTTFT, fallbackHasTTFT)
 				refundReservation()

--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -4249,6 +4249,14 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 		ErrorCh:              make(chan protocol.InferenceErrorMessage, 1),
 	}
 
+	// Public inference routes (not self-route / prefer-owner) enforce the
+	// OpenRouter TTFT ceiling inside the scheduler. This makes the preflight
+	// check authoritative: the router cannot select a provider whose estimated
+	// TTFT is above the threshold.
+	if !policy.enabled && !policy.prefer {
+		pr.MaxTTFTMs = openRouterTTFT429Threshold.Seconds() * 1000.0
+	}
+
 	// refundExtra credits back the provider-specific surcharge that
 	// reserveAdditionalForProvider may have added on top of the base
 	// reservation. Without this, failing after the extra charge leaks
@@ -4312,6 +4320,16 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 		break
 	}
 	if provider == nil {
+		// Providers are available but all exceed the TTFT ceiling. Fail fast
+		// with a retryable 429 rather than queueing for a provider that would
+		// miss the OpenRouter SLA target.
+		if decision.TTFTRejections > 0 {
+			bestTTFT := time.Duration(decision.BestTTFTMs * float64(time.Millisecond))
+			refundReservation()
+			s.writeTTFTTooSlow(w, model, publicModel, bestTTFT)
+			return
+		}
+
 		// No online provider can physically fit this model — queueing/retrying
 		// can't help, so fast-fail with a clear, non-retryable error instead of
 		// blocking for 120s then 503-ing. Mirrors the streaming dispatch path.

--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -242,6 +242,12 @@ func failedProviderVersion(p *registry.Provider) string {
 // queuing for 120s — queueing can't help a model that will never fit.
 const errModelTooLarge = "model too large for any available provider"
 
+// errTTFTTooSlow is the dispatch error returned when providers are available
+// but all of them exceed the per-request TTFT ceiling. Distinct from
+// "no provider available" so the caller returns a retryable 429 instead of
+// queueing for a provider that would miss the OpenRouter SLA target.
+const errTTFTTooSlow = "all available providers exceed the TTFT target"
+
 // consumerModel returns the model name to echo back to the consumer: the public
 // alias they requested when set, otherwise the concrete build id (raw-id
 // requests and any internal caller that didn't populate PublicModel).
@@ -297,24 +303,25 @@ func (s *Server) resolveRequestedModel(parsed map[string]any, rawBody []byte, re
 // routable, but if every desired provider is transiently full and Previous has
 // immediate capacity, route this request to Previous instead of returning a fast
 // 429. Hard constraints and permanent model-too-large failures are handled by the
-// caller and do not use this fallback.
-func (s *Server) maybeFallbackAliasCapacity(parsed map[string]any, publicModel, currentModel string, estimatedPromptTokens, requestedMaxTokens int, traits registry.RequestTraits, requiresVision bool, allowedProviderSerials []string) (string, int, int, int, bool) {
+// caller and do not use this fallback. The TTFT estimate for Previous is also
+// returned so the caller does not need to recompute it.
+func (s *Server) maybeFallbackAliasCapacity(parsed map[string]any, publicModel, currentModel string, estimatedPromptTokens, requestedMaxTokens int, traits registry.RequestTraits, requiresVision bool, allowedProviderSerials []string) (string, int, int, int, time.Duration, bool, bool) {
 	if publicModel == "" || publicModel == currentModel {
-		return currentModel, 0, 0, 0, false
+		return currentModel, 0, 0, 0, 0, false, false
 	}
 	target, ok := s.registry.AliasTarget(publicModel)
 	if !ok || target.Desired != currentModel || target.Previous == "" {
-		return currentModel, 0, 0, 0, false
+		return currentModel, 0, 0, 0, 0, false, false
 	}
 	if !s.registry.IsModelInCatalog(target.Previous) {
-		return currentModel, 0, 0, 0, false
+		return currentModel, 0, 0, 0, 0, false, false
 	}
-	candidates, rejections, tooLarge := s.registry.QuickCapacityCheckForRequest(target.Previous, estimatedPromptTokens, requestedMaxTokens, traits, requiresVision, allowedProviderSerials...)
+	candidates, rejections, tooLarge, bestTTFT, hasTTFT := s.registry.QuickCapacityCheckWithTTFTForRequest(target.Previous, estimatedPromptTokens, requestedMaxTokens, traits, requiresVision, allowedProviderSerials...)
 	if candidates <= 0 {
-		return currentModel, candidates, rejections, tooLarge, false
+		return currentModel, candidates, rejections, tooLarge, bestTTFT, hasTTFT, false
 	}
 	parsed["model"] = target.Previous
-	return target.Previous, candidates, rejections, tooLarge, true
+	return target.Previous, candidates, rejections, tooLarge, bestTTFT, hasTTFT, true
 }
 
 func (s *Server) maybeFallbackAliasTTFT(parsed map[string]any, publicModel, currentModel string, estimatedPromptTokens, requestedMaxTokens int, traits registry.RequestTraits, requiresVision bool, allowedProviderSerials []string) (string, int, int, int, time.Duration, bool, bool) {
@@ -435,6 +442,14 @@ func (s *Server) dispatchOneProvider(
 		Timing:                 timing,
 	}
 
+	// Public inference routes (not self-route / prefer-owner) enforce the
+	// OpenRouter TTFT ceiling inside the scheduler. This makes the preflight
+	// check authoritative: the router cannot select a provider whose estimated
+	// TTFT is above the threshold.
+	if !policy.enabled && !policy.prefer {
+		pr.MaxTTFTMs = openRouterTTFT429Threshold.Seconds() * 1000.0
+	}
+
 	excludeList := func() []string {
 		ids := make([]string, 0, len(excludeProviders))
 		for id := range excludeProviders {
@@ -449,6 +464,12 @@ func (s *Server) dispatchOneProvider(
 		// the caller queue/retry for something that will never load.
 		if decision.CandidateCount == 0 && decision.CapacityRejections == 0 && decision.ModelTooLargeRejections > 0 {
 			return nil, nil, decision, errModelTooLarge, http.StatusServiceUnavailable
+		}
+		// Providers are available but all exceed the TTFT ceiling. Fail fast
+		// with a retryable 429 rather than queueing or routing to a slow
+		// provider.
+		if decision.TTFTRejections > 0 {
+			return nil, nil, decision, errTTFTTooSlow, http.StatusTooManyRequests
 		}
 		return nil, nil, decision, "no provider available", http.StatusServiceUnavailable
 	}
@@ -1636,10 +1657,10 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 		// owner's machine instead (handled below).
 		candidateCount, capacityRejections, modelTooLarge, bestTTFT, hasTTFT := s.registry.QuickCapacityCheckWithTTFTForRequest(model, estimatedPromptTokens, requestedMaxTokens, registry.RequestTraits{HasTools: hasTools}, requiresVision, allowedProviderSerials...)
 		if candidateCount == 0 && capacityRejections > 0 {
-			if fallbackModel, fallbackCandidates, fallbackRejections, fallbackTooLarge, switched := s.maybeFallbackAliasCapacity(parsed, publicModel, model, estimatedPromptTokens, requestedMaxTokens, registry.RequestTraits{HasTools: hasTools}, requiresVision, allowedProviderSerials); switched {
+			if fallbackModel, fallbackCandidates, fallbackRejections, fallbackTooLarge, fallbackTTFT, fallbackHasTTFT, switched := s.maybeFallbackAliasCapacity(parsed, publicModel, model, estimatedPromptTokens, requestedMaxTokens, registry.RequestTraits{HasTools: hasTools}, requiresVision, allowedProviderSerials); switched {
 				model = fallbackModel
 				candidateCount, capacityRejections, modelTooLarge = fallbackCandidates, fallbackRejections, fallbackTooLarge
-				_, _, _, bestTTFT, hasTTFT = s.registry.QuickCapacityCheckWithTTFTForRequest(model, estimatedPromptTokens, requestedMaxTokens, registry.RequestTraits{HasTools: hasTools}, requiresVision, allowedProviderSerials...)
+				bestTTFT, hasTTFT = fallbackTTFT, fallbackHasTTFT
 				if isResponsesAPI {
 					providerParsed, err := responsesRequestToChatCompletions(parsed)
 					if err != nil {
@@ -4146,10 +4167,10 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 	} else {
 		candidateCount, capacityRejections, modelTooLarge, bestTTFT, hasTTFT := s.registry.QuickCapacityCheckWithTTFTForRequest(model, estimatedPromptTokens, requestedMaxTokens, registry.RequestTraits{HasTools: hasTools}, requiresVision, allowedProviderSerials...)
 		if candidateCount == 0 && capacityRejections > 0 {
-			if fallbackModel, fallbackCandidates, fallbackRejections, fallbackTooLarge, switched := s.maybeFallbackAliasCapacity(parsed, publicModel, model, estimatedPromptTokens, requestedMaxTokens, registry.RequestTraits{HasTools: hasTools}, requiresVision, allowedProviderSerials); switched {
+			if fallbackModel, fallbackCandidates, fallbackRejections, fallbackTooLarge, fallbackTTFT, fallbackHasTTFT, switched := s.maybeFallbackAliasCapacity(parsed, publicModel, model, estimatedPromptTokens, requestedMaxTokens, registry.RequestTraits{HasTools: hasTools}, requiresVision, allowedProviderSerials); switched {
 				model = fallbackModel
 				candidateCount, capacityRejections, modelTooLarge = fallbackCandidates, fallbackRejections, fallbackTooLarge
-				_, _, _, bestTTFT, hasTTFT = s.registry.QuickCapacityCheckWithTTFTForRequest(model, estimatedPromptTokens, requestedMaxTokens, registry.RequestTraits{HasTools: hasTools}, requiresVision, allowedProviderSerials...)
+				bestTTFT, hasTTFT = fallbackTTFT, fallbackHasTTFT
 			}
 		}
 		if candidateCount == 0 && capacityRejections == 0 && modelTooLarge > 0 {

--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -88,6 +88,11 @@ const (
 	// block. Using context.Background() unbounded here risks hanging the HTTP
 	// handler goroutine when a WebSocket is half-dead.
 	cancelWriteTimeout = 2 * time.Second
+
+	// openRouterTTFT429Threshold is the hard admission target for external
+	// routers: if the fastest eligible provider is already estimated to miss a
+	// 10s TTFT, return a retryable 429 instead of letting the caller time out.
+	openRouterTTFT429Threshold = 10 * time.Second
 )
 
 var thinkBlockPattern = regexp.MustCompile(`(?is)<think>(.*?)</think>\s*`)
@@ -310,6 +315,60 @@ func (s *Server) maybeFallbackAliasCapacity(parsed map[string]any, publicModel, 
 	}
 	parsed["model"] = target.Previous
 	return target.Previous, candidates, rejections, tooLarge, true
+}
+
+func (s *Server) maybeFallbackAliasTTFT(parsed map[string]any, publicModel, currentModel string, estimatedPromptTokens, requestedMaxTokens int, traits registry.RequestTraits, requiresVision bool, allowedProviderSerials []string) (string, int, int, int, time.Duration, bool, bool) {
+	if publicModel == "" || publicModel == currentModel {
+		return currentModel, 0, 0, 0, 0, false, false
+	}
+	target, ok := s.registry.AliasTarget(publicModel)
+	if !ok || target.Desired != currentModel || target.Previous == "" {
+		return currentModel, 0, 0, 0, 0, false, false
+	}
+	if !s.registry.IsModelInCatalog(target.Previous) {
+		return currentModel, 0, 0, 0, 0, false, false
+	}
+	candidates, rejections, tooLarge, bestTTFT, hasTTFT := s.registry.QuickCapacityCheckWithTTFTForRequest(target.Previous, estimatedPromptTokens, requestedMaxTokens, traits, requiresVision, allowedProviderSerials...)
+	if candidates <= 0 || ttftTooSlow(bestTTFT, hasTTFT) {
+		return target.Previous, candidates, rejections, tooLarge, bestTTFT, hasTTFT, false
+	}
+	parsed["model"] = target.Previous
+	return target.Previous, candidates, rejections, tooLarge, bestTTFT, hasTTFT, true
+}
+
+func ttftTooSlow(bestTTFT time.Duration, hasTTFT bool) bool {
+	return hasTTFT && bestTTFT > openRouterTTFT429Threshold
+}
+
+func fasterTTFTEstimate(primaryModel string, primary time.Duration, alternateModel string, alternate time.Duration, alternateOK bool) (string, time.Duration) {
+	if alternateOK && alternate < primary {
+		return alternateModel, alternate
+	}
+	return primaryModel, primary
+}
+
+func (s *Server) estimateTTFTRetryAfter(model string, bestTTFT time.Duration) int {
+	overage := bestTTFT - openRouterTTFT429Threshold
+	seconds := int(math.Ceil(overage.Seconds()))
+	if base := s.estimateRetryAfter(model); seconds < base {
+		seconds = base
+	}
+	if seconds < 2 {
+		seconds = 2
+	}
+	if seconds > 30 {
+		seconds = 30
+	}
+	return seconds
+}
+
+func (s *Server) writeTTFTTooSlow(w http.ResponseWriter, model, publicModel string, bestTTFT time.Duration) {
+	retryAfter := s.estimateTTFTRetryAfter(model, bestTTFT)
+	w.Header().Set("Retry-After", strconv.Itoa(retryAfter))
+	s.ddIncr("routing.decisions", []string{"model:" + model, "model_type:" + s.registry.ModelType(model), "outcome:ttft_429"})
+	writeJSON(w, http.StatusTooManyRequests, errorResponse("rate_limit_exceeded",
+		fmt.Sprintf("all providers for model %q are above the %ds TTFT target (best estimate %.1fs); retry after %ds", publicModel, int(openRouterTTFT429Threshold.Seconds()), bestTTFT.Seconds(), retryAfter),
+		withCode("rate_limit_exceeded")))
 }
 
 // dispatchOneProvider encrypts and sends an inference request to a single
@@ -1575,11 +1634,12 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 		// 503 which counts as downtime. Fast 429s also preserve our TTFT
 		// metrics. Self-route skips this fleet-wide gate — it queues on the
 		// owner's machine instead (handled below).
-		candidateCount, capacityRejections, modelTooLarge := s.registry.QuickCapacityCheckForRequest(model, estimatedPromptTokens, requestedMaxTokens, registry.RequestTraits{HasTools: hasTools}, requiresVision, allowedProviderSerials...)
+		candidateCount, capacityRejections, modelTooLarge, bestTTFT, hasTTFT := s.registry.QuickCapacityCheckWithTTFTForRequest(model, estimatedPromptTokens, requestedMaxTokens, registry.RequestTraits{HasTools: hasTools}, requiresVision, allowedProviderSerials...)
 		if candidateCount == 0 && capacityRejections > 0 {
 			if fallbackModel, fallbackCandidates, fallbackRejections, fallbackTooLarge, switched := s.maybeFallbackAliasCapacity(parsed, publicModel, model, estimatedPromptTokens, requestedMaxTokens, registry.RequestTraits{HasTools: hasTools}, requiresVision, allowedProviderSerials); switched {
 				model = fallbackModel
 				candidateCount, capacityRejections, modelTooLarge = fallbackCandidates, fallbackRejections, fallbackTooLarge
+				_, _, _, bestTTFT, hasTTFT = s.registry.QuickCapacityCheckWithTTFTForRequest(model, estimatedPromptTokens, requestedMaxTokens, registry.RequestTraits{HasTools: hasTools}, requiresVision, allowedProviderSerials...)
 				if isResponsesAPI {
 					providerParsed, err := responsesRequestToChatCompletions(parsed)
 					if err != nil {
@@ -1634,6 +1694,29 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 				fmt.Sprintf("no provider for model %q is available right now — retry after %ds", publicModel, retryAfter),
 				withCode("model_unavailable")))
 			return
+		}
+		if ttftTooSlow(bestTTFT, hasTTFT) {
+			if fallbackModel, fallbackCandidates, fallbackRejections, fallbackTooLarge, fallbackTTFT, fallbackHasTTFT, switched := s.maybeFallbackAliasTTFT(parsed, publicModel, model, estimatedPromptTokens, requestedMaxTokens, registry.RequestTraits{HasTools: hasTools}, requiresVision, allowedProviderSerials); switched {
+				model = fallbackModel
+				candidateCount, capacityRejections, modelTooLarge = fallbackCandidates, fallbackRejections, fallbackTooLarge
+				bestTTFT, hasTTFT = fallbackTTFT, fallbackHasTTFT
+				if isResponsesAPI {
+					providerParsed, err := responsesRequestToChatCompletions(parsed)
+					if err != nil {
+						refundReservation()
+						writeJSON(w, http.StatusBadRequest, errorResponse("invalid_request_error", err.Error()))
+						return
+					}
+					rawBody, _ = marshalForwardBody(providerParsed)
+				} else {
+					rawBody, _ = marshalForwardBody(parsed)
+				}
+			} else {
+				retryModel, retryTTFT := fasterTTFTEstimate(model, bestTTFT, fallbackModel, fallbackTTFT, fallbackHasTTFT)
+				refundReservation()
+				s.writeTTFTTooSlow(w, retryModel, publicModel, retryTTFT)
+				return
+			}
 		}
 	}
 
@@ -4063,11 +4146,12 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 		// Prefer mode skips the public fleet pre-flight (no owner-trust
 		// relaxation there); owned-first dispatch + paid fallback + queue gate it.
 	} else {
-		candidateCount, capacityRejections, modelTooLarge := s.registry.QuickCapacityCheckForRequest(model, estimatedPromptTokens, requestedMaxTokens, registry.RequestTraits{HasTools: hasTools}, requiresVision, allowedProviderSerials...)
+		candidateCount, capacityRejections, modelTooLarge, bestTTFT, hasTTFT := s.registry.QuickCapacityCheckWithTTFTForRequest(model, estimatedPromptTokens, requestedMaxTokens, registry.RequestTraits{HasTools: hasTools}, requiresVision, allowedProviderSerials...)
 		if candidateCount == 0 && capacityRejections > 0 {
 			if fallbackModel, fallbackCandidates, fallbackRejections, fallbackTooLarge, switched := s.maybeFallbackAliasCapacity(parsed, publicModel, model, estimatedPromptTokens, requestedMaxTokens, registry.RequestTraits{HasTools: hasTools}, requiresVision, allowedProviderSerials); switched {
 				model = fallbackModel
 				candidateCount, capacityRejections, modelTooLarge = fallbackCandidates, fallbackRejections, fallbackTooLarge
+				_, _, _, bestTTFT, hasTTFT = s.registry.QuickCapacityCheckWithTTFTForRequest(model, estimatedPromptTokens, requestedMaxTokens, registry.RequestTraits{HasTools: hasTools}, requiresVision, allowedProviderSerials...)
 			}
 		}
 		if candidateCount == 0 && capacityRejections == 0 && modelTooLarge > 0 {
@@ -4102,6 +4186,17 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 				fmt.Sprintf("no provider for model %q is available right now — retry after %ds", publicModel, retryAfter),
 				withCode("model_unavailable")))
 			return
+		}
+		if ttftTooSlow(bestTTFT, hasTTFT) {
+			if fallbackModel, _, _, _, fallbackTTFT, fallbackHasTTFT, switched := s.maybeFallbackAliasTTFT(parsed, publicModel, model, estimatedPromptTokens, requestedMaxTokens, registry.RequestTraits{HasTools: hasTools}, requiresVision, allowedProviderSerials); switched {
+				model = fallbackModel
+				bestTTFT, hasTTFT = fallbackTTFT, fallbackHasTTFT
+			} else {
+				retryModel, retryTTFT := fasterTTFTEstimate(model, bestTTFT, fallbackModel, fallbackTTFT, fallbackHasTTFT)
+				refundReservation()
+				s.writeTTFTTooSlow(w, retryModel, publicModel, retryTTFT)
+				return
+			}
 		}
 	}
 

--- a/coordinator/api/consumer_test.go
+++ b/coordinator/api/consumer_test.go
@@ -1979,3 +1979,156 @@ func TestWriteServiceUnavailableSetsRetryAfter(t *testing.T) {
 		t.Errorf("code = %q, want service_unavailable", body.Error.Code)
 	}
 }
+
+func TestWriteTTFTTooSlowSets429RetryAfter(t *testing.T) {
+	srv, _ := testServer(t)
+	if got := srv.estimateTTFTRetryAfter("no-queue", 13*time.Second); got != 3 {
+		t.Fatalf("Retry-After without queue = %d, want 3s over target", got)
+	}
+
+	model := "slow-ttft-model"
+	for i := 0; i < 5; i++ {
+		if err := srv.registry.Queue().Enqueue(&registry.QueuedRequest{RequestID: "queued-" + strconv.Itoa(i), Model: model}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	w := httptest.NewRecorder()
+	srv.writeTTFTTooSlow(w, model, model, 11*time.Second)
+
+	if w.Code != http.StatusTooManyRequests {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusTooManyRequests)
+	}
+	if got := w.Header().Get("Retry-After"); got != "15" {
+		t.Fatalf("Retry-After = %q, want 15 from existing queue-depth estimate", got)
+	}
+	var body struct {
+		Error struct {
+			Code    string `json:"code"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if body.Error.Code != "rate_limit_exceeded" {
+		t.Fatalf("code = %q, want rate_limit_exceeded", body.Error.Code)
+	}
+	if !strings.Contains(body.Error.Message, "10s TTFT target") {
+		t.Fatalf("message = %q, want TTFT target detail", body.Error.Message)
+	}
+}
+
+func TestTTFTAdmission429ForInferenceEndpoints(t *testing.T) {
+	srv, _ := testServer(t)
+	model := "route-slow-ttft-model"
+	srv.registry.SetModelCatalog([]registry.CatalogEntry{{ID: model, SizeGB: 1, MinRAMGB: 24}})
+	p := registerBuildsProvider(srv, "route-slow-provider", model)
+	p.Mu().Lock()
+	p.DecodeTPS = 100
+	p.PrefillTPS = 400
+	p.BackendCapacity.Slots[0].MaxTokensPotential = 2_000
+	p.Mu().Unlock()
+
+	cases := []struct {
+		name string
+		path string
+		body string
+	}{
+		{
+			name: "responses-style chat completions",
+			path: "/v1/chat/completions",
+			body: `{"model":"MODEL","input":"hello","max_output_tokens":128}`,
+		},
+		{
+			name: "completions",
+			path: "/v1/completions",
+			body: `{"model":"MODEL","prompt":"hello","max_tokens":128}`,
+		},
+		{
+			name: "anthropic messages",
+			path: "/v1/messages",
+			body: `{"model":"MODEL","messages":[{"role":"user","content":"hello"}],"max_tokens":128}`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, tc.path, strings.NewReader(strings.ReplaceAll(tc.body, "MODEL", model)))
+			req.Header.Set("Authorization", "Bearer test-key")
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+			srv.Handler().ServeHTTP(w, req)
+
+			if w.Code != http.StatusTooManyRequests {
+				t.Fatalf("status = %d, want %d; body = %s", w.Code, http.StatusTooManyRequests, w.Body.String())
+			}
+			if got := w.Header().Get("Retry-After"); got == "" {
+				t.Fatal("Retry-After header missing")
+			}
+			var body struct {
+				Error struct {
+					Code string `json:"code"`
+				} `json:"error"`
+			}
+			if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if body.Error.Code != "rate_limit_exceeded" {
+				t.Fatalf("code = %q, want rate_limit_exceeded", body.Error.Code)
+			}
+		})
+	}
+}
+
+func TestMaybeFallbackAliasTTFTSwitchesToPrevious(t *testing.T) {
+	srv, _ := testServer(t)
+	publicModel := "public-ttft-alias"
+	desired := "desired-ttft-build"
+	previous := "previous-ttft-build"
+	srv.registry.SetModelCatalog([]registry.CatalogEntry{
+		{ID: desired, SizeGB: 1, MinRAMGB: 24},
+		{ID: previous, SizeGB: 1, MinRAMGB: 24},
+	})
+	srv.registry.SetModelAliases(map[string]registry.AliasTarget{
+		publicModel: {Desired: desired, Previous: previous},
+	})
+
+	desiredProvider := registerBuildsProvider(srv, "desired-slow", desired)
+	desiredProvider.Mu().Lock()
+	desiredProvider.DecodeTPS = 100
+	desiredProvider.PrefillTPS = 400
+	desiredProvider.BackendCapacity.Slots[0].MaxTokensPotential = 2_000
+	desiredProvider.Mu().Unlock()
+
+	previousProvider := registerBuildsProvider(srv, "previous-fast", previous)
+	previousProvider.Mu().Lock()
+	previousProvider.DecodeTPS = 100
+	previousProvider.PrefillTPS = 400
+	previousProvider.Mu().Unlock()
+
+	parsed := map[string]any{"model": desired}
+	fallbackModel, candidates, rejections, tooLarge, bestTTFT, hasTTFT, switched := srv.maybeFallbackAliasTTFT(
+		parsed,
+		publicModel,
+		desired,
+		100,
+		128,
+		registry.RequestTraits{},
+		false,
+		nil,
+	)
+
+	if !switched {
+		t.Fatalf("switched = false, candidates=%d rejections=%d tooLarge=%d bestTTFT=%v has=%v", candidates, rejections, tooLarge, bestTTFT, hasTTFT)
+	}
+	if fallbackModel != previous || parsed["model"] != previous {
+		t.Fatalf("fallback model = %q parsed=%v, want previous %q", fallbackModel, parsed["model"], previous)
+	}
+	if candidates != 1 || rejections != 0 || tooLarge != 0 {
+		t.Fatalf("capacity = (%d,%d,%d), want (1,0,0)", candidates, rejections, tooLarge)
+	}
+	if !hasTTFT || bestTTFT > openRouterTTFT429Threshold {
+		t.Fatalf("bestTTFT = %v has=%v, want within threshold", bestTTFT, hasTTFT)
+	}
+}

--- a/coordinator/api/dispatch.go
+++ b/coordinator/api/dispatch.go
@@ -134,6 +134,16 @@ func (d *dispatchState) traits() registry.RequestTraits {
 	return registry.RequestTraits{HasTools: d.hasTools, AvoidVersion: d.lastFailedVersion}
 }
 
+// queueMaxTTFTMs returns the TTFT ceiling for queued requests. Public routes
+// inherit the OpenRouter 10s target; self-route / prefer-owner paths are not
+// subject to the public SLA ceiling.
+func queueMaxTTFTMs(policy selfRoutePolicy) float64 {
+	if policy.enabled || policy.prefer {
+		return 0
+	}
+	return openRouterTTFT429Threshold.Seconds() * 1000.0
+}
+
 // dispatchPrimary selects (and, when no idle provider exists on the first
 // attempt, queues + dispatches) the primary provider for this attempt. It is the
 // extraction of the original loop's dispatch-primary block (incl. the queue path).
@@ -146,7 +156,8 @@ func (d *dispatchState) dispatchPrimary() dispatchOutcome {
 	// Dispatch the primary provider.
 	var dispatchErr string
 	var dispatchErrCode int
-	d.provider, d.pr, _, dispatchErr, dispatchErrCode = s.dispatchOneProvider(
+	var decision registry.RoutingDecision
+	d.provider, d.pr, decision, dispatchErr, dispatchErrCode = s.dispatchOneProvider(
 		r, d.model, d.publicModel, d.rawBody, d.consumerKey, d.consumerLocation, d.reservedMicroUSD,
 		d.estimatedPromptTokens, d.requestedMaxTokens, d.tokenAdmission, d.requiresVision,
 		d.traits(),
@@ -161,6 +172,23 @@ func (d *dispatchState) dispatchPrimary() dispatchOutcome {
 			d.lastErr = dispatchErr
 			d.lastErrCode = dispatchErrCode
 			return outcomeFailFast
+		}
+
+		// Providers are available but all exceed the TTFT ceiling. On the
+		// first attempt, fail fast with a retryable 429 instead of queueing
+		// for a provider that would miss the OpenRouter SLA target. On retry
+		// attempts, fall through to normal retry logic so we don't abort an
+		// in-flight stream mid-way.
+		if dispatchErr == errTTFTTooSlow && attempt == 0 {
+			bestTTFT := time.Duration(decision.BestTTFTMs * float64(time.Millisecond))
+			retryAfter := s.estimateTTFTRetryAfter(d.model, bestTTFT)
+			w.Header().Set("Retry-After", strconv.Itoa(retryAfter))
+			d.refundReservation()
+			s.ddIncr("routing.decisions", []string{"model:" + d.model, "model_type:" + s.registry.ModelType(d.model), "outcome:ttft_429"})
+			writeJSON(w, http.StatusTooManyRequests, errorResponse("rate_limit_exceeded",
+				fmt.Sprintf("all providers for model %q are above the %ds TTFT target (best estimate %.1fs); retry after %ds", d.publicModel, int(openRouterTTFT429Threshold.Seconds()), bestTTFT.Seconds(), retryAfter),
+				withCode("rate_limit_exceeded")))
+			return outcomeResponseWritten
 		}
 
 		// dispatchOneProvider may have found a provider but rejected it
@@ -213,6 +241,7 @@ func (d *dispatchState) dispatchPrimary() dispatchOutcome {
 			PreferOwner:            d.policy.prefer,
 			OwnerAccountID:         d.policy.ownerAccountID,
 			FreeSelfRoute:          d.policy.enabled,
+			MaxTTFTMs:              queueMaxTTFTMs(d.policy),
 			AcceptedCh:             make(chan struct{}, 1),
 			ChunkCh:                make(chan string, chunkBufferSize),
 			CompleteCh:             make(chan protocol.UsageInfo, 1),

--- a/coordinator/api/model_alias_handlers_test.go
+++ b/coordinator/api/model_alias_handlers_test.go
@@ -280,7 +280,7 @@ func TestAliasCapacityFallbackUsesPreviousWhenDesiredFull(t *testing.T) {
 		"model":    aliasQAT,
 		"messages": []any{map[string]any{"role": "user", "content": "hi"}},
 	}
-	fallback, _, _, _, switched := srv.maybeFallbackAliasCapacity(parsed, "gemma-4-26b", aliasQAT, 10, 128, registry.RequestTraits{}, false, nil)
+	fallback, _, _, _, _, _, switched := srv.maybeFallbackAliasCapacity(parsed, "gemma-4-26b", aliasQAT, 10, 128, registry.RequestTraits{}, false, nil)
 	if !switched || fallback != aliasFP8 {
 		t.Fatalf("fallback = %q switched=%v, want previous %q", fallback, switched, aliasFP8)
 	}

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -3037,18 +3037,43 @@ func (r *Registry) Disconnect(id string) {
 		return
 	}
 
-	// Close all pending request channels so consumers get errors.
+	// Close all pending request channels so consumers get errors. Pending
+	// requests created by tests may leave these channels nil, and consumer
+	// goroutines may have already closed them on a successful/error path. Use
+	// non-nil checks and recover so a single bad request cannot hang or panic
+	// the disconnect cleanup.
 	p.mu.Lock()
 	for reqID, pr := range p.pendingReqs {
-		pr.ErrorCh <- protocol.InferenceErrorMessage{
-			Type:       protocol.TypeInferenceError,
-			RequestID:  reqID,
-			Error:      "provider disconnected",
-			StatusCode: 502,
+		if pr == nil {
+			continue
 		}
-		close(pr.ChunkCh)
-		close(pr.CompleteCh)
-		close(pr.ErrorCh)
+		if pr.ErrorCh != nil {
+			func() {
+				defer func() { recover() }()
+				pr.ErrorCh <- protocol.InferenceErrorMessage{
+					Type:       protocol.TypeInferenceError,
+					RequestID:  reqID,
+					Error:      "provider disconnected",
+					StatusCode: 502,
+				}
+			}()
+			func() {
+				defer func() { recover() }()
+				close(pr.ErrorCh)
+			}()
+		}
+		if pr.ChunkCh != nil {
+			func() {
+				defer func() { recover() }()
+				close(pr.ChunkCh)
+			}()
+		}
+		if pr.CompleteCh != nil {
+			func() {
+				defer func() { recover() }()
+				close(pr.CompleteCh)
+			}()
+		}
 	}
 	p.pendingReqs = make(map[string]*PendingRequest)
 	p.mu.Unlock()

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -139,6 +139,11 @@ type PendingRequest struct {
 	// RequestedMaxTokens is the consumer's requested output budget (or a
 	// sensible default when omitted). It is used for backlog estimation.
 	RequestedMaxTokens int
+	// MaxTTFTMs is an optional per-request TTFT ceiling in milliseconds.
+	// When > 0, the scheduler only selects providers whose estimated TTFT is
+	// <= MaxTTFTMs. Used by public inference routes to honor the OpenRouter
+	// 10s TTFT target. Self-route / prefer-owner requests leave this at 0.
+	MaxTTFTMs float64
 	// CacheAffinityKey is SHA256(prompt_cache_key) from the request body. Empty
 	// means no cache-affinity routing. It is scoped again by account and model in
 	// the registry tracker and is never persisted.

--- a/coordinator/registry/scheduler.go
+++ b/coordinator/registry/scheduler.go
@@ -1104,14 +1104,20 @@ func (r *Registry) providerCanAdmitLocked(p *Provider, model string, traits Requ
 //     a model that will never fit (the client would retry forever) — it should
 //     surface model_too_large / 503 instead.
 func (r *Registry) QuickCapacityCheck(model string, estimatedPromptTokens, requestedMaxTokens int, traits RequestTraits, allowedSerials ...string) (candidateCount, capacityRejections, modelTooLarge int) {
-	return r.quickCapacityCheck(model, estimatedPromptTokens, requestedMaxTokens, traits, false, allowedSerials...)
+	candidateCount, capacityRejections, modelTooLarge, _, _ = r.quickCapacityCheck(model, estimatedPromptTokens, requestedMaxTokens, traits, false, allowedSerials...)
+	return candidateCount, capacityRejections, modelTooLarge
 }
 
 func (r *Registry) QuickCapacityCheckForRequest(model string, estimatedPromptTokens, requestedMaxTokens int, traits RequestTraits, requiresVision bool, allowedSerials ...string) (candidateCount, capacityRejections, modelTooLarge int) {
+	candidateCount, capacityRejections, modelTooLarge, _, _ = r.quickCapacityCheck(model, estimatedPromptTokens, requestedMaxTokens, traits, requiresVision, allowedSerials...)
+	return candidateCount, capacityRejections, modelTooLarge
+}
+
+func (r *Registry) QuickCapacityCheckWithTTFTForRequest(model string, estimatedPromptTokens, requestedMaxTokens int, traits RequestTraits, requiresVision bool, allowedSerials ...string) (candidateCount, capacityRejections, modelTooLarge int, bestTTFT time.Duration, hasTTFT bool) {
 	return r.quickCapacityCheck(model, estimatedPromptTokens, requestedMaxTokens, traits, requiresVision, allowedSerials...)
 }
 
-func (r *Registry) quickCapacityCheck(model string, estimatedPromptTokens, requestedMaxTokens int, traits RequestTraits, requiresVision bool, allowedSerials ...string) (candidateCount, capacityRejections, modelTooLarge int) {
+func (r *Registry) quickCapacityCheck(model string, estimatedPromptTokens, requestedMaxTokens int, traits RequestTraits, requiresVision bool, allowedSerials ...string) (candidateCount, capacityRejections, modelTooLarge int, bestTTFT time.Duration, hasTTFT bool) {
 	// Use a dummy PendingRequest with the caller's actual token estimates
 	// for the admission gate (freeMemoryAdmits).
 	if estimatedPromptTokens <= 0 {
@@ -1176,6 +1182,9 @@ func (r *Registry) quickCapacityCheck(model string, estimatedPromptTokens, reque
 			model:         model,
 			slotState:     "unknown",
 			totalPending:  p.pendingCount(),
+			systemMetrics: p.SystemMetrics,
+			decodeTPS:     resolvedDecodeTPS(p),
+			prefillTPS:    resolvedPrefillTPS(p),
 			totalMemoryGB: float64(p.Hardware.MemoryGB),
 			modelSizeGB:   r.catalogSizeGBLocked(model),
 			minRAMGb:      r.catalogMinRAMGbLocked(model),
@@ -1197,6 +1206,9 @@ func (r *Registry) quickCapacityCheck(model string, estimatedPromptTokens, reque
 					continue
 				}
 				snap.slotState = slot.State
+				snap.backendRunning = int(slot.NumRunning)
+				snap.backendWaiting = int(slot.NumWaiting)
+				snap.observedDecodeTPS = slot.ObservedDecodeTPS
 				snap.activeTokenBudgetUsed = slot.ActiveTokenBudgetUsed
 				snap.activeTokenBudgetMax = slot.ActiveTokenBudgetMax
 				snap.queuedTokenBudget = slot.QueuedTokenBudget
@@ -1206,6 +1218,7 @@ func (r *Registry) quickCapacityCheck(model string, estimatedPromptTokens, reque
 		}
 		snap.modelLoaded = slotStateModelLoaded(snap.slotState)
 		snap.availableOnDisk = !snap.modelLoaded
+		snap.fleetMedianTPS = r.tpsRegistry.Median(model, p.Hardware.ChipFamily)
 
 		p.mu.Unlock()
 
@@ -1231,8 +1244,58 @@ func (r *Registry) quickCapacityCheck(model string, estimatedPromptTokens, reque
 		}
 
 		candidateCount++
+		ttft := estimatedTTFTFromSnapshot(snap, estimatedPromptTokens, requestedMaxTokens)
+		if !hasTTFT || ttft < bestTTFT {
+			bestTTFT = ttft
+			hasTTFT = true
+		}
 	}
-	return candidateCount, capacityRejections, modelTooLarge
+	return candidateCount, capacityRejections, modelTooLarge, bestTTFT, hasTTFT
+}
+
+func estimatedTTFTFromSnapshot(snap routingSnapshot, reqPromptTokens, reqMaxTokens int) time.Duration {
+	statePenalty, _ := slotStatePenalty(snap.slotState)
+	if reqPromptTokens < 0 {
+		reqPromptTokens = 0
+	}
+	if reqMaxTokens <= 0 {
+		reqMaxTokens = defaultRequestedMaxTokens
+	}
+	prefillTPS := snap.prefillTPS
+	if prefillTPS <= 0 {
+		prefillTPS = 1.0
+	}
+	effectiveTPS := resolveEffectiveTPS(snap)
+	if effectiveTPS <= 0 {
+		effectiveTPS = 1.0
+	}
+
+	var backlogMs float64
+	if snap.activeTokenBudgetMax > 0 {
+		tokensAhead := float64(snap.activeTokenBudgetUsed) + float64(snap.queuedTokenBudget)
+		coordinatorExtra := float64(snap.pendingMaxTokens) - float64(committedTokenBudget(snap))
+		if coordinatorExtra > 0 {
+			tokensAhead += coordinatorExtra
+		}
+		backlogMs = tokensAhead / effectiveTPS * 1000.0
+	} else {
+		runningBacklogTokens := float64(snap.maxTokensPotential)
+		if runningBacklogTokens <= 0 && snap.backendRunning > 0 {
+			runningBacklogTokens = float64(snap.backendRunning * reqMaxTokens)
+		}
+		waitingBacklogTokens := float64(snap.backendWaiting * reqMaxTokens)
+		unaccountedPendingTokens := float64(snap.pendingMaxTokens) - runningBacklogTokens - waitingBacklogTokens
+		if unaccountedPendingTokens < 0 {
+			unaccountedPendingTokens = 0
+		}
+		backlogMs = (runningBacklogTokens + waitingBacklogTokens + unaccountedPendingTokens) / effectiveTPS * 1000.0
+	}
+
+	ttftMs := statePenalty + backlogMs + float64(reqPromptTokens)/prefillTPS*1000.0
+	if ttftMs <= 0 || math.IsNaN(ttftMs) || math.IsInf(ttftMs, 0) {
+		return 0
+	}
+	return time.Duration(ttftMs * float64(time.Millisecond))
 }
 
 // DrainQueuedRequestsForModel attempts to assign queued requests for a

--- a/coordinator/registry/scheduler.go
+++ b/coordinator/registry/scheduler.go
@@ -90,6 +90,7 @@ type routingSnapshot struct {
 	activeTokenBudgetMax  int64
 	queuedTokenBudget     int64
 	fleetMedianTPS        float64
+	hasBackendCapacity    bool // provider reports BackendCapacity; TTFT estimates are reliable
 }
 
 type routingCandidate struct {
@@ -273,6 +274,8 @@ func (r *Registry) ReserveProviderEx(model string, pr *PendingRequest, excludeID
 			CapacityRejections:      capacityRejections,
 			ModelTooLargeRejections: tooLargeRejections,
 			VisionRejections:        visionRejections,
+			TTFTRejections:          ttftRejections,
+			BestTTFTMs:              bestTTFTMs,
 		}
 	}
 
@@ -403,18 +406,22 @@ func (r *Registry) selectBestCandidateLockedFull(model string, pr *PendingReques
 			continue
 		}
 
-		// Track the best TTFT seen among providers that passed all structural
-		// and capacity gates. Even if this candidate is over the ceiling, the
-		// value is used for Retry-After on the TTFT 429 path.
-		if !enforceTTFT || candidate.breakdown.TTFTMs < bestTTFTMs || bestTTFTMs == 0 {
+		// Track the best reliable TTFT seen among providers that passed all
+		// structural and capacity gates. Even if this candidate is over the
+		// ceiling, the value is used for Retry-After on the TTFT 429 path.
+		// Providers without BackendCapacity do not contribute a reliable TTFT
+		// estimate, so they are skipped here.
+		if snap.hasBackendCapacity && (candidate.breakdown.TTFTMs < bestTTFTMs || bestTTFTMs == 0) {
 			bestTTFTMs = candidate.breakdown.TTFTMs
 		}
 
 		// Enforce the per-request TTFT ceiling for public inference routes.
 		// Providers above the threshold are counted as TTFT rejections and
 		// excluded from cost-based selection so the router cannot pick a
-		// provider that misses the OpenRouter SLA target.
-		if enforceTTFT && candidate.breakdown.TTFTMs > pr.MaxTTFTMs {
+		// provider that misses the OpenRouter SLA target. Providers without
+		// BackendCapacity have no reliable TTFT estimate, so the ceiling is
+		// not enforced on them (matching the preflight behavior).
+		if enforceTTFT && snap.hasBackendCapacity && candidate.breakdown.TTFTMs > pr.MaxTTFTMs {
 			ttftRejections++
 			continue
 		}
@@ -749,6 +756,7 @@ func (r *Registry) snapshotProviderLocked(p *Provider, model string, traits Requ
 		snap.pendingMaxTokens += pendingTokenBudget(pr)
 	}
 	snap.hasHeadroom = p.hasConcurrencyHeadroomForModelLocked(model)
+	snap.hasBackendCapacity = p.BackendCapacity != nil
 
 	if p.BackendCapacity != nil {
 		snap.gpuMemoryActiveGB = p.BackendCapacity.GPUMemoryActiveGB
@@ -936,12 +944,10 @@ func (r *Registry) buildCandidateWithReason(snap routingSnapshot, pr *PendingReq
 
 	// Estimated time-to-first-token for this candidate. Used for the
 	// OpenRouter TTFT ceiling: public routes only select providers whose
-	// estimated TTFT is within the per-request threshold.
-	prefillTPS := snap.prefillTPS
-	if prefillTPS <= 0 {
-		prefillTPS = 1.0
-	}
-	ttftMs := statePenalty + backlogMs + float64(reqPrompt)/prefillTPS*1000.0
+	// estimated TTFT is within the per-request threshold. Providers without
+	// BackendCapacity get 0 (unreliable estimate) and are not rejected by the
+	// ceiling, matching the preflight behavior.
+	ttftMs := ttftMsFromSnapshot(snap, reqPrompt, reqMax)
 	if ttftMs <= 0 || math.IsNaN(ttftMs) || math.IsInf(ttftMs, 0) {
 		ttftMs = 0
 	}
@@ -1228,16 +1234,17 @@ func (r *Registry) quickCapacityCheck(model string, estimatedPromptTokens, reque
 
 		// Build a snapshot for the admission gate (slot state + free memory).
 		snap := routingSnapshot{
-			provider:      p,
-			model:         model,
-			slotState:     "unknown",
-			totalPending:  p.pendingCount(),
-			systemMetrics: p.SystemMetrics,
-			decodeTPS:     resolvedDecodeTPS(p),
-			prefillTPS:    resolvedPrefillTPS(p),
-			totalMemoryGB: float64(p.Hardware.MemoryGB),
-			modelSizeGB:   r.catalogSizeGBLocked(model),
-			minRAMGb:      r.catalogMinRAMGbLocked(model),
+			provider:           p,
+			model:              model,
+			slotState:          "unknown",
+			totalPending:       p.pendingCount(),
+			systemMetrics:      p.SystemMetrics,
+			decodeTPS:          resolvedDecodeTPS(p),
+			prefillTPS:         resolvedPrefillTPS(p),
+			totalMemoryGB:      float64(p.Hardware.MemoryGB),
+			modelSizeGB:        r.catalogSizeGBLocked(model),
+			minRAMGb:           r.catalogMinRAMGbLocked(model),
+			hasBackendCapacity: p.BackendCapacity != nil,
 		}
 		for _, pending := range p.pendingReqs {
 			if pending.Model != model {
@@ -1246,8 +1253,7 @@ func (r *Registry) quickCapacityCheck(model string, estimatedPromptTokens, reque
 			snap.pendingForModel++
 			snap.pendingMaxTokens += pendingTokenBudget(pending)
 		}
-		hasBackendCapacity := p.BackendCapacity != nil
-		if p.BackendCapacity != nil {
+		if snap.hasBackendCapacity {
 			snap.gpuMemoryActiveGB = p.BackendCapacity.GPUMemoryActiveGB
 			if p.BackendCapacity.TotalMemoryGB > 0 {
 				snap.totalMemoryGB = p.BackendCapacity.TotalMemoryGB
@@ -1295,7 +1301,7 @@ func (r *Registry) quickCapacityCheck(model string, estimatedPromptTokens, reque
 		}
 
 		candidateCount++
-		if hasBackendCapacity {
+		if snap.hasBackendCapacity {
 			ttft := estimatedTTFTFromSnapshot(snap, estimatedPromptTokens, requestedMaxTokens)
 			if !hasTTFT || ttft < bestTTFT {
 				bestTTFT = ttft
@@ -1312,6 +1318,22 @@ func (r *Registry) quickCapacityCheck(model string, estimatedPromptTokens, reque
 }
 
 func estimatedTTFTFromSnapshot(snap routingSnapshot, reqPromptTokens, reqMaxTokens int) time.Duration {
+	ttftMs := ttftMsFromSnapshot(snap, reqPromptTokens, reqMaxTokens)
+	if ttftMs <= 0 || math.IsNaN(ttftMs) || math.IsInf(ttftMs, 0) {
+		return 0
+	}
+	return time.Duration(ttftMs * float64(time.Millisecond))
+}
+
+// ttftMsFromSnapshot returns the estimated time-to-first-token in milliseconds
+// for a candidate/provider snapshot. It is shared between the preflight
+// (QuickCapacityCheckWithTTFTForRequest) and the scheduler
+// (buildCandidateWithReason) so the two paths cannot drift on what "TTFT"
+// means.
+func ttftMsFromSnapshot(snap routingSnapshot, reqPromptTokens, reqMaxTokens int) float64 {
+	if !snap.hasBackendCapacity {
+		return 0
+	}
 	statePenalty, _ := slotStatePenalty(snap.slotState)
 	if reqPromptTokens < 0 {
 		reqPromptTokens = 0
@@ -1349,11 +1371,7 @@ func estimatedTTFTFromSnapshot(snap routingSnapshot, reqPromptTokens, reqMaxToke
 		backlogMs = (runningBacklogTokens + waitingBacklogTokens + unaccountedPendingTokens) / effectiveTPS * 1000.0
 	}
 
-	ttftMs := statePenalty + backlogMs + float64(reqPromptTokens)/prefillTPS*1000.0
-	if ttftMs <= 0 || math.IsNaN(ttftMs) || math.IsInf(ttftMs, 0) {
-		return 0
-	}
-	return time.Duration(ttftMs * float64(time.Millisecond))
+	return statePenalty + backlogMs + float64(reqPromptTokens)/prefillTPS*1000.0
 }
 
 // DrainQueuedRequestsForModel attempts to assign queued requests for a

--- a/coordinator/registry/scheduler.go
+++ b/coordinator/registry/scheduler.go
@@ -163,6 +163,7 @@ type costBreakdown struct {
 	BacklogMs float64
 	ThisReqMs float64
 	HealthMs  float64
+	TTFTMs    float64 // estimated time-to-first-token for this candidate
 	Total     float64
 }
 
@@ -192,8 +193,18 @@ type RoutingDecision struct {
 	// precise "no vision-capable provider for this model" error instead of a
 	// generic capacity/queue signal.
 	VisionRejections int
-	EffectiveTPS     float64 // load-scaled decode TPS used in cost (Phase 4)
-	StaticTPS        float64 // benchmarked decode TPS before load scaling
+	// TTFTRejections counts providers that passed all other gates but exceeded
+	// the per-request MaxTTFTMs ceiling. Lets the caller fail fast with a 429
+	// instead of queueing or routing to a provider that misses the SLA.
+	TTFTRejections int
+	EffectiveTPS   float64 // load-scaled decode TPS used in cost (Phase 4)
+	StaticTPS      float64 // benchmarked decode TPS before load scaling
+	// BestTTFTMs is the lowest TTFT estimate seen during selection, even if it
+	// exceeded MaxTTFTMs. Used to compute an accurate Retry-After when all
+	// candidates are too slow.
+	BestTTFTMs float64
+	// TTFTMs is the estimated time-to-first-token of the selected provider.
+	TTFTMs float64
 }
 
 // ReserveProvider selects a hardware-routable provider for the request and
@@ -224,7 +235,7 @@ func (r *Registry) ReserveProviderEx(model string, pr *PendingRequest, excludeID
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	selected, candidateCount, capacityRejections, tooLargeRejections, visionRejections := r.selectBestCandidateLockedFull(model, pr, excludeIDs...)
+	selected, candidateCount, capacityRejections, tooLargeRejections, visionRejections, ttftRejections, bestTTFTMs := r.selectBestCandidateLockedFull(model, pr, excludeIDs...)
 	if selected == nil {
 		return nil, RoutingDecision{
 			Model:                   model,
@@ -232,6 +243,8 @@ func (r *Registry) ReserveProviderEx(model string, pr *PendingRequest, excludeID
 			CapacityRejections:      capacityRejections,
 			ModelTooLargeRejections: tooLargeRejections,
 			VisionRejections:        visionRejections,
+			TTFTRejections:          ttftRejections,
+			BestTTFTMs:              bestTTFTMs,
 		}
 	}
 
@@ -288,6 +301,9 @@ func (r *Registry) ReserveProviderEx(model string, pr *PendingRequest, excludeID
 		CapacityRejections:      capacityRejections,
 		ModelTooLargeRejections: tooLargeRejections,
 		VisionRejections:        visionRejections,
+		TTFTRejections:          ttftRejections,
+		BestTTFTMs:              bestTTFTMs,
+		TTFTMs:                  bd.TTFTMs,
 		EffectiveTPS:            selected.effectiveTPS,
 		StaticTPS:               selected.snapshot.decodeTPS,
 	}
@@ -301,8 +317,8 @@ func (r *Registry) ReserveProviderEx(model string, pr *PendingRequest, excludeID
 // provider is over-subscribed", which is the difference between the
 // no_provider and over_capacity outcome counters.
 // Returns (winner, candidateCount, capacityRejections, modelTooLargeRejections,
-// visionRejections).
-func (r *Registry) selectBestCandidateLockedFull(model string, pr *PendingRequest, excludeIDs ...string) (*routingCandidate, int, int, int, int) {
+// visionRejections, ttftRejections, bestTTFTMs).
+func (r *Registry) selectBestCandidateLockedFull(model string, pr *PendingRequest, excludeIDs ...string) (*routingCandidate, int, int, int, int, int, float64) {
 	excludeSet := make(map[string]struct{}, len(excludeIDs))
 	for _, id := range excludeIDs {
 		excludeSet[id] = struct{}{}
@@ -323,6 +339,9 @@ func (r *Registry) selectBestCandidateLockedFull(model string, pr *PendingReques
 	capacityRejections := 0
 	tooLargeRejections := 0
 	visionRejections := 0
+	ttftRejections := 0
+	bestTTFTMs := 0.0
+	enforceTTFT := pr.MaxTTFTMs > 0
 	affinityProviderID := ""
 	affinityLookup := pr.CacheAffinityKey != "" && pr.ConsumerKey != ""
 	if affinityLookup && r.cacheAffinityBonusMs > 0 {
@@ -383,6 +402,23 @@ func (r *Registry) selectBestCandidateLockedFull(model string, pr *PendingReques
 			}
 			continue
 		}
+
+		// Track the best TTFT seen among providers that passed all structural
+		// and capacity gates. Even if this candidate is over the ceiling, the
+		// value is used for Retry-After on the TTFT 429 path.
+		if !enforceTTFT || candidate.breakdown.TTFTMs < bestTTFTMs || bestTTFTMs == 0 {
+			bestTTFTMs = candidate.breakdown.TTFTMs
+		}
+
+		// Enforce the per-request TTFT ceiling for public inference routes.
+		// Providers above the threshold are counted as TTFT rejections and
+		// excluded from cost-based selection so the router cannot pick a
+		// provider that misses the OpenRouter SLA target.
+		if enforceTTFT && candidate.breakdown.TTFTMs > pr.MaxTTFTMs {
+			ttftRejections++
+			continue
+		}
+
 		if affinityProviderID != "" && p.ID == affinityProviderID {
 			bonus := r.cacheAffinityBonusMs
 			if bonus > candidate.costMs {
@@ -396,7 +432,7 @@ func (r *Registry) selectBestCandidateLockedFull(model string, pr *PendingReques
 	}
 
 	if len(candidates) == 0 {
-		return nil, candidateCount, capacityRejections, tooLargeRejections, visionRejections
+		return nil, candidateCount, capacityRejections, tooLargeRejections, visionRejections, ttftRejections, bestTTFTMs
 	}
 
 	// Prefer-with-fallback: if the caller asked to prefer their own machine and
@@ -482,7 +518,7 @@ func (r *Registry) selectBestCandidateLockedFull(model string, pr *PendingReques
 		}
 	}
 	r.logRoutingDecision(model, pr, winner, candidateCount)
-	return winner, candidateCount, capacityRejections, tooLargeRejections, visionRejections
+	return winner, candidateCount, capacityRejections, tooLargeRejections, visionRejections, ttftRejections, bestTTFTMs
 }
 
 func providerMatchesAllowedSerial(p *Provider, allowed map[string]struct{}) bool {
@@ -898,6 +934,18 @@ func (r *Registry) buildCandidateWithReason(snap routingSnapshot, pr *PendingReq
 	healthMs := healthPenaltyMs(snap.systemMetrics, snap.gpuMemoryActiveGB, snap.totalMemoryGB)
 	cost := statePenalty + queueMs + pendingMs + backlogMs + thisReqMs + healthMs
 
+	// Estimated time-to-first-token for this candidate. Used for the
+	// OpenRouter TTFT ceiling: public routes only select providers whose
+	// estimated TTFT is within the per-request threshold.
+	prefillTPS := snap.prefillTPS
+	if prefillTPS <= 0 {
+		prefillTPS = 1.0
+	}
+	ttftMs := statePenalty + backlogMs + float64(reqPrompt)/prefillTPS*1000.0
+	if ttftMs <= 0 || math.IsNaN(ttftMs) || math.IsInf(ttftMs, 0) {
+		ttftMs = 0
+	}
+
 	return &routingCandidate{
 		provider:       snap.provider,
 		snapshot:       snap,
@@ -911,6 +959,7 @@ func (r *Registry) buildCandidateWithReason(snap routingSnapshot, pr *PendingReq
 			BacklogMs: backlogMs,
 			ThisReqMs: thisReqMs,
 			HealthMs:  healthMs,
+			TTFTMs:    ttftMs,
 			Total:     cost,
 		},
 	}, rejectNone, true
@@ -1142,6 +1191,7 @@ func (r *Registry) quickCapacityCheck(model string, estimatedPromptTokens, reque
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
+	unknownTTFTCandidate := false
 	now := time.Now()
 	for _, p := range r.providers {
 		// Filter by allowed serials before acquiring the provider lock
@@ -1196,6 +1246,7 @@ func (r *Registry) quickCapacityCheck(model string, estimatedPromptTokens, reque
 			snap.pendingForModel++
 			snap.pendingMaxTokens += pendingTokenBudget(pending)
 		}
+		hasBackendCapacity := p.BackendCapacity != nil
 		if p.BackendCapacity != nil {
 			snap.gpuMemoryActiveGB = p.BackendCapacity.GPUMemoryActiveGB
 			if p.BackendCapacity.TotalMemoryGB > 0 {
@@ -1244,11 +1295,18 @@ func (r *Registry) quickCapacityCheck(model string, estimatedPromptTokens, reque
 		}
 
 		candidateCount++
-		ttft := estimatedTTFTFromSnapshot(snap, estimatedPromptTokens, requestedMaxTokens)
-		if !hasTTFT || ttft < bestTTFT {
-			bestTTFT = ttft
-			hasTTFT = true
+		if hasBackendCapacity {
+			ttft := estimatedTTFTFromSnapshot(snap, estimatedPromptTokens, requestedMaxTokens)
+			if !hasTTFT || ttft < bestTTFT {
+				bestTTFT = ttft
+				hasTTFT = true
+			}
+		} else {
+			unknownTTFTCandidate = true
 		}
+	}
+	if unknownTTFTCandidate {
+		return candidateCount, capacityRejections, modelTooLarge, 0, false
 	}
 	return candidateCount, capacityRejections, modelTooLarge, bestTTFT, hasTTFT
 }

--- a/coordinator/registry/scheduler_test.go
+++ b/coordinator/registry/scheduler_test.go
@@ -114,6 +114,73 @@ func TestReserveProviderExReturnsCostBreakdown(t *testing.T) {
 	}
 }
 
+func TestQuickCapacityCheckWithTTFTEstimatesBestEligibleProvider(t *testing.T) {
+	reg := New(testLogger())
+	model := "ttft-model"
+	slow := makeSchedulerProvider(t, reg, "slow", model, 100)
+	slow.mu.Lock()
+	slow.BackendCapacity.Slots[0].MaxTokensPotential = 2_000
+	slow.mu.Unlock()
+
+	candidates, rejections, tooLarge, bestTTFT, hasTTFT := reg.QuickCapacityCheckWithTTFTForRequest(model, 100, 128, RequestTraits{}, false)
+	if candidates != 1 || rejections != 0 || tooLarge != 0 {
+		t.Fatalf("capacity = (%d,%d,%d), want (1,0,0)", candidates, rejections, tooLarge)
+	}
+	if !hasTTFT || bestTTFT <= 10*time.Second {
+		t.Fatalf("bestTTFT = %v has=%v, want above 10s with backlog", bestTTFT, hasTTFT)
+	}
+
+	makeSchedulerProvider(t, reg, "fast", model, 100)
+	candidates, rejections, tooLarge, bestTTFT, hasTTFT = reg.QuickCapacityCheckWithTTFTForRequest(model, 100, 128, RequestTraits{}, false)
+	if candidates != 2 || rejections != 0 || tooLarge != 0 {
+		t.Fatalf("capacity with fast provider = (%d,%d,%d), want (2,0,0)", candidates, rejections, tooLarge)
+	}
+	if !hasTTFT || bestTTFT >= 10*time.Second {
+		t.Fatalf("bestTTFT = %v has=%v, want under 10s from fast provider", bestTTFT, hasTTFT)
+	}
+}
+
+func TestQuickCapacityCheckWithTTFTIncludesTokenBudgetBacklog(t *testing.T) {
+	reg := New(testLogger())
+	model := "ttft-token-budget-model"
+	p := makeTokenBudgetProvider(t, reg, "budget", model, 100, 1_000, 20_000, 100)
+	p.mu.Lock()
+	p.BackendCapacity.Slots[0].QueuedTokenBudget = 2_000
+	p.mu.Unlock()
+	p.AddPending(&PendingRequest{
+		RequestID:             "coordinator-pending",
+		Model:                 model,
+		EstimatedPromptTokens: 4_000,
+		RequestedMaxTokens:    1_000,
+	})
+
+	candidates, rejections, tooLarge, bestTTFT, hasTTFT := reg.QuickCapacityCheckWithTTFTForRequest(model, 100, 128, RequestTraits{}, false)
+	if candidates != 1 || rejections != 0 || tooLarge != 0 {
+		t.Fatalf("capacity = (%d,%d,%d), want (1,0,0)", candidates, rejections, tooLarge)
+	}
+	if !hasTTFT || bestTTFT < 50*time.Second || bestTTFT > 51*time.Second {
+		t.Fatalf("bestTTFT = %v has=%v, want about 50s from active+queued+coordinator backlog", bestTTFT, hasTTFT)
+	}
+}
+
+func TestQuickCapacityCheckWithTTFTIncludesBackendRunningFallback(t *testing.T) {
+	reg := New(testLogger())
+	model := "ttft-running-fallback-model"
+	p := makeSchedulerProvider(t, reg, "running", model, 100)
+	p.mu.Lock()
+	p.BackendCapacity.Slots[0].NumRunning = 1
+	p.BackendCapacity.Slots[0].MaxTokensPotential = 0
+	p.mu.Unlock()
+
+	candidates, rejections, tooLarge, bestTTFT, hasTTFT := reg.QuickCapacityCheckWithTTFTForRequest(model, 100, 2048, RequestTraits{}, false)
+	if candidates != 1 || rejections != 0 || tooLarge != 0 {
+		t.Fatalf("capacity = (%d,%d,%d), want (1,0,0)", candidates, rejections, tooLarge)
+	}
+	if !hasTTFT || bestTTFT <= 20*time.Second {
+		t.Fatalf("bestTTFT = %v has=%v, want running request backlog above 20s", bestTTFT, hasTTFT)
+	}
+}
+
 func TestReserveProviderHonorsAllowedProviderSerials(t *testing.T) {
 	reg := New(testLogger())
 	model := "targeted-model"

--- a/coordinator/registry/scheduler_test.go
+++ b/coordinator/registry/scheduler_test.go
@@ -181,6 +181,100 @@ func TestQuickCapacityCheckWithTTFTIncludesBackendRunningFallback(t *testing.T) 
 	}
 }
 
+func TestReserveProviderExcludesSlowProviderWhenTTFTCeilingSet(t *testing.T) {
+	reg := New(testLogger())
+	model := "ttft-ceiling-model"
+
+	// slow-but-cheap: moderate backlog keeps its cost below the expensive
+	// provider, but the backlog pushes its TTFT above the 10s target.
+	slow := makeSchedulerProvider(t, reg, "slow", model, 100)
+	slow.mu.Lock()
+	slow.PrefillTPS = 1000
+	// 5_000 tokens / 100 TPS = 50s backlog; TTFT ≈ 50s + 0.1s > 10s.
+	slow.BackendCapacity.Slots[0].MaxTokensPotential = 5_000
+	slow.mu.Unlock()
+
+	// fast-but-expensive: low decode TPS inflates cost, but TTFT stays tiny.
+	fast := makeSchedulerProvider(t, reg, "fast", model, 1)
+	fast.mu.Lock()
+	fast.PrefillTPS = 1000
+	fast.mu.Unlock()
+
+	// Without a TTFT ceiling the router picks the slow (lower-cost) provider.
+	reqNoCeiling := &PendingRequest{
+		RequestID:             "req-no-ceiling",
+		Model:                 model,
+		EstimatedPromptTokens: 100,
+		RequestedMaxTokens:    128,
+	}
+	selected, decision := reg.ReserveProviderEx(model, reqNoCeiling)
+	if selected == nil {
+		t.Fatalf("ReserveProviderEx returned nil: %+v", decision)
+	}
+	if selected.ID != slow.ID {
+		t.Fatalf("without ceiling selected %q, want slow provider", selected.ID)
+	}
+	selected.RemovePending(reqNoCeiling.RequestID)
+	reg.SetProviderIdle(selected.ID)
+
+	// With the TTFT ceiling the router must exclude slow and pick fast.
+	reqWithCeiling := &PendingRequest{
+		RequestID:             "req-with-ceiling",
+		Model:                 model,
+		EstimatedPromptTokens: 100,
+		RequestedMaxTokens:    128,
+		MaxTTFTMs:             10_000, // 10s
+	}
+	selected, decision = reg.ReserveProviderEx(model, reqWithCeiling)
+	if selected == nil {
+		t.Fatalf("ReserveProviderEx returned nil: %+v", decision)
+	}
+	if selected.ID != fast.ID {
+		t.Fatalf("with ceiling selected %q, want fast provider; decision=%+v", selected.ID, decision)
+	}
+	if decision.TTFTRejections != 1 {
+		t.Fatalf("TTFTRejections = %d, want 1", decision.TTFTRejections)
+	}
+	if decision.BestTTFTMs <= 0 {
+		t.Fatalf("BestTTFTMs = %f, want > 0", decision.BestTTFTMs)
+	}
+	if decision.TTFTMs > 10_000 {
+		t.Fatalf("winning TTFTMs = %f, want <= 10000", decision.TTFTMs)
+	}
+}
+
+func TestReserveProviderReturnsTTFTRejectionsWhenAllTooSlow(t *testing.T) {
+	reg := New(testLogger())
+	model := "ttft-all-slow-model"
+
+	p := makeSchedulerProvider(t, reg, "slow", model, 100)
+	p.mu.Lock()
+	p.PrefillTPS = 1000
+	p.BackendCapacity.Slots[0].MaxTokensPotential = 2_000_000
+	p.mu.Unlock()
+
+	req := &PendingRequest{
+		RequestID:             "req-all-slow",
+		Model:                 model,
+		EstimatedPromptTokens: 100,
+		RequestedMaxTokens:    128,
+		MaxTTFTMs:             10_000,
+	}
+	selected, decision := reg.ReserveProviderEx(model, req)
+	if selected != nil {
+		t.Fatalf("expected no provider, got %q", selected.ID)
+	}
+	if decision.TTFTRejections != 1 {
+		t.Fatalf("TTFTRejections = %d, want 1", decision.TTFTRejections)
+	}
+	if decision.BestTTFTMs <= 10_000 {
+		t.Fatalf("BestTTFTMs = %f, want > 10000", decision.BestTTFTMs)
+	}
+	if decision.CandidateCount != 0 {
+		t.Fatalf("CandidateCount = %d, want 0", decision.CandidateCount)
+	}
+}
+
 func TestReserveProviderHonorsAllowedProviderSerials(t *testing.T) {
 	reg := New(testLogger())
 	model := "targeted-model"


### PR DESCRIPTION
## Summary
- Add TTFT-aware admission before public inference dispatch.
- Return standard HTTP `429` with `Retry-After` when the fastest eligible provider is estimated to miss the `10s` TTFT target.
- Preserve rollout safety: public aliases try `previous_build` before returning 429 if the desired build is too slow.
- Apply the gate to `/v1/chat/completions`, Responses-style `input`, `/v1/completions`, and `/v1/messages`.
- Estimate `Retry-After` from TTFT overage, bounded to `2-30s`, and never lower than the existing queue-depth estimate.

## Problem
OpenRouter asked us to return retryable `429`s instead of accepting requests that will likely time out. Before this PR, the coordinator only failed fast when all providers were capacity-rejected. If a provider was technically routable but had enough backend backlog to miss TTFT, we still dispatched the request and OpenRouter observed a timeout or bad latency.

## Before
```mermaid
sequenceDiagram
    participant OR as OpenRouter
    participant C as Coordinator
    participant R as Registry preflight
    participant P as Provider backend

    OR->>C: POST /v1/chat/completions
    C->>R: QuickCapacityCheck
    R-->>C: candidateCount > 0
    C->>P: Dispatch request
    P-->>C: First token delayed by backend backlog
    OR-->>OR: Client-side timeout / poor latency sample
    C-->>OR: Response arrives too late or fails
```

## After
```mermaid
sequenceDiagram
    participant OR as OpenRouter
    participant C as Coordinator
    participant R as Registry preflight
    participant A as Alias fallback
    participant P as Provider backend

    OR->>C: POST /v1/chat/completions
    C->>R: Capacity + TTFT preflight
    R-->>C: Best eligible TTFT estimate
    alt Best TTFT <= 10s
        C->>P: Dispatch normally
        P-->>C: Stream first token
        C-->>OR: 200 / stream
    else Alias desired build too slow and previous is fast
        C->>A: Try previous_build
        A-->>C: Previous build TTFT <= 10s
        C->>P: Dispatch to previous build
        P-->>C: Stream first token
        C-->>OR: 200 / stream using public alias name
    else Best effective TTFT > 10s
        C-->>OR: 429 rate_limit_exceeded + Retry-After
    end
```

## Testing
- `go test ./registry -run 'TestQuickCapacityCheckWithTTFT'`
- `go test ./registry`
- `go test ./api -run 'TestTTFTAdmission429ForInferenceEndpoints|TestWriteTTFTTooSlowSets429RetryAfter|TestMaybeFallbackAliasTTFTSwitchesToPrevious|TestWriteServiceUnavailableSetsRetryAfter'`
- `go test -race ./api -run 'TestTTFTAdmission429ForInferenceEndpoints|TestWriteTTFTTooSlowSets429RetryAfter|TestMaybeFallbackAliasTTFTSwitchesToPrevious'`
- `go test ./api -run '^$'`
- `golangci-lint run`
- `git diff --check`

## Notes
- Uses standard HTTP `429`, not a nonstandard status code, so OpenRouter can classify these as retryable rate-limit responses instead of timeouts.
- The TTFT estimate uses the same public routing gates as the existing capacity preflight, then considers prompt tokens, prefill TPS, active/queued token budgets, backend running/waiting counts, `MaxTokensPotential`, slot state penalties, observed decode TPS, and fleet-median fallback.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/360"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784151680&installation_id=133247490&pr_number=360&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F360&signature=51f8522e46a5b636f1ad7e52f51258a33e461466d9962566aa4b5f5247732a60"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
