### PR TITLE
fix(provider): resumable 4-bit model download + restart-safe detection

### DIFF
--- a/provider-swift/Sources/ProviderCore/Models/ModelCatalog.swift
+++ b/provider-swift/Sources/ProviderCore/Models/ModelCatalog.swift
@@ -12,330 +12,12 @@
 /// matching what `ModelScanner` already discovers.
 
 import Foundation
-#if canImport(Darwin)
-import Darwin
-#endif
 
 // MARK: - Download progress tracking & rendering
-
-/// Per-file progress state used by `DownloadProgressTracker`.
-private struct FileProgress: Sendable {
-    let label: String
-    let expectedBytes: Int64
-    var downloadedBytes: Int64 = 0
-    var startTime: Date = Date()
-    var completed: Bool = false
-    var completionTime: Date?
-    var destinationURL: URL?
-
-    /// Bytes/second using elapsed wall time.
-    var speed: Double {
-        let elapsed = (completionTime ?? Date()).timeIntervalSince(startTime)
-        guard elapsed > 0.1 else { return 0 }
-        return Double(downloadedBytes) / elapsed
-    }
-
-    /// Estimated seconds remaining.
-    var eta: Double? {
-        guard speed > 0, expectedBytes > 0 else { return nil }
-        let remaining = Double(expectedBytes - downloadedBytes)
-        guard remaining > 0 else { return nil }
-        return remaining / speed
-    }
-
-    var fraction: Double {
-        guard expectedBytes > 0 else { return 0 }
-        return min(1.0, Double(downloadedBytes) / Double(expectedBytes))
-    }
-}
-
-/// Delegate-based download tracker that provides incremental progress.
-///
-/// Each download task is registered with `register(taskID:label:expectedBytes:)`.
-/// The delegate callbacks update shared state that `ProgressRenderer` reads.
-/// Completed downloads are signalled via per-task continuations.
-private final class DownloadProgressTracker: NSObject, URLSessionDownloadDelegate, @unchecked Sendable {
-
-    /// Result of a single file download: the temporary location where
-    /// URLSession wrote the file (must be moved before the delegate returns).
-    struct DownloadResult {
-        let location: URL
-        let response: URLResponse
-    }
-
-    private let lock = NSLock()
-    private var progressMap: [Int: FileProgress] = [:]  // taskIdentifier -> progress
-    private var continuations: [Int: CheckedContinuation<DownloadResult, Error>] = [:]
-    private var _allProgress: [FileProgress] = []
-
-    /// Register a task so we can track its progress.
-    func register(taskID: Int, label: String, expectedBytes: Int64) {
-        lock.lock()
-        progressMap[taskID] = FileProgress(label: label, expectedBytes: expectedBytes)
-        rebuildSnapshot()
-        lock.unlock()
-    }
-
-    /// Store the continuation that will be resumed when the download finishes.
-    func setContinuation(_ cont: CheckedContinuation<DownloadResult, Error>, forTaskID taskID: Int) {
-        lock.lock()
-        continuations[taskID] = cont
-        lock.unlock()
-    }
-
-    /// Thread-safe snapshot of all tracked file progress, ordered by
-    /// registration time.
-    var allProgress: [FileProgress] {
-        lock.lock()
-        defer { lock.unlock() }
-        return _allProgress
-    }
-
-    /// Whether all registered downloads have completed (or errored).
-    var isComplete: Bool {
-        lock.lock()
-        defer { lock.unlock() }
-        return !progressMap.isEmpty && progressMap.values.allSatisfy(\.completed)
-    }
-
-    private func rebuildSnapshot() {
-        _allProgress = progressMap.keys.sorted().map { progressMap[$0]! }
-    }
-
-    // MARK: URLSessionDownloadDelegate
-
-    func urlSession(
-        _ session: URLSession,
-        downloadTask: URLSessionDownloadTask,
-        didWriteData bytesWritten: Int64,
-        totalBytesWritten: Int64,
-        totalBytesExpectedToWrite: Int64
-    ) {
-        lock.lock()
-        let id = downloadTask.taskIdentifier
-        if var p = progressMap[id] {
-            p.downloadedBytes = totalBytesWritten
-            if totalBytesExpectedToWrite > 0 {
-                // Update expected if the server tells us (e.g. after resume
-                // partial content).  Keep original manifest value if server
-                // returns -1.
-            }
-            progressMap[id] = p
-            rebuildSnapshot()
-        }
-        lock.unlock()
-    }
-
-    func urlSession(
-        _ session: URLSession,
-        downloadTask: URLSessionDownloadTask,
-        didFinishDownloadingTo location: URL
-    ) {
-        // URLSession deletes the temp file when this callback returns.
-        // Move it to a stable location so the continuation consumer can
-        // process it.
-        let stableLocation = FileManager.default.temporaryDirectory
-            .appendingPathComponent("darkbloom-dl-\(downloadTask.taskIdentifier)-\(UUID().uuidString)")
-        try? FileManager.default.moveItem(at: location, to: stableLocation)
-
-        lock.lock()
-        let id = downloadTask.taskIdentifier
-        if var p = progressMap[id] {
-            p.downloadedBytes = p.expectedBytes > 0 ? p.expectedBytes : p.downloadedBytes
-            p.completed = true
-            p.completionTime = Date()
-            p.destinationURL = stableLocation
-            progressMap[id] = p
-            rebuildSnapshot()
-        }
-        let cont = continuations.removeValue(forKey: id)
-        lock.unlock()
-
-        let response = downloadTask.response ?? HTTPURLResponse(
-            url: downloadTask.originalRequest?.url ?? URL(string: "about:blank")!,
-            statusCode: 200,
-            httpVersion: nil,
-            headerFields: nil
-        )!
-        cont?.resume(returning: DownloadResult(location: stableLocation, response: response))
-    }
-
-    func urlSession(
-        _ session: URLSession,
-        task: URLSessionTask,
-        didCompleteWithError error: (any Error)?
-    ) {
-        guard let error else { return }
-        lock.lock()
-        let id = task.taskIdentifier
-        if var p = progressMap[id] {
-            p.completed = true
-            p.completionTime = Date()
-            progressMap[id] = p
-            rebuildSnapshot()
-        }
-        let cont = continuations.removeValue(forKey: id)
-        lock.unlock()
-        cont?.resume(throwing: error)
-    }
-}
-
-/// Renders a multi-line progress display to the terminal using ANSI escape
-/// codes. Falls back to simple per-file messages when stdout is not a TTY.
-private final class ProgressRenderer: @unchecked Sendable {
-
-    private let isTTY: Bool
-    private var linesPrinted: Int = 0
-    private let lock = NSLock()
-    /// Set of labels already printed in non-TTY mode.
-    private var printedLabels: Set<String> = []
-
-    init() {
-        self.isTTY = isatty(STDOUT_FILENO) != 0
-    }
-
-    /// Render a frame given the current file progress snapshot.
-    func render(_ files: [FileProgress]) {
-        lock.lock()
-        defer { lock.unlock() }
-
-        if !isTTY {
-            renderPlain(files)
-            return
-        }
-        renderANSI(files)
-    }
-
-    /// Final render: clear the progress area and print completion summary.
-    func finish(_ files: [FileProgress]) {
-        lock.lock()
-        defer { lock.unlock() }
-
-        if isTTY {
-            // Move up and clear all lines.
-            if linesPrinted > 0 {
-                print("\u{1B}[\(linesPrinted)A", terminator: "")
-                for _ in 0..<linesPrinted {
-                    print("\u{1B}[2K")
-                }
-                print("\u{1B}[\(linesPrinted)A", terminator: "")
-                linesPrinted = 0
-            }
-        }
-
-        // Print final summary lines.
-        for f in files {
-            let totalStr = Self.formatBytes(f.expectedBytes > 0 ? f.expectedBytes : f.downloadedBytes)
-            let elapsed = (f.completionTime ?? Date()).timeIntervalSince(f.startTime)
-            let avgSpeed = elapsed > 0.1 ? Double(f.downloadedBytes) / elapsed : 0
-            let speedStr = Self.formatSpeed(avgSpeed)
-            let timeStr = Self.formatDuration(elapsed)
-            print("  \u{2713} \(f.label)  \(totalStr)  \(speedStr)  \(timeStr)")
-        }
-    }
-
-    // MARK: - ANSI rendering
-
-    private func renderANSI(_ files: [FileProgress]) {
-        // Move cursor up to overwrite previous render.
-        if linesPrinted > 0 {
-            print("\u{1B}[\(linesPrinted)A", terminator: "")
-        }
-
-        let termWidth = Self.terminalWidth()
-        var lines = 0
-        for f in files {
-            print("\u{1B}[2K", terminator: "")  // Clear the line
-            let line = Self.formatLine(f, termWidth: termWidth)
-            print(line)
-            lines += 1
-        }
-        linesPrinted = lines
-        fflush(stdout)
-    }
-
-    private func renderPlain(_ files: [FileProgress]) {
-        for f in files where f.completed && !printedLabels.contains(f.label) {
-            printedLabels.insert(f.label)
-            let totalStr = Self.formatBytes(f.expectedBytes > 0 ? f.expectedBytes : f.downloadedBytes)
-            print("  \u{2713} \(f.label)  \(totalStr)")
-        }
-    }
-
-    // MARK: - Line formatting
-
-    private static func formatLine(_ f: FileProgress, termWidth: Int) -> String {
-        if f.completed {
-            let totalStr = formatBytes(f.expectedBytes > 0 ? f.expectedBytes : f.downloadedBytes)
-            let elapsed = (f.completionTime ?? Date()).timeIntervalSince(f.startTime)
-            let avgSpeed = elapsed > 0.1 ? Double(f.downloadedBytes) / elapsed : 0
-            return "  \u{2713} \(f.label)  \(totalStr)  \(formatSpeed(avgSpeed))  done"
-        }
-
-        let pct = Int(f.fraction * 100)
-        let dlStr = formatBytes(f.downloadedBytes)
-        let totStr = formatBytes(f.expectedBytes)
-        let speedStr = formatSpeed(f.speed)
-        let etaStr: String
-        if let eta = f.eta {
-            etaStr = "ETA \(formatDuration(eta))"
-        } else {
-            etaStr = "---"
-        }
-
-        // Assemble the suffix: "  62%  2.1/4.8 GB  113 MB/s  ETA 24s"
-        let suffix = "  \(String(format: "%3d", pct))%  \(dlStr)/\(totStr)  \(speedStr)  \(etaStr)"
-
-        // Calculate bar width: total - label - prefix - suffix - brackets - spaces
-        let labelMaxWidth = min(f.label.count, 45)
-        let label = f.label.count > labelMaxWidth
-            ? String(f.label.suffix(labelMaxWidth - 1)).padding(toLength: labelMaxWidth, withPad: " ", startingAt: 0)
-            : f.label
-        let prefix = "  \(label)  ["
-        let postfix = "]\(suffix)"
-        let barWidth = max(10, termWidth - prefix.count - postfix.count)
-
-        let filled = Int(f.fraction * Double(barWidth))
-        let empty = barWidth - filled
-        let bar = String(repeating: "\u{2588}", count: filled) + String(repeating: "\u{2591}", count: empty)
-
-        return "\(prefix)\(bar)\(postfix)"
-    }
-
-    // MARK: - Formatting helpers
-
-    static func formatBytes(_ bytes: Int64) -> String {
-        let b = Double(bytes)
-        if b < 1024 { return "\(bytes) B" }
-        if b < 1_048_576 { return String(format: "%.1f KB", b / 1024) }
-        if b < 1_073_741_824 { return String(format: "%.1f MB", b / 1_048_576) }
-        return String(format: "%.1f GB", b / 1_073_741_824)
-    }
-
-    static func formatSpeed(_ bytesPerSec: Double) -> String {
-        if bytesPerSec < 1024 { return String(format: "%.0f B/s", bytesPerSec) }
-        if bytesPerSec < 1_048_576 { return String(format: "%.0f KB/s", bytesPerSec / 1024) }
-        if bytesPerSec < 1_073_741_824 { return String(format: "%.0f MB/s", bytesPerSec / 1_048_576) }
-        return String(format: "%.1f GB/s", bytesPerSec / 1_073_741_824)
-    }
-
-    static func formatDuration(_ seconds: Double) -> String {
-        let s = Int(seconds)
-        if s < 60 { return "\(s)s" }
-        if s < 3600 { return "\(s / 60)m \(s % 60)s" }
-        return "\(s / 3600)h \(s / 60 % 60)m"
-    }
-
-    static func terminalWidth() -> Int {
-        #if canImport(Darwin)
-        var w = winsize()
-        if ioctl(STDOUT_FILENO, TIOCGWINSZ, &w) == 0, w.ws_col > 0 {
-            return Int(w.ws_col)
-        }
-        #endif
-        return 80
-    }
-}
+//
+// Progress state (`FileProgress`, `ManifestDownloadProgress`) and terminal
+// rendering (`ProgressRenderer`) live in `ModelDownloadProgress.swift` so this
+// file stays focused on catalog + download orchestration.
 
 // MARK: - Catalog model
 
@@ -811,8 +493,13 @@ public struct ModelDownloader: Sendable {
     /// from a `.part` file when present, verifying size + SHA-256 before
     /// promoting to the final staged path. Reuses the resume-capable
     /// `downloadFile` helper (Range requests, Content-Range validation, retries).
+    ///
+    /// `onChunk(bytesOnDisk)` reports cumulative bytes-on-disk for this file as
+    /// it streams, so the foreground path can render a live per-shard bar; the
+    /// background prefetch passes nil and accounts progress per whole file.
     private func downloadManifestFileWithResume(
-        _ job: (file: ManifestFile, destination: URL, url: String)
+        _ job: (file: ManifestFile, destination: URL, url: String),
+        onChunk: (@Sendable (Int64) -> Void)? = nil
     ) async throws {
         let ok = try await downloadFile(
             from: job.url,
@@ -820,7 +507,8 @@ public struct ModelDownloader: Sendable {
             label: job.file.path,
             onProgress: nil,
             required: true,
-            expectedSHA256: job.file.sha256.lowercased()
+            expectedSHA256: job.file.sha256.lowercased(),
+            onChunk: onChunk
         )
         guard ok else {
             throw ModelCatalogError.downloadFailed("\(job.file.path): required file could not be fetched")
@@ -953,14 +641,13 @@ public struct ModelDownloader: Sendable {
         try FileManager.default.createDirectory(at: snapshotsDir, withIntermediateDirectories: true)
 
         // STABLE staging dir keyed by the manifest prefix (NOT a random UUID) so an
-        // interrupted foreground download resumes — already-completed files are
-        // skipped instead of re-fetching the whole model. Same resume contract as
-        // the background `prefetch` path: staging is kept on a transient failure
-        // and cleared only on an aggregate-hash mismatch (poison) below.
-        let stagingName = ".local-staging-" + manifest.r2Prefix
-            .replacingOccurrences(of: "/", with: "__")
-            .replacingOccurrences(of: "\\", with: "__")
-        let stagingDir = snapshotsDir.appendingPathComponent(stagingName, isDirectory: true)
+        // interrupted foreground download resumes: already-completed files are
+        // skipped and partially-fetched shards continue from their `.part` instead
+        // of re-fetching the whole model. Same resume contract as the background
+        // `prefetch` path: staging is kept on a transient failure and cleared only
+        // on an aggregate-hash mismatch (poison) below.
+        let stagingDir = snapshotsDir.appendingPathComponent(
+            Self.localStagingDirName(r2Prefix: manifest.r2Prefix), isDirectory: true)
         try FileManager.default.createDirectory(at: stagingDir, withIntermediateDirectories: true)
 
         let jobs = try manifest.files.map { file -> (file: ManifestFile, destination: URL, url: String) in
@@ -972,52 +659,66 @@ public struct ModelDownloader: Sendable {
             )
         }
 
-        // Resume: skip files already staged + valid, and size the capacity
-        // pre-check to only the bytes that remain (less anything already saved in a
-        // `.part`) so a near-complete resume isn't rejected for lacking room equal
-        // to the whole model. Only the not-yet-valid files are enqueued below.
+        // Resume: skip files already staged + valid; only the not-yet-valid files
+        // are enqueued below.
         let alreadyValid = jobs.map { Self.fileMatches($0.destination, size: $0.file.sizeBytes, sha256: $0.file.sha256) }
-        // The foreground per-file downloader does a full GET (it does NOT byte-
-        // resume — it deletes any stale `.part`), so only fully-valid files are
-        // creditable here; every not-yet-valid file needs its full size. (Only the
-        // background `prefetch` path byte-resumes and may credit `.part` bytes.)
+        // The foreground per-file downloader now byte-resumes (streams to a stable
+        // `.part` and appends via HTTP `Range`), so credit any bytes already saved
+        // in each `.part`: a near-complete resume of a big shard must not be charged
+        // disk room equal to the whole shard.
+        let partBytes = jobs.map { fileSize($0.destination.appendingPathExtension("part")) }
         try Self.ensureAvailableCapacity(
             at: snapshotsDir,
             requiredBytes: Self.remainingBytesToFetch(
-                sizes: jobs.map(\.file.sizeBytes), alreadyValid: alreadyValid
+                sizes: jobs.map(\.file.sizeBytes), alreadyValid: alreadyValid, partBytes: partBytes
             )
         )
         let pending = zip(jobs, alreadyValid).filter { !$0.1 }.map(\.0)
 
-        // Set up delegate-based session for progress tracking.
-        let tracker = DownloadProgressTracker()
-        let delegateSession = URLSession(
-            configuration: urlSession.configuration,
-            delegate: tracker,
-            delegateQueue: nil
-        )
-        defer { delegateSession.finishTasksAndInvalidate() }
+        // FINISH-ON-RESTART: a prior run already staged every shard size+SHA-valid
+        // but was killed before publishing (the hidden staging dir is invisible to
+        // the scanner, so the picker showed "not downloaded"). Don't re-download —
+        // verify the aggregate and publish.
+        if pending.isEmpty {
+            try finalizeStagedManifest(model: model, manifest: manifest, jobs: jobs, stagingDir: stagingDir, cacheDir: cacheDir)
+            onProgress?(ProgressEvent(file: model.id, bytesDownloaded: manifest.totalSizeBytes, bytesTotal: manifest.totalSizeBytes))
+            return
+        }
+
+        // Live per-shard progress. Seed each pending file's bar with any bytes
+        // already saved in its `.part` (a resumed prefix) so the display reflects
+        // real on-disk progress instead of restarting the bar at 0%.
+        let progress = ManifestDownloadProgress()
+        for job in pending {
+            progress.register(
+                label: job.file.path,
+                expectedBytes: job.file.sizeBytes,
+                initialBytes: fileSize(job.destination.appendingPathExtension("part"))
+            )
+        }
 
         let renderer = ProgressRenderer()
-
         // Start the render loop as a detached task.
-        let renderTask = Task.detached { [renderer, tracker] in
+        let renderTask = Task.detached { [renderer, progress] in
             while !Task.isCancelled {
-                renderer.render(tracker.allProgress)
+                renderer.render(progress.allProgress)
                 try? await Task.sleep(nanoseconds: 250_000_000)  // 250ms
             }
         }
 
         do {
+            // 4-way concurrent download; each shard streams to its own `.part` and
+            // resumes from it via a `Range` request after an interruption.
             try await withThrowingTaskGroup(of: Void.self) { group in
                 var next = 0
                 for _ in 0..<min(concurrency, pending.count) {
                     let job = pending[next]
                     next += 1
                     group.addTask {
-                        try await self.downloadManifestFileWithProgress(
-                            job, tracker: tracker, session: delegateSession
-                        )
+                        try await self.downloadManifestFileWithResume(job, onChunk: { bytes in
+                            progress.update(label: job.file.path, downloadedBytes: bytes)
+                        })
+                        progress.complete(label: job.file.path)
                     }
                 }
 
@@ -1026,28 +727,26 @@ public struct ModelDownloader: Sendable {
                         let job = pending[next]
                         next += 1
                         group.addTask {
-                            try await self.downloadManifestFileWithProgress(
-                                job, tracker: tracker, session: delegateSession
-                            )
+                            try await self.downloadManifestFileWithResume(job, onChunk: { bytes in
+                                progress.update(label: job.file.path, downloadedBytes: bytes)
+                            })
+                            progress.complete(label: job.file.path)
                         }
                     }
                 }
             }
 
-            // Stop the render loop and print final summary.
+            // Stop the render loop and print the final summary.
             renderTask.cancel()
-            renderer.finish(tracker.allProgress)
-
-            onProgress?(ProgressEvent(file: model.id, bytesDownloaded: manifest.totalSizeBytes, bytesTotal: manifest.totalSizeBytes))
+            renderer.finish(progress.allProgress)
         } catch {
             renderTask.cancel()
             // One last render so the user sees where things stopped.
-            renderer.render(tracker.allProgress)
+            renderer.render(progress.allProgress)
             // Keep staging ONLY if it holds resumable content (a completed file or
-            // a `.part`); otherwise remove the empty husk so a first-file failure
-            // doesn't leave a stray staging dir behind. (Size check only — a
-            // promoted file is full-size + SHA-verified; size/SHA failures are
-            // removed before this point.)
+            // a `.part` prefix); otherwise remove the empty husk so a first-file
+            // failure doesn't leave a stray staging dir behind. (A promoted file is
+            // full-size + SHA-verified; size/SHA failures delete the `.part` first.)
             let hasResumable = jobs.contains {
                 fileSize($0.destination) == $0.file.sizeBytes
                     || fileSize($0.destination.appendingPathExtension("part")) > 0
@@ -1058,125 +757,35 @@ public struct ModelDownloader: Sendable {
             throw error
         }
 
+        try finalizeStagedManifest(model: model, manifest: manifest, jobs: jobs, stagingDir: stagingDir, cacheDir: cacheDir)
+        onProgress?(ProgressEvent(file: model.id, bytesDownloaded: manifest.totalSizeBytes, bytesTotal: manifest.totalSizeBytes))
+    }
+
+    /// Verify the aggregate hash over the staged files, then publish the snapshot
+    /// (`snapshots/local` + `refs/main`) so `ModelScanner` discovers it. Shared by
+    /// the normal completion path and the finish-on-restart short-circuit.
+    ///
+    /// On an aggregate mismatch over internally-valid files (a poisoned manifest:
+    /// every per-file SHA passed but the claimed aggregate is wrong) staging is
+    /// cleared so a corrected manifest re-downloads cleanly — otherwise skip-valid
+    /// would re-fail the aggregate forever. Transient per-file/network failures
+    /// throw earlier and deliberately KEEP staging so the next attempt resumes.
+    private func finalizeStagedManifest(
+        model: CatalogModel,
+        manifest: ModelManifest,
+        jobs: [(file: ManifestFile, destination: URL, url: String)],
+        stagingDir: URL,
+        cacheDir: URL
+    ) throws {
         let aggregate = WeightHasher.hashFilesWithRelativeKey(jobs.map { (file: $0.destination, sortKey: $0.file.path) })
         guard aggregate == manifest.aggregateSHA256 else {
-            // Internally-valid files that don't match the claimed aggregate = a
-            // poisoned manifest; clear staging so a corrected manifest re-downloads
-            // (otherwise skip-valid would re-fail the aggregate forever). Transient
-            // per-file/network failures throw earlier and deliberately KEEP staging
-            // so the next attempt resumes.
             try? FileManager.default.removeItem(at: stagingDir)
             throw ModelCatalogError.downloadFailed("aggregate hash mismatch for \(model.id)")
         }
-
         try Self.publishStagedSnapshot(stagingDir, to: cacheDir)
         try writeMainRef(for: model.id)
         // Staging was consumed by publishStagedSnapshot; best-effort husk cleanup.
         try? FileManager.default.removeItem(at: stagingDir)
-    }
-
-    /// Download a single manifest file using delegate-based URLSession for
-    /// incremental progress reporting.
-    private func downloadManifestFileWithProgress(
-        _ job: (file: ManifestFile, destination: URL, url: String),
-        tracker: DownloadProgressTracker,
-        session: URLSession
-    ) async throws {
-        let fm = FileManager.default
-        try fm.createDirectory(at: job.destination.deletingLastPathComponent(), withIntermediateDirectories: true)
-
-        var lastError: Error?
-        for attempt in 1...3 {
-            guard let url = URL(string: job.url) else {
-                throw ModelCatalogError.downloadFailed("invalid URL: \(job.url)")
-            }
-
-            var request = URLRequest(url: url)
-            request.httpMethod = "GET"
-            request.timeoutInterval = 6 * 60 * 60
-
-            let task = session.downloadTask(with: request)
-            tracker.register(
-                taskID: task.taskIdentifier,
-                label: job.file.path,
-                expectedBytes: job.file.sizeBytes
-            )
-
-            do {
-                let result = try await withCheckedThrowingContinuation { (cont: CheckedContinuation<DownloadProgressTracker.DownloadResult, Error>) in
-                    tracker.setContinuation(cont, forTaskID: task.taskIdentifier)
-                    task.resume()
-                }
-
-                guard let http = result.response as? HTTPURLResponse else {
-                    try? fm.removeItem(at: result.location)
-                    throw ModelCatalogError.downloadFailed("\(job.file.path): unexpected response type")
-                }
-                guard (200..<300).contains(http.statusCode) else {
-                    try? fm.removeItem(at: result.location)
-                    throw ModelCatalogError.downloadFailed("\(job.file.path): HTTP \(http.statusCode)")
-                }
-
-                // Move temp file to .part for SHA verification.
-                let partial = job.destination.appendingPathExtension("part")
-                try? fm.removeItem(at: partial)
-                try fm.moveItem(at: result.location, to: partial)
-
-                // SHA-256 verification.
-                let expectedSHA = job.file.sha256.lowercased()
-                let actual = Self.sha256HexForVerification(of: partial)
-
-                let size = fileSize(partial)
-                guard actual == expectedSHA else {
-                    try? fm.removeItem(at: partial)
-                    throw ModelCatalogError.downloadFailed(
-                        "\(job.file.path): SHA-256 mismatch (size=\(size), expected=\(expectedSHA.prefix(16))..., got=\(actual.prefix(16))...)"
-                    )
-                }
-
-                guard size == job.file.sizeBytes else {
-                    try? fm.removeItem(at: partial)
-                    throw ModelCatalogError.downloadFailed(
-                        "\(job.file.path): size \(size) != manifest size \(job.file.sizeBytes)"
-                    )
-                }
-
-                // Promote .part to final destination.
-                try? fm.removeItem(at: job.destination)
-                try fm.moveItem(at: partial, to: job.destination)
-                return
-
-            } catch {
-                lastError = error
-                if attempt < 3 {
-                    try await Task.sleep(nanoseconds: UInt64(attempt) * 1_000_000_000)
-                    continue
-                }
-            }
-        }
-
-        throw ModelCatalogError.downloadFailed(
-            Self.downloadFailureMessage(label: job.file.path, error: lastError)
-        )
-    }
-
-    private func downloadManifestFile(
-        _ job: (file: ManifestFile, destination: URL, url: String),
-        onProgress: (@Sendable (ProgressEvent) -> Void)?
-    ) async throws {
-        onProgress?(ProgressEvent(file: job.file.path, bytesDownloaded: 0, bytesTotal: job.file.sizeBytes))
-        try await downloadFile(
-            from: job.url,
-            to: job.destination,
-            label: job.file.path,
-            onProgress: onProgress,
-            required: true,
-            expectedSHA256: job.file.sha256.lowercased()
-        )
-        let size = fileSize(job.destination)
-        guard size == job.file.sizeBytes else {
-            throw ModelCatalogError.downloadFailed("\(job.file.path): size \(size) != manifest size \(job.file.sizeBytes)")
-        }
     }
 
     /// Remove a downloaded model from the cache. Returns true if anything was
@@ -1202,6 +811,33 @@ public struct ModelDownloader: Sendable {
         cacheModelDirectory(for: modelID)
             .appendingPathComponent("snapshots", isDirectory: true)
             .appendingPathComponent("local", isDirectory: true)
+    }
+
+    /// Stable foreground-download staging dir name, keyed by the manifest's
+    /// `r2Prefix` so an interrupted download resumes into the SAME dir instead of
+    /// a throwaway UUID. `r2Prefix` is path-like (e.g. "v2/org__name/version");
+    /// flatten it to a single safe component.
+    static func localStagingDirName(r2Prefix: String) -> String {
+        ".local-staging-" + r2Prefix
+            .replacingOccurrences(of: "/", with: "__")
+            .replacingOccurrences(of: "\\", with: "__")
+    }
+
+    /// Whether an interrupted foreground download left resumable content staged on
+    /// disk for this model build (keyed by `r2Prefix`): a completed shard or a
+    /// `.part` prefix in the stable `.local-staging-…` dir. Lets the picker show
+    /// "resuming" instead of "not downloaded" for a partially-downloaded model so
+    /// re-selecting it FINISHES the download rather than appearing to start over.
+    public static func hasResumableStaging(modelID: String, r2Prefix: String) -> Bool {
+        let stagingDir = cacheModelDirectory(for: modelID)
+            .appendingPathComponent("snapshots", isDirectory: true)
+            .appendingPathComponent(localStagingDirName(r2Prefix: r2Prefix), isDirectory: true)
+        guard let entries = try? FileManager.default.contentsOfDirectory(atPath: stagingDir.path) else {
+            return false
+        }
+        // Any non-hidden staged entry (a finished file, a `.part`, or a nested
+        // subdir like `adapters/`) is resumable content worth finishing.
+        return entries.contains { !$0.hasPrefix(".") }
     }
 
     static func parseShardNames(indexPath: URL) throws -> [String] {
@@ -1277,7 +913,8 @@ public struct ModelDownloader: Sendable {
         label: String,
         onProgress: (@Sendable (ProgressEvent) -> Void)?,
         required: Bool,
-        expectedSHA256: String? = nil
+        expectedSHA256: String? = nil,
+        onChunk: (@Sendable (Int64) -> Void)? = nil
     ) async throws -> Bool {
         guard let url = URL(string: urlString) else {
             if required { throw ModelCatalogError.downloadFailed("invalid URL: \(urlString)") }
@@ -1300,7 +937,8 @@ public struct ModelDownloader: Sendable {
                     from: url,
                     to: partial,
                     label: label,
-                    required: required
+                    required: required,
+                    onChunk: onChunk
                 )
                 guard ok else {
                     // Optional file that does not exist (404/403). `streamDownload`
@@ -1362,11 +1000,16 @@ public struct ModelDownloader: Sendable {
     ///
     /// `Task.checkCancellation()` is checked between chunks so cancellation stops
     /// promptly and leaves a resumable `.part`.
+    ///
+    /// `onChunk(bytesOnDisk)` is invoked as each buffer flushes (and at the end)
+    /// with the cumulative size of `partial` on disk, so callers can render live
+    /// per-file progress. It is NOT called on the 404/403 drain path.
     private func streamDownload(
         from url: URL,
         to partial: URL,
         label: String,
-        required: Bool
+        required: Bool,
+        onChunk: (@Sendable (Int64) -> Void)? = nil
     ) async throws -> Bool {
         let fm = FileManager.default
         let existingBytes = fileSize(partial)
@@ -1441,6 +1084,10 @@ public struct ModelDownloader: Sendable {
         // errors mid-transfer (connection drop), flush whatever was buffered
         // before rethrowing so EVERY received byte lands in `.part` and the
         // retry resumes from exactly where the drop happened (never from zero).
+        // Cumulative bytes durably written this run; added to the resumed prefix
+        // (`baseline`) when reporting on-disk progress to `onChunk`.
+        let baseline = append ? existingBytes : 0
+        var written: Int64 = 0
         var buffer = Data()
         buffer.reserveCapacity(Self.streamFlushThreshold)
         var sinceCancelCheck = 0
@@ -1450,7 +1097,9 @@ public struct ModelDownloader: Sendable {
                 sinceCancelCheck += 1
                 if buffer.count >= Self.streamFlushThreshold {
                     try writer.write(contentsOf: buffer)
+                    written += Int64(buffer.count)
                     buffer.removeAll(keepingCapacity: true)
+                    onChunk?(baseline + written)
                 }
                 // Check cancellation periodically (every ~64KB) without paying
                 // the cost on every single byte. The partial flush above means a
@@ -1458,7 +1107,11 @@ public struct ModelDownloader: Sendable {
                 if sinceCancelCheck >= Self.streamFlushThreshold {
                     sinceCancelCheck = 0
                     if Task.isCancelled {
-                        if !buffer.isEmpty { try writer.write(contentsOf: buffer) }
+                        if !buffer.isEmpty {
+                            try writer.write(contentsOf: buffer)
+                            written += Int64(buffer.count)
+                            buffer.removeAll(keepingCapacity: true)
+                        }
                         throw CancellationError()
                     }
                 }
@@ -1471,7 +1124,10 @@ public struct ModelDownloader: Sendable {
         }
         if !buffer.isEmpty {
             try writer.write(contentsOf: buffer)
+            written += Int64(buffer.count)
+            buffer.removeAll(keepingCapacity: true)
         }
+        onChunk?(baseline + written)
         return true
     }
 

--- a/provider-swift/Sources/ProviderCore/Models/ModelCatalog.swift
+++ b/provider-swift/Sources/ProviderCore/Models/ModelCatalog.swift
@@ -983,27 +983,17 @@ public struct ModelDownloader: Sendable {
         return false
     }
 
-    /// Stream an HTTP GET body incrementally into `partial`, appending to any
-    /// bytes already present (true byte-level resume).
+    /// Stream an HTTP GET body to `partial` in OS-sized chunks, appending to any
+    /// bytes already present (true byte-level resume). Delegates the transfer to
+    /// `StreamingFileDownloadDelegate`, which writes each chunk synchronously to
+    /// disk so the socket is throttled to disk speed (backpressure) with nothing
+    /// buffered in memory — replacing the old per-byte `URLSession.AsyncBytes`
+    /// loop that issued one async step per byte.
     ///
-    /// Behavior:
-    /// - If `partial` already has N bytes, sends `Range: bytes=N-`.
-    /// - 206 with a `Content-Range` whose start == N → append to `partial`.
-    /// - 200 (server ignored the Range / no range support) → truncate `partial`
-    ///   and write from byte 0 (restart THIS file only).
-    /// - 206 whose start != N (server resumed at the wrong offset) → truncate and
-    ///   restart this file rather than append onto a mismatched stream.
-    /// - 404/403 → remove `partial`; throw if `required`, else return false.
-    /// - On a mid-stream transport drop, the bytes received so far stay in
-    ///   `partial` and the error propagates (the caller retries with a fresh
-    ///   `Range` request that appends the remainder).
-    ///
-    /// `Task.checkCancellation()` is checked between chunks so cancellation stops
-    /// promptly and leaves a resumable `.part`.
-    ///
-    /// `onChunk(bytesOnDisk)` is invoked as each buffer flushes (and at the end)
-    /// with the cumulative size of `partial` on disk, so callers can render live
-    /// per-file progress. It is NOT called on the 404/403 drain path.
+    /// Resume/restart/404/416 semantics and the `onChunk(bytesOnDisk)` progress
+    /// contract are documented on the delegate. Cancellation propagates promptly
+    /// (`task.cancel()` via the cancellation handler) and leaves a resumable
+    /// `.part`.
     private func streamDownload(
         from url: URL,
         to partial: URL,
@@ -1011,151 +1001,53 @@ public struct ModelDownloader: Sendable {
         required: Bool,
         onChunk: (@Sendable (Int64) -> Void)? = nil
     ) async throws -> Bool {
-        let fm = FileManager.default
         let existingBytes = fileSize(partial)
 
         var request = URLRequest(url: url)
         request.httpMethod = "GET"
         // Model shards are multi-GB files. A short request timeout causes
-        // legitimate downloads to fail; the streaming byte sequence keeps the
-        // connection alive across the whole transfer.
+        // legitimate downloads to fail; the streamed transfer keeps the
+        // connection alive across the whole download.
         request.timeoutInterval = 6 * 60 * 60
         if existingBytes > 0 {
             request.setValue("bytes=\(existingBytes)-", forHTTPHeaderField: "Range")
         }
 
-        let (byteStream, response) = try await urlSession.bytes(for: request)
+        let delegate = StreamingFileDownloadDelegate(
+            partial: partial,
+            existingBytes: existingBytes,
+            label: label,
+            onChunk: onChunk
+        )
+        let task = urlSession.dataTask(with: request)
+        task.delegate = delegate
 
-        guard let http = response as? HTTPURLResponse else {
-            try? fm.removeItem(at: partial)
-            throw ModelCatalogError.downloadFailed("\(label): unexpected response type")
-        }
-
-        if http.statusCode == 404 || http.statusCode == 403 {
-            try? fm.removeItem(at: partial)
-            if required {
-                throw ModelCatalogError.downloadFailed("\(label): HTTP \(http.statusCode)")
+        let outcome = try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation {
+                (cont: CheckedContinuation<StreamingFileDownloadDelegate.Outcome, Error>) in
+                delegate.attach(cont)
+                task.resume()
             }
-            // Drain so the connection can be reused; ignore the bytes.
-            for try await _ in byteStream {}
-            return false
+        } onCancel: {
+            // Leaves the bytes already written durably in `.part` for resume.
+            task.cancel()
         }
-        // 416 Range Not Satisfiable: we asked for `bytes=N-` and the server says N
-        // is at/beyond the resource length — i.e. the `.part` already holds the
-        // whole file. This happens when a prior run received every byte but the
-        // process died before the file was verified + promoted. Do NOT delete the
-        // prefix and re-download it from zero: drain the (empty) body and return
-        // success so the caller's SHA/size check promotes a complete file (or
-        // deletes + restarts a corrupt/oversized one). Only trust this when we
-        // actually sent a Range (existingBytes > 0); a 416 with no prefix is a
-        // genuine error and falls through to the guard below.
-        if http.statusCode == 416, existingBytes > 0 {
-            for try await _ in byteStream {}
+
+        switch outcome {
+        case .notFound(let status):
+            try? FileManager.default.removeItem(at: partial)
+            if required {
+                throw ModelCatalogError.downloadFailed("\(label): HTTP \(status)")
+            }
+            return false
+        case .completeBeyondRange:
+            // The `.part` already holds the whole object; the caller's SHA/size
+            // check promotes it (or deletes + restarts a corrupt/oversized one).
             onChunk?(existingBytes)
             return true
+        case .success:
+            return true
         }
-        guard (200..<300).contains(http.statusCode) else {
-            try? fm.removeItem(at: partial)
-            throw ModelCatalogError.downloadFailed("\(label): HTTP \(http.statusCode)")
-        }
-
-        // Decide whether we append to the existing prefix or restart this file.
-        var append = false
-        if existingBytes > 0, http.statusCode == 206 {
-            // Validate the server resumed at our offset before appending.
-            if let contentRange = http.value(forHTTPHeaderField: "Content-Range"),
-               let rangeStart = Self.parseContentRangeStart(contentRange),
-               rangeStart == UInt64(existingBytes) {
-                append = true
-            }
-        }
-        // 200 (no range support) or an unverifiable/mismatched 206 → restart
-        // THIS file only: truncate the stale prefix and write from byte 0.
-        if !append {
-            try? fm.removeItem(at: partial)
-        }
-
-        if !fm.fileExists(atPath: partial.path) {
-            fm.createFile(atPath: partial.path, contents: nil)
-        }
-
-        let writer: FileHandle
-        do {
-            writer = try FileHandle(forWritingTo: partial)
-        } catch {
-            throw ModelCatalogError.downloadFailed("\(label): could not open .part for writing (\(error.localizedDescription))")
-        }
-        defer { try? writer.close() }
-        if append {
-            try writer.seekToEnd()
-        } else {
-            try writer.truncate(atOffset: 0)
-        }
-
-        // Buffer chunks so we don't issue a write() syscall per byte. Flush as
-        // each buffer fills (and at the end) so the bytes are durable on disk —
-        // a mid-stream drop leaves a resumable prefix. CRITICAL: if the stream
-        // errors mid-transfer (connection drop), flush whatever was buffered
-        // before rethrowing so EVERY received byte lands in `.part` and the
-        // retry resumes from exactly where the drop happened (never from zero).
-        // Cumulative bytes durably written this run; added to the resumed prefix
-        // (`baseline`) when reporting on-disk progress to `onChunk`.
-        let baseline = append ? existingBytes : 0
-        var written: Int64 = 0
-        var buffer = Data()
-        buffer.reserveCapacity(Self.streamFlushThreshold)
-        var sinceCancelCheck = 0
-        do {
-            for try await byte in byteStream {
-                buffer.append(byte)
-                sinceCancelCheck += 1
-                if buffer.count >= Self.streamFlushThreshold {
-                    try writer.write(contentsOf: buffer)
-                    written += Int64(buffer.count)
-                    buffer.removeAll(keepingCapacity: true)
-                    onChunk?(baseline + written)
-                }
-                // Check cancellation periodically (every ~64KB) without paying
-                // the cost on every single byte. The partial flush above means a
-                // cancelled transfer still leaves a resumable .part.
-                if sinceCancelCheck >= Self.streamFlushThreshold {
-                    sinceCancelCheck = 0
-                    if Task.isCancelled {
-                        if !buffer.isEmpty {
-                            try writer.write(contentsOf: buffer)
-                            written += Int64(buffer.count)
-                            buffer.removeAll(keepingCapacity: true)
-                        }
-                        throw CancellationError()
-                    }
-                }
-            }
-        } catch {
-            // Persist the prefix received before the drop, then propagate so the
-            // caller retries with a `Range` request that appends the remainder.
-            if !buffer.isEmpty { try? writer.write(contentsOf: buffer) }
-            throw error
-        }
-        if !buffer.isEmpty {
-            try writer.write(contentsOf: buffer)
-            written += Int64(buffer.count)
-            buffer.removeAll(keepingCapacity: true)
-        }
-        onChunk?(baseline + written)
-        return true
-    }
-
-    /// Flush the streaming download buffer to disk every 64 KB. Also the
-    /// cadence at which cancellation is checked during streaming.
-    private static let streamFlushThreshold = 65536
-
-    /// Parse the start offset from a Content-Range header value.
-    /// Expected format: "bytes 12345-67890/123456".
-    private static func parseContentRangeStart(_ value: String) -> UInt64? {
-        guard value.hasPrefix("bytes ") else { return nil }
-        let afterBytes = value.dropFirst("bytes ".count)
-        guard let dashIndex = afterBytes.firstIndex(of: "-") else { return nil }
-        return UInt64(afterBytes[afterBytes.startIndex..<dashIndex])
     }
 
     private static func downloadFailureMessage(label: String, error: Error?) -> String {

--- a/provider-swift/Sources/ProviderCore/Models/ModelCatalog.swift
+++ b/provider-swift/Sources/ProviderCore/Models/ModelCatalog.swift
@@ -1040,6 +1040,20 @@ public struct ModelDownloader: Sendable {
             for try await _ in byteStream {}
             return false
         }
+        // 416 Range Not Satisfiable: we asked for `bytes=N-` and the server says N
+        // is at/beyond the resource length — i.e. the `.part` already holds the
+        // whole file. This happens when a prior run received every byte but the
+        // process died before the file was verified + promoted. Do NOT delete the
+        // prefix and re-download it from zero: drain the (empty) body and return
+        // success so the caller's SHA/size check promotes a complete file (or
+        // deletes + restarts a corrupt/oversized one). Only trust this when we
+        // actually sent a Range (existingBytes > 0); a 416 with no prefix is a
+        // genuine error and falls through to the guard below.
+        if http.statusCode == 416, existingBytes > 0 {
+            for try await _ in byteStream {}
+            onChunk?(existingBytes)
+            return true
+        }
         guard (200..<300).contains(http.statusCode) else {
             try? fm.removeItem(at: partial)
             throw ModelCatalogError.downloadFailed("\(label): HTTP \(http.statusCode)")

--- a/provider-swift/Sources/ProviderCore/Models/ModelDownloadProgress.swift
+++ b/provider-swift/Sources/ProviderCore/Models/ModelDownloadProgress.swift
@@ -1,0 +1,263 @@
+/// Download progress tracking + terminal rendering for the foreground model
+/// download path (`darkbloom models download` / the interactive picker).
+///
+/// Split out of `ModelCatalog.swift` so that file stays focused on catalog +
+/// download orchestration. The tracker here is callback-driven (fed by the
+/// streaming, byte-resumable downloader in `ModelCatalog.swift`) rather than a
+/// `URLSessionDownloadDelegate`: downloads now stream straight to a `.part`
+/// file for true byte-level resume, so there is no `URLSessionDownloadTask` to
+/// observe — progress arrives as cumulative-bytes-on-disk callbacks instead.
+
+import Foundation
+#if canImport(Darwin)
+import Darwin
+#endif
+
+// MARK: - Per-file progress
+
+/// Per-file progress state rendered by `ProgressRenderer`.
+struct FileProgress: Sendable {
+    let label: String
+    let expectedBytes: Int64
+    var downloadedBytes: Int64 = 0
+    /// Bytes already on disk when tracking started (a resumed `.part` prefix).
+    /// Excluded from the speed/ETA math so a resume doesn't report an inflated
+    /// instantaneous rate for bytes it never actually transferred this run.
+    var baselineBytes: Int64 = 0
+    var startTime: Date = Date()
+    var completed: Bool = false
+    var completionTime: Date?
+
+    /// Bytes/second over this run's transfer (excludes the resumed prefix).
+    var speed: Double {
+        let elapsed = (completionTime ?? Date()).timeIntervalSince(startTime)
+        guard elapsed > 0.1 else { return 0 }
+        return Double(max(0, downloadedBytes - baselineBytes)) / elapsed
+    }
+
+    /// Estimated seconds remaining.
+    var eta: Double? {
+        guard speed > 0, expectedBytes > 0 else { return nil }
+        let remaining = Double(expectedBytes - downloadedBytes)
+        guard remaining > 0 else { return nil }
+        return remaining / speed
+    }
+
+    var fraction: Double {
+        guard expectedBytes > 0 else { return 0 }
+        return min(1.0, Double(downloadedBytes) / Double(expectedBytes))
+    }
+}
+
+// MARK: - Tracker
+
+/// Thread-safe per-file download progress keyed by file label (manifest path).
+///
+/// Fed by byte-progress callbacks from the streaming downloader and read on a
+/// timer by `ProgressRenderer`. Registration order is preserved so the rendered
+/// rows stay stable across frames.
+final class ManifestDownloadProgress: @unchecked Sendable {
+
+    private let lock = NSLock()
+    private var progress: [String: FileProgress] = [:]
+    private var order: [String] = []
+
+    /// Register a file to track. `initialBytes` seeds a resumed `.part` prefix
+    /// so the bar starts where the previous run left off (and is excluded from
+    /// the speed math via `baselineBytes`).
+    func register(label: String, expectedBytes: Int64, initialBytes: Int64 = 0) {
+        lock.lock()
+        defer { lock.unlock() }
+        if progress[label] == nil { order.append(label) }
+        var p = FileProgress(label: label, expectedBytes: expectedBytes)
+        p.downloadedBytes = max(0, initialBytes)
+        p.baselineBytes = max(0, initialBytes)
+        progress[label] = p
+    }
+
+    /// Update cumulative bytes-on-disk for a file.
+    func update(label: String, downloadedBytes: Int64) {
+        lock.lock()
+        defer { lock.unlock() }
+        guard var p = progress[label] else { return }
+        p.downloadedBytes = downloadedBytes
+        progress[label] = p
+    }
+
+    /// Mark a file complete (full size, stop the clock).
+    func complete(label: String) {
+        lock.lock()
+        defer { lock.unlock() }
+        guard var p = progress[label] else { return }
+        p.downloadedBytes = p.expectedBytes > 0 ? p.expectedBytes : p.downloadedBytes
+        p.completed = true
+        p.completionTime = Date()
+        progress[label] = p
+    }
+
+    /// Thread-safe snapshot of all tracked file progress, in registration order.
+    var allProgress: [FileProgress] {
+        lock.lock()
+        defer { lock.unlock() }
+        return order.compactMap { progress[$0] }
+    }
+}
+
+// MARK: - Renderer
+
+/// Renders a multi-line progress display to the terminal using ANSI escape
+/// codes. Falls back to simple per-file messages when stdout is not a TTY.
+final class ProgressRenderer: @unchecked Sendable {
+
+    private let isTTY: Bool
+    private var linesPrinted: Int = 0
+    private let lock = NSLock()
+    /// Set of labels already printed in non-TTY mode.
+    private var printedLabels: Set<String> = []
+
+    init() {
+        self.isTTY = isatty(STDOUT_FILENO) != 0
+    }
+
+    /// Render a frame given the current file progress snapshot.
+    func render(_ files: [FileProgress]) {
+        lock.lock()
+        defer { lock.unlock() }
+
+        if !isTTY {
+            renderPlain(files)
+            return
+        }
+        renderANSI(files)
+    }
+
+    /// Final render: clear the progress area and print completion summary.
+    func finish(_ files: [FileProgress]) {
+        lock.lock()
+        defer { lock.unlock() }
+
+        if isTTY {
+            // Move up and clear all lines.
+            if linesPrinted > 0 {
+                print("\u{1B}[\(linesPrinted)A", terminator: "")
+                for _ in 0..<linesPrinted {
+                    print("\u{1B}[2K")
+                }
+                print("\u{1B}[\(linesPrinted)A", terminator: "")
+                linesPrinted = 0
+            }
+        }
+
+        // Print final summary lines.
+        for f in files {
+            let totalStr = Self.formatBytes(f.expectedBytes > 0 ? f.expectedBytes : f.downloadedBytes)
+            let elapsed = (f.completionTime ?? Date()).timeIntervalSince(f.startTime)
+            let avgSpeed = elapsed > 0.1 ? Double(max(0, f.downloadedBytes - f.baselineBytes)) / elapsed : 0
+            let speedStr = Self.formatSpeed(avgSpeed)
+            let timeStr = Self.formatDuration(elapsed)
+            print("  \u{2713} \(f.label)  \(totalStr)  \(speedStr)  \(timeStr)")
+        }
+    }
+
+    // MARK: - ANSI rendering
+
+    private func renderANSI(_ files: [FileProgress]) {
+        // Move cursor up to overwrite previous render.
+        if linesPrinted > 0 {
+            print("\u{1B}[\(linesPrinted)A", terminator: "")
+        }
+
+        let termWidth = Self.terminalWidth()
+        var lines = 0
+        for f in files {
+            print("\u{1B}[2K", terminator: "")  // Clear the line
+            let line = Self.formatLine(f, termWidth: termWidth)
+            print(line)
+            lines += 1
+        }
+        linesPrinted = lines
+        fflush(stdout)
+    }
+
+    private func renderPlain(_ files: [FileProgress]) {
+        for f in files where f.completed && !printedLabels.contains(f.label) {
+            printedLabels.insert(f.label)
+            let totalStr = Self.formatBytes(f.expectedBytes > 0 ? f.expectedBytes : f.downloadedBytes)
+            print("  \u{2713} \(f.label)  \(totalStr)")
+        }
+    }
+
+    // MARK: - Line formatting
+
+    private static func formatLine(_ f: FileProgress, termWidth: Int) -> String {
+        if f.completed {
+            let totalStr = formatBytes(f.expectedBytes > 0 ? f.expectedBytes : f.downloadedBytes)
+            let elapsed = (f.completionTime ?? Date()).timeIntervalSince(f.startTime)
+            let avgSpeed = elapsed > 0.1 ? Double(max(0, f.downloadedBytes - f.baselineBytes)) / elapsed : 0
+            return "  \u{2713} \(f.label)  \(totalStr)  \(formatSpeed(avgSpeed))  done"
+        }
+
+        let pct = Int(f.fraction * 100)
+        let dlStr = formatBytes(f.downloadedBytes)
+        let totStr = formatBytes(f.expectedBytes)
+        let speedStr = formatSpeed(f.speed)
+        let etaStr: String
+        if let eta = f.eta {
+            etaStr = "ETA \(formatDuration(eta))"
+        } else {
+            etaStr = "---"
+        }
+
+        // Assemble the suffix: "  62%  2.1/4.8 GB  113 MB/s  ETA 24s"
+        let suffix = "  \(String(format: "%3d", pct))%  \(dlStr)/\(totStr)  \(speedStr)  \(etaStr)"
+
+        // Calculate bar width: total - label - prefix - suffix - brackets - spaces
+        let labelMaxWidth = min(f.label.count, 45)
+        let label = f.label.count > labelMaxWidth
+            ? String(f.label.suffix(labelMaxWidth - 1)).padding(toLength: labelMaxWidth, withPad: " ", startingAt: 0)
+            : f.label
+        let prefix = "  \(label)  ["
+        let postfix = "]\(suffix)"
+        let barWidth = max(10, termWidth - prefix.count - postfix.count)
+
+        let filled = Int(f.fraction * Double(barWidth))
+        let empty = barWidth - filled
+        let bar = String(repeating: "\u{2588}", count: filled) + String(repeating: "\u{2591}", count: empty)
+
+        return "\(prefix)\(bar)\(postfix)"
+    }
+
+    // MARK: - Formatting helpers
+
+    static func formatBytes(_ bytes: Int64) -> String {
+        let b = Double(bytes)
+        if b < 1024 { return "\(bytes) B" }
+        if b < 1_048_576 { return String(format: "%.1f KB", b / 1024) }
+        if b < 1_073_741_824 { return String(format: "%.1f MB", b / 1_048_576) }
+        return String(format: "%.1f GB", b / 1_073_741_824)
+    }
+
+    static func formatSpeed(_ bytesPerSec: Double) -> String {
+        if bytesPerSec < 1024 { return String(format: "%.0f B/s", bytesPerSec) }
+        if bytesPerSec < 1_048_576 { return String(format: "%.0f KB/s", bytesPerSec / 1024) }
+        if bytesPerSec < 1_073_741_824 { return String(format: "%.0f MB/s", bytesPerSec / 1_048_576) }
+        return String(format: "%.1f GB/s", bytesPerSec / 1_073_741_824)
+    }
+
+    static func formatDuration(_ seconds: Double) -> String {
+        let s = Int(seconds)
+        if s < 60 { return "\(s)s" }
+        if s < 3600 { return "\(s / 60)m \(s % 60)s" }
+        return "\(s / 3600)h \(s / 60 % 60)m"
+    }
+
+    static func terminalWidth() -> Int {
+        #if canImport(Darwin)
+        var w = winsize()
+        if ioctl(STDOUT_FILENO, TIOCGWINSZ, &w) == 0, w.ws_col > 0 {
+            return Int(w.ws_col)
+        }
+        #endif
+        return 80
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Models/StreamingFileDownloadDelegate.swift
+++ b/provider-swift/Sources/ProviderCore/Models/StreamingFileDownloadDelegate.swift
@@ -1,0 +1,207 @@
+import Foundation
+
+/// Streams an HTTP GET body straight to a `.part` file in OS-sized chunks using
+/// the `URLSession` data-delegate callbacks.
+///
+/// This replaces `URLSession.AsyncBytes`, whose `for await byte in …` yields a
+/// single `UInt8` per async-iterator step. That is pathologically slow for the
+/// multi-GB model shards we download (one async resumption per byte → billions
+/// of them per file). `URLSession.bytes` only exposes a per-byte sequence, so to
+/// get OS-sized `Data` chunks we drop to the delegate API.
+///
+/// Backpressure — the one virtue of `AsyncBytes` we must NOT lose — is preserved
+/// without any in-memory queue: `URLSession` serializes delegate callbacks and
+/// does not invoke `urlSession(_:dataTask:didReceive:)` again until the previous
+/// call returns. Writing each chunk synchronously to disk here therefore
+/// throttles the socket to disk speed; nothing is buffered beyond the single
+/// chunk the system hands us (so no drops and no unbounded growth on a slow
+/// disk / fast network).
+///
+/// The resume contract matches the previous `streamDownload` implementation:
+/// - If `existingBytes > 0` the caller sent `Range: bytes=N-`.
+/// - 206 whose `Content-Range` start == N → append to the existing prefix.
+/// - 200 (range ignored) or a mismatched/unverifiable 206 → truncate and rewrite
+///   THIS file from byte 0.
+/// - 404/403 → `.notFound` (caller removes the `.part`; throws iff required).
+/// - 416 with a prefix → `.completeBeyondRange` (the `.part` already holds the
+///   whole object; caller verifies + promotes it instead of re-downloading).
+/// - A mid-stream transport drop leaves every received byte durably in `.part`
+///   and surfaces as a thrown error so the caller retries with a fresh `Range`.
+/// - Cooperative cancellation (`task.cancel()`) surfaces as `CancellationError`
+///   and likewise leaves a resumable `.part`.
+final class StreamingFileDownloadDelegate: NSObject, URLSessionDataDelegate, @unchecked Sendable {
+    enum Outcome {
+        /// Body streamed to `.part` successfully (appended or rewritten).
+        case success
+        /// 416: the `.part` is already at/beyond the object length.
+        case completeBeyondRange
+        /// 404/403 for an optional file.
+        case notFound(Int)
+    }
+
+    private let partial: URL
+    private let existingBytes: Int64
+    private let label: String
+    private let onChunk: (@Sendable (Int64) -> Void)?
+    private let fm = FileManager.default
+
+    // Mutated only from the URLSession delegate queue (callbacks are serialized).
+    private var writer: FileHandle?
+    private var baseline: Int64 = 0
+    private var written: Int64 = 0
+    private var decided: Outcome?
+    private var setupError: Error?
+
+    // The continuation may be resumed from any delegate callback; guard it.
+    private let lock = NSLock()
+    private var continuation: CheckedContinuation<Outcome, Error>?
+    private var resumed = false
+
+    init(
+        partial: URL,
+        existingBytes: Int64,
+        label: String,
+        onChunk: (@Sendable (Int64) -> Void)?
+    ) {
+        self.partial = partial
+        self.existingBytes = existingBytes
+        self.label = label
+        self.onChunk = onChunk
+        super.init()
+    }
+
+    /// Attach the awaiting continuation. Call exactly once, immediately before
+    /// `task.resume()`.
+    func attach(_ continuation: CheckedContinuation<Outcome, Error>) {
+        lock.lock()
+        self.continuation = continuation
+        lock.unlock()
+    }
+
+    private func finish(_ result: Result<Outcome, Error>) {
+        lock.lock()
+        guard !resumed, let cont = continuation else { lock.unlock(); return }
+        resumed = true
+        continuation = nil
+        lock.unlock()
+        switch result {
+        case .success(let outcome): cont.resume(returning: outcome)
+        case .failure(let error): cont.resume(throwing: error)
+        }
+    }
+
+    // MARK: URLSessionDataDelegate
+
+    func urlSession(
+        _ session: URLSession,
+        dataTask: URLSessionDataTask,
+        didReceive response: URLResponse,
+        completionHandler: @escaping (URLSession.ResponseDisposition) -> Void
+    ) {
+        guard let http = response as? HTTPURLResponse else {
+            setupError = ModelCatalogError.downloadFailed("\(label): unexpected response type")
+            completionHandler(.cancel)
+            return
+        }
+        let status = http.statusCode
+
+        if status == 404 || status == 403 {
+            decided = .notFound(status)
+            completionHandler(.cancel)
+            return
+        }
+        // 416 Range Not Satisfiable: we asked for bytes past EOF, so the `.part`
+        // already holds the whole file. Let the caller verify + promote it.
+        if status == 416, existingBytes > 0 {
+            decided = .completeBeyondRange
+            completionHandler(.cancel)
+            return
+        }
+        guard (200..<300).contains(status) else {
+            setupError = ModelCatalogError.downloadFailed("\(label): HTTP \(status)")
+            completionHandler(.cancel)
+            return
+        }
+
+        // Append only when the server confirms it resumed at our exact offset.
+        var append = false
+        if existingBytes > 0, status == 206,
+            let contentRange = http.value(forHTTPHeaderField: "Content-Range"),
+            let start = Self.parseContentRangeStart(contentRange),
+            start == UInt64(existingBytes) {
+            append = true
+        }
+
+        do {
+            if !append { try? fm.removeItem(at: partial) }
+            if !fm.fileExists(atPath: partial.path) {
+                fm.createFile(atPath: partial.path, contents: nil)
+            }
+            let handle = try FileHandle(forWritingTo: partial)
+            if append {
+                try handle.seekToEnd()
+            } else {
+                try handle.truncate(atOffset: 0)
+            }
+            writer = handle
+            baseline = append ? existingBytes : 0
+        } catch {
+            setupError = ModelCatalogError.downloadFailed(
+                "\(label): could not open .part for writing (\(error.localizedDescription))")
+            completionHandler(.cancel)
+            return
+        }
+        completionHandler(.allow)
+    }
+
+    func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
+        guard setupError == nil, let writer else { return }
+        do {
+            // Synchronous write == backpressure: the next didReceive(data:) is
+            // not delivered until this returns, throttling the socket to disk.
+            try writer.write(contentsOf: data)
+            written += Int64(data.count)
+            onChunk?(baseline + written)
+        } catch {
+            setupError = ModelCatalogError.downloadFailed(
+                "\(label): write failed (\(error.localizedDescription))")
+            dataTask.cancel()
+        }
+    }
+
+    func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+        try? writer?.close()
+        writer = nil
+
+        // Decisions taken during response handling win over the cancellation
+        // error that our own `completionHandler(.cancel)` produces.
+        if let setupError {
+            finish(.failure(setupError))
+            return
+        }
+        if let decided {
+            finish(.success(decided))
+            return
+        }
+        if let error {
+            if (error as? URLError)?.code == .cancelled {
+                finish(.failure(CancellationError()))
+            } else {
+                // Transport drop mid-stream: the prefix stays in `.part`.
+                finish(.failure(error))
+            }
+            return
+        }
+        onChunk?(baseline + written)
+        finish(.success(.success))
+    }
+
+    /// Parse the start offset from a `Content-Range` value, e.g.
+    /// "bytes 12345-67890/123456".
+    static func parseContentRangeStart(_ value: String) -> UInt64? {
+        guard value.hasPrefix("bytes ") else { return nil }
+        let afterBytes = value.dropFirst("bytes ".count)
+        guard let dashIndex = afterBytes.firstIndex(of: "-") else { return nil }
+        return UInt64(afterBytes[afterBytes.startIndex..<dashIndex])
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Models/StreamingFileDownloadDelegate.swift
+++ b/provider-swift/Sources/ProviderCore/Models/StreamingFileDownloadDelegate.swift
@@ -23,8 +23,11 @@ import Foundation
 /// - 200 (range ignored) or a mismatched/unverifiable 206 → truncate and rewrite
 ///   THIS file from byte 0.
 /// - 404/403 → `.notFound` (caller removes the `.part`; throws iff required).
-/// - 416 with a prefix → `.completeBeyondRange` (the `.part` already holds the
-///   whole object; caller verifies + promotes it instead of re-downloading).
+/// - 416 with a prefix → size-verify against the 416's `Content-Range: bytes
+///   */<total>`. If the `.part` size equals `<total>` it is the whole object →
+///   `.completeBeyondRange` (caller verifies + promotes it). Otherwise the
+///   `.part` is stale/oversized/undersized → delete it and surface a retryable
+///   error so the caller re-downloads it cleanly from byte 0.
 /// - A mid-stream transport drop leaves every received byte durably in `.part`
 ///   and surfaces as a thrown error so the caller retries with a fresh `Range`.
 /// - Cooperative cancellation (`task.cancel()`) surfaces as `CancellationError`
@@ -110,10 +113,34 @@ final class StreamingFileDownloadDelegate: NSObject, URLSessionDataDelegate, @un
             completionHandler(.cancel)
             return
         }
-        // 416 Range Not Satisfiable: we asked for bytes past EOF, so the `.part`
-        // already holds the whole file. Let the caller verify + promote it.
+        // 416 Range Not Satisfiable: we asked for bytes past EOF. A 416 carries
+        // `Content-Range: bytes */<total>` (RFC 7233; R2/S3 send it), so use the
+        // total to verify the `.part` is EXACTLY the full object before promoting
+        // it — regardless of whether a SHA is available. This closes the legacy
+        // path gap: `downloadLegacyModelFromCDN` calls `downloadFile` with
+        // `expectedSHA256 == nil`, so without this check a stale/oversized/
+        // undersized `.part` would be promoted and served with NO verification.
         if status == 416, existingBytes > 0 {
-            decided = .completeBeyondRange
+            let total = http.value(forHTTPHeaderField: "Content-Range")
+                .flatMap(Self.parseContentRangeTotal)
+            if let total, UInt64(existingBytes) == total {
+                // The `.part` is precisely the whole object — promote it (the
+                // manifest path additionally SHA-checks before publishing).
+                decided = .completeBeyondRange
+            } else {
+                // Total missing/unknown, or the `.part` size disagrees with the
+                // object size: the `.part` is untrustworthy (stale/oversized/
+                // undersized). Discard it and surface a RETRYABLE error so
+                // `downloadFile`'s loop re-runs `streamDownload` from byte 0
+                // (existingBytes == 0 → no Range → full GET). This must NOT be a
+                // CancellationError, which `downloadFile` special-cases to never
+                // retry.
+                try? fm.removeItem(at: partial)
+                let totalDesc = total.map { "\($0)" } ?? "unknown"
+                setupError = ModelCatalogError.downloadFailed(
+                    "\(label): 416 with untrustworthy .part (size \(existingBytes) != object total "
+                        + "\(totalDesc)); discarded for clean re-download")
+            }
             completionHandler(.cancel)
             return
         }
@@ -203,5 +230,17 @@ final class StreamingFileDownloadDelegate: NSObject, URLSessionDataDelegate, @un
         let afterBytes = value.dropFirst("bytes ".count)
         guard let dashIndex = afterBytes.firstIndex(of: "-") else { return nil }
         return UInt64(afterBytes[afterBytes.startIndex..<dashIndex])
+    }
+
+    /// Parse the total object length (the value after the "/") from a
+    /// `Content-Range` value, supporting BOTH the unsatisfied-range form a 416
+    /// uses, "bytes */123", and the satisfied form "bytes 0-9/123". Returns nil
+    /// when the total is absent or unknown ("bytes */*").
+    static func parseContentRangeTotal(_ value: String) -> UInt64? {
+        guard value.hasPrefix("bytes ") else { return nil }
+        guard let slashIndex = value.lastIndex(of: "/") else { return nil }
+        let total = value[value.index(after: slashIndex)...]
+            .trimmingCharacters(in: .whitespaces)
+        return UInt64(total)
     }
 }

--- a/provider-swift/Sources/darkbloom/ModelsCommand.swift
+++ b/provider-swift/Sources/darkbloom/ModelsCommand.swift
@@ -122,9 +122,14 @@ extension Models {
                 return
             }
 
+            // UNFILTERED on-disk scan: a downloaded model that exceeds available
+            // RAM is still on disk, so it must show the "downloaded" checkmark
+            // (and appear under "Local only" when off-catalog) rather than reading
+            // as not-downloaded on a marginal-RAM box. The memory filter only
+            // governs loadability, not presence.
             let localModels: [ModelInfo]
             if let hardware = snapshot.hardware {
-                localModels = ModelScanner.scanModels(hardwareInfo: hardware)
+                localModels = ModelScanner.scanAllModels(hardwareInfo: hardware)
             } else {
                 localModels = []
             }

--- a/provider-swift/Sources/darkbloom/StartCommand.swift
+++ b/provider-swift/Sources/darkbloom/StartCommand.swift
@@ -642,6 +642,69 @@ struct Start: AsyncParsableCommand {
         return entries
     }
 
+    /// Memory held back for the OS before the per-model serving budget. Shared by
+    /// the interactive TUI picker and the non-TTY fallback so both agree on what
+    /// "fits".
+    static let pickerOSReserveGb = 4.0
+
+    /// Whether a single model of `sizeGb` can be served on a box with `memoryGb`
+    /// RAM. One model is warm at a time, so this is an individual-fit check with
+    /// the OS reserve held back.
+    static func modelFitsBudget(sizeGb: Double, memoryGb: Double) -> Bool {
+        sizeGb <= memoryGb - pickerOSReserveGb
+    }
+
+    /// Outcome of resolving a non-TTY fallback-picker input line.
+    enum FallbackSelection: Equatable {
+        case cancelled
+        case selected([String])
+        case rejected(String)
+    }
+
+    /// Resolve a fallback-picker input ("all" or comma-separated 1-based indices)
+    /// into model IDs, rejecting any pick that can't fit in RAM — the non-TTY
+    /// equivalent of the TUI refusing to toggle a won't-fit row. Pure + testable.
+    /// Without this guard a scripted/piped `darkbloom start` could select a model
+    /// that is on disk but too large for this box and always OOMs on load.
+    static func resolveFallbackSelection(
+        input rawInput: String,
+        entries: [PickerEntry],
+        memoryGb: Double
+    ) -> FallbackSelection {
+        let input = rawInput.trimmingCharacters(in: .whitespaces)
+        guard !input.isEmpty else { return .cancelled }
+        let budget = memoryGb - pickerOSReserveGb
+        func fits(_ e: PickerEntry) -> Bool { modelFitsBudget(sizeGb: e.sizeGb, memoryGb: memoryGb) }
+
+        if input.lowercased() == "all" {
+            let fitting = entries.filter(fits)
+            guard !fitting.isEmpty else {
+                return .rejected(
+                    "No model fits in \(Int(memoryGb)) GB RAM (need ≤ \(String(format: "%.1f", budget)) GB per model).")
+            }
+            return .selected(fitting.map(\.id))
+        }
+
+        var picked: [PickerEntry] = []
+        for token in input.split(separator: ",") {
+            let t = token.trimmingCharacters(in: .whitespaces)
+            guard let n = Int(t) else {
+                return .rejected("Invalid selection: '\(t)' is not a number.")
+            }
+            guard n >= 1, n <= entries.count else {
+                return .rejected("Invalid selection: \(n) (must be 1-\(entries.count)).")
+            }
+            let entry = entries[n - 1]
+            guard fits(entry) else {
+                return .rejected(
+                    "\(entry.displayName) (\(String(format: "%.1f", entry.sizeGb)) GB) needs more memory than this Mac has "
+                        + "(\(Int(memoryGb)) GB RAM, ~\(String(format: "%.1f", budget)) GB usable). Choose a smaller model.")
+            }
+            picked.append(entry)
+        }
+        return .selected(picked.map(\.id))
+    }
+
     private static let gemmaPublicID = "gemma-4-26b"
     private static let gemmaQATID = "gemma-4-26b-qat-4bit"
     private static let gemmaRollbackID = "gemma-4-26b-8bit"
@@ -756,7 +819,7 @@ struct Start: AsyncParsableCommand {
 
         // Fall back to simple numbered picker if stdin is not a TTY.
         guard isatty(STDIN_FILENO) != 0 else {
-            return try await fallbackPicker(entries: entries, client: client)
+            return try await fallbackPicker(entries: entries, memoryGb: memoryGb, client: client)
         }
 
         // Run the interactive TUI picker.
@@ -803,6 +866,7 @@ struct Start: AsyncParsableCommand {
     /// Simple numbered fallback picker for non-TTY environments.
     private func fallbackPicker(
         entries: [PickerEntry],
+        memoryGb: Double,
         client: ModelCatalogClient
     ) async throws -> [String] {
         print()
@@ -819,32 +883,25 @@ struct Start: AsyncParsableCommand {
             }
             let sizeStr = String(format: "%.1f GB", entry.sizeGb)
             let ramStr = entry.minRamGb.map { " (>= \($0) GB RAM)" } ?? ""
-            print("    [\(i + 1)] \(entry.displayName)  \(sizeStr)\(ramStr)  [\(status)]")
+            // Parity with the TUI: a downloaded-but-too-big model is shown but
+            // flagged so a non-interactive caller knows it can't be served here.
+            let fitStr = Start.modelFitsBudget(sizeGb: entry.sizeGb, memoryGb: memoryGb) ? "" : "  [won't fit]"
+            print("    [\(i + 1)] \(entry.displayName)  \(sizeStr)\(ramStr)  [\(status)]\(fitStr)")
         }
         print()
         print("  Select models (comma-separated numbers, or 'all'): ", terminator: "")
 
-        guard let input = readLine()?.trimmingCharacters(in: .whitespaces), !input.isEmpty else {
-            return []
-        }
-
         let selected: [PickerEntry]
-        if input.lowercased() == "all" {
-            selected = entries
-        } else {
-            let indices = input.split(separator: ",").compactMap { token -> Int? in
-                guard let n = Int(token.trimmingCharacters(in: .whitespaces)) else { return nil }
-                return n
-            }
-            var picked: [PickerEntry] = []
-            for idx in indices {
-                guard idx >= 1, idx <= entries.count else {
-                    printError("Invalid selection: \(idx) (must be 1-\(entries.count))")
-                    throw ExitCode.failure
-                }
-                picked.append(entries[idx - 1])
-            }
-            selected = picked
+        switch Start.resolveFallbackSelection(input: readLine() ?? "", entries: entries, memoryGb: memoryGb) {
+        case .cancelled:
+            return []
+        case .rejected(let message):
+            printError(message)
+            printError("hint: pick a model that fits, or run on a Mac with more RAM")
+            throw ExitCode.failure
+        case .selected(let ids):
+            let byID = Dictionary(entries.map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first })
+            selected = ids.compactMap { byID[$0] }
         }
 
         let localIDs = Set(entries.filter(\.downloaded).map(\.id))
@@ -880,8 +937,7 @@ struct Start: AsyncParsableCommand {
     /// Arrow keys navigate, Space toggles selection, Enter confirms, Esc/q cancels.
     /// Enforces memory budget and shows two sections: downloaded and available.
     private func runModelPicker(entries: [PickerEntry], memoryGb: Double) throws -> [Int] {
-        let osReserve = 4.0
-        let budget = memoryGb - osReserve
+        let budget = memoryGb - Start.pickerOSReserveGb
 
         var cursorPos = 0
         var selected = [Bool](repeating: false, count: entries.count)
@@ -919,7 +975,7 @@ struct Start: AsyncParsableCommand {
         }
 
         func canFitIndividually(_ entry: PickerEntry) -> Bool {
-            entry.sizeGb <= budget
+            Start.modelFitsBudget(sizeGb: entry.sizeGb, memoryGb: memoryGb)
         }
 
         // Pre-select the largest downloaded model that can fit on this machine.

--- a/provider-swift/Sources/darkbloom/StartCommand.swift
+++ b/provider-swift/Sources/darkbloom/StartCommand.swift
@@ -578,18 +578,68 @@ struct Start: AsyncParsableCommand {
     // MARK: - Interactive Catalog Picker
 
     /// Entry shown in the interactive TUI model picker.
-    private struct PickerEntry {
+    ///
+    /// `downloaded` is computed from an UNFILTERED on-disk check (not the
+    /// available-memory-filtered scan) so a fully-downloaded model that exceeds
+    /// available RAM still reads "downloaded (won't fit)" rather than "not
+    /// downloaded". `resumable` flags a build whose foreground download was
+    /// interrupted (staging on disk) so the picker can show "resuming".
+    struct PickerEntry: Equatable {
         let id: String
         let catalogModel: CatalogModel
         let displayName: String
         let sizeGb: Double
         let minRamGb: Int?
         let downloaded: Bool
+        var resumable: Bool = false
     }
 
-    private struct PickerCatalogRow {
+    struct PickerCatalogRow {
         let model: CatalogModel
         let displayName: String
+    }
+
+    /// Build picker entries from catalog rows and on-disk state. Pure (no IO) so
+    /// the downloaded / won't-fit / resuming classification is unit-testable.
+    ///
+    /// - `downloadedIDs` MUST come from an UNFILTERED on-disk scan so a
+    ///   present-but-too-big model still reads "downloaded".
+    /// - `localMemoryByID` carries the on-disk estimated memory for sizing
+    ///   downloaded rows (falls back to the catalog `size_gb` when absent).
+    /// - `resumableIDs` are builds with interrupted-download staging on disk.
+    /// - A not-yet-downloaded model whose declared `min_ram_gb` exceeds this box
+    ///   is hidden; a downloaded one is always shown (with a won't-fit note in
+    ///   the renderer).
+    static func buildPickerEntries(
+        rows: [PickerCatalogRow],
+        downloadedIDs: Set<String>,
+        localMemoryByID: [String: Double],
+        resumableIDs: Set<String>,
+        memoryGb: Double
+    ) -> [PickerEntry] {
+        var entries: [PickerEntry] = rows.compactMap { row in
+            let model = row.model
+            let isDownloaded = downloadedIDs.contains(model.id)
+            if !isDownloaded, let minRam = model.minRamGb, Double(minRam) > memoryGb {
+                return nil
+            }
+            let size = isDownloaded ? (localMemoryByID[model.id] ?? model.sizeGb) : model.sizeGb
+            return PickerEntry(
+                id: model.id,
+                catalogModel: model,
+                displayName: row.displayName,
+                sizeGb: size,
+                minRamGb: model.minRamGb,
+                downloaded: isDownloaded,
+                resumable: !isDownloaded && resumableIDs.contains(model.id)
+            )
+        }
+        // Downloaded first, then larger first.
+        entries.sort { a, b in
+            if a.downloaded != b.downloaded { return a.downloaded }
+            return a.sizeGb > b.sizeGb
+        }
+        return entries
     }
 
     private static let gemmaPublicID = "gemma-4-26b"
@@ -674,37 +724,30 @@ struct Start: AsyncParsableCommand {
             throw ExitCode.failure
         }
 
-        let localByID = Dictionary(uniqueKeysWithValues: snapshot.models.map { ($0.id, $0) })
         let memoryGb: Double = Double(snapshot.hardware?.memoryGb ?? 16)
 
-        // Build picker entries: filter to models that fit, sort downloaded-first
-        // then by size descending.
-        var entries: [PickerEntry] = catalog.compactMap { row -> PickerEntry? in
-            let entry = row.model
-            if let minRam = entry.minRamGb, Double(minRam) > memoryGb {
-                return nil
-            }
-            let isDownloaded = localByID[entry.id] != nil
-            let size: Double
-            if isDownloaded, let local = localByID[entry.id] {
-                size = local.estimatedMemoryGb
-            } else {
-                size = entry.sizeGb
-            }
-            return PickerEntry(
-                id: entry.id,
-                catalogModel: entry,
-                displayName: row.displayName,
-                sizeGb: size,
-                minRamGb: entry.minRamGb,
-                downloaded: isDownloaded
-            )
-        }
+        // "Downloaded" must be computed from an UNFILTERED on-disk scan: the
+        // memory-filtered `snapshot.models` drops models too large for available
+        // RAM, which would make a fully-downloaded-but-too-big model read "not
+        // downloaded" forever on a marginal-RAM box. The filtered scan is only
+        // used (via the renderer's budget check) to flag "won't fit".
+        let allLocal = snapshot.hardware.map { ModelScanner.scanAllModels(hardwareInfo: $0) } ?? []
+        let downloadedIDs = Set(allLocal.map(\.id))
+        let localMemoryByID = Dictionary(allLocal.map { ($0.id, $0.estimatedMemoryGb) }, uniquingKeysWith: { first, _ in first })
+        // Builds with an interrupted foreground download staged on disk: show
+        // "resuming" so re-selecting finishes rather than restarts.
+        let resumableIDs = Set(catalog.compactMap { row -> String? in
+            guard !downloadedIDs.contains(row.model.id), let prefix = row.model.r2Prefix else { return nil }
+            return ModelDownloader.hasResumableStaging(modelID: row.model.id, r2Prefix: prefix) ? row.model.id : nil
+        })
 
-        entries.sort { a, b in
-            if a.downloaded != b.downloaded { return a.downloaded }
-            return a.sizeGb > b.sizeGb
-        }
+        let entries = Start.buildPickerEntries(
+            rows: catalog,
+            downloadedIDs: downloadedIDs,
+            localMemoryByID: localMemoryByID,
+            resumableIDs: resumableIDs,
+            memoryGb: memoryGb
+        )
 
         guard !entries.isEmpty else {
             printError("No supported models fit in \(Int(memoryGb)) GB RAM.")
@@ -766,7 +809,14 @@ struct Start: AsyncParsableCommand {
         print("  Models (from coordinator catalog):")
         print()
         for (i, entry) in entries.enumerated() {
-            let status = entry.downloaded ? "downloaded" : "not downloaded"
+            let status: String
+            if entry.downloaded {
+                status = "downloaded"
+            } else if entry.resumable {
+                status = "resuming"
+            } else {
+                status = "not downloaded"
+            }
             let sizeStr = String(format: "%.1f GB", entry.sizeGb)
             let ramStr = entry.minRamGb.map { " (>= \($0) GB RAM)" } ?? ""
             print("    [\(i + 1)] \(entry.displayName)  \(sizeStr)\(ramStr)  [\(status)]")
@@ -918,7 +968,10 @@ struct Start: AsyncParsableCommand {
                     let check = sel[idx] ? "\u{2713}" : " "
                     let highlight = idx == pos ? "\u{1B}[36m" : ""
                     let reset = highlight.isEmpty ? "" : "\u{1B}[0m"
-                    output += "    \(highlight)\(arrow) [\(check)] \(entry.displayName) (\(formattedGB(entry.sizeGb)) GB)\(reset)\r\n"
+                    // A downloaded model that exceeds this box's budget is shown
+                    // (it IS on disk) but flagged "won't fit" — never hidden.
+                    let warn = canFitIndividually(entry) ? "" : " \u{26A0} won't fit"
+                    output += "    \(highlight)\(arrow) [\(check)] \(entry.displayName) (\(formattedGB(entry.sizeGb)) GB)\(warn)\(reset)\r\n"
                     lines += 1
                     idx += 1
                 }
@@ -944,8 +997,13 @@ struct Start: AsyncParsableCommand {
                     } else {
                         highlight = "\u{1B}[2m"
                     }
-                    let warn = tooLargeForMachine ? " \u{26A0} exceeds RAM" : ""
-                    output += "    \(highlight)\(arrow) [\(check)] \u{2193} \(entry.displayName) (\(formattedGB(entry.sizeGb)) GB)\(warn)\u{1B}[0m\r\n"
+                    let note: String
+                    if entry.resumable {
+                        note = tooLargeForMachine ? " \u{21BB} resuming \u{00B7} \u{26A0} exceeds RAM" : " \u{21BB} resuming"
+                    } else {
+                        note = tooLargeForMachine ? " \u{26A0} exceeds RAM" : ""
+                    }
+                    output += "    \(highlight)\(arrow) [\(check)] \u{2193} \(entry.displayName) (\(formattedGB(entry.sizeGb)) GB)\(note)\u{1B}[0m\r\n"
                     lines += 1
                     idx += 1
                 }

--- a/provider-swift/Tests/DarkbloomCLITests/PickerEntryTests.swift
+++ b/provider-swift/Tests/DarkbloomCLITests/PickerEntryTests.swift
@@ -28,6 +28,71 @@ struct PickerEntryTests {
         Start.PickerCatalogRow(model: m, displayName: m.displayName)
     }
 
+    private func entry(_ id: String, sizeGb: Double, downloaded: Bool = true) -> Start.PickerEntry {
+        Start.PickerEntry(
+            id: id,
+            catalogModel: model(id, sizeGb: sizeGb),
+            displayName: id,
+            sizeGb: sizeGb,
+            minRamGb: nil,
+            downloaded: downloaded
+        )
+    }
+
+    // MARK: - resolveFallbackSelection (non-TTY picker won't-fit guard)
+
+    @Test("fallback 'all' selects only models that fit in RAM")
+    func fallbackAllExcludesWontFit() {
+        let small = entry("org/small", sizeGb: 8)
+        let huge = entry("org/huge", sizeGb: 200)
+        // 18 GB box → 14 GB budget: small fits, huge does not.
+        let r = Start.resolveFallbackSelection(input: "all", entries: [small, huge], memoryGb: 18)
+        #expect(r == .selected(["org/small"]))
+    }
+
+    @Test("fallback rejects an explicit won't-fit pick instead of serving it")
+    func fallbackRejectsWontFitIndex() {
+        let small = entry("org/small", sizeGb: 8)
+        let huge = entry("org/huge", sizeGb: 200)
+        guard case .rejected = Start.resolveFallbackSelection(input: "2", entries: [small, huge], memoryGb: 18) else {
+            Issue.record("expected a won't-fit explicit selection to be rejected")
+            return
+        }
+    }
+
+    @Test("fallback selects explicit fitting models in order")
+    func fallbackSelectsFitting() {
+        let small = entry("org/small", sizeGb: 8)
+        let mid = entry("org/mid", sizeGb: 12)
+        #expect(
+            Start.resolveFallbackSelection(input: "1,2", entries: [small, mid], memoryGb: 18)
+                == .selected(["org/small", "org/mid"]))
+    }
+
+    @Test("fallback rejects 'all' when nothing fits")
+    func fallbackRejectsAllTooBig() {
+        let huge = entry("org/huge", sizeGb: 200)
+        guard case .rejected = Start.resolveFallbackSelection(input: "all", entries: [huge], memoryGb: 18) else {
+            Issue.record("expected rejection when no model fits")
+            return
+        }
+    }
+
+    @Test("fallback empty input cancels, out-of-range and non-numeric are rejected")
+    func fallbackEmptyAndRange() {
+        let small = entry("org/small", sizeGb: 8)
+        #expect(Start.resolveFallbackSelection(input: "", entries: [small], memoryGb: 18) == .cancelled)
+        #expect(Start.resolveFallbackSelection(input: "   ", entries: [small], memoryGb: 18) == .cancelled)
+        guard case .rejected = Start.resolveFallbackSelection(input: "5", entries: [small], memoryGb: 18) else {
+            Issue.record("expected out-of-range rejection")
+            return
+        }
+        guard case .rejected = Start.resolveFallbackSelection(input: "x", entries: [small], memoryGb: 18) else {
+            Issue.record("expected non-numeric rejection")
+            return
+        }
+    }
+
     @Test("a downloaded-but-too-big model still shows downloaded (never hidden by RAM)")
     func tooBigDownloadedShowsDownloaded() {
         let big = model("org/too-big", sizeGb: 200, minRamGb: 256)  // far over an 18 GB box

--- a/provider-swift/Tests/DarkbloomCLITests/PickerEntryTests.swift
+++ b/provider-swift/Tests/DarkbloomCLITests/PickerEntryTests.swift
@@ -1,0 +1,92 @@
+import Testing
+import ProviderCore
+
+@testable import darkbloom
+
+/// Unit tests for the pure picker-entry classifier `Start.buildPickerEntries`.
+///
+/// The key invariant (the "invisible after interruption" fix): a model that is
+/// physically on disk reads "downloaded" even when it exceeds available RAM —
+/// `downloaded` is computed from an UNFILTERED on-disk check, never the
+/// memory-filtered scan. Resumable (interrupted-download) builds are flagged so
+/// the picker can show "resuming" rather than "not downloaded".
+@Suite("Start.buildPickerEntries classification")
+struct PickerEntryTests {
+
+    private func model(_ id: String, sizeGb: Double = 10, minRamGb: Int? = nil) -> CatalogModel {
+        CatalogModel(
+            id: id,
+            s3Name: id,
+            displayName: id,
+            sizeGb: sizeGb,
+            minRamGb: minRamGb,
+            r2Prefix: "v2/\(id)/v1"
+        )
+    }
+
+    private func row(_ m: CatalogModel) -> Start.PickerCatalogRow {
+        Start.PickerCatalogRow(model: m, displayName: m.displayName)
+    }
+
+    @Test("a downloaded-but-too-big model still shows downloaded (never hidden by RAM)")
+    func tooBigDownloadedShowsDownloaded() {
+        let big = model("org/too-big", sizeGb: 200, minRamGb: 256)  // far over an 18 GB box
+        let entries = Start.buildPickerEntries(
+            rows: [row(big)],
+            downloadedIDs: ["org/too-big"],            // present on disk (UNFILTERED)
+            localMemoryByID: ["org/too-big": 240.0],   // way over budget
+            resumableIDs: [],
+            memoryGb: 18
+        )
+        #expect(entries.count == 1)
+        #expect(entries[0].id == "org/too-big")
+        #expect(entries[0].downloaded == true, "a model on disk must read downloaded even when it won't fit")
+        // Sized from the on-disk estimate, not the catalog size.
+        #expect(entries[0].sizeGb == 240.0)
+    }
+
+    @Test("a NOT-downloaded model whose min RAM exceeds the box is hidden")
+    func tooBigNotDownloadedHidden() {
+        let big = model("org/too-big", sizeGb: 200, minRamGb: 256)
+        let entries = Start.buildPickerEntries(
+            rows: [row(big)],
+            downloadedIDs: [],
+            localMemoryByID: [:],
+            resumableIDs: [],
+            memoryGb: 18
+        )
+        #expect(entries.isEmpty, "an unrunnable model that isn't on disk should not clutter the picker")
+    }
+
+    @Test("an interrupted (staged) not-downloaded model is flagged resumable")
+    func stagedModelIsResumable() {
+        let m = model("org/partial", sizeGb: 12, minRamGb: 16)
+        let entries = Start.buildPickerEntries(
+            rows: [row(m)],
+            downloadedIDs: [],
+            localMemoryByID: [:],
+            resumableIDs: ["org/partial"],
+            memoryGb: 32
+        )
+        #expect(entries.count == 1)
+        #expect(entries[0].downloaded == false)
+        #expect(entries[0].resumable == true)
+    }
+
+    @Test("downloaded entries sort before not-downloaded, larger first")
+    func sortingDownloadedFirst() {
+        let a = model("org/a-small-dl", sizeGb: 4, minRamGb: 8)
+        let b = model("org/b-big-dl", sizeGb: 40, minRamGb: 8)
+        let c = model("org/c-avail", sizeGb: 20, minRamGb: 8)
+        let entries = Start.buildPickerEntries(
+            rows: [row(a), row(b), row(c)],
+            downloadedIDs: ["org/a-small-dl", "org/b-big-dl"],
+            localMemoryByID: ["org/a-small-dl": 4, "org/b-big-dl": 40],
+            resumableIDs: [],
+            memoryGb: 64
+        )
+        #expect(entries.map(\.id) == ["org/b-big-dl", "org/a-small-dl", "org/c-avail"])
+        #expect(entries.prefix(2).allSatisfy { $0.downloaded })
+        #expect(entries.last?.downloaded == false)
+    }
+}

--- a/provider-swift/Tests/ProviderCoreTests/ModelCatalogTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/ModelCatalogTests.swift
@@ -240,6 +240,48 @@ struct ModelCatalogTests {
         #expect(RangeURLProtocol.lastRangeHeader == "bytes=16-")
     }
 
+    @Test("downloadFile discards an oversized .part on 416 and re-downloads it")
+    func downloadFileDiscardsOversizedPartOn416() async throws {
+        // A stale/oversized `.part` (the full object PLUS extra trailing garbage)
+        // must NOT be promoted on a 416. The 416's `Content-Range: bytes */<total>`
+        // says the object is 16 bytes but the `.part` is larger, so it cannot be
+        // the complete object. The legacy path passes no SHA, so the size check is
+        // the ONLY thing standing between this garbage and being served: we must
+        // delete the `.part` and re-fetch the correct payload from byte 0.
+        let full = Data("0123456789abcdef".utf8)  // 16 bytes
+        RangeURLProtocol.payload = full
+        RangeURLProtocol.lastRangeHeader = nil
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [RangeURLProtocol.self]
+        let session = URLSession(configuration: config)
+        let downloader = ModelDownloader(r2CDNURL: "https://cdn.example.test", urlSession: session)
+
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("model-download-test-\(UUID().uuidString)", isDirectory: true)
+        let final = dir.appendingPathComponent("model.safetensors")
+        let partial = final.appendingPathExtension("part")
+        defer { try? FileManager.default.removeItem(at: dir) }
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        // An oversized `.part`: the full payload plus extra trailing bytes, so its
+        // size (21) exceeds the object total (16) reported by the 416.
+        let oversized = full + Data("EXTRA".utf8)
+        try oversized.write(to: partial)
+        #expect(Int64(oversized.count) > Int64(full.count))
+
+        let ok = try await downloader.downloadFileForTesting(
+            from: "https://cdn.example.test/model.safetensors",
+            to: final
+        )
+
+        #expect(ok)
+        // The final file is the CORRECT full payload (re-downloaded from scratch),
+        // never the oversized garbage that was sitting in `.part`.
+        #expect(try Data(contentsOf: final) == full)
+        #expect(try Data(contentsOf: final) != oversized)
+        // The untrustworthy `.part` was discarded, not published.
+        #expect(!FileManager.default.fileExists(atPath: partial.path))
+    }
+
     @Test("downloadFile assembles a body delivered in many chunks into the final file")
     func downloadFileAssemblesMultiChunk() async throws {
         // Exercises the chunked delegate write path: the body arrives as many

--- a/provider-swift/Tests/ProviderCoreTests/ModelCatalogTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/ModelCatalogTests.swift
@@ -240,6 +240,61 @@ struct ModelCatalogTests {
         #expect(RangeURLProtocol.lastRangeHeader == "bytes=16-")
     }
 
+    @Test("downloadFile assembles a body delivered in many chunks into the final file")
+    func downloadFileAssemblesMultiChunk() async throws {
+        // Exercises the chunked delegate write path: the body arrives as many
+        // separate didReceive(data:) callbacks that must append in order.
+        let full = Data((0..<1000).map { UInt8($0 % 251) })
+        ChunkedURLProtocol.payload = full
+        ChunkedURLProtocol.chunkSize = 7  // force ~143 separate chunks
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [ChunkedURLProtocol.self]
+        let session = URLSession(configuration: config)
+        let downloader = ModelDownloader(r2CDNURL: "https://cdn.example.test", urlSession: session)
+
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("model-download-test-\(UUID().uuidString)", isDirectory: true)
+        let final = dir.appendingPathComponent("model.safetensors")
+        let partial = final.appendingPathExtension("part")
+        defer { try? FileManager.default.removeItem(at: dir) }
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+
+        let ok = try await downloader.downloadFileForTesting(
+            from: "https://cdn.example.test/model.safetensors",
+            to: final
+        )
+
+        #expect(ok)
+        #expect(try Data(contentsOf: final) == full)
+        #expect(!FileManager.default.fileExists(atPath: partial.path))
+    }
+
+    @Test("downloadFile returns false and clears a stale .part for an optional 404")
+    func downloadFileOptional404ClearsPart() async throws {
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [NotFoundURLProtocol.self]
+        let session = URLSession(configuration: config)
+        let downloader = ModelDownloader(r2CDNURL: "https://cdn.example.test", urlSession: session)
+
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("model-download-test-\(UUID().uuidString)", isDirectory: true)
+        let final = dir.appendingPathComponent("optional.bin")
+        let partial = final.appendingPathExtension("part")
+        defer { try? FileManager.default.removeItem(at: dir) }
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        try Data("stale prefix".utf8).write(to: partial)
+
+        let ok = try await downloader.downloadFileForTesting(
+            from: "https://cdn.example.test/optional.bin",
+            to: final,
+            required: false
+        )
+
+        #expect(!ok)
+        #expect(!FileManager.default.fileExists(atPath: partial.path), "a 404 must clear the stale .part")
+        #expect(!FileManager.default.fileExists(atPath: final.path))
+    }
+
     @Test("manifest download failure preserves existing local snapshot")
     func manifestDownloadFailurePreservesExistingSnapshot() async throws {
         let modelID = "test-org/staging-preserves-\(UUID().uuidString)"
@@ -359,6 +414,55 @@ private final class RangeURLProtocol: URLProtocol, @unchecked Sendable {
         )!
         client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
         client?.urlProtocol(self, didLoad: Data(body))
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+}
+
+/// Delivers the payload as many small `didLoad` chunks (multiple
+/// `didReceive(data:)` delegate callbacks) to exercise chunked assembly.
+private final class ChunkedURLProtocol: URLProtocol, @unchecked Sendable {
+    nonisolated(unsafe) static var payload = Data()
+    nonisolated(unsafe) static var chunkSize = 8
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        let response = HTTPURLResponse(
+            url: request.url!,
+            statusCode: 200,
+            httpVersion: "HTTP/1.1",
+            headerFields: ["Content-Length": "\(Self.payload.count)"]
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        var offset = 0
+        let size = max(1, Self.chunkSize)
+        while offset < Self.payload.count {
+            let end = min(offset + size, Self.payload.count)
+            client?.urlProtocol(self, didLoad: Self.payload.subdata(in: offset..<end))
+            offset = end
+        }
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+}
+
+/// Always answers 404 (optional-file miss path).
+private final class NotFoundURLProtocol: URLProtocol, @unchecked Sendable {
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        let response = HTTPURLResponse(
+            url: request.url!,
+            statusCode: 404,
+            httpVersion: "HTTP/1.1",
+            headerFields: nil
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
         client?.urlProtocolDidFinishLoading(self)
     }
 

--- a/provider-swift/Tests/ProviderCoreTests/ModelCatalogTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/ModelCatalogTests.swift
@@ -205,6 +205,41 @@ struct ModelCatalogTests {
         #expect(RangeURLProtocol.lastRangeHeader == "bytes=8-")
     }
 
+    @Test("downloadFile promotes a complete .part on 416 instead of re-downloading")
+    func downloadFilePromotesCompletePartOn416() async throws {
+        // A prior run received every byte into `.part` but died before promoting
+        // it. The next run sends `Range: bytes=<full>-`, the store answers 416,
+        // and we must promote the existing complete prefix — NOT delete it and
+        // re-fetch the whole file from byte 0.
+        let full = Data("0123456789abcdef".utf8)
+        RangeURLProtocol.payload = full
+        RangeURLProtocol.lastRangeHeader = nil
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [RangeURLProtocol.self]
+        let session = URLSession(configuration: config)
+        let downloader = ModelDownloader(r2CDNURL: "https://cdn.example.test", urlSession: session)
+
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("model-download-test-\(UUID().uuidString)", isDirectory: true)
+        let final = dir.appendingPathComponent("model.safetensors")
+        let partial = final.appendingPathExtension("part")
+        defer { try? FileManager.default.removeItem(at: dir) }
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        // The complete file already sits in `.part`.
+        try full.write(to: partial)
+
+        let ok = try await downloader.downloadFileForTesting(
+            from: "https://cdn.example.test/model.safetensors",
+            to: final
+        )
+
+        #expect(ok)
+        #expect(try Data(contentsOf: final) == full)
+        #expect(!FileManager.default.fileExists(atPath: partial.path))
+        // We asked to resume past EOF (got 416) rather than re-fetching from 0.
+        #expect(RangeURLProtocol.lastRangeHeader == "bytes=16-")
+    }
+
     @Test("manifest download failure preserves existing local snapshot")
     func manifestDownloadFailurePreservesExistingSnapshot() async throws {
         let modelID = "test-org/staging-preserves-\(UUID().uuidString)"
@@ -295,6 +330,20 @@ private final class RangeURLProtocol: URLProtocol, @unchecked Sendable {
             start = Int(range.dropFirst("bytes=".count).dropLast()) ?? 0
         } else {
             start = 0
+        }
+        // A range whose start is at/beyond EOF is unsatisfiable — real object
+        // stores (R2/S3) answer 416, not an empty 206. Model this so the
+        // complete-but-unpromoted `.part` resume path is exercised faithfully.
+        if start >= Self.payload.count, start > 0 {
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 416,
+                httpVersion: "HTTP/1.1",
+                headerFields: ["Content-Range": "bytes */\(Self.payload.count)"]
+            )!
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocolDidFinishLoading(self)
+            return
         }
         let body = Self.payload.dropFirst(start)
         let status = start > 0 ? 206 : 200

--- a/provider-swift/Tests/ProviderCoreTests/ModelPrefetchDownloaderTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/ModelPrefetchDownloaderTests.swift
@@ -831,6 +831,156 @@ struct ModelPrefetchDownloaderTests {
         #expect(try Data(contentsOf: cacheDir.appendingPathComponent("config.json")) == smallBytes)
     }
 
+    @Test("foreground download byte-resumes a mid-stream-dropped shard via Range and never re-fetches from zero")
+    func foregroundDownloadByteResumesAcrossRestart() async throws {
+        // The core fix: the FOREGROUND (CLI / serve-time) download path must
+        // byte-resume like the background prefetch. A shard whose connection drops
+        // mid-stream must leave its received prefix in `<dest>.part` and, on the
+        // next `download()` call, resume with `Range: bytes=<prefix>-` instead of
+        // re-GETting the shard from byte 0. (Previously it used
+        // `URLSession.downloadTask` with no Range and lost the partial entirely.)
+        PrefetchURLProtocol.reset()
+        let modelID = "test-org/fg-byteresume-\(UUID().uuidString)"
+        let prefix = "v2/fg-byteresume/v1"
+        let shardName = "model-00001-of-00002.safetensors"
+        let shardPath = "/\(prefix)/\(shardName)"
+        // Large enough that a 1500-byte prefix is a meaningful fraction (so a
+        // restart-from-zero would be obviously wrong) and 3 partial appends can't
+        // finish it within one call.
+        let shardBytes = Data((0..<32768).map { UInt8(($0 &* 131 &+ 7) & 0xFF) })
+        let dropAt = 1500
+        let files = [
+            ManifestFile(path: shardName, sizeBytes: Int64(shardBytes.count), sha256: sha256Hex(shardBytes), role: "weight"),
+        ]
+        let aggregate = aggregateHash(files: [(shardName, shardBytes)])
+        let manifest = ModelManifest(
+            schemaVersion: 1, modelID: modelID, version: "v1", r2Prefix: prefix,
+            aggregateSHA256: aggregate, totalSizeBytes: Int64(shardBytes.count),
+            fileCount: 1, files: files, createdAt: Date(timeIntervalSince1970: 0)
+        )
+        let enc = JSONEncoder()
+        enc.dateEncodingStrategy = .iso8601
+        PrefetchURLProtocol.files = [
+            "/\(prefix)/manifest.json": try enc.encode(manifest),
+            shardPath: shardBytes,
+        ]
+
+        let cacheDir = ModelDownloader.cacheSnapshotDirectory(for: modelID)
+        let snapshotsDir = cacheDir.deletingLastPathComponent()
+        let modelDir = ModelDownloader.cacheModelDirectory(for: modelID)
+        defer { try? FileManager.default.removeItem(at: modelDir) }
+
+        let stagingName = ".local-staging-" + prefix.replacingOccurrences(of: "/", with: "__")
+        let stagingDir = snapshotsDir.appendingPathComponent(stagingName, isDirectory: true)
+        let partFile = stagingDir.appendingPathComponent(shardName).appendingPathExtension("part")
+
+        let downloader = ModelDownloader(r2CDNURL: "https://cdn.example.test", urlSession: makeSession())
+        let model = CatalogModel(id: modelID, s3Name: "unused", displayName: "FGByteResume", sizeGb: 0.001,
+                                 r2Prefix: prefix, aggregateSHA256: aggregate)
+
+        // ---- Attempt 1: the shard drops ~1500 bytes into EVERY response, so the 3
+        // in-call retries exhaust and download() throws — but each dropped retry
+        // APPENDS its prefix to `.part`, making real on-disk progress. ----
+        PrefetchURLProtocol.dropAfterBytes = [shardPath: dropAt]
+        var threw = false
+        do { try await downloader.download(model: model) } catch { threw = true }
+        #expect(threw)
+        let part1 = (try? Data(contentsOf: partFile))?.count ?? 0
+        #expect(part1 >= dropAt, "`.part` must retain the appended prefix, got \(part1)")
+        #expect(part1 < shardBytes.count, "shard must not be complete yet, got \(part1)/\(shardBytes.count)")
+        #expect(!FileManager.default.fileExists(atPath: cacheDir.path), "nothing must be published mid-resume")
+
+        // ---- Attempt 2 (a process restart = a fresh download() call): the network
+        // is healthy. The shard MUST resume from its `.part` via a Range request
+        // and complete — never restarting from byte 0. ----
+        PrefetchURLProtocol.dropAfterBytes = [:]
+        PrefetchURLProtocol.clearRequested()
+        try await downloader.download(model: model)
+
+        let shardRanges = PrefetchURLProtocol.rangeHeaders(for: shardPath)
+        #expect(!shardRanges.isEmpty, "the shard must be requested on resume")
+        // Every resume request carried a Range (never a bare from-zero GET)...
+        #expect(shardRanges.allSatisfy { ($0 ?? "").hasPrefix("bytes=") },
+                "restart must resume via Range, not re-fetch from 0; got \(shardRanges)")
+        // ...continuing from exactly the bytes already on disk.
+        #expect(shardRanges.contains("bytes=\(part1)-"),
+                "resume must continue from the saved prefix; got \(shardRanges)")
+        #expect(!shardRanges.contains("bytes=0-"), "must never restart the shard from byte 0")
+        // The published snapshot has the complete, correct shard + refs/main.
+        #expect(try Data(contentsOf: cacheDir.appendingPathComponent(shardName)) == shardBytes)
+        #expect(try String(contentsOf: modelDir.appendingPathComponent("refs/main"), encoding: .utf8) == "local")
+        #expect(!FileManager.default.fileExists(atPath: partFile.path), "`.part` must be consumed on success")
+    }
+
+    @Test("a complete staging dir publishes on restart without re-downloading any shard")
+    func foregroundDownloadFinishesCompleteStagingWithoutRefetch() async throws {
+        // Finish-on-restart: a prior foreground download staged EVERY shard
+        // size+SHA-valid but was killed before the aggregate-verify + publish step
+        // (the hidden staging dir is invisible to the scanner, so the picker showed
+        // "not downloaded"). The next download() must verify + publish WITHOUT
+        // re-fetching a single shard.
+        PrefetchURLProtocol.reset()
+        let modelID = "test-org/fg-finish-\(UUID().uuidString)"
+        let prefix = "v2/fg-finish/v1"
+        let names = ["config.json", "model-00001-of-00002.safetensors", "model-00002-of-00002.safetensors"]
+        var files: [ManifestFile] = []
+        var served: [String: Data] = [:]
+        var pairs: [(String, Data)] = []
+        for (i, name) in names.enumerated() {
+            let bytes = Data("complete-staging-\(i)-\(name)-payload".utf8)
+            files.append(ManifestFile(path: name, sizeBytes: Int64(bytes.count), sha256: sha256Hex(bytes),
+                                      role: name.hasSuffix(".json") ? "config" : "weight"))
+            served["/\(prefix)/\(name)"] = bytes
+            pairs.append((name, bytes))
+        }
+        let aggregate = aggregateHash(files: pairs)
+        let manifest = ModelManifest(
+            schemaVersion: 1, modelID: modelID, version: "v1", r2Prefix: prefix,
+            aggregateSHA256: aggregate, totalSizeBytes: Int64(pairs.reduce(0) { $0 + $1.1.count }),
+            fileCount: files.count, files: files, createdAt: Date(timeIntervalSince1970: 0)
+        )
+        let enc = JSONEncoder()
+        enc.dateEncodingStrategy = .iso8601
+        var serveFiles = served
+        serveFiles["/\(prefix)/manifest.json"] = try enc.encode(manifest)
+        PrefetchURLProtocol.files = serveFiles
+
+        let cacheDir = ModelDownloader.cacheSnapshotDirectory(for: modelID)
+        let snapshotsDir = cacheDir.deletingLastPathComponent()
+        let modelDir = ModelDownloader.cacheModelDirectory(for: modelID)
+        defer { try? FileManager.default.removeItem(at: modelDir) }
+
+        // Pre-seed the foreground staging dir with ALL files complete + valid.
+        let stagingName = ".local-staging-" + prefix.replacingOccurrences(of: "/", with: "__")
+        let stagingDir = snapshotsDir.appendingPathComponent(stagingName, isDirectory: true)
+        try FileManager.default.createDirectory(at: stagingDir, withIntermediateDirectories: true)
+        for (name, bytes) in pairs {
+            try bytes.write(to: stagingDir.appendingPathComponent(name))
+        }
+        // The build is "resumable" on disk before publishing (drives the picker's
+        // "resuming" surfacing).
+        #expect(ModelDownloader.hasResumableStaging(modelID: modelID, r2Prefix: prefix))
+
+        let downloader = ModelDownloader(r2CDNURL: "https://cdn.example.test", urlSession: makeSession())
+        let model = CatalogModel(id: modelID, s3Name: "unused", displayName: "FGFinish", sizeGb: 0.001,
+                                 r2Prefix: prefix, aggregateSHA256: aggregate)
+
+        try await downloader.download(model: model)
+
+        // Only the manifest was fetched; NOT one shard/config was re-downloaded.
+        let fetched = PrefetchURLProtocol.fetchedPaths()
+        #expect(fetched.contains("/\(prefix)/manifest.json"))
+        #expect(fetched.allSatisfy { $0.hasSuffix("/manifest.json") },
+                "a complete staging dir must publish without re-downloading; fetched \(fetched)")
+        // The snapshot was published from staging (+ refs/main) and staging cleaned.
+        for (name, bytes) in pairs {
+            #expect(try Data(contentsOf: cacheDir.appendingPathComponent(name)) == bytes)
+        }
+        #expect(try String(contentsOf: modelDir.appendingPathComponent("refs/main"), encoding: .utf8) == "local")
+        #expect(!FileManager.default.fileExists(atPath: stagingDir.path), "staging removed after publish")
+        #expect(!ModelDownloader.hasResumableStaging(modelID: modelID, r2Prefix: prefix))
+    }
+
     @Test("prefetch fails on aggregate hash mismatch and does not publish")
     func prefetchAggregateMismatchFails() async throws {
         PrefetchURLProtocol.reset()

--- a/provider-swift/Tests/ProviderCoreTests/ModelScannerMemoryFilterTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/ModelScannerMemoryFilterTests.swift
@@ -1,0 +1,60 @@
+import Foundation
+import Testing
+@testable import ProviderCore
+import ProviderCoreFoundation
+
+/// The on-disk-detection half of the "invisible after interruption" fix: a model
+/// that is fully downloaded but too large for available RAM must still be
+/// discoverable on disk. `scanAllModels` (unfiltered) is what the picker /
+/// `models` listing now use to compute the "downloaded" flag, while the
+/// memory-filtered `scanModels(in:availableMemoryGB:)` governs only loadability.
+@Suite("ModelScanner memory filter (downloaded != fits)", .serialized)
+struct ModelScannerMemoryFilterTests {
+
+    /// Build a minimal HuggingFace-cache model dir with a SPARSE weight file of
+    /// `weightBytes` logical size (sparse via `truncate`, so the test never writes
+    /// gigabytes to disk but the scanner still reads the full size).
+    private func makeModel(in cacheDir: URL, id: String, weightBytes: Int64) throws {
+        let dirName = "models--" + id.replacingOccurrences(of: "/", with: "--")
+        let snapshot = cacheDir.appendingPathComponent(dirName)
+            .appendingPathComponent("snapshots")
+            .appendingPathComponent("local")
+        try FileManager.default.createDirectory(at: snapshot, withIntermediateDirectories: true)
+        try Data(#"{"model_type":"llama"}"#.utf8).write(to: snapshot.appendingPathComponent("config.json"))
+        let weight = snapshot.appendingPathComponent("model.safetensors")
+        FileManager.default.createFile(atPath: weight.path, contents: nil)
+        let fh = try FileHandle(forWritingTo: weight)
+        try fh.truncate(atOffset: UInt64(weightBytes))
+        try fh.close()
+    }
+
+    @Test("scanAllModels sees a too-big model that the memory-filtered scan drops")
+    func unfilteredScanSeesTooBigModel() throws {
+        let cacheDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("hf-cache-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: cacheDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: cacheDir) }
+
+        // ~3 GiB weight → estimatedMemoryGb ≈ 3.6 GB (×1.2 overhead factor).
+        let threeGiB: Int64 = 3 * 1024 * 1024 * 1024
+        try makeModel(in: cacheDir, id: "test-org/too-big-4bit", weightBytes: threeGiB)
+
+        // Unfiltered: the model is present on disk (this is what drives the
+        // picker's "downloaded" flag now).
+        let all = ModelScanner.scanAllModels(in: cacheDir)
+        #expect(all.contains { $0.id == "test-org/too-big-4bit" },
+                "unfiltered scan must see the downloaded model")
+
+        // Memory-filtered with only 2 GB available: the model is dropped — which is
+        // exactly why computing "downloaded" from the filtered scan made a present
+        // model read "not downloaded".
+        let fits = ModelScanner.scanModels(in: cacheDir, availableMemoryGB: 2)
+        #expect(!fits.contains { $0.id == "test-org/too-big-4bit" },
+                "memory-filtered scan drops the too-big model")
+
+        // With ample memory it IS included — confirming the filter (not discovery)
+        // is what removed it above.
+        let roomy = ModelScanner.scanModels(in: cacheDir, availableMemoryGB: 64)
+        #expect(roomy.contains { $0.id == "test-org/too-big-4bit" })
+    }
+}


### PR DESCRIPTION
## Problem

Providers on flaky Wi-Fi can never complete the ~15.6 GB 3-shard `gemma-4-26b-qat-4bit` download, and after it "completes" it isn't detected so it re-downloads. Targets the **0.6.12** release.

## Root causes (verified against `master`)

1. **The foreground/CLI manifest download path was not resumable.** `ModelCatalog.swift` had two downloaders: the resumable byte-stream `streamDownload` (HTTP `Range`, flush to a stable `.part`, `Content-Range` validation — `ModelCatalog.swift:1365`) wired only to the background prefetch (`prefetch` → `downloadManifestFileWithResume` → `downloadFile`); and the path the CLI actually runs, `downloadManifestModel` → `downloadManifestFileWithProgress` (`ModelCatalog.swift:930`/`:1080`), which used `URLSession.downloadTask` with **no Range and no resume data** (`ModelCatalog.swift:1098`). Every interruption restarted the shard from byte 0 (throwaway `CFNetworkDownload_*.tmp`). Callers: `StartCommand.swift:737`/`:810`, `ModelsCommand.swift:206`.
2. **Interrupted downloads were invisible.** Completed shards land in a hidden `.local-staging-…` dir; `snapshots/local` is only created at final publish, and `ModelScanner.findLatestSnapshot` uses `.skipsHiddenFiles` (`ModelScanner.swift:101`), so a download killed before publish looked "not downloaded" and re-downloaded from scratch.
3. **On-disk models hidden by the RAM filter.** The picker's "downloaded" flag came from the memory-filtered scan (`ModelScanner+Discovery.swift:46-56` via `Darkbloom.swift:136`, flagged at `StartCommand.swift:677`/`:687`; same bug in `ModelsCommand.swift:127`), so a fully-downloaded model that exceeds available RAM read "not downloaded" forever on marginal-RAM boxes.

Related field report: `darkbloom models download` got jetsam-killed (SIGKILL/OOM) on 36 GB Macs — the old `downloadTask` path could buffer whole shards; the streaming path flushes every 64 KB.

## Fix (scoped to `provider-swift`)

1. **Resumable + restart-safe foreground download.** `downloadManifestModel` now downloads each shard through the resume-capable `downloadManifestFileWithResume` → `downloadFile` → `streamDownload` (Range + `Content-Range` validation + 64 KB streaming flush to a stable per-shard `.part`). An interrupted shard resumes via `Range: bytes=N-` and never restarts from zero. Preserved: the stable `.local-staging-{prefix}` dir, the size+SHA `alreadyValid` skip, **4-way concurrency** (each shard owns its `.part`), the aggregate-hash gate, and `publishStagedSnapshot`. Live per-shard progress is threaded through `streamDownload` via a byte-progress callback into a new callback-based tracker (the old `URLSessionDownloadDelegate` tracker is gone). The streaming path never holds a full shard in RAM.
2. **Finish-on-restart.** When the stable staging dir already holds every shard size+SHA-valid, `downloadManifestModel` verifies the aggregate and publishes **without re-downloading** (shared `finalizeStagedManifest` helper). The picker surfaces "resuming" (via `ModelDownloader.hasResumableStaging`) instead of "not downloaded".
3. **Unfiltered downloaded detection.** The picker (`Start.buildPickerEntries`) and `models` listing compute "downloaded" from an UNFILTERED on-disk scan (`scanAllModels`); the memory filter only drives a "won't fit" warning. A present-but-too-big model now reads **"downloaded (won't fit)"**, never "not downloaded".

**Dead code removed:** `downloadManifestFileWithProgress`, `DownloadProgressTracker`, and the unused `downloadManifestFile`. Progress UI extracted into `ModelDownloadProgress.swift` so `ModelCatalog.swift` stays focused (net −517 lines there).

## Tests (mock `URLProtocol`)

- `foregroundDownloadByteResumesAcrossRestart` — a mid-stream-dropped foreground shard leaves a `.part`, and the next `download()` resumes with `Range: bytes=<prefix>-` (never `bytes=0-`) and completes.
- `foregroundDownloadFinishesCompleteStagingWithoutRefetch` — a pre-populated complete staging dir publishes with **zero** shard re-downloads (only `manifest.json` is fetched).
- `ModelScannerMemoryFilterTests` — `scanAllModels` sees a too-big model the memory-filtered scan drops.
- `PickerEntryTests` — `Start.buildPickerEntries` classifies an on-disk-but-too-big model as `downloaded`, hides only not-downloaded unrunnable models, flags staged builds `resumable`, and sorts downloaded-first.

## Verification

```
cd provider-swift && swift build        # clean
swift test --filter ModelPrefetchDownloaderTests   # 16 passed
swift test --filter ModelCatalogTests --filter ModelScannerMemoryFilterTests   # passed
swift test --filter PickerEntryTests --filter ModelScanner --filter CLIDispatchTests   # passed
```

No coordinator / submodule / unrelated files touched.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/372"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784230995&installation_id=133247490&pr_number=372&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F372&signature=26e701d32a7e92b34fac3cbad0f074886d5f0f7a837c67f44a2243a479d2f40f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->