### PR TITLE
fix(release): robust ProviderCore version injection

### DIFF
--- a/.github/workflows/release-swift.yml
+++ b/.github/workflows/release-swift.yml
@@ -241,11 +241,15 @@ jobs:
       - name: Inject release version into ProviderCore
         run: |
           set -euo pipefail
-          CURRENT=$(grep -o '"[^"]*"' provider-swift/Sources/ProviderCore/ProviderCore.swift | tr -d '"')
-          echo "Replacing ProviderCore.version: $CURRENT → $VERSION"
-          sed -i '' "s|public static let version = \"$CURRENT\"|public static let version = \"$VERSION\"|" \
-            provider-swift/Sources/ProviderCore/ProviderCore.swift
-          grep 'public static let version' provider-swift/Sources/ProviderCore/ProviderCore.swift
+          FILE=provider-swift/Sources/ProviderCore/ProviderCore.swift
+          echo "Setting ProviderCore.version → $VERSION"
+          # Target ONLY the version line. Do not grep every string literal: nearby
+          # comments contain quoted words ("crashed"/"reloading"/"idle") which made
+          # the old `grep -o '"..."'` capture multiple lines and break sed.
+          sed -i '' -E "s|(public static let version = )\"[^\"]*\"|\1\"${VERSION}\"|" "$FILE"
+          grep -n 'public static let version' "$FILE"
+          grep -q "public static let version = \"${VERSION}\"" "$FILE" \
+            || { echo "::error::version injection failed for $VERSION"; exit 1; }
 
       - name: Build provider-swift (release)
         working-directory: provider-swift


### PR DESCRIPTION
## Problem

The `v0.6.16` provider release run failed at **Inject release version into ProviderCore** with `sed: unterminated substitute pattern`.

Root cause: the step read the current version via

```sh
CURRENT=$(grep -o '"[^"]*"' .../ProviderCore.swift | tr -d '"')
```

which matches **every** quoted string in the file. A recent comment added quoted words (`"crashed"`/`"reloading"`/`"idle"`) on `ProviderCore.swift:70`, so `CURRENT` became multi-line and the follow-up `sed` blew up.

## Fix

Rewrite only the version line with a line-targeted regex `sed`, independent of the current value, and hard-fail if the injection didn't take:

```sh
sed -i '' -E "s|(public static let version = )\"[^\"]*\"|\1\"${VERSION}\"|" "$FILE"
grep -q "public static let version = \"${VERSION}\"" "$FILE" || exit 1
```

## Verification

- Simulated on a scratch copy with `VERSION=9.9.9-rc1`: only line 73 (version) changed; the line 70 comment was untouched; guard passed.
- `python3 -c 'yaml.safe_load(...)'` → YAML OK.

## Follow-up

Once merged, re-tag `v0.6.16` at the new `master` HEAD to re-run the release.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/419"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784521936&installation_id=133247490&pr_number=419&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F419&signature=6666c17e1fc34a1e24b5ccf2b93f3e18afeab40cdad21aa289b62821f7aae4a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->