### PR TITLE
feat(coordinator): routing telemetry, rejection ledger, admin export + non-blocking sink

### DIFF
--- a/coordinator/api/admin_telemetry.go
+++ b/coordinator/api/admin_telemetry.go
@@ -139,8 +139,14 @@ func parseSince(r *http.Request) time.Time {
 	return time.Now().Add(-24 * time.Hour)
 }
 
-// parseLimit reads ?limit= as a non-negative row cap. A missing or invalid
-// value falls back to def; a value of 0 (or def == 0) means "no limit".
+// maxBrowseLimit bounds the caller-supplied ?limit= so a single browse response
+// can't be asked to materialize an unreasonable number of rows. It matches the
+// store-side read cap; the store never returns more than that regardless.
+const maxBrowseLimit = 50000
+
+// parseLimit reads ?limit= as a non-negative row cap, clamped to maxBrowseLimit.
+// A missing or invalid value falls back to def; a value of 0 (or def == 0) means
+// "no in-memory cap" (the store still hard-caps the underlying read).
 func parseLimit(r *http.Request, def int) int {
 	raw := strings.TrimSpace(r.URL.Query().Get("limit"))
 	if raw == "" {
@@ -149,6 +155,9 @@ func parseLimit(r *http.Request, def int) int {
 	n, err := strconv.Atoi(raw)
 	if err != nil || n < 0 {
 		return def
+	}
+	if n > maxBrowseLimit {
+		return maxBrowseLimit
 	}
 	return n
 }

--- a/coordinator/api/admin_telemetry.go
+++ b/coordinator/api/admin_telemetry.go
@@ -1,0 +1,447 @@
+// Admin read + download endpoints for routing telemetry.
+//
+// These handlers expose the coordinator's routing-decision and rejection
+// telemetry for offline analysis and calibration. They are admin-gated and
+// metadata-only: no prompt or response content is recorded or exported, so
+// every column is safe to download in bulk. See
+// docs/architecture/routing-telemetry-and-calibration.md.
+
+package api
+
+import (
+	"encoding/csv"
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/store"
+)
+
+// defaultBrowseLimit caps how many records the JSON browse handlers return when
+// the caller does not pass an explicit ?limit=. Exports are uncapped by default.
+const defaultBrowseLimit = 1000
+
+// --- Handlers -------------------------------------------------------------
+
+// handleAdminRoutes serves GET /v1/admin/routes: a JSON page of routing
+// decision records in the requested time window, with optional filtering by
+// provider, model, and outcome.
+func (s *Server) handleAdminRoutes(w http.ResponseWriter, r *http.Request) {
+	if !s.requireAdminKey(w, r) {
+		return
+	}
+	q := r.URL.Query()
+	records := filterRouteRecords(
+		s.store.InferenceRouteRecordsSince(parseSince(r)),
+		q.Get("provider"), q.Get("model"), q.Get("outcome"),
+	)
+	records = capRecords(records, parseLimit(r, defaultBrowseLimit))
+	writeJSON(w, http.StatusOK, map[string]any{
+		"object": "list",
+		"count":  len(records),
+		"data":   records,
+	})
+}
+
+// handleAdminRoutesExport serves GET /v1/admin/routes/export: a streamed CSV
+// (default) or NDJSON download of routing decision records.
+func (s *Server) handleAdminRoutesExport(w http.ResponseWriter, r *http.Request) {
+	if !s.requireAdminKey(w, r) {
+		return
+	}
+	q := r.URL.Query()
+	records := filterRouteRecords(
+		s.store.InferenceRouteRecordsSince(parseSince(r)),
+		q.Get("provider"), q.Get("model"), q.Get("outcome"),
+	)
+	records = capRecords(records, parseLimit(r, 0))
+
+	format := exportFormat(r)
+	setExportHeaders(w, "routes", format)
+	if format == "ndjson" {
+		if err := writeNDJSON(w, records); err != nil {
+			s.logger.Error("admin routes ndjson export failed", "error", err)
+		}
+		return
+	}
+	if err := writeRouteCSV(w, records); err != nil {
+		s.logger.Error("admin routes csv export failed", "error", err)
+	}
+}
+
+// handleAdminRejections serves GET /v1/admin/rejections: a JSON page of
+// rejected-request records in the requested time window, with optional
+// filtering by reason, model, and could_have_served.
+func (s *Server) handleAdminRejections(w http.ResponseWriter, r *http.Request) {
+	if !s.requireAdminKey(w, r) {
+		return
+	}
+	q := r.URL.Query()
+	records := filterRejectionRecords(
+		s.store.RejectionRecordsSince(parseSince(r)),
+		q.Get("reason"), q.Get("model"), q.Get("could_have_served"),
+	)
+	records = capRecords(records, parseLimit(r, defaultBrowseLimit))
+	writeJSON(w, http.StatusOK, map[string]any{
+		"object": "list",
+		"count":  len(records),
+		"data":   records,
+	})
+}
+
+// handleAdminRejectionsExport serves GET /v1/admin/rejections/export: a streamed
+// CSV (default) or NDJSON download of rejected-request records.
+func (s *Server) handleAdminRejectionsExport(w http.ResponseWriter, r *http.Request) {
+	if !s.requireAdminKey(w, r) {
+		return
+	}
+	q := r.URL.Query()
+	records := filterRejectionRecords(
+		s.store.RejectionRecordsSince(parseSince(r)),
+		q.Get("reason"), q.Get("model"), q.Get("could_have_served"),
+	)
+	records = capRecords(records, parseLimit(r, 0))
+
+	format := exportFormat(r)
+	setExportHeaders(w, "rejections", format)
+	if format == "ndjson" {
+		if err := writeNDJSON(w, records); err != nil {
+			s.logger.Error("admin rejections ndjson export failed", "error", err)
+		}
+		return
+	}
+	if err := writeRejectionCSV(w, records); err != nil {
+		s.logger.Error("admin rejections csv export failed", "error", err)
+	}
+}
+
+// --- Request parsing helpers ---------------------------------------------
+
+// parseSince resolves the ?since= query parameter to an absolute lower-bound
+// timestamp. It accepts either a Go duration relative to now (e.g. "24h",
+// "168h") or an RFC3339 timestamp. When absent or unparseable it defaults to
+// the last 24 hours.
+func parseSince(r *http.Request) time.Time {
+	raw := strings.TrimSpace(r.URL.Query().Get("since"))
+	if raw != "" {
+		if d, err := time.ParseDuration(raw); err == nil {
+			if d < 0 {
+				d = -d
+			}
+			return time.Now().Add(-d)
+		}
+		if t, err := time.Parse(time.RFC3339, raw); err == nil {
+			return t
+		}
+	}
+	return time.Now().Add(-24 * time.Hour)
+}
+
+// parseLimit reads ?limit= as a non-negative row cap. A missing or invalid
+// value falls back to def; a value of 0 (or def == 0) means "no limit".
+func parseLimit(r *http.Request, def int) int {
+	raw := strings.TrimSpace(r.URL.Query().Get("limit"))
+	if raw == "" {
+		return def
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil || n < 0 {
+		return def
+	}
+	return n
+}
+
+// exportFormat returns the normalized ?format= value: "ndjson" when explicitly
+// requested, otherwise "csv" (the default).
+func exportFormat(r *http.Request) string {
+	if strings.EqualFold(strings.TrimSpace(r.URL.Query().Get("format")), "ndjson") {
+		return "ndjson"
+	}
+	return "csv"
+}
+
+// setExportHeaders sets the download Content-Type and a timestamped attachment
+// filename for the given base name ("routes"/"rejections") and format.
+func setExportHeaders(w http.ResponseWriter, base, format string) {
+	ext, ctype := "csv", "text/csv"
+	if format == "ndjson" {
+		ext, ctype = "ndjson", "application/x-ndjson"
+	}
+	filename := base + "-" + time.Now().UTC().Format(time.RFC3339) + "." + ext
+	w.Header().Set("Content-Type", ctype)
+	w.Header().Set("Content-Disposition", "attachment; filename="+strconv.Quote(filename))
+}
+
+// capRecords truncates in to at most limit rows. limit <= 0 means no cap.
+func capRecords[T any](in []T, limit int) []T {
+	if limit > 0 && len(in) > limit {
+		return in[:limit]
+	}
+	return in
+}
+
+// --- Filters --------------------------------------------------------------
+
+// filterRouteRecords applies the optional in-memory filters supported by the
+// routes endpoints. Empty filter values are ignored. model matches either the
+// concrete Model or the consumer-facing PublicModel.
+func filterRouteRecords(in []store.InferenceRouteRecord, provider, model, outcome string) []store.InferenceRouteRecord {
+	if provider == "" && model == "" && outcome == "" {
+		return in
+	}
+	out := make([]store.InferenceRouteRecord, 0, len(in))
+	for _, rec := range in {
+		if provider != "" && rec.ProviderID != provider {
+			continue
+		}
+		if model != "" && rec.Model != model && rec.PublicModel != model {
+			continue
+		}
+		if outcome != "" && rec.Outcome != outcome {
+			continue
+		}
+		out = append(out, rec)
+	}
+	return out
+}
+
+// filterRejectionRecords applies the optional in-memory filters supported by the
+// rejections endpoints. Empty filter values are ignored. model matches either
+// RequestedModel or ResolvedModel; couldHaveServed filters on the boolean only
+// when it is exactly "true" or "false".
+func filterRejectionRecords(in []store.RejectionRecord, reason, model, couldHaveServed string) []store.RejectionRecord {
+	var wantServed *bool
+	switch strings.ToLower(strings.TrimSpace(couldHaveServed)) {
+	case "true":
+		v := true
+		wantServed = &v
+	case "false":
+		v := false
+		wantServed = &v
+	}
+	if reason == "" && model == "" && wantServed == nil {
+		return in
+	}
+	out := make([]store.RejectionRecord, 0, len(in))
+	for _, rec := range in {
+		if reason != "" && rec.ReasonCode != reason {
+			continue
+		}
+		if model != "" && rec.RequestedModel != model && rec.ResolvedModel != model {
+			continue
+		}
+		if wantServed != nil && rec.CouldHaveServed != *wantServed {
+			continue
+		}
+		out = append(out, rec)
+	}
+	return out
+}
+
+// --- NDJSON ---------------------------------------------------------------
+
+// writeNDJSON encodes one JSON object per line. json.Encoder.Encode appends a
+// newline after each value, yielding newline-delimited JSON, and streams each
+// record straight to w.
+func writeNDJSON[T any](w http.ResponseWriter, records []T) error {
+	enc := json.NewEncoder(w)
+	for i := range records {
+		if err := enc.Encode(records[i]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// --- CSV ------------------------------------------------------------------
+
+// routeCSVHeader lists the route export columns in struct-field order.
+var routeCSVHeader = []string{
+	"request_id", "attempt", "provider_id", "model", "public_model",
+	"consumer_key_hash", "key_id", "outcome",
+	"cost_ms", "state_ms", "queue_ms", "pending_ms", "backlog_ms",
+	"this_req_ms", "health_ms", "ttft_ms", "best_ttft_ms",
+	"effective_queue", "candidate_count", "capacity_rejections",
+	"model_too_large_rejections", "vision_rejections", "ttft_rejections",
+	"effective_tps", "static_tps",
+	"provider_status", "provider_trust_level", "provider_version",
+	"hardware_chip", "hardware_chip_family", "hardware_tier",
+	"memory_gb", "gpu_cores", "cpu_cores",
+	"system_memory_pressure", "system_cpu_usage", "system_thermal_state",
+	"gpu_memory_active_gb", "gpu_memory_peak_gb", "gpu_memory_cache_gb",
+	"slot_state", "backend_running", "backend_waiting",
+	"active_token_budget_used", "active_token_budget_max", "queued_token_budget",
+	"estimated_prompt_tokens", "requested_max_tokens",
+	"requires_vision", "has_tools", "self_route_only", "prefer_owner",
+	"cache_affinity_key", "provider_region", "consumer_region",
+	"created_at", "updated_at",
+}
+
+// writeRouteCSV streams a header row followed by one row per record to w, then
+// flushes and reports any write error.
+func writeRouteCSV(w http.ResponseWriter, records []store.InferenceRouteRecord) error {
+	cw := csv.NewWriter(w)
+	if err := cw.Write(routeCSVHeader); err != nil {
+		return err
+	}
+	for i := range records {
+		if err := cw.Write(routeCSVRow(records[i])); err != nil {
+			return err
+		}
+	}
+	cw.Flush()
+	return cw.Error()
+}
+
+// routeCSVRow flattens one record into CSV cells matching routeCSVHeader.
+func routeCSVRow(rec store.InferenceRouteRecord) []string {
+	return []string{
+		rec.RequestID,
+		csvInt(rec.Attempt),
+		rec.ProviderID,
+		rec.Model,
+		rec.PublicModel,
+		rec.ConsumerKeyHash,
+		rec.KeyID,
+		rec.Outcome,
+		csvFloat(rec.CostMs),
+		csvFloat(rec.StateMs),
+		csvFloat(rec.QueueMs),
+		csvFloat(rec.PendingMs),
+		csvFloat(rec.BacklogMs),
+		csvFloat(rec.ThisReqMs),
+		csvFloat(rec.HealthMs),
+		csvFloat(rec.TTFTMs),
+		csvFloat(rec.BestTTFTMs),
+		csvInt(rec.EffectiveQueue),
+		csvInt(rec.CandidateCount),
+		csvInt(rec.CapacityRejections),
+		csvInt(rec.ModelTooLargeRejections),
+		csvInt(rec.VisionRejections),
+		csvInt(rec.TTFTRejections),
+		csvFloat(rec.EffectiveTPS),
+		csvFloat(rec.StaticTPS),
+		rec.ProviderStatus,
+		rec.ProviderTrustLevel,
+		rec.ProviderVersion,
+		rec.HardwareChip,
+		rec.HardwareChipFamily,
+		rec.HardwareTier,
+		csvInt(rec.MemoryGB),
+		csvInt(rec.GPUCores),
+		csvInt(rec.CPUCores),
+		csvFloat(rec.SystemMemoryPressure),
+		csvFloat(rec.SystemCPUUsage),
+		rec.SystemThermalState,
+		csvFloat(rec.GPUMemoryActiveGB),
+		csvFloat(rec.GPUMemoryPeakGB),
+		csvFloat(rec.GPUMemoryCacheGB),
+		rec.SlotState,
+		csvInt(rec.BackendRunning),
+		csvInt(rec.BackendWaiting),
+		csvI64(rec.ActiveTokenBudgetUsed),
+		csvI64(rec.ActiveTokenBudgetMax),
+		csvI64(rec.QueuedTokenBudget),
+		csvInt(rec.EstimatedPromptTokens),
+		csvInt(rec.RequestedMaxTokens),
+		csvBool(rec.RequiresVision),
+		csvBool(rec.HasTools),
+		csvBool(rec.SelfRouteOnly),
+		csvBool(rec.PreferOwner),
+		rec.CacheAffinityKey,
+		rec.ProviderRegion,
+		rec.ConsumerRegion,
+		csvTime(rec.CreatedAt),
+		csvTime(rec.UpdatedAt),
+	}
+}
+
+// rejectionCSVHeader lists the rejection export columns in struct-field order.
+var rejectionCSVHeader = []string{
+	"request_id", "endpoint", "stage", "reason_code", "http_status",
+	"consumer_key_hash", "key_id", "client_class",
+	"requested_model", "resolved_model", "stream", "n",
+	"estimated_prompt_tokens", "requested_max_tokens",
+	"requires_vision", "has_image", "has_audio", "has_tools", "tool_count",
+	"response_format", "self_route_only", "prefer_owner", "params",
+	"request_body_bytes", "retry_after_ms",
+	"could_have_served", "candidate_count", "capacity_rejections",
+	"model_too_large_rejections", "vision_rejections", "warm_provider_existed",
+	"best_ttft_ms", "shortfall_micro_usd", "limit_kind", "over_by",
+	"created_at",
+}
+
+// writeRejectionCSV streams a header row followed by one row per record to w,
+// then flushes and reports any write error.
+func writeRejectionCSV(w http.ResponseWriter, records []store.RejectionRecord) error {
+	cw := csv.NewWriter(w)
+	if err := cw.Write(rejectionCSVHeader); err != nil {
+		return err
+	}
+	for i := range records {
+		if err := cw.Write(rejectionCSVRow(records[i])); err != nil {
+			return err
+		}
+	}
+	cw.Flush()
+	return cw.Error()
+}
+
+// rejectionCSVRow flattens one record into CSV cells matching
+// rejectionCSVHeader. The json.RawMessage Params field is emitted as a string.
+func rejectionCSVRow(rec store.RejectionRecord) []string {
+	return []string{
+		rec.RequestID,
+		rec.Endpoint,
+		rec.Stage,
+		rec.ReasonCode,
+		csvInt(rec.HTTPStatus),
+		rec.ConsumerKeyHash,
+		rec.KeyID,
+		rec.ClientClass,
+		rec.RequestedModel,
+		rec.ResolvedModel,
+		csvBool(rec.Stream),
+		csvInt(rec.N),
+		csvInt(rec.EstimatedPromptTokens),
+		csvInt(rec.RequestedMaxTokens),
+		csvBool(rec.RequiresVision),
+		csvBool(rec.HasImage),
+		csvBool(rec.HasAudio),
+		csvBool(rec.HasTools),
+		csvInt(rec.ToolCount),
+		rec.ResponseFormat,
+		csvBool(rec.SelfRouteOnly),
+		csvBool(rec.PreferOwner),
+		string(rec.Params),
+		csvInt(rec.RequestBodyBytes),
+		csvInt(rec.RetryAfterMs),
+		csvBool(rec.CouldHaveServed),
+		csvInt(rec.CandidateCount),
+		csvInt(rec.CapacityRejections),
+		csvInt(rec.ModelTooLargeRejections),
+		csvInt(rec.VisionRejections),
+		csvBool(rec.WarmProviderExisted),
+		csvFloat(rec.BestTTFTMs),
+		csvI64(rec.ShortfallMicroUSD),
+		rec.LimitKind,
+		csvI64(rec.OverBy),
+		csvTime(rec.CreatedAt),
+	}
+}
+
+// --- scalar formatting ----------------------------------------------------
+
+func csvInt(v int) string       { return strconv.Itoa(v) }
+func csvI64(v int64) string     { return strconv.FormatInt(v, 10) }
+func csvFloat(v float64) string { return strconv.FormatFloat(v, 'f', -1, 64) }
+func csvBool(v bool) string     { return strconv.FormatBool(v) }
+
+func csvTime(t time.Time) string {
+	if t.IsZero() {
+		return ""
+	}
+	return t.Format(time.RFC3339)
+}

--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -450,6 +450,7 @@ func (s *Server) dispatchOneProvider(
 	serviceReservation bool,
 	cacheAffinityKey string,
 	excludeProviders map[string]struct{},
+	attempt int,
 ) (
 	provider *registry.Provider,
 	pr *registry.PendingRequest,
@@ -459,7 +460,13 @@ func (s *Server) dispatchOneProvider(
 ) {
 	requestID := uuid.New().String()
 	pr = &registry.PendingRequest{
-		RequestID:              requestID,
+		RequestID: requestID,
+		// Attempt is stamped at construction — BEFORE the request is encrypted
+		// and sent to the provider — so a fast provider that returns
+		// inference_complete immediately is correlated to the right route row.
+		// Setting it after the send (on the dispatch goroutine) would race the
+		// provider WS reader goroutine's handleComplete read of pr.Attempt.
+		Attempt:                attempt,
 		Model:                  model,
 		PublicModel:            publicModel,
 		ConsumerKey:            consumerKey,

--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -393,6 +393,38 @@ func (s *Server) recordWarmPoolQueueState(model string) {
 	s.triggerWarmPool()
 }
 
+// ttftMsForRejection converts a pre-flight TTFT estimate to milliseconds for the
+// rejection ledger, returning 0 when the pre-flight produced no estimate.
+func ttftMsForRejection(bestTTFT time.Duration, hasTTFT bool) float64 {
+	if !hasTTFT {
+		return 0
+	}
+	return float64(bestTTFT.Milliseconds())
+}
+
+// rejectionSamplingParams captures only the non-content sampling knobs already
+// parsed from an inbound request body for the rejection ledger. It never
+// includes prompt/message/input content. Returns nil when none are present.
+func rejectionSamplingParams(parsed map[string]any) json.RawMessage {
+	if parsed == nil {
+		return nil
+	}
+	knobs := make(map[string]any, 4)
+	for _, k := range []string{"temperature", "top_p", "presence_penalty", "frequency_penalty"} {
+		if v, ok := parsed[k]; ok {
+			knobs[k] = v
+		}
+	}
+	if len(knobs) == 0 {
+		return nil
+	}
+	b, err := json.Marshal(knobs)
+	if err != nil {
+		return nil
+	}
+	return b
+}
+
 // dispatchOneProvider encrypts and sends an inference request to a single
 // provider. It returns the pending request and provider on success, or an
 // error string on failure. The excludeProviders set is updated on failure.
@@ -1514,6 +1546,16 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 	messages, _ := parsed["messages"].([]any)
 	input := parsed["input"]
 	if len(messages) == 0 && input == nil {
+		s.recordRejection(rejectionInfo{
+			r:               r,
+			stage:           "validation",
+			reasonCode:      "messages_required",
+			httpStatus:      http.StatusBadRequest,
+			keyID:           keyIDFromContext(r.Context()),
+			consumerKeyHash: store.HashKey(consumerKeyFromContext(r.Context())),
+			requestedModel:  model,
+			params:          rejectionSamplingParams(parsed),
+		})
 		writeJSON(w, http.StatusBadRequest, errorResponse("invalid_request_error", "messages or input is required"))
 		return
 	}
@@ -1521,6 +1563,17 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 	// Multiple choices per request are not supported — fail loudly instead of
 	// silently returning a single choice the consumer didn't ask for.
 	if copies, ok := intFromRequestValue(parsed["n"]); ok && copies > 1 {
+		s.recordRejection(rejectionInfo{
+			r:               r,
+			stage:           "validation",
+			reasonCode:      "bad_param",
+			httpStatus:      http.StatusBadRequest,
+			keyID:           keyIDFromContext(r.Context()),
+			consumerKeyHash: store.HashKey(consumerKeyFromContext(r.Context())),
+			requestedModel:  model,
+			n:               copies,
+			params:          rejectionSamplingParams(parsed),
+		})
 		writeJSON(w, http.StatusBadRequest, errorResponse("invalid_request_error",
 			"n > 1 is not supported", withParam("n")))
 		return
@@ -1528,6 +1581,16 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 
 	allowedProviderSerials, hasProviderAllowlist, err := parseProviderSerialAllowlist(parsed)
 	if err != nil {
+		s.recordRejection(rejectionInfo{
+			r:               r,
+			stage:           "validation",
+			reasonCode:      "bad_param",
+			httpStatus:      http.StatusBadRequest,
+			keyID:           keyIDFromContext(r.Context()),
+			consumerKeyHash: store.HashKey(consumerKeyFromContext(r.Context())),
+			requestedModel:  model,
+			params:          rejectionSamplingParams(parsed),
+		})
 		writeJSON(w, http.StatusBadRequest, errorResponse("invalid_request_error", err.Error()))
 		return
 	}
@@ -1550,6 +1613,16 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 	buildModel, publicModel, resolvedBody, ok := s.resolveRequestedModel(
 		parsed, rawBody, model, allowedProviderSerials, policy)
 	if !ok {
+		s.recordRejection(rejectionInfo{
+			r:               r,
+			stage:           "model_resolution",
+			reasonCode:      "model_unavailable",
+			httpStatus:      http.StatusServiceUnavailable,
+			keyID:           keyIDFromContext(r.Context()),
+			consumerKeyHash: store.HashKey(consumerKeyFromContext(r.Context())),
+			requestedModel:  model,
+			params:          rejectionSamplingParams(parsed),
+		})
 		writeJSON(w, http.StatusServiceUnavailable, errorResponse("model_unavailable",
 			fmt.Sprintf("model %q has no available build right now", model), withParam("model")))
 		return
@@ -1617,6 +1690,22 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 	if isResponsesAPI {
 		providerParsed, err := responsesRequestToChatCompletions(parsed)
 		if err != nil {
+			s.recordRejection(rejectionInfo{
+				r:                     r,
+				stage:                 "validation",
+				reasonCode:            "bad_param",
+				httpStatus:            http.StatusBadRequest,
+				keyID:                 keyIDFromContext(r.Context()),
+				consumerKeyHash:       store.HashKey(consumerKeyFromContext(r.Context())),
+				requestedModel:        publicModel,
+				resolvedModel:         model,
+				stream:                stream,
+				estimatedPromptTokens: estimatedPromptTokens,
+				requestedMaxTokens:    requestedMaxTokens,
+				requiresVision:        requiresVision,
+				hasTools:              hasTools,
+				params:                rejectionSamplingParams(parsed),
+			})
 			writeJSON(w, http.StatusBadRequest, errorResponse("invalid_request_error", err.Error()))
 			return
 		}
@@ -1649,6 +1738,22 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 		// Per-key spend cap (phase 1) — checked before the reservation so a
 		// capped key never debits the account ledger.
 		if msg, ok := s.checkKeySpendCap(r.Context(), reservedMicroUSD); !ok {
+			s.recordRejection(rejectionInfo{
+				r:                     r,
+				stage:                 "balance",
+				reasonCode:            "insufficient_quota",
+				httpStatus:            http.StatusPaymentRequired,
+				keyID:                 keyIDFromContext(r.Context()),
+				consumerKeyHash:       store.HashKey(consumerKeyFromContext(r.Context())),
+				requestedModel:        publicModel,
+				resolvedModel:         model,
+				stream:                stream,
+				estimatedPromptTokens: estimatedPromptTokens,
+				requestedMaxTokens:    requestedMaxTokens,
+				requiresVision:        requiresVision,
+				hasTools:              hasTools,
+				params:                rejectionSamplingParams(parsed),
+			})
 			writeJSON(w, http.StatusPaymentRequired, errorResponse("insufficient_quota", msg, withCode("insufficient_quota")))
 			return
 		}
@@ -1656,6 +1761,22 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 		serviceReservation, err = s.reserveInitialBalance(consumerKey, model, reservedMicroUSD)
 		if err != nil {
 			if errors.Is(err, store.ErrInsufficientBalance) {
+				s.recordRejection(rejectionInfo{
+					r:                     r,
+					stage:                 "balance",
+					reasonCode:            "insufficient_funds",
+					httpStatus:            http.StatusPaymentRequired,
+					keyID:                 keyIDFromContext(r.Context()),
+					consumerKeyHash:       store.HashKey(consumerKeyFromContext(r.Context())),
+					requestedModel:        publicModel,
+					resolvedModel:         model,
+					stream:                stream,
+					estimatedPromptTokens: estimatedPromptTokens,
+					requestedMaxTokens:    requestedMaxTokens,
+					requiresVision:        requiresVision,
+					hasTools:              hasTools,
+					params:                rejectionSamplingParams(parsed),
+				})
 				writeJSON(w, http.StatusPaymentRequired, errorResponse("insufficient_funds",
 					"your balance is too low for this request — add funds at /billing or lower max_tokens", withCode("insufficient_quota")))
 			} else {
@@ -1677,6 +1798,22 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 	// Reject requests for models not in the catalog.
 	if !s.registry.IsModelInCatalog(model) {
 		refundReservation()
+		s.recordRejection(rejectionInfo{
+			r:                     r,
+			stage:                 "model_resolution",
+			reasonCode:            "model_not_found",
+			httpStatus:            http.StatusNotFound,
+			keyID:                 keyIDFromContext(r.Context()),
+			consumerKeyHash:       store.HashKey(consumerKeyFromContext(r.Context())),
+			requestedModel:        publicModel,
+			resolvedModel:         model,
+			stream:                stream,
+			estimatedPromptTokens: estimatedPromptTokens,
+			requestedMaxTokens:    requestedMaxTokens,
+			requiresVision:        requiresVision,
+			hasTools:              hasTools,
+			params:                rejectionSamplingParams(parsed),
+		})
 		writeJSON(w, http.StatusNotFound, errorResponse("model_not_found",
 			fmt.Sprintf("model %q is not available — see /v1/models for supported models", publicModel), withParam("model")))
 		return
@@ -1714,6 +1851,22 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 					providerParsed, err := responsesRequestToChatCompletions(parsed)
 					if err != nil {
 						refundReservation()
+						s.recordRejection(rejectionInfo{
+							r:                     r,
+							stage:                 "validation",
+							reasonCode:            "bad_param",
+							httpStatus:            http.StatusBadRequest,
+							keyID:                 keyIDFromContext(r.Context()),
+							consumerKeyHash:       store.HashKey(consumerKeyFromContext(r.Context())),
+							requestedModel:        publicModel,
+							resolvedModel:         model,
+							stream:                stream,
+							estimatedPromptTokens: estimatedPromptTokens,
+							requestedMaxTokens:    requestedMaxTokens,
+							requiresVision:        requiresVision,
+							hasTools:              hasTools,
+							params:                rejectionSamplingParams(parsed),
+						})
 						writeJSON(w, http.StatusBadRequest, errorResponse("invalid_request_error", err.Error()))
 						return
 					}
@@ -1728,6 +1881,27 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 			// Surface a clear 503 instead of a 429 the client would retry forever.
 			refundReservation()
 			s.ddIncr("routing.decisions", []string{"model:" + model, "model_type:" + s.registry.ModelType(model), "outcome:model_too_large"})
+			s.recordRejection(rejectionInfo{
+				r:                       r,
+				stage:                   "preflight_capacity",
+				reasonCode:              "model_too_large",
+				httpStatus:              http.StatusServiceUnavailable,
+				keyID:                   keyIDFromContext(r.Context()),
+				consumerKeyHash:         store.HashKey(consumerKeyFromContext(r.Context())),
+				requestedModel:          publicModel,
+				resolvedModel:           model,
+				stream:                  stream,
+				estimatedPromptTokens:   estimatedPromptTokens,
+				requestedMaxTokens:      requestedMaxTokens,
+				requiresVision:          requiresVision,
+				hasTools:                hasTools,
+				params:                  rejectionSamplingParams(parsed),
+				servabilityComputed:     true,
+				candidateCount:          candidateCount,
+				capacityRejections:      capacityRejections,
+				modelTooLargeRejections: modelTooLarge,
+				bestTTFTMs:              ttftMsForRejection(bestTTFT, hasTTFT),
+			})
 			writeJSON(w, http.StatusServiceUnavailable, errorResponse("model_unavailable",
 				fmt.Sprintf("model %q is too large for any currently available provider", publicModel),
 				withCode("model_unavailable")))
@@ -1741,6 +1915,28 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Retry-After", strconv.Itoa(retryAfter))
 			refundReservation()
 			s.ddIncr("routing.decisions", []string{"model:" + model, "model_type:" + s.registry.ModelType(model), "outcome:capacity_429"})
+			s.recordRejection(rejectionInfo{
+				r:                       r,
+				stage:                   "preflight_capacity",
+				reasonCode:              "machine_busy",
+				httpStatus:              http.StatusTooManyRequests,
+				keyID:                   keyIDFromContext(r.Context()),
+				consumerKeyHash:         store.HashKey(consumerKeyFromContext(r.Context())),
+				requestedModel:          publicModel,
+				resolvedModel:           model,
+				stream:                  stream,
+				estimatedPromptTokens:   estimatedPromptTokens,
+				requestedMaxTokens:      requestedMaxTokens,
+				requiresVision:          requiresVision,
+				hasTools:                hasTools,
+				retryAfterMs:            retryAfter * 1000,
+				params:                  rejectionSamplingParams(parsed),
+				servabilityComputed:     true,
+				candidateCount:          candidateCount,
+				capacityRejections:      capacityRejections,
+				modelTooLargeRejections: modelTooLarge,
+				bestTTFTMs:              ttftMsForRejection(bestTTFT, hasTTFT),
+			})
 			writeJSON(w, http.StatusTooManyRequests, errorResponse("rate_limit_exceeded",
 				fmt.Sprintf("all providers for model %q are at capacity — retry after %ds", publicModel, retryAfter),
 				withCode("rate_limit_exceeded")))
@@ -1761,6 +1957,28 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Retry-After", strconv.Itoa(retryAfter))
 			refundReservation()
 			s.ddIncr("routing.decisions", []string{"model:" + model, "model_type:" + s.registry.ModelType(model), "outcome:no_eligible_provider"})
+			s.recordRejection(rejectionInfo{
+				r:                       r,
+				stage:                   "preflight_capacity",
+				reasonCode:              "no_provider",
+				httpStatus:              http.StatusServiceUnavailable,
+				keyID:                   keyIDFromContext(r.Context()),
+				consumerKeyHash:         store.HashKey(consumerKeyFromContext(r.Context())),
+				requestedModel:          publicModel,
+				resolvedModel:           model,
+				stream:                  stream,
+				estimatedPromptTokens:   estimatedPromptTokens,
+				requestedMaxTokens:      requestedMaxTokens,
+				requiresVision:          requiresVision,
+				hasTools:                hasTools,
+				retryAfterMs:            retryAfter * 1000,
+				params:                  rejectionSamplingParams(parsed),
+				servabilityComputed:     true,
+				candidateCount:          candidateCount,
+				capacityRejections:      capacityRejections,
+				modelTooLargeRejections: modelTooLarge,
+				bestTTFTMs:              ttftMsForRejection(bestTTFT, hasTTFT),
+			})
 			writeJSON(w, http.StatusServiceUnavailable, errorResponse("model_unavailable",
 				fmt.Sprintf("no provider for model %q is available right now — retry after %ds", publicModel, retryAfter),
 				withCode("model_unavailable")))
@@ -1773,6 +1991,22 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 					providerParsed, err := responsesRequestToChatCompletions(parsed)
 					if err != nil {
 						refundReservation()
+						s.recordRejection(rejectionInfo{
+							r:                     r,
+							stage:                 "validation",
+							reasonCode:            "bad_param",
+							httpStatus:            http.StatusBadRequest,
+							keyID:                 keyIDFromContext(r.Context()),
+							consumerKeyHash:       store.HashKey(consumerKeyFromContext(r.Context())),
+							requestedModel:        publicModel,
+							resolvedModel:         model,
+							stream:                stream,
+							estimatedPromptTokens: estimatedPromptTokens,
+							requestedMaxTokens:    requestedMaxTokens,
+							requiresVision:        requiresVision,
+							hasTools:              hasTools,
+							params:                rejectionSamplingParams(parsed),
+						})
 						writeJSON(w, http.StatusBadRequest, errorResponse("invalid_request_error", err.Error()))
 						return
 					}
@@ -1783,6 +2017,27 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 			} else {
 				retryModel, retryTTFT := fasterTTFTEstimate(model, bestTTFT, fallbackModel, fallbackTTFT, fallbackHasTTFT)
 				refundReservation()
+				s.recordRejection(rejectionInfo{
+					r:                       r,
+					stage:                   "routing_ttft",
+					reasonCode:              "ttft_too_slow",
+					httpStatus:              http.StatusTooManyRequests,
+					keyID:                   keyIDFromContext(r.Context()),
+					consumerKeyHash:         store.HashKey(consumerKeyFromContext(r.Context())),
+					requestedModel:          publicModel,
+					resolvedModel:           model,
+					stream:                  stream,
+					estimatedPromptTokens:   estimatedPromptTokens,
+					requestedMaxTokens:      requestedMaxTokens,
+					requiresVision:          requiresVision,
+					hasTools:                hasTools,
+					params:                  rejectionSamplingParams(parsed),
+					servabilityComputed:     true,
+					candidateCount:          candidateCount,
+					capacityRejections:      capacityRejections,
+					modelTooLargeRejections: modelTooLarge,
+					bestTTFTMs:              float64(retryTTFT.Milliseconds()),
+				})
 				s.writeTTFTTooSlow(w, retryModel, publicModel, retryTTFT, ttftThreshold)
 				return
 			}
@@ -1819,6 +2074,23 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 	// at this point, so refund before returning.
 	if len(rawBody) > maxInferenceBodyBytes {
 		refundReservation()
+		s.recordRejection(rejectionInfo{
+			r:                     r,
+			stage:                 "validation",
+			reasonCode:            "payload_too_large",
+			httpStatus:            http.StatusRequestEntityTooLarge,
+			keyID:                 keyIDFromContext(r.Context()),
+			consumerKeyHash:       store.HashKey(consumerKeyFromContext(r.Context())),
+			requestedModel:        publicModel,
+			resolvedModel:         model,
+			stream:                stream,
+			estimatedPromptTokens: estimatedPromptTokens,
+			requestedMaxTokens:    requestedMaxTokens,
+			requiresVision:        requiresVision,
+			hasTools:              hasTools,
+			requestBodyBytes:      len(rawBody),
+			params:                rejectionSamplingParams(parsed),
+		})
 		writeJSON(w, http.StatusRequestEntityTooLarge, errorResponse("invalid_request_error",
 			fmt.Sprintf("request body exceeds the %d-byte limit", maxInferenceBodyBytes)))
 		return
@@ -4106,6 +4378,16 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 
 	allowedProviderSerials, hasProviderAllowlist, err := parseProviderSerialAllowlist(parsed)
 	if err != nil {
+		s.recordRejection(rejectionInfo{
+			r:               r,
+			stage:           "validation",
+			reasonCode:      "bad_param",
+			httpStatus:      http.StatusBadRequest,
+			keyID:           keyIDFromContext(r.Context()),
+			consumerKeyHash: store.HashKey(consumerKeyFromContext(r.Context())),
+			requestedModel:  model,
+			params:          rejectionSamplingParams(parsed),
+		})
 		writeJSON(w, http.StatusBadRequest, errorResponse("invalid_request_error", err.Error()))
 		return
 	}
@@ -4122,6 +4404,16 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 	// from `parsed` (inferenceBody below), so rawBody isn't threaded here.
 	buildModel, publicModel, _, ok := s.resolveRequestedModel(parsed, rawBody, model, allowedProviderSerials, policy)
 	if !ok {
+		s.recordRejection(rejectionInfo{
+			r:               r,
+			stage:           "model_resolution",
+			reasonCode:      "model_unavailable",
+			httpStatus:      http.StatusServiceUnavailable,
+			keyID:           keyIDFromContext(r.Context()),
+			consumerKeyHash: store.HashKey(consumerKeyFromContext(r.Context())),
+			requestedModel:  model,
+			params:          rejectionSamplingParams(parsed),
+		})
 		writeJSON(w, http.StatusServiceUnavailable, errorResponse("model_unavailable",
 			fmt.Sprintf("model %q has no available build right now", model), withParam("model")))
 		return
@@ -4130,6 +4422,17 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 	cacheAffinityKey := requestCacheAffinityKey(parsed)
 
 	if !s.registry.IsModelInCatalog(model) {
+		s.recordRejection(rejectionInfo{
+			r:               r,
+			stage:           "model_resolution",
+			reasonCode:      "model_not_found",
+			httpStatus:      http.StatusNotFound,
+			keyID:           keyIDFromContext(r.Context()),
+			consumerKeyHash: store.HashKey(consumerKeyFromContext(r.Context())),
+			requestedModel:  publicModel,
+			resolvedModel:   model,
+			params:          rejectionSamplingParams(parsed),
+		})
 		writeJSON(w, http.StatusNotFound, errorResponse("model_not_found",
 			fmt.Sprintf("model %q is not available — see /v1/models for supported models", publicModel), withParam("model")))
 		return
@@ -4181,6 +4484,22 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 		reservedMicroUSD = s.reservationCost(model, billingPromptTokens, requestedMaxTokens)
 		// Per-key spend cap (phase 1) — checked before the reservation.
 		if msg, ok := s.checkKeySpendCap(r.Context(), reservedMicroUSD); !ok {
+			s.recordRejection(rejectionInfo{
+				r:                     r,
+				stage:                 "balance",
+				reasonCode:            "insufficient_quota",
+				httpStatus:            http.StatusPaymentRequired,
+				keyID:                 keyIDFromContext(r.Context()),
+				consumerKeyHash:       store.HashKey(consumerKeyFromContext(r.Context())),
+				requestedModel:        publicModel,
+				resolvedModel:         model,
+				stream:                stream,
+				estimatedPromptTokens: estimatedPromptTokens,
+				requestedMaxTokens:    requestedMaxTokens,
+				requiresVision:        requiresVision,
+				hasTools:              hasTools,
+				params:                rejectionSamplingParams(parsed),
+			})
 			writeJSON(w, http.StatusPaymentRequired, errorResponse("insufficient_quota", msg, withCode("insufficient_quota")))
 			return
 		}
@@ -4188,6 +4507,22 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 		serviceReservation, err = s.reserveInitialBalance(consumerKey, model, reservedMicroUSD)
 		if err != nil {
 			if errors.Is(err, store.ErrInsufficientBalance) {
+				s.recordRejection(rejectionInfo{
+					r:                     r,
+					stage:                 "balance",
+					reasonCode:            "insufficient_funds",
+					httpStatus:            http.StatusPaymentRequired,
+					keyID:                 keyIDFromContext(r.Context()),
+					consumerKeyHash:       store.HashKey(consumerKeyFromContext(r.Context())),
+					requestedModel:        publicModel,
+					resolvedModel:         model,
+					stream:                stream,
+					estimatedPromptTokens: estimatedPromptTokens,
+					requestedMaxTokens:    requestedMaxTokens,
+					requiresVision:        requiresVision,
+					hasTools:              hasTools,
+					params:                rejectionSamplingParams(parsed),
+				})
 				writeJSON(w, http.StatusPaymentRequired, errorResponse("insufficient_funds",
 					"your balance is too low for this request — add funds at /billing or lower max_tokens", withCode("insufficient_quota")))
 			} else {
@@ -4225,6 +4560,27 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 		if candidateCount == 0 && capacityRejections == 0 && modelTooLarge > 0 {
 			refundReservation()
 			s.ddIncr("routing.decisions", []string{"model:" + model, "model_type:" + s.registry.ModelType(model), "outcome:model_too_large"})
+			s.recordRejection(rejectionInfo{
+				r:                       r,
+				stage:                   "preflight_capacity",
+				reasonCode:              "model_too_large",
+				httpStatus:              http.StatusServiceUnavailable,
+				keyID:                   keyIDFromContext(r.Context()),
+				consumerKeyHash:         store.HashKey(consumerKeyFromContext(r.Context())),
+				requestedModel:          publicModel,
+				resolvedModel:           model,
+				stream:                  stream,
+				estimatedPromptTokens:   estimatedPromptTokens,
+				requestedMaxTokens:      requestedMaxTokens,
+				requiresVision:          requiresVision,
+				hasTools:                hasTools,
+				params:                  rejectionSamplingParams(parsed),
+				servabilityComputed:     true,
+				candidateCount:          candidateCount,
+				capacityRejections:      capacityRejections,
+				modelTooLargeRejections: modelTooLarge,
+				bestTTFTMs:              ttftMsForRejection(bestTTFT, hasTTFT),
+			})
 			writeJSON(w, http.StatusServiceUnavailable, errorResponse("model_unavailable",
 				fmt.Sprintf("model %q is too large for any currently available provider", publicModel),
 				withCode("model_unavailable")))
@@ -4237,6 +4593,28 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 			w.Header().Set("Retry-After", strconv.Itoa(retryAfter))
 			refundReservation()
 			s.ddIncr("routing.decisions", []string{"model:" + model, "model_type:" + s.registry.ModelType(model), "outcome:capacity_429"})
+			s.recordRejection(rejectionInfo{
+				r:                       r,
+				stage:                   "preflight_capacity",
+				reasonCode:              "machine_busy",
+				httpStatus:              http.StatusTooManyRequests,
+				keyID:                   keyIDFromContext(r.Context()),
+				consumerKeyHash:         store.HashKey(consumerKeyFromContext(r.Context())),
+				requestedModel:          publicModel,
+				resolvedModel:           model,
+				stream:                  stream,
+				estimatedPromptTokens:   estimatedPromptTokens,
+				requestedMaxTokens:      requestedMaxTokens,
+				requiresVision:          requiresVision,
+				hasTools:                hasTools,
+				retryAfterMs:            retryAfter * 1000,
+				params:                  rejectionSamplingParams(parsed),
+				servabilityComputed:     true,
+				candidateCount:          candidateCount,
+				capacityRejections:      capacityRejections,
+				modelTooLargeRejections: modelTooLarge,
+				bestTTFTMs:              ttftMsForRejection(bestTTFT, hasTTFT),
+			})
 			writeJSON(w, http.StatusTooManyRequests, errorResponse("rate_limit_exceeded",
 				fmt.Sprintf("all providers for model %q are at capacity — retry after %ds", publicModel, retryAfter),
 				withCode("rate_limit_exceeded")))
@@ -4251,6 +4629,28 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 			w.Header().Set("Retry-After", strconv.Itoa(retryAfter))
 			refundReservation()
 			s.ddIncr("routing.decisions", []string{"model:" + model, "model_type:" + s.registry.ModelType(model), "outcome:no_eligible_provider"})
+			s.recordRejection(rejectionInfo{
+				r:                       r,
+				stage:                   "preflight_capacity",
+				reasonCode:              "no_provider",
+				httpStatus:              http.StatusServiceUnavailable,
+				keyID:                   keyIDFromContext(r.Context()),
+				consumerKeyHash:         store.HashKey(consumerKeyFromContext(r.Context())),
+				requestedModel:          publicModel,
+				resolvedModel:           model,
+				stream:                  stream,
+				estimatedPromptTokens:   estimatedPromptTokens,
+				requestedMaxTokens:      requestedMaxTokens,
+				requiresVision:          requiresVision,
+				hasTools:                hasTools,
+				retryAfterMs:            retryAfter * 1000,
+				params:                  rejectionSamplingParams(parsed),
+				servabilityComputed:     true,
+				candidateCount:          candidateCount,
+				capacityRejections:      capacityRejections,
+				modelTooLargeRejections: modelTooLarge,
+				bestTTFTMs:              ttftMsForRejection(bestTTFT, hasTTFT),
+			})
 			writeJSON(w, http.StatusServiceUnavailable, errorResponse("model_unavailable",
 				fmt.Sprintf("no provider for model %q is available right now — retry after %ds", publicModel, retryAfter),
 				withCode("model_unavailable")))
@@ -4263,6 +4663,27 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 			} else {
 				retryModel, retryTTFT := fasterTTFTEstimate(model, bestTTFT, fallbackModel, fallbackTTFT, fallbackHasTTFT)
 				refundReservation()
+				s.recordRejection(rejectionInfo{
+					r:                       r,
+					stage:                   "routing_ttft",
+					reasonCode:              "ttft_too_slow",
+					httpStatus:              http.StatusTooManyRequests,
+					keyID:                   keyIDFromContext(r.Context()),
+					consumerKeyHash:         store.HashKey(consumerKeyFromContext(r.Context())),
+					requestedModel:          publicModel,
+					resolvedModel:           model,
+					stream:                  stream,
+					estimatedPromptTokens:   estimatedPromptTokens,
+					requestedMaxTokens:      requestedMaxTokens,
+					requiresVision:          requiresVision,
+					hasTools:                hasTools,
+					params:                  rejectionSamplingParams(parsed),
+					servabilityComputed:     true,
+					candidateCount:          candidateCount,
+					capacityRejections:      capacityRejections,
+					modelTooLargeRejections: modelTooLarge,
+					bestTTFTMs:              float64(retryTTFT.Milliseconds()),
+				})
 				s.writeTTFTTooSlow(w, retryModel, publicModel, retryTTFT, ttftThreshold)
 				return
 			}
@@ -4474,6 +4895,22 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 			refundExtra()
 			refundReservation()
 			if errors.Is(err, store.ErrInsufficientBalance) {
+				s.recordRejection(rejectionInfo{
+					r:                     r,
+					stage:                 "balance",
+					reasonCode:            "insufficient_funds",
+					httpStatus:            http.StatusPaymentRequired,
+					keyID:                 keyIDFromContext(r.Context()),
+					consumerKeyHash:       store.HashKey(consumerKeyFromContext(r.Context())),
+					requestedModel:        publicModel,
+					resolvedModel:         model,
+					stream:                stream,
+					estimatedPromptTokens: estimatedPromptTokens,
+					requestedMaxTokens:    requestedMaxTokens,
+					requiresVision:        requiresVision,
+					hasTools:              hasTools,
+					params:                rejectionSamplingParams(parsed),
+				})
 				writeJSON(w, http.StatusPaymentRequired, errorResponse("insufficient_funds",
 					"your balance is too low for this provider price — add funds at /billing or lower max_tokens", withCode("insufficient_quota")))
 			} else {
@@ -4495,6 +4932,23 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 		cleanupPending()
 		refundExtra()
 		refundReservation()
+		s.recordRejection(rejectionInfo{
+			r:                     r,
+			stage:                 "validation",
+			reasonCode:            "payload_too_large",
+			httpStatus:            http.StatusRequestEntityTooLarge,
+			keyID:                 keyIDFromContext(r.Context()),
+			consumerKeyHash:       store.HashKey(consumerKeyFromContext(r.Context())),
+			requestedModel:        publicModel,
+			resolvedModel:         model,
+			stream:                stream,
+			estimatedPromptTokens: estimatedPromptTokens,
+			requestedMaxTokens:    requestedMaxTokens,
+			requiresVision:        requiresVision,
+			hasTools:              hasTools,
+			requestBodyBytes:      len(inferenceBody),
+			params:                rejectionSamplingParams(parsed),
+		})
 		writeJSON(w, http.StatusRequestEntityTooLarge, errorResponse("invalid_request_error",
 			fmt.Sprintf("request body exceeds the %d-byte limit", maxInferenceBodyBytes)))
 		return

--- a/coordinator/api/dispatch.go
+++ b/coordinator/api/dispatch.go
@@ -266,7 +266,7 @@ func (d *dispatchState) recordRoutingDecision(decision registry.RoutingDecision,
 		d.provider.Mu().Unlock()
 	}
 
-	saferun.Go(s.logger, "recordInferenceRoute", func() {
+	s.submitTelemetry("recordInferenceRoute", func() {
 		_ = s.store.RecordInferenceRoute(record)
 	})
 }
@@ -352,7 +352,7 @@ func (d *dispatchState) updateRoutingOutcome(outcome *store.InferenceRouteOutcom
 	if requestID == "" {
 		return
 	}
-	saferun.Go(d.s.logger, "updateInferenceRoute", func() {
+	d.s.submitTelemetry("updateInferenceRoute", func() {
 		_ = d.s.store.UpdateInferenceRouteOutcome(requestID, d.attempt, outcome)
 	})
 }

--- a/coordinator/api/dispatch.go
+++ b/coordinator/api/dispatch.go
@@ -288,7 +288,12 @@ func timingMsBetween(a, b time.Time) float64 {
 // (timingMsBetween returns 0 otherwise), so a partially-instrumented request
 // never records a negative or bogus segment. QueueWaitMs is 0 for requests that
 // were dispatched without queueing (QueuedAt unset).
-func applyTimingDecomposition(out *store.InferenceRouteOutcome, t *registry.RequestTiming) {
+//
+// firstChunk is passed in (not read from t.FirstChunkAt) so this can also be
+// called from the provider read-loop goroutine (handleComplete) with a value
+// obtained via PendingRequest.FirstChunkAtSafe; t.FirstChunkAt itself must only
+// be read directly by the dispatch goroutine that owns the request.
+func applyTimingDecomposition(out *store.InferenceRouteOutcome, t *registry.RequestTiming, firstChunk time.Time) {
 	if out == nil || t == nil {
 		return
 	}
@@ -297,7 +302,7 @@ func applyTimingDecomposition(out *store.InferenceRouteOutcome, t *registry.Requ
 	out.RouteMs = timingMsBetween(t.ReservedAt, t.RoutedAt)
 	out.EncryptMs = timingMsBetween(t.RoutedAt, t.EncryptedAt)
 	out.QueueWaitMs = timingMsBetween(t.QueuedAt, t.DispatchedAt)
-	out.DispatchMs = timingMsBetween(t.DispatchedAt, t.FirstChunkAt)
+	out.DispatchMs = timingMsBetween(t.DispatchedAt, firstChunk)
 }
 
 // successRoutingOutcome builds a success outcome for the committed attempt.
@@ -316,7 +321,8 @@ func (d *dispatchState) successRoutingOutcome() *store.InferenceRouteOutcome {
 			out.TotalDurationMs = float64(time.Since(t.ReceivedAt).Milliseconds())
 		}
 		// Coordinator-side latency decomposition (defensive; zero when unmeasured).
-		applyTimingDecomposition(out, t)
+		// Runs on the dispatch goroutine, so reading t.FirstChunkAt directly is safe.
+		applyTimingDecomposition(out, t, t.FirstChunkAt)
 	}
 	return out
 }
@@ -352,8 +358,11 @@ func (d *dispatchState) updateRoutingOutcome(outcome *store.InferenceRouteOutcom
 	if requestID == "" {
 		return
 	}
+	// Capture attempt on the dispatch goroutine: the closure runs on a telemetry
+	// sink worker, while run()'s retry loop concurrently advances d.attempt.
+	attempt := d.attempt
 	d.s.submitTelemetry("updateInferenceRoute", func() {
-		_ = d.s.store.UpdateInferenceRouteOutcome(requestID, d.attempt, outcome)
+		_ = d.s.store.UpdateInferenceRouteOutcome(requestID, attempt, outcome)
 	})
 }
 
@@ -697,18 +706,14 @@ func (d *dispatchState) waitFirstChunk() (outcome dispatchOutcome) {
 		case chunk, ok := <-pr.ChunkCh:
 			if ok && len(d.heldChunks) < maxHeldBoilerplate && isBoilerplateChunk(chunk) {
 				d.heldChunks = append(d.heldChunks, chunk)
-				if pr.Timing.FirstChunkAt.IsZero() {
-					pr.Timing.FirstChunkAt = time.Now()
-				}
+				pr.MarkFirstChunkArrived()
 				continue
 			}
 			speculativeTimer.Stop()
 			deadlineTimer.Stop()
 			if ok {
 				d.firstChunk = chunk
-				if pr.Timing.FirstChunkAt.IsZero() {
-					pr.Timing.FirstChunkAt = time.Now()
-				}
+				pr.MarkFirstChunkArrived()
 				d.committed = true
 			} else {
 				select {
@@ -899,17 +904,13 @@ func (d *dispatchState) waitNoBackup() dispatchOutcome {
 		case chunk, ok := <-pr.ChunkCh:
 			if ok && len(d.heldChunks) < maxHeldBoilerplate && isBoilerplateChunk(chunk) {
 				d.heldChunks = append(d.heldChunks, chunk)
-				if pr.Timing.FirstChunkAt.IsZero() {
-					pr.Timing.FirstChunkAt = time.Now()
-				}
+				pr.MarkFirstChunkArrived()
 				continue
 			}
 			remainingDeadline.Stop()
 			if ok {
 				d.firstChunk = chunk
-				if pr.Timing.FirstChunkAt.IsZero() {
-					pr.Timing.FirstChunkAt = time.Now()
-				}
+				pr.MarkFirstChunkArrived()
 				d.committed = true
 			} else {
 				select {
@@ -1016,9 +1017,7 @@ func (d *dispatchState) runRace(backupProvider *registry.Provider, backupPR *reg
 				// Preamble only — the primary hasn't proven it can
 				// generate; keep the backup racing for first content.
 				d.heldChunks = append(d.heldChunks, chunk)
-				if pr.Timing.FirstChunkAt.IsZero() {
-					pr.Timing.FirstChunkAt = time.Now()
-				}
+				pr.MarkFirstChunkArrived()
 				continue
 			}
 			// Primary wins!
@@ -1026,9 +1025,7 @@ func (d *dispatchState) runRace(backupProvider *registry.Provider, backupPR *reg
 			s.cancelDispatch(backupProvider, backupPR)
 			if ok {
 				d.firstChunk = chunk
-				if pr.Timing.FirstChunkAt.IsZero() {
-					pr.Timing.FirstChunkAt = time.Now()
-				}
+				pr.MarkFirstChunkArrived()
 				d.committed = true
 			} else {
 				select {
@@ -1053,9 +1050,7 @@ func (d *dispatchState) runRace(backupProvider *registry.Provider, backupPR *reg
 			if ok && len(backupHeld) < maxHeldBoilerplate && isBoilerplateChunk(chunk) {
 				// Backup preamble doesn't win the race — first CONTENT does.
 				backupHeld = append(backupHeld, chunk)
-				if backupPR.Timing.FirstChunkAt.IsZero() {
-					backupPR.Timing.FirstChunkAt = time.Now()
-				}
+				backupPR.MarkFirstChunkArrived()
 				continue
 			}
 			// Backup wins!
@@ -1069,9 +1064,7 @@ func (d *dispatchState) runRace(backupProvider *registry.Provider, backupPR *reg
 				d.requestID = d.pr.RequestID
 				d.heldChunks = backupHeld
 				d.firstChunk = chunk
-				if d.pr.Timing.FirstChunkAt.IsZero() {
-					d.pr.Timing.FirstChunkAt = time.Now()
-				}
+				d.pr.MarkFirstChunkArrived()
 				d.committed = true
 			} else {
 				select {
@@ -1191,17 +1184,13 @@ func (d *dispatchState) raceBackupChunkClosedWaitPrimary(provider *registry.Prov
 		case chunk, ok := <-pr.ChunkCh:
 			if ok && len(d.heldChunks) < maxHeldBoilerplate && isBoilerplateChunk(chunk) {
 				d.heldChunks = append(d.heldChunks, chunk)
-				if pr.Timing.FirstChunkAt.IsZero() {
-					pr.Timing.FirstChunkAt = time.Now()
-				}
+				pr.MarkFirstChunkArrived()
 				continue
 			}
 			remainingPrimary.Stop()
 			if ok {
 				d.firstChunk = chunk
-				if pr.Timing.FirstChunkAt.IsZero() {
-					pr.Timing.FirstChunkAt = time.Now()
-				}
+				pr.MarkFirstChunkArrived()
 				d.committed = true
 			} else {
 				select {
@@ -1284,9 +1273,7 @@ func (d *dispatchState) racePrimaryFailedWaitBackup(backupProvider *registry.Pro
 		case chunk, ok := <-backupPR.ChunkCh:
 			if ok && len(backupHeld) < maxHeldBoilerplate && isBoilerplateChunk(chunk) {
 				backupHeld = append(backupHeld, chunk)
-				if backupPR.Timing.FirstChunkAt.IsZero() {
-					backupPR.Timing.FirstChunkAt = time.Now()
-				}
+				backupPR.MarkFirstChunkArrived()
 				continue
 			}
 			backupDeadline.Stop()
@@ -1296,9 +1283,7 @@ func (d *dispatchState) racePrimaryFailedWaitBackup(backupProvider *registry.Pro
 				d.requestID = d.pr.RequestID
 				d.heldChunks = backupHeld
 				d.firstChunk = chunk
-				if d.pr.Timing.FirstChunkAt.IsZero() {
-					d.pr.Timing.FirstChunkAt = time.Now()
-				}
+				d.pr.MarkFirstChunkArrived()
 				d.committed = true
 			} else {
 				select {
@@ -1385,17 +1370,13 @@ func (d *dispatchState) raceBackupErrWaitPrimary(provider *registry.Provider, pr
 		case chunk, ok := <-pr.ChunkCh:
 			if ok && len(d.heldChunks) < maxHeldBoilerplate && isBoilerplateChunk(chunk) {
 				d.heldChunks = append(d.heldChunks, chunk)
-				if pr.Timing.FirstChunkAt.IsZero() {
-					pr.Timing.FirstChunkAt = time.Now()
-				}
+				pr.MarkFirstChunkArrived()
 				continue
 			}
 			primaryDeadline.Stop()
 			if ok {
 				d.firstChunk = chunk
-				if pr.Timing.FirstChunkAt.IsZero() {
-					pr.Timing.FirstChunkAt = time.Now()
-				}
+				pr.MarkFirstChunkArrived()
 				d.committed = true
 			} else {
 				select {
@@ -1500,17 +1481,13 @@ func (d *dispatchState) waitAccepted() (outcome dispatchOutcome) {
 		case chunk, ok := <-pr.ChunkCh:
 			if ok && len(d.heldChunks) < maxHeldBoilerplate && isBoilerplateChunk(chunk) {
 				d.heldChunks = append(d.heldChunks, chunk)
-				if pr.Timing.FirstChunkAt.IsZero() {
-					pr.Timing.FirstChunkAt = time.Now()
-				}
+				pr.MarkFirstChunkArrived()
 				continue
 			}
 			chunkTimer.Stop()
 			if ok {
 				d.firstChunk = chunk
-				if pr.Timing.FirstChunkAt.IsZero() {
-					pr.Timing.FirstChunkAt = time.Now()
-				}
+				pr.MarkFirstChunkArrived()
 				d.committed = true
 			} else {
 				// Closed — check for error. Use a short grace

--- a/coordinator/api/dispatch.go
+++ b/coordinator/api/dispatch.go
@@ -126,6 +126,11 @@ type dispatchState struct {
 	attempt          int
 	accepted         bool
 	preambleLiveness bool
+	// dispatchErr captures the non-empty error string from dispatchOneProvider
+	// for this attempt so outcome telemetry can classify the routing decision.
+	dispatchErr string
+	// dispatchErrCode captures the HTTP status code associated with dispatchErr.
+	dispatchErrCode int
 }
 
 // traits builds the routing traits for the current attempt, steering away from
@@ -142,6 +147,214 @@ func queueMaxTTFTMs(policy selfRoutePolicy, deadline time.Duration) float64 {
 		return 0
 	}
 	return float64(deadline.Milliseconds())
+}
+
+// routingOutcomeKey returns a stable requestID + attempt identifier used for
+// telemetry updates. It prefers the explicit dispatch requestID, falling back
+// to the pending request's ID when the dispatch requestID has not been set yet.
+func (d *dispatchState) routingOutcomeKey() string {
+	if d.requestID != "" {
+		return d.requestID
+	}
+	if d.pr != nil {
+		return d.pr.RequestID
+	}
+	return ""
+}
+
+// recordRoutingDecision writes a best-effort snapshot of the scheduler decision
+// for the current attempt. It never blocks inference.
+func (d *dispatchState) recordRoutingDecision(decision registry.RoutingDecision, dispatchErr, outcomeOverride string) {
+	s := d.s
+	requestID := d.routingOutcomeKey()
+
+	providerID := ""
+	if d.provider != nil {
+		providerID = d.provider.ID
+	} else if decision.ProviderID != "" {
+		providerID = decision.ProviderID
+	}
+
+	outcome := outcomeOverride
+	if outcome == "" {
+		switch {
+		case providerID != "":
+			outcome = "selected"
+		case dispatchErr == errModelTooLarge:
+			outcome = "model_too_large"
+		case dispatchErr == errTTFTTooSlow:
+			outcome = "ttft_429"
+		case dispatchErr == "no provider available":
+			outcome = "no_provider"
+		default:
+			outcome = "error"
+		}
+	}
+
+	keyID := ""
+	if d.pr != nil {
+		keyID = d.pr.KeyID
+	}
+
+	record := &store.InferenceRouteRecord{
+		RequestID:               requestID,
+		Attempt:                 d.attempt,
+		ProviderID:              providerID,
+		Model:                   d.model,
+		PublicModel:             d.publicModel,
+		ConsumerKeyHash:         store.HashKey(d.consumerKey),
+		KeyID:                   keyID,
+		Outcome:                 outcome,
+		CostMs:                  decision.CostMs,
+		StateMs:                 decision.StateMs,
+		QueueMs:                 decision.QueueMs,
+		PendingMs:               decision.PendingMs,
+		BacklogMs:               decision.BacklogMs,
+		ThisReqMs:               decision.ThisReqMs,
+		HealthMs:                decision.HealthMs,
+		TTFTMs:                  decision.TTFTMs,
+		BestTTFTMs:              decision.BestTTFTMs,
+		EffectiveQueue:          decision.EffectiveQueue,
+		CandidateCount:          decision.CandidateCount,
+		CapacityRejections:      decision.CapacityRejections,
+		ModelTooLargeRejections: decision.ModelTooLargeRejections,
+		VisionRejections:        decision.VisionRejections,
+		TTFTRejections:          decision.TTFTRejections,
+		EffectiveTPS:            decision.EffectiveTPS,
+		StaticTPS:               decision.StaticTPS,
+		EstimatedPromptTokens:   d.estimatedPromptTokens,
+		RequestedMaxTokens:      d.requestedMaxTokens,
+		RequiresVision:          d.requiresVision,
+		HasTools:                d.hasTools,
+		SelfRouteOnly:           d.policy.enabled,
+		PreferOwner:             d.policy.prefer,
+		CacheAffinityKey:        d.cacheAffinityKey,
+		CreatedAt:               time.Now(),
+		UpdatedAt:               time.Now(),
+	}
+
+	if d.provider != nil {
+		d.provider.Mu().Lock()
+		record.ProviderStatus = string(d.provider.Status)
+		record.ProviderTrustLevel = string(d.provider.TrustLevel)
+		record.ProviderVersion = d.provider.Version
+		record.HardwareChip = d.provider.Hardware.ChipName
+		record.HardwareChipFamily = d.provider.Hardware.ChipFamily
+		record.HardwareTier = d.provider.Hardware.ChipTier
+		record.MemoryGB = d.provider.Hardware.MemoryGB
+		record.GPUCores = d.provider.Hardware.GPUCores
+		record.CPUCores = d.provider.Hardware.CPUCores.Total
+		record.SystemMemoryPressure = d.provider.SystemMetrics.MemoryPressure
+		record.SystemCPUUsage = d.provider.SystemMetrics.CPUUsage
+		record.SystemThermalState = d.provider.SystemMetrics.ThermalState
+		if cap := d.provider.BackendCapacity; cap != nil {
+			record.GPUMemoryActiveGB = cap.GPUMemoryActiveGB
+			record.GPUMemoryPeakGB = cap.GPUMemoryPeakGB
+			record.GPUMemoryCacheGB = cap.GPUMemoryCacheGB
+			for _, slot := range cap.Slots {
+				if slot.Model == d.model {
+					record.SlotState = slot.State
+					record.BackendRunning = slot.NumRunning
+					record.BackendWaiting = slot.NumWaiting
+					record.ActiveTokenBudgetUsed = slot.ActiveTokenBudgetUsed
+					record.ActiveTokenBudgetMax = slot.ActiveTokenBudgetMax
+					record.QueuedTokenBudget = slot.QueuedTokenBudget
+					break
+				}
+			}
+		}
+		d.provider.Mu().Unlock()
+	}
+
+	saferun.Go(s.logger, "recordInferenceRoute", func() {
+		_ = s.store.RecordInferenceRoute(record)
+	})
+}
+
+// timingMsBetween returns the elapsed milliseconds between two request-lifecycle
+// timestamps, or 0 when either endpoint is unset or the interval is non-positive.
+// It keeps the latency-decomposition fields defensive: never a negative value,
+// never a panic on a zero timestamp.
+func timingMsBetween(a, b time.Time) float64 {
+	if a.IsZero() || b.IsZero() || !b.After(a) {
+		return 0
+	}
+	return float64(b.Sub(a).Milliseconds())
+}
+
+// applyTimingDecomposition fills the coordinator-side latency-decomposition
+// fields (ParseMs..DispatchMs) on a routing outcome from the per-request timing
+// stamps. Each segment is populated only when both of its endpoints are set
+// (timingMsBetween returns 0 otherwise), so a partially-instrumented request
+// never records a negative or bogus segment. QueueWaitMs is 0 for requests that
+// were dispatched without queueing (QueuedAt unset).
+func applyTimingDecomposition(out *store.InferenceRouteOutcome, t *registry.RequestTiming) {
+	if out == nil || t == nil {
+		return
+	}
+	out.ParseMs = timingMsBetween(t.ReceivedAt, t.ParsedAt)
+	out.ReserveMs = timingMsBetween(t.ParsedAt, t.ReservedAt)
+	out.RouteMs = timingMsBetween(t.ReservedAt, t.RoutedAt)
+	out.EncryptMs = timingMsBetween(t.RoutedAt, t.EncryptedAt)
+	out.QueueWaitMs = timingMsBetween(t.QueuedAt, t.DispatchedAt)
+	out.DispatchMs = timingMsBetween(t.DispatchedAt, t.FirstChunkAt)
+}
+
+// successRoutingOutcome builds a success outcome for the committed attempt.
+// Token counts are left at zero because the final usage is only available when
+// the provider later sends the completion message; handleComplete updates them.
+func (d *dispatchState) successRoutingOutcome() *store.InferenceRouteOutcome {
+	out := &store.InferenceRouteOutcome{FinalStatus: "success"}
+	if d.pr != nil && d.pr.Timing != nil {
+		t := d.pr.Timing
+		if !t.FirstChunkAt.IsZero() && !t.DispatchedAt.IsZero() {
+			ms := float64(t.FirstChunkAt.Sub(t.DispatchedAt).Milliseconds())
+			out.ActualTTFTMs = ms
+			out.DispatchToFirstChunkMs = ms
+		}
+		if !t.ReceivedAt.IsZero() {
+			out.TotalDurationMs = float64(time.Since(t.ReceivedAt).Milliseconds())
+		}
+		// Coordinator-side latency decomposition (defensive; zero when unmeasured).
+		applyTimingDecomposition(out, t)
+	}
+	return out
+}
+
+// errorRoutingOutcome builds an error / timeout / cancelled outcome.
+func (d *dispatchState) errorRoutingOutcome(status, class string, code int) *store.InferenceRouteOutcome {
+	return &store.InferenceRouteOutcome{
+		FinalStatus: status,
+		ErrorCode:   code,
+		ErrorClass:  class,
+	}
+}
+
+// providerFailedRoutingOutcome builds the outcome for a POST-DISPATCH provider
+// failure: the request had already been admitted to a specific provider (passed
+// the admission gate and was dispatched over the WebSocket) and that provider
+// then reported an error — including provider-reported OOM / model-load failures
+// that surface on pr.ErrorCh. It flags AdmittedButFailed to expose the
+// admission-gate mismatch (coordinator said "this provider can serve" but it
+// could not). It is intentionally only used from the post-dispatch wait loops;
+// pre-dispatch failures (queue reservation DB error, invalid key, keygen, send
+// failure) and coordinator-side timeouts are NOT flagged.
+func (d *dispatchState) providerFailedRoutingOutcome() *store.InferenceRouteOutcome {
+	out := d.errorRoutingOutcome("error", "provider_error", d.lastErrCode)
+	out.AdmittedButFailed = true
+	return out
+}
+
+// updateRoutingOutcome writes a final outcome update for the current attempt
+// asynchronously. It is a no-op when there is no request ID to correlate.
+func (d *dispatchState) updateRoutingOutcome(outcome *store.InferenceRouteOutcome) {
+	requestID := d.routingOutcomeKey()
+	if requestID == "" {
+		return
+	}
+	saferun.Go(d.s.logger, "updateInferenceRoute", func() {
+		_ = d.s.store.UpdateInferenceRouteOutcome(requestID, d.attempt, outcome)
+	})
 }
 
 // dispatchPrimary selects (and, when no idle provider exists on the first
@@ -163,6 +376,9 @@ func (d *dispatchState) dispatchPrimary() dispatchOutcome {
 		d.traits(),
 		d.allowedProviderSerials, d.isResponsesAPI, d.policy, d.timing, d.serviceReservation, d.cacheAffinityKey, d.excludeProviders,
 	)
+	d.dispatchErr = dispatchErr
+	d.dispatchErrCode = dispatchErrCode
+	d.recordRoutingDecision(decision, dispatchErr, "")
 	if d.provider == nil {
 		// No online provider has enough memory to ever fit this model.
 		// Retrying and queueing are both pointless — reject immediately
@@ -214,6 +430,7 @@ func (d *dispatchState) dispatchPrimary() dispatchOutcome {
 		d.requestID = uuid.New().String()
 		queuePR := &registry.PendingRequest{
 			RequestID:              d.requestID,
+			Attempt:                d.attempt,
 			Model:                  d.model,
 			PublicModel:            d.publicModel,
 			ConsumerKey:            d.consumerKey,
@@ -267,6 +484,7 @@ func (d *dispatchState) dispatchPrimary() dispatchOutcome {
 		}
 		s.recordWarmPoolQueueState(d.model)
 		s.ddIncr("routing.decisions", []string{"model:" + d.model, "model_type:" + s.registry.ModelType(d.model), "outcome:queued"})
+		d.recordRoutingDecision(decision, "", "queued")
 
 		s.logger.Info("request queued, waiting for provider",
 			"model", d.model,
@@ -278,9 +496,11 @@ func (d *dispatchState) dispatchPrimary() dispatchOutcome {
 		if err != nil {
 			if errors.Is(err, context.Canceled) {
 				s.recordWarmPoolQueueState(d.model)
+				d.updateRoutingOutcome(d.errorRoutingOutcome("cancelled", "client_gone", 0))
 				d.refundReservation()
 				return outcomeClientGone
 			}
+			d.updateRoutingOutcome(d.errorRoutingOutcome("timeout", "queue_timeout", http.StatusTooManyRequests))
 			d.refundReservation()
 			s.ddIncr("request_queue.timeout", []string{"model:" + d.model, "model_type:" + s.registry.ModelType(d.model)})
 			s.registry.RecordWarmPoolQueueTimeout(d.model, time.Since(queuedReq.EnqueuedAt))
@@ -341,6 +561,7 @@ func (d *dispatchState) dispatchPrimary() dispatchOutcome {
 					)
 					d.lastErr = "insufficient funds for provider price"
 					d.lastErrCode = http.StatusPaymentRequired
+					d.updateRoutingOutcome(d.errorRoutingOutcome("error", "insufficient_funds", d.lastErrCode))
 				} else {
 					s.logger.Error("queued provider reservation failed (DB error)",
 						"request_id", d.requestID,
@@ -349,6 +570,7 @@ func (d *dispatchState) dispatchPrimary() dispatchOutcome {
 					)
 					d.lastErr = "service temporarily unavailable — please retry"
 					d.lastErrCode = http.StatusServiceUnavailable
+					d.updateRoutingOutcome(d.errorRoutingOutcome("error", "provider_error", d.lastErrCode))
 				}
 				return outcomeRetry
 			}
@@ -360,6 +582,7 @@ func (d *dispatchState) dispatchPrimary() dispatchOutcome {
 			s.refundProviderExtra(d.pr)
 			d.excludeProviders[d.provider.ID] = struct{}{}
 			d.lastErr = "no provider with E2E encryption"
+			d.updateRoutingOutcome(d.errorRoutingOutcome("error", "encryption_missing", 0))
 			return outcomeRetry
 		}
 		providerPubKey, err := e2e.ParsePublicKey(d.provider.PublicKey)
@@ -369,6 +592,7 @@ func (d *dispatchState) dispatchPrimary() dispatchOutcome {
 			s.refundProviderExtra(d.pr)
 			d.excludeProviders[d.provider.ID] = struct{}{}
 			d.lastErr = "provider public key invalid"
+			d.updateRoutingOutcome(d.errorRoutingOutcome("error", "provider_error", 0))
 			return outcomeRetry
 		}
 		sessionKeys, err := e2e.GenerateSessionKeys()
@@ -377,6 +601,7 @@ func (d *dispatchState) dispatchPrimary() dispatchOutcome {
 			s.registry.SetProviderIdle(d.provider.ID)
 			s.refundProviderExtra(d.pr)
 			d.lastErr = "failed to generate session keys"
+			d.updateRoutingOutcome(d.errorRoutingOutcome("error", "provider_error", 0))
 			return outcomeRetry
 		}
 		// Version-gated penalty strip (see bodyForProvider). The queued path seals
@@ -388,6 +613,7 @@ func (d *dispatchState) dispatchPrimary() dispatchOutcome {
 			s.registry.SetProviderIdle(d.provider.ID)
 			s.refundProviderExtra(d.pr)
 			d.lastErr = "failed to encrypt request"
+			d.updateRoutingOutcome(d.errorRoutingOutcome("error", "encryption_missing", 0))
 			return outcomeRetry
 		}
 		d.timing.EncryptedAt = time.Now()
@@ -409,6 +635,7 @@ func (d *dispatchState) dispatchPrimary() dispatchOutcome {
 			s.refundProviderExtra(d.pr)
 			d.excludeProviders[d.provider.ID] = struct{}{}
 			d.lastErr = "failed to send request to provider"
+			d.updateRoutingOutcome(d.errorRoutingOutcome("error", "provider_error", 0))
 			return outcomeRetry
 		}
 		d.pr.Timing.DispatchedAt = time.Now()
@@ -433,10 +660,26 @@ func (d *dispatchState) noteDispatchRetry(provider *registry.Provider, pr *regis
 // primary is slow. Returns outcomeCommitted (content / clean close), outcomeAccepted
 // (cold-load or preamble liveness — proceed to waitAccepted), outcomeRetry
 // (advance to the next attempt), or outcomeClientGone (context cancelled, refunded).
-func (d *dispatchState) waitFirstChunk() dispatchOutcome {
+func (d *dispatchState) waitFirstChunk() (outcome dispatchOutcome) {
 	s := d.s
 	r := d.r
 	provider, pr := d.provider, d.pr
+
+	defer func() {
+		switch outcome {
+		case outcomeCommitted:
+			d.updateRoutingOutcome(d.successRoutingOutcome())
+		case outcomeRetry:
+			if d.lastErrCode == http.StatusGatewayTimeout {
+				d.updateRoutingOutcome(d.errorRoutingOutcome("timeout", "first_chunk_timeout", d.lastErrCode))
+			} else {
+				// Post-dispatch provider failure (incl. OOM/model-load): admitted but failed.
+				d.updateRoutingOutcome(d.providerFailedRoutingOutcome())
+			}
+		case outcomeClientGone:
+			d.updateRoutingOutcome(d.errorRoutingOutcome("cancelled", "client_gone", 0))
+		}
+	}()
 
 	speculativeTimer := time.NewTimer(d.speculativeAt)
 	deadlineTimer := time.NewTimer(d.deadline)
@@ -1220,10 +1463,30 @@ func (d *dispatchState) raceBackupErrWaitPrimary(provider *registry.Provider, pr
 // inferenceTimeout; a boilerplate-liveness extension past an expired TTFT deadline
 // gets only preambleContentTimeout (zero bytes written to the client, so a
 // preamble-then-stall provider must fail over instead of pinning for 10 minutes).
-func (d *dispatchState) waitAccepted() dispatchOutcome {
+func (d *dispatchState) waitAccepted() (outcome dispatchOutcome) {
 	s := d.s
 	r := d.r
 	provider, pr := d.provider, d.pr
+
+	defer func() {
+		switch outcome {
+		case outcomeCommitted:
+			d.updateRoutingOutcome(d.successRoutingOutcome())
+		case outcomeRetry:
+			if d.lastErrCode == http.StatusGatewayTimeout {
+				if d.preambleLiveness {
+					d.updateRoutingOutcome(d.errorRoutingOutcome("timeout", "preamble_liveness_timeout", d.lastErrCode))
+				} else {
+					d.updateRoutingOutcome(d.errorRoutingOutcome("timeout", "accepted_timeout", d.lastErrCode))
+				}
+			} else {
+				// Post-dispatch provider failure (incl. OOM/model-load): admitted but failed.
+				d.updateRoutingOutcome(d.providerFailedRoutingOutcome())
+			}
+		case outcomeClientGone:
+			d.updateRoutingOutcome(d.errorRoutingOutcome("cancelled", "client_gone", 0))
+		}
+	}()
 
 	firstContentBudget := inferenceTimeout
 	if d.preambleLiveness {
@@ -1381,6 +1644,7 @@ func (d *dispatchState) run() {
 		}
 
 		d.requestID = d.pr.RequestID
+		d.pr.Attempt = d.attempt
 		if d.timing.RoutedAt.IsZero() {
 			d.timing.RoutedAt = time.Now()
 		}

--- a/coordinator/api/dispatch.go
+++ b/coordinator/api/dispatch.go
@@ -375,6 +375,7 @@ func (d *dispatchState) dispatchPrimary() dispatchOutcome {
 		d.estimatedPromptTokens, d.requestedMaxTokens, d.tokenAdmission, d.requiresVision,
 		d.traits(),
 		d.allowedProviderSerials, d.isResponsesAPI, d.policy, d.timing, d.serviceReservation, d.cacheAffinityKey, d.excludeProviders,
+		d.attempt,
 	)
 	d.dispatchErr = dispatchErr
 	d.dispatchErrCode = dispatchErrCode
@@ -862,6 +863,7 @@ func (d *dispatchState) runSpeculative() dispatchOutcome {
 			d.serviceReservation,
 			d.cacheAffinityKey,
 			backupExclude,
+			d.attempt,
 		)
 	}
 
@@ -1644,7 +1646,9 @@ func (d *dispatchState) run() {
 		}
 
 		d.requestID = d.pr.RequestID
-		d.pr.Attempt = d.attempt
+		// d.pr.Attempt is already stamped at PendingRequest construction in
+		// dispatchOneProvider (and on the queued path), before the provider send —
+		// so it is never written here, where it would race handleComplete.
 		if d.timing.RoutedAt.IsZero() {
 			d.timing.RoutedAt = time.Now()
 		}

--- a/coordinator/api/provider.go
+++ b/coordinator/api/provider.go
@@ -1945,6 +1945,43 @@ func (s *Server) handleComplete(providerID string, provider *registry.Provider, 
 			})
 		}
 
+		// Update the routing telemetry outcome with final token counts and timing.
+		// handleComplete is the authoritative final writer for a SUCCESSFUL request
+		// (UpdateInferenceRouteOutcome overwrites the whole row), so this outcome
+		// carries the full coordinator-side latency decomposition and the measured
+		// decode throughput in addition to tokens/cost.
+		saferun.Go(s.logger, "updateInferenceRoute", func() {
+			outcome := &store.InferenceRouteOutcome{
+				FinalStatus:      "success",
+				PromptTokens:     msg.Usage.PromptTokens,
+				CompletionTokens: msg.Usage.CompletionTokens,
+				ReasoningTokens:  msg.Usage.ReasoningTokens,
+				CostMicroUSD:     totalCost,
+			}
+			if pr.Timing != nil {
+				t := pr.Timing
+				if !t.FirstChunkAt.IsZero() && !t.DispatchedAt.IsZero() {
+					ms := float64(t.FirstChunkAt.Sub(t.DispatchedAt).Milliseconds())
+					outcome.ActualTTFTMs = ms
+					outcome.DispatchToFirstChunkMs = ms
+				}
+				if !t.ReceivedAt.IsZero() {
+					outcome.TotalDurationMs = float64(time.Since(t.ReceivedAt).Milliseconds())
+				}
+				// Coordinator-side latency decomposition (ParseMs..DispatchMs).
+				applyTimingDecomposition(outcome, t)
+				// Measured decode throughput: completion tokens over the decode
+				// window (first chunk -> completion). Guard zero/negative
+				// durations and zero tokens so unmeasurable requests record 0.
+				if msg.Usage.CompletionTokens > 0 && !t.FirstChunkAt.IsZero() {
+					if decodeSecs := time.Since(t.FirstChunkAt).Seconds(); decodeSecs > 0 {
+						outcome.ActualDecodeTPS = float64(msg.Usage.CompletionTokens) / decodeSecs
+					}
+				}
+			}
+			_ = s.store.UpdateInferenceRouteOutcome(msg.RequestID, pr.Attempt, outcome)
+		})
+
 		s.ddIncr("inference.completions", []string{"model:" + pr.Model})
 		s.ddCount("inference.prompt_tokens_total", int64(msg.Usage.PromptTokens), []string{"model:" + pr.Model})
 		s.ddHistogram("inference.prompt_tokens", float64(msg.Usage.PromptTokens), []string{"model:" + pr.Model})

--- a/coordinator/api/provider.go
+++ b/coordinator/api/provider.go
@@ -1950,7 +1950,7 @@ func (s *Server) handleComplete(providerID string, provider *registry.Provider, 
 		// (UpdateInferenceRouteOutcome overwrites the whole row), so this outcome
 		// carries the full coordinator-side latency decomposition and the measured
 		// decode throughput in addition to tokens/cost.
-		saferun.Go(s.logger, "updateInferenceRoute", func() {
+		s.submitTelemetry("updateInferenceRoute", func() {
 			outcome := &store.InferenceRouteOutcome{
 				FinalStatus:      "success",
 				PromptTokens:     msg.Usage.PromptTokens,

--- a/coordinator/api/provider.go
+++ b/coordinator/api/provider.go
@@ -1642,6 +1642,14 @@ func (s *Server) handleInferenceAccepted(provider *registry.Provider, msg *proto
 	}
 }
 
+// maxPlausibleDecodeTPS is the sanity ceiling applied to the telemetry-only
+// ActualDecodeTPS before it is persisted. Real decode throughput on the fleet's
+// Apple-silicon hardware is in the tens-to-low-hundreds of tokens/sec; this
+// ceiling is far above any genuine value and exists solely to stop a dishonest
+// or buggy provider's unbounded CompletionTokens from writing an absurd TPS that
+// could skew routing calibration. The value is advisory, never a security gate.
+const maxPlausibleDecodeTPS = 10000.0
+
 func (s *Server) handleComplete(providerID string, provider *registry.Provider, msg *protocol.InferenceCompleteMessage) {
 	if provider == nil {
 		s.logger.Warn("complete from unregistered provider", "provider_id", providerID)
@@ -1973,9 +1981,18 @@ func (s *Server) handleComplete(providerID string, provider *registry.Provider, 
 				// Measured decode throughput: completion tokens over the decode
 				// window (first chunk -> completion). Guard zero/negative
 				// durations and zero tokens so unmeasurable requests record 0.
+				// CompletionTokens is provider-supplied and untrusted, so clamp the
+				// derived TPS to a sanity ceiling: a dishonest/buggy provider must
+				// not be able to write an absurd value that would skew routing
+				// calibration (threat-model T-007/T-027). Throughput is advisory,
+				// never a security gate.
 				if msg.Usage.CompletionTokens > 0 && !t.FirstChunkAt.IsZero() {
 					if decodeSecs := time.Since(t.FirstChunkAt).Seconds(); decodeSecs > 0 {
-						outcome.ActualDecodeTPS = float64(msg.Usage.CompletionTokens) / decodeSecs
+						tps := float64(msg.Usage.CompletionTokens) / decodeSecs
+						if tps > maxPlausibleDecodeTPS {
+							tps = maxPlausibleDecodeTPS
+						}
+						outcome.ActualDecodeTPS = tps
 					}
 				}
 			}

--- a/coordinator/api/provider.go
+++ b/coordinator/api/provider.go
@@ -1968,8 +1968,16 @@ func (s *Server) handleComplete(providerID string, provider *registry.Provider, 
 			}
 			if pr.Timing != nil {
 				t := pr.Timing
-				if !t.FirstChunkAt.IsZero() && !t.DispatchedAt.IsZero() {
-					ms := float64(t.FirstChunkAt.Sub(t.DispatchedAt).Milliseconds())
+				// This runs on the provider read-loop goroutine, not the request
+				// owner. FirstChunkAt is the one Timing field the dispatch goroutine
+				// writes after dispatch (while streaming), so read it via the
+				// mutex-guarded accessor to avoid a data race. The remaining fields
+				// (DispatchedAt, ReceivedAt, and those used by applyTimingDecomposition)
+				// are all stamped before dispatch and are safe to read here via the
+				// provider-registration happens-before edge.
+				firstChunk := pr.FirstChunkAtSafe()
+				if !firstChunk.IsZero() && !t.DispatchedAt.IsZero() {
+					ms := float64(firstChunk.Sub(t.DispatchedAt).Milliseconds())
 					outcome.ActualTTFTMs = ms
 					outcome.DispatchToFirstChunkMs = ms
 				}
@@ -1977,7 +1985,7 @@ func (s *Server) handleComplete(providerID string, provider *registry.Provider, 
 					outcome.TotalDurationMs = float64(time.Since(t.ReceivedAt).Milliseconds())
 				}
 				// Coordinator-side latency decomposition (ParseMs..DispatchMs).
-				applyTimingDecomposition(outcome, t)
+				applyTimingDecomposition(outcome, t, firstChunk)
 				// Measured decode throughput: completion tokens over the decode
 				// window (first chunk -> completion). Guard zero/negative
 				// durations and zero tokens so unmeasurable requests record 0.
@@ -1986,8 +1994,8 @@ func (s *Server) handleComplete(providerID string, provider *registry.Provider, 
 				// not be able to write an absurd value that would skew routing
 				// calibration (threat-model T-007/T-027). Throughput is advisory,
 				// never a security gate.
-				if msg.Usage.CompletionTokens > 0 && !t.FirstChunkAt.IsZero() {
-					if decodeSecs := time.Since(t.FirstChunkAt).Seconds(); decodeSecs > 0 {
+				if msg.Usage.CompletionTokens > 0 && !firstChunk.IsZero() {
+					if decodeSecs := time.Since(firstChunk).Seconds(); decodeSecs > 0 {
 						tps := float64(msg.Usage.CompletionTokens) / decodeSecs
 						if tps > maxPlausibleDecodeTPS {
 							tps = maxPlausibleDecodeTPS

--- a/coordinator/api/rejection_telemetry.go
+++ b/coordinator/api/rejection_telemetry.go
@@ -147,6 +147,12 @@ func clientClassFromUserAgent(ua string) string {
 	if ua == "" {
 		return "unknown"
 	}
+	// Bound work on this untrusted header: only the prefix is needed to classify
+	// the client, so cap the length before lowercasing to avoid spending effort
+	// on a maliciously long User-Agent.
+	if len(ua) > 256 {
+		ua = ua[:256]
+	}
 	lc := strings.ToLower(ua)
 	switch {
 	case strings.Contains(lc, "openrouter"):

--- a/coordinator/api/rejection_telemetry.go
+++ b/coordinator/api/rejection_telemetry.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/eigeninference/d-inference/coordinator/registry"
-	"github.com/eigeninference/d-inference/coordinator/saferun"
 	"github.com/eigeninference/d-inference/coordinator/store"
 )
 
@@ -121,7 +120,7 @@ func (s *Server) recordRejection(info rejectionInfo) {
 	requiresVision := info.requiresVision
 	hasTools := info.hasTools
 
-	saferun.Go(s.logger, "recordRejection", func() {
+	s.submitTelemetry("recordRejection", func() {
 		if computeServability {
 			traits := registry.RequestTraits{HasTools: hasTools}
 			cc, capRej, tooLarge, bestTTFT, hasTTFT := reg.QuickCapacityCheckWithTTFTForRequest(

--- a/coordinator/api/rejection_telemetry.go
+++ b/coordinator/api/rejection_telemetry.go
@@ -1,0 +1,166 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/registry"
+	"github.com/eigeninference/d-inference/coordinator/saferun"
+	"github.com/eigeninference/d-inference/coordinator/store"
+)
+
+// rejectionInfo carries everything known about a rejected inbound inference
+// request at a 4xx/5xx exit point. Callers populate what they have; zero values
+// are fine. It is the single contract the consumer/handler code uses to feed the
+// rejection ledger (see docs/architecture/routing-telemetry-and-calibration.md §4.9).
+type rejectionInfo struct {
+	r          *http.Request
+	stage      string // auth, validation, model_resolution, balance, rate_limit, preflight_capacity, routing_ttft
+	reasonCode string // e.g. model_not_found, machine_busy, insufficient_funds
+	httpStatus int
+
+	keyID           string
+	consumerKeyHash string
+
+	requestedModel string // raw, as the client sent it
+	resolvedModel  string // after alias resolution, when known
+
+	stream                bool
+	n                     int
+	estimatedPromptTokens int
+	requestedMaxTokens    int
+	requiresVision        bool
+	hasImage              bool
+	hasAudio              bool
+	hasTools              bool
+	toolCount             int
+	responseFormat        string
+	selfRouteOnly         bool
+	preferOwner           bool
+	params                json.RawMessage // non-content knobs (temperature, top_p, …)
+	requestBodyBytes      int
+	retryAfterMs          int
+
+	// 402 / 429 extras.
+	shortfallMicroUSD int64
+	limitKind         string
+	overBy            int64
+
+	// Counterfactual. When servabilityComputed is true the caller already ran the
+	// capacity check (e.g. the pre-flight) and the candidate*/bestTTFTMs fields
+	// below are authoritative — recordRejection will NOT recompute. Otherwise, when
+	// a resolvedModel is set, recordRejection computes servability itself.
+	servabilityComputed     bool
+	candidateCount          int
+	capacityRejections      int
+	modelTooLargeRejections int
+	visionRejections        int
+	bestTTFTMs              float64
+}
+
+// recordRejection persists a rejected-request record asynchronously, computing
+// the counterfactual servability ("could the fleet have served it?") off the
+// request path when the caller did not already do so. Best-effort: it never
+// blocks or fails the request.
+func (s *Server) recordRejection(info rejectionInfo) {
+	if s == nil || s.store == nil {
+		return
+	}
+
+	rec := &store.RejectionRecord{
+		Stage:                 info.stage,
+		ReasonCode:            info.reasonCode,
+		HTTPStatus:            info.httpStatus,
+		KeyID:                 info.keyID,
+		ConsumerKeyHash:       info.consumerKeyHash,
+		RequestedModel:        info.requestedModel,
+		ResolvedModel:         info.resolvedModel,
+		Stream:                info.stream,
+		N:                     info.n,
+		EstimatedPromptTokens: info.estimatedPromptTokens,
+		RequestedMaxTokens:    info.requestedMaxTokens,
+		RequiresVision:        info.requiresVision,
+		HasImage:              info.hasImage,
+		HasAudio:              info.hasAudio,
+		HasTools:              info.hasTools,
+		ToolCount:             info.toolCount,
+		ResponseFormat:        info.responseFormat,
+		SelfRouteOnly:         info.selfRouteOnly,
+		PreferOwner:           info.preferOwner,
+		Params:                info.params,
+		RequestBodyBytes:      info.requestBodyBytes,
+		RetryAfterMs:          info.retryAfterMs,
+		ShortfallMicroUSD:     info.shortfallMicroUSD,
+		LimitKind:             info.limitKind,
+		OverBy:                info.overBy,
+		CreatedAt:             time.Now(),
+	}
+	if info.r != nil {
+		rec.Endpoint = info.r.URL.Path
+		rec.ClientClass = clientClassFromUserAgent(info.r.UserAgent())
+		if rec.RequestBodyBytes == 0 && info.r.ContentLength > 0 {
+			rec.RequestBodyBytes = int(info.r.ContentLength)
+		}
+	}
+
+	// Seed the counterfactual from whatever the caller already computed.
+	rec.CandidateCount = info.candidateCount
+	rec.CapacityRejections = info.capacityRejections
+	rec.ModelTooLargeRejections = info.modelTooLargeRejections
+	rec.VisionRejections = info.visionRejections
+	rec.BestTTFTMs = info.bestTTFTMs
+
+	// Decide whether we still need to compute servability inside the goroutine.
+	computeServability := !info.servabilityComputed && info.resolvedModel != "" && s.registry != nil
+	reg := s.registry
+	resolvedModel := info.resolvedModel
+	estPrompt := info.estimatedPromptTokens
+	reqMax := info.requestedMaxTokens
+	requiresVision := info.requiresVision
+	hasTools := info.hasTools
+
+	saferun.Go(s.logger, "recordRejection", func() {
+		if computeServability {
+			traits := registry.RequestTraits{HasTools: hasTools}
+			cc, capRej, tooLarge, bestTTFT, hasTTFT := reg.QuickCapacityCheckWithTTFTForRequest(
+				resolvedModel, estPrompt, reqMax, traits, requiresVision,
+			)
+			rec.CandidateCount = cc
+			rec.CapacityRejections = capRej
+			rec.ModelTooLargeRejections = tooLarge
+			if hasTTFT {
+				rec.BestTTFTMs = float64(bestTTFT.Milliseconds())
+			}
+		}
+		// A request could have produced output iff at least one provider could
+		// serve it right now. This is the headline "was the 'no' necessary?" flag.
+		rec.CouldHaveServed = rec.CandidateCount > 0
+		_ = s.store.RecordRejection(rec)
+	})
+}
+
+// clientClassFromUserAgent buckets the caller into a coarse, non-private class so
+// we can compare rejection patterns across integrations (e.g. OpenRouter vs
+// direct API users) without storing the raw user agent.
+func clientClassFromUserAgent(ua string) string {
+	if ua == "" {
+		return "unknown"
+	}
+	lc := strings.ToLower(ua)
+	switch {
+	case strings.Contains(lc, "openrouter"):
+		return "openrouter"
+	case strings.Contains(lc, "darkbloom"):
+		return "darkbloom"
+	case strings.Contains(lc, "python"), strings.Contains(lc, "openai"):
+		return "openai-sdk"
+	case strings.Contains(lc, "node"), strings.Contains(lc, "axios"), strings.Contains(lc, "fetch"):
+		return "js-sdk"
+	case strings.Contains(lc, "curl"):
+		return "curl"
+	default:
+		return "direct"
+	}
+}

--- a/coordinator/api/server.go
+++ b/coordinator/api/server.go
@@ -344,6 +344,13 @@ type Server struct {
 	// the key inherits the account-level limits. Nil disables per-key limiting.
 	keyRPMLimiter   *ratelimit.Limiter
 	keyTokenLimiter *ratelimit.KeyTokenLimiter
+
+	// routeTelemetry is the bounded, non-blocking sink that persists
+	// best-effort routing telemetry (inference-route records, outcome updates,
+	// rejection ledger rows) off the request path. It is set by NewServer; a
+	// Server built directly (e.g. &Server{} in tests) leaves it nil, and
+	// submitTelemetry falls back to a per-write saferun.Go in that case.
+	routeTelemetry *telemetrySink
 }
 
 // SetRateLimiter configures the per-account rate limiter applied to
@@ -629,6 +636,7 @@ func NewServer(reg *registry.Registry, st store.Store, cfg ServerConfig, logger 
 		settlements:          newSettlementHolder(),
 		zombieCanceller:      newZombieStreamCanceller(),
 		serviceReservations:  newServiceReservationManager(st, cfg.ServiceReservations),
+		routeTelemetry:       newTelemetrySink(logger, defaultTelemetrySinkCapacity, defaultTelemetrySinkWorkers),
 	}
 	s.registerDefaultGauges()
 	s.routes()
@@ -656,6 +664,31 @@ func NewServer(reg *registry.Registry, st store.Store, cfg ServerConfig, logger 
 	s.releaseKey = cfg.ReleaseKey
 
 	return s
+}
+
+// submitTelemetry enqueues a best-effort telemetry write onto the non-blocking
+// routing-telemetry sink. It never blocks the caller (the inference request
+// path): when the sink's buffer is full the write is dropped and counted. name
+// identifies the write for panic/drop diagnostics.
+//
+// Nil-safety: a Server constructed directly (e.g. &Server{} in tests, which
+// never runs NewServer) has no sink. In that case it falls back to the previous
+// behavior — a per-write panic-safe goroutine — so those tests keep working.
+func (s *Server) submitTelemetry(name string, fn func()) {
+	if s.routeTelemetry != nil {
+		s.routeTelemetry.submit(fn)
+		return
+	}
+	saferun.Go(s.logger, name, fn)
+}
+
+// Close releases background resources owned by the Server. Currently it stops
+// the routing-telemetry sink's worker pool. It is idempotent and never blocks on
+// in-flight telemetry writes, so it is safe to defer from main's shutdown path.
+func (s *Server) Close() {
+	if s.routeTelemetry != nil {
+		s.routeTelemetry.close()
+	}
 }
 
 // SetAdminKey configures the admin API key for admin-only endpoints.

--- a/coordinator/api/server.go
+++ b/coordinator/api/server.go
@@ -1675,6 +1675,15 @@ func (s *Server) routes() {
 	// Metrics snapshot (admin only)
 	s.mux.HandleFunc("GET /v1/admin/metrics", s.handleAdminMetrics)
 
+	// Routing telemetry (admin-gated; metadata only — no prompt/response content).
+	// Browse as JSON or stream a CSV/NDJSON download for offline analysis.
+	// See docs/architecture/routing-telemetry-and-calibration.md §6. Handlers
+	// enforce admin auth internally via requireAdminKey.
+	s.mux.HandleFunc("GET /v1/admin/routes", s.handleAdminRoutes)
+	s.mux.HandleFunc("GET /v1/admin/routes/export", s.handleAdminRoutesExport)
+	s.mux.HandleFunc("GET /v1/admin/rejections", s.handleAdminRejections)
+	s.mux.HandleFunc("GET /v1/admin/rejections/export", s.handleAdminRejectionsExport)
+
 	// Catch-all for unimplemented OpenAI-compatible endpoints.
 	// Registered last (old-style pattern) so explicit method+path routes
 	// take precedence. Any /v1/* path not handled above gets a structured

--- a/coordinator/api/telemetry_sink.go
+++ b/coordinator/api/telemetry_sink.go
@@ -1,0 +1,160 @@
+package api
+
+// Non-blocking sink for best-effort routing-telemetry persistence.
+//
+// Routing telemetry (inference-route records, outcome updates, rejection ledger
+// rows) is observability data: useful, but it must NEVER add latency or
+// backpressure to inference, and it must never let a slow/unavailable store
+// (Postgres) grow goroutines or memory without bound. Previously each telemetry
+// write was persisted with its own saferun.Go(...) goroutine — one goroutine per
+// write. When the store fell behind, those goroutines (each pinning the captured
+// record) piled up unboundedly.
+//
+// telemetrySink replaces that with a single bounded, non-blocking queue: the
+// request path enqueues a closure via submit (which never blocks), a small fixed
+// pool of long-lived workers drains the queue, and when the buffer is full the
+// write is DROPPED and counted. Goroutines and memory are therefore bounded by
+// construction, and inference latency is fully decoupled from store latency.
+
+import (
+	"log/slog"
+	"sync"
+	"sync/atomic"
+
+	"github.com/eigeninference/d-inference/coordinator/saferun"
+)
+
+// Sink defaults. The buffer absorbs brief store stalls without dropping, while
+// the small fixed worker pool caps the goroutines (and concurrent store calls)
+// telemetry can ever consume. Both are deliberately modest — telemetry is
+// best-effort and must not compete with inference for resources.
+const (
+	defaultTelemetrySinkCapacity = 4096
+	defaultTelemetrySinkWorkers  = 2
+)
+
+// telemetrySink is a bounded, non-blocking work queue for best-effort telemetry
+// persistence. submit enqueues a closure without blocking; a fixed pool of
+// long-lived workers drains the queue and runs each closure inside a panic-safe
+// wrapper. When the buffer is full the write is dropped and counted, so the
+// inference path can never be slowed or blocked by telemetry — even if the store
+// is slow or down — and goroutine/memory growth is bounded.
+type telemetrySink struct {
+	ch      chan func()
+	done    chan struct{}
+	logger  *slog.Logger
+	dropped atomic.Int64
+	// closeOnce makes close idempotent: done is closed exactly once even when
+	// close is reached from more than one shutdown path.
+	closeOnce sync.Once
+}
+
+// newTelemetrySink starts workers long-lived goroutines, each draining the
+// buffered work channel until the sink is closed. capacity and workers fall back
+// to the package defaults when non-positive.
+func newTelemetrySink(logger *slog.Logger, capacity, workers int) *telemetrySink {
+	if capacity <= 0 {
+		capacity = defaultTelemetrySinkCapacity
+	}
+	if workers <= 0 {
+		workers = defaultTelemetrySinkWorkers
+	}
+	t := &telemetrySink{
+		ch:     make(chan func(), capacity),
+		done:   make(chan struct{}),
+		logger: logger,
+	}
+	for i := 0; i < workers; i++ {
+		go t.worker()
+	}
+	return t
+}
+
+// worker drains the work channel until the sink is closed. The worker IS the
+// long-lived goroutine — it runs each task inline (inside a panic-safe wrapper)
+// and never spawns a goroutine per task.
+func (t *telemetrySink) worker() {
+	for {
+		select {
+		case fn := <-t.ch:
+			t.run(fn)
+		case <-t.done:
+			return
+		}
+	}
+}
+
+// run executes one telemetry closure with saferun's recover semantics (log +
+// observe a panic, never propagate it). It reuses saferun.Recover rather than
+// saferun.Go precisely so no new goroutine is spawned per task.
+func (t *telemetrySink) run(fn func()) {
+	defer saferun.Recover(t.logger, "telemetrySink")
+	if fn != nil {
+		fn()
+	}
+}
+
+// submit enqueues fn without ever blocking. It returns true when the work was
+// accepted, or false when the buffer was full — in which case the write is
+// dropped and the drop counter is incremented. The inference request path calls
+// this, so it must never block.
+func (t *telemetrySink) submit(fn func()) bool {
+	if t == nil || fn == nil {
+		return false
+	}
+	select {
+	case t.ch <- fn:
+		return true
+	default:
+		n := t.dropped.Add(1)
+		t.maybeLogDrop(n)
+		return false
+	}
+}
+
+// close signals the workers to stop and is idempotent. It never blocks on
+// in-flight telemetry writes: a stuck store call (the exact failure this sink
+// guards against) must not be able to stall coordinator shutdown. Workers return
+// on their next loop iteration once done is closed; any buffered-but-unrun
+// telemetry is best-effort and discarded.
+func (t *telemetrySink) close() {
+	if t == nil {
+		return
+	}
+	t.closeOnce.Do(func() {
+		close(t.done)
+	})
+}
+
+// droppedCount returns the cumulative number of dropped telemetry writes.
+func (t *telemetrySink) droppedCount() int64 {
+	if t == nil {
+		return 0
+	}
+	return t.dropped.Load()
+}
+
+// maybeLogDrop emits a throttled warning so operators notice sustained drops
+// without flooding logs: it logs only when the cumulative drop count crosses a
+// power of ten (1, 10, 100, 1000, …).
+func (t *telemetrySink) maybeLogDrop(total int64) {
+	if t.logger == nil || !isPowerOfTen(total) {
+		return
+	}
+	t.logger.Warn("routing telemetry sink dropping writes (buffer full) — inference is unaffected",
+		"dropped_total", total,
+		"capacity", cap(t.ch),
+	)
+}
+
+// isPowerOfTen reports whether n is 1, 10, 100, 1000, … It is the throttle key
+// for drop logging.
+func isPowerOfTen(n int64) bool {
+	if n < 1 {
+		return false
+	}
+	for n%10 == 0 {
+		n /= 10
+	}
+	return n == 1
+}

--- a/coordinator/api/telemetry_sink.go
+++ b/coordinator/api/telemetry_sink.go
@@ -126,14 +126,6 @@ func (t *telemetrySink) close() {
 	})
 }
 
-// droppedCount returns the cumulative number of dropped telemetry writes.
-func (t *telemetrySink) droppedCount() int64 {
-	if t == nil {
-		return 0
-	}
-	return t.dropped.Load()
-}
-
 // maybeLogDrop emits a throttled warning so operators notice sustained drops
 // without flooding logs: it logs only when the cumulative drop count crosses a
 // power of ten (1, 10, 100, 1000, …).

--- a/coordinator/cmd/coordinator/main.go
+++ b/coordinator/cmd/coordinator/main.go
@@ -160,6 +160,11 @@ func main() {
 	}
 
 	srv := api.NewServer(reg, st, cfg.ServerConfig, logger)
+	// Stop the routing-telemetry sink's worker pool on shutdown. Deferred so it
+	// runs after the HTTP server has drained (no in-flight request can still be
+	// submitting telemetry); Close is idempotent and never blocks on in-flight
+	// writes, so it cannot stall shutdown.
+	defer srv.Close()
 
 	// Per-account rate limiter on consumer (inference) endpoints. The default
 	// is intentionally generous (20 rps / burst 120) — the fleet token-budget

--- a/coordinator/cmd/coordinator/main.go
+++ b/coordinator/cmd/coordinator/main.go
@@ -510,11 +510,21 @@ func main() {
 
 	// HTTP server with graceful shutdown.
 	httpServer := &http.Server{
-		Addr:         ":" + cfg.ServerConfig.Port,
-		Handler:      srv.Handler(),
-		ReadTimeout:  10 * time.Second,
-		WriteTimeout: 0, // SSE streaming requires no write timeout
-		IdleTimeout:  120 * time.Second,
+		Addr:    ":" + cfg.ServerConfig.Port,
+		Handler: srv.Handler(),
+		// ReadHeaderTimeout bounds the request-header read phase independently of
+		// the body, closing the slow-header (Slowloris) DoS window: a client that
+		// trickles or never finishes its header block is dropped at 5s instead of
+		// tying up a connection/goroutine. Kept shorter than ReadTimeout so header
+		// hardening doesn't constrain legitimate (larger) request bodies.
+		ReadHeaderTimeout: 5 * time.Second,
+		ReadTimeout:       10 * time.Second,
+		WriteTimeout:      0, // SSE streaming requires no write timeout
+		IdleTimeout:       120 * time.Second,
+		// MaxHeaderBytes caps per-connection header memory at 64 KB (Go's default
+		// is 1 MB), bounding what an attacker can force the server to buffer for
+		// headers and rejecting abusive oversized-header requests early.
+		MaxHeaderBytes: 64 << 10,
 	}
 
 	// Start listening.

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -69,7 +69,11 @@ func BackendUsesSwiftRuntime(backend string) bool {
 
 // PendingRequest is a channel-based handle for an in-flight inference request.
 type PendingRequest struct {
-	RequestID  string
+	RequestID string
+	// Attempt is the zero-based dispatch attempt number that produced this
+	// pending request. It lets outcome telemetry correlate the final result
+	// with the routing decision record for the same attempt.
+	Attempt    int
 	ProviderID string
 	// Model is the CONCRETE build id used for routing, admission, billing, and
 	// warm-model matching (e.g. "mlx-community/gemma-4-26B-A4B-it-qat-4bit").

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -180,12 +180,44 @@ type PendingRequest struct {
 	reservationMu        sync.Mutex
 	reservationFinalized bool
 
-	// Timing fields for latency decomposition. Written and read only by the
-	// consumer/dispatch goroutine that owns the request — never shared. The
-	// reputation latency sample is therefore recorded from that goroutine at
-	// commit (see dispatch.writeCommittedResponse), never from the provider
-	// read-loop goroutine that runs handleComplete.
-	Timing *RequestTiming
+	// Timing fields for latency decomposition. Written and read by the
+	// consumer/dispatch goroutine that owns the request. The reputation latency
+	// sample is recorded from that goroutine at commit (see
+	// dispatch.writeCommittedResponse). The ONE field the provider read-loop
+	// goroutine (handleComplete) also needs — FirstChunkAt, for the routing
+	// telemetry decode-throughput metric — must be accessed via
+	// MarkFirstChunkArrived / FirstChunkAtSafe, which guard it with timingMu so
+	// that cross-goroutine access is race-free. All other Timing fields remain
+	// dispatch-goroutine-only.
+	Timing   *RequestTiming
+	timingMu sync.Mutex
+}
+
+// MarkFirstChunkArrived stamps Timing.FirstChunkAt to now exactly once, under
+// timingMu. The dispatch goroutine calls this when the first inference chunk
+// (incl. held boilerplate) arrives, so the provider read-loop goroutine can read
+// the value via FirstChunkAtSafe without a data race.
+func (pr *PendingRequest) MarkFirstChunkArrived() {
+	if pr == nil || pr.Timing == nil {
+		return
+	}
+	pr.timingMu.Lock()
+	if pr.Timing.FirstChunkAt.IsZero() {
+		pr.Timing.FirstChunkAt = time.Now()
+	}
+	pr.timingMu.Unlock()
+}
+
+// FirstChunkAtSafe returns Timing.FirstChunkAt under timingMu. It is the only
+// safe way for a goroutine other than the request owner (e.g. the provider
+// read-loop running handleComplete) to read FirstChunkAt.
+func (pr *PendingRequest) FirstChunkAtSafe() time.Time {
+	if pr == nil || pr.Timing == nil {
+		return time.Time{}
+	}
+	pr.timingMu.Lock()
+	defer pr.timingMu.Unlock()
+	return pr.Timing.FirstChunkAt
 }
 
 type TokenAdmission struct {

--- a/coordinator/store/interface.go
+++ b/coordinator/store/interface.go
@@ -110,6 +110,27 @@ type Store interface {
 	// plus the optional consumer-facing model name returned by usage history.
 	RecordUsageFullWithPublicModel(providerID, consumerKey, keyID, model, publicModel, requestID string, promptTokens, completionTokens int, costMicroUSD int64, requestLocation *ProviderLocation)
 
+	// RecordInferenceRoute writes the routing decision snapshot for a request
+	// attempt. Best-effort; failures must not block inference.
+	RecordInferenceRoute(record *InferenceRouteRecord) error
+
+	// UpdateInferenceRouteOutcome updates the attempt with final outcome data
+	// (tokens, timing, error). Best-effort; failures must not block inference.
+	UpdateInferenceRouteOutcome(requestID string, attempt int, outcome *InferenceRouteOutcome) error
+
+	// InferenceRouteRecords returns routing records created at or after the
+	// given time. Zero since returns all records.
+	InferenceRouteRecordsSince(since time.Time) []InferenceRouteRecord
+
+	// RecordRejection writes a rejected-request record (4xx/5xx) with its
+	// counterfactual servability snapshot. Best-effort; failures must not block
+	// the request path.
+	RecordRejection(record *RejectionRecord) error
+
+	// RejectionRecordsSince returns rejection records created at or after the
+	// given time. Zero since returns all records.
+	RejectionRecordsSince(since time.Time) []RejectionRecord
+
 	// RecordPayment records a settled payment between consumer and provider.
 	RecordPayment(txHash, consumerAddr, providerAddr, amountUSD, model string, promptTokens, completionTokens int, memo string) error
 
@@ -548,6 +569,154 @@ type UsageRecord struct {
 	RequestID        string            `json:"request_id,omitempty"`
 	CostMicroUSD     int64             `json:"cost_micro_usd,omitempty"`
 	CreatedAt        time.Time         `json:"created_at,omitempty"`
+}
+
+// InferenceRouteRecord captures a single routing decision and the provider
+// snapshot at the moment the scheduler made the choice. It contains no user
+// prompt or response content.
+type InferenceRouteRecord struct {
+	RequestID               string  `json:"request_id"`
+	Attempt                 int     `json:"attempt"`
+	ProviderID              string  `json:"provider_id"`
+	Model                   string  `json:"model"`
+	PublicModel             string  `json:"public_model"`
+	ConsumerKeyHash         string  `json:"consumer_key_hash"`
+	KeyID                   string  `json:"key_id"`
+	Outcome                 string  `json:"outcome"`
+	CostMs                  float64 `json:"cost_ms"`
+	StateMs                 float64 `json:"state_ms"`
+	QueueMs                 float64 `json:"queue_ms"`
+	PendingMs               float64 `json:"pending_ms"`
+	BacklogMs               float64 `json:"backlog_ms"`
+	ThisReqMs               float64 `json:"this_req_ms"`
+	HealthMs                float64 `json:"health_ms"`
+	TTFTMs                  float64 `json:"ttft_ms"`
+	BestTTFTMs              float64 `json:"best_ttft_ms"`
+	EffectiveQueue          int     `json:"effective_queue"`
+	CandidateCount          int     `json:"candidate_count"`
+	CapacityRejections      int     `json:"capacity_rejections"`
+	ModelTooLargeRejections int     `json:"model_too_large_rejections"`
+	VisionRejections        int     `json:"vision_rejections"`
+	TTFTRejections          int     `json:"ttft_rejections"`
+	EffectiveTPS            float64 `json:"effective_tps"`
+	StaticTPS               float64 `json:"static_tps"`
+
+	ProviderStatus        string  `json:"provider_status"`
+	ProviderTrustLevel    string  `json:"provider_trust_level"`
+	ProviderVersion       string  `json:"provider_version"`
+	HardwareChip          string  `json:"hardware_chip"`
+	HardwareChipFamily    string  `json:"hardware_chip_family"`
+	HardwareTier          string  `json:"hardware_tier"`
+	MemoryGB              int     `json:"memory_gb"`
+	GPUCores              int     `json:"gpu_cores"`
+	CPUCores              int     `json:"cpu_cores"`
+	SystemMemoryPressure  float64 `json:"system_memory_pressure"`
+	SystemCPUUsage        float64 `json:"system_cpu_usage"`
+	SystemThermalState    string  `json:"system_thermal_state"`
+	GPUMemoryActiveGB     float64 `json:"gpu_memory_active_gb"`
+	GPUMemoryPeakGB       float64 `json:"gpu_memory_peak_gb"`
+	GPUMemoryCacheGB      float64 `json:"gpu_memory_cache_gb"`
+	SlotState             string  `json:"slot_state"`
+	BackendRunning        int     `json:"backend_running"`
+	BackendWaiting        int     `json:"backend_waiting"`
+	ActiveTokenBudgetUsed int64   `json:"active_token_budget_used"`
+	ActiveTokenBudgetMax  int64   `json:"active_token_budget_max"`
+	QueuedTokenBudget     int64   `json:"queued_token_budget"`
+
+	EstimatedPromptTokens int    `json:"estimated_prompt_tokens"`
+	RequestedMaxTokens    int    `json:"requested_max_tokens"`
+	RequiresVision        bool   `json:"requires_vision"`
+	HasTools              bool   `json:"has_tools"`
+	SelfRouteOnly         bool   `json:"self_route_only"`
+	PreferOwner           bool   `json:"prefer_owner"`
+	CacheAffinityKey      string `json:"cache_affinity_key"`
+
+	// Geo (coarse region of provider/consumer; no raw IPs). Optional.
+	ProviderRegion string `json:"provider_region,omitempty"`
+	ConsumerRegion string `json:"consumer_region,omitempty"`
+
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+// InferenceRouteOutcome carries the final result of a routed request attempt.
+type InferenceRouteOutcome struct {
+	FinalStatus            string  `json:"final_status"`
+	ErrorCode              int     `json:"error_code"`
+	ErrorClass             string  `json:"error_class"`
+	PromptTokens           int     `json:"prompt_tokens"`
+	CompletionTokens       int     `json:"completion_tokens"`
+	ReasoningTokens        int     `json:"reasoning_tokens"`
+	CostMicroUSD           int64   `json:"cost_micro_usd"`
+	ActualTTFTMs           float64 `json:"actual_ttft_ms"`
+	DispatchToFirstChunkMs float64 `json:"dispatch_to_first_chunk_ms"`
+	TotalDurationMs        float64 `json:"total_duration_ms"`
+
+	// Coordinator-side latency decomposition (ms). Zero = not measured.
+	ParseMs     float64 `json:"parse_ms"`
+	ReserveMs   float64 `json:"reserve_ms"`
+	RouteMs     float64 `json:"route_ms"`
+	EncryptMs   float64 `json:"encrypt_ms"`
+	QueueWaitMs float64 `json:"queue_wait_ms"` // measured enqueue -> dispatch
+	DispatchMs  float64 `json:"dispatch_ms"`
+
+	// Measured decode throughput for the completed request (tokens/s).
+	ActualDecodeTPS float64 `json:"actual_decode_tps"`
+
+	// AdmittedButFailed is true when the coordinator admitted the request but the
+	// provider failed it (OOM / load failure) — the admission-gate mismatch.
+	AdmittedButFailed bool `json:"admitted_but_failed"`
+	// Speculative/backup-race dispatch outcome.
+	UsedBackup bool `json:"used_backup"`
+	BackupWon  bool `json:"backup_won"`
+}
+
+// RejectionRecord captures a single rejected inbound inference request (4xx/5xx)
+// at any stage of the pipeline, with the request's parameters and a
+// counterfactual servability snapshot ("could the fleet have served it?"). It
+// contains no prompt or response content.
+type RejectionRecord struct {
+	RequestID       string `json:"request_id,omitempty"`
+	Endpoint        string `json:"endpoint"`
+	Stage           string `json:"stage"`       // auth, validation, model_resolution, balance, rate_limit, preflight_capacity, routing_ttft
+	ReasonCode      string `json:"reason_code"` // e.g. model_not_found, machine_busy, insufficient_funds
+	HTTPStatus      int    `json:"http_status"`
+	ConsumerKeyHash string `json:"consumer_key_hash,omitempty"`
+	KeyID           string `json:"key_id,omitempty"`
+	ClientClass     string `json:"client_class,omitempty"` // e.g. openrouter, direct
+
+	// Request shape / params (non-private — no content).
+	RequestedModel        string          `json:"requested_model"` // raw, as the client sent it
+	ResolvedModel         string          `json:"resolved_model,omitempty"`
+	Stream                bool            `json:"stream"`
+	N                     int             `json:"n,omitempty"`
+	EstimatedPromptTokens int             `json:"estimated_prompt_tokens"`
+	RequestedMaxTokens    int             `json:"requested_max_tokens"`
+	RequiresVision        bool            `json:"requires_vision"`
+	HasImage              bool            `json:"has_image"`
+	HasAudio              bool            `json:"has_audio"`
+	HasTools              bool            `json:"has_tools"`
+	ToolCount             int             `json:"tool_count,omitempty"`
+	ResponseFormat        string          `json:"response_format,omitempty"`
+	SelfRouteOnly         bool            `json:"self_route_only"`
+	PreferOwner           bool            `json:"prefer_owner"`
+	Params                json.RawMessage `json:"params,omitempty"` // non-content knobs (temperature, top_p, …)
+	RequestBodyBytes      int             `json:"request_body_bytes,omitempty"`
+	RetryAfterMs          int             `json:"retry_after_ms,omitempty"`
+
+	// Counterfactual servability — "could it have produced output?"
+	CouldHaveServed         bool    `json:"could_have_served"`
+	CandidateCount          int     `json:"candidate_count"`
+	CapacityRejections      int     `json:"capacity_rejections"`
+	ModelTooLargeRejections int     `json:"model_too_large_rejections"`
+	VisionRejections        int     `json:"vision_rejections"`
+	WarmProviderExisted     bool    `json:"warm_provider_existed"`
+	BestTTFTMs              float64 `json:"best_ttft_ms,omitempty"`
+	ShortfallMicroUSD       int64   `json:"shortfall_micro_usd,omitempty"` // for 402
+	LimitKind               string  `json:"limit_kind,omitempty"`          // for 429 rate-limit
+	OverBy                  int64   `json:"over_by,omitempty"`
+
+	CreatedAt time.Time `json:"created_at"`
 }
 
 // UsageTotals aggregates the entire usage table.

--- a/coordinator/store/interface.go
+++ b/coordinator/store/interface.go
@@ -571,6 +571,13 @@ type UsageRecord struct {
 	CreatedAt        time.Time         `json:"created_at,omitempty"`
 }
 
+// maxTelemetryReadRows is the hard upper bound on rows returned by the routing
+// telemetry readers (InferenceRouteRecordsSince / RejectionRecordsSince). These
+// tables grow unbounded over time, so the readers always cap the result set
+// (newest-first) to keep an admin query — or a wide `since` window — from
+// loading the whole table into memory. Narrow the time window to see older rows.
+const maxTelemetryReadRows = 50000
+
 // InferenceRouteRecord captures a single routing decision and the provider
 // snapshot at the moment the scheduler made the choice. It contains no user
 // prompt or response content.

--- a/coordinator/store/memory.go
+++ b/coordinator/store/memory.go
@@ -857,6 +857,9 @@ func (s *MemoryStore) InferenceRouteRecordsSince(since time.Time) []InferenceRou
 			continue
 		}
 		out = append(out, r)
+		if len(out) >= maxTelemetryReadRows {
+			break
+		}
 	}
 	if out == nil {
 		return []InferenceRouteRecord{}
@@ -896,6 +899,9 @@ func (s *MemoryStore) RejectionRecordsSince(since time.Time) []RejectionRecord {
 			continue
 		}
 		out = append(out, r)
+		if len(out) >= maxTelemetryReadRows {
+			break
+		}
 	}
 	if out == nil {
 		return []RejectionRecord{}

--- a/coordinator/store/memory.go
+++ b/coordinator/store/memory.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -118,6 +119,14 @@ type MemoryStore struct {
 	// Provider sessions (connect→disconnect uptime history)
 	providerSessions   []ProviderSession
 	providerSessionSeq int64
+
+	// Inference routing telemetry
+	inferenceRoutes        []InferenceRouteRecord
+	inferenceRouteIndex    map[string]int // request_id/attempt -> index in inferenceRoutes
+	inferenceRouteOutcomes map[string]InferenceRouteOutcome
+
+	// Rejected inbound inference requests (4xx/5xx) with servability snapshot.
+	inferenceRejections []RejectionRecord
 }
 
 // NewMemory creates a new MemoryStore. If adminKey is non-empty it is
@@ -164,6 +173,10 @@ func NewMemory(scfg Config) *MemoryStore {
 		providerRecords:               make(map[string]*ProviderRecord),
 		reputationRecords:             make(map[string]*ReputationRecord),
 		serialToProviderID:            make(map[string]string),
+		inferenceRoutes:               make([]InferenceRouteRecord, 0),
+		inferenceRouteIndex:           make(map[string]int),
+		inferenceRouteOutcomes:        make(map[string]InferenceRouteOutcome),
+		inferenceRejections:           make([]RejectionRecord, 0),
 	}
 	if scfg.AdminKey != "" {
 		s.keyRecords[scfg.AdminKey] = &APIKey{
@@ -783,6 +796,111 @@ func (s *MemoryStore) RecordUsageFullWithPublicModel(providerID, consumerKey, ke
 	if keyID != "" && costMicroUSD > 0 {
 		s.addKeySpendLocked(keyID, costMicroUSD, now)
 	}
+}
+
+// RecordInferenceRoute writes the routing decision snapshot for a request
+// attempt. Best-effort; failures are discarded.
+func (s *MemoryStore) RecordInferenceRoute(record *InferenceRouteRecord) error {
+	if record == nil {
+		return nil
+	}
+
+	now := time.Now()
+	rec := *record
+	if rec.CreatedAt.IsZero() {
+		rec.CreatedAt = now
+	}
+	if rec.UpdatedAt.IsZero() {
+		rec.UpdatedAt = now
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.inferenceRoutes = append(s.inferenceRoutes, rec)
+	key := record.RequestID + "/" + strconv.Itoa(record.Attempt)
+	s.inferenceRouteIndex[key] = len(s.inferenceRoutes) - 1
+	return nil
+}
+
+// UpdateInferenceRouteOutcome updates the attempt with final outcome data.
+// Best-effort; failures are discarded.
+func (s *MemoryStore) UpdateInferenceRouteOutcome(requestID string, attempt int, outcome *InferenceRouteOutcome) error {
+	if outcome == nil {
+		return nil
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	key := requestID + "/" + strconv.Itoa(attempt)
+	idx, ok := s.inferenceRouteIndex[key]
+	if !ok {
+		return nil
+	}
+
+	s.inferenceRouteOutcomes[key] = *outcome
+	s.inferenceRoutes[idx].UpdatedAt = time.Now()
+	return nil
+}
+
+// InferenceRouteRecordsSince returns routing records created at or after the
+// given time. Zero since returns all records.
+func (s *MemoryStore) InferenceRouteRecordsSince(since time.Time) []InferenceRouteRecord {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	out := make([]InferenceRouteRecord, 0, len(s.inferenceRoutes))
+	for i := len(s.inferenceRoutes) - 1; i >= 0; i-- {
+		r := s.inferenceRoutes[i]
+		if !since.IsZero() && r.CreatedAt.Before(since) {
+			continue
+		}
+		out = append(out, r)
+	}
+	if out == nil {
+		return []InferenceRouteRecord{}
+	}
+	return out
+}
+
+// RecordRejection writes a rejected-request record with its counterfactual
+// servability snapshot. Best-effort; failures are discarded.
+func (s *MemoryStore) RecordRejection(record *RejectionRecord) error {
+	if record == nil {
+		return nil
+	}
+
+	rec := *record
+	if rec.CreatedAt.IsZero() {
+		rec.CreatedAt = time.Now()
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.inferenceRejections = append(s.inferenceRejections, rec)
+	return nil
+}
+
+// RejectionRecordsSince returns rejection records created at or after the
+// given time. Zero since returns all records.
+func (s *MemoryStore) RejectionRecordsSince(since time.Time) []RejectionRecord {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	out := make([]RejectionRecord, 0, len(s.inferenceRejections))
+	for i := len(s.inferenceRejections) - 1; i >= 0; i-- {
+		r := s.inferenceRejections[i]
+		if !since.IsZero() && r.CreatedAt.Before(since) {
+			continue
+		}
+		out = append(out, r)
+	}
+	if out == nil {
+		return []RejectionRecord{}
+	}
+	return out
 }
 
 // addKeySpendLocked increments the per-key spend accumulator. Caller holds s.mu.

--- a/coordinator/store/postgres.go
+++ b/coordinator/store/postgres.go
@@ -1533,8 +1533,8 @@ func (s *PostgresStore) InferenceRouteRecordsSince(since time.Time) []InferenceR
 	defer cancel()
 
 	rows, err := s.pool.Query(ctx,
-		`SELECT * FROM inference_routes WHERE created_at >= $1 ORDER BY created_at DESC`,
-		since)
+		`SELECT * FROM inference_routes WHERE created_at >= $1 ORDER BY created_at DESC LIMIT $2`,
+		since, maxTelemetryReadRows)
 	if err != nil {
 		return nil
 	}
@@ -1662,8 +1662,8 @@ func (s *PostgresStore) RejectionRecordsSince(since time.Time) []RejectionRecord
 	defer cancel()
 
 	rows, err := s.pool.Query(ctx,
-		`SELECT * FROM request_rejections WHERE created_at >= $1 ORDER BY created_at DESC`,
-		since)
+		`SELECT * FROM request_rejections WHERE created_at >= $1 ORDER BY created_at DESC LIMIT $2`,
+		since, maxTelemetryReadRows)
 	if err != nil {
 		return nil
 	}

--- a/coordinator/store/postgres.go
+++ b/coordinator/store/postgres.go
@@ -728,6 +728,161 @@ func (s *PostgresStore) migrate(ctx context.Context) error {
 		// Partial index over still-open sessions — speeds the online-now count and
 		// the startup reconcile. (session_id lookups use the UNIQUE index.)
 		`CREATE INDEX IF NOT EXISTS idx_provider_sessions_open ON provider_sessions(connected_at) WHERE disconnected_at IS NULL`,
+
+		// Inference routing telemetry — per-request scheduler decisions and outcomes.
+		// Contains no prompt or response content.
+		`CREATE TABLE IF NOT EXISTS inference_routes (
+			id BIGSERIAL PRIMARY KEY,
+			request_id TEXT NOT NULL,
+			attempt INTEGER NOT NULL DEFAULT 0,
+			provider_id TEXT NOT NULL DEFAULT '',
+			model TEXT NOT NULL,
+			public_model TEXT NOT NULL DEFAULT '',
+			consumer_key_hash TEXT NOT NULL DEFAULT '',
+			key_id TEXT NOT NULL DEFAULT '',
+			outcome TEXT NOT NULL DEFAULT '',
+			cost_ms DOUBLE PRECISION,
+			state_ms DOUBLE PRECISION,
+			queue_ms DOUBLE PRECISION,
+			pending_ms DOUBLE PRECISION,
+			backlog_ms DOUBLE PRECISION,
+			this_req_ms DOUBLE PRECISION,
+			health_ms DOUBLE PRECISION,
+			ttft_ms DOUBLE PRECISION,
+			best_ttft_ms DOUBLE PRECISION,
+			effective_queue INTEGER,
+			candidate_count INTEGER,
+			capacity_rejections INTEGER,
+			model_too_large_rejections INTEGER,
+			vision_rejections INTEGER,
+			ttft_rejections INTEGER,
+			effective_tps DOUBLE PRECISION,
+			static_tps DOUBLE PRECISION,
+			provider_status TEXT,
+			provider_trust_level TEXT,
+			provider_version TEXT,
+			hardware_chip TEXT,
+			hardware_chip_family TEXT,
+			hardware_tier TEXT,
+			memory_gb INTEGER,
+			gpu_cores INTEGER,
+			cpu_cores INTEGER,
+			system_memory_pressure DOUBLE PRECISION,
+			system_cpu_usage DOUBLE PRECISION,
+			system_thermal_state TEXT,
+			gpu_memory_active_gb DOUBLE PRECISION,
+			gpu_memory_peak_gb DOUBLE PRECISION,
+			gpu_memory_cache_gb DOUBLE PRECISION,
+			slot_state TEXT,
+			backend_running INTEGER,
+			backend_waiting INTEGER,
+			active_token_budget_used BIGINT,
+			active_token_budget_max BIGINT,
+			queued_token_budget BIGINT,
+			estimated_prompt_tokens INTEGER,
+			requested_max_tokens INTEGER,
+			requires_vision BOOLEAN NOT NULL DEFAULT FALSE,
+			has_tools BOOLEAN NOT NULL DEFAULT FALSE,
+			self_route_only BOOLEAN NOT NULL DEFAULT FALSE,
+			prefer_owner BOOLEAN NOT NULL DEFAULT FALSE,
+			cache_affinity_key TEXT NOT NULL DEFAULT '',
+			final_status TEXT NOT NULL DEFAULT '',
+			error_code INTEGER,
+			error_class TEXT,
+			prompt_tokens INTEGER,
+			completion_tokens INTEGER,
+			reasoning_tokens INTEGER,
+			cost_micro_usd BIGINT,
+			actual_ttft_ms DOUBLE PRECISION,
+			dispatch_to_first_chunk_ms DOUBLE PRECISION,
+			total_duration_ms DOUBLE PRECISION,
+			created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			provider_region TEXT,
+			consumer_region TEXT,
+			parse_ms DOUBLE PRECISION,
+			reserve_ms DOUBLE PRECISION,
+			route_ms DOUBLE PRECISION,
+			encrypt_ms DOUBLE PRECISION,
+			queue_wait_ms DOUBLE PRECISION,
+			dispatch_ms DOUBLE PRECISION,
+			actual_decode_tps DOUBLE PRECISION,
+			admitted_but_failed BOOL,
+			used_backup BOOL,
+			backup_won BOOL,
+			UNIQUE(request_id, attempt)
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_inference_routes_created ON inference_routes(created_at DESC)`,
+		`CREATE INDEX IF NOT EXISTS idx_inference_routes_provider ON inference_routes(provider_id, created_at DESC)`,
+		`CREATE INDEX IF NOT EXISTS idx_inference_routes_model ON inference_routes(model, created_at DESC)`,
+		`CREATE INDEX IF NOT EXISTS idx_inference_routes_request ON inference_routes(request_id)`,
+		// Phase 1 additions to inference_routes: coarse geo, coordinator-side
+		// latency decomposition, measured decode TPS, and admission/backup-race
+		// outcome flags. Added idempotently so a dev DB that already created the
+		// Phase 0 table picks them up. New columns are appended AFTER updated_at
+		// in the CREATE TABLE above so fresh and ALTER'd DBs share one column
+		// order (InferenceRouteRecordsSince scans `SELECT *` positionally).
+		`ALTER TABLE inference_routes ADD COLUMN IF NOT EXISTS provider_region TEXT`,
+		`ALTER TABLE inference_routes ADD COLUMN IF NOT EXISTS consumer_region TEXT`,
+		`ALTER TABLE inference_routes ADD COLUMN IF NOT EXISTS parse_ms DOUBLE PRECISION`,
+		`ALTER TABLE inference_routes ADD COLUMN IF NOT EXISTS reserve_ms DOUBLE PRECISION`,
+		`ALTER TABLE inference_routes ADD COLUMN IF NOT EXISTS route_ms DOUBLE PRECISION`,
+		`ALTER TABLE inference_routes ADD COLUMN IF NOT EXISTS encrypt_ms DOUBLE PRECISION`,
+		`ALTER TABLE inference_routes ADD COLUMN IF NOT EXISTS queue_wait_ms DOUBLE PRECISION`,
+		`ALTER TABLE inference_routes ADD COLUMN IF NOT EXISTS dispatch_ms DOUBLE PRECISION`,
+		`ALTER TABLE inference_routes ADD COLUMN IF NOT EXISTS actual_decode_tps DOUBLE PRECISION`,
+		`ALTER TABLE inference_routes ADD COLUMN IF NOT EXISTS admitted_but_failed BOOL`,
+		`ALTER TABLE inference_routes ADD COLUMN IF NOT EXISTS used_backup BOOL`,
+		`ALTER TABLE inference_routes ADD COLUMN IF NOT EXISTS backup_won BOOL`,
+
+		// Rejected inbound inference requests (4xx/5xx) at any pipeline stage,
+		// with the request shape and a counterfactual servability snapshot
+		// ("could the fleet have served it?"). Contains no prompt or response
+		// content.
+		`CREATE TABLE IF NOT EXISTS request_rejections (
+			id BIGSERIAL PRIMARY KEY,
+			request_id TEXT,
+			endpoint TEXT,
+			stage TEXT,
+			reason_code TEXT,
+			http_status INT,
+			consumer_key_hash TEXT,
+			key_id TEXT,
+			client_class TEXT,
+			requested_model TEXT,
+			resolved_model TEXT,
+			stream BOOL,
+			n INT,
+			estimated_prompt_tokens INT,
+			requested_max_tokens INT,
+			requires_vision BOOL,
+			has_image BOOL,
+			has_audio BOOL,
+			has_tools BOOL,
+			tool_count INT,
+			response_format TEXT,
+			self_route_only BOOL,
+			prefer_owner BOOL,
+			params JSONB,
+			request_body_bytes INT,
+			retry_after_ms INT,
+			could_have_served BOOL,
+			candidate_count INT,
+			capacity_rejections INT,
+			model_too_large_rejections INT,
+			vision_rejections INT,
+			warm_provider_existed BOOL,
+			best_ttft_ms DOUBLE PRECISION,
+			shortfall_micro_usd BIGINT,
+			limit_kind TEXT,
+			over_by BIGINT,
+			created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_request_rejections_created ON request_rejections(created_at DESC)`,
+		`CREATE INDEX IF NOT EXISTS idx_request_rejections_reason ON request_rejections(reason_code, created_at DESC)`,
+		`CREATE INDEX IF NOT EXISTS idx_request_rejections_model ON request_rejections(resolved_model, created_at DESC)`,
+		`CREATE INDEX IF NOT EXISTS idx_request_rejections_status ON request_rejections(http_status, created_at DESC)`,
+		`CREATE INDEX IF NOT EXISTS idx_request_rejections_servable ON request_rejections(could_have_served, created_at DESC) WHERE could_have_served = true`,
 	}
 
 	for _, m := range migrations {
@@ -743,6 +898,9 @@ func hashKey(key string) string {
 	h := sha256.Sum256([]byte(key))
 	return hex.EncodeToString(h[:])
 }
+
+// HashKey returns the SHA-256 hex digest of the given API key.
+func HashKey(key string) string { return hashKey(key) }
 
 // apiKeyColumns is the canonical SELECT list for reading an api_keys row into
 // an APIKey via scanAPIKeyRow.
@@ -1256,6 +1414,285 @@ func (s *PostgresStore) RecordUsageFullWithPublicModel(providerID, consumerKey, 
 		WHERE id = 1`,
 		providerID, h, keyID, model, publicModel, promptTokens, completionTokens, requestID, costMicroUSD, marshalProviderLocation(requestLocation),
 	)
+}
+
+// RecordInferenceRoute writes the routing decision snapshot for a request
+// attempt. Best-effort; failures are discarded and never block inference.
+func (s *PostgresStore) RecordInferenceRoute(record *InferenceRouteRecord) error {
+	if record == nil {
+		return nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	now := time.Now().UTC()
+	createdAt := record.CreatedAt
+	if createdAt.IsZero() {
+		createdAt = now
+	}
+	updatedAt := record.UpdatedAt
+	if updatedAt.IsZero() {
+		updatedAt = now
+	}
+
+	_, _ = s.pool.Exec(ctx,
+		`INSERT INTO inference_routes (
+			request_id, attempt, provider_id, model, public_model, consumer_key_hash, key_id, outcome,
+			cost_ms, state_ms, queue_ms, pending_ms, backlog_ms, this_req_ms, health_ms, ttft_ms, best_ttft_ms,
+			effective_queue, candidate_count, capacity_rejections, model_too_large_rejections, vision_rejections, ttft_rejections,
+			effective_tps, static_tps, provider_status, provider_trust_level, provider_version,
+			hardware_chip, hardware_chip_family, hardware_tier, memory_gb, gpu_cores, cpu_cores,
+			system_memory_pressure, system_cpu_usage, system_thermal_state,
+			gpu_memory_active_gb, gpu_memory_peak_gb, gpu_memory_cache_gb,
+			slot_state, backend_running, backend_waiting,
+			active_token_budget_used, active_token_budget_max, queued_token_budget,
+			estimated_prompt_tokens, requested_max_tokens,
+			requires_vision, has_tools, self_route_only, prefer_owner, cache_affinity_key,
+			created_at, updated_at,
+			provider_region, consumer_region
+		) VALUES (
+			$1, $2, $3, $4, $5, $6, $7, $8,
+			$9, $10, $11, $12, $13, $14, $15, $16, $17,
+			$18, $19, $20, $21, $22, $23,
+			$24, $25, $26, $27, $28,
+			$29, $30, $31, $32, $33, $34,
+			$35, $36, $37,
+			$38, $39, $40,
+			$41, $42, $43,
+			$44, $45, $46,
+			$47, $48,
+			$49, $50, $51, $52, $53,
+			$54, $55,
+			$56, $57
+		) ON CONFLICT (request_id, attempt) DO NOTHING`,
+		record.RequestID, record.Attempt, record.ProviderID, record.Model, record.PublicModel, record.ConsumerKeyHash, record.KeyID, record.Outcome,
+		record.CostMs, record.StateMs, record.QueueMs, record.PendingMs, record.BacklogMs, record.ThisReqMs, record.HealthMs, record.TTFTMs, record.BestTTFTMs,
+		record.EffectiveQueue, record.CandidateCount, record.CapacityRejections, record.ModelTooLargeRejections, record.VisionRejections, record.TTFTRejections,
+		record.EffectiveTPS, record.StaticTPS, record.ProviderStatus, record.ProviderTrustLevel, record.ProviderVersion,
+		record.HardwareChip, record.HardwareChipFamily, record.HardwareTier, record.MemoryGB, record.GPUCores, record.CPUCores,
+		record.SystemMemoryPressure, record.SystemCPUUsage, record.SystemThermalState,
+		record.GPUMemoryActiveGB, record.GPUMemoryPeakGB, record.GPUMemoryCacheGB,
+		record.SlotState, record.BackendRunning, record.BackendWaiting,
+		record.ActiveTokenBudgetUsed, record.ActiveTokenBudgetMax, record.QueuedTokenBudget,
+		record.EstimatedPromptTokens, record.RequestedMaxTokens,
+		record.RequiresVision, record.HasTools, record.SelfRouteOnly, record.PreferOwner, record.CacheAffinityKey,
+		createdAt, updatedAt,
+		record.ProviderRegion, record.ConsumerRegion,
+	)
+	return nil
+}
+
+// UpdateInferenceRouteOutcome updates the attempt with final outcome data
+// (tokens, timing, error). Best-effort; failures are discarded.
+func (s *PostgresStore) UpdateInferenceRouteOutcome(requestID string, attempt int, outcome *InferenceRouteOutcome) error {
+	if outcome == nil {
+		return nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, _ = s.pool.Exec(ctx,
+		`UPDATE inference_routes SET
+			final_status = $3,
+			error_code = $4,
+			error_class = $5,
+			prompt_tokens = $6,
+			completion_tokens = $7,
+			reasoning_tokens = $8,
+			cost_micro_usd = $9,
+			actual_ttft_ms = $10,
+			dispatch_to_first_chunk_ms = $11,
+			total_duration_ms = $12,
+			parse_ms = $13,
+			reserve_ms = $14,
+			route_ms = $15,
+			encrypt_ms = $16,
+			queue_wait_ms = $17,
+			dispatch_ms = $18,
+			actual_decode_tps = $19,
+			admitted_but_failed = $20,
+			used_backup = $21,
+			backup_won = $22,
+			updated_at = NOW()
+		 WHERE request_id = $1 AND attempt = $2`,
+		requestID, attempt,
+		outcome.FinalStatus, outcome.ErrorCode, outcome.ErrorClass, outcome.PromptTokens, outcome.CompletionTokens, outcome.ReasoningTokens,
+		outcome.CostMicroUSD, outcome.ActualTTFTMs, outcome.DispatchToFirstChunkMs, outcome.TotalDurationMs,
+		outcome.ParseMs, outcome.ReserveMs, outcome.RouteMs, outcome.EncryptMs, outcome.QueueWaitMs, outcome.DispatchMs, outcome.ActualDecodeTPS,
+		outcome.AdmittedButFailed, outcome.UsedBackup, outcome.BackupWon,
+	)
+	return nil
+}
+
+// InferenceRouteRecordsSince returns routing records created at or after the
+// given time. Zero since returns all records.
+func (s *PostgresStore) InferenceRouteRecordsSince(since time.Time) []InferenceRouteRecord {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	rows, err := s.pool.Query(ctx,
+		`SELECT * FROM inference_routes WHERE created_at >= $1 ORDER BY created_at DESC`,
+		since)
+	if err != nil {
+		return nil
+	}
+	defer rows.Close()
+
+	var records []InferenceRouteRecord
+	for rows.Next() {
+		var r InferenceRouteRecord
+		var id int64
+		var finalStatus string
+		var errorCode *int
+		var errorClass *string
+		var promptTokens *int
+		var completionTokens *int
+		var reasoningTokens *int
+		var costMicroUSD *int64
+		var actualTTFTMs *float64
+		var dispatchToFirstChunkMs *float64
+		var totalDurationMs *float64
+		// Region fields are real record fields; the remaining outcome-gap
+		// columns are scanned into throwaway locals (mirrors the existing
+		// outcome columns above, which the record type does not carry).
+		var providerRegion *string
+		var consumerRegion *string
+		var parseMs *float64
+		var reserveMs *float64
+		var routeMs *float64
+		var encryptMs *float64
+		var queueWaitMs *float64
+		var dispatchMs *float64
+		var actualDecodeTPS *float64
+		var admittedButFailed *bool
+		var usedBackup *bool
+		var backupWon *bool
+
+		if err := rows.Scan(
+			&id,
+			&r.RequestID, &r.Attempt, &r.ProviderID, &r.Model, &r.PublicModel, &r.ConsumerKeyHash, &r.KeyID, &r.Outcome,
+			&r.CostMs, &r.StateMs, &r.QueueMs, &r.PendingMs, &r.BacklogMs, &r.ThisReqMs, &r.HealthMs, &r.TTFTMs, &r.BestTTFTMs,
+			&r.EffectiveQueue, &r.CandidateCount, &r.CapacityRejections, &r.ModelTooLargeRejections, &r.VisionRejections, &r.TTFTRejections,
+			&r.EffectiveTPS, &r.StaticTPS, &r.ProviderStatus, &r.ProviderTrustLevel, &r.ProviderVersion,
+			&r.HardwareChip, &r.HardwareChipFamily, &r.HardwareTier, &r.MemoryGB, &r.GPUCores, &r.CPUCores,
+			&r.SystemMemoryPressure, &r.SystemCPUUsage, &r.SystemThermalState,
+			&r.GPUMemoryActiveGB, &r.GPUMemoryPeakGB, &r.GPUMemoryCacheGB,
+			&r.SlotState, &r.BackendRunning, &r.BackendWaiting,
+			&r.ActiveTokenBudgetUsed, &r.ActiveTokenBudgetMax, &r.QueuedTokenBudget,
+			&r.EstimatedPromptTokens, &r.RequestedMaxTokens,
+			&r.RequiresVision, &r.HasTools, &r.SelfRouteOnly, &r.PreferOwner, &r.CacheAffinityKey,
+			&finalStatus, &errorCode, &errorClass, &promptTokens, &completionTokens, &reasoningTokens, &costMicroUSD,
+			&actualTTFTMs, &dispatchToFirstChunkMs, &totalDurationMs,
+			&r.CreatedAt, &r.UpdatedAt,
+			&providerRegion, &consumerRegion,
+			&parseMs, &reserveMs, &routeMs, &encryptMs, &queueWaitMs, &dispatchMs, &actualDecodeTPS,
+			&admittedButFailed, &usedBackup, &backupWon,
+		); err != nil {
+			continue
+		}
+		if providerRegion != nil {
+			r.ProviderRegion = *providerRegion
+		}
+		if consumerRegion != nil {
+			r.ConsumerRegion = *consumerRegion
+		}
+		records = append(records, r)
+	}
+	return records
+}
+
+// RecordRejection writes a rejected-request record with its counterfactual
+// servability snapshot. Best-effort; failures are discarded and never block
+// the request path.
+func (s *PostgresStore) RecordRejection(record *RejectionRecord) error {
+	if record == nil {
+		return nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	createdAt := record.CreatedAt
+	if createdAt.IsZero() {
+		createdAt = time.Now().UTC()
+	}
+
+	// Mirror marshalProviderLocation's JSONB handling: pass nil (→ SQL NULL)
+	// when there are no params so we never write an invalid empty JSONB value.
+	var params json.RawMessage
+	if len(record.Params) > 0 {
+		params = record.Params
+	}
+
+	_, _ = s.pool.Exec(ctx,
+		`INSERT INTO request_rejections (
+			request_id, endpoint, stage, reason_code, http_status, consumer_key_hash, key_id, client_class,
+			requested_model, resolved_model, stream, n, estimated_prompt_tokens, requested_max_tokens,
+			requires_vision, has_image, has_audio, has_tools, tool_count, response_format, self_route_only, prefer_owner,
+			params, request_body_bytes, retry_after_ms,
+			could_have_served, candidate_count, capacity_rejections, model_too_large_rejections, vision_rejections,
+			warm_provider_existed, best_ttft_ms, shortfall_micro_usd, limit_kind, over_by,
+			created_at
+		) VALUES (
+			$1, $2, $3, $4, $5, $6, $7, $8,
+			$9, $10, $11, $12, $13, $14,
+			$15, $16, $17, $18, $19, $20, $21, $22,
+			$23, $24, $25,
+			$26, $27, $28, $29, $30,
+			$31, $32, $33, $34, $35,
+			$36
+		)`,
+		record.RequestID, record.Endpoint, record.Stage, record.ReasonCode, record.HTTPStatus, record.ConsumerKeyHash, record.KeyID, record.ClientClass,
+		record.RequestedModel, record.ResolvedModel, record.Stream, record.N, record.EstimatedPromptTokens, record.RequestedMaxTokens,
+		record.RequiresVision, record.HasImage, record.HasAudio, record.HasTools, record.ToolCount, record.ResponseFormat, record.SelfRouteOnly, record.PreferOwner,
+		params, record.RequestBodyBytes, record.RetryAfterMs,
+		record.CouldHaveServed, record.CandidateCount, record.CapacityRejections, record.ModelTooLargeRejections, record.VisionRejections,
+		record.WarmProviderExisted, record.BestTTFTMs, record.ShortfallMicroUSD, record.LimitKind, record.OverBy,
+		createdAt,
+	)
+	return nil
+}
+
+// RejectionRecordsSince returns rejection records created at or after the given
+// time. Zero since returns all records.
+func (s *PostgresStore) RejectionRecordsSince(since time.Time) []RejectionRecord {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	rows, err := s.pool.Query(ctx,
+		`SELECT * FROM request_rejections WHERE created_at >= $1 ORDER BY created_at DESC`,
+		since)
+	if err != nil {
+		return nil
+	}
+	defer rows.Close()
+
+	var records []RejectionRecord
+	for rows.Next() {
+		var r RejectionRecord
+		var id int64
+		var paramsRaw []byte
+
+		if err := rows.Scan(
+			&id,
+			&r.RequestID, &r.Endpoint, &r.Stage, &r.ReasonCode, &r.HTTPStatus, &r.ConsumerKeyHash, &r.KeyID, &r.ClientClass,
+			&r.RequestedModel, &r.ResolvedModel, &r.Stream, &r.N, &r.EstimatedPromptTokens, &r.RequestedMaxTokens,
+			&r.RequiresVision, &r.HasImage, &r.HasAudio, &r.HasTools, &r.ToolCount, &r.ResponseFormat, &r.SelfRouteOnly, &r.PreferOwner,
+			&paramsRaw, &r.RequestBodyBytes, &r.RetryAfterMs,
+			&r.CouldHaveServed, &r.CandidateCount, &r.CapacityRejections, &r.ModelTooLargeRejections, &r.VisionRejections,
+			&r.WarmProviderExisted, &r.BestTTFTMs, &r.ShortfallMicroUSD, &r.LimitKind, &r.OverBy,
+			&r.CreatedAt,
+		); err != nil {
+			continue
+		}
+		if len(paramsRaw) > 0 {
+			r.Params = paramsRaw
+		}
+		records = append(records, r)
+	}
+	return records
 }
 
 // UsageLocationBuckets aggregates usage by approximate request origin.

--- a/coordinator/store/postgres_test.go
+++ b/coordinator/store/postgres_test.go
@@ -51,6 +51,8 @@ func testPostgresStore(t *testing.T) *PostgresStore {
 		"providers",
 		"stripe_withdrawals",
 		"provider_sessions",
+		"inference_routes",
+		"request_rejections",
 	} {
 		if _, err := s.pool.Exec(ctx, "TRUNCATE "+table+" CASCADE"); err != nil {
 			t.Fatalf("truncate %s: %v", table, err)

--- a/coordinator/store/store_test.go
+++ b/coordinator/store/store_test.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 	"time"
@@ -751,5 +752,293 @@ func TestGetLatestReleasePrefersHigherSemverOverNewerTimestamp(t *testing.T) {
 	}
 	if latest.Version != "0.3.9" {
 		t.Fatalf("latest version = %q, want %q", latest.Version, "0.3.9")
+	}
+}
+
+func TestInferenceRoute_Memory(t *testing.T) {
+	s := NewMemory(Config{})
+	testInferenceRouteStore(t, s)
+}
+
+func TestInferenceRoute_Postgres(t *testing.T) {
+	s := testPostgresStore(t)
+	testInferenceRouteStore(t, s)
+}
+
+func testInferenceRouteStore(t *testing.T, s Store) {
+	t.Helper()
+
+	beforeRecord := time.Now().Add(-time.Minute)
+
+	rec := &InferenceRouteRecord{
+		RequestID:               "req-1",
+		Attempt:                 1,
+		ProviderID:              "prov-1",
+		Model:                   "mlx-community/Qwen3.5-9B-MLX-4bit",
+		PublicModel:             "qwen3.5-9b",
+		ConsumerKeyHash:         "abc123hash",
+		KeyID:                   "key_123",
+		Outcome:                 "routed",
+		CostMs:                  12.5,
+		StateMs:                 3.0,
+		QueueMs:                 1.5,
+		PendingMs:               0.5,
+		BacklogMs:               0.25,
+		ThisReqMs:               2.0,
+		HealthMs:                1.0,
+		TTFTMs:                  50.0,
+		BestTTFTMs:              40.0,
+		EffectiveQueue:          2,
+		CandidateCount:          4,
+		CapacityRejections:      1,
+		ModelTooLargeRejections: 0,
+		VisionRejections:        0,
+		TTFTRejections:          0,
+		EffectiveTPS:            45.2,
+		StaticTPS:               38.0,
+		ProviderStatus:          "idle",
+		ProviderTrustLevel:      "attested",
+		ProviderVersion:         "0.5.0",
+		HardwareChip:            "Apple M3 Max",
+		HardwareChipFamily:      "M3",
+		HardwareTier:            "high",
+		MemoryGB:                128,
+		GPUCores:                40,
+		CPUCores:                16,
+		SystemMemoryPressure:    0.2,
+		SystemCPUUsage:          0.15,
+		SystemThermalState:      "Nominal",
+		GPUMemoryActiveGB:       8.5,
+		GPUMemoryPeakGB:         12.0,
+		GPUMemoryCacheGB:        2.0,
+		SlotState:               "idle",
+		BackendRunning:          1,
+		BackendWaiting:          0,
+		ActiveTokenBudgetUsed:   1000,
+		ActiveTokenBudgetMax:    4096,
+		QueuedTokenBudget:       0,
+		EstimatedPromptTokens:   500,
+		RequestedMaxTokens:      1024,
+		RequiresVision:          true,
+		HasTools:                false,
+		SelfRouteOnly:           false,
+		PreferOwner:             true,
+		CacheAffinityKey:        "owner-123",
+	}
+
+	if err := s.RecordInferenceRoute(rec); err != nil {
+		t.Fatalf("RecordInferenceRoute: %v", err)
+	}
+
+	// Lookup by request_id via zero-time since returns all records.
+	all := s.InferenceRouteRecordsSince(time.Time{})
+	if len(all) != 1 {
+		t.Fatalf("InferenceRouteRecordsSince(zero) = %d records, want 1", len(all))
+	}
+	got := all[0]
+	if got.RequestID != "req-1" || got.Attempt != 1 || got.ProviderID != "prov-1" {
+		t.Errorf("record mismatch: got request_id=%q attempt=%d provider_id=%q", got.RequestID, got.Attempt, got.ProviderID)
+	}
+	if got.Model != rec.Model || got.PublicModel != rec.PublicModel {
+		t.Errorf("model/public_model mismatch: got %q/%q want %q/%q", got.Model, got.PublicModel, rec.Model, rec.PublicModel)
+	}
+	if got.Outcome != "routed" {
+		t.Errorf("outcome = %q, want routed", got.Outcome)
+	}
+	if got.CostMs != 12.5 {
+		t.Errorf("cost_ms = %f, want 12.5", got.CostMs)
+	}
+	if got.CreatedAt.IsZero() || got.UpdatedAt.IsZero() {
+		t.Error("created_at and updated_at should be set")
+	}
+	if !got.CreatedAt.After(beforeRecord) {
+		t.Error("created_at should be after beforeRecord")
+	}
+
+	// RecordsSince filters out older records.
+	old := s.InferenceRouteRecordsSince(time.Now().Add(time.Hour))
+	if len(old) != 0 {
+		t.Fatalf("InferenceRouteRecordsSince(future) = %d records, want 0", len(old))
+	}
+
+	// Update outcome.
+	beforeUpdate := time.Now()
+	outcome := &InferenceRouteOutcome{
+		FinalStatus:            "success",
+		ErrorCode:              0,
+		ErrorClass:             "",
+		PromptTokens:           50,
+		CompletionTokens:       100,
+		ReasoningTokens:        10,
+		CostMicroUSD:           2500,
+		ActualTTFTMs:           150.0,
+		DispatchToFirstChunkMs: 180.0,
+		TotalDurationMs:        1200.0,
+	}
+	if err := s.UpdateInferenceRouteOutcome("req-1", 1, outcome); err != nil {
+		t.Fatalf("UpdateInferenceRouteOutcome: %v", err)
+	}
+
+	all = s.InferenceRouteRecordsSince(time.Time{})
+	if len(all) != 1 {
+		t.Fatalf("after update: expected 1 record, got %d", len(all))
+	}
+	if all[0].UpdatedAt.IsZero() {
+		t.Error("updated_at should not be zero after update")
+	}
+	if !all[0].UpdatedAt.After(beforeUpdate) {
+		// Allow a small amount of clock skew between process and DB for Postgres.
+		if all[0].UpdatedAt.Sub(beforeUpdate) < -time.Second {
+			t.Errorf("updated_at should be after beforeUpdate, got %v (beforeUpdate %v)", all[0].UpdatedAt, beforeUpdate)
+		}
+	}
+
+	// Record a second attempt for the same request and verify lookup by request_id.
+	rec2 := &InferenceRouteRecord{
+		RequestID:  "req-1",
+		Attempt:    2,
+		ProviderID: "prov-2",
+		Model:      rec.Model,
+		Outcome:    "fallback",
+	}
+	if err := s.RecordInferenceRoute(rec2); err != nil {
+		t.Fatalf("RecordInferenceRoute attempt 2: %v", err)
+	}
+
+	all = s.InferenceRouteRecordsSince(time.Time{})
+	if len(all) != 2 {
+		t.Fatalf("expected 2 records, got %d", len(all))
+	}
+
+	// Records should be newest-first (by created_at).
+	if all[0].Attempt != 2 {
+		t.Errorf("first record attempt = %d, want 2", all[0].Attempt)
+	}
+	if all[1].Attempt != 1 {
+		t.Errorf("second record attempt = %d, want 1", all[1].Attempt)
+	}
+
+	// Updating a non-existent attempt is best-effort and returns no error.
+	if err := s.UpdateInferenceRouteOutcome("req-missing", 99, outcome); err != nil {
+		t.Errorf("UpdateInferenceRouteOutcome missing record: %v", err)
+	}
+}
+
+func TestRejection_Memory(t *testing.T) {
+	s := NewMemory(Config{})
+	testRejectionStore(t, s)
+}
+
+func TestRejection_Postgres(t *testing.T) {
+	s := testPostgresStore(t)
+	testRejectionStore(t, s)
+}
+
+func testRejectionStore(t *testing.T, s Store) {
+	t.Helper()
+
+	beforeRecord := time.Now().Add(-time.Minute)
+
+	rec := &RejectionRecord{
+		RequestID:               "req-rej-1",
+		Endpoint:                "/v1/chat/completions",
+		Stage:                   "preflight_capacity",
+		ReasonCode:              "machine_busy",
+		HTTPStatus:              429,
+		ConsumerKeyHash:         "abc123hash",
+		KeyID:                   "key_123",
+		ClientClass:             "openrouter",
+		RequestedModel:          "mlx-community/Qwen3.5-9B-MLX-4bit",
+		ResolvedModel:           "qwen3.5-9b",
+		Stream:                  true,
+		N:                       1,
+		EstimatedPromptTokens:   500,
+		RequestedMaxTokens:      1024,
+		RequiresVision:          true,
+		HasImage:                true,
+		HasAudio:                false,
+		HasTools:                false,
+		ToolCount:               0,
+		ResponseFormat:          "json_object",
+		SelfRouteOnly:           false,
+		PreferOwner:             true,
+		Params:                  json.RawMessage(`{"temperature":0.7}`),
+		RequestBodyBytes:        2048,
+		RetryAfterMs:            1500,
+		CouldHaveServed:         true,
+		CandidateCount:          4,
+		CapacityRejections:      3,
+		ModelTooLargeRejections: 1,
+		VisionRejections:        0,
+		WarmProviderExisted:     true,
+		BestTTFTMs:              42.5,
+		ShortfallMicroUSD:       0,
+		LimitKind:               "itpm",
+		OverBy:                  120,
+	}
+
+	if err := s.RecordRejection(rec); err != nil {
+		t.Fatalf("RecordRejection: %v", err)
+	}
+
+	// Zero-time since returns all records.
+	all := s.RejectionRecordsSince(time.Time{})
+	if len(all) != 1 {
+		t.Fatalf("RejectionRecordsSince(zero) = %d records, want 1", len(all))
+	}
+	got := all[0]
+	if got.Stage != "preflight_capacity" {
+		t.Errorf("stage = %q, want preflight_capacity", got.Stage)
+	}
+	if got.ReasonCode != "machine_busy" {
+		t.Errorf("reason_code = %q, want machine_busy", got.ReasonCode)
+	}
+	if got.HTTPStatus != 429 {
+		t.Errorf("http_status = %d, want 429", got.HTTPStatus)
+	}
+	if got.RequestedModel != rec.RequestedModel {
+		t.Errorf("requested_model = %q, want %q", got.RequestedModel, rec.RequestedModel)
+	}
+	if !got.CouldHaveServed {
+		t.Error("could_have_served = false, want true")
+	}
+	if got.CandidateCount != 4 {
+		t.Errorf("candidate_count = %d, want 4", got.CandidateCount)
+	}
+	if got.CreatedAt.IsZero() {
+		t.Error("created_at should be set")
+	}
+	if !got.CreatedAt.After(beforeRecord) {
+		t.Error("created_at should be after beforeRecord")
+	}
+
+	// RecordsSince filters out older records.
+	old := s.RejectionRecordsSince(time.Now().Add(time.Hour))
+	if len(old) != 0 {
+		t.Fatalf("RejectionRecordsSince(future) = %d records, want 0", len(old))
+	}
+
+	// A second rejection at a different stage; records are newest-first.
+	rec2 := &RejectionRecord{
+		RequestID:      "req-rej-2",
+		Endpoint:       "/v1/chat/completions",
+		Stage:          "model_resolution",
+		ReasonCode:     "model_not_found",
+		HTTPStatus:     404,
+		RequestedModel: "no-such-model",
+	}
+	if err := s.RecordRejection(rec2); err != nil {
+		t.Fatalf("RecordRejection attempt 2: %v", err)
+	}
+
+	all = s.RejectionRecordsSince(time.Time{})
+	if len(all) != 2 {
+		t.Fatalf("expected 2 records, got %d", len(all))
+	}
+	if all[0].RequestID != "req-rej-2" {
+		t.Errorf("first record request_id = %q, want req-rej-2 (newest-first)", all[0].RequestID)
+	}
+	if all[1].RequestID != "req-rej-1" {
+		t.Errorf("second record request_id = %q, want req-rej-1", all[1].RequestID)
 	}
 }

--- a/docs/architecture/routing-telemetry-and-calibration.md
+++ b/docs/architecture/routing-telemetry-and-calibration.md
@@ -1,0 +1,458 @@
+# Routing Telemetry & Algorithm Calibration
+
+**Status:** Plan / design (branch `feat/inference-routing-telemetry`)
+**Scope:** Coordinator only. No provider-swift or console-ui changes required for data collection. No prompt/response content is ever stored.
+
+## 1. Why we are doing this
+
+The router's scheduler (`coordinator/registry/scheduler.go`) is a **hand-tuned cost
+model**. Every weight in it was calibrated *once*, on *one machine*
+(M4 Max) against **Qwen2.5-7B-4bit — a model we do not even serve** (see the
+`scheduler.go:42,57` comments) — and then frozen as a constant. Our actual fleet
+serves **`gpt-oss-20b`** (min_ram_gb 24) and **`gemma-4-26b`** (alias →
+`mlx-community/gemma-4-26B-A4B-it-qat-4bit`, min_ram_gb 36) — a 20B and a 26B,
+both far larger than the 7B the constants were tuned on. Examples straight from
+the code:
+
+- `queueDepthPenaltyMs = 3000`, `totalPendingPenaltyMs = 750`
+- `effectiveTPSLoadFactor = 0.27` (per-request TPS decay under batch)
+- `kvCacheBytesPerToken = 400000` (KV footprint for the admission gate)
+- health penalties: `memoryPressure×4000 + cpuUsage×1500 + gpuUtil×5000 + thermal(fair 2000 / serious 8000)`
+- cold-load penalty `slotStatePenaltyUnknown = 30000`, `idle_shutdown = 20000`
+- decode-TPS fallback chain `observed EWMA → fleet median → sqrt(memBandwidth)`
+- prefill-TPS fallback `decodeTPS × 4.0`
+
+These numbers decide which machine every request lands on, yet **we have no
+measured feedback telling us whether they are right** for `gpt-oss-20b` or
+`gemma-4-26b` on the hardware tiers we actually run (M-series Macs of varying
+chip/memory), or for a thermally-throttled laptop. The constants were tuned on a
+7B model on one M4 Max; we serve a 20B and a 26B across a heterogeneous fleet. We
+are flying blind. **The concrete calibration grid is therefore small and
+tractable: 2 models × the handful of chip/memory tiers in the fleet.**
+
+The goal of this work is to **record every input the scheduler saw, the decision
+it made, and what actually happened**, so we can:
+
+1. **Explain any single routing decision** — "why did request X go to machine Y,
+   what were Y's numbers, and what were the runners-up?"
+2. **Calibrate the cost model from real data** — replace frozen global constants
+   with measured, per-(hardware-tier, model) values.
+3. **Detect mismatches** — where the model's prediction diverged from reality
+   (predicted-fast-but-slow, admitted-but-OOM'd, TTFT-ceiling false rejects).
+4. **Account for every "no"** — record every 4xx we return, the parameters that
+   triggered it, and **whether the fleet could actually have served it**. The
+   point is to find requests we reject that *should* have produced output (false
+   429s, unknown-model demand, balance/limit friction) — see §4.9.
+
+Everything here is **non-private operational metadata**. Privacy invariants in §8.
+
+---
+
+## 2. The current algorithm (ground truth we are measuring against)
+
+For each request the scheduler scores every eligible provider and picks the
+lowest cost. **Lower cost = better.** From `buildCandidateWithReason`:
+
+```
+cost = statePenalty       // slot warmth: running/idle=0, idle_shutdown=20000, cold-load=30000
+     + queueMs            // effectiveQueue × 3000
+     + pendingMs          // totalPending × 750
+     + backlogMs          // tokensAhead / effectiveTPS × 1000
+     + thisReqMs          // prompt/prefillTPS×1000 + maxTokens/effectiveTPS×1000
+     + healthMs           // memPressure×4000 + cpu×1500 + gpuUtil×5000 + thermal
+```
+
+with:
+
+- `effectiveQueue = max(pendingForModel, backendRunning + backendWaiting)`
+- `effectiveTPS = observedEWMA → fleetMedian → staticTPS/(1 + 0.27×batchSize)`
+- `tokensAhead = activeTokenBudgetUsed + queuedTokenBudget` (token-budget providers)
+
+**Selection** then: take the min-cost candidate, build a **near-tie pool**
+(within `nearTieCostWindowMs = 3000`), tie-break by `effectiveQueue`, then
+`totalPending`, then random; a `cacheAffinityBonusMs` can pull a sticky provider
+in; `PreferOwner` filters to owned machines; `AvoidVersion` filters the retry
+pool.
+
+**Gates** run *before* cost (any failure drops the candidate):
+status / trust / slot-state / thermal-critical / trait gates → vision gate →
+hardware-fit gate (`modelFitsHardware`, prefers catalog `min_ram_gb`, else
+`weightGB × 2.0`) → free-memory admission gate (`freeMemoryAdmits`, uses
+`kvCacheBytesPerToken`).
+
+**Known structural mismatch:** the coordinator's `freeMemoryAdmits` is *less*
+conservative than the provider's own `ensureModelLoaded` (which demands
+`estimatedMemoryGb × 3.0` headroom). So the coordinator can admit a request the
+provider then refuses/OOMs. We currently cannot measure how often this happens.
+
+Every constant and fallback above is a **calibration target**. The data model in
+§4 is designed so each one has a column (or derived metric) that tells us whether
+it is right.
+
+---
+
+## 3. Data architecture
+
+Four tables, written best-effort and async so they never add request latency.
+
+| Table | Grain | Purpose |
+|-------|-------|---------|
+| `inference_routes` | one row per **request attempt** (the winner + outcome) | Explain the chosen machine; predicted-vs-actual; retry chains. **(Phase 0 — already built.)** |
+| `request_rejections` | one row per **rejected inbound request** (4xx/5xx, at any stage) | The **"what are we saying no to"** ledger — captures rejections that never reach routing (auth, validation, balance, rate-limit, pre-flight), each with a counterfactual *could-we-have-served-it* snapshot. **(Phase 1 — the new ask.)** |
+| `inference_route_candidates` | one row per **(attempt × candidate provider considered)** | The per-candidate scores — *why the winner won and the losers lost*. **(Phase 2.)** |
+| `provider_capacity_samples` | one row per **provider heartbeat snapshot** (sampled) | Time-series of fleet state independent of requests; calibrate TPS/health decay. **(Phase 3 — optional but high value.)** |
+
+A key realization: `inference_routes` only sees requests that **reached routing**.
+Most 4xx (auth, validation, unknown-model, balance, rate-limit, pre-flight 429)
+are returned *earlier* and are invisible today. `request_rejections` closes that
+hole and is the answer to "what are we saying no to, and what could have actually
+resulted in an output?"
+
+`inference_routes.id` is the parent key for `inference_route_candidates`.
+`(request_id, attempt)` correlates everything for one dispatch.
+
+### 3.1 Where it's stored & how the data flows
+
+```
+ inference request                       admin / analyst
+        │                                       ▲
+        ▼                                       │ read
+┌───────────────────┐   write (async,    ┌──────┴───────────────┐
+│ coordinator        │   best-effort)     │  GET /v1/admin/routes │  JSON (filtered)
+│  • dispatch.go     ├───────────────────▶│  GET /v1/admin/...    │  + CSV/NDJSON export
+│  • recordRejection │   store.Store iface │      /export          │  (download)
+└───────────────────┘        │            └──────────────────────┘
+                             ▼
+                    ┌──────────────────┐
+                    │ PostgresStore     │  inference_routes
+                    │ (store/postgres)  │  request_rejections
+                    └──────────────────┘  inference_route_candidates …
+```
+
+- **Write side:** the coordinator already holds every datum in memory at decision
+  time (`Provider`, `RoutingDecision`, `pr.Timing`, the request struct). We write
+  it through the existing `store.Store` interface — `dispatch.go` for routes,
+  `handleComplete` for outcomes, a new `recordRejection(...)` helper for 4xx.
+  All writes are `saferun.Go` async + timed-out, so a DB hiccup never touches the
+  request path.
+- **Storage backend — the prerequisite:** the store is chosen at boot in
+  `cmd/coordinator/main.go:83-108` by **`EIGENINFERENCE_DATABASE_URL`**:
+  - set → **PostgresStore** (durable; what we want).
+  - unset → in-memory store, and the process **refuses to start** unless
+    `EIGENINFERENCE_ALLOW_MEMORY_STORE=true`. In-memory means the data is **lost
+    on every restart/deploy and is not queryable** (`docs/operations/dev-environment.md:208`).
+  - **Therefore: this telemetry is only useful where Postgres is enabled.** Dev
+    already wires Cloud SQL (`dev-environment.md:153`). Prod (EigenCloud) must have
+    `EIGENINFERENCE_DATABASE_URL` set — confirm before relying on the data. This is
+    the single gating dependency for the whole effort.
+- **Read side:** admin-authed HTTP — a filtered JSON view *and* a streaming
+  **CSV/NDJSON download** for offline analysis (spreadsheet / notebook / DuckDB).
+  Details in §6.
+
+---
+
+## 4. Every data point — and what each one is *for*
+
+This is the core of the plan. Each datum is tagged with the algorithm question or
+constant it lets us answer/calibrate. **Bold = not yet captured (gap to add).**
+
+### 4.1 Identity & correlation (`inference_routes`)
+| Field | Why we collect it |
+|-------|-------------------|
+| `request_id`, `attempt` | Correlate decision → outcome → candidates; reconstruct retry chains across machines. |
+| `provider_id` | The machine that won (empty if none). |
+| `model`, `public_model` | Per-model calibration; alias-vs-build analysis. |
+| `consumer_key_hash`, `key_id` | Per-tenant load patterns, abuse/hot-key detection. Hashed, never raw. |
+
+### 4.2 The decision & its scoring (the winner's cost terms)
+All already in `inference_routes`. These are the **predicted** numbers.
+| Field | Calibrates / answers |
+|-------|----------------------|
+| `outcome` (`selected`/`queued`/`no_provider`/`model_too_large`/`ttft_429`/`error`) | Decision-class distribution; how often we reject vs route vs queue. |
+| `cost_ms` (total) + `state_ms`,`queue_ms`,`pending_ms`,`backlog_ms`,`this_req_ms`,`health_ms` | The exact cost decomposition of the winner. Lets us see which term dominated the choice. |
+| `ttft_ms`, `best_ttft_ms` | Predicted TTFT of winner + best available; validate vs `actual_ttft_ms`; Retry-After accuracy. |
+| `effective_tps`, `static_tps` | The TPS the model *assumed*; compare to measured decode TPS → calibrate `effectiveTPSLoadFactor` and the fallback chain. |
+| `effective_queue`, `candidate_count` | Load spread; how many real options existed. |
+| `capacity_rejections`, `model_too_large_rejections`, `vision_rejections`, `ttft_rejections` | The aggregate "mismatch" — why candidates were dropped. Drives capacity planning + ceiling tuning. |
+
+### 4.3 The winner's hardware/runtime snapshot (the machine's numbers)
+All already in `inference_routes`. These are the **inputs** the cost used.
+| Field | Calibrates / answers |
+|-------|----------------------|
+| `provider_status`, `provider_trust_level`, `provider_version` | Does trust/version correlate with failures? Per-version regression detection. |
+| `hardware_chip`, `hardware_chip_family`, `hardware_tier`, `memory_gb`, `gpu_cores`, `cpu_cores` | **The grouping key for all calibration.** TPS, load-factor `k`, and headroom must become per-tier, not global. |
+| `system_memory_pressure`, `system_cpu_usage`, `system_thermal_state` | Validate the health penalties (`×4000`, `×1500`, thermal) — do they actually predict slowdown? |
+| `gpu_memory_active_gb`, `gpu_memory_peak_gb`, `gpu_memory_cache_gb` | Validate the `gpuUtil×5000` penalty and the memory-admission gate. |
+| `slot_state` | Validate `statePenalty` (cold-load 30000 / idle_shutdown 20000). |
+| `backend_running`, `backend_waiting` | Batch size at decision time → the x-axis for the TPS-decay curve. |
+| `active_token_budget_used`, `active_token_budget_max`, `queued_token_budget` | Validate `backlogMs`; calibrate token-budget admission. |
+
+### 4.4 Request shape (`inference_routes`)
+| Field | Calibrates / answers |
+|-------|----------------------|
+| `estimated_prompt_tokens`, `requested_max_tokens` | Inputs to `thisReqMs`/`backlogMs`; compare estimate vs actual `prompt_tokens`. |
+| `requires_vision`, `has_tools`, `self_route_only`, `prefer_owner` | Per-shape routing behaviour; vision/tools capacity. |
+| `cache_affinity_key` | Measure cache-affinity bonus efficacy (hit → faster?). |
+
+### 4.5 The outcome (what actually happened) — `inference_routes`
+| Field | Calibrates / answers |
+|-------|----------------------|
+| `final_status` (`success`/`error`/`timeout`/`cancelled`) | Reliability per machine/model/version. |
+| `error_code`, `error_class` (`client_gone`,`queue_timeout`,`insufficient_funds`,`provider_error`,`encryption_missing`,`first_chunk_timeout`,`accepted_timeout`,`preamble_liveness_timeout`) | Failure taxonomy; which failure modes dominate. |
+| `prompt_tokens`, `completion_tokens`, `reasoning_tokens`, `cost_micro_usd` | Actual work done; estimate accuracy; cost-per-token by tier. |
+| `actual_ttft_ms`, `dispatch_to_first_chunk_ms`, `total_duration_ms` | **The ground truth.** `actual_ttft_ms − ttft_ms` = TTFT prediction error. `total_duration_ms` vs predicted `cost_ms` = cost-model error. |
+
+### 4.6 Gaps to ADD to `inference_routes` (Phase 1)
+| **New field** | Why it matters |
+|-----------|----------------|
+| **`parse_ms`, `reserve_ms`, `route_ms`, `encrypt_ms`, `queue_wait_ms`, `dispatch_ms`** | The `X-Timing` decomposition is computed per request and returned in a header but **thrown away**. This is our coordinator-side overhead budget — needed to separate "our latency" from "provider latency". Cheap: already on `pr.Timing`. |
+| **`actual_queue_wait_ms`** | We store the queue *penalty estimate* (`queue_ms`) but not the *measured* wait (`EnqueuedAt → dispatch`). Without it we cannot validate the queue penalty. |
+| **`actual_decode_tps`** | Measured decode TPS for the completed request (`completion_tokens / decode_time`). The single most important calibration signal vs `effective_tps`. |
+| **`used_backup`, `backup_won`** | Speculative/backup-race dispatch happens (`raceBackupErrWaitPrimary`) but its win/loss is invisible. Tells us if speculation helps. |
+| **`provider_region`, `consumer_region`** | "Closest machine" reasoning; geo-aware routing later. (Provider geo from registry; consumer geo already GeoIP-bucketed for usage.) |
+| **`admitted_but_failed`** (bool) + `provider_reported_free_gb` | Detect the coordinator-admits / provider-OOMs mismatch (§2). Calibrates `kvCacheBytesPerToken` and the 2.0-vs-3.0 headroom gap. |
+| **`prefix_cache_hit`, `prefix_cache_hit_tokens`** | Whether the provider actually reused KV/prefix cache. Validates cache-affinity routing. (Requires one new optional field on the provider `complete` message — only protocol touch in the whole plan, and it's additive.) |
+| **`is_final_attempt`, `total_attempts`** | Make retry chains queryable without window functions. |
+
+### 4.7 Per-candidate scores — `inference_route_candidates` (Phase 2, the new ask)
+One row per provider the scheduler *considered* for an attempt. This is what lets
+us answer "why this machine and not that one," and run **counterfactual /
+regret** analysis.
+
+| Field | Why |
+|-------|-----|
+| `route_id` (FK → `inference_routes.id`), `request_id`, `attempt` | Link to the parent decision. |
+| `provider_id`, `rank` (0 = winner) | Identify each candidate and its finishing position. |
+| `selected` (bool) | Was this the winner? |
+| `eligible` (bool), `rejection_reason` (`capacity`/`model_too_large`/`vision`/`ttft`/`thermal`/`trust`/`slot_state`/`none`) | **Why a candidate lost before scoring** — the per-machine mismatch. |
+| `cost_ms` + full breakdown (`state_ms`,`queue_ms`,`pending_ms`,`backlog_ms`,`this_req_ms`,`health_ms`,`ttft_ms`) | The loser's score, term by term. "A won at 1.2s, B was 1.35s (its `backlog_ms` was 2× higher)." |
+| `effective_queue`, `effective_tps`, `static_tps`, `batch_size` | The loser's live state — needed to know if the model *correctly* ranked it. |
+| hardware snapshot (`chip_family`, `tier`, `memory_gb`, `slot_state`, mem pressure, thermal, gpu active) | Compare winner vs loser hardware; detect "we picked a worse machine." |
+| `cache_affinity_applied` (bool), `affinity_bonus_ms` | Did affinity change the ranking? |
+
+**Counterfactual value:** once we have outcomes *and* candidates, we can ask: when
+the winner was slow/failed, **would the runner-up have been faster?** If the #2
+candidate consistently beats the #1 we picked, the cost model is mis-ranking and
+we know exactly which term to fix. This is the highest-leverage analysis in the
+whole plan and is impossible without per-candidate rows.
+
+### 4.8 Fleet time-series — `provider_capacity_samples` (Phase 3, optional)
+Sampled heartbeat snapshots (e.g. 1/min/provider), independent of requests:
+`provider_id`, `ts`, hardware tier, `backend_running`, `backend_waiting`,
+`observed_decode_tps`, `active_token_budget_used/max`, mem pressure, cpu, thermal,
+gpu active/peak/cache, `warm_models`, `current_model`, `slot_states`.
+Purpose: build the **TPS-vs-batch-size decay curve per hardware tier** (the
+`effectiveTPSLoadFactor` calibration) and the health-vs-throughput correlation
+from clean, evenly-sampled data instead of request-biased data.
+
+### 4.9 Rejection & lost-demand — `request_rejections` (the "what are we saying no to")
+
+`inference_routes` only captures requests that reached routing. This table
+captures **every rejection on the inference path**, with the request's parameters
+*and* — critically — **whether the fleet could actually have served it** ("what
+could have resulted in an output"). The funnel, grounded in code:
+
+| Stage | HTTP | `reason_code` (examples) | Code |
+|-------|------|--------------------------|------|
+| `auth` | 401/403 | `missing_credentials`, `invalid_api_key`, `invalid_privy`, `key_disabled`, `forbidden` | `server.go:1949-2077` |
+| `validation` | 400/413/422 | `messages_required`, `malformed_json`, `bad_param`, `payload_too_large`, `unsupported_param` | `consumer.go:1470-1484,1774` |
+| `model_resolution` | 404/503 | `model_not_found`, `model_unavailable`, `alias_unresolved` | `consumer.go:1506,1632,4085` |
+| `balance` | 402 | `insufficient_quota` (per-key cap), `insufficient_funds` (account), `insufficient_funds_provider_price` | `consumer.go:1604-1611,4135-4142,4426` |
+| `rate_limit` | 429 | `rpm_exceeded`, `itpm_exceeded`, `otpm_exceeded`, `global_rate_limit` | `server.go:525,568,2174` |
+| `preflight_capacity` | 429/503 | `machine_busy` (all full), `no_provider` (none serve model), `model_too_large` | `consumer.go:1658-1714,4168-4204` |
+| `routing_ttft` | 429 | `ttft_429`, `queue_timeout` (also in `inference_routes`) | `dispatch.go:358-473` |
+
+**Request shape & params (non-private — no content):**
+`request_id`, `endpoint`, `ts`, `key_id`/`consumer_key_hash`, `client_class`
+(e.g. openrouter vs direct, from user-agent), **`requested_model` (RAW as sent —
+captures typos / unknown names)**, `resolved_model` (or empty), `stream`, `n`,
+`estimated_prompt_tokens`, `requested_max_tokens`, `requires_vision`, `has_image`,
+`has_audio`, `has_tools`, `tool_count`, `response_format` (e.g. json_schema),
+`self_route_only`, `prefer_owner`, a `params` JSON blob of **non-content** knobs
+(temperature, top_p, penalties, stop-count…), `request_body_bytes`, plus
+`stage`, `http_status`, `reason_code`, `retry_after_ms`.
+
+**Counterfactual servability — "could it have produced output?"**
+The pre-flight *already* calls `QuickCapacityCheckWithTTFTForRequest`
+(`consumer.go:1658,4168`), which returns this exactly. For rejections that happen
+*before* pre-flight (auth/validation/balance/rate-limit) we run the same cheap,
+read-only fleet scan at rejection time:
+| Field | Meaning |
+|-------|---------|
+| `could_have_served` (bool) | `candidate_count_at_reject > 0` — **the headline signal** |
+| `candidate_count_at_reject`, `capacity_rejections_at_reject`, `model_too_large_at_reject`, `vision_rejections_at_reject` | The fleet picture at the moment we said no |
+| `warm_provider_existed` (bool) | Was the model already resident somewhere? |
+| `best_ttft_ms_at_reject` | For `ttft_429`: how close to the ceiling were we? |
+| `shortfall_micro_usd` | For 402: required − available (the *amount*, never the balance) → lost revenue |
+| `limit_kind`, `over_by` | For 429 rate-limit: which limit and by how much → legit-burst signal |
+
+This makes every "no" answerable — *was it necessary?*
+- 429 with `could_have_served=true` → **false rejection** (we had capacity; a limit or ordering bug blocked it).
+- 404 unknown `requested_model` → **pure demand** for something we don't serve / an unresolved alias.
+- 402 with a warm provider available → **lost revenue** blocked only by balance/top-up friction.
+- 400 with `requested_max_tokens` > model cap → **fixable param/UX issue**, not real incapacity.
+
+---
+
+## 5. How we use the data to improve the algorithm
+
+Concrete analyses, each tied to a constant/decision in §2:
+
+1. **TTFT model calibration.** Plot `actual_ttft_ms` vs predicted `ttft_ms`,
+   grouped by `hardware_tier × model × batch_size`. Fit per-tier correction.
+   → fixes the `prefillTPS = decodeTPS×4.0` and `sqrt(bandwidth)` guesses.
+2. **Decode-TPS / load-factor `k`.** Regress `actual_decode_tps` against
+   `batch_size` per tier/model. The slope *is* `effectiveTPSLoadFactor`. Today
+   `k=0.27` is a single global constant measured on Qwen-7B; replace it with a
+   measured `k[tier][model]` table for our real models (`gpt-oss-20b`,
+   `gemma-4-26b`) — a 20B/26B will decay very differently from the 7B it was tuned on.
+3. **Queue / pending penalty validation.** Correlate `actual_queue_wait_ms` and
+   `total_duration_ms` with `effective_queue` and `total_pending`. If the real
+   marginal cost of one queued request ≠ 3000 ms, retune `queueDepthPenaltyMs`.
+4. **Admission-gate calibration.** Count `admitted_but_failed` by tier/model →
+   derive the true `kvCacheBytesPerToken` and whether to raise the coordinator's
+   2.0× headroom toward the provider's 3.0×.
+5. **Health-penalty validation.** Does high `system_memory_pressure` /
+   `thermal_state=serious` actually reduce `actual_decode_tps`? If not, the
+   `×4000` / `8000` penalties are over/under-weighted.
+6. **Cold-load penalty.** Measure real load latency (slot `unknown` →
+   first chunk) vs the flat `30000 ms` assumption; make it size/tier aware.
+7. **Cost-model regret (counterfactual).** Using `inference_route_candidates` +
+   outcomes: how often did the winner underperform an available runner-up?
+   This is the top-line "is the algorithm choosing right" metric.
+8. **TTFT-ceiling false-reject rate.** When `outcome=ttft_429`, how often would a
+   rejected provider actually have met the SLA? Tune `MaxTTFTMs`.
+9. **Cache-affinity efficacy.** Compare TTFT/`prefix_cache_hit` for affinity hits
+   vs misses → justify or retune `cacheAffinityBonusMs`.
+
+The next group uses `request_rejections` (§4.9) — the "what are we saying no to":
+
+10. **False-rejection rate.** % of 4xx where `could_have_served=true`. The
+    headline "are we needlessly saying no" metric — alert on regressions. A
+    rising false-429 rate means a limit or ordering bug, not real saturation.
+11. **Lost-demand by reason.** Group rejections by `reason_code × model × tier` →
+    decide *what to fix first*: add capacity, raise a limit, load a VLM build, or
+    onboard a new model.
+12. **Unknown-model demand.** Top `requested_model` values that 404 → models users
+    want that we don't serve, and unresolved/typo'd aliases worth aliasing.
+13. **Param-driven 400s.** Cluster validation rejections by offending param (e.g.
+    `requested_max_tokens` > model cap, unsupported `response_format`) → raise a
+    limit or fix the error UX instead of silently losing the request.
+14. **Lost revenue.** Sum `shortfall_micro_usd` on 402s where
+    `could_have_served=true` → demand blocked purely by balance/top-up friction,
+    quantified in dollars.
+
+These start as **offline SQL/notebook analyses** (safe, no production risk). Only
+once a recalibration is validated offline do we change a constant — ideally
+promoting the worst constants to a config table the coordinator reads, so future
+recalibration is a data change, not a redeploy (Phase 4).
+
+---
+
+## 6. Read / analytics path
+
+The data is currently write-only (`InferenceRouteRecordsSince` exists on the
+Store but is unwired). Two complementary ways to get it out:
+
+**A. Browse (JSON, paged)** — for quick "why did request X go to machine Y?":
+- `GET /v1/admin/routes?since=&provider=&model=&outcome=` (Privy-admin) → recent
+  decisions + their candidates.
+- `GET /v1/admin/rejections?since=&reason=&model=&could_have_served=` → the "what
+  are we saying no to" feed, filterable to just the *false* rejections.
+
+**B. Download (bulk export)** — the simpler path for real analysis, as requested.
+Rather than paging a giant JSON reply, **stream the rows straight to a file**:
+- `GET /v1/admin/routes/export?since=&until=&format=csv` (also `ndjson`)
+- `GET /v1/admin/rejections/export?...&format=csv`
+- `GET /v1/admin/candidates/export?...&format=csv`
+- Implementation: `Content-Disposition: attachment; filename=...`, a server-side
+  cursor (`pgx` row stream / `COPY ... TO STDOUT`) written directly to the
+  `http.ResponseWriter` so memory stays flat even for millions of rows. Admin can
+  then open it in a spreadsheet, a notebook, or DuckDB (`SELECT … FROM 'routes.csv'`).
+- CSV columns mirror the table 1:1; CSV is content-free metadata so it's safe to
+  hand to an analyst. (A small `scripts/admin.sh routes export > routes.csv`
+  wrapper makes this one command.)
+
+**C. Dashboards / alerting:**
+- Canned SQL views (regret, TTFT-error-by-tier, admission-mismatch rate,
+  false-rejection rate, lost-demand by model) checked into `docs/architecture/`
+  or a `coordinator/datadog/` dashboard.
+- Optionally forward aggregates to Datadog (we already have DogStatsD) for
+  alerting on regret / mismatch-rate regressions.
+
+---
+
+## 7. Volume, sampling & retention
+
+- `inference_routes`: 1 row/attempt. Fine at current scale; partition by
+  `created_at` (monthly) when it grows.
+- `inference_route_candidates`: ~`candidate_count`× the routes volume (often
+  3–10×). Controls:
+  - **Always** store the winner + all *rejected* candidates (cheap, high value).
+  - **Sample** the full near-tie pool at, say, 10–25% of requests (configurable),
+    or always store top-K (winner + 3 runners-up). Counterfactual analysis only
+    needs a representative sample, not 100%.
+- `request_rejections`: 1 row/rejection. Volume depends on traffic health; a
+  busy/abused coordinator can produce many 401/429. Controls: always log
+  authenticated rejections (real demand); **sample anonymous 401/403** (scanner
+  noise) and skip pure `malformed_json` 400s where the body never parsed.
+- `provider_capacity_samples`: bounded by fleet-size × sample-rate; short
+  retention (e.g. 30 days) is enough for curve fitting.
+- All writes remain `saferun.Go` best-effort with a short timeout; a telemetry
+  outage must never affect inference. Add a global on/off + sample-rate flag.
+
+---
+
+## 8. Privacy & safety invariants (non-negotiable)
+
+- **No prompt or response content, ever.** Only counts, timings, and machine
+  metadata.
+- Consumer key is **SHA-256 hashed** (`store.HashKey`); raw keys never stored.
+- **No raw client IPs.** Geo is coarse-bucketed (city/region), reusing the same
+  GeoIP path as the usage table.
+- Writes are async + best-effort + timed out (no latency impact, no failure
+  propagation).
+- Everything is coordinator-internal; the one optional provider-side addition
+  (`prefix_cache_hit` on the `complete` message) is a non-sensitive integer.
+
+---
+
+## 9. Phased implementation
+
+> **Prerequisite (gating):** the target environment must run the **PostgresStore**
+> (`EIGENINFERENCE_DATABASE_URL` set — `cmd/coordinator/main.go:84`). On the
+> in-memory store the tables don't persist and the read/export paths return
+> nothing across restarts. Confirm prod (EigenCloud) has the DSN before Phase 1.
+> The code itself stays store-agnostic (writes go through `store.Store`), so dev
+> with Cloud SQL works today; this is purely an ops switch for prod.
+
+| Phase | Deliverable | Risk |
+|-------|-------------|------|
+| **0 — done** | `inference_routes` table + two-phase write wired through dispatch/complete; memory+postgres stores; tests green. | shipped on this branch |
+| **1** | Add §4.6 gap fields (timing decomposition, actual queue wait, actual decode TPS, admit-but-failed, backup win/loss). **Add `request_rejections` table (§4.9) — the rejection / lost-demand ledger with counterfactual servability.** Add read endpoints (§6). | low-medium — additive columns + a `recordRejection(...)` helper called at each 4xx exit |
+| **2** | `inference_route_candidates` table + surface per-candidate scores from `selectBestCandidateLockedFull` (return the scored pool + rejections, not just the winner). Sampling controls. | medium — touches the hot scheduler path; must stay allocation-light and behind the existing `r.mu` |
+| **3** | `provider_capacity_samples` from heartbeats; offline calibration notebooks/SQL views; Datadog dashboard. | low — read-only analysis |
+| **4** | Promote the worst-fitting constants to a DB-backed `routing_params[tier][model]` config the scheduler reads; close the loop. | higher — changes live routing; gate behind validation + rollback |
+
+---
+
+## 10. Open decisions (need your call)
+
+1. **Candidate sampling rate** — store all candidates always, or sample
+   (winner+rejections always, full pool at N%)? Trades storage for completeness.
+2. **`provider_capacity_samples`** — build it now (Phase 3) or rely on
+   request-driven snapshots only? Cleaner curves vs. more tables.
+3. **One protocol touch** — are we OK adding an optional `prefix_cache_hit`
+   integer to the provider `complete` message to measure cache efficacy? It's the
+   only non-coordinator change in the plan.
+4. **Anonymous-rejection logging** — log every 401/403 (complete demand picture,
+   but adds scanner/abuse noise and volume), or only authenticated rejections plus
+   sampled anonymous ones? Recommended: authenticated always, anonymous sampled.
+5. **Counterfactual on every stage** — running `QuickCapacityCheck` on *every*
+   pre-pre-flight rejection (auth/validation/balance/rate-limit) is a read-only
+   fleet scan but not free under load. Recommended: run it for `balance` and
+   `rate_limit` (high-value lost-demand) and reuse the existing pre-flight result
+   elsewhere; skip it for malformed/auth-noise.
+4. **Calibration target order** — which constant do we attack first? Recommended:
+   decode-TPS/`k` (#2) and the admission mismatch (#4), since those cause the most
+   visible failures (wrong-machine slowness, post-route OOM).

--- a/docs/legal/privacy-policy.md
+++ b/docs/legal/privacy-policy.md
@@ -1,6 +1,6 @@
 # Darkbloom Privacy Policy
 
-Updated: April 17, 2026
+Updated: June 16, 2026
 
 This Privacy Policy explains how Eigen Labs, Inc., operating the Darkbloom platform ("Eigen Labs," "Darkbloom," "we," "us," or "our") collects, uses, discloses, and otherwise processes personal information in connection with Darkbloom's websites, console, APIs, software, provider applications, hosted services, and related products and features (collectively, the "Services").
 
@@ -82,6 +82,15 @@ MDM enrollment is configured for security verification. Darkbloom requests only 
 
 **2.7 Communications and support information.** If you contact us, we collect the contents of your message, attachments, and related contact details.
 
+**2.8 Operational and routing telemetry.** To route requests reliably, plan capacity, and improve the accuracy and reliability of our scheduling, we record operational metadata about how each inference request is routed and about requests we decline. This telemetry is metadata only: it never includes prompt text, message or input content, generated responses or completions, tool-call arguments or results, image or audio bytes, or raw client IP addresses. It may include:
+
+- request characteristics: the model requested and the resolved model build, the API endpoint, whether the response is streamed, an estimated prompt token count and the requested maximum output tokens, whether the request uses vision, image, audio, or tool features, a coarse client classification derived from the User-Agent (for example, aggregator versus direct), the size of the request body in bytes (not its contents), and a limited, non-content set of sampling parameters (such as temperature, top_p, presence penalty, and frequency penalty);
+- request identity: a one-way SHA-256 hash of the API or consumer key, together with the associated account and key identifiers — never the raw API key;
+- routing and performance data: which provider was selected, the scheduler's cost breakdown, the number of candidate providers considered and the reasons candidates were not selected, predicted and measured time-to-first-token and decode throughput, queue and latency timings, prompt, completion, and reasoning token counts, and per-request cost in micro-US-dollars;
+- provider and hardware data: the selected provider's chip family and tier, memory, GPU and CPU core counts, system-load signals such as memory pressure, CPU usage, and thermal state, and GPU memory usage;
+- coarse location: a city- or region-level geographic area for the request and the provider, derived using GeoIP rather than from a stored raw IP address;
+- declined-request records: for requests we decline (for example, with an HTTP 4xx response), the HTTP status, the reason for the decline, and a signal indicating whether the request could have been served given fleet capacity at the time.
+
 ## 3. How We Collect Personal Information
 
 We collect personal information:
@@ -102,6 +111,7 @@ We use personal information to:
 - if applicable, collect tax identification information and fulfill tax reporting obligations, including IRS Form 1099-NEC reporting for qualifying US providers;
 - communicate with you about the Services, updates, support issues, and legal or security notices;
 - monitor performance, reliability, and abuse;
+- analyze routing decisions, performance measurements, and declined requests to improve scheduling accuracy, reliability, and capacity planning;
 - investigate and enforce compliance with our Terms of Service and other legal requirements;
 - comply with law, regulation, court order, or lawful government request;
 - create aggregated or de-identified information for analytics, reporting, security, and service improvement, where permitted by law.
@@ -114,7 +124,7 @@ Because Darkbloom is an inference platform, Content handling is central to how t
 
 **5.2 Coordinator access.** The current service architecture requires our coordinator to process request payloads in plaintext on a transient basis for routing, compatibility, metering, and operation of the Services. You should not treat the current architecture as guaranteeing that the coordinator is technically incapable of accessing request payloads in every service path.
 
-**5.3 Logging.** Our coordinator code is designed not to log prompt content in ordinary request logs. However, we do log operational metadata such as request path, status, duration, and remote address. Content may also be disclosed to us if you intentionally provide it in support requests, bug reports, or other communications.
+**5.3 Logging.** Our coordinator code is designed not to log prompt content in ordinary request logs. However, we do log operational metadata such as request path, status, duration, and remote address. We also retain operational and routing telemetry about each request and about requests we decline, as described under "Operational and routing telemetry" above; this telemetry is limited to metadata — such as counts, timings, routing decisions, hashed identifiers, machine characteristics, and coarse geographic region — and never includes prompt text, message or input content, generated responses or completions, tool-call arguments or results, image or audio bytes, or raw client IP addresses. Content may also be disclosed to us if you intentionally provide it in support requests, bug reports, or other communications.
 
 **5.4 Selected providers.** To fulfill inference requests, we disclose relevant Content to the provider selected to process the request. If you operate provider software, that means customer requests may be routed to your device subject to the Services' security and attestation controls.
 
@@ -162,6 +172,7 @@ Retention periods may vary by data type. For example:
 
 - account and billing records may be retained for legal and accounting periods;
 - usage and security logs may be retained for operational, fraud-prevention, and support purposes;
+- operational and routing telemetry may be retained for operational, security, capacity-planning, and service-improvement purposes;
 - tax identification information (W-9/W-8BEN data) is retained for as long as required by IRS regulations;
 - provider attestation and device-link data, including hardware serial numbers, binary hashes, Secure Enclave public keys, MDM SecurityInfo responses, and challenge-response records, may be retained for trust, audit, and network-integrity purposes;
 - Content may be retained for shorter operational periods unless preserved longer for support, abuse review, legal compliance, or dispute resolution.

--- a/docs/threat-model.yaml
+++ b/docs/threat-model.yaml
@@ -181,16 +181,15 @@ trust_boundaries:
       inference endpoints (chat/completions, completions, messages) call io.ReadAll on
       r.Body with no MaxBytesReader wrapper.
 
-      HTTP server config (cmd/coordinator/main.go): ReadTimeout=10s, WriteTimeout=0
-      (streaming), IdleTimeout=120s. No ReadHeaderTimeout and no MaxHeaderBytes are set.
+      HTTP server config (cmd/coordinator/main.go): ReadHeaderTimeout=5s,
+      ReadTimeout=10s, WriteTimeout=0 (streaming), IdleTimeout=120s,
+      MaxHeaderBytes=64 KB.
     current_limitations:
       - "API key validation uses a simple store lookup — not constant-time comparison.
         Allows timing attacks to enumerate valid key prefixes (server.go:1216)."
       - "No body size limit on plaintext inference endpoints (consumer.go:526, 2359).
         An authenticated consumer can send arbitrarily large bodies to exhaust coordinator
         memory."
-      - "ReadHeaderTimeout and MaxHeaderBytes are absent from the HTTP server config,
-        leaving the server exposed to slow-header attacks (cmd/coordinator/main.go:496)."
       - "WriteTimeout=0 combined with unbounded body reads enables slow-read DoS on
         inference endpoints."
       - "Consumer rate limiter defaults to nil (unlimited) unless explicitly configured
@@ -1809,9 +1808,12 @@ threats:
     mitigations:
       - description: ReadTimeout and IdleTimeout are set.
         status: implemented
-      - description: ReadHeaderTimeout and MaxHeaderBytes are absent.
-        status: open
-    open_findings: [SEC-027]
+      - description: >
+          ReadHeaderTimeout (5s) and MaxHeaderBytes (64 KB) are set in
+          cmd/coordinator/main.go, bounding the slow-header window and
+          per-connection header memory.
+        status: implemented
+    open_findings: []
     severity: medium
     detection_hint: >
       Changes to the http.Server configuration in main.go should verify


### PR DESCRIPTION
## Summary

Persist **per-request routing decisions** and a **rejected-request ("what are we saying no to") ledger** to Postgres so we can explain every routing choice, recalibrate the scheduler cost model against the models we actually serve, and quantify lost demand. Plus a **non-blocking telemetry sink** so none of this can ever add latency to inference, and admin **read + CSV/NDJSON download** endpoints.

Everything here is **metadata only** — no prompt or response content is ever stored (inference stays end-to-end encrypted).

Design doc: `docs/architecture/routing-telemetry-and-calibration.md`.

---

## Before / After

**Before** — routing decisions and rejections were ephemeral; only aggregate Datadog counters existed; nothing was queryable per-request.

```mermaid
flowchart LR
  C[Consumer] -->|request| CO[Coordinator]
  CO -->|route + dispatch| P[Provider]
  P -->|encrypted stream| CO
  CO -->|response / 4xx| C
  CO -. aggregate counters .-> DD[(Datadog)]
  X["❌ no per-request routing decisions stored
  ❌ no record of rejected requests
  ❌ nothing queryable / downloadable"]
```

**After** — every decision and every 4xx is captured (with a counterfactual), flushed through a bounded non-blocking sink to Postgres, and readable/downloadable by admins.

```mermaid
flowchart TB
  C[Consumer] -->|request| A
  subgraph COORD[Coordinator]
    A[auth + validate] --> B[preflight capacity check]
    B --> R[scheduler / route]
    R --> D[dispatch]
  end
  D -->|encrypted| P[Provider]
  P -->|stream + complete| D

  A -. 4xx .-> REJ["recordRejection
  + counterfactual: could_have_served?"]
  B -. 4xx .-> REJ
  R -. decision + cost breakdown .-> RTL[route telemetry]
  D -. measured outcome .-> RTL

  REJ --> SINK{{non-blocking telemetry sink
  bounded queue • 2 workers • drop-if-full}}
  RTL --> SINK
  SINK -. drop if full .-> DROP[(dropped counter)]
  SINK --> PG[("Postgres
  inference_routes
  request_rejections")]
  ADMIN[Admin] -->|"/v1/admin/routes • /rejections
  + CSV/NDJSON export"| PG
```

---

## Why these new parameters?

The scheduler (`registry/scheduler.go`) is a hand-tuned cost model whose constants were calibrated **once, on an M4 Max against Qwen2.5-7B — a model we don't even serve.** We actually run **`gpt-oss-20b`** and **`gemma-4-26b`** across a heterogeneous Apple-silicon fleet. We had no measured feedback on whether those constants are right. Each new field exists to close that gap or to answer "what are we declining, and should we have?".

| New parameter group | Fields | Why we added it |
|---|---|---|
| **Decision cost breakdown** | `cost_ms`, `state_ms`, `queue_ms`, `pending_ms`, `backlog_ms`, `this_req_ms`, `health_ms`, `effective_tps`, `static_tps`, `ttft_ms`, `best_ttft_ms`, candidate/rejection counts | Records *why a machine won* — the exact scoring terms — so we can see which term drove each choice and validate the penalty weights. |
| **Provider/hardware snapshot** | chip family/tier, memory, GPU/CPU cores, memory pressure, CPU, thermal state, GPU memory, slot state, token budgets | The grouping key for calibration: TPS and the load factor `k=0.27` must become per-(tier, model), not one global constant tuned on a 7B. |
| **Measured outcome** | `actual_ttft_ms`, `actual_decode_tps`, `parse/reserve/route/encrypt/queue_wait/dispatch_ms`, token counts, cost | The ground truth to diff against predictions (predicted vs actual TTFT/TPS), and to separate coordinator overhead from provider latency. |
| **`admitted_but_failed`** | bool | Detects the known mismatch where the coordinator admits a request but the provider OOMs/fails — calibrates `kvCacheBytesPerToken` and the 2.0× vs 3.0× memory headroom gap. |
| **Rejection ledger** | stage, reason_code, http_status, request shape (model, est. tokens, vision/tools/stream, sampling-knob allowlist), hashed key | Captures **every 4xx** (auth/validation/balance/preflight) which previously vanished — to see what we decline and why. |
| **Counterfactual servability** | `could_have_served`, candidate counts, `best_ttft_ms`, `shortfall_micro_usd` | The headline "was the *no* necessary?" signal: a 429 with `could_have_served=true` is a false rejection; a 404 on an unknown model is real demand; a 402 with capacity available is lost revenue. Reuses the preflight's existing `QuickCapacityCheck` result, so it's nearly free. |
| **Coarse geo** | `provider_region`, `consumer_region` | "Closest machine" analysis. City/region via GeoIP — **no raw IPs**. |

---

## Non-blocking telemetry node

`telemetrySink` (`coordinator/api/telemetry_sink.go`): a bounded (4096) work queue drained by a fixed pool of 2 long-lived, panic-safe workers. `submit()` enqueues without ever blocking and **drops + counts** when the buffer is full. This replaces the previous per-write `saferun.Go` goroutine, so telemetry:

- never adds latency or backpressure to inference, even if Postgres is slow/down;
- can't grow goroutines/memory without bound;
- stops cleanly on `Server.Close()` (deferred after `httpServer.Shutdown` in `main.go`).

`submitTelemetry()` falls back to `saferun.Go` when no sink is wired (direct `&Server{}` test construction), preserving behavior. Billing/usage writes are intentionally left as guaranteed writes.

---

## Admin read + download

- `GET /v1/admin/routes` and `/v1/admin/rejections` — JSON browse (filters: provider/model/outcome, reason/`could_have_served`, `since`, `limit`).
- `GET /v1/admin/routes/export` and `/v1/admin/rejections/export` — streamed **CSV** (default) or **NDJSON** download for spreadsheets / notebooks / DuckDB.
- All admin-key gated (`requireAdminKey`). Metadata only.

---

## Privacy

`docs/legal/privacy-policy.md` updated: new "Operational and routing telemetry" disclosure under *Information We Collect*, plus *How We Use*, *Logging*, and *Retention*. Reaffirms we never store prompt/response content, tool args, media bytes, or raw IPs; identifiers are SHA-256 hashed. Last-updated date bumped.

---

## ⚠️ Deployment prerequisite

This data persists **only when the coordinator runs the Postgres store** — i.e. `EIGENINFERENCE_DATABASE_URL` is set (our AWS RDS instance). On the in-memory store the tables aren't durable and the read/export endpoints return nothing across restarts. Migrations are idempotent (`CREATE TABLE IF NOT EXISTS` + `ALTER TABLE ... ADD COLUMN IF NOT EXISTS`) and standard-SQL (RDS-safe).

---

## Testing

- `go build ./...`, `gofmt -l`, and full `go test ./...` all green.
- Memory-store route/rejection round-trip tests run and assert; Postgres-backed store tests skip without `DATABASE_URL` (expected) — so the **SQL three-way column alignment** (CREATE = INSERT = positional `SELECT *` scan) for both tables was verified by hand and by an independent verifier pass.
- Telemetry writes are async/best-effort; tests do not hang on the new worker lifecycle.

## Follow-ups (intentionally out of scope)

- Rejection capture for token-rate-limit 429s, auth 401/403, and `parseInferencePrelude` body errors (live in sibling files).
- Per-candidate scores (Phase 2) and `provider_capacity_samples` (Phase 3).
- Harden the dual success-outcome write (early `successRoutingOutcome` + authoritative `handleComplete`) against rare reordering.

## Commits
- `routing telemetry + rejection ledger + admin export`
- `non-blocking telemetry sink + privacy policy update`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/375"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784232646&installation_id=133247490&pr_number=375&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F375&signature=074089b526f4bc390fb0e9bfc2e93df4ce390c0925e376dad9a3680943ed1c84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->