### PR TITLE
Fix P1 WebSocket stability gaps

### DIFF
--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -88,6 +88,15 @@ const (
 	// block. Using context.Background() unbounded here risks hanging the HTTP
 	// handler goroutine when a WebSocket is half-dead.
 	cancelWriteTimeout = 2 * time.Second
+
+	// Provider dispatch writes can be large (sealed/base64 inference requests), so
+	// the external wait budget scales with frame size. The Write itself deliberately
+	// uses a non-canceling context because nhooyr closes the entire WebSocket when a
+	// write context is cancelled/expired. On timeout we immediately close the
+	// provider socket as unhealthy so request cleanup can continue.
+	providerDispatchWriteMinTimeout     = 5 * time.Second
+	providerDispatchWriteMaxTimeout     = 30 * time.Second
+	providerDispatchWriteBytesPerSecond = 2 << 20 // 2 MiB/s (~16 Mbps) floor.
 )
 
 var thinkBlockPattern = regexp.MustCompile(`(?is)<think>(.*?)</think>\s*`)
@@ -99,6 +108,20 @@ func ttftDeadline(estimatedPromptTokens int) time.Duration {
 	base := 5 * time.Second
 	perToken := time.Duration(estimatedPromptTokens) * time.Millisecond
 	return base + perToken
+}
+
+func providerDispatchWriteTimeout(frameBytes int) time.Duration {
+	if frameBytes <= 0 {
+		return providerDispatchWriteMinTimeout
+	}
+	d := time.Duration(frameBytes) * time.Second / providerDispatchWriteBytesPerSecond
+	if d < providerDispatchWriteMinTimeout {
+		return providerDispatchWriteMinTimeout
+	}
+	if d > providerDispatchWriteMaxTimeout {
+		return providerDispatchWriteMaxTimeout
+	}
+	return d
 }
 
 // sendProviderCancel sends a Cancel message for the given request to the
@@ -120,6 +143,28 @@ func (s *Server) sendProviderCancel(provider *registry.Provider, requestID strin
 	if err := provider.Conn.Write(ctx, websocket.MessageText, cancelData); err != nil {
 		s.logger.Debug("failed to send cancel (provider may have disconnected)",
 			"request_id", requestID, "error", err)
+	}
+}
+
+func writeProviderInferenceRequest(_ context.Context, provider *registry.Provider, data []byte) error {
+	if provider == nil || provider.Conn == nil {
+		return errors.New("provider websocket is not connected")
+	}
+	done := make(chan error, 1)
+	go func() {
+		// Do not pass the consumer request context (or any timeout context) to
+		// nhooyr.Conn.Write: any cancellation/expiration passed to nhooyr can close
+		// the shared provider socket. Keep the timeout outside the Write call.
+		done <- provider.Conn.Write(context.Background(), websocket.MessageText, data)
+	}()
+	timer := time.NewTimer(providerDispatchWriteTimeout(len(data)))
+	defer timer.Stop()
+	select {
+	case err := <-done:
+		return err
+	case <-timer.C:
+		_ = provider.Conn.CloseNow()
+		return errors.New("provider websocket write timeout")
 	}
 }
 
@@ -658,7 +703,7 @@ func (s *Server) dispatchOneProvider(
 	if pr.Timing != nil {
 		pr.Timing.DispatchedAt = time.Now()
 	}
-	if err := provider.Conn.Write(r.Context(), websocket.MessageText, data); err != nil {
+	if err := writeProviderInferenceRequest(r.Context(), provider, data); err != nil {
 		refundExtra()
 		cleanupPending()
 		excludeProviders[provider.ID] = struct{}{}
@@ -5235,7 +5280,7 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 	pr.SessionPrivKey = &sessionKeys.PrivateKey
 	data, _ := json.Marshal(wireMsg)
 	timing.DispatchedAt = time.Now()
-	if err := provider.Conn.Write(r.Context(), websocket.MessageText, data); err != nil {
+	if err := writeProviderInferenceRequest(r.Context(), provider, data); err != nil {
 		cleanupPending()
 		refundExtra()
 		refundReservation()

--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -129,7 +129,7 @@ func providerDispatchWriteTimeout(frameBytes int) time.Duration {
 // caller. Errors are logged at debug level because a disconnect race is the
 // expected case — the provider may already be gone.
 func (s *Server) sendProviderCancel(provider *registry.Provider, requestID string) {
-	if provider == nil || provider.Conn == nil {
+	if provider == nil {
 		return
 	}
 	cancelMsg := protocol.CancelMessage{Type: protocol.TypeCancel, RequestID: requestID}
@@ -140,31 +140,49 @@ func (s *Server) sendProviderCancel(provider *registry.Provider, requestID strin
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), cancelWriteTimeout)
 	defer cancel()
-	if err := provider.Conn.Write(ctx, websocket.MessageText, cancelData); err != nil {
+	if err := provider.Write(ctx, websocket.MessageText, cancelData); err != nil {
 		s.logger.Debug("failed to send cancel (provider may have disconnected)",
 			"request_id", requestID, "error", err)
 	}
 }
 
 func writeProviderInferenceRequest(_ context.Context, provider *registry.Provider, data []byte) error {
-	if provider == nil || provider.Conn == nil {
+	if provider == nil {
 		return errors.New("provider websocket is not connected")
 	}
+	timeout := providerDispatchWriteTimeout(len(data))
+	gateCtx, cancelGate := context.WithTimeout(context.Background(), timeout)
+	defer cancelGate()
 	done := make(chan error, 1)
 	go func() {
 		// Do not pass the consumer request context (or any timeout context) to
 		// nhooyr.Conn.Write: any cancellation/expiration passed to nhooyr can close
-		// the shared provider socket. Keep the timeout outside the Write call.
-		done <- provider.Conn.Write(context.Background(), websocket.MessageText, data)
+		// the shared provider socket. The gate wait is bounded separately.
+		done <- provider.WriteWithContexts(gateCtx, context.Background(), websocket.MessageText, data)
 	}()
-	timer := time.NewTimer(providerDispatchWriteTimeout(len(data)))
+	timer := time.NewTimer(timeout)
 	defer timer.Stop()
 	select {
 	case err := <-done:
+		if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+			closeProviderConnNow(provider)
+		}
 		return err
 	case <-timer.C:
-		_ = provider.Conn.CloseNow()
+		closeProviderConnNow(provider)
 		return errors.New("provider websocket write timeout")
+	}
+}
+
+func closeProviderConnNow(provider *registry.Provider) {
+	if provider == nil {
+		return
+	}
+	provider.Mu().Lock()
+	conn := provider.Conn
+	provider.Mu().Unlock()
+	if conn != nil {
+		conn.CloseNow()
 	}
 }
 

--- a/coordinator/api/dispatch.go
+++ b/coordinator/api/dispatch.go
@@ -44,7 +44,6 @@ import (
 	"github.com/eigeninference/d-inference/coordinator/saferun"
 	"github.com/eigeninference/d-inference/coordinator/store"
 	"github.com/google/uuid"
-	"nhooyr.io/websocket"
 )
 
 // dispatchOutcome is the result of a per-attempt dispatch phase (provider
@@ -752,7 +751,7 @@ func (d *dispatchState) dispatchPrimary() dispatchOutcome {
 		// have been increased by reserveAdditionalForProvider. Don't overwrite.
 		data, _ := json.Marshal(wireMsg)
 		d.pr.Timing.DispatchedAt = time.Now()
-		if err := d.provider.Conn.Write(r.Context(), websocket.MessageText, data); err != nil {
+		if err := writeProviderInferenceRequest(r.Context(), d.provider, data); err != nil {
 			d.provider.RemovePending(d.requestID)
 			s.registry.SetProviderIdle(d.provider.ID)
 			s.refundProviderExtra(d.pr)

--- a/coordinator/api/provider.go
+++ b/coordinator/api/provider.go
@@ -49,6 +49,17 @@ import (
 )
 
 const (
+	// providerPreRegisterReadLimitBytes bounds unauthenticated provider frames.
+	// The first message must be a compact RegisterMessage; keep this small so
+	// unauthenticated sockets cannot each pin a full encrypted-inference frame.
+	providerPreRegisterReadLimitBytes = 1 * 1024 * 1024
+
+	// providerRegisteredReadLimitBytes bounds a single registered
+	// provider→coordinator WebSocket frame. It matches the Swift provider's
+	// coordinator→provider inbound cap so either direction has the same envelope
+	// budget for encrypted inference chunks.
+	providerRegisteredReadLimitBytes = 32 * 1024 * 1024
+
 	// DefaultChallengeInterval is how often the coordinator challenges providers.
 	DefaultChallengeInterval = 5 * time.Minute
 
@@ -117,9 +128,9 @@ func (s *Server) handleProviderWS(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Raise the read limit to 10 MB. The default 32 KB is too small for
-	// large inference responses.
-	conn.SetReadLimit(10 * 1024 * 1024)
+	// Keep the pre-register cap small because this socket is unauthenticated.
+	// Raise it only after the first valid RegisterMessage is parsed.
+	conn.SetReadLimit(providerPreRegisterReadLimitBytes)
 
 	providerID := uuid.New().String()
 	s.logger.Info("provider websocket connected", "provider_id", providerID, "remote", r.RemoteAddr)
@@ -136,6 +147,7 @@ func (s *Server) handleProviderWS(w http.ResponseWriter, r *http.Request) {
 // them. It runs until the connection closes or the context is cancelled.
 func (s *Server) providerReadLoop(ctx context.Context, conn *websocket.Conn, providerID string, acmeResult *ACMEVerificationResult, r *http.Request) {
 	var provider *registry.Provider
+	registered := false
 	tracker := newChallengeTracker()
 
 	// Cancel context for cleanup of the challenge loop goroutine.
@@ -203,167 +215,181 @@ func (s *Server) providerReadLoop(ctx context.Context, conn *websocket.Conn, pro
 
 		switch msg.Type {
 		case protocol.TypeRegister:
-			regMsg := msg.Payload.(*protocol.RegisterMessage)
-			provider = s.registry.Register(providerID, conn, regMsg)
-			s.attachProviderLocation(providerID, provider, r)
-			s.verifyProviderAttestation(providerID, provider, regMsg)
-
-			// Record registration outcome metrics + telemetry.
-			if s.metrics != nil {
-				s.metrics.IncCounter("provider_registrations_total",
-					MetricLabel{"trust_level", string(provider.TrustLevel)},
-				)
+			if registered {
+				s.logger.Warn("duplicate register on provider websocket; closing", "provider_id", providerID)
+				_ = conn.Close(websocket.StatusPolicyViolation, "duplicate register")
+				return
 			}
-			s.ddIncr("providers.registrations", []string{"trust_level:" + string(provider.TrustLevel)})
-			s.emit(context.Background(), protocol.SeverityInfo, protocol.KindLog,
-				"provider registered",
-				map[string]any{
-					"provider_id":   providerID,
-					"trust_level":   string(provider.TrustLevel),
-					"hardware_chip": regMsg.Hardware.ChipName,
-					"memory_gb":     regMsg.Hardware.MemoryGB,
-				})
+			releaseRegister, ok := s.acquireProviderRegisterSlot(loopCtx)
+			if !ok {
+				return
+			}
+			func() {
+				defer releaseRegister()
+				registered = true
+				conn.SetReadLimit(providerRegisteredReadLimitBytes)
+				regMsg := msg.Payload.(*protocol.RegisterMessage)
+				provider = s.registry.Register(providerID, conn, regMsg)
+				s.attachProviderLocation(providerID, provider, r)
+				s.verifyProviderAttestation(providerID, provider, regMsg)
 
-			// Resolve auth token → account linkage.
-			if regMsg.AuthToken != "" {
-				pt, err := s.store.GetProviderToken(regMsg.AuthToken)
-				if err != nil {
-					s.logger.Warn("provider auth token invalid",
-						"provider_id", providerID,
-						"error", err,
+				// Record registration outcome metrics + telemetry.
+				if s.metrics != nil {
+					s.metrics.IncCounter("provider_registrations_total",
+						MetricLabel{"trust_level", string(provider.TrustLevel)},
 					)
-				} else {
+				}
+				s.ddIncr("providers.registrations", []string{"trust_level:" + string(provider.TrustLevel)})
+				s.emit(context.Background(), protocol.SeverityInfo, protocol.KindLog,
+					"provider registered",
+					map[string]any{
+						"provider_id":   providerID,
+						"trust_level":   string(provider.TrustLevel),
+						"hardware_chip": regMsg.Hardware.ChipName,
+						"memory_gb":     regMsg.Hardware.MemoryGB,
+					})
+
+				// Resolve auth token → account linkage.
+				if regMsg.AuthToken != "" {
+					pt, err := s.store.GetProviderToken(regMsg.AuthToken)
+					if err != nil {
+						s.logger.Warn("provider auth token invalid",
+							"provider_id", providerID,
+							"error", err,
+						)
+					} else {
+						provider.Mu().Lock()
+						provider.AccountID = pt.AccountID
+						provider.Mu().Unlock()
+						s.logger.Info("provider linked to account",
+							"provider_id", providerID,
+							"account_id", pt.AccountID,
+							"token_label", pt.Label,
+						)
+					}
+				}
+
+				// Store provider version.
+				if regMsg.Version != "" {
 					provider.Mu().Lock()
-					provider.AccountID = pt.AccountID
+					provider.Version = regMsg.Version
 					provider.Mu().Unlock()
-					s.logger.Info("provider linked to account",
-						"provider_id", providerID,
-						"account_id", pt.AccountID,
-						"token_label", pt.Label,
-					)
 				}
-			}
 
-			// Store provider version.
-			if regMsg.Version != "" {
-				provider.Mu().Lock()
-				provider.Version = regMsg.Version
-				provider.Mu().Unlock()
-			}
+				// Verify runtime integrity against the known-good manifest. Swift
+				// providers omit Python/vllm hashes, but they still report external
+				// runtime assets such as mlx.metallib under template_hashes.
+				if s.knownRuntimeManifest != nil {
+					runtimeOK, mismatches := s.verifyRuntimeHashesForBackend(
+						regMsg.Backend, regMsg.PythonHash, regMsg.RuntimeHash, regMsg.TemplateHashes)
+					provider.Mu().Lock()
+					provider.RuntimeVerified = runtimeOK
+					provider.RuntimeManifestChecked = runtimeOK
+					provider.PythonHash = regMsg.PythonHash
+					provider.RuntimeHash = regMsg.RuntimeHash
+					provider.TemplateHashes = registry.CloneStringMap(regMsg.TemplateHashes)
+					provider.Mu().Unlock()
 
-			// Verify runtime integrity against the known-good manifest. Swift
-			// providers omit Python/vllm hashes, but they still report external
-			// runtime assets such as mlx.metallib under template_hashes.
-			if s.knownRuntimeManifest != nil {
-				runtimeOK, mismatches := s.verifyRuntimeHashesForBackend(
-					regMsg.Backend, regMsg.PythonHash, regMsg.RuntimeHash, regMsg.TemplateHashes)
-				provider.Mu().Lock()
-				provider.RuntimeVerified = runtimeOK
-				provider.RuntimeManifestChecked = runtimeOK
-				provider.PythonHash = regMsg.PythonHash
-				provider.RuntimeHash = regMsg.RuntimeHash
-				provider.TemplateHashes = registry.CloneStringMap(regMsg.TemplateHashes)
-				provider.Mu().Unlock()
-
-				if !runtimeOK {
-					// Send runtime status feedback only on mismatch so the
-					// provider can self-heal. Skip the message when everything
-					// matches — it would only add noise on the WebSocket.
-					statusMsg := protocol.RuntimeStatusMessage{
-						Type:       protocol.TypeRuntimeStatus,
-						Verified:   false,
-						Mismatches: mismatches,
+					if !runtimeOK {
+						// Send runtime status feedback only on mismatch so the
+						// provider can self-heal. Skip the message when everything
+						// matches — it would only add noise on the WebSocket.
+						statusMsg := protocol.RuntimeStatusMessage{
+							Type:       protocol.TypeRuntimeStatus,
+							Verified:   false,
+							Mismatches: mismatches,
+						}
+						statusData, err := json.Marshal(statusMsg)
+						if err == nil {
+							writeCtx, writeCancel := context.WithTimeout(loopCtx, 5*time.Second)
+							_ = provider.Write(writeCtx, websocket.MessageText, statusData)
+							writeCancel()
+						}
+						mismatchDetails := make([]string, 0, len(mismatches))
+						for _, m := range mismatches {
+							mismatchDetails = append(mismatchDetails, m.Component+"="+m.Got)
+						}
+						s.logger.Warn("provider runtime integrity mismatch — excluded from routing",
+							"provider_id", providerID,
+							"mismatches", len(mismatches),
+							"details", mismatchDetails,
+							"backend", regMsg.Backend,
+						)
+					} else {
+						s.logger.Info("provider runtime integrity verified",
+							"provider_id", providerID,
+							"python_hash", regMsg.PythonHash,
+							"runtime_hash", regMsg.RuntimeHash,
+						)
 					}
-					statusData, err := json.Marshal(statusMsg)
-					if err == nil {
-						writeCtx, writeCancel := context.WithTimeout(loopCtx, 5*time.Second)
-						_ = conn.Write(writeCtx, websocket.MessageText, statusData)
-						writeCancel()
-					}
-					mismatchDetails := make([]string, 0, len(mismatches))
-					for _, m := range mismatches {
-						mismatchDetails = append(mismatchDetails, m.Component+"="+m.Got)
-					}
-					s.logger.Warn("provider runtime integrity mismatch — excluded from routing",
-						"provider_id", providerID,
-						"mismatches", len(mismatches),
-						"details", mismatchDetails,
-						"backend", regMsg.Backend,
-					)
 				} else {
-					s.logger.Info("provider runtime integrity verified",
+					// No manifest configured — fail-closed for routing.
+					provider.Mu().Lock()
+					provider.RuntimeVerified = true
+					provider.RuntimeManifestChecked = false
+					provider.Mu().Unlock()
+				}
+
+				// Version cutoff check — runs AFTER runtime check so it takes precedence.
+				// If version is below minimum, override RuntimeVerified to false.
+				if s.minProviderVersion != "" && regMsg.Version != "" && semverLess(regMsg.Version, s.minProviderVersion) {
+					s.logger.Warn("provider version below minimum — excluded from routing",
 						"provider_id", providerID,
-						"python_hash", regMsg.PythonHash,
-						"runtime_hash", regMsg.RuntimeHash,
+						"version", regMsg.Version,
+						"min_version", s.minProviderVersion,
 					)
+					s.ddIncr("provider_version_below_minimum", []string{"gate:registration", "version:" + regMsg.Version})
+					provider.Mu().Lock()
+					provider.RuntimeVerified = false
+					provider.RuntimeManifestChecked = false
+					provider.Mu().Unlock()
 				}
-			} else {
-				// No manifest configured — fail-closed for routing.
-				provider.Mu().Lock()
-				provider.RuntimeVerified = true
-				provider.RuntimeManifestChecked = false
-				provider.Mu().Unlock()
-			}
 
-			// Version cutoff check — runs AFTER runtime check so it takes precedence.
-			// If version is below minimum, override RuntimeVerified to false.
-			if s.minProviderVersion != "" && regMsg.Version != "" && semverLess(regMsg.Version, s.minProviderVersion) {
-				s.logger.Warn("provider version below minimum — excluded from routing",
-					"provider_id", providerID,
-					"version", regMsg.Version,
-					"min_version", s.minProviderVersion,
-				)
-				s.ddIncr("provider_version_below_minimum", []string{"gate:registration", "version:" + regMsg.Version})
-				provider.Mu().Lock()
-				provider.RuntimeVerified = false
-				provider.RuntimeManifestChecked = false
-				provider.Mu().Unlock()
-			}
+				s.applyACMETrust(providerID, provider, acmeResult)
 
-			s.applyACMETrust(providerID, provider, acmeResult)
-
-			// Declaratively tell the provider the desired build per alias it
-			// already serves, so a fresh/reconnected provider converges without a
-			// separate catalog pull. Sent even when EMPTY: a provider that
-			// reconnects (same process, prefetch state intact) after the alias it
-			// was converging to was deleted/repointed must learn that nothing is
-			// desired anymore, or its in-flight prefetch would hard-swap anyway.
-			// Gated on Swift backend + feature version: a pre-feature provider's
-			// strict decoder throws on unknown types.
-			if s.providerSupportsDesiredModels(regMsg.Backend, regMsg.Version) {
-				if err := s.registry.SendDesiredModels(providerID, s.registry.DesiredModelsForProvider(providerID)); err != nil {
-					s.logger.Warn("failed to send desired_models after register",
-						"provider_id", providerID, "error", err)
+				// Declaratively tell the provider the desired build per alias it
+				// already serves, so a fresh/reconnected provider converges without a
+				// separate catalog pull. Sent even when EMPTY: a provider that
+				// reconnects (same process, prefetch state intact) after the alias it
+				// was converging to was deleted/repointed must learn that nothing is
+				// desired anymore, or its in-flight prefetch would hard-swap anyway.
+				// Gated on Swift backend + feature version: a pre-feature provider's
+				// strict decoder throws on unknown types.
+				if s.providerSupportsDesiredModels(regMsg.Backend, regMsg.Version) {
+					if err := s.registry.SendDesiredModels(providerID, s.registry.DesiredModelsForProvider(providerID)); err != nil {
+						s.logger.Warn("failed to send desired_models after register",
+							"provider_id", providerID, "error", err)
+					}
 				}
-			}
 
-			// Start challenge loop after registration
-			saferun.Go(s.logger, "challengeLoop", func() {
-				s.challengeLoop(loopCtx, conn, providerID, provider, tracker)
-			})
-
-			// Start the per-connection MDM verification loop. It runs the initial
-			// SecurityInfo check + a bounded, push-budget-aware retry, decoupled
-			// from the 5-minute challenge ticker. No-op when no MDM client is
-			// configured or the attestation carried no serial.
-			saferun.Go(s.logger, "mdmVerificationLoop", func() {
-				s.mdmVerificationLoop(loopCtx, providerID, provider)
-			})
-
-			// v0.6.0: APNs code-identity attestation. Runs only when an attestor is
-			// configured; otherwise the provider simply never becomes CodeAttested
-			// (fail-closed at the routing chokepoint once enforcement begins). The
-			// code-identity proof and the SIP/liveness pillar compose at the routing
-			// gate (providerSupportsPrivateTextLocked requires both). The loop pushes
-			// (within the per-device budget) and polls; verification of the reply
-			// happens in the read-loop delivery path (handleCodeAttestationResponse),
-			// so a single dropped/late background push doesn't strand a capable
-			// provider, and a reply on a reconnected socket still attests (Fix 1).
-			if s.codeAttestor != nil {
-				saferun.Go(s.logger, "codeAttest", func() {
-					s.codeAttestLoop(loopCtx, providerID, provider)
+				// Start challenge loop after registration
+				saferun.Go(s.logger, "challengeLoop", func() {
+					s.challengeLoop(loopCtx, conn, providerID, provider, tracker)
 				})
-			}
+
+				// Start the per-connection MDM verification loop. It runs the initial
+				// SecurityInfo check + a bounded, push-budget-aware retry, decoupled
+				// from the 5-minute challenge ticker. No-op when no MDM client is
+				// configured or the attestation carried no serial.
+				saferun.Go(s.logger, "mdmVerificationLoop", func() {
+					s.mdmVerificationLoop(loopCtx, providerID, provider)
+				})
+
+				// v0.6.0: APNs code-identity attestation. Runs only when an attestor is
+				// configured; otherwise the provider simply never becomes CodeAttested
+				// (fail-closed at the routing chokepoint once enforcement begins). The
+				// code-identity proof and the SIP/liveness pillar compose at the routing
+				// gate (providerSupportsPrivateTextLocked requires both). The loop pushes
+				// (within the per-device budget) and polls; verification of the reply
+				// happens in the read-loop delivery path (handleCodeAttestationResponse),
+				// so a single dropped/late background push doesn't strand a capable
+				// provider, and a reply on a reconnected socket still attests (Fix 1).
+				if s.codeAttestor != nil {
+					saferun.Go(s.logger, "codeAttest", func() {
+						s.codeAttestLoop(loopCtx, providerID, provider)
+					})
+				}
+			}()
 
 		case protocol.TypeHeartbeat:
 			hbMsg := msg.Payload.(*protocol.HeartbeatMessage)
@@ -574,7 +600,13 @@ func (s *Server) codeAttestLoop(ctx context.Context, providerID string, provider
 				return
 			}
 			s.codeAttestThrottle.recordPush(seKey)
-			prevSent = s.sendCodeIdentityChallenge(ctx, providerID, provider)
+			sent := false
+			if !s.runProviderVerifyWork(ctx, "code_attest", func() {
+				sent = s.sendCodeIdentityChallenge(ctx, providerID, provider)
+			}) {
+				return
+			}
+			prevSent = sent
 			pushes++
 		}
 
@@ -1125,7 +1157,7 @@ func (s *Server) sendChallenge(ctx context.Context, conn *websocket.Conn, provid
 
 	writeCtx, writeCancel := context.WithTimeout(ctx, 5*time.Second)
 	defer writeCancel()
-	if err := conn.Write(writeCtx, websocket.MessageText, data); err != nil {
+	if err := provider.Write(writeCtx, websocket.MessageText, data); err != nil {
 		s.logger.Error("failed to send challenge", "provider_id", providerID, "error", err)
 		tracker.remove(nonce)
 		return
@@ -1555,18 +1587,16 @@ func (s *Server) verifyChallengeResponse(providerID string, provider *registry.P
 			// Send status feedback but do NOT fail the challenge or mark untrusted.
 			// The provider remains connected but is excluded from routing until
 			// it reports matching hashes.
-			if provider.Conn != nil {
-				statusMsg := protocol.RuntimeStatusMessage{
-					Type:       protocol.TypeRuntimeStatus,
-					Verified:   false,
-					Mismatches: mismatches,
-				}
-				statusData, err := json.Marshal(statusMsg)
-				if err == nil {
-					writeCtx, writeCancel := context.WithTimeout(context.Background(), 5*time.Second)
-					_ = provider.Conn.Write(writeCtx, websocket.MessageText, statusData)
-					writeCancel()
-				}
+			statusMsg := protocol.RuntimeStatusMessage{
+				Type:       protocol.TypeRuntimeStatus,
+				Verified:   false,
+				Mismatches: mismatches,
+			}
+			statusData, err := json.Marshal(statusMsg)
+			if err == nil {
+				writeCtx, writeCancel := context.WithTimeout(context.Background(), 5*time.Second)
+				_ = provider.Write(writeCtx, websocket.MessageText, statusData)
+				writeCancel()
 			}
 			return
 		}
@@ -1721,7 +1751,7 @@ func (s *Server) handleTransientChallengeFailure(conn *websocket.Conn, providerI
 	}
 	// Closing the conn unblocks providerReadLoop's conn.Read, which cancels the
 	// loop context (stopping this challenge loop) and runs registry.Disconnect.
-	_ = conn.Close(websocket.StatusPolicyViolation, "attestation unresponsive — reconnect required")
+	conn.CloseNow()
 }
 
 // handleChallengeFailure records a failed challenge and marks the provider
@@ -1780,9 +1810,23 @@ func (s *Server) handleChunk(providerID string, provider *registry.Provider, msg
 		// gone / already settled), burning its GPU and token-budget admission.
 		// Nudge it to stop — throttled so a chunk-per-token zombie doesn't flood
 		// the provider with cancels.
-		if s.zombieCanceller.shouldCancel(msg.RequestID, time.Now()) {
+		action := s.zombieCanceller.record(msg.RequestID, time.Now())
+		if action.sendCancel {
 			s.sendProviderCancel(provider, msg.RequestID)
 			s.ddIncr("inference.zombie_stream_cancel", []string{})
+		}
+		if action.forceReconnect {
+			s.logger.Warn("provider kept streaming an abandoned request after repeated cancels — forcing reconnect",
+				"provider_id", providerID,
+				"request_id", msg.RequestID,
+			)
+			s.ddIncr("inference.zombie_stream_force_reconnect", []string{})
+			provider.Mu().Lock()
+			conn := provider.Conn
+			provider.Mu().Unlock()
+			if conn != nil {
+				conn.CloseNow()
+			}
 		}
 		return
 	}
@@ -1802,11 +1846,52 @@ func (s *Server) handleChunk(providerID string, provider *registry.Provider, msg
 		})
 		return
 	}
-	// Non-blocking send — if consumer is gone the chunk is dropped.
+	delivered, closed := deliverChunkWithBackpressure(pr, chunkData)
+	if delivered {
+		return
+	}
+	if closed {
+		// The consumer already closed out this request. Tell the provider to
+		// stop generating so it does not burn GPU up to max_tokens.
+		s.logger.Warn("chunk channel closed before provider stopped streaming",
+			"provider_id", providerID,
+			"request_id", msg.RequestID,
+		)
+		s.sendProviderCancel(provider, msg.RequestID)
+		s.ddIncr("inference.chunk_channel_closed", []string{})
+		return
+	}
+
+	s.logger.Warn("consumer chunk channel backpressure exceeded; failing request",
+		"provider_id", providerID,
+		"request_id", msg.RequestID,
+	)
+	s.ddIncr("inference.chunk_backpressure_full", []string{})
+	s.handleInferenceError(providerID, provider, &protocol.InferenceErrorMessage{
+		Type:       protocol.TypeInferenceError,
+		RequestID:  msg.RequestID,
+		Error:      "consumer stream backpressure exceeded",
+		StatusCode: http.StatusBadGateway,
+	})
+	s.sendProviderCancel(provider, msg.RequestID)
+}
+
+func deliverChunkWithBackpressure(pr *registry.PendingRequest, chunkData string) (delivered bool, closed bool) {
+	if pr == nil || pr.ChunkCh == nil {
+		return false, true
+	}
+	defer func() {
+		if recover() != nil {
+			delivered = false
+			closed = true
+		}
+	}()
+
 	select {
 	case pr.ChunkCh <- chunkData:
+		return true, false
 	default:
-		s.logger.Warn("dropped chunk, consumer channel full", "request_id", msg.RequestID)
+		return false, false
 	}
 }
 
@@ -2987,7 +3072,13 @@ func (s *Server) mdmVerificationLoop(ctx context.Context, providerID string, pro
 		if provider.ChallengeShouldStop() {
 			return
 		}
-		switch s.verifyProviderViaMDM(ctx, providerID, provider, *result) {
+		var outcome mdmVerifyOutcome
+		if !s.runProviderVerifyWork(ctx, "mdm", func() {
+			outcome = s.verifyProviderViaMDM(ctx, providerID, provider, *result)
+		}) {
+			return
+		}
+		switch outcome {
 		case mdmVerifyGranted, mdmVerifyTerminal:
 			return
 		}
@@ -3264,10 +3355,6 @@ func (s *Server) handleProviderAttestation(w http.ResponseWriter, r *http.Reques
 // the WebSocket connection. This allows the provider to react — e.g. by
 // auto-reporting unified logs when it learns it is self_signed or untrusted.
 func (s *Server) sendTrustStatus(provider *registry.Provider, trustLevel registry.TrustLevel, status string, reason string) {
-	conn := provider.Conn
-	if conn == nil {
-		return
-	}
 	msg := protocol.TrustStatusMessage{
 		Type:       protocol.TypeTrustStatus,
 		TrustLevel: string(trustLevel),
@@ -3280,5 +3367,5 @@ func (s *Server) sendTrustStatus(provider *registry.Provider, trustLevel registr
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	_ = conn.Write(ctx, websocket.MessageText, data)
+	_ = provider.Write(ctx, websocket.MessageText, data)
 }

--- a/coordinator/api/provider_test.go
+++ b/coordinator/api/provider_test.go
@@ -99,6 +99,69 @@ func TestProviderWebSocketConnect(t *testing.T) {
 	}
 }
 
+func TestProviderWebSocketReadLimitRaisesAfterRegister(t *testing.T) {
+	if providerPreRegisterReadLimitBytes >= providerRegisteredReadLimitBytes {
+		t.Fatalf("pre-register read limit %d must be below registered limit %d",
+			providerPreRegisterReadLimitBytes, providerRegisteredReadLimitBytes)
+	}
+	if providerPreRegisterReadLimitBytes > 2*1024*1024 {
+		t.Fatalf("pre-register read limit %d is too large for unauthenticated sockets",
+			providerPreRegisterReadLimitBytes)
+	}
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelError}))
+	st := store.NewMemory(store.Config{AdminKey: "test-key"})
+	reg := registry.New(logger)
+	srv := NewServer(reg, st, ServerConfig{}, logger)
+
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http") + "/ws/provider"
+	conn, _, err := websocket.Dial(ctx, wsURL, nil)
+	if err != nil {
+		t.Fatalf("websocket dial: %v", err)
+	}
+	defer conn.Close(websocket.StatusNormalClosure, "")
+
+	regMsg := protocol.RegisterMessage{
+		Type: protocol.TypeRegister,
+		Hardware: protocol.Hardware{
+			MachineModel: "Mac15,8",
+			ChipName:     "Apple M3 Max",
+			MemoryGB:     64,
+		},
+		Models:  []protocol.ModelInfo{{ID: "test-model", SizeBytes: 1000, ModelType: "chat", Quantization: "4bit"}},
+		Backend: "mlx-swift",
+	}
+	regData, _ := json.Marshal(regMsg)
+	if err := conn.Write(ctx, websocket.MessageText, regData); err != nil {
+		t.Fatalf("write register: %v", err)
+	}
+	time.Sleep(100 * time.Millisecond)
+	if reg.ProviderCount() != 1 {
+		t.Fatalf("provider count = %d, want 1", reg.ProviderCount())
+	}
+
+	oversizedPreRegisterFrame := strings.Repeat("{", providerPreRegisterReadLimitBytes+1024)
+	if err := conn.Write(ctx, websocket.MessageText, []byte(oversizedPreRegisterFrame)); err != nil {
+		t.Fatalf("write post-register oversized frame: %v", err)
+	}
+
+	hbMsg := protocol.HeartbeatMessage{
+		Type:   protocol.TypeHeartbeat,
+		Status: "idle",
+		Stats:  protocol.HeartbeatStats{RequestsServed: 1, TokensGenerated: 100},
+	}
+	hbData, _ := json.Marshal(hbMsg)
+	if err := conn.Write(ctx, websocket.MessageText, hbData); err != nil {
+		t.Fatalf("write heartbeat after oversized post-register frame: %v", err)
+	}
+}
+
 func TestProviderWebSocketMultiple(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	st := store.NewMemory(store.Config{AdminKey: "test-key"})

--- a/coordinator/api/provider_verify_limiter.go
+++ b/coordinator/api/provider_verify_limiter.go
@@ -1,0 +1,34 @@
+package api
+
+import "context"
+
+func (s *Server) acquireProviderRegisterSlot(ctx context.Context) (func(), bool) {
+	if s.providerRegisterSem == nil {
+		return func() {}, true
+	}
+
+	select {
+	case s.providerRegisterSem <- struct{}{}:
+		return func() { <-s.providerRegisterSem }, true
+	case <-ctx.Done():
+		return nil, false
+	}
+}
+
+func (s *Server) runProviderVerifyWork(ctx context.Context, name string, fn func()) bool {
+	if s.providerVerifySem == nil {
+		fn()
+		return true
+	}
+
+	select {
+	case s.providerVerifySem <- struct{}{}:
+		defer func() { <-s.providerVerifySem }()
+	case <-ctx.Done():
+		return false
+	}
+
+	s.ddIncr("provider.verify_work_started", []string{"kind:" + name})
+	fn()
+	return true
+}

--- a/coordinator/api/provider_write_test.go
+++ b/coordinator/api/provider_write_test.go
@@ -1,0 +1,74 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/registry"
+	"nhooyr.io/websocket"
+)
+
+func TestProviderDispatchWriteTimeoutScalesWithFrameSize(t *testing.T) {
+	if got := providerDispatchWriteTimeout(1); got != providerDispatchWriteMinTimeout {
+		t.Fatalf("tiny frame timeout = %v, want min %v", got, providerDispatchWriteMinTimeout)
+	}
+	large := providerDispatchWriteBytesPerSecond * 10
+	if got := providerDispatchWriteTimeout(large); got != 10*time.Second {
+		t.Fatalf("large frame timeout = %v, want 10s", got)
+	}
+	tooLarge := providerDispatchWriteBytesPerSecond * 100
+	if got := providerDispatchWriteTimeout(tooLarge); got != providerDispatchWriteMaxTimeout {
+		t.Fatalf("huge frame timeout = %v, want max %v", got, providerDispatchWriteMaxTimeout)
+	}
+}
+
+func TestWriteProviderInferenceRequestIgnoresConsumerCancel(t *testing.T) {
+	serverConnCh := make(chan *websocket.Conn, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			t.Errorf("accept websocket: %v", err)
+			return
+		}
+		serverConnCh <- conn
+	}))
+	defer server.Close()
+
+	dialCtx, cancelDial := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancelDial()
+	clientConn, _, err := websocket.Dial(dialCtx, "ws"+strings.TrimPrefix(server.URL, "http"), nil)
+	if err != nil {
+		t.Fatalf("dial websocket: %v", err)
+	}
+	defer clientConn.Close(websocket.StatusNormalClosure, "done")
+
+	var serverConn *websocket.Conn
+	select {
+	case serverConn = <-serverConnCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for server websocket")
+	}
+	defer serverConn.Close(websocket.StatusNormalClosure, "done")
+
+	consumerCtx, cancelConsumer := context.WithCancel(context.Background())
+	cancelConsumer()
+
+	provider := &registry.Provider{Conn: serverConn}
+	if err := writeProviderInferenceRequest(consumerCtx, provider, []byte(`{"type":"inference_request"}`)); err != nil {
+		t.Fatalf("writeProviderInferenceRequest returned error with canceled consumer context: %v", err)
+	}
+
+	readCtx, cancelRead := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancelRead()
+	_, data, err := clientConn.Read(readCtx)
+	if err != nil {
+		t.Fatalf("client read: %v", err)
+	}
+	if string(data) != `{"type":"inference_request"}` {
+		t.Fatalf("data = %s", data)
+	}
+}

--- a/coordinator/api/server.go
+++ b/coordinator/api/server.go
@@ -62,6 +62,17 @@ type apiKeyCacheEntry struct {
 const (
 	apiKeyCacheTTL     = 60 * time.Second
 	apiKeyCacheMaxSize = 1000
+
+	// providerVerifyConcurrency caps the number of concurrent post-register
+	// verification workers that can hit MDM/APNs. Provider reconnects still
+	// register immediately; expensive trust/code-identity work queues behind
+	// this lane so a coordinator restart does not fan out an unbounded herd.
+	providerVerifyConcurrency = 32
+
+	// providerRegisterConcurrency caps the short synchronous register path
+	// (state creation, attestation parse, initial commands). Connections beyond
+	// this wait on their own read loop instead of stampeding the coordinator.
+	providerRegisterConcurrency = 128
 )
 
 // contextKey is an unexported type for context keys in this package.
@@ -185,6 +196,8 @@ type Server struct {
 	codeAttestor           apns.CodeIdentityAttestor // APNs code-identity attestor (nil = disabled; v0.6.0)
 	codeAttestThrottle     *codeAttestThrottle       // per-device APNs push budget + reuse cache (v0.6.0)
 	trustReuseCache        *trustReuseCache          // per-device trust-reuse cache: skip a fleet-wide live MDM herd on restart (DAR-326)
+	providerRegisterSem    chan struct{}             // bounds concurrent first-register processing during reconnect storms
+	providerVerifySem      chan struct{}             // bounds concurrent MDM/APNs verification work during reconnect storms
 
 	// knownBinaryHashes is the set of accepted provider binary SHA-256 hashes.
 	// When binaryHashPolicyConfigured is true, providers whose binary hash is
@@ -653,6 +666,8 @@ func NewServer(reg *registry.Registry, st store.Store, cfg ServerConfig, logger 
 		pendingACME:          make(map[string]*ACMEVerificationResult),
 		codeAttestThrottle:   newCodeAttestThrottle(),
 		trustReuseCache:      newTrustReuseCache(),
+		providerRegisterSem:  make(chan struct{}, providerRegisterConcurrency),
+		providerVerifySem:    make(chan struct{}, providerVerifyConcurrency),
 		settlements:          newSettlementHolder(),
 		zombieCanceller:      newZombieStreamCanceller(),
 		serviceReservations:  newServiceReservationManager(st, cfg.ServiceReservations),

--- a/coordinator/api/zombie_stream.go
+++ b/coordinator/api/zombie_stream.go
@@ -12,6 +12,17 @@ import (
 // actually listening, and harmless against one that isn't.
 const zombieCancelThrottle = 10 * time.Second
 const zombieCancelMaxEntries = 4096
+const zombieCancelForceReconnectAttempts = 3
+
+type zombieCancelRecord struct {
+	last     time.Time
+	attempts int
+}
+
+type zombieCancelAction struct {
+	sendCancel     bool
+	forceReconnect bool
+}
 
 // zombieStreamCanceller throttles cancels sent for chunks that arrive for a
 // request the coordinator no longer tracks (consumer gone / already settled).
@@ -20,44 +31,52 @@ const zombieCancelMaxEntries = 4096
 // throttle window per request.
 type zombieStreamCanceller struct {
 	mu   sync.Mutex
-	sent map[string]time.Time
+	sent map[string]zombieCancelRecord
 }
 
 func newZombieStreamCanceller() *zombieStreamCanceller {
-	return &zombieStreamCanceller{sent: make(map[string]time.Time)}
+	return &zombieStreamCanceller{sent: make(map[string]zombieCancelRecord)}
 }
 
-// shouldCancel reports whether to send a cancel for requestID now, recording
-// the send. Returns false within zombieCancelThrottle of the last send for that
-// id. Opportunistically sweeps expired entries so the map stays bounded.
-func (z *zombieStreamCanceller) shouldCancel(requestID string, now time.Time) bool {
+// record records an unknown-request chunk and returns what recovery action the
+// caller should take. After repeated throttled cancel attempts, forceReconnect
+// asks the caller to cycle the provider connection: either the provider never
+// received our cancels or its generation loop ignored them, and letting it run
+// to max_tokens burns fleet capacity.
+func (z *zombieStreamCanceller) record(requestID string, now time.Time) zombieCancelAction {
 	z.mu.Lock()
 	defer z.mu.Unlock()
 
-	if t, ok := z.sent[requestID]; ok {
-		if now.Sub(t) < zombieCancelThrottle {
-			return false
+	rec, ok := z.sent[requestID]
+	if ok {
+		if now.Sub(rec.last) < zombieCancelThrottle {
+			return zombieCancelAction{}
 		}
-		delete(z.sent, requestID)
 	}
 
-	if len(z.sent) >= zombieCancelMaxEntries {
+	if !ok && len(z.sent) >= zombieCancelMaxEntries {
 		var oldestID string
-		var oldest time.Time
-		for id, t := range z.sent {
-			if now.Sub(t) > zombieCancelThrottle {
+		var oldest zombieCancelRecord
+		for id, rec := range z.sent {
+			if now.Sub(rec.last) > zombieCancelThrottle {
 				delete(z.sent, id)
 				continue
 			}
-			if oldestID == "" || t.Before(oldest) {
+			if oldestID == "" || rec.last.Before(oldest.last) {
 				oldestID = id
-				oldest = t
+				oldest = rec
 			}
 		}
 		if len(z.sent) >= zombieCancelMaxEntries && oldestID != "" {
 			delete(z.sent, oldestID)
 		}
 	}
-	z.sent[requestID] = now
-	return true
+
+	rec.last = now
+	rec.attempts++
+	z.sent[requestID] = rec
+	return zombieCancelAction{
+		sendCancel:     true,
+		forceReconnect: rec.attempts >= zombieCancelForceReconnectAttempts,
+	}
 }

--- a/coordinator/api/zombie_stream_test.go
+++ b/coordinator/api/zombie_stream_test.go
@@ -3,25 +3,47 @@ package api
 import (
 	"testing"
 	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/registry"
 )
 
 func TestZombieStreamCancellerThrottle(t *testing.T) {
 	z := newZombieStreamCanceller()
 	t0 := time.Now()
 
-	if !z.shouldCancel("req-1", t0) {
+	if !z.record("req-1", t0).sendCancel {
 		t.Fatal("first chunk for an unknown request should cancel")
 	}
-	if z.shouldCancel("req-1", t0.Add(time.Second)) {
+	if z.record("req-1", t0.Add(time.Second)).sendCancel {
 		t.Fatal("second chunk within the throttle window should NOT re-cancel")
 	}
 	// A different request is independent.
-	if !z.shouldCancel("req-2", t0.Add(time.Second)) {
+	if !z.record("req-2", t0.Add(time.Second)).sendCancel {
 		t.Fatal("a different unknown request should cancel")
 	}
 	// After the throttle window, the same request cancels again.
-	if !z.shouldCancel("req-1", t0.Add(zombieCancelThrottle+time.Second)) {
+	if !z.record("req-1", t0.Add(zombieCancelThrottle+time.Second)).sendCancel {
 		t.Fatal("after the throttle window the same request should cancel again")
+	}
+}
+
+func TestZombieStreamCancellerEscalatesAfterRepeatedCancels(t *testing.T) {
+	z := newZombieStreamCanceller()
+	t0 := time.Now()
+
+	first := z.record("req-1", t0)
+	if !first.sendCancel || first.forceReconnect {
+		t.Fatalf("first abandoned chunk action = %+v, want cancel without reconnect", first)
+	}
+
+	second := z.record("req-1", t0.Add(zombieCancelThrottle+time.Second))
+	if !second.sendCancel || second.forceReconnect {
+		t.Fatalf("second abandoned chunk action = %+v, want cancel without reconnect", second)
+	}
+
+	third := z.record("req-1", t0.Add(2*zombieCancelThrottle+2*time.Second))
+	if !third.sendCancel || !third.forceReconnect {
+		t.Fatalf("third abandoned chunk action = %+v, want cancel and reconnect", third)
 	}
 }
 
@@ -29,7 +51,7 @@ func TestZombieStreamCancellerSweepBounded(t *testing.T) {
 	z := newZombieStreamCanceller()
 	base := time.Now()
 	for i := 0; i < 5000; i++ {
-		z.shouldCancel(string(rune('a'+i%26))+string(rune('0'+i%10))+string(rune(i)), base)
+		z.record(string(rune('a'+i%26))+string(rune('0'+i%10))+string(rune(i)), base)
 	}
 	z.mu.Lock()
 	n := len(z.sent)
@@ -39,12 +61,49 @@ func TestZombieStreamCancellerSweepBounded(t *testing.T) {
 	}
 
 	// All those are expired relative to a far-future call, which triggers the sweep.
-	z.shouldCancel("trigger", base.Add(zombieCancelThrottle+time.Hour))
+	z.record("trigger", base.Add(zombieCancelThrottle+time.Hour))
 	z.mu.Lock()
 	n = len(z.sent)
 	z.mu.Unlock()
 	if n > zombieCancelMaxEntries {
 		t.Fatalf("map not bounded after sweep: %d entries", n)
+	}
+}
+
+func TestDeliverChunkWithBackpressureDelivers(t *testing.T) {
+	pr := &registry.PendingRequest{ChunkCh: make(chan string, 1)}
+
+	delivered, closed := deliverChunkWithBackpressure(pr, "chunk")
+	if !delivered || closed {
+		t.Fatalf("deliverChunkWithBackpressure = delivered:%v closed:%v, want delivered open", delivered, closed)
+	}
+	if got := <-pr.ChunkCh; got != "chunk" {
+		t.Fatalf("delivered chunk = %q, want chunk", got)
+	}
+}
+
+func TestDeliverChunkWithBackpressureFailsInsteadOfDropping(t *testing.T) {
+	pr := &registry.PendingRequest{ChunkCh: make(chan string)}
+
+	delivered, closed := deliverChunkWithBackpressure(pr, "chunk")
+	if delivered || closed {
+		t.Fatalf("deliverChunkWithBackpressure = delivered:%v closed:%v, want backpressure failure", delivered, closed)
+	}
+	select {
+	case got := <-pr.ChunkCh:
+		t.Fatalf("chunk was delivered despite backpressure: %q", got)
+	default:
+	}
+}
+
+func TestDeliverChunkWithBackpressureDetectsClosedChannel(t *testing.T) {
+	ch := make(chan string)
+	close(ch)
+	pr := &registry.PendingRequest{ChunkCh: ch}
+
+	delivered, closed := deliverChunkWithBackpressure(pr, "chunk")
+	if delivered || !closed {
+		t.Fatalf("deliverChunkWithBackpressure = delivered:%v closed:%v, want closed", delivered, closed)
 	}
 }
 

--- a/coordinator/registry/config.go
+++ b/coordinator/registry/config.go
@@ -3,6 +3,8 @@ package registry
 import (
 	"fmt"
 	"os"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/eigeninference/d-inference/coordinator/env"
@@ -50,6 +52,10 @@ type WarmPoolConfig struct {
 	FallbackQualityConcurrency int
 	AssumedPromptTokens        int
 	AssumedCompletionTokens    int
+	// MinWarmByModel is an operator floor for concrete model IDs, e.g.
+	// EIGENINFERENCE_WARM_POOL_MIN_WARM="gpt-oss-20b=4,gemma-4-26b-qat-4bit=2".
+	// Floors are capped by warm+eligibleCold and still obey load throttles.
+	MinWarmByModel map[string]int
 
 	// Ramp shaping. MaxLoadsPerTick is the baseline per-tick load burst;
 	// RampGapFraction scales the burst up with the remaining target gap, bounded
@@ -98,6 +104,7 @@ func ReadConfig() Config {
 			FallbackQualityConcurrency: env.EnvInt(env.EnvPrefix+"_WARM_POOL_FALLBACK_QUALITY_CONCURRENCY", 4),
 			AssumedPromptTokens:        env.EnvInt(env.EnvPrefix+"_WARM_POOL_ASSUMED_PROMPT_TOKENS", 512),
 			AssumedCompletionTokens:    env.EnvInt(env.EnvPrefix+"_WARM_POOL_ASSUMED_COMPLETION_TOKENS", 256),
+			MinWarmByModel:             envModelIntMap(env.EnvPrefix + "_WARM_POOL_MIN_WARM"),
 
 			MaxLoadsPerTick:        env.EnvInt(env.EnvPrefix+"_WARM_POOL_MAX_LOADS_PER_TICK", 4),
 			MaxLoadsPerTickCeiling: env.EnvInt(env.EnvPrefix+"_WARM_POOL_MAX_LOADS_PER_TICK_CEILING", 16),
@@ -151,6 +158,37 @@ func (c CacheAffinityConfig) Check() error {
 		return fmt.Errorf("registry: cache affinity bonus must be <= 10000ms")
 	}
 	return nil
+}
+
+func envModelIntMap(key string) map[string]int {
+	raw := strings.TrimSpace(os.Getenv(key))
+	if raw == "" {
+		return nil
+	}
+	out := make(map[string]int)
+	for _, entry := range strings.Split(raw, ",") {
+		entry = strings.TrimSpace(entry)
+		if entry == "" {
+			continue
+		}
+		model, value, ok := strings.Cut(entry, "=")
+		if !ok {
+			continue
+		}
+		model = strings.TrimSpace(model)
+		if model == "" {
+			continue
+		}
+		n, err := strconv.Atoi(strings.TrimSpace(value))
+		if err != nil || n <= 0 {
+			continue
+		}
+		out[model] = n
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 func (c WarmPoolConfig) Check() error {

--- a/coordinator/registry/config_test.go
+++ b/coordinator/registry/config_test.go
@@ -22,6 +22,7 @@ func clearWarmPoolEnv(t *testing.T) {
 		"WARM_POOL_SPECULATIVE_WIN_THRESHOLD",
 		"WARM_POOL_COLD_DISPATCH_THRESHOLD",
 		"WARM_POOL_LOAD_DURATION_THRESHOLD",
+		"WARM_POOL_MIN_WARM",
 		"WARM_POOL_MAX_LOADS_PER_TICK",
 		"WARM_POOL_MAX_GLOBAL_PENDING_LOADS",
 	}
@@ -51,6 +52,25 @@ func TestReadConfigWarmPoolDefaultsActive(t *testing.T) {
 	}
 	if cfg.MaxGlobalPendingLoads != 16 {
 		t.Fatalf("MaxGlobalPendingLoads = %d, want 16", cfg.MaxGlobalPendingLoads)
+	}
+}
+
+func TestReadConfigWarmPoolMinWarmByModel(t *testing.T) {
+	clearWarmPoolEnv(t)
+	t.Setenv(env.EnvPrefix+"_WARM_POOL_MIN_WARM", "gpt-oss-20b=4, bad, gemma=0, other=-1, qwen=2")
+
+	got := ReadConfig().WarmPool.MinWarmByModel
+	if got["gpt-oss-20b"] != 4 {
+		t.Fatalf("gpt-oss floor = %d, want 4", got["gpt-oss-20b"])
+	}
+	if got["qwen"] != 2 {
+		t.Fatalf("qwen floor = %d, want 2", got["qwen"])
+	}
+	if _, ok := got["gemma"]; ok {
+		t.Fatal("zero min-warm entry should be ignored")
+	}
+	if _, ok := got["other"]; ok {
+		t.Fatal("negative min-warm entry should be ignored")
 	}
 }
 

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -438,7 +438,52 @@ type Provider struct {
 	CodeAttested bool
 
 	mu          sync.Mutex
+	writeGate   chan struct{}
 	pendingReqs map[string]*PendingRequest
+}
+
+// Write sends one WebSocket message to the provider, serializing all coordinator
+// writers before they enter nhooyr's connection-level write path. This matters
+// because nhooyr closes the whole connection when a write context expires; a
+// caller timing out while merely queued behind another writer must not kill the
+// provider socket.
+func (p *Provider) Write(ctx context.Context, typ websocket.MessageType, data []byte) error {
+	return p.WriteWithContexts(ctx, ctx, typ, data)
+}
+
+// WriteWithContexts is Write with separate contexts for waiting on the
+// coordinator-side serialization gate and for the actual nhooyr write. This is
+// needed for request dispatch: timeout while queued behind another coordinator
+// writer must not pass a cancelled context into nhooyr.Conn.Write, because
+// nhooyr treats write-context expiry as connection-fatal.
+func (p *Provider) WriteWithContexts(gateCtx context.Context, writeCtx context.Context, typ websocket.MessageType, data []byte) error {
+	if gateCtx == nil {
+		gateCtx = context.Background()
+	}
+	if writeCtx == nil {
+		writeCtx = context.Background()
+	}
+
+	p.mu.Lock()
+	conn := p.Conn
+	if p.writeGate == nil {
+		p.writeGate = make(chan struct{}, 1)
+	}
+	gate := p.writeGate
+	p.mu.Unlock()
+
+	if conn == nil {
+		return fmt.Errorf("provider %q has no active connection", p.ID)
+	}
+
+	select {
+	case gate <- struct{}{}:
+		defer func() { <-gate }()
+	case <-gateCtx.Done():
+		return gateCtx.Err()
+	}
+
+	return conn.Write(writeCtx, typ, data)
 }
 
 // providerSupportsPrivateTextLocked is the SINGLE routing chokepoint for
@@ -2362,6 +2407,7 @@ func (r *Registry) Register(id string, conn *websocket.Conn, msg *protocol.Regis
 		Conn:                    conn,
 		LastHeartbeat:           time.Now(),
 		Reputation:              NewReputation(),
+		writeGate:               make(chan struct{}, 1),
 		pendingReqs:             make(map[string]*PendingRequest),
 		challengeSettled:        make(chan struct{}, 1),
 	}
@@ -2630,15 +2676,7 @@ func (r *Registry) SendLoadModel(providerID, modelID string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	p.mu.Lock()
-	conn := p.Conn
-	p.mu.Unlock()
-
-	if conn == nil {
-		return fmt.Errorf("provider %q has no active connection", providerID)
-	}
-
-	if err := conn.Write(ctx, websocket.MessageText, data); err != nil {
+	if err := p.Write(ctx, websocket.MessageText, data); err != nil {
 		return fmt.Errorf("failed to send load_model to provider %q: %w", providerID, err)
 	}
 
@@ -2678,15 +2716,7 @@ func (r *Registry) SendPrefetchModel(providerID, modelID string, priority int) e
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	p.mu.Lock()
-	conn := p.Conn
-	p.mu.Unlock()
-
-	if conn == nil {
-		return fmt.Errorf("provider %q has no active connection", providerID)
-	}
-
-	if err := conn.Write(ctx, websocket.MessageText, data); err != nil {
+	if err := p.Write(ctx, websocket.MessageText, data); err != nil {
 		return fmt.Errorf("failed to send prefetch_model to provider %q: %w", providerID, err)
 	}
 
@@ -2736,15 +2766,7 @@ func (r *Registry) SendDesiredModels(providerID string, entries []protocol.Desir
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	p.mu.Lock()
-	conn := p.Conn
-	p.mu.Unlock()
-
-	if conn == nil {
-		return fmt.Errorf("provider %q has no active connection", providerID)
-	}
-
-	if err := conn.Write(ctx, websocket.MessageText, data); err != nil {
+	if err := p.Write(ctx, websocket.MessageText, data); err != nil {
 		return fmt.Errorf("failed to send desired_models to provider %q: %w", providerID, err)
 	}
 

--- a/coordinator/registry/registry_test.go
+++ b/coordinator/registry/registry_test.go
@@ -3,9 +3,13 @@ package registry
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
+	"net/http"
+	"net/http/httptest"
 	"os"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -13,6 +17,7 @@ import (
 	"github.com/eigeninference/d-inference/coordinator/attestation"
 	"github.com/eigeninference/d-inference/coordinator/protocol"
 	"github.com/eigeninference/d-inference/coordinator/store"
+	"nhooyr.io/websocket"
 )
 
 func testLogger() *slog.Logger {
@@ -66,6 +71,46 @@ func testMakeTextRoutable(p *Provider) {
 	p.ChallengeVerifiedSIP = true
 	p.RuntimeManifestChecked = true
 	p.ChallengeVerifiedSIP = true
+}
+
+func TestProviderWriteWithContextsTimesOutWaitingForGate(t *testing.T) {
+	serverConnCh := make(chan *websocket.Conn, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			t.Errorf("accept websocket: %v", err)
+			return
+		}
+		serverConnCh <- conn
+	}))
+	defer server.Close()
+
+	dialCtx, cancelDial := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancelDial()
+	clientConn, _, err := websocket.Dial(dialCtx, "ws"+strings.TrimPrefix(server.URL, "http"), nil)
+	if err != nil {
+		t.Fatalf("dial websocket: %v", err)
+	}
+	defer clientConn.Close(websocket.StatusNormalClosure, "done")
+
+	var serverConn *websocket.Conn
+	select {
+	case serverConn = <-serverConnCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for server websocket")
+	}
+	defer serverConn.Close(websocket.StatusNormalClosure, "done")
+
+	gate := make(chan struct{}, 1)
+	gate <- struct{}{}
+	provider := &Provider{ID: "p1", Conn: serverConn, writeGate: gate}
+
+	gateCtx, cancelGate := context.WithTimeout(context.Background(), time.Millisecond)
+	defer cancelGate()
+	err = provider.WriteWithContexts(gateCtx, context.Background(), websocket.MessageText, []byte("blocked"))
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("WriteWithContexts error = %v, want context deadline exceeded", err)
+	}
 }
 
 // TestCodeAttestationGate verifies the v0.6.0 APNs code-identity gate at the

--- a/coordinator/registry/warm_pool_controller.go
+++ b/coordinator/registry/warm_pool_controller.go
@@ -387,6 +387,12 @@ func (c *warmPoolController) targetWarm(fleet warmPoolModelSnapshot, pressure wa
 			target = maxReachable
 		}
 	}
+	if floor := c.config.MinWarmByModel[fleet.model]; floor > target {
+		target = floor
+		if maxReachable := fleet.warm + len(fleet.eligibleCold); target > maxReachable {
+			target = maxReachable
+		}
+	}
 	return target
 }
 

--- a/coordinator/registry/warm_pool_controller_test.go
+++ b/coordinator/registry/warm_pool_controller_test.go
@@ -218,6 +218,49 @@ func TestWarmPoolNoPressureForLongActiveDecodeAlone(t *testing.T) {
 	}
 }
 
+func TestWarmPoolMinWarmFloorLoadsWithoutPressure(t *testing.T) {
+	reg := New(testLogger())
+	model := "warm-pool-min-floor"
+	makeSchedulerProvider(t, reg, "warm", model, 80)
+	makeWarmPoolColdProvider(t, reg, "cold-a", model, 80, 64, 8)
+	makeWarmPoolColdProvider(t, reg, "cold-b", model, 80, 64, 8)
+	cfg := testWarmPoolConfig()
+	cfg.MinWarmByModel = map[string]int{model: 3}
+	reg.ConfigureWarmPool(cfg)
+	sent := captureWarmPoolLoads(reg)
+
+	snaps := reg.warmPool.tick(time.Now())
+
+	if len(snaps) != 1 {
+		t.Fatalf("snapshots = %d, want 1", len(snaps))
+	}
+	if snaps[0].TargetWarm != 3 {
+		t.Fatalf("TargetWarm = %d, want min floor 3", snaps[0].TargetWarm)
+	}
+	if len(*sent) != 1 {
+		t.Fatalf("sent loads = %d, want 1 (bounded by MaxLoadsPerTick)", len(*sent))
+	}
+}
+
+func TestWarmPoolMinWarmFloorCapsAtReachable(t *testing.T) {
+	reg := New(testLogger())
+	model := "warm-pool-min-floor-cap"
+	makeSchedulerProvider(t, reg, "warm", model, 80)
+	makeWarmPoolColdProvider(t, reg, "cold", model, 80, 64, 8)
+	cfg := testWarmPoolConfig()
+	cfg.MinWarmByModel = map[string]int{model: 5}
+	reg.ConfigureWarmPool(cfg)
+
+	snaps := reg.warmPool.tick(time.Now())
+
+	if len(snaps) != 1 {
+		t.Fatalf("snapshots = %d, want 1", len(snaps))
+	}
+	if snaps[0].TargetWarm != 2 {
+		t.Fatalf("TargetWarm = %d, want reachable cap 2", snaps[0].TargetWarm)
+	}
+}
+
 func TestWarmPoolFleetSnapshotUsesObservedSlotTPS(t *testing.T) {
 	reg := New(testLogger())
 	model := "warm-pool-observed-tps"

--- a/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClient.swift
+++ b/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClient.swift
@@ -503,6 +503,11 @@ public actor CoordinatorClient {
     /// after base64 expansion (×4/3 ≈ 21.3 MiB).
     static let maxInboundMessageBytes = 32 * 1024 * 1024
 
+    /// Keep provider→coordinator frames below the coordinator's 32 MiB read
+    /// limit. One oversized encrypted SSE chunk should fail that request, not
+    /// close the shared provider WebSocket and kill every in-flight request.
+    static let maxOutboundMessageBytes = 30 * 1024 * 1024
+
     /// Raise a task's inbound message limit to ``maxInboundMessageBytes``. Factored
     /// out so a unit test can assert the limit is applied without opening a live
     /// socket.
@@ -760,6 +765,10 @@ public actor CoordinatorClient {
                     let shutting = await self.shutdownRequested
                     if shutting { break }
                     let json = await self.encodeOutbound(msg)
+                    guard json.utf8.count <= Self.maxOutboundMessageBytes else {
+                        await self.handleOversizedOutboundFrame(msg, byteCount: json.utf8.count, ws: ws)
+                        continue
+                    }
                     try await ws.send(.string(json))
                 }
             }
@@ -1034,6 +1043,21 @@ public actor CoordinatorClient {
 
     private func encodeOutbound(_ msg: OutboundMessage) -> String {
         (try? CoordinatorClientCodec.encodeOutboundMessageString(msg)) ?? "{}"
+    }
+
+    private func handleOversizedOutboundFrame(_ msg: OutboundMessage, byteCount: Int, ws: URLSessionWebSocketTask) async {
+        logger.error("Outbound WebSocket frame too large: \(byteCount) bytes")
+        switch msg {
+        case .inferenceChunk(let requestId, _, _):
+            let errorJSON = encodeInferenceError(
+                requestId: requestId,
+                error: "response chunk exceeded transport frame limit",
+                statusCode: 502
+            )
+            try? await ws.send(.string(errorJSON))
+        default:
+            ws.cancel(with: .messageTooBig, reason: nil)
+        }
     }
 
     private func encodeInferenceError(requestId: String, error: String, statusCode: UInt16) -> String {

--- a/provider-swift/Tests/ProviderCoreTests/CoordinatorClientTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/CoordinatorClientTests.swift
@@ -379,6 +379,11 @@ import Testing
     #expect(ws.maximumMessageSize >= 22 * 1024 * 1024)
 }
 
+@Test func outboundMessageLimitStaysBelowCoordinatorReadLimit() {
+    #expect(CoordinatorClient.maxOutboundMessageBytes < CoordinatorClient.maxInboundMessageBytes)
+    #expect(CoordinatorClient.maxOutboundMessageBytes >= 20 * 1024 * 1024)
+}
+
 private func clientSampleHardware() -> HardwareInfo {
     HardwareInfo(
         machineModel: "Mac16,5",


### PR DESCRIPTION
## Summary
- stacked on #402 and uses its `writeProviderInferenceRequest` path instead of carrying a competing dispatch-write implementation
- routes #402's request writes plus cancels/control messages through the serialized `Provider.Write` gate
- aligns provider WebSocket frame limits and adds a provider outbound frame cap so oversized chunks fail a request instead of tearing down the shared socket
- replaces silent chunk drops with bounded backpressure failure + provider cancel
- escalates repeated zombie streams from throttled cancels to a forced reconnect
- adds bounded registration and MDM/APNs verification lanes to reduce reconnect-storm fan-out
- keeps unauthenticated provider sockets at a 1 MiB read cap and raises to 32 MiB only after a valid register message

## Tests
- `go test ./api -run 'TestProviderWebSocketReadLimitRaisesAfterRegister|TestWriteProviderInferenceRequestIgnoresConsumerCancel'`
- `go test ./api`
- `go test ./registry`
- Swift test was previously attempted in this worktree but blocked by local disk exhaustion compiling MLX dependencies (`No space left on device`); Swift sanity check for `.messageTooBig` passed with a local module cache

Part of #400. Stacked on #402.
