### PR TITLE
feat: provider reports free_for_load_gb; coordinator uses it for cold-load admission

### DIFF
--- a/coordinator/protocol/messages.go
+++ b/coordinator/protocol/messages.go
@@ -232,6 +232,14 @@ type BackendCapacity struct {
 	GPUMemoryPeakGB   float64               `json:"gpu_memory_peak_gb"`   // Metal peak memory
 	GPUMemoryCacheGB  float64               `json:"gpu_memory_cache_gb"`  // Metal cache memory (reclaimable)
 	TotalMemoryGB     float64               `json:"total_memory_gb"`      // total system/GPU memory
+	// FreeForLoadGB is the max additional model-WEIGHT footprint (GB) the
+	// provider can load right now: net of the 90% unified-memory cap, OS/operator
+	// reserve, and activation+min-KV load headroom, clamped to real OS-available
+	// memory, and treating idle resident models as evictable. It is the single
+	// source of truth for cold-load admission (the coordinator no longer
+	// re-derives free memory). A pointer so a legacy provider that doesn't report
+	// it is nil (→ coordinator falls back to the total-memory heuristic).
+	FreeForLoadGB *float64 `json:"free_for_load_gb,omitempty"`
 }
 
 // SystemMetrics contains live resource utilization reported by a provider.

--- a/coordinator/registry/clamp_test.go
+++ b/coordinator/registry/clamp_test.go
@@ -84,6 +84,31 @@ func TestClampBackendCapacityMaliciousValues(t *testing.T) {
 	}
 }
 
+func TestClampBackendCapacityFreeForLoad(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+
+	// Out-of-range reported values are nilled (→ cold-load gate falls back to the
+	// heuristic) rather than trusted.
+	for _, bad := range []float64{math.NaN(), math.Inf(1), -3, 1e9} {
+		v := bad
+		bc := &protocol.BackendCapacity{TotalMemoryGB: 64, FreeForLoadGB: &v}
+		clampBackendCapacity(logger, "p1", bc)
+		if bc.FreeForLoadGB != nil {
+			t.Errorf("FreeForLoadGB=%v should be nilled, got %v", bad, *bc.FreeForLoadGB)
+		}
+	}
+
+	// A legitimate value (including 0) is preserved.
+	for _, ok := range []float64{0, 9, 128} {
+		v := ok
+		bc := &protocol.BackendCapacity{TotalMemoryGB: 64, FreeForLoadGB: &v}
+		clampBackendCapacity(logger, "p1", bc)
+		if bc.FreeForLoadGB == nil || *bc.FreeForLoadGB != ok {
+			t.Errorf("FreeForLoadGB=%v should be preserved, got %v", ok, bc.FreeForLoadGB)
+		}
+	}
+}
+
 func TestClampBackendCapacityReasonableValues(t *testing.T) {
 	// Realistic values should pass through unchanged.
 	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))

--- a/coordinator/registry/cold_dispatch.go
+++ b/coordinator/registry/cold_dispatch.go
@@ -127,6 +127,14 @@ func (r *Registry) coldSpillProviderEligibleLocked(p *Provider, model string, tr
 		if !modelFitsHardware(entry.MinRAMGB, entry.SizeGB, float64(p.Hardware.MemoryGB)) {
 			return false
 		}
+		// Live free-capacity gate (shared helper): keep cold-spill in sync with the
+		// load planner. If the provider reports it cannot fit this model, don't spill
+		// the request into its queue — the planner (modelLoadCandidatePendingLocked)
+		// would refuse the load and the request would wait out the 120s queue timeout
+		// instead of failing fast (#390).
+		if admit, reported := reportedFreeForLoadAdmits(entry.SizeGB, backendFreeForLoadGB(p.BackendCapacity)); reported && !admit {
+			return false
+		}
 	}
 
 	return true

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -2875,6 +2875,18 @@ func (r *Registry) modelLoadCandidatePendingLocked(p *Provider, model string, no
 		if !modelFitsHardware(entry.MinRAMGB, entry.SizeGB, float64(p.Hardware.MemoryGB)) {
 			return 0, false
 		}
+		// Live free-capacity gate: don't plan a load the provider already reports
+		// it cannot fit (free_for_load_gb = max model weight loadable right now,
+		// net of cap/reserve/headroom and evictable idle models). Mirrors the
+		// direct-routing freeMemoryAdmits gate so the warming planner can't send a
+		// load_model the provider then OOM-rejects — which would otherwise leave
+		// queued cold-dispatch requests sitting until they time out. Only applies
+		// when the provider reports the field (legacy providers fall through to the
+		// static hardware gate above).
+		if entry.SizeGB > 0 && p.BackendCapacity != nil && p.BackendCapacity.FreeForLoadGB != nil &&
+			entry.SizeGB > *p.BackendCapacity.FreeForLoadGB {
+			return 0, false
+		}
 	}
 
 	return p.pendingCount(), true

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -2875,16 +2875,12 @@ func (r *Registry) modelLoadCandidatePendingLocked(p *Provider, model string, no
 		if !modelFitsHardware(entry.MinRAMGB, entry.SizeGB, float64(p.Hardware.MemoryGB)) {
 			return 0, false
 		}
-		// Live free-capacity gate: don't plan a load the provider already reports
-		// it cannot fit (free_for_load_gb = max model weight loadable right now,
-		// net of cap/reserve/headroom and evictable idle models). Mirrors the
-		// direct-routing freeMemoryAdmits gate so the warming planner can't send a
-		// load_model the provider then OOM-rejects — which would otherwise leave
-		// queued cold-dispatch requests sitting until they time out. Only applies
-		// when the provider reports the field (legacy providers fall through to the
-		// static hardware gate above).
-		if entry.SizeGB > 0 && p.BackendCapacity != nil && p.BackendCapacity.FreeForLoadGB != nil &&
-			entry.SizeGB > *p.BackendCapacity.FreeForLoadGB {
+		// Live free-capacity gate (shared helper with the direct path): don't plan
+		// a load the provider already reports it cannot fit. Mirrors freeMemoryAdmits
+		// so the warming planner can't send a load_model the provider then
+		// OOM-rejects, which would leave queued cold-dispatch requests sitting until
+		// they time out. Legacy providers (no report) fall through to the static gate.
+		if admit, reported := reportedFreeForLoadAdmits(entry.SizeGB, backendFreeForLoadGB(p.BackendCapacity)); reported && !admit {
 			return 0, false
 		}
 	}

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -2074,6 +2074,18 @@ func clampBackendCapacity(logger *slog.Logger, providerID string, bc *protocol.B
 	if v, changed := clampNonNeg(bc.GPUMemoryCacheGB, maxMemoryGBFloat); changed {
 		bc.GPUMemoryCacheGB = v
 	}
+	// free_for_load_gb: an out-of-range value (NaN/Inf/negative or absurdly high)
+	// is treated as NOT reported (nil) so the cold-load gate falls back to the
+	// total-memory heuristic, rather than trusting a garbage value that would
+	// over- or under-admit. A legitimate 0 ("can't load anything now") is kept.
+	if bc.FreeForLoadGB != nil {
+		v := *bc.FreeForLoadGB
+		if math.IsNaN(v) || math.IsInf(v, 0) || v < 0 || v > maxMemoryGBFloat {
+			logger.Warn("provider free_for_load_gb out of range; ignoring (fall back to heuristic)",
+				"provider_id", providerID, "reported", v)
+			bc.FreeForLoadGB = nil
+		}
+	}
 	for i := range bc.Slots {
 		s := &bc.Slots[i]
 		if s.MaxTokensPotential < 0 || s.MaxTokensPotential > maxTokensPotential {

--- a/coordinator/registry/scheduler.go
+++ b/coordinator/registry/scheduler.go
@@ -80,10 +80,15 @@ type routingSnapshot struct {
 	systemMetrics      protocol.SystemMetrics
 	gpuMemoryActiveGB  float64
 	totalMemoryGB      float64
-	modelSizeGB        float64 // catalog-reported weight footprint (0 = unknown, gate disabled)
-	minRAMGb           int     // catalog authoritative min RAM (GB) to run the model (0 = unknown)
-	modelLoaded        bool    // true when the requested model is resident (running or idle)
-	availableOnDisk    bool    // model is in provider's Models list but not currently loaded
+	// freeForLoadGB is the provider-reported max additional model-weight (GB) it
+	// can load right now (net of cap/reserve/headroom, idle models reclaimed).
+	// When non-nil it is the authoritative cold-load gate; nil = legacy provider
+	// (fall back to the total-memory heuristic). See protocol.BackendCapacity.
+	freeForLoadGB   *float64
+	modelSizeGB     float64 // catalog-reported weight footprint (0 = unknown, gate disabled)
+	minRAMGb        int     // catalog authoritative min RAM (GB) to run the model (0 = unknown)
+	modelLoaded     bool    // true when the requested model is resident (running or idle)
+	availableOnDisk bool    // model is in provider's Models list but not currently loaded
 
 	observedDecodeTPS     float64
 	observedPrefillTPS    float64 // measured per-slot prefill EWMA; 0 = unreported (fall back to prefillTPS chain)
@@ -780,6 +785,7 @@ func (r *Registry) snapshotProviderLocked(p *Provider, model string, traits Requ
 
 	if p.BackendCapacity != nil {
 		snap.gpuMemoryActiveGB = p.BackendCapacity.GPUMemoryActiveGB
+		snap.freeForLoadGB = p.BackendCapacity.FreeForLoadGB
 		if p.BackendCapacity.TotalMemoryGB > 0 {
 			snap.totalMemoryGB = p.BackendCapacity.TotalMemoryGB
 		}
@@ -842,16 +848,28 @@ func freeMemoryAdmits(snap routingSnapshot, reqPromptTokens, reqMaxTokens int) b
 	required += kvCacheGB
 
 	// When the model is available on disk but not currently loaded, the
-	// provider will evict idle models to make room (LRU eviction). Check
-	// whether the model individually fits in total memory (with OS/KV
-	// overhead) rather than requiring it to fit alongside existing loaded
-	// models. The provider handles the swap autonomously.
+	// provider will evict idle models to make room (LRU eviction), so we check
+	// whether the model can be loaded rather than requiring it to fit alongside
+	// existing loaded models. The provider handles the swap autonomously.
 	//
-	// However, if the provider has in-flight requests (totalPending > 0),
-	// it cannot evict the currently-serving model. In that case, fall
-	// through to the standard free-memory check which requires room
-	// alongside active models.
+	// However, if the provider has in-flight requests (totalPending > 0), it
+	// cannot evict the currently-serving model. In that case, fall through to the
+	// standard free-memory check which requires room alongside active models.
 	if snap.availableOnDisk && !snap.modelLoaded && snap.totalPending == 0 {
+		// Preferred: the provider reports freeForLoadGB — the max model WEIGHT it
+		// can load right now, already net of the 90% unified cap, OS/operator
+		// reserve, activation+min-KV headroom, real OS-available memory, and
+		// eviction of idle models. This is the single source of truth and exactly
+		// mirrors the provider's own ModelLoadAdmission gate, so the coordinator
+		// can't over-admit a load the provider then OOM-rejects (the meltdown
+		// mechanism) nor under-admit because of evictable idle weights.
+		if snap.freeForLoadGB != nil {
+			return snap.modelSizeGB <= *snap.freeForLoadGB
+		}
+		// Fallback for legacy providers that don't report freeForLoadGB: the old
+		// total-memory heuristic (provider evicts idle models, so compare against
+		// total rather than free). Coarser — can't see the unified cap or OS
+		// baseline — but only used until the fleet reports the field.
 		const osReserveGB = 4.0
 		return snap.modelSizeGB+kvCacheGB+osReserveGB <= snap.totalMemoryGB
 	}
@@ -1354,6 +1372,7 @@ func (r *Registry) quickCapacityCheck(model string, estimatedPromptTokens, reque
 		}
 		if snap.hasBackendCapacity {
 			snap.gpuMemoryActiveGB = p.BackendCapacity.GPUMemoryActiveGB
+			snap.freeForLoadGB = p.BackendCapacity.FreeForLoadGB
 			if p.BackendCapacity.TotalMemoryGB > 0 {
 				snap.totalMemoryGB = p.BackendCapacity.TotalMemoryGB
 			}

--- a/coordinator/registry/scheduler.go
+++ b/coordinator/registry/scheduler.go
@@ -812,6 +812,42 @@ func (r *Registry) snapshotProviderLocked(p *Provider, model string, traits Requ
 	return snap, true
 }
 
+// coldLoadCatalogGBToMemGiB converts a model's catalog on-disk size (decimal GB,
+// TotalSizeBytes/1e9, unpadded) into the provider's load-gate basis (padded GiB).
+// The provider's ModelLoadAdmission.canLoad weighs estimatedMemoryGb = on-disk
+// bytes × 1.2 (scanner memory-overhead) / 2^30, and free_for_load_gb is reported
+// in that same padded-GiB basis. So a raw catalog size must be padded+converted
+// the same way before comparing, or a near-threshold model whose RAW size fits
+// but whose PADDED estimate doesn't would be admitted here and then 503'd at load
+// (Codex #390). 1.2 mirrors the provider scanner's overhead factor; (1e9/2^30)
+// converts decimal GB → GiB. Conservative: if the scanner's factor ever drops,
+// this stays safe (slightly stricter); it must not be set BELOW the provider's.
+const coldLoadCatalogGBToMemGiB = 1.2 * (1e9 / float64(int64(1)<<30)) // ≈ 1.1176
+
+// backendFreeForLoadGB returns the provider-reported free_for_load_gb (nil-safe).
+// Caller must hold the provider lock when passing p.BackendCapacity.
+func backendFreeForLoadGB(bc *protocol.BackendCapacity) *float64 {
+	if bc == nil {
+		return nil
+	}
+	return bc.FreeForLoadGB
+}
+
+// reportedFreeForLoadAdmits reports whether a cold load of a model with the given
+// catalog size (decimal GB) fits the provider's reported free_for_load_gb (max
+// loadable model weight, padded GiB — the provider's authoritative gate). The
+// second return is whether the provider reported the value at all; false means
+// the caller should fall back to its static hardware heuristic (legacy provider,
+// or unknown catalog size that can't be normalized). Used by every cold-load
+// decision path (direct admission, the swap planner, the warm pool, and the
+// cold-spill predicate) so they cannot drift.
+func reportedFreeForLoadAdmits(catalogSizeGB float64, freeForLoadGB *float64) (admit bool, reported bool) {
+	if freeForLoadGB == nil || catalogSizeGB <= 0 {
+		return false, false
+	}
+	return catalogSizeGB*coldLoadCatalogGBToMemGiB <= *freeForLoadGB, true
+}
+
 // freeMemoryAdmits returns true when the provider has enough headroom.
 // Providers that report a token budget use budget-based admission;
 // legacy providers fall back to memory-based estimation.
@@ -859,12 +895,12 @@ func freeMemoryAdmits(snap routingSnapshot, reqPromptTokens, reqMaxTokens int) b
 		// Preferred: the provider reports freeForLoadGB — the max model WEIGHT it
 		// can load right now, already net of the 90% unified cap, OS/operator
 		// reserve, activation+min-KV headroom, real OS-available memory, and
-		// eviction of idle models. This is the single source of truth and exactly
-		// mirrors the provider's own ModelLoadAdmission gate, so the coordinator
-		// can't over-admit a load the provider then OOM-rejects (the meltdown
-		// mechanism) nor under-admit because of evictable idle weights.
-		if snap.freeForLoadGB != nil {
-			return snap.modelSizeGB <= *snap.freeForLoadGB
+		// eviction of idle models. The single source of truth, normalized to the
+		// provider's padded-GiB load basis so it exactly mirrors the provider's own
+		// ModelLoadAdmission gate (no over-admit → OOM, no under-admit on evictable
+		// weights).
+		if admit, reported := reportedFreeForLoadAdmits(snap.modelSizeGB, snap.freeForLoadGB); reported {
+			return admit
 		}
 		// Fallback for legacy providers that don't report freeForLoadGB: the old
 		// total-memory heuristic (provider evicts idle models, so compare against

--- a/coordinator/registry/scheduler_test.go
+++ b/coordinator/registry/scheduler_test.go
@@ -1658,6 +1658,45 @@ func TestFreeMemoryAdmitsColdLoadReportedZeroRejects(t *testing.T) {
 	}
 }
 
+// The cold-load *planner* (modelLoadCandidatePendingLocked, used by warm-pool /
+// queue-before-shed) must also respect free_for_load_gb, so it never sends a
+// load_model the direct gate would reject (Codex #390 P2). Mirrors the direct path.
+func TestModelLoadCandidateRespectsFreeForLoad(t *testing.T) {
+	reg := New(testLogger())
+	const model = "free-for-load-planner"
+	reg.SetModelCatalog([]CatalogEntry{{ID: model, SizeGB: 14}})
+
+	p := registerProviderWithModel(reg, "p1", model)
+	makeProviderRoutable(p)
+	p.mu.Lock()
+	p.Hardware.MemoryGB = 64 // passes the static hardware gate
+	p.mu.Unlock()
+	now := time.Now()
+
+	setFFL := func(v *float64) {
+		p.mu.Lock()
+		p.BackendCapacity = &protocol.BackendCapacity{TotalMemoryGB: 64, FreeForLoadGB: v}
+		p.mu.Unlock()
+	}
+
+	low := 9.0
+	setFFL(&low)
+	if _, ok := reg.modelLoadCandidatePendingLocked(p, model, now); ok {
+		t.Fatal("planner must reject a 14GB model when the provider reports 9GB free-for-load")
+	}
+
+	high := 20.0
+	setFFL(&high)
+	if _, ok := reg.modelLoadCandidatePendingLocked(p, model, now); !ok {
+		t.Fatal("planner must accept a 14GB model when the provider reports 20GB free-for-load")
+	}
+
+	setFFL(nil) // legacy provider → fall back to the static hardware gate (64GB box)
+	if _, ok := reg.modelLoadCandidatePendingLocked(p, model, now); !ok {
+		t.Fatal("legacy provider (no free-for-load) must fall back to the static hardware gate")
+	}
+}
+
 // Legacy provider (freeForLoadGB nil) falls back to the total-memory heuristic.
 func TestFreeMemoryAdmitsColdLoadFallsBackWhenUnreported(t *testing.T) {
 	snap := routingSnapshot{

--- a/coordinator/registry/scheduler_test.go
+++ b/coordinator/registry/scheduler_test.go
@@ -1658,6 +1658,29 @@ func TestFreeMemoryAdmitsColdLoadReportedZeroRejects(t *testing.T) {
 	}
 }
 
+// The cold-load gate must compare against the provider's PADDED-GiB load basis,
+// not the raw catalog size, or a near-threshold model whose raw size fits but
+// whose padded estimate doesn't gets routed and then 503'd at load (Codex #390).
+func TestFreeMemoryAdmitsColdLoadNormalizesCatalogSize(t *testing.T) {
+	free := 10.0
+	// Raw 9.5GB naively "fits" 10, but padded 9.5*1.1176≈10.6 > 10 → must reject.
+	snap := routingSnapshot{
+		modelSizeGB:     9.5,
+		totalMemoryGB:   64,
+		availableOnDisk: true,
+		modelLoaded:     false,
+		totalPending:    0,
+		freeForLoadGB:   &free,
+	}
+	if freeMemoryAdmits(snap, 100, 256) {
+		t.Fatal("near-threshold model must reject: padded estimate exceeds reported free-for-load")
+	}
+	snap.modelSizeGB = 8 // padded 8*1.1176≈8.94 <= 10 → admit
+	if !freeMemoryAdmits(snap, 100, 256) {
+		t.Fatal("8GB model must admit: padded estimate fits reported free-for-load")
+	}
+}
+
 // The cold-load *planner* (modelLoadCandidatePendingLocked, used by warm-pool /
 // queue-before-shed) must also respect free_for_load_gb, so it never sends a
 // load_model the direct gate would reject (Codex #390 P2). Mirrors the direct path.

--- a/coordinator/registry/scheduler_test.go
+++ b/coordinator/registry/scheduler_test.go
@@ -1615,6 +1615,64 @@ func TestFreeMemoryAdmitsFallsBackWithoutBudget(t *testing.T) {
 	}
 }
 
+// When the provider reports freeForLoadGB, the cold-load gate uses it as the
+// single source of truth: admit iff the model's weights fit, regardless of the
+// coarse total-memory heuristic.
+func TestFreeMemoryAdmitsColdLoadUsesReportedFreeForLoad(t *testing.T) {
+	freeForLoad := 9.0 // e.g. a 24GB box reports ~9GB loadable
+	base := routingSnapshot{
+		totalMemoryGB:   64, // heuristic would happily admit; reported value must win
+		availableOnDisk: true,
+		modelLoaded:     false,
+		totalPending:    0,
+		freeForLoadGB:   &freeForLoad,
+	}
+
+	fits := base
+	fits.modelSizeGB = 8 // 8 <= 9 → admit
+	if !freeMemoryAdmits(fits, 100, 256) {
+		t.Fatal("8GB model must be admitted: fits in reported 9GB free-for-load")
+	}
+
+	tooBig := base
+	tooBig.modelSizeGB = 14 // 14 > 9 → reject, even though heuristic on 64GB would admit
+	if freeMemoryAdmits(tooBig, 100, 256) {
+		t.Fatal("14GB model must be rejected: exceeds reported 9GB free-for-load")
+	}
+}
+
+// A reported 0 ("can't load anything now") must reject any cold load, not fall
+// back to the heuristic (nil is the only fallback trigger).
+func TestFreeMemoryAdmitsColdLoadReportedZeroRejects(t *testing.T) {
+	zero := 0.0
+	snap := routingSnapshot{
+		modelSizeGB:     4,
+		totalMemoryGB:   64,
+		availableOnDisk: true,
+		modelLoaded:     false,
+		totalPending:    0,
+		freeForLoadGB:   &zero,
+	}
+	if freeMemoryAdmits(snap, 100, 256) {
+		t.Fatal("reported free-for-load 0 must reject a cold load")
+	}
+}
+
+// Legacy provider (freeForLoadGB nil) falls back to the total-memory heuristic.
+func TestFreeMemoryAdmitsColdLoadFallsBackWhenUnreported(t *testing.T) {
+	snap := routingSnapshot{
+		modelSizeGB:     16,
+		totalMemoryGB:   64, // 16 + ~0 + 4 = 20 <= 64 → admit via heuristic
+		availableOnDisk: true,
+		modelLoaded:     false,
+		totalPending:    0,
+		freeForLoadGB:   nil,
+	}
+	if !freeMemoryAdmits(snap, 100, 256) {
+		t.Fatal("legacy provider must fall back to the total-memory heuristic (admit)")
+	}
+}
+
 func TestSlotHeadroomWithExhaustedTokenBudgetRejectsCapacity(t *testing.T) {
 	reg := New(testLogger())
 	model := "budget-headroom-model"

--- a/coordinator/registry/warm_pool_controller.go
+++ b/coordinator/registry/warm_pool_controller.go
@@ -522,6 +522,13 @@ func (r *Registry) warmPoolCandidateLocked(p *Provider, model string, now time.T
 	if !modelFitsHardware(r.catalogMinRAMGbLocked(model), r.catalogSizeGBLocked(model), totalMemoryGB) {
 		return warmPoolCandidate{}, false
 	}
+	// Live free-capacity gate (shared helper with the direct/planner paths): don't
+	// pick a warm-pool target the provider already reports it cannot fit, or the
+	// warm pool issues a load_model the provider rejects (failed warm + pending-load
+	// cooldown) instead of choosing a truly loadable node (#390).
+	if admit, reported := reportedFreeForLoadAdmits(r.catalogSizeGBLocked(model), backendFreeForLoadGB(p.BackendCapacity)); reported && !admit {
+		return warmPoolCandidate{}, false
+	}
 	freeGB := totalMemoryGB - gpuActiveGB
 	if freeGB < 0 {
 		freeGB = 0

--- a/provider-swift/Sources/ProviderCore/Inference/ModelLoadAdmission.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/ModelLoadAdmission.swift
@@ -66,6 +66,43 @@ public enum ModelLoadAdmission {
         return Double(usable) / bytesPerGb
     }
 
+    /// Maximum model-WEIGHT footprint (GB) this machine could load right now,
+    /// assuming idle/evictable resident models are unloaded to make room. This is
+    /// the number the coordinator needs for COLD-LOAD routing: it answers "if I
+    /// send this model, will the provider successfully load it?" — net of the
+    /// unified-memory cap, OS/operator reserve, the activation + min-serveable-KV
+    /// load headroom, and real OS-available memory.
+    ///
+    /// Unlike `freeForLoadGb`, `mlxUsedBytes` (MLX active + cache) is treated as
+    /// RECLAIMABLE: on a cold load the provider LRU-evicts idle models, freeing
+    /// that memory back to the OS, so the memory we could reclaim is
+    /// `min(total, systemAvailable + mlxUsed)`. The coordinator only consults this
+    /// value on the idle path (totalPending == 0), where every resident model is
+    /// in fact evictable, so the full-eviction assumption holds. The result is the
+    /// loadable headroom MINUS the load headroom, i.e. weights only; clamped >= 0.
+    ///
+    /// - Parameters:
+    ///   - reserveBytes: OS/operator reserve to hold back, i.e.
+    ///     `UnifiedMemoryCap.loadReserveBytes(...)` = max(configReserve,
+    ///     physical − hardCap). This is what enforces the 90% unified cap.
+    ///   - headroomGb: activation reserve + min serveable KV (defaults to the
+    ///     same `defaultLoadHeadroomGb` the load gate requires above weights).
+    public static func maxLoadableWeightGb(
+        totalBytes: UInt64,
+        systemAvailableBytes: UInt64 = .max,
+        mlxUsedBytes: UInt64,
+        reserveBytes: UInt64,
+        headroomGb: Double = defaultLoadHeadroomGb
+    ) -> Double {
+        // Evicting idle models frees their MLX memory back to the OS, so the
+        // reclaimable pool is current OS-available plus our own MLX usage, capped
+        // at total physical. Hold back the load reserve, then the load headroom.
+        let reclaimable = min(totalBytes, saturatingAdd(systemAvailableBytes, mlxUsedBytes))
+        let usable = reclaimable > reserveBytes ? reclaimable - reserveBytes : 0
+        let freeGb = Double(usable) / bytesPerGb
+        return max(0, freeGb - max(0, headroomGb))
+    }
+
     /// Memory (GB) required to load a model and serve at least one request:
     /// the (overhead-padded) weight footprint plus one-request headroom.
     public static func requiredToLoadGb(weightsGb: Double, headroomGb: Double = defaultLoadHeadroomGb) -> Double {

--- a/provider-swift/Sources/ProviderCore/Inference/ModelLoadAdmission.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/ModelLoadAdmission.swift
@@ -87,18 +87,26 @@ public enum ModelLoadAdmission {
     ///     physical − hardCap). This is what enforces the 90% unified cap.
     ///   - headroomGb: activation reserve + min serveable KV (defaults to the
     ///     same `defaultLoadHeadroomGb` the load gate requires above weights).
+    ///   - outstandingReservationBytes: KV already promised to in-flight requests
+    ///     (coordinator OR local-endpoint streams). Subtracted just like the
+    ///     real load gate (`availableMemoryGb`) does, so a heartbeat can't
+    ///     advertise bytes a mid-decode request is counting on but that the OS
+    ///     hasn't shown as used yet.
     public static func maxLoadableWeightGb(
         totalBytes: UInt64,
         systemAvailableBytes: UInt64 = .max,
         mlxUsedBytes: UInt64,
         reserveBytes: UInt64,
-        headroomGb: Double = defaultLoadHeadroomGb
+        headroomGb: Double = defaultLoadHeadroomGb,
+        outstandingReservationBytes: UInt64 = 0
     ) -> Double {
         // Evicting idle models frees their MLX memory back to the OS, so the
         // reclaimable pool is current OS-available plus our own MLX usage, capped
-        // at total physical. Hold back the load reserve, then the load headroom.
+        // at total physical. Hold back the load reserve and any outstanding KV
+        // reservation, then the load headroom.
         let reclaimable = min(totalBytes, saturatingAdd(systemAvailableBytes, mlxUsedBytes))
-        let usable = reclaimable > reserveBytes ? reclaimable - reserveBytes : 0
+        let committed = saturatingAdd(reserveBytes, outstandingReservationBytes)
+        let usable = reclaimable > committed ? reclaimable - committed : 0
         let freeGb = Double(usable) / bytesPerGb
         return max(0, freeGb - max(0, headroomGb))
     }

--- a/provider-swift/Sources/ProviderCore/Protocol/Types.swift
+++ b/provider-swift/Sources/ProviderCore/Protocol/Types.swift
@@ -420,6 +420,14 @@ public struct BackendCapacity: Codable, Sendable, Equatable {
     public var gpuMemoryPeakGb: Double
     public var gpuMemoryCacheGb: Double
     public var totalMemoryGb: Double
+    /// Max additional model-WEIGHT footprint (GB) the provider can load right
+    /// now, accounting for the 90% unified cap, OS/operator reserve, load
+    /// headroom, real OS-available memory, and eviction of idle resident models
+    /// (see `ModelLoadAdmission.maxLoadableWeightGb`). The coordinator consumes
+    /// this as the single source of truth for cold-load routing instead of
+    /// re-deriving free memory from the gpu/total figures. 0 means "cannot load
+    /// anything new right now".
+    public var freeForLoadGb: Double
 
     enum CodingKeys: String, CodingKey {
         case slots
@@ -427,6 +435,7 @@ public struct BackendCapacity: Codable, Sendable, Equatable {
         case gpuMemoryPeakGb = "gpu_memory_peak_gb"
         case gpuMemoryCacheGb = "gpu_memory_cache_gb"
         case totalMemoryGb = "total_memory_gb"
+        case freeForLoadGb = "free_for_load_gb"
     }
 
     public init(
@@ -434,13 +443,27 @@ public struct BackendCapacity: Codable, Sendable, Equatable {
         gpuMemoryActiveGb: Double,
         gpuMemoryPeakGb: Double,
         gpuMemoryCacheGb: Double,
-        totalMemoryGb: Double
+        totalMemoryGb: Double,
+        freeForLoadGb: Double = 0
     ) {
         self.slots = slots
         self.gpuMemoryActiveGb = gpuMemoryActiveGb
         self.gpuMemoryPeakGb = gpuMemoryPeakGb
         self.gpuMemoryCacheGb = gpuMemoryCacheGb
         self.totalMemoryGb = totalMemoryGb
+        self.freeForLoadGb = freeForLoadGb
+    }
+
+    // Explicit decode so older payloads without `free_for_load_gb` still decode
+    // (defaults to 0). Encoding stays synthesized and always emits the field.
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        self.slots = try c.decode([BackendSlotCapacity].self, forKey: .slots)
+        self.gpuMemoryActiveGb = try c.decode(Double.self, forKey: .gpuMemoryActiveGb)
+        self.gpuMemoryPeakGb = try c.decode(Double.self, forKey: .gpuMemoryPeakGb)
+        self.gpuMemoryCacheGb = try c.decode(Double.self, forKey: .gpuMemoryCacheGb)
+        self.totalMemoryGb = try c.decode(Double.self, forKey: .totalMemoryGb)
+        self.freeForLoadGb = try c.decodeIfPresent(Double.self, forKey: .freeForLoadGb) ?? 0
     }
 }
 

--- a/provider-swift/Sources/ProviderCore/ProviderLoop.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop.swift
@@ -3178,16 +3178,26 @@ public actor ProviderLoop {
         let totalMem = ProcessInfo.processInfo.physicalMemory
 
         // Max model weight we could load right now (single source of truth for
-        // the coordinator's cold-load routing). Treats current MLX usage as
-        // reclaimable (idle models are evicted on a cold load) and holds back the
-        // same load reserve the load gate uses, so it enforces the 90% cap.
+        // the coordinator's cold-load routing). Holds back the same load reserve
+        // the load gate uses, so it enforces the 90% cap.
+        //
+        // Eviction handling: current MLX usage may be reclaimed by evicting idle
+        // models on a cold load — BUT ONLY when nothing is being served. MLX
+        // memory is global (it also covers the local inference endpoint, whose
+        // streams are tracked by localReservations, not modelSlots), so a model
+        // serving a local request is NOT evictable. `hasInflightWork` is the
+        // comprehensive signal (coordinator inflight + local streams): when work
+        // is in flight we treat NOTHING as reclaimable (conservative, never
+        // advertises an actively-served model's weights as free); only when fully
+        // idle do we assume idle models can be evicted.
         let mlxUsed = UInt64(max(0, MLX.GPU.activeMemory)) + UInt64(max(0, MLX.GPU.cacheMemory))
+        let reclaimableMlx: UInt64 = hasInflightWork ? 0 : mlxUsed
         let loadReserve = UnifiedMemoryCap.loadReserveBytes(
             configReserveBytes: Self.memoryReserveBytes(forGiB: loopConfig.config.provider.memoryReserveGB))
         let freeForLoadGb = ModelLoadAdmission.maxLoadableWeightGb(
             totalBytes: totalMem,
             systemAvailableBytes: SystemMemory.availableBytes() ?? .max,
-            mlxUsedBytes: mlxUsed,
+            mlxUsedBytes: reclaimableMlx,
             reserveBytes: loadReserve)
 
         state.backendCapacity = BackendCapacity(

--- a/provider-swift/Sources/ProviderCore/ProviderLoop.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop.swift
@@ -3194,11 +3194,16 @@ public actor ProviderLoop {
         let reclaimableMlx: UInt64 = hasInflightWork ? 0 : mlxUsed
         let loadReserve = UnifiedMemoryCap.loadReserveBytes(
             configReserveBytes: Self.memoryReserveBytes(forGiB: loopConfig.config.provider.memoryReserveGB))
+        // Subtract KV already promised to in-flight requests (coordinator + local
+        // streams), exactly as the real load gate (availableMemoryGb) does, so the
+        // heartbeat can't advertise reserved-but-not-yet-allocated bytes as loadable.
+        let outstandingKV = await kvBudget.outstandingReservedBytes()
         let freeForLoadGb = ModelLoadAdmission.maxLoadableWeightGb(
             totalBytes: totalMem,
             systemAvailableBytes: SystemMemory.availableBytes() ?? .max,
             mlxUsedBytes: reclaimableMlx,
-            reserveBytes: loadReserve)
+            reserveBytes: loadReserve,
+            outstandingReservationBytes: outstandingKV)
 
         state.backendCapacity = BackendCapacity(
             slots: allSlots,

--- a/provider-swift/Sources/ProviderCore/ProviderLoop.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop.swift
@@ -3176,12 +3176,27 @@ public actor ProviderLoop {
 
         let gbDivisor = 1024.0 * 1024.0 * 1024.0
         let totalMem = ProcessInfo.processInfo.physicalMemory
+
+        // Max model weight we could load right now (single source of truth for
+        // the coordinator's cold-load routing). Treats current MLX usage as
+        // reclaimable (idle models are evicted on a cold load) and holds back the
+        // same load reserve the load gate uses, so it enforces the 90% cap.
+        let mlxUsed = UInt64(max(0, MLX.GPU.activeMemory)) + UInt64(max(0, MLX.GPU.cacheMemory))
+        let loadReserve = UnifiedMemoryCap.loadReserveBytes(
+            configReserveBytes: Self.memoryReserveBytes(forGiB: loopConfig.config.provider.memoryReserveGB))
+        let freeForLoadGb = ModelLoadAdmission.maxLoadableWeightGb(
+            totalBytes: totalMem,
+            systemAvailableBytes: SystemMemory.availableBytes() ?? .max,
+            mlxUsedBytes: mlxUsed,
+            reserveBytes: loadReserve)
+
         state.backendCapacity = BackendCapacity(
             slots: allSlots,
             gpuMemoryActiveGb: Double(MLX.GPU.activeMemory) / gbDivisor,
             gpuMemoryPeakGb: Double(MLX.GPU.peakMemory) / gbDivisor,
             gpuMemoryCacheGb: Double(MLX.GPU.cacheMemory) / gbDivisor,
-            totalMemoryGb: Double(totalMem) / gbDivisor
+            totalMemoryGb: Double(totalMem) / gbDivisor,
+            freeForLoadGb: freeForLoadGb
         )
         state.inferenceActive = totalActive > 0
     }

--- a/provider-swift/Tests/ProviderCoreTests/ModelLoadAdmissionTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/ModelLoadAdmissionTests.swift
@@ -133,3 +133,76 @@ private let gib: UInt64 = 1024 * 1024 * 1024
         outstandingReservationBytes: 0)
     #expect(ok, "the core fix must still hold under the OOM-safety clamps")
 }
+
+// MARK: - maxLoadableWeightGb (heartbeat free_for_load_gb the coordinator consumes)
+
+// Idle resident models are reclaimable: the provider LRU-evicts them on a cold
+// load, so the loadable headroom is computed as if that memory were free.
+@Test func maxLoadableWeightReclaimsIdleModels() {
+    // 64 GB box, 30 GB idle model resident, sysAvail unknown (.max):
+    // reclaimable = min(64, 30) = ... actually min(total, sysAvail+mlxUsed) with
+    // sysAvail=.max → min(64, .max)=64; minus 4 reserve minus 4 headroom = 56.
+    let w = ModelLoadAdmission.maxLoadableWeightGb(
+        totalBytes: 64 * gib, mlxUsedBytes: 30 * gib, reserveBytes: 4 * gib, headroomGb: 4.0)
+    #expect(abs(w - 56.0) < 0.001, "idle weights must be reclaimed (got \(w))")
+}
+
+// The OS-available clamp still binds — evicting our own MLX adds back only our
+// usage, not memory other processes hold.
+@Test func maxLoadableWeightClampsToSystemAvailable() {
+    // OS reports 10 GB available; evicting our 5 GB MLX → 15 reclaimable.
+    // min(64, 10+5)=15; minus 4 reserve minus 4 headroom = 7.
+    let w = ModelLoadAdmission.maxLoadableWeightGb(
+        totalBytes: 64 * gib, systemAvailableBytes: 10 * gib,
+        mlxUsedBytes: 5 * gib, reserveBytes: 4 * gib, headroomGb: 4.0)
+    #expect(abs(w - 7.0) < 0.001, "must clamp to OS-available + reclaimable MLX (got \(w))")
+}
+
+@Test func maxLoadableWeightFloorsAtZero() {
+    let w = ModelLoadAdmission.maxLoadableWeightGb(
+        totalBytes: 8 * gib, systemAvailableBytes: 2 * gib,
+        mlxUsedBytes: 0, reserveBytes: 4 * gib, headroomGb: 4.0)
+    #expect(w == 0, "never negative")
+}
+
+// THE INVARIANT the coordinator relies on: for an idle box (gpuActive≈0), the
+// reported max-loadable-weight equals the largest weight the provider's own
+// canLoad gate would accept. So `modelSizeGB <= free_for_load_gb` on the
+// coordinator is exactly the provider's load decision — no over/under-admit.
+@Test func maxLoadableWeightMirrorsCanLoadWhenIdle() {
+    let total: UInt64 = 24 * gib
+    let sysAvail: UInt64 = 22 * gib
+    let reserve: UInt64 = 4 * gib
+    let headroom = 4.0
+    let maxW = ModelLoadAdmission.maxLoadableWeightGb(
+        totalBytes: total, systemAvailableBytes: sysAvail,
+        mlxUsedBytes: 0, reserveBytes: reserve, headroomGb: headroom)
+    #expect(ModelLoadAdmission.canLoad(
+        weightsGb: maxW, headroomGb: headroom, totalBytes: total,
+        systemAvailableBytes: sysAvail, gpuActiveBytes: 0, gpuCacheBytes: 0, reserveBytes: reserve),
+        "a model at the reported max must load")
+    #expect(!ModelLoadAdmission.canLoad(
+        weightsGb: maxW + 0.1, headroomGb: headroom, totalBytes: total,
+        systemAvailableBytes: sysAvail, gpuActiveBytes: 0, gpuCacheBytes: 0, reserveBytes: reserve),
+        "a model just above the reported max must be rejected")
+}
+
+// MARK: - BackendCapacity wire compatibility
+
+@Test func backendCapacityRoundTripsFreeForLoad() throws {
+    let cap = BackendCapacity(
+        slots: [], gpuMemoryActiveGb: 1, gpuMemoryPeakGb: 2,
+        gpuMemoryCacheGb: 0.5, totalMemoryGb: 64, freeForLoadGb: 17.5)
+    let data = try JSONEncoder().encode(cap)
+    #expect(String(decoding: data, as: UTF8.self).contains("free_for_load_gb"))
+    let decoded = try JSONDecoder().decode(BackendCapacity.self, from: data)
+    #expect(decoded == cap)
+    #expect(abs(decoded.freeForLoadGb - 17.5) < 0.001)
+}
+
+@Test func backendCapacityDecodesLegacyWithoutFreeForLoad() throws {
+    let legacy = #"{"slots":[],"gpu_memory_active_gb":1,"gpu_memory_peak_gb":2,"gpu_memory_cache_gb":0.5,"total_memory_gb":64}"#
+    let decoded = try JSONDecoder().decode(BackendCapacity.self, from: Data(legacy.utf8))
+    #expect(decoded.freeForLoadGb == 0, "legacy payload defaults to 0, no throw")
+    #expect(abs(decoded.totalMemoryGb - 64) < 0.001)
+}

--- a/provider-swift/Tests/ProviderCoreTests/ModelLoadAdmissionTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/ModelLoadAdmissionTests.swift
@@ -165,6 +165,17 @@ private let gib: UInt64 = 1024 * 1024 * 1024
     #expect(w == 0, "never negative")
 }
 
+// KV already promised to in-flight requests (coordinator or local streams) must
+// be held back, exactly as the real load gate does (Codex #390).
+@Test func maxLoadableWeightSubtractsOutstandingReservations() {
+    // 64 GB idle, 4 GB reserve, 4 GB headroom, 6 GB outstanding KV:
+    // reclaimable = 64; minus (4 + 6) committed = 54; minus 4 headroom = 50.
+    let w = ModelLoadAdmission.maxLoadableWeightGb(
+        totalBytes: 64 * gib, mlxUsedBytes: 0, reserveBytes: 4 * gib,
+        headroomGb: 4.0, outstandingReservationBytes: 6 * gib)
+    #expect(abs(w - 50.0) < 0.001, "outstanding KV must be subtracted (got \(w))")
+}
+
 // THE INVARIANT the coordinator relies on: for an idle box (gpuActive≈0), the
 // reported max-loadable-weight equals the largest weight the provider's own
 // canLoad gate would accept. So `modelSizeGB <= free_for_load_gb` on the


### PR DESCRIPTION
## Provider-reported `free_for_load_gb` — the single source of truth for cold-load admission

This is the proper "fix A" for the cold-load memory mismatch that drove the routing-v2 meltdown (and the residual Codex flagged on #389 P2). Instead of the coordinator re-deriving "can this provider load model X?" from gpu/total memory figures, the **provider reports the answer it already computes** via its authoritative `ModelLoadAdmission` gate.

### Why
The coordinator's re-derivation can't see the 90% unified-memory cap, the OS baseline, the activation/min-KV load headroom, or eviction of idle models. So it both:
- **over-admits** cold loads the provider then OOM-rejects (the meltdown's `insufficient memory to load model` → jetsam → WS `read_error`), and
- **under-admits** when idle-but-evictable models are resident (Codex #389 P2 #1).

There is no way to perfectly mirror the provider's gate from the coordinator — so report it.

### Provider (Swift)
- `ModelLoadAdmission.maxLoadableWeightGb(...)` — pure helper: max additional model **weight** (GB) loadable now, net of the load reserve (which enforces the 90% cap) + load headroom (activation 3 GiB + min serveable KV 1 GiB), clamped to real OS-available memory, treating current MLX usage as **reclaimable** (idle models are LRU-evicted on a cold load).
- `BackendCapacity.free_for_load_gb` populated in `updateAggregateCapacity` with the **same** `loadReserve`/headroom the load gate uses. **Invariant test:** for an idle box, the reported value equals the largest weight the provider's own `canLoad()` accepts.
- Backward-compatible: additive field, decode tolerates absence (defaults to 0).

### Coordinator (Go)
- `protocol.BackendCapacity.FreeForLoadGB *float64` (`omitempty`). Pointer ⇒ legacy provider that doesn't report it is `nil`.
- `freeMemoryAdmits` cold branch: if reported, **admit iff `modelSizeGB <= freeForLoadGb`** (exact mirror of the provider gate); else fall back to the existing heuristic.
- `clampBackendCapacity` nils out-of-range values (NaN/Inf/neg/absurd) → fall back rather than mis-admit; a legitimate `0` is preserved.

### How this behaves on a 24 GB machine (asked during review)
Production headroom = activation 3 + min-KV 1 = **4 GiB**; reserve = `max(configReserve 4, physical − 90% cap)` = **4 GiB**. With the OS reporting ~21–22 GB available on an idle 24 GB box:

`free_for_load_gb ≈ min(24, sysAvail) − 4 (reserve) − 4 (headroom) ≈ 13–14 GB`

So a 24 GB box advertises ~13–14 GB of loadable weight and the coordinator routes **gpt-oss-20b (~13.5 GB)** to it *only when it genuinely has the room*, and never sends it **gemma-26b (~14–31 GB)**. The machine reports its real, momentary capacity (it already does this for its own load gate — see `gptOssLoadsOn24GB`); the coordinator now respects it instead of guessing from total RAM (which would send a 24 GB box a 14 GB model: `14+4 ≤ 24` → admit → provider OOM/reject). It's self-tuning per machine — no hardcoded RAM tiers.

### Tests
- Swift: `maxLoadableWeightReclaimsIdleModels`, `…ClampsToSystemAvailable`, `…FloorsAtZero`, `…MirrorsCanLoadWhenIdle`, `backendCapacityRoundTripsFreeForLoad`, `…DecodesLegacyWithoutFreeForLoad`. `swift build --build-tests` clean; selected suites pass.
- Go: `freeMemoryAdmits` reported-value admit/reject, reported-0 rejects, legacy nil falls back, clamp validation. `go build ./...` + `go test ./...` green; gofmt clean.

### Note on stacking / reconciliation with #389
Branched off `master` (per request), so the fallback heuristic here is master's `modelSizeGB + kv + 4 ≤ total`. **#389** independently improves that same fallback to the evictable-idle real-free check. They touch the same cold branch, so when both land I'll reconcile to: **reported value (this PR) as the fast path + #389's evictable heuristic as the fallback.** No behavioral conflict — they converge.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/390"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784303033&installation_id=133247490&pr_number=390&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F390&signature=8c65eb62dc4c605c64f73ef33539eca6d6b545cbf28960a1db37b8f718f2ea76"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->