### PR TITLE
fix(coordinator): DAR-349 remove provider_earnings dedupe from startup path

### DIFF
--- a/coordinator/store/dar349_startup_test.go
+++ b/coordinator/store/dar349_startup_test.go
@@ -1,0 +1,106 @@
+package store
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"testing"
+)
+
+// TestMigrate_NoBootTimeProviderEarningsDedupe is the always-on (no-DB) guard for
+// DAR-349: a boot-time `DELETE ... GROUP BY job_id` on the hot provider_earnings
+// table once held a relation lock for ~15m and stopped the coordinator from
+// binding :8080 (production outage). It must never return to the startup
+// migration path. Dedupe, if ever needed, is an offline job
+// (coordinator/store/migrations/dedupe_provider_earnings.sql).
+func TestMigrate_NoBootTimeProviderEarningsDedupe(t *testing.T) {
+	src, err := os.ReadFile("postgres.go")
+	if err != nil {
+		t.Fatalf("read postgres.go: %v", err)
+	}
+	for _, banned := range []string{
+		"DELETE FROM provider_earnings WHERE id NOT IN",
+		"GROUP BY job_id) AND job_id",
+	} {
+		if bytes.Contains(src, []byte(banned)) {
+			t.Fatalf("DAR-349 regression: boot-time provider_earnings dedupe reintroduced "+
+				"(found %q in postgres.go); move destructive cleanup to an offline job", banned)
+		}
+	}
+}
+
+// TestProviderEarningsJobIndex_BootSafe verifies the safe replacement: startup
+// builds a valid partial unique index on provider_earnings(job_id) without a
+// dedupe DELETE, migrate() is re-entrant, and the index backs the idempotent
+// ON CONFLICT write path. Runs only with DATABASE_URL (throwaway test DB).
+func TestProviderEarningsJobIndex_BootSafe(t *testing.T) {
+	s := testPostgresStore(t) // t.Skip()s when DATABASE_URL is unset
+	ctx := context.Background()
+
+	// NewPostgres -> migrate -> ensureProviderEarningsJobIndex left a VALID index.
+	if !jobIndexValid(t, s) {
+		t.Fatal("idx_provider_earnings_job missing or invalid after startup")
+	}
+
+	// Re-entrancy: a coordinator restart re-runs migrate() and must not error or
+	// do heavy work (the valid-index fast path makes index creation a no-op).
+	if err := s.migrate(ctx); err != nil {
+		t.Fatalf("re-running migrate (restart): %v", err)
+	}
+	if !jobIndexValid(t, s) {
+		t.Fatal("idx_provider_earnings_job invalid after re-running migrate")
+	}
+
+	// RecordProviderEarning is idempotent for a non-empty job_id (ON CONFLICT
+	// needs the partial unique index to exist — which it now does).
+	job := uniqueID("job")
+	for i := 0; i < 2; i++ {
+		e := &ProviderEarning{
+			AccountID: uniqueID("acct"), ProviderID: "p", ProviderKey: uniqueID("pk"),
+			JobID: job, Model: "m", AmountMicroUSD: 1000, PromptTokens: 1, CompletionTokens: 2,
+		}
+		if err := s.RecordProviderEarning(e); err != nil {
+			t.Fatalf("record earning %d: %v", i, err)
+		}
+	}
+	if n := countEarningsByJob(t, s, job); n != 1 {
+		t.Fatalf("rows for job %q = %d, want 1 (idempotent)", job, n)
+	}
+
+	// Empty job_id is excluded from the partial index, so multiple rows are kept.
+	for i := 0; i < 2; i++ {
+		e := &ProviderEarning{
+			AccountID: uniqueID("acct"), ProviderID: "p", ProviderKey: uniqueID("pk"),
+			JobID: "", Model: "m", AmountMicroUSD: 1000, PromptTokens: 1, CompletionTokens: 2,
+		}
+		if err := s.RecordProviderEarning(e); err != nil {
+			t.Fatalf("record empty-job earning %d: %v", i, err)
+		}
+	}
+	if n := countEarningsByJob(t, s, ""); n != 2 {
+		t.Fatalf("rows for empty job_id = %d, want 2 (partial index excludes '')", n)
+	}
+}
+
+func jobIndexValid(t *testing.T, s *PostgresStore) bool {
+	t.Helper()
+	var valid bool
+	if err := s.pool.QueryRow(context.Background(), `
+		SELECT COALESCE((
+			SELECT i.indisvalid FROM pg_class c JOIN pg_index i ON i.indexrelid = c.oid
+			WHERE c.relname = 'idx_provider_earnings_job'
+		), false)`).Scan(&valid); err != nil {
+		t.Fatalf("check idx_provider_earnings_job: %v", err)
+	}
+	return valid
+}
+
+func countEarningsByJob(t *testing.T, s *PostgresStore, job string) int {
+	t.Helper()
+	var n int
+	if err := s.pool.QueryRow(context.Background(),
+		`SELECT count(*) FROM provider_earnings WHERE job_id = $1`, job).Scan(&n); err != nil {
+		t.Fatalf("count earnings: %v", err)
+	}
+	return n
+}

--- a/coordinator/store/migrations/dedupe_provider_earnings.sql
+++ b/coordinator/store/migrations/dedupe_provider_earnings.sql
@@ -1,0 +1,51 @@
+-- Offline / admin-only dedupe for provider_earnings(job_id).
+--
+-- DAR-349: this cleanup used to run inside the coordinator's startup migration
+-- path (NewPostgresStore -> migrate). On the production table (~900k rows /
+-- ~443MB) the `DELETE ... GROUP BY job_id` full-scanned and held a relation lock
+-- for ~15 minutes, blocking the subsequent CREATE INDEX statements and stopping
+-- the coordinator from ever binding :8080 — a production outage. Production has
+-- zero duplicate job_ids, so it was also doing no useful work.
+--
+-- It now lives here as a MANUAL job. The coordinator never dedupes at boot; it
+-- only verifies the duplicate count and, if zero, builds the partial unique index
+-- CONCURRENTLY (see ensureProviderEarningsJobIndex in postgres.go). Run this ONLY
+-- if startup reports duplicate job_id groups blocking idx_provider_earnings_job.
+--
+-- Run it OUT OF BAND (psql against the DB, off the serving startup path), ideally
+-- in a maintenance window, NOT during a coordinator deploy.
+
+-- 1. How many duplicate job_id groups exist (0 on healthy prod)?
+SELECT count(*) AS duplicate_job_id_groups
+FROM (
+    SELECT job_id
+    FROM provider_earnings
+    WHERE job_id <> ''
+    GROUP BY job_id
+    HAVING count(*) > 1
+) d;
+
+-- 2. Dedupe: keep the earliest row (MIN(id)) per job_id, delete the rest.
+--    Wrapped in an explicit transaction so it can be reviewed/rolled back.
+--    Idempotent: a second run deletes 0 rows.
+BEGIN;
+DELETE FROM provider_earnings pe
+USING (
+    SELECT job_id, MIN(id) AS keep_id
+    FROM provider_earnings
+    WHERE job_id <> ''
+    GROUP BY job_id
+    HAVING count(*) > 1
+) dup
+WHERE pe.job_id = dup.job_id
+  AND pe.job_id <> ''
+  AND pe.id <> dup.keep_id;
+COMMIT;
+
+-- 3. Build the partial unique index CONCURRENTLY (no write-blocking lock).
+--    CONCURRENTLY cannot run inside a transaction block, so it is OUTSIDE the
+--    BEGIN/COMMIT above. If a prior attempt left an INVALID index, drop it first:
+--    DROP INDEX IF EXISTS idx_provider_earnings_job;
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS idx_provider_earnings_job
+    ON provider_earnings(job_id)
+    WHERE job_id <> '';

--- a/coordinator/store/postgres.go
+++ b/coordinator/store/postgres.go
@@ -965,12 +965,15 @@ func (s *PostgresStore) migrate(ctx context.Context) error {
 			verified_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 		)`,
 
-		// Base-rewards: idempotency on per-job settlement (design §8 "required fix").
-		// Deduplicate any existing rows first so the unique index builds on prod DBs
-		// that may have retried credits with the same job_id. The DO block is safe
-		// on fresh DBs where no duplicates exist (0-row delete).
-		`DO $$ BEGIN DELETE FROM provider_earnings WHERE id NOT IN (SELECT MIN(id) FROM provider_earnings WHERE job_id <> '' GROUP BY job_id) AND job_id <> ''; EXCEPTION WHEN others THEN NULL; END $$`,
-		`CREATE UNIQUE INDEX IF NOT EXISTS idx_provider_earnings_job ON provider_earnings(job_id) WHERE job_id <> ''`,
+		// Base-rewards per-job settlement idempotency relies on a partial UNIQUE
+		// index on provider_earnings(job_id). DAR-349: that index is built AFTER
+		// this migration loop, CONCURRENTLY and at most once, by
+		// ensureProviderEarningsJobIndex — NEVER with a boot-time dedupe DELETE.
+		// The old `DELETE ... GROUP BY job_id` here full-scanned and locked this
+		// hot table (~900k rows / ~443MB) for ~15m on deploy, blocking the
+		// coordinator from binding :8080 and causing a production outage, while
+		// doing no useful work (prod duplicate count is 0). Offline dedupe, if it
+		// is ever needed, lives in coordinator/store/migrations/dedupe_provider_earnings.sql.
 
 		// Base-rewards: unify sessions↔earnings identity (design §8).
 		`DO $$ BEGIN ALTER TABLE provider_sessions ADD COLUMN IF NOT EXISTS provider_key TEXT NOT NULL DEFAULT ''; EXCEPTION WHEN others THEN NULL; END $$`,
@@ -998,6 +1001,79 @@ func (s *PostgresStore) migrate(ctx context.Context) error {
 		if _, err := s.pool.Exec(ctx, m); err != nil {
 			return fmt.Errorf("migration failed: %w", err)
 		}
+	}
+
+	// DAR-349: build the provider_earnings(job_id) partial unique index outside
+	// the loop — CONCURRENTLY, duplicate-checked, and at most once — so coordinator
+	// startup never runs a long, lock-holding data migration on this hot table.
+	if err := s.ensureProviderEarningsJobIndex(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+// ensureProviderEarningsJobIndex creates the partial UNIQUE index that backs the
+// `ON CONFLICT (job_id) WHERE job_id <> ” DO NOTHING` idempotency used by
+// RecordProviderEarning and CreditProviderAccount.
+//
+// DAR-349: this MUST stay cheap and non-blocking on the serving startup path.
+//   - Fast path: if a valid index already exists, return immediately (every boot
+//     after the first does no work here).
+//   - It NEVER deletes rows. If existing data would violate uniqueness it fails
+//     loudly with an actionable message rather than running a destructive,
+//     table-locking cleanup at boot (the original outage).
+//   - The build is CONCURRENTLY so a blue-green old coordinator still writing to
+//     provider_earnings is never lock-blocked, and uses the simple query protocol
+//     because CREATE INDEX CONCURRENTLY cannot run inside the extended protocol's
+//     implicit transaction.
+func (s *PostgresStore) ensureProviderEarningsJobIndex(ctx context.Context) error {
+	const idxName = "idx_provider_earnings_job"
+
+	// Already present AND valid? No-op fast path for every boot after the first.
+	var valid bool
+	if err := s.pool.QueryRow(ctx, `
+		SELECT COALESCE((
+			SELECT i.indisvalid
+			FROM pg_class c JOIN pg_index i ON i.indexrelid = c.oid
+			WHERE c.relname = $1
+		), false)`, idxName).Scan(&valid); err != nil {
+		return fmt.Errorf("store: check %s: %w", idxName, err)
+	}
+	if valid {
+		return nil
+	}
+
+	// A leftover *invalid* index from a previously interrupted CONCURRENTLY build
+	// would make CREATE ... IF NOT EXISTS a silent no-op, so drop it first.
+	if _, err := s.pool.Exec(ctx, `DROP INDEX IF EXISTS `+idxName); err != nil {
+		return fmt.Errorf("store: drop invalid %s: %w", idxName, err)
+	}
+
+	// Verify the data can support a UNIQUE index. We do NOT dedupe at boot.
+	var dupGroups int64
+	if err := s.pool.QueryRow(ctx, `
+		SELECT count(*) FROM (
+			SELECT 1 FROM provider_earnings
+			WHERE job_id <> '' GROUP BY job_id HAVING count(*) > 1
+		) d`).Scan(&dupGroups); err != nil {
+		return fmt.Errorf("store: count duplicate provider_earnings job_ids: %w", err)
+	}
+	if dupGroups > 0 {
+		return fmt.Errorf("store: %d duplicate provider_earnings.job_id group(s) block unique index %s; "+
+			"run the offline dedupe (coordinator/store/migrations/dedupe_provider_earnings.sql) before deploying "+
+			"— boot does NOT auto-dedupe (DAR-349)", dupGroups, idxName)
+	}
+
+	// Build CONCURRENTLY on a dedicated connection via the simple query protocol.
+	conn, err := s.pool.Acquire(ctx)
+	if err != nil {
+		return fmt.Errorf("store: acquire conn for %s: %w", idxName, err)
+	}
+	defer conn.Release()
+	mrr := conn.Conn().PgConn().Exec(ctx,
+		`CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS idx_provider_earnings_job ON provider_earnings(job_id) WHERE job_id <> ''`)
+	if _, err := mrr.ReadAll(); err != nil {
+		return fmt.Errorf("store: create %s concurrently: %w", idxName, err)
 	}
 	return nil
 }


### PR DESCRIPTION
Fixes **DAR-349** (Urgent). Resolves the deploy outage where the coordinator never bound `:8080`.

## Root cause
`NewPostgres → migrate()` ran an expensive boot-time dedupe on the hot `provider_earnings` table (~900k rows / ~443MB):

```sql
DO $$ BEGIN DELETE FROM provider_earnings
  WHERE id NOT IN (SELECT MIN(id) FROM provider_earnings WHERE job_id <> '' GROUP BY job_id)
  AND job_id <> ''; EXCEPTION WHEN others THEN NULL; END $$
```

On deploy it full-scanned and held a relation lock for ~15m, blocking the following `CREATE INDEX` statements, so the HTTP server never started. Production duplicate count is **0**, so it did no useful work — pure downside. The swallowed `EXCEPTION WHEN others THEN NULL` also hid the behavior.

## Fix
- **Remove the boot-time dedupe `DELETE` entirely.** Serving startup no longer runs data cleanup.
- **Build the partial unique index safely**, after the migration loop, in `ensureProviderEarningsJobIndex`:
  - **Fast path** — if a valid `idx_provider_earnings_job` already exists, return immediately (no-op on every boot after the first).
  - **Non-destructive guard** — counts duplicate `job_id` groups; if any exist, fail loudly with an actionable message pointing at the offline script instead of deleting rows.
  - **`CREATE UNIQUE INDEX CONCURRENTLY`** on a dedicated connection via the simple query protocol — no write-blocking lock, so a blue-green old coordinator still writing earnings is unaffected.
  - Drops a leftover *invalid* index (from an interrupted concurrent build) so `IF NOT EXISTS` can't silently skip a rebuild.
- The idempotent write path (`RecordProviderEarning`, `CreditProviderAccount` already use `ON CONFLICT (job_id) WHERE job_id <> '' DO NOTHING`) is now reliably backed by the index.
- **Offline dedupe** moved to `coordinator/store/migrations/dedupe_provider_earnings.sql` for the (currently non-existent) duplicate case — run out of band, never at boot.

## Tests
- `TestMigrate_NoBootTimeProviderEarningsDedupe` — always-on (no DB) guard against reintroducing the boot dedupe.
- `TestProviderEarningsJobIndex_BootSafe` — postgres-gated (`DATABASE_URL`): valid index after startup, `migrate()` re-entrancy, idempotent earnings writes, and empty `job_id` rows preserved (partial index).

Local: `go build ./...`, `go vet ./store/`, `gofmt` clean; store tests pass (postgres tests skip without `DATABASE_URL`, run in CI).

## Acceptance criteria
- [x] Coordinator binds `:8080` without running the dedupe query.
- [x] No long-running `provider_earnings` startup queries (one-time concurrent index build only when missing; no locks).
- [x] Base rewards don't require startup dedupe.
- [x] Duplicate prevention via index + idempotent writes, not recurring startup cleanup.

> Coordinator-only. Per repo policy, **prod GCP deploy is human-only** — this PR does not deploy.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/440"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784613299&installation_id=133247490&pr_number=440&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F440&signature=d90acf99877f51b45337985d181090f2c7957e4fb3301656e348a2fa0bd96ec1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->