### PR TITLE
chore(provider): default-on MLX resource-count telemetry in reports (mlx-swift-lm#42)

### DIFF
--- a/provider-swift/Sources/ProviderCore/Service/LaunchAgent.swift
+++ b/provider-swift/Sources/ProviderCore/Service/LaunchAgent.swift
@@ -244,7 +244,7 @@ public enum LaunchAgent: Sendable {
     /// Env vars passed through from the installing shell into the launchd plist's
     /// `EnvironmentVariables`. Kept to a small allowlist so the daemon's
     /// environment stays predictable; only non-empty values are forwarded.
-    static let passthroughEnvKeys = ["DARKBLOOM_PREFIX_CACHE"]
+    static let passthroughEnvKeys = ["DARKBLOOM_PREFIX_CACHE", "DARKBLOOM_MLX_RESOURCE_DEBUG"]
 
     /// Build the daemon `EnvironmentVariables` map from a source environment,
     /// keeping only the allowlisted, non-empty keys. Pure (environment injected)

--- a/provider-swift/Tests/ProviderCoreTests/BatchKVCacheTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/BatchKVCacheTests.swift
@@ -349,6 +349,36 @@ struct BatchKVCacheTests {
         }
     }
 
+    @Test("rotating decode keeps the window mask at the boundary when window < cache size")
+    func rotatingMaskedAtWindowBoundary() {
+        // When windowSize < maxCacheSize the buffer can hold keys older than the
+        // active window. makeMask runs BEFORE update, which appends the new token
+        // and trims only at maxCacheSize, so at `_idx == windowSize` the
+        // post-update cache holds windowSize + 1 keys. Returning .none there would
+        // let the new query attend one token PAST the window, so the windowed mask
+        // must be kept. (Gemma is unaffected: there window == maxCacheSize, so the
+        // trim already bounds the cache and the fast path stays on — see above.)
+        let boundary = BatchRotatingKVCache(maxSize: 8, leftPadding: [0, 0])
+        _ = boundary.update(  // _idx = 4 == window; 4 < maxCacheSize 8 => no trim
+            keys: MLXArray.zeros([2, 1, 4, 1]), values: MLXArray.zeros([2, 1, 4, 1]))
+        #expect(boundary.leftPadding.max().item(Int32.self) == 0)  // unpadded boundary
+        guard case .array = boundary.makeMask(n: 1, windowSize: 4, returnArray: true) else {
+            Issue.record("expected .array at the window boundary (window < cache); .none over-attends")
+            return
+        }
+
+        // Below the boundary the unmasked fast path is still taken: the post-update
+        // length (_idx + 1) still fits the window, so the tighter guard must NOT
+        // regress the fast path here.
+        let below = BatchRotatingKVCache(maxSize: 8, leftPadding: [0, 0])
+        _ = below.update(
+            keys: MLXArray.zeros([2, 1, 2, 1]), values: MLXArray.zeros([2, 1, 2, 1]))
+        guard case .none = below.makeMask(n: 1, windowSize: 4, returnArray: true) else {
+            Issue.record("expected .none below the window boundary (post-update still fits)")
+            return
+        }
+    }
+
     // MARK: - dynamicRoll helper
 
     @Test("dynamicRoll shifts each row by its own amount along axis")

--- a/provider-swift/Tests/ProviderCoreTests/BatchKVCacheTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/BatchKVCacheTests.swift
@@ -326,6 +326,29 @@ struct BatchKVCacheTests {
         }
     }
 
+    @Test("rotating decode stays unmasked after trimming past the window (negative padding)")
+    func rotatingUnmaskedAfterWindowTrim() {
+        // A rotating cache that generates past its window trims slots and
+        // subtracts the trim from leftPadding, so unpadded rows go NEGATIVE.
+        // The decode-mask fast path must treat negative padding as unpadded
+        // (<= 0), or every long (> window) Gemma 4 decode falls back to the
+        // explicit-mask path on each sliding layer (the mlx#3384 slow/divergent
+        // path the repetition fix avoids).
+        let cache = BatchRotatingKVCache(maxSize: 3, leftPadding: [0, 0])
+        _ = cache.update(  // prefill 4 > window 3 -> trims, leftPadding goes negative
+            keys: MLXArray.zeros([2, 1, 4, 1]), values: MLXArray.zeros([2, 1, 4, 1]))
+        _ = cache.update(  // one decode step
+            keys: MLXArray.zeros([2, 1, 1, 1]), values: MLXArray.zeros([2, 1, 1, 1]))
+        // Precondition that makes this a real regression test: rows are now
+        // negatively padded, so a `== 0` guard would (wrongly) mask.
+        #expect(cache.leftPadding.max().item(Int32.self) < 0)
+        let mask = cache.makeMask(n: 1, windowSize: 3, returnArray: true)
+        guard case .none = mask else {
+            Issue.record("expected .none for unpadded rotating decode past window, got \(mask)")
+            return
+        }
+    }
+
     // MARK: - dynamicRoll helper
 
     @Test("dynamicRoll shifts each row by its own amount along axis")

--- a/provider-swift/Tests/ProviderCoreTests/LaunchAgentRestartTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/LaunchAgentRestartTests.swift
@@ -36,6 +36,15 @@ struct LaunchAgentEnvironmentTests {
         #expect(LaunchAgent.passthroughEnvironment(from: [:]).isEmpty)
         #expect(LaunchAgent.passthroughEnvironment(from: ["DARKBLOOM_PREFIX_CACHE": ""]).isEmpty)
     }
+
+    @Test func forwardsResourceDebugOptOutToDaemon() {
+        // The MLX resource telemetry is default-on; its documented opt-out
+        // (DARKBLOOM_MLX_RESOURCE_DEBUG=0) only works on the launchd service if it
+        // is forwarded into the plist. Without this, the daemon can't be quieted.
+        let out = LaunchAgent.passthroughEnvironment(
+            from: ["DARKBLOOM_MLX_RESOURCE_DEBUG": "0", "PATH": "/usr/bin"])
+        #expect(out == ["DARKBLOOM_MLX_RESOURCE_DEBUG": "0"])
+    }
 }
 
 @Suite("LaunchAgent service plist")


### PR DESCRIPTION
Bumps the submodule to **Layr-Labs/mlx-swift-lm#42** so the `[rsrc]` resource-count diagnostic is **default-on** and emitted via **os_log** under `dev.darkbloom.provider`.

## Why
The `[metal::malloc] Resource limit (499000)` crash is a live Metal buffer-count climb; diagnosing it needs the resource-count trajectory. Verified against real prod log-reports (Gumbii's M3 Ultra, ids 518/520 via `/v1/admin/log-reports`): they contain **zero** `[rsrc]` lines because the diagnostic was off by default and `print()`-only (the report tool captures `log show --predicate subsystem == dev.darkbloom.provider`). After this, every uploaded report carries the live resource-count trace.

Coarse os_log cadence keeps reports under the 10 MB cap, but always logs at ≥70% pressure so the ramp toward 499000 is captured. Opt out: `DARKBLOOM_MLX_RESOURCE_DEBUG=0`. Target: 0.6.12. Merge mlx-swift-lm#42 first, then re-point if its merge SHA differs.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/373"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784231129&installation_id=133247490&pr_number=373&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F373&signature=6d3d0fcff3791a849eaec5edef0c88c000bc939eaeba5186177e87cb84037cae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

## Credits
Builds directly on @anupsv's work, credited via `Co-authored-by` on the bump commit:\n- Bumps the submodule onto the default-on `[rsrc]` telemetry he introduced in Layr-Labs/mlx-swift-lm#39, plus the negative-padding decode-mask fix that mirrors his Layr-Labs/mlx-swift-lm#40.