### PR TITLE
fix(coordinator): add model-shed admission circuit breaker

### DIFF
--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -100,6 +100,48 @@ func ttftDeadline(estimatedPromptTokens int) time.Duration {
 	return base + perToken
 }
 
+// shedIfModelRejected answers a public/prefer-owner request with 429 +
+// Retry-After when its requested alias or resolved build is in the operator
+// reject set (EIGENINFERENCE_REJECT_MODELS). This is a deterministic
+// per-model circuit breaker: it takes an unhealthy model out of rotation before
+// rate-limit, reservation, or routing work, so aggregators see rate limiting
+// rather than dropped/cancelled streams. Exclusive self-route bypasses the shed
+// because it never falls back to the public fleet.
+func (s *Server) shedIfModelRejected(w http.ResponseWriter, r *http.Request, parsed map[string]any, policy selfRoutePolicy, publicModel, model string, stream bool, estimatedPromptTokens, requestedMaxTokens int, requiresVision, hasTools bool) bool {
+	if policy.enabled || !s.modelShed(model, publicModel) {
+		return false
+	}
+	retryAfter := s.estimateRetryAfter(model)
+	if retryAfter <= 0 {
+		retryAfter = 30
+	}
+	s.ddIncr("routing.decisions", []string{"model:" + model, "model_type:" + s.registry.ModelType(model), "outcome:model_shed"})
+	s.recordRejection(rejectionInfo{
+		r:                     r,
+		stage:                 "model_shed",
+		reasonCode:            "model_shed",
+		httpStatus:            http.StatusTooManyRequests,
+		keyID:                 keyIDFromContext(r.Context()),
+		consumerKeyHash:       store.HashKey(consumerKeyFromContext(r.Context())),
+		requestedModel:        publicModel,
+		resolvedModel:         model,
+		stream:                stream,
+		estimatedPromptTokens: estimatedPromptTokens,
+		requestedMaxTokens:    requestedMaxTokens,
+		requiresVision:        requiresVision,
+		hasTools:              hasTools,
+		selfRouteOnly:         policy.enabled,
+		preferOwner:           policy.prefer,
+		retryAfterMs:          retryAfter * 1000,
+		params:                rejectionSamplingParams(parsed),
+	})
+	w.Header().Set("Retry-After", strconv.Itoa(retryAfter))
+	writeJSON(w, http.StatusTooManyRequests, errorResponse("rate_limit_exceeded",
+		fmt.Sprintf("model %q is temporarily rate-limited — retry after %ds", publicModel, retryAfter),
+		withCode("rate_limit_exceeded")))
+	return true
+}
+
 // sendProviderCancel sends a Cancel message for the given request to the
 // provider with a bounded timeout so a half-dead WebSocket doesn't hang the
 // caller. Errors are logged at debug level because a disconnect race is the
@@ -314,6 +356,9 @@ func (s *Server) maybeFallbackAliasCapacity(parsed map[string]any, publicModel, 
 	if !ok || target.Desired != currentModel || target.Previous == "" {
 		return currentModel, 0, 0, 0, 0, false, false
 	}
+	if s.modelShed(target.Previous, publicModel) {
+		return currentModel, 0, 0, 0, 0, false, false
+	}
 	if !s.registry.IsModelInCatalog(target.Previous) {
 		return currentModel, 0, 0, 0, 0, false, false
 	}
@@ -331,6 +376,9 @@ func (s *Server) maybeFallbackAliasTTFT(parsed map[string]any, publicModel, curr
 	}
 	target, ok := s.registry.AliasTarget(publicModel)
 	if !ok || target.Desired != currentModel || target.Previous == "" {
+		return currentModel, 0, 0, 0, 0, false, false
+	}
+	if s.modelShed(target.Previous, publicModel) {
 		return currentModel, 0, 0, 0, 0, false, false
 	}
 	if !s.registry.IsModelInCatalog(target.Previous) {
@@ -1713,6 +1761,9 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 	requestedMaxTokens := estimateRequestedMaxTokens(parsed)
 	deadline := ttftDeadline(estimatedPromptTokens)
 	timing.ParsedAt = time.Now()
+	if s.shedIfModelRejected(w, r, parsed, policy, publicModel, model, stream, estimatedPromptTokens, requestedMaxTokens, requiresVision, hasTools) {
+		return
+	}
 
 	if isResponsesAPI {
 		providerParsed, err := responsesRequestToChatCompletions(parsed)
@@ -4569,6 +4620,9 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 	requestedMaxTokens := estimateRequestedMaxTokens(parsed)
 	genericDeadline := ttftDeadline(estimatedPromptTokens)
 	timing.ParsedAt = time.Now()
+	if s.shedIfModelRejected(w, r, parsed, policy, publicModel, model, stream, estimatedPromptTokens, requestedMaxTokens, requiresVision, hasTools) {
+		return
+	}
 
 	// Inject the endpoint so the provider knows which local path to forward to.
 	parsed["endpoint"] = endpoint

--- a/coordinator/api/consumer_test.go
+++ b/coordinator/api/consumer_test.go
@@ -2236,3 +2236,51 @@ func TestMaybeFallbackAliasTTFTSwitchesToPrevious(t *testing.T) {
 		t.Fatalf("bestTTFT = %v has=%v, want within threshold", bestTTFT, hasTTFT)
 	}
 }
+
+func TestMaybeFallbackAliasTTFTSkipsRejectedPrevious(t *testing.T) {
+	srv, _ := testServer(t)
+	publicModel := "public-ttft-shed-alias"
+	desired := "desired-ttft-shed-build"
+	previous := "previous-ttft-shed-build"
+	srv.SetRejectModels(map[string]bool{previous: true})
+	srv.registry.SetModelCatalog([]registry.CatalogEntry{
+		{ID: desired, SizeGB: 1, MinRAMGB: 24},
+		{ID: previous, SizeGB: 1, MinRAMGB: 24},
+	})
+	srv.registry.SetModelAliases(map[string]registry.AliasTarget{
+		publicModel: {Desired: desired, Previous: previous},
+	})
+	registerBuildsProvider(srv, "previous-fast-shed", previous)
+	parsed := map[string]any{"model": desired}
+
+	fallbackModel, _, _, _, _, _, switched := srv.maybeFallbackAliasTTFT(
+		parsed, publicModel, desired, 100, 128, ttftDeadline(100), registry.RequestTraits{}, false, nil)
+
+	if switched || fallbackModel != desired || parsed["model"] != desired {
+		t.Fatalf("fallback switched to rejected previous: switched=%v fallback=%q parsed=%v", switched, fallbackModel, parsed)
+	}
+}
+
+func TestMaybeFallbackAliasCapacitySkipsRejectedPrevious(t *testing.T) {
+	srv, _ := testServer(t)
+	publicModel := "public-capacity-shed-alias"
+	desired := "desired-capacity-shed-build"
+	previous := "previous-capacity-shed-build"
+	srv.SetRejectModels(map[string]bool{previous: true})
+	srv.registry.SetModelCatalog([]registry.CatalogEntry{
+		{ID: desired, SizeGB: 1, MinRAMGB: 24},
+		{ID: previous, SizeGB: 1, MinRAMGB: 24},
+	})
+	srv.registry.SetModelAliases(map[string]registry.AliasTarget{
+		publicModel: {Desired: desired, Previous: previous},
+	})
+	registerBuildsProvider(srv, "previous-capacity-shed", previous)
+	parsed := map[string]any{"model": desired}
+
+	fallbackModel, _, _, _, _, _, switched := srv.maybeFallbackAliasCapacity(
+		parsed, publicModel, desired, 100, 128, registry.RequestTraits{}, false, nil)
+
+	if switched || fallbackModel != desired || parsed["model"] != desired {
+		t.Fatalf("capacity fallback switched to rejected previous: switched=%v fallback=%q parsed=%v", switched, fallbackModel, parsed)
+	}
+}

--- a/coordinator/api/model_shed_test.go
+++ b/coordinator/api/model_shed_test.go
@@ -1,0 +1,103 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func modelShedRequest() *http.Request {
+	return httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(`{}`))
+}
+
+func waitForRejectionCount(t *testing.T, srv *Server, want int) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if got := len(srv.store.RejectionRecordsSince(time.Time{})); got >= want {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("rejection records = %d, want >= %d", len(srv.store.RejectionRecordsSince(time.Time{})), want)
+}
+
+func TestModelShedRejectsRequestedAlias(t *testing.T) {
+	srv, st := testServer(t)
+	srv.SetRejectModels(map[string]bool{"gemma-4-26b": true})
+	w := httptest.NewRecorder()
+
+	if !srv.shedIfModelRejected(w, modelShedRequest(), map[string]any{"temperature": 0.2}, selfRoutePolicy{}, "gemma-4-26b", "gemma-4-26b-qat-4bit", true, 1200, 256, false, true) {
+		t.Fatal("shedIfModelRejected = false, want true")
+	}
+	if w.Code != http.StatusTooManyRequests {
+		t.Fatalf("status = %d, want 429", w.Code)
+	}
+	if w.Header().Get("Retry-After") == "" {
+		t.Fatal("Retry-After header missing")
+	}
+	if !strings.Contains(w.Body.String(), "rate_limit_exceeded") {
+		t.Fatalf("body = %s, want rate_limit_exceeded", w.Body.String())
+	}
+	waitForRejectionCount(t, srv, 1)
+	recs := st.RejectionRecordsSince(time.Time{})
+	if got := recs[0].ReasonCode; got != "model_shed" {
+		t.Fatalf("ReasonCode = %q, want model_shed", got)
+	}
+	if got := recs[0].RequestedModel; got != "gemma-4-26b" {
+		t.Fatalf("RequestedModel = %q", got)
+	}
+	if got := recs[0].ResolvedModel; got != "gemma-4-26b-qat-4bit" {
+		t.Fatalf("ResolvedModel = %q", got)
+	}
+	if !recs[0].Stream || !recs[0].HasTools || recs[0].RetryAfterMs <= 0 {
+		t.Fatalf("record fields = %+v", recs[0])
+	}
+}
+
+func TestModelShedRejectsResolvedConcreteModel(t *testing.T) {
+	srv, _ := testServer(t)
+	srv.SetRejectModels(map[string]bool{"gemma-4-26b-qat-4bit": true})
+	w := httptest.NewRecorder()
+
+	if !srv.shedIfModelRejected(w, modelShedRequest(), nil, selfRoutePolicy{}, "gemma-4-26b", "gemma-4-26b-qat-4bit", false, 100, 64, false, false) {
+		t.Fatal("shedIfModelRejected = false, want true")
+	}
+	if w.Code != http.StatusTooManyRequests {
+		t.Fatalf("status = %d, want 429", w.Code)
+	}
+}
+
+func TestModelShedDoesNotRejectOtherModels(t *testing.T) {
+	srv, _ := testServer(t)
+	srv.SetRejectModels(map[string]bool{"gemma-4-26b": true})
+	w := httptest.NewRecorder()
+
+	if srv.shedIfModelRejected(w, modelShedRequest(), nil, selfRoutePolicy{}, "gpt-oss-20b", "gpt-oss-20b", false, 100, 64, false, false) {
+		t.Fatal("shedIfModelRejected = true for non-shed model")
+	}
+	if w.Code == http.StatusTooManyRequests {
+		t.Fatal("non-shed model was written as a 429")
+	}
+}
+
+func TestModelShedPolicySelfRouteBypassesPreferOwnerSheds(t *testing.T) {
+	srv, st := testServer(t)
+	srv.SetRejectModels(map[string]bool{"gemma-4-26b": true})
+	self := httptest.NewRecorder()
+	prefer := httptest.NewRecorder()
+
+	if srv.shedIfModelRejected(self, modelShedRequest(), nil, selfRoutePolicy{enabled: true}, "gemma-4-26b", "gemma-4-26b-qat-4bit", false, 100, 64, false, false) {
+		t.Fatal("exclusive self-route should bypass model shed")
+	}
+	if !srv.shedIfModelRejected(prefer, modelShedRequest(), nil, selfRoutePolicy{prefer: true}, "gemma-4-26b", "gemma-4-26b-qat-4bit", false, 100, 64, false, false) {
+		t.Fatal("prefer-owner should be model-shed because it can fall back to public fleet")
+	}
+	waitForRejectionCount(t, srv, 1)
+	rec := st.RejectionRecordsSince(time.Time{})[0]
+	if !rec.PreferOwner || rec.SelfRouteOnly {
+		t.Fatalf("policy telemetry = %+v", rec)
+	}
+}

--- a/coordinator/api/server.go
+++ b/coordinator/api/server.go
@@ -217,6 +217,15 @@ type Server struct {
 	// (EIGENINFERENCE_TTFT_HARD_REJECT=true) to restore the legacy hard 429.
 	ttftHardReject bool
 
+	// rejectModels are requested aliases or resolved model IDs the coordinator
+	// takes out of public/prefer-owner routing: every matching request is answered
+	// with 429 + Retry-After at admission instead of being routed. This is a
+	// deterministic per-model circuit breaker for unhealthy models (for example,
+	// keep Gemma shed while allowing gpt-oss traffic with TTFT_HARD_REJECT=false).
+	// Exclusive self-route bypasses this because it never falls back to the public
+	// fleet and is useful for owner debugging. nil/empty = none.
+	rejectModels map[string]bool
+
 	// minDecodeTPS is the per-request sustained-decode floor (tokens/sec) passed
 	// to the scheduler as PendingRequest.MinDecodeTPS. When > 0 the router prefers
 	// providers that keep a newly admitted request at >= this rate (avoid
@@ -986,6 +995,38 @@ func (s *Server) SetBinaryHashEnforcement(enabled bool) {
 // the ttftHardReject field for rationale. Call before serving starts.
 func (s *Server) SetTTFTHardReject(enabled bool) {
 	s.ttftHardReject = enabled
+}
+
+// SetRejectModels sets the requested/resolved model IDs to 429 at public
+// admission. Call before serving starts.
+func (s *Server) SetRejectModels(models map[string]bool) {
+	if len(models) == 0 {
+		s.rejectModels = nil
+		return
+	}
+	copy := make(map[string]bool, len(models))
+	for model, reject := range models {
+		if !reject {
+			continue
+		}
+		model = strings.TrimSpace(model)
+		if model == "" {
+			continue
+		}
+		copy[model] = true
+	}
+	if len(copy) == 0 {
+		s.rejectModels = nil
+		return
+	}
+	s.rejectModels = copy
+}
+
+func (s *Server) modelShed(resolved, requested string) bool {
+	if len(s.rejectModels) == 0 {
+		return false
+	}
+	return s.rejectModels[resolved] || s.rejectModels[requested]
 }
 
 // SetMinDecodeTPS sets the per-request sustained-decode floor (tokens/sec) the

--- a/coordinator/cmd/coordinator/main.go
+++ b/coordinator/cmd/coordinator/main.go
@@ -303,6 +303,23 @@ func main() {
 		logger.Warn("TTFT hard-reject ENABLED via EIGENINFERENCE_TTFT_HARD_REJECT (legacy 429-on-slow-estimate; soft preference is the default)")
 	}
 
+	// Routing: deterministic per-model shed list. These requested aliases/resolved
+	// builds return 429 + Retry-After at admission, before rate-limit/billing/routing.
+	// Use this for unhealthy models (e.g. Gemma 4) while keeping TTFT hard-reject
+	// disabled globally so healthy models like gpt-oss can keep flowing.
+	if v := os.Getenv("EIGENINFERENCE_REJECT_MODELS"); v != "" {
+		shed := map[string]bool{}
+		for _, name := range strings.Split(v, ",") {
+			if name = strings.TrimSpace(name); name != "" {
+				shed[name] = true
+			}
+		}
+		if len(shed) > 0 {
+			srv.SetRejectModels(shed)
+			logger.Warn("model shed ENABLED via EIGENINFERENCE_REJECT_MODELS (429 at admission)", "models", v)
+		}
+	}
+
 	// Routing: decode→prefill ratio fallback, used to estimate prefill TPS when a
 	// provider does not report a measured prefill_tps. Defaults to
 	// registry.defaultPrefillToDecodeRatio.


### PR DESCRIPTION
## Summary
- Add `EIGENINFERENCE_REJECT_MODELS`, a deterministic per-model admission circuit breaker that returns 429 + Retry-After before rate limit, billing, or routing.
- Check both requested alias and resolved concrete model ID.
- Add model-shed rejection telemetry (`stage=model_shed`, `reason_code=model_shed`).
- Preserve exclusive self-route bypass; prefer-owner remains shed because it can fall back to the public fleet.
- Prevent alias fallback to a rejected previous build.

## Why not TTFT_HARD_REJECT?
`TTFT_HARD_REJECT` is global and estimate-driven, and previously rejected healthy gpt-oss traffic. This feature lets us run `TTFT_HARD_REJECT=false` globally while shedding only unhealthy Gemma 4 models.

## Before
```mermaid
flowchart TD
  A[Request for Gemma alias] --> B[Resolve alias to concrete build]
  B --> C[Rate limit / billing reservation]
  C --> D[Routing / warm-pool / provider dispatch]
  D --> E[Slow or unhealthy model path]
  E --> F[client_gone / timeout / provider errors]
```

## After
```mermaid
flowchart TD
  A[Request for model] --> B[Resolve alias to concrete build]
  B --> C{Requested alias or resolved build in REJECT_MODELS?}
  C -->|yes| D[429 rate_limit_exceeded + Retry-After]
  D --> E[record rejection: model_shed]
  C -->|no| F[normal rate-limit / billing / routing]
```

## Config
```text
EIGENINFERENCE_REJECT_MODELS=gemma-4-26b-qat-4bit,gemma-4-26b
```

Use exact IDs; model IDs are not lowercased.

## Policy
- Exclusive self-route bypasses model shed because it never falls back to public fleet and is useful for owner debugging.
- Prefer-owner is shed because it can fall back to public fleet.

## Tests
- `go test ./coordinator/api -run "TestModelShed|TestMaybeFallbackAlias(TTFTSkipsRejectedPrevious|CapacitySkipsRejectedPrevious)"`
- `go test ./coordinator/...`

## Deployment note
Before deploying merged master to prod, set:
```text
EIGENINFERENCE_REJECT_MODELS=gemma-4-26b-qat-4bit,gemma-4-26b
EIGENINFERENCE_TTFT_HARD_REJECT=false
```
This preserves Gemma protection while opening healthy gpt-oss traffic.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/406"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784488901&installation_id=133247490&pr_number=406&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F406&signature=75e51a1ff9685b78bab7adc6e064c87263211000a30ead8f93d26f1dfb103a5c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->