### PR TITLE
fix(coordinator): restore inference route persistence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,12 +9,28 @@ jobs:
   test-coordinator:
     name: Coordinator Tests
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: testbed
+          POSTGRES_PASSWORD: testbed
+          POSTGRES_DB: testbed
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U testbed -d testbed"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
           go-version-file: go.mod
       - name: Run tests
+        env:
+          DATABASE_URL: postgres://testbed:testbed@127.0.0.1:5432/testbed?sslmode=disable
         run: go test -race $(go list ./... | grep -v /e2e)
       - name: Check formatting
         run: |

--- a/coordinator/api/dispatch.go
+++ b/coordinator/api/dispatch.go
@@ -288,7 +288,15 @@ func (d *dispatchState) recordRoutingDecisionFor(provider *registry.Provider, pr
 	}
 
 	s.submitTelemetry("recordInferenceRoute", func() {
-		_ = s.store.RecordInferenceRoute(record)
+		if err := s.store.RecordInferenceRoute(record); err != nil && s.logger != nil {
+			s.logger.Error("inference_routes record write failed",
+				"request_id", record.RequestID,
+				"attempt", record.Attempt,
+				"provider_id", record.ProviderID,
+				"model", record.Model,
+				"error", err,
+			)
+		}
 	})
 }
 

--- a/coordinator/api/route_outcome.go
+++ b/coordinator/api/route_outcome.go
@@ -38,10 +38,6 @@ var validInferenceErrorReasons = map[string]struct{}{
 	errorReasonUnknown:            {},
 }
 
-func (s *Server) updateInferenceRouteOutcome(requestID string, attempt int, outcome *store.InferenceRouteOutcome) {
-	s.updateInferenceRouteOutcomeWithModel(requestID, attempt, "", outcome)
-}
-
 func (s *Server) updateInferenceRouteOutcomeWithModel(requestID string, attempt int, model string, outcome *store.InferenceRouteOutcome) {
 	if s == nil || s.store == nil || requestID == "" || outcome == nil {
 		return

--- a/coordinator/api/route_outcome.go
+++ b/coordinator/api/route_outcome.go
@@ -48,7 +48,17 @@ func (s *Server) updateInferenceRouteOutcomeWithModel(requestID string, attempt 
 	}
 	s.emitInferenceErrorMetric(model, outcome)
 	s.submitTelemetry("updateInferenceRoute", func() {
-		_ = s.store.UpdateInferenceRouteOutcome(requestID, attempt, outcome)
+		if err := s.store.UpdateInferenceRouteOutcome(requestID, attempt, outcome); err != nil && s.logger != nil {
+			s.logger.Error("inference_routes outcome update failed",
+				"request_id", requestID,
+				"attempt", attempt,
+				"model", model,
+				"final_status", outcome.FinalStatus,
+				"error_class", outcome.ErrorClass,
+				"error_reason", outcome.ErrorReason,
+				"error", err,
+			)
+		}
 	})
 }
 

--- a/coordinator/registry/scheduler.go
+++ b/coordinator/registry/scheduler.go
@@ -1494,18 +1494,6 @@ func providerModelIDs(p *Provider) []string {
 	return ids
 }
 
-// providerCanAdmitLocked is the under-the-provider-lock admit re-check run in
-// ReserveProviderEx after a winner is selected: it re-applies every routing
-// gate (via the shared providerPassesRoutingGatesLocked — same catalog, trust,
-// privacy, challenge, shape-keyed inference-error cooldown, and trait gates as
-// selection) plus the admit-specific capacity gates (concurrency headroom and
-// non-crashed/non-reloading slot state). This guards the race where the
-// provider's state changed between snapshot and reservation. Caller holds r.mu
-// and p.mu.
-func (r *Registry) providerCanAdmitLocked(p *Provider, model string, traits RequestTraits, selfRouteOwner bool) bool {
-	return r.providerCanAdmitLockedEx(p, model, traits, selfRouteOwner, false)
-}
-
 // providerCanAdmitLockedEx is providerCanAdmitLocked with an explicit
 // ignoreProviderBreaker switch. ReserveProviderEx sets it true ONLY when the
 // selected winner is itself node-health-breaker-open — which can happen only

--- a/coordinator/store/postgres.go
+++ b/coordinator/store/postgres.go
@@ -836,7 +836,7 @@ func (s *PostgresStore) migrate(ctx context.Context) error {
 				WHERE t.oid = 'inference_routes'::regclass
 				  AND i.indisunique
 				  AND ARRAY(
-					SELECT a.attname
+					SELECT a.attname::text
 					FROM unnest(i.indkey) WITH ORDINALITY AS k(attnum, ord)
 					JOIN pg_attribute a ON a.attrelid = t.oid AND a.attnum = k.attnum
 					ORDER BY k.ord

--- a/coordinator/store/postgres.go
+++ b/coordinator/store/postgres.go
@@ -827,6 +827,24 @@ func (s *PostgresStore) migrate(ctx context.Context) error {
 		`CREATE INDEX IF NOT EXISTS idx_inference_routes_provider ON inference_routes(provider_id, created_at DESC)`,
 		`CREATE INDEX IF NOT EXISTS idx_inference_routes_model ON inference_routes(model, created_at DESC)`,
 		`CREATE INDEX IF NOT EXISTS idx_inference_routes_request ON inference_routes(request_id)`,
+		`DO $$
+		BEGIN
+			IF NOT EXISTS (
+				SELECT 1
+				FROM pg_index i
+				JOIN pg_class t ON t.oid = i.indrelid
+				WHERE t.oid = 'inference_routes'::regclass
+				  AND i.indisunique
+				  AND ARRAY(
+					SELECT a.attname
+					FROM unnest(i.indkey) WITH ORDINALITY AS k(attnum, ord)
+					JOIN pg_attribute a ON a.attrelid = t.oid AND a.attnum = k.attnum
+					ORDER BY k.ord
+				  ) = ARRAY['request_id', 'attempt']
+			) THEN
+				CREATE UNIQUE INDEX idx_inference_routes_request_attempt_unique ON inference_routes(request_id, attempt);
+			END IF;
+		END $$`,
 		// Phase 1 additions to inference_routes: coarse geo, coordinator-side
 		// latency decomposition, measured decode TPS, and admission/backup-race
 		// outcome flags. Added idempotently so a dev DB that already created the
@@ -1478,8 +1496,31 @@ func (s *PostgresStore) RecordUsageFullWithPublicModel(providerID, consumerKey, 
 	)
 }
 
+const inferenceRouteErrorReasonUpsertAssignment = "error_reason = COALESCE(NULLIF(EXCLUDED.error_reason, ''), inference_routes.error_reason)"
+
+const inferenceRouteSelectColumns = `
+			id,
+			request_id, attempt, provider_id, model, public_model, consumer_key_hash, key_id, outcome,
+			cost_ms, state_ms, queue_ms, pending_ms, backlog_ms, this_req_ms, health_ms, ttft_ms, best_ttft_ms,
+			effective_queue, candidate_count, capacity_rejections, model_too_large_rejections, vision_rejections, ttft_rejections,
+			effective_tps, static_tps, provider_status, provider_trust_level, provider_version,
+			hardware_chip, hardware_chip_family, hardware_tier, memory_gb, gpu_cores, cpu_cores,
+			system_memory_pressure, system_cpu_usage, system_thermal_state,
+			gpu_memory_active_gb, gpu_memory_peak_gb, gpu_memory_cache_gb,
+			slot_state, backend_running, backend_waiting,
+			active_token_budget_used, active_token_budget_max, queued_token_budget,
+			estimated_prompt_tokens, requested_max_tokens,
+			requires_vision, has_tools, self_route_only, prefer_owner, cache_affinity_key,
+			final_status, error_code, error_class, prompt_tokens, completion_tokens, reasoning_tokens, cost_micro_usd,
+			actual_ttft_ms, dispatch_to_first_chunk_ms, total_duration_ms,
+			created_at, updated_at,
+			provider_region, consumer_region,
+			parse_ms, reserve_ms, route_ms, encrypt_ms, queue_wait_ms, dispatch_ms, actual_decode_tps,
+			admitted_but_failed, used_backup, backup_won, error_reason`
+
 // RecordInferenceRoute writes the routing decision snapshot for a request
-// attempt. Best-effort; failures are discarded and never block inference.
+// attempt. Callers keep this best-effort by logging returned errors off the
+// request path rather than blocking inference.
 func (s *PostgresStore) RecordInferenceRoute(record *InferenceRouteRecord) error {
 	if record == nil {
 		return nil
@@ -1498,7 +1539,7 @@ func (s *PostgresStore) RecordInferenceRoute(record *InferenceRouteRecord) error
 		updatedAt = now
 	}
 
-	_, _ = s.pool.Exec(ctx,
+	_, err := s.pool.Exec(ctx,
 		`INSERT INTO inference_routes (
 			request_id, attempt, provider_id, model, public_model, consumer_key_hash, key_id, outcome,
 			cost_ms, state_ms, queue_ms, pending_ms, backlog_ms, this_req_ms, health_ms, ttft_ms, best_ttft_ms,
@@ -1581,7 +1622,7 @@ func (s *PostgresStore) RecordInferenceRoute(record *InferenceRouteRecord) error
 			cache_affinity_key = EXCLUDED.cache_affinity_key,
 			provider_region = EXCLUDED.provider_region,
 			consumer_region = EXCLUDED.consumer_region,
-			error_reason = COALESCE(NULLIF(EXCLUDED.error_reason, ''), error_reason),
+			`+inferenceRouteErrorReasonUpsertAssignment+`,
 			updated_at = EXCLUDED.updated_at`,
 		record.RequestID, record.Attempt, record.ProviderID, record.Model, record.PublicModel, record.ConsumerKeyHash, record.KeyID, record.Outcome,
 		record.CostMs, record.StateMs, record.QueueMs, record.PendingMs, record.BacklogMs, record.ThisReqMs, record.HealthMs, record.TTFTMs, record.BestTTFTMs,
@@ -1597,11 +1638,15 @@ func (s *PostgresStore) RecordInferenceRoute(record *InferenceRouteRecord) error
 		createdAt, updatedAt,
 		record.ProviderRegion, record.ConsumerRegion, record.ErrorReason,
 	)
+	if err != nil {
+		return fmt.Errorf("store: record inference route: %w", err)
+	}
 	return nil
 }
 
 // UpdateInferenceRouteOutcome updates the attempt with final outcome data
-// (tokens, timing, error). Best-effort; failures are discarded.
+// (tokens, timing, error). Callers keep this best-effort by logging returned
+// errors off the request path rather than blocking inference.
 func (s *PostgresStore) UpdateInferenceRouteOutcome(requestID string, attempt int, outcome *InferenceRouteOutcome) error {
 	if outcome == nil {
 		return nil
@@ -1610,7 +1655,7 @@ func (s *PostgresStore) UpdateInferenceRouteOutcome(requestID string, attempt in
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	_, _ = s.pool.Exec(ctx,
+	_, err := s.pool.Exec(ctx,
 		`UPDATE inference_routes SET
 			final_status = COALESCE(NULLIF($3, ''), final_status),
 			error_code = CASE WHEN $4 <> 0 THEN $4 ELSE error_code END,
@@ -1641,6 +1686,9 @@ func (s *PostgresStore) UpdateInferenceRouteOutcome(requestID string, attempt in
 		outcome.ParseMs, outcome.ReserveMs, outcome.RouteMs, outcome.EncryptMs, outcome.QueueWaitMs, outcome.DispatchMs, outcome.ActualDecodeTPS,
 		outcome.AdmittedButFailed, outcome.UsedBackup, outcome.BackupWon,
 	)
+	if err != nil {
+		return fmt.Errorf("store: update inference route outcome: %w", err)
+	}
 	return nil
 }
 
@@ -1651,7 +1699,7 @@ func (s *PostgresStore) InferenceRouteRecordsSince(since time.Time) []InferenceR
 	defer cancel()
 
 	rows, err := s.pool.Query(ctx,
-		`SELECT * FROM inference_routes WHERE created_at >= $1 ORDER BY created_at DESC LIMIT $2`,
+		`SELECT `+inferenceRouteSelectColumns+` FROM inference_routes WHERE created_at >= $1 ORDER BY created_at DESC LIMIT $2`,
 		since, maxTelemetryReadRows)
 	if err != nil {
 		return nil

--- a/coordinator/store/postgres_test.go
+++ b/coordinator/store/postgres_test.go
@@ -181,7 +181,16 @@ func TestPostgresRecordUsage(t *testing.T) {
 		t.Fatalf("usage records = %d, want 2", len(records))
 	}
 
-	r := records[0]
+	var r *UsageRecord
+	for i := range records {
+		if records[i].ProviderID == "provider-1" {
+			r = &records[i]
+			break
+		}
+	}
+	if r == nil {
+		t.Fatalf("provider-1 usage record missing: %+v", records)
+	}
 	if r.ProviderID != "provider-1" {
 		t.Errorf("provider_id = %q", r.ProviderID)
 	}
@@ -877,8 +886,8 @@ func TestPostgresDeleteProvidersBySerial(t *testing.T) {
 
 	// Owner rows (two sessions, one serial) + a guard row for another account.
 	for _, rec := range []ProviderRecord{
-		{ID: "a", SerialNumber: "SER", AccountID: "acct-1", RegisteredAt: time.Now(), LastSeen: time.Now()},
-		{ID: "guard", SerialNumber: "SER-G", AccountID: "acct-2", RegisteredAt: time.Now(), LastSeen: time.Now()},
+		{ID: "a", Hardware: json.RawMessage(`{}`), Models: json.RawMessage(`[]`), Backend: "vllm_mlx", SerialNumber: "SER", AccountID: "acct-1", RegisteredAt: time.Now(), LastSeen: time.Now()},
+		{ID: "guard", Hardware: json.RawMessage(`{}`), Models: json.RawMessage(`[]`), Backend: "vllm_mlx", SerialNumber: "SER-G", AccountID: "acct-2", RegisteredAt: time.Now(), LastSeen: time.Now()},
 	} {
 		if err := s.UpsertProvider(ctx, rec); err != nil {
 			t.Fatalf("UpsertProvider(%s): %v", rec.ID, err)
@@ -931,7 +940,7 @@ func TestPostgresDeleteProvidersBySerial_WrongOwner(t *testing.T) {
 	s := testPostgresStore(t)
 	ctx := context.Background()
 
-	if err := s.UpsertProvider(ctx, ProviderRecord{ID: "a", SerialNumber: "SER", AccountID: "acct-1", RegisteredAt: time.Now(), LastSeen: time.Now()}); err != nil {
+	if err := s.UpsertProvider(ctx, ProviderRecord{ID: "a", Hardware: json.RawMessage(`{}`), Models: json.RawMessage(`[]`), Backend: "vllm_mlx", SerialNumber: "SER", AccountID: "acct-1", RegisteredAt: time.Now(), LastSeen: time.Now()}); err != nil {
 		t.Fatalf("UpsertProvider: %v", err)
 	}
 

--- a/coordinator/store/postgres_test.go
+++ b/coordinator/store/postgres_test.go
@@ -64,6 +64,15 @@ func testPostgresStore(t *testing.T) *PostgresStore {
 	return s
 }
 
+func TestPostgresInferenceRouteErrorReasonUpsertQualifiesTargetColumn(t *testing.T) {
+	if !strings.Contains(inferenceRouteErrorReasonUpsertAssignment, "inference_routes.error_reason") {
+		t.Fatalf("error_reason upsert fallback must qualify target table: %s", inferenceRouteErrorReasonUpsertAssignment)
+	}
+	if strings.Contains(inferenceRouteErrorReasonUpsertAssignment, "), error_reason)") {
+		t.Fatalf("error_reason upsert fallback is ambiguous in ON CONFLICT: %s", inferenceRouteErrorReasonUpsertAssignment)
+	}
+}
+
 func TestPostgresCreateKey(t *testing.T) {
 	s := testPostgresStore(t)
 


### PR DESCRIPTION
## Summary
- fixes the DAR-342 Postgres upsert failure by qualifying the `error_reason` fallback as `inference_routes.error_reason`
- returns and logs inference_routes INSERT/UPDATE errors instead of silently discarding them
- hardens inference_routes schema/read paths with a unique-index migration, explicit SELECT columns, and CI Postgres coverage

## Testing
- `go test ./coordinator/store -run 'TestPostgresInferenceRouteErrorReasonUpsertQualifiesTargetColumn|TestInferenceRoute_Memory'`\n- `go test ./coordinator/store ./coordinator/api`\n- `go test ./coordinator/...`\n- `go build -o /var/folders/hv/5779vnmn5c564l3tdknlf4x80000gp/T/opencode/coordinator-dar342 ./coordinator/cmd/coordinator`\n\nLinear: DAR-342

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/428"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784575501&installation_id=133247490&pr_number=428&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F428&signature=46b649ec39f4af8a9a0816cd769a3ea468d7acda2882f0b35f849aeef5b8cdf7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->