### PR TITLE
fix(provider): only sample cold prefills for observed_prefill_tps (no cache-hit overflow)

### DIFF
--- a/provider-swift/Sources/ProviderCore/Inference/BatchScheduler+EngineBridge.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/BatchScheduler+EngineBridge.swift
@@ -22,6 +22,26 @@ import MLXLMCommon
 
 extension BatchScheduler {
 
+    // MARK: - Prefill-EWMA sampling bounds
+    //
+    // `observed_prefill_tps` feeds the coordinator's routing-v2 TTFT estimate, so
+    // a single bogus sample skews routing for later cold prompts. We therefore
+    // sample ONLY a genuine cold prefill and drop implausible measurements.
+
+    /// Minimum admitted→first-token window (seconds) for a prefill sample to
+    /// count. A prefix-cache HIT restores the KV and emits the first token almost
+    /// instantly, collapsing the window toward ~0; dividing a positive prompt
+    /// length by a near-zero denominator produced the "billions of tok/s" readings
+    /// the coordinator clamped to 5000. 1ms is far below any real cold prefill yet
+    /// rejects that near-zero-window artifact.
+    static let minPrefillWindowSeconds = 0.001
+
+    /// Upper plausibility bound (tok/s) for a prefill sample. Set above the
+    /// coordinator's 5000 clamp so a legitimately fast cold prefill still
+    /// registers, while clearly impossible rates are dropped (defense in depth
+    /// behind the cold-only + window-floor guards).
+    static let maxPlausiblePrefillTps = 8000.0
+
     // MARK: - Bridge runner (called from `submit` in the main file)
 
     /// Spin up the per-request stream consumer that translates
@@ -232,30 +252,37 @@ extension BatchScheduler {
         }
 
         // Prefill rate: prompt tokens processed between engine admission and the
-        // first generated token. Measured with the same wall-clock methodology
-        // as the decode EWMA above — and, like decode, it reflects co-resident
-        // batch load (an OBSERVED effective rate, not an isolated kernel rate).
-        // Recorded only when a genuine prefill window exists (admitted, produced
-        // a first token, non-empty prompt, positive elapsed); otherwise omitted.
+        // first generated token, measured with the same wall-clock methodology as
+        // the decode EWMA above (an OBSERVED effective rate under co-resident batch
+        // load, not an isolated kernel rate). routing-v2 consumes this EWMA for
+        // TTFT estimates, so a single bogus sample skews TTFT for later cold
+        // prompts. Sample ONLY a genuine COLD prefill, and reject implausible ones:
+        //   * restoredPrefixTokens == 0 — a prefix-cache restore materializes the
+        //     prefix KV and emits the first token almost instantly, so the
+        //     admitted→first-token window covers only the uncached suffix and is
+        //     NOT representative of a cold prefill. The near-zero window also
+        //     collapses the denominator and explodes tps to billions (which the
+        //     coordinator then clamps to 5000, corrupting its TTFT estimate). Skip
+        //     cache hits entirely rather than recording an unrepresentative rate.
+        //   * prefilledTokens > 0 — need a real prompt to have prefilled.
+        //   * prefillSeconds >= minPrefillWindowSeconds — floor the denominator so
+        //     a near-zero window can't manufacture an absurd rate.
+        //   * tps finite and <= maxPlausiblePrefillTps — defense in depth: drop any
+        //     surviving implausible sample instead of poisoning the EWMA.
         if success,
             let admittedAt = bridge.admittedAt,
             let firstTokenAt = bridge.firstTokenAt,
-            finalPrompt > 0 {
+            bridge.restoredPrefixTokens == 0 {
             let prefillElapsed = firstTokenAt - admittedAt
             let prefillSeconds = Double(prefillElapsed.components.seconds)
                 + Double(prefillElapsed.components.attoseconds) / 1e18
-            // Exclude any prefix restored from the checkpoint cache: the
-            // admitted→first-token window only covers prefilling the UNCACHED
-            // suffix, so charging the FULL prompt would inflate the rate far above
-            // the true cold-prefill speed. Divide by the tokens ACTUALLY prefilled
-            // so `observed_prefill_tps` stays representative of a cold prefill —
-            // routing-v2 consumes this EWMA for TTFT estimates, and an inflated
-            // value makes the coordinator under-estimate TTFT for later cold large
-            // prompts (`restoredPrefixTokens` is 0 on a cold prefill, so this is a
-            // no-op for the non-cached path).
+            // Cold prefill ⇒ restoredPrefixTokens == 0, so this is the full prompt.
             let prefilledTokens = finalPrompt - bridge.restoredPrefixTokens
-            if prefillSeconds > 0, prefilledTokens > 0 {
-                updatePrefillTpsEwma(tps: Double(prefilledTokens) / prefillSeconds)
+            if prefilledTokens > 0, prefillSeconds >= Self.minPrefillWindowSeconds {
+                let tps = Double(prefilledTokens) / prefillSeconds
+                if tps.isFinite, tps <= Self.maxPlausiblePrefillTps {
+                    updatePrefillTpsEwma(tps: tps)
+                }
             }
         }
 

--- a/provider-swift/Sources/ProviderCore/Inference/BatchScheduler+EngineBridge.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/BatchScheduler+EngineBridge.swift
@@ -264,6 +264,14 @@ extension BatchScheduler {
         //     collapses the denominator and explodes tps to billions (which the
         //     coordinator then clamps to 5000, corrupting its TTFT estimate). Skip
         //     cache hits entirely rather than recording an unrepresentative rate.
+        //   * !enginePrefixCacheActive — the engine-tier (in-GPU) prefix cache
+        //     restores a matched prefix WITHOUT surfacing a per-request
+        //     restored-token count, so restoredPrefixTokens stays 0 even on a hit
+        //     and the bullet above can't catch it. Pure-attention (.engine) models
+        //     therefore skip prefill sampling entirely; checkpoint-tier models
+        //     (Gemma-4, GPT-OSS) DO set restoredPrefixTokens on a hit and are
+        //     unaffected. (Long-term: have the engine report reused tokens so cold
+        //     engine prefills can be sampled too — tracked as a follow-up.)
         //   * prefilledTokens > 0 — need a real prompt to have prefilled.
         //   * prefillSeconds >= minPrefillWindowSeconds — floor the denominator so
         //     a near-zero window can't manufacture an absurd rate.
@@ -272,7 +280,8 @@ extension BatchScheduler {
         if success,
             let admittedAt = bridge.admittedAt,
             let firstTokenAt = bridge.firstTokenAt,
-            bridge.restoredPrefixTokens == 0 {
+            bridge.restoredPrefixTokens == 0,
+            !enginePrefixCacheActive {
             let prefillElapsed = firstTokenAt - admittedAt
             let prefillSeconds = Double(prefillElapsed.components.seconds)
                 + Double(prefillElapsed.components.attoseconds) / 1e18

--- a/provider-swift/Sources/ProviderCore/Inference/BatchScheduler.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/BatchScheduler.swift
@@ -97,6 +97,32 @@ public actor BatchScheduler {
     var engineTierOwner: EncryptedPrefixCachePersistence?
     var engineTierAccountantToken: AccountantToken?
 
+    /// Test-only override backing `enginePrefixCacheActive`, set via
+    /// `_setEnginePrefixCacheActiveForTest` so tests can exercise the engine-tier
+    /// prefill-sampling skip without constructing a real
+    /// `EncryptedPrefixCachePersistence`. Production code leaves this false and
+    /// the gate derives solely from `engineTierOwner`.
+    private var _forceEnginePrefixCacheActiveForTest = false
+
+    /// True when an engine-tier (in-GPU block) prefix cache is active for the
+    /// loaded model. The engine restores a matched prefix internally and does
+    /// NOT surface a per-request restored-token count, so `restoredPrefixTokens`
+    /// stays 0 even on a cache hit — a hit is therefore indistinguishable from a
+    /// cold prefill. `recordFinish` skips prefill-EWMA sampling while this is
+    /// active so an unrepresentative cache-hit window can't poison routing-v2's
+    /// TTFT estimate. Single source of truth: `engineTierOwner` (set when the
+    /// engine-tier cache is built, cleared on teardown). Checkpoint-tier models
+    /// (Gemma-4, GPT-OSS) are unaffected — their `restoredPrefixTokens` IS set
+    /// on a hit, so the cold-only guard already excludes their restores.
+    var enginePrefixCacheActive: Bool {
+        engineTierOwner != nil || _forceEnginePrefixCacheActiveForTest
+    }
+
+    /// Test seam: force `enginePrefixCacheActive` without a real engine-tier owner.
+    func _setEnginePrefixCacheActiveForTest(_ active: Bool) {
+        _forceEnginePrefixCacheActiveForTest = active
+    }
+
     /// Admission control + token budget tracking. `nil` until `loadModel()`.
     var planner: BatchQueuePlanner?
 

--- a/provider-swift/Tests/ProviderCoreTests/BatchSchedulerBudgetTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/BatchSchedulerBudgetTests.swift
@@ -428,6 +428,36 @@ struct BatchSchedulerBudgetTests {
             "near-zero window must not poison the EWMA; stays at 0 default (got \(tps))")
     }
 
+    /// Engine-tier (in-GPU) prefix cache: the engine restores a matched prefix
+    /// WITHOUT surfacing a per-request restored-token count, so a cache hit
+    /// leaves `restoredPrefixTokens == 0` and would be misread as a cold prefill
+    /// — recording fullPrompt / collapsed-window and re-poisoning the very EWMA
+    /// the cold-only guard protects (the gap Codex flagged on the #388 fix).
+    /// While an engine-tier prefix cache is active, `recordFinish` must skip
+    /// prefill sampling entirely, even for a window that LOOKS like a clean cold
+    /// prefill (we can't prove it wasn't a hit).
+    @Test("recordFinish skips prefill sampling for engine-tier prefix-cache models")
+    func prefillEwmaSkipsEngineTierCache() async {
+        let s = BatchScheduler()
+        await s._setEnginePrefixCacheActiveForTest(true)
+        await s._testSeedBridge(id: "engine", promptTokens: 1000, maxTokens: 16)
+        let t0 = ContinuousClock.now
+        // A perfectly representative-looking cold window (1000 tok over 1s, well
+        // above the 1ms floor and below the 8000 cap): the ONLY reason to skip is
+        // that an engine-tier hit is indistinguishable from a cold prefill.
+        await s.recordAdmission(requestId: "engine", at: t0.advanced(by: .seconds(-2)))
+        await s.recordFirstToken(requestId: "engine", at: t0.advanced(by: .seconds(-1)))
+        _ = await s.recordFinish(
+            requestId: "engine", promptTokens: 1000, completionTokens: 8, success: true)
+        let tps = await s.observedPrefillTpsEwma
+        let initialized = await s.prefillEwmaInitialized
+
+        #expect(!initialized,
+            "engine-tier prefix cache active ⇒ no prefill-EWMA sample (hit vs cold ambiguous)")
+        #expect(tps == 0,
+            "engine-tier sampling skipped; EWMA stays at its 0 default (got \(tps))")
+    }
+
     // MARK: - Billing-zero leak: terminal must not zero observed tokens
 
     /// Regression for the revenue leak: when the engine's terminal

--- a/provider-swift/Tests/ProviderCoreTests/BatchSchedulerBudgetTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/BatchSchedulerBudgetTests.swift
@@ -357,23 +357,19 @@ struct BatchSchedulerBudgetTests {
             "P2: queued-not-admitted bridges must NOT inflate observedBatchSize")
     }
 
-    // MARK: - Prefill EWMA excludes restored prefix (routing-v2 TTFT correctness)
+    // MARK: - Prefill EWMA samples cold prefills only (routing-v2 TTFT correctness)
 
-    /// W1 measures `observed_prefill_tps` = promptTokens / (firstToken −
-    /// admitted). When the default-on prefix cache restores a checkpoint, that
-    /// window only covers the UNCACHED suffix, so dividing the FULL prompt by it
-    /// inflates the rate far above the true cold-prefill speed. routing-v2 now
-    /// consumes this EWMA for TTFT estimates, so an inflated value would make the
-    /// coordinator route later COLD large prompts as if they prefill at cached
-    /// speed (under-estimated TTFT). `recordFinish` must divide by the tokens
-    /// ACTUALLY prefilled (prompt − restored prefix).
-    @Test("recordFinish excludes restored-checkpoint prefix from the prefill EWMA")
-    func prefillEwmaExcludesRestoredPrefix() async {
-        // Identical 1-second prefill window and 1000-token prompt in both cases;
-        // explicit instants make the window deterministic (no wall-clock flake).
-        let window = Duration.seconds(1)
-
-        // Cold prefill: all 1000 tokens prefilled in 1s → ~1000 tok/s.
+    /// `observed_prefill_tps` = prefilledTokens / (firstToken − admitted) feeds
+    /// routing-v2's TTFT estimate. A prefix-cache RESTORE window is NOT
+    /// representative of a cold prefill: the engine emits the first token almost
+    /// instantly (KV already materialized), so the window covers only the uncached
+    /// suffix and the near-zero denominator explodes tps to the "billions" the
+    /// coordinator clamps to 5000. `recordFinish` must skip cache hits entirely
+    /// (cold-only) and sample only a genuine cold prefill.
+    @Test("recordFinish samples a cold prefill but skips a cache-restore window")
+    func prefillEwmaSamplesColdPrefillOnly() async {
+        // Cold prefill: all 1000 tokens prefilled in 1s → ~1000 tok/s. Explicit
+        // instants make the window deterministic (no wall-clock flake).
         let cold = BatchScheduler()
         await cold._testSeedBridge(id: "cold", promptTokens: 1000, maxTokens: 16)
         let c0 = ContinuousClock.now
@@ -382,10 +378,11 @@ struct BatchSchedulerBudgetTests {
         _ = await cold.recordFinish(
             requestId: "cold", promptTokens: 1000, completionTokens: 8, success: true)
         let coldTps = await cold.observedPrefillTpsEwma
+        let coldInitialized = await cold.prefillEwmaInitialized
 
         // Restore hit: 900 of the 1000 prompt tokens came from the checkpoint
-        // cache, so only the 100-token suffix was actually prefilled in the same
-        // 1s window → ~100 tok/s, NOT ~1000.
+        // cache, so the admitted→first-token window is unrepresentative of a cold
+        // prefill. NO sample is recorded — the EWMA stays at its 0 default.
         let restore = BatchScheduler()
         await restore._testSeedBridge(
             id: "warm", promptTokens: 1000, maxTokens: 16, restoredPrefixTokens: 900)
@@ -395,13 +392,40 @@ struct BatchSchedulerBudgetTests {
         _ = await restore.recordFinish(
             requestId: "warm", promptTokens: 1000, completionTokens: 8, success: true)
         let restoreTps = await restore.observedPrefillTpsEwma
+        let restoreInitialized = await restore.prefillEwmaInitialized
 
+        #expect(coldInitialized,
+            "cold prefill must record a prefill-EWMA sample")
         #expect(abs(coldTps - 1000) < 1.0,
             "cold prefill: full 1000-token prompt over 1s ≈ 1000 tok/s (got \(coldTps))")
-        #expect(abs(restoreTps - 100) < 1.0,
-            "restore: only the 100 uncached suffix tokens count ≈ 100 tok/s (got \(restoreTps))")
-        #expect(restoreTps < coldTps / 2,
-            "restored prefix must NOT inflate the prefill EWMA toward the cold rate")
+        #expect(!restoreInitialized,
+            "a prefix-cache restore must NOT record a prefill-EWMA sample")
+        #expect(restoreTps == 0,
+            "restore window is unrepresentative; EWMA stays at its 0 default (got \(restoreTps))")
+    }
+
+    /// The production bug: on a near-instant first token the admitted→first-token
+    /// window collapses toward ~0, so prefilledTokens / ~0 explodes to billions of
+    /// tok/s (which the coordinator clamps to 5000, corrupting its TTFT estimate).
+    /// A sub-millisecond window must be rejected even on the cold path
+    /// (restoredPrefixTokens == 0) so the EWMA is never poisoned.
+    @Test("recordFinish rejects a sub-millisecond prefill window (overflow guard)")
+    func prefillEwmaRejectsNearZeroWindow() async {
+        let s = BatchScheduler()
+        await s._testSeedBridge(id: "tiny", promptTokens: 1000, maxTokens: 16)
+        let t0 = ContinuousClock.now
+        await s.recordAdmission(requestId: "tiny", at: t0)
+        // 50µs window: well under the 1ms floor. Pre-fix this yielded ~2e7 tok/s.
+        await s.recordFirstToken(requestId: "tiny", at: t0.advanced(by: .microseconds(50)))
+        _ = await s.recordFinish(
+            requestId: "tiny", promptTokens: 1000, completionTokens: 8, success: true)
+        let tps = await s.observedPrefillTpsEwma
+        let initialized = await s.prefillEwmaInitialized
+
+        #expect(!initialized,
+            "a sub-millisecond prefill window must NOT record a sample")
+        #expect(tps == 0,
+            "near-zero window must not poison the EWMA; stays at 0 default (got \(tps))")
     }
 
     // MARK: - Billing-zero leak: terminal must not zero observed tokens


### PR DESCRIPTION
## Root cause
`observed_prefill_tps` was sampled whenever `prefillSeconds > 0`. On a prefix-cache HIT the engine restores KV and emits the first token in micro/nanoseconds, so the admitted→first-token window collapses toward ~0 while `prefilledTokens` stays > 0 → **tps explodes to billions**, which the coordinator clamps to 5000 and which corrupts the routing-v2 TTFT estimate (and undermines the hard gate).

## Fix (`BatchScheduler+EngineBridge.swift`)
Sample only a genuine **cold** prefill and reject implausible measurements:
1. `restoredPrefixTokens == 0` (skip cache hits entirely — unrepresentative window)
2. `prefilledTokens > 0`
3. `prefillSeconds >= minPrefillWindowSeconds` (1ms floor — kills the near-zero-window artifact)
4. `tps` finite and `<= maxPlausiblePrefillTps` (8000; above the coordinator's 5000 clamp so legit fast cold prefills still register)

## Tests
`prefillEwmaSamplesColdPrefillOnly` (cold updates EWMA; cache-restore records nothing) and `prefillEwmaRejectsNearZeroWindow` (50µs window → no sample). `swift build` succeeds; `swift test --filter prefillEwma` passes. (GPU/metallib tests are env-gated and unrelated to this CPU-side bookkeeping change.)

Pairs with the coordinator stopgap #387. Ships in **provider 0.6.14**.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/388"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784273556&installation_id=133247490&pr_number=388&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F388&signature=cfa2213e713902f1d220d87aea64527fbe723ef5668d4926600347f5d603fe89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->