### PR TITLE
fix(routing): ignore garbage observed_prefill_tps (stopgap for hard-gate accuracy)

### DIFF
--- a/coordinator/registry/clamp_test.go
+++ b/coordinator/registry/clamp_test.go
@@ -108,3 +108,34 @@ func TestClampBackendCapacityReasonableValues(t *testing.T) {
 		t.Errorf("MaxConcurrency mutated: %v", bc.Slots[0].MaxConcurrency)
 	}
 }
+
+func TestClampBackendCapacityPrefillOverflowIgnored(t *testing.T) {
+	// A provider-side overflow (billions of tok/s, seen when the
+	// admitted->first-token window collapses on a prefix-cache hit) must be
+	// treated as NO measurement (0) so resolvePrefillTPS falls back to the
+	// conservative decode×ratio estimate — NOT clamped UP to maxPrefillTPS, which
+	// would make the TTFT estimate over-optimistic and the hard gate over-accept.
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	bc := &protocol.BackendCapacity{
+		Slots: []protocol.BackendSlotCapacity{
+			{Model: "gpt-oss-20b", ObservedPrefillTPS: 3.5e9}, // overflow garbage
+			{Model: "gemma", ObservedPrefillTPS: -1},          // negative
+			{Model: "nan", ObservedPrefillTPS: math.NaN()},    // NaN
+			{Model: "ok", ObservedPrefillTPS: 1600},           // plausible -> kept
+		},
+	}
+	clampBackendCapacity(logger, "p1", bc)
+
+	if bc.Slots[0].ObservedPrefillTPS != 0 {
+		t.Errorf("overflow ObservedPrefillTPS = %v, want 0 (ignored, not clamped to max)", bc.Slots[0].ObservedPrefillTPS)
+	}
+	if bc.Slots[1].ObservedPrefillTPS != 0 {
+		t.Errorf("negative ObservedPrefillTPS = %v, want 0", bc.Slots[1].ObservedPrefillTPS)
+	}
+	if bc.Slots[2].ObservedPrefillTPS != 0 {
+		t.Errorf("NaN ObservedPrefillTPS = %v, want 0", bc.Slots[2].ObservedPrefillTPS)
+	}
+	if bc.Slots[3].ObservedPrefillTPS != 1600 {
+		t.Errorf("plausible ObservedPrefillTPS = %v, want 1600 (unchanged)", bc.Slots[3].ObservedPrefillTPS)
+	}
+}

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -2105,10 +2105,18 @@ func clampBackendCapacity(logger *slog.Logger, providerID string, bc *protocol.B
 				"provider_id", providerID, "model", s.Model, "reported", s.ObservedDecodeTPS, "clamped", v)
 			s.ObservedDecodeTPS = v
 		}
-		if v, changed := clampNonNeg(s.ObservedPrefillTPS, maxPrefillTPS); changed {
-			logger.Warn("provider slot observed_prefill_tps out of range, clamping",
-				"provider_id", providerID, "model", s.Model, "reported", s.ObservedPrefillTPS, "clamped", v)
-			s.ObservedPrefillTPS = v
+		// observed_prefill_tps: an out-of-range value (NaN/negative, or absurdly
+		// high — a known provider-side overflow when the admitted→first-token
+		// window collapses on a prefix-cache hit) is treated as NO measurement (0)
+		// rather than clamped to the ceiling. Clamping garbage UP to maxPrefillTPS
+		// would make the TTFT estimate over-optimistic (prefill looks instant) and
+		// the hard gate over-accept; zeroing it makes resolvePrefillTPS fall back to
+		// the conservative decode×ratio estimate until the provider reports a sane
+		// value (provider fix: only sample cold prefills).
+		if math.IsNaN(s.ObservedPrefillTPS) || s.ObservedPrefillTPS < 0 || s.ObservedPrefillTPS > maxPrefillTPS {
+			logger.Warn("provider slot observed_prefill_tps out of range; ignoring (fall back to estimate)",
+				"provider_id", providerID, "model", s.Model, "reported", s.ObservedPrefillTPS)
+			s.ObservedPrefillTPS = 0
 		}
 		if s.ModelLoadTimeMS < 0 || s.ModelLoadTimeMS > maxModelLoadTimeMS {
 			logger.Warn("provider slot model_load_time_ms out of range, clamping",


### PR DESCRIPTION
## Problem
0.6.13 providers report `observed_prefill_tps` in the **billions** — a provider-side overflow when the admitted→first-token window collapses on a prefix-cache hit (logs: "observed_prefill_tps out of range, clamping"). The ingestion clamp turned that garbage into `maxPrefillTPS` (5000), so the **hard TTFT gate ran on an optimistic constant** (prefill looks ~instant) and could over-accept large prompts it can't actually fulfill — the opposite of the gate's intent and a regression risk for OpenRouter latency.

## Fix (coordinator stopgap — deploys immediately, no provider release needed)
Treat an out-of-range `observed_prefill_tps` (NaN/negative or `> maxPrefillTPS`) as **no measurement (0)** so `resolvePrefillTPS` falls back to the conservative decode×ratio (×12) estimate, instead of clamping garbage *up* to the ceiling.

Pairs with the provider-side root-cause fix (only sample genuine cold prefills) shipping in 0.6.14.

Test: `TestClampBackendCapacityPrefillOverflowIgnored`. Full `go test ./...` green; gofmt clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/387"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784273267&installation_id=133247490&pr_number=387&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F387&signature=181b8558d7cd5993ef007bae28ece80d81a35dcd56ea5e4b559f9e647d3a3336"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->