### PR TITLE
fix(provider): Gemma 4 VLM continuous-batched decode — no more repetition

### DIFF
--- a/provider-swift/Tests/ProviderCoreTests/BatchKVCacheTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/BatchKVCacheTests.swift
@@ -294,6 +294,38 @@ struct BatchKVCacheTests {
         #expect(row1 == [true, true, true, true])
     }
 
+    @Test("single-token decode with no left padding emits no explicit mask")
+    func decodeNoPaddingReturnsNoneMask() {
+        // MLX #3384 workaround: a decode step (n=1) over a batch with zero
+        // left padding must NOT inject an explicit boolean mask, because the
+        // fast-attention kernel's explicit-mask path numerically diverges on
+        // 4-bit Gemma 4 and traps generation in repetition loops. Every stored
+        // key is a real token here, so the unmasked causal path is correct.
+        let cache = BatchKVCache(leftPadding: [0, 0])
+        _ = cache.update(
+            keys: MLXArray.zeros([2, 1, 5, 4]),
+            values: MLXArray.zeros([2, 1, 5, 4])
+        )
+
+        let mask = cache.makeMask(n: 1, windowSize: nil, returnArray: true)
+        guard case .none = mask else {
+            Issue.record("expected .none mask for unpadded n=1 decode, got \(mask)")
+            return
+        }
+
+        // But a padded row at n=1 still needs the explicit mask to block its
+        // padding slots — the workaround must not weaken correctness there.
+        let padded = BatchKVCache(leftPadding: [1, 0])
+        _ = padded.update(
+            keys: MLXArray.zeros([2, 1, 5, 4]),
+            values: MLXArray.zeros([2, 1, 5, 4])
+        )
+        guard case .array = padded.makeMask(n: 1, windowSize: nil, returnArray: true) else {
+            Issue.record("expected .array mask when any row is left-padded")
+            return
+        }
+    }
+
     // MARK: - dynamicRoll helper
 
     @Test("dynamicRoll shifts each row by its own amount along axis")

--- a/provider-swift/Tests/ProviderCoreTests/ContinuousBatchingLiveTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/ContinuousBatchingLiveTests.swift
@@ -3,6 +3,7 @@ import Testing
 import MLX
 import MLXLLM
 import MLXLMCommon
+import MLXVLM
 import Tokenizers
 @testable import ProviderCore
 
@@ -67,6 +68,110 @@ struct ContinuousBatchingLiveTests {
             maxTokens: 6,
             wiredMemoryGB: 64
         )
+    }
+
+    /// Production reproduction: `gemma-4-26b` ships with `vision_config`, so the
+    /// provider loads it via `VLMModelFactory` and serves text through the VLM
+    /// model's batched path. That path used a scalar `cache.offset` for RoPE
+    /// (wrong per-row positions in a mixed-length batch) and an explicit-mask
+    /// fused kernel (MLX #3384 4-bit drift) — together producing the repetition
+    /// users hit. This test loads via the VLM factory (NOT LLMModelFactory like
+    /// `runDiffTest`), runs a mixed-length B=2 greedy batch on the 4-bit QAT
+    /// build, and asserts the output is coherent (no degenerate repetition) and
+    /// the short row tracks its single-stream reference.
+    @Test(
+        "Gemma 4 VLM qat-4bit mixed-length batch is coherent (no repetition)",
+        .enabled(if:
+            ProcessInfo.processInfo.environment["DARKBLOOM_LIVE_MLX_TESTS"] != nil
+                && ProcessInfo.processInfo.environment["DARKBLOOM_LIVE_MLX_GEMMA"] != nil
+        )
+    )
+    func gemma4VLMMixedLengthCoherent() async throws {
+        try ensureMetallibAvailable()
+        MLX.GPU.set(memoryLimit: 96 * 1024 * 1024 * 1024)
+
+        let modelID = ProcessInfo.processInfo.environment["DARKBLOOM_GEMMA_MODEL"]
+            ?? "mlx-community/gemma-4-26B-A4B-it-qat-4bit"
+        guard let modelDir = ModelScanner.resolveLocalPath(modelID: modelID) else {
+            Issue.record("model '\(modelID)' is not in the local cache")
+            return
+        }
+
+        // Production loads vision checkpoints through VLMModelFactory.
+        let container = try await VLMModelFactory.shared.loadContainer(
+            from: modelDir, using: LocalTokenizerLoader())
+
+        // Deliberately different lengths so the shorter row carries left-padding
+        // (the case the scalar-offset bug mis-positions). Row 0 is the shorter,
+        // higher-entropy prompt — open-ended continuations have close argmax
+        // calls, so wrong RoPE positions / mask-kernel drift flip the top token
+        // and trap it in a loop (the "One of of of of" failure mode).
+        let prompts = [
+            "Tell me something interesting about machine learning.",
+            "Write a detailed multi-paragraph essay about the history, present state, "
+                + "and likely future of renewable energy technologies across the world.",
+        ]
+        let encoded: [[Int]] = try await container.perform { ctx in
+            try prompts.map {
+                try ctx.tokenizer.applyChatTemplate(
+                    messages: [["role": "user", "content": $0]],
+                    tools: nil, additionalContext: nil)
+            }
+        }
+        let maxTokens = 110
+
+        let batched = try await runBatchedEngine(
+            container: container, modelID: modelID, prompts: encoded, maxTokens: maxTokens)
+        let single = await singleStreamGreedy(
+            container: container, prompts: encoded, maxTokens: maxTokens)
+
+        // The batched engine honors EOS, so coherent rows terminate cleanly.
+        // This is the path under test (per-row offset + manual masked attention);
+        // it must not degenerate into repetition.
+        for (k, toks) in batched.enumerated() {
+            let text = await container.decode(tokenIds: toks)
+            print("[gemma4-vlm-mixed] batched row \(k): \(text)")
+            #expect(
+                !Self.hasDegenerateRepetition(toks),
+                Comment(rawValue: "batched row \(k) degenerates into repetition: \(toks)"))
+        }
+        // The short, low-entropy row 0 is the one mis-positioned by the
+        // scalar-offset bug. Compare batched vs single-stream up to the natural
+        // end-of-turn (the fixed-length single-stream helper force-generates
+        // past EOS, so only the pre-EOS prefix is meaningful). With per-row
+        // offsets the two agree on the opening tokens.
+        let eos = 106
+        let singleHead = Array(single[0].prefix(while: { $0 != eos }))
+        let batchedHead = Array(batched[0].prefix(while: { $0 != eos }))
+        let shortMatch = zip(batchedHead, singleHead).prefix(while: ==).count
+        #expect(
+            shortMatch >= 3,
+            Comment(rawValue:
+                "short row diverges immediately (batched=\(batchedHead) single=\(singleHead))"))
+    }
+
+    /// Detects degenerate generation: an n-gram (n = 1...4) repeated
+    /// consecutively many times — the signature of decode loops like
+    /// "of of of", "you've you've", or "the era of the era of the era of".
+    /// Coherent prose never trips this; the batching bug produces exactly
+    /// these cycles.
+    static func hasDegenerateRepetition(_ tokens: [Int]) -> Bool {
+        for n in 1 ... 4 {
+            let minReps = n == 1 ? 8 : (n == 2 ? 6 : 4)
+            var i = 0
+            while i + n * minReps <= tokens.count {
+                let gram = Array(tokens[i ..< i + n])
+                var reps = 1
+                var j = i + n
+                while j + n <= tokens.count && Array(tokens[j ..< j + n]) == gram {
+                    reps += 1
+                    j += n
+                }
+                if reps >= minReps { return true }
+                i += 1
+            }
+        }
+        return false
     }
 
     @Test(


### PR DESCRIPTION
## Summary

Fixes the Gemma 4 **token-repetition loops** users hit on the chat console (e.g. `"...the era of the era of..."`, `"One of of of of"`, `"you've you've you've..."`).

`gemma-4-26b` declares `vision_config`, so providers load it via `VLMModelFactory` and serve **text** through the VLM model's continuous-batched path. That path had two bugs that compound on 4-bit builds:

1. **Scalar RoPE offset** — used `cache.offset` (max across rows), mis-positioning shorter rows in a mixed-length batch.
2. **Explicit-mask fused-kernel divergence** ([ml-explore/mlx#3384](https://github.com/ml-explore/mlx/issues/3384)) — `MLXFast.scaledDotProductAttention` numerically diverges with an explicit array mask on 4-bit Gemma 4, flipping top-1 logits.

The earlier v0.6.9 NaN fix targeted `MLXLLM/Gemma4Text.swift` — a class providers don't load for vision checkpoints — which is why it didn't help.

The actual code fix is in the submodule: **Layr-Labs/mlx-swift-lm#41**. This PR bumps the submodule pointer to that fix and adds regression coverage.

## Changes

- **`libs/mlx-swift-lm`**: `404afee → 429d83c` (per-row RoPE offset + NaN-guarded manual masked attention in `MLXVLM/Models/Gemma4.swift`; `.none` decode mask in `BatchKVCache`). See Layr-Labs/mlx-swift-lm#41.
- **`ContinuousBatchingLiveTests.gemma4VLMMixedLengthCoherent`** — loads `gemma-4-26B-A4B-it-qat-4bit` via `VLMModelFactory` (the production path; the existing `runDiffTest` used `LLMModelFactory`, which is why it never caught this) and asserts a mixed-length `B=2` greedy batch is coherent. Gated by `DARKBLOOM_LIVE_MLX_TESTS=1` + `DARKBLOOM_LIVE_MLX_GEMMA=1`.
- **`BatchKVCacheTests`** — adds a case asserting `.none` mask for unpadded `n==1` decode and `.array` when any row is left-padded.

## Verification

On `gemma-4-26B-A4B-it-qat-4bit` via `VLMModelFactory`, mixed-length `B=2` greedy:

- **Before:** `"...the era of the era of the era of the era of..."`
- **After:** coherent (full "Shortcut Learning" answer + a coherent renewable-energy essay).

A/B verified by reverting the submodule fix (repetition returns → test fails) and re-applying (coherent → test passes). All `BatchKVCache` unit tests pass.

## Merge order

Merge the submodule PR (Layr-Labs/mlx-swift-lm#41) first, then re-point `libs/mlx-swift-lm` here to the merged SHA if it differs (squash-merge changes the hash). After merge, **bump the provider version** so the fleet picks up the fix (`LatestProviderVersion` gate).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/369"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784225487&installation_id=133247490&pr_number=369&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F369&signature=763a54e71aca1e7df4b9ac2d7d4b46cde277752bc472b676eab1f9675d0ae69a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->