### PR TITLE
fix(coordinator): detach provider dispatch writes and add min-warm floors

### DIFF
--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -37,7 +37,6 @@ import (
 	"github.com/eigeninference/d-inference/coordinator/saferun"
 	"github.com/eigeninference/d-inference/coordinator/store"
 	"github.com/google/uuid"
-	"nhooyr.io/websocket"
 
 	"github.com/eigeninference/d-inference/coordinator/api/types"
 )
@@ -117,10 +116,17 @@ func (s *Server) sendProviderCancel(provider *registry.Provider, requestID strin
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), cancelWriteTimeout)
 	defer cancel()
-	if err := provider.Conn.Write(ctx, websocket.MessageText, cancelData); err != nil {
+	if err := provider.EnqueueText(ctx, cancelData); err != nil {
 		s.logger.Debug("failed to send cancel (provider may have disconnected)",
 			"request_id", requestID, "error", err)
 	}
+}
+
+func writeProviderInferenceRequest(ctx context.Context, provider *registry.Provider, data []byte) error {
+	if provider == nil || provider.Conn == nil {
+		return errors.New("provider websocket is not connected")
+	}
+	return provider.WriteText(ctx, data)
 }
 
 // cancelDispatch cleans up a speculative dispatch participant that lost the
@@ -658,7 +664,7 @@ func (s *Server) dispatchOneProvider(
 	if pr.Timing != nil {
 		pr.Timing.DispatchedAt = time.Now()
 	}
-	if err := provider.Conn.Write(r.Context(), websocket.MessageText, data); err != nil {
+	if err := writeProviderInferenceRequest(r.Context(), provider, data); err != nil {
 		refundExtra()
 		cleanupPending()
 		excludeProviders[provider.ID] = struct{}{}
@@ -5235,7 +5241,7 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 	pr.SessionPrivKey = &sessionKeys.PrivateKey
 	data, _ := json.Marshal(wireMsg)
 	timing.DispatchedAt = time.Now()
-	if err := provider.Conn.Write(r.Context(), websocket.MessageText, data); err != nil {
+	if err := writeProviderInferenceRequest(r.Context(), provider, data); err != nil {
 		cleanupPending()
 		refundExtra()
 		refundReservation()

--- a/coordinator/api/dispatch.go
+++ b/coordinator/api/dispatch.go
@@ -44,7 +44,6 @@ import (
 	"github.com/eigeninference/d-inference/coordinator/saferun"
 	"github.com/eigeninference/d-inference/coordinator/store"
 	"github.com/google/uuid"
-	"nhooyr.io/websocket"
 )
 
 // dispatchOutcome is the result of a per-attempt dispatch phase (provider
@@ -752,7 +751,7 @@ func (d *dispatchState) dispatchPrimary() dispatchOutcome {
 		// have been increased by reserveAdditionalForProvider. Don't overwrite.
 		data, _ := json.Marshal(wireMsg)
 		d.pr.Timing.DispatchedAt = time.Now()
-		if err := d.provider.Conn.Write(r.Context(), websocket.MessageText, data); err != nil {
+		if err := writeProviderInferenceRequest(r.Context(), d.provider, data); err != nil {
 			d.provider.RemovePending(d.requestID)
 			s.registry.SetProviderIdle(d.provider.ID)
 			s.refundProviderExtra(d.pr)

--- a/coordinator/api/provider.go
+++ b/coordinator/api/provider.go
@@ -276,9 +276,7 @@ func (s *Server) providerReadLoop(ctx context.Context, conn *websocket.Conn, pro
 					}
 					statusData, err := json.Marshal(statusMsg)
 					if err == nil {
-						writeCtx, writeCancel := context.WithTimeout(loopCtx, 5*time.Second)
-						_ = conn.Write(writeCtx, websocket.MessageText, statusData)
-						writeCancel()
+						_ = provider.EnqueueText(loopCtx, statusData)
 					}
 					mismatchDetails := make([]string, 0, len(mismatches))
 					for _, m := range mismatches {
@@ -339,7 +337,7 @@ func (s *Server) providerReadLoop(ctx context.Context, conn *websocket.Conn, pro
 
 			// Start challenge loop after registration
 			saferun.Go(s.logger, "challengeLoop", func() {
-				s.challengeLoop(loopCtx, conn, providerID, provider, tracker)
+				s.challengeLoop(loopCtx, providerID, provider, tracker)
 			})
 
 			// Start the per-connection MDM verification loop. It runs the initial
@@ -1051,7 +1049,7 @@ func providerAttestationMatchesACMEKey(provider *registry.Provider, acmeResult *
 }
 
 // challengeLoop periodically sends attestation challenges to a provider.
-func (s *Server) challengeLoop(ctx context.Context, conn *websocket.Conn, providerID string, provider *registry.Provider, tracker *challengeTracker) {
+func (s *Server) challengeLoop(ctx context.Context, providerID string, provider *registry.Provider, tracker *challengeTracker) {
 	if s.skipChallenge {
 		return
 	}
@@ -1063,7 +1061,7 @@ func (s *Server) challengeLoop(ctx context.Context, conn *websocket.Conn, provid
 
 	// Send initial challenge immediately so the provider is routable
 	// without waiting for the first ticker interval.
-	s.sendChallenge(ctx, conn, providerID, provider, tracker)
+	s.sendChallenge(ctx, providerID, provider, tracker)
 
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
@@ -1079,7 +1077,7 @@ func (s *Server) challengeLoop(ctx context.Context, conn *websocket.Conn, provid
 			if provider.ChallengeShouldStop() {
 				return
 			}
-			s.sendChallenge(ctx, conn, providerID, provider, tracker)
+			s.sendChallenge(ctx, providerID, provider, tracker)
 		}
 	}
 }
@@ -1094,7 +1092,7 @@ func generateNonce() (string, error) {
 }
 
 // sendChallenge sends an attestation challenge to a provider and waits for the response.
-func (s *Server) sendChallenge(ctx context.Context, conn *websocket.Conn, providerID string, provider *registry.Provider, tracker *challengeTracker) {
+func (s *Server) sendChallenge(ctx context.Context, providerID string, provider *registry.Provider, tracker *challengeTracker) {
 	nonce, err := generateNonce()
 	if err != nil {
 		s.logger.Error("failed to generate challenge nonce", "provider_id", providerID, "error", err)
@@ -1125,7 +1123,7 @@ func (s *Server) sendChallenge(ctx context.Context, conn *websocket.Conn, provid
 
 	writeCtx, writeCancel := context.WithTimeout(ctx, 5*time.Second)
 	defer writeCancel()
-	if err := conn.Write(writeCtx, websocket.MessageText, data); err != nil {
+	if err := provider.WriteText(writeCtx, data); err != nil {
 		s.logger.Error("failed to send challenge", "provider_id", providerID, "error", err)
 		tracker.remove(nonce)
 		return
@@ -1144,13 +1142,13 @@ func (s *Server) sendChallenge(ctx context.Context, conn *websocket.Conn, provid
 		tracker.remove(nonce)
 		if resp == nil {
 			// Channel closed without response
-			s.handleTransientChallengeFailure(conn, providerID, "no response")
+			s.handleTransientChallengeFailure(provider.Conn, providerID, "no response")
 			return
 		}
 		s.verifyChallengeResponse(providerID, provider, pc, resp)
 	case <-time.After(timeout):
 		tracker.remove(nonce)
-		s.handleTransientChallengeFailure(conn, providerID, "timeout")
+		s.handleTransientChallengeFailure(provider.Conn, providerID, "timeout")
 	}
 }
 
@@ -1563,9 +1561,7 @@ func (s *Server) verifyChallengeResponse(providerID string, provider *registry.P
 				}
 				statusData, err := json.Marshal(statusMsg)
 				if err == nil {
-					writeCtx, writeCancel := context.WithTimeout(context.Background(), 5*time.Second)
-					_ = provider.Conn.Write(writeCtx, websocket.MessageText, statusData)
-					writeCancel()
+					_ = provider.EnqueueText(context.Background(), statusData)
 				}
 			}
 			return
@@ -3264,8 +3260,7 @@ func (s *Server) handleProviderAttestation(w http.ResponseWriter, r *http.Reques
 // the WebSocket connection. This allows the provider to react — e.g. by
 // auto-reporting unified logs when it learns it is self_signed or untrusted.
 func (s *Server) sendTrustStatus(provider *registry.Provider, trustLevel registry.TrustLevel, status string, reason string) {
-	conn := provider.Conn
-	if conn == nil {
+	if provider == nil || provider.Conn == nil {
 		return
 	}
 	msg := protocol.TrustStatusMessage{
@@ -3278,7 +3273,5 @@ func (s *Server) sendTrustStatus(provider *registry.Provider, trustLevel registr
 	if err != nil {
 		return
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	_ = conn.Write(ctx, websocket.MessageText, data)
+	_ = provider.EnqueueText(context.Background(), data)
 }

--- a/coordinator/api/provider_write_test.go
+++ b/coordinator/api/provider_write_test.go
@@ -1,0 +1,62 @@
+package api
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+	"github.com/eigeninference/d-inference/coordinator/registry"
+	"nhooyr.io/websocket"
+)
+
+func TestWriteProviderInferenceRequestUsesProviderQueue(t *testing.T) {
+	serverConnCh := make(chan *websocket.Conn, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			t.Errorf("accept websocket: %v", err)
+			return
+		}
+		serverConnCh <- conn
+	}))
+	defer server.Close()
+
+	dialCtx, cancelDial := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancelDial()
+	clientConn, _, err := websocket.Dial(dialCtx, "ws"+strings.TrimPrefix(server.URL, "http"), nil)
+	if err != nil {
+		t.Fatalf("dial websocket: %v", err)
+	}
+	defer clientConn.Close(websocket.StatusNormalClosure, "done")
+
+	var serverConn *websocket.Conn
+	select {
+	case serverConn = <-serverConnCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for server websocket")
+	}
+	defer serverConn.Close(websocket.StatusNormalClosure, "done")
+
+	reg := registry.New(slog.New(slog.NewTextHandler(io.Discard, nil)))
+	provider := reg.Register("provider-write-test", serverConn, &protocol.RegisterMessage{})
+	defer reg.Disconnect(provider.ID)
+	if err := writeProviderInferenceRequest(context.Background(), provider, []byte(`{"type":"inference_request"}`)); err != nil {
+		t.Fatalf("writeProviderInferenceRequest returned error: %v", err)
+	}
+
+	readCtx, cancelRead := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancelRead()
+	_, data, err := clientConn.Read(readCtx)
+	if err != nil {
+		t.Fatalf("client read: %v", err)
+	}
+	if string(data) != `{"type":"inference_request"}` {
+		t.Fatalf("data = %s", data)
+	}
+}

--- a/coordinator/registry/config.go
+++ b/coordinator/registry/config.go
@@ -3,6 +3,8 @@ package registry
 import (
 	"fmt"
 	"os"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/eigeninference/d-inference/coordinator/env"
@@ -50,6 +52,10 @@ type WarmPoolConfig struct {
 	FallbackQualityConcurrency int
 	AssumedPromptTokens        int
 	AssumedCompletionTokens    int
+	// MinWarmByModel is an operator floor for concrete model IDs, e.g.
+	// EIGENINFERENCE_WARM_POOL_MIN_WARM="gpt-oss-20b=4,gemma-4-26b-qat-4bit=2".
+	// Floors are capped by warm+eligibleCold and still obey load throttles.
+	MinWarmByModel map[string]int
 
 	// Ramp shaping. MaxLoadsPerTick is the baseline per-tick load burst;
 	// RampGapFraction scales the burst up with the remaining target gap, bounded
@@ -98,6 +104,7 @@ func ReadConfig() Config {
 			FallbackQualityConcurrency: env.EnvInt(env.EnvPrefix+"_WARM_POOL_FALLBACK_QUALITY_CONCURRENCY", 4),
 			AssumedPromptTokens:        env.EnvInt(env.EnvPrefix+"_WARM_POOL_ASSUMED_PROMPT_TOKENS", 512),
 			AssumedCompletionTokens:    env.EnvInt(env.EnvPrefix+"_WARM_POOL_ASSUMED_COMPLETION_TOKENS", 256),
+			MinWarmByModel:             envModelIntMap(env.EnvPrefix + "_WARM_POOL_MIN_WARM"),
 
 			MaxLoadsPerTick:        env.EnvInt(env.EnvPrefix+"_WARM_POOL_MAX_LOADS_PER_TICK", 4),
 			MaxLoadsPerTickCeiling: env.EnvInt(env.EnvPrefix+"_WARM_POOL_MAX_LOADS_PER_TICK_CEILING", 16),
@@ -151,6 +158,37 @@ func (c CacheAffinityConfig) Check() error {
 		return fmt.Errorf("registry: cache affinity bonus must be <= 10000ms")
 	}
 	return nil
+}
+
+func envModelIntMap(key string) map[string]int {
+	raw := strings.TrimSpace(os.Getenv(key))
+	if raw == "" {
+		return nil
+	}
+	out := make(map[string]int)
+	for _, entry := range strings.Split(raw, ",") {
+		entry = strings.TrimSpace(entry)
+		if entry == "" {
+			continue
+		}
+		model, value, ok := strings.Cut(entry, "=")
+		if !ok {
+			continue
+		}
+		model = strings.TrimSpace(model)
+		if model == "" {
+			continue
+		}
+		n, err := strconv.Atoi(strings.TrimSpace(value))
+		if err != nil || n <= 0 {
+			continue
+		}
+		out[model] = n
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 func (c WarmPoolConfig) Check() error {

--- a/coordinator/registry/config_test.go
+++ b/coordinator/registry/config_test.go
@@ -22,6 +22,7 @@ func clearWarmPoolEnv(t *testing.T) {
 		"WARM_POOL_SPECULATIVE_WIN_THRESHOLD",
 		"WARM_POOL_COLD_DISPATCH_THRESHOLD",
 		"WARM_POOL_LOAD_DURATION_THRESHOLD",
+		"WARM_POOL_MIN_WARM",
 		"WARM_POOL_MAX_LOADS_PER_TICK",
 		"WARM_POOL_MAX_GLOBAL_PENDING_LOADS",
 	}
@@ -51,6 +52,25 @@ func TestReadConfigWarmPoolDefaultsActive(t *testing.T) {
 	}
 	if cfg.MaxGlobalPendingLoads != 16 {
 		t.Fatalf("MaxGlobalPendingLoads = %d, want 16", cfg.MaxGlobalPendingLoads)
+	}
+}
+
+func TestReadConfigWarmPoolMinWarmByModel(t *testing.T) {
+	clearWarmPoolEnv(t)
+	t.Setenv(env.EnvPrefix+"_WARM_POOL_MIN_WARM", "gpt-oss-20b=4, bad, gemma=0, other=-1, qwen=2")
+
+	got := ReadConfig().WarmPool.MinWarmByModel
+	if got["gpt-oss-20b"] != 4 {
+		t.Fatalf("gpt-oss floor = %d, want 4", got["gpt-oss-20b"])
+	}
+	if got["qwen"] != 2 {
+		t.Fatalf("qwen floor = %d, want 2", got["qwen"])
+	}
+	if _, ok := got["gemma"]; ok {
+		t.Fatal("zero min-warm entry should be ignored")
+	}
+	if _, ok := got["other"]; ok {
+		t.Fatal("negative min-warm entry should be ignored")
 	}
 }
 

--- a/coordinator/registry/provider_writer.go
+++ b/coordinator/registry/provider_writer.go
@@ -1,0 +1,289 @@
+package registry
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"nhooyr.io/websocket"
+)
+
+const (
+	providerWriteQueueSize        = 128
+	providerWriteMinTimeout       = 5 * time.Second
+	providerWriteMaxTimeout       = 30 * time.Second
+	providerWriteBytesPerSecond   = 2 << 20 // 2 MiB/s (~16 Mbps) floor.
+	providerControlWriteTimeout   = 5 * time.Second
+	providerWriteDrainErrorString = "provider websocket writer stopped"
+)
+
+var errProviderWriterStopped = errors.New(providerWriteDrainErrorString)
+var errProviderWriterQueueFull = errors.New("provider websocket writer queue full")
+
+type providerWriteRequest struct {
+	ctx   context.Context
+	data  []byte
+	done  chan error
+	state atomic.Int32 // 0 queued, 1 canceled before start, 2 started
+}
+
+type providerWriter struct {
+	conn     *websocket.Conn
+	queue    chan *providerWriteRequest
+	stop     chan struct{}
+	done     chan struct{}
+	acceptMu sync.Mutex
+	dead     atomic.Bool
+}
+
+func newProviderWriter(conn *websocket.Conn) *providerWriter {
+	if conn == nil {
+		return nil
+	}
+	w := &providerWriter{
+		conn:  conn,
+		queue: make(chan *providerWriteRequest, providerWriteQueueSize),
+		stop:  make(chan struct{}),
+		done:  make(chan struct{}),
+	}
+	go w.run()
+	return w
+}
+
+func (w *providerWriter) write(ctx context.Context, data []byte) error {
+	if w == nil {
+		return errProviderWriterStopped
+	}
+	if w.dead.Load() {
+		return errProviderWriterStopped
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	req := &providerWriteRequest{
+		ctx:  ctx,
+		data: append([]byte(nil), data...),
+		done: make(chan error, 1),
+	}
+	w.acceptMu.Lock()
+	if w.dead.Load() {
+		w.acceptMu.Unlock()
+		return errProviderWriterStopped
+	}
+	select {
+	case w.queue <- req:
+		w.acceptMu.Unlock()
+	case <-w.done:
+		w.acceptMu.Unlock()
+		return errProviderWriterStopped
+	default:
+		w.acceptMu.Unlock()
+		return errProviderWriterQueueFull
+	}
+	select {
+	case err := <-req.done:
+		return err
+	case <-ctx.Done():
+		if req.state.CompareAndSwap(0, 1) {
+			return ctx.Err()
+		}
+		select {
+		case err := <-req.done:
+			return err
+		case <-w.done:
+			return errProviderWriterStopped
+		}
+	case <-w.done:
+		return errProviderWriterStopped
+	}
+}
+
+func (w *providerWriter) enqueue(ctx context.Context, data []byte) error {
+	if w == nil {
+		return errProviderWriterStopped
+	}
+	if w.dead.Load() {
+		return errProviderWriterStopped
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	req := &providerWriteRequest{
+		ctx:  context.Background(),
+		data: append([]byte(nil), data...),
+	}
+	w.acceptMu.Lock()
+	if w.dead.Load() {
+		w.acceptMu.Unlock()
+		return errProviderWriterStopped
+	}
+	select {
+	case w.queue <- req:
+		w.acceptMu.Unlock()
+		return nil
+	case <-w.done:
+		w.acceptMu.Unlock()
+		return errProviderWriterStopped
+	default:
+		w.acceptMu.Unlock()
+		return errProviderWriterQueueFull
+	}
+}
+
+func (w *providerWriter) closeNow() {
+	if w == nil {
+		return
+	}
+	w.acceptMu.Lock()
+	if !w.dead.CompareAndSwap(false, true) {
+		w.acceptMu.Unlock()
+		return
+	}
+	close(w.stop)
+	if w.conn != nil {
+		_ = w.conn.CloseNow()
+	}
+	w.acceptMu.Unlock()
+}
+
+func (w *providerWriter) run() {
+	defer w.dead.Store(true)
+	defer close(w.done)
+	for {
+		select {
+		case <-w.stop:
+			w.drain(errProviderWriterStopped)
+			return
+		case req := <-w.queue:
+			if (req.ctx != nil && req.ctx.Err() != nil) || !req.state.CompareAndSwap(0, 2) {
+				if req.done != nil {
+					if req.ctx != nil && req.ctx.Err() != nil {
+						req.done <- req.ctx.Err()
+					} else {
+						req.done <- context.Canceled
+					}
+				}
+				continue
+			}
+			if err := w.writeFrame(req.data); err != nil {
+				if req.done != nil {
+					req.done <- err
+				}
+				w.closeNow()
+				w.drain(err)
+				return
+			}
+			if req.done != nil {
+				req.done <- nil
+			}
+		}
+	}
+}
+
+func (w *providerWriter) drain(err error) {
+	for {
+		select {
+		case req := <-w.queue:
+			if req.done != nil {
+				req.done <- err
+			}
+		default:
+			return
+		}
+	}
+}
+
+func (w *providerWriter) writeFrame(data []byte) error {
+	done := make(chan error, 1)
+	go func() {
+		// Do not pass a cancelable/expiring context to nhooyr.Conn.Write: context
+		// expiration is treated as a connection-level failure by the library. The
+		// writer owns timeout/backpressure externally and closes unhealthy sockets
+		// explicitly with CloseNow.
+		done <- w.conn.Write(context.Background(), websocket.MessageText, data)
+	}()
+	timer := time.NewTimer(providerWriteTimeout(len(data)))
+	defer timer.Stop()
+	select {
+	case err := <-done:
+		return err
+	case <-timer.C:
+		if w.conn != nil {
+			_ = w.conn.CloseNow()
+		}
+		return errors.New("provider websocket write timeout")
+	case <-w.stop:
+		if w.conn != nil {
+			_ = w.conn.CloseNow()
+		}
+		return errProviderWriterStopped
+	}
+}
+
+func providerWriteTimeout(frameBytes int) time.Duration {
+	if frameBytes <= 0 {
+		return providerWriteMinTimeout
+	}
+	d := time.Duration(frameBytes) * time.Second / providerWriteBytesPerSecond
+	if d < providerWriteMinTimeout {
+		return providerWriteMinTimeout
+	}
+	if d > providerWriteMaxTimeout {
+		return providerWriteMaxTimeout
+	}
+	return d
+}
+
+// WriteText serializes a text WebSocket frame through this provider's single
+// writer. ctx controls enqueue/result waiting only; it is never passed to the
+// underlying WebSocket write.
+func (p *Provider) WriteText(ctx context.Context, data []byte) error {
+	if p == nil {
+		return errors.New("provider is nil")
+	}
+	p.mu.Lock()
+	w := p.writer
+	p.mu.Unlock()
+	if w == nil {
+		return errProviderWriterStopped
+	}
+	return w.write(ctx, data)
+}
+
+// EnqueueText queues a text WebSocket frame without waiting for write
+// completion. It is for control-plane best-effort sends (cancel/load/prefetch/
+// status) where a caller must not block behind prior data frames. ctx controls
+// enqueue only; it is never passed to the underlying WebSocket write.
+func (p *Provider) EnqueueText(ctx context.Context, data []byte) error {
+	if p == nil {
+		return errors.New("provider is nil")
+	}
+	p.mu.Lock()
+	w := p.writer
+	p.mu.Unlock()
+	if w == nil {
+		return errProviderWriterStopped
+	}
+	return w.enqueue(ctx, data)
+}
+
+func (p *Provider) closeWriterNow() {
+	if p == nil {
+		return
+	}
+	p.mu.Lock()
+	w := p.writer
+	p.writer = nil
+	p.mu.Unlock()
+	if w != nil {
+		w.closeNow()
+	}
+}

--- a/coordinator/registry/provider_writer_test.go
+++ b/coordinator/registry/provider_writer_test.go
@@ -1,0 +1,154 @@
+package registry
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"nhooyr.io/websocket"
+)
+
+func testWebSocketPair(t *testing.T) (*websocket.Conn, *websocket.Conn) {
+	t.Helper()
+	serverConnCh := make(chan *websocket.Conn, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			t.Errorf("accept websocket: %v", err)
+			return
+		}
+		serverConnCh <- conn
+	}))
+	t.Cleanup(server.Close)
+
+	dialCtx, cancelDial := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancelDial()
+	clientConn, _, err := websocket.Dial(dialCtx, "ws"+strings.TrimPrefix(server.URL, "http"), nil)
+	if err != nil {
+		t.Fatalf("dial websocket: %v", err)
+	}
+	t.Cleanup(func() { _ = clientConn.Close(websocket.StatusNormalClosure, "done") })
+
+	select {
+	case serverConn := <-serverConnCh:
+		t.Cleanup(func() { _ = serverConn.Close(websocket.StatusNormalClosure, "done") })
+		return serverConn, clientConn
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for server websocket")
+	}
+	return nil, nil
+}
+
+func TestProviderWriteTimeoutScalesWithFrameSize(t *testing.T) {
+	if got := providerWriteTimeout(1); got != providerWriteMinTimeout {
+		t.Fatalf("tiny frame timeout = %v, want min %v", got, providerWriteMinTimeout)
+	}
+	large := providerWriteBytesPerSecond * 10
+	if got := providerWriteTimeout(large); got != 10*time.Second {
+		t.Fatalf("large frame timeout = %v, want 10s", got)
+	}
+	tooLarge := providerWriteBytesPerSecond * 100
+	if got := providerWriteTimeout(tooLarge); got != providerWriteMaxTimeout {
+		t.Fatalf("huge frame timeout = %v, want max %v", got, providerWriteMaxTimeout)
+	}
+}
+
+func TestProviderWriteTextCanceledContextDoesNotCloseSocket(t *testing.T) {
+	serverConn, clientConn := testWebSocketPair(t)
+	p := &Provider{Conn: serverConn, writer: newProviderWriter(serverConn)}
+	t.Cleanup(p.closeWriterNow)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := p.WriteText(ctx, []byte(`{"type":"ignored"}`)); err != context.Canceled {
+		t.Fatalf("WriteText canceled ctx error = %v, want context.Canceled", err)
+	}
+
+	if err := p.WriteText(context.Background(), []byte(`{"type":"ok"}`)); err != nil {
+		t.Fatalf("WriteText after canceled enqueue = %v", err)
+	}
+	readCtx, cancelRead := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancelRead()
+	_, data, err := clientConn.Read(readCtx)
+	if err != nil {
+		t.Fatalf("client read after canceled enqueue: %v", err)
+	}
+	if string(data) != `{"type":"ok"}` {
+		t.Fatalf("data = %s", data)
+	}
+}
+
+func TestProviderWriterQueueFullReturnsImmediately(t *testing.T) {
+	w := &providerWriter{
+		queue: make(chan *providerWriteRequest, 1),
+		done:  make(chan struct{}),
+	}
+	w.queue <- &providerWriteRequest{done: make(chan error, 1)}
+
+	if err := w.write(context.Background(), []byte(`{"type":"overflow"}`)); err != errProviderWriterQueueFull {
+		t.Fatalf("write on full queue = %v, want errProviderWriterQueueFull", err)
+	}
+	if err := w.enqueue(context.Background(), []byte(`{"type":"overflow"}`)); err != errProviderWriterQueueFull {
+		t.Fatalf("enqueue on full queue = %v, want errProviderWriterQueueFull", err)
+	}
+}
+
+func TestProviderWriteTextCancellationBeforeStartSkipsFrame(t *testing.T) {
+	w := &providerWriter{
+		queue: make(chan *providerWriteRequest, 1),
+		done:  make(chan struct{}),
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- w.write(ctx, []byte(`{"type":"skip"}`))
+	}()
+
+	var req *providerWriteRequest
+	select {
+	case req = <-w.queue:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for queued write")
+	}
+	cancel()
+	select {
+	case err := <-errCh:
+		if err != context.Canceled {
+			t.Fatalf("write error = %v, want context.Canceled", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for canceled write")
+	}
+	if req.state.Load() != 1 {
+		t.Fatalf("queued request state = %d, want canceled-before-start state 1", req.state.Load())
+	}
+}
+
+func TestSendModelLoadActionsClearsPendingWhenWriterQueueFull(t *testing.T) {
+	r := New(testLogger())
+	p := &Provider{
+		ID:          "queue-full-provider",
+		writer:      &providerWriter{queue: make(chan *providerWriteRequest, 1), done: make(chan struct{})},
+		pendingReqs: make(map[string]*PendingRequest),
+	}
+	p.writer.queue <- &providerWriteRequest{done: make(chan error, 1)}
+	r.mu.Lock()
+	r.providers[p.ID] = p
+	r.mu.Unlock()
+
+	actions := r.reservePendingModelLoads([]modelLoadAction{{providerID: p.ID, modelID: "m"}}, time.Now())
+	if len(actions) != 1 {
+		t.Fatalf("reserved actions = %d, want 1", len(actions))
+	}
+	r.sendModelLoadActions(actions)
+
+	r.mu.Lock()
+	hasPending := r.providerHasPendingLoad(p.ID)
+	r.mu.Unlock()
+	if hasPending {
+		t.Fatal("pending model load was not cleared after writer queue rejected load_model")
+	}
+}

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -335,6 +335,7 @@ type Provider struct {
 
 	Status           ProviderStatus
 	Conn             *websocket.Conn
+	writer           *providerWriter
 	LastHeartbeat    time.Time
 	Stats            protocol.HeartbeatStats // lifetime counters shown to users
 	lastSessionStats protocol.HeartbeatStats // raw counters from the current provider process
@@ -2360,6 +2361,7 @@ func (r *Registry) Register(id string, conn *websocket.Conn, msg *protocol.Regis
 		TemplateHashes:          CloneStringMap(msg.TemplateHashes),
 		Status:                  StatusOnline,
 		Conn:                    conn,
+		writer:                  newProviderWriter(conn),
 		LastHeartbeat:           time.Now(),
 		Reputation:              NewReputation(),
 		pendingReqs:             make(map[string]*PendingRequest),
@@ -2627,18 +2629,9 @@ func (r *Registry) SendLoadModel(providerID, modelID string) error {
 		return fmt.Errorf("failed to marshal load_model message: %w", err)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), providerControlWriteTimeout)
 	defer cancel()
-
-	p.mu.Lock()
-	conn := p.Conn
-	p.mu.Unlock()
-
-	if conn == nil {
-		return fmt.Errorf("provider %q has no active connection", providerID)
-	}
-
-	if err := conn.Write(ctx, websocket.MessageText, data); err != nil {
+	if err := p.WriteText(ctx, data); err != nil {
 		return fmt.Errorf("failed to send load_model to provider %q: %w", providerID, err)
 	}
 
@@ -2675,18 +2668,9 @@ func (r *Registry) SendPrefetchModel(providerID, modelID string, priority int) e
 		return fmt.Errorf("failed to marshal prefetch_model message: %w", err)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), providerControlWriteTimeout)
 	defer cancel()
-
-	p.mu.Lock()
-	conn := p.Conn
-	p.mu.Unlock()
-
-	if conn == nil {
-		return fmt.Errorf("provider %q has no active connection", providerID)
-	}
-
-	if err := conn.Write(ctx, websocket.MessageText, data); err != nil {
+	if err := p.WriteText(ctx, data); err != nil {
 		return fmt.Errorf("failed to send prefetch_model to provider %q: %w", providerID, err)
 	}
 
@@ -2733,18 +2717,9 @@ func (r *Registry) SendDesiredModels(providerID string, entries []protocol.Desir
 		return fmt.Errorf("failed to marshal desired_models message: %w", err)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), providerControlWriteTimeout)
 	defer cancel()
-
-	p.mu.Lock()
-	conn := p.Conn
-	p.mu.Unlock()
-
-	if conn == nil {
-		return fmt.Errorf("provider %q has no active connection", providerID)
-	}
-
-	if err := conn.Write(ctx, websocket.MessageText, data); err != nil {
+	if err := p.WriteText(ctx, data); err != nil {
 		return fmt.Errorf("failed to send desired_models to provider %q: %w", providerID, err)
 	}
 
@@ -3347,9 +3322,7 @@ func (r *Registry) Disconnect(id string) {
 	// Disconnect runs serially in the eviction loop and Close would block ~5s
 	// waiting for a handshake the stale peer won't send. No-op if already closed;
 	// outside r.mu so it can't stall the registry.
-	if p.Conn != nil {
-		_ = p.Conn.CloseNow()
-	}
+	p.closeWriterNow()
 
 	// Close this connection's session row (async; durable uptime history).
 	// Covers both graceful disconnects and evictStale (which calls Disconnect).

--- a/coordinator/registry/warm_pool_controller.go
+++ b/coordinator/registry/warm_pool_controller.go
@@ -242,7 +242,15 @@ func (c *warmPoolController) planObserveOnly(now time.Time, reserve func([]model
 	for model := range models {
 		ordered = append(ordered, model)
 	}
-	sort.Strings(ordered)
+	sort.Slice(ordered, func(i, j int) bool {
+		left, right := ordered[i], ordered[j]
+		lp := c.hasDemandPressure(fleet[left], pressure[left], queue[left])
+		rp := c.hasDemandPressure(fleet[right], pressure[right], queue[right])
+		if lp != rp {
+			return lp
+		}
+		return left < right
+	})
 
 	perTickCeiling := c.config.perTickCeiling()
 	loadsRemaining := perTickCeiling
@@ -383,6 +391,12 @@ func (c *warmPoolController) targetWarm(fleet warmPoolModelSnapshot, pressure wa
 	target := warmTarget(c.targetInputs(fleet, pressure, queue), params, svc)
 	if c.config.MinDwell > 0 && pressure.lastTarget > target && now.Sub(pressure.lastTargetChangedAt) < c.config.MinDwell {
 		target = pressure.lastTarget
+		if maxReachable := fleet.warm + len(fleet.eligibleCold); target > maxReachable {
+			target = maxReachable
+		}
+	}
+	if floor := c.config.MinWarmByModel[fleet.model]; floor > target {
+		target = floor
 		if maxReachable := fleet.warm + len(fleet.eligibleCold); target > maxReachable {
 			target = maxReachable
 		}

--- a/coordinator/registry/warm_pool_controller_test.go
+++ b/coordinator/registry/warm_pool_controller_test.go
@@ -218,6 +218,78 @@ func TestWarmPoolNoPressureForLongActiveDecodeAlone(t *testing.T) {
 	}
 }
 
+func TestWarmPoolMinWarmFloorLoadsWithoutPressure(t *testing.T) {
+	reg := New(testLogger())
+	model := "warm-pool-min-floor"
+	makeSchedulerProvider(t, reg, "warm", model, 80)
+	makeWarmPoolColdProvider(t, reg, "cold-a", model, 80, 64, 8)
+	makeWarmPoolColdProvider(t, reg, "cold-b", model, 80, 64, 8)
+	cfg := testWarmPoolConfig()
+	cfg.MinWarmByModel = map[string]int{model: 3}
+	reg.ConfigureWarmPool(cfg)
+	sent := captureWarmPoolLoads(reg)
+
+	snaps := reg.warmPool.tick(time.Now())
+
+	if len(snaps) != 1 {
+		t.Fatalf("snapshots = %d, want 1", len(snaps))
+	}
+	if snaps[0].TargetWarm != 3 {
+		t.Fatalf("TargetWarm = %d, want min floor 3", snaps[0].TargetWarm)
+	}
+	if len(*sent) != 1 {
+		t.Fatalf("sent loads = %d, want 1 (bounded by MaxLoadsPerTick)", len(*sent))
+	}
+}
+
+func TestWarmPoolMinWarmFloorCapsAtReachable(t *testing.T) {
+	reg := New(testLogger())
+	model := "warm-pool-min-floor-cap"
+	makeSchedulerProvider(t, reg, "warm", model, 80)
+	makeWarmPoolColdProvider(t, reg, "cold", model, 80, 64, 8)
+	cfg := testWarmPoolConfig()
+	cfg.MinWarmByModel = map[string]int{model: 5}
+	reg.ConfigureWarmPool(cfg)
+
+	snaps := reg.warmPool.tick(time.Now())
+
+	if len(snaps) != 1 {
+		t.Fatalf("snapshots = %d, want 1", len(snaps))
+	}
+	if snaps[0].TargetWarm != 2 {
+		t.Fatalf("TargetWarm = %d, want reachable cap 2", snaps[0].TargetWarm)
+	}
+}
+
+func TestWarmPoolPressureLoadsBeforeMinWarmFloor(t *testing.T) {
+	reg := New(testLogger())
+	floorModel := "aaa-floor-model"
+	pressureModel := "zzz-pressure-model"
+	makeSchedulerProvider(t, reg, "floor-warm", floorModel, 80)
+	floorCold := makeWarmPoolColdProvider(t, reg, "floor-cold", floorModel, 80, 64, 8)
+	makeSchedulerProvider(t, reg, "pressure-warm", pressureModel, 80)
+	pressureCold := makeWarmPoolColdProvider(t, reg, "pressure-cold", pressureModel, 80, 64, 8)
+	cfg := testWarmPoolConfig()
+	cfg.MaxLoadsPerTick = 1
+	cfg.MaxLoadsPerTickCeiling = 1
+	cfg.MinWarmByModel = map[string]int{floorModel: 2}
+	reg.ConfigureWarmPool(cfg)
+	sent := captureWarmPoolLoads(reg)
+	reg.RecordWarmPoolCapacityReject(pressureModel)
+
+	reg.warmPool.tick(time.Now())
+
+	if len(*sent) != 1 {
+		t.Fatalf("sent loads = %d, want 1", len(*sent))
+	}
+	if (*sent)[0].providerID != pressureCold.ID || (*sent)[0].modelID != pressureModel {
+		t.Fatalf("sent %+v, want pressure model/provider", (*sent)[0])
+	}
+	if (*sent)[0].providerID == floorCold.ID {
+		t.Fatal("floor-only warmup consumed pressure load budget")
+	}
+}
+
 func TestWarmPoolFleetSnapshotUsesObservedSlotTPS(t *testing.T) {
 	reg := New(testLogger())
 	model := "warm-pool-observed-tps"


### PR DESCRIPTION
## Summary
- Add a per-provider WebSocket writer queue so production provider writes have exactly one `Conn.Write` owner.
- Route inference dispatch, cancel, attestation challenge/status, trust-status, `load_model`, `prefetch_model`, and `desired_models` writes through `Provider.WriteText` / `Provider.EnqueueText`.
- Add bounded queue/backpressure semantics: queue-full returns immediately; write timeouts are external to `Conn.Write`; unhealthy sockets are terminated with `CloseNow()`.
- Add a per-model warm-pool floor via `EIGENINFERENCE_WARM_POOL_MIN_WARM`.
- Prioritize pressure-driven warm-pool loads over floor-only baseline maintenance.
- Keep demand-driven `prefetch_model` for providers missing the hot model as follow-up work.

## Before: multiple goroutines wrote directly to provider WebSocket
```mermaid
flowchart TD
  A[Consumer request] --> B[dispatch goroutine]
  C[Cancel path] --> D[cancel goroutine]
  E[Attestation / trust / load_model] --> F[control goroutine]
  B --> G[Conn.Write with request/control ctx]
  D --> G
  F --> G
  H[Client cancel / timeout] --> G
  G --> I[nhooyr write context canceled or write mutex blocked]
  I --> J[Entire provider WebSocket can close]
  J --> K[All in-flight requests on provider fail]
```

## After: single provider writer owns socket writes
```mermaid
flowchart TD
  A[All provider outbound messages] --> B{Need write completion?}
  B -->|Inference dispatch / challenge| C[Provider.WriteText]
  B -->|Cancel / status / load_model / prefetch / desired_models| D[Provider.EnqueueText]
  C --> E[Bounded provider writer queue]
  D --> E
  E --> F[Single provider writer worker]
  F --> G[Only production owner of Conn.Write]
  H[Caller context cancel] -. if queued, marks request canceled .-> C
  G --> I[Conn.Write uses context.Background]
  F -->|write timeout / unhealthy provider| J[CloseNow provider socket]
  J --> K[Drain queued writes with error]
  K --> L[Existing cleanup/refund/exclude paths run]
```

## Writer invariants
- One write owner per provider.
- No production direct `Conn.Write` outside `coordinator/registry/provider_writer.go`.
- Caller context controls enqueue/result wait only; it is never passed to the WebSocket write.
- `WriteText` cancellation semantics:
  - If caller cancels while the frame is still queued, the frame is skipped and caller returns.
  - If the writer has started the socket write, caller cancellation cannot cancel that socket write; caller waits for write result, writer timeout, or writer stop.
- `EnqueueText` is enqueue-only for best-effort control messages that must not block behind data frames.
- Queue is bounded; full queue returns an error instead of creating unbounded goroutines.
- Write timeout is external to `Conn.Write` and size-scaled.
- Timed-out/unhealthy provider sockets are terminated with `CloseNow()` and queued writes are failed.
- `Disconnect()` stops the writer and drains queued waiters.

## Before: floor warmups could consume pressure load budget
```mermaid
flowchart TD
  A[Warm-pool tick] --> B[Models sorted lexicographically]
  B --> C[Floor-only model has gap]
  C --> D[Consumes shared loadsRemaining]
  D --> E[Pressure model later in order gets no action]
```

## After: pressure before floor maintenance
```mermaid
flowchart TD
  A[Warm-pool tick] --> B[Classify hasDemandPressure]
  B --> C[Pressure models first]
  C --> D[Use load budget for queued/capacity/TTFT pressure]
  D --> E[Floor-only min-warm uses leftover capacity]
```

## Min-warm config
`EIGENINFERENCE_WARM_POOL_MIN_WARM="gpt-oss-20b=4,gemma-4-26b-qat-4bit=2"`

Rules:
- Concrete model IDs only (warm-pool runs post-alias).
- Non-positive/invalid entries ignored.
- Floor is capped by `warm + eligible_cold` and still obeys observe-only, per-tick, and global pending-load limits.

## Tests
- `go test ./coordinator/api -run "TestWriteProviderInferenceRequestUsesProviderQueue"`
- `go test ./coordinator/registry -run "Test(ProviderWriteTimeoutScalesWithFrameSize|ProviderWriteTextCanceledContextDoesNotCloseSocket|ProviderWriterQueueFullReturnsImmediately|ProviderWriteTextCancellationBeforeStartSkipsFrame|SendModelLoadActionsClearsPendingWhenWriterQueueFull|WarmPoolPressureLoadsBeforeMinWarmFloor|ReadConfigWarmPoolMinWarmByModel|WarmPoolMinWarmFloorLoadsWithoutPressure|WarmPoolMinWarmFloorCapsAtReachable|ColdSpillProviders)"`
- `go test ./coordinator/...`

## Verified invariant
`rg` over production Go files shows the only remaining `Conn.Write` call is in `coordinator/registry/provider_writer.go`.

## Follow-ups intentionally not in this PR
- Demand-driven `prefetch_model` for providers that do not advertise the hot model on disk.
- Dashboard updates for eligible cold / model residency / WS write queue metrics.
- Optional protocol/library cleanup: migrate import path from `nhooyr.io/websocket` to `github.com/coder/websocket` in a separate dependency PR.
