### PR TITLE
stats: clarify leaderboard window is rolling and earnings are early-ramp, not calculator projection

### DIFF
--- a/console-ui/src/app/stats/page.tsx
+++ b/console-ui/src/app/stats/page.tsx
@@ -2244,7 +2244,18 @@ function LeaderboardSection() {
               <h2 className="text-sm font-semibold text-text-primary">Provider Earnings Leaderboard</h2>
             </div>
             <p className="mt-1 max-w-2xl text-xs text-text-tertiary">
-              Pseudonymized provider accounts ranked from the coordinator leaderboard.
+              Pseudonymized provider accounts ranked from the coordinator leaderboard. Each
+              window is a <span className="text-text-secondary">rolling lookback</span> ending now
+              (e.g. 24h = the last 24 hours), not a fixed calendar day.
+            </p>
+            <p className="mt-2 max-w-2xl rounded-lg border border-border-dim bg-bg-secondary px-3 py-2 text-xs text-text-tertiary">
+              These are <span className="text-text-secondary">actual earnings during early network ramp-up</span>,
+              not steady-state figures. Request acceptance is intentionally conservative today and is being
+              scaled up as we validate the data, so live numbers run well below the{" "}
+              <Link href="/earn" className="text-accent-brand hover:underline">
+                earnings calculator
+              </Link>{" "}
+              projection, which estimates potential at full utilization.
             </p>
           </div>
           <div className="flex flex-wrap gap-2">


### PR DESCRIPTION
## What

Adds clarifying copy to the Provider Earnings Leaderboard on `/stats` so the live earnings figures aren't misread as steady-state "today's" numbers.

Two additions to `LeaderboardSection` (`console-ui/src/app/stats/page.tsx`):
1. **Window semantics** — each window is a rolling lookback ending now (24h = the last 24 hours), not a fixed calendar day. Matches the backend `parseLeaderboardWindow` (`now.Add(-24*time.Hour)`).
2. **Ramp-up disclaimer** — figures are actual earnings during early, intentionally-conservative request acceptance, not steady-state, with a link to the `/earn` calculator framed as the full-utilization estimate.

Copy-only; no API, data, or behavior changes.

## Why

Provider feedback on X flagged that the live numbers look "a far cry from what the calculator suggests," @gajesh confirmed the acceptance algo is intentionally conservative, and @0xkydo asked to "add a tag somewhere that these numbers are not 'today's' number." tostr also noted a bare "24h" filter is ambiguous (rolling vs fixed window).

Closes #367

## Verification

- `npx tsc --noEmit` introduces no new errors at the edited lines (pre-existing baseline errors in test fixtures / telemetry / `stats/page.tsx:931` are unrelated).
- `Link` is already imported in the file.

> Note: not rendered in a live browser from this environment — change is copy-only within existing markup/classes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/368"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784223636&installation_id=133247490&pr_number=368&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F368&signature=27c60c4960f3c582de8567d6edc5a8134bbdc92e12880a0bcfa1185ccf80ce58"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->