### PR TITLE
fix(provider): settle delivered tokens on client-gone cancels

### DIFF
--- a/provider-swift/Sources/ProviderCore/Inference/UsageAccounting.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/UsageAccounting.swift
@@ -55,3 +55,66 @@ public struct UsageAccumulator: Sendable {
         InferenceUsage(promptTokens: promptTokens, completionTokens: completionTokens)
     }
 }
+
+/// Usage state accumulated while relaying an upstream streaming response.
+///
+/// A normal stream finishes with an upstream usage frame. A coordinator cancel
+/// usually stops before that final frame arrives, so the provider must settle
+/// from the output it already emitted. This helper keeps that policy small and
+/// testable: no visible output means refund; visible output means send an
+/// `inference_complete` terminal using reported usage when available, otherwise
+/// conservative token floors.
+struct StreamedGenerationUsage: Equatable, Sendable {
+    var promptTokens: Int
+    var completionTokens: Int
+    var reasoningTokens: Int
+    var contentFrameCount: Int
+    var deliveredCompletionTokenFloor: Int
+    var hasVisibleOutput: Bool
+
+    init(
+        promptTokens: Int,
+        completionTokens: Int,
+        reasoningTokens: Int = 0,
+        contentFrameCount: Int,
+        deliveredCompletionTokenFloor: Int = 0,
+        hasVisibleOutput: Bool
+    ) {
+        self.promptTokens = max(0, promptTokens)
+        self.completionTokens = max(0, completionTokens)
+        self.reasoningTokens = max(0, reasoningTokens)
+        self.contentFrameCount = max(0, contentFrameCount)
+        self.deliveredCompletionTokenFloor = max(0, deliveredCompletionTokenFloor)
+        self.hasVisibleOutput = hasVisibleOutput
+    }
+
+    func cancelledTerminal(promptTokenFloor: @autoclosure () -> Int) -> CancelledGenerationTerminal {
+        guard let usage = cancelledUsageInfo(promptTokenFloor: promptTokenFloor()) else {
+            return .refund
+        }
+        return .complete(usage)
+    }
+
+    func cancelledUsageInfo(promptTokenFloor: @autoclosure () -> Int) -> UsageInfo? {
+        guard hasVisibleOutput else { return nil }
+        let completionFloor = max(deliveredCompletionTokenFloor, contentFrameCount)
+        let settledCompletionTokens = completionTokens > 0 ? completionTokens : completionFloor
+        guard settledCompletionTokens > 0 else { return nil }
+        let settledPromptTokens = promptTokens > 0 ? promptTokens : max(0, promptTokenFloor())
+        return usageInfo(promptTokens: settledPromptTokens, completionTokens: settledCompletionTokens)
+    }
+
+    private func usageInfo(promptTokens: Int, completionTokens: Int) -> UsageInfo {
+        let completions = max(0, completionTokens)
+        return UsageInfo(
+            promptTokens: UInt64(max(0, promptTokens)),
+            completionTokens: UInt64(completions),
+            reasoningTokens: UInt64(min(max(0, reasoningTokens), completions))
+        )
+    }
+}
+
+enum CancelledGenerationTerminal: Equatable, Sendable {
+    case refund
+    case complete(UsageInfo)
+}

--- a/provider-swift/Sources/ProviderCore/ProviderLoop.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop.swift
@@ -1447,30 +1447,76 @@ public actor ProviderLoop {
             }
             if token.isCancelled { cancelledMidStream = true }
 
-            // Cancelled with nothing delivered: 499 so the coordinator refunds.
-            if cancelledMidStream && contentFrameCount == 0 && fullResponseText.isEmpty {
-                providerStats.incrementCancellationsBeforeOutput()
-                send.send(.inferenceError(
-                    requestId: requestId,
-                    error: "request cancelled",
-                    statusCode: 499,
-                    errorReason: nil
+            if cancelledMidStream {
+                if reasoningTokens == 0 && !reasoningText.isEmpty {
+                    let completionFloor = completionTokens > 0 ? completionTokens : contentFrameCount
+                    if completionFloor > 0 {
+                        reasoningTokens = min(
+                            tokenizer.inner.encode(
+                                text: reasoningText, addSpecialTokens: false
+                            ).count,
+                            completionFloor
+                        )
+                    }
+                }
+
+                let partialUsage = StreamedGenerationUsage(
+                    promptTokens: promptTokens,
+                    completionTokens: completionTokens,
+                    reasoningTokens: reasoningTokens,
+                    contentFrameCount: contentFrameCount,
+                    deliveredCompletionTokenFloor: tokenizer.inner.encode(
+                        text: fullResponseText, addSpecialTokens: false
+                    ).count,
+                    hasVisibleOutput: Self.hasVisibleStreamOutput(
+                        contentFrameCount: contentFrameCount,
+                        fullResponseText: fullResponseText
+                    )
+                )
+                let terminal = partialUsage.cancelledTerminal(promptTokenFloor: Self.promptTokenFloor(
+                    request: streamingRequest,
+                    tokenizer: tokenizer,
+                    reasoningEffort: reasoningEffort
                 ))
-                return
+                guard case .complete(let settledUsage) = terminal else {
+                    // Cancelled with nothing delivered: 499 so the coordinator refunds.
+                    providerStats.incrementCancellationsBeforeOutput()
+                    send.send(.inferenceError(
+                        requestId: requestId,
+                        error: "request cancelled",
+                        statusCode: 499,
+                        errorReason: nil
+                    ))
+                    return
+                }
+                if completionTokens == 0 {
+                    log.warning(
+                        "[\(requestId)] usage chunk missing/zero completion tokens (cancelled mid-stream); "
+                        + "billing \(settledUsage.completionTokens) delivered completion tokens as a floor."
+                    )
+                }
+                if promptTokens == 0 && settledUsage.promptTokens > 0 {
+                    log.warning(
+                        "[\(requestId)] usage chunk missing/zero prompt tokens (cancelled mid-stream); "
+                        + "billing \(settledUsage.promptTokens) re-templated prompt tokens as a floor."
+                    )
+                }
+                promptTokens = Int(clamping: settledUsage.promptTokens)
+                completionTokens = Int(clamping: settledUsage.completionTokens)
+                reasoningTokens = Int(clamping: settledUsage.reasoningTokens)
             }
 
-            // No usage chunk (the normal case for a cancelled stream, since the
-            // engine's usage rides the final chunk an abort never sends; also an
-            // upstream regression on clean finish). Recover a billing floor:
-            // completion = content-frame count (~1 token/frame); prompt =
-            // re-template via the engine's exact applyChatTemplate path. VLM
-            // prompts under-count (no image tokens) — a floor, never an overcharge.
-            if promptTokens == 0 || completionTokens == 0 {
+            // No usage chunk on a clean finish means an upstream regression.
+            // Recover a billing floor: completion = content-frame count (~1
+            // token/frame); prompt = re-template via the engine's exact
+            // applyChatTemplate path. VLM prompts under-count (no image tokens) —
+            // a floor, never an overcharge.
+            if !cancelledMidStream && (promptTokens == 0 || completionTokens == 0) {
                 if completionTokens == 0 && contentFrameCount > 0 {
                     completionTokens = contentFrameCount
                     log.warning(
                         "[\(requestId)] usage chunk missing/zero completion tokens"
-                        + "\(cancelledMidStream ? " (cancelled mid-stream)" : ""); "
+                        + "; "
                         + "billing \(contentFrameCount) observed content frames as a floor."
                     )
                 }
@@ -1483,13 +1529,12 @@ public actor ProviderLoop {
                     if promptTokens > 0 {
                         log.warning(
                             "[\(requestId)] usage chunk missing/zero prompt tokens"
-                            + "\(cancelledMidStream ? " (cancelled mid-stream)" : ""); "
+                            + "; "
                             + "billing \(promptTokens) re-templated prompt tokens as a floor."
                         )
                     }
                 }
-                // Re-tokenize reasoning here too — a cancel ends before the
-                // usage parse that normally does it.
+                // Re-tokenize reasoning here too when the usage frame is missing.
                 if reasoningTokens == 0 && !reasoningText.isEmpty && completionTokens > 0 {
                     reasoningTokens = min(
                         tokenizer.inner.encode(

--- a/provider-swift/Tests/ProviderCoreTests/UsageAccountingTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/UsageAccountingTests.swift
@@ -1,0 +1,79 @@
+import Testing
+@testable import ProviderCore
+
+@Test("cancel before visible output has no billable usage")
+func cancelledUsageWithoutVisibleOutputRefunds() {
+    let usage = StreamedGenerationUsage(
+        promptTokens: 0,
+        completionTokens: 0,
+        contentFrameCount: 0,
+        hasVisibleOutput: false
+    )
+
+    #expect(usage.cancelledUsageInfo(promptTokenFloor: 128) == nil)
+    #expect(usage.cancelledTerminal(promptTokenFloor: 128) == .refund)
+}
+
+@Test("cancel after visible output settles from conservative floors")
+func cancelledUsageAfterVisibleOutputUsesFloors() throws {
+    let usage = StreamedGenerationUsage(
+        promptTokens: 0,
+        completionTokens: 0,
+        contentFrameCount: 7,
+        hasVisibleOutput: true
+    )
+
+    let settled = try #require(usage.cancelledUsageInfo(promptTokenFloor: 321))
+    #expect(settled.promptTokens == 321)
+    #expect(settled.completionTokens == 7)
+    #expect(settled.reasoningTokens == 0)
+
+    #expect(usage.cancelledTerminal(promptTokenFloor: 321) == .complete(settled))
+}
+
+@Test("cancel after visible output prefers delivered token floor over frame count")
+func cancelledUsageUsesDeliveredTokenFloor() throws {
+    let usage = StreamedGenerationUsage(
+        promptTokens: 0,
+        completionTokens: 0,
+        contentFrameCount: 2,
+        deliveredCompletionTokenFloor: 19,
+        hasVisibleOutput: true
+    )
+
+    let settled = try #require(usage.cancelledUsageInfo(promptTokenFloor: 321))
+    #expect(settled.promptTokens == 321)
+    #expect(settled.completionTokens == 19)
+}
+
+@Test("cancel settlement keeps provider-reported usage when present")
+func cancelledUsageKeepsReportedCounts() throws {
+    let usage = StreamedGenerationUsage(
+        promptTokens: 100,
+        completionTokens: 50,
+        reasoningTokens: 12,
+        contentFrameCount: 7,
+        hasVisibleOutput: true
+    )
+
+    let settled = try #require(usage.cancelledUsageInfo(promptTokenFloor: 321))
+    #expect(settled.promptTokens == 100)
+    #expect(settled.completionTokens == 50)
+    #expect(settled.reasoningTokens == 12)
+}
+
+@Test("cancel settlement clamps reasoning tokens to completion tokens")
+func cancelledUsageClampsReasoningToCompletion() throws {
+    let usage = StreamedGenerationUsage(
+        promptTokens: 100,
+        completionTokens: 5,
+        reasoningTokens: 20,
+        contentFrameCount: 7,
+        hasVisibleOutput: true
+    )
+
+    let settled = try #require(usage.cancelledUsageInfo(promptTokenFloor: 321))
+    #expect(settled.promptTokens == 100)
+    #expect(settled.completionTokens == 5)
+    #expect(settled.reasoningTokens == 5)
+}


### PR DESCRIPTION
## Summary
- Make provider cancellation settlement explicit: pre-output cancels still emit 499/refund, while cancels after visible output emit inference_complete with billable usage.
- Add a testable StreamedGenerationUsage helper that prefers provider-reported usage, otherwise settles from conservative delivered-token floors.
- Use a tokenizer-derived delivered completion-token floor for mid-stream cancels instead of only counting SSE frames.

Fixes DAR-343.

## Verification
- `go test ./api -run 'ClientGone|Settlement|CompleteAfterGrace|HandleComplete'` from `coordinator/`
- `swift test --filter UsageAccountingTests` from `provider-swift/`
- `swift build` from `provider-swift/`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/433"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784585271&installation_id=133247490&pr_number=433&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F433&signature=a3247fe037bbc57df292fff38b090fa131e6e538e956c416f8231954ac86f84f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->