### PR TITLE
fix(billing): allow changing Stripe Express country by creating new account

### DIFF
--- a/console-ui/src/app/billing/BillingContent.tsx
+++ b/console-ui/src/app/billing/BillingContent.tsx
@@ -682,7 +682,7 @@ function StripePayoutsCard({
             <span className="font-medium text-text-primary">
               {STRIPE_CONNECT_COUNTRIES.find((c) => c.code === status?.stripe_account_country)?.name || status?.stripe_account_country || "your selected country"}
             </span>
-            . If you need a different country, select it below and we will create a new account.
+            . If that is not correct, select your country below and we will create a new account.
           </p>
           <label className="block text-xs font-mono text-text-tertiary uppercase tracking-wider mb-2">
             Country

--- a/console-ui/src/app/billing/BillingContent.tsx
+++ b/console-ui/src/app/billing/BillingContent.tsx
@@ -31,7 +31,6 @@ import {
   CreditCard,
   Building2,
   Zap,
-  AlertCircle,
   ArrowDownToLine,
 } from "lucide-react";
 import { UsageChart } from "@/components/UsageChart";
@@ -90,6 +89,15 @@ export default function BillingContent() {
   const [withdrawMethod, setWithdrawMethod] = useState<"standard" | "instant">("standard");
   const [withdrawLoading, setWithdrawLoading] = useState(false);
   const [selectedStripeCountry, setSelectedStripeCountry] = useState("");
+
+  // Once a Stripe Express account exists, its country is locked. Pre-select
+  // that country so the user sees what will actually be used, and so a
+  // deliberate change triggers backend creation of a new account.
+  useEffect(() => {
+    if (stripeStatus?.stripe_account_country) {
+      setSelectedStripeCountry(stripeStatus.stripe_account_country);
+    }
+  }, [stripeStatus?.stripe_account_country]);
 
   const loadData = useCallback(async () => {
     setLoading(true);
@@ -669,24 +677,36 @@ function StripePayoutsCard({
         </>
       ) : (
         <>
-          <p className="text-sm text-text-secondary mb-4 leading-relaxed flex items-start gap-2">
-            <AlertCircle size={14} className="text-coral mt-0.5 flex-shrink-0" />
-            {restricted
-              ? "Stripe needs more information to enable payouts on your account."
-              : rejected
-              ? "Stripe has disabled payouts on this account. Contact support."
-              : "Finish linking your account on Stripe to enable withdrawals."}
+          <p className="text-sm text-text-secondary mb-4 leading-relaxed">
+            Your Stripe account is locked to{" "}
+            <span className="font-medium text-text-primary">
+              {STRIPE_CONNECT_COUNTRIES.find((c) => c.code === status?.stripe_account_country)?.name || status?.stripe_account_country || "your selected country"}
+            </span>
+            . If you need a different country, select it below and we will create a new account.
           </p>
-          {!rejected && (
-            <button
-              onClick={onOnboard}
-              disabled={onboardLoading}
-              className="flex items-center gap-2 px-5 py-2.5 rounded-lg bg-teal border-2 border-ink text-white text-sm font-bold hover:opacity-90 disabled:opacity-50 transition-all"
-            >
-              {onboardLoading ? <Loader2 size={14} className="animate-spin" /> : <Building2 size={14} />}
-              {onboardLoading ? "Redirecting..." : restricted ? "Provide more info" : "Continue setup"}
-            </button>
-          )}
+          <label className="block text-xs font-mono text-text-tertiary uppercase tracking-wider mb-2">
+            Country
+          </label>
+          <select
+            value={selectedCountry}
+            onChange={(e) => onCountryChange(e.target.value)}
+            className="w-full mb-4 bg-bg-primary border border-border-dim rounded-lg px-4 py-3 text-sm text-text-primary outline-none transition-colors hover:border-teal/40 focus:border-teal"
+          >
+            <option value="">Select your country</option>
+            {STRIPE_CONNECT_COUNTRIES.map((country) => (
+              <option key={country.code} value={country.code}>
+                {country.name} ({country.code})
+              </option>
+            ))}
+          </select>
+          <button
+            onClick={onOnboard}
+            disabled={onboardLoading || !selectedCountry}
+            className="flex items-center gap-2 px-5 py-2.5 rounded-lg bg-teal border-2 border-ink text-white text-sm font-bold hover:opacity-90 disabled:opacity-50 transition-all"
+          >
+            {onboardLoading ? <Loader2 size={14} className="animate-spin" /> : <Building2 size={14} />}
+            {onboardLoading ? "Redirecting..." : restricted ? "Provide more info" : "Continue setup"}
+          </button>
         </>
       )}
 

--- a/console-ui/src/app/providers/earnings/EarningsContent.tsx
+++ b/console-ui/src/app/providers/earnings/EarningsContent.tsx
@@ -21,7 +21,6 @@ import {
   LogIn,
   ArrowDownToLine,
   Check,
-  AlertCircle,
   Building2,
   CreditCard,
   Clock,
@@ -102,6 +101,15 @@ export default function EarningsContent() {
   const [withdrawMethod, setWithdrawMethod] = useState<"standard" | "instant">("standard");
   const [withdrawLoading, setWithdrawLoading] = useState(false);
   const [selectedCountry, setSelectedCountry] = useState("");
+
+  // Once a Stripe Express account exists, its country is locked. Pre-select
+  // that country so the user sees what will actually be used, and so a
+  // deliberate change triggers backend creation of a new account.
+  useEffect(() => {
+    if (stripeStatus?.stripe_account_country) {
+      setSelectedCountry(stripeStatus.stripe_account_country);
+    }
+  }, [stripeStatus?.stripe_account_country]);
   const [countryDropdownOpen, setCountryDropdownOpen] = useState(false);
   const [countryFilter, setCountryFilter] = useState("");
   const countryDropdownRef = useRef<HTMLDivElement>(null);
@@ -484,19 +492,83 @@ export default function EarningsContent() {
           </>
         ) : (
           <>
-            <p className="text-sm text-text-secondary mb-4 leading-relaxed flex items-start gap-2">
-              <AlertCircle size={14} className="text-coral mt-0.5 flex-shrink-0" />
-              {restricted
-                ? "Stripe needs more information to enable payouts on your account."
-                : rejected
-                ? "Stripe has disabled payouts on this account. Contact support."
-                : "Finish linking your account on Stripe to enable withdrawals."}
+            <p className="text-sm text-text-secondary mb-4 leading-relaxed">
+              Your Stripe account is locked to{" "}
+              <span className="font-medium text-text-primary">
+                {STRIPE_CONNECT_COUNTRIES.find(c => c.code === stripeStatus?.stripe_account_country)?.name || stripeStatus?.stripe_account_country || "your selected country"}
+              </span>
+              . If you need a different country, select it below and we will create a new account.
             </p>
+            <label className="block text-xs font-mono text-text-tertiary uppercase tracking-wider mb-2">
+              Country
+            </label>
+            <div className="relative mb-4" ref={countryDropdownRef}>
+              <button
+                type="button"
+                onClick={() => { setCountryDropdownOpen(!countryDropdownOpen); setCountryFilter(""); }}
+                className="w-full flex items-center justify-between gap-2 bg-bg-primary border border-border-dim rounded-lg px-4 py-3 text-sm text-left transition-colors hover:border-teal/40 focus:outline-none focus:border-teal"
+              >
+                {selectedCountry ? (
+                  <span className="flex items-center gap-2 text-text-primary">
+                    <span>{STRIPE_CONNECT_COUNTRIES.find(c => c.code === selectedCountry)?.flag}</span>
+                    <span>{STRIPE_CONNECT_COUNTRIES.find(c => c.code === selectedCountry)?.name}</span>
+                  </span>
+                ) : (
+                  <span className="flex items-center gap-2 text-text-tertiary">
+                    <Globe size={14} />
+                    <span>Select your country</span>
+                  </span>
+                )}
+                <ChevronDown size={14} className={`text-text-tertiary transition-transform ${countryDropdownOpen ? "rotate-180" : ""}`} />
+              </button>
+
+              {countryDropdownOpen && (
+                <div className="absolute z-50 mt-1 w-full bg-bg-white border border-border-dim rounded-xl shadow-lg overflow-hidden">
+                  <div className="p-2 border-b border-border-dim">
+                    <div className="relative">
+                      <Search size={14} className="absolute left-3 top-1/2 -translate-y-1/2 text-text-tertiary" />
+                      <input
+                        type="text"
+                        value={countryFilter}
+                        onChange={(e) => setCountryFilter(e.target.value)}
+                        placeholder="Search countries..."
+                        autoFocus
+                        className="w-full bg-bg-primary border border-border-dim rounded-lg pl-9 pr-3 py-2 text-sm text-text-primary placeholder:text-text-tertiary outline-none focus:border-teal"
+                      />
+                    </div>
+                  </div>
+                  <div className="max-h-64 overflow-y-auto">
+                    {STRIPE_CONNECT_COUNTRIES
+                      .filter(c => {
+                        const q = countryFilter.toLowerCase();
+                        return !q || c.name.toLowerCase().includes(q) || c.code.toLowerCase().includes(q);
+                      })
+                      .map(c => (
+                        <button
+                          key={c.code}
+                          type="button"
+                          onClick={() => { setSelectedCountry(c.code); setCountryDropdownOpen(false); }}
+                          className={`w-full flex items-center gap-3 px-4 py-2.5 text-sm text-left transition-colors ${
+                            selectedCountry === c.code
+                              ? "bg-teal/10 text-teal"
+                              : "text-text-secondary hover:bg-bg-hover"
+                          }`}
+                        >
+                          <span className="text-base">{c.flag}</span>
+                          <span className="flex-1">{c.name}</span>
+                          <span className="text-xs font-mono text-text-tertiary">{c.code}</span>
+                        </button>
+                      ))
+                    }
+                  </div>
+                </div>
+              )}
+            </div>
             {!rejected && (
               <button
                 onClick={handleStripeOnboard}
-                disabled={stripeOnboardLoading}
-                className="flex items-center gap-2 px-5 py-2.5 rounded-lg bg-teal border-2 border-ink text-white text-sm font-bold hover:opacity-90 disabled:opacity-50 transition-all"
+                disabled={stripeOnboardLoading || !selectedCountry}
+                className="flex items-center gap-2 px-5 py-2.5 rounded-lg bg-teal border-2 border-ink text-white text-sm font-bold hover:opacity-90 disabled:opacity-50 disabled:cursor-not-allowed transition-all"
               >
                 {stripeOnboardLoading ? <Loader2 size={14} className="animate-spin" /> : <Building2 size={14} />}
                 {stripeOnboardLoading ? "Redirecting..." : restricted ? "Provide more info" : "Continue setup"}

--- a/console-ui/src/app/providers/earnings/EarningsContent.tsx
+++ b/console-ui/src/app/providers/earnings/EarningsContent.tsx
@@ -497,7 +497,7 @@ export default function EarningsContent() {
               <span className="font-medium text-text-primary">
                 {STRIPE_CONNECT_COUNTRIES.find(c => c.code === stripeStatus?.stripe_account_country)?.name || stripeStatus?.stripe_account_country || "your selected country"}
               </span>
-              . If you need a different country, select it below and we will create a new account.
+              . If that is not correct, select your country below and we will create a new account.
             </p>
             <label className="block text-xs font-mono text-text-tertiary uppercase tracking-wider mb-2">
               Country
@@ -564,16 +564,14 @@ export default function EarningsContent() {
                 </div>
               )}
             </div>
-            {!rejected && (
-              <button
-                onClick={handleStripeOnboard}
-                disabled={stripeOnboardLoading || !selectedCountry}
-                className="flex items-center gap-2 px-5 py-2.5 rounded-lg bg-teal border-2 border-ink text-white text-sm font-bold hover:opacity-90 disabled:opacity-50 disabled:cursor-not-allowed transition-all"
-              >
-                {stripeOnboardLoading ? <Loader2 size={14} className="animate-spin" /> : <Building2 size={14} />}
-                {stripeOnboardLoading ? "Redirecting..." : restricted ? "Provide more info" : "Continue setup"}
-              </button>
-            )}
+            <button
+              onClick={handleStripeOnboard}
+              disabled={stripeOnboardLoading || !selectedCountry}
+              className="flex items-center gap-2 px-5 py-2.5 rounded-lg bg-teal border-2 border-ink text-white text-sm font-bold hover:opacity-90 disabled:opacity-50 disabled:cursor-not-allowed transition-all"
+            >
+              {stripeOnboardLoading ? <Loader2 size={14} className="animate-spin" /> : <Building2 size={14} />}
+              {stripeOnboardLoading ? "Redirecting..." : restricted ? "Provide more info" : "Continue setup"}
+            </button>
           </>
         )}
 

--- a/console-ui/src/lib/api.ts
+++ b/console-ui/src/lib/api.ts
@@ -253,6 +253,7 @@ export interface StripeStatus {
   configured: boolean;
   has_account: boolean;
   stripe_account_id?: string;
+  stripe_account_country?: string;
   status: "" | "pending" | "ready" | "restricted" | "rejected";
   destination_type?: "" | "bank" | "card";
   destination_last4?: string;

--- a/coordinator/api/stripe_payouts.go
+++ b/coordinator/api/stripe_payouts.go
@@ -122,7 +122,7 @@ func (s *Server) handleStripeOnboard(w http.ResponseWriter, r *http.Request) {
 	// changed later.
 	stripeAcctID := user.StripeAccountID
 	countryChanged := stripeAcctID != "" && requestedCountry != "" &&
-		user.StripeAccountCountry != "" && requestedCountry != user.StripeAccountCountry
+		(user.StripeAccountCountry == "" || requestedCountry != user.StripeAccountCountry)
 
 	if stripeAcctID == "" || countryChanged {
 		country := requestedCountry

--- a/coordinator/api/stripe_payouts.go
+++ b/coordinator/api/stripe_payouts.go
@@ -105,17 +105,29 @@ func (s *Server) handleStripeOnboard(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Reuse the user's existing Stripe account if we have one. If we don't,
-	// create a fresh Express account and persist the ID before we ever hand
-	// the user a link — otherwise a webhook arriving before our DB write
-	// could reference an unknown account.
+	// Normalize the requested country up front. Stripe Express country is
+	// immutable once the account is created, so we treat the user's selection
+	// as the source of truth.
+	requestedCountry := strings.ToUpper(strings.TrimSpace(req.Country))
+	if requestedCountry == "" && user.StripeAccountID == "" {
+		writeJSON(w, http.StatusBadRequest, errorResponse("invalid_request_error",
+			"country is required before creating a Stripe payout account"))
+		return
+	}
+
+	// Stripe locks the country when the Express account is created. If the
+	// user picked a different country than their existing (possibly unfinished)
+	// account, create a new account so they can onboard in the right country.
+	// See https://docs.stripe.com/connect/accounts — Express country cannot be
+	// changed later.
 	stripeAcctID := user.StripeAccountID
-	if stripeAcctID == "" {
-		country := strings.ToUpper(strings.TrimSpace(req.Country))
+	countryChanged := stripeAcctID != "" && requestedCountry != "" &&
+		user.StripeAccountCountry != "" && requestedCountry != user.StripeAccountCountry
+
+	if stripeAcctID == "" || countryChanged {
+		country := requestedCountry
 		if country == "" {
-			writeJSON(w, http.StatusBadRequest, errorResponse("invalid_request_error",
-				"country is required before creating a Stripe payout account"))
-			return
+			country = s.billing.StripeConnect().PlatformCountry()
 		}
 		acct, err := s.billing.StripeConnect().CreateExpressAccount(billing.CreateExpressAccountParams{
 			Email:   user.Email,
@@ -127,7 +139,7 @@ func (s *Server) handleStripeOnboard(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		stripeAcctID = acct.ID
-		if err := s.billing.Store().SetUserStripeAccount(user.AccountID, stripeAcctID, stripeStatusPending, "", "", false); err != nil {
+		if err := s.billing.Store().SetUserStripeAccount(user.AccountID, stripeAcctID, stripeStatusPending, country, "", "", false); err != nil {
 			s.logger.Error("stripe connect: persist account id failed", "error", err)
 			writeJSON(w, http.StatusInternalServerError, errorResponse("internal_error", "failed to persist Stripe account"))
 			return
@@ -173,6 +185,7 @@ func (s *Server) handleStripeStatus(w http.ResponseWriter, r *http.Request) {
 		"configured":             true,
 		"stripe_account_id":      user.StripeAccountID,
 		"status":                 user.StripeAccountStatus,
+		"stripe_account_country": user.StripeAccountCountry,
 		"destination_type":       user.StripeDestinationType,
 		"destination_last4":      user.StripeDestinationLast4,
 		"instant_eligible":       user.StripeInstantEligible,
@@ -191,7 +204,7 @@ func (s *Server) handleStripeStatus(w http.ResponseWriter, r *http.Request) {
 		} else {
 			status := stripeStatusForAccount(acct)
 			if err := s.billing.Store().SetUserStripeAccount(user.AccountID, user.StripeAccountID,
-				status, acct.DestinationType, acct.DestinationLast4, acct.InstantEligible); err != nil {
+				status, "", acct.DestinationType, acct.DestinationLast4, acct.InstantEligible); err != nil {
 				s.logger.Warn("stripe connect: status persist failed", "error", err)
 			} else {
 				resp["status"] = status
@@ -523,7 +536,7 @@ func (s *Server) handleAccountUpdated(event *billing.WebhookEvent) {
 	}
 	status := stripeStatusForAccount(acct)
 	if err := s.billing.Store().SetUserStripeAccount(user.AccountID, acct.ID,
-		status, acct.DestinationType, acct.DestinationLast4, acct.InstantEligible); err != nil {
+		status, "", acct.DestinationType, acct.DestinationLast4, acct.InstantEligible); err != nil {
 		s.logger.Error("stripe connect webhook: persist account state failed", "error", err)
 	}
 }

--- a/coordinator/api/stripe_payouts_test.go
+++ b/coordinator/api/stripe_payouts_test.go
@@ -202,11 +202,11 @@ func TestStripeOnboardReusesExistingAccount(t *testing.T) {
 	srv, st := stripePayoutsTestServer(t, true, nil)
 	user := seedUser(t, st, "acct-reuse-1", "bob@example.com")
 
-	// Pre-seed an existing Stripe account ID.
-	_ = st.SetUserStripeAccount(user.AccountID, "acct_existing_123", "ready", "bank", "1234", false)
+	// Pre-seed an existing Stripe account ID locked to the US.
+	_ = st.SetUserStripeAccount(user.AccountID, "acct_existing_123", "ready", "US", "bank", "1234", false)
 	user, _ = st.GetUserByAccountID(user.AccountID)
 
-	req := httptest.NewRequest(http.MethodPost, "/v1/billing/stripe/onboard", strings.NewReader(`{}`))
+	req := httptest.NewRequest(http.MethodPost, "/v1/billing/stripe/onboard", strings.NewReader(`{"country":"US"}`))
 	req = withPrivyUser(req, user)
 	w := httptest.NewRecorder()
 	srv.handleStripeOnboard(w, req)
@@ -221,12 +221,74 @@ func TestStripeOnboardReusesExistingAccount(t *testing.T) {
 	}
 }
 
+func TestStripeOnboardCreatesNewAccountWhenCountryChanges(t *testing.T) {
+	var mu sync.Mutex
+	var createdCountries []string
+
+	fakeStripe := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/v1/accounts" && r.Method == http.MethodPost:
+			body, _ := io.ReadAll(r.Body)
+			parsed, _ := url.ParseQuery(string(body))
+			mu.Lock()
+			createdCountries = append(createdCountries, parsed.Get("country"))
+			mu.Unlock()
+			w.WriteHeader(200)
+			id := "acct_" + strings.ToLower(parsed.Get("country")) + "_new"
+			_, _ = w.Write([]byte(`{"id":"` + id + `","type":"express","charges_enabled":false,"payouts_enabled":false,"details_submitted":false}`))
+		case strings.HasPrefix(r.URL.Path, "/v1/account_links"):
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte(`{"url":"https://connect.stripe.com/setup/e/new"}`))
+		default:
+			w.WriteHeader(404)
+		}
+	}))
+	defer fakeStripe.Close()
+
+	srv, st := stripePayoutsTestServer(t, false, fakeStripe)
+	user := seedUser(t, st, "acct-country-change-1", "alice@example.com")
+
+	// Pre-seed an existing Stripe account ID locked to the US.
+	_ = st.SetUserStripeAccount(user.AccountID, "acct_us_old", "pending", "US", "", "", false)
+	user, _ = st.GetUserByAccountID(user.AccountID)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/billing/stripe/onboard",
+		strings.NewReader(`{"country":"GB"}`))
+	req = withPrivyUser(req, user)
+	w := httptest.NewRecorder()
+	srv.handleStripeOnboard(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("got %d: %s", w.Code, w.Body.String())
+	}
+	var resp map[string]any
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp["stripe_account_id"] != "acct_gb_new" {
+		t.Errorf("expected new GB account, got %v", resp["stripe_account_id"])
+	}
+
+	refreshed, _ := st.GetUserByAccountID(user.AccountID)
+	if refreshed.StripeAccountCountry != "GB" {
+		t.Errorf("StripeAccountCountry = %q, want GB", refreshed.StripeAccountCountry)
+	}
+	if refreshed.StripeAccountStatus != "pending" {
+		t.Errorf("status = %q, want pending", refreshed.StripeAccountStatus)
+	}
+
+	mu.Lock()
+	countries := append([]string(nil), createdCountries...)
+	mu.Unlock()
+	if len(countries) != 1 || countries[0] != "GB" {
+		t.Errorf("Stripe create account countries = %v, want [GB]", countries)
+	}
+}
+
 // --- Status ---
 
 func TestStripeStatusReportsCurrentState(t *testing.T) {
 	srv, st := stripePayoutsTestServer(t, true, nil)
 	user := seedUser(t, st, "acct-status-1", "alice@example.com")
-	_ = st.SetUserStripeAccount(user.AccountID, "acct_x", "ready", "card", "4242", true)
+	_ = st.SetUserStripeAccount(user.AccountID, "acct_x", "ready", "", "card", "4242", true)
 	user, _ = st.GetUserByAccountID(user.AccountID)
 
 	req := httptest.NewRequest(http.MethodGet, "/v1/billing/stripe/status", nil)
@@ -696,7 +758,7 @@ func TestConnectWebhookAccountUpdatedFlipsStatusToReady(t *testing.T) {
 
 	srv, st := stripePayoutsTestServer(t, false, fakeStripe)
 	user := seedUser(t, st, "acct-wh-1", "alice@example.com")
-	_ = st.SetUserStripeAccount(user.AccountID, "acct_x_wh", "pending", "", "", false)
+	_ = st.SetUserStripeAccount(user.AccountID, "acct_x_wh", "pending", "", "", "", false)
 
 	payload := []byte(`{
 		"type": "account.updated",
@@ -889,7 +951,7 @@ func readyUser(t *testing.T, st *store.MemoryStore, accountID, email string, ins
 		dest = "card"
 		last4 = "4242"
 	}
-	if err := st.SetUserStripeAccount(u.AccountID, "acct_"+accountID, "ready", dest, last4, instantEligible); err != nil {
+	if err := st.SetUserStripeAccount(u.AccountID, "acct_"+accountID, "ready", "", dest, last4, instantEligible); err != nil {
 		t.Fatal(err)
 	}
 	got, _ := st.GetUserByAccountID(u.AccountID)

--- a/coordinator/api/stripe_payouts_test.go
+++ b/coordinator/api/stripe_payouts_test.go
@@ -283,6 +283,33 @@ func TestStripeOnboardCreatesNewAccountWhenCountryChanges(t *testing.T) {
 	}
 }
 
+func TestStripeOnboardCreatesNewAccountWhenExistingCountryUnknown(t *testing.T) {
+	srv, st := stripePayoutsTestServer(t, true, nil)
+	user := seedUser(t, st, "acct-country-unknown-1", "carol@example.com")
+
+	// Simulates users created before stripe_account_country existed. If they
+	// explicitly select a country, don't reuse the unknown-country account.
+	_ = st.SetUserStripeAccount(user.AccountID, "acct_old_unknown", "pending", "", "", "", false)
+	user, _ = st.GetUserByAccountID(user.AccountID)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/billing/stripe/onboard",
+		strings.NewReader(`{"country":"GB"}`))
+	req = withPrivyUser(req, user)
+	w := httptest.NewRecorder()
+	srv.handleStripeOnboard(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("got %d: %s", w.Code, w.Body.String())
+	}
+	refreshed, _ := st.GetUserByAccountID(user.AccountID)
+	if refreshed.StripeAccountID == "acct_old_unknown" {
+		t.Fatal("expected a new Stripe account for explicit country selection")
+	}
+	if refreshed.StripeAccountCountry != "GB" {
+		t.Errorf("StripeAccountCountry = %q, want GB", refreshed.StripeAccountCountry)
+	}
+}
+
 // --- Status ---
 
 func TestStripeStatusReportsCurrentState(t *testing.T) {

--- a/coordinator/billing/stripe_connect.go
+++ b/coordinator/billing/stripe_connect.go
@@ -102,6 +102,10 @@ func NewStripeConnect(secretKey, connectWebhookSecret, platformCountry string, m
 // MockMode reports whether the client is short-circuiting Stripe API calls.
 func (c *StripeConnect) MockMode() bool { return c.mockMode }
 
+// PlatformCountry returns the ISO 3166-1 alpha-2 platform default country
+// used when the user doesn't provide one.
+func (c *StripeConnect) PlatformCountry() string { return c.platformCountry }
+
 // stripeAPIBase is overridden by tests to point at httptest.NewServer().
 var stripeAPIBase = "https://api.stripe.com"
 

--- a/coordinator/store/interface.go
+++ b/coordinator/store/interface.go
@@ -330,7 +330,9 @@ type Store interface {
 
 	// SetUserStripeAccount upserts the Stripe Connect fields on a user record.
 	// Pass empty strings to clear the destination (e.g. before re-onboarding).
-	SetUserStripeAccount(accountID, stripeAccountID, status, destinationType, destinationLast4 string, instantEligible bool) error
+	// stripeAccountCountry is the ISO 3166-1 alpha-2 country the Express
+	// account is locked to; empty leaves the column unchanged.
+	SetUserStripeAccount(accountID, stripeAccountID, status, stripeAccountCountry, destinationType, destinationLast4 string, instantEligible bool) error
 
 	// GetUserByStripeAccount finds a user by their Stripe connected account ID.
 	// Used by webhook handlers to route account.updated / payout.* events.
@@ -1074,6 +1076,7 @@ type User struct {
 	// "rejected" (Stripe permanently disabled the account).
 	StripeAccountID        string `json:"stripe_account_id,omitempty"`
 	StripeAccountStatus    string `json:"stripe_account_status,omitempty"`
+	StripeAccountCountry   string `json:"stripe_account_country,omitempty"`  // ISO 3166-1 alpha-2 country the Express account is locked to
 	StripeDestinationType  string `json:"stripe_destination_type,omitempty"` // "bank" | "card" | ""
 	StripeDestinationLast4 string `json:"stripe_destination_last4,omitempty"`
 	StripeInstantEligible  bool   `json:"stripe_instant_eligible,omitempty"` // debit-card destination supports Instant Payouts

--- a/coordinator/store/memory.go
+++ b/coordinator/store/memory.go
@@ -1987,7 +1987,9 @@ func (s *MemoryStore) GetUserByAccountID(accountID string) (*User, error) {
 }
 
 // SetUserStripeAccount upserts the Stripe Connect fields on a user record.
-func (s *MemoryStore) SetUserStripeAccount(accountID, stripeAccountID, status, destinationType, destinationLast4 string, instantEligible bool) error {
+// stripeAccountCountry is the ISO country the Express account is locked to.
+// Pass an empty string to leave the existing country value unchanged.
+func (s *MemoryStore) SetUserStripeAccount(accountID, stripeAccountID, status, stripeAccountCountry, destinationType, destinationLast4 string, instantEligible bool) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -2004,6 +2006,9 @@ func (s *MemoryStore) SetUserStripeAccount(accountID, stripeAccountID, status, d
 
 	u.StripeAccountID = stripeAccountID
 	u.StripeAccountStatus = status
+	if stripeAccountCountry != "" {
+		u.StripeAccountCountry = stripeAccountCountry
+	}
 	u.StripeDestinationType = destinationType
 	u.StripeDestinationLast4 = destinationLast4
 	u.StripeInstantEligible = instantEligible

--- a/coordinator/store/postgres.go
+++ b/coordinator/store/postgres.go
@@ -637,6 +637,7 @@ func (s *PostgresStore) migrate(ctx context.Context) error {
 		// Stripe Connect — bank/card payouts
 		`DO $$ BEGIN ALTER TABLE users ADD COLUMN IF NOT EXISTS stripe_account_id TEXT NOT NULL DEFAULT ''; EXCEPTION WHEN others THEN NULL; END $$`,
 		`DO $$ BEGIN ALTER TABLE users ADD COLUMN IF NOT EXISTS stripe_account_status TEXT NOT NULL DEFAULT ''; EXCEPTION WHEN others THEN NULL; END $$`,
+		`DO $$ BEGIN ALTER TABLE users ADD COLUMN IF NOT EXISTS stripe_account_country TEXT NOT NULL DEFAULT ''; EXCEPTION WHEN others THEN NULL; END $$`,
 		`DO $$ BEGIN ALTER TABLE users ADD COLUMN IF NOT EXISTS stripe_destination_type TEXT NOT NULL DEFAULT ''; EXCEPTION WHEN others THEN NULL; END $$`,
 		`DO $$ BEGIN ALTER TABLE users ADD COLUMN IF NOT EXISTS stripe_destination_last4 TEXT NOT NULL DEFAULT ''; EXCEPTION WHEN others THEN NULL; END $$`,
 		`DO $$ BEGIN ALTER TABLE users ADD COLUMN IF NOT EXISTS stripe_instant_eligible BOOLEAN NOT NULL DEFAULT FALSE; EXCEPTION WHEN others THEN NULL; END $$`,
@@ -3006,16 +3007,16 @@ func (s *PostgresStore) CreateUser(user *User) error {
 }
 
 const userSelectColumns = `account_id, privy_user_id, email, role, platform_fee_percent,
-	stripe_account_id, stripe_account_status, stripe_destination_type,
-	stripe_destination_last4, stripe_instant_eligible, created_at`
+	stripe_account_id, stripe_account_status, stripe_account_country,
+	stripe_destination_type, stripe_destination_last4, stripe_instant_eligible, created_at`
 
 func scanUser(row interface {
 	Scan(...any) error
 }) (*User, error) {
 	var u User
 	if err := row.Scan(&u.AccountID, &u.PrivyUserID, &u.Email, &u.Role, &u.PlatformFeePercent,
-		&u.StripeAccountID, &u.StripeAccountStatus, &u.StripeDestinationType,
-		&u.StripeDestinationLast4, &u.StripeInstantEligible, &u.CreatedAt); err != nil {
+		&u.StripeAccountID, &u.StripeAccountStatus, &u.StripeAccountCountry,
+		&u.StripeDestinationType, &u.StripeDestinationLast4, &u.StripeInstantEligible, &u.CreatedAt); err != nil {
 		return nil, err
 	}
 	return &u, nil
@@ -3052,19 +3053,28 @@ func (s *PostgresStore) GetUserByAccountID(accountID string) (*User, error) {
 }
 
 // SetUserStripeAccount upserts the Stripe Connect fields on a user record.
-func (s *PostgresStore) SetUserStripeAccount(accountID, stripeAccountID, status, destinationType, destinationLast4 string, instantEligible bool) error {
+// stripeAccountCountry is the ISO country the Express account is locked to.
+// Pass an empty string to leave the existing country value unchanged.
+func (s *PostgresStore) SetUserStripeAccount(accountID, stripeAccountID, status, stripeAccountCountry, destinationType, destinationLast4 string, instantEligible bool) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
+	countryClause := ""
+	args := []any{accountID, stripeAccountID, status, destinationType, destinationLast4, instantEligible}
+	if stripeAccountCountry != "" {
+		countryClause = ", stripe_account_country = $7"
+		args = append(args, stripeAccountCountry)
+	}
+
 	tag, err := s.pool.Exec(ctx,
-		`UPDATE users SET
+		fmt.Sprintf(`UPDATE users SET
 			stripe_account_id = $2,
 			stripe_account_status = $3,
 			stripe_destination_type = $4,
 			stripe_destination_last4 = $5,
-			stripe_instant_eligible = $6
-		 WHERE account_id = $1`,
-		accountID, stripeAccountID, status, destinationType, destinationLast4, instantEligible,
+			stripe_instant_eligible = $6%s
+		 WHERE account_id = $1`, countryClause),
+		args...,
 	)
 	if err != nil {
 		return fmt.Errorf("store: set stripe account: %w", err)

--- a/coordinator/store/postgres_test.go
+++ b/coordinator/store/postgres_test.go
@@ -433,7 +433,7 @@ func TestPostgresSetUserStripeAccount(t *testing.T) {
 		t.Fatalf("create user: %v", err)
 	}
 
-	if err := s.SetUserStripeAccount("acct-pg-1", "acct_123", "ready", "card", "4242", true); err != nil {
+	if err := s.SetUserStripeAccount("acct-pg-1", "acct_123", "ready", "US", "card", "4242", true); err != nil {
 		t.Fatalf("set stripe account: %v", err)
 	}
 
@@ -447,11 +447,23 @@ func TestPostgresSetUserStripeAccount(t *testing.T) {
 	if got.StripeAccountStatus != "ready" {
 		t.Errorf("status = %q", got.StripeAccountStatus)
 	}
+	if got.StripeAccountCountry != "US" {
+		t.Errorf("StripeAccountCountry = %q, want US", got.StripeAccountCountry)
+	}
 	if got.StripeDestinationType != "card" || got.StripeDestinationLast4 != "4242" {
 		t.Errorf("destination = %q ••%q", got.StripeDestinationType, got.StripeDestinationLast4)
 	}
 	if !got.StripeInstantEligible {
 		t.Error("instant_eligible should be true")
+	}
+
+	// Updating without a country should leave it unchanged.
+	if err := s.SetUserStripeAccount("acct-pg-1", "acct_123", "restricted", "", "card", "4242", true); err != nil {
+		t.Fatalf("set stripe account without country: %v", err)
+	}
+	got, _ = s.GetUserByAccountID("acct-pg-1")
+	if got.StripeAccountCountry != "US" {
+		t.Errorf("StripeAccountCountry after no-country update = %q, want US", got.StripeAccountCountry)
 	}
 
 	// Lookup by stripe account ID.
@@ -507,7 +519,7 @@ func TestPostgresCreateUserPersistsRoleAndFee(t *testing.T) {
 
 func TestPostgresSetUserStripeAccountUserNotFound(t *testing.T) {
 	s := testPostgresStore(t)
-	err := s.SetUserStripeAccount("nope", "acct_x", "pending", "", "", false)
+	err := s.SetUserStripeAccount("nope", "acct_x", "pending", "", "", "", false)
 	if err == nil {
 		t.Fatal("expected error for missing user")
 	}
@@ -518,7 +530,7 @@ func TestPostgresStripeWithdrawalCRUD(t *testing.T) {
 
 	u := &User{AccountID: "acct-pg-wd", PrivyUserID: "did:privy:pgwd"}
 	_ = s.CreateUser(u)
-	_ = s.SetUserStripeAccount("acct-pg-wd", "acct_wd", "ready", "bank", "6789", false)
+	_ = s.SetUserStripeAccount("acct-pg-wd", "acct_wd", "ready", "", "bank", "6789", false)
 
 	wd := &StripeWithdrawal{
 		ID:              "wd-pg-1",
@@ -581,7 +593,7 @@ func TestPostgresStripeWithdrawalRefundFlag(t *testing.T) {
 	s := testPostgresStore(t)
 	u := &User{AccountID: "acct-pg-rf", PrivyUserID: "did:privy:pgrf"}
 	_ = s.CreateUser(u)
-	_ = s.SetUserStripeAccount("acct-pg-rf", "acct_rf", "ready", "bank", "1", false)
+	_ = s.SetUserStripeAccount("acct-pg-rf", "acct_rf", "ready", "", "bank", "1", false)
 
 	wd := &StripeWithdrawal{
 		ID: "wd-pg-rf", AccountID: "acct-pg-rf", StripeAccountID: "acct_rf",
@@ -612,7 +624,7 @@ func TestPostgresStripeWithdrawalDuplicateIDRejected(t *testing.T) {
 	s := testPostgresStore(t)
 	u := &User{AccountID: "acct-pg-dup", PrivyUserID: "did:privy:pgdup"}
 	_ = s.CreateUser(u)
-	_ = s.SetUserStripeAccount("acct-pg-dup", "acct_dup", "ready", "bank", "1", false)
+	_ = s.SetUserStripeAccount("acct-pg-dup", "acct_dup", "ready", "", "bank", "1", false)
 
 	wd := &StripeWithdrawal{
 		ID: "wd-dup", AccountID: "acct-pg-dup", StripeAccountID: "acct_dup",


### PR DESCRIPTION
## Summary
- Store the locked Stripe Express account country alongside the connected account ID.
- Create a fresh Stripe Express account when a user explicitly selects a different country, including migrated users whose existing account country is unknown.
- Surface the locked country in Billing and Provider Earnings so users can pick the correct country and restart onboarding.
- Allow rejected Provider Earnings accounts to submit a replacement country from that page.

## Why
Stripe Express account country is immutable after account creation. Reusing an existing wrong-country account sent users back to Stripe still seeing USA. With this change, selecting the correct country creates a new connected account while existing internal earnings balances remain unchanged.

## Existing Users
Users stuck with a wrong-country Stripe account can select their correct country in Billing or Provider Earnings and continue. The backend creates a new Express account for future withdrawals. Historical withdrawals remain tied to the old account.

## Verification
- `go test ./api/ -run TestStripe`
- `go test ./store/ -count=1`
- `go test ./billing/ -count=1`
- `go build ./...`
- `golangci-lint run`
- `npm test -- --run`
- `npx eslint src/app/billing/BillingContent.tsx src/app/providers/earnings/EarningsContent.tsx src/lib/api.ts`
- `npm run build`