### PR TITLE
perf(coordinator): use WriteString for per-chunk SSE writes

### DIFF
--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -316,6 +316,17 @@ func rewriteChunkModel(chunk string, pr *registry.PendingRequest) string {
 	return chunk
 }
 
+// writeSSEFrame writes an already-serialized SSE frame followed by the event
+// terminator ("\n\n"). It is the hot-path equivalent of
+// fmt.Fprintf(w, "%s\n\n", frame) but avoids the reflection-based formatting
+// and the intermediate buffer allocation fmt incurs on every streamed token.
+// Write errors are intentionally ignored, matching the fmt.Fprintf call sites
+// it replaces — a broken client connection surfaces on the following Flush.
+func writeSSEFrame(w io.Writer, frame string) {
+	_, _ = io.WriteString(w, frame)
+	_, _ = io.WriteString(w, "\n\n")
+}
+
 // resolveRequestedModel maps the consumer-requested model — which may be a
 // public alias like "gemma-4-26b" — to the concrete build id used for routing,
 // billing, and serving, returning the public name to echo back to the consumer.
@@ -2331,7 +2342,7 @@ func (s *Server) handleStreamingResponseWithFirstChunk(w http.ResponseWriter, r 
 				firstChunk = normalizeSSEChunk(firstChunk)
 			}
 			firstChunk = rewriteChunkModel(firstChunk, pr)
-			fmt.Fprintf(w, "%s\n\n", firstChunk)
+			writeSSEFrame(w, firstChunk)
 			flusher.Flush()
 		}
 	}
@@ -2398,7 +2409,7 @@ func (s *Server) handleStreamingResponseWithFirstChunk(w http.ResponseWriter, r 
 					}
 					if pendingFinish != nil {
 						if out := finalizeFinishChunk(pendingFinish, usage, pr); out != "" {
-							fmt.Fprintf(w, "%s\n\n", out)
+							writeSSEFrame(w, out)
 							flusher.Flush()
 						}
 					}
@@ -2411,7 +2422,7 @@ func (s *Server) handleStreamingResponseWithFirstChunk(w http.ResponseWriter, r 
 							pendingUsage["response_hash"] = pr.ResponseHash
 						}
 						if out := finalizeUsageChunk(pendingUsage, usage, pr); out != "" {
-							fmt.Fprintf(w, "%s\n\n", out)
+							writeSSEFrame(w, out)
 							flusher.Flush()
 						}
 					} else if pr.SESignature != "" {
@@ -2485,7 +2496,7 @@ func (s *Server) handleStreamingResponseWithFirstChunk(w http.ResponseWriter, r 
 				}
 			}
 			chunk = rewriteChunkModel(chunk, pr)
-			fmt.Fprintf(w, "%s\n\n", chunk)
+			writeSSEFrame(w, chunk)
 			flusher.Flush()
 
 		case errMsg, ok := <-pr.ErrorCh:

--- a/coordinator/api/sse_frame_test.go
+++ b/coordinator/api/sse_frame_test.go
@@ -1,0 +1,37 @@
+package api
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+)
+
+// TestWriteSSEFrame verifies the hot-path SSE writer produces output that is
+// byte-identical to the fmt.Fprintf(w, "%s\n\n", frame) call sites it replaced.
+// This is the regression guard for the perf change: it ensures dropping fmt's
+// reflection-based formatting never silently alters the SSE wire framing.
+func TestWriteSSEFrame(t *testing.T) {
+	cases := []struct {
+		name  string
+		frame string
+	}{
+		{"chat_completion_chunk", `data: {"id":"chatcmpl-1","object":"chat.completion.chunk","choices":[{"delta":{"content":"hi"}}]}`},
+		{"done_sentinel", "data: [DONE]"},
+		{"empty_frame", ""},
+		{"unicode_payload", `data: {"content":"héllo 🌸"}`},
+		{"percent_literal", `data: {"content":"100% done"}`}, // must NOT be treated as a format verb
+		{"embedded_newline", "data: line1\nline2"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var got bytes.Buffer
+			writeSSEFrame(&got, tc.frame)
+
+			// The exact expression the helper replaced at every call site.
+			want := fmt.Sprintf("%s\n\n", tc.frame)
+			if got.String() != want {
+				t.Errorf("writeSSEFrame(%q) = %q, want %q", tc.frame, got.String(), want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Replace `fmt.Fprintf(w, "%s\n\n", frame)` on the streaming SSE hot path with a `writeSSEFrame` helper backed by `io.WriteString`.
- Avoids reflection-based formatting and per-chunk buffer allocation on every streamed token.
- Behavior-preserving: wire output is byte-identical to the old call sites.

## What changed

`handleStreamingResponseWithFirstChunk` now uses `writeSSEFrame` for the four passthrough writes that emit an already-serialized frame:

- first-chunk forward
- per-token relay
- finish-chunk finalize
- usage-chunk finalize

Terminal/error writes (`data: %s\n\n`) are unchanged — they run once per request, not on the hot path.

Adds `TestWriteSSEFrame` to lock in byte-identical framing (unicode, `%` literals, embedded newlines, empty frames).

## Test plan

- [x] `cd coordinator && go test ./api -run TestWriteSSEFrame -v`
- [x] `cd coordinator && go test ./api/...`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/411"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784501495&installation_id=133247490&pr_number=411&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F411&signature=9dc53de76fb7ad9d1f5ad76be2f791aaf360b25ee8f9221365c92d48981fd254"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->