### PR TITLE
DAR-326 Phase 0: provider trust-reuse cache (skip MDM re-verify herd on coordinator restart/swap)

### DIFF
--- a/coordinator/api/provider.go
+++ b/coordinator/api/provider.go
@@ -2746,6 +2746,7 @@ func (s *Server) verifyProviderViaMDM(ctx context.Context, providerID string, pr
 	// re-proves the same identity, unchanged binary, and good posture within the
 	// window. Written only here, AFTER the verified MDM pass + hardware grant.
 	s.recordTrustReuse(
+		provider,
 		attestResult.PublicKey,
 		attestResult.SerialNumber,
 		attestResult.BinaryHash,
@@ -2832,6 +2833,21 @@ func (s *Server) ApplyLateSecurityInfo(udid string, info *mdm.SecurityInfoRespon
 			"udid", udid,
 		)
 		s.registry.PersistProvider(c.provider)
+
+		// DAR-326 FIX B: cache this late grant in the trust-reuse cache too, so it
+		// gets the same restart-survivable fast-skip as the synchronous MDM path.
+		// Posture was confirmed good above (SIP on + Secure Boot full). Uses the
+		// same epoch-checked synchronous write-through (recordTrustReuse) — a
+		// concurrent hard untrust is detected and not persisted. seKey + binary hash
+		// come from the registration-bound SE attestation.
+		c.provider.Mu().Lock()
+		var seKey, binaryHash string
+		if c.provider.AttestationResult != nil {
+			seKey = c.provider.AttestationResult.PublicKey
+			binaryHash = c.provider.AttestationResult.BinaryHash
+		}
+		c.provider.Mu().Unlock()
+		s.recordTrustReuse(c.provider, seKey, c.serial, binaryHash, true /*sip*/, true /*secureBootFull*/, udid)
 	}
 }
 

--- a/coordinator/api/provider.go
+++ b/coordinator/api/provider.go
@@ -1639,6 +1639,11 @@ func (s *Server) verifyChallengeResponse(providerID string, provider *registry.P
 		// window elapsed, hard-untrusted) returns false and falls through to the
 		// unchanged full live MDM verify.
 		if !s.tryTrustReuseFastSkip(providerID, provider, resp, statusFieldsTrusted) {
+			// DAR-326 FIX 3: the live challenge settled WITHOUT a trust-reuse fast-skip
+			// grant. Signal the per-connection mdmVerificationLoop so a non-fast-skip
+			// candidate stops deferring and proceeds to the full live MDM verify
+			// immediately, instead of stalling the whole trust-reuse grace window.
+			provider.SignalChallengeSettled()
 			// Re-attempt ACME (mTLS device-cert) trust for self_signed providers.
 			// applyACMETrust ran at registration before attestation was bound, so a
 			// provider that presented a valid device cert can be promoted to hardware

--- a/coordinator/api/provider.go
+++ b/coordinator/api/provider.go
@@ -1626,12 +1626,25 @@ func (s *Server) verifyChallengeResponse(providerID string, provider *registry.P
 	trustLevel := provider.TrustLevel
 	provider.Mu().Unlock()
 
-	// Re-attempt ACME (mTLS device-cert) trust for self_signed providers.
-	// applyACMETrust ran at registration before attestation was bound, so a
-	// provider that presented a valid device cert can be promoted to hardware
-	// now that the challenge has passed. No-op if nothing was stashed.
 	if trustLevel == registry.TrustSelfSigned {
-		s.retryACMETrust(providerID, provider)
+		// DAR-326 Phase 0: trust-reuse fast-skip. The live SE challenge above just
+		// re-proved this connection's identity + posture. If this device recently
+		// passed a FULL live MDM verification (a fresh trust-reuse record) and the
+		// fresh SIGNED challenge re-proves the SAME identity, an unchanged binary,
+		// and good posture within the window, grant hardware now — letting the
+		// per-connection mdmVerificationLoop SKIP its live MDM SecurityInfo
+		// round-trip. This is what avoids a fleet-wide MDM/APNs herd on a planned
+		// coordinator restart/swap. SECURITY: the live SE challenge always ran
+		// first; any gate miss (no record, binary changed, posture bad/unsigned,
+		// window elapsed, hard-untrusted) returns false and falls through to the
+		// unchanged full live MDM verify.
+		if !s.tryTrustReuseFastSkip(providerID, provider, resp, statusFieldsTrusted) {
+			// Re-attempt ACME (mTLS device-cert) trust for self_signed providers.
+			// applyACMETrust ran at registration before attestation was bound, so a
+			// provider that presented a valid device cert can be promoted to hardware
+			// now that the challenge has passed. No-op if nothing was stashed.
+			s.retryACMETrust(providerID, provider)
+		}
 	}
 }
 
@@ -2722,6 +2735,20 @@ func (s *Server) verifyProviderViaMDM(ctx context.Context, providerID string, pr
 	// Persist the trust upgrade.
 	s.registry.PersistProvider(provider)
 
+	// DAR-326 Phase 0: record this FULL live MDM verification in the trust-reuse
+	// cache (in-memory + durable) so a planned coordinator restart/swap can
+	// fast-skip this device's live MDM round-trip — once a fresh live SE challenge
+	// re-proves the same identity, unchanged binary, and good posture within the
+	// window. Written only here, AFTER the verified MDM pass + hardware grant.
+	s.recordTrustReuse(
+		attestResult.PublicKey,
+		attestResult.SerialNumber,
+		attestResult.BinaryHash,
+		mdmResult.MDMSIPEnabled,
+		mdmResult.MDMSecureBootFull,
+		mdmResult.UDID,
+	)
+
 	// Request Apple Device Attestation — Apple's servers generate a
 	// certificate chain that proves this device's identity. This cert
 	// chain can be independently verified by users against Apple's
@@ -2839,6 +2866,22 @@ func (s *Server) mdmVerificationLoop(ctx context.Context, providerID string, pro
 	// passed (verifyProviderAttestation returns early otherwise).
 	if result == nil || !result.Valid || result.SerialNumber == "" {
 		return
+	}
+
+	// DAR-326 Phase 0: if this device has a fresh trust-reuse record (it recently
+	// passed a FULL live MDM verification), give the live SE challenge a brief head
+	// start to re-prove identity + posture and grant hardware via the trust-reuse
+	// fast-skip BEFORE we run the (herd-causing) live MDM SecurityInfo round-trip.
+	// Without this, this loop's immediate first attempt would race ahead of the
+	// challenge and re-run the full verify anyway, recreating the fleet-wide MDM/APNs
+	// herd on a planned coordinator restart/swap. Only candidates wait; a first-ever
+	// / expired device proceeds straight to the full live verify (unchanged). If the
+	// challenge does not grant within the window (slow / gate miss / hard untrust),
+	// we fall through to the unchanged full live MDM verify below.
+	if s.trustReuseCache.hasFreshRecord(result.PublicKey, result.SerialNumber) {
+		if s.awaitTrustReuseGrant(ctx, provider) {
+			return // fast-skip granted hardware — no live MDM round-trip needed
+		}
 	}
 
 	// One attempt up front, then a gentle cadence. The initial push (with the

--- a/coordinator/api/provider.go
+++ b/coordinator/api/provider.go
@@ -954,6 +954,38 @@ func (s *Server) clearPendingACME(providerID string) {
 	s.pendingACMEMu.Unlock()
 }
 
+// hasPendingACME reports whether a connect-time ACME result is still stashed for a
+// provider (i.e. its SE-key binding has not completed — applyACMETrust clears it on
+// a successful bind).
+func (s *Server) hasPendingACME(providerID string) bool {
+	s.pendingACMEMu.Lock()
+	_, ok := s.pendingACME[providerID]
+	s.pendingACMEMu.Unlock()
+	return ok
+}
+
+// reconcileACMEAfterFastSkip keeps ACMEVerified honest after a trust-reuse
+// fast-skip granted hardware via MDM-reuse (DAR-326 FIX 4a). applyACMETrust sets
+// ACMEVerified=true as soon as a device cert is valid, BEFORE its SE-key binding is
+// proven (the binding needs a passing challenge). The challenge has now passed, so
+// try the binding once: if it binds, ACME genuinely backs hardware and the flag is
+// legitimate (applyACMETrust clears the pending result on success). If it still
+// does not bind, the cert was never proven against the attested SE key, so we must
+// NOT report acme_verified=true off an MDM-reuse grant — clear the flag and discard
+// the stale pending result. No-op when nothing is stashed (then any ACMEVerified
+// was already granted+bound, or was never set).
+func (s *Server) reconcileACMEAfterFastSkip(providerID string, provider *registry.Provider) {
+	if !s.hasPendingACME(providerID) {
+		return
+	}
+	s.retryACMETrust(providerID, provider)
+	if s.hasPendingACME(providerID) {
+		// Binding still did not complete → unbound ACME. Don't claim ACME proof.
+		provider.SetACMEVerified(false)
+		s.clearPendingACME(providerID)
+	}
+}
+
 // retryACMETrust re-applies a stashed ACME result. Called from the
 // challenge-success path so a provider whose device cert was presented at
 // connect — but whose attestation had not yet bound — gets upgraded to
@@ -1638,17 +1670,28 @@ func (s *Server) verifyChallengeResponse(providerID string, provider *registry.P
 		// first; any gate miss (no record, binary changed, posture bad/unsigned,
 		// window elapsed, hard-untrusted) returns false and falls through to the
 		// unchanged full live MDM verify.
-		if !s.tryTrustReuseFastSkip(providerID, provider, resp, statusFieldsTrusted) {
-			// DAR-326 FIX 3: the live challenge settled WITHOUT a trust-reuse fast-skip
-			// grant. Signal the per-connection mdmVerificationLoop so a non-fast-skip
-			// candidate stops deferring and proceeds to the full live MDM verify
-			// immediately, instead of stalling the whole trust-reuse grace window.
-			provider.SignalChallengeSettled()
-			// Re-attempt ACME (mTLS device-cert) trust for self_signed providers.
-			// applyACMETrust ran at registration before attestation was bound, so a
-			// provider that presented a valid device cert can be promoted to hardware
-			// now that the challenge has passed. No-op if nothing was stashed.
+		if s.tryTrustReuseFastSkip(providerID, provider, resp, statusFieldsTrusted) {
+			// DAR-326 FIX 3: the fast-skip just granted hardware, so this provider is
+			// freshly routable — drain any queued requests now instead of waiting for
+			// the next heartbeat / 120s queue timeout. Off the challenge goroutine,
+			// mirroring the code-attest / MDM hardware-grant drain.
+			saferun.Go(s.logger, "trustReuseDrain", func() {
+				s.registry.DrainQueuedRequestsForProvider(provider)
+			})
+			// FIX 4a: keep ACMEVerified honest after an MDM-reuse grant — a connect-time
+			// cert may have set the flag before its SE-key binding completed.
+			s.reconcileACMEAfterFastSkip(providerID, provider)
+		} else {
+			// Fast-skip missed. FIX 4b: re-attempt ACME FIRST — applyACMETrust ran at
+			// registration before attestation was bound, so a provider that presented a
+			// valid device cert can be promoted to hardware now that the challenge has
+			// passed, WITHOUT forcing a live MDM round-trip. Only nudge the
+			// mdmVerificationLoop (SignalChallengeSettled, so it stops deferring and
+			// runs the live verify) if ACME did NOT grant hardware.
 			s.retryACMETrust(providerID, provider)
+			if provider.GetTrustLevel() != registry.TrustHardware {
+				provider.SignalChallengeSettled()
+			}
 		}
 	}
 }
@@ -2840,6 +2883,12 @@ func (s *Server) ApplyLateSecurityInfo(udid string, info *mdm.SecurityInfoRespon
 		// same epoch-checked synchronous write-through (recordTrustReuse) — a
 		// concurrent hard untrust is detected and not persisted. seKey + binary hash
 		// come from the registration-bound SE attestation.
+		//
+		// FIX 1: nil-guard the derivation. The candidate set guaranteed a valid
+		// attestation + non-empty serial, but NOT a non-empty SE key or binary hash
+		// (Swift providers may omit the self-reported binary hash). Skip caching
+		// rather than call recordTrustReuse with empty values (which it would reject
+		// anyway) — keeps the intent explicit and avoids a useless call.
 		c.provider.Mu().Lock()
 		var seKey, binaryHash string
 		if c.provider.AttestationResult != nil {
@@ -2847,7 +2896,9 @@ func (s *Server) ApplyLateSecurityInfo(udid string, info *mdm.SecurityInfoRespon
 			binaryHash = c.provider.AttestationResult.BinaryHash
 		}
 		c.provider.Mu().Unlock()
-		s.recordTrustReuse(c.provider, seKey, c.serial, binaryHash, true /*sip*/, true /*secureBootFull*/, udid)
+		if seKey != "" && binaryHash != "" {
+			s.recordTrustReuse(c.provider, seKey, c.serial, binaryHash, true /*sip*/, true /*secureBootFull*/, udid)
+		}
 	}
 }
 

--- a/coordinator/api/provider_test.go
+++ b/coordinator/api/provider_test.go
@@ -354,6 +354,36 @@ func testChallengeSignature(nonce, timestamp, encryptionKey string) string {
 	return "dGVzdHNpZ25hdHVyZQ=="
 }
 
+// testStatusSignature signs the canonical status payload with the SE private key
+// registered for encryptionKey, so verifyChallengeResponse treats the status
+// fields as cryptographically bound (statusFieldsTrusted=true) — required to reach
+// the trust-reuse fast-skip in tests.
+func testStatusSignature(t *testing.T, in attestation.StatusCanonicalInput, encryptionKey string) string {
+	t.Helper()
+	rawKey, ok := testAttestationChallengeKeys.Load(encryptionKey)
+	if !ok {
+		t.Fatalf("no challenge signer registered for %q", encryptionKey)
+	}
+	privKey, ok := rawKey.(*ecdsa.PrivateKey)
+	if !ok || privKey == nil {
+		t.Fatalf("invalid challenge signer for %q", encryptionKey)
+	}
+	canonical, err := attestation.BuildStatusCanonical(in)
+	if err != nil {
+		t.Fatalf("BuildStatusCanonical: %v", err)
+	}
+	hash := sha256.Sum256(canonical)
+	r, s, err := ecdsa.Sign(rand.Reader, privKey, hash[:])
+	if err != nil {
+		t.Fatalf("sign status: %v", err)
+	}
+	sigDER, err := asn1.Marshal(ecdsaSigHelper{R: r, S: s})
+	if err != nil {
+		t.Fatalf("marshal status sig: %v", err)
+	}
+	return base64.StdEncoding.EncodeToString(sigDER)
+}
+
 func rawP256PublicKeyB64ForTest(t *testing.T, pubKey *ecdsa.PublicKey) string {
 	t.Helper()
 	xBytes := pubKey.X.Bytes()

--- a/coordinator/api/server.go
+++ b/coordinator/api/server.go
@@ -184,6 +184,7 @@ type Server struct {
 	profileSigner          *profilesign.Signer       // CMS signer for the /v1/enroll .mobileconfig (nil = serve unsigned)
 	codeAttestor           apns.CodeIdentityAttestor // APNs code-identity attestor (nil = disabled; v0.6.0)
 	codeAttestThrottle     *codeAttestThrottle       // per-device APNs push budget + reuse cache (v0.6.0)
+	trustReuseCache        *trustReuseCache          // per-device trust-reuse cache: skip a fleet-wide live MDM herd on restart (DAR-326)
 
 	// knownBinaryHashes is the set of accepted provider binary SHA-256 hashes.
 	// When binaryHashPolicyConfigured is true, providers whose binary hash is
@@ -651,6 +652,7 @@ func NewServer(reg *registry.Registry, st store.Store, cfg ServerConfig, logger 
 		apiKeyCache:          make(map[string]apiKeyCacheEntry),
 		pendingACME:          make(map[string]*ACMEVerificationResult),
 		codeAttestThrottle:   newCodeAttestThrottle(),
+		trustReuseCache:      newTrustReuseCache(),
 		settlements:          newSettlementHolder(),
 		zombieCanceller:      newZombieStreamCanceller(),
 		serviceReservations:  newServiceReservationManager(st, cfg.ServiceReservations),

--- a/coordinator/api/trust_reuse.go
+++ b/coordinator/api/trust_reuse.go
@@ -349,14 +349,18 @@ func (s *Server) SeedTrustReuseCache(ctx context.Context) {
 // the forgery. This is bounded by the webhook being localhost-only; full
 // mitigation is authenticating the webhook (SEC-004, tracked separately).
 func (s *Server) recordTrustReuse(provider *registry.Provider, seKey, serial, binaryHash string, sipEnabled, secureBootFull bool, udid string) {
-	if s == nil || s.trustReuseCache == nil || provider == nil || seKey == "" || serial == "" {
+	// FIX 1: an empty seKey or binaryHash is a hard no-op — never record in-memory
+	// or persist. An empty-seKey row would be unkeyed (poisoning the cache / store);
+	// an empty binaryHash can never satisfy the read gate (b) so it would be a dead
+	// row. (ApplyLateSecurityInfo can derive empty values when AttestationResult is
+	// absent or carries no binary hash.)
+	if s == nil || s.trustReuseCache == nil || provider == nil || seKey == "" || serial == "" || binaryHash == "" {
 		return
 	}
 	normHash, err := normalizeSHA256Hex(binaryHash, "binary_hash")
 	if err != nil {
-		// No usable signed binary hash to bind the reuse record to; the read gate
-		// (b) requires a binary-hash match, so an unbindable record would never be
-		// reused. Skip caching rather than store a dead row.
+		// Non-empty but not a usable SHA-256 hex; the read gate (b) requires a
+		// binary-hash match, so this would be a dead row. Skip caching.
 		return
 	}
 	rec := store.ProviderTrustReuse{
@@ -381,9 +385,9 @@ func (s *Server) recordTrustReuse(provider *registry.Provider, seKey, serial, bi
 		return // no durable store wired; the in-memory record is enough
 	}
 
-	// Re-check immediately before the synchronous upsert: if a hard untrust raced
-	// this grant (the provider is now hard-untrusted, or the epoch bumped), drop the
-	// in-memory entry and do NOT persist a stale `hardware` row.
+	// PRE-write recheck: if a hard untrust raced this grant (the provider is now
+	// hard-untrusted, or the epoch bumped), drop the in-memory entry and do NOT
+	// persist a stale `hardware` row.
 	if provider.ChallengeShouldStop() || provider.HardUntrustEpoch() != epoch {
 		s.trustReuseCache.invalidateReuse(seKey)
 		return
@@ -392,6 +396,24 @@ func (s *Server) recordTrustReuse(provider *registry.Provider, seKey, serial, bi
 	defer cancel()
 	if err := st.UpsertProviderTrustReuse(ctx, rec); err != nil {
 		s.logger.Warn("trust-reuse: failed to persist reuse record", "error", err)
+		return
+	}
+
+	// POST-write recheck (FIX 2 — close the check-then-write TOCTOU). The pre-write
+	// check alone leaves a window: a hard untrust landing between it and the upsert
+	// COMMITTING runs its synchronous delete first, then this upsert resurrects the
+	// row → reseeded on restart. So re-check AFTER the write: if a hard untrust raced
+	// in, delete the row we just wrote (idempotent, bounded retry) and drop the
+	// in-memory entry. Combined with markUntrusted's own synchronous delete this
+	// fully linearizes write vs delete on the epoch — an untrust before the
+	// pre-check is dropped, one during the write is compensated here, and one after
+	// is removed by its own delete (our committed row is already visible to it).
+	if provider.ChallengeShouldStop() || provider.HardUntrustEpoch() != epoch {
+		s.trustReuseCache.invalidateReuse(seKey)
+		if err := s.deletePersistedTrustReuseWithRetry(st, seKey); err != nil {
+			s.logger.Warn("trust-reuse: failed to delete reuse record after post-write untrust recheck",
+				"error", err, "attempts", trustReuseDeleteAttempts)
+		}
 	}
 }
 
@@ -422,19 +444,29 @@ func (s *Server) invalidateTrustReuse(seKey string) {
 	}
 	// Bounded inline retry of the persisted delete (FIX 1): keep "hard untrust
 	// takes effect" durable across a restart even through a transient DB error.
+	if err := s.deletePersistedTrustReuseWithRetry(st, seKey); err != nil {
+		// Log only after the final attempt fails (avoids alarming logs on a
+		// recovered transient blip).
+		s.logger.Warn("trust-reuse: failed to delete persisted reuse record on hard untrust after retries",
+			"error", err, "attempts", trustReuseDeleteAttempts)
+	}
+}
+
+// deletePersistedTrustReuseWithRetry deletes the persisted reuse row with a bounded
+// inline retry, returning nil on success or the last error. Idempotent (deleting a
+// missing row is fine), so it is reused both by the hard-untrust hook
+// (invalidateTrustReuse) and by recordTrustReuse's post-write recheck (FIX 2).
+func (s *Server) deletePersistedTrustReuseWithRetry(st trustReuseStore, seKey string) error {
 	var err error
 	for attempt := 0; attempt < trustReuseDeleteAttempts; attempt++ {
 		if attempt > 0 {
 			time.Sleep(trustReuseDeleteRetryBackoff)
 		}
 		if err = deleteProviderTrustReuseOnce(st, seKey); err == nil {
-			return
+			return nil
 		}
 	}
-	// Log only after the final attempt fails (avoids alarming logs on a recovered
-	// transient blip).
-	s.logger.Warn("trust-reuse: failed to delete persisted reuse record on hard untrust after retries",
-		"error", err, "attempts", trustReuseDeleteAttempts)
+	return err
 }
 
 // deleteProviderTrustReuseOnce runs one persisted-delete attempt with its own
@@ -523,9 +555,15 @@ func (s *Server) tryTrustReuseFastSkip(providerID string, provider *registry.Pro
 		return false
 	}
 	provider.SetMDMFailureReason("")
-	// The device is now hardware, so any connect-time ACME result stashed for a
-	// later retry is moot — drop it (FIX 5b), mirroring a normal hardware upgrade.
-	s.clearPendingACME(providerID)
+	// MDA-freshness trade-off (Threat-Model TB-005 / T-036): this fast-skip skips the
+	// live MDA cert-chain re-verification (and the live MDM SecurityInfo round-trip)
+	// that the full path performs. It relies on the SIP/Secure-Boot posture captured
+	// at the LAST full verification (within the reuse window) plus the always-run
+	// live SE challenge that just re-proved identity + posture + unchanged binary. It
+	// does NOT re-prove MDA cert-chain freshness within the window — an accepted
+	// trade-off for the restart-herd problem, bounded by the (short) reuse window and
+	// the live SE challenge. Connect-time ACME state is reconciled by the caller
+	// (reconcileACMEAfterFastSkip) so an unbound cert is not reported as verified.
 	s.sendTrustStatus(provider, registry.TrustHardware, "online", "trust-reuse fast-skip (recent MDM verification re-proven by live SE challenge)")
 	s.registry.PersistProvider(provider)
 	s.ddIncr("mdm.verification", []string{"outcome:granted-trust-reuse"})

--- a/coordinator/api/trust_reuse.go
+++ b/coordinator/api/trust_reuse.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/eigeninference/d-inference/coordinator/protocol"
 	"github.com/eigeninference/d-inference/coordinator/registry"
-	"github.com/eigeninference/d-inference/coordinator/saferun"
 	"github.com/eigeninference/d-inference/coordinator/store"
 )
 
@@ -16,9 +15,11 @@ import (
 // honored for a NEW connection from the same device — without re-running the live
 // MDM SecurityInfo round-trip — provided a fresh live SE challenge re-proves the
 // SAME identity, binary, and good posture. It bounds the staleness of the MDM
-// proof, so it is kept short (mirrors the code-identity reuse window). Overridable
-// via EIGENINFERENCE_TRUST_REUSE_WINDOW.
-const defaultTrustReuseWindow = 30 * time.Minute
+// proof. Kept SHORT (Threat-Model #3): the reuse must not be able to span a
+// SIP-disable reboot cycle (where a box reboots into Recovery, disables SIP, and
+// reconnects), so a window comfortably under a realistic reboot+reconnect is used.
+// Overridable via EIGENINFERENCE_TRUST_REUSE_WINDOW.
+const defaultTrustReuseWindow = 10 * time.Minute
 
 // trustReuseGrantWait bounds how long the per-connection mdmVerificationLoop
 // defers to the live SE challenge's trust-reuse fast-skip for a known, recently
@@ -275,10 +276,17 @@ func (c *trustReuseCache) seed(rows []store.ProviderTrustReuse) int {
 // server setup. The hard-untrust hook is wired UNCONDITIONALLY (independent of
 // store presence) so a hard untrust always drops the in-memory record even under
 // the memory-store fallback; persistence + startup seeding are skipped when no
-// store is wired. SECURITY: seeding only repopulates the cache that reuseTrust
-// re-validates (behind a live SE challenge) on every read — it cannot grant
-// hardware by itself, and a stale/wrong-binary/expired row still falls through to
-// a full live MDM verify.
+// store is wired. SECURITY: seeding TRUSTS the DB contents — a row that says
+// `hardware` is loaded as a fast-skip candidate. That trust is bounded because
+// reuseTrust re-validates every row on read behind an always-run live SE challenge
+// (re-proving SIP/Secure-Boot posture + binary + identity) and rejects future-
+// dated rows, so a stale/wrong-binary/expired/forged row still falls through to a
+// full live MDM verify — seeding cannot grant hardware by itself. The write path
+// (provider_trust_reuse table) must therefore be guarded like the payment ledger
+// (Threat-Model #5): only the coordinator writes it, after a verified live MDM
+// pass. SEC-004: a forged localhost MDM webhook that drove a grant would be
+// persisted + reseeded here (amplified across restarts); bounded by the
+// localhost-only webhook, fully mitigated by authenticating it (tracked separately).
 func (s *Server) SeedTrustReuseCache(ctx context.Context) {
 	if s == nil || s.trustReuseCache == nil {
 		return
@@ -310,18 +318,38 @@ func (s *Server) SeedTrustReuseCache(ctx context.Context) {
 }
 
 // recordTrustReuse writes a successful FULL live MDM verification to the reuse
-// cache: in-memory (recordTrust) AND durable write-through (persistTrustReuse), so
-// a planned coordinator restart/swap can fast-skip the live MDM round-trip for
-// this device within the freshness window. Called from verifyProviderViaMDM AFTER
-// hardware is granted. The recorded binary hash is the SE-attested provider binary
-// (normalized); the read gate compares it to the binary hash in the fresh SIGNED
-// challenge, so a binary change between connections forces a full re-verify. If the
-// SE attestation carries no usable binary hash, no record is cached (the read gate
-// requires a binary match anyway) — the device simply re-verifies via full MDM next
-// time. SECURITY: written only after a full, verified live MDM pass — never from an
-// unverified self-report.
-func (s *Server) recordTrustReuse(seKey, serial, binaryHash string, sipEnabled, secureBootFull bool, udid string) {
-	if s == nil || s.trustReuseCache == nil || seKey == "" || serial == "" {
+// cache — in-memory AND a SYNCHRONOUS, epoch-checked durable write-through — so a
+// planned coordinator restart/swap can fast-skip the live MDM round-trip for this
+// device within the freshness window. Called from verifyProviderViaMDM and
+// ApplyLateSecurityInfo AFTER hardware is granted.
+//
+// FIX A (durable hard-untrust — close the write-after-delete race): the persist is
+// SYNCHRONOUS, not fire-and-forget. A fire-and-forget write could land AFTER a
+// concurrent hard-untrust's synchronous delete (invalidateTrustReuse) and
+// resurrect a stale `hardware` row that a restart would reseed → fast-skip
+// untrusted hardware (Codex trust_reuse.go:366 / Threat-Model #6). We capture the
+// provider's hard-untrust epoch at grant time and, immediately before the upsert,
+// re-check that no hard untrust has raced in (provider not hard-untrusted AND the
+// epoch is unchanged); if it has, we drop the in-memory entry and skip the
+// persist. markUntrusted bumps the epoch BEFORE its synchronous delete hook, so
+// this linearizes write vs delete on the epoch: a write that began before the
+// untrust is dropped by the recheck, and a write that lands before the untrust's
+// delete is removed by that delete. The always-required live SE challenge on reuse
+// is the backstop for the residual instruction-level window between recheck and
+// upsert.
+//
+// The recorded binary hash is the SE-attested provider binary (normalized); the
+// read gate compares it to the binary hash in the fresh SIGNED challenge, so a
+// binary change between connections forces a full re-verify. If the SE attestation
+// carries no usable binary hash, no record is cached (the read gate requires a
+// binary match anyway). SECURITY: written only after a full, verified live MDM
+// pass — never from an unverified self-report. SEC-004: were a forged MDM webhook
+// (unauthenticated, but localhost-bound in-container) ever to drive a grant, that
+// grant would be durably persisted here and reseeded across restarts — amplifying
+// the forgery. This is bounded by the webhook being localhost-only; full
+// mitigation is authenticating the webhook (SEC-004, tracked separately).
+func (s *Server) recordTrustReuse(provider *registry.Provider, seKey, serial, binaryHash string, sipEnabled, secureBootFull bool, udid string) {
+	if s == nil || s.trustReuseCache == nil || provider == nil || seKey == "" || serial == "" {
 		return
 	}
 	normHash, err := normalizeSHA256Hex(binaryHash, "binary_hash")
@@ -341,29 +369,30 @@ func (s *Server) recordTrustReuse(seKey, serial, binaryHash string, sipEnabled, 
 		MDAUDID:        udid,
 		VerifiedAt:     s.trustReuseCache.now(),
 	}
-	s.trustReuseCache.recordTrust(rec) // in-memory
-	s.persistTrustReuse(rec)           // durable write-through
-}
 
-// persistTrustReuse best-effort writes a reuse record to the store off the read
-// loop (saferun.Go) so it survives a coordinator restart/deploy. Behind the store
-// seam (no-op until SeedTrustReuseCache wires a store). Mirrors
-// Server.persistCodeAttestation.
-func (s *Server) persistTrustReuse(rec store.ProviderTrustReuse) {
-	if s == nil || s.trustReuseCache == nil || rec.SEPubKey == "" {
-		return
-	}
+	// Capture the hard-untrust epoch at grant time (FIX A).
+	epoch := provider.HardUntrustEpoch()
+
+	// Record in-memory so an immediate same-process reconnect can fast-skip.
+	s.trustReuseCache.recordTrust(rec)
+
 	st := s.trustReuseCache.store
 	if st == nil {
+		return // no durable store wired; the in-memory record is enough
+	}
+
+	// Re-check immediately before the synchronous upsert: if a hard untrust raced
+	// this grant (the provider is now hard-untrusted, or the epoch bumped), drop the
+	// in-memory entry and do NOT persist a stale `hardware` row.
+	if provider.ChallengeShouldStop() || provider.HardUntrustEpoch() != epoch {
+		s.trustReuseCache.invalidateReuse(seKey)
 		return
 	}
-	saferun.Go(s.logger, "persistTrustReuse", func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-		if err := st.UpsertProviderTrustReuse(ctx, rec); err != nil {
-			s.logger.Warn("trust-reuse: failed to persist reuse record", "error", err)
-		}
-	})
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := st.UpsertProviderTrustReuse(ctx, rec); err != nil {
+		s.logger.Warn("trust-reuse: failed to persist reuse record", "error", err)
+	}
 }
 
 // invalidateTrustReuse drops a device's reuse record in-memory AND deletes the
@@ -431,9 +460,20 @@ func deleteProviderTrustReuseOnce(st trustReuseStore, seKey string) error {
 //	(c) fresh posture is good AND cryptographically bound: SIPEnabled &&
 //	    SecureBootEnabled && statusFieldsTrusted;
 //	(d) within the freshness window (enforced in reuseTrust);
-//	(e) the provider is not currently HARD-untrusted.
+//	(e) the provider is not currently HARD-untrusted;
+//	(f) an MDM client is configured (FIX C) — the fast-skip only ever SUBSTITUTES
+//	    for a live MDM round-trip, so on a no-MDM / misconfigured deploy there is no
+//	    live fallback and we must not grant hardware from a (possibly stale) cache.
 func (s *Server) tryTrustReuseFastSkip(providerID string, provider *registry.Provider, resp *protocol.AttestationResponseMessage, statusFieldsTrusted bool) bool {
 	if s == nil || s.trustReuseCache == nil || provider == nil || resp == nil {
+		return false
+	}
+	// (f) require MDM to be configured. The trust-reuse fast-skip is purely an
+	// optimization that REPLACES a live MDM SecurityInfo round-trip; if no MDM
+	// client is wired (no-MDM or misconfigured deploy), the normal path would never
+	// grant hardware via MDM at all, so granting it here from the reuse cache would
+	// be a strictly weaker trust decision with no live fallback. Decline.
+	if s.mdmClient == nil {
 		return false
 	}
 	// (c) fresh good posture, cryptographically bound to the SE key. Without a

--- a/coordinator/api/trust_reuse.go
+++ b/coordinator/api/trust_reuse.go
@@ -1,0 +1,467 @@
+package api
+
+import (
+	"context"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+	"github.com/eigeninference/d-inference/coordinator/registry"
+	"github.com/eigeninference/d-inference/coordinator/saferun"
+	"github.com/eigeninference/d-inference/coordinator/store"
+)
+
+// defaultTrustReuseWindow is how long a successful FULL live MDM verification is
+// honored for a NEW connection from the same device — without re-running the live
+// MDM SecurityInfo round-trip — provided a fresh live SE challenge re-proves the
+// SAME identity, binary, and good posture. It bounds the staleness of the MDM
+// proof, so it is kept short (mirrors the code-identity reuse window). Overridable
+// via EIGENINFERENCE_TRUST_REUSE_WINDOW.
+const defaultTrustReuseWindow = 30 * time.Minute
+
+// trustReuseGrantWait bounds how long the per-connection mdmVerificationLoop
+// defers to the live SE challenge's trust-reuse fast-skip for a known, recently
+// fully-verified device before falling back to the full live MDM round-trip. The
+// SE challenge round-trip is sub-second, so this is rarely fully consumed; it
+// exists only so this loop does not race AHEAD of the challenge and re-run the
+// live MDM verify the fast-skip is meant to avoid — the fleet-wide MDM/APNs herd
+// on a planned coordinator restart/swap that this feature targets.
+const (
+	trustReuseGrantWait = 10 * time.Second
+	trustReuseGrantPoll = 100 * time.Millisecond
+)
+
+// trustReuseStore is the minimal slice of store.Store the trust-reuse cache needs
+// to survive coordinator restarts/blue-green deploys (DAR-326 Phase 0). store.Store
+// satisfies it; tests can inject a fake. SECURITY: persistence is a performance
+// optimization (avoid a fleet-wide live MDM re-verification within the reuse
+// window) — it is NEVER consulted to grant hardware trust. The reuse decision
+// (reuseTrust) re-applies, behind a live SE challenge, the identity + binary +
+// fresh-posture + freshness gates on every read, so a stale/wrong-binary/expired
+// persisted row falls through to a real, full live MDM verification.
+type trustReuseStore interface {
+	ListProviderTrustReuse(ctx context.Context) ([]store.ProviderTrustReuse, error)
+	UpsertProviderTrustReuse(ctx context.Context, rec store.ProviderTrustReuse) error
+	DeleteProviderTrustReuse(ctx context.Context, seKey string) error
+}
+
+// trustReuseCache lets a planned coordinator restart/swap skip a fleet-wide live
+// MDM SecurityInfo + APNs re-verification herd. It mirrors the code-identity reuse
+// cache (codeAttestThrottle): one durable record per device of its most recent
+// FULL live MDM verification, keyed by the Secure Enclave public key — the stable
+// per-device identity that survives reconnects AND coordinator restarts.
+//
+// On reconnect today, every provider's per-connection mdmVerificationLoop fires a
+// live MDM SecurityInfo round-trip (and APNs push) almost immediately; doing that
+// across the whole fleet at once (a restart/blue-green swap) is the herd. With a
+// fresh record, once the live SE challenge re-proves identity + posture, the
+// coordinator grants hardware from the record and the MDM loop skips its live
+// round-trip.
+//
+// SECURITY — the skip is a gated optimization, never a trust shortcut:
+//   - The live SE challenge ALWAYS runs first (never skipped). The fast-skip only
+//     happens AFTER it passes (verifyChallengeResponse -> tryTrustReuseFastSkip).
+//   - reuseTrust re-checks, on every read: SE-key + serial identity match (a), the
+//     binary hash in the FRESH signed challenge == the one proven at the last MDM
+//     verification (b), the recorded posture was good + trust was hardware, and the
+//     freshness window (d). The caller additionally requires fresh good posture
+//     cryptographically bound to the SE key (c) and that the provider is not
+//     hard-untrusted (e). Any miss falls through to the full live MDM verify —
+//     byte-identical to today.
+//   - A hard untrust deletes the record (in-memory + persisted), so it can never
+//     reseed and fast-skip after a restart. First-ever verification (no record)
+//     always does the full live MDM.
+type trustReuseCache struct {
+	mu      sync.Mutex
+	records map[string]trustReuseRecord // seKey -> last successful FULL live MDM verification
+
+	reuseWindow time.Duration
+
+	now func() time.Time
+
+	// store persists the reuse cache across restarts/deploys. nil until wired by
+	// Server.SeedTrustReuseCache at startup (and nil in unit tests that construct a
+	// bare cache), so every persistence path is nil-safe — the in-memory reuse
+	// cache works identically with or without a store.
+	store trustReuseStore
+}
+
+// trustReuseRecord is the in-memory form of store.ProviderTrustReuse: what was
+// proven about a device at its last FULL live MDM verification.
+type trustReuseRecord struct {
+	serial         string
+	trustLevel     string
+	binaryHash     string // normalized SHA-256 hex of the provider binary at last verification
+	sipEnabled     bool
+	secureBootFull bool
+	mdaUDID        string
+	at             time.Time
+}
+
+func newTrustReuseCache() *trustReuseCache {
+	return &trustReuseCache{
+		records:     make(map[string]trustReuseRecord),
+		reuseWindow: trustReuseWindowFromEnv(),
+		now:         time.Now,
+	}
+}
+
+// trustReuseWindowFromEnv reads EIGENINFERENCE_TRUST_REUSE_WINDOW (a Go duration,
+// e.g. "45m"), falling back to defaultTrustReuseWindow when unset/invalid.
+func trustReuseWindowFromEnv() time.Duration {
+	if v := os.Getenv("EIGENINFERENCE_TRUST_REUSE_WINDOW"); v != "" {
+		if d, err := time.ParseDuration(v); err == nil && d > 0 {
+			return d
+		}
+	}
+	return defaultTrustReuseWindow
+}
+
+// reuseTrust reports whether the device has a record-side basis to skip a live MDM
+// re-verification: a fresh record (within the window) for the SAME SE key + serial,
+// earned at HARDWARE trust with good recorded posture, whose recorded binary hash
+// matches the one in the fresh SIGNED challenge (freshBinaryHash, already
+// normalized by the caller). It does NOT check the fresh posture or hard-untrust
+// state — those are the caller's gates (c)/(e) — keeping this method a pure,
+// clock-driven record lookup that mirrors codeAttestThrottle.reuseAttestation.
+// SECURITY: every field here re-validates the persisted/seeded record on read, so a
+// seeded row can never by itself grant trust.
+func (c *trustReuseCache) reuseTrust(seKey, serial, freshBinaryHash string) (trustReuseRecord, bool) {
+	if seKey == "" || serial == "" || freshBinaryHash == "" {
+		return trustReuseRecord{}, false
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	r, ok := c.records[seKey]
+	if !ok {
+		return trustReuseRecord{}, false
+	}
+	if r.serial != serial { // (a) identity: serial bound to the same SE key
+		return trustReuseRecord{}, false
+	}
+	if r.trustLevel != string(registry.TrustHardware) { // only a full MDM/hardware verification is reusable
+		return trustReuseRecord{}, false
+	}
+	if r.binaryHash == "" || r.binaryHash != freshBinaryHash { // (b) code identity unchanged
+		return trustReuseRecord{}, false
+	}
+	if !r.sipEnabled || !r.secureBootFull { // recorded posture must have been good (defensive)
+		return trustReuseRecord{}, false
+	}
+	if c.now().Sub(r.at) >= c.reuseWindow { // (d) freshness window
+		return trustReuseRecord{}, false
+	}
+	return r, true
+}
+
+// hasFreshRecord reports whether a fresh, hardware, identity-matching record
+// exists for a device. It is a SUBSET of reuseTrust (no binary/posture check) used
+// ONLY to decide whether the mdmVerificationLoop should briefly defer to the SE
+// challenge's fast-skip. It is a timing hint, never a trust decision — the actual
+// grant always goes through reuseTrust + the caller's full gates.
+func (c *trustReuseCache) hasFreshRecord(seKey, serial string) bool {
+	if seKey == "" || serial == "" {
+		return false
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	r, ok := c.records[seKey]
+	if !ok || r.serial != serial || r.trustLevel != string(registry.TrustHardware) {
+		return false
+	}
+	return c.now().Sub(r.at) < c.reuseWindow
+}
+
+// recordTrust updates the in-memory reuse record for a device after a successful
+// FULL live MDM verification. Mirrors codeAttestThrottle.recordAttested; the
+// durable write-through is Server.persistTrustReuse, called alongside it.
+func (c *trustReuseCache) recordTrust(rec store.ProviderTrustReuse) {
+	if rec.SEPubKey == "" {
+		return
+	}
+	c.mu.Lock()
+	c.records[rec.SEPubKey] = trustReuseRecord{
+		serial:         rec.Serial,
+		trustLevel:     rec.TrustLevel,
+		binaryHash:     rec.BinaryHash,
+		sipEnabled:     rec.SIPEnabled,
+		secureBootFull: rec.SecureBootFull,
+		mdaUDID:        rec.MDAUDID,
+		at:             rec.VerifiedAt,
+	}
+	c.mu.Unlock()
+}
+
+// invalidateReuse drops any cached reuse record for a device so the NEXT reconnect
+// cannot be short-circuited by reuseTrust and must run a full live MDM
+// verification. Used on HARD untrust (posture/binary/identity mismatch). This
+// drops only the IN-MEMORY record; the caller (Server.invalidateTrustReuse) also
+// deletes the PERSISTED row so a coordinator restart cannot reseed and fast-skip
+// on a stale, pre-untrust record. Mirrors codeAttestThrottle.invalidateReuse.
+func (c *trustReuseCache) invalidateReuse(seKey string) {
+	if seKey == "" {
+		return
+	}
+	c.mu.Lock()
+	delete(c.records, seKey)
+	c.mu.Unlock()
+}
+
+// seed loads persisted trust-reuse records into the in-memory cache at startup.
+// It applies the SAME freshness window used on read, so only rows that could still
+// be reused are kept, and never overwrites a fresher in-memory record (a device
+// that reconnected and re-verified before seeding finished). Returns the number of
+// rows seeded. Mirrors codeAttestThrottle.seed. SECURITY: seeding only populates
+// the cache that reuseTrust re-validates (identity + binary + posture + freshness)
+// behind a live SE challenge on every read — it cannot by itself grant hardware.
+func (c *trustReuseCache) seed(rows []store.ProviderTrustReuse) int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	now := c.now()
+	n := 0
+	for _, r := range rows {
+		if r.SEPubKey == "" {
+			continue
+		}
+		if now.Sub(r.VerifiedAt) >= c.reuseWindow {
+			continue // already outside the reuse window — would never be reused
+		}
+		if cur, ok := c.records[r.SEPubKey]; ok && !r.VerifiedAt.After(cur.at) {
+			continue // keep the fresher in-memory record
+		}
+		c.records[r.SEPubKey] = trustReuseRecord{
+			serial:         r.Serial,
+			trustLevel:     r.TrustLevel,
+			binaryHash:     r.BinaryHash,
+			sipEnabled:     r.SIPEnabled,
+			secureBootFull: r.SecureBootFull,
+			mdaUDID:        r.MDAUDID,
+			at:             r.VerifiedAt,
+		}
+		n++
+	}
+	return n
+}
+
+// SeedTrustReuseCache wires the store into the trust-reuse cache, wires durable
+// invalidation on hard untrust, and seeds the cache from persisted records at
+// startup (DAR-326 Phase 0). This is what makes the reuse cache survive a
+// coordinator restart / blue-green deploy so a fresh instance does not re-run a
+// fleet-wide live MDM SecurityInfo + APNs verification. Safe to call once during
+// server setup, AFTER the store is set; a nil store or nil cache is a no-op.
+// SECURITY: seeding only repopulates the cache that reuseTrust re-validates (behind
+// a live SE challenge) on every read — it cannot grant hardware by itself, and a
+// stale/wrong-binary/expired row still falls through to a full live MDM verify.
+func (s *Server) SeedTrustReuseCache(ctx context.Context) {
+	if s == nil || s.trustReuseCache == nil || s.store == nil {
+		return
+	}
+	// Wire the write-through path so future successful verifications are persisted.
+	s.trustReuseCache.store = s.store
+	// Wire durable invalidation: a HARD untrust must delete the persisted record so
+	// a coordinator restart cannot reseed and fast-skip on a stale, pre-untrust row.
+	if s.registry != nil {
+		s.registry.SetHardUntrustHook(s.invalidateTrustReuse)
+	}
+
+	rows, err := s.store.ListProviderTrustReuse(ctx)
+	if err != nil {
+		s.logger.Warn("trust-reuse: failed to seed reuse cache from store", "error", err)
+		return
+	}
+	n := s.trustReuseCache.seed(rows)
+	if n > 0 {
+		s.logger.Info("trust-reuse: seeded reuse cache from persisted records (survives deploys)", "records", n)
+	}
+}
+
+// recordTrustReuse writes a successful FULL live MDM verification to the reuse
+// cache: in-memory (recordTrust) AND durable write-through (persistTrustReuse), so
+// a planned coordinator restart/swap can fast-skip the live MDM round-trip for
+// this device within the freshness window. Called from verifyProviderViaMDM AFTER
+// hardware is granted. The recorded binary hash is the SE-attested provider binary
+// (normalized); the read gate compares it to the binary hash in the fresh SIGNED
+// challenge, so a binary change between connections forces a full re-verify. If the
+// SE attestation carries no usable binary hash, no record is cached (the read gate
+// requires a binary match anyway) — the device simply re-verifies via full MDM next
+// time. SECURITY: written only after a full, verified live MDM pass — never from an
+// unverified self-report.
+func (s *Server) recordTrustReuse(seKey, serial, binaryHash string, sipEnabled, secureBootFull bool, udid string) {
+	if s == nil || s.trustReuseCache == nil || seKey == "" || serial == "" {
+		return
+	}
+	normHash, err := normalizeSHA256Hex(binaryHash, "binary_hash")
+	if err != nil {
+		// No usable signed binary hash to bind the reuse record to; the read gate
+		// (b) requires a binary-hash match, so an unbindable record would never be
+		// reused. Skip caching rather than store a dead row.
+		return
+	}
+	rec := store.ProviderTrustReuse{
+		SEPubKey:       seKey,
+		Serial:         serial,
+		TrustLevel:     string(registry.TrustHardware),
+		BinaryHash:     normHash,
+		SIPEnabled:     sipEnabled,
+		SecureBootFull: secureBootFull,
+		MDAUDID:        udid,
+		VerifiedAt:     s.trustReuseCache.now(),
+	}
+	s.trustReuseCache.recordTrust(rec) // in-memory
+	s.persistTrustReuse(rec)           // durable write-through
+}
+
+// persistTrustReuse best-effort writes a reuse record to the store off the read
+// loop (saferun.Go) so it survives a coordinator restart/deploy. Behind the store
+// seam (no-op until SeedTrustReuseCache wires a store). Mirrors
+// Server.persistCodeAttestation.
+func (s *Server) persistTrustReuse(rec store.ProviderTrustReuse) {
+	if s == nil || s.trustReuseCache == nil || rec.SEPubKey == "" {
+		return
+	}
+	st := s.trustReuseCache.store
+	if st == nil {
+		return
+	}
+	saferun.Go(s.logger, "persistTrustReuse", func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := st.UpsertProviderTrustReuse(ctx, rec); err != nil {
+			s.logger.Warn("trust-reuse: failed to persist reuse record", "error", err)
+		}
+	})
+}
+
+// invalidateTrustReuse drops a device's reuse record in-memory AND deletes the
+// persisted row (off the read loop). Wired as the registry's hard-untrust hook, so
+// EVERY hard/security deroute (SIP off, Secure Boot off, binary/model-hash change,
+// MDM posture mismatch, serial impersonation, bad encrypted chunk, ...) makes
+// "hard untrust always takes effect" durable across restarts: the device cannot
+// fast-skip on a stale, pre-untrust record after a coordinator restart. No-op when
+// no store is wired (in-memory invalidation still applies). Mirrors
+// Server.invalidatePersistedCodeAttestation.
+func (s *Server) invalidateTrustReuse(seKey string) {
+	if s == nil || s.trustReuseCache == nil || seKey == "" {
+		return
+	}
+	s.trustReuseCache.invalidateReuse(seKey)
+	st := s.trustReuseCache.store
+	if st == nil {
+		return
+	}
+	saferun.Go(s.logger, "invalidateTrustReuse", func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := st.DeleteProviderTrustReuse(ctx, seKey); err != nil {
+			s.logger.Warn("trust-reuse: failed to delete persisted reuse record on hard untrust", "error", err)
+		}
+	})
+}
+
+// tryTrustReuseFastSkip is the read-path gate + grant. It runs AFTER the live SE
+// challenge has passed (from verifyChallengeResponse). If a fresh trust-reuse
+// record re-proves this exact, recently-fully-verified device — and the fresh
+// SIGNED challenge re-proves good posture and an unchanged binary — it grants
+// hardware immediately and returns true, letting the mdmVerificationLoop skip its
+// live MDM SecurityInfo round-trip. Any gate miss returns false (fall through to
+// the unchanged full live MDM verify).
+//
+// Gates (ALL required), mapping to the DAR-326 spec:
+//
+//	(a) SE pubkey AND serial match the registration-bound attestation;
+//	(b) the binary hash in the fresh SIGNED challenge == the cached one;
+//	(c) fresh posture is good AND cryptographically bound: SIPEnabled &&
+//	    SecureBootEnabled && statusFieldsTrusted;
+//	(d) within the freshness window (enforced in reuseTrust);
+//	(e) the provider is not currently HARD-untrusted.
+func (s *Server) tryTrustReuseFastSkip(providerID string, provider *registry.Provider, resp *protocol.AttestationResponseMessage, statusFieldsTrusted bool) bool {
+	if s == nil || s.trustReuseCache == nil || provider == nil || resp == nil {
+		return false
+	}
+	// (c) fresh good posture, cryptographically bound to the SE key. Without a
+	// status signature (statusFieldsTrusted == false) the SIP/SecureBoot/binary
+	// fields are advisory and must never drive a trust decision.
+	if !statusFieldsTrusted {
+		return false
+	}
+	if resp.SIPEnabled == nil || !*resp.SIPEnabled {
+		return false
+	}
+	if resp.SecureBootEnabled == nil || !*resp.SecureBootEnabled {
+		return false
+	}
+	// (e) never fast-skip a hard-untrusted provider. (GrantHardwareIfNotUntrusted
+	// below is the authoritative atomic backstop; this is an early-out.)
+	if provider.ChallengeShouldStop() {
+		return false
+	}
+	// (a) identity: SE pubkey + serial from the registration-bound attestation —
+	// never values supplied in the response.
+	provider.Mu().Lock()
+	var seKey, serial string
+	if provider.AttestationResult != nil {
+		seKey = provider.AttestationResult.PublicKey
+		serial = provider.AttestationResult.SerialNumber
+	}
+	provider.Mu().Unlock()
+	if seKey == "" || serial == "" {
+		return false
+	}
+	// (b) code identity: the binary hash in the fresh SIGNED challenge must match
+	// the one proven at the last full MDM verification (both normalized).
+	freshBinaryHash, err := normalizeSHA256Hex(resp.BinaryHash, "binary_hash")
+	if err != nil {
+		return false
+	}
+	// reuseTrust enforces (a) serial, (b) binary, (d) freshness + hardware/recorded
+	// posture. Any miss → fall through to the full live MDM verify.
+	rec, ok := s.trustReuseCache.reuseTrust(seKey, serial, freshBinaryHash)
+	if !ok {
+		return false
+	}
+	// Atomically grant hardware unless a concurrent hard untrust raced in (closes
+	// the TOCTOU; mirrors verifyProviderViaMDM's grant).
+	if !provider.GrantHardwareIfNotUntrusted() {
+		return false
+	}
+	provider.SetMDMFailureReason("")
+	s.sendTrustStatus(provider, registry.TrustHardware, "online", "trust-reuse fast-skip (recent MDM verification re-proven by live SE challenge)")
+	s.registry.PersistProvider(provider)
+	s.ddIncr("mdm.verification", []string{"outcome:granted-trust-reuse"})
+	s.logger.Info("trust-reuse fast-skip — granted hardware without live MDM round-trip",
+		"provider_id", providerID,
+		"serial_number", serial,
+		"mda_udid", rec.mdaUDID,
+	)
+	return true
+}
+
+// awaitTrustReuseGrant lets the mdmVerificationLoop briefly defer to the live SE
+// challenge's trust-reuse fast-skip before running the (herd-causing) live MDM
+// round-trip. It returns true if hardware is granted within trustReuseGrantWait
+// (by the fast-skip, or the ACME leg), false otherwise (slow challenge / gate miss
+// / hard untrust / ctx done) — in which case the caller proceeds to the full live
+// MDM verify, unchanged. Only invoked for fast-skip candidates (hasFreshRecord),
+// so a first-ever / expired device is never delayed.
+func (s *Server) awaitTrustReuseGrant(ctx context.Context, provider *registry.Provider) bool {
+	timer := time.NewTimer(trustReuseGrantWait)
+	defer timer.Stop()
+	ticker := time.NewTicker(trustReuseGrantPoll)
+	defer ticker.Stop()
+	for {
+		if provider.GetTrustLevel() == registry.TrustHardware {
+			return true
+		}
+		if provider.ChallengeShouldStop() {
+			return false
+		}
+		select {
+		case <-ctx.Done():
+			return false
+		case <-timer.C:
+			return provider.GetTrustLevel() == registry.TrustHardware
+		case <-ticker.C:
+		}
+	}
+}

--- a/coordinator/api/trust_reuse.go
+++ b/coordinator/api/trust_reuse.go
@@ -32,6 +32,24 @@ const (
 	trustReuseGrantPoll = 100 * time.Millisecond
 )
 
+// clockSkewTolerance lets a record whose VerifiedAt is slightly in the FUTURE
+// (coordinator/provider clock skew, or a small NTP step) still count as fresh,
+// while rejecting one dated implausibly far in the future — a corrupt/forged
+// VerifiedAt that would otherwise keep a record "fresh" long past the real
+// window. Applied identically in reuseTrust / hasFreshRecord / seed (DAR-326
+// FIX 2): a record is fresh iff age in [-clockSkewTolerance, reuseWindow).
+const clockSkewTolerance = 2 * time.Minute
+
+// trustReuseDeleteAttempts / trustReuseDeleteRetryBackoff bound the INLINE
+// persisted-delete retry on hard untrust (DAR-326 FIX 1). The hard-untrust hook
+// runs off all registry locks and a hard untrust is rare, so a brief blocking,
+// retried delete is safe — and keeps "hard untrust always takes effect" durable
+// across a coordinator restart even through a transient DB blip. The backoff is a
+// var so tests can shorten it.
+const trustReuseDeleteAttempts = 3
+
+var trustReuseDeleteRetryBackoff = 200 * time.Millisecond
+
 // trustReuseStore is the minimal slice of store.Store the trust-reuse cache needs
 // to survive coordinator restarts/blue-green deploys (DAR-326 Phase 0). store.Store
 // satisfies it; tests can inject a fake. SECURITY: persistence is a performance
@@ -149,7 +167,10 @@ func (c *trustReuseCache) reuseTrust(seKey, serial, freshBinaryHash string) (tru
 	if !r.sipEnabled || !r.secureBootFull { // recorded posture must have been good (defensive)
 		return trustReuseRecord{}, false
 	}
-	if c.now().Sub(r.at) >= c.reuseWindow { // (d) freshness window
+	// (d) freshness window, with clock-skew tolerance: reject a record dated
+	// implausibly far in the FUTURE (corrupt/forged VerifiedAt) as well as an
+	// expired one.
+	if age := c.now().Sub(r.at); age < -clockSkewTolerance || age >= c.reuseWindow {
 		return trustReuseRecord{}, false
 	}
 	return r, true
@@ -170,7 +191,9 @@ func (c *trustReuseCache) hasFreshRecord(seKey, serial string) bool {
 	if !ok || r.serial != serial || r.trustLevel != string(registry.TrustHardware) {
 		return false
 	}
-	return c.now().Sub(r.at) < c.reuseWindow
+	// Fresh iff within the window and not implausibly future-dated (clock skew).
+	age := c.now().Sub(r.at)
+	return age >= -clockSkewTolerance && age < c.reuseWindow
 }
 
 // recordTrust updates the in-memory reuse record for a device after a successful
@@ -224,8 +247,8 @@ func (c *trustReuseCache) seed(rows []store.ProviderTrustReuse) int {
 		if r.SEPubKey == "" {
 			continue
 		}
-		if now.Sub(r.VerifiedAt) >= c.reuseWindow {
-			continue // already outside the reuse window — would never be reused
+		if age := now.Sub(r.VerifiedAt); age < -clockSkewTolerance || age >= c.reuseWindow {
+			continue // outside the reuse window, or implausibly future-dated — never reusable
 		}
 		if cur, ok := c.records[r.SEPubKey]; ok && !r.VerifiedAt.After(cur.at) {
 			continue // keep the fresher in-memory record
@@ -244,26 +267,36 @@ func (c *trustReuseCache) seed(rows []store.ProviderTrustReuse) int {
 	return n
 }
 
-// SeedTrustReuseCache wires the store into the trust-reuse cache, wires durable
-// invalidation on hard untrust, and seeds the cache from persisted records at
+// SeedTrustReuseCache wires durable invalidation on hard untrust, wires the store
+// into the trust-reuse cache, and seeds the cache from persisted records at
 // startup (DAR-326 Phase 0). This is what makes the reuse cache survive a
 // coordinator restart / blue-green deploy so a fresh instance does not re-run a
 // fleet-wide live MDM SecurityInfo + APNs verification. Safe to call once during
-// server setup, AFTER the store is set; a nil store or nil cache is a no-op.
-// SECURITY: seeding only repopulates the cache that reuseTrust re-validates (behind
-// a live SE challenge) on every read — it cannot grant hardware by itself, and a
-// stale/wrong-binary/expired row still falls through to a full live MDM verify.
+// server setup. The hard-untrust hook is wired UNCONDITIONALLY (independent of
+// store presence) so a hard untrust always drops the in-memory record even under
+// the memory-store fallback; persistence + startup seeding are skipped when no
+// store is wired. SECURITY: seeding only repopulates the cache that reuseTrust
+// re-validates (behind a live SE challenge) on every read — it cannot grant
+// hardware by itself, and a stale/wrong-binary/expired row still falls through to
+// a full live MDM verify.
 func (s *Server) SeedTrustReuseCache(ctx context.Context) {
-	if s == nil || s.trustReuseCache == nil || s.store == nil {
+	if s == nil || s.trustReuseCache == nil {
+		return
+	}
+	// Wire durable invalidation UNCONDITIONALLY — independent of store presence. A
+	// HARD untrust must always drop the in-memory record (and, when a store is
+	// wired, the persisted row too), so a hard-untrusted device cannot fast-skip on
+	// reconnect even under the memory-store fallback (FIX 5).
+	if s.registry != nil {
+		s.registry.SetHardUntrustHook(s.invalidateTrustReuse)
+	}
+	// Persistence + startup seeding require a store; the in-memory reuse cache works
+	// identically with or without one.
+	if s.store == nil {
 		return
 	}
 	// Wire the write-through path so future successful verifications are persisted.
 	s.trustReuseCache.store = s.store
-	// Wire durable invalidation: a HARD untrust must delete the persisted record so
-	// a coordinator restart cannot reseed and fast-skip on a stale, pre-untrust row.
-	if s.registry != nil {
-		s.registry.SetHardUntrustHook(s.invalidateTrustReuse)
-	}
 
 	rows, err := s.store.ListProviderTrustReuse(ctx)
 	if err != nil {
@@ -334,29 +367,53 @@ func (s *Server) persistTrustReuse(rec store.ProviderTrustReuse) {
 }
 
 // invalidateTrustReuse drops a device's reuse record in-memory AND deletes the
-// persisted row (off the read loop). Wired as the registry's hard-untrust hook, so
-// EVERY hard/security deroute (SIP off, Secure Boot off, binary/model-hash change,
-// MDM posture mismatch, serial impersonation, bad encrypted chunk, ...) makes
-// "hard untrust always takes effect" durable across restarts: the device cannot
-// fast-skip on a stale, pre-untrust record after a coordinator restart. No-op when
-// no store is wired (in-memory invalidation still applies). Mirrors
+// persisted row. Wired as the registry's hard-untrust hook, so EVERY hard/security
+// deroute (SIP off, Secure Boot off, binary/model-hash change, MDM posture
+// mismatch, serial impersonation, bad encrypted chunk, ...) makes "hard untrust
+// always takes effect" durable across restarts: the device cannot fast-skip on a
+// stale, pre-untrust record after a coordinator restart.
+//
+// DAR-326 FIX 1: the in-memory invalidation is synchronous and unconditional; the
+// persisted delete runs INLINE with a bounded retry (not fire-and-forget) so a
+// transient DB blip cannot silently leave a stale row that reseeds + fast-skips
+// after a restart. This is safe because the hook fires off ALL registry locks
+// (registry.markUntrusted) and a hard untrust is rare. No-op on the persisted leg
+// when no store is wired (in-memory invalidation still applies). Mirrors
 // Server.invalidatePersistedCodeAttestation.
 func (s *Server) invalidateTrustReuse(seKey string) {
 	if s == nil || s.trustReuseCache == nil || seKey == "" {
 		return
 	}
+	// Synchronous, unconditional in-memory invalidation: an immediate reconnect
+	// (no restart) must not fast-skip on the dropped record.
 	s.trustReuseCache.invalidateReuse(seKey)
 	st := s.trustReuseCache.store
 	if st == nil {
 		return
 	}
-	saferun.Go(s.logger, "invalidateTrustReuse", func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-		if err := st.DeleteProviderTrustReuse(ctx, seKey); err != nil {
-			s.logger.Warn("trust-reuse: failed to delete persisted reuse record on hard untrust", "error", err)
+	// Bounded inline retry of the persisted delete (FIX 1): keep "hard untrust
+	// takes effect" durable across a restart even through a transient DB error.
+	var err error
+	for attempt := 0; attempt < trustReuseDeleteAttempts; attempt++ {
+		if attempt > 0 {
+			time.Sleep(trustReuseDeleteRetryBackoff)
 		}
-	})
+		if err = deleteProviderTrustReuseOnce(st, seKey); err == nil {
+			return
+		}
+	}
+	// Log only after the final attempt fails (avoids alarming logs on a recovered
+	// transient blip).
+	s.logger.Warn("trust-reuse: failed to delete persisted reuse record on hard untrust after retries",
+		"error", err, "attempts", trustReuseDeleteAttempts)
+}
+
+// deleteProviderTrustReuseOnce runs one persisted-delete attempt with its own
+// bounded timeout (kept out of the retry loop to avoid a defer-in-loop).
+func deleteProviderTrustReuseOnce(st trustReuseStore, seKey string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	return st.DeleteProviderTrustReuse(ctx, seKey)
 }
 
 // tryTrustReuseFastSkip is the read-path gate + grant. It runs AFTER the live SE
@@ -426,6 +483,9 @@ func (s *Server) tryTrustReuseFastSkip(providerID string, provider *registry.Pro
 		return false
 	}
 	provider.SetMDMFailureReason("")
+	// The device is now hardware, so any connect-time ACME result stashed for a
+	// later retry is moot — drop it (FIX 5b), mirroring a normal hardware upgrade.
+	s.clearPendingACME(providerID)
 	s.sendTrustStatus(provider, registry.TrustHardware, "online", "trust-reuse fast-skip (recent MDM verification re-proven by live SE challenge)")
 	s.registry.PersistProvider(provider)
 	s.ddIncr("mdm.verification", []string{"outcome:granted-trust-reuse"})
@@ -440,11 +500,17 @@ func (s *Server) tryTrustReuseFastSkip(providerID string, provider *registry.Pro
 // awaitTrustReuseGrant lets the mdmVerificationLoop briefly defer to the live SE
 // challenge's trust-reuse fast-skip before running the (herd-causing) live MDM
 // round-trip. It returns true if hardware is granted within trustReuseGrantWait
-// (by the fast-skip, or the ACME leg), false otherwise (slow challenge / gate miss
-// / hard untrust / ctx done) — in which case the caller proceeds to the full live
-// MDM verify, unchanged. Only invoked for fast-skip candidates (hasFreshRecord),
-// so a first-ever / expired device is never delayed.
+// (by the fast-skip, or the ACME leg), false otherwise (challenge settled without
+// a grant / hard untrust / ctx done / timeout) — in which case the caller proceeds
+// to the full live MDM verify, unchanged. Only invoked for fast-skip candidates
+// (hasFreshRecord), so a first-ever / expired device is never delayed.
+//
+// DAR-326 FIX 3: the challenge-settled signal lets a candidate whose gates DON'T
+// pass proceed to the full live verify immediately instead of stalling the whole
+// trustReuseGrantWait — the timer is only the backstop for a slow/never-arriving
+// challenge.
 func (s *Server) awaitTrustReuseGrant(ctx context.Context, provider *registry.Provider) bool {
+	settled := provider.ChallengeSettledChan()
 	timer := time.NewTimer(trustReuseGrantWait)
 	defer timer.Stop()
 	ticker := time.NewTicker(trustReuseGrantPoll)
@@ -459,6 +525,11 @@ func (s *Server) awaitTrustReuseGrant(ctx context.Context, provider *registry.Pr
 		select {
 		case <-ctx.Done():
 			return false
+		case <-settled:
+			// The live challenge settled WITHOUT a fast-skip grant — stop waiting and
+			// fall through to the full live MDM verify now (no up-to-10s stall). Re-read
+			// trust in case the ACME leg granted in the same challenge pass.
+			return provider.GetTrustLevel() == registry.TrustHardware
 		case <-timer.C:
 			return provider.GetTrustLevel() == registry.TrustHardware
 		case <-ticker.C:

--- a/coordinator/api/trust_reuse_test.go
+++ b/coordinator/api/trust_reuse_test.go
@@ -2,7 +2,9 @@ package api
 
 import (
 	"context"
+	"fmt"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -11,6 +13,33 @@ import (
 	"github.com/eigeninference/d-inference/coordinator/registry"
 	"github.com/eigeninference/d-inference/coordinator/store"
 )
+
+// flakyDeleteStore wraps a real store and fails the first failFirst calls to
+// DeleteProviderTrustReuse, then delegates. Used to prove the inline bounded retry
+// in invalidateTrustReuse (DAR-326 FIX 1) ultimately deletes the persisted row.
+type flakyDeleteStore struct {
+	store.Store
+	mu          sync.Mutex
+	failFirst   int
+	deleteCalls int
+}
+
+func (f *flakyDeleteStore) DeleteProviderTrustReuse(ctx context.Context, seKey string) error {
+	f.mu.Lock()
+	f.deleteCalls++
+	n := f.deleteCalls
+	f.mu.Unlock()
+	if n <= f.failFirst {
+		return fmt.Errorf("simulated transient delete failure #%d", n)
+	}
+	return f.Store.DeleteProviderTrustReuse(ctx, seKey)
+}
+
+func (f *flakyDeleteStore) calls() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.deleteCalls
+}
 
 // Two distinct, valid 64-char SHA-256 hex digests for binary-hash gate tests.
 var (
@@ -65,6 +94,17 @@ func TestTrustReuseCacheReuseAndWindow(t *testing.T) {
 	}
 	if c.hasFreshRecord(se, serial) {
 		t.Fatal("candidate status must expire after the window")
+	}
+
+	// FIX 2 clock-skew guard: a record dated implausibly far in the FUTURE
+	// (corrupt/forged VerifiedAt) must be rejected, not treated as eternally fresh.
+	future := c.now().Add(c.reuseWindow + time.Minute)
+	c.recordTrust(hardwareReuseRecord(se, serial, trHashA, future))
+	if _, ok := c.reuseTrust(se, serial, trHashA); ok {
+		t.Fatal("a future-dated record (beyond skew tolerance) must not reuse")
+	}
+	if c.hasFreshRecord(se, serial) {
+		t.Fatal("a future-dated record must not be a candidate")
 	}
 }
 
@@ -141,8 +181,10 @@ func TestTrustReuseCacheSeed(t *testing.T) {
 	fresh := hardwareReuseRecord("se-fresh", "SER-F", trHashA, cur.Add(-time.Minute))
 	expired := hardwareReuseRecord("se-old", "SER-O", trHashA, cur.Add(-2*c.reuseWindow))
 	empty := hardwareReuseRecord("", "SER-E", trHashA, cur)
+	// FIX 2: a future-dated row (beyond skew tolerance) must be skipped on seed too.
+	future := hardwareReuseRecord("se-future", "SER-FU", trHashA, cur.Add(c.reuseWindow+time.Minute))
 
-	if n := c.seed([]store.ProviderTrustReuse{fresh, expired, empty}); n != 1 {
+	if n := c.seed([]store.ProviderTrustReuse{fresh, expired, empty, future}); n != 1 {
 		t.Fatalf("seed count = %d, want 1 (only the in-window keyed row)", n)
 	}
 	if _, ok := c.reuseTrust("se-fresh", "SER-F", trHashA); !ok {
@@ -150,6 +192,9 @@ func TestTrustReuseCacheSeed(t *testing.T) {
 	}
 	if c.hasFreshRecord("se-old", "SER-O") {
 		t.Fatal("expired row must not be seeded")
+	}
+	if c.hasFreshRecord("se-future", "SER-FU") {
+		t.Fatal("future-dated row must not be seeded (clock-skew guard)")
 	}
 
 	// A newer in-memory record must not be clobbered by an older persisted row.
@@ -225,8 +270,9 @@ func TestRecordTrustReusePersists(t *testing.T) {
 }
 
 // TestInvalidateTrustReuseDeletesPersisted proves the hard-untrust invalidation
-// removes the record both in-memory and from the store (durable across restarts),
-// and that wiring the registry hook fires it on a real hard untrust.
+// removes the record both in-memory and from the store SYNCHRONOUSLY (FIX 1: the
+// persisted delete is inline now, not fire-and-forget), and that wiring the
+// registry hook fires it on a real hard untrust.
 func TestInvalidateTrustReuseDeletesPersisted(t *testing.T) {
 	srv, st := trustReuseServer(t)
 	srv.SeedTrustReuseCache(context.Background()) // wires store + hard-untrust hook
@@ -241,14 +287,14 @@ func TestInvalidateTrustReuseDeletesPersisted(t *testing.T) {
 	if _, ok := srv.trustReuseCache.reuseTrust("se-z", "SER-Z", trHashA); ok {
 		t.Fatal("invalidate must drop the in-memory record")
 	}
-	if !waitForCond(2*time.Second, func() bool {
-		rows, _ := st.ListProviderTrustReuse(context.Background())
-		return len(rows) == 0
-	}) {
-		t.Fatal("invalidate must delete the persisted record")
+	// Inline delete → row gone as soon as invalidateTrustReuse returns (no polling).
+	if rows, _ := st.ListProviderTrustReuse(context.Background()); len(rows) != 0 {
+		t.Fatalf("invalidate must delete the persisted record synchronously, got %d rows", len(rows))
 	}
 
-	// The registry hard-untrust hook must invalidate on a real hard untrust.
+	// The registry hard-untrust hook must invalidate on a real hard untrust. The
+	// hook fires synchronously off all registry locks, and the in-memory + inline
+	// persisted delete are both synchronous, so no polling is needed.
 	msg := &protocol.RegisterMessage{
 		Type: protocol.TypeRegister, Backend: "mlx-swift", PublicKey: testPublicKeyB64(),
 		Models: []protocol.ModelInfo{{ID: "m", ModelType: "chat", Quantization: "4bit"}},
@@ -261,10 +307,83 @@ func TestInvalidateTrustReuseDeletesPersisted(t *testing.T) {
 
 	srv.registry.MarkUntrusted("prov-hook") // hard untrust → hook fires
 
-	if !waitForCond(2*time.Second, func() bool {
-		return !srv.trustReuseCache.hasFreshRecord("se-hook", "SER-H")
-	}) {
+	if srv.trustReuseCache.hasFreshRecord("se-hook", "SER-H") {
 		t.Fatal("a hard untrust must invalidate the device's trust-reuse record (durable hard-untrust)")
+	}
+}
+
+// TestInvalidateTrustReuseRetriesPersistedDelete proves FIX 1's bounded inline
+// retry: a transient store-delete failure is retried, and the persisted row is
+// ultimately removed (so a restart cannot reseed it).
+func TestInvalidateTrustReuseRetriesPersistedDelete(t *testing.T) {
+	old := trustReuseDeleteRetryBackoff
+	trustReuseDeleteRetryBackoff = time.Millisecond // keep the test fast
+	defer func() { trustReuseDeleteRetryBackoff = old }()
+
+	srv, _ := trustReuseServer(t)
+	mem := store.NewMemory(store.Config{})
+	flaky := &flakyDeleteStore{Store: mem, failFirst: 2} // fail twice, succeed on the 3rd
+	srv.trustReuseCache.store = flaky
+
+	rec := hardwareReuseRecord("se-retry", "SER-RT", trHashA, time.Now())
+	srv.trustReuseCache.recordTrust(rec)
+	if err := mem.UpsertProviderTrustReuse(context.Background(), rec); err != nil {
+		t.Fatalf("seed store: %v", err)
+	}
+
+	srv.invalidateTrustReuse("se-retry")
+
+	if srv.trustReuseCache.hasFreshRecord("se-retry", "SER-RT") {
+		t.Fatal("in-memory record must be dropped synchronously")
+	}
+	if got := flaky.calls(); got != 3 {
+		t.Fatalf("delete attempts = %d, want 3 (2 failures then success)", got)
+	}
+	if rows, _ := mem.ListProviderTrustReuse(context.Background()); len(rows) != 0 {
+		t.Fatalf("persisted row must be deleted after retries, got %d rows", len(rows))
+	}
+}
+
+// TestInvalidateTrustReuseDurableAcrossRestart proves FIX 1's durability goal: a
+// hard untrust (via the registry hook) deletes the persisted row, so a simulated
+// restart that seeds a FRESH cache from the SAME store finds nothing — the
+// device cannot fast-skip after a restart on a stale, pre-untrust record.
+func TestInvalidateTrustReuseDurableAcrossRestart(t *testing.T) {
+	srv, st := trustReuseServer(t)
+	srv.SeedTrustReuseCache(context.Background()) // wires store + hook
+
+	msg := &protocol.RegisterMessage{
+		Type: protocol.TypeRegister, Backend: "mlx-swift", PublicKey: testPublicKeyB64(),
+		Models: []protocol.ModelInfo{{ID: "m", ModelType: "chat", Quantization: "4bit"}},
+	}
+	p := srv.registry.Register("prov-dur", nil, msg)
+	p.Mu().Lock()
+	p.AttestationResult = &attestation.VerificationResult{Valid: true, SerialNumber: "SER-DUR", PublicKey: "se-dur"}
+	p.Mu().Unlock()
+
+	srv.recordTrustReuse("se-dur", "SER-DUR", trHashA, true, true, "udid-dur")
+	// recordTrustReuse persists via saferun.Go — wait for it before untrusting so
+	// the delete cannot race ahead of the write-through.
+	if !waitForCond(2*time.Second, func() bool {
+		rows, _ := st.ListProviderTrustReuse(context.Background())
+		return len(rows) == 1
+	}) {
+		t.Fatal("precondition: record must be persisted")
+	}
+
+	srv.registry.MarkUntrusted("prov-dur") // hard untrust → hook → synchronous persisted delete
+
+	// "Restart": a FRESH cache seeded from the SAME store must find nothing.
+	fresh := newTrustReuseCache()
+	rows, err := st.ListProviderTrustReuse(context.Background())
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if n := fresh.seed(rows); n != 0 {
+		t.Fatalf("seeded %d records after a hard untrust; want 0 (durable invalidation)", n)
+	}
+	if fresh.hasFreshRecord("se-dur", "SER-DUR") {
+		t.Fatal("a hard-untrusted device must not be reusable after a restart reseed")
 	}
 }
 
@@ -344,6 +463,26 @@ func TestTrustReuseFastSkipFallsThrough(t *testing.T) {
 			},
 		},
 		{
+			name:        "serial mismatch",
+			seedRecord:  false, // custom seed below
+			statusTrust: true,
+			mutate: func(_ *registry.Provider, _ *protocol.AttestationResponseMessage, _ *func() time.Time, c *trustReuseCache) {
+				// Record keyed by the right SE key but a DIFFERENT serial than the
+				// attestation ("SERIAL-1") → identity gate (a) fails.
+				c.recordTrust(hardwareReuseRecord("se-pub-key-bytes", "SERIAL-2", trHashA, c.now()))
+			},
+		},
+		{
+			name:        "SE key mismatch",
+			seedRecord:  false, // custom seed below
+			statusTrust: true,
+			mutate: func(_ *registry.Provider, _ *protocol.AttestationResponseMessage, _ *func() time.Time, c *trustReuseCache) {
+				// Record under a DIFFERENT SE key than the attestation's
+				// ("se-pub-key-bytes") → lookup finds nothing → falls through.
+				c.recordTrust(hardwareReuseRecord("other-se-key", "SERIAL-1", trHashA, c.now()))
+			},
+		},
+		{
 			name:        "status fields not signed",
 			seedRecord:  true,
 			statusTrust: false, // statusFieldsTrusted=false → posture advisory, never trusted
@@ -419,5 +558,71 @@ func TestTrustReuseFastSkipFallsThrough(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// --- FIX 3: awaitTrustReuseGrant fast-path on the challenge-settled signal ---
+
+// TestAwaitTrustReuseGrantReturnsOnSettledSignal proves FIX 3: when the live
+// challenge settles WITHOUT a fast-skip grant, the settled signal makes
+// awaitTrustReuseGrant return promptly (false) instead of stalling the full
+// trustReuseGrantWait — so a non-fast-skip candidate proceeds to the full live MDM
+// verify without an up-to-10s delay.
+func TestAwaitTrustReuseGrantReturnsOnSettledSignal(t *testing.T) {
+	srv, p, _ := trustReuseFastSkipProvider(t)
+
+	// Mimic verifyChallengeResponse firing the signal after the fast-skip declined.
+	p.SignalChallengeSettled()
+
+	start := time.Now()
+	if srv.awaitTrustReuseGrant(context.Background(), p) {
+		t.Fatal("awaitTrustReuseGrant must return false when the challenge settled without a grant")
+	}
+	if elapsed := time.Since(start); elapsed >= trustReuseGrantWait {
+		t.Fatalf("settled signal must return well under the wait; took %s (>= %s)", elapsed, trustReuseGrantWait)
+	}
+}
+
+// TestAwaitTrustReuseGrantReturnsTrueOnHardware proves the success path: once the
+// fast-skip (or ACME) grants hardware, awaitTrustReuseGrant returns true so the
+// mdmVerificationLoop skips the live MDM round-trip.
+func TestAwaitTrustReuseGrantReturnsTrueOnHardware(t *testing.T) {
+	srv, p, _ := trustReuseFastSkipProvider(t)
+	if !p.GrantHardwareIfNotUntrusted() {
+		t.Fatal("precondition: grant should succeed")
+	}
+	if !srv.awaitTrustReuseGrant(context.Background(), p) {
+		t.Fatal("awaitTrustReuseGrant must return true once hardware is granted")
+	}
+}
+
+// --- FIX 5: hard-untrust hook is wired independent of store presence ---
+
+// TestSeedTrustReuseCacheWiresHookWithoutStore proves FIX 5: SeedTrustReuseCache
+// wires the hard-untrust invalidation hook even when no store is available for
+// persistence/seeding, so a hard untrust still drops the in-memory record (under
+// the memory-store fallback the in-memory cache must stay correct).
+func TestSeedTrustReuseCacheWiresHookWithoutStore(t *testing.T) {
+	logger := quietLogger()
+	srv := NewServer(registry.New(logger), store.NewMemory(store.Config{}), ServerConfig{}, logger)
+	// Simulate "no store wired for persistence/seeding". The hook must STILL be
+	// wired (decoupled from the store) by SeedTrustReuseCache.
+	srv.store = nil
+	srv.SeedTrustReuseCache(context.Background())
+
+	msg := &protocol.RegisterMessage{
+		Type: protocol.TypeRegister, Backend: "mlx-swift", PublicKey: testPublicKeyB64(),
+		Models: []protocol.ModelInfo{{ID: "m", ModelType: "chat", Quantization: "4bit"}},
+	}
+	p := srv.registry.Register("prov-nostore", nil, msg)
+	p.Mu().Lock()
+	p.AttestationResult = &attestation.VerificationResult{Valid: true, SerialNumber: "SER-NS", PublicKey: "se-nostore"}
+	p.Mu().Unlock()
+	srv.trustReuseCache.recordTrust(hardwareReuseRecord("se-nostore", "SER-NS", trHashA, time.Now()))
+
+	srv.registry.MarkUntrusted("prov-nostore") // hard untrust → hook must fire even w/o store
+
+	if srv.trustReuseCache.hasFreshRecord("se-nostore", "SER-NS") {
+		t.Fatal("hard untrust must invalidate the in-memory record even with no store wired (FIX 5 decoupling)")
 	}
 }

--- a/coordinator/api/trust_reuse_test.go
+++ b/coordinator/api/trust_reuse_test.go
@@ -9,10 +9,18 @@ import (
 	"time"
 
 	"github.com/eigeninference/d-inference/coordinator/attestation"
+	"github.com/eigeninference/d-inference/coordinator/mdm"
 	"github.com/eigeninference/d-inference/coordinator/protocol"
 	"github.com/eigeninference/d-inference/coordinator/registry"
 	"github.com/eigeninference/d-inference/coordinator/store"
 )
+
+// dummyMDMClient returns a non-nil *mdm.Client (no network at construction) so
+// tryTrustReuseFastSkip's "MDM configured" gate (FIX C) is satisfied in unit tests
+// that don't stand up a fake MicroMDM server.
+func dummyMDMClient() *mdm.Client {
+	return mdm.NewClient("http://127.0.0.1:1", "test", quietLogger())
+}
 
 // flakyDeleteStore wraps a real store and fails the first failFirst calls to
 // DeleteProviderTrustReuse, then delegates. Used to prove the inline bounded retry
@@ -232,6 +240,22 @@ func trustReuseServer(t *testing.T) (*Server, store.Store) {
 	return srv, st
 }
 
+// newTrustReuseProvider registers a fresh, online (not-untrusted, epoch 0) provider
+// with the given SE key + serial, for exercising recordTrustReuse's epoch-checked
+// write-through (FIX A) and the late-SecurityInfo path (FIX B).
+func newTrustReuseProvider(t *testing.T, srv *Server, id, seKey, serial string) *registry.Provider {
+	t.Helper()
+	msg := &protocol.RegisterMessage{
+		Type: protocol.TypeRegister, Backend: "mlx-swift", PublicKey: testPublicKeyB64(),
+		Models: []protocol.ModelInfo{{ID: "m", ModelType: "chat", Quantization: "4bit"}},
+	}
+	p := srv.registry.Register(id, nil, msg)
+	p.Mu().Lock()
+	p.AttestationResult = &attestation.VerificationResult{Valid: true, SerialNumber: serial, PublicKey: seKey}
+	p.Mu().Unlock()
+	return p
+}
+
 // TestTrustReuseSeedFromStore proves SeedTrustReuseCache repopulates the in-memory
 // cache from persisted rows at startup (survives a coordinator restart/deploy).
 func TestTrustReuseSeedFromStore(t *testing.T) {
@@ -246,24 +270,25 @@ func TestTrustReuseSeedFromStore(t *testing.T) {
 	}
 }
 
-// TestRecordTrustReusePersists proves the write-through reaches the store, so a
-// simulated restart (fresh cache seeded from the store) can fast-skip.
+// TestRecordTrustReusePersists proves the write-through reaches the store
+// SYNCHRONOUSLY (FIX A), so a simulated restart (fresh cache seeded from the store)
+// can fast-skip.
 func TestRecordTrustReusePersists(t *testing.T) {
 	srv, st := trustReuseServer(t)
 	srv.SeedTrustReuseCache(context.Background()) // wires the store (empty seed)
+	p := newTrustReuseProvider(t, srv, "prov-y", "se-y", "SER-Y")
 
-	srv.recordTrustReuse("se-y", "SER-Y", trHashA, true, true, "UDID-Y")
+	srv.recordTrustReuse(p, "se-y", "SER-Y", trHashA, true, true, "UDID-Y")
 
-	// Write-through is async (saferun.Go); poll the store.
-	if !waitForCond(2*time.Second, func() bool {
-		rows, _ := st.ListProviderTrustReuse(context.Background())
-		return len(rows) == 1 && rows[0].SEPubKey == "se-y" && rows[0].BinaryHash == trHashA
-	}) {
-		t.Fatal("recordTrustReuse must persist the record to the store")
+	// Write-through is now synchronous — the row is present as soon as it returns.
+	rows, _ := st.ListProviderTrustReuse(context.Background())
+	if len(rows) != 1 || rows[0].SEPubKey != "se-y" || rows[0].BinaryHash != trHashA {
+		t.Fatalf("recordTrustReuse must persist the record synchronously, got %+v", rows)
 	}
 
 	// A record with no usable binary hash is NOT cached (read gate requires a match).
-	srv.recordTrustReuse("se-nohash", "SER-N", "not-a-hash", true, true, "UDID-N")
+	p2 := newTrustReuseProvider(t, srv, "prov-nohash", "se-nohash", "SER-N")
+	srv.recordTrustReuse(p2, "se-nohash", "SER-N", "not-a-hash", true, true, "UDID-N")
 	if _, ok := srv.trustReuseCache.reuseTrust("se-nohash", "SER-N", trHashA); ok {
 		t.Fatal("a record with an unusable binary hash must not be cached/reusable")
 	}
@@ -361,14 +386,11 @@ func TestInvalidateTrustReuseDurableAcrossRestart(t *testing.T) {
 	p.AttestationResult = &attestation.VerificationResult{Valid: true, SerialNumber: "SER-DUR", PublicKey: "se-dur"}
 	p.Mu().Unlock()
 
-	srv.recordTrustReuse("se-dur", "SER-DUR", trHashA, true, true, "udid-dur")
-	// recordTrustReuse persists via saferun.Go — wait for it before untrusting so
-	// the delete cannot race ahead of the write-through.
-	if !waitForCond(2*time.Second, func() bool {
-		rows, _ := st.ListProviderTrustReuse(context.Background())
-		return len(rows) == 1
-	}) {
-		t.Fatal("precondition: record must be persisted")
+	// Synchronous, epoch-checked write-through (FIX A): the row is persisted before
+	// this returns.
+	srv.recordTrustReuse(p, "se-dur", "SER-DUR", trHashA, true, true, "udid-dur")
+	if rows, _ := st.ListProviderTrustReuse(context.Background()); len(rows) != 1 {
+		t.Fatalf("precondition: record must be persisted, got %d rows", len(rows))
 	}
 
 	srv.registry.MarkUntrusted("prov-dur") // hard untrust → hook → synchronous persisted delete
@@ -396,6 +418,7 @@ func trustReuseFastSkipProvider(t *testing.T) (*Server, *registry.Provider, *fun
 	t.Helper()
 	logger := quietLogger()
 	srv := NewServer(registry.New(logger), store.NewMemory(store.Config{}), ServerConfig{}, logger)
+	srv.mdmClient = dummyMDMClient() // satisfy the FIX C "MDM configured" gate
 	cur := time.Unix(1_700_000_000, 0)
 	clock := func() time.Time { return cur }
 	srv.trustReuseCache.now = clock
@@ -624,5 +647,127 @@ func TestSeedTrustReuseCacheWiresHookWithoutStore(t *testing.T) {
 
 	if srv.trustReuseCache.hasFreshRecord("se-nostore", "SER-NS") {
 		t.Fatal("hard untrust must invalidate the in-memory record even with no store wired (FIX 5 decoupling)")
+	}
+}
+
+// --- FIX A: durable hard-untrust epoch (close the write-after-delete race) ---
+
+// TestRecordTrustReuseSkipsPersistAfterHardUntrust proves FIX A ordering B: a hard
+// untrust that has landed by the time recordTrustReuse does its pre-upsert recheck
+// (epoch bumped + provider hard-untrusted) makes it persist NOTHING and keep no
+// in-memory entry — so a synchronous write can never resurrect a row the untrust's
+// synchronous delete already removed.
+func TestRecordTrustReuseSkipsPersistAfterHardUntrust(t *testing.T) {
+	srv, st := trustReuseServer(t)
+	srv.SeedTrustReuseCache(context.Background())
+	p := newTrustReuseProvider(t, srv, "prov-epoch", "se-epoch", "SER-EP")
+
+	epochBefore := p.HardUntrustEpoch()
+	srv.registry.MarkUntrusted("prov-epoch") // bumps the epoch + sets Status=Untrusted
+	if p.HardUntrustEpoch() == epochBefore {
+		t.Fatal("a hard untrust must bump the provider's hard-untrust epoch")
+	}
+
+	// The grant's write-through arrives AFTER the untrust — it must be refused.
+	srv.recordTrustReuse(p, "se-epoch", "SER-EP", trHashA, true, true, "udid")
+
+	if rows, _ := st.ListProviderTrustReuse(context.Background()); len(rows) != 0 {
+		t.Fatalf("must NOT persist a record after a hard untrust, got %d rows", len(rows))
+	}
+	if srv.trustReuseCache.hasFreshRecord("se-epoch", "SER-EP") {
+		t.Fatal("must NOT keep an in-memory record after a hard untrust")
+	}
+}
+
+// TestRecordTrustReuseDurableBothOrderings proves FIX A's durability goal in both
+// orderings: whether the hard untrust lands AFTER the record (ordering A: the
+// untrust's synchronous delete removes the persisted row) or BEFORE the record
+// completes (ordering B: the epoch recheck refuses to persist), a fresh cache
+// seeded from the SAME store after a simulated restart finds no record.
+func TestRecordTrustReuseDurableBothOrderings(t *testing.T) {
+	seedFromStore := func(t *testing.T, st store.Store) int {
+		t.Helper()
+		rows, err := st.ListProviderTrustReuse(context.Background())
+		if err != nil {
+			t.Fatalf("list: %v", err)
+		}
+		return newTrustReuseCache().seed(rows)
+	}
+
+	t.Run("ordering A: record then untrust", func(t *testing.T) {
+		srv, st := trustReuseServer(t)
+		srv.SeedTrustReuseCache(context.Background())
+		p := newTrustReuseProvider(t, srv, "prov-a", "se-a", "SER-A")
+
+		srv.recordTrustReuse(p, "se-a", "SER-A", trHashA, true, true, "udid")
+		if rows, _ := st.ListProviderTrustReuse(context.Background()); len(rows) != 1 {
+			t.Fatalf("record must be persisted first, got %d rows", len(rows))
+		}
+		srv.registry.MarkUntrusted("prov-a") // hook → synchronous delete
+		if n := seedFromStore(t, st); n != 0 {
+			t.Fatalf("ordering A: restart reseed = %d, want 0", n)
+		}
+	})
+
+	t.Run("ordering B: untrust then record", func(t *testing.T) {
+		srv, st := trustReuseServer(t)
+		srv.SeedTrustReuseCache(context.Background())
+		p := newTrustReuseProvider(t, srv, "prov-b", "se-b", "SER-B")
+
+		srv.registry.MarkUntrusted("prov-b") // epoch bumped + delete (no row yet)
+		srv.recordTrustReuse(p, "se-b", "SER-B", trHashA, true, true, "udid")
+		if n := seedFromStore(t, st); n != 0 {
+			t.Fatalf("ordering B: restart reseed = %d, want 0", n)
+		}
+	})
+}
+
+// --- FIX B: late-SecurityInfo grants are cached too ---
+
+// TestApplyLateSecurityInfoCachesReuse proves FIX B: a self_signed→hardware upgrade
+// via a late SecurityInfo persists a trust-reuse record (same epoch-checked
+// write-through as the synchronous MDM path) so it gets restart-survivable
+// fast-skip.
+func TestApplyLateSecurityInfoCachesReuse(t *testing.T) {
+	fake := &fakeMDMServer{device: &mdm.DeviceInfo{SerialNumber: "SERIAL-1", UDID: "UDID-1", EnrollmentStatus: true}}
+	srv, p := mdmReliabilityServer(t, fake)
+	srv.SeedTrustReuseCache(context.Background()) // wire store + hook
+	// Give the provider a usable signed binary hash so the reuse record can bind.
+	p.Mu().Lock()
+	p.AttestationResult.BinaryHash = trHashA
+	p.Mu().Unlock()
+
+	srv.ApplyLateSecurityInfo("UDID-1", &mdm.SecurityInfoResponse{
+		SystemIntegrityProtectionEnabled: true,
+		SecureBootLevel:                  "full",
+	})
+
+	if lvl := p.GetTrustLevel(); lvl != registry.TrustHardware {
+		t.Fatalf("late SecurityInfo must upgrade to hardware, got %q", lvl)
+	}
+	if _, ok := srv.trustReuseCache.reuseTrust("se-pub-key-bytes", "SERIAL-1", trHashA); !ok {
+		t.Fatal("late SecurityInfo grant must cache a reusable trust-reuse record (FIX B)")
+	}
+	if rows, _ := srv.store.ListProviderTrustReuse(context.Background()); len(rows) != 1 {
+		t.Fatalf("late grant must persist exactly one reuse row, got %d", len(rows))
+	}
+}
+
+// --- FIX C: fast-skip requires a configured MDM client ---
+
+// TestTrustReuseFastSkipRequiresMDMConfigured proves FIX C: with a valid fresh
+// record and all other gates passing, a nil mdmClient (no-MDM / misconfigured
+// deploy) makes the fast-skip decline so hardware is never granted from cache with
+// no live MDM fallback.
+func TestTrustReuseFastSkipRequiresMDMConfigured(t *testing.T) {
+	srv, p, _ := trustReuseFastSkipProvider(t)
+	srv.mdmClient = nil // no MDM configured
+	srv.trustReuseCache.recordTrust(hardwareReuseRecord("se-pub-key-bytes", "SERIAL-1", trHashA, srv.trustReuseCache.now()))
+
+	if srv.tryTrustReuseFastSkip("prov-fs", p, goodFastSkipResp(), true) {
+		t.Fatal("fast-skip must NOT grant when no MDM client is configured (no live fallback)")
+	}
+	if lvl := p.GetTrustLevel(); lvl != registry.TrustSelfSigned {
+		t.Fatalf("provider must stay self_signed, got %q", lvl)
 	}
 }

--- a/coordinator/api/trust_reuse_test.go
+++ b/coordinator/api/trust_reuse_test.go
@@ -49,6 +49,22 @@ func (f *flakyDeleteStore) calls() int {
 	return f.deleteCalls
 }
 
+// upsertHookStore wraps a real store and runs onUpsert just BEFORE delegating the
+// reuse-record upsert. It deterministically injects a hard untrust into the
+// check-then-write window (between recordTrustReuse's pre-write epoch check and the
+// upsert committing) to exercise the FIX 2 post-write recheck.
+type upsertHookStore struct {
+	store.Store
+	onUpsert func()
+}
+
+func (s *upsertHookStore) UpsertProviderTrustReuse(ctx context.Context, rec store.ProviderTrustReuse) error {
+	if s.onUpsert != nil {
+		s.onUpsert()
+	}
+	return s.Store.UpsertProviderTrustReuse(ctx, rec)
+}
+
 // Two distinct, valid 64-char SHA-256 hex digests for binary-hash gate tests.
 var (
 	trHashA = strings.Repeat("a", 64)
@@ -769,5 +785,287 @@ func TestTrustReuseFastSkipRequiresMDMConfigured(t *testing.T) {
 	}
 	if lvl := p.GetTrustLevel(); lvl != registry.TrustSelfSigned {
 		t.Fatalf("provider must stay self_signed, got %q", lvl)
+	}
+}
+
+// --- Round 2 FIX 1: empty-seKey / empty-binaryHash guard ---
+
+// TestRecordTrustReuseRejectsEmptyInputs proves FIX 1: recordTrustReuse is a hard
+// no-op for an empty seKey or empty binaryHash — no in-memory entry, no persisted
+// row (an empty-key row would poison the cache/store; an empty binary hash can
+// never satisfy the read gate).
+func TestRecordTrustReuseRejectsEmptyInputs(t *testing.T) {
+	srv, st := trustReuseServer(t)
+	srv.SeedTrustReuseCache(context.Background())
+	p := newTrustReuseProvider(t, srv, "prov-empty", "se-empty", "SER-E")
+
+	srv.recordTrustReuse(p, "", "SER-E", trHashA, true, true, "udid")    // empty seKey
+	srv.recordTrustReuse(p, "se-empty", "SER-E", "", true, true, "udid") // empty binaryHash
+
+	if srv.trustReuseCache.hasFreshRecord("se-empty", "SER-E") {
+		t.Fatal("empty seKey/binaryHash must not record in-memory")
+	}
+	if rows, _ := st.ListProviderTrustReuse(context.Background()); len(rows) != 0 {
+		t.Fatalf("empty seKey/binaryHash must not persist, got %d rows", len(rows))
+	}
+}
+
+// TestApplyLateSecurityInfoSkipsWhenNoBinaryHash proves FIX 1's ApplyLateSecurityInfo
+// guard: a late grant for a provider whose SE attestation carries no binary hash
+// upgrades trust but caches NO reuse record (rather than a dead/unbindable row).
+func TestApplyLateSecurityInfoSkipsWhenNoBinaryHash(t *testing.T) {
+	fake := &fakeMDMServer{device: &mdm.DeviceInfo{SerialNumber: "SERIAL-1", UDID: "UDID-1", EnrollmentStatus: true}}
+	srv, p := mdmReliabilityServer(t, fake)
+	srv.SeedTrustReuseCache(context.Background())
+	// mdmReliabilityServer leaves AttestationResult.BinaryHash empty.
+
+	srv.ApplyLateSecurityInfo("UDID-1", &mdm.SecurityInfoResponse{
+		SystemIntegrityProtectionEnabled: true,
+		SecureBootLevel:                  "full",
+	})
+
+	if lvl := p.GetTrustLevel(); lvl != registry.TrustHardware {
+		t.Fatalf("late SecurityInfo must still upgrade to hardware, got %q", lvl)
+	}
+	if rows, _ := srv.store.ListProviderTrustReuse(context.Background()); len(rows) != 0 {
+		t.Fatalf("no reuse record may be cached without a binary hash, got %d rows", len(rows))
+	}
+}
+
+// --- Round 2 FIX 2: post-write epoch recheck (check-then-write TOCTOU) ---
+
+// TestRecordTrustReusePostWriteRecheckDeletesOnRacedUntrust proves FIX 2: a hard
+// untrust landing in the window between the pre-write epoch check and the upsert
+// committing is caught by the POST-write recheck, which deletes the just-written
+// row and drops the in-memory entry — so nothing reseeds on a restart.
+func TestRecordTrustReusePostWriteRecheckDeletesOnRacedUntrust(t *testing.T) {
+	srv, _ := trustReuseServer(t)
+	mem := store.NewMemory(store.Config{})
+	p := newTrustReuseProvider(t, srv, "prov-toctou", "se-tt", "SER-TT")
+
+	// Inject the hard untrust exactly during the upsert (i.e. after the pre-write
+	// check passed, before/at the write committing).
+	hooked := &upsertHookStore{Store: mem, onUpsert: func() {
+		srv.registry.MarkUntrusted("prov-toctou")
+	}}
+	srv.trustReuseCache.store = hooked
+
+	srv.recordTrustReuse(p, "se-tt", "SER-TT", trHashA, true, true, "udid")
+
+	// The post-write recheck must have deleted the row it wrote under the race.
+	if rows, _ := mem.ListProviderTrustReuse(context.Background()); len(rows) != 0 {
+		t.Fatalf("post-write recheck must delete the row written under a racing untrust, got %d rows", len(rows))
+	}
+	if srv.trustReuseCache.hasFreshRecord("se-tt", "SER-TT") {
+		t.Fatal("post-write recheck must drop the in-memory entry")
+	}
+	// A fresh cache seeded from the same store (simulated restart) finds nothing.
+	if n := newTrustReuseCache().seed(mustList(t, mem)); n != 0 {
+		t.Fatalf("restart reseed = %d, want 0 (durable untrust)", n)
+	}
+}
+
+func mustList(t *testing.T, st store.Store) []store.ProviderTrustReuse {
+	t.Helper()
+	rows, err := st.ListProviderTrustReuse(context.Background())
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	return rows
+}
+
+// --- Round 2 FIX 4a: reconcile ACME after a fast-skip grant ---
+
+// TestReconcileACMEAfterFastSkipClearsUnboundFlag proves FIX 4a: when an MDM-reuse
+// fast-skip grants hardware while a connect-time ACME cert is stashed but never
+// bound (its SE-key binding can't complete), the unbound, unvalidated ACMEVerified
+// flag is cleared and the stale pending result discarded — so the attestation
+// report does not falsely claim acme_verified.
+func TestReconcileACMEAfterFastSkipClearsUnboundFlag(t *testing.T) {
+	srv, _ := trustReuseServer(t)
+	p := newTrustReuseProvider(t, srv, "prov-acme", "se-acme", "SER-AC")
+	// AttestationResult has no EncryptionPublicKey, so the ACME SE-key binding can
+	// never complete on retry (providerHasBoundEncryptionAttestation is false).
+	p.Mu().Lock()
+	p.ACMEVerified = true // optimistically set by applyACMETrust before binding
+	p.Mu().Unlock()
+	s := srv
+	s.stashPendingACME("prov-acme", &ACMEVerificationResult{Valid: true, SerialNumber: "SER-AC"})
+
+	s.reconcileACMEAfterFastSkip("prov-acme", p)
+
+	p.Mu().Lock()
+	acme := p.ACMEVerified
+	p.Mu().Unlock()
+	if acme {
+		t.Fatal("an unbound ACME result must not leave ACMEVerified=true after a fast-skip grant")
+	}
+	if s.hasPendingACME("prov-acme") {
+		t.Fatal("the stale unbound pending ACME result must be discarded")
+	}
+}
+
+// TestReconcileACMEAfterFastSkipNoPendingIsNoop proves reconcile is a no-op when no
+// ACME was stashed (so a genuinely-bound-and-granted ACME flag is left intact).
+func TestReconcileACMEAfterFastSkipNoPendingIsNoop(t *testing.T) {
+	srv, _ := trustReuseServer(t)
+	p := newTrustReuseProvider(t, srv, "prov-acme2", "se-acme2", "SER-AC2")
+	p.Mu().Lock()
+	p.ACMEVerified = true // simulate an already-bound+granted ACME
+	p.Mu().Unlock()
+
+	srv.reconcileACMEAfterFastSkip("prov-acme2", p)
+
+	p.Mu().Lock()
+	acme := p.ACMEVerified
+	p.Mu().Unlock()
+	if !acme {
+		t.Fatal("reconcile must not clear ACMEVerified when nothing is stashed (already bound)")
+	}
+}
+
+// --- Round 2 FIX 3 / FIX 4b: verifyChallengeResponse wiring (drain + ACME/signal) ---
+
+// fastSkipChallengeResp builds a fully-signed challenge response (challenge sig +
+// status sig so statusFieldsTrusted=true) that satisfies the fast-skip posture +
+// binary gates for a provider registered with createTestAttestationJSONWithBinaryHash.
+func fastSkipChallengeResp(t *testing.T, nonce, ts, pubKey, binHash string) *protocol.AttestationResponseMessage {
+	t.Helper()
+	sip, sb, rdma := true, true, true
+	resp := &protocol.AttestationResponseMessage{
+		Type:              protocol.TypeAttestationResponse,
+		Nonce:             nonce,
+		Signature:         testChallengeSignature(nonce, ts, pubKey),
+		PublicKey:         pubKey,
+		SIPEnabled:        &sip,
+		SecureBootEnabled: &sb,
+		RDMADisabled:      &rdma,
+		BinaryHash:        binHash,
+	}
+	resp.StatusSignature = testStatusSignature(t, attestation.StatusCanonicalInput{
+		Nonce: nonce, Timestamp: ts, RDMADisabled: &rdma,
+		SIPEnabled: &sip, SecureBootEnabled: &sb, BinaryHash: binHash,
+	}, pubKey)
+	return resp
+}
+
+// TestVerifyChallengeFastSkipGrantDrainsQueue proves FIX 3: when the fast-skip
+// grants hardware from the trust-reuse cache, verifyChallengeResponse drains the
+// provider's queued work immediately (instead of waiting for a heartbeat / 120s
+// timeout). Without the drain the queued request would not dispatch from the
+// challenge path at all.
+func TestVerifyChallengeFastSkipGrantDrainsQueue(t *testing.T) {
+	logger := quietLogger()
+	st := store.NewMemory(store.Config{})
+	reg := registry.New(logger)
+	srv := NewServer(reg, st, ServerConfig{}, logger)
+	srv.mdmClient = dummyMDMClient()
+	srv.SeedTrustReuseCache(context.Background())
+
+	const model = "fast-skip-drain-model"
+	binHash := trHashA
+	pubKey := testPublicKeyB64()
+	regMsg := &protocol.RegisterMessage{
+		Type:                    protocol.TypeRegister,
+		Hardware:                protocol.Hardware{ChipName: "Apple M3 Max", MemoryGB: 64},
+		Models:                  []protocol.ModelInfo{{ID: model, ModelType: "chat", Quantization: "4bit"}},
+		Backend:                 registry.BackendMLXSwift,
+		PublicKey:               pubKey,
+		DecodeTPS:               90,
+		PrefillTPS:              900,
+		EncryptedResponseChunks: true,
+		PrivacyCapabilities:     testPrivacyCaps(),
+		Attestation:             createTestAttestationJSONWithBinaryHash(t, pubKey, binHash),
+	}
+	p := reg.Register("prov-drain", nil, regMsg)
+	srv.verifyProviderAttestation("prov-drain", p, regMsg)
+
+	// Test attestation blobs carry no serial; set one + make the provider routable.
+	p.Mu().Lock()
+	seKey := p.AttestationResult.PublicKey
+	p.AttestationResult.SerialNumber = "SER-DRAIN"
+	p.BackendCapacity = &protocol.BackendCapacity{
+		TotalMemoryGB: 64,
+		Slots:         []protocol.BackendSlotCapacity{{Model: model, State: "running"}},
+	}
+	p.SystemMetrics = protocol.SystemMetrics{MemoryPressure: 0.1, CPUUsage: 0.1, ThermalState: "nominal"}
+	p.Mu().Unlock()
+
+	// Seed a fresh trust-reuse record so the fast-skip can grant.
+	srv.trustReuseCache.recordTrust(hardwareReuseRecord(seKey, "SER-DRAIN", binHash, time.Now()))
+
+	// Enqueue work for the model.
+	req := &registry.QueuedRequest{
+		RequestID:  "queued-fast-skip",
+		Model:      model,
+		ResponseCh: make(chan *registry.Provider, 1),
+		Pending: &registry.PendingRequest{
+			RequestID: "queued-fast-skip", Model: model,
+			RequestedMaxTokens: 256, EstimatedPromptTokens: 50,
+		},
+	}
+	if err := reg.Queue().Enqueue(req); err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+
+	nonce, ts := "nonce-fs", "2026-04-24T12:00:00Z"
+	srv.verifyChallengeResponse("prov-drain", p, &pendingChallenge{nonce: nonce, timestamp: ts},
+		fastSkipChallengeResp(t, nonce, ts, pubKey, binHash))
+
+	if lvl := p.GetTrustLevel(); lvl != registry.TrustHardware {
+		t.Fatalf("fast-skip must grant hardware, got %q", lvl)
+	}
+	select {
+	case assigned := <-req.ResponseCh:
+		if assigned == nil || assigned.ID != "prov-drain" {
+			t.Fatalf("expected drain dispatch to prov-drain, got %+v", assigned)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("fast-skip grant must drain the queued request to the provider (FIX 3)")
+	}
+}
+
+// TestVerifyChallengeFastSkipMissSignalsSettled proves FIX 4b: when the fast-skip
+// MISSES (no reuse record) and ACME does not promote, verifyChallengeResponse fires
+// the challenge-settled signal so the mdmVerificationLoop stops deferring and runs
+// the full live MDM verify. The provider stays self_signed.
+func TestVerifyChallengeFastSkipMissSignalsSettled(t *testing.T) {
+	logger := quietLogger()
+	st := store.NewMemory(store.Config{})
+	reg := registry.New(logger)
+	srv := NewServer(reg, st, ServerConfig{}, logger)
+	srv.mdmClient = dummyMDMClient()
+	srv.SeedTrustReuseCache(context.Background())
+
+	binHash := trHashA
+	pubKey := testPublicKeyB64()
+	regMsg := &protocol.RegisterMessage{
+		Type:                protocol.TypeRegister,
+		Hardware:            protocol.Hardware{ChipName: "Apple M3 Max", MemoryGB: 64},
+		Models:              []protocol.ModelInfo{{ID: "fast-skip-miss-model", ModelType: "chat", Quantization: "4bit"}},
+		Backend:             registry.BackendMLXSwift,
+		PublicKey:           pubKey,
+		PrivacyCapabilities: testPrivacyCaps(),
+		Attestation:         createTestAttestationJSONWithBinaryHash(t, pubKey, binHash),
+	}
+	p := reg.Register("prov-miss", nil, regMsg)
+	srv.verifyProviderAttestation("prov-miss", p, regMsg)
+	p.Mu().Lock()
+	p.AttestationResult.SerialNumber = "SER-MISS"
+	p.Mu().Unlock()
+
+	// No trust-reuse record seeded → fast-skip misses. No pending ACME → no promotion.
+	nonce, ts := "nonce-miss", "2026-04-24T12:00:00Z"
+	srv.verifyChallengeResponse("prov-miss", p, &pendingChallenge{nonce: nonce, timestamp: ts},
+		fastSkipChallengeResp(t, nonce, ts, pubKey, binHash))
+
+	if lvl := p.GetTrustLevel(); lvl != registry.TrustSelfSigned {
+		t.Fatalf("no record + no ACME → provider must stay self_signed, got %q", lvl)
+	}
+	select {
+	case <-p.ChallengeSettledChan():
+		// good — settled signal fired so the MDM loop proceeds to live verify.
+	default:
+		t.Fatal("a fast-skip miss with no ACME promotion must fire the challenge-settled signal (FIX 4b)")
 	}
 }

--- a/coordinator/api/trust_reuse_test.go
+++ b/coordinator/api/trust_reuse_test.go
@@ -1,0 +1,423 @@
+package api
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/attestation"
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+	"github.com/eigeninference/d-inference/coordinator/registry"
+	"github.com/eigeninference/d-inference/coordinator/store"
+)
+
+// Two distinct, valid 64-char SHA-256 hex digests for binary-hash gate tests.
+var (
+	trHashA = strings.Repeat("a", 64)
+	trHashB = strings.Repeat("b", 64)
+)
+
+func trBoolPtr(b bool) *bool { return &b }
+
+// hardwareReuseRecord builds a fresh, all-gates-good record for the given device.
+func hardwareReuseRecord(seKey, serial, binaryHash string, at time.Time) store.ProviderTrustReuse {
+	return store.ProviderTrustReuse{
+		SEPubKey:       seKey,
+		Serial:         serial,
+		TrustLevel:     string(registry.TrustHardware),
+		BinaryHash:     binaryHash,
+		SIPEnabled:     true,
+		SecureBootFull: true,
+		MDAUDID:        "UDID-1",
+		VerifiedAt:     at,
+	}
+}
+
+// TestTrustReuseCacheReuseAndWindow covers the core reuse decision with a fake
+// clock: a fresh hardware record with matching identity + binary reuses, and reuse
+// expires after the window. Mirrors TestCodeAttestThrottleBudgetAndReuse.
+func TestTrustReuseCacheReuseAndWindow(t *testing.T) {
+	cur := time.Unix(1_700_000_000, 0)
+	c := newTrustReuseCache()
+	c.now = func() time.Time { return cur }
+	const se, serial = "se-1", "SER-1"
+
+	if _, ok := c.reuseTrust(se, serial, trHashA); ok {
+		t.Fatal("no record yet → no reuse")
+	}
+	if c.hasFreshRecord(se, serial) {
+		t.Fatal("no record yet → not a candidate")
+	}
+
+	c.recordTrust(hardwareReuseRecord(se, serial, trHashA, cur))
+
+	if _, ok := c.reuseTrust(se, serial, trHashA); !ok {
+		t.Fatal("fresh, matching record must reuse")
+	}
+	if !c.hasFreshRecord(se, serial) {
+		t.Fatal("fresh record must be a candidate")
+	}
+
+	cur = cur.Add(c.reuseWindow) // window elapsed
+	if _, ok := c.reuseTrust(se, serial, trHashA); ok {
+		t.Fatal("reuse must expire after the window")
+	}
+	if c.hasFreshRecord(se, serial) {
+		t.Fatal("candidate status must expire after the window")
+	}
+}
+
+// TestTrustReuseCacheRejectsMismatch pins every record-side gate reuseTrust
+// enforces: empty inputs, SE/serial mismatch, binary-hash change, non-hardware
+// trust, and bad recorded posture all fail (fall through to full MDM).
+func TestTrustReuseCacheRejectsMismatch(t *testing.T) {
+	cur := time.Unix(1_700_000_000, 0)
+	c := newTrustReuseCache()
+	c.now = func() time.Time { return cur }
+	const se, serial = "se-1", "SER-1"
+	c.recordTrust(hardwareReuseRecord(se, serial, trHashA, cur))
+
+	if _, ok := c.reuseTrust("", serial, trHashA); ok {
+		t.Fatal("empty SE key must not reuse")
+	}
+	if _, ok := c.reuseTrust(se, "", trHashA); ok {
+		t.Fatal("empty serial must not reuse")
+	}
+	if _, ok := c.reuseTrust(se, serial, ""); ok {
+		t.Fatal("empty fresh binary hash must not reuse")
+	}
+	if _, ok := c.reuseTrust("se-OTHER", serial, trHashA); ok {
+		t.Fatal("different SE key must not reuse")
+	}
+	if _, ok := c.reuseTrust(se, "SER-OTHER", trHashA); ok {
+		t.Fatal("serial mismatch must not reuse (identity gate)")
+	}
+	if _, ok := c.reuseTrust(se, serial, trHashB); ok {
+		t.Fatal("binary-hash change must not reuse (code-identity gate)")
+	}
+
+	// A non-hardware record (e.g. a downgraded write) is never reusable.
+	c.recordTrust(store.ProviderTrustReuse{SEPubKey: "se-ss", Serial: "SER-2", TrustLevel: "self_signed", BinaryHash: trHashA, SIPEnabled: true, SecureBootFull: true, VerifiedAt: cur})
+	if _, ok := c.reuseTrust("se-ss", "SER-2", trHashA); ok {
+		t.Fatal("non-hardware record must not reuse")
+	}
+
+	// A record whose recorded posture was not good is never reusable (defensive).
+	c.recordTrust(store.ProviderTrustReuse{SEPubKey: "se-bad", Serial: "SER-3", TrustLevel: string(registry.TrustHardware), BinaryHash: trHashA, SIPEnabled: true, SecureBootFull: false, VerifiedAt: cur})
+	if _, ok := c.reuseTrust("se-bad", "SER-3", trHashA); ok {
+		t.Fatal("record with bad recorded posture must not reuse")
+	}
+}
+
+// TestTrustReuseCacheInvalidate proves invalidateReuse drops the record so the
+// next reconnect cannot fast-skip. Mirrors the code-attest invalidate behavior.
+func TestTrustReuseCacheInvalidate(t *testing.T) {
+	cur := time.Unix(1_700_000_000, 0)
+	c := newTrustReuseCache()
+	c.now = func() time.Time { return cur }
+	const se, serial = "se-1", "SER-1"
+	c.recordTrust(hardwareReuseRecord(se, serial, trHashA, cur))
+	if _, ok := c.reuseTrust(se, serial, trHashA); !ok {
+		t.Fatal("precondition: record should reuse")
+	}
+	c.invalidateReuse(se)
+	if _, ok := c.reuseTrust(se, serial, trHashA); ok {
+		t.Fatal("invalidated record must not reuse")
+	}
+	if c.hasFreshRecord(se, serial) {
+		t.Fatal("invalidated record must not be a candidate")
+	}
+}
+
+// TestTrustReuseCacheSeed mirrors codeAttestThrottle.seed: only rows within the
+// window are seeded, an expired row is skipped, and a fresher in-memory record is
+// not overwritten by an older persisted row.
+func TestTrustReuseCacheSeed(t *testing.T) {
+	cur := time.Unix(1_700_000_000, 0)
+	c := newTrustReuseCache()
+	c.now = func() time.Time { return cur }
+
+	fresh := hardwareReuseRecord("se-fresh", "SER-F", trHashA, cur.Add(-time.Minute))
+	expired := hardwareReuseRecord("se-old", "SER-O", trHashA, cur.Add(-2*c.reuseWindow))
+	empty := hardwareReuseRecord("", "SER-E", trHashA, cur)
+
+	if n := c.seed([]store.ProviderTrustReuse{fresh, expired, empty}); n != 1 {
+		t.Fatalf("seed count = %d, want 1 (only the in-window keyed row)", n)
+	}
+	if _, ok := c.reuseTrust("se-fresh", "SER-F", trHashA); !ok {
+		t.Fatal("in-window seeded row must reuse")
+	}
+	if c.hasFreshRecord("se-old", "SER-O") {
+		t.Fatal("expired row must not be seeded")
+	}
+
+	// A newer in-memory record must not be clobbered by an older persisted row.
+	c.recordTrust(hardwareReuseRecord("se-fresh", "SER-F", trHashB, cur)) // newer (cur) + different binary
+	older := hardwareReuseRecord("se-fresh", "SER-F", trHashA, cur.Add(-10*time.Minute))
+	c.seed([]store.ProviderTrustReuse{older})
+	if _, ok := c.reuseTrust("se-fresh", "SER-F", trHashB); !ok {
+		t.Fatal("seed must not overwrite a fresher in-memory record")
+	}
+}
+
+// TestTrustReuseWindowFromEnv proves the freshness window is configurable via
+// EIGENINFERENCE_TRUST_REUSE_WINDOW and falls back to the default otherwise.
+func TestTrustReuseWindowFromEnv(t *testing.T) {
+	if got := newTrustReuseCache().reuseWindow; got != defaultTrustReuseWindow {
+		t.Fatalf("default window = %s, want %s", got, defaultTrustReuseWindow)
+	}
+	t.Setenv("EIGENINFERENCE_TRUST_REUSE_WINDOW", "45m")
+	if got := newTrustReuseCache().reuseWindow; got != 45*time.Minute {
+		t.Fatalf("env window = %s, want 45m", got)
+	}
+	t.Setenv("EIGENINFERENCE_TRUST_REUSE_WINDOW", "garbage")
+	if got := newTrustReuseCache().reuseWindow; got != defaultTrustReuseWindow {
+		t.Fatalf("invalid env window = %s, want default %s", got, defaultTrustReuseWindow)
+	}
+}
+
+// --- Server-level store integration (seed / write-through / invalidate) ---
+
+func trustReuseServer(t *testing.T) (*Server, store.Store) {
+	t.Helper()
+	logger := quietLogger()
+	st := store.NewMemory(store.Config{})
+	srv := NewServer(registry.New(logger), st, ServerConfig{}, logger)
+	return srv, st
+}
+
+// TestTrustReuseSeedFromStore proves SeedTrustReuseCache repopulates the in-memory
+// cache from persisted rows at startup (survives a coordinator restart/deploy).
+func TestTrustReuseSeedFromStore(t *testing.T) {
+	srv, st := trustReuseServer(t)
+	now := time.Now()
+	if err := st.UpsertProviderTrustReuse(context.Background(), hardwareReuseRecord("se-x", "SER-X", trHashA, now)); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	srv.SeedTrustReuseCache(context.Background())
+	if _, ok := srv.trustReuseCache.reuseTrust("se-x", "SER-X", trHashA); !ok {
+		t.Fatal("seeded record must be reusable after SeedTrustReuseCache")
+	}
+}
+
+// TestRecordTrustReusePersists proves the write-through reaches the store, so a
+// simulated restart (fresh cache seeded from the store) can fast-skip.
+func TestRecordTrustReusePersists(t *testing.T) {
+	srv, st := trustReuseServer(t)
+	srv.SeedTrustReuseCache(context.Background()) // wires the store (empty seed)
+
+	srv.recordTrustReuse("se-y", "SER-Y", trHashA, true, true, "UDID-Y")
+
+	// Write-through is async (saferun.Go); poll the store.
+	if !waitForCond(2*time.Second, func() bool {
+		rows, _ := st.ListProviderTrustReuse(context.Background())
+		return len(rows) == 1 && rows[0].SEPubKey == "se-y" && rows[0].BinaryHash == trHashA
+	}) {
+		t.Fatal("recordTrustReuse must persist the record to the store")
+	}
+
+	// A record with no usable binary hash is NOT cached (read gate requires a match).
+	srv.recordTrustReuse("se-nohash", "SER-N", "not-a-hash", true, true, "UDID-N")
+	if _, ok := srv.trustReuseCache.reuseTrust("se-nohash", "SER-N", trHashA); ok {
+		t.Fatal("a record with an unusable binary hash must not be cached/reusable")
+	}
+}
+
+// TestInvalidateTrustReuseDeletesPersisted proves the hard-untrust invalidation
+// removes the record both in-memory and from the store (durable across restarts),
+// and that wiring the registry hook fires it on a real hard untrust.
+func TestInvalidateTrustReuseDeletesPersisted(t *testing.T) {
+	srv, st := trustReuseServer(t)
+	srv.SeedTrustReuseCache(context.Background()) // wires store + hard-untrust hook
+
+	srv.trustReuseCache.recordTrust(hardwareReuseRecord("se-z", "SER-Z", trHashA, time.Now()))
+	if err := st.UpsertProviderTrustReuse(context.Background(), hardwareReuseRecord("se-z", "SER-Z", trHashA, time.Now())); err != nil {
+		t.Fatalf("seed store: %v", err)
+	}
+
+	srv.invalidateTrustReuse("se-z")
+
+	if _, ok := srv.trustReuseCache.reuseTrust("se-z", "SER-Z", trHashA); ok {
+		t.Fatal("invalidate must drop the in-memory record")
+	}
+	if !waitForCond(2*time.Second, func() bool {
+		rows, _ := st.ListProviderTrustReuse(context.Background())
+		return len(rows) == 0
+	}) {
+		t.Fatal("invalidate must delete the persisted record")
+	}
+
+	// The registry hard-untrust hook must invalidate on a real hard untrust.
+	msg := &protocol.RegisterMessage{
+		Type: protocol.TypeRegister, Backend: "mlx-swift", PublicKey: testPublicKeyB64(),
+		Models: []protocol.ModelInfo{{ID: "m", ModelType: "chat", Quantization: "4bit"}},
+	}
+	p := srv.registry.Register("prov-hook", nil, msg)
+	p.Mu().Lock()
+	p.AttestationResult = &attestation.VerificationResult{Valid: true, SerialNumber: "SER-H", PublicKey: "se-hook"}
+	p.Mu().Unlock()
+	srv.trustReuseCache.recordTrust(hardwareReuseRecord("se-hook", "SER-H", trHashA, time.Now()))
+
+	srv.registry.MarkUntrusted("prov-hook") // hard untrust → hook fires
+
+	if !waitForCond(2*time.Second, func() bool {
+		return !srv.trustReuseCache.hasFreshRecord("se-hook", "SER-H")
+	}) {
+		t.Fatal("a hard untrust must invalidate the device's trust-reuse record (durable hard-untrust)")
+	}
+}
+
+// --- Read-path fast-skip gate tests (tryTrustReuseFastSkip) ---
+
+// trustReuseFastSkipProvider builds a server + self_signed provider with a valid
+// registration-bound attestation (serial + SE key + binary hash), and a fake clock
+// on the cache so freshness is deterministic.
+func trustReuseFastSkipProvider(t *testing.T) (*Server, *registry.Provider, *func() time.Time) {
+	t.Helper()
+	logger := quietLogger()
+	srv := NewServer(registry.New(logger), store.NewMemory(store.Config{}), ServerConfig{}, logger)
+	cur := time.Unix(1_700_000_000, 0)
+	clock := func() time.Time { return cur }
+	srv.trustReuseCache.now = clock
+
+	msg := &protocol.RegisterMessage{
+		Type: protocol.TypeRegister, Backend: "mlx-swift", PublicKey: testPublicKeyB64(),
+		Models: []protocol.ModelInfo{{ID: "m", ModelType: "chat", Quantization: "4bit"}},
+	}
+	p := srv.registry.Register("prov-fs", nil, msg)
+	p.Mu().Lock()
+	p.TrustLevel = registry.TrustSelfSigned
+	p.AttestationResult = &attestation.VerificationResult{
+		Valid: true, SerialNumber: "SERIAL-1", SIPEnabled: true, SecureBootEnabled: true,
+		PublicKey: "se-pub-key-bytes", BinaryHash: trHashA,
+	}
+	p.Mu().Unlock()
+	return srv, p, &clock
+}
+
+// goodFastSkipResp is a fresh SIGNED challenge response that satisfies the
+// posture + binary gates for the device built by trustReuseFastSkipProvider.
+func goodFastSkipResp() *protocol.AttestationResponseMessage {
+	return &protocol.AttestationResponseMessage{
+		SIPEnabled:        trBoolPtr(true),
+		SecureBootEnabled: trBoolPtr(true),
+		BinaryHash:        trHashA,
+	}
+}
+
+// TestTrustReuseFastSkipGrantsOnAllGates: all gates pass → hardware granted, MDM
+// round-trip skipped (the loop returns on hardware).
+func TestTrustReuseFastSkipGrantsOnAllGates(t *testing.T) {
+	srv, p, _ := trustReuseFastSkipProvider(t)
+	srv.trustReuseCache.recordTrust(hardwareReuseRecord("se-pub-key-bytes", "SERIAL-1", trHashA, srv.trustReuseCache.now()))
+
+	if !srv.tryTrustReuseFastSkip("prov-fs", p, goodFastSkipResp(), true /*statusFieldsTrusted*/) {
+		t.Fatal("all gates pass → fast-skip must grant")
+	}
+	if lvl := p.GetTrustLevel(); lvl != registry.TrustHardware {
+		t.Fatalf("trust = %q, want hardware after fast-skip grant", lvl)
+	}
+}
+
+// TestTrustReuseFastSkipFallsThrough enumerates every gate miss; each must return
+// false and leave the provider at self_signed (fall through to the unchanged full
+// live MDM verify). Mirrors the spec's required fall-through cases.
+func TestTrustReuseFastSkipFallsThrough(t *testing.T) {
+	cases := []struct {
+		name        string
+		seedRecord  bool
+		statusTrust bool
+		mutate      func(p *registry.Provider, resp *protocol.AttestationResponseMessage, clock *func() time.Time, c *trustReuseCache)
+	}{
+		{
+			name:        "no record",
+			seedRecord:  false,
+			statusTrust: true,
+		},
+		{
+			name:        "binary hash changed",
+			seedRecord:  true,
+			statusTrust: true,
+			mutate: func(_ *registry.Provider, resp *protocol.AttestationResponseMessage, _ *func() time.Time, _ *trustReuseCache) {
+				resp.BinaryHash = trHashB // differs from the cached/attested hash
+			},
+		},
+		{
+			name:        "status fields not signed",
+			seedRecord:  true,
+			statusTrust: false, // statusFieldsTrusted=false → posture advisory, never trusted
+		},
+		{
+			name:        "SIP not enabled in fresh challenge",
+			seedRecord:  true,
+			statusTrust: true,
+			mutate: func(_ *registry.Provider, resp *protocol.AttestationResponseMessage, _ *func() time.Time, _ *trustReuseCache) {
+				resp.SIPEnabled = trBoolPtr(false)
+			},
+		},
+		{
+			name:        "Secure Boot not enabled in fresh challenge",
+			seedRecord:  true,
+			statusTrust: true,
+			mutate: func(_ *registry.Provider, resp *protocol.AttestationResponseMessage, _ *func() time.Time, _ *trustReuseCache) {
+				resp.SecureBootEnabled = trBoolPtr(false)
+			},
+		},
+		{
+			name:        "Secure Boot omitted in fresh challenge",
+			seedRecord:  true,
+			statusTrust: true,
+			mutate: func(_ *registry.Provider, resp *protocol.AttestationResponseMessage, _ *func() time.Time, _ *trustReuseCache) {
+				resp.SecureBootEnabled = nil
+			},
+		},
+		{
+			name:        "freshness window elapsed",
+			seedRecord:  true,
+			statusTrust: true,
+			mutate: func(_ *registry.Provider, _ *protocol.AttestationResponseMessage, clock *func() time.Time, c *trustReuseCache) {
+				base := (*clock)()
+				*clock = func() time.Time { return base.Add(c.reuseWindow + time.Minute) }
+				c.now = *clock
+			},
+		},
+		{
+			name:        "provider hard-untrusted",
+			seedRecord:  true,
+			statusTrust: true,
+			mutate: func(p *registry.Provider, _ *protocol.AttestationResponseMessage, _ *func() time.Time, _ *trustReuseCache) {
+				// Hard untrust (no hook wired in this harness, so the record stays —
+				// the (e) gate alone must block the skip).
+				// providerID is "prov-fs".
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv, p, clock := trustReuseFastSkipProvider(t)
+			if tc.seedRecord {
+				srv.trustReuseCache.recordTrust(hardwareReuseRecord("se-pub-key-bytes", "SERIAL-1", trHashA, srv.trustReuseCache.now()))
+			}
+			resp := goodFastSkipResp()
+			if tc.name == "provider hard-untrusted" {
+				srv.registry.MarkUntrusted("prov-fs")
+			}
+			if tc.mutate != nil {
+				tc.mutate(p, resp, clock, srv.trustReuseCache)
+			}
+
+			if srv.tryTrustReuseFastSkip("prov-fs", p, resp, tc.statusTrust) {
+				t.Fatalf("%s: fast-skip must NOT grant", tc.name)
+			}
+			// Hard-untrust legitimately changes Status; in all other cases the
+			// provider must remain exactly self_signed (full MDM still owes it).
+			if tc.name != "provider hard-untrusted" {
+				if lvl := p.GetTrustLevel(); lvl != registry.TrustSelfSigned {
+					t.Fatalf("%s: trust = %q, want self_signed (must fall through to full MDM)", tc.name, lvl)
+				}
+			}
+		})
+	}
+}

--- a/coordinator/cmd/coordinator/main.go
+++ b/coordinator/cmd/coordinator/main.go
@@ -544,6 +544,16 @@ func main() {
 		logger.Info("APNs code-identity attestation not configured — providers route without code-identity proof")
 	}
 
+	// DAR-326 Phase 0: seed the provider trust-reuse cache from the store (and wire
+	// write-through + the hard-untrust invalidation hook). This lets a planned
+	// coordinator restart / blue-green swap skip a fleet-wide live MDM SecurityInfo
+	// + APNs re-verification herd: a reconnecting, recently-fully-verified provider
+	// is granted hardware from its record once a fresh live SE challenge re-proves
+	// identity + posture. Durable in prod (Postgres store; see the store selection
+	// above); a no-op only under the in-memory store fallback. Independent of the
+	// APNs attestor — MDM verification runs whenever an MDM client is configured.
+	srv.SeedTrustReuseCache(ctx)
+
 	// Start background eviction of stale providers.
 	reg.StartEvictionLoop(ctx, 90*time.Second)
 

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -390,6 +390,15 @@ type Provider struct {
 	// nil channel degrades safely to the timer-based wait.
 	challengeSettled chan struct{}
 
+	// untrustEpoch is bumped on every HARD untrust of this provider (DAR-326
+	// FIX A). The trust-reuse write-through (api.recordTrustReuse) captures it at
+	// grant time and re-checks it immediately before persisting; a bump in between
+	// means a hard untrust raced the grant, so the stale `hardware` row is not
+	// persisted. This closes the write-after-delete race where an async write could
+	// land AFTER the hard-untrust's synchronous delete and resurrect a row that a
+	// restart would reseed. atomic so it is read/written without p.mu.
+	untrustEpoch atomic.Uint64
+
 	// untrustedRecoverable marks an untrust as a *transient* missed-challenge
 	// deroute (timeout / no-response) that may self-recover on the next passing
 	// challenge. It is false for every hard/security deroute. In-memory only —
@@ -712,6 +721,14 @@ func (p *Provider) SignalChallengeSettled() {
 // select then simply never fires that case and falls back to the timer).
 func (p *Provider) ChallengeSettledChan() <-chan struct{} {
 	return p.challengeSettled
+}
+
+// HardUntrustEpoch returns the current hard-untrust epoch (thread-safe). It is
+// bumped on every hard untrust; the trust-reuse write-through captures it at grant
+// time and re-checks it before persisting so a hard untrust that races a grant
+// cannot leave a stale, reseedable `hardware` row (DAR-326 FIX A).
+func (p *Provider) HardUntrustEpoch() uint64 {
+	return p.untrustEpoch.Load()
 }
 
 // SetAttestationResult stores a snapshot of the parsed attestation result
@@ -3356,8 +3373,16 @@ func (r *Registry) markUntrusted(providerID string, recoverable bool) {
 	// on a stale, pre-untrust record (DAR-326). Fired after releasing the locks; a
 	// transient (recoverable) untrust does NOT invalidate — it can self-recover via
 	// a passing challenge.
-	if hook != nil && seKey != "" {
-		hook(seKey)
+	if !recoverable {
+		// FIX A: bump the hard-untrust epoch BEFORE firing the delete hook. A
+		// concurrent recordTrustReuse that captured the old epoch at grant time then
+		// sees the change on its pre-upsert recheck and refuses to persist a stale
+		// `hardware` row — closing the write-after-delete race (a write landing after
+		// the synchronous delete that a restart would otherwise reseed).
+		p.untrustEpoch.Add(1)
+		if hook != nil && seKey != "" {
+			hook(seKey)
+		}
 	}
 }
 

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -381,6 +381,15 @@ type Provider struct {
 	LastChallengeVerified time.Time // last successful challenge verification
 	FailedChallenges      int       // consecutive failed challenges
 
+	// challengeSettled is a per-connection buffered (cap 1) signal fired by the
+	// challenge path AFTER a challenge passes but the trust-reuse fast-skip did NOT
+	// grant hardware (DAR-326). It lets awaitTrustReuseGrant stop waiting
+	// immediately for a non-fast-skip provider instead of stalling up to
+	// trustReuseGrantWait before falling back to the full live MDM verify. Created
+	// fresh per Provider (so it never carries a stale signal across reconnects); a
+	// nil channel degrades safely to the timer-based wait.
+	challengeSettled chan struct{}
+
 	// untrustedRecoverable marks an untrust as a *transient* missed-challenge
 	// deroute (timeout / no-response) that may self-recover on the next passing
 	// challenge. It is false for every hard/security deroute. In-memory only —
@@ -680,6 +689,29 @@ func (p *Provider) ChallengeShouldStop() bool {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	return p.Status == StatusUntrusted && !p.untrustedRecoverable
+}
+
+// SignalChallengeSettled fires the per-connection "challenge settled without a
+// trust-reuse fast-skip grant" signal (non-blocking; buffered cap 1). The
+// mdmVerificationLoop's awaitTrustReuseGrant selects on it so a non-fast-skip
+// provider proceeds to the full live MDM verify immediately instead of stalling
+// the trust-reuse grace window (DAR-326). The channel is set once at construction
+// and never reassigned, so no lock is needed; a nil channel is a no-op.
+func (p *Provider) SignalChallengeSettled() {
+	if p.challengeSettled == nil {
+		return
+	}
+	select {
+	case p.challengeSettled <- struct{}{}:
+	default: // a prior signal is still buffered — one is enough to stop the wait
+	}
+}
+
+// ChallengeSettledChan returns the per-connection challenge-settled signal for
+// awaitTrustReuseGrant to select on. May be nil for a zero-value Provider (the
+// select then simply never fires that case and falls back to the timer).
+func (p *Provider) ChallengeSettledChan() <-chan struct{} {
+	return p.challengeSettled
 }
 
 // SetAttestationResult stores a snapshot of the parsed attestation result
@@ -2244,6 +2276,7 @@ func (r *Registry) Register(id string, conn *websocket.Conn, msg *protocol.Regis
 		LastHeartbeat:           time.Now(),
 		Reputation:              NewReputation(),
 		pendingReqs:             make(map[string]*PendingRequest),
+		challengeSettled:        make(chan struct{}, 1),
 	}
 
 	r.mu.Lock()

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -935,6 +935,14 @@ type Registry struct {
 	warmPool             *warmPoolController
 	// loadModelSender is a test seam for SendLoadModel. Nil uses the provider WebSocket.
 	loadModelSender func(providerID, modelID string) error
+
+	// onHardUntrust is an optional hook fired (off the registry locks) whenever a
+	// provider is HARD-untrusted (a non-recoverable security deroute). The api
+	// layer wires it to invalidate that device's trust-reuse record (DAR-326), so
+	// "hard untrust always takes effect" stays durable across coordinator
+	// restarts. Keyed by the device's Secure Enclave public key. Set once at
+	// startup; nil = no-op. Guarded by r.mu (set + read).
+	onHardUntrust func(seKey string)
 }
 
 // pendingModelLoadTTL bounds how long an outstanding (or failed) load_model
@@ -3230,6 +3238,17 @@ func (r *Registry) CountProvidersByBinaryHash(hash string) int {
 	return count
 }
 
+// SetHardUntrustHook registers an optional callback fired whenever a provider is
+// HARD-untrusted (non-recoverable). It is invoked with the device's Secure Enclave
+// public key, off the registry locks, so the callback may do store I/O. The api
+// layer uses it to invalidate the device's trust-reuse record (DAR-326). Set once
+// at startup before providers connect; nil clears it. Thread-safe.
+func (r *Registry) SetHardUntrustHook(fn func(seKey string)) {
+	r.mu.Lock()
+	r.onHardUntrust = fn
+	r.mu.Unlock()
+}
+
 // MarkUntrusted sets a provider's status to untrusted for a hard/security
 // reason (bad encrypted chunk, MDM/MDA failure, SIP disabled, binary or model
 // hash mismatch, serial impersonation, attestation failure). The deroute is
@@ -3271,6 +3290,7 @@ func (r *Registry) markUntrusted(providerID string, recoverable bool) {
 		r.mu.Unlock()
 		return
 	}
+	hook := r.onHardUntrust // capture under r.mu (race-safe)
 
 	p.mu.Lock()
 	if p.Status != StatusUntrusted {
@@ -3284,6 +3304,11 @@ func (r *Registry) markUntrusted(providerID string, recoverable bool) {
 		p.untrustedRecoverable = false
 	}
 	failed := p.FailedChallenges // read under p.mu (the old code read this unlocked)
+	// Capture the SE key for the hard-untrust hook while we hold p.mu.
+	var seKey string
+	if !recoverable && p.AttestationResult != nil {
+		seKey = p.AttestationResult.PublicKey
+	}
 	p.mu.Unlock()
 	r.mu.Unlock()
 
@@ -3292,6 +3317,15 @@ func (r *Registry) markUntrusted(providerID string, recoverable bool) {
 		"failed_challenges", failed,
 		"recoverable", recoverable,
 	)
+
+	// A HARD untrust invalidates the device's trust-reuse record (in-memory +
+	// persisted) so a later reconnect cannot fast-skip the live MDM re-verification
+	// on a stale, pre-untrust record (DAR-326). Fired after releasing the locks; a
+	// transient (recoverable) untrust does NOT invalidate — it can self-recover via
+	// a passing challenge.
+	if hook != nil && seKey != "" {
+		hook(seKey)
+	}
 }
 
 // SetTrustLevel updates a provider's trust level (thread-safe).

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -540,6 +540,17 @@ func (p *Provider) GetStatus() ProviderStatus {
 	return p.Status
 }
 
+// SetACMEVerified sets the ACME-verified flag (thread-safe). Used to clear a
+// flag that applyACMETrust set optimistically (it marks the cert verified before
+// the SE-key binding completes) when a trust-reuse fast-skip grants hardware via
+// MDM-reuse and the stashed ACME never bound (DAR-326 FIX 4a) — so the attestation
+// report does not claim acme_verified for an unproven binding.
+func (p *Provider) SetACMEVerified(v bool) {
+	p.mu.Lock()
+	p.ACMEVerified = v
+	p.mu.Unlock()
+}
+
 // SetMDMFailureReason records the bucketed reason this connection's MDM
 // verification has not (yet) granted hardware trust (thread-safe). Empty string
 // clears it (verified / no failure).
@@ -721,6 +732,21 @@ func (p *Provider) SignalChallengeSettled() {
 // select then simply never fires that case and falls back to the timer).
 func (p *Provider) ChallengeSettledChan() <-chan struct{} {
 	return p.challengeSettled
+}
+
+// ResetChallengeSettled drains any buffered challenge-settled signal so a fresh
+// connection can never consume a stale one (DAR-326 FIX 4c). Register allocates a
+// fresh channel per connection, so this is also belt-and-suspenders that keeps the
+// connection-scoping invariant explicit and robust to any future Provider reuse.
+// Non-blocking; safe on a nil channel.
+func (p *Provider) ResetChallengeSettled() {
+	if p.challengeSettled == nil {
+		return
+	}
+	select {
+	case <-p.challengeSettled:
+	default:
+	}
 }
 
 // HardUntrustEpoch returns the current hard-untrust epoch (thread-safe). It is
@@ -2295,6 +2321,11 @@ func (r *Registry) Register(id string, conn *websocket.Conn, msg *protocol.Regis
 		pendingReqs:             make(map[string]*PendingRequest),
 		challengeSettled:        make(chan struct{}, 1),
 	}
+
+	// Connection-scope the challenge-settled signal (DAR-326 FIX 4c): the channel is
+	// freshly allocated above, and draining here makes the "no stale signal carries
+	// into a new connection" invariant explicit and robust to future Provider reuse.
+	p.ResetChallengeSettled()
 
 	r.mu.Lock()
 	r.providers[id] = p

--- a/coordinator/registry/registry_test.go
+++ b/coordinator/registry/registry_test.go
@@ -1015,6 +1015,30 @@ func TestHardUntrustEpoch(t *testing.T) {
 	}
 }
 
+// TestResetChallengeSettledDrainsStaleSignal proves DAR-326 FIX 4c: a freshly
+// registered provider carries no settled signal, and ResetChallengeSettled drains a
+// buffered one so a new connection cannot consume a stale signal.
+func TestResetChallengeSettledDrainsStaleSignal(t *testing.T) {
+	reg := New(testLogger())
+	p := reg.Register("p1", nil, testRegisterMessage())
+
+	// A freshly-registered provider's signal is empty (Register resets it).
+	select {
+	case <-p.ChallengeSettledChan():
+		t.Fatal("a freshly-registered provider must have no buffered settled signal")
+	default:
+	}
+
+	// Buffer a (stale) signal, then reset → drained.
+	p.SignalChallengeSettled()
+	p.ResetChallengeSettled()
+	select {
+	case <-p.ChallengeSettledChan():
+		t.Fatal("ResetChallengeSettled must drain the buffered signal")
+	default:
+	}
+}
+
 func TestFindProviderSkipsUntrusted(t *testing.T) {
 	reg := New(testLogger())
 	msg := testRegisterMessage()

--- a/coordinator/registry/registry_test.go
+++ b/coordinator/registry/registry_test.go
@@ -949,6 +949,43 @@ func TestMarkUntrusted(t *testing.T) {
 	}
 }
 
+// TestHardUntrustHook proves the DAR-326 invalidation hook fires with the
+// device's SE public key on a HARD untrust, but NOT on a transient (recoverable)
+// untrust — so a missed-challenge deroute that can self-recover does not drop the
+// trust-reuse record, while a real security deroute durably invalidates it.
+func TestHardUntrustHook(t *testing.T) {
+	reg := New(testLogger())
+	msg := testRegisterMessage()
+	p := reg.Register("p1", nil, msg)
+	p.mu.Lock()
+	p.AttestationResult = &attestation.VerificationResult{PublicKey: "se-key-1"}
+	p.mu.Unlock()
+
+	var mu sync.Mutex
+	var fired []string
+	reg.SetHardUntrustHook(func(seKey string) {
+		mu.Lock()
+		fired = append(fired, seKey)
+		mu.Unlock()
+	})
+
+	// A transient untrust must NOT fire the hook.
+	reg.MarkUntrustedTransient("p1")
+	mu.Lock()
+	if len(fired) != 0 {
+		t.Fatalf("transient untrust must not fire the hard-untrust hook, got %v", fired)
+	}
+	mu.Unlock()
+
+	// A hard untrust must fire the hook with the device's SE key.
+	reg.MarkUntrusted("p1")
+	mu.Lock()
+	if len(fired) != 1 || fired[0] != "se-key-1" {
+		t.Fatalf("hard untrust must fire the hook with the SE key, got %v", fired)
+	}
+	mu.Unlock()
+}
+
 func TestFindProviderSkipsUntrusted(t *testing.T) {
 	reg := New(testLogger())
 	msg := testRegisterMessage()

--- a/coordinator/registry/registry_test.go
+++ b/coordinator/registry/registry_test.go
@@ -986,6 +986,35 @@ func TestHardUntrustHook(t *testing.T) {
 	mu.Unlock()
 }
 
+// TestHardUntrustEpoch proves the DAR-326 FIX A epoch counter: it starts at 0,
+// bumps on every HARD untrust, and does NOT bump on a transient untrust (which can
+// self-recover). recordTrustReuse captures + re-checks this epoch to refuse a
+// stale write that races a hard untrust.
+func TestHardUntrustEpoch(t *testing.T) {
+	reg := New(testLogger())
+	p := reg.Register("p1", nil, testRegisterMessage())
+
+	if e := p.HardUntrustEpoch(); e != 0 {
+		t.Fatalf("fresh provider epoch = %d, want 0", e)
+	}
+
+	// A transient untrust must NOT bump the epoch.
+	reg.MarkUntrustedTransient("p1")
+	if e := p.HardUntrustEpoch(); e != 0 {
+		t.Fatalf("transient untrust must not bump the epoch, got %d", e)
+	}
+
+	// Each hard untrust bumps it (monotonic).
+	reg.MarkUntrusted("p1")
+	if e := p.HardUntrustEpoch(); e != 1 {
+		t.Fatalf("epoch after first hard untrust = %d, want 1", e)
+	}
+	reg.MarkUntrusted("p1")
+	if e := p.HardUntrustEpoch(); e != 2 {
+		t.Fatalf("epoch after second hard untrust = %d, want 2", e)
+	}
+}
+
 func TestFindProviderSkipsUntrusted(t *testing.T) {
 	reg := New(testLogger())
 	msg := testRegisterMessage()

--- a/coordinator/store/interface.go
+++ b/coordinator/store/interface.go
@@ -547,6 +547,38 @@ type Store interface {
 	// restarts. Best-effort; must not block the read loop.
 	DeleteCodeAttestation(ctx context.Context, seKey string) error
 
+	// --- Provider trust-reuse cache (DAR-326 Phase 0) ---
+	//
+	// These mirror the code-identity reuse cache above. A persisted row records
+	// that a device (keyed by its Secure Enclave public key) completed a FULL live
+	// MDM SecurityInfo verification at VerifiedAt — proven SIP/Secure-Boot posture,
+	// serial, and binary hash. It lets a planned coordinator restart/blue-green
+	// swap skip a fleet-wide live MDM SecurityInfo + APNs re-verification HERD: on
+	// reconnect, once the live SE challenge re-proves identity + posture, a fresh
+	// record short-circuits the (otherwise immediate) live MDM round-trip.
+	//
+	// SECURITY: a persisted row NEVER by itself grants hardware trust. The reuse
+	// decision (api.trustReuseCache.reuseTrust) re-applies, on every read, a live
+	// SE challenge, a serial+SE-key identity match, a binary-hash match, a fresh
+	// good-posture check, and the freshness window — so a stale / wrong-binary /
+	// expired / hard-untrusted row falls through to the full live MDM verification.
+
+	// ListProviderTrustReuse returns all persisted trust-reuse records (for
+	// seeding the in-memory reuse cache at startup).
+	ListProviderTrustReuse(ctx context.Context) ([]ProviderTrustReuse, error)
+
+	// UpsertProviderTrustReuse creates or updates the trust-reuse record for a
+	// device (keyed by SEPubKey). Called after a successful live MDM verification;
+	// best-effort, must not block the read loop.
+	UpsertProviderTrustReuse(ctx context.Context, rec ProviderTrustReuse) error
+
+	// DeleteProviderTrustReuse removes a device's persisted trust-reuse record
+	// (keyed by SEPubKey). Called when the provider is HARD-untrusted so a later
+	// coordinator restart cannot reseed and fast-skip on a stale pre-untrust
+	// record — keeping "hard untrust always takes effect" durable across restarts.
+	// Best-effort; must not block the read loop.
+	DeleteProviderTrustReuse(ctx context.Context, seKey string) error
+
 	// --- Provider Log Reports ---
 
 	// StoreLogReport stores a provider log report.
@@ -1367,4 +1399,29 @@ type CodeAttestation struct {
 	Version    string    `json:"version"`     // provider binary version that attested
 	AttestedAt time.Time `json:"attested_at"` // instant of the successful round-trip
 	APNsToken  string    `json:"apns_token"`  // APNs device token the proof was bound to; reuse requires it to match the new registration token (Codex #7). "" = legacy row from before token-binding.
+}
+
+// ProviderTrustReuse is the persistent representation of one device's most recent
+// successful FULL live MDM SecurityInfo verification (DAR-326 Phase 0). It is the
+// durable form of api.trustReuseRecord. Keyed by the Secure Enclave public key —
+// the stable per-device identity that survives reconnects AND coordinator
+// restarts. It mirrors CodeAttestation: persistence lets a planned coordinator
+// restart/blue-green swap skip a fleet-wide live MDM SecurityInfo + APNs
+// re-verification herd.
+//
+// SECURITY: the row is written ONLY after a full, verified live MDM
+// verification; it is never created from an unverified heartbeat or self-report.
+// On read, the reuse decision still re-applies a live SE challenge, a serial+SE
+// identity match, a binary-hash match, a fresh good-posture check, and the
+// freshness window, so a persisted row can only ever let the coordinator skip a
+// redundant live MDM round-trip — never extend or fabricate trust.
+type ProviderTrustReuse struct {
+	SEPubKey       string    `json:"se_pubkey"`        // base64 Secure Enclave P-256 public key (bound at registration)
+	Serial         string    `json:"serial"`           // device serial number proven by the SE attestation at last verification
+	TrustLevel     string    `json:"trust_level"`      // trust level earned at last verification (only "hardware" is reusable)
+	BinaryHash     string    `json:"binary_hash"`      // provider binary SHA-256 at last verification; reuse requires the fresh signed challenge to match
+	SIPEnabled     bool      `json:"sip_enabled"`      // SIP posture confirmed by MDM at last verification
+	SecureBootFull bool      `json:"secure_boot_full"` // Secure Boot (full) confirmed by MDM at last verification
+	MDAUDID        string    `json:"mda_udid"`         // MDM/MDA device UDID at last verification (diagnostics)
+	VerifiedAt     time.Time `json:"verified_at"`      // instant of the successful live MDM verification
 }

--- a/coordinator/store/memory.go
+++ b/coordinator/store/memory.go
@@ -118,6 +118,12 @@ type MemoryStore struct {
 	// persists for real once it is the production backend.
 	codeAttestations map[string]CodeAttestation
 
+	// Provider trust-reuse cache (DAR-326 Phase 0). Keyed by SE pubkey. Mirrors
+	// codeAttestations: lost on restart in the memory store (same as the in-memory
+	// cache it backs), but the methods exist so the store seam is uniform and
+	// Postgres persists for real as the production backend.
+	providerTrustReuse map[string]ProviderTrustReuse
+
 	// Provider log reports
 	logReports   []LogReport
 	logReportSeq int64
@@ -180,6 +186,7 @@ func NewMemory(scfg Config) *MemoryStore {
 		reputationRecords:             make(map[string]*ReputationRecord),
 		serialToProviderID:            make(map[string]string),
 		codeAttestations:              make(map[string]CodeAttestation),
+		providerTrustReuse:            make(map[string]ProviderTrustReuse),
 		inferenceRoutes:               make([]InferenceRouteRecord, 0),
 		inferenceRouteIndex:           make(map[string]int),
 		inferenceRouteOutcomes:        make(map[string]InferenceRouteOutcome),
@@ -2834,6 +2841,40 @@ func (s *MemoryStore) DeleteCodeAttestation(_ context.Context, seKey string) err
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	delete(s.codeAttestations, seKey)
+	return nil
+}
+
+// --- Provider trust-reuse cache (DAR-326 Phase 0) ---
+
+func (s *MemoryStore) ListProviderTrustReuse(_ context.Context) ([]ProviderTrustReuse, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	out := make([]ProviderTrustReuse, 0, len(s.providerTrustReuse))
+	for _, rec := range s.providerTrustReuse {
+		out = append(out, rec)
+	}
+	return out, nil
+}
+
+func (s *MemoryStore) UpsertProviderTrustReuse(_ context.Context, rec ProviderTrustReuse) error {
+	if rec.SEPubKey == "" {
+		return nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.providerTrustReuse[rec.SEPubKey] = rec
+	return nil
+}
+
+func (s *MemoryStore) DeleteProviderTrustReuse(_ context.Context, seKey string) error {
+	if seKey == "" {
+		return nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.providerTrustReuse, seKey)
 	return nil
 }
 

--- a/coordinator/store/postgres.go
+++ b/coordinator/store/postgres.go
@@ -912,6 +912,15 @@ func (s *PostgresStore) migrate(ctx context.Context) error {
 		// on READ (in the coordinator, behind a live SE challenge), so a
 		// stale/wrong-binary/expired row never extends trust — it only lets the
 		// coordinator skip a redundant live MDM round-trip.
+		//
+		// SECURITY-SENSITIVE (Threat-Model #5): a row here grants a hardware
+		// fast-skip, so write access must be guarded like the payment ledger — only
+		// the coordinator writes it, and only after a verified live MDM pass.
+		// SeedTrustReuseCache TRUSTS this table's contents on restart; that trust is
+		// bounded by the always-run live SE challenge on read (re-proving posture +
+		// binary + identity) plus future-date rejection, so a tampered/stale row
+		// still falls through to a full live MDM verification rather than silently
+		// granting hardware.
 		`CREATE TABLE IF NOT EXISTS provider_trust_reuse (
 			se_pubkey TEXT PRIMARY KEY,
 			serial TEXT NOT NULL DEFAULT '',

--- a/coordinator/store/postgres.go
+++ b/coordinator/store/postgres.go
@@ -901,6 +901,27 @@ func (s *PostgresStore) migrate(ctx context.Context) error {
 		// Token-binding column for reuse (Codex #7): additive for DBs whose
 		// code_attestations table predates it (the CREATE above is a no-op there).
 		`ALTER TABLE code_attestations ADD COLUMN IF NOT EXISTS apns_token TEXT NOT NULL DEFAULT ''`,
+
+		// Provider trust-reuse cache (DAR-326 Phase 0). Mirrors code_attestations.
+		// Persists the in-memory trust-reuse cache so a blue-green deploy / restart
+		// does not wipe it and provoke a fleet-wide live MDM SecurityInfo + APNs
+		// re-verification herd. One row per device (keyed by Secure Enclave public
+		// key). The row records that the device completed a FULL live MDM
+		// verification at verified_at (proven serial, binary hash, SIP, Secure
+		// Boot). The identity + binary + fresh-posture + freshness gate is applied
+		// on READ (in the coordinator, behind a live SE challenge), so a
+		// stale/wrong-binary/expired row never extends trust — it only lets the
+		// coordinator skip a redundant live MDM round-trip.
+		`CREATE TABLE IF NOT EXISTS provider_trust_reuse (
+			se_pubkey TEXT PRIMARY KEY,
+			serial TEXT NOT NULL DEFAULT '',
+			trust_level TEXT NOT NULL DEFAULT '',
+			binary_hash TEXT NOT NULL DEFAULT '',
+			sip_enabled BOOL NOT NULL DEFAULT FALSE,
+			secure_boot_full BOOL NOT NULL DEFAULT FALSE,
+			mda_udid TEXT NOT NULL DEFAULT '',
+			verified_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+		)`,
 	}
 
 	for _, m := range migrations {
@@ -4158,6 +4179,66 @@ func (s *PostgresStore) DeleteCodeAttestation(ctx context.Context, seKey string)
 
 	if _, err := s.pool.Exec(ctx, `DELETE FROM code_attestations WHERE se_pubkey = $1`, seKey); err != nil {
 		return fmt.Errorf("store: delete code attestation: %w", err)
+	}
+	return nil
+}
+
+// --- Provider trust-reuse cache (DAR-326 Phase 0) ---
+
+func (s *PostgresStore) ListProviderTrustReuse(ctx context.Context) ([]ProviderTrustReuse, error) {
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	rows, err := s.pool.Query(ctx,
+		`SELECT se_pubkey, serial, trust_level, binary_hash, sip_enabled, secure_boot_full, mda_udid, verified_at FROM provider_trust_reuse`)
+	if err != nil {
+		return nil, fmt.Errorf("store: list provider trust reuse: %w", err)
+	}
+	defer rows.Close()
+
+	var out []ProviderTrustReuse
+	for rows.Next() {
+		var rec ProviderTrustReuse
+		if err := rows.Scan(&rec.SEPubKey, &rec.Serial, &rec.TrustLevel, &rec.BinaryHash, &rec.SIPEnabled, &rec.SecureBootFull, &rec.MDAUDID, &rec.VerifiedAt); err != nil {
+			return nil, fmt.Errorf("store: scan provider trust reuse: %w", err)
+		}
+		out = append(out, rec)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("store: iterate provider trust reuse: %w", err)
+	}
+	return out, nil
+}
+
+func (s *PostgresStore) UpsertProviderTrustReuse(ctx context.Context, rec ProviderTrustReuse) error {
+	if rec.SEPubKey == "" {
+		return nil
+	}
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	_, err := s.pool.Exec(ctx,
+		`INSERT INTO provider_trust_reuse (se_pubkey, serial, trust_level, binary_hash, sip_enabled, secure_boot_full, mda_udid, verified_at)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+		 ON CONFLICT (se_pubkey) DO UPDATE SET
+			serial = $2, trust_level = $3, binary_hash = $4, sip_enabled = $5, secure_boot_full = $6, mda_udid = $7, verified_at = $8`,
+		rec.SEPubKey, rec.Serial, rec.TrustLevel, rec.BinaryHash, rec.SIPEnabled, rec.SecureBootFull, rec.MDAUDID, rec.VerifiedAt,
+	)
+	if err != nil {
+		return fmt.Errorf("store: upsert provider trust reuse: %w", err)
+	}
+	return nil
+}
+
+func (s *PostgresStore) DeleteProviderTrustReuse(ctx context.Context, seKey string) error {
+	if seKey == "" {
+		return nil
+	}
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	if _, err := s.pool.Exec(ctx, `DELETE FROM provider_trust_reuse WHERE se_pubkey = $1`, seKey); err != nil {
+		return fmt.Errorf("store: delete provider trust reuse: %w", err)
 	}
 	return nil
 }

--- a/coordinator/store/postgres_test.go
+++ b/coordinator/store/postgres_test.go
@@ -53,6 +53,7 @@ func testPostgresStore(t *testing.T) *PostgresStore {
 		"provider_sessions",
 		"inference_routes",
 		"request_rejections",
+		"provider_trust_reuse",
 	} {
 		if _, err := s.pool.Exec(ctx, "TRUNCATE "+table+" CASCADE"); err != nil {
 			t.Fatalf("truncate %s: %v", table, err)

--- a/coordinator/store/provider_trust_reuse_test.go
+++ b/coordinator/store/provider_trust_reuse_test.go
@@ -1,0 +1,104 @@
+package store
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// providerTrustReuseRoundTrip exercises the persistence contract the trust-reuse
+// cache relies on (DAR-326 Phase 0), mirroring codeAttestRoundTrip: upsert is
+// keyed by SE pubkey, list returns every row with all fields, delete removes a
+// row, and a second upsert for the same key overwrites rather than duplicates.
+func providerTrustReuseRoundTrip(t *testing.T, st Store) {
+	t.Helper()
+	ctx := context.Background()
+	// Truncate to avoid sub-second/tz round-trip noise across backends.
+	t0 := time.Now().UTC().Truncate(time.Second)
+
+	// Empty SE key is a no-op (defensive — never persist an unkeyed row).
+	if err := st.UpsertProviderTrustReuse(ctx, ProviderTrustReuse{TrustLevel: "hardware", VerifiedAt: t0}); err != nil {
+		t.Fatalf("upsert empty key: %v", err)
+	}
+	if rows, err := st.ListProviderTrustReuse(ctx); err != nil || len(rows) != 0 {
+		t.Fatalf("empty-key upsert must not persist a row: rows=%d err=%v", len(rows), err)
+	}
+
+	recA := ProviderTrustReuse{
+		SEPubKey:       "se-A",
+		Serial:         "SER-A",
+		TrustLevel:     "hardware",
+		BinaryHash:     "aaaa",
+		SIPEnabled:     true,
+		SecureBootFull: true,
+		MDAUDID:        "UDID-A",
+		VerifiedAt:     t0,
+	}
+	if err := st.UpsertProviderTrustReuse(ctx, recA); err != nil {
+		t.Fatalf("upsert A: %v", err)
+	}
+	if err := st.UpsertProviderTrustReuse(ctx, ProviderTrustReuse{SEPubKey: "se-B", Serial: "SER-B", TrustLevel: "hardware", VerifiedAt: t0}); err != nil {
+		t.Fatalf("upsert B: %v", err)
+	}
+
+	rows, err := st.ListProviderTrustReuse(ctx)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("len = %d, want 2", len(rows))
+	}
+	byKey := map[string]ProviderTrustReuse{}
+	for _, r := range rows {
+		byKey[r.SEPubKey] = r
+	}
+	got := byKey["se-A"]
+	if got.Serial != "SER-A" || got.TrustLevel != "hardware" || got.BinaryHash != "aaaa" ||
+		!got.SIPEnabled || !got.SecureBootFull || got.MDAUDID != "UDID-A" || !got.VerifiedAt.Equal(t0) {
+		t.Fatalf("se-A round-trip mismatch: %+v", got)
+	}
+
+	// Upsert the same key with new values overwrites (no duplicate).
+	t1 := t0.Add(10 * time.Minute)
+	if err := st.UpsertProviderTrustReuse(ctx, ProviderTrustReuse{
+		SEPubKey: "se-A", Serial: "SER-A2", TrustLevel: "hardware", BinaryHash: "bbbb",
+		SIPEnabled: true, SecureBootFull: false, MDAUDID: "UDID-A2", VerifiedAt: t1,
+	}); err != nil {
+		t.Fatalf("re-upsert A: %v", err)
+	}
+	rows, err = st.ListProviderTrustReuse(ctx)
+	if err != nil {
+		t.Fatalf("list after re-upsert: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("re-upsert must not duplicate: len = %d, want 2", len(rows))
+	}
+	for _, r := range rows {
+		if r.SEPubKey == "se-A" && (r.Serial != "SER-A2" || r.BinaryHash != "bbbb" || r.SecureBootFull || r.MDAUDID != "UDID-A2" || !r.VerifiedAt.Equal(t1)) {
+			t.Fatalf("se-A overwrite mismatch: %+v", r)
+		}
+	}
+
+	// Delete removes one row; an empty-key delete is a no-op.
+	if err := st.DeleteProviderTrustReuse(ctx, ""); err != nil {
+		t.Fatalf("delete empty key: %v", err)
+	}
+	if err := st.DeleteProviderTrustReuse(ctx, "se-A"); err != nil {
+		t.Fatalf("delete A: %v", err)
+	}
+	rows, err = st.ListProviderTrustReuse(ctx)
+	if err != nil {
+		t.Fatalf("list after delete: %v", err)
+	}
+	if len(rows) != 1 || rows[0].SEPubKey != "se-B" {
+		t.Fatalf("after delete want only se-B, got %+v", rows)
+	}
+}
+
+func TestMemoryProviderTrustReuseRoundTrip(t *testing.T) {
+	providerTrustReuseRoundTrip(t, NewMemory(Config{}))
+}
+
+func TestPostgresProviderTrustReuseRoundTrip(t *testing.T) {
+	providerTrustReuseRoundTrip(t, testPostgresStore(t))
+}

--- a/docs/threat-model.yaml
+++ b/docs/threat-model.yaml
@@ -1757,6 +1757,21 @@ threats:
         status: open
       - description: Attestation tests require AuthenticatedRootEnabled=true or earlier errors are overwritten.
         status: implemented
+      - description: >
+          DAR-326 trust-reuse fast-skip (coordinator/api/trust_reuse.go tryTrustReuseFastSkip)
+          lets a reconnecting, recently-fully-verified provider regain hardware trust from a
+          persisted record without re-running the live MDM SecurityInfo round-trip — avoiding a
+          fleet-wide MDM/APNs re-verification herd on a planned coordinator restart/swap. ACCEPTED
+          TRADE-OFF (relative to TB-005): within the reuse window the fast-skip captures the prior
+          SIP/Secure-Boot posture but does NOT re-prove MDA cert-chain freshness. It is bounded by
+          (1) the short reuse window (EIGENINFERENCE_TRUST_REUSE_WINDOW, default 10m — cannot span a
+          SIP-disable reboot cycle), (2) the ALWAYS-run live SE challenge that re-proves
+          identity + SIP/Secure-Boot posture + unchanged binary on every reuse, (3) a durable
+          hard-untrust epoch that refuses/removes a record if a hard untrust races the grant, and
+          (4) declining the fast-skip entirely when no MDM client is configured. A genuine MDA
+          re-verification still runs for every first-ever connection and for any reconnect outside
+          the window or failing a gate.
+        status: accepted
     open_findings: [SEC-004]
     severity: critical
     detection_hint: >


### PR DESCRIPTION
## What
DAR-326 Phase 0: a coordinator-side **provider trust-reuse cache** so a planned coordinator restart/swap no longer triggers a fleet-wide MDM SecurityInfo + APNs re-verification herd.

## Why
Today every provider reconnect caps trust to `self_signed` (`RestoreProviderState`) and runs a live MDM SecurityInfo round-trip (`verifyProviderViaMDM`), so a coordinator restart = a fleet-wide MDM/APNs herd. This is the enabling piece (Phase 0) for blue-green hot-swaps: after it lands, the *first* restart populates the cache and **every restart/swap after is a sub-second, SE-challenge-only re-trust** — making config flips (e.g. `TTFT_HARD_REJECT`) and future coordinator upgrades cheap instead of a herd.

## How
Mirrors the existing RDS-persisted code-identity reuse cache (`api/code_attest_throttle.go`):
- New `provider_trust_reuse` table + `List/Upsert/Delete` (postgres + memory + interface).
- `api/trust_reuse.go`: `trustReuseCache` with write-through on each hardware grant, a gated fast-skip on reconnect, durable hard-untrust invalidation, seeded from RDS at startup.
- The fast-skip runs **only after the live SE attestation challenge fully passes**, then skips the live MDM round-trip iff ALL gates hold: `se_pubkey`+`serial` match, signed `binary_hash` match, fresh posture good (`statusFieldsTrusted` + SIP + Secure Boot), within the freshness window (default 30m), and not hard-untrusted (atomic backstop). Any gate miss / no record → **byte-identical fall-through to full live MDM**.

## Security
The live SE challenge always runs first and is never skipped; the fast-skip is a gated optimization, never a trust shortcut. Independently reviewed by an adversarial verifier (traced the full flow, enumerated all hard-untrust sites, mutation-tested the gates) → **GO, no trust-model hole**. All review findings addressed in `4ccbae48`:
- Durable hard-untrust invalidation (synchronous bounded-retry persisted delete, off-locks).
- Clock-skew guard (reject future-dated records in read + seed).
- Eliminated the up-to-10s candidate stall (per-connection "challenge settled" signal).
- Added fast-skip identity-mismatch tests + a hook-wired-without-store test.
- Hard-untrust hook wired independent of store presence.

(Note: the inline-retry delete was intentionally **not** mirrored into the code-attest path — that runs on the WebSocket read loop, where a bounded blocking delete would stall WS reads; only the trust-reuse hook is guaranteed off-locks.)

## Testing
`gofmt -l` clean · `go build ./...` OK · `go test ./...` all pass (postgres store tests skip without `DATABASE_URL`; memory + all new tests pass) · `-race` clean on new api/registry tests · security gates mutation-tested.

## Deploy note
The **first** deploy of this is the last *expensive* reconnect wave — the table starts empty, so providers do full MDM once (which write-through-populates the cache); every coordinator restart/swap after is a sub-second re-trust. Recommended to deploy folded in with the pending `TTFT_HARD_REJECT=false` flip.

## Commits
- `396b6b11` feat: DAR-326 Phase 0 — provider trust-reuse cache
- `4ccbae48` fix: address review findings

Part of the blue-green hot-swap effort.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/391"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784321546&installation_id=133247490&pr_number=391&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F391&signature=5a79f4b0588be891c824152b8a32cd71893685365ba4c1e8f15e2bf5a8f16c7f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->