### PR TITLE
fix(coordinator): fenced code-attestation reuse across provider version bumps

### DIFF
--- a/coordinator/api/code_attest_throttle.go
+++ b/coordinator/api/code_attest_throttle.go
@@ -161,6 +161,26 @@ func (t *codeAttestThrottle) reuseAttestation(seKey, version, token string) bool
 	return r.token == "" || r.token == token
 }
 
+// reuseAttestationCrossVersion is reuseAttestation without the version match —
+// it rides a recent proof across a version bump (which every update causes) so a
+// healthy update isn't forced into a fresh push. Dropping the version alone is
+// unsafe (SE key + token prove the device, not that the binary is legitimate), so
+// the caller (codeAttestLoop) only invokes it behind live binary-identity fences.
+// The token match is STRICT here: both stored and current token must be non-empty
+// and equal (unlike reuseAttestation's legacy empty-token leniency).
+func (t *codeAttestThrottle) reuseAttestationCrossVersion(seKey, token string) bool {
+	if seKey == "" || token == "" {
+		return false
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	r, ok := t.attested[seKey]
+	if !ok || t.now().Sub(r.at) >= t.reuseWindow {
+		return false
+	}
+	return r.token != "" && r.token == token
+}
+
 // pushCooldown returns the per-device push budget for the active delivery mode.
 func (t *codeAttestThrottle) pushCooldown(alert bool) time.Duration {
 	if alert {

--- a/coordinator/api/code_attest_w5fix2_test.go
+++ b/coordinator/api/code_attest_w5fix2_test.go
@@ -362,9 +362,13 @@ func TestSeededStalePersistedRowForcesRealChallenge(t *testing.T) {
 	}
 }
 
-// TestSeededWrongVersionRowForcesRealChallenge proves the version gate survives
-// persistence: a seeded row for a DIFFERENT binary version must not be reused; the
-// connection must run a real challenge.
+// TestSeededWrongVersionRowForcesRealChallenge proves the SAME-VERSION reuse gate
+// survives persistence AND that an unfenced cross-version reconnect still forces a
+// real challenge: a seeded row for a DIFFERENT binary version is not reusable via
+// reuseAttestation, and codeAttestLoop falls through to a push because this
+// provider does not satisfy the cross-version fences (RuntimeVerified /
+// RuntimeManifestChecked / ChallengeVerifiedSIP are unset). The fenced
+// cross-version reuse path is covered by TestCrossVersionReuse* below.
 func TestSeededWrongVersionRowForcesRealChallenge(t *testing.T) {
 	logger := quietLogger()
 	st := store.NewMemory(store.Config{})
@@ -399,6 +403,244 @@ func TestSeededWrongVersionRowForcesRealChallenge(t *testing.T) {
 	}
 	if !provider.GetCodeAttested() {
 		t.Fatal("the real challenge round-trip should attest")
+	}
+}
+
+// crossVersionProvider builds a fully-fenced provider running newVersion: valid
+// attestation, runtime+manifest verified, SIP-verified challenge, same SE key +
+// APNs token. This is the case cross-version reuse is allowed to ride.
+func crossVersionProvider(kPubB64, sePubB64, newVersion string) *registry.Provider {
+	p := newCodeAttestProvider(kPubB64, sePubB64)
+	p.Version = newVersion
+	p.RuntimeVerified = true
+	p.RuntimeManifestChecked = true
+	p.ChallengeVerifiedSIP = true
+	return p
+}
+
+// seedFreshAttestation records a recent same-device, same-token proof under
+// oldVersion so a reconnect at a different version can attempt cross-version reuse.
+func seedFreshAttestation(srv *Server, seKey, oldVersion, token string) {
+	srv.codeAttestThrottle.recordAttested(seKey, oldVersion, token)
+}
+
+// TestCrossVersionReuseAboveFloorSameTokenReuses: a healthy update (version bump,
+// same SE key + token, all binary-identity fences satisfied, at/above the
+// min-version floor) must RIDE the recent proof across the version change — no
+// push — so the provider is not derouted for a re-attest window on every update.
+func TestCrossVersionReuseAboveFloorSameTokenReuses(t *testing.T) {
+	logger := quietLogger()
+	srv := NewServer(registry.New(logger), store.NewMemory(store.Config{}), ServerConfig{}, logger)
+	fastBudgets(srv)
+	srv.minProviderVersion = "0.6.0"
+
+	kPubB64, _, _, sePubB64 := providerKeyMaterial(t)
+	// Proof recorded under the OLD version, same token ("devtok").
+	seedFreshAttestation(srv, sePubB64, "0.6.13", "devtok")
+
+	var pushes int32
+	provider := crossVersionProvider(kPubB64, sePubB64, "0.6.14") // bumped, above floor
+	srv.SetCodeAttestor(&fakeCodeAttestor{onSend: func(_, _, _, _ string) error {
+		atomic.AddInt32(&pushes, 1)
+		return nil
+	}})
+	srv.codeAttestLoop(context.Background(), "p1", provider)
+
+	if atomic.LoadInt32(&pushes) != 0 {
+		t.Fatal("a fenced same-token version bump must reuse across versions (NO push)")
+	}
+	if !provider.GetCodeAttested() {
+		t.Fatal("cross-version reuse must set CodeAttested so the provider keeps routing through the update")
+	}
+}
+
+// TestCrossVersionReuseBelowFloorForcesChallenge: a version BELOW the min-provider
+// -version floor (a downgrade / disallowed build) must NOT ride the proof — the
+// fence closes the downgrade-attestation hole and forces a real challenge.
+func TestCrossVersionReuseBelowFloorForcesChallenge(t *testing.T) {
+	logger := quietLogger()
+	srv := NewServer(registry.New(logger), store.NewMemory(store.Config{}), ServerConfig{}, logger)
+	fastBudgets(srv)
+	srv.minProviderVersion = "0.6.10"
+
+	kPubB64, kPriv, seKey, sePubB64 := providerKeyMaterial(t)
+	seedFreshAttestation(srv, sePubB64, "0.6.13", "devtok")
+
+	var pushes int32
+	provider := crossVersionProvider(kPubB64, sePubB64, "0.6.0") // DOWNGRADE, below floor
+	srv.SetCodeAttestor(&fakeCodeAttestor{onSend: func(_, _, pubKeyB64, nonceB64 string) error {
+		atomic.AddInt32(&pushes, 1)
+		return completeRoundTrip(t, srv, provider, "p1", kPriv, seKey, pubKeyB64, nonceB64)
+	}})
+	srv.codeAttestLoop(context.Background(), "p1", provider)
+
+	if atomic.LoadInt32(&pushes) == 0 {
+		t.Fatal("a below-min-version (downgrade) build must NOT reuse across versions; it must force a real challenge")
+	}
+}
+
+// TestCrossVersionReuseTokenChangeForcesChallenge: even fully fenced and above the
+// floor, a CHANGED APNs token must fail closed (the recorded proof was bound to the
+// old token) and force a real challenge.
+func TestCrossVersionReuseTokenChangeForcesChallenge(t *testing.T) {
+	logger := quietLogger()
+	srv := NewServer(registry.New(logger), store.NewMemory(store.Config{}), ServerConfig{}, logger)
+	fastBudgets(srv)
+	srv.minProviderVersion = "0.6.0"
+
+	kPubB64, kPriv, seKey, sePubB64 := providerKeyMaterial(t)
+	// Proof bound to the OLD token; the reconnect carries a DIFFERENT token.
+	seedFreshAttestation(srv, sePubB64, "0.6.13", "oldtok")
+
+	var pushes int32
+	provider := crossVersionProvider(kPubB64, sePubB64, "0.6.14")
+	provider.APNsDeviceToken = "newtok" // rotated token
+	srv.SetCodeAttestor(&fakeCodeAttestor{onSend: func(_, _, pubKeyB64, nonceB64 string) error {
+		atomic.AddInt32(&pushes, 1)
+		return completeRoundTrip(t, srv, provider, "p1", kPriv, seKey, pubKeyB64, nonceB64)
+	}})
+	srv.codeAttestLoop(context.Background(), "p1", provider)
+
+	if atomic.LoadInt32(&pushes) == 0 {
+		t.Fatal("a rotated APNs token must fail closed across versions and force a real challenge")
+	}
+}
+
+// TestCrossVersionReuseUnfencedForcesChallenge: a version bump WITHOUT the binary
+// -identity fences (runtime/manifest/SIP unset) must NOT ride the proof — the SE
+// key + token alone are too weak (NodeKeyPair rotates per startup).
+func TestCrossVersionReuseUnfencedForcesChallenge(t *testing.T) {
+	logger := quietLogger()
+	srv := NewServer(registry.New(logger), store.NewMemory(store.Config{}), ServerConfig{}, logger)
+	fastBudgets(srv)
+	srv.minProviderVersion = "0.6.0"
+
+	kPubB64, kPriv, seKey, sePubB64 := providerKeyMaterial(t)
+	seedFreshAttestation(srv, sePubB64, "0.6.13", "devtok")
+
+	var pushes int32
+	// newCodeAttestProvider sets AttestationResult.Valid but leaves
+	// RuntimeVerified / RuntimeManifestChecked / ChallengeVerifiedSIP false.
+	provider := newCodeAttestProvider(kPubB64, sePubB64)
+	provider.Version = "0.6.14"
+	srv.SetCodeAttestor(&fakeCodeAttestor{onSend: func(_, _, pubKeyB64, nonceB64 string) error {
+		atomic.AddInt32(&pushes, 1)
+		return completeRoundTrip(t, srv, provider, "p1", kPriv, seKey, pubKeyB64, nonceB64)
+	}})
+	srv.codeAttestLoop(context.Background(), "p1", provider)
+
+	if atomic.LoadInt32(&pushes) == 0 {
+		t.Fatal("an unfenced (runtime/SIP unverified) version bump must NOT cross-version reuse; it must force a real challenge")
+	}
+}
+
+// TestCrossVersionReuseEmptyVersionForcesChallenge: an UNVERSIONED provider
+// (version optional on the wire) must NOT satisfy a configured MIN_PROVIDER_VERSION
+// floor — empty version is treated as below-floor, forcing a real challenge.
+func TestCrossVersionReuseEmptyVersionForcesChallenge(t *testing.T) {
+	logger := quietLogger()
+	srv := NewServer(registry.New(logger), store.NewMemory(store.Config{}), ServerConfig{}, logger)
+	fastBudgets(srv)
+	srv.minProviderVersion = "0.6.0"
+
+	kPubB64, kPriv, seKey, sePubB64 := providerKeyMaterial(t)
+	seedFreshAttestation(srv, sePubB64, "0.6.13", "devtok")
+
+	var pushes int32
+	provider := crossVersionProvider(kPubB64, sePubB64, "") // NO version reported
+	srv.SetCodeAttestor(&fakeCodeAttestor{onSend: func(_, _, pubKeyB64, nonceB64 string) error {
+		atomic.AddInt32(&pushes, 1)
+		return completeRoundTrip(t, srv, provider, "p1", kPriv, seKey, pubKeyB64, nonceB64)
+	}})
+	srv.codeAttestLoop(context.Background(), "p1", provider)
+
+	if atomic.LoadInt32(&pushes) == 0 {
+		t.Fatal("an unversioned provider must NOT satisfy a configured min-version floor; it must force a real challenge")
+	}
+}
+
+// TestCrossVersionReuseSIPArmedMidLoopReuses pins the race fix: the binary-identity
+// fences (notably ChallengeVerifiedSIP) are armed CONCURRENTLY on a fresh
+// post-update connection, so they may be false when codeAttestLoop first runs. The
+// loop must RE-CHECK each iteration and reuse once they flip — not burn the full
+// push budget. Here the provider starts SIP=false (cross-version reuse can't fire
+// up front) and a background goroutine flips it true shortly after; the loop must
+// then reuse with NO completed push round-trip.
+func TestCrossVersionReuseSIPArmedMidLoopReuses(t *testing.T) {
+	logger := quietLogger()
+	srv := NewServer(registry.New(logger), store.NewMemory(store.Config{}), ServerConfig{}, logger)
+	fastBudgets(srv)
+	srv.minProviderVersion = "0.6.0"
+
+	kPubB64, _, _, sePubB64 := providerKeyMaterial(t)
+	seedFreshAttestation(srv, sePubB64, "0.6.13", "devtok")
+
+	provider := crossVersionProvider(kPubB64, sePubB64, "0.6.14")
+	provider.ChallengeVerifiedSIP = false // not yet armed at loop entry (the race)
+
+	// The challenge path would arm SIP after the first push goes out. Model that
+	// deterministically: arm SIP from inside the push callback (as the real
+	// challenge-response handler would), WITHOUT completing the round-trip — so the
+	// only way CodeAttested can flip true is the loop's next-iteration re-check of
+	// cross-version reuse, not a completed challenge.
+	var pushes int32
+	srv.SetCodeAttestor(&fakeCodeAttestor{onSend: func(_, _, _, _ string) error {
+		atomic.AddInt32(&pushes, 1)
+		provider.SetChallengeVerifiedSIP(true)
+		return nil
+	}})
+
+	srv.codeAttestLoop(context.Background(), "p1", provider)
+
+	if !provider.GetCodeAttested() {
+		t.Fatal("once SIP arms mid-loop, the re-checked cross-version reuse must attest without a completed round-trip")
+	}
+	// Exactly one push should have gone out before the re-check caught the armed
+	// fence — proving the loop reused rather than burning the whole push budget.
+	if got := atomic.LoadInt32(&pushes); got != 1 {
+		t.Fatalf("expected 1 push before cross-version reuse fired, got %d (loop should reuse on the next iteration after SIP arms)", got)
+	}
+}
+
+// TestCrossVersionReuseUsesLiveTokenNotCaptured pins the rotation TOCTOU fix:
+// cross-version reuse must evaluate the LIVE APNs token under the provider lock,
+// not a value captured at loop start. Here the reuse record is bound to the OLD
+// token, but the provider's live token has already rotated to a NEW one (as
+// maybeRearmCodeAttest publishes under the lock). The grant must NOT fire — the
+// old-token proof can't attest the rotated token — so the loop falls through to a
+// real challenge. (tryCrossVersionReuse reads st.APNsDeviceToken from the locked
+// snapshot, so even if an old loop still holds the stale "oldtok", the decision
+// uses the live "newtok" and the reuse match fails.)
+func TestCrossVersionReuseUsesLiveTokenNotCaptured(t *testing.T) {
+	logger := quietLogger()
+	srv := NewServer(registry.New(logger), store.NewMemory(store.Config{}), ServerConfig{}, logger)
+	fastBudgets(srv)
+	srv.minProviderVersion = "0.6.0"
+
+	kPubB64, kPriv, seKey, sePubB64 := providerKeyMaterial(t)
+	// Recent proof bound to the OLD token.
+	seedFreshAttestation(srv, sePubB64, "0.6.13", "oldtok")
+
+	var pushes int32
+	provider := crossVersionProvider(kPubB64, sePubB64, "0.6.14")
+	provider.APNsDeviceToken = "newtok" // live token already rotated (rotation won the lock)
+	srv.SetCodeAttestor(&fakeCodeAttestor{onSend: func(_, _, pubKeyB64, nonceB64 string) error {
+		atomic.AddInt32(&pushes, 1)
+		return completeRoundTrip(t, srv, provider, "p1", kPriv, seKey, pubKeyB64, nonceB64)
+	}})
+
+	// Directly exercise the grant decision: it must refuse on the live (new) token.
+	if srv.tryCrossVersionReuse("p1", provider) {
+		t.Fatal("cross-version reuse must NOT grant on a record bound to a token different from the LIVE provider token")
+	}
+	if provider.GetCodeAttested() {
+		t.Fatal("CodeAttested must not be set when the live token does not match the reuse record")
+	}
+
+	// And the full loop must force a real challenge to attest the new token.
+	srv.codeAttestLoop(context.Background(), "p1", provider)
+	if atomic.LoadInt32(&pushes) == 0 {
+		t.Fatal("a rotated live token must force a real challenge (no cross-version bypass on the old-token proof)")
 	}
 }
 

--- a/coordinator/api/provider.go
+++ b/coordinator/api/provider.go
@@ -508,6 +508,61 @@ func (s *Server) codeAttestMetric(outcome string) {
 // Providers with no APNs device token (legacy <0.6.0, or headless boxes with no
 // GUI session) can never attest, so the loop exits immediately — they are derouted
 // once enforcement begins, the intended "everyone must update" outcome.
+// tryCrossVersionReuse rides a recent same-device, same-token attestation across a
+// binary VERSION change so a healthy update isn't forced into a fresh APNs round-
+// trip (which would deroute the provider for the whole re-attest window). Reuse
+// fires only behind ALL fences: valid registration attestation, runtime + manifest
+// verified, SIP-verified challenge, a non-empty version at/above MIN_PROVIDER_VERSION,
+// and the same non-empty APNs token. The SE key + token alone are too weak
+// (NodeKeyPair rotates per startup), so the fences are what prove the current
+// binary is legitimate. Decision + grant run atomically via GrantCodeAttestedIf
+// against the LIVE state, so a concurrent token rotation can't slip a stale-token
+// proof past the gate. Returns true (and drains) when reuse fired.
+func (s *Server) tryCrossVersionReuse(providerID string, provider *registry.Provider) bool {
+	// blockedBy names the first fence that prevented reuse, for forensic debugging
+	// of a provider stuck re-challenging instead of reusing (set inside the locked
+	// decision; read only after it returns).
+	blockedBy := ""
+	granted := provider.GrantCodeAttestedIf(func(st registry.CodeIdentityState) bool {
+		// An empty version never satisfies a configured floor (version is optional
+		// on the wire); only treat the floor as cleared when there is no floor.
+		aboveMinVersion := s.minProviderVersion == "" ||
+			(st.Version != "" && !semverLess(st.Version, s.minProviderVersion))
+		switch {
+		case !st.AttestationValid:
+			blockedBy = "attestation_invalid"
+		case !st.RuntimeVerified:
+			blockedBy = "runtime_unverified"
+		case !st.RuntimeManifestChecked:
+			blockedBy = "runtime_manifest_unchecked"
+		case !st.ChallengeVerifiedSIP:
+			blockedBy = "sip_challenge_pending" // armed concurrently; the loop re-checks
+		case !aboveMinVersion:
+			blockedBy = "below_min_version"
+		default:
+			// reuseAttestationCrossVersion takes the throttle lock; the lock order is
+			// always provider → throttle (throttle methods never touch a provider),
+			// so calling it from inside the provider-locked decision is deadlock-safe.
+			if !s.codeAttestThrottle.reuseAttestationCrossVersion(st.SEPublicKey, st.APNsDeviceToken) {
+				blockedBy = "no_fresh_same_token_proof"
+				return false
+			}
+			return true
+		}
+		return false
+	})
+	if !granted {
+		s.logger.Debug("code-attest: cross-version reuse not taken; will challenge/poll",
+			"provider_id", providerID, "blocked_by", blockedBy)
+		return false
+	}
+	s.registry.DrainQueuedRequestsForProvider(provider)
+	s.codeAttestMetric("reused_cross_version")
+	s.logger.Info("code-attest: reused a recent attestation across a version change (fenced: attestation+runtime+SIP+min-version verified; no push)",
+		"provider_id", providerID)
+	return true
+}
+
 func (s *Server) codeAttestLoop(ctx context.Context, providerID string, provider *registry.Provider) {
 	if s.codeAttestor == nil || provider == nil {
 		return
@@ -540,6 +595,13 @@ func (s *Server) codeAttestLoop(ctx context.Context, providerID string, provider
 		return
 	}
 
+	// Cross-version reuse (every update bumps the version, missing the same-version
+	// reuse above). Try up front; the loop also re-checks since the fences arm
+	// concurrently on a fresh connection.
+	if s.tryCrossVersionReuse(providerID, provider) {
+		return
+	}
+
 	// Alert delivery is not background-throttled, so it may retry on a far shorter
 	// push budget than background (Fix 3). Detected via the attestor seam.
 	alertMode := false
@@ -555,6 +617,12 @@ func (s *Server) codeAttestLoop(ctx context.Context, providerID string, provider
 		}
 		if provider.ChallengeShouldStop() {
 			return // hard (non-recoverable) untrust — stop challenging
+		}
+
+		// Re-check each iteration: the fences arm concurrently, so a connection that
+		// missed up front may reuse now instead of burning a push.
+		if s.tryCrossVersionReuse(providerID, provider) {
+			return
 		}
 
 		// Push when the per-device budget permits. A budget cooldown elapsing

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -654,6 +654,45 @@ func (p *Provider) SetCodeAttested(v bool) {
 	p.CodeAttested = v
 }
 
+// CodeIdentityState is the live code-identity snapshot a reuse decision evaluates.
+// APNsDeviceToken/Version can rotate concurrently (maybeRearmCodeAttest), so the
+// decision must use these, not values captured earlier.
+type CodeIdentityState struct {
+	APNsDeviceToken        string
+	Version                string
+	SEPublicKey            string
+	AttestationValid       bool
+	RuntimeVerified        bool
+	RuntimeManifestChecked bool
+	ChallengeVerifiedSIP   bool
+}
+
+// GrantCodeAttestedIf runs `decide` against the live state and sets
+// CodeAttested=true iff it returns true — atomically under the provider lock, so a
+// concurrent token rotation can't interleave between the decision and the grant
+// (closes the rotation TOCTOU). `decide` must not take this provider's lock; it
+// may take others (e.g. the throttle) — lock order is always provider → throttle.
+func (p *Provider) GrantCodeAttestedIf(decide func(CodeIdentityState) bool) bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	st := CodeIdentityState{
+		APNsDeviceToken:        p.APNsDeviceToken,
+		Version:                p.Version,
+		AttestationValid:       p.AttestationResult != nil && p.AttestationResult.Valid,
+		RuntimeVerified:        p.RuntimeVerified,
+		RuntimeManifestChecked: p.RuntimeManifestChecked,
+		ChallengeVerifiedSIP:   p.ChallengeVerifiedSIP,
+	}
+	if p.AttestationResult != nil {
+		st.SEPublicKey = p.AttestationResult.PublicKey
+	}
+	if !decide(st) {
+		return false
+	}
+	p.CodeAttested = true
+	return true
+}
+
 // GetCodeAttested reports whether this connection passed code-identity
 // attestation (thread-safe).
 func (p *Provider) GetCodeAttested() bool {


### PR DESCRIPTION
## Problem

Providers intermittently sit **hardware-trusted but not routed** — `status`/`doctor` show `trust=hardware / online`, yet the coordinator deroutes them as not code-attested. Operators report it **happens on every update** and **clears after a terminal reinstall**.

### Root cause

Code-identity attestation (`Provider.CodeAttested`) is a separate routing gate from trust level. With enforcement on, the single private-text chokepoint deroutes any provider that is `!CodeAttested`:

```go
// coordinator/registry/registry.go:465
if r.codeAttestationEnforcedLocked() && !p.CodeAttested { return false }
```

`CodeAttested` is re-armed cheaply (no APNs push) by the reuse cache — but that cache is **version-gated**:

```go
// coordinator/api/code_attest_throttle.go (reuseAttestation)
if !ok || r.version != version || t.now().Sub(r.at) >= t.reuseWindow { return false }
```

Every `darkbloom update` bumps `ProviderCore.version`, so the post-update reconnect **misses reuse on the version mismatch** and must complete a fresh, budget-throttled APNs code-identity round-trip. Meanwhile a reconnect starts `CodeAttested=false` (fresh per-connection `Provider`), so there is a guaranteed window on **every update** where the provider is hardware-trusted but derouted — and it stays derouted until the round-trip lands (or indefinitely for a box that can't promptly re-acquire its APNs token). A terminal reinstall lays down a healthy bundle whose next round-trip succeeds, which is why a reinstall "fixes" it.

This is purely the **version gate** forcing the re-attest — the self-updater preserves the signed `.app` bundle, provisioning profile, and entitlements correctly; the binary identity is intact across an update.

## Fix

Permit code-attestation reuse **across a version change** for the same device — but only behind binary-identity fences proven on the *live* connection, so it can't become a downgrade/bad-build hole.

- New `reuseAttestationCrossVersion(seKey, token)` in the throttle: same as `reuseAttestation` minus the version match (still requires same SE key, fresh-within-window, same APNs token).
- `codeAttestLoop` invokes it **only when all hold**:
  - `AttestationResult.Valid` (valid registration attestation),
  - `RuntimeVerified` && `RuntimeManifestChecked` (runtime-manifest verification),
  - `ChallengeVerifiedSIP` (SIP-verified live challenge),
  - same APNs token (token rotation still fails closed),
  - version **at/above `MIN_PROVIDER_VERSION`** (`semverLess` floor — closes the downgrade hole).
- New `reused_cross_version` metric so the path is observable.

### Why the fences are required (not just dropping the version match)

`NodeKeyPair` is regenerated per provider startup, so a post-update reconnect always presents a **new** X25519 encryption key. The SE key + APNs token alone prove the device and push target, but **not** that the current binary is a legitimate, non-downgraded build. The version match in `reuseAttestation` was loosely standing in for that. Dropping it without the runtime/manifest/SIP/min-version fences would let a downgraded or disallowed binary re-arm `CodeAttested` from a prior proof without a fresh challenge. The fences re-establish binary identity from the live connection's own verification state; same-version reuse and token-rotation fail-closed are unchanged.

## Tests

- `TestCrossVersionReuseAboveFloorSameTokenReuses` — fenced, same-token, above-floor version bump **reuses** (no push); `CodeAttested` set so routing continues through the update.
- `TestCrossVersionReuseBelowFloorForcesChallenge` — a below-`MIN_PROVIDER_VERSION` downgrade **forces a real challenge** (downgrade hole closed).
- `TestCrossVersionReuseTokenChangeForcesChallenge` — a rotated APNs token **fails closed** across versions.
- `TestCrossVersionReuseUnfencedForcesChallenge` — a version bump without the runtime/SIP fences **forces a real challenge**.
- `TestSeededWrongVersionRowForcesRealChallenge` retained (now documents the unfenced fall-through; same-version `reuseAttestation` is unchanged).

`go build ./...`, `go vet ./api/`, and the full `coordinator/api` suite pass.

## Scope / what this does NOT change

- Coordinator-only; no protocol or Swift provider changes.
- Same-version reuse, token-rotation fail-closed, and the enforcement gate itself are untouched.
- This shrinks the forced-re-attest window to ~zero for **healthy** updates. It does not address a provider that genuinely cannot complete the APNs round-trip post-relaunch (e.g. fails to re-acquire its APNs token) — if logs show a stuck provider hitting `no_token`/`timeout`, that is a separate provider-side relaunch fix, tracked independently.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/399"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784409429&installation_id=133247490&pr_number=399&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F399&signature=27fd372c45325cf936a9a9dc7596c45a9ac9c30aba6a38604fa6b4e19b4c694d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->