### PR TITLE
feat(provider): only discover/advertise coordinator-catalog models

### DIFF
--- a/coordinator/api/provider.go
+++ b/coordinator/api/provider.go
@@ -133,13 +133,20 @@ func (s *Server) handleProviderWS(w http.ResponseWriter, r *http.Request) {
 }
 
 // filterRegistrationModels returns the subset of provider-reported models that
-// are in the coordinator catalog, plus a list of any dropped IDs. A nil catalog
-// (dev/test) disables the gate and keeps all models.
+// are in the coordinator catalog or are a previous/retired member of an active
+// alias lineage, plus a list of any dropped IDs. A nil catalog (dev/test)
+// disables the gate and keeps all models.
+//
+// Retired alias builds are intentionally kept: a provider that was offline
+// through the end of an alias rollout may only advertise a retired build.
+// DesiredModelsForProvider uses that retired lineage to recognize the provider
+// as part of the alias fleet and push the current desired build. Dropping the
+// retired build here would strand that provider with no desired_models update.
 func (s *Server) filterRegistrationModels(models []protocol.ModelInfo) ([]protocol.ModelInfo, []string) {
 	var filtered []protocol.ModelInfo
 	var dropped []string
 	for _, m := range models {
-		if s.registry.IsModelInCatalog(m.ID) {
+		if s.registry.IsModelInCatalog(m.ID) || s.registry.IsAliasLineageBuild(m.ID) {
 			filtered = append(filtered, m)
 		} else {
 			dropped = append(dropped, m.ID)

--- a/coordinator/api/provider.go
+++ b/coordinator/api/provider.go
@@ -132,6 +132,22 @@ func (s *Server) handleProviderWS(w http.ResponseWriter, r *http.Request) {
 	s.providerReadLoop(r.Context(), conn, providerID, acmeResult, r)
 }
 
+// filterRegistrationModels returns the subset of provider-reported models that
+// are in the coordinator catalog, plus a list of any dropped IDs. A nil catalog
+// (dev/test) disables the gate and keeps all models.
+func (s *Server) filterRegistrationModels(models []protocol.ModelInfo) ([]protocol.ModelInfo, []string) {
+	var filtered []protocol.ModelInfo
+	var dropped []string
+	for _, m := range models {
+		if s.registry.IsModelInCatalog(m.ID) {
+			filtered = append(filtered, m)
+		} else {
+			dropped = append(dropped, m.ID)
+		}
+	}
+	return filtered, dropped
+}
+
 // providerReadLoop reads messages from the provider WebSocket and dispatches
 // them. It runs until the connection closes or the context is cancelled.
 func (s *Server) providerReadLoop(ctx context.Context, conn *websocket.Conn, providerID string, acmeResult *ACMEVerificationResult, r *http.Request) {
@@ -204,6 +220,17 @@ func (s *Server) providerReadLoop(ctx context.Context, conn *websocket.Conn, pro
 		switch msg.Type {
 		case protocol.TypeRegister:
 			regMsg := msg.Payload.(*protocol.RegisterMessage)
+			// Drop any models not in the coordinator catalog at registration time.
+			// The provider is expected to filter its advertised set client-side,
+			// but this is the server-side backstop that keeps unsupported weights
+			// out of provider counts and routing state.
+			if filtered, dropped := s.filterRegistrationModels(regMsg.Models); len(dropped) > 0 {
+				s.logger.Warn("provider registered non-catalog models; dropping",
+					"provider_id", providerID,
+					"dropped", dropped,
+					"kept_count", len(filtered))
+				regMsg.Models = filtered
+			}
 			provider = s.registry.Register(providerID, conn, regMsg)
 			s.attachProviderLocation(providerID, provider, r)
 			s.verifyProviderAttestation(providerID, provider, regMsg)

--- a/coordinator/api/provider_test.go
+++ b/coordinator/api/provider_test.go
@@ -165,6 +165,83 @@ func TestProviderRegistrationFiltersNonCatalogModels(t *testing.T) {
 	}
 }
 
+func TestProviderRegistrationKeepsRetiredAliasBuild(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	st := store.NewMemory(store.Config{AdminKey: "test-key"})
+	reg := registry.New(logger)
+	// Active catalog only contains the desired build; the retired build is
+	// intentionally no longer present.
+	reg.SetModelCatalog([]registry.CatalogEntry{
+		{ID: "desired-build", SizeGB: 1, MinRAMGB: 8},
+	})
+	reg.SetModelAliases(map[string]registry.AliasTarget{
+		"gemma-4-26b": {Desired: "desired-build", Retired: []string{"retired-build"}},
+	})
+	srv := NewServer(reg, st, ServerConfig{}, logger)
+
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http") + "/ws/provider"
+	conn, _, err := websocket.Dial(ctx, wsURL, nil)
+	if err != nil {
+		t.Fatalf("websocket dial: %v", err)
+	}
+	defer conn.Close(websocket.StatusNormalClosure, "")
+
+	regMsg := protocol.RegisterMessage{
+		Type: protocol.TypeRegister,
+		Hardware: protocol.Hardware{
+			MachineModel: "Mac15,8",
+			ChipName:     "Apple M3 Max",
+			MemoryGB:     64,
+		},
+		Models: []protocol.ModelInfo{
+			{ID: "retired-build", SizeBytes: 1000, ModelType: "chat", Quantization: "4bit"},
+		},
+		Backend: "mlx-swift",
+	}
+	regData, _ := json.Marshal(regMsg)
+	if err := conn.Write(ctx, websocket.MessageText, regData); err != nil {
+		t.Fatalf("write register: %v", err)
+	}
+
+	time.Sleep(100 * time.Millisecond)
+
+	if reg.ProviderCount() != 1 {
+		t.Fatalf("provider count = %d, want 1", reg.ProviderCount())
+	}
+	ids := reg.ProviderIDs()
+	if len(ids) != 1 {
+		t.Fatalf("provider ids = %v, want 1", ids)
+	}
+	p := reg.GetProvider(ids[0])
+	if p == nil {
+		t.Fatal("expected provider to exist")
+	}
+	p.Mu().Lock()
+	modelIDs := make([]string, len(p.Models))
+	for i, m := range p.Models {
+		modelIDs[i] = m.ID
+	}
+	p.Mu().Unlock()
+
+	want := []string{"retired-build"}
+	if len(modelIDs) != len(want) || modelIDs[0] != want[0] {
+		t.Errorf("registered models = %v, want %v", modelIDs, want)
+	}
+
+	// The retired lineage must be enough for DesiredModelsForProvider to
+	// recognize the provider and push the current desired build.
+	entries := reg.DesiredModelsForProvider(ids[0])
+	if len(entries) != 1 || entries[0].DesiredBuild != "desired-build" {
+		t.Errorf("desired models = %+v, want one entry pointing to desired-build", entries)
+	}
+}
+
 func TestProviderWebSocketMultiple(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	st := store.NewMemory(store.Config{AdminKey: "test-key"})

--- a/coordinator/api/provider_test.go
+++ b/coordinator/api/provider_test.go
@@ -99,6 +99,72 @@ func TestProviderWebSocketConnect(t *testing.T) {
 	}
 }
 
+func TestProviderRegistrationFiltersNonCatalogModels(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	st := store.NewMemory(store.Config{AdminKey: "test-key"})
+	reg := registry.New(logger)
+	reg.SetModelCatalog([]registry.CatalogEntry{
+		{ID: "catalog-model", SizeGB: 1, MinRAMGB: 8},
+	})
+	srv := NewServer(reg, st, ServerConfig{}, logger)
+
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http") + "/ws/provider"
+	conn, _, err := websocket.Dial(ctx, wsURL, nil)
+	if err != nil {
+		t.Fatalf("websocket dial: %v", err)
+	}
+	defer conn.Close(websocket.StatusNormalClosure, "")
+
+	regMsg := protocol.RegisterMessage{
+		Type: protocol.TypeRegister,
+		Hardware: protocol.Hardware{
+			MachineModel: "Mac15,8",
+			ChipName:     "Apple M3 Max",
+			MemoryGB:     64,
+		},
+		Models: []protocol.ModelInfo{
+			{ID: "catalog-model", SizeBytes: 1000, ModelType: "chat", Quantization: "4bit"},
+			{ID: "local-only-model", SizeBytes: 1000, ModelType: "chat", Quantization: "4bit"},
+		},
+		Backend: "mlx-swift",
+	}
+	regData, _ := json.Marshal(regMsg)
+	if err := conn.Write(ctx, websocket.MessageText, regData); err != nil {
+		t.Fatalf("write register: %v", err)
+	}
+
+	time.Sleep(100 * time.Millisecond)
+
+	if reg.ProviderCount() != 1 {
+		t.Fatalf("provider count = %d, want 1", reg.ProviderCount())
+	}
+	ids := reg.ProviderIDs()
+	if len(ids) != 1 {
+		t.Fatalf("provider ids = %v, want 1", ids)
+	}
+	p := reg.GetProvider(ids[0])
+	if p == nil {
+		t.Fatal("expected provider to exist")
+	}
+	p.Mu().Lock()
+	modelIDs := make([]string, len(p.Models))
+	for i, m := range p.Models {
+		modelIDs[i] = m.ID
+	}
+	p.Mu().Unlock()
+
+	want := []string{"catalog-model"}
+	if len(modelIDs) != len(want) || modelIDs[0] != want[0] {
+		t.Errorf("registered models = %v, want %v", modelIDs, want)
+	}
+}
+
 func TestProviderWebSocketMultiple(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	st := store.NewMemory(store.Config{AdminKey: "test-key"})

--- a/docs/provider/cli-reference.md
+++ b/docs/provider/cli-reference.md
@@ -27,8 +27,8 @@ darkbloom start [flags]
 | Flag | Description |
 |------|-------------|
 | `--coordinator-url <url>` | Override the coordinator WebSocket URL |
-| `--model <id>` | Model to serve; repeatable (skips the interactive picker) |
-| `--all` | Serve all downloaded models |
+| `--model <id>` | Supported model to serve; repeatable (skips the interactive picker) |
+| `--all` | Serve all downloaded models that are in the coordinator catalog |
 | `--idle-timeout <mins>` | Idle timeout before unloading a model |
 | `--foreground` | Run in the foreground (used by launchd; normally implicit) |
 | `--local` | Run a local OpenAI server only; do not connect to the coordinator |
@@ -126,7 +126,9 @@ darkbloom verify [--coordinator <url>]
 
 ## `darkbloom models`
 
-Manage locally cached MLX models.
+Manage locally cached MLX models. Only models that are in the coordinator's
+active catalog can be served; other downloaded weights are ignored by the
+provider and are not advertised to the network.
 
 ### `darkbloom models catalog`
 

--- a/docs/provider/quickstart.md
+++ b/docs/provider/quickstart.md
@@ -129,7 +129,7 @@ start = "22:00"
 end = "08:00"
 ```
 
-- `backend.enabled_models` — if non-empty, only these models are advertised.
+- `backend.enabled_models` — if non-empty, only these catalog-supported models are advertised.
 - `backend.idle_timeout_mins` — minutes of inactivity before an idle model is
   unloaded (default 60; 0 disables eviction).
 - `backend.max_model_slots` — maximum resident models at once (default 3).

--- a/provider-swift/Sources/ProviderCore/Config/ProviderConfig.swift
+++ b/provider-swift/Sources/ProviderCore/Config/ProviderConfig.swift
@@ -54,7 +54,9 @@ public struct BackendSettings: Sendable, Equatable, Codable {
     public var port: UInt16
     public var model: String?
     public var continuousBatching: Bool
-    /// Which models to advertise to the network. If empty, all downloaded models
+    /// Which supported models to advertise to the network. Only models that are
+    /// in the coordinator catalog can be served; this list further restricts that
+    /// catalog-supported set. If empty, all catalog-supported downloaded models
     /// are advertised. If set, only these models are offered.
     public var enabledModels: [String]
     /// Minutes of inactivity before the backend is shut down to free GPU memory.

--- a/provider-swift/Sources/ProviderCore/Models/ModelCatalog.swift
+++ b/provider-swift/Sources/ProviderCore/Models/ModelCatalog.swift
@@ -137,14 +137,58 @@ public struct CatalogAlias: Codable, Sendable, Equatable {
     }
 }
 
-public struct CatalogSnapshot: Sendable, Equatable {
+public struct CatalogSnapshot: Sendable, Equatable, Codable {
     public let models: [CatalogModel]
     public let aliases: [CatalogAlias]
+
+    public init(models: [CatalogModel], aliases: [CatalogAlias] = []) {
+        self.models = models
+        self.aliases = aliases
+    }
 }
 
 private struct CatalogResponse: Codable {
     let models: [CatalogModel]
     let aliases: [CatalogAlias]?
+}
+
+// MARK: - Catalog cache
+
+/// On-disk cache for the coordinator catalog so offline commands (`doctor`,
+/// `status`, `models list`) can still distinguish supported models from
+/// downloaded-but-unsupported weights.
+public enum CatalogCache: Sendable {
+    /// Default cache file path: `~/.cache/darkbloom/catalog.json`.
+    public static func defaultPath() -> URL {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".cache", isDirectory: true)
+            .appendingPathComponent("darkbloom", isDirectory: true)
+            .appendingPathComponent("catalog.json", isDirectory: false)
+    }
+
+    /// Read the cached snapshot, if any. Returns `nil` when the file is missing
+    /// or unreadable; callers decide whether an empty catalog is appropriate.
+    public static func read(from path: URL = defaultPath()) -> CatalogSnapshot? {
+        guard FileManager.default.fileExists(atPath: path.path),
+              let data = try? Data(contentsOf: path)
+        else {
+            return nil
+        }
+        do {
+            return try JSONDecoder().decode(CatalogSnapshot.self, from: data)
+        } catch {
+            return nil
+        }
+    }
+
+    /// Persist a snapshot to disk, creating parent directories as needed.
+    public static func write(_ snapshot: CatalogSnapshot, to path: URL = defaultPath()) {
+        let dir = path.deletingLastPathComponent()
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        if let data = try? JSONEncoder().encode(snapshot) {
+            try? data.write(to: path, options: .atomic)
+        }
+    }
 }
 
 // MARK: - Errors

--- a/provider-swift/Sources/ProviderCore/Models/ModelCatalog.swift
+++ b/provider-swift/Sources/ProviderCore/Models/ModelCatalog.swift
@@ -12,6 +12,7 @@
 /// matching what `ModelScanner` already discovers.
 
 import Foundation
+import CryptoKit
 
 // MARK: - Download progress tracking & rendering
 //
@@ -127,6 +128,22 @@ public struct CatalogAlias: Codable, Sendable, Equatable {
     public let retiredBuilds: [String]?
     public let primaryBuild: String?
 
+    public init(
+        id: String,
+        displayName: String,
+        desiredBuild: String,
+        previousBuild: String? = nil,
+        retiredBuilds: [String]? = nil,
+        primaryBuild: String? = nil
+    ) {
+        self.id = id
+        self.displayName = displayName
+        self.desiredBuild = desiredBuild
+        self.previousBuild = previousBuild
+        self.retiredBuilds = retiredBuilds
+        self.primaryBuild = primaryBuild
+    }
+
     enum CodingKeys: String, CodingKey {
         case id
         case displayName = "display_name"
@@ -158,12 +175,28 @@ private struct CatalogResponse: Codable {
 /// `status`, `models list`) can still distinguish supported models from
 /// downloaded-but-unsupported weights.
 public enum CatalogCache: Sendable {
-    /// Default cache file path: `~/.cache/darkbloom/catalog.json`.
-    public static func defaultPath() -> URL {
+    /// Default cache directory: `~/.cache/darkbloom/`.
+    public static func defaultDirectory() -> URL {
         FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent(".cache", isDirectory: true)
             .appendingPathComponent("darkbloom", isDirectory: true)
-            .appendingPathComponent("catalog.json", isDirectory: false)
+    }
+
+    /// Legacy/default cache file path: `~/.cache/darkbloom/catalog.json`.
+    public static func defaultPath() -> URL {
+        defaultDirectory().appendingPathComponent("catalog.json", isDirectory: false)
+    }
+
+    /// Cache file path scoped to a coordinator base URL. Prevents a transient
+    /// fetch failure on one coordinator from falling back to a cache populated
+    /// by a different coordinator (prod vs staging vs self-hosted).
+    public static func path(for coordinatorURL: String) -> URL {
+        let base = coordinatorHTTPBase(coordinatorURL)
+        let hash = SHA256.hash(data: Data(base.utf8))
+            .compactMap { String(format: "%02x", $0) }
+            .joined()
+            .prefix(16)
+        return defaultDirectory().appendingPathComponent("catalog-\(hash).json", isDirectory: false)
     }
 
     /// Read the cached snapshot, if any. Returns `nil` when the file is missing

--- a/provider-swift/Sources/ProviderCore/ProviderLoop.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop.swift
@@ -125,6 +125,9 @@ public struct ProviderLoopConfig: Sendable {
     /// endpoint off the SAME loaded models it serves to the coordinator
     /// (unified mode). nil = coordinator-only (the default).
     public let localEndpoint: LocalInferenceHTTPConfig?
+    /// Coordinator catalog snapshot captured at startup. Used to gate runtime
+    /// prefetch advertising so only supported builds are ever announced.
+    public let catalog: CatalogSnapshot?
 
     public init(
         coordinatorURL: String,
@@ -135,7 +138,8 @@ public struct ProviderLoopConfig: Sendable {
         runtimeHashes: RuntimeHashes? = nil,
         modelHashes: [String: String] = [:],
         modelHashFingerprints: [String: String] = [:],
-        localEndpoint: LocalInferenceHTTPConfig? = nil
+        localEndpoint: LocalInferenceHTTPConfig? = nil,
+        catalog: CatalogSnapshot? = nil
     ) {
         self.coordinatorURL = coordinatorURL
         self.hardware = hardware
@@ -146,6 +150,7 @@ public struct ProviderLoopConfig: Sendable {
         self.modelHashes = modelHashes
         self.modelHashFingerprints = modelHashFingerprints
         self.localEndpoint = localEndpoint
+        self.catalog = catalog
     }
 }
 
@@ -1756,6 +1761,19 @@ public actor ProviderLoop {
             desiredSwapDrop.removeValue(forKey: modelId)
             logger.info("Ignoring verified prefetch for stale desired build \(modelId); alias target changed before verification completed")
             return
+        }
+
+        // Refuse to advertise a build that is not in the coordinator catalog.
+        // The coordinator already rejects unknown builds in models_update, but
+        // dropping it here prevents the provider from raising its slot cap or
+        // performing a hard-swap for a build it should never serve.
+        if let catalog = loopConfig.catalog {
+            let catalogIDs = Set(catalog.models.map(\.id))
+            guard catalogIDs.contains(modelId) else {
+                desiredSwapDrop.removeValue(forKey: modelId)
+                logger.error("Prefetch verified \(modelId) but it is not in the coordinator catalog; not advertising")
+                return
+            }
         }
 
         // Compute ModelInfo + weight hash off-actor (CPU/IO heavy for big

--- a/provider-swift/Sources/ProviderCore/ProviderLoop.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop.swift
@@ -125,9 +125,6 @@ public struct ProviderLoopConfig: Sendable {
     /// endpoint off the SAME loaded models it serves to the coordinator
     /// (unified mode). nil = coordinator-only (the default).
     public let localEndpoint: LocalInferenceHTTPConfig?
-    /// Coordinator catalog snapshot captured at startup. Used to gate runtime
-    /// prefetch advertising so only supported builds are ever announced.
-    public let catalog: CatalogSnapshot?
 
     public init(
         coordinatorURL: String,
@@ -138,8 +135,7 @@ public struct ProviderLoopConfig: Sendable {
         runtimeHashes: RuntimeHashes? = nil,
         modelHashes: [String: String] = [:],
         modelHashFingerprints: [String: String] = [:],
-        localEndpoint: LocalInferenceHTTPConfig? = nil,
-        catalog: CatalogSnapshot? = nil
+        localEndpoint: LocalInferenceHTTPConfig? = nil
     ) {
         self.coordinatorURL = coordinatorURL
         self.hardware = hardware
@@ -150,7 +146,6 @@ public struct ProviderLoopConfig: Sendable {
         self.modelHashes = modelHashes
         self.modelHashFingerprints = modelHashFingerprints
         self.localEndpoint = localEndpoint
-        self.catalog = catalog
     }
 }
 
@@ -1763,18 +1758,12 @@ public actor ProviderLoop {
             return
         }
 
-        // Refuse to advertise a build that is not in the coordinator catalog.
-        // The coordinator already rejects unknown builds in models_update, but
-        // dropping it here prevents the provider from raising its slot cap or
-        // performing a hard-swap for a build it should never serve.
-        if let catalog = loopConfig.catalog {
-            let catalogIDs = Set(catalog.models.map(\.id))
-            guard catalogIDs.contains(modelId) else {
-                desiredSwapDrop.removeValue(forKey: modelId)
-                logger.error("Prefetch verified \(modelId) but it is not in the coordinator catalog; not advertising")
-                return
-            }
-        }
+        // Note: we intentionally do NOT re-check the startup catalog here.
+        // `CatalogModelPrefetcher` already resolves desired builds against the
+        // live coordinator catalog before downloading, and the coordinator's
+        // `models_update` gate is the authoritative backstop. Gating on a stale
+        // startup snapshot would break live alias repoints / new build rollouts
+        // that happen while the provider is already connected.
 
         // Compute ModelInfo + weight hash off-actor (CPU/IO heavy for big
         // builds). The prefetcher already aggregate-verified the snapshot, so

--- a/provider-swift/Sources/darkbloom/AutoUpdateCommand.swift
+++ b/provider-swift/Sources/darkbloom/AutoUpdateCommand.swift
@@ -24,7 +24,7 @@ struct AutoUpdate: AsyncParsableCommand {
     var action: String
 
     mutating func run() async throws {
-        let snapshot = try loadRuntimeSnapshot(configOptions: configOptions)
+        let snapshot = try await loadRuntimeSnapshot(configOptions: configOptions)
         let path = snapshot.configPath
 
         switch action.lowercased() {

--- a/provider-swift/Sources/darkbloom/BenchmarkCommand.swift
+++ b/provider-swift/Sources/darkbloom/BenchmarkCommand.swift
@@ -51,14 +51,14 @@ struct Benchmark: AsyncParsableCommand {
             throw ExitCode.failure
         }
 
-        let snapshot = try loadRuntimeSnapshot(configOptions: configOptions)
+        let snapshot = try await loadRuntimeSnapshot(configOptions: configOptions)
 
         guard let hardware = snapshot.hardware else {
             printError("hardware detection failed: \(snapshot.hardwareError?.localizedDescription ?? "unknown")")
             throw ExitCode.failure
         }
 
-        let models = advertisedModels(from: snapshot.models, config: snapshot.config)
+        let models = advertisedModels(from: snapshot.models, config: snapshot.config, catalog: snapshot.catalog)
 
         guard let selectedModel = ModelBenchmark.selectModel(
             models: models,

--- a/provider-swift/Sources/darkbloom/BenchmarkCommand.swift
+++ b/provider-swift/Sources/darkbloom/BenchmarkCommand.swift
@@ -58,7 +58,15 @@ struct Benchmark: AsyncParsableCommand {
             throw ExitCode.failure
         }
 
-        let models = advertisedModels(from: snapshot.models, config: snapshot.config, catalog: snapshot.catalog)
+        // Benchmarking is a local operation: if a coordinator catalog is
+        // available, filter to supported models; otherwise fall back to the
+        // local scan so offline performance experiments still work.
+        let models: [ModelInfo]
+        if snapshot.catalog != nil {
+            models = advertisedModels(from: snapshot.models, config: snapshot.config, catalog: snapshot.catalog)
+        } else {
+            models = localAdvertisedModels(from: snapshot.models, config: snapshot.config)
+        }
 
         guard let selectedModel = ModelBenchmark.selectModel(
             models: models,

--- a/provider-swift/Sources/darkbloom/Darkbloom.swift
+++ b/provider-swift/Sources/darkbloom/Darkbloom.swift
@@ -107,12 +107,12 @@ struct RuntimeSnapshot {
     let catalog: CatalogSnapshot?
 }
 
-func loadRuntimeSnapshot(configOptions: ConfigOptions) async throws -> RuntimeSnapshot {
+func loadRuntimeSnapshot(configOptions: ConfigOptions, coordinatorURLOverride: String? = nil) async throws -> RuntimeSnapshot {
     Darkbloom.ensureLogging()
-    return try await loadRuntimeSnapshot(configPath: configOptions.config)
+    return try await loadRuntimeSnapshot(configPath: configOptions.config, coordinatorURLOverride: coordinatorURLOverride)
 }
 
-func loadRuntimeSnapshot(configPath rawPath: String?) async throws -> RuntimeSnapshot {
+func loadRuntimeSnapshot(configPath rawPath: String?, coordinatorURLOverride: String? = nil) async throws -> RuntimeSnapshot {
     let configPath = try resolveConfigPath(rawPath)
     let configFileExists = FileManager.default.fileExists(atPath: configPath.path)
 
@@ -130,9 +130,12 @@ func loadRuntimeSnapshot(configPath rawPath: String?) async throws -> RuntimeSna
 
     let models = hardware.map { ModelScanner.scanModels(hardwareInfo: $0) } ?? []
 
-    // Fetch the coordinator catalog. A cached snapshot is used as a fallback
-    // so offline commands can still distinguish supported models.
-    let catalog = try? await fetchCatalogSnapshot(coordinatorURL: config.coordinator.url)
+    // Fetch the coordinator catalog. Use the CLI-provided override if present
+    // so `--coordinator-url` changes the catalog source as well as the connect
+    // target. A cached snapshot is used as a fallback so offline commands can
+    // still distinguish supported models.
+    let catalogURL = coordinatorURLOverride ?? config.coordinator.url
+    let catalog = await fetchCatalogSnapshot(coordinatorURL: catalogURL)
 
     return RuntimeSnapshot(
         configPath: configPath,
@@ -336,6 +339,28 @@ func advertisedModels(
     }
     let enabled = Set(config.backend.enabledModels)
     return supported.filter { enabled.contains($0.id) }
+}
+
+/// Local/direct-mode variant of `advertisedModels` that bypasses the
+/// coordinator catalog. Used when `--local` is requested and the catalog is
+/// unavailable (offline/airgapped), so the user can still serve downloaded
+/// weights. `enabledModels` and explicit `--model` / `--all` flags are still
+/// honored.
+func localAdvertisedModels(
+    from models: [ModelInfo],
+    config: ProviderConfig,
+    modelOverrides: [String] = [],
+    includeDisabled: Bool = false
+) -> [ModelInfo] {
+    if !modelOverrides.isEmpty {
+        let byID = Dictionary(uniqueKeysWithValues: models.map { ($0.id, $0) })
+        return modelOverrides.compactMap { byID[$0] }
+    }
+    guard !includeDisabled, !config.backend.enabledModels.isEmpty else {
+        return models
+    }
+    let enabled = Set(config.backend.enabledModels)
+    return models.filter { enabled.contains($0.id) }
 }
 
 func attachWeightHashes(to models: [ModelInfo]) -> (

--- a/provider-swift/Sources/darkbloom/Darkbloom.swift
+++ b/provider-swift/Sources/darkbloom/Darkbloom.swift
@@ -76,9 +76,10 @@ public func runUpdateBannerIfEnabled() async {
     // wrapper is uninitialized outside ArgumentParser's decoding lifecycle
     // and accessing it causes a fatal error. Pass nil to use defaults.
     let coordinatorURL: String
-    if let snapshot = try? loadRuntimeSnapshot(configPath: nil) {
-        coordinatorURL = snapshot.config.coordinator.url
-    } else {
+    do {
+        let config = try loadProviderConfig(configPath: nil)
+        coordinatorURL = config.coordinator.url
+    } catch {
         coordinatorURL = "https://api.darkbloom.dev"
     }
     await UpdateBanner.run(coordinatorURL: coordinatorURL)
@@ -100,16 +101,22 @@ struct RuntimeSnapshot {
     let hardware: HardwareInfo?
     let hardwareError: Error?
     let models: [ModelInfo]
+    /// Coordinator catalog fetched at load time. `nil` means the catalog could
+    /// not be fetched and no cached catalog was available; callers should treat
+    /// it as an empty catalog (fail closed) and warn the operator.
+    let catalog: CatalogSnapshot?
 }
 
-func loadRuntimeSnapshot(configOptions: ConfigOptions) throws -> RuntimeSnapshot {
+func loadRuntimeSnapshot(configOptions: ConfigOptions) async throws -> RuntimeSnapshot {
     Darkbloom.ensureLogging()
-    return try loadRuntimeSnapshot(configPath: configOptions.config)
+    return try await loadRuntimeSnapshot(configPath: configOptions.config)
 }
 
-func loadRuntimeSnapshot(configPath rawPath: String?) throws -> RuntimeSnapshot {
+func loadRuntimeSnapshot(configPath rawPath: String?) async throws -> RuntimeSnapshot {
     let configPath = try resolveConfigPath(rawPath)
     let configFileExists = FileManager.default.fileExists(atPath: configPath.path)
+
+    let config = try loadProviderConfig(configPath: configPath, configFileExists: configFileExists)
 
     let hardware: HardwareInfo?
     let hardwareError: Error?
@@ -119,6 +126,39 @@ func loadRuntimeSnapshot(configPath rawPath: String?) throws -> RuntimeSnapshot 
     } catch {
         hardware = nil
         hardwareError = error
+    }
+
+    let models = hardware.map { ModelScanner.scanModels(hardwareInfo: $0) } ?? []
+
+    // Fetch the coordinator catalog. A cached snapshot is used as a fallback
+    // so offline commands can still distinguish supported models.
+    let catalog = try? await fetchCatalogSnapshot(coordinatorURL: config.coordinator.url)
+
+    return RuntimeSnapshot(
+        configPath: configPath,
+        configFileExists: configFileExists,
+        config: config,
+        hardware: hardware,
+        hardwareError: hardwareError,
+        models: models,
+        catalog: catalog
+    )
+}
+
+/// Load just the provider config, without scanning models or fetching the
+/// coordinator catalog. Useful for commands that only need the coordinator URL.
+func loadProviderConfig(configPath rawPath: String?) throws -> ProviderConfig {
+    let configPath = try resolveConfigPath(rawPath)
+    let configFileExists = FileManager.default.fileExists(atPath: configPath.path)
+    return try loadProviderConfig(configPath: configPath, configFileExists: configFileExists)
+}
+
+private func loadProviderConfig(configPath: URL, configFileExists: Bool) throws -> ProviderConfig {
+    let hardware: HardwareInfo?
+    do {
+        hardware = try HardwareDetector.detect()
+    } catch {
+        hardware = nil
     }
 
     var config: ProviderConfig
@@ -132,17 +172,20 @@ func loadRuntimeSnapshot(configPath rawPath: String?) throws -> RuntimeSnapshot 
 
     // Auto-migrate stale config values (idempotent, best-effort).
     config = migrateConfigIfNeeded(configPath: configPath, config: config)
+    return config
+}
 
-    let models = hardware.map { ModelScanner.scanModels(hardwareInfo: $0) } ?? []
-
-    return RuntimeSnapshot(
-        configPath: configPath,
-        configFileExists: configFileExists,
-        config: config,
-        hardware: hardware,
-        hardwareError: hardwareError,
-        models: models
-    )
+private func fetchCatalogSnapshot(coordinatorURL: String) async -> CatalogSnapshot? {
+    let client = ModelCatalogClient(coordinatorURL: coordinatorURL)
+    do {
+        let snapshot = try await client.fetchCatalogSnapshot(includeAliases: true)
+        CatalogCache.write(snapshot)
+        return snapshot
+    } catch {
+        // Fall back to the on-disk cache so offline/briefly-unreachable
+        // commands still see the last known catalog.
+        return CatalogCache.read()
+    }
 }
 
 private func resolveConfigPath(_ rawPath: String?) throws -> URL {
@@ -263,21 +306,36 @@ func describeConfigPath(_ snapshot: RuntimeSnapshot) -> String {
     return "\(snapshot.configPath.path) (missing, using defaults)"
 }
 
+/// Filter local models to those present in the coordinator catalog.
+/// Non-catalog weights are invisible to the network and should not be
+/// advertised, served, or diagnosed. If the catalog is unavailable, fail
+/// closed and return an empty list.
+func catalogFilteredModels(
+    _ models: [ModelInfo],
+    catalog: CatalogSnapshot?
+) -> [ModelInfo] {
+    guard let catalog else { return [] }
+    let allowed = Set(catalog.models.map(\.id))
+    return models.filter { allowed.contains($0.id) }
+}
+
 func advertisedModels(
     from models: [ModelInfo],
     config: ProviderConfig,
+    catalog: CatalogSnapshot?,
     modelOverrides: [String] = [],
     includeDisabled: Bool = false
 ) -> [ModelInfo] {
+    let supported = catalogFilteredModels(models, catalog: catalog)
     if !modelOverrides.isEmpty {
-        let byID = Dictionary(uniqueKeysWithValues: models.map { ($0.id, $0) })
+        let byID = Dictionary(uniqueKeysWithValues: supported.map { ($0.id, $0) })
         return modelOverrides.compactMap { byID[$0] }
     }
     guard !includeDisabled, !config.backend.enabledModels.isEmpty else {
-        return models
+        return supported
     }
     let enabled = Set(config.backend.enabledModels)
-    return models.filter { enabled.contains($0.id) }
+    return supported.filter { enabled.contains($0.id) }
 }
 
 func attachWeightHashes(to models: [ModelInfo]) -> (

--- a/provider-swift/Sources/darkbloom/Darkbloom.swift
+++ b/provider-swift/Sources/darkbloom/Darkbloom.swift
@@ -100,7 +100,13 @@ struct RuntimeSnapshot {
     let config: ProviderConfig
     let hardware: HardwareInfo?
     let hardwareError: Error?
+    /// Local models that fit in currently-available memory (the provider's
+    /// actual loadable set).
     let models: [ModelInfo]
+    /// All locally-discovered models, including those too large for current
+    /// available memory. Used by diagnostics so too-large supported models are
+    /// still flagged rather than silently skipped.
+    let allModels: [ModelInfo]
     /// Coordinator catalog fetched at load time. `nil` means the catalog could
     /// not be fetched and no cached catalog was available; callers should treat
     /// it as an empty catalog (fail closed) and warn the operator.
@@ -128,7 +134,16 @@ func loadRuntimeSnapshot(configPath rawPath: String?, coordinatorURLOverride: St
         hardwareError = error
     }
 
-    let models = hardware.map { ModelScanner.scanModels(hardwareInfo: $0) } ?? []
+    // Scan both the loadable subset and the full unfiltered local set.
+    // Diagnostics need the unfiltered list so too-large supported models are
+    // still diagnosed rather than silently skipped.
+    let allModels = hardware.map { ModelScanner.scanAllModels(hardwareInfo: $0) } ?? []
+    let models: [ModelInfo]
+    if let hardware {
+        models = allModels.filter { $0.estimatedMemoryGb <= Double(hardware.memoryAvailableGb) }
+    } else {
+        models = []
+    }
 
     // Fetch the coordinator catalog. Use the CLI-provided override if present
     // so `--coordinator-url` changes the catalog source as well as the connect
@@ -144,6 +159,7 @@ func loadRuntimeSnapshot(configPath rawPath: String?, coordinatorURLOverride: St
         hardware: hardware,
         hardwareError: hardwareError,
         models: models,
+        allModels: allModels,
         catalog: catalog
     )
 }
@@ -180,14 +196,16 @@ private func loadProviderConfig(configPath: URL, configFileExists: Bool) throws 
 
 private func fetchCatalogSnapshot(coordinatorURL: String) async -> CatalogSnapshot? {
     let client = ModelCatalogClient(coordinatorURL: coordinatorURL)
+    let cachePath = CatalogCache.path(for: coordinatorURL)
     do {
         let snapshot = try await client.fetchCatalogSnapshot(includeAliases: true)
-        CatalogCache.write(snapshot)
+        CatalogCache.write(snapshot, to: cachePath)
         return snapshot
     } catch {
-        // Fall back to the on-disk cache so offline/briefly-unreachable
-        // commands still see the last known catalog.
-        return CatalogCache.read()
+        // Fall back to the on-disk cache scoped to this coordinator so
+        // switching between prod/staging/self-hosted coordinators does not
+        // cross-pollute offline fallback state.
+        return CatalogCache.read(from: cachePath)
     }
 }
 
@@ -339,6 +357,26 @@ func advertisedModels(
     }
     let enabled = Set(config.backend.enabledModels)
     return supported.filter { enabled.contains($0.id) }
+}
+
+/// Returns the set of model IDs that are allowed by the coordinator catalog,
+/// including active catalog models and any previous/retired members of active
+/// aliases. Providers offline through an alias rollout may only have those
+/// lineage builds locally; keeping them in the allowed set lets the foreground
+/// filter preserve stale plist `--model` flags and lets the coordinator push a
+/// `desired_models` update after registration.
+func catalogAllowedIDs(catalog: CatalogSnapshot?) -> Set<String> {
+    guard let catalog else { return [] }
+    var ids = Set(catalog.models.map(\.id))
+    for alias in catalog.aliases {
+        if let previous = alias.previousBuild {
+            ids.insert(previous)
+        }
+        for retired in alias.retiredBuilds ?? [] {
+            ids.insert(retired)
+        }
+    }
+    return ids
 }
 
 /// Local/direct-mode variant of `advertisedModels` that bypasses the

--- a/provider-swift/Sources/darkbloom/Diagnostics/DoctorRunner.swift
+++ b/provider-swift/Sources/darkbloom/Diagnostics/DoctorRunner.swift
@@ -97,9 +97,13 @@ enum DoctorRunner {
                 gpuActiveGb: gpuActiveGb,
                 gpuCacheGb: gpuCacheGb)
 
-            // Diagnose only models the coordinator currently advertises. Local
-            // weights that are not in the catalog are never served.
-            let supportedModels = catalogFilteredModels(snapshot.models, catalog: snapshot.catalog)
+            // Diagnose from the unfiltered local scan so too-large supported
+            // models are still flagged. Apply the catalog filter only after
+            // selecting candidates, so weights not in the catalog are never
+            // promoted as targets but supported-yet-oversized models are still
+            // reported.
+            let localModels = snapshot.allModels
+            let supportedModels = catalogFilteredModels(localModels, catalog: snapshot.catalog)
             let alternatives = supportedModels.map {
                 ModelFitDiagnostic.ModelOption(id: $0.id, weightGb: $0.estimatedMemoryGb)
             }
@@ -123,7 +127,7 @@ enum DoctorRunner {
                 return alternatives.max(by: { $0.weightGb < $1.weightGb })?.id
             }()
 
-            if let targetID, let target = supportedModels.first(where: { $0.id == targetID }) {
+            if let targetID, let target = localModels.first(where: { $0.id == targetID }) {
                 out.append(ModelFitDiagnostic.diagnose(
                     modelID: targetID, weightGb: target.estimatedMemoryGb,
                     usableGb: usableGb, alternatives: alternatives))

--- a/provider-swift/Sources/darkbloom/Diagnostics/DoctorRunner.swift
+++ b/provider-swift/Sources/darkbloom/Diagnostics/DoctorRunner.swift
@@ -74,7 +74,11 @@ enum DoctorRunner {
         }
 
         // ---- Traffic readiness: does the assigned/configured model fit RAM? ----
-        if let hw = snapshot.hardware {
+        if snapshot.catalog == nil {
+            out.append(Diagnostic(section: .traffic, name: "model catalog", level: .warn,
+                                  message: "could not fetch the coordinator model catalog; traffic readiness check skipped.",
+                                  fix: "check connectivity to the coordinator and re-run."))
+        } else if let hw = snapshot.hardware {
             // Mirror the provider's REAL load gate via ModelFitDiagnostic →
             // ModelLoadAdmission: clamp to live OS-available memory and subtract
             // the OS reserve + resident MLX memory, not raw total−reserve —
@@ -93,32 +97,36 @@ enum DoctorRunner {
                 gpuActiveGb: gpuActiveGb,
                 gpuCacheGb: gpuCacheGb)
 
-            // Prefer the live loaded model ONLY when the daemon is up and fresh;
-            // otherwise diagnose the CONFIGURED model. A stale state file (daemon
-            // stopped/crashed, then provider.toml changed to a larger model)
-            // would otherwise check last session's model and miss the new misfit.
-            let liveModel = stateFresh ? state?.currentModel : nil
-            let targetID = liveModel ?? snapshot.config.backend.model ?? snapshot.config.backend.enabledModels.first
-
-            // Use the UNFILTERED model list: ModelScanner.scanModels drops models
-            // too large for this box, so a too-large CONFIGURED model would be
-            // absent and doctor would silently diagnose a different (fitting) one
-            // instead of flagging the one that will never load.
-            let allModels = ModelScanner.scanAllModels(hardwareInfo: hw)
-            let alternatives = allModels.map {
+            // Diagnose only models the coordinator currently advertises. Local
+            // weights that are not in the catalog are never served.
+            let supportedModels = catalogFilteredModels(snapshot.models, catalog: snapshot.catalog)
+            let alternatives = supportedModels.map {
                 ModelFitDiagnostic.ModelOption(id: $0.id, weightGb: $0.estimatedMemoryGb)
             }
-            if let targetID, let target = allModels.first(where: { $0.id == targetID }) {
+
+            // Target precedence: live loaded model → configured model → first
+            // enabled model → largest catalog-filtered local model. All targets
+            // must be in the current coordinator catalog.
+            let targetID: String? = {
+                if stateFresh, let current = state?.currentModel,
+                   supportedModels.contains(where: { $0.id == current }) {
+                    return current
+                }
+                if let configured = snapshot.config.backend.model,
+                   supportedModels.contains(where: { $0.id == configured }) {
+                    return configured
+                }
+                if let firstEnabled = snapshot.config.backend.enabledModels.first,
+                   supportedModels.contains(where: { $0.id == firstEnabled }) {
+                    return firstEnabled
+                }
+                return alternatives.max(by: { $0.weightGb < $1.weightGb })?.id
+            }()
+
+            if let targetID, let target = supportedModels.first(where: { $0.id == targetID }) {
                 out.append(ModelFitDiagnostic.diagnose(
                     modelID: targetID, weightGb: target.estimatedMemoryGb,
                     usableGb: usableGb, alternatives: alternatives))
-            } else if !alternatives.isEmpty {
-                // No specific/known target; check the largest local model fits.
-                if let biggest = alternatives.max(by: { $0.weightGb < $1.weightGb }) {
-                    out.append(ModelFitDiagnostic.diagnose(
-                        modelID: biggest.id, weightGb: biggest.weightGb,
-                        usableGb: usableGb, alternatives: alternatives))
-                }
             }
         }
 

--- a/provider-swift/Sources/darkbloom/DoctorCommand.swift
+++ b/provider-swift/Sources/darkbloom/DoctorCommand.swift
@@ -22,7 +22,7 @@ struct Doctor: AsyncParsableCommand {
     mutating func run() async throws {
         await runUpdateBannerIfEnabled()
 
-        let snapshot = try loadRuntimeSnapshot(configOptions: configOptions)
+        let snapshot = try await loadRuntimeSnapshot(configOptions: configOptions)
         var checks = buildDoctorChecks(snapshot: snapshot)
         checks.append(contentsOf: await buildCoordinatorDoctorChecks(
             snapshot: snapshot,

--- a/provider-swift/Sources/darkbloom/DoctorCommand.swift
+++ b/provider-swift/Sources/darkbloom/DoctorCommand.swift
@@ -22,7 +22,13 @@ struct Doctor: AsyncParsableCommand {
     mutating func run() async throws {
         await runUpdateBannerIfEnabled()
 
-        let snapshot = try await loadRuntimeSnapshot(configOptions: configOptions)
+        // Pass the explicit --coordinator override into the snapshot loader so
+        // doctor fetches/caches the catalog from the same coordinator used for
+        // network diagnostics.
+        let snapshot = try await loadRuntimeSnapshot(
+            configOptions: configOptions,
+            coordinatorURLOverride: coordinator
+        )
         var checks = buildDoctorChecks(snapshot: snapshot)
         checks.append(contentsOf: await buildCoordinatorDoctorChecks(
             snapshot: snapshot,

--- a/provider-swift/Sources/darkbloom/EnrollCommand.swift
+++ b/provider-swift/Sources/darkbloom/EnrollCommand.swift
@@ -26,9 +26,9 @@ struct Enroll: AsyncParsableCommand {
     var noOpen = false
 
     mutating func run() async throws {
-        let snapshot = try loadRuntimeSnapshot(configOptions: configOptions)
+        let config = try loadProviderConfig(configPath: configOptions.config)
         let coordinatorURL = coordinator
-            ?? snapshot.config.coordinator.url
+            ?? config.coordinator.url
         let httpBase = coordinatorHTTPBase(coordinatorURL)
 
         print("Darkbloom Device Attestation Enrollment")

--- a/provider-swift/Sources/darkbloom/LoginCommand.swift
+++ b/provider-swift/Sources/darkbloom/LoginCommand.swift
@@ -16,7 +16,7 @@ struct Login: AsyncParsableCommand {
     @OptionGroup var configOptions: ConfigOptions
 
     mutating func run() async throws {
-        let snapshot = try loadRuntimeSnapshot(configOptions: configOptions)
+        let snapshot = try await loadRuntimeSnapshot(configOptions: configOptions)
         let coordinatorURL = snapshot.config.coordinator.url
 
         do {

--- a/provider-swift/Sources/darkbloom/ModelsCommand.swift
+++ b/provider-swift/Sources/darkbloom/ModelsCommand.swift
@@ -54,10 +54,11 @@ extension Models {
                 return
             }
 
-            let snapshot = try loadRuntimeSnapshot(configOptions: configOptions)
+            let snapshot = try await loadRuntimeSnapshot(configOptions: configOptions)
             let models = advertisedModels(
                 from: snapshot.models,
                 config: snapshot.config,
+                catalog: snapshot.catalog,
                 includeDisabled: all
             )
 
@@ -105,7 +106,7 @@ extension Models {
         var type: String?
 
         mutating func run() async throws {
-            let snapshot = try loadRuntimeSnapshot(configOptions: configOptions)
+            let snapshot = try await loadRuntimeSnapshot(configOptions: configOptions)
             let coordinatorURL = coordinator ?? snapshot.config.coordinator.url
             let client = ModelCatalogClient(coordinatorURL: coordinatorURL)
 
@@ -124,9 +125,8 @@ extension Models {
 
             // UNFILTERED on-disk scan: a downloaded model that exceeds available
             // RAM is still on disk, so it must show the "downloaded" checkmark
-            // (and appear under "Local only" when off-catalog) rather than reading
-            // as not-downloaded on a marginal-RAM box. The memory filter only
-            // governs loadability, not presence.
+            // rather than reading as not-downloaded on a marginal-RAM box. The
+            // memory filter only governs loadability, not presence.
             let localModels: [ModelInfo]
             if let hardware = snapshot.hardware {
                 localModels = ModelScanner.scanAllModels(hardwareInfo: hardware)
@@ -150,18 +150,11 @@ extension Models {
                 }
             }
 
-            // -- Local-only models (downloaded but not in current catalog) --
-            let localOnly = localModels.filter { !catalogIDs.contains($0.id) }
-            if !localOnly.isEmpty {
+            // -- Downloaded models not in the supported catalog --
+            let offCatalog = localModels.filter { !catalogIDs.contains($0.id) }
+            if !offCatalog.isEmpty {
                 print()
-                print("Local only (not in current catalog)")
-                print()
-                for m in localOnly {
-                    print("  \(m.id)  \(String(format: "%.1f", m.estimatedMemoryGb)) GB")
-                }
-                print()
-                print("  These models are no longer served by the network.")
-                print("  Remove with: darkbloom models remove <id>")
+                print("  \(offCatalog.count) downloaded model\(offCatalog.count == 1 ? "" : "s") \(offCatalog.count == 1 ? "is" : "are") not in the supported catalog and will not be served.")
             }
         }
     }
@@ -187,7 +180,7 @@ extension Models {
         var r2CDN: String?
 
         mutating func run() async throws {
-            let snapshot = try loadRuntimeSnapshot(configOptions: configOptions)
+            let snapshot = try await loadRuntimeSnapshot(configOptions: configOptions)
             let coordinatorURL = coordinator ?? snapshot.config.coordinator.url
             let client = ModelCatalogClient(coordinatorURL: coordinatorURL)
 

--- a/provider-swift/Sources/darkbloom/ModelsCommand.swift
+++ b/provider-swift/Sources/darkbloom/ModelsCommand.swift
@@ -55,12 +55,24 @@ extension Models {
             }
 
             let snapshot = try await loadRuntimeSnapshot(configOptions: configOptions)
-            let models = advertisedModels(
-                from: snapshot.models,
-                config: snapshot.config,
-                catalog: snapshot.catalog,
-                includeDisabled: all
-            )
+            // `--all` inventories every discovered local weight, bypassing both
+            // the coordinator catalog and the config enabled_models filter so
+            // operators can see (and remove) unsupported downloads.
+            let models: [ModelInfo]
+            if all {
+                models = localAdvertisedModels(
+                    from: snapshot.allModels,
+                    config: snapshot.config,
+                    includeDisabled: true
+                )
+            } else {
+                models = advertisedModels(
+                    from: snapshot.models,
+                    config: snapshot.config,
+                    catalog: snapshot.catalog,
+                    includeDisabled: false
+                )
+            }
 
             if json {
                 let payload = ModelsOutput(

--- a/provider-swift/Sources/darkbloom/ReportCommand.swift
+++ b/provider-swift/Sources/darkbloom/ReportCommand.swift
@@ -27,7 +27,7 @@ struct Report: AsyncParsableCommand {
     mutating func run() async throws {
         await runUpdateBannerIfEnabled()
 
-        let snapshot = try loadRuntimeSnapshot(configOptions: configOptions)
+        let snapshot = try await loadRuntimeSnapshot(configOptions: configOptions)
         let coordinatorURL = snapshot.config.coordinator.url
         let httpBase = coordinatorHTTPBase(coordinatorURL)
 

--- a/provider-swift/Sources/darkbloom/StartCommand.swift
+++ b/provider-swift/Sources/darkbloom/StartCommand.swift
@@ -566,9 +566,29 @@ struct Start: AsyncParsableCommand {
         let selectedModelIDs: [String]
 
         if !model.isEmpty {
+            // Fail up-front on explicit user selections that are not supported.
+            // The daemon's foreground path also filters stale plist flags, but
+            // validating here prevents installing a launchd plist that is
+            // guaranteed to exit on every relaunch.
+            try validateModelSelections(against: snapshot.catalog, localModels: snapshot.models)
             selectedModelIDs = model
         } else if all {
-            selectedModelIDs = snapshot.models.map(\.id)
+            guard snapshot.catalog != nil else {
+                printError("Cannot use --all: coordinator model catalog is unavailable.")
+                printError("hint: check your network connection and coordinator URL, or retry after the coordinator is reachable.")
+                throw ExitCode.failure
+            }
+            let advertised = advertisedModels(
+                from: snapshot.models,
+                config: config,
+                catalog: snapshot.catalog,
+                includeDisabled: true
+            )
+            guard !advertised.isEmpty else {
+                printError("No supported models selected.")
+                throw ExitCode.failure
+            }
+            selectedModelIDs = advertised.map(\.id)
         } else {
             selectedModelIDs = try await interactiveCatalogPicker(
                 snapshot: snapshot,

--- a/provider-swift/Sources/darkbloom/StartCommand.swift
+++ b/provider-swift/Sources/darkbloom/StartCommand.swift
@@ -84,7 +84,10 @@ struct Start: AsyncParsableCommand {
             throw ExitCode.failure
         }
 
-        let snapshot = try await loadRuntimeSnapshot(configOptions: configOptions)
+        // Pass the explicit --coordinator-url override (if any) into the
+        // snapshot loader so the catalog is fetched from the same coordinator
+        // the daemon will connect to.
+        let snapshot = try await loadRuntimeSnapshot(configOptions: configOptions, coordinatorURLOverride: coordinatorURL)
         let effectiveCoordinator = coordinatorURL ?? snapshot.config.coordinator.url
         var effectiveConfig = snapshot.config
         if let idleTimeout {
@@ -125,20 +128,32 @@ struct Start: AsyncParsableCommand {
         config: ProviderConfig,
         hardware: HardwareInfo
     ) async throws {
-        guard snapshot.catalog != nil else {
-            printError("Cannot start: coordinator model catalog is unavailable.")
-            printError("hint: check your network connection and coordinator URL, or retry after the coordinator is reachable.")
-            throw ExitCode.failure
+        // `--local` is coordinator-less by design. If we have a catalog, filter
+        // against it (same behavior as daemon mode). If the catalog is
+        // unavailable, fall back to local model selection so airgapped/trusted
+        // use is still possible.
+        let catalog = snapshot.catalog
+        if catalog != nil {
+            try validateModelSelections(against: catalog, localModels: snapshot.models)
         }
-        try validateModelSelections(against: snapshot.catalog, localModels: snapshot.models)
 
-        let advertised = advertisedModels(
-            from: snapshot.models,
-            config: config,
-            catalog: snapshot.catalog,
-            modelOverrides: model,
-            includeDisabled: all
-        )
+        let advertised: [ModelInfo]
+        if let catalog {
+            advertised = advertisedModels(
+                from: snapshot.models,
+                config: config,
+                catalog: catalog,
+                modelOverrides: model,
+                includeDisabled: all
+            )
+        } else {
+            advertised = localAdvertisedModels(
+                from: snapshot.models,
+                config: config,
+                modelOverrides: model,
+                includeDisabled: all
+            )
+        }
 
         guard !advertised.isEmpty else {
             printError("No supported models selected.")
@@ -246,8 +261,17 @@ struct Start: AsyncParsableCommand {
         let effectiveOverrides = catalogFilteredOverrides(model, catalog: snapshot.catalog)
 
         let selectedModels: [ModelInfo]
-        if !effectiveOverrides.isEmpty {
-            selectedModels = advertisedModels(from: snapshot.models, config: config, catalog: snapshot.catalog, modelOverrides: effectiveOverrides)
+        let hadExplicitOverrides = !model.isEmpty
+        if hadExplicitOverrides {
+            // If the operator explicitly pinned models, keep that intent: an
+            // empty filtered override set means none of the pinned models are
+            // supported, so advertise nothing rather than falling through to
+            // --all or the default enabled set.
+            if effectiveOverrides.isEmpty {
+                selectedModels = []
+            } else {
+                selectedModels = advertisedModels(from: snapshot.models, config: config, catalog: snapshot.catalog, modelOverrides: effectiveOverrides)
+            }
         } else if all {
             selectedModels = catalogFilteredModels(snapshot.models, catalog: snapshot.catalog)
         } else {
@@ -352,8 +376,7 @@ struct Start: AsyncParsableCommand {
             runtimeHashes: runtimeHashes,
             modelHashes: modelHashes,
             modelHashFingerprints: modelHashFingerprints,
-            localEndpoint: localEndpointConfig,
-            catalog: snapshot.catalog
+            localEndpoint: localEndpointConfig
         )
 
         do {

--- a/provider-swift/Sources/darkbloom/StartCommand.swift
+++ b/provider-swift/Sources/darkbloom/StartCommand.swift
@@ -84,7 +84,7 @@ struct Start: AsyncParsableCommand {
             throw ExitCode.failure
         }
 
-        let snapshot = try loadRuntimeSnapshot(configOptions: configOptions)
+        let snapshot = try await loadRuntimeSnapshot(configOptions: configOptions)
         let effectiveCoordinator = coordinatorURL ?? snapshot.config.coordinator.url
         var effectiveConfig = snapshot.config
         if let idleTimeout {
@@ -125,12 +125,25 @@ struct Start: AsyncParsableCommand {
         config: ProviderConfig,
         hardware: HardwareInfo
     ) async throws {
+        guard snapshot.catalog != nil else {
+            printError("Cannot start: coordinator model catalog is unavailable.")
+            printError("hint: check your network connection and coordinator URL, or retry after the coordinator is reachable.")
+            throw ExitCode.failure
+        }
+        try validateModelSelections(against: snapshot.catalog, localModels: snapshot.models)
+
         let advertised = advertisedModels(
             from: snapshot.models,
             config: config,
+            catalog: snapshot.catalog,
             modelOverrides: model,
             includeDisabled: all
         )
+
+        guard !advertised.isEmpty else {
+            printError("No supported models selected.")
+            throw ExitCode.failure
+        }
 
         // Direct/local mode: mint (or reuse) a bearer token so the loopback
         // server isn't open to every local process / hostile webpage. --no-auth
@@ -222,17 +235,27 @@ struct Start: AsyncParsableCommand {
         config: ProviderConfig,
         coordinatorURL: String
     ) async throws {
+        guard snapshot.catalog != nil else {
+            printError("Cannot start: coordinator model catalog is unavailable.")
+            printError("hint: check your network connection and coordinator URL, or retry after the coordinator is reachable.")
+            throw ExitCode.failure
+        }
+
+        // The launchd plist may contain stale --model flags from before a model
+        // was retired. Filter them to catalog IDs rather than failing to start.
+        let effectiveOverrides = catalogFilteredOverrides(model, catalog: snapshot.catalog)
+
         let selectedModels: [ModelInfo]
-        if !model.isEmpty {
-            selectedModels = advertisedModels(from: snapshot.models, config: config, modelOverrides: model)
+        if !effectiveOverrides.isEmpty {
+            selectedModels = advertisedModels(from: snapshot.models, config: config, catalog: snapshot.catalog, modelOverrides: effectiveOverrides)
         } else if all {
-            selectedModels = snapshot.models
+            selectedModels = catalogFilteredModels(snapshot.models, catalog: snapshot.catalog)
         } else {
-            selectedModels = advertisedModels(from: snapshot.models, config: config)
+            selectedModels = advertisedModels(from: snapshot.models, config: config, catalog: snapshot.catalog)
         }
 
         guard !selectedModels.isEmpty else {
-            printError("No models selected.")
+            printError("No supported models selected.")
             throw ExitCode.failure
         }
 
@@ -329,7 +352,8 @@ struct Start: AsyncParsableCommand {
             runtimeHashes: runtimeHashes,
             modelHashes: modelHashes,
             modelHashFingerprints: modelHashFingerprints,
-            localEndpoint: localEndpointConfig
+            localEndpoint: localEndpointConfig,
+            catalog: snapshot.catalog
         )
 
         do {
@@ -1128,5 +1152,41 @@ struct Start: AsyncParsableCommand {
 
             lastLineCount = render(pos: cursorPos, sel: selected, prevLines: lastLineCount)
         }
+    }
+
+    // MARK: - Catalog validation
+
+    /// Reject `--model` selections that are not in the coordinator catalog.
+    /// Used for explicit user invocations (`--local`); the foreground launchd
+    /// path uses `catalogFilteredOverrides` so a stale plist does not kill the
+    /// daemon on every restart.
+    private func validateModelSelections(against catalog: CatalogSnapshot?, localModels: [ModelInfo]) throws {
+        guard !model.isEmpty else { return }
+        guard let catalog else {
+            throw ValidationError("Cannot validate --model selections: coordinator catalog is unavailable.")
+        }
+        let catalogIDs = Set(catalog.models.map(\.id))
+        for id in model {
+            guard catalogIDs.contains(id) else {
+                throw ValidationError("'\(id)' is not in the coordinator model catalog; only supported models can be served.")
+            }
+        }
+    }
+
+    /// Filter `--model` overrides to catalog-known IDs, warning about any
+    /// stale/non-catalog IDs. Returns the original array when the catalog is
+    /// unavailable so the caller's existing "no models" guard still fires.
+    private func catalogFilteredOverrides(_ overrides: [String], catalog: CatalogSnapshot?) -> [String] {
+        guard let catalog else { return overrides }
+        let catalogIDs = Set(catalog.models.map(\.id))
+        var kept: [String] = []
+        for id in overrides {
+            if catalogIDs.contains(id) {
+                kept.append(id)
+            } else {
+                printError("Ignoring --model '\(id)': not in the coordinator model catalog.")
+            }
+        }
+        return kept
     }
 }

--- a/provider-swift/Sources/darkbloom/StartCommand.swift
+++ b/provider-swift/Sources/darkbloom/StartCommand.swift
@@ -1179,32 +1179,34 @@ struct Start: AsyncParsableCommand {
 
     // MARK: - Catalog validation
 
-    /// Reject `--model` selections that are not in the coordinator catalog.
-    /// Used for explicit user invocations (`--local`); the foreground launchd
-    /// path uses `catalogFilteredOverrides` so a stale plist does not kill the
-    /// daemon on every restart.
+    /// Reject `--model` selections that are not allowed by the coordinator
+    /// catalog (including alias previous/retired lineage builds). Used for
+    /// explicit user invocations (`--local`); the foreground launchd path uses
+    /// `catalogFilteredOverrides` so a stale plist does not kill the daemon on
+    /// every restart.
     private func validateModelSelections(against catalog: CatalogSnapshot?, localModels: [ModelInfo]) throws {
         guard !model.isEmpty else { return }
-        guard let catalog else {
+        guard catalog != nil else {
             throw ValidationError("Cannot validate --model selections: coordinator catalog is unavailable.")
         }
-        let catalogIDs = Set(catalog.models.map(\.id))
+        let allowedIDs = catalogAllowedIDs(catalog: catalog)
         for id in model {
-            guard catalogIDs.contains(id) else {
+            guard allowedIDs.contains(id) else {
                 throw ValidationError("'\(id)' is not in the coordinator model catalog; only supported models can be served.")
             }
         }
     }
 
-    /// Filter `--model` overrides to catalog-known IDs, warning about any
-    /// stale/non-catalog IDs. Returns the original array when the catalog is
-    /// unavailable so the caller's existing "no models" guard still fires.
+    /// Filter `--model` overrides to catalog-known IDs (including alias
+    /// previous/retired lineage builds), warning about any stale/non-catalog
+    /// IDs. Returns the original array when the catalog is unavailable so the
+    /// caller's existing "no models" guard still fires.
     private func catalogFilteredOverrides(_ overrides: [String], catalog: CatalogSnapshot?) -> [String] {
-        guard let catalog else { return overrides }
-        let catalogIDs = Set(catalog.models.map(\.id))
+        guard catalog != nil else { return overrides }
+        let allowedIDs = catalogAllowedIDs(catalog: catalog)
         var kept: [String] = []
         for id in overrides {
-            if catalogIDs.contains(id) {
+            if allowedIDs.contains(id) {
                 kept.append(id)
             } else {
                 printError("Ignoring --model '\(id)': not in the coordinator model catalog.")

--- a/provider-swift/Sources/darkbloom/StatusCommand.swift
+++ b/provider-swift/Sources/darkbloom/StatusCommand.swift
@@ -14,9 +14,9 @@ struct Status: AsyncParsableCommand {
         // we dump current status. Bounded by a 2s timeout in UpdateBanner.
         await runUpdateBannerIfEnabled()
 
-        let snapshot = try loadRuntimeSnapshot(configOptions: configOptions)
+        let snapshot = try await loadRuntimeSnapshot(configOptions: configOptions)
         let config = snapshot.config
-        let models = advertisedModels(from: snapshot.models, config: config)
+        let models = advertisedModels(from: snapshot.models, config: config, catalog: snapshot.catalog)
 
         print("darkbloom \(ProviderCore.version)")
         print("Provider: \(config.provider.name)")

--- a/provider-swift/Sources/darkbloom/UpdateCommand.swift
+++ b/provider-swift/Sources/darkbloom/UpdateCommand.swift
@@ -18,8 +18,7 @@ struct Update: AsyncParsableCommand {
     mutating func run() async throws {
         let config: ProviderConfig
         do {
-            let snapshot = try loadRuntimeSnapshot(configOptions: configOptions)
-            config = snapshot.config
+            config = try loadProviderConfig(configPath: configOptions.config)
         } catch {
             config = ConfigManager.loadDefault()
         }

--- a/provider-swift/Sources/darkbloom/VerifyCommand.swift
+++ b/provider-swift/Sources/darkbloom/VerifyCommand.swift
@@ -15,7 +15,7 @@ struct Verify: AsyncParsableCommand {
     var coordinator: String?
 
     mutating func run() async throws {
-        let snapshot = try loadRuntimeSnapshot(configOptions: configOptions)
+        let snapshot = try await loadRuntimeSnapshot(configOptions: configOptions)
         var checks = buildDoctorChecks(snapshot: snapshot)
         checks.append(contentsOf: await buildCoordinatorDoctorChecks(
             snapshot: snapshot,

--- a/provider-swift/Tests/DarkbloomCLITests/CatalogFilterTests.swift
+++ b/provider-swift/Tests/DarkbloomCLITests/CatalogFilterTests.swift
@@ -102,4 +102,90 @@ import ProviderCore
         )
         #expect(advertised.map({ $0.id }) == ["supported"])
     }
+
+    @Test func localAdvertisedModels_bypassesCatalogFilter() {
+        let local = [
+            makeModel(id: "supported"),
+            makeModel(id: "unsupported")
+        ]
+        let config = ProviderConfig.defaultForHardware(HardwareInfo(
+            machineModel: "Mac16,1",
+            chipName: "Apple M1",
+            chipFamily: .m1,
+            chipTier: .base,
+            memoryGb: 16,
+            memoryAvailableGb: 12,
+            cpuCores: CpuCores(total: 8, performance: 4, efficiency: 4),
+            gpuCores: 8,
+            memoryBandwidthGbs: 50
+        ))
+
+        let advertised = localAdvertisedModels(from: local, config: config)
+        #expect(advertised.map({ $0.id }) == ["supported", "unsupported"])
+    }
+
+    @Test func localAdvertisedModels_honorsEnabledModels() {
+        let local = [
+            makeModel(id: "enabled"),
+            makeModel(id: "disabled")
+        ]
+        var config = ProviderConfig.defaultForHardware(HardwareInfo(
+            machineModel: "Mac16,1",
+            chipName: "Apple M1",
+            chipFamily: .m1,
+            chipTier: .base,
+            memoryGb: 16,
+            memoryAvailableGb: 12,
+            cpuCores: CpuCores(total: 8, performance: 4, efficiency: 4),
+            gpuCores: 8,
+            memoryBandwidthGbs: 50
+        ))
+        config.backend.enabledModels = ["enabled"]
+
+        let advertised = localAdvertisedModels(from: local, config: config)
+        #expect(advertised.map({ $0.id }) == ["enabled"])
+    }
+
+    @Test func localAdvertisedModels_honorsModelOverrides() {
+        let local = [
+            makeModel(id: "a"),
+            makeModel(id: "b")
+        ]
+        let config = ProviderConfig.defaultForHardware(HardwareInfo(
+            machineModel: "Mac16,1",
+            chipName: "Apple M1",
+            chipFamily: .m1,
+            chipTier: .base,
+            memoryGb: 16,
+            memoryAvailableGb: 12,
+            cpuCores: CpuCores(total: 8, performance: 4, efficiency: 4),
+            gpuCores: 8,
+            memoryBandwidthGbs: 50
+        ))
+
+        let advertised = localAdvertisedModels(from: local, config: config, modelOverrides: ["b"])
+        #expect(advertised.map({ $0.id }) == ["b"])
+    }
+
+    @Test func localAdvertisedModels_allFlagIgnoresEnabledList() {
+        let local = [
+            makeModel(id: "enabled"),
+            makeModel(id: "disabled")
+        ]
+        var config = ProviderConfig.defaultForHardware(HardwareInfo(
+            machineModel: "Mac16,1",
+            chipName: "Apple M1",
+            chipFamily: .m1,
+            chipTier: .base,
+            memoryGb: 16,
+            memoryAvailableGb: 12,
+            cpuCores: CpuCores(total: 8, performance: 4, efficiency: 4),
+            gpuCores: 8,
+            memoryBandwidthGbs: 50
+        ))
+        config.backend.enabledModels = ["enabled"]
+
+        let advertised = localAdvertisedModels(from: local, config: config, includeDisabled: true)
+        #expect(advertised.map({ $0.id }) == ["enabled", "disabled"])
+    }
 }

--- a/provider-swift/Tests/DarkbloomCLITests/CatalogFilterTests.swift
+++ b/provider-swift/Tests/DarkbloomCLITests/CatalogFilterTests.swift
@@ -1,0 +1,105 @@
+import Foundation
+import Testing
+import ProviderCore
+@testable import darkbloom
+
+/// Tests for the catalog-only model discovery gate: only coordinator-catalog
+/// models may be advertised, served, or diagnosed.
+@Suite struct CatalogFilterTests {
+    private func makeModel(id: String) -> ModelInfo {
+        ModelInfo(
+            id: id,
+            modelType: "text",
+            parameters: nil,
+            quantization: nil,
+            sizeBytes: 1_000_000,
+            estimatedMemoryGb: 1.0,
+            weightHash: nil,
+            isVision: nil,
+            templateRenderOK: nil
+        )
+    }
+
+    private func makeCatalog(ids: [String]) -> CatalogSnapshot {
+        CatalogSnapshot(models: ids.map { id in
+            CatalogModel(
+                id: id,
+                s3Name: id,
+                displayName: id,
+                modelType: "text",
+                sizeGb: 1.0
+            )
+        })
+    }
+
+    @Test func catalogFilteredModels_keepsCatalogModels() {
+        let local = [makeModel(id: "supported-a"), makeModel(id: "supported-b")]
+        let catalog = makeCatalog(ids: ["supported-a", "supported-b"])
+        let filtered = catalogFilteredModels(local, catalog: catalog)
+        #expect(filtered.map({ $0.id }) == ["supported-a", "supported-b"])
+    }
+
+    @Test func catalogFilteredModels_dropsNonCatalogModels() {
+        let local = [makeModel(id: "supported"), makeModel(id: "unsupported")]
+        let catalog = makeCatalog(ids: ["supported"])
+        let filtered = catalogFilteredModels(local, catalog: catalog)
+        #expect(filtered.map({ $0.id }) == ["supported"])
+    }
+
+    @Test func catalogFilteredModels_failsClosedWithoutCatalog() {
+        let local = [makeModel(id: "supported")]
+        let filtered = catalogFilteredModels(local, catalog: nil)
+        #expect(filtered.isEmpty)
+    }
+
+    @Test func advertisedModels_appliesCatalogFilterBeforeEnabledList() {
+        let local = [
+            makeModel(id: "supported-a"),
+            makeModel(id: "supported-b"),
+            makeModel(id: "unsupported")
+        ]
+        let catalog = makeCatalog(ids: ["supported-a", "supported-b"])
+        var config = ProviderConfig.defaultForHardware(HardwareInfo(
+            machineModel: "Mac16,1",
+            chipName: "Apple M1",
+            chipFamily: .m1,
+            chipTier: .base,
+            memoryGb: 16,
+            memoryAvailableGb: 12,
+            cpuCores: CpuCores(total: 8, performance: 4, efficiency: 4),
+            gpuCores: 8,
+            memoryBandwidthGbs: 50
+        ))
+        config.backend.enabledModels = ["supported-a"]
+
+        let advertised = advertisedModels(from: local, config: config, catalog: catalog)
+        #expect(advertised.map({ $0.id }) == ["supported-a"])
+    }
+
+    @Test func advertisedModels_modelOverridesAreFilteredByCatalog() {
+        let local = [
+            makeModel(id: "supported"),
+            makeModel(id: "unsupported")
+        ]
+        let catalog = makeCatalog(ids: ["supported"])
+        let config = ProviderConfig.defaultForHardware(HardwareInfo(
+            machineModel: "Mac16,1",
+            chipName: "Apple M1",
+            chipFamily: .m1,
+            chipTier: .base,
+            memoryGb: 16,
+            memoryAvailableGb: 12,
+            cpuCores: CpuCores(total: 8, performance: 4, efficiency: 4),
+            gpuCores: 8,
+            memoryBandwidthGbs: 50
+        ))
+
+        let advertised = advertisedModels(
+            from: local,
+            config: config,
+            catalog: catalog,
+            modelOverrides: ["supported", "unsupported"]
+        )
+        #expect(advertised.map({ $0.id }) == ["supported"])
+    }
+}

--- a/provider-swift/Tests/DarkbloomCLITests/CatalogFilterTests.swift
+++ b/provider-swift/Tests/DarkbloomCLITests/CatalogFilterTests.swift
@@ -188,4 +188,36 @@ import ProviderCore
         let advertised = localAdvertisedModels(from: local, config: config, includeDisabled: true)
         #expect(advertised.map({ $0.id }) == ["enabled", "disabled"])
     }
+
+    @Test func catalogAllowedIDs_includesModelsAndAliasLineage() {
+        let catalog = CatalogSnapshot(
+            models: [
+                CatalogModel(id: "active-a", s3Name: "active-a", displayName: "Active A", modelType: "text", sizeGb: 1.0),
+                CatalogModel(id: "active-b", s3Name: "active-b", displayName: "Active B", modelType: "text", sizeGb: 1.0)
+            ],
+            aliases: [
+                CatalogAlias(
+                    id: "alias-1",
+                    displayName: "Alias 1",
+                    desiredBuild: "active-a",
+                    previousBuild: "previous-build",
+                    retiredBuilds: ["retired-build"],
+                    primaryBuild: nil
+                )
+            ]
+        )
+        let allowed = catalogAllowedIDs(catalog: catalog)
+        #expect(allowed == Set(["active-a", "active-b", "previous-build", "retired-build"]))
+    }
+
+    @Test func catalogAllowedIDs_isEmptyWhenCatalogMissing() {
+        #expect(catalogAllowedIDs(catalog: nil).isEmpty)
+    }
+
+    @Test func catalogCachePath_scopesByCoordinatorURL() {
+        let prodPath = CatalogCache.path(for: "wss://api.darkbloom.dev/ws/provider")
+        let stagingPath = CatalogCache.path(for: "wss://api.staging.darkbloom.dev/ws/provider")
+        #expect(prodPath.lastPathComponent != stagingPath.lastPathComponent)
+        #expect(prodPath.deletingLastPathComponent() == CatalogCache.defaultDirectory())
+    }
 }


### PR DESCRIPTION
## Summary

Make the Darkbloom provider treat the coordinator model catalog as the single source of truth for which local weights can be discovered, advertised, served, or diagnosed. Non-catalog weights are invisible to the network and to the operator-facing CLI.

## Before / After

### Before: any local MLX weight directory could be advertised

```mermaid
sequenceDiagram
    participant U as Operator
    participant P as darkbloom provider
    participant C as Coordinator
    participant R as Registry/Scheduler

    U->>P: darkbloom start --all
    P->>P: scan ~/.cache/lm-studio/Models
    P->>P: scan ~/.lmstudio/models
    P->>C: register with every discovered model
    C->>R: expose unsupported IDs as available capacity
    R->>C: route consumer requests to unsupported weights
```

### After: only coordinator-catalog models are discovered or advertised

```mermaid
sequenceDiagram
    participant U as Operator
    participant P as darkbloom provider
    participant C as Coordinator
    participant R as Registry/Scheduler

    U->>P: darkbloom start --all
    P->>C: GET /v1/models/catalog
    C-->>P: supported model IDs
    P->>P: scan local directories
    P->>P: filter discovered models against catalog
    P->>C: register only catalog-matching models
    C->>R: expose only supported IDs as available capacity
    R->>C: route consumer requests to supported weights only
```

## Changes

### Provider (Swift)
- `loadRuntimeSnapshot` fetches `GET /v1/models/catalog` at startup and caches it to `~/.cache/darkbloom/catalog.json`. Offline commands fall back to the cache; if none exists, the catalog is treated as empty (fail closed).
- New `catalogFilteredModels()` and updated `advertisedModels()` filter every local model through the coordinator catalog before applying `enabled_models` or `--model`.
- `darkbloom start --all` now means "all downloaded models that are in the catalog."
- `darkbloom start --model <non-catalog-id>` fails with a clear error for explicit user invocations; the launchd `--foreground` path filters stale plist flags and logs warnings instead of refusing to start.
- `darkbloom doctor` diagnoses only catalog models and warns when the catalog cannot be fetched.
- `darkbloom models catalog` no longer shows a "Local only" section; off-catalog weights get a one-line "will not be served" note.
- `ProviderLoop.applyVerifiedPrefetch` refuses to advertise a prefetched build that is not in the catalog.
- `ProviderLoopConfig` carries the startup catalog snapshot.

### Coordinator (Go)
- Provider registration filters `msg.Models` to catalog-known IDs and logs any dropped non-catalog models as a defense-in-depth backstop.

### Tests & docs
- Added `CatalogFilterTests.swift` covering `catalogFilteredModels` and `advertisedModels`.
- Added `TestProviderRegistrationFiltersNonCatalogModels`.
- Updated `docs/provider/cli-reference.md` and `docs/provider/quickstart.md`.

## Verification

- `cd coordinator && go test ./... -count=1` ✅
- `cd provider-swift && swift build` ✅
- `cd provider-swift && swift test --filter "CLIDispatchTests|CatalogFilterTests|ModelPrefetchCoordinatorTests"` ✅
- Full `swift test` exits non-zero due to a pre-existing `MLX error: Failed to load the default metallib` crash in a live-model test, unrelated to these changes.

Closes the feedback where providers "actively try to use" models that the coordinator does not support.
