### PR TITLE
fix(registry): dedup network token-budget utilization for multi-model providers

### DIFF
--- a/coordinator/registry/utilization.go
+++ b/coordinator/registry/utilization.go
@@ -3,6 +3,8 @@ package registry
 import (
 	"math"
 	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
 )
 
 // utilization.go computes a network-utilization summary for the fleet.
@@ -120,9 +122,14 @@ func (n NetworkUtilization) Public() PublicNetworkUtilization {
 // per-model ModelCapacity rows (a provider advertising N models appears in N
 // rows, and slots on one machine share a single memory pool).
 type FleetCapacity struct {
-	DecodeTPS   float64 // Σ per-provider rated decode tok/s (counted once)
-	BudgetUsed  int64   // Σ per-provider used+queued token budget
-	BudgetTotal int64   // Σ per-provider token budget (largest slot per provider)
+	DecodeTPS  float64 // Σ per-provider rated decode tok/s (counted once)
+	BudgetUsed int64   // Σ per-provider committed (used+queued) token budget across slots
+	// BudgetTotal is Σ per-provider pooled token budget, where each provider's
+	// pool is its committed tokens plus the single shared KV headroom counted
+	// ONCE (slots on one machine share a unified-memory pool, so their reported
+	// per-slot maxes — each already committed+sharedHeadroom — are NOT additive).
+	// See providerTokenBudget for the reconstruction. BudgetUsed <= BudgetTotal.
+	BudgetTotal int64
 }
 
 // FleetCapacitySnapshot returns the provider-deduped fleet capacity using the
@@ -139,26 +146,64 @@ func (r *Registry) FleetCapacitySnapshot() FleetCapacity {
 			continue
 		}
 		fc.DecodeTPS += resolvedDecodeTPS(p)
-		// Slots on one machine share a single unified-memory pool, so the
-		// provider's budget is the largest slot's max (not the sum), while used
-		// reservations across its slots do add up (capped at that max).
+		// Reconstruct the provider's true pooled KV/token budget from its
+		// per-model slots. Slots on one machine share a single unified-memory
+		// pool, so their reported per-slot maxes are not additive; see
+		// providerTokenBudget.
 		if p.BackendCapacity != nil {
-			var provMax, provUsed int64
-			for _, slot := range p.BackendCapacity.Slots {
-				if slot.ActiveTokenBudgetMax > provMax {
-					provMax = slot.ActiveTokenBudgetMax
-				}
-				provUsed += slot.ActiveTokenBudgetUsed + slot.QueuedTokenBudget
-			}
-			if provUsed > provMax {
-				provUsed = provMax
-			}
-			fc.BudgetTotal += provMax
-			fc.BudgetUsed += provUsed
+			used, total := providerTokenBudget(p.BackendCapacity.Slots)
+			fc.BudgetUsed += used
+			fc.BudgetTotal += total
 		}
 		p.mu.Unlock()
 	}
 	return fc
+}
+
+// providerTokenBudget reconstructs a provider's true pooled token (KV-cache)
+// budget from its per-model backend slots, returning used and total token
+// budget for that single provider.
+//
+// A provider reports one slot per resident model, and each slot's
+// ActiveTokenBudgetMax is NOT a private per-slot cap: the provider computes it as
+// (that slot's own committed tokens) + the provider's SHARED live KV headroom,
+// where the headroom is a single unified-memory pool shared across every
+// co-resident model on the machine (provider side:
+// BatchScheduler+Telemetry.swift, tokenBudgetMax = activeTokenBudgetUsed +
+// sharedHeadroom; ProviderLoop.swift concatenates one slot per resident model
+// into the reported slots). So for two resident models A,B sharing headroom H:
+// maxA = usedA + H and maxB = usedB + H — the per-slot maxes are NOT additive,
+// and neither summing them nor taking the largest reconstructs the real pool.
+//
+// The true pooled capacity is committed (which DOES add across slots, since each
+// model's reservations are distinct) plus the shared free headroom counted
+// exactly ONCE. All slots observe the same shared pool, so the largest observed
+// per-slot free is the live headroom. This makes used <= total by construction,
+// reduces exactly to the single slot's max for single-model providers, and
+// matches the per-model snapshot (registry.go) and the admission gate
+// (scheduler.go), which both treat each slot's budget independently.
+//
+// Slots that report no token budget (ActiveTokenBudgetMax <= 0) are ignored, and
+// negative per-slot committed values are floored at 0. A nil/empty slice (or a
+// provider whose slots all lack a budget) yields used=0, total=0.
+func providerTokenBudget(slots []protocol.BackendSlotCapacity) (used, total int64) {
+	var committed, sharedFree int64
+	for _, slot := range slots {
+		if slot.ActiveTokenBudgetMax <= 0 {
+			continue
+		}
+		slotCommitted := slot.ActiveTokenBudgetUsed + slot.QueuedTokenBudget
+		if slotCommitted < 0 {
+			slotCommitted = 0
+		}
+		committed += slotCommitted
+		// Per-slot free headroom; all slots see the same shared pool, so the
+		// largest is the live shared headroom (counted once below).
+		if free := slot.ActiveTokenBudgetMax - slotCommitted; free > sharedFree {
+			sharedFree = free
+		}
+	}
+	return committed, committed + sharedFree
 }
 
 // NetworkUtilizationSnapshot computes the fleet-wide utilization summary by

--- a/coordinator/registry/utilization_test.go
+++ b/coordinator/registry/utilization_test.go
@@ -3,6 +3,8 @@ package registry
 import (
 	"testing"
 	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
 )
 
 // approx reuses the package's approxEqual helper with a fixed tolerance.
@@ -236,5 +238,142 @@ func TestComputeNetworkUtilization_Empty(t *testing.T) {
 	got := computeNetworkUtilization(nil, nil, FleetCapacity{}, time.Time{}, time.Now())
 	if got.Utilization != 0 || got.CapacityTPS != 0 || len(got.Models) != 0 {
 		t.Fatalf("empty snapshot should be zero-valued, got %+v", got)
+	}
+}
+
+// TestProviderTokenBudget pins the pooled-budget reconstruction. Each backend
+// slot's ActiveTokenBudgetMax = (that slot's committed tokens) + the provider's
+// SHARED KV headroom, so per-slot maxes are not additive: total must be Σ
+// committed + the shared free headroom counted ONCE, and used must be Σ
+// committed. used <= total must hold by construction.
+func TestProviderTokenBudget(t *testing.T) {
+	tests := []struct {
+		name      string
+		slots     []protocol.BackendSlotCapacity
+		wantUsed  int64
+		wantTotal int64
+	}{
+		{
+			name:      "nil slots",
+			slots:     nil,
+			wantUsed:  0,
+			wantTotal: 0,
+		},
+		{
+			name:      "empty slots",
+			slots:     []protocol.BackendSlotCapacity{},
+			wantUsed:  0,
+			wantTotal: 0,
+		},
+		{
+			name: "single slot reduces to old value",
+			slots: []protocol.BackendSlotCapacity{
+				{ActiveTokenBudgetMax: 10000, ActiveTokenBudgetUsed: 7000},
+			},
+			wantUsed:  7000,
+			wantTotal: 10000,
+		},
+		{
+			name: "single slot counts queued as committed",
+			slots: []protocol.BackendSlotCapacity{
+				{ActiveTokenBudgetMax: 10000, ActiveTokenBudgetUsed: 5000, QueuedTokenBudget: 2000},
+			},
+			wantUsed:  7000,
+			wantTotal: 10000,
+		},
+		{
+			name: "two slots share one headroom pool",
+			slots: []protocol.BackendSlotCapacity{
+				{ActiveTokenBudgetMax: 10000, ActiveTokenBudgetUsed: 7000},
+				{ActiveTokenBudgetMax: 10000, ActiveTokenBudgetUsed: 7000},
+			},
+			// committed 14000 + shared free 3000 (counted once) = 17000.
+			wantUsed:  14000,
+			wantTotal: 17000,
+		},
+		{
+			name: "over-committed single slot floors free at zero",
+			slots: []protocol.BackendSlotCapacity{
+				{ActiveTokenBudgetMax: 10000, ActiveTokenBudgetUsed: 11000},
+			},
+			wantUsed:  11000,
+			wantTotal: 11000,
+		},
+		{
+			name: "static-bound mix takes max shared free",
+			slots: []protocol.BackendSlotCapacity{
+				{ActiveTokenBudgetMax: 10000, ActiveTokenBudgetUsed: 8000},
+				{ActiveTokenBudgetMax: 5000, ActiveTokenBudgetUsed: 3000},
+			},
+			// committed 11000 + max(2000, 2000) = 13000.
+			wantUsed:  11000,
+			wantTotal: 13000,
+		},
+		{
+			name: "slot with zero max is ignored",
+			slots: []protocol.BackendSlotCapacity{
+				{ActiveTokenBudgetMax: 0, ActiveTokenBudgetUsed: 5000, QueuedTokenBudget: 9000},
+			},
+			wantUsed:  0,
+			wantTotal: 0,
+		},
+		{
+			name: "slot with negative max is ignored alongside a valid slot",
+			slots: []protocol.BackendSlotCapacity{
+				{ActiveTokenBudgetMax: 10000, ActiveTokenBudgetUsed: 7000},
+				{ActiveTokenBudgetMax: -1, ActiveTokenBudgetUsed: 9000, QueuedTokenBudget: 9000},
+			},
+			wantUsed:  7000,
+			wantTotal: 10000,
+		},
+		{
+			name: "negative committed is floored at zero",
+			slots: []protocol.BackendSlotCapacity{
+				{ActiveTokenBudgetMax: 10000, ActiveTokenBudgetUsed: -500},
+			},
+			wantUsed:  0,
+			wantTotal: 10000,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			used, total := providerTokenBudget(tt.slots)
+			if used != tt.wantUsed || total != tt.wantTotal {
+				t.Fatalf("providerTokenBudget() = used %d, total %d; want used %d, total %d",
+					used, total, tt.wantUsed, tt.wantTotal)
+			}
+			if used > total {
+				t.Fatalf("invariant violated: used %d > total %d", used, total)
+			}
+		})
+	}
+}
+
+// TestFleetCapacitySnapshotDedupsTokenBudget proves the dedup end-to-end: a
+// single provider holding two resident-model slots that share one KV pool yields
+// committed + shared-free-once via FleetCapacitySnapshot, not the old
+// max-slot-as-denominator-with-summed-numerator (which clamped to 14000/10000).
+func TestFleetCapacitySnapshotDedupsTokenBudget(t *testing.T) {
+	reg := New(testLogger())
+	modelA := "fleet-budget-a"
+	modelB := "fleet-budget-b"
+	p := makeSchedulerProvider(t, reg, "fleet-budget-provider", modelA, 100)
+	p.mu.Lock()
+	p.Models = append(p.Models, protocol.ModelInfo{ID: modelB, ModelType: "chat", Quantization: "4bit"})
+	// Two co-resident models sharing a single 3000-token live headroom: each
+	// slot reports max = its own committed (7000) + shared headroom (3000).
+	p.BackendCapacity.Slots = []protocol.BackendSlotCapacity{
+		{Model: modelA, State: "running", ActiveTokenBudgetUsed: 7000, ActiveTokenBudgetMax: 10000},
+		{Model: modelB, State: "running", ActiveTokenBudgetUsed: 7000, ActiveTokenBudgetMax: 10000},
+	}
+	p.mu.Unlock()
+
+	fc := reg.FleetCapacitySnapshot()
+	if fc.BudgetUsed != 14000 || fc.BudgetTotal != 17000 {
+		t.Fatalf("fleet token budget = used %d, total %d; want 14000/17000 (deduped shared pool)",
+			fc.BudgetUsed, fc.BudgetTotal)
+	}
+	if fc.BudgetUsed > fc.BudgetTotal {
+		t.Fatalf("invariant violated: used %d > total %d", fc.BudgetUsed, fc.BudgetTotal)
 	}
 }


### PR DESCRIPTION
## Summary

Fixes a correctness bug in the network **token-budget utilization** metric (`token_budget_utilization` on `/v1/stats` and `/v1/admin/utilization`, plus the `capacity.*` gauges). It systematically **over-reported** multi-model providers, pegging them near 100% when they were far from full.

Bug introduced in #407 (network utilization metric).

## Root cause

`FleetCapacitySnapshot` (`coordinator/registry/utilization.go`) aggregated each provider's token budget with a mismatched numerator/denominator:

```go
provMax  = max over slots of ActiveTokenBudgetMax   // denominator: ONE slot
provUsed = Σ over slots of (used + queued)           // numerator:   ALL slots
if provUsed > provMax { provUsed = provMax }          // clamp band-aid
```

A provider reports **one slot per resident model**, and each slot's `ActiveTokenBudgetMax` already equals *that slot's committed tokens + the provider's **shared** live KV headroom* — a single unified-memory pool, reported once per resident model (provider side: `BatchScheduler+Telemetry.swift` `tokenBudgetMax = activeTokenBudgetUsed + sharedHeadroom`; `ProviderLoop.swift` concatenates one slot per model).

So for two resident models A, B sharing headroom `H`: `maxA = usedA + H`, `maxB = usedB + H`. The per-slot maxes are **not additive**. Summing usage over all slots but dividing by a single slot's max inflates the ratio. This also disagreed with the two places that actually treat slot budgets independently:
- per-model snapshot — `ModelCapacitySnapshot` (`registry.go`)
- admission gate — `freeMemoryAdmits` (`scheduler.go`)

## Fix

Reconstruct the provider's true pooled budget:

- `used  = Σ committed` (committed = `used + queued`, distinct per model — these *do* add)
- `total = Σ committed + sharedFree`, where `sharedFree = max over slots of (max − committed)` — the shared headroom counted **once**

This makes `used ≤ total` by construction (drops the clamp), reduces **exactly** to the old value for single-slot providers, and matches the admission / per-model views for multi-model providers. Extracted as a pure, unit-testable `providerTokenBudget` helper.

### Worked example (2 resident models, used 7000 / max 10000 each)

| view | used | total | util |
|---|---|---|---|
| old (network) | 10000 (clamped) | 10000 | **100%** |
| **new (network)** | 14000 | 17000 | **82.4%** |
| true pooled KV | 14000 | 17000 | 82.4% |

## Scope

Token-budget axis only. The warm / Little's-Law axis (quality-concurrency vs admission maxConcurrency) is a separate design question and is intentionally **unchanged** here.

## Testing

- `gofmt -l`: clean
- `go build ./...`: OK
- `go test ./registry/...`: green, incl. new `TestProviderTokenBudget` (single / multi-slot shared pool / over-committed / static-bound mix / zero / negative) and an end-to-end `TestFleetCapacitySnapshotDedupsTokenBudget` (14000/17000, was 10000/10000). No regression in existing utilization tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/412"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784509560&installation_id=133247490&pr_number=412&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F412&signature=c618433d930c41c91506a4e3ab2a8e72923869cc2ff808730b01b09af37b8e04"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->