### PR TITLE
feat(provider): `darkbloom beta` command to enable opt-in beta features

### DIFF
--- a/docs/provider/beta-features.md
+++ b/docs/provider/beta-features.md
@@ -1,0 +1,76 @@
+# Beta Features
+
+Beta features are experimental provider capabilities that are **off by default**.
+They are validated enough to try in production but may change, carry caveats, or
+only apply to specific model families. Enable them per provider when you want to
+opt in.
+
+## How beta features are toggled
+
+Beta features are **config-backed**, not environment-variable backed. Each one is
+a field in your provider TOML config (`~/.config/darkbloom/provider.toml`). This
+matters: the launchd daemon started by `darkbloom start` only inherits a tiny
+allowlist of `DARKBLOOM_*` environment variables
+(`provider-swift/Sources/ProviderCore/Daemon/LaunchAgent.swift`), so an env-var
+toggle would silently have no effect on the running daemon. A TOML field is always
+read by every serve path (daemon, `--foreground`, and `--local`).
+
+The registry of available features lives in
+`provider-swift/Sources/ProviderCore/Config/BetaFeatures.swift`.
+
+## The `darkbloom beta` command
+
+```bash
+darkbloom beta list                 # show all beta features and whether each is on (default)
+darkbloom beta status [feature]     # show details for all features, or one
+darkbloom beta enable <feature>     # turn a feature on
+darkbloom beta disable <feature>    # turn a feature off
+```
+
+`enable`/`disable` perform a read-modify-write of the TOML config and print
+whether a restart is required. Most beta features take effect on the next backend
+start:
+
+```bash
+darkbloom beta enable kv-quant
+darkbloom restart
+```
+
+You can also see which beta features are active in `darkbloom status` (the
+`Beta features:` line), or edit the TOML directly.
+
+## Available features
+
+### `kv-quant` — KV-cache quantization
+
+Stores attention keys/values in 8-bit for the validated model families
+(**GPT-OSS** and **Gemma 4**), roughly doubling the number of tokens a provider
+can admit concurrently (~1.9x more KV capacity). Other model families are
+unaffected and continue to serve fp16.
+
+```bash
+darkbloom beta enable kv-quant
+darkbloom restart
+```
+
+Equivalent TOML:
+
+```toml
+[backend]
+kv_quant = true
+```
+
+After restarting, confirm quantization actually engaged for a served model with:
+
+```bash
+darkbloom logs        # look for the `kv-quant` logger
+```
+
+Notes and caveats:
+
+- Only GPT-OSS and Gemma 4 are quantized; the provider falls back to fp16 for any
+  other family, so enabling it is safe across a mixed catalog.
+- The setting is read at backend start, so a restart is required after toggling.
+- Default is `false` (fp16). The field is defined in
+  `provider-swift/Sources/ProviderCore/Config/ProviderConfig.swift` and consumed
+  by the scheduler via `resolveKVQuantScheme(...)`.

--- a/docs/provider/cli-reference.md
+++ b/docs/provider/cli-reference.md
@@ -206,6 +206,27 @@ darkbloom autoupdate <enable|disable|status>
 
 This toggles `provider.auto_update` in `provider.toml`.
 
+## `darkbloom beta`
+
+Manage opt-in beta features. Beta features are off by default and config-backed
+(a TOML field), so they apply to the launchd daemon too — unlike environment
+variables, which the daemon does not inherit.
+
+```bash
+darkbloom beta list                 # all features + on/off (default subcommand)
+darkbloom beta status [feature]     # details for all features, or one
+darkbloom beta enable <feature>     # turn on (then: darkbloom restart)
+darkbloom beta disable <feature>    # turn off
+```
+
+| Feature | Effect |
+|---------|--------|
+| `kv-quant` | 8-bit KV cache for GPT-OSS / Gemma 4 (~1.9x more concurrent context); toggles `backend.kv_quant` |
+
+`enable`/`disable` read-modify-write the TOML config and report whether a restart
+is required. See [Beta Features](beta-features.md) for the full guide. `darkbloom
+beta list` also accepts `--json`.
+
 ## `darkbloom login`
 
 Link this machine to a Darkbloom account via RFC 8628 device-code flow.

--- a/docs/provider/quickstart.md
+++ b/docs/provider/quickstart.md
@@ -117,6 +117,7 @@ continuous_batching = true
 enabled_models = []
 idle_timeout_mins = 60
 max_model_slots = 3
+kv_quant = false
 
 [coordinator]
 url = "wss://api.darkbloom.dev/ws/provider"
@@ -133,6 +134,9 @@ end = "08:00"
 - `backend.idle_timeout_mins` — minutes of inactivity before an idle model is
   unloaded (default 60; 0 disables eviction).
 - `backend.max_model_slots` — maximum resident models at once (default 3).
+- `backend.kv_quant` — opt-in beta: 8-bit KV cache for GPT-OSS / Gemma 4 (~1.9x
+  more concurrent context). Off by default. Manage it with `darkbloom beta` — see
+  [Beta Features](beta-features.md).
 - `coordinator.private_only` — serve only your own self-route traffic; never
   join the public fleet.
 

--- a/provider-swift/Sources/ProviderCore/Config/BetaFeatures.swift
+++ b/provider-swift/Sources/ProviderCore/Config/BetaFeatures.swift
@@ -1,0 +1,92 @@
+import Foundation
+
+/// A user-facing opt-in *beta* feature.
+///
+/// Beta features are intentionally **config-backed**, not environment-variable
+/// backed: the launchd daemon started by `darkbloom start` only inherits a tiny
+/// allowlist of `DARKBLOOM_*` variables (`LaunchAgent.passthroughEnvKeys`), so an
+/// env-var toggle would silently no-op for the normal daemon. A field in the TOML
+/// config is always read by every serve path (daemon, `--foreground`, `--local`).
+///
+/// Each feature maps to one `Bool` field of ``ProviderConfig``. The getter/setter
+/// are stored as `@Sendable` closures so the registry is a concurrency-safe
+/// `static let` under Swift 6 strict concurrency.
+public struct BetaFeature: Sendable, Identifiable {
+    /// Stable CLI identifier, e.g. `kv-quant`. Lowercase, hyphenated.
+    public let id: String
+    /// Short human-readable name.
+    public let title: String
+    /// One-line description shown by `darkbloom beta list`.
+    public let summary: String
+    /// Longer guidance shown when toggling and by `darkbloom beta status <id>`.
+    public let details: String
+    /// Whether `darkbloom restart` is required for a change to take effect.
+    public let requiresRestart: Bool
+
+    private let read: @Sendable (ProviderConfig) -> Bool
+    private let write: @Sendable (Bool, inout ProviderConfig) -> Void
+
+    public init(
+        id: String,
+        title: String,
+        summary: String,
+        details: String,
+        requiresRestart: Bool,
+        read: @escaping @Sendable (ProviderConfig) -> Bool,
+        write: @escaping @Sendable (Bool, inout ProviderConfig) -> Void
+    ) {
+        self.id = id
+        self.title = title
+        self.summary = summary
+        self.details = details
+        self.requiresRestart = requiresRestart
+        self.read = read
+        self.write = write
+    }
+
+    /// Whether the feature is currently enabled in `config`.
+    public func isEnabled(in config: ProviderConfig) -> Bool {
+        read(config)
+    }
+
+    /// Set the feature's enabled state on `config` in place.
+    public func apply(_ enabled: Bool, to config: inout ProviderConfig) {
+        write(enabled, &config)
+    }
+}
+
+/// The registry of opt-in beta features.
+///
+/// Adding a beta toggle = adding one ``BetaFeature`` entry here (and its backing
+/// `ProviderConfig` field). The `darkbloom beta` command and `darkbloom status`
+/// are driven entirely off this list, so they need no per-feature code.
+public enum BetaFeatures {
+    public static let all: [BetaFeature] = [
+        BetaFeature(
+            id: "kv-quant",
+            title: "KV-cache quantization",
+            summary: "8-bit KV cache for ~1.9x more concurrent context on supported models.",
+            details: """
+            Stores attention keys/values in 8-bit for the validated model \
+            families (GPT-OSS and Gemma 4), roughly doubling the tokens a \
+            provider can admit at once. Other model families are unaffected and \
+            keep fp16. After enabling and restarting, confirm it engaged with \
+            `darkbloom logs` (look for the `kv-quant` logger).
+            """,
+            requiresRestart: true,
+            read: { $0.backend.kvQuant },
+            write: { enabled, config in config.backend.kvQuant = enabled }
+        )
+    ]
+
+    /// Look up a feature by its CLI id (case-insensitive).
+    public static func feature(id: String) -> BetaFeature? {
+        let needle = id.lowercased()
+        return all.first { $0.id.lowercased() == needle }
+    }
+
+    /// The ids of all features currently enabled in `config`.
+    public static func enabledIDs(in config: ProviderConfig) -> [String] {
+        all.filter { $0.isEnabled(in: config) }.map(\.id)
+    }
+}

--- a/provider-swift/Sources/darkbloom/BetaCommand.swift
+++ b/provider-swift/Sources/darkbloom/BetaCommand.swift
@@ -180,19 +180,33 @@ private func setBetaFeature(
     let snapshot = try loadRuntimeSnapshot(configOptions: configOptions)
     var config = snapshot.config
 
-    // Already in the desired state and the file exists — no-op (mirrors autoupdate).
-    if feature.isEnabled(in: config) == enabled && snapshot.configFileExists {
+    // Persist to the path the daemon will actually read. With no explicit
+    // --config, loadRuntimeSnapshot may have just migrated a legacy config to
+    // the canonical ~/.config/darkbloom/provider.toml; `darkbloom restart` and
+    // the launchd daemon resolve that canonical path first, so writing back to
+    // the (legacy) snapshot.configPath would leave the restarted daemon on the
+    // stale value. Re-resolving the default returns the post-migration canonical.
+    let savePath: URL
+    if configOptions.config != nil {
+        savePath = snapshot.configPath
+    } else {
+        savePath = try ConfigManager.defaultConfigPath()
+    }
+
+    // Already in the desired state and the target file exists — no-op.
+    if feature.isEnabled(in: config) == enabled
+        && FileManager.default.fileExists(atPath: savePath.path) {
         print("\(feature.title) (\(feature.id)) is already \(enabled ? "enabled" : "disabled").")
         return
     }
 
     feature.apply(enabled, to: &config)
-    try ConfigManager.save(config, to: snapshot.configPath)
+    try ConfigManager.save(config, to: savePath)
 
     print("\(enabled ? "Enabled" : "Disabled") beta feature: \(feature.title) (\(feature.id))")
     print("  \(feature.details)")
     if feature.requiresRestart {
         print("  Restart to apply:  darkbloom restart")
     }
-    print("  Config: \(snapshot.configPath.path)")
+    print("  Config: \(savePath.path)")
 }

--- a/provider-swift/Sources/darkbloom/BetaCommand.swift
+++ b/provider-swift/Sources/darkbloom/BetaCommand.swift
@@ -1,0 +1,198 @@
+import Foundation
+import ArgumentParser
+import ProviderCore
+
+struct Beta: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "beta",
+        abstract: "Manage opt-in beta features.",
+        discussion: """
+        Beta features are experimental and off by default. Toggling one writes a
+        field in your provider TOML config, so the change also applies to the
+        launchd daemon (unlike environment variables, which the daemon does not
+        inherit).
+
+        Subcommands:
+          list                 Show all beta features and whether each is on (default).
+          enable <feature>     Turn a beta feature on.
+          disable <feature>    Turn a beta feature off.
+          status [feature]     Show details for all features, or one.
+
+        Most changes require a restart to take effect:
+          darkbloom beta enable kv-quant
+          darkbloom restart
+        """,
+        subcommands: [List.self, Enable.self, Disable.self, Status.self],
+        defaultSubcommand: List.self
+    )
+}
+
+// MARK: - JSON payload
+
+private struct BetaFeatureReport: Encodable {
+    let id: String
+    let title: String
+    let enabled: Bool
+    let requiresRestart: Bool
+    let summary: String
+}
+
+// MARK: - list
+
+extension Beta {
+    struct List: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            abstract: "List beta features and whether each is enabled."
+        )
+
+        @OptionGroup var configOptions: ConfigOptions
+
+        @Flag(help: "Emit JSON instead of a table.")
+        var json = false
+
+        mutating func run() async throws {
+            let snapshot = try loadRuntimeSnapshot(configOptions: configOptions)
+            let config = snapshot.config
+
+            if json {
+                let payload = BetaFeatures.all.map { feature in
+                    BetaFeatureReport(
+                        id: feature.id,
+                        title: feature.title,
+                        enabled: feature.isEnabled(in: config),
+                        requiresRestart: feature.requiresRestart,
+                        summary: feature.summary
+                    )
+                }
+                try printJSON(payload)
+                return
+            }
+
+            print("Beta features (config: \(describeConfigPath(snapshot)))")
+            print("")
+            if BetaFeatures.all.isEmpty {
+                print("  (none available in this build)")
+            } else {
+                for feature in BetaFeatures.all {
+                    let mark = feature.isEnabled(in: config) ? "on " : "off"
+                    print("  [\(mark)] \(feature.id)  —  \(feature.summary)")
+                }
+            }
+            print("")
+            print("Enable with:  darkbloom beta enable <feature>   (then: darkbloom restart)")
+            print("Details with: darkbloom beta status <feature>")
+        }
+    }
+}
+
+// MARK: - status
+
+extension Beta {
+    struct Status: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            abstract: "Show beta feature details and current state."
+        )
+
+        @OptionGroup var configOptions: ConfigOptions
+
+        @Argument(help: "Optional feature id; omit to show every feature.")
+        var feature: String?
+
+        mutating func run() async throws {
+            let snapshot = try loadRuntimeSnapshot(configOptions: configOptions)
+            let config = snapshot.config
+
+            let features: [BetaFeature]
+            if let id = feature {
+                guard let match = BetaFeatures.feature(id: id) else {
+                    throw unknownFeatureError(id)
+                }
+                features = [match]
+            } else {
+                features = BetaFeatures.all
+            }
+
+            print("Config: \(describeConfigPath(snapshot))")
+            for feature in features {
+                print("")
+                print("\(feature.title) (\(feature.id)): \(feature.isEnabled(in: config) ? "ENABLED" : "disabled")")
+                print("  \(feature.details)")
+                if feature.requiresRestart {
+                    print("  Requires `darkbloom restart` after a change.")
+                }
+            }
+        }
+    }
+}
+
+// MARK: - enable / disable
+
+extension Beta {
+    struct Enable: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            abstract: "Enable a beta feature."
+        )
+
+        @OptionGroup var configOptions: ConfigOptions
+
+        @Argument(help: "Beta feature id (see `darkbloom beta list`).")
+        var feature: String
+
+        mutating func run() async throws {
+            try setBetaFeature(feature, enabled: true, configOptions: configOptions)
+        }
+    }
+
+    struct Disable: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            abstract: "Disable a beta feature."
+        )
+
+        @OptionGroup var configOptions: ConfigOptions
+
+        @Argument(help: "Beta feature id (see `darkbloom beta list`).")
+        var feature: String
+
+        mutating func run() async throws {
+            try setBetaFeature(feature, enabled: false, configOptions: configOptions)
+        }
+    }
+}
+
+// MARK: - Shared helpers
+
+private func unknownFeatureError(_ id: String) -> ValidationError {
+    let known = BetaFeatures.all.map(\.id).joined(separator: ", ")
+    let available = known.isEmpty ? "(none available in this build)" : known
+    return ValidationError("Unknown beta feature '\(id)'. Available: \(available). Run `darkbloom beta list`.")
+}
+
+/// Read-modify-write a single beta feature's config field and persist it.
+private func setBetaFeature(
+    _ id: String,
+    enabled: Bool,
+    configOptions: ConfigOptions
+) throws {
+    guard let feature = BetaFeatures.feature(id: id) else {
+        throw unknownFeatureError(id)
+    }
+
+    let snapshot = try loadRuntimeSnapshot(configOptions: configOptions)
+    var config = snapshot.config
+
+    // Already in the desired state and the file exists — no-op (mirrors autoupdate).
+    if feature.isEnabled(in: config) == enabled && snapshot.configFileExists {
+        print("\(feature.title) (\(feature.id)) is already \(enabled ? "enabled" : "disabled").")
+        return
+    }
+
+    feature.apply(enabled, to: &config)
+    try ConfigManager.save(config, to: snapshot.configPath)
+
+    print("\(enabled ? "Enabled" : "Disabled") beta feature: \(feature.title) (\(feature.id))")
+    print("  \(feature.details)")
+    if feature.requiresRestart {
+        print("  Restart to apply:  darkbloom restart")
+    }
+    print("  Config: \(snapshot.configPath.path)")
+}

--- a/provider-swift/Sources/darkbloom/Darkbloom.swift
+++ b/provider-swift/Sources/darkbloom/Darkbloom.swift
@@ -44,6 +44,7 @@ struct Darkbloom: AsyncParsableCommand {
             Logs.self,
             Report.self,
             AutoUpdate.self,
+            Beta.self,
             Watchdog.self,
         ]
     )

--- a/provider-swift/Sources/darkbloom/StatusCommand.swift
+++ b/provider-swift/Sources/darkbloom/StatusCommand.swift
@@ -26,6 +26,8 @@ struct Status: AsyncParsableCommand {
         print("Configured model: \(config.backend.model ?? "auto-select")")
         print("Continuous batching: \(config.backend.continuousBatching ? "enabled" : "disabled")")
         print("Idle timeout: \(config.backend.idleTimeoutMins == 0 ? "disabled" : "\(config.backend.idleTimeoutMins)m")")
+        let enabledBeta = BetaFeatures.enabledIDs(in: config)
+        print("Beta features: \(enabledBeta.isEmpty ? "none" : enabledBeta.joined(separator: ", ")) (manage with `darkbloom beta`)")
         print("Auto-restart: \(autoRestartStatus(config: config))")
 
         if let hardware = snapshot.hardware {

--- a/provider-swift/Tests/ProviderCoreTests/BetaFeaturesTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/BetaFeaturesTests.swift
@@ -1,0 +1,84 @@
+import Testing
+@testable import ProviderCore
+
+@Suite("Beta feature registry")
+struct BetaFeaturesTests {
+
+    private func freshConfig() -> ProviderConfig {
+        ProviderConfig(
+            provider: ProviderSettings(name: "test-provider"),
+            backend: BackendSettings(),
+            coordinator: CoordinatorSettings()
+        )
+    }
+
+    @Test("registry exposes the kv-quant feature")
+    func registryContainsKVQuant() {
+        #expect(BetaFeatures.all.contains { $0.id == "kv-quant" })
+    }
+
+    @Test("feature lookup is case-insensitive and nil for unknown ids")
+    func featureLookup() {
+        #expect(BetaFeatures.feature(id: "kv-quant")?.id == "kv-quant")
+        #expect(BetaFeatures.feature(id: "KV-QUANT")?.id == "kv-quant")
+        #expect(BetaFeatures.feature(id: "does-not-exist") == nil)
+    }
+
+    @Test("kv-quant defaults to disabled")
+    func kvQuantDefaultsOff() {
+        let feature = BetaFeatures.feature(id: "kv-quant")!
+        #expect(feature.isEnabled(in: freshConfig()) == false)
+        #expect(feature.requiresRestart == true)
+    }
+
+    @Test("apply toggles the backing config field both ways")
+    func applyTogglesField() {
+        let feature = BetaFeatures.feature(id: "kv-quant")!
+        var config = freshConfig()
+
+        feature.apply(true, to: &config)
+        #expect(config.backend.kvQuant == true)
+        #expect(feature.isEnabled(in: config) == true)
+
+        feature.apply(false, to: &config)
+        #expect(config.backend.kvQuant == false)
+        #expect(feature.isEnabled(in: config) == false)
+    }
+
+    @Test("apply only mutates its mapped field")
+    func applyIsScoped() {
+        let feature = BetaFeatures.feature(id: "kv-quant")!
+        var config = freshConfig()
+        let before = config
+
+        feature.apply(true, to: &config)
+
+        #expect(config.backend.port == before.backend.port)
+        #expect(config.backend.maxModelSlots == before.backend.maxModelSlots)
+        #expect(config.backend.enabledModels == before.backend.enabledModels)
+        #expect(config.provider == before.provider)
+        #expect(config.coordinator == before.coordinator)
+    }
+
+    @Test("enabledIDs reflects the current config")
+    func enabledIDsReflectsConfig() {
+        var config = freshConfig()
+        #expect(BetaFeatures.enabledIDs(in: config).isEmpty)
+
+        BetaFeatures.feature(id: "kv-quant")!.apply(true, to: &config)
+        #expect(BetaFeatures.enabledIDs(in: config) == ["kv-quant"])
+    }
+
+    @Test("toggling kv-quant survives a TOML round-trip")
+    func roundTripsThroughTOML() {
+        let feature = BetaFeatures.feature(id: "kv-quant")!
+        var config = freshConfig()
+        feature.apply(true, to: &config)
+
+        let toml = ConfigManager.serialize(config)
+        let decoded = ConfigManager.parse(toml)
+
+        #expect(toml.contains("kv_quant"))
+        #expect(feature.isEnabled(in: decoded) == true)
+    }
+}


### PR DESCRIPTION
## What

For the beta tag: a clean, discoverable way for providers to opt into experimental features. Starts with **KV-cache quantization** (`kv-quant`), but is a general framework.

```bash
darkbloom beta list                 # all features + on/off (default subcommand)
darkbloom beta status [feature]     # details for all, or one
darkbloom beta enable kv-quant      # writes [backend] kv_quant=true
darkbloom restart                   # apply
darkbloom beta disable kv-quant
```

`darkbloom status` now also shows a `Beta features:` line.

## Before / after

How a provider enables a beta feature (`kv-quant`):

**Before** — only an undocumented TOML field; hand-edit, no discoverability/validation/verification:

```mermaid
flowchart TD
    U([Operator wants ~2x KV capacity]) --> Q{How do I<br/>enable kv-quant?}
    Q -->|no command| NC[no beta command<br/>not shown in status]
    Q -->|not in docs| ND[kv_quant undocumented<br/>absent from quickstart + cli-reference]
    Q -->|env var?| NE[no kv_quant env var exists<br/>and launchd daemon ignores<br/>non-allowlisted DARKBLOOM_*]
    NC --> M[Only path: hand-edit<br/>~/.config/darkbloom/provider.toml]
    ND --> M
    NE --> M
    M --> TY["manually add: [backend] kv_quant = true<br/>typo-prone, no validation, no caveats"]
    TY --> R[darkbloom restart]
    R --> S[serve reads config.backend.kvQuant]
    S --> OK[engaged... but no built-in<br/>way to confirm or see state]

    style ND fill:#ffe9cc,stroke:#cc8400
    style NE fill:#ffe9cc,stroke:#cc8400
    style TY fill:#ffd6d6,stroke:#cc0000
    style OK fill:#ffe9cc,stroke:#cc8400
```

**After** — discoverable, validated, config-backed (reaches the daemon), with a verification path:

```mermaid
flowchart TD
    U([Operator wants ~2x KV capacity]) --> L[darkbloom beta list<br/>discovers kv-quant + on/off state]
    L --> EN[darkbloom beta enable kv-quant]
    EN --> REG[[BetaFeatures registry<br/>kv-quant → backend.kvQuant]]
    REG --> RMW[ConfigManager: load → set → save<br/>writes kv_quant = true to TOML]
    RMW --> HINT[prints model-family caveat<br/>+ 'restart to apply']
    HINT --> R[darkbloom restart]
    R --> D[launchd daemon reads provider.toml<br/>config-backed → always reaches daemon]
    D --> S["serve: kvQuantEnabled = config.backend.kvQuant<br/>(ProviderLoop / StandaloneServer)"]
    S --> RES{BatchScheduler<br/>resolveKVQuantScheme}
    RES -->|Gemma-4 / GPT-OSS| OK([KV-quant engaged ~1.9x capacity])
    RES -->|other family| FP[fp16 fallback - safe]
    OK --> V[Verify: darkbloom status 'Beta features' line<br/>+ darkbloom logs 'kv-quant' logger]

    style OK fill:#d6f5d6,stroke:#1a8a1a
    style V fill:#d6f5d6,stroke:#1a8a1a
    style REG fill:#dbe9ff,stroke:#2b6cb0
    style FP fill:#eeeeee,stroke:#888
```

## Why a command + config (not docs-only, not env vars)

- **Config-backed, not env-var:** the launchd daemon from `darkbloom start` only inherits an allowlist of two `DARKBLOOM_*` vars (`LaunchAgent.passthroughEnvKeys`), so an env-var toggle would silently no-op for the normal daemon. A TOML field is read by every serve path (daemon / `--foreground` / `--local`).
- **Command over docs-only:** discoverable, validated, prints the model-family caveat + restart hint, and writes the TOML correctly. Hand-editing TOML is error-prone, and `kv_quant` was previously 100% undocumented.
- **General `beta` namespace** so future beta flags don't clutter the top-level command list.

## Design

- `ProviderCore/Config/BetaFeatures.swift` — a small registry. Each `BetaFeature` maps to one `ProviderConfig` `Bool` field via `@Sendable` getter/setter closures (Swift 6 strict-concurrency safe). `kv-quant` → `backend.kvQuant`. The command + status are driven entirely off `BetaFeatures.all`, so adding a beta flag is one entry + a config field.
- `darkbloom/BetaCommand.swift` — `list` / `status` / `enable` / `disable`, modeled on the existing `autoupdate` read-modify-write precedent (`ConfigManager.save`). Idempotent no-op when already in the desired state; helpful error (exit 64) on unknown feature; `list --json`.
- Default stays **off** (fp16). No change to gating/runtime — `kv-quant` just toggles the existing `backend.kv_quant` field consumed by `resolveKVQuantScheme(...)`.

## Docs

- New `docs/provider/beta-features.md` (guide + caveats + how to verify via `darkbloom logs`).
- `kv_quant` added to the `[backend]` reference in `quickstart.md`.
- `darkbloom beta` section in `cli-reference.md`.

## Testing

- `BetaFeaturesTests` (7) green: registry lookup (case-insensitive), default-off, apply toggles + is scoped to its field, `enabledIDs`, TOML round-trip. `ConfigTests` (16) green.
- `darkbloom` CLI builds (Swift 6.1).
- Manual smoke (temp config): list/enable/persist/json/idempotent/unknown-feature/status/disable all verified.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/423"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784528726&installation_id=133247490&pr_number=423&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F423&signature=ae10ecfd6e5408985c65e8bfe9f59bf38b2ad09be1e1dd8794ba67127c1f913b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
