### PR TITLE
[codex] add provider memory limit

### DIFF
--- a/provider-swift/Package.swift
+++ b/provider-swift/Package.swift
@@ -212,7 +212,7 @@ let package = Package(
         // ----------------------------------------------------------------
         .testTarget(
             name: "DarkbloomCLITests",
-            dependencies: ["darkbloom"],
+            dependencies: ["darkbloom", "ProviderCore"],
             path: "Tests/DarkbloomCLITests"
         ),
     ]

--- a/provider-swift/Sources/ProviderCore/Config/ProviderConfig.swift
+++ b/provider-swift/Sources/ProviderCore/Config/ProviderConfig.swift
@@ -22,14 +22,25 @@ import TOMLKit
 public struct ProviderSettings: Sendable, Equatable, Codable {
     public var name: String
     public var memoryReserveGB: UInt64
+    /// Optional hard cap for provider inference memory. When set, the provider
+    /// advertises and admits work as if the machine had at most this many GiB
+    /// of unified memory. `memoryReserveGB` is still subtracted from the cap.
+    public var memoryLimitGB: UInt64?
     public var autoUpdate: Bool
     /// When true (default), the watchdog relaunches the provider ~5 min after a
     /// crash. `false` opts out while keeping the provider installed.
     public var autoRestart: Bool
 
-    public init(name: String, memoryReserveGB: UInt64 = 4, autoUpdate: Bool = true, autoRestart: Bool = true) {
+    public init(
+        name: String,
+        memoryReserveGB: UInt64 = 4,
+        memoryLimitGB: UInt64? = nil,
+        autoUpdate: Bool = true,
+        autoRestart: Bool = true
+    ) {
         self.name = name
         self.memoryReserveGB = memoryReserveGB
+        self.memoryLimitGB = memoryLimitGB
         self.autoUpdate = autoUpdate
         self.autoRestart = autoRestart
     }
@@ -37,6 +48,7 @@ public struct ProviderSettings: Sendable, Equatable, Codable {
     enum CodingKeys: String, CodingKey {
         case name
         case memoryReserveGB = "memory_reserve_gb"
+        case memoryLimitGB = "memory_limit_gb"
         case autoUpdate = "auto_update"
         case autoRestart = "auto_restart"
     }
@@ -45,6 +57,9 @@ public struct ProviderSettings: Sendable, Equatable, Codable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.name = try container.decodeIfPresent(String.self, forKey: .name) ?? "darkbloom"
         self.memoryReserveGB = try container.decodeIfPresent(UInt64.self, forKey: .memoryReserveGB) ?? 4
+        self.memoryLimitGB = try container.decodeIfPresent(UInt64.self, forKey: .memoryLimitGB).flatMap {
+            $0 > 0 ? $0 : nil
+        }
         self.autoUpdate = try container.decodeIfPresent(Bool.self, forKey: .autoUpdate) ?? true
         self.autoRestart = try container.decodeIfPresent(Bool.self, forKey: .autoRestart) ?? true
     }

--- a/provider-swift/Sources/ProviderCore/Config/ProviderMemoryLimit.swift
+++ b/provider-swift/Sources/ProviderCore/Config/ProviderMemoryLimit.swift
@@ -2,6 +2,7 @@ import Foundation
 
 public enum ProviderMemoryLimit {
     private static let bytesPerGiB: UInt64 = 1024 * 1024 * 1024
+    private static let maxWholeGiBBeforeOverflow = UInt64.max / bytesPerGiB
 
     public struct EffectiveBytes: Sendable, Equatable {
         public let totalBytes: UInt64
@@ -53,7 +54,7 @@ public enum ProviderMemoryLimit {
     }
 
     private static func saturatingGiBToBytes(_ gb: UInt64) -> UInt64 {
-        guard gb <= UInt64.max / bytesPerGiB else {
+        guard gb <= maxWholeGiBBeforeOverflow else {
             return UInt64.max
         }
         return gb * bytesPerGiB

--- a/provider-swift/Sources/ProviderCore/Config/ProviderMemoryLimit.swift
+++ b/provider-swift/Sources/ProviderCore/Config/ProviderMemoryLimit.swift
@@ -3,15 +3,9 @@ import Foundation
 public enum ProviderMemoryLimit {
     private static let bytesPerGiB: UInt64 = 1024 * 1024 * 1024
 
-    public static func effectiveHardware(
-        _ hardware: HardwareInfo,
-        settings: ProviderSettings
-    ) -> HardwareInfo {
-        effectiveHardware(
-            hardware,
-            limitGB: settings.memoryLimitGB,
-            reserveGB: settings.memoryReserveGB
-        )
+    public struct EffectiveBytes: Sendable, Equatable {
+        public let totalBytes: UInt64
+        public let limitBytes: UInt64?
     }
 
     public static func effectiveHardware(
@@ -19,10 +13,7 @@ public enum ProviderMemoryLimit {
         limitGB: UInt64?,
         reserveGB: UInt64
     ) -> HardwareInfo {
-        let effectiveMemory = effectiveMemoryGB(
-            physicalGB: hardware.memoryGb,
-            limitGB: limitGB
-        )
+        let effectiveMemory = applyLimit(hardware.memoryGb, limit: limitGB)
         let effectiveAvailable = effectiveMemory > reserveGB
             ? effectiveMemory - reserveGB
             : 0
@@ -40,15 +31,15 @@ public enum ProviderMemoryLimit {
         )
     }
 
-    public static func effectiveTotalBytes(
+    public static func effectiveBytes(
         physicalBytes: UInt64,
         limitGB: UInt64?
-    ) -> UInt64 {
-        guard let limitGB, limitGB > 0 else {
-            return physicalBytes
-        }
-        let limitBytes = saturatingGiBToBytes(limitGB)
-        return min(physicalBytes, limitBytes)
+    ) -> EffectiveBytes {
+        let bytes = limitBytes(limitGB: limitGB)
+        return EffectiveBytes(
+            totalBytes: applyLimit(physicalBytes, limit: bytes),
+            limitBytes: bytes
+        )
     }
 
     public static func limitBytes(limitGB: UInt64?) -> UInt64? {
@@ -56,18 +47,15 @@ public enum ProviderMemoryLimit {
         return saturatingGiBToBytes(limitGB)
     }
 
-    private static func effectiveMemoryGB(
-        physicalGB: UInt64,
-        limitGB: UInt64?
-    ) -> UInt64 {
-        guard let limitGB, limitGB > 0 else {
-            return physicalGB
-        }
-        return min(physicalGB, limitGB)
+    private static func applyLimit(_ value: UInt64, limit: UInt64?) -> UInt64 {
+        guard let limit, limit > 0 else { return value }
+        return min(value, limit)
     }
 
     private static func saturatingGiBToBytes(_ gb: UInt64) -> UInt64 {
-        let (bytes, overflow) = gb.multipliedReportingOverflow(by: bytesPerGiB)
-        return overflow ? UInt64.max : bytes
+        guard gb <= UInt64.max / bytesPerGiB else {
+            return UInt64.max
+        }
+        return gb * bytesPerGiB
     }
 }

--- a/provider-swift/Sources/ProviderCore/Config/ProviderMemoryLimit.swift
+++ b/provider-swift/Sources/ProviderCore/Config/ProviderMemoryLimit.swift
@@ -1,0 +1,73 @@
+import Foundation
+
+public enum ProviderMemoryLimit {
+    private static let bytesPerGiB: UInt64 = 1024 * 1024 * 1024
+
+    public static func effectiveHardware(
+        _ hardware: HardwareInfo,
+        settings: ProviderSettings
+    ) -> HardwareInfo {
+        effectiveHardware(
+            hardware,
+            limitGB: settings.memoryLimitGB,
+            reserveGB: settings.memoryReserveGB
+        )
+    }
+
+    public static func effectiveHardware(
+        _ hardware: HardwareInfo,
+        limitGB: UInt64?,
+        reserveGB: UInt64
+    ) -> HardwareInfo {
+        let effectiveMemory = effectiveMemoryGB(
+            physicalGB: hardware.memoryGb,
+            limitGB: limitGB
+        )
+        let effectiveAvailable = effectiveMemory > reserveGB
+            ? effectiveMemory - reserveGB
+            : 0
+
+        return HardwareInfo(
+            machineModel: hardware.machineModel,
+            chipName: hardware.chipName,
+            chipFamily: hardware.chipFamily,
+            chipTier: hardware.chipTier,
+            memoryGb: effectiveMemory,
+            memoryAvailableGb: min(hardware.memoryAvailableGb, effectiveAvailable),
+            cpuCores: hardware.cpuCores,
+            gpuCores: hardware.gpuCores,
+            memoryBandwidthGbs: hardware.memoryBandwidthGbs
+        )
+    }
+
+    public static func effectiveTotalBytes(
+        physicalBytes: UInt64,
+        limitGB: UInt64?
+    ) -> UInt64 {
+        guard let limitGB, limitGB > 0 else {
+            return physicalBytes
+        }
+        let limitBytes = saturatingGiBToBytes(limitGB)
+        return min(physicalBytes, limitBytes)
+    }
+
+    public static func limitBytes(limitGB: UInt64?) -> UInt64? {
+        guard let limitGB, limitGB > 0 else { return nil }
+        return saturatingGiBToBytes(limitGB)
+    }
+
+    private static func effectiveMemoryGB(
+        physicalGB: UInt64,
+        limitGB: UInt64?
+    ) -> UInt64 {
+        guard let limitGB, limitGB > 0 else {
+            return physicalGB
+        }
+        return min(physicalGB, limitGB)
+    }
+
+    private static func saturatingGiBToBytes(_ gb: UInt64) -> UInt64 {
+        let (bytes, overflow) = gb.multipliedReportingOverflow(by: bytesPerGiB)
+        return overflow ? UInt64.max : bytes
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Inference/BatchScheduler+Telemetry.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/BatchScheduler+Telemetry.swift
@@ -39,17 +39,45 @@ extension BatchScheduler {
             return staticBudget
         }
 
-        let totalMemory = Int(ProcessInfo.processInfo.physicalMemory)
-        let osReserve = 4 * 1024 * 1024 * 1024
-        let safetyMargin = totalMemory / 10
-        let globalUsed = Int(MLX.GPU.activeMemory) + Int(MLX.GPU.cacheMemory)
-        let mlxFree = max(0, totalMemory - globalUsed)
+        return Self.memoryAwareTokenBudgetMax(
+            staticBudget: staticBudget,
+            modelWeightBytes: modelWeightBytes,
+            kvBytesPerToken: kvBytesPerToken,
+            totalMemoryBytes: totalMemoryBytes,
+            activeMemoryBytes: UInt64(max(0, MLX.GPU.activeMemory)),
+            cacheMemoryBytes: UInt64(max(0, MLX.GPU.cacheMemory)),
+            systemAvailableBytes: SystemMemory.availableBytes() ?? .max,
+            activeTokenBudgetUsed: activeTokenBudgetUsed
+        )
+    }
+
+    static func memoryAwareTokenBudgetMax(
+        staticBudget: Int,
+        modelWeightBytes: Int,
+        kvBytesPerToken: Int,
+        totalMemoryBytes: UInt64,
+        activeMemoryBytes: UInt64,
+        cacheMemoryBytes: UInt64,
+        systemAvailableBytes: UInt64,
+        activeTokenBudgetUsed: Int
+    ) -> Int {
+        guard modelWeightBytes > 0, kvBytesPerToken > 0 else {
+            return staticBudget
+        }
+
+        let osReserve = UInt64(4 * 1024 * 1024 * 1024)
+        let safetyMargin = totalMemoryBytes / 10
+        let globalUsed = Self.saturatingAdd(activeMemoryBytes, cacheMemoryBytes)
+        let mlxFree = totalMemoryBytes > globalUsed ? totalMemoryBytes - globalUsed : 0
         // Clamp the MLX-only view to real OS-free RAM (other processes' usage),
         // same as the load gate / GlobalKVCacheBudget; else we OOM on shared boxes.
-        let osAvailable = SystemMemory.availableBytes().map { Int(min($0, UInt64(Int.max))) } ?? Int.max
-        let realFree = min(mlxFree, osAvailable)
-        let availableHeadroom = max(0, realFree - osReserve - safetyMargin)
-        let liveBudget = activeTokenBudgetUsed + (availableHeadroom / kvBytesPerToken)
+        let realFree = min(mlxFree, systemAvailableBytes)
+        let committed = Self.saturatingAdd(osReserve, safetyMargin)
+        let availableHeadroom: UInt64 = realFree > committed ? realFree - committed : 0
+        let tokens = availableHeadroom / UInt64(kvBytesPerToken)
+        let availableTokens = Int(min(tokens, UInt64(Int.max)))
+        let (sum, overflow) = activeTokenBudgetUsed.addingReportingOverflow(availableTokens)
+        let liveBudget = overflow ? Int.max : sum
         return max(1024, min(staticBudget, liveBudget))
     }
 
@@ -220,5 +248,15 @@ extension BatchScheduler {
         #else
         return 0
         #endif
+    }
+
+    static func saturatingAdd(_ values: UInt64...) -> UInt64 {
+        var total: UInt64 = 0
+        for value in values {
+            let (next, overflow) = total.addingReportingOverflow(value)
+            if overflow { return .max }
+            total = next
+        }
+        return total
     }
 }

--- a/provider-swift/Sources/ProviderCore/Inference/BatchScheduler+Telemetry.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/BatchScheduler+Telemetry.swift
@@ -38,14 +38,16 @@ extension BatchScheduler {
         guard modelWeightBytes > 0, kvBytesPerToken > 0 else {
             return staticBudget
         }
+        let activeMemoryBytes = UInt64(max(0, MLX.GPU.activeMemory))
+        let cacheMemoryBytes = UInt64(max(0, MLX.GPU.cacheMemory))
 
         return Self.memoryAwareTokenBudgetMax(
             staticBudget: staticBudget,
             modelWeightBytes: modelWeightBytes,
             kvBytesPerToken: kvBytesPerToken,
             totalMemoryBytes: totalMemoryBytes,
-            activeMemoryBytes: UInt64(max(0, MLX.GPU.activeMemory)),
-            cacheMemoryBytes: UInt64(max(0, MLX.GPU.cacheMemory)),
+            activeMemoryBytes: activeMemoryBytes,
+            cacheMemoryBytes: cacheMemoryBytes,
             systemAvailableBytes: SystemMemory.availableBytes() ?? .max,
             activeTokenBudgetUsed: activeTokenBudgetUsed
         )
@@ -250,13 +252,14 @@ extension BatchScheduler {
         #endif
     }
 
-    static func saturatingAdd(_ values: UInt64...) -> UInt64 {
-        var total: UInt64 = 0
-        for value in values {
-            let (next, overflow) = total.addingReportingOverflow(value)
-            if overflow { return .max }
-            total = next
-        }
-        return total
+    static func saturatingAdd(_ lhs: UInt64, _ rhs: UInt64) -> UInt64 {
+        let (sum, overflow) = lhs.addingReportingOverflow(rhs)
+        return overflow ? .max : sum
+    }
+
+    static func saturatingAdd(_ first: UInt64, _ second: UInt64, _ third: UInt64) -> UInt64 {
+        let partial = saturatingAdd(first, second)
+        guard partial < UInt64.max else { return .max }
+        return saturatingAdd(partial, third)
     }
 }

--- a/provider-swift/Sources/ProviderCore/Inference/BatchScheduler.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/BatchScheduler.swift
@@ -47,6 +47,7 @@ public actor BatchScheduler {
 
     let maxConcurrentRequests: Int
     let pendingTimeout: Duration
+    let totalMemoryBytes: UInt64
     /// Default max output tokens when the consumer omits `max_tokens`.
     /// Starts at the init value (typically 4096) and is raised post-load
     /// when the model's context length is known.
@@ -172,10 +173,12 @@ public actor BatchScheduler {
         pendingTimeout: Duration = .seconds(120),
         defaultMaxTokens: Int = 4096,
         kvBudget: GlobalKVCacheBudget? = nil,
-        diskAccountant: GlobalDiskAccountant? = nil
+        diskAccountant: GlobalDiskAccountant? = nil,
+        totalMemoryBytes: UInt64 = ProcessInfo.processInfo.physicalMemory
     ) {
         self.maxConcurrentRequests = max(1, maxConcurrentRequests)
         self.pendingTimeout = pendingTimeout
+        self.totalMemoryBytes = totalMemoryBytes
         self.defaultMaxTokens = defaultMaxTokens
         self.initDefaultMaxTokens = defaultMaxTokens
         self.kvBudget = kvBudget
@@ -225,7 +228,8 @@ public actor BatchScheduler {
             maxConcurrentRequests: maxConcurrentRequests,
             eosTokenIds: snapshot.eosTokenIds,
             architecture: snapshot.architecture,
-            diskAccountant: diskAccountant
+            diskAccountant: diskAccountant,
+            totalMemoryBytes: totalMemoryBytes
         )
         let engine = build.engine
         // Re-check epoch after the engine.start suspension. If another
@@ -966,7 +970,8 @@ public actor BatchScheduler {
         maxConcurrentRequests: Int,
         eosTokenIds: Set<Int>,
         architecture: ModelArchitecture,
-        diskAccountant: GlobalDiskAccountant? = nil
+        diskAccountant: GlobalDiskAccountant? = nil,
+        totalMemoryBytes: UInt64
     ) async -> EngineBuild {
         // TB-007: the prefix cache is ON by default (operator decision) with an
         // ENCRYPTED-at-rest backend; opt out with DARKBLOOM_PREFIX_CACHE=0.
@@ -984,9 +989,10 @@ public actor BatchScheduler {
             modelId: modelId, weightHash: weightHash, architecture: architecture
         )
         let kvBytesPerToken = resolvedKVBytesPerToken(architecture: architecture, weightBytes: weightBytes)
+        let prefixBudgetBytes = prefixCacheBudgetBytes(physicalMemory: totalMemoryBytes)
         let maxBlocks = prefixCacheMaxBlocks(
             kvBytesPerToken: kvBytesPerToken,
-            budgetBytes: prefixCacheBudgetBytes(),
+            budgetBytes: prefixBudgetBytes,
             blockSize: blockSize
         )
         // now() for the manager index timestamps — wall clock is fine here.
@@ -1063,7 +1069,7 @@ public actor BatchScheduler {
                         binding: checkpointBinding,
                         // RAM tier respects the same memory budget as the
                         // engine block tier (DARKBLOOM_PREFIX_CACHE_MAX_GB).
-                        ram: PrefixCacheRAM(maxBytes: prefixCacheBudgetBytes()),
+                        ram: PrefixCacheRAM(maxBytes: prefixBudgetBytes),
                         index: PrefixCacheIndex(
                             fileURL: backing.dir.appendingPathComponent("index.json")),
                         kek: backing.kek,
@@ -1340,10 +1346,13 @@ public actor BatchScheduler {
     /// NOTE: this is read UNCONDITIONALLY at every model load (to size
     /// maxBlocks) even when the cache is disabled, so a malformed value must
     /// degrade — never crash. See resolveMemoryBudget.
-    static func prefixCacheBudgetBytes() -> Int {
+    static func prefixCacheBudgetBytes(
+        physicalMemory: UInt64 = ProcessInfo.processInfo.physicalMemory
+    ) -> Int {
         let envGB: Double? = ProcessInfo.processInfo.environment["DARKBLOOM_PREFIX_CACHE_MAX_GB"]
             .flatMap(Double.init)
-        return resolveMemoryBudget(envGB: envGB, physicalMemory: Int(ProcessInfo.processInfo.physicalMemory))
+        let clampedPhysical = Int(min(physicalMemory, UInt64(Int.max)))
+        return resolveMemoryBudget(envGB: envGB, physicalMemory: clampedPhysical)
     }
 
     /// Pure memory-budget policy (testable). A valid positive env override
@@ -1471,12 +1480,13 @@ public actor BatchScheduler {
             architecture: snapshot.architecture,
             weightBytes: snapshot.bytes
         )
-        let totalMemory = Int(ProcessInfo.processInfo.physicalMemory)
-        let osReserve = 4 * 1024 * 1024 * 1024
-        let safetyMargin = totalMemory / 10
-        let availableForKV = totalMemory - snapshot.bytes - osReserve - safetyMargin
+        let osReserve = UInt64(4 * 1024 * 1024 * 1024)
+        let safetyMargin = totalMemoryBytes / 10
+        let committed = Self.saturatingAdd(UInt64(max(0, snapshot.bytes)), osReserve, safetyMargin)
+        let availableForKV = totalMemoryBytes > committed ? totalMemoryBytes - committed : 0
         if availableForKV > 0 && kvBytesPerToken > 0 {
-            self.dynamicTokenBudgetMax = max(availableForKV / kvBytesPerToken, 1024)
+            let tokens = availableForKV / UInt64(kvBytesPerToken)
+            self.dynamicTokenBudgetMax = max(Int(min(tokens, UInt64(Int.max))), 1024)
         } else {
             self.dynamicTokenBudgetMax = 1024
         }
@@ -1906,7 +1916,7 @@ public actor BatchScheduler {
             gpuMemoryActiveBytes: gpuMemory(.active),
             gpuMemoryPeakBytes: gpuMemory(.peak),
             gpuMemoryCacheBytes: gpuMemory(.cache),
-            totalMemoryBytes: ProcessInfo.processInfo.physicalMemory
+            totalMemoryBytes: totalMemoryBytes
         )
     }
 

--- a/provider-swift/Sources/ProviderCore/Inference/BatchScheduler.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/BatchScheduler.swift
@@ -1482,7 +1482,8 @@ public actor BatchScheduler {
         )
         let osReserve = UInt64(4 * 1024 * 1024 * 1024)
         let safetyMargin = totalMemoryBytes / 10
-        let committed = Self.saturatingAdd(UInt64(max(0, snapshot.bytes)), osReserve, safetyMargin)
+        let weightBytes = UInt64(max(0, snapshot.bytes))
+        let committed = Self.saturatingAdd(weightBytes, osReserve, safetyMargin)
         let availableForKV = totalMemoryBytes > committed ? totalMemoryBytes - committed : 0
         if availableForKV > 0 && kvBytesPerToken > 0 {
             let tokens = availableForKV / UInt64(kvBytesPerToken)

--- a/provider-swift/Sources/ProviderCore/Inference/GlobalKVCacheBudget.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/GlobalKVCacheBudget.swift
@@ -16,12 +16,18 @@ public actor GlobalKVCacheBudget {
 
     private let safetyFactor: Double
     private let reserveBytes: UInt64
+    private let memoryLimitBytes: UInt64?
     private let memorySnapshot: @Sendable () -> MemorySnapshot
     private var reservations: [String: UInt64] = [:]
 
-    public init(reserveBytes: UInt64 = 0, safetyFactor: Double = 0.7) {
+    public init(
+        reserveBytes: UInt64 = 0,
+        safetyFactor: Double = 0.7,
+        memoryLimitBytes: UInt64? = nil
+    ) {
         self.reserveBytes = reserveBytes
         self.safetyFactor = Self.clampedSafetyFactor(safetyFactor)
+        self.memoryLimitBytes = memoryLimitBytes
         self.memorySnapshot = {
             MemorySnapshot(
                 total: ProcessInfo.processInfo.physicalMemory,
@@ -35,10 +41,12 @@ public actor GlobalKVCacheBudget {
     init(
         reserveBytes: UInt64 = 0,
         safetyFactor: Double = 0.7,
+        memoryLimitBytes: UInt64? = nil,
         memorySnapshot: @escaping @Sendable () -> MemorySnapshot
     ) {
         self.reserveBytes = reserveBytes
         self.safetyFactor = Self.clampedSafetyFactor(safetyFactor)
+        self.memoryLimitBytes = memoryLimitBytes
         self.memorySnapshot = memorySnapshot
     }
 
@@ -87,12 +95,21 @@ public actor GlobalKVCacheBudget {
 
     private func availableReservationBytes() -> UInt64 {
         let snap = memorySnapshot()
+        let total: UInt64
+        let systemAvailable: UInt64
+        if let memoryLimitBytes {
+            total = min(snap.total, memoryLimitBytes)
+            systemAvailable = min(snap.systemAvailable, memoryLimitBytes)
+        } else {
+            total = snap.total
+            systemAvailable = snap.systemAvailable
+        }
         let mlxUsed = Self.saturatingAdd(snap.active, snap.cache)
-        let mlxFree = snap.total > mlxUsed ? snap.total - mlxUsed : 0
+        let mlxFree = total > mlxUsed ? total - mlxUsed : 0
         // Clamp the MLX-only view (blind to other processes) to real OS-free RAM,
         // mirroring the load gate (ModelLoadAdmission.freeForLoadGb). Without it
         // the runtime admits against memory other apps hold → jetsam OOM.
-        let realFree = min(mlxFree, snap.systemAvailable)
+        let realFree = min(mlxFree, systemAvailable)
         let usable = realFree > reserveBytes ? realFree - reserveBytes : 0
         let capped = Double(usable) * safetyFactor
         let reservationCap = capped >= Double(UInt64.max) ? UInt64.max : UInt64(capped)

--- a/provider-swift/Sources/ProviderCore/Inference/ModelLoadAdmission.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/ModelLoadAdmission.swift
@@ -48,8 +48,15 @@ public enum ModelLoadAdmission {
         outstandingReservationBytes: UInt64 = 0,
         memoryLimitBytes: UInt64? = nil
     ) -> Double {
-        let effectiveTotal = min(totalBytes, memoryLimitBytes ?? totalBytes)
-        let effectiveSystemAvailable = min(systemAvailableBytes, memoryLimitBytes ?? systemAvailableBytes)
+        let effectiveTotal: UInt64
+        let effectiveSystemAvailable: UInt64
+        if let memoryLimitBytes {
+            effectiveTotal = min(totalBytes, memoryLimitBytes)
+            effectiveSystemAvailable = min(systemAvailableBytes, memoryLimitBytes)
+        } else {
+            effectiveTotal = totalBytes
+            effectiveSystemAvailable = systemAvailableBytes
+        }
         let mlxUsed = saturatingAdd(gpuActiveBytes, gpuCacheBytes)
         let mlxFree = effectiveTotal > mlxUsed ? effectiveTotal - mlxUsed : 0
         // The OS view and the MLX view can each be the tighter bound; take the

--- a/provider-swift/Sources/ProviderCore/Inference/ModelLoadAdmission.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/ModelLoadAdmission.swift
@@ -45,13 +45,16 @@ public enum ModelLoadAdmission {
         gpuActiveBytes: UInt64,
         gpuCacheBytes: UInt64,
         reserveBytes: UInt64,
-        outstandingReservationBytes: UInt64 = 0
+        outstandingReservationBytes: UInt64 = 0,
+        memoryLimitBytes: UInt64? = nil
     ) -> Double {
+        let effectiveTotal = min(totalBytes, memoryLimitBytes ?? totalBytes)
+        let effectiveSystemAvailable = min(systemAvailableBytes, memoryLimitBytes ?? systemAvailableBytes)
         let mlxUsed = saturatingAdd(gpuActiveBytes, gpuCacheBytes)
-        let mlxFree = totalBytes > mlxUsed ? totalBytes - mlxUsed : 0
+        let mlxFree = effectiveTotal > mlxUsed ? effectiveTotal - mlxUsed : 0
         // The OS view and the MLX view can each be the tighter bound; take the
         // smaller so we never over-count free memory.
-        let realFree = min(mlxFree, systemAvailableBytes)
+        let realFree = min(mlxFree, effectiveSystemAvailable)
         let committed = saturatingAdd(reserveBytes, outstandingReservationBytes)
         let usable = realFree > committed ? realFree - committed : 0
         return Double(usable) / bytesPerGb
@@ -72,7 +75,8 @@ public enum ModelLoadAdmission {
         gpuActiveBytes: UInt64,
         gpuCacheBytes: UInt64,
         reserveBytes: UInt64,
-        outstandingReservationBytes: UInt64 = 0
+        outstandingReservationBytes: UInt64 = 0,
+        memoryLimitBytes: UInt64? = nil
     ) -> Bool {
         let free = freeForLoadGb(
             totalBytes: totalBytes,
@@ -80,7 +84,8 @@ public enum ModelLoadAdmission {
             gpuActiveBytes: gpuActiveBytes,
             gpuCacheBytes: gpuCacheBytes,
             reserveBytes: reserveBytes,
-            outstandingReservationBytes: outstandingReservationBytes)
+            outstandingReservationBytes: outstandingReservationBytes,
+            memoryLimitBytes: memoryLimitBytes)
         return requiredToLoadGb(weightsGb: weightsGb, headroomGb: headroomGb) <= free
     }
 

--- a/provider-swift/Sources/ProviderCore/ProviderLoop.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop.swift
@@ -460,15 +460,19 @@ public actor ProviderLoop {
         return overflow ? UInt64.max : bytes
     }
 
-    private var memoryLimitBytes: UInt64? {
-        ProviderMemoryLimit.limitBytes(limitGB: loopConfig.config.provider.memoryLimitGB)
-    }
-
-    private var effectivePhysicalMemoryBytes: UInt64 {
-        ProviderMemoryLimit.effectiveTotalBytes(
+    private var effectiveMemory: ProviderMemoryLimit.EffectiveBytes {
+        ProviderMemoryLimit.effectiveBytes(
             physicalBytes: ProcessInfo.processInfo.physicalMemory,
             limitGB: loopConfig.config.provider.memoryLimitGB
         )
+    }
+
+    private var memoryLimitBytes: UInt64? {
+        effectiveMemory.limitBytes
+    }
+
+    private var effectivePhysicalMemoryBytes: UInt64 {
+        effectiveMemory.totalBytes
     }
 
     // MARK: - Model Slot

--- a/provider-swift/Sources/ProviderCore/ProviderLoop.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop.swift
@@ -159,6 +159,7 @@ public actor ProviderLoop {
     private let stats: AtomicProviderStats
     private let state: ProviderState
     private let cancellationRegistry: InferenceCancellationRegistry
+    private let effectiveMemory: ProviderMemoryLimit.EffectiveBytes
     private let kvBudget: GlobalKVCacheBudget
     /// Phase 3: global disk accountant (process-wide, shared across models).
     private let diskAccountant: GlobalDiskAccountant
@@ -432,6 +433,11 @@ public actor ProviderLoop {
         self.stats = AtomicProviderStats()
         self.state = ProviderState()
         self.cancellationRegistry = InferenceCancellationRegistry()
+        let effectiveMemory = ProviderMemoryLimit.effectiveBytes(
+            physicalBytes: ProcessInfo.processInfo.physicalMemory,
+            limitGB: config.config.provider.memoryLimitGB
+        )
+        self.effectiveMemory = effectiveMemory
         // The effective cap (`maxModelSlots`) is computed from the live
         // advertised set; here we capture the operator hard cap and the
         // de-duplicated startup count it is clamped against. Using the deduped
@@ -442,7 +448,7 @@ public actor ProviderLoop {
         let reserveBytes = Self.memoryReserveBytes(forGiB: config.config.provider.memoryReserveGB)
         self.kvBudget = GlobalKVCacheBudget(
             reserveBytes: reserveBytes,
-            memoryLimitBytes: ProviderMemoryLimit.limitBytes(limitGB: config.config.provider.memoryLimitGB)
+            memoryLimitBytes: effectiveMemory.limitBytes
         )
         // Phase 3: construct the global disk accountant (one per host).
         let kvRoot = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first?
@@ -461,13 +467,6 @@ public actor ProviderLoop {
     static func memoryReserveBytes(forGiB gb: UInt64) -> UInt64 {
         let (bytes, overflow) = gb.multipliedReportingOverflow(by: bytesPerGiB)
         return overflow ? UInt64.max : bytes
-    }
-
-    private var effectiveMemory: ProviderMemoryLimit.EffectiveBytes {
-        ProviderMemoryLimit.effectiveBytes(
-            physicalBytes: ProcessInfo.processInfo.physicalMemory,
-            limitGB: loopConfig.config.provider.memoryLimitGB
-        )
     }
 
     private var memoryLimitBytes: UInt64? {

--- a/provider-swift/Sources/ProviderCore/ProviderLoop.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop.swift
@@ -460,6 +460,17 @@ public actor ProviderLoop {
         return overflow ? UInt64.max : bytes
     }
 
+    private var memoryLimitBytes: UInt64? {
+        ProviderMemoryLimit.limitBytes(limitGB: loopConfig.config.provider.memoryLimitGB)
+    }
+
+    private var effectivePhysicalMemoryBytes: UInt64 {
+        ProviderMemoryLimit.effectiveTotalBytes(
+            physicalBytes: ProcessInfo.processInfo.physicalMemory,
+            limitGB: loopConfig.config.provider.memoryLimitGB
+        )
+    }
+
     // MARK: - Model Slot
 
     private static let schedulerMaxConcurrent = 24
@@ -2119,7 +2130,7 @@ public actor ProviderLoop {
         // first big allocation happens in ensureModelLoaded → loadModelContainer,
         // which runs after this). Idempotent; the BatchScheduler.loadModel call
         // is a backstop for the standalone path. See MLXMemoryGuard.
-        MLXMemoryGuard.configureOnce(log: { [logger] limits in
+        MLXMemoryGuard.configureOnce(physicalBytes: effectivePhysicalMemoryBytes, log: { [logger] limits in
             logger.info(
                 "MLX memory ceiling: limit=\(limits.memoryLimitBytes / (1024 * 1024 * 1024))GB cache=\(limits.cacheLimitBytes / (1024 * 1024 * 1024))GB")
         })
@@ -2814,7 +2825,8 @@ public actor ProviderLoop {
             gpuActiveBytes: UInt64(max(0, MLX.GPU.activeMemory)),
             gpuCacheBytes: UInt64(max(0, MLX.GPU.cacheMemory)),
             reserveBytes: Self.memoryReserveBytes(forGiB: loopConfig.config.provider.memoryReserveGB),
-            outstandingReservationBytes: outstanding)
+            outstandingReservationBytes: outstanding,
+            memoryLimitBytes: memoryLimitBytes)
     }
 
     /// Headroom (GB) reserved above the weights at load time for ONE request.
@@ -3098,7 +3110,7 @@ public actor ProviderLoop {
         }
 
         let gbDivisor = 1024.0 * 1024.0 * 1024.0
-        let totalMem = ProcessInfo.processInfo.physicalMemory
+        let totalMem = effectivePhysicalMemoryBytes
         state.backendCapacity = BackendCapacity(
             slots: allSlots,
             gpuMemoryActiveGb: Double(MLX.GPU.activeMemory) / gbDivisor,

--- a/provider-swift/Sources/ProviderCore/ProviderLoop.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop.swift
@@ -440,7 +440,10 @@ public actor ProviderLoop {
         self.configuredMaxModelSlots = max(1, Int(config.config.backend.maxModelSlots))
         self.startupModelCount = max(1, advertised.count)
         let reserveBytes = Self.memoryReserveBytes(forGiB: config.config.provider.memoryReserveGB)
-        self.kvBudget = GlobalKVCacheBudget(reserveBytes: reserveBytes)
+        self.kvBudget = GlobalKVCacheBudget(
+            reserveBytes: reserveBytes,
+            memoryLimitBytes: ProviderMemoryLimit.limitBytes(limitGB: config.config.provider.memoryLimitGB)
+        )
         // Phase 3: construct the global disk accountant (one per host).
         let kvRoot = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first?
             .appendingPathComponent("darkbloom/kv", isDirectory: true)
@@ -2692,7 +2695,8 @@ public actor ProviderLoop {
                 pendingTimeout: Self.schedulerPendingTimeout,
                 defaultMaxTokens: Self.schedulerDefaultMaxTokens,
                 kvBudget: kvBudget,
-                diskAccountant: diskAccountant
+                diskAccountant: diskAccountant,
+                totalMemoryBytes: effectivePhysicalMemoryBytes
             )
             await scheduler.loadModel(
                 container: container,

--- a/provider-swift/Sources/ProviderCore/Server/StandaloneServer.swift
+++ b/provider-swift/Sources/ProviderCore/Server/StandaloneServer.swift
@@ -112,7 +112,9 @@ public actor StandaloneServer {
     ) {
         self.config = config
         self.models = models
-        self.kvBudget = GlobalKVCacheBudget()
+        self.kvBudget = GlobalKVCacheBudget(
+            memoryLimitBytes: ProviderMemoryLimit.limitBytes(limitGB: config.memoryLimitGB)
+        )
         // Phase 3: construct the global disk accountant (one per host).
         let kvRoot = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first?
             .appendingPathComponent("darkbloom/kv", isDirectory: true)
@@ -264,7 +266,11 @@ public actor StandaloneServer {
             pendingTimeout: Self.schedulerPendingTimeout,
             defaultMaxTokens: Self.schedulerDefaultMaxTokens,
             kvBudget: kvBudget,
-            diskAccountant: diskAccountant
+            diskAccountant: diskAccountant,
+            totalMemoryBytes: ProviderMemoryLimit.effectiveBytes(
+                physicalBytes: ProcessInfo.processInfo.physicalMemory,
+                limitGB: config.memoryLimitGB
+            ).totalBytes
         )
         await scheduler.loadModel(container: container, modelId: modelId)
         let tokenizer: TokenizerHandle = await container.perform { ctx in

--- a/provider-swift/Sources/ProviderCore/Server/StandaloneServer.swift
+++ b/provider-swift/Sources/ProviderCore/Server/StandaloneServer.swift
@@ -123,10 +123,10 @@ public actor StandaloneServer {
         // Pin the MLX memory ceiling before any model weights load on this path
         // (the coordinator path does this in ProviderLoop.startMemoryProtection).
         MLXMemoryGuard.configureOnce(
-            physicalBytes: ProviderMemoryLimit.effectiveTotalBytes(
+            physicalBytes: ProviderMemoryLimit.effectiveBytes(
                 physicalBytes: ProcessInfo.processInfo.physicalMemory,
                 limitGB: config.memoryLimitGB
-            )
+            ).totalBytes
         )
     }
 

--- a/provider-swift/Sources/ProviderCore/Server/StandaloneServer.swift
+++ b/provider-swift/Sources/ProviderCore/Server/StandaloneServer.swift
@@ -51,12 +51,21 @@ public struct StandaloneServerConfig: Sendable {
     /// Bearer token required on every inference route (direct/local mode).
     /// nil = no auth (library default / explicit `--no-auth`).
     public let authToken: String?
+    /// Optional hard cap for local inference memory. nil = use physical RAM.
+    public let memoryLimitGB: UInt64?
 
-    public init(port: UInt16 = 8000, host: String = "127.0.0.1", maxCachedModels: Int = 3, authToken: String? = nil) {
+    public init(
+        port: UInt16 = 8000,
+        host: String = "127.0.0.1",
+        maxCachedModels: Int = 3,
+        authToken: String? = nil,
+        memoryLimitGB: UInt64? = nil
+    ) {
         self.port = port
         self.host = host
         self.maxCachedModels = max(1, maxCachedModels)
         self.authToken = authToken
+        self.memoryLimitGB = memoryLimitGB
     }
 }
 
@@ -113,7 +122,12 @@ public actor StandaloneServer {
             configuredCeiling: BatchScheduler.prefixCacheGlobalDiskCeiling())
         // Pin the MLX memory ceiling before any model weights load on this path
         // (the coordinator path does this in ProviderLoop.startMemoryProtection).
-        MLXMemoryGuard.configureOnce()
+        MLXMemoryGuard.configureOnce(
+            physicalBytes: ProviderMemoryLimit.effectiveTotalBytes(
+                physicalBytes: ProcessInfo.processInfo.physicalMemory,
+                limitGB: config.memoryLimitGB
+            )
+        )
     }
 
     static let schedulerMaxConcurrent = 24
@@ -348,7 +362,8 @@ public actor StandaloneServer {
             gpuActiveBytes: UInt64(max(0, MLX.GPU.activeMemory)),
             gpuCacheBytes: UInt64(max(0, MLX.GPU.cacheMemory)),
             reserveBytes: 0,
-            outstandingReservationBytes: outstanding)
+            outstandingReservationBytes: outstanding,
+            memoryLimitBytes: ProviderMemoryLimit.limitBytes(limitGB: config.memoryLimitGB))
     }
 
     /// Touch the cached scheduler's last-used timestamp on access.
@@ -561,4 +576,3 @@ public actor StandaloneServer {
         }
     }
 }
-

--- a/provider-swift/Sources/ProviderCore/Service/LaunchAgent.swift
+++ b/provider-swift/Sources/ProviderCore/Service/LaunchAgent.swift
@@ -105,6 +105,7 @@ public enum LaunchAgent: Sendable {
         coordinatorURL: String,
         models: [String] = [],
         idleTimeout: UInt64? = nil,
+        memoryLimitGB: UInt64? = nil,
         localEndpoint: LocalEndpointOptions = LocalEndpointOptions()
     ) throws {
         // Determine the binary path (current executable)
@@ -124,6 +125,7 @@ public enum LaunchAgent: Sendable {
             coordinatorURL: coordinatorURL,
             models: models,
             idleTimeout: idleTimeout,
+            memoryLimitGB: memoryLimitGB,
             localEndpoint: localEndpoint
         )
         try loadService()
@@ -264,6 +266,7 @@ public enum LaunchAgent: Sendable {
         coordinatorURL: String,
         models: [String],
         idleTimeout: UInt64?,
+        memoryLimitGB: UInt64?,
         localEndpoint: LocalEndpointOptions = LocalEndpointOptions()
     ) throws {
         let plist = plistPath()
@@ -275,7 +278,38 @@ public enum LaunchAgent: Sendable {
 
         let log = logPath().path
 
-        // Build the ProgramArguments array.
+        let programArguments = Self.programArguments(
+            binaryPath: binaryPath,
+            coordinatorURL: coordinatorURL,
+            models: models,
+            idleTimeout: idleTimeout,
+            memoryLimitGB: memoryLimitGB,
+            localEndpoint: localEndpoint
+        )
+
+        let plistDict = makeServicePlist(
+            label: label,
+            programArguments: programArguments,
+            logPath: log,
+            environment: ProcessInfo.processInfo.environment
+        )
+
+        let data = try PropertyListSerialization.data(
+            fromPropertyList: plistDict,
+            format: .xml,
+            options: 0
+        )
+        try data.write(to: plist, options: .atomic)
+    }
+
+    static func programArguments(
+        binaryPath: String,
+        coordinatorURL: String,
+        models: [String],
+        idleTimeout: UInt64?,
+        memoryLimitGB: UInt64?,
+        localEndpoint: LocalEndpointOptions = LocalEndpointOptions()
+    ) -> [String] {
         var programArguments: [String] = [
             binaryPath,
             "start",
@@ -291,6 +325,10 @@ public enum LaunchAgent: Sendable {
             programArguments.append("--idle-timeout")
             programArguments.append("\(timeout)")
         }
+        if let memoryLimitGB, memoryLimitGB > 0 {
+            programArguments.append("--memory-limit-gb")
+            programArguments.append("\(memoryLimitGB)")
+        }
         if localEndpoint.enabled {
             programArguments.append("--local-endpoint")
             programArguments.append(contentsOf: ["--port", "\(localEndpoint.port)"])
@@ -299,20 +337,7 @@ public enum LaunchAgent: Sendable {
                 programArguments.append("--no-auth")
             }
         }
-
-        let plistDict = makeServicePlist(
-            label: label,
-            programArguments: programArguments,
-            logPath: log,
-            environment: ProcessInfo.processInfo.environment
-        )
-
-        let data = try PropertyListSerialization.data(
-            fromPropertyList: plistDict,
-            format: .xml,
-            options: 0
-        )
-        try data.write(to: plist, options: .atomic)
+        return programArguments
     }
 
     /// Build the launchd plist dictionary for the provider service. Pure (no I/O)

--- a/provider-swift/Sources/darkbloom/Darkbloom.swift
+++ b/provider-swift/Sources/darkbloom/Darkbloom.swift
@@ -97,6 +97,7 @@ struct RuntimeSnapshot {
     let configPath: URL
     let configFileExists: Bool
     let config: ProviderConfig
+    let physicalHardware: HardwareInfo?
     let hardware: HardwareInfo?
     let hardwareError: Error?
     let models: [ModelInfo]
@@ -133,15 +134,39 @@ func loadRuntimeSnapshot(configPath rawPath: String?) throws -> RuntimeSnapshot 
     // Auto-migrate stale config values (idempotent, best-effort).
     config = migrateConfigIfNeeded(configPath: configPath, config: config)
 
-    let models = hardware.map { ModelScanner.scanModels(hardwareInfo: $0) } ?? []
+    let effectiveHardware = hardware.map {
+        ProviderMemoryLimit.effectiveHardware($0, settings: config.provider)
+    }
+    let models = effectiveHardware.map { ModelScanner.scanModels(hardwareInfo: $0) } ?? []
 
     return RuntimeSnapshot(
         configPath: configPath,
         configFileExists: configFileExists,
         config: config,
-        hardware: hardware,
+        physicalHardware: hardware,
+        hardware: effectiveHardware,
         hardwareError: hardwareError,
         models: models
+    )
+}
+
+func runtimeSnapshot(
+    from snapshot: RuntimeSnapshot,
+    config: ProviderConfig,
+    hardware: HardwareInfo
+) -> RuntimeSnapshot {
+    let effectiveHardware = ProviderMemoryLimit.effectiveHardware(
+        hardware,
+        settings: config.provider
+    )
+    return RuntimeSnapshot(
+        configPath: snapshot.configPath,
+        configFileExists: snapshot.configFileExists,
+        config: config,
+        physicalHardware: snapshot.physicalHardware,
+        hardware: effectiveHardware,
+        hardwareError: snapshot.hardwareError,
+        models: ModelScanner.scanModels(hardwareInfo: effectiveHardware)
     )
 }
 

--- a/provider-swift/Sources/darkbloom/Darkbloom.swift
+++ b/provider-swift/Sources/darkbloom/Darkbloom.swift
@@ -134,9 +134,7 @@ func loadRuntimeSnapshot(configPath rawPath: String?) throws -> RuntimeSnapshot 
     // Auto-migrate stale config values (idempotent, best-effort).
     config = migrateConfigIfNeeded(configPath: configPath, config: config)
 
-    let effectiveHardware = hardware.map {
-        ProviderMemoryLimit.effectiveHardware($0, settings: config.provider)
-    }
+    let effectiveHardware = hardware.map { effectiveProviderHardware($0, config: config) }
     let models = effectiveHardware.map { ModelScanner.scanModels(hardwareInfo: $0) } ?? []
 
     return RuntimeSnapshot(
@@ -155,10 +153,7 @@ func runtimeSnapshot(
     config: ProviderConfig,
     hardware: HardwareInfo
 ) -> RuntimeSnapshot {
-    let effectiveHardware = ProviderMemoryLimit.effectiveHardware(
-        hardware,
-        settings: config.provider
-    )
+    let effectiveHardware = effectiveProviderHardware(hardware, config: config)
     return RuntimeSnapshot(
         configPath: snapshot.configPath,
         configFileExists: snapshot.configFileExists,
@@ -167,6 +162,14 @@ func runtimeSnapshot(
         hardware: effectiveHardware,
         hardwareError: snapshot.hardwareError,
         models: ModelScanner.scanModels(hardwareInfo: effectiveHardware)
+    )
+}
+
+func effectiveProviderHardware(_ hardware: HardwareInfo, config: ProviderConfig) -> HardwareInfo {
+    ProviderMemoryLimit.effectiveHardware(
+        hardware,
+        limitGB: config.provider.memoryLimitGB,
+        reserveGB: config.provider.memoryReserveGB
     )
 }
 

--- a/provider-swift/Sources/darkbloom/StartCommand.swift
+++ b/provider-swift/Sources/darkbloom/StartCommand.swift
@@ -63,6 +63,21 @@ struct Start: AsyncParsableCommand {
         print()
     }
 
+    static func persistMemoryLimitOverride(
+        memoryLimitGB: UInt64?,
+        baseConfig: ProviderConfig,
+        to configPath: URL
+    ) throws -> ProviderConfig {
+        guard let memoryLimitGB else {
+            return baseConfig
+        }
+
+        var persisted = baseConfig
+        persisted.provider.memoryLimitGB = memoryLimitGB
+        try ConfigManager.save(persisted, to: configPath)
+        return persisted
+    }
+
     mutating func run() async throws {
         Darkbloom.ensureLogging()
 
@@ -105,6 +120,19 @@ struct Start: AsyncParsableCommand {
             printError("Cannot start: hardware detection failed (\(snapshot.hardwareError?.localizedDescription ?? "unknown"))")
             throw ExitCode.failure
         }
+        if memoryLimitGB != nil {
+            let configPath = try startConfigPersistencePath(snapshot: snapshot)
+            do {
+                _ = try Self.persistMemoryLimitOverride(
+                    memoryLimitGB: memoryLimitGB,
+                    baseConfig: snapshot.config,
+                    to: configPath
+                )
+            } catch {
+                printError("Could not save --memory-limit-gb to \(configPath.path): \(error)")
+                throw ExitCode.failure
+            }
+        }
         let effectiveSnapshot = runtimeSnapshot(
             from: snapshot,
             config: effectiveConfig,
@@ -135,6 +163,13 @@ struct Start: AsyncParsableCommand {
                 coordinatorURL: effectiveCoordinator
             )
         }
+    }
+
+    private func startConfigPersistencePath(snapshot: RuntimeSnapshot) throws -> URL {
+        guard configOptions.config == nil else {
+            return snapshot.configPath
+        }
+        return try ConfigManager.defaultConfigPath()
     }
 
     // MARK: - Standalone (--local)

--- a/provider-swift/Sources/darkbloom/StartCommand.swift
+++ b/provider-swift/Sources/darkbloom/StartCommand.swift
@@ -59,6 +59,15 @@ struct Start: AsyncParsableCommand {
         let coordinatorURL: String
     }
 
+    struct ModelSelectionError: Error, CustomStringConvertible, Equatable {
+        let missingIDs: [String]
+
+        var description: String {
+            let ids = missingIDs.joined(separator: ", ")
+            return "Selected model(s) are unavailable under the current provider configuration: \(ids)"
+        }
+    }
+
     /// Prints a one-line terms-of-service notice. Starting the provider is the
     /// act of acceptance — there is no separate yes/no prompt — so this is an
     /// informational notice, not a gate. Shown only for the user-facing
@@ -83,6 +92,18 @@ struct Start: AsyncParsableCommand {
         persisted.provider.memoryLimitGB = memoryLimitGB
         try ConfigManager.save(persisted, to: configPath)
         return persisted
+    }
+
+    static func validatedModelOverrideIDs(
+        _ modelIDs: [String],
+        availableModels: [ModelInfo]
+    ) throws -> [String] {
+        let available = Set(availableModels.map(\.id))
+        let missing = modelIDs.filter { !available.contains($0) }
+        guard missing.isEmpty else {
+            throw ModelSelectionError(missingIDs: missing)
+        }
+        return modelIDs
     }
 
     private func prepareStartConfiguration(snapshot: RuntimeSnapshot) throws -> PreparedStartConfiguration {
@@ -593,7 +614,15 @@ struct Start: AsyncParsableCommand {
         let selectedModelIDs: [String]
 
         if !model.isEmpty {
-            selectedModelIDs = model
+            do {
+                selectedModelIDs = try Self.validatedModelOverrideIDs(
+                    model,
+                    availableModels: snapshot.models
+                )
+            } catch {
+                printError("\(error)")
+                throw ExitCode.failure
+            }
         } else if all {
             selectedModelIDs = snapshot.models.map(\.id)
         } else {

--- a/provider-swift/Sources/darkbloom/StartCommand.swift
+++ b/provider-swift/Sources/darkbloom/StartCommand.swift
@@ -52,6 +52,13 @@ struct Start: AsyncParsableCommand {
     /// Public URL of the Darkbloom Terms of Service.
     static let termsURL = "https://darkbloom.dev/terms.html"
 
+    private struct PreparedStartConfiguration {
+        let snapshot: RuntimeSnapshot
+        let config: ProviderConfig
+        let hardware: HardwareInfo
+        let coordinatorURL: String
+    }
+
     /// Prints a one-line terms-of-service notice. Starting the provider is the
     /// act of acceptance — there is no separate yes/no prompt — so this is an
     /// informational notice, not a gate. Shown only for the user-facing
@@ -78,31 +85,7 @@ struct Start: AsyncParsableCommand {
         return persisted
     }
 
-    mutating func run() async throws {
-        Darkbloom.ensureLogging()
-
-        if !foreground {
-            printTermsNotice()
-        }
-
-        // --local (coordinator-less) and --local-endpoint (alongside the
-        // coordinator) are mutually exclusive serve modes; reject the ambiguous
-        // combination rather than silently picking one.
-        if local && localEndpoint {
-            printError("--local and --local-endpoint are mutually exclusive: use --local for a coordinator-less local server, or --local-endpoint to serve a local endpoint alongside the coordinator.")
-            throw ExitCode.failure
-        }
-
-        // GPU is required. Reject CPU fallback up-front so we never
-        // come up reporting healthy and then silently churn at 0.5 tok/s.
-        do {
-            _ = try GPUEnforcement.requireMetal()
-        } catch {
-            printError("\(error)")
-            throw ExitCode.failure
-        }
-
-        let snapshot = try loadRuntimeSnapshot(configOptions: configOptions)
+    private func prepareStartConfiguration(snapshot: RuntimeSnapshot) throws -> PreparedStartConfiguration {
         let effectiveCoordinator = coordinatorURL ?? snapshot.config.coordinator.url
         var effectiveConfig = snapshot.config
         if let idleTimeout {
@@ -133,6 +116,7 @@ struct Start: AsyncParsableCommand {
                 throw ExitCode.failure
             }
         }
+
         let effectiveSnapshot = runtimeSnapshot(
             from: snapshot,
             config: effectiveConfig,
@@ -143,24 +127,59 @@ struct Start: AsyncParsableCommand {
             throw ExitCode.failure
         }
 
+        return PreparedStartConfiguration(
+            snapshot: effectiveSnapshot,
+            config: effectiveConfig,
+            hardware: effectiveHardware,
+            coordinatorURL: effectiveCoordinator
+        )
+    }
+
+    mutating func run() async throws {
+        Darkbloom.ensureLogging()
+
+        if !foreground {
+            printTermsNotice()
+        }
+
+        // --local (coordinator-less) and --local-endpoint (alongside the
+        // coordinator) are mutually exclusive serve modes; reject the ambiguous
+        // combination rather than silently picking one.
+        if local && localEndpoint {
+            printError("--local and --local-endpoint are mutually exclusive: use --local for a coordinator-less local server, or --local-endpoint to serve a local endpoint alongside the coordinator.")
+            throw ExitCode.failure
+        }
+
+        // GPU is required. Reject CPU fallback up-front so we never
+        // come up reporting healthy and then silently churn at 0.5 tok/s.
+        do {
+            _ = try GPUEnforcement.requireMetal()
+        } catch {
+            printError("\(error)")
+            throw ExitCode.failure
+        }
+
+        let snapshot = try loadRuntimeSnapshot(configOptions: configOptions)
+        let prepared = try prepareStartConfiguration(snapshot: snapshot)
+
         if local {
             try await runLocalStandalone(
-                snapshot: effectiveSnapshot,
-                config: effectiveConfig,
-                hardware: effectiveHardware
+                snapshot: prepared.snapshot,
+                config: prepared.config,
+                hardware: prepared.hardware
             )
         } else if foreground {
             try await runForeground(
-                snapshot: effectiveSnapshot,
-                hardware: effectiveHardware,
-                config: effectiveConfig,
-                coordinatorURL: effectiveCoordinator
+                snapshot: prepared.snapshot,
+                hardware: prepared.hardware,
+                config: prepared.config,
+                coordinatorURL: prepared.coordinatorURL
             )
         } else {
             try await launchDaemon(
-                snapshot: effectiveSnapshot,
-                config: effectiveConfig,
-                coordinatorURL: effectiveCoordinator
+                snapshot: prepared.snapshot,
+                config: prepared.config,
+                coordinatorURL: prepared.coordinatorURL
             )
         }
     }

--- a/provider-swift/Sources/darkbloom/StartCommand.swift
+++ b/provider-swift/Sources/darkbloom/StartCommand.swift
@@ -106,9 +106,8 @@ struct Start: AsyncParsableCommand {
         return modelIDs
     }
 
-    private func prepareStartConfiguration(snapshot: RuntimeSnapshot) throws -> PreparedStartConfiguration {
-        let effectiveCoordinator = coordinatorURL ?? snapshot.config.coordinator.url
-        var effectiveConfig = snapshot.config
+    private func providerConfigApplyingOverrides(_ baseConfig: ProviderConfig) throws -> ProviderConfig {
+        var effectiveConfig = baseConfig
         if let idleTimeout {
             effectiveConfig.backend.idleTimeoutMins = idleTimeout
         }
@@ -119,24 +118,33 @@ struct Start: AsyncParsableCommand {
             }
             effectiveConfig.provider.memoryLimitGB = memoryLimitGB
         }
+        return effectiveConfig
+    }
+
+    private func persistMemoryLimitOverrideIfNeeded(snapshot: RuntimeSnapshot) throws {
+        guard memoryLimitGB != nil else { return }
+        let configPath = try startConfigPersistencePath(snapshot: snapshot)
+        do {
+            _ = try Self.persistMemoryLimitOverride(
+                memoryLimitGB: memoryLimitGB,
+                baseConfig: snapshot.config,
+                to: configPath
+            )
+        } catch {
+            printError("Could not save --memory-limit-gb to \(configPath.path): \(error)")
+            throw ExitCode.failure
+        }
+    }
+
+    private func prepareStartConfiguration(snapshot: RuntimeSnapshot) throws -> PreparedStartConfiguration {
+        let effectiveCoordinator = coordinatorURL ?? snapshot.config.coordinator.url
+        let effectiveConfig = try providerConfigApplyingOverrides(snapshot.config)
 
         guard let hardware = snapshot.hardware else {
             printError("Cannot start: hardware detection failed (\(snapshot.hardwareError?.localizedDescription ?? "unknown"))")
             throw ExitCode.failure
         }
-        if memoryLimitGB != nil {
-            let configPath = try startConfigPersistencePath(snapshot: snapshot)
-            do {
-                _ = try Self.persistMemoryLimitOverride(
-                    memoryLimitGB: memoryLimitGB,
-                    baseConfig: snapshot.config,
-                    to: configPath
-                )
-            } catch {
-                printError("Could not save --memory-limit-gb to \(configPath.path): \(error)")
-                throw ExitCode.failure
-            }
-        }
+        try persistMemoryLimitOverrideIfNeeded(snapshot: snapshot)
 
         let effectiveSnapshot = runtimeSnapshot(
             from: snapshot,
@@ -153,6 +161,32 @@ struct Start: AsyncParsableCommand {
             config: effectiveConfig,
             hardware: effectiveHardware,
             coordinatorURL: effectiveCoordinator
+        )
+    }
+
+    private mutating func selectedModelIDsForDaemon(
+        snapshot: RuntimeSnapshot,
+        config: ProviderConfig,
+        coordinatorURL: String
+    ) async throws -> [String] {
+        if !model.isEmpty {
+            do {
+                return try Self.validatedModelOverrideIDs(
+                    model,
+                    availableModels: snapshot.models
+                )
+            } catch {
+                printError("\(error)")
+                throw ExitCode.failure
+            }
+        }
+        if all {
+            return snapshot.models.map(\.id)
+        }
+        return try await interactiveCatalogPicker(
+            snapshot: snapshot,
+            config: config,
+            coordinatorURL: coordinatorURL
         )
     }
 
@@ -611,27 +645,11 @@ struct Start: AsyncParsableCommand {
         // Offer account linking before the model picker.
         await offerInlineLogin(coordinatorURL: coordinatorURL)
 
-        let selectedModelIDs: [String]
-
-        if !model.isEmpty {
-            do {
-                selectedModelIDs = try Self.validatedModelOverrideIDs(
-                    model,
-                    availableModels: snapshot.models
-                )
-            } catch {
-                printError("\(error)")
-                throw ExitCode.failure
-            }
-        } else if all {
-            selectedModelIDs = snapshot.models.map(\.id)
-        } else {
-            selectedModelIDs = try await interactiveCatalogPicker(
-                snapshot: snapshot,
-                config: config,
-                coordinatorURL: coordinatorURL
-            )
-        }
+        let selectedModelIDs = try await selectedModelIDsForDaemon(
+            snapshot: snapshot,
+            config: config,
+            coordinatorURL: coordinatorURL
+        )
 
         guard !selectedModelIDs.isEmpty else {
             printError("No models selected.")

--- a/provider-swift/Sources/darkbloom/StartCommand.swift
+++ b/provider-swift/Sources/darkbloom/StartCommand.swift
@@ -28,6 +28,9 @@ struct Start: AsyncParsableCommand {
     @Option(help: "Idle timeout in minutes before unloading the model.")
     var idleTimeout: UInt64?
 
+    @Option(help: "Limit provider inference memory to this many GiB for model selection, registration, and load admission.")
+    var memoryLimitGB: UInt64?
+
     @Flag(inversion: .prefixedNo, help: .hidden)
     var foreground = false
 
@@ -90,28 +93,44 @@ struct Start: AsyncParsableCommand {
         if let idleTimeout {
             effectiveConfig.backend.idleTimeoutMins = idleTimeout
         }
+        if let memoryLimitGB {
+            guard memoryLimitGB > 0 else {
+                printError("--memory-limit-gb must be greater than 0.")
+                throw ExitCode.failure
+            }
+            effectiveConfig.provider.memoryLimitGB = memoryLimitGB
+        }
 
         guard let hardware = snapshot.hardware else {
+            printError("Cannot start: hardware detection failed (\(snapshot.hardwareError?.localizedDescription ?? "unknown"))")
+            throw ExitCode.failure
+        }
+        let effectiveSnapshot = runtimeSnapshot(
+            from: snapshot,
+            config: effectiveConfig,
+            hardware: snapshot.physicalHardware ?? hardware
+        )
+        guard let effectiveHardware = effectiveSnapshot.hardware else {
             printError("Cannot start: hardware detection failed (\(snapshot.hardwareError?.localizedDescription ?? "unknown"))")
             throw ExitCode.failure
         }
 
         if local {
             try await runLocalStandalone(
-                snapshot: snapshot,
+                snapshot: effectiveSnapshot,
                 config: effectiveConfig,
-                hardware: hardware
+                hardware: effectiveHardware
             )
         } else if foreground {
             try await runForeground(
-                snapshot: snapshot,
-                hardware: hardware,
+                snapshot: effectiveSnapshot,
+                hardware: effectiveHardware,
                 config: effectiveConfig,
                 coordinatorURL: effectiveCoordinator
             )
         } else {
             try await launchDaemon(
-                snapshot: snapshot,
+                snapshot: effectiveSnapshot,
                 config: effectiveConfig,
                 coordinatorURL: effectiveCoordinator
             )
@@ -174,7 +193,8 @@ struct Start: AsyncParsableCommand {
                 port: port,
                 host: bind,
                 maxCachedModels: Int(clamping: config.backend.maxModelSlots),
-                authToken: token
+                authToken: token,
+                memoryLimitGB: config.provider.memoryLimitGB
             ),
             models: advertised
         )
@@ -539,6 +559,7 @@ struct Start: AsyncParsableCommand {
             coordinatorURL: coordinatorURL,
             models: selectedModelIDs,
             idleTimeout: idleTimeout ?? (config.backend.idleTimeoutMins > 0 ? config.backend.idleTimeoutMins : nil),
+            memoryLimitGB: config.provider.memoryLimitGB,
             localEndpoint: LaunchAgent.LocalEndpointOptions(
                 enabled: localEndpoint, port: port, bind: bind, noAuth: noAuth
             )

--- a/provider-swift/Tests/DarkbloomCLITests/StartCommandConfigTests.swift
+++ b/provider-swift/Tests/DarkbloomCLITests/StartCommandConfigTests.swift
@@ -54,6 +54,17 @@ struct StartCommandConfigTests {
         #expect(!FileManager.default.fileExists(atPath: configPath.path))
     }
 
+    @Test("model overrides are rejected when absent from capped model list")
+    func modelOverridesRejectedWhenFilteredByCap() throws {
+        let models = [
+            ModelInfo(id: "small", sizeBytes: 1, estimatedMemoryGb: 4)
+        ]
+
+        #expect(throws: Start.ModelSelectionError.self) {
+            _ = try Start.validatedModelOverrideIDs(["too-large"], availableModels: models)
+        }
+    }
+
     private func tempConfigPath() -> URL {
         FileManager.default.temporaryDirectory
             .appendingPathComponent("start-config-\(UUID().uuidString).toml")

--- a/provider-swift/Tests/DarkbloomCLITests/StartCommandConfigTests.swift
+++ b/provider-swift/Tests/DarkbloomCLITests/StartCommandConfigTests.swift
@@ -1,0 +1,61 @@
+import Foundation
+import ProviderCore
+import Testing
+
+@testable import darkbloom
+
+@Suite("Start command config persistence")
+struct StartCommandConfigTests {
+
+    @Test("memory-limit override is written to provider config")
+    func memoryLimitOverridePersistsToConfig() throws {
+        let configPath = tempConfigPath()
+        defer { try? FileManager.default.removeItem(at: configPath) }
+
+        let original = ProviderConfig(
+            provider: ProviderSettings(name: "test-provider", memoryReserveGB: 6),
+            backend: BackendSettings(idleTimeoutMins: 45),
+            coordinator: CoordinatorSettings(url: "wss://example.test/ws/provider", heartbeatIntervalSecs: 9)
+        )
+        try ConfigManager.save(original, to: configPath)
+
+        let persisted = try Start.persistMemoryLimitOverride(
+            memoryLimitGB: 24,
+            baseConfig: original,
+            to: configPath
+        )
+        let reloaded = try ConfigManager.load(from: configPath)
+
+        #expect(persisted.provider.memoryLimitGB == 24)
+        #expect(reloaded.provider.memoryLimitGB == 24)
+        #expect(reloaded.provider.memoryReserveGB == 6)
+        #expect(reloaded.backend.idleTimeoutMins == 45)
+        #expect(reloaded.coordinator.url == "wss://example.test/ws/provider")
+    }
+
+    @Test("absent memory-limit override does not write config")
+    func absentMemoryLimitOverrideDoesNotWriteConfig() throws {
+        let configPath = tempConfigPath()
+        defer { try? FileManager.default.removeItem(at: configPath) }
+
+        let original = ProviderConfig(
+            provider: ProviderSettings(name: "test-provider"),
+            backend: BackendSettings(),
+            coordinator: CoordinatorSettings()
+        )
+
+        let returned = try Start.persistMemoryLimitOverride(
+            memoryLimitGB: nil,
+            baseConfig: original,
+            to: configPath
+        )
+
+        #expect(returned == original)
+        #expect(!FileManager.default.fileExists(atPath: configPath.path))
+    }
+
+    private func tempConfigPath() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("start-config-\(UUID().uuidString).toml")
+    }
+}

--- a/provider-swift/Tests/ProviderCoreTests/BatchSchedulerBudgetTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/BatchSchedulerBudgetTests.swift
@@ -72,6 +72,32 @@ struct BatchSchedulerBudgetTests {
             "P1 gate: third bridge pushing cumulative over tokenBudgetMax must trigger rejection")
     }
 
+    @Test("scheduler stores configured total memory cap")
+    func schedulerStoresConfiguredTotalMemoryCap() async {
+        let cappedBytes = UInt64(8 * 1_073_741_824)
+        let scheduler = BatchScheduler(totalMemoryBytes: cappedBytes)
+
+        #expect(await scheduler.totalMemoryBytes == cappedBytes)
+    }
+
+    @Test("token budget math uses capped total memory")
+    func tokenBudgetMathUsesCappedTotalMemory() {
+        let gib = 1_073_741_824
+        let budget = BatchScheduler.memoryAwareTokenBudgetMax(
+            staticBudget: 1_000_000,
+            modelWeightBytes: 2 * gib,
+            kvBytesPerToken: 1_048_576,
+            totalMemoryBytes: UInt64(8 * gib),
+            activeMemoryBytes: 0,
+            cacheMemoryBytes: 0,
+            systemAvailableBytes: .max,
+            activeTokenBudgetUsed: 0
+        )
+
+        #expect(budget >= 1024)
+        #expect(budget < 4_000)
+    }
+
     /// Restored checkpoint hits can hold more live KV than their prompt+decode
     /// token count because the restored cache is already materialized. The
     /// scheduler's active-budget view must charge the explicit reservation, not

--- a/provider-swift/Tests/ProviderCoreTests/ConfigTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/ConfigTests.swift
@@ -11,6 +11,7 @@ import Testing
     """)
 
     #expect(config.backend.maxModelSlots == 3)
+    #expect(config.provider.memoryLimitGB == nil)
 }
 
 @Test func configParsingUsesCustomMaxModelSlots() throws {
@@ -25,6 +26,16 @@ import Testing
     #expect(config.backend.maxModelSlots == 7)
 }
 
+@Test func configParsingUsesCustomProviderMemoryLimit() throws {
+    let config = ConfigManager.parse("""
+    [provider]
+    name = "test-provider"
+    memory_limit_gb = 32
+    """)
+
+    #expect(config.provider.memoryLimitGB == 32)
+}
+
 @Test func configSerializationRoundTripsMaxModelSlots() throws {
     let original = ProviderConfig(
         provider: ProviderSettings(name: "test-provider"),
@@ -37,4 +48,65 @@ import Testing
 
     #expect(toml.contains("max_model_slots"))
     #expect(decoded.backend.maxModelSlots == 5)
+}
+
+@Test func configSerializationRoundTripsProviderMemoryLimit() throws {
+    let original = ProviderConfig(
+        provider: ProviderSettings(name: "test-provider", memoryLimitGB: 24),
+        backend: BackendSettings(),
+        coordinator: CoordinatorSettings()
+    )
+
+    let toml = ConfigManager.serialize(original)
+    let decoded = ConfigManager.parse(toml)
+
+    #expect(toml.contains("memory_limit_gb"))
+    #expect(decoded.provider.memoryLimitGB == 24)
+}
+
+@Test func providerMemoryLimitCapsEffectiveHardware() throws {
+    let hardware = HardwareInfo(
+        machineModel: "Mac16,1",
+        chipName: "Apple M4 Max",
+        chipFamily: .m4,
+        chipTier: .max,
+        memoryGb: 64,
+        memoryAvailableGb: 60,
+        cpuCores: CpuCores(total: 16, performance: 12, efficiency: 4),
+        gpuCores: 40,
+        memoryBandwidthGbs: 546
+    )
+
+    let capped = ProviderMemoryLimit.effectiveHardware(
+        hardware,
+        limitGB: 32,
+        reserveGB: 4
+    )
+
+    #expect(capped.memoryGb == 32)
+    #expect(capped.memoryAvailableGb == 28)
+    #expect(capped.gpuCores == hardware.gpuCores)
+}
+
+@Test func providerMemoryLimitDoesNotInflateSmallHardware() throws {
+    let hardware = HardwareInfo(
+        machineModel: "Mac16,1",
+        chipName: "Apple M4 Max",
+        chipFamily: .m4,
+        chipTier: .max,
+        memoryGb: 24,
+        memoryAvailableGb: 20,
+        cpuCores: CpuCores(total: 16, performance: 12, efficiency: 4),
+        gpuCores: 40,
+        memoryBandwidthGbs: 546
+    )
+
+    let capped = ProviderMemoryLimit.effectiveHardware(
+        hardware,
+        limitGB: 32,
+        reserveGB: 4
+    )
+
+    #expect(capped.memoryGb == 24)
+    #expect(capped.memoryAvailableGb == 20)
 }

--- a/provider-swift/Tests/ProviderCoreTests/GlobalKVCacheBudgetTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/GlobalKVCacheBudgetTests.swift
@@ -70,6 +70,25 @@ import Testing
     #expect(await budget.reserve(requestID: "fits", kvBytesPerToken: 1, tokenCount: 400))
 }
 
+@Test func globalKVCacheBudgetHonorsMemoryLimitCap() async {
+    let budget = GlobalKVCacheBudget(
+        reserveBytes: 0,
+        safetyFactor: 1.0,
+        memoryLimitBytes: 100_000,
+        memorySnapshot: {
+            GlobalKVCacheBudget.MemorySnapshot(
+                total: 1_000_000,
+                active: 0,
+                cache: 0,
+                systemAvailable: .max
+            )
+        }
+    )
+
+    #expect(!(await budget.reserve(requestID: "over-cap", kvBytesPerToken: 1, tokenCount: 100_001)))
+    #expect(await budget.reserve(requestID: "fits-cap", kvBytesPerToken: 1, tokenCount: 100_000))
+}
+
 @Test func providerLoopMemoryReserveBytesSaturatesOnOverflow() {
     #expect(ProviderLoop.memoryReserveBytes(forGiB: 4) == 4 * 1024 * 1024 * 1024)
     #expect(ProviderLoop.memoryReserveBytes(forGiB: UInt64.max) == UInt64.max)

--- a/provider-swift/Tests/ProviderCoreTests/LaunchAgentRestartTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/LaunchAgentRestartTests.swift
@@ -40,6 +40,37 @@ struct LaunchAgentEnvironmentTests {
 
 @Suite("LaunchAgent service plist")
 struct LaunchAgentServicePlistTests {
+    @Test func programArgumentsIncludeMemoryLimitWhenConfigured() {
+        let args = LaunchAgent.programArguments(
+            binaryPath: "/usr/local/bin/darkbloom",
+            coordinatorURL: "wss://coord/ws/provider",
+            models: ["model-a"],
+            idleTimeout: 30,
+            memoryLimitGB: 24,
+            localEndpoint: LaunchAgent.LocalEndpointOptions(enabled: true, port: 9000, bind: "127.0.0.1", noAuth: true)
+        )
+
+        #expect(args == [
+            "/usr/local/bin/darkbloom",
+            "start",
+            "--foreground",
+            "--coordinator-url",
+            "wss://coord/ws/provider",
+            "--model",
+            "model-a",
+            "--idle-timeout",
+            "30",
+            "--memory-limit-gb",
+            "24",
+            "--local-endpoint",
+            "--port",
+            "9000",
+            "--bind",
+            "127.0.0.1",
+            "--no-auth",
+        ])
+    }
+
     @Test func autoStartsAtLoadAndForwardsAllowlistedEnv() {
         let plist = LaunchAgent.makeServicePlist(
             label: "io.darkbloom.provider",

--- a/provider-swift/Tests/ProviderCoreTests/ModelLoadAdmissionTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/ModelLoadAdmissionTests.swift
@@ -11,6 +11,43 @@ private let gib: UInt64 = 1024 * 1024 * 1024
     #expect(abs(free - 28.0) < 0.001)
 }
 
+@Test func freeForLoadHonorsConfiguredMemoryLimit() {
+    // 64 GB physical box capped to 32 GB should admit like a 32 GB box:
+    // 32 GB cap - 4 GB reserve = 28 GB usable for loading.
+    let free = ModelLoadAdmission.freeForLoadGb(
+        totalBytes: 64 * gib,
+        systemAvailableBytes: .max,
+        gpuActiveBytes: 0,
+        gpuCacheBytes: 0,
+        reserveBytes: 4 * gib,
+        memoryLimitBytes: 32 * gib)
+    #expect(abs(free - 28.0) < 0.001)
+}
+
+@Test func memoryLimitCannotInflatePhysicalMemory() {
+    let free = ModelLoadAdmission.freeForLoadGb(
+        totalBytes: 24 * gib,
+        systemAvailableBytes: .max,
+        gpuActiveBytes: 0,
+        gpuCacheBytes: 0,
+        reserveBytes: 4 * gib,
+        memoryLimitBytes: 64 * gib)
+    #expect(abs(free - 20.0) < 0.001)
+}
+
+@Test func memoryLimitBlocksLoadWhenResidentMemoryAlreadyExceedsCap() {
+    let ok = ModelLoadAdmission.canLoad(
+        weightsGb: 4.0,
+        headroomGb: 2.0,
+        totalBytes: 64 * gib,
+        systemAvailableBytes: .max,
+        gpuActiveBytes: 32 * gib,
+        gpuCacheBytes: 0,
+        reserveBytes: 4 * gib,
+        memoryLimitBytes: 24 * gib)
+    #expect(!ok, "resident MLX memory above the configured cap leaves no load headroom")
+}
+
 @Test func freeForLoadSubtractsResidentAndReserve() {
     // 64 GB, 30 GB already resident (active), 2 GB cache, 4 GB reserve → 28 GB.
     let free = ModelLoadAdmission.freeForLoadGb(


### PR DESCRIPTION
## Summary
- add provider `memory_limit_gb` config and `darkbloom start --memory-limit-gb`
- apply the cap to effective hardware/model scanning, launchd replay args, coordinator capacity, MLX memory ceiling, connected provider load admission, and standalone local mode
- add regression coverage for config parsing/serialization, capped load-admission math, effective hardware, and launchd arguments

## Validation
- `CLANG_MODULE_CACHE_PATH="$PWD/.build/module-cache" swift test --disable-sandbox --filter 'ConfigTests|ModelLoadAdmission|LaunchAgent'`
- `CLANG_MODULE_CACHE_PATH="$PWD/.build/module-cache" swift run --skip-build darkbloom start --help | rg -n "memory-limit|Limit provider"`
- `git show --check --stat --oneline --no-renames HEAD`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/361"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784156104&installation_id=133247490&pr_number=361&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F361&signature=5ea76a2d62e5d6c96a97f4d3822aa6ce5da20af400428992df2a355ccdfd5119"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->