### PR TITLE
DAR-345: enforce public model pools

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -202,7 +202,7 @@ Provider state lives in several fields that are read by different code paths wit
 - `CurrentModel` is set from heartbeat `active_model`. A nil/omitted `active_model` means no model is loaded. Stale `CurrentModel` can cause attestation hash mismatches.
 - `pendingModelLoads` is only checked by `TriggerModelSwaps` planning. It is NOT checked by `QuickCapacityCheck`, `ReserveProviderEx`, or `freeMemoryAdmits`. Do not assume pending-load state affects routing decisions.
 - Provider-reported slot states include `"running"` (active requests), `"idle"` (loaded, no requests), `"crashed"`, `"reloading"`, and `"idle_shutdown"`. The `"idle"` state means the model IS loaded — treat it the same as `"running"` for warm detection, not as `"unknown"`.
-- Providers can hold up to `maxModelSlots` models simultaneously (default 3). Do not assume a model swap evicts all other models.
+- Providers default to one model slot for public serving. Operators can opt into more with `backend.maxModelSlots`; do not assume a model swap evicts all other models when multi-slot is explicitly enabled.
 - The provider's `ensureModelLoaded` requires `estimatedMemoryGb * 3.0` headroom. The coordinator's `freeMemoryAdmits` uses a different (less conservative) check. A model the coordinator admits can still fail on the provider side.
 
 ### Coordinator Mutation Checklist

--- a/coordinator/api/adaptive_capacity_integration_test.go
+++ b/coordinator/api/adaptive_capacity_integration_test.go
@@ -104,6 +104,7 @@ func adaptiveChatRequest(ctx context.Context, baseURL, model string, maxTokens i
 func TestAdaptiveCapacityIntegrationHeartbeatMaxConcurrencyDrivesMultiModelRouting(t *testing.T) {
 	ts, reg := setupAdaptiveCapacityIntegration(t)
 	defer ts.Close()
+	reg.SetModelPoolEnforcement(false)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
@@ -151,6 +152,7 @@ func TestAdaptiveCapacityIntegrationHeartbeatMaxConcurrencyDrivesMultiModelRouti
 func TestAdaptiveCapacityIntegrationQueueDrainUsesHeartbeatSlotCaps(t *testing.T) {
 	ts, reg := setupAdaptiveCapacityIntegration(t)
 	defer ts.Close()
+	reg.SetModelPoolEnforcement(false)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()

--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -1994,6 +1994,10 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 		if s.shedIfUnservable(w, r, parsed, publicModel, model, modelMaxContext, stream, estimatedPromptTokens, requestedMaxTokens, requiresVision, hasTools, allowedProviderSerials, refundReservation) {
 			return
 		}
+		if candidateCount == 0 && capacityRejections == 0 && modelTooLarge == 0 &&
+			s.shedIfPoolExhausted(w, r, parsed, publicModel, model, stream, estimatedPromptTokens, requestedMaxTokens, requiresVision, hasTools, allowedProviderSerials, refundReservation) {
+			return
+		}
 		if candidateCount == 0 && capacityRejections == 0 && modelTooLarge > 0 {
 			// Providers serve this model but none can ever fit it — non-retryable.
 			// Surface a clear 503 instead of a 429 the client would retry forever.
@@ -4793,6 +4797,10 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 		// handleChatCompletions): runs AFTER the alias capacity fallback. Gated
 		// (default off), fail-open.
 		if s.shedIfUnservable(w, r, parsed, publicModel, model, modelMaxContext, stream, estimatedPromptTokens, requestedMaxTokens, requiresVision, hasTools, allowedProviderSerials, refundReservation) {
+			return
+		}
+		if candidateCount == 0 && capacityRejections == 0 && modelTooLarge == 0 &&
+			s.shedIfPoolExhausted(w, r, parsed, publicModel, model, stream, estimatedPromptTokens, requestedMaxTokens, requiresVision, hasTools, allowedProviderSerials, refundReservation) {
 			return
 		}
 		if candidateCount == 0 && capacityRejections == 0 && modelTooLarge > 0 {

--- a/coordinator/api/me_handlers.go
+++ b/coordinator/api/me_handlers.go
@@ -94,6 +94,9 @@ type myProvider struct {
 	BackendCapacity *protocol.BackendCapacity `json:"backend_capacity,omitempty"`
 	WarmModels      []string                  `json:"warm_models,omitempty"`
 	CurrentModel    string                    `json:"current_model,omitempty"`
+	AssignedPool    string                    `json:"assigned_pool,omitempty"`
+	ActivePools     []string                  `json:"active_pools,omitempty"`
+	ResidentSlots   int                       `json:"resident_slots,omitempty"`
 	PendingRequests int                       `json:"pending_requests"`
 	MaxConcurrency  int                       `json:"max_concurrency"`
 	PrefillTPS      float64                   `json:"prefill_tps,omitempty"`
@@ -302,7 +305,7 @@ func (s *Server) mergeFleet(ctx context.Context, accountID string) ([]myProvider
 		if live == nil {
 			live = liveByIdentity[recordIdentity(&deduped[i])]
 		}
-		mp := buildMyProvider(&deduped[i], live)
+		mp := s.buildMyProvider(&deduped[i], live)
 		out = append(out, mp)
 		seenIDs[deduped[i].ID] = true
 		if live != nil {
@@ -316,7 +319,7 @@ func (s *Server) mergeFleet(ctx context.Context, accountID string) ([]myProvider
 		if liveMatchesEmittedIdentity(p, out) {
 			continue
 		}
-		out = append(out, buildMyProvider(nil, p))
+		out = append(out, s.buildMyProvider(nil, p))
 	}
 	return out, nil
 }
@@ -455,7 +458,7 @@ func (s *Server) attachStoredReputation(ctx context.Context, mp *myProvider) {
 // buildMyProvider merges a persisted record with the live registry snapshot.
 // Either may be nil (a never-connected stored record OR a fresh registration
 // that hasn't been persisted yet), but at least one must be non-nil.
-func buildMyProvider(rec *store.ProviderRecord, live *registry.Provider) myProvider {
+func (s *Server) buildMyProvider(rec *store.ProviderRecord, live *registry.Provider) myProvider {
 	mp := myProvider{Status: "never_seen"}
 
 	// 1. Start from the persisted record (covers offline machines).
@@ -528,6 +531,8 @@ func buildMyProvider(rec *store.ProviderRecord, live *registry.Provider) myProvi
 
 	// 2. Overlay the live snapshot if present.
 	if live != nil {
+		var assignedPoolSeed string
+		var activePoolSeeds []string
 		live.Mu().Lock()
 		mp.ID = live.ID
 		if live.AccountID != "" {
@@ -604,6 +609,8 @@ func buildMyProvider(rec *store.ProviderRecord, live *registry.Provider) myProvi
 		}
 		mp.WarmModels = append([]string{}, live.WarmModels...)
 		mp.CurrentModel = live.CurrentModel
+		assignedPoolSeed = live.AssignedPool
+		activePoolSeeds = activePoolSeedsFromLive(live.BackendCapacity, live.WarmModels, live.CurrentModel)
 		// Reputation snapshot.
 		mp.Reputation = myReputation{
 			Score:              live.Reputation.Score(),
@@ -619,9 +626,57 @@ func buildMyProvider(rec *store.ProviderRecord, live *registry.Provider) myProvi
 		// Concurrency limit lookup acquires its own lock.
 		mp.PendingRequests = live.PendingCount()
 		mp.MaxConcurrency = live.MaxConcurrency()
+		mp.AssignedPool = s.registry.ModelPoolKey(assignedPoolSeed)
+		mp.ActivePools = modelPoolKeys(s.registry, activePoolSeeds)
+		mp.ResidentSlots = len(activePoolSeeds)
 	}
 
 	return mp
+}
+
+func activePoolSeedsFromLive(capacity *protocol.BackendCapacity, warmModels []string, currentModel string) []string {
+	seen := make(map[string]struct{})
+	var seeds []string
+	add := func(model string) {
+		if model == "" {
+			return
+		}
+		if _, ok := seen[model]; ok {
+			return
+		}
+		seen[model] = struct{}{}
+		seeds = append(seeds, model)
+	}
+	if capacity != nil {
+		for _, slot := range capacity.Slots {
+			if slot.State == "running" || slot.State == "idle" {
+				add(slot.Model)
+			}
+		}
+		return seeds
+	}
+	for _, model := range warmModels {
+		add(model)
+	}
+	add(currentModel)
+	return seeds
+}
+
+func modelPoolKeys(reg *registry.Registry, models []string) []string {
+	seen := make(map[string]struct{})
+	var pools []string
+	for _, model := range models {
+		pool := reg.ModelPoolKey(model)
+		if pool == "" {
+			continue
+		}
+		if _, ok := seen[pool]; ok {
+			continue
+		}
+		seen[pool] = struct{}{}
+		pools = append(pools, pool)
+	}
+	return pools
 }
 
 // handleDeleteMyProvider handles DELETE /v1/me/providers/{serial}.

--- a/coordinator/api/servability_gate.go
+++ b/coordinator/api/servability_gate.go
@@ -93,6 +93,58 @@ func (s *Server) shedIfUnservable(
 	return true
 }
 
+func (s *Server) shedIfPoolExhausted(
+	w http.ResponseWriter,
+	r *http.Request,
+	parsed map[string]any,
+	publicModel, model string,
+	stream bool,
+	estimatedPromptTokens, requestedMaxTokens int,
+	requiresVision, hasTools bool,
+	allowedProviderSerials []string,
+	refundReservation func(),
+) bool {
+	if s == nil || s.registry == nil {
+		return false
+	}
+	traits := registry.RequestTraits{HasTools: hasTools}
+	if s.registry.PoolRejectedProviderCount(model, traits, requiresVision, allowedProviderSerials...) == 0 {
+		return false
+	}
+
+	retryAfter := s.estimateRetryAfter(model)
+	w.Header().Set("Retry-After", strconv.Itoa(retryAfter))
+	refundReservation()
+
+	tags := []string{"model:" + model, "model_type:" + s.registry.ModelType(model)}
+	s.ddIncr("routing.decisions", append(tags, "outcome:pool_exhausted"))
+	s.ddIncr("routing.pool_exhausted", tags)
+	s.recordRejection(rejectionInfo{
+		r:                     r,
+		stage:                 "preflight_capacity",
+		reasonCode:            "pool_exhausted",
+		httpStatus:            http.StatusTooManyRequests,
+		keyID:                 keyIDFromContext(r.Context()),
+		consumerKeyHash:       store.HashKey(consumerKeyFromContext(r.Context())),
+		requestedModel:        publicModel,
+		resolvedModel:         model,
+		stream:                stream,
+		estimatedPromptTokens: estimatedPromptTokens,
+		requestedMaxTokens:    requestedMaxTokens,
+		requiresVision:        requiresVision,
+		hasTools:              hasTools,
+		retryAfterMs:          retryAfter * 1000,
+		params:                rejectionSamplingParams(parsed),
+		servabilityComputed:   true,
+		candidateCount:        0,
+	})
+
+	writeJSON(w, http.StatusTooManyRequests, errorResponse("rate_limit_exceeded",
+		fmt.Sprintf("assigned provider pool for model %q is exhausted - retry after %ds", publicModel, retryAfter),
+		withCode("rate_limit_exceeded")))
+	return true
+}
+
 // unservableMessage builds the client-facing 429 body for an unservable request.
 func unservableMessage(publicModel string, v registry.ServabilityVerdict, retryAfterSecs int) string {
 	switch v.Reason {

--- a/coordinator/api/server.go
+++ b/coordinator/api/server.go
@@ -1935,6 +1935,17 @@ func (s *Server) StartDDGaugeLoop(ctx context.Context) {
 			for _, m := range util.Models {
 				s.ddGauge("utilization.model", m.Utilization, []string{"model:" + m.Model})
 			}
+			for _, pool := range util.ModelPools {
+				tags := []string{"model_pool:" + pool.Pool}
+				s.ddGauge("model_pool.providers", float64(pool.AssignedProviders), tags)
+				s.ddGauge("model_pool.warm_providers", float64(pool.WarmProviders), tags)
+				s.ddGauge("model_pool.serving_providers", float64(pool.ServingProviders), tags)
+				s.ddGauge("model_pool.active_requests", float64(pool.ActiveRequests), tags)
+				s.ddGauge("model_pool.token_budget_used", float64(pool.TokenBudgetUsed), tags)
+				s.ddGauge("model_pool.token_budget_total", float64(pool.TokenBudgetTotal), tags)
+			}
+			s.ddGauge("model_pool.providers_with_multiple_resident_slots", float64(util.ModelPoolAudit.ProvidersWithMultipleResidentSlots), nil)
+			s.ddGauge("model_pool.providers_with_multiple_active_pools", float64(util.ModelPoolAudit.ProvidersWithMultipleActivePools), nil)
 		}
 	}
 }

--- a/coordinator/cmd/coordinator/main.go
+++ b/coordinator/cmd/coordinator/main.go
@@ -157,6 +157,8 @@ func main() {
 		reg.MinTrustLevel = registry.TrustLevel(cfg.RegistryCfg.MinTrustLevel)
 		logger.Info("minimum trust level override", "level", cfg.RegistryCfg.MinTrustLevel)
 	}
+	reg.SetModelPoolEnforcement(cfg.RegistryCfg.ModelPoolsEnabled)
+	logger.Info("model pool enforcement configured", "enabled", cfg.RegistryCfg.ModelPoolsEnabled)
 	reg.ConfigureCacheAffinity(cfg.RegistryCfg.CacheAffinity)
 	cacheAffinityCfg := reg.CacheAffinityConfigSnapshot()
 	logger.Info("cache affinity configured", "ttl", cacheAffinityCfg.TTL.String(), "bonus_ms", cacheAffinityCfg.BonusMs, "enabled", cacheAffinityCfg.BonusMs > 0)

--- a/coordinator/registry/alias_test.go
+++ b/coordinator/registry/alias_test.go
@@ -248,6 +248,7 @@ func TestPublicNameForBuild(t *testing.T) {
 
 func TestMergeProviderModelsMakesProviderServeBuild(t *testing.T) {
 	reg := New(testLogger())
+	reg.SetModelPoolEnforcement(false)
 	makeProviderRoutable(registerProviderWithModel(reg, "p1", aliasFP8)) // serves only fp8
 
 	if got := reg.RoutableProviderIDsForBuild(aliasQAT); len(got) != 0 {
@@ -417,6 +418,7 @@ func TestMergeProviderModelsRejectsMissingHashAndKeepsPrevious(t *testing.T) {
 
 func TestMergeProviderModelsDoesNotDropSiblingForUnrelatedSharedAlias(t *testing.T) {
 	reg := New(testLogger())
+	reg.SetModelPoolEnforcement(false)
 	const (
 		oldA   = "alias-a-old"
 		shared = "shared-build"

--- a/coordinator/registry/alias_test.go
+++ b/coordinator/registry/alias_test.go
@@ -487,6 +487,30 @@ func TestDesiredModelsForProviderConservative(t *testing.T) {
 	}
 }
 
+func TestDesiredModelsForProviderHonorsModelPoolDisable(t *testing.T) {
+	reg := New(testLogger())
+	reg.SetModelPoolEnforcement(false)
+	const (
+		poolA    = "pool-disable-a"
+		previous = "pool-disable-b-previous"
+		desired  = "pool-disable-b-desired"
+	)
+	p := registerProviderWithModel(reg, "p-pool-disable", poolA)
+	p.mu.Lock()
+	p.AssignedPool = poolA
+	p.Models = append(p.Models, protocol.ModelInfo{ID: previous, ModelType: "chat"})
+	p.mu.Unlock()
+	reg.SetModelCatalog([]CatalogEntry{{ID: poolA}, {ID: previous}, {ID: desired}})
+	reg.SetModelAliases(map[string]AliasTarget{
+		"pool-b": {Desired: desired, Previous: previous},
+	})
+
+	entries := reg.DesiredModelsForProvider("p-pool-disable")
+	if len(entries) != 1 || entries[0].DesiredBuild != desired {
+		t.Fatalf("desired entries = %+v, want alias-b desired while pools disabled", entries)
+	}
+}
+
 // A provider that was offline through a retirement (still advertising only a
 // RETIRED member of the alias) is still recognized as part of the alias's fleet
 // at registration and told to converge — without this it would be permanently

--- a/coordinator/registry/cold_dispatch_test.go
+++ b/coordinator/registry/cold_dispatch_test.go
@@ -3,6 +3,8 @@ package registry
 import (
 	"testing"
 	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
 )
 
 // An idle provider that has the model on disk (serving a DIFFERENT model) is a
@@ -79,5 +81,25 @@ func TestColdSpillProvidersZeroWhenLoadPending(t *testing.T) {
 
 	if n := reg.ColdSpillProviders(model, RequestTraits{}, false); n != 0 {
 		t.Fatalf("ColdSpillProviders = %d, want 0 (load already pending)", n)
+	}
+}
+
+func TestColdSpillProvidersZeroForUnassignedModelPool(t *testing.T) {
+	reg := New(testLogger())
+	assigned := "cold-spill-assigned"
+	unassigned := "cold-spill-unassigned"
+	p := makeSchedulerProvider(t, reg, "cold-wrong-pool", assigned, 80)
+	p.mu.Lock()
+	p.Models = append(p.Models, protocol.ModelInfo{ID: unassigned, ModelType: "chat", Quantization: "4bit"})
+	p.BackendCapacity = nil
+	p.WarmModels = nil
+	p.CurrentModel = ""
+	p.mu.Unlock()
+
+	if n := reg.ColdSpillProviders(unassigned, RequestTraits{}, false); n != 0 {
+		t.Fatalf("ColdSpillProviders = %d, want 0 for unassigned pool", n)
+	}
+	if got := reg.PoolRejectedProviderCount(unassigned, RequestTraits{}, false); got != 1 {
+		t.Fatalf("PoolRejectedProviderCount = %d, want 1", got)
 	}
 }

--- a/coordinator/registry/cold_dispatch_test.go
+++ b/coordinator/registry/cold_dispatch_test.go
@@ -84,7 +84,7 @@ func TestColdSpillProvidersZeroWhenLoadPending(t *testing.T) {
 	}
 }
 
-func TestColdSpillProvidersZeroForUnassignedModelPool(t *testing.T) {
+func TestColdSpillProvidersDetectsIdleReassignableProvider(t *testing.T) {
 	reg := New(testLogger())
 	assigned := "cold-spill-assigned"
 	unassigned := "cold-spill-unassigned"
@@ -96,8 +96,23 @@ func TestColdSpillProvidersZeroForUnassignedModelPool(t *testing.T) {
 	p.CurrentModel = ""
 	p.mu.Unlock()
 
+	if n := reg.ColdSpillProviders(unassigned, RequestTraits{}, false); n != 1 {
+		t.Fatalf("ColdSpillProviders = %d, want 1 for idle reassignable provider", n)
+	}
+}
+
+func TestColdSpillProvidersZeroForResidentUnassignedModelPool(t *testing.T) {
+	reg := New(testLogger())
+	assigned := "cold-spill-resident-assigned"
+	unassigned := "cold-spill-resident-unassigned"
+	p := makeSchedulerProvider(t, reg, "cold-resident-wrong-pool", assigned, 80)
+	p.mu.Lock()
+	p.Models = append(p.Models, protocol.ModelInfo{ID: unassigned, ModelType: "chat", Quantization: "4bit"})
+	p.BackendCapacity.Slots = []protocol.BackendSlotCapacity{{Model: assigned, State: "idle"}}
+	p.mu.Unlock()
+
 	if n := reg.ColdSpillProviders(unassigned, RequestTraits{}, false); n != 0 {
-		t.Fatalf("ColdSpillProviders = %d, want 0 for unassigned pool", n)
+		t.Fatalf("ColdSpillProviders = %d, want 0 for resident wrong-pool provider", n)
 	}
 	if got := reg.PoolRejectedProviderCount(unassigned, RequestTraits{}, false); got != 1 {
 		t.Fatalf("PoolRejectedProviderCount = %d, want 1", got)

--- a/coordinator/registry/config.go
+++ b/coordinator/registry/config.go
@@ -12,9 +12,10 @@ import (
 
 // Config holds registry-level configuration.
 type Config struct {
-	MinTrustLevel string
-	WarmPool      WarmPoolConfig
-	CacheAffinity CacheAffinityConfig
+	MinTrustLevel     string
+	ModelPoolsEnabled bool
+	WarmPool          WarmPoolConfig
+	CacheAffinity     CacheAffinityConfig
 }
 
 type CacheAffinityConfig struct {
@@ -84,7 +85,8 @@ func (c WarmPoolConfig) perTickCeiling() int {
 // ReadConfig reads registry configuration from environment variables.
 func ReadConfig() Config {
 	return Config{
-		MinTrustLevel: os.Getenv(env.EnvPrefix + "_MIN_TRUST"),
+		MinTrustLevel:     os.Getenv(env.EnvPrefix + "_MIN_TRUST"),
+		ModelPoolsEnabled: env.EnvBool(env.EnvPrefix+"_MODEL_POOLS_ENABLED", true),
 		WarmPool: WarmPoolConfig{
 			Enabled:                   env.EnvBool(env.EnvPrefix+"_WARM_POOL_ENABLED", true),
 			ObserveOnly:               env.EnvBool(env.EnvPrefix+"_WARM_POOL_OBSERVE_ONLY", false),

--- a/coordinator/registry/config_test.go
+++ b/coordinator/registry/config_test.go
@@ -55,6 +55,22 @@ func TestReadConfigWarmPoolDefaultsActive(t *testing.T) {
 	}
 }
 
+func TestReadConfigModelPoolsDefaultEnabled(t *testing.T) {
+	t.Setenv(env.EnvPrefix+"_MODEL_POOLS_ENABLED", "")
+
+	if !ReadConfig().ModelPoolsEnabled {
+		t.Fatal("model pools should default to enabled")
+	}
+}
+
+func TestReadConfigModelPoolsCanBeDisabled(t *testing.T) {
+	t.Setenv(env.EnvPrefix+"_MODEL_POOLS_ENABLED", "false")
+
+	if ReadConfig().ModelPoolsEnabled {
+		t.Fatal("model pools enabled despite explicit false")
+	}
+}
+
 func TestReadConfigWarmPoolMinWarmByModel(t *testing.T) {
 	clearWarmPoolEnv(t)
 	t.Setenv(env.EnvPrefix+"_WARM_POOL_MIN_WARM", "gpt-oss-20b=4, bad, gemma=0, other=-1, qwen=2")

--- a/coordinator/registry/model_pools.go
+++ b/coordinator/registry/model_pools.go
@@ -47,33 +47,38 @@ func (r *Registry) ModelPoolKey(model string) string {
 }
 
 func (r *Registry) modelPoolKeyLocked(model string) string {
-	if model == "" {
+	keys := r.modelPoolKeysLocked(model)
+	if len(keys) == 0 {
 		return ""
 	}
-	if _, ok := r.modelAliases[model]; ok {
-		return model
+	return keys[0]
+}
+
+func (r *Registry) modelPoolKeysLocked(model string) []string {
+	if model == "" {
+		return nil
 	}
-	best := ""
+	if _, ok := r.modelAliases[model]; ok {
+		return []string{model}
+	}
+	var keys []string
 	for alias, target := range r.modelAliases {
 		if target.Desired == model || target.Previous == model {
-			if best == "" || alias < best {
-				best = alias
-			}
+			keys = append(keys, alias)
 			continue
 		}
 		for _, retired := range target.Retired {
 			if retired == model {
-				if best == "" || alias < best {
-					best = alias
-				}
+				keys = append(keys, alias)
 				break
 			}
 		}
 	}
-	if best != "" {
-		return best
+	if len(keys) > 0 {
+		sort.Strings(keys)
+		return keys
 	}
-	return model
+	return []string{model}
 }
 
 func (r *Registry) modelCanSeedPoolLocked(model string) bool {
@@ -149,27 +154,68 @@ func (r *Registry) providerModelPoolSeedLocked(p *Provider) string {
 			return model
 		}
 	}
-	singleAdvertised := ""
+	var commonPools map[string]struct{}
+	firstAdvertised := ""
 	for _, model := range p.Models {
 		if r.modelCanSeedPoolLocked(model.ID) && r.modelAllowedByCatalogLocked(model) {
-			if singleAdvertised != "" {
+			keys := r.modelPoolKeysLocked(model.ID)
+			if len(keys) == 0 {
+				continue
+			}
+			if firstAdvertised == "" {
+				firstAdvertised = model.ID
+				commonPools = make(map[string]struct{}, len(keys))
+				for _, key := range keys {
+					commonPools[key] = struct{}{}
+				}
+				continue
+			}
+			next := make(map[string]struct{})
+			for _, key := range keys {
+				if _, ok := commonPools[key]; ok {
+					next[key] = struct{}{}
+				}
+			}
+			commonPools = next
+			if len(commonPools) == 0 {
 				return ""
 			}
-			singleAdvertised = model.ID
 		}
 	}
-	return singleAdvertised
+	if firstAdvertised == "" {
+		return ""
+	}
+	if len(commonPools) == 1 {
+		for key := range commonPools {
+			if key == firstAdvertised {
+				return firstAdvertised
+			}
+			return key
+		}
+	}
+	if len(commonPools) > 1 {
+		return firstAdvertised
+	}
+	return ""
 }
 
 func (r *Registry) providerAssignedToModelPoolLocked(p *Provider, model string, allowPrivate bool) bool {
 	if !r.enforceModelPools || allowPrivate {
 		return true
 	}
-	assigned := r.assignProviderModelPoolLocked(p)
-	if assigned == "" {
+	if r.assignProviderModelPoolLocked(p) == "" || p.AssignedPool == "" {
 		return false
 	}
-	return assigned == r.modelPoolKeyLocked(model)
+	assigned := r.modelPoolKeysLocked(p.AssignedPool)
+	requested := r.modelPoolKeysLocked(model)
+	for _, a := range assigned {
+		for _, req := range requested {
+			if a == req {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func (r *Registry) providerPassesRoutingGatesBeforePoolLockedEx(p *Provider, model string, traits RequestTraits, selfRouteOwner bool, now time.Time, ignoreProviderBreaker bool) bool {

--- a/coordinator/registry/model_pools.go
+++ b/coordinator/registry/model_pools.go
@@ -155,12 +155,16 @@ func (r *Registry) providerModelPoolSeedLocked(p *Provider) string {
 		}
 	}
 	var commonPools map[string]struct{}
+	candidatePools := make(map[string]struct{})
 	firstAdvertised := ""
 	for _, model := range p.Models {
 		if r.modelCanSeedPoolLocked(model.ID) && r.modelAllowedByCatalogLocked(model) {
 			keys := r.modelPoolKeysLocked(model.ID)
 			if len(keys) == 0 {
 				continue
+			}
+			for _, key := range keys {
+				candidatePools[key] = struct{}{}
 			}
 			if firstAdvertised == "" {
 				firstAdvertised = model.ID
@@ -177,9 +181,6 @@ func (r *Registry) providerModelPoolSeedLocked(p *Provider) string {
 				}
 			}
 			commonPools = next
-			if len(commonPools) == 0 {
-				return ""
-			}
 		}
 	}
 	if firstAdvertised == "" {
@@ -196,7 +197,7 @@ func (r *Registry) providerModelPoolSeedLocked(p *Provider) string {
 	if len(commonPools) > 1 {
 		return firstAdvertised
 	}
-	return ""
+	return firstSortedMapKey(candidatePools)
 }
 
 func (r *Registry) providerAssignedToModelPoolLocked(p *Provider, model string, allowPrivate bool) bool {
@@ -213,6 +214,34 @@ func (r *Registry) providerAssignedToModelPoolLocked(p *Provider, model string, 
 			if a == req {
 				return true
 			}
+		}
+	}
+	return false
+}
+
+func firstSortedMapKey(keys map[string]struct{}) string {
+	if len(keys) == 0 {
+		return ""
+	}
+	ordered := make([]string, 0, len(keys))
+	for key := range keys {
+		ordered = append(ordered, key)
+	}
+	sort.Strings(ordered)
+	return ordered[0]
+}
+
+func poolKeysOverlap(a, b []string) bool {
+	if len(a) == 0 || len(b) == 0 {
+		return false
+	}
+	seen := make(map[string]struct{}, len(a))
+	for _, key := range a {
+		seen[key] = struct{}{}
+	}
+	for _, key := range b {
+		if _, ok := seen[key]; ok {
+			return true
 		}
 	}
 	return false

--- a/coordinator/registry/model_pools.go
+++ b/coordinator/registry/model_pools.go
@@ -1,0 +1,342 @@
+package registry
+
+import (
+	"sort"
+	"time"
+)
+
+// ModelPoolMetrics is an admin/metrics snapshot of coordinator-managed public
+// model pools. A provider contributes to exactly one AssignedProviders pool;
+// active/warm counts are derived from its current backend slots.
+type ModelPoolMetrics struct {
+	Pool                  string  `json:"pool"`
+	AssignedProviders     int     `json:"assigned_providers"`
+	WarmProviders         int     `json:"warm_providers"`
+	ServingProviders      int     `json:"serving_providers"`
+	ActiveRequests        int     `json:"active_requests"`
+	TokenBudgetUsed       int64   `json:"token_budget_used"`
+	TokenBudgetTotal      int64   `json:"token_budget_total"`
+	ObservedDecodeTPS     float64 `json:"observed_decode_tps"`
+	ResidentSlotProviders int     `json:"resident_slot_providers"`
+}
+
+// ModelPoolAudit captures policy violations DAR-345 wants visible: machines with
+// more than one resident public model, and machines co-resident across unrelated
+// public pools. Alias desired/previous builds count as the same pool.
+type ModelPoolAudit struct {
+	ProvidersWithMultipleResidentSlots int `json:"providers_with_multiple_resident_slots"`
+	ProvidersWithMultipleActivePools   int `json:"providers_with_multiple_active_pools"`
+}
+
+func (r *Registry) SetModelPoolEnforcement(enabled bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.enforceModelPools = enabled
+}
+
+func (r *Registry) ModelPoolEnforcementEnabled() bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.enforceModelPools
+}
+
+func (r *Registry) ModelPoolKey(model string) string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.modelPoolKeyLocked(model)
+}
+
+func (r *Registry) modelPoolKeyLocked(model string) string {
+	if model == "" {
+		return ""
+	}
+	if _, ok := r.modelAliases[model]; ok {
+		return model
+	}
+	best := ""
+	for alias, target := range r.modelAliases {
+		if target.Desired == model || target.Previous == model {
+			if best == "" || alias < best {
+				best = alias
+			}
+			continue
+		}
+		for _, retired := range target.Retired {
+			if retired == model {
+				if best == "" || alias < best {
+					best = alias
+				}
+				break
+			}
+		}
+	}
+	if best != "" {
+		return best
+	}
+	return model
+}
+
+func (r *Registry) modelCanSeedPoolLocked(model string) bool {
+	if model == "" {
+		return false
+	}
+	if r.modelCatalog == nil {
+		return true
+	}
+	if _, ok := r.modelCatalog[model]; ok {
+		return true
+	}
+	return r.modelPoolKeyLocked(model) != model
+}
+
+func (r *Registry) providerCanSeedPoolModelLocked(p *Provider, model string) bool {
+	if !r.modelCanSeedPoolLocked(model) {
+		return false
+	}
+	for _, advertised := range p.Models {
+		if advertised.ID == model && r.modelAllowedByCatalogLocked(advertised) {
+			return true
+		}
+	}
+	return r.modelPoolKeyLocked(model) != model
+}
+
+func (r *Registry) assignProviderModelPoolLocked(p *Provider) string {
+	if p == nil {
+		return ""
+	}
+	if p.AssignedPool != "" {
+		return r.modelPoolKeyLocked(p.AssignedPool)
+	}
+	seed := r.providerModelPoolSeedLocked(p)
+	if seed == "" {
+		return ""
+	}
+	p.AssignedPool = seed
+	return r.modelPoolKeyLocked(seed)
+}
+
+func (r *Registry) assignProviderModelPool(providerID string) string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	p, ok := r.providers[providerID]
+	if !ok {
+		return ""
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return r.assignProviderModelPoolLocked(p)
+}
+
+func (r *Registry) providerModelPoolSeedLocked(p *Provider) string {
+	if r.providerCanSeedPoolModelLocked(p, p.CurrentModel) {
+		return p.CurrentModel
+	}
+	if p.BackendCapacity != nil {
+		for _, slot := range p.BackendCapacity.Slots {
+			if slot.State == "running" && r.providerCanSeedPoolModelLocked(p, slot.Model) {
+				return slot.Model
+			}
+		}
+		for _, slot := range p.BackendCapacity.Slots {
+			if slotStateModelLoaded(slot.State) && r.providerCanSeedPoolModelLocked(p, slot.Model) {
+				return slot.Model
+			}
+		}
+	}
+	for _, model := range p.WarmModels {
+		if r.providerCanSeedPoolModelLocked(p, model) {
+			return model
+		}
+	}
+	singleAdvertised := ""
+	for _, model := range p.Models {
+		if r.modelCanSeedPoolLocked(model.ID) && r.modelAllowedByCatalogLocked(model) {
+			if singleAdvertised != "" {
+				return ""
+			}
+			singleAdvertised = model.ID
+		}
+	}
+	return singleAdvertised
+}
+
+func (r *Registry) providerAssignedToModelPoolLocked(p *Provider, model string, allowPrivate bool) bool {
+	if !r.enforceModelPools || allowPrivate {
+		return true
+	}
+	assigned := r.assignProviderModelPoolLocked(p)
+	if assigned == "" {
+		return false
+	}
+	return assigned == r.modelPoolKeyLocked(model)
+}
+
+func (r *Registry) providerPassesRoutingGatesBeforePoolLockedEx(p *Provider, model string, traits RequestTraits, selfRouteOwner bool, now time.Time, ignoreProviderBreaker bool) bool {
+	if !r.providerServesCatalogModelLocked(p, model) {
+		return false
+	}
+	if r.dispatchLoadCooldownActiveLocked(p.ID, model, now) {
+		return false
+	}
+	if r.inferenceErrorCooldownActiveLocked(p.ID, model, traits.CooldownShape(), now) {
+		return false
+	}
+	if !ignoreProviderBreaker && r.providerBreakerOpenLocked(p.ID, now) {
+		return false
+	}
+	if p.Status == StatusOffline || p.Status == StatusUntrusted {
+		return false
+	}
+	if p.PrivateOnly && !selfRouteOwner {
+		return false
+	}
+	minTrust := r.MinTrustLevel
+	if selfRouteOwner {
+		minTrust = TrustNone
+	}
+	if trustRank(p.TrustLevel) < trustRank(minTrust) {
+		return false
+	}
+	if !p.RuntimeVerified {
+		return false
+	}
+	if !r.providerSupportsPrivateTextLocked(p) {
+		return false
+	}
+	if p.LastChallengeVerified.IsZero() || now.Sub(p.LastChallengeVerified) > challengeFreshnessMaxAge {
+		return false
+	}
+	return r.providerEligibleForTraitsLocked(p, model, traits)
+}
+
+func (r *Registry) providerRejectedByModelPoolLocked(p *Provider, model string, traits RequestTraits, now time.Time, ignoreProviderBreaker bool) bool {
+	if !r.enforceModelPools {
+		return false
+	}
+	if !r.providerPassesRoutingGatesBeforePoolLockedEx(p, model, traits, false, now, ignoreProviderBreaker) {
+		return false
+	}
+	if p.SystemMetrics.ThermalState == "critical" {
+		return false
+	}
+	return !r.providerAssignedToModelPoolLocked(p, model, false)
+}
+
+func (r *Registry) PoolRejectedProviderCount(model string, traits RequestTraits, requiresVision bool, allowedSerials ...string) int {
+	allowedSet := make(map[string]struct{}, len(allowedSerials))
+	for _, serial := range allowedSerials {
+		allowedSet[serial] = struct{}{}
+	}
+	now := time.Now()
+	count := 0
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	for _, p := range r.providers {
+		if len(allowedSet) > 0 && !providerMatchesAllowedSerial(p, allowedSet) {
+			continue
+		}
+		p.mu.Lock()
+		poolRejected := r.providerRejectedByModelPoolLocked(p, model, traits, now, true)
+		if poolRejected && requiresVision && !r.providerServesVisionModelLocked(p, model) {
+			poolRejected = false
+		}
+		p.mu.Unlock()
+		if poolRejected {
+			count++
+		}
+	}
+	return count
+}
+
+func (r *Registry) ModelPoolMetricsSnapshot() ([]ModelPoolMetrics, ModelPoolAudit) {
+	now := time.Now()
+	pools := make(map[string]*ModelPoolMetrics)
+	audit := ModelPoolAudit{}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	for _, p := range r.providers {
+		p.mu.Lock()
+		if !r.publiclyRoutableLocked(p, now) {
+			p.mu.Unlock()
+			continue
+		}
+		assigned := r.assignProviderModelPoolLocked(p)
+		if assigned == "" {
+			p.mu.Unlock()
+			continue
+		}
+		pool := pools[assigned]
+		if pool == nil {
+			pool = &ModelPoolMetrics{Pool: assigned}
+			pools[assigned] = pool
+		}
+		pool.AssignedProviders++
+		residentPools := make(map[string]struct{})
+		residentSlots := 0
+		providerActiveRequests := 0
+		assignedWarm := false
+		assignedServing := false
+		if p.BackendCapacity != nil {
+			used, total := providerTokenBudget(p.BackendCapacity.Slots)
+			pool.TokenBudgetUsed += used
+			pool.TokenBudgetTotal += total
+			for _, slot := range p.BackendCapacity.Slots {
+				if !slotStateModelLoaded(slot.State) {
+					continue
+				}
+				residentSlots++
+				poolKey := r.modelPoolKeyLocked(slot.Model)
+				residentPools[poolKey] = struct{}{}
+				if poolKey == assigned {
+					assignedWarm = true
+					if slot.State == "running" {
+						assignedServing = true
+					}
+					providerActiveRequests += slot.NumRunning + slot.NumWaiting
+					if slot.ObservedDecodeTPS > 0 {
+						pool.ObservedDecodeTPS += slot.ObservedDecodeTPS
+					}
+				}
+			}
+		} else {
+			for _, model := range p.WarmModels {
+				residentSlots++
+				poolKey := r.modelPoolKeyLocked(model)
+				residentPools[poolKey] = struct{}{}
+				if poolKey == assigned {
+					assignedWarm = true
+				}
+			}
+			if r.modelPoolKeyLocked(p.CurrentModel) == assigned {
+				providerActiveRequests = p.pendingCountForModelLocked(p.CurrentModel)
+				assignedServing = providerActiveRequests > 0
+			}
+		}
+		if assignedWarm {
+			pool.WarmProviders++
+		}
+		if assignedServing {
+			pool.ServingProviders++
+		}
+		if residentSlots > 0 {
+			pool.ResidentSlotProviders++
+		}
+		if residentSlots > 1 {
+			audit.ProvidersWithMultipleResidentSlots++
+		}
+		if len(residentPools) > 1 {
+			audit.ProvidersWithMultipleActivePools++
+		}
+		if providerActiveRequests > 0 {
+			pool.ActiveRequests += providerActiveRequests
+		}
+		p.mu.Unlock()
+	}
+	result := make([]ModelPoolMetrics, 0, len(pools))
+	for _, pool := range pools {
+		result = append(result, *pool)
+	}
+	sort.Slice(result, func(i, j int) bool { return result[i].Pool < result[j].Pool })
+	return result, audit
+}

--- a/coordinator/registry/model_pools.go
+++ b/coordinator/registry/model_pools.go
@@ -207,6 +207,31 @@ func (r *Registry) providerAssignedToModelPoolLocked(p *Provider, model string, 
 	if r.assignProviderModelPoolLocked(p) == "" || p.AssignedPool == "" {
 		return false
 	}
+	return r.providerAssignedPoolMatchesModelLocked(p, model)
+}
+
+func (r *Registry) providerAssignedOrIdleReassignableToModelPoolLocked(p *Provider, model string, allowPrivate bool) bool {
+	if !r.enforceModelPools || allowPrivate {
+		return true
+	}
+	if r.assignProviderModelPoolLocked(p) == "" || p.AssignedPool == "" {
+		if !r.providerPoolReassignableLocked(p) {
+			return false
+		}
+		p.AssignedPool = model
+		return true
+	}
+	if r.providerAssignedPoolMatchesModelLocked(p, model) {
+		return true
+	}
+	if !r.providerPoolReassignableLocked(p) {
+		return false
+	}
+	p.AssignedPool = model
+	return true
+}
+
+func (r *Registry) providerAssignedPoolMatchesModelLocked(p *Provider, model string) bool {
 	assigned := r.modelPoolKeysLocked(p.AssignedPool)
 	requested := r.modelPoolKeysLocked(model)
 	for _, a := range assigned {
@@ -217,6 +242,21 @@ func (r *Registry) providerAssignedToModelPoolLocked(p *Provider, model string, 
 		}
 	}
 	return false
+}
+
+func (r *Registry) providerPoolReassignableLocked(p *Provider) bool {
+	if p.pendingCount() != 0 {
+		return false
+	}
+	if p.BackendCapacity != nil {
+		for _, slot := range p.BackendCapacity.Slots {
+			if backendSlotBusy(slot) || slotStateModelLoaded(slot.State) {
+				return false
+			}
+		}
+		return true
+	}
+	return p.CurrentModel == "" && len(p.WarmModels) == 0
 }
 
 func firstSortedMapKey(keys map[string]struct{}) string {

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -369,6 +369,10 @@ type Provider struct {
 	// Warm model cache tracking
 	WarmModels   []string // models currently loaded in provider's memory
 	CurrentModel string   // model currently being served
+	// AssignedPool is the coordinator-managed public model pool seed for this
+	// connection. The rendered pool is modelPoolKeyLocked(AssignedPool), so an
+	// alias desired/previous build stays in the same pool across version rollout.
+	AssignedPool string
 
 	// Live system metrics from heartbeats
 	SystemMetrics protocol.SystemMetrics
@@ -1097,6 +1101,7 @@ type Registry struct {
 
 	cacheAffinity        *cacheAffinityTracker
 	cacheAffinityBonusMs float64
+	enforceModelPools    bool
 	warmPool             *warmPoolController
 	// loadModelSender is a test seam for SendLoadModel. Nil uses the provider WebSocket.
 	loadModelSender func(providerID, modelID string) error
@@ -1164,6 +1169,7 @@ func New(logger *slog.Logger) *Registry {
 		evictStrikes:             make(map[string]int),
 		cacheAffinity:            newCacheAffinityTracker(cacheAffinityTTL),
 		cacheAffinityBonusMs:     defaultCacheAffinityBonusMs,
+		enforceModelPools:        true,
 		logger:                   logger,
 	}
 }
@@ -1800,6 +1806,9 @@ func (r *Registry) anyEligibleProviderCanRouteLocked(buildID string, allowedSeri
 // slot required — they load on first demand). Caller holds r.mu (RLock) and p.mu.
 func (r *Registry) providerCanRouteBuildLocked(p *Provider, buildID string, minTrust TrustLevel, now time.Time, allowPrivate bool) bool {
 	if !r.providerServesCatalogModelLocked(p, buildID) {
+		return false
+	}
+	if !r.providerAssignedToModelPoolLocked(p, buildID, allowPrivate) {
 		return false
 	}
 	if r.dispatchLoadCooldownActiveLocked(p.ID, buildID, now) {
@@ -2664,6 +2673,7 @@ func (r *Registry) Heartbeat(id string, msg *protocol.HeartbeatMessage) {
 		}
 	}
 	p.mu.Unlock()
+	r.assignProviderModelPool(id)
 
 	r.PersistProviderThrottled(p)
 	// Persist accumulated uptime (throttled) so it survives restarts/reconnects;
@@ -2686,19 +2696,27 @@ func (r *Registry) Heartbeat(id string, msg *protocol.HeartbeatMessage) {
 // does not block waiting for the load to complete. The provider replies
 // asynchronously with a load_model_status message.
 func (r *Registry) SendLoadModel(providerID, modelID string) error {
+	r.mu.RLock()
+	p, ok := r.providers[providerID]
+	if ok {
+		p.mu.Lock()
+		allowed := r.providerAssignedToModelPoolLocked(p, modelID, false)
+		p.mu.Unlock()
+		if !allowed {
+			r.mu.RUnlock()
+			return fmt.Errorf("provider %q is not assigned to model pool for %q", providerID, modelID)
+		}
+	}
+	r.mu.RUnlock()
+	if !ok {
+		return fmt.Errorf("provider %q not found", providerID)
+	}
 	if r.loadModelSender != nil {
 		if err := r.loadModelSender(providerID, modelID); err != nil {
 			return err
 		}
 		r.logger.Info("sent load_model to provider", "provider_id", providerID, "model_id", modelID)
 		return nil
-	}
-
-	r.mu.RLock()
-	p, ok := r.providers[providerID]
-	r.mu.RUnlock()
-	if !ok {
-		return fmt.Errorf("provider %q not found", providerID)
 	}
 
 	msg := protocol.LoadModelMessage{
@@ -2832,11 +2850,15 @@ func (r *Registry) DesiredModelsForProvider(providerID string) []protocol.Desire
 			advertised[m.ID] = struct{}{}
 		}
 	}
+	assignedPool := r.assignProviderModelPoolLocked(p)
 	p.mu.Unlock()
 
 	var entries []protocol.DesiredModelEntry
 	for alias, t := range r.modelAliases {
 		if t.Desired == "" {
+			continue
+		}
+		if assignedPool != "" && assignedPool != r.modelPoolKeyLocked(t.Desired) {
 			continue
 		}
 		_, hasDesired := advertised[t.Desired]
@@ -2971,6 +2993,9 @@ func (r *Registry) providerHasWarmModelLocked(p *Provider, model string, now tim
 	if !r.providerServesCatalogModelLocked(p, model) {
 		return false
 	}
+	if !r.providerAssignedToModelPoolLocked(p, model, false) {
+		return false
+	}
 	if p.BackendCapacity != nil {
 		for _, slot := range p.BackendCapacity.Slots {
 			if slot.Model == model {
@@ -3049,6 +3074,9 @@ func (r *Registry) modelLoadCandidatePendingLocked(p *Provider, model string, no
 		return 0, false
 	}
 	if !r.providerServesCatalogModelLocked(p, model) {
+		return 0, false
+	}
+	if !r.providerAssignedToModelPoolLocked(p, model, false) {
 		return 0, false
 	}
 
@@ -3137,12 +3165,18 @@ func (r *Registry) providerHasPendingLoad(providerID string) bool {
 func (r *Registry) MarkModelWarm(providerID, modelID string) {
 	r.mu.RLock()
 	p, ok := r.providers[providerID]
-	r.mu.RUnlock()
 	if !ok {
+		r.mu.RUnlock()
 		return
 	}
 
 	p.mu.Lock()
+	if !r.providerAssignedToModelPoolLocked(p, modelID, false) {
+		p.mu.Unlock()
+		r.mu.RUnlock()
+		return
+	}
+	r.mu.RUnlock()
 	defer p.mu.Unlock()
 	for _, wm := range p.WarmModels {
 		if wm == modelID {
@@ -3160,7 +3194,7 @@ func (r *Registry) MarkModelWarm(providerID, modelID string) {
 	//
 	// We only add/update the new model's slot and leave existing slots
 	// untouched — the provider may have multiple model slots loaded
-	// simultaneously (maxModelSlots defaults to 3). The next heartbeat
+	// simultaneously when explicitly configured. The next heartbeat
 	// will provide the authoritative slot list.
 	if p.BackendCapacity != nil {
 		found := false
@@ -4489,26 +4523,29 @@ func (r *Registry) Snapshot() FleetSnapshot {
 
 // ModelCapacity describes the live capacity for a single model.
 type ModelCapacity struct {
-	ModelID              string  `json:"id"`
-	Ready                bool    `json:"ready"`                  // at least one routable provider with headroom
-	CanAccept            bool    `json:"can_accept"`             // ready AND queue not full
-	RoutableProviders    int     `json:"routable_providers"`     // passed all gates
-	WarmProviders        int     `json:"warm_providers"`         // model loaded (slot state "running" or "idle")
-	RunningProviders     int     `json:"running_providers"`      // model loaded with active requests (slot state "running")
-	ColdProviders        int     `json:"cold_providers"`         // model available but not loaded
-	ActiveRequests       int     `json:"active_requests"`        // in-flight across fleet
-	QueuedRequests       int     `json:"queued_requests"`        // waiting in coordinator queue
-	QueueLimit           int     `json:"queue_limit"`            // max queue depth per model
-	AggregateTPS         float64 `json:"aggregate_tps"`          // sum of effective decode TPS
-	EstimatedTTFTMs      int64   `json:"estimated_ttft_ms"`      // best-case TTFT from lowest-cost warm provider
-	TokenBudgetRemaining int64   `json:"token_budget_remaining"` // aggregate free budget across providers
-	TokenBudgetTotal     int64   `json:"token_budget_total"`     // aggregate total budget
+	ModelID               string  `json:"id"`
+	AssignedPool          string  `json:"assigned_pool"`
+	AssignedPoolProviders int     `json:"assigned_pool_providers"`
+	Ready                 bool    `json:"ready"`                  // at least one routable provider with headroom
+	CanAccept             bool    `json:"can_accept"`             // ready AND queue not full
+	RoutableProviders     int     `json:"routable_providers"`     // passed all gates
+	WarmProviders         int     `json:"warm_providers"`         // model loaded (slot state "running" or "idle")
+	RunningProviders      int     `json:"running_providers"`      // model loaded with active requests (slot state "running")
+	ColdProviders         int     `json:"cold_providers"`         // model available but not loaded
+	ActiveRequests        int     `json:"active_requests"`        // in-flight across fleet
+	QueuedRequests        int     `json:"queued_requests"`        // waiting in coordinator queue
+	QueueLimit            int     `json:"queue_limit"`            // max queue depth per model
+	AggregateTPS          float64 `json:"aggregate_tps"`          // sum of effective decode TPS
+	EstimatedTTFTMs       int64   `json:"estimated_ttft_ms"`      // best-case TTFT from lowest-cost warm provider
+	TokenBudgetRemaining  int64   `json:"token_budget_remaining"` // aggregate free budget across providers
+	TokenBudgetTotal      int64   `json:"token_budget_total"`     // aggregate total budget
 }
 
 // providerCapSnap is a per-provider snapshot collected under the registry
 // lock, then aggregated into ModelCapacity outside the lock.
 type providerCapSnap struct {
 	model                 string
+	assignedPool          string
 	warm                  bool
 	running               bool
 	hasHeadroom           bool // pending < maxConcurrency
@@ -4578,6 +4615,9 @@ func (r *Registry) ModelCapacitySnapshot() []ModelCapacity {
 			if !r.modelAllowedByCatalogLocked(m) {
 				continue
 			}
+			if !r.providerAssignedToModelPoolLocked(p, m.ID, false) {
+				continue
+			}
 			hasHeadroom := p.hasConcurrencyHeadroomForModelLocked(m.ID)
 			// Count only pending requests for this specific model, not the
 			// total across all models. Using the total inflates
@@ -4591,6 +4631,7 @@ func (r *Registry) ModelCapacitySnapshot() []ModelCapacity {
 
 			snap := providerCapSnap{
 				model:          m.ID,
+				assignedPool:   r.modelPoolKeyLocked(m.ID),
 				hasHeadroom:    hasHeadroom,
 				effectiveTPS:   decodeTPS,
 				prefillTPS:     prefillTPS,
@@ -4637,17 +4678,19 @@ func (r *Registry) ModelCapacitySnapshot() []ModelCapacity {
 
 	// Phase 2: aggregate per-model outside the lock.
 	type modelAgg struct {
-		routable         int
-		warm             int
-		running          int
-		cold             int
-		activeRequests   int
-		aggregateTPS     float64
-		budgetRemaining  int64
-		budgetTotal      int64
-		bestWarmTTFTMs   int64 // -1 = not set
-		bestColdTTFTMs   int64 // -1 = not set
-		anyImmediateSlot bool  // at least one provider with headroom
+		assignedPool      string
+		assignedProviders int
+		routable          int
+		warm              int
+		running           int
+		cold              int
+		activeRequests    int
+		aggregateTPS      float64
+		budgetRemaining   int64
+		budgetTotal       int64
+		bestWarmTTFTMs    int64 // -1 = not set
+		bestColdTTFTMs    int64 // -1 = not set
+		anyImmediateSlot  bool  // at least one provider with headroom
 	}
 	agg := make(map[string]*modelAgg)
 	for _, s := range snaps {
@@ -4656,6 +4699,8 @@ func (r *Registry) ModelCapacitySnapshot() []ModelCapacity {
 			a = &modelAgg{bestWarmTTFTMs: -1, bestColdTTFTMs: -1}
 			agg[s.model] = a
 		}
+		a.assignedPool = s.assignedPool
+		a.assignedProviders++
 		if s.warm {
 			a.warm++
 			if s.running {
@@ -4729,20 +4774,22 @@ func (r *Registry) ModelCapacitySnapshot() []ModelCapacity {
 		}
 
 		result = append(result, ModelCapacity{
-			ModelID:              model,
-			Ready:                ready,
-			CanAccept:            canAccept,
-			RoutableProviders:    a.routable,
-			WarmProviders:        a.warm,
-			RunningProviders:     a.running,
-			ColdProviders:        a.cold,
-			ActiveRequests:       a.activeRequests,
-			QueuedRequests:       queued,
-			QueueLimit:           queueLimit,
-			AggregateTPS:         a.aggregateTPS,
-			EstimatedTTFTMs:      ttft,
-			TokenBudgetRemaining: a.budgetRemaining,
-			TokenBudgetTotal:     a.budgetTotal,
+			ModelID:               model,
+			AssignedPool:          a.assignedPool,
+			AssignedPoolProviders: a.assignedProviders,
+			Ready:                 ready,
+			CanAccept:             canAccept,
+			RoutableProviders:     a.routable,
+			WarmProviders:         a.warm,
+			RunningProviders:      a.running,
+			ColdProviders:         a.cold,
+			ActiveRequests:        a.activeRequests,
+			QueuedRequests:        queued,
+			QueueLimit:            queueLimit,
+			AggregateTPS:          a.aggregateTPS,
+			EstimatedTTFTMs:       ttft,
+			TokenBudgetRemaining:  a.budgetRemaining,
+			TokenBudgetTotal:      a.budgetTotal,
 		})
 	}
 	return result

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -1808,9 +1808,6 @@ func (r *Registry) providerCanRouteBuildLocked(p *Provider, buildID string, minT
 	if !r.providerServesCatalogModelLocked(p, buildID) {
 		return false
 	}
-	if !r.providerAssignedToModelPoolLocked(p, buildID, allowPrivate) {
-		return false
-	}
 	if r.dispatchLoadCooldownActiveLocked(p.ID, buildID, now) {
 		return false
 	}
@@ -2190,6 +2187,7 @@ func (r *Registry) HasVisionProviderForModel(model string, allowedSerials ...str
 		// whole eligibility read must happen under the provider lock.
 		p.mu.Lock()
 		eligible := p.Status != StatusOffline && p.Status != StatusUntrusted &&
+			r.providerAssignedToModelPoolLocked(p, model, false) &&
 			r.providerServesVisionModelLocked(p, model)
 		p.mu.Unlock()
 		if eligible {

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -4521,29 +4521,26 @@ func (r *Registry) Snapshot() FleetSnapshot {
 
 // ModelCapacity describes the live capacity for a single model.
 type ModelCapacity struct {
-	ModelID               string  `json:"id"`
-	AssignedPool          string  `json:"assigned_pool"`
-	AssignedPoolProviders int     `json:"assigned_pool_providers"`
-	Ready                 bool    `json:"ready"`                  // at least one routable provider with headroom
-	CanAccept             bool    `json:"can_accept"`             // ready AND queue not full
-	RoutableProviders     int     `json:"routable_providers"`     // passed all gates
-	WarmProviders         int     `json:"warm_providers"`         // model loaded (slot state "running" or "idle")
-	RunningProviders      int     `json:"running_providers"`      // model loaded with active requests (slot state "running")
-	ColdProviders         int     `json:"cold_providers"`         // model available but not loaded
-	ActiveRequests        int     `json:"active_requests"`        // in-flight across fleet
-	QueuedRequests        int     `json:"queued_requests"`        // waiting in coordinator queue
-	QueueLimit            int     `json:"queue_limit"`            // max queue depth per model
-	AggregateTPS          float64 `json:"aggregate_tps"`          // sum of effective decode TPS
-	EstimatedTTFTMs       int64   `json:"estimated_ttft_ms"`      // best-case TTFT from lowest-cost warm provider
-	TokenBudgetRemaining  int64   `json:"token_budget_remaining"` // aggregate free budget across providers
-	TokenBudgetTotal      int64   `json:"token_budget_total"`     // aggregate total budget
+	ModelID              string  `json:"id"`
+	Ready                bool    `json:"ready"`                  // at least one routable provider with headroom
+	CanAccept            bool    `json:"can_accept"`             // ready AND queue not full
+	RoutableProviders    int     `json:"routable_providers"`     // passed all gates
+	WarmProviders        int     `json:"warm_providers"`         // model loaded (slot state "running" or "idle")
+	RunningProviders     int     `json:"running_providers"`      // model loaded with active requests (slot state "running")
+	ColdProviders        int     `json:"cold_providers"`         // model available but not loaded
+	ActiveRequests       int     `json:"active_requests"`        // in-flight across fleet
+	QueuedRequests       int     `json:"queued_requests"`        // waiting in coordinator queue
+	QueueLimit           int     `json:"queue_limit"`            // max queue depth per model
+	AggregateTPS         float64 `json:"aggregate_tps"`          // sum of effective decode TPS
+	EstimatedTTFTMs      int64   `json:"estimated_ttft_ms"`      // best-case TTFT from lowest-cost warm provider
+	TokenBudgetRemaining int64   `json:"token_budget_remaining"` // aggregate free budget across providers
+	TokenBudgetTotal     int64   `json:"token_budget_total"`     // aggregate total budget
 }
 
 // providerCapSnap is a per-provider snapshot collected under the registry
 // lock, then aggregated into ModelCapacity outside the lock.
 type providerCapSnap struct {
 	model                 string
-	assignedPool          string
 	warm                  bool
 	running               bool
 	hasHeadroom           bool // pending < maxConcurrency
@@ -4629,7 +4626,6 @@ func (r *Registry) ModelCapacitySnapshot() []ModelCapacity {
 
 			snap := providerCapSnap{
 				model:          m.ID,
-				assignedPool:   r.modelPoolKeyLocked(m.ID),
 				hasHeadroom:    hasHeadroom,
 				effectiveTPS:   decodeTPS,
 				prefillTPS:     prefillTPS,
@@ -4676,19 +4672,17 @@ func (r *Registry) ModelCapacitySnapshot() []ModelCapacity {
 
 	// Phase 2: aggregate per-model outside the lock.
 	type modelAgg struct {
-		assignedPool      string
-		assignedProviders int
-		routable          int
-		warm              int
-		running           int
-		cold              int
-		activeRequests    int
-		aggregateTPS      float64
-		budgetRemaining   int64
-		budgetTotal       int64
-		bestWarmTTFTMs    int64 // -1 = not set
-		bestColdTTFTMs    int64 // -1 = not set
-		anyImmediateSlot  bool  // at least one provider with headroom
+		routable         int
+		warm             int
+		running          int
+		cold             int
+		activeRequests   int
+		aggregateTPS     float64
+		budgetRemaining  int64
+		budgetTotal      int64
+		bestWarmTTFTMs   int64 // -1 = not set
+		bestColdTTFTMs   int64 // -1 = not set
+		anyImmediateSlot bool  // at least one provider with headroom
 	}
 	agg := make(map[string]*modelAgg)
 	for _, s := range snaps {
@@ -4697,8 +4691,6 @@ func (r *Registry) ModelCapacitySnapshot() []ModelCapacity {
 			a = &modelAgg{bestWarmTTFTMs: -1, bestColdTTFTMs: -1}
 			agg[s.model] = a
 		}
-		a.assignedPool = s.assignedPool
-		a.assignedProviders++
 		if s.warm {
 			a.warm++
 			if s.running {
@@ -4772,22 +4764,20 @@ func (r *Registry) ModelCapacitySnapshot() []ModelCapacity {
 		}
 
 		result = append(result, ModelCapacity{
-			ModelID:               model,
-			AssignedPool:          a.assignedPool,
-			AssignedPoolProviders: a.assignedProviders,
-			Ready:                 ready,
-			CanAccept:             canAccept,
-			RoutableProviders:     a.routable,
-			WarmProviders:         a.warm,
-			RunningProviders:      a.running,
-			ColdProviders:         a.cold,
-			ActiveRequests:        a.activeRequests,
-			QueuedRequests:        queued,
-			QueueLimit:            queueLimit,
-			AggregateTPS:          a.aggregateTPS,
-			EstimatedTTFTMs:       ttft,
-			TokenBudgetRemaining:  a.budgetRemaining,
-			TokenBudgetTotal:      a.budgetTotal,
+			ModelID:              model,
+			Ready:                ready,
+			CanAccept:            canAccept,
+			RoutableProviders:    a.routable,
+			WarmProviders:        a.warm,
+			RunningProviders:     a.running,
+			ColdProviders:        a.cold,
+			ActiveRequests:       a.activeRequests,
+			QueuedRequests:       queued,
+			QueueLimit:           queueLimit,
+			AggregateTPS:         a.aggregateTPS,
+			EstimatedTTFTMs:      ttft,
+			TokenBudgetRemaining: a.budgetRemaining,
+			TokenBudgetTotal:     a.budgetTotal,
 		})
 	}
 	return result

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -2187,7 +2187,7 @@ func (r *Registry) HasVisionProviderForModel(model string, allowedSerials ...str
 		// whole eligibility read must happen under the provider lock.
 		p.mu.Lock()
 		eligible := p.Status != StatusOffline && p.Status != StatusUntrusted &&
-			r.providerAssignedToModelPoolLocked(p, model, false) &&
+			r.providerAssignedOrIdleReassignableToModelPoolLocked(p, model, false) &&
 			r.providerServesVisionModelLocked(p, model)
 		p.mu.Unlock()
 		if eligible {
@@ -2698,7 +2698,7 @@ func (r *Registry) SendLoadModel(providerID, modelID string) error {
 	p, ok := r.providers[providerID]
 	if ok {
 		p.mu.Lock()
-		allowed := r.providerAssignedToModelPoolLocked(p, modelID, false)
+		allowed := r.providerAssignedOrIdleReassignableToModelPoolLocked(p, modelID, false)
 		p.mu.Unlock()
 		if !allowed {
 			r.mu.RUnlock()
@@ -3078,7 +3078,7 @@ func (r *Registry) modelLoadCandidatePendingLocked(p *Provider, model string, no
 	if !r.providerServesCatalogModelLocked(p, model) {
 		return 0, false
 	}
-	if !r.providerAssignedToModelPoolLocked(p, model, false) {
+	if !r.providerAssignedOrIdleReassignableToModelPoolLocked(p, model, false) {
 		return 0, false
 	}
 

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -2848,7 +2848,11 @@ func (r *Registry) DesiredModelsForProvider(providerID string) []protocol.Desire
 			advertised[m.ID] = struct{}{}
 		}
 	}
-	assignedPool := r.assignProviderModelPoolLocked(p)
+	var assignedPoolKeys []string
+	if r.enforceModelPools {
+		r.assignProviderModelPoolLocked(p)
+		assignedPoolKeys = r.modelPoolKeysLocked(p.AssignedPool)
+	}
 	p.mu.Unlock()
 
 	var entries []protocol.DesiredModelEntry
@@ -2856,7 +2860,7 @@ func (r *Registry) DesiredModelsForProvider(providerID string) []protocol.Desire
 		if t.Desired == "" {
 			continue
 		}
-		if assignedPool != "" && assignedPool != r.modelPoolKeyLocked(t.Desired) {
+		if r.enforceModelPools && len(assignedPoolKeys) > 0 && !poolKeysOverlap(assignedPoolKeys, r.modelPoolKeysLocked(t.Desired)) {
 			continue
 		}
 		_, hasDesired := advertised[t.Desired]

--- a/coordinator/registry/request_traits.go
+++ b/coordinator/registry/request_traits.go
@@ -204,7 +204,7 @@ func (r *Registry) HasToolCapableProviderForModel(model string, allowedSerials .
 		p.mu.Lock()
 		eligible := p.Status != StatusOffline && p.Status != StatusUntrusted &&
 			r.providerServesCatalogModelLocked(p, model) &&
-			r.providerAssignedToModelPoolLocked(p, model, false) &&
+			r.providerAssignedOrIdleReassignableToModelPoolLocked(p, model, false) &&
 			r.providerEligibleForTraitsLocked(p, model, traits)
 		p.mu.Unlock()
 		if eligible {

--- a/coordinator/registry/request_traits.go
+++ b/coordinator/registry/request_traits.go
@@ -204,6 +204,7 @@ func (r *Registry) HasToolCapableProviderForModel(model string, allowedSerials .
 		p.mu.Lock()
 		eligible := p.Status != StatusOffline && p.Status != StatusUntrusted &&
 			r.providerServesCatalogModelLocked(p, model) &&
+			r.providerAssignedToModelPoolLocked(p, model, false) &&
 			r.providerEligibleForTraitsLocked(p, model, traits)
 		p.mu.Unlock()
 		if eligible {

--- a/coordinator/registry/scheduler.go
+++ b/coordinator/registry/scheduler.go
@@ -782,7 +782,7 @@ func (r *Registry) providerPassesRoutingGatesLockedEx(p *Provider, model string,
 	if !r.providerPassesRoutingGatesBeforePoolLockedEx(p, model, traits, selfRouteOwner, now, ignoreProviderBreaker) {
 		return false
 	}
-	if !r.providerAssignedToModelPoolLocked(p, model, selfRouteOwner) {
+	if !r.providerAssignedOrIdleReassignableToModelPoolLocked(p, model, selfRouteOwner) {
 		return false
 	}
 	return true

--- a/coordinator/registry/scheduler.go
+++ b/coordinator/registry/scheduler.go
@@ -89,6 +89,9 @@ type routingSnapshot struct {
 	minRAMGb        int     // catalog authoritative min RAM (GB) to run the model (0 = unknown)
 	modelLoaded     bool    // true when the requested model is resident (running or idle)
 	availableOnDisk bool    // model is in provider's Models list but not currently loaded
+	// coldLoadBlockedByBusySlot is true when a different model slot is actively
+	// running/waiting, so the provider cannot evict it to cold-load this model.
+	coldLoadBlockedByBusySlot bool
 
 	observedDecodeTPS     float64
 	observedPrefillTPS    float64 // measured per-slot prefill EWMA; 0 = unreported (fall back to prefillTPS chain)
@@ -845,6 +848,9 @@ func (r *Registry) snapshotProviderLockedEx(p *Provider, model string, traits Re
 			snap.totalMemoryGB = p.BackendCapacity.TotalMemoryGB
 		}
 		for _, slot := range p.BackendCapacity.Slots {
+			if slot.Model != model && backendSlotBusy(slot) {
+				snap.coldLoadBlockedByBusySlot = true
+			}
 			if slot.Model != model {
 				continue
 			}
@@ -1004,6 +1010,9 @@ func (r *Registry) buildCandidateWithReason(snap routingSnapshot, pr *PendingReq
 		return nil, rejectNone, false
 	}
 	if !snap.hasHeadroom {
+		return nil, rejectCapacity, false
+	}
+	if !snap.modelLoaded && snap.coldLoadBlockedByBusySlot {
 		return nil, rejectCapacity, false
 	}
 
@@ -1611,6 +1620,9 @@ func (r *Registry) quickCapacityCheck(model string, estimatedPromptTokens, reque
 				snap.totalMemoryGB = p.BackendCapacity.TotalMemoryGB
 			}
 			for _, slot := range p.BackendCapacity.Slots {
+				if slot.Model != model && backendSlotBusy(slot) {
+					snap.coldLoadBlockedByBusySlot = true
+				}
 				if slot.Model != model {
 					continue
 				}
@@ -1647,6 +1659,10 @@ func (r *Registry) quickCapacityCheck(model string, estimatedPromptTokens, reque
 		if _, eligible := slotStatePenalty(snap.slotState); !eligible {
 			continue
 		}
+		if !snap.modelLoaded && snap.coldLoadBlockedByBusySlot {
+			capacityRejections++
+			continue
+		}
 
 		// Free memory / token budget admission gate.
 		if !freeMemoryAdmits(snap, dummyPR.EstimatedPromptTokens, dummyPR.RequestedMaxTokens) {
@@ -1669,6 +1685,10 @@ func (r *Registry) quickCapacityCheck(model string, estimatedPromptTokens, reque
 		return candidateCount, capacityRejections, modelTooLarge, 0, false
 	}
 	return candidateCount, capacityRejections, modelTooLarge, bestTTFT, hasTTFT
+}
+
+func backendSlotBusy(slot protocol.BackendSlotCapacity) bool {
+	return slot.NumRunning > 0 || slot.NumWaiting > 0 || slot.State == "running"
 }
 
 func estimatedTTFTFromSnapshot(snap routingSnapshot, reqPromptTokens int) time.Duration {

--- a/coordinator/registry/scheduler.go
+++ b/coordinator/registry/scheduler.go
@@ -776,63 +776,10 @@ func (r *Registry) providerPassesRoutingGatesLocked(p *Provider, model string, t
 // through the default wrapper above (breaker always honored). Caller holds r.mu
 // and p.mu.
 func (r *Registry) providerPassesRoutingGatesLockedEx(p *Provider, model string, traits RequestTraits, selfRouteOwner bool, now time.Time, ignoreProviderBreaker bool) bool {
-	if !r.providerServesCatalogModelLocked(p, model) {
+	if !r.providerPassesRoutingGatesBeforePoolLockedEx(p, model, traits, selfRouteOwner, now, ignoreProviderBreaker) {
 		return false
 	}
-	// Skip a provider-model pair cooling down after a dispatch-time load
-	// failure ("insufficient memory") — it would instant-503 again, burning a
-	// dispatch attempt.
-	if r.dispatchLoadCooldownActiveLocked(p.ID, model, now) {
-		return false
-	}
-	// Skip a triple quarantined by the inference-error circuit breaker for THIS
-	// request shape: repeated provider-side (5xx) failures — e.g. a deterministic
-	// chat-template render crash on tool schemas — mean a retry here fails
-	// identically, so routing must fall to a different provider. Shape-keyed so a
-	// tool failure does not deroute clean text traffic. Cleared by
-	// RecordInferenceSuccess (same shape) or by TTL expiry.
-	if r.inferenceErrorCooldownActiveLocked(p.ID, model, traits.CooldownShape(), now) {
-		return false
-	}
-	// Skip a provider quarantined by the per-provider node-health breaker: a
-	// node returning GENUINE-FAULT errors (500/502/504 or a
-	// fault-shaped 503) for ~all of its requests is sick regardless of model or
-	// shape, so it is derouted fleet-wide. This catches the node that fault-503s
-	// every request — invisible to the shape-keyed inference-error breaker above
-	// (which skips 503 as a capacity signal). Honored on the normal routing
-	// path; the selectBestCandidateLockedFull fail-open pass sets
-	// ignoreProviderBreaker so a bad fleet-wide rollout can't deroute everyone.
-	if !ignoreProviderBreaker && r.providerBreakerOpenLocked(p.ID, now) {
-		return false
-	}
-	if p.Status == StatusOffline || p.Status == StatusUntrusted {
-		return false
-	}
-	// A private-only machine never serves the public fleet — only its owner's
-	// self-route requests.
-	if p.PrivateOnly && !selfRouteOwner {
-		return false
-	}
-	minTrust := r.MinTrustLevel
-	if selfRouteOwner {
-		minTrust = TrustNone
-	}
-	if trustRank(p.TrustLevel) < trustRank(minTrust) {
-		return false
-	}
-	if !p.RuntimeVerified {
-		return false
-	}
-	if !r.providerSupportsPrivateTextLocked(p) {
-		return false
-	}
-	if p.LastChallengeVerified.IsZero() || now.Sub(p.LastChallengeVerified) > challengeFreshnessMaxAge {
-		return false
-	}
-	// Trait eligibility: a render-broken build is fenced for EVERY request shape
-	// (a crashing chat template breaks plain text, tools, and multimodal alike),
-	// while the capability version floors stay trait-scoped (tools-only today).
-	if !r.providerEligibleForTraitsLocked(p, model, traits) {
+	if !r.providerAssignedToModelPoolLocked(p, model, selfRouteOwner) {
 		return false
 	}
 	return true

--- a/coordinator/registry/scheduler_test.go
+++ b/coordinator/registry/scheduler_test.go
@@ -1596,6 +1596,41 @@ func TestModelPoolAssignmentUsesFirstHeartbeatBeforeAdvertisedOrder(t *testing.T
 	}
 }
 
+func TestModelPoolAssignmentUsesDeterministicSeedForUnrelatedAdvertisedModels(t *testing.T) {
+	reg := New(testLogger())
+	modelA := "pool-deterministic-a"
+	modelB := "pool-deterministic-b"
+	msg := testRegisterMessage()
+	msg.Models = []protocol.ModelInfo{
+		{ID: modelB, ModelType: "chat", Quantization: "4bit"},
+		{ID: modelA, ModelType: "chat", Quantization: "4bit"},
+	}
+	p := reg.Register("pool-deterministic-provider", nil, msg)
+	p.mu.Lock()
+	p.TrustLevel = TrustHardware
+	p.RuntimeVerified = true
+	p.RuntimeManifestChecked = true
+	p.ChallengeVerifiedSIP = true
+	p.LastChallengeVerified = time.Now()
+	p.SystemMetrics = protocol.SystemMetrics{ThermalState: "nominal"}
+	p.BackendCapacity = &protocol.BackendCapacity{TotalMemoryGB: 64}
+	p.mu.Unlock()
+
+	reg.mu.Lock()
+	p.mu.Lock()
+	assignedA := reg.providerAssignedToModelPoolLocked(p, modelA, false)
+	assignedB := reg.providerAssignedToModelPoolLocked(p, modelB, false)
+	assignedPool := p.AssignedPool
+	p.mu.Unlock()
+	reg.mu.Unlock()
+	if !assignedA {
+		t.Fatalf("provider was not assigned to deterministic seed %q (assigned_pool=%q)", modelA, assignedPool)
+	}
+	if assignedB {
+		t.Fatalf("provider assigned to non-selected unrelated pool %q (assigned_pool=%q)", modelB, assignedPool)
+	}
+}
+
 func TestModelPoolAssignmentAllowsAdvertisedAliasBuildsInSamePool(t *testing.T) {
 	reg := New(testLogger())
 	previous := "pool-alias-previous"
@@ -1654,6 +1689,38 @@ func TestModelPoolAssignmentAllowsSharedBuildInOwningAliasPool(t *testing.T) {
 	})
 	if selected == nil || selected.ID != p.ID {
 		t.Fatalf("selected %#v for shared build in owning alias pool, want %q", selected, p.ID)
+	}
+}
+
+func TestColdDispatchBlockedByBusyOtherSlot(t *testing.T) {
+	reg := New(testLogger())
+	previous := "busy-slot-previous"
+	desired := "busy-slot-desired"
+	reg.SetModelAliases(map[string]AliasTarget{
+		"busy-slot-alias": {Desired: desired, Previous: previous},
+	})
+	p := makeSchedulerProvider(t, reg, "busy-slot-provider", previous, 100)
+	p.mu.Lock()
+	p.Models = append(p.Models, protocol.ModelInfo{ID: desired, ModelType: "chat", Quantization: "4bit"})
+	p.BackendCapacity.Slots = []protocol.BackendSlotCapacity{
+		{Model: previous, State: "running", NumRunning: 1, MaxConcurrency: 1},
+	}
+	p.mu.Unlock()
+
+	selected, decision := reg.ReserveProviderEx(desired, &PendingRequest{
+		RequestID:          "req-busy-slot-desired",
+		Model:              desired,
+		RequestedMaxTokens: 128,
+	})
+	if selected != nil {
+		t.Fatalf("selected %q, want nil while another slot is busy", selected.ID)
+	}
+	if decision.CandidateCount != 0 || decision.CapacityRejections != 1 {
+		t.Fatalf("decision=%+v, want one capacity rejection from busy other slot", decision)
+	}
+	candidates, rejections, _ := reg.QuickCapacityCheck(desired, 100, 128, RequestTraits{})
+	if candidates != 0 || rejections != 1 {
+		t.Fatalf("QuickCapacityCheck candidates=%d rejections=%d, want 0/1", candidates, rejections)
 	}
 }
 

--- a/coordinator/registry/scheduler_test.go
+++ b/coordinator/registry/scheduler_test.go
@@ -1749,8 +1749,8 @@ func TestModelCapacitySnapshotOnlyIncludesAssignedPool(t *testing.T) {
 	if !ok {
 		t.Fatalf("assigned model %q missing from capacity snapshot: %+v", modelA, snapshots)
 	}
-	if snap.AssignedPool != modelA || snap.AssignedPoolProviders != 1 {
-		t.Fatalf("assigned pool fields = %q/%d, want %q/1", snap.AssignedPool, snap.AssignedPoolProviders, modelA)
+	if !snap.Ready || snap.RoutableProviders != 1 {
+		t.Fatalf("assigned model snapshot = %+v, want ready with one routable provider", snap)
 	}
 }
 

--- a/coordinator/registry/scheduler_test.go
+++ b/coordinator/registry/scheduler_test.go
@@ -1551,6 +1551,59 @@ func TestModelPoolAssignmentBlocksUnassignedPublicModel(t *testing.T) {
 	}
 }
 
+func TestIdleShutdownProviderCanReassignPoolOnDemand(t *testing.T) {
+	reg := New(testLogger())
+	modelA := "pool-idle-shutdown-a"
+	modelB := "pool-idle-shutdown-b"
+	p := makeSchedulerProvider(t, reg, "pool-idle-shutdown-provider", modelA, 100)
+	p.mu.Lock()
+	p.Models = append(p.Models, protocol.ModelInfo{ID: modelB, ModelType: "chat", Quantization: "4bit"})
+	p.BackendCapacity.Slots = []protocol.BackendSlotCapacity{
+		{Model: modelA, State: "idle_shutdown", MaxConcurrency: 2},
+	}
+	p.mu.Unlock()
+
+	selected, decision := reg.ReserveProviderEx(modelB, &PendingRequest{
+		RequestID:          "req-reassign-idle-shutdown",
+		Model:              modelB,
+		RequestedMaxTokens: 128,
+	})
+	if selected == nil || selected.ID != p.ID {
+		t.Fatalf("selected %#v for idle-shutdown reassignment, want %q; decision=%+v", selected, p.ID, decision)
+	}
+	p.mu.Lock()
+	assigned := p.AssignedPool
+	p.mu.Unlock()
+	if reg.ModelPoolKey(assigned) != modelB {
+		t.Fatalf("assigned_pool = %q (pool %q), want %q", assigned, reg.ModelPoolKey(assigned), modelB)
+	}
+}
+
+func TestResidentIdleProviderDoesNotReassignPoolOnDemand(t *testing.T) {
+	reg := New(testLogger())
+	modelA := "pool-resident-a"
+	modelB := "pool-resident-b"
+	p := makeSchedulerProvider(t, reg, "pool-resident-provider", modelA, 100)
+	p.mu.Lock()
+	p.Models = append(p.Models, protocol.ModelInfo{ID: modelB, ModelType: "chat", Quantization: "4bit"})
+	p.BackendCapacity.Slots = []protocol.BackendSlotCapacity{
+		{Model: modelA, State: "idle", MaxConcurrency: 2},
+	}
+	p.mu.Unlock()
+
+	selected, decision := reg.ReserveProviderEx(modelB, &PendingRequest{
+		RequestID:          "req-resident-no-reassign",
+		Model:              modelB,
+		RequestedMaxTokens: 128,
+	})
+	if selected != nil {
+		t.Fatalf("selected %q, want nil while another model is resident", selected.ID)
+	}
+	if decision.CandidateCount != 0 || decision.CapacityRejections != 0 {
+		t.Fatalf("decision=%+v, want pool mismatch without capacity signal", decision)
+	}
+}
+
 func TestModelPoolAssignmentUsesFirstHeartbeatBeforeAdvertisedOrder(t *testing.T) {
 	reg := New(testLogger())
 	modelA := "pool-registration-a"

--- a/coordinator/registry/scheduler_test.go
+++ b/coordinator/registry/scheduler_test.go
@@ -850,6 +850,7 @@ func TestDrainQueuedRequestsUsesAllAvailableCapacity(t *testing.T) {
 
 func TestDrainQueuedRequestsRespectsPerSlotCapsAcrossModels(t *testing.T) {
 	reg := New(testLogger())
+	reg.SetModelPoolEnforcement(false)
 	modelA := "queue-slot-full-a"
 	modelB := "queue-slot-open-b"
 	p := makeSchedulerProvider(t, reg, "multi-slot", modelA, 100)
@@ -906,6 +907,7 @@ func TestDrainQueuedRequestsRespectsPerSlotCapsAcrossModels(t *testing.T) {
 
 func TestSetProviderIdleDrainsOnlyFreedModelCapacity(t *testing.T) {
 	reg := New(testLogger())
+	reg.SetModelPoolEnforcement(false)
 	modelA := "idle-freed-a"
 	modelB := "idle-unchanged-b"
 	p := makeSchedulerProvider(t, reg, "idle-multi", modelA, 100)
@@ -1478,6 +1480,7 @@ func TestManyPerSlotCapsRespectProviderWideAggregateCap(t *testing.T) {
 
 func TestModelCapacitySnapshotRespectsPerSlotMaxConcurrency(t *testing.T) {
 	reg := New(testLogger())
+	reg.SetModelPoolEnforcement(false)
 	modelA := "snapshot-full-model"
 	modelB := "snapshot-open-model"
 	p := makeSchedulerProvider(t, reg, "snapshot-provider", modelA, 100)
@@ -1512,6 +1515,140 @@ func TestModelCapacitySnapshotRespectsPerSlotMaxConcurrency(t *testing.T) {
 	}
 	if !open.Ready || !open.CanAccept || open.RoutableProviders != 1 {
 		t.Fatalf("open model snapshot=%+v, want ready with one routable provider", open)
+	}
+}
+
+func TestModelPoolAssignmentBlocksUnassignedPublicModel(t *testing.T) {
+	reg := New(testLogger())
+	modelA := "pool-gpt-oss"
+	modelB := "pool-gemma"
+	p := makeSchedulerProvider(t, reg, "pool-provider", modelA, 100)
+	p.mu.Lock()
+	p.Models = append(p.Models, protocol.ModelInfo{ID: modelB, ModelType: "chat", Quantization: "4bit"})
+	p.BackendCapacity.Slots = []protocol.BackendSlotCapacity{
+		{Model: modelA, State: "idle", MaxConcurrency: 2},
+		{Model: modelB, State: "idle", MaxConcurrency: 2},
+	}
+	p.mu.Unlock()
+
+	selected, decision := reg.ReserveProviderEx(modelB, &PendingRequest{
+		RequestID:          "req-wrong-pool",
+		Model:              modelB,
+		RequestedMaxTokens: 128,
+	})
+	if selected != nil {
+		t.Fatalf("selected %q for unassigned model %q", selected.ID, modelB)
+	}
+	if decision.CandidateCount != 0 || decision.CapacityRejections != 0 || decision.ModelTooLargeRejections != 0 {
+		t.Fatalf("decision=%+v, want no normal candidate/capacity signal", decision)
+	}
+	if got := reg.PoolRejectedProviderCount(modelB, RequestTraits{}, false); got != 1 {
+		t.Fatalf("PoolRejectedProviderCount = %d, want 1", got)
+	}
+	candidates, rejections, tooLarge := reg.QuickCapacityCheck(modelB, 100, 128, RequestTraits{})
+	if candidates != 0 || rejections != 0 || tooLarge != 0 {
+		t.Fatalf("QuickCapacityCheck = (%d,%d,%d), want (0,0,0) for pool mismatch", candidates, rejections, tooLarge)
+	}
+}
+
+func TestModelPoolAssignmentUsesFirstHeartbeatBeforeAdvertisedOrder(t *testing.T) {
+	reg := New(testLogger())
+	modelA := "pool-registration-a"
+	modelB := "pool-registration-b"
+	msg := testRegisterMessage()
+	msg.Models = []protocol.ModelInfo{
+		{ID: modelA, ModelType: "chat", Quantization: "4bit"},
+		{ID: modelB, ModelType: "chat", Quantization: "4bit"},
+	}
+	p := reg.Register("pool-registration-provider", nil, msg)
+	p.mu.Lock()
+	p.TrustLevel = TrustHardware
+	p.RuntimeVerified = true
+	p.RuntimeManifestChecked = true
+	p.ChallengeVerifiedSIP = true
+	p.LastChallengeVerified = time.Now()
+	p.SystemMetrics = protocol.SystemMetrics{ThermalState: "nominal"}
+	p.mu.Unlock()
+
+	active := modelB
+	reg.Heartbeat(p.ID, &protocol.HeartbeatMessage{
+		Status:      "idle",
+		ActiveModel: &active,
+		WarmModels:  []string{modelB},
+		BackendCapacity: &protocol.BackendCapacity{
+			TotalMemoryGB: 64,
+			Slots: []protocol.BackendSlotCapacity{
+				{Model: modelB, State: "idle", MaxConcurrency: 2},
+			},
+		},
+	})
+
+	selected, _ := reg.ReserveProviderEx(modelB, &PendingRequest{
+		RequestID:          "req-heartbeat-pool",
+		Model:              modelB,
+		RequestedMaxTokens: 128,
+	})
+	if selected == nil || selected.ID != p.ID {
+		t.Fatalf("selected %#v for heartbeat-active model %q, want %q", selected, modelB, p.ID)
+	}
+	if got := reg.PoolRejectedProviderCount(modelA, RequestTraits{}, false); got != 1 {
+		t.Fatalf("PoolRejectedProviderCount(%s) = %d, want 1", modelA, got)
+	}
+}
+
+func TestModelPoolAssignmentBypassesOwnedSelfRoute(t *testing.T) {
+	reg := New(testLogger())
+	modelA := "self-pool-a"
+	modelB := "self-pool-b"
+	p := makeSchedulerProvider(t, reg, "self-pool-provider", modelA, 100)
+	p.mu.Lock()
+	p.AccountID = "acct-owner"
+	p.Models = append(p.Models, protocol.ModelInfo{ID: modelB, ModelType: "chat", Quantization: "4bit"})
+	p.BackendCapacity.Slots = []protocol.BackendSlotCapacity{
+		{Model: modelA, State: "idle", MaxConcurrency: 2},
+		{Model: modelB, State: "idle", MaxConcurrency: 2},
+	}
+	p.mu.Unlock()
+
+	selected, _ := reg.ReserveProviderEx(modelB, &PendingRequest{
+		RequestID:          "req-owned-pool-bypass",
+		Model:              modelB,
+		RequestedMaxTokens: 128,
+		SelfRouteOnly:      true,
+		OwnerAccountID:     "acct-owner",
+	})
+	if selected == nil || selected.ID != p.ID {
+		t.Fatalf("owned self-route selected %#v, want %q", selected, p.ID)
+	}
+}
+
+func TestModelCapacitySnapshotOnlyIncludesAssignedPool(t *testing.T) {
+	reg := New(testLogger())
+	modelA := "capacity-pool-a"
+	modelB := "capacity-pool-b"
+	p := makeSchedulerProvider(t, reg, "capacity-pool-provider", modelA, 100)
+	p.mu.Lock()
+	p.Models = append(p.Models, protocol.ModelInfo{ID: modelB, ModelType: "chat", Quantization: "4bit"})
+	p.BackendCapacity.Slots = []protocol.BackendSlotCapacity{
+		{Model: modelA, State: "idle", MaxConcurrency: 2},
+		{Model: modelB, State: "idle", MaxConcurrency: 2},
+	}
+	p.mu.Unlock()
+
+	snapshots := reg.ModelCapacitySnapshot()
+	byModel := make(map[string]ModelCapacity, len(snapshots))
+	for _, snap := range snapshots {
+		byModel[snap.ModelID] = snap
+	}
+	if _, ok := byModel[modelB]; ok {
+		t.Fatalf("unassigned model %q appeared in capacity snapshot: %+v", modelB, snapshots)
+	}
+	snap, ok := byModel[modelA]
+	if !ok {
+		t.Fatalf("assigned model %q missing from capacity snapshot: %+v", modelA, snapshots)
+	}
+	if snap.AssignedPool != modelA || snap.AssignedPoolProviders != 1 {
+		t.Fatalf("assigned pool fields = %q/%d, want %q/1", snap.AssignedPool, snap.AssignedPoolProviders, modelA)
 	}
 }
 

--- a/coordinator/registry/scheduler_test.go
+++ b/coordinator/registry/scheduler_test.go
@@ -1596,6 +1596,89 @@ func TestModelPoolAssignmentUsesFirstHeartbeatBeforeAdvertisedOrder(t *testing.T
 	}
 }
 
+func TestModelPoolAssignmentAllowsAdvertisedAliasBuildsInSamePool(t *testing.T) {
+	reg := New(testLogger())
+	previous := "pool-alias-previous"
+	desired := "pool-alias-desired"
+	reg.SetModelCatalog([]CatalogEntry{{ID: previous}, {ID: desired}})
+	reg.SetModelAliases(map[string]AliasTarget{
+		"pool-alias": {Desired: desired, Previous: previous},
+	})
+	msg := testRegisterMessage()
+	msg.Models = []protocol.ModelInfo{
+		{ID: previous, ModelType: "chat", Quantization: "4bit"},
+		{ID: desired, ModelType: "chat", Quantization: "4bit"},
+	}
+	p := reg.Register("pool-alias-provider", nil, msg)
+	p.mu.Lock()
+	p.TrustLevel = TrustHardware
+	p.RuntimeVerified = true
+	p.RuntimeManifestChecked = true
+	p.ChallengeVerifiedSIP = true
+	p.LastChallengeVerified = time.Now()
+	p.SystemMetrics = protocol.SystemMetrics{ThermalState: "nominal"}
+	p.mu.Unlock()
+
+	selected, _ := reg.ReserveProviderEx(desired, &PendingRequest{
+		RequestID:          "req-alias-pool-desired",
+		Model:              desired,
+		RequestedMaxTokens: 128,
+	})
+	if selected == nil || selected.ID != p.ID {
+		t.Fatalf("selected %#v for alias desired build, want %q", selected, p.ID)
+	}
+}
+
+func TestModelPoolAssignmentAllowsSharedBuildInOwningAliasPool(t *testing.T) {
+	reg := New(testLogger())
+	shared := "pool-shared-build"
+	other := "pool-alias-b-build"
+	reg.SetModelCatalog([]CatalogEntry{{ID: shared}, {ID: other}})
+	reg.SetModelAliases(map[string]AliasTarget{
+		"alias-a": {Desired: shared},
+		"alias-b": {Desired: other, Previous: shared},
+	})
+	p := makeSchedulerProvider(t, reg, "shared-pool-provider", other, 100)
+	p.mu.Lock()
+	p.Models = append(p.Models, protocol.ModelInfo{ID: shared, ModelType: "chat", Quantization: "4bit"})
+	p.BackendCapacity.Slots = []protocol.BackendSlotCapacity{
+		{Model: other, State: "idle", MaxConcurrency: 2},
+		{Model: shared, State: "idle", MaxConcurrency: 2},
+	}
+	p.mu.Unlock()
+
+	selected, _ := reg.ReserveProviderEx(shared, &PendingRequest{
+		RequestID:          "req-shared-pool-build",
+		Model:              shared,
+		RequestedMaxTokens: 128,
+	})
+	if selected == nil || selected.ID != p.ID {
+		t.Fatalf("selected %#v for shared build in owning alias pool, want %q", selected, p.ID)
+	}
+}
+
+func TestResolveModelConstrainedIgnoresPoolMismatchForPreflightClassification(t *testing.T) {
+	reg := New(testLogger())
+	assigned := "pinned-assigned-pool"
+	desired := "pinned-wrong-pool-build"
+	reg.SetModelCatalog([]CatalogEntry{{ID: assigned}, {ID: desired}})
+	reg.SetModelAliases(map[string]AliasTarget{"pinned-alias": {Desired: desired}})
+	p := makeSchedulerProvider(t, reg, "pinned-provider", assigned, 100)
+	setSchedulerProviderSerial(p, "PINNED-SERIAL")
+	p.mu.Lock()
+	p.Models = append(p.Models, protocol.ModelInfo{ID: desired, ModelType: "chat", Quantization: "4bit"})
+	p.BackendCapacity.Slots = []protocol.BackendSlotCapacity{{Model: assigned, State: "idle", MaxConcurrency: 2}}
+	p.mu.Unlock()
+
+	resolved, isAlias, ok := reg.ResolveModelConstrained("pinned-alias", []string{"PINNED-SERIAL"}, "", false, false)
+	if !ok || !isAlias || resolved != desired {
+		t.Fatalf("ResolveModelConstrained = %q alias=%v ok=%v, want %q/true/true", resolved, isAlias, ok, desired)
+	}
+	if got := reg.PoolRejectedProviderCount(desired, RequestTraits{}, false, "PINNED-SERIAL"); got != 1 {
+		t.Fatalf("PoolRejectedProviderCount = %d, want 1", got)
+	}
+}
+
 func TestModelPoolAssignmentBypassesOwnedSelfRoute(t *testing.T) {
 	reg := New(testLogger())
 	modelA := "self-pool-a"
@@ -1619,6 +1702,25 @@ func TestModelPoolAssignmentBypassesOwnedSelfRoute(t *testing.T) {
 	})
 	if selected == nil || selected.ID != p.ID {
 		t.Fatalf("owned self-route selected %#v, want %q", selected, p.ID)
+	}
+}
+
+func TestCapabilityChecksIgnoreOffPoolProviders(t *testing.T) {
+	reg := New(testLogger())
+	assigned := "capability-assigned-pool"
+	target := "capability-off-pool-model"
+	p := makeSchedulerProvider(t, reg, "capability-off-pool", assigned, 100)
+	setProviderVersion(p, "0.6.5")
+	p.mu.Lock()
+	p.Models = append(p.Models, protocol.ModelInfo{ID: target, ModelType: "chat", Quantization: "4bit", IsVision: true})
+	p.BackendCapacity.Slots = []protocol.BackendSlotCapacity{{Model: assigned, State: "idle", MaxConcurrency: 2}}
+	p.mu.Unlock()
+
+	if reg.HasToolCapableProviderForModel(target) {
+		t.Fatal("off-pool tool-capable provider must not satisfy tools capability check")
+	}
+	if reg.HasVisionProviderForModel(target) {
+		t.Fatal("off-pool vision-capable provider must not satisfy vision capability check")
 	}
 }
 

--- a/coordinator/registry/utilization.go
+++ b/coordinator/registry/utilization.go
@@ -79,6 +79,8 @@ type NetworkUtilization struct {
 	QueuedRequests    int     `json:"queued_requests"`
 
 	Models          []ModelUtilization `json:"models"`
+	ModelPools      []ModelPoolMetrics `json:"model_pools"`
+	ModelPoolAudit  ModelPoolAudit     `json:"model_pool_audit"`
 	GeneratedAt     time.Time          `json:"generated_at"`
 	WarmDataAgeSecs float64            `json:"warm_data_age_seconds"` // staleness of warm-pool snapshot (0 = none)
 	HasWarmPoolData bool               `json:"has_warm_pool_data"`
@@ -215,7 +217,9 @@ func (r *Registry) NetworkUtilizationSnapshot() NetworkUtilization {
 	caps := r.ModelCapacitySnapshot()
 	snaps, snapAt := r.LatestWarmPoolSnapshots()
 	fleet := r.FleetCapacitySnapshot()
-	return computeNetworkUtilization(caps, snaps, fleet, snapAt, time.Now())
+	util := computeNetworkUtilization(caps, snaps, fleet, snapAt, time.Now())
+	util.ModelPools, util.ModelPoolAudit = r.ModelPoolMetricsSnapshot()
+	return util
 }
 
 // computeNetworkUtilization is the pure core, split out for unit testing without

--- a/coordinator/registry/warm_pool_controller.go
+++ b/coordinator/registry/warm_pool_controller.go
@@ -573,7 +573,7 @@ func (r *Registry) warmPoolCandidateLocked(p *Provider, model string, now time.T
 	if !r.providerServesCatalogModelLocked(p, model) {
 		return warmPoolCandidate{}, false
 	}
-	if !r.providerAssignedToModelPoolLocked(p, model, false) {
+	if !r.providerAssignedOrIdleReassignableToModelPoolLocked(p, model, false) {
 		return warmPoolCandidate{}, false
 	}
 	totalMemoryGB := float64(p.Hardware.MemoryGB)

--- a/coordinator/registry/warm_pool_controller.go
+++ b/coordinator/registry/warm_pool_controller.go
@@ -573,6 +573,9 @@ func (r *Registry) warmPoolCandidateLocked(p *Provider, model string, now time.T
 	if !r.providerServesCatalogModelLocked(p, model) {
 		return warmPoolCandidate{}, false
 	}
+	if !r.providerAssignedToModelPoolLocked(p, model, false) {
+		return warmPoolCandidate{}, false
+	}
 	totalMemoryGB := float64(p.Hardware.MemoryGB)
 	gpuActiveGB := 0.0
 	if p.BackendCapacity != nil {

--- a/coordinator/registry/warm_pool_controller_test.go
+++ b/coordinator/registry/warm_pool_controller_test.go
@@ -419,6 +419,34 @@ func TestWarmPoolPicksBetterIdleProvider(t *testing.T) {
 	}
 }
 
+func TestWarmPoolSkipsUnassignedPoolCandidate(t *testing.T) {
+	reg := New(testLogger())
+	target := "warm-pool-target-pool"
+	assignedOther := "warm-pool-other-pool"
+	offPool := makeSchedulerProvider(t, reg, "off-pool", assignedOther, 200)
+	offPool.mu.Lock()
+	offPool.Models = append(offPool.Models, protocol.ModelInfo{ID: target, ModelType: "chat", Quantization: "4bit"})
+	offPool.BackendCapacity = &protocol.BackendCapacity{
+		TotalMemoryGB:     128,
+		GPUMemoryActiveGB: 4,
+		Slots:             []protocol.BackendSlotCapacity{{Model: assignedOther, State: "idle"}},
+	}
+	offPool.mu.Unlock()
+	assigned := makeWarmPoolColdProvider(t, reg, "assigned-pool", target, 40, 64, 8)
+
+	reg.ConfigureWarmPool(testWarmPoolConfig())
+	sent := captureWarmPoolLoads(reg)
+	reg.RecordWarmPoolCapacityReject(target)
+	reg.warmPool.tick(time.Now())
+
+	if len(*sent) != 1 {
+		t.Fatalf("sent loads = %d, want 1", len(*sent))
+	}
+	if (*sent)[0].providerID != assigned.ID {
+		t.Fatalf("selected provider = %q, want assigned provider %q", (*sent)[0].providerID, assigned.ID)
+	}
+}
+
 // --- Little's Law target math (pure, warm_pool_target.go) ---
 
 func TestQualityConcurrencyFromDecodeFloor(t *testing.T) {

--- a/provider-swift/Sources/ProviderCore/Config/ProviderConfig.swift
+++ b/provider-swift/Sources/ProviderCore/Config/ProviderConfig.swift
@@ -77,7 +77,7 @@ public struct BackendSettings: Sendable, Equatable, Codable {
         continuousBatching: Bool = true,
         enabledModels: [String] = [],
         idleTimeoutMins: UInt64 = 60,
-        maxModelSlots: UInt64 = 3,
+        maxModelSlots: UInt64 = 1,
         kvQuant: Bool = false
     ) {
         self.port = port
@@ -106,7 +106,7 @@ public struct BackendSettings: Sendable, Equatable, Codable {
         self.continuousBatching = try container.decodeIfPresent(Bool.self, forKey: .continuousBatching) ?? true
         self.enabledModels = try container.decodeIfPresent([String].self, forKey: .enabledModels) ?? []
         self.idleTimeoutMins = try container.decodeIfPresent(UInt64.self, forKey: .idleTimeoutMins) ?? 60
-        self.maxModelSlots = try container.decodeIfPresent(UInt64.self, forKey: .maxModelSlots) ?? 3
+        self.maxModelSlots = try container.decodeIfPresent(UInt64.self, forKey: .maxModelSlots) ?? 1
         self.kvQuant = try container.decodeIfPresent(Bool.self, forKey: .kvQuant) ?? false
     }
 }
@@ -186,7 +186,7 @@ public struct ProviderConfig: Sendable, Equatable, Codable {
                 continuousBatching: true,
                 enabledModels: [],
                 idleTimeoutMins: 60,
-                maxModelSlots: 3
+                maxModelSlots: 1
             ),
             coordinator: CoordinatorSettings(
                 url: "wss://api.darkbloom.dev/ws/provider",

--- a/provider-swift/Tests/ProviderCoreTests/ConfigTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/ConfigTests.swift
@@ -10,7 +10,7 @@ import Testing
     port = 8100
     """)
 
-    #expect(config.backend.maxModelSlots == 3)
+    #expect(config.backend.maxModelSlots == 1)
 }
 
 @Test func configParsingUsesCustomMaxModelSlots() throws {


### PR DESCRIPTION
## Summary
- add coordinator-managed public model pool assignment and enforce it in routing, preflight, cold dispatch, warm pool load_model, capacity snapshots, alias routability, and desired-model surfaces
- return uptime-neutral 429 pool_exhausted when a requested model's assigned pool has no capacity, instead of spilling into another model's machines
- add pool observability to admin utilization, Datadog gauges, /v1/me/providers, and update provider default max_model_slots to 1

## Before/After

Before: a Mac could advertise both GPT-OSS and Gemma 4, so the coordinator could route either model to the same machine and opportunistically cold-load the other model. That made GPT-OSS and Gemma compete for one GPU/unified-memory/KV/thermal budget.

```mermaid
flowchart LR
    openrouter[OpenRouter request] --> coordinator[Coordinator routing]
    coordinator --> advertised{Provider advertises requested model?}
    advertised -->|GPT-OSS request| mac[Same Mac: GPT-OSS + Gemma advertised]
    advertised -->|Gemma 4 request| mac
    mac --> coldLoad[May cold-load / keep both public models warm]
    coldLoad --> coresident[GPT-OSS and Gemma 4 co-resident]
    coresident --> pressure[Shared GPU, unified memory, KV cache, thermal budget]
    pressure --> failures[503 / cancel / TTFT risk leaks across models]
```

After: each public provider is assigned to one active model pool at a time. A provider can serve many concurrent requests, but only for that assigned model. If it is idle/unloaded, the coordinator can safely reassign it to another pool on demand; if it is resident or busy, cross-pool requests do not spill into it.

```mermaid
flowchart LR
    openrouter[OpenRouter request] --> model{Requested model}
    model -->|GPT-OSS| gptPool[GPT-OSS pool]
    model -->|Gemma 4| gemmaPool[Gemma 4 pool]

    gptPool --> gptCheck{GPT-OSS pool has capacity?}
    gemmaPool --> gemmaCheck{Gemma 4 pool has capacity?}

    gptCheck -->|yes| gptRoute[Route to GPT-OSS-assigned provider]
    gemmaCheck -->|yes| gemmaRoute[Route to Gemma-assigned provider]

    gptCheck -->|no| gptIdle{Idle/unloaded provider can safely reassign?}
    gemmaCheck -->|no| gemmaIdle{Idle/unloaded provider can safely reassign?}

    gptIdle -->|yes| reassignGPT[Assign provider to GPT-OSS, load/warm GPT-OSS]
    gemmaIdle -->|yes| reassignGemma[Assign provider to Gemma 4, load/warm Gemma]

    gptIdle -->|no| gpt429[429 pool_exhausted + Retry-After]
    gemmaIdle -->|no| gemma429[429 pool_exhausted + Retry-After]

    gpt429 --> openrouterRetry[OpenRouter retries/fails over without uptime penalty]
    gemma429 --> openrouterRetry
```

## Tests
- go test ./... (coordinator)
- swift test --filter ConfigTests (provider-swift)
- git diff --check

## Notes
- Pool changes are safe only when a provider is idle/unloaded in this PR. Draining an actively resident provider from one pool into another remains a follow-up.
- Existing provider configs with explicit max_model_slots > 1 remain opt-in until migrated.

Linear: https://linear.app/darkbloom-dev/issue/DAR-345/coordinatorprovider-enforce-one-active-public-model-per-machine-via

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/432"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784583906&installation_id=133247490&pr_number=432&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F432&signature=4a06733bf78dba31c6351c2e131cdb0bd133bd4359fcca2ee07a23574ddd068e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
