### PR TITLE
feat(coordinator): route Gemma 4 only to dedicated providers; 429 shed

### DIFF
--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -2096,6 +2096,44 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 			if s.coldDispatchEnabled() && s.coldSpillAvailable(model, registry.RequestTraits{HasTools: hasTools}, requiresVision, allowedProviderSerials) {
 				s.ddIncr("routing.decisions", []string{"model:" + model, "model_type:" + s.registry.ModelType(model), "outcome:cold_dispatch_spill"})
 				// Fall through to dispatch+queue; reservation kept.
+			} else if s.registry.IsDedicatedModel(model) && s.registry.HasProviderForModel(model, allowedProviderSerials...) {
+				// Dedicated-box model (e.g. Gemma 4): the fleet DOES serve this
+				// model, but no provider DEDICATED to it can take the request right
+				// now — either none are dedicated, or the dedicated ones are busy/
+				// cooling. That is transient capacity pressure, not an absent model,
+				// so shed to OpenRouter as a 429 + Retry-After (clean failover)
+				// rather than a 503 (which can get the endpoint marked unhealthy /
+				// deranked). Mirrors the capacity_429 path above.
+				retryAfter := s.estimateRetryAfter(model)
+				w.Header().Set("Retry-After", strconv.Itoa(retryAfter))
+				refundReservation()
+				s.ddIncr("routing.decisions", []string{"model:" + model, "model_type:" + s.registry.ModelType(model), "outcome:dedicated_capacity_429"})
+				s.recordRejection(rejectionInfo{
+					r:                       r,
+					stage:                   "preflight_capacity",
+					reasonCode:              "machine_busy",
+					httpStatus:              http.StatusTooManyRequests,
+					keyID:                   keyIDFromContext(r.Context()),
+					consumerKeyHash:         store.HashKey(consumerKeyFromContext(r.Context())),
+					requestedModel:          publicModel,
+					resolvedModel:           model,
+					stream:                  stream,
+					estimatedPromptTokens:   estimatedPromptTokens,
+					requestedMaxTokens:      requestedMaxTokens,
+					requiresVision:          requiresVision,
+					hasTools:                hasTools,
+					retryAfterMs:            retryAfter * 1000,
+					params:                  rejectionSamplingParams(parsed),
+					servabilityComputed:     true,
+					candidateCount:          candidateCount,
+					capacityRejections:      capacityRejections,
+					modelTooLargeRejections: modelTooLarge,
+					bestTTFTMs:              ttftMsForRejection(bestTTFT, hasTTFT),
+				})
+				writeJSON(w, http.StatusTooManyRequests, errorResponse("rate_limit_exceeded",
+					fmt.Sprintf("no provider dedicated to model %q is available right now — retry after %ds", publicModel, retryAfter),
+					withCode("rate_limit_exceeded")))
+				return
 			} else {
 				// None of these clear by a slot freeing up, so queueing for up to
 				// 120s only adds misleading latency before the same error. Fail
@@ -4882,6 +4920,41 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 			if s.coldDispatchEnabled() && s.coldSpillAvailable(model, registry.RequestTraits{HasTools: hasTools}, requiresVision, allowedProviderSerials) {
 				s.ddIncr("routing.decisions", []string{"model:" + model, "model_type:" + s.registry.ModelType(model), "outcome:cold_dispatch_spill"})
 				// Fall through to dispatch+queue; reservation kept.
+			} else if s.registry.IsDedicatedModel(model) && s.registry.HasProviderForModel(model, allowedProviderSerials...) {
+				// Dedicated-box model served by the fleet but no dedicated box is
+				// available right now: transient capacity, so shed with 429 +
+				// Retry-After (not 503). Mirrors the chat-completions preflight so
+				// /v1/completions and /v1/messages classify the shed identically.
+				retryAfter := s.estimateRetryAfter(model)
+				w.Header().Set("Retry-After", strconv.Itoa(retryAfter))
+				refundReservation()
+				s.ddIncr("routing.decisions", []string{"model:" + model, "model_type:" + s.registry.ModelType(model), "outcome:dedicated_capacity_429"})
+				s.recordRejection(rejectionInfo{
+					r:                       r,
+					stage:                   "preflight_capacity",
+					reasonCode:              "machine_busy",
+					httpStatus:              http.StatusTooManyRequests,
+					keyID:                   keyIDFromContext(r.Context()),
+					consumerKeyHash:         store.HashKey(consumerKeyFromContext(r.Context())),
+					requestedModel:          publicModel,
+					resolvedModel:           model,
+					stream:                  stream,
+					estimatedPromptTokens:   estimatedPromptTokens,
+					requestedMaxTokens:      requestedMaxTokens,
+					requiresVision:          requiresVision,
+					hasTools:                hasTools,
+					retryAfterMs:            retryAfter * 1000,
+					params:                  rejectionSamplingParams(parsed),
+					servabilityComputed:     true,
+					candidateCount:          candidateCount,
+					capacityRejections:      capacityRejections,
+					modelTooLargeRejections: modelTooLarge,
+					bestTTFTMs:              ttftMsForRejection(bestTTFT, hasTTFT),
+				})
+				writeJSON(w, http.StatusTooManyRequests, errorResponse("rate_limit_exceeded",
+					fmt.Sprintf("no provider dedicated to model %q is available right now — retry after %ds", publicModel, retryAfter),
+					withCode("rate_limit_exceeded")))
+				return
 			} else {
 				// Queueing cannot help — fail fast with a retryable 503 instead of
 				// a 120s queue. Mirrors the chat-completions preflight.

--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -2036,10 +2036,16 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 			// it. The dispatch/queue path still returns a 429 when the queue is
 			// full or the wait times out (true saturation). The reservation is
 			// kept for dispatch.
-			if s.queueBeforeShedEnabled() {
+			// Dedicated-family models (e.g. Gemma 4) bypass queue-before-shed when
+			// their dedicated boxes are saturated: holding an OpenRouter request in
+			// the 120s queue would blow its TTFT SLA, so shed immediately with a
+			// 429 + Retry-After for a clean failover rather than waiting on a
+			// dedicated slot that may not free in time.
+			if s.queueBeforeShedEnabled() && !s.registry.IsDedicatedModel(model) {
 				s.ddIncr("routing.decisions", []string{"model:" + model, "model_type:" + s.registry.ModelType(model), "outcome:capacity_queue_spill"})
 			} else {
-				// Legacy fast-shed: immediate 429.
+				// Fast-shed: immediate 429 (always for dedicated models; for every
+				// model when queue-before-shed is disabled).
 				retryAfter := s.estimateRetryAfter(model)
 				w.Header().Set("Retry-After", strconv.Itoa(retryAfter))
 				refundReservation()
@@ -4870,7 +4876,10 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 			// capacity right now. Fall through to the dispatch+queue path so a slot
 			// freeing — or a cold load completing — within the queue window serves
 			// it; the queue path still 429s on a full queue or wait timeout.
-			if s.queueBeforeShedEnabled() {
+			// Dedicated-family models (e.g. Gemma 4) bypass queue-before-shed when
+			// saturated — fast-429 for a clean OpenRouter failover instead of a
+			// 120s queue that would blow the TTFT SLA. Mirrors handleChatCompletions.
+			if s.queueBeforeShedEnabled() && !s.registry.IsDedicatedModel(model) {
 				s.ddIncr("routing.decisions", []string{"model:" + model, "model_type:" + s.registry.ModelType(model), "outcome:capacity_queue_spill"})
 			} else {
 				retryAfter := s.estimateRetryAfter(model)

--- a/coordinator/api/dedicated_models_test.go
+++ b/coordinator/api/dedicated_models_test.go
@@ -1,0 +1,119 @@
+package api
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+	"nhooyr.io/websocket"
+)
+
+// chatRequestWithHeaders posts a chat completion and returns status, body, and
+// the Retry-After header (adaptiveChatRequest drops headers).
+func chatRequestWithHeaders(ctx context.Context, baseURL, model string) (int, string, string, error) {
+	body := `{"model":"` + model + `","messages":[{"role":"user","content":"hello"}],"stream":true,"max_tokens":64}`
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, baseURL+"/v1/chat/completions", strings.NewReader(body))
+	if err != nil {
+		return 0, "", "", err
+	}
+	req.Header.Set("Authorization", "Bearer test-key")
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return 0, "", "", err
+	}
+	defer resp.Body.Close()
+	data, _ := io.ReadAll(resp.Body)
+	return resp.StatusCode, string(data), resp.Header.Get("Retry-After"), nil
+}
+
+// TestDedicatedModelShed429NotServiceUnavailable verifies that when a dedicated
+// model (gemma-4) is served by the fleet but no DEDICATED box can take the
+// request (only a mixed gemma-4+qwen box exists), the coordinator sheds to
+// OpenRouter with a transient 429 + Retry-After — NOT a 503. A truly-absent,
+// non-dedicated model still returns 503.
+func TestDedicatedModelShed429NotServiceUnavailable(t *testing.T) {
+	ts, reg := setupAdaptiveCapacityIntegration(t)
+	defer ts.Close()
+	reg.SetDedicatedModels([]string{"gemma-4"})
+	// Keep cold-dispatch from spilling to the queue; pin the preflight shed path.
+	t.Setenv(envColdDispatch, "false")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	gemma := "gemma-4-26b-test"
+	qwen := "qwen-3-test"
+	// A single MIXED provider: advertises gemma-4 AND qwen -> not dedicated.
+	conn := connectProvider(t, ctx, ts.URL, []protocol.ModelInfo{
+		{ID: gemma, ModelType: "chat", Quantization: "4bit"},
+		{ID: qwen, ModelType: "chat", Quantization: "4bit"},
+	}, testPublicKeyB64())
+	defer conn.Close(websocket.StatusNormalClosure, "done")
+	p := markOnlyProviderRoutable(t, reg)
+
+	writeAdaptiveHeartbeat(t, ctx, conn, gemma, &protocol.BackendCapacity{
+		TotalMemoryGB: 64,
+		Slots: []protocol.BackendSlotCapacity{
+			{Model: gemma, State: "running", MaxConcurrency: 8, ActiveTokenBudgetMax: 32_768},
+		},
+	})
+	waitForAdaptiveCondition(t, time.Second, func() bool {
+		p.Mu().Lock()
+		defer p.Mu().Unlock()
+		return p.BackendCapacity != nil
+	})
+
+	// Gemma-4 to a mixed-only fleet -> transient 429 + Retry-After (not 503).
+	status, body, retryAfter, err := chatRequestWithHeaders(ctx, ts.URL, gemma)
+	if err != nil {
+		t.Fatalf("gemma request: %v", err)
+	}
+	if status != http.StatusTooManyRequests {
+		t.Fatalf("gemma status = %d, want 429; body = %s", status, body)
+	}
+	if !strings.Contains(body, "rate_limit_exceeded") {
+		t.Fatalf("gemma body = %s, want rate_limit_exceeded", body)
+	}
+	if retryAfter == "" {
+		t.Fatalf("gemma 429 missing Retry-After header")
+	}
+
+	// Control: a non-dedicated model absent from the fleet still 503s.
+	statusC, bodyC, _, err := chatRequestWithHeaders(ctx, ts.URL, "totally-absent-model")
+	if err != nil {
+		t.Fatalf("control request: %v", err)
+	}
+	if statusC != http.StatusServiceUnavailable {
+		t.Fatalf("control status = %d, want 503; body = %s", statusC, bodyC)
+	}
+	if !strings.Contains(bodyC, "model_unavailable") {
+		t.Fatalf("control body = %s, want model_unavailable", bodyC)
+	}
+
+	// The legacy /v1/completions endpoint (handleGenericInference) must classify
+	// the dedicated shed identically — 429, not 503.
+	cbody := `{"model":"` + gemma + `","prompt":"hello","stream":true,"max_tokens":64}`
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, ts.URL+"/v1/completions", strings.NewReader(cbody))
+	if err != nil {
+		t.Fatalf("completions request build: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer test-key")
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("completions request: %v", err)
+	}
+	defer resp.Body.Close()
+	cdata, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusTooManyRequests {
+		t.Fatalf("/v1/completions status = %d, want 429; body = %s", resp.StatusCode, string(cdata))
+	}
+	if resp.Header.Get("Retry-After") == "" {
+		t.Fatalf("/v1/completions 429 missing Retry-After header")
+	}
+}

--- a/coordinator/api/dedicated_models_test.go
+++ b/coordinator/api/dedicated_models_test.go
@@ -117,3 +117,52 @@ func TestDedicatedModelShed429NotServiceUnavailable(t *testing.T) {
 		t.Fatalf("/v1/completions 429 missing Retry-After header")
 	}
 }
+
+// TestDedicatedSaturatedBoxFast429 verifies that when the dedicated box for a
+// Gemma 4 request EXISTS but is at capacity, the request is fast-429'd
+// immediately instead of sitting in the 120s queue-before-shed window (which is
+// left at its default ON) — so OpenRouter fails over within its TTFT SLA.
+func TestDedicatedSaturatedBoxFast429(t *testing.T) {
+	ts, reg := setupAdaptiveCapacityIntegration(t)
+	defer ts.Close()
+	reg.SetDedicatedModels([]string{"gemma-4"})
+	// queue-before-shed left at default (ON): dedicated models must still fast-429.
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	gemma := "gemma-4-26b-test"
+	// A single DEDICATED gemma-4 box with its token budget nearly exhausted.
+	conn := connectProvider(t, ctx, ts.URL, []protocol.ModelInfo{
+		{ID: gemma, ModelType: "chat", Quantization: "4bit"},
+	}, testPublicKeyB64())
+	defer conn.Close(websocket.StatusNormalClosure, "done")
+	p := markOnlyProviderRoutable(t, reg)
+
+	writeAdaptiveHeartbeat(t, ctx, conn, gemma, &protocol.BackendCapacity{
+		TotalMemoryGB: 64,
+		Slots: []protocol.BackendSlotCapacity{{
+			Model:                 gemma,
+			State:                 "running",
+			MaxConcurrency:        8,
+			ActiveTokenBudgetUsed: 950,
+			ActiveTokenBudgetMax:  1_000,
+		}},
+	})
+	waitForAdaptiveCondition(t, time.Second, func() bool {
+		p.Mu().Lock()
+		defer p.Mu().Unlock()
+		return p.BackendCapacity != nil && p.BackendCapacity.Slots[0].ActiveTokenBudgetMax == 1_000
+	})
+
+	status, body, retryAfter, err := chatRequestWithHeaders(ctx, ts.URL, gemma)
+	if err != nil {
+		t.Fatalf("request: %v (a hang here means the dedicated request was queued instead of fast-429'd)", err)
+	}
+	if status != http.StatusTooManyRequests {
+		t.Fatalf("status = %d, want 429 (dedicated boxes bypass queue-before-shed when saturated); body = %s", status, body)
+	}
+	if retryAfter == "" {
+		t.Fatalf("saturated dedicated 429 missing Retry-After header")
+	}
+}

--- a/coordinator/cmd/coordinator/main.go
+++ b/coordinator/cmd/coordinator/main.go
@@ -157,6 +157,30 @@ func main() {
 		reg.MinTrustLevel = registry.TrustLevel(cfg.RegistryCfg.MinTrustLevel)
 		logger.Info("minimum trust level override", "level", cfg.RegistryCfg.MinTrustLevel)
 	}
+
+	// Dedicated-box routing: model families (matched as case-insensitive
+	// substrings of the resolved build id) that may ONLY route to providers
+	// whose entire advertised catalog is that family — isolating an unstable
+	// model (e.g. Gemma 4) onto dedicated machines so it never contends with
+	// other models. Default: "gemma-4". Override with a comma-separated list, or
+	// set the value to empty / "none" to disable. With no dedicated box
+	// available, a request for such a model sheds to OpenRouter as a transient
+	// 429 (not 503).
+	dedicatedModels := []string{"gemma-4"}
+	if v, ok := os.LookupEnv("EIGENINFERENCE_DEDICATED_MODELS"); ok {
+		if strings.EqualFold(strings.TrimSpace(v), "none") {
+			dedicatedModels = nil
+		} else {
+			dedicatedModels = registry.ParseDedicatedModels(v)
+		}
+	}
+	reg.SetDedicatedModels(dedicatedModels)
+	if len(dedicatedModels) > 0 {
+		logger.Info("dedicated-model routing ENABLED", "patterns", strings.Join(dedicatedModels, ","))
+	} else {
+		logger.Info("dedicated-model routing disabled")
+	}
+
 	reg.ConfigureCacheAffinity(cfg.RegistryCfg.CacheAffinity)
 	cacheAffinityCfg := reg.CacheAffinityConfigSnapshot()
 	logger.Info("cache affinity configured", "ttl", cacheAffinityCfg.TTL.String(), "bonus_ms", cacheAffinityCfg.BonusMs, "enabled", cacheAffinityCfg.BonusMs > 0)

--- a/coordinator/registry/dedicated_models.go
+++ b/coordinator/registry/dedicated_models.go
@@ -1,0 +1,142 @@
+package registry
+
+import "strings"
+
+// Dedicated-model routing isolates a model family (e.g. Gemma 4) to providers
+// that run ONLY that family. A "dedicated" provider is one whose entire
+// advertised catalog matches the family pattern; nothing else can ever load on
+// that machine, so the isolated model never contends for memory or compute with
+// other models on the same box. The patterns are configured at startup
+// (EIGENINFERENCE_DEDICATED_MODELS, default "gemma-4") and applied in the single
+// routing/preflight gate providerPassesRoutingGatesLockedEx, which both the
+// dispatch hot path and the OpenRouter capacity preflight funnel through.
+
+// ParseDedicatedModels parses a comma-separated list of model-family patterns
+// into normalized (trimmed, lowercased, non-empty) substring patterns. Used by
+// the coordinator entrypoint to read EIGENINFERENCE_DEDICATED_MODELS. An empty
+// or all-blank input yields a nil slice (feature disabled).
+func ParseDedicatedModels(csv string) []string {
+	var out []string
+	for _, p := range strings.Split(csv, ",") {
+		p = strings.ToLower(strings.TrimSpace(p))
+		if p == "" {
+			continue
+		}
+		out = append(out, p)
+	}
+	return out
+}
+
+// SetDedicatedModels configures the dedicated-model routing patterns. Patterns
+// are matched case-insensitively as substrings of the resolved build id. An
+// empty (or all-blank) list disables the feature. Called once at startup before
+// the coordinator begins serving.
+func (r *Registry) SetDedicatedModels(patterns []string) {
+	normalized := make([]string, 0, len(patterns))
+	for _, p := range patterns {
+		p = strings.ToLower(strings.TrimSpace(p))
+		if p == "" {
+			continue
+		}
+		normalized = append(normalized, p)
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if len(normalized) == 0 {
+		r.dedicatedModels = nil
+		return
+	}
+	r.dedicatedModels = normalized
+}
+
+// dedicatedPatternForLocked returns the first configured pattern that the given
+// resolved build id contains, or "", false when the model is not a dedicated
+// model (or the feature is disabled). Caller holds r.mu.
+func (r *Registry) dedicatedPatternForLocked(model string) (string, bool) {
+	if len(r.dedicatedModels) == 0 {
+		return "", false
+	}
+	m := strings.ToLower(model)
+	for _, p := range r.dedicatedModels {
+		if strings.Contains(m, p) {
+			return p, true
+		}
+	}
+	return "", false
+}
+
+// providerDedicatedToPatternLocked reports whether EVERY catalog-allowed model
+// the provider advertises matches pattern — i.e. the box is dedicated to that
+// model family. A provider that advertises no catalog-allowed model is not
+// dedicated (returns false). Non-catalog-allowed advertised builds (stale or
+// unknown) are ignored so they cannot spuriously disqualify a dedicated box.
+// Caller holds r.mu AND p.mu (mirrors providerServesCatalogModelLocked).
+func (r *Registry) providerDedicatedToPatternLocked(p *Provider, pattern string) bool {
+	advertised := 0
+	for _, m := range p.Models {
+		if !r.modelAllowedByCatalogLocked(m) {
+			continue
+		}
+		advertised++
+		if !strings.Contains(strings.ToLower(m.ID), pattern) {
+			return false
+		}
+	}
+	return advertised > 0
+}
+
+// providerExcludedByDedicatedRuleLocked reports whether the dedicated-box rule
+// excludes this provider from PUBLIC routing/warming for the model: true when
+// the model is a dedicated family AND the provider is not dedicated to it. It is
+// the single predicate shared by the routing gate, the capacity preflight, the
+// cold-spill check, the warm-pool target picker, and the model-swap planner, so
+// every place that selects or pre-warms a provider for a public request applies
+// the same constraint and cannot drift. (Self-route exemption is the caller's
+// concern — only the routing gate honors it.) Caller holds r.mu AND p.mu.
+func (r *Registry) providerExcludedByDedicatedRuleLocked(p *Provider, model string) bool {
+	pat, ok := r.dedicatedPatternForLocked(model)
+	if !ok {
+		return false
+	}
+	return !r.providerDedicatedToPatternLocked(p, pat)
+}
+
+// IsDedicatedModel reports whether the resolved build id is governed by the
+// dedicated-model routing rule. The consumer layer uses it to classify a
+// "no eligible provider" shed for such a model as a transient 429 (rather than
+// a 503): with no dedicated box available, the request must fail over cleanly.
+func (r *Registry) IsDedicatedModel(model string) bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	_, ok := r.dedicatedPatternForLocked(model)
+	return ok
+}
+
+// HasProviderForModel reports whether any online, non-untrusted provider
+// advertises a catalog-allowed build of the resolved model id (ignoring
+// dedicated-box and capacity gates). It distinguishes "the fleet serves this
+// model but no dedicated/available box can take it right now" (transient — a
+// 429 shed) from "the model is absent from the fleet entirely" (a 503). When
+// allowedSerials is non-empty the check is restricted to providers whose
+// attested serial is in the set, mirroring the routing candidate filter.
+func (r *Registry) HasProviderForModel(model string, allowedSerials ...string) bool {
+	allowedSet := make(map[string]struct{}, len(allowedSerials))
+	for _, s := range allowedSerials {
+		allowedSet[s] = struct{}{}
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	for _, p := range r.providers {
+		if len(allowedSet) > 0 && !providerMatchesAllowedSerial(p, allowedSet) {
+			continue
+		}
+		p.mu.Lock()
+		eligible := p.Status != StatusOffline && p.Status != StatusUntrusted &&
+			r.providerServesCatalogModelLocked(p, model)
+		p.mu.Unlock()
+		if eligible {
+			return true
+		}
+	}
+	return false
+}

--- a/coordinator/registry/dedicated_models_test.go
+++ b/coordinator/registry/dedicated_models_test.go
@@ -329,6 +329,41 @@ func TestDedicatedWarmDetectionIgnoresMixedBox(t *testing.T) {
 	}
 }
 
+// During a staged rollout, if a dedicated alias's Desired build is advertised
+// only by a mixed-catalog box (not yet on a dedicated box) while the Previous
+// build still has a dedicated box, alias resolution must fail over to Previous —
+// not resolve to Desired and then 429 at dispatch. This is the alias-routability
+// drift Codex flagged: providerCanRouteBuildLocked must apply the dedicated gate.
+func TestDedicatedAliasFailsOverToPreviousOnDedicatedBox(t *testing.T) {
+	desired := gemmaBuild      // would-be new build, only on a mixed box here
+	previous := gemmaBuildSmol // stable build on a dedicated box
+
+	setup := func(reg *Registry) {
+		mixed := makeSchedulerProvider(t, reg, "mixed", desired, 200)
+		addAdvertisedModel(mixed, qwenBuild) // Desired's only advertiser is mixed
+		_ = makeSchedulerProvider(t, reg, "dedicated-prev", previous, 80)
+		reg.SetModelAliases(map[string]AliasTarget{
+			"gemma-4-26b": {Desired: desired, Previous: previous},
+		})
+	}
+
+	// Baseline (rule OFF): Desired is routable on the mixed box → resolves Desired.
+	off := New(testLogger())
+	setup(off)
+	if build, _, _ := off.ResolveModel("gemma-4-26b"); build != desired {
+		t.Fatalf("rule off: resolved %q, want desired %q", build, desired)
+	}
+
+	// Rule ON: Desired only on a mixed box → not routable → fail over to the
+	// dedicated Previous box instead of resolving Desired (which would 429).
+	on := New(testLogger())
+	on.SetDedicatedModels([]string{"gemma-4"})
+	setup(on)
+	if build, isAlias, ok := on.ResolveModel("gemma-4-26b"); !ok || !isAlias || build != previous {
+		t.Fatalf("rule on: resolved %q (isAlias=%v ok=%v), want previous %q", build, isAlias, ok, previous)
+	}
+}
+
 func TestIsDedicatedModel(t *testing.T) {
 	reg := New(testLogger())
 	if reg.IsDedicatedModel(gemmaBuild) {

--- a/coordinator/registry/dedicated_models_test.go
+++ b/coordinator/registry/dedicated_models_test.go
@@ -1,0 +1,365 @@
+package registry
+
+import (
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+)
+
+const (
+	gemmaBuild     = "gemma-4-26b-qat-4bit"
+	gemmaBuildOrg  = "mlx-community/gemma-4-26B-A4B-it-qat-4bit"
+	gemmaBuildSmol = "gemma-4-12b-qat-4bit"
+	qwenBuild      = "qwen-3-32b"
+)
+
+// addModelToProvider appends an advertised model id to an already-registered
+// provider (makeSchedulerProvider gives it exactly one). Mirrors how a real
+// multi-model provider advertises its on-disk catalog.
+func addAdvertisedModel(p *Provider, modelID string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.Models = append(p.Models, protocol.ModelInfo{ID: modelID, ModelType: "chat", Quantization: "4bit"})
+}
+
+func TestParseDedicatedModels(t *testing.T) {
+	cases := []struct {
+		in   string
+		want []string
+	}{
+		{"gemma-4", []string{"gemma-4"}},
+		{"gemma-4,Foo ", []string{"gemma-4", "foo"}},
+		{" GEMMA-4 , Qwen ", []string{"gemma-4", "qwen"}},
+		{"a, ,b", []string{"a", "b"}},
+		{"", nil},
+		{"   ", nil},
+		{" , , ", nil},
+	}
+	for _, tc := range cases {
+		got := ParseDedicatedModels(tc.in)
+		if len(got) != len(tc.want) {
+			t.Fatalf("ParseDedicatedModels(%q) = %v, want %v", tc.in, got, tc.want)
+		}
+		for i := range got {
+			if got[i] != tc.want[i] {
+				t.Fatalf("ParseDedicatedModels(%q)[%d] = %q, want %q", tc.in, i, got[i], tc.want[i])
+			}
+		}
+	}
+}
+
+func TestDedicatedPatternForLocked(t *testing.T) {
+	reg := New(testLogger())
+	reg.SetDedicatedModels([]string{"gemma-4"})
+
+	reg.mu.RLock()
+	defer reg.mu.RUnlock()
+
+	matches := []string{gemmaBuild, gemmaBuildOrg, "GEMMA-4-foo", gemmaBuildSmol}
+	for _, m := range matches {
+		if pat, ok := reg.dedicatedPatternForLocked(m); !ok || pat != "gemma-4" {
+			t.Fatalf("dedicatedPatternForLocked(%q) = (%q,%v), want (gemma-4,true)", m, pat, ok)
+		}
+	}
+	for _, m := range []string{qwenBuild, "gpt-oss-20b", "gemma-3-27b"} {
+		if _, ok := reg.dedicatedPatternForLocked(m); ok {
+			t.Fatalf("dedicatedPatternForLocked(%q) matched, want no match", m)
+		}
+	}
+}
+
+func TestDedicatedPatternDisabledWhenUnset(t *testing.T) {
+	reg := New(testLogger())
+	reg.mu.RLock()
+	defer reg.mu.RUnlock()
+	if _, ok := reg.dedicatedPatternForLocked(gemmaBuild); ok {
+		t.Fatalf("dedicatedPatternForLocked matched with no patterns configured")
+	}
+}
+
+func TestSetDedicatedModelsNoneDisables(t *testing.T) {
+	reg := New(testLogger())
+	reg.SetDedicatedModels([]string{"gemma-4"})
+	reg.SetDedicatedModels(nil) // explicit disable
+	if reg.IsDedicatedModel(gemmaBuild) {
+		t.Fatalf("IsDedicatedModel true after clearing patterns")
+	}
+	reg.SetDedicatedModels([]string{"  ", ""}) // all-blank also disables
+	if reg.IsDedicatedModel(gemmaBuild) {
+		t.Fatalf("IsDedicatedModel true after all-blank patterns")
+	}
+}
+
+func TestProviderDedicatedToPatternLocked(t *testing.T) {
+	reg := New(testLogger())
+	reg.SetDedicatedModels([]string{"gemma-4"})
+
+	check := func(p *Provider) bool {
+		reg.mu.RLock()
+		defer reg.mu.RUnlock()
+		p.mu.Lock()
+		defer p.mu.Unlock()
+		return reg.providerDedicatedToPatternLocked(p, "gemma-4")
+	}
+
+	// Dedicated: single gemma-4 build.
+	dedicated := makeSchedulerProvider(t, reg, "dedicated", gemmaBuild, 80)
+	if !check(dedicated) {
+		t.Fatal("single gemma-4 build provider should be dedicated")
+	}
+
+	// Dedicated: two gemma-4 builds.
+	dedicated2 := makeSchedulerProvider(t, reg, "dedicated2", gemmaBuild, 80)
+	addAdvertisedModel(dedicated2, gemmaBuildSmol)
+	if !check(dedicated2) {
+		t.Fatal("multiple gemma-4 builds provider should be dedicated")
+	}
+
+	// Mixed: gemma-4 + qwen.
+	mixed := makeSchedulerProvider(t, reg, "mixed", gemmaBuild, 80)
+	addAdvertisedModel(mixed, qwenBuild)
+	if check(mixed) {
+		t.Fatal("gemma-4 + qwen provider must NOT be dedicated")
+	}
+
+	// Qwen-only.
+	qwen := makeSchedulerProvider(t, reg, "qwen", qwenBuild, 80)
+	if check(qwen) {
+		t.Fatal("qwen-only provider must NOT be dedicated to gemma-4")
+	}
+
+	// No advertised model → not dedicated.
+	empty := makeSchedulerProvider(t, reg, "empty", gemmaBuild, 80)
+	empty.mu.Lock()
+	empty.Models = nil
+	empty.mu.Unlock()
+	if check(empty) {
+		t.Fatal("provider advertising nothing must NOT be dedicated")
+	}
+}
+
+func TestProviderDedicatedIgnoresNonCatalogModels(t *testing.T) {
+	reg := New(testLogger())
+	reg.SetDedicatedModels([]string{"gemma-4"})
+	// Catalog allows only the gemma-4 build; a stale/unknown qwen advert is not
+	// catalog-allowed and must NOT disqualify the box from being dedicated.
+	reg.SetModelCatalog([]CatalogEntry{{ID: gemmaBuild}})
+
+	p := makeSchedulerProvider(t, reg, "p", gemmaBuild, 80)
+	addAdvertisedModel(p, qwenBuild) // not in catalog -> ignored
+
+	reg.mu.RLock()
+	defer reg.mu.RUnlock()
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if !reg.providerDedicatedToPatternLocked(p, "gemma-4") {
+		t.Fatal("a non-catalog-allowed advert must not disqualify a dedicated box")
+	}
+}
+
+func TestDedicatedRoutingSelectsOnlyDedicatedBox(t *testing.T) {
+	reg := New(testLogger())
+	reg.SetDedicatedModels([]string{"gemma-4"})
+
+	// Mixed box is FASTER (higher TPS) but must be skipped for gemma-4.
+	dedicated := makeSchedulerProvider(t, reg, "dedicated", gemmaBuild, 80)
+	mixed := makeSchedulerProvider(t, reg, "mixed", gemmaBuild, 400)
+	addAdvertisedModel(mixed, qwenBuild)
+
+	req := &PendingRequest{RequestID: "g1", Model: gemmaBuild, EstimatedPromptTokens: 10, RequestedMaxTokens: 128}
+	selected := reg.ReserveProvider(gemmaBuild, req)
+	if selected == nil || selected.ID != dedicated.ID {
+		t.Fatalf("gemma-4 routed to %#v, want dedicated %q", selected, dedicated.ID)
+	}
+
+	// Excluding the dedicated box yields NO candidate — never falls back to mixed.
+	req2 := &PendingRequest{RequestID: "g2", Model: gemmaBuild, EstimatedPromptTokens: 10, RequestedMaxTokens: 128}
+	selected2, decision := reg.ReserveProviderEx(gemmaBuild, req2, dedicated.ID)
+	if selected2 != nil {
+		t.Fatalf("gemma-4 fell back to %q after excluding dedicated, want nil", selected2.ID)
+	}
+	if decision.CandidateCount != 0 {
+		t.Fatalf("candidate count = %d after excluding dedicated, want 0", decision.CandidateCount)
+	}
+}
+
+func TestDedicatedRuleDoesNotAffectOtherModels(t *testing.T) {
+	reg := New(testLogger())
+	reg.SetDedicatedModels([]string{"gemma-4"})
+
+	// Only a mixed box exists; a qwen request must still route to it.
+	mixed := makeSchedulerProvider(t, reg, "mixed", qwenBuild, 200)
+	addAdvertisedModel(mixed, gemmaBuild)
+
+	req := &PendingRequest{RequestID: "q1", Model: qwenBuild, EstimatedPromptTokens: 10, RequestedMaxTokens: 128}
+	selected := reg.ReserveProvider(qwenBuild, req)
+	if selected == nil || selected.ID != mixed.ID {
+		t.Fatalf("qwen routed to %#v, want mixed %q (rule must not touch non-dedicated models)", selected, mixed.ID)
+	}
+}
+
+func TestDedicatedShedPreflightCountsOnlyDedicatedBoxes(t *testing.T) {
+	reg := New(testLogger())
+	reg.SetDedicatedModels([]string{"gemma-4"})
+
+	// Only a mixed box serves gemma-4 → preflight sees zero candidates (the
+	// coordinator says no / sheds to OpenRouter).
+	mixed := makeSchedulerProvider(t, reg, "mixed", gemmaBuild, 200)
+	addAdvertisedModel(mixed, qwenBuild)
+
+	cc, _, _, _, _ := reg.QuickCapacityCheckWithTTFTForRequest(gemmaBuild, 500, 128, RequestTraits{}, false)
+	if cc != 0 {
+		t.Fatalf("preflight candidate count = %d with only a mixed box, want 0", cc)
+	}
+
+	// Add a dedicated box → capacity reappears.
+	_ = makeSchedulerProvider(t, reg, "dedicated", gemmaBuild, 80)
+	cc2, _, _, _, _ := reg.QuickCapacityCheckWithTTFTForRequest(gemmaBuild, 500, 128, RequestTraits{}, false)
+	if cc2 < 1 {
+		t.Fatalf("preflight candidate count = %d after adding a dedicated box, want >= 1", cc2)
+	}
+}
+
+func TestDedicatedSelfRouteExempt(t *testing.T) {
+	reg := New(testLogger())
+	reg.SetDedicatedModels([]string{"gemma-4"})
+
+	// Owner's own mixed machine: self-route must still reach it for gemma-4.
+	mixed := makeSchedulerProvider(t, reg, "mixed", gemmaBuild, 200)
+	addAdvertisedModel(mixed, qwenBuild)
+	mixed.mu.Lock()
+	mixed.AccountID = "acct-1"
+	mixed.mu.Unlock()
+
+	req := &PendingRequest{
+		RequestID:             "self-1",
+		Model:                 gemmaBuild,
+		EstimatedPromptTokens: 10,
+		RequestedMaxTokens:    128,
+		SelfRouteOnly:         true,
+		OwnerAccountID:        "acct-1",
+	}
+	selected := reg.ReserveProvider(gemmaBuild, req)
+	if selected == nil || selected.ID != mixed.ID {
+		t.Fatalf("self-route gemma-4 selected %#v, want owner's mixed box %q (rule must be exempt)", selected, mixed.ID)
+	}
+}
+
+func TestDedicatedDisabledByDefaultRoutesToMixed(t *testing.T) {
+	reg := New(testLogger()) // no SetDedicatedModels -> feature off
+	mixed := makeSchedulerProvider(t, reg, "mixed", gemmaBuild, 200)
+	addAdvertisedModel(mixed, qwenBuild)
+
+	req := &PendingRequest{RequestID: "g1", Model: gemmaBuild, EstimatedPromptTokens: 10, RequestedMaxTokens: 128}
+	selected := reg.ReserveProvider(gemmaBuild, req)
+	if selected == nil || selected.ID != mixed.ID {
+		t.Fatalf("with rule OFF, gemma-4 routed to %#v, want mixed %q", selected, mixed.ID)
+	}
+}
+
+// The warm-pool / model-swap planner must honor the dedicated rule too —
+// otherwise it pre-warms gemma-4 onto mixed boxes that routing will never use,
+// and counts a warm mixed box as covering demand for a dedicated box.
+
+func TestDedicatedWarmPoolSkipsMixedBox(t *testing.T) {
+	reg := New(testLogger())
+	now := time.Now()
+	dedicated := makeSchedulerProvider(t, reg, "dedicated", gemmaBuild, 80)
+	mixed := makeSchedulerProvider(t, reg, "mixed", gemmaBuild, 80)
+	addAdvertisedModel(mixed, qwenBuild)
+
+	warmCand := func(p *Provider) bool {
+		reg.mu.RLock()
+		defer reg.mu.RUnlock()
+		p.mu.Lock()
+		defer p.mu.Unlock()
+		_, ok := reg.warmPoolCandidateLocked(p, gemmaBuild, now)
+		return ok
+	}
+	loadCand := func(p *Provider) bool {
+		reg.mu.RLock()
+		defer reg.mu.RUnlock()
+		_, ok := reg.modelLoadCandidatePendingLocked(p, gemmaBuild, now)
+		return ok
+	}
+
+	// Baseline: with the rule OFF, the mixed box is a valid warm/load target.
+	if !warmCand(mixed) || !loadCand(mixed) {
+		t.Fatal("baseline (rule off): mixed box should be a warm/load candidate")
+	}
+
+	reg.SetDedicatedModels([]string{"gemma-4"})
+	if !warmCand(dedicated) || !loadCand(dedicated) {
+		t.Fatal("dedicated box should remain a warm/load candidate for gemma-4")
+	}
+	if warmCand(mixed) {
+		t.Fatal("warm pool must NOT pre-warm gemma-4 onto a mixed box")
+	}
+	if loadCand(mixed) {
+		t.Fatal("swap planner must NOT target a mixed box for gemma-4")
+	}
+}
+
+func TestDedicatedWarmDetectionIgnoresMixedBox(t *testing.T) {
+	reg := New(testLogger())
+	now := time.Now()
+	// makeSchedulerProvider gives a "running" gemma slot => warm.
+	dedicated := makeSchedulerProvider(t, reg, "dedicated", gemmaBuild, 80)
+	mixed := makeSchedulerProvider(t, reg, "mixed", gemmaBuild, 80)
+	addAdvertisedModel(mixed, qwenBuild)
+
+	warm := func(p *Provider) bool {
+		reg.mu.RLock()
+		defer reg.mu.RUnlock()
+		p.mu.Lock()
+		defer p.mu.Unlock()
+		return reg.providerHasWarmModelLocked(p, gemmaBuild, now)
+	}
+
+	if !warm(mixed) {
+		t.Fatal("baseline (rule off): a warm mixed box should count as warm")
+	}
+	reg.SetDedicatedModels([]string{"gemma-4"})
+	if !warm(dedicated) {
+		t.Fatal("a warm dedicated box should count as warm for gemma-4")
+	}
+	if warm(mixed) {
+		t.Fatal("a warm mixed box must NOT count as warm for the dedicated model")
+	}
+}
+
+func TestIsDedicatedModel(t *testing.T) {
+	reg := New(testLogger())
+	if reg.IsDedicatedModel(gemmaBuild) {
+		t.Fatal("IsDedicatedModel true with no patterns")
+	}
+	reg.SetDedicatedModels([]string{"gemma-4"})
+	if !reg.IsDedicatedModel(gemmaBuild) || !reg.IsDedicatedModel(gemmaBuildOrg) {
+		t.Fatal("IsDedicatedModel should be true for gemma-4 builds")
+	}
+	if reg.IsDedicatedModel(qwenBuild) {
+		t.Fatal("IsDedicatedModel should be false for qwen")
+	}
+}
+
+func TestHasProviderForModel(t *testing.T) {
+	reg := New(testLogger())
+	if reg.HasProviderForModel(gemmaBuild) {
+		t.Fatal("HasProviderForModel true with empty fleet")
+	}
+	p := makeSchedulerProvider(t, reg, "p", gemmaBuild, 80)
+	if !reg.HasProviderForModel(gemmaBuild) {
+		t.Fatal("HasProviderForModel should be true when a provider advertises the model")
+	}
+	if reg.HasProviderForModel("totally-absent-model") {
+		t.Fatal("HasProviderForModel should be false for an unadvertised model")
+	}
+	// Offline providers are excluded.
+	p.mu.Lock()
+	p.Status = StatusOffline
+	p.mu.Unlock()
+	if reg.HasProviderForModel(gemmaBuild) {
+		t.Fatal("HasProviderForModel should exclude offline providers")
+	}
+}

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -1806,11 +1806,22 @@ func (r *Registry) anyEligibleProviderCanRouteLocked(buildID string, allowedSeri
 // provider actually serve this build right now" — the same gates
 // snapshotProviderLocked applies (advertises the build + in catalog, not
 // offline/untrusted, public, trust ≥ floor, runtime verified, private-text
-// capable, fresh challenge, AND the model fits the provider's RAM), minus the
-// per-request capacity/headroom checks. Cold-but-healthy providers pass (no warm
-// slot required — they load on first demand). Caller holds r.mu (RLock) and p.mu.
+// capable, fresh challenge, the dedicated-box rule, AND the model fits the
+// provider's RAM), minus the per-request capacity/headroom checks. Cold-but-
+// healthy providers pass (no warm slot required — they load on first demand).
+// Caller holds r.mu (RLock) and p.mu.
 func (r *Registry) providerCanRouteBuildLocked(p *Provider, buildID string, minTrust TrustLevel, now time.Time, allowPrivate bool) bool {
 	if !r.providerServesCatalogModelLocked(p, buildID) {
+		return false
+	}
+	// Dedicated-box isolation, mirroring providerPassesRoutingGatesLockedEx so
+	// alias routability (and rollout/drop measurement) matches actual dispatch
+	// routability: a dedicated-family build is only routable on a provider
+	// dedicated to that family. Without this, an alias whose Desired build is
+	// advertised only by a mixed box would resolve to Desired (then 429 at
+	// dispatch) instead of failing over to a Previous build on a dedicated box.
+	// allowPrivate marks the owner self-route context, exempt like selfRouteOwner.
+	if !allowPrivate && r.providerExcludedByDedicatedRuleLocked(p, buildID) {
 		return false
 	}
 	if r.dispatchLoadCooldownActiveLocked(p.ID, buildID, now) {

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -998,6 +998,17 @@ type Registry struct {
 
 	MinTrustLevel TrustLevel
 
+	// dedicatedModels holds lowercased substring patterns identifying model
+	// families that may ONLY route to providers dedicated to that family (a
+	// provider whose entire advertised catalog matches the pattern). A request
+	// whose resolved build id contains one of these patterns is restricted to
+	// such dedicated boxes — for both routing candidate selection and the
+	// capacity preflight that decides whether to shed (429) to OpenRouter. Empty
+	// = feature disabled (default in tests and the e2e testbed, which never set
+	// it). Configured once at startup from EIGENINFERENCE_DEDICATED_MODELS; see
+	// SetDedicatedModels and dedicated_models.go. Guarded by r.mu.
+	dedicatedModels []string
+
 	// APNs code-identity rollout policy (v0.6.0), guarded by r.mu and evaluated
 	// LIVE at every routing decision so a deadline can flip enforcement on/off
 	// without forcing providers to reconnect.
@@ -2971,6 +2982,13 @@ func (r *Registry) providerHasWarmModelLocked(p *Provider, model string, now tim
 	if !r.providerServesCatalogModelLocked(p, model) {
 		return false
 	}
+	// For a dedicated-family model (e.g. Gemma 4), a warm mixed-catalog box is not
+	// a usable warm provider — routing won't send the model there. Treat it as not
+	// warm so it neither suppresses cold-spill/swap planning onto a real dedicated
+	// box nor counts toward the model's warm-capacity demand target.
+	if r.providerExcludedByDedicatedRuleLocked(p, model) {
+		return false
+	}
 	if p.BackendCapacity != nil {
 		for _, slot := range p.BackendCapacity.Slots {
 			if slot.Model == model {
@@ -3049,6 +3067,11 @@ func (r *Registry) modelLoadCandidatePendingLocked(p *Provider, model string, no
 		return 0, false
 	}
 	if !r.providerServesCatalogModelLocked(p, model) {
+		return 0, false
+	}
+	// A dedicated-family model (e.g. Gemma 4) may only be loaded onto a provider
+	// dedicated to it — never a mixed-catalog box (routing would never use it).
+	if r.providerExcludedByDedicatedRuleLocked(p, model) {
 		return 0, false
 	}
 

--- a/coordinator/registry/scheduler.go
+++ b/coordinator/registry/scheduler.go
@@ -779,6 +779,15 @@ func (r *Registry) providerPassesRoutingGatesLockedEx(p *Provider, model string,
 	if !r.providerServesCatalogModelLocked(p, model) {
 		return false
 	}
+	// Dedicated-box isolation: a request for a dedicated model family (e.g.
+	// Gemma 4) may ONLY route to a provider whose ENTIRE advertised catalog is
+	// that family. This single gate is shared by the dispatch hot path and the
+	// OpenRouter capacity preflight, so the filter restricts the routing
+	// candidate set AND the shed (429) decision together with no drift. A caller
+	// self-routing to its OWN machine is exempt — owners may run mixed boxes.
+	if !selfRouteOwner && r.providerExcludedByDedicatedRuleLocked(p, model) {
+		return false
+	}
 	// Skip a provider-model pair cooling down after a dispatch-time load
 	// failure ("insufficient memory") — it would instant-503 again, burning a
 	// dispatch attempt.

--- a/coordinator/registry/warm_pool_controller.go
+++ b/coordinator/registry/warm_pool_controller.go
@@ -573,6 +573,13 @@ func (r *Registry) warmPoolCandidateLocked(p *Provider, model string, now time.T
 	if !r.providerServesCatalogModelLocked(p, model) {
 		return warmPoolCandidate{}, false
 	}
+	// Don't pre-warm a dedicated-family model (e.g. Gemma 4) onto a non-dedicated
+	// (mixed-catalog) box: routing will never send the model there, so the warm
+	// would be wasted GPU memory and would mislead the demand calc into thinking
+	// the model is already covered. Mirrors the routing/preflight gate.
+	if r.providerExcludedByDedicatedRuleLocked(p, model) {
+		return warmPoolCandidate{}, false
+	}
 	totalMemoryGB := float64(p.Hardware.MemoryGB)
 	gpuActiveGB := 0.0
 	if p.BackendCapacity != nil {


### PR DESCRIPTION
## What & why

Gemma 4 destabilizes when it shares a Mac with other models/work (memory contention, OOM/jetsam, ragged-batch NaN, Metal resource-count leaks). This restricts **a dedicated model family (default `gemma-4`) to providers whose entire advertised catalog is that family** — i.e. machines dedicated to Gemma 4. Those dedicated boxes are the only routing candidates *and* the only providers counted when deciding whether to accept or shed a request to OpenRouter.

Coordinator-only — no provider/Swift or protocol changes.

## Routing behavior: before → after

**Before** — a Gemma 4 request could land on any box serving it (including mixed boxes where it contends), and "no provider" shed as `503`:

```mermaid
flowchart TD
    Req["Gemma 4 request"] --> Gate{"Provider serves gemma-4?"}
    Gate -->|"Dedicated box ✓<br/>(gemma-4 only)"| Cand["Candidate pool"]
    Gate -->|"Mixed box ✓<br/>(gemma-4 + qwen/gpt-oss)"| Cand
    Cand --> Cap{"Capacity?"}
    Cap -->|"Yes"| Route["Route to best score —<br/>⚠️ often a MIXED box →<br/>Gemma 4 contends → OOM / NaN / leak"]
    Cap -->|"All busy"| R429["429 rate_limit"]
    Cap -->|"None eligible"| R503["❌ 503 model_unavailable<br/>(OpenRouter may derank us)"]
```

**After** — mixed boxes are filtered out at the single shared gate (routing *and* capacity preflight), so only dedicated boxes are eligible; "no dedicated box" sheds as `429`:

```mermaid
flowchart TD
    Req["Gemma 4 request"] --> Gate{"Provider serves gemma-4?"}
    Gate -->|"Dedicated box ✓"| Ded{"Dedicated to gemma-4?<br/>(advertised catalog == gemma-4 only)"}
    Gate -->|"Mixed box ✓"| Ded
    Ded -->|"No — mixed"| Drop["🚫 Excluded from routing<br/>AND capacity count<br/>(self-route to own box exempt)"]
    Ded -->|"Yes — dedicated"| Cand["Candidate pool =<br/>dedicated boxes only"]
    Cand --> Cap{"Capacity?"}
    Cap -->|"Yes"| Route["✅ Route to a DEDICATED box →<br/>Gemma 4 isolated, no contention"]
    Cap -->|"No dedicated box free"| R429["✅ 429 + Retry-After →<br/>clean OpenRouter failover"]
```

## How

One shared predicate, `registry.providerExcludedByDedicatedRuleLocked(p, model)` (*model is a dedicated family AND the provider isn't dedicated to it*), applied at **every** public provider-selection site so routing, shedding, and pre-warming can never drift:

- **`providerPassesRoutingGatesLockedEx`** — the documented single gate shared by the dispatch hot path (`snapshotProviderLockedEx`) **and** the OpenRouter capacity preflight (`quickCapacityCheck`).
- **`coldSpillProviderEligibleLocked`**, **`warmPoolCandidateLocked`**, **`modelLoadCandidatePendingLocked`** — so the autoscaler/swap planner never pre-warms a dedicated model onto a mixed box.
- **`providerHasWarmModelLocked`** — so a warm *mixed* box isn't counted as warm capacity for a dedicated model (which would suppress warming a real dedicated box).

A caller self-routing to its **own** machine is exempt (`!selfRouteOwner`). Eligibility is catalog-based, not load-based, so an **idle** dedicated box stays eligible (cold-loads on demand).

## 429, not 503

When the fleet serves the model but no dedicated box is available (none exist, or all busy), the preflight `no_eligible_provider` shed now returns **`429 rate_limit_exceeded` + `Retry-After`** instead of `503` — for OpenRouter this is a clean transient failover rather than an "unhealthy endpoint" signal. Applied in **both** `handleChatCompletions` and the generic `/v1/completions` + `/v1/messages` path. A genuinely-absent model still `503`s (guarded by `IsDedicatedModel(model) && HasProviderForModel(model, serials...)`).

## Config & rollout

- `EIGENINFERENCE_DEDICATED_MODELS` — comma-separated, case-insensitive substring patterns. **Unset → default `gemma-4` (ON)**; set to `none`/empty → disabled.
- The registry field defaults nil (OFF), so unit tests and the e2e testbed (both build via `registry.New`) are unaffected — the rule only activates via `cmd/coordinator/main.go` at startup.

> [!IMPORTANT]
> **Default is ON.** Once deployed, if the fleet has no Gemma-4-only boxes, all Gemma 4 traffic sheds to OpenRouter (429). Ensure dedicated machines exist (operationally: only Gemma 4 downloaded on them) or set `EIGENINFERENCE_DEDICATED_MODELS=none`. Coordinator deploy is human-only.

## Testing

- New: 15 registry tests (parse, predicate, routing-selects-only-dedicated, never-falls-back-to-mixed, preflight shed counts only dedicated boxes, self-route exempt, default-off, warm-pool/swap/warm-detection gating) + a real-HTTP test asserting **429 + Retry-After** for both `/v1/chat/completions` and `/v1/completions`, with a 503 control for a truly-absent model. Tests fail without the change; baselines confirm the dedicated rule is the differentiator.
- `go build ./...`, linux cross-compile, and the **full coordinator suite** pass; `gofmt` clean.

## Known follow-ups (non-blocking, cosmetic)

- `ModelCapacitySnapshot` / `/v1/models` / the OpenRouter feed are display-only and left ungated, so they over-report Gemma 4 capacity by counting mixed boxes. No routing/admission impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
