### PR TITLE
fix x.com profile

### DIFF
--- a/landing/index.html
+++ b/landing/index.html
@@ -19,7 +19,7 @@
 
   <!-- Twitter / X -->
   <meta name="twitter:card" content="summary">
-  <meta name="twitter:site" content="@eigen_labs">
+  <meta name="twitter:site" content="@eigenlabs">
   <meta name="twitter:title" content="Darkbloom — Cost-Efficient Private AI Inference on Verified Macs">
   <meta name="twitter:description" content="Encrypted inference on hardware-verified Apple Silicon. Comparable model performance, operator-blind privacy, and about 50% lower cost.">
 
@@ -47,7 +47,7 @@
       "name": "Eigen Labs",
       "url": "https://www.eigenlabs.org",
       "sameAs": [
-        "https://x.com/eigen_labs",
+        "https://x.com/eigenlabs",
         "https://www.linkedin.com/company/eigenlabsorg",
         "https://github.com/Layr-Labs"
       ]
@@ -1519,7 +1519,7 @@ response = client.chat.completions.create(
         <a href="https://github.com/Layr-Labs/d-inference/blob/master/papers/dginf-private-inference.pdf" target="_blank">Paper</a>
         <a href="https://console.darkbloom.dev" target="_blank">Console</a>
         <a href="https://github.com/Layr-Labs/d-inference" target="_blank">GitHub</a>
-        <a href="https://x.com/eigen_labs" target="_blank">X</a>
+        <a href="https://x.com/eigenlabs" target="_blank">X</a>
         <a href="https://www.linkedin.com/company/eigenlabsorg" target="_blank">LinkedIn</a>
         <a href="terms.html" target="_blank">Terms</a>
         <a href="privacy.html" target="_blank">Privacy</a>

--- a/landing/privacy.html
+++ b/landing/privacy.html
@@ -431,7 +431,7 @@
         <a href="https://github.com/Layr-Labs/d-inference/blob/master/papers/dginf-private-inference.pdf" target="_blank">Paper</a>
         <a href="https://console.darkbloom.dev" target="_blank">Console</a>
         <a href="https://github.com/Layr-Labs/d-inference" target="_blank">GitHub</a>
-        <a href="https://x.com/eigen_labs" target="_blank">X</a>
+        <a href="https://x.com/eigenlabs" target="_blank">X</a>
         <a href="https://www.linkedin.com/company/eigenlabsorg" target="_blank">LinkedIn</a>
         <a href="terms.html" target="_blank">Terms</a>
         <a href="privacy.html" target="_blank">Privacy</a>

--- a/landing/terms.html
+++ b/landing/terms.html
@@ -451,7 +451,7 @@
         <a href="https://github.com/Layr-Labs/d-inference/blob/master/papers/dginf-private-inference.pdf" target="_blank">Paper</a>
         <a href="https://console.darkbloom.dev" target="_blank">Console</a>
         <a href="https://github.com/Layr-Labs/d-inference" target="_blank">GitHub</a>
-        <a href="https://x.com/eigen_labs" target="_blank">X</a>
+        <a href="https://x.com/eigenlabs" target="_blank">X</a>
         <a href="https://www.linkedin.com/company/eigenlabsorg" target="_blank">LinkedIn</a>
         <a href="terms.html" target="_blank">Terms</a>
         <a href="privacy.html" target="_blank">Privacy</a>


### PR DESCRIPTION
## Summary

x.com profile was incorrect, i fixed it, was "eigen_labs" should be eigenlabs



## Test plan

no tests needed, just updating a url

## Components touched

<!-- Tick all that apply so reviewers know what to look at. -->

- [ ] coordinator (Go)
- [ ] provider (Rust, legacy)
- [ ] provider-swift (Swift CLI)
- [ ] console-ui (Next.js)
- [ ] enclave (Swift)
- [ ] infra / CI / release
- [ ] docs
- [x] frontend files

## Protocol / interface changes

<!--
If you changed a WebSocket message, an HTTP endpoint, a config key, or a CLI flag:
- Did you update the matching side? (provider/src/protocol.rs ↔ coordinator/internal/protocol/messages.go)
- Are release artifacts (`release-swift.yml`, `scripts/install.sh`, `LatestProviderVersion`) still consistent?
- Does this need a version bump or a migration note?
-->

- [x] No protocol/interface changes
- [ ] Yes — described above and matching side updated

## Notes for reviewers

small pr, x.com profile link currently directs to https://x.com/eigen_labs (not a real profile), i've updated to be the real profile https://x.com/eigenlabs

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/441"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784621475&installation_id=133247490&pr_number=441&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F441&signature=e248687903f8acd273ad70c3aa81a392fde7c9cbd76351fc969c85f2a957c510"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->