### PR TITLE
privacy: remove provider hardware serials from public API surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Providers carry one of three trust levels, surfaced to consumers on every respon
 | `self_signed` | Secure Enclave P-256 signature + periodic challenge-response |
 | `hardware` | MDM enrollment + Apple Managed Device Attestation (MDA) certificate chain |
 
-The strongest production gate is **APNs code-identity attestation**, which proves the running provider binary is genuine and team-provisioned. The full attestation chain for any provider is publicly verifiable at **`GET /v1/providers/attestation`**.
+The strongest production gate is **APNs code-identity attestation**, which proves the running provider binary is genuine and team-provisioned. The coordinator-verified attestation status for all online providers is available at **`GET /v1/providers/attestation`**; raw MDA certificate chains and device serial numbers are not exposed publicly.
 
 ## Quickstart (consumers)
 

--- a/console-ui/__tests__/components.test.tsx
+++ b/console-ui/__tests__/components.test.tsx
@@ -15,7 +15,6 @@ function makeTrust(overrides: Partial<TrustMetadata> = {}): TrustMetadata {
     secureEnclave: false,
     mdaVerified: false,
     providerChip: "",
-    providerSerial: "",
     providerModel: "",
     ...overrides,
   };

--- a/console-ui/__tests__/verification-mode.test.tsx
+++ b/console-ui/__tests__/verification-mode.test.tsx
@@ -92,36 +92,4 @@ describe("VerificationModeProvider", () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// Serial masking (tested via TrustBadge integration, but also unit-testable)
-// ---------------------------------------------------------------------------
 
-describe("maskSerial", () => {
-  // The maskSerial function is defined locally in VerificationPanel and
-  // E2ELockIndicator. We test the logic here to ensure correctness.
-  function maskSerial(serial: string): string {
-    if (serial.length <= 6) return serial;
-    return (
-      serial.slice(0, 4) +
-      "\u2022".repeat(serial.length - 6) +
-      serial.slice(-2)
-    );
-  }
-
-  it("masks a 10-char serial", () => {
-    expect(maskSerial("L7Q172774D")).toBe("L7Q1\u2022\u2022\u2022\u20224D");
-  });
-
-  it("preserves serials 6 chars or shorter", () => {
-    expect(maskSerial("ABC")).toBe("ABC");
-    expect(maskSerial("ABCDEF")).toBe("ABCDEF");
-  });
-
-  it("masks a 7-char serial correctly", () => {
-    expect(maskSerial("ABCDEFG")).toBe("ABCD\u2022FG");
-  });
-
-  it("handles empty string", () => {
-    expect(maskSerial("")).toBe("");
-  });
-});

--- a/console-ui/src/app/api-console/page.tsx
+++ b/console-ui/src/app/api-console/page.tsx
@@ -146,23 +146,21 @@ const ENDPOINTS = [
   {
     method: "GET",
     path: "/v1/providers/attestation",
-    description: "Full attestation chain for all online providers",
+    description: "Attestation metadata for all online providers",
     icon: Shield,
     auth: false,
     response: `{
   "providers": [{
     "id": "...",
     "chip": "Apple M4 Max",
-    "serial": "F46G****0H",
     "trust_level": "hardware",
     "secure_enclave": true,
     "sip_enabled": true,
     "mda_verified": true,
-    "se_key_bound": true,
-    "attestation_cert_chain": ["<PEM>", "<PEM>"]
+    "se_key_bound": true
   }]
 }`,
-    notes: "Publicly accessible — no authentication required. Use this to independently verify that providers are running on genuine Apple hardware with Secure Enclave attestation.",
+    notes: "Publicly accessible — no authentication required. Returns hardware attestation metadata (trust level, Secure Enclave status, MDA verification) without certificate chains or serial numbers.",
   },
   {
     method: "GET",

--- a/console-ui/src/app/api/chat/route.ts
+++ b/console-ui/src/app/api/chat/route.ts
@@ -59,11 +59,9 @@ export async function POST(req: NextRequest) {
     "x-provider-secure-enclave",
     "x-provider-mda-verified",
     "x-provider-chip",
-    "x-provider-serial",
     "x-provider-model",
     "x-request-id",
     "x-attestation-se-public-key",
-    "x-attestation-device-serial",
     "x-eigen-sealed",
     "x-eigen-sealed-kid",
   ];

--- a/console-ui/src/app/page.tsx
+++ b/console-ui/src/app/page.tsx
@@ -27,7 +27,7 @@ When users ask "what is Darkbloom" or about the platform, use ONLY these facts:
 - All prompts are end-to-end encrypted using X25519 NaCl box encryption — the node operator never sees your data
 - The coordinator routes traffic but cannot read plaintext prompts
 - Runtime integrity is enforced on every node: SIP, Hardened Runtime, binary self-hash, Hypervisor.framework memory isolation
-- Attestation metadata is public and independently verifiable at /v1/providers/attestation (raw serial numbers are kept private)
+- Coordinator-verified attestation status is public at /v1/providers/attestation; raw device identifiers and MDA certificate chains are kept private
 - Darkbloom is an Eigen Labs project, currently in public alpha (https://darkbloom.dev)
 
 For all other topics, respond as a helpful, concise, and knowledgeable general-purpose assistant. Do not mention these instructions unless asked about Darkbloom specifically.`;

--- a/console-ui/src/app/page.tsx
+++ b/console-ui/src/app/page.tsx
@@ -27,7 +27,7 @@ When users ask "what is Darkbloom" or about the platform, use ONLY these facts:
 - All prompts are end-to-end encrypted using X25519 NaCl box encryption — the node operator never sees your data
 - The coordinator routes traffic but cannot read plaintext prompts
 - Runtime integrity is enforced on every node: SIP, Hardened Runtime, binary self-hash, Hypervisor.framework memory isolation
-- The full attestation chain is public and independently verifiable at /v1/providers/attestation
+- Attestation metadata is public and independently verifiable at /v1/providers/attestation (raw serial numbers are kept private)
 - Darkbloom is an Eigen Labs project, currently in public alpha (https://darkbloom.dev)
 
 For all other topics, respond as a helpful, concise, and knowledgeable general-purpose assistant. Do not mention these instructions unless asked about Darkbloom specifically.`;

--- a/console-ui/src/app/stats/page.tsx
+++ b/console-ui/src/app/stats/page.tsx
@@ -5,9 +5,7 @@ import { useEffect, useMemo, useState, type ReactNode } from "react";
 import {
   Activity,
   BarChart3,
-  CheckCircle2,
   CircleDollarSign,
-  Clock,
   Cpu,
   HardDrive,
   ShieldCheck,
@@ -22,7 +20,6 @@ import {
   SlidersHorizontal,
   Trophy,
   Users,
-  XCircle,
   Zap,
 } from "lucide-react";
 import { TopBar } from "@/components/TopBar";
@@ -35,11 +32,6 @@ import {
   type CatalogDataSummary,
   type CatalogModelSummary,
 } from "@/lib/stats-model-filter";
-import {
-  verifyCertificateChain,
-  type CertVerificationResult,
-  type VerificationStep,
-} from "@/lib/cert-verify";
 import { formatPower } from "@/lib/format-power";
 import { activeNetworkPowerWatts } from "@/lib/network-power";
 
@@ -172,25 +164,6 @@ interface PlatformStats {
   suppressed_request_city_requests?: number;
   request_location_privacy_min_requests?: number;
   time_series: TimeSeriesBucket[];
-}
-
-interface ProviderAttestation {
-  provider_id: string;
-  trust_level: string;
-  status: string;
-  serial_number?: string;
-  se_public_key?: string;
-  mda_verified?: boolean;
-  acme_verified?: boolean;
-  secure_enclave?: boolean;
-  sip_enabled?: boolean;
-  secure_boot_enabled?: boolean;
-  authenticated_root_enabled?: boolean;
-  system_volume_hash?: string;
-  mda_cert_chain_b64?: string[];
-  mda_serial?: string;
-  mda_os_version?: string;
-  mda_sepos_version?: string;
 }
 
 type NodeStatusFilter = "all" | "routable" | "serving" | "online" | "attention";
@@ -1038,12 +1011,6 @@ function compareProviders(a: ProviderStats, b: ProviderStats, sortKey: NodeSortK
 function compactId(id: string): string {
   if (id.length <= 14) return id;
   return `${id.slice(0, 8)}...${id.slice(-4)}`;
-}
-
-function maskSerial(serial?: string): string {
-  if (!serial) return "";
-  if (serial.length <= 7) return serial;
-  return `${serial.slice(0, 4)}...${serial.slice(-3)}`;
 }
 
 function verificationLabel(provider: ProviderStats): string {
@@ -2153,33 +2120,6 @@ function NodeMetric({
   );
 }
 
-function VerifyStepLine({ step }: { step: VerificationStep }) {
-  let icon = <Clock size={12} className="text-text-tertiary" />;
-  if (step.status === "success") {
-    icon = <CheckCircle2 size={12} className="text-accent-green" />;
-  }
-  if (step.status === "error") {
-    icon = <XCircle size={12} className="text-accent-red" />;
-  }
-  if (step.status === "running") {
-    icon = <Loader2 size={12} className="animate-spin text-accent-brand" />;
-  }
-
-  return (
-    <div className="flex gap-2 py-1.5">
-      <div className="mt-0.5 shrink-0">{icon}</div>
-      <div className="min-w-0">
-        <p className="text-xs text-text-secondary">{step.label}</p>
-        {step.detail && (
-          <p className="mt-0.5 break-words text-[11px] font-mono text-text-tertiary">
-            {step.detail}
-          </p>
-        )}
-      </div>
-    </div>
-  );
-}
-
 function LeaderboardSection() {
   const [metric, setMetric] = useState<LeaderboardMetric>("earnings");
   const [window, setWindow] = useState<LeaderboardWindow>("7d");
@@ -2529,44 +2469,16 @@ function NodeRow({
   );
 }
 
-function NodeDetail({
-  provider,
-  verifying,
-  verifySteps,
-  verifyResult,
-  attestation,
-  onVerify,
-}: {
-  provider: ProviderStats | null;
-  verifying: boolean;
-  verifySteps: VerificationStep[];
-  verifyResult: CertVerificationResult | null;
-  attestation: ProviderAttestation | null;
-  onVerify: (provider: ProviderStats) => void;
-}) {
+function NodeDetail({ provider }: { provider: ProviderStats | null }) {
   if (!provider) {
     return (
       <div className="rounded-xl border border-border-dim bg-bg-secondary p-5 text-sm text-text-tertiary">
-        Select a node to inspect its capacity and verification state.
+        Select a node to inspect its capacity and attestation state.
       </div>
     );
   }
 
-  const certCount = attestation?.mda_cert_chain_b64?.length ?? 0;
-  const verifiedSerial = maskSerial(
-    verifyResult?.deviceInfo?.serial || attestation?.mda_serial || attestation?.serial_number
-  );
   const modelList = provider.models ?? [];
-  let verificationState = "Certificate not checked";
-  let verificationColor = "text-text-tertiary";
-  if (verifyResult?.success) {
-    verificationState = "Apple certificate verified";
-    verificationColor = "text-accent-green";
-  }
-  if (verifyResult && !verifyResult.success) {
-    verificationState = "Certificate check failed";
-    verificationColor = "text-accent-red";
-  }
 
   return (
     <div className="rounded-xl border border-border-dim bg-bg-secondary p-5 shadow-sm">
@@ -2593,24 +2505,7 @@ function NodeDetail({
       </div>
 
       <div className="mt-4 rounded-lg border border-border-dim bg-bg-primary p-3">
-        <div className="flex items-start justify-between gap-3">
-          <div>
-            <p className="text-xs font-semibold text-text-primary">Certificate verification</p>
-            <p className={`mt-0.5 text-[11px] font-mono ${verificationColor}`}>
-              {verificationState}
-            </p>
-          </div>
-          <button
-            type="button"
-            onClick={() => onVerify(provider)}
-            disabled={verifying}
-            className="inline-flex items-center gap-1.5 rounded-lg border border-border-subtle px-2.5 py-1.5 text-xs font-medium text-text-secondary transition-colors hover:bg-bg-hover disabled:cursor-not-allowed disabled:opacity-60"
-          >
-            {verifying ? <Loader2 size={12} className="animate-spin" /> : <ShieldCheck size={12} />}
-            Verify
-          </button>
-        </div>
-
+        <p className="text-xs font-semibold text-text-primary">Attestation metadata</p>
         <div className="mt-3 grid grid-cols-2 gap-2 text-[11px] font-mono">
           <div className="rounded-md bg-bg-secondary px-2 py-1.5">
             <p className="text-text-tertiary">Trust</p>
@@ -2621,27 +2516,14 @@ function NodeDetail({
             <p className="text-text-primary">{relativeChallengeLabel(provider.last_challenge_verified)}</p>
           </div>
           <div className="rounded-md bg-bg-secondary px-2 py-1.5">
-            <p className="text-text-tertiary">Certificates</p>
-            <p className="text-text-primary">{certCount > 0 ? certCount : provider.certificate_available ? "available" : "none"}</p>
+            <p className="text-text-tertiary">MDA verified</p>
+            <p className="text-text-primary">{provider.mda_verified ? "Yes" : "No"}</p>
           </div>
           <div className="rounded-md bg-bg-secondary px-2 py-1.5">
-            <p className="text-text-tertiary">Serial</p>
-            <p className="text-text-primary">{verifiedSerial || "hidden"}</p>
+            <p className="text-text-tertiary">ACME bound</p>
+            <p className="text-text-primary">{provider.acme_verified ? "Yes" : "No"}</p>
           </div>
         </div>
-
-        {(verifySteps.length > 0 || verifyResult?.error) && (
-          <div className="mt-3 border-t border-border-dim pt-2">
-            {verifySteps.map((step) => (
-              <VerifyStepLine key={step.label} step={step} />
-            ))}
-            {verifyResult?.error && (
-              <p className="mt-2 rounded-md bg-accent-red/5 px-2 py-1.5 text-[11px] text-accent-red">
-                {verifyResult.error}
-              </p>
-            )}
-          </div>
-        )}
       </div>
 
       <div className="mt-4">
@@ -2678,10 +2560,6 @@ function NetworkNodes({ providers }: { providers: ProviderStats[] }) {
   const [trustFilter, setTrustFilter] = useState<NodeTrustFilter>("all");
   const [modelFilter, setModelFilter] = useState("all");
   const [sortKey, setSortKey] = useState<NodeSortKey>("capacity");
-  const [verifyingId, setVerifyingId] = useState<string | null>(null);
-  const [verifySteps, setVerifySteps] = useState<VerificationStep[]>([]);
-  const [verifyResult, setVerifyResult] = useState<CertVerificationResult | null>(null);
-  const [attestation, setAttestation] = useState<ProviderAttestation | null>(null);
   const statusOptions: Array<{ value: NodeStatusFilter; label: string }> = [
     { value: "all", label: "All" },
     { value: "routable", label: "Routable" },
@@ -2747,71 +2625,6 @@ function NetworkNodes({ providers }: { providers: ProviderStats[] }) {
     }
   }, [selectedProvider, selectedProviderId]);
 
-  useEffect(() => {
-    setVerifySteps([]);
-    setVerifyResult(null);
-    setAttestation(null);
-  }, [selectedProviderId]);
-
-  async function handleVerify(provider: ProviderStats) {
-    setVerifyingId(provider.id);
-    setVerifySteps([]);
-    setVerifyResult(null);
-    setAttestation(null);
-
-    try {
-      const response = await fetch("/api/attestation");
-      if (!response.ok) {
-        throw new Error(`Attestation API returned HTTP ${response.status}`);
-      }
-      const data = await response.json();
-      const attestedProviders: ProviderAttestation[] = data.providers ?? [];
-      const matched =
-        attestedProviders.find((entry) => entry.provider_id === provider.id) ??
-        attestedProviders.find((entry) => entry.provider_id?.startsWith(provider.id)) ??
-        null;
-
-      if (!matched) {
-        setVerifyResult({
-          success: false,
-          steps: [],
-          error: "Node was not present in the public attestation feed.",
-        });
-        return;
-      }
-
-      setAttestation(matched);
-      const certs = matched.mda_cert_chain_b64 ?? [];
-      if (certs.length < 2) {
-        setVerifyResult({
-          success: false,
-          steps: [
-            {
-              status: "error",
-              label: "Insufficient certificate chain",
-              detail: `Got ${certs.length}, need at least 2 certificates.`,
-            },
-          ],
-          error: "This node has no Apple MDA certificate chain available yet.",
-        });
-        return;
-      }
-
-      const result = await verifyCertificateChain(certs, (steps) => {
-        setVerifySteps(steps);
-      });
-      setVerifyResult(result);
-    } catch (error) {
-      setVerifyResult({
-        success: false,
-        steps: [],
-        error: error instanceof Error ? error.message : String(error),
-      });
-    } finally {
-      setVerifyingId(null);
-    }
-  }
-
   return (
     <section className="rounded-xl border border-border-dim bg-bg-primary p-5 shadow-sm">
       <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
@@ -2821,7 +2634,7 @@ function NetworkNodes({ providers }: { providers: ProviderStats[] }) {
             <h2 className="text-sm font-semibold text-text-primary">Provider Dashboard</h2>
           </div>
           <p className="mt-1 text-xs text-text-tertiary">
-            Routability, node health, model coverage, and certificate verification
+            Routability, node health, model coverage, and attestation metadata
           </p>
         </div>
         <div className="grid grid-cols-3 gap-3 text-right">
@@ -2932,14 +2745,7 @@ function NetworkNodes({ providers }: { providers: ProviderStats[] }) {
                 />
                 {provider.id === selectedProvider?.id && (
                   <div className="pl-0 sm:pl-8">
-                    <NodeDetail
-                      provider={provider}
-                      verifying={verifyingId === provider.id}
-                      verifySteps={verifySteps}
-                      verifyResult={verifyResult}
-                      attestation={attestation}
-                      onVerify={handleVerify}
-                    />
+                    <NodeDetail provider={provider} />
                   </div>
                 )}
               </div>

--- a/console-ui/src/components/E2ELockIndicator.tsx
+++ b/console-ui/src/components/E2ELockIndicator.tsx
@@ -3,20 +3,13 @@
 import { useState, useRef, useEffect } from "react";
 import { Lock } from "lucide-react";
 import type { TrustMetadata } from "@/lib/api";
-import { useVerificationMode } from "@/lib/verification-mode";
 
 interface E2ELockIndicatorProps {
   trust?: TrustMetadata;
   onOpenExplainer?: () => void;
 }
 
-function maskSerial(serial: string): string {
-  if (serial.length <= 6) return serial;
-  return serial.slice(0, 4) + "\u2022".repeat(serial.length - 6) + serial.slice(-2);
-}
-
 export function E2ELockIndicator({ trust, onOpenExplainer }: E2ELockIndicatorProps) {
-  const { mode } = useVerificationMode();
   const [showPopover, setShowPopover] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
 
@@ -57,18 +50,12 @@ export function E2ELockIndicator({ trust, onOpenExplainer }: E2ELockIndicatorPro
               Messages are secured with end-to-end encryption.
               Only the verified provider hardware can decrypt your prompts.
             </p>
-            {trust && (trust.providerChip || trust.providerSerial) && (
+            {trust && trust.providerChip && (
               <div className="rounded-lg bg-bg-secondary px-3 py-2">
                 {trust.providerChip && (
                   <p className="text-xs text-text-secondary">
                     <span className="font-mono text-text-tertiary">Chip:</span>{" "}
                     {trust.providerChip}
-                  </p>
-                )}
-                {trust.providerSerial && (
-                  <p className="text-xs text-text-secondary">
-                    <span className="font-mono text-text-tertiary">Serial:</span>{" "}
-                    {mode === "normal" ? maskSerial(trust.providerSerial) : trust.providerSerial}
                   </p>
                 )}
               </div>

--- a/console-ui/src/components/VerificationPanel.tsx
+++ b/console-ui/src/components/VerificationPanel.tsx
@@ -5,11 +5,6 @@ import type { TrustMetadata } from "@/lib/api";
 import { useVerificationMode } from "@/lib/verification-mode";
 import { TrustExplainerModal } from "./TrustExplainerModal";
 import {
-  verifyCertificateChain,
-  type VerificationStep,
-  type CertVerificationResult,
-} from "@/lib/cert-verify";
-import {
   ShieldCheck,
   Shield,
   ChevronDown,
@@ -19,21 +14,10 @@ import {
   Lock,
   HardDrive,
   Fingerprint,
-  Loader2,
-  ExternalLink,
   Code,
   Eye,
   Info,
 } from "lucide-react";
-
-const ATTESTATION_API = "https://api.darkbloom.dev";
-
-/** Mask a serial number for normal mode: show first 4 + last 2, mask the rest. */
-function maskSerial(serial: string): string {
-  if (serial.length <= 6) return serial;
-  const masked = serial.slice(0, 4) + "\u2022".repeat(serial.length - 6) + serial.slice(-2);
-  return masked;
-}
 
 function StatusLine({
   ok,
@@ -61,46 +45,13 @@ function StatusLine({
   );
 }
 
-function VerifyStepLine({ step }: { step: VerificationStep }) {
-  return (
-    <div className="flex items-center gap-2 py-0.5">
-      {step.status === "success" && (
-        <Check size={12} className="text-accent-green shrink-0" />
-      )}
-      {step.status === "error" && (
-        <X size={12} className="text-accent-red shrink-0" />
-      )}
-      {step.status === "running" && (
-        <Loader2 size={12} className="text-accent-brand animate-spin shrink-0" />
-      )}
-      {step.status === "pending" && (
-        <div className="w-3 h-3 rounded-full border border-border-dim shrink-0" />
-      )}
-      <span className="text-xs text-text-primary">{step.label}</span>
-      {step.detail && (
-        <span className="text-xs text-text-tertiary ml-auto font-mono truncate max-w-[180px]">
-          {step.detail}
-        </span>
-      )}
-    </div>
-  );
-}
-
-/** Normal mode: human-readable trust guarantees with one-click verification. */
+/** Normal mode: human-readable trust guarantees. */
 function NormalModeContent({
   trust,
   onOpenExplainer,
-  verifySteps,
-  verifyResult,
-  verifying,
-  onVerify,
 }: {
   trust: TrustMetadata;
   onOpenExplainer: () => void;
-  verifySteps: VerificationStep[];
-  verifyResult: CertVerificationResult | null;
-  verifying: boolean;
-  onVerify: () => void;
 }) {
   const isHardware = trust.trustLevel === "hardware";
 
@@ -168,50 +119,6 @@ function NormalModeContent({
         </div>
       ))}
 
-      {/* One-click verification for normal users */}
-      {isHardware && (
-        <div className="pt-2 border-t border-border-dim/50">
-          <button
-            onClick={onVerify}
-            disabled={verifying}
-            className="flex items-center gap-2 px-3 py-2 rounded-lg bg-teal-light/50 border-2 border-teal/30 text-teal text-xs font-semibold hover:bg-teal-light/70 transition-colors disabled:opacity-50 w-full justify-center"
-          >
-            {verifying ? (
-              <Loader2 size={14} className="animate-spin" />
-            ) : (
-              <ShieldCheck size={14} />
-            )}
-            {verifying
-              ? "Verifying..."
-              : verifyResult?.success
-                ? "Apple-verified hardware"
-                : "Verify device"}
-          </button>
-
-          {/* Step-by-step progress */}
-          {verifySteps.length > 0 && (
-            <div className="mt-2 space-y-0.5">
-              {verifySteps.map((step, i) => (
-                <VerifyStepLine key={i} step={step} />
-              ))}
-            </div>
-          )}
-
-          {/* Result message */}
-          {verifyResult && (
-            <p
-              className={`mt-2 text-xs font-semibold text-center ${
-                verifyResult.success ? "text-accent-green" : "text-accent-red"
-              }`}
-            >
-              {verifyResult.success
-                ? `Genuine Apple device ${verifyResult.deviceInfo?.serial ? `(${verifyResult.deviceInfo.serial})` : ""}`
-                : verifyResult.error || "Verification failed"}
-            </p>
-          )}
-        </div>
-      )}
-
       <button
         onClick={onOpenExplainer}
         className="flex items-center gap-1.5 text-xs text-teal font-semibold hover:underline mt-2"
@@ -226,18 +133,8 @@ function NormalModeContent({
 /** Technical mode: detailed checks with raw values. */
 function TechnicalModeContent({
   trust,
-  verifySteps,
-  verifyResult,
-  verifying,
-  onVerify,
-  providerDetail,
 }: {
   trust: TrustMetadata;
-  verifySteps: VerificationStep[];
-  verifyResult: CertVerificationResult | null;
-  verifying: boolean;
-  onVerify: () => void;
-  providerDetail: ProviderDetail | null;
 }) {
   const isHardware = trust.trustLevel === "hardware";
 
@@ -346,111 +243,6 @@ function TechnicalModeContent({
         </div>
       )}
 
-      {isHardware && (
-        <div className="mt-3 pt-2 border-t border-border-dim/50">
-          <button
-            onClick={onVerify}
-            disabled={verifying}
-            className="flex items-center gap-2 px-3 py-2 rounded-lg bg-accent-brand/10 text-accent-brand text-xs font-medium hover:bg-accent-brand/20 transition-colors disabled:opacity-50"
-          >
-            {verifying ? (
-              <Loader2 size={12} className="animate-spin" />
-            ) : (
-              <ShieldCheck size={12} />
-            )}
-            Verify Apple Attestation
-          </button>
-
-          {/* Live verification steps */}
-          {verifySteps.length > 0 && (
-            <div className="mt-2 space-y-0.5">
-              {verifySteps.map((step, i) => (
-                <VerifyStepLine key={i} step={step} />
-              ))}
-            </div>
-          )}
-
-          {/* Final result */}
-          {verifyResult && (
-            <p
-              className={`mt-2 text-xs font-semibold leading-relaxed ${
-                verifyResult.success ? "text-accent-green" : "text-accent-red"
-              }`}
-            >
-              {verifyResult.success
-                ? "Genuine Apple device — certificate chain verified against Apple Root CA."
-                : verifyResult.error || "Verification failed"}
-            </p>
-          )}
-
-          {/* Provider details from API */}
-          {providerDetail && (
-            <div className="mt-2 space-y-1.5 text-xs text-text-tertiary">
-              {providerDetail.mdaSerial && (
-                <p>
-                  <span className="font-mono">MDA Serial:</span>{" "}
-                  {providerDetail.mdaSerial}
-                </p>
-              )}
-              {providerDetail.mdaOsVersion && (
-                <p>
-                  <span className="font-mono">macOS:</span>{" "}
-                  {providerDetail.mdaOsVersion}
-                  {providerDetail.mdaSepVersion &&
-                    ` · SepOS: ${providerDetail.mdaSepVersion}`}
-                </p>
-              )}
-              {providerDetail.mdaCertCount !== undefined &&
-                providerDetail.mdaCertCount > 0 && (
-                  <p>
-                    <span className="font-mono">Apple Certs:</span>{" "}
-                    {providerDetail.mdaCertCount} (leaf + intermediate)
-                  </p>
-                )}
-              {providerDetail.systemVolumeHash && (
-                <div>
-                  <p className="font-mono">Volume Hash:</p>
-                  <p className="text-xs font-mono break-all bg-bg-tertiary rounded px-2 py-1 mt-0.5">
-                    {providerDetail.systemVolumeHash}
-                  </p>
-                </div>
-              )}
-              {providerDetail.sePublicKey && (
-                <div>
-                  <p className="font-mono">SE Public Key:</p>
-                  <p className="text-xs font-mono break-all bg-bg-tertiary rounded px-2 py-1 mt-0.5">
-                    {providerDetail.sePublicKey}
-                  </p>
-                </div>
-              )}
-            </div>
-          )}
-
-          <p className="mt-2 text-xs text-text-tertiary leading-relaxed">
-            Manual: download MDA cert chain from{" "}
-            <a
-              href={`${ATTESTATION_API}/v1/providers/attestation`}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-accent-brand hover:underline inline-flex items-center gap-0.5"
-            >
-              attestation API
-              <ExternalLink size={10} />
-            </a>
-            , decode base64 to DER, verify against{" "}
-            <a
-              href="https://www.apple.com/certificateauthority/"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-accent-brand hover:underline inline-flex items-center gap-0.5"
-            >
-              Apple&apos;s Root CA
-              <ExternalLink size={10} />
-            </a>
-          </p>
-        </div>
-      )}
-
       {!isHardware && (
         <div className="mt-3 pt-2 border-t border-border-dim/50">
           <p className="text-xs text-text-tertiary leading-relaxed">
@@ -462,24 +254,9 @@ function TechnicalModeContent({
   );
 }
 
-interface ProviderDetail {
-  systemVolumeHash?: string;
-  sePublicKey?: string;
-  mdaSerial?: string;
-  mdaOsVersion?: string;
-  mdaSepVersion?: string;
-  mdaCertCount?: number;
-}
-
 export function VerificationPanel({ trust }: { trust: TrustMetadata }) {
   const { mode, toggle } = useVerificationMode();
   const [open, setOpen] = useState(false);
-  const [verifying, setVerifying] = useState(false);
-  const [verifySteps, setVerifySteps] = useState<VerificationStep[]>([]);
-  const [verifyResult, setVerifyResult] = useState<CertVerificationResult | null>(
-    null
-  );
-  const [providerDetail, setProviderDetail] = useState<ProviderDetail | null>(null);
   const [showExplainer, setShowExplainer] = useState(false);
 
   const isHardware = trust.trustLevel === "hardware";
@@ -495,79 +272,7 @@ export function VerificationPanel({ trust }: { trust: TrustMetadata }) {
       : "Hardware Verified"
     : "Unverified";
 
-  const displaySerial = trust.providerSerial
-    ? mode === "normal" ? maskSerial(trust.providerSerial) : trust.providerSerial
-    : "";
-  const chipLabel = trust.providerChip
-    ? `${trust.providerChip}${displaySerial ? ` · ${displaySerial}` : ""}`
-    : "";
-
-  async function handleVerify() {
-    setVerifying(true);
-    setVerifyResult(null);
-    setVerifySteps([]);
-
-    try {
-      const res = await fetch(`${ATTESTATION_API}/v1/providers/attestation`);
-      const data = await res.json();
-
-      const provider =
-        data.providers?.find(
-          (p: { serial_number: string }) =>
-            p.serial_number === trust.providerSerial
-        ) || data.providers?.[0];
-
-      if (!provider) {
-        setVerifyResult({
-          success: false,
-          steps: [],
-          error: "Provider not found in attestation API",
-        });
-        return;
-      }
-
-      setProviderDetail({
-        systemVolumeHash: provider.system_volume_hash,
-        sePublicKey: provider.se_public_key,
-        mdaSerial: provider.mda_serial,
-        mdaOsVersion: provider.mda_os_version,
-        mdaSepVersion: provider.mda_sepos_version,
-        mdaCertCount: provider.mda_cert_chain_b64?.length || 0,
-      });
-
-      const certs: string[] = provider.mda_cert_chain_b64 || [];
-
-      if (certs.length < 2) {
-        setVerifyResult({
-          success: false,
-          steps: [
-            {
-              status: "error",
-              label: "Insufficient certificates",
-              detail: `Got ${certs.length}, need at least 2`,
-            },
-          ],
-          error: "Certificate chain too short for verification",
-        });
-        return;
-      }
-
-      // Real X.509 verification!
-      const result = await verifyCertificateChain(certs, (steps) => {
-        setVerifySteps(steps);
-      });
-
-      setVerifyResult(result);
-    } catch (e) {
-      setVerifyResult({
-        success: false,
-        steps: [],
-        error: `Error: ${e instanceof Error ? e.message : String(e)}`,
-      });
-    } finally {
-      setVerifying(false);
-    }
-  }
+  const chipLabel = trust.providerChip ? trust.providerChip : "";
 
   return (
     <>
@@ -625,20 +330,9 @@ export function VerificationPanel({ trust }: { trust: TrustMetadata }) {
               <NormalModeContent
                 trust={trust}
                 onOpenExplainer={() => setShowExplainer(true)}
-                verifySteps={verifySteps}
-                verifyResult={verifyResult}
-                verifying={verifying}
-                onVerify={handleVerify}
               />
             ) : (
-              <TechnicalModeContent
-                trust={trust}
-                verifySteps={verifySteps}
-                verifyResult={verifyResult}
-                verifying={verifying}
-                onVerify={handleVerify}
-                providerDetail={providerDetail}
-              />
+              <TechnicalModeContent trust={trust} />
             )}
           </div>
         )}

--- a/console-ui/src/lib/api.ts
+++ b/console-ui/src/lib/api.ts
@@ -107,13 +107,11 @@ export interface TrustMetadata {
   secureEnclave: boolean;
   mdaVerified: boolean;
   providerChip: string;
-  providerSerial: string;
   providerModel: string;
   // Attestation receipt fields (per-request SE signature)
   responseHash?: string;
   seSignature?: string;
   sePublicKey?: string;
-  deviceSerial?: string;
 }
 
 export interface StreamMetrics {
@@ -620,11 +618,9 @@ export async function streamChat(
     secureEnclave: res.headers.get("x-provider-secure-enclave") === "true",
     mdaVerified: res.headers.get("x-provider-mda-verified") === "true",
     providerChip: res.headers.get("x-provider-chip") || "",
-    providerSerial: res.headers.get("x-provider-serial") || "",
     providerModel: res.headers.get("x-provider-model") || "",
     // Attestation receipt fields (populated from headers + SSE events)
     sePublicKey: res.headers.get("x-attestation-se-public-key") || undefined,
-    deviceSerial: res.headers.get("x-attestation-device-serial") || undefined,
   };
 
   const reader = res.body?.getReader();

--- a/coordinator/api/dispatch.go
+++ b/coordinator/api/dispatch.go
@@ -1805,7 +1805,6 @@ func (d *dispatchState) writeCommittedResponse() {
 	w.Header().Set("X-Provider-Chip", chipName)
 	w.Header().Set("X-Provider-Model", machineModel)
 	if attestResult != nil {
-		w.Header().Set("X-Provider-Serial", attestResult.SerialNumber)
 		if attestResult.SecureEnclaveAvailable {
 			w.Header().Set("X-Provider-Secure-Enclave", "true")
 		} else {
@@ -1819,7 +1818,6 @@ func (d *dispatchState) writeCommittedResponse() {
 	// Consumers can use this to verify SE signatures on response hashes.
 	if attestResult != nil && attestResult.PublicKey != "" {
 		w.Header().Set("X-Attestation-Se-Public-Key", attestResult.PublicKey)
-		w.Header().Set("X-Attestation-Device-Serial", attestResult.SerialNumber)
 	}
 
 	// Latency decomposition header for observability.

--- a/coordinator/api/provider.go
+++ b/coordinator/api/provider.go
@@ -2846,15 +2846,14 @@ func (s *Server) verifyAppleDeviceAttestation(ctx context.Context, providerID st
 	}
 }
 
-// handleProviderAttestation returns the attestation proof for all providers.
-// Users can independently verify the Apple MDA certificate chain against
-// Apple's public Enterprise Attestation Root CA.
+// handleProviderAttestation returns the coordinator-verified attestation status
+// for all providers. Device serial numbers and per-device MDA certificate chains
+// are intentionally omitted; they remain internal to the coordinator.
 func (s *Server) handleProviderAttestation(w http.ResponseWriter, r *http.Request) {
 	type providerAttestation struct {
 		ProviderID    string `json:"provider_id"`
 		ChipName      string `json:"chip_name"`
 		HardwareModel string `json:"hardware_model"`
-		SerialNumber  string `json:"serial_number"`
 		TrustLevel    string `json:"trust_level"`
 		Status        string `json:"status"`
 
@@ -2877,13 +2876,14 @@ func (s *Server) handleProviderAttestation(w http.ResponseWriter, r *http.Reques
 		// ACME device-attest-01 (SE key proven by Apple)
 		ACMEVerified bool `json:"acme_verified"`
 
-		// Apple Device Attestation (MDA) — certificate chain signed by Apple
-		MDAVerified   bool     `json:"mda_verified"`
-		MDACertChain  []string `json:"mda_cert_chain_b64,omitempty"`
-		MDASerial     string   `json:"mda_serial,omitempty"`
-		MDAUDID       string   `json:"mda_udid,omitempty"`
-		MDAOSVersion  string   `json:"mda_os_version,omitempty"`
-		MDASepVersion string   `json:"mda_sepos_version,omitempty"`
+		// Apple Device Attestation (MDA) — status signed by Apple.
+		// Device serial numbers and the per-device MDA certificate chain are
+		// intentionally omitted from this public endpoint; they remain internal
+		// to the coordinator for debugging, deduplication, and MDM verification.
+		MDAVerified   bool   `json:"mda_verified"`
+		MDAUDID       string `json:"mda_udid,omitempty"`
+		MDAOSVersion  string `json:"mda_os_version,omitempty"`
+		MDASepVersion string `json:"mda_sepos_version,omitempty"`
 	}
 
 	var providers []providerAttestation
@@ -2897,7 +2897,6 @@ func (s *Server) handleProviderAttestation(w http.ResponseWriter, r *http.Reques
 		mdaVerified := p.MDAVerified
 		acmeVerified := p.ACMEVerified
 		attestResult := p.AttestationResult
-		mdaCertChain := p.MDACertChain
 		mdaResult := p.MDAResult
 		// p.Models is replaced copy-on-write by UpdateModelWeightHashes on the
 		// challenge goroutine, so its slice header must be read under p.mu. Copy
@@ -2933,7 +2932,6 @@ func (s *Server) handleProviderAttestation(w http.ResponseWriter, r *http.Reques
 		if attestResult != nil {
 			pa.ChipName = attestResult.ChipName
 			pa.HardwareModel = attestResult.HardwareModel
-			pa.SerialNumber = attestResult.SerialNumber
 			pa.SecureEnclave = attestResult.SecureEnclaveAvailable
 			pa.SIPEnabled = attestResult.SIPEnabled
 			pa.SecureBootEnabled = attestResult.SecureBootEnabled
@@ -2942,36 +2940,29 @@ func (s *Server) handleProviderAttestation(w http.ResponseWriter, r *http.Reques
 			pa.SEPublicKey = attestResult.PublicKey
 		}
 
-		// Include the MDA cert chain + parsed fields for independent verification
-		// ONLY for a connection currently holding hardware trust — same gate as the
-		// mda_verified boolean above. The late-MDA callback (main.go) can attach a
-		// cert chain to a provider that has since reconnected as self_signed; without
-		// this gate the endpoint would emit mda_verified=false alongside a non-empty
-		// mda_cert_chain_b64/serial/udid, which is exactly the drift this fix removes.
-		if isHardware {
-			if len(mdaCertChain) > 0 {
-				for _, der := range mdaCertChain {
-					pa.MDACertChain = append(pa.MDACertChain, base64.StdEncoding.EncodeToString(der))
-				}
-			}
-			if mdaResult != nil {
-				pa.MDASerial = mdaResult.DeviceSerial
-				pa.MDAUDID = mdaResult.DeviceUDID
-				pa.MDAOSVersion = mdaResult.OSVersion
-				pa.MDASepVersion = mdaResult.SepOSVersion
-			}
+		// Include the parsed MDA fields for independent verification ONLY for a
+		// connection currently holding hardware trust — same gate as the
+		// mda_verified boolean above. The late-MDA callback (main.go) can attach
+		// MDA metadata to a provider that has since reconnected as self_signed;
+		// without this gate the endpoint would emit mda_verified=false alongside
+		// a populated udid/os_version/sepos_version, which is the same class of
+		// drift the cert-chain removal fixes. Per-device MDA certificate chains
+		// and serial numbers are not exposed publicly.
+		if isHardware && mdaResult != nil {
+			pa.MDAUDID = mdaResult.DeviceUDID
+			pa.MDAOSVersion = mdaResult.OSVersion
+			pa.MDASepVersion = mdaResult.SepOSVersion
 		}
 
 		providers = append(providers, pa)
 	})
 
 	resp := map[string]any{
-		"providers":                providers,
-		"apple_root_ca_url":        "https://www.apple.com/certificateauthority/",
-		"apple_enterprise_root_ca": "Apple Enterprise Attestation Root CA",
-		"verification_instructions": "Download each provider's mda_cert_chain_b64, decode from base64 to DER, " +
-			"then verify the certificate chain against Apple's Enterprise Attestation Root CA. " +
-			"If verification passes, Apple has confirmed this is a real Apple device with the attested properties.",
+		"providers": providers,
+		"verification_instructions": "This endpoint shows the coordinator-verified MDA status for each provider. " +
+			"mda_verified is true only for providers currently holding hardware trust, meaning Apple Device Attestation " +
+			"was verified by the coordinator against Apple's Enterprise Attestation Root CA. " +
+			"Per-device MDA certificate chains and serial numbers are not exposed on this public endpoint.",
 	}
 	writeJSON(w, http.StatusOK, resp)
 }

--- a/coordinator/api/provider.go
+++ b/coordinator/api/provider.go
@@ -2877,11 +2877,11 @@ func (s *Server) handleProviderAttestation(w http.ResponseWriter, r *http.Reques
 		ACMEVerified bool `json:"acme_verified"`
 
 		// Apple Device Attestation (MDA) — status signed by Apple.
-		// Device serial numbers and the per-device MDA certificate chain are
-		// intentionally omitted from this public endpoint; they remain internal
-		// to the coordinator for debugging, deduplication, and MDM verification.
+		// Device serial numbers, UDIDs, and the per-device MDA certificate chain
+		// are intentionally omitted from this public endpoint; they remain
+		// internal to the coordinator for debugging, deduplication, and MDM
+		// verification.
 		MDAVerified   bool   `json:"mda_verified"`
-		MDAUDID       string `json:"mda_udid,omitempty"`
 		MDAOSVersion  string `json:"mda_os_version,omitempty"`
 		MDASepVersion string `json:"mda_sepos_version,omitempty"`
 	}
@@ -2940,16 +2940,15 @@ func (s *Server) handleProviderAttestation(w http.ResponseWriter, r *http.Reques
 			pa.SEPublicKey = attestResult.PublicKey
 		}
 
-		// Include the parsed MDA fields for independent verification ONLY for a
-		// connection currently holding hardware trust — same gate as the
-		// mda_verified boolean above. The late-MDA callback (main.go) can attach
-		// MDA metadata to a provider that has since reconnected as self_signed;
-		// without this gate the endpoint would emit mda_verified=false alongside
-		// a populated udid/os_version/sepos_version, which is the same class of
-		// drift the cert-chain removal fixes. Per-device MDA certificate chains
-		// and serial numbers are not exposed publicly.
+		// Include the parsed MDA OS/security fields ONLY for a connection
+		// currently holding hardware trust — same gate as the mda_verified
+		// boolean above. The late-MDA callback (main.go) can attach MDA metadata
+		// to a provider that has since reconnected as self_signed; without this
+		// gate the endpoint would emit mda_verified=false alongside populated
+		// os_version/sepos_version, which is the same class of drift the
+		// cert-chain removal fixes. Device identifiers (serial/UDID) and the
+		// per-device MDA certificate chain are not exposed publicly.
 		if isHardware && mdaResult != nil {
-			pa.MDAUDID = mdaResult.DeviceUDID
 			pa.MDAOSVersion = mdaResult.OSVersion
 			pa.MDASepVersion = mdaResult.SepOSVersion
 		}
@@ -2962,7 +2961,7 @@ func (s *Server) handleProviderAttestation(w http.ResponseWriter, r *http.Reques
 		"verification_instructions": "This endpoint shows the coordinator-verified MDA status for each provider. " +
 			"mda_verified is true only for providers currently holding hardware trust, meaning Apple Device Attestation " +
 			"was verified by the coordinator against Apple's Enterprise Attestation Root CA. " +
-			"Per-device MDA certificate chains and serial numbers are not exposed on this public endpoint.",
+			"Device identifiers (serial numbers / UDIDs) and per-device MDA certificate chains are not exposed on this public endpoint.",
 	}
 	writeJSON(w, http.StatusOK, resp)
 }

--- a/coordinator/api/provider_mdm_reliability_test.go
+++ b/coordinator/api/provider_mdm_reliability_test.go
@@ -495,9 +495,9 @@ func TestProviderAttestationGatesMDAPayloadOnHardware(t *testing.T) {
 
 	var parsed struct {
 		Providers []struct {
-			ProviderID  string `json:"provider_id"`
-			MDAVerified bool   `json:"mda_verified"`
-			MDAUDID     string `json:"mda_udid"`
+			ProviderID   string `json:"provider_id"`
+			MDAVerified  bool   `json:"mda_verified"`
+			MDAOSVersion string `json:"mda_os_version"`
 		} `json:"providers"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
@@ -506,16 +506,16 @@ func TestProviderAttestationGatesMDAPayloadOnHardware(t *testing.T) {
 	for _, pr := range parsed.Providers {
 		switch pr.ProviderID {
 		case "ss-payload":
-			if pr.MDAVerified || pr.MDAUDID != "" {
-				t.Errorf("self_signed provider leaked MDA payload: verified=%v udid=%q",
-					pr.MDAVerified, pr.MDAUDID)
+			if pr.MDAVerified || pr.MDAOSVersion != "" {
+				t.Errorf("self_signed provider leaked MDA payload: verified=%v os_version=%q",
+					pr.MDAVerified, pr.MDAOSVersion)
 			}
 		case "hw-payload":
 			if !pr.MDAVerified {
 				t.Errorf("hardware provider should be mda_verified=true, got %v", pr.MDAVerified)
 			}
-			if pr.MDAUDID == "" {
-				t.Errorf("hardware provider should expose mda_udid, got empty")
+			if pr.MDAOSVersion == "" {
+				t.Errorf("hardware provider should expose mda_os_version, got empty")
 			}
 		}
 	}

--- a/coordinator/api/provider_mdm_reliability_test.go
+++ b/coordinator/api/provider_mdm_reliability_test.go
@@ -457,7 +457,8 @@ func TestVerifyProviderViaMDM_TransportErrorTransient(t *testing.T) {
 // hardware but still emitted the MDA cert chain + serial/udid payload (which the
 // late-MDA callback can attach to a since-reconnected self_signed provider). The
 // whole MDA payload must be suppressed for non-hardware connections, so the
-// endpoint can never show mda_verified=false alongside a populated cert chain.
+// endpoint can never show mda_verified=false alongside populated MDA metadata.
+// Per-device MDA certificate chains are no longer exposed on this public endpoint.
 func TestProviderAttestationGatesMDAPayloadOnHardware(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	st := store.NewMemory(store.Config{AdminKey: "test-key"})
@@ -494,11 +495,9 @@ func TestProviderAttestationGatesMDAPayloadOnHardware(t *testing.T) {
 
 	var parsed struct {
 		Providers []struct {
-			ProviderID   string   `json:"provider_id"`
-			MDAVerified  bool     `json:"mda_verified"`
-			MDACertChain []string `json:"mda_cert_chain_b64"`
-			MDASerial    string   `json:"mda_serial"`
-			MDAUDID      string   `json:"mda_udid"`
+			ProviderID  string `json:"provider_id"`
+			MDAVerified bool   `json:"mda_verified"`
+			MDAUDID     string `json:"mda_udid"`
 		} `json:"providers"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
@@ -507,14 +506,16 @@ func TestProviderAttestationGatesMDAPayloadOnHardware(t *testing.T) {
 	for _, pr := range parsed.Providers {
 		switch pr.ProviderID {
 		case "ss-payload":
-			if pr.MDAVerified || len(pr.MDACertChain) != 0 || pr.MDASerial != "" || pr.MDAUDID != "" {
-				t.Errorf("self_signed provider leaked MDA payload: verified=%v chain=%d serial=%q udid=%q",
-					pr.MDAVerified, len(pr.MDACertChain), pr.MDASerial, pr.MDAUDID)
+			if pr.MDAVerified || pr.MDAUDID != "" {
+				t.Errorf("self_signed provider leaked MDA payload: verified=%v udid=%q",
+					pr.MDAVerified, pr.MDAUDID)
 			}
 		case "hw-payload":
-			if !pr.MDAVerified || len(pr.MDACertChain) != 2 || pr.MDASerial == "" {
-				t.Errorf("hardware provider should expose MDA payload: verified=%v chain=%d serial=%q",
-					pr.MDAVerified, len(pr.MDACertChain), pr.MDASerial)
+			if !pr.MDAVerified {
+				t.Errorf("hardware provider should be mda_verified=true, got %v", pr.MDAVerified)
+			}
+			if pr.MDAUDID == "" {
+				t.Errorf("hardware provider should expose mda_udid, got empty")
 			}
 		}
 	}

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -2264,7 +2264,10 @@ func (r *Registry) DisconnectDuplicatesBySerial(keepID string, serial string) {
 		if id == keepID {
 			continue
 		}
-		if p.AttestationResult != nil && p.AttestationResult.SerialNumber == serial {
+		// AttestationResult is written under p.mu (SetAttestationResult), so
+		// read it through the thread-safe accessor — this loop holds only the
+		// registry lock, not the per-provider one.
+		if ar := p.GetAttestationResult(); ar != nil && ar.SerialNumber == serial {
 			toEvict = append(toEvict, id)
 		}
 	}

--- a/docs/architecture/security/attestation.md
+++ b/docs/architecture/security/attestation.md
@@ -97,13 +97,14 @@ Limits and honest residuals:
 `GET /v1/providers/attestation` (no auth required) returns, per provider:
 
 - Secure Enclave P-256 public key,
-- hardware info (chip, model, serial, system volume hash),
+- hardware info (chip, model, system volume hash),
 - security state (SIP, SecureBoot, ARV, SE),
 - MDM verification status,
-- Apple MDA certificate chain (base64 DER, leaf + intermediate),
-- MDA-extracted properties (serial, UDID, OS version, SepOS version).
+- `mda_verified` boolean,
+- MDA-extracted properties (UDID, OS version, SepOS version).
 
-Users can independently verify the MDA chain against Apple's public Enterprise Attestation Root CA.
+The coordinator verifies the MDA chain internally; the raw chain is not exposed
+publicly because the leaf certificate contains the device serial number.
 
 ## See also
 

--- a/docs/architecture/security/enrollment.md
+++ b/docs/architecture/security/enrollment.md
@@ -67,7 +67,7 @@ Apple Enterprise Attestation Root CA (P-384, embedded in coordinator)
           └─ Freshness code  (OID 1.2.840.113635.100.8.11.1)
 ```
 
-The coordinator verifies the chain against the embedded root CA, cross-checks the serial number against the provider's self-reported attestation, and stores the chain for public inspection. Code:
+The coordinator verifies the chain against the embedded root CA, cross-checks the serial number against the provider's self-reported attestation, and stores the chain internally for coordinator verification. Device serial numbers are not exposed publicly. Code:
 
 - MDA verification: `coordinator/attestation/mda.go:98-186`
 - MDA dispatch and key binding: `coordinator/api/provider.go:2342-2429`
@@ -99,7 +99,7 @@ The ACME payload remains in the profile for future use. Removing it (or slimming
 
 1. Provider registers with SE-signed attestation → trust level = `self_signed`.
 2. MDM `SecurityInfo` passes → upgraded to `hardware`.
-3. MDA certificate chain verifies and the serial number matches → MDA proof stored for public inspection.
+3. MDA certificate chain verifies and the serial number matches → MDA proof stored for coordinator verification; serial numbers remain internal and are not exposed publicly.
 4. APNs code-identity round-trip passes → `CodeAttested = true`, private traffic may route.
 
 Code:

--- a/docs/consumer/verification.md
+++ b/docs/consumer/verification.md
@@ -1,6 +1,6 @@
 # Verifying Provider Attestation
 
-Consumers and operators can independently verify provider attestation state.
+Consumers and operators can inspect provider attestation state through the public API.
 
 ## Public attestation endpoint
 
@@ -11,20 +11,18 @@ curl https://api.darkbloom.dev/v1/providers/attestation
 Returns, per provider:
 
 - Secure Enclave P-256 public key,
-- hardware info (chip, model, serial, system volume hash),
+- hardware info (chip, model, system volume hash),
 - security state (SIP, SecureBoot, ARV, SE),
 - MDM verification status,
-- Apple MDA certificate chain (base64 DER),
-- MDA-extracted properties (serial, UDID, OS version, SepOS version).
+- `mda_verified` boolean,
+- MDA-extracted properties (UDID, OS version, SepOS version).
 
-## Verify the MDA chain yourself
+## MDA verification
 
-1. Download Apple's Enterprise Attestation Root CA from
-   [apple.com/certificateauthority](https://www.apple.com/certificateauthority/).
-2. Decode the `mda_cert_chain_b64` certificates from base64 to DER.
-3. Verify the cert chain against Apple's root CA using any x509 library.
-4. Check that the serial number in the Apple cert matches the provider's
-   self-reported attestation.
+The coordinator verifies the Apple MDA certificate chain internally against the
+embedded Apple Enterprise Attestation Root CA. The raw MDA certificate chain is
+not exposed publicly because the leaf certificate contains the device serial
+number. Consumers see only the `mda_verified` boolean result.
 
 ## What verification tells you
 

--- a/docs/legal/privacy-policy.md
+++ b/docs/legal/privacy-policy.md
@@ -63,7 +63,7 @@ We refer to this material as "Content."
 
 - hardware and device characteristics, such as machine model, chip family, memory, CPU/GPU information, and available capacity;
 - provider wallet addresses;
-- attestation materials and related security data, including: Secure Enclave-generated P-256 public keys and ECDSA attestation signatures; SHA-256 hashes of the provider binary; hardware serial numbers used to cross-reference device identity in our MDM server; SIP status, Secure Boot level, and Authenticated Root Volume integrity status as reported by the device;
+- attestation materials and related security data, including: Secure Enclave-generated P-256 public keys and ECDSA attestation signatures; SHA-256 hashes of the provider binary; hardware serial numbers used to cross-reference device identity in our MDM server (internal use only, not exposed publicly); SIP status, Secure Boot level, and Authenticated Root Volume integrity status as reported by the device;
 - challenge-response verification data: approximately every five minutes, our coordinator sends a 32-byte cryptographic nonce to the provider's device. The device signs the nonce using its Secure Enclave key and returns a response including fresh SIP and Secure Boot status. We collect and process the nonce, the signed response, and the accompanying security posture data for each challenge cycle;
 - heartbeats, health checks, thermal state, memory pressure, security posture, and version information;
 - device-linking tokens and account-link status.
@@ -174,7 +174,7 @@ Retention periods may vary by data type. For example:
 - usage and security logs may be retained for operational, fraud-prevention, and support purposes;
 - operational and routing telemetry may be retained for operational, security, capacity-planning, and service-improvement purposes;
 - tax identification information (W-9/W-8BEN data) is retained for as long as required by IRS regulations;
-- provider attestation and device-link data, including hardware serial numbers, binary hashes, Secure Enclave public keys, MDM SecurityInfo responses, and challenge-response records, may be retained for trust, audit, and network-integrity purposes;
+- provider attestation and device-link data, including hardware serial numbers (retained for internal trust verification only and not exposed publicly), binary hashes, Secure Enclave public keys, MDM SecurityInfo responses, and challenge-response records, may be retained for trust, audit, and network-integrity purposes;
 - Content may be retained for shorter operational periods unless preserved longer for support, abuse review, legal compliance, or dispute resolution.
 
 ## 9. Your Privacy Choices and Rights

--- a/docs/provider/attestation.md
+++ b/docs/provider/attestation.md
@@ -194,15 +194,11 @@ SE key + version.
 Anyone can inspect provider attestations:
 
 ```bash
-# All providers
 curl https://api.darkbloom.dev/v1/providers/attestation
-
-# Specific provider
-curl https://api.darkbloom.dev/v1/providers/<provider_id>/attestation
 ```
 
 The response is built by `handleProviderAttestation`
-(`coordinator/api/provider.go:2471-2580`) and includes:
+(`coordinator/api/provider.go:2849-2968`) and includes:
 
 | Field | Meaning |
 |-------|---------|
@@ -210,13 +206,13 @@ The response is built by `handleProviderAttestation`
 | `status` | `online`, `offline`, `untrusted`, etc. |
 | `mdm_verified` | `true` for `hardware` trust via MDM |
 | `acme_verified` | `true` if ACME device-attest-01 verified |
-| `mda_verified` | `true` if Apple MDA chain verified |
-| `mda_cert_chain_b64` | Base64 DER certificates for independent verification |
+| `mda_verified` | `true` if the coordinator verified the Apple MDA chain |
 | `sip_enabled`, `secure_boot_enabled`, `authenticated_root_enabled` | Latest verified posture |
 | `se_public_key` | SE P-256 public key |
 
-The response also includes Apple root CA URLs and instructions for verifying the
-MDA chain independently.
+The coordinator verifies the MDA chain internally against the embedded Apple
+Enterprise Attestation Root CA. The raw certificate chain is not exposed
+publicly because the leaf certificate contains the device serial number.
 
 ## Troubleshooting attestation
 


### PR DESCRIPTION
Closes #229

## Summary

Provider hardware serial numbers were exposed on fully public/unauthenticated surfaces. This PR removes them from public view while preserving all internal coordinator uses (registration, dedup, MDM verification, owner dashboard, admin UI, logs).

## What changed

### Coordinator
- `GET /v1/providers/attestation` no longer returns:
  - `serial_number`
  - `mda_serial`
  - `mda_udid` (also a stable device identifier)
  - `mda_cert_chain_b64` (the leaf cert embeds the device serial, so the chain itself leaked it)
  - `apple_root_ca_url` / `apple_enterprise_root_ca` fields
- Inference response headers no longer include:
  - `X-Provider-Serial`
  - `X-Attestation-Device-Serial`
- Fixed a pre-existing data race in `registry.DisconnectDuplicatesBySerial` by using the thread-safe `GetAttestationResult()` accessor.

### Console UI
- Removed serial header passthrough in the chat proxy.
- Removed `providerSerial`/`deviceSerial` from `TrustMetadata`.
- Removed public cert-chain verification and serial/UDID display from `VerificationPanel` and the stats page `NodeDetail`.
- Updated the API console example and homepage wording.

### Docs
- Updated `README.md`, `docs/consumer/verification.md`, `docs/architecture/security/attestation.md`, `docs/provider/attestation.md`, `docs/architecture/security/enrollment.md`, and `docs/legal/privacy-policy.md` to reflect that serial numbers, UDIDs, and the raw MDA chain are verified internally and not exposed publicly.

## What was intentionally left unchanged

- Internal serial handling: provider registration, store deduplication, MDM/MDA verification, enrollment, server logs.
- Authenticated owner-scoped `GET /v1/me/providers` still returns the owner's own `serial_number`/`mda_serial`/`mda_udid` (optionally masked in the UI).
- `admin-ui` still displays serials for internal operators.

## Transparency / trust-model note

Previously a third party could independently verify the full Apple MDA certificate chain from `/v1/providers/attestation`. After this PR, the public endpoint exposes only the coordinator's `mda_verified` assertion plus non-identifying MDA metadata (OS/SepOS versions). The coordinator's internal verification path is unchanged, so security enforcement is identical, but independent verifiability is reduced in exchange for device-operator privacy. This trade-off is consistent with the goal of keeping hardware identifiers private to the provider and to Darkbloom operators.

## Verification

- `cd coordinator && go test ./...` — all pass
- `cd coordinator && go test -race ./api/... ./registry/... -run "TestProviderAttestation|TestDisconnectDuplicatesBySerial" -count=2` — pass
- `cd console-ui && npm test` — 292 passed
- `cd console-ui && npm run build` — success
- `gofmt -l` on edited Go files — clean
- The checked-in `coordinator/coordinator` binary was not modified.
