### PR TITLE
DAR-345: one active model per machine via coordinator model pools

### DIFF
--- a/coordinator/api/admin_utilization.go
+++ b/coordinator/api/admin_utilization.go
@@ -1,6 +1,10 @@
 package api
 
-import "net/http"
+import (
+	"net/http"
+
+	"github.com/eigeninference/d-inference/coordinator/registry"
+)
 
 // handleAdminUtilization serves GET /v1/admin/utilization: the full
 // network-utilization snapshot (demand/capacity across the warm-serving and
@@ -10,5 +14,15 @@ func (s *Server) handleAdminUtilization(w http.ResponseWriter, r *http.Request) 
 	if !s.requireAdminKey(w, r) {
 		return
 	}
-	writeJSON(w, http.StatusOK, s.registry.NetworkUtilizationSnapshot())
+	type utilizationResponse struct {
+		registry.NetworkUtilization
+		// ModelPools is the DAR-345 pool/assignment + co-residency audit, surfaced
+		// alongside the demand/capacity snapshot so admins can answer pool sizes,
+		// who-serves-what, and co-residency in one call.
+		ModelPools registry.ModelPoolReport `json:"model_pools"`
+	}
+	writeJSON(w, http.StatusOK, utilizationResponse{
+		NetworkUtilization: s.registry.NetworkUtilizationSnapshot(),
+		ModelPools:         s.registry.ModelPoolReport(),
+	})
 }

--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -149,6 +149,64 @@ func (s *Server) shedIfModelRejected(w http.ResponseWriter, r *http.Request, par
 	return true
 }
 
+// shedIfPoolExhausted answers a public/prefer-owner request with an
+// uptime-neutral 429 + Retry-After when its model is a managed pool (DAR-345)
+// that currently has no machine assigned-and-serving it, while the fleet does
+// have machines that could serve it. This is the no-spillover admission decision:
+// rather than queue against zero in-pool machines (or 503 because the isolation
+// gate filtered every provider), shed cleanly — the placement controller grows
+// the pool on its next tick. A pool that has serving machines but is merely
+// saturated is left to the normal capacity/queue path. Exclusive self-route
+// bypasses the shed (it never falls back to the public fleet and bypasses the
+// isolation gate). No-op when the assignment gate is disabled.
+func (s *Server) shedIfPoolExhausted(w http.ResponseWriter, r *http.Request, parsed map[string]any, policy selfRoutePolicy, publicModel, model string, stream bool, estimatedPromptTokens, requestedMaxTokens int, requiresVision, hasTools bool) bool {
+	if policy.enabled || s.registry == nil {
+		return false
+	}
+	exhausted, catalogCapable := s.registry.PoolExhausted(model)
+	if !exhausted {
+		return false
+	}
+	retryAfter := s.estimateRetryAfter(model)
+	if retryAfter < 10 {
+		// Floor above a cold-load (~10-30s): the pool must warm a machine before
+		// it can serve, so a 2s retry would only restorm. Uptime-neutral either
+		// way — an aggregator fails over on the first 429.
+		retryAfter = 10
+	}
+	s.ddIncr("routing.decisions", []string{"model:" + model, "model_type:" + s.registry.ModelType(model), "outcome:pool_exhausted"})
+	s.recordRejection(rejectionInfo{
+		r:                     r,
+		stage:                 "preflight_capacity",
+		reasonCode:            "pool_exhausted",
+		httpStatus:            http.StatusTooManyRequests,
+		keyID:                 keyIDFromContext(r.Context()),
+		consumerKeyHash:       store.HashKey(consumerKeyFromContext(r.Context())),
+		requestedModel:        publicModel,
+		resolvedModel:         model,
+		stream:                stream,
+		estimatedPromptTokens: estimatedPromptTokens,
+		requestedMaxTokens:    requestedMaxTokens,
+		requiresVision:        requiresVision,
+		hasTools:              hasTools,
+		selfRouteOnly:         policy.enabled,
+		preferOwner:           policy.prefer,
+		retryAfterMs:          retryAfter * 1000,
+		params:                rejectionSamplingParams(parsed),
+		// The fleet HAS the model on catalogCapable machines — it just isn't in
+		// this pool right now — so the request could have been served. Mark it
+		// could-have-served (candidateCount>0) and skip the off-path recompute,
+		// which would see 0 gated candidates and wrongly flag it unservable.
+		servabilityComputed: true,
+		candidateCount:      catalogCapable,
+	})
+	w.Header().Set("Retry-After", strconv.Itoa(retryAfter))
+	writeJSON(w, http.StatusTooManyRequests, errorResponse("rate_limit_exceeded",
+		fmt.Sprintf("model %q is at capacity right now — retry after %ds", publicModel, retryAfter),
+		withCode("rate_limit_exceeded")))
+	return true
+}
+
 // sendProviderCancel sends a Cancel message for the given request to the
 // provider with a bounded timeout so a half-dead WebSocket doesn't hang the
 // caller. Errors are logged at debug level because a disconnect race is the
@@ -1793,6 +1851,9 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 	deadline := ttftDeadline(estimatedPromptTokens)
 	timing.ParsedAt = time.Now()
 	if s.shedIfModelRejected(w, r, parsed, policy, publicModel, model, stream, estimatedPromptTokens, requestedMaxTokens, requiresVision, hasTools) {
+		return
+	}
+	if s.shedIfPoolExhausted(w, r, parsed, policy, publicModel, model, stream, estimatedPromptTokens, requestedMaxTokens, requiresVision, hasTools) {
 		return
 	}
 
@@ -4715,6 +4776,9 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 	genericDeadline := ttftDeadline(estimatedPromptTokens)
 	timing.ParsedAt = time.Now()
 	if s.shedIfModelRejected(w, r, parsed, policy, publicModel, model, stream, estimatedPromptTokens, requestedMaxTokens, requiresVision, hasTools) {
+		return
+	}
+	if s.shedIfPoolExhausted(w, r, parsed, policy, publicModel, model, stream, estimatedPromptTokens, requestedMaxTokens, requiresVision, hasTools) {
 		return
 	}
 

--- a/coordinator/api/inference_failure_class.go
+++ b/coordinator/api/inference_failure_class.go
@@ -131,6 +131,13 @@ var capacityClassMarkers = []string{
 	// these markers match "model not loaded" / "is not loaded on this provider".
 	"not loaded",
 	"no model loaded",
+	// DAR-345 model-pool transitions: a managed provider mid-switch
+	// (protocol.ProviderSwitchingModel = "provider switching model") or refusing a
+	// non-assigned model ("… is not this machine's assigned pool model …"). The
+	// request didn't run, so failover/reroute is safe — must NOT count as a node
+	// fault against the per-provider breaker during the brief transition race.
+	"provider switching model",
+	"assigned pool model",
 }
 
 // faultClassMarkers are BUCKET B substrings: genuine server faults that MUST stay

--- a/coordinator/api/model_alias_handlers.go
+++ b/coordinator/api/model_alias_handlers.go
@@ -282,3 +282,18 @@ func (s *Server) providerSupportsDesiredModels(backend, version string) bool {
 	}
 	return !semverLess(version, minProviderVersionForDesiredModels)
 }
+
+// providerSupportsModelAssignment reports whether a provider can receive the
+// assign_model message (DAR-345 model pools): Swift backend, reported version
+// at or above minProviderVersionForModelAssignment. No version → too old
+// (fail-closed), so an un-upgraded provider is never pushed an assignment and
+// keeps its current multi-slot behavior.
+func (s *Server) providerSupportsModelAssignment(backend, version string) bool {
+	if !registry.BackendUsesSwiftRuntime(backend) {
+		return false
+	}
+	if version == "" {
+		return false
+	}
+	return !semverLess(version, minProviderVersionForModelAssignment)
+}

--- a/coordinator/api/pool_exhausted_test.go
+++ b/coordinator/api/pool_exhausted_test.go
@@ -1,0 +1,79 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+	"nhooyr.io/websocket"
+)
+
+// TestPoolExhaustedReturns429NoSpillover exercises the real HTTP path: with
+// model-pool isolation enabled (DAR-345), a request for a model whose pool has
+// no assigned-and-serving machine — even though a machine in the fleet has that
+// model on disk (assigned to a DIFFERENT model) — must get an uptime-neutral 429
+// rather than spilling onto the other pool's machine.
+func TestPoolExhaustedReturns429NoSpillover(t *testing.T) {
+	ts, reg := setupAdaptiveCapacityIntegration(t)
+	defer ts.Close()
+	t.Setenv(envColdDispatch, "false")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	const modelA, modelB = "pool-gptoss", "pool-gemma"
+	// One provider with BOTH models on disk (the "flexible" machine).
+	conn := connectProvider(t, ctx, ts.URL, []protocol.ModelInfo{
+		{ID: modelA, ModelType: "chat", Quantization: "4bit"},
+		{ID: modelB, ModelType: "chat", Quantization: "4bit"},
+	}, testPublicKeyB64())
+	defer conn.Close(websocket.StatusNormalClosure, "done")
+	p := markOnlyProviderRoutable(t, reg)
+
+	writeAdaptiveHeartbeat(t, ctx, conn, modelA, &protocol.BackendCapacity{
+		TotalMemoryGB: 64,
+		Slots: []protocol.BackendSlotCapacity{{
+			Model: modelA, State: "running", MaxConcurrency: 8, ActiveTokenBudgetMax: 100_000,
+		}},
+	})
+	waitForAdaptiveCondition(t, time.Second, func() bool {
+		p.Mu().Lock()
+		defer p.Mu().Unlock()
+		return p.BackendCapacity != nil
+	})
+
+	// Enable isolation and bind the only machine to pool A (serving).
+	reg.SetAssignmentGateEnabled(true)
+	epoch, _, err := reg.AssignProviderModel(p.ID, modelA)
+	if err != nil {
+		t.Fatalf("assign: %v", err)
+	}
+	reg.ApplyAssignModelStatus(p.ID, modelA, epoch, protocol.AssignModelStatusSucceeded)
+
+	// A request for model B: its pool is empty (the only machine is in pool A),
+	// but B is catalog-capable on that machine. Must be a clean 429 with
+	// Retry-After — NOT a spill onto the model-A machine, and NOT a 503.
+	status, body, err := adaptiveChatRequest(ctx, ts.URL, modelB, 64)
+	if err != nil {
+		t.Fatalf("request error: %v", err)
+	}
+	if status != http.StatusTooManyRequests {
+		t.Fatalf("model B status=%d body=%s, want 429 (pool_exhausted, no spillover)", status, body)
+	}
+
+	// Sanity: the registry verdict agrees the pool is exhausted and the fleet is
+	// catalog-capable (could-have-served), so the 429 is uptime-neutral.
+	exhausted, capable := reg.PoolExhausted(modelB)
+	if !exhausted || capable < 1 {
+		t.Fatalf("PoolExhausted(modelB)=%v,%d want true,>=1", exhausted, capable)
+	}
+
+	// With the kill switch off, the same request is no longer pool-shed (the
+	// isolation is fully reversible).
+	reg.SetAssignmentGateEnabled(false)
+	if ex, _ := reg.PoolExhausted(modelB); ex {
+		t.Fatal("disabling the gate must drop pool_exhausted")
+	}
+}

--- a/coordinator/api/provider.go
+++ b/coordinator/api/provider.go
@@ -476,6 +476,34 @@ func (s *Server) providerReadLoop(ctx context.Context, conn *websocket.Conn, pro
 			}
 			// "started" status: no action — load is in progress.
 
+		case protocol.TypeAssignModelStatus:
+			statusMsg := msg.Payload.(*protocol.AssignModelStatusMessage)
+			s.logger.Info("provider assign_model_status",
+				"provider_id", providerID,
+				"model_id", statusMsg.ModelID,
+				"epoch", statusMsg.Epoch,
+				"status", statusMsg.Status,
+				"error", statusMsg.Error,
+			)
+			// Epoch-guarded apply: a stale ack (superseded epoch / wrong model) is
+			// ignored. On succeeded the machine is warm + serving its assigned pool
+			// model — mark it warm, release the pending-load reservation, and drain
+			// any queued requests. On failed, ApplyAssignModelStatus already set
+			// AssignmentStateFailed + armed the dispatch-load cooldown; clear the
+			// reservation so the placement controller reconsiders after the cooldown.
+			if s.registry.ApplyAssignModelStatus(providerID, statusMsg.ModelID, statusMsg.Epoch, statusMsg.Status) {
+				switch statusMsg.Status {
+				case protocol.AssignModelStatusSucceeded:
+					s.registry.MarkModelWarm(providerID, statusMsg.ModelID)
+					s.registry.ClearPendingModelLoad(providerID, statusMsg.ModelID)
+					s.registry.DrainQueuedRequestsForModel(statusMsg.ModelID)
+					s.ddIncr("routing.model_assignment", []string{"model:" + statusMsg.ModelID, "outcome:assigned"})
+				case protocol.AssignModelStatusFailed:
+					s.registry.ClearPendingModelLoad(providerID, statusMsg.ModelID)
+					s.ddIncr("routing.model_assignment", []string{"model:" + statusMsg.ModelID, "outcome:failed"})
+				}
+			}
+
 		case protocol.TypeModelsUpdate:
 			updateMsg := msg.Payload.(*protocol.ModelsUpdateMessage)
 			s.handleModelsUpdate(providerID, provider, updateMsg)

--- a/coordinator/api/server.go
+++ b/coordinator/api/server.go
@@ -154,6 +154,13 @@ var LatestProviderVersion = "0.6.11"
 // desired_models support (ProviderCore.version at that cut).
 const minProviderVersionForDesiredModels = "0.5.17"
 
+// minProviderVersionForModelAssignment is the floor for the DAR-345 assign_model
+// push (one-model-per-machine pools). Same fail-closed rationale as
+// minProviderVersionForDesiredModels: a pre-feature provider's strict decoder
+// throws on the unknown assign_model type. KEEP THIS IN SYNC with the release
+// that ships Swift assign_model support (ProviderCore.version at that cut).
+const minProviderVersionForModelAssignment = "0.6.18"
+
 // latestReleasedVersion returns the highest active release version from
 // the store, falling back to the hardcoded LatestProviderVersion when
 // no release record exists.
@@ -703,6 +710,12 @@ func NewServer(reg *registry.Registry, st store.Store, cfg ServerConfig, logger 
 	}
 	s.registerDefaultGauges()
 	s.routes()
+
+	// DAR-345: gate which providers the placement controller may bind to a pool
+	// on the same backend+version rule used for the assign_model push, so a
+	// pre-feature provider (whose strict decoder would throw on assign_model)
+	// stays unmanaged.
+	reg.SetManageableProviderFunc(s.providerSupportsModelAssignment)
 
 	// Load stored provider records into a lookup table for matching
 	// reconnecting providers to their persisted state.

--- a/coordinator/cmd/coordinator/main.go
+++ b/coordinator/cmd/coordinator/main.go
@@ -191,6 +191,17 @@ func main() {
 	if cfg.RegistryCfg.WarmPool.Enabled {
 		logger.Info("warm-pool controller enabled", "observe_only", cfg.RegistryCfg.WarmPool.ObserveOnly, "interval", cfg.RegistryCfg.WarmPool.Interval.String())
 	}
+	// DAR-345 model pools: enable the routing isolation gate + pool_exhausted 429
+	// admission, and surface whether the placement controller is computing
+	// (shadow) or enforcing (pushing assign_model). All default-off.
+	reg.SetAssignmentGateEnabled(cfg.RegistryCfg.WarmPool.AssignmentGateEnabled)
+	if cfg.RegistryCfg.WarmPool.AssignmentGateEnabled || cfg.RegistryCfg.WarmPool.PlacementEnabled {
+		logger.Info("model-pool placement",
+			"assignment_gate", cfg.RegistryCfg.WarmPool.AssignmentGateEnabled,
+			"placement_enabled", cfg.RegistryCfg.WarmPool.PlacementEnabled,
+			"placement_enforce", cfg.RegistryCfg.WarmPool.PlacementEnforce,
+		)
+	}
 
 	srv := api.NewServer(reg, st, cfg.ServerConfig, logger)
 	// Stop the routing-telemetry sink's worker pool on shutdown. Deferred so it

--- a/coordinator/protocol/messages.go
+++ b/coordinator/protocol/messages.go
@@ -43,6 +43,9 @@ const (
 	TypeLoadModelStatus         = "load_model_status"
 	TypePrefetchModelStatus     = "prefetch_model_status"
 	TypeModelsUpdate            = "models_update"
+	// TypeAssignModelStatus is the provider's reply to an AssignModelMessage,
+	// reporting the per-model pool-assignment lifecycle (DAR-345).
+	TypeAssignModelStatus = "assign_model_status"
 
 	// Coordinator → Provider.
 	TypeInferenceRequest     = "inference_request"
@@ -53,6 +56,11 @@ const (
 	TypePrefetchModel        = "prefetch_model"
 	TypeDesiredModels        = "desired_models"
 	TypeTrustStatus          = "trust_status"
+	// TypeAssignModel binds a managed provider to exactly one public model
+	// (DAR-345 model pools): drain the current model, unload every other
+	// resident model, then load+warm the assigned one. Distinct from
+	// TypeLoadModel (additive warm, no exclusivity).
+	TypeAssignModel = "assign_model"
 )
 
 // LoadModelStatus is the lifecycle state reported by a provider in response
@@ -71,6 +79,26 @@ const (
 // the full cooldown. Mirrored in
 // provider-swift/Sources/ProviderCore/Protocol/Types.swift.
 const ProviderDrainingForUpdate = "provider draining for update"
+
+// AssignModelStatus is the lifecycle a provider reports while reconciling an
+// AssignModelMessage (DAR-345). The provider walks draining → loading →
+// succeeded (warm + servable) or failed. Distinct from LoadModelStatus*: an
+// assignment includes draining in-flight work and unloading every other model.
+const (
+	AssignModelStatusDraining  = "draining"
+	AssignModelStatusLoading   = "loading"
+	AssignModelStatusSucceeded = "succeeded"
+	AssignModelStatusFailed    = "failed"
+)
+
+// ProviderSwitchingModel is the well-known transient error reason a managed
+// provider attaches to inference / load_model rejections while it is draining
+// + swapping to a newly-assigned pool model (DAR-345). Mirrors
+// ProviderDrainingForUpdate: the coordinator matches this exact string to treat
+// the rejection as a brief transition (short reroute/backoff), not a genuine
+// failure earning the full cooldown. Mirrored in
+// provider-swift/Sources/ProviderCore/Protocol/Types.swift.
+const ProviderSwitchingModel = "provider switching model"
 
 // PrefetchModelStatus is the lifecycle state reported by a provider in
 // response to a PrefetchModelMessage. Unlike a load, a prefetch only
@@ -385,6 +413,34 @@ type LoadModelStatusMessage struct {
 	Error   string `json:"error,omitempty"`
 }
 
+// AssignModelMessage binds a managed provider to a single public model (DAR-345
+// model pools). On receipt the provider drains in-flight work, unloads every
+// resident model that is not ModelID, then loads + warms ModelID, refusing to
+// opportunistically load any other model while the assignment stands. Epoch is a
+// monotonic per-provider generation: the provider ignores an assignment whose
+// epoch is older than one it has already applied, and echoes Epoch in its
+// AssignModelStatusMessage so the coordinator can discard stale acks.
+//
+// Sent only to Swift-runtime providers at or above the assign-model feature
+// version (a pre-feature provider's strict decoder throws on unknown types).
+type AssignModelMessage struct {
+	Type    string `json:"type"`
+	ModelID string `json:"model_id"`
+	Epoch   uint64 `json:"epoch"`
+}
+
+// AssignModelStatusMessage is the provider's reply to an AssignModelMessage.
+// Status is one of AssignModelStatus{Draining,Loading,Succeeded,Failed}. Epoch
+// echoes the assignment generation the provider is acting on. On failure, Error
+// carries a human-readable reason (e.g. "GPU OOM", "model not in local cache").
+type AssignModelStatusMessage struct {
+	Type    string `json:"type"`
+	ModelID string `json:"model_id"`
+	Epoch   uint64 `json:"epoch"`
+	Status  string `json:"status"`
+	Error   string `json:"error,omitempty"`
+}
+
 // PrefetchModelMessage instructs a provider to download AND verify a model
 // build in the background WITHOUT loading it into GPU memory and without
 // disrupting whatever model it is currently serving. It is the transport
@@ -625,6 +681,13 @@ func (pm *ProviderMessage) UnmarshalJSON(data []byte) error {
 		var msg LoadModelStatusMessage
 		if err := json.Unmarshal(data, &msg); err != nil {
 			return fmt.Errorf("protocol: failed to unmarshal load_model_status: %w", err)
+		}
+		pm.Payload = &msg
+
+	case TypeAssignModelStatus:
+		var msg AssignModelStatusMessage
+		if err := json.Unmarshal(data, &msg); err != nil {
+			return fmt.Errorf("protocol: failed to unmarshal assign_model_status: %w", err)
 		}
 		pm.Payload = &msg
 

--- a/coordinator/registry/assignment_test.go
+++ b/coordinator/registry/assignment_test.go
@@ -1,0 +1,301 @@
+package registry
+
+import (
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+)
+
+// addAssignableProvider inserts a minimal online provider for assignment tests.
+func addAssignableProvider(r *Registry, id string) {
+	r.mu.Lock()
+	r.providers[id] = &Provider{ID: id, Status: StatusOnline}
+	r.mu.Unlock()
+}
+
+func assignmentState(t *testing.T, r *Registry, id string) ProviderAssignment {
+	t.Helper()
+	snap, ok := r.ProviderAssignmentSnapshot(id)
+	if !ok {
+		t.Fatalf("provider %q not found for assignment snapshot", id)
+	}
+	return snap
+}
+
+func TestAssignProviderModelBumpsEpochAndState(t *testing.T) {
+	r := New(testLogger())
+	addAssignableProvider(r, "p1")
+
+	epoch, changed, err := r.AssignProviderModel("p1", "gpt-oss-20b")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !changed || epoch != 1 {
+		t.Fatalf("first assign: changed=%v epoch=%d, want true/1", changed, epoch)
+	}
+	snap := assignmentState(t, r, "p1")
+	if snap.Model != "gpt-oss-20b" || snap.State != AssignmentStateLoading {
+		t.Fatalf("snapshot=%+v, want model=gpt-oss-20b state=loading", snap)
+	}
+	if snap.AssignedAt.IsZero() {
+		t.Fatal("AssignedAt not stamped")
+	}
+
+	// A switch to a different model bumps the epoch again.
+	epoch2, changed2, _ := r.AssignProviderModel("p1", "gemma-4-26b")
+	if !changed2 || epoch2 != 2 {
+		t.Fatalf("switch assign: changed=%v epoch=%d, want true/2", changed2, epoch2)
+	}
+}
+
+func TestAssignProviderModelIdempotentWhenAlreadyServing(t *testing.T) {
+	r := New(testLogger())
+	addAssignableProvider(r, "p1")
+
+	epoch, _, _ := r.AssignProviderModel("p1", "gpt-oss-20b")
+	// Provider confirms it is warm and serving.
+	if !r.ApplyAssignModelStatus("p1", "gpt-oss-20b", epoch, protocol.AssignModelStatusSucceeded) {
+		t.Fatal("succeeded status not applied")
+	}
+	if got := assignmentState(t, r, "p1").State; got != AssignmentStateAssigned {
+		t.Fatalf("state=%q, want assigned", got)
+	}
+
+	// Re-assigning the same, already-serving model is a no-op: no epoch bump,
+	// so the caller skips a redundant assign_model push.
+	epoch2, changed, _ := r.AssignProviderModel("p1", "gpt-oss-20b")
+	if changed || epoch2 != epoch {
+		t.Fatalf("redundant assign: changed=%v epoch=%d, want false/%d", changed, epoch2, epoch)
+	}
+}
+
+func TestApplyAssignModelStatusEpochGuard(t *testing.T) {
+	r := New(testLogger())
+	addAssignableProvider(r, "p1")
+
+	// Assign twice → current epoch is 2.
+	r.AssignProviderModel("p1", "gpt-oss-20b")
+	epoch2, _, _ := r.AssignProviderModel("p1", "gemma-4-26b")
+
+	// A stale ack from the superseded epoch-1 assignment is ignored.
+	if r.ApplyAssignModelStatus("p1", "gpt-oss-20b", 1, protocol.AssignModelStatusSucceeded) {
+		t.Fatal("stale-epoch status was applied")
+	}
+	// A status for the wrong model is ignored.
+	if r.ApplyAssignModelStatus("p1", "whisper", epoch2, protocol.AssignModelStatusSucceeded) {
+		t.Fatal("wrong-model status was applied")
+	}
+	// The current-epoch ack lands.
+	if !r.ApplyAssignModelStatus("p1", "gemma-4-26b", epoch2, protocol.AssignModelStatusDraining) {
+		t.Fatal("current-epoch draining status not applied")
+	}
+	if got := assignmentState(t, r, "p1").State; got != AssignmentStateDraining {
+		t.Fatalf("state=%q, want draining", got)
+	}
+}
+
+func TestApplyAssignModelStatusFailedArmsCooldownAndStaysIsolated(t *testing.T) {
+	r := New(testLogger())
+	addAssignableProvider(r, "p1")
+
+	epoch, _, _ := r.AssignProviderModel("p1", "gemma-4-26b")
+	if !r.ApplyAssignModelStatus("p1", "gemma-4-26b", epoch, protocol.AssignModelStatusFailed) {
+		t.Fatal("failed status not applied")
+	}
+
+	snap := assignmentState(t, r, "p1")
+	// Still bound to the model (no spillover) but not routing-eligible.
+	if snap.Model != "gemma-4-26b" || snap.State != AssignmentStateFailed {
+		t.Fatalf("snapshot=%+v, want model=gemma-4-26b state=failed", snap)
+	}
+	// The (provider,model) dispatch-load cooldown is armed.
+	r.mu.RLock()
+	active := r.dispatchLoadCooldownActiveLocked("p1", "gemma-4-26b", time.Now())
+	r.mu.RUnlock()
+	if !active {
+		t.Fatal("failed assignment did not arm the dispatch-load cooldown")
+	}
+}
+
+// registerProviderWithModels registers a routable-ready provider advertising
+// several catalog models, so assignment-gate isolation can be tested
+// independently of the catalog-membership gate.
+func registerProviderWithModels(reg *Registry, id string, modelIDs ...string) *Provider {
+	msg := testRegisterMessage()
+	msg.Models = nil
+	for _, m := range modelIDs {
+		msg.Models = append(msg.Models, protocol.ModelInfo{ID: m, SizeBytes: 5_000_000_000, ModelType: "gemma", Quantization: "4bit"})
+	}
+	p := reg.Register(id, nil, msg)
+	makeProviderRoutable(p)
+	return p
+}
+
+func TestAssignmentGateIsolatesPools(t *testing.T) {
+	reg := New(testLogger())
+	const mA, mB = "model-a", "model-b"
+	p := registerProviderWithModels(reg, "p1", mA, mB)
+	now := time.Now()
+
+	// Gate disabled (default): an unmanaged provider serves both models.
+	if !reg.providerPassesRoutingGatesLockedEx(p, mA, RequestTraits{}, false, now, false) ||
+		!reg.providerPassesRoutingGatesLockedEx(p, mB, RequestTraits{}, false, now, false) {
+		t.Fatal("unmanaged provider should serve both catalog models")
+	}
+
+	// Enable isolation + assign to A (live/serving).
+	reg.SetAssignmentGateEnabled(true)
+	epoch, _, _ := reg.AssignProviderModel("p1", mA)
+	reg.ApplyAssignModelStatus("p1", mA, epoch, protocol.AssignModelStatusSucceeded)
+
+	if !reg.providerPassesRoutingGatesLockedEx(p, mA, RequestTraits{}, false, now, false) {
+		t.Fatal("assigned provider should serve its model A")
+	}
+	if reg.providerPassesRoutingGatesLockedEx(p, mB, RequestTraits{}, false, now, false) {
+		t.Fatal("assigned provider must NOT serve model B (no spillover)")
+	}
+	// Self-route owner bypasses the gate (never filtered into no-candidate).
+	if !reg.providerPassesRoutingGatesLockedEx(p, mB, RequestTraits{}, true, now, false) {
+		t.Fatal("self-route owner should bypass the assignment gate")
+	}
+	// Kill switch off → no restriction again.
+	reg.SetAssignmentGateEnabled(false)
+	if !reg.providerPassesRoutingGatesLockedEx(p, mB, RequestTraits{}, false, now, false) {
+		t.Fatal("disabling the gate should drop pool isolation")
+	}
+}
+
+func TestAssignmentGateExcludesMidTransition(t *testing.T) {
+	reg := New(testLogger())
+	const mA = "model-a"
+	p := registerProviderWithModels(reg, "p1", mA)
+	reg.SetAssignmentGateEnabled(true)
+	now := time.Now()
+
+	// Loading (assigned but not yet warm) → excluded from routing.
+	epoch, _, _ := reg.AssignProviderModel("p1", mA)
+	if reg.providerPassesRoutingGatesLockedEx(p, mA, RequestTraits{}, false, now, false) {
+		t.Fatal("provider mid-load must not be routing-eligible")
+	}
+	// Once it confirms warm → eligible.
+	reg.ApplyAssignModelStatus("p1", mA, epoch, protocol.AssignModelStatusSucceeded)
+	if !reg.providerPassesRoutingGatesLockedEx(p, mA, RequestTraits{}, false, now, false) {
+		t.Fatal("provider should be eligible once the assignment succeeds")
+	}
+}
+
+func TestPoolExhausted(t *testing.T) {
+	reg := New(testLogger())
+	const mA, mB = "model-a", "model-b"
+
+	// Gate off: never exhausted (no enforcement).
+	p1 := registerProviderWithModels(reg, "p1", mA, mB)
+	if ex, _ := reg.PoolExhausted(mA); ex {
+		t.Fatal("gate disabled must report not-exhausted")
+	}
+
+	reg.SetAssignmentGateEnabled(true)
+
+	// p1 (has both on disk) is assigned to A and serving. Pool A has a serving
+	// machine → not exhausted. Pool B has zero serving but is catalog-capable on
+	// p1 → exhausted.
+	epoch, _, _ := reg.AssignProviderModel("p1", mA)
+	reg.ApplyAssignModelStatus("p1", mA, epoch, protocol.AssignModelStatusSucceeded)
+
+	if ex, _ := reg.PoolExhausted(mA); ex {
+		t.Fatal("pool A has a serving machine; must not be exhausted")
+	}
+	exB, capable := reg.PoolExhausted(mB)
+	if !exB || capable < 1 {
+		t.Fatalf("pool B exhausted=%v catalogCapable=%d, want true/>=1", exB, capable)
+	}
+
+	// A model no provider has on disk is NOT pool_exhausted (a different
+	// rejection — model_not_found / no_provider).
+	if ex, _ := reg.PoolExhausted("model-c"); ex {
+		t.Fatal("model with no catalog-capable provider must not be pool_exhausted")
+	}
+
+	// Once a machine is assigned+serving B, pool B is no longer exhausted.
+	_ = p1
+	epochB, _, _ := reg.AssignProviderModel("p1", mB)
+	reg.ApplyAssignModelStatus("p1", mB, epochB, protocol.AssignModelStatusSucceeded)
+	if ex, _ := reg.PoolExhausted(mB); ex {
+		t.Fatal("pool B now has a serving machine; must not be exhausted")
+	}
+}
+
+// TestPoolExhaustedMixedFleetNoFalsePositive guards the rollout case (review
+// finding #1): an UNMANAGED machine that serves the model is routing-eligible,
+// so the pool is NOT exhausted even when no managed machine is assigned it.
+func TestPoolExhaustedMixedFleetNoFalsePositive(t *testing.T) {
+	reg := New(testLogger())
+	reg.SetAssignmentGateEnabled(true)
+	const mA, mB = "model-a", "model-b"
+
+	// p1 managed → assigned + serving A. p2 left UNMANAGED, serving both.
+	p1 := registerProviderWithModels(reg, "p1", mA, mB)
+	_ = registerProviderWithModels(reg, "p2", mA, mB)
+	epoch, _, _ := reg.AssignProviderModel(p1.ID, mA)
+	reg.ApplyAssignModelStatus(p1.ID, mA, epoch, protocol.AssignModelStatusSucceeded)
+
+	// Pool B has no MANAGED machine, but the unmanaged p2 serves it and the gate
+	// would route there → NOT exhausted (no false 429).
+	if ex, _ := reg.PoolExhausted(mB); ex {
+		t.Fatal("unmanaged machine serving B must make pool B not-exhausted")
+	}
+
+	// Now manage p2 too, assigned to A → no eligible machine for B → exhausted.
+	epoch2, _, _ := reg.AssignProviderModel("p2", mA)
+	reg.ApplyAssignModelStatus("p2", mA, epoch2, protocol.AssignModelStatusSucceeded)
+	if ex, _ := reg.PoolExhausted(mB); !ex {
+		t.Fatal("with both machines managed onto A, pool B must be exhausted")
+	}
+}
+
+func TestModelPoolReport(t *testing.T) {
+	reg := New(testLogger())
+	reg.SetAssignmentGateEnabled(true)
+	const mA, mB = "model-a", "model-b"
+
+	// p1 managed → assigned A. p2 unmanaged but holding TWO warm models (the
+	// co-residency the pools are meant to eliminate).
+	p1 := registerProviderWithModels(reg, "p1", mA, mB)
+	epoch, _, _ := reg.AssignProviderModel(p1.ID, mA)
+	reg.ApplyAssignModelStatus(p1.ID, mA, epoch, protocol.AssignModelStatusSucceeded)
+	p2 := registerProviderWithModels(reg, "p2", mA, mB)
+	p2.mu.Lock()
+	p2.WarmModels = []string{mA, mB}
+	p2.mu.Unlock()
+
+	rep := reg.ModelPoolReport()
+	if !rep.GateEnabled {
+		t.Fatal("report should reflect the enabled gate")
+	}
+	if rep.ManagedProviders != 1 {
+		t.Fatalf("ManagedProviders=%d, want 1", rep.ManagedProviders)
+	}
+	if rep.CoResidentProviders != 1 {
+		t.Fatalf("CoResidentProviders=%d, want 1 (p2 holds 2 warm models)", rep.CoResidentProviders)
+	}
+	if len(rep.Providers) != 2 {
+		t.Fatalf("expected 2 provider entries, got %d", len(rep.Providers))
+	}
+}
+
+func TestSendAssignModelUsesSenderSeam(t *testing.T) {
+	r := New(testLogger())
+	var gotProvider, gotModel string
+	var gotEpoch uint64
+	r.assignModelSender = func(providerID, modelID string, epoch uint64) error {
+		gotProvider, gotModel, gotEpoch = providerID, modelID, epoch
+		return nil
+	}
+	if err := r.SendAssignModel("p1", "gpt-oss-20b", 7); err != nil {
+		t.Fatalf("SendAssignModel: %v", err)
+	}
+	if gotProvider != "p1" || gotModel != "gpt-oss-20b" || gotEpoch != 7 {
+		t.Fatalf("seam saw provider=%q model=%q epoch=%d", gotProvider, gotModel, gotEpoch)
+	}
+}

--- a/coordinator/registry/config.go
+++ b/coordinator/registry/config.go
@@ -65,6 +65,23 @@ type WarmPoolConfig struct {
 	MaxLoadsPerTickCeiling int
 	RampGapFraction        float64
 	MaxGlobalPendingLoads  int
+
+	// Placement controller (DAR-345 one-model-per-machine). PlacementEnabled runs
+	// the allocator each tick (computes the desired model→machine assignment and
+	// emits metrics/logs). PlacementEnforce additionally PUSHES assign_model to
+	// switch machines between pools (else shadow/observe-only). ModelPriority
+	// orders pools when demand exceeds the fleet (higher wins; default 0). The
+	// allocator reuses MinDwell (per-machine hold), MinWarmByModel (per-pool
+	// floor), MaxGlobalPendingLoads + MaxLoadsPerTick (switch budget) as its
+	// anti-thrash knobs.
+	PlacementEnabled bool
+	PlacementEnforce bool
+	ModelPriority    map[string]int
+
+	// AssignmentGateEnabled turns on the routing-layer isolation gate + the
+	// pool_exhausted 429 admission (DAR-345 stage 3/4). Independent of the
+	// placement controller so enforcement can be a separate, reversible switch.
+	AssignmentGateEnabled bool
 }
 
 // perTickCeiling is the hard per-tick load cap after demand scaling. It is the
@@ -110,6 +127,11 @@ func ReadConfig() Config {
 			MaxLoadsPerTickCeiling: env.EnvInt(env.EnvPrefix+"_WARM_POOL_MAX_LOADS_PER_TICK_CEILING", 16),
 			RampGapFraction:        env.EnvFloat(env.EnvPrefix+"_WARM_POOL_RAMP_GAP_FRACTION", 0.5),
 			MaxGlobalPendingLoads:  env.EnvInt(env.EnvPrefix+"_WARM_POOL_MAX_GLOBAL_PENDING_LOADS", 16),
+
+			PlacementEnabled:      env.EnvBool(env.EnvPrefix+"_WARM_POOL_PLACEMENT_ENABLED", false),
+			PlacementEnforce:      env.EnvBool(env.EnvPrefix+"_WARM_POOL_PLACEMENT_ENFORCE", false),
+			ModelPriority:         envModelIntMap(env.EnvPrefix + "_WARM_POOL_MODEL_PRIORITY"),
+			AssignmentGateEnabled: env.EnvBool(env.EnvPrefix+"_WARM_POOL_ASSIGNMENT_GATE", false),
 		},
 		CacheAffinity: CacheAffinityConfig{
 			TTL:     envDuration(env.EnvPrefix+"_CACHE_AFFINITY_TTL", cacheAffinityTTL),

--- a/coordinator/registry/model_pool_report.go
+++ b/coordinator/registry/model_pool_report.go
@@ -1,0 +1,76 @@
+package registry
+
+import "time"
+
+// ProviderPoolEntry is one machine's pool assignment for the admin report.
+type ProviderPoolEntry struct {
+	ProviderID    string   `json:"provider_id"`
+	AssignedModel string   `json:"assigned_model"`
+	State         string   `json:"state"` // "" (unmanaged) | assigned | draining | loading | failed
+	AgeSecs       float64  `json:"age_secs"`
+	WarmModels    []string `json:"warm_models"`
+}
+
+// ModelPoolReport is the DAR-345 observability snapshot: who is assigned what,
+// the placement plan (desired vs current pool sizes + last switch count), and
+// the co-residency audit (machines holding >1 warm model — should trend to 0
+// once pools are enforced). Powers GET /v1/admin/utilization.
+type ModelPoolReport struct {
+	GateEnabled         bool                `json:"gate_enabled"`
+	PlacementEnabled    bool                `json:"placement_enabled"`
+	PlacementEnforce    bool                `json:"placement_enforce"`
+	Desired             map[string]int      `json:"desired"`
+	Current             map[string]int      `json:"current"`
+	LastSwitches        int                 `json:"last_switches"`
+	ManagedProviders    int                 `json:"managed_providers"`
+	CoResidentProviders int                 `json:"co_resident_providers"`
+	Providers           []ProviderPoolEntry `json:"providers"`
+}
+
+// ModelPoolReport assembles the current pool-assignment + co-residency view.
+func (r *Registry) ModelPoolReport() ModelPoolReport {
+	report := ModelPoolReport{
+		GateEnabled: r.assignmentGateEnabled.Load(),
+		Desired:     map[string]int{},
+		Current:     map[string]int{},
+	}
+	if plan, ok := r.LatestPlacementSnapshot(); ok {
+		report.Desired = plan.Desired
+		report.Current = plan.Current
+		report.LastSwitches = plan.Switches
+	}
+
+	now := time.Now()
+	r.mu.RLock()
+	if r.warmPool != nil {
+		report.PlacementEnabled = r.warmPool.config.PlacementEnabled
+		report.PlacementEnforce = r.warmPool.config.PlacementEnforce
+	}
+	report.Providers = make([]ProviderPoolEntry, 0, len(r.providers))
+	for id, p := range r.providers {
+		p.mu.Lock()
+		if p.Status == StatusOffline {
+			p.mu.Unlock()
+			continue
+		}
+		entry := ProviderPoolEntry{
+			ProviderID:    id,
+			AssignedModel: p.AssignedModel,
+			State:         p.AssignmentState,
+			WarmModels:    append([]string(nil), p.WarmModels...),
+		}
+		if p.AssignedModel != "" {
+			report.ManagedProviders++
+			if !p.AssignedAt.IsZero() {
+				entry.AgeSecs = now.Sub(p.AssignedAt).Seconds()
+			}
+		}
+		if len(p.WarmModels) > 1 {
+			report.CoResidentProviders++
+		}
+		p.mu.Unlock()
+		report.Providers = append(report.Providers, entry)
+	}
+	r.mu.RUnlock()
+	return report
+}

--- a/coordinator/registry/placement_controller.go
+++ b/coordinator/registry/placement_controller.go
@@ -1,0 +1,385 @@
+package registry
+
+import (
+	"sort"
+	"time"
+)
+
+// Placement controller (DAR-345 one-model-per-machine). It turns the warm
+// pool's per-model demand targets into an exclusive model→machine assignment:
+// each managed machine holds exactly one public model, the fleet is partitioned
+// by demand (priority/floor/cap), and surplus machines are switched into
+// deficit pools — conservatively, reusing the warm pool's anti-thrash budget
+// (MinDwell per machine, MaxGlobalPendingLoads + MaxLoadsPerTick switch budget,
+// the per-(provider,model) dispatch-load cooldown). The allocator is a pure,
+// deterministic function (planPlacement) so it is fully unit-testable; the
+// builder/enforcer below are the only parts that touch live registry state.
+
+// placementModel is one pool's demand for the allocator.
+type placementModel struct {
+	model    string
+	need     int // desired machine count (Little's Law target this tick)
+	floor    int // operator minimum (MinWarmByModel)
+	priority int // higher wins when total demand exceeds the fleet
+}
+
+// placementMachine is one routable, managed-eligible machine.
+type placementMachine struct {
+	id         string
+	current    string             // currently assigned model ("" = unmanaged/unassigned)
+	assignedAt time.Time          // last assignment change (zero for never-assigned)
+	idle       bool               // no in-flight work — safe to switch without dropping requests
+	capable    map[string]float64 // model -> score for models this machine can hold (on disk + fits + not cooling down)
+}
+
+type placementAction struct {
+	machineID string
+	model     string
+}
+
+// placementPlan is the allocator output: the normalized desired assignment, the
+// observed current assignment, and the switches to apply this tick.
+type placementPlan struct {
+	desired map[string]int
+	current map[string]int
+	actions []placementAction
+}
+
+// planPlacement is the pure allocator. Given per-model demand and the current
+// machine assignment, it (1) normalizes desired machine counts to the fleet by
+// floor-then-priority, (2) diffs against current, and (3) greedily switches
+// idle, off-dwell, capable surplus/unmanaged machines into the highest-priority
+// deficit pools, bounded by switchBudget. Deterministic: ties break by model
+// name and machine id.
+func planPlacement(models []placementModel, machines []placementMachine, minDwell time.Duration, switchBudget int, now time.Time) placementPlan {
+	plan := placementPlan{desired: map[string]int{}, current: map[string]int{}}
+
+	// Current assignment, counted from the machines themselves (independent of
+	// whether the model still has demand — a machine on a now-undemanded model is
+	// surplus and releasable).
+	for _, m := range machines {
+		if m.current != "" {
+			plan.current[m.current]++
+		}
+	}
+
+	fleetSize := len(machines)
+	if fleetSize == 0 || switchBudget <= 0 {
+		return plan
+	}
+
+	// Stable priority order: higher priority first, then model name.
+	ordered := append([]placementModel(nil), models...)
+	sort.Slice(ordered, func(i, j int) bool {
+		if ordered[i].priority != ordered[j].priority {
+			return ordered[i].priority > ordered[j].priority
+		}
+		return ordered[i].model < ordered[j].model
+	})
+
+	// Normalize desired counts. Pass 1 reserves operator floors (so a low-priority
+	// pool with demand is never fully starved by a high-priority one); pass 2
+	// fills remaining capacity by demand, both in priority order, capped at the
+	// fleet size.
+	remaining := fleetSize
+	for _, m := range ordered {
+		f := m.floor
+		if f > remaining {
+			f = remaining
+		}
+		if f < 0 {
+			f = 0
+		}
+		plan.desired[m.model] = f
+		remaining -= f
+	}
+	for _, m := range ordered {
+		want := m.need
+		if want < m.floor {
+			want = m.floor // effective need is at least the floor
+		}
+		extra := want - plan.desired[m.model]
+		if extra > remaining {
+			extra = remaining
+		}
+		if extra > 0 {
+			plan.desired[m.model] += extra
+			remaining -= extra
+		}
+	}
+
+	// Deficit/surplus per model.
+	surplus := map[string]int{} // current - desired, only positive entries
+	for model, cur := range plan.current {
+		if d := cur - plan.desired[model]; d > 0 {
+			surplus[model] = d
+		}
+	}
+
+	// Track which machines we've already moved this tick.
+	used := map[string]bool{}
+
+	// A machine is an eligible SOURCE iff it is idle, past min-dwell (unmanaged
+	// machines have a zero assignedAt and are always past dwell), and either
+	// unmanaged or sitting in a surplus pool.
+	dwellOK := func(m placementMachine) bool {
+		if m.current == "" || m.assignedAt.IsZero() {
+			return true
+		}
+		return now.Sub(m.assignedAt) >= minDwell
+	}
+
+	// Fill deficits, highest-priority / largest-deficit first.
+	for _, m := range ordered {
+		for switchBudget > 0 {
+			deficit := plan.desired[m.model] - plan.current[m.model]
+			if deficit <= 0 {
+				break
+			}
+			best := -1
+			bestScore := -1.0
+			bestUnmanaged := false
+			for i, mach := range machines {
+				if used[mach.id] || mach.id == "" {
+					continue
+				}
+				if !mach.idle || !dwellOK(mach) {
+					continue
+				}
+				score, ok := mach.capable[m.model]
+				if !ok {
+					continue // can't hold this model (not on disk / won't fit / cooling down)
+				}
+				unmanaged := mach.current == ""
+				if !unmanaged && surplus[mach.current] <= 0 {
+					continue // its pool is not over-provisioned — don't yank it
+				}
+				// Prefer unmanaged sources (free capacity) over yanking a surplus
+				// machine; then prefer the higher-scoring (faster/larger) machine.
+				better := best < 0 ||
+					(unmanaged && !bestUnmanaged) ||
+					(unmanaged == bestUnmanaged && score > bestScore)
+				if better {
+					best, bestScore, bestUnmanaged = i, score, unmanaged
+				}
+			}
+			if best < 0 {
+				break // no eligible source for this deficit
+			}
+			mach := machines[best]
+			used[mach.id] = true
+			if mach.current != "" {
+				plan.current[mach.current]--
+				surplus[mach.current]--
+			}
+			plan.current[m.model]++
+			plan.actions = append(plan.actions, placementAction{machineID: mach.id, model: m.model})
+			switchBudget--
+		}
+	}
+	return plan
+}
+
+// buildPlacementInputs scans the live fleet into allocator inputs. Only online,
+// trusted, non-PrivateOnly, manageable (version-gated) machines are eligible to
+// be placed; PrivateOnly/owner machines and pre-feature providers stay unmanaged
+// (the routing gate leaves AssignedModel=="" machines unconstrained). demand is
+// the model→target-machine map from the warm-pool snapshots.
+func (r *Registry) buildPlacementInputs(demand map[string]int, now time.Time) ([]placementModel, []placementMachine) {
+	floors := map[string]int{}
+	priorities := map[string]int{}
+	if r.warmPool != nil {
+		floors = r.warmPool.config.MinWarmByModel
+		priorities = r.warmPool.config.ModelPriority
+	}
+
+	// The model universe: anything with demand, an operator floor, or a configured
+	// priority.
+	modelSet := map[string]struct{}{}
+	for m := range demand {
+		modelSet[m] = struct{}{}
+	}
+	for m := range floors {
+		modelSet[m] = struct{}{}
+	}
+	for m := range priorities {
+		modelSet[m] = struct{}{}
+	}
+	models := make([]placementModel, 0, len(modelSet))
+	for m := range modelSet {
+		models = append(models, placementModel{
+			model:    m,
+			need:     demand[m],
+			floor:    floors[m],
+			priority: priorities[m],
+		})
+	}
+
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	machines := make([]placementMachine, 0, len(r.providers))
+	for id, p := range r.providers {
+		p.mu.Lock()
+		eligible := p.Status != StatusOffline && p.Status != StatusUntrusted && !p.PrivateOnly && r.manageableLocked(p)
+		if !eligible {
+			p.mu.Unlock()
+			continue
+		}
+		idle := p.pendingCount() == 0 && !warmPoolBackendSlotBusyLocked(p)
+		capable := make(map[string]float64)
+		for m := range modelSet {
+			if !r.providerServesCatalogModelLocked(p, m) {
+				continue
+			}
+			if r.dispatchLoadCooldownActiveLocked(id, m, now) {
+				continue // just failed to load m here — don't reassign it
+			}
+			if !modelFitsHardware(r.catalogMinRAMGbLocked(m), r.catalogSizeGBLocked(m), float64(p.Hardware.MemoryGB)) {
+				continue
+			}
+			score := resolvedDecodeTPS(p)
+			if score <= 0 {
+				score = float64(p.Hardware.MemoryGB)
+			}
+			capable[m] = score
+		}
+		machines = append(machines, placementMachine{
+			id:         id,
+			current:    p.AssignedModel,
+			assignedAt: p.AssignedAt,
+			idle:       idle,
+			capable:    capable,
+		})
+		p.mu.Unlock()
+	}
+	return models, machines
+}
+
+// manageableLocked reports whether a provider may be bound to a pool. Defaults
+// permissive when no version gate is wired (tests); the api sets the gate to
+// providerSupportsModelAssignment so pre-feature providers stay unmanaged.
+// Caller holds p.mu.
+func (r *Registry) manageableLocked(p *Provider) bool {
+	if r.manageableProvider == nil {
+		return true
+	}
+	return r.manageableProvider(p.Backend, p.Version)
+}
+
+// SetManageableProviderFunc wires the version/backend gate the placement
+// controller uses to decide which providers may be assigned a pool. Set once at
+// startup. nil = permissive (test default).
+func (r *Registry) SetManageableProviderFunc(fn func(backend, version string) bool) {
+	r.mu.Lock()
+	r.manageableProvider = fn
+	r.mu.Unlock()
+}
+
+// runPlacement runs one placement pass off the warm-pool tick. In shadow mode
+// (PlacementEnforce=false or ObserveOnly) it only computes + records the plan;
+// when enforcing it reserves the shared pending-load budget and pushes
+// assign_model to switch machines between pools.
+func (c *warmPoolController) runPlacement(now time.Time, snapshots []WarmPoolSnapshot) {
+	if c == nil || c.registry == nil || !c.config.PlacementEnabled {
+		return
+	}
+	demand := make(map[string]int, len(snapshots))
+	for _, s := range snapshots {
+		demand[s.Model] = s.TargetWarm
+	}
+
+	// Switch budget shares the global pending-load reservation with warm loads
+	// (both reserve via pendingModelLoads), so a tick never moves more than a few
+	// machines and fleet capacity never dips.
+	budget := c.config.MaxLoadsPerTick
+	if budget <= 0 {
+		budget = 1
+	}
+	if rem := c.config.MaxGlobalPendingLoads - c.registry.pendingModelLoadCount(now); rem < budget {
+		budget = rem
+	}
+	if budget < 0 {
+		budget = 0
+	}
+
+	models, machines := c.registry.buildPlacementInputs(demand, now)
+	plan := planPlacement(models, machines, c.config.MinDwell, budget, now)
+	c.storePlacement(plan, now)
+
+	enforce := c.config.PlacementEnforce && !c.config.ObserveOnly
+	if c.registry.logger != nil {
+		c.registry.logger.Info("placement_tick",
+			"enforce", enforce,
+			"machines", len(machines),
+			"pools", len(plan.desired),
+			"switches", len(plan.actions),
+		)
+	}
+	if !enforce || len(plan.actions) == 0 {
+		return
+	}
+
+	// Reserve the pending-load budget for the switches, then assign + push.
+	loadActions := make([]modelLoadAction, 0, len(plan.actions))
+	for _, a := range plan.actions {
+		loadActions = append(loadActions, modelLoadAction{providerID: a.machineID, modelID: a.model})
+	}
+	reserved := c.registry.reservePendingModelLoads(loadActions, now)
+	for _, a := range reserved {
+		epoch, changed, err := c.registry.AssignProviderModel(a.providerID, a.modelID)
+		if err != nil || !changed {
+			// Couldn't record the assignment (provider gone / already serving it):
+			// release the reservation we just took so it isn't stranded for the TTL.
+			c.registry.ClearPendingModelLoad(a.providerID, a.modelID)
+			continue
+		}
+		if err := c.registry.SendAssignModel(a.providerID, a.modelID, epoch); err != nil {
+			// Push failed (e.g. a half-dead WebSocket). Release the pending
+			// reservation so the next tick can re-attempt rather than waiting out
+			// the 2-min TTL; the provider stays AssignmentStateLoading (not
+			// routable) until it acks or is evicted. Mirrors the load_model path.
+			c.registry.ClearPendingModelLoad(a.providerID, a.modelID)
+			if c.registry.logger != nil {
+				c.registry.logger.Warn("placement assign_model push failed",
+					"provider_id", a.providerID, "model_id", a.modelID, "error", err)
+			}
+		}
+	}
+}
+
+// PlacementSnapshot is a read-only view of the latest placement plan for
+// observability (assigned-pool sizes, co-residency audit, switch count).
+type PlacementSnapshot struct {
+	Desired  map[string]int
+	Current  map[string]int
+	Switches int
+	At       time.Time
+}
+
+func (c *warmPoolController) storePlacement(plan placementPlan, now time.Time) {
+	c.lastMu.Lock()
+	defer c.lastMu.Unlock()
+	c.lastPlacement = PlacementSnapshot{
+		Desired:  plan.desired,
+		Current:  plan.current,
+		Switches: len(plan.actions),
+		At:       now,
+	}
+}
+
+// LatestPlacementSnapshot returns the most recent placement plan, or (zero,
+// false) if the placement controller has not run.
+func (r *Registry) LatestPlacementSnapshot() (PlacementSnapshot, bool) {
+	r.mu.RLock()
+	c := r.warmPool
+	r.mu.RUnlock()
+	if c == nil {
+		return PlacementSnapshot{}, false
+	}
+	c.lastMu.RLock()
+	defer c.lastMu.RUnlock()
+	if c.lastPlacement.At.IsZero() {
+		return PlacementSnapshot{}, false
+	}
+	return c.lastPlacement, true
+}

--- a/coordinator/registry/placement_controller_test.go
+++ b/coordinator/registry/placement_controller_test.go
@@ -1,0 +1,229 @@
+package registry
+
+import (
+	"testing"
+	"time"
+)
+
+var placementNow = time.Unix(1_700_000_000, 0)
+
+func capable(models ...string) map[string]float64 {
+	m := make(map[string]float64, len(models))
+	for _, x := range models {
+		m[x] = 50 // representative decode tps
+	}
+	return m
+}
+
+func actionMap(plan placementPlan) map[string]string {
+	out := map[string]string{}
+	for _, a := range plan.actions {
+		out[a.machineID] = a.model
+	}
+	return out
+}
+
+func TestPlanPlacementAssignsUnmanagedToDemand(t *testing.T) {
+	models := []placementModel{{model: "A", need: 2}, {model: "B", need: 1}}
+	machines := []placementMachine{
+		{id: "m1", current: "", idle: true, capable: capable("A", "B")},
+		{id: "m2", current: "", idle: true, capable: capable("A", "B")},
+		{id: "m3", current: "", idle: true, capable: capable("A", "B")},
+	}
+	plan := planPlacement(models, machines, 5*time.Minute, 10, placementNow)
+	if plan.desired["A"] != 2 || plan.desired["B"] != 1 {
+		t.Fatalf("desired=%v, want A:2 B:1", plan.desired)
+	}
+	if len(plan.actions) != 3 {
+		t.Fatalf("expected 3 assignments, got %d (%v)", len(plan.actions), plan.actions)
+	}
+	// Every machine ends assigned; pool sizes match desired.
+	if plan.current["A"] != 2 || plan.current["B"] != 1 {
+		t.Fatalf("current after plan=%v, want A:2 B:1", plan.current)
+	}
+}
+
+func TestPlanPlacementNormalizesByPriorityWhenOversubscribed(t *testing.T) {
+	// Demand (5) exceeds the fleet (3). High-priority A should win the extra
+	// machines, but B's floor of 1 must still be honored (no starvation).
+	models := []placementModel{
+		{model: "A", need: 4, priority: 10},
+		{model: "B", need: 1, floor: 1, priority: 1},
+	}
+	machines := []placementMachine{
+		{id: "m1", current: "", idle: true, capable: capable("A", "B")},
+		{id: "m2", current: "", idle: true, capable: capable("A", "B")},
+		{id: "m3", current: "", idle: true, capable: capable("A", "B")},
+	}
+	plan := planPlacement(models, machines, 5*time.Minute, 10, placementNow)
+	if plan.desired["A"] != 2 || plan.desired["B"] != 1 {
+		t.Fatalf("desired=%v, want A:2 B:1 (B floor honored, A gets the rest)", plan.desired)
+	}
+}
+
+func TestPlanPlacementSwitchesSurplusToDeficit(t *testing.T) {
+	// 3 machines all on A; demand shifts to A:1 B:2. Two surplus A machines
+	// should switch to B.
+	models := []placementModel{{model: "A", need: 1}, {model: "B", need: 2}}
+	old := placementNow.Add(-time.Hour) // past min-dwell
+	machines := []placementMachine{
+		{id: "m1", current: "A", assignedAt: old, idle: true, capable: capable("A", "B")},
+		{id: "m2", current: "A", assignedAt: old, idle: true, capable: capable("A", "B")},
+		{id: "m3", current: "A", assignedAt: old, idle: true, capable: capable("A", "B")},
+	}
+	plan := planPlacement(models, machines, 5*time.Minute, 10, placementNow)
+	switched := 0
+	for _, a := range plan.actions {
+		if a.model == "B" {
+			switched++
+		}
+	}
+	if switched != 2 {
+		t.Fatalf("expected 2 switches to B, got %d (%v)", switched, plan.actions)
+	}
+	if plan.current["A"] != 1 || plan.current["B"] != 2 {
+		t.Fatalf("post-plan current=%v, want A:1 B:2", plan.current)
+	}
+}
+
+func TestPlanPlacementRespectsMinDwell(t *testing.T) {
+	// A machine assigned 1 minute ago must NOT be yanked under a 5-minute dwell,
+	// even though it sits in a surplus pool.
+	models := []placementModel{{model: "A", need: 0}, {model: "B", need: 1}}
+	machines := []placementMachine{
+		{id: "fresh", current: "A", assignedAt: placementNow.Add(-time.Minute), idle: true, capable: capable("A", "B")},
+	}
+	plan := planPlacement(models, machines, 5*time.Minute, 10, placementNow)
+	if len(plan.actions) != 0 {
+		t.Fatalf("min-dwell should block the switch, got %v", plan.actions)
+	}
+}
+
+func TestPlanPlacementRespectsSwitchBudget(t *testing.T) {
+	models := []placementModel{{model: "A", need: 0}, {model: "B", need: 3}}
+	old := placementNow.Add(-time.Hour)
+	machines := []placementMachine{
+		{id: "m1", current: "A", assignedAt: old, idle: true, capable: capable("A", "B")},
+		{id: "m2", current: "A", assignedAt: old, idle: true, capable: capable("A", "B")},
+		{id: "m3", current: "A", assignedAt: old, idle: true, capable: capable("A", "B")},
+	}
+	plan := planPlacement(models, machines, 5*time.Minute, 1, placementNow) // budget 1
+	if len(plan.actions) != 1 {
+		t.Fatalf("switch budget=1 should cap at one switch, got %d", len(plan.actions))
+	}
+}
+
+func TestPlanPlacementSkipsIncapableAndBusyMachines(t *testing.T) {
+	models := []placementModel{{model: "B", need: 2}}
+	old := placementNow.Add(-time.Hour)
+	machines := []placementMachine{
+		{id: "incapable", current: "", idle: true, capable: capable("A")},            // can't hold B
+		{id: "busy", current: "", idle: false, capable: capable("B")},                // in-flight work
+		{id: "ok", current: "A", assignedAt: old, idle: true, capable: capable("B")}, // surplus A, capable B
+	}
+	plan := planPlacement(models, machines, 5*time.Minute, 10, placementNow)
+	got := actionMap(plan)
+	if got["incapable"] != "" {
+		t.Fatal("incapable machine must not be assigned B")
+	}
+	if got["busy"] != "" {
+		t.Fatal("busy machine must not be switched")
+	}
+	if got["ok"] != "B" {
+		t.Fatalf("the idle capable surplus machine should switch to B, got %v", plan.actions)
+	}
+}
+
+func placementTestConfig(enforce bool) WarmPoolConfig {
+	return WarmPoolConfig{
+		Enabled:               true,
+		PlacementEnabled:      true,
+		PlacementEnforce:      enforce,
+		MinDwell:              5 * time.Minute,
+		MaxLoadsPerTick:       4,
+		MaxGlobalPendingLoads: 16,
+		ModelPriority:         map[string]int{"A": 10, "B": 1},
+	}
+}
+
+func TestRunPlacementEnforcePushesAssignments(t *testing.T) {
+	reg := New(testLogger())
+	reg.ConfigureWarmPool(placementTestConfig(true))
+	var pushed []string
+	reg.assignModelSender = func(pid, mid string, _ uint64) error {
+		pushed = append(pushed, mid)
+		return nil
+	}
+	registerProviderWithModels(reg, "p1", "A", "B")
+	registerProviderWithModels(reg, "p2", "A", "B")
+
+	snaps := []WarmPoolSnapshot{{Model: "A", TargetWarm: 1}, {Model: "B", TargetWarm: 1}}
+	reg.warmPool.runPlacement(placementNow, snaps)
+
+	if len(pushed) != 2 {
+		t.Fatalf("enforce: expected 2 assign_model pushes, got %v", pushed)
+	}
+	// Both pools should have been assigned exactly one machine.
+	models := map[string]int{}
+	for _, m := range pushed {
+		models[m]++
+	}
+	if models["A"] != 1 || models["B"] != 1 {
+		t.Fatalf("enforce: pushes should cover A:1 B:1, got %v", models)
+	}
+	// And the assignments are reflected in registry state.
+	a1, _ := reg.ProviderAssignmentSnapshot("p1")
+	a2, _ := reg.ProviderAssignmentSnapshot("p2")
+	if a1.Model == "" || a2.Model == "" || a1.Model == a2.Model {
+		t.Fatalf("expected the two machines split across pools, got %q / %q", a1.Model, a2.Model)
+	}
+}
+
+func TestRunPlacementShadowDoesNotPush(t *testing.T) {
+	reg := New(testLogger())
+	reg.ConfigureWarmPool(placementTestConfig(false)) // PlacementEnforce=false → shadow
+	pushed := 0
+	reg.assignModelSender = func(string, string, uint64) error { pushed++; return nil }
+	registerProviderWithModels(reg, "p1", "A", "B")
+
+	reg.warmPool.runPlacement(placementNow, []WarmPoolSnapshot{{Model: "A", TargetWarm: 1}})
+	if pushed != 0 {
+		t.Fatalf("shadow mode must not push assignments, pushed=%d", pushed)
+	}
+	// But the plan is still computed + recorded for observability.
+	snap, ok := reg.LatestPlacementSnapshot()
+	if !ok || snap.Desired["A"] != 1 {
+		t.Fatalf("shadow mode should record a plan with desired A:1, got %+v ok=%v", snap, ok)
+	}
+}
+
+func TestRunPlacementSkipsUnmanageableProviders(t *testing.T) {
+	reg := New(testLogger())
+	reg.ConfigureWarmPool(placementTestConfig(true))
+	reg.SetManageableProviderFunc(func(_, _ string) bool { return false }) // all too old
+	pushed := 0
+	reg.assignModelSender = func(string, string, uint64) error { pushed++; return nil }
+	registerProviderWithModels(reg, "p1", "A", "B")
+
+	reg.warmPool.runPlacement(placementNow, []WarmPoolSnapshot{{Model: "A", TargetWarm: 1}})
+	if pushed != 0 {
+		t.Fatalf("pre-feature providers must stay unmanaged (no push), pushed=%d", pushed)
+	}
+}
+
+func TestPlanPlacementPrefersUnmanagedSource(t *testing.T) {
+	// Both an unmanaged machine and a surplus-A machine can serve B; the
+	// unmanaged one should be chosen first (don't disturb a serving pool).
+	models := []placementModel{{model: "A", need: 1}, {model: "B", need: 1}}
+	old := placementNow.Add(-time.Hour)
+	machines := []placementMachine{
+		{id: "surplusA", current: "A", assignedAt: old, idle: true, capable: capable("A", "B")},
+		{id: "keepA", current: "A", assignedAt: old, idle: true, capable: capable("A", "B")},
+		{id: "free", current: "", idle: true, capable: capable("A", "B")},
+	}
+	plan := planPlacement(models, machines, 5*time.Minute, 1, placementNow)
+	got := actionMap(plan)
+	if got["free"] != "B" {
+		t.Fatalf("unmanaged machine should be the preferred source for B, got %v", plan.actions)
+	}
+}

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -334,6 +334,14 @@ type Provider struct {
 	ACMEVerified      bool                   // true if ACME device-attest-01 client cert verified (SE key proven)
 	SEKeyBound        bool                   // true if SE key was bound to device via MDA nonce
 
+	// restoredMDAChain holds the durable Apple-signed MDA cert chain recovered
+	// from the store on reconnect (see RestoreProviderState). It is a CANDIDATE
+	// only: it is surfaced as a verified proof (MDAVerified/MDACertChain/MDAResult)
+	// solely after attachCachedMDAProof re-verifies it against Apple's pinned root
+	// AND re-binds it to this connection's SE key at hardware-grant time. Kept
+	// unexported so it never serializes to the store or the attestation endpoint.
+	restoredMDAChain [][]byte
+
 	// MDMFailureReason records the last MDM verification outcome for this
 	// connection, bucketed for observability: "" (verified/none),
 	// "device-not-found", "found-not-enrolled", "securityinfo-timeout",
@@ -369,6 +377,20 @@ type Provider struct {
 	// Warm model cache tracking
 	WarmModels   []string // models currently loaded in provider's memory
 	CurrentModel string   // model currently being served
+
+	// Model pool assignment (DAR-345). When AssignedModel != "", the coordinator
+	// has bound this machine to exactly one public model: the scheduler routes
+	// only AssignedModel to it (see providerPassesRoutingGatesLockedEx) and a
+	// managed provider refuses to load any other model. "" = unmanaged (legacy /
+	// dev multi-slot). AssignmentEpoch is a monotonic per-provider generation
+	// echoed by the provider so stale assign_model_status acks are discarded.
+	// AssignmentState is "" (unmanaged) or one of AssignmentState{Assigned,
+	// Draining,Loading}; only Assigned is routing-eligible. AssignedAt stamps the
+	// last assignment change for the min-dwell anti-thrash guard. Guarded by p.mu.
+	AssignedModel   string
+	AssignmentEpoch uint64
+	AssignmentState string
+	AssignedAt      time.Time
 
 	// Live system metrics from heartbeats
 	SystemMetrics protocol.SystemMetrics
@@ -626,6 +648,45 @@ func (p *Provider) SetMDAProofIfHardware(certChain [][]byte, mdaResult *attestat
 	p.MDACertChain = certChain
 	p.MDAResult = mdaResult
 	return true
+}
+
+// SetMDAProofIfHardwareBound atomically attaches an Apple Device Attestation proof
+// IFF the provider currently holds hardware trust AND the proof binds to THIS
+// machine — either by SE-key freshness (seKeyBound, the FreshnessCode OID equals
+// SHA-256 of this connection's SE public key) OR by a matching attested serial.
+// Returns true if attached. Unlike SetMDAProofIfHardware (which requires a serial
+// match), this accepts an SE-key binding so a privacy-preserving attestation that
+// omits the serial can still be reused. Same single-lock TOCTOU/race rationale as
+// SetMDAProofIfHardware.
+func (p *Provider) SetMDAProofIfHardwareBound(certChain [][]byte, mdaResult *attestation.MDAResult, seKeyBound bool) bool {
+	if mdaResult == nil {
+		return false
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.TrustLevel != TrustHardware {
+		return false
+	}
+	serialOK := mdaResult.DeviceSerial != "" && p.AttestationResult != nil &&
+		mdaResult.DeviceSerial == p.AttestationResult.SerialNumber
+	if !seKeyBound && !serialOK {
+		return false
+	}
+	p.MDAVerified = true
+	p.MDACertChain = certChain
+	p.MDAResult = mdaResult
+	p.SEKeyBound = seKeyBound
+	return true
+}
+
+// StagedMDAChain returns the durable MDA cert chain restored from the store for
+// this reconnect (nil if none). Thread-safe. The chain is a CANDIDATE only: the
+// caller must re-verify it against Apple's root and re-bind it to the live SE key
+// before trusting it (see api.attachCachedMDAProof).
+func (p *Provider) StagedMDAChain() [][]byte {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.restoredMDAChain
 }
 
 // SetLastChallengeVerified updates the challenge timestamp (thread-safe).
@@ -1111,6 +1172,23 @@ type Registry struct {
 	warmPool             *warmPoolController
 	// loadModelSender is a test seam for SendLoadModel. Nil uses the provider WebSocket.
 	loadModelSender func(providerID, modelID string) error
+	// assignModelSender is a test seam for SendAssignModel (DAR-345). Nil uses the
+	// provider WebSocket.
+	assignModelSender func(providerID, modelID string, epoch uint64) error
+
+	// manageableProvider gates which providers the placement controller may bind
+	// to a pool (DAR-345): the api wires it to providerSupportsModelAssignment so
+	// pre-feature providers stay unmanaged. nil = permissive (test default).
+	// Guarded by r.mu.
+	manageableProvider func(backend, version string) bool
+
+	// assignmentGateEnabled turns on DAR-345 model-pool isolation in the routing
+	// gate: when true, a managed provider (AssignedModel set) is routing-eligible
+	// only for its assigned model and only while AssignmentStateAssigned. An
+	// explicit, reversible kill switch independent of whether the placement
+	// controller has pushed assignments. atomic so the hot routing path reads it
+	// without caring which lock is held.
+	assignmentGateEnabled atomic.Bool
 
 	// onHardUntrust is an optional hook fired (off the registry locks) whenever a
 	// provider is HARD-untrusted (a non-recoverable security deroute). The api
@@ -1154,6 +1232,33 @@ const dispatchLoadCooldownTTL = 2 * time.Minute
 type modelLoadAction struct {
 	providerID string
 	modelID    string
+}
+
+// Pool-assignment lifecycle states (DAR-345). Stored on Provider.AssignmentState.
+// Only AssignmentStateAssigned is routing-eligible; Draining/Loading are
+// transitional and excluded by the scheduler isolation gate. "" means the
+// provider is unmanaged (no pool assignment).
+const (
+	AssignmentStateAssigned = "assigned"
+	AssignmentStateDraining = "draining"
+	AssignmentStateLoading  = "loading"
+	// AssignmentStateFailed marks an assignment whose load failed. The provider
+	// stays bound to AssignedModel (so it is NOT eligible for any other model —
+	// no spillover) but is not routing-eligible until a later assignment
+	// succeeds; the placement controller reconsiders it after the failed-load
+	// cooldown elapses.
+	AssignmentStateFailed = "failed"
+)
+
+// ProviderAssignment is a read-only snapshot of a provider's pool assignment
+// (DAR-345), used by the placement controller, the scheduler gate, and
+// observability without exposing the live Provider under lock.
+type ProviderAssignment struct {
+	ProviderID string
+	Model      string
+	Epoch      uint64
+	State      string
+	AssignedAt time.Time
 }
 
 // New creates a new Registry.
@@ -1331,6 +1436,23 @@ func (r *Registry) RestoreProviderState(p *Provider, rec *store.ProviderRecord) 
 	// this connection.
 	p.MDAVerified = false
 	p.ACMEVerified = false
+
+	// Stage the durable Apple-signed MDA cert chain (if the store has one) for
+	// local re-verification at this connection's hardware-grant. We deliberately
+	// do NOT set MDAVerified/MDACertChain here — the proof is surfaced only after
+	// attachCachedMDAProof re-verifies it against Apple's pinned root AND re-binds
+	// it to this connection's SE key. This lets a reconnect/restart reuse a
+	// still-valid attestation instead of forcing a fresh, Apple-rate-limited
+	// (≈1/device/7d) DevicePropertiesAttestation round-trip over the throttled
+	// MicroMDM→APNs channel — the root cause of providers showing "Apple Device
+	// Attestation incomplete" after a restart.
+	p.restoredMDAChain = nil
+	if len(rec.MDACertChain) > 0 {
+		var chain [][]byte
+		if err := json.Unmarshal(rec.MDACertChain, &chain); err == nil && len(chain) > 0 {
+			p.restoredMDAChain = chain
+		}
+	}
 
 	// Restore challenge state, but never move a fresh live verification
 	// backwards. Registration attestation sets LastChallengeVerified=now before
@@ -2743,6 +2865,192 @@ func (r *Registry) SendLoadModel(providerID, modelID string) error {
 		"model_id", modelID,
 	)
 	return nil
+}
+
+// SendAssignModel binds a managed provider to a single public model (DAR-345
+// model pools). The provider drains in-flight work, unloads every other
+// resident model, then loads + warms modelID, refusing other models while the
+// assignment stands. Like SendLoadModel this is fire-and-forget — the provider
+// replies asynchronously with assign_model_status messages echoing epoch. The
+// caller is responsible for version-gating (assign_model is only understood by
+// Swift providers at or above the assign-model feature version).
+func (r *Registry) SendAssignModel(providerID, modelID string, epoch uint64) error {
+	if r.assignModelSender != nil {
+		if err := r.assignModelSender(providerID, modelID, epoch); err != nil {
+			return err
+		}
+		r.logger.Info("sent assign_model to provider", "provider_id", providerID, "model_id", modelID, "epoch", epoch)
+		return nil
+	}
+
+	r.mu.RLock()
+	p, ok := r.providers[providerID]
+	r.mu.RUnlock()
+	if !ok {
+		return fmt.Errorf("provider %q not found", providerID)
+	}
+
+	msg := protocol.AssignModelMessage{
+		Type:    protocol.TypeAssignModel,
+		ModelID: modelID,
+		Epoch:   epoch,
+	}
+	data, err := json.Marshal(msg)
+	if err != nil {
+		return fmt.Errorf("failed to marshal assign_model message: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), providerControlWriteTimeout)
+	defer cancel()
+	if err := p.WriteText(ctx, data); err != nil {
+		return fmt.Errorf("failed to send assign_model to provider %q: %w", providerID, err)
+	}
+
+	r.logger.Info("sent assign_model to provider",
+		"provider_id", providerID,
+		"model_id", modelID,
+		"epoch", epoch,
+	)
+	return nil
+}
+
+// AssignProviderModel records a new pool assignment for a provider (DAR-345):
+// it sets AssignedModel, bumps the monotonic AssignmentEpoch, marks the
+// provider AssignmentStateLoading, and stamps AssignedAt. It returns the new
+// epoch and whether anything changed (changed=false — and the existing epoch —
+// when the provider is already assigned this model and serving it, so the
+// caller skips a redundant assign_model push). Callers pair a changed result
+// with SendAssignModel(providerID, modelID, epoch).
+func (r *Registry) AssignProviderModel(providerID, modelID string) (epoch uint64, changed bool, err error) {
+	r.mu.RLock()
+	p, ok := r.providers[providerID]
+	r.mu.RUnlock()
+	if !ok {
+		return 0, false, fmt.Errorf("provider %q not found", providerID)
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.AssignedModel == modelID && p.AssignmentState == AssignmentStateAssigned {
+		return p.AssignmentEpoch, false, nil
+	}
+	p.AssignmentEpoch++
+	p.AssignedModel = modelID
+	p.AssignmentState = AssignmentStateLoading
+	p.AssignedAt = time.Now()
+	return p.AssignmentEpoch, true, nil
+}
+
+// ApplyAssignModelStatus applies a provider's assign_model_status ack (DAR-345).
+// It is epoch-guarded: a status echoing an epoch older than the provider's
+// current AssignmentEpoch, or naming a different model, is ignored (stale ack
+// from a superseded assignment). On succeeded the provider becomes
+// AssignmentStateAssigned (routing-eligible); draining/loading update the
+// transitional state; failed marks AssignmentStateFailed and arms the
+// (provider,model) dispatch-load cooldown so the controller waits before
+// retrying. Returns true when the status was applied (not stale).
+func (r *Registry) ApplyAssignModelStatus(providerID, modelID string, epoch uint64, status string) bool {
+	r.mu.RLock()
+	p, ok := r.providers[providerID]
+	r.mu.RUnlock()
+	if !ok {
+		return false
+	}
+	p.mu.Lock()
+	stale := p.AssignedModel != modelID || epoch < p.AssignmentEpoch
+	if stale {
+		p.mu.Unlock()
+		return false
+	}
+	switch status {
+	case protocol.AssignModelStatusDraining:
+		p.AssignmentState = AssignmentStateDraining
+	case protocol.AssignModelStatusLoading:
+		p.AssignmentState = AssignmentStateLoading
+	case protocol.AssignModelStatusSucceeded:
+		p.AssignmentState = AssignmentStateAssigned
+	case protocol.AssignModelStatusFailed:
+		p.AssignmentState = AssignmentStateFailed
+	}
+	p.mu.Unlock()
+	if status == protocol.AssignModelStatusFailed {
+		// Stay isolated (AssignedModel still set) but arm the cooldown so the
+		// controller doesn't immediately re-push the same model.
+		r.RecordDispatchLoadFailure(providerID, modelID)
+	}
+	return true
+}
+
+// SetAssignmentGateEnabled toggles DAR-345 model-pool isolation in the routing
+// gate (stage-3 enforcement switch). When false (default) AssignedModel does not
+// constrain routing, so assignments can be staged/observed without enforcement.
+func (r *Registry) SetAssignmentGateEnabled(enabled bool) {
+	r.assignmentGateEnabled.Store(enabled)
+}
+
+// AssignmentGateEnabled reports whether model-pool isolation is enforced.
+func (r *Registry) AssignmentGateEnabled() bool {
+	return r.assignmentGateEnabled.Load()
+}
+
+// PoolExhausted reports whether model m is a managed pool that currently has no
+// machine assigned-and-serving it, while the fleet DOES have machines that could
+// serve it (the model is on their disk, assigned elsewhere or mid-switch). In
+// that state a request should get an uptime-neutral 429 pool_exhausted rather
+// than queueing against zero machines or 503-ing — the placement controller will
+// grow the pool. It returns false when the assignment gate is off (no
+// enforcement), when the pool already has a serving machine (let normal
+// dispatch/queue handle saturation), or when no provider serves the model at all
+// (a different rejection — model_not_found / no_provider). The second return is
+// the count of fleet machines that could serve the model (catalog-capable),
+// recorded so the rejection is correctly marked could-have-served.
+func (r *Registry) PoolExhausted(model string) (exhausted bool, catalogCapable int) {
+	if !r.assignmentGateEnabled.Load() {
+		return false, 0
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	poolServing := 0
+	for _, p := range r.providers {
+		p.mu.Lock()
+		online := p.Status != StatusOffline && p.Status != StatusUntrusted
+		serves := online && r.providerServesCatalogModelLocked(p, model)
+		// Mirror the routing gate's eligibility EXACTLY (see
+		// providerPassesRoutingGatesLockedEx): an UNMANAGED machine
+		// (AssignedModel=="") still serves the model — so it must count as serving,
+		// or a mixed managed/unmanaged fleet during rollout would 429 a request
+		// the gate would happily route to that unmanaged box. A managed machine is
+		// eligible only for its assigned model while AssignmentStateAssigned.
+		eligible := p.AssignedModel == "" || (p.AssignedModel == model && p.AssignmentState == AssignmentStateAssigned)
+		p.mu.Unlock()
+		if serves {
+			catalogCapable++
+			if eligible {
+				poolServing++
+			}
+		}
+	}
+	return poolServing == 0 && catalogCapable > 0, catalogCapable
+}
+
+// ProviderAssignmentSnapshot returns a provider's current pool assignment, or
+// (zero, false) when the provider is unknown. Read-only; safe under no caller
+// lock.
+func (r *Registry) ProviderAssignmentSnapshot(providerID string) (ProviderAssignment, bool) {
+	r.mu.RLock()
+	p, ok := r.providers[providerID]
+	r.mu.RUnlock()
+	if !ok {
+		return ProviderAssignment{}, false
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return ProviderAssignment{
+		ProviderID: providerID,
+		Model:      p.AssignedModel,
+		Epoch:      p.AssignmentEpoch,
+		State:      p.AssignmentState,
+		AssignedAt: p.AssignedAt,
+	}, true
 }
 
 // SendPrefetchModel instructs a provider to download + verify a model build

--- a/coordinator/registry/scheduler.go
+++ b/coordinator/registry/scheduler.go
@@ -779,14 +779,30 @@ func (r *Registry) providerPassesRoutingGatesLockedEx(p *Provider, model string,
 	if !r.providerServesCatalogModelLocked(p, model) {
 		return false
 	}
-	// Dedicated-box isolation: a request for a dedicated model family (e.g.
-	// Gemma 4) may ONLY route to a provider whose ENTIRE advertised catalog is
-	// that family. This single gate is shared by the dispatch hot path and the
-	// OpenRouter capacity preflight, so the filter restricts the routing
-	// candidate set AND the shed (429) decision together with no drift. A caller
-	// self-routing to its OWN machine is exempt — owners may run mixed boxes.
+	// Dedicated-box isolation (catalog-based, already on master): a request for a
+	// dedicated model family (e.g. Gemma 4) may ONLY route to a provider whose
+	// ENTIRE advertised catalog is that family. Shared by the dispatch hot path
+	// and the OpenRouter capacity preflight. A caller self-routing to its OWN
+	// machine is exempt — owners may run mixed boxes.
 	if !selfRouteOwner && r.providerExcludedByDedicatedRuleLocked(p, model) {
 		return false
+	}
+	// DAR-345 model-pool isolation (assignment-based, this PR). A managed provider
+	// (AssignedModel != "") serves ONLY its assigned model, and only while the
+	// assignment is live (AssignmentStateAssigned) — draining/loading/failed
+	// transitions are excluded so no request lands on a machine mid-swap. This
+	// single gate makes no-spillover structural across selection, queue-drain,
+	// preflight, and admit-recheck (all route through here) and makes
+	// candidate/capacity counts pool-scoped. Unmanaged providers are unaffected.
+	// Self-route owners bypass it (never filtered into "no candidate" on their own
+	// machine; the placement controller never manages PrivateOnly machines). Gated
+	// by assignmentGateEnabled (default off). Composes with the catalog-based
+	// dedicated-box rule above — both are independent eligibility filters; the team
+	// can consolidate the two pool approaches in a follow-up.
+	if r.assignmentGateEnabled.Load() && !selfRouteOwner && p.AssignedModel != "" {
+		if p.AssignedModel != model || p.AssignmentState != AssignmentStateAssigned {
+			return false
+		}
 	}
 	// Skip a provider-model pair cooling down after a dispatch-time load
 	// failure ("insufficient memory") — it would instant-503 again, burning a

--- a/coordinator/registry/warm_pool_controller.go
+++ b/coordinator/registry/warm_pool_controller.go
@@ -31,6 +31,10 @@ type warmPoolController struct {
 	lastMu      sync.RWMutex
 	lastSnaps   []WarmPoolSnapshot
 	lastSnapsAt time.Time
+
+	// lastPlacement caches the most recent DAR-345 placement plan (desired/current
+	// pool sizes + switch count) for observability. Guarded by lastMu.
+	lastPlacement PlacementSnapshot
 }
 
 type syncQueuePressure struct {
@@ -250,6 +254,10 @@ func (c *warmPoolController) tick(now time.Time) []WarmPoolSnapshot {
 		}
 		c.registry.sendModelLoadActions(snap.Actions)
 	}
+	// DAR-345 placement: turn the per-model demand targets into an exclusive
+	// model→machine assignment. Runs after warm loads so it sees (and shares) the
+	// updated pending-load budget. No-op unless PlacementEnabled.
+	c.runPlacement(now, snapshots)
 	return snapshots
 }
 

--- a/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClient.swift
+++ b/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClient.swift
@@ -34,6 +34,11 @@ public enum CoordinatorEvent: Sendable {
     case desiredModels(entries: [CoordinatorMessage.DesiredModelEntry])
     /// Coordinator informs the provider of its current trust level and status.
     case trustStatus(trustLevel: String, status: String, reason: String)
+    /// Coordinator-driven exclusive pool assignment (DAR-345). Provider drains,
+    /// unloads every other model, then loads + warms `modelId`, refusing other
+    /// models while assigned. Reply with `assignModelStatus` outbound messages
+    /// (echoing `epoch`). `epoch` is the monotonic assignment generation.
+    case assignModel(modelId: String, epoch: UInt64)
 }
 
 // MARK: - Shared State
@@ -396,6 +401,7 @@ public enum OutboundMessage: Sendable {
     case attestationResponse(AttestationResponsePayload)
     case codeAttestationResponse(nonce: String, signature: String)
     case loadModelStatus(modelId: String, status: ProviderMessage.LoadModelStatus.Status, error: String?)
+    case assignModelStatus(modelId: String, epoch: UInt64, status: ProviderMessage.AssignModelStatus.Status, error: String?)
     case prefetchModelStatus(
         modelId: String,
         status: ProviderMessage.PrefetchModelStatus.Status,
@@ -950,6 +956,10 @@ public actor CoordinatorClient {
                 status: ts.status,
                 reason: ts.reason
             ))
+
+        case .assignModel(let a):
+            logger.info("Received coordinator-driven pool assignment: \(a.modelId) (epoch=\(a.epoch))")
+            eventContinuation?.yield(.assignModel(modelId: a.modelId, epoch: a.epoch))
         }
     }
 

--- a/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClientCodec.swift
+++ b/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClientCodec.swift
@@ -158,6 +158,14 @@ public enum CoordinatorClientCodec {
                 error: error
             ))
 
+        case .assignModelStatus(let modelId, let epoch, let status, let error):
+            return .assignModelStatus(ProviderMessage.AssignModelStatus(
+                modelId: modelId,
+                epoch: epoch,
+                status: status,
+                error: error
+            ))
+
         case .prefetchModelStatus(let modelId, let status, let bytesDone, let bytesTotal, let error):
             return .prefetchModelStatus(ProviderMessage.PrefetchModelStatus(
                 modelId: modelId,

--- a/provider-swift/Sources/ProviderCore/Protocol/Messages.swift
+++ b/provider-swift/Sources/ProviderCore/Protocol/Messages.swift
@@ -14,6 +14,7 @@ public enum ProviderMessage: Sendable, Equatable {
     case loadModelStatus(LoadModelStatus)
     case prefetchModelStatus(PrefetchModelStatus)
     case modelsUpdate(ModelsUpdate)
+    case assignModelStatus(AssignModelStatus)
 
     public struct Register: Sendable, Equatable {
         public var hardware: HardwareInfo
@@ -190,6 +191,31 @@ public enum ProviderMessage: Sendable, Equatable {
         }
     }
 
+    /// Lifecycle reply to a `CoordinatorMessage.assignModel` (DAR-345 model
+    /// pools). The provider walks draining → loading → succeeded (warm +
+    /// servable) or failed. `epoch` echoes the assignment generation so the
+    /// coordinator can discard a stale ack from a superseded assignment.
+    public struct AssignModelStatus: Sendable, Equatable {
+        public enum Status: String, Sendable, Equatable {
+            case draining
+            case loading
+            case succeeded
+            case failed
+        }
+
+        public var modelId: String
+        public var epoch: UInt64
+        public var status: Status
+        public var error: String?
+
+        public init(modelId: String, epoch: UInt64, status: Status, error: String? = nil) {
+            self.modelId = modelId
+            self.epoch = epoch
+            self.status = status
+            self.error = error
+        }
+    }
+
     /// Progress/terminal reply to a `CoordinatorMessage.prefetchModel`. A
     /// prefetch only downloads + verifies the build on disk; it does NOT load
     /// weights into GPU. `verified` is the terminal success state (build is on
@@ -321,6 +347,7 @@ extension ProviderMessage: Codable {
         case loadModelStatus = "load_model_status"
         case prefetchModelStatus = "prefetch_model_status"
         case modelsUpdate = "models_update"
+        case assignModelStatus = "assign_model_status"
     }
 
     enum CodingKeys: String, CodingKey {
@@ -376,6 +403,8 @@ extension ProviderMessage: Codable {
         // PrefetchModelStatus
         case bytesDone = "bytes_done"
         case bytesTotal = "bytes_total"
+        // AssignModelStatus
+        case epoch
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -498,6 +527,13 @@ extension ProviderMessage: Codable {
             try container.encode(TypeValue.modelsUpdate, forKey: .type)
             // Reuse the ModelInfo encoding shared with `register`'s models[].
             try container.encode(u.models, forKey: .models)
+
+        case .assignModelStatus(let a):
+            try container.encode(TypeValue.assignModelStatus, forKey: .type)
+            try container.encode(a.modelId, forKey: .modelId)
+            try container.encode(a.epoch, forKey: .epoch)
+            try container.encode(a.status.rawValue, forKey: .status)
+            try container.encodeIfPresent(a.error, forKey: .error)
         }
     }
 
@@ -628,6 +664,22 @@ extension ProviderMessage: Codable {
             self = .modelsUpdate(ModelsUpdate(
                 models: try container.decode([ModelInfo].self, forKey: .models)
             ))
+
+        case .assignModelStatus:
+            let raw = try container.decode(String.self, forKey: .status)
+            guard let status = AssignModelStatus.Status(rawValue: raw) else {
+                throw DecodingError.dataCorruptedError(
+                    forKey: .status,
+                    in: container,
+                    debugDescription: "unknown assign_model_status value: \(raw)"
+                )
+            }
+            self = .assignModelStatus(AssignModelStatus(
+                modelId: try container.decode(String.self, forKey: .modelId),
+                epoch: try container.decodeIfPresent(UInt64.self, forKey: .epoch) ?? 0,
+                status: status,
+                error: try container.decodeIfPresent(String.self, forKey: .error)
+            ))
         }
     }
 }
@@ -643,6 +695,7 @@ public enum CoordinatorMessage: Sendable, Equatable {
     case prefetchModel(PrefetchModel)
     case desiredModels(DesiredModels)
     case trustStatus(TrustStatus)
+    case assignModel(AssignModel)
 
     public struct InferenceRequest: Sendable, Equatable {
         public var requestId: String
@@ -686,6 +739,22 @@ public enum CoordinatorMessage: Sendable, Equatable {
     public struct LoadModel: Sendable, Equatable {
         public var modelId: String
         public init(modelId: String) { self.modelId = modelId }
+    }
+
+    /// Coordinator-driven exclusive pool assignment (DAR-345). The provider
+    /// drains in-flight work, unloads every resident model that is not `modelId`,
+    /// then loads + warms `modelId`, refusing to opportunistically load any other
+    /// model while the assignment stands. `epoch` is a monotonic per-provider
+    /// generation: ignore an assignment older than one already applied, and echo
+    /// it in every `assignModelStatus` reply. Distinct from `loadModel` (additive
+    /// warm, no exclusivity, no drain).
+    public struct AssignModel: Sendable, Equatable {
+        public var modelId: String
+        public var epoch: UInt64
+        public init(modelId: String, epoch: UInt64) {
+            self.modelId = modelId
+            self.epoch = epoch
+        }
     }
 
     /// Coordinator-driven background prefetch. Provider should download AND
@@ -757,6 +826,7 @@ extension CoordinatorMessage: Codable {
         case prefetchModel = "prefetch_model"
         case desiredModels = "desired_models"
         case trustStatus = "trust_status"
+        case assignModel = "assign_model"
     }
 
     enum CodingKeys: String, CodingKey {
@@ -771,6 +841,7 @@ extension CoordinatorMessage: Codable {
         case trustLevel = "trust_level"
         case status, reason
         case models
+        case epoch
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -822,6 +893,11 @@ extension CoordinatorMessage: Codable {
             if !t.reason.isEmpty {
                 try container.encode(t.reason, forKey: .reason)
             }
+
+        case .assignModel(let a):
+            try container.encode(TypeValue.assignModel, forKey: .type)
+            try container.encode(a.modelId, forKey: .modelId)
+            try container.encode(a.epoch, forKey: .epoch)
         }
     }
 
@@ -875,6 +951,12 @@ extension CoordinatorMessage: Codable {
                 trustLevel: try container.decode(String.self, forKey: .trustLevel),
                 status: try container.decode(String.self, forKey: .status),
                 reason: try container.decodeIfPresent(String.self, forKey: .reason) ?? ""
+            ))
+
+        case .assignModel:
+            self = .assignModel(AssignModel(
+                modelId: try container.decode(String.self, forKey: .modelId),
+                epoch: try container.decodeIfPresent(UInt64.self, forKey: .epoch) ?? 0
             ))
         }
     }

--- a/provider-swift/Sources/ProviderCore/Protocol/Types.swift
+++ b/provider-swift/Sources/ProviderCore/Protocol/Types.swift
@@ -8,6 +8,14 @@ import Foundation
 /// (ProviderDrainingForUpdate) — keep the two in sync.
 public let providerDrainingForUpdateReason = "provider draining for update"
 
+/// Well-known transient error reason a managed provider attaches to rejections
+/// while it is draining + swapping to a newly-assigned pool model (DAR-345).
+/// Like `providerDrainingForUpdateReason`, the coordinator matches this exact
+/// string to treat the rejection as a brief transition (reroute/backoff), not a
+/// genuine failure. Mirrored in coordinator/protocol/messages.go
+/// (ProviderSwitchingModel) — keep the two in sync.
+public let providerSwitchingModelReason = "provider switching model"
+
 public struct HardwareInfo: Codable, Sendable, Equatable {
     public var machineModel: String
     public var chipName: String

--- a/provider-swift/Sources/ProviderCore/ProviderCore.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderCore.swift
@@ -75,5 +75,11 @@ public enum ProviderCore {
     // jinja_null_bridge / jinja_template / model_load), so durable telemetry can
     // tell the two indistinguishable gpt-oss 500 modes apart. Wire-compatible:
     // `error_reason` is an optional inference-error field, omitted when nil.
-    public static let version = "0.6.17"
+    // 0.6.18 adds DAR-345 model-pool support: the provider understands the
+    // coordinator's assign_model push (drain → unload-others → load+warm), refuses
+    // non-assigned models (refuse-don't-swap), and replies assign_model_status.
+    // This MUST stay >= minProviderVersionForModelAssignment in the coordinator
+    // (coordinator/api/server.go) — they are the two ends of the same version gate,
+    // so a provider only receives assign_model once it actually supports it.
+    public static let version = "0.6.18"
 }

--- a/provider-swift/Sources/ProviderCore/ProviderLoop.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop.swift
@@ -193,6 +193,19 @@ public actor ProviderLoop {
         return max(1, min(configuredMaxModelSlots, live))
     }
 
+    /// DAR-345 model-pool assignment. When non-nil, the coordinator has bound
+    /// this machine to exactly one public model: the provider keeps only this
+    /// model loaded/warm and REFUSES to load any other (refuse-don't-swap, vs
+    /// the legacy LRU swap). `assignmentEpoch` is the monotonic generation of the
+    /// latest applied/accepted assignment; a stale assign_model (older epoch) is
+    /// ignored. nil = unmanaged (legacy multi-slot behaviour). Actor-isolated.
+    private var assignedModel: String?
+    private var assignmentEpoch: UInt64 = 0
+    /// In-flight pool switch, run off the event loop so a long drain/cold-load
+    /// doesn't stall cancels or the attestation challenge. A newer assign_model
+    /// cancels the prior switch (the epoch guards make the cancel safe).
+    private var assignmentTask: Task<Void, Never>?
+
     /// Maps request IDs to the model they're running on, so the idle
     /// monitor knows which model has in-flight work.
     private var requestToModel: [String: String] = [:]
@@ -724,6 +737,15 @@ public actor ProviderLoop {
 
                 case .loadModel(let modelId):
                     handleLoadModelRequest(modelId: modelId, send: send)
+
+                case .assignModel(let modelId, let epoch):
+                    // Run off the event loop: a switch's drain (≤30s) + cold load
+                    // can take a while, and blocking here would stall cancels and
+                    // the attestation challenge. A newer assignment cancels the
+                    // prior in-flight switch; the epoch guards keep that safe.
+                    assignmentTask?.cancel()
+                    let me = self
+                    assignmentTask = Task { await me.handleAssignModelRequest(modelId: modelId, epoch: epoch, send: send) }
 
                 case .prefetchModel(let modelId, let priority):
                     if isDrainingForUpdate {
@@ -1696,6 +1718,83 @@ public actor ProviderLoop {
         }
     }
 
+    // MARK: - Coordinator-driven pool assignment (DAR-345)
+
+    /// Max time to wait for in-flight work on the outgoing models to drain before
+    /// unloading them during a pool switch. Bounded like the update drain so a
+    /// stuck stream cannot wedge the switch forever.
+    private static let assignDrainTimeout: Duration = .seconds(30)
+
+    /// Handle an `assign_model` push: bind this machine to exactly one model.
+    /// Walks draining → unload-others → loading → succeeded (or failed), echoing
+    /// `epoch` so the coordinator can discard a stale ack. Idempotent for an
+    /// already-warm assigned model. Reuses waitForInflightDrain + unloadModel +
+    /// ensureModelLoaded.
+    private func handleAssignModelRequest(modelId: String, epoch: UInt64, send: SendHandle) async {
+        // Stale assignment (an older generation than one already applied) — ignore.
+        if epoch < assignmentEpoch {
+            logger.info("Ignoring stale assign_model for \(modelId): epoch \(epoch) < current \(assignmentEpoch)")
+            return
+        }
+        if isShuttingDown {
+            send.send(.assignModelStatus(modelId: modelId, epoch: epoch, status: .failed, error: "provider is shutting down"))
+            return
+        }
+        if isDrainingForUpdate {
+            send.send(.assignModelStatus(modelId: modelId, epoch: epoch, status: .failed, error: providerSwitchingModelReason))
+            return
+        }
+
+        // Accept the assignment up front so refuse-don't-swap + the idle monitor
+        // immediately treat this as the single pool model.
+        assignmentEpoch = epoch
+        assignedModel = modelId
+        logger.info("Pool assignment accepted: \(modelId) (epoch=\(epoch))")
+
+        // Already warm + serving the assigned model: just make sure nothing else
+        // is resident, then ack succeeded. If OTHER models ARE resident (the
+        // co-residency this assignment eliminates), drain in-flight work first so
+        // unloadModelsExcept doesn't abort an active stream on those models.
+        if modelSlots[modelId] != nil, !modelsUnloading.contains(modelId) {
+            let othersResident = modelSlots.keys.contains { $0 != modelId && !modelsUnloading.contains($0) }
+            if othersResident {
+                send.send(.assignModelStatus(modelId: modelId, epoch: epoch, status: .draining, error: nil))
+                _ = await waitForInflightDrain(timeout: Self.assignDrainTimeout)
+                guard assignmentEpoch == epoch else { return } // superseded mid-drain
+            }
+            await unloadModelsExcept(modelId)
+            send.send(.assignModelStatus(modelId: modelId, epoch: epoch, status: .succeeded, error: nil))
+            return
+        }
+
+        send.send(.assignModelStatus(modelId: modelId, epoch: epoch, status: .draining, error: nil))
+        _ = await waitForInflightDrain(timeout: Self.assignDrainTimeout)
+        guard assignmentEpoch == epoch else { return } // superseded mid-drain
+        await unloadModelsExcept(modelId)
+
+        send.send(.assignModelStatus(modelId: modelId, epoch: epoch, status: .loading, error: nil))
+        do {
+            try await ensureModelLoaded(modelId: modelId)
+            guard assignmentEpoch == epoch else { return } // superseded mid-load
+            send.send(.assignModelStatus(modelId: modelId, epoch: epoch, status: .succeeded, error: nil))
+        } catch is CancellationError {
+            return
+        } catch {
+            logger.warning("Pool assignment load failed for \(modelId): \(error.localizedDescription)")
+            send.send(.assignModelStatus(modelId: modelId, epoch: epoch, status: .failed, error: error.localizedDescription))
+        }
+    }
+
+    /// Unload every resident model that is not `keep` (the assigned model),
+    /// enforcing one-model-per-machine. Called after a bounded drain.
+    private func unloadModelsExcept(_ keep: String) async {
+        let toUnload = modelSlots.keys.filter { $0 != keep && !modelsUnloading.contains($0) }
+        for model in toUnload {
+            logger.info("Pool switch: unloading non-assigned model \(model)")
+            await unloadModel(model)
+        }
+    }
+
     // MARK: - Coordinator-driven background prefetch (Layer 3)
 
     /// Build the prefetch coordinator, wiring the pre-check (already
@@ -1974,6 +2073,16 @@ public actor ProviderLoop {
 
     /// Test seam: whether a model id is currently advertised.
     func isModelAdvertised(_ id: String) -> Bool { advertisedModels[id] != nil }
+
+    /// Test seam: drive the DAR-345 pool-assignment handler directly (the real
+    /// entry point is private and otherwise only reached via the coordinator
+    /// event loop).
+    func handleAssignModelForTesting(modelId: String, epoch: UInt64, send: SendHandle) async {
+        await handleAssignModelRequest(modelId: modelId, epoch: epoch, send: send)
+    }
+
+    /// Test seam: the currently-assigned pool model (nil = unmanaged) + its epoch.
+    func assignmentForTesting() -> (model: String?, epoch: UInt64) { (assignedModel, assignmentEpoch) }
 
     /// Test seam: recorded weight hash for a model (nil when unknown).
     func modelHashForTesting(_ id: String) -> String? { modelHashes[id] }
@@ -2650,6 +2759,19 @@ public actor ProviderLoop {
     private func ensureModelLoaded(modelId: String) async throws {
         if isShuttingDown {
             throw CancellationError()
+        }
+
+        // DAR-345 refuse-don't-swap: a managed machine (assignedModel set) serves
+        // ONLY its assigned model. A request for any other model is refused —
+        // checked FIRST so an already-resident non-assigned model (e.g. mid-switch,
+        // or a local/self-route path) is refused rather than served, and so the
+        // legacy LRU eviction below can never swap a different model in. The
+        // coordinator's isolation gate normally prevents non-assigned routing
+        // reaching here; this is the provider-side backstop.
+        if let assigned = assignedModel, modelId != assigned {
+            throw InferenceError.invalidModelDirectory(
+                "model '\(modelId)' is not this machine's assigned pool model '\(assigned)'"
+            )
         }
 
         while modelsUnloading.contains(modelId) {

--- a/provider-swift/Tests/ProviderCoreTests/Helpers/MockCoordinator.swift
+++ b/provider-swift/Tests/ProviderCoreTests/Helpers/MockCoordinator.swift
@@ -40,6 +40,7 @@ public struct CapturedMessages: Sendable {
     public var inferenceErrors: [ProviderMessage.InferenceError] = []
     public var loadModelStatuses: [ProviderMessage.LoadModelStatus] = []
     public var prefetchModelStatuses: [ProviderMessage.PrefetchModelStatus] = []
+    public var assignModelStatuses: [ProviderMessage.AssignModelStatus] = []
     public var modelsUpdates: [ProviderMessage.ModelsUpdate] = []
     public var telemetryBatches: [TelemetryBatch] = []
 
@@ -572,6 +573,7 @@ public final class MockCoordinator: @unchecked Sendable {
             case .loadModelStatus(let s):    captured.loadModelStatuses.append(s)
             case .prefetchModelStatus(let s): captured.prefetchModelStatuses.append(s)
             case .modelsUpdate(let u):       captured.modelsUpdates.append(u)
+            case .assignModelStatus(let s):  captured.assignModelStatuses.append(s)
             }
         }
         eventContinuation.yield(.providerMessage(parsed))

--- a/provider-swift/Tests/ProviderCoreTests/ModelPrefetchCoordinatorTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/ModelPrefetchCoordinatorTests.swift
@@ -493,6 +493,15 @@ private final class OutboundRecorder: @unchecked Sendable {
             return nil
         }
     }
+    func assignStatuses() -> [ProviderMessage.AssignModelStatus] {
+        lock.lock(); defer { lock.unlock() }
+        return _messages.compactMap { msg in
+            if case .assignModelStatus(let modelId, let epoch, let status, let error) = msg {
+                return ProviderMessage.AssignModelStatus(modelId: modelId, epoch: epoch, status: status, error: error)
+            }
+            return nil
+        }
+    }
 }
 
 /// Fake prefetcher that succeeds without touching the network — used by the
@@ -543,6 +552,33 @@ struct ProviderLoopPrefetchTests {
             )
         )
         return try ProviderLoop(config: config, purgeLegacyFiles: false, attestationSigner: nil)
+    }
+
+    /// DAR-345: the assign_model handler walks the lifecycle, echoes the epoch on
+    /// every status, binds the machine (arming refuse-don't-swap), and ignores a
+    /// stale (older-epoch) assignment. The model isn't on disk so the load fails —
+    /// but the orchestration + epoch guard are exactly what we assert.
+    @Test func assignModelLifecycleEchoesEpochAndIsEpochGuarded() async throws {
+        let model = ModelInfo(id: "org/assign-pool", sizeBytes: 1, estimatedMemoryGb: 1)
+        let loop = try makeLoop(models: [model], maxModelSlots: 3)
+        let outbound = OutboundRecorder()
+        let send = SendHandle { outbound.record($0) }
+
+        await loop.handleAssignModelForTesting(modelId: model.id, epoch: 5, send: send)
+        let statuses = outbound.assignStatuses()
+        #expect(!statuses.isEmpty)
+        #expect(statuses.allSatisfy { $0.epoch == 5 })
+        #expect(statuses.contains { $0.status == .draining })
+        #expect(statuses.last?.status == .failed) // not on disk → load fails after the lifecycle ran
+
+        let assignment = await loop.assignmentForTesting()
+        #expect(assignment.model == model.id)
+        #expect(assignment.epoch == 5)
+
+        // A stale, older-epoch assignment is ignored — no further status messages.
+        let before = outbound.assignStatuses().count
+        await loop.handleAssignModelForTesting(modelId: model.id, epoch: 4, send: send)
+        #expect(outbound.assignStatuses().count == before)
     }
 
     private func makeClient() -> CoordinatorClient {

--- a/provider-swift/Tests/ProviderCoreTests/ProtocolTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/ProtocolTests.swift
@@ -307,6 +307,39 @@ import Testing
     #expect(failedObj["error"] as? String == "GPU OOM")
 }
 
+@Test func assignModelMessagesRoundTripWithCoordinator() throws {
+    // Coordinator → provider pool assignment (decode a Go-emitted wire form).
+    let goAssign = #"{"type":"assign_model","model_id":"gpt-oss-20b","epoch":7}"#
+    let decoded = try ProviderProtocolCodec.decodeCoordinatorMessage(from: goAssign)
+    guard case .assignModel(let a) = decoded else {
+        throw TestFailure.unexpectedMessage
+    }
+    #expect(a.modelId == "gpt-oss-20b")
+    #expect(a.epoch == 7)
+
+    // Provider → coordinator lifecycle replies (all four states), echoing epoch.
+    let replies: [ProviderMessage] = [
+        .assignModelStatus(ProviderMessage.AssignModelStatus(modelId: "gpt-oss-20b", epoch: 7, status: .draining)),
+        .assignModelStatus(ProviderMessage.AssignModelStatus(modelId: "gpt-oss-20b", epoch: 7, status: .loading)),
+        .assignModelStatus(ProviderMessage.AssignModelStatus(modelId: "gpt-oss-20b", epoch: 7, status: .succeeded)),
+        .assignModelStatus(ProviderMessage.AssignModelStatus(modelId: "gpt-oss-20b", epoch: 7, status: .failed, error: "GPU OOM")),
+    ]
+    for reply in replies {
+        let encoded = try ProviderProtocolCodec.encodeProviderMessage(reply)
+        let object = try jsonObject(encoded)
+        #expect(object["type"] as? String == "assign_model_status")
+        #expect(object["model_id"] as? String == "gpt-oss-20b")
+        #expect((object["epoch"] as? NSNumber)?.uint64Value == 7)
+        let roundTripped = try ProviderProtocolCodec.decodeProviderMessage(from: encoded)
+        #expect(roundTripped == reply)
+    }
+
+    // Failed status surfaces the error string on the wire.
+    let failedObj = try jsonObject(try ProviderProtocolCodec.encodeProviderMessage(replies[3]))
+    #expect(failedObj["status"] as? String == "failed")
+    #expect(failedObj["error"] as? String == "GPU OOM")
+}
+
 @Test func prefetchModelMessagesRoundTripWithCoordinator() throws {
     // Coordinator → provider prefetch request (decode a Go-emitted wire form).
     let goPrefetchRequest = #"{"type":"prefetch_model","model_id":"mlx-community/gemma-4-26B-A4B-it-qat-4bit","priority":5}"#


### PR DESCRIPTION
## Summary

Enforce **exactly one active public model per provider**, with the coordinator partitioning the fleet into per-model pools. Each managed machine is assigned one model; the scheduler routes only that model to it; pool exhaustion returns an uptime-neutral **429 `pool_exhausted`** instead of spilling into another model's machines. A demand-driven placement controller decides which machine holds which model and switches machines between pools conservatively. Closes [DAR-345](https://linear.app/darkbloom-dev/issue/DAR-345).

**All enforcement is DEFAULT-OFF** (atomic `assignmentGateEnabled` + `WARM_POOL_PLACEMENT_ENABLED`/`_ENFORCE`) — this PR is inert until flags are flipped, enabling a staged rollout.

## Why (grounded in prod telemetry, Jun 17–20)

A Mac has one shared GPU / unified-memory / **memory-bandwidth** budget; co-resident models split it nonlinearly.
- Two models dominate: **gpt-oss-20b ~83%** of served traffic, **gemma-4-26b ~17%**.
- gpt-oss decodes at **57 tps** p50; gemma at **2.6 tps** (~22× slower, far below the 15-tps quality bar).
- The #1 rejection is `model_shed` of gemma (**526K**, all `could_have_served`); #2 is `ttft_too_slow` (**342K**, 249K of it *on gpt-oss during gemma co-residency*).
- **Temporal proof of isolation:** gpt-oss `ttft_429` collapsed under co-residency, then recovered to **0%** once gemma was re-shed — while gpt-oss demand kept growing.

Pools replace the blunt global `model_shed` with surgical per-machine isolation, so gemma can be safely un-shed into a bounded, concurrency-capped pool without degrading gpt-oss. Switching is rare by design (regime changes + slow growth, not minute-scale flapping); anti-thrash reuses the warm pool's existing `MinDwell` (5m) / `MaxGlobalPendingLoads` / `MaxLoadsPerTick` knobs.

## What changed

**Coordinator (Go)**
- `protocol`: `assign_model` / `assign_model_status` messages (epoch + draining/loading/succeeded/failed).
- `registry`: per-provider assignment state + epoch; `AssignProviderModel`/`ApplyAssignModelStatus` (epoch-guarded, failed→isolated+cooldown); `PoolExhausted` (mirrors gate eligibility — counts unmanaged machines so a mixed-fleet rollout never false-429s).
- `scheduler`: one isolation gate in `providerPassesRoutingGatesLockedEx` (the shared selection/queue-drain/preflight/admit chokepoint) → no-spillover is **structural**; self-route owners bypass.
- `placement_controller`: pure `planPlacement` allocator (floor-then-priority normalization, surplus→deficit switching, anti-thrash, unmanaged-source preference); shadow vs enforce.
- admission: `shedIfPoolExhausted` 429 in **both** chat + responses handlers; version gate `>= 0.6.18` (fail-closed); pool-transition strings classified capacity-class (no false breaker trips).
- observability: `ModelPoolReport` (pool sizes, per-provider assignment, co-residency audit) on `/v1/admin/utilization`.

**Provider (Swift, protocol-symmetric)**
- `assign_model` handler: drain → unload-others → load+warm → status, epoch-guarded, off the event loop in a cancellable task; **refuse-don't-swap** (a managed machine refuses any non-assigned model instead of LRU-swapping). `ProviderCore.version` → `0.6.18`.

## Testing

- **Go:** allocator (9 cases), assignment/epoch/`pool_exhausted` (incl. real `httptest` no-spillover + mixed-fleet), observability. Full `registry` + `api` suites green.
- **Swift:** cross-language wire round-trip + handler lifecycle/epoch-guard/refuse. `darkbloom` builds; Swift tests pass.
- Dual review (Codex + independent); all blockers/highs fixed (status-handler wiring, version-gate, drain-before-unload, refuse ordering, send-failure cleanup).

## Notes for reviewers

- **Coordinator deploy is human-only** (EigenCloud prod) — not part of this PR.
- The `0.6.18` provider version and `minProviderVersionForModelAssignment` are the two ends of one gate; bump them together at release.
- A separate parallel branch `dar-345-model-pools` exists from another effort — worth reconciling before merge.
- Deferred follow-up (advisory, non-blocking): `PoolExhausted` could additionally honor cooldown/breaker/trust gates for more precise `pool_exhausted` labeling; "public model" wording in some comments is build-id in practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/435"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784597854&installation_id=133247490&pr_number=435&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F435&signature=f7eb1455998aadd1b0efb733432c3cc79fd3187e8c5cfc890eb1483869a3ea78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->