### PR TITLE
Reclaim the MLX KV pool instead of shedding traffic (admission self-heal, cancel reclaim, orphan-row fix)

### DIFF
--- a/provider-swift/Sources/ProviderCore/Inference/BatchScheduler.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/BatchScheduler.swift
@@ -2057,11 +2057,19 @@ public actor BatchScheduler {
 
         if let engine = self.engine {
             _ = engine.core.abortAllRequests()
-            await engine.stop()
+            // Stop the loop AND wait for it to fully exit: this fences any in-flight
+            // step's MLX work and releases the loop's hold on the engine, so the
+            // teardown reclaim below is both safe and actually frees the batch KV.
+            await engine.core.stopAndWait()
         }
         self.engine = nil
         modelContainer = nil
         tokenizer = nil
+        // The engine chain is released above, so the batch KV is now in the
+        // reclaimable pool. Fence any async GPU completion before clearing, to
+        // avoid the M4 IOKit race.
+        MLX.Stream().synchronize()
+        MLX.Memory.clearCache()
         // Drain the bounded capture pipeline FIRST (#374): the engine is stopped
         // (no more capture hooks fire), so finish the stream and cancel the
         // consumer. This releases retained KV snapshots and stops an in-flight

--- a/provider-swift/Sources/ProviderCore/Inference/BatchScheduler.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/BatchScheduler.swift
@@ -1634,6 +1634,22 @@ public actor BatchScheduler {
 
     // MARK: - Submit / cancel
 
+    /// The scheduler token gate (`tokenBudgetMax`) counts MLX's reclaimable pool as
+    /// used, so a request can be rejected with `token_budget_exhausted` even though
+    /// flushing that pool would admit it — and that gate runs before the per-request
+    /// KV reservation (which has its own self-heal). Flush once here when the gate is
+    /// tight (rate-limited + shortfall-gated, sharing the reservation gate's limiter)
+    /// so the gate is re-evaluated against the reclaimed headroom. Call this BEFORE
+    /// reading `activeTokenBudgetUsed`, so its only suspension is outside the atomic
+    /// activeUsed→bridge section the cumulative gate relies on.
+    private func reclaimPoolForTokenBudget(requestBudget: Int) async {
+        guard kvBytesPerToken > 0, let kvBudget else { return }
+        let need = activeTokenBudgetUsed + requestBudget
+        guard need > tokenBudgetMax else { return }
+        let shortfallBytes = UInt64(need - tokenBudgetMax) * UInt64(kvBytesPerToken)
+        _ = await kvBudget.reclaimForShortfall(shortfallBytes)
+    }
+
     /// Submit a pre-tokenized prompt. Used by `MultiModelBatchSchedulerEngine`
     /// which tokenizes the full OpenAI request (including tools, tool_call_id,
     /// reasoning_content, etc.) itself, then hands the token IDs here.
@@ -1663,18 +1679,23 @@ public actor BatchScheduler {
         let submitEpoch = generationEpoch
 
         let requestBudget = promptTokens.count + maxTokens
-        guard requestBudget <= tokenBudgetMax else {
+        // Flush the reclaimable pool before the token gate if it's tight (the gate
+        // counts the pool as used). The await is here, before the atomic
+        // activeUsed→bridge section below, so it adds no reentrancy there.
+        await reclaimPoolForTokenBudget(requestBudget: requestBudget)
+        let budgetMax = tokenBudgetMax
+        guard requestBudget <= budgetMax else {
             continuation.yield(.error(
-                "token_budget_exhausted: request requires \(requestBudget) tokens but only \(tokenBudgetMax) available"
+                "token_budget_exhausted: request requires \(requestBudget) tokens but only \(budgetMax) available"
             ))
             continuation.finish()
             return stream
         }
 
         let activeUsed = activeTokenBudgetUsed
-        if activeUsed + requestBudget > tokenBudgetMax {
+        if activeUsed + requestBudget > budgetMax {
             continuation.yield(.error(
-                "token_budget_exhausted: request requires \(requestBudget) tokens but only \(tokenBudgetMax - activeUsed) available"
+                "token_budget_exhausted: request requires \(requestBudget) tokens but only \(budgetMax - activeUsed) available"
             ))
             continuation.finish()
             return stream
@@ -1829,9 +1850,14 @@ public actor BatchScheduler {
         )
 
         let requestBudget = promptTokens.count + maxTokens
-        guard requestBudget <= tokenBudgetMax else {
+        // Flush the reclaimable pool before the token gate if it's tight (the gate
+        // counts the pool as used). This await is intentionally before the atomic
+        // activeUsed→bridge section below, so it adds no reentrancy there.
+        await reclaimPoolForTokenBudget(requestBudget: requestBudget)
+        let budgetMax = tokenBudgetMax
+        guard requestBudget <= budgetMax else {
             continuation.yield(.error(
-                "token_budget_exhausted: request requires \(requestBudget) tokens but only \(tokenBudgetMax) available"
+                "token_budget_exhausted: request requires \(requestBudget) tokens but only \(budgetMax) available"
             ))
             continuation.finish()
             return stream
@@ -1849,9 +1875,9 @@ public actor BatchScheduler {
         // exit below (planner reject, KV reject) must roll back the
         // bridge via `dropBridge(...)`.
         let activeUsed = activeTokenBudgetUsed
-        if activeUsed + requestBudget > tokenBudgetMax {
+        if activeUsed + requestBudget > budgetMax {
             continuation.yield(.error(
-                "token_budget_exhausted: request requires \(requestBudget) tokens but only \(tokenBudgetMax - activeUsed) available"
+                "token_budget_exhausted: request requires \(requestBudget) tokens but only \(budgetMax - activeUsed) available"
             ))
             continuation.finish()
             return stream
@@ -2052,7 +2078,7 @@ public actor BatchScheduler {
         // engineStillCurrent (epoch already bumped, identity still matches) and get
         // enqueued onto an engine being torn down. Nil'ing it now makes those
         // submits fail the guard and reject/retry against the next model instead.
-        let stoppingEngine = self.engine
+        var stoppingEngine = self.engine
         self.engine = nil
         pendingTimeoutTask?.cancel()
         pendingTimeoutTask = nil
@@ -2066,17 +2092,15 @@ public actor BatchScheduler {
         if let engine = stoppingEngine {
             _ = engine.core.abortAllRequests()
             // Stop the loop AND wait for it to fully exit: this fences any in-flight
-            // step's MLX work and releases the loop's hold on the engine, so the
-            // teardown reclaim below is both safe and actually frees the batch KV.
+            // step's MLX work and releases the loop's hold on the engine.
             await engine.core.stopAndWait()
         }
+        // Drop our own reference too, so the engine — and its batch KV, including
+        // rows from the requests we just aborted — is released to the reclaimable
+        // pool before the clearCache at the end of teardown.
+        stoppingEngine = nil
         modelContainer = nil
         tokenizer = nil
-        // The engine chain is released above, so the batch KV is now in the
-        // reclaimable pool. Fence any async GPU completion before clearing, to
-        // avoid the M4 IOKit race.
-        MLX.Stream().synchronize()
-        MLX.Memory.clearCache()
         // Drain the bounded capture pipeline FIRST (#374): the engine is stopped
         // (no more capture hooks fire), so finish the stream and cancel the
         // consumer. This releases retained KV snapshots and stops an in-flight
@@ -2096,6 +2120,15 @@ public actor BatchScheduler {
         checkpointManager = nil
         checkpointBoundaries = []
         checkpointLayerSignatures = []
+
+        // Now that everything holding KV is released — the engine chain (batch KV),
+        // the capture pipeline (retained snapshots) and the RAM prefix tier — return
+        // the freed pool to the OS. Done here, after those releases, so the flush
+        // doesn't miss KV that those steps move into the pool. Fence async GPU
+        // completion first (M4 IOKit guard). Teardown runs with no engine, so this
+        // actor block can't starve request admission.
+        MLX.Stream().synchronize()
+        MLX.Memory.clearCache()
 
         // Purge the engine-tier owner's on-disk dir too (same kv/<modelKey> dir;
         // whichever tier ran first already removed it, so this no-ops then).

--- a/provider-swift/Sources/ProviderCore/Inference/BatchScheduler.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/BatchScheduler.swift
@@ -2046,6 +2046,14 @@ public actor BatchScheduler {
 
     private func stopCurrentEngine() async {
         generationEpoch &+= 1
+        // Detach the engine synchronously, before any suspension below. The teardown
+        // awaits (stats logging, stopAndWait) let a submit interleave on the actor;
+        // if self.engine still pointed at the stopping engine it would pass
+        // engineStillCurrent (epoch already bumped, identity still matches) and get
+        // enqueued onto an engine being torn down. Nil'ing it now makes those
+        // submits fail the guard and reject/retry against the next model instead.
+        let stoppingEngine = self.engine
+        self.engine = nil
         pendingTimeoutTask?.cancel()
         pendingTimeoutTask = nil
         // Log a final stats line before teardown, then stop the periodic logger.
@@ -2055,14 +2063,13 @@ public actor BatchScheduler {
         ttlReapTask?.cancel()
         ttlReapTask = nil
 
-        if let engine = self.engine {
+        if let engine = stoppingEngine {
             _ = engine.core.abortAllRequests()
             // Stop the loop AND wait for it to fully exit: this fences any in-flight
             // step's MLX work and releases the loop's hold on the engine, so the
             // teardown reclaim below is both safe and actually frees the batch KV.
             await engine.core.stopAndWait()
         }
-        self.engine = nil
         modelContainer = nil
         tokenizer = nil
         // The engine chain is released above, so the batch KV is now in the

--- a/provider-swift/Sources/ProviderCore/Inference/GlobalKVCacheBudget.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/GlobalKVCacheBudget.swift
@@ -25,7 +25,12 @@ public actor GlobalKVCacheBudget {
     /// grow into memory the operator reserved. 0 = no extra reserve (cap only).
     private let configReserveBytes: UInt64
     private let memorySnapshot: @Sendable () -> MemorySnapshot
+    private let clearCache: @Sendable () -> Void
     private var reservations: [String: UInt64] = [:]
+    /// Minimum reclaimable MLX pool worth flushing on the admission self-heal.
+    /// Below this, a flush frees too little to change an admission decision, so the
+    /// heal is skipped — the case when active memory (not the pool) is what's full.
+    private static let minReclaimableForHealBytes: UInt64 = 256 * 1024 * 1024
 
     public init(
         capFraction: Double? = nil,
@@ -35,6 +40,12 @@ public actor GlobalKVCacheBudget {
         self.capFraction = capFraction
         self.activationReserveBytes = activationReserveBytes
         self.configReserveBytes = configReserveBytes
+        // Fence async GPU completion before freeing buffers, matching the engine's
+        // own reclaim paths (avoids the IOKit completeMemory race seen on M4).
+        self.clearCache = {
+            MLX.Stream().synchronize()
+            MLX.Memory.clearCache()
+        }
         self.memorySnapshot = {
             MemorySnapshot(
                 total: ProcessInfo.processInfo.physicalMemory,
@@ -49,12 +60,14 @@ public actor GlobalKVCacheBudget {
         capFraction: Double? = nil,
         activationReserveBytes: UInt64? = nil,
         configReserveBytes: UInt64 = 0,
-        memorySnapshot: @escaping @Sendable () -> MemorySnapshot
+        memorySnapshot: @escaping @Sendable () -> MemorySnapshot,
+        clearCache: @escaping @Sendable () -> Void = {}
     ) {
         self.capFraction = capFraction
         self.activationReserveBytes = activationReserveBytes
         self.configReserveBytes = configReserveBytes
         self.memorySnapshot = memorySnapshot
+        self.clearCache = clearCache
     }
 
     public func reserve(requestID: String, kvBytesPerToken: Int, tokenCount: Int) -> Bool {
@@ -62,10 +75,7 @@ public actor GlobalKVCacheBudget {
         guard reservations[requestID] == nil else { return false }
         let (bytesNeeded, overflow) = UInt64(kvBytesPerToken).multipliedReportingOverflow(by: UInt64(tokenCount))
         if overflow { return false }
-        let available = availableReservationBytes()
-        if bytesNeeded > available { return false }
-        reservations[requestID] = bytesNeeded
-        return true
+        return commit(requestID: requestID, bytes: bytesNeeded)
     }
 
     public func release(requestID: String) {
@@ -83,9 +93,7 @@ public actor GlobalKVCacheBudget {
     public func reserveBytes(requestID: String, bytes: UInt64) -> Bool {
         guard bytes > 0 else { return false }
         guard reservations[requestID] == nil else { return false }
-        if bytes > availableReservationBytes() { return false }
-        reservations[requestID] = bytes
-        return true
+        return commit(requestID: requestID, bytes: bytes)
     }
 
     /// Reserve a loading model's WEIGHT footprint for the duration of its load,
@@ -134,6 +142,31 @@ public actor GlobalKVCacheBudget {
             let (sum, overflow) = partial.addingReportingOverflow(value)
             return overflow ? UInt64.max : sum
         }
+    }
+
+    /// Reserve `bytes` against current live headroom. The headroom math counts the
+    /// reclaimable MLX pool as used, so on a near-miss we flush that pool and
+    /// resample once before denying — otherwise we'd reject a request the box can
+    /// actually serve. Caller has validated `bytes > 0` and no existing reservation.
+    private func commit(requestID: String, bytes: UInt64) -> Bool {
+        var available = availableReservationBytes()
+        if bytes > available {
+            if selfHealClear() { available = availableReservationBytes() }
+            if bytes > available { return false }
+        }
+        reservations[requestID] = bytes
+        return true
+    }
+
+    /// One-shot reclaim for the admission self-heal. Returns true if it actually
+    /// flushed the pool (so the caller should resample). Skips the flush when the
+    /// reclaimable pool is already small — e.g. when active memory (not the pool)
+    /// is what's full, so a flush frees nothing — to avoid thrashing the pool (and
+    /// stalling on its GPU sync) on every rejected admission under sustained load.
+    private func selfHealClear() -> Bool {
+        guard memorySnapshot().cache >= Self.minReclaimableForHealBytes else { return false }
+        clearCache()
+        return true
     }
 
     private func availableReservationBytes() -> UInt64 {

--- a/provider-swift/Sources/ProviderCore/Inference/GlobalKVCacheBudget.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/GlobalKVCacheBudget.swift
@@ -156,22 +156,23 @@ public actor GlobalKVCacheBudget {
     private func commit(requestID: String, bytes: UInt64) -> Bool {
         var available = availableReservationBytes()
         if bytes > available {
-            if selfHealClear(toCover: bytes - available) { available = availableReservationBytes() }
+            if reclaimForShortfall(bytes - available) { available = availableReservationBytes() }
             if bytes > available { return false }
         }
         reservations[requestID] = bytes
         return true
     }
 
-    /// One-shot, rate-limited reclaim for the admission self-heal. Returns true if
-    /// it actually flushed the pool (so the caller should resample). Two guards:
-    /// skip when the reclaimable pool can't cover `shortfall` (the bytes the request
-    /// is short by) — a flush would still leave it rejected, e.g. when active memory
-    /// rather than the pool is what's full; and skip when a flush ran within
-    /// `selfHealMinInterval` — the flush blocks on a GPU sync, so this bounds how
-    /// often a flood of near-miss admissions can chain syncs and stall the actor.
-    private func selfHealClear(toCover shortfall: UInt64) -> Bool {
-        guard memorySnapshot().cache >= shortfall else { return false }
+    /// Rate-limited pool reclaim for the admission self-heal, shared by the live KV
+    /// reservation gate (`commit`) and the scheduler's token-budget gate. Returns
+    /// true if it actually flushed the pool (so the caller should resample). Two
+    /// guards: skip when the reclaimable pool can't cover `shortfall` (the bytes the
+    /// request is short by — a flush would still leave it rejected, e.g. when active
+    /// memory rather than the pool is what's full); and skip when a flush ran within
+    /// `selfHealMinInterval` (the flush blocks on a GPU sync, so this bounds how
+    /// often a flood of near-miss admissions can chain syncs and stall the actor).
+    public func reclaimForShortfall(_ shortfall: UInt64) -> Bool {
+        guard shortfall > 0, memorySnapshot().cache >= shortfall else { return false }
         let now = ContinuousClock.now
         if let last = lastSelfHealAt, now - last < selfHealMinInterval { return false }
         lastSelfHealAt = now

--- a/provider-swift/Sources/ProviderCore/Inference/GlobalKVCacheBudget.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/GlobalKVCacheBudget.swift
@@ -31,6 +31,12 @@ public actor GlobalKVCacheBudget {
     /// Below this, a flush frees too little to change an admission decision, so the
     /// heal is skipped — the case when active memory (not the pool) is what's full.
     private static let minReclaimableForHealBytes: UInt64 = 256 * 1024 * 1024
+    /// Rate-limit the self-heal flush to at most once per this interval. The flush
+    /// blocks on a GPU sync, so this bounds how often a flood of near-miss
+    /// admissions can chain GPU syncs on the actor and stall other reservations.
+    private var lastSelfHealAt: ContinuousClock.Instant?
+    private let selfHealMinInterval: Duration
+    private static let defaultSelfHealMinInterval: Duration = .seconds(1)
 
     public init(
         capFraction: Double? = nil,
@@ -40,6 +46,7 @@ public actor GlobalKVCacheBudget {
         self.capFraction = capFraction
         self.activationReserveBytes = activationReserveBytes
         self.configReserveBytes = configReserveBytes
+        self.selfHealMinInterval = Self.defaultSelfHealMinInterval
         // Fence async GPU completion before freeing buffers, matching the engine's
         // own reclaim paths (avoids the IOKit completeMemory race seen on M4).
         self.clearCache = {
@@ -61,11 +68,13 @@ public actor GlobalKVCacheBudget {
         activationReserveBytes: UInt64? = nil,
         configReserveBytes: UInt64 = 0,
         memorySnapshot: @escaping @Sendable () -> MemorySnapshot,
-        clearCache: @escaping @Sendable () -> Void = {}
+        clearCache: @escaping @Sendable () -> Void = {},
+        selfHealMinInterval: Duration = GlobalKVCacheBudget.defaultSelfHealMinInterval
     ) {
         self.capFraction = capFraction
         self.activationReserveBytes = activationReserveBytes
         self.configReserveBytes = configReserveBytes
+        self.selfHealMinInterval = selfHealMinInterval
         self.memorySnapshot = memorySnapshot
         self.clearCache = clearCache
     }
@@ -158,13 +167,17 @@ public actor GlobalKVCacheBudget {
         return true
     }
 
-    /// One-shot reclaim for the admission self-heal. Returns true if it actually
-    /// flushed the pool (so the caller should resample). Skips the flush when the
-    /// reclaimable pool is already small — e.g. when active memory (not the pool)
-    /// is what's full, so a flush frees nothing — to avoid thrashing the pool (and
-    /// stalling on its GPU sync) on every rejected admission under sustained load.
+    /// One-shot, rate-limited reclaim for the admission self-heal. Returns true if
+    /// it actually flushed the pool (so the caller should resample). Two guards:
+    /// skip when the reclaimable pool is already small (a flush would free nothing,
+    /// e.g. when active memory is what's full), and skip when a flush ran within
+    /// `selfHealMinInterval` — the flush blocks on a GPU sync, so this bounds how
+    /// often a flood of near-miss admissions can chain syncs and stall the actor.
     private func selfHealClear() -> Bool {
         guard memorySnapshot().cache >= Self.minReclaimableForHealBytes else { return false }
+        let now = ContinuousClock.now
+        if let last = lastSelfHealAt, now - last < selfHealMinInterval { return false }
+        lastSelfHealAt = now
         clearCache()
         return true
     }

--- a/provider-swift/Sources/ProviderCore/Inference/GlobalKVCacheBudget.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/GlobalKVCacheBudget.swift
@@ -27,10 +27,6 @@ public actor GlobalKVCacheBudget {
     private let memorySnapshot: @Sendable () -> MemorySnapshot
     private let clearCache: @Sendable () -> Void
     private var reservations: [String: UInt64] = [:]
-    /// Minimum reclaimable MLX pool worth flushing on the admission self-heal.
-    /// Below this, a flush frees too little to change an admission decision, so the
-    /// heal is skipped — the case when active memory (not the pool) is what's full.
-    private static let minReclaimableForHealBytes: UInt64 = 256 * 1024 * 1024
     /// Rate-limit the self-heal flush to at most once per this interval. The flush
     /// blocks on a GPU sync, so this bounds how often a flood of near-miss
     /// admissions can chain GPU syncs on the actor and stall other reservations.
@@ -160,7 +156,7 @@ public actor GlobalKVCacheBudget {
     private func commit(requestID: String, bytes: UInt64) -> Bool {
         var available = availableReservationBytes()
         if bytes > available {
-            if selfHealClear() { available = availableReservationBytes() }
+            if selfHealClear(toCover: bytes - available) { available = availableReservationBytes() }
             if bytes > available { return false }
         }
         reservations[requestID] = bytes
@@ -169,12 +165,13 @@ public actor GlobalKVCacheBudget {
 
     /// One-shot, rate-limited reclaim for the admission self-heal. Returns true if
     /// it actually flushed the pool (so the caller should resample). Two guards:
-    /// skip when the reclaimable pool is already small (a flush would free nothing,
-    /// e.g. when active memory is what's full), and skip when a flush ran within
+    /// skip when the reclaimable pool can't cover `shortfall` (the bytes the request
+    /// is short by) — a flush would still leave it rejected, e.g. when active memory
+    /// rather than the pool is what's full; and skip when a flush ran within
     /// `selfHealMinInterval` — the flush blocks on a GPU sync, so this bounds how
     /// often a flood of near-miss admissions can chain syncs and stall the actor.
-    private func selfHealClear() -> Bool {
-        guard memorySnapshot().cache >= Self.minReclaimableForHealBytes else { return false }
+    private func selfHealClear(toCover shortfall: UInt64) -> Bool {
+        guard memorySnapshot().cache >= shortfall else { return false }
         let now = ContinuousClock.now
         if let last = lastSelfHealAt, now - last < selfHealMinInterval { return false }
         lastSelfHealAt = now

--- a/provider-swift/Tests/ProviderCoreTests/GlobalKVCacheBudgetSelfHealTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/GlobalKVCacheBudgetSelfHealTests.swift
@@ -64,6 +64,25 @@ private let gib: UInt64 = 1024 * 1024 * 1024
     #expect(memory.clearCount == 0)   // pool too small to be worth flushing
 }
 
+@Test func globalKVCacheBudgetRateLimitsRepeatedSelfHealFlushes() async {
+    // A large pool that the fake clear doesn't shrink (cacheAfterClear == cache,
+    // simulating immediate refill), so both near-miss admissions pass the pool-size
+    // gate. With a long interval injected, the second flush is rate-limited — the
+    // blocking GPU sync runs at most once per window, not once per admission.
+    let memory = MutableMemorySnapshot(
+        total: 8 * gib, active: 5 * gib, cache: 2 * gib, cacheAfterClear: 2 * gib)
+    let budget = GlobalKVCacheBudget(
+        capFraction: 1.0,
+        activationReserveBytes: 0,
+        memorySnapshot: { memory.snapshot() },
+        clearCache: { memory.clearCache() },
+        selfHealMinInterval: .seconds(3600))
+
+    #expect(!(await budget.reserve(requestID: "a", kvBytesPerToken: 1, tokenCount: Int(2 * gib))))
+    #expect(!(await budget.reserve(requestID: "b", kvBytesPerToken: 1, tokenCount: Int(2 * gib))))
+    #expect(memory.clearCount == 1)   // second flush rate-limited within the window
+}
+
 /// Lock-guarded so @Sendable closures can mutate fake MLX cache state safely.
 private final class MutableMemorySnapshot: @unchecked Sendable {
     private let lock = NSLock()

--- a/provider-swift/Tests/ProviderCoreTests/GlobalKVCacheBudgetSelfHealTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/GlobalKVCacheBudgetSelfHealTests.swift
@@ -47,10 +47,10 @@ private let gib: UInt64 = 1024 * 1024 * 1024
     #expect(memory.clearCount == 1)
 }
 
-@Test func globalKVCacheBudgetSkipsHealWhenReclaimablePoolIsTiny() async {
-    // Active-dominated near-cap with only a tiny reclaimable pool (100 MiB, below
-    // the heal threshold): a flush would free almost nothing, so the self-heal is
-    // skipped entirely (no clear, no GPU sync) and the request is rejected.
+@Test func globalKVCacheBudgetSkipsHealWhenPoolCannotCoverShortfall() async {
+    // Active-dominated near-cap: the reclaimable pool (100 MiB) can't cover the
+    // 1 GiB the request is short by, so flushing it wouldn't admit the request —
+    // the self-heal is skipped (no clear, no GPU sync) and the request is rejected.
     let mib: UInt64 = 1024 * 1024
     let memory = MutableMemorySnapshot(
         total: 8 * gib, active: 6 * gib, cache: 100 * mib, cacheAfterClear: 0)
@@ -81,6 +81,24 @@ private let gib: UInt64 = 1024 * 1024 * 1024
     #expect(!(await budget.reserve(requestID: "a", kvBytesPerToken: 1, tokenCount: Int(2 * gib))))
     #expect(!(await budget.reserve(requestID: "b", kvBytesPerToken: 1, tokenCount: Int(2 * gib))))
     #expect(memory.clearCount == 1)   // second flush rate-limited within the window
+}
+
+@Test func globalKVCacheBudgetHealsSmallShortfallFromSmallPool() async {
+    // The gate is shortfall-based, not an absolute pool floor: a small pool
+    // (200 MiB) that covers a small shortfall must still heal. cap = 6 GiB;
+    // active 6000 MiB + cache 200 MiB > cap → 0 free; the request is short by
+    // 64 MiB, which the 200 MiB pool covers, so the flush frees ~144 MiB and admits.
+    let mib: UInt64 = 1024 * 1024
+    let memory = MutableMemorySnapshot(
+        total: 8 * gib, active: 6000 * mib, cache: 200 * mib, cacheAfterClear: 0)
+    let budget = GlobalKVCacheBudget(
+        capFraction: 1.0,
+        activationReserveBytes: 0,
+        memorySnapshot: { memory.snapshot() },
+        clearCache: { memory.clearCache() })
+
+    #expect(await budget.reserveBytes(requestID: "small", bytes: 64 * mib))
+    #expect(memory.clearCount == 1)
 }
 
 /// Lock-guarded so @Sendable closures can mutate fake MLX cache state safely.

--- a/provider-swift/Tests/ProviderCoreTests/GlobalKVCacheBudgetSelfHealTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/GlobalKVCacheBudgetSelfHealTests.swift
@@ -1,0 +1,113 @@
+import Foundation
+import Testing
+@testable import ProviderCore
+
+private let gib: UInt64 = 1024 * 1024 * 1024
+
+@Test func globalKVCacheBudgetReserveClearsCacheAndAdmitsOnResample() async {
+    // cap = 6 GiB (1.0 × 8 GiB, but the 2 GiB OS floor binds); mlxUsed = active 5
+    // + cache 2 = 7 GiB → 0 free. The 2 GiB pool is above the heal threshold, so
+    // clearCache drops cache → 0, leaving 1 GiB free — enough for the 1 GiB request.
+    let memory = MutableMemorySnapshot(cacheAfterClear: 0)
+    let budget = GlobalKVCacheBudget(
+        capFraction: 1.0,
+        activationReserveBytes: 0,
+        memorySnapshot: { memory.snapshot() },
+        clearCache: { memory.clearCache() })
+
+    #expect(await budget.reserve(requestID: "fits-after-clear", kvBytesPerToken: 1, tokenCount: Int(gib)))
+    #expect(memory.clearCount == 1)
+}
+
+@Test func globalKVCacheBudgetReserveStillRejectsAfterClearWhenTooLarge() async {
+    // Same 6 GiB cap and 2 GiB pool, but the request needs 2 GiB. Even after the
+    // pool is flushed only 1 GiB is free, so it's still rejected — one heal attempt.
+    let memory = MutableMemorySnapshot(cacheAfterClear: 0)
+    let budget = GlobalKVCacheBudget(
+        capFraction: 1.0,
+        activationReserveBytes: 0,
+        memorySnapshot: { memory.snapshot() },
+        clearCache: { memory.clearCache() })
+
+    #expect(!(await budget.reserve(requestID: "too-large", kvBytesPerToken: 1, tokenCount: Int(2 * gib))))
+    #expect(memory.clearCount == 1)
+}
+
+@Test func globalKVCacheBudgetReserveBytesClearsCacheAndAdmitsOnResample() async {
+    // reserveBytes path: same headroom as the reserve() admit case — the 2 GiB
+    // pool is flushed to free 1 GiB, admitting the 1 GiB byte reservation.
+    let memory = MutableMemorySnapshot(cacheAfterClear: 0)
+    let budget = GlobalKVCacheBudget(
+        capFraction: 1.0,
+        activationReserveBytes: 0,
+        memorySnapshot: { memory.snapshot() },
+        clearCache: { memory.clearCache() })
+
+    #expect(await budget.reserveBytes(requestID: "bytes-fit-after-clear", bytes: gib))
+    #expect(memory.clearCount == 1)
+}
+
+@Test func globalKVCacheBudgetSkipsHealWhenReclaimablePoolIsTiny() async {
+    // Active-dominated near-cap with only a tiny reclaimable pool (100 MiB, below
+    // the heal threshold): a flush would free almost nothing, so the self-heal is
+    // skipped entirely (no clear, no GPU sync) and the request is rejected.
+    let mib: UInt64 = 1024 * 1024
+    let memory = MutableMemorySnapshot(
+        total: 8 * gib, active: 6 * gib, cache: 100 * mib, cacheAfterClear: 0)
+    let budget = GlobalKVCacheBudget(
+        capFraction: 1.0,
+        activationReserveBytes: 0,
+        memorySnapshot: { memory.snapshot() },
+        clearCache: { memory.clearCache() })
+
+    #expect(!(await budget.reserve(requestID: "tiny-pool", kvBytesPerToken: 1, tokenCount: Int(gib))))
+    #expect(memory.clearCount == 0)   // pool too small to be worth flushing
+}
+
+/// Lock-guarded so @Sendable closures can mutate fake MLX cache state safely.
+private final class MutableMemorySnapshot: @unchecked Sendable {
+    private let lock = NSLock()
+    private let total: UInt64
+    private let active: UInt64
+    private let cacheAfterClear: UInt64
+    private let systemAvailable: UInt64
+    private var cache: UInt64
+    private var clears = 0
+
+    init(
+        total: UInt64 = 8 * gib,
+        active: UInt64 = 5 * gib,
+        cache: UInt64 = 2 * gib,
+        cacheAfterClear: UInt64,
+        systemAvailable: UInt64 = .max
+    ) {
+        self.total = total
+        self.active = active
+        self.cache = cache
+        self.cacheAfterClear = cacheAfterClear
+        self.systemAvailable = systemAvailable
+    }
+
+    func snapshot() -> GlobalKVCacheBudget.MemorySnapshot {
+        lock.lock()
+        defer { lock.unlock() }
+        return GlobalKVCacheBudget.MemorySnapshot(
+            total: total,
+            active: active,
+            cache: cache,
+            systemAvailable: systemAvailable)
+    }
+
+    func clearCache() {
+        lock.lock()
+        clears += 1
+        cache = cacheAfterClear
+        lock.unlock()
+    }
+
+    var clearCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return clears
+    }
+}


### PR DESCRIPTION
## Summary

Three fixes for a single systemic failure: the provider treated MLX's **reclaimable** KV buffer pool as permanently occupied, and nothing returned it to the OS while the box was busy. The result was a provider that shed traffic with false "busy"/429 rejections while its RAM was actually free, plus wasted compute on cancelled requests.

Each issue is one commit; two of them ride on a companion engine-submodule PR (see below).

## Before / After

How a request is admitted, and when KV memory returns to the OS.

**Before** — both admission gates subtract MLX's *reclaimable* buffer pool, and nothing returns that pool to the OS under load, so it inflates and the box rejects traffic it could actually serve:

```mermaid
flowchart TD
    req["Request"] --> tok{"Token-budget gate<br/>(subtracts reclaimable pool)"}
    tok -->|"pool inflated → over"| rej["429 — provider busy"]
    tok -->|"ok"| res{"KV reservation gate<br/>(subtracts reclaimable pool)"}
    res -->|"pool inflated → over"| rej
    res -->|"ok"| run["Admit + decode"]
    run --> fin["Complete / cancel / abort"]
    fin --> pool[("KV bytes → MLX reclaimable pool")]
    pool -->|"counted as used"| tok
    pool -->|"counted as used"| res
    pool -.->|"returned to OS only by the idle clearCache —<br/>never fires under sustained load"| os[("OS free RAM")]
    classDef bad fill:#ffd7d7,stroke:#d33
    classDef warn fill:#fff3cd,stroke:#d9a406
    class rej bad
    class pool warn
```

**After** — each gate flushes the reclaimable pool and re-evaluates before rejecting, and the pool is returned to the OS promptly after aborts and on teardown:

```mermaid
flowchart TD
    req["Request"] --> tok{"Token-budget gate"}
    tok -->|"tight"| heal1["Flush reclaimable pool<br/>(rate-limited + shortfall-gated)"]
    heal1 --> tok2{"Re-evaluate"}
    tok -->|"ok"| res{"KV reservation gate"}
    tok2 -->|"fits now"| res
    tok2 -->|"still over"| rej["429"]
    res -->|"tight"| heal2["Flush + resample"]
    heal2 --> res2{"Re-evaluate"}
    res -->|"ok"| run["Admit + decode"]
    res2 -->|"fits now"| run
    res2 -->|"still over"| rej
    run --> fin["Complete / cancel / abort"]
    fin --> rec["Engine reclaims pool<br/>after abort-bearing step"]
    swap["Model unload / swap"] --> tdr["Reclaim after engine release<br/>+ capture & RAM-tier purge"]
    rec --> os[("Returned to OS")]
    tdr --> os
    classDef good fill:#d7f5dd,stroke:#2a2
    class run good
    class os good
```

### 1 — Reclaim the MLX pool before rejecting a KV reservation
`provider-swift/.../GlobalKVCacheBudget.swift`

The live admission gate computed headroom as `cap − (active + cache)`, counting the reclaimable pool as used. Under load the pool grows, so requests were rejected for headroom a `clearCache` would instantly free. The model-**load** path already self-healed this way; the live reserve path did not.

`reserve()`/`reserveBytes()` now flush the reclaimable pool and resample once before denying. The flush is **skipped when the pool is already small** (so an active-dominated, near-cap box doesn't thrash on every rejected admission) and fences GPU completion first, matching the engine's other reclaim paths.

### 2 — Reclaim the MLX pool on the cancel and teardown paths
`provider-swift/.../BatchScheduler.swift` + engine submodule

Freed KV from a cancelled request lingered in the pool because the only reclaim was the idle-gated clear, which never fires under sustained load. The engine now reclaims after abort-bearing steps (throttled), and `stopCurrentEngine` waits for the engine loop to fully exit (`stopAndWait()`) before fencing the GPU and returning the released batch KV to the OS.

### 3 — Stop the abort/cleanup race from orphaning a decode row
engine submodule

A race between stream cleanup and the deferred abort could leave an orphaned batch row decoding to `maxTokens` with its output discarded (wasted compute, a stolen slot, engine never idling). Cleanup now removes the batch row and releases the request's prefix-cache blocks regardless of which path wins.

## Submodule dependency

The engine fixes (2 and 3) live in `libs/mlx-swift-lm`:
**Layr-Labs/mlx-swift-lm#47**

**#47 is merged.** The submodule pointer in this PR now tracks its squash-merged `main` commit (`ff35b30d`), so the gitlink resolves on `mlx-swift-lm` `main`.

## Testing

- `make provider-build` green; `make provider-test` green — **942 tests, 0 failures**.
- Issue 1 is covered by new unit tests (`GlobalKVCacheBudgetSelfHealTests`): heal-admits, still-rejects, `reserveBytes`, and the pool-too-small skip.
- Reviewed by independent correctness/concurrency, logic, and style passes; all flagged issues addressed (notably: the teardown loop-task fence and synchronizing the self-heal clear came out of that review).

## Validation boundary

Per a clean-from-master base, the live MLX repro probes that *measure* pool behavior are not in this branch (they need a model + metallib + the live-test harness). Validation here is build + unit tests + code review. The pool-reclaim behavior can be measured separately by running those probes against this branch with a live model.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/408"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784495156&installation_id=133247490&pr_number=408&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F408&signature=d09422c337a7a9457f577233e2d2318b59b06b306f6a903af0dc0a01620a8f98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
