### PR TITLE
fix(coordinator): cap per-box concurrency at quality_concurrency; keep dedicated pool warm

### DIFF
--- a/coordinator/cmd/coordinator/main.go
+++ b/coordinator/cmd/coordinator/main.go
@@ -183,6 +183,24 @@ func main() {
 		logger.Info("dedicated-model routing disabled")
 	}
 
+	// Quality-concurrency admission cap: tighten the flat per-provider concurrency
+	// cap (24) to each model's quality_concurrency × overcommit, computed from the
+	// provider's static single-stream decode rate. Stops slow, saturated models
+	// (e.g. Gemma) from over-admitting onto a few boxes and collapsing decode TPS;
+	// near-no-op for fast/over-provisioned models. Reuses the warm-pool decode
+	// floor + fallback so admission and warm-pool planning share the same math.
+	reg.SetQualityConcurrencyCap(
+		cfg.RegistryCfg.QualityCap.Enabled,
+		cfg.RegistryCfg.QualityCap.Overcommit,
+		cfg.RegistryCfg.WarmPool.DecodeFloorTPS,
+		cfg.RegistryCfg.WarmPool.FallbackQualityConcurrency,
+	)
+	logger.Info("quality-concurrency cap",
+		"enabled", cfg.RegistryCfg.QualityCap.Enabled,
+		"overcommit", cfg.RegistryCfg.QualityCap.Overcommit,
+		"decode_floor_tps", cfg.RegistryCfg.WarmPool.DecodeFloorTPS,
+	)
+
 	reg.ConfigureCacheAffinity(cfg.RegistryCfg.CacheAffinity)
 	cacheAffinityCfg := reg.CacheAffinityConfigSnapshot()
 	logger.Info("cache affinity configured", "ttl", cacheAffinityCfg.TTL.String(), "bonus_ms", cacheAffinityCfg.BonusMs, "enabled", cacheAffinityCfg.BonusMs > 0)

--- a/coordinator/registry/concurrency_cap.go
+++ b/coordinator/registry/concurrency_cap.go
@@ -1,0 +1,80 @@
+package registry
+
+import "math"
+
+// Quality-concurrency admission cap.
+//
+// The legacy per-provider concurrency cap is a flat 24 (maxConcurrency, for
+// token-budget providers) — a hard-coded approximation of "how many concurrent
+// decodes a backend can run before per-request TPS collapses". That single
+// number is wrong for slow models: a 26B model that decodes ~23 tok/s solo
+// drops below the 15 tok/s quality floor at a batch of 2, yet the flat cap let
+// it accept up to 24 concurrent, collapsing every stream to a few tok/s and
+// triggering cancellations.
+//
+// This computes the ceiling per provider+model from the model's batch-
+// degradation curve instead — the same rate(B) = solo/(1+k·B) model the
+// warm-pool target math uses (qualityConcurrency in warm_pool_target.go) — so
+// admission and capacity planning cannot drift. Slow models get a tight cap;
+// fast / over-provisioned models keep the flat fallback (their quality batch is
+// already at or above it). The cap is computed from the provider's STATIC
+// single-stream decode rate (resolvedDecodeTPS), NEVER the observed-under-load
+// EWMA: the observed rate collapses under the very overload this cap exists to
+// prevent, which would force the cap to 1 — a feedback loop.
+
+// SetQualityConcurrencyCap configures the per-provider quality-concurrency
+// admission cap. enabled=false leaves the legacy flat cap unchanged. overcommit
+// multiplies the strict (floor-preserving) quality batch; <=0 falls back to 1.0.
+// floorTPS and fallback mirror the warm-pool DecodeFloorTPS and
+// FallbackQualityConcurrency so admission uses the same quality math as the
+// warm-pool target. Called once at startup before the coordinator serves.
+func (r *Registry) SetQualityConcurrencyCap(enabled bool, overcommit, floorTPS float64, fallback int) {
+	if overcommit <= 0 {
+		overcommit = 1.0
+	}
+	if fallback < 1 {
+		fallback = 1
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.qualityCapEnabled = enabled
+	r.qualityCapOvercommit = overcommit
+	r.qualityCapFloorTPS = floorTPS
+	r.qualityCapFallback = fallback
+}
+
+// effectiveMaxConcurrencyForModelLocked returns the per-provider admission
+// concurrency cap for model: the MINIMUM of the legacy cap
+// (p.maxConcurrencyForModelLocked — a provider-reported per-slot MaxConcurrency
+// if set, else the flat fallback) and quality_concurrency × overcommit. Taking
+// the min means a provider that self-reports a TIGHTER cap still binds (it knows
+// its backend best), while a provider that reports a looser cap — or none — is
+// still held to the quality bar, so neither path can over-admit. staticDecodeTPS
+// must be the provider's single-stream (static) decode rate for the model
+// (resolvedDecodeTPS), not the observed-under-load value (which collapses under
+// the overload this cap exists to prevent). Caller holds r.mu and p.mu.
+func (r *Registry) effectiveMaxConcurrencyForModelLocked(p *Provider, model string, staticDecodeTPS float64) int {
+	base := p.maxConcurrencyForModelLocked(model)
+	if !r.qualityCapEnabled {
+		return base
+	}
+	qc := qualityConcurrency(staticDecodeTPS, r.qualityCapFloorTPS, effectiveTPSLoadFactor, base, r.qualityCapFallback)
+	capped := int(math.Ceil(float64(qc) * r.qualityCapOvercommit))
+	if capped < 1 {
+		capped = 1
+	}
+	if capped < base {
+		return capped
+	}
+	return base
+}
+
+// hasConcurrencyHeadroomForModelCapLocked mirrors
+// Provider.hasConcurrencyHeadroomForModelLocked but applies the registry's
+// quality-concurrency cap to the per-model limit. staticDecodeTPS is the
+// provider's single-stream decode rate for the model. Caller holds r.mu and
+// p.mu.
+func (r *Registry) hasConcurrencyHeadroomForModelCapLocked(p *Provider, model string, staticDecodeTPS float64) bool {
+	return p.pendingLoadForModelLocked(model) < r.effectiveMaxConcurrencyForModelLocked(p, model, staticDecodeTPS) &&
+		p.pendingCount() < p.maxConcurrency()
+}

--- a/coordinator/registry/concurrency_cap.go
+++ b/coordinator/registry/concurrency_cap.go
@@ -58,6 +58,19 @@ func (r *Registry) effectiveMaxConcurrencyForModelLocked(p *Provider, model stri
 	if !r.qualityCapEnabled {
 		return base
 	}
+	// The cap needs a trustworthy single-stream rate. p.DecodeTPS is the
+	// provider-reported registration benchmark; without it, resolvedDecodeTPS falls
+	// back to sqrt(memory_bandwidth) — a coarse, MODEL-AGNOSTIC hardware proxy that
+	// under-estimates fast models (a ~57 tok/s gpt-oss reads as ~28), so hard-capping
+	// a fast non-dedicated model from it could shed healthy traffic. Only cap from
+	// the bandwidth fallback for DEDICATED models, which are known-slow and urgently
+	// need it; a non-dedicated model without a real benchmark keeps the legacy flat
+	// cap until its provider reports decode_tps.
+	if p.DecodeTPS <= 0 {
+		if _, dedicated := r.dedicatedPatternForLocked(model); !dedicated {
+			return base
+		}
+	}
 	qc := qualityConcurrency(staticDecodeTPS, r.qualityCapFloorTPS, effectiveTPSLoadFactor, base, r.qualityCapFallback)
 	capped := int(math.Ceil(float64(qc) * r.qualityCapOvercommit))
 	if capped < 1 {
@@ -77,4 +90,14 @@ func (r *Registry) effectiveMaxConcurrencyForModelLocked(p *Provider, model stri
 func (r *Registry) hasConcurrencyHeadroomForModelCapLocked(p *Provider, model string, staticDecodeTPS float64) bool {
 	return p.pendingLoadForModelLocked(model) < r.effectiveMaxConcurrencyForModelLocked(p, model, staticDecodeTPS) &&
 		p.pendingCount() < p.maxConcurrency()
+}
+
+// hasConcurrencyHeadroomForModelCapResolvedLocked is hasConcurrencyHeadroomForModelCapLocked
+// with the provider's static single-stream decode rate resolved internally. Used
+// by the public capacity feeds (ModelCapacitySnapshot) so /v1/models[/capacity]
+// report the SAME headroom the routing path enforces — otherwise a capped box is
+// advertised as routable and upstream routers keep sending requests it 429s.
+// Caller holds r.mu and p.mu.
+func (r *Registry) hasConcurrencyHeadroomForModelCapResolvedLocked(p *Provider, model string) bool {
+	return r.hasConcurrencyHeadroomForModelCapLocked(p, model, resolvedDecodeTPS(p))
 }

--- a/coordinator/registry/concurrency_cap_test.go
+++ b/coordinator/registry/concurrency_cap_test.go
@@ -1,0 +1,191 @@
+package registry
+
+import (
+	"testing"
+	"time"
+)
+
+// budgetSlot turns a makeSchedulerProvider box into a token-budget provider (the
+// real Gemma/gpt-oss shape) so its legacy flat concurrency fallback is 24 — the
+// value the quality cap must tighten. Optionally injects a collapsed observed
+// decode EWMA to prove the cap reads the STATIC rate, not the observed one.
+func budgetSlot(p *Provider, observedDecodeTPS float64) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.BackendCapacity.Slots[0].ActiveTokenBudgetMax = 500_000
+	p.BackendCapacity.Slots[0].ObservedDecodeTPS = observedDecodeTPS
+}
+
+// effCap evaluates the registry's effective per-model concurrency cap for p
+// under the locks the routing path holds, using the provider's STATIC decode
+// rate (mirrors snapshotProviderLockedEx / quickCapacityCheck).
+func effCap(reg *Registry, p *Provider, model string) int {
+	reg.mu.RLock()
+	defer reg.mu.RUnlock()
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return reg.effectiveMaxConcurrencyForModelLocked(p, model, resolvedDecodeTPS(p))
+}
+
+// TestQualityCapUsesStaticNotObservedTPS is the regression that matters: a slow
+// model's box is capped from its STATIC single-stream rate (~23 tok/s → quality
+// batch 1 → cap 2 at overcommit 2), and the collapsed observed-under-load EWMA
+// (~2.6 tok/s, which would force a cap of 1) must NOT change the result —
+// otherwise the cap inherits the very feedback loop it exists to break.
+func TestQualityCapUsesStaticNotObservedTPS(t *testing.T) {
+	reg := New(testLogger())
+	reg.SetQualityConcurrencyCap(true, 2.0, 15, 4)
+	p := makeSchedulerProvider(t, reg, "gemma-box", gemmaBuild, 23) // static 23 tok/s
+	budgetSlot(p, 2.6)                                              // collapsed observed EWMA
+
+	if got := effCap(reg, p, gemmaBuild); got != 2 {
+		t.Fatalf("effective cap = %d, want 2 (quality batch 1 from STATIC 23 tok/s × overcommit 2, ignoring observed 2.6)", got)
+	}
+}
+
+// TestQualityCapScalesWithModelSpeed shows the cap is universal and self-tuning:
+// a fast model (57 tok/s → quality batch 10) keeps a high cap (20) that never
+// bites normal load, while a slow model (23 tok/s) is tightened to 2.
+func TestQualityCapScalesWithModelSpeed(t *testing.T) {
+	reg := New(testLogger())
+	reg.SetQualityConcurrencyCap(true, 2.0, 15, 4)
+
+	slow := makeSchedulerProvider(t, reg, "slow", gemmaBuild, 23)
+	budgetSlot(slow, 0)
+	fast := makeSchedulerProvider(t, reg, "fast", qwenBuild, 57)
+	budgetSlot(fast, 0)
+
+	if got := effCap(reg, slow, gemmaBuild); got != 2 {
+		t.Fatalf("slow cap = %d, want 2", got)
+	}
+	if got := effCap(reg, fast, qwenBuild); got != 20 {
+		t.Fatalf("fast cap = %d, want 20 (qc 10 × 2, ≤ flat 24) — far above normal load, no regression", got)
+	}
+}
+
+// TestQualityCapDisabledKeepsFlatCap: with the cap off, the legacy flat
+// token-budget fallback (24) applies unchanged.
+func TestQualityCapDisabledKeepsFlatCap(t *testing.T) {
+	reg := New(testLogger())
+	reg.SetQualityConcurrencyCap(false, 2.0, 15, 4)
+	p := makeSchedulerProvider(t, reg, "gemma-box", gemmaBuild, 23)
+	budgetSlot(p, 2.6)
+	if got := effCap(reg, p, gemmaBuild); got != 24 {
+		t.Fatalf("effective cap = %d, want 24 (cap disabled → flat fallback)", got)
+	}
+}
+
+// TestQualityCapTakesMinOfReportedAndQuality: the effective cap is the MINIMUM of
+// the provider-reported per-slot cap and the quality cap. A provider that reports
+// a LOOSE cap (8) for a slow model is still held to the quality bar (2); a
+// provider that reports a TIGHTER cap (1) than quality binds at 1. Neither path
+// over-admits.
+func TestQualityCapTakesMinOfReportedAndQuality(t *testing.T) {
+	reg := New(testLogger())
+	reg.SetQualityConcurrencyCap(true, 2.0, 15, 4)
+
+	// Slow model, provider reports 8 (above its quality batch) -> quality binds at 2.
+	loose := makeSchedulerProvider(t, reg, "loose", gemmaBuild, 23)
+	loose.mu.Lock()
+	loose.BackendCapacity.Slots[0].ActiveTokenBudgetMax = 500_000
+	loose.BackendCapacity.Slots[0].MaxConcurrency = 8
+	loose.mu.Unlock()
+	if got := effCap(reg, loose, gemmaBuild); got != 2 {
+		t.Fatalf("effective cap = %d, want 2 (provider-reported 8 is looser than quality 2 → quality binds)", got)
+	}
+
+	// Fast model, provider reports 1 (tighter than its high quality batch) -> 1 binds.
+	tight := makeSchedulerProvider(t, reg, "tight", qwenBuild, 57)
+	tight.mu.Lock()
+	tight.BackendCapacity.Slots[0].ActiveTokenBudgetMax = 500_000
+	tight.BackendCapacity.Slots[0].MaxConcurrency = 1
+	tight.mu.Unlock()
+	if got := effCap(reg, tight, qwenBuild); got != 1 {
+		t.Fatalf("effective cap = %d, want 1 (provider-reported 1 is tighter than quality → provider binds)", got)
+	}
+}
+
+// TestQualityCapSpreadsAndSheds drives the real routing path: with two dedicated
+// Gemma boxes capped at 2, filling box A to its cap forces the next request onto
+// idle box B; with only a capped box available, the request is rejected for
+// capacity (→ the dedicated fast-429 shed upstream) instead of over-admitting.
+func TestQualityCapSpreadsAndSheds(t *testing.T) {
+	reg := New(testLogger())
+	reg.SetDedicatedModels([]string{"gemma-4"})
+	reg.SetQualityConcurrencyCap(true, 2.0, 15, 4)
+
+	a := makeSchedulerProvider(t, reg, "gemma-a", gemmaBuild, 23)
+	budgetSlot(a, 2.6)
+
+	// Fill box A to its cap (2) with coordinator-tracked pending requests.
+	a.AddPending(&PendingRequest{RequestID: "fill-a", Model: gemmaBuild})
+	a.AddPending(&PendingRequest{RequestID: "fill-b", Model: gemmaBuild})
+
+	// Only the saturated box exists → no candidate (capacity-rejected, not over-admitted).
+	if got := reg.ReserveProvider(gemmaBuild, &PendingRequest{RequestID: "req-shed", Model: gemmaBuild, RequestedMaxTokens: 128}); got != nil {
+		t.Fatalf("reserved %q for a Gemma request when the only box was at its cap; want nil (shed)", got.ID)
+	}
+
+	// Add an idle box B → the request must land there, not pile onto A.
+	b := makeSchedulerProvider(t, reg, "gemma-b", gemmaBuild, 23)
+	budgetSlot(b, 2.6)
+	got := reg.ReserveProvider(gemmaBuild, &PendingRequest{RequestID: "req-spread", Model: gemmaBuild, RequestedMaxTokens: 128})
+	if got == nil {
+		t.Fatal("ReserveProvider returned nil with an idle box available")
+	}
+	if got.ID != b.ID {
+		t.Fatalf("selected %q, want idle box %q (load must spread, not concentrate on the capped box)", got.ID, b.ID)
+	}
+}
+
+// TestWarmTargetDedicatedWholePool: for a dedicated model the warm-pool target is
+// the entire eligible pool (warm + eligibleCold) regardless of demand pressure,
+// so idle dedicated boxes get warmed; a non-dedicated model with no pressure is
+// left at its current warm count.
+func TestWarmTargetDedicatedWholePool(t *testing.T) {
+	reg := New(testLogger())
+	reg.SetDedicatedModels([]string{"gemma-4"})
+	c := newWarmPoolController(reg, WarmPoolConfig{
+		DecodeFloorTPS:             15,
+		FallbackQualityConcurrency: 4,
+		BurstBuffer:                1,
+		AssumedPromptTokens:        512,
+		AssumedCompletionTokens:    256,
+		// Realistic pressure thresholds (≥1) so a zero-pressure snapshot registers NO
+		// demand pressure — otherwise the 0>=0 default makes every model look pressured.
+		CapacityRejectThreshold:   1,
+		TTFTMissThreshold:         1,
+		ColdDispatchThreshold:     1,
+		SpeculativeStartThreshold: 1,
+		SpeculativeWinThreshold:   1,
+		WarmSaturationThreshold:   0.8,
+	})
+	params := c.targetParams()
+	now := time.Now()
+
+	dedicated := warmPoolModelSnapshot{
+		model:         gemmaBuild,
+		warm:          2,
+		soloDecodeTPS: 23,
+		prefillTPS:    276,
+		eligibleCold: []warmPoolCandidate{
+			{providerID: "c1"}, {providerID: "c2"}, {providerID: "c3"},
+		},
+	}
+	svc := estimateServiceTime(dedicated.prefillTPS, dedicated.soloDecodeTPS, params)
+	if got := c.targetWarm(dedicated, warmPoolPressureBucket{}, warmPoolQueuePressure{}, params, svc, now); got != 5 {
+		t.Fatalf("dedicated warm target = %d, want 5 (warm 2 + eligibleCold 3 = whole pool)", got)
+	}
+
+	nonDedicated := warmPoolModelSnapshot{
+		model:         qwenBuild,
+		warm:          2,
+		soloDecodeTPS: 57,
+		prefillTPS:    684,
+		eligibleCold:  []warmPoolCandidate{{providerID: "c1"}, {providerID: "c2"}, {providerID: "c3"}},
+	}
+	svc2 := estimateServiceTime(nonDedicated.prefillTPS, nonDedicated.soloDecodeTPS, params)
+	if got := c.targetWarm(nonDedicated, warmPoolPressureBucket{}, warmPoolQueuePressure{}, params, svc2, now); got != 2 {
+		t.Fatalf("non-dedicated warm target = %d, want 2 (no demand pressure → left as-is)", got)
+	}
+}

--- a/coordinator/registry/concurrency_cap_test.go
+++ b/coordinator/registry/concurrency_cap_test.go
@@ -173,6 +173,37 @@ func TestQualityCapSpreadsAndSheds(t *testing.T) {
 	}
 }
 
+// TestQualityCapAppliedAtAdmitRecheck: the FINAL admit re-check (providerCanAdmitLockedEx,
+// used by ReserveProviderEx after selection) must apply the quality cap too — otherwise
+// a heartbeat that bumps load between snapshot and reservation lets a box past its
+// quality cap be over-admitted via the legacy flat-cap re-check (TOCTOU).
+func TestQualityCapAppliedAtAdmitRecheck(t *testing.T) {
+	reg := New(testLogger())
+	reg.SetDedicatedModels([]string{"gemma-4"})
+	reg.SetQualityConcurrencyCap(true, 2.0, 15, 4)
+	p := makeSchedulerProvider(t, reg, "gemma", gemmaBuild, 23)
+	budgetSlot(p, 2.6)
+
+	admit := func() bool {
+		reg.mu.RLock()
+		defer reg.mu.RUnlock()
+		p.mu.Lock()
+		defer p.mu.Unlock()
+		return reg.providerCanAdmitLockedEx(p, gemmaBuild, RequestTraits{}, false, false)
+	}
+
+	// Under the cap (1 in flight, cap 2) → admit re-check passes.
+	p.AddPending(&PendingRequest{RequestID: "a", Model: gemmaBuild})
+	if !admit() {
+		t.Fatal("admit re-check rejected a box below its quality cap (1 < 2)")
+	}
+	// At the cap (2 in flight) → admit re-check must reject (not the flat 24).
+	p.AddPending(&PendingRequest{RequestID: "b", Model: gemmaBuild})
+	if admit() {
+		t.Fatal("admit re-check admitted a box already at its quality cap (2); final re-check must apply the cap")
+	}
+}
+
 // TestWarmTargetDedicatedWholePool: for a dedicated model UNDER DEMAND the
 // warm-pool target is the entire eligible pool (warm + eligibleCold), so idle
 // dedicated boxes get warmed. With NO demand for that build it is left at the

--- a/coordinator/registry/concurrency_cap_test.go
+++ b/coordinator/registry/concurrency_cap_test.go
@@ -63,6 +63,41 @@ func TestQualityCapScalesWithModelSpeed(t *testing.T) {
 	}
 }
 
+// TestQualityCapFallbackRateOnlyCapsDedicated guards the P1 regression: when a
+// provider has NOT reported a real decode benchmark (DecodeTPS==0), resolvedDecodeTPS
+// falls back to sqrt(memory_bandwidth) — a model-agnostic hardware proxy that
+// under-estimates fast models. The cap must therefore bite only DEDICATED models
+// from that fallback; a non-dedicated model keeps the flat cap (so healthy
+// fast-model traffic isn't shed on a bad rate estimate).
+func TestQualityCapFallbackRateOnlyCapsDedicated(t *testing.T) {
+	reg := New(testLogger())
+	reg.SetDedicatedModels([]string{"gemma-4"})
+	reg.SetQualityConcurrencyCap(true, 2.0, 15, 4)
+
+	// No DecodeTPS benchmark; rate comes from sqrt(bandwidth)=sqrt(800)≈28.
+	mkFallback := func(id, model string) *Provider {
+		p := makeSchedulerProvider(t, reg, id, model, 0) // DecodeTPS unset
+		p.mu.Lock()
+		p.Hardware.MemoryBandwidthGBs = 800
+		p.BackendCapacity.Slots[0].ActiveTokenBudgetMax = 500_000
+		p.mu.Unlock()
+		return p
+	}
+
+	// Non-dedicated on the fallback rate → NOT capped (flat 24): don't shed a fast
+	// model on a hardware proxy that can't see its true ~57 tok/s rate.
+	nonDed := mkFallback("qwen-box", qwenBuild)
+	if got := effCap(reg, nonDed, qwenBuild); got != 24 {
+		t.Fatalf("non-dedicated fallback-rate cap = %d, want 24 (no benchmark → not capped from sqrt(bw))", got)
+	}
+
+	// Dedicated on the same fallback rate → capped (best-effort): qc from ~28 tok/s.
+	ded := mkFallback("gemma-box", gemmaBuild)
+	if got := effCap(reg, ded, gemmaBuild); got >= 24 || got < 1 {
+		t.Fatalf("dedicated fallback-rate cap = %d, want a tightened value < 24 (dedicated capped even without a benchmark)", got)
+	}
+}
+
 // TestQualityCapDisabledKeepsFlatCap: with the cap off, the legacy flat
 // token-budget fallback (24) applies unchanged.
 func TestQualityCapDisabledKeepsFlatCap(t *testing.T) {
@@ -138,10 +173,12 @@ func TestQualityCapSpreadsAndSheds(t *testing.T) {
 	}
 }
 
-// TestWarmTargetDedicatedWholePool: for a dedicated model the warm-pool target is
-// the entire eligible pool (warm + eligibleCold) regardless of demand pressure,
-// so idle dedicated boxes get warmed; a non-dedicated model with no pressure is
-// left at its current warm count.
+// TestWarmTargetDedicatedWholePool: for a dedicated model UNDER DEMAND the
+// warm-pool target is the entire eligible pool (warm + eligibleCold), so idle
+// dedicated boxes get warmed. With NO demand for that build it is left at the
+// demand-derived count (so an idle/stale build — e.g. the previous build during
+// an alias migration — is not force-warmed across the whole pool). A
+// non-dedicated model with no pressure is left at its current warm count.
 func TestWarmTargetDedicatedWholePool(t *testing.T) {
 	reg := New(testLogger())
 	reg.SetDedicatedModels([]string{"gemma-4"})
@@ -173,8 +210,14 @@ func TestWarmTargetDedicatedWholePool(t *testing.T) {
 		},
 	}
 	svc := estimateServiceTime(dedicated.prefillTPS, dedicated.soloDecodeTPS, params)
-	if got := c.targetWarm(dedicated, warmPoolPressureBucket{}, warmPoolQueuePressure{}, params, svc, now); got != 5 {
-		t.Fatalf("dedicated warm target = %d, want 5 (warm 2 + eligibleCold 3 = whole pool)", got)
+	// Under demand (a capacity reject) → warm the whole eligible pool (2 + 3 = 5).
+	underDemand := warmPoolPressureBucket{capacityRejects: 1}
+	if got := c.targetWarm(dedicated, underDemand, warmPoolQueuePressure{}, params, svc, now); got != 5 {
+		t.Fatalf("dedicated (under demand) warm target = %d, want 5 (warm 2 + eligibleCold 3 = whole pool)", got)
+	}
+	// No demand for this build → NOT force-warmed across the pool (left demand-derived).
+	if got := c.targetWarm(dedicated, warmPoolPressureBucket{}, warmPoolQueuePressure{}, params, svc, now); got == 5 {
+		t.Fatalf("dedicated (no demand) warm target = %d, want < 5 (idle/stale build must not force-warm the whole pool)", got)
 	}
 
 	nonDedicated := warmPoolModelSnapshot{

--- a/coordinator/registry/config.go
+++ b/coordinator/registry/config.go
@@ -15,11 +15,29 @@ type Config struct {
 	MinTrustLevel string
 	WarmPool      WarmPoolConfig
 	CacheAffinity CacheAffinityConfig
+	QualityCap    QualityCapConfig
 }
 
 type CacheAffinityConfig struct {
 	TTL     time.Duration
 	BonusMs float64
+}
+
+// QualityCapConfig governs the per-provider admission concurrency cap derived
+// from each model's quality_concurrency (the largest batch that keeps every
+// request at/above the decode floor), replacing the flat-24 fallback. Universal:
+// it caps slow/saturated models tightly while leaving fast, over-provisioned
+// models effectively unchanged. See concurrency_cap.go.
+type QualityCapConfig struct {
+	// Enabled turns the cap on. When false the legacy flat per-provider cap
+	// (maxConcurrencyForModelLocked) applies unchanged.
+	Enabled bool
+	// Overcommit multiplies the strict quality batch. 1.0 = the exact
+	// decode-floor-preserving batch; 2.0 (default) allows double that, trading a
+	// little per-request TPS for ~double pool capacity. The decode floor + load
+	// factor are shared with the warm-pool target math (WarmPool.DecodeFloorTPS,
+	// effectiveTPSLoadFactor) so admission and planning cannot drift.
+	Overcommit float64
 }
 
 type WarmPoolConfig struct {
@@ -115,6 +133,10 @@ func ReadConfig() Config {
 			TTL:     envDuration(env.EnvPrefix+"_CACHE_AFFINITY_TTL", cacheAffinityTTL),
 			BonusMs: env.EnvFloat(env.EnvPrefix+"_CACHE_AFFINITY_BONUS_MS", defaultCacheAffinityBonusMs),
 		},
+		QualityCap: QualityCapConfig{
+			Enabled:    env.EnvBool(env.EnvPrefix+"_QUALITY_CONCURRENCY_CAP", true),
+			Overcommit: env.EnvFloat(env.EnvPrefix+"_QUALITY_CONCURRENCY_OVERCOMMIT", 2.0),
+		},
 	}
 }
 
@@ -130,21 +152,20 @@ func envDuration(key string, fallback time.Duration) time.Duration {
 // Check validates the configuration.
 // An empty MinTrustLevel is valid and means "use the default".
 func (c Config) Check() error {
-	if c.MinTrustLevel == "" {
-		if err := c.WarmPool.Check(); err != nil {
-			return err
-		}
-		return c.CacheAffinity.Check()
-	}
-	// trustRank returns -1 for unrecognized trust levels.
-	if trustRank(TrustLevel(c.MinTrustLevel)) < 0 {
+	// An empty MinTrustLevel is valid ("use the default"); a non-empty one must be
+	// a recognized level (trustRank returns -1 otherwise). Either way, all
+	// sub-configs are validated on every path.
+	if c.MinTrustLevel != "" && trustRank(TrustLevel(c.MinTrustLevel)) < 0 {
 		return fmt.Errorf("registry: invalid MinTrustLevel %q (valid: %q, %q, %q)",
 			c.MinTrustLevel, TrustNone, TrustSelfSigned, TrustHardware)
 	}
 	if err := c.WarmPool.Check(); err != nil {
 		return err
 	}
-	return c.CacheAffinity.Check()
+	if err := c.CacheAffinity.Check(); err != nil {
+		return err
+	}
+	return c.QualityCap.Check()
 }
 
 func (c CacheAffinityConfig) Check() error {
@@ -156,6 +177,13 @@ func (c CacheAffinityConfig) Check() error {
 	}
 	if c.BonusMs > 10_000 {
 		return fmt.Errorf("registry: cache affinity bonus must be <= 10000ms")
+	}
+	return nil
+}
+
+func (c QualityCapConfig) Check() error {
+	if c.Overcommit < 0 {
+		return fmt.Errorf("registry: quality concurrency overcommit must be >= 0")
 	}
 	return nil
 }

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -1009,6 +1009,19 @@ type Registry struct {
 	// SetDedicatedModels and dedicated_models.go. Guarded by r.mu.
 	dedicatedModels []string
 
+	// Quality-concurrency admission cap (see concurrency_cap.go). When enabled,
+	// the per-provider concurrency cap for a model is tightened from the flat
+	// fallback to quality_concurrency × overcommit, computed from the provider's
+	// STATIC single-stream decode rate so slow/saturated models stop
+	// over-admitting. Set once at startup via SetQualityConcurrencyCap; read on the
+	// routing/preflight paths (which hold r.mu). qualityCapFloorTPS / qualityCapFallback
+	// mirror the warm-pool DecodeFloorTPS / FallbackQualityConcurrency so admission
+	// and warm-pool planning share the same quality math.
+	qualityCapEnabled    bool
+	qualityCapOvercommit float64
+	qualityCapFloorTPS   float64
+	qualityCapFallback   int
+
 	// APNs code-identity rollout policy (v0.6.0), guarded by r.mu and evaluated
 	// LIVE at every routing decision so a deadline can flip enforcement on/off
 	// without forcing providers to reconnect.

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -4625,7 +4625,11 @@ func (r *Registry) ModelCapacitySnapshot() []ModelCapacity {
 			if !r.modelAllowedByCatalogLocked(m) {
 				continue
 			}
-			hasHeadroom := p.hasConcurrencyHeadroomForModelLocked(m.ID)
+			// Use the SAME quality-concurrency-capped headroom the routing/preflight
+			// path enforces, so the public capacity feed doesn't advertise a capped
+			// box (e.g. Gemma at 2) as routable up to the flat fallback (24) and lure
+			// upstream routers into sending requests this coordinator immediately 429s.
+			hasHeadroom := r.hasConcurrencyHeadroomForModelCapResolvedLocked(p, m.ID)
 			// Count only pending requests for this specific model, not the
 			// total across all models. Using the total inflates
 			// activeRequests for multi-model providers.

--- a/coordinator/registry/scheduler.go
+++ b/coordinator/registry/scheduler.go
@@ -1530,7 +1530,11 @@ func (r *Registry) providerCanAdmitLockedEx(p *Provider, model string, traits Re
 	if !r.providerPassesRoutingGatesLockedEx(p, model, traits, selfRouteOwner, now, ignoreProviderBreaker) {
 		return false
 	}
-	if !p.hasConcurrencyHeadroomForModelLocked(model) {
+	// Apply the SAME quality-concurrency cap as the selection snapshot and the
+	// preflight. This is the final admit re-check in ReserveProviderEx; if a
+	// heartbeat bumped NumRunning after the snapshot was built, the legacy flat-cap
+	// check here would let a box that just reached its quality cap be over-admitted.
+	if !r.hasConcurrencyHeadroomForModelCapResolvedLocked(p, model) {
 		return false
 	}
 	if p.BackendCapacity != nil {

--- a/coordinator/registry/scheduler.go
+++ b/coordinator/registry/scheduler.go
@@ -424,7 +424,15 @@ func (r *Registry) selectBestCandidateScanLocked(model string, pr *PendingReques
 	affinityProviderID := ""
 	affinityLookup := pr.CacheAffinityKey != "" && pr.ConsumerKey != ""
 	if affinityLookup && r.cacheAffinityBonusMs > 0 {
-		affinityProviderID = r.cacheAffinity.lookup(pr.ConsumerKey, model, pr.CacheAffinityKey, now)
+		// Cache affinity is disabled for dedicated-pool models (e.g. Gemma): pinning
+		// a consumer's repeat traffic to one box (via the bonus AND the hard
+		// near-tie override below) reintroduces exactly the concentration the
+		// per-box quality cap + cost-based spreading exist to prevent. The dedicated
+		// pool is concurrency-bound, not prompt-cache-bound, so the pin is not worth
+		// it. Leaving affinityProviderID empty skips both the bonus and the override.
+		if _, dedicated := r.dedicatedPatternForLocked(model); !dedicated {
+			affinityProviderID = r.cacheAffinity.lookup(pr.ConsumerKey, model, pr.CacheAffinityKey, now)
+		}
 	}
 	for _, p := range r.providers {
 		owned := providerOwnedBy(p, pr.OwnerAccountID)
@@ -897,7 +905,13 @@ func (r *Registry) snapshotProviderLockedEx(p *Provider, model string, traits Re
 		snap.pendingForModel++
 		snap.pendingMaxTokens += pendingTokenBudget(pr)
 	}
-	snap.hasHeadroom = p.hasConcurrencyHeadroomForModelLocked(model)
+	// Concurrency headroom with the quality-concurrency cap: a slow model whose
+	// quality batch is below the flat fallback (e.g. Gemma at ~23 tok/s solo →
+	// batch 1-2) stops being admittable once it is at its quality cap, so load
+	// spreads across boxes instead of collapsing a few. Uses the static
+	// single-stream decode rate (snap.decodeTPS = resolvedDecodeTPS), not the
+	// observed-under-load value. No-op (legacy flat cap) when the cap is disabled.
+	snap.hasHeadroom = r.hasConcurrencyHeadroomForModelCapLocked(p, model, snap.decodeTPS)
 	snap.hasBackendCapacity = p.BackendCapacity != nil
 
 	if p.BackendCapacity != nil {
@@ -1638,8 +1652,11 @@ func (r *Registry) quickCapacityCheck(model string, estimatedPromptTokens, reque
 			continue
 		}
 
-		// Concurrency gate.
-		if !p.hasConcurrencyHeadroomForModelLocked(model) {
+		// Concurrency gate (with the quality-concurrency cap, same as the dispatch
+		// snapshot — uses the static single-stream decode rate so routing and the
+		// shed preflight stay consistent and a slow model's quality cap counts a
+		// saturated box as a capacity rejection here too).
+		if !r.hasConcurrencyHeadroomForModelCapLocked(p, model, resolvedDecodeTPS(p)) {
 			p.mu.Unlock()
 			capacityRejections++
 			continue

--- a/coordinator/registry/warm_pool_controller.go
+++ b/coordinator/registry/warm_pool_controller.go
@@ -69,6 +69,14 @@ type WarmPoolSnapshot struct {
 	ServiceTime        time.Duration
 	QualityConcurrency int
 	DemandConcurrency  float64
+
+	// ColdIneligible is the count of cold (on-disk, not-warm) providers advertising
+	// the model that failed the warm-pool candidate gate this tick, with
+	// ColdDisqualifiers breaking it down by reason (warmColdReason). Diagnoses why
+	// the eligible-cold set (and thus the warmable target) is smaller than the raw
+	// cold-provider count — counts only, no provider identities.
+	ColdIneligible    int
+	ColdDisqualifiers map[string]int
 }
 
 type warmPoolModelSnapshot struct {
@@ -86,6 +94,11 @@ type warmPoolModelSnapshot struct {
 	prefillTPS      float64
 	maxProviderConc int
 	eligibleCold    []warmPoolCandidate
+	// coldIneligible / coldDisq tally cold (on-disk, not-warm) providers that
+	// FAILED the warm-pool candidate gate, by reason — diagnostics for why
+	// eligibleCold is smaller than the raw cold count.
+	coldIneligible int
+	coldDisq       map[warmColdReason]int
 }
 
 type warmPoolCandidate struct {
@@ -343,11 +356,24 @@ func (c *warmPoolController) planObserveOnly(now time.Time, reserve func([]model
 		}
 		loadsRemaining -= len(actions)
 		c.state.rememberTarget(model, target, now)
+		// Surface why cold boxes aren't warmable (counts only). For a dedicated pool
+		// this explains a gap between the raw cold count and what we can actually warm.
+		if f.coldIneligible > 0 && c.registry != nil && c.registry.logger != nil && c.registry.IsDedicatedModel(model) {
+			c.registry.logger.Info("warm-pool cold-ineligible (dedicated)",
+				"model", model,
+				"warm", f.warm,
+				"eligible_cold", len(f.eligibleCold),
+				"cold_ineligible", f.coldIneligible,
+				"reasons", warmColdReasonStrings(f.coldDisq),
+			)
+		}
 		out = append(out, WarmPoolSnapshot{
 			Model:              model,
 			TargetWarm:         target,
 			WarmProviders:      f.warm,
 			EligibleCold:       len(f.eligibleCold),
+			ColdIneligible:     f.coldIneligible,
+			ColdDisqualifiers:  warmColdReasonStrings(f.coldDisq),
 			QueueDepth:         q.Depth,
 			OldestQueueAge:     q.OldestAge,
 			CapacityRejects:    p.capacityRejects,
@@ -447,6 +473,17 @@ func (c *warmPoolController) targetWarm(fleet warmPoolModelSnapshot, pressure wa
 			target = maxReachable
 		}
 	}
+	// Dedicated pools (e.g. Gemma) exist solely to serve one model family, so keep
+	// the ENTIRE eligible pool warm rather than demand-tracking it: this lifts idle
+	// dedicated boxes into service and removes cold-start lag on demand spikes
+	// (a cold box's ~30s load makes it un-routable on the request hot path, so the
+	// only way it ever serves is proactive warming). Bounded by warm+eligibleCold
+	// (all we can warm); the per-tick ramp still throttles how fast loads issue.
+	if c.registry != nil && c.registry.IsDedicatedModel(fleet.model) {
+		if whole := fleet.warm + len(fleet.eligibleCold); whole > target {
+			target = whole
+		}
+	}
 	return target
 }
 
@@ -513,15 +550,23 @@ func (r *Registry) warmPoolFleetSnapshot(now time.Time) map[string]warmPoolModel
 				concSamples[model] = append(concSamples[model], float64(p.maxConcurrencyForModelLocked(model)))
 				continue
 			}
-			if candidate, ok := r.warmPoolCandidateLocked(p, model, now); ok {
-				s := out[model]
-				s.model = model
+			candidate, reason := r.warmPoolCandidateReasonLocked(p, model, now)
+			s := out[model]
+			s.model = model
+			if reason == warmColdEligible {
 				s.eligibleCold = append(s.eligibleCold, candidate)
 				out[model] = s
 				decodeTPS, prefillTPS := resolvedModelTPSLocked(p, model)
 				decodeSamples[model] = append(decodeSamples[model], decodeTPS)
 				prefillSamples[model] = append(prefillSamples[model], prefillTPS)
 				concSamples[model] = append(concSamples[model], float64(p.maxConcurrencyForModelLocked(model)))
+			} else {
+				if s.coldDisq == nil {
+					s.coldDisq = make(map[warmColdReason]int)
+				}
+				s.coldDisq[reason]++
+				s.coldIneligible++
+				out[model] = s
 			}
 		}
 		p.mu.Unlock()
@@ -551,34 +596,75 @@ func warmPoolModelLoadLocked(p *Provider, model string) (running, waiting int) {
 	return 0, 0
 }
 
+// warmColdReason labels why a cold (on-disk, not-warm) provider is or isn't an
+// eligible warm-pool target. Empty ("") means eligible. Used to instrument why
+// the eligible-cold set is smaller than the raw cold-provider count (e.g. a
+// dedicated pool reporting many cold boxes but warming few) — counts only, no
+// provider identities, so it is privacy-safe to log/expose.
+type warmColdReason string
+
+const (
+	warmColdEligible       warmColdReason = ""
+	warmColdOfflineUntrust warmColdReason = "offline_untrusted_private"
+	warmColdPendingLoad    warmColdReason = "pending_load_or_cooldown"
+	warmColdNotIdle        warmColdReason = "not_idle"
+	warmColdThermal        warmColdReason = "thermal_critical"
+	warmColdTrust          warmColdReason = "trust_or_runtime"
+	warmColdStaleChallenge warmColdReason = "stale_challenge"
+	warmColdNotServing     warmColdReason = "not_serving_catalog"
+	warmColdDedicated      warmColdReason = "dedicated_excluded"
+	warmColdTooLarge       warmColdReason = "model_too_large"
+	warmColdNoFreeForLoad  warmColdReason = "no_free_for_load"
+)
+
+// warmColdReasonStrings converts a reason tally to a string-keyed map for
+// logging / the snapshot. Returns nil for an empty tally.
+func warmColdReasonStrings(in map[warmColdReason]int) map[string]int {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]int, len(in))
+	for reason, n := range in {
+		out[string(reason)] = n
+	}
+	return out
+}
+
 func (r *Registry) warmPoolCandidateLocked(p *Provider, model string, now time.Time) (warmPoolCandidate, bool) {
+	c, reason := r.warmPoolCandidateReasonLocked(p, model, now)
+	return c, reason == warmColdEligible
+}
+
+// warmPoolCandidateReasonLocked is warmPoolCandidateLocked with the
+// disqualification reason exposed for instrumentation. Caller holds r.mu + p.mu.
+func (r *Registry) warmPoolCandidateReasonLocked(p *Provider, model string, now time.Time) (warmPoolCandidate, warmColdReason) {
 	if p.Status == StatusOffline || p.Status == StatusUntrusted || p.PrivateOnly {
-		return warmPoolCandidate{}, false
+		return warmPoolCandidate{}, warmColdOfflineUntrust
 	}
 	if r.providerHasPendingLoad(p.ID) || r.dispatchLoadCooldownActiveLocked(p.ID, model, now) {
-		return warmPoolCandidate{}, false
+		return warmPoolCandidate{}, warmColdPendingLoad
 	}
 	if p.pendingCount() != 0 || warmPoolBackendSlotBusyLocked(p) {
-		return warmPoolCandidate{}, false
+		return warmPoolCandidate{}, warmColdNotIdle
 	}
 	if p.SystemMetrics.ThermalState == "critical" {
-		return warmPoolCandidate{}, false
+		return warmPoolCandidate{}, warmColdThermal
 	}
 	if trustRank(p.TrustLevel) < trustRank(r.MinTrustLevel) || !p.RuntimeVerified || !r.providerSupportsPrivateTextLocked(p) {
-		return warmPoolCandidate{}, false
+		return warmPoolCandidate{}, warmColdTrust
 	}
 	if p.LastChallengeVerified.IsZero() || now.Sub(p.LastChallengeVerified) > challengeFreshnessMaxAge {
-		return warmPoolCandidate{}, false
+		return warmPoolCandidate{}, warmColdStaleChallenge
 	}
 	if !r.providerServesCatalogModelLocked(p, model) {
-		return warmPoolCandidate{}, false
+		return warmPoolCandidate{}, warmColdNotServing
 	}
 	// Don't pre-warm a dedicated-family model (e.g. Gemma 4) onto a non-dedicated
 	// (mixed-catalog) box: routing will never send the model there, so the warm
 	// would be wasted GPU memory and would mislead the demand calc into thinking
 	// the model is already covered. Mirrors the routing/preflight gate.
 	if r.providerExcludedByDedicatedRuleLocked(p, model) {
-		return warmPoolCandidate{}, false
+		return warmPoolCandidate{}, warmColdDedicated
 	}
 	totalMemoryGB := float64(p.Hardware.MemoryGB)
 	gpuActiveGB := 0.0
@@ -589,14 +675,14 @@ func (r *Registry) warmPoolCandidateLocked(p *Provider, model string, now time.T
 		gpuActiveGB = p.BackendCapacity.GPUMemoryActiveGB
 	}
 	if !modelFitsHardware(r.catalogMinRAMGbLocked(model), r.catalogSizeGBLocked(model), totalMemoryGB) {
-		return warmPoolCandidate{}, false
+		return warmPoolCandidate{}, warmColdTooLarge
 	}
 	// Live free-capacity gate (shared helper with the direct/planner paths): don't
 	// pick a warm-pool target the provider already reports it cannot fit, or the
 	// warm pool issues a load_model the provider rejects (failed warm + pending-load
 	// cooldown) instead of choosing a truly loadable node (#390).
 	if admit, reported := reportedFreeForLoadAdmits(r.catalogSizeGBLocked(model), backendFreeForLoadGB(p.BackendCapacity)); reported && !admit {
-		return warmPoolCandidate{}, false
+		return warmPoolCandidate{}, warmColdNoFreeForLoad
 	}
 	freeGB := totalMemoryGB - gpuActiveGB
 	if freeGB < 0 {
@@ -610,7 +696,7 @@ func (r *Registry) warmPoolCandidateLocked(p *Provider, model string, now time.T
 		thermalPenalty = 250
 	}
 	score := freeGB*100 + resolvedDecodeTPS(p)*10 - p.SystemMetrics.MemoryPressure*500 - p.SystemMetrics.CPUUsage*100 - thermalPenalty
-	return warmPoolCandidate{providerID: p.ID, score: score}, true
+	return warmPoolCandidate{providerID: p.ID, score: score}, warmColdEligible
 }
 
 func warmPoolBackendSlotBusyLocked(p *Provider) bool {

--- a/coordinator/registry/warm_pool_controller.go
+++ b/coordinator/registry/warm_pool_controller.go
@@ -473,13 +473,17 @@ func (c *warmPoolController) targetWarm(fleet warmPoolModelSnapshot, pressure wa
 			target = maxReachable
 		}
 	}
-	// Dedicated pools (e.g. Gemma) exist solely to serve one model family, so keep
-	// the ENTIRE eligible pool warm rather than demand-tracking it: this lifts idle
-	// dedicated boxes into service and removes cold-start lag on demand spikes
-	// (a cold box's ~30s load makes it un-routable on the request hot path, so the
-	// only way it ever serves is proactive warming). Bounded by warm+eligibleCold
-	// (all we can warm); the per-tick ramp still throttles how fast loads issue.
-	if c.registry != nil && c.registry.IsDedicatedModel(fleet.model) {
+	// Dedicated pools (e.g. Gemma): when a dedicated build is under demand, warm the
+	// ENTIRE eligible pool rather than demand-tracking it — this lifts idle dedicated
+	// boxes into service and removes cold-start lag (a cold box's ~30s load makes it
+	// un-routable on the request hot path, so proactive warming is the only way it
+	// ever serves). Gated on demand for THIS build so we don't force-warm every
+	// build a box advertises matching the family pattern — e.g. during an alias
+	// migration where desired+previous Gemma builds are both catalog-allowed, only
+	// the build actually receiving traffic gets the whole pool, not the stale one
+	// (which would otherwise burn model slots/memory and evict the live build).
+	// Bounded by warm+eligibleCold; the per-tick ramp still throttles the load rate.
+	if c.registry != nil && c.registry.IsDedicatedModel(fleet.model) && c.hasDemandPressure(fleet, pressure, queue) {
 		if whole := fleet.warm + len(fleet.eligibleCold); whole > target {
 			target = whole
 		}


### PR DESCRIPTION
## Problem

The Gemma dedicated pool (PR #434 isolated Gemma-4 onto dedicated boxes — isolation works) is **collapsing under load**. Live routing telemetry (`/v1/admin/routes`, 4,923 Gemma reqs / 30 min):

- **~80% of requests fail**: 53% cancelled, 27% error, ~15% success.
- Success rate vs the box's in-flight load at dispatch:

  | box load when dispatched | requests | success |
  |---|---|---|
  | 0 (idle) | 968 | **47%** |
  | 10–19 | 2,046 | **4%** |
  | 20+ | 1,222 | **3%** |

- **66% of traffic lands on boxes already running ≥10 concurrent**; median served decode **5 tok/s**. Meanwhile ~48 cold dedicated boxes sit idle.

## Root cause (universal latent flaw)

The per-provider concurrency cap is a **flat 24** (`maxConcurrencyForModelLocked` fallback for token-budget providers). It's a hard-coded guess at "how many concurrent decodes before per-request TPS collapses" — but a 26B model at ~23 tok/s solo only sustains ~2 concurrent at the 15 tok/s quality floor. `quality_concurrency` IS computed (warm-pool planning) but **never enforced at admission**. The 15 tok/s guard that should stop this is non-binding: the decode-floor preference is *soft* ("never fails closed"), and `TTFT_HARD_REJECT` gates first-token latency, not sustained decode.

- **gpt-oss doesn't trigger it**: fast (~57 tok/s → real qc 7, far below 24) AND 4% utilized. The bug is universal; Gemma just exposes it.
- Cold dedicated boxes are **unreachable on demand**: a cold box's ~30s model-load TTFT exceeds the ~5s ceiling, so it's always TTFT-rejected — and nothing was warming the pool.
- The "~2.6 tok/s solo" the warm-pool used is the **degraded under-load rate** (a feedback loop: overload → observed EWMA collapses → qc computed as 1 → pool looks 350% over capacity). True single-stream is **~23 tok/s** (registration benchmark; 16–28 range).

## Before → After

```mermaid
flowchart TD
  subgraph Before
    A1[Gemma request] --> A2{box has headroom?<br/>cap = flat 24}
    A2 -->|yes, always<br/>token budget 0.4%| A3[pile onto warm box<br/>→ 10-23 concurrent]
    A3 --> A4[decode collapses ~5 tok/s<br/>→ cancel / error]
    A5[48 cold boxes] -.30s TTFT > 5s ceiling.-> A6[never selected,<br/>never warmed → idle]
  end
```
```mermaid
flowchart TD
  subgraph After
    B1[Gemma request] --> B2{box at quality cap?<br/>cap = quality_concurrency x overcommit<br/>from STATIC tps → Gemma 2}
    B2 -->|under cap| B3[admit → spread across boxes]
    B2 -->|all warm boxes at cap| B4[fast-429 to OpenRouter]
    B5[warm-pool: keep WHOLE dedicated<br/>pool warm] --> B6[48 idle boxes enter service]
  end
```

## The fix (coordinator-only; default-on; env-tunable)

1. **Universal per-box cap = `min(reported_cap, quality_concurrency × overcommit)`**, computed from each provider's **static single-stream decode rate** (`resolvedDecodeTPS`), *not* the observed-under-load EWMA (which would inherit the feedback loop and force cap=1). Slow models capped tight (Gemma→**2**); fast/over-provisioned models effectively unchanged (gpt-oss→20, ≤ the old 24, far above its load). A provider-reported per-slot `MaxConcurrency` still binds when it's *tighter*. Hooked into the single shared admission gate (`snap.hasHeadroom` + the preflight), so routing and the 429-shed decision stay consistent.
2. **Keep the whole dedicated pool warm**: for dedicated models the warm-pool target = `warm + eligibleCold` (the entire eligible pool), so idle dedicated boxes are proactively warmed into service. Adds per-reason `EligibleCold` disqualifier instrumentation to surface why cold boxes aren't warmable.
3. **Disable cache-affinity pinning for dedicated models** (concurrency-bound, not prompt-cache-bound) so it can't reintroduce concentration.

Knobs (live env, no rebuild): `EIGENINFERENCE_QUALITY_CONCURRENCY_CAP` (default on), `EIGENINFERENCE_QUALITY_CONCURRENCY_OVERCOMMIT` (default 2.0 → Gemma 2/box; set 1.0 for the strict 15-tok/s batch, higher for throughput). Reuses the warm-pool `DECODE_FLOOR_TPS` (15) and `FALLBACK_QUALITY_CONCURRENCY`.

**Default off in `registry.New`**, so existing unit tests and the e2e testbed are unaffected; only the coordinator entrypoint turns it on.

## Tests
- `concurrency_cap_test.go`: cap reads STATIC (not observed) TPS — the regression that matters; scales with model speed (slow→2, fast→20); `min(reported, quality)` both directions; disabled→flat-24; **spread + shed** through the real `ReserveProvider` path; dedicated warm-target = whole pool.
- Full `go test ./registry/... ./api/...` green; `go build`, `gofmt`, `go vet`, `-race`, and the Linux/amd64 (EigenCloud) cross-build all pass.

## Verify after deploy (read-only)
`/v1/admin/routes`: expect backend_running-at-dispatch ≤ cap, cancel rate to fall from 53%, `running_providers` to climb toward the pool size, success rate up from ~15%.

> Coordinator-only. **Deploy is human-only** (EigenCloud prod / GCP dev) — this PR prepares the code; it does not deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/439"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784602980&installation_id=133247490&pr_number=439&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F439&signature=fe0f133da38f0f9d75e7726b81c3a238c604a25b6a5254b6309891d68ad60e0c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->