### PR TITLE
DAR-327 Phase 2: true blue-green coordinator deploy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,8 @@ coordinator/.env
 *.pem
 *.csr
 *.p12
+*.key
+*.crt
 enclave_key.data
 
 # Database dumps (contain prod data)

--- a/coordinator/Dockerfile
+++ b/coordinator/Dockerfile
@@ -21,6 +21,14 @@ COPY coordinator/Caddyfile /Caddyfile
 COPY coordinator/deploy/start.sh /usr/local/bin/start.sh
 RUN chmod +x /usr/local/bin/start.sh
 
+# Blue-green split entrypoints (DAR-327 Phase 2). The default CMD stays start.sh
+# (the combined EigenCloud path). For the GCE blue-green deployment the systemd
+# units override the container command with start-platform.sh (long-lived
+# step-ca + MicroMDM) and start-coordinator.sh (swappable coordinator-only).
+COPY coordinator/deploy/start-platform.sh /usr/local/bin/start-platform.sh
+COPY coordinator/deploy/start-coordinator.sh /usr/local/bin/start-coordinator.sh
+RUN chmod +x /usr/local/bin/start-platform.sh /usr/local/bin/start-coordinator.sh
+
 ENV EIGENINFERENCE_PORT=8080
 ENV EIGENINFERENCE_MDM_URL=https://localhost:9002
 ENV EIGENINFERENCE_MDM_API_KEY=eigeninference-micromdm-api

--- a/coordinator/deploy/start-coordinator.sh
+++ b/coordinator/deploy/start-coordinator.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+set -eu
+
+# ============================================================================
+# start-coordinator.sh — swappable "coordinator-only" half of the split.
+# (DAR-327 Phase 2)
+#
+# This is the half that blue-green swaps. The long-lived platform
+# (start-platform.sh) already owns step-ca, MicroMDM and first-boot init of the
+# shared /mnt/disks/userdata volume. This script therefore does the bare
+# minimum a fresh per-color container needs:
+#   1. re-create the /data -> persistent-volume symlink inside THIS container
+#   2. wait (bounded) for the platform to publish the step-ca root cert
+#   3. exec the coordinator, honoring EIGENINFERENCE_PORT (blue=8080, green=8081)
+#
+# It deliberately does NOT init/run step-ca, run MicroMDM, or do any first-boot
+# work — that belongs to the platform and must not run per color (running two
+# step-ca/MicroMDM instances against the same volume would corrupt state).
+# ============================================================================
+
+PERSIST="${USER_PERSISTENT_DATA_PATH:-/mnt/disks/userdata}"
+
+# Each container has its own root filesystem; the volume bytes are shared via
+# the bind mount, but the /data symlink is per-container. Re-create it so the
+# coordinator finds the step-ca certs at EIGENINFERENCE_STEP_CA_ROOT
+# (default /data/step-ca/certs/root_ca.crt).
+ln -sfn "$PERSIST" /data
+
+# Bounded wait for platform first-boot init so a cold box (coordinator started
+# before the platform finished initializing the CA) doesn't crash-loop.
+CA_ROOT="${EIGENINFERENCE_STEP_CA_ROOT:-/data/step-ca/certs/root_ca.crt}"
+WAIT_SECS="${COORDINATOR_PLATFORM_WAIT_SECS:-60}"
+i=0
+while [ ! -f "$CA_ROOT" ]; do
+    if [ "$i" -eq 0 ]; then
+        echo "start-coordinator: waiting (up to ${WAIT_SECS}s) for platform step-ca root cert at $CA_ROOT ..."
+    fi
+    if [ "$i" -ge "$WAIT_SECS" ]; then
+        echo "start-coordinator: WARNING: $CA_ROOT still absent after ${WAIT_SECS}s; starting anyway." >&2
+        break
+    fi
+    i=$((i + 1))
+    sleep 1
+done
+
+echo "start-coordinator: starting coordinator on port ${EIGENINFERENCE_PORT:-8080}..."
+exec coordinator

--- a/coordinator/deploy/start-coordinator.sh
+++ b/coordinator/deploy/start-coordinator.sh
@@ -27,17 +27,18 @@ PERSIST="${USER_PERSISTENT_DATA_PATH:-/mnt/disks/userdata}"
 ln -sfn "$PERSIST" /data
 
 # Bounded wait for platform first-boot init so a cold box (coordinator started
-# before the platform finished initializing the CA) doesn't crash-loop.
+# before the platform finished initializing the CA) retries under the supervisor
+# instead of starting in a degraded ACME-off state.
 CA_ROOT="${EIGENINFERENCE_STEP_CA_ROOT:-/data/step-ca/certs/root_ca.crt}"
-WAIT_SECS="${COORDINATOR_PLATFORM_WAIT_SECS:-60}"
+WAIT_SECS="${COORDINATOR_PLATFORM_WAIT_SECS:-120}"
 i=0
 while [ ! -f "$CA_ROOT" ]; do
     if [ "$i" -eq 0 ]; then
         echo "start-coordinator: waiting (up to ${WAIT_SECS}s) for platform step-ca root cert at $CA_ROOT ..."
     fi
     if [ "$i" -ge "$WAIT_SECS" ]; then
-        echo "start-coordinator: WARNING: $CA_ROOT still absent after ${WAIT_SECS}s; starting anyway." >&2
-        break
+        echo "start-coordinator: ERROR: $CA_ROOT still absent after ${WAIT_SECS}s; refusing to start coordinator. Supervisor will retry." >&2
+        exit 1
     fi
     i=$((i + 1))
     sleep 1

--- a/coordinator/deploy/start-platform.sh
+++ b/coordinator/deploy/start-platform.sh
@@ -1,0 +1,193 @@
+#!/bin/sh
+set -e
+
+# ============================================================================
+# start-platform.sh — long-lived "platform" half of the blue-green split.
+# (DAR-327 Phase 2)
+#
+# Owns the stateful, NON-swappable services so they survive a coordinator
+# color flip untouched:
+#   - the persistent /mnt/disks/userdata volume + the /data symlink
+#   - step-ca (ACME device-attest-01 CA) on :9000, incl. first-boot init
+#   - MicroMDM (SCEP + MDM checkin/connect) on :9002
+#
+# It does NOT start the coordinator. The coordinator runs in its own
+# per-color container via start-coordinator.sh and is swapped behind Caddy.
+#
+# This is a faithful factoring of coordinator/deploy/start.sh (lines 1-125):
+# the combined start.sh is intentionally LEFT UNCHANGED as the EigenCloud
+# entrypoint. Keep this file diff-able against start.sh so the two stay in sync.
+#
+# MDM webhook coupling fix: start.sh hardcodes the command-webhook URL to
+# http://localhost:8080/v1/mdm/webhook, which only works when the coordinator
+# shares the container on :8080. In the split the active coordinator may be on
+# :8080 (blue) or :8081 (green), so the webhook target is now configurable via
+# EIGENINFERENCE_MDM_WEBHOOK_URL. In the GCE blue-green deployment the platform
+# unit points it at a stable loopback Caddy listener
+# (http://127.0.0.1:8090/v1/mdm/webhook) that imports the same (coordinator_routes)
+# snippet as the public sites, so the SINGLE upstream swap in that snippet
+# reroutes the webhook to the active color automatically. Default below keeps
+# legacy localhost:8080 behavior for any combined-style use.
+# ============================================================================
+
+# EigenCloud / GCE persistent storage (survives upgrades + color swaps).
+PERSIST=${USER_PERSISTENT_DATA_PATH:-/mnt/disks/userdata}
+mkdir -p "$PERSIST/step-ca" "$PERSIST/micromdm"
+
+# Symlink /data -> persistent storage so all components use the same paths.
+ln -sfn "$PERSIST" /data
+
+# ---- step-ca ----
+if [ ! -d "/data/step-ca/config" ]; then
+    echo "Initializing step-ca (first boot)..."
+    mkdir -p /data/step-ca/secrets
+    echo "eigeninference-step-ca" > /data/step-ca/secrets/password
+
+    # Copy Apple attestation root CA and ACME template to persistent storage
+    mkdir -p /data/step-ca/apple /data/step-ca/templates
+    cp /opt/step-ca-seed/acme-device.tpl /data/step-ca/templates/
+
+    STEPPATH=/data/step-ca step ca init \
+        --name "Darkbloom CA" \
+        --dns "${DOMAIN:-localhost}" \
+        --address ":9000" \
+        --provisioner "eigeninference-admin" \
+        --password-file /data/step-ca/secrets/password \
+        --deployment-type standalone \
+        --acme 2>&1
+    echo "step-ca initialized."
+
+    # Patch ca.json: replace the default ACME provisioner with one configured
+    # for device-attest-01 (Apple Secure Enclave attestation).
+    echo "Configuring ACME device-attest-01 provisioner..."
+    CA_JSON=/data/step-ca/config/ca.json
+    jq '(.authority.provisioners[] | select(.type == "ACME")) |=
+        {
+            "type": "ACME",
+            "name": "eigeninference-acme",
+            "challenges": ["device-attest-01"],
+            "attestationFormats": ["apple"],
+            "forceCN": false,
+            "options": {
+                "x509": {
+                    "templateFile": "/data/step-ca/templates/acme-device.tpl"
+                }
+            }
+        }' "$CA_JSON" > /tmp/ca.json && mv /tmp/ca.json "$CA_JSON"
+    echo "ACME provisioner configured."
+fi
+echo "Starting step-ca..."
+STEPPATH=/data/step-ca step-ca /data/step-ca/config/ca.json \
+    --password-file /data/step-ca/secrets/password \
+    >> /data/step-ca.log 2>&1 &
+STEP_CA_PID=$!
+echo "step-ca started (port 9000, pid $STEP_CA_PID)."
+
+# ---- MicroMDM ----
+MICROMDM_PID=""
+if [ -n "$MICROMDM_API_KEY" ]; then
+    # Decode push cert from PKCS#12 bundle on first boot
+    # P12 is base64url-encoded (no +/) to survive KMS/shell pipeline intact.
+    if [ -n "$MDM_PUSH_P12_B64" ] && [ ! -f /data/micromdm/push.crt ]; then
+        echo "Decoding MDM push certificate from PKCS#12..."
+        printf '%s' "$MDM_PUSH_P12_B64" | tr '_-' '/+' | base64 -d > /tmp/push.p12
+        openssl pkcs12 -in /tmp/push.p12 -clcerts -nokeys -passin pass:eigeninference \
+            -out /data/micromdm/push.crt 2>/dev/null
+        openssl pkcs12 -in /tmp/push.p12 -nocerts -nodes -passin pass:eigeninference \
+            -out /tmp/push_pkcs8.key 2>/dev/null
+        openssl rsa -in /tmp/push_pkcs8.key -traditional -out /data/micromdm/push.key 2>/dev/null
+        rm -f /tmp/push.p12 /tmp/push_pkcs8.key
+        chmod 600 /data/micromdm/push.key
+        echo "Key format: $(head -1 /data/micromdm/push.key)"
+    fi
+
+    # Generate self-signed TLS cert for MicroMDM on first boot (internal only)
+    if [ ! -f /data/micromdm/server.crt ]; then
+        echo "Generating MicroMDM self-signed TLS cert..."
+        openssl req -x509 -newkey rsa:2048 -nodes \
+            -keyout /data/micromdm/server.key \
+            -out /data/micromdm/server.crt \
+            -days 3650 -subj "/CN=localhost" 2>/dev/null
+    fi
+
+    # If the coordinator is configured with EIGENINFERENCE_MDM_WEBHOOK_SECRET it
+    # rejects any MDM callback that doesn't present that secret. MicroMDM has no
+    # option to set a header on the command webhook, so the shared secret rides
+    # as a ?token= query param (the coordinator also accepts the X-Webhook-Token
+    # header — see HandleMDMWebhook). These MUST stay in sync: setting the secret
+    # on the coordinator without this token would 403 every legitimate
+    # SecurityInfo/MDA callback and stall provider hardware-trust verification.
+    #
+    # Blue-green: the base URL is configurable so MicroMDM reaches the ACTIVE
+    # coordinator color. Default stays localhost:8080 (legacy/combined). In the
+    # split, the platform unit sets EIGENINFERENCE_MDM_WEBHOOK_URL to the stable
+    # loopback Caddy webhook listener (http://127.0.0.1:8090/v1/mdm/webhook).
+    MDM_WEBHOOK_URL="${EIGENINFERENCE_MDM_WEBHOOK_URL:-http://localhost:8080/v1/mdm/webhook}"
+    if [ -n "${EIGENINFERENCE_MDM_WEBHOOK_SECRET:-}" ]; then
+        MDM_WEBHOOK_URL="${MDM_WEBHOOK_URL}?token=${EIGENINFERENCE_MDM_WEBHOOK_SECRET}"
+    fi
+
+    echo "Starting MicroMDM (webhook -> ${EIGENINFERENCE_MDM_WEBHOOK_URL:-http://localhost:8080/v1/mdm/webhook})..."
+    micromdm serve \
+        -server-url "https://${DOMAIN:-localhost}" \
+        -api-key "${MICROMDM_API_KEY:-eigeninference-micromdm-api}" \
+        -filerepo /data/micromdm \
+        -config-path /data/micromdm \
+        -tls-cert /data/micromdm/server.crt \
+        -tls-key /data/micromdm/server.key \
+        -http-addr :9002 \
+        -http-proxy-headers \
+        -command-webhook-url "${MDM_WEBHOOK_URL}" \
+        >> /data/micromdm.log 2>&1 &
+    MICROMDM_PID=$!
+
+    # Wait for MicroMDM to be ready, then import push cert if needed
+    sleep 2
+    if [ -f /data/micromdm/push.crt ] && [ ! -f /data/micromdm/.push_imported ]; then
+        echo "Importing MDM push certificate..."
+        mdmctl config set \
+            -name eigeninference \
+            -server-url "https://localhost:9002" \
+            -api-token "${MICROMDM_API_KEY:-eigeninference-micromdm-api}" \
+            -skip-verify
+        mdmctl mdmcert upload \
+            -cert /data/micromdm/push.crt \
+            -private-key /data/micromdm/push.key \
+            2>&1 || echo "Push cert import failed (may already exist)"
+        touch /data/micromdm/.push_imported
+    fi
+    echo "MicroMDM ready (port 9002, pid $MICROMDM_PID)."
+else
+    echo "MICROMDM_API_KEY not set — skipping MicroMDM."
+fi
+
+# ---- Supervise (PID 1) ----
+# The platform has no foreground process of its own (step-ca + MicroMDM run in
+# the background above), so block here to keep the container alive and to
+# forward termination signals. Exit non-zero if a critical child dies so the
+# supervisor (systemd Restart=always, or EigenCloud) restarts the platform.
+# shellcheck disable=SC2329  # invoked indirectly via `trap term TERM INT` below
+term() {
+    echo "platform: signal received — shutting down children..."
+    kill "$STEP_CA_PID" 2>/dev/null || true
+    if [ -n "${MICROMDM_PID:-}" ]; then
+        kill "$MICROMDM_PID" 2>/dev/null || true
+    fi
+    exit 0
+}
+trap term TERM INT
+
+echo "Platform ready (step-ca :9000$( [ -n "${MICROMDM_PID:-}" ] && printf ', MicroMDM :9002' )). Supervising..."
+while kill -0 "$STEP_CA_PID" 2>/dev/null; do
+    if [ -n "${MICROMDM_PID:-}" ]; then
+        if ! kill -0 "$MICROMDM_PID" 2>/dev/null; then
+            echo "platform: MicroMDM (pid $MICROMDM_PID) exited — restarting platform." >&2
+            kill "$STEP_CA_PID" 2>/dev/null || true
+            exit 1
+        fi
+    fi
+    sleep 5
+done
+
+echo "platform: step-ca (pid $STEP_CA_PID) exited — restarting platform." >&2
+exit 1

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,452 @@
+#!/usr/bin/env bash
+# deploy.sh — DAR-327 Phase 2: true blue-green coordinator deploy orchestrator.
+#
+# Runs ON the GCE coordinator box. Performs a zero-downtime color swap:
+#
+#   1. detect the active color from the on-box Caddyfile upstream port
+#   2. (optional) pin the new image for the idle color
+#   3. start the IDLE color           (systemctl start darkbloom-coordinator@<idle>)
+#   4. wait for idle /health AND /readyz  (DAR-327 Phase 1 endpoints)
+#   5. flip the Caddy upstream old->new + graceful `caddy reload`  (cutover)
+#   6. drain the OLD color            (POST /v1/admin/drain, Phase 1) until inflight==0
+#   7. stop the OLD color             (systemctl stop darkbloom-coordinator@<old>)
+#
+# Stopping the old color triggers the coordinator's `going_away` provider
+# broadcast (DAR-327 Phase 3, separate PR) so providers reconnect to the new
+# color instantly instead of waiting for a heartbeat timeout. This script only
+# performs the graceful stop; the broadcast itself ships in Phase 3.
+#
+# ROLLBACK (valid any time AFTER the flip and BEFORE the old color is stopped):
+#   ./deploy.sh --rollback
+# flips the Caddy upstream back to the still-running previous color and reloads.
+#
+# SAFETY:
+#   * --dry-run prints the full plan and mutates NOTHING.
+#   * destructive steps require interactive confirmation (skip with -y/--yes).
+#   * the Caddy port flip is the self-contained, unit-tested function
+#     flip_upstream(); see deploy/gcp/prod/deploy_test.sh.
+#   * sourcing this file (e.g. from the test) defines the functions but NEVER
+#     runs main — see the BASH_SOURCE guard at the bottom.
+#   * NO secrets are read or written here; coordinator secrets stay in
+#     /etc/d-inference/env (Secret Manager -> tmpfs -> --env-file).
+#
+# Cross-phase contracts (separate PRs; referenced, not implemented here):
+#   Phase 1 : GET /readyz  +  POST /v1/admin/drain
+#   Phase 3 : graceful coordinator stop broadcasts `going_away`
+
+# NOTE: shell options are set inside main() so that sourcing this file for tests
+# does not mutate the caller's shell. The functions below are written to not
+# depend on `set -e`.
+
+# ---------------------------------------------------------------------------
+# Configuration (all overridable via environment)
+# ---------------------------------------------------------------------------
+CADDYFILE_DEFAULT="/etc/caddy/Caddyfile"
+CADDYFILE="${CADDYFILE:-}"
+BLUE_PORT="${BLUE_PORT:-8080}"
+GREEN_PORT="${GREEN_PORT:-8081}"
+HEALTH_HOST="${HEALTH_HOST:-127.0.0.1}"
+HEALTH_PATH="${HEALTH_PATH:-/health}"
+READYZ_PATH="${READYZ_PATH:-/readyz}"
+DRAIN_PATH="${DRAIN_PATH:-/v1/admin/drain}"
+HEALTH_TIMEOUT="${HEALTH_TIMEOUT:-120}"
+DRAIN_TIMEOUT="${DRAIN_TIMEOUT:-120}"
+CADDY_BIN="${CADDY_BIN:-caddy}"
+SYSTEMCTL_BIN="${SYSTEMCTL_BIN:-systemctl}"
+CURL_BIN="${CURL_BIN:-curl}"
+DINF_DEPLOY_ENV="${DINF_DEPLOY_ENV:-/etc/d-inference/deploy.env}"
+
+# Runtime flags (main overrides from CLI args).
+DRY_RUN="${DRY_RUN:-0}"
+ROLLBACK=0
+ASSUME_YES=0
+IMAGE_REF=""
+
+# ---------------------------------------------------------------------------
+# Logging
+# ---------------------------------------------------------------------------
+log()  { printf '[deploy] %s\n' "$*"; }
+warn() { printf '[deploy] WARNING: %s\n' "$*" >&2; }
+err()  { printf '[deploy] ERROR: %s\n' "$*" >&2; }
+die()  { err "$*"; exit 1; }
+
+# ===========================================================================
+# Pure, unit-tested helpers (no side effects beyond the named file).
+# ===========================================================================
+
+# flip_upstream <caddyfile> <from_port> <to_port>
+#
+# Rewrites ONLY the coordinator upstream line inside the (coordinator_routes)
+# snippet:
+#     reverse_proxy 127.0.0.1:<from_port>  ->  reverse_proxy 127.0.0.1:<to_port>
+# The step-ca (https://127.0.0.1:9000) and MicroMDM (https://127.0.0.1:9002)
+# upstreams are NOT touched: they use the https:// scheme and different ports.
+# All other bytes — indentation, comments, the proxy block body — are preserved,
+# and the original file's inode/permissions are kept (in-place truncate+write).
+#
+# Returns: 0 = at least one upstream line flipped; 2 = bad args/missing file;
+#          3 = no matching upstream line found (file left untouched).
+flip_upstream() {
+  if [ "$#" -ne 3 ]; then
+    echo "flip_upstream: usage: flip_upstream <caddyfile> <from_port> <to_port>" >&2
+    return 2
+  fi
+  local caddyfile="$1" from_port="$2" to_port="$3"
+  if [ ! -f "$caddyfile" ]; then
+    echo "flip_upstream: file not found: $caddyfile" >&2
+    return 2
+  fi
+  local tmp
+  tmp="$(mktemp)" || return 2
+
+  awk -v fromp="$from_port" -v top="$to_port" '
+    # Only the coordinator upstream: a reverse_proxy to bare loopback (no
+    # https:// scheme) on the from-port, delimited so :808 never matches :8080.
+    /^[[:space:]]*reverse_proxy[[:space:]]+127\.0\.0\.1:/ && $0 !~ /https:\/\// {
+      if ($0 ~ ("127\\.0\\.0\\.1:" fromp "([^0-9]|$)")) {
+        sub("127\\.0\\.0\\.1:" fromp, "127.0.0.1:" top)
+        changed++
+      }
+    }
+    { print }
+    END { exit (changed + 0 == 0) ? 3 : 0 }
+  ' "$caddyfile" > "$tmp"
+  local rc=$?
+
+  if [ "$rc" -ne 0 ]; then
+    rm -f "$tmp"
+    return "$rc"
+  fi
+  if ! cat "$tmp" > "$caddyfile"; then
+    rm -f "$tmp"
+    echo "flip_upstream: failed to write $caddyfile" >&2
+    return 2
+  fi
+  rm -f "$tmp"
+  return 0
+}
+
+# current_upstream_port <caddyfile>
+# Prints the coordinator upstream port (the blue-green swap target). Returns 3
+# if no coordinator upstream line is present.
+current_upstream_port() {
+  if [ "$#" -ne 1 ]; then
+    echo "current_upstream_port: usage: current_upstream_port <caddyfile>" >&2
+    return 2
+  fi
+  local caddyfile="$1"
+  if [ ! -f "$caddyfile" ]; then
+    echo "current_upstream_port: file not found: $caddyfile" >&2
+    return 2
+  fi
+  awk '
+    /^[[:space:]]*reverse_proxy[[:space:]]+127\.0\.0\.1:/ && $0 !~ /https:\/\// {
+      if (match($0, /127\.0\.0\.1:[0-9]+/)) {
+        tok = substr($0, RSTART, RLENGTH)
+        sub(/.*:/, "", tok)
+        print tok
+        found = 1
+        exit
+      }
+    }
+    END { if (found != 1) exit 3 }
+  ' "$caddyfile"
+}
+
+port_for_color() {
+  case "$1" in
+    blue)  echo "$BLUE_PORT" ;;
+    green) echo "$GREEN_PORT" ;;
+    *) echo "port_for_color: unknown color: $1" >&2; return 2 ;;
+  esac
+}
+
+color_for_port() {
+  if [ "$1" = "$BLUE_PORT" ]; then
+    echo blue
+  elif [ "$1" = "$GREEN_PORT" ]; then
+    echo green
+  else
+    echo "color_for_port: port '$1' is neither blue($BLUE_PORT) nor green($GREEN_PORT)" >&2
+    return 2
+  fi
+}
+
+other_color() {
+  case "$1" in
+    blue)  echo green ;;
+    green) echo blue ;;
+    *) echo "other_color: unknown color: $1" >&2; return 2 ;;
+  esac
+}
+
+# ===========================================================================
+# Effectful helpers (dry-run aware).
+# ===========================================================================
+
+run_cmd() {
+  if [ "$DRY_RUN" -eq 1 ]; then
+    log "DRY-RUN exec: $*"
+    return 0
+  fi
+  "$@"
+}
+
+confirm() {
+  [ "$ASSUME_YES" -eq 1 ] && return 0
+  [ "$DRY_RUN" -eq 1 ] && return 0
+  local prompt="$1" ans
+  printf '%s [y/N] ' "$prompt" >&2
+  if ! IFS= read -r ans; then
+    return 1
+  fi
+  case "$ans" in
+    y|Y|yes|YES|Yes) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+http_code() {
+  # No -f: we WANT the real status code for 4xx/5xx (not a curl error). On a
+  # connection failure curl prints "000"; default to 000 if it prints nothing.
+  local code
+  code="$("$CURL_BIN" -sS -o /dev/null -w '%{http_code}' --max-time 5 "$1" 2>/dev/null)"
+  printf '%s' "${code:-000}"
+}
+
+reload_caddy() {
+  if [ "$DRY_RUN" -eq 1 ]; then
+    log "DRY-RUN: would run: $CADDY_BIN validate --config $CADDYFILE --adapter caddyfile"
+    log "DRY-RUN: would run: $CADDY_BIN reload --config $CADDYFILE --adapter caddyfile"
+    return 0
+  fi
+  log "Validating Caddyfile ($CADDYFILE)..."
+  if ! "$CADDY_BIN" validate --config "$CADDYFILE" --adapter caddyfile; then
+    err "caddy validate failed; not reloading"
+    return 1
+  fi
+  log "Reloading Caddy (graceful, zero-downtime)..."
+  "$CADDY_BIN" reload --config "$CADDYFILE" --adapter caddyfile
+}
+
+pin_image() {
+  local ref="$1"
+  log "Pinning idle-color image: DINF_IMAGE=$ref -> $DINF_DEPLOY_ENV"
+  if [ "$DRY_RUN" -eq 1 ]; then
+    log "DRY-RUN: would write DINF_IMAGE=$ref to $DINF_DEPLOY_ENV (read by darkbloom-run.sh via EnvironmentFile)"
+    return 0
+  fi
+  local dir tmp
+  dir="$(dirname "$DINF_DEPLOY_ENV")"
+  mkdir -p "$dir"
+  tmp="$(mktemp)" || die "mktemp failed"
+  if [ -f "$DINF_DEPLOY_ENV" ]; then
+    grep -v '^DINF_IMAGE=' "$DINF_DEPLOY_ENV" > "$tmp" || true
+  fi
+  printf 'DINF_IMAGE=%s\n' "$ref" >> "$tmp"
+  cat "$tmp" > "$DINF_DEPLOY_ENV"
+  rm -f "$tmp"
+  chmod 644 "$DINF_DEPLOY_ENV"
+}
+
+# wait_healthy <color> <port> — poll /health AND /readyz until both 200 or timeout.
+wait_healthy() {
+  local color="$1" port="$2"
+  if [ "$DRY_RUN" -eq 1 ]; then
+    log "DRY-RUN: would poll http://${HEALTH_HOST}:${port}${HEALTH_PATH} AND ${READYZ_PATH} until 200 (timeout ${HEALTH_TIMEOUT}s)"
+    return 0
+  fi
+  log "Waiting for $color (port $port) /health + /readyz (timeout ${HEALTH_TIMEOUT}s)..."
+  local now deadline h r
+  now="$(date +%s)"
+  deadline=$(( now + HEALTH_TIMEOUT ))
+  while [ "$(date +%s)" -lt "$deadline" ]; do
+    h="$(http_code "http://${HEALTH_HOST}:${port}${HEALTH_PATH}")"
+    r="$(http_code "http://${HEALTH_HOST}:${port}${READYZ_PATH}")"
+    if [ "$h" = "200" ] && [ "$r" = "200" ]; then
+      log "$color is healthy (/health=200, /readyz=200)."
+      return 0
+    fi
+    log "  $color /health=$h /readyz=$r; waiting..."
+    sleep 2
+  done
+  err "$color did not become healthy within ${HEALTH_TIMEOUT}s."
+  return 1
+}
+
+# drain_color <color> <port> — POST /v1/admin/drain then poll /readyz inflight==0.
+drain_color() {
+  local color="$1" port="$2"
+  log "Draining $color (port $port): POST $DRAIN_PATH, then poll $READYZ_PATH inflight==0..."
+  if [ "$DRY_RUN" -eq 1 ]; then
+    log "DRY-RUN: would POST $DRAIN_PATH to $color:$port and poll inflight==0 (timeout ${DRAIN_TIMEOUT}s)"
+    return 0
+  fi
+  # Phase 1 contract: admin-authenticated drain endpoint.
+  if ! "$CURL_BIN" -fsS -X POST \
+        -H "Authorization: Bearer ${EIGENINFERENCE_ADMIN_KEY:-}" \
+        --max-time 10 \
+        "http://${HEALTH_HOST}:${port}${DRAIN_PATH}" >/dev/null; then
+    warn "drain request to $color returned an error (continuing to poll readiness)"
+  fi
+  local now deadline body inflight
+  now="$(date +%s)"
+  deadline=$(( now + DRAIN_TIMEOUT ))
+  while [ "$(date +%s)" -lt "$deadline" ]; do
+    body="$("$CURL_BIN" -fsS --max-time 5 "http://${HEALTH_HOST}:${port}${READYZ_PATH}" 2>/dev/null || true)"
+    # Phase 1 contract: /readyz exposes an inflight counter, e.g. {"inflight":0}.
+    inflight="$(printf '%s' "$body" | sed -n 's/.*"inflight"[[:space:]]*:[[:space:]]*\([0-9][0-9]*\).*/\1/p' | head -n1)"
+    if [ -n "$inflight" ] && [ "$inflight" -eq 0 ]; then
+      log "$color drained (inflight=0)."
+      return 0
+    fi
+    log "  $color inflight=${inflight:-unknown}; waiting..."
+    sleep 3
+  done
+  warn "$color did not reach inflight==0 within ${DRAIN_TIMEOUT}s; the graceful container stop (docker stop -t) will finish remaining requests."
+  return 0
+}
+
+# ===========================================================================
+# Rollback
+# ===========================================================================
+do_rollback() {
+  local cur_port cur_color target_color target_port
+  cur_port="$(current_upstream_port "$CADDYFILE")" || die "could not read current upstream port from $CADDYFILE"
+  cur_color="$(color_for_port "$cur_port")" || die "current upstream port $cur_port is not a known color"
+  target_color="$(other_color "$cur_color")"
+  target_port="$(port_for_color "$target_color")"
+  log "ROLLBACK: Caddy currently -> $cur_color ($cur_port); reverting to $target_color ($target_port)."
+  warn "Rollback only restores routing. The $target_color container must still be RUNNING (valid only before it was stopped)."
+  if [ "$DRY_RUN" -eq 1 ]; then
+    log "DRY-RUN: would flip_upstream $CADDYFILE $cur_port $target_port, then reload Caddy."
+    return 0
+  fi
+  confirm "Flip Caddy upstream $cur_port -> $target_port and reload?" || { log "Rollback aborted."; return 1; }
+  flip_upstream "$CADDYFILE" "$cur_port" "$target_port" || die "flip_upstream failed (rc $?)"
+  reload_caddy || die "caddy reload failed after rollback flip"
+  log "ROLLBACK complete: Caddy -> $target_color ($target_port)."
+}
+
+# ===========================================================================
+# CLI
+# ===========================================================================
+usage_main() {
+  cat <<'USAGE'
+Usage: deploy.sh [options]
+
+Blue-green coordinator deploy on the GCE box. Detects the active color from the
+Caddy upstream, brings up the idle color, cuts over, drains, and stops the old.
+
+Options:
+  --image <ref>      Pin this container image for the idle color before starting.
+  --caddyfile <path> Caddyfile to read/flip (default: /etc/caddy/Caddyfile).
+  --rollback         Flip Caddy back to the other (still-running) color + reload.
+  --dry-run          Print the plan; change nothing.
+  -y, --yes          Assume "yes" to all confirmation prompts (non-interactive).
+  -h, --help         Show this help.
+
+Environment overrides: CADDYFILE, BLUE_PORT(8080), GREEN_PORT(8081), HEALTH_HOST,
+HEALTH_TIMEOUT, DRAIN_TIMEOUT, CADDY_BIN, SYSTEMCTL_BIN, CURL_BIN, DINF_DEPLOY_ENV.
+USAGE
+}
+
+main() {
+  set -uo pipefail
+
+  DRY_RUN=0
+  ROLLBACK=0
+  ASSUME_YES=0
+  IMAGE_REF=""
+
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --dry-run) DRY_RUN=1 ;;
+      --rollback) ROLLBACK=1 ;;
+      -y|--yes) ASSUME_YES=1 ;;
+      --image) [ "$#" -ge 2 ] || { err "--image requires a value"; return 2; }; IMAGE_REF="$2"; shift ;;
+      --image=*) IMAGE_REF="${1#*=}" ;;
+      --caddyfile) [ "$#" -ge 2 ] || { err "--caddyfile requires a value"; return 2; }; CADDYFILE="$2"; shift ;;
+      --caddyfile=*) CADDYFILE="${1#*=}" ;;
+      -h|--help) usage_main; return 0 ;;
+      *) err "unknown argument: $1"; usage_main; return 2 ;;
+    esac
+    shift
+  done
+
+  CADDYFILE="${CADDYFILE:-$CADDYFILE_DEFAULT}"
+  [ -f "$CADDYFILE" ] || die "Caddyfile not found: $CADDYFILE (use --caddyfile or set CADDYFILE)"
+
+  if [ "$ROLLBACK" -eq 1 ]; then
+    do_rollback
+    return $?
+  fi
+
+  local active_port active_color idle_color idle_port
+  active_port="$(current_upstream_port "$CADDYFILE")" || die "could not detect active upstream port in $CADDYFILE"
+  active_color="$(color_for_port "$active_port")" || die "active upstream port $active_port is neither blue($BLUE_PORT) nor green($GREEN_PORT)"
+  idle_color="$(other_color "$active_color")"
+  idle_port="$(port_for_color "$idle_color")"
+
+  log "=============================================================="
+  log " Blue-green deploy plan"
+  log "   Caddyfile      : $CADDYFILE"
+  log "   Active (live)  : $active_color (port $active_port)"
+  log "   Idle  (target) : $idle_color (port $idle_port)"
+  [ -n "$IMAGE_REF" ] && log "   New image      : $IMAGE_REF"
+  [ "$DRY_RUN" -eq 1 ] && log "   MODE           : DRY-RUN (no changes will be made)"
+  log "=============================================================="
+
+  # 1. Pin image for the idle color (optional).
+  if [ -n "$IMAGE_REF" ]; then
+    pin_image "$IMAGE_REF"
+  fi
+
+  # 2. Start the idle color.
+  confirm "Start idle color '$idle_color'?" || die "aborted before starting idle color"
+  run_cmd "$SYSTEMCTL_BIN" start "darkbloom-coordinator@${idle_color}"
+
+  # 3. Wait for idle health + readiness.
+  if ! wait_healthy "$idle_color" "$idle_port"; then
+    err "Idle color $idle_color failed health check; stopping it. Caddy untouched ($active_color still live)."
+    run_cmd "$SYSTEMCTL_BIN" stop "darkbloom-coordinator@${idle_color}"
+    die "deploy aborted: idle color unhealthy"
+  fi
+
+  # 4. Cutover: flip Caddy upstream active->idle + graceful reload (DESTRUCTIVE).
+  if ! confirm "CUTOVER: flip Caddy $active_port -> $idle_port (live traffic to $idle_color) and reload?"; then
+    err "Cutover declined; stopping idle color. Caddy still -> $active_color."
+    run_cmd "$SYSTEMCTL_BIN" stop "darkbloom-coordinator@${idle_color}"
+    die "deploy aborted before cutover"
+  fi
+  if [ "$DRY_RUN" -eq 1 ]; then
+    log "DRY-RUN: would flip_upstream $CADDYFILE $active_port $idle_port, then reload Caddy."
+  else
+    flip_upstream "$CADDYFILE" "$active_port" "$idle_port" || die "flip_upstream failed (rc $?); Caddy unchanged, $active_color still live"
+    if ! reload_caddy; then
+      err "caddy reload failed after flip; attempting automatic rollback flip."
+      flip_upstream "$CADDYFILE" "$idle_port" "$active_port" || err "rollback flip ALSO failed — manual intervention required on $CADDYFILE"
+      reload_caddy || true
+      die "deploy aborted: caddy reload failed (attempted rollback to $active_color)"
+    fi
+  fi
+  log "Cutover complete: Caddy -> $idle_color ($idle_port). $active_color still running for drain."
+  log "Rollback window OPEN: run '$0 --rollback' to revert to $active_color (valid until it is stopped)."
+
+  # 5. Drain the old color.
+  drain_color "$active_color" "$active_port"
+
+  # 6. Stop the old color (closes rollback window; triggers Phase 3 going_away).
+  if ! confirm "Stop old color '$active_color'? (closes rollback window; triggers Phase 3 going_away broadcast)"; then
+    warn "Old color $active_color left RUNNING. Stop later with: $SYSTEMCTL_BIN stop darkbloom-coordinator@${active_color}"
+    log "Deploy finished (old color intentionally not stopped)."
+    return 0
+  fi
+  run_cmd "$SYSTEMCTL_BIN" stop "darkbloom-coordinator@${active_color}"
+  log "Old color $active_color stopped. Deploy complete: $idle_color is now the sole live coordinator."
+}
+
+# Only auto-run when executed directly — NEVER when sourced (e.g. by the test).
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+  main "$@"
+fi

--- a/deploy.sh
+++ b/deploy.sh
@@ -6,8 +6,8 @@
 # color never serves consumers with zero providers (which would 429):
 #
 #   1. detect the active color from the on-box Caddyfile upstream port
-#   2. (optional) pin the new image for the idle color (rolled back if the deploy
-#      is aborted before cutover; kept once the cutover is accepted)
+#   2. (optional) pin the new image in the idle color's per-color env file
+#      (rolled back if the deploy is aborted before cutover; kept once accepted)
 #   3. restart the IDLE color         (systemctl restart darkbloom-coordinator@<idle>)
 #      — restart, NOT start, so a stale idle container re-execs with the new image
 #   4. wait for idle /health AND /readyz  (DAR-327 Phase 1 endpoints)
@@ -20,8 +20,8 @@
 #
 # Steps 6-7 explicitly hand providers to the new color via the Phase 3
 # going-away endpoint; the drain (8) and stop (9) then retire the old color with
-# no capacity gap. If the drain does not complete the old color is NOT stopped
-# (it would cut in-flight requests) unless --force is given.
+# no capacity gap. If providers do not land on the new color, or if the drain
+# does not complete, the old color is NOT drained/stopped unless --force is given.
 #
 # ROLLBACK (valid any time AFTER the flip and BEFORE the old color is stopped):
 #   ./deploy.sh --rollback
@@ -84,11 +84,11 @@ PROVIDERS_TIMEOUT="${PROVIDERS_TIMEOUT:-60}"
 CADDY_BIN="${CADDY_BIN:-caddy}"
 SYSTEMCTL_BIN="${SYSTEMCTL_BIN:-systemctl}"
 CURL_BIN="${CURL_BIN:-curl}"
-DINF_DEPLOY_ENV="${DINF_DEPLOY_ENV:-/etc/d-inference/deploy.env}"
+DINF_DEPLOY_ENV_TMPL="${DINF_DEPLOY_ENV_TMPL:-/etc/d-inference/deploy-%s.env}"
 # Secrets env file (Secret Manager -> tmpfs). Holds EIGENINFERENCE_ADMIN_KEY,
 # whose single line is PARSED (never sourced; see load_admin_env) at cutover time
 # to authenticate the admin going-away/drain POSTs. Distinct from the non-secret
-# DINF_DEPLOY_ENV image-pin file above. Overridable for tests.
+# per-color DINF_DEPLOY_ENV_TMPL image-pin files above. Overridable for tests.
 DINF_ENV_FILE="${DINF_ENV_FILE:-/etc/d-inference/env}"
 
 # Runtime flags (main overrides from CLI args).
@@ -98,12 +98,12 @@ ASSUME_YES=0
 FORCE=0
 IMAGE_REF=""
 
-# Image-pin rollback state (set by pin_image, consumed by restore/accept). The
-# pin in DINF_DEPLOY_ENV is shared by BOTH colors, so an aborted deploy must
-# restore it or the still-live OLD color would pull the unaccepted image on its
-# next restart. DINF_DEPLOY_ENV_BAK="" means "no pin to roll back".
+# Image-pin rollback state (set by pin_image, consumed by restore/accept).
+# DINF_DEPLOY_ENV_BAK="" means "no pin to roll back"; DINF_DEPLOY_ENV_PINNED
+# keeps restore/accept pointed at the exact per-color file pin_image touched.
 DINF_DEPLOY_ENV_BAK=""
 DINF_DEPLOY_ENV_EXISTED=0
+DINF_DEPLOY_ENV_PINNED=""
 
 # ---------------------------------------------------------------------------
 # Logging
@@ -223,6 +223,22 @@ other_color() {
   esac
 }
 
+deploy_env_for_color() {
+  if [ "$#" -ne 1 ]; then
+    echo "deploy_env_for_color: usage: deploy_env_for_color <blue|green>" >&2
+    return 2
+  fi
+  local color="$1"
+  case "$color" in
+    blue|green) ;;
+    *) echo "deploy_env_for_color: unknown color: $color" >&2; return 2 ;;
+  esac
+  case "$DINF_DEPLOY_ENV_TMPL" in
+    *%s*) printf '%s\n' "${DINF_DEPLOY_ENV_TMPL/\%s/$color}" ;;
+    *) echo "deploy_env_for_color: DINF_DEPLOY_ENV_TMPL must contain %s: $DINF_DEPLOY_ENV_TMPL" >&2; return 2 ;;
+  esac
+}
+
 # ===========================================================================
 # Effectful helpers (dry-run aware).
 # ===========================================================================
@@ -272,39 +288,70 @@ reload_caddy() {
   "$CADDY_BIN" reload --config "$CADDYFILE" --adapter caddyfile
 }
 
-# pin_image <ref> — write DINF_IMAGE=<ref> to the (shared) DINF_DEPLOY_ENV pin
-# file so the idle color re-execs with the new image. The previous pin state is
-# snapshotted first so restore_image_pin can undo it if the deploy is aborted
-# BEFORE the cutover is accepted (the OLD color shares this file and would
-# otherwise pull the unaccepted image on its next systemd restart). The pin is
-# made permanent by accept_image_pin once the cutover succeeds.
+# pin_image <color> <ref> — write DINF_IMAGE=<ref> to the idle color's per-color
+# deploy env file so only that color re-execs with the new image. The previous
+# pin state is snapshotted first so restore_image_pin can undo it if the deploy
+# is aborted BEFORE the cutover is accepted. The pin is made permanent by
+# accept_image_pin once the cutover succeeds.
 pin_image() {
-  local ref="$1"
-  log "Pinning idle-color image: DINF_IMAGE=$ref -> $DINF_DEPLOY_ENV"
+  if [ "$#" -ne 2 ]; then
+    echo "pin_image: usage: pin_image <blue|green> <image-ref>" >&2
+    return 2
+  fi
+  local color="$1" ref="$2" pin_file
+  pin_file="$(deploy_env_for_color "$color")" || return $?
+  log "Pinning $color image: DINF_IMAGE=$ref -> $pin_file"
   if [ "$DRY_RUN" -eq 1 ]; then
-    log "DRY-RUN: would snapshot $DINF_DEPLOY_ENV, then write DINF_IMAGE=$ref (read by darkbloom-run.sh via EnvironmentFile); the pin is rolled back if the deploy aborts before cutover, kept once cutover is accepted"
+    log "DRY-RUN: would snapshot $pin_file, then write DINF_IMAGE=$ref (read by darkbloom-run.sh via EnvironmentFile); the pin is rolled back if the deploy aborts before cutover, kept once cutover is accepted"
     return 0
   fi
-  local dir tmp
-  dir="$(dirname "$DINF_DEPLOY_ENV")"
-  mkdir -p "$dir"
+  local dir bak tmp rc
+  dir="$(dirname "$pin_file")"
+  if ! mkdir -p "$dir"; then
+    err "failed to create deploy env directory $dir"
+    return 1
+  fi
   # Snapshot the current pin so an aborted/declined/unhealthy deploy can restore
   # it. An empty backup with DINF_DEPLOY_ENV_EXISTED=0 marks "file did not exist".
-  DINF_DEPLOY_ENV_BAK="$(mktemp)" || die "mktemp failed"
-  if [ -f "$DINF_DEPLOY_ENV" ]; then
+  bak="$(mktemp)" || { err "mktemp failed"; return 1; }
+  if [ -f "$pin_file" ]; then
+    if ! cat "$pin_file" > "$bak"; then
+      rm -f "$bak"
+      err "failed to snapshot existing image pin $pin_file"
+      return 1
+    fi
     DINF_DEPLOY_ENV_EXISTED=1
-    cat "$DINF_DEPLOY_ENV" > "$DINF_DEPLOY_ENV_BAK"
   else
     DINF_DEPLOY_ENV_EXISTED=0
   fi
-  tmp="$(mktemp)" || die "mktemp failed"
-  if [ -f "$DINF_DEPLOY_ENV" ]; then
-    grep -v '^DINF_IMAGE=' "$DINF_DEPLOY_ENV" > "$tmp" || true
+  DINF_DEPLOY_ENV_BAK="$bak"
+  DINF_DEPLOY_ENV_PINNED="$pin_file"
+
+  tmp="$(mktemp)" || { err "mktemp failed"; return 1; }
+  if [ -f "$pin_file" ]; then
+    grep -v '^DINF_IMAGE=' "$pin_file" > "$tmp"
+    rc=$?
+    if [ "$rc" -gt 1 ]; then
+      rm -f "$tmp"
+      err "failed to read existing image pin $pin_file"
+      return 1
+    fi
   fi
-  printf 'DINF_IMAGE=%s\n' "$ref" >> "$tmp"
-  cat "$tmp" > "$DINF_DEPLOY_ENV"
+  if ! printf 'DINF_IMAGE=%s\n' "$ref" >> "$tmp"; then
+    rm -f "$tmp"
+    err "failed to write temporary image pin for $pin_file"
+    return 1
+  fi
+  if ! cat "$tmp" > "$pin_file"; then
+    rm -f "$tmp"
+    err "failed to write image pin $pin_file"
+    return 1
+  fi
   rm -f "$tmp"
-  chmod 644 "$DINF_DEPLOY_ENV"
+  if ! chmod 644 "$pin_file"; then
+    err "failed to chmod image pin $pin_file"
+    return 1
+  fi
 }
 
 # restore_image_pin — undo a pin_image() write. Called on any exit BEFORE the
@@ -313,16 +360,24 @@ pin_image() {
 restore_image_pin() {
   [ -n "${DINF_DEPLOY_ENV_BAK:-}" ] || return 0
   [ "$DRY_RUN" -eq 1 ] && return 0
+  local pin_file="${DINF_DEPLOY_ENV_PINNED:-}"
+  if [ -z "$pin_file" ]; then
+    warn "Deploy aborted before cutover, but no pinned deploy env path was recorded; cannot restore image pin."
+    rm -f "$DINF_DEPLOY_ENV_BAK"
+    DINF_DEPLOY_ENV_BAK=""
+    return 0
+  fi
   if [ "${DINF_DEPLOY_ENV_EXISTED:-0}" -eq 1 ]; then
-    warn "Deploy aborted before cutover: restoring previous image pin in $DINF_DEPLOY_ENV."
-    cat "$DINF_DEPLOY_ENV_BAK" > "$DINF_DEPLOY_ENV" 2>/dev/null || warn "failed to restore $DINF_DEPLOY_ENV"
-    chmod 644 "$DINF_DEPLOY_ENV" 2>/dev/null || true
+    warn "Deploy aborted before cutover: restoring previous image pin in $pin_file."
+    cat "$DINF_DEPLOY_ENV_BAK" > "$pin_file" 2>/dev/null || warn "failed to restore $pin_file"
+    chmod 644 "$pin_file" 2>/dev/null || true
   else
-    warn "Deploy aborted before cutover: removing image pin $DINF_DEPLOY_ENV (created this run)."
-    rm -f "$DINF_DEPLOY_ENV" 2>/dev/null || warn "failed to remove $DINF_DEPLOY_ENV"
+    warn "Deploy aborted before cutover: removing image pin $pin_file (created this run)."
+    rm -f "$pin_file" 2>/dev/null || warn "failed to remove $pin_file"
   fi
   rm -f "$DINF_DEPLOY_ENV_BAK"
   DINF_DEPLOY_ENV_BAK=""
+  DINF_DEPLOY_ENV_PINNED=""
 }
 
 # accept_image_pin — keep the pin permanently (cutover succeeded) and disarm the
@@ -331,6 +386,7 @@ accept_image_pin() {
   [ -n "${DINF_DEPLOY_ENV_BAK:-}" ] || return 0
   rm -f "$DINF_DEPLOY_ENV_BAK"
   DINF_DEPLOY_ENV_BAK=""
+  DINF_DEPLOY_ENV_PINNED=""
 }
 
 # wait_healthy <color> <port> — poll /health AND /readyz until both 200 or timeout.
@@ -509,8 +565,8 @@ clear_going_away() {
 # wait_for_providers <color> <port> — after going-away, poll the NEW color's
 # /health until its provider count is > 0 (reconnects have landed). /health shape
 # (coordinator api/types HealthResponse): {"status":"ok","providers":N,...}.
-# WARNS on timeout (does NOT abort): Caddy is already flipped and the old color is
-# still up, so a human can investigate without a hard failure.
+# Returns nonzero on timeout; the forward deploy treats that as fatal unless
+# --force, while rollback only warns because routing is already restored.
 wait_for_providers() {
   local color="$1" port="$2"
   if [ "$DRY_RUN" -eq 1 ]; then
@@ -531,8 +587,8 @@ wait_for_providers() {
     log "  $color providers=${count:-unknown}; waiting for reconnects..."
     sleep 2
   done
-  warn "$color did not report providers>0 within ${PROVIDERS_TIMEOUT}s; providers may still be reconnecting (heartbeat timeout). Proceeding to drain the old color — monitor capacity."
-  return 0
+  warn "$color did not report providers>0 within ${PROVIDERS_TIMEOUT}s; providers may still be reconnecting (heartbeat timeout)."
+  return 1
 }
 
 # ===========================================================================
@@ -612,7 +668,11 @@ do_rollback() {
   signal_going_away "$cur_color" "$cur_port"
 
   # STEP D — confirm capacity actually returned to $target_color (reconnects landed).
-  wait_for_providers "$target_color" "$target_port"
+  # Rollback has already restored routing; a provider wait timeout must not undo
+  # that recovery path, so tolerate it with a warning.
+  if ! wait_for_providers "$target_color" "$target_port"; then
+    warn "Rollback routing is already restored to $target_color; continuing despite provider wait timeout. Monitor capacity and provider reconnects."
+  fi
 
   log "ROLLBACK complete: Caddy -> $target_color ($target_port); providers pushed back to it."
   log "The abandoned $cur_color ($cur_port) is left RUNNING (idle, providers drained off) for inspection; stop it manually with '$SYSTEMCTL_BIN stop darkbloom-coordinator@${cur_color}'."
@@ -635,15 +695,17 @@ Options:
                      (undrain + clear its going-away latch), flip Caddy back +
                      reload, then push providers back onto it and wait for
                      providers>0.
-  --force            With --rollback: flip even if the target color fails its
-                     health check (DANGEROUS — may route traffic to a dead port).
+  --force            Forward: continue drain/stop even if providers do not land or
+                     drain times out. Rollback: flip even if target health fails
+                     (DANGEROUS — may route traffic to a dead port).
   --dry-run          Print the plan; change nothing.
   -y, --yes          Assume "yes" to all confirmation prompts (non-interactive).
   -h, --help         Show this help.
 
 Environment overrides: CADDYFILE, BLUE_PORT(8080), GREEN_PORT(8081), HEALTH_HOST,
 HEALTH_TIMEOUT, DRAIN_TIMEOUT, PROVIDERS_TIMEOUT(60), GOING_AWAY_PATH, CADDY_BIN,
-SYSTEMCTL_BIN, CURL_BIN, DINF_DEPLOY_ENV, DINF_ENV_FILE(/etc/d-inference/env).
+SYSTEMCTL_BIN, CURL_BIN, DINF_DEPLOY_ENV_TMPL(/etc/d-inference/deploy-%s.env),
+DINF_ENV_FILE(/etc/d-inference/env).
 USAGE
 }
 
@@ -680,11 +742,14 @@ main() {
     return $?
   fi
 
-  local active_port active_color idle_color idle_port
+  local active_port active_color idle_color idle_port image_pin_file
   active_port="$(current_upstream_port "$CADDYFILE")" || die "could not detect active upstream port in $CADDYFILE"
   active_color="$(color_for_port "$active_port")" || die "active upstream port $active_port is neither blue($BLUE_PORT) nor green($GREEN_PORT)"
   idle_color="$(other_color "$active_color")"
   idle_port="$(port_for_color "$idle_color")"
+  if [ -n "$IMAGE_REF" ]; then
+    image_pin_file="$(deploy_env_for_color "$idle_color")" || die "could not compute deploy env path for idle color $idle_color"
+  fi
 
   log "=============================================================="
   log " Blue-green deploy plan"
@@ -692,6 +757,7 @@ main() {
   log "   Active (live)  : $active_color (port $active_port)"
   log "   Idle  (target) : $idle_color (port $idle_port)"
   [ -n "$IMAGE_REF" ] && log "   New image      : $IMAGE_REF"
+  [ -n "$IMAGE_REF" ] && log "   Image pin file : $image_pin_file"
   [ "$DRY_RUN" -eq 1 ] && log "   MODE           : DRY-RUN (no changes will be made)"
   log "=============================================================="
 
@@ -701,9 +767,11 @@ main() {
   trap 'restore_image_pin' EXIT
 
   # 1. Pin image for the idle color (optional). Snapshotted so it is rolled back
-  #    if the deploy aborts before cutover (the OLD color shares this pin file).
+  #    if the deploy aborts before cutover.
   if [ -n "$IMAGE_REF" ]; then
-    pin_image "$IMAGE_REF"
+    if ! pin_image "$idle_color" "$IMAGE_REF"; then
+      die "deploy aborted: failed to pin image for idle color '$idle_color'; not restarting it"
+    fi
   fi
 
   # 2. Restart the idle color. RESTART (not start) so a stale already-running idle
@@ -761,7 +829,18 @@ main() {
   signal_going_away "$active_color" "$active_port"
 
   # 6. Wait until the NEW color actually has providers attached (reconnects landed).
-  wait_for_providers "$idle_color" "$idle_port"
+  #    If this times out, do NOT drain/stop the old color unless --force is set:
+  #    old providers have not proven they landed on the new color yet.
+  if ! wait_for_providers "$idle_color" "$idle_port"; then
+    if [ "$FORCE" -eq 1 ]; then
+      warn "Providers did not land on $idle_color within ${PROVIDERS_TIMEOUT}s, but --force was given; proceeding to drain/stop $active_color despite capacity risk."
+    else
+      err "NOT draining or stopping $active_color: $idle_color did not report providers>0 within ${PROVIDERS_TIMEOUT}s."
+      err "Caddy is already -> $idle_color; the old color stays RUNNING so providers/in-flight work are not disrupted."
+      err "Investigate provider reconnects, run '$0 --rollback' before stopping $active_color if needed, or re-run with --force to continue despite capacity risk."
+      die "deploy aborted: providers did not land on new color (cutover done, $active_color left running)"
+    fi
+  fi
 
   # 7. Drain the old color. If it does NOT drain in time, do NOT stop it (stopping
   #    would cut in-flight requests at the container SIGTERM deadline): abort with

--- a/deploy.sh
+++ b/deploy.sh
@@ -25,8 +25,16 @@
 #
 # ROLLBACK (valid any time AFTER the flip and BEFORE the old color is stopped):
 #   ./deploy.sh --rollback
-# flips the Caddy upstream back to the still-running previous color and reloads,
-# restoring the on-disk Caddyfile if the reload itself fails.
+# restores BOTH routing AND capacity to the previous color. A bare Caddy flip is
+# NOT sufficient once the forward deploy has signalled going-away to the old color:
+# that latches the old color to REFUSE new provider registrations (503) and pushes
+# its providers one-way onto the new color, so flipping back alone would route
+# consumers to a color with no providers (429). Rollback therefore (1) re-enables
+# the target color (undrain + clear its going-away latch so it accepts providers
+# again), (2) flips the Caddy upstream back to it and reloads (restoring the
+# on-disk Caddyfile if the reload itself fails), (3) broadcasts going-away to the
+# now-abandoned color so its providers reconnect and land back on the restored
+# color, and (4) waits for the restored color to report providers>0.
 #
 # SAFETY:
 #   * --dry-run prints the full plan (new ordering) and mutates NOTHING.
@@ -45,8 +53,11 @@
 #     coordinator secrets stay in that file and are never touched here.
 #
 # Cross-phase contracts (separate PRs; referenced, not implemented here):
-#   Phase 1 : GET /readyz  +  POST /v1/admin/drain
-#   Phase 3 : POST /v1/admin/going-away (admin-gated; returns 200 {"sent":N})
+#   Phase 1 : GET /readyz  +  POST /v1/admin/drain  (bodyless POST = start draining;
+#             POST {"draining":false} = clear the drain latch / undrain)
+#   Phase 3 : POST /v1/admin/going-away (admin-gated). Empty body = broadcast+latch,
+#             returns 200 {"sent":N}.  {"cancel":true} = clear the latch,
+#             returns 200 {"going_away":false,"cleared":true}.
 
 # NOTE: shell options are set inside main() so that sourcing this file for tests
 # does not mutate the caller's shell. The functions below are written to not
@@ -410,6 +421,32 @@ drain_color() {
   return 1
 }
 
+# undrain_color <color> <port> — POST /v1/admin/drain {"draining":false} to CLEAR a
+# color's drain latch so it re-accepts work (the inverse of drain_color's bodyless
+# POST, which STARTS draining). Used by --rollback to re-enable the rollback target,
+# which the forward deploy may have drained. Best-effort: warns and continues on any
+# failure so a not-yet-deployed endpoint degrades gracefully. DRY_RUN-aware.
+# EIGENINFERENCE_ADMIN_KEY is loaded once by the caller (load_admin_env).
+undrain_color() {
+  local color="$1" port="$2"
+  log "Undraining $color (port $port): POST $DRAIN_PATH {\"draining\":false} (re-accept work)..."
+  if [ "$DRY_RUN" -eq 1 ]; then
+    log "DRY-RUN: would POST $DRAIN_PATH {\"draining\":false} to $color:$port"
+    return 0
+  fi
+  # Phase 1 contract: the drain endpoint accepts {"draining":false} to UN-drain.
+  if ! "$CURL_BIN" -fsS -X POST \
+        -H "Authorization: Bearer ${EIGENINFERENCE_ADMIN_KEY:-}" \
+        -H "Content-Type: application/json" \
+        --max-time 10 \
+        --data '{"draining":false}' \
+        "http://${HEALTH_HOST}:${port}${DRAIN_PATH}" >/dev/null; then
+    warn "undrain request to $color returned an error (continuing; it may already accept work, or the endpoint is not deployed yet)."
+  else
+    log "$color undrained (now re-accepting work)."
+  fi
+}
+
 # signal_going_away <color> <port> — POST /v1/admin/going-away to the OLD color so
 # its providers reconnect and (Caddy already flipped) re-land on the NEW color.
 # Phase 3 (PR #396) contract: admin-gated, returns 200 {"sent":N}. Best-effort:
@@ -434,6 +471,38 @@ signal_going_away() {
     log "going-away accepted by $color (sent=$sent; those providers will reconnect to the new color)."
   else
     warn "going-away to $color did not return a parseable {\"sent\":N} (continuing; providers will still reconnect within the heartbeat timeout)."
+  fi
+}
+
+# clear_going_away <color> <port> — POST /v1/admin/going-away {"cancel":true} to
+# CLEAR a color's going-away latch (set by a prior signal_going_away). Until cleared
+# that latch makes the color REFUSE new provider registrations (503), so --rollback
+# MUST clear it on the rollback target before flipping traffic back, or the restored
+# color would route consumers to zero providers. Phase 3 (PR #396) contract:
+# admin-gated; empty body = broadcast+latch (signal_going_away), {"cancel":true} =
+# clear, returns 200 {"going_away":false,"cleared":true}. Best-effort: warns and
+# continues on failure (a not-yet-deployed endpoint degrades gracefully).
+# DRY_RUN-aware. EIGENINFERENCE_ADMIN_KEY is loaded once by the caller (load_admin_env).
+clear_going_away() {
+  local color="$1" port="$2"
+  log "Clearing going-away latch on $color (port $port): POST $GOING_AWAY_PATH {\"cancel\":true} (re-accept providers)..."
+  if [ "$DRY_RUN" -eq 1 ]; then
+    log "DRY-RUN: would POST $GOING_AWAY_PATH {\"cancel\":true} to $color:$port (admin-gated; expect 200 {\"going_away\":false,\"cleared\":true})"
+    return 0
+  fi
+  local body cleared
+  body="$("$CURL_BIN" -fsS -X POST \
+        -H "Authorization: Bearer ${EIGENINFERENCE_ADMIN_KEY:-}" \
+        -H "Content-Type: application/json" \
+        --max-time 10 \
+        --data '{"cancel":true}' \
+        "http://${HEALTH_HOST}:${port}${GOING_AWAY_PATH}" 2>/dev/null || true)"
+  # Contract response: {"going_away":false,"cleared":true}.
+  cleared="$(printf '%s' "$body" | sed -n 's/.*"cleared"[[:space:]]*:[[:space:]]*true.*/true/p' | head -n1)"
+  if [ "$cleared" = "true" ]; then
+    log "going-away latch cleared on $color (now re-accepts provider registrations)."
+  else
+    warn "clear going-away on $color did not confirm {\"cleared\":true} (continuing; endpoint may not be deployed yet — providers will still re-register once it accepts them)."
   fi
 }
 
@@ -476,10 +545,16 @@ do_rollback() {
   target_color="$(other_color "$cur_color")"
   target_port="$(port_for_color "$target_color")"
   log "ROLLBACK: Caddy currently -> $cur_color ($cur_port); reverting to $target_color ($target_port)."
-  warn "Rollback only restores routing. The $target_color container must still be RUNNING (valid only before it was stopped)."
+  log "Rollback restores routing AND capacity: re-enable $target_color (undrain + clear its going-away latch), flip Caddy back, then push providers off $cur_color back onto $target_color."
+  warn "The $target_color container must still be RUNNING (rollback is valid only before it was stopped)."
   if [ "$DRY_RUN" -eq 1 ]; then
     log "DRY-RUN: would health-check $target_color at http://${HEALTH_HOST}:${target_port}${HEALTH_PATH} before flipping."
-    log "DRY-RUN: would flip_upstream $CADDYFILE $cur_port $target_port, then reload Caddy."
+    log "DRY-RUN: would load_admin_env (parse EIGENINFERENCE_ADMIN_KEY for the admin POSTs below)."
+    log "DRY-RUN: STEP A — would re-enable $target_color: POST $DRAIN_PATH {\"draining\":false} (undrain) + POST $GOING_AWAY_PATH {\"cancel\":true} (clear going-away latch) to ${HEALTH_HOST}:${target_port}."
+    log "DRY-RUN: STEP B — would flip_upstream $CADDYFILE $cur_port $target_port, then reload Caddy (auto-revert to $cur_color if reload fails)."
+    log "DRY-RUN: STEP C — would POST $GOING_AWAY_PATH to the now-abandoned $cur_color ($cur_port) so its providers reconnect and land on $target_color."
+    log "DRY-RUN: STEP D — would poll $target_color ($target_port) /health for providers>0 (timeout ${PROVIDERS_TIMEOUT}s)."
+    log "DRY-RUN: would leave $cur_color running (idle, providers drained off) for inspection; stop it manually with '$SYSTEMCTL_BIN stop darkbloom-coordinator@${cur_color}'."
     return 0
   fi
   # Never flip onto a dead port (connection refused -> 502s): probe the target's
@@ -498,19 +573,49 @@ do_rollback() {
     err "Start it first (e.g. '$SYSTEMCTL_BIN start darkbloom-coordinator@${target_color}'), or re-run with --force to flip anyway."
     return 1
   fi
-  confirm "Flip Caddy upstream $cur_port -> $target_port and reload?" || { log "Rollback aborted."; return 1; }
+  confirm "Roll back to $target_color: re-enable it, flip Caddy $cur_port -> $target_port, and push providers back?" || { log "Rollback aborted."; return 1; }
+
+  # Parse the admin key for the authenticated undrain + going-away POSTs below. Real
+  # run only — the --dry-run path returned above, so the plan stays secret-free.
+  load_admin_env
+  if [ -z "${EIGENINFERENCE_ADMIN_KEY:-}" ]; then
+    warn "EIGENINFERENCE_ADMIN_KEY is empty ($DINF_ENV_FILE missing or unset); the undrain/going-away POSTs will be unauthenticated and likely rejected — continuing (best-effort)."
+  fi
+
+  # STEP A — re-enable the rollback target BEFORE flipping traffic onto it. The
+  # forward deploy latched it going-away (it now refuses new provider registrations,
+  # 503) and may have drained it; undo BOTH so it can re-accept providers once Caddy
+  # points back at it. Best-effort (warn + continue) so a not-yet-deployed Phase 1/3
+  # endpoint degrades gracefully.
+  undrain_color "$target_color" "$target_port"
+  clear_going_away "$target_color" "$target_port"
+
+  # STEP B — flip Caddy cur->target + reload. Mirror the cutover path: if the reload
+  # fails after flipping the on-disk Caddyfile, flip it BACK so on-disk state matches
+  # live Caddy (still -> $cur_color); otherwise a later run would read the stale
+  # on-disk port and flip/stop the wrong color.
   flip_upstream "$CADDYFILE" "$cur_port" "$target_port" || die "flip_upstream failed (rc $?)"
-  # Mirror the cutover path: if the reload fails after flipping the on-disk
-  # Caddyfile, flip it BACK so on-disk state matches live Caddy (still -> $cur_color).
-  # Otherwise a later run would read the stale on-disk port and flip/stop the
-  # wrong color.
   if ! reload_caddy; then
     err "caddy reload failed after rollback flip; restoring Caddyfile to $cur_color ($cur_port) so on-disk state matches live Caddy."
     flip_upstream "$CADDYFILE" "$target_port" "$cur_port" || err "restore flip ALSO failed — manual intervention required on $CADDYFILE"
     reload_caddy || true
     die "rollback aborted: caddy reload failed (Caddyfile restored to $cur_color)"
   fi
-  log "ROLLBACK complete: Caddy -> $target_color ($target_port)."
+  log "Caddy now -> $target_color ($target_port)."
+
+  # STEP C — push providers off the now-abandoned $cur_color back onto $target_color.
+  # Broadcast going-away to $cur_color: its providers reconnect and — Caddy already
+  # flipped — land on $target_color. (signal_going_away logs this as the "OLD" color;
+  # in a rollback that is the abandoned new color we are retiring.) Best-effort like
+  # the forward path; providers also reconnect within the heartbeat timeout.
+  log "Pushing providers off the abandoned $cur_color back onto $target_color..."
+  signal_going_away "$cur_color" "$cur_port"
+
+  # STEP D — confirm capacity actually returned to $target_color (reconnects landed).
+  wait_for_providers "$target_color" "$target_port"
+
+  log "ROLLBACK complete: Caddy -> $target_color ($target_port); providers pushed back to it."
+  log "The abandoned $cur_color ($cur_port) is left RUNNING (idle, providers drained off) for inspection; stop it manually with '$SYSTEMCTL_BIN stop darkbloom-coordinator@${cur_color}'."
 }
 
 # ===========================================================================
@@ -526,7 +631,10 @@ Caddy upstream, brings up the idle color, cuts over, drains, and stops the old.
 Options:
   --image <ref>      Pin this container image for the idle color before starting.
   --caddyfile <path> Caddyfile to read/flip (default: /etc/caddy/Caddyfile).
-  --rollback         Flip Caddy back to the other (still-running) color + reload.
+  --rollback         Roll back to the other (still-running) color: re-enable it
+                     (undrain + clear its going-away latch), flip Caddy back +
+                     reload, then push providers back onto it and wait for
+                     providers>0.
   --force            With --rollback: flip even if the target color fails its
                      health check (DANGEROUS — may route traffic to a dead port).
   --dry-run          Print the plan; change nothing.

--- a/deploy.sh
+++ b/deploy.sh
@@ -14,7 +14,7 @@
 #   5. flip the Caddy upstream old->new + graceful `caddy reload`  (cutover)
 #   6. POST /v1/admin/going-away to the OLD color (DAR-327 Phase 3, PR #396) so its
 #      providers reconnect and — Caddy already flipped — land on the NEW color
-#   7. wait until the NEW color reports providers>0 (the reconnects landed)
+#   7. wait until the NEW color reports routable capacity>0 (providers landed + trusted)
 #   8. drain the OLD color            (POST /v1/admin/drain, Phase 1) until inflight==0
 #   9. stop the OLD color             (systemctl stop darkbloom-coordinator@<old>)
 #
@@ -34,7 +34,7 @@
 # again), (2) flips the Caddy upstream back to it and reloads (restoring the
 # on-disk Caddyfile if the reload itself fails), (3) broadcasts going-away to the
 # now-abandoned color so its providers reconnect and land back on the restored
-# color, and (4) waits for the restored color to report providers>0.
+# color, and (4) waits for the restored color to report routable capacity>0.
 #
 # SAFETY:
 #   * --dry-run prints the full plan (new ordering) and mutates NOTHING.
@@ -74,12 +74,13 @@ HEALTH_HOST="${HEALTH_HOST:-127.0.0.1}"
 HEALTH_PATH="${HEALTH_PATH:-/health}"
 READYZ_PATH="${READYZ_PATH:-/readyz}"
 DRAIN_PATH="${DRAIN_PATH:-/v1/admin/drain}"
+CAPACITY_PATH="${CAPACITY_PATH:-/v1/models/capacity}"
 # Phase 3 (PR #396) endpoint: tells the OLD color's providers to reconnect so
 # they re-land on the already-flipped NEW color. Admin-gated; returns {"sent":N}.
 GOING_AWAY_PATH="${GOING_AWAY_PATH:-/v1/admin/going-away}"
 HEALTH_TIMEOUT="${HEALTH_TIMEOUT:-120}"
 DRAIN_TIMEOUT="${DRAIN_TIMEOUT:-120}"
-# How long to wait for the NEW color to report providers>0 after going-away.
+# How long to wait for the NEW color to report routable capacity>0 after going-away.
 PROVIDERS_TIMEOUT="${PROVIDERS_TIMEOUT:-60}"
 CADDY_BIN="${CADDY_BIN:-caddy}"
 SYSTEMCTL_BIN="${SYSTEMCTL_BIN:-systemctl}"
@@ -562,32 +563,44 @@ clear_going_away() {
   fi
 }
 
+# capacity_model_count reads GET /v1/models/capacity JSON from stdin and prints the
+# number of routable capacity entries. Empty/malformed bodies produce 0. Uses
+# python3 instead of jq because the GCE deploy box already relies on python3 in
+# darkbloom-run.sh for registry auth, while jq may not be installed.
+capacity_model_count() {
+  python3 -c 'import json,sys
+try:
+    body=json.load(sys.stdin)
+    print(len(body.get("models") or []))
+except Exception:
+    print(0)'
+}
+
 # wait_for_providers <color> <port> — after going-away, poll the NEW color's
-# /health until its provider count is > 0 (reconnects have landed). /health shape
-# (coordinator api/types HealthResponse): {"status":"ok","providers":N,...}.
-# Returns nonzero on timeout; the forward deploy treats that as fatal unless
-# --force, while rollback only warns because routing is already restored.
+# routable capacity feed until at least one model has capacity. Raw /health
+# providers only proves a WebSocket registered; /v1/models/capacity proves the
+# provider is trusted/routable enough for consumers. Returns nonzero on timeout.
 wait_for_providers() {
   local color="$1" port="$2"
   if [ "$DRY_RUN" -eq 1 ]; then
-    log "DRY-RUN: would poll http://${HEALTH_HOST}:${port}${HEALTH_PATH} for providers>0 (timeout ${PROVIDERS_TIMEOUT}s)"
+    log "DRY-RUN: would poll http://${HEALTH_HOST}:${port}${CAPACITY_PATH} for routable capacity>0 (timeout ${PROVIDERS_TIMEOUT}s)"
     return 0
   fi
-  log "Waiting for NEW color $color (port $port) to report providers>0 (timeout ${PROVIDERS_TIMEOUT}s)..."
+  log "Waiting for $color (port $port) to report routable capacity>0 via $CAPACITY_PATH (timeout ${PROVIDERS_TIMEOUT}s)..."
   local now deadline body count
   now="$(date +%s)"
   deadline=$(( now + PROVIDERS_TIMEOUT ))
   while [ "$(date +%s)" -lt "$deadline" ]; do
-    body="$("$CURL_BIN" -fsS --max-time 5 "http://${HEALTH_HOST}:${port}${HEALTH_PATH}" 2>/dev/null || true)"
-    count="$(printf '%s' "$body" | sed -n 's/.*"providers"[[:space:]]*:[[:space:]]*\([0-9][0-9]*\).*/\1/p' | head -n1)"
+    body="$($CURL_BIN -fsS --max-time 5 "http://${HEALTH_HOST}:${port}${CAPACITY_PATH}" 2>/dev/null || true)"
+    count="$(printf '%s' "$body" | capacity_model_count)"
     if [ -n "$count" ] && [ "$count" -gt 0 ]; then
-      log "$color now has $count provider(s) attached."
+      log "$color now has $count routable capacity entr(ies)."
       return 0
     fi
-    log "  $color providers=${count:-unknown}; waiting for reconnects..."
+    log "  $color routable_capacity=${count:-0}; waiting for trusted/routable providers..."
     sleep 2
   done
-  warn "$color did not report providers>0 within ${PROVIDERS_TIMEOUT}s; providers may still be reconnecting (heartbeat timeout)."
+  warn "$color did not report routable capacity>0 within ${PROVIDERS_TIMEOUT}s; providers may still be reconnecting/attesting."
   return 1
 }
 
@@ -609,7 +622,7 @@ do_rollback() {
     log "DRY-RUN: STEP A — would re-enable $target_color: POST $DRAIN_PATH {\"draining\":false} (undrain) + POST $GOING_AWAY_PATH {\"cancel\":true} (clear going-away latch) to ${HEALTH_HOST}:${target_port}."
     log "DRY-RUN: STEP B — would flip_upstream $CADDYFILE $cur_port $target_port, then reload Caddy (auto-revert to $cur_color if reload fails)."
     log "DRY-RUN: STEP C — would POST $GOING_AWAY_PATH to the now-abandoned $cur_color ($cur_port) so its providers reconnect and land on $target_color."
-    log "DRY-RUN: STEP D — would poll $target_color ($target_port) /health for providers>0 (timeout ${PROVIDERS_TIMEOUT}s)."
+    log "DRY-RUN: STEP D — would poll $target_color ($target_port) $CAPACITY_PATH for routable capacity>0 (timeout ${PROVIDERS_TIMEOUT}s)."
     log "DRY-RUN: would leave $cur_color running (idle, providers drained off) for inspection; stop it manually with '$SYSTEMCTL_BIN stop darkbloom-coordinator@${cur_color}'."
     return 0
   fi
@@ -667,11 +680,20 @@ do_rollback() {
   log "Pushing providers off the abandoned $cur_color back onto $target_color..."
   signal_going_away "$cur_color" "$cur_port"
 
-  # STEP D — confirm capacity actually returned to $target_color (reconnects landed).
-  # Rollback has already restored routing; a provider wait timeout must not undo
-  # that recovery path, so tolerate it with a warning.
+  # STEP D — confirm routable capacity actually returned to $target_color. If it
+  # does not, restore routing to the previously-live $cur_color rather than
+  # declaring rollback success on a provider-empty target.
   if ! wait_for_providers "$target_color" "$target_port"; then
-    warn "Rollback routing is already restored to $target_color; continuing despite provider wait timeout. Monitor capacity and provider reconnects."
+    warn "Rollback target $target_color did not regain routable capacity; restoring Caddy back to $cur_color."
+    undrain_color "$cur_color" "$cur_port"
+    clear_going_away "$cur_color" "$cur_port"
+    flip_upstream "$CADDYFILE" "$target_port" "$cur_port" || die "rollback recovery failed: could not flip Caddy back to $cur_color ($cur_port); manual intervention required"
+    if ! reload_caddy; then
+      die "rollback recovery failed: Caddy reload back to $cur_color ($cur_port) failed; manual intervention required"
+    fi
+    signal_going_away "$target_color" "$target_port"
+    wait_for_providers "$cur_color" "$cur_port" || warn "Previously-live $cur_color did not confirm routable capacity after rollback recovery; monitor capacity immediately."
+    die "rollback aborted: providers did not return to $target_color; Caddy restored to $cur_color"
   fi
 
   log "ROLLBACK complete: Caddy -> $target_color ($target_port); providers pushed back to it."
@@ -694,7 +716,7 @@ Options:
   --rollback         Roll back to the other (still-running) color: re-enable it
                      (undrain + clear its going-away latch), flip Caddy back +
                      reload, then push providers back onto it and wait for
-                     providers>0.
+                     routable capacity>0.
   --force            Forward: continue drain/stop even if providers do not land or
                      drain times out. Rollback: flip even if target health fails
                      (DANGEROUS — may route traffic to a dead port).
@@ -703,9 +725,9 @@ Options:
   -h, --help         Show this help.
 
 Environment overrides: CADDYFILE, BLUE_PORT(8080), GREEN_PORT(8081), HEALTH_HOST,
-HEALTH_TIMEOUT, DRAIN_TIMEOUT, PROVIDERS_TIMEOUT(60), GOING_AWAY_PATH, CADDY_BIN,
-SYSTEMCTL_BIN, CURL_BIN, DINF_DEPLOY_ENV_TMPL(/etc/d-inference/deploy-%s.env),
-DINF_ENV_FILE(/etc/d-inference/env).
+HEALTH_TIMEOUT, DRAIN_TIMEOUT, PROVIDERS_TIMEOUT(60), GOING_AWAY_PATH,
+CAPACITY_PATH(/v1/models/capacity), CADDY_BIN, SYSTEMCTL_BIN, CURL_BIN,
+DINF_DEPLOY_ENV_TMPL(/etc/d-inference/deploy-%s.env), DINF_ENV_FILE(/etc/d-inference/env).
 USAGE
 }
 
@@ -828,17 +850,25 @@ main() {
   #    consumers with zero providers during the drain window (429s).
   signal_going_away "$active_color" "$active_port"
 
-  # 6. Wait until the NEW color actually has providers attached (reconnects landed).
-  #    If this times out, do NOT drain/stop the old color unless --force is set:
-  #    old providers have not proven they landed on the new color yet.
+  # 6. Wait until the NEW color actually has routable capacity (reconnects landed
+  #    and providers are trusted/routable). If this times out, do NOT drain/stop
+  #    the old color unless --force is set: old providers have not proven they
+  #    landed on the new color yet.
   if ! wait_for_providers "$idle_color" "$idle_port"; then
     if [ "$FORCE" -eq 1 ]; then
-      warn "Providers did not land on $idle_color within ${PROVIDERS_TIMEOUT}s, but --force was given; proceeding to drain/stop $active_color despite capacity risk."
+      warn "Routable capacity did not land on $idle_color within ${PROVIDERS_TIMEOUT}s, but --force was given; proceeding to drain/stop $active_color despite capacity risk."
     else
-      err "NOT draining or stopping $active_color: $idle_color did not report providers>0 within ${PROVIDERS_TIMEOUT}s."
-      err "Caddy is already -> $idle_color; the old color stays RUNNING so providers/in-flight work are not disrupted."
-      err "Investigate provider reconnects, run '$0 --rollback' before stopping $active_color if needed, or re-run with --force to continue despite capacity risk."
-      die "deploy aborted: providers did not land on new color (cutover done, $active_color left running)"
+      err "NOT draining or stopping $active_color: $idle_color did not report routable capacity>0 within ${PROVIDERS_TIMEOUT}s."
+      err "Restoring Caddy back to $active_color so production traffic returns to the known-capacity color."
+      undrain_color "$active_color" "$active_port"
+      clear_going_away "$active_color" "$active_port"
+      flip_upstream "$CADDYFILE" "$idle_port" "$active_port" || die "provider handoff failed and Caddy restore flip back to $active_color failed; manual intervention required"
+      if ! reload_caddy; then
+        die "provider handoff failed and Caddy reload back to $active_color failed; manual intervention required"
+      fi
+      signal_going_away "$idle_color" "$idle_port"
+      wait_for_providers "$active_color" "$active_port" || warn "$active_color did not confirm routable capacity after restore; monitor capacity immediately."
+      die "deploy aborted: providers did not land on new color; Caddy restored to $active_color and $active_color left running"
     fi
   fi
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -27,8 +27,11 @@
 #     flip_upstream(); see deploy/gcp/prod/deploy_test.sh.
 #   * sourcing this file (e.g. from the test) defines the functions but NEVER
 #     runs main — see the BASH_SOURCE guard at the bottom.
-#   * NO secrets are read or written here; coordinator secrets stay in
-#     /etc/d-inference/env (Secret Manager -> tmpfs -> --env-file).
+#   * the ONLY secret touched here is EIGENINFERENCE_ADMIN_KEY: it is sourced
+#     from /etc/d-inference/env (Secret Manager -> tmpfs -> --env-file) at drain
+#     time to authenticate POST /v1/admin/drain. It is never printed or written,
+#     and is NOT read in --dry-run. All other coordinator secrets stay in that
+#     file and are never touched here.
 #
 # Cross-phase contracts (separate PRs; referenced, not implemented here):
 #   Phase 1 : GET /readyz  +  POST /v1/admin/drain
@@ -55,11 +58,16 @@ CADDY_BIN="${CADDY_BIN:-caddy}"
 SYSTEMCTL_BIN="${SYSTEMCTL_BIN:-systemctl}"
 CURL_BIN="${CURL_BIN:-curl}"
 DINF_DEPLOY_ENV="${DINF_DEPLOY_ENV:-/etc/d-inference/deploy.env}"
+# Secrets env file (Secret Manager -> tmpfs). Holds EIGENINFERENCE_ADMIN_KEY,
+# sourced at drain time to authenticate POST /v1/admin/drain. Distinct from the
+# non-secret DINF_DEPLOY_ENV image-pin file above. Overridable for tests.
+DINF_ENV_FILE="${DINF_ENV_FILE:-/etc/d-inference/env}"
 
 # Runtime flags (main overrides from CLI args).
 DRY_RUN="${DRY_RUN:-0}"
 ROLLBACK=0
 ASSUME_YES=0
+FORCE=0
 IMAGE_REF=""
 
 # ---------------------------------------------------------------------------
@@ -274,6 +282,25 @@ wait_healthy() {
   return 1
 }
 
+# load_admin_env — source the secrets env file so EIGENINFERENCE_ADMIN_KEY is
+# available for the authenticated drain request. `set -a` exports each assignment
+# for the duration of the source; values are NEVER printed. Called only at real
+# drain time (after the --dry-run early return) so the plan stays secret-free.
+# No-op + warning if the file is absent/unreadable (caller still warns on empty
+# key and continues).
+load_admin_env() {
+  if [ -r "$DINF_ENV_FILE" ]; then
+    # Runtime secrets file (Secret Manager -> tmpfs); not present at lint time, so
+    # its source path cannot be followed by shellcheck.
+    set -a
+    # shellcheck source=/dev/null
+    . "$DINF_ENV_FILE"
+    set +a
+  else
+    warn "secrets env file not readable at $DINF_ENV_FILE; admin key unavailable for drain auth"
+  fi
+}
+
 # drain_color <color> <port> — POST /v1/admin/drain then poll /readyz inflight==0.
 drain_color() {
   local color="$1" port="$2"
@@ -281,6 +308,12 @@ drain_color() {
   if [ "$DRY_RUN" -eq 1 ]; then
     log "DRY-RUN: would POST $DRAIN_PATH to $color:$port and poll inflight==0 (timeout ${DRAIN_TIMEOUT}s)"
     return 0
+  fi
+  # Pull EIGENINFERENCE_ADMIN_KEY from the secrets env file (only now, never in
+  # --dry-run) so the drain request below is actually authenticated.
+  load_admin_env
+  if [ -z "${EIGENINFERENCE_ADMIN_KEY:-}" ]; then
+    warn "EIGENINFERENCE_ADMIN_KEY is empty (env file $DINF_ENV_FILE missing or unset); drain will likely be rejected — continuing to poll readiness."
   fi
   # Phase 1 contract: admin-authenticated drain endpoint.
   if ! "$CURL_BIN" -fsS -X POST \
@@ -319,8 +352,25 @@ do_rollback() {
   log "ROLLBACK: Caddy currently -> $cur_color ($cur_port); reverting to $target_color ($target_port)."
   warn "Rollback only restores routing. The $target_color container must still be RUNNING (valid only before it was stopped)."
   if [ "$DRY_RUN" -eq 1 ]; then
+    log "DRY-RUN: would health-check $target_color at http://${HEALTH_HOST}:${target_port}${HEALTH_PATH} before flipping."
     log "DRY-RUN: would flip_upstream $CADDYFILE $cur_port $target_port, then reload Caddy."
     return 0
+  fi
+  # Never flip onto a dead port (connection refused -> 502s): probe the target's
+  # liveness BEFORE flipping. Single-shot http_code (not the up-to-${HEALTH_TIMEOUT}s
+  # wait_healthy poll) so a dead target is refused fast. /health is liveness only:
+  # a drained-but-running old color stays rollback-able even if /readyz is not 200.
+  local target_health
+  target_health="$(http_code "http://${HEALTH_HOST}:${target_port}${HEALTH_PATH}")"
+  if [ "$target_health" = "200" ]; then
+    log "Rollback target $target_color (port $target_port) is alive (/health=200)."
+  elif [ "$FORCE" -eq 1 ]; then
+    warn "!!! Rollback target $target_color (port $target_port) is NOT healthy (/health=$target_health); proceeding anyway because --force was given — traffic may hit a dead port (502s) !!!"
+  else
+    err "Rollback target $target_color (port $target_port) is NOT healthy (/health=$target_health)."
+    err "Refusing to flip Caddy onto a dead/unhealthy port (would cause 502s)."
+    err "Start it first (e.g. '$SYSTEMCTL_BIN start darkbloom-coordinator@${target_color}'), or re-run with --force to flip anyway."
+    return 1
   fi
   confirm "Flip Caddy upstream $cur_port -> $target_port and reload?" || { log "Rollback aborted."; return 1; }
   flip_upstream "$CADDYFILE" "$cur_port" "$target_port" || die "flip_upstream failed (rc $?)"
@@ -342,12 +392,15 @@ Options:
   --image <ref>      Pin this container image for the idle color before starting.
   --caddyfile <path> Caddyfile to read/flip (default: /etc/caddy/Caddyfile).
   --rollback         Flip Caddy back to the other (still-running) color + reload.
+  --force            With --rollback: flip even if the target color fails its
+                     health check (DANGEROUS — may route traffic to a dead port).
   --dry-run          Print the plan; change nothing.
   -y, --yes          Assume "yes" to all confirmation prompts (non-interactive).
   -h, --help         Show this help.
 
 Environment overrides: CADDYFILE, BLUE_PORT(8080), GREEN_PORT(8081), HEALTH_HOST,
-HEALTH_TIMEOUT, DRAIN_TIMEOUT, CADDY_BIN, SYSTEMCTL_BIN, CURL_BIN, DINF_DEPLOY_ENV.
+HEALTH_TIMEOUT, DRAIN_TIMEOUT, CADDY_BIN, SYSTEMCTL_BIN, CURL_BIN, DINF_DEPLOY_ENV,
+DINF_ENV_FILE(/etc/d-inference/env).
 USAGE
 }
 
@@ -357,12 +410,14 @@ main() {
   DRY_RUN=0
   ROLLBACK=0
   ASSUME_YES=0
+  FORCE=0
   IMAGE_REF=""
 
   while [ "$#" -gt 0 ]; do
     case "$1" in
       --dry-run) DRY_RUN=1 ;;
       --rollback) ROLLBACK=1 ;;
+      --force) FORCE=1 ;;
       -y|--yes) ASSUME_YES=1 ;;
       --image) [ "$#" -ge 2 ] || { err "--image requires a value"; return 2; }; IMAGE_REF="$2"; shift ;;
       --image=*) IMAGE_REF="${1#*=}" ;;
@@ -402,9 +457,12 @@ main() {
     pin_image "$IMAGE_REF"
   fi
 
-  # 2. Start the idle color.
+  # 2. Start the idle color. Check the start rc and fail fast: a failed unit start
+  #    would otherwise only surface after wait_healthy times out (up to ${HEALTH_TIMEOUT}s).
   confirm "Start idle color '$idle_color'?" || die "aborted before starting idle color"
-  run_cmd "$SYSTEMCTL_BIN" start "darkbloom-coordinator@${idle_color}"
+  if ! run_cmd "$SYSTEMCTL_BIN" start "darkbloom-coordinator@${idle_color}"; then
+    die "failed to start idle color '$idle_color' ($SYSTEMCTL_BIN start darkbloom-coordinator@${idle_color} exited non-zero); Caddy untouched ($active_color still live). Inspect: $SYSTEMCTL_BIN status darkbloom-coordinator@${idle_color}"
+  fi
 
   # 3. Wait for idle health + readiness.
   if ! wait_healthy "$idle_color" "$idle_port"; then

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,41 +1,52 @@
 #!/usr/bin/env bash
 # deploy.sh — DAR-327 Phase 2: true blue-green coordinator deploy orchestrator.
 #
-# Runs ON the GCE coordinator box. Performs a zero-downtime color swap:
+# Runs ON the GCE coordinator box. Performs a zero-downtime color swap. Providers
+# are moved to the new color BEFORE the old color is drained/stopped, so the new
+# color never serves consumers with zero providers (which would 429):
 #
 #   1. detect the active color from the on-box Caddyfile upstream port
-#   2. (optional) pin the new image for the idle color
-#   3. start the IDLE color           (systemctl start darkbloom-coordinator@<idle>)
+#   2. (optional) pin the new image for the idle color (rolled back if the deploy
+#      is aborted before cutover; kept once the cutover is accepted)
+#   3. restart the IDLE color         (systemctl restart darkbloom-coordinator@<idle>)
+#      — restart, NOT start, so a stale idle container re-execs with the new image
 #   4. wait for idle /health AND /readyz  (DAR-327 Phase 1 endpoints)
 #   5. flip the Caddy upstream old->new + graceful `caddy reload`  (cutover)
-#   6. drain the OLD color            (POST /v1/admin/drain, Phase 1) until inflight==0
-#   7. stop the OLD color             (systemctl stop darkbloom-coordinator@<old>)
+#   6. POST /v1/admin/going-away to the OLD color (DAR-327 Phase 3, PR #396) so its
+#      providers reconnect and — Caddy already flipped — land on the NEW color
+#   7. wait until the NEW color reports providers>0 (the reconnects landed)
+#   8. drain the OLD color            (POST /v1/admin/drain, Phase 1) until inflight==0
+#   9. stop the OLD color             (systemctl stop darkbloom-coordinator@<old>)
 #
-# Stopping the old color triggers the coordinator's `going_away` provider
-# broadcast (DAR-327 Phase 3, separate PR) so providers reconnect to the new
-# color instantly instead of waiting for a heartbeat timeout. This script only
-# performs the graceful stop; the broadcast itself ships in Phase 3.
+# Steps 6-7 explicitly hand providers to the new color via the Phase 3
+# going-away endpoint; the drain (8) and stop (9) then retire the old color with
+# no capacity gap. If the drain does not complete the old color is NOT stopped
+# (it would cut in-flight requests) unless --force is given.
 #
 # ROLLBACK (valid any time AFTER the flip and BEFORE the old color is stopped):
 #   ./deploy.sh --rollback
-# flips the Caddy upstream back to the still-running previous color and reloads.
+# flips the Caddy upstream back to the still-running previous color and reloads,
+# restoring the on-disk Caddyfile if the reload itself fails.
 #
 # SAFETY:
-#   * --dry-run prints the full plan and mutates NOTHING.
+#   * --dry-run prints the full plan (new ordering) and mutates NOTHING.
 #   * destructive steps require interactive confirmation (skip with -y/--yes).
 #   * the Caddy port flip is the self-contained, unit-tested function
 #     flip_upstream(); see deploy/gcp/prod/deploy_test.sh.
 #   * sourcing this file (e.g. from the test) defines the functions but NEVER
 #     runs main — see the BASH_SOURCE guard at the bottom.
-#   * the ONLY secret touched here is EIGENINFERENCE_ADMIN_KEY: it is sourced
-#     from /etc/d-inference/env (Secret Manager -> tmpfs -> --env-file) at drain
-#     time to authenticate POST /v1/admin/drain. It is never printed or written,
-#     and is NOT read in --dry-run. All other coordinator secrets stay in that
-#     file and are never touched here.
+#   * the ONLY secret touched here is EIGENINFERENCE_ADMIN_KEY: it is PARSED (a
+#     single grep'd line — never `source`d/`.`d) from /etc/d-inference/env
+#     (Secret Manager -> tmpfs -> --env-file) at cutover time to authenticate the
+#     admin going-away/drain POSTs. That file is docker --env-file syntax, NOT
+#     shell: sourcing it would execute secret values (e.g. the 12-word MNEMONIC,
+#     '&'/URL chars) as shell commands AS ROOT, so we never source it. The key is
+#     never printed or written, and is NOT read in --dry-run. All other
+#     coordinator secrets stay in that file and are never touched here.
 #
 # Cross-phase contracts (separate PRs; referenced, not implemented here):
 #   Phase 1 : GET /readyz  +  POST /v1/admin/drain
-#   Phase 3 : graceful coordinator stop broadcasts `going_away`
+#   Phase 3 : POST /v1/admin/going-away (admin-gated; returns 200 {"sent":N})
 
 # NOTE: shell options are set inside main() so that sourcing this file for tests
 # does not mutate the caller's shell. The functions below are written to not
@@ -52,15 +63,21 @@ HEALTH_HOST="${HEALTH_HOST:-127.0.0.1}"
 HEALTH_PATH="${HEALTH_PATH:-/health}"
 READYZ_PATH="${READYZ_PATH:-/readyz}"
 DRAIN_PATH="${DRAIN_PATH:-/v1/admin/drain}"
+# Phase 3 (PR #396) endpoint: tells the OLD color's providers to reconnect so
+# they re-land on the already-flipped NEW color. Admin-gated; returns {"sent":N}.
+GOING_AWAY_PATH="${GOING_AWAY_PATH:-/v1/admin/going-away}"
 HEALTH_TIMEOUT="${HEALTH_TIMEOUT:-120}"
 DRAIN_TIMEOUT="${DRAIN_TIMEOUT:-120}"
+# How long to wait for the NEW color to report providers>0 after going-away.
+PROVIDERS_TIMEOUT="${PROVIDERS_TIMEOUT:-60}"
 CADDY_BIN="${CADDY_BIN:-caddy}"
 SYSTEMCTL_BIN="${SYSTEMCTL_BIN:-systemctl}"
 CURL_BIN="${CURL_BIN:-curl}"
 DINF_DEPLOY_ENV="${DINF_DEPLOY_ENV:-/etc/d-inference/deploy.env}"
 # Secrets env file (Secret Manager -> tmpfs). Holds EIGENINFERENCE_ADMIN_KEY,
-# sourced at drain time to authenticate POST /v1/admin/drain. Distinct from the
-# non-secret DINF_DEPLOY_ENV image-pin file above. Overridable for tests.
+# whose single line is PARSED (never sourced; see load_admin_env) at cutover time
+# to authenticate the admin going-away/drain POSTs. Distinct from the non-secret
+# DINF_DEPLOY_ENV image-pin file above. Overridable for tests.
 DINF_ENV_FILE="${DINF_ENV_FILE:-/etc/d-inference/env}"
 
 # Runtime flags (main overrides from CLI args).
@@ -69,6 +86,13 @@ ROLLBACK=0
 ASSUME_YES=0
 FORCE=0
 IMAGE_REF=""
+
+# Image-pin rollback state (set by pin_image, consumed by restore/accept). The
+# pin in DINF_DEPLOY_ENV is shared by BOTH colors, so an aborted deploy must
+# restore it or the still-live OLD color would pull the unaccepted image on its
+# next restart. DINF_DEPLOY_ENV_BAK="" means "no pin to roll back".
+DINF_DEPLOY_ENV_BAK=""
+DINF_DEPLOY_ENV_EXISTED=0
 
 # ---------------------------------------------------------------------------
 # Logging
@@ -237,16 +261,31 @@ reload_caddy() {
   "$CADDY_BIN" reload --config "$CADDYFILE" --adapter caddyfile
 }
 
+# pin_image <ref> — write DINF_IMAGE=<ref> to the (shared) DINF_DEPLOY_ENV pin
+# file so the idle color re-execs with the new image. The previous pin state is
+# snapshotted first so restore_image_pin can undo it if the deploy is aborted
+# BEFORE the cutover is accepted (the OLD color shares this file and would
+# otherwise pull the unaccepted image on its next systemd restart). The pin is
+# made permanent by accept_image_pin once the cutover succeeds.
 pin_image() {
   local ref="$1"
   log "Pinning idle-color image: DINF_IMAGE=$ref -> $DINF_DEPLOY_ENV"
   if [ "$DRY_RUN" -eq 1 ]; then
-    log "DRY-RUN: would write DINF_IMAGE=$ref to $DINF_DEPLOY_ENV (read by darkbloom-run.sh via EnvironmentFile)"
+    log "DRY-RUN: would snapshot $DINF_DEPLOY_ENV, then write DINF_IMAGE=$ref (read by darkbloom-run.sh via EnvironmentFile); the pin is rolled back if the deploy aborts before cutover, kept once cutover is accepted"
     return 0
   fi
   local dir tmp
   dir="$(dirname "$DINF_DEPLOY_ENV")"
   mkdir -p "$dir"
+  # Snapshot the current pin so an aborted/declined/unhealthy deploy can restore
+  # it. An empty backup with DINF_DEPLOY_ENV_EXISTED=0 marks "file did not exist".
+  DINF_DEPLOY_ENV_BAK="$(mktemp)" || die "mktemp failed"
+  if [ -f "$DINF_DEPLOY_ENV" ]; then
+    DINF_DEPLOY_ENV_EXISTED=1
+    cat "$DINF_DEPLOY_ENV" > "$DINF_DEPLOY_ENV_BAK"
+  else
+    DINF_DEPLOY_ENV_EXISTED=0
+  fi
   tmp="$(mktemp)" || die "mktemp failed"
   if [ -f "$DINF_DEPLOY_ENV" ]; then
     grep -v '^DINF_IMAGE=' "$DINF_DEPLOY_ENV" > "$tmp" || true
@@ -255,6 +294,32 @@ pin_image() {
   cat "$tmp" > "$DINF_DEPLOY_ENV"
   rm -f "$tmp"
   chmod 644 "$DINF_DEPLOY_ENV"
+}
+
+# restore_image_pin — undo a pin_image() write. Called on any exit BEFORE the
+# cutover is accepted (via the EXIT trap in main). No-op if nothing was pinned or
+# the pin was already accepted (accept_image_pin clears the backup).
+restore_image_pin() {
+  [ -n "${DINF_DEPLOY_ENV_BAK:-}" ] || return 0
+  [ "$DRY_RUN" -eq 1 ] && return 0
+  if [ "${DINF_DEPLOY_ENV_EXISTED:-0}" -eq 1 ]; then
+    warn "Deploy aborted before cutover: restoring previous image pin in $DINF_DEPLOY_ENV."
+    cat "$DINF_DEPLOY_ENV_BAK" > "$DINF_DEPLOY_ENV" 2>/dev/null || warn "failed to restore $DINF_DEPLOY_ENV"
+    chmod 644 "$DINF_DEPLOY_ENV" 2>/dev/null || true
+  else
+    warn "Deploy aborted before cutover: removing image pin $DINF_DEPLOY_ENV (created this run)."
+    rm -f "$DINF_DEPLOY_ENV" 2>/dev/null || warn "failed to remove $DINF_DEPLOY_ENV"
+  fi
+  rm -f "$DINF_DEPLOY_ENV_BAK"
+  DINF_DEPLOY_ENV_BAK=""
+}
+
+# accept_image_pin — keep the pin permanently (cutover succeeded) and disarm the
+# restore_image_pin rollback by dropping the backup.
+accept_image_pin() {
+  [ -n "${DINF_DEPLOY_ENV_BAK:-}" ] || return 0
+  rm -f "$DINF_DEPLOY_ENV_BAK"
+  DINF_DEPLOY_ENV_BAK=""
 }
 
 # wait_healthy <color> <port> — poll /health AND /readyz until both 200 or timeout.
@@ -282,26 +347,36 @@ wait_healthy() {
   return 1
 }
 
-# load_admin_env — source the secrets env file so EIGENINFERENCE_ADMIN_KEY is
-# available for the authenticated drain request. `set -a` exports each assignment
-# for the duration of the source; values are NEVER printed. Called only at real
-# drain time (after the --dry-run early return) so the plan stays secret-free.
-# No-op + warning if the file is absent/unreadable (caller still warns on empty
-# key and continues).
+# load_admin_env — read ONLY the EIGENINFERENCE_ADMIN_KEY line from the secrets
+# env file into the global of the same name, for the authenticated going-away +
+# drain requests.
+#
+# SECURITY: that file is docker --env-file syntax (KEY=VALUE), NOT shell. Sourcing
+# it (`.`/`source`) would execute values — the 12-word MNEMONIC, '&', URL/`$()`
+# chars — as shell commands AS ROOT (secret leak / RCE). So we never source it; we
+# grep the single line and strip optional surrounding quotes. No eval, no source.
+# The value is never printed. Called only at real cutover time (after the
+# --dry-run early returns) so the plan stays secret-free. No-op + warning if the
+# file is absent/unreadable (caller still warns on empty key and continues).
 load_admin_env() {
   if [ -r "$DINF_ENV_FILE" ]; then
-    # Runtime secrets file (Secret Manager -> tmpfs); not present at lint time, so
-    # its source path cannot be followed by shellcheck.
-    set -a
-    # shellcheck source=/dev/null
-    . "$DINF_ENV_FILE"
-    set +a
+    # First match wins; cut -f2- keeps '=' chars in the value; 2>/dev/null + the
+    # lack of `set -e` make a no-match safely yield an empty key.
+    EIGENINFERENCE_ADMIN_KEY="$(grep -E '^EIGENINFERENCE_ADMIN_KEY=' "$DINF_ENV_FILE" 2>/dev/null | head -n1 | cut -d= -f2-)"
+    # Strip one pair of surrounding quotes if the value is quoted in the env file.
+    case "$EIGENINFERENCE_ADMIN_KEY" in
+      '"'*'"') EIGENINFERENCE_ADMIN_KEY="${EIGENINFERENCE_ADMIN_KEY#\"}"; EIGENINFERENCE_ADMIN_KEY="${EIGENINFERENCE_ADMIN_KEY%\"}" ;;
+      "'"*"'") EIGENINFERENCE_ADMIN_KEY="${EIGENINFERENCE_ADMIN_KEY#\'}"; EIGENINFERENCE_ADMIN_KEY="${EIGENINFERENCE_ADMIN_KEY%\'}" ;;
+    esac
   else
-    warn "secrets env file not readable at $DINF_ENV_FILE; admin key unavailable for drain auth"
+    warn "secrets env file not readable at $DINF_ENV_FILE; admin key unavailable for going-away/drain auth"
   fi
 }
 
 # drain_color <color> <port> — POST /v1/admin/drain then poll /readyz inflight==0.
+# Returns 0 once inflight==0, NON-ZERO on timeout so the caller does NOT stop a
+# color that still has in-flight requests (stopping would cut them at the SIGTERM
+# deadline). EIGENINFERENCE_ADMIN_KEY is loaded once by the caller (load_admin_env).
 drain_color() {
   local color="$1" port="$2"
   log "Draining $color (port $port): POST $DRAIN_PATH, then poll $READYZ_PATH inflight==0..."
@@ -309,13 +384,8 @@ drain_color() {
     log "DRY-RUN: would POST $DRAIN_PATH to $color:$port and poll inflight==0 (timeout ${DRAIN_TIMEOUT}s)"
     return 0
   fi
-  # Pull EIGENINFERENCE_ADMIN_KEY from the secrets env file (only now, never in
-  # --dry-run) so the drain request below is actually authenticated.
-  load_admin_env
-  if [ -z "${EIGENINFERENCE_ADMIN_KEY:-}" ]; then
-    warn "EIGENINFERENCE_ADMIN_KEY is empty (env file $DINF_ENV_FILE missing or unset); drain will likely be rejected — continuing to poll readiness."
-  fi
-  # Phase 1 contract: admin-authenticated drain endpoint.
+  # Phase 1 contract: admin-authenticated drain endpoint. The bearer key was
+  # parsed (not sourced) from the env file by the caller's load_admin_env.
   if ! "$CURL_BIN" -fsS -X POST \
         -H "Authorization: Bearer ${EIGENINFERENCE_ADMIN_KEY:-}" \
         --max-time 10 \
@@ -336,7 +406,63 @@ drain_color() {
     log "  $color inflight=${inflight:-unknown}; waiting..."
     sleep 3
   done
-  warn "$color did not reach inflight==0 within ${DRAIN_TIMEOUT}s; the graceful container stop (docker stop -t) will finish remaining requests."
+  err "$color did not reach inflight==0 within ${DRAIN_TIMEOUT}s."
+  return 1
+}
+
+# signal_going_away <color> <port> — POST /v1/admin/going-away to the OLD color so
+# its providers reconnect and (Caddy already flipped) re-land on the NEW color.
+# Phase 3 (PR #396) contract: admin-gated, returns 200 {"sent":N}. Best-effort:
+# warns and continues if it fails (providers still reconnect within the heartbeat
+# timeout, and the drain + graceful stop still finish in-flight work).
+# EIGENINFERENCE_ADMIN_KEY is loaded once by the caller (load_admin_env).
+signal_going_away() {
+  local color="$1" port="$2"
+  log "Going-away to OLD color $color (port $port): POST $GOING_AWAY_PATH (providers reconnect -> new color)..."
+  if [ "$DRY_RUN" -eq 1 ]; then
+    log "DRY-RUN: would POST $GOING_AWAY_PATH to $color:$port (admin-gated; expect 200 {\"sent\":N})"
+    return 0
+  fi
+  local body sent
+  body="$("$CURL_BIN" -fsS -X POST \
+        -H "Authorization: Bearer ${EIGENINFERENCE_ADMIN_KEY:-}" \
+        --max-time 10 \
+        "http://${HEALTH_HOST}:${port}${GOING_AWAY_PATH}" 2>/dev/null || true)"
+  # Contract response: {"sent":N}.
+  sent="$(printf '%s' "$body" | sed -n 's/.*"sent"[[:space:]]*:[[:space:]]*\([0-9][0-9]*\).*/\1/p' | head -n1)"
+  if [ -n "$sent" ]; then
+    log "going-away accepted by $color (sent=$sent; those providers will reconnect to the new color)."
+  else
+    warn "going-away to $color did not return a parseable {\"sent\":N} (continuing; providers will still reconnect within the heartbeat timeout)."
+  fi
+}
+
+# wait_for_providers <color> <port> — after going-away, poll the NEW color's
+# /health until its provider count is > 0 (reconnects have landed). /health shape
+# (coordinator api/types HealthResponse): {"status":"ok","providers":N,...}.
+# WARNS on timeout (does NOT abort): Caddy is already flipped and the old color is
+# still up, so a human can investigate without a hard failure.
+wait_for_providers() {
+  local color="$1" port="$2"
+  if [ "$DRY_RUN" -eq 1 ]; then
+    log "DRY-RUN: would poll http://${HEALTH_HOST}:${port}${HEALTH_PATH} for providers>0 (timeout ${PROVIDERS_TIMEOUT}s)"
+    return 0
+  fi
+  log "Waiting for NEW color $color (port $port) to report providers>0 (timeout ${PROVIDERS_TIMEOUT}s)..."
+  local now deadline body count
+  now="$(date +%s)"
+  deadline=$(( now + PROVIDERS_TIMEOUT ))
+  while [ "$(date +%s)" -lt "$deadline" ]; do
+    body="$("$CURL_BIN" -fsS --max-time 5 "http://${HEALTH_HOST}:${port}${HEALTH_PATH}" 2>/dev/null || true)"
+    count="$(printf '%s' "$body" | sed -n 's/.*"providers"[[:space:]]*:[[:space:]]*\([0-9][0-9]*\).*/\1/p' | head -n1)"
+    if [ -n "$count" ] && [ "$count" -gt 0 ]; then
+      log "$color now has $count provider(s) attached."
+      return 0
+    fi
+    log "  $color providers=${count:-unknown}; waiting for reconnects..."
+    sleep 2
+  done
+  warn "$color did not report providers>0 within ${PROVIDERS_TIMEOUT}s; providers may still be reconnecting (heartbeat timeout). Proceeding to drain the old color — monitor capacity."
   return 0
 }
 
@@ -374,7 +500,16 @@ do_rollback() {
   fi
   confirm "Flip Caddy upstream $cur_port -> $target_port and reload?" || { log "Rollback aborted."; return 1; }
   flip_upstream "$CADDYFILE" "$cur_port" "$target_port" || die "flip_upstream failed (rc $?)"
-  reload_caddy || die "caddy reload failed after rollback flip"
+  # Mirror the cutover path: if the reload fails after flipping the on-disk
+  # Caddyfile, flip it BACK so on-disk state matches live Caddy (still -> $cur_color).
+  # Otherwise a later run would read the stale on-disk port and flip/stop the
+  # wrong color.
+  if ! reload_caddy; then
+    err "caddy reload failed after rollback flip; restoring Caddyfile to $cur_color ($cur_port) so on-disk state matches live Caddy."
+    flip_upstream "$CADDYFILE" "$target_port" "$cur_port" || err "restore flip ALSO failed — manual intervention required on $CADDYFILE"
+    reload_caddy || true
+    die "rollback aborted: caddy reload failed (Caddyfile restored to $cur_color)"
+  fi
   log "ROLLBACK complete: Caddy -> $target_color ($target_port)."
 }
 
@@ -399,8 +534,8 @@ Options:
   -h, --help         Show this help.
 
 Environment overrides: CADDYFILE, BLUE_PORT(8080), GREEN_PORT(8081), HEALTH_HOST,
-HEALTH_TIMEOUT, DRAIN_TIMEOUT, CADDY_BIN, SYSTEMCTL_BIN, CURL_BIN, DINF_DEPLOY_ENV,
-DINF_ENV_FILE(/etc/d-inference/env).
+HEALTH_TIMEOUT, DRAIN_TIMEOUT, PROVIDERS_TIMEOUT(60), GOING_AWAY_PATH, CADDY_BIN,
+SYSTEMCTL_BIN, CURL_BIN, DINF_DEPLOY_ENV, DINF_ENV_FILE(/etc/d-inference/env).
 USAGE
 }
 
@@ -452,16 +587,24 @@ main() {
   [ "$DRY_RUN" -eq 1 ] && log "   MODE           : DRY-RUN (no changes will be made)"
   log "=============================================================="
 
-  # 1. Pin image for the idle color (optional).
+  # Roll the image pin back automatically on ANY exit before the cutover is
+  # accepted (declined confirm, failed start, unhealthy idle, failed flip/reload).
+  # accept_image_pin() disarms this once the cutover succeeds. No-op without --image.
+  trap 'restore_image_pin' EXIT
+
+  # 1. Pin image for the idle color (optional). Snapshotted so it is rolled back
+  #    if the deploy aborts before cutover (the OLD color shares this pin file).
   if [ -n "$IMAGE_REF" ]; then
     pin_image "$IMAGE_REF"
   fi
 
-  # 2. Start the idle color. Check the start rc and fail fast: a failed unit start
-  #    would otherwise only surface after wait_healthy times out (up to ${HEALTH_TIMEOUT}s).
-  confirm "Start idle color '$idle_color'?" || die "aborted before starting idle color"
-  if ! run_cmd "$SYSTEMCTL_BIN" start "darkbloom-coordinator@${idle_color}"; then
-    die "failed to start idle color '$idle_color' ($SYSTEMCTL_BIN start darkbloom-coordinator@${idle_color} exited non-zero); Caddy untouched ($active_color still live). Inspect: $SYSTEMCTL_BIN status darkbloom-coordinator@${idle_color}"
+  # 2. Restart the idle color. RESTART (not start) so a stale already-running idle
+  #    container re-execs darkbloom-run.sh and picks up the newly pinned image.
+  #    Check the rc and fail fast: a failed unit (re)start would otherwise only
+  #    surface after wait_healthy times out (up to ${HEALTH_TIMEOUT}s).
+  confirm "Restart idle color '$idle_color' (re-exec with the pinned image)?" || die "aborted before starting idle color"
+  if ! run_cmd "$SYSTEMCTL_BIN" restart "darkbloom-coordinator@${idle_color}"; then
+    die "failed to (re)start idle color '$idle_color' ($SYSTEMCTL_BIN restart darkbloom-coordinator@${idle_color} exited non-zero); Caddy untouched ($active_color still live). Inspect: $SYSTEMCTL_BIN status darkbloom-coordinator@${idle_color}"
   fi
 
   # 3. Wait for idle health + readiness.
@@ -488,19 +631,56 @@ main() {
       die "deploy aborted: caddy reload failed (attempted rollback to $active_color)"
     fi
   fi
+  # Cutover accepted: the NEW color is live. Keep the image pin permanently and
+  # disarm the EXIT-trap rollback.
+  accept_image_pin
   log "Cutover complete: Caddy -> $idle_color ($idle_port). $active_color still running for drain."
   log "Rollback window OPEN: run '$0 --rollback' to revert to $active_color (valid until it is stopped)."
 
-  # 5. Drain the old color.
-  drain_color "$active_color" "$active_port"
+  # Parse the admin key ONCE (real run only; never in --dry-run so the plan stays
+  # secret-free) for the authenticated going-away + drain POSTs below.
+  if [ "$DRY_RUN" -ne 1 ]; then
+    load_admin_env
+    if [ -z "${EIGENINFERENCE_ADMIN_KEY:-}" ]; then
+      warn "EIGENINFERENCE_ADMIN_KEY is empty ($DINF_ENV_FILE missing or unset); going-away and drain POSTs will be unauthenticated and likely rejected — continuing."
+    fi
+  fi
 
-  # 6. Stop the old color (closes rollback window; triggers Phase 3 going_away).
-  if ! confirm "Stop old color '$active_color'? (closes rollback window; triggers Phase 3 going_away broadcast)"; then
+  # 5. Move providers to the NEW color BEFORE draining the old one: POST
+  #    going-away to the OLD color so its providers reconnect and land on the
+  #    (already-flipped) new color. Without this the new color would serve
+  #    consumers with zero providers during the drain window (429s).
+  signal_going_away "$active_color" "$active_port"
+
+  # 6. Wait until the NEW color actually has providers attached (reconnects landed).
+  wait_for_providers "$idle_color" "$idle_port"
+
+  # 7. Drain the old color. If it does NOT drain in time, do NOT stop it (stopping
+  #    would cut in-flight requests at the container SIGTERM deadline): abort with
+  #    a nonzero exit (Caddy already -> new color, old color left running) unless
+  #    --force is given.
+  if ! drain_color "$active_color" "$active_port"; then
+    if [ "$FORCE" -eq 1 ]; then
+      warn "Drain of $active_color did not complete, but --force was given; proceeding to stop it (in-flight requests may be cut at the container SIGTERM deadline)."
+    else
+      err "NOT stopping $active_color: its drain did not reach inflight==0 within ${DRAIN_TIMEOUT}s."
+      err "Caddy is already -> $idle_color; the old color stays RUNNING (rollback still possible)."
+      err "Investigate, then stop manually ('$SYSTEMCTL_BIN stop darkbloom-coordinator@${active_color}'), or re-run with --force to stop despite in-flight requests."
+      die "deploy aborted: old color drain incomplete (cutover done, $active_color left running)"
+    fi
+  fi
+
+  # 8. Stop the old color (closes the rollback window). Fail if the stop fails:
+  #    a still-running old color stays attached to providers and must not linger
+  #    silently as if the deploy succeeded.
+  if ! confirm "Stop old color '$active_color'? (closes rollback window)"; then
     warn "Old color $active_color left RUNNING. Stop later with: $SYSTEMCTL_BIN stop darkbloom-coordinator@${active_color}"
     log "Deploy finished (old color intentionally not stopped)."
     return 0
   fi
-  run_cmd "$SYSTEMCTL_BIN" stop "darkbloom-coordinator@${active_color}"
+  if ! run_cmd "$SYSTEMCTL_BIN" stop "darkbloom-coordinator@${active_color}"; then
+    die "failed to stop old color '$active_color' ($SYSTEMCTL_BIN stop darkbloom-coordinator@${active_color} exited non-zero); it may still be attached to providers — investigate: $SYSTEMCTL_BIN status darkbloom-coordinator@${active_color}"
+  fi
   log "Old color $active_color stopped. Deploy complete: $idle_color is now the sole live coordinator."
 }
 

--- a/deploy/gcp/prod/Caddyfile
+++ b/deploy/gcp/prod/Caddyfile
@@ -1,0 +1,102 @@
+# Prod host Caddy (darkbloom-mainnet GCE box) — TLS termination + reverse proxy.
+#
+# coord-staging.darkbloom.dev : auto-HTTPS via Let's Encrypt HTTP-01 (validation host).
+# api.darkbloom.dev           : served with a DNS-01-issued LE cert (static `tls`),
+#   pre-provisioned BEFORE the DNS flip so cutover has zero TLS cold-start. AFTER the
+#   flip (once api.darkbloom.dev resolves to this box) the `tls` line can be removed to
+#   let Caddy auto-renew via HTTP-01.
+#
+# Shared routing lives in the (coordinator_routes) snippet. The bare
+# `reverse_proxy 127.0.0.1:8080` is the coordinator upstream (blue-green swap target).
+#
+# BLUE-GREEN (DAR-327 Phase 2):
+#   There is exactly ONE coordinator upstream line in this file (inside the
+#   snippet). blue = 127.0.0.1:8080, green = 127.0.0.1:8081. deploy.sh flips that
+#   single line old<->new and `caddy reload`s gracefully; because every site
+#   below imports the same snippet, the flip atomically moves ALL traffic — the
+#   public sites AND the internal MDM-webhook listener — to the new color.
+#   Do NOT add a second `reverse_proxy 127.0.0.1:<port>` line; that would break
+#   the single-swap-point invariant deploy.sh / flip_upstream rely on. The
+#   step-ca (:9000) and MicroMDM (:9002) upstreams use the https:// scheme and a
+#   different port, so the port flip never touches them.
+
+(coordinator_routes) {
+	# step-ca ACME proxy (device-attest-01 challenges)
+	handle /acme/* {
+		reverse_proxy https://127.0.0.1:9000 {
+			transport http {
+				tls_insecure_skip_verify
+			}
+			header_up Host {host}
+		}
+	}
+
+	# MicroMDM — SCEP enrollment + MDM checkin/connect
+	handle /scep {
+		reverse_proxy https://127.0.0.1:9002 {
+			transport http {
+				tls_insecure_skip_verify
+			}
+		}
+	}
+	handle /mdm/* {
+		reverse_proxy https://127.0.0.1:9002 {
+			transport http {
+				tls_insecure_skip_verify
+			}
+		}
+	}
+
+	# Everything else -> coordinator (HTTP + WebSocket). Blue-green swap target.
+	# THE single upstream line flipped by deploy.sh / flip_upstream (8080<->8081).
+	reverse_proxy 127.0.0.1:8080 {
+		health_uri /health
+		health_interval 30s
+		health_timeout 5s
+		health_status 200
+	}
+
+	request_body {
+		max_size 25MB
+	}
+
+	header {
+		X-Content-Type-Options "nosniff"
+		X-Frame-Options "DENY"
+		Referrer-Policy "strict-origin-when-cross-origin"
+		-Server
+	}
+
+	log {
+		output stdout
+		format console
+		level INFO
+	}
+}
+
+coord-staging.darkbloom.dev {
+	import coordinator_routes
+}
+
+api.darkbloom.dev {
+	# DNS-01-issued Let's Encrypt cert (pre-provisioned before the DNS flip).
+	tls /etc/caddy/certs/api.darkbloom.dev.crt /etc/caddy/certs/api.darkbloom.dev.key
+	import coordinator_routes
+}
+
+# Internal-only stable webhook endpoint (DAR-327 Phase 2 — MDM coupling fix).
+#
+# MicroMDM runs in the long-lived platform container and must POST MDM command
+# callbacks to the ACTIVE coordinator color, but its -command-webhook-url is set
+# once at startup and cannot follow a color flip on its own. Binding to the
+# loopback address 127.0.0.1 keeps this listener host-local (no firewall change,
+# never publicly reachable). It imports the SAME (coordinator_routes) snippet, so
+# /v1/mdm/webhook falls through to the one swap-target upstream and is rerouted
+# to the active color by the exact same single-line flip — no extra swap point.
+#
+# The platform points MicroMDM here via
+#   EIGENINFERENCE_MDM_WEBHOOK_URL=http://127.0.0.1:8090/v1/mdm/webhook
+# (the shared ?token= secret is appended by start-platform.sh, not stored here).
+http://127.0.0.1:8090 {
+	import coordinator_routes
+}

--- a/deploy/gcp/prod/Caddyfile
+++ b/deploy/gcp/prod/Caddyfile
@@ -47,6 +47,20 @@
 		}
 	}
 
+	# Static downloads (install script + provider bundles), served from the host
+	# /var/www/html — the SAME route the combined coordinator/Caddyfile serves.
+	# The coordinator has NO /dl/* handler, so without this the release fallback URL
+	# /dl/eigeninference-bundle-macos-arm64.tar.gz (api/version, consumer.go) would
+	# fall through to the coordinator and 404, breaking scripts/install.sh.
+	# ASSUMPTION: /var/www/html exists on the box and holds the published bundle
+	# (same precondition as the combined coordinator/Caddyfile setup). This is a
+	# static handler, not a reverse_proxy, so it does NOT add a second upstream
+	# swap point (deploy.sh / flip_upstream remain single-swap).
+	handle /dl/* {
+		root * /var/www/html
+		file_server
+	}
+
 	# Everything else -> coordinator (HTTP + WebSocket). Blue-green swap target.
 	# THE single upstream line flipped by deploy.sh / flip_upstream (8080<->8081).
 	reverse_proxy 127.0.0.1:8080 {

--- a/deploy/gcp/prod/Caddyfile
+++ b/deploy/gcp/prod/Caddyfile
@@ -18,7 +18,8 @@
 #   Do NOT add a second `reverse_proxy 127.0.0.1:<port>` line; that would break
 #   the single-swap-point invariant deploy.sh / flip_upstream rely on. The
 #   step-ca (:9000) and MicroMDM (:9002) upstreams use the https:// scheme and a
-#   different port, so the port flip never touches them.
+#   different port, so the port flip never touches them. Static host-served routes
+#   (/dl/* and /enroll.mobileconfig) are handlers, not swap targets.
 
 (coordinator_routes) {
 	# step-ca ACME proxy (device-attest-01 challenges)
@@ -47,16 +48,22 @@
 		}
 	}
 
-	# Static downloads (install script + provider bundles), served from the host
-	# /var/www/html — the SAME route the combined coordinator/Caddyfile serves.
+	# Static downloads + enrollment profile, served from the host /var/www/html —
+	# the SAME routes the combined coordinator/Caddyfile serves.
 	# The coordinator has NO /dl/* handler, so without this the release fallback URL
 	# /dl/eigeninference-bundle-macos-arm64.tar.gz (api/version, consumer.go) would
-	# fall through to the coordinator and 404, breaking scripts/install.sh.
+	# fall through to the coordinator and 404, breaking scripts/install.sh. The ACME
+	# enrollment helper also publishes /enroll.mobileconfig directly under the host
+	# web root.
 	# ASSUMPTION: /var/www/html exists on the box and holds the published bundle
-	# (same precondition as the combined coordinator/Caddyfile setup). This is a
-	# static handler, not a reverse_proxy, so it does NOT add a second upstream
-	# swap point (deploy.sh / flip_upstream remain single-swap).
+	# and enrollment profile (same precondition as the combined coordinator/Caddyfile
+	# setup). These are static handlers, not reverse_proxy, so they do NOT add a
+	# second upstream swap point (deploy.sh / flip_upstream remain single-swap).
 	handle /dl/* {
+		root * /var/www/html
+		file_server
+	}
+	handle /enroll.mobileconfig {
 		root * /var/www/html
 		file_server
 	}

--- a/deploy/gcp/prod/darkbloom-coordinator@.service
+++ b/deploy/gcp/prod/darkbloom-coordinator@.service
@@ -42,14 +42,14 @@ Restart=always
 RestartSec=5
 # Stop-timeout hierarchy must EXCEED the coordinator's drain budget so systemd never
 # SIGKILLs mid-drain: the coordinator drains up to EIGENINFERENCE_DRAIN_GRACE (Phase 1
-# default 120s) + a 15s hard http.Server.Shutdown backstop = ~135s. TimeoutStopSec=180
-# (> docker's `-t 150` below) lets the whole ExecStop run; the docker `-t 150` is the
-# in-container SIGTERM->SIGKILL ceiling (150 > 120s drain grace + 15s hard shutdown).
+# default 10m) + a 15s hard http.Server.Shutdown backstop = ~615s. TimeoutStopSec=660
+# (> docker's `-t 630` below) lets the whole ExecStop run; the docker `-t 630` is the
+# in-container SIGTERM->SIGKILL ceiling (630 > 10m drain grace + 15s hard shutdown).
 # The deploy.sh happy path drains each color to inflight==0 BEFORE `systemctl stop`, so
 # a pre-drained color still exits in well under a second (WaitForInflightZero returns
 # immediately at 0); the long ceiling is only a backstop for a color stopped with
 # genuinely stuck in-flight work.
-TimeoutStopSec=180
+TimeoutStopSec=660
 # Optional non-secret per-color deploy config (e.g. DINF_IMAGE pin written by
 # deploy.sh). The leading '-' makes it optional: the unit starts even if the file
 # is absent. Keep the platform unit on /etc/d-inference/deploy.env; these pins are
@@ -58,7 +58,7 @@ EnvironmentFile=-/etc/d-inference/deploy-%i.env
 ExecStartPre=-/usr/bin/docker stop darkbloom-coordinator-%i
 ExecStartPre=-/usr/bin/docker rm darkbloom-coordinator-%i
 ExecStart=/usr/local/bin/darkbloom-run.sh coordinator %i
-ExecStop=/usr/bin/docker stop -t 150 darkbloom-coordinator-%i
+ExecStop=/usr/bin/docker stop -t 630 darkbloom-coordinator-%i
 
 [Install]
 WantedBy=multi-user.target

--- a/deploy/gcp/prod/darkbloom-coordinator@.service
+++ b/deploy/gcp/prod/darkbloom-coordinator@.service
@@ -29,12 +29,15 @@
 [Unit]
 Description=Darkbloom coordinator (%i color, blue-green)
 After=docker.service network-online.target darkbloom-platform.service cloud-sql-proxy.service
-# Hard deps: without Docker or the Cloud SQL proxy the coordinator cannot run.
+# Hard deps: without Docker, the platform services (step-ca/MicroMDM), or the
+# Cloud SQL proxy the coordinator cannot run safely.
 # When EIGENINFERENCE_DATABASE_URL is set (prod), the DB is reached via the proxy
 # on 127.0.0.1:5432, so requiring cloud-sql-proxy.service avoids a crash-loop on a
 # cold/failed proxy (mirrors deploy/gcp/vm-startup.sh's d-inference-coordinator).
-Requires=docker.service cloud-sql-proxy.service
-Wants=network-online.target darkbloom-platform.service
+# Requiring darkbloom-platform.service prevents cutting over to a color while the
+# trust/enrollment plane behind /acme, /scep, and /mdm is down.
+Requires=docker.service darkbloom-platform.service cloud-sql-proxy.service
+Wants=network-online.target
 
 [Service]
 Type=simple

--- a/deploy/gcp/prod/darkbloom-coordinator@.service
+++ b/deploy/gcp/prod/darkbloom-coordinator@.service
@@ -1,0 +1,49 @@
+# darkbloom-coordinator@.service (DAR-327 Phase 2)
+#
+# TEMPLATED, swappable "coordinator-only" half of the blue-green split.
+# %i is the color: blue or green.
+#   darkbloom-coordinator@blue  -> coordinator-only container on EIGENINFERENCE_PORT=8080
+#   darkbloom-coordinator@green -> coordinator-only container on EIGENINFERENCE_PORT=8081
+# Both colors share the same /mnt/disks/userdata volume and the same step-ca/
+# MicroMDM state owned by darkbloom-platform.service. The color->port mapping
+# and per-color container name live in darkbloom-run.sh (so this template needs
+# no arithmetic and no per-color drop-in files).
+#
+# deploy.sh starts the IDLE color, waits for /health + /readyz, flips Caddy,
+# drains the OLD color, then `systemctl stop darkbloom-coordinator@<old>`.
+# NOTE: stopping a color triggers the coordinator's `going_away` provider
+# broadcast (DAR-327 Phase 3, separate PR) so providers reconnect to the new
+# color instantly instead of waiting for a heartbeat timeout.
+#
+# Install (on the GCE box, as root):
+#   install -m 0755 deploy/gcp/prod/darkbloom-run.sh /usr/local/bin/darkbloom-run.sh
+#   install -m 0644 deploy/gcp/prod/darkbloom-coordinator@.service \
+#       /etc/systemd/system/darkbloom-coordinator@.service
+#   systemctl daemon-reload
+#   systemctl enable --now darkbloom-coordinator@blue   # initial/active color
+#
+# Secrets are NOT inlined: config + secrets come from /etc/d-inference/env via
+# --env-file (inside darkbloom-run.sh). The per-color EIGENINFERENCE_PORT is
+# passed as an explicit `-e` AFTER --env-file so it overrides the file default.
+
+[Unit]
+Description=Darkbloom coordinator (%i color, blue-green)
+After=docker.service network-online.target darkbloom-platform.service cloud-sql-proxy.service
+Requires=docker.service
+Wants=network-online.target darkbloom-platform.service
+
+[Service]
+Type=simple
+Restart=always
+RestartSec=5
+TimeoutStopSec=45
+# Optional non-secret deploy config (e.g. DINF_IMAGE pin written by deploy.sh).
+# The leading '-' makes it optional: the unit starts even if the file is absent.
+EnvironmentFile=-/etc/d-inference/deploy.env
+ExecStartPre=-/usr/bin/docker stop darkbloom-coordinator-%i
+ExecStartPre=-/usr/bin/docker rm darkbloom-coordinator-%i
+ExecStart=/usr/local/bin/darkbloom-run.sh coordinator %i
+ExecStop=/usr/bin/docker stop -t 30 darkbloom-coordinator-%i
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/gcp/prod/darkbloom-coordinator@.service
+++ b/deploy/gcp/prod/darkbloom-coordinator@.service
@@ -50,9 +50,11 @@ RestartSec=5
 # immediately at 0); the long ceiling is only a backstop for a color stopped with
 # genuinely stuck in-flight work.
 TimeoutStopSec=180
-# Optional non-secret deploy config (e.g. DINF_IMAGE pin written by deploy.sh).
-# The leading '-' makes it optional: the unit starts even if the file is absent.
-EnvironmentFile=-/etc/d-inference/deploy.env
+# Optional non-secret per-color deploy config (e.g. DINF_IMAGE pin written by
+# deploy.sh). The leading '-' makes it optional: the unit starts even if the file
+# is absent. Keep the platform unit on /etc/d-inference/deploy.env; these pins are
+# only for swappable coordinator colors.
+EnvironmentFile=-/etc/d-inference/deploy-%i.env
 ExecStartPre=-/usr/bin/docker stop darkbloom-coordinator-%i
 ExecStartPre=-/usr/bin/docker rm darkbloom-coordinator-%i
 ExecStart=/usr/local/bin/darkbloom-run.sh coordinator %i

--- a/deploy/gcp/prod/darkbloom-coordinator@.service
+++ b/deploy/gcp/prod/darkbloom-coordinator@.service
@@ -29,7 +29,11 @@
 [Unit]
 Description=Darkbloom coordinator (%i color, blue-green)
 After=docker.service network-online.target darkbloom-platform.service cloud-sql-proxy.service
-Requires=docker.service
+# Hard deps: without Docker or the Cloud SQL proxy the coordinator cannot run.
+# When EIGENINFERENCE_DATABASE_URL is set (prod), the DB is reached via the proxy
+# on 127.0.0.1:5432, so requiring cloud-sql-proxy.service avoids a crash-loop on a
+# cold/failed proxy (mirrors deploy/gcp/vm-startup.sh's d-inference-coordinator).
+Requires=docker.service cloud-sql-proxy.service
 Wants=network-online.target darkbloom-platform.service
 
 [Service]

--- a/deploy/gcp/prod/darkbloom-coordinator@.service
+++ b/deploy/gcp/prod/darkbloom-coordinator@.service
@@ -40,14 +40,23 @@ Wants=network-online.target darkbloom-platform.service
 Type=simple
 Restart=always
 RestartSec=5
-TimeoutStopSec=45
+# Stop-timeout hierarchy must EXCEED the coordinator's drain budget so systemd never
+# SIGKILLs mid-drain: the coordinator drains up to EIGENINFERENCE_DRAIN_GRACE (Phase 1
+# default 120s) + a 15s hard http.Server.Shutdown backstop = ~135s. TimeoutStopSec=180
+# (> docker's `-t 150` below) lets the whole ExecStop run; the docker `-t 150` is the
+# in-container SIGTERM->SIGKILL ceiling (150 > 120s drain grace + 15s hard shutdown).
+# The deploy.sh happy path drains each color to inflight==0 BEFORE `systemctl stop`, so
+# a pre-drained color still exits in well under a second (WaitForInflightZero returns
+# immediately at 0); the long ceiling is only a backstop for a color stopped with
+# genuinely stuck in-flight work.
+TimeoutStopSec=180
 # Optional non-secret deploy config (e.g. DINF_IMAGE pin written by deploy.sh).
 # The leading '-' makes it optional: the unit starts even if the file is absent.
 EnvironmentFile=-/etc/d-inference/deploy.env
 ExecStartPre=-/usr/bin/docker stop darkbloom-coordinator-%i
 ExecStartPre=-/usr/bin/docker rm darkbloom-coordinator-%i
 ExecStart=/usr/local/bin/darkbloom-run.sh coordinator %i
-ExecStop=/usr/bin/docker stop -t 30 darkbloom-coordinator-%i
+ExecStop=/usr/bin/docker stop -t 150 darkbloom-coordinator-%i
 
 [Install]
 WantedBy=multi-user.target

--- a/deploy/gcp/prod/darkbloom-platform.service
+++ b/deploy/gcp/prod/darkbloom-platform.service
@@ -1,0 +1,43 @@
+# darkbloom-platform.service (DAR-327 Phase 2)
+#
+# Long-lived "platform" half of the blue-green split: step-ca (:9000) +
+# MicroMDM (:9002) + ownership of the shared /mnt/disks/userdata volume and
+# its first-boot init. This unit is NOT part of the color swap — it stays up
+# across coordinator flips so CA/MDM state and provider trust survive a deploy.
+#
+# Install (on the GCE box, as root):
+#   install -m 0755 deploy/gcp/prod/darkbloom-run.sh /usr/local/bin/darkbloom-run.sh
+#   install -m 0644 deploy/gcp/prod/darkbloom-platform.service \
+#       /etc/systemd/system/darkbloom-platform.service
+#   systemctl daemon-reload && systemctl enable --now darkbloom-platform.service
+#
+# Secrets are NOT inlined: app config + secrets are read at runtime from
+# /etc/d-inference/env (written from GCP Secret Manager by refresh-env.sh) and
+# passed to the container via --env-file inside darkbloom-run.sh.
+
+[Unit]
+Description=Darkbloom platform (step-ca + MicroMDM + shared /data volume)
+After=docker.service network-online.target cloud-sql-proxy.service
+Requires=docker.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+Restart=always
+RestartSec=5
+# step-ca/MicroMDM get time to drain; the container traps SIGTERM (see
+# start-platform.sh) and docker stop -t below bounds the wait.
+TimeoutStopSec=45
+# Point MicroMDM's command webhook at the stable loopback Caddy listener so it
+# follows the active coordinator color through the single upstream swap.
+Environment=EIGENINFERENCE_MDM_WEBHOOK_URL=http://127.0.0.1:8090/v1/mdm/webhook
+# Optional non-secret deploy config (e.g. DINF_IMAGE pin written by deploy.sh).
+# The leading '-' makes it optional: the unit starts even if the file is absent.
+EnvironmentFile=-/etc/d-inference/deploy.env
+ExecStartPre=-/usr/bin/docker stop darkbloom-platform
+ExecStartPre=-/usr/bin/docker rm darkbloom-platform
+ExecStart=/usr/local/bin/darkbloom-run.sh platform
+ExecStop=/usr/bin/docker stop -t 30 darkbloom-platform
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/gcp/prod/darkbloom-run.sh
+++ b/deploy/gcp/prod/darkbloom-run.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+# darkbloom-run.sh (DAR-327 Phase 2) — blue-green container launcher for the
+# GCE coordinator box. Invoked by the systemd units:
+#   darkbloom-platform.service       -> darkbloom-run.sh platform
+#   darkbloom-coordinator@<color>    -> darkbloom-run.sh coordinator <blue|green>
+#
+# Mirrors deploy/gcp/vm-startup.sh's d-inference-run.sh: resolves the pinned
+# image (explicit DINF_IMAGE, else the DINF_IMAGE_TAG instance-metadata tag,
+# else :latest), authenticates to Artifact Registry using the VM service-account
+# token from the metadata server, pulls, then launches the requested container.
+#
+# Secret-safety: nothing secret is baked in here. Registry auth uses the
+# metadata server (no stored key); app config + secrets are read by the
+# container from --env-file /etc/d-inference/env (written by refresh-env.sh from
+# GCP Secret Manager). The per-color EIGENINFERENCE_PORT is passed as an
+# explicit `-e` AFTER --env-file so it overrides the file's default.
+set -euo pipefail
+
+usage() {
+  echo "usage: darkbloom-run.sh platform" >&2
+  echo "       darkbloom-run.sh coordinator <blue|green>" >&2
+  exit 2
+}
+
+ROLE="${1:-}"
+[ -n "$ROLE" ] || usage
+
+META="http://metadata.google.internal/computeMetadata/v1/instance"
+
+# ---- Resolve image ref ----
+# DINF_IMAGE (full ref) wins; otherwise build from repo + metadata tag.
+IMAGE_REPO="${DINF_IMAGE_REPO:-us-central1-docker.pkg.dev/sepolia-ai/coordinator/coordinator}"
+if [ -n "${DINF_IMAGE:-}" ]; then
+  IMAGE="$DINF_IMAGE"
+else
+  TAG="$(curl -fsSL -H 'Metadata-Flavor: Google' "$META/attributes/DINF_IMAGE_TAG" 2>/dev/null || echo latest)"
+  IMAGE="${IMAGE_REPO}:${TAG}"
+fi
+REGISTRY_HOST="${IMAGE%%/*}"
+
+DATA_MOUNT="${DINF_DATA_MOUNT:-/mnt/disks/userdata}"
+ENV_FILE="${DINF_ENV_FILE:-/etc/d-inference/env}"
+DOCKER="${DOCKER:-/usr/bin/docker}"
+
+echo "darkbloom-run: role=$ROLE image=$IMAGE"
+
+# ---- Registry auth via metadata service-account token ----
+# Skip when DINF_SKIP_REGISTRY_LOGIN=1 (image already present, or public).
+if [ "${DINF_SKIP_REGISTRY_LOGIN:-0}" != "1" ]; then
+  TOKEN="$(curl -fsSL -H 'Metadata-Flavor: Google' \
+    "$META/service-accounts/default/token" \
+    | python3 -c 'import sys,json;print(json.load(sys.stdin)["access_token"])')"
+  printf '%s' "$TOKEN" | "$DOCKER" login -u oauth2accesstoken --password-stdin "$REGISTRY_HOST"
+  unset TOKEN
+fi
+
+"$DOCKER" pull "$IMAGE"
+
+case "$ROLE" in
+  platform)
+    NAME="${DINF_PLATFORM_NAME:-darkbloom-platform}"
+    # MicroMDM webhook -> stable loopback Caddy listener (active color follows
+    # the single upstream swap). Override via EIGENINFERENCE_MDM_WEBHOOK_URL.
+    WEBHOOK_URL="${EIGENINFERENCE_MDM_WEBHOOK_URL:-http://127.0.0.1:8090/v1/mdm/webhook}"
+    exec "$DOCKER" run --rm --name "$NAME" \
+      --network host \
+      --env-file "$ENV_FILE" \
+      -e "EIGENINFERENCE_MDM_WEBHOOK_URL=${WEBHOOK_URL}" \
+      --mount "type=bind,source=${DATA_MOUNT},target=${DATA_MOUNT}" \
+      "$IMAGE" start-platform.sh
+    ;;
+  coordinator)
+    COLOR="${2:-}"
+    case "$COLOR" in
+      blue)  PORT="${BLUE_PORT:-8080}" ;;
+      green) PORT="${GREEN_PORT:-8081}" ;;
+      *) echo "darkbloom-run: unknown color '${COLOR}' (want blue|green)" >&2; usage ;;
+    esac
+    exec "$DOCKER" run --rm --name "darkbloom-coordinator-${COLOR}" \
+      --network host \
+      --env-file "$ENV_FILE" \
+      -e "EIGENINFERENCE_PORT=${PORT}" \
+      --mount "type=bind,source=${DATA_MOUNT},target=${DATA_MOUNT}" \
+      "$IMAGE" start-coordinator.sh
+    ;;
+  *)
+    echo "darkbloom-run: unknown role '${ROLE}'" >&2
+    usage
+    ;;
+esac

--- a/deploy/gcp/prod/deploy_test.sh
+++ b/deploy/gcp/prod/deploy_test.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# deploy_test.sh — infra-free unit tests for deploy.sh's pure functions
+# (DAR-327 Phase 2). No Docker, systemd, Caddy, gcloud or network required.
+#
+# Sources deploy.sh (which, thanks to its BASH_SOURCE guard, defines functions
+# without running main), writes a sample Caddyfile, and exercises flip_upstream
+# and current_upstream_port: the upstream flips, is reversible and idempotent,
+# and NO other line (step-ca :9000, MicroMDM :9002, internal :8090 listener) is
+# mutated.
+#
+# Run:  ./deploy/gcp/prod/deploy_test.sh        (or: bash deploy/gcp/prod/deploy_test.sh)
+# Exit: 0 if all assertions pass, 1 otherwise.
+
+# Intentionally NOT `set -e`: flip_upstream returns 3 (no-op) by design and the
+# idempotency test asserts on that non-zero return.
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEPLOY_SH="${DEPLOY_SH:-${SCRIPT_DIR}/../../../deploy.sh}"
+
+if [ ! -f "$DEPLOY_SH" ]; then
+  echo "deploy_test: cannot find deploy.sh at $DEPLOY_SH" >&2
+  exit 1
+fi
+
+# shellcheck source=/dev/null
+source "$DEPLOY_SH"
+
+PASS=0
+FAIL=0
+pass() { printf 'ok     - %s\n' "$1"; PASS=$((PASS + 1)); }
+fail() { printf 'NOT OK - %s\n' "$1"; [ -n "${2:-}" ] && printf '         %s\n' "$2"; FAIL=$((FAIL + 1)); }
+
+assert_eq() { # <desc> <expected> <actual>
+  if [ "$2" = "$3" ]; then pass "$1"; else fail "$1" "expected [$2] got [$3]"; fi
+}
+assert_rc() { # <desc> <expected_rc> <actual_rc>
+  if [ "$2" -eq "$3" ]; then pass "$1"; else fail "$1" "expected rc $2 got $3"; fi
+}
+assert_contains() { # <desc> <file> <needle>
+  if grep -qF "$3" "$2"; then pass "$1"; else fail "$1" "missing [$3] in $2"; fi
+}
+assert_absent() { # <desc> <file> <needle>
+  if grep -qF "$3" "$2"; then fail "$1" "unexpected [$3] in $2"; else pass "$1"; fi
+}
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+ORIG="$WORK/Caddyfile.orig"
+CF="$WORK/Caddyfile"
+
+# Sample mirrors deploy/gcp/prod/Caddyfile: the snippet contains the step-ca
+# (:9000) and MicroMDM (:9002) https upstreams plus the single coordinator
+# upstream (:8080), imported by two public sites and the internal :8090 listener.
+cat > "$ORIG" <<'CADDY'
+(coordinator_routes) {
+	handle /acme/* {
+		reverse_proxy https://127.0.0.1:9000 {
+			transport http {
+				tls_insecure_skip_verify
+			}
+			header_up Host {host}
+		}
+	}
+	handle /mdm/* {
+		reverse_proxy https://127.0.0.1:9002 {
+			transport http {
+				tls_insecure_skip_verify
+			}
+		}
+	}
+	reverse_proxy 127.0.0.1:8080 {
+		health_uri /health
+		health_interval 30s
+	}
+}
+
+coord-staging.darkbloom.dev {
+	import coordinator_routes
+}
+
+api.darkbloom.dev {
+	tls /etc/caddy/certs/api.darkbloom.dev.crt /etc/caddy/certs/api.darkbloom.dev.key
+	import coordinator_routes
+}
+
+http://127.0.0.1:8090 {
+	import coordinator_routes
+}
+CADDY
+
+cp "$ORIG" "$CF"
+
+echo "# deploy_test: flip_upstream / current_upstream_port"
+
+# ---- detect initial active port ----
+port="$(current_upstream_port "$CF")"; rc=$?
+assert_rc "current_upstream_port returns 0 on a valid file" 0 "$rc"
+assert_eq "current_upstream_port reads 8080 initially" "8080" "$port"
+
+# ---- flip 8080 -> 8081 ----
+flip_upstream "$CF" 8080 8081; rc=$?
+assert_rc "flip_upstream 8080->8081 returns 0" 0 "$rc"
+assert_contains "coordinator upstream now 8081" "$CF" "reverse_proxy 127.0.0.1:8081"
+assert_absent  "old coordinator upstream 8080 gone" "$CF" "reverse_proxy 127.0.0.1:8080"
+assert_eq "current_upstream_port reads 8081 after flip" "8081" "$(current_upstream_port "$CF")"
+
+# ---- only the coordinator line changed (exactly 1 removed + 1 added) ----
+diffout="$(diff "$ORIG" "$CF")"
+removed="$(printf '%s\n' "$diffout" | grep -c '^<')"
+added="$(printf '%s\n' "$diffout" | grep -c '^>')"
+assert_eq "exactly one line removed by flip" "1" "$removed"
+assert_eq "exactly one line added by flip" "1" "$added"
+
+# ---- step-ca / MicroMDM / internal-listener lines untouched ----
+assert_contains "step-ca upstream :9000 untouched" "$CF" "reverse_proxy https://127.0.0.1:9000"
+assert_contains "MicroMDM upstream :9002 untouched" "$CF" "reverse_proxy https://127.0.0.1:9002"
+assert_contains "internal webhook listener :8090 untouched" "$CF" "http://127.0.0.1:8090 {"
+
+# ---- reversible: flip back restores the file byte-for-byte ----
+flip_upstream "$CF" 8081 8080; rc=$?
+assert_rc "flip_upstream 8081->8080 returns 0" 0 "$rc"
+if diff -q "$ORIG" "$CF" >/dev/null; then
+  pass "flip is reversible (file identical to original)"
+else
+  fail "flip is reversible" "$(diff "$ORIG" "$CF")"
+fi
+
+# ---- idempotent: flipping when from-port is absent is a no-op (rc 3) ----
+cp "$ORIG" "$CF"
+flip_upstream "$CF" 8080 8081 >/dev/null; rc=$?   # first: changes
+assert_rc "first flip changes (rc 0)" 0 "$rc"
+before_second="$(cat "$CF")"
+flip_upstream "$CF" 8080 8081 >/dev/null 2>&1; rc=$?   # second: 8080 already gone
+assert_rc "second identical flip is a no-op (rc 3)" 3 "$rc"
+assert_eq "file unchanged after no-op flip" "$before_second" "$(cat "$CF")"
+
+# ---- error handling ----
+flip_upstream "$WORK/does-not-exist" 8080 8081 >/dev/null 2>&1; rc=$?
+assert_rc "flip_upstream on missing file returns 2" 2 "$rc"
+flip_upstream "$CF" >/dev/null 2>&1; rc=$?
+assert_rc "flip_upstream with too few args returns 2" 2 "$rc"
+current_upstream_port "$WORK/does-not-exist" >/dev/null 2>&1; rc=$?
+assert_rc "current_upstream_port on missing file returns 2" 2 "$rc"
+
+# ---- a Caddyfile with no coordinator upstream -> rc 3 ----
+printf 'example.com {\n\trespond "hi"\n}\n' > "$WORK/no-upstream"
+current_upstream_port "$WORK/no-upstream" >/dev/null 2>&1; rc=$?
+assert_rc "current_upstream_port with no upstream returns 3" 3 "$rc"
+
+# ---- color/port helpers ----
+assert_eq "port_for_color blue" "8080" "$(port_for_color blue)"
+assert_eq "port_for_color green" "8081" "$(port_for_color green)"
+assert_eq "color_for_port 8080" "blue" "$(color_for_port 8080)"
+assert_eq "color_for_port 8081" "green" "$(color_for_port 8081)"
+assert_eq "other_color blue" "green" "$(other_color blue)"
+assert_eq "other_color green" "blue" "$(other_color green)"
+
+echo
+echo "# deploy_test: ${PASS} passed, ${FAIL} failed"
+[ "$FAIL" -eq 0 ]

--- a/deploy/gcp/prod/deploy_test.sh
+++ b/deploy/gcp/prod/deploy_test.sh
@@ -11,8 +11,9 @@
 # Also covers two security/safety-critical helpers added in the Phase 2 review:
 #   - load_admin_env: PARSES (never sources) the EIGENINFERENCE_ADMIN_KEY line,
 #     incl. a regression canary proving env-file values are NOT executed.
-#   - pin_image / restore_image_pin / accept_image_pin: the image-pin rollback so
-#     an aborted deploy never leaves the shared pin file on an unaccepted image.
+#   - pin_image / restore_image_pin / accept_image_pin: the per-color image-pin
+#     rollback so an aborted deploy never leaves the idle color on an unaccepted
+#     image.
 #
 # Run:  ./deploy/gcp/prod/deploy_test.sh        (or: bash deploy/gcp/prod/deploy_test.sh)
 # Exit: 0 if all assertions pass, 1 otherwise.
@@ -57,9 +58,9 @@ ORIG="$WORK/Caddyfile.orig"
 CF="$WORK/Caddyfile"
 
 # Sample mirrors deploy/gcp/prod/Caddyfile: the snippet contains the step-ca
-# (:9000) and MicroMDM (:9002) https upstreams, the /dl/* static handler, and the
-# single coordinator upstream (:8080), imported by two public sites and the
-# internal :8090 listener.
+# (:9000) and MicroMDM (:9002) https upstreams, the /dl/* and
+# /enroll.mobileconfig static handlers, and the single coordinator upstream
+# (:8080), imported by two public sites and the internal :8090 listener.
 cat > "$ORIG" <<'CADDY'
 (coordinator_routes) {
 	handle /acme/* {
@@ -78,6 +79,10 @@ cat > "$ORIG" <<'CADDY'
 		}
 	}
 	handle /dl/* {
+		root * /var/www/html
+		file_server
+	}
+	handle /enroll.mobileconfig {
 		root * /var/www/html
 		file_server
 	}
@@ -128,6 +133,7 @@ assert_eq "exactly one line added by flip" "1" "$added"
 assert_contains "step-ca upstream :9000 untouched" "$CF" "reverse_proxy https://127.0.0.1:9000"
 assert_contains "MicroMDM upstream :9002 untouched" "$CF" "reverse_proxy https://127.0.0.1:9002"
 assert_contains "/dl/* static handler untouched by flip" "$CF" "handle /dl/* {"
+assert_contains "/enroll.mobileconfig static handler untouched by flip" "$CF" "handle /enroll.mobileconfig {"
 assert_contains "internal webhook listener :8090 untouched" "$CF" "http://127.0.0.1:8090 {"
 
 # ---- reversible: flip back restores the file byte-for-byte ----
@@ -217,40 +223,78 @@ EIGENINFERENCE_ADMIN_KEY=""; load_admin_env
 assert_eq "load_admin_env yields empty key when absent" "" "${EIGENINFERENCE_ADMIN_KEY:-}"
 
 echo
-echo "# deploy_test: image-pin rollback (pin_image / restore_image_pin / accept_image_pin)"
+echo "# deploy_test: provider wait timeout"
+
+# wait_for_providers must return nonzero on timeout so forward deploy can abort
+# before draining/stopping the old color. Use a zero-second timeout so no network
+# or curl mock is required.
+# shellcheck disable=SC2034  # read by wait_for_providers in sourced deploy.sh
+PROVIDERS_TIMEOUT=0
+wait_for_providers blue 8080 >/dev/null 2>&1; rc=$?
+assert_rc "wait_for_providers returns nonzero on timeout" 1 "$rc"
+# shellcheck disable=SC2034  # read by wait_for_providers in sourced deploy.sh
+DRY_RUN=1
+wait_for_providers blue 8080 >/dev/null 2>&1; rc=$?
+assert_rc "wait_for_providers dry-run returns 0" 0 "$rc"
+
+echo
+echo "# deploy_test: per-color image-pin rollback (pin_image / restore_image_pin / accept_image_pin)"
 
 # shellcheck disable=SC2034  # DRY_RUN read by the dry-run guards in sourced deploy.sh
 DRY_RUN=0
-PINENV="$WORK/deploy.env"
-# shellcheck disable=SC2034  # read by pin_image/restore_image_pin in sourced deploy.sh
-DINF_DEPLOY_ENV="$PINENV"
-# DINF_DEPLOY_ENV_BAK / DINF_DEPLOY_ENV_EXISTED are set by pin_image itself, so the
-# tests below intentionally do NOT pre-seed them.
+PIN_TMPL="$WORK/deploy-%s.env"
+PINBLUE="$WORK/deploy-blue.env"
+PINGREEN="$WORK/deploy-green.env"
+# shellcheck disable=SC2034  # read by deploy_env_for_color/pin_image in sourced deploy.sh
+DINF_DEPLOY_ENV_TMPL="$PIN_TMPL"
+# DINF_DEPLOY_ENV_BAK / DINF_DEPLOY_ENV_EXISTED / DINF_DEPLOY_ENV_PINNED are set by
+# pin_image itself, so the tests below intentionally do NOT pre-seed them.
 
-# (a) pin when the file did NOT exist -> restore removes it entirely.
-rm -f "$PINENV"
-pin_image "repo/coord:abc" >/dev/null 2>&1
-assert_contains "pin_image writes DINF_IMAGE" "$PINENV" "DINF_IMAGE=repo/coord:abc"
+assert_eq "deploy_env_for_color blue" "$PINBLUE" "$(deploy_env_for_color blue)"
+assert_eq "deploy_env_for_color green" "$PINGREEN" "$(deploy_env_for_color green)"
+deploy_env_for_color red >/dev/null 2>&1; rc=$?
+assert_rc "deploy_env_for_color rejects unknown colors" 2 "$rc"
+
+# (a) pin when the color file did NOT exist -> restore removes only that file.
+rm -f "$PINBLUE" "$PINGREEN"
+pin_image blue "repo/coord:abc" >/dev/null 2>&1; rc=$?
+assert_rc "pin_image blue returns 0" 0 "$rc"
+assert_contains "pin_image writes DINF_IMAGE to blue" "$PINBLUE" "DINF_IMAGE=repo/coord:abc"
+if [ ! -f "$PINGREEN" ]; then pass "pin_image blue does not create green pin file"; else fail "pin_image blue should not create green pin file"; fi
 restore_image_pin >/dev/null 2>&1
-if [ ! -f "$PINENV" ]; then pass "restore_image_pin removes a pin file created this run"; else fail "restore_image_pin should remove a newly-created pin file"; fi
+if [ ! -f "$PINBLUE" ]; then pass "restore_image_pin removes a blue pin file created this run"; else fail "restore_image_pin should remove a newly-created blue pin file"; fi
 
 # (b) pin OVER an existing file -> accept keeps it (restore becomes a no-op).
-printf 'OTHER=1\n' > "$PINENV"
-pin_image "repo/coord:def" >/dev/null 2>&1
-assert_contains "pin_image preserves other keys" "$PINENV" "OTHER=1"
-assert_contains "pin_image sets the new image" "$PINENV" "DINF_IMAGE=repo/coord:def"
+printf 'OTHER=1\n' > "$PINGREEN"
+pin_image green "repo/coord:def" >/dev/null 2>&1; rc=$?
+assert_rc "pin_image green returns 0" 0 "$rc"
+assert_contains "pin_image preserves other keys in green" "$PINGREEN" "OTHER=1"
+assert_contains "pin_image sets the new image in green" "$PINGREEN" "DINF_IMAGE=repo/coord:def"
 accept_image_pin
 restore_image_pin >/dev/null 2>&1
-assert_contains "accept_image_pin keeps the pin (restore is a no-op)" "$PINENV" "DINF_IMAGE=repo/coord:def"
+assert_contains "accept_image_pin keeps the green pin (restore is a no-op)" "$PINGREEN" "DINF_IMAGE=repo/coord:def"
 
-# (c) pin OVER an existing pinned file -> restore brings back the original image.
-printf 'DINF_IMAGE=old/img:1\nOTHER=2\n' > "$PINENV"
-pin_image "new/img:2" >/dev/null 2>&1
-assert_contains "pin_image replaces the old image line" "$PINENV" "DINF_IMAGE=new/img:2"
-assert_absent  "pin_image drops the prior image line" "$PINENV" "DINF_IMAGE=old/img:1"
+# (c) pin OVER an existing pinned file -> restore brings back the original image
+# in the exact file pin_image touched, even if the template changes before restore.
+printf 'DINF_IMAGE=old/img:1\nOTHER=2\n' > "$PINBLUE"
+pin_image blue "new/img:2" >/dev/null 2>&1; rc=$?
+assert_rc "pin_image blue over existing pin returns 0" 0 "$rc"
+assert_contains "pin_image replaces the old blue image line" "$PINBLUE" "DINF_IMAGE=new/img:2"
+assert_absent  "pin_image drops the prior blue image line" "$PINBLUE" "DINF_IMAGE=old/img:1"
+# shellcheck disable=SC2034  # restore_image_pin must use DINF_DEPLOY_ENV_PINNED, not this new template
+DINF_DEPLOY_ENV_TMPL="$WORK/other-%s.env"
 restore_image_pin >/dev/null 2>&1
-assert_contains "restore_image_pin restores the prior image pin" "$PINENV" "DINF_IMAGE=old/img:1"
-assert_absent  "restore_image_pin drops the unaccepted image pin" "$PINENV" "DINF_IMAGE=new/img:2"
+assert_contains "restore_image_pin restores the prior blue image pin" "$PINBLUE" "DINF_IMAGE=old/img:1"
+assert_absent  "restore_image_pin drops the unaccepted blue image pin" "$PINBLUE" "DINF_IMAGE=new/img:2"
+if [ ! -e "$WORK/other-blue.env" ]; then pass "restore_image_pin uses the pinned file, not the current template"; else fail "restore_image_pin wrote to the current template instead of pinned file"; fi
+
+# (d) pin_image fails before restart if the per-color env path cannot be written.
+BAD_PARENT="$WORK/not-a-dir"
+printf 'x\n' > "$BAD_PARENT"
+# shellcheck disable=SC2034  # read by deploy_env_for_color/pin_image in sourced deploy.sh
+DINF_DEPLOY_ENV_TMPL="$BAD_PARENT/deploy-%s.env"
+pin_image blue "bad/img:1" >/dev/null 2>&1; rc=$?
+assert_rc "pin_image fails when deploy env directory cannot be created" 1 "$rc"
 
 echo
 echo "# deploy_test: ${PASS} passed, ${FAIL} failed"

--- a/deploy/gcp/prod/deploy_test.sh
+++ b/deploy/gcp/prod/deploy_test.sh
@@ -8,6 +8,12 @@
 # and NO other line (step-ca :9000, MicroMDM :9002, internal :8090 listener) is
 # mutated.
 #
+# Also covers two security/safety-critical helpers added in the Phase 2 review:
+#   - load_admin_env: PARSES (never sources) the EIGENINFERENCE_ADMIN_KEY line,
+#     incl. a regression canary proving env-file values are NOT executed.
+#   - pin_image / restore_image_pin / accept_image_pin: the image-pin rollback so
+#     an aborted deploy never leaves the shared pin file on an unaccepted image.
+#
 # Run:  ./deploy/gcp/prod/deploy_test.sh        (or: bash deploy/gcp/prod/deploy_test.sh)
 # Exit: 0 if all assertions pass, 1 otherwise.
 
@@ -51,8 +57,9 @@ ORIG="$WORK/Caddyfile.orig"
 CF="$WORK/Caddyfile"
 
 # Sample mirrors deploy/gcp/prod/Caddyfile: the snippet contains the step-ca
-# (:9000) and MicroMDM (:9002) https upstreams plus the single coordinator
-# upstream (:8080), imported by two public sites and the internal :8090 listener.
+# (:9000) and MicroMDM (:9002) https upstreams, the /dl/* static handler, and the
+# single coordinator upstream (:8080), imported by two public sites and the
+# internal :8090 listener.
 cat > "$ORIG" <<'CADDY'
 (coordinator_routes) {
 	handle /acme/* {
@@ -69,6 +76,10 @@ cat > "$ORIG" <<'CADDY'
 				tls_insecure_skip_verify
 			}
 		}
+	}
+	handle /dl/* {
+		root * /var/www/html
+		file_server
 	}
 	reverse_proxy 127.0.0.1:8080 {
 		health_uri /health
@@ -113,9 +124,10 @@ added="$(printf '%s\n' "$diffout" | grep -c '^>')"
 assert_eq "exactly one line removed by flip" "1" "$removed"
 assert_eq "exactly one line added by flip" "1" "$added"
 
-# ---- step-ca / MicroMDM / internal-listener lines untouched ----
+# ---- step-ca / MicroMDM / /dl static / internal-listener lines untouched ----
 assert_contains "step-ca upstream :9000 untouched" "$CF" "reverse_proxy https://127.0.0.1:9000"
 assert_contains "MicroMDM upstream :9002 untouched" "$CF" "reverse_proxy https://127.0.0.1:9002"
+assert_contains "/dl/* static handler untouched by flip" "$CF" "handle /dl/* {"
 assert_contains "internal webhook listener :8090 untouched" "$CF" "http://127.0.0.1:8090 {"
 
 # ---- reversible: flip back restores the file byte-for-byte ----
@@ -156,6 +168,89 @@ assert_eq "color_for_port 8080" "blue" "$(color_for_port 8080)"
 assert_eq "color_for_port 8081" "green" "$(color_for_port 8081)"
 assert_eq "other_color blue" "green" "$(other_color blue)"
 assert_eq "other_color green" "blue" "$(other_color green)"
+
+echo
+echo "# deploy_test: load_admin_env (PARSE the admin key — never source the env file)"
+
+# load_admin_env reads ONLY EIGENINFERENCE_ADMIN_KEY from a docker --env-file
+# (KEY=VALUE) file. It must NEVER source/eval it (the file holds secrets like the
+# 12-word MNEMONIC and URLs with shell metacharacters that would run AS ROOT).
+SECENV="$WORK/secrets.env"
+# shellcheck disable=SC2034  # read by load_admin_env() in the sourced deploy.sh
+DINF_ENV_FILE="$SECENV"
+
+printf 'EIGENINFERENCE_ADMIN_KEY=plainkey123\nOTHER=x\n' > "$SECENV"
+EIGENINFERENCE_ADMIN_KEY=""; load_admin_env
+assert_eq "load_admin_env reads a plain key" "plainkey123" "${EIGENINFERENCE_ADMIN_KEY:-}"
+
+printf 'EIGENINFERENCE_ADMIN_KEY=a=b=c\n' > "$SECENV"
+EIGENINFERENCE_ADMIN_KEY=""; load_admin_env
+assert_eq "load_admin_env keeps '=' chars in the value (cut -f2-)" "a=b=c" "${EIGENINFERENCE_ADMIN_KEY:-}"
+
+printf 'EIGENINFERENCE_ADMIN_KEY="quotedkey"\n' > "$SECENV"
+EIGENINFERENCE_ADMIN_KEY=""; load_admin_env
+assert_eq "load_admin_env strips surrounding double quotes" "quotedkey" "${EIGENINFERENCE_ADMIN_KEY:-}"
+
+printf "EIGENINFERENCE_ADMIN_KEY='quotedkey2'\n" > "$SECENV"
+EIGENINFERENCE_ADMIN_KEY=""; load_admin_env
+assert_eq "load_admin_env strips surrounding single quotes" "quotedkey2" "${EIGENINFERENCE_ADMIN_KEY:-}"
+
+# SECURITY REGRESSION: hostile values (command substitution) must NOT execute.
+# Sourcing the file (the bug this fixes) would run touch $CANARY; parsing must not.
+CANARY="$WORK/CANARY_EXECUTED"
+rm -f "$CANARY"
+cat > "$SECENV" <<EOF2
+MNEMONIC=word1 word2 \$(touch $CANARY) more
+EVIL=\`touch $CANARY\`
+EIGENINFERENCE_ADMIN_KEY=safekey
+EOF2
+EIGENINFERENCE_ADMIN_KEY=""; load_admin_env
+assert_eq "load_admin_env reads the key past hostile lines" "safekey" "${EIGENINFERENCE_ADMIN_KEY:-}"
+if [ ! -e "$CANARY" ]; then
+  pass "load_admin_env does NOT execute env-file values (no source/eval)"
+else
+  fail "SECURITY: env-file value was executed" "canary $CANARY exists"
+fi
+
+printf 'OTHER=x\n' > "$SECENV"
+EIGENINFERENCE_ADMIN_KEY=""; load_admin_env
+assert_eq "load_admin_env yields empty key when absent" "" "${EIGENINFERENCE_ADMIN_KEY:-}"
+
+echo
+echo "# deploy_test: image-pin rollback (pin_image / restore_image_pin / accept_image_pin)"
+
+# shellcheck disable=SC2034  # DRY_RUN read by the dry-run guards in sourced deploy.sh
+DRY_RUN=0
+PINENV="$WORK/deploy.env"
+# shellcheck disable=SC2034  # read by pin_image/restore_image_pin in sourced deploy.sh
+DINF_DEPLOY_ENV="$PINENV"
+# DINF_DEPLOY_ENV_BAK / DINF_DEPLOY_ENV_EXISTED are set by pin_image itself, so the
+# tests below intentionally do NOT pre-seed them.
+
+# (a) pin when the file did NOT exist -> restore removes it entirely.
+rm -f "$PINENV"
+pin_image "repo/coord:abc" >/dev/null 2>&1
+assert_contains "pin_image writes DINF_IMAGE" "$PINENV" "DINF_IMAGE=repo/coord:abc"
+restore_image_pin >/dev/null 2>&1
+if [ ! -f "$PINENV" ]; then pass "restore_image_pin removes a pin file created this run"; else fail "restore_image_pin should remove a newly-created pin file"; fi
+
+# (b) pin OVER an existing file -> accept keeps it (restore becomes a no-op).
+printf 'OTHER=1\n' > "$PINENV"
+pin_image "repo/coord:def" >/dev/null 2>&1
+assert_contains "pin_image preserves other keys" "$PINENV" "OTHER=1"
+assert_contains "pin_image sets the new image" "$PINENV" "DINF_IMAGE=repo/coord:def"
+accept_image_pin
+restore_image_pin >/dev/null 2>&1
+assert_contains "accept_image_pin keeps the pin (restore is a no-op)" "$PINENV" "DINF_IMAGE=repo/coord:def"
+
+# (c) pin OVER an existing pinned file -> restore brings back the original image.
+printf 'DINF_IMAGE=old/img:1\nOTHER=2\n' > "$PINENV"
+pin_image "new/img:2" >/dev/null 2>&1
+assert_contains "pin_image replaces the old image line" "$PINENV" "DINF_IMAGE=new/img:2"
+assert_absent  "pin_image drops the prior image line" "$PINENV" "DINF_IMAGE=old/img:1"
+restore_image_pin >/dev/null 2>&1
+assert_contains "restore_image_pin restores the prior image pin" "$PINENV" "DINF_IMAGE=old/img:1"
+assert_absent  "restore_image_pin drops the unaccepted image pin" "$PINENV" "DINF_IMAGE=new/img:2"
 
 echo
 echo "# deploy_test: ${PASS} passed, ${FAIL} failed"

--- a/docs/operations/coordinator-blue-green.md
+++ b/docs/operations/coordinator-blue-green.md
@@ -148,35 +148,63 @@ stopped (the "rollback window" `deploy.sh` prints):
 sudo ./deploy.sh --rollback
 ```
 
-This flips the Caddy upstream back to the other (still-running) color and
-reloads. Before flipping, `deploy.sh` health-checks the rollback target with a
-single-shot `GET /health` liveness probe so it never cuts traffic over to a dead
-port (which would surface as 502s). If the target is **not** healthy the rollback
-is refused; start it again first (`systemctl start darkbloom-coordinator@<old>`),
-then re-run `--rollback`.
+A bare Caddy flip back is **not** enough once the forward deploy has signalled
+going-away to the old color: that **latches** the old color to refuse new provider
+registrations (503) and moves its providers one-way onto the new color, so simply
+re-pointing Caddy at the old color would route consumers to a color with **zero**
+providers (429). `--rollback` therefore restores **both routing and capacity**:
 
-To override the health gate and flip anyway (for example, you are certain the
-probe is wrong), add `--force`:
+1. **Health-check** the rollback target with a single-shot `GET /health` liveness
+   probe so it never cuts traffic over to a dead port (which would surface as
+   502s). If the target is **not** healthy the rollback is refused; start it again
+   first (`systemctl start darkbloom-coordinator@<old>`), then re-run `--rollback`.
+2. **Re-enable** the target *before* flipping: `POST /v1/admin/drain {"draining":false}`
+   (undrain) and `POST /v1/admin/going-away {"cancel":true}` (clear the going-away
+   latch) so it accepts providers again. Both are best-effort — they warn and
+   continue if the endpoint is not deployed yet.
+3. **Flip** the Caddy upstream back to the target + graceful `caddy reload` (the
+   on-disk Caddyfile is restored to the current color if the reload itself fails).
+4. **Push providers back**: `POST /v1/admin/going-away` to the now-abandoned color
+   so its providers reconnect and — Caddy already flipped — land back on the
+   restored color.
+5. **Wait for providers**: poll the restored color's `/health` until
+   `providers > 0` (warns, does not abort, on timeout).
+
+The abandoned color is left **running** (idle, providers drained off) for
+inspection; stop it manually with
+`systemctl stop darkbloom-coordinator@<abandoned>`.
+
+To override the health gate in step 1 and flip anyway (for example, you are
+certain the probe is wrong), add `--force`:
 
 ```bash
 sudo ./deploy.sh --rollback --force   # DANGEROUS: may route traffic to a dead port
 ```
 
-`deploy.sh` also auto-rolls-back the flip if `caddy reload` fails mid-cutover.
+`--dry-run` prints this whole plan and changes nothing.
 
 ## Cross-phase contracts
 
 `deploy.sh` consumes endpoints/behaviors delivered by sibling PRs:
 
 - **Phase 1** — `GET /readyz` (exposes an `inflight` counter, e.g.
-  `{"inflight":0}`) and `POST /v1/admin/drain` (admin-authenticated). Until
-  Phase 1 lands, steps 4 and 8 will not see these endpoints.
-- **Phase 3** (PR #396) — `POST /v1/admin/going-away` (admin-authenticated;
-  returns `200 {"sent":N}`) tells the old color's providers to reconnect so they
-  re-land on the already-flipped new color. (`going_away` is also broadcast on a
-  graceful coordinator stop.) Until Phase 3 lands, step 6 has no endpoint to call
-  (it warns and continues; providers still reconnect within the heartbeat
-  timeout).
+  `{"inflight":0}`) and `POST /v1/admin/drain` (admin-authenticated). A bodyless
+  `POST /v1/admin/drain` **starts** draining; `POST /v1/admin/drain {"draining":false}`
+  **clears** the drain latch (used by `--rollback` to undrain the rollback target).
+  Until Phase 1 lands, steps 4 and 8 (and the rollback undrain) will not see these
+  endpoints.
+- **Phase 3** (PR #396) — `POST /v1/admin/going-away` (admin-authenticated):
+  - **empty body** = broadcast going-away **and latch** the color to refuse new
+    provider registrations; returns `200 {"sent":N}`. Tells that color's providers
+    to reconnect so they re-land on the already-flipped color. (`going_away` is also
+    broadcast on a graceful coordinator stop.)
+  - **`{"cancel":true}`** = **clear** the latch; returns
+    `200 {"going_away":false,"cleared":true}`. Used by `--rollback` to re-enable the
+    rollback target so it accepts providers again.
+
+  Until Phase 3 lands, step 6 (and the rollback clear + push-back) have no endpoint
+  to call — they warn and continue; providers still reconnect within the heartbeat
+  timeout.
 
 ## One-time install on the box
 

--- a/docs/operations/coordinator-blue-green.md
+++ b/docs/operations/coordinator-blue-green.md
@@ -132,9 +132,20 @@ sudo ./deploy.sh --rollback
 ```
 
 This flips the Caddy upstream back to the other (still-running) color and
-reloads. If the old color was already stopped, start it again first
-(`systemctl start darkbloom-coordinator@<old>`), then `--rollback`. `deploy.sh`
-also auto-rolls-back the flip if `caddy reload` fails mid-cutover.
+reloads. Before flipping, `deploy.sh` health-checks the rollback target with a
+single-shot `GET /health` liveness probe so it never cuts traffic over to a dead
+port (which would surface as 502s). If the target is **not** healthy the rollback
+is refused; start it again first (`systemctl start darkbloom-coordinator@<old>`),
+then re-run `--rollback`.
+
+To override the health gate and flip anyway (for example, you are certain the
+probe is wrong), add `--force`:
+
+```bash
+sudo ./deploy.sh --rollback --force   # DANGEROUS: may route traffic to a dead port
+```
+
+`deploy.sh` also auto-rolls-back the flip if `caddy reload` fails mid-cutover.
 
 ## Cross-phase contracts
 
@@ -167,6 +178,12 @@ Secrets are unchanged: GCP Secret Manager → tmpfs `/etc/d-inference/env`
 `darkbloom-run.sh`. Nothing secret is committed; registry auth uses the VM
 service-account token from the metadata server. `/etc/d-inference/deploy.env`
 holds only the non-secret `DINF_IMAGE` pin.
+
+`deploy.sh` itself sources `EIGENINFERENCE_ADMIN_KEY` from `/etc/d-inference/env`
+(path overridable via `DINF_ENV_FILE`) **only at drain time**, to authenticate
+`POST /v1/admin/drain`. It never prints or writes secret values and skips this
+entirely under `--dry-run`. If the key is missing the drain step warns and
+continues (the graceful container stop still finishes in-flight requests).
 
 ## Manual validation (human-only, on the GCP box)
 

--- a/docs/operations/coordinator-blue-green.md
+++ b/docs/operations/coordinator-blue-green.md
@@ -93,23 +93,40 @@ from `EIGENINFERENCE_MDM_WEBHOOK_SECRET` (never stored in the Caddyfile).
 
 ## Deploy sequence (`deploy.sh`)
 
-Run on the box. `deploy.sh`:
+Run on the box. `deploy.sh` moves providers to the new color **before** draining
+and stopping the old one, so the new color never serves consumers with zero
+providers (which would 429):
 
 1. **Detect** the active color from the Caddyfile upstream port.
 2. **Pin** the new image for the idle color (`--image`, optional → `DINF_IMAGE`
-   in `/etc/d-inference/deploy.env`, read by `darkbloom-run.sh`).
-3. **Start** the idle color: `systemctl start darkbloom-coordinator@<idle>`.
+   in `/etc/d-inference/deploy.env`, read by `darkbloom-run.sh`). The pin is
+   snapshotted and rolled back if the deploy aborts before cutover; it is kept
+   once the cutover is accepted (so an aborted deploy never leaves the shared pin
+   file pointing at an unaccepted image).
+3. **Restart** the idle color: `systemctl restart darkbloom-coordinator@<idle>`
+   (**restart, not start** — a stale already-running idle container must re-exec
+   `darkbloom-run.sh` to pick up the newly pinned `DINF_IMAGE`).
 4. **Wait** for the idle color's `/health` **and** `/readyz` to return 200
    (Phase 1 endpoints).
 5. **Cut over**: `flip_upstream` the Caddy port old→new + graceful `caddy reload`.
-6. **Drain** the old color: `POST /v1/admin/drain` (Phase 1), then poll its
-   `/readyz` until `inflight == 0` (or timeout).
-7. **Stop** the old color: `systemctl stop darkbloom-coordinator@<old>`.
+6. **Going-away**: `POST /v1/admin/going-away` to the **old** color
+   (**DAR-327 Phase 3**, PR #396; admin-gated, returns `{"sent":N}`) so its
+   providers reconnect and — Caddy already flipped — land on the **new** color.
+7. **Wait for providers**: poll the new color's `/health` until its `providers`
+   count is `> 0` (the reconnects landed). Warns (does not abort) on timeout.
+8. **Drain** the old color: `POST /v1/admin/drain` (Phase 1), then poll its
+   `/readyz` until `inflight == 0`. If it does **not** drain in time the old
+   color is **not** stopped (that would cut in-flight requests) — `deploy.sh`
+   exits nonzero with the cutover already done; re-run with `--force` to stop
+   despite in-flight requests.
+9. **Stop** the old color: `systemctl stop darkbloom-coordinator@<old>`
+   (`deploy.sh` fails if the stop returns nonzero, so a still-attached old color
+   never lingers silently).
 
-Stopping the old color triggers the coordinator's `going_away` provider broadcast
-(**DAR-327 Phase 3**, separate PR) so providers reconnect to the new color
-instantly instead of waiting for a heartbeat timeout. `deploy.sh` only performs
-the graceful stop; the broadcast ships in Phase 3.
+The going-away POST in step 6 is what hands providers to the new color; steps 8–9
+then retire the old color with no capacity gap. (`going_away` is also broadcast
+when a coordinator is stopped, but step 6 triggers it explicitly and early so the
+reconnects happen *before* the drain rather than after the old color is gone.)
 
 ```bash
 # Preview everything, change nothing:
@@ -153,10 +170,43 @@ sudo ./deploy.sh --rollback --force   # DANGEROUS: may route traffic to a dead p
 
 - **Phase 1** — `GET /readyz` (exposes an `inflight` counter, e.g.
   `{"inflight":0}`) and `POST /v1/admin/drain` (admin-authenticated). Until
-  Phase 1 lands, steps 4 and 6 will not see these endpoints.
-- **Phase 3** — graceful coordinator stop broadcasts `going_away` to providers.
+  Phase 1 lands, steps 4 and 8 will not see these endpoints.
+- **Phase 3** (PR #396) — `POST /v1/admin/going-away` (admin-authenticated;
+  returns `200 {"sent":N}`) tells the old color's providers to reconnect so they
+  re-land on the already-flipped new color. (`going_away` is also broadcast on a
+  graceful coordinator stop.) Until Phase 3 lands, step 6 has no endpoint to call
+  (it warns and continues; providers still reconnect within the heartbeat
+  timeout).
 
 ## One-time install on the box
+
+> **Prerequisite units.** `darkbloom-coordinator@.service` declares
+> `Requires=docker.service cloud-sql-proxy.service`, so both must already be
+> installed and startable on the box (the coordinator reaches Cloud SQL via the
+> proxy on `127.0.0.1:5432` when `EIGENINFERENCE_DATABASE_URL` is set). Install
+> `cloud-sql-proxy.service` the same way `deploy/gcp/vm-startup.sh` does before
+> enabling a color, or the unit will refuse to start instead of crash-looping.
+
+> **PROD ENV — required before starting any service.**
+> `deploy/gcp/refresh-env.sh` (and `vm-startup.sh`) currently hardcode **DEV**
+> values into `/etc/d-inference/env`: `DOMAIN=api.dev.darkbloom.xyz`,
+> `EIGENINFERENCE_BASE_URL=https://api.dev.darkbloom.xyz`,
+> `EIGENINFERENCE_CONSOLE_URL`/`CORS_ORIGIN=…console.dev.darkbloom.xyz`. The
+> platform passes `DOMAIN` to MicroMDM's `-server-url` and step-ca's `--dns`
+> (`start-platform.sh`), and the coordinator builds enrollment/callback URLs from
+> `EIGENINFERENCE_BASE_URL`. Starting the **prod** box with dev values mis-issues
+> the MDM server URL, ACME DNS name, and enrollment profiles. Before
+> `enable --now` below you MUST either:
+> - add a **prod** env generator (a prod variant of `refresh-env.sh`), or
+> - override `DOMAIN`, `EIGENINFERENCE_BASE_URL`, `EIGENINFERENCE_CONSOLE_URL`,
+>   and `CORS_ORIGIN` in `/etc/d-inference/env` to the prod hostnames (e.g.
+>   `api.darkbloom.dev`).
+>
+> The `/dl/*` route added to `deploy/gcp/prod/Caddyfile` serves static bundles
+> from `/var/www/html` (same as the combined `coordinator/Caddyfile`); ensure
+> that directory exists on the box and holds the published provider bundle, or the
+> release fallback URL `/dl/eigeninference-bundle-macos-arm64.tar.gz` 404s and
+> `scripts/install.sh` breaks.
 
 ```bash
 # Wrapper + units (committed, secret-free):
@@ -168,6 +218,13 @@ sudo install -m 0644 deploy/gcp/prod/darkbloom-coordinator@.service /etc/systemd
 sudo install -m 0644 deploy/gcp/prod/Caddyfile /etc/caddy/Caddyfile
 
 sudo systemctl daemon-reload
+
+# MIGRATION (existing box only): the pre-split single unit d-inference-coordinator
+# owns ports 8080 / 9000 / 9002. Disable it FIRST so the platform (9000/9002) and
+# coordinator@blue (8080) can bind those ports and Caddy stops proxying the old
+# process. Skip on a fresh box that never ran the combined unit.
+sudo systemctl disable --now d-inference-coordinator.service || true
+
 sudo systemctl enable --now darkbloom-platform.service
 sudo systemctl enable --now darkbloom-coordinator@blue   # initial active color
 sudo systemctl reload caddy
@@ -179,11 +236,16 @@ Secrets are unchanged: GCP Secret Manager → tmpfs `/etc/d-inference/env`
 service-account token from the metadata server. `/etc/d-inference/deploy.env`
 holds only the non-secret `DINF_IMAGE` pin.
 
-`deploy.sh` itself sources `EIGENINFERENCE_ADMIN_KEY` from `/etc/d-inference/env`
-(path overridable via `DINF_ENV_FILE`) **only at drain time**, to authenticate
-`POST /v1/admin/drain`. It never prints or writes secret values and skips this
-entirely under `--dry-run`. If the key is missing the drain step warns and
-continues (the graceful container stop still finishes in-flight requests).
+`deploy.sh` **parses** `EIGENINFERENCE_ADMIN_KEY` from `/etc/d-inference/env`
+(path overridable via `DINF_ENV_FILE`) **only at cutover time**, to authenticate
+the going-away and drain POSTs. It reads that single line with `grep`/`cut` and
+**never `source`s/`. `s the file** — the file is docker `--env-file` syntax
+(`KEY=VALUE`), not shell, so sourcing it would execute secret values (the 12-word
+`MNEMONIC`, `&`/URL/`$()` characters) as shell commands **as root**. The key is
+never printed or written, and is not read under `--dry-run`. If the key is missing
+the going-away/drain steps warn and continue (the explicit going-away may be
+rejected, but providers still reconnect within the heartbeat timeout; the graceful
+container stop still finishes in-flight requests).
 
 ## Manual validation (human-only, on the GCP box)
 

--- a/docs/operations/coordinator-blue-green.md
+++ b/docs/operations/coordinator-blue-green.md
@@ -1,0 +1,191 @@
+# Coordinator blue-green deploys (DAR-327 Phase 2)
+
+True zero-downtime coordinator deploys on the GCE box: run two coordinator
+"colors" (blue / green) side by side, cut traffic over at the host Caddy, then
+drain and retire the old color. This replaces the in-place
+`systemctl restart d-inference-coordinator` (which drops every in-flight request
+and every provider WebSocket for the duration of the restart).
+
+> Scope: this document describes the **GCP-hosted** coordinator. EigenCloud prod
+> does its own blue-green at the platform layer and keeps using the combined
+> `coordinator/deploy/start.sh` entrypoint, which is intentionally unchanged.
+
+## The split: platform vs coordinator
+
+The single container entrypoint is split into two roles (same image, different
+command):
+
+| Role | Entrypoint | systemd unit | Lifetime | Owns |
+|------|-----------|--------------|----------|------|
+| **platform** | `start-platform.sh` | `darkbloom-platform.service` | long-lived, survives deploys | `/mnt/disks/userdata` + `/data` symlink, step-ca (`:9000`) incl. first-boot init, MicroMDM (`:9002`) |
+| **coordinator** | `start-coordinator.sh` | `darkbloom-coordinator@<color>.service` | swappable per deploy | just the coordinator process, on `EIGENINFERENCE_PORT` (blue=8080, green=8081) |
+
+Why split: step-ca holds the CA state and MicroMDM holds BoltDB + provider-trust
+state. Those must NOT be restarted on every coordinator deploy (a CA/MDM bounce
+disrupts ACME and device attestation). Keeping them in a separate long-lived
+unit lets the coordinator swap freely underneath them.
+
+Both colors bind-mount the same `/mnt/disks/userdata` and each re-creates its own
+`/data` symlink, so they share step-ca certs and all persistent state. The
+coordinator reads the step-ca root at `EIGENINFERENCE_STEP_CA_ROOT`
+(`/data/step-ca/certs/root_ca.crt`); `start-coordinator.sh` waits (bounded) for
+that file so a cold box doesn't crash-loop before the platform finishes init.
+
+`coordinator/deploy/start.sh` (the combined EigenCloud entrypoint) is left
+unchanged. `start-platform.sh` is a faithful factoring of its step-ca + MicroMDM
+sections; keep them diff-able so they stay in sync.
+
+```
+                          ┌────────────────────────── GCE box ──────────────────────────┐
+   api.darkbloom.dev ───► │  Caddy (:443/:80)  ── (coordinator_routes) snippet           │
+                          │     │                    └─ reverse_proxy 127.0.0.1:<active>  │  ← single swap point
+                          │     │                                                         │
+                          │     ├─► darkbloom-coordinator@blue   :8080  (active OR idle)  │
+                          │     ├─► darkbloom-coordinator@green  :8081  (idle OR active)  │
+                          │     │                                                         │
+                          │     ├─ /acme/* ─► step-ca  :9000  ┐                           │
+                          │     └─ /scep,/mdm/* ─► MicroMDM :9002 ├─ darkbloom-platform   │
+   MicroMDM webhook ──────┼─► http://127.0.0.1:8090 (loopback)  ┘  (long-lived)          │
+     (loopback only)      │        └ imports the SAME snippet ⇒ follows the active color  │
+                          └──────────────────────────────────────────────────────────────┘
+```
+
+## The single swap point
+
+`deploy/gcp/prod/Caddyfile` defines all coordinator routing once, in the
+`(coordinator_routes)` snippet, imported by `api.darkbloom.dev`,
+`coord-staging.darkbloom.dev`, and the internal `http://127.0.0.1:8090` listener.
+The snippet contains exactly **one** coordinator upstream line:
+
+```
+reverse_proxy 127.0.0.1:8080 { health_uri /health; ... }
+```
+
+Flipping that one line `8080 ↔ 8081` and reloading Caddy atomically moves **all**
+traffic — both public sites and the internal MDM-webhook listener — to the new
+color. Do not add a second `reverse_proxy 127.0.0.1:<port>` line; that breaks the
+invariant `deploy.sh` / `flip_upstream` rely on. (The step-ca `:9000` and
+MicroMDM `:9002` upstreams use the `https://` scheme and different ports, so the
+port flip never touches them.)
+
+## MDM webhook coupling fix
+
+The combined `start.sh` hardcodes MicroMDM's command-webhook URL to
+`http://localhost:8080/v1/mdm/webhook` — correct only when the coordinator shares
+the container on `:8080`. In the split the active coordinator may be on `:8080`
+**or** `:8081`, and MicroMDM lives in the platform, so it can't be hardcoded to
+either color.
+
+Fix: `start-platform.sh` reads the webhook base URL from
+`EIGENINFERENCE_MDM_WEBHOOK_URL` (default keeps legacy `localhost:8080`). The
+platform unit sets it to the stable loopback Caddy listener:
+
+```
+EIGENINFERENCE_MDM_WEBHOOK_URL=http://127.0.0.1:8090/v1/mdm/webhook
+```
+
+That listener binds to `127.0.0.1` only (no firewall change, never publicly
+reachable) and imports the same `(coordinator_routes)` snippet, so the webhook
+falls through to the one swap-target upstream and is rerouted to the active color
+by the exact same single-line flip — no extra swap point, no per-deploy MicroMDM
+restart. The shared `?token=` secret is still appended by `start-platform.sh`
+from `EIGENINFERENCE_MDM_WEBHOOK_SECRET` (never stored in the Caddyfile).
+
+## Deploy sequence (`deploy.sh`)
+
+Run on the box. `deploy.sh`:
+
+1. **Detect** the active color from the Caddyfile upstream port.
+2. **Pin** the new image for the idle color (`--image`, optional → `DINF_IMAGE`
+   in `/etc/d-inference/deploy.env`, read by `darkbloom-run.sh`).
+3. **Start** the idle color: `systemctl start darkbloom-coordinator@<idle>`.
+4. **Wait** for the idle color's `/health` **and** `/readyz` to return 200
+   (Phase 1 endpoints).
+5. **Cut over**: `flip_upstream` the Caddy port old→new + graceful `caddy reload`.
+6. **Drain** the old color: `POST /v1/admin/drain` (Phase 1), then poll its
+   `/readyz` until `inflight == 0` (or timeout).
+7. **Stop** the old color: `systemctl stop darkbloom-coordinator@<old>`.
+
+Stopping the old color triggers the coordinator's `going_away` provider broadcast
+(**DAR-327 Phase 3**, separate PR) so providers reconnect to the new color
+instantly instead of waiting for a heartbeat timeout. `deploy.sh` only performs
+the graceful stop; the broadcast ships in Phase 3.
+
+```bash
+# Preview everything, change nothing:
+./deploy.sh --dry-run --image <REGISTRY>/coordinator:<sha>
+
+# Real deploy (interactive confirmations at each destructive step):
+sudo ./deploy.sh --image <REGISTRY>/coordinator:<sha>
+
+# Non-interactive (CI):
+sudo ./deploy.sh -y --image <REGISTRY>/coordinator:<sha>
+```
+
+### Rollback
+
+Valid any time **after** the cutover flip and **before** the old color is
+stopped (the "rollback window" `deploy.sh` prints):
+
+```bash
+sudo ./deploy.sh --rollback
+```
+
+This flips the Caddy upstream back to the other (still-running) color and
+reloads. If the old color was already stopped, start it again first
+(`systemctl start darkbloom-coordinator@<old>`), then `--rollback`. `deploy.sh`
+also auto-rolls-back the flip if `caddy reload` fails mid-cutover.
+
+## Cross-phase contracts
+
+`deploy.sh` consumes endpoints/behaviors delivered by sibling PRs:
+
+- **Phase 1** — `GET /readyz` (exposes an `inflight` counter, e.g.
+  `{"inflight":0}`) and `POST /v1/admin/drain` (admin-authenticated). Until
+  Phase 1 lands, steps 4 and 6 will not see these endpoints.
+- **Phase 3** — graceful coordinator stop broadcasts `going_away` to providers.
+
+## One-time install on the box
+
+```bash
+# Wrapper + units (committed, secret-free):
+sudo install -m 0755 deploy/gcp/prod/darkbloom-run.sh /usr/local/bin/darkbloom-run.sh
+sudo install -m 0644 deploy/gcp/prod/darkbloom-platform.service     /etc/systemd/system/darkbloom-platform.service
+sudo install -m 0644 deploy/gcp/prod/darkbloom-coordinator@.service /etc/systemd/system/darkbloom-coordinator@.service
+
+# Host Caddy config (single swap point + loopback webhook listener):
+sudo install -m 0644 deploy/gcp/prod/Caddyfile /etc/caddy/Caddyfile
+
+sudo systemctl daemon-reload
+sudo systemctl enable --now darkbloom-platform.service
+sudo systemctl enable --now darkbloom-coordinator@blue   # initial active color
+sudo systemctl reload caddy
+```
+
+Secrets are unchanged: GCP Secret Manager → tmpfs `/etc/d-inference/env`
+(written by `deploy/gcp/refresh-env.sh`) → `--env-file` inside
+`darkbloom-run.sh`. Nothing secret is committed; registry auth uses the VM
+service-account token from the metadata server. `/etc/d-inference/deploy.env`
+holds only the non-secret `DINF_IMAGE` pin.
+
+## Manual validation (human-only, on the GCP box)
+
+Real blue-green validation requires the live box and is **not** run in CI or from
+a worktree. The infra-free unit tests (`deploy/gcp/prod/deploy_test.sh`) only
+cover the pure `flip_upstream` / `current_upstream_port` logic.
+
+1. `systemctl status darkbloom-platform` — step-ca `:9000`, MicroMDM `:9002` up.
+2. `./deploy.sh --dry-run --image <ref>` — confirm the detected active/idle
+   colors and the printed plan.
+3. Start a deploy; while both colors run, in another shell:
+   - `curl -s 127.0.0.1:8080/health` and `curl -s 127.0.0.1:8081/health` → 200.
+   - drive sustained traffic at `https://api.darkbloom.dev` and confirm zero
+     errors across the cutover.
+4. After the flip: `current_upstream_port /etc/caddy/Caddyfile` (sourced from
+   `deploy.sh`) shows the new port; `caddy validate --config /etc/caddy/Caddyfile`.
+5. Enroll/trigger an MDM SecurityInfo callback and confirm it reaches the
+   **active** color (check coordinator logs for the webhook hit on the new port).
+6. Test `--rollback` before stopping the old color; confirm traffic returns to
+   the previous color with no errors.
+ 7. Verify providers reconnect promptly after the old color stops (instant once
+    Phase 3 `going_away` lands; otherwise within the heartbeat timeout).

--- a/docs/operations/coordinator-blue-green.md
+++ b/docs/operations/coordinator-blue-green.md
@@ -99,10 +99,10 @@ providers (which would 429):
 
 1. **Detect** the active color from the Caddyfile upstream port.
 2. **Pin** the new image for the idle color (`--image`, optional → `DINF_IMAGE`
-   in `/etc/d-inference/deploy.env`, read by `darkbloom-run.sh`). The pin is
-   snapshotted and rolled back if the deploy aborts before cutover; it is kept
-   once the cutover is accepted (so an aborted deploy never leaves the shared pin
-   file pointing at an unaccepted image).
+   in `/etc/d-inference/deploy-<color>.env`, read by `darkbloom-run.sh` via the
+   coordinator unit's per-color `EnvironmentFile`). The pin is snapshotted and
+   rolled back if the deploy aborts before cutover; it is kept once the cutover
+   is accepted, so the active color never reads the idle color's unaccepted pin.
 3. **Restart** the idle color: `systemctl restart darkbloom-coordinator@<idle>`
    (**restart, not start** — a stale already-running idle container must re-exec
    `darkbloom-run.sh` to pick up the newly pinned `DINF_IMAGE`).
@@ -113,7 +113,8 @@ providers (which would 429):
    (**DAR-327 Phase 3**, PR #396; admin-gated, returns `{"sent":N}`) so its
    providers reconnect and — Caddy already flipped — land on the **new** color.
 7. **Wait for providers**: poll the new color's `/health` until its `providers`
-   count is `> 0` (the reconnects landed). Warns (does not abort) on timeout.
+   count is `> 0` (the reconnects landed). If this times out, the deploy exits
+   nonzero unless `--force` is set and does **not** drain or stop the old color.
 8. **Drain** the old color: `POST /v1/admin/drain` (Phase 1), then poll its
    `/readyz` until `inflight == 0`. If it does **not** drain in time the old
    color is **not** stopped (that would cut in-flight requests) — `deploy.sh`
@@ -168,7 +169,8 @@ providers (429). `--rollback` therefore restores **both routing and capacity**:
    so its providers reconnect and — Caddy already flipped — land back on the
    restored color.
 5. **Wait for providers**: poll the restored color's `/health` until
-   `providers > 0` (warns, does not abort, on timeout).
+   `providers > 0` (warns and continues on timeout because routing is already
+   flipped back to the restored color).
 
 The abandoned color is left **running** (idle, providers drained off) for
 inspection; stop it manually with
@@ -230,11 +232,12 @@ sudo ./deploy.sh --rollback --force   # DANGEROUS: may route traffic to a dead p
 >   and `CORS_ORIGIN` in `/etc/d-inference/env` to the prod hostnames (e.g.
 >   `api.darkbloom.dev`).
 >
-> The `/dl/*` route added to `deploy/gcp/prod/Caddyfile` serves static bundles
-> from `/var/www/html` (same as the combined `coordinator/Caddyfile`); ensure
-> that directory exists on the box and holds the published provider bundle, or the
-> release fallback URL `/dl/eigeninference-bundle-macos-arm64.tar.gz` 404s and
-> `scripts/install.sh` breaks.
+> The `/dl/*` and `/enroll.mobileconfig` routes in `deploy/gcp/prod/Caddyfile`
+> serve static files from `/var/www/html` (same as the combined
+> `coordinator/Caddyfile`); ensure that directory exists on the box and holds the
+> published provider bundle plus enrollment profile, or the release fallback URL
+> `/dl/eigeninference-bundle-macos-arm64.tar.gz` 404s and `scripts/install.sh`
+> breaks, and ACME enrollment profile downloads fail.
 
 ```bash
 # Wrapper + units (committed, secret-free):
@@ -262,7 +265,9 @@ Secrets are unchanged: GCP Secret Manager → tmpfs `/etc/d-inference/env`
 (written by `deploy/gcp/refresh-env.sh`) → `--env-file` inside
 `darkbloom-run.sh`. Nothing secret is committed; registry auth uses the VM
 service-account token from the metadata server. `/etc/d-inference/deploy.env`
-holds only the non-secret `DINF_IMAGE` pin.
+remains the platform unit's optional non-secret deploy config, while each
+coordinator color reads its own non-secret image pin from
+`/etc/d-inference/deploy-blue.env` or `/etc/d-inference/deploy-green.env`.
 
 `deploy.sh` **parses** `EIGENINFERENCE_ADMIN_KEY` from `/etc/d-inference/env`
 (path overridable via `DINF_ENV_FILE`) **only at cutover time**, to authenticate

--- a/docs/operations/coordinator-blue-green.md
+++ b/docs/operations/coordinator-blue-green.md
@@ -112,9 +112,11 @@ providers (which would 429):
 6. **Going-away**: `POST /v1/admin/going-away` to the **old** color
    (**DAR-327 Phase 3**, PR #396; admin-gated, returns `{"sent":N}`) so its
    providers reconnect and — Caddy already flipped — land on the **new** color.
-7. **Wait for providers**: poll the new color's `/health` until its `providers`
-   count is `> 0` (the reconnects landed). If this times out, the deploy exits
-   nonzero unless `--force` is set and does **not** drain or stop the old color.
+7. **Wait for routable capacity**: poll the new color's `/v1/models/capacity`
+   until it reports at least one model capacity entry. This proves providers have
+   landed and passed routing/trust gates, not merely opened a WebSocket. If this
+   times out, the deploy restores Caddy to the old color, exits nonzero unless
+   `--force` is set, and does **not** drain or stop the old color.
 8. **Drain** the old color: `POST /v1/admin/drain` (Phase 1), then poll its
    `/readyz` until `inflight == 0`. If it does **not** drain in time the old
    color is **not** stopped (that would cut in-flight requests) — `deploy.sh`
@@ -168,9 +170,10 @@ providers (429). `--rollback` therefore restores **both routing and capacity**:
 4. **Push providers back**: `POST /v1/admin/going-away` to the now-abandoned color
    so its providers reconnect and — Caddy already flipped — land back on the
    restored color.
-5. **Wait for providers**: poll the restored color's `/health` until
-   `providers > 0` (warns and continues on timeout because routing is already
-   flipped back to the restored color).
+5. **Wait for routable capacity**: poll the restored color's `/v1/models/capacity`
+   until at least one model capacity entry is present. If capacity does not return,
+   rollback restores Caddy to the previously-live color and exits nonzero instead
+   of declaring success on a provider-empty target.
 
 The abandoned color is left **running** (idle, providers drained off) for
 inspection; stop it manually with


### PR DESCRIPTION
**DAR-327 Phase 2 of 3 — true blue-green coordinator deploy** (independent, on top of Phase 0 / DAR-326). Phase 1 = #393.

Makes coordinator upgrades zero-gap on the consumer HTTP path by splitting the single container into a long-lived **platform** service (step-ca + MicroMDM + the `/mnt/disks/userdata` volume) and a swappable **coordinator-only** service (`@blue`/`@green`, ports 8080/8081, sharing `/data`). A host-Caddy upstream flip + graceful reload performs the cutover; rollback = flip back.

### What's here (11 files, secret-free)
- **New container roles:** `coordinator/deploy/start-platform.sh`, `coordinator/deploy/start-coordinator.sh`. Original `coordinator/deploy/start.sh` left **byte-for-byte unchanged** (EigenCloud combined path keeps working).
- **Orchestrator:** root `deploy.sh` — detect active color → start idle color → gate on `/health`+`/readyz` → `flip_upstream` Caddy 8080↔8081 + `caddy reload` → drain old via `POST /v1/admin/drain` + poll `/readyz` until inflight==0 → stop old color. `--dry-run` supported; `main` guarded by `[ "${BASH_SOURCE[0]}" = "$0" ]` so sourcing/tests never deploy. Rollback flag flips back.
- **systemd (newly tracked under `deploy/gcp/prod/`):** `darkbloom-platform.service`, `darkbloom-coordinator@.service` (templated `%i`), `darkbloom-run.sh`, plus `Caddyfile` (was untracked on the box) and `deploy_test.sh`.
- **Guardrail:** `.gitignore` += `*.key`, `*.crt`. **Dockerfile:** additive COPY+chmod for the two new scripts (`CMD ["start.sh"]` unchanged).
- **Docs:** `docs/operations/coordinator-blue-green.md` (split, swap sequence, rollback, manual validation).

### Decisions / risks
- **MDM webhook routing:** `start.sh`'s hardcoded `localhost:8080` would miss green. Fix: `EIGENINFERENCE_MDM_WEBHOOK_URL` (default preserves legacy) pointed at a loopback-only Caddy listener `127.0.0.1:8090` that imports the same `(coordinator_routes)` snippet, so the single upstream flip reroutes the webhook to the active color too — no extra swap point.
- **flip_upstream** only matches the bare-loopback coordinator `reverse_proxy` line (skips `:9000`/`:9002`), preserves indentation/inode, returns rc 3 on no-op.
- **Newly tracked `deploy/gcp/prod/*`** — flagged for maintainer confirmation (previously untracked, verified secret-free).

### Cross-phase contracts (separate PRs)
Phase 1 (#393): `GET /readyz`, `POST /v1/admin/drain`. Phase 3: stopping a coordinator broadcasts `going_away` → providers reconnect instantly to the new color.

### Verification (infra-free; NO real deploy run)
- `shellcheck` 0.11.0 clean on all 5 scripts (one justified inline `SC2329`).
- `bash -n` / `sh -n` pass on all scripts.
- `deploy_test.sh`: **26/26 pass** (flip changes only the coordinator line; reversible; idempotent; `:9000`/`:9002`/`:8090` untouched).
- `deploy.sh --dry-run` prints the full plan and mutates nothing.

**Confirmed: no secrets committed** (runtime secrets stay Secret Manager → tmpfs `/etc/d-inference/env` → `--env-file`; `coordinator/.env` remains gitignored). Real blue-green validation is human-only on the GCP box.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/394"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784332134&installation_id=133247490&pr_number=394&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F394&signature=004557411667c7abea364181a0cad823de44b3a929e1ee43818844ad62ef9599"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->