### PR TITLE
DAR-327 Phase 3: instant provider reconnect (going_away)

### DIFF
--- a/coordinator/api/going_away.go
+++ b/coordinator/api/going_away.go
@@ -1,0 +1,38 @@
+package api
+
+import (
+	"github.com/eigeninference/d-inference/coordinator/registry"
+)
+
+// going_away.go is the API-layer glue for DAR-327 Phase 3 (instant reconnect):
+// the version gate that decides which providers can be told the coordinator is
+// going away, and a thin wrapper that broadcasts it during graceful shutdown.
+// The wire mechanics (snapshot-then-write over the provider WebSockets) live in
+// registry.BroadcastGoingAway; the version floor const lives next to its sibling
+// in server.go. This mirrors the desired_models split (const in server.go,
+// gate helper out of server.go).
+
+// providerSupportsGoingAway reports whether a provider can receive the
+// going_away message: it must run the Swift backend and report a version at or
+// above minProviderVersionForGoingAway. A provider that reports no version is
+// treated as too old (fail-closed) so a strict decoder never disconnects on an
+// unknown message type. Mirrors providerSupportsDesiredModels.
+func (s *Server) providerSupportsGoingAway(backend, version string) bool {
+	if !registry.BackendUsesSwiftRuntime(backend) {
+		return false
+	}
+	if version == "" {
+		return false
+	}
+	return !semverLess(version, minProviderVersionForGoingAway)
+}
+
+// BroadcastGoingAway tells every connected, eligible provider that the
+// coordinator is going away for a planned restart, gated by
+// providerSupportsGoingAway. Called at the START of graceful shutdown (before
+// any WebSocket teardown) so providers drain in-flight work and reconnect with
+// their backoff reset onto the freshly-deployed coordinator. Returns the number
+// of providers the message was successfully written to.
+func (s *Server) BroadcastGoingAway() int {
+	return s.registry.BroadcastGoingAway(s.providerSupportsGoingAway)
+}

--- a/coordinator/api/going_away.go
+++ b/coordinator/api/going_away.go
@@ -1,6 +1,8 @@
 package api
 
 import (
+	"net/http"
+
 	"github.com/eigeninference/d-inference/coordinator/registry"
 )
 
@@ -29,10 +31,37 @@ func (s *Server) providerSupportsGoingAway(backend, version string) bool {
 
 // BroadcastGoingAway tells every connected, eligible provider that the
 // coordinator is going away for a planned restart, gated by
-// providerSupportsGoingAway. Called at the START of graceful shutdown (before
-// any WebSocket teardown) so providers drain in-flight work and reconnect with
-// their backoff reset onto the freshly-deployed coordinator. Returns the number
-// of providers the message was successfully written to.
+// providerSupportsGoingAway. Called both from the admin POST /v1/admin/going-away
+// endpoint (the blue-green cutover trigger) and at the START of graceful
+// shutdown (before any WebSocket teardown) so providers drain in-flight work and
+// reconnect with their backoff reset onto the freshly-deployed coordinator.
+// Returns the number of providers the message was successfully written to.
+//
+// It also latches the goingAway flag FIRST so that any provider reconnecting
+// after receiving the broadcast (or one that missed it) is refused a NEW
+// registration on this dying instance — see handleProviderWS. The flag is set
+// before the broadcast write so there is no window where a provider could close,
+// reconnect, and re-register here in between.
 func (s *Server) BroadcastGoingAway() int {
+	s.goingAway.Store(true)
 	return s.registry.BroadcastGoingAway(s.providerSupportsGoingAway)
+}
+
+// handleGoingAway handles POST /v1/admin/going-away — the discrete planned-restart
+// trigger for the zero-downtime blue-green cutover (DAR-327 Phase 3). It is
+// admin-gated (admin key OR Privy admin) via isAdminAuthorized, takes no body,
+// broadcasts going_away to every connected eligible provider, latches the
+// going-away flag (refusing new registrations on this instance thereafter), and
+// returns 200 with {"sent": <int>} — the number of providers the message reached.
+//
+// The route is wrapped in requireAuth (see routes()) so auth.UserFromContext is
+// populated for the Privy-admin path; isAdminAuthorized then accepts either the
+// admin key (a pseudo-account from requireAuth) or a Privy admin token.
+func (s *Server) handleGoingAway(w http.ResponseWriter, r *http.Request) {
+	if !s.isAdminAuthorized(w, r) {
+		return
+	}
+	sent := s.BroadcastGoingAway()
+	s.logger.Info("admin triggered going_away broadcast", "sent", sent)
+	writeJSON(w, http.StatusOK, map[string]any{"sent": sent})
 }

--- a/coordinator/api/going_away.go
+++ b/coordinator/api/going_away.go
@@ -1,6 +1,9 @@
 package api
 
 import (
+	"encoding/json"
+	"errors"
+	"io"
 	"net/http"
 
 	"github.com/eigeninference/d-inference/coordinator/registry"
@@ -47,12 +50,25 @@ func (s *Server) BroadcastGoingAway() int {
 	return s.registry.BroadcastGoingAway(s.providerSupportsGoingAway)
 }
 
-// handleGoingAway handles POST /v1/admin/going-away — the discrete planned-restart
-// trigger for the zero-downtime blue-green cutover (DAR-327 Phase 3). It is
-// admin-gated (admin key OR Privy admin) via isAdminAuthorized, takes no body,
-// broadcasts going_away to every connected eligible provider, latches the
-// going-away flag (refusing new registrations on this instance thereafter), and
-// returns 200 with {"sent": <int>} — the number of providers the message reached.
+// ClearGoingAway un-latches the going-away state so this coordinator accepts
+// new provider registrations again. Used by the blue-green ROLLBACK path: when
+// a cutover is reverted, the rolled-back-to color must stop refusing providers
+// (handleProviderWS) and re-accept them. Safe for concurrent use.
+func (s *Server) ClearGoingAway() { s.goingAway.Store(false) }
+
+// handleGoingAway handles POST /v1/admin/going-away — the planned-restart trigger
+// for the zero-downtime blue-green cutover (DAR-327 Phase 3). It is admin-gated
+// (admin key OR Privy admin) via isAdminAuthorized.
+//
+// It accepts an OPTIONAL JSON body {"cancel": bool}:
+//   - cancel:true  → ROLLBACK: un-latch the going-away flag via ClearGoingAway so
+//     this coordinator re-accepts provider registrations, returning 200 with
+//     {"going_away": false, "cleared": true}. The Phase 2 deploy.sh rollback path
+//     calls exactly this.
+//   - empty body / cancel absent / cancel:false → broadcast going_away to every
+//     connected eligible provider, latch the going-away flag (refusing new
+//     registrations thereafter), and return 200 with {"sent": <int>,
+//     "going_away": true}.
 //
 // The route is wrapped in requireAuth (see routes()) so auth.UserFromContext is
 // populated for the Privy-admin path; isAdminAuthorized then accepts either the
@@ -61,7 +77,38 @@ func (s *Server) handleGoingAway(w http.ResponseWriter, r *http.Request) {
 	if !s.isAdminAuthorized(w, r) {
 		return
 	}
+
+	// Parse an OPTIONAL {"cancel": bool} body, mirroring handleAdminDrain's body
+	// handling: tolerate an empty body (io.EOF), cap the read with MaxBytesReader,
+	// map an over-cap body to 413 and any other decode error to 400. An empty
+	// body / absent / false "cancel" keeps the default broadcast behavior.
+	r.Body = http.MaxBytesReader(w, r.Body, maxControlPlaneBodyBytes)
+	var req struct {
+		Cancel bool `json:"cancel"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil && !errors.Is(err, io.EOF) {
+		var maxErr *http.MaxBytesError
+		if errors.As(err, &maxErr) {
+			writeJSON(w, http.StatusRequestEntityTooLarge,
+				errorResponse("invalid_request_error", "request body too large"))
+			return
+		}
+		writeJSON(w, http.StatusBadRequest,
+			errorResponse("invalid_request_error", "invalid JSON"))
+		return
+	}
+
+	// ROLLBACK (blue-green): a cutover was reverted, so this color must stop
+	// refusing providers and re-accept registrations. CROSS-PHASE CONTRACT: the
+	// Phase 2 deploy.sh rollback calls exactly this — POST {"cancel":true}.
+	if req.Cancel {
+		s.ClearGoingAway()
+		s.logger.Info("admin cleared going_away (rollback)")
+		writeJSON(w, http.StatusOK, map[string]any{"going_away": false, "cleared": true})
+		return
+	}
+
 	sent := s.BroadcastGoingAway()
 	s.logger.Info("admin triggered going_away broadcast", "sent", sent)
-	writeJSON(w, http.StatusOK, map[string]any{"sent": sent})
+	writeJSON(w, http.StatusOK, map[string]any{"sent": sent, "going_away": true})
 }

--- a/coordinator/api/going_away_test.go
+++ b/coordinator/api/going_away_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/eigeninference/d-inference/coordinator/registry"
@@ -58,6 +59,41 @@ func TestHandleGoingAway_AdminKeyReturnsSentCount(t *testing.T) {
 	// The endpoint must latch the flag so subsequent registrations are refused.
 	if !srv.goingAway.Load() {
 		t.Error("goingAway flag must be set after the broadcast")
+	}
+}
+
+// TestHandleGoingAway_CancelClearsLatch verifies the blue-green ROLLBACK path
+// (DAR-327 Phase 3 / cross-phase contract with the Phase 2 deploy.sh rollback):
+// a POST with body {"cancel":true} un-latches the going-away flag so this
+// coordinator re-accepts provider registrations (handleProviderWS), returning
+// 200 with {"going_away":false,"cleared":true}.
+func TestHandleGoingAway_CancelClearsLatch(t *testing.T) {
+	srv, _ := newGoingAwayServer(t)
+
+	// Simulate a coordinator that has already announced going_away.
+	srv.goingAway.Store(true)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/admin/going-away",
+		strings.NewReader(`{"cancel":true}`))
+	req.Header.Set("Authorization", "Bearer "+goingAwayAdminKey)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d (body: %s)", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	// The latch must be cleared so handleProviderWS accepts registrations again.
+	if srv.goingAway.Load() {
+		t.Error("goingAway flag must be cleared after a cancel request")
+	}
+
+	var body map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if cleared, _ := body["cleared"].(bool); !cleared {
+		t.Errorf("response cleared = %v, want true (body: %s)", body["cleared"], w.Body.String())
 	}
 }
 

--- a/coordinator/api/going_away_test.go
+++ b/coordinator/api/going_away_test.go
@@ -1,0 +1,138 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/eigeninference/d-inference/coordinator/registry"
+	"github.com/eigeninference/d-inference/coordinator/store"
+)
+
+const goingAwayAdminKey = "going-away-admin-key"
+
+// newGoingAwayServer builds a real Server with the admin key set so the
+// admin-gated POST /v1/admin/going-away endpoint can be exercised end-to-end.
+func newGoingAwayServer(t *testing.T) (*Server, *store.MemoryStore) {
+	t.Helper()
+	logger := quietLogger()
+	st := store.NewMemory(store.Config{})
+	srv := NewServer(registry.New(logger), st, ServerConfig{}, logger)
+	srv.SetAdminKey(goingAwayAdminKey)
+	return srv, st
+}
+
+// TestHandleGoingAway_AdminKeyReturnsSentCount verifies the discrete planned-
+// restart trigger (DAR-327 Phase 3): an admin-keyed POST broadcasts going_away,
+// returns 200 with the {"sent": <int>} count, and latches the going-away flag.
+func TestHandleGoingAway_AdminKeyReturnsSentCount(t *testing.T) {
+	srv, _ := newGoingAwayServer(t)
+
+	if srv.goingAway.Load() {
+		t.Fatal("goingAway flag must start false")
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/admin/going-away", nil)
+	req.Header.Set("Authorization", "Bearer "+goingAwayAdminKey)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d (body: %s)", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	var body map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	// No providers connected, so the broadcast reaches zero.
+	sent, ok := body["sent"].(float64)
+	if !ok {
+		t.Fatalf("response missing numeric \"sent\" field: %v", body)
+	}
+	if sent != 0 {
+		t.Errorf("sent = %v, want 0 (no providers connected)", sent)
+	}
+
+	// The endpoint must latch the flag so subsequent registrations are refused.
+	if !srv.goingAway.Load() {
+		t.Error("goingAway flag must be set after the broadcast")
+	}
+}
+
+// TestHandleGoingAway_RequiresAdmin verifies the endpoint is admin-gated: a
+// request with no credentials is rejected by requireAuth (401), and a valid but
+// non-admin API key is rejected by isAdminAuthorized (403). Neither path may
+// latch the going-away flag.
+func TestHandleGoingAway_RequiresAdmin(t *testing.T) {
+	t.Run("missing credentials", func(t *testing.T) {
+		srv, _ := newGoingAwayServer(t)
+
+		req := httptest.NewRequest(http.MethodPost, "/v1/admin/going-away", nil)
+		w := httptest.NewRecorder()
+		srv.Handler().ServeHTTP(w, req)
+
+		if w.Code != http.StatusUnauthorized {
+			t.Fatalf("status = %d, want %d", w.Code, http.StatusUnauthorized)
+		}
+		if srv.goingAway.Load() {
+			t.Error("goingAway flag must NOT be set when auth fails")
+		}
+	})
+
+	t.Run("non-admin api key", func(t *testing.T) {
+		srv, st := newGoingAwayServer(t)
+
+		raw, err := st.CreateKey()
+		if err != nil {
+			t.Fatalf("CreateKey: %v", err)
+		}
+
+		req := httptest.NewRequest(http.MethodPost, "/v1/admin/going-away", nil)
+		req.Header.Set("Authorization", "Bearer "+raw)
+		w := httptest.NewRecorder()
+		srv.Handler().ServeHTTP(w, req)
+
+		if w.Code != http.StatusForbidden {
+			t.Fatalf("status = %d, want %d (body: %s)", w.Code, http.StatusForbidden, w.Body.String())
+		}
+		if srv.goingAway.Load() {
+			t.Error("goingAway flag must NOT be set for a non-admin caller")
+		}
+	})
+}
+
+// TestBroadcastGoingAway_LatchesFlag verifies the flag is set by the shared
+// BroadcastGoingAway path (used by both the admin endpoint and graceful
+// shutdown), independent of how many providers it reaches.
+func TestBroadcastGoingAway_LatchesFlag(t *testing.T) {
+	srv, _ := newGoingAwayServer(t)
+
+	if got := srv.BroadcastGoingAway(); got != 0 {
+		t.Errorf("BroadcastGoingAway sent = %d, want 0 (no providers)", got)
+	}
+	if !srv.goingAway.Load() {
+		t.Error("goingAway flag must be set after BroadcastGoingAway")
+	}
+}
+
+// TestHandleProviderWS_RefusesRegistrationWhenGoingAway verifies finding (C):
+// once the coordinator has announced going_away, the provider WebSocket upgrade
+// handler refuses NEW registrations with 503 (and a Retry-After) BEFORE the
+// upgrade, so a reconnecting provider doesn't stick to this dying instance.
+func TestHandleProviderWS_RefusesRegistrationWhenGoingAway(t *testing.T) {
+	srv, _ := newGoingAwayServer(t)
+	srv.goingAway.Store(true)
+
+	req := httptest.NewRequest(http.MethodGet, "/ws/provider", nil)
+	w := httptest.NewRecorder()
+	srv.handleProviderWS(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusServiceUnavailable)
+	}
+	if got := w.Header().Get("Retry-After"); got == "" {
+		t.Error("expected a Retry-After header on the 503")
+	}
+}

--- a/coordinator/api/provider.go
+++ b/coordinator/api/provider.go
@@ -219,6 +219,16 @@ func (s *Server) providerReadLoop(ctx context.Context, conn *websocket.Conn, pro
 		switch msg.Type {
 		case protocol.TypeRegister:
 			regMsg := msg.Payload.(*protocol.RegisterMessage)
+			// DAR-327 Phase 3: a provider can pass the pre-upgrade goingAway check,
+			// then lose the race with BroadcastGoingAway before its register frame is
+			// processed. Refuse that late registration too; it was not in the broadcast
+			// snapshot and would otherwise miss going_away and fall back to normal
+			// reconnect backoff when this dying coordinator exits.
+			if s.goingAway.Load() {
+				_ = conn.Close(websocket.StatusTryAgainLater,
+					"coordinator is going away (planned restart); reconnect to the new instance")
+				return
+			}
 			provider = s.registry.Register(providerID, conn, regMsg)
 			s.attachProviderLocation(providerID, provider, r)
 			s.verifyProviderAttestation(providerID, provider, regMsg)

--- a/coordinator/api/provider.go
+++ b/coordinator/api/provider.go
@@ -108,6 +108,21 @@ func (ct *challengeTracker) remove(nonce string) *pendingChallenge {
 // handleProviderWS upgrades the connection to WebSocket and manages the
 // provider's lifecycle: registration, heartbeats, and inference responses.
 func (s *Server) handleProviderWS(w http.ResponseWriter, r *http.Request) {
+	// DAR-327 Phase 3 (instant reconnect): once this coordinator has announced a
+	// planned restart (going_away, via the admin endpoint or graceful shutdown),
+	// refuse NEW provider registrations BEFORE the WebSocket upgrade. Otherwise an
+	// idle provider that closes and immediately reconnects could re-register on
+	// this dying instance, miss the broadcast (it isn't in the snapshot), and
+	// later fall back to backoff when the instance exits. A 503 (with Retry-After)
+	// surfaces as a transient connect failure so the provider retries and lands on
+	// the freshly-deployed coordinator via the load balancer instead.
+	if s.goingAway.Load() {
+		w.Header().Set("Retry-After", "1")
+		writeJSON(w, http.StatusServiceUnavailable, errorResponse("service_unavailable",
+			"coordinator is going away (planned restart); reconnect to the new instance"))
+		return
+	}
+
 	conn, err := websocket.Accept(w, r, &websocket.AcceptOptions{
 		// Allow any origin for provider connections.
 		InsecureSkipVerify: true,

--- a/coordinator/api/server.go
+++ b/coordinator/api/server.go
@@ -32,6 +32,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/eigeninference/d-inference/coordinator/apns"
@@ -414,6 +415,18 @@ type Server struct {
 	// Server built directly (e.g. &Server{} in tests) leaves it nil, and
 	// submitTelemetry falls back to a per-write saferun.Go in that case.
 	routeTelemetry *telemetrySink
+
+	// goingAway is latched true the first time this coordinator announces a
+	// planned restart (DAR-327 Phase 3) — via BroadcastGoingAway, which fires
+	// both from the admin POST /v1/admin/going-away endpoint and at the start of
+	// graceful shutdown. Once set, handleProviderWS refuses NEW provider
+	// registrations with 503 so a provider reconnecting after going_away can't
+	// stick to this dying instance (it would miss the broadcast and later fall
+	// back to backoff); it instead retries and lands on the freshly-deployed
+	// coordinator via the load balancer. One-way (never cleared): a coordinator
+	// that has announced going_away is on its way out. Named distinctly from any
+	// request-draining flag to avoid colliding with Phase 1.
+	goingAway atomic.Bool
 }
 
 // SetRateLimiter configures the per-account rate limiter applied to
@@ -1838,6 +1851,15 @@ func (s *Server) routes() {
 	// Admin credit & reward
 	s.mux.HandleFunc("POST /v1/admin/credit", s.requireAuth(s.handleAdminCredit))
 	s.mux.HandleFunc("POST /v1/admin/reward", s.requireAuth(s.handleAdminReward))
+
+	// Admin planned-restart trigger (DAR-327 Phase 3 instant reconnect). The
+	// blue-green deploy calls this on the OLD coordinator to make providers
+	// reconnect onto the new color BEFORE the old one is stopped. Wrapped in
+	// requireAuth so auth.UserFromContext is populated and isAdminAuthorized
+	// accepts BOTH the admin key (pseudo-account) and a Privy admin token — the
+	// same pattern as POST /v1/admin/credit above. Registered here, before the
+	// /v1/ catch-all.
+	s.mux.HandleFunc("POST /v1/admin/going-away", s.requireAuth(s.handleGoingAway))
 
 	// Telemetry ingestion — authentication is resolved inside the handler
 	// because providers, consumers, and anonymous clients all hit this path.

--- a/coordinator/api/server.go
+++ b/coordinator/api/server.go
@@ -144,7 +144,7 @@ func keyLimitResetFromContext(ctx context.Context) string {
 // 0.6.0 is the APNs code-identity / VLM-routing / graceful-update release.
 // Keep this fallback in sync with ProviderCore.version so dev/in-memory
 // coordinators advertise the same floor as the Swift binary they expect.
-var LatestProviderVersion = "0.6.11"
+var LatestProviderVersion = "0.6.18"
 
 // minProviderVersionForDesiredModels is the first provider version whose Swift
 // runtime understands the desired_models message. The coordinator must NOT send
@@ -160,12 +160,11 @@ const minProviderVersionForDesiredModels = "0.5.17"
 // below this version (or on a non-Swift backend): a pre-feature provider's
 // strict decoder throws on unknown message types and would disconnect.
 //
-// This is forward-looking: ProviderCore.version is 0.6.13 at the time this
-// landed, so the floor is the NEXT cut (0.6.14). going_away stays dormant until
-// providers ship at/above the floor — at that release cut bump ProviderCore.version
-// to 0.6.14 to activate it, mirroring the minProviderVersionForDesiredModels
-// convention above.
-const minProviderVersionForGoingAway = "0.6.14"
+// This is forward-looking: ProviderCore.version is 0.6.17 in the parent branch,
+// so the floor is the NEXT cut (0.6.18). going_away stays dormant for existing
+// released providers and activates only once the release that includes the Swift
+// decoder is cut, mirroring the minProviderVersionForDesiredModels convention.
+const minProviderVersionForGoingAway = "0.6.18"
 
 // latestReleasedVersion returns the highest active release version from
 // the store, falling back to the hardcoded LatestProviderVersion when

--- a/coordinator/api/server.go
+++ b/coordinator/api/server.go
@@ -423,9 +423,11 @@ type Server struct {
 	// registrations with 503 so a provider reconnecting after going_away can't
 	// stick to this dying instance (it would miss the broadcast and later fall
 	// back to backoff); it instead retries and lands on the freshly-deployed
-	// coordinator via the load balancer. One-way (never cleared): a coordinator
-	// that has announced going_away is on its way out. Named distinctly from any
-	// request-draining flag to avoid colliding with Phase 1.
+	// coordinator via the load balancer. Normally one-way (a coordinator that has
+	// announced going_away is on its way out), but ClearGoingAway can un-latch it
+	// for the blue-green ROLLBACK path — when a cutover is reverted, the
+	// rolled-back-to color must stop refusing providers and re-accept them. Named
+	// distinctly from any request-draining flag to avoid colliding with Phase 1.
 	goingAway atomic.Bool
 }
 

--- a/coordinator/api/server.go
+++ b/coordinator/api/server.go
@@ -153,6 +153,19 @@ var LatestProviderVersion = "0.6.11"
 // desired_models support (ProviderCore.version at that cut).
 const minProviderVersionForDesiredModels = "0.5.17"
 
+// minProviderVersionForGoingAway is the first provider version whose Swift
+// runtime understands the going_away message (DAR-327 Phase 3 instant
+// reconnect). The coordinator must NOT broadcast going_away to any provider
+// below this version (or on a non-Swift backend): a pre-feature provider's
+// strict decoder throws on unknown message types and would disconnect.
+//
+// This is forward-looking: ProviderCore.version is 0.6.13 at the time this
+// landed, so the floor is the NEXT cut (0.6.14). going_away stays dormant until
+// providers ship at/above the floor — at that release cut bump ProviderCore.version
+// to 0.6.14 to activate it, mirroring the minProviderVersionForDesiredModels
+// convention above.
+const minProviderVersionForGoingAway = "0.6.14"
+
 // latestReleasedVersion returns the highest active release version from
 // the store, falling back to the hardcoded LatestProviderVersion when
 // no release record exists.

--- a/coordinator/cmd/coordinator/main.go
+++ b/coordinator/cmd/coordinator/main.go
@@ -702,6 +702,12 @@ func main() {
 	// re-trusts it sub-second. Version-gated to providers that understand the
 	// message. Broadcast FIRST so providers skip backoff instead of discovering
 	// the drop only once the socket is already torn down.
+	//
+	// CANONICAL MERGE ORDER (DAR-327): srv.SetDraining(true) [Phase 1] →
+	// srv.BroadcastGoingAway() [this call] → cancel() → srv.WaitForInflightZero()
+	// [Phase 1] → httpServer.Shutdown(). When merged with Phase 1, this broadcast
+	// goes right AFTER SetDraining(true) and BEFORE cancel()/WaitForInflightZero
+	// so providers drain+reconnect while in-flight HTTP finishes.
 	sentGoingAway := srv.BroadcastGoingAway()
 	logger.Info("broadcast going_away to providers", "count", sentGoingAway)
 

--- a/coordinator/cmd/coordinator/main.go
+++ b/coordinator/cmd/coordinator/main.go
@@ -694,6 +694,17 @@ func main() {
 	sig := <-sigCh
 	logger.Info("shutting down", "signal", sig.String())
 
+	// DAR-327 Phase 3 (instant reconnect): before tearing anything down, tell
+	// every connected provider we are going away for a planned restart. On
+	// receipt a provider finishes its in-flight work, closes its socket, and
+	// reconnects with its backoff RESET (no sleep) so it lands on the
+	// freshly-deployed coordinator near-instantly — where Phase 0 trust-reuse
+	// re-trusts it sub-second. Version-gated to providers that understand the
+	// message. Broadcast FIRST so providers skip backoff instead of discovering
+	// the drop only once the socket is already torn down.
+	sentGoingAway := srv.BroadcastGoingAway()
+	logger.Info("broadcast going_away to providers", "count", sentGoingAway)
+
 	// Graceful shutdown with a deadline.
 	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer shutdownCancel()

--- a/coordinator/protocol/messages.go
+++ b/coordinator/protocol/messages.go
@@ -53,6 +53,7 @@ const (
 	TypePrefetchModel        = "prefetch_model"
 	TypeDesiredModels        = "desired_models"
 	TypeTrustStatus          = "trust_status"
+	TypeGoingAway            = "going_away"
 )
 
 // LoadModelStatus is the lifecycle state reported by a provider in response
@@ -540,6 +541,23 @@ type TrustStatusMessage struct {
 	TrustLevel string `json:"trust_level"` // "none", "self_signed", "hardware"
 	Status     string `json:"status"`      // "online", "untrusted", etc.
 	Reason     string `json:"reason,omitempty"`
+}
+
+// GoingAwayMessage is broadcast by the coordinator to every connected provider
+// at the START of a planned restart (graceful shutdown), BEFORE any WebSocket
+// teardown. On receipt a provider finishes its in-flight work, closes its
+// WebSocket, and reconnects with its exponential backoff RESET (no backoff
+// sleep) so it lands on the freshly-deployed coordinator near-instantly — where
+// Phase 0 trust-reuse re-trusts it sub-second. This is the coordinator side of
+// DAR-327 Phase 3 (instant reconnect).
+//
+// It is type-only on the wire ({"type":"going_away"}): no payload is needed
+// because the provider's drain + reconnect policy lives entirely on the provider
+// side. Sent only to Swift-runtime providers at/above the version that
+// understands it (see api.minProviderVersionForGoingAway); a pre-feature
+// provider's strict decoder throws on unknown message types, so it is gated out.
+type GoingAwayMessage struct {
+	Type string `json:"type"`
 }
 
 // ---------------------------------------------------------------------------

--- a/coordinator/protocol/messages_test.go
+++ b/coordinator/protocol/messages_test.go
@@ -1416,3 +1416,31 @@ func TestDesiredModelsMessageMarshal(t *testing.T) {
 		t.Errorf("entry 1 previous_build should be empty, got %q", decoded.Models[1].PreviousBuild)
 	}
 }
+
+// TestGoingAwayMessageMarshal verifies the going_away wire shape the coordinator
+// broadcasts at the start of a planned restart (DAR-327 Phase 3). It is
+// type-only on the wire ({"type":"going_away"}) and must round-trip — this is
+// the protocol-symmetry guard the Swift decoder side (goingAwayMessageRoundTrips
+// WithCoordinator) is paired with. A bare type-only message is what a strict
+// Swift CoordinatorMessage decoder expects; any extra/renamed key would break it.
+func TestGoingAwayMessageMarshal(t *testing.T) {
+	msg := GoingAwayMessage{Type: TypeGoingAway}
+
+	data, err := json.Marshal(msg)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	// Exact wire form: the discriminator only, no payload keys.
+	if got, want := string(data), `{"type":"going_away"}`; got != want {
+		t.Errorf("going_away wire = %s, want %s", got, want)
+	}
+
+	var decoded GoingAwayMessage
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if decoded.Type != TypeGoingAway {
+		t.Errorf("type = %q, want %q", decoded.Type, TypeGoingAway)
+	}
+}

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -2427,6 +2427,7 @@ func (r *Registry) Register(id string, conn *websocket.Conn, msg *protocol.Regis
 		Hardware:                msg.Hardware,
 		Models:                  models,
 		Backend:                 msg.Backend,
+		Version:                 msg.Version,
 		PublicKey:               pubKey,
 		EncryptedResponseChunks: msg.EncryptedResponseChunks,
 		PrivateOnly:             msg.PrivateOnly,
@@ -2723,10 +2724,10 @@ func (r *Registry) SendLoadModel(providerID, modelID string) error {
 	return nil
 }
 
-// goingAwayBroadcastTimeout bounds the WHOLE going_away broadcast (every per-conn
-// write shares it), so a slow/blocked socket or a large fleet can never eat into
-// the caller's graceful-shutdown window. going_away is a best-effort nudge: a
-// provider that misses it just discovers the drop and reconnects with backoff.
+// goingAwayBroadcastTimeout bounds the WHOLE going_away broadcast enqueue pass,
+// so a slow/blocked socket or a large fleet can never eat into the caller's
+// graceful-shutdown window. going_away is a best-effort nudge: a provider that
+// misses it just discovers the drop and reconnects with backoff.
 const goingAwayBroadcastTimeout = 3 * time.Second
 
 // BroadcastGoingAway tells every connected, eligible provider that the
@@ -2738,43 +2739,44 @@ const goingAwayBroadcastTimeout = 3 * time.Second
 // Concurrency: provider connections are SNAPSHOTTED under r.mu.RLock (reading
 // p.Conn / p.Backend / p.Version under p.mu, matching the r.mu→p.mu lock
 // ordering used by ForEachProvider, evictStale, and Disconnect) and the
-// websocket writes happen AFTER the lock is released — never while holding r.mu.
-// The writes then fan out CONCURRENTLY (one goroutine per conn) under a single
-// goingAwayBroadcastTimeout deadline shared by all of them, so the cost is
-// ~one timeout rather than N×perWrite and the broadcast can't stall shutdown.
-// nhooyr.io/websocket Conn.Write is concurrency-safe and each conn is distinct,
-// so the writes don't contend. A snapshotted conn may already be closing
-// (Disconnect runs concurrently and calls CloseNow), so per-conn write errors
-// are tolerated: log and continue, never abort the broadcast. Each goroutine
-// also recovers via saferun so one bad write can never crash the process.
+// message enqueues happen AFTER the lock is released — never while holding r.mu.
+// The enqueues then fan out CONCURRENTLY (one goroutine per provider) under a
+// single goingAwayBroadcastTimeout deadline shared by all of them, so the cost is
+// ~one timeout rather than N×perWrite and the broadcast can't stall shutdown. The
+// per-provider writer owns the actual websocket write and deliberately does not
+// pass expiring contexts to nhooyr.Conn.Write, so a broadcast timeout cannot close
+// a slow-but-healthy provider socket. A snapshotted provider may already be
+// closing (Disconnect runs concurrently), so per-provider enqueue errors are
+// tolerated: log and continue, never abort the broadcast. Each goroutine also
+// recovers via saferun so one bad enqueue can never crash the process.
 //
 // eligible, when non-nil, gates which providers are notified (backend + version
 // floor) so a provider whose strict decoder would throw on an unknown message
-// type is skipped. Returns the number of providers the message was successfully
-// written to.
+// type is skipped. Returns the number of providers whose writer accepted the
+// message for best-effort delivery.
 func (r *Registry) BroadcastGoingAway(eligible func(backend, version string) bool) int {
 	type target struct {
-		id   string
-		conn *websocket.Conn
+		id       string
+		provider *Provider
 	}
 
-	// Snapshot eligible conns under the read lock, then release it before any
-	// write so a slow/blocked socket can never stall the registry.
+	// Snapshot eligible providers under the read lock, then release it before any
+	// enqueue/write so a slow/blocked socket can never stall the registry.
 	r.mu.RLock()
 	targets := make([]target, 0, len(r.providers))
 	for id, p := range r.providers {
 		p.mu.Lock()
-		conn := p.Conn
+		hasConn := p.Conn != nil
 		backend := p.Backend
 		version := p.Version
 		p.mu.Unlock()
-		if conn == nil {
+		if !hasConn {
 			continue
 		}
 		if eligible != nil && !eligible(backend, version) {
 			continue
 		}
-		targets = append(targets, target{id: id, conn: conn})
+		targets = append(targets, target{id: id, provider: p})
 	}
 	r.mu.RUnlock()
 
@@ -2789,8 +2791,11 @@ func (r *Registry) BroadcastGoingAway(eligible func(backend, version string) boo
 		return 0
 	}
 
-	// One deadline for the entire broadcast (shared by every write), so the
-	// worst case is a single timeout no matter how many providers are connected.
+	// One enqueue deadline for the entire broadcast (shared by every target), so
+	// the worst case is a single timeout no matter how many providers are connected.
+	// The provider writer never passes this expiring context into nhooyr.Conn.Write;
+	// it only bounds enqueue/result waiting, avoiding context-expiry-induced socket
+	// closes for slow/backpressured writes.
 	ctx, cancel := context.WithTimeout(context.Background(), goingAwayBroadcastTimeout)
 	defer cancel()
 
@@ -2805,9 +2810,10 @@ func (r *Registry) BroadcastGoingAway(eligible func(backend, version string) boo
 			// releases the WaitGroup — wg.Wait below can never hang.
 			defer wg.Done()
 			defer saferun.Recover(r.logger, "registry.broadcastGoingAway")
-			if err := t.conn.Write(ctx, websocket.MessageText, data); err != nil {
+			if err := t.provider.EnqueueText(ctx, data); err != nil {
 				// A snapshotted conn may already be closed (concurrent
-				// Disconnect / CloseNow) or the shared deadline fired.
+				// Disconnect / CloseNow), its writer queue may be full, or the
+				// shared enqueue deadline fired.
 				// Tolerate it — never abort the broadcast.
 				r.logger.Warn("failed to send going_away to provider", "provider_id", t.id, "error", err)
 				return

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -2723,6 +2723,118 @@ func (r *Registry) SendLoadModel(providerID, modelID string) error {
 	return nil
 }
 
+// SendGoingAway tells a single provider the coordinator is going away for a
+// planned restart. Like SendLoadModel it is fire-and-forget: the provider
+// drains its in-flight work, closes its socket, and reconnects with its backoff
+// RESET (DAR-327 Phase 3 instant reconnect). The provider conn is read under
+// r.mu.RLock then p.mu, and the write happens OUTSIDE both locks with a 5s
+// timeout (nhooyr.io/websocket Conn.Write is concurrency-safe).
+func (r *Registry) SendGoingAway(providerID string) error {
+	r.mu.RLock()
+	p, ok := r.providers[providerID]
+	r.mu.RUnlock()
+	if !ok {
+		return fmt.Errorf("provider %q not found", providerID)
+	}
+
+	msg := protocol.GoingAwayMessage{Type: protocol.TypeGoingAway}
+	data, err := json.Marshal(msg)
+	if err != nil {
+		return fmt.Errorf("failed to marshal going_away message: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	p.mu.Lock()
+	conn := p.Conn
+	p.mu.Unlock()
+
+	if conn == nil {
+		return fmt.Errorf("provider %q has no active connection", providerID)
+	}
+
+	if err := conn.Write(ctx, websocket.MessageText, data); err != nil {
+		return fmt.Errorf("failed to send going_away to provider %q: %w", providerID, err)
+	}
+
+	r.logger.Info("sent going_away to provider", "provider_id", providerID)
+	return nil
+}
+
+// BroadcastGoingAway tells every connected, eligible provider that the
+// coordinator is going away for a planned restart (graceful shutdown). It is the
+// coordinator side of DAR-327 Phase 3: a provider that receives going_away
+// finishes its in-flight work, closes its socket, and reconnects with its
+// backoff RESET so it lands on the freshly-deployed coordinator near-instantly.
+//
+// Concurrency: provider connections are SNAPSHOTTED under r.mu.RLock (reading
+// p.Conn / p.Backend / p.Version under p.mu, matching the r.mu→p.mu lock
+// ordering used by ForEachProvider, evictStale, and Disconnect) and the
+// websocket writes happen AFTER the lock is released — never while holding
+// r.mu. A snapshotted conn may already be closing (Disconnect runs concurrently
+// and calls CloseNow), so per-conn write errors are tolerated: log and continue,
+// like sendModelLoadActions, never panic or abort the broadcast.
+//
+// eligible, when non-nil, gates which providers are notified (backend + version
+// floor) so a provider whose strict decoder would throw on an unknown message
+// type is skipped. Returns the number of providers the message was successfully
+// written to.
+func (r *Registry) BroadcastGoingAway(eligible func(backend, version string) bool) int {
+	type target struct {
+		id   string
+		conn *websocket.Conn
+	}
+
+	// Snapshot eligible conns under the read lock, then release it before any
+	// write so a slow/blocked socket can never stall the registry.
+	r.mu.RLock()
+	targets := make([]target, 0, len(r.providers))
+	for id, p := range r.providers {
+		p.mu.Lock()
+		conn := p.Conn
+		backend := p.Backend
+		version := p.Version
+		p.mu.Unlock()
+		if conn == nil {
+			continue
+		}
+		if eligible != nil && !eligible(backend, version) {
+			continue
+		}
+		targets = append(targets, target{id: id, conn: conn})
+	}
+	r.mu.RUnlock()
+
+	if len(targets) == 0 {
+		return 0
+	}
+
+	msg := protocol.GoingAwayMessage{Type: protocol.TypeGoingAway}
+	data, err := json.Marshal(msg)
+	if err != nil {
+		r.logger.Error("failed to marshal going_away message", "error", err)
+		return 0
+	}
+
+	sent := 0
+	for _, t := range targets {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		err := t.conn.Write(ctx, websocket.MessageText, data)
+		cancel()
+		if err != nil {
+			// A snapshotted conn may already be closed (concurrent Disconnect /
+			// CloseNow). Tolerate it — never panic or abort the broadcast.
+			r.logger.Warn("failed to send going_away to provider", "provider_id", t.id, "error", err)
+			continue
+		}
+		sent++
+	}
+
+	r.logger.Info("broadcast going_away to providers", "sent", sent, "eligible", len(targets))
+	return sent
+}
+
 // SendPrefetchModel instructs a provider to download + verify a model build
 // in the background without loading it into GPU memory. It mirrors
 // SendLoadModel but carries no expectation that the model becomes warm; the

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -2723,44 +2723,11 @@ func (r *Registry) SendLoadModel(providerID, modelID string) error {
 	return nil
 }
 
-// SendGoingAway tells a single provider the coordinator is going away for a
-// planned restart. Like SendLoadModel it is fire-and-forget: the provider
-// drains its in-flight work, closes its socket, and reconnects with its backoff
-// RESET (DAR-327 Phase 3 instant reconnect). The provider conn is read under
-// r.mu.RLock then p.mu, and the write happens OUTSIDE both locks with a 5s
-// timeout (nhooyr.io/websocket Conn.Write is concurrency-safe).
-func (r *Registry) SendGoingAway(providerID string) error {
-	r.mu.RLock()
-	p, ok := r.providers[providerID]
-	r.mu.RUnlock()
-	if !ok {
-		return fmt.Errorf("provider %q not found", providerID)
-	}
-
-	msg := protocol.GoingAwayMessage{Type: protocol.TypeGoingAway}
-	data, err := json.Marshal(msg)
-	if err != nil {
-		return fmt.Errorf("failed to marshal going_away message: %w", err)
-	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-
-	p.mu.Lock()
-	conn := p.Conn
-	p.mu.Unlock()
-
-	if conn == nil {
-		return fmt.Errorf("provider %q has no active connection", providerID)
-	}
-
-	if err := conn.Write(ctx, websocket.MessageText, data); err != nil {
-		return fmt.Errorf("failed to send going_away to provider %q: %w", providerID, err)
-	}
-
-	r.logger.Info("sent going_away to provider", "provider_id", providerID)
-	return nil
-}
+// goingAwayBroadcastTimeout bounds the WHOLE going_away broadcast (every per-conn
+// write shares it), so a slow/blocked socket or a large fleet can never eat into
+// the caller's graceful-shutdown window. going_away is a best-effort nudge: a
+// provider that misses it just discovers the drop and reconnects with backoff.
+const goingAwayBroadcastTimeout = 3 * time.Second
 
 // BroadcastGoingAway tells every connected, eligible provider that the
 // coordinator is going away for a planned restart (graceful shutdown). It is the
@@ -2771,10 +2738,15 @@ func (r *Registry) SendGoingAway(providerID string) error {
 // Concurrency: provider connections are SNAPSHOTTED under r.mu.RLock (reading
 // p.Conn / p.Backend / p.Version under p.mu, matching the r.mu→p.mu lock
 // ordering used by ForEachProvider, evictStale, and Disconnect) and the
-// websocket writes happen AFTER the lock is released — never while holding
-// r.mu. A snapshotted conn may already be closing (Disconnect runs concurrently
-// and calls CloseNow), so per-conn write errors are tolerated: log and continue,
-// like sendModelLoadActions, never panic or abort the broadcast.
+// websocket writes happen AFTER the lock is released — never while holding r.mu.
+// The writes then fan out CONCURRENTLY (one goroutine per conn) under a single
+// goingAwayBroadcastTimeout deadline shared by all of them, so the cost is
+// ~one timeout rather than N×perWrite and the broadcast can't stall shutdown.
+// nhooyr.io/websocket Conn.Write is concurrency-safe and each conn is distinct,
+// so the writes don't contend. A snapshotted conn may already be closing
+// (Disconnect runs concurrently and calls CloseNow), so per-conn write errors
+// are tolerated: log and continue, never abort the broadcast. Each goroutine
+// also recovers via saferun so one bad write can never crash the process.
 //
 // eligible, when non-nil, gates which providers are notified (backend + version
 // floor) so a provider whose strict decoder would throw on an unknown message
@@ -2817,22 +2789,37 @@ func (r *Registry) BroadcastGoingAway(eligible func(backend, version string) boo
 		return 0
 	}
 
-	sent := 0
-	for _, t := range targets {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		err := t.conn.Write(ctx, websocket.MessageText, data)
-		cancel()
-		if err != nil {
-			// A snapshotted conn may already be closed (concurrent Disconnect /
-			// CloseNow). Tolerate it — never panic or abort the broadcast.
-			r.logger.Warn("failed to send going_away to provider", "provider_id", t.id, "error", err)
-			continue
-		}
-		sent++
-	}
+	// One deadline for the entire broadcast (shared by every write), so the
+	// worst case is a single timeout no matter how many providers are connected.
+	ctx, cancel := context.WithTimeout(context.Background(), goingAwayBroadcastTimeout)
+	defer cancel()
 
-	r.logger.Info("broadcast going_away to providers", "sent", sent, "eligible", len(targets))
-	return sent
+	var (
+		wg   sync.WaitGroup
+		sent atomic.Int64
+	)
+	for _, t := range targets {
+		wg.Add(1)
+		go func(t target) {
+			// wg.Done is the OUTERMOST defer so a recovered panic still
+			// releases the WaitGroup — wg.Wait below can never hang.
+			defer wg.Done()
+			defer saferun.Recover(r.logger, "registry.broadcastGoingAway")
+			if err := t.conn.Write(ctx, websocket.MessageText, data); err != nil {
+				// A snapshotted conn may already be closed (concurrent
+				// Disconnect / CloseNow) or the shared deadline fired.
+				// Tolerate it — never abort the broadcast.
+				r.logger.Warn("failed to send going_away to provider", "provider_id", t.id, "error", err)
+				return
+			}
+			sent.Add(1)
+		}(t)
+	}
+	wg.Wait()
+
+	total := int(sent.Load())
+	r.logger.Info("broadcast going_away to providers", "sent", total, "eligible", len(targets))
+	return total
 }
 
 // SendPrefetchModel instructs a provider to download + verify a model build

--- a/coordinator/registry/registry_test.go
+++ b/coordinator/registry/registry_test.go
@@ -5,7 +5,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"net/http"
+	"net/http/httptest"
 	"os"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -13,6 +16,7 @@ import (
 	"github.com/eigeninference/d-inference/coordinator/attestation"
 	"github.com/eigeninference/d-inference/coordinator/protocol"
 	"github.com/eigeninference/d-inference/coordinator/store"
+	"nhooyr.io/websocket"
 )
 
 func testLogger() *slog.Logger {
@@ -3361,4 +3365,124 @@ func TestRemoveProviderBySerialRaceWithAttestation(t *testing.T) {
 		}()
 	}
 	wg.Wait()
+}
+
+// wsConnPair stands up a real nhooyr websocket connection pair via an httptest
+// server. It returns the coordinator-side (accepted) conn — the one to store in
+// Provider.Conn so BroadcastGoingAway writes to it — and the provider-side
+// (dialed) conn used to read back what the registry wrote. cleanup tears both
+// down. This mirrors production: the coordinator holds the accepted conn and
+// writes control messages to the provider over it.
+func wsConnPair(t *testing.T) (serverConn, clientConn *websocket.Conn, cleanup func()) {
+	t.Helper()
+	accepted := make(chan *websocket.Conn, 1)
+	done := make(chan struct{})
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			t.Errorf("ws accept: %v", err)
+			return
+		}
+		accepted <- c
+		<-done // keep the handler (and accepted conn) alive until cleanup
+	}))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http")
+	cc, _, err := websocket.Dial(ctx, wsURL, nil)
+	if err != nil {
+		close(done)
+		ts.Close()
+		t.Fatalf("ws dial: %v", err)
+	}
+	sc := <-accepted
+
+	cleanup = func() {
+		// CloseNow (not Close): the peer server conn is parked on <-done and
+		// never reads, so a Close handshake would block until its timeout. We
+		// just want the transport torn down promptly.
+		_ = cc.CloseNow()
+		close(done)
+		ts.Close()
+	}
+	return sc, cc, cleanup
+}
+
+// TestBroadcastGoingAway verifies the coordinator side of DAR-327 Phase 3: the
+// broadcast writes the going_away message to connected, eligible providers, is
+// gated by the eligibility predicate (version/backend floor), and tolerates a
+// provider whose snapshotted conn is already closed (no panic, no abort — the
+// other providers still get the message).
+func TestBroadcastGoingAway(t *testing.T) {
+	r := New(testLogger())
+
+	// p1: connected + eligible -> must receive going_away.
+	sc1, cc1, cleanup1 := wsConnPair(t)
+	defer cleanup1()
+	r.providers["p1"] = &Provider{
+		ID:      "p1",
+		Backend: BackendMLXSwift,
+		Version: "0.6.14",
+		Conn:    sc1,
+		Status:  StatusOnline,
+	}
+
+	// p2: connected + eligible, but its coordinator-side conn is already CLOSED.
+	// BroadcastGoingAway must tolerate the write error and still deliver to p1.
+	sc2, _, cleanup2 := wsConnPair(t)
+	defer cleanup2()
+	sc2.CloseNow()
+	r.providers["p2"] = &Provider{
+		ID:      "p2",
+		Backend: BackendMLXSwift,
+		Version: "0.6.14",
+		Conn:    sc2,
+		Status:  StatusOnline,
+	}
+
+	// p3: connected but INELIGIBLE (below the version floor) -> must be skipped.
+	sc3, cc3, cleanup3 := wsConnPair(t)
+	defer cleanup3()
+	r.providers["p3"] = &Provider{
+		ID:      "p3",
+		Backend: BackendMLXSwift,
+		Version: "0.6.13",
+		Conn:    sc3,
+		Status:  StatusOnline,
+	}
+
+	eligible := func(backend, version string) bool {
+		return BackendUsesSwiftRuntime(backend) && version == "0.6.14"
+	}
+
+	sent := r.BroadcastGoingAway(eligible)
+	if sent != 1 {
+		t.Errorf("BroadcastGoingAway sent = %d, want 1 (p1 only; p2 conn closed, p3 ineligible)", sent)
+	}
+
+	// p1 received the exact going_away wire form.
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	typ, data, err := cc1.Read(ctx)
+	if err != nil {
+		t.Fatalf("read going_away on p1: %v", err)
+	}
+	if typ != websocket.MessageText {
+		t.Errorf("message type = %v, want text", typ)
+	}
+	var decoded protocol.GoingAwayMessage
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal going_away: %v", err)
+	}
+	if decoded.Type != protocol.TypeGoingAway {
+		t.Errorf("decoded type = %q, want %q", decoded.Type, protocol.TypeGoingAway)
+	}
+
+	// p3 (ineligible) must NOT have received anything: a short read times out.
+	ctx3, cancel3 := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel3()
+	if _, _, err := cc3.Read(ctx3); err == nil {
+		t.Errorf("ineligible provider p3 unexpectedly received a message")
+	}
 }

--- a/coordinator/registry/registry_test.go
+++ b/coordinator/registry/registry_test.go
@@ -3420,37 +3420,43 @@ func TestBroadcastGoingAway(t *testing.T) {
 	// p1: connected + eligible -> must receive going_away.
 	sc1, cc1, cleanup1 := wsConnPair(t)
 	defer cleanup1()
-	r.providers["p1"] = &Provider{
+	p1 := &Provider{
 		ID:      "p1",
 		Backend: BackendMLXSwift,
 		Version: "0.6.14",
 		Conn:    sc1,
+		writer:  newProviderWriter(sc1),
 		Status:  StatusOnline,
 	}
+	r.providers["p1"] = p1
 
 	// p2: connected + eligible, but its coordinator-side conn is already CLOSED.
 	// BroadcastGoingAway must tolerate the write error and still deliver to p1.
 	sc2, _, cleanup2 := wsConnPair(t)
 	defer cleanup2()
-	sc2.CloseNow()
-	r.providers["p2"] = &Provider{
+	p2 := &Provider{
 		ID:      "p2",
 		Backend: BackendMLXSwift,
 		Version: "0.6.14",
 		Conn:    sc2,
+		writer:  newProviderWriter(sc2),
 		Status:  StatusOnline,
 	}
+	p2.closeWriterNow()
+	r.providers["p2"] = p2
 
 	// p3: connected but INELIGIBLE (below the version floor) -> must be skipped.
 	sc3, cc3, cleanup3 := wsConnPair(t)
 	defer cleanup3()
-	r.providers["p3"] = &Provider{
+	p3 := &Provider{
 		ID:      "p3",
 		Backend: BackendMLXSwift,
 		Version: "0.6.13",
 		Conn:    sc3,
+		writer:  newProviderWriter(sc3),
 		Status:  StatusOnline,
 	}
+	r.providers["p3"] = p3
 
 	eligible := func(backend, version string) bool {
 		return BackendUsesSwiftRuntime(backend) && version == "0.6.14"

--- a/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClient.swift
+++ b/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClient.swift
@@ -678,21 +678,30 @@ public actor CoordinatorClient {
         plannedRestart = true
     }
 
-    /// Tear down the current coordinator connection and reconnect IMMEDIATELY
-    /// with the backoff RESET (no sleep). Used when the coordinator announces a
-    /// planned restart (`going_away`, DAR-327 Phase 3): after the provider drains
-    /// its in-flight work it closes the socket here and lands on the
-    /// freshly-deployed coordinator near-instantly. Unlike `shutdown()` this does
-    /// NOT set `shutdownRequested`, so the connection loop keeps running; unlike a
-    /// plain connection error it skips the reconnect backoff sleep. No-op once a
-    /// real shutdown is already in progress. Cancelling the socket surfaces as a
-    /// connection error so `runLoop` re-runs `sendRegistration` on the new
-    /// coordinator (the 1001 close code literally means "going away"). The
-    /// `plannedRestart` flag is set here too (idempotent with `markPlannedRestart`)
-    /// so this remains correct when called on its own.
+    /// Force the planned-restart close that makes `runLoop` reconnect IMMEDIATELY
+    /// with the backoff RESET (no exponential sleep, only a small jitter). Used
+    /// when the coordinator announces a planned restart (`going_away`, DAR-327
+    /// Phase 3): after the provider drains its in-flight work it closes the socket
+    /// here and lands on the freshly-deployed coordinator near-instantly. Unlike
+    /// `shutdown()` this does NOT set `shutdownRequested`, so the connection loop
+    /// keeps running; unlike a plain connection error it skips the reconnect
+    /// backoff sleep (the 1001 close code literally means "going away").
+    ///
+    /// MUST be preceded by `markPlannedRestart()` — which the `.goingAway` arm in
+    /// ProviderLoop always calls on receipt, before the drain — as that is what
+    /// arms `plannedRestart`. This method does NOT arm it. If an earlier
+    /// UNEXPECTED close already consumed `plannedRestart` and drove the no-backoff
+    /// reconnect, we are now on a FRESH, healthy connection, so this SELF-CANCELS
+    /// into a no-op rather than cancelling that healthy socket and flapping it.
+    /// No-op once a real shutdown is already in progress.
     public func requestPlannedRestart() {
         guard !shutdownRequested else { return }
-        plannedRestart = true
+        // If an earlier (unexpected) close already drove the no-backoff reconnect
+        // path, `plannedRestart` was consumed and we are now on a FRESH connection —
+        // do not cancel it (that would flap a healthy socket). Only the still-armed
+        // case (normal drain-then-close) should close here. `markPlannedRestart()`
+        // (always called on going_away receipt, before the drain) is what arms it.
+        guard plannedRestart else { return }
         webSocketTask?.cancel(with: .goingAway, reason: nil)
     }
 

--- a/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClient.swift
+++ b/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClient.swift
@@ -557,11 +557,11 @@ public actor CoordinatorClient {
 
     private var shutdownRequested = false
 
-    /// Set by `requestPlannedRestart()` when the coordinator announces it is
+    /// Set by `markPlannedRestart()` when the coordinator announces it is
     /// going away (DAR-327 Phase 3). Unlike `shutdownRequested` this does NOT
     /// exit the connection loop — it makes the next reconnect skip the backoff
     /// sleep so the provider lands on the freshly-deployed coordinator
-    /// near-instantly. Cleared by `runLoop` once the immediate reconnect is taken.
+    /// near-instantly. Cleared only after a new registration succeeds.
     private var plannedRestart = false
 
     /// Mutable advertised-model list. Seeded from `config.models`; background
@@ -670,9 +670,11 @@ public actor CoordinatorClient {
     /// mid-drain (an early/unexpected close, not our explicit post-drain
     /// `requestPlannedRestart`), `runLoop` still observes `plannedRestart` and
     /// takes the no-backoff reconnect path instead of treating it as an ordinary
-    /// disconnect and backing off. The socket is left ALIVE here so in-flight
-    /// work can finish draining first (drain-before-close). Idempotent; no-op once
-    /// a real shutdown is already in progress.
+    /// disconnect and backing off. The flag stays armed across failed reconnect
+    /// attempts and is cleared once a new registration succeeds. The socket is
+    /// left ALIVE here so in-flight work can finish draining first
+    /// (drain-before-close). Idempotent; no-op once a real shutdown is already
+    /// in progress.
     public func markPlannedRestart() {
         guard !shutdownRequested else { return }
         plannedRestart = true
@@ -690,17 +692,16 @@ public actor CoordinatorClient {
     /// MUST be preceded by `markPlannedRestart()` — which the `.goingAway` arm in
     /// ProviderLoop always calls on receipt, before the drain — as that is what
     /// arms `plannedRestart`. This method does NOT arm it. If an earlier
-    /// UNEXPECTED close already consumed `plannedRestart` and drove the no-backoff
-    /// reconnect, we are now on a FRESH, healthy connection, so this SELF-CANCELS
-    /// into a no-op rather than cancelling that healthy socket and flapping it.
-    /// No-op once a real shutdown is already in progress.
+    /// UNEXPECTED close already drove the fast reconnect and a fresh registration
+    /// succeeded, `connectAndRun` cleared `plannedRestart`, so a delayed drain
+    /// self-cancels into a no-op rather than cancelling that healthy socket and
+    /// flapping it. No-op once a real shutdown is already in progress.
     public func requestPlannedRestart() {
         guard !shutdownRequested else { return }
-        // If an earlier (unexpected) close already drove the no-backoff reconnect
-        // path, `plannedRestart` was consumed and we are now on a FRESH connection —
-        // do not cancel it (that would flap a healthy socket). Only the still-armed
-        // case (normal drain-then-close) should close here. `markPlannedRestart()`
-        // (always called on going_away receipt, before the drain) is what arms it.
+        // If an earlier (unexpected) close already drove the fast reconnect and a
+        // fresh registration succeeded, `plannedRestart` has been cleared; do not
+        // cancel that healthy socket. Only the still-armed case (normal
+        // drain-then-close or repeated failed reconnects) should close here.
         guard plannedRestart else { return }
         webSocketTask?.cancel(with: .goingAway, reason: nil)
     }
@@ -728,11 +729,10 @@ public actor CoordinatorClient {
                 // A planned restart (going_away) that closed the socket cleanly:
                 // reconnect with the backoff reset, but apply a small RANDOM
                 // jitter first so the synchronized fleet-wide going_away doesn't
-                // stampede the freshly-deployed coordinator. A plain clean close
-                // still reconnects immediately. Consume the flag exactly once so
-                // a later real error uses normal backoff.
+                // stampede the freshly-deployed coordinator. Keep the flag armed
+                // until a new registration succeeds, so repeated old-node closes
+                // stay on the fast reconnect path instead of exponential backoff.
                 if plannedRestart {
-                    plannedRestart = false
                     await sleepPlannedRestartJitter()
                 }
                 continue
@@ -745,10 +745,10 @@ public actor CoordinatorClient {
                 // going_away is fleet-wide and synchronized, so a zero-delay
                 // reconnect would send every idle provider onto the just-deployed
                 // (most fragile) coordinator in lockstep — the exact herd
-                // ExponentialBackoff's jitter exists to break. Consume the flag
-                // exactly once. Mirrors the clean-close path above.
+                // ExponentialBackoff's jitter exists to break. Keep the flag armed
+                // across failed reconnect attempts (for example old-node 503s)
+                // until `connectAndRun` successfully registers on a new socket.
                 if plannedRestart {
-                    plannedRestart = false
                     backoff.reset()
                     await sleepPlannedRestartJitter()
                     continue
@@ -811,6 +811,9 @@ public actor CoordinatorClient {
 
         try await sendRegistration(ws: ws)
         logger.info("Sent registration to coordinator")
+        // Successful registration means this planned restart landed; end the
+        // fast-reconnect window so delayed drains won't flap the fresh socket.
+        plannedRestart = false
 
         // Fresh outbound stream for THIS connection. AsyncStream is single-shot:
         // its iterator is terminated when the previous session's consumer task is

--- a/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClient.swift
+++ b/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClient.swift
@@ -34,6 +34,10 @@ public enum CoordinatorEvent: Sendable {
     case desiredModels(entries: [CoordinatorMessage.DesiredModelEntry])
     /// Coordinator informs the provider of its current trust level and status.
     case trustStatus(trustLevel: String, status: String, reason: String)
+    /// Coordinator announced a planned restart (graceful shutdown), DAR-327
+    /// Phase 3. The provider drains in-flight work then forces an immediate
+    /// reconnect (backoff reset) so it lands on the freshly-deployed coordinator.
+    case goingAway
 }
 
 // MARK: - Shared State
@@ -553,6 +557,13 @@ public actor CoordinatorClient {
 
     private var shutdownRequested = false
 
+    /// Set by `requestPlannedRestart()` when the coordinator announces it is
+    /// going away (DAR-327 Phase 3). Unlike `shutdownRequested` this does NOT
+    /// exit the connection loop — it makes the next reconnect skip the backoff
+    /// sleep so the provider lands on the freshly-deployed coordinator
+    /// near-instantly. Cleared by `runLoop` once the immediate reconnect is taken.
+    private var plannedRestart = false
+
     /// Mutable advertised-model list. Seeded from `config.models`; background
     /// prefetch (Layer 3) appends newly-verified builds so re-registration and
     /// reconnects pick them up without dropping the currently-served model.
@@ -653,6 +664,22 @@ public actor CoordinatorClient {
         webSocketTask?.cancel(with: .goingAway, reason: nil)
     }
 
+    /// Tear down the current coordinator connection and reconnect IMMEDIATELY
+    /// with the backoff RESET (no sleep). Used when the coordinator announces a
+    /// planned restart (`going_away`, DAR-327 Phase 3): after the provider drains
+    /// its in-flight work it closes the socket here and lands on the
+    /// freshly-deployed coordinator near-instantly. Unlike `shutdown()` this does
+    /// NOT set `shutdownRequested`, so the connection loop keeps running; unlike a
+    /// plain connection error it skips the reconnect backoff sleep. No-op once a
+    /// real shutdown is already in progress. Cancelling the socket surfaces as a
+    /// connection error so `runLoop` re-runs `sendRegistration` on the new
+    /// coordinator (the 1001 close code literally means "going away").
+    public func requestPlannedRestart() {
+        guard !shutdownRequested else { return }
+        plannedRestart = true
+        webSocketTask?.cancel(with: .goingAway, reason: nil)
+    }
+
     /// Record refreshed per-model weight hashes for use in future
     /// (re)registrations. Called by the provider loop after a model (re)load
     /// recomputes the on-disk weight hash. See `modelWeightHashOverrides`.
@@ -672,10 +699,24 @@ public actor CoordinatorClient {
             do {
                 try await connectAndRun()
                 logger.info("Coordinator connection closed, reconnecting...")
+                // A planned restart (going_away) that closed the socket cleanly:
+                // the clean path already reconnects with no sleep; just clear the
+                // flag so a later real error still uses normal backoff.
+                plannedRestart = false
                 backoff.reset()
                 continue
             } catch {
                 if shutdownRequested { break }
+
+                // Planned restart (coordinator going_away, DAR-327 Phase 3): skip
+                // the backoff sleep and reconnect immediately so we land on the
+                // freshly-deployed coordinator. Mirrors the clean-close path above.
+                if plannedRestart {
+                    plannedRestart = false
+                    backoff.reset()
+                    logger.info("Planned restart: reconnecting immediately (backoff reset, no sleep)")
+                    continue
+                }
 
                 eventContinuation?.yield(.disconnected)
                 let delay = backoff.nextDelay()
@@ -950,6 +991,10 @@ public actor CoordinatorClient {
                 status: ts.status,
                 reason: ts.reason
             ))
+
+        case .goingAway:
+            logger.info("Coordinator announced going_away (planned restart); will drain in-flight work and reconnect")
+            eventContinuation?.yield(.goingAway)
         }
     }
 

--- a/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClient.swift
+++ b/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClient.swift
@@ -664,6 +664,20 @@ public actor CoordinatorClient {
         webSocketTask?.cancel(with: .goingAway, reason: nil)
     }
 
+    /// Mark that the NEXT disconnect is a planned restart (`going_away`, DAR-327
+    /// Phase 3) WITHOUT closing the socket. This is called the moment going_away
+    /// is received — before the in-flight drain — so that if the socket dies
+    /// mid-drain (an early/unexpected close, not our explicit post-drain
+    /// `requestPlannedRestart`), `runLoop` still observes `plannedRestart` and
+    /// takes the no-backoff reconnect path instead of treating it as an ordinary
+    /// disconnect and backing off. The socket is left ALIVE here so in-flight
+    /// work can finish draining first (drain-before-close). Idempotent; no-op once
+    /// a real shutdown is already in progress.
+    public func markPlannedRestart() {
+        guard !shutdownRequested else { return }
+        plannedRestart = true
+    }
+
     /// Tear down the current coordinator connection and reconnect IMMEDIATELY
     /// with the backoff RESET (no sleep). Used when the coordinator announces a
     /// planned restart (`going_away`, DAR-327 Phase 3): after the provider drains
@@ -673,7 +687,9 @@ public actor CoordinatorClient {
     /// plain connection error it skips the reconnect backoff sleep. No-op once a
     /// real shutdown is already in progress. Cancelling the socket surfaces as a
     /// connection error so `runLoop` re-runs `sendRegistration` on the new
-    /// coordinator (the 1001 close code literally means "going away").
+    /// coordinator (the 1001 close code literally means "going away"). The
+    /// `plannedRestart` flag is set here too (idempotent with `markPlannedRestart`)
+    /// so this remains correct when called on its own.
     public func requestPlannedRestart() {
         guard !shutdownRequested else { return }
         plannedRestart = true

--- a/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClient.swift
+++ b/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClient.swift
@@ -699,22 +699,33 @@ public actor CoordinatorClient {
             do {
                 try await connectAndRun()
                 logger.info("Coordinator connection closed, reconnecting...")
-                // A planned restart (going_away) that closed the socket cleanly:
-                // the clean path already reconnects with no sleep; just clear the
-                // flag so a later real error still uses normal backoff.
-                plannedRestart = false
                 backoff.reset()
+                // A planned restart (going_away) that closed the socket cleanly:
+                // reconnect with the backoff reset, but apply a small RANDOM
+                // jitter first so the synchronized fleet-wide going_away doesn't
+                // stampede the freshly-deployed coordinator. A plain clean close
+                // still reconnects immediately. Consume the flag exactly once so
+                // a later real error uses normal backoff.
+                if plannedRestart {
+                    plannedRestart = false
+                    await sleepPlannedRestartJitter()
+                }
                 continue
             } catch {
                 if shutdownRequested { break }
 
                 // Planned restart (coordinator going_away, DAR-327 Phase 3): skip
-                // the backoff sleep and reconnect immediately so we land on the
-                // freshly-deployed coordinator. Mirrors the clean-close path above.
+                // the EXPONENTIAL backoff sleep so we land on the freshly-deployed
+                // coordinator fast — but still apply a small bounded RANDOM jitter.
+                // going_away is fleet-wide and synchronized, so a zero-delay
+                // reconnect would send every idle provider onto the just-deployed
+                // (most fragile) coordinator in lockstep — the exact herd
+                // ExponentialBackoff's jitter exists to break. Consume the flag
+                // exactly once. Mirrors the clean-close path above.
                 if plannedRestart {
                     plannedRestart = false
                     backoff.reset()
-                    logger.info("Planned restart: reconnecting immediately (backoff reset, no sleep)")
+                    await sleepPlannedRestartJitter()
                     continue
                 }
 
@@ -739,6 +750,22 @@ public actor CoordinatorClient {
 
         logger.info("Coordinator client shut down")
         eventContinuation?.finish()
+    }
+
+    /// Sleep a small bounded random jitter (0–3s) before a planned-restart
+    /// reconnect. `going_away` (DAR-327 Phase 3) is a fleet-wide synchronized
+    /// event: a zero-delay reconnect would stampede every idle provider onto the
+    /// just-deployed — and most fragile — coordinator in lockstep, the
+    /// synchronized herd that `ExponentialBackoff`'s own jitter exists to break.
+    /// Spreading reconnects over a few seconds keeps the landing "near-instant"
+    /// while avoiding the thundering herd. Cancellable (`try?`): a shutdown
+    /// during the sleep simply falls through to the loop's `shutdownRequested`
+    /// guard, which breaks on the next iteration. Does NOT touch
+    /// `shutdownRequested` or the exponential backoff state.
+    private func sleepPlannedRestartJitter() async {
+        let jitterMs = Int.random(in: 0...3000)
+        logger.info("Planned restart: reconnecting after \(jitterMs)ms jitter (backoff reset)")
+        try? await Task.sleep(for: .milliseconds(jitterMs))
     }
 
     // MARK: - Single Connection Session

--- a/provider-swift/Sources/ProviderCore/Protocol/Messages.swift
+++ b/provider-swift/Sources/ProviderCore/Protocol/Messages.swift
@@ -643,6 +643,7 @@ public enum CoordinatorMessage: Sendable, Equatable {
     case prefetchModel(PrefetchModel)
     case desiredModels(DesiredModels)
     case trustStatus(TrustStatus)
+    case goingAway(GoingAway)
 
     public struct InferenceRequest: Sendable, Equatable {
         public var requestId: String
@@ -743,6 +744,16 @@ public enum CoordinatorMessage: Sendable, Equatable {
             self.reason = reason
         }
     }
+
+    /// Coordinator announces a planned restart (graceful shutdown), DAR-327
+    /// Phase 3. On receipt the provider finishes its in-flight work, closes its
+    /// WebSocket, and reconnects with its exponential backoff RESET (no backoff
+    /// sleep) so it lands on the freshly-deployed coordinator near-instantly.
+    /// Type-only on the wire ({"type":"going_away"}); the drain + reconnect
+    /// policy lives entirely on the provider. Mirrors Go protocol.GoingAwayMessage.
+    public struct GoingAway: Sendable, Equatable {
+        public init() {}
+    }
 }
 
 // MARK: - CoordinatorMessage Codable
@@ -757,6 +768,7 @@ extension CoordinatorMessage: Codable {
         case prefetchModel = "prefetch_model"
         case desiredModels = "desired_models"
         case trustStatus = "trust_status"
+        case goingAway = "going_away"
     }
 
     enum CodingKeys: String, CodingKey {
@@ -822,6 +834,10 @@ extension CoordinatorMessage: Codable {
             if !t.reason.isEmpty {
                 try container.encode(t.reason, forKey: .reason)
             }
+
+        case .goingAway:
+            // Type-only: matches Go's GoingAwayMessage ({"type":"going_away"}).
+            try container.encode(TypeValue.goingAway, forKey: .type)
         }
     }
 
@@ -876,6 +892,9 @@ extension CoordinatorMessage: Codable {
                 status: try container.decode(String.self, forKey: .status),
                 reason: try container.decodeIfPresent(String.self, forKey: .reason) ?? ""
             ))
+
+        case .goingAway:
+            self = .goingAway(GoingAway())
         }
     }
 }

--- a/provider-swift/Sources/ProviderCore/ProviderCore.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderCore.swift
@@ -75,5 +75,8 @@ public enum ProviderCore {
     // jinja_null_bridge / jinja_template / model_load), so durable telemetry can
     // tell the two indistinguishable gpt-oss 500 modes apart. Wire-compatible:
     // `error_reason` is an optional inference-error field, omitted when nil.
-    public static let version = "0.6.17"
+    // 0.6.18 adds the DAR-327 coordinator `going_away` control message decoder +
+    // planned-restart reconnect path. Coordinator broadcasts are gated to
+    // provider version >= 0.6.18 so pre-feature strict decoders never see it.
+    public static let version = "0.6.18"
 }

--- a/provider-swift/Sources/ProviderCore/ProviderLoop.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop.swift
@@ -789,7 +789,8 @@ public actor ProviderLoop {
                             await self.drainThenPlannedRestart(coordinator: coordinator)
                         }
                     } else {
-                        logger.info("going_away received during an in-progress update; deferring to that update's restart")
+                        await coordinator.markPlannedRestart()
+                        logger.info("going_away received during an in-progress update; planned restart armed, deferring actual restart to that update")
                     }
                 }
             }
@@ -2552,6 +2553,9 @@ public actor ProviderLoop {
     /// admission afterward via `resumeServingAfterUpdate`.
     private func drainThenPlannedRestart(coordinator: CoordinatorClient) async {
         let drained = await waitForInflightDrain(timeout: Self.goingAwayDrainTimeout)
+        if Task.isCancelled {
+            return
+        }
         if !drained {
             logger.warning("going_away: in-flight drain timed out; cancelling remaining requests")
             await cancelAllInflight()

--- a/provider-swift/Sources/ProviderCore/ProviderLoop.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop.swift
@@ -229,6 +229,12 @@ public actor ProviderLoop {
     }
     private var updatePhase: UpdatePhase = .idle
 
+    /// Coordinator-only restart drain (`going_away`): refuse new coordinator-routed
+    /// work while the WebSocket reconnects, but keep the local unified endpoint
+    /// serving. This is intentionally separate from updatePhase `.draining`, which
+    /// precedes a process restart and therefore must also refuse local work.
+    private var coordinatorRestartDraining = false
+
     /// Verified update bundle staged on disk during `.installing`, awaiting the
     /// post-drain commit. The live layout is untouched until the commit, so a
     /// request can never observe a half-replaced bundle. Consumed by
@@ -763,10 +769,12 @@ public actor ProviderLoop {
 
                 case .goingAway:
                     // Coordinator is restarting (graceful shutdown / blue-green
-                    // cutover, DAR-327 Phase 3). Flip admission to draining
-                    // SYNCHRONOUSLY here — before any await — so new work is
-                    // refused immediately and a second going_away can't
-                    // double-spawn the drain. Then mark the planned restart on the
+                    // cutover, DAR-327 Phase 3). Flip COORDINATOR admission to
+                    // draining SYNCHRONOUSLY here — before any await — so new
+                    // coordinator-routed work is refused immediately and a second
+                    // going_away can't double-spawn the drain. Local unified-mode
+                    // inference keeps serving because only the coordinator
+                    // WebSocket is reconnecting. Then mark the planned restart on the
                     // coordinator client IMMEDIATELY (before the drain), so that
                     // even if the socket dies mid-drain — an early/unexpected close
                     // rather than our own post-drain close — runLoop still takes
@@ -781,8 +789,8 @@ public actor ProviderLoop {
                     // ordering. If an auto-update is already draining/installing it
                     // owns the process restart — defer to it.
                     if updatePhase == .idle {
-                        logger.warning("Coordinator going away (planned restart); draining in-flight work then reconnecting")
-                        beginUpdateDraining()
+                        logger.warning("Coordinator going away (planned restart); draining coordinator-routed work then reconnecting")
+                        beginCoordinatorRestartDraining()
                         await coordinator.markPlannedRestart()
                         goingAwayTask?.cancel()
                         goingAwayTask = Task { [coordinator] in
@@ -976,10 +984,12 @@ public actor ProviderLoop {
     /// registration that follows (no suspension in between).
     private var isDrainingForUpdate: Bool { updatePhase == .draining }
 
+    private var isRefusingCoordinatorWork: Bool { isDrainingForUpdate || coordinatorRestartDraining }
+
     /// Coordinator admission: sends the 503 reroute and returns true if the
     /// request must be dropped because we're draining.
     private func rejectIfDrainingForUpdate(requestId: String, send: SendHandle) -> Bool {
-        guard isDrainingForUpdate else { return false }
+        guard isRefusingCoordinatorWork else { return false }
         send.send(.inferenceError(
             requestId: requestId,
             error: providerDrainingForUpdateReason,
@@ -2541,18 +2551,31 @@ public actor ProviderLoop {
         updatePhase = .draining
     }
 
+    /// Enter the coordinator-only restart drain used for `going_away`. Unlike an
+    /// update drain, this does NOT set updatePhase `.draining`, so the local
+    /// endpoint does not reject or block on localReservations for a coordinator
+    /// WebSocket reconnect.
+    private func beginCoordinatorRestartDraining() {
+        coordinatorRestartDraining = true
+    }
+
+    private func resumeServingAfterCoordinatorRestart() {
+        coordinatorRestartDraining = false
+    }
+
     /// Drain in-flight work then force the planned-restart reconnect, run off the
     /// event-consumer loop as a child task (DAR-327 Phase 3). The caller has
-    /// already flipped `updatePhase` to `.draining` (synchronously) AND called
-    /// `markPlannedRestart()` on receipt, so admission is closed and the
-    /// no-backoff reconnect is armed even if the socket dies mid-drain. Here
-    /// we only drain → close → reopen, preserving the drain-before-close ordering.
+    /// already flipped coordinator-only admission to draining (synchronously) AND
+    /// called `markPlannedRestart()` on receipt, so coordinator-routed admission is
+    /// closed and the no-backoff reconnect is armed even if the socket dies mid-
+    /// drain. Local unified-mode inference remains admitted and is not part of this
+    /// drain because only the coordinator WebSocket is reconnecting.
     /// `requestPlannedRestart` cancels the socket (the flag is already set, so this
     /// is the explicit graceful close) so `runLoop` reconnects (jittered) onto the
     /// freshly-deployed coordinator; the process does NOT restart, so we reopen
     /// admission afterward via `resumeServingAfterUpdate`.
     private func drainThenPlannedRestart(coordinator: CoordinatorClient) async {
-        let drained = await waitForInflightDrain(timeout: Self.goingAwayDrainTimeout)
+        let drained = await waitForCoordinatorInflightDrain(timeout: Self.goingAwayDrainTimeout)
         if Task.isCancelled {
             return
         }
@@ -2561,7 +2584,7 @@ public actor ProviderLoop {
             await cancelAllInflight()
         }
         await coordinator.requestPlannedRestart()
-        await resumeServingAfterUpdate()
+        resumeServingAfterCoordinatorRestart()
     }
 
     /// Download, verify, and stage the release bundle while still serving.
@@ -3277,10 +3300,17 @@ public actor ProviderLoop {
 
     /// Whether any inference work is still in flight — coordinator-routed
     /// (`inflightTasks`/`requestToModel`) OR local-endpoint streams
-    /// (`localReservations`). Drain logic (shutdown + update hot-swap) waits on
-    /// all three so a local stream is never cut off mid-generation.
+    /// (`localReservations`). Shutdown + update hot-swap drains wait on all three
+    /// so a local stream is never cut off mid-generation.
     private var hasInflightWork: Bool {
         !inflightTasks.isEmpty || !requestToModel.isEmpty || localReservations.hasAny
+    }
+
+    /// Coordinator-routed work only. Used for coordinator `going_away` reconnects:
+    /// local unified-mode inference does not depend on the coordinator WebSocket
+    /// and must not block re-registration or start returning queue-full locally.
+    private var hasCoordinatorInflightWork: Bool {
+        !inflightTasks.isEmpty || !requestToModel.isEmpty
     }
 
     private func waitForInflightDrain(timeout: Duration) async -> Bool {
@@ -3288,6 +3318,24 @@ public actor ProviderLoop {
         logger.info("Waiting up to \(timeout.components.seconds)s for active inference to finish before shutdown")
         let started = ContinuousClock.now
         while hasInflightWork {
+            if Task.isCancelled { return false }
+            if ContinuousClock.now - started >= timeout {
+                return false
+            }
+            do {
+                try await Task.sleep(for: .milliseconds(250))
+            } catch {
+                return false
+            }
+        }
+        return true
+    }
+
+    private func waitForCoordinatorInflightDrain(timeout: Duration) async -> Bool {
+        guard hasCoordinatorInflightWork else { return true }
+        logger.info("Waiting up to \(timeout.components.seconds)s for coordinator-routed inference to finish before reconnect")
+        let started = ContinuousClock.now
+        while hasCoordinatorInflightWork {
             if Task.isCancelled { return false }
             if ContinuousClock.now - started >= timeout {
                 return false

--- a/provider-swift/Sources/ProviderCore/ProviderLoop.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop.swift
@@ -396,6 +396,12 @@ public actor ProviderLoop {
     private let logger = ProviderLogger(subsystem: "dev.darkbloom.provider", category: "loop")
 
     private static let shutdownDrainTimeout: Duration = .seconds(600)
+    /// Drain budget for a coordinator-announced planned restart (going_away,
+    /// DAR-327 Phase 3). Shorter than `shutdownDrainTimeout` (600s) on purpose:
+    /// the goal is to land on the freshly-deployed coordinator fast, so we let
+    /// in-flight work finish but cap the wait at ~the coordinator's request-queue
+    /// timeout (120s) before force-cancelling and reconnecting.
+    private static let goingAwayDrainTimeout: Duration = .seconds(120)
     private static let preloadShutdownTimeout: Duration = .seconds(10)
     private static let bytesPerGiB: UInt64 = 1024 * 1024 * 1024
 
@@ -747,6 +753,30 @@ public actor ProviderLoop {
 
                 case .trustStatus(let trustLevel, let status, let reason):
                     handleTrustStatus(trustLevel: trustLevel, status: status, reason: reason)
+
+                case .goingAway:
+                    // Coordinator is restarting (graceful shutdown, DAR-327
+                    // Phase 3). Drain in-flight work the same way the auto-update
+                    // and shutdown paths do, then force an IMMEDIATE reconnect
+                    // (backoff reset) so we land on the freshly-deployed
+                    // coordinator. The process does NOT restart, so we reopen
+                    // admission afterward (resumeServingAfterUpdate) instead of
+                    // exiting. If an auto-update is already draining/installing it
+                    // will restart the process (reconnecting fresh) — let it own
+                    // the lifecycle and fall back to the normal reconnect.
+                    if updatePhase == .idle {
+                        logger.warning("Coordinator going away (planned restart); draining in-flight work then reconnecting")
+                        beginUpdateDraining()
+                        let drained = await waitForInflightDrain(timeout: Self.goingAwayDrainTimeout)
+                        if !drained {
+                            logger.warning("going_away: in-flight drain timed out; cancelling remaining requests")
+                            await cancelAllInflight()
+                        }
+                        await coordinator.requestPlannedRestart()
+                        await resumeServingAfterUpdate()
+                    } else {
+                        logger.info("going_away received during an in-progress update; deferring to that update's restart")
+                    }
                 }
             }
         } onCancel: {

--- a/provider-swift/Sources/ProviderCore/ProviderLoop.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop.swift
@@ -388,6 +388,13 @@ public actor ProviderLoop {
     /// before `run()` starts it.
     private var autoUpdateTask: Task<Void, Never>?
 
+    /// Child task running the going_away drain → planned-restart reconnect off
+    /// the event-consumer loop (DAR-327 Phase 3). Spawned by the `.goingAway`
+    /// arm so a long (≤120s) in-flight drain can't stall other coordinator
+    /// events. Tracked so shutdown cancels it instead of leaving it draining
+    /// after the event stream ends.
+    private var goingAwayTask: Task<Void, Never>?
+
     /// Reacts to kernel memory pressure (reclaim MLX cache, mark an imminent
     /// OOM). Held for the loop's lifetime so the DispatchSource isn't
     /// deallocated. See `MemoryPressureMonitor` / `OOMDetector`.
@@ -756,24 +763,25 @@ public actor ProviderLoop {
 
                 case .goingAway:
                     // Coordinator is restarting (graceful shutdown, DAR-327
-                    // Phase 3). Drain in-flight work the same way the auto-update
-                    // and shutdown paths do, then force an IMMEDIATE reconnect
-                    // (backoff reset) so we land on the freshly-deployed
-                    // coordinator. The process does NOT restart, so we reopen
-                    // admission afterward (resumeServingAfterUpdate) instead of
-                    // exiting. If an auto-update is already draining/installing it
-                    // will restart the process (reconnecting fresh) — let it own
-                    // the lifecycle and fall back to the normal reconnect.
+                    // Phase 3). Flip admission to draining SYNCHRONOUSLY here —
+                    // before any await — so new work is refused immediately and a
+                    // second going_away can't double-spawn the drain. Then run the
+                    // drain → planned-restart reconnect → reopen sequence on a
+                    // CHILD TASK so a long (≤120s) drain no longer blocks this
+                    // single event-consumer loop: cancellations (which free
+                    // in-flight work and let the drain finish sooner) and
+                    // attestation challenges (a 120s stall could trip the
+                    // coordinator's trust timer) keep flowing meanwhile. The child
+                    // preserves the drain-before-reconnect ordering. If an
+                    // auto-update is already draining/installing it owns the
+                    // process restart — defer to it.
                     if updatePhase == .idle {
                         logger.warning("Coordinator going away (planned restart); draining in-flight work then reconnecting")
                         beginUpdateDraining()
-                        let drained = await waitForInflightDrain(timeout: Self.goingAwayDrainTimeout)
-                        if !drained {
-                            logger.warning("going_away: in-flight drain timed out; cancelling remaining requests")
-                            await cancelAllInflight()
+                        goingAwayTask?.cancel()
+                        goingAwayTask = Task { [coordinator] in
+                            await self.drainThenPlannedRestart(coordinator: coordinator)
                         }
-                        await coordinator.requestPlannedRestart()
-                        await resumeServingAfterUpdate()
                     } else {
                         logger.info("going_away received during an in-progress update; deferring to that update's restart")
                     }
@@ -793,6 +801,12 @@ public actor ProviderLoop {
         autoUpdateTask = nil
         autoReportTask?.cancel()
         autoReportTask = nil
+        // Stop the going_away drain task (DAR-327 Phase 3) if one is mid-drain:
+        // we're shutting down, so its reconnect/reopen is moot. Cancelling makes
+        // its waitForInflightDrain return promptly; the teardown below owns the
+        // final drain + coordinator.shutdown().
+        goingAwayTask?.cancel()
+        goingAwayTask = nil
         // Cancel any scheduled desired-build prefetch retries before tearing
         // the prefetch subsystem down.
         for task in desiredPrefetchRetryTasks.values { task.cancel() }
@@ -2518,6 +2532,24 @@ public actor ProviderLoop {
     /// hot-swap.
     private func beginUpdateDraining() {
         updatePhase = .draining
+    }
+
+    /// Drain in-flight work then force the planned-restart reconnect, run off the
+    /// event-consumer loop as a child task (DAR-327 Phase 3). The caller has
+    /// already flipped `updatePhase` to `.draining` synchronously, so admission
+    /// is closed; here we only drain → reconnect → reopen, preserving the
+    /// drain-before-reconnect ordering. `requestPlannedRestart` cancels the
+    /// socket so `runLoop` reconnects (jittered) onto the freshly-deployed
+    /// coordinator; the process does NOT restart, so we reopen admission
+    /// afterward via `resumeServingAfterUpdate`.
+    private func drainThenPlannedRestart(coordinator: CoordinatorClient) async {
+        let drained = await waitForInflightDrain(timeout: Self.goingAwayDrainTimeout)
+        if !drained {
+            logger.warning("going_away: in-flight drain timed out; cancelling remaining requests")
+            await cancelAllInflight()
+        }
+        await coordinator.requestPlannedRestart()
+        await resumeServingAfterUpdate()
     }
 
     /// Download, verify, and stage the release bundle while still serving.

--- a/provider-swift/Sources/ProviderCore/ProviderLoop.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop.swift
@@ -762,22 +762,28 @@ public actor ProviderLoop {
                     handleTrustStatus(trustLevel: trustLevel, status: status, reason: reason)
 
                 case .goingAway:
-                    // Coordinator is restarting (graceful shutdown, DAR-327
-                    // Phase 3). Flip admission to draining SYNCHRONOUSLY here —
-                    // before any await — so new work is refused immediately and a
-                    // second going_away can't double-spawn the drain. Then run the
-                    // drain → planned-restart reconnect → reopen sequence on a
-                    // CHILD TASK so a long (≤120s) drain no longer blocks this
-                    // single event-consumer loop: cancellations (which free
-                    // in-flight work and let the drain finish sooner) and
-                    // attestation challenges (a 120s stall could trip the
-                    // coordinator's trust timer) keep flowing meanwhile. The child
-                    // preserves the drain-before-reconnect ordering. If an
-                    // auto-update is already draining/installing it owns the
-                    // process restart — defer to it.
+                    // Coordinator is restarting (graceful shutdown / blue-green
+                    // cutover, DAR-327 Phase 3). Flip admission to draining
+                    // SYNCHRONOUSLY here — before any await — so new work is
+                    // refused immediately and a second going_away can't
+                    // double-spawn the drain. Then mark the planned restart on the
+                    // coordinator client IMMEDIATELY (before the drain), so that
+                    // even if the socket dies mid-drain — an early/unexpected close
+                    // rather than our own post-drain close — runLoop still takes
+                    // the no-backoff planned-restart path instead of backing off
+                    // and defeating instant reconnect. Only THEN run the
+                    // drain → close → reconnect → reopen sequence on a CHILD TASK
+                    // so a long (≤120s) drain no longer blocks this single
+                    // event-consumer loop: cancellations (which free in-flight work
+                    // and let the drain finish sooner) and attestation challenges
+                    // (a 120s stall could trip the coordinator's trust timer) keep
+                    // flowing meanwhile. The child preserves the drain-before-close
+                    // ordering. If an auto-update is already draining/installing it
+                    // owns the process restart — defer to it.
                     if updatePhase == .idle {
                         logger.warning("Coordinator going away (planned restart); draining in-flight work then reconnecting")
                         beginUpdateDraining()
+                        await coordinator.markPlannedRestart()
                         goingAwayTask?.cancel()
                         goingAwayTask = Task { [coordinator] in
                             await self.drainThenPlannedRestart(coordinator: coordinator)
@@ -2536,12 +2542,14 @@ public actor ProviderLoop {
 
     /// Drain in-flight work then force the planned-restart reconnect, run off the
     /// event-consumer loop as a child task (DAR-327 Phase 3). The caller has
-    /// already flipped `updatePhase` to `.draining` synchronously, so admission
-    /// is closed; here we only drain → reconnect → reopen, preserving the
-    /// drain-before-reconnect ordering. `requestPlannedRestart` cancels the
-    /// socket so `runLoop` reconnects (jittered) onto the freshly-deployed
-    /// coordinator; the process does NOT restart, so we reopen admission
-    /// afterward via `resumeServingAfterUpdate`.
+    /// already flipped `updatePhase` to `.draining` (synchronously) AND called
+    /// `markPlannedRestart()` on receipt, so admission is closed and the
+    /// no-backoff reconnect is armed even if the socket dies mid-drain. Here
+    /// we only drain → close → reopen, preserving the drain-before-close ordering.
+    /// `requestPlannedRestart` cancels the socket (the flag is already set, so this
+    /// is the explicit graceful close) so `runLoop` reconnects (jittered) onto the
+    /// freshly-deployed coordinator; the process does NOT restart, so we reopen
+    /// admission afterward via `resumeServingAfterUpdate`.
     private func drainThenPlannedRestart(coordinator: CoordinatorClient) async {
         let drained = await waitForInflightDrain(timeout: Self.goingAwayDrainTimeout)
         if !drained {

--- a/provider-swift/Tests/ProviderCoreTests/ProtocolTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/ProtocolTests.swift
@@ -401,6 +401,26 @@ import Testing
     #expect(emptyDesired.models.isEmpty)
 }
 
+@Test func goingAwayMessageRoundTripsWithCoordinator() throws {
+    // Coordinator → provider planned-restart announcement (DAR-327 Phase 3).
+    // Decode the exact Go-emitted wire form: a type-only {"type":"going_away"}
+    // (Go's GoingAwayMessage carries no payload). This is the Swift half of the
+    // protocol-symmetry guard paired with Go's TestGoingAwayMessageMarshal.
+    let goWire = #"{"type":"going_away"}"#
+    let decoded = try ProviderProtocolCodec.decodeCoordinatorMessage(from: goWire)
+    guard case .goingAway = decoded else {
+        throw TestFailure.unexpectedMessage
+    }
+
+    // Re-encode and confirm the wire shape: the snake_case discriminator and
+    // NOTHING else — a strict Go/Swift decoder must see exactly one key.
+    let encoded = try ProviderProtocolCodec.encodeCoordinatorMessage(decoded)
+    let object = try jsonObject(encoded)
+    #expect(object["type"] as? String == "going_away")
+    #expect(object.count == 1) // type-only: no payload keys on the wire
+    #expect(try ProviderProtocolCodec.decodeCoordinatorMessage(from: encoded) == decoded)
+}
+
 @Test func desiredModelEntryCodableRoundTripUsesSnakeCaseKeys() throws {
     // Direct Codable round-trip of the entry struct (independent of the envelope):
     // proves the CodingKeys map to snake_case and previous_build omitempty parity.


### PR DESCRIPTION
**DAR-327 Phase 3 of 3 — instant provider reconnect on planned restart** (independent, on top of Phase 0 / DAR-326). Phase 1 = #393, Phase 2 = #394.

Adds a coordinator→provider `going_away` control message. The coordinator broadcasts it at the start of a graceful shutdown (before WS teardown); each provider finishes in-flight work, closes, and reconnects with its exponential backoff **reset (no sleep)**, so it lands on the freshly-deployed coordinator near-instantly (where Phase 0 trust-reuse re-trusts it sub-second).

### Protocol (symmetry preserved)
- Go `coordinator/protocol/messages.go`: `TypeGoingAway = "going_away"` + `GoingAwayMessage` (type-only). No `UnmarshalJSON` change (C→P messages are never decoded in Go).
- Swift `Protocol/Messages.swift`: `CoordinatorMessage.goingAway(GoingAway)` + `TypeValue` + encode/decode arms.
- Symmetry tests BOTH sides pinning `{"type":"going_away"}`: Go `TestGoingAwayMessageMarshal`, Swift `goingAwayMessageRoundTripsWithCoordinator`.

### Coordinator
- `registry/registry.go`: `SendGoingAway(providerID)` + `BroadcastGoingAway()` — snapshot conns under `r.mu.RLock`→`p.mu`, write OUTSIDE locks, tolerate closed conns (honors `Disconnect`), skip providers below the version floor. Test `TestBroadcastGoingAway` (real nhooyr ws via httptest: delivery + closed-conn tolerance + below-floor skip).
- `api/server.go`: `minProviderVersionForGoingAway = "0.6.14"`; `api/going_away.go`: `providerSupportsGoingAway` gate + `Server.BroadcastGoingAway` wrapper.
- `cmd/coordinator/main.go`: broadcast at the START of graceful shutdown, before WS teardown. (No new HTTP route — avoids colliding with Phase 1's route changes.)

### Provider
- `Coordinator/CoordinatorClient.swift`: `.goingAway` event, `plannedRestart` flag, `requestPlannedRestart()`, no-sleep reconnect path in `runLoop`, dispatch in `handleIncomingText`.
- `ProviderLoop.swift`: `.goingAway` arm → drain in-flight (120s cap, force-cancel on timeout) → `requestPlannedRestart()` → resume serving after reconnect.

### Version-floor / release coordination
Floor = `0.6.14` (next cut after current `ProviderCore.version = 0.6.13`); `ProviderCore.version` intentionally NOT bumped here (release-cut action). **The release that ships this provider code must be cut at ≥ 0.6.14** so the gate matches the first binary containing the handler; until then `BroadcastGoingAway` skips all providers (safe no-op).

### Verification
- Go: `gofmt -l .` clean · `go build ./...` ok · `go test ./...` 0 failures (17 pkgs).
- Swift: `swift build` ok · `swift test --filter Protocol` → 27/27 incl. the new test.

Phase 3 of DAR-327 (independent, on top of Phase 0).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/396"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784332820&installation_id=133247490&pr_number=396&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F396&signature=31e64cd74c45d58070d6da73fd3264304e486d0144c8a16c4cc5b4f02028f335"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->