### PR TITLE
fix(provider): bound Gemma-4 checkpoint-capture to stop the Metal live-resource (499000) leak

### DIFF
--- a/provider-swift/Sources/ProviderCore/Inference/BatchScheduler.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/BatchScheduler.swift
@@ -83,6 +83,12 @@ public actor BatchScheduler {
     var checkpointBoundaries: [Int] = []
     /// Per-layer cache class/window signature for restore validation.
     var checkpointLayerSignatures: [CheckpointLayerSignature] = []
+    /// Bounded, single-consumer pipeline that drains checkpoint KV snapshots
+    /// into `checkpointManager`. Caps the number of live KV snapshots retained
+    /// in flight so a busy manager can't drive the live Metal buffer count to
+    /// the 499000 ceiling (the Gemma-4 leak). Built with the engine; shut down
+    /// in `stopCurrentEngine`. nil ⇒ feature off / no checkpoint manager.
+    var capturePipeline: CheckpointCapturePipeline<CheckpointCapture>?
 
     /// Engine-tier owner (EncryptedPrefixCachePersistence) for pure-
     /// attention models. Non-nil only when the model classifies as `.engine` AND
@@ -240,6 +246,7 @@ public actor BatchScheduler {
         self.checkpointBoundaries = build.checkpointBoundaries
         self.checkpointLayerSignatures = build.checkpointLayerSignatures
         self.engineTierOwner = build.engineTierOwner
+        self.capturePipeline = build.capturePipeline
         await engine.start()
         // Final epoch check after start() — start can suspend too.
         // Identity-checked cleanup — only nil self.engine if it's
@@ -251,6 +258,7 @@ public actor BatchScheduler {
             if self.checkpointBoundaries == build.checkpointBoundaries { self.checkpointBoundaries = [] }
             if self.checkpointLayerSignatures == build.checkpointLayerSignatures { self.checkpointLayerSignatures = [] }
             if self.engineTierOwner === build.engineTierOwner { self.engineTierOwner = nil }
+            if self.capturePipeline === build.capturePipeline { self.capturePipeline?.shutdown(); self.capturePipeline = nil }
             await engine.stop()
             return
         }
@@ -294,6 +302,7 @@ public actor BatchScheduler {
             if self.checkpointBoundaries == build.checkpointBoundaries { self.checkpointBoundaries = [] }
             if self.checkpointLayerSignatures == build.checkpointLayerSignatures { self.checkpointLayerSignatures = [] }
             if self.engineTierOwner === build.engineTierOwner { self.engineTierOwner = nil }
+            if self.capturePipeline === build.capturePipeline { self.capturePipeline?.shutdown(); self.capturePipeline = nil }
             await engine.stop()
             return
         }
@@ -333,6 +342,7 @@ public actor BatchScheduler {
                     if self.checkpointBoundaries == build.checkpointBoundaries { self.checkpointBoundaries = [] }
                     if self.checkpointLayerSignatures == build.checkpointLayerSignatures { self.checkpointLayerSignatures = [] }
                     if self.engineTierOwner === build.engineTierOwner { self.engineTierOwner = nil }
+                    if self.capturePipeline === build.capturePipeline { self.capturePipeline?.shutdown(); self.capturePipeline = nil }
                     await engine.stop()
                     return
                 }
@@ -818,11 +828,12 @@ public actor BatchScheduler {
             )
         } ?? []
         engine?.core.scheduler.checkpointBoundaries = boundaries
-        engine?.core.scheduler.onCheckpointCapture = { prefixTokens, length, caches in
-            let box = SendableKVCaches(caches)
-            // TB-016 sub-feature B: test seam also RAM-only (no eager flush).
-            Task { await mgr.store(tokens: prefixTokens, checkpointLength: length, caches: box) }
-        }
+        // Same bounded + admission-gated wiring production uses, so the test
+        // seam exercises the real backpressure path (not the old unbounded one).
+        self.capturePipeline?.shutdown()
+        let wiring = Self.makeCheckpointCaptureWiring(manager: mgr)
+        self.capturePipeline = wiring.pipeline
+        engine?.core.scheduler.onCheckpointCapture = wiring.hook
     }
 
     /// TEST SEAM: drive the real `finalizeRestore` fallback path without a live
@@ -956,6 +967,9 @@ public actor BatchScheduler {
         let checkpointBoundaries: [Int]
         let checkpointLayerSignatures: [CheckpointLayerSignature]
         let engineTierOwner: EncryptedPrefixCachePersistence?
+        /// Bounded capture pipeline (non-nil iff `checkpointManager` is). The
+        /// caller stores it on the actor and shuts it down at teardown.
+        let capturePipeline: CheckpointCapturePipeline<CheckpointCapture>?
     }
 
     private static func makeBatchedEngine(
@@ -1001,6 +1015,7 @@ public actor BatchScheduler {
 
             var enginePrefixCache: PrefixCache? = nil
             var checkpointManager: PrefixCacheManager? = nil
+            var capturePipeline: CheckpointCapturePipeline<CheckpointCapture>? = nil
             var boundaries: [Int] = []
             var checkpointLayerSignatures: [CheckpointLayerSignature] = []
             // Capture the engine-tier owner for accountant registration.
@@ -1112,16 +1127,14 @@ public actor BatchScheduler {
             // when a manager exists, so .engine/.none models are untouched.
             if let mgr = checkpointManager {
                 scheduler.checkpointBoundaries = boundaries
-                scheduler.onCheckpointCapture = { prefixTokens, length, caches in
-                    let box = SendableKVCaches(caches)
-                    // TB-016 sub-feature B: capture = RAM-ONLY. Store to RAM
-                    // (fast); 2nd-use promotion handles SSD persistence when the
-                    // prefix is re-accessed (RAM-first admission stops the write
-                    // storm). No eager flushToSSD.
-                    Task {
-                        await mgr.store(tokens: prefixTokens, checkpointLength: length, caches: box)
-                    }
-                }
+                // Bound the capture pipeline: at most `max-in-flight` live KV
+                // snapshots retained while the manager actor is busy (crypto +
+                // fsync), dropping the surplus rather than queuing it. This is
+                // the fix for the Gemma-4 Metal live-resource (499000) leak — the
+                // old `Task { await mgr.store(...) }` per boundary was unbounded.
+                let wiring = Self.makeCheckpointCaptureWiring(manager: mgr)
+                capturePipeline = wiring.pipeline
+                scheduler.onCheckpointCapture = wiring.hook
             }
             return EngineBuild(
                 engine: BatchedEngine(
@@ -1139,7 +1152,8 @@ public actor BatchScheduler {
                 checkpointManager: checkpointManager,
                 checkpointBoundaries: boundaries,
                 checkpointLayerSignatures: checkpointLayerSignatures,
-                engineTierOwner: engineTierOwner
+                engineTierOwner: engineTierOwner,
+                capturePipeline: capturePipeline
             )
         }
     }
@@ -1930,6 +1944,13 @@ public actor BatchScheduler {
         self.engine = nil
         modelContainer = nil
         tokenizer = nil
+        // Drain the bounded capture pipeline: the engine is stopped (no more
+        // capture hooks fire), so finish the stream and cancel the consumer.
+        // This releases any retained KV snapshots and stops an in-flight
+        // `mgr.store` from racing the index flush / accountant deregister below,
+        // and guarantees no snapshot (or consumer Task) leaks across a swap.
+        capturePipeline?.shutdown()
+        capturePipeline = nil
         // Persist any coalesced index writes before dropping the manager, so
         // checkpoints written since the last coalesced save survive restart.
         if let mgr = checkpointManager {

--- a/provider-swift/Sources/ProviderCore/Inference/CheckpointCapturePipeline.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/CheckpointCapturePipeline.swift
@@ -89,6 +89,21 @@ final class CheckpointCapturePipeline<Payload: Sendable>: @unchecked Sendable {
         self.continuation = continuation
         self.consumer = Task {
             for await payload in stream {
+                // Honor shutdown before consuming. `shutdown()` calls
+                // `finish()` + `cancel()`, but `finish()` still delivers
+                // already-buffered payloads to this loop and an AsyncStream
+                // `for await` does NOT observe Task cancellation on its own.
+                // Without this guard we would `store(...)` old-model KV
+                // snapshots after a model swap has begun — pinning large live
+                // Metal buffers that must not overlap the next engine.
+                //
+                // We `continue` rather than `break`: the buffered remainder must
+                // still be pulled so each payload is released as it drains (the
+                // retained `continuation` keeps the stream's internal buffer —
+                // and anything stranded in it — alive). Skipping `consume` drops
+                // the captures (best-effort) without storing them; the finished
+                // stream then terminates the loop once its buffer empties.
+                if Task.isCancelled { continue }
                 await consume(payload)
             }
         }

--- a/provider-swift/Sources/ProviderCore/Inference/CheckpointCapturePipeline.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/CheckpointCapturePipeline.swift
@@ -1,0 +1,233 @@
+// Copyright © 2026 Eigen Labs.
+//
+// Bounded, single-consumer pipeline for best-effort checkpoint KV capture.
+//
+// Background — the Gemma-4 `[metal::malloc] Resource limit (499000) exceeded`
+// crash. Heterogeneous models (Gemma-4: sliding [8,256] + full [2,512]) use the
+// `.checkpoint` prefix-cache tier. At each checkpoint boundary the engine hands
+// the provider a freshly-extracted, per-layer KV snapshot (live MLXArrays,
+// ≈ layers × 2 Metal buffers). The previous wiring spawned an UNBOUNDED
+// `Task { await mgr.store(...) }` per boundary:
+//
+//     scheduler.onCheckpointCapture = { prefixTokens, length, caches in
+//         let box = SendableKVCaches(caches)
+//         Task { await mgr.store(...) }   // <-- one detached Task per boundary
+//     }
+//
+// `PrefixCacheManager` is a single actor that serializes `store` behind
+// AES-GCM serialize + fsync and against every lookup/materialize. Under
+// sustained traffic the actor falls behind, the spawned Tasks queue, and each
+// queued Task keeps its live KV snapshot pinned until it runs. The live Metal
+// resource COUNT (not bytes/cache) climbs to the `iogpu.rsrc_limit` ceiling
+// (~499000) → crash. The mlx/mlx-c "count-aware" cache trims can only reclaim
+// CACHED buffers; these snapshots are LIVE, so trimming cannot help and the
+// idle-gated `Memory.clearCache()` never fires under load.
+//
+// This pipeline caps the number of snapshots retained in flight. Capture is
+// best-effort cache-warming: when the bounded buffer is full the surplus
+// snapshot is DROPPED (and released, freeing its Metal buffers) rather than
+// queued. Dropping a snapshot only costs a future cache miss, never
+// correctness.
+
+import Foundation
+import MLX
+import MLXLMCommon
+
+/// One checkpoint capture: the prefix tokens it covers, the checkpoint length,
+/// and the boxed per-layer KV snapshot to hand to `PrefixCacheManager.store`.
+/// `SendableKVCaches` is the ownership-transfer box; this struct is the
+/// production payload for ``CheckpointCapturePipeline``.
+struct CheckpointCapture: Sendable {
+    let tokens: [Int]
+    let length: Int
+    let caches: SendableKVCaches
+}
+
+/// Bounded, single-consumer delivery pipeline.
+///
+/// A small `AsyncStream` (buffering policy `.bufferingNewest(capacity)`) feeds a
+/// single long-lived consumer Task. `submit(_:)` is synchronous, non-blocking,
+/// and `@Sendable`, so it is safe to call from the engine queue inside
+/// `Scheduler.onCheckpointCapture`. At most `capacity` payloads sit in the
+/// buffer and the consumer holds at most one more while it `await`s, so the
+/// pipeline retains at most `capacity + 1` payloads — regardless of how far
+/// behind the consumer falls. (Counting the single payload being handed to
+/// `submit` during an evicting enqueue, at most `capacity + 2` are live for an
+/// instant.) Surplus payloads are dropped (and released) rather than queued —
+/// this small constant bound is what caps the live Metal buffer count and
+/// fixes the 499000 leak.
+///
+/// Generic over `Payload` so the bounding/drop/teardown logic is unit-testable
+/// without MLX (the production instantiation is `Payload == CheckpointCapture`).
+final class CheckpointCapturePipeline<Payload: Sendable>: @unchecked Sendable {
+    /// Maximum number of payloads buffered before the surplus is dropped.
+    let capacity: Int
+
+    private let continuation: AsyncStream<Payload>.Continuation
+    private let consumer: Task<Void, Never>
+
+    // Lightweight counters (lock-guarded; read from tests / future telemetry).
+    private let statsLock = NSLock()
+    private var _accepted = 0
+    private var _dropped = 0
+
+    /// - Parameters:
+    ///   - capacity: max buffered payloads (clamped to ≥ 1). Small by design
+    ///     (1–2): this is the hard cap on live KV snapshots retained in flight.
+    ///   - consume: the (async) sink. Invoked serially by the single consumer
+    ///     Task, one payload at a time.
+    init(
+        capacity: Int,
+        consume: @escaping @Sendable (Payload) async -> Void
+    ) {
+        let cap = max(1, capacity)
+        self.capacity = cap
+        let (stream, continuation) = AsyncStream.makeStream(
+            of: Payload.self,
+            bufferingPolicy: .bufferingNewest(cap)
+        )
+        self.continuation = continuation
+        self.consumer = Task {
+            for await payload in stream {
+                await consume(payload)
+            }
+        }
+    }
+
+    /// Enqueue a payload. Synchronous, non-blocking, `@Sendable`.
+    ///
+    /// Returns `true` when the payload was buffered without eviction, `false`
+    /// when the buffer was already full (an overflow occurred and the surplus
+    /// payload was dropped + released) or the pipeline has been shut down.
+    @discardableResult
+    func submit(_ payload: Payload) -> Bool {
+        switch continuation.yield(payload) {
+        case .enqueued:
+            statsLock.lock(); _accepted += 1; statsLock.unlock()
+            return true
+        case .dropped:
+            // `.bufferingNewest` keeps the newest `capacity` payloads and
+            // returns the evicted (oldest) one here; letting it go out of scope
+            // releases its KV snapshot so the Metal buffers free immediately.
+            statsLock.lock(); _dropped += 1; statsLock.unlock()
+            return false
+        case .terminated:
+            return false
+        @unknown default:
+            return false
+        }
+    }
+
+    /// Count of `submit` calls that buffered without eviction.
+    var acceptedCount: Int { statsLock.lock(); defer { statsLock.unlock() }; return _accepted }
+    /// Count of `submit` calls that overflowed the buffer (a payload dropped).
+    var droppedCount: Int { statsLock.lock(); defer { statsLock.unlock() }; return _dropped }
+
+    /// Stop accepting, end the consumer loop, and cancel it so an in-flight
+    /// `consume` is not awaited indefinitely across a model swap. Idempotent.
+    /// Releases the stream's buffered payloads (their Metal buffers free).
+    func shutdown() {
+        continuation.finish()
+        consumer.cancel()
+    }
+
+    /// Test seam: await the consumer Task draining to completion. Production
+    /// teardown does not need to await this (ARC + `finish()` reclaim the
+    /// buffered snapshots); tests use it to assert no payloads leak.
+    func waitUntilDrained() async {
+        await consumer.value
+    }
+
+    deinit {
+        // Belt-and-suspenders: if the owner dropped us without `shutdown()`,
+        // make sure the stream terminates and the consumer Task ends.
+        continuation.finish()
+        consumer.cancel()
+    }
+}
+
+// MARK: - BatchScheduler capture wiring
+
+extension BatchScheduler {
+    /// Fraction of `Memory.resourceLimit` above which checkpoint capture is
+    /// skipped. Matches the submodule's `[rsrc]` pressure threshold (70%).
+    static let captureResourcePressureFraction = 0.7
+
+    /// Default cap on KV snapshots retained in flight. Intentionally tiny:
+    /// capture is best-effort, and the whole point is to bound live buffers.
+    static let captureDefaultMaxInFlight = 2
+
+    /// Resolve the in-flight cap. Env-tunable via
+    /// `DARKBLOOM_KV_CAPTURE_MAX_INFLIGHT` (clamped to ≥ 1).
+    static func captureMaxInFlight() -> Int {
+        let raw = ProcessInfo.processInfo.environment["DARKBLOOM_KV_CAPTURE_MAX_INFLIGHT"]?
+            .trimmingCharacters(in: .whitespaces)
+        if let raw, let n = Int(raw), n >= 1 { return n }
+        return captureDefaultMaxInFlight
+    }
+
+    /// Pure decision (testable): is the live Metal buffer count high enough that
+    /// we should skip capture and stop feeding the leak? An unknown limit (0 —
+    /// non-Metal backend / unset sysctl) is treated as "no pressure" so capture
+    /// is never disabled spuriously.
+    static func captureResourcePressureHigh(numResources: Int, resourceLimit: Int) -> Bool {
+        guard resourceLimit > 0 else { return false }
+        return Double(numResources) > captureResourcePressureFraction * Double(resourceLimit)
+    }
+
+    /// Live reading of the above against the MLX allocator counters.
+    static func captureResourcePressureHigh() -> Bool {
+        captureResourcePressureHigh(
+            numResources: MLX.Memory.numResources,
+            resourceLimit: MLX.Memory.resourceLimit
+        )
+    }
+
+    /// The `onCheckpointCapture` hook type the engine's `Scheduler` exposes.
+    typealias CheckpointCaptureHook =
+        @Sendable (_ prefixTokens: [Int], _ checkpointLength: Int, _ caches: [any KVCache]) -> Void
+
+    /// Build the bounded capture pipeline + the synchronous `@Sendable` hook for
+    /// a checkpoint-tier manager. Shared by the production engine builder and the
+    /// test seam so both get identical backpressure + admission-gating.
+    ///
+    /// The hook does two things, both cheap and non-blocking:
+    ///   1. Admission gate — skip (and release) the snapshot when the live Metal
+    ///      buffer count is already high; that is exactly when feeding more
+    ///      snapshots risks the 499000 ceiling.
+    ///   2. Backpressure — submit to the bounded pipeline, which drops on full.
+    static func makeCheckpointCaptureWiring(
+        manager mgr: PrefixCacheManager
+    ) -> (pipeline: CheckpointCapturePipeline<CheckpointCapture>, hook: CheckpointCaptureHook) {
+        let maxInFlight = captureMaxInFlight()
+        let pipeline = CheckpointCapturePipeline<CheckpointCapture>(
+            capacity: maxInFlight
+        ) { capture in
+            // TB-016 sub-feature B: capture = RAM-ONLY. The 2nd-use promotion in
+            // the manager handles SSD persistence; no eager flushToSSD here.
+            await mgr.store(
+                tokens: capture.tokens,
+                checkpointLength: capture.length,
+                caches: capture.caches
+            )
+        }
+        prefixCacheLogger.info(
+            "checkpoint capture pipeline: max-in-flight \(maxInFlight) (drop-on-full), admission-gate at \(Int(captureResourcePressureFraction * 100))% of Metal resource limit")
+        let hook: CheckpointCaptureHook = { [pipeline] prefixTokens, length, caches in
+            // 1. Admission gate. Returning here lets the `caches` argument go
+            //    out of scope → its Metal buffers free immediately.
+            if captureResourcePressureHigh() { return }
+            // Bounded, single-consumer, drop-on-full backpressure. Caps the live
+            // KV snapshots retained while the manager actor is busy with
+            // crypto + fsync, regardless of how far behind it falls.
+            pipeline.submit(
+                CheckpointCapture(
+                    tokens: prefixTokens,
+                    length: length,
+                    caches: SendableKVCaches(caches)
+                )
+            )
+        }
+        return (pipeline, hook)
+    }
+}

--- a/provider-swift/Tests/ProviderCoreTests/CheckpointCapturePipelineTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/CheckpointCapturePipelineTests.swift
@@ -1,0 +1,142 @@
+import Foundation
+import Testing
+
+@testable import ProviderCore
+
+// Regression tests for the Gemma-4 Metal live-resource (499000) leak fix.
+//
+// The leak was an UNBOUNDED `Task { await mgr.store(...) }` spawned per
+// checkpoint boundary: each Task pinned a live per-layer KV snapshot until the
+// (slow, serialized) PrefixCacheManager actor ran it, so under load the live
+// Metal buffer count climbed to the ceiling. `CheckpointCapturePipeline` bounds
+// the number of snapshots retained in flight and drops the surplus. These tests
+// prove the bound holds and that overflow is dropped (not queued).
+
+/// Instance-scoped live/peak counter so parallel tests don't share global
+/// state. `enter()` on payload construction, `leave()` on deinit.
+private final class LiveCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _live = 0
+    private var _peak = 0
+    func enter() {
+        lock.lock()
+        _live += 1
+        if _live > _peak { _peak = _live }
+        lock.unlock()
+    }
+    func leave() {
+        lock.lock(); _live -= 1; lock.unlock()
+    }
+    var snapshot: (live: Int, peak: Int) {
+        lock.lock(); defer { lock.unlock() }; return (_live, _peak)
+    }
+}
+
+/// A payload that registers its lifetime with a `LiveCounter`. Stands in for a
+/// `SendableKVCaches` snapshot — when it is dropped/evicted, ARC frees it and
+/// `leave()` runs, exactly as releasing a `SendableKVCaches` frees its buffers.
+private final class TrackedPayload: @unchecked Sendable {
+    let counter: LiveCounter
+    init(_ counter: LiveCounter) { self.counter = counter; counter.enter() }
+    deinit { counter.leave() }
+}
+
+/// A one-shot async latch used to freeze the pipeline's single consumer so the
+/// buffer fills (mirrors a PrefixCacheManager actor that has fallen behind).
+private actor Latch {
+    private var open = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+    func wait() async {
+        if open { return }
+        await withCheckedContinuation { (c: CheckedContinuation<Void, Never>) in
+            if open { c.resume() } else { waiters.append(c) }
+        }
+    }
+    func release() {
+        open = true
+        let pending = waiters
+        waiters.removeAll()
+        for c in pending { c.resume() }
+    }
+}
+
+@Test
+func capturePipelineBoundsInFlightSnapshots() async {
+    let cap = 2
+    let total = 200
+    let counter = LiveCounter()
+    let latch = Latch()
+
+    // Consumer blocks on the first payload, so the buffer fills and stays full —
+    // the worst case the leak exploited.
+    let pipeline = CheckpointCapturePipeline<TrackedPayload>(capacity: cap) { _ in
+        await latch.wait()
+    }
+
+    // Flood the pipeline. Each payload is built inline and ownership is handed
+    // to `submit`, so the only references that survive are the bounded buffer
+    // (≤ cap) and the at-most-one payload the consumer is holding.
+    for _ in 0..<total {
+        pipeline.submit(TrackedPayload(counter))
+    }
+
+    // Give the consumer scheduling turns to pull one payload and block.
+    for _ in 0..<50 { await Task.yield() }
+
+    let s = counter.snapshot
+    // The buffer actually filled (test isn't trivially passing)...
+    // ...but never beyond the hard bound. Stable retention is buffer (cap) +
+    // ≤1 in the consumer = cap+1; during an evicting submit the just-built
+    // payload and the one being evicted briefly coexist, so the transient peak
+    // is at most cap+2. Either way it is a small constant — never unbounded.
+    #expect(s.peak >= cap, "buffer never filled: peak \(s.peak) < cap \(cap)")
+    #expect(s.peak <= cap + 2, "peak retained snapshots \(s.peak) exceeded cap+2 (\(cap + 2))")
+    // Steady state (no submit in flight): buffer + the one held by the consumer.
+    #expect(s.live <= cap + 1, "live retained snapshots \(s.live) exceeded cap+1 (\(cap + 1))")
+    // Proves boundedness vs the old unbounded Task-per-capture behavior, which
+    // would have retained all `total` snapshots at once.
+    #expect(s.peak < total)
+    // Overflow path engaged: surplus snapshots were dropped, not queued.
+    #expect(pipeline.droppedCount > 0, "expected overflow drops, got none")
+    #expect(
+        pipeline.acceptedCount + pipeline.droppedCount == total,
+        "every submit must be accounted for (accepted+dropped == total)")
+
+    // Drain: unblock the consumer, shut down, wait for the consumer to finish.
+    // No snapshot (or consumer Task) should leak.
+    await latch.release()
+    pipeline.shutdown()
+    await pipeline.waitUntilDrained()
+
+    let drained = counter.snapshot
+    #expect(drained.live == 0, "snapshots leaked after drain: \(drained.live)")
+}
+
+@Test
+func capturePipelineCapacityFloorIsOne() async {
+    // A non-positive capacity must clamp to ≥ 1, never 0 (a 0-buffer stream
+    // would drop everything and never warm the cache).
+    let p = CheckpointCapturePipeline<TrackedPayload>(capacity: 0) { _ in }
+    #expect(p.capacity == 1)
+    p.shutdown()
+}
+
+@Test
+func captureAdmissionGateThreshold() {
+    // Unknown / non-Metal limit (0) must never gate capture.
+    #expect(BatchScheduler.captureResourcePressureHigh(numResources: 999_999, resourceLimit: 0) == false)
+    // Below the 70% pressure line → allow capture.
+    #expect(BatchScheduler.captureResourcePressureHigh(numResources: 69_000, resourceLimit: 100_000) == false)
+    // Exactly at the line → allow (strict greater-than).
+    #expect(BatchScheduler.captureResourcePressureHigh(numResources: 70_000, resourceLimit: 100_000) == false)
+    // Above the line → gate (skip capture, stop feeding the leak).
+    #expect(BatchScheduler.captureResourcePressureHigh(numResources: 70_001, resourceLimit: 100_000) == true)
+    // Near the real ~499000 ceiling.
+    #expect(BatchScheduler.captureResourcePressureHigh(numResources: 400_000, resourceLimit: 499_000) == true)
+}
+
+@Test
+func captureMaxInFlightIsSmallAndPositive() {
+    #expect(BatchScheduler.captureDefaultMaxInFlight == 2)
+    #expect(BatchScheduler.captureMaxInFlight() >= 1)
+}

--- a/provider-swift/Tests/ProviderCoreTests/CheckpointCapturePipelineTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/CheckpointCapturePipelineTests.swift
@@ -113,6 +113,47 @@ func capturePipelineBoundsInFlightSnapshots() async {
 }
 
 @Test
+func capturePipelineDropsBufferedCapturesOnShutdown() async {
+    // `shutdown()` calls `finish()` + `cancel()`. `finish()` alone still lets the
+    // stream deliver already-buffered payloads, and an AsyncStream `for await`
+    // does NOT observe Task cancellation on its own — so without the in-loop
+    // `Task.isCancelled` guard the consumer would keep `consume`-ing the buffered
+    // remainder after a model swap began, storing old-model KV snapshots that pin
+    // live Metal buffers. This proves the buffered surplus is DROPPED on
+    // teardown: only the single in-flight capture runs.
+    let cap = 4
+    let total = 64
+    let counter = LiveCounter()
+    let firstEntered = Latch()   // fires once the consumer is inside consume #1
+    let release = Latch()        // unblocks that in-flight consume
+    let consumeCalls = LiveCounter()  // peak == number of consume invocations
+
+    let pipeline = CheckpointCapturePipeline<TrackedPayload>(capacity: cap) { _ in
+        consumeCalls.enter()
+        await firstEntered.release()
+        await release.wait()
+    }
+
+    for _ in 0..<total { pipeline.submit(TrackedPayload(counter)) }
+
+    // Wait until the consumer is actually blocked inside consume() for payload #1,
+    // then let the buffer fill behind it.
+    await firstEntered.wait()
+    for _ in 0..<50 { await Task.yield() }
+
+    // Tear down while the buffer is full and the consumer is mid-consume, then
+    // let the in-flight consume return. The loop must observe cancellation and
+    // break BEFORE consuming any buffered payload.
+    pipeline.shutdown()
+    await release.release()
+    await pipeline.waitUntilDrained()
+
+    let calls = consumeCalls.snapshot.peak
+    #expect(calls == 1, "expected only the in-flight capture to run after shutdown, got \(calls)")
+    #expect(counter.snapshot.live == 0, "buffered snapshots leaked after shutdown")
+}
+
+@Test
 func capturePipelineCapacityFloorIsOne() async {
     // A non-positive capacity must clamp to ≥ 1, never 0 (a 0-buffer stream
     // would drop everything and never warm the cache).


### PR DESCRIPTION
## Summary

Gemma-4 (`gemma-4-26b-qat-4bit`) crash-loops on busy providers with
`[metal::malloc] Resource limit (499000) exceeded` (≈ every 15 min on an M3
Ultra with free RAM). This is a **live Metal buffer-COUNT leak**, not a
bytes/cache problem. This PR bounds the checkpoint KV-capture pipeline so the
live resource count plateaus instead of climbing to the ceiling.

Provider-only change. The `libs/mlx-swift*` submodules are untouched.

Target: **0.6.12**.

## Root cause (verified)

Gemma-4 is heterogeneous (sliding `[8,256]` + full `[2,512]`), so it uses the
`.checkpoint` prefix-cache tier, which is **on by default** (opt out with
`DARKBLOOM_PREFIX_CACHE=0`):

- `provider-swift/Sources/ProviderCore/Inference/BatchScheduler.swift:1029-1066` — `.checkpoint` tier setup
- `provider-swift/Sources/ProviderCore/Inference/BatchScheduler.swift:1185-1188` — prefix cache default-ON / opt-out

The capture hook, fired per checkpoint boundary, spawned an **unbounded**
detached Task:

- `provider-swift/Sources/ProviderCore/Inference/BatchScheduler.swift:1115-1124` (production) and `:821-825` (test seam)

```swift
scheduler.onCheckpointCapture = { prefixTokens, length, caches in
    let box = SendableKVCaches(caches)
    Task { await mgr.store(tokens: prefixTokens, checkpointLength: length, caches: box) }  // <-- UNBOUNDED
}
```

The hook is fired synchronously on the engine queue with a freshly-extracted,
per-layer KV snapshot:

- `libs/mlx-swift-lm/Libraries/MLXLMCommon/ContinuousBatching/Scheduler.swift:396-401` — `caches = pp.ppBatch.promptCache.map { $0.extractBatched(0) }`

Each spawned `Task` **pins a full per-layer KV snapshot (live `MLXArray`s,
≈ layers × 2 Metal buffers) until `mgr.store` runs**. `PrefixCacheManager` is a
single actor that serializes `store` behind AES-GCM serialize + fsync and
against every `lookup`/`materialize`:

- `provider-swift/Sources/ProviderCore/KVCache/PrefixCacheManager.swift:752` — `func store(...)`

Under sustained traffic the actor falls behind, the capture Tasks queue, their
live snapshots accumulate, and the **live Metal resource COUNT** (independent of
bytes — see `Memory.numResources` /  `Memory.resourceLimit` in
`libs/mlx-swift/Source/MLX/Memory.swift:199-222`) climbs to the
`iogpu.rsrc_limit` ceiling (~499000) → crash.

## Why the prior mlx/mlx-c "count-aware" fixes can't fix this

Those fixes trim the **cache** (recycled, freed buffers) by making the trim
count-aware. But the snapshots held by the queued capture Tasks are **LIVE**,
not cached — they are still referenced, so the allocator cannot reclaim them no
matter how aggressively the cache is trimmed. The idle-gated
`Memory.clearCache()` also never fires under sustained load. The only fix is to
**bound the number of live snapshots retained in flight**, which is what this PR
does.

## The fix (provider-only)

1. **Backpressure / bounded capture pipeline (primary).** New
   `CheckpointCapturePipeline` (`BatchScheduler.swift` → new
   `CheckpointCapturePipeline.swift`): a bounded, single-consumer `AsyncStream`
   (`bufferingNewest(max-in-flight)`) feeding one consumer Task that calls
   `mgr.store`. `submit` is synchronous/non-blocking and **drops the surplus
   snapshot on full** (released immediately, so its Metal buffers free). This
   caps retained live snapshots to a small constant — `max-in-flight + 1`
   (buffer + the one in the consumer) — regardless of how far behind the
   manager actor falls. Default `max-in-flight = 2`, env-tunable via
   `DARKBLOOM_KV_CAPTURE_MAX_INFLIGHT`. Dropping is safe: capture is best-effort
   cache-warming, so a drop only costs a future cache miss, never correctness.

2. **Admission gate under resource pressure (secondary, cheap).** Before
   enqueuing, skip capture when the live Metal resource count is high —
   `Memory.numResources > 0.7 × Memory.resourceLimit` (guards
   `resourceLimit == 0`). This stops feeding the leak exactly when it matters,
   and matches the engine's existing `[rsrc]` 70%-pressure threshold.

3. **Teardown drains/cancels.** `stopCurrentEngine` (and the superseded-load
   bailouts) finish the stream and cancel the consumer, releasing any retained
   snapshots so nothing leaks across model swaps. Ordered before the manager
   flush so an in-flight `store` can't race the index flush / accountant
   deregister.

The decode path, KV-cache classes, and the manager's persistence logic are
unchanged; the only behavior change is bounding capture. Both capture-hook
sites (production builder + test seam) share one `makeCheckpointCaptureWiring`
helper.

## Tests

`swift build` passes; new + existing suites are green against `master`
(`v0.6.11`) submodule pins:

- **New** `CheckpointCapturePipelineTests` (4 tests):
  - `capturePipelineBoundsInFlightSnapshots` — floods the pipeline against a
    deliberately-stalled consumer and asserts the number of retained snapshots
    never exceeds the small constant bound (vs all N if unbounded), that
    overflow is **dropped not queued**, and that nothing leaks after drain.
  - `capturePipelineCapacityFloorIsOne` — capacity clamps to ≥ 1.
  - `captureAdmissionGateThreshold` — 70% threshold math incl. the
    `resourceLimit == 0` guard.
  - `captureMaxInFlightIsSmallAndPositive` — default cap + env knob.
- Regression suites: `BatchScheduler`, `PrefixCache`, `Continuous`, `Hybrid`,
  `KVCache` — **226 tests pass** (live model-download tests skip without
  `DARKBLOOM_LIVE_MLX_TESTS=1`).

## Validating in prod

Run a provider on Gemma-4 with the resource-count diagnostic (default-on; this
just makes the cadence explicit):

```
DARKBLOOM_MLX_RESOURCE_DEBUG=1 darkbloom serve
```

Watch the `[rsrc]` log line (subsystem `dev.darkbloom.provider`, category
`rsrc`). Before this change the live `resources` count climbs monotonically
toward 499000 under sustained traffic; after it should **plateau** well below
the limit. Optionally tune `DARKBLOOM_KV_CAPTURE_MAX_INFLIGHT` (default 2).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/374"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784231935&installation_id=133247490&pr_number=374&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F374&signature=c31180d5314632a4d2fa896e71e56fb92d6a40e4d6f5c5a2c779d51586d70d88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->