### PR TITLE
fix(registry): use observed slot TPS for warm-pool calibration

### DIFF
--- a/coordinator/registry/scheduler.go
+++ b/coordinator/registry/scheduler.go
@@ -1170,6 +1170,32 @@ func resolvedDecodeTPS(p *Provider) float64 {
 	return 1.0
 }
 
+// resolvedModelTPSLocked returns the best per-model decode/prefill TPS samples
+// for a provider. BackendCapacity.Slots is authoritative for Swift providers:
+// when the matching slot reports observed EWMAs, prefer them over static
+// registration benchmarks. Non-positive observed values are treated as missing.
+// Caller must hold p.mu.
+func resolvedModelTPSLocked(p *Provider, model string) (decodeTPS, prefillTPS float64) {
+	decodeTPS = resolvedDecodeTPS(p)
+	prefillTPS = resolvedPrefillTPS(p)
+	if p.BackendCapacity == nil {
+		return decodeTPS, prefillTPS
+	}
+	for _, slot := range p.BackendCapacity.Slots {
+		if slot.Model != model {
+			continue
+		}
+		if slot.ObservedDecodeTPS > 0 {
+			decodeTPS = slot.ObservedDecodeTPS
+		}
+		if slot.ObservedPrefillTPS > 0 {
+			prefillTPS = slot.ObservedPrefillTPS
+		}
+		break
+	}
+	return decodeTPS, prefillTPS
+}
+
 // defaultPrefillToDecodeRatio is the fallback multiplier applied to a provider's
 // decode TPS to estimate its prefill TPS when the provider does not report a
 // measured prefill rate (prefill_tps). Apple-Silicon MLX prefills the prompt in

--- a/coordinator/registry/scheduler_test.go
+++ b/coordinator/registry/scheduler_test.go
@@ -1562,6 +1562,54 @@ func TestResolveEffectiveTPSFallback(t *testing.T) {
 	}
 }
 
+func TestResolvedModelTPSLockedUsesMatchingObservedSlot(t *testing.T) {
+	reg := New(testLogger())
+	model := "observed-model-tps"
+	p := makeSchedulerProvider(t, reg, "observed", model, 23)
+	p.mu.Lock()
+	p.PrefillTPS = 700
+	p.BackendCapacity.Slots = append(p.BackendCapacity.Slots, protocol.BackendSlotCapacity{
+		Model:              "other-model",
+		ObservedDecodeTPS:  999,
+		ObservedPrefillTPS: 9999,
+	})
+	p.BackendCapacity.Slots[0].ObservedDecodeTPS = 73
+	p.BackendCapacity.Slots[0].ObservedPrefillTPS = 0
+	decodeTPS, prefillTPS := resolvedModelTPSLocked(p, model)
+	p.mu.Unlock()
+
+	if decodeTPS != 73 {
+		t.Fatalf("decodeTPS = %v, want matching observed decode 73", decodeTPS)
+	}
+	if prefillTPS != 700 {
+		t.Fatalf("prefillTPS = %v, want static prefill fallback 700", prefillTPS)
+	}
+}
+
+func TestResolvedModelTPSLockedIgnoresOtherModelObservedSlot(t *testing.T) {
+	reg := New(testLogger())
+	model := "static-model-tps"
+	p := makeSchedulerProvider(t, reg, "static", model, 23)
+	p.mu.Lock()
+	p.PrefillTPS = 700
+	p.BackendCapacity.Slots[0].ObservedDecodeTPS = 0
+	p.BackendCapacity.Slots[0].ObservedPrefillTPS = 0
+	p.BackendCapacity.Slots = append(p.BackendCapacity.Slots, protocol.BackendSlotCapacity{
+		Model:              "other-model",
+		ObservedDecodeTPS:  999,
+		ObservedPrefillTPS: 9999,
+	})
+	decodeTPS, prefillTPS := resolvedModelTPSLocked(p, model)
+	p.mu.Unlock()
+
+	if decodeTPS != 23 {
+		t.Fatalf("decodeTPS = %v, want static decode fallback 23", decodeTPS)
+	}
+	if prefillTPS != 700 {
+		t.Fatalf("prefillTPS = %v, want static prefill fallback 700", prefillTPS)
+	}
+}
+
 func TestFreeMemoryAdmitsTokenBudget(t *testing.T) {
 	// With token budget, should use budget-based admission.
 	snap := routingSnapshot{

--- a/coordinator/registry/warm_pool_controller.go
+++ b/coordinator/registry/warm_pool_controller.go
@@ -447,8 +447,9 @@ func (r *Registry) warmPoolFleetSnapshot(now time.Time) map[string]warmPoolModel
 					s.warmSaturated++
 				}
 				out[model] = s
-				decodeSamples[model] = append(decodeSamples[model], resolvedDecodeTPS(p))
-				prefillSamples[model] = append(prefillSamples[model], resolvedPrefillTPS(p))
+				decodeTPS, prefillTPS := resolvedModelTPSLocked(p, model)
+				decodeSamples[model] = append(decodeSamples[model], decodeTPS)
+				prefillSamples[model] = append(prefillSamples[model], prefillTPS)
 				concSamples[model] = append(concSamples[model], float64(p.maxConcurrencyForModelLocked(model)))
 				continue
 			}
@@ -457,8 +458,9 @@ func (r *Registry) warmPoolFleetSnapshot(now time.Time) map[string]warmPoolModel
 				s.model = model
 				s.eligibleCold = append(s.eligibleCold, candidate)
 				out[model] = s
-				decodeSamples[model] = append(decodeSamples[model], resolvedDecodeTPS(p))
-				prefillSamples[model] = append(prefillSamples[model], resolvedPrefillTPS(p))
+				decodeTPS, prefillTPS := resolvedModelTPSLocked(p, model)
+				decodeSamples[model] = append(decodeSamples[model], decodeTPS)
+				prefillSamples[model] = append(prefillSamples[model], prefillTPS)
 				concSamples[model] = append(concSamples[model], float64(p.maxConcurrencyForModelLocked(model)))
 			}
 		}

--- a/coordinator/registry/warm_pool_controller_test.go
+++ b/coordinator/registry/warm_pool_controller_test.go
@@ -218,6 +218,69 @@ func TestWarmPoolNoPressureForLongActiveDecodeAlone(t *testing.T) {
 	}
 }
 
+func TestWarmPoolFleetSnapshotUsesObservedSlotTPS(t *testing.T) {
+	reg := New(testLogger())
+	model := "warm-pool-observed-tps"
+	p := makeSchedulerProvider(t, reg, "warm", model, 23)
+	p.mu.Lock()
+	p.BackendCapacity.Slots[0].ObservedDecodeTPS = 73
+	p.BackendCapacity.Slots[0].ObservedPrefillTPS = 1000
+	p.mu.Unlock()
+
+	snap := reg.warmPoolFleetSnapshot(time.Now())[model]
+
+	if snap.soloDecodeTPS != 73 {
+		t.Fatalf("soloDecodeTPS = %v, want observed slot TPS 73", snap.soloDecodeTPS)
+	}
+	if snap.prefillTPS != 1000 {
+		t.Fatalf("prefillTPS = %v, want observed slot prefill TPS 1000", snap.prefillTPS)
+	}
+}
+
+func TestWarmPoolFleetSnapshotFallsBackToStaticTPS(t *testing.T) {
+	reg := New(testLogger())
+	model := "warm-pool-static-tps"
+	makeSchedulerProvider(t, reg, "warm", model, 23)
+
+	snap := reg.warmPoolFleetSnapshot(time.Now())[model]
+
+	if snap.soloDecodeTPS != 23 {
+		t.Fatalf("soloDecodeTPS = %v, want static TPS 23", snap.soloDecodeTPS)
+	}
+	if snap.prefillTPS != 23*PrefillToDecodeRatio() {
+		t.Fatalf("prefillTPS = %v, want static fallback %v", snap.prefillTPS, 23*PrefillToDecodeRatio())
+	}
+}
+
+func TestWarmPoolDiagnosticsReflectObservedTPS(t *testing.T) {
+	reg := New(testLogger())
+	model := "warm-pool-observed-diagnostics"
+	p := makeSchedulerProvider(t, reg, "warm", model, 23)
+	p.mu.Lock()
+	p.BackendCapacity.Slots[0].ObservedDecodeTPS = 73
+	p.BackendCapacity.Slots[0].ObservedPrefillTPS = 1000
+	p.mu.Unlock()
+
+	cfg := testWarmPoolConfig()
+	cfg.DecodeFloorTPS = 15
+	cfg.AssumedPromptTokens = 512
+	cfg.AssumedCompletionTokens = 256
+	reg.ConfigureWarmPool(cfg)
+	reg.RecordWarmPoolCapacityReject(model)
+
+	snaps := reg.warmPool.tick(time.Now())
+	if len(snaps) != 1 {
+		t.Fatalf("snapshots = %d, want 1", len(snaps))
+	}
+	snap := snaps[0]
+	if snap.QualityConcurrency <= 2 {
+		t.Fatalf("QualityConcurrency = %d, want observed TPS to raise it above stale value 2", snap.QualityConcurrency)
+	}
+	if snap.ServiceTime >= 10*time.Second {
+		t.Fatalf("ServiceTime = %v, want observed TPS to keep it below stale 12.8s", snap.ServiceTime)
+	}
+}
+
 func TestWarmPoolSkipsIneligibleProviders(t *testing.T) {
 	reg := New(testLogger())
 	model := "warm-pool-skip"


### PR DESCRIPTION
## Summary
- Add a model-specific TPS helper that prefers the matching `BackendCapacity` slot observed decode/prefill EWMAs over static registration/fallback TPS.
- Use that helper in warm-pool fleet snapshots so target math, service-time diagnostics, and quality concurrency use measured provider performance.
- Add regression coverage for matching-slot observed TPS, static fallback, and warm-pool diagnostics.

## Before
```mermaid
flowchart TD
  A[Provider heartbeat] --> B[BackendCapacity.Slots includes ObservedDecodeTPS and ObservedPrefillTPS]
  B --> C[Warm-pool fleet snapshot]
  C --> D[Ignore slot observed TPS]
  D --> E[resolvedDecodeTPS provider]
  E --> F[Provider DecodeTPS or sqrt memory bandwidth fallback]
  F --> G[Median soloDecodeTPS and prefillTPS]
  G --> H[estimateServiceTime and qualityConcurrency]
  H --> I[Bad target math: stale service_time_ms and low quality_concurrency]
  I --> J[False TTFT misses, bad warm targets, over-rejection]
```

## After
```mermaid
flowchart TD
  A[Provider heartbeat] --> B[BackendCapacity.Slots includes ObservedDecodeTPS and ObservedPrefillTPS]
  B --> C[Warm-pool fleet snapshot]
  C --> D[Find matching slot for requested model]
  D --> E{Observed TPS present?}
  E -->|Yes| F[Use slot ObservedDecodeTPS and ObservedPrefillTPS]
  E -->|No| G[Fallback to static DecodeTPS or existing prefill fallback]
  F --> H[Median soloDecodeTPS and prefillTPS]
  G --> H
  H --> I[estimateServiceTime and qualityConcurrency]
  I --> J[Warm target uses measured per-model provider performance]
```

## Context
This addresses DAR-328 calibration issue: warm-pool target sizing sampled static or sqrt-bandwidth TPS instead of per-slot `ObservedDecodeTPS`, producing stale `service_time_ms`, bad `quality_concurrency`, and incorrect warm targets.

## Tests
- `go test ./coordinator/registry -run "Test(WarmPoolFleetSnapshotUsesObservedSlotTPS|WarmPoolFleetSnapshotFallsBackToStaticTPS|WarmPoolDiagnosticsReflectObservedTPS|ResolvedModelTPSLockedUsesMatchingObservedSlot|ResolvedModelTPSLockedIgnoresOtherModelObservedSlot|ResolveEffectiveTPSFallback)"`
- `go test ./coordinator/...`
