### PR TITLE
fix: reuse durable Apple MDA attestation across reconnect + correct dashboard warning

### DIFF
--- a/console-ui/src/app/providers/dashboard/fixes.ts
+++ b/console-ui/src/app/providers/dashboard/fixes.ts
@@ -85,10 +85,9 @@ const FIX_TABLE: Record<string, FixAction> = {
     command: "darkbloom restart",
   },
   mda_missing: {
-    kind: "link",
-    label: "Finish Apple attestation",
-    href: "/providers/setup",
-    note: "Proves to consumers this is a real Apple device.",
+    kind: "guidance",
+    label: "Automatic — no setup needed",
+    note: "Earned automatically once the coordinator completes the Apple attestation, then reused across restarts. Keep the Mac awake and reachable if it stays pending.",
   },
   thermal_serious: {
     kind: "guidance",

--- a/console-ui/src/app/providers/dashboard/mda-warning.test.ts
+++ b/console-ui/src/app/providers/dashboard/mda-warning.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import { computeWarnings } from "../warnings";
+import { deriveRouting } from "./routing";
+import { resolveFix } from "./fixes";
+import { makeProvider } from "./testFixtures";
+
+const ctx = {
+  latest_provider_version: "0.6.5",
+  min_provider_version: "0.6.0",
+  heartbeat_timeout_seconds: 90,
+  challenge_max_age_seconds: 360,
+};
+
+describe("Apple Device Attestation (mda_missing) warning", () => {
+  it("is informational, NOT degrading — MDA is not a routing factor", () => {
+    const p = makeProvider({ status: "serving", online: true, mda_verified: false });
+    const mda = computeWarnings(p, ctx).find((w) => w.id === "mda_missing");
+
+    expect(mda).toBeTruthy();
+    expect(mda!.severity).toBe("info"); // not "degrading"
+    expect(mda!.title).not.toMatch(/incomplete/i);
+  });
+
+  it("toggling mda_verified does not change routing — same state with and without it", () => {
+    const withMda = makeProvider({ status: "serving", online: true, mda_verified: true });
+    const withoutMda = makeProvider({ status: "serving", online: true, mda_verified: false });
+    const r1 = deriveRouting(withMda, computeWarnings(withMda, ctx));
+    const r2 = deriveRouting(withoutMda, computeWarnings(withoutMda, ctx));
+    expect(r2).toBe(r1); // MDA presence/absence must not alter the earning state
+  });
+
+  it("offers no action CTA — MDA is earned automatically and reused across restarts", () => {
+    const fix = resolveFix("mda_missing");
+    expect(fix.kind).toBe("guidance");
+    expect(fix.command).toBeUndefined();
+    expect(fix.href).toBeUndefined();
+  });
+
+  it("is absent once MDA is verified", () => {
+    const p = makeProvider({ status: "serving", online: true, mda_verified: true });
+    expect(computeWarnings(p, ctx).some((w) => w.id === "mda_missing")).toBe(false);
+  });
+});

--- a/console-ui/src/app/providers/warnings.ts
+++ b/console-ui/src/app/providers/warnings.ts
@@ -177,10 +177,10 @@ export function computeWarnings(
   ) {
     out.push({
       id: "mda_missing",
-      severity: "degrading",
-      title: "Apple Device Attestation incomplete",
+      severity: "info",
+      title: "Apple Device Attestation pending",
       detail:
-        "MDA proves to consumers that this is a real Apple device. Without it, some consumers will skip this machine.",
+        "This machine is hardware-trusted and earning at full priority — Apple Device Attestation does not affect routing. It's an extra Apple-signed identity proof that consumers can verify; it's earned automatically and reused across restarts. If it stays pending for a long time, keep the Mac awake and reachable so the coordinator can complete it.",
     });
   }
 

--- a/coordinator/api/mda_reuse_test.go
+++ b/coordinator/api/mda_reuse_test.go
@@ -1,0 +1,277 @@
+package api
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/attestation"
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+	"github.com/eigeninference/d-inference/coordinator/registry"
+	"github.com/eigeninference/d-inference/coordinator/store"
+)
+
+// mintMDALeafChain builds a single-cert DER chain (leaf signed by a test CA)
+// carrying the DevicePropertiesAttestation serial + freshness OIDs, and returns
+// the chain plus the test CA to install via attestation.OverrideRootCAForTest.
+func mintMDALeafChain(t *testing.T, serial string, freshness []byte) (chain [][]byte, root *x509.Certificate) {
+	return mintMDALeafChainExp(t, serial, freshness, time.Now().Add(24*time.Hour))
+}
+
+// mintMDALeafChainExp is mintMDALeafChain with an explicit leaf NotAfter, so tests
+// can exercise reuse behavior across the cert's validity window over time.
+func mintMDALeafChainExp(t *testing.T, serial string, freshness []byte, notAfter time.Time) (chain [][]byte, root *x509.Certificate) {
+	t.Helper()
+	caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	caTmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "Test Root"},
+		NotBefore:             time.Now().Add(-2 * time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	caDER, err := x509.CreateCertificate(rand.Reader, caTmpl, caTmpl, &caKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	root, err = x509.ParseCertificate(caDER)
+	if err != nil {
+		t.Fatal(err)
+	}
+	leafKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	serialBytes, _ := asn1.Marshal(serial)
+	freshBytes, _ := asn1.Marshal(freshness)
+	leafTmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: "Leaf"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     notAfter,
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtraExtensions: []pkix.Extension{
+			{Id: attestation.OIDDeviceSerialNumber, Value: serialBytes},
+			{Id: attestation.OIDFreshnessCode, Value: freshBytes},
+		},
+	}
+	leafDER, err := x509.CreateCertificate(rand.Reader, leafTmpl, root, &leafKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return [][]byte{leafDER}, root
+}
+
+// reconnectWithStagedChain mints a chain bound to (serial, sePubKey), installs the
+// test CA, and drives a provider through the reconnect → re-grant sequence so the
+// durable chain is staged and hardware is held — exactly the state the reuse path
+// runs in. Returns the live server + provider.
+func reconnectWithStagedChain(t *testing.T, serial, sePubKey string) (*Server, *registry.Provider, func()) {
+	t.Helper()
+	seHash := sha256.Sum256([]byte(sePubKey))
+	chain, root := mintMDALeafChain(t, serial, seHash[:])
+	restore := attestation.OverrideRootCAForTest(root)
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelError}))
+	reg := registry.New(logger)
+	// mdmClient deliberately nil: the reuse path must never touch it. A fresh
+	// DevicePropertiesAttestation send would deref nil and panic, so a green result
+	// here proves the rate-limited APNs round-trip was skipped.
+	srv := &Server{registry: reg, logger: logger}
+
+	regMsg := &protocol.RegisterMessage{
+		Type:     protocol.TypeRegister,
+		Hardware: protocol.Hardware{ChipName: "M4 Max", MemoryGB: 64},
+		Models:   []protocol.ModelInfo{{ID: "m", ModelType: "chat"}},
+		Backend:  "mlx-swift",
+	}
+	p := reg.Register("prov-mda", nil, regMsg)
+	p.SetAttestationResult(&attestation.VerificationResult{SerialNumber: serial, PublicKey: sePubKey})
+
+	// Simulate reconnect: the store has a durable chain; RestoreProviderState stages
+	// it (capping trust to self_signed). Hardware is then re-earned live.
+	chainJSON, _ := json.Marshal(chain)
+	reg.RestoreProviderState(p, &store.ProviderRecord{
+		ID:           "prov-mda",
+		TrustLevel:   string(registry.TrustHardware),
+		MDAVerified:  true,
+		MDACertChain: chainJSON,
+	})
+	p.SetAttested(true, registry.TrustHardware)
+	return srv, p, restore
+}
+
+// TestAttachCachedMDAProof_ReusesWithoutMDM is the core guarantee: after a
+// reconnect, a still-valid durable MDA chain is reused — re-verified locally and
+// re-bound to the SE key — with NO MicroMDM/APNs round-trip. This is what keeps
+// mda_verified green across a provider restart and dodges Apple's ≈1/device/7d
+// fresh-attestation rate limit.
+func TestAttachCachedMDAProof_ReusesWithoutMDM(t *testing.T) {
+	srv, p, restore := reconnectWithStagedChain(t, "SERIAL-A", "se-pub-key")
+	defer restore()
+
+	ar := p.GetAttestationResult()
+	if !srv.attachCachedMDAProof("prov-mda", p, *ar) {
+		t.Fatal("expected cached MDA proof to be reused")
+	}
+	p.Mu().Lock()
+	defer p.Mu().Unlock()
+	if !p.MDAVerified {
+		t.Error("MDAVerified must be true after reuse")
+	}
+	if !p.SEKeyBound {
+		t.Error("SEKeyBound must be true (freshness code matched the SE key hash)")
+	}
+	if len(p.MDACertChain) == 0 {
+		t.Error("MDACertChain must be attached for the attestation endpoint")
+	}
+}
+
+// TestVerifyAppleDeviceAttestation_CachedShortCircuit proves the full entry point
+// short-circuits on a cached proof: with a nil mdmClient, reaching the fresh
+// DevicePropertiesAttestation send would panic. A green, panic-free result means
+// the MDM command path was skipped entirely.
+func TestVerifyAppleDeviceAttestation_CachedShortCircuit(t *testing.T) {
+	srv, p, restore := reconnectWithStagedChain(t, "SERIAL-A", "se-pub-key")
+	defer restore()
+
+	ar := p.GetAttestationResult()
+	// udid is non-empty: if the cache path did NOT short-circuit, execution would
+	// fall through to s.mdmClient.SendDeviceAttestationCommand and panic on nil.
+	srv.verifyAppleDeviceAttestation(context.Background(), "prov-mda", p, *ar, "some-udid")
+
+	if !mdaVerified(p) {
+		t.Error("MDAVerified must be true via the cached short-circuit (no fresh MDM request)")
+	}
+}
+
+// mdaVerified reads MDAVerified under the provider lock (race-safe).
+func mdaVerified(p *registry.Provider) bool {
+	p.Mu().Lock()
+	defer p.Mu().Unlock()
+	return p.MDAVerified
+}
+
+// TestStageDurableMDAChain_LiveStoreReusedAcrossReconnect proves the prod path:
+// the chain is recovered from a LIVE store read (not the empty startup
+// storedProviders snapshot), so a provider that earned MDA in a prior connection
+// keeps mda_verified green on reconnect — with no fresh MDM/APNs round-trip.
+func TestStageDurableMDAChain_LiveStoreReusedAcrossReconnect(t *testing.T) {
+	const serial, sePub = "SERIAL-LIVE", "se-pub-live"
+	seHash := sha256.Sum256([]byte(sePub))
+	chain, root := mintMDALeafChain(t, serial, seHash[:])
+	defer attestation.OverrideRootCAForTest(root)()
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelError}))
+	mem := store.NewMemory(store.Config{AdminKey: "k"})
+	chainJSON, _ := json.Marshal(chain)
+	// A previous connection earned MDA and persisted it; the record survives the
+	// provider's disconnect.
+	if err := mem.UpsertProvider(context.Background(), store.ProviderRecord{
+		ID:           "old-session",
+		SerialNumber: serial,
+		TrustLevel:   string(registry.TrustHardware),
+		MDAVerified:  true,
+		MDACertChain: chainJSON,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	reg := registry.New(logger)
+	srv := &Server{registry: reg, logger: logger, store: mem}
+
+	// New reconnect session: storedProviders is nil/empty (startup snapshot), so the
+	// chain must come from the live store read.
+	p := reg.Register("new-session", nil, &protocol.RegisterMessage{Type: protocol.TypeRegister, Backend: "mlx-swift"})
+	p.SetAttestationResult(&attestation.VerificationResult{SerialNumber: serial, PublicKey: sePub})
+
+	srv.stageDurableMDAChain(p, serial)
+	if len(p.StagedMDAChain()) == 0 {
+		t.Fatal("expected the durable chain to be staged from the live store read")
+	}
+
+	p.SetAttested(true, registry.TrustHardware)
+	if !srv.attachCachedMDAProof("new-session", p, *p.GetAttestationResult()) {
+		t.Fatal("expected reuse of the live-store chain")
+	}
+	if !mdaVerified(p) {
+		t.Error("MDAVerified must be true after reuse via the live store path")
+	}
+}
+
+// TestAttachCachedMDAProof_ExpiredChainNotReused proves the time dimension: an
+// expired cached chain fails local re-verification, so reuse is declined and a
+// fresh attestation is requested instead of trusting a stale cert. (Apple uses a
+// freshness model rather than a fixed expiry; this is the relying-party staleness
+// check.)
+func TestAttachCachedMDAProof_ExpiredChainNotReused(t *testing.T) {
+	const serial, sePub = "SERIAL-EXP", "se-pub-exp"
+	seHash := sha256.Sum256([]byte(sePub))
+	// Leaf already expired.
+	chain, root := mintMDALeafChainExp(t, serial, seHash[:], time.Now().Add(-time.Minute))
+	defer attestation.OverrideRootCAForTest(root)()
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelError}))
+	reg := registry.New(logger)
+	srv := &Server{registry: reg, logger: logger}
+	p := reg.Register("p", nil, &protocol.RegisterMessage{Type: protocol.TypeRegister, Backend: "mlx-swift"})
+	p.SetAttestationResult(&attestation.VerificationResult{SerialNumber: serial, PublicKey: sePub})
+	chainJSON, _ := json.Marshal(chain)
+	p.StageMDAChainFromJSON(chainJSON)
+	p.SetAttested(true, registry.TrustHardware)
+
+	if srv.attachCachedMDAProof("p", p, *p.GetAttestationResult()) {
+		t.Fatal("expected an expired cached chain NOT to be reused")
+	}
+	if mdaVerified(p) {
+		t.Error("MDAVerified must stay false when the cached chain is expired")
+	}
+}
+
+// TestAttachCachedMDAProof_NoStagedChain confirms the reuse path declines when no
+// durable chain exists, so a fresh request is still made for first-time devices.
+func TestAttachCachedMDAProof_NoStagedChain(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelError}))
+	reg := registry.New(logger)
+	srv := &Server{registry: reg, logger: logger}
+	p := reg.Register("p", nil, &protocol.RegisterMessage{Type: protocol.TypeRegister, Backend: "mlx-swift"})
+	p.SetAttestationResult(&attestation.VerificationResult{SerialNumber: "S", PublicKey: "K"})
+	p.SetAttested(true, registry.TrustHardware)
+
+	if srv.attachCachedMDAProof("p", p, *p.GetAttestationResult()) {
+		t.Fatal("expected no reuse when there is no staged chain")
+	}
+}
+
+// TestAttachCachedMDAProof_RelayRejected proves anti-relay: a chain whose
+// freshness code binds a DIFFERENT SE key and whose serial does not match this
+// machine is NOT reused (it would otherwise let one machine inherit another's
+// Apple attestation).
+func TestAttachCachedMDAProof_RelayRejected(t *testing.T) {
+	// Chain is bound to "victim-se-key" + serial "VICTIM".
+	srv, p, restore := reconnectWithStagedChain(t, "VICTIM", "victim-se-key")
+	defer restore()
+
+	// But THIS connection presents a different SE key and serial.
+	p.SetAttestationResult(&attestation.VerificationResult{SerialNumber: "ATTACKER", PublicKey: "attacker-se-key"})
+
+	if srv.attachCachedMDAProof("prov-mda", p, *p.GetAttestationResult()) {
+		t.Fatal("expected reuse to be rejected when neither SE key nor serial binds")
+	}
+	if mdaVerified(p) {
+		t.Error("MDAVerified must stay false on a rejected (relay) reuse")
+	}
+}

--- a/coordinator/api/mda_reuse_test.go
+++ b/coordinator/api/mda_reuse_test.go
@@ -210,6 +210,18 @@ func TestStageDurableMDAChain_LiveStoreReusedAcrossReconnect(t *testing.T) {
 	if !mdaVerified(p) {
 		t.Error("MDAVerified must be true after reuse via the live store path")
 	}
+
+	// The reuse must persist the chain under THIS session's record, so a later
+	// reconnect can reuse it again instead of re-hitting Apple's rate limit. Look
+	// it up by serial (which now indexes this session) and confirm the chain is
+	// durable.
+	rec, err := mem.GetProviderBySerial(context.Background(), serial)
+	if err != nil || rec == nil {
+		t.Fatalf("expected a persisted record for serial after reuse: %v", err)
+	}
+	if !rec.MDAVerified || len(rec.MDACertChain) == 0 {
+		t.Errorf("reuse must persist the chain: mda_verified=%v chain_len=%d", rec.MDAVerified, len(rec.MDACertChain))
+	}
 }
 
 // TestAttachCachedMDAProof_ExpiredChainNotReused proves the time dimension: an

--- a/coordinator/api/provider.go
+++ b/coordinator/api/provider.go
@@ -3148,16 +3148,6 @@ func (s *Server) mdmVerificationLoop(ctx context.Context, providerID string, pro
 	}
 }
 
-// attachCachedMDAProof tries to satisfy the Apple Device Attestation (MDA) leg
-// from the durable cert chain restored on reconnect, WITHOUT a fresh
-// DevicePropertiesAttestation round-trip. Apple rate-limits a fresh attestation to
-// ≈1/device/7d and it rides the same throttled MicroMDM→APNs channel as
-// SecurityInfo, so re-fetching on every reconnect is the reason restarted
-// providers show "Apple Device Attestation incomplete". The cached chain is
-// re-verified here against Apple's pinned Enterprise Attestation Root CA (an
-// expired or tampered chain is rejected) and re-bound to THIS connection's SE key
-// via the FreshnessCode OID (anti-relay). Returns true if a valid, bound proof was
-// attached — which requires the provider to already hold hardware trust.
 // stageDurableMDAChain recovers a previously-earned Apple MDA cert chain from the
 // store (by serial) and stages it on the provider as a reuse candidate for this
 // reconnect. The store record survives provider disconnect, so this works under
@@ -3168,13 +3158,28 @@ func (s *Server) stageDurableMDAChain(provider *registry.Provider, serial string
 	if s.store == nil || serial == "" {
 		return
 	}
-	rec, err := s.store.GetProviderBySerial(context.Background(), serial)
+	// Bound the store read: this runs on the attestation path, so a slow or
+	// unavailable Postgres must not stall it — on timeout we skip staging and fall
+	// back to a fresh attestation.
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	rec, err := s.store.GetProviderBySerial(ctx, serial)
 	if err != nil || rec == nil || len(rec.MDACertChain) == 0 {
 		return
 	}
 	provider.StageMDAChainFromJSON(rec.MDACertChain)
 }
 
+// attachCachedMDAProof tries to satisfy the Apple Device Attestation (MDA) leg
+// from the durable cert chain restored on reconnect, WITHOUT a fresh
+// DevicePropertiesAttestation round-trip. Apple rate-limits a fresh attestation to
+// ≈1/device/7d and it rides the same throttled MicroMDM→APNs channel as
+// SecurityInfo, so re-fetching on every reconnect is the reason restarted
+// providers show "Apple Device Attestation incomplete". The cached chain is
+// re-verified here against Apple's pinned Enterprise Attestation Root CA (an
+// expired or tampered chain is rejected) and re-bound to THIS connection's SE key
+// via the FreshnessCode OID (anti-relay). Returns true if a valid, bound proof was
+// attached — which requires the provider to already hold hardware trust.
 func (s *Server) attachCachedMDAProof(providerID string, provider *registry.Provider, attestResult attestation.VerificationResult) bool {
 	chain := provider.StagedMDAChain()
 	if len(chain) == 0 {
@@ -3197,6 +3202,11 @@ func (s *Server) attachCachedMDAProof(providerID string, provider *registry.Prov
 	if attestResult.PublicKey == "" || len(mdaResult.FreshnessCode) == 0 {
 		return false
 	}
+	// INVARIANT: this must use the exact same input as the fresh path's nonce
+	// (verifyAppleDeviceAttestation computes expectedFreshness = sha256([]byte(
+	// attestResult.PublicKey)) and sends its base64 as the DeviceAttestationNonce).
+	// Apple echoes the decoded nonce as the FreshnessCode, so a chain earned fresh
+	// has FreshnessCode == this digest. Keep the two formulas identical.
 	want := sha256.Sum256([]byte(attestResult.PublicKey))
 	if !bytes.Equal(mdaResult.FreshnessCode, want[:]) {
 		return false

--- a/coordinator/api/provider.go
+++ b/coordinator/api/provider.go
@@ -3049,6 +3049,14 @@ func (s *Server) ApplyLateSecurityInfo(udid string, info *mdm.SecurityInfoRespon
 		if seKey != "" && binaryHash != "" {
 			s.recordTrustReuse(c.provider, seKey, c.serial, binaryHash, true /*sip*/, true /*secureBootFull*/, udid)
 		}
+
+		// The late grant earned hardware WITHOUT the synchronous MDM verify (which
+		// runs the MDA leg via verifyAppleDeviceAttestation), so attach the durable
+		// MDA proof here too — otherwise a provider upgraded via late SecurityInfo
+		// stays mda_verified=false despite a valid cached chain.
+		if ar := c.provider.GetAttestationResult(); ar != nil {
+			s.attachCachedMDAProof(c.provider.ID, c.provider, *ar)
+		}
 	}
 }
 

--- a/coordinator/api/provider.go
+++ b/coordinator/api/provider.go
@@ -1770,6 +1770,14 @@ func (s *Server) verifyChallengeResponse(providerID string, provider *registry.P
 		// window elapsed, hard-untrusted) returns false and falls through to the
 		// unchanged full live MDM verify.
 		if s.tryTrustReuseFastSkip(providerID, provider, resp, statusFieldsTrusted) {
+			// The fast-skip granted hardware WITHOUT running the full live MDM verify,
+			// so verifyAppleDeviceAttestation never ran on this connection. Reuse the
+			// durable MDA proof (re-verified locally against Apple's root + re-bound to
+			// this SE key) so a restart keeps mda_verified green with zero MDM/APNs
+			// traffic — the whole point of the fast-skip is to avoid that round-trip.
+			if ar := provider.GetAttestationResult(); ar != nil {
+				s.attachCachedMDAProof(providerID, provider, *ar)
+			}
 			// DAR-326 FIX 3: the fast-skip just granted hardware, so this provider is
 			// freshly routable — drain any queued requests now instead of waiting for
 			// the next heartbeat / 120s queue timeout. Off the challenge goroutine,
@@ -2729,6 +2737,15 @@ func (s *Server) verifyProviderAttestation(providerID string, provider *registry
 		}
 	}
 
+	// Stage the durable Apple MDA cert chain from a LIVE store read. storedProviders
+	// above is a one-time startup snapshot — empty for the coordinator's whole life
+	// under the in-memory store used in prod — so it cannot surface a chain earned
+	// during this coordinator's lifetime. The store record survives provider
+	// disconnect, so a serial lookup recovers a chain a previous connection earned,
+	// letting attachCachedMDAProof reuse it (re-verified + SE-key-bound) instead of
+	// forcing a fresh, Apple-rate-limited DevicePropertiesAttestation round-trip.
+	s.stageDurableMDAChain(provider, result.SerialNumber)
+
 	// Deduplicate: if another provider connection exists from the same physical
 	// device (same serial number), disconnect it. This prevents multiple
 	// provider processes on the same machine from registering independently
@@ -3122,9 +3139,90 @@ func (s *Server) mdmVerificationLoop(ctx context.Context, providerID string, pro
 	}
 }
 
+// attachCachedMDAProof tries to satisfy the Apple Device Attestation (MDA) leg
+// from the durable cert chain restored on reconnect, WITHOUT a fresh
+// DevicePropertiesAttestation round-trip. Apple rate-limits a fresh attestation to
+// ≈1/device/7d and it rides the same throttled MicroMDM→APNs channel as
+// SecurityInfo, so re-fetching on every reconnect is the reason restarted
+// providers show "Apple Device Attestation incomplete". The cached chain is
+// re-verified here against Apple's pinned Enterprise Attestation Root CA (an
+// expired or tampered chain is rejected) and re-bound to THIS connection's SE key
+// via the FreshnessCode OID (anti-relay). Returns true if a valid, bound proof was
+// attached — which requires the provider to already hold hardware trust.
+// stageDurableMDAChain recovers a previously-earned Apple MDA cert chain from the
+// store (by serial) and stages it on the provider as a reuse candidate for this
+// reconnect. The store record survives provider disconnect, so this works under
+// the in-memory store used in prod — where the startup storedProviders snapshot is
+// empty — as well as a durable store. Best-effort: a missing record / chain or a
+// read error simply stages nothing, and a fresh attestation is requested.
+func (s *Server) stageDurableMDAChain(provider *registry.Provider, serial string) {
+	if s.store == nil || serial == "" {
+		return
+	}
+	rec, err := s.store.GetProviderBySerial(context.Background(), serial)
+	if err != nil || rec == nil || len(rec.MDACertChain) == 0 {
+		return
+	}
+	provider.StageMDAChainFromJSON(rec.MDACertChain)
+}
+
+func (s *Server) attachCachedMDAProof(providerID string, provider *registry.Provider, attestResult attestation.VerificationResult) bool {
+	chain := provider.StagedMDAChain()
+	if len(chain) == 0 {
+		return false
+	}
+	mdaResult, err := attestation.VerifyMDADeviceAttestation(chain)
+	if err != nil || mdaResult == nil || !mdaResult.Valid {
+		// Chain no longer verifies (expired / not Apple-signed) — fall through to a
+		// fresh request.
+		return false
+	}
+
+	// Cached reuse REQUIRES the strong SE-key binding: the FreshnessCode OID in the
+	// Apple-signed chain must equal SHA-256 of THIS connection's SE public key. A
+	// serial-only match is deliberately NOT sufficient to reuse a stored chain — if
+	// the SE key rotated (re-image / keychain reset) the old chain no longer binds
+	// this key, so we fall through to a fresh attestation rather than letting a new
+	// key inherit the prior device's Apple proof. (A live challenge has already
+	// proven possession of this SE key, so the binding is meaningful.)
+	if attestResult.PublicKey == "" || len(mdaResult.FreshnessCode) == 0 {
+		return false
+	}
+	want := sha256.Sum256([]byte(attestResult.PublicKey))
+	if !bytes.Equal(mdaResult.FreshnessCode, want[:]) {
+		return false
+	}
+	// Defense in depth: when Apple included a serial, it must match this machine's
+	// attested serial (privacy-enrolled chains omit the serial — the SE-key binding
+	// above carries the proof in that case).
+	if mdaResult.DeviceSerial != "" && mdaResult.DeviceSerial != attestResult.SerialNumber {
+		return false
+	}
+
+	if !provider.SetMDAProofIfHardwareBound(chain, mdaResult, true) {
+		// Not hardware-trusted (yet) — nothing to attach the proof to.
+		return false
+	}
+	s.logger.Info("MDA reused from durable cert chain — skipped fresh DevicePropertiesAttestation",
+		"provider_id", providerID,
+		"mda_serial", mdaResult.DeviceSerial,
+		"se_key_bound", true,
+	)
+	s.ddIncr("mda.verification", []string{"outcome:reused"})
+	return true
+}
+
 // verifyAppleDeviceAttestation sends a DeviceInformation command requesting
 // DevicePropertiesAttestation and verifies the Apple-signed certificate chain.
 func (s *Server) verifyAppleDeviceAttestation(ctx context.Context, providerID string, provider *registry.Provider, attestResult attestation.VerificationResult, udid string) {
+	// Fast path: reuse a still-valid, SE-key-bound Apple attestation recovered from
+	// the durable store instead of requesting a fresh one. This skips the
+	// rate-limited APNs round-trip entirely on reconnect/restart and is what keeps
+	// mda_verified green across a provider restart.
+	if s.attachCachedMDAProof(providerID, provider, attestResult) {
+		return
+	}
+
 	if udid == "" {
 		s.logger.Warn("no UDID for MDA verification", "provider_id", providerID)
 		return
@@ -3217,6 +3315,15 @@ func (s *Server) verifyAppleDeviceAttestation(ctx context.Context, providerID st
 	provider.MDAResult = mdaResult
 	provider.SEKeyBound = seKeyBound
 	provider.Mu().Unlock()
+
+	// Persist the freshly-earned chain NOW so it is durable for reuse. The
+	// hardware-grant PersistProvider ran before this MDA leg, so without an explicit
+	// write here the chain would only reach the store on the next throttled
+	// heartbeat persist — and would be lost (and re-fetched, hitting Apple's
+	// ~1/device/7d rate limit) if the provider disconnects in that window. With a
+	// durable (Postgres) store this is what makes the proof recoverable across a
+	// coordinator restart.
+	s.registry.PersistProvider(provider)
 
 	// Log results.
 	if seKeyNonce != "" && len(mdaResult.FreshnessCode) > 0 {

--- a/coordinator/api/provider.go
+++ b/coordinator/api/provider.go
@@ -1796,7 +1796,16 @@ func (s *Server) verifyChallengeResponse(providerID string, provider *registry.P
 			// mdmVerificationLoop (SignalChallengeSettled, so it stops deferring and
 			// runs the live verify) if ACME did NOT grant hardware.
 			s.retryACMETrust(providerID, provider)
-			if provider.GetTrustLevel() != registry.TrustHardware {
+			if provider.GetTrustLevel() == registry.TrustHardware {
+				// ACME granted hardware without the live MDM verify, so
+				// verifyAppleDeviceAttestation (which runs the MDA leg) never fires and
+				// the mdmVerificationLoop exits. Attach the durable MDA proof here too,
+				// or an ACME-trusted reconnect keeps mda_verified=false despite a valid
+				// cached chain.
+				if ar := provider.GetAttestationResult(); ar != nil {
+					s.attachCachedMDAProof(providerID, provider, *ar)
+				}
+			} else {
 				provider.SignalChallengeSettled()
 			}
 		}
@@ -3203,6 +3212,13 @@ func (s *Server) attachCachedMDAProof(providerID string, provider *registry.Prov
 		// Not hardware-trusted (yet) — nothing to attach the proof to.
 		return false
 	}
+	// Persist immediately under THIS connection's record. The grant-path
+	// PersistProvider ran before this attach, so without this write the new
+	// session's row would carry an empty mda_cert_chain until the next throttled
+	// heartbeat — and a disconnect in that window would lose the chain (serial now
+	// indexes this session's row), forcing a fresh, rate-limited refetch on the
+	// next reconnect. Mirrors the fresh-MDA path's immediate persist.
+	s.registry.PersistProvider(provider)
 	s.logger.Info("MDA reused from durable cert chain — skipped fresh DevicePropertiesAttestation",
 		"provider_id", providerID,
 		"mda_serial", mdaResult.DeviceSerial,

--- a/coordinator/api/provider.go
+++ b/coordinator/api/provider.go
@@ -3163,11 +3163,15 @@ func (s *Server) stageDurableMDAChain(provider *registry.Provider, serial string
 	// back to a fresh attestation.
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
-	rec, err := s.store.GetProviderBySerial(ctx, serial)
-	if err != nil || rec == nil || len(rec.MDACertChain) == 0 {
+	// Newest NON-EMPTY chain for this serial: a reconnect persists a new row that
+	// may briefly carry an empty chain (async persists race the reattach), which
+	// would shadow a still-valid chain via a plain by-serial lookup. This looks
+	// past those empty rows.
+	chain, err := s.store.GetMDAChainBySerial(ctx, serial)
+	if err != nil || len(chain) == 0 {
 		return
 	}
-	provider.StageMDAChainFromJSON(rec.MDACertChain)
+	provider.StageMDAChainFromJSON(chain)
 }
 
 // attachCachedMDAProof tries to satisfy the Apple Device Attestation (MDA) leg

--- a/coordinator/attestation/mda.go
+++ b/coordinator/attestation/mda.go
@@ -20,6 +20,7 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
+	"sync"
 )
 
 // Apple MDA OID constants — ACME device-attest-01 path (existing).
@@ -59,6 +60,16 @@ ZwFEh9bhKjJ+5VQ9/Do1os0u3LEkgN/r
 
 var appleEnterpriseAttestationRootCA *x509.Certificate
 
+// verifyRoot is the trust anchor MDA certificate chains are verified against. In
+// production it is the embedded Apple Enterprise Attestation Root CA (set in
+// init). Tests swap it via OverrideRootCAForTest to exercise the verification and
+// reuse paths with a chain signed by a CA they control — Apple's private key is,
+// of course, unavailable to tests. Guarded by verifyRootMu.
+var (
+	verifyRootMu sync.RWMutex
+	verifyRoot   *x509.Certificate
+)
+
 func init() {
 	block, _ := pem.Decode([]byte(appleEnterpriseAttestationRootCAPEM))
 	if block == nil {
@@ -68,6 +79,30 @@ func init() {
 	appleEnterpriseAttestationRootCA, err = x509.ParseCertificate(block.Bytes)
 	if err != nil {
 		panic(fmt.Sprintf("attestation: failed to parse embedded Apple Root CA: %v", err))
+	}
+	verifyRoot = appleEnterpriseAttestationRootCA
+}
+
+// currentVerifyRoot returns the active MDA trust anchor (Apple's embedded root in
+// production).
+func currentVerifyRoot() *x509.Certificate {
+	verifyRootMu.RLock()
+	defer verifyRootMu.RUnlock()
+	return verifyRoot
+}
+
+// OverrideRootCAForTest swaps the MDA trust anchor and returns a restore func.
+// TEST-ONLY: production always verifies against the embedded Apple Enterprise
+// Attestation Root CA. Never call this from non-test code.
+func OverrideRootCAForTest(root *x509.Certificate) func() {
+	verifyRootMu.Lock()
+	prev := verifyRoot
+	verifyRoot = root
+	verifyRootMu.Unlock()
+	return func() {
+		verifyRootMu.Lock()
+		verifyRoot = prev
+		verifyRootMu.Unlock()
 	}
 }
 
@@ -119,7 +154,7 @@ func VerifyMDADeviceAttestation(certChainDER [][]byte) (*MDAResult, error) {
 
 	// Build verification chain.
 	roots := x509.NewCertPool()
-	roots.AddCert(appleEnterpriseAttestationRootCA)
+	roots.AddCert(currentVerifyRoot())
 
 	intermediates := x509.NewCertPool()
 	for _, ic := range certs[1:] {

--- a/coordinator/attestation/mda_reuse_test.go
+++ b/coordinator/attestation/mda_reuse_test.go
@@ -1,0 +1,154 @@
+package attestation
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
+	"math/big"
+	"testing"
+	"time"
+)
+
+// mintDevicePropertiesChain builds a DER cert chain (leaf signed by a test CA)
+// carrying the DevicePropertiesAttestation OIDs: device serial, UDID, and the
+// freshness code (the SHA-256 of the SE public key the attestation was requested
+// with). It returns the single-cert DER chain (leaf first) and the test CA so a
+// caller can install it via OverrideRootCAForTest.
+func mintDevicePropertiesChain(t *testing.T, serial, udid string, freshness []byte, notAfter time.Time) (chainDER [][]byte, root *x509.Certificate) {
+	t.Helper()
+
+	caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	caTmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "Apple Enterprise Attestation Root CA (Test)"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	caDER, err := x509.CreateCertificate(rand.Reader, caTmpl, caTmpl, &caKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	root, err = x509.ParseCertificate(caDER)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	leafKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	serialBytes, _ := asn1.Marshal(serial)
+	udidBytes, _ := asn1.Marshal(udid)
+	freshBytes, _ := asn1.Marshal(freshness) // OCTET STRING wrapping the raw hash
+
+	leafTmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: "Test Device Leaf"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     notAfter,
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtraExtensions: []pkix.Extension{
+			{Id: OIDDeviceSerialNumber, Value: serialBytes},
+			{Id: OIDDeviceUDID, Value: udidBytes},
+			{Id: OIDFreshnessCode, Value: freshBytes},
+		},
+	}
+	leafDER, err := x509.CreateCertificate(rand.Reader, leafTmpl, root, &leafKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return [][]byte{leafDER}, root
+}
+
+// TestVerifyMDADeviceAttestation_DevicePropertiesPath verifies the
+// DevicePropertiesAttestation (DeviceInformation) path end-to-end against a
+// test root: the chain validates, and the device serial/UDID/freshness OIDs are
+// extracted. The freshness code must equal the raw SE-key hash so the caller can
+// re-bind the proof to a specific machine.
+func TestVerifyMDADeviceAttestation_DevicePropertiesPath(t *testing.T) {
+	seHash := sha256.Sum256([]byte("se-public-key"))
+	chain, root := mintDevicePropertiesChain(t, "C02XL3FHJG5J", "UDID-1234", seHash[:], time.Now().Add(24*time.Hour))
+
+	restore := OverrideRootCAForTest(root)
+	defer restore()
+
+	res, err := VerifyMDADeviceAttestation(chain)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !res.Valid {
+		t.Fatalf("expected valid, got error: %s", res.Error)
+	}
+	if res.DeviceSerial != "C02XL3FHJG5J" {
+		t.Errorf("serial = %q, want C02XL3FHJG5J", res.DeviceSerial)
+	}
+	if res.DeviceUDID != "UDID-1234" {
+		t.Errorf("udid = %q, want UDID-1234", res.DeviceUDID)
+	}
+	if string(res.FreshnessCode) != string(seHash[:]) {
+		t.Errorf("freshness code does not match SE key hash")
+	}
+}
+
+// TestVerifyMDADeviceAttestation_ExpiredLeafRejected confirms an expired cached
+// chain is rejected by re-verification (so the reuse path falls back to a fresh
+// request instead of trusting a stale cert).
+func TestVerifyMDADeviceAttestation_ExpiredLeafRejected(t *testing.T) {
+	seHash := sha256.Sum256([]byte("se-public-key"))
+	chain, root := mintDevicePropertiesChain(t, "SERIAL", "UDID", seHash[:], time.Now().Add(-time.Minute))
+
+	restore := OverrideRootCAForTest(root)
+	defer restore()
+
+	res, err := VerifyMDADeviceAttestation(chain)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Valid {
+		t.Fatal("expected invalid result for an expired leaf cert")
+	}
+}
+
+// TestVerifyMDADeviceAttestation_WrongRootRejected confirms a chain not signed by
+// the active root fails — i.e. production still requires Apple's pinned root.
+func TestVerifyMDADeviceAttestation_WrongRootRejected(t *testing.T) {
+	seHash := sha256.Sum256([]byte("k"))
+	chain, _ := mintDevicePropertiesChain(t, "SERIAL", "UDID", seHash[:], time.Now().Add(time.Hour))
+	// Do NOT install the minting CA as the verify root — the default Apple root is
+	// in effect, so the test chain must fail to verify.
+	res, err := VerifyMDADeviceAttestation(chain)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Valid {
+		t.Fatal("expected invalid result when chain is not signed by the active root CA")
+	}
+}
+
+// TestOverrideRootCAForTest_Restores ensures the test seam restores the real
+// Apple root so it cannot leak across tests.
+func TestOverrideRootCAForTest_Restores(t *testing.T) {
+	orig := currentVerifyRoot()
+	if orig != appleEnterpriseAttestationRootCA {
+		t.Fatal("default verify root should be the embedded Apple root")
+	}
+	other := &x509.Certificate{}
+	restore := OverrideRootCAForTest(other)
+	if currentVerifyRoot() != other {
+		t.Fatal("override did not take effect")
+	}
+	restore()
+	if currentVerifyRoot() != appleEnterpriseAttestationRootCA {
+		t.Fatal("restore did not return the embedded Apple root")
+	}
+}

--- a/coordinator/cmd/coordinator/main.go
+++ b/coordinator/cmd/coordinator/main.go
@@ -542,6 +542,9 @@ func main() {
 			// is re-granted this connection.
 			reg.ForEachProvider(func(p *registry.Provider) {
 				if p.SetMDAProofIfHardware(certChain, mdaResult) {
+					// Persist now so the late-arriving chain is durable for reuse on
+					// the next reconnect, rather than waiting on a throttled heartbeat.
+					reg.PersistProvider(p)
 					logger.Info("late MDA cert stored on provider",
 						"provider_id", p.ID,
 						"serial", mdaResult.DeviceSerial,

--- a/coordinator/registry/mda_reuse_test.go
+++ b/coordinator/registry/mda_reuse_test.go
@@ -1,0 +1,120 @@
+package registry
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/eigeninference/d-inference/coordinator/attestation"
+	"github.com/eigeninference/d-inference/coordinator/store"
+)
+
+// TestRestoreProviderStateStagesMDAChain verifies that a reconnect stages the
+// durable Apple-signed MDA cert chain from the store WITHOUT surfacing it as a
+// verified proof. The staged chain is what lets the hardware-grant path reuse a
+// still-valid attestation instead of forcing a fresh, rate-limited request.
+func TestRestoreProviderStateStagesMDAChain(t *testing.T) {
+	reg := New(testLogger())
+	p := reg.Register("p1", nil, testRegisterMessage())
+
+	chain := [][]byte{[]byte("leaf-der-bytes")}
+	chainJSON, _ := json.Marshal(chain)
+	rec := &store.ProviderRecord{
+		ID:           "p1",
+		TrustLevel:   string(TrustHardware),
+		MDAVerified:  true,
+		MDACertChain: chainJSON,
+	}
+
+	reg.RestoreProviderState(p, rec)
+
+	// MDAVerified must stay false (drift guard) — the proof is re-earned this
+	// connection, not resurrected.
+	p.Mu().Lock()
+	mda := p.MDAVerified
+	p.Mu().Unlock()
+	if mda {
+		t.Error("MDAVerified must be false after restore (drift guard)")
+	}
+
+	// ...but the chain is staged for local re-verification at hardware-grant.
+	staged := p.StagedMDAChain()
+	if len(staged) != 1 || string(staged[0]) != "leaf-der-bytes" {
+		t.Errorf("StagedMDAChain = %v, want the stored chain", staged)
+	}
+}
+
+// TestRestoreProviderStateNoMDAChain confirms an absent stored chain leaves the
+// staging slot empty (so the reuse path declines and a fresh request is made).
+func TestRestoreProviderStateNoMDAChain(t *testing.T) {
+	reg := New(testLogger())
+	p := reg.Register("p1", nil, testRegisterMessage())
+	reg.RestoreProviderState(p, &store.ProviderRecord{ID: "p1", TrustLevel: string(TrustSelfSigned)})
+	if staged := p.StagedMDAChain(); staged != nil {
+		t.Errorf("StagedMDAChain = %v, want nil", staged)
+	}
+}
+
+// TestSetMDAProofIfHardwareBound covers the binding matrix: a proof is attached
+// only when the provider holds hardware trust AND the proof binds to this machine
+// by SE-key freshness OR by a matching attested serial.
+func TestSetMDAProofIfHardwareBound(t *testing.T) {
+	chain := [][]byte{[]byte("der")}
+
+	newHardwareProvider := func(serial string) *Provider {
+		reg := New(testLogger())
+		p := reg.Register("p", nil, testRegisterMessage())
+		p.SetAttestationResult(&attestation.VerificationResult{SerialNumber: serial, PublicKey: "PUB"})
+		p.TrustLevel = TrustHardware
+		return p
+	}
+
+	t.Run("se-key bound, serial omitted -> attached", func(t *testing.T) {
+		p := newHardwareProvider("SERIAL-A")
+		ok := p.SetMDAProofIfHardwareBound(chain, &attestation.MDAResult{Valid: true, DeviceSerial: ""}, true)
+		if !ok {
+			t.Fatal("expected attach with SE-key binding and omitted serial")
+		}
+		p.Mu().Lock()
+		defer p.Mu().Unlock()
+		if !p.MDAVerified || !p.SEKeyBound {
+			t.Errorf("MDAVerified=%v SEKeyBound=%v, want both true", p.MDAVerified, p.SEKeyBound)
+		}
+	})
+
+	t.Run("serial match, not se-key bound -> attached", func(t *testing.T) {
+		p := newHardwareProvider("SERIAL-A")
+		ok := p.SetMDAProofIfHardwareBound(chain, &attestation.MDAResult{Valid: true, DeviceSerial: "SERIAL-A"}, false)
+		if !ok {
+			t.Fatal("expected attach on serial match")
+		}
+	})
+
+	t.Run("no binding -> rejected", func(t *testing.T) {
+		p := newHardwareProvider("SERIAL-A")
+		ok := p.SetMDAProofIfHardwareBound(chain, &attestation.MDAResult{Valid: true, DeviceSerial: "SERIAL-B"}, false)
+		if ok {
+			t.Fatal("expected reject when neither SE key nor serial binds (relay/device-swap)")
+		}
+		p.Mu().Lock()
+		defer p.Mu().Unlock()
+		if p.MDAVerified {
+			t.Error("MDAVerified must stay false on a rejected attach")
+		}
+	})
+
+	t.Run("self_signed -> rejected even when bound", func(t *testing.T) {
+		p := newHardwareProvider("SERIAL-A")
+		p.TrustLevel = TrustSelfSigned
+		ok := p.SetMDAProofIfHardwareBound(chain, &attestation.MDAResult{Valid: true, DeviceSerial: "SERIAL-A"}, true)
+		if ok {
+			t.Fatal("expected reject when not hardware-trusted")
+		}
+	})
+
+	t.Run("nil result -> rejected", func(t *testing.T) {
+		p := newHardwareProvider("SERIAL-A")
+		if p.SetMDAProofIfHardwareBound(chain, nil, true) {
+			t.Fatal("expected reject for nil mdaResult")
+		}
+	})
+}

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -334,6 +334,14 @@ type Provider struct {
 	ACMEVerified      bool                   // true if ACME device-attest-01 client cert verified (SE key proven)
 	SEKeyBound        bool                   // true if SE key was bound to device via MDA nonce
 
+	// restoredMDAChain holds the durable Apple-signed MDA cert chain recovered
+	// from the store on reconnect (see RestoreProviderState). It is a CANDIDATE
+	// only: it is surfaced as a verified proof (MDAVerified/MDACertChain/MDAResult)
+	// solely after attachCachedMDAProof re-verifies it against Apple's pinned root
+	// AND re-binds it to this connection's SE key at hardware-grant time. Kept
+	// unexported so it never serializes to the store or the attestation endpoint.
+	restoredMDAChain [][]byte
+
 	// MDMFailureReason records the last MDM verification outcome for this
 	// connection, bucketed for observability: "" (verified/none),
 	// "device-not-found", "found-not-enrolled", "securityinfo-timeout",
@@ -626,6 +634,63 @@ func (p *Provider) SetMDAProofIfHardware(certChain [][]byte, mdaResult *attestat
 	p.MDACertChain = certChain
 	p.MDAResult = mdaResult
 	return true
+}
+
+// SetMDAProofIfHardwareBound atomically attaches an Apple Device Attestation proof
+// IFF the provider currently holds hardware trust AND the proof binds to THIS
+// machine — either by SE-key freshness (seKeyBound, the FreshnessCode OID equals
+// SHA-256 of this connection's SE public key) OR by a matching attested serial.
+// Returns true if attached. Unlike SetMDAProofIfHardware (which requires a serial
+// match), this accepts an SE-key binding so a privacy-preserving attestation that
+// omits the serial can still be reused. Same single-lock TOCTOU/race rationale as
+// SetMDAProofIfHardware.
+func (p *Provider) SetMDAProofIfHardwareBound(certChain [][]byte, mdaResult *attestation.MDAResult, seKeyBound bool) bool {
+	if mdaResult == nil {
+		return false
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.TrustLevel != TrustHardware {
+		return false
+	}
+	serialOK := mdaResult.DeviceSerial != "" && p.AttestationResult != nil &&
+		mdaResult.DeviceSerial == p.AttestationResult.SerialNumber
+	if !seKeyBound && !serialOK {
+		return false
+	}
+	p.MDAVerified = true
+	p.MDACertChain = certChain
+	p.MDAResult = mdaResult
+	p.SEKeyBound = seKeyBound
+	return true
+}
+
+// StagedMDAChain returns the durable MDA cert chain restored from the store for
+// this reconnect (nil if none). Thread-safe. The chain is a CANDIDATE only: the
+// caller must re-verify it against Apple's root and re-bind it to the live SE key
+// before trusting it (see api.attachCachedMDAProof).
+func (p *Provider) StagedMDAChain() [][]byte {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.restoredMDAChain
+}
+
+// StageMDAChainFromJSON stages a JSON-encoded ([][]byte) MDA cert chain — recovered
+// from a live store record at reconnect — as a reuse candidate. No-op on empty
+// input or a decode error. Like the staging in RestoreProviderState, this only
+// sets the candidate; the proof is surfaced only after attachCachedMDAProof
+// re-verifies it against Apple's root and re-binds it to this SE key.
+func (p *Provider) StageMDAChainFromJSON(raw json.RawMessage) {
+	if len(raw) == 0 {
+		return
+	}
+	var chain [][]byte
+	if err := json.Unmarshal(raw, &chain); err != nil || len(chain) == 0 {
+		return
+	}
+	p.mu.Lock()
+	p.restoredMDAChain = chain
+	p.mu.Unlock()
 }
 
 // SetLastChallengeVerified updates the challenge timestamp (thread-safe).
@@ -1331,6 +1396,23 @@ func (r *Registry) RestoreProviderState(p *Provider, rec *store.ProviderRecord) 
 	// this connection.
 	p.MDAVerified = false
 	p.ACMEVerified = false
+
+	// Stage the durable Apple-signed MDA cert chain (if the store has one) for
+	// local re-verification at this connection's hardware-grant. We deliberately
+	// do NOT set MDAVerified/MDACertChain here — the proof is surfaced only after
+	// attachCachedMDAProof re-verifies it against Apple's pinned root AND re-binds
+	// it to this connection's SE key. This lets a reconnect/restart reuse a
+	// still-valid attestation instead of forcing a fresh, Apple-rate-limited
+	// (≈1/device/7d) DevicePropertiesAttestation round-trip over the throttled
+	// MicroMDM→APNs channel — the root cause of providers showing "Apple Device
+	// Attestation incomplete" after a restart.
+	p.restoredMDAChain = nil
+	if len(rec.MDACertChain) > 0 {
+		var chain [][]byte
+		if err := json.Unmarshal(rec.MDACertChain, &chain); err == nil && len(chain) > 0 {
+			p.restoredMDAChain = chain
+		}
+	}
 
 	// Restore challenge state, but never move a fresh live verification
 	// backwards. Registration attestation sets LastChallengeVerified=now before

--- a/coordinator/store/interface.go
+++ b/coordinator/store/interface.go
@@ -466,6 +466,14 @@ type Store interface {
 	// GetProviderBySerial returns a provider record by serial number.
 	GetProviderBySerial(ctx context.Context, serial string) (*ProviderRecord, error)
 
+	// GetMDAChainBySerial returns the newest NON-EMPTY Apple MDA cert chain stored
+	// for a serial, or (nil, nil) if none. A reconnecting provider gets a new row
+	// (keyed by a fresh provider id) that may be persisted with an empty chain
+	// before the chain is reattached; GetProviderBySerial would return that newer
+	// empty row and shadow a still-valid chain from a prior connection. This query
+	// looks past empty rows so MDA reuse survives that race.
+	GetMDAChainBySerial(ctx context.Context, serial string) (json.RawMessage, error)
+
 	// ListProviders returns all stored provider records.
 	ListProviderRecords(ctx context.Context) ([]ProviderRecord, error)
 

--- a/coordinator/store/memory.go
+++ b/coordinator/store/memory.go
@@ -2726,6 +2726,33 @@ func (s *MemoryStore) GetProviderBySerial(_ context.Context, serial string) (*Pr
 	return &cp, nil
 }
 
+func (s *MemoryStore) GetMDAChainBySerial(_ context.Context, serial string) (json.RawMessage, error) {
+	if serial == "" {
+		return nil, nil
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	// Scan all records (not just the serial-indexed latest) so a newer empty-chain
+	// row cannot shadow a chain-bearing one from a prior connection. Pick the most
+	// recently seen non-empty chain.
+	var best *ProviderRecord
+	for _, p := range s.providerRecords {
+		if p.SerialNumber != serial || len(p.MDACertChain) == 0 {
+			continue
+		}
+		if best == nil || p.LastSeen.After(best.LastSeen) {
+			best = p
+		}
+	}
+	if best == nil {
+		return nil, nil
+	}
+	out := make(json.RawMessage, len(best.MDACertChain))
+	copy(out, best.MDACertChain)
+	return out, nil
+}
+
 func (s *MemoryStore) ListProviderRecords(_ context.Context) ([]ProviderRecord, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()

--- a/coordinator/store/postgres.go
+++ b/coordinator/store/postgres.go
@@ -4118,6 +4118,30 @@ func (s *PostgresStore) GetProviderBySerial(ctx context.Context, serial string) 
 	return &p, nil
 }
 
+func (s *PostgresStore) GetMDAChainBySerial(ctx context.Context, serial string) (json.RawMessage, error) {
+	if serial == "" {
+		return nil, nil
+	}
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	// Newest NON-EMPTY chain for the serial — skips a reconnect's empty row that
+	// would otherwise shadow a still-valid chain from a prior connection.
+	var chain json.RawMessage
+	err := s.pool.QueryRow(ctx,
+		`SELECT mda_cert_chain FROM providers
+		 WHERE serial_number = $1 AND serial_number != '' AND mda_cert_chain IS NOT NULL
+		 ORDER BY last_seen DESC LIMIT 1`, serial,
+	).Scan(&chain)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("store: get mda chain by serial: %w", err)
+	}
+	return chain, nil
+}
+
 func (s *PostgresStore) ListProviderRecords(ctx context.Context) ([]ProviderRecord, error) {
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()

--- a/coordinator/store/provider_records_test.go
+++ b/coordinator/store/provider_records_test.go
@@ -2,9 +2,54 @@ package store
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 	"time"
 )
+
+// TestMemoryGetMDAChainBySerial_NotShadowedByNewerEmptyRow is the durability fix
+// for the MDA-reuse race: a reconnect creates a new row (fresh provider id) that
+// can be persisted with an empty chain before the chain is reattached. A plain
+// by-serial lookup returns that newer empty row and shadows a still-valid chain
+// from the prior connection. GetMDAChainBySerial must look past empty rows.
+func TestMemoryGetMDAChainBySerial_NotShadowedByNewerEmptyRow(t *testing.T) {
+	st := NewMemory(Config{})
+	ctx := context.Background()
+	now := time.Now()
+	chain, _ := json.Marshal([][]byte{[]byte("leaf-der")})
+
+	// Prior connection earned + persisted the chain.
+	if err := st.UpsertProvider(ctx, ProviderRecord{
+		ID: "sess-old", SerialNumber: "SER-1", LastSeen: now.Add(-time.Minute),
+		MDAVerified: true, MDACertChain: chain,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	// Reconnect: newer row, same serial, empty chain (not reattached yet).
+	if err := st.UpsertProvider(ctx, ProviderRecord{
+		ID: "sess-new", SerialNumber: "SER-1", LastSeen: now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// The plain serial index now points at the newer empty row...
+	if rec, _ := st.GetProviderBySerial(ctx, "SER-1"); rec == nil || len(rec.MDACertChain) != 0 {
+		t.Fatalf("precondition: expected serial index to point at the empty newer row")
+	}
+	// ...but the chain-aware lookup recovers the prior chain.
+	got, err := st.GetMDAChainBySerial(ctx, "SER-1")
+	if err != nil {
+		t.Fatalf("GetMDAChainBySerial: %v", err)
+	}
+	if string(got) != string(chain) {
+		t.Fatalf("GetMDAChainBySerial = %q, want the prior non-empty chain %q", got, chain)
+	}
+
+	// No chain for an unknown serial.
+	if got, err := st.GetMDAChainBySerial(ctx, "SER-NONE"); err != nil || got != nil {
+		t.Fatalf("expected (nil,nil) for a serial with no chain, got (%q,%v)", got, err)
+	}
+}
 
 func TestMemoryListProvidersByAccount(t *testing.T) {
 	st := NewMemory(Config{})


### PR DESCRIPTION
## Problem

A lot of providers showed **"Apple Device Attestation incomplete"** on the dashboard after a restart, even though they held `hardware` trust and were routing/earning normally. Two distinct issues:

1. **Coordinator threw away a durable, Apple-signed identity.** On every reconnect the MDA cert chain was discarded (`RestoreProviderState` zeroed `MDAVerified`) and a **fresh** `DevicePropertiesAttestation` was re-fetched. Apple rate-limits a fresh attestation to **~1/device/7d** and it rides the same throttled MicroMDM→APNs channel as SecurityInfo, so a restart could never re-earn it. The DAR-326 trust-reuse fast-skip also grants hardware **without** running the MDA leg.
2. **The dashboard over-warned.** `mda_verified` is **not** a coordinator routing factor (absent from scheduler scoring), yet the warning was `degrading` severity — flipping the card to amber *"EARNING (reduced priority)"* / *"consumers will skip this machine."*

MDA is identity / anti-relay proof, **not** a routing gate — so this was never blocking traffic, only the badge.

## Flow: before vs. after

**Before — every reconnect threw away the chain and re-hit Apple's rate limit:**

```mermaid
flowchart TD
    A["Provider restarts, reconnects"] --> B["RestoreProviderState:<br/>discards stored chain,<br/>MDAVerified = false"]
    B --> C["Hardware re-earned<br/>(SecurityInfo / fast-skip / ACME)"]
    C --> D["verifyAppleDeviceAttestation:<br/>ALWAYS requests a FRESH<br/>DevicePropertiesAttestation"]
    D --> E{"Apple fresh-attestation<br/>rate limit ~1/device/7d"}
    E -->|"throttled / omitted"| F["60s APNs timeout"]
    F --> G["MDAVerified = false<br/>'Apple Device Attestation incomplete'<br/>dashboard: amber, 'reduced priority'"]
```

**After — reuse the durable, Apple-signed chain; touch Apple only when genuinely needed:**

```mermaid
flowchart TD
    A["Provider restarts, reconnects"] --> B["stageDurableMDAChain:<br/>live store read recovers the<br/>persisted chain (Postgres-durable)"]
    B --> C["Hardware re-earned<br/>(SecurityInfo / fast-skip / ACME)"]
    C --> D["attachCachedMDAProof<br/>(wired on all 3 grant paths)"]
    D --> E{"Re-verify locally vs Apple root<br/>and SE-key bind:<br/>FreshnessCode = sha256(SE pubkey)"}
    E -->|"valid and bound"| F["MDAVerified = true<br/>persisted, NO Apple round-trip<br/>dashboard: 'earning at full priority'"]
    E -->|"expired / SE key rotated / no chain"| H["Request a fresh attestation<br/>(only when actually needed)"]
```

## Fix

**Coordinator** — treat the Apple-signed chain as durable device identity:
- Recover the chain from a **live store read** on reconnect (`stageDurableMDAChain`); the store record survives provider disconnect, so it works under both the in-memory and Postgres stores. It's persisted in Postgres (`mda_cert_chain JSONB`), so the proof also survives a **coordinator restart**.
- **Persist a freshly-earned chain immediately** (`verifyAppleDeviceAttestation` + the late-MDA callback) instead of waiting on the next throttled heartbeat.
- `attachCachedMDAProof` re-verifies the chain locally against Apple's pinned Enterprise Attestation Root CA (rejecting expired / not-yet-valid certs — the relying-party freshness check, so reuse stays correct over time) and **requires the SE-key binding** (`FreshnessCode == sha256(this connection's SE public key)`; serial cross-checked when present). A serial-only match cannot let a rotated SE key inherit a chain.
- `verifyAppleDeviceAttestation` short-circuits on a valid cached proof; the fast-skip path attaches it too. A fresh attestation is requested only when there is no valid bound cached chain.

**Console UI** — `mda_missing` downgraded to `info` (*"Apple Device Attestation pending — hardware-trusted and earning at full priority; earned automatically and reused across restarts"*), misleading "Finish Apple attestation" CTA replaced with guidance.

**Provider Swift `doctor`** — verified it already treats hardware trust as sufficient and shows no MDA warning; **no change needed**.

## Trust is preserved

Hardware trust (secure boot + SIP via MicroMDM SecurityInfo) is still required to route; the chain is cryptographically re-verified against Apple's pinned root on **every** reconnect; the SE-key binding keeps the anti-relay guarantee. No `self_signed → mda_verified` drift (the attestation endpoint still gates on `isHardware`).

## Testing

- Coordinator: injectable test root (`OverrideRootCAForTest`); tests for live-store reuse without any MDM round-trip, the cached short-circuit (proven via nil mdmClient), expired-chain rejection, anti-relay rejection, staging, and the SE-key/serial binding matrix. `go build`, full suite, and `-race` on attestation/registry/api all green.
- Console UI: vitest asserting `info` severity and that toggling `mda_verified` does not change the derived routing state. eslint clean (no new warnings).

## Note for reviewers

This is **coordinator-only + frontend** (no protocol/provider change), so it deploys via the normal coordinator path. The `registry.go` additions here are the canonical source; an in-progress local DAR-345 branch accidentally captured a copy of them in an unrelated commit (`51901ee0`, **not on origin**) — when that work is pushed, drop those stray `registry.go` lines to avoid a conflict with this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/436"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784599213&installation_id=133247490&pr_number=436&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F436&signature=d724424c39fc836b8a7230db25c1d388c00d18ff842cfba5300a2e4f58f24887"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
