### PR TITLE
fix(console-ui): stop provider dashboard KPI/vitals text overlap

### DIFF
--- a/console-ui/src/app/providers/dashboard/CardVitals.tsx
+++ b/console-ui/src/app/providers/dashboard/CardVitals.tsx
@@ -20,9 +20,9 @@ function Vital({
 }) {
   return (
     <div className="space-y-1.5">
-      <div className="flex items-center justify-between gap-2">
-        <span className="text-[10px] uppercase tracking-wider text-text-tertiary">{label}</span>
-        <span className="text-xs font-mono font-semibold text-text-primary capitalize tabular-nums">{value}</span>
+      <div className="flex items-center justify-between gap-2 min-w-0">
+        <span className="text-[10px] uppercase tracking-wider text-text-tertiary truncate">{label}</span>
+        <span className="text-xs font-mono font-semibold text-text-primary capitalize tabular-nums shrink-0">{value}</span>
       </div>
       {children}
     </div>
@@ -52,9 +52,9 @@ export function CardVitals({
   const decodePct = fleetMaxDecodeTps > 0 ? (decode / fleetMaxDecodeTps) * 100 : 0;
 
   return (
-    <div className="px-4 py-3 space-y-3">
+    <div className="px-4 py-3 space-y-3 @container">
       {sm && (
-        <div className="grid grid-cols-2 md:grid-cols-4 gap-x-4 gap-y-3">
+        <div className="grid grid-cols-2 @lg:grid-cols-4 gap-x-4 gap-y-3">
           <Vital label="Thermal" value={sm.thermal_state}>
             <ThermalPips state={sm.thermal_state} />
           </Vital>

--- a/console-ui/src/app/providers/dashboard/CardVitals.tsx
+++ b/console-ui/src/app/providers/dashboard/CardVitals.tsx
@@ -19,7 +19,7 @@ function Vital({
   children: React.ReactNode;
 }) {
   return (
-    <div className="space-y-1.5">
+    <div className="space-y-1.5 min-w-0">
       <div className="flex items-center justify-between gap-2 min-w-0">
         <span className="text-[10px] uppercase tracking-wider text-text-tertiary truncate">{label}</span>
         <span className="text-xs font-mono font-semibold text-text-primary capitalize tabular-nums shrink-0">{value}</span>

--- a/console-ui/src/app/providers/dashboard/FleetHealthStrip.tsx
+++ b/console-ui/src/app/providers/dashboard/FleetHealthStrip.tsx
@@ -29,12 +29,12 @@ function KPI({
   dot?: boolean;
 }) {
   return (
-    <div>
+    <div className="min-w-0">
       <p className="text-[10px] uppercase tracking-wider text-text-tertiary flex items-center gap-1">
         {dot && <span className="w-1.5 h-1.5 rounded-full bg-accent-green" />}
         {label}
       </p>
-      <p className="text-2xl font-mono font-bold text-text-primary leading-tight mt-0.5 tabular-nums">{value}</p>
+      <p className="text-xl font-mono font-bold text-text-primary leading-tight mt-0.5 tabular-nums break-words">{value}</p>
       {sub && <p className="text-[11px] text-text-tertiary">{sub}</p>}
     </div>
   );
@@ -51,8 +51,11 @@ export function FleetHealthStrip({
   const Icon = ICON[verdict.state];
 
   return (
-    <div className={`rounded-xl bg-bg-secondary shadow-sm border border-border-dim border-l-[3px] ${meta.rail} p-5`}>
-      <div className="grid gap-5 lg:grid-cols-[36%_1fr] lg:items-center">
+    <div className={`@container rounded-xl bg-bg-secondary shadow-sm border border-border-dim border-l-[3px] ${meta.rail} p-5`}>
+      {/* Side-by-side verdict + KPIs only once the strip is genuinely wide
+          enough (container-, not viewport-keyed). Below that it stacks, so a
+          narrow strip never crams the verdict on top of the numbers. */}
+      <div className="grid gap-5 @3xl:grid-cols-[36%_1fr] @3xl:items-center">
         {/* Left: the plain-language fleet verdict (worst state wins) */}
         <div className="flex items-center gap-3">
           <div className={`w-14 h-14 rounded-full flex items-center justify-center shrink-0 ${meta.tint}`}>
@@ -64,10 +67,13 @@ export function FleetHealthStrip({
           </div>
         </div>
 
-        {/* Right: segmented capacity bar over the money + routable KPIs */}
-        <div className="space-y-4">
+        {/* Right: segmented capacity bar over the money + routable KPIs.
+            @container so columns track this region's real width, not the
+            viewport — the sidebar + 36%/1fr split leaves far less room than
+            a viewport breakpoint assumes, which is what piled the values up. */}
+        <div className="space-y-4 @container">
           <CapacityBar counts={verdict.counts} />
-          <div className="grid grid-cols-2 sm:grid-cols-5 gap-4">
+          <div className="grid grid-cols-2 @md:grid-cols-3 @2xl:grid-cols-5 gap-4">
             <KPI
               label="Total earned"
               value={summary ? formatUSD(summary.lifetime_micro_usd) : "—"}

--- a/console-ui/src/app/providers/dashboard/FleetHealthStrip.tsx
+++ b/console-ui/src/app/providers/dashboard/FleetHealthStrip.tsx
@@ -53,9 +53,11 @@ export function FleetHealthStrip({
   return (
     <div className={`@container rounded-xl bg-bg-secondary shadow-sm border border-border-dim border-l-[3px] ${meta.rail} p-5`}>
       {/* Side-by-side verdict + KPIs only once the strip is genuinely wide
-          enough (container-, not viewport-keyed). Below that it stacks, so a
-          narrow strip never crams the verdict on top of the numbers. */}
-      <div className="grid gap-5 @3xl:grid-cols-[36%_1fr] @3xl:items-center">
+          enough — @5xl (64rem) mirrors the original lg viewport threshold but
+          keys off the strip's real width, not the viewport. Below that it
+          stacks, so a narrow strip never crams the verdict on top of the
+          numbers, and the split only fires where the 5-column KPI row fits. */}
+      <div className="grid gap-5 @5xl:grid-cols-[36%_1fr] @5xl:items-center">
         {/* Left: the plain-language fleet verdict (worst state wins) */}
         <div className="flex items-center gap-3">
           <div className={`w-14 h-14 rounded-full flex items-center justify-center shrink-0 ${meta.tint}`}>


### PR DESCRIPTION
## Summary

The provider dashboard's fleet-health strip crammed KPI values and vital
labels into each other at certain widths. This reworks the strip to use
container queries keyed off the strip's real width (not the viewport), with
breakpoints chosen so the side-by-side split only fires where the 5-column
KPI row actually fits, and adds an overflow guard so a long vital value can't
push its column past its `1fr` allocation and overlap the neighbor.

## Linked issue

<!-- No tracked issue; regression in the prior dashboard layout work. -->
Closes #424 

## Test plan

- [x] `make ui-lint` — 0 errors (pre-existing warnings only)
- [x] `make ui-test` — 309 vitest tests pass (incl. `MachineCard`, `CardVitals`-adjacent suites)
- [x] `make ui-build` — Next build succeeds, no unknown-breakpoint warnings
- [x] Live Chrome DevTools sweep across strip widths — measured computed
      `grid-template-columns` and per-column overflow at each step:

  | strip width | verdict/KPI split | KPI columns | overlap |
  |---|---|---|---|
  | <28rem | stacked | 2 | none |
  | 42–60rem | stacked | 5 | none |
  | ≥64rem | side-by-side (36% / 1fr) | 3 | none |

  Split fires only at strip ≥64rem; 5-column KPIs appear when the keyed
  region ≥42rem; no KPI/vital value clips into a neighbor with real data.

## Components touched

- [ ] coordinator (Go)
- [ ] provider (Rust, legacy)
- [ ] provider-swift (Swift CLI)
- [x] console-ui (Next.js)
- [ ] enclave (Swift)
- [ ] infra / CI / release
- [ ] docs

## Protocol / interface changes

- [x] No protocol/interface changes

## Notes for reviewers

- CSS-only change (two Tailwind utility edits): the verdict/KPI split moves
  from `@3xl` (48rem, ~768px — split fired too early on narrow desktops) to
  `@5xl` (64rem, the original `lg` viewport intent expressed as a container
  query).
- The KPI row intentionally stays at `@2xl:grid-cols-5`, **not** `@5xl`:
  `@5xl` would key off the right-region container reaching 64rem, which never
  happens inside the `max-w-6xl` (72rem) shell, so it would permanently cap
  the row at 3 columns and kill the 5-column layout.
- Tradeoff: in side-by-side state the right region tops out at ~41rem (just
  under the 42rem trigger), so it shows 3 clean columns rather than 5. That
  preserves the no-overlap guarantee, which is the actual goal.
- Earlier review feedback claimed `@3xl`/`@2xl` were *undefined* in Tailwind
  v4 — they are defined (48rem / 42rem). The real issue was the threshold
  values, not missing utilities.
