### PR TITLE
fix(coordinator): calibrate TTFT preflight admission

### DIFF
--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -386,6 +386,15 @@ func (s *Server) writeTTFTTooSlow(w http.ResponseWriter, model, publicModel stri
 		withCode("rate_limit_exceeded")))
 }
 
+func (s *Server) triggerWarmPoolAsync(reason string) {
+	if s == nil || s.registry == nil {
+		return
+	}
+	saferun.Go(s.logger, "warm_pool."+reason, func() {
+		s.registry.TriggerWarmPool()
+	})
+}
+
 // dispatchOneProvider encrypts and sends an inference request to a single
 // provider. It returns the pending request and provider on success, or an
 // error string on failure. The excludeProviders set is updated on failure.
@@ -1695,6 +1704,7 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 		}
 		if candidateCount == 0 && capacityRejections > 0 {
 			s.registry.RecordWarmPoolCapacityReject(model)
+			s.triggerWarmPoolAsync("capacity_reject")
 			// Providers exist for this model but ALL are at capacity.
 			retryAfter := s.estimateRetryAfter(model)
 			w.Header().Set("Retry-After", strconv.Itoa(retryAfter))
@@ -4192,6 +4202,7 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 		}
 		if candidateCount == 0 && capacityRejections > 0 {
 			s.registry.RecordWarmPoolCapacityReject(model)
+			s.triggerWarmPoolAsync("capacity_reject")
 			retryAfter := s.estimateRetryAfter(model)
 			w.Header().Set("Retry-After", strconv.Itoa(retryAfter))
 			refundReservation()
@@ -4374,6 +4385,7 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 		}
 		if depth, oldest := s.registry.Queue().QueueStats(model); depth > 0 {
 			s.registry.RecordWarmPoolQueueEnqueued(model, depth, oldest)
+			s.triggerWarmPoolAsync("queue_enqueued")
 		}
 		s.ddIncr("routing.decisions", []string{"model:" + model, "model_type:" + s.registry.ModelType(model), "outcome:queued"})
 		provider, err = s.registry.Queue().WaitForProviderContext(r.Context(), queuedReq)

--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -89,9 +89,9 @@ const (
 	// handler goroutine when a WebSocket is half-dead.
 	cancelWriteTimeout = 2 * time.Second
 
-	// openRouterTTFT429Threshold is the hard admission target for external
-	// routers: if the fastest eligible provider is already estimated to miss a
-	// 10s TTFT, return a retryable 429 instead of letting the caller time out.
+	// openRouterTTFT429Threshold is the floor for external-router TTFT admission:
+	// small prompts keep the existing 10s target, while long prompts can use the
+	// same prompt-scaled deadline enforced by the dispatch wait.
 	openRouterTTFT429Threshold = 10 * time.Second
 )
 
@@ -104,6 +104,14 @@ func ttftDeadline(estimatedPromptTokens int) time.Duration {
 	base := 5 * time.Second
 	perToken := time.Duration(estimatedPromptTokens) * time.Millisecond
 	return base + perToken
+}
+
+func ttftAdmissionThreshold(estimatedPromptTokens int) time.Duration {
+	deadline := ttftDeadline(estimatedPromptTokens)
+	if deadline < openRouterTTFT429Threshold {
+		return openRouterTTFT429Threshold
+	}
+	return deadline
 }
 
 // sendProviderCancel sends a Cancel message for the given request to the
@@ -336,15 +344,15 @@ func (s *Server) maybeFallbackAliasTTFT(parsed map[string]any, publicModel, curr
 		return currentModel, 0, 0, 0, 0, false, false
 	}
 	candidates, rejections, tooLarge, bestTTFT, hasTTFT := s.registry.QuickCapacityCheckWithTTFTForRequest(target.Previous, estimatedPromptTokens, requestedMaxTokens, traits, requiresVision, allowedProviderSerials...)
-	if candidates <= 0 || ttftTooSlow(bestTTFT, hasTTFT) {
+	if candidates <= 0 || ttftTooSlow(bestTTFT, hasTTFT, ttftAdmissionThreshold(estimatedPromptTokens)) {
 		return target.Previous, candidates, rejections, tooLarge, bestTTFT, hasTTFT, false
 	}
 	parsed["model"] = target.Previous
 	return target.Previous, candidates, rejections, tooLarge, bestTTFT, hasTTFT, true
 }
 
-func ttftTooSlow(bestTTFT time.Duration, hasTTFT bool) bool {
-	return hasTTFT && bestTTFT > openRouterTTFT429Threshold
+func ttftTooSlow(bestTTFT time.Duration, hasTTFT bool, threshold time.Duration) bool {
+	return hasTTFT && bestTTFT > threshold
 }
 
 func fasterTTFTEstimate(primaryModel string, primary time.Duration, alternateModel string, alternate time.Duration, alternateOK bool) (string, time.Duration) {
@@ -354,8 +362,8 @@ func fasterTTFTEstimate(primaryModel string, primary time.Duration, alternateMod
 	return primaryModel, primary
 }
 
-func (s *Server) estimateTTFTRetryAfter(model string, bestTTFT time.Duration) int {
-	overage := bestTTFT - openRouterTTFT429Threshold
+func (s *Server) estimateTTFTRetryAfter(model string, bestTTFT, threshold time.Duration) int {
+	overage := bestTTFT - threshold
 	seconds := int(math.Ceil(overage.Seconds()))
 	if base := s.estimateRetryAfter(model); seconds < base {
 		seconds = base
@@ -369,12 +377,12 @@ func (s *Server) estimateTTFTRetryAfter(model string, bestTTFT time.Duration) in
 	return seconds
 }
 
-func (s *Server) writeTTFTTooSlow(w http.ResponseWriter, model, publicModel string, bestTTFT time.Duration) {
-	retryAfter := s.estimateTTFTRetryAfter(model, bestTTFT)
+func (s *Server) writeTTFTTooSlow(w http.ResponseWriter, model, publicModel string, bestTTFT, threshold time.Duration) {
+	retryAfter := s.estimateTTFTRetryAfter(model, bestTTFT, threshold)
 	w.Header().Set("Retry-After", strconv.Itoa(retryAfter))
 	s.ddIncr("routing.decisions", []string{"model:" + model, "model_type:" + s.registry.ModelType(model), "outcome:ttft_429"})
 	writeJSON(w, http.StatusTooManyRequests, errorResponse("rate_limit_exceeded",
-		fmt.Sprintf("all providers for model %q are above the %ds TTFT target (best estimate %.1fs); retry after %ds", publicModel, int(openRouterTTFT429Threshold.Seconds()), bestTTFT.Seconds(), retryAfter),
+		fmt.Sprintf("all providers for model %q are above the %ds TTFT target (best estimate %.1fs); retry after %ds", publicModel, int(math.Ceil(threshold.Seconds())), bestTTFT.Seconds(), retryAfter),
 		withCode("rate_limit_exceeded")))
 }
 
@@ -447,7 +455,7 @@ func (s *Server) dispatchOneProvider(
 	// check authoritative: the router cannot select a provider whose estimated
 	// TTFT is above the threshold.
 	if !policy.enabled && !policy.prefer {
-		pr.MaxTTFTMs = openRouterTTFT429Threshold.Seconds() * 1000.0
+		pr.MaxTTFTMs = ttftAdmissionThreshold(estimatedPromptTokens).Seconds() * 1000.0
 	}
 
 	excludeList := func() []string {
@@ -1649,6 +1657,7 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 		// routing with a paid public fallback and the normal queue, which is the
 		// correct gate for prefer.
 	} else {
+		ttftThreshold := ttftAdmissionThreshold(estimatedPromptTokens)
 		// Pre-flight capacity check: can ANY provider serve this model right
 		// now? If not, return 429 immediately rather than queueing for up to
 		// 120s. OpenRouter treats 429 as "rate limited" (no uptime penalty) vs
@@ -1716,7 +1725,7 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 				withCode("model_unavailable")))
 			return
 		}
-		if ttftTooSlow(bestTTFT, hasTTFT) {
+		if ttftTooSlow(bestTTFT, hasTTFT, ttftThreshold) {
 			if fallbackModel, _, _, _, fallbackTTFT, fallbackHasTTFT, switched := s.maybeFallbackAliasTTFT(parsed, publicModel, model, estimatedPromptTokens, requestedMaxTokens, registry.RequestTraits{HasTools: hasTools}, requiresVision, allowedProviderSerials); switched {
 				model = fallbackModel
 				if isResponsesAPI {
@@ -1733,7 +1742,7 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 			} else {
 				retryModel, retryTTFT := fasterTTFTEstimate(model, bestTTFT, fallbackModel, fallbackTTFT, fallbackHasTTFT)
 				refundReservation()
-				s.writeTTFTTooSlow(w, retryModel, publicModel, retryTTFT)
+				s.writeTTFTTooSlow(w, retryModel, publicModel, retryTTFT, ttftThreshold)
 				return
 			}
 		}
@@ -4206,13 +4215,14 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 				withCode("model_unavailable")))
 			return
 		}
-		if ttftTooSlow(bestTTFT, hasTTFT) {
+		ttftThreshold := ttftAdmissionThreshold(estimatedPromptTokens)
+		if ttftTooSlow(bestTTFT, hasTTFT, ttftThreshold) {
 			if fallbackModel, _, _, _, fallbackTTFT, fallbackHasTTFT, switched := s.maybeFallbackAliasTTFT(parsed, publicModel, model, estimatedPromptTokens, requestedMaxTokens, registry.RequestTraits{HasTools: hasTools}, requiresVision, allowedProviderSerials); switched {
 				model = fallbackModel
 			} else {
 				retryModel, retryTTFT := fasterTTFTEstimate(model, bestTTFT, fallbackModel, fallbackTTFT, fallbackHasTTFT)
 				refundReservation()
-				s.writeTTFTTooSlow(w, retryModel, publicModel, retryTTFT)
+				s.writeTTFTTooSlow(w, retryModel, publicModel, retryTTFT, ttftThreshold)
 				return
 			}
 		}
@@ -4254,7 +4264,7 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 	// check authoritative: the router cannot select a provider whose estimated
 	// TTFT is above the threshold.
 	if !policy.enabled && !policy.prefer {
-		pr.MaxTTFTMs = openRouterTTFT429Threshold.Seconds() * 1000.0
+		pr.MaxTTFTMs = ttftAdmissionThreshold(estimatedPromptTokens).Seconds() * 1000.0
 	}
 
 	// refundExtra credits back the provider-specific surcharge that
@@ -4326,7 +4336,7 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 		if decision.TTFTRejections > 0 {
 			bestTTFT := time.Duration(decision.BestTTFTMs * float64(time.Millisecond))
 			refundReservation()
-			s.writeTTFTTooSlow(w, model, publicModel, bestTTFT)
+			s.writeTTFTTooSlow(w, model, publicModel, bestTTFT, ttftAdmissionThreshold(estimatedPromptTokens))
 			return
 		}
 

--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -101,10 +101,6 @@ func ttftDeadline(estimatedPromptTokens int) time.Duration {
 	return base + perToken
 }
 
-func ttftAdmissionThreshold(estimatedPromptTokens int) time.Duration {
-	return ttftDeadline(estimatedPromptTokens)
-}
-
 // sendProviderCancel sends a Cancel message for the given request to the
 // provider with a bounded timeout so a half-dead WebSocket doesn't hang the
 // caller. Errors are logged at debug level because a disconnect race is the
@@ -323,7 +319,7 @@ func (s *Server) maybeFallbackAliasCapacity(parsed map[string]any, publicModel, 
 	return target.Previous, candidates, rejections, tooLarge, bestTTFT, hasTTFT, true
 }
 
-func (s *Server) maybeFallbackAliasTTFT(parsed map[string]any, publicModel, currentModel string, estimatedPromptTokens, requestedMaxTokens int, traits registry.RequestTraits, requiresVision bool, allowedProviderSerials []string) (string, int, int, int, time.Duration, bool, bool) {
+func (s *Server) maybeFallbackAliasTTFT(parsed map[string]any, publicModel, currentModel string, estimatedPromptTokens, requestedMaxTokens int, ttftThreshold time.Duration, traits registry.RequestTraits, requiresVision bool, allowedProviderSerials []string) (string, int, int, int, time.Duration, bool, bool) {
 	if publicModel == "" || publicModel == currentModel {
 		return currentModel, 0, 0, 0, 0, false, false
 	}
@@ -335,7 +331,7 @@ func (s *Server) maybeFallbackAliasTTFT(parsed map[string]any, publicModel, curr
 		return currentModel, 0, 0, 0, 0, false, false
 	}
 	candidates, rejections, tooLarge, bestTTFT, hasTTFT := s.registry.QuickCapacityCheckWithTTFTForRequest(target.Previous, estimatedPromptTokens, requestedMaxTokens, traits, requiresVision, allowedProviderSerials...)
-	if candidates <= 0 || ttftTooSlow(bestTTFT, hasTTFT, ttftAdmissionThreshold(estimatedPromptTokens)) {
+	if candidates <= 0 || ttftTooSlow(bestTTFT, hasTTFT, ttftThreshold) {
 		return target.Previous, candidates, rejections, tooLarge, bestTTFT, hasTTFT, false
 	}
 	parsed["model"] = target.Previous
@@ -466,7 +462,7 @@ func (s *Server) dispatchOneProvider(
 	// check authoritative: the router cannot select a provider whose estimated
 	// TTFT is above the threshold.
 	if !policy.enabled && !policy.prefer {
-		pr.MaxTTFTMs = float64(ttftAdmissionThreshold(estimatedPromptTokens).Milliseconds())
+		pr.MaxTTFTMs = float64(ttftDeadline(estimatedPromptTokens).Milliseconds())
 	}
 
 	excludeList := func() []string {
@@ -1615,6 +1611,7 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 	estimatedPromptTokens := estimatePromptTokens(parsed)
 	billingPromptTokens := estimateBillingPromptTokens(parsed)
 	requestedMaxTokens := estimateRequestedMaxTokens(parsed)
+	deadline := ttftDeadline(estimatedPromptTokens)
 	timing.ParsedAt = time.Now()
 
 	if isResponsesAPI {
@@ -1700,7 +1697,7 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 		// routing with a paid public fallback and the normal queue, which is the
 		// correct gate for prefer.
 	} else {
-		ttftThreshold := ttftAdmissionThreshold(estimatedPromptTokens)
+		ttftThreshold := deadline
 		// Pre-flight capacity check: can ANY provider serve this model right
 		// now? If not, return 429 immediately rather than queueing for up to
 		// 120s. OpenRouter treats 429 as "rate limited" (no uptime penalty) vs
@@ -1770,7 +1767,7 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if ttftTooSlow(bestTTFT, hasTTFT, ttftThreshold) {
-			if fallbackModel, _, _, _, fallbackTTFT, fallbackHasTTFT, switched := s.maybeFallbackAliasTTFT(parsed, publicModel, model, estimatedPromptTokens, requestedMaxTokens, registry.RequestTraits{HasTools: hasTools}, requiresVision, allowedProviderSerials); switched {
+			if fallbackModel, _, _, _, fallbackTTFT, fallbackHasTTFT, switched := s.maybeFallbackAliasTTFT(parsed, publicModel, model, estimatedPromptTokens, requestedMaxTokens, ttftThreshold, registry.RequestTraits{HasTools: hasTools}, requiresVision, allowedProviderSerials); switched {
 				model = fallbackModel
 				if isResponsesAPI {
 					providerParsed, err := responsesRequestToChatCompletions(parsed)
@@ -1808,8 +1805,6 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 	// commits exactly once, then writes attestation/timing headers and streams.
 	consumerKey := consumerKeyFromContext(r.Context())
 	consumerLocation := s.requestLocation(r)
-	deadline := ttftDeadline(estimatedPromptTokens)
-
 	// Final cap on the body we'll seal. The read cap (parseInferencePrelude)
 	// bounded the request as received, but rawBody has since been re-marshaled at
 	// several points — alias resolution, allowlist/routing-field stripping,
@@ -4163,6 +4158,7 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 	estimatedPromptTokens := estimatePromptTokens(parsed)
 	billingPromptTokens := estimateBillingPromptTokens(parsed)
 	requestedMaxTokens := estimateRequestedMaxTokens(parsed)
+	genericDeadline := ttftDeadline(estimatedPromptTokens)
 
 	// Inject the endpoint so the provider knows which local path to forward to.
 	parsed["endpoint"] = endpoint
@@ -4260,9 +4256,9 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 				withCode("model_unavailable")))
 			return
 		}
-		ttftThreshold := ttftAdmissionThreshold(estimatedPromptTokens)
+		ttftThreshold := genericDeadline
 		if ttftTooSlow(bestTTFT, hasTTFT, ttftThreshold) {
-			if fallbackModel, _, _, _, fallbackTTFT, fallbackHasTTFT, switched := s.maybeFallbackAliasTTFT(parsed, publicModel, model, estimatedPromptTokens, requestedMaxTokens, registry.RequestTraits{HasTools: hasTools}, requiresVision, allowedProviderSerials); switched {
+			if fallbackModel, _, _, _, fallbackTTFT, fallbackHasTTFT, switched := s.maybeFallbackAliasTTFT(parsed, publicModel, model, estimatedPromptTokens, requestedMaxTokens, ttftThreshold, registry.RequestTraits{HasTools: hasTools}, requiresVision, allowedProviderSerials); switched {
 				model = fallbackModel
 			} else {
 				retryModel, retryTTFT := fasterTTFTEstimate(model, bestTTFT, fallbackModel, fallbackTTFT, fallbackHasTTFT)
@@ -4309,7 +4305,7 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 	// check authoritative: the router cannot select a provider whose estimated
 	// TTFT is above the threshold.
 	if !policy.enabled && !policy.prefer {
-		pr.MaxTTFTMs = float64(ttftAdmissionThreshold(estimatedPromptTokens).Milliseconds())
+		pr.MaxTTFTMs = float64(genericDeadline.Milliseconds())
 	}
 
 	// refundExtra credits back the provider-specific surcharge that
@@ -4381,7 +4377,7 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 		if decision.TTFTRejections > 0 {
 			bestTTFT := time.Duration(decision.BestTTFTMs * float64(time.Millisecond))
 			refundReservation()
-			s.writeTTFTTooSlow(w, model, publicModel, bestTTFT, ttftAdmissionThreshold(estimatedPromptTokens))
+			s.writeTTFTTooSlow(w, model, publicModel, bestTTFT, genericDeadline)
 			return
 		}
 
@@ -4576,7 +4572,6 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 	// before committing. This mirrors the chat completions path but without
 	// speculative dispatch (single attempt). If the provider misses the
 	// TTFT deadline, the request fails instead of streaming forever.
-	genericDeadline := ttftDeadline(estimatedPromptTokens)
 	ttftTimer := time.NewTimer(genericDeadline)
 	var firstChunk string
 	committed := false

--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -377,13 +377,24 @@ func (s *Server) writeTTFTTooSlow(w http.ResponseWriter, model, publicModel stri
 		withCode("rate_limit_exceeded")))
 }
 
-func (s *Server) triggerWarmPoolAsync(reason string) {
+func (s *Server) triggerWarmPool() {
 	if s == nil || s.registry == nil {
 		return
 	}
-	saferun.Go(s.logger, "warm_pool."+reason, func() {
-		s.registry.TriggerWarmPool()
-	})
+	s.registry.RequestWarmPoolTrigger()
+}
+
+func (s *Server) recordWarmPoolQueueState(model string) {
+	if s == nil || s.registry == nil || s.registry.Queue() == nil {
+		return
+	}
+	depth, oldest := s.registry.Queue().QueueStats(model)
+	if depth <= 0 {
+		s.registry.RecordWarmPoolQueueCleared(model)
+		return
+	}
+	s.registry.RecordWarmPoolQueueEnqueued(model, depth, oldest)
+	s.triggerWarmPool()
 }
 
 // dispatchOneProvider encrypts and sends an inference request to a single
@@ -1727,7 +1738,7 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 		}
 		if candidateCount == 0 && capacityRejections > 0 {
 			s.registry.RecordWarmPoolCapacityReject(model)
-			s.triggerWarmPoolAsync("capacity_reject")
+			s.triggerWarmPool()
 			// Providers exist for this model but ALL are at capacity.
 			retryAfter := s.estimateRetryAfter(model)
 			w.Header().Set("Retry-After", strconv.Itoa(retryAfter))
@@ -4225,7 +4236,7 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 		}
 		if candidateCount == 0 && capacityRejections > 0 {
 			s.registry.RecordWarmPoolCapacityReject(model)
-			s.triggerWarmPoolAsync("capacity_reject")
+			s.triggerWarmPool()
 			retryAfter := s.estimateRetryAfter(model)
 			w.Header().Set("Retry-After", strconv.Itoa(retryAfter))
 			refundReservation()
@@ -4406,14 +4417,12 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 			}
 			return
 		}
-		if depth, oldest := s.registry.Queue().QueueStats(model); depth > 0 {
-			s.registry.RecordWarmPoolQueueEnqueued(model, depth, oldest)
-			s.triggerWarmPoolAsync("queue_enqueued")
-		}
+		s.recordWarmPoolQueueState(model)
 		s.ddIncr("routing.decisions", []string{"model:" + model, "model_type:" + s.registry.ModelType(model), "outcome:queued"})
 		provider, err = s.registry.Queue().WaitForProviderContext(r.Context(), queuedReq)
 		if err != nil {
 			if errors.Is(err, context.Canceled) {
+				s.recordWarmPoolQueueState(model)
 				refundReservation()
 				return
 			}
@@ -4431,6 +4440,7 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 			}
 			return
 		}
+		s.recordWarmPoolQueueState(model)
 		decision = queuedReq.Decision
 	}
 	s.ddIncr("routing.decisions", []string{"model:" + model, "model_type:" + s.registry.ModelType(model), "outcome:selected"})

--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -88,11 +88,6 @@ const (
 	// block. Using context.Background() unbounded here risks hanging the HTTP
 	// handler goroutine when a WebSocket is half-dead.
 	cancelWriteTimeout = 2 * time.Second
-
-	// openRouterTTFT429Threshold is the floor for external-router TTFT admission:
-	// small prompts keep the existing 10s target, while long prompts can use the
-	// same prompt-scaled deadline enforced by the dispatch wait.
-	openRouterTTFT429Threshold = 10 * time.Second
 )
 
 var thinkBlockPattern = regexp.MustCompile(`(?is)<think>(.*?)</think>\s*`)
@@ -107,11 +102,7 @@ func ttftDeadline(estimatedPromptTokens int) time.Duration {
 }
 
 func ttftAdmissionThreshold(estimatedPromptTokens int) time.Duration {
-	deadline := ttftDeadline(estimatedPromptTokens)
-	if deadline < openRouterTTFT429Threshold {
-		return openRouterTTFT429Threshold
-	}
-	return deadline
+	return ttftDeadline(estimatedPromptTokens)
 }
 
 // sendProviderCancel sends a Cancel message for the given request to the
@@ -464,7 +455,7 @@ func (s *Server) dispatchOneProvider(
 	// check authoritative: the router cannot select a provider whose estimated
 	// TTFT is above the threshold.
 	if !policy.enabled && !policy.prefer {
-		pr.MaxTTFTMs = ttftAdmissionThreshold(estimatedPromptTokens).Seconds() * 1000.0
+		pr.MaxTTFTMs = float64(ttftAdmissionThreshold(estimatedPromptTokens).Milliseconds())
 	}
 
 	excludeList := func() []string {
@@ -706,7 +697,7 @@ func estimatePromptTokens(parsed map[string]any) int {
 		total += messagesPromptTokens(v)
 	}
 	if v, ok := parsed["input"]; ok {
-		total += approximateTokenCount(v)
+		total += inputPromptTokens(v)
 	}
 	if v, ok := parsed["prompt"]; ok {
 		total += approximateTokenCount(v)
@@ -794,7 +785,7 @@ func messageContentTokens(content any) int {
 			}
 			typ, _ := pm["type"].(string)
 			switch {
-			case typ == "text":
+			case typ == "text" || typ == "input_text":
 				if s, ok := pm["text"].(string); ok {
 					total += textTokens(s)
 				}
@@ -833,6 +824,38 @@ func messagesPromptTokens(messages any) int {
 		total += messageContentTokens(mm["content"])
 	}
 	return total
+}
+
+// inputPromptTokens estimates the Responses API `input` field. A string input
+// is plain text (len/4). Structured input is an array of message-like items with
+// `content` parts, so reuse the same media-aware content estimator as chat
+// messages instead of counting JSON wrapper bytes.
+func inputPromptTokens(input any) int {
+	switch x := input.(type) {
+	case string:
+		return approximateTokenCount(x)
+	case []any:
+		total := 0
+		for _, item := range x {
+			switch m := item.(type) {
+			case string:
+				total += approximateTokenCount(m)
+			case map[string]any:
+				content, ok := m["content"]
+				if !ok {
+					total += approximateTokenCount(m)
+					continue
+				}
+				total += 4 // role/type framing, matching messagesPromptTokens.
+				total += messageContentTokens(content)
+			default:
+				total += approximateTokenCount(item)
+			}
+		}
+		return total
+	default:
+		return approximateTokenCount(input)
+	}
 }
 
 // contentPartsHaveMedia reports whether a `content` value (a content-part array)
@@ -4275,7 +4298,7 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 	// check authoritative: the router cannot select a provider whose estimated
 	// TTFT is above the threshold.
 	if !policy.enabled && !policy.prefer {
-		pr.MaxTTFTMs = ttftAdmissionThreshold(estimatedPromptTokens).Seconds() * 1000.0
+		pr.MaxTTFTMs = float64(ttftAdmissionThreshold(estimatedPromptTokens).Milliseconds())
 	}
 
 	// refundExtra credits back the provider-specific surcharge that

--- a/coordinator/api/consumer_test.go
+++ b/coordinator/api/consumer_test.go
@@ -1420,26 +1420,37 @@ func TestEstimatePromptTokens(t *testing.T) {
 	tests := []struct {
 		name  string
 		input map[string]any
+		want  int
 	}{
 		{
 			name:  "messages field",
 			input: map[string]any{"messages": []any{map[string]any{"role": "user", "content": "hello"}}},
+			want:  5, // 4 framing + 5/4 text tokens.
 		},
 		{
 			name:  "prompt field",
 			input: map[string]any{"prompt": "Tell me a story"},
+			want:  3,
 		},
 		{
 			name:  "input field",
 			input: map[string]any{"input": "Translate this"},
+			want:  3,
+		},
+		{
+			name: "responses structured input",
+			input: map[string]any{"input": []any{map[string]any{"role": "user", "content": []any{
+				map[string]any{"type": "input_text", "text": "hello"},
+			}}}},
+			want: 5, // 4 framing + 5/4 text tokens; do not count JSON wrapper bytes.
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			routing := estimatePromptTokens(tt.input)
 			billing := estimateBillingPromptTokens(tt.input)
-			if routing < 1 {
-				t.Errorf("estimatePromptTokens() = %d, want >= 1", routing)
+			if routing != tt.want {
+				t.Errorf("estimatePromptTokens() = %d, want %d", routing, tt.want)
 			}
 			if billing < routing {
 				t.Errorf("billing(%d) < routing(%d)", billing, routing)
@@ -1630,16 +1641,24 @@ func TestDetectMediaRequirementAndTokenEstimate(t *testing.T) {
 // (input[].content parts) is gated too, so a media request there fails fast
 // rather than being silently routed text-blind.
 func TestDetectMediaRequirementResponsesInput(t *testing.T) {
+	bigImage := "data:image/png;base64," + strings.Repeat("A", 200_000)
 	withImage := map[string]any{
 		"input": []any{
 			map[string]any{"role": "user", "content": []any{
 				map[string]any{"type": "input_text", "text": "describe"},
-				map[string]any{"type": "input_image", "image_url": "data:image/png;base64,AAAA"},
+				map[string]any{"type": "input_image", "image_url": bigImage},
 			}},
 		},
 	}
 	if !detectMediaRequirement(withImage) {
 		t.Fatal("expected media detected in Responses API input parts")
+	}
+	got := estimatePromptTokens(withImage)
+	if got > 1000 {
+		t.Fatalf("Responses input estimate must ignore base64 length; got %d tokens for a 200KB image", got)
+	}
+	if got < imagePromptTokenCost {
+		t.Fatalf("Responses input estimate should include flat image cost (%d); got %d", imagePromptTokenCost, got)
 	}
 	textOnly := map[string]any{"input": "just a string prompt"}
 	if detectMediaRequirement(textOnly) {
@@ -1980,9 +1999,31 @@ func TestWriteServiceUnavailableSetsRetryAfter(t *testing.T) {
 	}
 }
 
+func TestTTFTAdmissionThresholdExact(t *testing.T) {
+	tests := []struct {
+		inputTokens int
+		want        time.Duration
+	}{
+		{inputTokens: 0, want: 5 * time.Second},
+		{inputTokens: 1, want: 5*time.Second + time.Millisecond},
+		{inputTokens: 5_000, want: 10 * time.Second},
+		{inputTokens: 5_001, want: 10*time.Second + time.Millisecond},
+	}
+
+	for _, tt := range tests {
+		if got := ttftAdmissionThreshold(tt.inputTokens); got != tt.want {
+			t.Fatalf("ttftAdmissionThreshold(%d) = %v, want %v", tt.inputTokens, got, tt.want)
+		}
+	}
+}
+
 func TestWriteTTFTTooSlowSets429RetryAfter(t *testing.T) {
 	srv, _ := testServer(t)
-	if got := srv.estimateTTFTRetryAfter("no-queue", 13*time.Second, openRouterTTFT429Threshold); got != 3 {
+	threshold := ttftAdmissionThreshold(0)
+	if threshold != 5*time.Second {
+		t.Fatalf("ttftAdmissionThreshold(0) = %v, want 5s", threshold)
+	}
+	if got := srv.estimateTTFTRetryAfter("no-queue", 8*time.Second, threshold); got != 3 {
 		t.Fatalf("Retry-After without queue = %d, want 3s over target", got)
 	}
 
@@ -1994,7 +2035,7 @@ func TestWriteTTFTTooSlowSets429RetryAfter(t *testing.T) {
 	}
 
 	w := httptest.NewRecorder()
-	srv.writeTTFTTooSlow(w, model, model, 11*time.Second, openRouterTTFT429Threshold)
+	srv.writeTTFTTooSlow(w, model, model, 6*time.Second, threshold)
 
 	if w.Code != http.StatusTooManyRequests {
 		t.Fatalf("status = %d, want %d", w.Code, http.StatusTooManyRequests)
@@ -2014,8 +2055,33 @@ func TestWriteTTFTTooSlowSets429RetryAfter(t *testing.T) {
 	if body.Error.Code != "rate_limit_exceeded" {
 		t.Fatalf("code = %q, want rate_limit_exceeded", body.Error.Code)
 	}
-	if !strings.Contains(body.Error.Message, "10s TTFT target") {
+	if !strings.Contains(body.Error.Message, "5s TTFT target") {
 		t.Fatalf("message = %q, want TTFT target detail", body.Error.Message)
+	}
+}
+
+func TestTTFTAdmission429BelowOldTenSecondFloor(t *testing.T) {
+	srv, _ := testServer(t)
+	model := "exact-ttft-floor-model"
+	srv.registry.SetModelCatalog([]registry.CatalogEntry{{ID: model, SizeGB: 1, MinRAMGB: 24}})
+	p := registerBuildsProvider(srv, "exact-floor-provider", model)
+	p.Mu().Lock()
+	p.DecodeTPS = 100
+	p.PrefillTPS = 0.2 // 1 input token => ~5s prefill + first decode, above exact 5.001s target but below old 10s floor.
+	p.Mu().Unlock()
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(
+		strings.ReplaceAll(`{"model":"MODEL","input":"hello","max_output_tokens":128}`, "MODEL", model)))
+	req.Header.Set("Authorization", "Bearer test-key")
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusTooManyRequests {
+		t.Fatalf("status = %d, want %d; body = %s", w.Code, http.StatusTooManyRequests, w.Body.String())
+	}
+	if got := w.Header().Get("Retry-After"); got == "" {
+		t.Fatal("Retry-After header missing")
 	}
 }
 
@@ -2128,7 +2194,7 @@ func TestMaybeFallbackAliasTTFTSwitchesToPrevious(t *testing.T) {
 	if candidates != 1 || rejections != 0 || tooLarge != 0 {
 		t.Fatalf("capacity = (%d,%d,%d), want (1,0,0)", candidates, rejections, tooLarge)
 	}
-	if !hasTTFT || bestTTFT > openRouterTTFT429Threshold {
+	if !hasTTFT || bestTTFT > ttftAdmissionThreshold(100) {
 		t.Fatalf("bestTTFT = %v has=%v, want within threshold", bestTTFT, hasTTFT)
 	}
 }

--- a/coordinator/api/consumer_test.go
+++ b/coordinator/api/consumer_test.go
@@ -1999,7 +1999,7 @@ func TestWriteServiceUnavailableSetsRetryAfter(t *testing.T) {
 	}
 }
 
-func TestTTFTAdmissionThresholdExact(t *testing.T) {
+func TestTTFTDeadlineExact(t *testing.T) {
 	tests := []struct {
 		inputTokens int
 		want        time.Duration
@@ -2011,17 +2011,17 @@ func TestTTFTAdmissionThresholdExact(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		if got := ttftAdmissionThreshold(tt.inputTokens); got != tt.want {
-			t.Fatalf("ttftAdmissionThreshold(%d) = %v, want %v", tt.inputTokens, got, tt.want)
+		if got := ttftDeadline(tt.inputTokens); got != tt.want {
+			t.Fatalf("ttftDeadline(%d) = %v, want %v", tt.inputTokens, got, tt.want)
 		}
 	}
 }
 
 func TestWriteTTFTTooSlowSets429RetryAfter(t *testing.T) {
 	srv, _ := testServer(t)
-	threshold := ttftAdmissionThreshold(0)
+	threshold := ttftDeadline(0)
 	if threshold != 5*time.Second {
-		t.Fatalf("ttftAdmissionThreshold(0) = %v, want 5s", threshold)
+		t.Fatalf("ttftDeadline(0) = %v, want 5s", threshold)
 	}
 	if got := srv.estimateTTFTRetryAfter("no-queue", 8*time.Second, threshold); got != 3 {
 		t.Fatalf("Retry-After without queue = %d, want 3s over target", got)
@@ -2180,6 +2180,7 @@ func TestMaybeFallbackAliasTTFTSwitchesToPrevious(t *testing.T) {
 		desired,
 		100,
 		128,
+		ttftDeadline(100),
 		registry.RequestTraits{},
 		false,
 		nil,
@@ -2194,7 +2195,7 @@ func TestMaybeFallbackAliasTTFTSwitchesToPrevious(t *testing.T) {
 	if candidates != 1 || rejections != 0 || tooLarge != 0 {
 		t.Fatalf("capacity = (%d,%d,%d), want (1,0,0)", candidates, rejections, tooLarge)
 	}
-	if !hasTTFT || bestTTFT > ttftAdmissionThreshold(100) {
+	if !hasTTFT || bestTTFT > ttftDeadline(100) {
 		t.Fatalf("bestTTFT = %v has=%v, want within threshold", bestTTFT, hasTTFT)
 	}
 }

--- a/coordinator/api/consumer_test.go
+++ b/coordinator/api/consumer_test.go
@@ -1982,7 +1982,7 @@ func TestWriteServiceUnavailableSetsRetryAfter(t *testing.T) {
 
 func TestWriteTTFTTooSlowSets429RetryAfter(t *testing.T) {
 	srv, _ := testServer(t)
-	if got := srv.estimateTTFTRetryAfter("no-queue", 13*time.Second); got != 3 {
+	if got := srv.estimateTTFTRetryAfter("no-queue", 13*time.Second, openRouterTTFT429Threshold); got != 3 {
 		t.Fatalf("Retry-After without queue = %d, want 3s over target", got)
 	}
 
@@ -1994,7 +1994,7 @@ func TestWriteTTFTTooSlowSets429RetryAfter(t *testing.T) {
 	}
 
 	w := httptest.NewRecorder()
-	srv.writeTTFTTooSlow(w, model, model, 11*time.Second)
+	srv.writeTTFTTooSlow(w, model, model, 11*time.Second, openRouterTTFT429Threshold)
 
 	if w.Code != http.StatusTooManyRequests {
 		t.Fatalf("status = %d, want %d", w.Code, http.StatusTooManyRequests)
@@ -2027,7 +2027,7 @@ func TestTTFTAdmission429ForInferenceEndpoints(t *testing.T) {
 	p.Mu().Lock()
 	p.DecodeTPS = 100
 	p.PrefillTPS = 400
-	p.BackendCapacity.Slots[0].MaxTokensPotential = 2_000
+	p.BackendCapacity.Slots[0].State = "idle_shutdown"
 	p.Mu().Unlock()
 
 	cases := []struct {
@@ -2098,7 +2098,7 @@ func TestMaybeFallbackAliasTTFTSwitchesToPrevious(t *testing.T) {
 	desiredProvider.Mu().Lock()
 	desiredProvider.DecodeTPS = 100
 	desiredProvider.PrefillTPS = 400
-	desiredProvider.BackendCapacity.Slots[0].MaxTokensPotential = 2_000
+	desiredProvider.BackendCapacity.Slots[0].State = "idle_shutdown"
 	desiredProvider.Mu().Unlock()
 
 	previousProvider := registerBuildsProvider(srv, "previous-fast", previous)

--- a/coordinator/api/dispatch.go
+++ b/coordinator/api/dispatch.go
@@ -141,7 +141,7 @@ func queueMaxTTFTMs(policy selfRoutePolicy, estimatedPromptTokens int) float64 {
 	if policy.enabled || policy.prefer {
 		return 0
 	}
-	return ttftAdmissionThreshold(estimatedPromptTokens).Seconds() * 1000.0
+	return float64(ttftAdmissionThreshold(estimatedPromptTokens).Milliseconds())
 }
 
 // dispatchPrimary selects (and, when no idle provider exists on the first

--- a/coordinator/api/dispatch.go
+++ b/coordinator/api/dispatch.go
@@ -267,6 +267,7 @@ func (d *dispatchState) dispatchPrimary() dispatchOutcome {
 		}
 		if depth, oldest := s.registry.Queue().QueueStats(d.model); depth > 0 {
 			s.registry.RecordWarmPoolQueueEnqueued(d.model, depth, oldest)
+			s.triggerWarmPoolAsync("queue_enqueued")
 		}
 		s.ddIncr("routing.decisions", []string{"model:" + d.model, "model_type:" + s.registry.ModelType(d.model), "outcome:queued"})
 

--- a/coordinator/api/dispatch.go
+++ b/coordinator/api/dispatch.go
@@ -137,11 +137,11 @@ func (d *dispatchState) traits() registry.RequestTraits {
 // queueMaxTTFTMs returns the TTFT ceiling for queued requests. Public routes
 // inherit the prompt-scaled admission threshold; self-route / prefer-owner paths
 // are not subject to the public SLA ceiling.
-func queueMaxTTFTMs(policy selfRoutePolicy, estimatedPromptTokens int) float64 {
+func queueMaxTTFTMs(policy selfRoutePolicy, deadline time.Duration) float64 {
 	if policy.enabled || policy.prefer {
 		return 0
 	}
-	return float64(ttftAdmissionThreshold(estimatedPromptTokens).Milliseconds())
+	return float64(deadline.Milliseconds())
 }
 
 // dispatchPrimary selects (and, when no idle provider exists on the first
@@ -182,7 +182,7 @@ func (d *dispatchState) dispatchPrimary() dispatchOutcome {
 		if dispatchErr == errTTFTTooSlow && attempt == 0 {
 			bestTTFT := time.Duration(decision.BestTTFTMs * float64(time.Millisecond))
 			d.refundReservation()
-			s.writeTTFTTooSlow(w, d.model, d.publicModel, bestTTFT, ttftAdmissionThreshold(d.estimatedPromptTokens))
+			s.writeTTFTTooSlow(w, d.model, d.publicModel, bestTTFT, d.deadline)
 			return outcomeResponseWritten
 		}
 
@@ -236,7 +236,7 @@ func (d *dispatchState) dispatchPrimary() dispatchOutcome {
 			PreferOwner:            d.policy.prefer,
 			OwnerAccountID:         d.policy.ownerAccountID,
 			FreeSelfRoute:          d.policy.enabled,
-			MaxTTFTMs:              queueMaxTTFTMs(d.policy, d.estimatedPromptTokens),
+			MaxTTFTMs:              queueMaxTTFTMs(d.policy, d.deadline),
 			AcceptedCh:             make(chan struct{}, 1),
 			ChunkCh:                make(chan string, chunkBufferSize),
 			CompleteCh:             make(chan protocol.UsageInfo, 1),

--- a/coordinator/api/dispatch.go
+++ b/coordinator/api/dispatch.go
@@ -265,10 +265,7 @@ func (d *dispatchState) dispatchPrimary() dispatchOutcome {
 			}
 			return outcomeResponseWritten
 		}
-		if depth, oldest := s.registry.Queue().QueueStats(d.model); depth > 0 {
-			s.registry.RecordWarmPoolQueueEnqueued(d.model, depth, oldest)
-			s.triggerWarmPoolAsync("queue_enqueued")
-		}
+		s.recordWarmPoolQueueState(d.model)
 		s.ddIncr("routing.decisions", []string{"model:" + d.model, "model_type:" + s.registry.ModelType(d.model), "outcome:queued"})
 
 		s.logger.Info("request queued, waiting for provider",
@@ -280,6 +277,7 @@ func (d *dispatchState) dispatchPrimary() dispatchOutcome {
 		d.provider, err = s.registry.Queue().WaitForProviderContext(r.Context(), queuedReq)
 		if err != nil {
 			if errors.Is(err, context.Canceled) {
+				s.recordWarmPoolQueueState(d.model)
 				d.refundReservation()
 				return outcomeClientGone
 			}
@@ -298,6 +296,7 @@ func (d *dispatchState) dispatchPrimary() dispatchOutcome {
 			}
 			return outcomeResponseWritten
 		}
+		s.recordWarmPoolQueueState(d.model)
 		// Queue assigned a provider; still need to dispatch.
 		// Use the queue PR's channels.
 		d.pr = queuePR

--- a/coordinator/api/dispatch.go
+++ b/coordinator/api/dispatch.go
@@ -135,13 +135,13 @@ func (d *dispatchState) traits() registry.RequestTraits {
 }
 
 // queueMaxTTFTMs returns the TTFT ceiling for queued requests. Public routes
-// inherit the OpenRouter 10s target; self-route / prefer-owner paths are not
-// subject to the public SLA ceiling.
-func queueMaxTTFTMs(policy selfRoutePolicy) float64 {
+// inherit the prompt-scaled admission threshold; self-route / prefer-owner paths
+// are not subject to the public SLA ceiling.
+func queueMaxTTFTMs(policy selfRoutePolicy, estimatedPromptTokens int) float64 {
 	if policy.enabled || policy.prefer {
 		return 0
 	}
-	return openRouterTTFT429Threshold.Seconds() * 1000.0
+	return ttftAdmissionThreshold(estimatedPromptTokens).Seconds() * 1000.0
 }
 
 // dispatchPrimary selects (and, when no idle provider exists on the first
@@ -181,13 +181,8 @@ func (d *dispatchState) dispatchPrimary() dispatchOutcome {
 		// in-flight stream mid-way.
 		if dispatchErr == errTTFTTooSlow && attempt == 0 {
 			bestTTFT := time.Duration(decision.BestTTFTMs * float64(time.Millisecond))
-			retryAfter := s.estimateTTFTRetryAfter(d.model, bestTTFT)
-			w.Header().Set("Retry-After", strconv.Itoa(retryAfter))
 			d.refundReservation()
-			s.ddIncr("routing.decisions", []string{"model:" + d.model, "model_type:" + s.registry.ModelType(d.model), "outcome:ttft_429"})
-			writeJSON(w, http.StatusTooManyRequests, errorResponse("rate_limit_exceeded",
-				fmt.Sprintf("all providers for model %q are above the %ds TTFT target (best estimate %.1fs); retry after %ds", d.publicModel, int(openRouterTTFT429Threshold.Seconds()), bestTTFT.Seconds(), retryAfter),
-				withCode("rate_limit_exceeded")))
+			s.writeTTFTTooSlow(w, d.model, d.publicModel, bestTTFT, ttftAdmissionThreshold(d.estimatedPromptTokens))
 			return outcomeResponseWritten
 		}
 
@@ -241,7 +236,7 @@ func (d *dispatchState) dispatchPrimary() dispatchOutcome {
 			PreferOwner:            d.policy.prefer,
 			OwnerAccountID:         d.policy.ownerAccountID,
 			FreeSelfRoute:          d.policy.enabled,
-			MaxTTFTMs:              queueMaxTTFTMs(d.policy),
+			MaxTTFTMs:              queueMaxTTFTMs(d.policy, d.estimatedPromptTokens),
 			AcceptedCh:             make(chan struct{}, 1),
 			ChunkCh:                make(chan string, chunkBufferSize),
 			CompleteCh:             make(chan protocol.UsageInfo, 1),

--- a/coordinator/registry/config.go
+++ b/coordinator/registry/config.go
@@ -45,11 +45,11 @@ func ReadConfig() Config {
 	return Config{
 		MinTrustLevel: os.Getenv(env.EnvPrefix + "_MIN_TRUST"),
 		WarmPool: WarmPoolConfig{
-			Enabled:                   env.EnvBool(env.EnvPrefix+"_WARM_POOL_ENABLED", false),
-			ObserveOnly:               env.EnvBool(env.EnvPrefix+"_WARM_POOL_OBSERVE_ONLY", true),
-			Interval:                  envDuration(env.EnvPrefix+"_WARM_POOL_INTERVAL", 30*time.Second),
+			Enabled:                   env.EnvBool(env.EnvPrefix+"_WARM_POOL_ENABLED", true),
+			ObserveOnly:               env.EnvBool(env.EnvPrefix+"_WARM_POOL_OBSERVE_ONLY", false),
+			Interval:                  envDuration(env.EnvPrefix+"_WARM_POOL_INTERVAL", 10*time.Second),
 			MinDwell:                  envDuration(env.EnvPrefix+"_WARM_POOL_MIN_DWELL", 5*time.Minute),
-			QueueAgeThreshold:         envDuration(env.EnvPrefix+"_WARM_POOL_QUEUE_AGE_THRESHOLD", 5*time.Second),
+			QueueAgeThreshold:         envDuration(env.EnvPrefix+"_WARM_POOL_QUEUE_AGE_THRESHOLD", 0),
 			CapacityRejectThreshold:   env.EnvInt(env.EnvPrefix+"_WARM_POOL_CAPACITY_REJECT_THRESHOLD", 1),
 			WarmSaturationThreshold:   env.EnvFloat(env.EnvPrefix+"_WARM_POOL_WARM_SATURATION_THRESHOLD", 0.8),
 			TTFTMissThreshold:         env.EnvInt(env.EnvPrefix+"_WARM_POOL_TTFT_MISS_THRESHOLD", 1),
@@ -57,8 +57,8 @@ func ReadConfig() Config {
 			SpeculativeWinThreshold:   env.EnvInt(env.EnvPrefix+"_WARM_POOL_SPECULATIVE_WIN_THRESHOLD", 1),
 			ColdDispatchThreshold:     env.EnvInt(env.EnvPrefix+"_WARM_POOL_COLD_DISPATCH_THRESHOLD", 1),
 			LoadDurationThreshold:     envDuration(env.EnvPrefix+"_WARM_POOL_LOAD_DURATION_THRESHOLD", 20*time.Second),
-			MaxLoadsPerTick:           env.EnvInt(env.EnvPrefix+"_WARM_POOL_MAX_LOADS_PER_TICK", 1),
-			MaxGlobalPendingLoads:     env.EnvInt(env.EnvPrefix+"_WARM_POOL_MAX_GLOBAL_PENDING_LOADS", 4),
+			MaxLoadsPerTick:           env.EnvInt(env.EnvPrefix+"_WARM_POOL_MAX_LOADS_PER_TICK", 4),
+			MaxGlobalPendingLoads:     env.EnvInt(env.EnvPrefix+"_WARM_POOL_MAX_GLOBAL_PENDING_LOADS", 16),
 		},
 		CacheAffinity: CacheAffinityConfig{
 			TTL:     envDuration(env.EnvPrefix+"_CACHE_AFFINITY_TTL", cacheAffinityTTL),

--- a/coordinator/registry/config_test.go
+++ b/coordinator/registry/config_test.go
@@ -1,0 +1,69 @@
+package registry
+
+import (
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/env"
+)
+
+func clearWarmPoolEnv(t *testing.T) {
+	t.Helper()
+	keys := []string{
+		"WARM_POOL_ENABLED",
+		"WARM_POOL_OBSERVE_ONLY",
+		"WARM_POOL_INTERVAL",
+		"WARM_POOL_MIN_DWELL",
+		"WARM_POOL_QUEUE_AGE_THRESHOLD",
+		"WARM_POOL_CAPACITY_REJECT_THRESHOLD",
+		"WARM_POOL_WARM_SATURATION_THRESHOLD",
+		"WARM_POOL_TTFT_MISS_THRESHOLD",
+		"WARM_POOL_SPECULATIVE_START_THRESHOLD",
+		"WARM_POOL_SPECULATIVE_WIN_THRESHOLD",
+		"WARM_POOL_COLD_DISPATCH_THRESHOLD",
+		"WARM_POOL_LOAD_DURATION_THRESHOLD",
+		"WARM_POOL_MAX_LOADS_PER_TICK",
+		"WARM_POOL_MAX_GLOBAL_PENDING_LOADS",
+	}
+	for _, key := range keys {
+		t.Setenv(env.EnvPrefix+"_"+key, "")
+	}
+}
+
+func TestReadConfigWarmPoolDefaultsActive(t *testing.T) {
+	clearWarmPoolEnv(t)
+
+	cfg := ReadConfig().WarmPool
+	if !cfg.Enabled {
+		t.Fatal("warm pool should default to enabled")
+	}
+	if cfg.ObserveOnly {
+		t.Fatal("warm pool should default to active, not observe-only")
+	}
+	if cfg.Interval != 10*time.Second {
+		t.Fatalf("Interval = %v, want 10s", cfg.Interval)
+	}
+	if cfg.QueueAgeThreshold != 0 {
+		t.Fatalf("QueueAgeThreshold = %v, want 0", cfg.QueueAgeThreshold)
+	}
+	if cfg.MaxLoadsPerTick != 4 {
+		t.Fatalf("MaxLoadsPerTick = %d, want 4", cfg.MaxLoadsPerTick)
+	}
+	if cfg.MaxGlobalPendingLoads != 16 {
+		t.Fatalf("MaxGlobalPendingLoads = %d, want 16", cfg.MaxGlobalPendingLoads)
+	}
+}
+
+func TestReadConfigWarmPoolCanBeDisabled(t *testing.T) {
+	clearWarmPoolEnv(t)
+	t.Setenv(env.EnvPrefix+"_WARM_POOL_ENABLED", "false")
+	t.Setenv(env.EnvPrefix+"_WARM_POOL_OBSERVE_ONLY", "true")
+
+	cfg := ReadConfig().WarmPool
+	if cfg.Enabled {
+		t.Fatal("warm pool enabled despite explicit false")
+	}
+	if !cfg.ObserveOnly {
+		t.Fatal("warm pool observe-only override was not honored")
+	}
+}

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -141,8 +141,8 @@ type PendingRequest struct {
 	RequestedMaxTokens int
 	// MaxTTFTMs is an optional per-request TTFT ceiling in milliseconds.
 	// When > 0, the scheduler only selects providers whose estimated TTFT is
-	// <= MaxTTFTMs. Used by public inference routes to honor the OpenRouter
-	// 10s TTFT target. Self-route / prefer-owner requests leave this at 0.
+	// <= MaxTTFTMs. Used by public inference routes to honor the public
+	// TTFT target. Self-route / prefer-owner requests leave this at 0.
 	MaxTTFTMs float64
 	// CacheAffinityKey is SHA256(prompt_cache_key) from the request body. Empty
 	// means no cache-affinity routing. It is scoped again by account and model in

--- a/coordinator/registry/scheduler.go
+++ b/coordinator/registry/scheduler.go
@@ -947,7 +947,7 @@ func (r *Registry) buildCandidateWithReason(snap routingSnapshot, pr *PendingReq
 	// estimated TTFT is within the per-request threshold. Providers without
 	// BackendCapacity get 0 (unreliable estimate) and are not rejected by the
 	// ceiling, matching the preflight behavior.
-	ttftMs := ttftMsFromSnapshot(snap, reqPrompt, reqMax)
+	ttftMs := ttftMsFromSnapshot(snap, reqPrompt)
 	if ttftMs <= 0 || math.IsNaN(ttftMs) || math.IsInf(ttftMs, 0) {
 		ttftMs = 0
 	}
@@ -1302,7 +1302,7 @@ func (r *Registry) quickCapacityCheck(model string, estimatedPromptTokens, reque
 
 		candidateCount++
 		if snap.hasBackendCapacity {
-			ttft := estimatedTTFTFromSnapshot(snap, estimatedPromptTokens, requestedMaxTokens)
+			ttft := estimatedTTFTFromSnapshot(snap, estimatedPromptTokens)
 			if !hasTTFT || ttft < bestTTFT {
 				bestTTFT = ttft
 				hasTTFT = true
@@ -1317,8 +1317,8 @@ func (r *Registry) quickCapacityCheck(model string, estimatedPromptTokens, reque
 	return candidateCount, capacityRejections, modelTooLarge, bestTTFT, hasTTFT
 }
 
-func estimatedTTFTFromSnapshot(snap routingSnapshot, reqPromptTokens, reqMaxTokens int) time.Duration {
-	ttftMs := ttftMsFromSnapshot(snap, reqPromptTokens, reqMaxTokens)
+func estimatedTTFTFromSnapshot(snap routingSnapshot, reqPromptTokens int) time.Duration {
+	ttftMs := ttftMsFromSnapshot(snap, reqPromptTokens)
 	if ttftMs <= 0 || math.IsNaN(ttftMs) || math.IsInf(ttftMs, 0) {
 		return 0
 	}
@@ -1338,16 +1338,13 @@ func estimatedTTFTFromSnapshot(snap routingSnapshot, reqPromptTokens, reqMaxToke
 // step, which is already reflected by effectiveTPS. Count waiting prefills ahead
 // and this request's own prefill instead of treating active_token_budget_used as
 // a serial decode backlog.
-func ttftMsFromSnapshot(snap routingSnapshot, reqPromptTokens, reqMaxTokens int) float64 {
+func ttftMsFromSnapshot(snap routingSnapshot, reqPromptTokens int) float64 {
 	if !snap.hasBackendCapacity {
 		return 0
 	}
 	statePenalty, _ := slotStatePenalty(snap.slotState)
 	if reqPromptTokens < 0 {
 		reqPromptTokens = 0
-	}
-	if reqMaxTokens <= 0 {
-		reqMaxTokens = defaultRequestedMaxTokens
 	}
 	prefillTPS := snap.prefillTPS
 	if prefillTPS <= 0 {

--- a/coordinator/registry/scheduler.go
+++ b/coordinator/registry/scheduler.go
@@ -1330,6 +1330,14 @@ func estimatedTTFTFromSnapshot(snap routingSnapshot, reqPromptTokens, reqMaxToke
 // (QuickCapacityCheckWithTTFTForRequest) and the scheduler
 // (buildCandidateWithReason) so the two paths cannot drift on what "TTFT"
 // means.
+//
+// Token-budget fields are admission/memory reservations, not decode work that
+// must fully drain before this request can emit a first token. Continuous
+// batching lets a newly-admitted request join the decode loop once its prefill
+// completes; existing active max-output reservations only slow the next decode
+// step, which is already reflected by effectiveTPS. Count waiting prefills ahead
+// and this request's own prefill instead of treating active_token_budget_used as
+// a serial decode backlog.
 func ttftMsFromSnapshot(snap routingSnapshot, reqPromptTokens, reqMaxTokens int) float64 {
 	if !snap.hasBackendCapacity {
 		return 0
@@ -1350,28 +1358,25 @@ func ttftMsFromSnapshot(snap routingSnapshot, reqPromptTokens, reqMaxTokens int)
 		effectiveTPS = 1.0
 	}
 
-	var backlogMs float64
-	if snap.activeTokenBudgetMax > 0 {
-		tokensAhead := float64(snap.activeTokenBudgetUsed) + float64(snap.queuedTokenBudget)
-		coordinatorExtra := float64(snap.pendingMaxTokens) - float64(committedTokenBudget(snap))
-		if coordinatorExtra > 0 {
-			tokensAhead += coordinatorExtra
-		}
-		backlogMs = tokensAhead / effectiveTPS * 1000.0
-	} else {
-		runningBacklogTokens := float64(snap.maxTokensPotential)
-		if runningBacklogTokens <= 0 && snap.backendRunning > 0 {
-			runningBacklogTokens = float64(snap.backendRunning * reqMaxTokens)
-		}
-		waitingBacklogTokens := float64(snap.backendWaiting * reqMaxTokens)
-		unaccountedPendingTokens := float64(snap.pendingMaxTokens) - runningBacklogTokens - waitingBacklogTokens
-		if unaccountedPendingTokens < 0 {
-			unaccountedPendingTokens = 0
-		}
-		backlogMs = (runningBacklogTokens + waitingBacklogTokens + unaccountedPendingTokens) / effectiveTPS * 1000.0
-	}
+	queuedPrefillMs := queuedPrefillTokensAhead(snap, reqPromptTokens) / prefillTPS * 1000.0
+	thisPrefillMs := float64(reqPromptTokens) / prefillTPS * 1000.0
+	firstDecodeMs := 1000.0 / effectiveTPS
+	return statePenalty + queuedPrefillMs + thisPrefillMs + firstDecodeMs
+}
 
-	return statePenalty + backlogMs + float64(reqPromptTokens)/prefillTPS*1000.0
+func queuedPrefillTokensAhead(snap routingSnapshot, reqPromptTokens int) float64 {
+	if reqPromptTokens <= 0 {
+		return 0
+	}
+	waiting := snap.backendWaiting
+	reflected := snap.backendRunning + snap.backendWaiting
+	if extraPending := snap.pendingForModel - reflected; extraPending > 0 {
+		waiting += extraPending
+	}
+	if waiting <= 0 {
+		return 0
+	}
+	return float64(waiting * reqPromptTokens)
 }
 
 // DrainQueuedRequestsForModel attempts to assign queued requests for a

--- a/coordinator/registry/scheduler_test.go
+++ b/coordinator/registry/scheduler_test.go
@@ -119,7 +119,8 @@ func TestQuickCapacityCheckWithTTFTEstimatesBestEligibleProvider(t *testing.T) {
 	model := "ttft-model"
 	slow := makeSchedulerProvider(t, reg, "slow", model, 100)
 	slow.mu.Lock()
-	slow.BackendCapacity.Slots[0].MaxTokensPotential = 2_000
+	slow.BackendCapacity.Slots[0].NumWaiting = 100
+	slow.BackendCapacity.Slots[0].MaxConcurrency = 128
 	slow.mu.Unlock()
 
 	candidates, rejections, tooLarge, bestTTFT, hasTTFT := reg.QuickCapacityCheckWithTTFTForRequest(model, 100, 128, RequestTraits{}, false)
@@ -140,44 +141,41 @@ func TestQuickCapacityCheckWithTTFTEstimatesBestEligibleProvider(t *testing.T) {
 	}
 }
 
-func TestQuickCapacityCheckWithTTFTIncludesTokenBudgetBacklog(t *testing.T) {
+func TestQuickCapacityCheckWithTTFTIncludesWaitingPrefills(t *testing.T) {
 	reg := New(testLogger())
-	model := "ttft-token-budget-model"
-	p := makeTokenBudgetProvider(t, reg, "budget", model, 100, 1_000, 20_000, 100)
+	model := "ttft-waiting-prefill-model"
+	p := makeTokenBudgetProvider(t, reg, "budget", model, 100, 20_000, 100_000, 100)
 	p.mu.Lock()
-	p.BackendCapacity.Slots[0].QueuedTokenBudget = 2_000
+	p.BackendCapacity.Slots[0].NumWaiting = 3
+	p.BackendCapacity.Slots[0].MaxConcurrency = 8
+	p.BackendCapacity.Slots[0].QueuedTokenBudget = 40_000
 	p.mu.Unlock()
-	p.AddPending(&PendingRequest{
-		RequestID:             "coordinator-pending",
-		Model:                 model,
-		EstimatedPromptTokens: 4_000,
-		RequestedMaxTokens:    1_000,
-	})
 
-	candidates, rejections, tooLarge, bestTTFT, hasTTFT := reg.QuickCapacityCheckWithTTFTForRequest(model, 100, 128, RequestTraits{}, false)
+	candidates, rejections, tooLarge, bestTTFT, hasTTFT := reg.QuickCapacityCheckWithTTFTForRequest(model, 2_000, 128, RequestTraits{}, false)
 	if candidates != 1 || rejections != 0 || tooLarge != 0 {
 		t.Fatalf("capacity = (%d,%d,%d), want (1,0,0)", candidates, rejections, tooLarge)
 	}
-	if !hasTTFT || bestTTFT < 50*time.Second || bestTTFT > 51*time.Second {
-		t.Fatalf("bestTTFT = %v has=%v, want about 50s from active+queued+coordinator backlog", bestTTFT, hasTTFT)
+	if !hasTTFT || bestTTFT < 20*time.Second || bestTTFT > 21*time.Second {
+		t.Fatalf("bestTTFT = %v has=%v, want about 20s from waiting prefills plus this prefill", bestTTFT, hasTTFT)
 	}
 }
 
-func TestQuickCapacityCheckWithTTFTIncludesBackendRunningFallback(t *testing.T) {
+func TestQuickCapacityCheckWithTTFTIgnoresActiveReservations(t *testing.T) {
 	reg := New(testLogger())
-	model := "ttft-running-fallback-model"
-	p := makeSchedulerProvider(t, reg, "running", model, 100)
+	model := "ttft-active-reservation-model"
+	p := makeTokenBudgetProvider(t, reg, "running", model, 100, 80_000, 200_000, 100)
 	p.mu.Lock()
 	p.BackendCapacity.Slots[0].NumRunning = 1
-	p.BackendCapacity.Slots[0].MaxTokensPotential = 0
+	p.BackendCapacity.Slots[0].MaxTokensPotential = 100_000
+	p.BackendCapacity.Slots[0].QueuedTokenBudget = 40_000
 	p.mu.Unlock()
 
 	candidates, rejections, tooLarge, bestTTFT, hasTTFT := reg.QuickCapacityCheckWithTTFTForRequest(model, 100, 2048, RequestTraits{}, false)
 	if candidates != 1 || rejections != 0 || tooLarge != 0 {
 		t.Fatalf("capacity = (%d,%d,%d), want (1,0,0)", candidates, rejections, tooLarge)
 	}
-	if !hasTTFT || bestTTFT <= 20*time.Second {
-		t.Fatalf("bestTTFT = %v has=%v, want running request backlog above 20s", bestTTFT, hasTTFT)
+	if !hasTTFT || bestTTFT > time.Second {
+		t.Fatalf("bestTTFT = %v has=%v, want active reservations not to inflate first-token estimate", bestTTFT, hasTTFT)
 	}
 }
 
@@ -185,13 +183,12 @@ func TestReserveProviderExcludesSlowProviderWhenTTFTCeilingSet(t *testing.T) {
 	reg := New(testLogger())
 	model := "ttft-ceiling-model"
 
-	// slow-but-cheap: moderate backlog keeps its cost below the expensive
-	// provider, but the backlog pushes its TTFT above the 10s target.
+	// slow-but-cheap: cold state keeps its cost below the expensive provider,
+	// but pushes its TTFT above the 10s target.
 	slow := makeSchedulerProvider(t, reg, "slow", model, 100)
 	slow.mu.Lock()
 	slow.PrefillTPS = 1000
-	// 5_000 tokens / 100 TPS = 50s backlog; TTFT ≈ 50s + 0.1s > 10s.
-	slow.BackendCapacity.Slots[0].MaxTokensPotential = 5_000
+	slow.BackendCapacity.Slots[0].State = "idle_shutdown"
 	slow.mu.Unlock()
 
 	// fast-but-expensive: low decode TPS inflates cost, but TTFT stays tiny.
@@ -250,7 +247,7 @@ func TestReserveProviderReturnsTTFTRejectionsWhenAllTooSlow(t *testing.T) {
 	p := makeSchedulerProvider(t, reg, "slow", model, 100)
 	p.mu.Lock()
 	p.PrefillTPS = 1000
-	p.BackendCapacity.Slots[0].MaxTokensPotential = 2_000_000
+	p.BackendCapacity.Slots[0].State = "idle_shutdown"
 	p.mu.Unlock()
 
 	req := &PendingRequest{

--- a/coordinator/registry/warm_pool_controller.go
+++ b/coordinator/registry/warm_pool_controller.go
@@ -13,6 +13,7 @@ type warmPoolController struct {
 	config   WarmPoolConfig
 	state    *warmPoolState
 	queueMu  syncQueuePressure
+	tickMu   sync.Mutex
 }
 
 type syncQueuePressure struct {
@@ -87,6 +88,20 @@ func (r *Registry) StartWarmPoolController(ctx context.Context, cfg WarmPoolConf
 	return cancel
 }
 
+// TriggerWarmPool runs one active warm-pool planning pass immediately. It is a
+// non-periodic kick used by hot request paths after queue/capacity pressure is
+// observed so warming does not wait for the next controller interval. The normal
+// provider eligibility gates and pending-load caps still bound load_model sends.
+func (r *Registry) TriggerWarmPool() []WarmPoolSnapshot {
+	r.mu.RLock()
+	controller := r.warmPool
+	r.mu.RUnlock()
+	if controller == nil || !controller.config.Enabled || controller.config.ObserveOnly {
+		return nil
+	}
+	return controller.tick(time.Now())
+}
+
 func (c *warmPoolController) run(ctx context.Context) {
 	interval := c.config.Interval
 	if interval <= 0 {
@@ -108,6 +123,8 @@ func (c *warmPoolController) tick(now time.Time) []WarmPoolSnapshot {
 	if c == nil || c.registry == nil {
 		return nil
 	}
+	c.tickMu.Lock()
+	defer c.tickMu.Unlock()
 	snapshots := c.plan(now)
 	for _, snap := range snapshots {
 		if c.registry.logger != nil {

--- a/coordinator/registry/warm_pool_controller.go
+++ b/coordinator/registry/warm_pool_controller.go
@@ -14,6 +14,7 @@ type warmPoolController struct {
 	state    *warmPoolState
 	queueMu  syncQueuePressure
 	tickMu   sync.Mutex
+	triggerC chan struct{}
 }
 
 type syncQueuePressure struct {
@@ -62,6 +63,7 @@ func newWarmPoolController(r *Registry, cfg WarmPoolConfig) *warmPoolController 
 		config:   cfg,
 		state:    newWarmPoolState(),
 		queueMu:  syncQueuePressure{models: make(map[string]warmPoolQueuePressure)},
+		triggerC: make(chan struct{}, 1),
 	}
 }
 
@@ -88,10 +90,28 @@ func (r *Registry) StartWarmPoolController(ctx context.Context, cfg WarmPoolConf
 	return cancel
 }
 
+// RequestWarmPoolTrigger coalesces a hot-path warm-pool kick into the
+// controller's single run goroutine. It never blocks callers: if a trigger is
+// already queued or a tick is in progress, that pending pass is enough to observe
+// the latest queue/capacity pressure.
+func (r *Registry) RequestWarmPoolTrigger() bool {
+	r.mu.RLock()
+	controller := r.warmPool
+	r.mu.RUnlock()
+	if controller == nil || !controller.config.Enabled || controller.config.ObserveOnly {
+		return false
+	}
+	select {
+	case controller.triggerC <- struct{}{}:
+		return true
+	default:
+		return false
+	}
+}
+
 // TriggerWarmPool runs one active warm-pool planning pass immediately. It is a
-// non-periodic kick used by hot request paths after queue/capacity pressure is
-// observed so warming does not wait for the next controller interval. The normal
-// provider eligibility gates and pending-load caps still bound load_model sends.
+// used by tests and administrative callers that need the resulting snapshots.
+// Hot request paths should use RequestWarmPoolTrigger so bursts are coalesced.
 func (r *Registry) TriggerWarmPool() []WarmPoolSnapshot {
 	r.mu.RLock()
 	controller := r.warmPool
@@ -113,6 +133,8 @@ func (c *warmPoolController) run(ctx context.Context) {
 		select {
 		case <-ctx.Done():
 			return
+		case <-c.triggerC:
+			c.tick(time.Now())
 		case <-ticker.C:
 			c.tick(time.Now())
 		}
@@ -291,14 +313,15 @@ func (c *warmPoolController) targetWarm(fleet warmPoolModelSnapshot, pressure wa
 }
 
 func (c *warmPoolController) recordQueuePressure(model string, depth int, oldestAge time.Duration, now time.Time) {
-	if depth < 0 {
-		depth = 0
+	c.queueMu.mu.Lock()
+	defer c.queueMu.mu.Unlock()
+	if depth <= 0 {
+		delete(c.queueMu.models, model)
+		return
 	}
 	if oldestAge < 0 {
 		oldestAge = 0
 	}
-	c.queueMu.mu.Lock()
-	defer c.queueMu.mu.Unlock()
 	c.queueMu.models[model] = warmPoolQueuePressure{Depth: depth, OldestAge: oldestAge, UpdatedAt: now}
 }
 

--- a/coordinator/registry/warm_pool_controller_test.go
+++ b/coordinator/registry/warm_pool_controller_test.go
@@ -129,6 +129,51 @@ func TestTriggerWarmPoolRespondsToQueuePressureImmediately(t *testing.T) {
 	}
 }
 
+func TestRequestWarmPoolTriggerCoalescesBursts(t *testing.T) {
+	reg := New(testLogger())
+	reg.ConfigureWarmPool(testWarmPoolConfig())
+
+	if !reg.RequestWarmPoolTrigger() {
+		t.Fatal("first trigger should enqueue a warm-pool tick")
+	}
+	for i := 0; i < 10; i++ {
+		if reg.RequestWarmPoolTrigger() {
+			t.Fatalf("trigger %d was accepted despite an already pending tick", i+2)
+		}
+	}
+	if got := len(reg.warmPool.triggerC); got != 1 {
+		t.Fatalf("pending triggers = %d, want 1", got)
+	}
+}
+
+func TestWarmPoolQueueClearStopsStaleQueueLoads(t *testing.T) {
+	reg := New(testLogger())
+	model := "warm-pool-clear-queue"
+	makeSchedulerProvider(t, reg, "warm", model, 80)
+	makeWarmPoolColdProvider(t, reg, "cold-a", model, 80, 64, 8)
+	makeWarmPoolColdProvider(t, reg, "cold-b", model, 80, 64, 8)
+	cfg := testWarmPoolConfig()
+	cfg.QueueAgeThreshold = 0
+	cfg.MaxGlobalPendingLoads = 10
+	reg.ConfigureWarmPool(cfg)
+	sent := captureWarmPoolLoads(reg)
+
+	reg.RecordWarmPoolQueueEnqueued(model, 1, 0)
+	reg.TriggerWarmPool()
+	if len(*sent) != 1 {
+		t.Fatalf("sent loads after queue pressure = %d, want 1", len(*sent))
+	}
+
+	reg.RecordWarmPoolQueueCleared(model)
+	snaps := reg.TriggerWarmPool()
+	if len(*sent) != 1 {
+		t.Fatalf("sent loads after clearing queue = %d, want still 1", len(*sent))
+	}
+	if len(snaps) == 0 || snaps[0].QueueDepth != 0 || len(snaps[0].Actions) != 0 {
+		t.Fatalf("snapshot after clear = %+v, want no queue-driven action", snaps)
+	}
+}
+
 func TestTriggerWarmPoolObserveOnlyDoesNotSendLoads(t *testing.T) {
 	reg := New(testLogger())
 	model := "warm-pool-observe-only"

--- a/coordinator/registry/warm_pool_controller_test.go
+++ b/coordinator/registry/warm_pool_controller_test.go
@@ -108,6 +108,49 @@ func TestWarmPoolQueueAgePressureRaisesTarget(t *testing.T) {
 	}
 }
 
+func TestTriggerWarmPoolRespondsToQueuePressureImmediately(t *testing.T) {
+	reg := New(testLogger())
+	model := "warm-pool-immediate-queue"
+	makeSchedulerProvider(t, reg, "warm", model, 80)
+	makeWarmPoolColdProvider(t, reg, "cold", model, 80, 64, 8)
+	cfg := testWarmPoolConfig()
+	cfg.QueueAgeThreshold = 0
+	reg.ConfigureWarmPool(cfg)
+	sent := captureWarmPoolLoads(reg)
+
+	reg.RecordWarmPoolQueueEnqueued(model, 1, 0)
+	snaps := reg.TriggerWarmPool()
+
+	if len(*sent) != 1 {
+		t.Fatalf("sent loads = %d, want 1", len(*sent))
+	}
+	if len(snaps) == 0 || snaps[0].QueueDepth != 1 || len(snaps[0].Actions) != 1 {
+		t.Fatalf("snapshot = %+v, want immediate queue-pressure action", snaps)
+	}
+}
+
+func TestTriggerWarmPoolObserveOnlyDoesNotSendLoads(t *testing.T) {
+	reg := New(testLogger())
+	model := "warm-pool-observe-only"
+	makeSchedulerProvider(t, reg, "warm", model, 80)
+	makeWarmPoolColdProvider(t, reg, "cold", model, 80, 64, 8)
+	cfg := testWarmPoolConfig()
+	cfg.QueueAgeThreshold = 0
+	cfg.ObserveOnly = true
+	reg.ConfigureWarmPool(cfg)
+	sent := captureWarmPoolLoads(reg)
+
+	reg.RecordWarmPoolQueueEnqueued(model, 1, 0)
+	snaps := reg.TriggerWarmPool()
+
+	if len(*sent) != 0 {
+		t.Fatalf("sent loads = %d, want 0 in observe-only mode", len(*sent))
+	}
+	if len(snaps) != 0 {
+		t.Fatalf("snapshots = %+v, want no active trigger in observe-only mode", snaps)
+	}
+}
+
 func TestWarmPoolNoPressureForLongActiveDecodeAlone(t *testing.T) {
 	reg := New(testLogger())
 	model := "warm-pool-active-only"

--- a/coordinator/registry/warm_pool_state.go
+++ b/coordinator/registry/warm_pool_state.go
@@ -166,6 +166,13 @@ func (r *Registry) RecordWarmPoolQueueEnqueued(model string, depth int, oldestAg
 	r.warmPool.recordQueuePressure(model, depth, oldestAge, time.Now())
 }
 
+func (r *Registry) RecordWarmPoolQueueCleared(model string) {
+	if r.warmPool == nil || model == "" {
+		return
+	}
+	r.warmPool.recordQueuePressure(model, 0, 0, time.Now())
+}
+
 func (r *Registry) RecordWarmPoolQueueTimeout(model string, age time.Duration) {
 	if r.warmPool == nil || model == "" {
 		return


### PR DESCRIPTION
## Summary
- Recalibrates coordinator TTFT preflight so token-budget reservations are not treated as serial decode backlog.
- Uses the exact public TTFT budget everywhere: `5s + 1ms/input_token`, with no 10s floor.
- Keeps routing prompt estimates as temporary `len/4`, and fixes structured Responses `input` so JSON wrappers/base64 media do not inflate TTFT admission.
- Turns warm-pool control on by default and makes queue/capacity pressure kick warming immediately, while coalescing hot-path triggers so bursts cannot spawn unbounded goroutines.
- Clears queue pressure when queued requests leave the queue so transient queues do not cause repeated stale warming.

## TTFT Before
- `QuickCapacityCheckWithTTFTForRequest` counted `active_token_budget_used`, `queued_token_budget`, and `max_tokens_potential` as tokens ahead of a request.
- Those fields are worst-case memory/admission reservations, not serial work that must finish before the next request can emit a first token.
- Active running requests could therefore look like multi-minute decode queues.
- Admission also used a 10s floor, while runtime dispatch used the exact `5s + 1ms/input_token` deadline. For short prompts this could admit providers that dispatch would still time out.
- Structured Responses `input` was estimated as JSON length / 4, which could overcount wrappers and media payloads.

```mermaid
flowchart TD
  A[Incoming request] --> B[Preflight capacity check]
  B --> C[Read provider token-budget telemetry]
  C --> D[active_token_budget_used + queued_token_budget + max_tokens_potential]
  D --> E[Treat reservation total as serial decode backlog]
  E --> F[Predicted TTFT becomes very large under load]
  F --> G{Best predicted TTFT > mixed threshold?}
  G -->|yes| H[Return 429 before dispatch]
  G -->|no| I[Dispatch may still miss exact runtime deadline]
```

## TTFT After
- TTFT estimates count only queued prefills ahead, this request prefill, cold/load penalty, and one first decode step.
- Active token reservations still protect memory admission, but no longer inflate first-token timing.
- TTFT admission, scheduler `MaxTTFTMs`, queued requests, alias fallback, and retry-after all use the same exact threshold: `5s + 1ms/input_token`.
- Text prompt estimation remains temporary `len/4`; structured Responses input now reuses the media-aware content-part estimator.

```mermaid
flowchart TD
  A[Incoming request] --> B[Estimate input tokens]
  B --> C[text len/4]
  B --> D[media flat cost]
  B --> E[Responses content parts, not JSON wrapper bytes]
  C --> F[TTFT threshold = 5s + 1ms/input_token]
  D --> F
  E --> F
  F --> G[Preflight capacity check]
  G --> H[Use token budget only for admission safety]
  G --> I[Estimate first-token work]
  I --> J[queued prefills ahead]
  I --> K[this request prefill]
  I --> L[one decode step at effective TPS]
  I --> M[cold/load state penalty]
  J --> N[Predicted TTFT]
  K --> N
  L --> N
  M --> N
  N --> O{Predicted TTFT > exact threshold?}
  O -->|yes| P[Return 429]
  O -->|no| Q[Dispatch]
```

## Warming Before
- Warm-pool controller defaulted to disabled and observe-only.
- Queue pressure needed to age past 5s before affecting the warm target.
- The controller ticked every 30s, so even real demand could wait for the next interval.
- Queue enqueue recorded pressure, but did not immediately run a warming pass.

```mermaid
flowchart TD
  A[Request cannot get immediate slot] --> B[Request enqueued or 429 capacity]
  B --> C[Record queue/capacity pressure]
  C --> D{Warm pool enabled and active by env?}
  D -->|default no| E[No load_model sent]
  D -->|if enabled| F[Wait up to periodic tick]
  F --> G{Queue old enough?}
  G -->|not yet| H[No target increase]
  G -->|yes| I[At most 1 load this tick]
```

## Warming After
- Warm-pool controller defaults to enabled and active.
- Queue pressure has a 0s age threshold by default.
- Queue enqueue and capacity reject now request a warm-pool trigger through a buffered coalescing channel, not one goroutine per request.
- Queue pressure is cleared when queued requests are assigned or canceled, preventing repeated warming from stale one-minute queue snapshots.
- Periodic interval is shortened to 10s for follow-up pressure.
- Default load budget is raised to 4 loads per tick and 16 global pending loads.
- The provider selection remains conservative: only idle, public, trusted, runtime-verified providers that can fit the model are selected, and `pendingModelLoads` suppresses duplicate load_model storms.

```mermaid
flowchart TD
  A[Request cannot get immediate slot] --> B[Request enqueued or 429 capacity]
  B --> C[Record queue/capacity pressure]
  C --> D[Nonblocking warm-pool trigger signal]
  D --> E{Trigger already pending?}
  E -->|yes| F[Coalesce; no new goroutine]
  E -->|no| G[Controller run loop performs one tick]
  G --> H[Plan target warm replicas]
  H --> I{Eligible idle cold providers?}
  I -->|no| J[No load_model]
  I -->|yes| K[Reserve pendingModelLoads]
  K --> L[Send bounded load_model actions]
  L --> M[Provider warms model]
  M --> N[Queue drain can route more requests]
  B --> O[Queued request assigned/canceled]
  O --> P[Clear queue pressure if depth is zero]
```

## Sub-Agent Notes
- TTFT strategy review agreed the 10s floor should not ship mixed with exact runtime deadlines; exact `5s + 1ms/input_token` is the right PR-scope policy.
- Token-estimation review confirmed routing uses `len/4` today and recommended the Responses structured-input fix in this PR; tokenizer-accurate estimates, Anthropic `system`, and tool-schema accounting should be follow-ups.
- Warming review agreed immediate warming is directionally right, but called out operational churn risk. This PR keeps safety gates and env knobs, coalesces hot-path triggers, and clears queue pressure on drain.

## Tests
- `cd coordinator && go test ./api -run "TestEstimatePromptTokens|TestDetectMediaRequirementResponsesInput|TestTTFTAdmissionThresholdExact|TestWriteTTFTTooSlow|TestTTFTAdmission429BelowOldTenSecondFloor|TestTTFTAdmission429|TestMaybeFallbackAliasTTFT"`
- `cd coordinator && go test ./registry -run "TestRequestWarmPoolTrigger|TestWarmPoolQueue|TestTriggerWarmPool|TestReadConfigWarmPool|TestWarmPool"`
- `golangci-lint run`
- `cd coordinator && go test ./...`
