### PR TITLE
fix(provider): don't log raw request-parse errors (avoid prompt-fragment leak in reports)

### DIFF
--- a/provider-swift/Sources/ProviderCore/ProviderLoop.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop.swift
@@ -1036,9 +1036,12 @@ public actor ProviderLoop {
             // reports collect this subsystem — so never interpolate the raw decode
             // error, which on a malformed body can carry a fragment of the (now
             // decrypted) request, i.e. user prompt content. Log only the error TYPE.
-            // The full detail still goes to the requester via inferenceError below.
+            // The requester-facing string below is likewise kept generic: it transits
+            // the coordinator in plaintext and is logged server-side, so interpolating
+            // the raw error could resurface a prompt fragment in coordinator logs
+            // (defense-in-depth for the "coordinator never sees plaintext" invariant).
             logger.error("[\(requestId)] Failed to parse chat request (\(type(of: error)))")
-            send.send(.inferenceError(requestId: requestId, error: "invalid request body: \(error.localizedDescription)", statusCode: 400))
+            send.send(.inferenceError(requestId: requestId, error: "invalid request body", statusCode: 400))
             return
         }
 

--- a/provider-swift/Sources/ProviderCore/ProviderLoop.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop.swift
@@ -1032,7 +1032,12 @@ public actor ProviderLoop {
         do {
             chatRequest = try Self.decodeOpenAIRequest(decryptedData)
         } catch {
-            logger.error("[\(requestId)] Failed to parse chat request: \(error)")
+            // Privacy: the provider logger renders the whole message `.public`, and
+            // reports collect this subsystem — so never interpolate the raw decode
+            // error, which on a malformed body can carry a fragment of the (now
+            // decrypted) request, i.e. user prompt content. Log only the error TYPE.
+            // The full detail still goes to the requester via inferenceError below.
+            logger.error("[\(requestId)] Failed to parse chat request (\(type(of: error)))")
             send.send(.inferenceError(requestId: requestId, error: "invalid request body: \(error.localizedDescription)", statusCode: 400))
             return
         }


### PR DESCRIPTION
## Why
`ProviderLogger` renders every message and marks it `privacy: .public`, and `darkbloom report` collects this subsystem (`log show --predicate 'subsystem == "dev.darkbloom.provider"'`) — so anything logged lands verbatim in uploaded reports.

The request-parse `catch` logged the **raw decode error** (`ProviderLoop.swift:1035`). On a malformed body that error can carry a fragment of the (already-decrypted) request — i.e. **user prompt content**. Standard `DecodingError`s echo keys/types not values, so it's rare, but the privacy bar is zero PII in logs.

## Change
Log only the error **type** (`Failed to parse chat request (DecodingError)`); the full detail still returns to the requester via `inferenceError` (their own request, E2E-encrypted back to them — not a cross-user log).

## Privacy audit (context)
Done alongside making the `[rsrc]` resource telemetry default-on (mlx-swift-lm#42 / #373). Confirmed:
- The new `[rsrc]` line contains **only metrics** (step, batch-count, resource count/limit, cache+active MB) — no user data.
- All other captured `dev.darkbloom.provider` logs are operational only (KV content-hashes, model IDs, file paths, cache-stat counts, KEK identifiers, env-var names).
- This parse-error line was the one spot interpolating user-derived data into a public log.

Target: 0.6.12.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/376"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784232917&installation_id=133247490&pr_number=376&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F376&signature=0fac9737ac0c875573b72ccc35c1ee27e49e2ae2cb3f6c6ec54c613c4dd94947"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->