### PR TITLE
fix(routing): calibrate decode-floor shed + count in-flight VLM load

### DIFF
--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -1939,7 +1939,13 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 			// it. The dispatch/queue path still returns a 429 when the queue is
 			// full or the wait times out (true saturation). The reservation is
 			// kept for dispatch.
-			if s.queueBeforeShedEnabled() {
+			//
+			// EXCEPTION: when decode-floor hard-shed is armed, the capacity
+			// rejection may be a THROUGHPUT shed (no provider can decode at the
+			// floor), not transient memory pressure. Queueing a fundamentally
+			// too-slow fleet just defers the same outcome to a 120s timeout, so
+			// shed immediately instead — the whole point of the flag.
+			if s.queueBeforeShedEnabled() && !s.registry.DecodeFloorShedArmed() {
 				s.ddIncr("routing.decisions", []string{"model:" + model, "model_type:" + s.registry.ModelType(model), "outcome:capacity_queue_spill"})
 			} else {
 				// Legacy fast-shed: immediate 429.
@@ -4727,7 +4733,9 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 			// capacity right now. Fall through to the dispatch+queue path so a slot
 			// freeing — or a cold load completing — within the queue window serves
 			// it; the queue path still 429s on a full queue or wait timeout.
-			if s.queueBeforeShedEnabled() {
+			// EXCEPTION: decode-floor hard-shed armed → shed now, don't queue a
+			// too-slow fleet (see the matching note on the primary path above).
+			if s.queueBeforeShedEnabled() && !s.registry.DecodeFloorShedArmed() {
 				s.ddIncr("routing.decisions", []string{"model:" + model, "model_type:" + s.registry.ModelType(model), "outcome:capacity_queue_spill"})
 			} else {
 				retryAfter := s.estimateRetryAfter(model)

--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -342,6 +342,32 @@ func ttftTooSlow(bestTTFT time.Duration, hasTTFT bool, threshold time.Duration) 
 	return hasTTFT && bestTTFT > threshold
 }
 
+// pureThroughputShed reports whether a capacity rejection (candidateCount==0,
+// capacityRejections>0) is a PURE decode-floor (throughput) shed — every
+// rejection came from the throughput gate, so no provider can decode at the
+// floor. Only then does the consumer bypass queue-before-shed: queueing a
+// fundamentally too-slow fleet just defers the same outcome to a 120s timeout.
+// A mix with concurrency/memory-full-but-fast providers (decodeFloorRejections
+// < capacityRejections) must still queue — a slot can free and serve in time.
+func (s *Server) pureThroughputShed(decodeFloorRejections, capacityRejections int) bool {
+	return s.registry.DecodeFloorShedArmed() &&
+		decodeFloorRejections > 0 && decodeFloorRejections == capacityRejections
+}
+
+// capacityShedReason returns the rejection reason_code and routing.decisions
+// outcome label for a preflight capacity shed, distinguishing a decode-floor
+// (throughput) shed from an ordinary full-fleet rejection. Keeping them distinct
+// is the only way to observe the decode-floor shed in telemetry — it 429s on a
+// tuned, opt-in threshold, so its shed rate must be measurable separately from
+// genuine machine_busy capacity pressure (the lesson from the gemma incident:
+// the mitigations we could diagnose were the ones with their own reason codes).
+func capacityShedReason(throughputShed bool) (reasonCode, outcome string) {
+	if throughputShed {
+		return "decode_floor_shed", "decode_floor_shed"
+	}
+	return "machine_busy", "capacity_429"
+}
+
 func fasterTTFTEstimate(primaryModel string, primary time.Duration, alternateModel string, alternate time.Duration, alternateOK bool) (string, time.Duration) {
 	if alternateOK && alternate < primary {
 		return alternateModel, alternate
@@ -1953,20 +1979,22 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 			// would fast-429 a momentarily-full-but-fast fleet (a queue-before-shed
 			// regression). decodeFloorRejections is the subset of capacityRejections
 			// from the throughput gate; equality means a pure throughput shed.
-			pureThroughputShed := s.registry.DecodeFloorShedArmed() &&
-				decodeFloorRejections > 0 && decodeFloorRejections == capacityRejections
-			if s.queueBeforeShedEnabled() && !pureThroughputShed {
+			throughputShed := s.pureThroughputShed(decodeFloorRejections, capacityRejections)
+			if s.queueBeforeShedEnabled() && !throughputShed {
 				s.ddIncr("routing.decisions", []string{"model:" + model, "model_type:" + s.registry.ModelType(model), "outcome:capacity_queue_spill"})
 			} else {
-				// Legacy fast-shed: immediate 429.
+				// Fast-shed: immediate 429. A decode-floor (throughput) shed is
+				// recorded with a DISTINCT reason_code/outcome so it is observable
+				// separately from ordinary capacity pressure (see capacityShedReason).
+				reasonCode, outcome := capacityShedReason(throughputShed)
 				retryAfter := s.estimateRetryAfter(model)
 				w.Header().Set("Retry-After", strconv.Itoa(retryAfter))
 				refundReservation()
-				s.ddIncr("routing.decisions", []string{"model:" + model, "model_type:" + s.registry.ModelType(model), "outcome:capacity_429"})
+				s.ddIncr("routing.decisions", []string{"model:" + model, "model_type:" + s.registry.ModelType(model), "outcome:" + outcome})
 				s.recordRejection(rejectionInfo{
 					r:                       r,
 					stage:                   "preflight_capacity",
-					reasonCode:              "machine_busy",
+					reasonCode:              reasonCode,
 					httpStatus:              http.StatusTooManyRequests,
 					keyID:                   keyIDFromContext(r.Context()),
 					consumerKeyHash:         store.HashKey(consumerKeyFromContext(r.Context())),
@@ -1985,8 +2013,11 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 					modelTooLargeRejections: modelTooLarge,
 					bestTTFTMs:              ttftMsForRejection(bestTTFT, hasTTFT),
 				})
-				writeJSON(w, http.StatusTooManyRequests, errorResponse("rate_limit_exceeded",
-					fmt.Sprintf("all providers for model %q are at capacity — retry after %ds", publicModel, retryAfter),
+				msg := fmt.Sprintf("all providers for model %q are at capacity — retry after %ds", publicModel, retryAfter)
+				if throughputShed {
+					msg = fmt.Sprintf("all providers for model %q are overloaded below the decode-speed floor — retry after %ds", publicModel, retryAfter)
+				}
+				writeJSON(w, http.StatusTooManyRequests, errorResponse("rate_limit_exceeded", msg,
 					withCode("rate_limit_exceeded")))
 				return
 			}
@@ -4750,19 +4781,21 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 			// EXCEPTION: shed now ONLY when every rejection is a decode-floor
 			// (throughput) shed — a concurrency/memory-full fleet still queues (see
 			// the matching note on the primary path above).
-			pureThroughputShed := s.registry.DecodeFloorShedArmed() &&
-				decodeFloorRejections > 0 && decodeFloorRejections == capacityRejections
-			if s.queueBeforeShedEnabled() && !pureThroughputShed {
+			throughputShed := s.pureThroughputShed(decodeFloorRejections, capacityRejections)
+			if s.queueBeforeShedEnabled() && !throughputShed {
 				s.ddIncr("routing.decisions", []string{"model:" + model, "model_type:" + s.registry.ModelType(model), "outcome:capacity_queue_spill"})
 			} else {
+				// Distinct reason_code/outcome for a decode-floor (throughput) shed
+				// so it is observable separately from ordinary capacity pressure.
+				reasonCode, outcome := capacityShedReason(throughputShed)
 				retryAfter := s.estimateRetryAfter(model)
 				w.Header().Set("Retry-After", strconv.Itoa(retryAfter))
 				refundReservation()
-				s.ddIncr("routing.decisions", []string{"model:" + model, "model_type:" + s.registry.ModelType(model), "outcome:capacity_429"})
+				s.ddIncr("routing.decisions", []string{"model:" + model, "model_type:" + s.registry.ModelType(model), "outcome:" + outcome})
 				s.recordRejection(rejectionInfo{
 					r:                       r,
 					stage:                   "preflight_capacity",
-					reasonCode:              "machine_busy",
+					reasonCode:              reasonCode,
 					httpStatus:              http.StatusTooManyRequests,
 					keyID:                   keyIDFromContext(r.Context()),
 					consumerKeyHash:         store.HashKey(consumerKeyFromContext(r.Context())),
@@ -4781,8 +4814,11 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 					modelTooLargeRejections: modelTooLarge,
 					bestTTFTMs:              ttftMsForRejection(bestTTFT, hasTTFT),
 				})
-				writeJSON(w, http.StatusTooManyRequests, errorResponse("rate_limit_exceeded",
-					fmt.Sprintf("all providers for model %q are at capacity — retry after %ds", publicModel, retryAfter),
+				msg := fmt.Sprintf("all providers for model %q are at capacity — retry after %ds", publicModel, retryAfter)
+				if throughputShed {
+					msg = fmt.Sprintf("all providers for model %q are overloaded below the decode-speed floor — retry after %ds", publicModel, retryAfter)
+				}
+				writeJSON(w, http.StatusTooManyRequests, errorResponse("rate_limit_exceeded", msg,
 					withCode("rate_limit_exceeded")))
 				return
 			}

--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -311,7 +311,7 @@ func (s *Server) maybeFallbackAliasCapacity(parsed map[string]any, publicModel, 
 	if !s.registry.IsModelInCatalog(target.Previous) {
 		return currentModel, 0, 0, 0, 0, false, false
 	}
-	candidates, rejections, tooLarge, bestTTFT, hasTTFT := s.registry.QuickCapacityCheckWithTTFTForRequest(target.Previous, estimatedPromptTokens, requestedMaxTokens, traits, requiresVision, allowedProviderSerials...)
+	candidates, rejections, tooLarge, _, bestTTFT, hasTTFT := s.registry.QuickCapacityCheckWithTTFTForRequest(target.Previous, estimatedPromptTokens, requestedMaxTokens, traits, requiresVision, allowedProviderSerials...)
 	if candidates <= 0 {
 		return currentModel, candidates, rejections, tooLarge, bestTTFT, hasTTFT, false
 	}
@@ -330,7 +330,7 @@ func (s *Server) maybeFallbackAliasTTFT(parsed map[string]any, publicModel, curr
 	if !s.registry.IsModelInCatalog(target.Previous) {
 		return currentModel, 0, 0, 0, 0, false, false
 	}
-	candidates, rejections, tooLarge, bestTTFT, hasTTFT := s.registry.QuickCapacityCheckWithTTFTForRequest(target.Previous, estimatedPromptTokens, requestedMaxTokens, traits, requiresVision, allowedProviderSerials...)
+	candidates, rejections, tooLarge, _, bestTTFT, hasTTFT := s.registry.QuickCapacityCheckWithTTFTForRequest(target.Previous, estimatedPromptTokens, requestedMaxTokens, traits, requiresVision, allowedProviderSerials...)
 	if candidates <= 0 || ttftTooSlow(bestTTFT, hasTTFT, ttftThreshold) {
 		return target.Previous, candidates, rejections, tooLarge, bestTTFT, hasTTFT, false
 	}
@@ -1862,11 +1862,15 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 		// 503 which counts as downtime. Fast 429s also preserve our TTFT
 		// metrics. Self-route skips this fleet-wide gate — it queues on the
 		// owner's machine instead (handled below).
-		candidateCount, capacityRejections, modelTooLarge, bestTTFT, hasTTFT := s.registry.QuickCapacityCheckWithTTFTForRequest(model, estimatedPromptTokens, requestedMaxTokens, registry.RequestTraits{HasTools: hasTools}, requiresVision, allowedProviderSerials...)
+		candidateCount, capacityRejections, modelTooLarge, decodeFloorRejections, bestTTFT, hasTTFT := s.registry.QuickCapacityCheckWithTTFTForRequest(model, estimatedPromptTokens, requestedMaxTokens, registry.RequestTraits{HasTools: hasTools}, requiresVision, allowedProviderSerials...)
 		if candidateCount == 0 && capacityRejections > 0 {
 			if fallbackModel, fallbackCandidates, fallbackRejections, fallbackTooLarge, fallbackTTFT, fallbackHasTTFT, switched := s.maybeFallbackAliasCapacity(parsed, publicModel, model, estimatedPromptTokens, requestedMaxTokens, registry.RequestTraits{HasTools: hasTools}, requiresVision, allowedProviderSerials); switched {
 				model = fallbackModel
 				candidateCount, capacityRejections, modelTooLarge = fallbackCandidates, fallbackRejections, fallbackTooLarge
+				// The fallback only switches when it found candidates (candidateCount
+				// > 0), so the shed branch below won't run; the alias path is not a
+				// throughput shed, so its decode-floor subset is zero.
+				decodeFloorRejections = 0
 				bestTTFT, hasTTFT = fallbackTTFT, fallbackHasTTFT
 				if isResponsesAPI {
 					providerParsed, err := responsesRequestToChatCompletions(parsed)
@@ -1940,12 +1944,18 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 			// full or the wait times out (true saturation). The reservation is
 			// kept for dispatch.
 			//
-			// EXCEPTION: when decode-floor hard-shed is armed, the capacity
-			// rejection may be a THROUGHPUT shed (no provider can decode at the
-			// floor), not transient memory pressure. Queueing a fundamentally
-			// too-slow fleet just defers the same outcome to a 120s timeout, so
-			// shed immediately instead — the whole point of the flag.
-			if s.queueBeforeShedEnabled() && !s.registry.DecodeFloorShedArmed() {
+			// EXCEPTION: shed immediately ONLY when every capacity rejection is a
+			// decode-floor (THROUGHPUT) shed — no provider can decode at the floor.
+			// Queueing a fundamentally too-slow fleet just defers the same outcome
+			// to a 120s timeout. But a concurrency- or memory-full fleet (or a mix)
+			// can be served by a slot freeing within the queue window, so it must
+			// still queue: bypassing on the global DecodeFloorShedArmed() flag alone
+			// would fast-429 a momentarily-full-but-fast fleet (a queue-before-shed
+			// regression). decodeFloorRejections is the subset of capacityRejections
+			// from the throughput gate; equality means a pure throughput shed.
+			pureThroughputShed := s.registry.DecodeFloorShedArmed() &&
+				decodeFloorRejections > 0 && decodeFloorRejections == capacityRejections
+			if s.queueBeforeShedEnabled() && !pureThroughputShed {
 				s.ddIncr("routing.decisions", []string{"model:" + model, "model_type:" + s.registry.ModelType(model), "outcome:capacity_queue_spill"})
 			} else {
 				// Legacy fast-shed: immediate 429.
@@ -4688,11 +4698,15 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 		// Prefer mode skips the public fleet pre-flight (no owner-trust
 		// relaxation there); owned-first dispatch + paid fallback + queue gate it.
 	} else {
-		candidateCount, capacityRejections, modelTooLarge, bestTTFT, hasTTFT := s.registry.QuickCapacityCheckWithTTFTForRequest(model, estimatedPromptTokens, requestedMaxTokens, registry.RequestTraits{HasTools: hasTools}, requiresVision, allowedProviderSerials...)
+		candidateCount, capacityRejections, modelTooLarge, decodeFloorRejections, bestTTFT, hasTTFT := s.registry.QuickCapacityCheckWithTTFTForRequest(model, estimatedPromptTokens, requestedMaxTokens, registry.RequestTraits{HasTools: hasTools}, requiresVision, allowedProviderSerials...)
 		if candidateCount == 0 && capacityRejections > 0 {
 			if fallbackModel, fallbackCandidates, fallbackRejections, fallbackTooLarge, fallbackTTFT, fallbackHasTTFT, switched := s.maybeFallbackAliasCapacity(parsed, publicModel, model, estimatedPromptTokens, requestedMaxTokens, registry.RequestTraits{HasTools: hasTools}, requiresVision, allowedProviderSerials); switched {
 				model = fallbackModel
 				candidateCount, capacityRejections, modelTooLarge = fallbackCandidates, fallbackRejections, fallbackTooLarge
+				// The fallback only switches when it found candidates (candidateCount
+				// > 0), so the shed branch below won't run; the alias path is not a
+				// throughput shed, so its decode-floor subset is zero.
+				decodeFloorRejections = 0
 				bestTTFT, hasTTFT = fallbackTTFT, fallbackHasTTFT
 			}
 		}
@@ -4733,9 +4747,12 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 			// capacity right now. Fall through to the dispatch+queue path so a slot
 			// freeing — or a cold load completing — within the queue window serves
 			// it; the queue path still 429s on a full queue or wait timeout.
-			// EXCEPTION: decode-floor hard-shed armed → shed now, don't queue a
-			// too-slow fleet (see the matching note on the primary path above).
-			if s.queueBeforeShedEnabled() && !s.registry.DecodeFloorShedArmed() {
+			// EXCEPTION: shed now ONLY when every rejection is a decode-floor
+			// (throughput) shed — a concurrency/memory-full fleet still queues (see
+			// the matching note on the primary path above).
+			pureThroughputShed := s.registry.DecodeFloorShedArmed() &&
+				decodeFloorRejections > 0 && decodeFloorRejections == capacityRejections
+			if s.queueBeforeShedEnabled() && !pureThroughputShed {
 				s.ddIncr("routing.decisions", []string{"model:" + model, "model_type:" + s.registry.ModelType(model), "outcome:capacity_queue_spill"})
 			} else {
 				retryAfter := s.estimateRetryAfter(model)

--- a/coordinator/api/decode_floor_shed_http_test.go
+++ b/coordinator/api/decode_floor_shed_http_test.go
@@ -2,14 +2,66 @@ package api
 
 import (
 	"context"
+	"log/slog"
 	"net/http"
+	"os"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/eigeninference/d-inference/coordinator/protocol"
+	"github.com/eigeninference/d-inference/coordinator/registry"
+	"github.com/eigeninference/d-inference/coordinator/store"
 	"nhooyr.io/websocket"
 )
+
+// capacityShedReason must distinguish a decode-floor (throughput) shed from an
+// ordinary full-fleet rejection so the shed is observable in telemetry on its
+// own reason_code/outcome — the lesson from the gemma incident (only mitigations
+// with distinct reason codes were diagnosable).
+func TestCapacityShedReasonDistinguishesThroughputShed(t *testing.T) {
+	reason, outcome := capacityShedReason(true)
+	if reason != "decode_floor_shed" || outcome != "decode_floor_shed" {
+		t.Fatalf("throughput shed: got reason=%q outcome=%q, want decode_floor_shed/decode_floor_shed", reason, outcome)
+	}
+	reason, outcome = capacityShedReason(false)
+	if reason != "machine_busy" || outcome != "capacity_429" {
+		t.Fatalf("ordinary capacity: got reason=%q outcome=%q, want machine_busy/capacity_429", reason, outcome)
+	}
+}
+
+// pureThroughputShed: bypass queue-before-shed ONLY when the shed is armed AND
+// every capacity rejection is a throughput shed. A fast-but-full fleet
+// (decodeFloorRejections < capacityRejections) must keep queueing.
+func TestPureThroughputShedRequiresAllRejectionsBelowFloor(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	st := store.NewMemory(store.Config{AdminKey: "test-key"})
+	reg := registry.New(logger)
+	srv := NewServer(reg, st, ServerConfig{}, logger)
+
+	// Shed disarmed → never a pure throughput shed, regardless of counts.
+	if srv.pureThroughputShed(3, 3) {
+		t.Fatalf("shed disarmed must never report a pure throughput shed")
+	}
+
+	reg.SetDecodeFloorShed(10, true) // arm
+	cases := []struct {
+		decodeFloor, capacity int
+		want                  bool
+		why                   string
+	}{
+		{3, 3, true, "all rejections are throughput sheds → shed"},
+		{1, 3, false, "mixed (some fast-but-full) → still queue"},
+		{0, 3, false, "no throughput sheds → still queue"},
+		{0, 0, false, "no rejections at all → not a shed"},
+	}
+	for _, c := range cases {
+		if got := srv.pureThroughputShed(c.decodeFloor, c.capacity); got != c.want {
+			t.Errorf("pureThroughputShed(decodeFloor=%d, capacity=%d) = %v, want %v (%s)",
+				c.decodeFloor, c.capacity, got, c.want, c.why)
+		}
+	}
+}
 
 // HTTP-level regression for the gemma-4 over-admission fix: a fleet whose only
 // provider decodes BELOW the per-request floor (but has ample KV budget, so the
@@ -75,8 +127,12 @@ func TestDecodeFloorHardShedReturns429UnderDefaultQueueBeforeShed(t *testing.T) 
 	if status != http.StatusTooManyRequests {
 		t.Fatalf("status = %d, want 429 (decode-floor shed), body = %s", status, body)
 	}
-	if !strings.Contains(body, "at capacity") {
-		t.Fatalf("body = %s, want a capacity/429 error", body)
+	// A decode-floor (throughput) shed is surfaced with a DISTINCT message from an
+	// ordinary capacity 429 ("at capacity"), so it is observable as its own class
+	// — both to the client and, via the matching reason_code "decode_floor_shed",
+	// in the rejection ledger.
+	if !strings.Contains(body, "below the decode-speed floor") {
+		t.Fatalf("body = %s, want the distinct decode-floor-shed message", body)
 	}
 }
 

--- a/coordinator/api/decode_floor_shed_http_test.go
+++ b/coordinator/api/decode_floor_shed_http_test.go
@@ -80,6 +80,74 @@ func TestDecodeFloorHardShedReturns429UnderDefaultQueueBeforeShed(t *testing.T) 
 	}
 }
 
+// Finding-1 regression at the HTTP boundary: with decode-floor hard-shed ARMED,
+// a fast-but-budget-FULL fleet (a concurrency/memory capacity rejection, NOT a
+// throughput shed) must still QUEUE under queue-before-shed — not fast-429. The
+// pre-fix code bypassed the queue whenever DecodeFloorShedArmed() was true,
+// regardless of WHY the fleet was full, which regressed queue-before-shed for
+// healthy-but-momentarily-full fleets.
+func TestDecodeFloorShedArmedStillQueuesMemoryFullFastFleet(t *testing.T) {
+	ts, reg := setupAdaptiveCapacityIntegration(t)
+	defer ts.Close()
+
+	t.Setenv(envQueueBeforeShed, "true")
+	t.Setenv(envColdDispatch, "false")
+	reg.SetDecodeFloorShed(15, true) // shed ARMED
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	model := "gemma-fast-full-http"
+	conn := connectSlowDecodeProvider(t, ctx, ts.URL, model, 40)
+	defer conn.Close(websocket.StatusNormalClosure, "done")
+	p := markOnlyProviderRoutable(t, reg)
+
+	// Budget exhausted (31.5K of 32K, a 256-max request won't fit ⇒
+	// freeMemoryAdmits fails ⇒ capacity rejection) but observed decode 40 tok/s
+	// ⇒ NOT a decode-floor shed. So decodeFloorRejections (0) < capacityRejections
+	// (1): the consumer must queue, not fast-429.
+	writeAdaptiveHeartbeat(t, ctx, conn, model, &protocol.BackendCapacity{
+		TotalMemoryGB: 64,
+		Slots: []protocol.BackendSlotCapacity{{
+			Model:                 model,
+			State:                 "running",
+			MaxConcurrency:        8,
+			ActiveTokenBudgetUsed: 31_500,
+			ActiveTokenBudgetMax:  32_768,
+			ObservedDecodeTPS:     40,
+		}},
+	})
+	waitForAdaptiveCondition(t, time.Second, func() bool {
+		p.Mu().Lock()
+		defer p.Mu().Unlock()
+		return p.BackendCapacity != nil &&
+			p.BackendCapacity.Slots[0].ActiveTokenBudgetUsed == 31_500
+	})
+
+	reqCtx, reqCancel := context.WithCancel(ctx)
+	defer reqCancel()
+	done := make(chan int, 1)
+	go func() {
+		status, _, _ := adaptiveChatRequest(reqCtx, ts.URL, model, 256)
+		done <- status
+	}()
+	// A fast-but-full fleet must NOT be fast-429'd by the throughput-shed path;
+	// it should queue (the matching not-shed behaviour as the disabled case).
+	select {
+	case status := <-done:
+		if status == http.StatusTooManyRequests {
+			t.Fatalf("got fast 429 for a fast-but-memory-full fleet with shed armed; want queue (queue-before-shed regression)")
+		}
+	case <-time.After(750 * time.Millisecond):
+		// Still in flight (queued) — the expected non-shed path.
+	}
+	reqCancel()
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+	}
+}
+
 func TestDecodeFloorShedDisabledStillQueuesSlowFleet(t *testing.T) {
 	ts, reg := setupAdaptiveCapacityIntegration(t)
 	defer ts.Close()

--- a/coordinator/api/decode_floor_shed_http_test.go
+++ b/coordinator/api/decode_floor_shed_http_test.go
@@ -1,0 +1,144 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+	"nhooyr.io/websocket"
+)
+
+// HTTP-level regression for the gemma-4 over-admission fix: a fleet whose only
+// provider decodes BELOW the per-request floor (but has ample KV budget, so the
+// memory gate passes) must be SHED with an immediate 429 when decode-floor
+// hard-shed is armed — even under the default queue-before-shed=true. Without
+// the consumer-side coupling (DecodeFloorShedArmed bypassing queue-before-shed),
+// the request would instead queue and time out — the production symptom.
+
+// connectSlowDecodeProvider registers a provider with a large KV budget (memory
+// gate wide open) but a low observed decode TPS (below the floor under load).
+func connectSlowDecodeProvider(
+	t *testing.T, ctx context.Context, tsURL, model string, observedTPS float64,
+) *websocket.Conn {
+	t.Helper()
+	conn := connectProvider(t, ctx, tsURL,
+		[]protocol.ModelInfo{{ID: model, ModelType: "chat", Quantization: "4bit"}},
+		testPublicKeyB64())
+	return conn
+}
+
+func TestDecodeFloorHardShedReturns429UnderDefaultQueueBeforeShed(t *testing.T) {
+	ts, reg := setupAdaptiveCapacityIntegration(t)
+	defer ts.Close()
+
+	// Defaults that previously made this stall: queue-before-shed ON. The fix
+	// must shed anyway because decode-floor hard-shed is armed.
+	t.Setenv(envQueueBeforeShed, "true")
+	t.Setenv(envColdDispatch, "false")
+	reg.SetDecodeFloorShed(15, true) // arm the throughput shed at 15 tok/s
+
+	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Second)
+	defer cancel()
+
+	model := "gemma-slow-http"
+	conn := connectSlowDecodeProvider(t, ctx, ts.URL, model, 8)
+	defer conn.Close(websocket.StatusNormalClosure, "done")
+	p := markOnlyProviderRoutable(t, reg)
+
+	// KV budget wide open (memory gate passes), but observed decode 8 tok/s ⇒
+	// projected per-request TPS is below the 15 floor.
+	writeAdaptiveHeartbeat(t, ctx, conn, model, &protocol.BackendCapacity{
+		TotalMemoryGB: 64,
+		Slots: []protocol.BackendSlotCapacity{{
+			Model:                 model,
+			State:                 "running",
+			MaxConcurrency:        8,
+			ActiveTokenBudgetUsed: 1_000,
+			ActiveTokenBudgetMax:  1_000_000,
+			ObservedDecodeTPS:     8,
+		}},
+	})
+	waitForAdaptiveCondition(t, time.Second, func() bool {
+		p.Mu().Lock()
+		defer p.Mu().Unlock()
+		return p.BackendCapacity != nil &&
+			p.BackendCapacity.Slots[0].ObservedDecodeTPS == 8
+	})
+
+	status, body, err := adaptiveChatRequest(ctx, ts.URL, model, 256)
+	if err != nil {
+		t.Fatalf("chat request: %v", err)
+	}
+	if status != http.StatusTooManyRequests {
+		t.Fatalf("status = %d, want 429 (decode-floor shed), body = %s", status, body)
+	}
+	if !strings.Contains(body, "at capacity") {
+		t.Fatalf("body = %s, want a capacity/429 error", body)
+	}
+}
+
+func TestDecodeFloorShedDisabledStillQueuesSlowFleet(t *testing.T) {
+	ts, reg := setupAdaptiveCapacityIntegration(t)
+	defer ts.Close()
+
+	// Shed NOT armed (default). The same slow fleet must keep the pre-fix
+	// behaviour: queue-before-shed queues the request (over-admission), not 429.
+	t.Setenv(envQueueBeforeShed, "true")
+	t.Setenv(envColdDispatch, "false")
+	// reg.SetDecodeFloorShed not called ⇒ disabled.
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	model := "gemma-slow-noarm"
+	conn := connectSlowDecodeProvider(t, ctx, ts.URL, model, 8)
+	defer conn.Close(websocket.StatusNormalClosure, "done")
+	p := markOnlyProviderRoutable(t, reg)
+
+	writeAdaptiveHeartbeat(t, ctx, conn, model, &protocol.BackendCapacity{
+		TotalMemoryGB: 64,
+		Slots: []protocol.BackendSlotCapacity{{
+			Model:                 model,
+			State:                 "running",
+			MaxConcurrency:        8,
+			ActiveTokenBudgetUsed: 1_000,
+			ActiveTokenBudgetMax:  1_000_000,
+			ObservedDecodeTPS:     8,
+		}},
+	})
+	waitForAdaptiveCondition(t, time.Second, func() bool {
+		p.Mu().Lock()
+		defer p.Mu().Unlock()
+		return p.BackendCapacity != nil &&
+			p.BackendCapacity.Slots[0].ObservedDecodeTPS == 8
+	})
+
+	// With shed disabled, a large-KV-budget slow fleet ADMITS (candidate passes
+	// freeMemoryAdmits, decode floor advisory-only) — so the request dispatches
+	// rather than 429'ing. We only assert it is NOT shed with a fast 429.
+	reqCtx, reqCancel := context.WithCancel(ctx)
+	defer reqCancel()
+	done := make(chan int, 1)
+	go func() {
+		status, _, _ := adaptiveChatRequest(reqCtx, ts.URL, model, 256)
+		done <- status
+	}()
+	// It should NOT come back as a fast 429 in the first moment.
+	select {
+	case status := <-done:
+		if status == http.StatusTooManyRequests {
+			t.Fatalf("got fast 429 with shed DISABLED; want admit/dispatch (no over-admission shedding)")
+		}
+	case <-time.After(750 * time.Millisecond):
+		// Still in flight (dispatched/queued) — the expected non-shed path.
+	}
+	reqCancel()
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		// best-effort cleanup; not a failure condition for this assertion
+	}
+}

--- a/coordinator/api/rejection_telemetry.go
+++ b/coordinator/api/rejection_telemetry.go
@@ -123,7 +123,7 @@ func (s *Server) recordRejection(info rejectionInfo) {
 	s.submitTelemetry("recordRejection", func() {
 		if computeServability {
 			traits := registry.RequestTraits{HasTools: hasTools}
-			cc, capRej, tooLarge, bestTTFT, hasTTFT := reg.QuickCapacityCheckWithTTFTForRequest(
+			cc, capRej, tooLarge, _, bestTTFT, hasTTFT := reg.QuickCapacityCheckWithTTFTForRequest(
 				resolvedModel, estPrompt, reqMax, traits, requiresVision,
 			)
 			rec.CandidateCount = cc

--- a/coordinator/cmd/coordinator/main.go
+++ b/coordinator/cmd/coordinator/main.go
@@ -338,9 +338,28 @@ func main() {
 	// =true makes the capacity preflight SHED such requests with a fast
 	// 429/Retry-After instead. Default off (advisory). Sheds on THROUGHPUT only —
 	// orthogonal to the memory cap / free_for_load_gb / resource-count gates.
+	//
+	// The SHED floor is decoupled from the soft quality floor above and defaults
+	// LOWER. The soft floor (15) only ranks providers, so a high bar is harmless;
+	// the shed floor 429s, and only when EVERY eligible candidate projects below
+	// it. Production telemetry on the gemma-4 over-admission incident showed a
+	// healthy, uncontended (backend_running=0) request projects ~15 tok/s at p50
+	// on the 4-bit fleet, so a shed floor of 15 would 429 whenever the fleet's
+	// fast half briefly dropped out — converting a latency problem into an
+	// availability one. A floor of ~10 leaves headroom above the ~8-9 tok/s
+	// normal-load projection and only trips when the entire fleet is genuinely
+	// overpacked into uselessness. Tune with EIGENINFERENCE_DECODE_FLOOR_SHED_TPS.
 	decodeFloorHardShed := os.Getenv("EIGENINFERENCE_DECODE_FLOOR_HARD_SHED") == "true"
-	reg.SetDecodeFloorShed(minDecodeTPS, decodeFloorHardShed)
-	logger.Info("decode-floor load-shedding", "hard_shed", decodeFloorHardShed, "floor_tps", minDecodeTPS)
+	decodeFloorShedTPS := 10.0 // default shed threshold (decoupled from the soft quality bar)
+	if v := os.Getenv("EIGENINFERENCE_DECODE_FLOOR_SHED_TPS"); v != "" {
+		if tps, err := strconv.ParseFloat(v, 64); err == nil && tps >= 0 {
+			decodeFloorShedTPS = tps
+		} else {
+			logger.Warn("invalid EIGENINFERENCE_DECODE_FLOOR_SHED_TPS; using default", "value", v, "default", decodeFloorShedTPS)
+		}
+	}
+	reg.SetDecodeFloorShed(decodeFloorShedTPS, decodeFloorHardShed)
+	logger.Info("decode-floor load-shedding", "hard_shed", decodeFloorHardShed, "shed_floor_tps", decodeFloorShedTPS, "soft_floor_tps", minDecodeTPS)
 
 	// Load runtime template manifest from environment variable (optional override).
 	// When configured, providers whose template hashes don't match are excluded from

--- a/coordinator/cmd/coordinator/main.go
+++ b/coordinator/cmd/coordinator/main.go
@@ -331,6 +331,17 @@ func main() {
 	srv.SetMinDecodeTPS(minDecodeTPS)
 	logger.Info("per-request decode floor (quality bar)", "min_decode_tps", minDecodeTPS)
 
+	// Decode-floor LOAD-SHEDDING (opt-in). The per-request decode floor above is
+	// advisory: it ranks providers but never rejects, so a bandwidth-bound model
+	// whose whole fleet decodes below the floor (e.g. gemma-4 under load) is still
+	// admitted and then stalls in the queue. EIGENINFERENCE_DECODE_FLOOR_HARD_SHED
+	// =true makes the capacity preflight SHED such requests with a fast
+	// 429/Retry-After instead. Default off (advisory). Sheds on THROUGHPUT only —
+	// orthogonal to the memory cap / free_for_load_gb / resource-count gates.
+	decodeFloorHardShed := os.Getenv("EIGENINFERENCE_DECODE_FLOOR_HARD_SHED") == "true"
+	reg.SetDecodeFloorShed(minDecodeTPS, decodeFloorHardShed)
+	logger.Info("decode-floor load-shedding", "hard_shed", decodeFloorHardShed, "floor_tps", minDecodeTPS)
+
 	// Load runtime template manifest from environment variable (optional override).
 	// When configured, providers whose template hashes don't match are excluded from
 	// routing (but not disconnected) and receive feedback about mismatches.

--- a/coordinator/registry/decode_floor_shed_test.go
+++ b/coordinator/registry/decode_floor_shed_test.go
@@ -152,6 +152,36 @@ func TestDecodeFloorShed_MemoryFullFastFleet_NotCountedAsThroughputShed(t *testi
 	}
 }
 
+// Boundary: token-budget-full providers also queue until capacity frees. The
+// throughput check must therefore use the replacement/queued-start batch, not
+// the immediate "add one more request now" projection. Here the model still has
+// concurrency headroom, but token budget is full. Observed 11 tok/s at one
+// active request is above a 10 tok/s shed floor; adding one more immediately
+// would project below 10, but that immediate b+1 state is not what the queued
+// request will run at after token budget frees.
+func TestDecodeFloorShed_MemoryFullProviderUsesQueuedStartProjection(t *testing.T) {
+	reg := New(testLogger())
+	model := "gemma-memory-full-boundary"
+	p := makeTokenBudgetProvider(t, reg, "p1", model, 200, 30_000, 32_768, 11)
+	p.mu.Lock()
+	p.BackendCapacity.Slots[0].NumRunning = 1
+	p.BackendCapacity.Slots[0].MaxConcurrency = 8
+	p.mu.Unlock()
+
+	reg.SetDecodeFloorShed(10, true)
+
+	cc, capRej, _, decodeFloorRej, _, _ := reg.quickCapacityCheck(model, 500, 4096, RequestTraits{}, false)
+	if cc != 0 {
+		t.Fatalf("a token-budget-full provider must have no candidates; got cc=%d", cc)
+	}
+	if capRej == 0 {
+		t.Fatalf("a token-budget-full provider must be a capacity rejection; got capRej=%d", capRej)
+	}
+	if decodeFloorRej != 0 {
+		t.Fatalf("a token-budget-full provider above the shed floor after budget frees must queue, not throughput-shed; got decodeFloor=%d of %d", decodeFloorRej, capRej)
+	}
+}
+
 // setSlotFull marks a provider's slot concurrency-full so the concurrency gate
 // rejects it (MaxConcurrency=1, NumRunning=1 ⇒ no headroom).
 func setSlotFull(t *testing.T, p *Provider) {

--- a/coordinator/registry/decode_floor_shed_test.go
+++ b/coordinator/registry/decode_floor_shed_test.go
@@ -18,11 +18,11 @@ import "testing"
 // slowGemmaProvider: huge KV budget headroom (freeMemoryAdmits passes) but an
 // observed decode TPS so low that the projected per-request rate is below the
 // floor even with zero concurrent streams.
-func slowGemmaProvider(t *testing.T, reg *Registry, id, model string, observedTPS float64) {
+func slowGemmaProvider(t *testing.T, reg *Registry, id, model string, observedTPS float64) *Provider {
 	t.Helper()
 	// decodeTPS (static) high so only the OBSERVED rate drives the projection;
 	// budget 1K used of 1M max ⇒ KV gate wide open (the gemma "never exhausts KV").
-	makeTokenBudgetProvider(t, reg, id, model, 200, 1_000, 1_000_000, observedTPS)
+	return makeTokenBudgetProvider(t, reg, id, model, 200, 1_000, 1_000_000, observedTPS)
 }
 
 func TestDecodeFloorShed_OffByDefault_AdmitsSlowFleet(t *testing.T) {
@@ -149,6 +149,95 @@ func TestDecodeFloorShed_MemoryFullFastFleet_NotCountedAsThroughputShed(t *testi
 	}
 	if decodeFloorRej != 0 {
 		t.Fatalf("a FAST-but-full fleet must report 0 decode-floor rejections (so queue-before-shed still queues), got %d of %d capacity rejections", decodeFloorRej, capRej)
+	}
+}
+
+// setSlotFull marks a provider's slot concurrency-full so the concurrency gate
+// rejects it (MaxConcurrency=1, NumRunning=1 ⇒ no headroom).
+func setSlotFull(t *testing.T, p *Provider) {
+	t.Helper()
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.BackendCapacity.Slots[0].MaxConcurrency = 1
+	p.BackendCapacity.Slots[0].NumRunning = 1
+}
+
+// Finding regression: a fleet that is BOTH concurrency-full AND below the decode
+// floor must fast-429, not queue. The concurrency gate runs before the decode
+// floor; if a full provider short-circuited as a plain capacity rejection
+// without decode-floor classification, decodeFloorRejections would be 0 <
+// capacityRejections and the consumer would queue the request for 120s — exactly
+// the stall this shed is meant to prevent under peak saturation. The fix
+// classifies a full provider against the floor too, so a full+slow fleet reports
+// decodeFloorRejections == capacityRejections and sheds immediately.
+func TestDecodeFloorShed_FullAndSlowFleet_ShedsNotQueues(t *testing.T) {
+	reg := New(testLogger())
+	model := "gemma-full-slow"
+	// Wide-open budget (so freeMemoryAdmits would pass) but observed 8 tok/s
+	// (below the floor) AND concurrency-full.
+	p1 := slowGemmaProvider(t, reg, "p1", model, 8)
+	p2 := slowGemmaProvider(t, reg, "p2", model, 8)
+	setSlotFull(t, p1)
+	setSlotFull(t, p2)
+
+	reg.SetDecodeFloorShed(10, true)
+
+	cc, capRej, _, decodeFloorRej, _, _ := reg.quickCapacityCheck(model, 500, 4096, RequestTraits{}, false)
+	if cc != 0 {
+		t.Fatalf("a full+slow fleet must have no candidates; got cc=%d", cc)
+	}
+	if decodeFloorRej == 0 || decodeFloorRej != capRej {
+		t.Fatalf("a full+slow fleet must be a pure throughput shed (decodeFloorRejections==capacityRejections>0) so the consumer fast-429s instead of queueing 120s; got decodeFloor=%d cap=%d", decodeFloorRej, capRej)
+	}
+}
+
+// Counterpart: a fleet that is concurrency-full but FAST must NOT be a throughput
+// shed — a slot will free and serve at an acceptable rate, so queue-before-shed
+// must still queue it (decodeFloorRejections < capacityRejections).
+func TestDecodeFloorShed_FullButFastFleet_StillQueues(t *testing.T) {
+	reg := New(testLogger())
+	model := "gemma-full-fast"
+	p1 := slowGemmaProvider(t, reg, "p1", model, 40) // 40 tok/s observed ⇒ above floor
+	p2 := slowGemmaProvider(t, reg, "p2", model, 40)
+	setSlotFull(t, p1)
+	setSlotFull(t, p2)
+
+	reg.SetDecodeFloorShed(10, true)
+
+	cc, capRej, _, decodeFloorRej, _, _ := reg.quickCapacityCheck(model, 500, 4096, RequestTraits{}, false)
+	if cc != 0 {
+		t.Fatalf("a concurrency-full fleet must have no candidates; got cc=%d", cc)
+	}
+	if capRej == 0 {
+		t.Fatalf("a full fleet must be a capacity rejection; got capRej=%d", capRej)
+	}
+	if decodeFloorRej != 0 {
+		t.Fatalf("a full-but-FAST fleet must report 0 decode-floor rejections so queue-before-shed still queues (a slot will free and serve fast); got decodeFloor=%d of %d", decodeFloorRej, capRej)
+	}
+}
+
+// A MIXED fleet (one full+slow, one full+fast) must queue: because the fast
+// provider's slot can free and serve at an acceptable rate, the request is worth
+// queueing. decodeFloorRejections (1) < capacityRejections (2).
+func TestDecodeFloorShed_MixedFullFleet_Queues(t *testing.T) {
+	reg := New(testLogger())
+	model := "gemma-mixed-full"
+	slow := slowGemmaProvider(t, reg, "slow", model, 8)  // below floor
+	fast := slowGemmaProvider(t, reg, "fast", model, 40) // above floor
+	setSlotFull(t, slow)
+	setSlotFull(t, fast)
+
+	reg.SetDecodeFloorShed(10, true)
+
+	cc, capRej, _, decodeFloorRej, _, _ := reg.quickCapacityCheck(model, 500, 4096, RequestTraits{}, false)
+	if cc != 0 {
+		t.Fatalf("both providers full ⇒ no candidates; got cc=%d", cc)
+	}
+	if capRej != 2 {
+		t.Fatalf("both full providers must be capacity rejections; got capRej=%d", capRej)
+	}
+	if decodeFloorRej != 1 {
+		t.Fatalf("only the slow provider is below floor, so decodeFloorRejections must be 1 (< capRej) and the request queues; got decodeFloor=%d", decodeFloorRej)
 	}
 }
 

--- a/coordinator/registry/decode_floor_shed_test.go
+++ b/coordinator/registry/decode_floor_shed_test.go
@@ -122,3 +122,39 @@ func TestDecodeFloorShed_ZeroFloor_NoOp(t *testing.T) {
 		t.Fatalf("floor 0 must disable shedding (no-op); got cc=0")
 	}
 }
+
+// The shed floor is DECOUPLED from the soft quality floor and defaults lower
+// (shed 10 vs soft 15). A fleet decoding in the gap between them — too slow for
+// the quality preference but not degraded enough to shed — must be admitted, not
+// 429'd. This pins the decoupling that keeps a shed-floor of 15 (which the gemma
+// telemetry showed would 429 a healthy uncontended fleet projecting ~15) from
+// turning a latency problem into an availability outage.
+func TestDecodeFloorShed_BetweenSoftAndShedFloor_Admits(t *testing.T) {
+	reg := New(testLogger())
+	model := "gemma-mid"
+	// Observed ~14 tok/s at backend_running=0 ⇒ projection ≈ 14/(1+0.27) ≈ 11.0:
+	// below the soft quality bar (15) but above the shed floor (10).
+	slowGemmaProvider(t, reg, "p1", model, 14)
+
+	if got := projectedPerRequestDecodeTPS(routingSnapshot{observedDecodeTPS: 14, backendRunning: 0}); got < 10 || got >= 15 {
+		t.Fatalf("fixture must land in the (10,15) gap; projected %.2f", got)
+	}
+
+	// Shed floor 10 (the new decoupled default), hard shed armed.
+	reg.SetDecodeFloorShed(10, true)
+	cc, capRej, _ := reg.QuickCapacityCheck(model, 500, 4096, RequestTraits{})
+	if cc == 0 {
+		t.Fatalf("a fleet above the shed floor (10) must be admitted even when below the soft bar (15); got cc=0 capRej=%d", capRej)
+	}
+	if capRej != 0 {
+		t.Fatalf("no capacity rejection expected above the shed floor; got capRej=%d", capRej)
+	}
+
+	// And the SAME fleet, were the shed floor mistakenly coupled back to 15,
+	// WOULD be shed — proving the decoupling is load-bearing.
+	reg.SetDecodeFloorShed(15, true)
+	cc15, capRej15, _ := reg.QuickCapacityCheck(model, 500, 4096, RequestTraits{})
+	if cc15 != 0 || capRej15 == 0 {
+		t.Fatalf("control: a shed floor of 15 must shed this ~11-tok/s fleet; got cc=%d capRej=%d", cc15, capRej15)
+	}
+}

--- a/coordinator/registry/decode_floor_shed_test.go
+++ b/coordinator/registry/decode_floor_shed_test.go
@@ -123,6 +123,56 @@ func TestDecodeFloorShed_ZeroFloor_NoOp(t *testing.T) {
 	}
 }
 
+// Finding-1 regression: a memory/concurrency-full fleet (NOT a throughput shed)
+// must NOT be classified as a decode-floor shed, even when the shed flag is
+// armed. quickCapacityCheck folds concurrency, memory, and decode-floor failures
+// into one capacityRejections counter; decodeFloorRejections is the throughput
+// subset. The consumer bypasses queue-before-shed only when ALL rejections are
+// throughput sheds, so a fast-but-full fleet must report
+// decodeFloorRejections < capacityRejections and keep queueing.
+func TestDecodeFloorShed_MemoryFullFastFleet_NotCountedAsThroughputShed(t *testing.T) {
+	reg := New(testLogger())
+	model := "gemma-fast-full"
+	// Budget exhausted (30K of 32K used; a 500+4096 request won't fit ⇒
+	// freeMemoryAdmits fails ⇒ capacityRejection) but observed decode 40 tok/s
+	// (well above any floor ⇒ NOT a decode-floor shed).
+	makeTokenBudgetProvider(t, reg, "p1", model, 200, 30_000, 32_768, 40)
+
+	reg.SetDecodeFloorShed(10, true) // shed armed
+
+	cc, capRej, _, decodeFloorRej, _, _ := reg.quickCapacityCheck(model, 500, 4096, RequestTraits{}, false)
+	if cc != 0 {
+		t.Fatalf("a budget-full provider must not be a candidate; got cc=%d", cc)
+	}
+	if capRej == 0 {
+		t.Fatalf("a budget-full provider must be a capacity rejection; got capRej=%d", capRej)
+	}
+	if decodeFloorRej != 0 {
+		t.Fatalf("a FAST-but-full fleet must report 0 decode-floor rejections (so queue-before-shed still queues), got %d of %d capacity rejections", decodeFloorRej, capRej)
+	}
+}
+
+// Mirror: a genuinely slow fleet rejected purely on throughput must report
+// decodeFloorRejections == capacityRejections, so the consumer sheds immediately.
+func TestDecodeFloorShed_SlowFleet_AllRejectionsAreThroughput(t *testing.T) {
+	reg := New(testLogger())
+	model := "gemma-slow-pure"
+	// Wide-open budget (1K of 1M) so freeMemoryAdmits passes; observed 8 tok/s so
+	// the decode-floor gate is the ONLY thing that rejects.
+	slowGemmaProvider(t, reg, "p1", model, 8)
+	slowGemmaProvider(t, reg, "p2", model, 8)
+
+	reg.SetDecodeFloorShed(10, true)
+
+	cc, capRej, _, decodeFloorRej, _, _ := reg.quickCapacityCheck(model, 500, 4096, RequestTraits{}, false)
+	if cc != 0 {
+		t.Fatalf("a sub-floor fleet must be shed; got cc=%d", cc)
+	}
+	if decodeFloorRej == 0 || decodeFloorRej != capRej {
+		t.Fatalf("a pure-throughput shed must have decodeFloorRejections==capacityRejections>0; got decodeFloor=%d cap=%d", decodeFloorRej, capRej)
+	}
+}
+
 // The shed floor is DECOUPLED from the soft quality floor and defaults lower
 // (shed 10 vs soft 15). A fleet decoding in the gap between them — too slow for
 // the quality preference but not degraded enough to shed — must be admitted, not

--- a/coordinator/registry/decode_floor_shed_test.go
+++ b/coordinator/registry/decode_floor_shed_test.go
@@ -1,0 +1,98 @@
+package registry
+
+import "testing"
+
+// Regression for the gemma-4 over-admission bug (v0.6.14): a bandwidth-bound
+// model whose whole fleet decodes below the per-request quality floor still
+// passed the capacity preflight, because freeMemoryAdmits keys on KV memory
+// (which gemma never exhausts) and the decode floor was advisory-only. The
+// coordinator then admitted far more requests than the fleet could serve at
+// usable speed; they queued and timed out instead of being shed up front.
+//
+// These tests pin: (1) with the shed gate OFF (default), the preflight still
+// counts the slow-but-memory-free provider as a candidate (over-admission — the
+// pre-fix behavior, kept default for safety); (2) with the shed gate ON, the
+// preflight rejects it on THROUGHPUT, yielding candidateCount==0 /
+// capacityRejections>0 so the caller sheds with a fast 429.
+
+// slowGemmaProvider: huge KV budget headroom (freeMemoryAdmits passes) but an
+// observed decode TPS so low that the projected per-request rate is below the
+// floor even with zero concurrent streams.
+func slowGemmaProvider(t *testing.T, reg *Registry, id, model string, observedTPS float64) {
+	t.Helper()
+	// decodeTPS (static) high so only the OBSERVED rate drives the projection;
+	// budget 1K used of 1M max ⇒ KV gate wide open (the gemma "never exhausts KV").
+	makeTokenBudgetProvider(t, reg, id, model, 200, 1_000, 1_000_000, observedTPS)
+}
+
+func TestDecodeFloorShed_OffByDefault_AdmitsSlowFleet(t *testing.T) {
+	reg := New(testLogger())
+	model := "gemma-slow"
+	// Two providers, both decoding at ~8 tok/s observed — below the 15 floor.
+	slowGemmaProvider(t, reg, "p1", model, 8)
+	slowGemmaProvider(t, reg, "p2", model, 8)
+
+	// Sanity: the projection is genuinely below the floor (so this is a real
+	// "all-slow fleet", not a mis-set fixture).
+	if got := projectedPerRequestDecodeTPS(routingSnapshot{observedDecodeTPS: 8, backendRunning: 0}); got >= 15 {
+		t.Fatalf("fixture not slow enough: projected %.2f >= 15", got)
+	}
+
+	// Default: shed gate OFF → the slow fleet is still admissible (reproduces the
+	// over-admission: candidateCount > 0 despite no provider meeting the floor).
+	cc, capRej, _ := reg.QuickCapacityCheck(model, 500, 4096, RequestTraits{})
+	if cc == 0 {
+		t.Fatalf("with shed OFF expected over-admission (candidateCount>0), got cc=%d capRej=%d", cc, capRej)
+	}
+}
+
+func TestDecodeFloorShed_On_ShedsSlowFleet(t *testing.T) {
+	reg := New(testLogger())
+	model := "gemma-slow"
+	slowGemmaProvider(t, reg, "p1", model, 8)
+	slowGemmaProvider(t, reg, "p2", model, 8)
+
+	// Arm the shed gate at the 15 tok/s floor.
+	reg.SetDecodeFloorShed(15, true)
+
+	cc, capRej, tooLarge := reg.QuickCapacityCheck(model, 500, 4096, RequestTraits{})
+	if cc != 0 {
+		t.Fatalf("with shed ON expected candidateCount==0 (shed), got cc=%d", cc)
+	}
+	if capRej == 0 {
+		t.Fatalf("with shed ON expected capacityRejections>0 (so caller 429s, not 503), got capRej=%d", capRej)
+	}
+	if tooLarge != 0 {
+		t.Fatalf("slow providers must be capacity rejections, not model-too-large; tooLarge=%d", tooLarge)
+	}
+}
+
+func TestDecodeFloorShed_On_StillAdmitsFastFleet(t *testing.T) {
+	reg := New(testLogger())
+	model := "gemma-fast"
+	// Fast providers (~40 tok/s observed) — comfortably above the floor.
+	slowGemmaProvider(t, reg, "p1", model, 40)
+	slowGemmaProvider(t, reg, "p2", model, 40)
+
+	reg.SetDecodeFloorShed(15, true)
+
+	// A healthy fleet must NOT be shed by the gate — guards against over-correcting.
+	cc, capRej, _ := reg.QuickCapacityCheck(model, 500, 4096, RequestTraits{})
+	if cc == 0 {
+		t.Fatalf("a fast fleet must remain admissible with shed ON; got cc=0 capRej=%d", capRej)
+	}
+}
+
+func TestDecodeFloorShed_ZeroFloor_NoOp(t *testing.T) {
+	reg := New(testLogger())
+	model := "gemma-slow"
+	slowGemmaProvider(t, reg, "p1", model, 8)
+
+	// hardShed true but floor 0 ⇒ disabled (matches MIN_DECODE_TPS=0 semantics):
+	// must behave exactly like the off-by-default path (admit).
+	reg.SetDecodeFloorShed(0, true)
+	cc, _, _ := reg.QuickCapacityCheck(model, 500, 4096, RequestTraits{})
+	if cc == 0 {
+		t.Fatalf("floor 0 must disable shedding (no-op); got cc=0")
+	}
+}

--- a/coordinator/registry/decode_floor_shed_test.go
+++ b/coordinator/registry/decode_floor_shed_test.go
@@ -216,6 +216,32 @@ func TestDecodeFloorShed_FullButFastFleet_StillQueues(t *testing.T) {
 	}
 }
 
+// Boundary: for a concurrency-full provider, the decode-floor decision must use
+// the rate the queued request would see AFTER a slot frees, not the immediate
+// "admit one more now" projection. With k=0.27, observed 11 tok/s at one active
+// request is above a 10 tok/s shed floor, but projecting b+1 makes it ~9.1 tok/s.
+// That b+1 projection is correct for providers with headroom, but too pessimistic
+// for a full provider that queue-before-shed would wait on.
+func TestDecodeFloorShed_FullProviderUsesQueuedStartProjection(t *testing.T) {
+	reg := New(testLogger())
+	model := "gemma-full-boundary"
+	p := slowGemmaProvider(t, reg, "p1", model, 11)
+	setSlotFull(t, p)
+
+	reg.SetDecodeFloorShed(10, true)
+
+	cc, capRej, _, decodeFloorRej, _, _ := reg.quickCapacityCheck(model, 500, 4096, RequestTraits{}, false)
+	if cc != 0 {
+		t.Fatalf("a concurrency-full provider must have no candidates; got cc=%d", cc)
+	}
+	if capRej == 0 {
+		t.Fatalf("a concurrency-full provider must be a capacity rejection; got capRej=%d", capRej)
+	}
+	if decodeFloorRej != 0 {
+		t.Fatalf("a full provider above the shed floor after a slot frees must queue, not throughput-shed; got decodeFloor=%d of %d", decodeFloorRej, capRej)
+	}
+}
+
 // A MIXED fleet (one full+slow, one full+fast) must queue: because the fast
 // provider's slot can free and serve at an acceptable rate, the request is worth
 // queueing. decodeFloorRejections (1) < capacityRejections (2).

--- a/coordinator/registry/decode_floor_shed_test.go
+++ b/coordinator/registry/decode_floor_shed_test.go
@@ -81,6 +81,32 @@ func TestDecodeFloorShed_On_StillAdmitsFastFleet(t *testing.T) {
 	if cc == 0 {
 		t.Fatalf("a fast fleet must remain admissible with shed ON; got cc=0 capRej=%d", capRej)
 	}
+	// And it must not be a PARTIAL shed (both fast providers stay candidates,
+	// zero capacity rejections) — catches a subtly-wrong projection.
+	if capRej != 0 {
+		t.Fatalf("a fast fleet must have 0 capacity rejections with shed ON; got capRej=%d", capRej)
+	}
+	if cc != 2 {
+		t.Fatalf("both fast providers must be candidates; got cc=%d", cc)
+	}
+}
+
+// A freshly-warm provider that has not yet completed a request reports
+// observedDecodeTPS==0; the projection then falls back to the STATIC benchmark
+// decodeTPS. A healthy static TPS (here 200) must keep it above the floor — the
+// shed gate must NOT punish a provider merely for having no observed sample yet.
+func TestDecodeFloorShed_On_DoesNotShedFreshWarmProvider(t *testing.T) {
+	reg := New(testLogger())
+	model := "gemma-fresh"
+	// observedTPS 0 ⇒ projection uses static decodeTPS=200 (set by makeScheduler
+	// Provider inside slowGemmaProvider) ⇒ ~157 tok/s projected, well above 15.
+	slowGemmaProvider(t, reg, "p1", model, 0)
+	reg.SetDecodeFloorShed(15, true)
+
+	cc, _, _ := reg.QuickCapacityCheck(model, 500, 4096, RequestTraits{})
+	if cc == 0 {
+		t.Fatalf("a fresh-warm provider (observed=0, static=200) must NOT be shed; got cc=0")
+	}
 }
 
 func TestDecodeFloorShed_ZeroFloor_NoOp(t *testing.T) {

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -1129,6 +1129,17 @@ func (r *Registry) SetDecodeFloorShed(tps float64, hardShed bool) {
 	r.decodeFloorHardShed = hardShed
 }
 
+// DecodeFloorShedArmed reports whether the preflight throughput-shed gate is
+// active (hardShed on AND a positive floor). The consumer uses this to bypass
+// queue-before-shed for a decode-floor capacity rejection: a fundamentally
+// too-slow fleet does not get faster by waiting in the queue, so it must 429
+// immediately rather than queue-then-timeout.
+func (r *Registry) DecodeFloorShedArmed() bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.decodeFloorHardShed && r.decodeFloorTPS > 0
+}
+
 func (r *Registry) CacheAffinityConfigSnapshot() CacheAffinityConfig {
 	r.mu.RLock()
 	defer r.mu.RUnlock()

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -1031,6 +1031,27 @@ type Registry struct {
 	cacheAffinity        *cacheAffinityTracker
 	cacheAffinityBonusMs float64
 	warmPool             *warmPoolController
+
+	// decodeFloorTPS / decodeFloorHardShed control whether the capacity
+	// preflight (quickCapacityCheck) SHEDS load when no provider can sustain the
+	// per-request decode floor, instead of merely re-ranking at dispatch time.
+	//
+	// Routing v2's W2 decode floor is purely advisory in selectBestCandidate
+	// LockedFull ("never fails closed — keep the full pool"), and the preflight
+	// did not apply it at all — so a bandwidth-bound model whose providers all
+	// decode below the floor (e.g. gemma-4 under load) still counted every
+	// provider as an admissible candidate. The coordinator then admitted far more
+	// requests than the fleet could serve at usable speed; they queued and timed
+	// out rather than being shed up front. When decodeFloorHardShed is true and
+	// decodeFloorTPS > 0, a provider whose PROJECTED per-request decode TPS (with
+	// this request added) falls below the floor is counted as a capacity
+	// rejection in the preflight, so an all-slow fleet yields candidateCount==0 /
+	// capacityRejections>0 and the existing capacity-shed path returns a fast
+	// 429/Retry-After. Default OFF (advisory, pre-fix behavior) — opt in via
+	// EIGENINFERENCE_DECODE_FLOOR_HARD_SHED=true. This sheds on THROUGHPUT only;
+	// it does not touch the memory cap / free_for_load_gb / resource-count gates.
+	decodeFloorTPS      float64
+	decodeFloorHardShed bool
 	// loadModelSender is a test seam for SendLoadModel. Nil uses the provider WebSocket.
 	loadModelSender func(providerID, modelID string) error
 
@@ -1094,6 +1115,18 @@ func (r *Registry) ConfigureCacheAffinity(cfg CacheAffinityConfig) {
 	}
 	r.cacheAffinity = newCacheAffinityTracker(cfg.TTL)
 	r.cacheAffinityBonusMs = cfg.BonusMs
+}
+
+// SetDecodeFloorShed configures the preflight throughput-shed gate. `tps` is the
+// per-request decode floor (tokens/sec; typically the same value as the
+// per-request MinDecodeTPS quality bar) and `hardShed` enables shedding in the
+// capacity preflight when no provider can sustain it. When hardShed is false
+// (default) the preflight is unchanged and the floor stays advisory at dispatch.
+func (r *Registry) SetDecodeFloorShed(tps float64, hardShed bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.decodeFloorTPS = tps
+	r.decodeFloorHardShed = hardShed
 }
 
 func (r *Registry) CacheAffinityConfigSnapshot() CacheAffinityConfig {

--- a/coordinator/registry/routingsim/runner.go
+++ b/coordinator/registry/routingsim/runner.go
@@ -43,7 +43,7 @@ func TTFTDeadline(promptTokens int) time.Duration {
 // modelTooLarge / no-provider cases collapse into the served default here; a
 // well-formed fleet never produces them.
 func ClassifyWithGate(reg *registry.Registry, a Arrival, softTTFT bool) Outcome {
-	candidateCount, capacityRejections, _, bestTTFT, hasTTFT :=
+	candidateCount, capacityRejections, _, _, bestTTFT, hasTTFT :=
 		reg.QuickCapacityCheckWithTTFTForRequest(a.Model, a.PromptTokens, a.MaxTokens, registry.RequestTraits{}, false)
 
 	if candidateCount == 0 && capacityRejections > 0 {

--- a/coordinator/registry/scheduler.go
+++ b/coordinator/registry/scheduler.go
@@ -1312,20 +1312,24 @@ func (r *Registry) providerCanAdmitLocked(p *Provider, model string, traits Requ
 //     a model that will never fit (the client would retry forever) — it should
 //     surface model_too_large / 503 instead.
 func (r *Registry) QuickCapacityCheck(model string, estimatedPromptTokens, requestedMaxTokens int, traits RequestTraits, allowedSerials ...string) (candidateCount, capacityRejections, modelTooLarge int) {
-	candidateCount, capacityRejections, modelTooLarge, _, _ = r.quickCapacityCheck(model, estimatedPromptTokens, requestedMaxTokens, traits, false, allowedSerials...)
+	candidateCount, capacityRejections, modelTooLarge, _, _, _ = r.quickCapacityCheck(model, estimatedPromptTokens, requestedMaxTokens, traits, false, allowedSerials...)
 	return candidateCount, capacityRejections, modelTooLarge
 }
 
 func (r *Registry) QuickCapacityCheckForRequest(model string, estimatedPromptTokens, requestedMaxTokens int, traits RequestTraits, requiresVision bool, allowedSerials ...string) (candidateCount, capacityRejections, modelTooLarge int) {
-	candidateCount, capacityRejections, modelTooLarge, _, _ = r.quickCapacityCheck(model, estimatedPromptTokens, requestedMaxTokens, traits, requiresVision, allowedSerials...)
+	candidateCount, capacityRejections, modelTooLarge, _, _, _ = r.quickCapacityCheck(model, estimatedPromptTokens, requestedMaxTokens, traits, requiresVision, allowedSerials...)
 	return candidateCount, capacityRejections, modelTooLarge
 }
 
-func (r *Registry) QuickCapacityCheckWithTTFTForRequest(model string, estimatedPromptTokens, requestedMaxTokens int, traits RequestTraits, requiresVision bool, allowedSerials ...string) (candidateCount, capacityRejections, modelTooLarge int, bestTTFT time.Duration, hasTTFT bool) {
+// QuickCapacityCheckWithTTFTForRequest also returns decodeFloorRejections: the
+// subset of capacityRejections that are decode-floor (throughput) sheds. The
+// consumer uses it to bypass queue-before-shed ONLY when every rejection is a
+// throughput shed — a transient concurrency/memory-full fleet must still queue.
+func (r *Registry) QuickCapacityCheckWithTTFTForRequest(model string, estimatedPromptTokens, requestedMaxTokens int, traits RequestTraits, requiresVision bool, allowedSerials ...string) (candidateCount, capacityRejections, modelTooLarge, decodeFloorRejections int, bestTTFT time.Duration, hasTTFT bool) {
 	return r.quickCapacityCheck(model, estimatedPromptTokens, requestedMaxTokens, traits, requiresVision, allowedSerials...)
 }
 
-func (r *Registry) quickCapacityCheck(model string, estimatedPromptTokens, requestedMaxTokens int, traits RequestTraits, requiresVision bool, allowedSerials ...string) (candidateCount, capacityRejections, modelTooLarge int, bestTTFT time.Duration, hasTTFT bool) {
+func (r *Registry) quickCapacityCheck(model string, estimatedPromptTokens, requestedMaxTokens int, traits RequestTraits, requiresVision bool, allowedSerials ...string) (candidateCount, capacityRejections, modelTooLarge, decodeFloorRejections int, bestTTFT time.Duration, hasTTFT bool) {
 	// Use a dummy PendingRequest with the caller's actual token estimates
 	// for the admission gate (freeMemoryAdmits).
 	if estimatedPromptTokens <= 0 {
@@ -1465,9 +1469,17 @@ func (r *Registry) quickCapacityCheck(model string, estimatedPromptTokens, reque
 		// all-slow fleet yields candidateCount==0 / capacityRejections>0 and the
 		// caller sheds with a fast 429/Retry-After instead of admit-and-stall.
 		// Throughput-only — independent of the memory cap / free_for_load gates.
+		//
+		// Tracked ALSO in decodeFloorRejections (a subset of capacityRejections)
+		// so the caller can tell a pure-throughput shed (every rejection here)
+		// from a transient concurrency/memory-full fleet that queue-before-shed
+		// should still queue. Without that split, arming the shed flag would
+		// fast-429 a momentarily-full-but-fast fleet — a queue-before-shed
+		// regression.
 		if r.decodeFloorHardShed && r.decodeFloorTPS > 0 && snap.hasBackendCapacity {
 			if projectedPerRequestDecodeTPS(snap) < r.decodeFloorTPS {
 				capacityRejections++
+				decodeFloorRejections++
 				continue
 			}
 		}
@@ -1484,9 +1496,9 @@ func (r *Registry) quickCapacityCheck(model string, estimatedPromptTokens, reque
 		}
 	}
 	if unknownTTFTCandidate {
-		return candidateCount, capacityRejections, modelTooLarge, 0, false
+		return candidateCount, capacityRejections, modelTooLarge, decodeFloorRejections, 0, false
 	}
-	return candidateCount, capacityRejections, modelTooLarge, bestTTFT, hasTTFT
+	return candidateCount, capacityRejections, modelTooLarge, decodeFloorRejections, bestTTFT, hasTTFT
 }
 
 func estimatedTTFTFromSnapshot(snap routingSnapshot, reqPromptTokens int) time.Duration {

--- a/coordinator/registry/scheduler.go
+++ b/coordinator/registry/scheduler.go
@@ -1455,6 +1455,23 @@ func (r *Registry) quickCapacityCheck(model string, estimatedPromptTokens, reque
 			continue
 		}
 
+		// Decode-floor SHED gate (opt-in, EIGENINFERENCE_DECODE_FLOOR_HARD_SHED).
+		// freeMemoryAdmits keys on KV memory, which a bandwidth-bound model (e.g.
+		// gemma-4 under load) never exhausts — so the preflight would count every
+		// provider as admissible even when none can decode at usable speed,
+		// over-admitting requests that then queue and time out. When enabled, a
+		// provider whose PROJECTED per-request decode TPS (with this request
+		// added) falls below the floor is counted as a capacity rejection, so an
+		// all-slow fleet yields candidateCount==0 / capacityRejections>0 and the
+		// caller sheds with a fast 429/Retry-After instead of admit-and-stall.
+		// Throughput-only — independent of the memory cap / free_for_load gates.
+		if r.decodeFloorHardShed && r.decodeFloorTPS > 0 && snap.hasBackendCapacity {
+			if projectedPerRequestDecodeTPS(snap) < r.decodeFloorTPS {
+				capacityRejections++
+				continue
+			}
+		}
+
 		candidateCount++
 		if snap.hasBackendCapacity {
 			ttft := estimatedTTFTFromSnapshot(snap, estimatedPromptTokens)

--- a/coordinator/registry/scheduler.go
+++ b/coordinator/registry/scheduler.go
@@ -1220,16 +1220,27 @@ func projectedPerRequestDecodeTPS(snap routingSnapshot) float64 {
 	return projectedPerRequestDecodeTPSAtBatch(snap, snap.backendRunning+1)
 }
 
-// projectedQueuedStartDecodeTPS estimates the per-request decode TPS a queued
-// request would see after this model's slot frees. Unlike the immediate-admit
-// projection above, it does NOT add one on top of the already-full batch: the
-// request starts by replacing a completed/waiting slot, so the relevant batch is
-// the model's concurrency cap.
-func projectedQueuedStartDecodeTPS(snap routingSnapshot, modelMaxConcurrency int) float64 {
-	if modelMaxConcurrency < 1 {
-		modelMaxConcurrency = 1
+// queuedStartBatchSizeForCapacityRelease estimates the batch size a queued
+// request would see after model capacity frees. Unlike the immediate-admit
+// projection, it does not add one on top of the current batch: the request starts
+// by replacing capacity that just completed/freed. Waiting provider-side work is
+// included because a request queued behind it can still enter at the model cap.
+func queuedStartBatchSizeForCapacityRelease(snap routingSnapshot, modelMaxConcurrency int) int {
+	batch := snap.backendRunning + snap.backendWaiting
+	if batch < 1 {
+		batch = 1
 	}
-	return projectedPerRequestDecodeTPSAtBatch(snap, modelMaxConcurrency)
+	if modelMaxConcurrency > 0 && batch > modelMaxConcurrency {
+		batch = modelMaxConcurrency
+	}
+	return batch
+}
+
+func projectedQueuedStartDecodeTPS(snap routingSnapshot, modelMaxConcurrency int) float64 {
+	return projectedPerRequestDecodeTPSAtBatch(
+		snap,
+		queuedStartBatchSizeForCapacityRelease(snap, modelMaxConcurrency),
+	)
 }
 
 func projectedPerRequestDecodeTPSAtBatch(snap routingSnapshot, targetBatchSize int) float64 {
@@ -1483,20 +1494,20 @@ func (r *Registry) quickCapacityCheck(model string, estimatedPromptTokens, reque
 		}
 
 		// Decode-floor classification, applied BEFORE the concurrency and memory
-		// gates so a full/slow provider is still recognized as throughput-slow.
-		// belowDecodeFloor is true when the shed is armed and this provider's
-		// PROJECTED per-request decode TPS (with this request added) is under the
-		// floor — i.e. queueing for a slot here would still serve below the
-		// quality bar. freeMemoryAdmits keys on KV memory, which a bandwidth-bound
-		// model (e.g. gemma-4 under load) never exhausts, so without this gate the
-		// preflight counts every such provider as admissible and over-admits
+		// gates so full/slow providers are still recognized as throughput-slow.
+		// Use two projections because the capacity failure mode matters:
+		// immediate-admit requests join the current batch (b+1), while queued
+		// requests caused by concurrency or token-budget pressure start only after
+		// capacity frees/replaces existing work. freeMemoryAdmits keys on KV
+		// memory, which a bandwidth-bound model (e.g. gemma-4 under load) never
+		// exhausts, so without this throughput gate the preflight over-admits
 		// requests that then queue and time out.
-		projectedDecodeTPS := projectedPerRequestDecodeTPS(snap)
-		if !hasModelHeadroom {
-			projectedDecodeTPS = projectedQueuedStartDecodeTPS(snap, modelMaxConcurrency)
-		}
-		belowDecodeFloor := r.decodeFloorHardShed && r.decodeFloorTPS > 0 &&
-			snap.hasBackendCapacity && projectedDecodeTPS < r.decodeFloorTPS
+		immediateProjectedDecodeTPS := projectedPerRequestDecodeTPS(snap)
+		queuedProjectedDecodeTPS := projectedQueuedStartDecodeTPS(snap, modelMaxConcurrency)
+		belowImmediateDecodeFloor := r.decodeFloorHardShed && r.decodeFloorTPS > 0 &&
+			snap.hasBackendCapacity && immediateProjectedDecodeTPS < r.decodeFloorTPS
+		belowQueuedDecodeFloor := r.decodeFloorHardShed && r.decodeFloorTPS > 0 &&
+			snap.hasBackendCapacity && queuedProjectedDecodeTPS < r.decodeFloorTPS
 
 		// Concurrency gate. A full provider is a capacity rejection. CRUCIAL: if
 		// it is ALSO below the decode floor, count it in decodeFloorRejections too
@@ -1506,6 +1517,10 @@ func (r *Registry) quickCapacityCheck(model string, estimatedPromptTokens, reque
 		// slot will free and serve at an acceptable rate.
 		if !hasHeadroom {
 			capacityRejections++
+			belowDecodeFloor := belowImmediateDecodeFloor
+			if !hasModelHeadroom {
+				belowDecodeFloor = belowQueuedDecodeFloor
+			}
 			if belowDecodeFloor {
 				decodeFloorRejections++
 			}
@@ -1515,7 +1530,7 @@ func (r *Registry) quickCapacityCheck(model string, estimatedPromptTokens, reque
 		// Free memory / token budget admission gate.
 		if !freeMemoryAdmits(snap, dummyPR.EstimatedPromptTokens, dummyPR.RequestedMaxTokens) {
 			capacityRejections++
-			if belowDecodeFloor {
+			if belowQueuedDecodeFloor {
 				decodeFloorRejections++
 			}
 			continue
@@ -1534,7 +1549,7 @@ func (r *Registry) quickCapacityCheck(model string, estimatedPromptTokens, reque
 		// should still queue. Without that split, arming the shed flag would
 		// fast-429 a momentarily-full-but-fast fleet — a queue-before-shed
 		// regression.
-		if belowDecodeFloor {
+		if belowImmediateDecodeFloor {
 			capacityRejections++
 			decodeFloorRejections++
 			continue

--- a/coordinator/registry/scheduler.go
+++ b/coordinator/registry/scheduler.go
@@ -1217,6 +1217,22 @@ func resolvedPrefillTPS(p *Provider) float64 {
 // reapplied at b+1; otherwise the static benchmark is the solo proxy. Used by the
 // decode-floor quality preference (PendingRequest.MinDecodeTPS).
 func projectedPerRequestDecodeTPS(snap routingSnapshot) float64 {
+	return projectedPerRequestDecodeTPSAtBatch(snap, snap.backendRunning+1)
+}
+
+// projectedQueuedStartDecodeTPS estimates the per-request decode TPS a queued
+// request would see after this model's slot frees. Unlike the immediate-admit
+// projection above, it does NOT add one on top of the already-full batch: the
+// request starts by replacing a completed/waiting slot, so the relevant batch is
+// the model's concurrency cap.
+func projectedQueuedStartDecodeTPS(snap routingSnapshot, modelMaxConcurrency int) float64 {
+	if modelMaxConcurrency < 1 {
+		modelMaxConcurrency = 1
+	}
+	return projectedPerRequestDecodeTPSAtBatch(snap, modelMaxConcurrency)
+}
+
+func projectedPerRequestDecodeTPSAtBatch(snap routingSnapshot, targetBatchSize int) float64 {
 	k := effectiveTPSLoadFactor
 	if k < 0 {
 		k = 0
@@ -1225,6 +1241,9 @@ func projectedPerRequestDecodeTPS(snap routingSnapshot) float64 {
 	if b < 0 {
 		b = 0
 	}
+	if targetBatchSize < 1 {
+		targetBatchSize = 1
+	}
 	solo := snap.decodeTPS
 	if snap.observedDecodeTPS > 0 {
 		solo = snap.observedDecodeTPS * (1 + k*float64(b)) // unwind measured@b to solo (b=0)
@@ -1232,7 +1251,7 @@ func projectedPerRequestDecodeTPS(snap routingSnapshot) float64 {
 	if solo <= 0 {
 		return 0
 	}
-	return solo / (1 + k*float64(b+1))
+	return solo / (1 + k*float64(targetBatchSize))
 }
 
 func providerModelIDs(p *Provider) []string {
@@ -1436,7 +1455,15 @@ func (r *Registry) quickCapacityCheck(model string, estimatedPromptTokens, reque
 		// Capture concurrency headroom under the lock (the gate is applied after
 		// unlock, below, so a full-but-slow provider is still classified against
 		// the decode floor instead of short-circuiting as a plain capacity full).
-		hasHeadroom := p.hasConcurrencyHeadroomForModelLocked(model)
+		// Keep per-model and global headroom separate: if the model slot itself is
+		// full, queue-before-shed would wait for a model slot to free, so the
+		// decode-floor projection must use the queued-start batch size. If only the
+		// provider-wide/global cap is full but this model has headroom, the request
+		// will join this model's batch after an unrelated slot frees, so the normal
+		// immediate b+1 projection is still the right throughput check.
+		modelMaxConcurrency := p.maxConcurrencyForModelLocked(model)
+		hasModelHeadroom := p.pendingLoadForModelLocked(model) < modelMaxConcurrency
+		hasHeadroom := hasModelHeadroom && p.pendingCount() < p.maxConcurrency()
 
 		p.mu.Unlock()
 
@@ -1464,8 +1491,12 @@ func (r *Registry) quickCapacityCheck(model string, estimatedPromptTokens, reque
 		// model (e.g. gemma-4 under load) never exhausts, so without this gate the
 		// preflight counts every such provider as admissible and over-admits
 		// requests that then queue and time out.
+		projectedDecodeTPS := projectedPerRequestDecodeTPS(snap)
+		if !hasModelHeadroom {
+			projectedDecodeTPS = projectedQueuedStartDecodeTPS(snap, modelMaxConcurrency)
+		}
 		belowDecodeFloor := r.decodeFloorHardShed && r.decodeFloorTPS > 0 &&
-			snap.hasBackendCapacity && projectedPerRequestDecodeTPS(snap) < r.decodeFloorTPS
+			snap.hasBackendCapacity && projectedDecodeTPS < r.decodeFloorTPS
 
 		// Concurrency gate. A full provider is a capacity rejection. CRUCIAL: if
 		// it is ALSO below the decode floor, count it in decodeFloorRejections too

--- a/coordinator/registry/scheduler.go
+++ b/coordinator/registry/scheduler.go
@@ -1382,14 +1382,12 @@ func (r *Registry) quickCapacityCheck(model string, estimatedPromptTokens, reque
 			continue
 		}
 
-		// Concurrency gate.
-		if !p.hasConcurrencyHeadroomForModelLocked(model) {
-			p.mu.Unlock()
-			capacityRejections++
-			continue
-		}
-
 		// Build a snapshot for the admission gate (slot state + free memory).
+		// Built BEFORE the concurrency gate so a concurrency-full provider can
+		// still be classified against the decode floor below: a full-AND-slow
+		// fleet must fast-429 (queueing only defers the same too-slow outcome),
+		// while a full-but-FAST fleet stays a plain concurrency rejection that
+		// queue-before-shed still queues (a slot frees and serves quickly).
 		snap := routingSnapshot{
 			provider:           p,
 			model:              model,
@@ -1435,6 +1433,10 @@ func (r *Registry) quickCapacityCheck(model string, estimatedPromptTokens, reque
 		snap.modelLoaded = slotStateModelLoaded(snap.slotState)
 		snap.availableOnDisk = !snap.modelLoaded
 		snap.fleetMedianTPS = r.tpsRegistry.Median(model, p.Hardware.ChipFamily)
+		// Capture concurrency headroom under the lock (the gate is applied after
+		// unlock, below, so a full-but-slow provider is still classified against
+		// the decode floor instead of short-circuiting as a plain capacity full).
+		hasHeadroom := p.hasConcurrencyHeadroomForModelLocked(model)
 
 		p.mu.Unlock()
 
@@ -1453,35 +1455,58 @@ func (r *Registry) quickCapacityCheck(model string, estimatedPromptTokens, reque
 			continue
 		}
 
+		// Decode-floor classification, applied BEFORE the concurrency and memory
+		// gates so a full/slow provider is still recognized as throughput-slow.
+		// belowDecodeFloor is true when the shed is armed and this provider's
+		// PROJECTED per-request decode TPS (with this request added) is under the
+		// floor — i.e. queueing for a slot here would still serve below the
+		// quality bar. freeMemoryAdmits keys on KV memory, which a bandwidth-bound
+		// model (e.g. gemma-4 under load) never exhausts, so without this gate the
+		// preflight counts every such provider as admissible and over-admits
+		// requests that then queue and time out.
+		belowDecodeFloor := r.decodeFloorHardShed && r.decodeFloorTPS > 0 &&
+			snap.hasBackendCapacity && projectedPerRequestDecodeTPS(snap) < r.decodeFloorTPS
+
+		// Concurrency gate. A full provider is a capacity rejection. CRUCIAL: if
+		// it is ALSO below the decode floor, count it in decodeFloorRejections too
+		// — a full+slow fleet must fast-429 (queueing only defers the same
+		// too-slow outcome to a 120s timeout), whereas a full+FAST fleet stays a
+		// plain capacity rejection that queue-before-shed still queues because a
+		// slot will free and serve at an acceptable rate.
+		if !hasHeadroom {
+			capacityRejections++
+			if belowDecodeFloor {
+				decodeFloorRejections++
+			}
+			continue
+		}
+
 		// Free memory / token budget admission gate.
 		if !freeMemoryAdmits(snap, dummyPR.EstimatedPromptTokens, dummyPR.RequestedMaxTokens) {
 			capacityRejections++
+			if belowDecodeFloor {
+				decodeFloorRejections++
+			}
 			continue
 		}
 
 		// Decode-floor SHED gate (opt-in, EIGENINFERENCE_DECODE_FLOOR_HARD_SHED).
-		// freeMemoryAdmits keys on KV memory, which a bandwidth-bound model (e.g.
-		// gemma-4 under load) never exhausts — so the preflight would count every
-		// provider as admissible even when none can decode at usable speed,
-		// over-admitting requests that then queue and time out. When enabled, a
-		// provider whose PROJECTED per-request decode TPS (with this request
-		// added) falls below the floor is counted as a capacity rejection, so an
-		// all-slow fleet yields candidateCount==0 / capacityRejections>0 and the
-		// caller sheds with a fast 429/Retry-After instead of admit-and-stall.
-		// Throughput-only — independent of the memory cap / free_for_load gates.
+		// A provider with headroom and free memory but projecting below the floor
+		// is shed on THROUGHPUT alone, so an all-slow fleet yields
+		// candidateCount==0 / capacityRejections>0 (all decodeFloorRejections) and
+		// the caller sheds with a fast 429/Retry-After instead of admit-and-stall.
+		// Independent of the memory cap / free_for_load gates.
 		//
-		// Tracked ALSO in decodeFloorRejections (a subset of capacityRejections)
-		// so the caller can tell a pure-throughput shed (every rejection here)
-		// from a transient concurrency/memory-full fleet that queue-before-shed
+		// decodeFloorRejections is a subset of capacityRejections so the caller
+		// can tell a pure-throughput shed (every rejection is below-floor) from a
+		// transient concurrency/memory-full-but-FAST fleet that queue-before-shed
 		// should still queue. Without that split, arming the shed flag would
 		// fast-429 a momentarily-full-but-fast fleet — a queue-before-shed
 		// regression.
-		if r.decodeFloorHardShed && r.decodeFloorTPS > 0 && snap.hasBackendCapacity {
-			if projectedPerRequestDecodeTPS(snap) < r.decodeFloorTPS {
-				capacityRejections++
-				decodeFloorRejections++
-				continue
-			}
+		if belowDecodeFloor {
+			capacityRejections++
+			decodeFloorRejections++
+			continue
 		}
 
 		candidateCount++

--- a/coordinator/registry/scheduler_test.go
+++ b/coordinator/registry/scheduler_test.go
@@ -126,7 +126,7 @@ func TestQuickCapacityCheckWithTTFTEstimatesBestEligibleProvider(t *testing.T) {
 	slow.BackendCapacity.Slots[0].MaxConcurrency = 128
 	slow.mu.Unlock()
 
-	candidates, rejections, tooLarge, bestTTFT, hasTTFT := reg.QuickCapacityCheckWithTTFTForRequest(model, 100, 128, RequestTraits{}, false)
+	candidates, rejections, tooLarge, _, bestTTFT, hasTTFT := reg.QuickCapacityCheckWithTTFTForRequest(model, 100, 128, RequestTraits{}, false)
 	if candidates != 1 || rejections != 0 || tooLarge != 0 {
 		t.Fatalf("capacity = (%d,%d,%d), want (1,0,0)", candidates, rejections, tooLarge)
 	}
@@ -138,7 +138,7 @@ func TestQuickCapacityCheckWithTTFTEstimatesBestEligibleProvider(t *testing.T) {
 	fast.mu.Lock()
 	fast.PrefillTPS = 400
 	fast.mu.Unlock()
-	candidates, rejections, tooLarge, bestTTFT, hasTTFT = reg.QuickCapacityCheckWithTTFTForRequest(model, 100, 128, RequestTraits{}, false)
+	candidates, rejections, tooLarge, _, bestTTFT, hasTTFT = reg.QuickCapacityCheckWithTTFTForRequest(model, 100, 128, RequestTraits{}, false)
 	if candidates != 2 || rejections != 0 || tooLarge != 0 {
 		t.Fatalf("capacity with fast provider = (%d,%d,%d), want (2,0,0)", candidates, rejections, tooLarge)
 	}
@@ -160,7 +160,7 @@ func TestQuickCapacityCheckWithTTFTIncludesWaitingPrefills(t *testing.T) {
 	p.BackendCapacity.Slots[0].QueuedTokenBudget = 40_000
 	p.mu.Unlock()
 
-	candidates, rejections, tooLarge, bestTTFT, hasTTFT := reg.QuickCapacityCheckWithTTFTForRequest(model, 2_000, 128, RequestTraits{}, false)
+	candidates, rejections, tooLarge, _, bestTTFT, hasTTFT := reg.QuickCapacityCheckWithTTFTForRequest(model, 2_000, 128, RequestTraits{}, false)
 	if candidates != 1 || rejections != 0 || tooLarge != 0 {
 		t.Fatalf("capacity = (%d,%d,%d), want (1,0,0)", candidates, rejections, tooLarge)
 	}
@@ -179,7 +179,7 @@ func TestQuickCapacityCheckWithTTFTIgnoresActiveReservations(t *testing.T) {
 	p.BackendCapacity.Slots[0].QueuedTokenBudget = 40_000
 	p.mu.Unlock()
 
-	candidates, rejections, tooLarge, bestTTFT, hasTTFT := reg.QuickCapacityCheckWithTTFTForRequest(model, 100, 2048, RequestTraits{}, false)
+	candidates, rejections, tooLarge, _, bestTTFT, hasTTFT := reg.QuickCapacityCheckWithTTFTForRequest(model, 100, 2048, RequestTraits{}, false)
 	if candidates != 1 || rejections != 0 || tooLarge != 0 {
 		t.Fatalf("capacity = (%d,%d,%d), want (1,0,0)", candidates, rejections, tooLarge)
 	}
@@ -280,7 +280,7 @@ func TestQuickCapacityCheckTTFTUsesObservedPrefillTPS(t *testing.T) {
 	pBench.PrefillTPS = 400
 	pBench.BackendCapacity.Slots[0].MaxConcurrency = 8
 	pBench.mu.Unlock()
-	_, _, _, benchTTFT, hasBench := regBench.QuickCapacityCheckWithTTFTForRequest(model, prompt, 128, RequestTraits{}, false)
+	_, _, _, _, benchTTFT, hasBench := regBench.QuickCapacityCheckWithTTFTForRequest(model, prompt, 128, RequestTraits{}, false)
 	if !hasBench {
 		t.Fatal("expected a TTFT estimate for the benchmark-only provider")
 	}
@@ -298,7 +298,7 @@ func TestQuickCapacityCheckTTFTUsesObservedPrefillTPS(t *testing.T) {
 	pObs.BackendCapacity.Slots[0].MaxConcurrency = 8
 	pObs.BackendCapacity.Slots[0].ObservedPrefillTPS = 1600
 	pObs.mu.Unlock()
-	_, _, _, obsTTFT, hasObs := regObs.QuickCapacityCheckWithTTFTForRequest(model, prompt, 128, RequestTraits{}, false)
+	_, _, _, _, obsTTFT, hasObs := regObs.QuickCapacityCheckWithTTFTForRequest(model, prompt, 128, RequestTraits{}, false)
 	if !hasObs {
 		t.Fatal("expected a TTFT estimate for the observed-prefill provider")
 	}

--- a/provider-swift/Sources/ProviderCore/Inference/BatchScheduler+Telemetry.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/BatchScheduler+Telemetry.swift
@@ -131,6 +131,24 @@ extension BatchScheduler {
             maxTokensPotential += Int64(entry.promptTokens + entry.maxTokens)
         }
 
+        // Fold in-flight VLM/media load into the token telemetry the coordinator
+        // admits on. Vision requests run on the non-batched path and never create
+        // an activeBridges entry, so without this the coordinator's
+        // freeMemoryAdmits (which keys on activeTokenBudgetUsed + maxTokensPotential
+        // when a token budget is present) is blind to media load and over-admits.
+        // We charge each request's full KV-token span (prompt + vision + output,
+        // captured at reserve time) to BOTH the used and worst-case-potential
+        // figures — a media request reserves its whole span up front, so used and
+        // potential coincide for it. This is advisory routing signal only; the
+        // authoritative OOM gate remains the byte reservation in kvBudget (the 90%
+        // unified-memory cap), which already admitted these requests.
+        var visionTokens: Int64 = 0
+        for tokens in activeVisionRequests.values {
+            visionTokens += Int64(tokens)
+        }
+        activeTokens += visionTokens
+        maxTokensPotential += visionTokens
+
         let budgetMax = Int64(tokenBudgetMax)
 
         let slot = BackendSlotCapacity(
@@ -143,7 +161,7 @@ extension BatchScheduler {
             maxConcurrency: UInt32(cap.maxConcurrent),
             observedDecodeTps: observedDecodeTpsEwma,
             observedPrefillTps: observedPrefillTpsEwma,
-            activeTokenBudgetUsed: Int64(activeTokenBudgetUsed),
+            activeTokenBudgetUsed: Int64(activeTokenBudgetUsed) + visionTokens,
             activeTokenBudgetMax: budgetMax,
             queuedTokenBudget: Int64(queuedTokenBudget),
             kvBytesPerToken: Int64(kvBytesPerToken),

--- a/provider-swift/Sources/ProviderCore/Inference/BatchScheduler.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/BatchScheduler.swift
@@ -175,15 +175,25 @@ public actor BatchScheduler {
     /// distinct "request timed out waiting for capacity" error string
     /// (vs. "request cancelled" for client-initiated aborts).
     var timedOutBridges: Set<String> = []
-    /// In-flight VLM/media request ids. The vision path serves through the
+    /// In-flight VLM/media requests, mapping request id → the KV-token span the
+    /// request occupies (prompt text + image/video soft tokens + generated
+    /// output, as computed at reserve time). The vision path serves through the
     /// container's non-batched prepare/generate route and reserves memory via
     /// `reserveVisionRequest` instead of inserting an `activeBridges` entry, so
-    /// without this set `capacity().activeRequests` (= `activeBridges.count`)
-    /// reports the provider as less loaded than it is. The coordinator routes on
-    /// that count, so an under-report invites over-admission of concurrent media
-    /// requests. Inserted in `reserveVisionRequest`, removed in
-    /// `releaseVisionRequest`, and cleared by `cancelAll()`.
-    var activeVisionRequests: Set<String> = []
+    /// without this map both `capacity().activeRequests` (= `activeBridges.count`)
+    /// AND the token-budget telemetry (`activeTokenBudgetUsed` /
+    /// `maxTokensPotential`, derived only from `activeBridges`) report the
+    /// provider as less loaded than it is. The coordinator routes on the count
+    /// and admits on the token budget, so the under-report invites over-admission
+    /// of concurrent media requests. Inserted in `reserveVisionRequest`, removed
+    /// in `releaseVisionRequest`, and cleared by `cancelAll()`.
+    ///
+    /// NOTE: this token figure is ADVISORY — it makes media load visible to the
+    /// coordinator's coarse token-budget admission gate. The authoritative OOM
+    /// gate is the byte reservation in `kvBudget` (the 90% unified-memory cap),
+    /// which `reserveVisionRequest` already enforces; this token accounting must
+    /// not be read as a second memory gate and does not double-charge the bytes.
+    var activeVisionRequests: [String: Int] = [:]
 
     // MARK: - Telemetry state (read by `backendCapacity`)
 
@@ -1613,9 +1623,10 @@ public actor BatchScheduler {
     ) async -> Bool {
         guard let kvBudget else {
             // Budgeting disabled (legacy "always proceed"): still track the
-            // request as in-flight so `capacity().activeRequests` reflects the
-            // concurrent media load the coordinator routes on.
-            activeVisionRequests.insert(requestId)
+            // request as in-flight so `capacity().activeRequests` and the token
+            // telemetry reflect the concurrent media load the coordinator routes
+            // and admits on.
+            activeVisionRequests[requestId] = max(0, kvTokens)
             return true
         }
         // KV bytes = kvBytesPerToken × the FULL token span the cache will hold:
@@ -1634,9 +1645,10 @@ public actor BatchScheduler {
         let reserved = await kvBudget.reserveBytes(requestID: requestId, bytes: bytes)
         // Only count the request as in-flight once the reservation succeeds: a
         // rejected reserve never starts generation, so it must not inflate the
-        // reported active count. Released via `releaseVisionRequest`.
+        // reported active count or token budget. Released via
+        // `releaseVisionRequest`.
         if reserved {
-            activeVisionRequests.insert(requestId)
+            activeVisionRequests[requestId] = max(0, kvTokens)
         }
         return reserved
     }
@@ -1651,9 +1663,9 @@ public actor BatchScheduler {
     /// Release a prior `reserveVisionRequest` reservation. Safe/no-op if unknown
     /// or budgeting is disabled. Idempotent: the VLM stream releases on normal
     /// finish, on throw, and on `onTermination`, so the same id can arrive more
-    /// than once — `Set.remove` and `kvBudget.release` both no-op on a miss.
+    /// than once — `removeValue(forKey:)` and `kvBudget.release` both no-op on a miss.
     public func releaseVisionRequest(requestId: String) async {
-        activeVisionRequests.remove(requestId)
+        activeVisionRequests.removeValue(forKey: requestId)
         await kvBudget?.release(requestID: requestId)
     }
 
@@ -2052,7 +2064,7 @@ public actor BatchScheduler {
         // Release in-flight vision reservations too; their generation tasks are
         // cancelled with everything else, and the per-stream release may not run
         // before the next capacity report. Mirrors the activeBridges teardown.
-        let visionIds = Array(activeVisionRequests)
+        let visionIds = Array(activeVisionRequests.keys)
         for id in visionIds {
             await kvBudget?.release(requestID: id)
         }
@@ -2068,6 +2080,12 @@ public actor BatchScheduler {
     /// Pure bookkeeping (no MLX/GPU access) so it is unit-testable without a
     /// loaded engine or metallib.
     var activeRequestCount: Int { activeBridges.count + activeVisionRequests.count }
+
+    /// Sum of the KV-token spans of all in-flight VLM/media requests, folded into
+    /// the heartbeat's token-budget figures so the coordinator's admission gate
+    /// sees media load (see `backendCapacity()`). Advisory routing signal only —
+    /// the byte reservation in `kvBudget` is the authoritative memory gate.
+    var activeVisionTokens: Int { activeVisionRequests.values.reduce(0, +) }
 
     public func capacity() -> SchedulerCapacity {
         SchedulerCapacity(

--- a/provider-swift/Sources/ProviderCore/Inference/BatchScheduler.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/BatchScheduler.swift
@@ -175,6 +175,15 @@ public actor BatchScheduler {
     /// distinct "request timed out waiting for capacity" error string
     /// (vs. "request cancelled" for client-initiated aborts).
     var timedOutBridges: Set<String> = []
+    /// In-flight VLM/media request ids. The vision path serves through the
+    /// container's non-batched prepare/generate route and reserves memory via
+    /// `reserveVisionRequest` instead of inserting an `activeBridges` entry, so
+    /// without this set `capacity().activeRequests` (= `activeBridges.count`)
+    /// reports the provider as less loaded than it is. The coordinator routes on
+    /// that count, so an under-report invites over-admission of concurrent media
+    /// requests. Inserted in `reserveVisionRequest`, removed in
+    /// `releaseVisionRequest`, and cleared by `cancelAll()`.
+    var activeVisionRequests: Set<String> = []
 
     // MARK: - Telemetry state (read by `backendCapacity`)
 
@@ -1602,7 +1611,13 @@ public actor BatchScheduler {
     public func reserveVisionRequest(
         requestId: String, mediaDecodeBytes: UInt64, kvTokens: Int
     ) async -> Bool {
-        guard let kvBudget else { return true }
+        guard let kvBudget else {
+            // Budgeting disabled (legacy "always proceed"): still track the
+            // request as in-flight so `capacity().activeRequests` reflects the
+            // concurrent media load the coordinator routes on.
+            activeVisionRequests.insert(requestId)
+            return true
+        }
         // KV bytes = kvBytesPerToken × the FULL token span the cache will hold:
         // prompt text + image/video soft tokens + generated output (the caller
         // computes that conservative total). Reserving only the output tokens
@@ -1616,7 +1631,14 @@ public actor BatchScheduler {
         }
         let (total, overflow) = mediaDecodeBytes.addingReportingOverflow(genKVBytes)
         let bytes = overflow ? UInt64.max : total
-        return await kvBudget.reserveBytes(requestID: requestId, bytes: bytes)
+        let reserved = await kvBudget.reserveBytes(requestID: requestId, bytes: bytes)
+        // Only count the request as in-flight once the reservation succeeds: a
+        // rejected reserve never starts generation, so it must not inflate the
+        // reported active count. Released via `releaseVisionRequest`.
+        if reserved {
+            activeVisionRequests.insert(requestId)
+        }
+        return reserved
     }
 
     /// The model's configured context window (`max_position_embeddings`), or 0 if
@@ -1627,8 +1649,11 @@ public actor BatchScheduler {
     public func contextLength() -> Int { maxContextLength }
 
     /// Release a prior `reserveVisionRequest` reservation. Safe/no-op if unknown
-    /// or budgeting is disabled.
+    /// or budgeting is disabled. Idempotent: the VLM stream releases on normal
+    /// finish, on throw, and on `onTermination`, so the same id can arrive more
+    /// than once — `Set.remove` and `kvBudget.release` both no-op on a miss.
     public func releaseVisionRequest(requestId: String) async {
+        activeVisionRequests.remove(requestId)
         await kvBudget?.release(requestID: requestId)
     }
 
@@ -2024,14 +2049,30 @@ public actor BatchScheduler {
         }
         activeBridges.removeAll()
         timedOutBridges.removeAll()
+        // Release in-flight vision reservations too; their generation tasks are
+        // cancelled with everything else, and the per-stream release may not run
+        // before the next capacity report. Mirrors the activeBridges teardown.
+        let visionIds = Array(activeVisionRequests)
+        for id in visionIds {
+            await kvBudget?.release(requestID: id)
+        }
+        activeVisionRequests.removeAll()
     }
 
     // MARK: - Capacity
 
+    /// Combined in-flight request count reported to the coordinator: batched
+    /// (text) requests in `activeBridges` plus VLM/media requests on the
+    /// non-batched vision path (`activeVisionRequests`). Both occupy the model
+    /// and memory, so the coordinator must see the sum to admit correctly.
+    /// Pure bookkeeping (no MLX/GPU access) so it is unit-testable without a
+    /// loaded engine or metallib.
+    var activeRequestCount: Int { activeBridges.count + activeVisionRequests.count }
+
     public func capacity() -> SchedulerCapacity {
         SchedulerCapacity(
             model: modelId,
-            activeRequests: activeBridges.count,
+            activeRequests: activeRequestCount,
             pendingRequests: pendingRequestCount,
             maxConcurrent: effectiveMaxConcurrentRequests,
             engineMaxConcurrent: maxConcurrentRequests,

--- a/provider-swift/Sources/ProviderCore/Inference/BatchScheduler.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/BatchScheduler.swift
@@ -2161,6 +2161,18 @@ public actor BatchScheduler {
         }
         activeBridges.removeAll()
         timedOutBridges.removeAll()
+        // Release in-flight VLM/media reservations on teardown too. The vision
+        // path reserves against kvBudget without an activeBridges entry, so the
+        // bridge loop above misses it; on a forced unload/stop (vs. an LRU evict
+        // of idle work) the per-stream release may not have run yet, leaving a
+        // stale byte reservation + token accounting until the async stream
+        // termination fires. Mirror the activeBridges teardown. release is
+        // idempotent, so a later stream-termination release no-ops.
+        let visionIds = Array(activeVisionRequests.keys)
+        for id in visionIds {
+            await kvBudget?.release(requestID: id)
+        }
+        activeVisionRequests.removeAll()
         pendingSummaryCache = .empty
 
         modelWeightBytes = 0

--- a/provider-swift/Tests/ProviderCoreTests/BatchSchedulerVisionCapacityTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/BatchSchedulerVisionCapacityTests.swift
@@ -173,4 +173,39 @@ struct BatchSchedulerVisionCapacityTests {
         #expect(await scheduler.activeRequestCount == 0,
             "a drain/cancelAll must release vision reservations like it does bridges")
     }
+
+    @Test("unloadModel teardown clears in-flight vision reservations")
+    func unloadModelClearsVisionRequests() async {
+        // A forced unload/stop (not an LRU evict of idle work) can run while a
+        // vision stream is still in flight; its per-stream release may not have
+        // fired yet. stopCurrentEngine() must release the kvBudget reservation
+        // and clear the token accounting, not leak it until the async
+        // termination. (No model is loaded, so stopCurrentEngine skips the MLX
+        // engine paths and exercises the teardown bookkeeping directly.)
+        let budget = GlobalKVCacheBudget(capFraction: 1.0, activationReserveBytes: 0) {
+            GlobalKVCacheBudget.MemorySnapshot(total: 8 * gib, active: 0, cache: 0, systemAvailable: .max)
+        }
+        let scheduler = BatchScheduler(
+            maxConcurrentRequests: 4, defaultMaxTokens: 4096, kvBudget: budget)
+
+        for id in ["u", "v"] {
+            _ = await scheduler.reserveVisionRequest(
+                requestId: id, mediaDecodeBytes: 1024, kvTokens: 500)
+        }
+        #expect(await scheduler.activeRequestCount == 2)
+        #expect(await scheduler.activeVisionTokens == 1000)
+
+        await scheduler.unloadModel()
+        #expect(await scheduler.activeRequestCount == 0,
+            "unloadModel/stopCurrentEngine must clear in-flight vision requests")
+        #expect(await scheduler.activeVisionTokens == 0,
+            "unloadModel must zero the vision token accounting, not leak it")
+
+        // The kvBudget reservation must be freed too: a fresh reserve of the same
+        // id succeeds (reserveBytes rejects a still-held duplicate id).
+        let reReserved = await scheduler.reserveVisionRequest(
+            requestId: "u", mediaDecodeBytes: 1024, kvTokens: 500)
+        #expect(reReserved,
+            "unloadModel must release the kvBudget byte reservation, not just the local map")
+    }
 }

--- a/provider-swift/Tests/ProviderCoreTests/BatchSchedulerVisionCapacityTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/BatchSchedulerVisionCapacityTests.swift
@@ -113,6 +113,48 @@ struct BatchSchedulerVisionCapacityTests {
             "the reported active count must be text bridges + in-flight vision, not either alone")
     }
 
+    @Test("in-flight vision tokens are tracked for the coordinator token budget")
+    func visionTokensTrackedForTokenBudget() async {
+        let budget = GlobalKVCacheBudget(capFraction: 1.0, activationReserveBytes: 0) {
+            GlobalKVCacheBudget.MemorySnapshot(total: 8 * gib, active: 0, cache: 0, systemAvailable: .max)
+        }
+        let scheduler = BatchScheduler(
+            maxConcurrentRequests: 4, defaultMaxTokens: 4096, kvBudget: budget)
+
+        #expect(await scheduler.activeVisionTokens == 0)
+
+        // kvTokens is the full prompt+vision+output span the coordinator should
+        // see charged against the token budget (Finding 2).
+        _ = await scheduler.reserveVisionRequest(
+            requestId: "vlm-1", mediaDecodeBytes: 1024, kvTokens: 1200)
+        _ = await scheduler.reserveVisionRequest(
+            requestId: "vlm-2", mediaDecodeBytes: 1024, kvTokens: 800)
+        #expect(await scheduler.activeVisionTokens == 2000,
+            "the token budget must reflect the summed KV span of in-flight media")
+
+        await scheduler.releaseVisionRequest(requestId: "vlm-1")
+        #expect(await scheduler.activeVisionTokens == 800,
+            "releasing one request must subtract exactly its token span")
+
+        await scheduler.releaseVisionRequest(requestId: "vlm-2")
+        #expect(await scheduler.activeVisionTokens == 0)
+    }
+
+    @Test("a rejected vision reservation contributes no tokens")
+    func rejectedReservationContributesNoTokens() async {
+        let budget = GlobalKVCacheBudget(capFraction: 1.0, activationReserveBytes: 0) {
+            GlobalKVCacheBudget.MemorySnapshot(total: 2 * gib, active: 0, cache: 0, systemAvailable: 0)
+        }
+        let scheduler = BatchScheduler(
+            maxConcurrentRequests: 4, defaultMaxTokens: 4096, kvBudget: budget)
+
+        let ok = await scheduler.reserveVisionRequest(
+            requestId: "rejected", mediaDecodeBytes: 4 * gib, kvTokens: 5000)
+        #expect(!ok)
+        #expect(await scheduler.activeVisionTokens == 0,
+            "a rejected media request never runs, so it must charge zero tokens")
+    }
+
     @Test("cancelAll clears in-flight vision reservations")
     func cancelAllClearsVisionRequests() async {
         let budget = GlobalKVCacheBudget(capFraction: 1.0, activationReserveBytes: 0) {

--- a/provider-swift/Tests/ProviderCoreTests/BatchSchedulerVisionCapacityTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/BatchSchedulerVisionCapacityTests.swift
@@ -1,0 +1,134 @@
+import Foundation
+import Testing
+@testable import ProviderCore
+
+// Regression for the VLM load under-report behind the gemma-4 over-admission
+// incident: the vision/media path serves through the container's non-batched
+// prepare/generate route and reserves memory via `reserveVisionRequest` instead
+// of inserting an `activeBridges` entry. `capacity().activeRequests` used to be
+// `activeBridges.count` alone, so a provider busy with N concurrent media
+// requests reported itself idle to the coordinator, which routes on that count —
+// inviting over-admission. These pin that in-flight vision requests now count
+// toward the reported active concurrency, and that the lifecycle (reserve →
+// release, failed reserve, cancelAll) keeps the count exact.
+
+private let gib: UInt64 = 1024 * 1024 * 1024
+
+@Suite("BatchScheduler vision capacity accounting")
+struct BatchSchedulerVisionCapacityTests {
+
+    @Test("in-flight vision request counts toward capacity().activeRequests")
+    func visionReservationBumpsActiveRequests() async {
+        let budget = GlobalKVCacheBudget(capFraction: 1.0, activationReserveBytes: 0) {
+            GlobalKVCacheBudget.MemorySnapshot(total: 8 * gib, active: 0, cache: 0, systemAvailable: .max)
+        }
+        let scheduler = BatchScheduler(
+            maxConcurrentRequests: 4, defaultMaxTokens: 4096, kvBudget: budget)
+
+        #expect(await scheduler.activeRequestCount == 0)
+
+        let ok = await scheduler.reserveVisionRequest(
+            requestId: "vlm-1", mediaDecodeBytes: 1024, kvTokens: 8)
+        #expect(ok, "reservation must fit against an 8 GiB budget")
+        #expect(await scheduler.activeRequestCount == 1,
+            "an in-flight media request must be visible to the coordinator")
+
+        await scheduler.releaseVisionRequest(requestId: "vlm-1")
+        #expect(await scheduler.activeRequestCount == 0,
+            "release must restore the idle count")
+    }
+
+    @Test("concurrent vision requests sum; release is idempotent")
+    func concurrentVisionRequestsSumAndReleaseIsIdempotent() async {
+        let budget = GlobalKVCacheBudget(capFraction: 1.0, activationReserveBytes: 0) {
+            GlobalKVCacheBudget.MemorySnapshot(total: 8 * gib, active: 0, cache: 0, systemAvailable: .max)
+        }
+        let scheduler = BatchScheduler(
+            maxConcurrentRequests: 4, defaultMaxTokens: 4096, kvBudget: budget)
+
+        for id in ["a", "b", "c"] {
+            _ = await scheduler.reserveVisionRequest(
+                requestId: id, mediaDecodeBytes: 1024, kvTokens: 8)
+        }
+        #expect(await scheduler.activeRequestCount == 3)
+
+        // The VLM stream releases on finish, on throw, AND on onTermination, so
+        // the same id can be released more than once. The count must not go
+        // negative or double-decrement.
+        await scheduler.releaseVisionRequest(requestId: "a")
+        await scheduler.releaseVisionRequest(requestId: "a")
+        #expect(await scheduler.activeRequestCount == 2,
+            "a double release of one id must drop the count by exactly one")
+    }
+
+    @Test("a rejected vision reservation does not inflate the active count")
+    func rejectedReservationDoesNotCount() async {
+        // capFraction 1.0 of a 2 GiB total collapses to the hardCap OS floor (0),
+        // so any positive-byte reservation is rejected.
+        let budget = GlobalKVCacheBudget(capFraction: 1.0, activationReserveBytes: 0) {
+            GlobalKVCacheBudget.MemorySnapshot(total: 2 * gib, active: 0, cache: 0, systemAvailable: 0)
+        }
+        let scheduler = BatchScheduler(
+            maxConcurrentRequests: 4, defaultMaxTokens: 4096, kvBudget: budget)
+
+        let ok = await scheduler.reserveVisionRequest(
+            requestId: "rejected", mediaDecodeBytes: 4 * gib, kvTokens: 1_000_000)
+        #expect(!ok, "an over-budget media reservation must be rejected")
+        #expect(await scheduler.activeRequestCount == 0,
+            "a rejected reserve never starts generation, so it must not be counted")
+    }
+
+    @Test("budgeting disabled (nil budget) still tracks in-flight vision load")
+    func nilBudgetStillTracksLoad() async {
+        // Legacy "always proceed" path: no kvBudget. The request still runs and
+        // occupies the model, so it must still be reported as active.
+        let scheduler = BatchScheduler(maxConcurrentRequests: 4, defaultMaxTokens: 4096)
+
+        let ok = await scheduler.reserveVisionRequest(
+            requestId: "vlm-nobudget", mediaDecodeBytes: 1024, kvTokens: 8)
+        #expect(ok, "nil budget always proceeds")
+        #expect(await scheduler.activeRequestCount == 1,
+            "even with budgeting disabled, in-flight media must be reported as load")
+
+        await scheduler.releaseVisionRequest(requestId: "vlm-nobudget")
+        #expect(await scheduler.activeRequestCount == 0)
+    }
+
+    @Test("activeRequestCount sums batched (text) bridges and vision requests")
+    func textBridgesAndVisionRequestsSumTogether() async {
+        let budget = GlobalKVCacheBudget(capFraction: 1.0, activationReserveBytes: 0) {
+            GlobalKVCacheBudget.MemorySnapshot(total: 8 * gib, active: 0, cache: 0, systemAvailable: .max)
+        }
+        let scheduler = BatchScheduler(
+            maxConcurrentRequests: 4, defaultMaxTokens: 4096, kvBudget: budget)
+
+        // Two text (batched) requests via the activeBridges path...
+        await scheduler._testSeedBridge(id: "text-1", promptTokens: 100, maxTokens: 50)
+        await scheduler._testSeedBridge(id: "text-2", promptTokens: 100, maxTokens: 50)
+        // ...and one vision request via the non-batched reservation path.
+        _ = await scheduler.reserveVisionRequest(
+            requestId: "vlm-1", mediaDecodeBytes: 1024, kvTokens: 8)
+
+        #expect(await scheduler.activeRequestCount == 3,
+            "the reported active count must be text bridges + in-flight vision, not either alone")
+    }
+
+    @Test("cancelAll clears in-flight vision reservations")
+    func cancelAllClearsVisionRequests() async {
+        let budget = GlobalKVCacheBudget(capFraction: 1.0, activationReserveBytes: 0) {
+            GlobalKVCacheBudget.MemorySnapshot(total: 8 * gib, active: 0, cache: 0, systemAvailable: .max)
+        }
+        let scheduler = BatchScheduler(
+            maxConcurrentRequests: 4, defaultMaxTokens: 4096, kvBudget: budget)
+
+        for id in ["x", "y"] {
+            _ = await scheduler.reserveVisionRequest(
+                requestId: id, mediaDecodeBytes: 1024, kvTokens: 8)
+        }
+        #expect(await scheduler.activeRequestCount == 2)
+
+        await scheduler.cancelAll()
+        #expect(await scheduler.activeRequestCount == 0,
+            "a drain/cancelAll must release vision reservations like it does bridges")
+    }
+}


### PR DESCRIPTION
## What this fixes

Reworked from the original decode-floor-only approach after diagnosing the gemma-4 over-admission incident against admin route + rejection telemetry. The diagnosis was independently verified (adversarial review of the telemetry + a second-tool pass), which corrected the original framing and surfaced a provider-side accounting bug. Two distinct, verified defects:

### 1. The decode-floor shed threshold was mis-calibrated

The shed floor was coupled to the soft quality floor (`MIN_DECODE_TPS = 15`). But on the 4-bit gemma fleet, a **healthy, uncontended** request (backend_running=0) projects ~15 tok/s at p50 — so a hard shed at 15 would 429 roughly half of serveable traffic, trading a latency problem for an availability one (the same blunt-rejection failure mode as the emergency `model_shed` mitigation).

This decouples the shed threshold from the soft quality bar and gives it its own `EIGENINFERENCE_DECODE_FLOOR_SHED_TPS` (default **10**). The soft floor (15) still only *ranks* providers — never rejects — so a high bar there stays harmless. A floor of 10 sits in the gap between the ~8-9 tok/s normal-load projection and the genuinely-degraded overpacked projection, so it sheds only when the entire eligible fleet is too slow to be useful, not when the fast half briefly drops out.

The shed remains **opt-in** (`EIGENINFERENCE_DECODE_FLOOR_HARD_SHED=true`); default behavior is unchanged (advisory).

### 2. The provider under-reported VLM/media load

Vision/media requests serve through the container's non-batched prepare/generate path and reserve memory via `reserveVisionRequest`, but they never insert an `activeBridges` entry. `capacity().activeRequests` was `activeBridges.count` alone — so a provider busy with N concurrent media requests reported itself **idle** to the coordinator, which routes on that count. That invites over-admission of concurrent media work and (separately) made a VLM-only model eligible for idle eviction mid-stream.

This tracks in-flight vision requests in a dedicated set (inserted on a successful reserve, removed on release, cleared on drain) and reports `activeBridges.count + activeVisionRequests.count` as the active concurrency.

## Why not the levers considered and dropped

- **Per-provider concurrency cap (lower the flat 24):** gemma-4 uses the batched VLM engine; concurrency is the throughput mechanism, not the bug. Capping to ~1 would throw away batched throughput. Telemetry showed real per-provider load never exceeded ~3, so the flat-24 backstop never bound.
- **An absolute floor of 15 as the shed threshold:** would shed the whole fleet (uncontended p50 ~15). Hence the decoupled, lower default.

## Tests

- `coordinator/registry/decode_floor_shed_test.go`: decoupling regression — a fleet projecting in the (10, 15) gap is admitted at shed floor 10 but would be shed at a coupled floor of 15 (proving the decoupling is load-bearing). Existing shed/no-shed/fresh-warm/zero-floor cases retained.
- `provider-swift/Tests/ProviderCoreTests/BatchSchedulerVisionCapacityTests.swift`: VLM accounting — reserve bumps the count; release, double-release, rejected-reserve, nil-budget, mixed text+vision sum, and cancelAll all keep the count exact.

`go test ./registry/ ./api/ ./cmd/...` and the Swift vision suite pass.
