### PR TITLE
fix(provider): adopt upstream-fixed Gemma 4 chat template via non-mutating override (DAR-329)

### DIFF
--- a/provider-swift/Sources/ProviderCore/Inference/LocalTokenizerLoader.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/LocalTokenizerLoader.swift
@@ -13,6 +13,7 @@
 
 import Foundation
 import MLXLMCommon
+import ProviderCoreFoundation
 import Tokenizers
 
 public struct LocalTokenizerLoader: TokenizerLoader, Sendable {
@@ -20,7 +21,14 @@ public struct LocalTokenizerLoader: TokenizerLoader, Sendable {
 
     public func load(from directory: URL) async throws -> any MLXLMCommon.Tokenizer {
         let upstream = try await AutoTokenizer.from(modelFolder: directory)
-        return LocalTokenizerBridge(upstream)
+        // DAR-329: if the snapshot ships a known-broken `chat_template.jinja`
+        // (e.g. the outdated Gemma 4 tool template), render with the corrected
+        // upstream revision instead. Non-mutating — the on-disk file is left
+        // untouched so the model's attestation/integrity hash still matches the
+        // registry manifest; the corrected template is injected only at render
+        // time via swift-transformers' `.literal` chat-template argument.
+        let templateOverride = ChatTemplateOverride.correctedTemplate(forSnapshotDir: directory)
+        return LocalTokenizerBridge(upstream, chatTemplateOverride: templateOverride)
     }
 }
 
@@ -31,9 +39,15 @@ public struct LocalTokenizerLoader: TokenizerLoader, Sendable {
 /// library is internally thread-safe (read-only after construction).
 private struct LocalTokenizerBridge: @unchecked Sendable, MLXLMCommon.Tokenizer {
     private let upstream: any Tokenizers.Tokenizer
+    /// When set, the chat template the baked tokenizer config would use is
+    /// replaced at render time by this corrected template string (DAR-329).
+    /// `nil` for every model whose on-disk template is not a known-broken
+    /// revision — those keep the exact baked-template path unchanged.
+    private let chatTemplateOverride: String?
 
-    init(_ upstream: any Tokenizers.Tokenizer) {
+    init(_ upstream: any Tokenizers.Tokenizer, chatTemplateOverride: String? = nil) {
         self.upstream = upstream
+        self.chatTemplateOverride = chatTemplateOverride
     }
 
     func encode(text: String, addSpecialTokens: Bool) -> [Int] {
@@ -62,6 +76,21 @@ private struct LocalTokenizerBridge: @unchecked Sendable, MLXLMCommon.Tokenizer 
         additionalContext: [String: any Sendable]?
     ) throws -> [Int] {
         do {
+            if let chatTemplateOverride {
+                // Render with the corrected template (same messages/tools/
+                // special-token context as the baked path — swift-transformers
+                // injects those regardless of where the template string comes
+                // from), so output matches a registry republish of the fix.
+                return try upstream.applyChatTemplate(
+                    messages: messages,
+                    chatTemplate: .literal(chatTemplateOverride),
+                    addGenerationPrompt: true,
+                    truncation: false,
+                    maxLength: nil,
+                    tools: tools,
+                    additionalContext: additionalContext
+                )
+            }
             return try upstream.applyChatTemplate(
                 messages: messages,
                 tools: tools,

--- a/provider-swift/Sources/ProviderCoreFoundation/ChatTemplateOverride.swift
+++ b/provider-swift/Sources/ProviderCoreFoundation/ChatTemplateOverride.swift
@@ -1,0 +1,85 @@
+// Copyright © 2026 Eigen Labs.
+//
+// Hash-gated, NON-MUTATING chat-template override (DAR-329).
+//
+// Some published model snapshots ship a `chat_template.jinja` that throws at
+// request time on legitimate request shapes (see `GemmaToolTemplate` for the
+// Gemma 4 case: unguarded `value['type'] | upper` over union / typeless / null
+// tool-schema fields). The durable fix is to render with the upstream-fixed
+// template instead — WITHOUT touching the bytes on disk.
+//
+// Why non-mutating: `chat_template.jinja` is part of the model's integrity set
+// (`ModelScanner.integrityFileNames`), so `WeightHasher.computeHash` — the
+// attestation / integrity hash the provider reports — hashes it. Rewriting the
+// file on disk would change that hash and break the match against the published
+// registry manifest (which was built from the original template), failing
+// attestation. So instead we keep the file untouched and substitute the
+// corrected template ONLY at the two render chokepoints:
+//
+//   • `TemplateRenderCheck.renderOK` (scan-time self-check → `template_render_ok`)
+//   • `LocalTokenizerLoader` / `LocalTokenizerBridge.applyChatTemplate`
+//     (runtime tokenize, via swift-transformers' `.literal` template argument)
+//
+// Gating on the on-disk template's SHA-256 keeps this surgical: it fires ONLY
+// for the exact known-broken revision and self-disables the moment the registry
+// republishes a corrected template (the on-disk hash stops matching). It never
+// touches any other model or any healthy template, and — because the corrected
+// template renders byte-identically for healthy inputs (covered by tests) — it
+// is behavior-preserving outside the previously-crashing shapes.
+//
+// Relationship to `ToolSchemaNormalization` (DAR-130): that pass already
+// collapses union types and defaults typeless nodes within
+// `tools[].function.parameters` before render, so the common tool path is
+// protected even with the old template. This override removes the reliance on
+// that (lossy) normalization for Gemma: it renders unions faithfully and also
+// covers paths normalization does not walk (e.g. `function.response`). Both
+// layers are kept — normalization still defends every OTHER model's template.
+
+import Crypto
+import Foundation
+
+public enum ChatTemplateOverride {
+
+    /// Map of known-broken `chat_template.jinja` SHA-256 (lowercase hex) to the
+    /// corrected template text to render in its place.
+    ///
+    /// Keyed by content hash (not model ID) so the substitution is exact and
+    /// self-limiting. Add an entry per known-broken published revision.
+    static let replacements: [String: String] = [
+        GemmaToolTemplate.brokenSHA256: GemmaToolTemplate.correctedToolTemplate
+    ]
+
+    /// Corrected template for a raw template STRING, or `nil` when the string is
+    /// not a known-broken revision. Pure; does not touch disk. Used by the
+    /// scan-time render self-check, which already holds the template text.
+    public static func corrected(forTemplate template: String) -> String? {
+        corrected(forTemplate: template, using: replacements)
+    }
+
+    /// Corrected template for the `chat_template.jinja` in a model snapshot
+    /// directory, or `nil` when the file is absent or not a known-broken
+    /// revision. Reads (but never writes) the on-disk file. Used at tokenizer
+    /// load so the runtime render uses the corrected template via swift-
+    /// transformers' `.literal` chat-template argument.
+    public static func correctedTemplate(forSnapshotDir snapshotDir: URL) -> String? {
+        correctedTemplate(forSnapshotDir: snapshotDir, using: replacements)
+    }
+
+    // MARK: - Testable cores (replacement map injected)
+
+    static func corrected(forTemplate template: String, using map: [String: String]) -> String? {
+        map[sha256Hex(Data(template.utf8))]
+    }
+
+    static func correctedTemplate(forSnapshotDir snapshotDir: URL, using map: [String: String]) -> String? {
+        let url = snapshotDir.appendingPathComponent("chat_template.jinja")
+        guard let data = try? Data(contentsOf: url) else { return nil }
+        return map[sha256Hex(data)]
+    }
+
+    /// Lowercase-hex SHA-256, matching `WeightHasher`'s digest formatting and
+    /// the `shasum -a 256` values pinned in `GemmaToolTemplate`.
+    static func sha256Hex(_ data: Data) -> String {
+        SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
+    }
+}

--- a/provider-swift/Sources/ProviderCoreFoundation/GemmaToolTemplate.swift
+++ b/provider-swift/Sources/ProviderCoreFoundation/GemmaToolTemplate.swift
@@ -1,0 +1,437 @@
+// Copyright © 2026 Eigen Labs.
+//
+// Vendored, upstream-fixed Gemma 4 tool-calling chat template (DAR-329).
+//
+// The `mlx-community/gemma-4-26B-A4B-it-qat-4bit` snapshot we serve ships an
+// OUTDATED `chat_template.jinja` whose tool-schema rendering pipes `| upper`
+// (and `| map('upper')`) over `value['type']` WITHOUT a null/Optional guard.
+// swift-jinja's `upper` filter throws `"upper filter requires string"` on any
+// non-string value, so a tool whose schema carries a union type
+// (`"type": ["string","null"]`), omits `type`, or whose enum holds a
+// non-string element renders to a hard 500 (`Jinja.TemplateException`).
+//
+// The fixed upstream revision — published as
+// `lmstudio-community/gemma-4-26B-A4B-it-QAT-MLX-4bit` — null-guards every
+// `type` access and adds a `format_type_argument` macro that handles string /
+// list / absent type values. The two repos are the SAME qat-4bit weights and
+// tokenizer (byte-identical safetensors + tokenizer.json); the ONLY functional
+// delta is this template, so adopting it is a template-only fix that needs no
+// requant / reweight / tokenizer change.
+//
+// This is the verified upstream file, embedded byte-for-byte (see
+// `GemmaToolTemplateTests`, which asserts the sha256 below and that it renders
+// every canonical fixture in the exact swift-jinja engine the runtime uses).
+// It is applied as a NON-MUTATING, hash-gated render-time override
+// (`ChatTemplateOverride`): the on-disk `chat_template.jinja` is left untouched
+// so the model's attestation/integrity hash (`WeightHasher.computeHash`, which
+// includes `chat_template.jinja`) keeps matching the published registry
+// manifest. The override self-disables automatically once the registry
+// republishes the corrected template (the on-disk hash stops matching).
+//
+// Provenance / regeneration:
+//   curl -sSL https://huggingface.co/lmstudio-community/gemma-4-26B-A4B-it-QAT-MLX-4bit/resolve/main/chat_template.jinja
+//   (sha256 29af862bccabb14b90a4ff951bcd14c33fe74b651c5f07fc7f2e9aa46a59fe7c)
+
+import Foundation
+
+public enum GemmaToolTemplate {
+    /// sha256 of `mlx-community/gemma-4-26B-A4B-it-qat-4bit`'s shipped
+    /// (broken) `chat_template.jinja` — the exact revision this override
+    /// replaces. Gating on the content hash keeps the override surgical: it
+    /// fires ONLY for that one known-broken file and no other model/template.
+    public static let brokenSHA256 =
+        "94899c0f917d93f6fe81c95744d1e8ddab2d21d39228d2e4aec1fb2a25bff413"
+
+    /// sha256 of the embedded corrected template below (the upstream
+    /// `lmstudio-community` revision). Pinned so a test can prove the vendored
+    /// bytes are exactly the verified upstream file.
+    public static let correctedSHA256 =
+        "29af862bccabb14b90a4ff951bcd14c33fe74b651c5f07fc7f2e9aa46a59fe7c"
+
+    /// The upstream-fixed Gemma 4 tool-calling chat template, byte-for-byte.
+    public static let correctedToolTemplate: String = #"""
+{%- macro format_type_argument(type_value) -%}
+    {%- if type_value is string -%}
+        {{- '<|"|>' + (type_value | upper) + '<|"|>' -}}
+    {%- elif type_value is iterable -%}
+        [
+        {%- for item in type_value -%}
+            <|"|>{{- item | upper -}}<|"|>
+            {%- if not loop.last %},{% endif -%}
+        {%- endfor -%}
+        ]
+    {%- else -%}
+        {{- format_argument(type_value) -}}
+    {%- endif -%}
+{%- endmacro -%}
+{%- macro format_parameters(properties, required, filter_keys=false) -%}
+    {%- set standard_keys = ['description', 'type', 'properties', 'required', 'nullable'] -%}
+    {%- set ns = namespace(found_first=false) -%}
+    {%- for key, value in properties | dictsort -%}
+        {%- set add_comma = false -%}
+        {%- if not filter_keys or key not in standard_keys -%}
+            {%- if ns.found_first %},{% endif -%}
+            {%- set ns.found_first = true -%}
+            {{ key }}:{
+            {%- if value['description'] -%}
+                description:<|"|>{{ value['description'] }}<|"|>
+                {%- set add_comma = true -%}
+            {%- endif -%}
+            {%- if value['type'] and ('string' in value['type'] or 'STRING' in value['type']) -%}
+                {%- if value['enum'] -%}
+                    {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                    enum:{{ format_argument(value['enum']) }}
+                {%- endif -%}
+            {%- elif value['type'] and ('array' in value['type'] or 'ARRAY' in value['type']) -%}
+                {%- if value['items'] is mapping and value['items'] -%}
+                    {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                    items:{
+                    {%- set ns_items = namespace(found_first=false) -%}
+                    {%- for item_key, item_value in value['items'] | dictsort -%}
+                        {%- if item_value is not none -%}
+                            {%- if ns_items.found_first %},{% endif -%}
+                            {%- set ns_items.found_first = true -%}
+                            {%- if item_key == 'properties' -%}
+                                properties:{
+                                {%- if item_value is mapping -%}
+                                    {{- format_parameters(item_value, value['items']['required'] | default([])) -}}
+                                {%- endif -%}
+                                }
+                            {%- elif item_key == 'required' -%}
+                                required:[
+                                {%- for req_item in item_value -%}
+                                    <|"|>{{- req_item -}}<|"|>
+                                    {%- if not loop.last %},{% endif -%}
+                                {%- endfor -%}
+                                ]
+                            {%- elif item_key == 'type' -%}
+                                type:{{ format_type_argument(item_value) }}
+                            {%- else -%}
+                                {{ item_key }}:{{ format_argument(item_value) }}
+                            {%- endif -%}
+                        {%- endif -%}
+                    {%- endfor -%}
+                    }
+                {%- endif -%}
+            {%- endif -%}
+            {%- if value['nullable'] %}
+                {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                nullable:true
+            {%- endif -%}
+            {%- if value['type'] and ('object' in value['type'] or 'OBJECT' in value['type']) -%}
+                {%- if value['properties'] is defined and value['properties'] is mapping -%}
+                    {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                    properties:{
+                    {{- format_parameters(value['properties'], value['required'] | default([])) -}}
+                    }
+                {%- elif value is mapping -%}
+                    {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                    properties:{
+                    {{- format_parameters(value, value['required'] | default([]), filter_keys=true) -}}
+                    }
+                {%- endif -%}
+                {%- if value['required'] -%}
+                    {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                    required:[
+                    {%- for item in value['required'] | default([]) -%}
+                        <|"|>{{- item -}}<|"|>
+                        {%- if not loop.last %},{% endif -%}
+                    {%- endfor -%}
+                    ]
+                {%- endif -%}
+            {%- endif -%}
+            {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+            type:{{ format_type_argument(value['type']) }}}
+        {%- endif -%}
+    {%- endfor -%}
+{%- endmacro -%}
+{%- macro format_function_declaration(tool_data) -%}
+    declaration:{{- tool_data['function']['name'] -}}{description:<|"|>{{- tool_data['function']['description'] -}}<|"|>
+    {%- set params = tool_data['function']['parameters'] -%}
+    {%- if params -%}
+        ,parameters:{
+        {%- set ns_params = namespace(found_first=false) -%}
+        {%- if params['properties'] -%}
+            properties:{ {{- format_parameters(params['properties'], params['required']) -}} }
+            {%- set ns_params.found_first = true -%}
+        {%- endif -%}
+        {%- if params['required'] -%}
+            {%- if ns_params.found_first %},{% endif -%}
+            required:[
+            {%- for item in params['required'] -%}
+                <|"|>{{- item -}}<|"|>
+                {{- ',' if not loop.last -}}
+            {%- endfor -%}
+            ]
+            {%- set ns_params.found_first = true -%}
+        {%- endif -%}
+        {%- if params['type'] -%}
+            {%- if ns_params.found_first %},{% endif -%}
+            type:{{- format_type_argument(params['type']) -}}
+        {%- endif -%}
+        }
+    {%- endif -%}
+    {%- if 'response' in tool_data['function'] -%}
+        {%- set response_declaration = tool_data['function']['response'] -%}
+        ,response:{
+        {%- set ns_response = namespace(found_first=false) -%}
+        {%- if response_declaration['description'] -%}
+            description:<|"|>{{- response_declaration['description'] -}}<|"|>
+            {%- set ns_response.found_first = true -%}
+        {%- endif -%}
+        {%- if response_declaration['type'] -%}
+            {%- if ns_response.found_first %},{% endif -%}
+            type:{{- format_type_argument(response_declaration['type']) -}}
+        {%- endif -%}
+        }
+    {%- endif -%}
+    }
+{%- endmacro -%}
+{%- macro format_argument(argument, escape_keys=True) -%}
+    {%- if argument is string -%}
+        {{- '<|"|>' + argument + '<|"|>' -}}
+    {%- elif argument is boolean -%}
+        {{- 'true' if argument else 'false' -}}
+    {%- elif argument is mapping -%}
+        {{- '{' -}}
+        {%- set ns = namespace(found_first=false) -%}
+        {%- for key, value in argument | dictsort -%}
+            {%- if ns.found_first %},{% endif -%}
+            {%- set ns.found_first = true -%}
+            {%- if escape_keys -%}
+                {{- '<|"|>' + key + '<|"|>' -}}
+            {%- else -%}
+                {{- key -}}
+            {%- endif -%}
+            :{{- format_argument(value, escape_keys=escape_keys) -}}
+        {%- endfor -%}
+        {{- '}' -}}
+    {%- elif argument is iterable -%}
+        {{- '[' -}}
+        {%- for item in argument -%}
+            {{- format_argument(item, escape_keys=escape_keys) -}}
+            {%- if not loop.last %},{% endif -%}
+        {%- endfor -%}
+        {{- ']' -}}
+    {%- else -%}
+        {{- argument -}}
+    {%- endif -%}
+{%- endmacro -%}
+{%- macro strip_thinking(text) -%}
+    {%- set ns = namespace(result='') -%}
+    {%- for part in text.split('<channel|>') -%}
+        {%- if '<|channel>' in part -%}
+            {%- set ns.result = ns.result + part.split('<|channel>')[0] -%}
+        {%- else -%}
+            {%- set ns.result = ns.result + part -%}
+        {%- endif -%}
+    {%- endfor -%}
+    {{- ns.result | trim -}}
+{%- endmacro -%}
+
+{%- macro format_tool_response_block(tool_name, response) -%}
+    {{- '<|tool_response>' -}}
+    {%- if response is mapping -%}
+        {{- 'response:' + tool_name + '{' -}}
+        {%- for key, value in response | dictsort -%}
+            {{- key -}}:{{- format_argument(value, escape_keys=False) -}}
+            {%- if not loop.last %},{% endif -%}
+        {%- endfor -%}
+        {{- '}' -}}
+    {%- else -%}
+        {{- 'response:' + tool_name + '{value:' + format_argument(response, escape_keys=False) + '}' -}}
+    {%- endif -%}
+    {{- '<tool_response|>' -}}
+{%- endmacro -%}
+
+{%- set ns = namespace(prev_message_type=None) -%}
+{%- set loop_messages = messages -%}
+{{- bos_token -}}
+{#- Handle System/Tool Definitions Block -#}
+{%- if (enable_thinking is defined and enable_thinking) or tools or messages[0]['role'] in ['system', 'developer'] -%}
+    {{- '<|turn>system\n' -}}
+    {#- Inject Thinking token at the very top of the FIRST system turn -#}
+    {%- if enable_thinking is defined and enable_thinking -%}
+        {{- '<|think|>\n' -}}
+        {%- set ns.prev_message_type = 'think' -%}
+    {%- endif -%}
+    {%- if messages[0]['role'] in ['system', 'developer'] -%}
+        {%- if messages[0]['content'] is string -%}
+            {{- messages[0]['content'] | trim -}}
+        {%- elif messages[0]['content'] is iterable -%}
+            {%- for item in messages[0]['content'] -%}
+                {{- item['text'] | trim + ' '-}}
+            {%- endfor -%}
+        {%- endif -%}
+        {%- set loop_messages = messages[1:] -%}
+    {%- endif -%}
+    {%- if tools -%}
+        {%- for tool in tools %}
+            {{- '<|tool>' -}}
+            {{- format_function_declaration(tool) | trim -}}
+            {{- '<tool|>' -}}
+        {%- endfor %}
+        {%- set ns.prev_message_type = 'tool' -%}
+    {%- endif -%}
+    {{- '<turn|>\n' -}}
+{%- endif %}
+
+{#- Pre-scan: find last user message index for reasoning guard -#}
+{%- set ns_turn = namespace(last_user_idx=-1) -%}
+{%- for i in range(loop_messages | length) -%}
+    {%- if loop_messages[i]['role'] == 'user' -%}
+        {%- set ns_turn.last_user_idx = i -%}
+    {%- endif -%}
+{%- endfor -%}
+
+{#- Loop through messages -#}
+{%- for message in loop_messages -%}
+    {%- if message['role'] != 'tool' -%}
+    {%- set ns.prev_message_type = None -%}
+    {%- set role = 'model' if message['role'] == 'assistant' else message['role'] -%}
+    {#- Detect continuation: suppress duplicate <|turn>model when previous non-tool message was also assistant -#}
+    {%- set prev_nt = namespace(role=None, found=false) -%}
+    {%- if loop.index0 > 0 -%}
+        {%- for j in range(loop.index0 - 1, -1, -1) -%}
+            {%- if not prev_nt.found -%}
+                {%- if loop_messages[j]['role'] != 'tool' -%}
+                    {%- set prev_nt.role = loop_messages[j]['role'] -%}
+                    {%- set prev_nt.found = true -%}
+                {%- endif -%}
+            {%- endif -%}
+        {%- endfor -%}
+    {%- endif -%}
+    {%- set continue_same_model_turn = (role == 'model' and prev_nt.role == 'assistant') -%}
+    {%- if not continue_same_model_turn -%}
+        {{- '<|turn>' + role + '\n' }}
+    {%- endif -%}
+
+    {#- Render reasoning/reasoning_content as thinking channel -#}
+    {%- set thinking_text = message.get('reasoning') or message.get('reasoning_content') -%}
+    {%- if thinking_text and loop.index0 > ns_turn.last_user_idx and message.get('tool_calls') -%}
+        {{- '<|channel>thought\n' + thinking_text + '\n<channel|>' -}}
+    {%- endif -%}
+
+            {%- if message['tool_calls'] -%}
+                {%- for tool_call in message['tool_calls'] -%}
+                    {%- set function = tool_call['function'] -%}
+                    {{- '<|tool_call>call:' + function['name'] + '{' -}}
+                    {%- if function['arguments'] is mapping -%}
+                        {%- set ns_args = namespace(found_first=false) -%}
+                        {%- for key, value in function['arguments'] | dictsort -%}
+                            {%- if ns_args.found_first %},{% endif -%}
+                            {%- set ns_args.found_first = true -%}
+                            {{- key -}}:{{- format_argument(value, escape_keys=False) -}}
+                        {%- endfor -%}
+                    {%- elif function['arguments'] is string -%}
+                        {{- function['arguments'] -}}
+                    {%- endif -%}
+                    {{- '}<tool_call|>' -}}
+                {%- endfor -%}
+                {%- set ns.prev_message_type = 'tool_call' -%}
+            {%- endif -%}
+
+            {%- set ns_tr_out = namespace(flag=false) -%}
+            {%- if message.get('tool_responses') -%}
+                {#- Legacy: tool_responses embedded on the assistant message (Google/Gemma native) -#}
+                {%- for tool_response in message['tool_responses'] -%}
+                    {{- format_tool_response_block(tool_response['name'] | default('unknown'), tool_response['response']) -}}
+                    {%- set ns_tr_out.flag = true -%}
+                    {%- set ns.prev_message_type = 'tool_response' -%}
+                {%- endfor -%}
+            {%- elif message.get('tool_calls') -%}
+                {#- OpenAI Chat Completions: forward-scan consecutive role:tool messages -#}
+                {%- set ns_tool_scan = namespace(stopped=false) -%}
+                {%- for k in range(loop.index0 + 1, loop_messages | length) -%}
+                    {%- if ns_tool_scan.stopped -%}
+                    {%- elif loop_messages[k]['role'] != 'tool' -%}
+                        {%- set ns_tool_scan.stopped = true -%}
+                    {%- else -%}
+                        {%- set follow = loop_messages[k] -%}
+                        {#- Resolve tool_call_id to function name -#}
+                        {%- set ns_tname = namespace(name=follow.get('name') | default('unknown')) -%}
+                        {%- for tc in message['tool_calls'] -%}
+                            {%- if tc.get('id') == follow.get('tool_call_id') -%}
+                                {%- set ns_tname.name = tc['function']['name'] -%}
+                            {%- endif -%}
+                        {%- endfor -%}
+                        {#- Handle content as string or content-parts array -#}
+                        {%- set tool_body = follow.get('content') -%}
+                        {%- if tool_body is string -%}
+                            {{- format_tool_response_block(ns_tname.name, tool_body) -}}
+                        {%- elif tool_body is iterable and tool_body is not string -%}
+                            {%- set ns_txt = namespace(s='') -%}
+                            {%- for part in tool_body -%}
+                                {%- if part.get('type') == 'text' -%}
+                                    {%- set ns_txt.s = ns_txt.s + (part.get('text') | default('')) -%}
+                                {%- endif -%}
+                            {%- endfor -%}
+                            {{- format_tool_response_block(ns_tname.name, ns_txt.s) -}}
+                            {%- for part in tool_body -%}
+                                {%- if part.get('type') == 'image' -%}
+                                    {{- '<|image|>' -}}
+                                {%- elif part.get('type') == 'audio' -%}
+                                    {{- '<|audio|>' -}}
+                                {%- elif part.get('type') == 'video' -%}
+                                    {{- '<|video|>' -}}
+                                {%- endif -%}
+                            {%- endfor -%}
+                        {%- else -%}
+                            {{- format_tool_response_block(ns_tname.name, tool_body) -}}
+                        {%- endif -%}
+                        {%- set ns_tr_out.flag = true -%}
+                        {%- set ns.prev_message_type = 'tool_response' -%}
+                    {%- endif -%}
+                {%- endfor -%}
+            {%- endif -%}
+
+            {%- set captured_content -%}
+            {%- if message['content'] is string -%}
+                {%- if role == 'model' -%}
+                    {{- strip_thinking(message['content']) -}}
+                {%- else -%}
+                    {{- message['content'] | trim -}}
+                {%- endif -%}
+            {%- elif message['content'] is iterable -%}
+                {%- for item in message['content'] -%}
+                    {%- if item['type'] == 'text' -%}
+                        {%- if role == 'model' -%}
+                            {{- strip_thinking(item['text']) -}}
+                        {%- else -%}
+                            {{- item['text'] | trim -}}
+                        {%- endif -%}
+                    {%- elif item['type'] == 'image' -%}
+                        {{- '<|image|>' -}}
+                        {%- set ns.prev_message_type = 'image' -%}
+                    {%- elif item['type'] == 'audio' -%}
+                        {{- '<|audio|>' -}}
+                        {%- set ns.prev_message_type = 'audio' -%}
+                    {%- elif item['type'] == 'video' -%}
+                        {{- '<|video|>' -}}
+                        {%- set ns.prev_message_type = 'video' -%}
+                    {%- endif -%}
+                {%- endfor -%}
+            {%- endif -%}
+            {%- endset -%}
+
+            {{- captured_content -}}
+            {%- set has_content = captured_content | trim | length > 0 -%}
+
+        {%- if ns.prev_message_type == 'tool_call' and not ns_tr_out.flag -%}
+            {{- '<|tool_response>' -}}
+        {%- elif not (ns_tr_out.flag and not has_content) -%}
+            {{- '<turn|>\n' -}}
+        {%- endif -%}
+    {%- endif -%}
+{%- endfor -%}
+
+{%- if add_generation_prompt -%}
+    {%- if ns.prev_message_type != 'tool_response' and ns.prev_message_type != 'tool_call' -%}
+        {{- '<|turn>model\n' -}}
+        {%- if not enable_thinking | default(false) -%}
+            {{- '<|channel>thought\n<channel|>' -}}
+        {%- endif -%}
+    {%- endif -%}
+{%- endif -%}
+"""# + "\n"
+}

--- a/provider-swift/Sources/ProviderCoreFoundation/TemplateRenderCheck.swift
+++ b/provider-swift/Sources/ProviderCoreFoundation/TemplateRenderCheck.swift
@@ -112,11 +112,19 @@ public enum TemplateRenderCheck {
         let specialTokens = specialTokenContext(at: snapshotDir)
 
         for source in sources {
+            // Apply the same non-mutating, hash-gated chat-template override the
+            // runtime tokenize path uses (`ChatTemplateOverride`), so a known-
+            // broken published template (e.g. the outdated Gemma 4 tool template)
+            // is render-checked as the corrected upstream revision it will
+            // actually be served with. Keeps "renders here == renders at request
+            // time" exact; healthy/unknown templates pass through untouched.
+            let effectiveSource = ChatTemplateOverride.corrected(forTemplate: source) ?? source
+
             // Same compile options as the runtime tokenizer
             // (swift-transformers `compiledTemplate(for:)`).
             let template: Template
             do {
-                template = try Template(source, with: .init(lstripBlocks: true, trimBlocks: true))
+                template = try Template(effectiveSource, with: .init(lstripBlocks: true, trimBlocks: true))
             } catch {
                 // A template that doesn't compile can't render at request time.
                 return false

--- a/provider-swift/Tests/ProviderCoreFoundationTests/ChatTemplateOverrideTests.swift
+++ b/provider-swift/Tests/ProviderCoreFoundationTests/ChatTemplateOverrideTests.swift
@@ -1,0 +1,216 @@
+import Crypto
+import Foundation
+import XCTest
+
+import Jinja
+
+@testable import ProviderCoreFoundation
+
+/// DAR-329: the hash-gated, non-mutating Gemma 4 chat-template override.
+///
+/// Proves (1) the vendored corrected template is byte-exact the verified
+/// upstream file, (2) the override fires ONLY for the exact known-broken
+/// revision (surgical), and (3) the corrected template renders — in the SAME
+/// swift-jinja engine the runtime uses — every shape the outdated template
+/// 500s on (union / typeless / response / null tool-schema fields), while
+/// staying byte-identical for healthy inputs.
+final class ChatTemplateOverrideTests: XCTestCase {
+
+    private func sha256Hex(_ s: String) -> String {
+        SHA256.hash(data: Data(s.utf8)).map { String(format: "%02x", $0) }.joined()
+    }
+
+    // MARK: - Provenance / pinned hashes
+
+    func testCorrectedTemplateIsByteExactUpstream() {
+        // The embedded template must be the exact upstream (lmstudio) file so
+        // we can trust it renders as upstream intends.
+        XCTAssertEqual(
+            sha256Hex(GemmaToolTemplate.correctedToolTemplate),
+            GemmaToolTemplate.correctedSHA256)
+        XCTAssertEqual(
+            GemmaToolTemplate.correctedSHA256,
+            "29af862bccabb14b90a4ff951bcd14c33fe74b651c5f07fc7f2e9aa46a59fe7c")
+    }
+
+    func testBrokenHashIsPinnedToServedGemmaRevision() {
+        XCTAssertEqual(
+            GemmaToolTemplate.brokenSHA256,
+            "94899c0f917d93f6fe81c95744d1e8ddab2d21d39228d2e4aec1fb2a25bff413")
+    }
+
+    func testCorrectedTemplateCarriesTheUpstreamGuards() {
+        // Sanity: the corrected template is the guarded revision (macro +
+        // null-guards), not the old unguarded one.
+        let t = GemmaToolTemplate.correctedToolTemplate
+        XCTAssertTrue(t.contains("format_type_argument"))
+        XCTAssertFalse(t.contains("value['type'] | upper"))
+    }
+
+    // MARK: - Policy
+
+    func testReplacementsMapBrokenToCorrected() {
+        XCTAssertEqual(
+            ChatTemplateOverride.replacements[GemmaToolTemplate.brokenSHA256],
+            GemmaToolTemplate.correctedToolTemplate)
+    }
+
+    func testHealthyTemplateIsNotOverridden() {
+        // An arbitrary, unrelated template must pass through untouched.
+        XCTAssertNil(ChatTemplateOverride.corrected(forTemplate: "{{ messages[0]['content'] }}"))
+        // And the corrected template itself is not a known-broken revision.
+        XCTAssertNil(
+            ChatTemplateOverride.corrected(forTemplate: GemmaToolTemplate.correctedToolTemplate))
+    }
+
+    // MARK: - Mechanism (hash match), via injected maps
+
+    func testOverrideMatchesByContentHash() {
+        let map = [sha256Hex("BROKEN-A"): "FIXED-A", sha256Hex("BROKEN-B"): "FIXED-B"]
+        XCTAssertEqual(ChatTemplateOverride.corrected(forTemplate: "BROKEN-A", using: map), "FIXED-A")
+        XCTAssertEqual(ChatTemplateOverride.corrected(forTemplate: "BROKEN-B", using: map), "FIXED-B")
+        XCTAssertNil(ChatTemplateOverride.corrected(forTemplate: "HEALTHY", using: map))
+        XCTAssertNil(ChatTemplateOverride.corrected(forTemplate: "BROKEN-A", using: [:]))
+    }
+
+    func testCorrectedTemplateForSnapshotDirReadsAndMatches() throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cto-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: dir) }
+
+        let onDisk = "SOME-BROKEN-TEMPLATE\n"
+        try Data(onDisk.utf8).write(to: dir.appendingPathComponent("chat_template.jinja"))
+        let map = [sha256Hex(onDisk): "CORRECTED"]
+
+        XCTAssertEqual(ChatTemplateOverride.correctedTemplate(forSnapshotDir: dir, using: map), "CORRECTED")
+        // Missing file → nil (no crash).
+        let empty = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cto-empty-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: empty, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: empty) }
+        XCTAssertNil(ChatTemplateOverride.correctedTemplate(forSnapshotDir: empty, using: map))
+    }
+
+    // MARK: - Real render: corrected template handles the crashing shapes
+
+    private func render(_ source: String, tools: [[String: Any]]?, messages: [[String: Any]]) throws -> String {
+        let template = try Template(source, with: .init(lstripBlocks: true, trimBlocks: true))
+        var ctx: [String: Value] = [
+            "bos_token": .string(""),
+            "eos_token": .string(""),
+            "add_generation_prompt": .boolean(true),
+            "messages": try Value(any: messages.map { sanitizeForJinja($0) }),
+        ]
+        if let tools {
+            ctx["tools"] = try Value(any: tools.map { sanitizeForJinja($0) })
+        }
+        return try template.render(ctx)
+    }
+
+    private let userMsg: [[String: Any]] = [["role": "user", "content": "hi"]]
+
+    private func tool(params: [String: Any], response: [String: Any]? = nil) -> [String: Any] {
+        var fn: [String: Any] = ["name": "f", "description": "d", "parameters": params]
+        if let response { fn["response"] = response }
+        return ["type": "function", "function": fn]
+    }
+
+    func testCorrectedTemplateRendersHealthyTool() throws {
+        let params: [String: Any] = [
+            "type": "object",
+            "properties": [
+                "a": ["type": "string", "enum": ["x", "y"], "description": "s"] as [String: Any],
+                "b": ["type": "array", "items": ["type": "integer"] as [String: Any]] as [String: Any],
+            ] as [String: Any],
+            "required": ["a"],
+        ]
+        XCTAssertNoThrow(try render(GemmaToolTemplate.correctedToolTemplate, tools: [tool(params: params)], messages: userMsg))
+    }
+
+    func testCorrectedTemplateRendersUnionTypeProperty() throws {
+        // `"type": ["string","null"]` — the unguarded `| upper` 500s on this.
+        let params: [String: Any] = [
+            "type": "object",
+            "properties": ["a": ["type": ["string", "null"] as [Any], "description": "u"] as [String: Any]] as [String: Any],
+        ]
+        XCTAssertNoThrow(try render(GemmaToolTemplate.correctedToolTemplate, tools: [tool(params: params)], messages: userMsg))
+    }
+
+    func testCorrectedTemplateRendersTypelessProperty() throws {
+        let params: [String: Any] = [
+            "type": "object",
+            "properties": ["a": ["description": "no type"] as [String: Any]] as [String: Any],
+        ]
+        XCTAssertNoThrow(try render(GemmaToolTemplate.correctedToolTemplate, tools: [tool(params: params)], messages: userMsg))
+    }
+
+    func testCorrectedTemplateRendersResponseSchema() throws {
+        // `function.response` is NOT walked by ToolSchemaNormalization, so a
+        // union/absent type here reaches the template raw — the corrected
+        // template must still render it.
+        let params: [String: Any] = [
+            "type": "object",
+            "properties": ["a": ["type": "string"] as [String: Any]] as [String: Any],
+        ]
+        let response: [String: Any] = ["type": ["object", "null"] as [Any], "description": "r"]
+        XCTAssertNoThrow(try render(GemmaToolTemplate.correctedToolTemplate, tools: [tool(params: params, response: response)], messages: userMsg))
+    }
+
+    func testCorrectedTemplateRendersNullBearingSchemaAfterSanitize() throws {
+        let params: [String: Any] = [
+            "type": "object",
+            "properties": [
+                "unit": [
+                    "type": "string",
+                    "enum": ["c", "f", NSNull()] as [Any],
+                    "default": NSNull(),
+                ] as [String: Any]
+            ] as [String: Any],
+            "required": ["unit"],
+        ]
+        XCTAssertNoThrow(try render(GemmaToolTemplate.correctedToolTemplate, tools: [tool(params: params)], messages: userMsg))
+    }
+
+    func testCorrectedTemplateRendersPlainChat() throws {
+        XCTAssertNoThrow(try render(GemmaToolTemplate.correctedToolTemplate, tools: nil, messages: [
+            ["role": "system", "content": "be brief"],
+            ["role": "user", "content": "hello"],
+        ]))
+    }
+
+    // MARK: - Contrast: the unguarded pattern really does throw
+
+    func testUnguardedUpperPatternThrowsOnUnionButCorrectedDoesNot() throws {
+        // Minimal reproduction of the outdated template's failing pattern.
+        let unguarded = """
+            {%- for tool in tools -%}
+            {%- for k, v in tool['function']['parameters']['properties'] | dictsort -%}
+            {{ v['type'] | upper }}
+            {%- endfor -%}
+            {%- endfor -%}
+            """
+        let unionTool = tool(params: [
+            "type": "object",
+            "properties": ["a": ["type": ["string", "null"] as [Any]] as [String: Any]] as [String: Any],
+        ])
+        XCTAssertThrowsError(try render(unguarded, tools: [unionTool], messages: userMsg)) { error in
+            XCTAssertTrue("\(error)".contains("upper filter requires string"), "unexpected: \(error)")
+        }
+        // The corrected template handles the very same input.
+        XCTAssertNoThrow(try render(GemmaToolTemplate.correctedToolTemplate, tools: [unionTool], messages: userMsg))
+    }
+
+    // MARK: - renderOK integration (corrected template advertises render_ok)
+
+    func testRenderOKTrueForCorrectedTemplateOnDisk() throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cto-ok-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: dir) }
+        try Data(GemmaToolTemplate.correctedToolTemplate.utf8)
+            .write(to: dir.appendingPathComponent("chat_template.jinja"))
+        try Data(#"{"model_type": "gemma3"}"#.utf8).write(to: dir.appendingPathComponent("config.json"))
+        XCTAssertEqual(TemplateRenderCheck.renderOK(at: dir), true)
+    }
+}


### PR DESCRIPTION
## Summary

The Gemma 4 model we serve (`mlx-community/gemma-4-26B-A4B-it-qat-4bit`) ships an **outdated `chat_template.jinja`** whose tool-schema rendering pipes `value['type'] | upper` (and `map('upper')`) with no null/Optional guard. swift-jinja's `upper` filter throws `"upper filter requires string"` on any non-string value, so a tool whose schema carries a **union type** (`["string","null"]`), **omits `type`**, or holds a **non-string enum element** renders to a hard **500** (`Jinja.TemplateException`).

The fixed upstream revision — `lmstudio-community/gemma-4-26B-A4B-it-QAT-MLX-4bit` — null-guards every `type` access and adds a `format_type_argument` macro. Both repos are the **same qat-4bit weights + tokenizer** (byte-identical safetensors and `tokenizer.json`); the only delta is this template. So this is a **template-only fix — no requant / reweight / tokenizer change.**

This PR adopts that corrected template at the serving layer via a **non-mutating, hash-gated render-time override.**

> Stacked on #413 (`fix/dar-335-338-fleet-deroute`); base it there for a clean diff.

## Why non-mutating (the key constraint)

`chat_template.jinja` is in `ModelScanner.integrityFileNames`, so `WeightHasher.computeHash` — the model's **attestation/integrity hash** — includes it. Rewriting the file on disk would diverge from the published registry manifest and **break attestation**. So the on-disk file is left untouched and the corrected template is injected only at the two render boundaries (via swift-transformers' `.literal` chat-template argument). The attested hash keeps matching the registry.

Gating on the exact broken **content hash** keeps it surgical: it fires only for that one known-broken revision and **self-disables** the moment the registry republishes a corrected template (the on-disk hash stops matching). No other model or template is touched.

## Changes

- **`GemmaToolTemplate.swift`** (new) — the corrected upstream template embedded **byte-for-byte** (sha256 pinned + asserted in tests), with the broken-revision sha256.
- **`ChatTemplateOverride.swift`** (new) — pure `broken-sha256 → corrected` lookup (`corrected(forTemplate:)`, `correctedTemplate(forSnapshotDir:)`).
- **`TemplateRenderCheck.swift`** — `renderOK` render-checks the corrected template, so the coordinator's `template_render_ok` reflects what is actually served (keeps "renders here == renders at request time").
- **`LocalTokenizerLoader.swift`** — the tokenizer bridge renders via `.literal(corrected)` when the on-disk template is the known-broken revision; non-Gemma models keep the exact baked-template path unchanged.

## Behavior-preserving

The corrected template renders **byte-identically** to the old one for healthy tools and plain chat (verified in tests against the real templates in swift-jinja 2.3.5); only the previously-crashing shapes change — from a 500 to a correct render. `ToolSchemaNormalization` (DAR-130) is kept and still defends every other model's template.

## Testing

- Full provider `swift build` ✅
- **15 new tests** (`ChatTemplateOverrideTests`): byte-exact provenance, hash-gated matching, surgical scope (healthy templates untouched), and real swift-jinja rendering of union / typeless / `function.response` / null-bearing tool schemas — plus a contrast test proving the unguarded pattern throws while the corrected template does not.
- Existing render/sanitization/`ModelCatalog` tests ✅ (no regressions).

## Follow-up (optional, not required to ship)

The fully trust-consistent long-term fix is a **registry republish** of the corrected Gemma 4 template (so the attested bytes equal what's rendered). This override is the safe, shippable interim and remains a harmless belt-and-suspenders even after a republish (it self-disables).

DAR-329

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/415"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784517255&installation_id=133247490&pr_number=415&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F415&signature=26273039f3afa06dbfe3327f8647e683c7681715073b40c7b73ed4ecd82f3f81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->