### PR TITLE
fix(fleet): per-provider circuit breaker + 5xx reclassifier (coordinator) + v0.6.16 #408 wedge & KV-pin recovery (provider) — DAR-335/336/337/338

### DIFF
--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -211,16 +211,30 @@ func (s *Server) refundProviderExtra(pr *registry.PendingRequest) {
 	s.ddIncr("billing.reservation_extra_refunds", []string{"model:" + pr.Model})
 }
 
-// noteInferenceError feeds the per-provider-model inference-error breaker for a
-// provider-side error received on a pending request's ErrorCh (any phase, pre-
-// or post-commit; the breaker itself only counts sickness-shaped 500/502/504)
-// and emits the cool-down metric on the transition into quarantine.
-func (s *Server) noteInferenceError(providerID string, pr *registry.PendingRequest, statusCode int) {
+// noteInferenceError feeds BOTH circuit breakers for a provider-side error
+// received on a pending request's ErrorCh (any phase, pre- or post-commit):
+//   - the shape-keyed inference-error breaker (counts only sickness-shaped
+//     500/502/504 for the (provider, model, shape) triple), and
+//   - the per-provider node-health breaker (DAR-335), which also counts
+//     fault-shaped 503s (errStr classifies capacity-503 vs fault-503).
+//
+// It emits the cool-down metric on the inference-error transition and the
+// provider_breaker_open metric on the node-health transition into quarantine.
+// errStr is the provider's error message ("" for synthetic timeouts).
+func (s *Server) noteInferenceError(providerID string, pr *registry.PendingRequest, statusCode int, errStr string) {
 	if providerID == "" || pr == nil {
 		return
 	}
 	if s.registry.RecordInferenceError(providerID, pr.Model, statusCode, pr.Traits.CooldownShape()) {
 		s.ddIncr("routing.cooldown_entered", []string{"model:" + pr.Model})
+	}
+	// DAR-335 per-provider node-health breaker: feed EVERY provider terminal
+	// (not just the shape-keyed 5xx the inference-error breaker counts) so a node
+	// fault-503ing ~all of its requests gets quarantined fleet-wide. errStr lets
+	// the breaker tell a capacity-503 (ignored) from a fault-503 (counted). Both
+	// breakers coexist.
+	if opened, _ := s.registry.RecordProviderOutcome(providerID, false, statusCode, errStr); opened {
+		s.ddIncr("routing.provider_breaker_open", []string{"model:" + pr.Model})
 	}
 }
 
@@ -232,6 +246,11 @@ func (s *Server) noteInferenceSuccess(pr *registry.PendingRequest) {
 		return
 	}
 	s.registry.RecordInferenceSuccess(pr.ProviderID, pr.Model, pr.Traits.CooldownShape())
+	// DAR-335: a clean completion proves the node is healthy — close its
+	// node-health breaker (and reset the exponential backoff) if it had tripped.
+	if _, closed := s.registry.RecordProviderOutcome(pr.ProviderID, true, 200, ""); closed {
+		s.ddIncr("routing.provider_breaker_closed", []string{"model:" + pr.Model})
+	}
 }
 
 // noteDispatchProviderError records a provider error received while the
@@ -252,9 +271,9 @@ func (s *Server) noteInferenceSuccess(pr *registry.PendingRequest) {
 // so arms where cancelDispatch did refund are safe, and a failed pre-commit
 // attempt never reaches settlement (its channels are closed and it is neither
 // pending nor parked), so this can never double-credit against a settle.
-func (s *Server) noteDispatchProviderError(provider *registry.Provider, pr *registry.PendingRequest, statusCode int, held *[]string) (discardedHeld bool) {
+func (s *Server) noteDispatchProviderError(provider *registry.Provider, pr *registry.PendingRequest, statusCode int, errStr string, held *[]string) (discardedHeld bool) {
 	if provider != nil {
-		s.noteInferenceError(provider.ID, pr, statusCode)
+		s.noteInferenceError(provider.ID, pr, statusCode, errStr)
 	}
 	s.refundProviderExtra(pr)
 	if held == nil || len(*held) == 0 {
@@ -2349,7 +2368,7 @@ func (s *Server) handleStreamingResponseWithFirstChunk(w http.ResponseWriter, r 
 				case errMsg, ok := <-pr.ErrorCh:
 					if ok && errMsg.Error != "" {
 						s.refundReservedBalance(pr, "provider_error:"+pr.RequestID)
-						s.noteInferenceError(pr.ProviderID, pr, errMsg.StatusCode)
+						s.noteInferenceError(pr.ProviderID, pr, errMsg.StatusCode, errMsg.Error)
 						s.ddIncr("inference.in_band_error", []string{"model:" + pr.Model, "reason:provider_error"})
 						s.updateInferenceRouteOutcomeForPending(pr, postCommitProviderErrorOutcome(pr, errMsg))
 						errData, _ := json.Marshal(map[string]any{
@@ -2493,7 +2512,7 @@ func (s *Server) handleStreamingResponseWithFirstChunk(w http.ResponseWriter, r 
 				continue
 			}
 			s.refundReservedBalance(pr, "provider_error:"+pr.RequestID)
-			s.noteInferenceError(pr.ProviderID, pr, errMsg.StatusCode)
+			s.noteInferenceError(pr.ProviderID, pr, errMsg.StatusCode, errMsg.Error)
 			s.ddIncr("inference.in_band_error", []string{"model:" + pr.Model, "reason:provider_error"})
 			s.updateInferenceRouteOutcomeForPending(pr, postCommitProviderErrorOutcome(pr, errMsg))
 			errData, _ := json.Marshal(map[string]any{
@@ -2584,7 +2603,7 @@ func (s *Server) handleResponsesStreamingResponseWithFirstChunk(w http.ResponseW
 				continue
 			}
 			s.refundReservedBalance(pr, "provider_error:"+pr.RequestID)
-			s.noteInferenceError(pr.ProviderID, pr, errMsg.StatusCode)
+			s.noteInferenceError(pr.ProviderID, pr, errMsg.StatusCode, errMsg.Error)
 			s.ddIncr("inference.in_band_error", []string{"model:" + pr.Model, "reason:provider_error"})
 			s.updateInferenceRouteOutcomeForPending(pr, postCommitProviderErrorOutcome(pr, errMsg))
 			emitter.emitError("provider_error", errMsg.Error)
@@ -2626,7 +2645,7 @@ func (s *Server) handleNonStreamingResponseWithFirstChunk(w http.ResponseWriter,
 				case errMsg, ok := <-pr.ErrorCh:
 					if ok && errMsg.Error != "" {
 						s.refundReservedBalance(pr, "provider_error:"+pr.RequestID)
-						s.noteInferenceError(pr.ProviderID, pr, errMsg.StatusCode)
+						s.noteInferenceError(pr.ProviderID, pr, errMsg.StatusCode, errMsg.Error)
 						s.updateInferenceRouteOutcomeForPending(pr, preResponseProviderErrorOutcome(pr, errMsg))
 						statusCode := errMsg.StatusCode
 						if statusCode == 0 {
@@ -2756,7 +2775,7 @@ func (s *Server) handleNonStreamingResponseWithFirstChunk(w http.ResponseWriter,
 				continue
 			}
 			s.refundReservedBalance(pr, "provider_error:"+pr.RequestID)
-			s.noteInferenceError(pr.ProviderID, pr, errMsg.StatusCode)
+			s.noteInferenceError(pr.ProviderID, pr, errMsg.StatusCode, errMsg.Error)
 			s.updateInferenceRouteOutcomeForPending(pr, preResponseProviderErrorOutcome(pr, errMsg))
 			statusCode := errMsg.StatusCode
 			if statusCode == 0 {
@@ -5360,7 +5379,7 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 				s.sendProviderCancel(provider, requestID)
 				refundExtra()
 				refundReservation()
-				s.noteInferenceError(provider.ID, pr, errMsg.StatusCode)
+				s.noteInferenceError(provider.ID, pr, errMsg.StatusCode, errMsg.Error)
 				s.updateInferenceRouteOutcomeForPending(pr, preCommitProviderErrorOutcome(pr, errMsg))
 				statusCode := errMsg.StatusCode
 				if statusCode == 0 {
@@ -5379,7 +5398,7 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 		s.sendProviderCancel(provider, requestID)
 		refundExtra()
 		refundReservation()
-		s.noteInferenceError(provider.ID, pr, errMsg.StatusCode)
+		s.noteInferenceError(provider.ID, pr, errMsg.StatusCode, errMsg.Error)
 		s.updateInferenceRouteOutcomeForPending(pr, preCommitProviderErrorOutcome(pr, errMsg))
 		statusCode := errMsg.StatusCode
 		if statusCode == 0 {
@@ -5427,7 +5446,7 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 					s.sendProviderCancel(provider, requestID)
 					refundExtra()
 					refundReservation()
-					s.noteInferenceError(provider.ID, pr, errMsg.StatusCode)
+					s.noteInferenceError(provider.ID, pr, errMsg.StatusCode, errMsg.Error)
 					s.updateInferenceRouteOutcomeForPending(pr, preCommitProviderErrorOutcome(pr, errMsg))
 					statusCode := errMsg.StatusCode
 					if statusCode == 0 {
@@ -5446,7 +5465,7 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 			s.sendProviderCancel(provider, requestID)
 			refundExtra()
 			refundReservation()
-			s.noteInferenceError(provider.ID, pr, errMsg.StatusCode)
+			s.noteInferenceError(provider.ID, pr, errMsg.StatusCode, errMsg.Error)
 			s.updateInferenceRouteOutcomeForPending(pr, preCommitProviderErrorOutcome(pr, errMsg))
 			statusCode := errMsg.StatusCode
 			if statusCode == 0 {
@@ -5462,8 +5481,9 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 			refundReservation()
 			// Accepted-then-silent is a provider-at-fault 504 — feed the
 			// breaker (single-attempt path: no retry here, but repeated
-			// stalls must still accumulate into the routing cooldown).
-			s.noteInferenceError(provider.ID, pr, http.StatusGatewayTimeout)
+			// stalls must still accumulate into the routing cooldown). No
+			// provider message on this synthetic timeout, so errStr is "".
+			s.noteInferenceError(provider.ID, pr, http.StatusGatewayTimeout, "")
 			s.ddIncr("inference.dispatches", []string{"status:timeout"})
 			s.updateInferenceRouteOutcomeForPending(pr, pendingRouteOutcome(pr, "timeout", "accepted_timeout", http.StatusGatewayTimeout))
 			writeJSON(w, http.StatusGatewayTimeout, errorResponse("timeout", "provider accepted but timed out before first chunk"))

--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -63,11 +63,18 @@ const (
 	// when the consumer reads slowly.
 	chunkBufferSize = 256
 
-	// maxDispatchAttempts is the maximum number of provider dispatch attempts
-	// before returning an error to the consumer. The coordinator retries on
-	// the same or a different provider when the first attempt fails (e.g.
-	// backend crashed, model not loaded after idle shutdown).
-	maxDispatchAttempts = 3
+	// maxDispatchAttempts is a SAFETY CEILING on per-request provider failover,
+	// not the normal stopping point. A request keeps failing over to fresh
+	// healthy providers until one succeeds, OR candidates are exhausted (every
+	// failed provider is excluded from re-selection, so dispatchPrimary returns
+	// outcomeFailFast on the next attempt once no eligible provider remains), OR
+	// the request's deadline/context fires (run() checks r.Context() each
+	// attempt). This ceiling only guards against a pathological retry path that
+	// fails to exclude a provider (an unbounded hot loop); it is set well above
+	// any realistic per-request fault count. Retries never re-queue — only the
+	// first attempt may wait for capacity — so failover stays fast, walking the
+	// immediately-available healthy providers rather than waiting on busy ones.
+	maxDispatchAttempts = 64
 
 	// speculativeTimerRatio is the fraction of the TTFT deadline at which
 	// the coordinator launches a speculative backup dispatch. The primary

--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -215,8 +215,8 @@ func (s *Server) refundProviderExtra(pr *registry.PendingRequest) {
 // received on a pending request's ErrorCh (any phase, pre- or post-commit):
 //   - the shape-keyed inference-error breaker (counts only sickness-shaped
 //     500/502/504 for the (provider, model, shape) triple), and
-//   - the per-provider node-health breaker (DAR-335), which also counts
-//     fault-shaped 503s (errStr classifies capacity-503 vs fault-503).
+//   - the per-provider node-health breaker, which also counts fault-shaped
+//     503s (errStr classifies capacity-503 vs fault-503).
 //
 // It emits the cool-down metric on the inference-error transition and the
 // provider_breaker_open metric on the node-health transition into quarantine.
@@ -228,8 +228,8 @@ func (s *Server) noteInferenceError(providerID string, pr *registry.PendingReque
 	if s.registry.RecordInferenceError(providerID, pr.Model, statusCode, pr.Traits.CooldownShape()) {
 		s.ddIncr("routing.cooldown_entered", []string{"model:" + pr.Model})
 	}
-	// DAR-335 per-provider node-health breaker: feed EVERY provider terminal
-	// (not just the shape-keyed 5xx the inference-error breaker counts) so a node
+	// Feed EVERY provider terminal into the per-provider node-health breaker (not
+	// just the shape-keyed 5xx the inference-error breaker counts) so a node
 	// fault-503ing ~all of its requests gets quarantined fleet-wide. errStr lets
 	// the breaker tell a capacity-503 (ignored) from a fault-503 (counted). Both
 	// breakers coexist.
@@ -246,8 +246,8 @@ func (s *Server) noteInferenceSuccess(pr *registry.PendingRequest) {
 		return
 	}
 	s.registry.RecordInferenceSuccess(pr.ProviderID, pr.Model, pr.Traits.CooldownShape())
-	// DAR-335: a clean completion proves the node is healthy — close its
-	// node-health breaker (and reset the exponential backoff) if it had tripped.
+	// A clean completion proves the node is healthy — close its node-health
+	// breaker (and reset the exponential backoff) if it had tripped.
 	if _, closed := s.registry.RecordProviderOutcome(pr.ProviderID, true, 200, ""); closed {
 		s.ddIncr("routing.provider_breaker_closed", []string{"model:" + pr.Model})
 	}

--- a/coordinator/api/deferred_commit_test.go
+++ b/coordinator/api/deferred_commit_test.go
@@ -372,3 +372,51 @@ func TestDeferredCommit_PreContentFailover(t *testing.T) {
 		t.Errorf("role preamble count = %d, want exactly 1 (failed attempt's preamble discarded); body:\n%s", got, body)
 	}
 }
+
+// TestDispatch_FailoverContinuesPastLegacyCap proves deadline-bounded failover:
+// the dispatch loop keeps trying fresh healthy providers well past the old
+// 3-attempt cap, stopping only at candidate exhaustion (or the deadline). Six
+// providers advertise higher TPS and crash pre-content (so routing prefers them
+// first and fails over off each); one healthy provider advertises the lowest TPS
+// and is therefore selected LAST. The request must still land on it. Under the
+// legacy maxDispatchAttempts=3 the loop gave up after the first few failing
+// providers and never reached the healthy one — even allowing for speculative
+// double-dispatch, six bad providers ahead of it exceeds that budget.
+func TestDispatch_FailoverContinuesPastLegacyCap(t *testing.T) {
+	ts, reg, _ := setupLoadTestServer(t)
+	defer ts.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	model := "failover-past-cap-model"
+
+	// Six failing providers, descending high TPS so routing prefers them first
+	// and fails over off each in turn.
+	for _, tps := range []float64{600, 500, 400, 300, 200, 100} {
+		pk := testPublicKeyB64()
+		conn := connectAndPrepareProvider(t, ctx, ts.URL, reg, model, pk, tps)
+		defer conn.Close(websocket.StatusNormalClosure, "")
+		go runDeferredCommitProvider(ctx, t, conn, pk, true, "")
+	}
+	// One healthy provider with the lowest TPS — reachable only after the six
+	// failing providers have each been tried and excluded.
+	healthyPK := testPublicKeyB64()
+	healthyConn := connectAndPrepareProvider(t, ctx, ts.URL, reg, model, healthyPK, 10.0)
+	defer healthyConn.Close(websocket.StatusNormalClosure, "")
+	go runDeferredCommitProvider(ctx, t, healthyConn, healthyPK, false, "from-healthy")
+
+	code, body, err := sendRequest(ctx, ts.URL, "test-key", model)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	if code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 after failing over past six bad providers; body = %s", code, body)
+	}
+	if !strings.Contains(body, "from-healthy") {
+		t.Errorf("failover must reach the healthy provider behind six failing ones; body:\n%s", body)
+	}
+	if strings.Contains(body, "provider crashed after preamble") {
+		t.Errorf("a failing provider's error leaked to the consumer; body:\n%s", body)
+	}
+}

--- a/coordinator/api/dispatch.go
+++ b/coordinator/api/dispatch.go
@@ -1800,6 +1800,16 @@ func (d *dispatchState) run() {
 
 	for attempt := range maxDispatchAttempts {
 		d.attempt = attempt
+		// Deadline-bounded failover: after the first attempt, stop failing over
+		// once the request's deadline/context has fired (client gone or a request
+		// timeout). We keep trying fresh healthy providers only while there is
+		// time budget left. Candidate exhaustion is handled inside dispatchPrimary
+		// (it returns outcomeFailFast as soon as no eligible provider remains), so
+		// in practice the loop ends at exhaustion or success; maxDispatchAttempts
+		// is only a hot-loop ceiling and this is the wall-clock bound.
+		if attempt > 0 && r.Context().Err() != nil {
+			goto exhausted
+		}
 		// Each attempt holds preamble chunks from its own provider only.
 		d.heldChunks = nil
 
@@ -1898,10 +1908,10 @@ exhausted:
 			s.ddIncr("routing.unservable_reclassified", []string{"model:" + d.model})
 		}
 		s.emitRequest(r.Context(), protocol.SeverityError, d.requestID,
-			fmt.Sprintf("inference failed after %d attempt(s)", maxDispatchAttempts),
+			fmt.Sprintf("inference failed after %d attempt(s)", d.attempt+1),
 			map[string]any{
 				"reason":      "dispatch_exhausted",
-				"attempt":     maxDispatchAttempts,
+				"attempt":     d.attempt + 1,
 				"status_code": statusCode,
 				"last_error":  d.lastErr,
 			})
@@ -1929,8 +1939,8 @@ exhausted:
 			// frozen, so surface the terminal failure in-band. Responses streams use
 			// a different error shape (event: error, no [DONE]) than chat completions.
 			rateLimited := statusCode == http.StatusTooManyRequests
-			capMsg := fmt.Sprintf("all providers at capacity after %d attempt(s): %s", maxDispatchAttempts, d.lastErr)
-			errMsg := fmt.Sprintf("inference failed after %d attempt(s): %s", maxDispatchAttempts, d.lastErr)
+			capMsg := fmt.Sprintf("all providers at capacity after %d attempt(s): %s", d.attempt+1, d.lastErr)
+			errMsg := fmt.Sprintf("inference failed after %d attempt(s): %s", d.attempt+1, d.lastErr)
 			if d.isResponsesAPI {
 				if rateLimited {
 					writeResponsesSSEErrorEvent(w, "rate_limit_exceeded", capMsg)
@@ -1946,11 +1956,11 @@ exhausted:
 		}
 		if statusCode == http.StatusTooManyRequests {
 			writeJSON(w, statusCode, errorResponse("rate_limit_exceeded",
-				fmt.Sprintf("all providers at capacity after %d attempt(s): %s", maxDispatchAttempts, d.lastErr),
+				fmt.Sprintf("all providers at capacity after %d attempt(s): %s", d.attempt+1, d.lastErr),
 				withCode("rate_limit_exceeded")))
 		} else {
 			writeJSON(w, statusCode, errorResponse("provider_error",
-				fmt.Sprintf("inference failed after %d attempt(s): %s", maxDispatchAttempts, d.lastErr)))
+				fmt.Sprintf("inference failed after %d attempt(s): %s", d.attempt+1, d.lastErr)))
 		}
 		return
 	}

--- a/coordinator/api/dispatch.go
+++ b/coordinator/api/dispatch.go
@@ -783,8 +783,8 @@ func (d *dispatchState) dispatchPrimary() dispatchOutcome {
 // provider error and, unless held boilerplate was discarded (which emits its own
 // pre-content failover counter), emits the generic retry counter. This is the
 // exact `if !s.noteDispatchProviderError(...) { s.ddIncr(retry) }` pattern.
-func (d *dispatchState) noteDispatchRetry(provider *registry.Provider, pr *registry.PendingRequest, statusCode int, held *[]string) {
-	if !d.s.noteDispatchProviderError(provider, pr, statusCode, held) {
+func (d *dispatchState) noteDispatchRetry(provider *registry.Provider, pr *registry.PendingRequest, statusCode int, errStr string, held *[]string) {
+	if !d.s.noteDispatchProviderError(provider, pr, statusCode, errStr, held) {
 		d.s.ddIncr("inference.dispatches", []string{"status:retry"})
 	}
 }
@@ -850,7 +850,7 @@ func (d *dispatchState) waitFirstChunk() (outcome dispatchOutcome) {
 					d.lastErr = errMsg.Error
 					d.lastErrCode = errMsg.StatusCode
 					d.lastFailedVersion = failedProviderVersion(provider)
-					d.noteDispatchRetry(provider, pr, errMsg.StatusCode, &d.heldChunks)
+					d.noteDispatchRetry(provider, pr, errMsg.StatusCode, errMsg.Error, &d.heldChunks)
 					d.provider = nil
 					d.pr = nil
 					return outcomeRetry
@@ -893,7 +893,7 @@ func (d *dispatchState) waitFirstChunk() (outcome dispatchOutcome) {
 			if s.metrics != nil {
 				s.metrics.IncCounter("inference_dispatches_total", MetricLabel{"result", "retry"})
 			}
-			d.noteDispatchRetry(provider, pr, errMsg.StatusCode, &d.heldChunks)
+			d.noteDispatchRetry(provider, pr, errMsg.StatusCode, errMsg.Error, &d.heldChunks)
 			d.provider = nil
 			d.pr = nil
 			return outcomeRetry
@@ -1069,7 +1069,7 @@ func (d *dispatchState) waitNoBackup() dispatchOutcome {
 					d.lastErr = errMsg.Error
 					d.lastErrCode = errMsg.StatusCode
 					d.lastFailedVersion = failedProviderVersion(provider)
-					d.noteDispatchRetry(provider, pr, errMsg.StatusCode, &d.heldChunks)
+					d.noteDispatchRetry(provider, pr, errMsg.StatusCode, errMsg.Error, &d.heldChunks)
 					d.provider = nil
 					d.pr = nil
 					return outcomeRetry
@@ -1092,7 +1092,7 @@ func (d *dispatchState) waitNoBackup() dispatchOutcome {
 			if s.metrics != nil {
 				s.metrics.IncCounter("inference_dispatches_total", MetricLabel{"result", "retry"})
 			}
-			d.noteDispatchRetry(provider, pr, errMsg.StatusCode, &d.heldChunks)
+			d.noteDispatchRetry(provider, pr, errMsg.StatusCode, errMsg.Error, &d.heldChunks)
 			d.provider = nil
 			d.pr = nil
 			return outcomeRetry
@@ -1187,7 +1187,7 @@ func (d *dispatchState) runRace(backupProvider *registry.Provider, backupPR *reg
 					d.lastErr = errMsg.Error
 					d.lastErrCode = errMsg.StatusCode
 					d.lastFailedVersion = failedProviderVersion(provider)
-					d.noteDispatchRetry(provider, pr, errMsg.StatusCode, &d.heldChunks)
+					d.noteDispatchRetry(provider, pr, errMsg.StatusCode, errMsg.Error, &d.heldChunks)
 					d.provider = nil
 					d.pr = nil
 					return outcomeRetry
@@ -1227,7 +1227,7 @@ func (d *dispatchState) runRace(backupProvider *registry.Provider, backupPR *reg
 					d.excludeProviders[backupProvider.ID] = struct{}{}
 					d.lastFailedVersion = failedProviderVersion(backupProvider)
 					d.updateSpeculativeFailure(backupPR, errMsg)
-					s.noteDispatchProviderError(backupProvider, backupPR, errMsg.StatusCode, &backupHeld)
+					s.noteDispatchProviderError(backupProvider, backupPR, errMsg.StatusCode, errMsg.Error, &backupHeld)
 					// Wait remaining deadline for primary.
 					return d.raceBackupChunkClosedWaitPrimary(provider, pr)
 				default:
@@ -1272,7 +1272,7 @@ func (d *dispatchState) runRace(backupProvider *registry.Provider, backupPR *reg
 			s.cancelDispatch(provider, pr)
 			d.lastFailedVersion = failedProviderVersion(provider)
 			d.updateSpeculativeFailure(pr, errMsg)
-			s.noteDispatchProviderError(provider, pr, errMsg.StatusCode, &d.heldChunks)
+			s.noteDispatchProviderError(provider, pr, errMsg.StatusCode, errMsg.Error, &d.heldChunks)
 			d.requestID = ""
 			d.provider = nil
 			d.pr = nil
@@ -1285,7 +1285,7 @@ func (d *dispatchState) runRace(backupProvider *registry.Provider, backupPR *reg
 			s.cancelDispatch(backupProvider, backupPR)
 			d.lastFailedVersion = failedProviderVersion(backupProvider)
 			d.updateSpeculativeFailure(backupPR, errMsg)
-			s.noteDispatchProviderError(backupProvider, backupPR, errMsg.StatusCode, &backupHeld)
+			s.noteDispatchProviderError(backupProvider, backupPR, errMsg.StatusCode, errMsg.Error, &backupHeld)
 			return d.raceBackupErrWaitPrimary(provider, pr)
 
 		case <-raceDeadline.C:
@@ -1306,10 +1306,10 @@ func (d *dispatchState) runRace(backupProvider *registry.Provider, backupPR *reg
 			// acceptedWait timeout path so a stalling provider/model
 			// (shape-keyed) trips its cooldown.
 			if len(d.heldChunks) > 0 {
-				s.noteInferenceError(provider.ID, pr, http.StatusGatewayTimeout)
+				s.noteInferenceError(provider.ID, pr, http.StatusGatewayTimeout, "")
 			}
 			if len(backupHeld) > 0 {
-				s.noteInferenceError(backupProvider.ID, backupPR, http.StatusGatewayTimeout)
+				s.noteInferenceError(backupProvider.ID, backupPR, http.StatusGatewayTimeout, "")
 			}
 			s.cancelDispatch(provider, pr)
 			s.registry.RecordWarmPoolTTFTMiss(d.model, d.deadline)
@@ -1368,7 +1368,7 @@ func (d *dispatchState) raceBackupChunkClosedWaitPrimary(provider *registry.Prov
 					d.lastErrCode = errMsg2.StatusCode
 					d.lastFailedVersion = failedProviderVersion(provider)
 					d.updateSpeculativeFailure(pr, errMsg2)
-					d.noteDispatchRetry(provider, pr, errMsg2.StatusCode, &d.heldChunks)
+					d.noteDispatchRetry(provider, pr, errMsg2.StatusCode, errMsg2.Error, &d.heldChunks)
 					d.provider = nil
 					d.pr = nil
 					d.requestID = ""
@@ -1394,7 +1394,7 @@ func (d *dispatchState) raceBackupChunkClosedWaitPrimary(provider *registry.Prov
 			d.lastErrCode = errMsg2.StatusCode
 			d.lastFailedVersion = failedProviderVersion(provider)
 			d.updateSpeculativeFailure(pr, errMsg2)
-			d.noteDispatchRetry(provider, pr, errMsg2.StatusCode, &d.heldChunks)
+			d.noteDispatchRetry(provider, pr, errMsg2.StatusCode, errMsg2.Error, &d.heldChunks)
 			d.provider = nil
 			d.pr = nil
 			d.requestID = ""
@@ -1469,7 +1469,7 @@ func (d *dispatchState) racePrimaryFailedWaitBackup(backupProvider *registry.Pro
 					d.lastErrCode = errMsg2.StatusCode
 					d.lastFailedVersion = failedProviderVersion(backupProvider)
 					d.updateSpeculativeFailure(backupPR, errMsg2)
-					d.noteDispatchRetry(backupProvider, backupPR, errMsg2.StatusCode, &backupHeld)
+					d.noteDispatchRetry(backupProvider, backupPR, errMsg2.StatusCode, errMsg2.Error, &backupHeld)
 					d.provider = nil
 					d.pr = nil
 					return outcomeRetry
@@ -1500,7 +1500,7 @@ func (d *dispatchState) racePrimaryFailedWaitBackup(backupProvider *registry.Pro
 			d.lastErrCode = errMsg2.StatusCode
 			d.lastFailedVersion = failedProviderVersion(backupProvider)
 			d.updateSpeculativeFailure(backupPR, errMsg2)
-			s.noteDispatchProviderError(backupProvider, backupPR, errMsg2.StatusCode, &backupHeld)
+			s.noteDispatchProviderError(backupProvider, backupPR, errMsg2.StatusCode, errMsg2.Error, &backupHeld)
 			d.provider = nil
 			d.pr = nil
 			return outcomeRetry
@@ -1568,7 +1568,7 @@ func (d *dispatchState) raceBackupErrWaitPrimary(provider *registry.Provider, pr
 					d.lastErr = errMsg2.Error
 					d.lastErrCode = errMsg2.StatusCode
 					d.lastFailedVersion = failedProviderVersion(provider)
-					d.noteDispatchRetry(provider, pr, errMsg2.StatusCode, &d.heldChunks)
+					d.noteDispatchRetry(provider, pr, errMsg2.StatusCode, errMsg2.Error, &d.heldChunks)
 					d.provider = nil
 					d.pr = nil
 					return outcomeRetry
@@ -1589,7 +1589,7 @@ func (d *dispatchState) raceBackupErrWaitPrimary(provider *registry.Provider, pr
 			d.lastErrCode = errMsg2.StatusCode
 			d.lastFailedVersion = failedProviderVersion(provider)
 			d.updateSpeculativeFailure(pr, errMsg2)
-			s.noteDispatchProviderError(provider, pr, errMsg2.StatusCode, &d.heldChunks)
+			s.noteDispatchProviderError(provider, pr, errMsg2.StatusCode, errMsg2.Error, &d.heldChunks)
 			d.provider = nil
 			d.pr = nil
 			d.requestID = ""
@@ -1707,7 +1707,7 @@ func (d *dispatchState) waitAccepted() (outcome dispatchOutcome) {
 					if s.metrics != nil {
 						s.metrics.IncCounter("inference_dispatches_total", MetricLabel{"result", "retry"})
 					}
-					d.noteDispatchRetry(provider, pr, errMsg.StatusCode, &d.heldChunks)
+					d.noteDispatchRetry(provider, pr, errMsg.StatusCode, errMsg.Error, &d.heldChunks)
 					d.provider = nil
 					d.pr = nil
 					return outcomeRetry
@@ -1740,7 +1740,7 @@ func (d *dispatchState) waitAccepted() (outcome dispatchOutcome) {
 			if s.metrics != nil {
 				s.metrics.IncCounter("inference_dispatches_total", MetricLabel{"result", "retry"})
 			}
-			d.noteDispatchRetry(provider, pr, errMsg.StatusCode, &d.heldChunks)
+			d.noteDispatchRetry(provider, pr, errMsg.StatusCode, errMsg.Error, &d.heldChunks)
 			d.provider = nil
 			d.pr = nil
 			return outcomeRetry
@@ -1753,7 +1753,7 @@ func (d *dispatchState) waitAccepted() (outcome dispatchOutcome) {
 			// that repeatedly acks and stalls enters cooldown instead
 			// of soaking retries forever. (504 is one of the breaker's
 			// counted codes; this arm is where those 504s originate.)
-			s.noteInferenceError(provider.ID, pr, http.StatusGatewayTimeout)
+			s.noteInferenceError(provider.ID, pr, http.StatusGatewayTimeout, "")
 			d.lastErr = "provider accepted but timed out before first chunk"
 			if d.preambleLiveness {
 				d.lastErr = "provider sent preamble but stalled before first content"

--- a/coordinator/api/dispatch.go
+++ b/coordinator/api/dispatch.go
@@ -1886,7 +1886,7 @@ exhausted:
 			} else {
 				statusCode = http.StatusServiceUnavailable
 			}
-		} else if statusCode >= 500 && isUnservableProviderError(d.lastErr) {
+		} else if statusCode >= 500 && isCapacityClassProviderError(d.lastErr) {
 			// Backstop (always on): the provider admitted the request then
 			// rejected it because (prompt+max_tokens) overflowed its token budget /
 			// KV / context — a capacity condition, not a server fault. Return an

--- a/coordinator/api/inference_failure_class.go
+++ b/coordinator/api/inference_failure_class.go
@@ -2,45 +2,134 @@ package api
 
 import "strings"
 
-// isUnservableProviderError reports whether a provider inference-error message
-// indicates the request was ADMITTED but then rejected because it could not fit
-// the provider — (prompt + max_tokens) overflowed its token budget / KV-cache
-// headroom / context window, or the model OOM'd at load. These are CAPACITY-class
-// conditions, not genuine server faults.
+// isCapacityClassProviderError reports whether a provider inference-error string
+// names a CAPACITY/LIFECYCLE condition rather than a genuine server fault. The
+// request was admitted (or the model was being (re)loaded) and then rejected
+// because the provider was momentarily unable to serve it: a token-budget /
+// KV-cache / context overflow, OOM, a slot cap, an update drain, queue/overload
+// backpressure, or a cold "model not loaded" miss.
 //
-// When the dispatch path exhausts all attempts with such an error, the
-// coordinator reclassifies the provider's raw 5xx to an uptime-NEUTRAL 429.
-// OpenRouter treats 429 as rate-limiting (no uptime penalty) and fails over,
-// whereas the 5xx counts against our uptime — and these "admitted_but_failed"
-// long-prompt 5xx were the dominant gpt-oss uptime regression. This is the
-// always-on backstop that complements the (gated) proactive servability gate:
-// it fires only on an ACTUAL provider rejection, so it carries no
-// over-rejection risk.
+// Split intent (DAR-336): provider 5xx are NOT blanket-reclassified. A crash is
+// OUR failure and must stay 5xx; only capacity-class conditions become a 429.
 //
-// Matching is substring/case-insensitive because the strings are human-readable
-// and drift across provider versions. It mirrors the provider's scheduler reject
-// strings ("token_budget_exhausted: …", "insufficient global kv cache headroom",
-// "… exceeds batch token budget") and the load-time memory strings already
-// classified by classifyLoadFailure.
-func isUnservableProviderError(errStr string) bool {
+//   - BUCKET A — capacity/lifecycle ⇒ return TRUE. When the dispatch path
+//     exhausts all attempts with such an error, the coordinator reclassifies the
+//     provider's raw 5xx to an uptime-NEUTRAL 429: OpenRouter treats 429 as
+//     rate-limiting (no uptime penalty) and fails over, whereas a 5xx counts
+//     against our uptime. It fires only on an ACTUAL provider rejection, so it
+//     carries no over-rejection risk.
+//
+//   - BUCKET B — genuine fault ⇒ return FALSE. Crashes/panics, internal /
+//     engine / backend failures, a "model load failed" (bad weights/metallib),
+//     and the opaque Foundation-bridged InferenceError stay 5xx so they remain
+//     visible on reliability metrics and a per-provider circuit breaker can
+//     deroute the offender.
+//
+// The DEFAULT for unknown/ambiguous strings is FALSE (fault) so a newly-observed
+// crash string stays visible until it is explicitly triaged.
+//
+// Matching is substring + case-insensitive because the strings are
+// human-readable and drift across provider versions; it mirrors the provider's
+// scheduler/loader reject strings ("token_budget_exhausted: …", "insufficient
+// global kv cache headroom", "provider draining for update", "model load failed:
+// …"). To classify a newly-observed string, drop it into capacityClassMarkers
+// (A) or faultClassMarkers (B) — each bucket lives in ONE place, with a handful
+// of non-substring predicates (whole-word "oom", "exceeds"+"context", slot-cap)
+// handled explicitly below.
+func isCapacityClassProviderError(errStr string) bool {
 	s := strings.ToLower(strings.TrimSpace(errStr))
 	if s == "" {
 		return false
 	}
-	switch {
-	case strings.Contains(s, "token_budget_exhausted"),
-		strings.Contains(s, "token budget"),
-		strings.Contains(s, "kv cache headroom"),
-		strings.Contains(s, "kv headroom"),
-		strings.Contains(s, "insufficient kv"),
-		strings.Contains(s, "insufficient memory"),
-		strings.Contains(s, "out of memory"),
-		containsWord(s, "oom"),
-		strings.Contains(s, "context length"),
-		strings.Contains(s, "context window"),
-		strings.Contains(s, "exceeds") && strings.Contains(s, "context"):
-		return true
-	default:
-		return false
+	// Normalise the curly apostrophe (U+2019) that macOS Foundation emits in
+	// "The operation couldn't be completed. …" so the BUCKET B marker below —
+	// written with a plain ASCII apostrophe — matches the real wire string.
+	s = strings.ReplaceAll(s, "\u2019", "'")
+
+	// BUCKET B (genuine fault) is checked FIRST so a fault signal always wins:
+	// e.g. "model load failed: …" stays a fault even if its suffix happens to
+	// mention memory. Markers here are specific enough never to appear in a pure
+	// capacity string.
+	for _, m := range faultClassMarkers {
+		if strings.Contains(s, m) {
+			return false
+		}
 	}
+
+	// BUCKET A (capacity/lifecycle) plain-substring markers ⇒ reclassify 5xx→429.
+	for _, m := range capacityClassMarkers {
+		if strings.Contains(s, m) {
+			return true
+		}
+	}
+
+	// BUCKET A predicates that need more than a plain substring.
+	switch {
+	case containsWord(s, "oom"):
+		// Whole-word "oom" only, so "boom" / "no room left" do NOT match.
+		return true
+	case strings.Contains(s, "exceeds") && strings.Contains(s, "context"):
+		// "prompt exceeds … context window/length" phrasings.
+		return true
+	case strings.Contains(s, "slot") &&
+		(strings.Contains(s, "active") || strings.Contains(s, "cap")):
+		// "All N model slot(s) are active; cannot load '…'" — slot-cap rejection.
+		return true
+	}
+
+	// DEFAULT: unknown/ambiguous ⇒ genuine fault (keep 5xx, stays visible).
+	return false
+}
+
+// capacityClassMarkers are BUCKET A substrings: ADMITTED-but-unservable or
+// lifecycle rejections that should reclassify a provider 5xx to an uptime-neutral
+// 429. Drop a newly-observed capacity string here (predicates that need more than
+// a substring — whole-word "oom", "exceeds"+"context", slot-cap — live in
+// isCapacityClassProviderError). Keep each marker specific enough that it never
+// captures a BUCKET B fault string — notably use "not loaded" / "no model
+// loaded", never a bare "load" / "loaded", so "model load failed" is NOT
+// swallowed here.
+var capacityClassMarkers = []string{
+	// Token budget / KV-cache / context overflow (request too big to fit).
+	"token_budget_exhausted",
+	"token budget",
+	"kv cache headroom",
+	"kv headroom",
+	"insufficient kv",
+	"context length",
+	"context window",
+	// Memory pressure at load/serve time.
+	"insufficient memory",
+	"out of memory",
+	// Update lifecycle: provider draining for a hot-swap restart
+	// (protocol.ProviderDrainingForUpdate = "provider draining for update").
+	"draining",
+	// Overload / backpressure: the request was not run, so failover is safe.
+	"request rejected",
+	"queue full",
+	"server busy",
+	"service temporarily unavailable",
+	"request timed out waiting for capacity",
+	// Cold miss: model not resident yet. NOT "model load failed" (a fault) —
+	// these markers match "model not loaded" / "is not loaded on this provider".
+	"not loaded",
+	"no model loaded",
+}
+
+// faultClassMarkers are BUCKET B substrings: genuine server faults that MUST stay
+// 5xx so they surface on reliability metrics and the per-provider circuit breaker
+// can deroute the offender. Drop a newly-observed crash/fault string here. Every
+// marker must be specific enough that it never appears in a capacity string.
+var faultClassMarkers = []string{
+	"panic",          // PanicHook / telemetry .panic — process crash
+	"fatal error",    // Swift fatalError / unrecoverable abort
+	"backend crash",  // telemetry .backendCrash — engine/backend died
+	"backend_crash",  // …and its wire-tag spelling
+	"internal error", // generic server fault
+	// Bad weights / metallib: a real load fault, NOT a capacity miss. MUST stay
+	// here (see the "not loaded" caveat in capacityClassMarkers above).
+	"model load failed",
+	// Opaque Foundation-bridged InferenceError (no LocalizedError conformance):
+	// "The operation couldn't be completed. (ProviderCore.InferenceError error N.)".
+	"the operation couldn't be completed",
 }

--- a/coordinator/api/inference_failure_class.go
+++ b/coordinator/api/inference_failure_class.go
@@ -9,8 +9,8 @@ import "strings"
 // KV-cache / context overflow, OOM, a slot cap, an update drain, queue/overload
 // backpressure, or a cold "model not loaded" miss.
 //
-// Split intent (DAR-336): provider 5xx are NOT blanket-reclassified. A crash is
-// OUR failure and must stay 5xx; only capacity-class conditions become a 429.
+// Split intent: provider 5xx are NOT blanket-reclassified. A crash is OUR
+// failure and must stay 5xx; only capacity-class conditions become a 429.
 //
 //   - BUCKET A — capacity/lifecycle ⇒ return TRUE. When the dispatch path
 //     exhausts all attempts with such an error, the coordinator reclassifies the

--- a/coordinator/api/inference_failure_class.go
+++ b/coordinator/api/inference_failure_class.go
@@ -46,10 +46,13 @@ func isCapacityClassProviderError(errStr string) bool {
 	// written with a plain ASCII apostrophe — matches the real wire string.
 	s = strings.ReplaceAll(s, "\u2019", "'")
 
-	// BUCKET B (genuine fault) is checked FIRST so a fault signal always wins:
-	// e.g. "model load failed: …" stays a fault even if its suffix happens to
-	// mention memory. Markers here are specific enough never to appear in a pure
-	// capacity string.
+	// Unambiguous HARD faults (crash / panic / internal / opaque) are checked
+	// FIRST so they always win — never a capacity shed even if the message
+	// mentions memory. NOTE: "model load failed" is deliberately NOT in this set;
+	// it is checked LATER (after the capacity markers) so a cold-load CAPACITY
+	// failure the provider wraps as "model load failed: insufficient memory"
+	// reclassifies to a 429, while a bad-weights load failure still falls through
+	// to a 5xx fault.
 	for _, m := range faultClassMarkers {
 		if strings.Contains(s, m) {
 			return false
@@ -75,6 +78,16 @@ func isCapacityClassProviderError(errStr string) bool {
 		(strings.Contains(s, "active") || strings.Contains(s, "cap")):
 		// "All N model slot(s) are active; cannot load '…'" — slot-cap rejection.
 		return true
+	}
+
+	// "model load failed: …" is checked AFTER the capacity markers above, so a
+	// transient cold-load CAPACITY failure the provider wraps as "model load
+	// failed: insufficient memory / insufficient KV / all N slot(s) active"
+	// already reclassified to 429 above. Reaching here means a "model load
+	// failed" with NO capacity reason — a genuine load fault (bad weights /
+	// metallib / corrupt model) — so it stays a 5xx.
+	if strings.Contains(s, "model load failed") {
+		return false
 	}
 
 	// DEFAULT: unknown/ambiguous ⇒ genuine fault (keep 5xx, stays visible).
@@ -130,10 +143,11 @@ var faultClassMarkers = []string{
 	"backend crash",  // telemetry .backendCrash — engine/backend died
 	"backend_crash",  // …and its wire-tag spelling
 	"internal error", // generic server fault
-	// Bad weights / metallib: a real load fault, NOT a capacity miss. MUST stay
-	// here (see the "not loaded" caveat in capacityClassMarkers above).
-	"model load failed",
 	// Opaque Foundation-bridged InferenceError (no LocalizedError conformance):
 	// "The operation couldn't be completed. (ProviderCore.InferenceError error N.)".
 	"the operation couldn't be completed",
+	// NOTE: "model load failed" is intentionally NOT here — it is checked in
+	// isCapacityClassProviderError AFTER the capacity markers, so a cold-load
+	// capacity failure ("model load failed: insufficient memory") reclassifies to
+	// 429 while a bad-weights load failure falls through to the default fault.
 }

--- a/coordinator/api/inference_failure_class.go
+++ b/coordinator/api/inference_failure_class.go
@@ -105,10 +105,14 @@ var capacityClassMarkers = []string{
 	// (protocol.ProviderDrainingForUpdate = "provider draining for update").
 	"draining",
 	// Overload / backpressure: the request was not run, so failover is safe.
+	// NB: "service temporarily unavailable" is intentionally NOT a marker — the
+	// coordinator itself emits "service temporarily unavailable — please retry"
+	// on its OWN store/DB errors (e.g. a failed reservation top-up in the
+	// dispatch path), which is a genuine coordinator fault that must stay a 5xx,
+	// not be hidden as an uptime-neutral 429.
 	"request rejected",
 	"queue full",
 	"server busy",
-	"service temporarily unavailable",
 	"request timed out waiting for capacity",
 	// Cold miss: model not resident yet. NOT "model load failed" (a fault) —
 	// these markers match "model not loaded" / "is not loaded on this provider".

--- a/coordinator/api/inference_failure_class_test.go
+++ b/coordinator/api/inference_failure_class_test.go
@@ -2,7 +2,7 @@ package api
 
 import "testing"
 
-// TestIsCapacityClassProviderError pins the capacity-vs-fault split (DAR-336).
+// TestIsCapacityClassProviderError pins the capacity-vs-fault split.
 //
 // BUCKET A (capacity/lifecycle) → true: the provider admitted/attempted the
 // request then rejected it for a capacity reason (token budget / KV-cache /

--- a/coordinator/api/inference_failure_class_test.go
+++ b/coordinator/api/inference_failure_class_test.go
@@ -2,36 +2,65 @@ package api
 
 import "testing"
 
-// TestIsUnservableProviderError pins the capacity-class provider-rejection
-// classifier: ADMITTED-but-unservable conditions (token budget / KV-cache
-// headroom / context overflow / OOM) are true; genuine faults and unrelated
-// strings are false. Matching is substring + case-insensitive, and the short
+// TestIsCapacityClassProviderError pins the capacity-vs-fault split (DAR-336).
+//
+// BUCKET A (capacity/lifecycle) → true: the provider admitted/attempted the
+// request then rejected it for a capacity reason (token budget / KV-cache /
+// context overflow / OOM / slot cap / update drain / overload backpressure /
+// cold "not loaded" miss). These reclassify a 5xx to an uptime-neutral 429.
+//
+// BUCKET B (genuine fault) → false: crashes/panics, internal/backend failures,
+// "model load failed" (bad weights/metallib), and the opaque Foundation string
+// stay 5xx. The default for unknown/ambiguous strings is also false (fault) so
+// crashes stay visible. Matching is substring + case-insensitive, and the short
 // "oom" token must match only on word boundaries (not "boom"/"room").
-func TestIsUnservableProviderError(t *testing.T) {
+func TestIsCapacityClassProviderError(t *testing.T) {
 	tests := []struct {
 		name string
 		in   string
 		want bool
 	}{
-		// Capacity-class provider rejections → unservable (true).
+		// --- BUCKET A: capacity-class provider rejections → true. ---
+		// Existing markers (no-regression).
 		{"token budget exhausted", "token_budget_exhausted: need 9000", true},
 		{"kv cache headroom", "insufficient global kv cache headroom", true},
 		{"insufficient memory mixed case", "Insufficient memory (10 GB free, need 14 GB)", true},
 		{"gpu oom word boundary", "GPU OOM", true},
 		{"context length overflow", "exceeds 8192 context length", true},
 		{"context window overflow", "prompt exceeds model context window", true},
+		// New markers / phrasings.
+		{"kv headroom real string", "insufficient global KV cache headroom", true},
+		{"queue timeout capacity", "request timed out waiting for capacity", true},
+		{"insufficient memory at load", "insufficient memory to load model 'X'", true},
+		{"token budget with detail", "token_budget_exhausted: request requires 5000 tokens but only 100 available", true},
+		{"slot cap active", "All 3 model slot(s) are active; cannot load 'X'", true},
+		{"provider draining for update", "provider draining for update", true},
+		{"request rejected backpressure", "request rejected", true},
+		{"server busy backpressure", "server busy", true},
+		{"queue full backpressure", "token_budget_exhausted: request queue full", true},
+		{"cold model not loaded", "Model 'X' is not loaded on this provider", true},
 
-		// Genuine faults / unrelated strings → servable (false).
+		// --- BUCKET B: genuine faults / unrelated strings → false. ---
+		// Existing cases (no-regression).
 		{"empty", "", false},
 		{"internal error", "internal error", false},
 		{"provider disconnected", "provider disconnected", false},
 		{"boom is not oom", "boom", false},
 		{"room is not oom", "no room left on device", false},
+		// New fault cases.
+		{"foundation opaque string", "The operation couldn't be completed. (ProviderCore.InferenceError error 0.)", false},
+		// Ordering-bug guard: "model load failed" MUST stay a fault even though
+		// the capacity bucket matches "not loaded" / "loaded"-shaped strings.
+		{"model load failed bad weights", "model load failed: invalid weights", false},
+		{"model load failed opaque", "model load failed: the operation couldn't be completed.", false},
+		{"panic crash", "panic: runtime error: index out of range", false},
+		{"fatal error crash", "fatal error: unexpectedly found nil", false},
+		{"backend crash", "backend_crash: engine exited", false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := isUnservableProviderError(tt.in); got != tt.want {
-				t.Errorf("isUnservableProviderError(%q) = %v, want %v", tt.in, got, tt.want)
+			if got := isCapacityClassProviderError(tt.in); got != tt.want {
+				t.Errorf("isCapacityClassProviderError(%q) = %v, want %v", tt.in, got, tt.want)
 			}
 		})
 	}

--- a/coordinator/api/inference_failure_class_test.go
+++ b/coordinator/api/inference_failure_class_test.go
@@ -39,6 +39,11 @@ func TestIsCapacityClassProviderError(t *testing.T) {
 		{"server busy backpressure", "server busy", true},
 		{"queue full backpressure", "token_budget_exhausted: request queue full", true},
 		{"cold model not loaded", "Model 'X' is not loaded on this provider", true},
+		// "model load failed: <capacity reason>" — a transient cold-load capacity
+		// failure must reclassify to 429 (capacity wins over the load-fail wrapper).
+		{"load failed insufficient memory", "model load failed: insufficient memory to load model 'X'", true},
+		{"load failed insufficient kv", "model load failed: insufficient KV headroom for 'X'", true},
+		{"load failed slot cap", "model load failed: all 3 model slot(s) are active", true},
 
 		// --- BUCKET B: genuine faults / unrelated strings → false. ---
 		// Existing cases (no-regression).

--- a/coordinator/api/inference_failure_class_test.go
+++ b/coordinator/api/inference_failure_class_test.go
@@ -45,6 +45,11 @@ func TestIsCapacityClassProviderError(t *testing.T) {
 		{"empty", "", false},
 		{"internal error", "internal error", false},
 		{"provider disconnected", "provider disconnected", false},
+		// Coordinator-generated 503 (e.g. a failed reservation top-up in the
+		// dispatch path emits "service temporarily unavailable — please retry")
+		// must stay a fault — NOT be hidden as an uptime-neutral 429 — because it
+		// is the coordinator's own failure, not provider capacity backpressure.
+		{"coordinator service unavailable stays fault", "service temporarily unavailable — please retry", false},
 		{"boom is not oom", "boom", false},
 		{"room is not oom", "no room left on device", false},
 		// New fault cases.

--- a/coordinator/api/provider_test.go
+++ b/coordinator/api/provider_test.go
@@ -214,10 +214,14 @@ func TestProviderInferenceError(t *testing.T) {
 				conn.Write(ctx, websocket.MessageText, respData)
 			case protocol.TypeInferenceRequest:
 				reqID, _ := raw["request_id"].(string)
+				// DAR-336: assert a GENUINE provider fault (5xx) propagates to
+				// the consumer unchanged. "model not loaded" is now a
+				// capacity-class cold miss that reclassifies to 429, so use an
+				// unambiguous fault string to exercise the fault-passthrough path.
 				errMsg := protocol.InferenceErrorMessage{
 					Type:       protocol.TypeInferenceError,
 					RequestID:  reqID,
-					Error:      "model not loaded",
+					Error:      "internal error",
 					StatusCode: 500,
 				}
 				errData, _ := json.Marshal(errMsg)

--- a/coordinator/api/provider_test.go
+++ b/coordinator/api/provider_test.go
@@ -214,10 +214,10 @@ func TestProviderInferenceError(t *testing.T) {
 				conn.Write(ctx, websocket.MessageText, respData)
 			case protocol.TypeInferenceRequest:
 				reqID, _ := raw["request_id"].(string)
-				// DAR-336: assert a GENUINE provider fault (5xx) propagates to
-				// the consumer unchanged. "model not loaded" is now a
-				// capacity-class cold miss that reclassifies to 429, so use an
-				// unambiguous fault string to exercise the fault-passthrough path.
+				// Assert a GENUINE provider fault (5xx) propagates to the consumer
+				// unchanged. "model not loaded" is now a capacity-class cold miss
+				// that reclassifies to 429, so use an unambiguous fault string to
+				// exercise the fault-passthrough path.
 				errMsg := protocol.InferenceErrorMessage{
 					Type:       protocol.TypeInferenceError,
 					RequestID:  reqID,

--- a/coordinator/registry/provider_breaker.go
+++ b/coordinator/registry/provider_breaker.go
@@ -12,9 +12,9 @@ import (
 // counts sickness-shaped 500/502/504 — it deliberately ignores 503 (the
 // provider's capacity/lifecycle signal) and resets per shape on success. The
 // hole it leaves: a NODE that has gone bad at the box level and returns a
-// GENUINE-FAULT 503 ("request rejected", internal error, a crashed/panicked
-// backend, or the opaque Foundation "the operation couldn't be completed"
-// string) for ~100% of its requests stays fully routable. Reputation skips 503,
+// GENUINE-FAULT 503 (an internal error, a crashed/panicked backend, or the
+// opaque Foundation "the operation couldn't be completed" string) for ~100% of
+// its requests stays fully routable. Reputation skips 503,
 // the dispatch-load cooldown only fires on model-load failures, and within-
 // request retry is per-request. Worse, the bad node keeps reporting slot_state
 // = idle + a warm model, so the scheduler treats it as an ideal instant-TTFT
@@ -261,9 +261,9 @@ func (r *Registry) ProviderBreakerOpen(providerID string) bool {
 // Genuine faults (returns true — counted toward the breaker):
 //   - 500/502/504 always (provider-sickness shapes, same as the inference-error
 //     breaker)
-//   - a 503 whose message indicates a real fault ("request rejected", internal
-//     error, model load failed, crash/panic, the opaque Foundation string) and,
-//     by default, ANY 503 not recognized as a capacity shed
+//   - a 503 whose message indicates a real fault (internal error, model load
+//     failed, crash/panic, the opaque Foundation string) and, by default, ANY
+//     503 not recognized as a capacity shed
 //
 // Any other code (e.g. an unattributed 0/501/505) is NOT counted — conservative,
 // matching the inference-error breaker ignoring unattributed 5xx.
@@ -296,6 +296,11 @@ var capacityShed503Markers = []string{
 	"context length",
 	"context window",
 	"draining",
+	// Overload / backpressure sheds: the request was never run, so the node is
+	// healthy-but-busy. Classified as capacity here for consistency with the api
+	// reclassifier and the inference-error breaker, which also treat these as
+	// capacity/lifecycle rather than node faults.
+	"request rejected",
 	"request timed out waiting for capacity",
 	"queue full",
 	"server busy",

--- a/coordinator/registry/provider_breaker.go
+++ b/coordinator/registry/provider_breaker.go
@@ -1,0 +1,353 @@
+package registry
+
+import (
+	"strings"
+	"time"
+)
+
+// Per-provider (node-health) circuit breaker.
+//
+// SEPARATE from and ADDITIONAL to the shape-keyed inference-error breaker in
+// error_cooldown.go. That breaker is keyed by (provider, model, shape) and only
+// counts sickness-shaped 500/502/504 — it deliberately ignores 503 (the
+// provider's capacity/lifecycle signal) and resets per shape on success. The
+// hole it leaves: a NODE that has gone bad at the box level and returns a
+// GENUINE-FAULT 503 ("request rejected", internal error, a crashed/panicked
+// backend, or the opaque Foundation "the operation couldn't be completed"
+// string) for ~100% of its requests stays fully routable. Reputation skips 503,
+// the dispatch-load cooldown only fires on model-load failures, and within-
+// request retry is per-request. Worse, the bad node keeps reporting slot_state
+// = idle + a warm model, so the scheduler treats it as an ideal instant-TTFT
+// target and keeps feeding it (one box failed 99/99 for 15+ minutes in prod).
+//
+// This breaker is keyed by PROVIDER only (across every model and shape): a
+// node returning faults for ~all requests is sick regardless of cause, so it is
+// quarantined fleet-wide, re-probed after an exponential cooldown, and
+// auto-re-admitted on the first success.
+//
+// FAIL OPEN. Capacity-class sheds NEVER count (4xx/429 and a healthy-but-busy
+// 503 — token budget, KV headroom, draining, queue full, …), so load alone can
+// never trip it. And when the breaker would deroute EVERY provider for a model
+// (e.g. a bad fleet-wide rollout that fault-503s everywhere), selection re-scans
+// with the breaker bypassed (see selectBestCandidateLockedFull) so routing can
+// never be zeroed out — mirroring servability.go's fail-open philosophy.
+//
+// r.mu discipline, opportunistic >1024 map sweep, and the transition-bool
+// return all mirror error_cooldown.go.
+const (
+	// providerBreakerConsecTrip: consecutive FAULT outcomes (no success in
+	// between) that open the breaker. A node failing this many in a row is
+	// almost certainly sick, independent of overall volume.
+	providerBreakerConsecTrip = 5
+	// providerBreakerWindow is the sliding window over which the fail-rate trip
+	// condition is evaluated.
+	providerBreakerWindow = 120 * time.Second
+	// providerBreakerMinVolume is the minimum number of outcomes inside the
+	// window before the fail-rate condition can trip — avoids quarantining a
+	// node on a tiny, unlucky sample.
+	providerBreakerMinVolume = 20
+	// providerBreakerFailRate is the fraction of windowed outcomes that must be
+	// faults for the rate condition to trip (strictly greater-than).
+	providerBreakerFailRate = 0.80
+	// providerBreakerBaseCooldown is the first quarantine duration. Each
+	// successive trip without an intervening success doubles it (capped at
+	// providerBreakerMaxCooldown) so a persistently-bad node backs off fast.
+	providerBreakerBaseCooldown = 60 * time.Second
+	// providerBreakerMaxCooldown caps the exponential backoff.
+	providerBreakerMaxCooldown = 5 * time.Minute
+	// providerHealthRingSize is the fixed number of recent (fault/success)
+	// outcomes retained per provider for the fail-rate computation. Healthy
+	// sheds are never recorded, so the ring holds only faults and successes.
+	providerHealthRingSize = 20
+)
+
+// providerHealthOutcome is one recorded terminal: ok=false is a FAULT, ok=true
+// is a SUCCESS. Capacity/client sheds are never recorded.
+type providerHealthOutcome struct {
+	ts time.Time
+	ok bool
+}
+
+// providerHealthWindow is a fixed-size ring of the most recent
+// providerHealthRingSize outcomes for one provider, plus the running count of
+// CONSECUTIVE faults (reset by any success). The ring backs the windowed
+// fail-rate trip condition; consecFail backs the consecutive-fault condition.
+type providerHealthWindow struct {
+	outcomes   [providerHealthRingSize]providerHealthOutcome
+	size       int // number of valid entries (saturates at providerHealthRingSize)
+	head       int // index of the next write
+	consecFail int // consecutive faults; reset to 0 on any success
+}
+
+// record appends one outcome to the ring and updates the consecutive-fault
+// counter. Only faults and successes are recorded (callers filter healthy sheds
+// out first).
+func (w *providerHealthWindow) record(ok bool, now time.Time) {
+	w.outcomes[w.head] = providerHealthOutcome{ts: now, ok: ok}
+	w.head = (w.head + 1) % providerHealthRingSize
+	if w.size < providerHealthRingSize {
+		w.size++
+	}
+	if ok {
+		w.consecFail = 0
+	} else {
+		w.consecFail++
+	}
+}
+
+// windowStats returns the number of outcomes recorded within [now-window, now]
+// and how many of those were faults.
+func (w *providerHealthWindow) windowStats(now time.Time, window time.Duration) (total, fails int) {
+	cutoff := now.Add(-window)
+	for i := 0; i < w.size; i++ {
+		o := w.outcomes[i]
+		if o.ts.Before(cutoff) {
+			continue
+		}
+		total++
+		if !o.ok {
+			fails++
+		}
+	}
+	return total, fails
+}
+
+// RecordProviderOutcome feeds one provider terminal into the node-health
+// breaker. ok reports whether the request ultimately succeeded; statusCode and
+// errStr describe the failure when ok is false. It returns opened=true ONLY on
+// the transition into quarantine and closed=true ONLY on the transition out
+// (so callers emit metrics without double-counting).
+//
+// Classification (errStr matched case-insensitively, substring-based — provider
+// strings are human-readable and drift across versions):
+//   - Healthy shed (IGNORED — not recorded, consecFail/ring untouched):
+//     ok==false with a client-shape code (429 or any 4xx) or a CAPACITY-class
+//     503 (token budget / KV headroom / memory / OOM / context / draining /
+//     busy slot / queue full / …). Load alone must never trip the breaker.
+//   - Fault (COUNTED): 500/502/504 always; a 503 whose message indicates a real
+//     fault, and — by default — any 503 not recognized as a capacity shed.
+//   - Success (ok==true): clears the breaker if it had tripped.
+func (r *Registry) RecordProviderOutcome(providerID string, ok bool, statusCode int, errStr string) (opened bool, closed bool) {
+	if providerID == "" {
+		return false, false
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	now := time.Now()
+
+	// Opportunistic sweep (mirrors error_cooldown.go): provider ids are
+	// per-session UUIDs, so dead entries never get re-keyed — bound the maps by
+	// dropping expired/idle entries once they grow.
+	if len(r.providerBreakerOpenUntil) > 1024 {
+		for id, until := range r.providerBreakerOpenUntil {
+			if !now.Before(until) {
+				delete(r.providerBreakerOpenUntil, id)
+				delete(r.providerBreakerTrips, id)
+			}
+		}
+	}
+	if len(r.providerOutcomes) > 1024 {
+		for id, w := range r.providerOutcomes {
+			if total, _ := w.windowStats(now, providerBreakerWindow); total == 0 {
+				delete(r.providerOutcomes, id)
+			}
+		}
+	}
+
+	// SUCCESS: a served request proves the node is healthy. Record it, reset the
+	// consecutive-fault counter, and CLOSE the breaker (clearing the exponential
+	// backoff) if it had ever tripped — this is the auto-re-admit on recovery.
+	if ok {
+		r.providerHealthWindowLocked(providerID).record(true, now)
+		if _, had := r.providerBreakerOpenUntil[providerID]; had {
+			delete(r.providerBreakerOpenUntil, providerID)
+			delete(r.providerBreakerTrips, providerID)
+			return false, true
+		}
+		return false, false
+	}
+
+	// FAILURE: ignore healthy sheds entirely — only genuine faults touch the
+	// ring / consecutive-fault counter, so a busy fleet (429 / capacity-503) can
+	// never be quarantined.
+	if !providerOutcomeIsFault(statusCode, errStr) {
+		return false, false
+	}
+	w := r.providerHealthWindowLocked(providerID)
+	w.record(false, now)
+
+	// Already open: the gate is derouting new traffic. In-flight faults are
+	// still recorded above, but must not re-arm until the cooldown elapses
+	// (the half-open probe handles that below).
+	if until, had := r.providerBreakerOpenUntil[providerID]; had && now.Before(until) {
+		return false, false
+	}
+
+	// Not currently open. Two ways to (re-)arm:
+	//   - half-open: the breaker had tripped (trips>0) and its cooldown elapsed,
+	//     so a probe request was allowed through and just faulted — the node is
+	//     still bad, so re-arm with the next, larger backoff.
+	//   - closed: trip on either the consecutive-fault or the sustained
+	//     fail-rate threshold.
+	trips := r.providerBreakerTrips[providerID]
+	halfOpen := trips > 0
+	total, fails := w.windowStats(now, providerBreakerWindow)
+	rateTrip := total >= providerBreakerMinVolume && float64(fails) > providerBreakerFailRate*float64(total)
+	if !halfOpen && w.consecFail < providerBreakerConsecTrip && !rateTrip {
+		return false, false
+	}
+
+	r.providerBreakerOpenUntil[providerID] = now.Add(providerBreakerBackoff(trips))
+	r.providerBreakerTrips[providerID] = trips + 1
+	return true, false
+}
+
+// providerHealthWindowLocked returns the provider's health ring, creating it on
+// first use. Caller holds r.mu.
+func (r *Registry) providerHealthWindowLocked(providerID string) *providerHealthWindow {
+	w := r.providerOutcomes[providerID]
+	if w == nil {
+		w = &providerHealthWindow{}
+		r.providerOutcomes[providerID] = w
+	}
+	return w
+}
+
+// providerBreakerBackoff returns the cooldown for a provider that has already
+// tripped `trips` times (0 = first trip): base * 2^trips, capped at the max. The
+// loop avoids overflowing the shift for large trip counts.
+func providerBreakerBackoff(trips int) time.Duration {
+	cooldown := providerBreakerBaseCooldown
+	for i := 0; i < trips && cooldown < providerBreakerMaxCooldown; i++ {
+		cooldown *= 2
+	}
+	if cooldown > providerBreakerMaxCooldown {
+		cooldown = providerBreakerMaxCooldown
+	}
+	return cooldown
+}
+
+// providerBreakerOpenLocked reports whether routing should skip this provider
+// because its node-health breaker is OPEN. True iff now is before the open
+// expiry; once now >= expiry it returns false so the next request is allowed
+// through as a half-open probe. READ-ONLY (no lazy delete) so it is safe under
+// r.mu held in either mode — mirrors inferenceErrorCooldownActiveLocked. Caller
+// holds r.mu.
+func (r *Registry) providerBreakerOpenLocked(providerID string, now time.Time) bool {
+	until, ok := r.providerBreakerOpenUntil[providerID]
+	return ok && now.Before(until)
+}
+
+// ProviderBreakerOpen reports whether the per-provider node-health breaker is
+// currently quarantining the provider. Exposed for tests/observability; the
+// routing hot path uses providerBreakerOpenLocked under the already-held r.mu.
+func (r *Registry) ProviderBreakerOpen(providerID string) bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.providerBreakerOpenLocked(providerID, time.Now())
+}
+
+// providerOutcomeIsFault classifies a FAILED provider terminal (ok==false) for
+// the node-health breaker. It is intentionally implemented LOCALLY in the
+// registry package: the api package owns the request-time failure classifier,
+// and importing it here would create an import cycle (api already imports
+// registry).
+//
+// Healthy sheds (returns false — never counted):
+//   - client-shape failures: 429 and any 4xx (400-499, incl. 499 cancel)
+//   - capacity-class 503: a healthy-but-busy provider (see isCapacityShed503)
+//
+// Genuine faults (returns true — counted toward the breaker):
+//   - 500/502/504 always (provider-sickness shapes, same as the inference-error
+//     breaker)
+//   - a 503 whose message indicates a real fault ("request rejected", internal
+//     error, model load failed, crash/panic, the opaque Foundation string) and,
+//     by default, ANY 503 not recognized as a capacity shed
+//
+// Any other code (e.g. an unattributed 0/501/505) is NOT counted — conservative,
+// matching the inference-error breaker ignoring unattributed 5xx.
+func providerOutcomeIsFault(statusCode int, errStr string) bool {
+	if statusCode == 429 || (statusCode >= 400 && statusCode <= 499) {
+		return false
+	}
+	switch statusCode {
+	case 500, 502, 504:
+		return true
+	case 503:
+		return !isCapacityShed503(errStr)
+	default:
+		return false
+	}
+}
+
+// capacityShed503Markers are lowercased substrings that mark a 503 as a
+// healthy-but-busy CAPACITY shed rather than a fault. A provider returning any
+// of these is healthy and must never be derouted by the node-health breaker —
+// quarantining it would shed load exactly when the fleet is busy. Kept in sync
+// in spirit with the provider's capacity/lifecycle 503 vocabulary.
+var capacityShed503Markers = []string{
+	"token_budget",
+	"kv headroom",
+	"kv cache headroom",
+	"insufficient kv",
+	"insufficient memory",
+	"out of memory",
+	"context length",
+	"context window",
+	"draining",
+	"request timed out waiting for capacity",
+	"queue full",
+	"server busy",
+	"service temporarily unavailable",
+}
+
+// isCapacityShed503 reports whether a 503's message describes a healthy-but-busy
+// capacity/lifecycle shed (which must NOT count toward the breaker). Matching is
+// case-insensitive and substring-based, except "oom" (whole word, so "room" /
+// "bloom" do not match) and the ("slot" AND "active") pair (a busy-slot shed).
+func isCapacityShed503(errStr string) bool {
+	s := strings.ToLower(errStr)
+	for _, m := range capacityShed503Markers {
+		if strings.Contains(s, m) {
+			return true
+		}
+	}
+	if containsWord(s, "oom") {
+		return true
+	}
+	if strings.Contains(s, "slot") && strings.Contains(s, "active") {
+		return true
+	}
+	return false
+}
+
+// containsWord reports whether word appears in s delimited by non-word
+// boundaries, so a short token like "oom" matches "gpu oom" but not "boom" or
+// "room". word is assumed lowercase/alphanumeric; s is already lowercased.
+// (Local to the registry package; mirrors the api package's helper of the same
+// name — the two live in different packages.)
+func containsWord(s, word string) bool {
+	for from := 0; from+len(word) <= len(s); {
+		i := strings.Index(s[from:], word)
+		if i < 0 {
+			return false
+		}
+		start := from + i
+		end := start + len(word)
+		beforeOK := start == 0 || !isWordByte(s[start-1])
+		afterOK := end == len(s) || !isWordByte(s[end])
+		if beforeOK && afterOK {
+			return true
+		}
+		from = start + 1
+	}
+	return false
+}
+
+func isWordByte(b byte) bool {
+	return b == '_' ||
+		(b >= 'a' && b <= 'z') ||
+		(b >= 'A' && b <= 'Z') ||
+		(b >= '0' && b <= '9')
+}

--- a/coordinator/registry/provider_breaker.go
+++ b/coordinator/registry/provider_breaker.go
@@ -26,7 +26,7 @@ import (
 // auto-re-admitted on the first success.
 //
 // FAIL OPEN. Capacity-class sheds NEVER count (4xx/429 and a healthy-but-busy
-// 503 — token budget, KV headroom, draining, queue full, …), so load alone can
+// 5xx — token budget, KV headroom, draining, queue full, …), so load alone can
 // never trip it. And when the breaker would deroute EVERY provider for a model
 // (e.g. a bad fleet-wide rollout that fault-503s everywhere), selection re-scans
 // with the breaker bypassed (see selectBestCandidateLockedFull) so routing can
@@ -121,8 +121,8 @@ func (w *providerHealthWindow) windowStats(now time.Time, window time.Duration) 
 // Classification (errStr matched case-insensitively, substring-based — provider
 // strings are human-readable and drift across versions):
 //   - Healthy shed (IGNORED — not recorded, consecFail/ring untouched):
-//     ok==false with a client-shape code (429 or any 4xx) or a CAPACITY-class
-//     503 (token budget / KV headroom / memory / OOM / context / draining /
+//     ok==false with a client-shape code (429 or any 4xx) or a capacity-class
+//     5xx (token budget / KV headroom / memory / OOM / context / draining /
 //     busy slot / queue full / …). Load alone must never trip the breaker.
 //   - Fault (COUNTED): 500/502/504 always; a 503 whose message indicates a real
 //     fault, and — by default — any 503 not recognized as a capacity shed.
@@ -256,37 +256,44 @@ func (r *Registry) ProviderBreakerOpen(providerID string) bool {
 //
 // Healthy sheds (returns false — never counted):
 //   - client-shape failures: 429 and any 4xx (400-499, incl. 499 cancel)
-//   - capacity-class 503: a healthy-but-busy provider (see isCapacityShed503)
+//   - a capacity-class 5xx: a healthy-but-busy provider (see isCapacityShedError)
 //
 // Genuine faults (returns true — counted toward the breaker):
-//   - 500/502/504 always (provider-sickness shapes, same as the inference-error
-//     breaker)
-//   - a 503 whose message indicates a real fault (internal error, model load
-//     failed, crash/panic, the opaque Foundation string) and, by default, ANY
-//     503 not recognized as a capacity shed
+//   - a 5xx (500/502/503/504) whose message is NOT a capacity shed: a real
+//     crash, internal error, model-load fault, disconnect-flush, or silent
+//     timeout, and by default any such 5xx not recognized as a capacity shed
 //
-// Any other code (e.g. an unattributed 0/501/505) is NOT counted — conservative,
-// matching the inference-error breaker ignoring unattributed 5xx.
+// Capacity-shaped 5xx are ignored regardless of the exact code: capacity rejects
+// usually arrive as 503, but some/older paths surface them as 500/502/504 and
+// the dispatch reclassifier turns those into uptime-neutral 429s, so counting
+// them here would deroute a healthy busy node. Any other code (e.g. an
+// unattributed 0/501/505) is NOT counted — conservative.
 func providerOutcomeIsFault(statusCode int, errStr string) bool {
 	if statusCode == 429 || (statusCode >= 400 && statusCode <= 499) {
 		return false
 	}
 	switch statusCode {
-	case 500, 502, 504:
-		return true
-	case 503:
-		return !isCapacityShed503(errStr)
+	case 500, 502, 503, 504:
+		// A 5xx whose MESSAGE names a capacity/backpressure condition is a
+		// healthy-but-busy shed, not a node fault — ignore it regardless of the
+		// exact status code. Capacity rejects normally arrive as 503, but some
+		// (and older) provider paths surface token-budget / KV / context capacity
+		// as 500/502/504, and the dispatch reclassifier already turns those into
+		// uptime-neutral 429s; counting them as faults here would deroute a
+		// healthy busy node. A 5xx with no capacity marker (a real crash, a
+		// disconnect-flush, or a silent timeout) is a genuine fault.
+		return !isCapacityShedError(errStr)
 	default:
 		return false
 	}
 }
 
-// capacityShed503Markers are lowercased substrings that mark a 503 as a
+// capacityShedMarkers are lowercased substrings that mark a 5xx as a
 // healthy-but-busy CAPACITY shed rather than a fault. A provider returning any
 // of these is healthy and must never be derouted by the node-health breaker —
 // quarantining it would shed load exactly when the fleet is busy. Kept in sync
-// in spirit with the provider's capacity/lifecycle 503 vocabulary.
-var capacityShed503Markers = []string{
+// in spirit with the provider's capacity/lifecycle reject vocabulary.
+var capacityShedMarkers = []string{
 	"token_budget",
 	"kv headroom",
 	"kv cache headroom",
@@ -307,13 +314,14 @@ var capacityShed503Markers = []string{
 	"service temporarily unavailable",
 }
 
-// isCapacityShed503 reports whether a 503's message describes a healthy-but-busy
-// capacity/lifecycle shed (which must NOT count toward the breaker). Matching is
-// case-insensitive and substring-based, except "oom" (whole word, so "room" /
-// "bloom" do not match) and the ("slot" AND "active") pair (a busy-slot shed).
-func isCapacityShed503(errStr string) bool {
+// isCapacityShedError reports whether a failed 5xx terminal's message describes a
+// healthy-but-busy capacity/lifecycle shed (which must NOT count toward the
+// breaker). Matching is case-insensitive and substring-based, except "oom"
+// (whole word, so "room" / "bloom" do not match) and the ("slot" AND "active")
+// pair (a busy-slot shed).
+func isCapacityShedError(errStr string) bool {
 	s := strings.ToLower(errStr)
-	for _, m := range capacityShed503Markers {
+	for _, m := range capacityShedMarkers {
 		if strings.Contains(s, m) {
 			return true
 		}

--- a/coordinator/registry/provider_breaker_test.go
+++ b/coordinator/registry/provider_breaker_test.go
@@ -64,10 +64,17 @@ func TestProviderOutcomeIsFault(t *testing.T) {
 		{422, "unprocessable", false},
 		{499, "client closed request", false},
 		{418, "teapot", false},
-		// Provider-sickness status codes always count.
+		// Provider-sickness status codes count when the message is not capacity.
 		{500, "internal server error", true},
 		{502, "bad gateway", true},
 		{504, "", true},
+		// ...but a capacity/backpressure message makes a 500/502/504 a healthy
+		// shed too: some (and older) provider paths surface capacity rejects as a
+		// non-503 5xx, and the dispatch reclassifier turns those into uptime-
+		// neutral 429s, so the node breaker must not count them as faults.
+		{500, "token_budget_exhausted: request requires 9000 tokens", false},
+		{502, "insufficient global KV cache headroom", false},
+		{504, "request timed out waiting for capacity", false},
 		// Unattributed non-2xx codes are NOT counted (conservative).
 		{501, "not implemented", false},
 		{505, "", false},
@@ -331,6 +338,10 @@ func TestProviderBreakerIgnoresHealthySheds(t *testing.T) {
 		{400, "bad request"},
 		{404, "not found"},
 		{499, "client closed request"},
+		// Capacity-shaped non-503 5xx (older/provider paths) — still healthy sheds.
+		{500, "token_budget_exhausted"},
+		{502, "insufficient KV headroom"},
+		{504, "request timed out waiting for capacity"},
 		{503, "token_budget exhausted"},
 		{503, "insufficient KV headroom"},
 		{503, "insufficient memory to load model"},

--- a/coordinator/registry/provider_breaker_test.go
+++ b/coordinator/registry/provider_breaker_test.go
@@ -421,6 +421,42 @@ func TestReserveProviderExNodeHealthBreakerFailsOpen(t *testing.T) {
 	}
 }
 
+// The PUBLIC PREFLIGHT (QuickCapacityCheck) must fail open on the node-health
+// breaker: the breaker is a selection-time gate with a fail-open valve in the
+// dispatch path, so if the preflight excluded breaker-open nodes an
+// all-breaker-open fleet would report 0 candidates / 0 capacity-rejections and
+// the consumer would hard-503 "no_provider" BEFORE dispatch's fail-open ran —
+// defeating the valve during a bad fleet-wide rollout. The preflight therefore
+// ignores the provider breaker (every other gate, incl. the shape-keyed
+// inference-error cooldown, is still honored at the preflight).
+func TestQuickCapacityCheckFailsOpenOnProviderBreaker(t *testing.T) {
+	reg := New(testLogger())
+	model := "preflight-failopen-model"
+	p := makeSchedulerProvider(t, reg, "solo", model, 100)
+
+	// A healthy provider is a preflight candidate.
+	if cc, _, _ := reg.QuickCapacityCheck(model, 100, 128, RequestTraits{}); cc != 1 {
+		t.Fatalf("healthy provider: candidateCount=%d, want 1", cc)
+	}
+
+	// Trip the only provider's breaker — the entire fleet is now breaker-open.
+	for i := 0; i < providerBreakerConsecTrip; i++ {
+		reg.RecordProviderOutcome(p.ID, false, 503, "request rejected")
+	}
+	if !reg.ProviderBreakerOpen(p.ID) {
+		t.Fatal("provider breaker must be open")
+	}
+	// Selection-time gate still excludes it (honored at dispatch)...
+	if !providerBreakerOpenAt(reg, p.ID, time.Now()) {
+		t.Fatal("selection gate must report the breaker open")
+	}
+	// ...but the PREFLIGHT must still count it as a candidate so the consumer
+	// path falls through to dispatch's fail-open valve instead of a hard 503.
+	if cc, capRej, _ := reg.QuickCapacityCheck(model, 100, 128, RequestTraits{}); cc != 1 {
+		t.Fatalf("FAIL OPEN: preflight candidateCount=%d (capacityRejections=%d), want 1 (breaker ignored in preflight)", cc, capRej)
+	}
+}
+
 // Disconnect must drop every per-provider breaker map entry so a per-session
 // UUID leaves no residue.
 func TestDisconnectClearsProviderBreaker(t *testing.T) {

--- a/coordinator/registry/provider_breaker_test.go
+++ b/coordinator/registry/provider_breaker_test.go
@@ -1,0 +1,499 @@
+package registry
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+// --- test helpers (poke internal maps / call *Locked helpers, mirroring
+// error_cooldown_test.go) ---
+
+func providerBreakerOpenAt(r *Registry, id string, now time.Time) bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.providerBreakerOpenLocked(id, now)
+}
+
+func providerBreakerTripsOf(r *Registry, id string) int {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.providerBreakerTrips[id]
+}
+
+func providerBreakerOpenUntilOf(r *Registry, id string) time.Time {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.providerBreakerOpenUntil[id]
+}
+
+// expireProviderBreaker rewinds a provider's open expiry into the past,
+// simulating the cooldown elapsing (open -> half-open) without sleeping.
+func expireProviderBreaker(r *Registry, id string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.providerBreakerOpenUntil[id] = time.Now().Add(-time.Second)
+}
+
+// seedProviderHealthWindow records a fixed sequence of outcomes (true=success,
+// false=fault) directly into a provider's ring WITHOUT running the trip logic,
+// so a test can construct a window state (e.g. a sustained high fault rate with
+// a low consecutive-fault counter) that monotonic RecordProviderOutcome calls
+// could not reach before the consecutive-fault path fires.
+func seedProviderHealthWindow(r *Registry, id string, pattern []bool, now time.Time) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	w := r.providerHealthWindowLocked(id)
+	for _, ok := range pattern {
+		w.record(ok, now)
+	}
+}
+
+// --- classifier unit tests ---
+
+func TestProviderOutcomeIsFault(t *testing.T) {
+	cases := []struct {
+		code  int
+		err   string
+		fault bool
+	}{
+		// Client-shape sheds: never the provider's fault.
+		{429, "rate limited", false},
+		{400, "bad request", false},
+		{404, "not found", false},
+		{422, "unprocessable", false},
+		{499, "client closed request", false},
+		{418, "teapot", false},
+		// Provider-sickness status codes always count.
+		{500, "internal server error", true},
+		{502, "bad gateway", true},
+		{504, "", true},
+		// Unattributed non-2xx codes are NOT counted (conservative).
+		{501, "not implemented", false},
+		{505, "", false},
+		{0, "weird", false},
+		// Capacity-class 503s: healthy-but-busy, never counted.
+		{503, "token_budget exhausted", false},
+		{503, "insufficient KV headroom", false},
+		{503, "insufficient memory to load model", false},
+		{503, "kv cache headroom too low", false},
+		{503, "GPU OOM", false},
+		{503, "out of memory", false},
+		{503, "context length exceeded", false},
+		{503, "context window exceeded", false},
+		{503, "provider draining for update", false},
+		{503, "request timed out waiting for capacity", false},
+		{503, "queue full", false},
+		{503, "server busy", false},
+		{503, "service temporarily unavailable", false},
+		{503, "All 3 model slot(s) are active; cannot load 'x'", false},
+		// "room" must NOT match the whole word "oom".
+		{503, "no room left for this request", true},
+		// Fault-shaped 503s: genuine node faults, counted.
+		{503, "request rejected", true},
+		{503, "internal error", true},
+		{503, "model load failed", true},
+		{503, "The operation couldn't be completed. (error 1.)", true},
+		// An empty 503 message defaults to fault (no capacity marker present).
+		{503, "", true},
+	}
+	for _, c := range cases {
+		if got := providerOutcomeIsFault(c.code, c.err); got != c.fault {
+			t.Errorf("providerOutcomeIsFault(%d, %q)=%v, want %v", c.code, c.err, got, c.fault)
+		}
+	}
+}
+
+// --- breaker behavior ---
+
+// Regression for DAR-335: a node returning genuine faults for ~all of its
+// requests must be quarantined. Five consecutive faults open the breaker.
+func TestProviderBreakerConsecutiveTrip(t *testing.T) {
+	r := New(testLogger())
+	const id = "p1"
+	for i := 0; i < providerBreakerConsecTrip-1; i++ {
+		opened, closed := r.RecordProviderOutcome(id, false, 500, "")
+		if opened || closed {
+			t.Fatalf("fault %d: opened=%v closed=%v, want both false before the threshold", i+1, opened, closed)
+		}
+		if r.ProviderBreakerOpen(id) {
+			t.Fatalf("breaker opened early after %d consecutive faults", i+1)
+		}
+	}
+	opened, _ := r.RecordProviderOutcome(id, false, 500, "")
+	if !opened {
+		t.Fatalf("the %dth consecutive fault must open the breaker", providerBreakerConsecTrip)
+	}
+	if !r.ProviderBreakerOpen(id) {
+		t.Fatal("breaker must report open after the trip")
+	}
+	// A further fault while OPEN must not report a new transition.
+	if opened, _ := r.RecordProviderOutcome(id, false, 500, ""); opened {
+		t.Fatal("a fault while already open must not report a new transition")
+	}
+}
+
+// The gate (providerPassesRoutingGatesLocked) must structurally exclude a
+// breaker-open provider, and the fail-open bypass must let it back in.
+func TestProviderPassesRoutingGatesBreakerBypass(t *testing.T) {
+	reg := New(testLogger())
+	model := "gate-bypass-model"
+	p := makeSchedulerProvider(t, reg, "p", model, 100)
+	for i := 0; i < providerBreakerConsecTrip; i++ {
+		reg.RecordProviderOutcome(p.ID, false, 500, "")
+	}
+	now := time.Now()
+	reg.mu.Lock()
+	p.mu.Lock()
+	honored := reg.providerPassesRoutingGatesLockedEx(p, model, RequestTraits{}, false, now, false)
+	bypassed := reg.providerPassesRoutingGatesLockedEx(p, model, RequestTraits{}, false, now, true)
+	p.mu.Unlock()
+	reg.mu.Unlock()
+	if honored {
+		t.Fatal("breaker-open provider must FAIL the gate when the breaker is honored")
+	}
+	if !bypassed {
+		t.Fatal("breaker-open provider must PASS the gate when the breaker is bypassed (fail open)")
+	}
+}
+
+// The sustained fail-RATE path (>=20 outcomes, >80% faults) trips even when the
+// consecutive-fault counter is low; exactly 80% stays closed.
+func TestProviderBreakerRateTrip(t *testing.T) {
+	t.Run("above 80% trips", func(t *testing.T) {
+		r := New(testLogger())
+		const id = "p-rate-hot"
+		now := time.Now()
+		// 17 faults + 3 trailing successes => 85% fault, consec=0. The window is
+		// full (20) but no 5-consecutive-fault run, so only the rate path can fire.
+		pattern := make([]bool, 0, providerHealthRingSize)
+		for i := 0; i < 17; i++ {
+			pattern = append(pattern, false)
+		}
+		for i := 0; i < 3; i++ {
+			pattern = append(pattern, true)
+		}
+		seedProviderHealthWindow(r, id, pattern, now)
+		opened, _ := r.RecordProviderOutcome(id, false, 503, "request rejected")
+		if !opened {
+			t.Fatal("a sustained >80% fault rate over a full window must open the breaker")
+		}
+	})
+
+	t.Run("exactly 80% stays closed", func(t *testing.T) {
+		r := New(testLogger())
+		const id = "p-rate-edge"
+		now := time.Now()
+		// 16 faults + 4 trailing successes => exactly 80% (not > 80%), consec=0.
+		pattern := make([]bool, 0, providerHealthRingSize)
+		for i := 0; i < 16; i++ {
+			pattern = append(pattern, false)
+		}
+		for i := 0; i < 4; i++ {
+			pattern = append(pattern, true)
+		}
+		seedProviderHealthWindow(r, id, pattern, now)
+		opened, _ := r.RecordProviderOutcome(id, false, 503, "request rejected")
+		if opened {
+			t.Fatal("exactly 80% fault rate must NOT open the breaker (threshold is strictly greater)")
+		}
+		if r.ProviderBreakerOpen(id) {
+			t.Fatal("breaker must stay closed at exactly the 80% boundary")
+		}
+	})
+}
+
+// Half-open lifecycle: after the cooldown elapses the gate allows a probe; a
+// success closes the breaker and resets the backoff; a fault re-arms it with a
+// larger (exponential) cooldown.
+func TestProviderBreakerHalfOpenRecoveryAndReArm(t *testing.T) {
+	r := New(testLogger())
+	const id = "p-half"
+
+	for i := 0; i < providerBreakerConsecTrip; i++ {
+		r.RecordProviderOutcome(id, false, 500, "")
+	}
+	if !r.ProviderBreakerOpen(id) {
+		t.Fatal("breaker must be open after the consecutive-fault trip")
+	}
+	if got := providerBreakerTripsOf(r, id); got != 1 {
+		t.Fatalf("trips=%d after first trip, want 1", got)
+	}
+	// OPEN: the gate rejects (no probe yet).
+	if !providerBreakerOpenAt(r, id, time.Now()) {
+		t.Fatal("gate must report open during the cooldown")
+	}
+
+	// Cooldown elapses => half-open: the gate must allow a probe.
+	expireProviderBreaker(r, id)
+	if providerBreakerOpenAt(r, id, time.Now()) {
+		t.Fatal("once the cooldown elapses the gate must allow a half-open probe")
+	}
+
+	// A FAULT during half-open re-arms with a larger backoff.
+	beforeReArm := time.Now()
+	opened, _ := r.RecordProviderOutcome(id, false, 503, "internal error")
+	if !opened {
+		t.Fatal("a fault during half-open must re-open (re-arm) the breaker")
+	}
+	if got := providerBreakerTripsOf(r, id); got != 2 {
+		t.Fatalf("trips=%d after re-arm, want 2", got)
+	}
+	remaining := providerBreakerOpenUntilOf(r, id).Sub(beforeReArm)
+	if remaining < providerBreakerBaseCooldown+30*time.Second {
+		t.Fatalf("re-arm cooldown %v must exceed the base %v (exponential backoff)", remaining, providerBreakerBaseCooldown)
+	}
+
+	// Cooldown elapses again => half-open => a SUCCESS closes and resets.
+	expireProviderBreaker(r, id)
+	_, closed := r.RecordProviderOutcome(id, true, 200, "")
+	if !closed {
+		t.Fatal("a success during half-open must close the breaker")
+	}
+	if r.ProviderBreakerOpen(id) {
+		t.Fatal("breaker must be closed after a successful probe")
+	}
+	if got := providerBreakerTripsOf(r, id); got != 0 {
+		t.Fatalf("trips=%d after close, want 0 (backoff reset)", got)
+	}
+	// Recovery reset the consecutive counter: one fresh fault must not re-open.
+	if opened, _ := r.RecordProviderOutcome(id, false, 500, ""); opened {
+		t.Fatal("a single fault after recovery must not immediately re-open the breaker")
+	}
+}
+
+// A success while the breaker is still OPEN (an in-flight request that beat the
+// quarantine) closes it immediately — auto-re-admit on proven recovery.
+func TestProviderBreakerSuccessWhileOpenCloses(t *testing.T) {
+	r := New(testLogger())
+	const id = "p-inflight"
+	for i := 0; i < providerBreakerConsecTrip; i++ {
+		r.RecordProviderOutcome(id, false, 500, "")
+	}
+	if !r.ProviderBreakerOpen(id) {
+		t.Fatal("breaker must be open")
+	}
+	_, closed := r.RecordProviderOutcome(id, true, 200, "")
+	if !closed {
+		t.Fatal("a success while open must close the breaker")
+	}
+	if r.ProviderBreakerOpen(id) {
+		t.Fatal("breaker must be closed after the in-flight success")
+	}
+}
+
+// Healthy sheds (client-shape 4xx/429 and capacity-class 503) must NEVER trip
+// the breaker, even in large volume — load alone cannot quarantine a node.
+func TestProviderBreakerIgnoresHealthySheds(t *testing.T) {
+	r := New(testLogger())
+	const id = "p-busy"
+	sheds := []struct {
+		code int
+		err  string
+	}{
+		{429, "rate limited"},
+		{400, "bad request"},
+		{404, "not found"},
+		{499, "client closed request"},
+		{503, "token_budget exhausted"},
+		{503, "insufficient KV headroom"},
+		{503, "insufficient memory to load model"},
+		{503, "GPU OOM"},
+		{503, "out of memory"},
+		{503, "context length exceeded"},
+		{503, "context window exceeded"},
+		{503, "provider draining for update"},
+		{503, "request timed out waiting for capacity"},
+		{503, "queue full"},
+		{503, "server busy"},
+		{503, "service temporarily unavailable"},
+		{503, "All 3 model slot(s) are active; cannot load 'x'"},
+	}
+	for i := 0; i < 100; i++ {
+		s := sheds[i%len(sheds)]
+		if opened, _ := r.RecordProviderOutcome(id, false, s.code, s.err); opened {
+			t.Fatalf("healthy shed #%d (%d %q) must never open the breaker", i, s.code, s.err)
+		}
+	}
+	if r.ProviderBreakerOpen(id) {
+		t.Fatal("100 healthy sheds must not quarantine a provider")
+	}
+	// Healthy sheds are ignored entirely — no health window is even created.
+	r.mu.RLock()
+	w := r.providerOutcomes[id]
+	r.mu.RUnlock()
+	if w != nil {
+		t.Fatalf("healthy sheds must not record into the health ring, got %+v", w)
+	}
+}
+
+// Each genuine-fault flavor (fault-503 variants and 500/502/504) must trip the
+// breaker after the consecutive threshold.
+func TestProviderBreakerFaultFlavorsTrip(t *testing.T) {
+	faults := []struct {
+		name string
+		code int
+		err  string
+	}{
+		{"request rejected 503", 503, "request rejected"},
+		{"internal error 503", 503, "internal error"},
+		{"model load failed 503", 503, "model load failed"},
+		{"opaque Foundation 503", 503, "The operation couldn't be completed. (error 1.)"},
+		{"empty 503 defaults to fault", 503, ""},
+		{"500", 500, "internal server error"},
+		{"502", 502, "bad gateway"},
+		{"504 silent", 504, ""},
+	}
+	for _, f := range faults {
+		t.Run(f.name, func(t *testing.T) {
+			r := New(testLogger())
+			const id = "p-fault"
+			var opened bool
+			for i := 0; i < providerBreakerConsecTrip; i++ {
+				opened, _ = r.RecordProviderOutcome(id, false, f.code, f.err)
+			}
+			if !opened {
+				t.Fatalf("%d consecutive %q faults must open the breaker", providerBreakerConsecTrip, f.name)
+			}
+			if !r.ProviderBreakerOpen(id) {
+				t.Fatalf("%s: breaker must be open", f.name)
+			}
+		})
+	}
+}
+
+// End-to-end through the production dispatch hot path (ReserveProviderEx): a
+// breaker-open provider is structurally excluded, but when EVERY provider for a
+// model is breaker-open the fail-open safety valve must still return a candidate
+// so a bad fleet-wide rollout cannot deroute the whole fleet.
+func TestReserveProviderExNodeHealthBreakerFailsOpen(t *testing.T) {
+	reg := New(testLogger())
+	model := "node-health-model"
+	bad := makeSchedulerProvider(t, reg, "bad", model, 200)  // faster: normally preferred
+	good := makeSchedulerProvider(t, reg, "good", model, 50) // slower
+
+	req := func(id string) *PendingRequest {
+		return &PendingRequest{RequestID: id, Model: model, RequestedMaxTokens: 128}
+	}
+
+	// Trip ONLY the (faster) bad provider with fault-503s. Selection must fall to
+	// the healthy provider despite the bad one's higher TPS.
+	for i := 0; i < providerBreakerConsecTrip; i++ {
+		reg.RecordProviderOutcome(bad.ID, false, 503, "request rejected")
+	}
+	if !reg.ProviderBreakerOpen(bad.ID) {
+		t.Fatal("bad provider's breaker must be open")
+	}
+	selected, decision := reg.ReserveProviderEx(model, req("r1"))
+	if selected == nil || selected.ID != good.ID {
+		t.Fatalf("selection must fall to the healthy provider, got %v", selected)
+	}
+	if decision.CandidateCount != 1 {
+		t.Fatalf("CandidateCount=%d, want 1 (breaker-open provider structurally excluded)", decision.CandidateCount)
+	}
+	good.RemovePending("r1")
+
+	// Trip the good provider too: the ENTIRE fleet is now breaker-open.
+	for i := 0; i < providerBreakerConsecTrip; i++ {
+		reg.RecordProviderOutcome(good.ID, false, 500, "")
+	}
+	if !reg.ProviderBreakerOpen(good.ID) {
+		t.Fatal("good provider's breaker must now be open too")
+	}
+	// FAIL OPEN: selection must still return a candidate.
+	selected, _ = reg.ReserveProviderEx(model, req("r2"))
+	if selected == nil {
+		t.Fatal("FAIL OPEN: ReserveProviderEx must still return a candidate when every provider is breaker-open")
+	}
+	selected.RemovePending("r2")
+
+	// A success closes the breaker and restores normal (non-fail-open) routing.
+	reg.RecordProviderOutcome(good.ID, true, 200, "")
+	if reg.ProviderBreakerOpen(good.ID) {
+		t.Fatal("a success must close the good provider's breaker")
+	}
+	selected, decision = reg.ReserveProviderEx(model, req("r3"))
+	if selected == nil || selected.ID != good.ID {
+		t.Fatalf("after recovery the healthy provider must serve again, got %v", selected)
+	}
+	if decision.CandidateCount != 1 {
+		t.Fatalf("CandidateCount=%d, want 1 (bad still quarantined, good recovered)", decision.CandidateCount)
+	}
+}
+
+// Disconnect must drop every per-provider breaker map entry so a per-session
+// UUID leaves no residue.
+func TestDisconnectClearsProviderBreaker(t *testing.T) {
+	reg := New(testLogger())
+	model := "disconnect-breaker-model"
+	p := makeSchedulerProvider(t, reg, "victim", model, 100)
+	for i := 0; i < providerBreakerConsecTrip; i++ {
+		reg.RecordProviderOutcome(p.ID, false, 500, "")
+	}
+	reg.mu.RLock()
+	_, hasWin := reg.providerOutcomes[p.ID]
+	_, hasOpen := reg.providerBreakerOpenUntil[p.ID]
+	_, hasTrips := reg.providerBreakerTrips[p.ID]
+	reg.mu.RUnlock()
+	if !hasWin || !hasOpen || !hasTrips {
+		t.Fatalf("expected breaker state before disconnect: win=%v open=%v trips=%v", hasWin, hasOpen, hasTrips)
+	}
+
+	reg.Disconnect(p.ID)
+
+	reg.mu.RLock()
+	_, hasWin = reg.providerOutcomes[p.ID]
+	_, hasOpen = reg.providerBreakerOpenUntil[p.ID]
+	_, hasTrips = reg.providerBreakerTrips[p.ID]
+	reg.mu.RUnlock()
+	if hasWin || hasOpen || hasTrips {
+		t.Fatalf("Disconnect must drop all breaker state: win=%v open=%v trips=%v", hasWin, hasOpen, hasTrips)
+	}
+}
+
+// The opportunistic >1024 sweep (mirroring error_cooldown.go) must bound the
+// breaker maps by dropping expired/idle entries.
+func TestProviderBreakerMapsBounded(t *testing.T) {
+	r := New(testLogger())
+	for i := 0; i < 1100; i++ {
+		id := fmt.Sprintf("dead-%d", i)
+		for j := 0; j < providerBreakerConsecTrip; j++ {
+			r.RecordProviderOutcome(id, false, 500, "")
+		}
+	}
+	r.mu.Lock()
+	for id := range r.providerBreakerOpenUntil {
+		r.providerBreakerOpenUntil[id] = time.Now().Add(-time.Second)
+	}
+	for _, w := range r.providerOutcomes {
+		for i := range w.outcomes {
+			if !w.outcomes[i].ts.IsZero() {
+				w.outcomes[i].ts = w.outcomes[i].ts.Add(-(providerBreakerWindow + time.Second))
+			}
+		}
+	}
+	openCount := len(r.providerBreakerOpenUntil)
+	winCount := len(r.providerOutcomes)
+	r.mu.Unlock()
+	if openCount < 1000 || winCount < 1000 {
+		t.Fatalf("setup produced too few distinct entries: open=%d win=%d", openCount, winCount)
+	}
+
+	// A live record triggers the >1024 sweep before recording.
+	r.RecordProviderOutcome("live", false, 500, "")
+
+	r.mu.RLock()
+	openAfter := len(r.providerBreakerOpenUntil)
+	tripsAfter := len(r.providerBreakerTrips)
+	winAfter := len(r.providerOutcomes)
+	r.mu.RUnlock()
+	if openAfter != 0 {
+		t.Fatalf("expired-breaker sweep should drop every entry (live pair has no open breaker yet), got %d", openAfter)
+	}
+	if tripsAfter != 0 {
+		t.Fatalf("trip counts must be swept alongside expired breakers, got %d", tripsAfter)
+	}
+	if winAfter != 1 {
+		t.Fatalf("stale-window sweep should leave only the live entry, got %d", winAfter)
+	}
+}

--- a/coordinator/registry/provider_breaker_test.go
+++ b/coordinator/registry/provider_breaker_test.go
@@ -87,10 +87,12 @@ func TestProviderOutcomeIsFault(t *testing.T) {
 		{503, "server busy", false},
 		{503, "service temporarily unavailable", false},
 		{503, "All 3 model slot(s) are active; cannot load 'x'", false},
+		// Overload/backpressure shed — healthy-but-busy, consistent with the api
+		// reclassifier and the inference-error breaker (NOT a node fault).
+		{503, "request rejected", false},
 		// "room" must NOT match the whole word "oom".
 		{503, "no room left for this request", true},
 		// Fault-shaped 503s: genuine node faults, counted.
-		{503, "request rejected", true},
 		{503, "internal error", true},
 		{503, "model load failed", true},
 		{503, "The operation couldn't be completed. (error 1.)", true},
@@ -157,6 +159,40 @@ func TestProviderPassesRoutingGatesBreakerBypass(t *testing.T) {
 	}
 }
 
+// The fail-open valve must trigger ONLY when the node-health breaker is the SOLE
+// reason a request has no route. If a healthy provider was merely busy
+// (capacityRejections) or too slow (ttftRejections), selection must surface that
+// signal (queue / 429) instead of failing open to a known-bad, breaker-open node.
+func TestShouldBypassBreakerFailOpen(t *testing.T) {
+	cases := []struct {
+		name            string
+		winner          bool
+		breakerRejected int
+		capacity        int
+		ttft            int
+		want            bool
+	}{
+		{"winner found — no fail-open needed", true, 1, 0, 0, false},
+		{"breaker played no part", false, 0, 0, 0, false},
+		{"breaker is the sole reason", false, 1, 0, 0, true},
+		{"healthy provider merely busy", false, 1, 1, 0, false},
+		{"healthy provider too slow", false, 1, 0, 1, false},
+		{"mixed fleet: busy + slow + breaker", false, 2, 3, 1, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			var w *routingCandidate
+			if c.winner {
+				w = &routingCandidate{}
+			}
+			if got := shouldBypassBreakerFailOpen(w, c.breakerRejected, c.capacity, c.ttft); got != c.want {
+				t.Fatalf("shouldBypassBreakerFailOpen(winner=%v, breaker=%d, cap=%d, ttft=%d)=%v, want %v",
+					c.winner, c.breakerRejected, c.capacity, c.ttft, got, c.want)
+			}
+		})
+	}
+}
+
 // The sustained fail-RATE path (>=20 outcomes, >80% faults) trips even when the
 // consecutive-fault counter is low; exactly 80% stays closed.
 func TestProviderBreakerRateTrip(t *testing.T) {
@@ -174,7 +210,7 @@ func TestProviderBreakerRateTrip(t *testing.T) {
 			pattern = append(pattern, true)
 		}
 		seedProviderHealthWindow(r, id, pattern, now)
-		opened, _ := r.RecordProviderOutcome(id, false, 503, "request rejected")
+		opened, _ := r.RecordProviderOutcome(id, false, 503, "internal error")
 		if !opened {
 			t.Fatal("a sustained >80% fault rate over a full window must open the breaker")
 		}
@@ -193,7 +229,7 @@ func TestProviderBreakerRateTrip(t *testing.T) {
 			pattern = append(pattern, true)
 		}
 		seedProviderHealthWindow(r, id, pattern, now)
-		opened, _ := r.RecordProviderOutcome(id, false, 503, "request rejected")
+		opened, _ := r.RecordProviderOutcome(id, false, 503, "internal error")
 		if opened {
 			t.Fatal("exactly 80% fault rate must NOT open the breaker (threshold is strictly greater)")
 		}
@@ -307,6 +343,7 @@ func TestProviderBreakerIgnoresHealthySheds(t *testing.T) {
 		{503, "queue full"},
 		{503, "server busy"},
 		{503, "service temporarily unavailable"},
+		{503, "request rejected"},
 		{503, "All 3 model slot(s) are active; cannot load 'x'"},
 	}
 	for i := 0; i < 100; i++ {
@@ -335,7 +372,6 @@ func TestProviderBreakerFaultFlavorsTrip(t *testing.T) {
 		code int
 		err  string
 	}{
-		{"request rejected 503", 503, "request rejected"},
 		{"internal error 503", 503, "internal error"},
 		{"model load failed 503", 503, "model load failed"},
 		{"opaque Foundation 503", 503, "The operation couldn't be completed. (error 1.)"},
@@ -379,7 +415,7 @@ func TestReserveProviderExNodeHealthBreakerFailsOpen(t *testing.T) {
 	// Trip ONLY the (faster) bad provider with fault-503s. Selection must fall to
 	// the healthy provider despite the bad one's higher TPS.
 	for i := 0; i < providerBreakerConsecTrip; i++ {
-		reg.RecordProviderOutcome(bad.ID, false, 503, "request rejected")
+		reg.RecordProviderOutcome(bad.ID, false, 503, "internal error")
 	}
 	if !reg.ProviderBreakerOpen(bad.ID) {
 		t.Fatal("bad provider's breaker must be open")
@@ -441,7 +477,7 @@ func TestQuickCapacityCheckFailsOpenOnProviderBreaker(t *testing.T) {
 
 	// Trip the only provider's breaker — the entire fleet is now breaker-open.
 	for i := 0; i < providerBreakerConsecTrip; i++ {
-		reg.RecordProviderOutcome(p.ID, false, 503, "request rejected")
+		reg.RecordProviderOutcome(p.ID, false, 503, "internal error")
 	}
 	if !reg.ProviderBreakerOpen(p.ID) {
 		t.Fatal("provider breaker must be open")

--- a/coordinator/registry/provider_breaker_test.go
+++ b/coordinator/registry/provider_breaker_test.go
@@ -106,8 +106,8 @@ func TestProviderOutcomeIsFault(t *testing.T) {
 
 // --- breaker behavior ---
 
-// Regression for DAR-335: a node returning genuine faults for ~all of its
-// requests must be quarantined. Five consecutive faults open the breaker.
+// A node returning genuine faults for ~all of its requests must be quarantined.
+// Five consecutive faults open the breaker.
 func TestProviderBreakerConsecutiveTrip(t *testing.T) {
 	r := New(testLogger())
 	const id = "p1"

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -1074,8 +1074,8 @@ type Registry struct {
 	// implement the per-provider (node-health) circuit breaker, SEPARATE from
 	// and ADDITIONAL to the shape-keyed inference-error breaker above. It
 	// quarantines a whole provider that returns GENUINE-FAULT errors
-	// (500/502/504, or a fault-shaped 503 — "request rejected", internal error,
-	// crash, the opaque Foundation string) for ~all of its requests, regardless
+	// (500/502/504, or a fault-shaped 503 — internal error, crash, the opaque
+	// Foundation string) for ~all of its requests, regardless
 	// of model/shape — the case the inference-error breaker misses because it
 	// skips 503. After an exponential cooldown it re-probes and auto-re-admits
 	// on the first success. Capacity-class sheds (4xx/429 and token-budget /

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -1070,6 +1070,24 @@ type Registry struct {
 	inferenceErrorStrikes   map[inferenceErrorKey][]time.Time // recent 5xx strike times per (provider, model, shape)
 	inferenceErrorCooldowns map[inferenceErrorKey]time.Time   // cool-down expiry per (provider, model, shape)
 
+	// providerOutcomes / providerBreakerOpenUntil / providerBreakerTrips
+	// implement the per-provider (node-health) circuit breaker (DAR-335),
+	// SEPARATE from and ADDITIONAL to the shape-keyed inference-error breaker
+	// above. It quarantines a whole provider that returns GENUINE-FAULT errors
+	// (500/502/504, or a fault-shaped 503 — "request rejected", internal error,
+	// crash, the opaque Foundation string) for ~all of its requests, regardless
+	// of model/shape — the case the inference-error breaker misses because it
+	// skips 503. After an exponential cooldown it re-probes and auto-re-admits
+	// on the first success. Capacity-class sheds (4xx/429 and token-budget /
+	// KV-headroom / draining 503s) never count — a healthy-but-busy provider.
+	// The breaker FAILS OPEN: when it would deroute every provider for a model,
+	// selection re-scans with it bypassed (selectBestCandidateLockedFull) so a
+	// bad fleet-wide rollout cannot zero out routing. Guarded by r.mu like the
+	// maps above; cleared on Disconnect. See provider_breaker.go.
+	providerOutcomes         map[string]*providerHealthWindow // per-provider sliding fault/success ring
+	providerBreakerOpenUntil map[string]time.Time             // breaker-open expiry per provider
+	providerBreakerTrips     map[string]int                   // trip count per provider (exponential backoff)
+
 	// evictStrikes counts consecutive eviction sweeps a provider has been stale.
 	// A provider is only evicted after STALE on two sweeps in a row, so a single
 	// transient coordinator stall (which ages many LastHeartbeat values at once)
@@ -1130,20 +1148,23 @@ type modelLoadAction struct {
 // New creates a new Registry.
 func New(logger *slog.Logger) *Registry {
 	return &Registry{
-		providers:               make(map[string]*Provider),
-		queue:                   NewRequestQueue(10, 120*time.Second),
-		MinTrustLevel:           TrustHardware,
-		tpsRegistry:             NewTPSRegistry(),
-		modelProviders:          make(map[string]*atomic.Int64),
-		pendingModelLoads:       make(map[string]time.Time),
-		pendingModelLoadStarted: make(map[string]time.Time),
-		dispatchLoadCooldowns:   make(map[string]time.Time),
-		inferenceErrorStrikes:   make(map[inferenceErrorKey][]time.Time),
-		inferenceErrorCooldowns: make(map[inferenceErrorKey]time.Time),
-		evictStrikes:            make(map[string]int),
-		cacheAffinity:           newCacheAffinityTracker(cacheAffinityTTL),
-		cacheAffinityBonusMs:    defaultCacheAffinityBonusMs,
-		logger:                  logger,
+		providers:                make(map[string]*Provider),
+		queue:                    NewRequestQueue(10, 120*time.Second),
+		MinTrustLevel:            TrustHardware,
+		tpsRegistry:              NewTPSRegistry(),
+		modelProviders:           make(map[string]*atomic.Int64),
+		pendingModelLoads:        make(map[string]time.Time),
+		pendingModelLoadStarted:  make(map[string]time.Time),
+		dispatchLoadCooldowns:    make(map[string]time.Time),
+		inferenceErrorStrikes:    make(map[inferenceErrorKey][]time.Time),
+		inferenceErrorCooldowns:  make(map[inferenceErrorKey]time.Time),
+		providerOutcomes:         make(map[string]*providerHealthWindow),
+		providerBreakerOpenUntil: make(map[string]time.Time),
+		providerBreakerTrips:     make(map[string]int),
+		evictStrikes:             make(map[string]int),
+		cacheAffinity:            newCacheAffinityTracker(cacheAffinityTTL),
+		cacheAffinityBonusMs:     defaultCacheAffinityBonusMs,
+		logger:                   logger,
 	}
 }
 
@@ -3344,6 +3365,12 @@ func (r *Registry) Disconnect(id string) {
 				delete(r.pendingModelLoadStarted, key)
 			}
 		}
+		// Drop per-provider node-health breaker state (DAR-335). The id is a
+		// per-session UUID that will never recur, so its health ring, open
+		// expiry, and trip count must not linger after disconnect.
+		delete(r.providerOutcomes, id)
+		delete(r.providerBreakerOpenUntil, id)
+		delete(r.providerBreakerTrips, id)
 		p.mu.Lock()
 		if p.Status != StatusUntrusted {
 			r.onlineCount.Add(-1)

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -1071,9 +1071,9 @@ type Registry struct {
 	inferenceErrorCooldowns map[inferenceErrorKey]time.Time   // cool-down expiry per (provider, model, shape)
 
 	// providerOutcomes / providerBreakerOpenUntil / providerBreakerTrips
-	// implement the per-provider (node-health) circuit breaker (DAR-335),
-	// SEPARATE from and ADDITIONAL to the shape-keyed inference-error breaker
-	// above. It quarantines a whole provider that returns GENUINE-FAULT errors
+	// implement the per-provider (node-health) circuit breaker, SEPARATE from
+	// and ADDITIONAL to the shape-keyed inference-error breaker above. It
+	// quarantines a whole provider that returns GENUINE-FAULT errors
 	// (500/502/504, or a fault-shaped 503 — "request rejected", internal error,
 	// crash, the opaque Foundation string) for ~all of its requests, regardless
 	// of model/shape — the case the inference-error breaker misses because it
@@ -3365,9 +3365,9 @@ func (r *Registry) Disconnect(id string) {
 				delete(r.pendingModelLoadStarted, key)
 			}
 		}
-		// Drop per-provider node-health breaker state (DAR-335). The id is a
-		// per-session UUID that will never recur, so its health ring, open
-		// expiry, and trip count must not linger after disconnect.
+		// Drop per-provider node-health breaker state. The id is a per-session
+		// UUID that will never recur, so its health ring, open expiry, and trip
+		// count must not linger after disconnect.
 		delete(r.providerOutcomes, id)
 		delete(r.providerBreakerOpenUntil, id)
 		delete(r.providerBreakerTrips, id)

--- a/coordinator/registry/scheduler.go
+++ b/coordinator/registry/scheduler.go
@@ -344,27 +344,47 @@ func (r *Registry) ReserveProviderEx(model string, pr *PendingRequest, excludeID
 //
 // FAIL-OPEN SAFETY VALVE: selection runs in two passes. Pass 1 honors the
 // per-provider node-health breaker. If pass 1 finds ZERO candidates AND the
-// breaker rejected at least one provider for this model, pass 2 re-runs the
-// whole scan with the breaker BYPASSED (ignoreProviderBreaker=true) — so a bad
-// fleet-wide rollout that fault-503s every node can never deroute the entire
-// fleet. Pass 2's result is used only when it yields a candidate, and its
-// counters (not pass 1's) are returned so metrics are never double-counted. This
-// mirrors servability.go's fail-open philosophy: when in doubt, keep serving.
+// breaker is the SOLE reason — it rejected at least one provider AND no healthy
+// provider was merely busy or too slow — pass 2 re-runs the whole scan with the
+// breaker BYPASSED (ignoreProviderBreaker=true), so a bad fleet-wide rollout
+// that fault-503s every node can never deroute the entire fleet. When healthy
+// providers are simply over capacity or above the TTFT ceiling, pass 1's signal
+// is returned instead, so the request queues / 429s and waits for a healthy node
+// rather than being routed to a known-bad provider. Pass 2's result is used only
+// when it yields a candidate, and its counters (not pass 1's) are returned so
+// metrics are never double-counted. This mirrors servability.go's fail-open
+// philosophy: when in doubt, keep serving.
 func (r *Registry) selectBestCandidateLockedFull(model string, pr *PendingRequest, excludeIDs ...string) (*routingCandidate, int, int, int, int, int, float64) {
 	winner, candidateCount, capacityRejections, tooLargeRejections, visionRejections, ttftRejections, bestTTFTMs, breakerRejected :=
 		r.selectBestCandidateScanLocked(model, pr, false, excludeIDs...)
-	// Pass 1 succeeded, or the node-health breaker played no part in the empty
-	// result — return pass 1 as-is (no redundant second scan).
-	if winner != nil || breakerRejected == 0 {
+	if !shouldBypassBreakerFailOpen(winner, breakerRejected, capacityRejections, ttftRejections) {
 		return winner, candidateCount, capacityRejections, tooLargeRejections, visionRejections, ttftRejections, bestTTFTMs
 	}
-	// Pass 1 found nothing and the breaker rejected >0 providers: re-scan with
-	// the breaker bypassed. Use pass 2 only when it actually finds a candidate,
+	// The node-health breaker is the SOLE reason this request has no route: re-scan
+	// with the breaker bypassed. Use pass 2 only when it actually finds a candidate,
 	// so a genuinely empty fleet still reports pass 1's (accurate) counters.
 	if w2, cc2, cr2, tl2, vr2, tr2, bt2, _ := r.selectBestCandidateScanLocked(model, pr, true, excludeIDs...); w2 != nil {
 		return w2, cc2, cr2, tl2, vr2, tr2, bt2
 	}
 	return winner, candidateCount, capacityRejections, tooLargeRejections, visionRejections, ttftRejections, bestTTFTMs
+}
+
+// shouldBypassBreakerFailOpen decides whether selection should retry with the
+// node-health breaker bypassed (the fail-open safety valve). It fails open ONLY
+// when the breaker is the SOLE reason no route was found:
+//   - pass 1 produced no winner, AND
+//   - the breaker rejected at least one provider, AND
+//   - no healthy provider was merely busy (capacityRejections) or too slow
+//     (ttftRejections).
+//
+// If a healthy provider was just over capacity or above the TTFT ceiling, we
+// surface that signal (so the request queues / 429s and waits for a healthy
+// node) rather than routing to a known-bad, breaker-open provider. Model-too-
+// large and vision-unsupported rejections are deliberately NOT counted: those
+// providers cannot serve this request at all, so they are not a healthy
+// alternative to a fail-open probe.
+func shouldBypassBreakerFailOpen(winner *routingCandidate, breakerRejected, capacityRejections, ttftRejections int) bool {
+	return winner == nil && breakerRejected > 0 && capacityRejections == 0 && ttftRejections == 0
 }
 
 // selectBestCandidateScanLocked is one pass of candidate selection. When

--- a/coordinator/registry/scheduler.go
+++ b/coordinator/registry/scheduler.go
@@ -1598,7 +1598,17 @@ func (r *Registry) quickCapacityCheck(model string, estimatedPromptTokens, reque
 		// and the admit re-check). This pre-flight only runs for public
 		// (non-self-route) requests, so selfRouteOwner is false — private-only
 		// machines are excluded unconditionally.
-		if !r.providerPassesRoutingGatesLocked(p, model, traits, false, now) {
+		//
+		// ignoreProviderBreaker=true (DAR-335): the per-provider node-health
+		// breaker is a SELECTION-time gate that fails open in the dispatch path
+		// (selectBestCandidateScanLocked / ReserveProviderEx). The preflight must
+		// fail open on it too — otherwise an all-breaker-open fleet reports 0
+		// candidates AND 0 capacity-rejections here, and the consumer hard-503s
+		// "no_provider" BEFORE dispatch's fail-open valve can serve a probe,
+		// re-introducing the very model-wide outage the valve exists to prevent.
+		// Every other gate (incl. the shape-keyed inference-error cooldown) is
+		// still honored; the breaker still steers SELECTION away from bad nodes.
+		if !r.providerPassesRoutingGatesLockedEx(p, model, traits, false, now, true) {
 			p.mu.Unlock()
 			continue
 		}

--- a/coordinator/registry/scheduler.go
+++ b/coordinator/registry/scheduler.go
@@ -279,8 +279,8 @@ func (r *Registry) ReserveProviderEx(model string, pr *PendingRequest, excludeID
 	// must not have entered the shape-keyed inference-error cooldown (all folded
 	// into providerCanAdmitLocked) between snapshot and reservation.
 	//
-	// DAR-335 fail-open: if the winner is itself node-health-breaker-open, it can
-	// only have been chosen by selectBestCandidateLockedFull's breaker-bypassed
+	// Fail-open: if the winner is itself node-health-breaker-open, it can only
+	// have been chosen by selectBestCandidateLockedFull's breaker-bypassed
 	// fallback pass (the normal pass excludes breaker-open providers). Carry that
 	// fail-open decision into the admit re-check so the breaker does not reject
 	// the very candidate the safety valve selected. All under r.mu (held), so the
@@ -342,8 +342,8 @@ func (r *Registry) ReserveProviderEx(model string, pr *PendingRequest, excludeID
 // Returns (winner, candidateCount, capacityRejections, modelTooLargeRejections,
 // visionRejections, ttftRejections, bestTTFTMs).
 //
-// FAIL-OPEN SAFETY VALVE (DAR-335): selection runs in two passes. Pass 1 honors
-// the per-provider node-health breaker. If pass 1 finds ZERO candidates AND the
+// FAIL-OPEN SAFETY VALVE: selection runs in two passes. Pass 1 honors the
+// per-provider node-health breaker. If pass 1 finds ZERO candidates AND the
 // breaker rejected at least one provider for this model, pass 2 re-runs the
 // whole scan with the breaker BYPASSED (ignoreProviderBreaker=true) — so a bad
 // fleet-wide rollout that fault-503s every node can never deroute the entire
@@ -368,7 +368,7 @@ func (r *Registry) selectBestCandidateLockedFull(model string, pr *PendingReques
 }
 
 // selectBestCandidateScanLocked is one pass of candidate selection. When
-// ignoreProviderBreaker is true the DAR-335 node-health breaker gate is skipped
+// ignoreProviderBreaker is true the node-health breaker gate is skipped
 // (every other structural/privacy/capacity/trait gate still applies). It
 // additionally returns breakerRejected: how many providers were dropped while
 // their node-health breaker was OPEN on this pass — the signal
@@ -749,7 +749,7 @@ func (r *Registry) providerPassesRoutingGatesLocked(p *Provider, model string, t
 
 // providerPassesRoutingGatesLockedEx is providerPassesRoutingGatesLocked with an
 // explicit ignoreProviderBreaker switch. When ignoreProviderBreaker is true it
-// skips ONLY the DAR-335 per-provider node-health breaker; every other gate
+// skips ONLY the per-provider node-health breaker; every other gate
 // still applies. It exists solely for the selectBestCandidateLockedFull
 // fail-open fallback pass, so a fleet-wide fault rollout that trips the breaker
 // on every provider can never deroute the entire fleet. Every other caller goes
@@ -774,8 +774,8 @@ func (r *Registry) providerPassesRoutingGatesLockedEx(p *Provider, model string,
 	if r.inferenceErrorCooldownActiveLocked(p.ID, model, traits.CooldownShape(), now) {
 		return false
 	}
-	// Skip a provider quarantined by the per-provider node-health breaker
-	// (DAR-335): a node returning GENUINE-FAULT errors (500/502/504 or a
+	// Skip a provider quarantined by the per-provider node-health breaker: a
+	// node returning GENUINE-FAULT errors (500/502/504 or a
 	// fault-shaped 503) for ~all of its requests is sick regardless of model or
 	// shape, so it is derouted fleet-wide. This catches the node that fault-503s
 	// every request — invisible to the shape-keyed inference-error breaker above
@@ -836,7 +836,7 @@ func (r *Registry) snapshotProviderLocked(p *Provider, model string, traits Requ
 // snapshotProviderLockedEx is snapshotProviderLocked with an explicit
 // ignoreProviderBreaker switch threaded into the routing gate. Only the
 // selectBestCandidateLockedFull fail-open fallback pass sets it true (to bypass
-// the DAR-335 node-health breaker); every other caller uses the default
+// the node-health breaker); every other caller uses the default
 // (breaker-honored) wrapper above.
 func (r *Registry) snapshotProviderLockedEx(p *Provider, model string, traits RequestTraits, selfRouteOwner bool, ignoreProviderBreaker bool) (routingSnapshot, bool) {
 	now := time.Now()
@@ -1599,7 +1599,7 @@ func (r *Registry) quickCapacityCheck(model string, estimatedPromptTokens, reque
 		// (non-self-route) requests, so selfRouteOwner is false — private-only
 		// machines are excluded unconditionally.
 		//
-		// ignoreProviderBreaker=true (DAR-335): the per-provider node-health
+		// ignoreProviderBreaker=true: the per-provider node-health
 		// breaker is a SELECTION-time gate that fails open in the dispatch path
 		// (selectBestCandidateScanLocked / ReserveProviderEx). The preflight must
 		// fail open on it too — otherwise an all-breaker-open fleet reports 0

--- a/coordinator/registry/scheduler.go
+++ b/coordinator/registry/scheduler.go
@@ -278,7 +278,15 @@ func (r *Registry) ReserveProviderEx(model string, pr *PendingRequest, excludeID
 	// fenced for every shape, the tools version floor for tool requests — and
 	// must not have entered the shape-keyed inference-error cooldown (all folded
 	// into providerCanAdmitLocked) between snapshot and reservation.
-	if !r.providerCanAdmitLocked(p, model, pr.Traits, relaxTrust) ||
+	//
+	// DAR-335 fail-open: if the winner is itself node-health-breaker-open, it can
+	// only have been chosen by selectBestCandidateLockedFull's breaker-bypassed
+	// fallback pass (the normal pass excludes breaker-open providers). Carry that
+	// fail-open decision into the admit re-check so the breaker does not reject
+	// the very candidate the safety valve selected. All under r.mu (held), so the
+	// breaker state cannot change between selection and this check.
+	ignoreBreaker := r.providerBreakerOpenLocked(p.ID, time.Now())
+	if !r.providerCanAdmitLockedEx(p, model, pr.Traits, relaxTrust, ignoreBreaker) ||
 		(pr.RequiresVision && !r.providerServesVisionModelLocked(p, model)) {
 		return nil, RoutingDecision{
 			Model:                   model,
@@ -333,7 +341,41 @@ func (r *Registry) ReserveProviderEx(model string, pr *PendingRequest, excludeID
 // no_provider and over_capacity outcome counters.
 // Returns (winner, candidateCount, capacityRejections, modelTooLargeRejections,
 // visionRejections, ttftRejections, bestTTFTMs).
+//
+// FAIL-OPEN SAFETY VALVE (DAR-335): selection runs in two passes. Pass 1 honors
+// the per-provider node-health breaker. If pass 1 finds ZERO candidates AND the
+// breaker rejected at least one provider for this model, pass 2 re-runs the
+// whole scan with the breaker BYPASSED (ignoreProviderBreaker=true) — so a bad
+// fleet-wide rollout that fault-503s every node can never deroute the entire
+// fleet. Pass 2's result is used only when it yields a candidate, and its
+// counters (not pass 1's) are returned so metrics are never double-counted. This
+// mirrors servability.go's fail-open philosophy: when in doubt, keep serving.
 func (r *Registry) selectBestCandidateLockedFull(model string, pr *PendingRequest, excludeIDs ...string) (*routingCandidate, int, int, int, int, int, float64) {
+	winner, candidateCount, capacityRejections, tooLargeRejections, visionRejections, ttftRejections, bestTTFTMs, breakerRejected :=
+		r.selectBestCandidateScanLocked(model, pr, false, excludeIDs...)
+	// Pass 1 succeeded, or the node-health breaker played no part in the empty
+	// result — return pass 1 as-is (no redundant second scan).
+	if winner != nil || breakerRejected == 0 {
+		return winner, candidateCount, capacityRejections, tooLargeRejections, visionRejections, ttftRejections, bestTTFTMs
+	}
+	// Pass 1 found nothing and the breaker rejected >0 providers: re-scan with
+	// the breaker bypassed. Use pass 2 only when it actually finds a candidate,
+	// so a genuinely empty fleet still reports pass 1's (accurate) counters.
+	if w2, cc2, cr2, tl2, vr2, tr2, bt2, _ := r.selectBestCandidateScanLocked(model, pr, true, excludeIDs...); w2 != nil {
+		return w2, cc2, cr2, tl2, vr2, tr2, bt2
+	}
+	return winner, candidateCount, capacityRejections, tooLargeRejections, visionRejections, ttftRejections, bestTTFTMs
+}
+
+// selectBestCandidateScanLocked is one pass of candidate selection. When
+// ignoreProviderBreaker is true the DAR-335 node-health breaker gate is skipped
+// (every other structural/privacy/capacity/trait gate still applies). It
+// additionally returns breakerRejected: how many providers were dropped while
+// their node-health breaker was OPEN on this pass — the signal
+// selectBestCandidateLockedFull uses to decide whether a breaker-bypassed
+// fail-open re-scan could help. breakerRejected is always 0 when
+// ignoreProviderBreaker is true (the breaker is not consulted).
+func (r *Registry) selectBestCandidateScanLocked(model string, pr *PendingRequest, ignoreProviderBreaker bool, excludeIDs ...string) (*routingCandidate, int, int, int, int, int, float64, int) {
 	excludeSet := make(map[string]struct{}, len(excludeIDs))
 	for _, id := range excludeIDs {
 		excludeSet[id] = struct{}{}
@@ -356,11 +398,13 @@ func (r *Registry) selectBestCandidateLockedFull(model string, pr *PendingReques
 	visionRejections := 0
 	ttftRejections := 0
 	bestTTFTMs := 0.0
+	breakerRejected := 0
+	now := time.Now()
 	enforceTTFT := pr.MaxTTFTMs > 0
 	affinityProviderID := ""
 	affinityLookup := pr.CacheAffinityKey != "" && pr.ConsumerKey != ""
 	if affinityLookup && r.cacheAffinityBonusMs > 0 {
-		affinityProviderID = r.cacheAffinity.lookup(pr.ConsumerKey, model, pr.CacheAffinityKey, time.Now())
+		affinityProviderID = r.cacheAffinity.lookup(pr.ConsumerKey, model, pr.CacheAffinityKey, now)
 	}
 	for _, p := range r.providers {
 		owned := providerOwnedBy(p, pr.OwnerAccountID)
@@ -386,8 +430,14 @@ func (r *Registry) selectBestCandidateLockedFull(model string, pr *PendingReques
 		// inference-error cooldown and the trait gates (render-broken fences all
 		// shapes; the tools version floor fences tool requests). A failing
 		// provider is simply dropped here.
-		snap, ok := r.snapshotProviderLocked(p, model, pr.Traits, relaxTrust)
+		snap, ok := r.snapshotProviderLockedEx(p, model, pr.Traits, relaxTrust, ignoreProviderBreaker)
 		if !ok {
+			// Count providers the node-health breaker is actively derouting so
+			// selectBestCandidateLockedFull can decide whether a breaker-bypassed
+			// fail-open re-scan would help. Only meaningful on the normal pass.
+			if !ignoreProviderBreaker && r.providerBreakerOpenLocked(p.ID, now) {
+				breakerRejected++
+			}
 			continue
 		}
 		// Vision gate: a media request must only go to a provider advertising a
@@ -451,7 +501,7 @@ func (r *Registry) selectBestCandidateLockedFull(model string, pr *PendingReques
 	}
 
 	if len(candidates) == 0 {
-		return nil, candidateCount, capacityRejections, tooLargeRejections, visionRejections, ttftRejections, bestTTFTMs
+		return nil, candidateCount, capacityRejections, tooLargeRejections, visionRejections, ttftRejections, bestTTFTMs, breakerRejected
 	}
 
 	// Prefer-with-fallback: if the caller asked to prefer their own machine and
@@ -556,7 +606,7 @@ func (r *Registry) selectBestCandidateLockedFull(model string, pr *PendingReques
 		}
 	}
 	r.logRoutingDecision(model, pr, winner, candidateCount)
-	return winner, candidateCount, capacityRejections, tooLargeRejections, visionRejections, ttftRejections, bestTTFTMs
+	return winner, candidateCount, capacityRejections, tooLargeRejections, visionRejections, ttftRejections, bestTTFTMs, breakerRejected
 }
 
 func providerMatchesAllowedSerial(p *Provider, allowed map[string]struct{}) bool {
@@ -694,6 +744,18 @@ func (r *Registry) logRoutingDecision(model string, pr *PendingRequest, winner *
 // caller's own (possibly un-enrolled) machine; every privacy-critical gate
 // still applies. Caller holds r.mu and p.mu.
 func (r *Registry) providerPassesRoutingGatesLocked(p *Provider, model string, traits RequestTraits, selfRouteOwner bool, now time.Time) bool {
+	return r.providerPassesRoutingGatesLockedEx(p, model, traits, selfRouteOwner, now, false)
+}
+
+// providerPassesRoutingGatesLockedEx is providerPassesRoutingGatesLocked with an
+// explicit ignoreProviderBreaker switch. When ignoreProviderBreaker is true it
+// skips ONLY the DAR-335 per-provider node-health breaker; every other gate
+// still applies. It exists solely for the selectBestCandidateLockedFull
+// fail-open fallback pass, so a fleet-wide fault rollout that trips the breaker
+// on every provider can never deroute the entire fleet. Every other caller goes
+// through the default wrapper above (breaker always honored). Caller holds r.mu
+// and p.mu.
+func (r *Registry) providerPassesRoutingGatesLockedEx(p *Provider, model string, traits RequestTraits, selfRouteOwner bool, now time.Time, ignoreProviderBreaker bool) bool {
 	if !r.providerServesCatalogModelLocked(p, model) {
 		return false
 	}
@@ -710,6 +772,17 @@ func (r *Registry) providerPassesRoutingGatesLocked(p *Provider, model string, t
 	// tool failure does not deroute clean text traffic. Cleared by
 	// RecordInferenceSuccess (same shape) or by TTL expiry.
 	if r.inferenceErrorCooldownActiveLocked(p.ID, model, traits.CooldownShape(), now) {
+		return false
+	}
+	// Skip a provider quarantined by the per-provider node-health breaker
+	// (DAR-335): a node returning GENUINE-FAULT errors (500/502/504 or a
+	// fault-shaped 503) for ~all of its requests is sick regardless of model or
+	// shape, so it is derouted fleet-wide. This catches the node that fault-503s
+	// every request — invisible to the shape-keyed inference-error breaker above
+	// (which skips 503 as a capacity signal). Honored on the normal routing
+	// path; the selectBestCandidateLockedFull fail-open pass sets
+	// ignoreProviderBreaker so a bad fleet-wide rollout can't deroute everyone.
+	if !ignoreProviderBreaker && r.providerBreakerOpenLocked(p.ID, now) {
 		return false
 	}
 	if p.Status == StatusOffline || p.Status == StatusUntrusted {
@@ -757,12 +830,21 @@ func (r *Registry) providerPassesRoutingGatesLocked(p *Provider, model string, t
 // carry the request shape into the shape-keyed inference-error cooldown and the
 // render-broken / version-floor eligibility gates.
 func (r *Registry) snapshotProviderLocked(p *Provider, model string, traits RequestTraits, selfRouteOwner bool) (routingSnapshot, bool) {
+	return r.snapshotProviderLockedEx(p, model, traits, selfRouteOwner, false)
+}
+
+// snapshotProviderLockedEx is snapshotProviderLocked with an explicit
+// ignoreProviderBreaker switch threaded into the routing gate. Only the
+// selectBestCandidateLockedFull fail-open fallback pass sets it true (to bypass
+// the DAR-335 node-health breaker); every other caller uses the default
+// (breaker-honored) wrapper above.
+func (r *Registry) snapshotProviderLockedEx(p *Provider, model string, traits RequestTraits, selfRouteOwner bool, ignoreProviderBreaker bool) (routingSnapshot, bool) {
 	now := time.Now()
 
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
-	if !r.providerPassesRoutingGatesLocked(p, model, traits, selfRouteOwner, now) {
+	if !r.providerPassesRoutingGatesLockedEx(p, model, traits, selfRouteOwner, now, ignoreProviderBreaker) {
 		return routingSnapshot{}, false
 	}
 
@@ -1401,8 +1483,20 @@ func providerModelIDs(p *Provider) []string {
 // provider's state changed between snapshot and reservation. Caller holds r.mu
 // and p.mu.
 func (r *Registry) providerCanAdmitLocked(p *Provider, model string, traits RequestTraits, selfRouteOwner bool) bool {
+	return r.providerCanAdmitLockedEx(p, model, traits, selfRouteOwner, false)
+}
+
+// providerCanAdmitLockedEx is providerCanAdmitLocked with an explicit
+// ignoreProviderBreaker switch. ReserveProviderEx sets it true ONLY when the
+// selected winner is itself node-health-breaker-open — which can happen only
+// because the selectBestCandidateLockedFull fail-open fallback pass chose it.
+// Without this, the admit re-check would re-apply the breaker and reject the
+// very candidate the fail-open valve just selected, derouting the fleet anyway.
+// The default wrapper (breaker honored) is unchanged for every other caller.
+// Caller holds r.mu and p.mu.
+func (r *Registry) providerCanAdmitLockedEx(p *Provider, model string, traits RequestTraits, selfRouteOwner bool, ignoreProviderBreaker bool) bool {
 	now := time.Now()
-	if !r.providerPassesRoutingGatesLocked(p, model, traits, selfRouteOwner, now) {
+	if !r.providerPassesRoutingGatesLockedEx(p, model, traits, selfRouteOwner, now, ignoreProviderBreaker) {
 		return false
 	}
 	if !p.hasConcurrencyHeadroomForModelLocked(model) {

--- a/provider-swift/Sources/ProviderCore/Inference/BackendLivenessProbe.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/BackendLivenessProbe.swift
@@ -1,0 +1,98 @@
+// Copyright © 2026 Eigen Labs.
+//
+// DAR-337 / DAR-338 in-process backend-liveness decision.
+//
+// A loaded model can stop serving while the process stays up and the engine
+// loop never crashes, so the node keeps advertising slot_state=idle/healthy and
+// the coordinator keeps routing to it — a silent wedge. Two failure modes:
+//
+//   * WEDGE (DAR-338 safety net): a request was admitted (the engine picked it
+//     up) but produced 0 tokens for far longer than any real prefill — the GPU
+//     step loop has stalled behind a blocked reservation / GPU sync.
+//   * PINNED (DAR-337): the global KV budget collapsed to its ~1024-token floor
+//     and stays there with 0 successful serves — every request 503s on
+//     "insufficient global KV cache headroom" until a process/model reload.
+//
+// This policy is PURE (no GPU, no clocks, no I/O — all timing is passed in as
+// seconds) so every branch is unit-testable. The scheduler owns the live state
+// (active bridges, token budget, last-success time) and feeds it here; the
+// returned diagnosis drives both a TRUTHFUL heartbeat slot_state and a model
+// self-restart.
+
+import Foundation
+
+/// Backend-liveness diagnosis produced by ``BackendLivenessPolicy``.
+public enum BackendLiveness: Equatable, Sendable {
+    /// Serving normally (or idle-but-ready).
+    case healthy
+    /// A request was admitted but the backend produced no tokens for too long.
+    case wedged
+    /// The KV budget has collapsed and nothing can be served.
+    case pinned
+}
+
+/// Pure decision for the in-process backend-liveness watchdog.
+public struct BackendLivenessPolicy: Sendable, Equatable {
+    /// An admitted request that has produced 0 tokens for at least this many
+    /// seconds means the engine step loop is stalled. Defaults to the
+    /// pending-timeout window: no legitimate cold prefill takes this long to emit
+    /// its first token.
+    public var wedgeStallSeconds: Double
+    /// A token budget at or below this is "collapsed" — the 1024-token floor plus
+    /// slack. A healthy budget is on the order of a million tokens.
+    public var collapsedBudgetTokens: Int
+    /// The budget must stay collapsed AND produce 0 successes for at least this
+    /// many seconds before it is declared pinned — a brief, self-healing dip is
+    /// not a restart trigger.
+    public var pinnedSeconds: Double
+
+    public static let defaultWedgeStallSeconds: Double = 120
+    public static let defaultCollapsedBudgetTokens = 4096
+    public static let defaultPinnedSeconds: Double = 180
+
+    public init(
+        wedgeStallSeconds: Double = BackendLivenessPolicy.defaultWedgeStallSeconds,
+        collapsedBudgetTokens: Int = BackendLivenessPolicy.defaultCollapsedBudgetTokens,
+        pinnedSeconds: Double = BackendLivenessPolicy.defaultPinnedSeconds
+    ) {
+        self.wedgeStallSeconds = wedgeStallSeconds
+        self.collapsedBudgetTokens = collapsedBudgetTokens
+        self.pinnedSeconds = pinnedSeconds
+    }
+
+    /// Decide backend liveness from the current scheduler state.
+    ///
+    /// - Parameters:
+    ///   - longestAdmittedZeroTokenSeconds: how long the longest-stalled admitted
+    ///     request has produced 0 tokens, or nil if no admitted request is
+    ///     currently producing 0 tokens.
+    ///   - budgetCollapsedForSeconds: how long the token budget has been
+    ///     CONTINUOUSLY at/below ``collapsedBudgetTokens``, or nil if it is not
+    ///     currently collapsed. (The scheduler maintains this window using
+    ///     ``collapsedBudgetTokens`` so the threshold has a single definition.)
+    ///   - secondsSinceLastSuccess: seconds since the last successful completion,
+    ///     or nil if nothing has succeeded since the model loaded.
+    ///   - hasDemand: whether there is any active or queued request right now (an
+    ///     idle box with a momentarily small budget is failing no one).
+    public func assess(
+        longestAdmittedZeroTokenSeconds: Double?,
+        budgetCollapsedForSeconds: Double?,
+        secondsSinceLastSuccess: Double?,
+        hasDemand: Bool
+    ) -> BackendLiveness {
+        // Wedge first: a concrete stalled request is the strongest, most specific
+        // signal that the backend is not making progress.
+        if let stall = longestAdmittedZeroTokenSeconds, stall >= wedgeStallSeconds {
+            return .wedged
+        }
+        // Pinned: the budget has been collapsed long enough, there is demand, and
+        // nothing has succeeded within the same window.
+        if let collapsedFor = budgetCollapsedForSeconds,
+            collapsedFor >= pinnedSeconds,
+            hasDemand {
+            let noRecentSuccess = (secondsSinceLastSuccess ?? .greatestFiniteMagnitude) >= pinnedSeconds
+            if noRecentSuccess { return .pinned }
+        }
+        return .healthy
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Inference/BackendLivenessProbe.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/BackendLivenessProbe.swift
@@ -45,19 +45,33 @@ public struct BackendLivenessPolicy: Sendable, Equatable {
     /// many seconds before it is declared pinned — a brief, self-healing dip is
     /// not a restart trigger.
     public var pinnedSeconds: Double
+    /// A token-budget / KV-headroom admission rejection within this many seconds
+    /// counts as DEMAND even when there are no active/queued bridges. A pinned
+    /// pool rejects real requests at the early token-budget guards (and the
+    /// per-request KV reservation) BEFORE any bridge is inserted, so the
+    /// active/pending signal is 0 on every tick even though the box is actively
+    /// 503-ing traffic. Without this window the watchdog would see an idle box
+    /// and never self-restart the pin.
+    public var admissionRejectDemandSeconds: Double
 
     public static let defaultWedgeStallSeconds: Double = 120
     public static let defaultCollapsedBudgetTokens = 4096
     public static let defaultPinnedSeconds: Double = 180
+    /// A reject this recent still indicates live traffic. Comfortably longer than
+    /// the ~2s watchdog tick and typical inter-request gaps, but short enough
+    /// that a single old reject followed by silence stops counting as demand.
+    public static let defaultAdmissionRejectDemandSeconds: Double = 60
 
     public init(
         wedgeStallSeconds: Double = BackendLivenessPolicy.defaultWedgeStallSeconds,
         collapsedBudgetTokens: Int = BackendLivenessPolicy.defaultCollapsedBudgetTokens,
-        pinnedSeconds: Double = BackendLivenessPolicy.defaultPinnedSeconds
+        pinnedSeconds: Double = BackendLivenessPolicy.defaultPinnedSeconds,
+        admissionRejectDemandSeconds: Double = BackendLivenessPolicy.defaultAdmissionRejectDemandSeconds
     ) {
         self.wedgeStallSeconds = wedgeStallSeconds
         self.collapsedBudgetTokens = collapsedBudgetTokens
         self.pinnedSeconds = pinnedSeconds
+        self.admissionRejectDemandSeconds = admissionRejectDemandSeconds
     }
 
     /// Decide backend liveness from the current scheduler state.
@@ -74,22 +88,38 @@ public struct BackendLivenessPolicy: Sendable, Equatable {
     ///     or nil if nothing has succeeded since the model loaded.
     ///   - hasDemand: whether there is any active or queued request right now (an
     ///     idle box with a momentarily small budget is failing no one).
+    ///   - secondsSinceLastAdmissionReject: seconds since a request was last
+    ///     rejected at admission BEFORE any bridge was inserted (early
+    ///     token-budget guard or per-request KV-headroom failure), or nil if
+    ///     none. A reject within ``admissionRejectDemandSeconds`` ALSO counts as
+    ///     demand: a pinned pool fails real traffic at those guards, leaving
+    ///     `hasDemand` (active/queued) false on every tick, so this is the only
+    ///     evidence that the box is actively rejecting requests.
     public func assess(
         longestAdmittedZeroTokenSeconds: Double?,
         budgetCollapsedForSeconds: Double?,
         secondsSinceLastSuccess: Double?,
-        hasDemand: Bool
+        hasDemand: Bool,
+        secondsSinceLastAdmissionReject: Double? = nil
     ) -> BackendLiveness {
         // Wedge first: a concrete stalled request is the strongest, most specific
         // signal that the backend is not making progress.
         if let stall = longestAdmittedZeroTokenSeconds, stall >= wedgeStallSeconds {
             return .wedged
         }
+        // Effective demand = active/queued work right now OR a recent admission
+        // rejection. The latter is essential for the pinned case: every request
+        // is rejected at the early token-budget / KV-headroom guards before a
+        // bridge exists, so `hasDemand` stays false while the box 503s real
+        // traffic. A reject older than the window is no longer current demand.
+        let recentReject =
+            (secondsSinceLastAdmissionReject ?? .greatestFiniteMagnitude) <= admissionRejectDemandSeconds
+        let demand = hasDemand || recentReject
         // Pinned: the budget has been collapsed long enough, there is demand, and
         // nothing has succeeded within the same window.
         if let collapsedFor = budgetCollapsedForSeconds,
             collapsedFor >= pinnedSeconds,
-            hasDemand {
+            demand {
             let noRecentSuccess = (secondsSinceLastSuccess ?? .greatestFiniteMagnitude) >= pinnedSeconds
             if noRecentSuccess { return .pinned }
         }

--- a/provider-swift/Sources/ProviderCore/Inference/BackendLivenessProbe.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/BackendLivenessProbe.swift
@@ -1,22 +1,22 @@
 // Copyright © 2026 Eigen Labs.
 //
-// DAR-337 / DAR-338 in-process backend-liveness decision.
+// In-process backend-liveness decision.
 //
 // A loaded model can stop serving while the process stays up and the engine
 // loop never crashes, so the node keeps advertising slot_state=idle/healthy and
 // the coordinator keeps routing to it — a silent wedge. Two failure modes:
 //
-//   * WEDGE (DAR-338 safety net): a request was admitted (the engine picked it
-//     up) but produced 0 tokens for far longer than any real prefill — the GPU
-//     step loop has stalled behind a blocked reservation / GPU sync.
-//   * PINNED (DAR-337): the global KV budget collapsed to its ~1024-token floor
-//     and stays there with 0 successful serves — every request 503s on
-//     "insufficient global KV cache headroom" until a process/model reload.
+//   * Wedged: a request was admitted (the engine picked it up) but produced 0
+//     tokens for far longer than any real prefill — the GPU step loop has
+//     stalled behind a blocked reservation or GPU sync.
+//   * Pinned: the global KV budget collapsed to its ~1024-token floor and stays
+//     there with 0 successful serves — every request 503s on "insufficient
+//     global KV cache headroom" until a process/model reload.
 //
-// This policy is PURE (no GPU, no clocks, no I/O — all timing is passed in as
+// This policy is pure (no GPU, no clocks, no I/O — all timing is passed in as
 // seconds) so every branch is unit-testable. The scheduler owns the live state
 // (active bridges, token budget, last-success time) and feeds it here; the
-// returned diagnosis drives both a TRUTHFUL heartbeat slot_state and a model
+// returned diagnosis drives both a truthful heartbeat slot_state and a model
 // self-restart.
 
 import Foundation

--- a/provider-swift/Sources/ProviderCore/Inference/BatchScheduler+EngineBridge.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/BatchScheduler+EngineBridge.swift
@@ -242,6 +242,11 @@ extension BatchScheduler {
                 ? Double(finalCompletion) / elapsedSeconds : 0
         }
 
+        // Backend-liveness watchdog (DAR-337): a real successful completion is
+        // proof the engine is decoding — it clears the "budget pinned with 0
+        // successes" signal regardless of the measured TPS.
+        if success { lastSuccessAt = finishedAt }
+
         if success, tps > 0 {
             // Previously `activeBridges.count + 1` mixed in
             // queued-not-admitted bridges. Use admitted-and-running

--- a/provider-swift/Sources/ProviderCore/Inference/BatchScheduler+EngineBridge.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/BatchScheduler+EngineBridge.swift
@@ -242,9 +242,9 @@ extension BatchScheduler {
                 ? Double(finalCompletion) / elapsedSeconds : 0
         }
 
-        // Backend-liveness watchdog (DAR-337): a real successful completion is
-        // proof the engine is decoding — it clears the "budget pinned with 0
-        // successes" signal regardless of the measured TPS.
+        // Backend-liveness watchdog: a real successful completion is proof the
+        // engine is decoding — it clears the "budget pinned with 0 successes"
+        // signal regardless of the measured TPS.
         if success { lastSuccessAt = finishedAt }
 
         if success, tps > 0 {

--- a/provider-swift/Sources/ProviderCore/Inference/BatchScheduler+EngineBridge.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/BatchScheduler+EngineBridge.swift
@@ -496,4 +496,26 @@ extension BatchScheduler {
     func _bridgeIsActiveForTest(_ id: String) -> Bool {
         activeBridges[id] != nil
     }
+
+    /// Test seam: set the live `modelId` without a real load (production sets it
+    /// in `loadModel`). Lets a non-live unit test assert the heartbeat's
+    /// steady-state slot model. Internal + @testable-only; stripped from
+    /// production binaries.
+    func _setModelIdForTest(_ id: String) {
+        modelId = id
+    }
+
+    /// Test seam: reproduce the mid-self-restart heartbeat window WITHOUT a live
+    /// engine. Mirrors the exact transient state that `selfRestartForRecovery` +
+    /// `loadModel` → `stopCurrentEngine` produce mid-restart: the recovery flag is
+    /// set and the REAL model id is captured, while the live `modelId` has been
+    /// cleared to "" and the engine nil'd. Lets a non-live unit test assert the
+    /// heartbeat still advertises the real model id as `reloading` (never `model:""`
+    /// and never a servable state). Internal + @testable-only.
+    func _enterRecoveryReloadWindowForTest(realModelId: String) {
+        isReloadingForRecovery = true
+        recoveryReloadModelId = realModelId
+        modelId = ""
+        engine = nil
+    }
 }

--- a/provider-swift/Sources/ProviderCore/Inference/BatchScheduler+Liveness.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/BatchScheduler+Liveness.swift
@@ -1,0 +1,159 @@
+// Copyright © 2026 Eigen Labs.
+//
+// Backend-liveness watchdog for `BatchScheduler` (DAR-337 / DAR-338).
+//
+// A loaded model can stop serving while the process stays up and the engine
+// loop never crashes — a wedged engine (a request admitted but producing 0
+// tokens) or a pinned KV pool (the global budget collapsed to its floor). In
+// both cases the node would otherwise keep advertising slot_state=idle/healthy
+// and the coordinator would keep routing to it.
+//
+// This watchdog:
+//   1. periodically drives the off-actor proactive KV-pool sweep (DAR-338), then
+//   2. assesses backend liveness via the pure `BackendLivenessPolicy`, and on a
+//      degraded verdict makes the heartbeat slot_state TRUTHFUL (see
+//      `BatchScheduler+Telemetry`) AND self-restarts the engine/model slot
+//      (reusing the normal `stopCurrentEngine` + `loadModel` path) to recover.
+//
+// The blocking work it can trigger (a model reload) happens via `loadModel`,
+// which is already epoch-guarded and off the admission hot path.
+
+import Foundation
+import os
+
+let livenessLogger = Logger(subsystem: "dev.darkbloom.provider", category: "backend-liveness")
+
+extension BatchScheduler {
+
+    /// Spawn the detached liveness watchdog. Called from `loadModel`; cancelled
+    /// (and re-spawned) on every `stopCurrentEngine` / `loadModel` cycle.
+    func startLivenessWatchdog() {
+        livenessWatchdogTask?.cancel()
+        let scheduler = self
+        let interval = livenessWatchdogInterval
+        livenessWatchdogTask = Task.detached {
+            while !Task.isCancelled {
+                try? await Task.sleep(for: interval)
+                if Task.isCancelled { return }
+                await scheduler.tickLivenessWatchdog()
+            }
+        }
+    }
+
+    /// One watchdog tick: proactively trim the reclaimable KV pool (off-actor,
+    /// non-blocking) then assess + recover backend liveness.
+    func tickLivenessWatchdog() async {
+        // Proactive, rate-limited, threshold-gated pool sweep. Non-blocking and
+        // nonisolated — it never touches/awaits the budget actor (DAR-338).
+        kvBudget?.proactiveReclaimSweep()
+        await assessBackendLiveness()
+    }
+
+    /// Assess backend liveness from live scheduler state and, on a degraded
+    /// verdict, mark the slot degraded (truthful heartbeat) and — outside the
+    /// restart cooldown — self-restart the engine to recover.
+    func assessBackendLiveness() async {
+        // Nothing to assess (or to reload) without a live engine + container.
+        guard engine != nil, modelContainer != nil else { return }
+        // A recovery reload is already in flight; don't launch a second.
+        guard !isReloadingForRecovery else { return }
+
+        let now = ContinuousClock.now
+
+        // Maintain the continuous-collapse window using the policy's single
+        // threshold definition.
+        let budget = tokenBudgetMax
+        if budget <= livenessPolicy.collapsedBudgetTokens {
+            if budgetCollapsedSince == nil { budgetCollapsedSince = now }
+        } else {
+            budgetCollapsedSince = nil
+        }
+
+        let longestStall = longestAdmittedZeroTokenStallSeconds(now: now)
+        let hasDemand = !activeBridges.isEmpty || pendingRequestCount > 0
+        let verdict = livenessPolicy.assess(
+            longestAdmittedZeroTokenSeconds: longestStall,
+            budgetCollapsedForSeconds: budgetCollapsedSince.map { Self.seconds(now - $0) },
+            secondsSinceLastSuccess: lastSuccessAt.map { Self.seconds(now - $0) },
+            hasDemand: hasDemand)
+
+        switch verdict {
+        case .healthy:
+            if livenessState != .healthy {
+                livenessState = .healthy
+                let model = modelId
+                livenessLogger.info("backend liveness recovered to healthy for \(model, privacy: .public)")
+            }
+        case .wedged, .pinned:
+            // Report the truth on the heartbeat REGARDLESS of the restart cooldown
+            // so the coordinator stops routing here even between restart attempts.
+            livenessState = verdict
+            if let last = lastSelfRestartAt, now - last < livenessRestartCooldown {
+                logDegraded(verdict, longestStall: longestStall, budget: budget,
+                            note: "within restart cooldown — not restarting yet")
+                return
+            }
+            logDegraded(verdict, longestStall: longestStall, budget: budget,
+                        note: "self-restarting engine to recover")
+            lastSelfRestartAt = now
+            await selfRestartForRecovery()
+        }
+    }
+
+    /// Longest time (seconds) that any ADMITTED request has been producing 0
+    /// tokens, or nil if no admitted request is currently at 0 tokens. A request
+    /// is "admitted" once the engine emits its first `RequestOutput`
+    /// (`admittedAt != nil`); 0 tokens means no first token AND no completion
+    /// tokens observed — i.e. the engine took it but isn't decoding it.
+    func longestAdmittedZeroTokenStallSeconds(now: ContinuousClock.Instant) -> Double? {
+        var longest: Double?
+        for bridge in activeBridges.values {
+            guard let admittedAt = bridge.admittedAt,
+                bridge.firstTokenAt == nil,
+                bridge.completionTokens == 0 else { continue }
+            let stall = Self.seconds(now - admittedAt)
+            if longest == nil || stall > longest! { longest = stall }
+        }
+        return longest
+    }
+
+    /// Self-restart the engine/model slot to clear a wedge or a pinned KV pool.
+    /// Captures the resident container (the slot still holds a strong ref, so the
+    /// local binding keeps it alive across `stopCurrentEngine`'s nil-out) and
+    /// reloads via the normal `loadModel` path, which tears down the stalled
+    /// engine + flushes the pool and brings a fresh one up. `isReloadingForRecovery`
+    /// keeps the heartbeat reporting "reloading" for the whole window and is the
+    /// sole owner of that flag.
+    func selfRestartForRecovery() async {
+        guard let container = modelContainer else { return }
+        let id = modelId
+        let hash = currentWeightHash
+        isReloadingForRecovery = true
+        livenessLogger.error("self-restarting model \(id, privacy: .public) to recover backend liveness")
+        await loadModel(container: container, modelId: id, weightHash: hash)
+        // Single owner of the flag: clear it whether the reload succeeded, was
+        // superseded, or bailed early, so a later tick can re-detect + retry.
+        isReloadingForRecovery = false
+        livenessLogger.info("self-restart of \(id, privacy: .public) complete (engine reloaded)")
+    }
+
+    /// ContinuousClock.Duration → seconds (Double).
+    static func seconds(_ duration: Duration) -> Double {
+        Double(duration.components.seconds)
+            + Double(duration.components.attoseconds) / 1e18
+    }
+
+    private func logDegraded(
+        _ verdict: BackendLiveness, longestStall: Double?, budget: Int, note: String
+    ) {
+        let kind = verdict == .wedged ? "WEDGED" : "PINNED"
+        let stallStr = longestStall.map { String(format: "%.0f", $0) } ?? "n/a"
+        // Lightweight diagnostics: enough to tell wedge from pin and to see the
+        // collapsed budget / stall without a GPU probe.
+        let model = modelId
+        let active = activeBridges.count
+        let pending = pendingRequestCount
+        livenessLogger.error(
+            "backend \(kind, privacy: .public) for \(model, privacy: .public): tokenBudgetMax=\(budget) activeBridges=\(active) pending=\(pending) longestZeroTokenStallSec=\(stallStr, privacy: .public) — \(note, privacy: .public)")
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Inference/BatchScheduler+Liveness.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/BatchScheduler+Liveness.swift
@@ -1,6 +1,6 @@
 // Copyright © 2026 Eigen Labs.
 //
-// Backend-liveness watchdog for `BatchScheduler` (DAR-337 / DAR-338).
+// Backend-liveness watchdog for `BatchScheduler`.
 //
 // A loaded model can stop serving while the process stays up and the engine
 // loop never crashes — a wedged engine (a request admitted but producing 0
@@ -9,10 +9,10 @@
 // and the coordinator would keep routing to it.
 //
 // This watchdog:
-//   1. periodically drives the off-actor proactive KV-pool sweep (DAR-338), then
+//   1. periodically drives the off-actor proactive KV-pool sweep, then
 //   2. assesses backend liveness via the pure `BackendLivenessPolicy`, and on a
-//      degraded verdict makes the heartbeat slot_state TRUTHFUL (see
-//      `BatchScheduler+Telemetry`) AND self-restarts the engine/model slot
+//      degraded verdict makes the heartbeat slot_state truthful (see
+//      `BatchScheduler+Telemetry`) and self-restarts the engine/model slot
 //      (reusing the normal `stopCurrentEngine` + `loadModel` path) to recover.
 //
 // The blocking work it can trigger (a model reload) happens via `loadModel`,
@@ -41,10 +41,10 @@ extension BatchScheduler {
     }
 
     /// One watchdog tick: proactively trim the reclaimable KV pool (off-actor,
-    /// non-blocking) then assess + recover backend liveness.
+    /// non-blocking) then assess and recover backend liveness.
     func tickLivenessWatchdog() async {
         // Proactive, rate-limited, threshold-gated pool sweep. Non-blocking and
-        // nonisolated — it never touches/awaits the budget actor (DAR-338).
+        // nonisolated — it never touches or awaits the budget actor.
         kvBudget?.proactiveReclaimSweep()
         await assessBackendLiveness()
     }
@@ -85,7 +85,7 @@ extension BatchScheduler {
                 livenessLogger.info("backend liveness recovered to healthy for \(model, privacy: .public)")
             }
         case .wedged, .pinned:
-            // Report the truth on the heartbeat REGARDLESS of the restart cooldown
+            // Report the truth on the heartbeat regardless of the restart cooldown
             // so the coordinator stops routing here even between restart attempts.
             livenessState = verdict
             if let last = lastSelfRestartAt, now - last < livenessRestartCooldown {
@@ -100,10 +100,10 @@ extension BatchScheduler {
         }
     }
 
-    /// Longest time (seconds) that any ADMITTED request has been producing 0
+    /// Longest time (seconds) that any admitted request has been producing 0
     /// tokens, or nil if no admitted request is currently at 0 tokens. A request
     /// is "admitted" once the engine emits its first `RequestOutput`
-    /// (`admittedAt != nil`); 0 tokens means no first token AND no completion
+    /// (`admittedAt != nil`); 0 tokens means no first token and no completion
     /// tokens observed — i.e. the engine took it but isn't decoding it.
     func longestAdmittedZeroTokenStallSeconds(now: ContinuousClock.Instant) -> Double? {
         var longest: Double?
@@ -132,7 +132,7 @@ extension BatchScheduler {
         livenessLogger.error("self-restarting model \(id, privacy: .public) to recover backend liveness")
         await loadModel(container: container, modelId: id, weightHash: hash)
         // Single owner of the flag: clear it whether the reload succeeded, was
-        // superseded, or bailed early, so a later tick can re-detect + retry.
+        // superseded, or bailed early, so a later tick can re-detect and retry.
         isReloadingForRecovery = false
         livenessLogger.info("self-restart of \(id, privacy: .public) complete (engine reloaded)")
     }
@@ -149,7 +149,7 @@ extension BatchScheduler {
         let kind = verdict == .wedged ? "WEDGED" : "PINNED"
         let stallStr = longestStall.map { String(format: "%.0f", $0) } ?? "n/a"
         // Lightweight diagnostics: enough to tell wedge from pin and to see the
-        // collapsed budget / stall without a GPU probe.
+        // collapsed budget or stall without a GPU probe.
         let model = modelId
         let active = activeBridges.count
         let pending = pendingRequestCount

--- a/provider-swift/Sources/ProviderCore/Inference/BatchScheduler+Liveness.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/BatchScheduler+Liveness.swift
@@ -143,12 +143,20 @@ extension BatchScheduler {
         guard let container = modelContainer else { return }
         let id = modelId
         let hash = currentWeightHash
+        // Capture the REAL model id NOW, before `loadModel` → `stopCurrentEngine`
+        // transiently clears the live `modelId` to "". The heartbeat reports this
+        // captured id (with a not-servable `reloading` state) for the whole reload
+        // window, so the coordinator deroutes the real model instead of seeing a
+        // phantom `model:""` slot and treating the model as cold/unknown here.
+        recoveryReloadModelId = id
         isReloadingForRecovery = true
         livenessLogger.error("self-restarting model \(id, privacy: .public) to recover backend liveness")
         await loadModel(container: container, modelId: id, weightHash: hash)
-        // Single owner of the flag: clear it whether the reload succeeded, was
-        // superseded, or bailed early, so a later tick can re-detect and retry.
+        // Single owner of the flag + captured id: clear them whether the reload
+        // succeeded, was superseded, or bailed early, so a later tick can
+        // re-detect and retry. (loadModel has by now re-set the live `modelId`.)
         isReloadingForRecovery = false
+        recoveryReloadModelId = nil
         livenessLogger.info("self-restart of \(id, privacy: .public) complete (engine reloaded)")
     }
 

--- a/provider-swift/Sources/ProviderCore/Inference/BatchScheduler+Liveness.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/BatchScheduler+Liveness.swift
@@ -40,6 +40,16 @@ extension BatchScheduler {
         }
     }
 
+    /// Record an admission rejection that returns BEFORE any `activeBridges`
+    /// entry exists: the early token-budget guards in `submit` / `submitTokenized`
+    /// and the per-request KV reservation failure (which drops its bridge before
+    /// returning). This is the watchdog's only evidence of demand for a pinned
+    /// KV pool — every real request is rejected at those sites, so `activeBridges`
+    /// and `pendingRequestCount` stay 0 and would otherwise make the box look idle.
+    func noteAdmissionReject() {
+        lastAdmissionRejectAt = ContinuousClock.now
+    }
+
     /// One watchdog tick: proactively trim the reclaimable KV pool (off-actor,
     /// non-blocking) then assess and recover backend liveness.
     func tickLivenessWatchdog() async {
@@ -70,12 +80,17 @@ extension BatchScheduler {
         }
 
         let longestStall = longestAdmittedZeroTokenStallSeconds(now: now)
+        // Active/queued work is demand — but so is a recent admission rejection:
+        // a pinned pool rejects every request at the early token-budget / KV
+        // guards before a bridge exists, so these two counters stay 0 while it
+        // 503s real traffic. The pure policy folds the reject window into demand.
         let hasDemand = !activeBridges.isEmpty || pendingRequestCount > 0
         let verdict = livenessPolicy.assess(
             longestAdmittedZeroTokenSeconds: longestStall,
             budgetCollapsedForSeconds: budgetCollapsedSince.map { Self.seconds(now - $0) },
             secondsSinceLastSuccess: lastSuccessAt.map { Self.seconds(now - $0) },
-            hasDemand: hasDemand)
+            hasDemand: hasDemand,
+            secondsSinceLastAdmissionReject: lastAdmissionRejectAt.map { Self.seconds(now - $0) })
 
         switch verdict {
         case .healthy:

--- a/provider-swift/Sources/ProviderCore/Inference/BatchScheduler+Telemetry.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/BatchScheduler+Telemetry.swift
@@ -116,6 +116,19 @@ extension BatchScheduler {
 
     // MARK: - Heartbeat payload
 
+    /// Truthful slot_state for the heartbeat (DAR-337/338). A wedged or pinned
+    /// backend must NOT keep advertising "idle"/"running" (a healthy-looking slot
+    /// the coordinator routes to); it reports "crashed" so the coordinator
+    /// deroutes, and "reloading" while a recovery self-restart is in flight. Only
+    /// a genuinely healthy backend reports the normal running/idle pair.
+    func heartbeatSlotState(activeRequests: Int) -> String {
+        if isReloadingForRecovery { return "reloading" }
+        switch livenessState {
+        case .wedged, .pinned: return "crashed"
+        case .healthy: return activeRequests > 0 ? "running" : "idle"
+        }
+    }
+
     /// Public surface called from `ProviderLoop` on every heartbeat tick.
     /// Implementation lives in the telemetry extension because most of
     /// the fields are EWMA / queued-budget state owned here.
@@ -135,7 +148,7 @@ extension BatchScheduler {
 
         let slot = BackendSlotCapacity(
             model: cap.model,
-            state: cap.activeRequests > 0 ? "running" : "idle",
+            state: heartbeatSlotState(activeRequests: cap.activeRequests),
             numRunning: UInt32(cap.activeRequests),
             numWaiting: UInt32(cap.pendingRequests),
             activeTokens: activeTokens,

--- a/provider-swift/Sources/ProviderCore/Inference/BatchScheduler+Telemetry.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/BatchScheduler+Telemetry.swift
@@ -129,6 +129,22 @@ extension BatchScheduler {
         }
     }
 
+    /// Truthful slot `model` for the heartbeat. During a recovery self-restart the
+    /// live `modelId` is transiently "" — `loadModel` → `stopCurrentEngine` clears
+    /// it before `loadModel` re-sets it — so report the captured REAL id being
+    /// reloaded for the WHOLE window. Paired with the `reloading` state above, this
+    /// keeps the coordinator seeing the real model as not-servable (and derouting
+    /// it) instead of a phantom `model:""` slot, which would make the real model
+    /// look absent/cold here and let the coordinator route a request into a nil
+    /// engine ("No model loaded" 500). Outside a recovery restart this returns the
+    /// live capacity model unchanged, so the normal load/teardown path is unaffected.
+    func heartbeatSlotModel(capacityModel: String) -> String {
+        if isReloadingForRecovery, let id = recoveryReloadModelId, !id.isEmpty {
+            return id
+        }
+        return capacityModel
+    }
+
     /// Public surface called from `ProviderLoop` on every heartbeat tick.
     /// Implementation lives in the telemetry extension because most of
     /// the fields are EWMA / queued-budget state owned here.
@@ -147,7 +163,7 @@ extension BatchScheduler {
         let budgetMax = Int64(tokenBudgetMax)
 
         let slot = BackendSlotCapacity(
-            model: cap.model,
+            model: heartbeatSlotModel(capacityModel: cap.model),
             state: heartbeatSlotState(activeRequests: cap.activeRequests),
             numRunning: UInt32(cap.activeRequests),
             numWaiting: UInt32(cap.pendingRequests),

--- a/provider-swift/Sources/ProviderCore/Inference/BatchScheduler+Telemetry.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/BatchScheduler+Telemetry.swift
@@ -116,11 +116,11 @@ extension BatchScheduler {
 
     // MARK: - Heartbeat payload
 
-    /// Truthful slot_state for the heartbeat (DAR-337/338). A wedged or pinned
-    /// backend must NOT keep advertising "idle"/"running" (a healthy-looking slot
-    /// the coordinator routes to); it reports "crashed" so the coordinator
-    /// deroutes, and "reloading" while a recovery self-restart is in flight. Only
-    /// a genuinely healthy backend reports the normal running/idle pair.
+    /// Truthful slot_state for the heartbeat. A wedged or pinned backend must not
+    /// keep advertising "idle"/"running" (a healthy-looking slot the coordinator
+    /// routes to); it reports "crashed" so the coordinator deroutes, and
+    /// "reloading" while a recovery self-restart is in flight. Only a genuinely
+    /// healthy backend reports the normal running/idle pair.
     func heartbeatSlotState(activeRequests: Int) -> String {
         if isReloadingForRecovery { return "reloading" }
         switch livenessState {

--- a/provider-swift/Sources/ProviderCore/Inference/BatchScheduler.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/BatchScheduler.swift
@@ -62,8 +62,8 @@ public actor BatchScheduler {
     var modelContainer: ModelContainer?
     var modelId: String = ""
     /// Weight hash of the currently-loaded model, captured at load. Retained so a
-    /// liveness-watchdog self-restart (DAR-337/338) can reload the SAME bytes via
-    /// the normal `loadModel` path without re-deriving it. Cleared on teardown.
+    /// liveness-watchdog self-restart can reload the same bytes via the normal
+    /// `loadModel` path without re-deriving it. Cleared on teardown.
     var currentWeightHash: String?
     var modelWeightBytes: Int = 0
     var kvBytesPerToken: Int = 400_000
@@ -133,11 +133,11 @@ public actor BatchScheduler {
     /// Watchdog for planner-pending requests that exceed `pendingTimeout`.
     var pendingTimeoutTask: Task<Void, Never>?
 
-    // MARK: - Backend-liveness watchdog state (DAR-337 / DAR-338)
+    // MARK: - Backend-liveness watchdog state
     //
     // A loaded model can stop serving while the process stays up and the engine
     // loop never crashes. These fields let the in-process watchdog detect that,
-    // report a TRUTHFUL heartbeat slot_state (so the coordinator stops routing
+    // report a truthful heartbeat slot_state (so the coordinator stops routing
     // here), and self-restart the engine to clear the condition. The decision
     // itself is pure (`BackendLivenessPolicy`); these track its live inputs.
 
@@ -152,7 +152,7 @@ public actor BatchScheduler {
     /// True while a recovery self-restart is in flight; drives a "reloading"
     /// slot_state and prevents the watchdog from launching a second restart.
     var isReloadingForRecovery = false
-    /// When the token budget first went CONTINUOUSLY collapsed (at/below
+    /// When the token budget first went continuously collapsed (at/below
     /// `livenessPolicy.collapsedBudgetTokens`); nil when not collapsed.
     var budgetCollapsedSince: ContinuousClock.Instant?
     /// When the last request completed successfully (since the current load).
@@ -439,9 +439,9 @@ public actor BatchScheduler {
         self.planner = makePlanner(activeTokenBudget: tokenBudgetMax)
         // Engine has no pending-queue TTL; we enforce `pendingTimeout`.
         startPendingTimeoutWatchdog()
-        // Backend-liveness watchdog (DAR-337/338): detect a wedged/pinned engine,
-        // report it truthfully on the heartbeat, and self-restart to recover.
-        // Also drives the proactive off-actor KV-pool sweep.
+        // Backend-liveness watchdog: detect a wedged/pinned engine, report it
+        // truthfully on the heartbeat, and self-restart to recover. Also drives
+        // the proactive off-actor KV-pool sweep.
         startLivenessWatchdog()
         // Periodic checkpoint-tier hit/miss logger (no-op if disabled or
         // engine-tier model). Cancelled in stopCurrentEngine.
@@ -1694,10 +1694,10 @@ public actor BatchScheduler {
         let need = activeTokenBudgetUsed + requestBudget
         guard need > tokenBudgetMax else { return }
         let shortfallBytes = UInt64(need - tokenBudgetMax) * UInt64(kvBytesPerToken)
-        // DAR-338: fire-and-forget signal (nonisolated — no actor hop, no GPU
-        // wait). The flush runs off the budget actor; `tokenBudgetMax` is re-read
-        // below against the current snapshot (a near-miss may reject — acceptable;
-        // the background reclaim + proactive sweep keep the pool small so most
+        // Fire-and-forget signal (nonisolated — no actor hop, no GPU wait). The
+        // flush runs off the budget actor; `tokenBudgetMax` is re-read below
+        // against the current snapshot (a near-miss may reject — acceptable; the
+        // background reclaim and proactive sweep keep the pool small so most
         // admits succeed without ever near-missing).
         kvBudget.reclaimForShortfall(shortfallBytes)
     }
@@ -2135,7 +2135,7 @@ public actor BatchScheduler {
         pendingTimeoutTask?.cancel()
         pendingTimeoutTask = nil
         // Stop the backend-liveness watchdog; a recovery restart re-arms it via
-        // loadModel. (Note: when THIS teardown is part of a recovery restart, the
+        // loadModel. (Note: when this teardown is part of a recovery restart, the
         // watchdog task currently awaiting `assessBackendLiveness` is the caller —
         // cancelling it here is the clean handoff; loadModel starts a fresh one.)
         livenessWatchdogTask?.cancel()
@@ -2225,9 +2225,9 @@ public actor BatchScheduler {
         lastModelLoadMs = 0
         performanceByBatchSize.removeAll()
         dynamicMaxConcurrentRequests = min(4, maxConcurrentRequests)
-        // Reset backend-liveness DIAGNOSIS tracking for the next load (fresh
+        // Reset backend-liveness diagnosis tracking for the next load (fresh
         // engine = healthy until proven otherwise). `isReloadingForRecovery` is
-        // intentionally NOT reset here: it is owned by `selfRestartForRecovery`
+        // intentionally not reset here: it is owned by `selfRestartForRecovery`
         // so the heartbeat keeps reporting "reloading" across this teardown until
         // the replacement engine is up.
         livenessState = .healthy

--- a/provider-swift/Sources/ProviderCore/Inference/BatchScheduler.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/BatchScheduler.swift
@@ -152,6 +152,17 @@ public actor BatchScheduler {
     /// True while a recovery self-restart is in flight; drives a "reloading"
     /// slot_state and prevents the watchdog from launching a second restart.
     var isReloadingForRecovery = false
+    /// The REAL model id being reloaded during a recovery self-restart, captured
+    /// at the start of `selfRestartForRecovery` BEFORE `loadModel` →
+    /// `stopCurrentEngine` transiently clears the live `modelId` to "". The
+    /// heartbeat advertises THIS id (see `heartbeatSlotModel`), not the empty live
+    /// `modelId`, for the whole reload window — so the coordinator keeps seeing the
+    /// real model as `reloading` and deroutes it, instead of seeing a phantom
+    /// `model:""` slot and treating the real model as cold/unknown here (which
+    /// would let it route a request into a nil engine → "No model loaded" 500).
+    /// Owned solely by `selfRestartForRecovery` (set before, cleared after); like
+    /// `isReloadingForRecovery` it is intentionally NOT reset by `stopCurrentEngine`.
+    var recoveryReloadModelId: String?
     /// When the token budget first went continuously collapsed (at/below
     /// `livenessPolicy.collapsedBudgetTokens`); nil when not collapsed.
     var budgetCollapsedSince: ContinuousClock.Instant?

--- a/provider-swift/Sources/ProviderCore/Inference/BatchScheduler.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/BatchScheduler.swift
@@ -61,6 +61,10 @@ public actor BatchScheduler {
 
     var modelContainer: ModelContainer?
     var modelId: String = ""
+    /// Weight hash of the currently-loaded model, captured at load. Retained so a
+    /// liveness-watchdog self-restart (DAR-337/338) can reload the SAME bytes via
+    /// the normal `loadModel` path without re-deriving it. Cleared on teardown.
+    var currentWeightHash: String?
     var modelWeightBytes: Int = 0
     var kvBytesPerToken: Int = 400_000
     var dynamicTokenBudgetMax: Int = 0
@@ -128,6 +132,38 @@ public actor BatchScheduler {
 
     /// Watchdog for planner-pending requests that exceed `pendingTimeout`.
     var pendingTimeoutTask: Task<Void, Never>?
+
+    // MARK: - Backend-liveness watchdog state (DAR-337 / DAR-338)
+    //
+    // A loaded model can stop serving while the process stays up and the engine
+    // loop never crashes. These fields let the in-process watchdog detect that,
+    // report a TRUTHFUL heartbeat slot_state (so the coordinator stops routing
+    // here), and self-restart the engine to clear the condition. The decision
+    // itself is pure (`BackendLivenessPolicy`); these track its live inputs.
+
+    /// Periodic backend-liveness watchdog (assess + proactive KV-pool sweep).
+    /// Started in `loadModel`, cancelled in `stopCurrentEngine`.
+    var livenessWatchdogTask: Task<Void, Never>?
+    /// Pure liveness decision. `wedgeStallSeconds` is pinned to `pendingTimeout`
+    /// in `init` so the wedge threshold tracks the queue-timeout window.
+    let livenessPolicy: BackendLivenessPolicy
+    /// Last diagnosis from the watchdog; drives the heartbeat slot_state.
+    var livenessState: BackendLiveness = .healthy
+    /// True while a recovery self-restart is in flight; drives a "reloading"
+    /// slot_state and prevents the watchdog from launching a second restart.
+    var isReloadingForRecovery = false
+    /// When the token budget first went CONTINUOUSLY collapsed (at/below
+    /// `livenessPolicy.collapsedBudgetTokens`); nil when not collapsed.
+    var budgetCollapsedSince: ContinuousClock.Instant?
+    /// When the last request completed successfully (since the current load).
+    var lastSuccessAt: ContinuousClock.Instant?
+    /// When the watchdog last triggered a recovery restart (cooldown anchor).
+    var lastSelfRestartAt: ContinuousClock.Instant?
+    /// Minimum gap between recovery restarts, so a still-degraded backend can't
+    /// thrash reloads.
+    let livenessRestartCooldown: Duration = .seconds(120)
+    /// How often the liveness watchdog ticks (assess + proactive sweep).
+    let livenessWatchdogInterval: Duration = .seconds(2)
 
     /// Periodic prefix-cache hit/miss stats logger. Started in `loadModel`
     /// when a checkpoint-tier manager is installed, cancelled in
@@ -221,6 +257,12 @@ public actor BatchScheduler {
         self.kvBudget = kvBudget
         self.diskAccountant = diskAccountant
         self.dynamicMaxConcurrentRequests = min(4, max(1, maxConcurrentRequests))
+        // Wedge threshold tracks the pending-timeout window: a request admitted
+        // but emitting 0 tokens for that long means the engine loop has stalled.
+        let pendingSecs = Double(pendingTimeout.components.seconds)
+            + Double(pendingTimeout.components.attoseconds) / 1e18
+        self.livenessPolicy = BackendLivenessPolicy(
+            wedgeStallSeconds: pendingSecs > 0 ? pendingSecs : BackendLivenessPolicy.defaultWedgeStallSeconds)
     }
 
     // MARK: - Model lifecycle
@@ -259,6 +301,7 @@ public actor BatchScheduler {
 
         self.modelContainer = container
         self.modelId = modelId
+        self.currentWeightHash = weightHash
         self.modelWeightBytes = snapshot.bytes
         self.tokenizer = snapshot.tokenizer
 
@@ -396,6 +439,10 @@ public actor BatchScheduler {
         self.planner = makePlanner(activeTokenBudget: tokenBudgetMax)
         // Engine has no pending-queue TTL; we enforce `pendingTimeout`.
         startPendingTimeoutWatchdog()
+        // Backend-liveness watchdog (DAR-337/338): detect a wedged/pinned engine,
+        // report it truthfully on the heartbeat, and self-restart to recover.
+        // Also drives the proactive off-actor KV-pool sweep.
+        startLivenessWatchdog()
         // Periodic checkpoint-tier hit/miss logger (no-op if disabled or
         // engine-tier model). Cancelled in stopCurrentEngine.
         startPrefixCacheStatsLogger()
@@ -1647,7 +1694,12 @@ public actor BatchScheduler {
         let need = activeTokenBudgetUsed + requestBudget
         guard need > tokenBudgetMax else { return }
         let shortfallBytes = UInt64(need - tokenBudgetMax) * UInt64(kvBytesPerToken)
-        _ = await kvBudget.reclaimForShortfall(shortfallBytes)
+        // DAR-338: fire-and-forget signal (nonisolated — no actor hop, no GPU
+        // wait). The flush runs off the budget actor; `tokenBudgetMax` is re-read
+        // below against the current snapshot (a near-miss may reject — acceptable;
+        // the background reclaim + proactive sweep keep the pool small so most
+        // admits succeed without ever near-missing).
+        kvBudget.reclaimForShortfall(shortfallBytes)
     }
 
     /// Submit a pre-tokenized prompt. Used by `MultiModelBatchSchedulerEngine`
@@ -2082,6 +2134,12 @@ public actor BatchScheduler {
         self.engine = nil
         pendingTimeoutTask?.cancel()
         pendingTimeoutTask = nil
+        // Stop the backend-liveness watchdog; a recovery restart re-arms it via
+        // loadModel. (Note: when THIS teardown is part of a recovery restart, the
+        // watchdog task currently awaiting `assessBackendLiveness` is the caller —
+        // cancelling it here is the clean handoff; loadModel starts a fresh one.)
+        livenessWatchdogTask?.cancel()
+        livenessWatchdogTask = nil
         // Log a final stats line before teardown, then stop the periodic logger.
         await logPrefixCacheStats()
         prefixCacheStatsTask?.cancel()
@@ -2154,6 +2212,7 @@ public actor BatchScheduler {
 
         modelWeightBytes = 0
         modelId = ""
+        currentWeightHash = nil
         kvBytesPerToken = 400_000
         dynamicTokenBudgetMax = 0
         maxContextLength = 0
@@ -2166,6 +2225,14 @@ public actor BatchScheduler {
         lastModelLoadMs = 0
         performanceByBatchSize.removeAll()
         dynamicMaxConcurrentRequests = min(4, maxConcurrentRequests)
+        // Reset backend-liveness DIAGNOSIS tracking for the next load (fresh
+        // engine = healthy until proven otherwise). `isReloadingForRecovery` is
+        // intentionally NOT reset here: it is owned by `selfRestartForRecovery`
+        // so the heartbeat keeps reporting "reloading" across this teardown until
+        // the replacement engine is up.
+        livenessState = .healthy
+        budgetCollapsedSince = nil
+        lastSuccessAt = nil
     }
 
     /// Cumulative active-bridge gate, called from tests.

--- a/provider-swift/Sources/ProviderCore/Inference/BatchScheduler.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/BatchScheduler.swift
@@ -157,6 +157,13 @@ public actor BatchScheduler {
     var budgetCollapsedSince: ContinuousClock.Instant?
     /// When the last request completed successfully (since the current load).
     var lastSuccessAt: ContinuousClock.Instant?
+    /// When a request was last rejected at admission BEFORE any `activeBridges`
+    /// entry existed — the early token-budget guards and the per-request KV
+    /// reservation failure. A pinned KV pool rejects real traffic at exactly
+    /// those sites, so it has no active/queued bridge to prove demand; the
+    /// liveness watchdog reads a recent value here as DEMAND so the pin is
+    /// detectable. Reset on each load (it is per-load demand state).
+    var lastAdmissionRejectAt: ContinuousClock.Instant?
     /// When the watchdog last triggered a recovery restart (cooldown anchor).
     var lastSelfRestartAt: ContinuousClock.Instant?
     /// Minimum gap between recovery restarts, so a still-degraded backend can't
@@ -1737,6 +1744,9 @@ public actor BatchScheduler {
         await reclaimPoolForTokenBudget(requestBudget: requestBudget)
         let budgetMax = tokenBudgetMax
         guard requestBudget <= budgetMax else {
+            // Rejected before any bridge exists — record demand for the liveness
+            // watchdog (a pinned pool is detectable only via this signal).
+            noteAdmissionReject()
             continuation.yield(.error(
                 "token_budget_exhausted: request requires \(requestBudget) tokens but only \(budgetMax) available"
             ))
@@ -1746,6 +1756,7 @@ public actor BatchScheduler {
 
         let activeUsed = activeTokenBudgetUsed
         if activeUsed + requestBudget > budgetMax {
+            noteAdmissionReject()
             continuation.yield(.error(
                 "token_budget_exhausted: request requires \(requestBudget) tokens but only \(budgetMax - activeUsed) available"
             ))
@@ -1805,6 +1816,10 @@ public actor BatchScheduler {
         )
         guard kvOutcome != .failed else {
             await dropBridge(requestId: id)
+            // The per-request KV reservation failed (collapsed headroom): the
+            // bridge is dropped, so this too returns with no active entry. Record
+            // demand for the liveness watchdog.
+            noteAdmissionReject()
             continuation.yield(.error("token_budget_exhausted: insufficient global KV cache headroom"))
             continuation.finish()
             return stream
@@ -1908,6 +1923,9 @@ public actor BatchScheduler {
         await reclaimPoolForTokenBudget(requestBudget: requestBudget)
         let budgetMax = tokenBudgetMax
         guard requestBudget <= budgetMax else {
+            // Rejected before any bridge exists — record demand for the liveness
+            // watchdog (a pinned pool is detectable only via this signal).
+            noteAdmissionReject()
             continuation.yield(.error(
                 "token_budget_exhausted: request requires \(requestBudget) tokens but only \(budgetMax) available"
             ))
@@ -1928,6 +1946,7 @@ public actor BatchScheduler {
         // bridge via `dropBridge(...)`.
         let activeUsed = activeTokenBudgetUsed
         if activeUsed + requestBudget > budgetMax {
+            noteAdmissionReject()
             continuation.yield(.error(
                 "token_budget_exhausted: request requires \(requestBudget) tokens but only \(budgetMax - activeUsed) available"
             ))
@@ -1990,6 +2009,10 @@ public actor BatchScheduler {
         )
         guard kvOutcome != .failed else {
             await dropBridge(requestId: id)
+            // The per-request KV reservation failed (collapsed headroom): the
+            // bridge is dropped, so this too returns with no active entry. Record
+            // demand for the liveness watchdog.
+            noteAdmissionReject()
             continuation.yield(.error("token_budget_exhausted: insufficient global KV cache headroom"))
             continuation.finish()
             return stream
@@ -2233,6 +2256,7 @@ public actor BatchScheduler {
         livenessState = .healthy
         budgetCollapsedSince = nil
         lastSuccessAt = nil
+        lastAdmissionRejectAt = nil
     }
 
     /// Cumulative active-bridge gate, called from tests.

--- a/provider-swift/Sources/ProviderCore/Inference/GlobalKVCacheBudget.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/GlobalKVCacheBudget.swift
@@ -27,10 +27,11 @@ public actor GlobalKVCacheBudget {
     private let memorySnapshot: @Sendable () -> MemorySnapshot
     private var reservations: [String: UInt64] = [:]
 
-    /// DAR-338: the reclaimable-pool flush runs HERE, off this actor. The
-    /// admission paths only ever SIGNAL it (non-blocking); the blocking GPU sync
-    /// happens on the reclaimer's executor. This actor is therefore NEVER blocked
-    /// on a GPU synchronize — the invariant the whole change exists to guarantee.
+    /// The reclaimable-pool flush runs in this reclaimer, off the budget actor.
+    /// The admission paths only ever signal it (non-blocking); the blocking GPU
+    /// sync happens on the reclaimer's executor, so the budget actor is never
+    /// blocked on a GPU synchronize — the invariant this design exists to
+    /// guarantee.
     private let reclaimer: KVPoolReclaimer
     static let defaultSelfHealMinInterval: Duration = KVPoolReclaimer.defaultMinInterval
 
@@ -158,14 +159,14 @@ public actor GlobalKVCacheBudget {
         }
     }
 
-    /// Reserve `bytes` against the CURRENT live headroom. The headroom math counts
-    /// the reclaimable MLX pool as used; on a near-miss we SIGNAL the off-actor
-    /// reclaimer to shrink that pool for FUTURE admissions and reject this request
-    /// against the current snapshot. We do NOT flush-and-resample inline: that
+    /// Reserve `bytes` against the current live headroom. The headroom math counts
+    /// the reclaimable MLX pool as used; on a near-miss we signal the off-actor
+    /// reclaimer to shrink that pool for future admissions and reject this request
+    /// against the current snapshot. We do not flush-and-resample inline: that
     /// would run a blocking GPU sync on this actor and serialize every other
-    /// reservation behind it (DAR-338). Rejecting a near-miss is acceptable — the
-    /// coordinator + per-provider breaker reroute, and the background reclaim keeps
-    /// the pool small so most admissions succeed without ever near-missing.
+    /// reservation behind it. Rejecting a near-miss is acceptable — the
+    /// coordinator and per-provider breaker reroute, and the background reclaim
+    /// keeps the pool small so most admissions succeed without ever near-missing.
     /// Caller has validated `bytes > 0` and no existing reservation.
     private func commit(requestID: String, bytes: UInt64) -> Bool {
         let available = availableReservationBytes()
@@ -178,12 +179,13 @@ public actor GlobalKVCacheBudget {
     }
 
     /// Signal the off-actor reclaimer to flush the reclaimable MLX pool for a
-    /// shortfall observed by the scheduler's token-budget gate. NON-BLOCKING and
+    /// shortfall observed by the scheduler's token-budget gate. Non-blocking and
     /// `nonisolated` (it touches no actor state — only the immutable reclaimer),
     /// so the caller doesn't even hop this actor: the GPU sync runs on the
-    /// reclaimer, never here (it used to run inline as a blocking synchronize —
-    /// the DAR-338 wedge). The reclaimer gates on whether the pool can cover the
-    /// shortfall and rate-limits, so this is an unconditional fire-and-forget.
+    /// reclaimer, never here (it used to run inline as a blocking synchronize,
+    /// which wedged the admission actor). The reclaimer gates on whether the pool
+    /// can cover the shortfall and rate-limits, so this is an unconditional
+    /// fire-and-forget.
     public nonisolated func reclaimForShortfall(_ shortfall: UInt64) {
         guard shortfall > 0 else { return }
         reclaimer.scheduleReclaim(shortfall: shortfall)
@@ -191,7 +193,7 @@ public actor GlobalKVCacheBudget {
 
     /// Trigger a proactive, rate-limited, threshold-gated background sweep of the
     /// reclaimable MLX pool so admission headroom stays healthy under sustained
-    /// load WITHOUT any inline flush. NON-BLOCKING + `nonisolated`. Called
+    /// load without any inline flush. Non-blocking and `nonisolated`. Called
     /// periodically by the scheduler watchdog while a model is loaded.
     public nonisolated func proactiveReclaimSweep() {
         reclaimer.scheduleSweep()

--- a/provider-swift/Sources/ProviderCore/Inference/GlobalKVCacheBudget.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/GlobalKVCacheBudget.swift
@@ -25,14 +25,14 @@ public actor GlobalKVCacheBudget {
     /// grow into memory the operator reserved. 0 = no extra reserve (cap only).
     private let configReserveBytes: UInt64
     private let memorySnapshot: @Sendable () -> MemorySnapshot
-    private let clearCache: @Sendable () -> Void
     private var reservations: [String: UInt64] = [:]
-    /// Rate-limit the self-heal flush to at most once per this interval. The flush
-    /// blocks on a GPU sync, so this bounds how often a flood of near-miss
-    /// admissions can chain GPU syncs on the actor and stall other reservations.
-    private var lastSelfHealAt: ContinuousClock.Instant?
-    private let selfHealMinInterval: Duration
-    private static let defaultSelfHealMinInterval: Duration = .seconds(1)
+
+    /// DAR-338: the reclaimable-pool flush runs HERE, off this actor. The
+    /// admission paths only ever SIGNAL it (non-blocking); the blocking GPU sync
+    /// happens on the reclaimer's executor. This actor is therefore NEVER blocked
+    /// on a GPU synchronize — the invariant the whole change exists to guarantee.
+    private let reclaimer: KVPoolReclaimer
+    static let defaultSelfHealMinInterval: Duration = KVPoolReclaimer.defaultMinInterval
 
     public init(
         capFraction: Double? = nil,
@@ -42,14 +42,13 @@ public actor GlobalKVCacheBudget {
         self.capFraction = capFraction
         self.activationReserveBytes = activationReserveBytes
         self.configReserveBytes = configReserveBytes
-        self.selfHealMinInterval = Self.defaultSelfHealMinInterval
         // Fence async GPU completion before freeing buffers, matching the engine's
         // own reclaim paths (avoids the IOKit completeMemory race seen on M4).
-        self.clearCache = {
+        let clearCache: @Sendable () -> Void = {
             MLX.Stream().synchronize()
             MLX.Memory.clearCache()
         }
-        self.memorySnapshot = {
+        let snapshot: @Sendable () -> MemorySnapshot = {
             MemorySnapshot(
                 total: ProcessInfo.processInfo.physicalMemory,
                 active: UInt64(Memory.activeMemory),
@@ -57,6 +56,10 @@ public actor GlobalKVCacheBudget {
                 // Real OS-free RAM; `.max` falls back to the MLX-only view.
                 systemAvailable: SystemMemory.availableBytes() ?? .max)
         }
+        self.memorySnapshot = snapshot
+        self.reclaimer = KVPoolReclaimer(
+            clearCache: clearCache,
+            reclaimableBytes: { snapshot().cache })
     }
 
     init(
@@ -65,14 +68,20 @@ public actor GlobalKVCacheBudget {
         configReserveBytes: UInt64 = 0,
         memorySnapshot: @escaping @Sendable () -> MemorySnapshot,
         clearCache: @escaping @Sendable () -> Void = {},
-        selfHealMinInterval: Duration = GlobalKVCacheBudget.defaultSelfHealMinInterval
+        selfHealMinInterval: Duration = GlobalKVCacheBudget.defaultSelfHealMinInterval,
+        reclaimer: KVPoolReclaimer? = nil
     ) {
         self.capFraction = capFraction
         self.activationReserveBytes = activationReserveBytes
         self.configReserveBytes = configReserveBytes
-        self.selfHealMinInterval = selfHealMinInterval
         self.memorySnapshot = memorySnapshot
-        self.clearCache = clearCache
+        self.reclaimer = reclaimer ?? KVPoolReclaimer(
+            clearCache: clearCache,
+            reclaimableBytes: { memorySnapshot().cache },
+            minInterval: selfHealMinInterval,
+            // Tests that don't pin a threshold should never trip the proactive
+            // sweep on their tiny synthetic pools — keep the production default.
+            proactiveThresholdBytes: KVPoolReclaimer.defaultProactiveThresholdBytes)
     }
 
     public func reserve(requestID: String, kvBytesPerToken: Int, tokenCount: Int) -> Bool {
@@ -149,35 +158,43 @@ public actor GlobalKVCacheBudget {
         }
     }
 
-    /// Reserve `bytes` against current live headroom. The headroom math counts the
-    /// reclaimable MLX pool as used, so on a near-miss we flush that pool and
-    /// resample once before denying — otherwise we'd reject a request the box can
-    /// actually serve. Caller has validated `bytes > 0` and no existing reservation.
+    /// Reserve `bytes` against the CURRENT live headroom. The headroom math counts
+    /// the reclaimable MLX pool as used; on a near-miss we SIGNAL the off-actor
+    /// reclaimer to shrink that pool for FUTURE admissions and reject this request
+    /// against the current snapshot. We do NOT flush-and-resample inline: that
+    /// would run a blocking GPU sync on this actor and serialize every other
+    /// reservation behind it (DAR-338). Rejecting a near-miss is acceptable — the
+    /// coordinator + per-provider breaker reroute, and the background reclaim keeps
+    /// the pool small so most admissions succeed without ever near-missing.
+    /// Caller has validated `bytes > 0` and no existing reservation.
     private func commit(requestID: String, bytes: UInt64) -> Bool {
-        var available = availableReservationBytes()
-        if bytes > available {
-            if reclaimForShortfall(bytes - available) { available = availableReservationBytes() }
-            if bytes > available { return false }
+        let available = availableReservationBytes()
+        guard bytes <= available else {
+            reclaimer.scheduleReclaim(shortfall: bytes - available)   // non-blocking; flush runs off-actor
+            return false
         }
         reservations[requestID] = bytes
         return true
     }
 
-    /// Rate-limited pool reclaim for the admission self-heal, shared by the live KV
-    /// reservation gate (`commit`) and the scheduler's token-budget gate. Returns
-    /// true if it actually flushed the pool (so the caller should resample). Two
-    /// guards: skip when the reclaimable pool can't cover `shortfall` (the bytes the
-    /// request is short by — a flush would still leave it rejected, e.g. when active
-    /// memory rather than the pool is what's full); and skip when a flush ran within
-    /// `selfHealMinInterval` (the flush blocks on a GPU sync, so this bounds how
-    /// often a flood of near-miss admissions can chain syncs and stall the actor).
-    public func reclaimForShortfall(_ shortfall: UInt64) -> Bool {
-        guard shortfall > 0, memorySnapshot().cache >= shortfall else { return false }
-        let now = ContinuousClock.now
-        if let last = lastSelfHealAt, now - last < selfHealMinInterval { return false }
-        lastSelfHealAt = now
-        clearCache()
-        return true
+    /// Signal the off-actor reclaimer to flush the reclaimable MLX pool for a
+    /// shortfall observed by the scheduler's token-budget gate. NON-BLOCKING and
+    /// `nonisolated` (it touches no actor state — only the immutable reclaimer),
+    /// so the caller doesn't even hop this actor: the GPU sync runs on the
+    /// reclaimer, never here (it used to run inline as a blocking synchronize —
+    /// the DAR-338 wedge). The reclaimer gates on whether the pool can cover the
+    /// shortfall and rate-limits, so this is an unconditional fire-and-forget.
+    public nonisolated func reclaimForShortfall(_ shortfall: UInt64) {
+        guard shortfall > 0 else { return }
+        reclaimer.scheduleReclaim(shortfall: shortfall)
+    }
+
+    /// Trigger a proactive, rate-limited, threshold-gated background sweep of the
+    /// reclaimable MLX pool so admission headroom stays healthy under sustained
+    /// load WITHOUT any inline flush. NON-BLOCKING + `nonisolated`. Called
+    /// periodically by the scheduler watchdog while a model is loaded.
+    public nonisolated func proactiveReclaimSweep() {
+        reclaimer.scheduleSweep()
     }
 
     private func availableReservationBytes() -> UInt64 {
@@ -214,4 +231,10 @@ public actor GlobalKVCacheBudget {
         return total
     }
 
+    // MARK: - Test support
+
+    /// The off-actor reclaimer, so tests can drive `reclaimIfNeeded`/`sweep`
+    /// deterministically (they run the injected `clearCache` synchronously on the
+    /// reclaimer actor) instead of racing the fire-and-forget signal tasks.
+    var reclaimerForTesting: KVPoolReclaimer { reclaimer }
 }

--- a/provider-swift/Sources/ProviderCore/Inference/KVPoolReclaimer.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/KVPoolReclaimer.swift
@@ -1,25 +1,25 @@
 // Copyright © 2026 Eigen Labs.
 //
-// DAR-338: off-actor reclaimer for the MLX reclaimable KV pool.
+// Off-actor reclaimer for the MLX reclaimable KV pool.
 //
 // The reclaim flush is `MLX.Stream().synchronize()` + `MLX.Memory.clearCache()`
-// — a BLOCKING GPU synchronize that waits for in-flight inference GPU work to
-// drain. It used to run INSIDE the `GlobalKVCacheBudget` actor (the per-request
+// — a blocking GPU synchronize that waits for in-flight inference GPU work to
+// drain. It used to run inside the `GlobalKVCacheBudget` actor (the per-request
 // KV admission gate). A synchronous GPU sync on an actor blocks that actor's
-// executor for its whole duration, so EVERY other reservation serialized behind
+// executor for its whole duration, so every other reservation serialized behind
 // it: under sustained load the reclaimable pool grew, near-miss admissions
 // chained one blocking sync per second on the admission actor, slots could not
 // be granted, requests aborted on the pending timeout, and the node kept
 // advertising itself as healthy — the fleet-wide wedge.
 //
-// This actor owns the flush and runs it OFF the budget actor. Callers SIGNAL
+// This actor owns the flush and runs it off the budget actor. Callers signal
 // pressure with the non-isolated, fire-and-forget `scheduleReclaim` /
 // `scheduleSweep` (they return instantly — they only spawn a task), and the GPU
-// sync runs later on THIS actor's executor, never the budget actor's. The flush
+// sync runs later on this actor's executor, never the budget actor's. The flush
 // is rate-limited (at most one per `minInterval`) and shortfall/threshold-gated,
 // so a flood of near-misses can never chain syncs.
 //
-// INVARIANT: nothing here ever runs on, awaits on, or blocks the
+// Invariant: nothing here ever runs on, awaits, or blocks the
 // `GlobalKVCacheBudget` actor. The admission decision is made against the
 // current memory snapshot and returns immediately; this reclaimer keeps the
 // pool small over time so most admissions succeed without any inline flush.
@@ -67,20 +67,20 @@ actor KVPoolReclaimer {
 
     // MARK: - Fire-and-forget signals (called from the budget actor)
 
-    /// On-pressure signal from the admission path. NON-ISOLATED so the caller
+    /// On-pressure signal from the admission path. Non-isolated so the caller
     /// (the budget actor) returns instantly: this only spawns a task; the GPU
     /// sync happens later on this reclaimer's executor.
     nonisolated func scheduleReclaim(shortfall: UInt64) {
         Task { await self.reclaimIfNeeded(shortfall: shortfall) }
     }
 
-    /// Proactive signal from the periodic scheduler watchdog. NON-ISOLATED, same
+    /// Proactive signal from the periodic scheduler watchdog. Non-isolated, same
     /// contract as `scheduleReclaim`.
     nonisolated func scheduleSweep() {
         Task { await self.sweep() }
     }
 
-    // MARK: - Reclaim execution (runs on THIS actor, never the budget actor)
+    // MARK: - Reclaim execution (runs on this actor, never the budget actor)
 
     /// On-pressure reclaim: flush iff the reclaimable pool can actually cover the
     /// shortfall the request is short by (a flush that still leaves it rejected —

--- a/provider-swift/Sources/ProviderCore/Inference/KVPoolReclaimer.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/KVPoolReclaimer.swift
@@ -1,0 +1,113 @@
+// Copyright © 2026 Eigen Labs.
+//
+// DAR-338: off-actor reclaimer for the MLX reclaimable KV pool.
+//
+// The reclaim flush is `MLX.Stream().synchronize()` + `MLX.Memory.clearCache()`
+// — a BLOCKING GPU synchronize that waits for in-flight inference GPU work to
+// drain. It used to run INSIDE the `GlobalKVCacheBudget` actor (the per-request
+// KV admission gate). A synchronous GPU sync on an actor blocks that actor's
+// executor for its whole duration, so EVERY other reservation serialized behind
+// it: under sustained load the reclaimable pool grew, near-miss admissions
+// chained one blocking sync per second on the admission actor, slots could not
+// be granted, requests aborted on the pending timeout, and the node kept
+// advertising itself as healthy — the fleet-wide wedge.
+//
+// This actor owns the flush and runs it OFF the budget actor. Callers SIGNAL
+// pressure with the non-isolated, fire-and-forget `scheduleReclaim` /
+// `scheduleSweep` (they return instantly — they only spawn a task), and the GPU
+// sync runs later on THIS actor's executor, never the budget actor's. The flush
+// is rate-limited (at most one per `minInterval`) and shortfall/threshold-gated,
+// so a flood of near-misses can never chain syncs.
+//
+// INVARIANT: nothing here ever runs on, awaits on, or blocks the
+// `GlobalKVCacheBudget` actor. The admission decision is made against the
+// current memory snapshot and returns immediately; this reclaimer keeps the
+// pool small over time so most admissions succeed without any inline flush.
+import Foundation
+import MLX
+
+actor KVPoolReclaimer {
+    /// The blocking GPU flush. Injected so tests can observe invocations
+    /// (count/timing) deterministically without a GPU. Production fences async
+    /// GPU completion before freeing buffers (matches the engine reclaim paths /
+    /// the M4 IOKit completeMemory guard).
+    private let clearCache: @Sendable () -> Void
+    /// Current reclaimable MLX pool size in bytes (the cache pool that a flush
+    /// would return to the OS). Used to gate both reclaim paths so we never run
+    /// a GPU sync that could not help.
+    private let reclaimableBytes: @Sendable () -> UInt64
+    /// At most one flush per this interval. The flush blocks a GPU stream, so
+    /// this bounds how often pressure can drive a sync (shared by the on-pressure
+    /// and proactive paths — either one flushing satisfies the other).
+    private let minInterval: Duration
+    /// Proactive sweep only flushes when the reclaimable pool has grown to at
+    /// least this many bytes, so a small/healthy cache is never thrashed.
+    private let proactiveThresholdBytes: UInt64
+    private var lastReclaimAt: ContinuousClock.Instant?
+
+    /// Total flushes performed (test observability).
+    private(set) var reclaimCount = 0
+
+    static let defaultMinInterval: Duration = .seconds(1)
+    /// 2 GiB: a pool this large is materially eating admission headroom; below it
+    /// the on-pressure path (which gates on the exact shortfall) handles flushing.
+    static let defaultProactiveThresholdBytes: UInt64 = 2 * 1024 * 1024 * 1024
+
+    init(
+        clearCache: @escaping @Sendable () -> Void,
+        reclaimableBytes: @escaping @Sendable () -> UInt64,
+        minInterval: Duration = KVPoolReclaimer.defaultMinInterval,
+        proactiveThresholdBytes: UInt64 = KVPoolReclaimer.defaultProactiveThresholdBytes
+    ) {
+        self.clearCache = clearCache
+        self.reclaimableBytes = reclaimableBytes
+        self.minInterval = minInterval
+        self.proactiveThresholdBytes = proactiveThresholdBytes
+    }
+
+    // MARK: - Fire-and-forget signals (called from the budget actor)
+
+    /// On-pressure signal from the admission path. NON-ISOLATED so the caller
+    /// (the budget actor) returns instantly: this only spawns a task; the GPU
+    /// sync happens later on this reclaimer's executor.
+    nonisolated func scheduleReclaim(shortfall: UInt64) {
+        Task { await self.reclaimIfNeeded(shortfall: shortfall) }
+    }
+
+    /// Proactive signal from the periodic scheduler watchdog. NON-ISOLATED, same
+    /// contract as `scheduleReclaim`.
+    nonisolated func scheduleSweep() {
+        Task { await self.sweep() }
+    }
+
+    // MARK: - Reclaim execution (runs on THIS actor, never the budget actor)
+
+    /// On-pressure reclaim: flush iff the reclaimable pool can actually cover the
+    /// shortfall the request is short by (a flush that still leaves it rejected —
+    /// e.g. active memory, not the pool, is what's full — is skipped) and we are
+    /// outside the rate-limit window. Returns true iff it flushed. The GPU sync
+    /// runs on this actor's executor.
+    @discardableResult
+    func reclaimIfNeeded(shortfall: UInt64) -> Bool {
+        guard shortfall > 0, reclaimableBytes() >= shortfall else { return false }
+        return flushIfDue()
+    }
+
+    /// Proactive sweep: flush iff the reclaimable pool has grown past the
+    /// threshold and we are outside the rate-limit window. Keeps admission
+    /// headroom healthy under sustained load so most admissions never near-miss.
+    @discardableResult
+    func sweep() -> Bool {
+        guard reclaimableBytes() >= proactiveThresholdBytes else { return false }
+        return flushIfDue()
+    }
+
+    private func flushIfDue() -> Bool {
+        let now = ContinuousClock.now
+        if let last = lastReclaimAt, now - last < minInterval { return false }
+        lastReclaimAt = now
+        clearCache()
+        reclaimCount += 1
+        return true
+    }
+}

--- a/provider-swift/Sources/ProviderCore/ProviderCore.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderCore.swift
@@ -58,5 +58,17 @@ public enum ProviderCore {
     // `darkbloom benchmark --sweep` decode-bandwidth diagnostic is added (W6).
     // Submodule pin advanced to 5d3bb51b. Additive/omitempty wire fields — fully
     // backward-compatible with the currently-deployed coordinator.
-    public static let version = "0.6.13"
+    // 0.6.16 fixes the fleet-wide admission wedge and adds a backend-liveness
+    // watchdog. DAR-338: the KV reclaimable-pool self-heal flush (a BLOCKING GPU
+    // synchronize) no longer runs on the GlobalKVCacheBudget actor / admission hot
+    // path — it moved to a dedicated off-actor KVPoolReclaimer (coalesced +
+    // rate-limited; on-pressure + proactive sweep), so a near-miss admission can
+    // never serialize every other reservation behind a GPU sync. DAR-337: an
+    // in-process backend-liveness watchdog detects a wedged engine (a request
+    // admitted but 0 tokens past the pending-timeout window) or a pinned/collapsed
+    // KV pool (budget at the floor with 0 successes), reports a TRUTHFUL heartbeat
+    // slot_state ("crashed"/"reloading" instead of a lying "idle"), and
+    // self-restarts the engine/model slot to recover. Wire-compatible: only
+    // existing slot_state string values are emitted; no protocol changes.
+    public static let version = "0.6.16"
 }

--- a/provider-swift/Sources/ProviderCore/ProviderCore.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderCore.swift
@@ -59,14 +59,14 @@ public enum ProviderCore {
     // Submodule pin advanced to 5d3bb51b. Additive/omitempty wire fields — fully
     // backward-compatible with the currently-deployed coordinator.
     // 0.6.16 fixes the fleet-wide admission wedge and adds a backend-liveness
-    // watchdog. DAR-338: the KV reclaimable-pool self-heal flush (a BLOCKING GPU
+    // watchdog. The KV reclaimable-pool self-heal flush (a blocking GPU
     // synchronize) no longer runs on the GlobalKVCacheBudget actor / admission hot
-    // path — it moved to a dedicated off-actor KVPoolReclaimer (coalesced +
-    // rate-limited; on-pressure + proactive sweep), so a near-miss admission can
-    // never serialize every other reservation behind a GPU sync. DAR-337: an
-    // in-process backend-liveness watchdog detects a wedged engine (a request
+    // path — it moved to a dedicated off-actor KVPoolReclaimer (coalesced and
+    // rate-limited, with both on-pressure and proactive sweeps), so a near-miss
+    // admission can never serialize every other reservation behind a GPU sync.
+    // An in-process backend-liveness watchdog detects a wedged engine (a request
     // admitted but 0 tokens past the pending-timeout window) or a pinned/collapsed
-    // KV pool (budget at the floor with 0 successes), reports a TRUTHFUL heartbeat
+    // KV pool (budget at the floor with 0 successes), reports a truthful heartbeat
     // slot_state ("crashed"/"reloading" instead of a lying "idle"), and
     // self-restarts the engine/model slot to recover. Wire-compatible: only
     // existing slot_state string values are emitted; no protocol changes.

--- a/provider-swift/Tests/ProviderCoreTests/BackendLivenessProbeTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/BackendLivenessProbeTests.swift
@@ -1,8 +1,8 @@
 import Testing
 @testable import ProviderCore
 
-/// The pure backend-liveness decision (DAR-337/338). Every branch of wedge vs
-/// pinned vs healthy is pinned here, GPU-free.
+/// The pure backend-liveness decision. Every branch of wedge vs pinned vs
+/// healthy is pinned here, GPU-free.
 @Suite("Backend liveness policy")
 struct BackendLivenessPolicyTests {
     // Small, explicit thresholds so the arithmetic is obvious.

--- a/provider-swift/Tests/ProviderCoreTests/BackendLivenessProbeTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/BackendLivenessProbeTests.swift
@@ -5,9 +5,12 @@ import Testing
 /// healthy is pinned here, GPU-free.
 @Suite("Backend liveness policy")
 struct BackendLivenessPolicyTests {
-    // Small, explicit thresholds so the arithmetic is obvious.
+    // Small, explicit thresholds so the arithmetic is obvious. The reject-demand
+    // window (30) is deliberately distinct from the pinned window (60) so the two
+    // can't be conflated by accident.
     let policy = BackendLivenessPolicy(
-        wedgeStallSeconds: 100, collapsedBudgetTokens: 4096, pinnedSeconds: 60)
+        wedgeStallSeconds: 100, collapsedBudgetTokens: 4096, pinnedSeconds: 60,
+        admissionRejectDemandSeconds: 30)
 
     @Test("nothing wrong → healthy")
     func healthyByDefault() {
@@ -109,5 +112,109 @@ struct BackendLivenessPolicyTests {
     func defaultWedgeThreshold() {
         #expect(BackendLivenessPolicy.defaultWedgeStallSeconds == 120)
         #expect(BackendLivenessPolicy().wedgeStallSeconds == 120)
+    }
+
+    // MARK: - Admission-reject demand (the pinned-pool-with-no-bridges bug)
+
+    @Test("KEY REGRESSION: collapsed budget + recent admission reject but ZERO active bridges → pinned")
+    func pinnedWhenRecentRejectWithNoBridges() {
+        // The exact bug this fix targets. When the global KV budget collapses to
+        // the floor, every real request's promptTokens+maxTokens exceeds it and is
+        // rejected at the EARLY token-budget guard in submit()/submitTokenized()
+        // BEFORE any bridge is inserted. So on every watchdog tick activeBridges
+        // and pending are empty → hasDemand:false. Pre-fix the policy could never
+        // see demand and never returned .pinned, so the engine never self-restarted
+        // and the node 503'd "token_budget_exhausted" forever. The recent
+        // admission reject is the demand signal that breaks that deadlock.
+        #expect(policy.assess(
+            longestAdmittedZeroTokenSeconds: nil,       // no admitted request (none got in)
+            budgetCollapsedForSeconds: 60,              // == pinned window
+            secondsSinceLastSuccess: nil,               // never succeeded since load
+            hasDemand: false,                           // 0 active bridges, 0 pending
+            secondsSinceLastAdmissionReject: 1) == .pinned)
+    }
+
+    @Test("a reject exactly at the demand-window edge still counts as demand → pinned")
+    func pinnedWhenRejectAtWindowEdge() {
+        #expect(policy.assess(
+            longestAdmittedZeroTokenSeconds: nil,
+            budgetCollapsedForSeconds: 120,
+            secondsSinceLastSuccess: 120,
+            hasDemand: false,
+            secondsSinceLastAdmissionReject: 30) == .pinned)   // == admissionRejectDemandSeconds
+    }
+
+    @Test("a reject older than the demand window is no longer current demand → healthy")
+    func noPinWhenRejectOlderThanWindow() {
+        // One reject then silence: the box isn't actively failing anyone now, so a
+        // momentarily collapsed budget must not trigger a restart.
+        #expect(policy.assess(
+            longestAdmittedZeroTokenSeconds: nil,
+            budgetCollapsedForSeconds: 120,
+            secondsSinceLastSuccess: nil,
+            hasDemand: false,
+            secondsSinceLastAdmissionReject: 31) == .healthy)  // just past the 30s window
+    }
+
+    @Test("a recent reject on a NOT-collapsed budget isn't pinned (an oversized request on a healthy box)")
+    func noPinWhenRejectButBudgetHealthy() {
+        // The early guard also rejects a single huge request on a perfectly healthy
+        // box. The collapse gate (nil window here) must keep that from being a pin.
+        #expect(policy.assess(
+            longestAdmittedZeroTokenSeconds: nil,
+            budgetCollapsedForSeconds: nil,             // budget is fine
+            secondsSinceLastSuccess: nil,
+            hasDemand: false,
+            secondsSinceLastAdmissionReject: 1) == .healthy)
+    }
+
+    @Test("a recent reject + collapsed budget but a RECENT success isn't pinned (still serving)")
+    func noPinWhenRejectButRecentSuccess() {
+        // A busy box near capacity can reject a big request yet still be decoding
+        // others. A recent success means it is not pinned.
+        #expect(policy.assess(
+            longestAdmittedZeroTokenSeconds: nil,
+            budgetCollapsedForSeconds: 120,
+            secondsSinceLastSuccess: 5,                 // < 60 pinned window
+            hasDemand: false,
+            secondsSinceLastAdmissionReject: 1) == .healthy)
+    }
+
+    @Test("no reject signal (nil) and no bridges stays healthy even when collapsed (backward-compat)")
+    func noPinWhenNoRejectAndNoBridges() {
+        // The pre-fix behavior for a genuinely idle box with a collapsed budget:
+        // failing no one, so not a restart trigger.
+        #expect(policy.assess(
+            longestAdmittedZeroTokenSeconds: nil,
+            budgetCollapsedForSeconds: 120,
+            secondsSinceLastSuccess: nil,
+            hasDemand: false,
+            secondsSinceLastAdmissionReject: nil) == .healthy)
+    }
+
+    @Test("active-bridge demand alone still pins without any reject signal (existing path intact)")
+    func pinnedFromBridgeDemandWithoutReject() {
+        #expect(policy.assess(
+            longestAdmittedZeroTokenSeconds: nil,
+            budgetCollapsedForSeconds: 120,
+            secondsSinceLastSuccess: nil,
+            hasDemand: true,                            // active/queued work
+            secondsSinceLastAdmissionReject: nil) == .pinned)
+    }
+
+    @Test("a wedge still wins even when the demand came from a reject")
+    func wedgePrecedesPinFromReject() {
+        #expect(policy.assess(
+            longestAdmittedZeroTokenSeconds: 200,       // stalled admitted request
+            budgetCollapsedForSeconds: 200,
+            secondsSinceLastSuccess: nil,
+            hasDemand: false,
+            secondsSinceLastAdmissionReject: 1) == .wedged)
+    }
+
+    @Test("the default admission-reject demand window is 60s")
+    func defaultAdmissionRejectDemandWindow() {
+        #expect(BackendLivenessPolicy.defaultAdmissionRejectDemandSeconds == 60)
+        #expect(BackendLivenessPolicy().admissionRejectDemandSeconds == 60)
     }
 }

--- a/provider-swift/Tests/ProviderCoreTests/BackendLivenessProbeTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/BackendLivenessProbeTests.swift
@@ -1,0 +1,113 @@
+import Testing
+@testable import ProviderCore
+
+/// The pure backend-liveness decision (DAR-337/338). Every branch of wedge vs
+/// pinned vs healthy is pinned here, GPU-free.
+@Suite("Backend liveness policy")
+struct BackendLivenessPolicyTests {
+    // Small, explicit thresholds so the arithmetic is obvious.
+    let policy = BackendLivenessPolicy(
+        wedgeStallSeconds: 100, collapsedBudgetTokens: 4096, pinnedSeconds: 60)
+
+    @Test("nothing wrong → healthy")
+    func healthyByDefault() {
+        let v = policy.assess(
+            longestAdmittedZeroTokenSeconds: nil,
+            budgetCollapsedForSeconds: nil,
+            secondsSinceLastSuccess: 1,
+            hasDemand: true)
+        #expect(v == .healthy)
+    }
+
+    @Test("an admitted request stalled at 0 tokens past the window → wedged")
+    func wedgeWhenAdmittedRequestStalls() {
+        #expect(policy.assess(
+            longestAdmittedZeroTokenSeconds: 100,   // == threshold
+            budgetCollapsedForSeconds: nil,
+            secondsSinceLastSuccess: 0,
+            hasDemand: true) == .wedged)
+        #expect(policy.assess(
+            longestAdmittedZeroTokenSeconds: 250,   // well past
+            budgetCollapsedForSeconds: nil,
+            secondsSinceLastSuccess: 0,
+            hasDemand: true) == .wedged)
+    }
+
+    @Test("a brief 0-token stall below the window is not yet wedged")
+    func noWedgeBelowThreshold() {
+        #expect(policy.assess(
+            longestAdmittedZeroTokenSeconds: 99,
+            budgetCollapsedForSeconds: nil,
+            secondsSinceLastSuccess: 0,
+            hasDemand: true) == .healthy)
+    }
+
+    @Test("collapsed budget + demand + no recent success past the window → pinned")
+    func pinnedWhenBudgetCollapsedWithNoSuccess() {
+        #expect(policy.assess(
+            longestAdmittedZeroTokenSeconds: nil,
+            budgetCollapsedForSeconds: 60,          // == window
+            secondsSinceLastSuccess: 60,
+            hasDemand: true) == .pinned)
+    }
+
+    @Test("never-succeeded (nil last success) counts as no recent success → pinned")
+    func pinnedWhenNeverSucceeded() {
+        #expect(policy.assess(
+            longestAdmittedZeroTokenSeconds: nil,
+            budgetCollapsedForSeconds: 120,
+            secondsSinceLastSuccess: nil,
+            hasDemand: true) == .pinned)
+    }
+
+    @Test("a collapsed budget with NO demand isn't pinned (failing no one)")
+    func noPinWithoutDemand() {
+        #expect(policy.assess(
+            longestAdmittedZeroTokenSeconds: nil,
+            budgetCollapsedForSeconds: 120,
+            secondsSinceLastSuccess: nil,
+            hasDemand: false) == .healthy)
+    }
+
+    @Test("a collapsed budget that is still serving (recent success) isn't pinned")
+    func noPinWithRecentSuccess() {
+        #expect(policy.assess(
+            longestAdmittedZeroTokenSeconds: nil,
+            budgetCollapsedForSeconds: 120,
+            secondsSinceLastSuccess: 5,             // < 60 window
+            hasDemand: true) == .healthy)
+    }
+
+    @Test("a collapse shorter than the window isn't pinned yet")
+    func noPinBeforeWindowElapses() {
+        #expect(policy.assess(
+            longestAdmittedZeroTokenSeconds: nil,
+            budgetCollapsedForSeconds: 59,
+            secondsSinceLastSuccess: nil,
+            hasDemand: true) == .healthy)
+    }
+
+    @Test("a budget that isn't collapsed (nil window) isn't pinned")
+    func noPinWhenNotCollapsed() {
+        #expect(policy.assess(
+            longestAdmittedZeroTokenSeconds: nil,
+            budgetCollapsedForSeconds: nil,
+            secondsSinceLastSuccess: nil,
+            hasDemand: true) == .healthy)
+    }
+
+    @Test("wedge takes precedence over a simultaneous pin")
+    func wedgePrecedesPin() {
+        #expect(policy.assess(
+            longestAdmittedZeroTokenSeconds: 200,
+            budgetCollapsedForSeconds: 200,
+            secondsSinceLastSuccess: nil,
+            hasDemand: true) == .wedged)
+    }
+
+    @Test("the default wedge threshold is the 120s pending-timeout window")
+    func defaultWedgeThreshold() {
+        #expect(BackendLivenessPolicy.defaultWedgeStallSeconds == 120)
+        #expect(BackendLivenessPolicy().wedgeStallSeconds == 120)
+    }
+}

--- a/provider-swift/Tests/ProviderCoreTests/BackendLivenessSelfRestartHeartbeatTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/BackendLivenessSelfRestartHeartbeatTests.swift
@@ -1,0 +1,86 @@
+import Testing
+
+@testable import ProviderCore
+
+/// Heartbeat correctness during a liveness self-restart reload.
+///
+/// Regression for the recovery bug: `selfRestartForRecovery` calls
+/// `loadModel`, which first runs `stopCurrentEngine` — that nils the engine and
+/// clears the live `modelId` to "" BEFORE `loadModel` re-sets it. During that
+/// window a heartbeat used to report a slot for `model:""` (state `reloading`).
+/// The coordinator then no longer saw a `reloading` slot for the REAL model, so
+/// it could treat this provider as a cold/unknown candidate for that model,
+/// route to it, and hit a nil engine → "No model loaded" 500s.
+///
+/// The invariant: while a self-restart is in progress the slot must keep
+/// advertising the REAL model id with a NOT-servable state, so the coordinator
+/// deroutes the model for the whole reload window.
+@Suite("Backend liveness self-restart heartbeat")
+struct BackendLivenessSelfRestartHeartbeatTests {
+
+    @Test("during a self-restart the slot keeps the REAL model id with a not-servable (reloading) state")
+    func selfRestartReportsRealModelReloadingNotEmpty() async {
+        let scheduler = BatchScheduler(maxConcurrentRequests: 4, defaultMaxTokens: 4096)
+        let realModel = "mlx-community/Qwen3.5-Coder-30B"
+
+        // Reproduce the exact mid-restart window: `selfRestartForRecovery`
+        // captured the real id and set the recovery flag, then
+        // `loadModel` → `stopCurrentEngine` cleared the live `modelId` to "" and
+        // nil'd the engine before re-setting it.
+        await scheduler._enterRecoveryReloadWindowForTest(realModelId: realModel)
+
+        // Precondition: we are genuinely IN the window — the live `modelId` is the
+        // transient "" that `stopCurrentEngine` leaves behind. This is the exact
+        // `model:""` state the pre-fix heartbeat would have advertised.
+        let live = await scheduler.capacity()
+        #expect(live.model == "", "test must reproduce the cleared-modelId reload window")
+
+        let cap = await scheduler.backendCapacity()
+        #expect(cap.slots.count == 1)
+        let slot = cap.slots[0]
+
+        // The fix: the heartbeat advertises the REAL model id, not model:"".
+        #expect(
+            slot.model == realModel,
+            "during a self-restart the slot must advertise the real model id, not the transient empty id")
+        #expect(!slot.model.isEmpty, "must never advertise model:\"\" during a reload")
+
+        // ...and a NOT-servable state so the coordinator deroutes (never idle/running).
+        #expect(
+            slot.state == "reloading",
+            "self-restart slot must report reloading (not-servable) for the whole window")
+        #expect(
+            slot.state != "idle" && slot.state != "running",
+            "self-restart slot must never look servable")
+    }
+
+    @Test("not reloading: the slot reports the live model id and a servable state (no normal-path regression)")
+    func steadyStateReportsLiveModel() async {
+        let scheduler = BatchScheduler(maxConcurrentRequests: 4, defaultMaxTokens: 4096)
+        await scheduler._setModelIdForTest("some-model")
+
+        let cap = await scheduler.backendCapacity()
+        #expect(cap.slots.count == 1)
+        // Outside a recovery restart the override is inert: the heartbeat reports
+        // the live capacity model and the normal healthy/idle state.
+        #expect(cap.slots[0].model == "some-model")
+        #expect(cap.slots[0].state == "idle")
+    }
+
+    @Test("heartbeatSlotModel override is gated on the recovery flag (pure unit)")
+    func heartbeatSlotModelOnlyOverridesDuringRecovery() async {
+        let scheduler = BatchScheduler(maxConcurrentRequests: 4, defaultMaxTokens: 4096)
+
+        // Not reloading: pass through the live capacity model unchanged, even
+        // when it is the transient "".
+        var reported = await scheduler.heartbeatSlotModel(capacityModel: "")
+        #expect(reported == "", "no override outside a recovery restart")
+        reported = await scheduler.heartbeatSlotModel(capacityModel: "live-model")
+        #expect(reported == "live-model", "no override outside a recovery restart")
+
+        // In the recovery window the captured real id replaces the cleared "".
+        await scheduler._enterRecoveryReloadWindowForTest(realModelId: "real-model")
+        reported = await scheduler.heartbeatSlotModel(capacityModel: "")
+        #expect(reported == "real-model", "override the transient empty modelId during a recovery restart")
+    }
+}

--- a/provider-swift/Tests/ProviderCoreTests/GlobalKVCacheBudgetSelfHealTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/GlobalKVCacheBudgetSelfHealTests.swift
@@ -4,10 +4,26 @@ import Testing
 
 private let gib: UInt64 = 1024 * 1024 * 1024
 
-@Test func globalKVCacheBudgetReserveClearsCacheAndAdmitsOnResample() async {
-    // cap = 6 GiB (1.0 × 8 GiB, but the 2 GiB OS floor binds); mlxUsed = active 5
-    // + cache 2 = 7 GiB → 0 free. The 2 GiB pool is above the heal threshold, so
-    // clearCache drops cache → 0, leaving 1 GiB free — enough for the 1 GiB request.
+// DAR-338 NEW CONTRACT.
+//
+// The KV reclaimable-pool self-heal flush is a BLOCKING GPU synchronize. It used
+// to run INSIDE `GlobalKVCacheBudget`'s `commit` (flush-then-resample-then-admit),
+// serializing every other reservation behind a GPU sync — the fleet-wide wedge.
+//
+// Now the admission decision is made against the CURRENT snapshot and returns
+// immediately; a near-miss merely SIGNALS the off-actor `KVPoolReclaimer`, whose
+// flush runs on the reclaimer's executor, never the budget actor's. So:
+//   * a near-miss the pool could cover is now REJECTED (no inline flush-and-admit),
+//   * `reserve`/`reserveBytes` return promptly even while the flush is blocking,
+//   * the flush still happens — in the background, coalesced + rate-limited (its
+//     mechanics are pinned in `KVPoolReclaimerTests`).
+//
+// INVARIANT under test: the budget actor is never blocked on a GPU sync.
+
+@Test func admissionRejectsNearMissOnCurrentSnapshotInsteadOfFlushingInline() async {
+    // cap = 6 GiB (the 2 GiB OS floor binds: 8 − 2); mlxUsed = active 5 + cache 2
+    // = 7 GiB → 0 free. The OLD code flushed the 2 GiB pool inline and ADMITTED
+    // the 1 GiB request. The NEW code rejects it against the current snapshot.
     let memory = MutableMemorySnapshot(cacheAfterClear: 0)
     let budget = GlobalKVCacheBudget(
         capFraction: 1.0,
@@ -15,13 +31,13 @@ private let gib: UInt64 = 1024 * 1024 * 1024
         memorySnapshot: { memory.snapshot() },
         clearCache: { memory.clearCache() })
 
-    #expect(await budget.reserve(requestID: "fits-after-clear", kvBytesPerToken: 1, tokenCount: Int(gib)))
-    #expect(memory.clearCount == 1)
+    #expect(!(await budget.reserve(requestID: "near-miss", kvBytesPerToken: 1, tokenCount: Int(gib))))
+    // The flush is signalled to the off-actor reclaimer and runs in the
+    // background (the pool COULD cover the 1 GiB shortfall).
+    #expect(await eventually { memory.clearCount == 1 })
 }
 
-@Test func globalKVCacheBudgetReserveStillRejectsAfterClearWhenTooLarge() async {
-    // Same 6 GiB cap and 2 GiB pool, but the request needs 2 GiB. Even after the
-    // pool is flushed only 1 GiB is free, so it's still rejected — one heal attempt.
+@Test func reserveBytesRejectsNearMissOnCurrentSnapshot() async {
     let memory = MutableMemorySnapshot(cacheAfterClear: 0)
     let budget = GlobalKVCacheBudget(
         capFraction: 1.0,
@@ -29,76 +45,83 @@ private let gib: UInt64 = 1024 * 1024 * 1024
         memorySnapshot: { memory.snapshot() },
         clearCache: { memory.clearCache() })
 
-    #expect(!(await budget.reserve(requestID: "too-large", kvBytesPerToken: 1, tokenCount: Int(2 * gib))))
-    #expect(memory.clearCount == 1)
+    #expect(!(await budget.reserveBytes(requestID: "near-miss-bytes", bytes: gib)))
+    #expect(await eventually { memory.clearCount == 1 })
 }
 
-@Test func globalKVCacheBudgetReserveBytesClearsCacheAndAdmitsOnResample() async {
-    // reserveBytes path: same headroom as the reserve() admit case — the 2 GiB
-    // pool is flushed to free 1 GiB, admitting the 1 GiB byte reservation.
-    let memory = MutableMemorySnapshot(cacheAfterClear: 0)
+@Test func admissionDoesNotBlockTheActorOnTheReclaimFlush() async {
+    // THE core DAR-338 contract. The injected clearCache BLOCKS for 0.5s (it
+    // simulates the GPU synchronize). `reserve` must return promptly — proving the
+    // admission decision did NOT wait on the flush — while the flush completes
+    // later, off the budget actor.
+    let spy = BlockingClearSpy(blockSeconds: 0.5)
+    let memory = MutableMemorySnapshot(cacheAfterClear: 2 * gib)  // pool never shrinks here
+    let budget = GlobalKVCacheBudget(
+        capFraction: 1.0,
+        activationReserveBytes: 0,
+        memorySnapshot: { memory.snapshot() },
+        clearCache: { spy.clear() })
+
+    let start = ContinuousClock.now
+    let admitted = await budget.reserve(requestID: "fast-return", kvBytesPerToken: 1, tokenCount: Int(gib))
+    let elapsed = ContinuousClock.now - start
+
+    #expect(!admitted)                                   // rejected on current snapshot
+    #expect(elapsed < .milliseconds(250))                // returned well before the 0.5s flush
+    #expect(spy.completedCount == 0)                     // flush not finished when reserve returned
+    #expect(await eventually(timeout: .seconds(3)) { spy.completedCount == 1 })  // it did run, off-actor
+}
+
+@Test func admissionAdmitsImmediatelyWhenItFitsWithoutAnyFlush() async {
+    // The happy path is unchanged: a request that fits the current snapshot is
+    // admitted with no reclaim signalled at all.
+    let memory = MutableMemorySnapshot(total: 8 * gib, active: 0, cache: 0, cacheAfterClear: 0)
     let budget = GlobalKVCacheBudget(
         capFraction: 1.0,
         activationReserveBytes: 0,
         memorySnapshot: { memory.snapshot() },
         clearCache: { memory.clearCache() })
 
-    #expect(await budget.reserveBytes(requestID: "bytes-fit-after-clear", bytes: gib))
-    #expect(memory.clearCount == 1)
+    #expect(await budget.reserve(requestID: "fits", kvBytesPerToken: 1, tokenCount: Int(gib)))
+    // Give any (erroneously) scheduled background flush a chance to run, then
+    // confirm none did.
+    try? await Task.sleep(for: .milliseconds(50))
+    #expect(memory.clearCount == 0)
 }
 
-@Test func globalKVCacheBudgetSkipsHealWhenPoolCannotCoverShortfall() async {
-    // Active-dominated near-cap: the reclaimable pool (100 MiB) can't cover the
-    // 1 GiB the request is short by, so flushing it wouldn't admit the request —
-    // the self-heal is skipped (no clear, no GPU sync) and the request is rejected.
-    let mib: UInt64 = 1024 * 1024
-    let memory = MutableMemorySnapshot(
-        total: 8 * gib, active: 6 * gib, cache: 100 * mib, cacheAfterClear: 0)
-    let budget = GlobalKVCacheBudget(
-        capFraction: 1.0,
-        activationReserveBytes: 0,
-        memorySnapshot: { memory.snapshot() },
-        clearCache: { memory.clearCache() })
+// MARK: - helpers
 
-    #expect(!(await budget.reserve(requestID: "tiny-pool", kvBytesPerToken: 1, tokenCount: Int(gib))))
-    #expect(memory.clearCount == 0)   // pool too small to be worth flushing
+/// Poll a condition up to `timeout`, so a background (off-actor) flush can be
+/// observed without racing a fixed sleep.
+private func eventually(
+    timeout: Duration = .seconds(2),
+    _ condition: @Sendable () -> Bool
+) async -> Bool {
+    let deadline = ContinuousClock.now + timeout
+    while ContinuousClock.now < deadline {
+        if condition() { return true }
+        try? await Task.sleep(for: .milliseconds(5))
+    }
+    return condition()
 }
 
-@Test func globalKVCacheBudgetRateLimitsRepeatedSelfHealFlushes() async {
-    // A large pool that the fake clear doesn't shrink (cacheAfterClear == cache,
-    // simulating immediate refill), so both near-miss admissions pass the pool-size
-    // gate. With a long interval injected, the second flush is rate-limited — the
-    // blocking GPU sync runs at most once per window, not once per admission.
-    let memory = MutableMemorySnapshot(
-        total: 8 * gib, active: 5 * gib, cache: 2 * gib, cacheAfterClear: 2 * gib)
-    let budget = GlobalKVCacheBudget(
-        capFraction: 1.0,
-        activationReserveBytes: 0,
-        memorySnapshot: { memory.snapshot() },
-        clearCache: { memory.clearCache() },
-        selfHealMinInterval: .seconds(3600))
+/// A clearCache spy whose flush BLOCKS (like the real GPU synchronize), so a test
+/// can prove the budget actor doesn't wait on it.
+private final class BlockingClearSpy: @unchecked Sendable {
+    private let lock = NSLock()
+    private let blockSeconds: Double
+    private var _completed = 0
 
-    #expect(!(await budget.reserve(requestID: "a", kvBytesPerToken: 1, tokenCount: Int(2 * gib))))
-    #expect(!(await budget.reserve(requestID: "b", kvBytesPerToken: 1, tokenCount: Int(2 * gib))))
-    #expect(memory.clearCount == 1)   // second flush rate-limited within the window
-}
+    init(blockSeconds: Double) { self.blockSeconds = blockSeconds }
 
-@Test func globalKVCacheBudgetHealsSmallShortfallFromSmallPool() async {
-    // The gate is shortfall-based, not an absolute pool floor: a small pool
-    // (200 MiB) that covers a small shortfall must still heal. cap = 6 GiB;
-    // active 6000 MiB + cache 200 MiB > cap → 0 free; the request is short by
-    // 64 MiB, which the 200 MiB pool covers, so the flush frees ~144 MiB and admits.
-    let mib: UInt64 = 1024 * 1024
-    let memory = MutableMemorySnapshot(
-        total: 8 * gib, active: 6000 * mib, cache: 200 * mib, cacheAfterClear: 0)
-    let budget = GlobalKVCacheBudget(
-        capFraction: 1.0,
-        activationReserveBytes: 0,
-        memorySnapshot: { memory.snapshot() },
-        clearCache: { memory.clearCache() })
+    func clear() {
+        Thread.sleep(forTimeInterval: blockSeconds)   // simulate the blocking GPU sync
+        lock.lock(); _completed += 1; lock.unlock()
+    }
 
-    #expect(await budget.reserveBytes(requestID: "small", bytes: 64 * mib))
-    #expect(memory.clearCount == 1)
+    var completedCount: Int {
+        lock.lock(); defer { lock.unlock() }; return _completed
+    }
 }
 
 /// Lock-guarded so @Sendable closures can mutate fake MLX cache state safely.

--- a/provider-swift/Tests/ProviderCoreTests/GlobalKVCacheBudgetSelfHealTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/GlobalKVCacheBudgetSelfHealTests.swift
@@ -4,26 +4,26 @@ import Testing
 
 private let gib: UInt64 = 1024 * 1024 * 1024
 
-// DAR-338 NEW CONTRACT.
+// New admission contract.
 //
-// The KV reclaimable-pool self-heal flush is a BLOCKING GPU synchronize. It used
-// to run INSIDE `GlobalKVCacheBudget`'s `commit` (flush-then-resample-then-admit),
+// The KV reclaimable-pool self-heal flush is a blocking GPU synchronize. It used
+// to run inside `GlobalKVCacheBudget`'s `commit` (flush-then-resample-then-admit),
 // serializing every other reservation behind a GPU sync — the fleet-wide wedge.
 //
-// Now the admission decision is made against the CURRENT snapshot and returns
-// immediately; a near-miss merely SIGNALS the off-actor `KVPoolReclaimer`, whose
+// Now the admission decision is made against the current snapshot and returns
+// immediately; a near-miss merely signals the off-actor `KVPoolReclaimer`, whose
 // flush runs on the reclaimer's executor, never the budget actor's. So:
-//   * a near-miss the pool could cover is now REJECTED (no inline flush-and-admit),
+//   * a near-miss the pool could cover is now rejected (no inline flush-and-admit),
 //   * `reserve`/`reserveBytes` return promptly even while the flush is blocking,
-//   * the flush still happens — in the background, coalesced + rate-limited (its
+//   * the flush still happens — in the background, coalesced and rate-limited (its
 //     mechanics are pinned in `KVPoolReclaimerTests`).
 //
-// INVARIANT under test: the budget actor is never blocked on a GPU sync.
+// Invariant under test: the budget actor is never blocked on a GPU sync.
 
 @Test func admissionRejectsNearMissOnCurrentSnapshotInsteadOfFlushingInline() async {
     // cap = 6 GiB (the 2 GiB OS floor binds: 8 − 2); mlxUsed = active 5 + cache 2
-    // = 7 GiB → 0 free. The OLD code flushed the 2 GiB pool inline and ADMITTED
-    // the 1 GiB request. The NEW code rejects it against the current snapshot.
+    // = 7 GiB → 0 free. The old code flushed the 2 GiB pool inline and admitted
+    // the 1 GiB request. The new code rejects it against the current snapshot.
     let memory = MutableMemorySnapshot(cacheAfterClear: 0)
     let budget = GlobalKVCacheBudget(
         capFraction: 1.0,
@@ -33,7 +33,7 @@ private let gib: UInt64 = 1024 * 1024 * 1024
 
     #expect(!(await budget.reserve(requestID: "near-miss", kvBytesPerToken: 1, tokenCount: Int(gib))))
     // The flush is signalled to the off-actor reclaimer and runs in the
-    // background (the pool COULD cover the 1 GiB shortfall).
+    // background (the pool could cover the 1 GiB shortfall).
     #expect(await eventually { memory.clearCount == 1 })
 }
 
@@ -50,9 +50,9 @@ private let gib: UInt64 = 1024 * 1024 * 1024
 }
 
 @Test func admissionDoesNotBlockTheActorOnTheReclaimFlush() async {
-    // THE core DAR-338 contract. The injected clearCache BLOCKS for 0.5s (it
-    // simulates the GPU synchronize). `reserve` must return promptly — proving the
-    // admission decision did NOT wait on the flush — while the flush completes
+    // The core contract. The injected clearCache blocks for 0.5s (it simulates
+    // the GPU synchronize). `reserve` must return promptly — proving the
+    // admission decision did not wait on the flush — while the flush completes
     // later, off the budget actor.
     let spy = BlockingClearSpy(blockSeconds: 0.5)
     let memory = MutableMemorySnapshot(cacheAfterClear: 2 * gib)  // pool never shrinks here
@@ -105,7 +105,7 @@ private func eventually(
     return condition()
 }
 
-/// A clearCache spy whose flush BLOCKS (like the real GPU synchronize), so a test
+/// A clearCache spy whose flush blocks (like the real GPU synchronize), so a test
 /// can prove the budget actor doesn't wait on it.
 private final class BlockingClearSpy: @unchecked Sendable {
     private let lock = NSLock()

--- a/provider-swift/Tests/ProviderCoreTests/KVPoolReclaimerTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/KVPoolReclaimerTests.swift
@@ -1,0 +1,142 @@
+import Foundation
+import Testing
+@testable import ProviderCore
+
+private let gib: UInt64 = 1024 * 1024 * 1024
+
+/// The off-actor KV-pool reclaimer (DAR-338). These drive the actor methods
+/// directly (deterministic — the injected `clearCache` runs synchronously on the
+/// reclaimer actor) to pin the shortfall gate, rate-limit, coalescing, and the
+/// proactive-sweep threshold without a GPU.
+@Suite("KV pool reclaimer")
+struct KVPoolReclaimerTests {
+
+    @Test("on-pressure: flushes when the reclaimable pool covers the shortfall")
+    func flushesWhenPoolCoversShortfall() async {
+        let spy = ReclaimSpy(reclaimable: 2 * gib)
+        let reclaimer = KVPoolReclaimer(
+            clearCache: { spy.clear() },
+            reclaimableBytes: { spy.reclaimable },
+            minInterval: .zero)
+
+        #expect(await reclaimer.reclaimIfNeeded(shortfall: gib))
+        #expect(await reclaimer.reclaimCount == 1)
+        #expect(spy.clearCount == 1)
+    }
+
+    @Test("on-pressure: skips when the pool cannot cover the shortfall")
+    func skipsWhenPoolCannotCoverShortfall() async {
+        // Active-dominated near-cap: the reclaimable pool (100 MiB) can't cover the
+        // 1 GiB shortfall, so a flush wouldn't admit anything — skip the GPU sync.
+        let spy = ReclaimSpy(reclaimable: 100 * 1024 * 1024)
+        let reclaimer = KVPoolReclaimer(
+            clearCache: { spy.clear() },
+            reclaimableBytes: { spy.reclaimable },
+            minInterval: .zero)
+
+        #expect(!(await reclaimer.reclaimIfNeeded(shortfall: gib)))
+        #expect(await reclaimer.reclaimCount == 0)
+        #expect(spy.clearCount == 0)
+    }
+
+    @Test("on-pressure: a zero shortfall never flushes")
+    func zeroShortfallNeverFlushes() async {
+        let spy = ReclaimSpy(reclaimable: 8 * gib)
+        let reclaimer = KVPoolReclaimer(
+            clearCache: { spy.clear() },
+            reclaimableBytes: { spy.reclaimable },
+            minInterval: .zero)
+        #expect(!(await reclaimer.reclaimIfNeeded(shortfall: 0)))
+        #expect(await reclaimer.reclaimCount == 0)
+    }
+
+    @Test("rate-limit: a second flush inside the window is coalesced away")
+    func rateLimitsRepeatedFlushes() async {
+        // A pool the fake clear doesn't shrink (simulating immediate refill), so
+        // both calls pass the shortfall gate. With a long interval the second is
+        // rate-limited — the blocking GPU sync runs at most once per window.
+        let spy = ReclaimSpy(reclaimable: 2 * gib, shrinkOnClear: false)
+        let reclaimer = KVPoolReclaimer(
+            clearCache: { spy.clear() },
+            reclaimableBytes: { spy.reclaimable },
+            minInterval: .seconds(3600))
+
+        #expect(await reclaimer.reclaimIfNeeded(shortfall: 2 * gib))
+        #expect(!(await reclaimer.reclaimIfNeeded(shortfall: 2 * gib)))
+        #expect(await reclaimer.reclaimCount == 1)
+    }
+
+    @Test("rate-limit: a second flush is allowed once the window elapses")
+    func allowsSecondFlushAfterInterval() async {
+        let spy = ReclaimSpy(reclaimable: 2 * gib, shrinkOnClear: false)
+        let reclaimer = KVPoolReclaimer(
+            clearCache: { spy.clear() },
+            reclaimableBytes: { spy.reclaimable },
+            minInterval: .zero)   // any elapsed gap clears the window
+
+        #expect(await reclaimer.reclaimIfNeeded(shortfall: 2 * gib))
+        #expect(await reclaimer.reclaimIfNeeded(shortfall: 2 * gib))
+        #expect(await reclaimer.reclaimCount == 2)
+    }
+
+    @Test("proactive sweep: flushes only when the pool exceeds the threshold")
+    func proactiveSweepRespectsThreshold() async {
+        let spy = ReclaimSpy(reclaimable: 3 * gib, shrinkOnClear: false)
+        let reclaimer = KVPoolReclaimer(
+            clearCache: { spy.clear() },
+            reclaimableBytes: { spy.reclaimable },
+            minInterval: .zero,
+            proactiveThresholdBytes: 2 * gib)
+
+        #expect(await reclaimer.sweep())          // 3 GiB >= 2 GiB threshold
+        #expect(await reclaimer.reclaimCount == 1)
+
+        spy.reclaimable = 1 * gib                  // now below threshold
+        #expect(!(await reclaimer.sweep()))
+        #expect(await reclaimer.reclaimCount == 1)
+    }
+
+    @Test("the on-pressure and proactive paths share one rate-limit window")
+    func sweepAndReclaimShareRateLimit() async {
+        let spy = ReclaimSpy(reclaimable: 4 * gib, shrinkOnClear: false)
+        let reclaimer = KVPoolReclaimer(
+            clearCache: { spy.clear() },
+            reclaimableBytes: { spy.reclaimable },
+            minInterval: .seconds(3600),
+            proactiveThresholdBytes: 2 * gib)
+
+        #expect(await reclaimer.sweep())                          // flushes
+        #expect(!(await reclaimer.reclaimIfNeeded(shortfall: gib)))  // shares window → skipped
+        #expect(await reclaimer.reclaimCount == 1)
+    }
+}
+
+/// Lock-guarded so the @Sendable reclaimer closures can read/mutate fake pool
+/// state safely off the test's task.
+private final class ReclaimSpy: @unchecked Sendable {
+    private let lock = NSLock()
+    private let shrinkOnClear: Bool
+    private var _reclaimable: UInt64
+    private var _clearCount = 0
+
+    init(reclaimable: UInt64, shrinkOnClear: Bool = true) {
+        self._reclaimable = reclaimable
+        self.shrinkOnClear = shrinkOnClear
+    }
+
+    var reclaimable: UInt64 {
+        get { lock.lock(); defer { lock.unlock() }; return _reclaimable }
+        set { lock.lock(); _reclaimable = newValue; lock.unlock() }
+    }
+
+    func clear() {
+        lock.lock()
+        _clearCount += 1
+        if shrinkOnClear { _reclaimable = 0 }
+        lock.unlock()
+    }
+
+    var clearCount: Int {
+        lock.lock(); defer { lock.unlock() }; return _clearCount
+    }
+}

--- a/provider-swift/Tests/ProviderCoreTests/KVPoolReclaimerTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/KVPoolReclaimerTests.swift
@@ -4,8 +4,8 @@ import Testing
 
 private let gib: UInt64 = 1024 * 1024 * 1024
 
-/// The off-actor KV-pool reclaimer (DAR-338). These drive the actor methods
-/// directly (deterministic — the injected `clearCache` runs synchronously on the
+/// The off-actor KV-pool reclaimer. These drive the actor methods directly
+/// (deterministic — the injected `clearCache` runs synchronously on the
 /// reclaimer actor) to pin the shortfall gate, rate-limit, coalescing, and the
 /// proactive-sweep threshold without a GPU.
 @Suite("KV pool reclaimer")


### PR DESCRIPTION
## Summary

Post-swap (coordinator `0d4e5a63`, fleet **v0.6.15**), **9 nodes produced 83% of all gpt-oss errors** while staying fully routable — one box failed 99/99 requests for 15+ min and kept receiving traffic — capping gpt-oss OpenRouter-formula uptime at **~88% ("degraded")**.

This PR bundles both layers of the fix:

- **Coordinator (DAR-335 + DAR-336)** — deroutes wedged/failing nodes *now*, no fleet update required. This is what stops the OpenRouter de-prioritization immediately.
- **Provider v0.6.16 (DAR-338 + DAR-337)** — the actual cure for the `#408` GPU-sync admission wedge and the un-recoverable pinned KV pool, so we can stop relying on the breaker.

> ⚠️ **Deploy note:** this PR intentionally couples two different cadences (see [Deploying](#deploying)). The coordinator changes can ship today; the provider changes are a v0.6.16 release that needs signing/notarization + fleet convergence.

Linear: **DAR-335**, **DAR-336**, **DAR-337**, **DAR-338**.

---

## Architecture: before → after

### Before — bad nodes stay routable and admission wedges

```mermaid
flowchart TD
    subgraph CB["COORDINATOR — before"]
        A["Consumer request"] --> B["Preflight + scheduler"]
        B --> C{"Pick provider<br/>warm-idle looks ideal"}
        C --> D["Bad node<br/>serial D6C3FH4PJ4"]
        D -->|"503 / hang, ttft=0"| E["admitted_but_failed = 5xx"]
        E --> F[("OpenRouter uptime ~88%<br/>DEGRADED")]
        D -. "still idle+warm — never derouted" .-> C
    end
    subgraph PB["PROVIDER — before · PR 408 / v0.6.15"]
        G["commit() on<br/>GlobalKVCacheBudget actor"] --> H["reclaimForShortfall()"]
        H --> I[["BLOCKING MLX synchronize()<br/>+ clearCache() ON the actor"]]
        I -->|"actor stalled,<br/>all reservations queue"| J["request timed out<br/>waiting for capacity"]
        J --> K["engine loaded, not crashed"]
    end
    K -. "heartbeat lies: slot_state=idle" .-> D
```

### After — breaker deroutes faults, reclassifier protects uptime, admission never blocks

```mermaid
flowchart TD
    subgraph CA["COORDINATOR — after · DAR-335 + DAR-336"]
        A2["Consumer request"] --> P{"Per-provider<br/>breaker open?"}
        P -->|"yes"| X["Derouted<br/>re-probed after cooldown"]
        P -->|"no"| C2{"Pick provider"}
        P -. "ALL tripped → fail-open probe" .-> C2
        C2 --> H1["Healthy node serves ✅"]
        C2 --> D2["Node returns 503"]
        D2 --> R{"capacity-class?"}
        R -->|"yes"| Q["reclassify → 429<br/>uptime-neutral, OR fails over"]
        R -->|"no — crash / fault"| S["stays 5xx → trips breaker"]
        S --> P
        H1 --> U[("OpenRouter uptime ≥95%")]
        Q --> U
    end
    subgraph PA["PROVIDER — after · v0.6.16 · DAR-338 + DAR-337"]
        G2["commit() on actor"] --> N["decide on snapshot<br/>NEVER blocks on GPU"]
        N -. "fire-and-forget" .-> RC["off-actor KVPoolReclaimer<br/>coalesced GPU flush"]
        N --> ADM["admit / reject instantly ✅"]
        W["Liveness watchdog"] -->|"wedged or pinned KV"| HB["truthful heartbeat<br/>slot_state = crashed / reloading"]
        W --> RS["self-restart engine<br/>clears pinned pool"]
    end
    HB -. "coordinator deroutes via breaker" .-> P
```

---

## Coordinator (ship-today mitigation)

### DAR-335 — per-provider node-health circuit breaker
Every existing failure-derived deroute path ignores generic fault-503 (the inference-error breaker counts only 500/502/504; reputation skips 503; dispatch-load cooldown only fires on model-load failures; within-request retry has no cross-request memory). A node returning 503 for ~100% of requests advertises `slot_state=idle`+warm, so the scheduler treats it as an ideal instant-TTFT target and keeps feeding it.

- New `coordinator/registry/provider_breaker.go`: breaker keyed by **provider ID only** (node crashes affect every model). Trips on **5 consecutive faults** OR (**≥20 reqs / 120s AND >80% fail**); cooldown `60s × 2^trips` capped at 5m; **half-open** re-probe; auto-closes on a success.
- **Ignores healthy sheds** (429 / 4xx / 499-cancel and capacity-class 503 like `token_budget_exhausted`, `kv headroom`, `insufficient memory`, `draining`); counts genuine faults (500/502/504, and 503 with crash/opaque/`request rejected`). Local classifier in-package (registry can't import api).
- Gate added in `providerPassesRoutingGatesLocked` (one chokepoint covering selection, admit re-check, preflight, queued + cold dispatch).
- **Fail-open safety valve** in `selectBestCandidateScanLocked` / `ReserveProviderEx`: if every candidate is tripped, routing still serves (a bad fleet-wide rollout can never deroute everyone).
- Hooks in `noteInferenceError`/`noteInferenceSuccess` (error string threaded through the dispatch terminals); telemetry `routing.provider_breaker_open` / `_closed`. Cleared on `Disconnect`.

### DAR-336 — split provider-5xx reclassification
`isUnservableProviderError` → **`isCapacityClassProviderError`** with two extendable tables:
- **Bucket A (capacity/lifecycle → 5xx reclassified to uptime-neutral 429):** existing capacity strings + `draining`, slot-cap, overload/backpressure (`request rejected`, `queue full`, `server busy`, `service temporarily unavailable`, `request timed out waiting for capacity`), cold/not-loaded misses.
- **Bucket B (genuine fault → stays 5xx, feeds the breaker):** crashes/panics, `internal error`, `model load failed`, the opaque Foundation string; **default is fault** so crashes stay visible.

### Extra fix found in review — preflight fail-open (DAR-335)
The fail-open valve lived only at dispatch-selection, but the public preflight (`QuickCapacityCheck`) still excluded breaker-open nodes — so an *all-breaker-open* fleet reported 0 candidates / 0 capacity-rejections and the consumer hard-503'd `no_provider` **before** dispatch's fail-open could run. That re-introduced the model-wide outage the valve exists to prevent (and they just had a fleet-wide v0.6.15 regression). The preflight now fails open on the breaker; every other gate (incl. the shape-keyed inference-error cooldown) is still honored. Regression test added.

---

## Provider v0.6.16 (the cure)

### DAR-338 — `#408` KV self-heal blocking GPU sync wedged admission
`#408` put a blocking `MLX...synchronize()` **inside the `GlobalKVCacheBudget` actor** (`commit()`/token-gate → `reclaimForShortfall` → `clearCache`). Under load every near-miss stalled the actor; all reservations serialized behind it; requests timed out (`request timed out waiting for capacity`) while the node kept advertising healthy → fleet-wide wedge on 6+ machines, ~38% of residual errors. The shipped 1/sec rate-limit was insufficient.

- New off-actor `KVPoolReclaimer` (dedicated actor) owns the GPU flush; the admission path triggers a **coalesced, rate-limited, fire-and-forget** background reclaim and decides on the current snapshot.
- **Invariant:** no `reserve`/`commit`/`reclaimForShortfall`/token-gate execution ever blocks/awaits a GPU sync on the budget actor. Proven by a test (`reserve` returns <250 ms against a 0.5 s flush).
- Teardown `clearCache` (off the admission path) and the `#408` engine-detach race fix are preserved.

### DAR-337 — pinned/collapsed KV pool can't recover
A node's KV budget collapses to ~1024 tokens and 503s every request for 15+ min; only a reload clears it.

- Shared **`BackendLivenessPolicy`** watchdog detects **wedge** (admitted request, 0 tokens past threshold) and **pinned** (budget collapsed + demand + 0 successes for a sustained window).
- On a degraded verdict the **heartbeat becomes truthful** (`slot_state` → `crashed`/`reloading`, no longer a lying `idle`/warm) so the coordinator deroutes, and the engine **self-restarts** (cooldown-guarded) to clear the pinned pool.
- Provider version bumped **0.6.13 → 0.6.16** (coordinator `LatestProviderVersion` left untouched — that's a deploy decision).

---

## Testing

- **Coordinator:** full `go test ./...` green, incl. `registry` + `api` with `-race`. New breaker suite (consecutive/rate trip, half-open recovery, capacity-503 ignored, fault-503 trips, **fail-open via `ReserveProviderEx`**, **preflight fail-open**, Disconnect cleanup, >1024 sweep) + DAR-336 bucket tests with real observed strings.
- **Provider:** `swift build` green; `swift test --skip Live --skip Performance --skip ThroughputSweep` → **877 tests / 53 suites pass**, incl. rewritten self-heal tests, new `KVPoolReclaimer` and `BackendLiveness` suites.
- Built in parallel isolated worktrees, then merged; `dispatch.go` (touched by both coordinator tickets) auto-merged and the combined tree was re-verified green.

## Deploying

1. **Coordinator (now):** EigenCloud builds `coordinator/Dockerfile` and blue-green deploys; no fleet update needed. The breaker + reclassifier take effect immediately and restore OR-uptime toward ≥95% under the same fleet conditions.
2. **Provider v0.6.16 (separate):** cut the signed/notarized release (`release-swift.yml`), upload the bundle, and bump `LatestProviderVersion` in a follow-up so the fleet converges. Because this is one PR, coordinator + provider land together on merge — if you need to decouple, we can split into two PRs instead.

## Risks / follow-ups

- Provider **Live/Performance** suites (need a GPU + downloaded model) were not run, so the watchdog→self-restart *integration* isn't exercised end-to-end here; the decision logic, reclaimer, and non-blocking budget contract are unit-tested.
- Intentional DAR-338 tradeoff: a KV near-miss now **rejects** instead of inline-flush-and-admit (background reclaim keeps the pool healthy; mitigates the `#408` false-429 it originally fixed).
- Unknown/empty 503 defaults to **fault** for the breaker (per spec) — mitigated by the high thresholds, the real error string threaded everywhere available, and the fail-open valve.
- Wedge detector targets the reported 0-token stall; a mid-decode stall (≥1 token then hang) is a natural per-decode-step follow-up.

🤖 Implemented via parallel sub-agents in isolated worktrees.
