### PR TITLE
feat: per-operation energy tracking (DAR-324)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -224,6 +224,14 @@ Keep the codebase modular, never monolithic.
 - One file/component should do one thing. If a file mixes several concerns or grows past a few hundred lines, that's a signal to split it.
 - **At the end of every large piece of work, do a refactor pass to make it modular before calling it done.** Extract helpers/types/hooks into focused files, delete dead code, and keep the public entry point thin. The refactor must be behavior-preserving — build, lint, and tests stay green.
 
+## Pull Requests
+
+Every pull request **must** include a **before/after architecture diagram** — two Mermaid diagrams in the PR description, one showing the relevant flow/architecture *before* the change and one *after*. This is mandatory for every PR, no exceptions; it makes the structural impact of the change reviewable at a glance.
+
+- Use fenced ` ```mermaid ` blocks (GitHub renders them natively).
+- Scope the diagrams to the subsystem(s) the PR touches — the data flow, call path, or component wiring that changed — not the whole system.
+- For a purely additive change, the "before" diagram still shows the prior state so the delta is explicit.
+
 ## Formatting
 
 A pre-commit hook in `.githooks/pre-commit` checks staged files only. It is enabled via:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -260,6 +260,14 @@ Each reviewer should:
 
 Only proceed to the next objective after both reviewers pass. If either flags issues, fix them before moving on.
 
+## Pull Requests
+
+Every pull request **must** include a **before/after architecture diagram** — two Mermaid diagrams in the PR description, one showing the relevant flow/architecture *before* the change and one *after*. This is mandatory for every PR, no exceptions; it makes the structural impact of the change reviewable at a glance.
+
+- Use fenced ` ```mermaid ` blocks (GitHub renders them natively).
+- Scope the diagrams to the subsystem(s) the PR touches — the data flow, call path, or component wiring that changed — not the whole system.
+- For a purely additive change, the "before" diagram still shows the prior state so the delta is explicit.
+
 ## Git Hooks
 
 Hooks live in `.githooks/` and are enabled via `git config core.hooksPath .githooks` (already set for this repo).

--- a/coordinator/api/stats.go
+++ b/coordinator/api/stats.go
@@ -110,13 +110,15 @@ func (s *Server) handleStats(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		// Prefer the provider's measured SoC power (IOReport) when reported and
-		// within a sane bound; fall back to the static chip estimate otherwise.
-		// The bound stops a bogus/malicious heartbeat from inflating the public
-		// figure. Same observed→estimate precedence pattern used for decode TPS.
-		if pw := p.SystemMetrics.PowerWatts; pw > 0 && pw <= registry.MaxReasonablePowerWatts {
+		// plausible for THIS chip; fall back to the static estimate otherwise.
+		// Bounding to ~1.5x the chip's own estimate (rather than a loose global
+		// cap) stops a bogus/malicious heartbeat from inflating the public figure
+		// by an order of magnitude. Same observed→estimate precedence as decode TPS.
+		est := registry.EstimateMachineWatts(p.Hardware.ChipFamily, p.Hardware.ChipTier, p.Hardware.GPUCores)
+		if pw := p.SystemMetrics.PowerWatts; pw > 0 && pw <= est*1.5 {
 			activePowerWatts += pw
 		} else {
-			activePowerWatts += registry.EstimateMachineWatts(p.Hardware.ChipFamily, p.Hardware.ChipTier, p.Hardware.GPUCores)
+			activePowerWatts += est
 		}
 		totalRequests += p.Stats.RequestsServed
 		totalTokensGen += p.Stats.TokensGenerated

--- a/coordinator/api/stats.go
+++ b/coordinator/api/stats.go
@@ -109,10 +109,11 @@ func (s *Server) handleStats(w http.ResponseWriter, r *http.Request) {
 		if p.PrivateOnly {
 			return
 		}
-		// Prefer the provider's measured SoC power (IOReport) when reported;
-		// fall back to the static chip estimate otherwise. Same observed→estimate
-		// precedence pattern used for decode TPS.
-		if pw := p.SystemMetrics.PowerWatts; pw > 0 {
+		// Prefer the provider's measured SoC power (IOReport) when reported and
+		// within a sane bound; fall back to the static chip estimate otherwise.
+		// The bound stops a bogus/malicious heartbeat from inflating the public
+		// figure. Same observed→estimate precedence pattern used for decode TPS.
+		if pw := p.SystemMetrics.PowerWatts; pw > 0 && pw <= registry.MaxReasonablePowerWatts {
 			activePowerWatts += pw
 		} else {
 			activePowerWatts += registry.EstimateMachineWatts(p.Hardware.ChipFamily, p.Hardware.ChipTier, p.Hardware.GPUCores)

--- a/coordinator/api/stats.go
+++ b/coordinator/api/stats.go
@@ -109,7 +109,14 @@ func (s *Server) handleStats(w http.ResponseWriter, r *http.Request) {
 		if p.PrivateOnly {
 			return
 		}
-		activePowerWatts += registry.EstimateMachineWatts(p.Hardware.ChipFamily, p.Hardware.ChipTier, p.Hardware.GPUCores)
+		// Prefer the provider's measured SoC power (IOReport) when reported;
+		// fall back to the static chip estimate otherwise. Same observed→estimate
+		// precedence pattern used for decode TPS.
+		if pw := p.SystemMetrics.PowerWatts; pw > 0 {
+			activePowerWatts += pw
+		} else {
+			activePowerWatts += registry.EstimateMachineWatts(p.Hardware.ChipFamily, p.Hardware.ChipTier, p.Hardware.GPUCores)
+		}
 		totalRequests += p.Stats.RequestsServed
 		totalTokensGen += p.Stats.TokensGenerated
 		totalGPUCores += p.Hardware.GPUCores

--- a/coordinator/protocol/messages.go
+++ b/coordinator/protocol/messages.go
@@ -188,6 +188,7 @@ type HeartbeatMessage struct {
 	WarmModels      []string         `json:"warm_models,omitempty"`      // models currently loaded in memory
 	SystemMetrics   SystemMetrics    `json:"system_metrics"`             // live resource utilization
 	BackendCapacity *BackendCapacity `json:"backend_capacity,omitempty"` // live backend capacity (nil for old providers)
+	Energy          *EnergyLedger    `json:"energy,omitempty"`           // cumulative per-operation energy breakdown (nil for providers without IOReport)
 }
 
 // BackendSlotCapacity describes the capacity state of a single backend slot
@@ -221,9 +222,43 @@ type BackendCapacity struct {
 
 // SystemMetrics contains live resource utilization reported by a provider.
 type SystemMetrics struct {
-	MemoryPressure float64 `json:"memory_pressure"` // 0.0 to 1.0
-	CPUUsage       float64 `json:"cpu_usage"`       // 0.0 to 1.0
-	ThermalState   string  `json:"thermal_state"`   // nominal, fair, serious, critical
+	MemoryPressure float64 `json:"memory_pressure"`       // 0.0 to 1.0
+	CPUUsage       float64 `json:"cpu_usage"`             // 0.0 to 1.0
+	ThermalState   string  `json:"thermal_state"`         // nominal, fair, serious, critical
+	PowerWatts     float64 `json:"power_watts,omitempty"` // instantaneous total SoC power (IOReport); 0 = not measured
+}
+
+// EnergyLedger is the cumulative per-operation energy breakdown a provider
+// reports on the heartbeat. All joule fields are cumulative since the provider
+// process started (monotonic within a session; they reset to zero on restart).
+// The coordinator persists periodic snapshots and diffs consecutive rows per
+// session for time-series analysis of where energy goes. Every field is
+// omitempty so legacy providers and the no-IOReport fallback stay
+// byte-compatible on the wire. Mirrors EnergyLedgerSnapshot in
+// provider-swift/Sources/ProviderCore/Protocol/Types.swift.
+type EnergyLedger struct {
+	CurrentWatts float64 `json:"current_watts,omitempty"` // instantaneous total SoC power
+	IdleWatts    float64 `json:"idle_watts,omitempty"`    // measured idle-floor baseline
+
+	// Cumulative joules per operation bucket.
+	IdleJoules    float64 `json:"idle_joules,omitempty"`
+	PrefillJoules float64 `json:"prefill_joules,omitempty"`
+	DecodeJoules  float64 `json:"decode_joules,omitempty"`
+	LoadJoules    float64 `json:"load_joules,omitempty"`
+
+	// Cumulative joules per SoC subsystem (across all buckets).
+	CPUJoules  float64 `json:"cpu_joules,omitempty"`
+	GPUJoules  float64 `json:"gpu_joules,omitempty"`
+	ANEJoules  float64 `json:"ane_joules,omitempty"`
+	DRAMJoules float64 `json:"dram_joules,omitempty"`
+
+	// Normalizers + derived per-token energy coefficients.
+	PrefillTokens    float64 `json:"prefill_tokens,omitempty"`
+	DecodeTokens     float64 `json:"decode_tokens,omitempty"`
+	WarmSeconds      float64 `json:"warm_seconds,omitempty"`
+	ModelLoads       int     `json:"model_loads,omitempty"`
+	JPerPrefillToken float64 `json:"j_per_prefill_token,omitempty"`
+	JPerDecodeToken  float64 `json:"j_per_decode_token,omitempty"`
 }
 
 // HeartbeatStats contains counters reported in heartbeats.

--- a/coordinator/protocol/messages_test.go
+++ b/coordinator/protocol/messages_test.go
@@ -939,6 +939,75 @@ func TestHeartbeatWithSystemMetricsMarshal(t *testing.T) {
 	}
 }
 
+// TestSystemMetricsPowerWattsOmitempty verifies power_watts is omitted when
+// zero (legacy providers / no-IOReport fallback) and present when measured, so
+// the Swift `power_watts` optional (nil = omitted) stays wire-symmetric.
+func TestSystemMetricsPowerWattsOmitempty(t *testing.T) {
+	b, _ := json.Marshal(SystemMetrics{MemoryPressure: 0.5, CPUUsage: 0.2, ThermalState: "nominal"})
+	if bytes.Contains(b, []byte("power_watts")) {
+		t.Errorf("power_watts must be omitted when zero, got %s", b)
+	}
+	b, _ = json.Marshal(SystemMetrics{ThermalState: "nominal", PowerWatts: 42.5})
+	if !bytes.Contains(b, []byte(`"power_watts":42.5`)) {
+		t.Errorf("power_watts must be present when set, got %s", b)
+	}
+}
+
+// TestHeartbeatEnergyLedgerSymmetry verifies the energy ledger is omitted when
+// nil (providers without IOReport), that zero sub-fields are omitted
+// (byte-compatible with the Swift encodeIfNonZero snapshot), and that a
+// populated ledger round-trips.
+func TestHeartbeatEnergyLedgerSymmetry(t *testing.T) {
+	// Nil energy must be omitted.
+	b, _ := json.Marshal(HeartbeatMessage{Type: TypeHeartbeat, Status: "idle"})
+	var m map[string]any
+	json.Unmarshal(b, &m)
+	if _, ok := m["energy"]; ok {
+		t.Errorf("energy should be omitted when nil (omitempty), got %s", b)
+	}
+
+	msg := HeartbeatMessage{
+		Type:   TypeHeartbeat,
+		Status: "serving",
+		Energy: &EnergyLedger{
+			CurrentWatts:    45.5,
+			IdleWatts:       8.0,
+			IdleJoules:      900.0,
+			PrefillJoules:   300.0,
+			DecodeJoules:    1500.0,
+			DecodeTokens:    3000,
+			JPerDecodeToken: 0.5,
+			ModelLoads:      2,
+		},
+	}
+	data, err := json.Marshal(msg)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	// Zero sub-fields must be omitted (matches Swift snapshot encodeIfNonZero).
+	for _, key := range []string{"load_joules", "ane_joules", "gpu_joules", "j_per_prefill_token", "prefill_tokens"} {
+		if bytes.Contains(data, []byte(key)) {
+			t.Errorf("%s should be omitted when zero (omitempty): %s", key, data)
+		}
+	}
+	var decoded HeartbeatMessage
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if decoded.Energy == nil {
+		t.Fatal("energy lost in round-trip")
+	}
+	if decoded.Energy.DecodeJoules != 1500.0 {
+		t.Errorf("decode_joules = %f, want 1500", decoded.Energy.DecodeJoules)
+	}
+	if decoded.Energy.JPerDecodeToken != 0.5 {
+		t.Errorf("j_per_decode_token = %f, want 0.5", decoded.Energy.JPerDecodeToken)
+	}
+	if decoded.Energy.ModelLoads != 2 {
+		t.Errorf("model_loads = %d, want 2", decoded.Energy.ModelLoads)
+	}
+}
+
 func TestProviderMessageUnmarshalHeartbeatWithMetrics(t *testing.T) {
 	raw := `{"type":"heartbeat","status":"idle","active_model":null,"stats":{"requests_served":0,"tokens_generated":0},"system_metrics":{"memory_pressure":0.42,"cpu_usage":0.15,"thermal_state":"fair"}}`
 

--- a/coordinator/registry/power.go
+++ b/coordinator/registry/power.go
@@ -2,6 +2,12 @@ package registry
 
 import "strings"
 
+// MaxReasonablePowerWatts is an upper bound on a single Mac's plausible
+// wall/SoC power draw. Provider-reported power above this (or below zero) is
+// treated as bogus — a buggy or malicious provider must not be able to inflate
+// the public network-power figure — and callers fall back to the chip estimate.
+const MaxReasonablePowerWatts = 2000.0
+
 // machineWatts maps a normalized (chip family, tier) pair to a realistic
 // maximum sustained wall-socket power draw under a compute-intensive
 // (inference) load, in watts.

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -1270,14 +1270,20 @@ func (r *Registry) persistEnergyNow(p *Provider) {
 		if p.AttestationResult != nil {
 			serial = p.AttestationResult.SerialNumber
 		}
+		// The ledger is process-wide (whole-SoC energy can't be split per resident
+		// model). Tag with the active model only when at most one model is resident;
+		// with several resident, leave it empty rather than mislabel the interval's
+		// energy as belonging to whichever model happens to be current at snapshot
+		// time. See ProviderEnergyRecord.
+		model := p.CurrentModel
+		if len(p.WarmModels) > 1 {
+			model = ""
+		}
 		rec := store.ProviderEnergyRecord{
-			ProviderID:   p.ID,
-			AccountID:    p.AccountID,
-			SerialNumber: serial,
-			// Active model at snapshot time, for context only. The ledger is
-			// process-wide (whole-SoC energy can't be split per resident model),
-			// so this is NOT a per-model attribution key — see ProviderEnergyRecord.
-			Model:            p.CurrentModel,
+			ProviderID:       p.ID,
+			AccountID:        p.AccountID,
+			SerialNumber:     serial,
+			Model:            model,
 			ChipFamily:       p.Hardware.ChipFamily,
 			ChipTier:         p.Hardware.ChipTier,
 			GPUCores:         p.Hardware.GPUCores,

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -1271,9 +1271,12 @@ func (r *Registry) persistEnergyNow(p *Provider) {
 			serial = p.AttestationResult.SerialNumber
 		}
 		rec := store.ProviderEnergyRecord{
-			ProviderID:       p.ID,
-			AccountID:        p.AccountID,
-			SerialNumber:     serial,
+			ProviderID:   p.ID,
+			AccountID:    p.AccountID,
+			SerialNumber: serial,
+			// Active model at snapshot time, for context only. The ledger is
+			// process-wide (whole-SoC energy can't be split per resident model),
+			// so this is NOT a per-model attribution key — see ProviderEnergyRecord.
 			Model:            p.CurrentModel,
 			ChipFamily:       p.Hardware.ChipFamily,
 			ChipTier:         p.Hardware.ChipTier,

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -336,6 +336,10 @@ type Provider struct {
 	// Live backend capacity from heartbeats (nil for providers without capacity reporting)
 	BackendCapacity *protocol.BackendCapacity
 
+	// Live cumulative energy ledger from heartbeats (nil for providers without
+	// IOReport energy measurement). Persisted as a time-series for analysis.
+	Energy *protocol.EnergyLedger
+
 	// Reputation tracking
 	Reputation Reputation
 
@@ -362,6 +366,10 @@ type Provider struct {
 	// lastPersisted tracks when this provider was last written to the store.
 	// Used by PersistProviderThrottled to avoid hammering Postgres on every heartbeat.
 	lastPersisted time.Time
+
+	// lastEnergyPersisted throttles per-provider energy time-series writes from
+	// the heartbeat path (energy snapshots are sampled coarser than heartbeats).
+	lastEnergyPersisted time.Time
 
 	// lastReputationPersisted tracks when this provider's reputation was last
 	// written to the store from the heartbeat path. Used by
@@ -1223,6 +1231,76 @@ func (r *Registry) persistReputationThrottled(p *Provider) {
 	p.lastReputationPersisted = time.Now()
 	p.mu.Unlock()
 	r.persistReputation(p)
+}
+
+// persistEnergyThrottled appends a per-provider energy snapshot to the
+// time-series at most once per minute. The provider reports a cumulative ledger
+// on every heartbeat; we sample it at a coarser cadence to bound DB writes
+// while preserving enough resolution to diff consecutive rows.
+func (r *Registry) persistEnergyThrottled(p *Provider) {
+	const minInterval = 60 * time.Second
+	p.mu.Lock()
+	if p.Energy == nil {
+		p.mu.Unlock()
+		return
+	}
+	if time.Since(p.lastEnergyPersisted) < minInterval {
+		p.mu.Unlock()
+		return
+	}
+	p.lastEnergyPersisted = time.Now()
+	p.mu.Unlock()
+	r.persistEnergyNow(p)
+}
+
+// persistEnergyNow writes one energy ledger snapshot to the store. Called
+// asynchronously to avoid blocking the heartbeat path.
+func (r *Registry) persistEnergyNow(p *Provider) {
+	if r.store == nil {
+		return
+	}
+	saferun.Go(r.logger, "registry.persistEnergy", func() {
+		p.mu.Lock()
+		e := p.Energy
+		if e == nil {
+			p.mu.Unlock()
+			return
+		}
+		serial := ""
+		if p.AttestationResult != nil {
+			serial = p.AttestationResult.SerialNumber
+		}
+		rec := store.ProviderEnergyRecord{
+			ProviderID:       p.ID,
+			AccountID:        p.AccountID,
+			SerialNumber:     serial,
+			Model:            p.CurrentModel,
+			ChipFamily:       p.Hardware.ChipFamily,
+			ChipTier:         p.Hardware.ChipTier,
+			GPUCores:         p.Hardware.GPUCores,
+			CurrentWatts:     e.CurrentWatts,
+			IdleWatts:        e.IdleWatts,
+			IdleJoules:       e.IdleJoules,
+			PrefillJoules:    e.PrefillJoules,
+			DecodeJoules:     e.DecodeJoules,
+			LoadJoules:       e.LoadJoules,
+			CPUJoules:        e.CPUJoules,
+			GPUJoules:        e.GPUJoules,
+			ANEJoules:        e.ANEJoules,
+			DRAMJoules:       e.DRAMJoules,
+			PrefillTokens:    e.PrefillTokens,
+			DecodeTokens:     e.DecodeTokens,
+			WarmSeconds:      e.WarmSeconds,
+			ModelLoads:       e.ModelLoads,
+			JPerPrefillToken: e.JPerPrefillToken,
+			JPerDecodeToken:  e.JPerDecodeToken,
+			CreatedAt:        time.Now(),
+		}
+		p.mu.Unlock()
+		if err := r.store.RecordProviderEnergy(&rec); err != nil {
+			r.logger.Warn("failed to persist provider energy", "provider_id", p.ID, "error", err)
+		}
+	})
 }
 
 // persistProviderNow saves a provider's current state to the store.
@@ -2353,6 +2431,10 @@ func (r *Registry) Heartbeat(id string, msg *protocol.HeartbeatMessage) {
 	p.Stats.TokensGenerated += cumulativeDelta(p.lastSessionStats.TokensGenerated, msg.Stats.TokensGenerated)
 	p.lastSessionStats = msg.Stats
 	p.SystemMetrics = msg.SystemMetrics
+	// Cumulative energy ledger (nil for providers without IOReport). Replaces the
+	// pointer wholesale; the old pointee is never mutated, so readers holding it
+	// stay consistent.
+	p.Energy = msg.Energy
 	// Update backend capacity from heartbeat. A nil report clears prior live
 	// capacity so stale slot state cannot keep influencing routing.
 	p.BackendCapacity = msg.BackendCapacity
@@ -2412,6 +2494,8 @@ func (r *Registry) Heartbeat(id string, msg *protocol.HeartbeatMessage) {
 	// Persist accumulated uptime (throttled) so it survives restarts/reconnects;
 	// the heartbeat path is otherwise the only place uptime grows.
 	r.persistReputationThrottled(p)
+	// Append a per-provider energy snapshot to the time-series (throttled).
+	r.persistEnergyThrottled(p)
 
 	// Heartbeats can make a recovered slot routable again (for example after a
 	// crash auto-restart). Drain matching queues using the canonical scheduler

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -2422,6 +2422,21 @@ func (r *Registry) Heartbeat(id string, msg *protocol.HeartbeatMessage) {
 	if v, changed := clampNonNeg(msg.SystemMetrics.CPUUsage, 1.0); changed {
 		msg.SystemMetrics.CPUUsage = v
 	}
+	// Sanitize provider-reported power: out-of-range (negative or absurdly high)
+	// readings are dropped to 0 so /v1/stats falls back to the chip estimate and
+	// a bogus provider can't skew the public network-power figure. Cumulative
+	// joules are left as-is (analysis-only; not used for routing or public stats).
+	if msg.SystemMetrics.PowerWatts < 0 || msg.SystemMetrics.PowerWatts > MaxReasonablePowerWatts {
+		msg.SystemMetrics.PowerWatts = 0
+	}
+	if msg.Energy != nil {
+		if msg.Energy.CurrentWatts < 0 || msg.Energy.CurrentWatts > MaxReasonablePowerWatts {
+			msg.Energy.CurrentWatts = 0
+		}
+		if msg.Energy.IdleWatts < 0 || msg.Energy.IdleWatts > MaxReasonablePowerWatts {
+			msg.Energy.IdleWatts = 0
+		}
+	}
 
 	p.mu.Lock()
 	now := time.Now()

--- a/coordinator/store/energy_test.go
+++ b/coordinator/store/energy_test.go
@@ -1,0 +1,58 @@
+package store
+
+import (
+	"testing"
+	"time"
+)
+
+func TestProviderEnergyRoundTrip(t *testing.T) {
+	st := NewMemory(Config{})
+
+	rec := &ProviderEnergyRecord{
+		ProviderID:       "prov-1",
+		AccountID:        "acct-1",
+		SerialNumber:     "C02XYZ",
+		Model:            "qwen3.5-9b",
+		ChipFamily:       "M4",
+		ChipTier:         "Max",
+		GPUCores:         40,
+		CurrentWatts:     45.5,
+		IdleWatts:        8.0,
+		IdleJoules:       900,
+		PrefillJoules:    300,
+		DecodeJoules:     1500,
+		LoadJoules:       120,
+		CPUJoules:        400,
+		GPUJoules:        2000,
+		DRAMJoules:       500,
+		PrefillTokens:    2000,
+		DecodeTokens:     3000,
+		WarmSeconds:      120,
+		ModelLoads:       2,
+		JPerPrefillToken: 0.05,
+		JPerDecodeToken:  0.5,
+	}
+	if err := st.RecordProviderEnergy(rec); err != nil {
+		t.Fatalf("RecordProviderEnergy: %v", err)
+	}
+
+	got := st.ProviderEnergySince(time.Time{})
+	if len(got) != 1 {
+		t.Fatalf("ProviderEnergySince returned %d records, want 1", len(got))
+	}
+	r := got[0]
+	if r.ProviderID != "prov-1" || r.Model != "qwen3.5-9b" || r.ChipFamily != "M4" {
+		t.Errorf("identity mismatch: %+v", r)
+	}
+	if r.DecodeJoules != 1500 || r.JPerDecodeToken != 0.5 || r.ModelLoads != 2 {
+		t.Errorf("value mismatch: decodeJ=%v jPerDecode=%v loads=%d", r.DecodeJoules, r.JPerDecodeToken, r.ModelLoads)
+	}
+	if r.CreatedAt.IsZero() {
+		t.Error("CreatedAt should be auto-populated")
+	}
+
+	// `since` in the future excludes the record.
+	if n := len(st.ProviderEnergySince(time.Now().Add(time.Hour))); n != 0 {
+		t.Errorf("future since returned %d records, want 0", n)
+	}
+}

--- a/coordinator/store/interface.go
+++ b/coordinator/store/interface.go
@@ -529,6 +529,16 @@ type Store interface {
 	// GetLogReport retrieves a single log report by ID.
 	GetLogReport(id int64) (*LogReport, error)
 
+	// --- Provider Energy (per-node energy accounting time-series) ---
+
+	// RecordProviderEnergy appends a periodic energy ledger snapshot for a
+	// provider node. Best-effort; failures must not block the heartbeat path.
+	RecordProviderEnergy(record *ProviderEnergyRecord) error
+
+	// ProviderEnergySince returns energy snapshots created at or after the given
+	// time, newest first (capped). Zero since returns all (capped).
+	ProviderEnergySince(since time.Time) []ProviderEnergyRecord
+
 	// --- Telemetry ---
 	//
 	// Telemetry events are forwarded to Datadog (Logs API + DogStatsD)
@@ -722,6 +732,46 @@ type RejectionRecord struct {
 	ShortfallMicroUSD       int64   `json:"shortfall_micro_usd,omitempty"` // for 402
 	LimitKind               string  `json:"limit_kind,omitempty"`          // for 429 rate-limit
 	OverBy                  int64   `json:"over_by,omitempty"`
+
+	CreatedAt time.Time `json:"created_at"`
+}
+
+// ProviderEnergyRecord is a periodic snapshot of a provider node's cumulative
+// energy ledger (measured via IOReport on the provider). The joule fields are
+// cumulative since the provider process started; diffing consecutive snapshots
+// for the same provider session yields interval energy per operation, which is
+// how we analyze where energy goes. Contains no prompt or response content.
+type ProviderEnergyRecord struct {
+	ProviderID   string `json:"provider_id"`
+	AccountID    string `json:"account_id,omitempty"`
+	SerialNumber string `json:"serial_number,omitempty"`
+	Model        string `json:"model,omitempty"`
+	ChipFamily   string `json:"chip_family,omitempty"`
+	ChipTier     string `json:"chip_tier,omitempty"`
+	GPUCores     int    `json:"gpu_cores,omitempty"`
+
+	CurrentWatts float64 `json:"current_watts"`
+	IdleWatts    float64 `json:"idle_watts"`
+
+	// Cumulative joules per operation bucket.
+	IdleJoules    float64 `json:"idle_joules"`
+	PrefillJoules float64 `json:"prefill_joules"`
+	DecodeJoules  float64 `json:"decode_joules"`
+	LoadJoules    float64 `json:"load_joules"`
+
+	// Cumulative joules per SoC subsystem.
+	CPUJoules  float64 `json:"cpu_joules"`
+	GPUJoules  float64 `json:"gpu_joules"`
+	ANEJoules  float64 `json:"ane_joules"`
+	DRAMJoules float64 `json:"dram_joules"`
+
+	// Normalizers + derived per-token energy coefficients.
+	PrefillTokens    float64 `json:"prefill_tokens"`
+	DecodeTokens     float64 `json:"decode_tokens"`
+	WarmSeconds      float64 `json:"warm_seconds"`
+	ModelLoads       int     `json:"model_loads"`
+	JPerPrefillToken float64 `json:"j_per_prefill_token"`
+	JPerDecodeToken  float64 `json:"j_per_decode_token"`
 
 	CreatedAt time.Time `json:"created_at"`
 }

--- a/coordinator/store/interface.go
+++ b/coordinator/store/interface.go
@@ -746,6 +746,12 @@ type RejectionRecord struct {
 // new connection = new ProviderID), so diffing within a single ProviderID never
 // straddles a counter reset. SerialNumber is the stable machine identity for
 // cross-session rollups.
+//
+// The ledger is PROCESS-WIDE, not per-model: IOReport measures whole-SoC energy
+// and cannot be split across concurrently-resident models. Model is only the
+// active (serving) model at snapshot time, for context — do NOT treat it as a
+// per-model energy attribution key. Attribution is per-OPERATION (idle / prefill
+// / decode / load), which is the dimension this feature is built to analyze.
 type ProviderEnergyRecord struct {
 	ProviderID   string `json:"provider_id"`
 	AccountID    string `json:"account_id,omitempty"`

--- a/coordinator/store/interface.go
+++ b/coordinator/store/interface.go
@@ -739,8 +739,13 @@ type RejectionRecord struct {
 // ProviderEnergyRecord is a periodic snapshot of a provider node's cumulative
 // energy ledger (measured via IOReport on the provider). The joule fields are
 // cumulative since the provider process started; diffing consecutive snapshots
-// for the same provider session yields interval energy per operation, which is
-// how we analyze where energy goes. Contains no prompt or response content.
+// yields interval energy per operation, which is how we analyze where energy
+// goes. Contains no prompt or response content.
+//
+// ProviderID is the per-connection session id (a provider process restart =
+// new connection = new ProviderID), so diffing within a single ProviderID never
+// straddles a counter reset. SerialNumber is the stable machine identity for
+// cross-session rollups.
 type ProviderEnergyRecord struct {
 	ProviderID   string `json:"provider_id"`
 	AccountID    string `json:"account_id,omitempty"`

--- a/coordinator/store/memory.go
+++ b/coordinator/store/memory.go
@@ -127,6 +127,9 @@ type MemoryStore struct {
 
 	// Rejected inbound inference requests (4xx/5xx) with servability snapshot.
 	inferenceRejections []RejectionRecord
+
+	// Periodic per-provider energy ledger snapshots (time-series).
+	providerEnergy []ProviderEnergyRecord
 }
 
 // NewMemory creates a new MemoryStore. If adminKey is non-empty it is
@@ -905,6 +908,42 @@ func (s *MemoryStore) RejectionRecordsSince(since time.Time) []RejectionRecord {
 	}
 	if out == nil {
 		return []RejectionRecord{}
+	}
+	return out
+}
+
+// RecordProviderEnergy appends a periodic energy ledger snapshot for a provider
+// node. Best-effort; failures are discarded.
+func (s *MemoryStore) RecordProviderEnergy(record *ProviderEnergyRecord) error {
+	if record == nil {
+		return nil
+	}
+	rec := *record
+	if rec.CreatedAt.IsZero() {
+		rec.CreatedAt = time.Now()
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.providerEnergy = append(s.providerEnergy, rec)
+	return nil
+}
+
+// ProviderEnergySince returns energy snapshots created at or after the given
+// time, newest first (capped). Zero since returns all (capped).
+func (s *MemoryStore) ProviderEnergySince(since time.Time) []ProviderEnergyRecord {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	out := make([]ProviderEnergyRecord, 0, len(s.providerEnergy))
+	for i := len(s.providerEnergy) - 1; i >= 0; i-- {
+		r := s.providerEnergy[i]
+		if !since.IsZero() && r.CreatedAt.Before(since) {
+			continue
+		}
+		out = append(out, r)
+		if len(out) >= maxTelemetryReadRows {
+			break
+		}
 	}
 	return out
 }

--- a/coordinator/store/memory.go
+++ b/coordinator/store/memory.go
@@ -925,6 +925,12 @@ func (s *MemoryStore) RecordProviderEnergy(record *ProviderEnergyRecord) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.providerEnergy = append(s.providerEnergy, rec)
+	// Bound the in-memory series (the in-memory store is the production default).
+	// Reads are already capped at maxTelemetryReadRows; trim the oldest beyond a
+	// generous multiple so a long-lived process can't grow it without bound.
+	if max := maxTelemetryReadRows * 4; len(s.providerEnergy) > max {
+		s.providerEnergy = s.providerEnergy[len(s.providerEnergy)-max:]
+	}
 	return nil
 }
 

--- a/coordinator/store/postgres.go
+++ b/coordinator/store/postgres.go
@@ -1742,7 +1742,7 @@ func (s *PostgresStore) RecordProviderEnergy(record *ProviderEnergyRecord) error
 		createdAt = time.Now().UTC()
 	}
 
-	_, _ = s.pool.Exec(ctx,
+	_, err := s.pool.Exec(ctx,
 		`INSERT INTO provider_energy (
 			provider_id, account_id, serial_number, model, chip_family, chip_tier, gpu_cores,
 			current_watts, idle_watts,
@@ -1765,7 +1765,7 @@ func (s *PostgresStore) RecordProviderEnergy(record *ProviderEnergyRecord) error
 		record.PrefillTokens, record.DecodeTokens, record.WarmSeconds, record.ModelLoads,
 		record.JPerPrefillToken, record.JPerDecodeToken, createdAt,
 	)
-	return nil
+	return err
 }
 
 // ProviderEnergySince returns energy snapshots created at or after the given

--- a/coordinator/store/postgres.go
+++ b/coordinator/store/postgres.go
@@ -883,6 +883,39 @@ func (s *PostgresStore) migrate(ctx context.Context) error {
 		`CREATE INDEX IF NOT EXISTS idx_request_rejections_model ON request_rejections(resolved_model, created_at DESC)`,
 		`CREATE INDEX IF NOT EXISTS idx_request_rejections_status ON request_rejections(http_status, created_at DESC)`,
 		`CREATE INDEX IF NOT EXISTS idx_request_rejections_servable ON request_rejections(could_have_served, created_at DESC) WHERE could_have_served = true`,
+
+		// Per-provider energy ledger snapshots (time-series; diff consecutive
+		// rows per provider to get interval energy per operation).
+		`CREATE TABLE IF NOT EXISTS provider_energy (
+			id BIGSERIAL PRIMARY KEY,
+			provider_id TEXT NOT NULL,
+			account_id TEXT NOT NULL DEFAULT '',
+			serial_number TEXT NOT NULL DEFAULT '',
+			model TEXT NOT NULL DEFAULT '',
+			chip_family TEXT NOT NULL DEFAULT '',
+			chip_tier TEXT NOT NULL DEFAULT '',
+			gpu_cores INT NOT NULL DEFAULT 0,
+			current_watts DOUBLE PRECISION NOT NULL DEFAULT 0,
+			idle_watts DOUBLE PRECISION NOT NULL DEFAULT 0,
+			idle_joules DOUBLE PRECISION NOT NULL DEFAULT 0,
+			prefill_joules DOUBLE PRECISION NOT NULL DEFAULT 0,
+			decode_joules DOUBLE PRECISION NOT NULL DEFAULT 0,
+			load_joules DOUBLE PRECISION NOT NULL DEFAULT 0,
+			cpu_joules DOUBLE PRECISION NOT NULL DEFAULT 0,
+			gpu_joules DOUBLE PRECISION NOT NULL DEFAULT 0,
+			ane_joules DOUBLE PRECISION NOT NULL DEFAULT 0,
+			dram_joules DOUBLE PRECISION NOT NULL DEFAULT 0,
+			prefill_tokens DOUBLE PRECISION NOT NULL DEFAULT 0,
+			decode_tokens DOUBLE PRECISION NOT NULL DEFAULT 0,
+			warm_seconds DOUBLE PRECISION NOT NULL DEFAULT 0,
+			model_loads INT NOT NULL DEFAULT 0,
+			j_per_prefill_token DOUBLE PRECISION NOT NULL DEFAULT 0,
+			j_per_decode_token DOUBLE PRECISION NOT NULL DEFAULT 0,
+			created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_provider_energy_created ON provider_energy(created_at DESC)`,
+		`CREATE INDEX IF NOT EXISTS idx_provider_energy_provider ON provider_energy(provider_id, created_at DESC)`,
+		`CREATE INDEX IF NOT EXISTS idx_provider_energy_chip ON provider_energy(chip_family, chip_tier, created_at DESC)`,
 	}
 
 	for _, m := range migrations {
@@ -1689,6 +1722,85 @@ func (s *PostgresStore) RejectionRecordsSince(since time.Time) []RejectionRecord
 		}
 		if len(paramsRaw) > 0 {
 			r.Params = paramsRaw
+		}
+		records = append(records, r)
+	}
+	return records
+}
+
+// RecordProviderEnergy appends a periodic energy ledger snapshot for a provider
+// node. Best-effort; failures are discarded and never block the heartbeat path.
+func (s *PostgresStore) RecordProviderEnergy(record *ProviderEnergyRecord) error {
+	if record == nil {
+		return nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	createdAt := record.CreatedAt
+	if createdAt.IsZero() {
+		createdAt = time.Now().UTC()
+	}
+
+	_, _ = s.pool.Exec(ctx,
+		`INSERT INTO provider_energy (
+			provider_id, account_id, serial_number, model, chip_family, chip_tier, gpu_cores,
+			current_watts, idle_watts,
+			idle_joules, prefill_joules, decode_joules, load_joules,
+			cpu_joules, gpu_joules, ane_joules, dram_joules,
+			prefill_tokens, decode_tokens, warm_seconds, model_loads,
+			j_per_prefill_token, j_per_decode_token, created_at
+		) VALUES (
+			$1, $2, $3, $4, $5, $6, $7,
+			$8, $9,
+			$10, $11, $12, $13,
+			$14, $15, $16, $17,
+			$18, $19, $20, $21,
+			$22, $23, $24
+		)`,
+		record.ProviderID, record.AccountID, record.SerialNumber, record.Model, record.ChipFamily, record.ChipTier, record.GPUCores,
+		record.CurrentWatts, record.IdleWatts,
+		record.IdleJoules, record.PrefillJoules, record.DecodeJoules, record.LoadJoules,
+		record.CPUJoules, record.GPUJoules, record.ANEJoules, record.DRAMJoules,
+		record.PrefillTokens, record.DecodeTokens, record.WarmSeconds, record.ModelLoads,
+		record.JPerPrefillToken, record.JPerDecodeToken, createdAt,
+	)
+	return nil
+}
+
+// ProviderEnergySince returns energy snapshots created at or after the given
+// time, newest first (capped).
+func (s *PostgresStore) ProviderEnergySince(since time.Time) []ProviderEnergyRecord {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	rows, err := s.pool.Query(ctx,
+		`SELECT
+			provider_id, account_id, serial_number, model, chip_family, chip_tier, gpu_cores,
+			current_watts, idle_watts,
+			idle_joules, prefill_joules, decode_joules, load_joules,
+			cpu_joules, gpu_joules, ane_joules, dram_joules,
+			prefill_tokens, decode_tokens, warm_seconds, model_loads,
+			j_per_prefill_token, j_per_decode_token, created_at
+		 FROM provider_energy WHERE created_at >= $1 ORDER BY created_at DESC LIMIT $2`,
+		since, maxTelemetryReadRows)
+	if err != nil {
+		return nil
+	}
+	defer rows.Close()
+
+	var records []ProviderEnergyRecord
+	for rows.Next() {
+		var r ProviderEnergyRecord
+		if err := rows.Scan(
+			&r.ProviderID, &r.AccountID, &r.SerialNumber, &r.Model, &r.ChipFamily, &r.ChipTier, &r.GPUCores,
+			&r.CurrentWatts, &r.IdleWatts,
+			&r.IdleJoules, &r.PrefillJoules, &r.DecodeJoules, &r.LoadJoules,
+			&r.CPUJoules, &r.GPUJoules, &r.ANEJoules, &r.DRAMJoules,
+			&r.PrefillTokens, &r.DecodeTokens, &r.WarmSeconds, &r.ModelLoads,
+			&r.JPerPrefillToken, &r.JPerDecodeToken, &r.CreatedAt,
+		); err != nil {
+			continue
 		}
 		records = append(records, r)
 	}

--- a/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClient.swift
+++ b/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClient.swift
@@ -41,6 +41,9 @@ public enum CoordinatorEvent: Sendable {
 public final class AtomicProviderStats: Sendable {
     private let _requestsServed = ManagedAtomic<UInt64>(0)
     private let _tokensGenerated = ManagedAtomic<UInt64>(0)
+    // Cumulative prompt tokens that have completed prefill (counted at first
+    // token). Drives the energy accountant's J/prefill-token regression.
+    private let _promptTokensPrefilled = ManagedAtomic<UInt64>(0)
     // Count of completed requests whose usage chunk was missing/zero. Surfaced
     // in the daemon state file so `doctor` can flag a billing under-count.
     private let _usageGaps = ManagedAtomic<UInt64>(0)
@@ -55,6 +58,15 @@ public final class AtomicProviderStats: Sendable {
     public var tokensGenerated: UInt64 {
         get { _tokensGenerated.load() }
         set { _tokensGenerated.store(newValue) }
+    }
+
+    public var promptTokensPrefilled: UInt64 {
+        get { _promptTokensPrefilled.load() }
+        set { _promptTokensPrefilled.store(newValue) }
+    }
+
+    public func addPromptTokensPrefilled(_ count: UInt64) {
+        _promptTokensPrefilled.add(count)
     }
 
     public var usageGaps: UInt64 {
@@ -428,6 +440,12 @@ public actor CoordinatorClient {
     private let config: CoordinatorClientConfig
     private let stats: AtomicProviderStats
     private let state: ProviderState
+
+    /// Sudoless per-operation energy accountant (IOReport). Inert when IOReport
+    /// is unavailable, in which case the heartbeat omits energy and the
+    /// coordinator falls back to the static wall-power estimate.
+    private let energyAccountant = EnergyAccountant()
+    private var energyStarted = false
 
     private let logger = Logger(subsystem: "dev.darkbloom.provider", category: "coordinator")
 
@@ -889,12 +907,28 @@ public actor CoordinatorClient {
 
     // MARK: - Heartbeat
 
-    private func buildHeartbeatJSON() -> String {
+    private func buildHeartbeatJSON() async -> String {
         let isActive = state.inferenceActive
         let activeModel = state.currentModel
         let warmModels = state.warmModels
         let capacity = state.backendCapacity
-        let metrics = SystemMetricsCollector.collect(cpuCores: config.hardware.cpuCores.total)
+        var metrics = SystemMetricsCollector.collect(cpuCores: config.hardware.cpuCores.total)
+
+        // Start the energy accountant on the first heartbeat, then attach the
+        // latest cumulative snapshot. Inert (snapshot empty) without IOReport.
+        if !energyStarted {
+            energyStarted = true
+            await energyAccountant.start { [weak self] in
+                await self?.energyCounters()
+                    ?? EnergyActivityCounters(decodeTokensTotal: 0, prefillTokensTotal: 0, modelResident: false, loading: false)
+            }
+        }
+        var energySnapshot: EnergyLedgerSnapshot? = nil
+        if await energyAccountant.available() {
+            let snap = await energyAccountant.snapshot()
+            if snap.currentWatts > 0 { metrics.powerWatts = snap.currentWatts }
+            energySnapshot = snap
+        }
 
         let message = CoordinatorClientCodec.heartbeatMessage(
             status: isActive ? .serving : .idle,
@@ -905,7 +939,8 @@ public actor CoordinatorClient {
                 tokensGenerated: stats.tokensGenerated
             ),
             systemMetrics: metrics,
-            backendCapacity: capacity
+            backendCapacity: capacity,
+            energy: energySnapshot
         )
 
         guard let data = try? ProviderProtocolCodec.encodeProviderMessage(message),
@@ -913,6 +948,18 @@ public actor CoordinatorClient {
             return "{\"type\":\"heartbeat\",\"status\":\"idle\",\"stats\":{\"requests_served\":0,\"tokens_generated\":0},\"system_metrics\":{\"memory_pressure\":0,\"cpu_usage\":0,\"thermal_state\":\"nominal\"}}"
         }
         return json
+    }
+
+    /// Current cumulative activity counters for the energy accountant. Read once
+    /// per accounting tick; deltas are computed inside the accountant.
+    private func energyCounters() -> EnergyActivityCounters {
+        let model = state.currentModel
+        return EnergyActivityCounters(
+            decodeTokensTotal: stats.tokensGenerated,
+            prefillTokensTotal: stats.promptTokensPrefilled,
+            modelResident: !(model?.isEmpty ?? true),
+            loading: false
+        )
     }
 
     // MARK: - Outbound Encoding

--- a/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClient.swift
+++ b/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClient.swift
@@ -49,6 +49,12 @@ public final class AtomicProviderStats: Sendable {
     // Cumulative prompt tokens that have been prefilled (credited at request
     // completion). Denominator for the energy J/prefill-token ratio.
     private let _promptTokensPrefilled = ManagedAtomic<UInt64>(0)
+    // Nonzero while a model load/swap is in progress (cold load or coordinator
+    // preload). The energy accountant reads this to bucket load energy; the
+    // provider only ever reports running/idle slot states, so slot state cannot
+    // signal a load in progress. Int (not Bool) because ManagedAtomic requires
+    // a FixedWidthInteger here.
+    private let _modelLoading = ManagedAtomic<Int>(0)
     // Count of completed requests whose usage chunk was missing/zero. Surfaced
     // in the daemon state file so `doctor` can flag a billing under-count.
     private let _usageGaps = ManagedAtomic<UInt64>(0)
@@ -80,6 +86,14 @@ public final class AtomicProviderStats: Sendable {
     /// Increment as output frames stream (≈ one token per content frame).
     public func addEnergyDecodeTokens(_ count: UInt64) {
         _energyDecodeTokens.add(count)
+    }
+
+    /// True while a model load is in progress. Read by the energy accountant.
+    public var modelLoading: Bool { _modelLoading.load() != 0 }
+
+    /// Set by the load path (ProviderLoop) around model load/swap critical sections.
+    public func setModelLoading(_ value: Bool) {
+        _modelLoading.store(value ? 1 : 0)
     }
 
     public var usageGaps: UInt64 {
@@ -979,14 +993,15 @@ public actor CoordinatorClient {
     /// inside the accountant.
     private func energyCounters() -> EnergyActivityCounters {
         let model = state.currentModel
-        // A model is mid-load when any backend slot reports the reloading state.
-        let loading = state.backendCapacity?.slots.contains { $0.state == "reloading" } ?? false
         return EnergyActivityCounters(
             decodeTokensTotal: stats.energyDecodeTokens,
             prefillTokensTotal: stats.promptTokensPrefilled,
             inferenceActive: state.inferenceActive,
             modelResident: !(model?.isEmpty ?? true),
-            loading: loading
+            // Authoritative load signal from the provider's load critical section
+            // (covers cold loads + coordinator preloads). The provider never
+            // emits a "reloading" slot state, so this cannot come from capacity.
+            loading: stats.modelLoading
         )
     }
 

--- a/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClient.swift
+++ b/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClient.swift
@@ -41,8 +41,13 @@ public enum CoordinatorEvent: Sendable {
 public final class AtomicProviderStats: Sendable {
     private let _requestsServed = ManagedAtomic<UInt64>(0)
     private let _tokensGenerated = ManagedAtomic<UInt64>(0)
-    // Cumulative prompt tokens that have completed prefill (counted at first
-    // token). Drives the energy accountant's J/prefill-token regression.
+    // LIVE decode-token counter for energy accounting: incremented as output
+    // frames stream (≈ one per token), unlike `_tokensGenerated` which only
+    // settles at request completion. The energy accountant needs per-tick
+    // streaming progress, so it reads this, not the billing counter.
+    private let _energyDecodeTokens = ManagedAtomic<UInt64>(0)
+    // Cumulative prompt tokens that have been prefilled (credited at request
+    // completion). Denominator for the energy J/prefill-token ratio.
     private let _promptTokensPrefilled = ManagedAtomic<UInt64>(0)
     // Count of completed requests whose usage chunk was missing/zero. Surfaced
     // in the daemon state file so `doctor` can flag a billing under-count.
@@ -67,6 +72,14 @@ public final class AtomicProviderStats: Sendable {
 
     public func addPromptTokensPrefilled(_ count: UInt64) {
         _promptTokensPrefilled.add(count)
+    }
+
+    /// Live decode-token counter for energy accounting. Read by the accountant.
+    public var energyDecodeTokens: UInt64 { _energyDecodeTokens.load() }
+
+    /// Increment as output frames stream (≈ one token per content frame).
+    public func addEnergyDecodeTokens(_ count: UInt64) {
+        _energyDecodeTokens.add(count)
     }
 
     public var usageGaps: UInt64 {
@@ -668,6 +681,10 @@ public actor CoordinatorClient {
         // overhead on every ping; an unfair lock is cheaper for a single Instant.
         let pongTracker = PongTracker()
 
+        // Begin energy sampling at session start so the first interval after
+        // registration is captured (not skipped until the first heartbeat).
+        await startEnergyAccountant()
+
         try await withThrowingTaskGroup(of: Void.self) { group in
             // Task 1: Receive messages from coordinator
             group.addTask { [weak self] in
@@ -914,15 +931,8 @@ public actor CoordinatorClient {
         let capacity = state.backendCapacity
         var metrics = SystemMetricsCollector.collect(cpuCores: config.hardware.cpuCores.total)
 
-        // Start the energy accountant on the first heartbeat, then attach the
-        // latest cumulative snapshot. Inert (snapshot empty) without IOReport.
-        if !energyStarted {
-            energyStarted = true
-            await energyAccountant.start { [weak self] in
-                await self?.energyCounters()
-                    ?? EnergyActivityCounters(decodeTokensTotal: 0, prefillTokensTotal: 0, modelResident: false, loading: false)
-            }
-        }
+        // Attach the latest cumulative energy snapshot (the accountant is started
+        // at session start, see startEnergyAccountant). Inert without IOReport.
         var energySnapshot: EnergyLedgerSnapshot? = nil
         if await energyAccountant.available() {
             let snap = await energyAccountant.snapshot()
@@ -950,15 +960,33 @@ public actor CoordinatorClient {
         return json
     }
 
-    /// Current cumulative activity counters for the energy accountant. Read once
-    /// per accounting tick; deltas are computed inside the accountant.
+    /// Start the energy accountant's sampling loop once, at session start, so the
+    /// first interval after registration (preload, cold load, early inference) is
+    /// captured rather than skipped waiting for the first heartbeat.
+    private func startEnergyAccountant() async {
+        guard !energyStarted else { return }
+        energyStarted = true
+        await energyAccountant.start { [weak self] in
+            await self?.energyCounters()
+                ?? EnergyActivityCounters(
+                    decodeTokensTotal: 0, prefillTokensTotal: 0,
+                    inferenceActive: false, modelResident: false, loading: false)
+        }
+    }
+
+    /// Current cumulative activity counters + live flags for the energy
+    /// accountant. Read once per accounting tick; token deltas are computed
+    /// inside the accountant.
     private func energyCounters() -> EnergyActivityCounters {
         let model = state.currentModel
+        // A model is mid-load when any backend slot reports the reloading state.
+        let loading = state.backendCapacity?.slots.contains { $0.state == "reloading" } ?? false
         return EnergyActivityCounters(
-            decodeTokensTotal: stats.tokensGenerated,
+            decodeTokensTotal: stats.energyDecodeTokens,
             prefillTokensTotal: stats.promptTokensPrefilled,
+            inferenceActive: state.inferenceActive,
             modelResident: !(model?.isEmpty ?? true),
-            loading: false
+            loading: loading
         )
     }
 

--- a/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClientCodec.swift
+++ b/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClientCodec.swift
@@ -83,7 +83,8 @@ public enum CoordinatorClientCodec {
         warmModels: [String],
         stats: ProviderStats,
         systemMetrics: SystemMetrics,
-        backendCapacity: BackendCapacity?
+        backendCapacity: BackendCapacity?,
+        energy: EnergyLedgerSnapshot? = nil
     ) -> ProviderMessage {
         .heartbeat(ProviderMessage.Heartbeat(
             status: status,
@@ -91,7 +92,8 @@ public enum CoordinatorClientCodec {
             warmModels: warmModels,
             stats: stats,
             systemMetrics: systemMetrics,
-            backendCapacity: backendCapacity
+            backendCapacity: backendCapacity,
+            energy: energy
         ))
     }
 

--- a/provider-swift/Sources/ProviderCore/Hardware/EnergyAccountant.swift
+++ b/provider-swift/Sources/ProviderCore/Hardware/EnergyAccountant.swift
@@ -1,17 +1,21 @@
 import Foundation
 
-/// Cumulative activity counters read once per tick. The accountant diffs them
-/// internally to get per-tick prefill/decode token deltas, so the caller only
-/// needs to expose monotonic totals.
+/// Cumulative activity counters read once per tick. The accountant diffs the
+/// token totals internally to get per-tick deltas, so the caller only needs to
+/// expose monotonic totals plus the live flags. `decodeTokensTotal` MUST be a
+/// live streaming counter (incremented as tokens are emitted), not an
+/// end-of-request total, or attribution degenerates.
 public struct EnergyActivityCounters: Sendable, Equatable {
     public var decodeTokensTotal: UInt64
     public var prefillTokensTotal: UInt64
+    public var inferenceActive: Bool
     public var modelResident: Bool
     public var loading: Bool
 
-    public init(decodeTokensTotal: UInt64, prefillTokensTotal: UInt64, modelResident: Bool, loading: Bool) {
+    public init(decodeTokensTotal: UInt64, prefillTokensTotal: UInt64, inferenceActive: Bool, modelResident: Bool, loading: Bool) {
         self.decodeTokensTotal = decodeTokensTotal
         self.prefillTokensTotal = prefillTokensTotal
+        self.inferenceActive = inferenceActive
         self.modelResident = modelResident
         self.loading = loading
     }
@@ -31,6 +35,7 @@ public actor EnergyAccountant {
     private var ledger = EnergyLedger()
     private var prevDecode: UInt64 = 0
     private var prevPrefill: UInt64 = 0
+    private var wasLoading = false
     private var loopTask: Task<Void, Never>?
 
     public init(sampler: IOReportSampler = IOReportSampler()) {
@@ -39,7 +44,10 @@ public actor EnergyAccountant {
 
     public func available() async -> Bool { await sampler.available }
 
-    /// Start the background accounting loop. Idempotent.
+    /// Start the background accounting loop. Idempotent. Call this when the
+    /// session starts (not on the first heartbeat) so the first interval after
+    /// registration — coordinator preload, cold model load, early inference — is
+    /// sampled rather than skipped.
     public func start(intervalMs: UInt64 = 500, counters: @escaping CountersProvider) {
         guard loopTask == nil else { return }
         loopTask = Task { [weak self] in
@@ -66,14 +74,18 @@ public actor EnergyAccountant {
         let dPrefill = counters.prefillTokensTotal >= prevPrefill ? counters.prefillTokensTotal - prevPrefill : 0
         prevDecode = counters.decodeTokensTotal
         prevPrefill = counters.prefillTokensTotal
+
+        // Count a model load on the rising edge of `loading`.
+        if counters.loading && !wasLoading { ledger.noteModelLoad() }
+        wasLoading = counters.loading
+
         ledger.record(sample, activity: EnergyActivity(
             prefillTokens: Double(dPrefill),
             decodeTokens: Double(dDecode),
+            inferenceActive: counters.inferenceActive,
             modelResident: counters.modelResident,
             loading: counters.loading))
     }
-
-    public func noteModelLoad() { ledger.noteModelLoad() }
 
     public func snapshot() -> EnergyLedgerSnapshot { ledger.snapshot() }
 }

--- a/provider-swift/Sources/ProviderCore/Hardware/EnergyAccountant.swift
+++ b/provider-swift/Sources/ProviderCore/Hardware/EnergyAccountant.swift
@@ -1,0 +1,79 @@
+import Foundation
+
+/// Cumulative activity counters read once per tick. The accountant diffs them
+/// internally to get per-tick prefill/decode token deltas, so the caller only
+/// needs to expose monotonic totals.
+public struct EnergyActivityCounters: Sendable, Equatable {
+    public var decodeTokensTotal: UInt64
+    public var prefillTokensTotal: UInt64
+    public var modelResident: Bool
+    public var loading: Bool
+
+    public init(decodeTokensTotal: UInt64, prefillTokensTotal: UInt64, modelResident: Bool, loading: Bool) {
+        self.decodeTokensTotal = decodeTokensTotal
+        self.prefillTokensTotal = prefillTokensTotal
+        self.modelResident = modelResident
+        self.loading = loading
+    }
+}
+
+/// Owns the energy sampler + ledger and drives the periodic accounting loop.
+///
+/// The loop reads the latest cumulative activity counters (via a Sendable
+/// closure supplied by the provider runtime), samples IOReport, and folds one
+/// tick into the ledger. `snapshot()` is read by the heartbeat builder. When
+/// IOReport is unavailable the accountant is inert and `snapshot()` returns an
+/// empty ledger — the coordinator then falls back to the static estimate.
+public actor EnergyAccountant {
+    public typealias CountersProvider = @Sendable () async -> EnergyActivityCounters
+
+    private let sampler: IOReportSampler
+    private var ledger = EnergyLedger()
+    private var prevDecode: UInt64 = 0
+    private var prevPrefill: UInt64 = 0
+    private var loopTask: Task<Void, Never>?
+
+    public init(sampler: IOReportSampler = IOReportSampler()) {
+        self.sampler = sampler
+    }
+
+    public func available() async -> Bool { await sampler.available }
+
+    /// Start the background accounting loop. Idempotent.
+    public func start(intervalMs: UInt64 = 500, counters: @escaping CountersProvider) {
+        guard loopTask == nil else { return }
+        loopTask = Task { [weak self] in
+            let ns = intervalMs * 1_000_000
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: ns)
+                guard let self else { return }
+                let c = await counters()
+                await self.tick(c)
+            }
+        }
+    }
+
+    public func stop() {
+        loopTask?.cancel()
+        loopTask = nil
+    }
+
+    /// Fold a single tick. Exposed (not just internal to the loop) so unit tests
+    /// and one-shot CLI flows can drive it deterministically.
+    public func tick(_ counters: EnergyActivityCounters) async {
+        guard let sample = await sampler.sample() else { return }
+        let dDecode = counters.decodeTokensTotal >= prevDecode ? counters.decodeTokensTotal - prevDecode : 0
+        let dPrefill = counters.prefillTokensTotal >= prevPrefill ? counters.prefillTokensTotal - prevPrefill : 0
+        prevDecode = counters.decodeTokensTotal
+        prevPrefill = counters.prefillTokensTotal
+        ledger.record(sample, activity: EnergyActivity(
+            prefillTokens: Double(dPrefill),
+            decodeTokens: Double(dDecode),
+            modelResident: counters.modelResident,
+            loading: counters.loading))
+    }
+
+    public func noteModelLoad() { ledger.noteModelLoad() }
+
+    public func snapshot() -> EnergyLedgerSnapshot { ledger.snapshot() }
+}

--- a/provider-swift/Sources/ProviderCore/Hardware/EnergyLedger.swift
+++ b/provider-swift/Sources/ProviderCore/Hardware/EnergyLedger.swift
@@ -113,11 +113,18 @@ public struct EnergyLedger: Sendable {
         let joules = max(0, sample.totalJoules)
         lastWatts = joules / dt
 
-        // Off: machine idle with no model resident and not loading. Excluded
-        // from BOTH the operation buckets AND the subsystem totals so the two
-        // stay consistent (subsystem split == sum of buckets' scope). Tracked
-        // separately in offJoules; not reported on the wire.
-        if !activity.loading && !activity.inferenceActive && !activity.modelResident {
+        // Token progress means real serving work happened this tick, even if the
+        // capacity-derived `inferenceActive` flag is briefly stale (first ticks of
+        // a short request) or a model preload is concurrently in progress. So
+        // token progress forces "active".
+        let hasTokenProgress = activity.prefillTokens > 0 || activity.decodeTokens > 0
+        let active = activity.inferenceActive || hasTokenProgress
+
+        // Off: not active, not loading, no model resident. Excluded from BOTH the
+        // operation buckets AND the subsystem totals so the two stay consistent
+        // (subsystem split == sum of buckets' scope). Tracked separately in
+        // offJoules; not reported on the wire.
+        if !active && !activity.loading && !activity.modelResident {
             offJoules += joules
             consecutiveIdleTicks = 0
             return
@@ -132,7 +139,28 @@ public struct EnergyLedger: Sendable {
         prefillTokens += max(0, activity.prefillTokens)
         decodeTokens += max(0, activity.decodeTokens)
 
+        // Active serving takes precedence over a concurrent model load: when a
+        // preload overlaps an already-serving slot, attribute the energy above the
+        // idle baseline to decode/prefill so serving work keeps its denominator,
+        // rather than dumping the whole tick to load. Subtract the measured idle
+        // baseline (clamped to the tick's joules so buckets never exceed measured
+        // energy), then bucket by whether output tokens advanced this tick.
+        if active {
+            consecutiveIdleTicks = 0
+            warmSeconds += dt
+            let base = min(joules, idleWatts * dt)
+            idleJoules += base
+            let residual = joules - base
+            if activity.decodeTokens > 0 {
+                decodeJoules += residual
+            } else {
+                prefillJoules += residual
+            }
+            return
+        }
+
         if activity.loading {
+            // Pure load tick (no serving work in progress).
             consecutiveIdleTicks = 0
             warmSeconds += dt
             loadSeconds += dt
@@ -140,30 +168,13 @@ public struct EnergyLedger: Sendable {
             return
         }
 
-        if !activity.inferenceActive {
-            // Not serving, model resident → warm idle.
-            warmSeconds += dt
-            idleJoules += joules
-            consecutiveIdleTicks += 1
-            if consecutiveIdleTicks >= Self.idleStabilityThreshold {
-                let w = joules / dt
-                idleWatts = idleWatts > 0 ? (Self.idleAlpha * w + (1 - Self.idleAlpha) * idleWatts) : w
-            }
-            return
-        }
-
-        // Active (serving). Subtract the measured idle baseline (clamped to the
-        // tick's actual joules so buckets never exceed measured energy), then
-        // bucket the remainder by whether output tokens advanced this tick.
-        consecutiveIdleTicks = 0
+        // Not active, not loading, model resident → warm idle.
         warmSeconds += dt
-        let base = min(joules, idleWatts * dt)
-        idleJoules += base
-        let residual = joules - base
-        if activity.decodeTokens > 0 {
-            decodeJoules += residual
-        } else {
-            prefillJoules += residual
+        idleJoules += joules
+        consecutiveIdleTicks += 1
+        if consecutiveIdleTicks >= Self.idleStabilityThreshold {
+            let w = joules / dt
+            idleWatts = idleWatts > 0 ? (Self.idleAlpha * w + (1 - Self.idleAlpha) * idleWatts) : w
         }
     }
 

--- a/provider-swift/Sources/ProviderCore/Hardware/EnergyLedger.swift
+++ b/provider-swift/Sources/ProviderCore/Hardware/EnergyLedger.swift
@@ -3,23 +3,30 @@ import Foundation
 // Energy attribution ledger.
 //
 // Turns a stream of measured energy samples (joules consumed since the last
-// tick, broken down by SoC subsystem) plus a coarse activity signal (how many
-// prefill / decode tokens were produced in that tick) into a per-operation
+// tick, by SoC subsystem) plus a live activity signal into a per-operation
 // energy breakdown:
 //
-//   total = idle-floor baseline + prefill + decode + model-load
+//   measured = idle-floor baseline + prefill + decode + model-load
 //
-// The idle floor (watts the machine draws while a model is resident but no
-// request is running) is measured directly from quiet ticks. The energy ABOVE
-// that baseline on active ticks is attributed to prefill vs decode with an
-// online 2x2 non-negative least-squares fit:
+// Attribution is driven by LIVE per-tick signals, not end-of-request totals:
+//   - `inferenceActive` (the engine is serving) classifies a tick as active.
+//   - `loading` classifies a tick as a model load.
+//   - otherwise the tick is idle (only counted as warm idle when a model is
+//     resident — machine idle with no model resident is excluded from the warm
+//     baseline so it can't bias the idle floor or per-token coefficients).
 //
-//   residual_i  ~=  a * prefill_tokens_i  +  b * decode_tokens_i
+// On an active tick, energy ABOVE the measured idle floor is bucketed by whether
+// the engine emitted output tokens during the tick: ticks with decode-token
+// progress are decode work; active ticks with no output are prefill/compute.
+// Per-token energy is then a direct ratio (bucket joules / bucket tokens), which
+// is robust to continuous-batching timing and needs no regression.
 //
-// where `a` is J per prefill token and `b` is J per decode token. Pure-decode
-// ticks pin `b`; pure-prefill ticks pin `a`. Continuous-batching overlap (a
-// request prefilling while another decodes) is exactly what the regression
-// disentangles — you cannot get clean per-token numbers by bucketing alone.
+// Caveats (inherent to measuring the idle floor from quiet ticks):
+//   - If the box never goes idle (continuous load), `idleWatts` keeps its last
+//     learned value (or 0 if it has never idled), so early data slightly
+//     over-attributes to the active buckets.
+//   - On a cold start whose first ticks are already active, `idleWatts` stays 0
+//     until the first sustained quiet period.
 //
 // All energy values are joules. `1 Wh = 3600 J`.
 
@@ -42,17 +49,20 @@ public struct EnergySample: Sendable, Equatable {
     public var totalJoules: Double { cpuJoules + gpuJoules + aneJoules + dramJoules }
 }
 
-/// Coarse work signal for a tick. Token deltas drive the regression; the flags
-/// classify the tick.
+/// Per-tick work signal. Token fields are DELTAS for the tick; the flags
+/// classify the tick. `decodeTokens` must reflect live streaming progress (not
+/// an end-of-request total) for attribution to be correct.
 public struct EnergyActivity: Sendable, Equatable {
     public var prefillTokens: Double
     public var decodeTokens: Double
+    public var inferenceActive: Bool
     public var modelResident: Bool
     public var loading: Bool
 
-    public init(prefillTokens: Double, decodeTokens: Double, modelResident: Bool, loading: Bool) {
+    public init(prefillTokens: Double, decodeTokens: Double, inferenceActive: Bool, modelResident: Bool, loading: Bool) {
         self.prefillTokens = prefillTokens
         self.decodeTokens = decodeTokens
+        self.inferenceActive = inferenceActive
         self.modelResident = modelResident
         self.loading = loading
     }
@@ -65,6 +75,9 @@ public struct EnergyLedger: Sendable {
     public private(set) var prefillJoules = 0.0
     public private(set) var decodeJoules = 0.0
     public private(set) var loadJoules = 0.0
+    // Machine-idle energy while NO model is resident — tracked for completeness
+    // but deliberately excluded from the warm baseline and the wire snapshot.
+    public private(set) var offJoules = 0.0
 
     // Cumulative joules per subsystem (across all buckets).
     public private(set) var cpuJoules = 0.0
@@ -75,20 +88,18 @@ public struct EnergyLedger: Sendable {
     // Normalizers / counters.
     public private(set) var prefillTokens = 0.0
     public private(set) var decodeTokens = 0.0
-    public private(set) var warmSeconds = 0.0
+    public private(set) var warmSeconds = 0.0    // time a model was resident (idle warm + active + loading)
     public private(set) var loadSeconds = 0.0
     public private(set) var modelLoads = 0
 
-    // Derived: idle baseline watts, measured from quiet ticks.
+    // Derived: idle baseline watts, measured from sustained quiet (model resident,
+    // not serving). The stability filter prevents a transient spike from
+    // corrupting the floor.
     public private(set) var idleWatts = 0.0
 
     // Most recent instantaneous total power (W) for live stats.
     public private(set) var lastWatts = 0.0
 
-    // Online 2x2 regression accumulators (residual above idle on active ticks).
-    private var sPP = 0.0, sPD = 0.0, sDD = 0.0, sPR = 0.0, sDR = 0.0
-    // Idle-floor stability filter: only learn the floor from sustained quiet,
-    // so a one-tick model-load / GC spike can't corrupt the baseline.
     private var consecutiveIdleTicks = 0
     private static let idleStabilityThreshold = 2
     private static let idleAlpha = 0.2
@@ -108,72 +119,59 @@ public struct EnergyLedger: Sendable {
         aneJoules += max(0, sample.aneJoules)
         dramJoules += max(0, sample.dramJoules)
 
+        // Token deltas accrue regardless of how this tick is bucketed; they are
+        // the denominators for the per-token energy ratios.
+        prefillTokens += max(0, activity.prefillTokens)
+        decodeTokens += max(0, activity.decodeTokens)
+
         if activity.loading {
             consecutiveIdleTicks = 0
-            loadJoules += joules
+            warmSeconds += dt
             loadSeconds += dt
+            loadJoules += joules
             return
         }
 
-        let isActive = activity.prefillTokens > 0 || activity.decodeTokens > 0
-        if isActive {
-            consecutiveIdleTicks = 0
-            warmSeconds += dt
-            prefillTokens += activity.prefillTokens
-            decodeTokens += activity.decodeTokens
-
-            let base = idleWatts * dt
-            idleJoules += base
-            let residual = max(0, joules - base)
-
-            // Update regression accumulators.
-            let p = activity.prefillTokens, d = activity.decodeTokens
-            sPP += p * p
-            sPD += p * d
-            sDD += d * d
-            sPR += p * residual
-            sDR += d * residual
-
-            // Attribute this tick's residual using the current coefficients.
-            let (a, b) = coefficients()
-            let estP = a * p, estD = b * d
-            let denom = estP + estD
-            if denom > 1e-9 {
-                prefillJoules += residual * estP / denom
-                decodeJoules += residual * estD / denom
-            } else if d > 0 {
-                decodeJoules += residual
-            } else if p > 0 {
-                prefillJoules += residual
+        if !activity.inferenceActive {
+            // Not serving. Only count as warm idle when a model is resident;
+            // otherwise it's machine-idle and must not bias the warm baseline.
+            if activity.modelResident {
+                warmSeconds += dt
+                idleJoules += joules
+                consecutiveIdleTicks += 1
+                if consecutiveIdleTicks >= Self.idleStabilityThreshold {
+                    let w = joules / dt
+                    idleWatts = idleWatts > 0 ? (Self.idleAlpha * w + (1 - Self.idleAlpha) * idleWatts) : w
+                }
             } else {
-                idleJoules += residual
+                offJoules += joules
+                consecutiveIdleTicks = 0
             }
+            return
+        }
+
+        // Active (serving). Subtract the measured idle baseline (clamped to the
+        // tick's actual joules so buckets never exceed measured energy), then
+        // bucket the remainder by whether output tokens advanced this tick.
+        consecutiveIdleTicks = 0
+        warmSeconds += dt
+        let base = min(joules, idleWatts * dt)
+        idleJoules += base
+        let residual = joules - base
+        if activity.decodeTokens > 0 {
+            decodeJoules += residual
         } else {
-            // Quiet tick: whole sample is idle baseline.
-            warmSeconds += dt
-            idleJoules += joules
-            consecutiveIdleTicks += 1
-            if consecutiveIdleTicks >= Self.idleStabilityThreshold {
-                let w = joules / dt
-                idleWatts = idleWatts > 0 ? (Self.idleAlpha * w + (1 - Self.idleAlpha) * idleWatts) : w
-            }
+            prefillJoules += residual
         }
     }
 
     /// Record that a model finished loading (call once per load completion).
     public mutating func noteModelLoad() { modelLoads += 1 }
 
-    /// Solve [sPP sPD; sPD sDD][a;b] = [sPR; sDR], clamped to non-negative, with
-    /// graceful fallbacks when one dimension hasn't been excited yet.
+    /// Average energy per token, derived directly from the buckets.
     public func coefficients() -> (jPerPrefillToken: Double, jPerDecodeToken: Double) {
-        let det = sPP * sDD - sPD * sPD
-        if abs(det) > 1e-6 && sPP > 1e-6 && sDD > 1e-6 {
-            let a = (sDD * sPR - sPD * sDR) / det
-            let b = (sPP * sDR - sPD * sPR) / det
-            return (max(0, a), max(0, b))
-        }
-        let a = sPP > 1e-6 ? max(0, sPR / sPP) : 0
-        let b = sDD > 1e-6 ? max(0, sDR / sDD) : 0
+        let a = prefillTokens > 0 ? prefillJoules / prefillTokens : 0
+        let b = decodeTokens > 0 ? decodeJoules / decodeTokens : 0
         return (a, b)
     }
 

--- a/provider-swift/Sources/ProviderCore/Hardware/EnergyLedger.swift
+++ b/provider-swift/Sources/ProviderCore/Hardware/EnergyLedger.swift
@@ -1,0 +1,204 @@
+import Foundation
+
+// Energy attribution ledger.
+//
+// Turns a stream of measured energy samples (joules consumed since the last
+// tick, broken down by SoC subsystem) plus a coarse activity signal (how many
+// prefill / decode tokens were produced in that tick) into a per-operation
+// energy breakdown:
+//
+//   total = idle-floor baseline + prefill + decode + model-load
+//
+// The idle floor (watts the machine draws while a model is resident but no
+// request is running) is measured directly from quiet ticks. The energy ABOVE
+// that baseline on active ticks is attributed to prefill vs decode with an
+// online 2x2 non-negative least-squares fit:
+//
+//   residual_i  ~=  a * prefill_tokens_i  +  b * decode_tokens_i
+//
+// where `a` is J per prefill token and `b` is J per decode token. Pure-decode
+// ticks pin `b`; pure-prefill ticks pin `a`. Continuous-batching overlap (a
+// request prefilling while another decodes) is exactly what the regression
+// disentangles — you cannot get clean per-token numbers by bucketing alone.
+//
+// All energy values are joules. `1 Wh = 3600 J`.
+
+/// One measured energy delta over a wall-clock interval, split by subsystem.
+public struct EnergySample: Sendable, Equatable {
+    public var seconds: Double
+    public var cpuJoules: Double
+    public var gpuJoules: Double
+    public var aneJoules: Double
+    public var dramJoules: Double
+
+    public init(seconds: Double, cpuJoules: Double, gpuJoules: Double, aneJoules: Double, dramJoules: Double) {
+        self.seconds = seconds
+        self.cpuJoules = cpuJoules
+        self.gpuJoules = gpuJoules
+        self.aneJoules = aneJoules
+        self.dramJoules = dramJoules
+    }
+
+    public var totalJoules: Double { cpuJoules + gpuJoules + aneJoules + dramJoules }
+}
+
+/// Coarse work signal for a tick. Token deltas drive the regression; the flags
+/// classify the tick.
+public struct EnergyActivity: Sendable, Equatable {
+    public var prefillTokens: Double
+    public var decodeTokens: Double
+    public var modelResident: Bool
+    public var loading: Bool
+
+    public init(prefillTokens: Double, decodeTokens: Double, modelResident: Bool, loading: Bool) {
+        self.prefillTokens = prefillTokens
+        self.decodeTokens = decodeTokens
+        self.modelResident = modelResident
+        self.loading = loading
+    }
+}
+
+public struct EnergyLedger: Sendable {
+
+    // Cumulative joules per operation bucket (since process start).
+    public private(set) var idleJoules = 0.0
+    public private(set) var prefillJoules = 0.0
+    public private(set) var decodeJoules = 0.0
+    public private(set) var loadJoules = 0.0
+
+    // Cumulative joules per subsystem (across all buckets).
+    public private(set) var cpuJoules = 0.0
+    public private(set) var gpuJoules = 0.0
+    public private(set) var aneJoules = 0.0
+    public private(set) var dramJoules = 0.0
+
+    // Normalizers / counters.
+    public private(set) var prefillTokens = 0.0
+    public private(set) var decodeTokens = 0.0
+    public private(set) var warmSeconds = 0.0
+    public private(set) var loadSeconds = 0.0
+    public private(set) var modelLoads = 0
+
+    // Derived: idle baseline watts, measured from quiet ticks.
+    public private(set) var idleWatts = 0.0
+
+    // Most recent instantaneous total power (W) for live stats.
+    public private(set) var lastWatts = 0.0
+
+    // Online 2x2 regression accumulators (residual above idle on active ticks).
+    private var sPP = 0.0, sPD = 0.0, sDD = 0.0, sPR = 0.0, sDR = 0.0
+    // Idle-floor stability filter: only learn the floor from sustained quiet,
+    // so a one-tick model-load / GC spike can't corrupt the baseline.
+    private var consecutiveIdleTicks = 0
+    private static let idleStabilityThreshold = 2
+    private static let idleAlpha = 0.2
+
+    public init() {}
+
+    /// Fold one measured sample + its activity into the ledger.
+    public mutating func record(_ sample: EnergySample, activity: EnergyActivity) {
+        let dt = sample.seconds
+        guard dt > 0 else { return }
+        let joules = max(0, sample.totalJoules)
+        lastWatts = joules / dt
+
+        // Subsystem totals accrue regardless of bucket.
+        cpuJoules += max(0, sample.cpuJoules)
+        gpuJoules += max(0, sample.gpuJoules)
+        aneJoules += max(0, sample.aneJoules)
+        dramJoules += max(0, sample.dramJoules)
+
+        if activity.loading {
+            consecutiveIdleTicks = 0
+            loadJoules += joules
+            loadSeconds += dt
+            return
+        }
+
+        let isActive = activity.prefillTokens > 0 || activity.decodeTokens > 0
+        if isActive {
+            consecutiveIdleTicks = 0
+            warmSeconds += dt
+            prefillTokens += activity.prefillTokens
+            decodeTokens += activity.decodeTokens
+
+            let base = idleWatts * dt
+            idleJoules += base
+            let residual = max(0, joules - base)
+
+            // Update regression accumulators.
+            let p = activity.prefillTokens, d = activity.decodeTokens
+            sPP += p * p
+            sPD += p * d
+            sDD += d * d
+            sPR += p * residual
+            sDR += d * residual
+
+            // Attribute this tick's residual using the current coefficients.
+            let (a, b) = coefficients()
+            let estP = a * p, estD = b * d
+            let denom = estP + estD
+            if denom > 1e-9 {
+                prefillJoules += residual * estP / denom
+                decodeJoules += residual * estD / denom
+            } else if d > 0 {
+                decodeJoules += residual
+            } else if p > 0 {
+                prefillJoules += residual
+            } else {
+                idleJoules += residual
+            }
+        } else {
+            // Quiet tick: whole sample is idle baseline.
+            warmSeconds += dt
+            idleJoules += joules
+            consecutiveIdleTicks += 1
+            if consecutiveIdleTicks >= Self.idleStabilityThreshold {
+                let w = joules / dt
+                idleWatts = idleWatts > 0 ? (Self.idleAlpha * w + (1 - Self.idleAlpha) * idleWatts) : w
+            }
+        }
+    }
+
+    /// Record that a model finished loading (call once per load completion).
+    public mutating func noteModelLoad() { modelLoads += 1 }
+
+    /// Solve [sPP sPD; sPD sDD][a;b] = [sPR; sDR], clamped to non-negative, with
+    /// graceful fallbacks when one dimension hasn't been excited yet.
+    public func coefficients() -> (jPerPrefillToken: Double, jPerDecodeToken: Double) {
+        let det = sPP * sDD - sPD * sPD
+        if abs(det) > 1e-6 && sPP > 1e-6 && sDD > 1e-6 {
+            let a = (sDD * sPR - sPD * sDR) / det
+            let b = (sPP * sDR - sPD * sPR) / det
+            return (max(0, a), max(0, b))
+        }
+        let a = sPP > 1e-6 ? max(0, sPR / sPP) : 0
+        let b = sDD > 1e-6 ? max(0, sDR / sDD) : 0
+        return (a, b)
+    }
+
+    public var totalJoules: Double { idleJoules + prefillJoules + decodeJoules + loadJoules }
+
+    /// Immutable wire/report snapshot.
+    public func snapshot() -> EnergyLedgerSnapshot {
+        let (a, b) = coefficients()
+        return EnergyLedgerSnapshot(
+            currentWatts: lastWatts,
+            idleWatts: idleWatts,
+            idleJoules: idleJoules,
+            prefillJoules: prefillJoules,
+            decodeJoules: decodeJoules,
+            loadJoules: loadJoules,
+            cpuJoules: cpuJoules,
+            gpuJoules: gpuJoules,
+            aneJoules: aneJoules,
+            dramJoules: dramJoules,
+            prefillTokens: prefillTokens,
+            decodeTokens: decodeTokens,
+            warmSeconds: warmSeconds,
+            modelLoads: modelLoads,
+            jPerPrefillToken: a,
+            jPerDecodeToken: b
+        )
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Hardware/EnergyLedger.swift
+++ b/provider-swift/Sources/ProviderCore/Hardware/EnergyLedger.swift
@@ -113,14 +113,22 @@ public struct EnergyLedger: Sendable {
         let joules = max(0, sample.totalJoules)
         lastWatts = joules / dt
 
-        // Subsystem totals accrue regardless of bucket.
+        // Off: machine idle with no model resident and not loading. Excluded
+        // from BOTH the operation buckets AND the subsystem totals so the two
+        // stay consistent (subsystem split == sum of buckets' scope). Tracked
+        // separately in offJoules; not reported on the wire.
+        if !activity.loading && !activity.inferenceActive && !activity.modelResident {
+            offJoules += joules
+            consecutiveIdleTicks = 0
+            return
+        }
+
+        // Accounted tick (warm idle / prefill / decode / load): subsystem totals
+        // and token denominators accrue here so they match the buckets.
         cpuJoules += max(0, sample.cpuJoules)
         gpuJoules += max(0, sample.gpuJoules)
         aneJoules += max(0, sample.aneJoules)
         dramJoules += max(0, sample.dramJoules)
-
-        // Token deltas accrue regardless of how this tick is bucketed; they are
-        // the denominators for the per-token energy ratios.
         prefillTokens += max(0, activity.prefillTokens)
         decodeTokens += max(0, activity.decodeTokens)
 
@@ -133,19 +141,13 @@ public struct EnergyLedger: Sendable {
         }
 
         if !activity.inferenceActive {
-            // Not serving. Only count as warm idle when a model is resident;
-            // otherwise it's machine-idle and must not bias the warm baseline.
-            if activity.modelResident {
-                warmSeconds += dt
-                idleJoules += joules
-                consecutiveIdleTicks += 1
-                if consecutiveIdleTicks >= Self.idleStabilityThreshold {
-                    let w = joules / dt
-                    idleWatts = idleWatts > 0 ? (Self.idleAlpha * w + (1 - Self.idleAlpha) * idleWatts) : w
-                }
-            } else {
-                offJoules += joules
-                consecutiveIdleTicks = 0
+            // Not serving, model resident → warm idle.
+            warmSeconds += dt
+            idleJoules += joules
+            consecutiveIdleTicks += 1
+            if consecutiveIdleTicks >= Self.idleStabilityThreshold {
+                let w = joules / dt
+                idleWatts = idleWatts > 0 ? (Self.idleAlpha * w + (1 - Self.idleAlpha) * idleWatts) : w
             }
             return
         }

--- a/provider-swift/Sources/ProviderCore/Hardware/IOReportSampler.swift
+++ b/provider-swift/Sources/ProviderCore/Hardware/IOReportSampler.swift
@@ -1,0 +1,167 @@
+import Foundation
+
+// Sudoless energy sampling via Apple's private `IOReport` framework.
+//
+// IOReport exposes cumulative hardware energy counters in the "Energy Model"
+// channel group. We open ONE persistent subscription, then on each call diff
+// the current cumulative sample against the previous one — the delta is the
+// energy (mJ/µJ/nJ) consumed by each subsystem in between. No sudo, no
+// entitlement; this is the same source `powermetrics` reads.
+//
+// On macOS 13–26 the symbols live in the top-level dylib `/usr/lib/libIOReport.dylib`
+// (the old IOReport.framework path no longer resolves via dlopen on macOS 26).
+// If the library or any symbol is missing, the sampler degrades to `unavailable`
+// and the caller falls back to the static wall-power estimate.
+
+// MARK: - Private IOReport C signatures (resolved at runtime via dlsym)
+
+private typealias FnCopyChannels  = @convention(c) (CFString?, CFString?, UInt64, UInt64, UInt64) -> Unmanaged<CFDictionary>?
+private typealias FnCreateSub     = @convention(c) (UnsafeRawPointer?, CFMutableDictionary, UnsafeMutablePointer<Unmanaged<CFMutableDictionary>?>?, UInt64, CFTypeRef?) -> UnsafeMutableRawPointer?
+private typealias FnCreateSamples = @convention(c) (UnsafeMutableRawPointer?, CFMutableDictionary, CFTypeRef?) -> Unmanaged<CFDictionary>?
+private typealias FnDelta         = @convention(c) (CFDictionary, CFDictionary, CFTypeRef?) -> Unmanaged<CFDictionary>?
+private typealias FnChanStr       = @convention(c) (CFDictionary) -> Unmanaged<CFString>?
+private typealias FnSimpleInt     = @convention(c) (CFDictionary, Int32) -> Int64
+
+public actor IOReportSampler {
+
+    public private(set) var available = false
+
+    private var handle: UnsafeMutableRawPointer?
+    private var subscription: UnsafeMutableRawPointer?
+    private var sampleChannels: CFMutableDictionary?
+    private var prevSample: CFDictionary?
+    private var prevTime: Date?
+
+    private var fnSamples: FnCreateSamples?
+    private var fnDelta: FnDelta?
+    private var fnGroup: FnChanStr?
+    private var fnName: FnChanStr?
+    private var fnUnit: FnChanStr?
+    private var fnValue: FnSimpleInt?
+
+    public init() {
+        let candidates = [
+            "/usr/lib/libIOReport.dylib",
+            "libIOReport.dylib",
+            "/System/Library/PrivateFrameworks/IOReport.framework/IOReport",
+        ]
+        var h: UnsafeMutableRawPointer?
+        for path in candidates { if let opened = dlopen(path, RTLD_NOW) { h = opened; break } }
+        guard let handle = h else { return }
+        self.handle = handle
+
+        func sym<T>(_ name: String, _ type: T.Type) -> T? {
+            guard let p = dlsym(handle, name) else { return nil }
+            return unsafeBitCast(p, to: T.self)
+        }
+        guard
+            let copy = sym("IOReportCopyChannelsInGroup", FnCopyChannels.self),
+            let createSub = sym("IOReportCreateSubscription", FnCreateSub.self),
+            let samples = sym("IOReportCreateSamples", FnCreateSamples.self),
+            let delta = sym("IOReportCreateSamplesDelta", FnDelta.self),
+            let group = sym("IOReportChannelGetGroup", FnChanStr.self),
+            let name = sym("IOReportChannelGetChannelName", FnChanStr.self),
+            let unit = sym("IOReportChannelGetUnitLabel", FnChanStr.self),
+            let value = sym("IOReportSimpleGetIntegerValue", FnSimpleInt.self)
+        else { return }
+
+        guard
+            let channels = copy("Energy Model" as CFString, nil, 0, 0, 0)?.takeRetainedValue(),
+            let chanMut = CFDictionaryCreateMutableCopy(nil, 0, channels)
+        else { return }
+
+        var subbed: Unmanaged<CFMutableDictionary>?
+        guard let sub = createSub(nil, chanMut, &subbed, 0, nil) else { return }
+
+        self.subscription = sub
+        self.sampleChannels = subbed?.takeRetainedValue() ?? chanMut
+        self.fnSamples = samples
+        self.fnDelta = delta
+        self.fnGroup = group
+        self.fnName = name
+        self.fnUnit = unit
+        self.fnValue = value
+
+        // Prime the first sample so the next call yields a valid delta.
+        if let chans = sampleChannels, let first = samples(sub, chans, nil)?.takeRetainedValue() {
+            prevSample = first
+            prevTime = Date()
+            available = true
+        }
+    }
+
+    /// Energy consumed since the previous call, split by subsystem. Returns nil
+    /// on the first (priming) call or when measurement is unavailable.
+    public func sample() -> EnergySample? {
+        guard available,
+              let sub = subscription, let chans = sampleChannels,
+              let samples = fnSamples, let delta = fnDelta,
+              let prev = prevSample, let prevTime,
+              let cur = samples(sub, chans, nil)?.takeRetainedValue()
+        else { return nil }
+
+        let now = Date()
+        let elapsed = now.timeIntervalSince(prevTime)
+        prevSample = cur
+        self.prevTime = now
+        guard elapsed > 0, let d = delta(prev, cur, nil)?.takeRetainedValue() else { return nil }
+
+        let byName = energyByChannel(d)
+        let cpu = rollup(byName, exact: "CPU Energy", clusters: ["ECPU", "PCPU", "EACC_CPU", "PACC0_CPU", "PACC1_CPU", "MCPU0", "MCPU1"])
+        let gpu = rollup(byName, exact: "GPU Energy", clusters: ["GPU"])
+        let ane = rollup(byName, exact: "ANE", clusters: ["ANE0"])
+        let dram = rollup(byName, exact: "DRAM", clusters: ["DRAM0"])
+        return EnergySample(seconds: elapsed, cpuJoules: cpu, gpuJoules: gpu, aneJoules: ane, dramJoules: dram)
+    }
+
+    /// Sum joules per top-level channel name within the Energy Model group.
+    private func energyByChannel(_ delta: CFDictionary) -> [String: Double] {
+        guard let fnGroup, let fnName, let fnUnit, let fnValue else { return [:] }
+        let channelsKey = "IOReportChannels" as CFString
+        guard let arrPtr = CFDictionaryGetValue(delta, Unmanaged.passUnretained(channelsKey).toOpaque()) else { return [:] }
+        let channels = Unmanaged<CFArray>.fromOpaque(arrPtr).takeUnretainedValue()
+        let n = CFArrayGetCount(channels)
+        var byName: [String: Double] = [:]
+        for i in 0..<n {
+            guard let p = CFArrayGetValueAtIndex(channels, i) else { continue }
+            let ch = Unmanaged<CFDictionary>.fromOpaque(p).takeUnretainedValue()
+            let grp = (fnGroup(ch)?.takeUnretainedValue()) as String?
+            guard grp == "Energy Model" else { continue }
+            let name = (fnName(ch)?.takeUnretainedValue()) as String? ?? ""
+            let unit = (fnUnit(ch)?.takeUnretainedValue()) as String? ?? ""
+            let raw = fnValue(ch, 0)
+            byName[name, default: 0] += toJoules(raw, unit: unit)
+        }
+        return byName
+    }
+}
+
+// MARK: - Free helpers
+
+private func toJoules(_ value: Int64, unit: String) -> Double {
+    let v = Double(value)
+    switch unit.lowercased() {
+    case "mj":       return v / 1_000.0
+    case "uj", "µj": return v / 1_000_000.0
+    case "nj":       return v / 1_000_000_000.0
+    case "j":        return v
+    default:         return v / 1_000.0   // assume mJ when unlabeled
+    }
+}
+
+// IOReport reports the same energy at nested levels (per-DVFS-state *DTL*,
+// per-core PACC0_CPU3, cluster PACC0_CPU, rollup "CPU Energy"). Summing
+// everything triple-counts — read only the top rollup. `exact` is the single
+// rollup channel; `clusters` is the cluster-sum fallback for chips lacking it
+// (channel names differ M1–M4 vs M5).
+private func rollup(_ byName: [String: Double], exact: String, clusters: [String]) -> Double {
+    if let v = byName[exact], v > 0 { return v }
+    var sum = 0.0
+    for (name, v) in byName {
+        let u = name.uppercased()
+        if u.contains("DTL") || u.contains("SRAM") { continue }
+        if u.range(of: "_CPU[0-9]", options: .regularExpression) != nil { continue }
+        if clusters.contains(where: { u == $0 }) { sum += v }
+    }
+    return sum
+}

--- a/provider-swift/Sources/ProviderCore/Hardware/IOReportSampler.swift
+++ b/provider-swift/Sources/ProviderCore/Hardware/IOReportSampler.swift
@@ -26,6 +26,11 @@ public actor IOReportSampler {
 
     public private(set) var available = false
 
+    // The dlopen handle + IOReport subscription are held for the lifetime of the
+    // sampler. There is exactly one sampler per daemon process (and one per
+    // short-lived `darkbloom energy` run), so they are intentionally not torn
+    // down — the OS reclaims them at process exit. The ARC-managed CF sample
+    // dictionaries are released normally as they are replaced each tick.
     private var handle: UnsafeMutableRawPointer?
     private var subscription: UnsafeMutableRawPointer?
     private var sampleChannels: CFMutableDictionary?

--- a/provider-swift/Sources/ProviderCore/Protocol/Messages.swift
+++ b/provider-swift/Sources/ProviderCore/Protocol/Messages.swift
@@ -88,6 +88,7 @@ public enum ProviderMessage: Sendable, Equatable {
         public var stats: ProviderStats
         public var systemMetrics: SystemMetrics
         public var backendCapacity: BackendCapacity?
+        public var energy: EnergyLedgerSnapshot?
 
         public init(
             status: ProviderStatus,
@@ -95,7 +96,8 @@ public enum ProviderMessage: Sendable, Equatable {
             warmModels: [String] = [],
             stats: ProviderStats,
             systemMetrics: SystemMetrics,
-            backendCapacity: BackendCapacity? = nil
+            backendCapacity: BackendCapacity? = nil,
+            energy: EnergyLedgerSnapshot? = nil
         ) {
             self.status = status
             self.activeModel = activeModel
@@ -103,6 +105,7 @@ public enum ProviderMessage: Sendable, Equatable {
             self.stats = stats
             self.systemMetrics = systemMetrics
             self.backendCapacity = backendCapacity
+            self.energy = energy
         }
     }
 
@@ -328,6 +331,7 @@ extension ProviderMessage: Codable {
         case stats
         case systemMetrics = "system_metrics"
         case backendCapacity = "backend_capacity"
+        case energy
         // Common
         case requestId = "request_id"
         // InferenceResponseChunk
@@ -398,6 +402,7 @@ extension ProviderMessage: Codable {
             try container.encode(h.stats, forKey: .stats)
             try container.encode(h.systemMetrics, forKey: .systemMetrics)
             try container.encodeIfPresent(h.backendCapacity, forKey: .backendCapacity)
+            try container.encodeIfPresent(h.energy, forKey: .energy)
 
         case .inferenceAccepted(let a):
             try container.encode(TypeValue.inferenceAccepted, forKey: .type)
@@ -510,7 +515,8 @@ extension ProviderMessage: Codable {
                 warmModels: try container.decodeIfPresent([String].self, forKey: .warmModels) ?? [],
                 stats: try container.decode(ProviderStats.self, forKey: .stats),
                 systemMetrics: try container.decode(SystemMetrics.self, forKey: .systemMetrics),
-                backendCapacity: try container.decodeIfPresent(BackendCapacity.self, forKey: .backendCapacity)
+                backendCapacity: try container.decodeIfPresent(BackendCapacity.self, forKey: .backendCapacity),
+                energy: try container.decodeIfPresent(EnergyLedgerSnapshot.self, forKey: .energy)
             ))
 
         case .inferenceAccepted:

--- a/provider-swift/Sources/ProviderCore/Protocol/Types.swift
+++ b/provider-swift/Sources/ProviderCore/Protocol/Types.swift
@@ -70,17 +70,23 @@ public struct SystemMetrics: Codable, Sendable, Equatable {
     public var memoryPressure: Double
     public var cpuUsage: Double
     public var thermalState: ThermalState
+    /// Instantaneous total SoC power in watts (measured via IOReport). Optional:
+    /// omitted by legacy providers and when energy measurement is unavailable,
+    /// so old wire bytes are unchanged. Mirrors `power_watts,omitempty` in Go.
+    public var powerWatts: Double?
 
     enum CodingKeys: String, CodingKey {
         case memoryPressure = "memory_pressure"
         case cpuUsage = "cpu_usage"
         case thermalState = "thermal_state"
+        case powerWatts = "power_watts"
     }
 
-    public init(memoryPressure: Double, cpuUsage: Double, thermalState: ThermalState) {
+    public init(memoryPressure: Double, cpuUsage: Double, thermalState: ThermalState, powerWatts: Double? = nil) {
         self.memoryPressure = memoryPressure
         self.cpuUsage = cpuUsage
         self.thermalState = thermalState
+        self.powerWatts = powerWatts
     }
 }
 
@@ -429,6 +435,117 @@ public struct BackendCapacity: Codable, Sendable, Equatable {
         self.gpuMemoryPeakGb = gpuMemoryPeakGb
         self.gpuMemoryCacheGb = gpuMemoryCacheGb
         self.totalMemoryGb = totalMemoryGb
+    }
+}
+
+/// Cumulative per-operation energy breakdown reported on the heartbeat. All
+/// joule fields are cumulative since the provider process started; the
+/// coordinator persists periodic snapshots and diffs them for time-series
+/// analysis. Mirrors `EnergyLedger` in coordinator/protocol/messages.go.
+/// Every field is omit-when-zero so legacy providers (and the no-IOReport
+/// fallback) stay byte-compatible on the wire.
+public struct EnergyLedgerSnapshot: Codable, Sendable, Equatable {
+    public var currentWatts: Double      // instantaneous total SoC power
+    public var idleWatts: Double         // measured idle-floor baseline
+    public var idleJoules: Double
+    public var prefillJoules: Double
+    public var decodeJoules: Double
+    public var loadJoules: Double
+    public var cpuJoules: Double
+    public var gpuJoules: Double
+    public var aneJoules: Double
+    public var dramJoules: Double
+    public var prefillTokens: Double
+    public var decodeTokens: Double
+    public var warmSeconds: Double
+    public var modelLoads: Int
+    public var jPerPrefillToken: Double
+    public var jPerDecodeToken: Double
+
+    enum CodingKeys: String, CodingKey {
+        case currentWatts = "current_watts"
+        case idleWatts = "idle_watts"
+        case idleJoules = "idle_joules"
+        case prefillJoules = "prefill_joules"
+        case decodeJoules = "decode_joules"
+        case loadJoules = "load_joules"
+        case cpuJoules = "cpu_joules"
+        case gpuJoules = "gpu_joules"
+        case aneJoules = "ane_joules"
+        case dramJoules = "dram_joules"
+        case prefillTokens = "prefill_tokens"
+        case decodeTokens = "decode_tokens"
+        case warmSeconds = "warm_seconds"
+        case modelLoads = "model_loads"
+        case jPerPrefillToken = "j_per_prefill_token"
+        case jPerDecodeToken = "j_per_decode_token"
+    }
+
+    public init(
+        currentWatts: Double = 0, idleWatts: Double = 0,
+        idleJoules: Double = 0, prefillJoules: Double = 0, decodeJoules: Double = 0, loadJoules: Double = 0,
+        cpuJoules: Double = 0, gpuJoules: Double = 0, aneJoules: Double = 0, dramJoules: Double = 0,
+        prefillTokens: Double = 0, decodeTokens: Double = 0, warmSeconds: Double = 0, modelLoads: Int = 0,
+        jPerPrefillToken: Double = 0, jPerDecodeToken: Double = 0
+    ) {
+        self.currentWatts = currentWatts
+        self.idleWatts = idleWatts
+        self.idleJoules = idleJoules
+        self.prefillJoules = prefillJoules
+        self.decodeJoules = decodeJoules
+        self.loadJoules = loadJoules
+        self.cpuJoules = cpuJoules
+        self.gpuJoules = gpuJoules
+        self.aneJoules = aneJoules
+        self.dramJoules = dramJoules
+        self.prefillTokens = prefillTokens
+        self.decodeTokens = decodeTokens
+        self.warmSeconds = warmSeconds
+        self.modelLoads = modelLoads
+        self.jPerPrefillToken = jPerPrefillToken
+        self.jPerDecodeToken = jPerDecodeToken
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        func d(_ k: CodingKeys) throws -> Double { try c.decodeIfPresent(Double.self, forKey: k) ?? 0 }
+        currentWatts = try d(.currentWatts)
+        idleWatts = try d(.idleWatts)
+        idleJoules = try d(.idleJoules)
+        prefillJoules = try d(.prefillJoules)
+        decodeJoules = try d(.decodeJoules)
+        loadJoules = try d(.loadJoules)
+        cpuJoules = try d(.cpuJoules)
+        gpuJoules = try d(.gpuJoules)
+        aneJoules = try d(.aneJoules)
+        dramJoules = try d(.dramJoules)
+        prefillTokens = try d(.prefillTokens)
+        decodeTokens = try d(.decodeTokens)
+        warmSeconds = try d(.warmSeconds)
+        modelLoads = try c.decodeIfPresent(Int.self, forKey: .modelLoads) ?? 0
+        jPerPrefillToken = try d(.jPerPrefillToken)
+        jPerDecodeToken = try d(.jPerDecodeToken)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        func e(_ v: Double, _ k: CodingKeys) throws { if v != 0 { try c.encode(v, forKey: k) } }
+        try e(currentWatts, .currentWatts)
+        try e(idleWatts, .idleWatts)
+        try e(idleJoules, .idleJoules)
+        try e(prefillJoules, .prefillJoules)
+        try e(decodeJoules, .decodeJoules)
+        try e(loadJoules, .loadJoules)
+        try e(cpuJoules, .cpuJoules)
+        try e(gpuJoules, .gpuJoules)
+        try e(aneJoules, .aneJoules)
+        try e(dramJoules, .dramJoules)
+        try e(prefillTokens, .prefillTokens)
+        try e(decodeTokens, .decodeTokens)
+        try e(warmSeconds, .warmSeconds)
+        if modelLoads != 0 { try c.encode(modelLoads, forKey: .modelLoads) }
+        try e(jPerPrefillToken, .jPerPrefillToken)
+        try e(jPerDecodeToken, .jPerDecodeToken)
     }
 }
 

--- a/provider-swift/Sources/ProviderCore/ProviderLoop.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop.swift
@@ -1467,6 +1467,9 @@ public actor ProviderLoop {
             // Update stats
             providerStats.incrementRequestsServed()
             providerStats.addTokensGenerated(UInt64(max(completionTokens, 0)))
+            // Prefill tokens (counted at completion alongside decode tokens) feed
+            // the energy accountant's J/prefill-token regression.
+            providerStats.addPromptTokensPrefilled(UInt64(max(promptTokens, 0)))
 
             // Update state
             await me.updateAggregateCapacity()

--- a/provider-swift/Sources/ProviderCore/ProviderLoop.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop.swift
@@ -212,7 +212,12 @@ public actor ProviderLoop {
     private var loadingWaiters: [String: [CheckedContinuation<Void, any Error>]] = [:]
     private var modelsLoading: Set<String> = []
     private var loadGateWaiters: [CheckedContinuation<Void, Never>] = []
-    private var isLoadingAny: Bool = false
+    // Mirror the load-in-progress state to the shared stats so the energy
+    // accountant can bucket model-load energy (the provider never emits a
+    // "reloading" slot state, so this is the only reliable load signal).
+    private var isLoadingAny: Bool = false {
+        didSet { stats.setModelLoading(isLoadingAny) }
+    }
     private var isShuttingDown: Bool = false
 
     /// Phase of a graceful auto-update cycle. Drives admission: in `.draining`

--- a/provider-swift/Sources/ProviderCore/ProviderLoop.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop.swift
@@ -1411,6 +1411,19 @@ public actor ProviderLoop {
 
             // Cancelled with nothing delivered: 499 so the coordinator refunds.
             if cancelledMidStream && contentFrameCount == 0 && fullResponseText.isEmpty {
+                // Credit a prompt-token floor for the prefill work already done.
+                // The energy accountant may have bucketed the prefill ticks as
+                // prefill_joules; without a matching token denominator here (the
+                // completion-time credit below is skipped by this early return),
+                // j_per_prefill_token would skew in cancellation-heavy runs.
+                let prefillFloor = Self.promptTokenFloor(
+                    request: streamingRequest,
+                    tokenizer: tokenizer,
+                    reasoningEffort: reasoningEffort
+                )
+                if prefillFloor > 0 {
+                    providerStats.addPromptTokensPrefilled(UInt64(prefillFloor))
+                }
                 send.send(.inferenceError(
                     requestId: requestId,
                     error: "request cancelled",

--- a/provider-swift/Sources/ProviderCore/ProviderLoop.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop.swift
@@ -1348,6 +1348,12 @@ public actor ProviderLoop {
                         }
                         if frameHadContent {
                             contentFrameCount += 1
+                            // Live decode-token progress for energy accounting
+                            // (~one token per content frame). Unlike the billing
+                            // token count (settled at completion), this advances
+                            // every tick so the accountant attributes decode
+                            // energy to the ticks where it was actually spent.
+                            providerStats.addEnergyDecodeTokens(1)
                         }
                         if let usage = parsed.usage {
                             promptTokens = usage.promptTokens
@@ -1467,8 +1473,11 @@ public actor ProviderLoop {
             // Update stats
             providerStats.incrementRequestsServed()
             providerStats.addTokensGenerated(UInt64(max(completionTokens, 0)))
-            // Prefill tokens (counted at completion alongside decode tokens) feed
-            // the energy accountant's J/prefill-token regression.
+            // Prefill tokens are credited here at completion (the relay only
+            // learns prompt_tokens from the final usage frame). They are the
+            // DENOMINATOR for J/prefill-token; the prefill ENERGY itself is
+            // bucketed live by the accountant on active ticks that produce no
+            // output (the prefill phase), so the average ratio stays correct.
             providerStats.addPromptTokensPrefilled(UInt64(max(promptTokens, 0)))
 
             // Update state

--- a/provider-swift/Sources/darkbloom/Darkbloom.swift
+++ b/provider-swift/Sources/darkbloom/Darkbloom.swift
@@ -33,6 +33,7 @@ struct Darkbloom: AsyncParsableCommand {
             Status.self,
             Doctor.self,
             Models.self,
+            Energy.self,
             Local.self,
             Login.self,
             Logout.self,

--- a/provider-swift/Sources/darkbloom/EnergyCommand.swift
+++ b/provider-swift/Sources/darkbloom/EnergyCommand.swift
@@ -1,0 +1,83 @@
+import Foundation
+import ArgumentParser
+import ProviderCore
+
+// `darkbloom energy` — live SoC power/energy readout, sudoless via IOReport.
+//
+// Standalone meter (independent of the running provider): shows what the Mac is
+// drawing right now, split by subsystem (CPU / GPU / ANE / DRAM). The per-
+// operation attribution (idle vs prefill vs decode) is produced by the running
+// provider's EnergyAccountant and reported to the coordinator on the heartbeat;
+// this command is for spot-checking the raw numbers on the box.
+struct Energy: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "energy",
+        abstract: "Live SoC power/energy readout (sudoless, via IOReport)."
+    )
+
+    @Option(name: .long, help: "Sampling interval in milliseconds.")
+    var intervalMs: Int = 1000
+
+    @Option(name: .long, help: "Number of samples to print (0 = until interrupted).")
+    var count: Int = 10
+
+    @Flag(name: .long, help: "Emit JSON lines instead of a table.")
+    var json: Bool = false
+
+    struct Reading: Encodable {
+        let watts: Double
+        let cpuWatts: Double
+        let gpuWatts: Double
+        let aneWatts: Double
+        let dramWatts: Double
+    }
+
+    func run() async throws {
+        Darkbloom.ensureLogging()
+
+        let sampler = IOReportSampler()
+        guard await sampler.available else {
+            printError("IOReport energy measurement is unavailable on this system.")
+            throw ExitCode.failure
+        }
+
+        if !json {
+            printError("Live SoC power (sudoless via IOReport). interval=\(intervalMs)ms")
+            print(String(format: "%-5@  %8@  %8@  %8@  %8@  %10@",
+                         "#" as NSString, "CPU" as NSString, "GPU" as NSString,
+                         "ANE" as NSString, "DRAM" as NSString, "TOTAL" as NSString))
+        }
+
+        let interval = UInt64(max(100, intervalMs)) * 1_000_000
+        var samples = 0
+        var totalJoules = 0.0
+        var sumWatts = 0.0
+
+        while count == 0 || samples < count {
+            try? await Task.sleep(nanoseconds: interval)
+            guard let s = await sampler.sample(), s.seconds > 0 else { continue }
+            let cpu = s.cpuJoules / s.seconds
+            let gpu = s.gpuJoules / s.seconds
+            let ane = s.aneJoules / s.seconds
+            let dram = s.dramJoules / s.seconds
+            let total = s.totalJoules / s.seconds
+            samples += 1
+            totalJoules += s.totalJoules
+            sumWatts += total
+
+            if json {
+                let r = Reading(watts: total, cpuWatts: cpu, gpuWatts: gpu, aneWatts: ane, dramWatts: dram)
+                try? printJSON(r)
+            } else {
+                print(String(format: "%-5d  %6.2fW  %6.2fW  %6.2fW  %6.2fW  %8.2fW",
+                             samples, cpu, gpu, ane, dram, total))
+            }
+        }
+
+        if !json && samples > 0 {
+            let avg = sumWatts / Double(samples)
+            let wh = totalJoules / 3600.0
+            printError(String(format: "avg %.2f W   energy %.4f Wh over %d samples", avg, wh, samples))
+        }
+    }
+}

--- a/provider-swift/Tests/ProviderCoreTests/ProtocolTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/ProtocolTests.swift
@@ -517,6 +517,44 @@ import Testing
     #expect(!runtimeJSON.contains("mismatches"))
 }
 
+@Test func energyLedgerSnapshotSymmetry() throws {
+    // Nil energy + unmeasured power are omitted from the heartbeat.
+    let bare = ProviderMessage.heartbeat(ProviderMessage.Heartbeat(
+        status: .idle,
+        stats: ProviderStats(),
+        systemMetrics: SystemMetrics(memoryPressure: 0, cpuUsage: 0, thermalState: .nominal)
+    ))
+    let bareJSON = String(data: try ProviderProtocolCodec.encodeProviderMessage(bare), encoding: .utf8) ?? ""
+    #expect(!bareJSON.contains("energy"))
+    #expect(!bareJSON.contains("power_watts"))
+
+    // A populated ledger round-trips; zero sub-fields are omitted (matches the
+    // Go EnergyLedger omitempty so the wire bytes stay symmetric).
+    let snap = EnergyLedgerSnapshot(
+        currentWatts: 45.5, idleWatts: 8.0,
+        idleJoules: 900, prefillJoules: 300, decodeJoules: 1500,
+        decodeTokens: 3000, modelLoads: 2, jPerDecodeToken: 0.5
+    )
+    let hb = ProviderMessage.heartbeat(ProviderMessage.Heartbeat(
+        status: .serving,
+        stats: ProviderStats(),
+        systemMetrics: SystemMetrics(memoryPressure: 0, cpuUsage: 0, thermalState: .nominal, powerWatts: 45.5),
+        energy: snap
+    ))
+    let json = String(data: try ProviderProtocolCodec.encodeProviderMessage(hb), encoding: .utf8) ?? ""
+    #expect(json.contains("power_watts"))
+    #expect(json.contains("decode_joules"))
+    #expect(!json.contains("load_joules"))          // zero → omitted
+    #expect(!json.contains("ane_joules"))           // zero → omitted
+    #expect(!json.contains("j_per_prefill_token"))  // zero → omitted
+
+    let decoded = try JSONDecoder().decode(
+        EnergyLedgerSnapshot.self, from: try JSONEncoder().encode(snap))
+    #expect(decoded.decodeJoules == 1500)
+    #expect(decoded.jPerDecodeToken == 0.5)
+    #expect(decoded.modelLoads == 2)
+}
+
 @Test func backendSlotCapacityRoundTripsAdaptiveBatchingFields() throws {
     let slot = BackendSlotCapacity(
         model: "mlx-community/Qwen2.5-7B-4bit",


### PR DESCRIPTION
## Summary

Adds **per-operation energy tracking** so we can understand provider unit economics: measure real SoC energy on each Apple-Silicon provider via the **sudoless IOReport** API, attribute it to the operation the engine was doing (idle / prefill / decode / model-load), report it on the heartbeat, and **persist a per-provider time-series** in the coordinator for analysis.

The headline numbers it produces per model × chip: **J/decode-token**, **J/prefill-token**, **idle-floor watts**, and a per-subsystem split (CPU/GPU/ANE/DRAM) — enough to compute Wh/op and (with a $/kWh) $/request.

Refs **DAR-324**.

## Architecture — before / after

**Before** — power was a static estimate; no measured energy anywhere:

```mermaid
flowchart LR
  P["Provider (darkbloom)"] -->|"heartbeat: stats, system_metrics, backend_capacity"| RH["Registry.Heartbeat"]
  RH --> PS["Provider state"]
  PS --> STATS["GET /v1/stats"]
  STATS -->|"EstimateMachineWatts (static chip table)"| EST["active_power_watts<br/>(estimated)"]
```

**After** — measured energy is sampled, attributed per operation, reported, and persisted:

```mermaid
flowchart LR
  subgraph Provider["Provider (darkbloom)"]
    IOR["IOReportSampler<br/>/usr/lib/libIOReport.dylib"] --> ACC["EnergyAccountant<br/>EnergyLedger (phase bucketing)"]
    TOK["live decode frames +<br/>prefill tokens + inferenceActive"] --> ACC
    ACC --> HB["heartbeat<br/>+ power_watts<br/>+ energy ledger"]
    CLI["darkbloom energy CLI"] --> IOR
  end
  HB -->|WebSocket| RH["Registry.Heartbeat"]
  RH --> PS["Provider.Energy +<br/>SystemMetrics.PowerWatts"]
  PS --> STATS["GET /v1/stats"]
  STATS -->|"measured power, else estimate"| OUT["active_power_watts<br/>(measured)"]
  PS --> PE["persistEnergyThrottled (~60s)"]
  PE --> DB[("provider_energy<br/>time-series table")]
  DB --> AN["analysis:<br/>J/token, Wh/op, $/req"]
```

## How attribution works

IOReport's "Energy Model" group exposes **cumulative** joule counters (CPU/GPU/ANE/DRAM). We diff them each ~500ms tick and bucket the energy using **live** signals:

- **Classification:** `loading` (a backend slot is `reloading`) → load bucket; `inferenceActive` (the engine is serving) → active; otherwise idle — and idle is only counted as *warm* when a model is resident (machine idle with no model is excluded so it can't bias the floor).
- **Idle floor** is measured from sustained quiet ticks (stability-filtered against transient spikes).
- **Active ticks:** energy above the idle baseline (clamped to the tick's measured joules, so buckets never exceed measured energy) is bucketed by whether output tokens advanced this tick — ticks with **live** decode-token progress (≈ one per streamed content frame) are decode; active ticks with no output are prefill.
- **Per-token energy** is then a direct ratio — `decode_joules / decode_tokens`, `prefill_joules / prefill_tokens` — robust to continuous-batching timing.

> The first revision used a regression over completion-time token totals; PR review (independent verifier + GitHub Codex) correctly found those totals only update at request completion, so every streaming tick looked "idle." This revision drives classification + bucketing from live per-tick signals instead.

> Note: IOReport reports the same energy at nested levels (per-DVFS-state `*DTL*` → per-core → cluster → rollup); we read only the top rollup channels to avoid triple-counting. Channel names differ M1–M4 (`PACC`/`EACC`) vs M5 (`MCPU`).

## What changed

**Provider (Swift)** — new `ProviderCore/Hardware/` module:
- `IOReportSampler` — persistent IOReport subscription, per-subsystem joule deltas, graceful fallback when unavailable.
- `EnergyLedger` — idle/prefill/decode/load buckets + the regression + per-token coefficients.
- `EnergyAccountant` — 500ms accounting loop; snapshot attached to the heartbeat.
- `darkbloom energy` — live sudoless power readout.
- Wiring: prefill-token counter at request completion (`ProviderLoop`), `SystemMetrics.powerWatts` + `energy` on the heartbeat (`CoordinatorClient`, codec, `Messages`).

**Protocol** — `SystemMetrics.power_watts` + `EnergyLedger` (`messages.go` ↔ `Types.swift`/`Messages.swift`), all `omitempty`/encode-when-nonzero so legacy providers stay byte-compatible. Symmetry tests both sides.

**Coordinator** — `Registry.Heartbeat` ingests the ledger onto `Provider.Energy`; `persistEnergyThrottled` writes a snapshot/minute; `/v1/stats` prefers measured power over `EstimateMachineWatts` (same observed→estimate precedence as decode TPS).

**Store** — `ProviderEnergyRecord` + `RecordProviderEnergy`/`ProviderEnergySince` (interface, memory, postgres) + `provider_energy` table migration + round-trip test.

**Docs** — AGENTS.md + CLAUDE.md now require a before/after Mermaid diagram on every PR (this PR follows it).

## Verification

- **Swift:** full `swift build` ✅; `swift test` ✅ (`energyLedgerSnapshotSymmetry`, omitempty regression). Sampler + ledger validated on an M4 Max (live watts track load; regression recovers known coefficients).
- **Go:** `go build ./...` ✅, `gofmt` clean, `go test ./protocol/ ./store/ ./registry/ ./api/` ✅ (incl. energy round-trip).

## Addressed review feedback (commit 67137ae4)

- **P1** live token deltas — classify from `inferenceActive` + incremental streaming decode tokens; replaced the regression with phase bucketing.
- **P2** model-load activity wired (`loading` from `reloading` slot state + `noteModelLoad` on the rising edge) → `load_joules`/`model_loads` populate.
- **P2** skip warm-idle accounting when no model is resident.
- **P2** clamp the idle baseline to the tick's measured joules (conservative buckets).
- **P2** clamp untrusted `power_watts` (`MaxReasonablePowerWatts`) in `/v1/stats` and the heartbeat path.
- **P2** start the accountant at session start, not first heartbeat.
- Postgres `RecordProviderEnergy` returns its error; in-memory series bounded; per-session `ProviderID` + idle-floor caveats documented.

## Caveats / follow-ups

- **SoC vs wall power:** IOReport measures on-die energy, not wall-socket draw. The measured value augments (and falls back to) the existing wall estimate; a SoC→wall calibration (smart-plug ground truth) is the remaining open item.
- `loading` flag is stubbed `false` for v1 (load energy folds via the idle-stability filter); a precise model-load signal is a clean P2.
- Per-operation numbers populate once a provider runs a model under load → heartbeat → DB. `darkbloom energy` shows live machine power immediately.
- Out of scope (per issue): $/kWh sourcing, watts-per-token routing, console dashboards.

## Build note

`libs/mlx-swift*` are git submodules not auto-populated in fresh worktrees; run `git submodule update --init` before `swift build`.
