### PR TITLE
feat(provider): graceful drain for darkbloom stop/start/restart

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -224,6 +224,10 @@ Keep the codebase modular, never monolithic.
 - One file/component should do one thing. If a file mixes several concerns or grows past a few hundred lines, that's a signal to split it.
 - **At the end of every large piece of work, do a refactor pass to make it modular before calling it done.** Extract helpers/types/hooks into focused files, delete dead code, and keep the public entry point thin. The refactor must be behavior-preserving — build, lint, and tests stay green.
 
+## Pull Requests
+
+Every new PR must include a **before/after Mermaid diagram** in its description. The diagram should illustrate the change at the architectural or user-flow level so reviewers can see what behavior existed before and what replaces it. Keep the diagram focused on the moving parts affected by the change (e.g., CLI → daemon → launchd, coordinator → provider → inference engine).
+
 ## Formatting
 
 A pre-commit hook in `.githooks/pre-commit` checks staged files only. It is enabled via:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -260,6 +260,10 @@ Each reviewer should:
 
 Only proceed to the next objective after both reviewers pass. If either flags issues, fix them before moving on.
 
+## Pull Requests
+
+Every new PR must include a **before/after Mermaid diagram** in its description. The diagram should show the behavior before the change and the behavior after the change at the architectural or user-flow level. Focus on the components actually affected by the PR.
+
 ## Git Hooks
 
 Hooks live in `.githooks/` and are enabled via `git config core.hooksPath .githooks` (already set for this repo).

--- a/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClient.swift
+++ b/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClient.swift
@@ -587,6 +587,12 @@ public actor CoordinatorClient {
     /// generating instead of running until the drain timeout.
     private var drainCancelHandler: (@Sendable (String) async -> Void)?
 
+    /// Disconnect handler installed by `beginDraining`. If the socket drops while
+    /// draining (event stream no longer consumed), the coordinator fails our
+    /// in-flight requests, so this lets the provider cancel them rather than keep
+    /// generating frames that can never reach the consumer.
+    private var drainDisconnectHandler: (@Sendable () async -> Void)?
+
     /// Mutable advertised-model list. Seeded from `config.models`; background
     /// prefetch (Layer 3) appends newly-verified builds so re-registration and
     /// reconnects pick them up without dropping the currently-served model.
@@ -680,12 +686,20 @@ public actor CoordinatorClient {
     /// receive loop. Used during a graceful stop/restart, when the `ProviderLoop`
     /// event stream is no longer consuming events but the drain has not finished.
     ///
-    /// - Parameter onCancel: invoked for coordinator `cancel` frames received
-    ///   while draining, so an aborted in-flight request stops generating
-    ///   promptly instead of running until the drain timeout.
-    public func beginDraining(onCancel: (@Sendable (String) async -> Void)? = nil) {
+    /// - Parameters:
+    ///   - onCancel: invoked for coordinator `cancel` frames received while
+    ///     draining, so an aborted in-flight request stops generating promptly
+    ///     instead of running until the drain timeout.
+    ///   - onDisconnect: invoked if the socket drops while draining, so the
+    ///     provider can cancel in-flight work the coordinator has already failed
+    ///     instead of generating frames that can no longer be delivered.
+    public func beginDraining(
+        onCancel: (@Sendable (String) async -> Void)? = nil,
+        onDisconnect: (@Sendable () async -> Void)? = nil
+    ) {
         draining = true
         drainCancelHandler = onCancel
+        drainDisconnectHandler = onDisconnect
     }
 
     /// Wait until queued outbound messages have been written to the socket, or
@@ -722,6 +736,14 @@ public actor CoordinatorClient {
         modelWeightHashOverrides = hashes
     }
 
+    /// Handle a socket drop that happens while draining: the coordinator fails
+    /// our in-flight requests on disconnect, so cancel them (don't keep
+    /// generating undeliverable frames) and stop reconnecting.
+    private func handleDrainDisconnect() async {
+        logger.info("Coordinator socket closed during drain; cancelling in-flight work and stopping reconnects")
+        if let handler = drainDisconnectHandler { await handler() }
+    }
+
     // MARK: - Connection Loop
 
     private func runLoop() async {
@@ -734,10 +756,12 @@ public actor CoordinatorClient {
             do {
                 try await connectAndRun()
                 logger.info("Coordinator connection closed, reconnecting...")
+                if draining { await handleDrainDisconnect(); break }
                 backoff.reset()
                 continue
             } catch {
                 if shutdownRequested { break }
+                if draining { await handleDrainDisconnect(); break }
 
                 eventContinuation?.yield(.disconnected)
                 let delay = backoff.nextDelay()

--- a/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClient.swift
+++ b/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClient.swift
@@ -553,6 +553,13 @@ public actor CoordinatorClient {
 
     private var shutdownRequested = false
 
+    /// Set when a graceful shutdown drain has begun. The socket stays open so
+    /// in-flight responses can finish, but the `ProviderLoop` event stream is no
+    /// longer being consumed — so the receive loop rejects NEW inference requests
+    /// here with 503 (instead of yielding them into an unconsumed stream) so the
+    /// coordinator reroutes them immediately. See `beginDraining()`.
+    private var draining = false
+
     /// Mutable advertised-model list. Seeded from `config.models`; background
     /// prefetch (Layer 3) appends newly-verified builds so re-registration and
     /// reconnects pick them up without dropping the currently-served model.
@@ -639,6 +646,14 @@ public actor CoordinatorClient {
         webSocketTask?.cancel(with: .goingAway, reason: nil)
         eventContinuation?.finish()
         outboundRouter.finish()
+    }
+
+    /// Enter draining mode: keep the connection open (so in-flight responses can
+    /// still be delivered) but reject NEW inference requests with 503 from the
+    /// receive loop. Used during a graceful stop/restart, when the `ProviderLoop`
+    /// event stream is no longer consuming events but the drain has not finished.
+    public func beginDraining() {
+        draining = true
     }
 
     /// Re-register over a fresh connection carrying a device token that arrived
@@ -859,6 +874,23 @@ public actor CoordinatorClient {
         case .inferenceRequest(let request):
             let requestId = request.requestId
             logger.info("Received inference request: \(requestId)")
+
+            // Graceful drain in progress: the provider event loop has stopped
+            // consuming events, but this socket is intentionally kept open so
+            // in-flight responses can finish. Reject NEW requests with 503 right
+            // here so the coordinator reroutes them immediately instead of
+            // waiting for an inference timeout on a request that will never be
+            // processed.
+            if draining {
+                logger.info("Rejecting inference request during drain: \(requestId)")
+                let errorResponse = encodeInferenceError(
+                    requestId: requestId,
+                    error: "provider is shutting down",
+                    statusCode: 503
+                )
+                try? await ws.send(.string(errorResponse))
+                return
+            }
 
             guard let encrypted = request.encryptedBody else {
                 logger.error("Rejecting plaintext inference request: \(requestId)")

--- a/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClient.swift
+++ b/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClient.swift
@@ -280,12 +280,18 @@ private final class ManagedAtomic<Value: FixedWidthInteger>: @unchecked Sendable
 private final class OutboundRouter: @unchecked Sendable {
     private let lock = OSAllocatedUnfairLock()
     private var continuation: AsyncStream<OutboundMessage>.Continuation?
+    /// Count of messages yielded to the live connection but not yet confirmed
+    /// written to the socket. Lets a graceful shutdown flush the tail (e.g. the
+    /// final `inference_complete`) before the transport is torn down. Reset on
+    /// (re)connect / finish, since a stream's buffered messages are abandoned.
+    private var pendingWrites = 0
 
     /// Install the continuation for a new connection, finishing any prior one.
     func activate(_ cont: AsyncStream<OutboundMessage>.Continuation) {
         let previous: AsyncStream<OutboundMessage>.Continuation? = lock.withLock {
             let prev = continuation
             continuation = cont
+            pendingWrites = 0
             return prev
         }
         previous?.finish()
@@ -295,8 +301,22 @@ private final class OutboundRouter: @unchecked Sendable {
     /// while disconnected are dropped (the caller cannot reach the coordinator
     /// anyway) rather than buffered into a stream nothing is consuming.
     func yield(_ msg: OutboundMessage) {
-        let cont = lock.withLock { continuation }
+        let cont: AsyncStream<OutboundMessage>.Continuation? = lock.withLock {
+            guard let c = continuation else { return nil }
+            pendingWrites += 1
+            return c
+        }
         cont?.yield(msg)
+    }
+
+    /// Called by the outbound writer after a message is written to the socket.
+    func markWritten() {
+        lock.withLock { if pendingWrites > 0 { pendingWrites -= 1 } }
+    }
+
+    /// Messages yielded but not yet written to the socket.
+    func pendingCount() -> Int {
+        lock.withLock { pendingWrites }
     }
 
     /// Tear down outbound delivery permanently (shutdown).
@@ -304,6 +324,7 @@ private final class OutboundRouter: @unchecked Sendable {
         let cont: AsyncStream<OutboundMessage>.Continuation? = lock.withLock {
             let c = continuation
             continuation = nil
+            pendingWrites = 0
             return c
         }
         cont?.finish()
@@ -560,6 +581,12 @@ public actor CoordinatorClient {
     /// coordinator reroutes them immediately. See `beginDraining()`.
     private var draining = false
 
+    /// Cancel handler installed by `beginDraining`. While draining (the event
+    /// stream is no longer consumed), the receive loop routes coordinator
+    /// `cancel` frames straight here so an aborted in-flight request still stops
+    /// generating instead of running until the drain timeout.
+    private var drainCancelHandler: (@Sendable (String) async -> Void)?
+
     /// Mutable advertised-model list. Seeded from `config.models`; background
     /// prefetch (Layer 3) appends newly-verified builds so re-registration and
     /// reconnects pick them up without dropping the currently-served model.
@@ -652,8 +679,28 @@ public actor CoordinatorClient {
     /// still be delivered) but reject NEW inference requests with 503 from the
     /// receive loop. Used during a graceful stop/restart, when the `ProviderLoop`
     /// event stream is no longer consuming events but the drain has not finished.
-    public func beginDraining() {
+    ///
+    /// - Parameter onCancel: invoked for coordinator `cancel` frames received
+    ///   while draining, so an aborted in-flight request stops generating
+    ///   promptly instead of running until the drain timeout.
+    public func beginDraining(onCancel: (@Sendable (String) async -> Void)? = nil) {
         draining = true
+        drainCancelHandler = onCancel
+    }
+
+    /// Wait until queued outbound messages have been written to the socket, or
+    /// `timeout` elapses. Used during a graceful drain so the tail of a finished
+    /// request (chunks + the final `inference_complete`) is delivered before the
+    /// transport is torn down by `shutdown()`.
+    public func flushOutbound(timeout: Duration) async {
+        let deadline = ContinuousClock.now + timeout
+        while outboundRouter.pendingCount() > 0 {
+            if ContinuousClock.now >= deadline {
+                logger.warning("Outbound flush timed out with \(self.outboundRouter.pendingCount()) message(s) still queued")
+                return
+            }
+            try? await Task.sleep(for: .milliseconds(20))
+        }
     }
 
     /// Re-register over a fresh connection carrying a device token that arrived
@@ -776,6 +823,9 @@ public actor CoordinatorClient {
                     if shutting { break }
                     let json = await self.encodeOutbound(msg)
                     try await ws.send(.string(json))
+                    // Confirm the write so a graceful shutdown can flush the tail
+                    // (e.g. the final inference_complete) before tearing down.
+                    self.outboundRouter.markWritten()
                 }
             }
 
@@ -938,7 +988,14 @@ public actor CoordinatorClient {
         case .cancel(let cancel):
             let requestId = cancel.requestId
             logger.info("Received cancel for: \(requestId)")
-            eventContinuation?.yield(.cancel(requestId: requestId))
+            // While draining, the provider event stream is no longer consumed, so
+            // route cancels straight to the drain handler — otherwise an aborted
+            // request would keep generating until the drain timeout.
+            if draining, let handler = drainCancelHandler {
+                await handler(requestId)
+            } else {
+                eventContinuation?.yield(.cancel(requestId: requestId))
+            }
 
         case .attestationChallenge(let challenge):
             logger.info("Received attestation challenge")

--- a/provider-swift/Sources/ProviderCore/ProviderLoop.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop.swift
@@ -3174,14 +3174,20 @@ public actor ProviderLoop {
         logger.info("Waiting up to \(timeout.components.seconds)s for active inference to finish before shutdown")
         let started = ContinuousClock.now
         while hasInflightWork {
-            if Task.isCancelled { return false }
+            // During a controlled shutdown (user stop/restart, schedule window
+            // close, or update hot-swap) we want to finish active inference even
+            // if the outer task was cancelled. Only abort early on cancellation
+            // when we are not in the shutdown path.
+            if !isShuttingDown, Task.isCancelled { return false }
             if ContinuousClock.now - started >= timeout {
                 return false
             }
             do {
                 try await Task.sleep(for: .milliseconds(250))
             } catch {
-                return false
+                if !isShuttingDown { return false }
+                // Controlled shutdown: ignore cancellation from the sleep and
+                // keep polling until the work finishes or the timeout expires.
             }
         }
         return true

--- a/provider-swift/Sources/ProviderCore/ProviderLoop.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop.swift
@@ -805,6 +805,11 @@ public actor ProviderLoop {
         isShuttingDown = true
         if drainInflight {
             logger.info("Graceful shutdown requested; draining active inference before closing coordinator connection")
+            // The run loop has stopped consuming coordinator events, but we keep
+            // the socket open to finish in-flight responses. Tell the client to
+            // reject NEW inference requests with 503 so the coordinator reroutes
+            // them immediately instead of black-holing them for the whole drain.
+            await coordinatorClient?.beginDraining()
             // Cancel background work + preloads first, but keep the coordinator
             // socket open so in-flight responses can still be delivered while we
             // drain. `sparingInflightLoads: true` lets a request that was still

--- a/provider-swift/Sources/ProviderCore/ProviderLoop.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop.swift
@@ -215,6 +215,13 @@ public actor ProviderLoop {
     private var isLoadingAny: Bool = false
     private var isShuttingDown: Bool = false
 
+    /// Memoized graceful-shutdown task. Both the run-task cancellation handler
+    /// and the run-loop fall-through funnel through `startShutdown(drainInflight:)`
+    /// so they share ONE shutdown sequence instead of racing each other. Without
+    /// this, the fall-through could close the coordinator socket and unload
+    /// models while the drain task was still waiting for in-flight streams.
+    private var shutdownTask: Task<Void, Never>?
+
     /// Phase of a graceful auto-update cycle. Drives admission: in `.draining`
     /// we refuse new requests (503 reroute) so in-flight work can finish before
     /// the hot-swap restart. See `AutoUpdateController`.
@@ -751,40 +758,71 @@ public actor ProviderLoop {
                 }
             }
         } onCancel: {
-            Task { await self.beginGracefulShutdown() }
+            // SIGTERM / `darkbloom stop` / schedule-close cancels the run task.
+            // Kick off the shared graceful shutdown, which drains in-flight
+            // inference *before* the transport is torn down. The fall-through
+            // below awaits the same memoized task, so the coordinator socket and
+            // loaded models stay alive until the drain completes. The drain runs
+            // inside an unstructured Task (created by `startShutdown`) that does
+            // NOT inherit this cancellation, so `waitForInflightDrain` keeps
+            // polling instead of bailing on `Task.isCancelled`.
+            Task { await self.startShutdown(drainInflight: true).value }
         }
 
+        // The event stream ended. If the run task was cancelled (user stop /
+        // restart / schedule close) we drain in-flight inference first; otherwise
+        // (coordinator disconnect, stream finished on its own) we cancel promptly
+        // because responses can no longer be delivered. Either way we await the
+        // SINGLE shared shutdown task, so transport teardown and model unloading
+        // happen only after the drain — never racing it.
+        let runTaskCancelled = Task.isCancelled
         logger.info("Event stream ended, shutting down")
-        await completeShutdown()
+        await startShutdown(drainInflight: runTaskCancelled).value
     }
 
-    /// Begin graceful shutdown: reject new work, drain active inference while
-    /// keeping the coordinator socket open, then close the socket so the event
-    /// loop in `run()` can finish. Safe to call multiple times; subsequent calls
-    /// are no-ops once `isShuttingDown` is true.
-    private func beginGracefulShutdown() async {
-        guard !isShuttingDown else { return }
+    /// Start (once) the graceful-shutdown sequence and return the shared task so
+    /// every caller awaits the same drain + teardown. The first caller fixes
+    /// `drainInflight`; later callers receive the in-progress task. This memo is
+    /// what prevents the cancellation handler and the run-loop fall-through from
+    /// running two competing shutdowns.
+    @discardableResult
+    private func startShutdown(drainInflight: Bool) -> Task<Void, Never> {
+        if let shutdownTask { return shutdownTask }
+        let task = Task { await self.runShutdownSequence(drainInflight: drainInflight) }
+        shutdownTask = task
+        return task
+    }
+
+    /// The single graceful-shutdown sequence (runs exactly once via the
+    /// `startShutdown` memo):
+    ///   1. Mark `isShuttingDown` so new work is refused (503 reroute).
+    ///   2. Either drain in-flight inference while keeping the coordinator socket
+    ///      OPEN (so chunks + final completions still reach consumers), or — when
+    ///      the connection is already gone — cancel in-flight work outright.
+    ///   3. Only AFTER the drain completes, tear down the transport, the disk
+    ///      accountant, and unload models, then release power assertions.
+    private func runShutdownSequence(drainInflight: Bool) async {
         isShuttingDown = true
-        logger.info("Graceful shutdown requested; draining active inference before closing coordinator connection")
-        await cancelBackgroundWorkAndPreloads()
-        let drained = await waitForInflightDrain(timeout: Self.shutdownDrainTimeout)
-        if !drained {
-            logger.warning("Timed out waiting for active inference to drain; cancelling remaining requests")
+        if drainInflight {
+            logger.info("Graceful shutdown requested; draining active inference before closing coordinator connection")
+            // Cancel background work first, but keep the coordinator socket open
+            // so in-flight responses can still be delivered while we drain.
+            await cancelBackgroundWorkAndPreloads()
+            let drained = await waitForInflightDrain(timeout: Self.shutdownDrainTimeout)
+            if !drained {
+                logger.warning("Timed out waiting for active inference to drain; cancelling remaining requests")
+                await cancelAllInflight()
+            }
+        } else {
+            // The event stream ended without a controlled drain (e.g. coordinator
+            // disconnect): the connection is already gone, so cancel in-flight
+            // work rather than waiting on responses that can't be delivered.
             await cancelAllInflight()
+            await cancelBackgroundWorkAndPreloads()
         }
-        await coordinatorClient?.shutdown()
-    }
 
-    /// Finish shutdown after the event stream has ended. If a graceful shutdown
-    /// has already run, this only performs the remaining cleanup (disk accountant,
-    /// model unloading). If the stream ended for another reason (e.g., disconnect),
-    /// it cancels in-flight work and runs the full teardown.
-    private func completeShutdown() async {
-        if !isShuttingDown {
-            isShuttingDown = true
-            await cancelAllInflight()
-        }
-        await cancelBackgroundWorkAndPreloads()
+        // Drain (if any) is complete: now it is safe to close the transport and
+        // release GPU/model resources.
         await coordinatorClient?.shutdown()
         // Phase 3: shutdown the global disk accountant.
         await diskAccountant.shutdown()
@@ -801,7 +839,8 @@ public actor ProviderLoop {
     }
 
     /// Cancel optional background tasks and prefetch/preload work. Idempotent so
-    /// it can be called from both `beginGracefulShutdown` and `completeShutdown`.
+    /// it can be called from both the drain and non-drain branches of
+    /// `runShutdownSequence`.
     private func cancelBackgroundWorkAndPreloads() async {
         idleMonitorTask?.cancel()
         idleMonitorTask = nil
@@ -1113,12 +1152,24 @@ public actor ProviderLoop {
         }
 
         // 4. Authoritative drain re-check. `await fastAdmissionReject` above is a
-        // suspension point, so draining could have begun (and the drain snapshot
-        // taken) while this request was parked — letting it slip past the early
-        // gate. There is NO `await` between this check and the `requestToModel`
-        // registration below, so on the actor it is atomic: either we reject now,
-        // or the request is counted in `hasInflightWork` before any drain
-        // snapshot can miss it.
+        // suspension point, so a shutdown or update-drain could have begun (and
+        // its drain snapshot taken) while this request was parked — letting it
+        // slip past the early gates at the top of this method. There is NO
+        // `await` between these checks and the `requestToModel` registration
+        // below, so on the actor they are atomic: either we reject now, or the
+        // request is counted in `hasInflightWork` before any drain snapshot can
+        // miss it. The shutdown re-check must come first — without it, a request
+        // suspended in `fastAdmissionReject` when SIGTERM arrives would send
+        // `inference_accepted` and then be dropped as the socket/models tear
+        // down, instead of cleanly returning 503 so the coordinator reroutes.
+        if isShuttingDown {
+            send.send(.inferenceError(
+                requestId: requestId,
+                error: "provider is shutting down",
+                statusCode: 503
+            ))
+            return
+        }
         if rejectIfDrainingForUpdate(requestId: requestId, send: send) { return }
 
         // 5. Send inference_accepted

--- a/provider-swift/Sources/ProviderCore/ProviderLoop.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop.swift
@@ -822,9 +822,17 @@ public actor ProviderLoop {
             // and to route `cancel` frames for in-flight requests straight to
             // `handleCancellation` so an aborted stream stops generating promptly.
             let drainSelf = self
-            await coordinatorClient?.beginDraining(onCancel: { requestId in
-                await drainSelf.handleCancellation(requestId: requestId, receivedFromCoordinator: true)
-            })
+            await coordinatorClient?.beginDraining(
+                onCancel: { requestId in
+                    await drainSelf.handleCancellation(requestId: requestId, receivedFromCoordinator: true)
+                },
+                onDisconnect: {
+                    // The socket dropped mid-drain: the coordinator has failed our
+                    // in-flight requests, so cancel them instead of generating
+                    // frames that can no longer reach the consumer.
+                    await drainSelf.cancelAllInflight()
+                }
+            )
             // Cancel background work + preloads first, but keep the coordinator
             // socket open so in-flight responses can still be delivered while we
             // drain. `sparingInflightLoads: true` lets a request that was still
@@ -893,16 +901,27 @@ public actor ProviderLoop {
         if let prefetchCoordinator {
             await prefetchCoordinator.shutdown(timeout: Self.preloadShutdownTimeout)
         }
-        let preloads = Array(preloadTasks.values)
-        for task in preloads { task.cancel() }
+        // During a graceful drain, a preload may be the actual loader for a model
+        // that an already-accepted request is waiting on (the request sits in
+        // `loadingWaiters` while the preload owns `ensureModelLoaded`). Cancelling
+        // that preload would fail the accepted request instead of letting it
+        // drain, so spare preloads whose model still backs an in-flight request
+        // and only cancel/await the background-only ones. Spared preloads finish
+        // the load (waiters resume) and clean themselves up via `removePreloadTask`.
+        let inflightModels = sparingInflightLoads ? Set(requestToModel.values) : Set<String>()
+        let preloadsToCancel = preloadTasks.filter { !inflightModels.contains($0.key) }
+        for (_, task) in preloadsToCancel { task.cancel() }
         cancelLoadWaiters(sparingInflightRequests: sparingInflightLoads)
-        let preloadsFinished = await waitForPreloads(preloads, timeout: Self.preloadShutdownTimeout)
+        let cancelledPreloads = Array(preloadsToCancel.values)
+        let preloadsFinished = await waitForPreloads(cancelledPreloads, timeout: Self.preloadShutdownTimeout)
         if !preloadsFinished {
             logger.warning("Timed out waiting for coordinator-driven preloads to cancel during shutdown")
         }
-        preloadTasks.removeAll()
-        preloadTaskIds.removeAll()
-        preloadStatusSubscribers.removeAll()
+        for key in preloadsToCancel.keys {
+            preloadTasks.removeValue(forKey: key)
+            preloadTaskIds.removeValue(forKey: key)
+            preloadStatusSubscribers.removeValue(forKey: key)
+        }
     }
 
     // MARK: - Security Hardening
@@ -1245,6 +1264,20 @@ public actor ProviderLoop {
                 await updateAggregateCapacity()
             }
             await cancellationRegistry.finish(requestId: requestId)
+            // A cancelled load (client/coordinator cancel, or a shutdown drain
+            // cancelling the detached load task) is NOT a model fault. Reporting
+            // "model load failed" with a 5xx would make the coordinator cooldown
+            // / deroute a healthy provider+model. Map it to a clean shutdown 503
+            // (reroute) when draining, and stay silent for a plain cancel — the
+            // coordinator already aborted the request that triggered it.
+            if error is CancellationError {
+                if isShuttingDown {
+                    send.send(.inferenceError(requestId: requestId, error: "provider is shutting down", statusCode: 503))
+                } else {
+                    logger.info("[\(requestId)] Model load cancelled before completion")
+                }
+                return
+            }
             logger.error("[\(requestId)] Failed to load model '\(modelId)': \(error)")
             let statusCode = Self.loadErrorStatusCode(for: error)
             send.send(.inferenceError(requestId: requestId, error: "model load failed: \(error.localizedDescription)", statusCode: statusCode))

--- a/provider-swift/Sources/ProviderCore/ProviderLoop.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop.swift
@@ -257,6 +257,13 @@ public actor ProviderLoop {
     /// Tracks in-flight inference tasks by request ID so they can be cancelled.
     private var inflightTasks: [String: Task<Void, Never>] = [:]
 
+    /// Tracks the per-request DETACHED model-load tasks (see `handleInferenceRequest`)
+    /// so they can be cancelled when in-flight work is torn down. Without a retained
+    /// handle, a load that stalls past the drain timeout would leave
+    /// `handleInferenceRequest` awaiting `loadTask.value` forever, so `run()` could
+    /// never return and the CLI would escalate to SIGKILL instead of exiting cleanly.
+    private var inflightModelLoadTasks: [String: Task<Void, Error>] = [:]
+
     /// A detached task can finish before the actor stores it in `inflightTasks`.
     /// Track that edge so the post-spawn registration does not leave a stale task.
     private var completedBeforeTaskRegistration = Set<String>()
@@ -404,6 +411,9 @@ public actor ProviderLoop {
 
     private static let shutdownDrainTimeout: Duration = .seconds(600)
     private static let preloadShutdownTimeout: Duration = .seconds(10)
+    /// Max time to wait for queued outbound frames to flush to the socket during
+    /// a graceful drain before closing the transport.
+    private static let outboundFlushTimeout: Duration = .seconds(5)
     private static let bytesPerGiB: UInt64 = 1024 * 1024 * 1024
 
     // MARK: - Initialization
@@ -808,8 +818,13 @@ public actor ProviderLoop {
             // The run loop has stopped consuming coordinator events, but we keep
             // the socket open to finish in-flight responses. Tell the client to
             // reject NEW inference requests with 503 so the coordinator reroutes
-            // them immediately instead of black-holing them for the whole drain.
-            await coordinatorClient?.beginDraining()
+            // them immediately instead of black-holing them for the whole drain,
+            // and to route `cancel` frames for in-flight requests straight to
+            // `handleCancellation` so an aborted stream stops generating promptly.
+            let drainSelf = self
+            await coordinatorClient?.beginDraining(onCancel: { requestId in
+                await drainSelf.handleCancellation(requestId: requestId, receivedFromCoordinator: true)
+            })
             // Cancel background work + preloads first, but keep the coordinator
             // socket open so in-flight responses can still be delivered while we
             // drain. `sparingInflightLoads: true` lets a request that was still
@@ -824,6 +839,11 @@ public actor ProviderLoop {
                 // but never finished, so suspended load tasks unwind.
                 cancelLoadWaiters()
             }
+            // Flush queued outbound frames (the tail of a finished request — its
+            // last chunks and `inference_complete`) before tearing down the
+            // transport, so a slow socket doesn't drop responses for a request
+            // that just drained successfully.
+            await coordinatorClient?.flushOutbound(timeout: Self.outboundFlushTimeout)
         } else {
             // The event stream ended without a controlled drain (e.g. coordinator
             // disconnect): the connection is already gone, so cancel in-flight
@@ -1212,9 +1232,13 @@ public actor ProviderLoop {
         // model (`shutdownShouldAbortLoad`). Awaiting `.value` from a cancelled
         // run task does not throw — it waits for the load to finish.
         let loadSelf = self
+        let loadTask = Task.detached { try await loadSelf.ensureModelLoaded(modelId: modelId) }
+        inflightModelLoadTasks[requestId] = loadTask
         do {
-            try await Task.detached { try await loadSelf.ensureModelLoaded(modelId: modelId) }.value
+            try await loadTask.value
+            inflightModelLoadTasks[requestId] = nil
         } catch {
+            inflightModelLoadTasks[requestId] = nil
             if requestToModel.removeValue(forKey: requestId) != nil {
                 powerAssertion.release()
                 syncWarmModelState()
@@ -3268,6 +3292,12 @@ public actor ProviderLoop {
     }
 
     private func cancelAllInflight() async {
+        // Cancel detached model-load tasks first: a request still cold-loading
+        // (awaiting `loadTask.value` in `handleInferenceRequest`) only unblocks
+        // when its load task is cancelled or finishes. Without this, a stalled
+        // load would keep `run()` from returning past the drain timeout.
+        for task in inflightModelLoadTasks.values { task.cancel() }
+        inflightModelLoadTasks.removeAll()
         let requestIds = Array(inflightTasks.keys)
         for requestId in requestIds {
             await handleCancellation(requestId: requestId, receivedFromCoordinator: false)

--- a/provider-swift/Sources/ProviderCore/ProviderLoop.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop.swift
@@ -3286,6 +3286,14 @@ public actor ProviderLoop {
         syncWarmModelState()
         await updateAggregateCapacity()
 
+        // Cancel the detached cold-load task (if this request is still loading),
+        // so `handleInferenceRequest`'s `await loadTask.value` unblocks. Without
+        // this, a cancel during a stalled cold load would leave the serve task
+        // awaiting forever and the CLI would escalate to SIGKILL.
+        if let loadTask = inflightModelLoadTasks.removeValue(forKey: requestId) {
+            loadTask.cancel()
+        }
+
         if let task = inflightTasks.removeValue(forKey: requestId) {
             task.cancel()
         }

--- a/provider-swift/Sources/ProviderCore/ProviderLoop.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop.swift
@@ -1959,6 +1959,7 @@ public actor ProviderLoop {
             currentModel: state.currentModel,
             warmModels: state.warmModels,
             inferenceActive: state.inferenceActive,
+            inflightRequestCount: requestToModel.count + localReservations.totalInFlight,
             stats: DaemonState.Stats(
                 requestsServed: stats.requestsServed,
                 tokensGenerated: stats.tokensGenerated,

--- a/provider-swift/Sources/ProviderCore/ProviderLoop.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop.swift
@@ -684,8 +684,9 @@ public actor ProviderLoop {
         logger.info("Coordinator client started, entering event loop")
 
         // 5. Process events. Cancellation is used by schedule enforcement
-        // and service shutdown; explicitly close the WebSocket so the stream
-        // unblocks instead of waiting for the next coordinator event.
+        // and service shutdown. On cancellation we begin a graceful shutdown
+        // that drains active inference *before* closing the coordinator socket,
+        // so in-flight responses can still reach consumers while we wind down.
         await withTaskCancellationHandler {
             for await event in events {
                 switch event {
@@ -750,11 +751,58 @@ public actor ProviderLoop {
                 }
             }
         } onCancel: {
-            Task { await coordinator.shutdown() }
+            Task { await self.beginGracefulShutdown() }
         }
 
         logger.info("Event stream ended, shutting down")
+        await completeShutdown()
+    }
+
+    /// Begin graceful shutdown: reject new work, drain active inference while
+    /// keeping the coordinator socket open, then close the socket so the event
+    /// loop in `run()` can finish. Safe to call multiple times; subsequent calls
+    /// are no-ops once `isShuttingDown` is true.
+    private func beginGracefulShutdown() async {
+        guard !isShuttingDown else { return }
         isShuttingDown = true
+        logger.info("Graceful shutdown requested; draining active inference before closing coordinator connection")
+        await cancelBackgroundWorkAndPreloads()
+        let drained = await waitForInflightDrain(timeout: Self.shutdownDrainTimeout)
+        if !drained {
+            logger.warning("Timed out waiting for active inference to drain; cancelling remaining requests")
+            await cancelAllInflight()
+        }
+        await coordinatorClient?.shutdown()
+    }
+
+    /// Finish shutdown after the event stream has ended. If a graceful shutdown
+    /// has already run, this only performs the remaining cleanup (disk accountant,
+    /// model unloading). If the stream ended for another reason (e.g., disconnect),
+    /// it cancels in-flight work and runs the full teardown.
+    private func completeShutdown() async {
+        if !isShuttingDown {
+            isShuttingDown = true
+            await cancelAllInflight()
+        }
+        await cancelBackgroundWorkAndPreloads()
+        await coordinatorClient?.shutdown()
+        // Phase 3: shutdown the global disk accountant.
+        await diskAccountant.shutdown()
+        while !modelSlots.isEmpty {
+            if let unloading = modelsUnloading.first {
+                await waitForModelUnload(unloading)
+                continue
+            }
+            for modelId in Array(modelSlots.keys) {
+                await unloadModel(modelId)
+            }
+        }
+        powerAssertion.releaseAll()
+    }
+
+    /// Cancel optional background tasks and prefetch/preload work. Idempotent so
+    /// it can be called from both `beginGracefulShutdown` and `completeShutdown`.
+    private func cancelBackgroundWorkAndPreloads() async {
         idleMonitorTask?.cancel()
         idleMonitorTask = nil
         capacityRefreshTask?.cancel()
@@ -783,25 +831,6 @@ public actor ProviderLoop {
         preloadTasks.removeAll()
         preloadTaskIds.removeAll()
         preloadStatusSubscribers.removeAll()
-
-        let drained = await waitForInflightDrain(timeout: Self.shutdownDrainTimeout)
-        if !drained {
-            logger.warning("Timed out waiting for active inference to drain; cancelling remaining requests")
-            await cancelAllInflight()
-        }
-        await coordinator.shutdown()
-        // Phase 3: shutdown the global disk accountant.
-        await diskAccountant.shutdown()
-        while !modelSlots.isEmpty {
-            if let unloading = modelsUnloading.first {
-                await waitForModelUnload(unloading)
-                continue
-            }
-            for modelId in Array(modelSlots.keys) {
-                await unloadModel(modelId)
-            }
-        }
-        powerAssertion.releaseAll()
     }
 
     // MARK: - Security Hardening

--- a/provider-swift/Sources/ProviderCore/ProviderLoop.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop.swift
@@ -805,20 +805,26 @@ public actor ProviderLoop {
         isShuttingDown = true
         if drainInflight {
             logger.info("Graceful shutdown requested; draining active inference before closing coordinator connection")
-            // Cancel background work first, but keep the coordinator socket open
-            // so in-flight responses can still be delivered while we drain.
-            await cancelBackgroundWorkAndPreloads()
+            // Cancel background work + preloads first, but keep the coordinator
+            // socket open so in-flight responses can still be delivered while we
+            // drain. `sparingInflightLoads: true` lets a request that was still
+            // cold-loading when shutdown began finish its load (only background
+            // preloads are cancelled), so it can drain instead of erroring.
+            await cancelBackgroundWorkAndPreloads(sparingInflightLoads: true)
             let drained = await waitForInflightDrain(timeout: Self.shutdownDrainTimeout)
             if !drained {
                 logger.warning("Timed out waiting for active inference to drain; cancelling remaining requests")
                 await cancelAllInflight()
+                // The drain window is over: abort any loads that were spared above
+                // but never finished, so suspended load tasks unwind.
+                cancelLoadWaiters()
             }
         } else {
             // The event stream ended without a controlled drain (e.g. coordinator
             // disconnect): the connection is already gone, so cancel in-flight
             // work rather than waiting on responses that can't be delivered.
             await cancelAllInflight()
-            await cancelBackgroundWorkAndPreloads()
+            await cancelBackgroundWorkAndPreloads(sparingInflightLoads: false)
         }
 
         // Drain (if any) is complete: now it is safe to close the transport and
@@ -840,8 +846,10 @@ public actor ProviderLoop {
 
     /// Cancel optional background tasks and prefetch/preload work. Idempotent so
     /// it can be called from both the drain and non-drain branches of
-    /// `runShutdownSequence`.
-    private func cancelBackgroundWorkAndPreloads() async {
+    /// `runShutdownSequence`. `sparingInflightLoads` is forwarded to
+    /// `cancelLoadWaiters`: during a graceful drain we spare loads backing an
+    /// accepted request so they can finish.
+    private func cancelBackgroundWorkAndPreloads(sparingInflightLoads: Bool) async {
         idleMonitorTask?.cancel()
         idleMonitorTask = nil
         capacityRefreshTask?.cancel()
@@ -862,7 +870,7 @@ public actor ProviderLoop {
         }
         let preloads = Array(preloadTasks.values)
         for task in preloads { task.cancel() }
-        cancelLoadWaiters()
+        cancelLoadWaiters(sparingInflightRequests: sparingInflightLoads)
         let preloadsFinished = await waitForPreloads(preloads, timeout: Self.preloadShutdownTimeout)
         if !preloadsFinished {
             logger.warning("Timed out waiting for coordinator-driven preloads to cancel during shutdown")
@@ -1187,8 +1195,20 @@ public actor ProviderLoop {
         // request consuming the last slot or free memory between accept and
         // load). Map the failure to a status code so capacity errors reroute
         // (503) and missing models 404 instead of always counting as a fault.
+        //
+        // Run the load in a DETACHED task. `handleInferenceRequest` is awaited
+        // inline from the run loop, so it inherits the run task — which a stop/
+        // restart cancels. Detaching means a graceful drain lets this
+        // already-accepted request (it has `inference_accepted` + a
+        // `requestToModel` entry) finish its cold load instead of aborting it
+        // via `Task.checkCancellation()`. The detached task is not cancelled, so
+        // those gates (which exist to abort *background preloads*) don't fire for
+        // it; shutdown still aborts it only if no in-flight request needs the
+        // model (`shutdownShouldAbortLoad`). Awaiting `.value` from a cancelled
+        // run task does not throw — it waits for the load to finish.
+        let loadSelf = self
         do {
-            try await ensureModelLoaded(modelId: modelId)
+            try await Task.detached { try await loadSelf.ensureModelLoaded(modelId: modelId) }.value
         } catch {
             if requestToModel.removeValue(forKey: requestId) != nil {
                 powerAssertion.release()
@@ -2189,9 +2209,22 @@ public actor ProviderLoop {
         }
     }
 
-    private func cancelLoadWaiters() {
-        for waiters in loadingWaiters.values {
-            for waiter in waiters { waiter.resume(throwing: CancellationError()) }
+    /// Resume everyone suspended in the load path. With
+    /// `sparingInflightRequests: true` (graceful drain), waiters whose model
+    /// still backs an accepted request are resumed WITHOUT an error so their
+    /// load keeps going and the request can drain — only background-preload
+    /// waiters are cancelled. Gate waiters are always resumed (no error); each
+    /// resumed task re-checks `Task.isCancelled` / `shutdownShouldAbortLoad`, so
+    /// preloads still abort while spared in-flight loads continue. The final
+    /// teardown / post-drain-timeout path passes `false` to abort everything.
+    private func cancelLoadWaiters(sparingInflightRequests: Bool = false) {
+        let inflightModels = sparingInflightRequests ? Set(requestToModel.values) : Set<String>()
+        for (modelId, waiters) in loadingWaiters {
+            if inflightModels.contains(modelId) {
+                for waiter in waiters { waiter.resume() }
+            } else {
+                for waiter in waiters { waiter.resume(throwing: CancellationError()) }
+            }
         }
         loadingWaiters.removeAll()
         releaseLoadGateWaiters()
@@ -2606,7 +2639,7 @@ public actor ProviderLoop {
             return (fingerprint, WeightHasher.computeHash(snapshotDir: modelPath, modelID: modelId), false)
         }.value
         try Task.checkCancellation()
-        if isShuttingDown { throw CancellationError() }
+        if shutdownShouldAbortLoad(modelId) { throw CancellationError() }
 
         // Record the fingerprint ONLY when we have a hash that corresponds to it
         // (fresh or skip-confirmed). Caching it after a FAILED re-hash would make
@@ -2643,14 +2676,30 @@ public actor ProviderLoop {
         )
     }
 
+    /// During a graceful drain we still finish model loads that an
+    /// already-accepted coordinator request is waiting on — its `modelId` is
+    /// present in `requestToModel` (set, with `inference_accepted` already sent,
+    /// in the same actor-atomic step before the load begins). Only pure
+    /// background preloads (no in-flight request for the model) abort early. This
+    /// lets `darkbloom stop`/`restart` drain a request that was still
+    /// cold-loading when shutdown began instead of aborting it with an error.
+    ///
+    /// Local-endpoint requests are intentionally NOT spared: new local work is
+    /// already refused on shutdown (`throwIfRefusingNewLocalWork`) both before
+    /// and after the load, so sparing the load would only load a model the
+    /// request is about to be rejected for.
+    private func shutdownShouldAbortLoad(_ modelId: String) -> Bool {
+        isShuttingDown && !requestToModel.values.contains(modelId)
+    }
+
     private func ensureModelLoaded(modelId: String) async throws {
-        if isShuttingDown {
+        if shutdownShouldAbortLoad(modelId) {
             throw CancellationError()
         }
 
         while modelsUnloading.contains(modelId) {
             await waitForModelUnload(modelId)
-            if isShuttingDown { throw CancellationError() }
+            if shutdownShouldAbortLoad(modelId) { throw CancellationError() }
         }
 
         if modelSlots[modelId] != nil {
@@ -2662,10 +2711,10 @@ public actor ProviderLoop {
                 loadingWaiters[modelId, default: []].append(cont)
             }
             try Task.checkCancellation()
-            if isShuttingDown { throw CancellationError() }
+            if shutdownShouldAbortLoad(modelId) { throw CancellationError() }
             while modelsUnloading.contains(modelId) {
                 await waitForModelUnload(modelId)
-                if isShuttingDown { throw CancellationError() }
+                if shutdownShouldAbortLoad(modelId) { throw CancellationError() }
             }
             if modelSlots[modelId] != nil { return }
             try await ensureModelLoaded(modelId: modelId)
@@ -2692,10 +2741,10 @@ public actor ProviderLoop {
             // Honor cancellation (e.g. shutdown cancelled this preload task
             // while it was suspended at the gate).
             try Task.checkCancellation()
-            if isShuttingDown { throw CancellationError() }
+            if shutdownShouldAbortLoad(modelId) { throw CancellationError() }
             while modelsUnloading.contains(modelId) {
                 await waitForModelUnload(modelId)
-                if isShuttingDown { throw CancellationError() }
+                if shutdownShouldAbortLoad(modelId) { throw CancellationError() }
             }
             if modelSlots[modelId] != nil { return }
         }
@@ -2726,7 +2775,7 @@ public actor ProviderLoop {
         modelsLoading.insert(modelId)
         do {
             try Task.checkCancellation()
-            if isShuttingDown { throw CancellationError() }
+            if shutdownShouldAbortLoad(modelId) { throw CancellationError() }
 
             // Load gate: require room for the WEIGHTS plus headroom for ONE
             // request, not a full-concurrency multiple. Concurrency beyond one
@@ -2751,7 +2800,7 @@ public actor ProviderLoop {
                 throw InferenceError.modelLoadFailed(message)
             }
             try Task.checkCancellation()
-            if isShuttingDown { throw CancellationError() }
+            if shutdownShouldAbortLoad(modelId) { throw CancellationError() }
 
             // Q6: reserve this load's weight footprint in the shared KV budget so
             // a concurrent KV reservation on an already-loaded model can't grant
@@ -2775,11 +2824,11 @@ public actor ProviderLoop {
             if let beforeModelLoad {
                 await beforeModelLoad(modelId)
                 try Task.checkCancellation()
-                if isShuttingDown { throw CancellationError() }
+                if shutdownShouldAbortLoad(modelId) { throw CancellationError() }
             }
             let container = try await loadModelContainer(from: modelPath)
             try Task.checkCancellation()
-            if isShuttingDown { throw CancellationError() }
+            if shutdownShouldAbortLoad(modelId) { throw CancellationError() }
 
             // TOCTOU guard: the hash above was computed BEFORE loadModelContainer
             // read the weights. If a re-download landed in that window,
@@ -2815,7 +2864,7 @@ public actor ProviderLoop {
             // concurrent KV reservations see the weights from here on. (Also
             // released in catch for the error paths above.)
             await kvBudget.release(requestID: pendingLoadID)
-            if isShuttingDown || Task.isCancelled {
+            if shutdownShouldAbortLoad(modelId) || Task.isCancelled {
                 await scheduler.unloadModel()
                 MLX.Memory.clearCache()
                 throw CancellationError()

--- a/provider-swift/Sources/ProviderCore/Service/DaemonStateFile.swift
+++ b/provider-swift/Sources/ProviderCore/Service/DaemonStateFile.swift
@@ -26,6 +26,7 @@ public struct DaemonState: Codable, Sendable, Equatable {
     public var currentModel: String?
     public var warmModels: [String]
     public var inferenceActive: Bool
+    public var inflightRequestCount: Int
     public var stats: Stats
     public var system: SystemInfo?
     public var capacity: Capacity?
@@ -113,6 +114,7 @@ public struct DaemonState: Codable, Sendable, Equatable {
         currentModel: String? = nil,
         warmModels: [String] = [],
         inferenceActive: Bool = false,
+        inflightRequestCount: Int = 0,
         stats: Stats = Stats(),
         system: SystemInfo? = nil,
         capacity: Capacity? = nil,
@@ -128,6 +130,7 @@ public struct DaemonState: Codable, Sendable, Equatable {
         self.currentModel = currentModel
         self.warmModels = warmModels
         self.inferenceActive = inferenceActive
+        self.inflightRequestCount = inflightRequestCount
         self.stats = stats
         self.system = system
         self.capacity = capacity

--- a/provider-swift/Sources/ProviderCore/Service/DaemonStateFile.swift
+++ b/provider-swift/Sources/ProviderCore/Service/DaemonStateFile.swift
@@ -26,7 +26,7 @@ public struct DaemonState: Codable, Sendable, Equatable {
     public var currentModel: String?
     public var warmModels: [String]
     public var inferenceActive: Bool
-    public var inflightRequestCount: Int
+    public var inflightRequestCount: Int?
     public var stats: Stats
     public var system: SystemInfo?
     public var capacity: Capacity?
@@ -114,7 +114,7 @@ public struct DaemonState: Codable, Sendable, Equatable {
         currentModel: String? = nil,
         warmModels: [String] = [],
         inferenceActive: Bool = false,
-        inflightRequestCount: Int = 0,
+        inflightRequestCount: Int? = nil,
         stats: Stats = Stats(),
         system: SystemInfo? = nil,
         capacity: Capacity? = nil,

--- a/provider-swift/Sources/ProviderCore/Service/LaunchAgent.swift
+++ b/provider-swift/Sources/ProviderCore/Service/LaunchAgent.swift
@@ -329,6 +329,10 @@ public enum LaunchAgent: Sendable {
     /// the binary, racing the stage-then-swap. Crash-recovery is instead owned by
     /// the separate `WatchdogAgent`, which waits out a grace period before
     /// relaunching (so it never races the updater) and honours `darkbloom stop`.
+    ///
+    /// `ExitTimeOut = 600` gives the provider the same 10-minute window used by
+    /// `ProviderLoop.waitForInflightDrain()` to finish active inference before
+    /// launchd escalates `launchctl bootout` / logout shutdown to SIGKILL.
     static func makeServicePlist(
         label: String,
         programArguments: [String],
@@ -344,6 +348,7 @@ public enum LaunchAgent: Sendable {
             "StandardErrorPath": logPath,
             "ProcessType": "Interactive",
             "Nice": -5,
+            "ExitTimeOut": 600,
         ]
 
         // launchd does NOT inherit the installing shell's environment, so any

--- a/provider-swift/Sources/ProviderCore/Service/LaunchAgent.swift
+++ b/provider-swift/Sources/ProviderCore/Service/LaunchAgent.swift
@@ -68,22 +68,26 @@ public enum LaunchAgent: Sendable {
         }
     }
 
-    /// The PID launchd currently reports for the loaded provider service (the
-    /// canonical label, or the first loaded legacy label). Returns `nil` if no
-    /// supported label is loaded, or the job is loaded but not currently running
-    /// a process (e.g. installed-but-not-yet-kickstarted).
+    /// Every distinct PID launchd currently reports for loaded provider services,
+    /// across the canonical and legacy labels. Returns an empty array if no
+    /// supported label is loaded or none is currently running a process (e.g.
+    /// installed-but-not-yet-kickstarted).
     ///
-    /// This is the authoritative drain target: it ties a PID to the
-    /// launchd-managed daemon. Unlike the shared `~/.darkbloom/provider.pid`
-    /// lock file (which a standalone `start --local` server also writes), this
-    /// can never resolve to a non-launchd process.
-    public static func loadedServicePID() -> Int32? {
+    /// These are the authoritative drain targets: each PID is tied to a
+    /// launchd-managed daemon. Unlike the shared `~/.darkbloom/provider.pid` lock
+    /// file (which a standalone `start --local` server also writes), these can
+    /// never resolve to a non-launchd process. During an upgrade BOTH the
+    /// canonical and a legacy job can be loaded, and the stop/replace paths
+    /// unload every supported label — so all of them must be drained, not just
+    /// the first.
+    public static func loadedServicePIDs() -> [Int32] {
+        var pids: [Int32] = []
         for candidate in supportedLabels {
-            if let pid = servicePID(label: candidate) {
-                return pid
+            if let pid = servicePID(label: candidate), !pids.contains(pid) {
+                pids.append(pid)
             }
         }
-        return nil
+        return pids
     }
 
     /// Parse the `pid = N` field from `launchctl print gui/<uid>/<label>`.

--- a/provider-swift/Sources/ProviderCore/Service/LaunchAgent.swift
+++ b/provider-swift/Sources/ProviderCore/Service/LaunchAgent.swift
@@ -68,6 +68,58 @@ public enum LaunchAgent: Sendable {
         }
     }
 
+    /// The PID launchd currently reports for the loaded provider service (the
+    /// canonical label, or the first loaded legacy label). Returns `nil` if no
+    /// supported label is loaded, or the job is loaded but not currently running
+    /// a process (e.g. installed-but-not-yet-kickstarted).
+    ///
+    /// This is the authoritative drain target: it ties a PID to the
+    /// launchd-managed daemon. Unlike the shared `~/.darkbloom/provider.pid`
+    /// lock file (which a standalone `start --local` server also writes), this
+    /// can never resolve to a non-launchd process.
+    public static func loadedServicePID() -> Int32? {
+        for candidate in supportedLabels {
+            if let pid = servicePID(label: candidate) {
+                return pid
+            }
+        }
+        return nil
+    }
+
+    /// Parse the `pid = N` field from `launchctl print gui/<uid>/<label>`.
+    /// Returns `nil` when the label is not loaded or has no running PID.
+    private static func servicePID(label: String) -> Int32? {
+        let target = "gui/\(getuid())/\(label)"
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/launchctl")
+        process.arguments = ["print", target]
+        let stdout = Pipe()
+        process.standardOutput = stdout
+        process.standardError = FileHandle.nullDevice
+
+        do {
+            try process.run()
+        } catch {
+            return nil
+        }
+        // Read to EOF before waiting so a large `launchctl print` dump can't
+        // deadlock on a full pipe buffer.
+        let data = stdout.fileHandleForReading.readDataToEndOfFile()
+        process.waitUntilExit()
+        guard process.terminationStatus == 0,
+              let text = String(data: data, encoding: .utf8) else { return nil }
+
+        // launchctl prints a `\tpid = 12345` line only while the job is running.
+        for rawLine in text.split(separator: "\n") {
+            let line = rawLine.trimmingCharacters(in: .whitespaces)
+            guard line.hasPrefix("pid ") || line.hasPrefix("pid=") else { continue }
+            guard let eq = line.firstIndex(of: "=") else { continue }
+            let value = line[line.index(after: eq)...].trimmingCharacters(in: .whitespaces)
+            if let pid = Int32(value), pid > 0 { return pid }
+        }
+        return nil
+    }
+
     // MARK: - Install & Start
 
     /// Write the plist, load the service, and kickstart the process.

--- a/provider-swift/Sources/ProviderCore/Service/ProcessLifecycle.swift
+++ b/provider-swift/Sources/ProviderCore/Service/ProcessLifecycle.swift
@@ -160,6 +160,68 @@ public enum ProcessLifecycle {
         }
     }
 
+    /// Outcome of a graceful stop attempt via `stopProcessGracefully(_:timeout:onActiveRequests:)`.
+    public enum GracefulStopOutcome: Sendable, Equatable {
+        /// The target PID was not alive when the stop was requested.
+        case notRunning
+        /// The process exited after receiving SIGTERM (within the drain timeout).
+        case stoppedGracefully
+        /// The process did not exit within the drain timeout and was force-killed.
+        /// The value is the PID that was signalled.
+        case forceKilled(Int32)
+    }
+
+    /// Ask a running daemon process to shut down gracefully and wait for it to exit.
+    ///
+    /// Sends `SIGTERM`, then polls until the process exits or `timeout` elapses.
+    /// If the process is still alive after the timeout it is sent `SIGKILL` and
+    /// polled again briefly. This mirrors the provider's own shutdown drain:
+    /// `ProviderLoop.run()` cancels in-flight work and waits for active inference
+    /// to finish when its task is cancelled.
+    ///
+    /// - Parameters:
+    ///   - pid: Target process identifier.
+    ///   - timeout: Seconds to wait after sending SIGTERM before escalating to SIGKILL.
+    ///   - onActiveRequests: Called once if the process is still alive immediately
+    ///     after SIGTERM is delivered, signalling that the daemon is draining
+    ///     in-flight requests.
+    /// - Returns: The outcome of the stop attempt.
+    public static func stopProcessGracefully(
+        pid: Int32,
+        timeout: TimeInterval = 120.0,
+        onActiveRequests: (() -> Void)? = nil
+    ) async -> GracefulStopOutcome {
+        guard processIsAlive(pid) else { return .notRunning }
+
+        sendSignal(SIGTERM, to: pid)
+
+        // Fast path: process exited synchronously (nothing to drain).
+        if !processIsAlive(pid) { return .stoppedGracefully }
+
+        // The daemon is still running — it is draining. Notify the caller so the
+        // CLI can tell the user to wait.
+        onActiveRequests?()
+
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline, processIsAlive(pid) {
+            try? await Task.sleep(nanoseconds: 100_000_000) // 0.1s
+        }
+
+        if !processIsAlive(pid) {
+            return .stoppedGracefully
+        }
+
+        // Drain timeout expired: escalate to SIGKILL.
+        sendSignal(SIGKILL, to: pid)
+
+        let killDeadline = Date().addingTimeInterval(2.0)
+        while Date() < killDeadline, processIsAlive(pid) {
+            try? await Task.sleep(nanoseconds: 50_000_000) // 0.05s
+        }
+
+        return processIsAlive(pid) ? .forceKilled(pid) : .stoppedGracefully
+    }
+
     // MARK: - Internals
 
     private static func readPID(at url: URL) -> Int32? {
@@ -170,9 +232,10 @@ public enum ProcessLifecycle {
         return Int32(trimmed)
     }
 
-    private static func processIsAlive(_ pid: Int32) -> Bool {
-        // kill(pid, 0) returns 0 if we have permission to signal the process,
-        // even if signal 0 is a no-op. ESRCH means the process is gone.
+    /// Reports whether a process with the given PID is currently alive.
+    /// `kill(pid, 0)` returns 0 if we have permission to signal the process,
+    /// even though signal 0 is a no-op. `ESRCH` means the process is gone.
+    public static func processIsAlive(_ pid: Int32) -> Bool {
         let rc = kill(pid, 0)
         if rc == 0 { return true }
         return errno != ESRCH

--- a/provider-swift/Sources/ProviderCore/Service/ProcessLifecycle.swift
+++ b/provider-swift/Sources/ProviderCore/Service/ProcessLifecycle.swift
@@ -191,7 +191,7 @@ public enum ProcessLifecycle {
         timeout: TimeInterval = 120.0,
         onActiveRequests: (() -> Void)? = nil
     ) async -> GracefulStopOutcome {
-        guard processIsAlive(pid) else { return .notRunning }
+        guard pid > 0, processIsAlive(pid) else { return .notRunning }
 
         sendSignal(SIGTERM, to: pid)
 
@@ -211,7 +211,9 @@ public enum ProcessLifecycle {
             return .stoppedGracefully
         }
 
-        // Drain timeout expired: escalate to SIGKILL.
+        // Drain timeout expired: escalate to SIGKILL. Report this as a force
+        // kill even if SIGKILL eventually succeeds, because the graceful drain
+        // window was exceeded.
         sendSignal(SIGKILL, to: pid)
 
         let killDeadline = Date().addingTimeInterval(2.0)
@@ -219,7 +221,7 @@ public enum ProcessLifecycle {
             try? await Task.sleep(nanoseconds: 50_000_000) // 0.05s
         }
 
-        return processIsAlive(pid) ? .forceKilled(pid) : .stoppedGracefully
+        return .forceKilled(pid)
     }
 
     // MARK: - Internals

--- a/provider-swift/Sources/ProviderCore/Service/ProcessLifecycle.swift
+++ b/provider-swift/Sources/ProviderCore/Service/ProcessLifecycle.swift
@@ -188,7 +188,7 @@ public enum ProcessLifecycle {
     /// - Returns: The outcome of the stop attempt.
     public static func stopProcessGracefully(
         pid: Int32,
-        timeout: TimeInterval = 120.0,
+        timeout: TimeInterval = 600.0,
         onActiveRequests: (() -> Void)? = nil
     ) async -> GracefulStopOutcome {
         guard pid > 0, processIsAlive(pid) else { return .notRunning }
@@ -226,12 +226,14 @@ public enum ProcessLifecycle {
 
     // MARK: - Internals
 
-    private static func readPID(at url: URL) -> Int32? {
+    /// Read a PID from a file, returning `nil` if the file is missing or not a valid PID.
+    public static func readPID(at url: URL) -> Int32? {
         guard let raw = try? String(contentsOf: url, encoding: .utf8) else {
             return nil
         }
         let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
-        return Int32(trimmed)
+        guard let value = Int32(trimmed), value > 0 else { return nil }
+        return value
     }
 
     /// Reports whether a process with the given PID is currently alive.

--- a/provider-swift/Sources/ProviderCore/Service/ProcessLifecycle.swift
+++ b/provider-swift/Sources/ProviderCore/Service/ProcessLifecycle.swift
@@ -239,7 +239,14 @@ public enum ProcessLifecycle {
     /// Reports whether a process with the given PID is currently alive.
     /// `kill(pid, 0)` returns 0 if we have permission to signal the process,
     /// even though signal 0 is a no-op. `ESRCH` means the process is gone.
+    ///
+    /// Rejects nonpositive PIDs up front: `kill(0, …)` targets the caller's whole
+    /// process group and `kill(-1, …)` targets every process the user may signal.
+    /// This helper is fed by on-disk PID / daemon-state files, so a corrupt `0` or
+    /// `-1` must never be treated as "a live process" (and must never reach a real
+    /// `kill` via callers that gate on this result).
     public static func processIsAlive(_ pid: Int32) -> Bool {
+        guard pid > 0 else { return false }
         let rc = kill(pid, 0)
         if rc == 0 { return true }
         return errno != ESRCH

--- a/provider-swift/Sources/darkbloom/ProviderAppKitHost.swift
+++ b/provider-swift/Sources/darkbloom/ProviderAppKitHost.swift
@@ -44,10 +44,26 @@ enum ProviderAppKitHost {
 final class ProviderAppDelegate: NSObject, NSApplicationDelegate {
     private let args: [String]
 
+    /// The long-running serve task (`start --foreground` or `--local`). Retained
+    /// so that `applicationShouldTerminate` can request a graceful drain before
+    /// the app exits.
+    private var serveTask: Task<Void, Never>?
+
+    /// Set when AppKit asks us to terminate (SIGTERM from `launchctl bootout`,
+    /// logout, or `darkbloom stop` signalling the daemon PID). When true the
+    /// serve-task completion calls `reply(toApplicationShouldTerminate:)` instead
+    /// of `exit(0)` so AppKit finishes its own termination sequence cleanly.
+    private var terminationRequested = false
+
     init(args: [String]) {
         self.args = args
         super.init()
     }
+
+    /// Dispatch sources for SIGTERM/SIGINT. AppKit normally translates these
+    /// into `applicationShouldTerminate`, but a direct `kill <pid>` may bypass
+    /// that path; the sources ensure the graceful drain runs regardless.
+    private var signalSources: [DispatchSourceSignal] = []
 
     func applicationDidFinishLaunching(_: Notification) {
         // INVARIANT: register for REMOTE notifications only — never request
@@ -59,8 +75,14 @@ final class ProviderAppDelegate: NSObject, NSApplicationDelegate {
         // (apsd redacts the payload as <private> and keeps no cleartext copy —
         // verified on macOS 26.4, see docs/apns-code-attestation-design.md).
         NSApplication.shared.registerForRemoteNotifications()
+
+        // Install graceful-shutdown signal sources. We ignore the default action
+        // so DispatchSourceSignal fires, then ask AppKit to terminate, which
+        // routes through `applicationShouldTerminate` and cancels the serve task.
+        installShutdownSignalSources()
+
         let args = self.args
-        Task {
+        serveTask = Task {
             do {
                 let command = try Darkbloom.parseAsRoot(args)
                 if let asyncCommand = command as? AsyncParsableCommand {
@@ -70,10 +92,45 @@ final class ProviderAppDelegate: NSObject, NSApplicationDelegate {
                     var cmd = command
                     try cmd.run()
                 }
-                exit(0)
+                await self.finishServeTask()
             } catch {
+                await self.finishServeTask()
                 Darkbloom.exit(withError: error)
             }
+        }
+    }
+
+    /// Called by AppKit on SIGTERM / logout / `NSApp.terminate`. We cancel the
+    /// serve task so `ProviderLoop.run()` enters its shutdown drain, then tell
+    /// AppKit we'll reply later. The serve-task completion calls
+    /// `reply(toApplicationShouldTerminate: true)` once the drain finishes.
+    func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
+        terminationRequested = true
+        serveTask?.cancel()
+        return .terminateLater
+    }
+
+    private func finishServeTask() async {
+        if terminationRequested {
+            NSApp.reply(toApplicationShouldTerminate: true)
+        } else {
+            exit(0)
+        }
+    }
+
+    private func installShutdownSignalSources() {
+        let signals = [SIGTERM, SIGINT]
+        for signo in signals {
+            signal(signo, SIG_IGN)
+            let source = DispatchSource.makeSignalSource(signal: signo, queue: DispatchQueue.main)
+            source.setEventHandler { [weak self] in
+                self?.serveTask?.cancel()
+                // Also drive the AppKit termination path so the run loop exits
+                // cleanly once the serve task finishes draining.
+                NSApp.terminate(nil)
+            }
+            source.resume()
+            signalSources.append(source)
         }
     }
 

--- a/provider-swift/Sources/darkbloom/ProviderAppKitHost.swift
+++ b/provider-swift/Sources/darkbloom/ProviderAppKitHost.swift
@@ -55,6 +55,10 @@ final class ProviderAppDelegate: NSObject, NSApplicationDelegate {
     /// of `exit(0)` so AppKit finishes its own termination sequence cleanly.
     private var terminationRequested = false
 
+    /// Guard against calling `reply(toApplicationShouldTerminate:)` more than
+    /// once if AppKit re-enters termination or the signal source races it.
+    private var hasReplied = false
+
     init(args: [String]) {
         self.args = args
         super.init()
@@ -116,11 +120,12 @@ final class ProviderAppDelegate: NSObject, NSApplicationDelegate {
     }
 
     private func finishServeTask() async {
-        if terminationRequested {
-            NSApp.reply(toApplicationShouldTerminate: true)
-        } else {
+        guard terminationRequested else {
             exit(0)
         }
+        guard !hasReplied else { return }
+        hasReplied = true
+        NSApp.reply(toApplicationShouldTerminate: true)
     }
 
     private func installShutdownSignalSources() {

--- a/provider-swift/Sources/darkbloom/ProviderAppKitHost.swift
+++ b/provider-swift/Sources/darkbloom/ProviderAppKitHost.swift
@@ -94,7 +94,12 @@ final class ProviderAppDelegate: NSObject, NSApplicationDelegate {
                 }
                 await self.finishServeTask()
             } catch {
-                await self.finishServeTask()
+                // When AppKit requested termination, reply before exiting so
+                // the run loop terminates cleanly; otherwise preserve the
+                // nonzero exit from the actual failure.
+                if terminationRequested {
+                    await self.finishServeTask()
+                }
                 Darkbloom.exit(withError: error)
             }
         }

--- a/provider-swift/Sources/darkbloom/ProviderDrainHelper.swift
+++ b/provider-swift/Sources/darkbloom/ProviderDrainHelper.swift
@@ -37,38 +37,33 @@ func drainRunningProvider(
 ) async -> Bool {
     guard LaunchAgent.isAnySupportedLabelLoaded() else { return false }
 
+    // Authoritative drain target: the PID launchd reports for the loaded
+    // service. This ties the drain to the launchd-managed daemon, so a
+    // standalone `start --local` server — which also writes the shared
+    // `~/.darkbloom/provider.pid` lock file — is never the one we signal on
+    // `stop`/`restart`/replacement `start`.
+    guard let pid = LaunchAgent.loadedServicePID(), pid > 0, ProcessLifecycle.processIsAlive(pid) else {
+        // The job is loaded but launchd has no live PID for it (e.g. installed
+        // but not yet kickstarted). Fall back to the launchd-level path.
+        return false
+    }
+
+    // Read the daemon state for the user-facing in-flight count. If the freshest
+    // state describes a *different* process than the one launchd is running, the
+    // state file is stale/foreign — don't risk a confusing message, but still
+    // drain launchd's actual PID.
     let state = DaemonStateFile.read()
     let now = Date().timeIntervalSince1970
-    let statePID: Int32?
-    if let state, !state.isStale(now: now) {
-        statePID = state.pid
-    } else {
-        statePID = nil
-    }
+    let freshState: DaemonState? = {
+        guard let state, !state.isStale(now: now) else { return nil }
+        return state.pid == pid ? state : nil
+    }()
 
-    // Cross-check the state-file PID against the on-disk PID file to avoid
-    // signalling a PID that has been reused by another process.
-    let pidFilePID = ProcessLifecycle.readPID(at: ProcessLifecycle.defaultPIDFile())
-    let candidatePID = pidFilePID ?? statePID
-
-    guard let pid = candidatePID, pid > 0, ProcessLifecycle.processIsAlive(pid) else {
-        // launchd thinks the job is loaded but we have no trustworthy live PID.
-        // Fall back to the launchd-level stop/restart path.
-        return false
-    }
-
-    // If both sources are available they must agree; otherwise treat the
-    // running process as untrustworthy.
-    if let statePID, let pidFilePID, statePID != pidFilePID {
-        print("Warning: daemon state PID (\(statePID)) does not match PID file (\(pidFilePID)); skipping graceful drain.")
-        return false
-    }
-
-    let requestCount = state?.inflightRequestCount ?? (state?.inferenceActive == true ? 1 : 0)
+    let requestCount = freshState?.inflightRequestCount ?? (freshState?.inferenceActive == true ? 1 : 0)
     if requestCount > 0 {
         let plural = requestCount == 1 ? "" : "s"
         print("Provider is currently serving \(requestCount) request\(plural). Waiting up to \(Int(timeout))s for them to finish before \(action.verb)...")
-    } else if state?.inferenceActive == true {
+    } else if freshState?.inferenceActive == true {
         print("Provider is currently serving requests. Waiting up to \(Int(timeout))s for them to finish before \(action.verb)...")
     }
 

--- a/provider-swift/Sources/darkbloom/ProviderDrainHelper.swift
+++ b/provider-swift/Sources/darkbloom/ProviderDrainHelper.swift
@@ -33,26 +33,38 @@ enum DrainAction: Sendable {
 ///   its normal launchd path).
 func drainRunningProvider(
     action: DrainAction,
-    timeout: TimeInterval = 120.0
+    timeout: TimeInterval = 600.0
 ) async -> Bool {
     guard LaunchAgent.isAnySupportedLabelLoaded() else { return false }
 
     let state = DaemonStateFile.read()
     let now = Date().timeIntervalSince1970
-    let pid: Int32?
-    if let state, !state.isStale(now: now), ProcessLifecycle.processIsAlive(state.pid) {
-        pid = state.pid
+    let statePID: Int32?
+    if let state, !state.isStale(now: now) {
+        statePID = state.pid
     } else {
-        pid = nil
+        statePID = nil
     }
 
-    guard let pid else {
+    // Cross-check the state-file PID against the on-disk PID file to avoid
+    // signalling a PID that has been reused by another process.
+    let pidFilePID = ProcessLifecycle.readPID(at: ProcessLifecycle.defaultPIDFile())
+    let candidatePID = pidFilePID ?? statePID
+
+    guard let pid = candidatePID, pid > 0, ProcessLifecycle.processIsAlive(pid) else {
         // launchd thinks the job is loaded but we have no trustworthy live PID.
         // Fall back to the launchd-level stop/restart path.
         return false
     }
 
-    let requestCount = state?.inflightRequestCount ?? 0
+    // If both sources are available they must agree; otherwise treat the
+    // running process as untrustworthy.
+    if let statePID, let pidFilePID, statePID != pidFilePID {
+        print("Warning: daemon state PID (\(statePID)) does not match PID file (\(pidFilePID)); skipping graceful drain.")
+        return false
+    }
+
+    let requestCount = state?.inflightRequestCount ?? (state?.inferenceActive == true ? 1 : 0)
     if requestCount > 0 {
         let plural = requestCount == 1 ? "" : "s"
         print("Provider is currently serving \(requestCount) request\(plural). Waiting up to \(Int(timeout))s for them to finish before \(action.verb)...")

--- a/provider-swift/Sources/darkbloom/ProviderDrainHelper.swift
+++ b/provider-swift/Sources/darkbloom/ProviderDrainHelper.swift
@@ -35,7 +35,7 @@ func drainRunningProvider(
     action: DrainAction,
     timeout: TimeInterval = 120.0
 ) async -> Bool {
-    guard LaunchAgent.isLoaded() else { return false }
+    guard LaunchAgent.isAnySupportedLabelLoaded() else { return false }
 
     let state = DaemonStateFile.read()
     let now = Date().timeIntervalSince1970

--- a/provider-swift/Sources/darkbloom/ProviderDrainHelper.swift
+++ b/provider-swift/Sources/darkbloom/ProviderDrainHelper.swift
@@ -37,26 +37,28 @@ func drainRunningProvider(
 ) async -> Bool {
     guard LaunchAgent.isAnySupportedLabelLoaded() else { return false }
 
-    // Authoritative drain target: the PID launchd reports for the loaded
-    // service. This ties the drain to the launchd-managed daemon, so a
-    // standalone `start --local` server — which also writes the shared
+    // Authoritative drain targets: the PIDs launchd reports for the loaded
+    // service label(s). This ties the drain to the launchd-managed daemon(s), so
+    // a standalone `start --local` server — which also writes the shared
     // `~/.darkbloom/provider.pid` lock file — is never the one we signal on
-    // `stop`/`restart`/replacement `start`.
-    guard let pid = LaunchAgent.loadedServicePID(), pid > 0, ProcessLifecycle.processIsAlive(pid) else {
+    // `stop`/`restart`/replacement `start`. During an upgrade both the canonical
+    // and a legacy job can be loaded; the launchd stop/replace paths unload every
+    // supported label, so we must drain all of them.
+    let pids = LaunchAgent.loadedServicePIDs().filter { $0 > 0 && ProcessLifecycle.processIsAlive($0) }
+    guard !pids.isEmpty else {
         // The job is loaded but launchd has no live PID for it (e.g. installed
         // but not yet kickstarted). Fall back to the launchd-level path.
         return false
     }
 
-    // Read the daemon state for the user-facing in-flight count. If the freshest
-    // state describes a *different* process than the one launchd is running, the
-    // state file is stale/foreign — don't risk a confusing message, but still
-    // drain launchd's actual PID.
+    // Read the daemon state for the user-facing in-flight count. The state file
+    // is a single file (with multiple daemons it reflects whichever wrote last);
+    // only trust it for messaging when its PID is one we're about to drain.
     let state = DaemonStateFile.read()
     let now = Date().timeIntervalSince1970
     let freshState: DaemonState? = {
         guard let state, !state.isStale(now: now) else { return nil }
-        return state.pid == pid ? state : nil
+        return pids.contains(state.pid) ? state : nil
     }()
 
     let requestCount = freshState?.inflightRequestCount ?? (freshState?.inferenceActive == true ? 1 : 0)
@@ -67,15 +69,22 @@ func drainRunningProvider(
         print("Provider is currently serving requests. Waiting up to \(Int(timeout))s for them to finish before \(action.verb)...")
     }
 
-    let outcome = await ProcessLifecycle.stopProcessGracefully(pid: pid, timeout: timeout)
-
-    switch outcome {
-    case .notRunning:
-        return false
-    case .stoppedGracefully:
-        return true
-    case .forceKilled:
-        print("Warning: provider did not stop within \(Int(timeout))s; force-killing before \(action.verb).")
-        return true
+    // Drain all loaded-label daemons concurrently so the total wait is bounded by
+    // `timeout` even when two jobs are loaded.
+    let outcomes = await withTaskGroup(of: ProcessLifecycle.GracefulStopOutcome.self) { group in
+        for pid in pids {
+            group.addTask { await ProcessLifecycle.stopProcessGracefully(pid: pid, timeout: timeout) }
+        }
+        var results: [ProcessLifecycle.GracefulStopOutcome] = []
+        for await outcome in group { results.append(outcome) }
+        return results
     }
+
+    let forceKilled = outcomes.contains { if case .forceKilled = $0 { return true } else { return false } }
+    if forceKilled {
+        print("Warning: provider did not stop within \(Int(timeout))s; force-killing before \(action.verb).")
+    }
+    // True if at least one live daemon was found and signalled (so the caller
+    // knows a graceful drain was attempted).
+    return outcomes.contains { $0 != .notRunning }
 }

--- a/provider-swift/Sources/darkbloom/ProviderDrainHelper.swift
+++ b/provider-swift/Sources/darkbloom/ProviderDrainHelper.swift
@@ -52,8 +52,12 @@ func drainRunningProvider(
         return false
     }
 
-    if state?.inferenceActive == true {
-        print("Provider is currently serving requests. Waiting for them to finish before \(action.verb)...")
+    let requestCount = state?.inflightRequestCount ?? 0
+    if requestCount > 0 {
+        let plural = requestCount == 1 ? "" : "s"
+        print("Provider is currently serving \(requestCount) request\(plural). Waiting up to \(Int(timeout))s for them to finish before \(action.verb)...")
+    } else if state?.inferenceActive == true {
+        print("Provider is currently serving requests. Waiting up to \(Int(timeout))s for them to finish before \(action.verb)...")
     }
 
     let outcome = await ProcessLifecycle.stopProcessGracefully(pid: pid, timeout: timeout)

--- a/provider-swift/Sources/darkbloom/ProviderDrainHelper.swift
+++ b/provider-swift/Sources/darkbloom/ProviderDrainHelper.swift
@@ -1,0 +1,70 @@
+import Foundation
+import ProviderCore
+
+/// Human-readable action name used in user-facing drain messages.
+enum DrainAction: Sendable {
+    case stop
+    case restart
+    case startReplace
+
+    var verb: String {
+        switch self {
+        case .stop: return "stopping"
+        case .restart: return "restarting"
+        case .startReplace: return "replacing the running service"
+        }
+    }
+}
+
+/// Ask a running provider daemon to drain in-flight requests and exit gracefully
+/// before the caller manipulates its launchd job.
+///
+/// Reads the daemon PID from `DaemonStateFile`, sends `SIGTERM`, and waits up to
+/// `timeout` for the process to exit. If the daemon reports active inference,
+/// the user is told to wait. On timeout the daemon is force-killed and a warning
+/// is printed.
+///
+/// - Parameters:
+///   - action: Describes the operation that will happen after the drain, for
+///     user-facing messages.
+///   - timeout: Seconds to wait after `SIGTERM` before escalating to `SIGKILL`.
+/// - Returns: `true` if a live daemon was found and signalled; `false` if there
+///   was no loaded service or no live PID to drain (caller should fall back to
+///   its normal launchd path).
+func drainRunningProvider(
+    action: DrainAction,
+    timeout: TimeInterval = 120.0
+) async -> Bool {
+    guard LaunchAgent.isLoaded() else { return false }
+
+    let state = DaemonStateFile.read()
+    let now = Date().timeIntervalSince1970
+    let pid: Int32?
+    if let state, !state.isStale(now: now), ProcessLifecycle.processIsAlive(state.pid) {
+        pid = state.pid
+    } else {
+        pid = nil
+    }
+
+    guard let pid else {
+        // launchd thinks the job is loaded but we have no trustworthy live PID.
+        // Fall back to the launchd-level stop/restart path.
+        return false
+    }
+
+    if state?.inferenceActive == true {
+        print("Provider is currently serving requests. Waiting for them to finish before \(action.verb)...")
+    }
+
+    let outcome = await ProcessLifecycle.stopProcessGracefully(pid: pid, timeout: timeout)
+
+    switch outcome {
+    case .notRunning:
+        return false
+    case .stoppedGracefully:
+        return true
+    case .forceKilled:
+        print("Warning: provider did not stop within \(Int(timeout))s; force-killing before \(action.verb).")
+        return true
+    }
+}

--- a/provider-swift/Sources/darkbloom/RestartCommand.swift
+++ b/provider-swift/Sources/darkbloom/RestartCommand.swift
@@ -17,6 +17,11 @@ struct Restart: AsyncParsableCommand {
 
     mutating func run() async throws {
         let wasLoaded = LaunchAgent.isLoaded()
+
+        // Drain active inference before asking launchd to kill+relaunch, so in-flight
+        // requests finish on this instance instead of being aborted mid-stream.
+        _ = await drainRunningProvider(action: .restart)
+
         do {
             try LaunchAgent.restart()
         } catch LaunchAgentError.notInstalled {

--- a/provider-swift/Sources/darkbloom/StartCommand.swift
+++ b/provider-swift/Sources/darkbloom/StartCommand.swift
@@ -535,6 +535,13 @@ struct Start: AsyncParsableCommand {
             throw ExitCode.failure
         }
 
+        // If the service is already running, drain it before replacing the plist.
+        // This avoids aborting in-flight requests when the user re-runs `start`
+        // with a new model selection.
+        if LaunchAgent.isLoaded() {
+            _ = await drainRunningProvider(action: .startReplace)
+        }
+
         try LaunchAgent.installAndStart(
             coordinatorURL: coordinatorURL,
             models: selectedModelIDs,

--- a/provider-swift/Sources/darkbloom/StartCommand.swift
+++ b/provider-swift/Sources/darkbloom/StartCommand.swift
@@ -537,8 +537,9 @@ struct Start: AsyncParsableCommand {
 
         // If the service is already running, drain it before replacing the plist.
         // This avoids aborting in-flight requests when the user re-runs `start`
-        // with a new model selection.
-        if LaunchAgent.isLoaded() {
+        // with a new model selection. Legacy labels are included so upgraded
+        // providers drain before the new plist takes over.
+        if LaunchAgent.isAnySupportedLabelLoaded() {
             _ = await drainRunningProvider(action: .startReplace)
         }
 

--- a/provider-swift/Sources/darkbloom/StopCommand.swift
+++ b/provider-swift/Sources/darkbloom/StopCommand.swift
@@ -24,12 +24,20 @@ struct Stop: AsyncParsableCommand {
         try? FileManager.default.removeItem(at: WatchdogStateStore.path())
 
         if uninstall {
+            // Drain before uninstall so we don't tear down the launchd job while
+            // the daemon is still serving requests.
+            _ = await drainRunningProvider(action: .stop)
             try LaunchAgent.uninstall()
             print("Provider service uninstalled.")
         } else {
+            let didDrain = await drainRunningProvider(action: .stop)
             try LaunchAgent.stop()
             if wasLoaded {
-                print("Provider service stopped. (Auto-restart disabled until you start again.)")
+                if didDrain {
+                    print("Provider service stopped after draining active requests. (Auto-restart disabled until you start again.)")
+                } else {
+                    print("Provider service stopped. (Auto-restart disabled until you start again.)")
+                }
             } else {
                 print("Provider service is not running.")
             }

--- a/provider-swift/Tests/ProviderCoreTests/LaunchAgentRestartTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/LaunchAgentRestartTests.swift
@@ -60,6 +60,7 @@ struct LaunchAgentServicePlistTests {
         // APNs) with no human; KeepAlive stays false to avoid racing the self-updater.
         #expect(plist["RunAtLoad"] as? Bool == true)
         #expect(plist["KeepAlive"] as? Bool == false)
+        #expect(plist["ExitTimeOut"] as? Int == 600)
         #expect((plist["EnvironmentVariables"] as? [String: String]) == ["DARKBLOOM_PREFIX_CACHE": "0"])
     }
 

--- a/provider-swift/Tests/ProviderCoreTests/ProcessLifecycleTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/ProcessLifecycleTests.swift
@@ -85,6 +85,12 @@ struct ProcessLifecycleGracefulStopTests {
         #expect(outcome == .notRunning)
     }
 
+    @Test("stopProcessGracefully rejects nonpositive PIDs")
+    func gracefulStopRejectsNonpositivePids() async {
+        #expect(await ProcessLifecycle.stopProcessGracefully(pid: 0, timeout: 1.0) == .notRunning)
+        #expect(await ProcessLifecycle.stopProcessGracefully(pid: -1, timeout: 1.0) == .notRunning)
+    }
+
     @Test("stopProcessGracefully can stop a spawned subprocess")
     func gracefulStopStopsSubprocess() async throws {
         // Spawn a long-lived child process (`sleep`) that we can gracefully stop.
@@ -102,6 +108,26 @@ struct ProcessLifecycleGracefulStopTests {
         let outcome = await ProcessLifecycle.stopProcessGracefully(pid: pid, timeout: 2.0)
 
         #expect(outcome == .stoppedGracefully)
+        #expect(!ProcessLifecycle.processIsAlive(pid))
+    }
+
+    @Test("stopProcessGracefully reports force kill when SIGTERM is ignored")
+    func gracefulStopReportsForceKill() async throws {
+        // Spawn a shell that ignores SIGTERM and then execs sleep, so the helper
+        // has to escalate to SIGKILL. `trap '' TERM` sets SIGTERM to ignored,
+        // and `exec` preserves the ignored disposition across the replacement.
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/bash")
+        process.arguments = ["-c", "trap '' TERM; exec /bin/sleep 300"]
+        try process.run()
+        let pid = Int32(process.processIdentifier)
+
+        try? await Task.sleep(nanoseconds: 50_000_000)
+        #expect(ProcessLifecycle.processIsAlive(pid))
+
+        let outcome = await ProcessLifecycle.stopProcessGracefully(pid: pid, timeout: 0.5)
+
+        #expect(outcome == .forceKilled(pid))
         #expect(!ProcessLifecycle.processIsAlive(pid))
     }
 }

--- a/provider-swift/Tests/ProviderCoreTests/ProcessLifecycleTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/ProcessLifecycleTests.swift
@@ -100,16 +100,25 @@ struct ProcessLifecycleGracefulStopTests {
         try process.run()
         let pid = Int32(process.processIdentifier)
 
+        // Reap the child as soon as it exits. `processIsAlive` is `kill(pid, 0)`,
+        // which still succeeds for an un-reaped zombie — so without an active
+        // `waitpid`, a SIGTERM'd `/bin/sleep` would look "alive" for the full
+        // timeout and `stopProcessGracefully` would escalate to SIGKILL and
+        // report `.forceKilled`. Blocking a background task on `waitUntilExit()`
+        // keeps a reaper running so liveness reflects the real process state.
+        let reaper = Task.detached { process.waitUntilExit() }
+        defer { reaper.cancel() }
+
         // Give the kernel a moment to register the process.
         try? await Task.sleep(nanoseconds: 50_000_000)
 
         #expect(ProcessLifecycle.processIsAlive(pid))
 
         let outcome = await ProcessLifecycle.stopProcessGracefully(pid: pid, timeout: 2.0)
+        await reaper.value
 
         #expect(outcome == .stoppedGracefully)
         #expect(!ProcessLifecycle.processIsAlive(pid))
-        process.waitUntilExit()
     }
 
     @Test("stopProcessGracefully reports force kill when SIGTERM is ignored")
@@ -123,13 +132,18 @@ struct ProcessLifecycleGracefulStopTests {
         try process.run()
         let pid = Int32(process.processIdentifier)
 
+        // Reap the child once SIGKILL lands so the post-kill liveness check sees
+        // ESRCH instead of a lingering zombie (see the graceful-stop test above).
+        let reaper = Task.detached { process.waitUntilExit() }
+        defer { reaper.cancel() }
+
         try? await Task.sleep(nanoseconds: 50_000_000)
         #expect(ProcessLifecycle.processIsAlive(pid))
 
         let outcome = await ProcessLifecycle.stopProcessGracefully(pid: pid, timeout: 0.5)
+        await reaper.value
 
         #expect(outcome == .forceKilled(pid))
         #expect(!ProcessLifecycle.processIsAlive(pid))
-        process.waitUntilExit()
     }
 }

--- a/provider-swift/Tests/ProviderCoreTests/ProcessLifecycleTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/ProcessLifecycleTests.swift
@@ -1,9 +1,10 @@
 import Foundation
 import Testing
+
 @testable import ProviderCore
 
 @Suite("ProcessLifecycle PID lock")
-struct ProcessLifecycleTests {
+struct ProcessLifecyclePIDLockTests {
 
     private func tempPIDFile() -> URL {
         URL(fileURLWithPath: NSTemporaryDirectory())
@@ -58,5 +59,49 @@ struct ProcessLifecycleTests {
         let written = try String(contentsOf: pidFile, encoding: .utf8)
             .trimmingCharacters(in: .whitespacesAndNewlines)
         #expect(written == "\(ProcessInfo.processInfo.processIdentifier)")
+    }
+}
+
+/// Tests for `ProcessLifecycle` process-signalling helpers.
+@Suite("ProcessLifecycle graceful stop")
+struct ProcessLifecycleGracefulStopTests {
+
+    @Test("processIsAlive returns true for the current process")
+    func currentProcessIsAlive() {
+        let pid = ProcessInfo.processInfo.processIdentifier
+        #expect(ProcessLifecycle.processIsAlive(pid))
+    }
+
+    @Test("processIsAlive returns false for a clearly non-existent PID")
+    func nonExistentProcessIsNotAlive() {
+        // PID 1 is launchd on macOS and is alive, so pick an implausibly high
+        // PID that cannot exist in a normal user session.
+        #expect(!ProcessLifecycle.processIsAlive(999_999))
+    }
+
+    @Test("stopProcessGracefully returns notRunning for a dead PID")
+    func gracefulStopReturnsNotRunningForDeadPid() async {
+        let outcome = await ProcessLifecycle.stopProcessGracefully(pid: 999_999, timeout: 1.0)
+        #expect(outcome == .notRunning)
+    }
+
+    @Test("stopProcessGracefully can stop a spawned subprocess")
+    func gracefulStopStopsSubprocess() async throws {
+        // Spawn a long-lived child process (`sleep`) that we can gracefully stop.
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/sleep")
+        process.arguments = ["300"]
+        try process.run()
+        let pid = Int32(process.processIdentifier)
+
+        // Give the kernel a moment to register the process.
+        try? await Task.sleep(nanoseconds: 50_000_000)
+
+        #expect(ProcessLifecycle.processIsAlive(pid))
+
+        let outcome = await ProcessLifecycle.stopProcessGracefully(pid: pid, timeout: 2.0)
+
+        #expect(outcome == .stoppedGracefully)
+        #expect(!ProcessLifecycle.processIsAlive(pid))
     }
 }

--- a/provider-swift/Tests/ProviderCoreTests/ProcessLifecycleTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/ProcessLifecycleTests.swift
@@ -109,6 +109,7 @@ struct ProcessLifecycleGracefulStopTests {
 
         #expect(outcome == .stoppedGracefully)
         #expect(!ProcessLifecycle.processIsAlive(pid))
+        process.waitUntilExit()
     }
 
     @Test("stopProcessGracefully reports force kill when SIGTERM is ignored")
@@ -129,5 +130,6 @@ struct ProcessLifecycleGracefulStopTests {
 
         #expect(outcome == .forceKilled(pid))
         #expect(!ProcessLifecycle.processIsAlive(pid))
+        process.waitUntilExit()
     }
 }


### PR DESCRIPTION
When a user runs `darkbloom stop`, `start`, or `restart`, drain active inference before killing or replacing the daemon. This avoids aborting in-flight requests mid-stream and improves fleet reliability.

### Before / After

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {'primaryColor': '#ffcccc', 'primaryTextColor': '#333', 'primaryBorderColor': '#999', 'lineColor': '#666', 'secondaryColor': '#ccffcc', 'tertiaryColor': '#eeeeee'}}}%%
sequenceDiagram
    autonumber
    participant U as User
    participant CLI as darkbloom CLI
    participant L as launchd
    participant D as Provider daemon
    participant C as Coordinator

    rect rgb(255, 220, 220)
    Note over U,C: BEFORE: immediate kill/restart
    U->>CLI: darkbloom stop / restart / start
    CLI->>L: bootout / kickstart -k
    L->>D: SIGTERM → SIGKILL (20s default)
    D--xC: in-flight requests aborted
    end

    rect rgb(220, 255, 220)
    Note over U,C: AFTER: graceful drain
    U->>CLI: darkbloom stop / restart / start
    CLI->>D: SIGTERM via daemon PID
    D->>D: reject new work, wait for<br/>in-flight inference to finish
    D->>CLI: process exits cleanly
    CLI->>L: bootout / kickstart
    end
```

### What changed

- **Daemon now drains on SIGTERM/SIGINT.** The AppKit host cancels the serve task on termination and waits for `ProviderLoop.run()` to finish its existing 10-minute shutdown drain.
- **CLI drains before manipulating launchd.** `StopCommand`, `RestartCommand`, and `StartCommand` read the daemon PID from `DaemonStateFile`, send `SIGTERM`, and wait up to 120s before force-killing.
- **User-facing message with numbers.** When the daemon reports active requests, the CLI prints the exact count and timeout, e.g.: `Provider is currently serving 3 requests. Waiting up to 120s for them to finish before stopping...`
- **launchd plist.** Added `ExitTimeOut: 600` so `launchctl bootout` / logout shutdown gives the daemon the same 10-minute drain window before SIGKILL.
- **New helpers.** `ProcessLifecycle.stopProcessGracefully` and `ProviderDrainHelper.drainRunningProvider`.

### Tests

- `ProcessLifecycleTests` covers PID lock behavior and the new graceful stop helper (including stopping a real subprocess).
- `LaunchAgentServicePlistTests` asserts the new `ExitTimeOut = 600`.
- `swift build` passes.
- Targeted provider tests pass. The full `swift test` suite did not complete in this environment due to a missing MLX metallib (pre-existing, unrelated).
