### PR TITLE
fix(kvquant): cache-factory tests expect quantized sliding-window caches (#46)

### DIFF
--- a/provider-swift/Tests/ProviderCoreTests/KVQuantEngineTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/KVQuantEngineTests.swift
@@ -205,7 +205,7 @@ struct KVQuantEngineTests {
             "sliding-attention layer must use BatchRotatingKVCache")
     }
 
-    @Test("factory on kernel kind: full layers use QuantizedBatchKVCache, sliding stays BatchRotatingKVCache")
+    @Test("factory on kernel kind: full layers use QuantizedBatchKVCache, sliding uses QuantizedBatchRotatingKVCache")
     func factoryOnKernelKindUsesQuantizedBatchKVCache() {
         let quantConfig = KVQuantizationConfig(groupSize: 128, bits: 8, mode: .affine, cacheKind: .kernel)
         let fullName = Scheduler.cacheFactoryTypeName(
@@ -216,18 +216,26 @@ struct KVQuantEngineTests {
 
         #expect(fullName == "QuantizedBatchKVCache",
             "full-attention layer must use QuantizedBatchKVCache when quant kind is kernel")
-        #expect(slidingName == "BatchRotatingKVCache",
-            "sliding-attention layer must stay fp16 (BatchRotatingKVCache)")
+        // Sliding-window layers are quantized too (#46): the quant groups run along
+        // head-dim, so the rotating-window front-trim stays group-aligned.
+        #expect(slidingName == "QuantizedBatchRotatingKVCache",
+            "sliding-window layer must use QuantizedBatchRotatingKVCache when quant kind is kernel")
     }
 
-    @Test("factory on dequant kind: full layers use DequantBatchKVCache")
+    @Test("factory on dequant kind: full layers use DequantBatchKVCache, sliding uses DequantBatchRotatingKVCache")
     func factoryOnDequantKindUsesDequantBatchKVCache() {
         let quantConfig = KVQuantizationConfig(groupSize: 64, bits: 8, mode: .affine, cacheKind: .dequant)
         let fullName = Scheduler.cacheFactoryTypeName(
             for: KVCacheSimple(), quantConfig: quantConfig)
+        let slidingName = Scheduler.cacheFactoryTypeName(
+            for: RotatingKVCache(maxSize: 1024, keep: 0, step: 1024),
+            quantConfig: quantConfig)
 
         #expect(fullName == "DequantBatchKVCache",
             "full-attention layer must use DequantBatchKVCache when quant kind is dequant")
+        // Sliding-window layers are quantized too (#46).
+        #expect(slidingName == "DequantBatchRotatingKVCache",
+            "sliding-window layer must use DequantBatchRotatingKVCache when quant kind is dequant")
     }
 
     @Test("factory ignores quant config for arrays and mamba-style caches")


### PR DESCRIPTION
## What

`KVQuantEngineTests` encoded the **pre-#46** cache-factory contract — that KV-quant leaves sliding-window layers as fp16 `BatchRotatingKVCache`. PR #46 (now on engine main `8a9bc7c`, pulled in by the #378 submodule bump) deliberately changed this: a sliding-window `RotatingKVCache` now maps to `QuantizedBatchRotatingKVCache` (kernel kind) / `DequantBatchRotatingKVCache` (dequant kind).

That left **master red**: `factoryOnKernelKindUsesQuantizedBatchKVCache` asserts `slidingName == "BatchRotatingKVCache"` (KVQuantEngineTests.swift:219), but the factory now returns `QuantizedBatchRotatingKVCache`.

## Fix (test-only)

- Kernel-kind test: expect `QuantizedBatchRotatingKVCache` for the sliding layer.
- Dequant-kind test: add the previously-missing sliding-window assertion (`DequantBatchRotatingKVCache`).

This mirrors the engine-side `CBCacheFactorySelectionTests` that #46 already updated. **No production code changes** — the factory behavior (sliding-window quantization) is intended and is the whole point of #46 (Gemma-4 capacity ~1.08x → 1.87x, since it is 25/30 sliding-window layers).

## Why not revert the factory instead

Making the factory leave sliding layers fp16 would turn CI green but discard #46's entire benefit. The correct fix is to update the stale test to the new contract.

## Verification

Full `KVQuantEngineTests` suite (16 tests) green against engine `8a9bc7c`, including the two factory tests, the byte-accounting tests, and scheme-resolution tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/418"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784520875&installation_id=133247490&pr_number=418&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F418&signature=eb9ad5632827f093c9df5ea01dff658e1ae735ee2506c72e43daa213571ce14c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->