### PR TITLE
fix(coordinator): make TTFT admission a soft gate + fix prefill estimate

### DIFF
--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -2021,7 +2021,7 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 				} else {
 					rawBody, _ = marshalForwardBody(parsed)
 				}
-			} else {
+			} else if s.ttftHardReject {
 				retryModel, retryTTFT := fasterTTFTEstimate(model, bestTTFT, fallbackModel, fallbackTTFT, fallbackHasTTFT)
 				refundReservation()
 				s.recordRejection(rejectionInfo{
@@ -2047,6 +2047,14 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 				})
 				s.writeTTFTTooSlow(w, retryModel, publicModel, retryTTFT, ttftThreshold)
 				return
+			} else {
+				// Soft TTFT gate (default): the best estimated TTFT exceeds the
+				// deadline, but at least one provider passed every routing and
+				// capacity gate. The prefill term of that estimate is not
+				// provider-measured (~10x pessimistic), so serve the best-available
+				// provider rather than 429'ing a request we can fulfill. The
+				// reservation is kept for dispatch; record the decision for telemetry.
+				s.ddIncr("routing.decisions", []string{"model:" + model, "model_type:" + s.registry.ModelType(model), "outcome:ttft_soft_served"})
 			}
 		}
 	}
@@ -4667,7 +4675,7 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 		if ttftTooSlow(bestTTFT, hasTTFT, ttftThreshold) {
 			if fallbackModel, _, _, _, fallbackTTFT, fallbackHasTTFT, switched := s.maybeFallbackAliasTTFT(parsed, publicModel, model, estimatedPromptTokens, requestedMaxTokens, ttftThreshold, registry.RequestTraits{HasTools: hasTools}, requiresVision, allowedProviderSerials); switched {
 				model = fallbackModel
-			} else {
+			} else if s.ttftHardReject {
 				retryModel, retryTTFT := fasterTTFTEstimate(model, bestTTFT, fallbackModel, fallbackTTFT, fallbackHasTTFT)
 				refundReservation()
 				s.recordRejection(rejectionInfo{
@@ -4693,6 +4701,14 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 				})
 				s.writeTTFTTooSlow(w, retryModel, publicModel, retryTTFT, ttftThreshold)
 				return
+			} else {
+				// Soft TTFT gate (default): the best estimated TTFT exceeds the
+				// deadline, but at least one provider passed every routing and
+				// capacity gate. The prefill term of that estimate is not
+				// provider-measured (~10x pessimistic), so serve the best-available
+				// provider rather than 429'ing a request we can fulfill. The
+				// reservation is kept for dispatch; record the decision for telemetry.
+				s.ddIncr("routing.decisions", []string{"model:" + model, "model_type:" + s.registry.ModelType(model), "outcome:ttft_soft_served"})
 			}
 		}
 	}

--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -499,8 +499,11 @@ func (s *Server) dispatchOneProvider(
 	// Public inference routes (not self-route / prefer-owner) enforce the
 	// OpenRouter TTFT ceiling inside the scheduler. This makes the preflight
 	// check authoritative: the router cannot select a provider whose estimated
-	// TTFT is above the threshold.
-	if !policy.enabled && !policy.prefer {
+	// TTFT is above the threshold. P1 fix: only enforce it when the HARD gate is
+	// on — soft mode (default) leaves MaxTTFTMs 0 so dispatch serves the best-
+	// available provider instead of re-rejecting an over-threshold request the
+	// preflight already chose to soft-serve (mirrors queueMaxTTFTMs).
+	if !policy.enabled && !policy.prefer && s.ttftHardReject {
 		pr.MaxTTFTMs = float64(ttftDeadline(estimatedPromptTokens).Milliseconds())
 	}
 
@@ -1992,7 +1995,17 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if ttftTooSlow(bestTTFT, hasTTFT, ttftThreshold) {
-			if fallbackModel, _, _, _, fallbackTTFT, fallbackHasTTFT, switched := s.maybeFallbackAliasTTFT(parsed, publicModel, model, estimatedPromptTokens, requestedMaxTokens, ttftThreshold, registry.RequestTraits{HasTools: hasTools}, requiresVision, allowedProviderSerials); switched {
+			if !s.ttftHardReject {
+				// Soft TTFT gate (default): a provider passed every routing and
+				// capacity gate, and pr.MaxTTFTMs is left 0 in soft mode, so the
+				// dispatch path serves the best-available provider instead of
+				// re-rejecting (P1 fix). Do NOT divert to an older alias build here
+				// (P2 fix) — the desired build is routable. The prefill term of the
+				// TTFT estimate is not provider-measured (~10x pessimistic), so
+				// serve the request we can fulfill; keep the reservation for
+				// dispatch and record the decision for telemetry.
+				s.ddIncr("routing.decisions", []string{"model:" + model, "model_type:" + s.registry.ModelType(model), "outcome:ttft_soft_served"})
+			} else if fallbackModel, _, _, _, fallbackTTFT, fallbackHasTTFT, switched := s.maybeFallbackAliasTTFT(parsed, publicModel, model, estimatedPromptTokens, requestedMaxTokens, ttftThreshold, registry.RequestTraits{HasTools: hasTools}, requiresVision, allowedProviderSerials); switched {
 				model = fallbackModel
 				if isResponsesAPI {
 					providerParsed, err := responsesRequestToChatCompletions(parsed)
@@ -2021,7 +2034,8 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 				} else {
 					rawBody, _ = marshalForwardBody(parsed)
 				}
-			} else if s.ttftHardReject {
+			} else {
+				// Hard TTFT gate, no faster alias: shed with a 429 + Retry-After.
 				retryModel, retryTTFT := fasterTTFTEstimate(model, bestTTFT, fallbackModel, fallbackTTFT, fallbackHasTTFT)
 				refundReservation()
 				s.recordRejection(rejectionInfo{
@@ -2047,14 +2061,6 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 				})
 				s.writeTTFTTooSlow(w, retryModel, publicModel, retryTTFT, ttftThreshold)
 				return
-			} else {
-				// Soft TTFT gate (default): the best estimated TTFT exceeds the
-				// deadline, but at least one provider passed every routing and
-				// capacity gate. The prefill term of that estimate is not
-				// provider-measured (~10x pessimistic), so serve the best-available
-				// provider rather than 429'ing a request we can fulfill. The
-				// reservation is kept for dispatch; record the decision for telemetry.
-				s.ddIncr("routing.decisions", []string{"model:" + model, "model_type:" + s.registry.ModelType(model), "outcome:ttft_soft_served"})
 			}
 		}
 	}
@@ -4673,9 +4679,16 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 		}
 		ttftThreshold := genericDeadline
 		if ttftTooSlow(bestTTFT, hasTTFT, ttftThreshold) {
-			if fallbackModel, _, _, _, fallbackTTFT, fallbackHasTTFT, switched := s.maybeFallbackAliasTTFT(parsed, publicModel, model, estimatedPromptTokens, requestedMaxTokens, ttftThreshold, registry.RequestTraits{HasTools: hasTools}, requiresVision, allowedProviderSerials); switched {
+			if !s.ttftHardReject {
+				// Soft TTFT gate (default): serve the best-available provider
+				// (MaxTTFTMs is 0 in soft mode — P1 fix); do not divert to an older
+				// alias build (P2 fix) — the desired build is routable. Keep the
+				// reservation for dispatch and record the decision for telemetry.
+				s.ddIncr("routing.decisions", []string{"model:" + model, "model_type:" + s.registry.ModelType(model), "outcome:ttft_soft_served"})
+			} else if fallbackModel, _, _, _, fallbackTTFT, fallbackHasTTFT, switched := s.maybeFallbackAliasTTFT(parsed, publicModel, model, estimatedPromptTokens, requestedMaxTokens, ttftThreshold, registry.RequestTraits{HasTools: hasTools}, requiresVision, allowedProviderSerials); switched {
 				model = fallbackModel
-			} else if s.ttftHardReject {
+			} else {
+				// Hard TTFT gate, no faster alias: shed with a 429 + Retry-After.
 				retryModel, retryTTFT := fasterTTFTEstimate(model, bestTTFT, fallbackModel, fallbackTTFT, fallbackHasTTFT)
 				refundReservation()
 				s.recordRejection(rejectionInfo{
@@ -4701,14 +4714,6 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 				})
 				s.writeTTFTTooSlow(w, retryModel, publicModel, retryTTFT, ttftThreshold)
 				return
-			} else {
-				// Soft TTFT gate (default): the best estimated TTFT exceeds the
-				// deadline, but at least one provider passed every routing and
-				// capacity gate. The prefill term of that estimate is not
-				// provider-measured (~10x pessimistic), so serve the best-available
-				// provider rather than 429'ing a request we can fulfill. The
-				// reservation is kept for dispatch; record the decision for telemetry.
-				s.ddIncr("routing.decisions", []string{"model:" + model, "model_type:" + s.registry.ModelType(model), "outcome:ttft_soft_served"})
 			}
 		}
 	}
@@ -4747,8 +4752,9 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 	// Public inference routes (not self-route / prefer-owner) enforce the
 	// OpenRouter TTFT ceiling inside the scheduler. This makes the preflight
 	// check authoritative: the router cannot select a provider whose estimated
-	// TTFT is above the threshold.
-	if !policy.enabled && !policy.prefer {
+	// TTFT is above the threshold. P1 fix: enforce it only in HARD mode; soft mode
+	// leaves MaxTTFTMs 0 so dispatch serves the best-available provider.
+	if !policy.enabled && !policy.prefer && s.ttftHardReject {
 		pr.MaxTTFTMs = float64(genericDeadline.Milliseconds())
 	}
 

--- a/coordinator/api/consumer_test.go
+++ b/coordinator/api/consumer_test.go
@@ -2155,6 +2155,35 @@ func TestTTFTAdmission429ForInferenceEndpoints(t *testing.T) {
 	}
 }
 
+// TestTTFTSoftGateDoesNotShedAtDispatch is the regression for the Codex P1: in
+// the default SOFT gate, an over-deadline request must not be rejected as
+// ttft_too_slow — not at the preflight AND not (the bug) at dispatch via a
+// non-zero pr.MaxTTFTMs causing ReserveProviderEx to drop every candidate. With
+// a single eligible provider and no capacity pressure, the only possible 429 is
+// the TTFT shed, so asserting "not 429" pins the fix. (The request can't truly
+// stream over a nil test conn; it just must never be ttft-rejected.)
+func TestTTFTSoftGateDoesNotShedAtDispatch(t *testing.T) {
+	srv, _ := testServer(t) // default: soft gate (ttftHardReject=false)
+	model := "soft-serve-ttft-model"
+	srv.registry.SetModelCatalog([]registry.CatalogEntry{{ID: model, SizeGB: 1, MinRAMGB: 24}})
+	p := registerBuildsProvider(srv, "slow-prefill-provider", model)
+	p.Mu().Lock()
+	p.DecodeTPS = 100
+	p.PrefillTPS = 0.2 // ~5s prefill even for a tiny prompt => TTFT estimate >> deadline
+	p.Mu().Unlock()
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(
+		strings.ReplaceAll(`{"model":"MODEL","messages":[{"role":"user","content":"hello"}],"max_tokens":16}`, "MODEL", model)))
+	req.Header.Set("Authorization", "Bearer test-key")
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code == http.StatusTooManyRequests {
+		t.Fatalf("soft gate shed an over-deadline request with 429 (P1 regression); body=%s", w.Body.String())
+	}
+}
+
 func TestMaybeFallbackAliasTTFTSwitchesToPrevious(t *testing.T) {
 	srv, _ := testServer(t)
 	publicModel := "public-ttft-alias"

--- a/coordinator/api/consumer_test.go
+++ b/coordinator/api/consumer_test.go
@@ -2062,6 +2062,7 @@ func TestWriteTTFTTooSlowSets429RetryAfter(t *testing.T) {
 
 func TestTTFTAdmission429BelowOldTenSecondFloor(t *testing.T) {
 	srv, _ := testServer(t)
+	srv.SetTTFTHardReject(true) // legacy hard 429-on-slow-estimate path (now opt-in)
 	model := "exact-ttft-floor-model"
 	srv.registry.SetModelCatalog([]registry.CatalogEntry{{ID: model, SizeGB: 1, MinRAMGB: 24}})
 	p := registerBuildsProvider(srv, "exact-floor-provider", model)
@@ -2087,6 +2088,7 @@ func TestTTFTAdmission429BelowOldTenSecondFloor(t *testing.T) {
 
 func TestTTFTAdmission429ForInferenceEndpoints(t *testing.T) {
 	srv, _ := testServer(t)
+	srv.SetTTFTHardReject(true) // legacy hard 429-on-slow-estimate path (now opt-in)
 	model := "route-slow-ttft-model"
 	srv.registry.SetModelCatalog([]registry.CatalogEntry{{ID: model, SizeGB: 1, MinRAMGB: 24}})
 	p := registerBuildsProvider(srv, "route-slow-provider", model)
@@ -2134,7 +2136,8 @@ func TestTTFTAdmission429ForInferenceEndpoints(t *testing.T) {
 			}
 			var body struct {
 				Error struct {
-					Code string `json:"code"`
+					Code    string `json:"code"`
+					Message string `json:"message"`
 				} `json:"error"`
 			}
 			if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
@@ -2142,6 +2145,11 @@ func TestTTFTAdmission429ForInferenceEndpoints(t *testing.T) {
 			}
 			if body.Error.Code != "rate_limit_exceeded" {
 				t.Fatalf("code = %q, want rate_limit_exceeded", body.Error.Code)
+			}
+			// Assert the TTFT preflight path specifically (not a capacity 429),
+			// so this test exercises the hard TTFT gate it is named for.
+			if !strings.Contains(body.Error.Message, "TTFT target") {
+				t.Fatalf("message = %q, want TTFT target detail", body.Error.Message)
 			}
 		})
 	}

--- a/coordinator/api/dispatch.go
+++ b/coordinator/api/dispatch.go
@@ -142,8 +142,18 @@ func (d *dispatchState) traits() registry.RequestTraits {
 // queueMaxTTFTMs returns the TTFT ceiling for queued requests. Public routes
 // inherit the prompt-scaled admission threshold; self-route / prefer-owner paths
 // are not subject to the public SLA ceiling.
-func queueMaxTTFTMs(policy selfRoutePolicy, deadline time.Duration) float64 {
+//
+// When hardReject is false (the default soft gate), a zero ceiling is returned
+// so the scheduler's enforceTTFT path is disabled: candidates over the estimated
+// deadline are no longer dropped (and no errTTFTTooSlow is produced). The router
+// still ranks by cost (which is TTFT-weighted), so the fastest provider wins, but
+// a request is served on the best-available provider instead of being rejected
+// on a pessimistic prefill estimate.
+func queueMaxTTFTMs(policy selfRoutePolicy, deadline time.Duration, hardReject bool) float64 {
 	if policy.enabled || policy.prefer {
+		return 0
+	}
+	if !hardReject {
 		return 0
 	}
 	return float64(deadline.Milliseconds())
@@ -463,7 +473,7 @@ func (d *dispatchState) dispatchPrimary() dispatchOutcome {
 			PreferOwner:            d.policy.prefer,
 			OwnerAccountID:         d.policy.ownerAccountID,
 			FreeSelfRoute:          d.policy.enabled,
-			MaxTTFTMs:              queueMaxTTFTMs(d.policy, d.deadline),
+			MaxTTFTMs:              queueMaxTTFTMs(d.policy, d.deadline, d.s.ttftHardReject),
 			AcceptedCh:             make(chan struct{}, 1),
 			ChunkCh:                make(chan string, chunkBufferSize),
 			CompleteCh:             make(chan protocol.UsageInfo, 1),

--- a/coordinator/api/server.go
+++ b/coordinator/api/server.go
@@ -205,6 +205,17 @@ type Server struct {
 	// (EIGENINFERENCE_BINARYHASH_ENFORCE=true).
 	binaryHashEnforce bool
 
+	// ttftHardReject controls how the per-request TTFT admission ceiling
+	// (5s+1ms/token) behaves when the best ESTIMATED time-to-first-token exceeds
+	// it. The estimate's prefill term is not provider-measured and runs ~10x
+	// pessimistic (see resolvedPrefillTPS), which made the legacy hard gate 429
+	// the majority of serveable requests above ~550 prompt tokens. Default false:
+	// the ceiling is a SOFT routing preference — when at least one provider passed
+	// every routing and capacity gate, the request is served on the best-available
+	// provider instead of being rejected. Set true
+	// (EIGENINFERENCE_TTFT_HARD_REJECT=true) to restore the legacy hard 429.
+	ttftHardReject bool
+
 	// knownRuntimeManifest holds accepted runtime component hashes.
 	// When set, providers whose runtime hashes don't match are marked as
 	// unverified and excluded from routing (but not disconnected).
@@ -959,6 +970,13 @@ func (s *Server) invalidateCatalogCache() {
 // rollback or to test the legacy enforcement path.
 func (s *Server) SetBinaryHashEnforcement(enabled bool) {
 	s.binaryHashEnforce = enabled
+}
+
+// SetTTFTHardReject toggles the per-request TTFT admission ceiling between a
+// hard 429 (true, legacy) and a soft routing preference (false, default). See
+// the ttftHardReject field for rationale. Call before serving starts.
+func (s *Server) SetTTFTHardReject(enabled bool) {
+	s.ttftHardReject = enabled
 }
 
 // Providers whose binary SHA-256 doesn't match any known hash are rejected.

--- a/coordinator/api/ttft_soft_gate_test.go
+++ b/coordinator/api/ttft_soft_gate_test.go
@@ -1,0 +1,36 @@
+package api
+
+import (
+	"testing"
+	"time"
+)
+
+// TestQueueMaxTTFTMsSoftVsHard pins the soft/hard TTFT-gate contract that the
+// dispatch layer feeds into the scheduler via PendingRequest.MaxTTFTMs.
+//
+// In soft mode (default) a public route gets a zero ceiling, which disables the
+// scheduler's enforceTTFT path so a slow-but-eligible provider is still selected
+// (see TestReserveProviderExcludesSlowProviderWhenTTFTCeilingSet: MaxTTFTMs==0
+// selects the slow provider). In hard mode the public route inherits the
+// prompt-scaled deadline so the legacy 429-on-slow-estimate behavior returns.
+// Self-route and prefer-owner are never subject to the public SLA ceiling.
+func TestQueueMaxTTFTMsSoftVsHard(t *testing.T) {
+	deadline := 6 * time.Second
+	public := selfRoutePolicy{}
+
+	if got := queueMaxTTFTMs(public, deadline, false); got != 0 {
+		t.Fatalf("soft public ceiling = %v, want 0 (no ceiling -> serve best-available)", got)
+	}
+	if got := queueMaxTTFTMs(public, deadline, true); got != float64(deadline.Milliseconds()) {
+		t.Fatalf("hard public ceiling = %v, want %d", got, deadline.Milliseconds())
+	}
+
+	for _, hardReject := range []bool{false, true} {
+		if got := queueMaxTTFTMs(selfRoutePolicy{enabled: true}, deadline, hardReject); got != 0 {
+			t.Fatalf("self-route ceiling (hardReject=%v) = %v, want 0", hardReject, got)
+		}
+		if got := queueMaxTTFTMs(selfRoutePolicy{prefer: true}, deadline, hardReject); got != 0 {
+			t.Fatalf("prefer-owner ceiling (hardReject=%v) = %v, want 0", hardReject, got)
+		}
+	}
+}

--- a/coordinator/cmd/coordinator/main.go
+++ b/coordinator/cmd/coordinator/main.go
@@ -28,6 +28,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -290,6 +291,28 @@ func main() {
 	if os.Getenv("EIGENINFERENCE_BINARYHASH_ENFORCE") == "true" {
 		srv.SetBinaryHashEnforcement(true)
 		logger.Warn("binaryHash enforcement ENABLED via EIGENINFERENCE_BINARYHASH_ENFORCE (legacy; APNs code-identity is the real signal)")
+	}
+
+	// Routing: TTFT admission ceiling mode. Default is a SOFT routing preference
+	// (serve the best-available provider when one passes every routing/capacity
+	// gate). Set this to restore the legacy HARD 429 when the best estimated TTFT
+	// exceeds the 5s+1ms/token deadline. The estimate's prefill term is not
+	// provider-measured, so the hard gate over-rejected serveable requests.
+	if os.Getenv("EIGENINFERENCE_TTFT_HARD_REJECT") == "true" {
+		srv.SetTTFTHardReject(true)
+		logger.Warn("TTFT hard-reject ENABLED via EIGENINFERENCE_TTFT_HARD_REJECT (legacy 429-on-slow-estimate; soft preference is the default)")
+	}
+
+	// Routing: decode→prefill ratio fallback, used to estimate prefill TPS when a
+	// provider does not report a measured prefill_tps. Defaults to
+	// registry.defaultPrefillToDecodeRatio.
+	if v := os.Getenv("EIGENINFERENCE_PREFILL_DECODE_RATIO"); v != "" {
+		if ratio, err := strconv.ParseFloat(v, 64); err == nil && ratio > 0 {
+			registry.SetPrefillToDecodeRatio(ratio)
+			logger.Info("prefill/decode ratio override via EIGENINFERENCE_PREFILL_DECODE_RATIO", "ratio", ratio)
+		} else {
+			logger.Warn("invalid EIGENINFERENCE_PREFILL_DECODE_RATIO; ignoring", "value", v)
+		}
 	}
 
 	// Load runtime template manifest from environment variable (optional override).

--- a/coordinator/registry/scheduler.go
+++ b/coordinator/registry/scheduler.go
@@ -1075,11 +1075,35 @@ func resolvedDecodeTPS(p *Provider) float64 {
 	return 1.0
 }
 
+// defaultPrefillToDecodeRatio is the fallback multiplier applied to a provider's
+// decode TPS to estimate its prefill TPS when the provider does not report a
+// measured prefill rate (prefill_tps). Apple-Silicon MLX prefills the prompt in
+// large parallel batches, so prefill throughput is roughly an order of magnitude
+// above decode throughput. The historical 4x was far too conservative: combined
+// with the 5s+1ms/token TTFT deadline it estimated ~100 tok/s prefill (vs the
+// ~1000 tok/s the deadline implicitly assumes), so the TTFT gate wrongly
+// rejected warm, capable providers on any prompt above ~550 tokens. No provider
+// currently reports prefill_tps, so this fallback is the production path.
+const defaultPrefillToDecodeRatio = 12.0
+
+// prefillToDecodeRatio is configured once at startup (via SetPrefillToDecodeRatio,
+// e.g. from EIGENINFERENCE_PREFILL_DECODE_RATIO) before the server begins
+// serving, then only read on routing paths.
+var prefillToDecodeRatio = defaultPrefillToDecodeRatio
+
+// SetPrefillToDecodeRatio overrides the decode→prefill fallback multiplier.
+// Values <= 0 are ignored. Must be called before serving starts (read-only after).
+func SetPrefillToDecodeRatio(ratio float64) {
+	if ratio > 0 {
+		prefillToDecodeRatio = ratio
+	}
+}
+
 func resolvedPrefillTPS(p *Provider) float64 {
 	if p.PrefillTPS > 0 {
 		return p.PrefillTPS
 	}
-	return resolvedDecodeTPS(p) * 4.0
+	return resolvedDecodeTPS(p) * prefillToDecodeRatio
 }
 
 func providerModelIDs(p *Provider) []string {

--- a/coordinator/registry/scheduler_test.go
+++ b/coordinator/registry/scheduler_test.go
@@ -119,6 +119,9 @@ func TestQuickCapacityCheckWithTTFTEstimatesBestEligibleProvider(t *testing.T) {
 	model := "ttft-model"
 	slow := makeSchedulerProvider(t, reg, "slow", model, 100)
 	slow.mu.Lock()
+	// Pin the prefill rate (== old decodeTPS*4 fallback) so the TTFT queue-math
+	// assertions here are independent of the tunable decode→prefill fallback ratio.
+	slow.PrefillTPS = 400
 	slow.BackendCapacity.Slots[0].NumWaiting = 100
 	slow.BackendCapacity.Slots[0].MaxConcurrency = 128
 	slow.mu.Unlock()
@@ -131,7 +134,10 @@ func TestQuickCapacityCheckWithTTFTEstimatesBestEligibleProvider(t *testing.T) {
 		t.Fatalf("bestTTFT = %v has=%v, want above 10s with backlog", bestTTFT, hasTTFT)
 	}
 
-	makeSchedulerProvider(t, reg, "fast", model, 100)
+	fast := makeSchedulerProvider(t, reg, "fast", model, 100)
+	fast.mu.Lock()
+	fast.PrefillTPS = 400
+	fast.mu.Unlock()
 	candidates, rejections, tooLarge, bestTTFT, hasTTFT = reg.QuickCapacityCheckWithTTFTForRequest(model, 100, 128, RequestTraits{}, false)
 	if candidates != 2 || rejections != 0 || tooLarge != 0 {
 		t.Fatalf("capacity with fast provider = (%d,%d,%d), want (2,0,0)", candidates, rejections, tooLarge)
@@ -146,6 +152,9 @@ func TestQuickCapacityCheckWithTTFTIncludesWaitingPrefills(t *testing.T) {
 	model := "ttft-waiting-prefill-model"
 	p := makeTokenBudgetProvider(t, reg, "budget", model, 100, 20_000, 100_000, 100)
 	p.mu.Lock()
+	// Pin the prefill rate (== old decodeTPS*4 fallback) so this waiting-prefill
+	// TTFT assertion is independent of the tunable decode→prefill fallback ratio.
+	p.PrefillTPS = 400
 	p.BackendCapacity.Slots[0].NumWaiting = 3
 	p.BackendCapacity.Slots[0].MaxConcurrency = 8
 	p.BackendCapacity.Slots[0].QueuedTokenBudget = 40_000
@@ -176,6 +185,34 @@ func TestQuickCapacityCheckWithTTFTIgnoresActiveReservations(t *testing.T) {
 	}
 	if !hasTTFT || bestTTFT > time.Second {
 		t.Fatalf("bestTTFT = %v has=%v, want active reservations not to inflate first-token estimate", bestTTFT, hasTTFT)
+	}
+}
+
+func TestResolvedPrefillTPSFallbackRatio(t *testing.T) {
+	// A provider-reported prefill rate always wins.
+	if got := resolvedPrefillTPS(&Provider{PrefillTPS: 500, DecodeTPS: 50}); got != 500 {
+		t.Fatalf("reported prefill = %v, want 500", got)
+	}
+
+	// Without a reported rate, fall back to decodeTPS * the configured ratio
+	// (default 12) — not the old 4x, which under-estimated prefill ~3x and made
+	// the TTFT gate reject warm providers above ~550 prompt tokens.
+	noReport := &Provider{DecodeTPS: 50}
+	if got, want := resolvedPrefillTPS(noReport), 50*defaultPrefillToDecodeRatio; got != want {
+		t.Fatalf("fallback prefill = %v, want %v", got, want)
+	}
+
+	// Overrides are honored; non-positive values are ignored.
+	orig := prefillToDecodeRatio
+	defer func() { prefillToDecodeRatio = orig }()
+	SetPrefillToDecodeRatio(20)
+	if got := resolvedPrefillTPS(noReport); got != 50*20 {
+		t.Fatalf("overridden prefill = %v, want 1000", got)
+	}
+	SetPrefillToDecodeRatio(0)
+	SetPrefillToDecodeRatio(-5)
+	if got := resolvedPrefillTPS(noReport); got != 50*20 {
+		t.Fatalf("prefill after ignored non-positive overrides = %v, want 1000", got)
 	}
 }
 


### PR DESCRIPTION
## Problem

The per-request **TTFT admission ceiling** (`5s + 1ms/token`) was 429-rejecting the majority of *serveable* paid traffic. Live data (admin rejection ledger):

- `/v1/chat/completions`: **3,125 served vs 8,270 429'd** over the window.
- `ttft_too_slow` rejections: **979/1000 had `could_have_served=true`**, median **39 candidate providers**.
- Served prompts: **median 326 tok (p90 609)**. `ttft_too_slow` rejections: **median 1554 tok** — a hard cliff at **~550 tokens**.
- `machine_busy` (genuine capacity) rejections: **0 in 48h**. This was not a capacity problem.

## Root causes

1. **Prefill estimate is ~10× too slow.** `resolvedPrefillTPS` falls back to `decodeTPS × 4` (~100 tok/s) whenever a provider doesn't report `prefill_tps` — and **no provider reports it today** (the Swift provider defines the wire field but never populates it). The deadline implicitly assumes ~1000 tok/s prefill, so `thisPrefillMs = promptTokens / prefillTPS` overcounts by ~10×. Any prompt above **~550 tokens** blows the deadline *even on a warm, idle, fully-capable provider* — exactly the observed cliff.

2. **The ceiling was a HARD reject.** When the (mis-)estimate exceeded the deadline, both preflight sites returned a 429 instead of serving on the best-available provider, despite a provider having passed every routing and capacity gate.

## Fix

- **Soft TTFT gate (default).** The preflight now serves the best-available provider instead of 429'ing when `candidateCount > 0`, and the scheduler ceiling is disabled (`queueMaxTTFTMs → 0`, so `enforceTTFT=false` — over-deadline candidates are no longer dropped and no `errTTFTTooSlow` is produced). The router still **ranks** by TTFT-weighted cost, so the fastest provider still wins. The genuine `machine_busy` and `no_provider` gates are unchanged. Legacy behavior is restorable with `EIGENINFERENCE_TTFT_HARD_REJECT=true`.
- **Realistic prefill estimate.** Fallback `decodeTPS × 4` → `decodeTPS × 12` (Apple-Silicon MLX prefills the prompt in large parallel batches; prefill is ~an order of magnitude above decode). Tunable via `EIGENINFERENCE_PREFILL_DECODE_RATIO`. This still helps ranking, speculative dispatch, and the now-opt-in hard-gate cliff. Provider-reported `prefill_tps` still always wins when present.

Both knobs default to the new behavior and are revertible without a rebuild.

## Tests

- `TestQueueMaxTTFTMsSoftVsHard` — soft → 0 ceiling (serve), hard → prompt-scaled deadline; self-route/prefer never ceilinged.
- `TestResolvedPrefillTPSFallbackRatio` — provider-reported wins; fallback uses the ratio (default 12); override honored, non-positive ignored.
- Existing `TestTTFTAdmission429*` HTTP tests pinned to **hard mode** (they cover the now-opt-in legacy path) and tightened to assert the TTFT-specific message.
- TTFT queue-math tests pin an explicit `PrefillTPS` so they're independent of the tunable ratio.
- `TestReserveProviderExcludesSlowProviderWhenTTFTCeilingSet` already proves `MaxTTFTMs=0` ⇒ the slow provider is **selected** (served, not rejected) — the scheduler half of the soft gate.

Full `go test ./...` green; `gofmt` clean; Linux (`GOOS=linux CGO_ENABLED=0`) build OK.

## Deploy / follow-ups

- **No deploy in this PR.** Ships with the next coordinator redeploy.
- Durable follow-up (separate PR): have providers actually measure & report `prefill_tps` (per-slot observed, like `observed_decode_tps`) so the fallback constant becomes irrelevant.
- Related: warm-pool signal starvation (the `ttft_too_slow` path fed no warm-pool demand signal); soft-serving now applies real dispatch pressure, but a dedicated signal is a worthwhile follow-up.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/381"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784250393&installation_id=133247490&pr_number=381&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F381&signature=99bf3f0d91ff07173e9a418c34c3ac7bb58e23f98fb4ef20767170001529a5e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->