### PR TITLE
fix(provider): bound the Gemma batching memory envelope

### DIFF
--- a/coordinator/api/billing_integration_test.go
+++ b/coordinator/api/billing_integration_test.go
@@ -435,7 +435,7 @@ func TestIntegration_ReservationRefundedOnCompletion(t *testing.T) {
 	defer conn.Close(websocket.StatusNormalClosure, "")
 
 	// Short generation — completion_tokens (10) is far below the reservation
-	// based on default max_tokens=8192.
+	// based on the implicit default max_tokens bound.
 	usage := protocol.UsageInfo{PromptTokens: 5, CompletionTokens: 10}
 	providerDone := serveOneInference(ctx, t, conn, pubKey, usage)
 

--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -999,14 +999,21 @@ func bodyForProvider(rawBody []byte, requiresVision bool, provider *registry.Pro
 	return rawBody
 }
 
-// defaultMaxOutputTokens is the ceiling injected into requests that don't set
-// max_tokens. It bounds the worst-case cost of a single inference so the
+// defaultMaxOutputTokens is the generation bound injected into requests that
+// don't set max_tokens. It bounds the worst-case cost of a single inference so the
 // pre-flight balance reservation covers the entire generation; without this
 // cap a consumer could stream output exceeding their reservation and the
 // post-inference charge would fail silently (see GitHub issue #33). Consumers
 // who need longer generations must set max_tokens explicitly and carry the
 // balance to cover it.
-const defaultMaxOutputTokens = 8192
+const defaultMaxOutputTokens = 1024
+
+func implicitMaxTokensBound(modelMaxOutputLength int) int {
+	if modelMaxOutputLength > 0 && modelMaxOutputLength < defaultMaxOutputTokens {
+		return modelMaxOutputLength
+	}
+	return defaultMaxOutputTokens
+}
 
 // explicitMaxTokens returns the consumer-specified max output tokens from any
 // of the recognized field names, or 0 if none were set.
@@ -1176,11 +1183,10 @@ func (s *Server) reserveAdditionalForProvider(pr *registry.PendingRequest, provi
 // ensureMaxTokensBound injects a max-tokens bound into parsed when the
 // consumer didn't specify any max-tokens field, so the outgoing request to
 // the provider is bounded by the amount we reserve upfront. The bound is
-// the model's max_output_length from the registry (or defaultMaxOutputTokens
-// as fallback). The injected field name depends on the API flavor: Responses
-// API uses max_output_tokens, everything else uses max_tokens. Returns true
-// when an injection occurred, so the caller can re-marshal the outgoing body
-// if needed.
+// the platform default clamped by the model's max_output_length when lower.
+// The injected field name depends on the API flavor: Responses API uses
+// max_output_tokens, everything else uses max_tokens. Returns true when an
+// injection occurred, so the caller can re-marshal the outgoing body if needed.
 func ensureMaxTokensBound(parsed map[string]any, isResponsesAPI bool, bound int) bool {
 	if n := explicitMaxTokens(parsed); n > 0 {
 		// Normalize alias fields the provider engine doesn't read: a chat
@@ -1532,7 +1538,7 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 
 	// Inject model-specific defaults from the registry: reasoning_parser
 	// and max_tokens bound. Single DB lookup (cached for platform prices).
-	maxOutputBound := defaultMaxOutputTokens
+	maxOutputBound := implicitMaxTokensBound(0)
 	if rec, err := s.store.GetModelRegistryRecord(model); err == nil {
 		// Reasoning parser from runtime_parameters.
 		if _, hasRP := parsed["reasoning_parser"]; !hasRP && rec.RuntimeParameters != nil {
@@ -1541,18 +1547,15 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 				rawBody, _ = marshalForwardBody(parsed)
 			}
 		}
-		// Use the registry's max_output_length as the default max_tokens
-		// bound instead of the hardcoded 8192. This lets models like
-		// GPT-OSS 20B (32K output) generate longer responses when the
-		// consumer omits max_tokens.
-		if rec.MaxOutputLength > 0 {
-			maxOutputBound = rec.MaxOutputLength
-		}
+		// max_output_length is an advertised maximum, not the implicit default.
+		// Omitted max_tokens stays on the safer platform default; models with a
+		// lower published max still clamp the injected bound to their maximum.
+		maxOutputBound = implicitMaxTokensBound(rec.MaxOutputLength)
 	}
 
 	// Bound the generation so the pre-flight reservation covers it. If the
-	// consumer didn't set max_tokens, inject the model's max_output_length
-	// (or defaultMaxOutputTokens as fallback). Without this bound the
+	// consumer didn't set max_tokens, inject the platform default clamped by
+	// the model's max_output_length when lower. Without this bound the
 	// provider could return more tokens than we reserved for, and the
 	// silent post-inference charge failure would hand the consumer free
 	// inference (GitHub issue #33).
@@ -4100,9 +4103,9 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 	// Completions and Anthropic messages both use the max_tokens field (never
 	// max_output_tokens, which is Responses API only). Inject a default if
 	// unset so the pre-flight reservation bounds the generation.
-	genericMaxOutput := defaultMaxOutputTokens
+	genericMaxOutput := implicitMaxTokensBound(0)
 	if rec, err := s.store.GetModelRegistryRecord(model); err == nil && rec.MaxOutputLength > 0 {
-		genericMaxOutput = rec.MaxOutputLength
+		genericMaxOutput = implicitMaxTokensBound(rec.MaxOutputLength)
 	}
 	ensureMaxTokensBound(parsed, false, genericMaxOutput)
 

--- a/coordinator/api/consumer_test.go
+++ b/coordinator/api/consumer_test.go
@@ -1032,6 +1032,31 @@ func TestResponsesRequestToChatCompletions(t *testing.T) {
 	}
 }
 
+func TestImplicitMaxTokensBoundUsesSafeDefaultBelowModelMaximum(t *testing.T) {
+	if got := implicitMaxTokensBound(8192); got != defaultMaxOutputTokens {
+		t.Fatalf("implicitMaxTokensBound(8192) = %d, want %d", got, defaultMaxOutputTokens)
+	}
+}
+
+func TestImplicitMaxTokensBoundClampsToLowerModelMaximum(t *testing.T) {
+	if got := implicitMaxTokensBound(256); got != 256 {
+		t.Fatalf("implicitMaxTokensBound(256) = %d, want 256", got)
+	}
+}
+
+func TestEnsureMaxTokensBoundInjectsImplicitDefault(t *testing.T) {
+	parsed := map[string]any{
+		"model":    "gemma-4-26b",
+		"messages": []any{map[string]any{"role": "user", "content": "hello"}},
+	}
+	if !ensureMaxTokensBound(parsed, false, implicitMaxTokensBound(8192)) {
+		t.Fatal("ensureMaxTokensBound did not report injection")
+	}
+	if got := parsed["max_tokens"]; got != defaultMaxOutputTokens {
+		t.Fatalf("max_tokens = %v, want %d", got, defaultMaxOutputTokens)
+	}
+}
+
 func TestResponsesInputToolTranscriptToChatMessages(t *testing.T) {
 	input := []any{
 		map[string]any{

--- a/coordinator/registry/scheduler.go
+++ b/coordinator/registry/scheduler.go
@@ -79,6 +79,7 @@ type routingSnapshot struct {
 	prefillTPS         float64
 	systemMetrics      protocol.SystemMetrics
 	gpuMemoryActiveGB  float64
+	gpuMemoryCacheGB   float64
 	totalMemoryGB      float64
 	modelSizeGB        float64 // catalog-reported weight footprint (0 = unknown, gate disabled)
 	minRAMGb           int     // catalog authoritative min RAM (GB) to run the model (0 = unknown)
@@ -133,6 +134,21 @@ const (
 // gemma-4-26b min_ram_gb=36 vs 28*2.x rejecting the whole 64 GB tier).
 const modelMemoryHeadroomFactor = 2.0
 
+const (
+	providerMemoryCapFraction = 0.90
+	// providerMinimumReserveGB mirrors the provider's whole-machine MLX ceiling
+	// (MLXMemoryGuard.defaultReserveGB): the Swift allocator pins
+	// Memory.memoryLimit to physical − 6 GB, so the coordinator must not admit a
+	// cold load above that or it would route work the provider's own ceiling
+	// already rejects. The effective cap is the TIGHTER of the fraction and the
+	// reserve floor, so on small boxes (where total − 6 < 0.9 × total) we honor
+	// the provider's reserve, and on large boxes the 0.9 fraction dominates.
+	providerMinimumReserveGB          = 6.0
+	providerModelMemoryOverheadFactor = 1.2
+	providerActivationReserveGB       = 3.0
+	providerMinimumLoadKVGB           = 1.0
+)
+
 // modelFitsHardware reports whether a model can run on a node with the given
 // total unified memory (GB). It prefers the catalog's authoritative min_ram_gb
 // (the operator-published requirement) and only falls back to a heuristic
@@ -151,6 +167,28 @@ func modelFitsHardware(minRAMGb int, modelSizeGB, totalMemoryGB float64) bool {
 		return modelSizeGB*modelMemoryHeadroomFactor <= totalMemoryGB
 	}
 	return true
+}
+
+func providerHardMemoryCapGB(totalMemoryGB float64) float64 {
+	if totalMemoryGB <= 0 {
+		return 0
+	}
+	byFraction := totalMemoryGB * providerMemoryCapFraction
+	byFloor := 0.0
+	if totalMemoryGB > providerMinimumReserveGB {
+		byFloor = totalMemoryGB - providerMinimumReserveGB
+	}
+	if byFraction < byFloor {
+		return byFraction
+	}
+	return byFloor
+}
+
+func providerEstimatedModelLoadGB(modelSizeGB float64) float64 {
+	if modelSizeGB <= 0 {
+		return 0
+	}
+	return modelSizeGB * providerModelMemoryOverheadFactor
 }
 
 // costBreakdown decomposes the routing cost so callers can log or
@@ -760,6 +798,7 @@ func (r *Registry) snapshotProviderLocked(p *Provider, model string, traits Requ
 
 	if p.BackendCapacity != nil {
 		snap.gpuMemoryActiveGB = p.BackendCapacity.GPUMemoryActiveGB
+		snap.gpuMemoryCacheGB = p.BackendCapacity.GPUMemoryCacheGB
 		if p.BackendCapacity.TotalMemoryGB > 0 {
 			snap.totalMemoryGB = p.BackendCapacity.TotalMemoryGB
 		}
@@ -805,7 +844,8 @@ func freeMemoryAdmits(snap routingSnapshot, reqPromptTokens, reqMaxTokens int) b
 	if snap.modelSizeGB <= 0 || snap.totalMemoryGB <= 0 {
 		return true
 	}
-	required := snap.modelSizeGB
+	modelLoadGB := providerEstimatedModelLoadGB(snap.modelSizeGB)
+	required := modelLoadGB
 	if snap.modelLoaded {
 		required = 0
 	}
@@ -818,7 +858,15 @@ func freeMemoryAdmits(snap routingSnapshot, reqPromptTokens, reqMaxTokens int) b
 		tokens = maxTokensForCalc
 	}
 	kvCacheGB := float64(tokens*kvCacheBytesPerToken) / float64(bytesPerGB)
-	required += kvCacheGB
+
+	// A cold load (model not yet resident) must reserve at least the minimum
+	// serveable KV so we don't admit a model that loads but can serve nothing.
+	// Both cold paths below use this floor; a warm model charges only its real
+	// KV (it is already resident, so the minimum no longer applies).
+	coldKVGB := kvCacheGB
+	if coldKVGB < providerMinimumLoadKVGB {
+		coldKVGB = providerMinimumLoadKVGB
+	}
 
 	// When the model is available on disk but not currently loaded, the
 	// provider will evict idle models to make room (LRU eviction). Check
@@ -831,12 +879,22 @@ func freeMemoryAdmits(snap routingSnapshot, reqPromptTokens, reqMaxTokens int) b
 	// through to the standard free-memory check which requires room
 	// alongside active models.
 	if snap.availableOnDisk && !snap.modelLoaded && snap.totalPending == 0 {
-		const osReserveGB = 4.0
-		return snap.modelSizeGB+kvCacheGB+osReserveGB <= snap.totalMemoryGB
+		required := modelLoadGB + providerActivationReserveGB + coldKVGB
+		return required <= providerHardMemoryCapGB(snap.totalMemoryGB)
 	}
 
-	free := snap.totalMemoryGB - snap.gpuMemoryActiveGB
-	return free >= required
+	freeUnderCap := providerHardMemoryCapGB(snap.totalMemoryGB) - snap.gpuMemoryActiveGB - snap.gpuMemoryCacheGB
+	if freeUnderCap < 0 {
+		freeUnderCap = 0
+	}
+	required += providerActivationReserveGB
+	if snap.modelLoaded {
+		required += kvCacheGB
+	} else {
+		// Cold load on a busy provider: same KV floor as the no-pending path.
+		required += coldKVGB
+	}
+	return freeUnderCap >= required
 }
 
 func pendingTokenBudget(pr *PendingRequest) int {
@@ -1255,6 +1313,7 @@ func (r *Registry) quickCapacityCheck(model string, estimatedPromptTokens, reque
 		}
 		if snap.hasBackendCapacity {
 			snap.gpuMemoryActiveGB = p.BackendCapacity.GPUMemoryActiveGB
+			snap.gpuMemoryCacheGB = p.BackendCapacity.GPUMemoryCacheGB
 			if p.BackendCapacity.TotalMemoryGB > 0 {
 				snap.totalMemoryGB = p.BackendCapacity.TotalMemoryGB
 			}

--- a/coordinator/registry/scheduler_test.go
+++ b/coordinator/registry/scheduler_test.go
@@ -1423,6 +1423,67 @@ func TestFreeMemoryAdmitsFallsBackWithoutBudget(t *testing.T) {
 	}
 }
 
+func TestFreeMemoryAdmitsColdLoadMirrorsProviderMemoryEnvelope(t *testing.T) {
+	// 26 GB of raw weights looks like it fits on a 36 GB laptop under the old
+	// raw-size + 4 GB reserve check (30 <= 36). The provider actually loads with
+	// scanner overhead (1.2x), activation reserve, and minimum KV headroom under
+	// the provider's real MLX ceiling — min(0.9*total, total-6) = min(32.4, 30) =
+	// 30 GB on this box: 31.2 + 3 + 1 = 35.2 > 30, so the coordinator must not
+	// route it cold.
+	publicGemmaOnLaptop := routingSnapshot{
+		modelSizeGB:     26,
+		totalMemoryGB:   36,
+		availableOnDisk: true,
+		modelLoaded:     false,
+		totalPending:    0,
+	}
+	if freeMemoryAdmits(publicGemmaOnLaptop, 100, 256) {
+		t.Fatal("should reject cold load that only fits under raw-size accounting")
+	}
+
+	// The QAT build's smaller raw footprint still fits the same envelope.
+	qatGemmaOnLaptop := publicGemmaOnLaptop
+	qatGemmaOnLaptop.modelSizeGB = 15
+	if !freeMemoryAdmits(qatGemmaOnLaptop, 100, 256) {
+		t.Fatal("should admit smaller QAT build under provider-equivalent accounting")
+	}
+}
+
+func TestProviderHardMemoryCapGBTakesTighterOfFractionAndReserve(t *testing.T) {
+	// Small box: total-6 (30) is tighter than 0.9*total (32.4) -> honor reserve.
+	if got := providerHardMemoryCapGB(36); got != 30 {
+		t.Fatalf("providerHardMemoryCapGB(36) = %v, want 30 (= 36 - 6)", got)
+	}
+	// Large box: 0.9*total (115.2) is tighter than total-6 (122) -> honor fraction.
+	if got := providerHardMemoryCapGB(128); got != 128*0.90 {
+		t.Fatalf("providerHardMemoryCapGB(128) = %v, want %v (= 0.9*128)", got, 128*0.90)
+	}
+	if got := providerHardMemoryCapGB(0); got != 0 {
+		t.Fatalf("providerHardMemoryCapGB(0) = %v, want 0", got)
+	}
+}
+
+func TestFreeMemoryAdmitsBusyColdLoadUsesSameKVFloorAsIdle(t *testing.T) {
+	// A cold load on a BUSY provider (totalPending > 0) must charge the same
+	// minimum-KV floor as the idle cold path — never the full real KV ON TOP of
+	// the floor. With a tiny request (KV well under the 1 GB floor), the model's
+	// footprint must be evaluated against exactly modelLoad + activation + 1 GB
+	// of KV, matching the idle path's envelope rather than over-charging.
+	busy := routingSnapshot{
+		modelSizeGB:       15, // 1.2x -> 18 GB load
+		totalMemoryGB:     36, // cap = min(32.4, 30) = 30
+		availableOnDisk:   true,
+		modelLoaded:       false,
+		totalPending:      1, // busy: cannot evict -> general branch
+		gpuMemoryActiveGB: 0,
+		gpuMemoryCacheGB:  0,
+	}
+	// 18 (load) + 3 (activation) + 1 (min KV floor) = 22 <= 30 -> admit.
+	if !freeMemoryAdmits(busy, 100, 256) {
+		t.Fatal("busy cold load that fits under the min-KV floor must be admitted")
+	}
+}
+
 func TestSlotHeadroomWithExhaustedTokenBudgetRejectsCapacity(t *testing.T) {
 	reg := New(testLogger())
 	model := "budget-headroom-model"

--- a/provider-swift/Sources/ProviderCore/Inference/BatchScheduler.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/BatchScheduler.swift
@@ -1463,6 +1463,32 @@ public actor BatchScheduler {
         return n  // 0 ⇒ disabled
     }
 
+    static func makeSamplingParams(
+        maxTokens: Int,
+        temperature: Float,
+        topP: Float?,
+        topK: Int?,
+        repetitionPenalty: Float?,
+        presencePenalty: Float?,
+        frequencyPenalty: Float?,
+        seed: UInt64?
+    ) -> SamplingParams {
+        let requestedRepetitionPenalty = repetitionPenalty ?? 1.0
+        let safeRepetitionPenalty =
+            requestedRepetitionPenalty <= 0 ? Float(1.0) : requestedRepetitionPenalty
+        var sp = SamplingParams(
+            maxTokens: maxTokens,
+            temperature: temperature,
+            repetitionPenalty: safeRepetitionPenalty,
+            presencePenalty: presencePenalty ?? 0.0,
+            frequencyPenalty: frequencyPenalty ?? 0.0
+        )
+        if let topP { sp.topP = topP }
+        if let topK { sp.topK = topK }
+        if let seed { sp.seed = seed }
+        return sp
+    }
+
     /// Set the post-load budgets driven by architecture + physical
     /// memory. Pulled out of `loadModel` so the lifecycle reads as a
     /// short sequence; the arithmetic itself is unchanged.
@@ -1484,11 +1510,12 @@ public actor BatchScheduler {
         // Derive context-aware limits from config.json.
         self.maxContextLength = snapshot.architecture.maxContextLength ?? 0
         if maxContextLength > 0 {
-            // Raise the default max output tokens so consumers that omit
-            // `max_tokens` get a reasonable budget for the model's class.
-            // Cap at 8192 so we don't over-reserve with very-long-context
-            // models (e.g. 131K Qwen).
-            self.defaultMaxTokens = min(maxContextLength, 8192)
+            // Do not auto-raise omitted `max_tokens` after model load. Runaway
+            // loops then run to an unexpectedly large cap and over-reserve KV.
+            // Only clamp downward for unusually short-context models.
+            self.defaultMaxTokens = min(initDefaultMaxTokens, maxContextLength)
+        } else {
+            self.defaultMaxTokens = initDefaultMaxTokens
         }
 
         self.dynamicMaxConcurrentRequests = min(4, maxConcurrentRequests)
@@ -1514,6 +1541,9 @@ public actor BatchScheduler {
         temperature: Float = 0.0,
         topP: Float? = nil,
         topK: Int? = nil,
+        repetitionPenalty: Float? = nil,
+        presencePenalty: Float? = nil,
+        frequencyPenalty: Float? = nil,
         seed: UInt64? = nil,
         requestId: String? = nil,
         cacheScope: String = ""
@@ -1571,10 +1601,16 @@ public actor BatchScheduler {
             await refreshPendingSummaryCache()
         }
 
-        var sp = SamplingParams(maxTokens: maxTokens, temperature: temperature)
-        if let topP { sp.topP = topP }
-        if let topK { sp.topK = topK }
-        if let seed { sp.seed = seed }
+        let sp = Self.makeSamplingParams(
+            maxTokens: maxTokens,
+            temperature: temperature,
+            topP: topP,
+            topK: topK,
+            repetitionPenalty: repetitionPenalty,
+            presencePenalty: presencePenalty,
+            frequencyPenalty: frequencyPenalty,
+            seed: seed
+        )
 
         let req = Request(
             requestId: id,
@@ -1748,13 +1784,17 @@ public actor BatchScheduler {
             await refreshPendingSummaryCache()
         }
 
-        // Greedy (temperature == 0) hits the engine's vectorized argmax
-        // fast path automatically; just pass the requested value through.
         let temperature = request.temperature ?? 0.0
-        var sp = SamplingParams(maxTokens: maxTokens, temperature: temperature)
-        if let topP = request.top_p { sp.topP = topP }
-        if let topK = request.top_k { sp.topK = topK }
-        if let seed = request.seed { sp.seed = seed }
+        let sp = Self.makeSamplingParams(
+            maxTokens: maxTokens,
+            temperature: temperature,
+            topP: request.top_p,
+            topK: request.top_k,
+            repetitionPenalty: request.repetition_penalty,
+            presencePenalty: request.presence_penalty,
+            frequencyPenalty: request.frequency_penalty,
+            seed: request.seed
+        )
 
         let req = Request(
             requestId: id,

--- a/provider-swift/Sources/ProviderCore/Inference/MultiModelBatchSchedulerEngine.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/MultiModelBatchSchedulerEngine.swift
@@ -296,6 +296,9 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
             temperature: temperature,
             topP: request.topP,
             topK: request.topK,
+            repetitionPenalty: request.repetitionPenalty,
+            presencePenalty: request.presencePenalty,
+            frequencyPenalty: request.frequencyPenalty,
             requestId: requestId,
             cacheScope: cacheScope
         )

--- a/provider-swift/Sources/ProviderCore/ProviderLoop.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop.swift
@@ -462,9 +462,13 @@ public actor ProviderLoop {
 
     // MARK: - Model Slot
 
-    private static let schedulerMaxConcurrent = 24
+    // Production fan-in must match the MLX/Gemma memory envelope. The upstream
+    // scheduler's `maxNumSeqs` uses this value directly, so keeping it at the old
+    // fleet-wide 24 lets real batches grow far beyond the 4-way budget reported
+    // in heartbeats.
+    private static let schedulerMaxConcurrent = 4
     private static let schedulerPendingTimeout: Duration = .seconds(120)
-    private static let schedulerDefaultMaxTokens = 4096
+    private static let schedulerDefaultMaxTokens = 1024
 
     /// Infer the reasoning parser format from the model's `model_type`
     /// (read from config.json at scan time). Used to auto-select the

--- a/provider-swift/Sources/ProviderCore/Server/StandaloneServer.swift
+++ b/provider-swift/Sources/ProviderCore/Server/StandaloneServer.swift
@@ -116,11 +116,12 @@ public actor StandaloneServer {
         MLXMemoryGuard.configureOnce()
     }
 
-    static let schedulerMaxConcurrent = 24
+    // Keep local serving on the same memory-safe envelope as provider mode.
+    static let schedulerMaxConcurrent = 4
     static let schedulerPendingTimeout: Duration = .seconds(120)
     /// Internal access so the +HTTP extension can pass the same
     /// default through to ``MultiModelBatchSchedulerEngine``.
-    static let schedulerDefaultMaxTokens = 4096
+    static let schedulerDefaultMaxTokens = 1024
 
     /// Map a scheduler-side admission error message to an HTTP status. Used
     /// by tests and by any custom error-mapping middleware. Retained here
@@ -561,4 +562,3 @@ public actor StandaloneServer {
         }
     }
 }
-

--- a/provider-swift/Tests/ProviderCoreTests/BatchSchedulerBudgetTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/BatchSchedulerBudgetTests.swift
@@ -44,6 +44,47 @@ struct BatchSchedulerBudgetTests {
 
     // MARK: - P1: cumulative active-bridge gate
 
+    @Test("sampling params preserve OpenAI repetition penalties")
+    func samplingParamsPreservePenalties() {
+        let params = BatchScheduler.makeSamplingParams(
+            maxTokens: 128,
+            temperature: 0.2,
+            topP: 0.9,
+            topK: 40,
+            repetitionPenalty: 1.15,
+            presencePenalty: 0.3,
+            frequencyPenalty: 0.4,
+            seed: 42
+        )
+
+        #expect(params.maxTokens == 128)
+        #expect(params.temperature == 0.2)
+        #expect(params.topP == 0.9)
+        #expect(params.topK == 40)
+        #expect(params.repetitionPenalty == 1.15)
+        #expect(params.presencePenalty == 0.3)
+        #expect(params.frequencyPenalty == 0.4)
+        #expect(params.seed == 42)
+    }
+
+    @Test("sampling params coerce non-positive repetition penalty to disabled")
+    func samplingParamsCoerceInvalidRepetitionPenalty() {
+        let params = BatchScheduler.makeSamplingParams(
+            maxTokens: 128,
+            temperature: 0.0,
+            topP: nil,
+            topK: nil,
+            repetitionPenalty: 0,
+            presencePenalty: nil,
+            frequencyPenalty: nil,
+            seed: nil
+        )
+
+        #expect(params.repetitionPenalty == 1.0)
+        #expect(params.presencePenalty == 0.0)
+        #expect(params.frequencyPenalty == 0.0)
+    }
+
     /// Pre-fix: planner validated per-request limits + queue size only,
     /// so a burst of large requests each individually within budget
     /// could overcommit KV memory once they all reached the engine.


### PR DESCRIPTION
## Summary

Defense-in-depth against the recurring `[metal::malloc] Resource limit (499000) exceeded` provider crash. The **root cause** (Metal buffer-COUNT exhaustion → count-aware allocator trim) is already on master (#355). This PR tightens how much a provider can ever commit so the box stays well clear of the ceiling, and makes the coordinator's admission match what the provider actually enforces.

This is the **memory-envelope half** of the original combined branch. The Gemma-4 **repetition** fix (decode-mask divergence, `mlx-swift-lm` bump + 0.6.11 version) is intentionally **not** here — it already landed on master via #369 (released in v0.6.11). So this PR is purely the crash/OOM envelope, reviewable on its own.

## The crash (overnight report, 2026-06-15 23:53 → 2026-06-16 07:53 ET)

96 confirmed MLX crash events across 4 Macs in 8h; the same signature every time:

```
MLX/ErrorHandler.swift:345: Fatal error: [metal::malloc] Resource limit (499000) exceeded
  at mlx-c/mlx/c/transforms.cpp:15
  com.eigen.engine → ErrorHandler.dispatch → _mlx_error → mlx_async_eval → eval
    → GenerationBatch.step → GenerationBatch.next → Scheduler.step → EngineCore.engineLoop
```

| Machine | MLX crashes | restarts |
|---|---|---|
| M5 Max / LQW9G9WRDC | 33 | 34 |
| DRX M4 Max / DRXYPT2MKX | 26 | 26 |
| M3 Ultra / WV0NCDC2TX | 21 | 21 |
| KDQ M4 Max / KDQHYG765D | 16 | 17 |

No thermal warnings (`pmset -g therm` clean on all four) — this is MLX/Metal **resource-limit** instability during `gemma-4-26b-qat-4bit` generation under real traffic, worsened by GPU cache/resource accumulation (M3's cache jumped to ~69 GB). The 503s consumers saw were downstream: the provider crashes, launchd restarts it, and requests hit "model unavailable" while the daemon is cold/re-registering.

## Changes

**Provider**
- Scheduler max concurrency **24 → 4** and default max_tokens **4096 → 1024** (`ProviderLoop`, `StandaloneServer`). The upstream scheduler uses `maxNumSeqs` directly, so 24 let real batches grow far past the 4-way budget reported in heartbeats.
- `applyPostLoadBudgets` no longer **auto-raises** an omitted `max_tokens` to `min(maxContextLength, 8192)` after load — it only clamps **down** for short-context models. A runaway loop on a high-context model otherwise runs to a huge cap and over-reserves KV.
- OpenAI repetition/presence/frequency penalties now propagate through the batched path via a single `makeSamplingParams` helper; a non-positive repetition penalty is coerced to `1.0` (disabled) to avoid a sampler divide-by-zero.

**Coordinator**
- `defaultMaxOutputTokens` **8192 → 1024**; `max_output_length` is treated as an advertised maximum, not the implicit default an omitted-`max_tokens` request receives. `implicitMaxTokensBound` clamps the platform default down to the model's published max when lower. Consumers who need longer generations still set `max_tokens` explicitly (issue #33 reservation logic preserved).
- `freeMemoryAdmits` cold-load + warm admission now mirror the provider's **real** MLX ceiling: `min(0.90 × total, total − 6 GB)` — the tighter of the fraction and `MLXMemoryGuard`'s `physical − 6 GB` reserve, so the coordinator never admits a cold load above what the provider's allocator caps. Adds the 1.2× cold-load overhead, a 3 GB activation reserve, and a 1 GB minimum-KV floor, and counts reclaimable Metal cache (`gpu_memory_cache_gb`) alongside active. Both cold paths (idle + busy) use the same `max(realKV, 1 GB)` floor; a resident model charges only its real KV.

## Why this is conservative (won't reintroduce the crash)

Modern providers report a token budget and take the budget-based admission path that returns **before** any of the memory-envelope math, so this layer only tightens the legacy-fallback and cold-load paths. It can only *false-reject* (route elsewhere), never *false-admit*, so it cannot reintroduce the over-commit it's guarding against.

## Tests

- Provider: `BatchSchedulerBudgetTests` — penalty propagation + non-positive coercion (14 green).
- Coordinator: `implicitMaxTokensBound` semantics, the provider-equivalent cold-load envelope, the tighter-of-two cap, and the busy-cold-load KV floor (`scheduler_test`, `consumer_test`). **Full coordinator suite green.**
- Provider `swift build` clean.

## Review

Dual gate passed. Codex (xhigh) flagged that the coordinator cap initially assumed `total − 2 GB` (mirroring a not-yet-merged branch) while master's provider enforces `total − 6 GB`, and that the busy cold path over-charged KV by 1 GB — both fixed (cap aligned to the tighter of fraction/reserve; both cold paths share one `max(realKV, minKV)` floor) and re-verified resolved. Independent Opus 4.8 reviewer: PASS.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/379"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784235320&installation_id=133247490&pr_number=379&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F379&signature=e17a5e570473d2d25ca1fb3a280080e3ee5fed1fa46d4dadf8e9fb72d2872e1f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->