### PR TITLE
fix(coordinator): DAR-347 stop dispatch-storming unservable gpt-oss requests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -224,6 +224,27 @@ Keep the codebase modular, never monolithic.
 - One file/component should do one thing. If a file mixes several concerns or grows past a few hundred lines, that's a signal to split it.
 - **At the end of every large piece of work, do a refactor pass to make it modular before calling it done.** Extract helpers/types/hooks into focused files, delete dead code, and keep the public entry point thin. The refactor must be behavior-preserving — build, lint, and tests stay green.
 
+## Pull Requests
+
+**Every PR MUST include a before-and-after diagram (Mermaid) in its description** that details what changed — covering BOTH:
+
+- **Behavior**: the request/response flow, states, and outcomes a user or caller observes (e.g. dispatch → retry → 429/503/200).
+- **Code**: which functions/components changed and how control flows through them.
+
+Use two clearly labeled diagrams — a **Before** and an **After** — (or one side-by-side comparison) so a reviewer sees the delta at a glance. Scope it to what the PR changes; it is not a full-system map. A PR without a before/after diagram is not ready for review.
+
+````markdown
+```mermaid
+flowchart LR
+  subgraph Before
+    A1[request] --> B1[old behavior / code path]
+  end
+  subgraph After
+    A2[request] --> B2[new behavior / code path]
+  end
+```
+````
+
 ## Formatting
 
 A pre-commit hook in `.githooks/pre-commit` checks staged files only. It is enabled via:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -260,6 +260,27 @@ Each reviewer should:
 
 Only proceed to the next objective after both reviewers pass. If either flags issues, fix them before moving on.
 
+## Pull Requests
+
+**Every PR MUST include a before-and-after diagram (Mermaid) in its description** that details what changed — covering BOTH:
+
+- **Behavior**: the request/response flow, states, and outcomes a user or caller observes (e.g. dispatch → retry → 429/503/200).
+- **Code**: which functions/components changed and how control flows through them.
+
+Use two clearly labeled diagrams — a **Before** and an **After** — (or one side-by-side comparison) so a reviewer sees the delta at a glance. Scope it to what the PR changes; it is not a full-system map. A PR without a before/after diagram is not ready for review.
+
+````markdown
+```mermaid
+flowchart LR
+  subgraph Before
+    A1[request] --> B1[old behavior / code path]
+  end
+  subgraph After
+    A2[request] --> B2[new behavior / code path]
+  end
+```
+````
+
 ## Git Hooks
 
 Hooks live in `.githooks/` and are enabled via `git config core.hooksPath .githooks` (already set for this repo).

--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -76,6 +76,16 @@ const (
 	// immediately-available healthy providers rather than waiting on busy ones.
 	maxDispatchAttempts = 64
 
+	// maxCapacityClassRetries bounds failover specifically for TRANSIENT-capacity
+	// rejections (this provider's live KV budget, a full queue, an update drain).
+	// Such a shortage MAY clear on another provider, so we fail over — but only a
+	// few times, so a fleet-wide transient (or an oversized request the determinism
+	// check didn't tag) cannot walk all maxDispatchAttempts providers and 503 each
+	// (the prod storm: median 22, max 63 attempts, ~8.7 min, 0% eventual success).
+	// A DETERMINISTIC-context rejection (prompt > model context, identical on every
+	// provider) stops on the FIRST attempt regardless — see classifyRejection.
+	maxCapacityClassRetries = 3
+
 	// speculativeTimerRatio is the fraction of the TTFT deadline at which
 	// the coordinator launches a speculative backup dispatch. The primary
 	// provider gets this fraction of the deadline before the backup is

--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -2340,6 +2340,7 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 		timing:                 timing,
 		deadline:               deadline,
 		speculativeAt:          time.Duration(float64(deadline) * speculativeTimerRatio),
+		modelMaxContext:        modelMaxContext,
 		refundReservation:      refundReservation,
 		// Track providers that failed during retry so we don't dispatch to them again.
 		excludeProviders: make(map[string]struct{}),

--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -2316,6 +2316,17 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// model may have been rewritten by a capacity- or TTFT-fallback above
+	// (maybeFallbackAliasCapacity / maybeFallbackAliasTTFT), so refresh the context
+	// window for the FINAL build before handing it to the dispatch loop — otherwise
+	// shouldStopFailover/classifyRejection would compare a provider's budget against
+	// the originally-resolved model's context. Overwrite only on a successful lookup
+	// (fallback builds of the same alias normally share a context window; a build
+	// absent from the store keeps the prior value, matching the initial read).
+	if rec, err := s.store.GetModelRegistryRecord(model); err == nil {
+		modelMaxContext = rec.MaxContextLength
+	}
+
 	d := &dispatchState{
 		s:                      s,
 		w:                      w,

--- a/coordinator/api/dispatch.go
+++ b/coordinator/api/dispatch.go
@@ -107,6 +107,11 @@ type dispatchState struct {
 	timing                 *registry.RequestTiming
 	deadline               time.Duration
 	speculativeAt          time.Duration
+	// modelMaxContext is the model's context window (0 = unknown), used by
+	// shouldStopFailover/classifyRejection to tell a fleet-wide context overflow
+	// apart from a memory-pressured provider's shrunk KV budget when a "batch token
+	// budget" rejection arrives.
+	modelMaxContext int
 	// refundReservation refunds the shared base reservation (the caller's closure).
 	refundReservation func()
 
@@ -119,7 +124,14 @@ type dispatchState struct {
 	lastErr       string
 	lastErrCode   int
 	lastErrReason string
-	committed     bool
+	// lastErrProviderBudget is the rejecting provider's reported token budget
+	// (ActiveTokenBudgetMax) for d.model at the time lastErr was set, or 0 when the
+	// error is not a provider rejection / the provider reported no budget. Captured
+	// by setLastInferenceError so shouldStopFailover can classify a "batch token
+	// budget" rejection as deterministic (budget >= context) vs transient
+	// (budget < context — this node was memory-pressured).
+	lastErrProviderBudget int64
+	committed             bool
 	// keepalive emits SSE keepalive comments during a long prefill once the
 	// request has been dispatched, committing HTTP 200 early so the consumer
 	// connection does not time out. nil when disabled or non-streaming.
@@ -378,12 +390,31 @@ func (d *dispatchState) setLastError(errText string, statusCode int) {
 	d.lastErr = errText
 	d.lastErrCode = statusCode
 	d.lastErrReason = ""
+	// Not a provider capacity rejection (timeout / no-provider / coordinator
+	// fault): clear any budget captured from a prior attempt so it never bleeds
+	// into a later classification.
+	d.lastErrProviderBudget = 0
 }
 
-func (d *dispatchState) setLastInferenceError(msg protocol.InferenceErrorMessage) {
+// setLastInferenceError records a pre-content provider rejection as the dispatch
+// loop's last error and snapshots the rejecting provider's reported token budget
+// for d.model. shouldStopFailover needs that budget to tell a fleet-wide
+// DETERMINISTIC context overflow apart from THIS node's memory-pressured KV budget
+// (see classifyRejection). provider may be nil (budget 0 = unknown).
+func (d *dispatchState) setLastInferenceError(provider *registry.Provider, msg protocol.InferenceErrorMessage) {
 	d.lastErr = msg.Error
 	d.lastErrCode = msg.StatusCode
 	d.lastErrReason = msg.ErrorReason
+	d.lastErrProviderBudget = providerReportedBudget(provider, d.model)
+}
+
+// providerReportedBudget reads a provider's reported token budget for a model,
+// tolerating a nil provider (returns 0 = unknown).
+func providerReportedBudget(provider *registry.Provider, model string) int64 {
+	if provider == nil {
+		return 0
+	}
+	return provider.ReportedTokenBudgetMaxForModel(model)
 }
 
 // providerFailedRoutingOutcome builds the outcome for a POST-DISPATCH provider
@@ -855,8 +886,18 @@ const rejectionReasonOversized = "oversized_request"
 // ladder emits exactly one uptime-neutral 429 (not a storm, not a raw 5xx). It is
 // a no-op (returns false, no counters) for non-capacity outcomes, so timeouts and
 // faults are unaffected.
+//
+// A previously-LATCHED verdict wins: a speculative race records the loser's error
+// into speculative tracking, not d.lastErr (the surviving racer owns that), so a
+// deterministic context overflow from a race loser would otherwise be masked by
+// the survivor's later transient/timeout error and the loop would keep storming.
+// latchDeterministicLoser sets d.unservable at the loser site; the guard below
+// honors it at the first retry point regardless of what the survivor reported.
 func (d *dispatchState) shouldStopFailover() bool {
-	switch classifyRejection(d.lastErrReason, d.lastErr) {
+	if d.unservable {
+		return true
+	}
+	switch classifyRejection(d.lastErrReason, d.lastErr, d.lastErrProviderBudget, d.modelMaxContext) {
 	case rejectionDeterministicUnservable:
 		d.s.ddIncr("routing.dispatch_to_capacity_503", []string{"model:" + d.model, "reason:deterministic"})
 		d.unservable = true
@@ -873,6 +914,29 @@ func (d *dispatchState) shouldStopFailover() bool {
 		return false
 	default:
 		return false
+	}
+}
+
+// latchDeterministicLoser preserves a DETERMINISTIC-unservable rejection observed
+// from a speculative race LOSER. A race loser's error is recorded into speculative
+// tracking but NOT written to d.lastErr (the surviving racer owns that), so without
+// this latch a deterministic context overflow from the loser would be masked by the
+// survivor's later transient/timeout error and the dispatch loop would keep storming
+// the fleet (the exact gap shouldStopFailover otherwise closes only on the non-
+// speculative path). Once latched, shouldStopFailover stops at the next retry point
+// regardless of the survivor's outcome. It is budget-aware (see classifyRejection):
+// a memory-pressured loser's "batch token budget" is NOT latched, so failover to a
+// healthier provider still happens. Harmless if the survivor ultimately succeeds —
+// d.unservable is only consulted on the exhausted/retry path, never on a commit.
+func (d *dispatchState) latchDeterministicLoser(provider *registry.Provider, msg protocol.InferenceErrorMessage) {
+	if d.unservable {
+		return
+	}
+	budget := providerReportedBudget(provider, d.model)
+	if classifyRejection(msg.ErrorReason, msg.Error, budget, d.modelMaxContext) == rejectionDeterministicUnservable {
+		d.s.ddIncr("routing.dispatch_to_capacity_503", []string{"model:" + d.model, "reason:deterministic"})
+		d.unservable = true
+		d.unservableReason = rejectionReasonOversized
 	}
 }
 
@@ -934,7 +998,7 @@ func (d *dispatchState) waitFirstChunk() (outcome dispatchOutcome) {
 				case errMsg := <-pr.ErrorCh:
 					d.excludeProviders[provider.ID] = struct{}{}
 					s.cancelDispatch(provider, pr)
-					d.setLastInferenceError(errMsg)
+					d.setLastInferenceError(provider, errMsg)
 					d.lastFailedVersion = failedProviderVersion(provider)
 					d.noteDispatchRetry(provider, pr, errMsg.StatusCode, errMsg.Error, &d.heldChunks)
 					d.provider = nil
@@ -959,7 +1023,7 @@ func (d *dispatchState) waitFirstChunk() (outcome dispatchOutcome) {
 			deadlineTimer.Stop()
 			d.excludeProviders[provider.ID] = struct{}{}
 			s.cancelDispatch(provider, pr)
-			d.setLastInferenceError(errMsg)
+			d.setLastInferenceError(provider, errMsg)
 			d.lastFailedVersion = failedProviderVersion(provider)
 			s.logger.Warn("provider failed, retrying",
 				"request_id", d.requestID,
@@ -1150,7 +1214,7 @@ func (d *dispatchState) waitNoBackup() dispatchOutcome {
 				case errMsg := <-pr.ErrorCh:
 					d.excludeProviders[provider.ID] = struct{}{}
 					s.cancelDispatch(provider, pr)
-					d.setLastInferenceError(errMsg)
+					d.setLastInferenceError(provider, errMsg)
 					d.lastFailedVersion = failedProviderVersion(provider)
 					d.noteDispatchRetry(provider, pr, errMsg.StatusCode, errMsg.Error, &d.heldChunks)
 					d.provider = nil
@@ -1169,7 +1233,7 @@ func (d *dispatchState) waitNoBackup() dispatchOutcome {
 			remainingDeadline.Stop()
 			d.excludeProviders[provider.ID] = struct{}{}
 			s.cancelDispatch(provider, pr)
-			d.setLastInferenceError(errMsg)
+			d.setLastInferenceError(provider, errMsg)
 			d.lastFailedVersion = failedProviderVersion(provider)
 			if s.metrics != nil {
 				s.metrics.IncCounter("inference_dispatches_total", MetricLabel{"result", "retry"})
@@ -1265,7 +1329,7 @@ func (d *dispatchState) runRace(backupProvider *registry.Provider, backupPR *reg
 					d.markSpeculativeLoser(backupPR)
 					d.excludeProviders[provider.ID] = struct{}{}
 					s.cancelDispatch(provider, pr)
-					d.setLastInferenceError(errMsg)
+					d.setLastInferenceError(provider, errMsg)
 					d.lastFailedVersion = failedProviderVersion(provider)
 					d.noteDispatchRetry(provider, pr, errMsg.StatusCode, errMsg.Error, &d.heldChunks)
 					d.provider = nil
@@ -1308,6 +1372,9 @@ func (d *dispatchState) runRace(backupProvider *registry.Provider, backupPR *reg
 					d.lastFailedVersion = failedProviderVersion(backupProvider)
 					d.updateSpeculativeFailure(backupPR, errMsg)
 					s.noteDispatchProviderError(backupProvider, backupPR, errMsg.StatusCode, errMsg.Error, &backupHeld)
+					// Preserve a deterministic-unservable verdict from this loser so the
+					// surviving primary's error can't mask it (see latchDeterministicLoser).
+					d.latchDeterministicLoser(backupProvider, errMsg)
 					// Wait remaining deadline for primary.
 					return d.raceBackupChunkClosedWaitPrimary(provider, pr)
 				default:
@@ -1353,6 +1420,9 @@ func (d *dispatchState) runRace(backupProvider *registry.Provider, backupPR *reg
 			d.lastFailedVersion = failedProviderVersion(provider)
 			d.updateSpeculativeFailure(pr, errMsg)
 			s.noteDispatchProviderError(provider, pr, errMsg.StatusCode, errMsg.Error, &d.heldChunks)
+			// Preserve a deterministic-unservable verdict from this loser so the
+			// surviving backup's error can't mask it (see latchDeterministicLoser).
+			d.latchDeterministicLoser(provider, errMsg)
 			d.requestID = ""
 			d.provider = nil
 			d.pr = nil
@@ -1366,6 +1436,9 @@ func (d *dispatchState) runRace(backupProvider *registry.Provider, backupPR *reg
 			d.lastFailedVersion = failedProviderVersion(backupProvider)
 			d.updateSpeculativeFailure(backupPR, errMsg)
 			s.noteDispatchProviderError(backupProvider, backupPR, errMsg.StatusCode, errMsg.Error, &backupHeld)
+			// Preserve a deterministic-unservable verdict from this loser so the
+			// surviving primary's error can't mask it (see latchDeterministicLoser).
+			d.latchDeterministicLoser(backupProvider, errMsg)
 			return d.raceBackupErrWaitPrimary(provider, pr)
 
 		case <-raceDeadline.C:
@@ -1443,7 +1516,7 @@ func (d *dispatchState) raceBackupChunkClosedWaitPrimary(provider *registry.Prov
 				case errMsg2 := <-pr.ErrorCh:
 					d.excludeProviders[provider.ID] = struct{}{}
 					s.cancelDispatch(provider, pr)
-					d.setLastInferenceError(errMsg2)
+					d.setLastInferenceError(provider, errMsg2)
 					d.lastFailedVersion = failedProviderVersion(provider)
 					d.updateSpeculativeFailure(pr, errMsg2)
 					d.noteDispatchRetry(provider, pr, errMsg2.StatusCode, errMsg2.Error, &d.heldChunks)
@@ -1468,7 +1541,7 @@ func (d *dispatchState) raceBackupChunkClosedWaitPrimary(provider *registry.Prov
 			remainingPrimary.Stop()
 			d.excludeProviders[provider.ID] = struct{}{}
 			s.cancelDispatch(provider, pr)
-			d.setLastInferenceError(errMsg2)
+			d.setLastInferenceError(provider, errMsg2)
 			d.lastFailedVersion = failedProviderVersion(provider)
 			d.updateSpeculativeFailure(pr, errMsg2)
 			d.noteDispatchRetry(provider, pr, errMsg2.StatusCode, errMsg2.Error, &d.heldChunks)
@@ -1541,7 +1614,7 @@ func (d *dispatchState) racePrimaryFailedWaitBackup(backupProvider *registry.Pro
 				case errMsg2 := <-backupPR.ErrorCh:
 					d.excludeProviders[backupProvider.ID] = struct{}{}
 					s.cancelDispatch(backupProvider, backupPR)
-					d.setLastInferenceError(errMsg2)
+					d.setLastInferenceError(backupProvider, errMsg2)
 					d.lastFailedVersion = failedProviderVersion(backupProvider)
 					d.updateSpeculativeFailure(backupPR, errMsg2)
 					d.noteDispatchRetry(backupProvider, backupPR, errMsg2.StatusCode, errMsg2.Error, &backupHeld)
@@ -1571,7 +1644,7 @@ func (d *dispatchState) racePrimaryFailedWaitBackup(backupProvider *registry.Pro
 			backupDeadline.Stop()
 			d.excludeProviders[backupProvider.ID] = struct{}{}
 			s.cancelDispatch(backupProvider, backupPR)
-			d.setLastInferenceError(errMsg2)
+			d.setLastInferenceError(backupProvider, errMsg2)
 			d.lastFailedVersion = failedProviderVersion(backupProvider)
 			d.updateSpeculativeFailure(backupPR, errMsg2)
 			s.noteDispatchProviderError(backupProvider, backupPR, errMsg2.StatusCode, errMsg2.Error, &backupHeld)
@@ -1638,7 +1711,7 @@ func (d *dispatchState) raceBackupErrWaitPrimary(provider *registry.Provider, pr
 				case errMsg2 := <-pr.ErrorCh:
 					d.excludeProviders[provider.ID] = struct{}{}
 					s.cancelDispatch(provider, pr)
-					d.setLastInferenceError(errMsg2)
+					d.setLastInferenceError(provider, errMsg2)
 					d.lastFailedVersion = failedProviderVersion(provider)
 					d.noteDispatchRetry(provider, pr, errMsg2.StatusCode, errMsg2.Error, &d.heldChunks)
 					d.provider = nil
@@ -1657,7 +1730,7 @@ func (d *dispatchState) raceBackupErrWaitPrimary(provider *registry.Provider, pr
 			primaryDeadline.Stop()
 			d.excludeProviders[provider.ID] = struct{}{}
 			s.cancelDispatch(provider, pr)
-			d.setLastInferenceError(errMsg2)
+			d.setLastInferenceError(provider, errMsg2)
 			d.lastFailedVersion = failedProviderVersion(provider)
 			d.updateSpeculativeFailure(pr, errMsg2)
 			s.noteDispatchProviderError(provider, pr, errMsg2.StatusCode, errMsg2.Error, &d.heldChunks)
@@ -1757,7 +1830,7 @@ func (d *dispatchState) waitAccepted() (outcome dispatchOutcome) {
 				case errMsg := <-pr.ErrorCh:
 					d.excludeProviders[provider.ID] = struct{}{}
 					s.cancelDispatch(provider, pr)
-					d.setLastInferenceError(errMsg)
+					d.setLastInferenceError(provider, errMsg)
 					d.lastFailedVersion = failedProviderVersion(provider)
 					s.logger.Warn("provider failed after accepting request, retrying",
 						"request_id", d.requestID,
@@ -1789,7 +1862,7 @@ func (d *dispatchState) waitAccepted() (outcome dispatchOutcome) {
 			chunkTimer.Stop()
 			d.excludeProviders[provider.ID] = struct{}{}
 			s.cancelDispatch(provider, pr)
-			d.setLastInferenceError(errMsg)
+			d.setLastInferenceError(provider, errMsg)
 			d.lastFailedVersion = failedProviderVersion(provider)
 			s.logger.Warn("provider failed after accepting request, retrying",
 				"request_id", d.requestID,

--- a/coordinator/api/dispatch.go
+++ b/coordinator/api/dispatch.go
@@ -126,6 +126,18 @@ type dispatchState struct {
 	keepalive         *prefillKeepaliver
 	lastFailedVersion string
 	excludeProviders  map[string]struct{}
+	// capacityRetries counts pre-content TRANSIENT-capacity failovers (this
+	// node's live KV budget, a full queue, a drain). Bounded by
+	// maxCapacityClassRetries so a fleet-wide transient cannot storm; a
+	// DETERMINISTIC-context rejection (prompt > model context) stops on the first
+	// attempt regardless (see classifyRejection / failoverOutcome).
+	capacityRetries int
+	// unservable is set when the dispatch loop stops because the request cannot
+	// be served (deterministic-context rejection, or a transient that exhausted
+	// maxCapacityClassRetries). The exhausted ladder then emits a single
+	// uptime-neutral 429 with unservableReason instead of retrying/5xx'ing.
+	unservable       bool
+	unservableReason string
 
 	// ---- per-attempt scratch (reset each attempt) ----
 	attempt          int
@@ -812,6 +824,55 @@ func (d *dispatchState) dispatchPrimary() dispatchOutcome {
 func (d *dispatchState) noteDispatchRetry(provider *registry.Provider, pr *registry.PendingRequest, statusCode int, errStr string, held *[]string) {
 	if !d.s.noteDispatchProviderError(provider, pr, statusCode, errStr, held) {
 		d.s.ddIncr("inference.dispatches", []string{"status:retry"})
+	}
+}
+
+// rejectionReasonOversized is the rejection-ledger reason_code for a request the
+// dispatch loop stopped because no provider can serve it (deterministic context
+// overflow, or a transient-capacity shortage that exhausted
+// maxCapacityClassRetries). Distinct from the preflight "context_exceeded" /
+// "prompt_too_long" and the legacy dispatch-exhausted "unservable_token_budget".
+const rejectionReasonOversized = "oversized_request"
+
+// shouldStopFailover is the single choke point that decides, after a dispatched
+// attempt failed with outcomeRetry, whether the dispatch loop should STOP failing
+// over because the request is unservable — rather than walk all 64 providers and
+// 503 each. The orchestrator calls it at both post-dispatch retry points (after
+// waitFirstChunk and waitAccepted), through which EVERY pre-content provider
+// rejection funnels (including the speculative/race paths, which return their
+// outcome up through waitFirstChunk). It inspects the just-recorded error
+// (d.lastErr / d.lastErrReason via setLastInferenceError) and classifies it:
+//
+//   - DETERMINISTIC-context rejection (prompt > model context — identical on
+//     every provider): stop on the FIRST occurrence. Retrying is pure waste
+//     (prod: median 22 / max 63 futile attempts, ~8.7 min, 0% eventual success).
+//   - TRANSIENT-capacity rejection (this node's KV budget / queue / drain): keep
+//     failing over, but only up to maxCapacityClassRetries, then stop.
+//   - genuine fault / timeout / unrecognised: return false → existing fault
+//     failover (the per-provider breaker quarantines a persistently-sick node).
+//
+// When it returns true it sets d.unservable + d.unservableReason so the exhausted
+// ladder emits exactly one uptime-neutral 429 (not a storm, not a raw 5xx). It is
+// a no-op (returns false, no counters) for non-capacity outcomes, so timeouts and
+// faults are unaffected.
+func (d *dispatchState) shouldStopFailover() bool {
+	switch classifyRejection(d.lastErrReason, d.lastErr) {
+	case rejectionDeterministicUnservable:
+		d.s.ddIncr("routing.dispatch_to_capacity_503", []string{"model:" + d.model, "reason:deterministic"})
+		d.unservable = true
+		d.unservableReason = rejectionReasonOversized
+		return true
+	case rejectionTransientCapacity:
+		d.s.ddIncr("routing.dispatch_to_capacity_503", []string{"model:" + d.model, "reason:transient"})
+		d.capacityRetries++
+		if d.capacityRetries >= maxCapacityClassRetries {
+			d.unservable = true
+			d.unservableReason = rejectionReasonOversized
+			return true
+		}
+		return false
+	default:
+		return false
 	}
 }
 
@@ -1868,6 +1929,14 @@ func (d *dispatchState) run() {
 		// ---- Speculative TTFT-aware first-chunk wait ----
 		switch d.waitFirstChunk() {
 		case outcomeRetry:
+			// Post-dispatch provider failure. Stop failing over when the request is
+			// unservable (deterministic context overflow, or a capacity transient
+			// past maxCapacityClassRetries) so we don't storm all 64 providers; the
+			// exhausted ladder then emits one uptime-neutral 429. Faults/timeouts
+			// return false and keep failing over as before.
+			if d.shouldStopFailover() {
+				goto exhausted
+			}
 			continue
 		case outcomeClientGone:
 			return
@@ -1875,6 +1944,9 @@ func (d *dispatchState) run() {
 			// Provider accepted or held preamble but hasn't produced content.
 			switch d.waitAccepted() {
 			case outcomeRetry:
+				if d.shouldStopFailover() {
+					goto exhausted
+				}
 				continue
 			case outcomeClientGone:
 				return
@@ -1893,7 +1965,18 @@ exhausted:
 		keepaliveCommitted := d.keepalive.takeOver()
 		statusCode := d.lastErrCode
 		reason := "dispatch_exhausted"
-		if statusCode == 0 {
+		if d.unservable {
+			// The loop stopped early because no provider can serve this request
+			// (deterministic context overflow, or a capacity transient that
+			// exhausted maxCapacityClassRetries). We already know the verdict, so
+			// skip the quick-capacity probe and the 5xx→429 reclassification below:
+			// emit a single uptime-neutral 429. This is the proactive complement to
+			// the always-on backstop — it converts the request BEFORE storming the
+			// fleet, not after 64 attempts.
+			statusCode = http.StatusTooManyRequests
+			reason = rejectionReasonOversized
+			s.ddIncr("routing.oversized_request_rejected", []string{"model:" + d.model, "stage:dispatch"})
+		} else if statusCode == 0 {
 			// Distinguish capacity exhaustion (429) from genuine unavailability (503).
 			// A quick capacity check tells us if providers exist but are full.
 			_, capRej, _ := s.registry.QuickCapacityCheckForRequest(d.model, d.estimatedPromptTokens, d.requestedMaxTokens, registry.RequestTraits{HasTools: d.hasTools}, d.requiresVision, d.allowedProviderSerials...)
@@ -1936,7 +2019,16 @@ exhausted:
 		if statusCode == http.StatusTooManyRequests || statusCode == http.StatusServiceUnavailable {
 			retryAfter := s.estimateRetryAfter(d.model)
 			w.Header().Set("Retry-After", strconv.Itoa(retryAfter))
-			s.recordRejection(d.rejectionInfo("dispatch", reason, statusCode, retryAfter*1000))
+			info := d.rejectionInfo("dispatch", reason, statusCode, retryAfter*1000)
+			if d.unservable {
+				// No provider could serve this request (it exceeds the model
+				// context, identical fleet-wide). Mark it not-servable so the
+				// rejection ledger's could_have_served reflects reality — candidates
+				// existed but every one would reject — mirroring the preflight gate.
+				info.servabilityComputed = true
+				info.candidateCount = 0
+			}
+			s.recordRejection(info)
 		} else {
 			s.recordRejection(d.rejectionInfo("dispatch", reason, statusCode, 0))
 		}

--- a/coordinator/api/dispatch_oversized_pressure_test.go
+++ b/coordinator/api/dispatch_oversized_pressure_test.go
@@ -1,0 +1,220 @@
+package api
+
+// DAR-347 follow-ups: the dispatch-time "stop the storm" logic must NOT turn a
+// memory-pressured provider's ambiguous "batch token budget" rejection into a
+// permanent fleet-wide 429 (#1), and a deterministic verdict observed from a
+// speculative race LOSER must survive even when the surviving racer reports a
+// transient/timeout error (#2).
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+	"github.com/eigeninference/d-inference/coordinator/registry"
+	"github.com/eigeninference/d-inference/coordinator/store"
+)
+
+// registerModelContext registers modelID in the store with a known context window
+// so the dispatch path's modelMaxContext is populated (it reads
+// store.GetModelRegistryRecord(model).MaxContextLength). The record is only
+// returned when an active+ready version exists, so set+promote a minimal one.
+func registerModelContext(t *testing.T, st *store.MemoryStore, modelID string, ctxLen int) {
+	t.Helper()
+	entry := &store.ModelRegistryEntry{
+		ID: modelID, DisplayName: modelID, Quantization: "4bit",
+		MaxContextLength: ctxLen, MaxOutputLength: 8192, MinRAMGB: 8,
+		Capabilities: []string{"chat"}, Status: "active",
+	}
+	files := []store.ModelVersionFile{{Path: "config.json", SizeBytes: 1, SHA256: testHash, Role: "config"}}
+	if err := st.SetModelVersion(entry, &store.ModelVersion{
+		ModelID: modelID, Version: "v1", R2Prefix: modelR2Prefix(modelID, "v1"),
+		AggregateSHA256: testHash, TotalSizeBytes: 1, FileCount: 1, Status: "ready",
+	}, files); err != nil {
+		t.Fatalf("SetModelVersion: %v", err)
+	}
+	if err := st.PromoteModelVersion(modelID, "v1"); err != nil {
+		t.Fatalf("PromoteModelVersion: %v", err)
+	}
+}
+
+// setProviderModelBudget stamps a per-model reported token budget on a provider so
+// the dispatch path can read it (ReportedTokenBudgetMaxForModel) when classifying a
+// "batch token budget" rejection. Written under the provider mutex — the same lock
+// the reader takes.
+func setProviderModelBudget(t *testing.T, reg *registry.Registry, registryID, model string, budgetMax int64) {
+	t.Helper()
+	p := reg.GetProvider(registryID)
+	if p == nil {
+		t.Fatalf("provider %q missing", registryID)
+	}
+	p.Mu().Lock()
+	p.BackendCapacity = &protocol.BackendCapacity{
+		Slots: []protocol.BackendSlotCapacity{{
+			Model: model, State: "running", MaxConcurrency: 8, ActiveTokenBudgetMax: budgetMax,
+		}},
+	}
+	p.Mu().Unlock()
+}
+
+// TestDispatch_BatchTokenBudget_PressuredProvider_FailsOver (DAR-347 #1): a
+// "request exceeds batch token budget" rejection is NOT fleet-wide deterministic
+// when the rejecting provider was memory-pressured. The provider's admission cap is
+// min(context, activeTokenBudget); with a reported budget BELOW the model context,
+// the binding term may have been this node's shrunk KV budget, so a healthier
+// provider can still serve. The loop MUST fail over — not stop-at-1 and 429.
+// Fails against the pre-fix code, which classified every batch-budget string as
+// deterministic and stopped after the first provider.
+func TestDispatch_BatchTokenBudget_PressuredProvider_FailsOver(t *testing.T) {
+	reg, st, ts := setupFailoverServer(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	const model = "pressured-batch-budget-model"
+	const contextLen = 131072
+	registerModelContext(t, st, model, contextLen)
+
+	rec := &dispatchRecorder{}
+	script := func(ctx context.Context, fp *failoverProvider, req protocol.InferenceRequestMessage, body []byte) {
+		if rec.record(fp.name) == 1 {
+			// First-dispatched provider rejects with the ambiguous batch-budget string.
+			fp.sendInferenceError(ctx, req, "token_budget_exhausted: request exceeds batch token budget", http.StatusServiceUnavailable)
+			return
+		}
+		fp.serveFull(ctx, req, model, markerFor(fp.name))
+	}
+	pA := startFailoverProvider(t, ctx, ts, reg, failoverProviderConfig{
+		Name: "provider-a", Version: "0.6.20", DecodeTPS: 200,
+		Models: []failoverModelSpec{{ID: model}}, Script: script,
+	})
+	pB := startFailoverProvider(t, ctx, ts, reg, failoverProviderConfig{
+		Name: "provider-b", Version: "0.6.20", DecodeTPS: 1,
+		Models: []failoverModelSpec{{ID: model}}, Script: script,
+	})
+	// Both providers report a token budget BELOW the model context → memory-pressured,
+	// so a batch-budget rejection is provider-specific (transient), not fleet-wide.
+	setProviderModelBudget(t, reg, pA.registryID, model, 50_000)
+	setProviderModelBudget(t, reg, pB.registryID, model, 50_000)
+
+	status, body, err := postChat(ctx, ts.URL, "test-key", buildChatBody(t, model, true, nil))
+	if err != nil {
+		t.Fatalf("chat request: %v", err)
+	}
+	seq := rec.sequence()
+	if len(seq) != 2 {
+		t.Fatalf("dispatch sequence = %v, want 2 (a pressured batch-budget rejection must fail over, not stop-at-1); status=%d body=%s", seq, status, body)
+	}
+	if seq[0] == seq[1] {
+		t.Errorf("both dispatches went to %q — failover must retry a DIFFERENT provider", seq[0])
+	}
+	assertCleanFailoverStream(t, status, body, markerFor(seq[1]))
+}
+
+// TestDispatch_BatchTokenBudget_UnpressuredProvider_StopsAtOne (DAR-347 #1
+// counter-case): when the rejecting provider's reported budget is at/above the
+// model context, the batch-budget rejection IS fleet-wide deterministic — the
+// storm-stop must still fire (one dispatch, uptime-neutral 429). Guards against the
+// budget-aware path accidentally downgrading genuine oversize to failover.
+func TestDispatch_BatchTokenBudget_UnpressuredProvider_StopsAtOne(t *testing.T) {
+	reg, st, ts := setupFailoverServer(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	const model = "unpressured-batch-budget-model"
+	const contextLen = 131072
+	registerModelContext(t, st, model, contextLen)
+
+	script := rejectScript("token_budget_exhausted: request exceeds batch token budget", http.StatusServiceUnavailable)
+	pA := startFailoverProvider(t, ctx, ts, reg, failoverProviderConfig{
+		Name: "provider-a", Version: "0.6.20", DecodeTPS: 200,
+		Models: []failoverModelSpec{{ID: model}}, Script: script,
+	})
+	pB := startFailoverProvider(t, ctx, ts, reg, failoverProviderConfig{
+		Name: "provider-b", Version: "0.6.20", DecodeTPS: 1,
+		Models: []failoverModelSpec{{ID: model}}, Script: script,
+	})
+	// Budgets at/above the model context → the binding term is the context, so the
+	// rejection is identical on every provider.
+	setProviderModelBudget(t, reg, pA.registryID, model, 200_000)
+	setProviderModelBudget(t, reg, pB.registryID, model, 200_000)
+
+	status, body, err := postChat(ctx, ts.URL, "test-key", buildChatBody(t, model, false, nil))
+	if err != nil {
+		t.Fatalf("chat request: %v", err)
+	}
+	if status != http.StatusTooManyRequests {
+		t.Fatalf("status = %d, want 429 (deterministic oversize → uptime-neutral 429); body=%s", status, body)
+	}
+	if total := pA.dispatchCount() + pB.dispatchCount(); total != 1 {
+		t.Errorf("total dispatches = %d, want 1 — a context-bound oversize must STOP after the first attempt", total)
+	}
+}
+
+// newTestServerForDispatch builds a minimal Server for unit-testing dispatchState
+// helpers that only need s.ddIncr (nil-safe) and s.model.
+func newTestServerForDispatch(t *testing.T) *Server {
+	t.Helper()
+	logger := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelError}))
+	return NewServer(registry.New(logger), store.NewMemory(store.Config{}), ServerConfig{}, logger)
+}
+
+// TestLatchDeterministicLoser_Latches (DAR-347 #2): a deterministic-unservable
+// rejection from a speculative race loser sets d.unservable even though the loser's
+// error is never written to d.lastErr (the surviving racer owns that).
+func TestLatchDeterministicLoser_Latches(t *testing.T) {
+	d := &dispatchState{s: newTestServerForDispatch(t), model: "m"}
+	// Unknown budget + unknown context → a "batch token budget" string is deterministic.
+	d.latchDeterministicLoser(nil, protocol.InferenceErrorMessage{
+		Error: "token_budget_exhausted: request exceeds batch token budget",
+	})
+	if !d.unservable || d.unservableReason != rejectionReasonOversized {
+		t.Fatalf("deterministic loser must latch unservable; got unservable=%v reason=%q", d.unservable, d.unservableReason)
+	}
+}
+
+// TestLatchDeterministicLoser_IgnoresTransient (DAR-347 #2): a transient-capacity
+// loser must NOT latch — failover to a healthier provider must still happen.
+func TestLatchDeterministicLoser_IgnoresTransient(t *testing.T) {
+	d := &dispatchState{s: newTestServerForDispatch(t), model: "m"}
+	d.latchDeterministicLoser(nil, protocol.InferenceErrorMessage{Error: "request rejected: queue full"})
+	if d.unservable {
+		t.Fatalf("a transient loser must NOT latch unservable (it would block legitimate failover)")
+	}
+}
+
+// TestLatchDeterministicLoser_PressuredBatchBudgetNotLatched (DAR-347 #1 ∩ #2):
+// the loser latch is budget-aware. A memory-pressured loser's "batch token budget"
+// (reported budget below the model context) must NOT latch, so the race can still
+// fail over to a healthier provider.
+func TestLatchDeterministicLoser_PressuredBatchBudgetNotLatched(t *testing.T) {
+	p := &registry.Provider{BackendCapacity: &protocol.BackendCapacity{
+		Slots: []protocol.BackendSlotCapacity{{Model: "m", State: "running", ActiveTokenBudgetMax: 50_000}},
+	}}
+	d := &dispatchState{s: newTestServerForDispatch(t), model: "m", modelMaxContext: 131072}
+	d.latchDeterministicLoser(p, protocol.InferenceErrorMessage{
+		Error: "token_budget_exhausted: request exceeds batch token budget",
+	})
+	if d.unservable {
+		t.Fatalf("a pressured (budget<context) batch-budget loser must NOT latch unservable")
+	}
+}
+
+// TestShouldStopFailover_HonorsLatch (DAR-347 #2): once a deterministic loser has
+// latched d.unservable, shouldStopFailover stops at the next retry point regardless
+// of the surviving racer's (here transient) lastErr — the exact gap that let the
+// speculative path keep storming. Fails without the d.unservable guard, which would
+// classify "queue full" as a transient and keep failing over.
+func TestShouldStopFailover_HonorsLatch(t *testing.T) {
+	d := &dispatchState{
+		s: newTestServerForDispatch(t), model: "m",
+		unservable: true, unservableReason: rejectionReasonOversized,
+		lastErr: "request rejected: queue full", // a transient that alone would NOT stop failover
+	}
+	if !d.shouldStopFailover() {
+		t.Fatalf("shouldStopFailover must honor a previously-latched unservable verdict")
+	}
+}

--- a/coordinator/api/dispatch_oversized_test.go
+++ b/coordinator/api/dispatch_oversized_test.go
@@ -1,0 +1,157 @@
+package api
+
+// DAR-347 dispatch-loop integration tests: oversized / capacity rejections must
+// stop the failover loop early (uptime-neutral 429) instead of storming all 64
+// providers, while genuine transient-capacity rejections still fail over. They
+// reuse the failover harness (setupFailoverServer / startFailoverProvider /
+// postChat) and drive the REAL dispatch loop through fake WS providers.
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+)
+
+// rejectScript makes every dispatch reject pre-content with (errMsg, status) and
+// NO chunks — the shape of a provider token-budget admission rejection.
+func rejectScript(errMsg string, status int) inferenceScript {
+	return func(ctx context.Context, fp *failoverProvider, req protocol.InferenceRequestMessage, body []byte) {
+		fp.sendInferenceError(ctx, req, errMsg, status)
+	}
+}
+
+// TestDispatch_DeterministicTokenBudget_StopsAfterOneAttempt: a request whose
+// prompt exceeds the model context is rejected identically by every provider
+// ("request exceeds batch token budget"). The loop MUST stop after the first
+// attempt and return an uptime-neutral 429 + Retry-After — not retry across the
+// fleet (the prod storm: median 22 / max 63 attempts). Two providers are present
+// so a storm would be observable as >1 dispatch.
+func TestDispatch_DeterministicTokenBudget_StopsAfterOneAttempt(t *testing.T) {
+	reg, _, ts := setupFailoverServer(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	model := "oversized-deterministic-model"
+	script := rejectScript("token_budget_exhausted: request exceeds batch token budget", http.StatusServiceUnavailable)
+	pA := startFailoverProvider(t, ctx, ts, reg, failoverProviderConfig{
+		Name: "provider-a", Version: "0.6.20", DecodeTPS: 200,
+		Models: []failoverModelSpec{{ID: model}}, Script: script,
+	})
+	pB := startFailoverProvider(t, ctx, ts, reg, failoverProviderConfig{
+		Name: "provider-b", Version: "0.6.20", DecodeTPS: 1,
+		Models: []failoverModelSpec{{ID: model}}, Script: script,
+	})
+
+	// Inline request so we can assert the Retry-After header.
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, ts.URL+"/v1/chat/completions",
+		strings.NewReader(buildChatBody(t, model, false, nil)))
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer test-key")
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("chat request: %v", err)
+	}
+	defer resp.Body.Close()
+	bodyBytes, _ := io.ReadAll(resp.Body)
+	body := string(bodyBytes)
+
+	if resp.StatusCode != http.StatusTooManyRequests {
+		t.Fatalf("status = %d, want 429 (deterministic unservable → uptime-neutral 429); body=%s", resp.StatusCode, body)
+	}
+	if resp.Header.Get("Retry-After") == "" {
+		t.Errorf("missing Retry-After header on the 429")
+	}
+	if !strings.Contains(body, "rate_limit_exceeded") {
+		t.Errorf("body missing rate_limit_exceeded code; body=%s", body)
+	}
+	if total := pA.dispatchCount() + pB.dispatchCount(); total != 1 {
+		t.Errorf("total dispatches = %d, want 1 — a deterministic context rejection must STOP after the first attempt, not storm", total)
+	}
+}
+
+// TestDispatch_TransientCapacity_StillFailsOver: a provider-specific transient
+// shortage ("queue full") must NOT stop the loop — another provider may serve it.
+// Guards against over-rejection (the false-NO / underutilization direction).
+func TestDispatch_TransientCapacity_StillFailsOver(t *testing.T) {
+	reg, _, ts := setupFailoverServer(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	model := "transient-capacity-model"
+	rec := &dispatchRecorder{}
+	script := func(ctx context.Context, fp *failoverProvider, req protocol.InferenceRequestMessage, body []byte) {
+		if rec.record(fp.name) == 1 {
+			// First-dispatched provider: transient capacity shortage.
+			fp.sendInferenceError(ctx, req, "request rejected: queue full", http.StatusServiceUnavailable)
+			return
+		}
+		fp.serveFull(ctx, req, model, markerFor(fp.name))
+	}
+	startFailoverProvider(t, ctx, ts, reg, failoverProviderConfig{
+		Name: "provider-a", Version: "0.6.20", DecodeTPS: 200,
+		Models: []failoverModelSpec{{ID: model}}, Script: script,
+	})
+	startFailoverProvider(t, ctx, ts, reg, failoverProviderConfig{
+		Name: "provider-b", Version: "0.6.20", DecodeTPS: 1,
+		Models: []failoverModelSpec{{ID: model}}, Script: script,
+	})
+
+	status, body, err := postChat(ctx, ts.URL, "test-key", buildChatBody(t, model, true, nil))
+	if err != nil {
+		t.Fatalf("chat request: %v", err)
+	}
+	seq := rec.sequence()
+	if len(seq) != 2 {
+		t.Fatalf("dispatch sequence = %v, want 2 (transient capacity must fail over to a second provider); status=%d body=%s", seq, status, body)
+	}
+	if seq[0] == seq[1] {
+		t.Errorf("both dispatches went to %q — failover must retry on a DIFFERENT provider", seq[0])
+	}
+	assertCleanFailoverStream(t, status, body, markerFor(seq[1]))
+}
+
+// TestDispatch_TransientCapacity_CappedRetries: when EVERY provider returns a
+// transient capacity shortage, the loop must stop at maxCapacityClassRetries (not
+// walk all maxDispatchAttempts=64). Five providers are present so the cap — not
+// candidate exhaustion — is what stops it.
+func TestDispatch_TransientCapacity_CappedRetries(t *testing.T) {
+	reg, _, ts := setupFailoverServer(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	model := "transient-capped-model"
+	script := rejectScript("server busy", http.StatusServiceUnavailable)
+	const nProviders = 5
+	providers := make([]*failoverProvider, 0, nProviders)
+	for i := 0; i < nProviders; i++ {
+		providers = append(providers, startFailoverProvider(t, ctx, ts, reg, failoverProviderConfig{
+			Name: fmt.Sprintf("provider-%d", i), Version: "0.6.20", DecodeTPS: 100,
+			Models: []failoverModelSpec{{ID: model}}, Script: script,
+		}))
+	}
+
+	status, body, err := postChat(ctx, ts.URL, "test-key", buildChatBody(t, model, false, nil))
+	if err != nil {
+		t.Fatalf("chat request: %v", err)
+	}
+	if status != http.StatusTooManyRequests {
+		t.Fatalf("status = %d, want 429; body=%s", status, body)
+	}
+	total := 0
+	for _, p := range providers {
+		total += p.dispatchCount()
+	}
+	if total != maxCapacityClassRetries {
+		t.Errorf("total dispatches = %d, want %d (transient capacity must be capped, not stormed to %d)",
+			total, maxCapacityClassRetries, maxDispatchAttempts)
+	}
+}

--- a/coordinator/api/inference_failure_class.go
+++ b/coordinator/api/inference_failure_class.go
@@ -125,11 +125,26 @@ const (
 
 // classifyRejection refines a pre-content provider error into the dispatch
 // response kind. reason is the structured InferenceErrorMessage.ErrorReason
-// (may be empty); errStr is the human-readable provider error. A non-capacity
-// error returns rejectionNotCapacity so callers preserve fault failover + the
-// per-provider breaker. Matching mirrors isCapacityClassProviderError
-// (substring, case-insensitive, curly-apostrophe-normalised).
-func classifyRejection(reason, errStr string) rejectionKind {
+// (may be empty); errStr is the human-readable provider error. providerBudget is
+// the rejecting provider's most recently reported token budget for the model
+// (ActiveTokenBudgetMax, 0 = unknown); modelContext is the model's context window
+// (0 = unknown). A non-capacity error returns rejectionNotCapacity so callers
+// preserve fault failover + the per-provider breaker. Matching mirrors
+// isCapacityClassProviderError (substring, case-insensitive,
+// curly-apostrophe-normalised).
+//
+// providerBudget/modelContext exist to fix the unsound assumption that EVERY
+// "batch token budget" rejection is fleet-wide deterministic. The provider's
+// admission cap is min(context, activeTokenBudget) (BatchScheduler.swift
+// resolvedMaxTokensPerBatch), and activeTokenBudget is memory-aware: under
+// pressure it drops BELOW the context window. So the bare string can mean either
+// "prompt > context" (deterministic — every provider rejects) or "prompt > THIS
+// node's shrunk KV budget" (transient — a healthier provider serves). We treat it
+// as deterministic UNLESS we have positive evidence of memory pressure on the
+// rejecting provider (its reported budget is known and below the model context),
+// in which case it is transient. An explicit "exceeds … context" phrasing names
+// the context directly and is always deterministic.
+func classifyRejection(reason, errStr string, providerBudget int64, modelContext int) rejectionKind {
 	// Capacity-class is gated by isCapacityClassProviderError so fault strings
 	// (checked first there) can never be miscategorised as a capacity shed.
 	if !isCapacityClassProviderError(errStr) && !isCapacityClassProviderError(reason) {
@@ -137,15 +152,23 @@ func classifyRejection(reason, errStr string) rejectionKind {
 	}
 	s := strings.ToLower(strings.TrimSpace(errStr + " " + reason))
 	s = strings.ReplaceAll(s, "’", "'")
-	// Model-intrinsic (fleet-wide deterministic): the prompt exceeds the model's
-	// per-batch prompt cap (= min(context window, KV budget)) or its context
-	// window. The provider's KV budget is millions of tokens in practice, so the
-	// binding limit is the context window — identical on every provider serving
-	// the model. The provider emits "request exceeds batch token budget"
-	// (BatchSchedulerTypes: requestExceedsBatchTokenBudget) or a
-	// "prompt exceeds … context" phrasing. Retrying cannot help.
-	if strings.Contains(s, "batch token budget") ||
-		(strings.Contains(s, "exceeds") && strings.Contains(s, "context")) {
+	// An explicit "prompt exceeds … context window/length" phrasing names the
+	// model context directly — unambiguous, fleet-wide deterministic regardless of
+	// any provider's KV budget. Retrying cannot help.
+	if strings.Contains(s, "exceeds") && strings.Contains(s, "context") {
+		return rejectionDeterministicUnservable
+	}
+	// "request exceeds batch token budget" (BatchSchedulerTypes:
+	// requestExceedsBatchTokenBudget) is rejected at min(context, activeTokenBudget).
+	// Deterministic ONLY when we can rule out that this node was memory-pressured:
+	// a known reported budget below the model context means the binding term may
+	// have been THIS node's KV budget, so a less-pressured provider could serve —
+	// treat as transient (failover, capped). Otherwise (budget >= context, or
+	// either value unknown) the binding term is the context, identical fleet-wide.
+	if strings.Contains(s, "batch token budget") {
+		if modelContext > 0 && providerBudget > 0 && providerBudget < int64(modelContext) {
+			return rejectionTransientCapacity
+		}
 		return rejectionDeterministicUnservable
 	}
 	// Everything else capacity-class is provider/time-specific — this node's live

--- a/coordinator/api/inference_failure_class.go
+++ b/coordinator/api/inference_failure_class.go
@@ -165,10 +165,18 @@ func classifyRejection(reason, errStr string, providerBudget int64, modelContext
 	}
 	s := strings.ToLower(strings.TrimSpace(errStr + " " + reason))
 	s = strings.ReplaceAll(s, "’", "'")
-	// An explicit "prompt exceeds … context window/length" phrasing names the
-	// model context directly — unambiguous, fleet-wide deterministic regardless of
-	// any provider's KV budget. Retrying cannot help.
-	if strings.Contains(s, "exceeds") && strings.Contains(s, "context") {
+	// An explicit context-window/length overflow names the model context directly —
+	// unambiguous, fleet-wide deterministic regardless of any provider's KV budget.
+	// Match BOTH tenses ("exceeds"/"exceeded") and the bare "context length" /
+	// "context window" markers (mirrored in capacityClassMarkers and the provider
+	// breaker), so phrasings like "context length exceeded" / "context window
+	// exceeded" / "prompt too long for context window" stop on the first provider
+	// instead of failing over. Retrying cannot help.
+	if strings.Contains(s, "context") &&
+		(strings.Contains(s, "exceeds") || strings.Contains(s, "exceeded")) {
+		return rejectionDeterministicUnservable
+	}
+	if strings.Contains(s, "context length") || strings.Contains(s, "context window") {
 		return rejectionDeterministicUnservable
 	}
 	// "request exceeds batch token budget" (BatchSchedulerTypes:

--- a/coordinator/api/inference_failure_class.go
+++ b/coordinator/api/inference_failure_class.go
@@ -94,6 +94,68 @@ func isCapacityClassProviderError(errStr string) bool {
 	return false
 }
 
+// rejectionKind refines a CAPACITY-class provider rejection by how the dispatch
+// loop should respond. isCapacityClassProviderError only answers the 5xx→429
+// question; this answers the orthogonal "should we keep failing over?" question.
+//
+// A request that is intrinsically too large for the MODEL (its prompt exceeds
+// the context window / per-batch prompt cap) is rejected identically by EVERY
+// provider serving that model — so retrying across the fleet is pure waste. In
+// prod this produced a 22-63× dispatch storm (ceiling maxDispatchAttempts=64),
+// ~8.7 min latency per request, and 0% eventual success. Those stop after the
+// first rejection. A provider/time-specific shortage (this node's live KV
+// budget, a full queue, an update drain, a cold miss) MAY clear on another
+// provider, so those still fail over — but under a tight cap so a fleet-wide
+// transient can't storm either.
+type rejectionKind int
+
+const (
+	// rejectionNotCapacity: a genuine fault (or unrecognised string) — the caller
+	// keeps existing behavior (stays a 5xx fault, the per-provider breaker may
+	// deroute the offender, and fault failover continues to maxDispatchAttempts).
+	rejectionNotCapacity rejectionKind = iota
+	// rejectionDeterministicUnservable: the request exceeds the model's context /
+	// per-batch prompt limit — identical on every provider. Stop immediately and
+	// return an uptime-neutral 429; retrying cannot help.
+	rejectionDeterministicUnservable
+	// rejectionTransientCapacity: a provider/time-specific shortage. Failover may
+	// help, bounded by maxCapacityClassRetries.
+	rejectionTransientCapacity
+)
+
+// classifyRejection refines a pre-content provider error into the dispatch
+// response kind. reason is the structured InferenceErrorMessage.ErrorReason
+// (may be empty); errStr is the human-readable provider error. A non-capacity
+// error returns rejectionNotCapacity so callers preserve fault failover + the
+// per-provider breaker. Matching mirrors isCapacityClassProviderError
+// (substring, case-insensitive, curly-apostrophe-normalised).
+func classifyRejection(reason, errStr string) rejectionKind {
+	// Capacity-class is gated by isCapacityClassProviderError so fault strings
+	// (checked first there) can never be miscategorised as a capacity shed.
+	if !isCapacityClassProviderError(errStr) && !isCapacityClassProviderError(reason) {
+		return rejectionNotCapacity
+	}
+	s := strings.ToLower(strings.TrimSpace(errStr + " " + reason))
+	s = strings.ReplaceAll(s, "’", "'")
+	// Model-intrinsic (fleet-wide deterministic): the prompt exceeds the model's
+	// per-batch prompt cap (= min(context window, KV budget)) or its context
+	// window. The provider's KV budget is millions of tokens in practice, so the
+	// binding limit is the context window — identical on every provider serving
+	// the model. The provider emits "request exceeds batch token budget"
+	// (BatchSchedulerTypes: requestExceedsBatchTokenBudget) or a
+	// "prompt exceeds … context" phrasing. Retrying cannot help.
+	if strings.Contains(s, "batch token budget") ||
+		(strings.Contains(s, "exceeds") && strings.Contains(s, "context")) {
+		return rejectionDeterministicUnservable
+	}
+	// Everything else capacity-class is provider/time-specific — this node's live
+	// KV budget ("exceeds active token budget" / "requires N tokens but only M
+	// available" / "insufficient kv headroom"), a full queue, server busy, an
+	// update drain, or a cold "not loaded" miss. Another provider (bigger budget,
+	// free queue, already warm) may serve it, so fail over under the cap.
+	return rejectionTransientCapacity
+}
+
 // capacityClassMarkers are BUCKET A substrings: ADMITTED-but-unservable or
 // lifecycle rejections that should reclassify a provider 5xx to an uptime-neutral
 // 429. Drop a newly-observed capacity string here (predicates that need more than

--- a/coordinator/api/inference_failure_class.go
+++ b/coordinator/api/inference_failure_class.go
@@ -144,6 +144,19 @@ const (
 // rejecting provider (its reported budget is known and below the model context),
 // in which case it is transient. An explicit "exceeds … context" phrasing names
 // the context directly and is always deterministic.
+//
+// LIMITATION (residual stale-snapshot edge): providerBudget is the LAST
+// heartbeat's ActiveTokenBudgetMax, not the live budget the provider rejected
+// against — the wire InferenceErrorMessage carries no rejection-time budget. So if
+// a provider's budget was >= context at the last heartbeat but memory pressure
+// shrank it below context just before this request, we still classify
+// deterministic and stop after one attempt. This is strictly better than the
+// pre-DAR-347 behavior (which classified EVERY batch-budget rejection
+// deterministic) and degrades only to a rare uptime-neutral 429 the client
+// retries — never a 503 storm. The complete fix is provider-side: emit a distinct
+// reason for "prompt > context" vs "prompt > this node's budget" so the
+// coordinator never has to infer it from a stale snapshot (tracked as a follow-up;
+// requires a protocol/provider change across a mixed fleet, out of scope here).
 func classifyRejection(reason, errStr string, providerBudget int64, modelContext int) rejectionKind {
 	// Capacity-class is gated by isCapacityClassProviderError so fault strings
 	// (checked first there) can never be miscategorised as a capacity shed.

--- a/coordinator/api/prompt_calibration.go
+++ b/coordinator/api/prompt_calibration.go
@@ -1,0 +1,90 @@
+package api
+
+import (
+	"strconv"
+	"strings"
+	"sync"
+)
+
+// Prompt-token estimate calibration for the servability context gate.
+//
+// estimatePromptTokens (consumer.go) approximates prompt tokens as len/4. That
+// UNDERcounts real tokenization: measured prod actual/estimate ratios are p50
+// 1.19, p90 ~2.1, max ~5.9 (dense code/JSON tokenizes far below 4 chars/token).
+// Uncalibrated, a request whose exact prompt exceeds the model context window
+// looks small enough to pass the context tier (est+max < context), gets
+// dispatched, and the provider 503s with token_budget_exhausted. A conservative
+// per-family multiplier nudges the gate's input up so those are caught at
+// preflight (uptime-neutral 429, no dispatch). It is deliberately kept BELOW the
+// observed p90 so genuinely-servable mid-size prompts are not over-rejected — the
+// always-on dispatch-time deterministic stop (dispatch.go shouldStopFailover) is
+// the exact backstop for everything the estimate still misses.
+//
+// Applied ONLY to the servability context check (see shedIfUnservable). Billing
+// (estimateBillingPromptTokens upper-bounds independently) and the capacity/TTFT
+// estimate are intentionally left on the raw value.
+
+var (
+	calibrationMu sync.RWMutex
+	// promptContextCalibration maps a model-id substring (family) to a multiplier.
+	// Default is derived from observed gpt-oss ratios; tunable via
+	// EIGENINFERENCE_PROMPT_CALIBRATION ("gpt-oss:1.3,gemma:1.1").
+	promptContextCalibration = map[string]float64{
+		"gpt-oss": 1.3,
+	}
+)
+
+// calibratedContextPromptTokens returns the prompt-token estimate scaled by the
+// largest matching per-family multiplier (>= 1.0). Returns est unchanged when no
+// family matches or the input is non-positive. Choosing the MAX among matches is
+// deterministic (map iteration order is irrelevant) and conservative.
+func calibratedContextPromptTokens(model string, est int) int {
+	if est <= 0 {
+		return est
+	}
+	calibrationMu.RLock()
+	mult := 1.0
+	for fam, m := range promptContextCalibration {
+		if m > mult && strings.Contains(model, fam) {
+			mult = m
+		}
+	}
+	calibrationMu.RUnlock()
+	if mult <= 1.0 {
+		return est
+	}
+	return int(float64(est) * mult)
+}
+
+// SetPromptContextCalibrationFromEnv parses an override of the form
+// "family:factor,family:factor" (e.g. "gpt-oss:1.3,gemma:1.15") and REPLACES the
+// calibration map when at least one valid pair is present. Invalid pairs and
+// factors < 1.0 are skipped (a factor below 1 would under-reject, the wrong
+// direction). A blank string is a no-op (keeps the built-in default). Returns the
+// number of pairs applied. Called once at startup from main.go.
+func SetPromptContextCalibrationFromEnv(raw string) int {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return 0
+	}
+	next := make(map[string]float64)
+	for _, pair := range strings.Split(raw, ",") {
+		kv := strings.SplitN(strings.TrimSpace(pair), ":", 2)
+		if len(kv) != 2 {
+			continue
+		}
+		fam := strings.TrimSpace(kv[0])
+		factor, err := strconv.ParseFloat(strings.TrimSpace(kv[1]), 64)
+		if fam == "" || err != nil || factor < 1.0 {
+			continue
+		}
+		next[fam] = factor
+	}
+	if len(next) == 0 {
+		return 0
+	}
+	calibrationMu.Lock()
+	promptContextCalibration = next
+	calibrationMu.Unlock()
+	return len(next)
+}

--- a/coordinator/api/prompt_calibration_test.go
+++ b/coordinator/api/prompt_calibration_test.go
@@ -1,0 +1,60 @@
+package api
+
+import "testing"
+
+func TestCalibratedContextPromptTokens(t *testing.T) {
+	cases := []struct {
+		name  string
+		model string
+		est   int
+		want  int
+	}{
+		{"gpt_oss_scaled_1_3", "gpt-oss-20b", 100000, 130000},
+		{"gpt_oss_alias_scaled", "gpt-oss", 10000, 13000},
+		{"non_matching_family_unchanged", "gemma-4-26b-qat-4bit", 100000, 100000},
+		{"zero_unchanged", "gpt-oss-20b", 0, 0},
+		{"negative_unchanged", "gpt-oss-20b", -5, -5},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := calibratedContextPromptTokens(tc.model, tc.est); got != tc.want {
+				t.Errorf("calibratedContextPromptTokens(%q, %d) = %d, want %d", tc.model, tc.est, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSetPromptContextCalibrationFromEnv(t *testing.T) {
+	// Snapshot + restore the package default so this test cannot leak into others.
+	calibrationMu.Lock()
+	saved := promptContextCalibration
+	calibrationMu.Unlock()
+	t.Cleanup(func() {
+		calibrationMu.Lock()
+		promptContextCalibration = saved
+		calibrationMu.Unlock()
+	})
+
+	if n := SetPromptContextCalibrationFromEnv("gpt-oss:1.5,gemma:1.2"); n != 2 {
+		t.Fatalf("applied pairs = %d, want 2", n)
+	}
+	if got := calibratedContextPromptTokens("gpt-oss-20b", 100000); got != 150000 {
+		t.Errorf("after override, gpt-oss = %d, want 150000", got)
+	}
+	if got := calibratedContextPromptTokens("gemma-4-26b", 100000); got != 120000 {
+		t.Errorf("after override, gemma = %d, want 120000", got)
+	}
+
+	// Blank / invalid input is a no-op (keeps whatever is currently configured).
+	if n := SetPromptContextCalibrationFromEnv(""); n != 0 {
+		t.Errorf("blank applied = %d, want 0", n)
+	}
+	if n := SetPromptContextCalibrationFromEnv("garbage,gpt-oss:notafloat,foo:0.5"); n != 0 {
+		// 0.5 < 1.0 is rejected (would under-reject), the others are malformed.
+		t.Errorf("all-invalid applied = %d, want 0", n)
+	}
+	// The last valid override (1.5) must still be in effect after the no-ops.
+	if got := calibratedContextPromptTokens("gpt-oss-20b", 100000); got != 150000 {
+		t.Errorf("after no-op overrides, gpt-oss = %d, want 150000 (unchanged)", got)
+	}
+}

--- a/coordinator/api/rejection_classify_test.go
+++ b/coordinator/api/rejection_classify_test.go
@@ -5,15 +5,19 @@ import "testing"
 // TestClassifyRejection pins the deterministic-vs-transient split that drives the
 // dispatch loop's stop-or-failover decision (DAR-347). The exact provider strings
 // come from the Swift scheduler (BatchSchedulerTypes / BatchScheduler):
-//   - "request exceeds batch token budget"  → prompt > min(context, kv) ≈ context → deterministic
+//   - "request exceeds batch token budget"  → prompt > min(context, kv) → deterministic
+//     ONLY when the rejecting provider's budget was NOT below the model context
+//     (otherwise the binding term may have been this node's shrunk KV budget).
 //   - "request exceeds active token budget" → this node's KV budget          → transient
 //   - "request requires N tokens but only M available" → this node's KV budget → transient
 func TestClassifyRejection(t *testing.T) {
 	cases := []struct {
-		name   string
-		reason string
-		errStr string
-		want   rejectionKind
+		name           string
+		reason         string
+		errStr         string
+		providerBudget int64
+		modelContext   int
+		want           rejectionKind
 	}{
 		{
 			name:   "batch_token_budget_is_deterministic",
@@ -56,6 +60,53 @@ func TestClassifyRejection(t *testing.T) {
 			errStr: "request exceeds batch token budget",
 			want:   rejectionDeterministicUnservable,
 		},
+		// DAR-347 #1: a "batch token budget" rejection is rejected at
+		// min(context, activeTokenBudget). When the rejecting provider's reported
+		// budget is KNOWN and BELOW the model context, it was memory-pressured, so
+		// the binding term may have been THIS node's shrunk KV budget — a healthier
+		// provider may serve. Treat as transient (failover), NOT deterministic-stop.
+		{
+			name:           "batch_budget_pressured_provider_is_transient",
+			errStr:         "token_budget_exhausted: request exceeds batch token budget",
+			providerBudget: 50_000,
+			modelContext:   131072,
+			want:           rejectionTransientCapacity,
+		},
+		// Budget >= context: the binding term was the context, identical fleet-wide.
+		{
+			name:           "batch_budget_unpressured_provider_is_deterministic",
+			errStr:         "token_budget_exhausted: request exceeds batch token budget",
+			providerBudget: 200_000,
+			modelContext:   131072,
+			want:           rejectionDeterministicUnservable,
+		},
+		// Budget known but context unknown: can't prove pressure ⇒ deterministic
+		// (preserves the storm-stop default when context is unavailable).
+		{
+			name:           "batch_budget_unknown_context_is_deterministic",
+			errStr:         "token_budget_exhausted: request exceeds batch token budget",
+			providerBudget: 50_000,
+			modelContext:   0,
+			want:           rejectionDeterministicUnservable,
+		},
+		// Context known but provider budget unknown (no heartbeat budget): can't
+		// prove pressure ⇒ deterministic.
+		{
+			name:           "batch_budget_unknown_budget_is_deterministic",
+			errStr:         "token_budget_exhausted: request exceeds batch token budget",
+			providerBudget: 0,
+			modelContext:   131072,
+			want:           rejectionDeterministicUnservable,
+		},
+		// An explicit "exceeds … context" phrasing names the context directly, so it
+		// is deterministic regardless of the provider's (here pressured) budget.
+		{
+			name:           "explicit_context_overflow_ignores_budget",
+			errStr:         "prompt exceeds the model's context window",
+			providerBudget: 50_000,
+			modelContext:   131072,
+			want:           rejectionDeterministicUnservable,
+		},
 		// Genuine faults / unknown ⇒ not capacity (keep fault failover + breaker).
 		{name: "crash_is_not_capacity", errStr: "backend crash during generation", want: rejectionNotCapacity},
 		{name: "panic_is_not_capacity", errStr: "panic: nil map", want: rejectionNotCapacity},
@@ -69,8 +120,9 @@ func TestClassifyRejection(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := classifyRejection(tc.reason, tc.errStr); got != tc.want {
-				t.Errorf("classifyRejection(%q, %q) = %d, want %d", tc.reason, tc.errStr, got, tc.want)
+			if got := classifyRejection(tc.reason, tc.errStr, tc.providerBudget, tc.modelContext); got != tc.want {
+				t.Errorf("classifyRejection(%q, %q, budget=%d, ctx=%d) = %d, want %d",
+					tc.reason, tc.errStr, tc.providerBudget, tc.modelContext, got, tc.want)
 			}
 		})
 	}

--- a/coordinator/api/rejection_classify_test.go
+++ b/coordinator/api/rejection_classify_test.go
@@ -1,0 +1,77 @@
+package api
+
+import "testing"
+
+// TestClassifyRejection pins the deterministic-vs-transient split that drives the
+// dispatch loop's stop-or-failover decision (DAR-347). The exact provider strings
+// come from the Swift scheduler (BatchSchedulerTypes / BatchScheduler):
+//   - "request exceeds batch token budget"  → prompt > min(context, kv) ≈ context → deterministic
+//   - "request exceeds active token budget" → this node's KV budget          → transient
+//   - "request requires N tokens but only M available" → this node's KV budget → transient
+func TestClassifyRejection(t *testing.T) {
+	cases := []struct {
+		name   string
+		reason string
+		errStr string
+		want   rejectionKind
+	}{
+		{
+			name:   "batch_token_budget_is_deterministic",
+			errStr: "token_budget_exhausted: request exceeds batch token budget",
+			want:   rejectionDeterministicUnservable,
+		},
+		{
+			name:   "exceeds_context_window_is_deterministic",
+			errStr: "prompt exceeds the model's context window",
+			want:   rejectionDeterministicUnservable,
+		},
+		{
+			name:   "active_token_budget_is_transient",
+			errStr: "token_budget_exhausted: request exceeds active token budget",
+			want:   rejectionTransientCapacity,
+		},
+		{
+			name:   "requires_N_but_M_available_is_transient",
+			errStr: "token_budget_exhausted: request requires 115635 tokens but only 90000 available",
+			want:   rejectionTransientCapacity,
+		},
+		{
+			name:   "insufficient_kv_headroom_is_transient",
+			errStr: "token_budget_exhausted: insufficient global KV cache headroom",
+			want:   rejectionTransientCapacity,
+		},
+		{name: "queue_full_is_transient", errStr: "request rejected: queue full", want: rejectionTransientCapacity},
+		{name: "server_busy_is_transient", errStr: "server busy", want: rejectionTransientCapacity},
+		{name: "draining_is_transient", errStr: "provider draining for update", want: rejectionTransientCapacity},
+		{name: "not_loaded_is_transient", errStr: "model not loaded on this provider", want: rejectionTransientCapacity},
+		{
+			name:   "structured_reason_only_no_detail_is_transient",
+			reason: "token_budget_exhausted",
+			errStr: "",
+			want:   rejectionTransientCapacity,
+		},
+		{
+			name:   "reason_carries_batch_detail_is_deterministic",
+			reason: "token_budget_exhausted",
+			errStr: "request exceeds batch token budget",
+			want:   rejectionDeterministicUnservable,
+		},
+		// Genuine faults / unknown ⇒ not capacity (keep fault failover + breaker).
+		{name: "crash_is_not_capacity", errStr: "backend crash during generation", want: rejectionNotCapacity},
+		{name: "panic_is_not_capacity", errStr: "panic: nil map", want: rejectionNotCapacity},
+		{name: "first_chunk_timeout_is_not_capacity", errStr: "timeout waiting for first response", want: rejectionNotCapacity},
+		{name: "empty_is_not_capacity", errStr: "", want: rejectionNotCapacity},
+		{name: "model_load_failed_bad_weights_is_not_capacity", errStr: "model load failed: bad metallib", want: rejectionNotCapacity},
+		// A cold-load CAPACITY failure ("model load failed: insufficient memory") is
+		// capacity-class but not deterministic-context ⇒ transient (failover may hit
+		// a warmer/bigger node).
+		{name: "model_load_failed_oom_is_transient", errStr: "model load failed: insufficient memory", want: rejectionTransientCapacity},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := classifyRejection(tc.reason, tc.errStr); got != tc.want {
+				t.Errorf("classifyRejection(%q, %q) = %d, want %d", tc.reason, tc.errStr, got, tc.want)
+			}
+		})
+	}
+}

--- a/coordinator/api/rejection_classify_test.go
+++ b/coordinator/api/rejection_classify_test.go
@@ -29,6 +29,24 @@ func TestClassifyRejection(t *testing.T) {
 			errStr: "prompt exceeds the model's context window",
 			want:   rejectionDeterministicUnservable,
 		},
+		// Past-tense / marker-only context-overflow phrasings are deterministic too
+		// (the deterministic check matches both "exceeds"/"exceeded" and the bare
+		// context length/window markers).
+		{
+			name:   "context_length_exceeded_past_tense_is_deterministic",
+			errStr: "context length exceeded",
+			want:   rejectionDeterministicUnservable,
+		},
+		{
+			name:   "context_window_exceeded_past_tense_is_deterministic",
+			errStr: "context window exceeded",
+			want:   rejectionDeterministicUnservable,
+		},
+		{
+			name:   "too_long_for_context_window_is_deterministic",
+			errStr: "prompt too long for context window",
+			want:   rejectionDeterministicUnservable,
+		},
 		{
 			name:   "active_token_budget_is_transient",
 			errStr: "token_budget_exhausted: request exceeds active token budget",

--- a/coordinator/api/servability_gate.go
+++ b/coordinator/api/servability_gate.go
@@ -43,9 +43,21 @@ func (s *Server) shedIfUnservable(
 		return false
 	}
 
+	// The context tier gets a CALIBRATED prompt estimate; the token-budget tier
+	// keeps the RAW estimate (see PredictServable). estimatePromptTokens uses
+	// len/4, which UNDERcounts real tokenization (observed prod actual/estimate
+	// p50 1.19, heavy right tail to ~5.9 on dense code/JSON), so a ~130K-real
+	// prompt looks like ~100K est and slips past the raw context tier — then the
+	// provider exact-tokenizes and 503s. The per-family multiplier
+	// (calibratedContextPromptTokens) biases ONLY the context-window comparison so
+	// it never over-rejects a request that fits a provider's real KV budget; the
+	// dispatch-time deterministic stop is the exact backstop for what it misses.
+	// Billing (estimateBillingPromptTokens) and the capacity/TTFT estimate are
+	// likewise untouched.
 	verdict := s.registry.PredictServable(
 		model,
 		estimatedPromptTokens,
+		calibratedContextPromptTokens(model, estimatedPromptTokens),
 		requestedMaxTokens,
 		modelMaxContext,
 		registry.RequestTraits{HasTools: hasTools},
@@ -64,6 +76,16 @@ func (s *Server) shedIfUnservable(
 		"model:" + model,
 		"model_type:" + s.registry.ModelType(model),
 		"outcome:unservable_429",
+	})
+	// Oversized-request observability (DAR-347): counts the preflight catch so it
+	// can be compared against stage:dispatch (the deterministic dispatch-time stop)
+	// to measure how much the estimate calibration catches before any dispatch. The
+	// rejection ledger row below carries estimated_prompt_tokens / requested_max_tokens
+	// for the prompt/max histograms-by-outcome.
+	s.ddIncr("routing.oversized_request_rejected", []string{
+		"model:" + model,
+		"stage:preflight",
+		"reason:" + verdict.Reason,
 	})
 	s.recordRejection(rejectionInfo{
 		r:                     r,

--- a/coordinator/api/servability_gate_test.go
+++ b/coordinator/api/servability_gate_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/eigeninference/d-inference/coordinator/registry"
+	"github.com/eigeninference/d-inference/coordinator/store"
 )
 
 // End-to-end coverage for the smart servability gate (early-429 admission).
@@ -136,5 +137,76 @@ func TestServabilityGateDisabledAdmits(t *testing.T) {
 	// capacity path, which sheds it as a busy/at-capacity 429 instead.
 	if w.Code != http.StatusTooManyRequests || !strings.Contains(body, "at capacity") {
 		t.Fatalf("gate-off request did not take the capacity path: status=%d body=%s", w.Code, body)
+	}
+}
+
+// TestServabilityGate_CalibrationShedsContextOversized (DAR-347) proves the
+// per-family prompt-token calibration is wired into the context tier. The prompt
+// is sized so the RAW len/4 estimate + max_tokens stays UNDER the model context
+// (so an uncalibrated gate would admit it → dispatch → provider 503), while the
+// CALIBRATED estimate (gpt-oss ×1.3) crosses the context window and is shed at
+// preflight as an uptime-neutral 429. The provider carries a large token budget
+// so the token-budget tier cannot fire — isolating the context tier.
+func TestServabilityGate_CalibrationShedsContextOversized(t *testing.T) {
+	t.Setenv("EIGENINFERENCE_QUEUE_BEFORE_SHED", "false")
+	srv, st := testServer(t)
+	srv.SetServabilityGate(true)
+
+	const model = "gpt-oss-ctx-test" // contains "gpt-oss" → calibration ×1.3 applies
+	srv.registry.SetModelCatalog([]registry.CatalogEntry{{ID: model, SizeGB: 1, MinRAMGB: 24}})
+
+	// Model registry record supplies modelMaxContext. modelRegistryRecordLocked
+	// needs an active entry + a ready, promoted version.
+	entry := &store.ModelRegistryEntry{
+		ID: model, DisplayName: "ctx", Quantization: "4bit",
+		MaxContextLength: 131072, MaxOutputLength: 32768, MinRAMGB: 24, Status: "active",
+	}
+	files := []store.ModelVersionFile{{Path: "config.json", SizeBytes: 1, SHA256: testHash, Role: "config"}}
+	if err := st.SetModelVersion(entry, &store.ModelVersion{
+		ModelID: model, Version: "v1", R2Prefix: modelR2Prefix(model, "v1"),
+		AggregateSHA256: testHash, TotalSizeBytes: 1, FileCount: 1, Status: "ready",
+	}, files); err != nil {
+		t.Fatalf("SetModelVersion: %v", err)
+	}
+	if err := st.PromoteModelVersion(model, "v1"); err != nil {
+		t.Fatalf("PromoteModelVersion: %v", err)
+	}
+
+	// Resident provider with a LARGE structural token budget so PredictServable's
+	// tier-2 (prompt_too_long) cannot fire — the only tier that can shed here is
+	// tier-1 (context), and only because of the calibration.
+	p := registerBuildsProvider(srv, "ctx-provider", model)
+	p.Mu().Lock()
+	p.BackendCapacity.Slots[0].State = "running"
+	p.BackendCapacity.Slots[0].ActiveTokenBudgetMax = 5_000_000
+	p.Mu().Unlock()
+
+	// ~440,000 chars → est ~110,000 prompt tokens (len/4). With max_tokens 64:
+	//   raw:        110,064          < 131,072  → uncalibrated tier-1 PASSES
+	//   calibrated: 110,000×1.3 + 64 = 143,064 > 131,072 → calibrated tier-1 SHEDS
+	hugePrompt := strings.Repeat("x", 440000)
+	reqBody, err := json.Marshal(map[string]any{
+		"model":      model,
+		"messages":   []any{map[string]any{"role": "user", "content": hugePrompt}},
+		"max_tokens": 64,
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(string(reqBody)))
+	req.Header.Set("Authorization", "Bearer test-key")
+	req.Header.Set("Content-Type", "application/json")
+
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusTooManyRequests {
+		t.Fatalf("status = %d, want 429 (calibrated prompt exceeds context); body=%s", w.Code, w.Body.String())
+	}
+	if w.Header().Get("Retry-After") == "" {
+		t.Error("missing Retry-After on context-oversized 429")
+	}
+	if !strings.Contains(w.Body.String(), "context window") {
+		t.Errorf("body missing context-window detail (want the context_exceeded tier, proving calibration tripped tier-1); body=%s", w.Body.String())
 	}
 }

--- a/coordinator/cmd/coordinator/main.go
+++ b/coordinator/cmd/coordinator/main.go
@@ -427,6 +427,17 @@ func main() {
 		}
 	}
 
+	// Per-family prompt-token estimate calibration for the servability context
+	// check (the len/4 routing estimate undercounts dense content). Default
+	// {gpt-oss:1.3}; override with "family:factor,..." e.g. "gpt-oss:1.3,gemma:1.15".
+	if v := os.Getenv("EIGENINFERENCE_PROMPT_CALIBRATION"); v != "" {
+		if n := api.SetPromptContextCalibrationFromEnv(v); n > 0 {
+			logger.Info("prompt-token context calibration overridden", "pairs", n, "value", v)
+		} else {
+			logger.Warn("invalid EIGENINFERENCE_PROMPT_CALIBRATION; using default", "value", v)
+		}
+	}
+
 	// SSE keepalives during long prefill. ON by default at a 10s cadence so a long
 	// prefill never leaves the consumer connection idle long enough for OpenRouter's
 	// fetch timeout to fire and fail us over mid-prefill. The first keepalive fires

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -886,6 +886,32 @@ func (p *Provider) MaxConcurrencyForModel(model string) int {
 	return p.maxConcurrencyForModelLocked(model)
 }
 
+// ReportedTokenBudgetMaxForModel returns the provider's most recently reported
+// live token budget (ActiveTokenBudgetMax) for the given model, or 0 when the
+// provider has reported no per-model token budget. The provider derives this
+// value from live memory headroom (see BatchScheduler+Telemetry.swift
+// tokenBudgetMax = activeTokenBudgetUsed + headroom/kvBytesPerToken, floored at
+// 1024), so it SHRINKS under memory pressure and can fall below the model context
+// window. The dispatch path (classifyRejection) uses it to tell a fleet-wide
+// context overflow (budget >= model context ⇒ the provider's admission cap
+// min(context,budget) was the context, so every provider rejects identically)
+// apart from THIS node's shrunk KV budget (budget < context ⇒ a healthier
+// provider may still serve), which the bare "batch token budget" wire string
+// alone cannot distinguish.
+func (p *Provider) ReportedTokenBudgetMaxForModel(model string) int64 {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.BackendCapacity == nil {
+		return 0
+	}
+	for _, slot := range p.BackendCapacity.Slots {
+		if slot.Model == model {
+			return slot.ActiveTokenBudgetMax
+		}
+	}
+	return 0
+}
+
 // maxConcurrency is the lock-free version (caller must hold p.mu).
 //
 // Tier values were lowered in Phase 2 of the routing-algorithm rework

--- a/coordinator/registry/servability.go
+++ b/coordinator/registry/servability.go
@@ -130,28 +130,44 @@ func snapshotStructuralBudget(snap routingSnapshot) (budget int64, known bool) {
 // read-only and fail-open (see file header). Self-route requests should not use
 // this fleet-wide gate (they queue on the owner machine), matching the existing
 // preflight which only runs for public routes.
-func (r *Registry) PredictServable(model string, estimatedPromptTokens, requestedMaxTokens, contextLimit int, traits RequestTraits, requiresVision bool, allowedSerials ...string) ServabilityVerdict {
+//
+// contextPromptTokens is the prompt-token count used ONLY for the context-window
+// tier. It exists so a caller can feed a CALIBRATED estimate to the context tier
+// (the len/4 routing estimate undercounts dense content) WITHOUT inflating the
+// token-budget tier — the budget tier always uses the raw estimatedPromptTokens,
+// so a calibration multiplier can never over-reject a request that fits a
+// provider's real KV budget (a false-NO). Callers that don't calibrate pass
+// contextPromptTokens == estimatedPromptTokens; a value below the raw estimate is
+// floored to it (calibration only scales up).
+func (r *Registry) PredictServable(model string, estimatedPromptTokens, contextPromptTokens, requestedMaxTokens, contextLimit int, traits RequestTraits, requiresVision bool, allowedSerials ...string) ServabilityVerdict {
 	reqPrompt := estimatedPromptTokens
 	if reqPrompt < 0 {
 		reqPrompt = 0
+	}
+	reqContextPrompt := contextPromptTokens
+	if reqContextPrompt < reqPrompt {
+		reqContextPrompt = reqPrompt
 	}
 	reqMax := requestedMaxTokens
 	if reqMax <= 0 {
 		reqMax = defaultRequestedMaxTokens
 	}
-	requestTokens := reqPrompt + reqMax
+	budgetRequestTokens := reqPrompt + reqMax
+	contextRequestTokens := reqContextPrompt + reqMax
 
 	verdict := ServabilityVerdict{
 		Servable:      true,
-		RequestTokens: requestTokens,
+		RequestTokens: budgetRequestTokens,
 		ContextLimit:  contextLimit,
 	}
 
 	// Tier 1: context window. Model-level and provider-agnostic. Exceeding the
-	// model's context is a guaranteed failure on every provider.
-	if contextLimit > 0 && requestTokens > contextLimit {
+	// model's context is a guaranteed failure on every provider. Uses the
+	// (possibly calibrated) context-prompt count.
+	if contextLimit > 0 && contextRequestTokens > contextLimit {
 		verdict.Servable = false
 		verdict.Reason = ServabilityContextExceeded
+		verdict.RequestTokens = contextRequestTokens
 		return verdict
 	}
 
@@ -210,7 +226,7 @@ func (r *Registry) PredictServable(model string, estimatedPromptTokens, requeste
 	// all-zero-budget fleet would fail open and dispatch into a guaranteed
 	// provider-side token/KV rejection. Any unknown budget, or zero eligible
 	// providers (a different rejection path owns that), still fails open.
-	if providerCount > 0 && !sawUnknown && int64(requestTokens) > fleetMax {
+	if providerCount > 0 && !sawUnknown && int64(budgetRequestTokens) > fleetMax {
 		verdict.Servable = false
 		verdict.Reason = ServabilityPromptTooLong
 		return verdict

--- a/coordinator/registry/servability_test.go
+++ b/coordinator/registry/servability_test.go
@@ -124,7 +124,7 @@ func TestPredictServableContextTier(t *testing.T) {
 	model := "ctx-model"
 
 	// prompt 9000 + max 256 = 9256 > contextLimit 8192 → guaranteed-unservable.
-	v := reg.PredictServable(model, 9000, 256, 8192, RequestTraits{}, false)
+	v := reg.PredictServable(model, 9000, 9000, 256, 8192, RequestTraits{}, false)
 	if v.Servable {
 		t.Fatalf("over-context request reported servable: %+v", v)
 	}
@@ -140,7 +140,7 @@ func TestPredictServableContextTier(t *testing.T) {
 
 	// prompt 4000 + max 256 = 4256 <= contextLimit 131072 → context tier passes;
 	// with an empty fleet the budget tier fails open → servable.
-	v = reg.PredictServable(model, 4000, 256, 131072, RequestTraits{}, false)
+	v = reg.PredictServable(model, 4000, 4000, 256, 131072, RequestTraits{}, false)
 	if !v.Servable {
 		t.Fatalf("within-context request reported unservable (must fail open on empty fleet): %+v", v)
 	}
@@ -166,7 +166,7 @@ func TestPredictServableTokenBudgetTier(t *testing.T) {
 	// prompt 20000 + max 256 = 20256 > fleet max 8192, and every provider's
 	// budget is known → confident reject as prompt_too_long. contextLimit=0
 	// disables tier 1.
-	over := reg.PredictServable(model, 20000, 256, 0, RequestTraits{}, false)
+	over := reg.PredictServable(model, 20000, 20000, 256, 0, RequestTraits{}, false)
 	if over.Servable {
 		t.Fatalf("over-budget request reported servable: %+v", over)
 	}
@@ -184,7 +184,7 @@ func TestPredictServableTokenBudgetTier(t *testing.T) {
 	}
 
 	// prompt 1000 + max 256 = 1256 <= fleet max 8192 → fits → servable.
-	within := reg.PredictServable(model, 1000, 256, 0, RequestTraits{}, false)
+	within := reg.PredictServable(model, 1000, 1000, 256, 0, RequestTraits{}, false)
 	if !within.Servable {
 		t.Fatalf("within-budget request reported unservable: %+v", within)
 	}
@@ -196,6 +196,38 @@ func TestPredictServableTokenBudgetTier(t *testing.T) {
 	}
 	if within.FleetMaxBudget != 8192 {
 		t.Fatalf("FleetMaxBudget = %d, want 8192", within.FleetMaxBudget)
+	}
+}
+
+// TestPredictServableContextPromptOnlyAffectsContextTier guards the DAR-347
+// review fix: the calibrated contextPromptTokens must drive ONLY the context
+// tier, never the token-budget tier. The budget tier always uses the RAW
+// estimate, so a calibration multiplier can never over-reject a request that fits
+// a provider's real KV budget (a false-NO / underutilization).
+func TestPredictServableContextPromptOnlyAffectsContextTier(t *testing.T) {
+	reg := New(testLogger())
+	model := "context-prompt-isolation-model"
+	makeTokenBudgetProvider(t, reg, "p", model, 100, 0, 8192, 80) // fleet max budget 8192
+
+	// Budget tier (contextLimit=0 disables tier 1): raw 4000+256=4256 <= 8192
+	// fits. A calibrated context-prompt of 9000 (9256 > 8192) must NOT leak into
+	// the budget tier and shed it.
+	budget := reg.PredictServable(model, 4000, 9000, 256, 0, RequestTraits{}, false)
+	if !budget.Servable {
+		t.Fatalf("calibrated context prompt leaked into the budget tier and over-rejected a budget-fitting request: %+v", budget)
+	}
+	if budget.RequestTokens != 4256 {
+		t.Fatalf("RequestTokens = %d, want 4256 (budget tier must use the RAW estimate)", budget.RequestTokens)
+	}
+
+	// Context tier: raw 4000+256=4256 fits an 8192 context, but the calibrated
+	// 9000+256=9256 exceeds it — the context tier DOES use the calibrated prompt.
+	ctx := reg.PredictServable(model, 4000, 9000, 256, 8192, RequestTraits{}, false)
+	if ctx.Servable || ctx.Reason != ServabilityContextExceeded {
+		t.Fatalf("context tier did not use the calibrated context prompt: %+v", ctx)
+	}
+	if ctx.RequestTokens != 9256 {
+		t.Fatalf("RequestTokens = %d, want 9256 (context tier uses the calibrated prompt)", ctx.RequestTokens)
 	}
 }
 
@@ -211,7 +243,7 @@ func TestPredictServableFailsOpenOnUnknownBudget(t *testing.T) {
 	// force fail-open regardless of the known ceiling.
 	makeTokenBudgetProvider(t, reg, "known-small", model, 100, 0, 4096, 80)
 
-	huge := reg.PredictServable(model, 1_000_000, 256, 0, RequestTraits{}, false)
+	huge := reg.PredictServable(model, 1_000_000, 1_000_000, 256, 0, RequestTraits{}, false)
 	if !huge.Servable {
 		t.Fatalf("request must fail open when an eligible provider's budget is unknown: %+v", huge)
 	}
@@ -237,7 +269,7 @@ func TestPredictServableKnownZeroColdBudgetUnservable(t *testing.T) {
 	reg.SetModelCatalog([]CatalogEntry{{ID: model, SizeGB: 14, MinRAMGB: 14}})
 	makeWarmPoolColdProvider(t, reg, "tight", model, 80, 16, 0)
 
-	v := reg.PredictServable(model, 1000, 256, 0, RequestTraits{}, false)
+	v := reg.PredictServable(model, 1000, 1000, 256, 0, RequestTraits{}, false)
 	if v.Servable {
 		t.Fatalf("known-zero-budget fleet reported servable (must reject, not fail open): %+v", v)
 	}
@@ -257,7 +289,7 @@ func TestPredictServableKnownZeroColdBudgetUnservable(t *testing.T) {
 func TestPredictServableEmptyFleet(t *testing.T) {
 	reg := New(testLogger())
 
-	v := reg.PredictServable("no-such-model", 10_000_000, 256, 0, RequestTraits{}, false)
+	v := reg.PredictServable("no-such-model", 10_000_000, 10_000_000, 256, 0, RequestTraits{}, false)
 	if !v.Servable {
 		t.Fatalf("empty fleet must be servable (fail open): %+v", v)
 	}

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -27,6 +27,27 @@ This directory contains the public technical documentation for Darkbloom. Treat 
 7. **Runbooks are procedural.** Each `operations/` doc should have Prerequisites, Steps, Verification, and Rollback sections.
 8. **Reference docs are dry.** `reference/` docs should be tables, schemas, and contracts — minimal narrative.
 
+## Pull Requests
+
+**Every PR MUST include a before-and-after diagram (Mermaid) in its description** that details what changed — covering BOTH:
+
+- **Behavior**: the request/response flow, states, and outcomes a user or caller observes (e.g. dispatch → retry → 429/503/200).
+- **Code**: which functions/components changed and how control flows through them.
+
+Use two clearly labeled diagrams — a **Before** and an **After** — (or one side-by-side comparison) so a reviewer sees the delta at a glance. Scope it to what the PR changes; it is not a full-system map. A PR without a before/after diagram is not ready for review.
+
+````markdown
+```mermaid
+flowchart LR
+  subgraph Before
+    A1[request] --> B1[old behavior / code path]
+  end
+  subgraph After
+    A2[request] --> B2[new behavior / code path]
+  end
+```
+````
+
 ## Privacy model (canonical)
 
 - Consumer → coordinator: TLS by default; optional NaCl Box (X25519 + XSalsa20-Poly1305).


### PR DESCRIPTION
## DAR-347 — Stop dispatch-storming unservable gpt-oss requests

Closes DAR-347.

## Before / After (behavior + code)

**Before** — the `len/4` estimate undercounts dense prompts, so over-context requests pass preflight, get dispatched, and the failover loop retries a *deterministic* failure across the whole fleet:

```mermaid
flowchart TB
  R1["chat request<br/>~130K-real prompt"] --> PF1{"servability gate<br/>len/4 est ~100K<br/>est+max &lt; 131K ctx?"}
  PF1 -->|"passes (undercount)"| D1["dispatch to provider"]
  D1 --> X1["provider: prompt &gt; 131K context<br/>token_budget_exhausted 503"]
  X1 --> RT1{"failover loop<br/>treats as retryable"}
  RT1 -->|"retry next provider"| D1
  RT1 -.->|"up to 64x · ~8.7 min · 0% success"| F1["final 429"]
```

**After** — calibration biases the **context tier** so obvious oversize is caught at preflight; otherwise `shouldStopFailover` stops a deterministic rejection on the first attempt (transient capacity capped at 3), emitting **one** uptime-neutral 429. Faults/timeouts keep normal failover:

```mermaid
flowchart TB
  R2["chat request"] --> PF2{"servability gate<br/>calibratedContextPromptTokens<br/>(context tier only; budget tier raw)"}
  PF2 -->|"calibrated est+max &gt; ctx"| E2["early 429 + Retry-After<br/>oversized_request"]
  PF2 -->|"servable"| D2["dispatch to provider"]
  D2 -->|"content"| OK2["200 stream"]
  D2 --> X2{"pre-content rejection?<br/>classifyRejection"}
  X2 -->|"deterministic context<br/>'exceeds batch token budget'"| S2["shouldStopFailover:<br/>STOP at attempt 1"]
  X2 -->|"transient capacity"| C2{"capacityRetries &lt; 3?"}
  C2 -->|"yes"| D2
  C2 -->|"no"| S2
  X2 -->|"fault / timeout"| RT2["normal failover (≤64x, unchanged)"]
  S2 --> F2["one uptime-neutral 429<br/>oversized_request"]
```

### Problem (grounded in live prod telemetry)

Oversized gpt-oss requests were dispatched and failed as provider `token_budget_exhausted` 503. Pulling live admin telemetry (`/v1/admin/{utilization,routes,rejections}`) **overturned the original "8192 config-parse" theory**:

- Network was **90% idle** (gpt-oss 10.5% util, token-budget 0.24%, `queued=0`) — not a capacity wall.
- The 503s were on the **newest builds (v0.6.20)**, and a **89,034-token prompt succeeded** — so the cap is the real **131,072 context window**, not 8192.
- **0 of 464** requests that hit a 503 ever succeeded on retry — they are **deterministically unservable** (prompt exact-tokenizes past 131K context).
- Each was retried a **median of 22× (max 63, ceiling `maxDispatchAttempts=64`)**, ~**8.7 min**, burning provider CPU on an idle fleet — all from one consumer key looping oversized prompts.

**Root cause:** `estimatePromptTokens` uses `len/4`, which undercounts dense content (observed `actual/est` p50 1.19, p90 2.1, max 5.9). Over-context prompts slip past the servability context tier; the provider rejects `token_budget_exhausted: request exceeds batch token budget`; the pre-content failover loop (built for *transient* faults) then storms the whole fleet retrying a *deterministic* failure. Uptime was already mostly protected (the dispatch path reclassifies capacity 5xx → 429; both breakers ignore 503) — the real damage was the **storm** (latency + wasted provider work).

### Fix (coordinator-only; no protocol change)

- **`classifyRejection`** (`api/inference_failure_class.go`): splits a capacity rejection into **deterministic-context** (`exceeds batch token budget` / `exceeds …context` — identical fleet-wide) vs **transient-capacity** (this node's KV budget / queue / drain) vs fault.
- **`shouldStopFailover`** (`api/dispatch.go`): at the two post-dispatch retry choke points in `run()`. Deterministic → **stop on the first attempt**; transient → fail over but capped at `maxCapacityClassRetries=3`. The exhausted ladder emits **one uptime-neutral 429** (reason `oversized_request`, `could_have_served=false`). Genuine fault/timeout failover is unchanged.
- **Preflight calibration** (`api/prompt_calibration.go`, `servability_gate.go`, `registry/servability.go`): a per-family multiplier (gpt-oss ×1.3, env-tunable via `EIGENINFERENCE_PROMPT_CALIBRATION`) is fed to `PredictServable` through a new dedicated **`contextPromptTokens`** parameter, so it biases **only** the context-window tier. The token-budget tier always uses the raw estimate — calibration can never over-reject a request that fits a provider's real KV budget.
- **Telemetry:** `routing.oversized_request_rejected{model,stage}`, `routing.dispatch_to_capacity_503{model,reason}`.

### Why stop-at-1 is safe (no over-rejection)

`registry/scheduler.go` `freeMemoryAdmits` only routes to a provider when `requestTokens ≤ activeTokenBudgetMax`. So a `batch token budget` rejection implies `prompt > min(context, budget) = context` — i.e. the prompt exceeds the **model** context, identical on every provider. Retrying cannot help. The residual stale-snapshot edge degrades only to a rare uptime-neutral 429 (client retries), never a 503 storm.

### Tests

- Unit: `classifyRejection` table, calibration + env-override.
- Dispatch integration (real loop, fake WS providers): deterministic rejection stops at **1** dispatch (not 64); transient capacity still fails over; transient capped at **3**.
- Preflight: calibration sheds a context-oversized prompt that the raw estimate would have admitted.
- Regression: `PredictServable` context-prompt drives only the context tier, never the budget tier.
- Full `api` + `registry` suites green; `gofmt`/`vet` clean; Linux cross-compile OK.

### Quality gate

Both reviewers (codex-rescue + general-purpose) **PASS**. Codex initially flagged calibration leaking into the budget tier (a real false-NO risk); fixed via the dedicated `contextPromptTokens` param and re-verified.

### Also in this PR

- **`docs`**: CLAUDE.md + AGENTS.md now require a **before/after diagram in every PR** (behavior + code). This PR complies (see top).

### Deploy / scope notes

- Coordinator-only → **EigenCloud deploy is human-only** (not done here).
- The proactive preflight half acts only when `EIGENINFERENCE_SERVABILITY_GATE=true` (already set in prod); the dispatch-time storm fix is always-on.
- **Out of scope (product decision):** routing >131K-token prompts to a longer-context model (the only genuine lost demand); the separate gpt-oss multi-`tool_calls` 400.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
