### PR TITLE
fix(routing): relaunch safety — debounce cold-dispatch kick, real-free cold-load admission, safe-by-default flags

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -203,7 +203,7 @@ Provider state lives in several fields that are read by different code paths wit
 - `pendingModelLoads` is only checked by `TriggerModelSwaps` planning. It is NOT checked by `QuickCapacityCheck`, `ReserveProviderEx`, or `freeMemoryAdmits`. Do not assume pending-load state affects routing decisions.
 - Provider-reported slot states include `"running"` (active requests), `"idle"` (loaded, no requests), `"crashed"`, `"reloading"`, and `"idle_shutdown"`. The `"idle"` state means the model IS loaded — treat it the same as `"running"` for warm detection, not as `"unknown"`.
 - Providers can hold up to `maxModelSlots` models simultaneously (default 3). Do not assume a model swap evicts all other models.
-- The provider's `ensureModelLoaded` requires `estimatedMemoryGb * 3.0` headroom. The coordinator's `freeMemoryAdmits` uses a different (less conservative) check. A model the coordinator admits can still fail on the provider side.
+- The provider's `ModelLoadAdmission` gate (the source of truth for whether a load fits) admits a load when `weights + activation reserve + min serveable KV <= real free memory` (real free = total − resident, clamped to OS-available and kept under the 90% unified-memory cap). There is **no** `* 3.0` / 2.86× multiplier — that heuristic is stale. The coordinator's `freeMemoryAdmits` now mirrors this conservatively for cold loads (real free ≈ total − `gpuMemoryActiveGB` − OS reserve, required = weights + KV + ~3 GB activation reserve; see Fix 2 / `coordinator/registry/scheduler.go`), so it should no longer over-admit a load the provider then rejects. Long-term, the provider should report its own free-for-load figure in `BackendCapacity` so there is a single source of truth.
 
 ### Coordinator Mutation Checklist
 
@@ -213,7 +213,7 @@ When adding code that mutates provider state or sends commands (`load_model`, et
 2. Check what happens on the failure path — does state get cleaned up on disconnect, timeout, and load failure?
 3. Check concurrent access — heartbeats arrive per-provider on separate goroutines; `TriggerModelSwaps` can race with `drainQueuedRequestsForModels`.
 4. Check the cleanup path — `Disconnect()` must clear any per-provider state you add.
-5. Verify pre-existing invariants: `maxModelSlots`, heartbeat field omission semantics (`nil` vs empty), and the 3x memory gate on the provider side.
+5. Verify pre-existing invariants: `maxModelSlots`, heartbeat field omission semantics (`nil` vs empty), and the provider's real-free `ModelLoadAdmission` memory gate (weights + activation reserve + min serveable KV vs real free memory — no 3× multiplier; the coordinator's `freeMemoryAdmits` mirrors it conservatively).
 
 ## Code Structure & Modularity
 

--- a/coordinator/api/cold_dispatch.go
+++ b/coordinator/api/cold_dispatch.go
@@ -1,8 +1,11 @@
 package api
 
 import (
+	"log/slog"
 	"os"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/eigeninference/d-inference/coordinator/registry"
 	"github.com/eigeninference/d-inference/coordinator/saferun"
@@ -30,9 +33,17 @@ import (
 //     warmed for the queued demand without waiting for the next heartbeat.
 
 const (
-	envQueueBeforeShed = "EIGENINFERENCE_QUEUE_BEFORE_SHED"
-	envColdDispatch    = "EIGENINFERENCE_COLD_DISPATCH"
+	envQueueBeforeShed         = "EIGENINFERENCE_QUEUE_BEFORE_SHED"
+	envColdDispatch            = "EIGENINFERENCE_COLD_DISPATCH"
+	envColdDispatchMinInterval = "EIGENINFERENCE_COLD_DISPATCH_MIN_INTERVAL"
 )
+
+// defaultColdDispatchMinInterval bounds how often kickColdDispatch may run
+// TriggerModelSwaps. It collapses the per-enqueue kick (one per queued request)
+// into at most one model-swap pass per interval, which is what stops the
+// registry write-lock storm that took TriggerModelSwaps from O(1)/tick to
+// O(request volume) write-lock acquisitions.
+const defaultColdDispatchMinInterval = time.Second
 
 // envEnabledDefaultTrue parses a boolean env var that defaults to TRUE when
 // unset. Only an explicit falsey value ("0"/"false"/"no"/"off",
@@ -71,11 +82,75 @@ func (s *Server) coldSpillAvailable(model string, traits registry.RequestTraits,
 	return s.registry.ColdSpillProviders(model, traits, requiresVision, allowedSerials...) > 0
 }
 
+// coldDispatchMinInterval returns the minimum interval between cold-dispatch
+// model-swap passes. Configurable via EIGENINFERENCE_COLD_DISPATCH_MIN_INTERVAL
+// (any Go duration, e.g. "500ms", "2s"); a missing, empty, malformed, or
+// negative value falls back to defaultColdDispatchMinInterval.
+func coldDispatchMinInterval() time.Duration {
+	if v := strings.TrimSpace(os.Getenv(envColdDispatchMinInterval)); v != "" {
+		if d, err := time.ParseDuration(v); err == nil && d >= 0 {
+			return d
+		}
+	}
+	return defaultColdDispatchMinInterval
+}
+
+// coldKickState debounces cold-dispatch model-swap passes with a coalescing
+// single-flight + min-interval gate, so TriggerModelSwaps runs at most once per
+// interval no matter how many enqueues arrive. A burst of N enqueues collapses
+// into a single swap pass instead of N registry write-lock acquisitions — this
+// is the direct fix for the write-lock storm that caused the routing-v2
+// meltdown. The zero value is ready to use.
+type coldKickState struct {
+	mu       sync.Mutex
+	inFlight bool      // a swap pass is currently running
+	last     time.Time // completion time of the most recent swap pass
+}
+
+// kick runs trigger() on a recovered goroutine at most once per minInterval,
+// coalescing concurrent/rapid callers. It returns immediately (the swap never
+// blocks the request hot path):
+//   - if a pass is already in flight, drop (that pass covers this demand);
+//   - if the previous pass finished less than minInterval ago, drop (the next
+//     enqueue after the window, or a future heartbeat, covers it);
+//   - otherwise mark in-flight and dispatch exactly one trigger(), then record
+//     completion time and clear the in-flight flag.
+func (k *coldKickState) kick(minInterval time.Duration, logger *slog.Logger, trigger func()) {
+	now := time.Now()
+
+	k.mu.Lock()
+	if k.inFlight {
+		k.mu.Unlock()
+		return
+	}
+	if !k.last.IsZero() && now.Sub(k.last) < minInterval {
+		k.mu.Unlock()
+		return
+	}
+	k.inFlight = true
+	k.mu.Unlock()
+
+	saferun.Go(logger, "api.coldDispatchSwap", func() {
+		defer func() {
+			k.mu.Lock()
+			k.inFlight = false
+			k.last = time.Now()
+			k.mu.Unlock()
+		}()
+		trigger()
+	})
+}
+
 // kickColdDispatch proactively triggers the model-swap machinery so a cold
 // provider is warmed for a freshly-queued model without waiting for the next
-// heartbeat. It is a no-op when cold-dispatch is disabled. Safe to call on every
-// enqueue: TriggerModelSwaps only loads models that have queued demand and no
-// warm provider, and de-dups in-flight loads.
+// heartbeat. It is a no-op when cold-dispatch is disabled.
+//
+// It is called on EVERY queue enqueue, so it is debounced through coldKickState:
+// TriggerModelSwaps (which takes the registry WRITE lock) runs at most once per
+// coldDispatchMinInterval, coalescing an arbitrarily large enqueue burst into a
+// single swap pass. TriggerModelSwaps is itself idempotent — it only loads
+// models with queued demand and no warm provider, and de-dups in-flight loads —
+// so dropping redundant kicks loses nothing.
 //
 // It deliberately does NOT emit RecordWarmPoolColdDispatch: the queued request is
 // already counted via the warm-pool queue-depth signal, and the cold-dispatch
@@ -91,7 +166,7 @@ func (s *Server) kickColdDispatch(model string) {
 	if !s.coldDispatchEnabled() {
 		return
 	}
-	saferun.Go(s.logger, "api.coldDispatchSwap", func() {
+	s.coldKick.kick(coldDispatchMinInterval(), s.logger, func() {
 		s.registry.TriggerModelSwaps()
 	})
 }

--- a/coordinator/api/cold_dispatch.go
+++ b/coordinator/api/cold_dispatch.go
@@ -13,24 +13,26 @@ import (
 
 // Routing v2 — W3: cold-dispatch spill + queue-before-shed wiring.
 //
-// Both behaviours are default-ON and reversible without a rebuild via env flags.
-// They are read here (not on the Server struct) so this workstream stays
-// confined to its owned files — server.go / main.go are owned by parallel
-// workstreams. The flags are read per call: a feature-flag lookup is negligible
-// next to the JSON-parse + crypto + DB work each request already does, and
-// reading live env keeps the flags overridable in tests (t.Setenv).
+// Both behaviours are reversible without a rebuild via env flags, read per call:
+// a feature-flag lookup is negligible next to the JSON-parse + crypto + DB work
+// each request already does, and reading live env keeps the flags overridable in
+// tests (t.Setenv).
 //
-//   - EIGENINFERENCE_QUEUE_BEFORE_SHED (default true): when the preflight would
+//   - EIGENINFERENCE_QUEUE_BEFORE_SHED (default TRUE): when the preflight would
 //     429 `machine_busy` (providers exist for the model but all are at capacity),
 //     route the request into the normal dispatch+queue path instead, so a slot
 //     freeing — or a cold load completing — within the queue window serves it.
 //     The dispatch/queue path still returns a 429 when the queue is full or the
 //     wait times out (true saturation).
-//   - EIGENINFERENCE_COLD_DISPATCH (default true): (1) when the preflight would
-//     503 `no_provider` but an idle on-disk provider could load the model, spill
-//     the request into the queue instead of shedding; and (2) on every queue
-//     enqueue, proactively kick the model-swap machinery so a cold provider is
-//     warmed for the queued demand without waiting for the next heartbeat.
+//   - EIGENINFERENCE_COLD_DISPATCH (default FALSE, opt-in): (1) when the
+//     preflight would 503 `no_provider` but an idle on-disk provider could load
+//     the model, spill the request into the queue instead of shedding; and (2)
+//     on every queue enqueue, proactively (and debounced) kick the model-swap
+//     machinery so a cold provider is warmed for the queued demand without
+//     waiting for the next heartbeat. Default-off because this path drove the
+//     routing-v2 meltdown (registry write-lock storm + OOM cold loads); enable
+//     only after the safety fixes (kick debounce + real-free admission) are
+//     validated in the target environment.
 
 const (
 	envQueueBeforeShed         = "EIGENINFERENCE_QUEUE_BEFORE_SHED"
@@ -58,6 +60,20 @@ func envEnabledDefaultTrue(name string) bool {
 	}
 }
 
+// envEnabledDefaultFalse parses a boolean env var that defaults to FALSE when
+// unset. Only an explicit truthy value ("1"/"true"/"yes"/"on",
+// case-insensitive) enables the flag; anything else (including malformed input)
+// leaves the default-safe behaviour disabled. Used for opt-in features that are
+// risky on by default (e.g. cold-dispatch, which drove the routing-v2 meltdown).
+func envEnabledDefaultFalse(name string) bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(name))) {
+	case "1", "true", "yes", "on":
+		return true
+	default:
+		return false
+	}
+}
+
 // queueBeforeShedEnabled reports whether capacity-rejected preflight requests
 // are queued instead of immediately 429'd. Default true.
 func (s *Server) queueBeforeShedEnabled() bool {
@@ -66,9 +82,12 @@ func (s *Server) queueBeforeShedEnabled() bool {
 
 // coldDispatchEnabled reports whether the coordinator spills "no eligible
 // provider" requests into the queue when an idle on-disk provider could be
-// warmed, and proactively triggers cold loads for queued demand. Default true.
+// warmed, and proactively triggers cold loads for queued demand. Default FALSE
+// (opt-in): cold-dispatch was the routing-v2 meltdown trigger (write-lock storm
+// + OOM cold loads), so it must be explicitly enabled via
+// EIGENINFERENCE_COLD_DISPATCH=true after the safety fixes are validated.
 func (s *Server) coldDispatchEnabled() bool {
-	return envEnabledDefaultTrue(envColdDispatch)
+	return envEnabledDefaultFalse(envColdDispatch)
 }
 
 // coldSpillAvailable reports whether at least one idle on-disk provider could be

--- a/coordinator/api/cold_dispatch_test.go
+++ b/coordinator/api/cold_dispatch_test.go
@@ -72,14 +72,47 @@ func TestQueueBeforeShedFlagDefaultsOn(t *testing.T) {
 	}
 }
 
-func TestColdDispatchFlagDefaultsOn(t *testing.T) {
-	s := &Server{}
-	if !s.coldDispatchEnabled() {
-		t.Fatal("coldDispatchEnabled default = false, want true")
+func TestEnvEnabledDefaultFalse(t *testing.T) {
+	cases := []struct {
+		val  string
+		set  bool
+		want bool
+	}{
+		{set: false, want: false}, // unset → default false
+		{val: "", set: true, want: false},
+		{val: "true", set: true, want: true},
+		{val: "TRUE", set: true, want: true},
+		{val: "1", set: true, want: true},
+		{val: "yes", set: true, want: true},
+		{val: "on", set: true, want: true},
+		{val: " on ", set: true, want: true}, // trimmed
+		{val: "garbage", set: true, want: false},
+		{val: "false", set: true, want: false},
+		{val: "0", set: true, want: false},
+		{val: "no", set: true, want: false},
+		{val: "off", set: true, want: false},
 	}
-	t.Setenv(envColdDispatch, "off")
+	const name = "EIGENINFERENCE_W3_OPTIN_FLAG_TEST"
+	for _, c := range cases {
+		if c.set {
+			t.Setenv(name, c.val)
+		}
+		if got := envEnabledDefaultFalse(name); got != c.want {
+			t.Errorf("envEnabledDefaultFalse(%q set=%v) = %v, want %v", c.val, c.set, got, c.want)
+		}
+	}
+}
+
+// Cold-dispatch is now opt-in (default OFF): it drove the routing-v2 meltdown,
+// so it must be explicitly enabled.
+func TestColdDispatchFlagDefaultsOff(t *testing.T) {
+	s := &Server{}
 	if s.coldDispatchEnabled() {
-		t.Fatal("coldDispatchEnabled with =off = true, want false")
+		t.Fatal("coldDispatchEnabled default = true, want false (opt-in)")
+	}
+	t.Setenv(envColdDispatch, "true")
+	if !s.coldDispatchEnabled() {
+		t.Fatal("coldDispatchEnabled with =true = false, want true")
 	}
 }
 

--- a/coordinator/api/cold_dispatch_test.go
+++ b/coordinator/api/cold_dispatch_test.go
@@ -1,10 +1,35 @@
 package api
 
 import (
+	"io"
+	"log/slog"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/eigeninference/d-inference/coordinator/registry"
 )
+
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// waitColdKickIdle blocks until the cold-kick single-flight pass has completed
+// (inFlight cleared) or the deadline elapses.
+func waitColdKickIdle(t *testing.T, st *coldKickState) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		st.mu.Lock()
+		idle := !st.inFlight
+		st.mu.Unlock()
+		if idle {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatal("cold kick did not return to idle in time")
+}
 
 func TestEnvEnabledDefaultTrue(t *testing.T) {
 	cases := []struct {
@@ -70,4 +95,87 @@ func TestColdDispatchHelpersNilSafe(t *testing.T) {
 	s.kickColdDispatch("m")
 	t.Setenv(envColdDispatch, "false")
 	s.kickColdDispatch("m")
+}
+
+// A storm of kicks while a swap pass is in flight must coalesce into exactly one
+// trigger execution — this is the core anti-write-lock-storm property. Kicks
+// arriving within minInterval of the pass completing must also be dropped.
+func TestColdKickCoalescesInFlight(t *testing.T) {
+	logger := discardLogger()
+	var st coldKickState
+	var runs int32
+	started := make(chan struct{})
+	release := make(chan struct{})
+	blocking := func() {
+		atomic.AddInt32(&runs, 1)
+		close(started) // only the single admitted pass reaches here
+		<-release      // hold the pass in flight
+	}
+
+	// First kick admits the single in-flight pass.
+	st.kick(time.Hour, logger, blocking)
+	<-started // pass is now executing and blocked
+
+	// 1000 kicks while the pass is in flight must ALL drop (no write-lock storm).
+	for i := 0; i < 1000; i++ {
+		st.kick(time.Hour, logger, func() { atomic.AddInt32(&runs, 1) })
+	}
+	if got := atomic.LoadInt32(&runs); got != 1 {
+		t.Fatalf("in-flight coalescing: trigger ran %d times during one pass, want 1", got)
+	}
+
+	close(release)
+	waitColdKickIdle(t, &st)
+
+	// Within minInterval of completion, further kicks are still dropped.
+	for i := 0; i < 100; i++ {
+		st.kick(time.Hour, logger, func() { atomic.AddInt32(&runs, 1) })
+	}
+	if got := atomic.LoadInt32(&runs); got != 1 {
+		t.Fatalf("min-interval drop: trigger ran %d times within interval, want 1", got)
+	}
+}
+
+// With a zero min-interval, sequential (non-overlapping) kicks each run, so the
+// debounce never permanently wedges the swap machinery.
+func TestColdKickRunsAgainAfterInterval(t *testing.T) {
+	logger := discardLogger()
+	var st coldKickState
+	var runs int32
+	trig := func() { atomic.AddInt32(&runs, 1) }
+
+	st.kick(0, logger, trig)
+	waitColdKickIdle(t, &st)
+	if got := atomic.LoadInt32(&runs); got != 1 {
+		t.Fatalf("first kick ran %d times, want 1", got)
+	}
+
+	st.kick(0, logger, trig)
+	waitColdKickIdle(t, &st)
+	if got := atomic.LoadInt32(&runs); got != 2 {
+		t.Fatalf("second kick ran total %d times, want 2", got)
+	}
+}
+
+func TestColdDispatchMinInterval(t *testing.T) {
+	t.Setenv(envColdDispatchMinInterval, "")
+	if got := coldDispatchMinInterval(); got != defaultColdDispatchMinInterval {
+		t.Fatalf("unset = %v, want default %v", got, defaultColdDispatchMinInterval)
+	}
+	t.Setenv(envColdDispatchMinInterval, "250ms")
+	if got := coldDispatchMinInterval(); got != 250*time.Millisecond {
+		t.Fatalf("override = %v, want 250ms", got)
+	}
+	t.Setenv(envColdDispatchMinInterval, "not-a-duration")
+	if got := coldDispatchMinInterval(); got != defaultColdDispatchMinInterval {
+		t.Fatalf("malformed = %v, want default %v", got, defaultColdDispatchMinInterval)
+	}
+	t.Setenv(envColdDispatchMinInterval, "-5s")
+	if got := coldDispatchMinInterval(); got != defaultColdDispatchMinInterval {
+		t.Fatalf("negative = %v, want default %v", got, defaultColdDispatchMinInterval)
+	}
+	t.Setenv(envColdDispatchMinInterval, "0s")
+	if got := coldDispatchMinInterval(); got != 0 {
+		t.Fatalf("zero = %v, want 0", got)
+	}
 }

--- a/coordinator/api/server.go
+++ b/coordinator/api/server.go
@@ -369,6 +369,11 @@ type Server struct {
 	// Server built directly (e.g. &Server{} in tests) leaves it nil, and
 	// submitTelemetry falls back to a per-write saferun.Go in that case.
 	routeTelemetry *telemetrySink
+
+	// coldKick debounces the per-enqueue cold-dispatch model-swap kick into a
+	// coalescing single-flight + min-interval pass (see cold_dispatch.go), so a
+	// burst of enqueues cannot storm the registry write lock. Zero value ready.
+	coldKick coldKickState
 }
 
 // SetRateLimiter configures the per-account rate limiter applied to

--- a/coordinator/registry/config.go
+++ b/coordinator/registry/config.go
@@ -80,8 +80,14 @@ func ReadConfig() Config {
 	return Config{
 		MinTrustLevel: os.Getenv(env.EnvPrefix + "_MIN_TRUST"),
 		WarmPool: WarmPoolConfig{
-			Enabled:                   env.EnvBool(env.EnvPrefix+"_WARM_POOL_ENABLED", true),
-			ObserveOnly:               env.EnvBool(env.EnvPrefix+"_WARM_POOL_OBSERVE_ONLY", false),
+			Enabled: env.EnvBool(env.EnvPrefix+"_WARM_POOL_ENABLED", true),
+			// Default ObserveOnly=TRUE (safe by default): the warm pool computes
+			// load targets and emits telemetry but issues NO load_model actions
+			// unless explicitly opted in via WARM_POOL_OBSERVE_ONLY=false.
+			// Autonomous warm-pool loads were part of the routing-v2 meltdown
+			// (cold loads the providers OOM-rejected), so issuing them is gated
+			// behind an explicit operator decision.
+			ObserveOnly:               env.EnvBool(env.EnvPrefix+"_WARM_POOL_OBSERVE_ONLY", true),
 			Interval:                  envDuration(env.EnvPrefix+"_WARM_POOL_INTERVAL", 10*time.Second),
 			MinDwell:                  envDuration(env.EnvPrefix+"_WARM_POOL_MIN_DWELL", 5*time.Minute),
 			QueueAgeThreshold:         envDuration(env.EnvPrefix+"_WARM_POOL_QUEUE_AGE_THRESHOLD", 0),

--- a/coordinator/registry/config_test.go
+++ b/coordinator/registry/config_test.go
@@ -37,8 +37,10 @@ func TestReadConfigWarmPoolDefaultsActive(t *testing.T) {
 	if !cfg.Enabled {
 		t.Fatal("warm pool should default to enabled")
 	}
-	if cfg.ObserveOnly {
-		t.Fatal("warm pool should default to active, not observe-only")
+	// Safe by default: enabled (computes targets + telemetry) but observe-only
+	// (issues no load_model actions) until an operator opts in.
+	if !cfg.ObserveOnly {
+		t.Fatal("warm pool should default to observe-only (no autonomous loads)")
 	}
 	if cfg.Interval != 10*time.Second {
 		t.Fatalf("Interval = %v, want 10s", cfg.Interval)
@@ -65,5 +67,20 @@ func TestReadConfigWarmPoolCanBeDisabled(t *testing.T) {
 	}
 	if !cfg.ObserveOnly {
 		t.Fatal("warm pool observe-only override was not honored")
+	}
+}
+
+// Issuing autonomous warm-pool loads is an explicit opt-out of the safe
+// observe-only default: WARM_POOL_OBSERVE_ONLY=false.
+func TestReadConfigWarmPoolObserveOnlyOptOut(t *testing.T) {
+	clearWarmPoolEnv(t)
+	t.Setenv(env.EnvPrefix+"_WARM_POOL_OBSERVE_ONLY", "false")
+
+	cfg := ReadConfig().WarmPool
+	if !cfg.Enabled {
+		t.Fatal("warm pool should remain enabled")
+	}
+	if cfg.ObserveOnly {
+		t.Fatal("WARM_POOL_OBSERVE_ONLY=false should let the warm pool issue loads")
 	}
 }

--- a/coordinator/registry/scheduler.go
+++ b/coordinator/registry/scheduler.go
@@ -857,35 +857,38 @@ func freeMemoryAdmits(snap routingSnapshot, reqPromptTokens, reqMaxTokens int) b
 	kvCacheGB := float64(tokens*kvCacheBytesPerToken) / float64(bytesPerGB)
 	required += kvCacheGB
 
-	// When the model is available on disk but not currently loaded, the
-	// provider will LRU-evict idle models to make room, so we check the model
-	// fits in REAL FREE memory rather than requiring it to fit alongside the
-	// currently-loaded models. The provider handles the swap autonomously.
+	// When the model is available on disk but not currently loaded AND the
+	// provider has no in-flight requests (totalPending == 0), every resident
+	// model is idle and the provider will LRU-evict it to make room. Idle
+	// weights are therefore reclaimable, so we do NOT count them against the
+	// load: the model only needs to fit in (total - OS reserve), plus the
+	// activation-reserve headroom the provider's ModelLoadAdmission gate also
+	// requires on top of weights + KV. (An earlier version subtracted
+	// gpuMemoryActiveGB here, which wrongly rejected cold loads onto boxes whose
+	// only resident models were idle and evictable — Codex #389 P2.)
 	//
-	// However, if the provider has in-flight requests (totalPending > 0), it
-	// cannot evict the serving model, so we fall through to the standard
-	// free-memory check which requires room alongside active models.
+	// If the provider DOES have in-flight requests (totalPending > 0) it cannot
+	// evict the serving model, so we fall through to the standard free-memory
+	// check below, which counts active memory as unavailable.
 	//
 	// Source of truth: the provider's ModelLoadAdmission gate (provider-swift)
 	// admits a load only when weights + activation reserve + min serveable KV
-	// fit in its real free memory (total - resident, clamped to OS-available,
-	// under the 90% unified cap). We mirror that here CONSERVATIVELY: real free
-	// ≈ total - gpuMemoryActiveGB - coldLoadOSReserveGB, and required = weights
-	// + KV + activationReserveGB. GPU *cache* (gpuMemoryCacheGB) is reclaimable,
-	// so it is intentionally NOT subtracted — it counts as free. This is
-	// strictly safer than the previous check (which compared against TOTAL
-	// memory, assuming the provider would evict everything down to bare OS
-	// overhead): for any gpuMemoryActiveGB >= 0, this admits a subset of what
-	// the old check admitted, so it never over-admits a load the provider would
-	// reject (the meltdown's OOM-load mechanism).
+	// fit in its real free memory (clamped to OS-available, under the 90%
+	// unified cap). We mirror the activation-reserve headroom here. This stays
+	// strictly safer than the old check, which used the same TOTAL basis but
+	// WITHOUT the activation reserve: `required` is larger, so we admit a strict
+	// subset and never over-admit relative to the pre-fix behavior.
 	//
-	// TODO(routing): the cleanest long-term fix is for the provider to REPORT
-	// its own availableMemoryGb()/freeForLoadGb in BackendCapacity so the
-	// coordinator consumes a single source of truth instead of re-deriving free
-	// memory here. Until then this conservative mirror prevents over-admission.
+	// Known residual (Codex #389 P2): for a near-limit large model with tiny
+	// max_tokens this can still admit a load the provider's cap-aware reserve
+	// rejects (we use the request KV + a flat OS reserve, not the provider's
+	// max(configReserve, physical-hardCap) + min serveable KV). The clean fix is
+	// for the provider to REPORT its own freeForLoadGb in BackendCapacity so the
+	// coordinator consumes one source of truth instead of re-deriving it here.
 	if snap.availableOnDisk && !snap.modelLoaded && snap.totalPending == 0 {
-		realFree := snap.totalMemoryGB - snap.gpuMemoryActiveGB - coldLoadOSReserveGB
-		return required+activationReserveGB <= realFree
+		// Idle resident models are evictable, so they count as free.
+		evictableFree := snap.totalMemoryGB - coldLoadOSReserveGB
+		return required+activationReserveGB <= evictableFree
 	}
 
 	free := snap.totalMemoryGB - snap.gpuMemoryActiveGB

--- a/coordinator/registry/scheduler.go
+++ b/coordinator/registry/scheduler.go
@@ -49,6 +49,22 @@ const (
 	kvCacheBytesPerToken = 400_000 // ~0.38 MB; covers 7-8B with slack
 	bytesPerGB           = 1 << 30
 
+	// activationReserveGB is the working-memory headroom a cold load needs
+	// on top of weights + KV cache: transient activation/compute buffers the
+	// engine allocates while running. It mirrors the provider's authoritative
+	// ModelLoadAdmission activation reserve (provider-swift) so the
+	// coordinator's cold-load admission (freeMemoryAdmits) does not over-admit
+	// loads the provider would then OOM-reject. ~3 GB is conservative for the
+	// 7-8B-class models the fleet serves.
+	activationReserveGB = 3.0
+
+	// coldLoadOSReserveGB is the OS / non-engine memory we hold back when
+	// estimating real free memory for a cold load. It stands in for the
+	// provider's "clamp to OS-available, under the 90% unified-memory cap"
+	// term until the provider reports free-for-load directly (see the TODO in
+	// freeMemoryAdmits).
+	coldLoadOSReserveGB = 4.0
+
 	// effectiveTPSLoadFactor controls how aggressively decode TPS
 	// degrades as a provider takes on more concurrent requests. The
 	// effective TPS used in cost is `decodeTPS / (1 + k * batchSize)`
@@ -842,18 +858,34 @@ func freeMemoryAdmits(snap routingSnapshot, reqPromptTokens, reqMaxTokens int) b
 	required += kvCacheGB
 
 	// When the model is available on disk but not currently loaded, the
-	// provider will evict idle models to make room (LRU eviction). Check
-	// whether the model individually fits in total memory (with OS/KV
-	// overhead) rather than requiring it to fit alongside existing loaded
-	// models. The provider handles the swap autonomously.
+	// provider will LRU-evict idle models to make room, so we check the model
+	// fits in REAL FREE memory rather than requiring it to fit alongside the
+	// currently-loaded models. The provider handles the swap autonomously.
 	//
-	// However, if the provider has in-flight requests (totalPending > 0),
-	// it cannot evict the currently-serving model. In that case, fall
-	// through to the standard free-memory check which requires room
-	// alongside active models.
+	// However, if the provider has in-flight requests (totalPending > 0), it
+	// cannot evict the serving model, so we fall through to the standard
+	// free-memory check which requires room alongside active models.
+	//
+	// Source of truth: the provider's ModelLoadAdmission gate (provider-swift)
+	// admits a load only when weights + activation reserve + min serveable KV
+	// fit in its real free memory (total - resident, clamped to OS-available,
+	// under the 90% unified cap). We mirror that here CONSERVATIVELY: real free
+	// ≈ total - gpuMemoryActiveGB - coldLoadOSReserveGB, and required = weights
+	// + KV + activationReserveGB. GPU *cache* (gpuMemoryCacheGB) is reclaimable,
+	// so it is intentionally NOT subtracted — it counts as free. This is
+	// strictly safer than the previous check (which compared against TOTAL
+	// memory, assuming the provider would evict everything down to bare OS
+	// overhead): for any gpuMemoryActiveGB >= 0, this admits a subset of what
+	// the old check admitted, so it never over-admits a load the provider would
+	// reject (the meltdown's OOM-load mechanism).
+	//
+	// TODO(routing): the cleanest long-term fix is for the provider to REPORT
+	// its own availableMemoryGb()/freeForLoadGb in BackendCapacity so the
+	// coordinator consumes a single source of truth instead of re-deriving free
+	// memory here. Until then this conservative mirror prevents over-admission.
 	if snap.availableOnDisk && !snap.modelLoaded && snap.totalPending == 0 {
-		const osReserveGB = 4.0
-		return snap.modelSizeGB+kvCacheGB+osReserveGB <= snap.totalMemoryGB
+		realFree := snap.totalMemoryGB - snap.gpuMemoryActiveGB - coldLoadOSReserveGB
+		return required+activationReserveGB <= realFree
 	}
 
 	free := snap.totalMemoryGB - snap.gpuMemoryActiveGB

--- a/coordinator/registry/scheduler_test.go
+++ b/coordinator/registry/scheduler_test.go
@@ -1618,12 +1618,14 @@ func TestFreeMemoryAdmitsFallsBackWithoutBudget(t *testing.T) {
 // Cold load (model on disk, not loaded, no in-flight requests): admission must
 // use REAL FREE memory, not TOTAL. With other models already resident, the old
 // TOTAL-based check over-admitted and the provider OOM-rejected the load.
-func TestFreeMemoryAdmitsColdLoadRejectsOverActiveMemory(t *testing.T) {
-	// 64GB box, 45GB already resident in OTHER models, requested model NOT
-	// loaded, 16GB cold load:
-	//   old (TOTAL):     16 + ~0 KV + 4 = 20 <= 64           → ADMIT (then OOM)
-	//   new (real-free): realFree = 64 - 45 - 4 = 15;
-	//                    required = 16 + ~0 KV + 3 = 19 > 15  → REJECT
+// Idle resident models are evictable when the provider has no in-flight work
+// (totalPending == 0), so they must NOT count against a cold load. (Codex #389
+// P2: an earlier version subtracted gpuMemoryActiveGB here, wrongly rejecting a
+// load onto a box whose only resident model was idle and would be evicted.)
+func TestFreeMemoryAdmitsColdLoadIgnoresEvictableIdleMemory(t *testing.T) {
+	// 64GB box, 45GB idle resident model, requested model NOT loaded, no pending
+	// work, 16GB cold load: evictableFree = 64 - 4 = 60; required = 16 + ~0 KV
+	// + 3 = 19 <= 60 → ADMIT (the provider evicts the idle 45GB model and loads).
 	snap := routingSnapshot{
 		modelSizeGB:       16,
 		totalMemoryGB:     64,
@@ -1632,8 +1634,27 @@ func TestFreeMemoryAdmitsColdLoadRejectsOverActiveMemory(t *testing.T) {
 		modelLoaded:       false,
 		totalPending:      0,
 	}
+	if !freeMemoryAdmits(snap, 100, 256) {
+		t.Fatal("cold load must be admitted: idle 45GB model is evictable, 16GB fits in ~60GB")
+	}
+}
+
+// A provider WITH in-flight work cannot evict its serving model, so active
+// memory counts as unavailable — that is the standard (non-cold) branch.
+func TestFreeMemoryAdmitsServingProviderCountsActiveMemory(t *testing.T) {
+	// 64GB box, 52GB active, in-flight work (totalPending > 0), requested 16GB
+	// model not loaded: free = 64 - 52 = 12 < required 16 → REJECT (the serving
+	// model can't be evicted, so the cold-load eviction assumption doesn't hold).
+	snap := routingSnapshot{
+		modelSizeGB:       16,
+		totalMemoryGB:     64,
+		gpuMemoryActiveGB: 52,
+		availableOnDisk:   true,
+		modelLoaded:       false,
+		totalPending:      1,
+	}
 	if freeMemoryAdmits(snap, 100, 256) {
-		t.Fatal("cold load must be rejected: ~15GB real free, model needs ~19GB")
+		t.Fatal("serving provider must reject: only 12GB free, model needs 16GB, can't evict")
 	}
 }
 

--- a/coordinator/registry/scheduler_test.go
+++ b/coordinator/registry/scheduler_test.go
@@ -1615,6 +1615,92 @@ func TestFreeMemoryAdmitsFallsBackWithoutBudget(t *testing.T) {
 	}
 }
 
+// Cold load (model on disk, not loaded, no in-flight requests): admission must
+// use REAL FREE memory, not TOTAL. With other models already resident, the old
+// TOTAL-based check over-admitted and the provider OOM-rejected the load.
+func TestFreeMemoryAdmitsColdLoadRejectsOverActiveMemory(t *testing.T) {
+	// 64GB box, 45GB already resident in OTHER models, requested model NOT
+	// loaded, 16GB cold load:
+	//   old (TOTAL):     16 + ~0 KV + 4 = 20 <= 64           → ADMIT (then OOM)
+	//   new (real-free): realFree = 64 - 45 - 4 = 15;
+	//                    required = 16 + ~0 KV + 3 = 19 > 15  → REJECT
+	snap := routingSnapshot{
+		modelSizeGB:       16,
+		totalMemoryGB:     64,
+		gpuMemoryActiveGB: 45,
+		availableOnDisk:   true,
+		modelLoaded:       false,
+		totalPending:      0,
+	}
+	if freeMemoryAdmits(snap, 100, 256) {
+		t.Fatal("cold load must be rejected: ~15GB real free, model needs ~19GB")
+	}
+}
+
+// A genuinely-fitting cold load on an otherwise-idle box must still be admitted.
+func TestFreeMemoryAdmitsColdLoadAdmitsWhenRealFreeFits(t *testing.T) {
+	// 64GB box, nothing resident, 8GB cold load:
+	//   realFree = 64 - 0 - 4 = 60; required = 8 + ~0 KV + 3 = ~11 <= 60 → ADMIT
+	snap := routingSnapshot{
+		modelSizeGB:       8,
+		totalMemoryGB:     64,
+		gpuMemoryActiveGB: 0,
+		availableOnDisk:   true,
+		modelLoaded:       false,
+		totalPending:      0,
+	}
+	if !freeMemoryAdmits(snap, 100, 256) {
+		t.Fatal("cold load must be admitted: ~60GB real free, model needs ~11GB")
+	}
+}
+
+// Invariant: the new real-free cold-load gate is STRICTLY SAFER than the old
+// TOTAL-based one — it must never admit (return true) where the old check
+// rejected (return false). Verified across a representative grid of memory
+// shapes. This is the property the meltdown fix turns on.
+func TestFreeMemoryAdmitsColdLoadStrictlySaferThanTotal(t *testing.T) {
+	oldColdAdmit := func(snap routingSnapshot, prompt, maxTok int) bool {
+		tokens := int64(prompt) + int64(maxTok)
+		if tokens < 0 {
+			tokens = 0
+		}
+		const maxTokensForCalc = 16 << 20
+		if tokens > maxTokensForCalc {
+			tokens = maxTokensForCalc
+		}
+		kvCacheGB := float64(tokens*kvCacheBytesPerToken) / float64(bytesPerGB)
+		const osReserveGB = 4.0 // the pre-fix TOTAL-based reserve
+		return snap.modelSizeGB+kvCacheGB+osReserveGB <= snap.totalMemoryGB
+	}
+
+	totals := []float64{8, 16, 32, 64, 128, 192}
+	sizes := []float64{2, 4, 8, 16, 32, 70}
+	actives := []float64{0, 2, 8, 20, 45, 60}
+	maxToks := []int{0, 256, 4096, 32768}
+	for _, total := range totals {
+		for _, size := range sizes {
+			for _, active := range actives {
+				for _, maxTok := range maxToks {
+					snap := routingSnapshot{
+						modelSizeGB:       size,
+						totalMemoryGB:     total,
+						gpuMemoryActiveGB: active,
+						availableOnDisk:   true,
+						modelLoaded:       false,
+						totalPending:      0,
+					}
+					gotNew := freeMemoryAdmits(snap, 100, maxTok)
+					gotOld := oldColdAdmit(snap, 100, maxTok)
+					if gotNew && !gotOld {
+						t.Fatalf("strictly-safer violated: new admits, old rejects "+
+							"(total=%.0f size=%.0f active=%.0f maxTok=%d)", total, size, active, maxTok)
+					}
+				}
+			}
+		}
+	}
+}
+
 func TestSlotHeadroomWithExhaustedTokenBudgetRejectsCapacity(t *testing.T) {
 	reg := New(testLogger())
 	model := "budget-headroom-model"


### PR DESCRIPTION
## Routing v2 relaunch safety

Follow-up to the routing-v2 production incident (write-lock storm + OOM cold loads). Stacked on #387 (prefill-overflow gate); base is `fix/prefill-tps-coordinator`. Together the stack is the **Tier-1 relaunch posture**: prefill gate fixed, cold-dispatch off, warm-pool observe-only — plus the safety fixes so Tier-2 (turning cold-dispatch back on) is safe later.

### Changes

**1. Debounce the cold-dispatch kick (write-lock storm)** — `coordinator/api/cold_dispatch.go`, `server.go`
`kickColdDispatch` fired `TriggerModelSwaps` (registry **write** lock) on every enqueue → O(request volume) lock acquisitions → reader starvation (`/v1/stats` 503s, stale heartbeats). New `coldKickState` coalesces into single-flight + min-interval: a burst of N enqueues collapses to one swap pass. Interval via `EIGENINFERENCE_COLD_DISPATCH_MIN_INTERVAL` (default 1s). Idempotent `TriggerModelSwaps` means dropped kicks lose nothing.

**2. Cold-load admission uses real free memory, not total (OOM loads)** — `coordinator/registry/scheduler.go`
The cold-load branch of `freeMemoryAdmits` checked `weights + kv + 4 <= TOTAL` (assuming the provider evicts everything), while the provider's authoritative `ModelLoadAdmission` gate checks against **real free** memory. Coordinator over-admitted → `insufficient memory to load model` → jetsam OOM → WS `read_error` disconnects. Now: `realFree = total − gpuMemoryActiveGB − 4` and require `weights + kv + 3 (activation reserve) <= realFree`. GPU *cache* is reclaimable so it is not subtracted.

> **Strictly safer:** at the branch `required = modelSize + kv`, so new admit ⇔ `modelSize+kv+7+gpuActive ≤ total` vs old `modelSize+kv+4 ≤ total`. For all `gpuActive ≥ 0` the new set is a subset of the old — it never admits a load the old check rejected, so it cannot over-admit relative to today.

TODO left in code: the clean long-term fix is for the provider to report `freeForLoadGb` in `BackendCapacity` (single source of truth) — intentionally not done here (no protocol change).

**3. Safe-by-default flags** — `coordinator/api/cold_dispatch.go`, `coordinator/registry/config.go`
- `EIGENINFERENCE_COLD_DISPATCH` → **opt-in** (default false). It drove the meltdown; enable only after the safety fixes are validated.
- `WARM_POOL_OBSERVE_ONLY` → **default true**. Warm pool plans + emits telemetry but issues no `load_model` actions unless explicitly enabled.
- `EIGENINFERENCE_QUEUE_BEFORE_SHED` left default-true.

**4. Docs** — `AGENTS.md`
Corrected the stale `estimatedMemoryGb * 3.0` / "3× memory gate" claims (pitfall note + mutation checklist) to the real `ModelLoadAdmission` gate (`weights + activation reserve + min serveable KV ≤ real free`, no multiplier) and noted `freeMemoryAdmits` now mirrors it conservatively.

### Tests
- New: `TestColdKickCoalescesInFlight`, `TestColdKickRunsAgainAfterInterval`, `TestColdDispatchMinInterval`, `TestEnvEnabledDefaultFalse`, `TestColdDispatchFlagDefaultsOff`, `TestFreeMemoryAdmitsColdLoadStrictlySaferThanTotal` (grid), `…RejectsOverActiveMemory`, `…AdmitsWhenRealFreeFits`, `TestReadConfigWarmPoolObserveOnlyOptOut`.
- `go build ./...` clean; `go test ./...` green (incl. `registry`, `api`, `routingsim`, `internal/e2e`); `gofmt -l` empty; `-race` clean on the kick tests.

### Note on stacking
Base is `fix/prefill-tps-coordinator` (#387). After #387 merges to master I'll rebase this onto master so it reviews as a clean standalone diff.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/389"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784300943&installation_id=133247490&pr_number=389&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F389&signature=5ae7ec36127d2674cab0df8159b3e985b6f552e5df365aafe9e21cdde2034963"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->