### PR TITLE
feat(earn): realistic earnings calculator — 100% utilization + additive base reward

### DIFF
--- a/console-ui/__tests__/earn-page.test.tsx
+++ b/console-ui/__tests__/earn-page.test.tsx
@@ -85,8 +85,18 @@ describe("EarnPage", () => {
     fireEvent.click(gemmaButton);
 
     expect(
-      screen.getByText("Selected models share active inference hours, so earnings are not double-counted.")
+      screen.getByText("Selected models share active inference hours, so usage earnings are not double-counted.")
     ).toBeInTheDocument();
     expect(screen.getByText("40 GB weights / 48 GB RAM")).toBeInTheDocument();
+  });
+
+  it("adds the base-reward floor on top of usage earnings (additive, not max)", async () => {
+    const EarnPage = (await import("@/app/earn/page")).default;
+    render(<EarnPage />);
+
+    // Default hardware is MacBook Pro / M4 Max / 48GB → 48GB base-reward tier = $16/mo,
+    // at the default 24h online (100% uptime). The floor is shown on top of usage.
+    expect(await screen.findByText("Base rewards (earnings floor)")).toBeInTheDocument();
+    expect(await screen.findByText("+ $16.00")).toBeInTheDocument();
   });
 });

--- a/console-ui/src/app/earn/calc.ts
+++ b/console-ui/src/app/earn/calc.ts
@@ -10,7 +10,7 @@
  *
  *   • usage    — realistic THROUGHPUT at a fixed 80% utilization, where the
  *                throughput credits continuous batching at a quality-preserving
- *                2× (NOT the 16× ceiling the old calculator used — that
+ *                4× (NOT the 16× ceiling the old calculator used — that
  *                overstated earnings by ~10–20×). Utilization and hours are
  *                fixed by product direction and not exposed to the user.
  *   • floor    — the provider base-reward earnings floor (PR #282), set by
@@ -93,11 +93,11 @@ export const SINGLE_STREAM_EFFICIENCY = 0.6;
 /**
  * Continuous-batching gain over single-stream at quality-preserving
  * concurrency (provider-swift BatchScheduler sustains multiple requests in a
- * single fused decode step without dropping per-user latency). Capped at 2× —
+ * single fused decode step without dropping per-user latency). Capped at 4× —
  * NOT the theoretical 16× ceiling — to stay within the concurrency the engine
  * holds while keeping decode latency acceptable.
  */
-export const CONTINUOUS_BATCH_FACTOR = 2;
+export const CONTINUOUS_BATCH_FACTOR = 4;
 
 /**
  * Assumed network utilization (fraction of time the machine is actively
@@ -264,7 +264,7 @@ export function calculateModelEarnings(
   const { activeParamsGB, outputPriceMicro, inputPriceMicro } = model;
 
   // Effective decode throughput = single-stream × continuous batch × assumed
-  // utilization. The batch factor (2×) credits the engine's continuous batching
+  // utilization. The batch factor (4×) credits the engine's continuous batching
   // at quality-preserving concurrency; the utilization (80%) leaves realistic
   // idle gaps. See file header.
   const singleTokPerSec = (config.bandwidthGBs / activeParamsGB) * SINGLE_STREAM_EFFICIENCY;

--- a/console-ui/src/app/earn/calc.ts
+++ b/console-ui/src/app/earn/calc.ts
@@ -8,13 +8,11 @@
  *
  *   total = usage + floor − electricity
  *
- *   • usage    — realistic SINGLE-STREAM decode throughput, assuming 100%
- *                utilization (the machine is busy serving the whole time it is
- *                online). We deliberately do NOT multiply by a batch factor: at
- *                the utilization the network actually sees, a machine serves
- *                ~one request at a time (quality-first scheduling), so the
- *                16×-batch "ceiling" the old calculator used was unreachable in
- *                practice and overstated earnings by ~10–20×.
+ *   • usage    — realistic THROUGHPUT at a fixed 80% utilization, where the
+ *                throughput credits continuous batching at a quality-preserving
+ *                4× (NOT the 16× ceiling the old calculator used — that
+ *                overstated earnings by ~10–20×). Utilization and hours are
+ *                fixed by product direction and not exposed to the user.
  *   • floor    — the provider base-reward earnings floor (PR #282), set by
  *                verified-memory tier, ramped by uptime. Added ON TOP of usage
  *                (additive), not max(usage, floor).
@@ -93,11 +91,28 @@ export const DEFAULT_INPUT_PRICE_MICRO_USD = 50_000; // $0.05 / 1M input tokens
 export const SINGLE_STREAM_EFFICIENCY = 0.6;
 
 /**
+ * Continuous-batching gain over single-stream at quality-preserving
+ * concurrency (provider-swift BatchScheduler sustains multiple requests in a
+ * single fused decode step without dropping per-user latency). Capped at 4× —
+ * NOT the theoretical 16× ceiling — to stay within the concurrency the engine
+ * holds while keeping decode latency acceptable.
+ */
+export const CONTINUOUS_BATCH_FACTOR = 4;
+
+/**
+ * Assumed network utilization (fraction of time the machine is actively
+ * serving a request while online). 100% would mean a request every second;
+ * 80% leaves realistic idle gaps between requests at the demand level the
+ * calculator targets. Fixed by product direction — not exposed to the user.
+ */
+export const ASSUMED_UTILIZATION = 0.8;
+
+/**
  * Network-observed prompt:completion token ratio (≈3.5:1 from /v1/stats:
  * total_prompt_tokens / total_completion_tokens). Decode throughput limits
- * completion tokens; the matching prompt tokens are prefilled "for free" (prefill
- * is far faster than decode) and are also billed, so we credit input revenue at
- * this ratio.
+ * completion tokens; the matching prompt tokens are prefilled "for free"
+ * (prefill is far faster than decode) and are also billed, so we credit input
+ * revenue at this ratio.
  */
 export const PROMPT_TO_COMPLETION_RATIO = 3.5;
 
@@ -248,17 +263,23 @@ export function calculateModelEarnings(
 ): ModelEarnings {
   const { activeParamsGB, outputPriceMicro, inputPriceMicro } = model;
 
-  // Single-stream decode: bandwidth-bound, one request at a time. NO batch
-  // multiplier — see file header.
-  const decodeTokPerSec = (config.bandwidthGBs / activeParamsGB) * SINGLE_STREAM_EFFICIENCY;
+  // Effective decode throughput = single-stream × continuous batch × assumed
+  // utilization. The batch factor (4×) credits the engine's continuous batching
+  // at quality-preserving concurrency; the utilization (80%) leaves realistic
+  // idle gaps. See file header.
+  const singleTokPerSec = (config.bandwidthGBs / activeParamsGB) * SINGLE_STREAM_EFFICIENCY;
+  const decodeTokPerSec =
+    singleTokPerSec * CONTINUOUS_BATCH_FACTOR * ASSUMED_UTILIZATION;
   const completionTokPerHour = decodeTokPerSec * 3600;
   const promptTokPerHour = completionTokPerHour * PROMPT_TO_COMPLETION_RATIO;
   const revenuePerHour =
     (completionTokPerHour / 1_000_000) * (outputPriceMicro / 1_000_000) +
     (promptTokPerHour / 1_000_000) * (inputPriceMicro / 1_000_000);
 
+  // Marginal electricity: the machine is actually inferring at `utilization`
+  // of online time; the rest it sits at idle (no marginal draw).
   const marginalWatts = config.inferWatts - config.idleWatts;
-  const elecPerHour = (marginalWatts / 1000) * elecCostPerKWh;
+  const elecPerHour = (marginalWatts / 1000) * elecCostPerKWh * ASSUMED_UTILIZATION;
   const netPerHour = revenuePerHour - elecPerHour;
 
   const hoursPerMonth = hoursOnlinePerDay * 30;

--- a/console-ui/src/app/earn/calc.ts
+++ b/console-ui/src/app/earn/calc.ts
@@ -1,0 +1,399 @@
+/**
+ * Provider earnings-calculator math.
+ *
+ * Pure, side-effect-free logic for the /earn calculator. Keep this in sync with
+ * the vanilla mirror in landing/earn-calculator.js.
+ *
+ * Earnings model (see the PR that introduced this for the full rationale):
+ *
+ *   total = usage + floor − electricity
+ *
+ *   • usage    — realistic SINGLE-STREAM decode throughput, assuming 100%
+ *                utilization (the machine is busy serving the whole time it is
+ *                online). We deliberately do NOT multiply by a batch factor: at
+ *                the utilization the network actually sees, a machine serves
+ *                ~one request at a time (quality-first scheduling), so the
+ *                16×-batch "ceiling" the old calculator used was unreachable in
+ *                practice and overstated earnings by ~10–20×.
+ *   • floor    — the provider base-reward earnings floor (PR #282), set by
+ *                verified-memory tier, ramped by uptime. Added ON TOP of usage
+ *                (additive), not max(usage, floor).
+ *   • elec     — marginal electricity (inference watts over idle) during the
+ *                hours the machine is online.
+ */
+
+import type { Model, PricingResponse } from "@/lib/api";
+
+/* ─── Hardware database ─── */
+
+export interface MacConfig {
+  macType: string;
+  chip: string;
+  ramOptions: number[];
+  bandwidthGBs: number;
+  idleWatts: number; // power when model loaded, waiting for requests
+  inferWatts: number; // power during active token generation
+}
+
+export const MAC_CONFIGS: MacConfig[] = [
+  // --- MacBook Air ---
+  { macType: "MacBook Air", chip: "M1", ramOptions: [8, 16], bandwidthGBs: 68, idleWatts: 8, inferWatts: 12 },
+  { macType: "MacBook Air", chip: "M2", ramOptions: [8, 16, 24], bandwidthGBs: 100, idleWatts: 8, inferWatts: 12 },
+  { macType: "MacBook Air", chip: "M3", ramOptions: [8, 16, 24], bandwidthGBs: 100, idleWatts: 8, inferWatts: 12 },
+  { macType: "MacBook Air", chip: "M4", ramOptions: [16, 24, 32], bandwidthGBs: 120, idleWatts: 8, inferWatts: 12 },
+
+  // --- MacBook Pro ---
+  { macType: "MacBook Pro", chip: "M1 Pro", ramOptions: [16, 32], bandwidthGBs: 200, idleWatts: 12, inferWatts: 30 },
+  { macType: "MacBook Pro", chip: "M1 Max", ramOptions: [32, 64], bandwidthGBs: 400, idleWatts: 15, inferWatts: 40 },
+  { macType: "MacBook Pro", chip: "M2 Pro", ramOptions: [16, 32], bandwidthGBs: 200, idleWatts: 12, inferWatts: 30 },
+  { macType: "MacBook Pro", chip: "M2 Max", ramOptions: [32, 64, 96], bandwidthGBs: 400, idleWatts: 15, inferWatts: 40 },
+  { macType: "MacBook Pro", chip: "M3", ramOptions: [8, 16, 24], bandwidthGBs: 100, idleWatts: 10, inferWatts: 20 },
+  { macType: "MacBook Pro", chip: "M3 Pro", ramOptions: [18, 36], bandwidthGBs: 150, idleWatts: 15, inferWatts: 35 },
+  { macType: "MacBook Pro", chip: "M3 Max", ramOptions: [36, 48, 64, 96, 128], bandwidthGBs: 400, idleWatts: 20, inferWatts: 45 },
+  { macType: "MacBook Pro", chip: "M4", ramOptions: [16, 24, 32], bandwidthGBs: 120, idleWatts: 10, inferWatts: 20 },
+  { macType: "MacBook Pro", chip: "M4 Pro", ramOptions: [24, 48], bandwidthGBs: 273, idleWatts: 12, inferWatts: 30 },
+  { macType: "MacBook Pro", chip: "M4 Max", ramOptions: [36, 48, 64, 128], bandwidthGBs: 546, idleWatts: 20, inferWatts: 50 },
+  { macType: "MacBook Pro", chip: "M5", ramOptions: [16, 24, 32], bandwidthGBs: 153, idleWatts: 10, inferWatts: 20 },
+  { macType: "MacBook Pro", chip: "M5 Pro", ramOptions: [24, 48], bandwidthGBs: 300, idleWatts: 12, inferWatts: 30 },
+  { macType: "MacBook Pro", chip: "M5 Max", ramOptions: [36, 48, 64, 128], bandwidthGBs: 600, idleWatts: 20, inferWatts: 50 },
+
+  // --- Mac Mini ---
+  { macType: "Mac Mini", chip: "M1", ramOptions: [8, 16], bandwidthGBs: 68, idleWatts: 5, inferWatts: 10 },
+  { macType: "Mac Mini", chip: "M2", ramOptions: [8, 16, 24], bandwidthGBs: 100, idleWatts: 5, inferWatts: 12 },
+  { macType: "Mac Mini", chip: "M2 Pro", ramOptions: [16, 32], bandwidthGBs: 200, idleWatts: 8, inferWatts: 25 },
+  { macType: "Mac Mini", chip: "M4", ramOptions: [16, 24, 32], bandwidthGBs: 120, idleWatts: 5, inferWatts: 15 },
+  { macType: "Mac Mini", chip: "M4 Pro", ramOptions: [24, 48, 64], bandwidthGBs: 273, idleWatts: 8, inferWatts: 25 },
+
+  // --- Mac Studio ---
+  { macType: "Mac Studio", chip: "M1 Max", ramOptions: [32, 64], bandwidthGBs: 400, idleWatts: 20, inferWatts: 60 },
+  { macType: "Mac Studio", chip: "M1 Ultra", ramOptions: [64, 128], bandwidthGBs: 800, idleWatts: 30, inferWatts: 90 },
+  { macType: "Mac Studio", chip: "M2 Max", ramOptions: [32, 64, 96], bandwidthGBs: 400, idleWatts: 20, inferWatts: 60 },
+  { macType: "Mac Studio", chip: "M2 Ultra", ramOptions: [64, 128, 192], bandwidthGBs: 800, idleWatts: 35, inferWatts: 100 },
+  { macType: "Mac Studio", chip: "M3 Ultra", ramOptions: [96, 256, 512], bandwidthGBs: 819, idleWatts: 35, inferWatts: 110 },
+  { macType: "Mac Studio", chip: "M4 Max", ramOptions: [36, 48, 64, 128], bandwidthGBs: 546, idleWatts: 25, inferWatts: 65 },
+  { macType: "Mac Studio", chip: "M5 Max", ramOptions: [36, 48, 64, 128], bandwidthGBs: 600, idleWatts: 25, inferWatts: 65 },
+
+  // --- Mac Pro ---
+  { macType: "Mac Pro", chip: "M2 Ultra", ramOptions: [64, 128, 192], bandwidthGBs: 800, idleWatts: 40, inferWatts: 120 },
+  { macType: "Mac Pro", chip: "M3 Ultra", ramOptions: [96, 256, 512], bandwidthGBs: 819, idleWatts: 40, inferWatts: 120 },
+];
+
+export const MAC_TYPES = ["MacBook Air", "MacBook Pro", "Mac Mini", "Mac Studio", "Mac Pro"];
+
+/* ─── Tunable model constants ─── */
+
+export const DEFAULT_OUTPUT_PRICE_MICRO_USD = 200_000; // $0.20 / 1M output tokens
+export const DEFAULT_INPUT_PRICE_MICRO_USD = 50_000; // $0.05 / 1M input tokens
+
+/**
+ * Sustained fraction of peak unified-memory bandwidth a single decode stream
+ * achieves. Memory-bandwidth-bound decode reads the active weights once per
+ * token; 0.60 is a conservative midpoint of observed efficiency.
+ */
+export const SINGLE_STREAM_EFFICIENCY = 0.6;
+
+/**
+ * Network-observed prompt:completion token ratio (≈3.5:1 from /v1/stats:
+ * total_prompt_tokens / total_completion_tokens). Decode throughput limits
+ * completion tokens; the matching prompt tokens are prefilled "for free" (prefill
+ * is far faster than decode) and are also billed, so we credit input revenue at
+ * this ratio.
+ */
+export const PROMPT_TO_COMPLETION_RATIO = 3.5;
+
+/* ─── Base-reward earnings floor (PR #282) ─── */
+
+export interface FloorTier {
+  minGB: number;
+  label: string;
+  floorUSD: number;
+}
+
+/**
+ * Provider base-reward floor by verified unified-memory tier (USD/mo).
+ * Mirrors coordinator/payments/baserewards/floor.go (floorTiers). A machine is
+ * paid the floor of the largest tier whose minGB it meets; sub-24GB earns $0.
+ */
+export const FLOOR_TIERS: FloorTier[] = [
+  { minGB: 512, label: "512GB", floorUSD: 40 },
+  { minGB: 192, label: "192GB", floorUSD: 30 },
+  { minGB: 128, label: "128GB", floorUSD: 26 },
+  { minGB: 96, label: "96GB", floorUSD: 22 },
+  { minGB: 64, label: "64GB", floorUSD: 18 },
+  { minGB: 48, label: "48GB", floorUSD: 16 },
+  { minGB: 32, label: "32GB", floorUSD: 12 },
+  { minGB: 24, label: "24GB", floorUSD: 10 },
+  { minGB: 0, label: "Under 24GB", floorUSD: 0 },
+];
+
+/** Uptime fraction below which the floor is 0; it ramps linearly to full at 100%. */
+export const MIN_UPTIME_FOR_AVAIL = 0.9;
+
+/** Monthly floor (USD) for a verified memory size, before availability/taper. */
+export function tierFloorUSD(memGB: number): number {
+  for (const t of FLOOR_TIERS) {
+    if (memGB >= t.minGB) return t.floorUSD;
+  }
+  return 0;
+}
+
+/**
+ * Availability multiplier for a monthly uptime fraction: clamp((u-0.90)/0.10,0,1).
+ * 0 at/below 90% uptime, 1.0 at 100%. Mirrors baserewards.Avail.
+ */
+export function availFromUptime(uptimeFrac: number): number {
+  const v = (uptimeFrac - MIN_UPTIME_FOR_AVAIL) / (1 - MIN_UPTIME_FOR_AVAIL);
+  if (v < 0) return 0;
+  if (v > 1) return 1;
+  return v;
+}
+
+/** Per-machine monthly floor (USD): tier × availability × taper. taper=1 today. */
+export function scaledFloorUSD(memGB: number, uptimeFrac: number, taper = 1): number {
+  return tierFloorUSD(memGB) * availFromUptime(uptimeFrac) * taper;
+}
+
+/* ─── Live model catalog ─── */
+
+export interface CatalogModel {
+  id: string;
+  name: string;
+  minRAMGB: number;
+  demandNote: string;
+  activeParamsGB: number;
+  modelSizeGB: number;
+  outputPriceMicro: number;
+  inputPriceMicro: number;
+}
+
+interface PriceLookupEntry {
+  output: number;
+  input: number;
+}
+
+export function buildPricingLookup(pricing: PricingResponse | null): Record<string, PriceLookupEntry> {
+  if (!pricing) return {};
+  return Object.fromEntries(
+    pricing.prices.map((p) => [p.model, { output: p.output_price, input: p.input_price }])
+  );
+}
+
+export function modelSizeGB(model: Model): number {
+  if (model.size_gb && model.size_gb > 0) return model.size_gb;
+  if (model.size_bytes && model.size_bytes > 0) return model.size_bytes / 1e9;
+  const match = model.id.match(/(?:^|[^A-Za-z0-9])(\d{1,3})\s*[bB](?:[^A-Za-z0-9]|$)/);
+  return match ? Number(match[1]) : 27;
+}
+
+export function activeParamsGB(model: Model, sizeGB: number): number {
+  // Search id, architecture, and description; accept decimal active counts
+  // ("A3.6B" or "3.6B active") before falling back to the size-based estimate.
+  const text = `${model.id} ${model.architecture ?? ""} ${model.description ?? ""}`;
+  const active = text.match(/A(\d{1,3}(?:\.\d+)?)B/i) ?? text.match(/(\d{1,3}(?:\.\d+)?)B\s+active/i);
+  if (active) return Math.max(1, Math.round(Number(active[1])));
+  if (/moe/i.test(text)) return Math.max(3, Math.round(sizeGB * 0.15));
+  return Math.max(1, Math.round(sizeGB));
+}
+
+export function buildCatalogModels(models: Model[], pricing: PricingResponse | null): CatalogModel[] {
+  const prices = buildPricingLookup(pricing);
+  return models
+    .map((model) => {
+      const price = prices[model.id];
+      const size = Math.max(1, Math.round(modelSizeGB(model)));
+      return {
+        id: model.id,
+        name: model.display_name || model.id.split("/").pop() || model.id,
+        minRAMGB: model.min_ram_gb || Math.ceil(size * 1.35),
+        demandNote: "Uses the live coordinator catalog and current/default per-token pricing.",
+        activeParamsGB: activeParamsGB(model, size),
+        modelSizeGB: size,
+        outputPriceMicro: price?.output ?? DEFAULT_OUTPUT_PRICE_MICRO_USD,
+        inputPriceMicro: price?.input ?? DEFAULT_INPUT_PRICE_MICRO_USD,
+      };
+    })
+    .filter((model): model is CatalogModel => Boolean(model));
+}
+
+/* ─── Earnings calculation ─── */
+
+export interface ModelEarnings {
+  modelId: string;
+  modelName: string;
+  decodeTokPerSec: number; // single-stream decode throughput
+  revenuePerHour: number; // usage revenue (output + input tokens)
+  elecPerHour: number;
+  netPerHour: number; // usage net (revenue − elec), excludes floor
+  monthlyRevenue: number;
+  monthlyElec: number;
+  monthlyNet: number; // usage net, excludes floor
+  elecPercent: number;
+  activeParamsGB: number;
+  outputPriceMicro: number;
+  inputPriceMicro: number;
+  marginalWatts: number;
+  catalogModel: CatalogModel;
+}
+
+/**
+ * Per-model USAGE earnings at 100% utilization for `hoursOnlinePerDay` hours/day.
+ * Single-stream throughput, no batch multiplier. The base-reward floor is added
+ * separately at the portfolio level (it is per-machine, not per-model).
+ */
+export function calculateModelEarnings(
+  model: CatalogModel,
+  config: MacConfig,
+  hoursOnlinePerDay: number,
+  elecCostPerKWh: number
+): ModelEarnings {
+  const { activeParamsGB, outputPriceMicro, inputPriceMicro } = model;
+
+  // Single-stream decode: bandwidth-bound, one request at a time. NO batch
+  // multiplier — see file header.
+  const decodeTokPerSec = (config.bandwidthGBs / activeParamsGB) * SINGLE_STREAM_EFFICIENCY;
+  const completionTokPerHour = decodeTokPerSec * 3600;
+  const promptTokPerHour = completionTokPerHour * PROMPT_TO_COMPLETION_RATIO;
+  const revenuePerHour =
+    (completionTokPerHour / 1_000_000) * (outputPriceMicro / 1_000_000) +
+    (promptTokPerHour / 1_000_000) * (inputPriceMicro / 1_000_000);
+
+  const marginalWatts = config.inferWatts - config.idleWatts;
+  const elecPerHour = (marginalWatts / 1000) * elecCostPerKWh;
+  const netPerHour = revenuePerHour - elecPerHour;
+
+  const hoursPerMonth = hoursOnlinePerDay * 30;
+  const monthlyRevenue = revenuePerHour * hoursPerMonth;
+  const monthlyElec = elecPerHour * hoursPerMonth;
+  const monthlyNet = netPerHour * hoursPerMonth;
+  const elecPercent = monthlyRevenue > 0 ? (monthlyElec / monthlyRevenue) * 100 : 0;
+
+  return {
+    modelId: model.id,
+    modelName: model.name,
+    decodeTokPerSec,
+    revenuePerHour,
+    elecPerHour,
+    netPerHour,
+    monthlyRevenue,
+    monthlyElec,
+    monthlyNet,
+    elecPercent,
+    activeParamsGB,
+    outputPriceMicro,
+    inputPriceMicro,
+    marginalWatts,
+    catalogModel: model,
+  };
+}
+
+export interface PortfolioEarnings {
+  modelName: string;
+  selectedModels: ModelEarnings[];
+  selectedModelCount: number;
+  totalModelSizeGB: number;
+  hoursPerModel: number;
+  decodeTokPerSec: number;
+
+  // Usage (organic inference)
+  monthlyRevenue: number;
+  monthlyElec: number;
+  monthlyUsageNet: number; // usage revenue − electricity (excludes floor)
+  revenuePerHour: number;
+  elecPerHour: number;
+  netPerHour: number; // usage net per active hour (excludes floor)
+  elecPercent: number;
+
+  // Base-reward floor (additive)
+  memoryGB: number;
+  uptimeFrac: number;
+  monthlyFloor: number;
+
+  // Totals (usage + floor − elec)
+  monthlyNet: number;
+  annualNet: number;
+}
+
+/**
+ * Portfolio earnings = Σ per-model usage (selected models share the active
+ * hours) PLUS the per-machine base-reward floor, minus electricity.
+ *
+ *   total = usage + floor − elec
+ */
+export function calculatePortfolioEarnings(
+  models: CatalogModel[],
+  config: MacConfig,
+  ramGB: number,
+  hoursOnlinePerDay: number,
+  elecCostPerKWh: number
+): PortfolioEarnings | null {
+  if (models.length === 0) return null;
+  const totalModelSizeGB = models.reduce((sum, model) => sum + model.modelSizeGB, 0);
+  if (totalModelSizeGB > ramGB) return null;
+
+  const hoursPerModel = hoursOnlinePerDay / models.length;
+  const selectedModels = models.map((model) =>
+    calculateModelEarnings(model, config, hoursPerModel, elecCostPerKWh)
+  );
+
+  const monthlyRevenue = selectedModels.reduce((sum, m) => sum + m.monthlyRevenue, 0);
+  const monthlyElec = selectedModels.reduce((sum, m) => sum + m.monthlyElec, 0);
+  const monthlyUsageNet = monthlyRevenue - monthlyElec;
+
+  // Base-reward floor: per-machine, set by verified memory + uptime. The
+  // machine is assumed online `hoursOnlinePerDay` hours/day → uptime fraction.
+  const uptimeFrac = Math.min(1, hoursOnlinePerDay / 24);
+  const monthlyFloor = scaledFloorUSD(ramGB, uptimeFrac);
+
+  const monthlyNet = monthlyUsageNet + monthlyFloor;
+  const activeHoursPerMonth = Math.max(1, hoursOnlinePerDay * 30);
+
+  return {
+    modelName: models.length === 1 ? models[0].name : `${models.length} models selected`,
+    selectedModels,
+    selectedModelCount: models.length,
+    totalModelSizeGB,
+    hoursPerModel,
+    decodeTokPerSec:
+      selectedModels.reduce((sum, m) => sum + m.decodeTokPerSec, 0) / selectedModels.length,
+    monthlyRevenue,
+    monthlyElec,
+    monthlyUsageNet,
+    revenuePerHour: monthlyRevenue / activeHoursPerMonth,
+    elecPerHour: monthlyElec / activeHoursPerMonth,
+    netPerHour: monthlyUsageNet / activeHoursPerMonth,
+    elecPercent: monthlyRevenue > 0 ? (monthlyElec / monthlyRevenue) * 100 : 0,
+    memoryGB: ramGB,
+    uptimeFrac,
+    monthlyFloor,
+    monthlyNet,
+    annualNet: monthlyNet * 12,
+  };
+}
+
+/* ─── Fun comparisons ─── */
+
+export function getComparisons(monthlyNet: number): string[] {
+  const comparisons: string[] = [];
+  if (monthlyNet > 2) comparisons.push(`${Math.floor(monthlyNet / 2)} Spotify Premium subscriptions`);
+  if (monthlyNet > 5) comparisons.push(`${Math.floor(monthlyNet / 5)} lattes per month`);
+  if (monthlyNet > 15) comparisons.push(`${Math.floor(monthlyNet / 15)} Netflix Standard plans`);
+  if (monthlyNet > 50) comparisons.push(`a ${Math.floor(monthlyNet / 50)}-day parking meter`);
+  if (monthlyNet > 70) comparisons.push(`${Math.floor(monthlyNet / 70)}x your home internet bill`);
+  if (monthlyNet > 200)
+    comparisons.push(
+      `$${(monthlyNet * 12).toLocaleString(undefined, { maximumFractionDigits: 0 })}/yr — a nice side income`
+    );
+  return comparisons;
+}
+
+/* ─── Format helpers ─── */
+
+export function fmtUSD(n: number, decimals = 2): string {
+  if (n < 0) return "-$" + Math.abs(n).toFixed(decimals);
+  return "$" + n.toFixed(decimals);
+}
+
+export function fmtUSDWhole(n: number): string {
+  if (n < 0) return "-$" + Math.abs(n).toLocaleString(undefined, { maximumFractionDigits: 0 });
+  return "$" + n.toLocaleString(undefined, { maximumFractionDigits: 0 });
+}

--- a/console-ui/src/app/earn/calc.ts
+++ b/console-ui/src/app/earn/calc.ts
@@ -10,7 +10,7 @@
  *
  *   • usage    — realistic THROUGHPUT at a fixed 80% utilization, where the
  *                throughput credits continuous batching at a quality-preserving
- *                4× (NOT the 16× ceiling the old calculator used — that
+ *                2× (NOT the 16× ceiling the old calculator used — that
  *                overstated earnings by ~10–20×). Utilization and hours are
  *                fixed by product direction and not exposed to the user.
  *   • floor    — the provider base-reward earnings floor (PR #282), set by
@@ -93,11 +93,11 @@ export const SINGLE_STREAM_EFFICIENCY = 0.6;
 /**
  * Continuous-batching gain over single-stream at quality-preserving
  * concurrency (provider-swift BatchScheduler sustains multiple requests in a
- * single fused decode step without dropping per-user latency). Capped at 4× —
+ * single fused decode step without dropping per-user latency). Capped at 2× —
  * NOT the theoretical 16× ceiling — to stay within the concurrency the engine
  * holds while keeping decode latency acceptable.
  */
-export const CONTINUOUS_BATCH_FACTOR = 4;
+export const CONTINUOUS_BATCH_FACTOR = 2;
 
 /**
  * Assumed network utilization (fraction of time the machine is actively
@@ -264,7 +264,7 @@ export function calculateModelEarnings(
   const { activeParamsGB, outputPriceMicro, inputPriceMicro } = model;
 
   // Effective decode throughput = single-stream × continuous batch × assumed
-  // utilization. The batch factor (4×) credits the engine's continuous batching
+  // utilization. The batch factor (2×) credits the engine's continuous batching
   // at quality-preserving concurrency; the utilization (80%) leaves realistic
   // idle gaps. See file header.
   const singleTokPerSec = (config.bandwidthGBs / activeParamsGB) * SINGLE_STREAM_EFFICIENCY;

--- a/console-ui/src/app/earn/page.tsx
+++ b/console-ui/src/app/earn/page.tsx
@@ -17,6 +17,8 @@ import {
   fmtUSD,
   fmtUSDWhole,
   SINGLE_STREAM_EFFICIENCY,
+  CONTINUOUS_BATCH_FACTOR,
+  ASSUMED_UTILIZATION,
   PROMPT_TO_COMPLETION_RATIO,
 } from "./calc";
 import Link from "next/link";
@@ -36,10 +38,10 @@ import {
 } from "lucide-react";
 
 /* ─── Fixed assumptions ─── */
-// 100% utilization + always-on: the machine serves a request every second it
-// is online, 24/7. We deliberately don't expose utilization or hours to the
-// user — this is the optimistic ceiling the calculator estimates, and the
-// base-reward floor covers the gap to realistic (lower) demand.
+// 80% utilization + always-on, with continuous batching at a quality-preserving
+// 4×. We deliberately don't expose utilization or hours to the user — this is
+// the realistic "busy machine" figure the calculator estimates, and the
+// base-reward floor is added on top.
 const ALWAYS_ON_HOURS = 24;
 
 function comparisonIcon(text: string) {
@@ -550,7 +552,7 @@ export default function EarnPage() {
                       <span className="font-mono text-text-secondary">
                         {result.modelName}
                       </span>{" "}
-                      (always-on, 100% utilization)
+                      (always-on, {Math.round(ASSUMED_UTILIZATION * 100)}% utilization)
                     </p>
                     {result.selectedModelCount > 1 && (
                       <p className="text-xs text-text-tertiary mt-1">
@@ -560,14 +562,14 @@ export default function EarnPage() {
                   </div>
                 </div>
 
-                {/* 100% utilization assumption note */}
+                {/* Utilization & batching assumption note */}
                 <div className="flex items-start gap-2 px-3 py-2.5 rounded-lg bg-bg-tertiary mb-5">
                   <Info size={14} className="text-text-tertiary shrink-0 mt-0.5" />
                   <p className="text-xs text-text-tertiary">
-                    Usage assumes <span className="text-text-secondary font-medium">100% utilization</span>{" "}
-                    — your Mac serving a request every second it&apos;s online. The live network runs
-                    well below that today, which is exactly what the base reward is for: it covers you
-                    while demand ramps, and usage takes over as the network fills up.
+                    Usage assumes <span className="text-text-secondary font-medium">{Math.round(ASSUMED_UTILIZATION * 100)}% utilization</span>{" "}
+                    with continuous batching ({CONTINUOUS_BATCH_FACTOR}× concurrent requests at full speed).
+                    Real demand varies by model and time of day — the base reward covers you while the
+                    network is quiet, and usage scales up as it fills.
                   </p>
                 </div>
 
@@ -690,15 +692,19 @@ export default function EarnPage() {
                   {result.selectedModels[0] && (
                     <>
                       <p>
-                        decode_tok/s = ({selectedConfig.bandwidthGBs} GB/s / {result.selectedModels[0].activeParamsGB} GB) * {SINGLE_STREAM_EFFICIENCY} ={" "}
-                        {result.selectedModels[0].decodeTokPerSec.toFixed(1)} tok/s (single stream)
+                        single_stream = ({selectedConfig.bandwidthGBs} GB/s / {result.selectedModels[0].activeParamsGB} GB) * {SINGLE_STREAM_EFFICIENCY} ={" "}
+                        {((selectedConfig.bandwidthGBs / result.selectedModels[0].activeParamsGB) * SINGLE_STREAM_EFFICIENCY).toFixed(1)} tok/s
+                      </p>
+                      <p>
+                        decode_tok/s = single_stream * {CONTINUOUS_BATCH_FACTOR}x batch * {Math.round(ASSUMED_UTILIZATION * 100)}% util ={" "}
+                        {result.selectedModels[0].decodeTokPerSec.toFixed(1)} tok/s
                       </p>
                       <p>
                         usage_rev/hr = decode_tok/hr * out_price + (decode_tok/hr * {PROMPT_TO_COMPLETION_RATIO} prompt) * in_price ={" "}
                         {fmtUSD(result.revenuePerHour, 4)}
                       </p>
                       <p>
-                        electricity/hr = ({result.selectedModels[0].marginalWatts}W / 1000) * ${elecCostNum.toFixed(2)}/kWh ={" "}
+                        electricity/hr = ({result.selectedModels[0].marginalWatts}W / 1000) * ${elecCostNum.toFixed(2)}/kWh * {Math.round(ASSUMED_UTILIZATION * 100)}% ={" "}
                         {fmtUSD(result.elecPerHour, 4)}
                       </p>
                       <p>
@@ -758,7 +764,7 @@ export default function EarnPage() {
           {/* Disclaimer */}
           <div className="rounded-xl bg-bg-secondary p-5 mb-8">
             <p className="text-xs text-text-tertiary mb-2">
-              <span className="font-medium text-text-secondary">These are estimates only.</span> Usage earnings assume 100% utilization (your Mac fully busy while online); actual usage depends on network demand, model popularity, your provider reputation, and how many other providers serve the same model. The live network currently runs well below full utilization.
+              <span className="font-medium text-text-secondary">These are estimates only.</span> Usage earnings assume {Math.round(ASSUMED_UTILIZATION * 100)}% utilization with continuous batching ({CONTINUOUS_BATCH_FACTOR}× concurrent requests); actual usage depends on network demand, model popularity, your provider reputation, and how many other providers serve the same model. The live network currently runs well below this.
             </p>
             <p className="text-xs text-text-tertiary mb-2">
               <span className="font-medium text-text-secondary">Base rewards</span> are paid on top of usage to attested machines that stay online ≥90% of the month, up to a fixed monthly budget — they are not a guarantee and taper off as the network grows.

--- a/console-ui/src/app/earn/page.tsx
+++ b/console-ui/src/app/earn/page.tsx
@@ -4,11 +4,24 @@ import { useEffect, useState, useMemo } from "react";
 import { TopBar } from "@/components/TopBar";
 import { useAuth } from "@/hooks/useAuth";
 import { trackEvent } from "@/lib/google-analytics";
-import { fetchModels, fetchPricing, type Model, type PricingResponse } from "@/lib/api";
+import { fetchModels, fetchPricing, type Model } from "@/lib/api";
+import { BaseRewardsPanel } from "@/components/earn/BaseRewardsPanel";
+import {
+  MAC_CONFIGS,
+  MAC_TYPES,
+  type CatalogModel,
+  buildCatalogModels,
+  calculateModelEarnings,
+  calculatePortfolioEarnings,
+  getComparisons,
+  fmtUSD,
+  fmtUSDWhole,
+  SINGLE_STREAM_EFFICIENCY,
+  PROMPT_TO_COMPLETION_RATIO,
+} from "./calc";
 import Link from "next/link";
 import {
   Cpu,
-  Zap,
   DollarSign,
   TrendingUp,
   Coffee,
@@ -16,299 +29,27 @@ import {
   ParkingCircle,
   Info,
   Crown,
+  Shield,
   ArrowRight,
   Mail,
   Terminal,
 } from "lucide-react";
 
-/* ─── Hardware database ─── */
-
-interface MacConfig {
-  macType: string;
-  chip: string;
-  ramOptions: number[];
-  bandwidthGBs: number;
-  idleWatts: number;   // power when model loaded, waiting for requests
-  inferWatts: number;  // power during active token generation
-}
-
-const MAC_CONFIGS: MacConfig[] = [
-  // --- MacBook Air ---
-  { macType: "MacBook Air", chip: "M1",       ramOptions: [8, 16],                    bandwidthGBs: 68,  idleWatts: 8,  inferWatts: 12 },
-  { macType: "MacBook Air", chip: "M2",       ramOptions: [8, 16, 24],               bandwidthGBs: 100, idleWatts: 8,  inferWatts: 12 },
-  { macType: "MacBook Air", chip: "M3",       ramOptions: [8, 16, 24],               bandwidthGBs: 100, idleWatts: 8,  inferWatts: 12 },
-  { macType: "MacBook Air", chip: "M4",       ramOptions: [16, 24, 32],              bandwidthGBs: 120, idleWatts: 8,  inferWatts: 12 },
-
-  // --- MacBook Pro ---
-  { macType: "MacBook Pro", chip: "M1 Pro",   ramOptions: [16, 32],                  bandwidthGBs: 200, idleWatts: 12, inferWatts: 30 },
-  { macType: "MacBook Pro", chip: "M1 Max",   ramOptions: [32, 64],                  bandwidthGBs: 400, idleWatts: 15, inferWatts: 40 },
-  { macType: "MacBook Pro", chip: "M2 Pro",   ramOptions: [16, 32],                  bandwidthGBs: 200, idleWatts: 12, inferWatts: 30 },
-  { macType: "MacBook Pro", chip: "M2 Max",   ramOptions: [32, 64, 96],              bandwidthGBs: 400, idleWatts: 15, inferWatts: 40 },
-  { macType: "MacBook Pro", chip: "M3",       ramOptions: [8, 16, 24],               bandwidthGBs: 100, idleWatts: 10, inferWatts: 20 },
-  { macType: "MacBook Pro", chip: "M3 Pro",   ramOptions: [18, 36],                  bandwidthGBs: 150, idleWatts: 15, inferWatts: 35 },
-  { macType: "MacBook Pro", chip: "M3 Max",   ramOptions: [36, 48, 64, 96, 128],     bandwidthGBs: 300, idleWatts: 20, inferWatts: 45 },
-  { macType: "MacBook Pro", chip: "M4",       ramOptions: [16, 24, 32],              bandwidthGBs: 120, idleWatts: 10, inferWatts: 20 },
-  { macType: "MacBook Pro", chip: "M4 Pro",   ramOptions: [24, 48],                  bandwidthGBs: 273, idleWatts: 12, inferWatts: 30 },
-  { macType: "MacBook Pro", chip: "M4 Max",   ramOptions: [36, 48, 64, 128],         bandwidthGBs: 546, idleWatts: 20, inferWatts: 50 },
-  { macType: "MacBook Pro", chip: "M5",       ramOptions: [16, 24, 32],              bandwidthGBs: 153, idleWatts: 10, inferWatts: 20 },
-  { macType: "MacBook Pro", chip: "M5 Pro",   ramOptions: [24, 48],                  bandwidthGBs: 307, idleWatts: 12, inferWatts: 30 },
-  { macType: "MacBook Pro", chip: "M5 Max",   ramOptions: [36, 48, 64, 128],         bandwidthGBs: 614, idleWatts: 20, inferWatts: 50 },
-
-  // --- Mac Mini ---
-  { macType: "Mac Mini", chip: "M1",          ramOptions: [8, 16],                   bandwidthGBs: 68,  idleWatts: 5,  inferWatts: 10 },
-  { macType: "Mac Mini", chip: "M2",          ramOptions: [8, 16, 24],               bandwidthGBs: 100, idleWatts: 5,  inferWatts: 12 },
-  { macType: "Mac Mini", chip: "M2 Pro",      ramOptions: [16, 32],                  bandwidthGBs: 200, idleWatts: 8,  inferWatts: 25 },
-  { macType: "Mac Mini", chip: "M4",          ramOptions: [16, 24, 32],              bandwidthGBs: 120, idleWatts: 5,  inferWatts: 15 },
-  { macType: "Mac Mini", chip: "M4 Pro",      ramOptions: [24, 48],                  bandwidthGBs: 273, idleWatts: 8,  inferWatts: 25 },
-
-  // --- Mac Studio ---
-  { macType: "Mac Studio", chip: "M1 Max",    ramOptions: [32, 64],                  bandwidthGBs: 400, idleWatts: 20, inferWatts: 60 },
-  { macType: "Mac Studio", chip: "M1 Ultra",  ramOptions: [64, 128],                 bandwidthGBs: 800, idleWatts: 30, inferWatts: 90 },
-  { macType: "Mac Studio", chip: "M2 Max",    ramOptions: [32, 64, 96],              bandwidthGBs: 400, idleWatts: 20, inferWatts: 60 },
-  { macType: "Mac Studio", chip: "M2 Ultra",  ramOptions: [64, 128, 192],            bandwidthGBs: 800, idleWatts: 35, inferWatts: 100 },
-  { macType: "Mac Studio", chip: "M3 Ultra",  ramOptions: [96, 256, 512],             bandwidthGBs: 819, idleWatts: 35, inferWatts: 110 },
-  { macType: "Mac Studio", chip: "M4 Max",    ramOptions: [36, 48, 64, 128],         bandwidthGBs: 546, idleWatts: 25, inferWatts: 65 },
-  { macType: "Mac Studio", chip: "M5 Max",    ramOptions: [36, 48, 64, 128],         bandwidthGBs: 614, idleWatts: 25, inferWatts: 65 },
-
-  // --- Mac Pro ---
-  { macType: "Mac Pro", chip: "M2 Ultra",     ramOptions: [64, 128, 192],            bandwidthGBs: 800, idleWatts: 40, inferWatts: 120 },
-  { macType: "Mac Pro", chip: "M3 Ultra",     ramOptions: [96, 256, 512],             bandwidthGBs: 819, idleWatts: 40, inferWatts: 120 },
-];
-
-const MAC_TYPES = ["MacBook Air", "MacBook Pro", "Mac Mini", "Mac Studio", "Mac Pro"];
-
-/* ─── Live model catalog ─── */
-
-interface CatalogModel {
-  id: string;
-  name: string;
-  minRAMGB: number;
-  demandNote: string; // demand expectation shown as infotip
-  activeParamsGB: number;
-  modelSizeGB: number;
-  outputPriceMicro: number;
-}
-
-const DEFAULT_OUTPUT_PRICE_MICRO_USD = 200_000;
-
-function buildPricingLookup(pricing: PricingResponse | null): Record<string, number> {
-  if (!pricing) return {};
-  return Object.fromEntries(pricing.prices.map((p) => [p.model, p.output_price]));
-}
-
-function modelSizeGB(model: Model): number {
-  if (model.size_gb && model.size_gb > 0) return model.size_gb;
-  if (model.size_bytes && model.size_bytes > 0) return model.size_bytes / 1e9;
-  const match = model.id.match(/(?:^|[^A-Za-z0-9])(\d{1,3})\s*[bB](?:[^A-Za-z0-9]|$)/);
-  return match ? Number(match[1]) : 27;
-}
-
-function activeParamsGB(model: Model, sizeGB: number): number {
-  // Search id, architecture, and description; accept decimal active counts
-  // ("A3.6B" or "3.6B active") before falling back to the size-based estimate.
-  const text = `${model.id} ${model.architecture ?? ""} ${model.description ?? ""}`;
-  const active = text.match(/A(\d{1,3}(?:\.\d+)?)B/i) ?? text.match(/(\d{1,3}(?:\.\d+)?)B\s+active/i);
-  if (active) return Math.max(1, Math.round(Number(active[1])));
-  if (/moe/i.test(text)) return Math.max(3, Math.round(sizeGB * 0.15));
-  return Math.max(1, Math.round(sizeGB));
-}
-
-function buildCatalogModels(models: Model[], pricing: PricingResponse | null): CatalogModel[] {
-  const outputPrices = buildPricingLookup(pricing);
-  return models
-    .map((model) => {
-      const outputPriceMicro = outputPrices[model.id] ?? DEFAULT_OUTPUT_PRICE_MICRO_USD;
-      const size = Math.max(1, Math.round(modelSizeGB(model)));
-      return {
-        id: model.id,
-        name: model.display_name || model.id.split("/").pop() || model.id,
-        minRAMGB: model.min_ram_gb || Math.ceil(size * 1.35),
-        demandNote: "Uses the live coordinator catalog and current/default per-token pricing.",
-        activeParamsGB: activeParamsGB(model, size),
-        modelSizeGB: size,
-        outputPriceMicro,
-      };
-    })
-    .filter((model): model is CatalogModel => Boolean(model));
-}
-
-/* ─── Earnings calculation ─── */
-
-interface ModelEarnings {
-  modelId: string;
-  modelName: string;
-  decodeTokPerSec: number;
-  revenuePerHour: number;
-  elecPerHour: number;
-  netPerHour: number;
-  monthlyRevenue: number;
-  monthlyElec: number;
-  monthlyNet: number;
-  annualNet: number;
-  elecPercent: number;
-  // Formula breakdown fields
-  batchSize: number;
-  batchEff: number;
-  activeParamsGB: number;
-  outputPriceMicro: number;
-  marginalWatts: number;
-  // Catalog reference for formula display
-  catalogModel: CatalogModel;
-}
-
-function calculateModelEarnings(
-  model: CatalogModel,
-  config: MacConfig,
-  ramGB: number,
-  hoursPerDay: number,
-  elecCostPerKWh: number,
-  loadedModelSizeGB = model.modelSizeGB
-): ModelEarnings {
-  const freeRAM = ramGB - loadedModelSizeGB;
-  const batchSize = Math.max(1, Math.min(16, Math.floor(freeRAM / 2)));
-  const batchEff = batchSize <= 4 ? 0.80 : batchSize <= 8 ? 0.85 : 0.90;
-  const { activeParamsGB, outputPriceMicro } = model;
-  const singleTokPerSec = (config.bandwidthGBs / activeParamsGB) * 0.60;
-  const decodeTokPerSec = singleTokPerSec * batchSize * batchEff;
-  const tokPerHour = decodeTokPerSec * 3600;
-  const revenuePerHour = (tokPerHour / 1_000_000) * (outputPriceMicro / 1_000_000);
-
-  const marginalWatts = config.inferWatts - config.idleWatts;
-  const elecPerHour = (marginalWatts / 1000) * elecCostPerKWh;
-  const netPerHour = revenuePerHour - elecPerHour;
-
-  const hoursPerMonth = hoursPerDay * 30;
-  const monthlyRevenue = revenuePerHour * hoursPerMonth;
-  const monthlyElec = elecPerHour * hoursPerMonth;
-  const monthlyNet = netPerHour * hoursPerMonth;
-  const annualNet = monthlyNet * 12;
-  const elecPercent = monthlyRevenue > 0 ? (monthlyElec / monthlyRevenue) * 100 : 0;
-
-  return {
-    modelId: model.id,
-    modelName: model.name,
-    decodeTokPerSec,
-    revenuePerHour,
-    elecPerHour,
-    netPerHour,
-    monthlyRevenue,
-    monthlyElec,
-    monthlyNet,
-    annualNet,
-    elecPercent,
-    batchSize,
-    batchEff,
-    activeParamsGB,
-    outputPriceMicro,
-    marginalWatts,
-    catalogModel: model,
-  };
-}
-
-interface PortfolioEarnings {
-  modelName: string;
-  selectedModels: ModelEarnings[];
-  selectedModelCount: number;
-  totalModelSizeGB: number;
-  hoursPerModel: number;
-  decodeTokPerSec: number;
-  revenuePerHour: number;
-  elecPerHour: number;
-  netPerHour: number;
-  monthlyRevenue: number;
-  monthlyElec: number;
-  monthlyNet: number;
-  annualNet: number;
-  elecPercent: number;
-}
-
-function calculatePortfolioEarnings(
-  models: CatalogModel[],
-  config: MacConfig,
-  ramGB: number,
-  hoursPerDay: number,
-  elecCostPerKWh: number
-): PortfolioEarnings | null {
-  if (models.length === 0) return null;
-  const totalModelSizeGB = models.reduce((sum, model) => sum + model.modelSizeGB, 0);
-  if (totalModelSizeGB > ramGB) return null;
-
-  const hoursPerModel = hoursPerDay / models.length;
-  const selectedModels = models.map((model) =>
-    calculateModelEarnings(model, config, ramGB, hoursPerModel, elecCostPerKWh, totalModelSizeGB)
-  );
-
-  const monthlyRevenue = selectedModels.reduce((sum, model) => sum + model.monthlyRevenue, 0);
-  const monthlyElec = selectedModels.reduce((sum, model) => sum + model.monthlyElec, 0);
-  const monthlyNet = selectedModels.reduce((sum, model) => sum + model.monthlyNet, 0);
-  const activeHoursPerMonth = Math.max(1, hoursPerDay * 30);
-
-  return {
-    modelName:
-      models.length === 1
-        ? models[0].name
-        : `${models.length} models selected`,
-    selectedModels,
-    selectedModelCount: models.length,
-    totalModelSizeGB,
-    hoursPerModel,
-    decodeTokPerSec:
-      selectedModels.reduce((sum, model) => sum + model.decodeTokPerSec, 0) / selectedModels.length,
-    revenuePerHour: monthlyRevenue / activeHoursPerMonth,
-    elecPerHour: monthlyElec / activeHoursPerMonth,
-    netPerHour: monthlyNet / activeHoursPerMonth,
-    monthlyRevenue,
-    monthlyElec,
-    monthlyNet,
-    annualNet: monthlyNet * 12,
-    elecPercent: monthlyRevenue > 0 ? (monthlyElec / monthlyRevenue) * 100 : 0,
-  };
-}
-
-/* ─── Fun comparisons ─── */
-
-function getComparisons(monthlyNet: number): string[] {
-  const comparisons: string[] = [];
-  if (monthlyNet > 2)
-    comparisons.push(`${Math.floor(monthlyNet / 2)} Spotify Premium subscriptions`);
-  if (monthlyNet > 5)
-    comparisons.push(`${Math.floor(monthlyNet / 5)} lattes per month`);
-  if (monthlyNet > 15)
-    comparisons.push(`${Math.floor(monthlyNet / 15)} Netflix Standard plans`);
-  if (monthlyNet > 50)
-    comparisons.push(`a ${Math.floor(monthlyNet / 50)}-day parking meter`);
-  if (monthlyNet > 70)
-    comparisons.push(`${Math.floor(monthlyNet / 70)}x your home internet bill`);
-  if (monthlyNet > 200)
-    comparisons.push(
-      `$${(monthlyNet * 12).toLocaleString(undefined, { maximumFractionDigits: 0 })}/yr — a nice side income`
-    );
-  return comparisons;
-}
+/* ─── Fixed assumptions ─── */
+// 100% utilization + always-on: the machine serves a request every second it
+// is online, 24/7. We deliberately don't expose utilization or hours to the
+// user — this is the optimistic ceiling the calculator estimates, and the
+// base-reward floor covers the gap to realistic (lower) demand.
+const ALWAYS_ON_HOURS = 24;
 
 function comparisonIcon(text: string) {
   if (text.includes("Spotify") || text.includes("Netflix"))
     return <TrendingUp size={14} className="text-accent-green shrink-0" />;
-  if (text.includes("latte"))
-    return <Coffee size={14} className="text-accent-amber shrink-0" />;
-  if (text.includes("internet"))
-    return <Wifi size={14} className="text-accent-brand shrink-0" />;
+  if (text.includes("latte")) return <Coffee size={14} className="text-accent-amber shrink-0" />;
+  if (text.includes("internet")) return <Wifi size={14} className="text-accent-brand shrink-0" />;
   if (text.includes("parking"))
     return <ParkingCircle size={14} className="text-accent-amber shrink-0" />;
   return <DollarSign size={14} className="text-accent-green shrink-0" />;
-}
-
-/* ─── Format helpers ─── */
-
-function fmtUSD(n: number, decimals = 2): string {
-  if (n < 0) return "-$" + Math.abs(n).toFixed(decimals);
-  return "$" + n.toFixed(decimals);
-}
-
-function fmtUSDWhole(n: number): string {
-  if (n < 0)
-    return "-$" + Math.abs(n).toLocaleString(undefined, { maximumFractionDigits: 0 });
-  return "$" + n.toLocaleString(undefined, { maximumFractionDigits: 0 });
 }
 
 /* ─── Selector pill button ─── */
@@ -345,7 +86,6 @@ export default function EarnPage() {
   const [selectedMacType, setSelectedMacType] = useState("MacBook Pro");
   const [selectedChip, setSelectedChip] = useState("M4 Max");
   const [selectedRAM, setSelectedRAM] = useState(48);
-  const [inferenceHours, setInferenceHours] = useState(18);
   const [elecCost, setElecCost] = useState("0.15");
   const [selectedModelIds, setSelectedModelIds] = useState<string[]>([]);
   const [catalogModels, setCatalogModels] = useState<CatalogModel[]>([]);
@@ -391,12 +131,12 @@ export default function EarnPage() {
     ? selectedRAM
     : availableRAM[availableRAM.length - 1] ?? 8;
 
-  // Calculate earnings for ALL eligible models
+  // Calculate USAGE earnings for ALL eligible models (for ranking)
   const rankedModels = useMemo(() => {
     if (!selectedConfig) return [];
     const eligible = catalogModels.filter((m) => m.minRAMGB <= effectiveRAM);
     const results = eligible.map((m) =>
-      calculateModelEarnings(m, selectedConfig, effectiveRAM, 18, elecCostNum)
+      calculateModelEarnings(m, selectedConfig, ALWAYS_ON_HOURS, elecCostNum)
     );
     results.sort((a, b) => b.monthlyNet - a.monthlyNet);
     return results;
@@ -435,10 +175,10 @@ export default function EarnPage() {
       selectedCatalogModels,
       selectedConfig,
       effectiveRAM,
-      inferenceHours,
+      ALWAYS_ON_HOURS,
       elecCostNum
     );
-  }, [selectedConfig, selectedCatalogModels, effectiveRAM, inferenceHours, elecCostNum]);
+  }, [selectedConfig, selectedCatalogModels, effectiveRAM, elecCostNum]);
 
   const comparisons = useMemo(
     () => (result ? getComparisons(result.monthlyNet) : []),
@@ -471,12 +211,7 @@ export default function EarnPage() {
       if (validCurrent.length === 0) {
         return [modelId];
       }
-      const base =
-        validCurrent.length > 0
-          ? validCurrent
-          : bestModelId && eligibleModelIds.has(bestModelId)
-            ? [bestModelId]
-            : [];
+      const base = validCurrent;
       if (base.includes(modelId)) {
         const next = base.filter((id) => id !== modelId);
         return next.length > 0 ? next : base;
@@ -497,7 +232,7 @@ export default function EarnPage() {
     modelSelectorHint = "No compatible catalog model for this memory configuration";
   } else if (selectedModelIds.length > 0) {
     modelSelectorHint =
-      "Selected models share active inference hours, so earnings are not double-counted.";
+      "Selected models share active inference hours, so usage earnings are not double-counted.";
   }
 
   return (
@@ -513,7 +248,7 @@ export default function EarnPage() {
             </h2>
             <p className="text-sm text-text-tertiary">
               Estimate how much your Apple Silicon Mac can earn serving inference
-              on the Darkbloom network.
+              on the Darkbloom network — usage earnings plus the base-reward floor.
             </p>
           </div>
 
@@ -739,16 +474,16 @@ export default function EarnPage() {
                         {m.modelName}
                       </span>
 
-                      {/* Monthly net */}
+                      {/* Monthly usage net */}
                       <span className={`text-sm font-mono tabular-nums whitespace-nowrap ${
                         m.monthlyNet >= 0 ? "text-accent-green" : "text-accent-red"
                       }`}>
-                        {fmtUSD(m.monthlyNet)}/mo solo
+                        {fmtUSD(m.monthlyNet)}/mo usage
                       </span>
 
                       {isBest && m.monthlyNet > 0 && (
                         <span className="px-2 py-0.5 rounded text-xs font-medium bg-accent-green/10 text-accent-green border border-accent-green/20 whitespace-nowrap">
-                          Best solo
+                          Best model
                         </span>
                       )}
                     </button>
@@ -757,7 +492,7 @@ export default function EarnPage() {
                       <div className="px-4 pb-3 pl-11">
                         <div className="flex items-start gap-1.5 text-xs text-text-tertiary">
                           <Info size={11} className="shrink-0 mt-0.5" />
-                          <span>{catalogEntry.demandNote}{isUnprofitable ? " This model loses money on your hardware — electricity exceeds revenue." : ""}</span>
+                          <span>{catalogEntry.demandNote}{isUnprofitable ? " This model's usage revenue is below its electricity cost on your hardware — the base reward still applies." : ""}</span>
                         </div>
                       </div>
                     )}
@@ -777,61 +512,27 @@ export default function EarnPage() {
 
           {result ? (
             <>
-              {/* Inference Hours & Electricity */}
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-6">
-                {/* Inference hours slider */}
-                <div className="rounded-xl bg-bg-secondary p-5">
-                  <label className="block text-xs font-medium text-text-tertiary uppercase tracking-wider mb-3">
-                    <Zap size={12} className="inline mr-1.5 -mt-0.5" />
-                    Inference Hours
-                  </label>
-                  <div className="flex items-baseline gap-2 mb-3">
-                    <span className="text-2xl font-bold font-mono text-text-primary">
-                      {inferenceHours}
-                    </span>
-                    <span className="text-sm text-text-tertiary">
-                      hours of active inference per day
-                    </span>
-                  </div>
+              {/* Electricity cost (utilization & hours are fixed at 100% / always-on) */}
+              <div className="rounded-xl bg-bg-secondary p-5 mb-6">
+                <label className="block text-xs font-medium text-text-tertiary uppercase tracking-wider mb-3">
+                  <DollarSign size={12} className="inline mr-1.5 -mt-0.5" />
+                  Electricity Cost
+                </label>
+                <div className="flex items-baseline gap-2">
+                  <span className="text-text-secondary text-sm">$</span>
                   <input
-                    type="range"
-                    min={1}
-                    max={24}
-                    value={inferenceHours}
-                    onChange={(e) => {
-                      setInferenceHours(parseInt(e.target.value));
-                    }}
-                    className="w-full accent-accent-brand"
+                    type="number"
+                    step="0.01"
+                    min="0"
+                    value={elecCost}
+                    onChange={(e) => setElecCost(e.target.value)}
+                    className="w-24 bg-bg-tertiary rounded-lg px-3 py-2 text-sm font-mono text-text-primary focus:outline-none focus:ring-2 focus:ring-accent-brand/50"
                   />
-                  <div className="flex justify-between text-xs text-text-tertiary mt-1">
-                    <span>1 hr</span>
-                    <span>12 hrs</span>
-                    <span>24 hrs</span>
-                  </div>
+                  <span className="text-text-tertiary text-sm">/kWh</span>
                 </div>
-
-                {/* Electricity cost */}
-                <div className="rounded-xl bg-bg-secondary p-5">
-                  <label className="block text-xs font-medium text-text-tertiary uppercase tracking-wider mb-3">
-                    <DollarSign size={12} className="inline mr-1.5 -mt-0.5" />
-                    Electricity Cost
-                  </label>
-                  <div className="flex items-baseline gap-2">
-                    <span className="text-text-secondary text-sm">$</span>
-                    <input
-                      type="number"
-                      step="0.01"
-                      min="0"
-                      value={elecCost}
-                      onChange={(e) => setElecCost(e.target.value)}
-                      className="w-24 bg-bg-tertiary rounded-lg px-3 py-2 text-sm font-mono text-text-primary focus:outline-none focus:ring-2 focus:ring-accent-brand/50"
-                    />
-                    <span className="text-text-tertiary text-sm">/kWh</span>
-                  </div>
-                  <p className="text-xs text-text-tertiary mt-2">
-                    US avg: $0.15 | EU avg: $0.25 | CA avg: $0.22
-                  </p>
-                </div>
+                <p className="text-xs text-text-tertiary mt-2">
+                  US avg: $0.15 | EU avg: $0.25 | CA avg: $0.22
+                </p>
               </div>
 
               {/* Results */}
@@ -849,7 +550,7 @@ export default function EarnPage() {
                       <span className="font-mono text-text-secondary">
                         {result.modelName}
                       </span>{" "}
-                      at {inferenceHours} total active hrs/day
+                      (always-on, 100% utilization)
                     </p>
                     {result.selectedModelCount > 1 && (
                       <p className="text-xs text-text-tertiary mt-1">
@@ -857,6 +558,17 @@ export default function EarnPage() {
                       </p>
                     )}
                   </div>
+                </div>
+
+                {/* 100% utilization assumption note */}
+                <div className="flex items-start gap-2 px-3 py-2.5 rounded-lg bg-bg-tertiary mb-5">
+                  <Info size={14} className="text-text-tertiary shrink-0 mt-0.5" />
+                  <p className="text-xs text-text-tertiary">
+                    Usage assumes <span className="text-text-secondary font-medium">100% utilization</span>{" "}
+                    — your Mac serving a request every second it&apos;s online. The live network runs
+                    well below that today, which is exactly what the base reward is for: it covers you
+                    while demand ramps, and usage takes over as the network fills up.
+                  </p>
                 </div>
 
                 {/* Big number */}
@@ -872,19 +584,40 @@ export default function EarnPage() {
                   </p>
                 </div>
 
+                {/* Usage + floor breakdown */}
+                <div className="grid grid-cols-3 gap-3 mb-6">
+                  <div className="rounded-lg bg-bg-tertiary p-3 text-center">
+                    <p className="text-xs text-text-tertiary mb-1">Usage (inference)</p>
+                    <p className="text-lg font-mono text-text-primary">{fmtUSD(result.monthlyUsageNet)}</p>
+                    <p className="text-[10px] text-text-tertiary mt-0.5">revenue − electricity</p>
+                  </div>
+                  <div className="rounded-lg bg-accent-brand/5 border border-accent-brand/20 p-3 text-center">
+                    <p className="text-xs text-text-tertiary mb-1 flex items-center justify-center gap-1">
+                      <Shield size={11} className="text-accent-brand" /> Base reward
+                    </p>
+                    <p className="text-lg font-mono text-accent-brand">+ {fmtUSD(result.monthlyFloor)}</p>
+                    <p className="text-[10px] text-text-tertiary mt-0.5">{effectiveRAM}GB tier × uptime</p>
+                  </div>
+                  <div className="rounded-lg bg-accent-green/5 border border-accent-green/20 p-3 text-center">
+                    <p className="text-xs text-text-tertiary mb-1">Total / mo</p>
+                    <p className="text-lg font-mono text-accent-green">{fmtUSD(result.monthlyNet)}</p>
+                    <p className="text-[10px] text-text-tertiary mt-0.5">usage + base reward</p>
+                  </div>
+                </div>
+
                 {/* Detail grid */}
                 <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
                   <div>
                     <p className="text-xs text-text-tertiary mb-0.5">
-                      Batched decode speed
+                      Decode speed
                     </p>
                     <p className="text-sm font-mono text-text-primary">
-                      {result.decodeTokPerSec.toFixed(1)} tok/s avg
+                      {result.decodeTokPerSec.toFixed(1)} tok/s
                     </p>
                   </div>
                   <div>
                     <p className="text-xs text-text-tertiary mb-0.5">
-                      Monthly revenue
+                      Monthly usage revenue
                     </p>
                     <p className="text-sm font-mono text-text-primary">
                       {fmtUSD(result.monthlyRevenue)}
@@ -908,7 +641,7 @@ export default function EarnPage() {
                   </div>
                   <div>
                     <p className="text-xs text-text-tertiary mb-0.5">
-                      Revenue per hour
+                      Usage revenue per hour
                     </p>
                     <p className="text-sm font-mono text-text-primary">
                       {fmtUSD(result.revenuePerHour, 4)}
@@ -924,10 +657,10 @@ export default function EarnPage() {
                   </div>
                   <div>
                     <p className="text-xs text-text-tertiary mb-0.5">
-                      Net per hour
+                      Base reward / mo
                     </p>
-                    <p className="text-sm font-mono text-accent-green">
-                      {fmtUSD(result.netPerHour, 4)}
+                    <p className="text-sm font-mono text-accent-brand">
+                      {fmtUSD(result.monthlyFloor)}
                     </p>
                   </div>
                   <div>
@@ -936,7 +669,7 @@ export default function EarnPage() {
                       <span className="relative group">
                         <Info size={12} className="text-text-tertiary cursor-help" />
                         <span className="absolute bottom-full left-1/2 -translate-x-1/2 mb-1 w-48 px-2 py-1 text-[10px] text-text-secondary bg-bg-tertiary border border-border-primary rounded shadow-lg opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none z-10">
-                          Payouts are currently processed manually. Automatic payouts coming soon.
+                          You keep 100% of usage revenue and the base reward. Payouts are currently processed manually.
                         </span>
                       </span>
                     </p>
@@ -945,70 +678,42 @@ export default function EarnPage() {
                 </div>
               </div>
 
+              {/* Base rewards explainer */}
+              <BaseRewardsPanel highlightGB={effectiveRAM} />
+
               {/* Calculation breakdown */}
               <div className="rounded-xl bg-bg-secondary p-6 mb-6">
                 <h3 className="text-sm font-medium text-text-primary mb-3">
                   How this is calculated
                 </h3>
                 <div className="text-xs text-text-tertiary font-mono space-y-1 bg-bg-tertiary rounded-lg p-4 overflow-x-auto">
-                  {result.selectedModelCount > 1 ? (
+                  {result.selectedModels[0] && (
                     <>
                       <p>
-                        loaded_models = {result.selectedModels.map((m) => m.modelName).join(" + ")}
+                        decode_tok/s = ({selectedConfig.bandwidthGBs} GB/s / {result.selectedModels[0].activeParamsGB} GB) * {SINGLE_STREAM_EFFICIENCY} ={" "}
+                        {result.selectedModels[0].decodeTokPerSec.toFixed(1)} tok/s (single stream)
                       </p>
                       <p>
-                        model_weights = {result.totalModelSizeGB} GB / {effectiveRAM} GB RAM
+                        usage_rev/hr = decode_tok/hr * out_price + (decode_tok/hr * {PROMPT_TO_COMPLETION_RATIO} prompt) * in_price ={" "}
+                        {fmtUSD(result.revenuePerHour, 4)}
                       </p>
                       <p>
-                        active_hours/model = {inferenceHours} hrs/day / {result.selectedModelCount} models ={" "}
-                        {result.hoursPerModel.toFixed(1)} hrs/day
+                        electricity/hr = ({result.selectedModels[0].marginalWatts}W / 1000) * ${elecCostNum.toFixed(2)}/kWh ={" "}
+                        {fmtUSD(result.elecPerHour, 4)}
                       </p>
                       <p>
-                        monthly_revenue = sum(model revenue/hr * {result.hoursPerModel.toFixed(1)} hrs/day * 30) ={" "}
-                        {fmtUSD(result.monthlyRevenue)}
+                        monthly_usage = ({fmtUSD(result.revenuePerHour, 4)} - {fmtUSD(result.elecPerHour, 4)}) * 24 hrs/day * 30 ={" "}
+                        {fmtUSD(result.monthlyUsageNet)}
                       </p>
                       <p>
-                        monthly_electricity = shared active compute time * ${elecCostNum.toFixed(2)}/kWh ={" "}
-                        {fmtUSD(result.monthlyElec)}
+                        base_reward = {effectiveRAM}GB tier * 100% uptime = {fmtUSD(result.monthlyFloor)}/mo
                       </p>
-                      <p>
-                        monthly_net = {fmtUSD(result.monthlyRevenue)} - {fmtUSD(result.monthlyElec)} ={" "}
+                      <p className="text-text-secondary">
+                        monthly_total = {fmtUSD(result.monthlyUsageNet)} usage + {fmtUSD(result.monthlyFloor)} base reward ={" "}
                         {fmtUSD(result.monthlyNet)}
                       </p>
                     </>
-                  ) : result.selectedModels[0] ? (
-                    <>
-                      <p>
-                        single_tok/s = ({selectedConfig.bandwidthGBs} GB/s / {result.selectedModels[0].activeParamsGB} GB) * 0.60 ={" "}
-                        {((selectedConfig.bandwidthGBs / result.selectedModels[0].activeParamsGB) * 0.6).toFixed(1)} tok/s
-                      </p>
-                      <p>
-                        batched_tok/s ={" "}
-                        {((selectedConfig.bandwidthGBs / result.selectedModels[0].activeParamsGB) * 0.6).toFixed(1)} * {result.selectedModels[0].batchSize} * {result.selectedModels[0].batchEff} ={" "}
-                        {result.selectedModels[0].decodeTokPerSec.toFixed(1)} tok/s
-                      </p>
-                      <p>
-                        tok/hr = {result.selectedModels[0].decodeTokPerSec.toFixed(1)} * 3600 ={" "}
-                        {(result.selectedModels[0].decodeTokPerSec * 3600).toLocaleString(undefined, { maximumFractionDigits: 0 })}
-                      </p>
-                      <p>
-                        revenue/hr = ({(result.selectedModels[0].decodeTokPerSec * 3600).toLocaleString(undefined, { maximumFractionDigits: 0 })} / 1M) * $
-                        {(result.selectedModels[0].outputPriceMicro / 1_000_000).toFixed(6)} = {fmtUSD(result.revenuePerHour, 4)}
-                      </p>
-                      <p>
-                        marginal_watts = {selectedConfig.inferWatts}W (inference) - {selectedConfig.idleWatts}W (idle) = {result.selectedModels[0].marginalWatts}W
-                      </p>
-                      <p>
-                        elec/hr = ({result.selectedModels[0].marginalWatts}W / 1000) * ${elecCostNum.toFixed(2)}/kWh = {fmtUSD(result.elecPerHour, 4)}
-                      </p>
-                      <p>
-                        net/hr = {fmtUSD(result.revenuePerHour, 4)} - {fmtUSD(result.elecPerHour, 4)} = {fmtUSD(result.netPerHour, 4)}
-                      </p>
-                      <p>
-                        monthly = {fmtUSD(result.netPerHour, 4)} * {inferenceHours} hrs/day * 30 days = {fmtUSD(result.monthlyNet)}
-                      </p>
-                    </>
-                  ) : null}
+                  )}
                 </div>
               </div>
 
@@ -1016,7 +721,7 @@ export default function EarnPage() {
               {comparisons.length > 0 && (
                 <div className="rounded-xl bg-bg-secondary p-6 mb-8">
                   <h3 className="text-sm font-medium text-text-primary mb-3">
-                    Your Mac earns more idle than...
+                    Your Mac earns more than...
                   </h3>
                   <div className="space-y-2">
                     {comparisons.map((c) => (
@@ -1043,7 +748,7 @@ export default function EarnPage() {
                     No compatible model for this hardware
                   </h3>
                   <p className="text-sm text-text-tertiary">
-                    Current catalog models need at least 36 GB unified memory. Choose a Mac with more memory to estimate provider earnings.
+                    No live catalog model fits in {effectiveRAM} GB of unified memory. Choose a Mac with more memory to estimate provider earnings.
                   </p>
                 </div>
               </div>
@@ -1053,13 +758,13 @@ export default function EarnPage() {
           {/* Disclaimer */}
           <div className="rounded-xl bg-bg-secondary p-5 mb-8">
             <p className="text-xs text-text-tertiary mb-2">
-              <span className="font-medium text-text-secondary">These are estimates only.</span> We do not guarantee any specific utilization or earnings. Actual earnings depend on network demand, model popularity, your provider reputation score, and how many other providers are serving the same model.
+              <span className="font-medium text-text-secondary">These are estimates only.</span> Usage earnings assume 100% utilization (your Mac fully busy while online); actual usage depends on network demand, model popularity, your provider reputation, and how many other providers serve the same model. The live network currently runs well below full utilization.
             </p>
             <p className="text-xs text-text-tertiary mb-2">
-              When your Mac is idle (no inference requests), it consumes minimal power — you don&apos;t lose significant money waiting for requests. The electricity costs shown only apply during active inference.
+              <span className="font-medium text-text-secondary">Base rewards</span> are paid on top of usage to attested machines that stay online ≥90% of the month, up to a fixed monthly budget — they are not a guarantee and taper off as the network grows.
             </p>
             <p className="text-xs text-text-tertiary">
-              Models with higher demand and more active users tend to produce more consistent earnings.
+              When your Mac is idle (no requests), it draws minimal power — the electricity cost shown only applies during active inference. You keep 100% of both usage revenue and base rewards.
             </p>
           </div>
         </div>

--- a/console-ui/src/components/earn/BaseRewardsPanel.tsx
+++ b/console-ui/src/components/earn/BaseRewardsPanel.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { Shield, TrendingUp, Clock, Info } from "lucide-react";
+import { FLOOR_TIERS } from "@/app/earn/calc";
+
+/**
+ * BaseRewardsPanel — provider-facing explainer for the base-rewards earnings
+ * floor on the /earn page.
+ *
+ * Model: payout = usage_earnings + floor (additive). The floor is what a
+ * machine earns on top of real inference for staying online and attested; real
+ * inference is the upside that grows as the network fills up. The floor table
+ * mirrors coordinator/payments/baserewards/floor.go.
+ *
+ * Honesty constraints (see docs/base-rewards.md): the "covers your Netflix"
+ * line applies to 64GB+ machines only; we never call it a "guarantee" (it is
+ * eligibility-gated and capped by a fixed monthly pool).
+ */
+
+function netflixLabel(floorUSD: number): string {
+  if (floorUSD >= 18) return "Netflix Standard";
+  if (floorUSD > 0) return "Netflix w/ ads";
+  return "Usage only";
+}
+
+function netflixColor(floorUSD: number): string {
+  if (floorUSD >= 18) return "text-accent-green";
+  if (floorUSD > 0) return "text-accent-amber";
+  return "text-text-tertiary";
+}
+
+export function BaseRewardsPanel({ highlightGB }: { highlightGB?: number }) {
+  return (
+    <div className="rounded-xl bg-bg-secondary p-6 mb-6">
+      <div className="flex items-center gap-2 mb-2">
+        <Shield size={18} className="text-accent-brand" />
+        <h3 className="text-sm font-semibold text-text-primary">Base rewards (earnings floor)</h3>
+      </div>
+      <p className="text-sm text-text-secondary mb-5">
+        On top of what you earn from real inference, attested machines earn a monthly{" "}
+        <span className="text-text-primary font-medium">base reward</span> for staying online — so a{" "}
+        <span className="text-text-primary font-medium">64GB+ Mac</span> clears a full Netflix
+        subscription even while the network is still quiet. Real usage is the upside on top, and it
+        grows as demand fills up the network.
+      </p>
+
+      <div className="overflow-hidden rounded-lg border border-border-subtle">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="bg-bg-tertiary text-text-tertiary">
+              <th className="text-left font-medium px-4 py-2">Unified memory</th>
+              <th className="text-right font-medium px-4 py-2">Base reward / mo</th>
+              <th className="text-right font-medium px-4 py-2">Covers</th>
+            </tr>
+          </thead>
+          <tbody>
+            {FLOOR_TIERS.map((t) => {
+              const active = highlightGB != null && highlightGB >= t.minGB;
+              return (
+                <tr
+                  key={t.minGB}
+                  className={`border-t border-border-subtle ${active ? "bg-accent-brand/5" : ""}`}
+                >
+                  <td className="px-4 py-2 text-text-secondary">{t.label}</td>
+                  <td className="px-4 py-2 text-right font-mono text-text-primary">
+                    {t.floorUSD > 0 ? `$${t.floorUSD}` : "—"}
+                  </td>
+                  <td className="px-4 py-2 text-right">
+                    <span className={netflixColor(t.floorUSD)}>{netflixLabel(t.floorUSD)}</span>
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="mt-4 space-y-2">
+        <div className="flex items-start gap-2 text-xs text-text-tertiary">
+          <Clock size={13} className="shrink-0 mt-0.5" />
+          <span>Requires staying online ≥90% of the month (the base reward ramps with uptime).</span>
+        </div>
+        <div className="flex items-start gap-2 text-xs text-text-tertiary">
+          <TrendingUp size={13} className="shrink-0 mt-0.5" />
+          <span>Usage earnings are paid on top of the base reward — you keep 100% of both.</span>
+        </div>
+        <div className="flex items-start gap-2 text-xs text-text-tertiary">
+          <Info size={13} className="shrink-0 mt-0.5" />
+          <span>
+            Base rewards go to attested, actively-serving machines up to a fixed monthly budget; not
+            a guarantee. See the docs for eligibility.
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/landing/earn-calculator.js
+++ b/landing/earn-calculator.js
@@ -3,7 +3,7 @@
  *
  * Earnings model: total = usage + floor − electricity
  *   • usage — realistic throughput at 80% utilization, crediting continuous
- *     batching at a quality-preserving 2× (not the old 16× ceiling, which
+ *     batching at a quality-preserving 4× (not the old 16× ceiling, which
  *     overstated earnings).
  *   • floor — provider base reward (PR #282) by verified-memory tier, ramped by
  *     uptime, added ON TOP of usage (additive, not max).
@@ -52,8 +52,8 @@
   // Sustained fraction of peak memory bandwidth for a single decode stream.
   const SINGLE_STREAM_EFFICIENCY = 0.6;
   // Continuous-batching gain over single-stream at quality-preserving
-  // concurrency (capped at 2×, not the theoretical 16× ceiling).
-  const CONTINUOUS_BATCH_FACTOR = 2;
+  // concurrency (capped at 4×, not the theoretical 16× ceiling).
+  const CONTINUOUS_BATCH_FACTOR = 4;
   // Assumed network utilization (fraction of online time actively serving).
   const ASSUMED_UTILIZATION = 0.8;
   // Network-observed prompt:completion token ratio (≈3.5:1 from /v1/stats).
@@ -153,7 +153,7 @@
   // Per-model USAGE earnings at 100% utilization for hoursOnlinePerDay hours/day.
   // Single-stream throughput (no batch multiplier); floor is added separately.
   function calculateModelEarnings(model, config, hoursOnlinePerDay, elecCostPerKWh) {
-    // Effective decode = single-stream × continuous batch (2×) × utilization (80%).
+    // Effective decode = single-stream × continuous batch (4×) × utilization (80%).
     const singleTokPerSec = (config.bandwidthGBs / model.activeParamsGB) * SINGLE_STREAM_EFFICIENCY;
     const decodeTokPerSec = singleTokPerSec * CONTINUOUS_BATCH_FACTOR * ASSUMED_UTILIZATION;
     const completionTokPerHour = decodeTokPerSec * 3600;

--- a/landing/earn-calculator.js
+++ b/landing/earn-calculator.js
@@ -1,5 +1,13 @@
 /**
- * Provider earnings calculator — keep in sync with console-ui/src/app/earn/page.tsx
+ * Provider earnings calculator — keep in sync with console-ui/src/app/earn/calc.ts
+ *
+ * Earnings model: total = usage + floor − electricity
+ *   • usage — realistic SINGLE-STREAM decode at 100% utilization (no batch
+ *     multiplier: at the utilization the network actually sees a machine serves
+ *     ~one request at a time, so the old 16×-batch ceiling overstated earnings).
+ *   • floor — provider base reward (PR #282) by verified-memory tier, ramped by
+ *     uptime, added ON TOP of usage (additive, not max).
+ *   • elec — marginal inference watts over idle while online.
  */
 (function () {
   const MAC_TYPES = ["MacBook Air", "MacBook Pro", "Mac Mini", "Mac Studio", "Mac Pro"];
@@ -15,39 +23,75 @@
     { macType: "MacBook Pro", chip: "M2 Max", ramOptions: [32, 64, 96], bandwidthGBs: 400, idleWatts: 15, inferWatts: 40 },
     { macType: "MacBook Pro", chip: "M3", ramOptions: [8, 16, 24], bandwidthGBs: 100, idleWatts: 10, inferWatts: 20 },
     { macType: "MacBook Pro", chip: "M3 Pro", ramOptions: [18, 36], bandwidthGBs: 150, idleWatts: 15, inferWatts: 35 },
-    { macType: "MacBook Pro", chip: "M3 Max", ramOptions: [36, 48, 64, 96, 128], bandwidthGBs: 300, idleWatts: 20, inferWatts: 45 },
+    { macType: "MacBook Pro", chip: "M3 Max", ramOptions: [36, 48, 64, 96, 128], bandwidthGBs: 400, idleWatts: 20, inferWatts: 45 },
     { macType: "MacBook Pro", chip: "M4", ramOptions: [16, 24, 32], bandwidthGBs: 120, idleWatts: 10, inferWatts: 20 },
     { macType: "MacBook Pro", chip: "M4 Pro", ramOptions: [24, 48], bandwidthGBs: 273, idleWatts: 12, inferWatts: 30 },
     { macType: "MacBook Pro", chip: "M4 Max", ramOptions: [36, 48, 64, 128], bandwidthGBs: 546, idleWatts: 20, inferWatts: 50 },
     { macType: "MacBook Pro", chip: "M5", ramOptions: [16, 24, 32], bandwidthGBs: 153, idleWatts: 10, inferWatts: 20 },
-    { macType: "MacBook Pro", chip: "M5 Pro", ramOptions: [24, 48], bandwidthGBs: 307, idleWatts: 12, inferWatts: 30 },
-    { macType: "MacBook Pro", chip: "M5 Max", ramOptions: [36, 48, 64, 128], bandwidthGBs: 614, idleWatts: 20, inferWatts: 50 },
+    { macType: "MacBook Pro", chip: "M5 Pro", ramOptions: [24, 48], bandwidthGBs: 300, idleWatts: 12, inferWatts: 30 },
+    { macType: "MacBook Pro", chip: "M5 Max", ramOptions: [36, 48, 64, 128], bandwidthGBs: 600, idleWatts: 20, inferWatts: 50 },
     { macType: "Mac Mini", chip: "M1", ramOptions: [8, 16], bandwidthGBs: 68, idleWatts: 5, inferWatts: 10 },
     { macType: "Mac Mini", chip: "M2", ramOptions: [8, 16, 24], bandwidthGBs: 100, idleWatts: 5, inferWatts: 12 },
     { macType: "Mac Mini", chip: "M2 Pro", ramOptions: [16, 32], bandwidthGBs: 200, idleWatts: 8, inferWatts: 25 },
     { macType: "Mac Mini", chip: "M4", ramOptions: [16, 24, 32], bandwidthGBs: 120, idleWatts: 5, inferWatts: 15 },
-    { macType: "Mac Mini", chip: "M4 Pro", ramOptions: [24, 48], bandwidthGBs: 273, idleWatts: 8, inferWatts: 25 },
+    { macType: "Mac Mini", chip: "M4 Pro", ramOptions: [24, 48, 64], bandwidthGBs: 273, idleWatts: 8, inferWatts: 25 },
     { macType: "Mac Studio", chip: "M1 Max", ramOptions: [32, 64], bandwidthGBs: 400, idleWatts: 20, inferWatts: 60 },
     { macType: "Mac Studio", chip: "M1 Ultra", ramOptions: [64, 128], bandwidthGBs: 800, idleWatts: 30, inferWatts: 90 },
     { macType: "Mac Studio", chip: "M2 Max", ramOptions: [32, 64, 96], bandwidthGBs: 400, idleWatts: 20, inferWatts: 60 },
     { macType: "Mac Studio", chip: "M2 Ultra", ramOptions: [64, 128, 192], bandwidthGBs: 800, idleWatts: 35, inferWatts: 100 },
     { macType: "Mac Studio", chip: "M3 Ultra", ramOptions: [96, 256, 512], bandwidthGBs: 819, idleWatts: 35, inferWatts: 110 },
     { macType: "Mac Studio", chip: "M4 Max", ramOptions: [36, 48, 64, 128], bandwidthGBs: 546, idleWatts: 25, inferWatts: 65 },
-    { macType: "Mac Studio", chip: "M5 Max", ramOptions: [36, 48, 64, 128], bandwidthGBs: 614, idleWatts: 25, inferWatts: 65 },
+    { macType: "Mac Studio", chip: "M5 Max", ramOptions: [36, 48, 64, 128], bandwidthGBs: 600, idleWatts: 25, inferWatts: 65 },
     { macType: "Mac Pro", chip: "M2 Ultra", ramOptions: [64, 128, 192], bandwidthGBs: 800, idleWatts: 40, inferWatts: 120 },
     { macType: "Mac Pro", chip: "M3 Ultra", ramOptions: [96, 256, 512], bandwidthGBs: 819, idleWatts: 40, inferWatts: 120 },
   ];
 
   const API_BASE = "https://api.darkbloom.dev";
   const DEFAULT_OUTPUT_PRICE_MICRO = 200_000;
+  const DEFAULT_INPUT_PRICE_MICRO = 50_000;
+  // Sustained fraction of peak memory bandwidth for a single decode stream.
+  const SINGLE_STREAM_EFFICIENCY = 0.6;
+  // Network-observed prompt:completion token ratio (≈3.5:1 from /v1/stats).
+  const PROMPT_TO_COMPLETION_RATIO = 3.5;
+
+  // Provider base-reward floor by verified unified-memory tier (USD/mo).
+  // Mirrors coordinator/payments/baserewards/floor.go.
+  const FLOOR_TIERS = [
+    { minGB: 512, label: "512GB", floorUSD: 40 },
+    { minGB: 192, label: "192GB", floorUSD: 30 },
+    { minGB: 128, label: "128GB", floorUSD: 26 },
+    { minGB: 96, label: "96GB", floorUSD: 22 },
+    { minGB: 64, label: "64GB", floorUSD: 18 },
+    { minGB: 48, label: "48GB", floorUSD: 16 },
+    { minGB: 32, label: "32GB", floorUSD: 12 },
+    { minGB: 24, label: "24GB", floorUSD: 10 },
+    { minGB: 0, label: "Under 24GB", floorUSD: 0 },
+  ];
+  const MIN_UPTIME_FOR_AVAIL = 0.9;
+
+  function tierFloorUSD(memGB) {
+    for (const t of FLOOR_TIERS) {
+      if (memGB >= t.minGB) return t.floorUSD;
+    }
+    return 0;
+  }
+  function availFromUptime(uptimeFrac) {
+    const v = (uptimeFrac - MIN_UPTIME_FOR_AVAIL) / (1 - MIN_UPTIME_FOR_AVAIL);
+    if (v < 0) return 0;
+    if (v > 1) return 1;
+    return v;
+  }
+  function scaledFloorUSD(memGB, uptimeFrac, taper = 1) {
+    return tierFloorUSD(memGB) * availFromUptime(uptimeFrac) * taper;
+  }
 
   // CATALOG_MODELS is refreshed from the live coordinator catalog on load (see
   // DOMContentLoaded below). These static entries are a fallback for when the
   // API is unreachable; keep them to the currently-served lineup. Mirrors
-  // console-ui/src/app/earn/page.tsx (buildCatalogModels).
+  // console-ui/src/app/earn/calc.ts (buildCatalogModels).
   let CATALOG_MODELS = [
-    { id: "gpt-oss-20b", name: "GPT-OSS 20B", minRAMGB: 24, activeParamsGB: 4, modelSizeGB: 12, outputPriceMicro: 70_000, demandNote: "Uses the live coordinator catalog and current/default per-token pricing." },
-    { id: "gemma-4-26b", name: "Gemma 4 26B", minRAMGB: 36, activeParamsGB: 4, modelSizeGB: 28, outputPriceMicro: 165_000, demandNote: "Uses the live coordinator catalog and current/default per-token pricing." },
+    { id: "gpt-oss-20b", name: "GPT-OSS 20B", minRAMGB: 24, activeParamsGB: 4, modelSizeGB: 12, outputPriceMicro: 70_000, inputPriceMicro: 14_500, demandNote: "Uses the live coordinator catalog and current/default per-token pricing." },
+    { id: "gemma-4-26b", name: "Gemma 4 26B", minRAMGB: 36, activeParamsGB: 4, modelSizeGB: 28, outputPriceMicro: 165_000, inputPriceMicro: 30_000, demandNote: "Uses the live coordinator catalog and current/default per-token pricing." },
   ];
 
   // --- Live catalog → calculator model mapping (ported from console-ui) ---
@@ -58,8 +102,6 @@
     return match ? Number(match[1]) : 27;
   }
   function catalogActiveParamsGB(m, sizeGB) {
-    // Search id, architecture, and description; accept decimal active counts
-    // ("A3.6B" or "3.6B active") before falling back to the size-based estimate.
     const text = `${m.id || ""} ${m.architecture || ""} ${m.description || ""}`;
     const active = text.match(/A(\d{1,3}(?:\.\d+)?)B/i) || text.match(/(\d{1,3}(?:\.\d+)?)B\s+active/i);
     if (active) return Math.max(1, Math.round(Number(active[1])));
@@ -68,8 +110,12 @@
   }
   function buildCatalogModels(models, pricing) {
     const outputPrices = {};
+    const inputPrices = {};
     if (pricing && Array.isArray(pricing.prices)) {
-      pricing.prices.forEach((p) => { outputPrices[p.model] = p.output_price; });
+      pricing.prices.forEach((p) => {
+        outputPrices[p.model] = p.output_price;
+        inputPrices[p.model] = p.input_price;
+      });
     }
     return models.map((m) => {
       const size = Math.max(1, Math.round(catalogModelSizeGB(m)));
@@ -81,6 +127,7 @@
         activeParamsGB: catalogActiveParamsGB(m, size),
         modelSizeGB: size,
         outputPriceMicro: outputPrices[m.id] != null ? outputPrices[m.id] : DEFAULT_OUTPUT_PRICE_MICRO,
+        inputPriceMicro: inputPrices[m.id] != null ? inputPrices[m.id] : DEFAULT_INPUT_PRICE_MICRO,
       };
     });
   }
@@ -98,22 +145,22 @@
     return 0.15;
   }
 
-  function calculateModelEarnings(model, config, ramGB, hoursPerDay, elecCostPerKWh, loadedModelSizeGB = model.modelSizeGB) {
-    const freeRAM = ramGB - loadedModelSizeGB;
-    const batchSize = Math.max(1, Math.min(16, Math.floor(freeRAM / 2)));
-    const batchEff = batchSize <= 4 ? 0.8 : batchSize <= 8 ? 0.85 : 0.9;
-    const singleTokPerSec = (config.bandwidthGBs / model.activeParamsGB) * 0.6;
-    const decodeTokPerSec = singleTokPerSec * batchSize * batchEff;
-    const tokPerHour = decodeTokPerSec * 3600;
-    const revenuePerHour = (tokPerHour / 1_000_000) * (model.outputPriceMicro / 1_000_000);
+  // Per-model USAGE earnings at 100% utilization for hoursOnlinePerDay hours/day.
+  // Single-stream throughput (no batch multiplier); floor is added separately.
+  function calculateModelEarnings(model, config, hoursOnlinePerDay, elecCostPerKWh) {
+    const decodeTokPerSec = (config.bandwidthGBs / model.activeParamsGB) * SINGLE_STREAM_EFFICIENCY;
+    const completionTokPerHour = decodeTokPerSec * 3600;
+    const promptTokPerHour = completionTokPerHour * PROMPT_TO_COMPLETION_RATIO;
+    const revenuePerHour =
+      (completionTokPerHour / 1_000_000) * (model.outputPriceMicro / 1_000_000) +
+      (promptTokPerHour / 1_000_000) * (model.inputPriceMicro / 1_000_000);
     const marginalWatts = config.inferWatts - config.idleWatts;
     const elecPerHour = (marginalWatts / 1000) * elecCostPerKWh;
     const netPerHour = revenuePerHour - elecPerHour;
-    const hoursPerMonth = hoursPerDay * 30;
+    const hoursPerMonth = hoursOnlinePerDay * 30;
     const monthlyRevenue = revenuePerHour * hoursPerMonth;
     const monthlyElec = elecPerHour * hoursPerMonth;
     const monthlyNet = netPerHour * hoursPerMonth;
-    const annualNet = monthlyNet * 12;
     const elecPercent = monthlyRevenue > 0 ? (monthlyElec / monthlyRevenue) * 100 : 0;
     return {
       modelId: model.id,
@@ -125,23 +172,27 @@
       monthlyRevenue,
       monthlyElec,
       monthlyNet,
-      annualNet,
       elecPercent,
     };
   }
 
-  function calculatePortfolioEarnings(models, config, ramGB, hoursPerDay, elecCostPerKWh) {
+  // Portfolio earnings = Σ per-model usage (models share active hours) PLUS the
+  // per-machine base-reward floor, minus electricity. total = usage + floor − elec.
+  function calculatePortfolioEarnings(models, config, ramGB, hoursOnlinePerDay, elecCostPerKWh) {
     if (!models.length) return null;
     const totalModelSizeGB = models.reduce((sum, model) => sum + model.modelSizeGB, 0);
     if (totalModelSizeGB > ramGB) return null;
-    const hoursPerModel = hoursPerDay / models.length;
+    const hoursPerModel = hoursOnlinePerDay / models.length;
     const selectedModels = models.map((model) =>
-      calculateModelEarnings(model, config, ramGB, hoursPerModel, elecCostPerKWh, totalModelSizeGB)
+      calculateModelEarnings(model, config, hoursPerModel, elecCostPerKWh)
     );
     const monthlyRevenue = selectedModels.reduce((sum, model) => sum + model.monthlyRevenue, 0);
     const monthlyElec = selectedModels.reduce((sum, model) => sum + model.monthlyElec, 0);
-    const monthlyNet = selectedModels.reduce((sum, model) => sum + model.monthlyNet, 0);
-    const activeHoursPerMonth = Math.max(1, hoursPerDay * 30);
+    const monthlyUsageNet = monthlyRevenue - monthlyElec;
+    const uptimeFrac = Math.min(1, hoursOnlinePerDay / 24);
+    const monthlyFloor = scaledFloorUSD(ramGB, uptimeFrac);
+    const monthlyNet = monthlyUsageNet + monthlyFloor;
+    const activeHoursPerMonth = Math.max(1, hoursOnlinePerDay * 30);
     return {
       modelName: models.length === 1 ? models[0].name : `${models.length} models selected`,
       selectedModels,
@@ -149,14 +200,18 @@
       totalModelSizeGB,
       hoursPerModel,
       decodeTokPerSec: selectedModels.reduce((sum, model) => sum + model.decodeTokPerSec, 0) / selectedModels.length,
-      revenuePerHour: monthlyRevenue / activeHoursPerMonth,
-      elecPerHour: monthlyElec / activeHoursPerMonth,
-      netPerHour: monthlyNet / activeHoursPerMonth,
       monthlyRevenue,
       monthlyElec,
+      monthlyUsageNet,
+      revenuePerHour: monthlyRevenue / activeHoursPerMonth,
+      elecPerHour: monthlyElec / activeHoursPerMonth,
+      netPerHour: monthlyUsageNet / activeHoursPerMonth,
+      elecPercent: monthlyRevenue > 0 ? (monthlyElec / monthlyRevenue) * 100 : 0,
+      memoryGB: ramGB,
+      uptimeFrac,
+      monthlyFloor,
       monthlyNet,
       annualNet: monthlyNet * 12,
-      elecPercent: monthlyRevenue > 0 ? (monthlyElec / monthlyRevenue) * 100 : 0,
     };
   }
 
@@ -176,7 +231,7 @@
     macType: "MacBook Pro",
     chip: "M4 Max",
     ram: 48,
-    hours: 18,
+    hours: 24,
     elecCost: detectRegionElec(),
     selectedModelIds: [],
   };
@@ -224,7 +279,7 @@
 
   function rankedModels(config, ramGB, elecCost) {
     const eligible = CATALOG_MODELS.filter((m) => m.minRAMGB <= ramGB);
-    const results = eligible.map((m) => calculateModelEarnings(m, config, ramGB, 18, elecCost));
+    const results = eligible.map((m) => calculateModelEarnings(m, config, 24, elecCost));
     results.sort((a, b) => b.monthlyNet - a.monthlyNet);
     return results;
   }
@@ -326,12 +381,12 @@
         '<span class="calc-model-net"></span>';
       row.querySelector(".calc-model-name").textContent = m.modelName;
       const netEl = row.querySelector(".calc-model-net");
-      netEl.textContent = fmtUSD(m.monthlyNet) + "/mo solo";
+      netEl.textContent = fmtUSD(m.monthlyNet) + "/mo usage";
       netEl.className = "calc-model-net " + (m.monthlyNet >= 0 ? "pos" : "neg");
       if (isBest && m.monthlyNet > 0) {
         const badge = document.createElement("span");
         badge.className = "calc-model-badge";
-        badge.textContent = "Best solo";
+        badge.textContent = "Best model";
         row.appendChild(badge);
       }
       row.onclick = () => {
@@ -358,7 +413,7 @@
         note.textContent =
           catalog.demandNote +
           (m.monthlyNet < 0
-            ? " This model loses money on your hardware — electricity exceeds revenue."
+            ? " Usage revenue is below electricity on your hardware — the base reward still applies."
             : "");
         modelList.appendChild(note);
       }
@@ -376,17 +431,31 @@
     emptyEl.style.display = "none";
     resultsEl.style.display = "block";
 
-    document.getElementById("res-model-name").textContent = result.modelName;
-    document.getElementById("res-hours").textContent = String(state.hours);
-    document.getElementById("res-monthly-net").textContent = fmtUSDWhole(result.monthlyNet);
-    document.getElementById("res-annual-net").textContent = fmtUSDWhole(result.annualNet) + " / year";
-    document.getElementById("res-decode").textContent = result.decodeTokPerSec.toFixed(1) + " tok/s avg";
-    document.getElementById("res-revenue").textContent = fmtUSD(result.monthlyRevenue);
-    document.getElementById("res-elec").textContent = "-" + fmtUSD(result.monthlyElec);
-    document.getElementById("res-elec-pct").textContent = result.elecPercent.toFixed(1) + "%";
-    document.getElementById("res-rev-hr").textContent = fmtUSD(result.revenuePerHour, 4);
-    document.getElementById("res-elec-hr").textContent = fmtUSD(result.elecPerHour, 4);
-    document.getElementById("res-net-hr").textContent = fmtUSD(result.netPerHour, 4);
+    const uptimePct = 100; // fixed: always-on, 100% utilization assumed
+    const setText = (id, text) => {
+      const el = document.getElementById(id);
+      if (el) el.textContent = text;
+    };
+
+    setText("res-model-name", result.modelName);
+    setText("res-monthly-net", fmtUSDWhole(result.monthlyNet));
+    setText("res-annual-net", fmtUSDWhole(result.annualNet) + " / year");
+    setText("res-usage", fmtUSD(result.monthlyUsageNet));
+    setText("res-floor", "+ " + fmtUSD(result.monthlyFloor));
+    setText("res-total", fmtUSD(result.monthlyNet));
+    setText("res-decode", result.decodeTokPerSec.toFixed(1) + " tok/s");
+    setText("res-revenue", fmtUSD(result.monthlyRevenue));
+    setText("res-elec", "-" + fmtUSD(result.monthlyElec));
+    setText("res-elec-pct", result.elecPercent.toFixed(1) + "%");
+    setText("res-rev-hr", fmtUSD(result.revenuePerHour, 4));
+    setText("res-elec-hr", fmtUSD(result.elecPerHour, 4));
+    setText("res-net-hr", fmtUSD(result.netPerHour, 4));
+
+    const floorNote = document.getElementById("res-floor-note");
+    if (floorNote) {
+      floorNote.textContent =
+        "Includes the " + effectiveRAM + "GB base reward at " + uptimePct + "% uptime.";
+    }
   }
 
   function initPricingTableCurrency() {
@@ -398,8 +467,6 @@
         minimumFractionDigits: min ?? 2,
         maximumFractionDigits: max ?? min ?? 2,
       }).format(n);
-    // Model prices can be sub-cent (e.g. $0.015, $0.165), so allow up to 4
-    // fraction digits here instead of rounding to 2.
     document.querySelectorAll(".op,.cp").forEach((el) => {
       const m = el.textContent.trim().match(/^\$?([\d.]+)$/);
       if (m) el.textContent = fc(+m[1], 2, 4);
@@ -422,14 +489,7 @@
       elecInput.value = String(state.elecCost);
       elecInput.addEventListener("input", render);
     }
-    const hrsSlider = document.getElementById("hrs-slider");
-    if (hrsSlider) {
-      hrsSlider.addEventListener("input", (e) => {
-        state.hours = +e.target.value;
-        document.getElementById("hrs-val").textContent = String(state.hours);
-        render();
-      });
-    }
+    // Utilization & hours are fixed at 100% / always-on — no slider.
     initPricingTableCurrency();
     render();
 

--- a/landing/earn-calculator.js
+++ b/landing/earn-calculator.js
@@ -2,12 +2,12 @@
  * Provider earnings calculator — keep in sync with console-ui/src/app/earn/calc.ts
  *
  * Earnings model: total = usage + floor − electricity
- *   • usage — realistic SINGLE-STREAM decode at 100% utilization (no batch
- *     multiplier: at the utilization the network actually sees a machine serves
- *     ~one request at a time, so the old 16×-batch ceiling overstated earnings).
+ *   • usage — realistic throughput at 80% utilization, crediting continuous
+ *     batching at a quality-preserving 4× (not the old 16× ceiling, which
+ *     overstated earnings).
  *   • floor — provider base reward (PR #282) by verified-memory tier, ramped by
  *     uptime, added ON TOP of usage (additive, not max).
- *   • elec — marginal inference watts over idle while online.
+ *   • elec — marginal inference watts over idle, scaled by utilization.
  */
 (function () {
   const MAC_TYPES = ["MacBook Air", "MacBook Pro", "Mac Mini", "Mac Studio", "Mac Pro"];
@@ -51,6 +51,11 @@
   const DEFAULT_INPUT_PRICE_MICRO = 50_000;
   // Sustained fraction of peak memory bandwidth for a single decode stream.
   const SINGLE_STREAM_EFFICIENCY = 0.6;
+  // Continuous-batching gain over single-stream at quality-preserving
+  // concurrency (capped at 4×, not the theoretical 16× ceiling).
+  const CONTINUOUS_BATCH_FACTOR = 4;
+  // Assumed network utilization (fraction of online time actively serving).
+  const ASSUMED_UTILIZATION = 0.8;
   // Network-observed prompt:completion token ratio (≈3.5:1 from /v1/stats).
   const PROMPT_TO_COMPLETION_RATIO = 3.5;
 
@@ -148,14 +153,16 @@
   // Per-model USAGE earnings at 100% utilization for hoursOnlinePerDay hours/day.
   // Single-stream throughput (no batch multiplier); floor is added separately.
   function calculateModelEarnings(model, config, hoursOnlinePerDay, elecCostPerKWh) {
-    const decodeTokPerSec = (config.bandwidthGBs / model.activeParamsGB) * SINGLE_STREAM_EFFICIENCY;
+    // Effective decode = single-stream × continuous batch (4×) × utilization (80%).
+    const singleTokPerSec = (config.bandwidthGBs / model.activeParamsGB) * SINGLE_STREAM_EFFICIENCY;
+    const decodeTokPerSec = singleTokPerSec * CONTINUOUS_BATCH_FACTOR * ASSUMED_UTILIZATION;
     const completionTokPerHour = decodeTokPerSec * 3600;
     const promptTokPerHour = completionTokPerHour * PROMPT_TO_COMPLETION_RATIO;
     const revenuePerHour =
       (completionTokPerHour / 1_000_000) * (model.outputPriceMicro / 1_000_000) +
       (promptTokPerHour / 1_000_000) * (model.inputPriceMicro / 1_000_000);
     const marginalWatts = config.inferWatts - config.idleWatts;
-    const elecPerHour = (marginalWatts / 1000) * elecCostPerKWh;
+    const elecPerHour = (marginalWatts / 1000) * elecCostPerKWh * ASSUMED_UTILIZATION;
     const netPerHour = revenuePerHour - elecPerHour;
     const hoursPerMonth = hoursOnlinePerDay * 30;
     const monthlyRevenue = revenuePerHour * hoursPerMonth;

--- a/landing/earn-calculator.js
+++ b/landing/earn-calculator.js
@@ -3,7 +3,7 @@
  *
  * Earnings model: total = usage + floor − electricity
  *   • usage — realistic throughput at 80% utilization, crediting continuous
- *     batching at a quality-preserving 4× (not the old 16× ceiling, which
+ *     batching at a quality-preserving 2× (not the old 16× ceiling, which
  *     overstated earnings).
  *   • floor — provider base reward (PR #282) by verified-memory tier, ramped by
  *     uptime, added ON TOP of usage (additive, not max).
@@ -52,8 +52,8 @@
   // Sustained fraction of peak memory bandwidth for a single decode stream.
   const SINGLE_STREAM_EFFICIENCY = 0.6;
   // Continuous-batching gain over single-stream at quality-preserving
-  // concurrency (capped at 4×, not the theoretical 16× ceiling).
-  const CONTINUOUS_BATCH_FACTOR = 4;
+  // concurrency (capped at 2×, not the theoretical 16× ceiling).
+  const CONTINUOUS_BATCH_FACTOR = 2;
   // Assumed network utilization (fraction of online time actively serving).
   const ASSUMED_UTILIZATION = 0.8;
   // Network-observed prompt:completion token ratio (≈3.5:1 from /v1/stats).
@@ -153,7 +153,7 @@
   // Per-model USAGE earnings at 100% utilization for hoursOnlinePerDay hours/day.
   // Single-stream throughput (no batch multiplier); floor is added separately.
   function calculateModelEarnings(model, config, hoursOnlinePerDay, elecCostPerKWh) {
-    // Effective decode = single-stream × continuous batch (4×) × utilization (80%).
+    // Effective decode = single-stream × continuous batch (2×) × utilization (80%).
     const singleTokPerSec = (config.bandwidthGBs / model.activeParamsGB) * SINGLE_STREAM_EFFICIENCY;
     const decodeTokPerSec = singleTokPerSec * CONTINUOUS_BATCH_FACTOR * ASSUMED_UTILIZATION;
     const completionTokPerHour = decodeTokPerSec * 3600;

--- a/landing/index.html
+++ b/landing/index.html
@@ -890,6 +890,18 @@
     .calc-detail-grid .lbl { font-family: var(--font-mono); font-size: 10px; color: var(--grey-02); letter-spacing: 0.02em; }
     .calc-detail-grid .val { font-family: var(--font-mono); font-size: 13px; font-weight: 500; margin-top: 4px; }
     .calc-detail-grid .val.neg { color: #b91c1c; }
+    .calc-breakdown { display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; margin-bottom: 24px; }
+    .calc-breakdown > div { text-align: center; padding: 12px; border-radius: var(--radius-sm); background: var(--off-white); border: 1px solid var(--grey-01); }
+    .calc-breakdown .lbl { font-family: var(--font-mono); font-size: 10px; color: var(--grey-03); letter-spacing: 0.02em; }
+    .calc-breakdown .val { font-family: var(--font-mono); font-size: 18px; font-weight: 600; margin-top: 4px; }
+    .calc-breakdown .sub { font-family: var(--font-mono); font-size: 9px; color: var(--grey-02); margin-top: 2px; }
+    .calc-breakdown .bd-floor .val { color: var(--eigen-blue); }
+    .calc-floor-note { font-family: var(--font-mono); font-size: 10px; color: var(--grey-03); margin-top: 12px; text-align: center; line-height: 1.5; }
+    .calc-util-note { font-family: var(--font-mono); font-size: 11px; color: var(--grey-03); line-height: 1.5; margin: 0 0 20px; padding: 10px 12px; background: var(--off-white); border-radius: var(--radius-sm); border: 1px solid var(--grey-01); }
+    .calc-floor-tiers { display: grid; grid-template-columns: repeat(auto-fit, minmax(74px, 1fr)); gap: 8px; margin-top: 12px; }
+    .calc-floor-tiers .ft { text-align: center; padding: 8px 4px; border-radius: var(--radius-sm); background: var(--off-white); border: 1px solid var(--grey-01); }
+    .calc-floor-tiers .ft .g { font-family: var(--font-mono); font-size: 10px; color: var(--grey-03); }
+    .calc-floor-tiers .ft .d { font-family: var(--font-mono); font-size: 14px; font-weight: 600; color: var(--black); margin-top: 2px; }
     .calc-empty {
       margin-top: 24px; padding: 24px; text-align: center; color: var(--grey-03); font-size: 14px;
       border: 1px solid var(--grey-01); border-radius: var(--radius-sm); line-height: 1.5;
@@ -1425,7 +1437,7 @@ response = client.chat.completions.create(
       <!-- Earnings Calculator (logic synced with console-ui/src/app/earn/page.tsx) -->
       <div class="calc-box rv">
         <h3>Earnings estimate</h3>
-        <p class="calc-desc">Select your hardware, model, active hours, and electricity cost to estimate provider earnings.</p>
+        <p class="calc-desc">Usage earnings (at full utilization) plus the base-reward floor your machine earns for staying online. Select your hardware, model, online hours, and electricity cost.</p>
         <div class="csec"><label class="clabel">1. Mac type</label><div class="pills" id="mac-sel"></div></div>
         <div style="display:grid;grid-template-columns:1fr 1fr;gap:24px;">
           <div class="csec"><label class="clabel">2. Chip</label><div class="pills" id="chip-sel"></div></div>
@@ -1436,41 +1448,55 @@ response = client.chat.completions.create(
           <p class="calc-hint" id="model-hint">Auto-selected: most profitable for your hardware</p>
           <div class="calc-model-list" id="model-list"></div>
         </div>
-        <div class="calc-sliders csec">
-          <div>
-            <label class="clabel">Inference hours per day: <span id="hrs-val" style="color:var(--eigen-blue);">18</span></label>
-            <input type="range" id="hrs-slider" min="1" max="24" value="18">
+        <div class="csec" style="margin-top:8px;">
+          <label class="clabel">Electricity cost</label>
+          <div class="calc-elec-wrap">
+            <span style="font-size:14px;color:var(--grey-03);">$</span>
+            <input type="number" id="elec-cost" step="0.01" min="0" value="0.15">
+            <span style="font-size:14px;color:var(--grey-03);">/kWh</span>
           </div>
-          <div>
-            <label class="clabel">Electricity cost</label>
-            <div class="calc-elec-wrap">
-              <span style="font-size:14px;color:var(--grey-03);">$</span>
-              <input type="number" id="elec-cost" step="0.01" min="0" value="0.15">
-              <span style="font-size:14px;color:var(--grey-03);">/kWh</span>
-            </div>
-            <p class="calc-elec-hint">US avg: $0.15 · EU avg: $0.25 · CA avg: $0.22</p>
-          </div>
+          <p class="calc-elec-hint">US avg: $0.15 · EU avg: $0.25 · CA avg: $0.22 · usage assumes 100% utilization, always-on</p>
         </div>
-        <div id="calc-empty" class="calc-empty" style="display:none;">No models fit in this memory configuration. Catalog models need at least 36 GB unified memory.</div>
+        <div id="calc-empty" class="calc-empty" style="display:none;">No live catalog model fits in this memory configuration. Choose a Mac with more memory.</div>
         <div id="calc-results" class="calc-results" style="display:none;">
-          <p class="calc-serving">Serving <strong id="res-model-name">—</strong> at <span id="res-hours">18</span> hrs/day</p>
+          <p class="calc-serving">Serving <strong id="res-model-name">—</strong> (always-on, 100% utilization)</p>
           <div class="calc-results-hero">
             <p class="calc-net-label">Monthly net earnings</p>
             <p class="calc-net-big" id="res-monthly-net">$0</p>
             <p class="calc-net-annual" id="res-annual-net">$0 / year</p>
           </div>
+          <p class="calc-util-note">Usage assumes 100% utilization — your Mac serving a request every second it's online. The live network runs well below that today; the base reward covers you while demand ramps, and usage takes over as the network fills up.</p>
+          <div class="calc-breakdown">
+            <div class="bd-usage"><div class="lbl">Usage (inference)</div><div class="val" id="res-usage">—</div><div class="sub">revenue − electricity</div></div>
+            <div class="bd-floor"><div class="lbl">+ Base reward</div><div class="val" id="res-floor">—</div><div class="sub">memory tier × uptime</div></div>
+            <div class="bd-total"><div class="lbl">= Total / mo</div><div class="val" id="res-total">—</div><div class="sub">usage + base reward</div></div>
+          </div>
           <div class="calc-detail-grid">
-            <div><div class="lbl">Batched decode speed</div><div class="val" id="res-decode">—</div></div>
-            <div><div class="lbl">Monthly revenue</div><div class="val" id="res-revenue">—</div></div>
+            <div><div class="lbl">Decode speed</div><div class="val" id="res-decode">—</div></div>
+            <div><div class="lbl">Monthly usage revenue</div><div class="val" id="res-revenue">—</div></div>
             <div><div class="lbl">Monthly electricity</div><div class="val neg" id="res-elec">—</div></div>
             <div><div class="lbl">Electricity % of revenue</div><div class="val" id="res-elec-pct">—</div></div>
-            <div><div class="lbl">Revenue per hour</div><div class="val" id="res-rev-hr">—</div></div>
+            <div><div class="lbl">Usage revenue per hour</div><div class="val" id="res-rev-hr">—</div></div>
             <div><div class="lbl">Electricity per hour</div><div class="val" id="res-elec-hr">—</div></div>
-            <div><div class="lbl">Net per hour</div><div class="val" id="res-net-hr">—</div></div>
+            <div><div class="lbl">Usage net per hour</div><div class="val" id="res-net-hr">—</div></div>
             <div><div class="lbl">Provider share</div><div class="val">100%</div></div>
           </div>
+          <p class="calc-floor-note" id="res-floor-note">—</p>
         </div>
-        <p id="calc-disc" style="font-family:var(--font-mono);font-size:10px;color:var(--grey-02);margin-top:16px;text-align:center;line-height:1.5;letter-spacing:0.01em;">Estimates only. Actual earnings depend on demand, model popularity, provider reputation, uptime, and local electricity cost.</p>
+        <div class="csec" style="margin-top:8px;">
+          <label class="clabel">Base reward by memory tier (paid on top of usage)</label>
+          <div class="calc-floor-tiers">
+            <div class="ft"><div class="g">24GB</div><div class="d">$10</div></div>
+            <div class="ft"><div class="g">32GB</div><div class="d">$12</div></div>
+            <div class="ft"><div class="g">48GB</div><div class="d">$16</div></div>
+            <div class="ft"><div class="g">64GB</div><div class="d">$18</div></div>
+            <div class="ft"><div class="g">96GB</div><div class="d">$22</div></div>
+            <div class="ft"><div class="g">128GB</div><div class="d">$26</div></div>
+            <div class="ft"><div class="g">192GB</div><div class="d">$30</div></div>
+            <div class="ft"><div class="g">512GB</div><div class="d">$40</div></div>
+          </div>
+        </div>
+        <p id="calc-disc" style="font-family:var(--font-mono);font-size:10px;color:var(--grey-02);margin-top:16px;text-align:center;line-height:1.5;letter-spacing:0.01em;">Estimates only. Usage assumes 100% utilization; the live network runs lower today. Base rewards go to attested machines online ≥90% of the month, up to a fixed monthly budget — not a guarantee, and they taper as the network grows. Actual earnings depend on demand, model popularity, reputation, uptime, and local electricity cost.</p>
       </div>
 
       <!-- Paper CTA -->

--- a/landing/index.html
+++ b/landing/index.html
@@ -1465,7 +1465,7 @@ response = client.chat.completions.create(
             <p class="calc-net-big" id="res-monthly-net">$0</p>
             <p class="calc-net-annual" id="res-annual-net">$0 / year</p>
           </div>
-          <p class="calc-util-note">Usage assumes 80% utilization with continuous batching (4× concurrent requests at full speed). Real demand varies by model and time of day; the base reward covers you while the network is quiet, and usage scales up as it fills.</p>
+          <p class="calc-util-note">Usage assumes 80% utilization with continuous batching (2× concurrent requests at full speed). Real demand varies by model and time of day; the base reward covers you while the network is quiet, and usage scales up as it fills.</p>
           <div class="calc-breakdown">
             <div class="bd-usage"><div class="lbl">Usage (inference)</div><div class="val" id="res-usage">—</div><div class="sub">revenue − electricity</div></div>
             <div class="bd-floor"><div class="lbl">+ Base reward</div><div class="val" id="res-floor">—</div><div class="sub">memory tier × uptime</div></div>
@@ -1496,7 +1496,7 @@ response = client.chat.completions.create(
             <div class="ft"><div class="g">512GB</div><div class="d">$40</div></div>
           </div>
         </div>
-        <p id="calc-disc" style="font-family:var(--font-mono);font-size:10px;color:var(--grey-02);margin-top:16px;text-align:center;line-height:1.5;letter-spacing:0.01em;">Estimates only. Usage assumes 80% utilization with continuous batching (4×); the live network runs lower today. Base rewards go to attested machines online ≥90% of the month, up to a fixed monthly budget — not a guarantee, and they taper as the network grows. Actual earnings depend on demand, model popularity, reputation, uptime, and local electricity cost.</p>
+        <p id="calc-disc" style="font-family:var(--font-mono);font-size:10px;color:var(--grey-02);margin-top:16px;text-align:center;line-height:1.5;letter-spacing:0.01em;">Estimates only. Usage assumes 80% utilization with continuous batching (2×); the live network runs lower today. Base rewards go to attested machines online ≥90% of the month, up to a fixed monthly budget — not a guarantee, and they taper as the network grows. Actual earnings depend on demand, model popularity, reputation, uptime, and local electricity cost.</p>
       </div>
 
       <!-- Paper CTA -->

--- a/landing/index.html
+++ b/landing/index.html
@@ -1455,17 +1455,17 @@ response = client.chat.completions.create(
             <input type="number" id="elec-cost" step="0.01" min="0" value="0.15">
             <span style="font-size:14px;color:var(--grey-03);">/kWh</span>
           </div>
-          <p class="calc-elec-hint">US avg: $0.15 · EU avg: $0.25 · CA avg: $0.22 · usage assumes 100% utilization, always-on</p>
+          <p class="calc-elec-hint">US avg: $0.15 · EU avg: $0.25 · CA avg: $0.22 · usage assumes 80% utilization, always-on</p>
         </div>
         <div id="calc-empty" class="calc-empty" style="display:none;">No live catalog model fits in this memory configuration. Choose a Mac with more memory.</div>
         <div id="calc-results" class="calc-results" style="display:none;">
-          <p class="calc-serving">Serving <strong id="res-model-name">—</strong> (always-on, 100% utilization)</p>
+          <p class="calc-serving">Serving <strong id="res-model-name">—</strong> (always-on, 80% utilization)</p>
           <div class="calc-results-hero">
             <p class="calc-net-label">Monthly net earnings</p>
             <p class="calc-net-big" id="res-monthly-net">$0</p>
             <p class="calc-net-annual" id="res-annual-net">$0 / year</p>
           </div>
-          <p class="calc-util-note">Usage assumes 100% utilization — your Mac serving a request every second it's online. The live network runs well below that today; the base reward covers you while demand ramps, and usage takes over as the network fills up.</p>
+          <p class="calc-util-note">Usage assumes 80% utilization with continuous batching (4× concurrent requests at full speed). Real demand varies by model and time of day; the base reward covers you while the network is quiet, and usage scales up as it fills.</p>
           <div class="calc-breakdown">
             <div class="bd-usage"><div class="lbl">Usage (inference)</div><div class="val" id="res-usage">—</div><div class="sub">revenue − electricity</div></div>
             <div class="bd-floor"><div class="lbl">+ Base reward</div><div class="val" id="res-floor">—</div><div class="sub">memory tier × uptime</div></div>
@@ -1496,7 +1496,7 @@ response = client.chat.completions.create(
             <div class="ft"><div class="g">512GB</div><div class="d">$40</div></div>
           </div>
         </div>
-        <p id="calc-disc" style="font-family:var(--font-mono);font-size:10px;color:var(--grey-02);margin-top:16px;text-align:center;line-height:1.5;letter-spacing:0.01em;">Estimates only. Usage assumes 100% utilization; the live network runs lower today. Base rewards go to attested machines online ≥90% of the month, up to a fixed monthly budget — not a guarantee, and they taper as the network grows. Actual earnings depend on demand, model popularity, reputation, uptime, and local electricity cost.</p>
+        <p id="calc-disc" style="font-family:var(--font-mono);font-size:10px;color:var(--grey-02);margin-top:16px;text-align:center;line-height:1.5;letter-spacing:0.01em;">Estimates only. Usage assumes 80% utilization with continuous batching (4×); the live network runs lower today. Base rewards go to attested machines online ≥90% of the month, up to a fixed monthly budget — not a guarantee, and they taper as the network grows. Actual earnings depend on demand, model popularity, reputation, uptime, and local electricity cost.</p>
       </div>
 
       <!-- Paper CTA -->

--- a/landing/index.html
+++ b/landing/index.html
@@ -1465,7 +1465,7 @@ response = client.chat.completions.create(
             <p class="calc-net-big" id="res-monthly-net">$0</p>
             <p class="calc-net-annual" id="res-annual-net">$0 / year</p>
           </div>
-          <p class="calc-util-note">Usage assumes 80% utilization with continuous batching (2× concurrent requests at full speed). Real demand varies by model and time of day; the base reward covers you while the network is quiet, and usage scales up as it fills.</p>
+          <p class="calc-util-note">Usage assumes 80% utilization with continuous batching (4× concurrent requests at full speed). Real demand varies by model and time of day; the base reward covers you while the network is quiet, and usage scales up as it fills.</p>
           <div class="calc-breakdown">
             <div class="bd-usage"><div class="lbl">Usage (inference)</div><div class="val" id="res-usage">—</div><div class="sub">revenue − electricity</div></div>
             <div class="bd-floor"><div class="lbl">+ Base reward</div><div class="val" id="res-floor">—</div><div class="sub">memory tier × uptime</div></div>
@@ -1496,7 +1496,7 @@ response = client.chat.completions.create(
             <div class="ft"><div class="g">512GB</div><div class="d">$40</div></div>
           </div>
         </div>
-        <p id="calc-disc" style="font-family:var(--font-mono);font-size:10px;color:var(--grey-02);margin-top:16px;text-align:center;line-height:1.5;letter-spacing:0.01em;">Estimates only. Usage assumes 80% utilization with continuous batching (2×); the live network runs lower today. Base rewards go to attested machines online ≥90% of the month, up to a fixed monthly budget — not a guarantee, and they taper as the network grows. Actual earnings depend on demand, model popularity, reputation, uptime, and local electricity cost.</p>
+        <p id="calc-disc" style="font-family:var(--font-mono);font-size:10px;color:var(--grey-02);margin-top:16px;text-align:center;line-height:1.5;letter-spacing:0.01em;">Estimates only. Usage assumes 80% utilization with continuous batching (4×); the live network runs lower today. Base rewards go to attested machines online ≥90% of the month, up to a fixed monthly budget — not a guarantee, and they taper as the network grows. Actual earnings depend on demand, model popularity, reputation, uptime, and local electricity cost.</p>
       </div>
 
       <!-- Paper CTA -->


### PR DESCRIPTION
## Summary

Reworks the provider earnings calculators (`console-ui` `/earn` + the `darkbloom.dev` landing page) to show realistic numbers instead of the inflated full-saturation projection.

**New model:**

```
total = usage + floor − electricity
```

- **Usage** — realistic **single-stream** decode throughput at **100% utilization** (the machine serves a request every second it's online). The old calculator multiplied by a **16× batch factor** AND assumed 100% paid duty cycle, overstating earnings by **~10–20×** vs the live network, which runs at **~4% utilization** (~one concurrent request per machine). Per product direction, **utilization and hours are fixed at 100% / always-on** — no user-facing knobs — to keep the UX simple.
- **Floor** — the provider **base-reward floor** (PR #282), set by verified-memory tier, ramped by uptime, **added on top of usage (additive)**, not `max(usage, floor)`.
- **Electricity** — marginal inference watts over idle.

Revenue now also **counts input tokens** (at the network-observed **3.5:1** prompt:completion ratio from `/v1/stats`) in addition to output, so the usage figure matches what providers actually earn per request.

### Why the old number was ~10–20× too high

The old calculator was a **hardware ceiling presented as a forecast** with no demand term:
- 16× batch multiplier (assumes 16 paying users hammering one machine every second)
- 100% duty cycle (every generated token sold)
- Combined: ~14× (batch) × ~24× (utilization) inflation, partly offset by output-only pricing

Ground truth from the live `/v1/network/totals` + `/v1/stats` endpoints validates the new model: `single_stream × utilization` summed over the fleet reproduces the actual realized decode (~150 tok/s) and the actual 30-day work earnings (~$80) almost exactly.

### Headline number (sanity-checked against the live endpoint)

**M5 Max 128GB, gpt-oss-20b, 100% utilization, always-on:**
- usage net: **~$25/mo**
- base reward (128GB tier): **+$26/mo**
- electricity: **−$3/mo**
- **total: ~$51/mo** (vs the old calculator's **~$241/mo**)

## Mirrored surfaces

| File | Change |
|---|---|
| `console-ui/src/app/earn/calc.ts` (new) | Pure earnings math (single-stream + floor, additive) |
| `console-ui/src/components/earn/BaseRewardsPanel.tsx` (new) | Floor-tier explainer panel |
| `console-ui/src/app/earn/page.tsx` | Rewired to the module; removed hours slider; 100% utilization fixed; additive breakdown UI |
| `console-ui/__tests__/earn-page.test.tsx` | Updated copy assertion + locks in additive floor (`+ $16.00` for the 48GB tier) |
| `landing/earn-calculator.js` | Mirror of `calc.ts` math; removed hours slider; fixed 100% / 24h |
| `landing/index.html` | New result breakdown + floor-tier table; updated copy + disclaimer |

## Important sync point: PR #282

PR #282's engine currently computes `payout = max(usage, floor)`. **This calculator assumes the additive model** (`usage + floor`) the program will ship. The displayed numbers will match the actual payouts once #282 switches `Draw` from `max()` to additive. Flagging explicitly so the two changes land coherently.

## Verification

- `npm run build` (console-ui): ✅ green
- `npx eslint src/app/earn src/components/earn`: ✅ 0 errors
- `npx vitest run`: ✅ 306/306 pass (incl. updated `earn-page.test.tsx`)
- `landing/earn-calculator.js`: `node --check` ✅; math smoke-test reproduces the M5 Max ~$51/mo figure

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/414"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784514713&installation_id=133247490&pr_number=414&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F414&signature=d006d98b392364171cfb9c1df831367a2686d81ca71334cd0da197f1df68cd9c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->