### PR TITLE
fix(coordinator): let zero-balance owners use their own machine

### DIFF
--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -1845,8 +1845,28 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 		consumerKey := consumerKeyFromContext(r.Context())
 		reservedMicroUSD = s.reservationCost(model, billingPromptTokens, requestedMaxTokens)
 		// Per-key spend cap (phase 1) — checked before the reservation so a
-		// capped key never debits the account ledger.
-		if msg, ok := s.checkKeySpendCap(r.Context(), reservedMicroUSD); !ok {
+		// capped key never debits the account ledger. The reservation only runs
+		// when the cap passes, so a capped key never reaches the ledger.
+		capMsg, capOK := s.checkKeySpendCap(r.Context(), reservedMicroUSD)
+		var err error
+		if capOK {
+			serviceReservation, err = s.reserveInitialBalance(consumerKey, model, reservedMicroUSD)
+		}
+		// A capped key OR an insufficient balance blocks the request. But a
+		// zero-balance / spend-capped owner whose own machine can serve THIS
+		// request must never be blocked from their own Mac: downgrade prefer →
+		// exclusive self-route (free, owned-only). A free self-route neither
+		// spends (cap moot) nor reserves balance, exactly like a self_route_only
+		// key — so the cap/balance gates do not apply to it. The downgrade is
+		// attempted before either rejection so the cap can't pre-empt it.
+		blockedByCap := !capOK
+		blockedByBalance := errors.Is(err, store.ErrInsufficientBalance)
+		switch {
+		case (blockedByCap || blockedByBalance) &&
+			s.downgradePreferToSelfRoute(&policy, model, registry.RequestTraits{HasTools: hasTools}, requiresVision, allowedProviderSerials):
+			reservedMicroUSD = 0
+			serviceReservation = false
+		case blockedByCap:
 			s.recordRejection(rejectionInfo{
 				r:                     r,
 				stage:                 "balance",
@@ -1863,46 +1883,32 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 				hasTools:              hasTools,
 				params:                rejectionSamplingParams(parsed),
 			})
-			writeJSON(w, http.StatusPaymentRequired, errorResponse("insufficient_quota", msg, withCode("insufficient_quota")))
+			writeJSON(w, http.StatusPaymentRequired, errorResponse("insufficient_quota", capMsg, withCode("insufficient_quota")))
 			return
-		}
-		var err error
-		serviceReservation, err = s.reserveInitialBalance(consumerKey, model, reservedMicroUSD)
-		if err != nil {
-			if errors.Is(err, store.ErrInsufficientBalance) {
-				// Zero/low-balance owner whose own machine can serve this model
-				// right now: downgrade prefer → exclusive self-route (free,
-				// owned-only) instead of rejecting, so an owner is never blocked
-				// from using their own Mac just because they have no credits.
-				if s.downgradePreferToSelfRoute(&policy, model) {
-					reservedMicroUSD = 0
-					serviceReservation = false
-				} else {
-					s.recordRejection(rejectionInfo{
-						r:                     r,
-						stage:                 "balance",
-						reasonCode:            "insufficient_funds",
-						httpStatus:            http.StatusPaymentRequired,
-						keyID:                 keyIDFromContext(r.Context()),
-						consumerKeyHash:       store.HashKey(consumerKeyFromContext(r.Context())),
-						requestedModel:        publicModel,
-						resolvedModel:         model,
-						stream:                stream,
-						estimatedPromptTokens: estimatedPromptTokens,
-						requestedMaxTokens:    requestedMaxTokens,
-						requiresVision:        requiresVision,
-						hasTools:              hasTools,
-						params:                rejectionSamplingParams(parsed),
-					})
-					writeJSON(w, http.StatusPaymentRequired, errorResponse("insufficient_funds",
-						"your balance is too low for this request — add funds at /billing or lower max_tokens", withCode("insufficient_quota")))
-					return
-				}
-			} else {
-				s.logger.Error("balance reservation failed (DB error)", "consumer_key", consumerKey, "error", err)
-				s.writeServiceUnavailable(w, model)
-				return
-			}
+		case blockedByBalance:
+			s.recordRejection(rejectionInfo{
+				r:                     r,
+				stage:                 "balance",
+				reasonCode:            "insufficient_funds",
+				httpStatus:            http.StatusPaymentRequired,
+				keyID:                 keyIDFromContext(r.Context()),
+				consumerKeyHash:       store.HashKey(consumerKeyFromContext(r.Context())),
+				requestedModel:        publicModel,
+				resolvedModel:         model,
+				stream:                stream,
+				estimatedPromptTokens: estimatedPromptTokens,
+				requestedMaxTokens:    requestedMaxTokens,
+				requiresVision:        requiresVision,
+				hasTools:              hasTools,
+				params:                rejectionSamplingParams(parsed),
+			})
+			writeJSON(w, http.StatusPaymentRequired, errorResponse("insufficient_funds",
+				"your balance is too low for this request — add funds at /billing or lower max_tokens", withCode("insufficient_quota")))
+			return
+		case err != nil:
+			s.logger.Error("balance reservation failed (DB error)", "consumer_key", consumerKey, "error", err)
+			s.writeServiceUnavailable(w, model)
+			return
 		}
 	}
 	timing.ReservedAt = time.Now()
@@ -4692,8 +4698,26 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 	// Self-route is free: skip the reservation and per-key spend cap.
 	if s.billing != nil && !policy.enabled {
 		reservedMicroUSD = s.reservationCost(model, billingPromptTokens, requestedMaxTokens)
-		// Per-key spend cap (phase 1) — checked before the reservation.
-		if msg, ok := s.checkKeySpendCap(r.Context(), reservedMicroUSD); !ok {
+		// Per-key spend cap (phase 1) — checked before the reservation so a
+		// capped key never debits the account ledger.
+		capMsg, capOK := s.checkKeySpendCap(r.Context(), reservedMicroUSD)
+		var err error
+		if capOK {
+			serviceReservation, err = s.reserveInitialBalance(consumerKey, model, reservedMicroUSD)
+		}
+		// A capped key OR an insufficient balance blocks the request, unless a
+		// zero-balance / spend-capped owner whose own machine can serve THIS
+		// request downgrades prefer → exclusive self-route (free, owned-only). A
+		// free self-route neither spends nor reserves, so the cap/balance gates
+		// don't apply; the downgrade is attempted before either rejection.
+		blockedByCap := !capOK
+		blockedByBalance := errors.Is(err, store.ErrInsufficientBalance)
+		switch {
+		case (blockedByCap || blockedByBalance) &&
+			s.downgradePreferToSelfRoute(&policy, model, registry.RequestTraits{HasTools: hasTools}, requiresVision, allowedProviderSerials):
+			reservedMicroUSD = 0
+			serviceReservation = false
+		case blockedByCap:
 			s.recordRejection(rejectionInfo{
 				r:                     r,
 				stage:                 "balance",
@@ -4710,46 +4734,32 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 				hasTools:              hasTools,
 				params:                rejectionSamplingParams(parsed),
 			})
-			writeJSON(w, http.StatusPaymentRequired, errorResponse("insufficient_quota", msg, withCode("insufficient_quota")))
+			writeJSON(w, http.StatusPaymentRequired, errorResponse("insufficient_quota", capMsg, withCode("insufficient_quota")))
 			return
-		}
-		var err error
-		serviceReservation, err = s.reserveInitialBalance(consumerKey, model, reservedMicroUSD)
-		if err != nil {
-			if errors.Is(err, store.ErrInsufficientBalance) {
-				// Zero/low-balance owner whose own machine can serve this model
-				// right now: downgrade prefer → exclusive self-route (free,
-				// owned-only) instead of rejecting, so an owner is never blocked
-				// from using their own Mac just because they have no credits.
-				if s.downgradePreferToSelfRoute(&policy, model) {
-					reservedMicroUSD = 0
-					serviceReservation = false
-				} else {
-					s.recordRejection(rejectionInfo{
-						r:                     r,
-						stage:                 "balance",
-						reasonCode:            "insufficient_funds",
-						httpStatus:            http.StatusPaymentRequired,
-						keyID:                 keyIDFromContext(r.Context()),
-						consumerKeyHash:       store.HashKey(consumerKeyFromContext(r.Context())),
-						requestedModel:        publicModel,
-						resolvedModel:         model,
-						stream:                stream,
-						estimatedPromptTokens: estimatedPromptTokens,
-						requestedMaxTokens:    requestedMaxTokens,
-						requiresVision:        requiresVision,
-						hasTools:              hasTools,
-						params:                rejectionSamplingParams(parsed),
-					})
-					writeJSON(w, http.StatusPaymentRequired, errorResponse("insufficient_funds",
-						"your balance is too low for this request — add funds at /billing or lower max_tokens", withCode("insufficient_quota")))
-					return
-				}
-			} else {
-				s.logger.Error("balance reservation failed (DB error)", "consumer_key", consumerKey, "error", err)
-				s.writeServiceUnavailable(w, model)
-				return
-			}
+		case blockedByBalance:
+			s.recordRejection(rejectionInfo{
+				r:                     r,
+				stage:                 "balance",
+				reasonCode:            "insufficient_funds",
+				httpStatus:            http.StatusPaymentRequired,
+				keyID:                 keyIDFromContext(r.Context()),
+				consumerKeyHash:       store.HashKey(consumerKeyFromContext(r.Context())),
+				requestedModel:        publicModel,
+				resolvedModel:         model,
+				stream:                stream,
+				estimatedPromptTokens: estimatedPromptTokens,
+				requestedMaxTokens:    requestedMaxTokens,
+				requiresVision:        requiresVision,
+				hasTools:              hasTools,
+				params:                rejectionSamplingParams(parsed),
+			})
+			writeJSON(w, http.StatusPaymentRequired, errorResponse("insufficient_funds",
+				"your balance is too low for this request — add funds at /billing or lower max_tokens", withCode("insufficient_quota")))
+			return
+		case err != nil:
+			s.logger.Error("balance reservation failed (DB error)", "consumer_key", consumerKey, "error", err)
+			s.writeServiceUnavailable(w, model)
+			return
 		}
 	}
 	refundReservation := func() {

--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -1870,29 +1870,39 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 		serviceReservation, err = s.reserveInitialBalance(consumerKey, model, reservedMicroUSD)
 		if err != nil {
 			if errors.Is(err, store.ErrInsufficientBalance) {
-				s.recordRejection(rejectionInfo{
-					r:                     r,
-					stage:                 "balance",
-					reasonCode:            "insufficient_funds",
-					httpStatus:            http.StatusPaymentRequired,
-					keyID:                 keyIDFromContext(r.Context()),
-					consumerKeyHash:       store.HashKey(consumerKeyFromContext(r.Context())),
-					requestedModel:        publicModel,
-					resolvedModel:         model,
-					stream:                stream,
-					estimatedPromptTokens: estimatedPromptTokens,
-					requestedMaxTokens:    requestedMaxTokens,
-					requiresVision:        requiresVision,
-					hasTools:              hasTools,
-					params:                rejectionSamplingParams(parsed),
-				})
-				writeJSON(w, http.StatusPaymentRequired, errorResponse("insufficient_funds",
-					"your balance is too low for this request — add funds at /billing or lower max_tokens", withCode("insufficient_quota")))
+				// Zero/low-balance owner whose own machine can serve this model
+				// right now: downgrade prefer → exclusive self-route (free,
+				// owned-only) instead of rejecting, so an owner is never blocked
+				// from using their own Mac just because they have no credits.
+				if s.downgradePreferToSelfRoute(&policy, model) {
+					reservedMicroUSD = 0
+					serviceReservation = false
+				} else {
+					s.recordRejection(rejectionInfo{
+						r:                     r,
+						stage:                 "balance",
+						reasonCode:            "insufficient_funds",
+						httpStatus:            http.StatusPaymentRequired,
+						keyID:                 keyIDFromContext(r.Context()),
+						consumerKeyHash:       store.HashKey(consumerKeyFromContext(r.Context())),
+						requestedModel:        publicModel,
+						resolvedModel:         model,
+						stream:                stream,
+						estimatedPromptTokens: estimatedPromptTokens,
+						requestedMaxTokens:    requestedMaxTokens,
+						requiresVision:        requiresVision,
+						hasTools:              hasTools,
+						params:                rejectionSamplingParams(parsed),
+					})
+					writeJSON(w, http.StatusPaymentRequired, errorResponse("insufficient_funds",
+						"your balance is too low for this request — add funds at /billing or lower max_tokens", withCode("insufficient_quota")))
+					return
+				}
 			} else {
 				s.logger.Error("balance reservation failed (DB error)", "consumer_key", consumerKey, "error", err)
 				s.writeServiceUnavailable(w, model)
+				return
 			}
-			return
 		}
 	}
 	timing.ReservedAt = time.Now()
@@ -4707,29 +4717,39 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 		serviceReservation, err = s.reserveInitialBalance(consumerKey, model, reservedMicroUSD)
 		if err != nil {
 			if errors.Is(err, store.ErrInsufficientBalance) {
-				s.recordRejection(rejectionInfo{
-					r:                     r,
-					stage:                 "balance",
-					reasonCode:            "insufficient_funds",
-					httpStatus:            http.StatusPaymentRequired,
-					keyID:                 keyIDFromContext(r.Context()),
-					consumerKeyHash:       store.HashKey(consumerKeyFromContext(r.Context())),
-					requestedModel:        publicModel,
-					resolvedModel:         model,
-					stream:                stream,
-					estimatedPromptTokens: estimatedPromptTokens,
-					requestedMaxTokens:    requestedMaxTokens,
-					requiresVision:        requiresVision,
-					hasTools:              hasTools,
-					params:                rejectionSamplingParams(parsed),
-				})
-				writeJSON(w, http.StatusPaymentRequired, errorResponse("insufficient_funds",
-					"your balance is too low for this request — add funds at /billing or lower max_tokens", withCode("insufficient_quota")))
+				// Zero/low-balance owner whose own machine can serve this model
+				// right now: downgrade prefer → exclusive self-route (free,
+				// owned-only) instead of rejecting, so an owner is never blocked
+				// from using their own Mac just because they have no credits.
+				if s.downgradePreferToSelfRoute(&policy, model) {
+					reservedMicroUSD = 0
+					serviceReservation = false
+				} else {
+					s.recordRejection(rejectionInfo{
+						r:                     r,
+						stage:                 "balance",
+						reasonCode:            "insufficient_funds",
+						httpStatus:            http.StatusPaymentRequired,
+						keyID:                 keyIDFromContext(r.Context()),
+						consumerKeyHash:       store.HashKey(consumerKeyFromContext(r.Context())),
+						requestedModel:        publicModel,
+						resolvedModel:         model,
+						stream:                stream,
+						estimatedPromptTokens: estimatedPromptTokens,
+						requestedMaxTokens:    requestedMaxTokens,
+						requiresVision:        requiresVision,
+						hasTools:              hasTools,
+						params:                rejectionSamplingParams(parsed),
+					})
+					writeJSON(w, http.StatusPaymentRequired, errorResponse("insufficient_funds",
+						"your balance is too low for this request — add funds at /billing or lower max_tokens", withCode("insufficient_quota")))
+					return
+				}
 			} else {
 				s.logger.Error("balance reservation failed (DB error)", "consumer_key", consumerKey, "error", err)
 				s.writeServiceUnavailable(w, model)
+				return
 			}
-			return
 		}
 	}
 	refundReservation := func() {

--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -114,8 +114,20 @@ func ttftDeadline(estimatedPromptTokens int) time.Duration {
 // rate-limit, reservation, or routing work, so aggregators see rate limiting
 // rather than dropped/cancelled streams. Exclusive self-route bypasses the shed
 // because it never falls back to the public fleet.
-func (s *Server) shedIfModelRejected(w http.ResponseWriter, r *http.Request, parsed map[string]any, policy selfRoutePolicy, publicModel, model string, stream bool, estimatedPromptTokens, requestedMaxTokens int, requiresVision, hasTools bool) bool {
+func (s *Server) shedIfModelRejected(w http.ResponseWriter, r *http.Request, parsed map[string]any, policy selfRoutePolicy, publicModel, model string, stream bool, estimatedPromptTokens, requestedMaxTokens int, requiresVision, hasTools bool, allowedProviderSerials []string) bool {
 	if policy.enabled || !s.modelShed(model, publicModel) {
+		return false
+	}
+	// Model-shed is a public-fleet load lever, so it must not block a request
+	// that can run on the caller's OWN machine. Exclusive self-route already
+	// bypasses it above (policy.enabled); a prefer request whose owner has a
+	// structurally-eligible machine gets the same exemption — it would route
+	// owned-first (free) anyway, and on a zero-balance/capped owner it is the
+	// path the reservation downgrade later pins to. Without this it would 429
+	// here before that downgrade can run. The eligibility check uses the same
+	// shape (traits + vision + serial allowlist) as the downgrade.
+	if policy.prefer && s.registry.OwnedProviderEligible(policy.ownerAccountID, model,
+		registry.RequestTraits{HasTools: hasTools}, requiresVision, allowedProviderSerials) {
 		return false
 	}
 	retryAfter := s.estimateRetryAfter(model)
@@ -1792,7 +1804,7 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 	requestedMaxTokens := estimateRequestedMaxTokens(parsed)
 	deadline := ttftDeadline(estimatedPromptTokens)
 	timing.ParsedAt = time.Now()
-	if s.shedIfModelRejected(w, r, parsed, policy, publicModel, model, stream, estimatedPromptTokens, requestedMaxTokens, requiresVision, hasTools) {
+	if s.shedIfModelRejected(w, r, parsed, policy, publicModel, model, stream, estimatedPromptTokens, requestedMaxTokens, requiresVision, hasTools, allowedProviderSerials) {
 		return
 	}
 
@@ -4675,7 +4687,7 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 	requestedMaxTokens := estimateRequestedMaxTokens(parsed)
 	genericDeadline := ttftDeadline(estimatedPromptTokens)
 	timing.ParsedAt = time.Now()
-	if s.shedIfModelRejected(w, r, parsed, policy, publicModel, model, stream, estimatedPromptTokens, requestedMaxTokens, requiresVision, hasTools) {
+	if s.shedIfModelRejected(w, r, parsed, policy, publicModel, model, stream, estimatedPromptTokens, requestedMaxTokens, requiresVision, hasTools, allowedProviderSerials) {
 		return
 	}
 

--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -114,20 +114,8 @@ func ttftDeadline(estimatedPromptTokens int) time.Duration {
 // rate-limit, reservation, or routing work, so aggregators see rate limiting
 // rather than dropped/cancelled streams. Exclusive self-route bypasses the shed
 // because it never falls back to the public fleet.
-func (s *Server) shedIfModelRejected(w http.ResponseWriter, r *http.Request, parsed map[string]any, policy selfRoutePolicy, publicModel, model string, stream bool, estimatedPromptTokens, requestedMaxTokens int, requiresVision, hasTools bool, allowedProviderSerials []string) bool {
+func (s *Server) shedIfModelRejected(w http.ResponseWriter, r *http.Request, parsed map[string]any, policy selfRoutePolicy, publicModel, model string, stream bool, estimatedPromptTokens, requestedMaxTokens int, requiresVision, hasTools bool) bool {
 	if policy.enabled || !s.modelShed(model, publicModel) {
-		return false
-	}
-	// Model-shed is a public-fleet load lever, so it must not block a request
-	// that can run on the caller's OWN machine. Exclusive self-route already
-	// bypasses it above (policy.enabled); a prefer request whose owner has a
-	// structurally-eligible machine gets the same exemption — it would route
-	// owned-first (free) anyway, and on a zero-balance/capped owner it is the
-	// path the reservation downgrade later pins to. Without this it would 429
-	// here before that downgrade can run. The eligibility check uses the same
-	// shape (traits + vision + serial allowlist) as the downgrade.
-	if policy.prefer && s.registry.OwnedProviderEligible(policy.ownerAccountID, model,
-		registry.RequestTraits{HasTools: hasTools}, requiresVision, allowedProviderSerials) {
 		return false
 	}
 	retryAfter := s.estimateRetryAfter(model)
@@ -1804,7 +1792,13 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 	requestedMaxTokens := estimateRequestedMaxTokens(parsed)
 	deadline := ttftDeadline(estimatedPromptTokens)
 	timing.ParsedAt = time.Now()
-	if s.shedIfModelRejected(w, r, parsed, policy, publicModel, model, stream, estimatedPromptTokens, requestedMaxTokens, requiresVision, hasTools, allowedProviderSerials) {
+	// During a model shed, pin a prefer request whose owner can self-serve to an
+	// exclusive owned-only route (no paid public fallback) so the shed still
+	// protects the public fleet; non-eligible owners are shed normally below.
+	if s.modelShed(model, publicModel) {
+		s.pinPreferToSelfRouteOnShed(&policy, model, registry.RequestTraits{HasTools: hasTools}, requiresVision, allowedProviderSerials)
+	}
+	if s.shedIfModelRejected(w, r, parsed, policy, publicModel, model, stream, estimatedPromptTokens, requestedMaxTokens, requiresVision, hasTools) {
 		return
 	}
 
@@ -4687,7 +4681,13 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 	requestedMaxTokens := estimateRequestedMaxTokens(parsed)
 	genericDeadline := ttftDeadline(estimatedPromptTokens)
 	timing.ParsedAt = time.Now()
-	if s.shedIfModelRejected(w, r, parsed, policy, publicModel, model, stream, estimatedPromptTokens, requestedMaxTokens, requiresVision, hasTools, allowedProviderSerials) {
+	// During a model shed, pin a prefer request whose owner can self-serve to an
+	// exclusive owned-only route (no paid public fallback) so the shed still
+	// protects the public fleet; non-eligible owners are shed normally below.
+	if s.modelShed(model, publicModel) {
+		s.pinPreferToSelfRouteOnShed(&policy, model, registry.RequestTraits{HasTools: hasTools}, requiresVision, allowedProviderSerials)
+	}
+	if s.shedIfModelRejected(w, r, parsed, policy, publicModel, model, stream, estimatedPromptTokens, requestedMaxTokens, requiresVision, hasTools) {
 		return
 	}
 

--- a/coordinator/api/model_shed_test.go
+++ b/coordinator/api/model_shed_test.go
@@ -29,7 +29,7 @@ func TestModelShedRejectsRequestedAlias(t *testing.T) {
 	srv.SetRejectModels(map[string]bool{"gemma-4-26b": true})
 	w := httptest.NewRecorder()
 
-	if !srv.shedIfModelRejected(w, modelShedRequest(), map[string]any{"temperature": 0.2}, selfRoutePolicy{}, "gemma-4-26b", "gemma-4-26b-qat-4bit", true, 1200, 256, false, true, nil) {
+	if !srv.shedIfModelRejected(w, modelShedRequest(), map[string]any{"temperature": 0.2}, selfRoutePolicy{}, "gemma-4-26b", "gemma-4-26b-qat-4bit", true, 1200, 256, false, true) {
 		t.Fatal("shedIfModelRejected = false, want true")
 	}
 	if w.Code != http.StatusTooManyRequests {
@@ -62,7 +62,7 @@ func TestModelShedRejectsResolvedConcreteModel(t *testing.T) {
 	srv.SetRejectModels(map[string]bool{"gemma-4-26b-qat-4bit": true})
 	w := httptest.NewRecorder()
 
-	if !srv.shedIfModelRejected(w, modelShedRequest(), nil, selfRoutePolicy{}, "gemma-4-26b", "gemma-4-26b-qat-4bit", false, 100, 64, false, false, nil) {
+	if !srv.shedIfModelRejected(w, modelShedRequest(), nil, selfRoutePolicy{}, "gemma-4-26b", "gemma-4-26b-qat-4bit", false, 100, 64, false, false) {
 		t.Fatal("shedIfModelRejected = false, want true")
 	}
 	if w.Code != http.StatusTooManyRequests {
@@ -75,7 +75,7 @@ func TestModelShedDoesNotRejectOtherModels(t *testing.T) {
 	srv.SetRejectModels(map[string]bool{"gemma-4-26b": true})
 	w := httptest.NewRecorder()
 
-	if srv.shedIfModelRejected(w, modelShedRequest(), nil, selfRoutePolicy{}, "gpt-oss-20b", "gpt-oss-20b", false, 100, 64, false, false, nil) {
+	if srv.shedIfModelRejected(w, modelShedRequest(), nil, selfRoutePolicy{}, "gpt-oss-20b", "gpt-oss-20b", false, 100, 64, false, false) {
 		t.Fatal("shedIfModelRejected = true for non-shed model")
 	}
 	if w.Code == http.StatusTooManyRequests {
@@ -89,10 +89,10 @@ func TestModelShedPolicySelfRouteBypassesPreferOwnerSheds(t *testing.T) {
 	self := httptest.NewRecorder()
 	prefer := httptest.NewRecorder()
 
-	if srv.shedIfModelRejected(self, modelShedRequest(), nil, selfRoutePolicy{enabled: true}, "gemma-4-26b", "gemma-4-26b-qat-4bit", false, 100, 64, false, false, nil) {
+	if srv.shedIfModelRejected(self, modelShedRequest(), nil, selfRoutePolicy{enabled: true}, "gemma-4-26b", "gemma-4-26b-qat-4bit", false, 100, 64, false, false) {
 		t.Fatal("exclusive self-route should bypass model shed")
 	}
-	if !srv.shedIfModelRejected(prefer, modelShedRequest(), nil, selfRoutePolicy{prefer: true}, "gemma-4-26b", "gemma-4-26b-qat-4bit", false, 100, 64, false, false, nil) {
+	if !srv.shedIfModelRejected(prefer, modelShedRequest(), nil, selfRoutePolicy{prefer: true}, "gemma-4-26b", "gemma-4-26b-qat-4bit", false, 100, 64, false, false) {
 		t.Fatal("prefer-owner should be model-shed because it can fall back to public fleet")
 	}
 	waitForRejectionCount(t, srv, 1)

--- a/coordinator/api/model_shed_test.go
+++ b/coordinator/api/model_shed_test.go
@@ -29,7 +29,7 @@ func TestModelShedRejectsRequestedAlias(t *testing.T) {
 	srv.SetRejectModels(map[string]bool{"gemma-4-26b": true})
 	w := httptest.NewRecorder()
 
-	if !srv.shedIfModelRejected(w, modelShedRequest(), map[string]any{"temperature": 0.2}, selfRoutePolicy{}, "gemma-4-26b", "gemma-4-26b-qat-4bit", true, 1200, 256, false, true) {
+	if !srv.shedIfModelRejected(w, modelShedRequest(), map[string]any{"temperature": 0.2}, selfRoutePolicy{}, "gemma-4-26b", "gemma-4-26b-qat-4bit", true, 1200, 256, false, true, nil) {
 		t.Fatal("shedIfModelRejected = false, want true")
 	}
 	if w.Code != http.StatusTooManyRequests {
@@ -62,7 +62,7 @@ func TestModelShedRejectsResolvedConcreteModel(t *testing.T) {
 	srv.SetRejectModels(map[string]bool{"gemma-4-26b-qat-4bit": true})
 	w := httptest.NewRecorder()
 
-	if !srv.shedIfModelRejected(w, modelShedRequest(), nil, selfRoutePolicy{}, "gemma-4-26b", "gemma-4-26b-qat-4bit", false, 100, 64, false, false) {
+	if !srv.shedIfModelRejected(w, modelShedRequest(), nil, selfRoutePolicy{}, "gemma-4-26b", "gemma-4-26b-qat-4bit", false, 100, 64, false, false, nil) {
 		t.Fatal("shedIfModelRejected = false, want true")
 	}
 	if w.Code != http.StatusTooManyRequests {
@@ -75,7 +75,7 @@ func TestModelShedDoesNotRejectOtherModels(t *testing.T) {
 	srv.SetRejectModels(map[string]bool{"gemma-4-26b": true})
 	w := httptest.NewRecorder()
 
-	if srv.shedIfModelRejected(w, modelShedRequest(), nil, selfRoutePolicy{}, "gpt-oss-20b", "gpt-oss-20b", false, 100, 64, false, false) {
+	if srv.shedIfModelRejected(w, modelShedRequest(), nil, selfRoutePolicy{}, "gpt-oss-20b", "gpt-oss-20b", false, 100, 64, false, false, nil) {
 		t.Fatal("shedIfModelRejected = true for non-shed model")
 	}
 	if w.Code == http.StatusTooManyRequests {
@@ -89,10 +89,10 @@ func TestModelShedPolicySelfRouteBypassesPreferOwnerSheds(t *testing.T) {
 	self := httptest.NewRecorder()
 	prefer := httptest.NewRecorder()
 
-	if srv.shedIfModelRejected(self, modelShedRequest(), nil, selfRoutePolicy{enabled: true}, "gemma-4-26b", "gemma-4-26b-qat-4bit", false, 100, 64, false, false) {
+	if srv.shedIfModelRejected(self, modelShedRequest(), nil, selfRoutePolicy{enabled: true}, "gemma-4-26b", "gemma-4-26b-qat-4bit", false, 100, 64, false, false, nil) {
 		t.Fatal("exclusive self-route should bypass model shed")
 	}
-	if !srv.shedIfModelRejected(prefer, modelShedRequest(), nil, selfRoutePolicy{prefer: true}, "gemma-4-26b", "gemma-4-26b-qat-4bit", false, 100, 64, false, false) {
+	if !srv.shedIfModelRejected(prefer, modelShedRequest(), nil, selfRoutePolicy{prefer: true}, "gemma-4-26b", "gemma-4-26b-qat-4bit", false, 100, 64, false, false, nil) {
 		t.Fatal("prefer-owner should be model-shed because it can fall back to public fleet")
 	}
 	waitForRejectionCount(t, srv, 1)

--- a/coordinator/api/self_route.go
+++ b/coordinator/api/self_route.go
@@ -95,6 +95,27 @@ func (s *Server) downgradePreferToSelfRoute(policy *selfRoutePolicy, model strin
 	return true
 }
 
+// pinPreferToSelfRouteOnShed converts a PREFER request into an EXCLUSIVE
+// self-route when its model is being shed from the public fleet but the owner
+// has a structurally-eligible machine. Model-shed is a PUBLIC-fleet load lever,
+// so a prefer request must never be allowed to skip the shed and then fall back
+// to the paid public fleet (which would defeat the shed for exactly the fleet it
+// protects). Pinning it owned-only — exclusive, no fallback — keeps the shed
+// effective while never blocking an owner from their own Mac: it runs free on
+// the owner's machine (queuing there if busy) instead of touching the shed
+// public fleet. Owners with no eligible machine are left as prefer and shed
+// normally by shedIfModelRejected. Mutates policy in place.
+func (s *Server) pinPreferToSelfRouteOnShed(policy *selfRoutePolicy, model string, traits registry.RequestTraits, requiresVision bool, allowedSerials []string) {
+	if policy == nil || !policy.prefer || policy.ownerAccountID == "" {
+		return
+	}
+	if !s.registry.OwnedProviderEligible(policy.ownerAccountID, model, traits, requiresVision, allowedSerials) {
+		return
+	}
+	policy.enabled = true
+	policy.prefer = false
+}
+
 // selfRouteUnavailable reports whether a self-route request cannot proceed and,
 // when so, writes the precise terminal error. Self-route never falls back to
 // the paid fleet, so "can't serve" is an explicit failure rather than a

--- a/coordinator/api/self_route.go
+++ b/coordinator/api/self_route.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+
+	"github.com/eigeninference/d-inference/coordinator/registry"
 )
 
 // This file holds the consumer-side "use my own machine, for free" (self-route)
@@ -66,21 +68,26 @@ func (s *Server) resolveSelfRoutePolicy(r *http.Request) selfRoutePolicy {
 
 // downgradePreferToSelfRoute converts a PREFER request into an EXCLUSIVE
 // self-route when the owner can't afford the paid fallback but their own
-// machine can serve the model right now. This is what lets a zero-balance
+// machine can serve THIS request right now. This is what lets a zero-balance
 // provider-owner keep using their own Mac for free: instead of a 402, the
 // request is pinned to the owner's online machine (free, no paid fallback).
 //
+// Eligibility is the full request shape (model + serial allowlist + vision +
+// tools), not just "owns a provider for the model": if the owned machine can't
+// actually satisfy the request, we must NOT downgrade — doing so would strand an
+// exclusive self-route with no candidate (and no paid fallback) instead of
+// preserving the precise 402/error.
+//
 // It mutates policy in place and reports whether the downgrade happened. The
-// downgrade only fires for PREFER requests (never a normal paid request), and
-// only when an owned machine currently serves the model — so billing integrity
-// holds: the request can no longer settle on the paid fleet, and if the machine
-// drops between here and dispatch, the exclusive self-route pre-flight returns a
-// precise 503 rather than handing out free public inference.
-func (s *Server) downgradePreferToSelfRoute(policy *selfRoutePolicy, model string) bool {
+// downgrade only fires for PREFER requests (never a normal paid request) — so
+// billing integrity holds: the request can no longer settle on the paid fleet,
+// and if the machine drops between here and dispatch, the exclusive self-route
+// pre-flight returns a precise 503 rather than handing out free public inference.
+func (s *Server) downgradePreferToSelfRoute(policy *selfRoutePolicy, model string, traits registry.RequestTraits, requiresVision bool, allowedSerials []string) bool {
 	if policy == nil || !policy.prefer || policy.ownerAccountID == "" {
 		return false
 	}
-	if _, servesModel := s.registry.OwnedProviderSummary(policy.ownerAccountID, model); servesModel == 0 {
+	if !s.registry.OwnedProviderEligible(policy.ownerAccountID, model, traits, requiresVision, allowedSerials) {
 		return false
 	}
 	policy.enabled = true

--- a/coordinator/api/self_route.go
+++ b/coordinator/api/self_route.go
@@ -64,6 +64,30 @@ func (s *Server) resolveSelfRoutePolicy(r *http.Request) selfRoutePolicy {
 	return selfRoutePolicy{enabled: exclusive, prefer: prefer, ownerAccountID: owner}
 }
 
+// downgradePreferToSelfRoute converts a PREFER request into an EXCLUSIVE
+// self-route when the owner can't afford the paid fallback but their own
+// machine can serve the model right now. This is what lets a zero-balance
+// provider-owner keep using their own Mac for free: instead of a 402, the
+// request is pinned to the owner's online machine (free, no paid fallback).
+//
+// It mutates policy in place and reports whether the downgrade happened. The
+// downgrade only fires for PREFER requests (never a normal paid request), and
+// only when an owned machine currently serves the model — so billing integrity
+// holds: the request can no longer settle on the paid fleet, and if the machine
+// drops between here and dispatch, the exclusive self-route pre-flight returns a
+// precise 503 rather than handing out free public inference.
+func (s *Server) downgradePreferToSelfRoute(policy *selfRoutePolicy, model string) bool {
+	if policy == nil || !policy.prefer || policy.ownerAccountID == "" {
+		return false
+	}
+	if _, servesModel := s.registry.OwnedProviderSummary(policy.ownerAccountID, model); servesModel == 0 {
+		return false
+	}
+	policy.enabled = true
+	policy.prefer = false
+	return true
+}
+
 // selfRouteUnavailable reports whether a self-route request cannot proceed and,
 // when so, writes the precise terminal error. Self-route never falls back to
 // the paid fleet, so "can't serve" is an explicit failure rather than a

--- a/coordinator/api/self_route_test.go
+++ b/coordinator/api/self_route_test.go
@@ -440,6 +440,75 @@ func TestSelfRoute_PreferSpendCappedOwnerServedFree(t *testing.T) {
 	}
 }
 
+// TestSelfRoute_PreferShedModelServedOnOwnedMachine is the regression for the
+// Codex review finding that model-shed pre-empted the downgrade: a prefer
+// request for a SHED model whose owner has an eligible machine must bypass the
+// public model-shed 429 and run on the owner's machine — just like an explicit
+// self-route does.
+func TestSelfRoute_PreferShedModelServedOnOwnedMachine(t *testing.T) {
+	srv, st, ledger := billingTestServer(t)
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	const owner = "shed-owner"
+	raw, _, err := st.CreateAPIKey(owner, store.APIKeyCreate{Name: "mine"})
+	if err != nil {
+		t.Fatalf("CreateAPIKey: %v", err)
+	}
+	_ = st.Credit(owner, 100_000_000, store.LedgerDeposit, "test-setup")
+	initial := ledger.Balance(owner)
+
+	model := "shed-owner-model"
+	conn, _, pubKey := setupProviderForBilling(t, ctx, ts, srv.registry, model)
+	defer conn.Close(websocket.StatusNormalClosure, "")
+	setOwnedProvider(srv, owner)
+
+	// Shed the model fleet-wide: a normal/prefer public request would 429.
+	srv.SetRejectModels(map[string]bool{model: true})
+
+	providerDone := serveOneInference(ctx, t, conn, pubKey, protocol.UsageInfo{PromptTokens: 100, CompletionTokens: 50})
+	if status := sendRoutedRequest(t, ctx, ts.URL, model, raw, "prefer"); status != http.StatusOK {
+		t.Fatalf("prefer status = %d, want 200 (shed must not block an eligible owned machine)", status)
+	}
+	<-providerDone
+	time.Sleep(300 * time.Millisecond)
+
+	// Served on the owner's own machine → free.
+	if bal := ledger.Balance(owner); bal != initial {
+		t.Errorf("owner balance = %d, want %d (own machine must be net free)", bal, initial)
+	}
+}
+
+// TestSelfRoute_PreferShedModelNoOwnedMachineStill429: a prefer request for a
+// shed model whose caller has NO eligible owned machine is still shed (429) —
+// the bypass only covers owners who can actually self-serve.
+func TestSelfRoute_PreferShedModelNoOwnedMachineStill429(t *testing.T) {
+	srv, st, _ := billingTestServer(t)
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	const caller = "shed-owns-nothing"
+	raw, _, err := st.CreateAPIKey(caller, store.APIKeyCreate{Name: "mine"})
+	if err != nil {
+		t.Fatalf("CreateAPIKey: %v", err)
+	}
+	_ = st.Credit(caller, 100_000_000, store.LedgerDeposit, "test-setup")
+
+	model := "shed-nomachine-model"
+	conn, _, _ := setupProviderForBilling(t, ctx, ts, srv.registry, model)
+	defer conn.Close(websocket.StatusNormalClosure, "")
+	setOwnedProvider(srv, "someone-else") // caller owns nothing
+	srv.SetRejectModels(map[string]bool{model: true})
+
+	if status := sendRoutedRequest(t, ctx, ts.URL, model, raw, "prefer"); status != http.StatusTooManyRequests {
+		t.Fatalf("prefer status = %d, want 429 (shed must hold when caller has no eligible owned machine)", status)
+	}
+}
+
 // TestSelfRoute_PreferFallsBackToPaid: with prefer and an owner who owns NO
 // machine, the request falls back to the paid public fleet and is charged —
 // unlike exclusive self-route, which would 409. "Never a dead end."

--- a/coordinator/api/self_route_test.go
+++ b/coordinator/api/self_route_test.go
@@ -326,6 +326,80 @@ func TestSelfRoute_PreferFreeOnOwnedMachine(t *testing.T) {
 	}
 }
 
+// TestSelfRoute_PreferZeroBalanceOwnerServedFree is the regression for "if you
+// don't have credits you can't use your machine": a zero-balance owner sending
+// prefer (what the console "Use my machine" toggle sends) whose own machine can
+// serve the model must be served for free instead of getting a 402. The upfront
+// balance reservation fails, but because an owned machine serves the model the
+// request is downgraded to exclusive self-route (free, owned-only).
+func TestSelfRoute_PreferZeroBalanceOwnerServedFree(t *testing.T) {
+	srv, st, ledger := billingTestServer(t)
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	const owner = "broke-owner"
+	raw, _, err := st.CreateAPIKey(owner, store.APIKeyCreate{Name: "mine"})
+	if err != nil {
+		t.Fatalf("CreateAPIKey: %v", err)
+	}
+	// No Credit() call: the owner has zero balance.
+	if bal := ledger.Balance(owner); bal != 0 {
+		t.Fatalf("precondition: balance = %d, want 0", bal)
+	}
+
+	model := "broke-owner-model"
+	conn, _, pubKey := setupProviderForBilling(t, ctx, ts, srv.registry, model)
+	defer conn.Close(websocket.StatusNormalClosure, "")
+	setOwnedProvider(srv, owner)
+
+	providerDone := serveOneInference(ctx, t, conn, pubKey, protocol.UsageInfo{PromptTokens: 100, CompletionTokens: 50})
+	if status := sendRoutedRequest(t, ctx, ts.URL, model, raw, "prefer"); status != http.StatusOK {
+		t.Fatalf("prefer status = %d, want 200 (zero-balance owner must run free on own machine)", status)
+	}
+	<-providerDone
+	time.Sleep(300 * time.Millisecond)
+
+	if bal := ledger.Balance(owner); bal != 0 {
+		t.Errorf("owner balance = %d, want 0 (own machine must be net free)", bal)
+	}
+	earnings, _ := st.GetAccountEarnings(owner, 100)
+	if len(earnings) != 0 {
+		t.Errorf("provider earnings = %d, want 0 when own machine served a free request", len(earnings))
+	}
+}
+
+// TestSelfRoute_PreferZeroBalanceNoOwnedMachineStill402: a zero-balance caller
+// sending prefer who has NO owned machine that can serve the model must still be
+// rejected with 402 — the downgrade only rescues owners whose own machine can
+// serve, never grants free paid-fleet inference.
+func TestSelfRoute_PreferZeroBalanceNoOwnedMachineStill402(t *testing.T) {
+	srv, st, ledger := billingTestServer(t)
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	const caller = "broke-owns-nothing"
+	raw, _, err := st.CreateAPIKey(caller, store.APIKeyCreate{Name: "mine"})
+	if err != nil {
+		t.Fatalf("CreateAPIKey: %v", err)
+	}
+	if bal := ledger.Balance(caller); bal != 0 {
+		t.Fatalf("precondition: balance = %d, want 0", bal)
+	}
+
+	model := "broke-fallback-model"
+	conn, _, _ := setupProviderForBilling(t, ctx, ts, srv.registry, model)
+	defer conn.Close(websocket.StatusNormalClosure, "")
+	setOwnedProvider(srv, "someone-else") // caller owns nothing
+
+	if status := sendRoutedRequest(t, ctx, ts.URL, model, raw, "prefer"); status != http.StatusPaymentRequired {
+		t.Fatalf("prefer status = %d, want 402 (no owned machine + no balance must not get free paid inference)", status)
+	}
+}
+
 // TestSelfRoute_PreferFallsBackToPaid: with prefer and an owner who owns NO
 // machine, the request falls back to the paid public fleet and is charged —
 // unlike exclusive self-route, which would 409. "Never a dead end."

--- a/coordinator/api/self_route_test.go
+++ b/coordinator/api/self_route_test.go
@@ -400,6 +400,46 @@ func TestSelfRoute_PreferZeroBalanceNoOwnedMachineStill402(t *testing.T) {
 	}
 }
 
+// TestSelfRoute_PreferSpendCappedOwnerServedFree is the regression for the
+// Codex review finding: a spend-capped key must not pre-empt the owned-machine
+// downgrade. An owner whose key has an exhausted spend cap (and who would
+// otherwise get insufficient_quota before the balance check) sending prefer,
+// with an owned machine that serves the model, must be served for free.
+func TestSelfRoute_PreferSpendCappedOwnerServedFree(t *testing.T) {
+	srv, st, ledger := billingTestServer(t)
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	const owner = "capped-owner"
+	zeroCap := int64(0) // any spend exceeds a $0 cap
+	raw, _, err := st.CreateAPIKey(owner, store.APIKeyCreate{Name: "capped", LimitMicroUSD: &zeroCap})
+	if err != nil {
+		t.Fatalf("CreateAPIKey: %v", err)
+	}
+	// Even with a healthy balance, the $0 spend cap would reject a paid request.
+	_ = st.Credit(owner, 100_000_000, store.LedgerDeposit, "test-setup")
+	initial := ledger.Balance(owner)
+
+	model := "capped-owner-model"
+	conn, _, pubKey := setupProviderForBilling(t, ctx, ts, srv.registry, model)
+	defer conn.Close(websocket.StatusNormalClosure, "")
+	setOwnedProvider(srv, owner)
+
+	providerDone := serveOneInference(ctx, t, conn, pubKey, protocol.UsageInfo{PromptTokens: 100, CompletionTokens: 50})
+	if status := sendRoutedRequest(t, ctx, ts.URL, model, raw, "prefer"); status != http.StatusOK {
+		t.Fatalf("prefer status = %d, want 200 (spend cap must not block the owned-machine downgrade)", status)
+	}
+	<-providerDone
+	time.Sleep(300 * time.Millisecond)
+
+	// Free self-route spends nothing, so the cap is never touched.
+	if bal := ledger.Balance(owner); bal != initial {
+		t.Errorf("owner balance = %d, want %d (own machine must be net free)", bal, initial)
+	}
+}
+
 // TestSelfRoute_PreferFallsBackToPaid: with prefer and an owner who owns NO
 // machine, the request falls back to the paid public fleet and is charged —
 // unlike exclusive self-route, which would 409. "Never a dead end."

--- a/coordinator/registry/scheduler.go
+++ b/coordinator/registry/scheduler.go
@@ -764,6 +764,30 @@ func (r *Registry) OwnedProviderEligible(accountID, model string, traits Request
 		if eligible && requiresVision {
 			eligible = r.providerServesVisionModelLocked(p, model)
 		}
+		if eligible {
+			// Permanent hardware-fit gate (mirrors buildCandidateWithReason): a
+			// model whose footprint can never fit this Mac's total memory is a
+			// PERMANENT miss, not transient load — so, unlike slot-state/capacity,
+			// it must gate the downgrade (otherwise dispatch 503s on a machine
+			// that can never run the model). Skipped when the model is already
+			// resident, which proves it fit.
+			totalMemoryGB := float64(p.Hardware.MemoryGB)
+			resident := false
+			if p.BackendCapacity != nil {
+				if p.BackendCapacity.TotalMemoryGB > 0 {
+					totalMemoryGB = p.BackendCapacity.TotalMemoryGB
+				}
+				for _, slot := range p.BackendCapacity.Slots {
+					if slot.Model == model {
+						resident = slotStateModelLoaded(slot.State)
+						break
+					}
+				}
+			}
+			if !resident && !modelFitsHardware(r.catalogMinRAMGbLocked(model), r.catalogSizeGBLocked(model), totalMemoryGB) {
+				eligible = false
+			}
+		}
 		p.mu.Unlock()
 		if eligible {
 			return true

--- a/coordinator/registry/scheduler.go
+++ b/coordinator/registry/scheduler.go
@@ -713,6 +713,55 @@ func (r *Registry) OwnedProviderSummary(accountID, model string) (online, serves
 	return online, servesModel
 }
 
+// OwnedProviderEligible reports whether the account owns at least one online
+// machine that can serve `model` for THIS request's shape. Unlike
+// OwnedProviderSummary (which only answers "serves the model at all", for error
+// messaging), it applies the exact gates the dispatcher uses for an owner
+// self-route: the serial allowlist, the per-provider routing/trait gates via
+// snapshotProviderLockedEx with the hardware-trust floor relaxed only for the
+// owner's own machine, and the vision gate. The prefer→self-route downgrade
+// uses it so a zero-balance owner is pinned to their own machine only when that
+// machine can actually satisfy the request (model + serials + vision + tools) —
+// never when the downgrade would strand the request on an ineligible owned
+// provider with no candidate and no paid fallback.
+func (r *Registry) OwnedProviderEligible(accountID, model string, traits RequestTraits, requiresVision bool, allowedSerials []string) bool {
+	if accountID == "" {
+		return false
+	}
+	allowedSet := make(map[string]struct{}, len(allowedSerials))
+	for _, s := range allowedSerials {
+		allowedSet[s] = struct{}{}
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	for _, p := range r.providers {
+		// Ownership + allowlist first (both take p.mu internally), mirroring the
+		// candidate filter in selectBestCandidateScanLocked.
+		if !providerOwnedBy(p, accountID) {
+			continue
+		}
+		if len(allowedSet) > 0 && !providerMatchesAllowedSerial(p, allowedSet) {
+			continue
+		}
+		// relaxTrust=true: the owner's own (possibly un-enrolled) machine. The
+		// snapshot applies every privacy/runtime/challenge/trait gate, so a
+		// render-broken or below-floor (tools) build is excluded here.
+		if _, ok := r.snapshotProviderLockedEx(p, model, traits, true, false); !ok {
+			continue
+		}
+		if requiresVision {
+			p.mu.Lock()
+			servesVision := r.providerServesVisionModelLocked(p, model)
+			p.mu.Unlock()
+			if !servesVision {
+				continue
+			}
+		}
+		return true
+	}
+	return false
+}
+
 // logRoutingDecision emits a structured debug-level record of the
 // winning candidate and its cost breakdown. Cheap when the level is
 // disabled, since slog short-circuits before formatting.

--- a/coordinator/registry/scheduler.go
+++ b/coordinator/registry/scheduler.go
@@ -714,16 +714,25 @@ func (r *Registry) OwnedProviderSummary(accountID, model string) (online, serves
 }
 
 // OwnedProviderEligible reports whether the account owns at least one online
-// machine that can serve `model` for THIS request's shape. Unlike
-// OwnedProviderSummary (which only answers "serves the model at all", for error
-// messaging), it applies the exact gates the dispatcher uses for an owner
-// self-route: the serial allowlist, the per-provider routing/trait gates via
-// snapshotProviderLockedEx with the hardware-trust floor relaxed only for the
-// owner's own machine, and the vision gate. The prefer→self-route downgrade
-// uses it so a zero-balance owner is pinned to their own machine only when that
-// machine can actually satisfy the request (model + serials + vision + tools) —
-// never when the downgrade would strand the request on an ineligible owned
-// provider with no candidate and no paid fallback.
+// machine that is STRUCTURALLY CAPABLE of serving `model` for THIS request's
+// shape: it serves the catalog model, matches the serial allowlist, advertises a
+// vision build when the request carries media, and meets the tool-trait gates
+// (render-ok + version floor). The hardware-trust floor is relaxed for the
+// owner's own (possibly un-enrolled) machine, exactly as self-route dispatch
+// does, while every privacy-critical gate (runtime-verified, private-text,
+// challenge freshness) still applies.
+//
+// It deliberately tests CAPABILITY, not TRANSIENT load/health: the node-health
+// breaker, the slot state (crashed/reloading), free-memory/concurrency capacity,
+// and thermal pressure are NOT consulted. Those are the dimensions on which an
+// exclusive self-route QUEUES on the owner's machine (or fails open, as dispatch
+// does on the breaker) rather than hard-failing, so they must not gate the
+// prefer→self-route downgrade — gating on them would block an owner from their
+// own Mac in exactly the cases where an explicit `X-Darkbloom-Route: self`
+// request would still be served (or queued). The downgrade's job is only to
+// refuse the conversion when the machine can NEVER serve the request shape
+// (wrong model / serial / vision / tools), which would otherwise strand an
+// exclusive self-route with no candidate and no paid fallback.
 func (r *Registry) OwnedProviderEligible(accountID, model string, traits RequestTraits, requiresVision bool, allowedSerials []string) bool {
 	if accountID == "" {
 		return false
@@ -732,6 +741,7 @@ func (r *Registry) OwnedProviderEligible(accountID, model string, traits Request
 	for _, s := range allowedSerials {
 		allowedSet[s] = struct{}{}
 	}
+	now := time.Now()
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	for _, p := range r.providers {
@@ -743,21 +753,21 @@ func (r *Registry) OwnedProviderEligible(accountID, model string, traits Request
 		if len(allowedSet) > 0 && !providerMatchesAllowedSerial(p, allowedSet) {
 			continue
 		}
-		// relaxTrust=true: the owner's own (possibly un-enrolled) machine. The
-		// snapshot applies every privacy/runtime/challenge/trait gate, so a
-		// render-broken or below-floor (tools) build is excluded here.
-		if _, ok := r.snapshotProviderLockedEx(p, model, traits, true, false); !ok {
-			continue
+		p.mu.Lock()
+		// relaxTrust=true: the owner's own machine. ignoreProviderBreaker=true:
+		// the transient node-health breaker is not a capability gate — self-route
+		// fails open on it just like dispatch, so it must not block the
+		// downgrade. This applies serves-model, privacy/runtime/challenge, and
+		// the trait gates (render-broken fences all shapes; the tools version
+		// floor fences tool requests) but no slot-state/capacity gate.
+		eligible := r.providerPassesRoutingGatesLockedEx(p, model, traits, true, now, true)
+		if eligible && requiresVision {
+			eligible = r.providerServesVisionModelLocked(p, model)
 		}
-		if requiresVision {
-			p.mu.Lock()
-			servesVision := r.providerServesVisionModelLocked(p, model)
-			p.mu.Unlock()
-			if !servesVision {
-				continue
-			}
+		p.mu.Unlock()
+		if eligible {
+			return true
 		}
-		return true
 	}
 	return false
 }

--- a/coordinator/registry/self_route_test.go
+++ b/coordinator/registry/self_route_test.go
@@ -262,6 +262,44 @@ func TestOwnedProviderEligible(t *testing.T) {
 	}
 }
 
+// TestOwnedProviderEligibleHardwareFit verifies the PERMANENT hardware-fit gate:
+// a model that can never fit the owner's Mac is ineligible (so the downgrade is
+// refused rather than stranding an exclusive self-route on a 503), while a
+// fitting model — or one already resident — stays eligible.
+func TestOwnedProviderEligibleHardwareFit(t *testing.T) {
+	reg := New(testLogger())
+	model := "fit-model"
+
+	p := makeSchedulerProvider(t, reg, "mine", model, 100) // 64 GB Mac
+	setProviderAccount(p, "acct-A")
+	// Not resident, so the fit gate applies (a resident model has demonstrably fit).
+	p.mu.Lock()
+	p.BackendCapacity.Slots[0].State = "unknown"
+	p.mu.Unlock()
+
+	// Catalog says the model needs 128 GB — it can never fit the 64 GB Mac.
+	reg.SetModelCatalog([]CatalogEntry{{ID: model, MinRAMGB: 128}})
+	if reg.OwnedProviderEligible("acct-A", model, RequestTraits{}, false, nil) {
+		t.Fatal("a model that can't fit the Mac must be ineligible (no downgrade)")
+	}
+
+	// A fitting requirement → eligible again.
+	reg.SetModelCatalog([]CatalogEntry{{ID: model, MinRAMGB: 32}})
+	if !reg.OwnedProviderEligible("acct-A", model, RequestTraits{}, false, nil) {
+		t.Fatal("a model that fits the Mac must be eligible")
+	}
+
+	// A RESIDENT (loaded) model has demonstrably fit, so the fit gate is skipped
+	// even if the catalog over-states its footprint.
+	p.mu.Lock()
+	p.BackendCapacity.Slots[0].State = "running"
+	p.mu.Unlock()
+	reg.SetModelCatalog([]CatalogEntry{{ID: model, MinRAMGB: 128}})
+	if !reg.OwnedProviderEligible("acct-A", model, RequestTraits{}, false, nil) {
+		t.Fatal("a resident model must stay eligible despite an over-size catalog entry")
+	}
+}
+
 func setProviderPrivateOnly(p *Provider) {
 	p.mu.Lock()
 	defer p.mu.Unlock()

--- a/coordinator/registry/self_route_test.go
+++ b/coordinator/registry/self_route_test.go
@@ -2,6 +2,7 @@ package registry
 
 import (
 	"testing"
+	"time"
 )
 
 func setProviderAccount(p *Provider, accountID string) {
@@ -232,6 +233,32 @@ func TestOwnedProviderEligible(t *testing.T) {
 	// ineligible (a downgrade here would strand the request).
 	if reg.OwnedProviderEligible("acct-A", model, RequestTraits{}, true, nil) {
 		t.Fatal("text-only machine must be ineligible for a vision request")
+	}
+
+	// TRANSIENT state must NOT gate eligibility — the downgrade tests capability,
+	// not current load/health, because self-route queues / fails open on these
+	// just like dispatch.
+
+	// A crashed slot (transient) must still be eligible: an exclusive self-route
+	// queues on it, so the downgrade must not refuse it and force a 402.
+	mine.mu.Lock()
+	mine.BackendCapacity.Slots[0].State = "crashed"
+	mine.mu.Unlock()
+	if !reg.OwnedProviderEligible("acct-A", model, RequestTraits{}, false, nil) {
+		t.Fatal("crashed slot is transient and must not gate the downgrade")
+	}
+	mine.mu.Lock()
+	mine.BackendCapacity.Slots[0].State = "running"
+	mine.mu.Unlock()
+
+	// An OPEN node-health breaker (transient) must still be eligible: dispatch
+	// fails open on the breaker, so the preflight must too — otherwise an owner
+	// whose only Mac has a tripped breaker is wrongly forced to a 402.
+	reg.mu.Lock()
+	reg.providerBreakerOpenUntil[mine.ID] = time.Now().Add(time.Minute)
+	reg.mu.Unlock()
+	if !reg.OwnedProviderEligible("acct-A", model, RequestTraits{}, false, nil) {
+		t.Fatal("open node-health breaker is transient and must not gate the downgrade (fail open)")
 	}
 }
 

--- a/coordinator/registry/self_route_test.go
+++ b/coordinator/registry/self_route_test.go
@@ -179,6 +179,62 @@ func TestOwnedProviderSummary(t *testing.T) {
 	}
 }
 
+// TestOwnedProviderEligible verifies the trait/vision/serial-aware owner
+// eligibility gate used by the prefer→self-route downgrade. Unlike
+// OwnedProviderSummary it must reject an owned machine that serves the model but
+// can't satisfy the actual request shape.
+func TestOwnedProviderEligible(t *testing.T) {
+	reg := New(testLogger())
+	model := "eligible-model"
+
+	mine := makeSchedulerProvider(t, reg, "mine", model, 100)
+	setProviderAccount(mine, "acct-A")
+	setSchedulerProviderSerial(mine, "SERIAL-A")
+
+	// Plain request: owned + serving → eligible.
+	if !reg.OwnedProviderEligible("acct-A", model, RequestTraits{}, false, nil) {
+		t.Fatal("plain request: owned serving machine should be eligible")
+	}
+	// Different account / empty account never matches.
+	if reg.OwnedProviderEligible("acct-B", model, RequestTraits{}, false, nil) {
+		t.Fatal("acct-B must not match acct-A's machine")
+	}
+	if reg.OwnedProviderEligible("", model, RequestTraits{}, false, nil) {
+		t.Fatal("empty account must never match")
+	}
+	// Unknown model → not eligible.
+	if reg.OwnedProviderEligible("acct-A", "other-model", RequestTraits{}, false, nil) {
+		t.Fatal("machine that doesn't serve the model must not be eligible")
+	}
+
+	// Serial allowlist: a non-matching serial excludes the machine; a matching
+	// one admits it.
+	if reg.OwnedProviderEligible("acct-A", model, RequestTraits{}, false, []string{"SERIAL-OTHER"}) {
+		t.Fatal("serial allowlist miss must exclude the owned machine")
+	}
+	if !reg.OwnedProviderEligible("acct-A", model, RequestTraits{}, false, []string{"SERIAL-A"}) {
+		t.Fatal("serial allowlist hit must admit the owned machine")
+	}
+
+	// Tools trait: a below-floor binary (empty version) is gated for a
+	// tool-bearing request, even though it serves the model for plain text.
+	if reg.OwnedProviderEligible("acct-A", model, RequestTraits{HasTools: true}, false, nil) {
+		t.Fatal("below-floor binary must be ineligible for a tools request")
+	}
+	mine.mu.Lock()
+	mine.Version = "0.6.3" // first version meeting the tools floor
+	mine.mu.Unlock()
+	if !reg.OwnedProviderEligible("acct-A", model, RequestTraits{HasTools: true}, false, nil) {
+		t.Fatal("at-floor binary must be eligible for a tools request")
+	}
+
+	// Vision: this machine advertises only a text build, so a vision request is
+	// ineligible (a downgrade here would strand the request).
+	if reg.OwnedProviderEligible("acct-A", model, RequestTraits{}, true, nil) {
+		t.Fatal("text-only machine must be ineligible for a vision request")
+	}
+}
+
 func setProviderPrivateOnly(p *Provider) {
 	p.mu.Lock()
 	defer p.mu.Unlock()


### PR DESCRIPTION
## Problem

If you run your own provider but have **no credits**, you can't use your own machine. The console "Use my machine" toggle sends `X-Darkbloom-Route: prefer`, and the `prefer` path takes a worst-case balance reservation **up front** (so it can fall back to the paid fleet). A zero-balance owner failed that reservation and got a **402 `insufficient_funds`** at `coordinator/api/consumer.go` — before routing ever considered their own (free) machine. Only the exclusive `self` route skipped billing, but it has no fallback and the UI never uses it.

## Fix

When a `prefer` request fails the reservation with `ErrInsufficientBalance` **and** the owner's own machine can currently serve the model, downgrade it to exclusive self-route (free, owned-only) instead of rejecting.

- `coordinator/api/self_route.go` — new `downgradePreferToSelfRoute(policy, model)` helper (fires only for `prefer`, only when `OwnedProviderSummary` reports an owned machine serving the model).
- `coordinator/api/consumer.go` — wired into both reservation sites (chat/completions/responses and completions/messages).

No UI change needed — the toggle already sends the right `prefer` intent.

## Why billing integrity holds

- The downgrade pins the request to the owner's machine with **no paid fallback**, so it can never settle on the paid fleet for free.
- If the machine drops between the check and dispatch, the existing exclusive self-route pre-flight returns a precise 503 rather than free public inference.
- A non-owner (or owner with no available machine) with zero balance still gets a 402.

## Tests

Added two regression tests in `coordinator/api/self_route_test.go`:
- `TestSelfRoute_PreferZeroBalanceOwnerServedFree` — zero-balance owner + own machine → 200, net free.
- `TestSelfRoute_PreferZeroBalanceNoOwnedMachineStill402` — zero balance + owns nothing → still 402.

Coordinator builds clean; `api`/`registry` suites and all `TestSelfRoute_*` pass; gofmt clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/431"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784582937&installation_id=133247490&pr_number=431&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F431&signature=b1ee86830c2920367320113c43214a03d2d606fd5698659519488e320816f71b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->