### PR TITLE
TTFT contention Phase 0: telemetry fix + occupancy-aware shadow gate (behavior-neutral)

### DIFF
--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -3650,6 +3650,12 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 		if ok {
 			firstChunk = chunk
 			pr.MarkFirstChunkArrived()
+			// Stamp the actual_ttft_ms anchor at first CONTENT, before the
+			// committedRouteOutcome write below — the generic (/v1/completions,
+			// /v1/messages) path has no dispatch preamble filter, so without this
+			// stamp applyPendingRouteTelemetry would persist actual_ttft_ms as
+			// 0/NULL for successful generic requests.
+			pr.MarkFirstContentArrived()
 			committed = true
 		} else {
 			select {
@@ -3717,6 +3723,9 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 			if ok {
 				firstChunk = chunk
 				pr.MarkFirstChunkArrived()
+				// Stamp the actual_ttft_ms anchor at first CONTENT (see the
+				// pre-accept branch above) before committedRouteOutcome runs.
+				pr.MarkFirstContentArrived()
 				committed = true
 			} else {
 				select {

--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -3654,8 +3654,10 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 			// committedRouteOutcome write below — the generic (/v1/completions,
 			// /v1/messages) path has no dispatch preamble filter, so without this
 			// stamp applyPendingRouteTelemetry would persist actual_ttft_ms as
-			// 0/NULL for successful generic requests.
+			// 0/NULL for successful generic requests. MarkContentCommitted marks
+			// this attempt committed so handleComplete's fallback is scoped to it.
 			pr.MarkFirstContentArrived()
+			pr.MarkContentCommitted()
 			committed = true
 		} else {
 			select {
@@ -3723,9 +3725,10 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 			if ok {
 				firstChunk = chunk
 				pr.MarkFirstChunkArrived()
-				// Stamp the actual_ttft_ms anchor at first CONTENT (see the
-				// pre-accept branch above) before committedRouteOutcome runs.
+				// Stamp the actual_ttft_ms anchor + mark this attempt committed at
+				// first CONTENT (see the pre-accept branch above).
 				pr.MarkFirstContentArrived()
+				pr.MarkContentCommitted()
 				committed = true
 			} else {
 				select {

--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -106,8 +106,16 @@ const (
 var thinkBlockPattern = regexp.MustCompile(`(?is)<think>(.*?)</think>\s*`)
 
 // ttftDeadline returns the TTFT budget for a request based on prompt size.
-// Base: 5 seconds + 1ms per estimated input token. This meets the OpenRouter
-// SLA of TTFT < 5s + 1ms/input_token.
+// Base: 5 seconds + 1ms per estimated input token.
+//
+// NOTE (TTFT-contention Phase 0): this 5s base is the coordinator's INTERNAL
+// budget, not the deadline that actually cancels. Prod telemetry shows
+// client_gone cancels fit `10000 + 1ms·prompt_tokens` at a median ratio of 1.002
+// (telemetry-db findings §2); gating projected TTFT against this 5s base
+// over-sheds ~2x. The verified ~10s base lives in
+// registry.ttftDeadlineMsForPrompt (EIGENINFERENCE_TTFT_DEADLINE_BASE_MS) and is
+// used ONLY by the shadow evaluator. This live path is intentionally left at 5s
+// until the shadow validates; a future enforce step would reconcile them.
 func ttftDeadline(estimatedPromptTokens int) time.Duration {
 	base := 5 * time.Second
 	perToken := time.Duration(estimatedPromptTokens) * time.Millisecond

--- a/coordinator/api/dispatch.go
+++ b/coordinator/api/dispatch.go
@@ -388,6 +388,10 @@ func (d *dispatchState) commitFirstContent(pr *registry.PendingRequest, chunk st
 	d.firstChunk = chunk
 	pr.MarkFirstChunkArrived()
 	pr.MarkFirstContentArrived()
+	// Mark THIS attempt as the committed one so handleComplete's fallback only
+	// ever stamps FirstContentAt for the attempt that actually delivered content —
+	// never a late-completing abandoned/retried attempt sharing the same Timing.
+	pr.MarkContentCommitted()
 }
 
 // successRoutingOutcome builds a success outcome for the committed attempt.

--- a/coordinator/api/dispatch.go
+++ b/coordinator/api/dispatch.go
@@ -320,6 +320,11 @@ func (d *dispatchState) recordRoutingDecisionFor(provider *registry.Provider, pr
 		provider.Mu().Unlock()
 	}
 
+	// Phase-0 shadow TTFT admission/spread metrics. No-op unless the request was
+	// evaluated (admission mode != off AND a provider was selected). Emitted on
+	// the synchronous path (cheap counter incr), not inside the async store write.
+	s.emitTTFTShadowMetrics(d.model, decision)
+
 	s.submitTelemetry("recordInferenceRoute", func() {
 		if err := s.store.RecordInferenceRoute(record); err != nil && s.logger != nil {
 			s.logger.Error("inference_routes record write failed",
@@ -2296,9 +2301,10 @@ func (d *dispatchState) writeCommittedResponse() {
 	// (known up front, adequate for normalization) and the provider's benchmarked
 	// PrefillTPS (set once at registration, read-only thereafter).
 	if pr.Timing != nil && d.firstChunk != "" {
-		if pr.Timing.FirstContentAt.IsZero() {
-			pr.Timing.FirstContentAt = time.Now()
-		}
+		// Stamp under timingMu (MarkFirstContentArrived) because the route-
+		// telemetry path now reads FirstContentAt for actual_ttft_ms from the
+		// provider read-loop goroutine (handleComplete -> applyPendingRouteTelemetry).
+		pr.MarkFirstContentArrived()
 		sample := adjustLatencyForPrefill(contentLatency(pr.Timing), pr.EstimatedPromptTokens, provider.PrefillTPS)
 		s.registry.RecordLatency(provider.ID, sample)
 	}

--- a/coordinator/api/dispatch.go
+++ b/coordinator/api/dispatch.go
@@ -372,6 +372,24 @@ func applyTimingDecomposition(out *store.InferenceRouteOutcome, t *registry.Requ
 	out.DispatchMs = timingMsBetween(t.DispatchedAt, firstChunk)
 }
 
+// commitFirstContent records the first CONTENT chunk on the committed attempt and
+// stamps FirstContentAt (the actual_ttft_ms anchor) in the SAME instant, on the
+// dispatch goroutine that reads the chunk. Stamping HERE — rather than later in
+// writeCommittedResponse — guarantees FirstContentAt is set before ANY route
+// outcome is built for this attempt: the committed/success outcome written by
+// this goroutine (e.g. waitFirstChunk / waitAccepted's defer) AND the terminal
+// completeRouteOutcome written concurrently by handleComplete on the provider
+// read-loop. Without it a fast single-chunk completion could persist
+// actual_ttft_ms as 0/NULL (applyPendingRouteTelemetry derives it solely from
+// FirstContentAt). pr is the COMMITTED attempt — the backup on a speculative
+// backup win, the primary otherwise. MarkFirstChunkArrived is kept (idempotent:
+// it preserves an earlier preamble's first-byte time for dispatch_to_first_chunk_ms).
+func (d *dispatchState) commitFirstContent(pr *registry.PendingRequest, chunk string) {
+	d.firstChunk = chunk
+	pr.MarkFirstChunkArrived()
+	pr.MarkFirstContentArrived()
+}
+
 // successRoutingOutcome builds a success outcome for the committed attempt.
 // Token counts and final_status are left empty because the final terminal is
 // only known when the provider later sends complete/error; handleComplete or
@@ -1060,8 +1078,7 @@ func (d *dispatchState) waitFirstChunk() (outcome dispatchOutcome) {
 			speculativeTimer.Stop()
 			deadlineTimer.Stop()
 			if ok {
-				d.firstChunk = chunk
-				pr.MarkFirstChunkArrived()
+				d.commitFirstContent(pr, chunk)
 				d.committed = true
 			} else {
 				select {
@@ -1276,8 +1293,7 @@ func (d *dispatchState) waitNoBackup() dispatchOutcome {
 			}
 			remainingDeadline.Stop()
 			if ok {
-				d.firstChunk = chunk
-				pr.MarkFirstChunkArrived()
+				d.commitFirstContent(pr, chunk)
 				d.committed = true
 			} else {
 				select {
@@ -1389,8 +1405,7 @@ func (d *dispatchState) runRace(backupProvider *registry.Provider, backupPR *reg
 			s.cancelDispatch(backupProvider, backupPR)
 			if ok {
 				d.markSpeculativeLoser(backupPR)
-				d.firstChunk = chunk
-				pr.MarkFirstChunkArrived()
+				d.commitFirstContent(pr, chunk)
 				d.committed = true
 			} else {
 				select {
@@ -1431,8 +1446,7 @@ func (d *dispatchState) runRace(backupProvider *registry.Provider, backupPR *reg
 				d.pr = backupPR
 				d.requestID = d.pr.RequestID
 				d.heldChunks = backupHeld
-				d.firstChunk = chunk
-				d.pr.MarkFirstChunkArrived()
+				d.commitFirstContent(d.pr, chunk)
 				d.committed = true
 			} else {
 				select {
@@ -1578,8 +1592,7 @@ func (d *dispatchState) raceBackupChunkClosedWaitPrimary(provider *registry.Prov
 			}
 			remainingPrimary.Stop()
 			if ok {
-				d.firstChunk = chunk
-				pr.MarkFirstChunkArrived()
+				d.commitFirstContent(pr, chunk)
 				d.committed = true
 			} else {
 				select {
@@ -1676,8 +1689,7 @@ func (d *dispatchState) racePrimaryFailedWaitBackup(backupProvider *registry.Pro
 				d.pr = backupPR
 				d.requestID = d.pr.RequestID
 				d.heldChunks = backupHeld
-				d.firstChunk = chunk
-				d.pr.MarkFirstChunkArrived()
+				d.commitFirstContent(d.pr, chunk)
 				d.committed = true
 			} else {
 				select {
@@ -1773,8 +1785,7 @@ func (d *dispatchState) raceBackupErrWaitPrimary(provider *registry.Provider, pr
 			}
 			primaryDeadline.Stop()
 			if ok {
-				d.firstChunk = chunk
-				pr.MarkFirstChunkArrived()
+				d.commitFirstContent(pr, chunk)
 				d.committed = true
 			} else {
 				select {
@@ -1887,8 +1898,7 @@ func (d *dispatchState) waitAccepted() (outcome dispatchOutcome) {
 			}
 			chunkTimer.Stop()
 			if ok {
-				d.firstChunk = chunk
-				pr.MarkFirstChunkArrived()
+				d.commitFirstContent(pr, chunk)
 				d.committed = true
 			} else {
 				// Closed — check for error. Use a short grace
@@ -2301,10 +2311,10 @@ func (d *dispatchState) writeCommittedResponse() {
 	// (known up front, adequate for normalization) and the provider's benchmarked
 	// PrefillTPS (set once at registration, read-only thereafter).
 	if pr.Timing != nil && d.firstChunk != "" {
-		// Stamp under timingMu (MarkFirstContentArrived) because the route-
-		// telemetry path now reads FirstContentAt for actual_ttft_ms from the
-		// provider read-loop goroutine (handleComplete -> applyPendingRouteTelemetry).
-		pr.MarkFirstContentArrived()
+		// FirstContentAt was already stamped at the content-commit site
+		// (commitFirstContent), earlier in THIS goroutine, so contentLatency reads
+		// a set value here. No re-stamp needed; just read it for the reputation
+		// latency sample.
 		sample := adjustLatencyForPrefill(contentLatency(pr.Timing), pr.EstimatedPromptTokens, provider.PrefillTPS)
 		s.registry.RecordLatency(provider.ID, sample)
 	}

--- a/coordinator/api/provider.go
+++ b/coordinator/api/provider.go
@@ -1904,25 +1904,15 @@ func (s *Server) handleComplete(providerID string, provider *registry.Provider, 
 		// the full response.
 		outcome := completeRouteOutcome(pr, msg.Usage, totalCost, consumerGone)
 		if pr.Timing != nil {
-			t := pr.Timing
-			// This runs on the provider read-loop goroutine, not the request
-			// owner. FirstChunkAt is the one Timing field the dispatch goroutine
-			// writes after dispatch (while streaming), so read it via the
-			// mutex-guarded accessor to avoid a data race. The remaining fields
-			// (DispatchedAt, ReceivedAt, and those used by applyTimingDecomposition)
-			// are all stamped before dispatch and are safe to read here via the
-			// provider-registration happens-before edge.
+			// completeRouteOutcome already applied the per-attempt timing via
+			// applyPendingRouteTelemetry — actual_ttft_ms (from FirstContentAt),
+			// dispatch_to_first_chunk_ms (from FirstChunkAt), total_duration_ms,
+			// and the ParseMs..DispatchMs decomposition — all using the
+			// mutex-guarded timing accessors, which are race-free on this provider
+			// read-loop goroutine. This block only ADDS the measured decode
+			// throughput, which needs FirstChunkAt read via the same guarded
+			// accessor.
 			firstChunk := pr.FirstChunkAtSafe()
-			if !firstChunk.IsZero() && !t.DispatchedAt.IsZero() {
-				ms := float64(firstChunk.Sub(t.DispatchedAt).Milliseconds())
-				outcome.ActualTTFTMs = ms
-				outcome.DispatchToFirstChunkMs = ms
-			}
-			if !t.ReceivedAt.IsZero() {
-				outcome.TotalDurationMs = float64(time.Since(t.ReceivedAt).Milliseconds())
-			}
-			// Coordinator-side latency decomposition (ParseMs..DispatchMs).
-			applyTimingDecomposition(outcome, t, firstChunk)
 			// Measured decode throughput: completion tokens over the decode
 			// window (first chunk -> completion). Guard zero/negative durations
 			// and zero tokens so unmeasurable requests record 0.

--- a/coordinator/api/provider.go
+++ b/coordinator/api/provider.go
@@ -1897,6 +1897,22 @@ func (s *Server) handleComplete(providerID string, provider *registry.Provider, 
 			})
 		}
 
+		// Fallback actual_ttft_ms anchor. The dispatch goroutine normally stamps
+		// FirstContentAt at the content-commit site (commitFirstContent), which
+		// precedes this terminal. But a fast single-chunk completion can deliver its
+		// only content chunk and TypeInferenceComplete almost simultaneously, so
+		// this provider read-loop goroutine may reach completeRouteOutcome before the
+		// dispatch goroutine has processed the chunk. If the provider reported
+		// delivered tokens, content WAS produced, so stamp FirstContentAt now rather
+		// than persist actual_ttft_ms as 0/NULL. MarkFirstContentArrived is
+		// idempotent (timingMu-guarded, first-write-wins), so when the dispatch
+		// goroutine already stamped (the common case) this is a no-op and the
+		// accurate first-content time is preserved; it only fires in the race, where
+		// the near-simultaneous complete time is within ms of first content.
+		if msg.Usage.CompletionTokens > 0 {
+			pr.MarkFirstContentArrived()
+		}
+
 		// Update the routing telemetry outcome with final token counts and timing.
 		// handleComplete is the authoritative final writer for provider completion;
 		// when the consumer already disconnected this is a partial success because

--- a/coordinator/api/provider.go
+++ b/coordinator/api/provider.go
@@ -1897,19 +1897,19 @@ func (s *Server) handleComplete(providerID string, provider *registry.Provider, 
 			})
 		}
 
-		// Fallback actual_ttft_ms anchor. The dispatch goroutine normally stamps
-		// FirstContentAt at the content-commit site (commitFirstContent), which
-		// precedes this terminal. But a fast single-chunk completion can deliver its
-		// only content chunk and TypeInferenceComplete almost simultaneously, so
-		// this provider read-loop goroutine may reach completeRouteOutcome before the
-		// dispatch goroutine has processed the chunk. If the provider reported
-		// delivered tokens, content WAS produced, so stamp FirstContentAt now rather
-		// than persist actual_ttft_ms as 0/NULL. MarkFirstContentArrived is
-		// idempotent (timingMu-guarded, first-write-wins), so when the dispatch
-		// goroutine already stamped (the common case) this is a no-op and the
-		// accurate first-content time is preserved; it only fires in the race, where
-		// the near-simultaneous complete time is within ms of first content.
-		if msg.Usage.CompletionTokens > 0 {
+		// Fallback actual_ttft_ms anchor for the COMMITTED attempt only. The
+		// dispatch/handler goroutine normally stamps FirstContentAt at the
+		// content-commit site (commitFirstContent / the generic stamp); this
+		// fallback covers the fast single-chunk case where TypeInferenceComplete
+		// reaches this provider read-loop goroutine before that stamp runs. It is
+		// gated on ContentCommittedSafe so it ONLY ever stamps for the attempt that
+		// actually committed content: an abandoned/retried attempt that completes
+		// late (it never committed) must NOT stamp the SHARED Timing, or its stale
+		// timestamp would clamp/zero the real committed retry's actual_ttft_ms
+		// (FirstContentAt is first-write-wins). MarkFirstContentArrived is
+		// idempotent, so for the committed attempt this is a no-op when the
+		// dispatch goroutine already stamped.
+		if pr.ContentCommittedSafe() && msg.Usage.CompletionTokens > 0 {
 			pr.MarkFirstContentArrived()
 		}
 

--- a/coordinator/api/route_outcome.go
+++ b/coordinator/api/route_outcome.go
@@ -47,7 +47,17 @@ var validInferenceErrorReasons = map[string]struct{}{
 }
 
 func (s *Server) updateInferenceRouteOutcomeWithModel(requestID string, attempt int, model string, outcome *store.InferenceRouteOutcome) {
-	if s == nil || s.store == nil || requestID == "" || outcome == nil {
+	if s == nil || outcome == nil {
+		return
+	}
+	// Loud guard: a negative raw TTFT was clamped to 0 (see
+	// applyPendingRouteTelemetry). Emitting here — the single store-submit funnel
+	// every terminal/commit outcome flows through — makes any regression of the
+	// retried-request shared-Timing bug visible instead of silent.
+	if outcome.InvalidTTFT {
+		s.emitInvalidTTFT(model, "negative")
+	}
+	if s.store == nil || requestID == "" {
 		return
 	}
 	s.emitInferenceErrorMetric(model, outcome)
@@ -97,6 +107,24 @@ func routeOutcomeWithReason(status, class string, code int, providerReason, erro
 		ErrorCode:   code,
 		ErrorClass:  class,
 		ErrorReason: inferenceErrorReason(providerReason, status, class, code, errorText),
+		// Terminal cancel/error/timeout rows deliver 0 tokens; force-persist that
+		// 0 (instead of leaving completion_tokens NULL) so the incident-majority
+		// 0-token cancels are visible. Success writes its real count separately
+		// via completeRouteOutcome.
+		CompletionTokensSet: terminalForcesCompletionTokens(status),
+	}
+}
+
+// terminalForcesCompletionTokens reports whether a terminal final_status must
+// persist completion_tokens even when it is 0. Cancel/error/timeout rows deliver
+// zero tokens and must record 0 (not NULL) so the 0-token cancel population is
+// queryable; partial_success and success are handled by their own count writers.
+func terminalForcesCompletionTokens(status string) bool {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "cancelled", "error", "timeout":
+		return true
+	default:
+		return false
 	}
 }
 
@@ -207,8 +235,11 @@ func completeRouteOutcome(pr *registry.PendingRequest, usage protocol.UsageInfo,
 		ErrorClass:       errorClass,
 		PromptTokens:     usage.PromptTokens,
 		CompletionTokens: usage.CompletionTokens,
-		ReasoningTokens:  usage.ReasoningTokens,
-		CostMicroUSD:     costMicroUSD,
+		// Authoritative provider-reported count; persist it even when 0 so a
+		// 0-token success records 0 rather than NULL.
+		CompletionTokensSet: true,
+		ReasoningTokens:     usage.ReasoningTokens,
+		CostMicroUSD:        costMicroUSD,
 	}
 	if errorClass != "" {
 		out.ErrorReason = inferenceErrorReason("", status, errorClass, 0, "")
@@ -277,10 +308,34 @@ func applyPendingRouteTelemetry(out *store.InferenceRouteOutcome, pr *registry.P
 	}
 	t := pr.Timing
 	firstChunk := pr.FirstChunkAtSafe()
-	if !firstChunk.IsZero() && !t.DispatchedAt.IsZero() {
-		ms := float64(firstChunk.Sub(t.DispatchedAt).Milliseconds())
+	// actual_ttft_ms is time-to-first-DELIVERED-content (FirstContentAt) measured
+	// against the COMMITTED attempt's DispatchedAt. FirstContentAt is stamped only
+	// on the committed attempt and DispatchedAt is that same attempt's dispatch,
+	// so the two cannot come from different attempts — eliminating the
+	// retried-request shared-Timing bug (FirstChunkAt of an early attempt minus a
+	// later attempt's overwritten DispatchedAt) that produced the -378s rows.
+	// Held role-only / lifecycle preamble (FirstChunkAt) is deliberately NOT used
+	// here, so a fast-preamble-then-stall provider cannot look responsive. A
+	// non-committed terminal (cancel/error: no content) leaves FirstContentAt zero
+	// => actual_ttft_ms 0 (correct: zero tokens delivered).
+	firstContent := pr.FirstContentAtSafe()
+	if !firstContent.IsZero() && !t.DispatchedAt.IsZero() {
+		ms := float64(firstContent.Sub(t.DispatchedAt).Milliseconds())
+		if ms < 0 {
+			// Should be impossible (same attempt), but clamp + flag so any
+			// regression is loud (routing.invalid_ttft) rather than a poison -ms row.
+			out.InvalidTTFT = true
+			ms = 0
+		}
 		out.ActualTTFTMs = ms
-		out.DispatchToFirstChunkMs = ms
+	}
+	// dispatch_to_first_chunk_ms stays the held-preamble (first-byte) diagnostic.
+	// Clamp negatives so a stale-pointer regression cannot write a -ms value here
+	// either.
+	if !firstChunk.IsZero() && !t.DispatchedAt.IsZero() {
+		if ms := float64(firstChunk.Sub(t.DispatchedAt).Milliseconds()); ms >= 0 {
+			out.DispatchToFirstChunkMs = ms
+		}
 	}
 	if !t.ReceivedAt.IsZero() {
 		out.TotalDurationMs = float64(time.Since(t.ReceivedAt).Milliseconds())

--- a/coordinator/api/route_outcome.go
+++ b/coordinator/api/route_outcome.go
@@ -32,6 +32,17 @@ const (
 // every provider — so it is NOT a provider fault and NOT an admission mismatch.
 const errorClassClientError = "client_error"
 
+// Final-status values persisted on inference_routes (store.InferenceRouteOutcome
+// .FinalStatus). Centralized so status comparisons/constructions don't drift on a
+// bare string literal.
+const (
+	finalStatusSuccess        = "success"
+	finalStatusPartialSuccess = "partial_success"
+	finalStatusError          = "error"
+	finalStatusCancelled      = "cancelled"
+	finalStatusTimeout        = "timeout"
+)
+
 var validInferenceErrorReasons = map[string]struct{}{
 	errorReasonJinjaChannelTags:   {},
 	errorReasonJinjaNullBridge:    {},
@@ -77,7 +88,7 @@ func (s *Server) updateInferenceRouteOutcomeWithModel(requestID string, attempt 
 }
 
 func (s *Server) emitInferenceErrorMetric(model string, outcome *store.InferenceRouteOutcome) {
-	if s == nil || outcome == nil || outcome.ErrorReason == "" || outcome.FinalStatus == "" || outcome.FinalStatus == "success" {
+	if s == nil || outcome == nil || outcome.ErrorReason == "" || outcome.FinalStatus == "" || outcome.FinalStatus == finalStatusSuccess {
 		return
 	}
 	tags := []string{"reason:" + outcome.ErrorReason}
@@ -121,7 +132,7 @@ func routeOutcomeWithReason(status, class string, code int, providerReason, erro
 // queryable; partial_success and success are handled by their own count writers.
 func terminalForcesCompletionTokens(status string) bool {
 	switch strings.ToLower(strings.TrimSpace(status)) {
-	case "cancelled", "error", "timeout":
+	case finalStatusCancelled, finalStatusError, finalStatusTimeout:
 		return true
 	default:
 		return false
@@ -157,7 +168,7 @@ func providerFailedPendingRouteOutcomeWithReason(pr *registry.PendingRequest, st
 }
 
 func dispatchFailedPendingRouteOutcome(pr *registry.PendingRequest, class string, code int) *store.InferenceRouteOutcome {
-	return pendingRouteOutcome(pr, "error", class, code)
+	return pendingRouteOutcome(pr, finalStatusError, class, code)
 }
 
 func providerDisconnectedError(errorText string, statusCode int) bool {
@@ -169,7 +180,7 @@ func postCommitProviderErrorOutcome(pr *registry.PendingRequest, msg protocol.In
 	if providerDisconnectedError(msg.Error, msg.StatusCode) {
 		class = "provider_disconnect_after_commit"
 	}
-	return providerFailedPendingRouteOutcomeWithReason(pr, "partial_success", class, msg.StatusCode, msg.ErrorReason, msg.Error)
+	return providerFailedPendingRouteOutcomeWithReason(pr, finalStatusPartialSuccess, class, msg.StatusCode, msg.ErrorReason, msg.Error)
 }
 
 func preResponseProviderErrorOutcome(pr *registry.PendingRequest, msg protocol.InferenceErrorMessage) *store.InferenceRouteOutcome {
@@ -177,7 +188,7 @@ func preResponseProviderErrorOutcome(pr *registry.PendingRequest, msg protocol.I
 	if providerDisconnectedError(msg.Error, msg.StatusCode) {
 		class = "provider_disconnect_before_response"
 	}
-	return providerFailedPendingRouteOutcomeWithReason(pr, "error", class, msg.StatusCode, msg.ErrorReason, msg.Error)
+	return providerFailedPendingRouteOutcomeWithReason(pr, finalStatusError, class, msg.StatusCode, msg.ErrorReason, msg.Error)
 }
 
 func preCommitProviderErrorOutcome(pr *registry.PendingRequest, msg protocol.InferenceErrorMessage) *store.InferenceRouteOutcome {
@@ -186,48 +197,48 @@ func preCommitProviderErrorOutcome(pr *registry.PendingRequest, msg protocol.Inf
 		// by shape (fails identically on every provider), not a provider fault.
 		// Record as client_error WITHOUT AdmittedButFailed so it never pollutes the
 		// admission-mismatch gauge.
-		return pendingRouteOutcomeWithReason(pr, "error", errorClassClientError, msg.StatusCode, msg.ErrorReason, msg.Error)
+		return pendingRouteOutcomeWithReason(pr, finalStatusError, errorClassClientError, msg.StatusCode, msg.ErrorReason, msg.Error)
 	}
 	class := "provider_error"
 	if providerDisconnectedError(msg.Error, msg.StatusCode) {
 		class = "provider_disconnect_pre_commit"
 	}
-	return providerFailedPendingRouteOutcomeWithReason(pr, "error", class, msg.StatusCode, msg.ErrorReason, msg.Error)
+	return providerFailedPendingRouteOutcomeWithReason(pr, finalStatusError, class, msg.StatusCode, msg.ErrorReason, msg.Error)
 }
 
 func postCommitProviderIncompleteOutcome(pr *registry.PendingRequest) *store.InferenceRouteOutcome {
-	return providerFailedPendingRouteOutcome(pr, "partial_success", "provider_incomplete_after_commit", 502)
+	return providerFailedPendingRouteOutcome(pr, finalStatusPartialSuccess, "provider_incomplete_after_commit", 502)
 }
 
 func preResponseProviderIncompleteOutcome(pr *registry.PendingRequest) *store.InferenceRouteOutcome {
-	return providerFailedPendingRouteOutcome(pr, "error", "provider_incomplete_before_response", 502)
+	return providerFailedPendingRouteOutcome(pr, finalStatusError, "provider_incomplete_before_response", 502)
 }
 
 func postCommitStreamTimeoutOutcome(pr *registry.PendingRequest) *store.InferenceRouteOutcome {
-	return pendingRouteOutcome(pr, "partial_success", "stream_timeout_after_commit", 504)
+	return pendingRouteOutcome(pr, finalStatusPartialSuccess, "stream_timeout_after_commit", 504)
 }
 
 func preResponseTimeoutOutcome(pr *registry.PendingRequest, class string) *store.InferenceRouteOutcome {
-	return pendingRouteOutcome(pr, "timeout", class, 504)
+	return pendingRouteOutcome(pr, finalStatusTimeout, class, 504)
 }
 
 func noTerminalAfterCancelOutcome(pr *registry.PendingRequest) *store.InferenceRouteOutcome {
-	return pendingRouteOutcome(pr, "partial_success", "no_terminal_after_cancel", 504)
+	return pendingRouteOutcome(pr, finalStatusPartialSuccess, "no_terminal_after_cancel", 504)
 }
 
 func speculativeLoserOutcome(pr *registry.PendingRequest) *store.InferenceRouteOutcome {
-	return pendingRouteOutcome(pr, "cancelled", "speculative_loser", 0)
+	return pendingRouteOutcome(pr, finalStatusCancelled, "speculative_loser", 0)
 }
 
 func clientGoneBeforeResponseOutcome(pr *registry.PendingRequest) *store.InferenceRouteOutcome {
-	return pendingRouteOutcome(pr, "cancelled", "client_gone_before_response", 0)
+	return pendingRouteOutcome(pr, finalStatusCancelled, "client_gone_before_response", 0)
 }
 
 func completeRouteOutcome(pr *registry.PendingRequest, usage protocol.UsageInfo, costMicroUSD int64, consumerGone bool) *store.InferenceRouteOutcome {
-	status := "success"
+	status := finalStatusSuccess
 	errorClass := ""
 	if consumerGone {
-		status = "partial_success"
+		status = finalStatusPartialSuccess
 		errorClass = errorClassClientGoneAfterCommitCompleted
 	}
 	out := &store.InferenceRouteOutcome{
@@ -259,7 +270,7 @@ func inferenceErrorReason(providerReason, status, class string, code int, messag
 	if status == "" && class == "" && code == 0 && message == "" {
 		return ""
 	}
-	if strings.EqualFold(strings.TrimSpace(status), "success") {
+	if strings.EqualFold(strings.TrimSpace(status), finalStatusSuccess) {
 		return ""
 	}
 

--- a/coordinator/api/route_outcome_test.go
+++ b/coordinator/api/route_outcome_test.go
@@ -21,13 +21,18 @@ func TestCommittedRouteOutcomeIsNonTerminal(t *testing.T) {
 			DispatchedAt: now.Add(-50 * time.Millisecond),
 		},
 	}
+	// A committed response delivers content: the held preamble stamps FirstChunkAt
+	// (dispatch_to_first_chunk_ms diagnostic) and the first content chunk stamps
+	// FirstContentAt (actual_ttft_ms). Both must flow onto the non-terminal commit
+	// outcome.
 	pr.MarkFirstChunkArrived()
+	pr.MarkFirstContentArrived()
 	out := committedRouteOutcome(pr)
 	if out.FinalStatus != "" {
 		t.Fatalf("FinalStatus = %q, want empty until provider terminal", out.FinalStatus)
 	}
 	if out.ActualTTFTMs == 0 || out.DispatchToFirstChunkMs == 0 {
-		t.Fatalf("commit outcome should still carry TTFT fields: %+v", out)
+		t.Fatalf("commit outcome should carry content (actual_ttft_ms) + preamble (dispatch_to_first_chunk_ms): %+v", out)
 	}
 }
 

--- a/coordinator/api/ttft_first_content_test.go
+++ b/coordinator/api/ttft_first_content_test.go
@@ -17,10 +17,12 @@ import (
 // completeRouteOutcome would then persist actual_ttft_ms as 0/NULL even though
 // tokens were delivered.
 //
-// This drives handleComplete with FirstContentAt deliberately unstamped (the
-// race) and a positive completion-token count. handleComplete's fallback stamps
-// FirstContentAt because the provider reported delivered tokens, so the persisted
-// actual_ttft_ms is > 0. Without the fix this test fails (ActualTTFTMs == 0).
+// This drives handleComplete for the COMMITTED attempt (MarkContentCommitted set,
+// as commitFirstContent does in the dispatch path) with FirstContentAt
+// deliberately unstamped (the race) and a positive completion-token count.
+// handleComplete's committed-attempt fallback stamps FirstContentAt, so the
+// persisted actual_ttft_ms is > 0. Without the fix this test fails
+// (ActualTTFTMs == 0).
 func TestFastCompletionStampsActualTTFT(t *testing.T) {
 	srv, st, _ := billingTestServer(t)
 
@@ -46,6 +48,9 @@ func TestFastCompletionStampsActualTTFT(t *testing.T) {
 			// FirstChunkAt / FirstContentAt intentionally unset (zero).
 		},
 	}
+	// This IS the committed attempt (the dispatch path marks it via
+	// commitFirstContent); the fallback is scoped to committed attempts.
+	pr.MarkContentCommitted()
 	provider.AddPending(pr)
 
 	// Pre-create the route row so the (best-effort, async) outcome update lands.
@@ -81,5 +86,77 @@ func TestFastCompletionStampsActualTTFT(t *testing.T) {
 	}
 	if rec.ActualTTFTMs <= 0 {
 		t.Fatalf("actual_ttft_ms must be populated and > 0 for a delivered completion, got %f (0/NULL = the FirstContentAt stamp-ordering bug)", rec.ActualTTFTMs)
+	}
+}
+
+// TestAbandonedAttemptDoesNotStampCommittedTTFT is the regression for the
+// committed-attempt fallback guard (Codex P2 round 3): an abandoned/retried
+// attempt that completes LATE (the provider finished after the coordinator timed
+// it out and retried) must NOT stamp FirstContentAt on the Timing it SHARES with
+// the committed retry. FirstContentAt is first-write-wins, so a stale stamp from
+// the abandoned attempt would clamp/zero the committed retry's actual_ttft_ms.
+// The fallback is gated on ContentCommittedSafe, and the abandoned attempt was
+// never committed, so it must leave FirstContentAt untouched — letting the
+// committed retry's first-content time win.
+func TestAbandonedAttemptDoesNotStampCommittedTTFT(t *testing.T) {
+	srv, st, _ := billingTestServer(t)
+
+	model := "abandoned-ttft-model"
+	provider := srv.registry.Register("abandoned-ttft-provider", nil, &protocol.RegisterMessage{
+		Models: []protocol.ModelInfo{{ID: model, ModelType: "chat", Quantization: "4bit"}},
+	})
+
+	// Timing is SHARED across attempts (dispatch.go sets Timing: d.timing on every
+	// attempt). DispatchedAt reflects the committed retry's dispatch.
+	shared := &registry.RequestTiming{
+		ReceivedAt:   time.Now().Add(-time.Second),
+		DispatchedAt: time.Now().Add(-200 * time.Millisecond),
+		// FirstContentAt unset: the committed retry has not delivered content yet.
+	}
+	// The abandoned attempt (attempt 0) — never committed (no MarkContentCommitted).
+	abandoned := &registry.PendingRequest{
+		RequestID:        "abandoned-attempt",
+		Attempt:          0,
+		Model:            model,
+		ConsumerKey:      testConsumerID,
+		ReservedMicroUSD: 10_000_000,
+		ChunkCh:          make(chan string, 1),
+		CompleteCh:       make(chan protocol.UsageInfo, 1),
+		ErrorCh:          make(chan protocol.InferenceErrorMessage, 1),
+		Timing:           shared,
+	}
+	provider.AddPending(abandoned)
+	if err := st.RecordInferenceRoute(&store.InferenceRouteRecord{
+		RequestID: abandoned.RequestID, Attempt: abandoned.Attempt, Model: model, ProviderID: provider.ID,
+	}); err != nil {
+		t.Fatalf("record route: %v", err)
+	}
+
+	// The abandoned attempt completes late, with delivered tokens. The fallback
+	// must NOT stamp the shared FirstContentAt (it was never the committed attempt).
+	srv.handleComplete(provider.ID, provider, &protocol.InferenceCompleteMessage{
+		Type:      protocol.TypeInferenceComplete,
+		RequestID: abandoned.RequestID,
+		Usage:     protocol.UsageInfo{PromptTokens: 1000, CompletionTokens: 5},
+	})
+
+	if !shared.FirstContentAt.IsZero() {
+		t.Fatalf("abandoned attempt must NOT stamp the shared FirstContentAt, got %v (would clamp the committed retry's actual_ttft_ms)", shared.FirstContentAt)
+	}
+
+	// The committed retry then delivers its first content — its stamp wins, and
+	// its actual_ttft_ms is measured from the shared DispatchedAt (positive).
+	committed := &registry.PendingRequest{RequestID: "committed-retry", Attempt: 1, Model: model, Timing: shared}
+	committed.MarkContentCommitted()
+	committed.MarkFirstContentArrived()
+	if shared.FirstContentAt.IsZero() {
+		t.Fatal("committed retry's first-content stamp must win")
+	}
+	out := completeRouteOutcome(committed, protocol.UsageInfo{PromptTokens: 1000, CompletionTokens: 5}, 0, false)
+	if out.ActualTTFTMs <= 0 {
+		t.Fatalf("committed retry actual_ttft_ms must be > 0 (its own first-content time), got %f", out.ActualTTFTMs)
+	}
+	if out.InvalidTTFT {
+		t.Fatal("committed retry actual_ttft_ms must be a clean positive, not the negative-clamp guard")
 	}
 }

--- a/coordinator/api/ttft_first_content_test.go
+++ b/coordinator/api/ttft_first_content_test.go
@@ -1,0 +1,85 @@
+package api
+
+import (
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+	"github.com/eigeninference/d-inference/coordinator/registry"
+	"github.com/eigeninference/d-inference/coordinator/store"
+)
+
+// TestFastCompletionStampsActualTTFT is the regression for the FirstContentAt
+// stamp-ordering bug (Codex P2, dispatch.go ~2301): a fast single-chunk
+// completion can have its TypeInferenceComplete reach handleComplete BEFORE the
+// dispatch goroutine stamps FirstContentAt. Since applyPendingRouteTelemetry now
+// derives actual_ttft_ms SOLELY from FirstContentAt, the terminal
+// completeRouteOutcome would then persist actual_ttft_ms as 0/NULL even though
+// tokens were delivered.
+//
+// This drives handleComplete with FirstContentAt deliberately unstamped (the
+// race) and a positive completion-token count. handleComplete's fallback stamps
+// FirstContentAt because the provider reported delivered tokens, so the persisted
+// actual_ttft_ms is > 0. Without the fix this test fails (ActualTTFTMs == 0).
+func TestFastCompletionStampsActualTTFT(t *testing.T) {
+	srv, st, _ := billingTestServer(t)
+
+	model := "fast-ttft-model"
+	provider := srv.registry.Register("fast-ttft-provider", nil, &protocol.RegisterMessage{
+		Models: []protocol.ModelInfo{{ID: model, ModelType: "chat", Quantization: "4bit"}},
+	})
+
+	// Committed attempt whose dispatch happened 50ms ago, but whose first content
+	// chunk the dispatch goroutine has NOT yet stamped (FirstContentAt zero) —
+	// exactly the fast-completion race the fix closes.
+	pr := &registry.PendingRequest{
+		RequestID:        "fast-ttft-req",
+		Model:            model,
+		ConsumerKey:      testConsumerID,
+		ReservedMicroUSD: 10_000_000,
+		ChunkCh:          make(chan string, 1),
+		CompleteCh:       make(chan protocol.UsageInfo, 1),
+		ErrorCh:          make(chan protocol.InferenceErrorMessage, 1),
+		Timing: &registry.RequestTiming{
+			ReceivedAt:   time.Now().Add(-60 * time.Millisecond),
+			DispatchedAt: time.Now().Add(-50 * time.Millisecond),
+			// FirstChunkAt / FirstContentAt intentionally unset (zero).
+		},
+	}
+	provider.AddPending(pr)
+
+	// Pre-create the route row so the (best-effort, async) outcome update lands.
+	if err := st.RecordInferenceRoute(&store.InferenceRouteRecord{
+		RequestID:  pr.RequestID,
+		Attempt:    pr.Attempt,
+		Model:      model,
+		ProviderID: provider.ID,
+	}); err != nil {
+		t.Fatalf("record route: %v", err)
+	}
+
+	srv.handleComplete(provider.ID, provider, &protocol.InferenceCompleteMessage{
+		Type:      protocol.TypeInferenceComplete,
+		RequestID: pr.RequestID,
+		Usage:     protocol.UsageInfo{PromptTokens: 1000, CompletionTokens: 1},
+	})
+
+	// The outcome write is best-effort async (telemetry sink), so poll for it.
+	deadline := time.Now().Add(2 * time.Second)
+	var rec *store.InferenceRouteRecord
+	for time.Now().Before(deadline) {
+		if rec = findRouteRecord(st, pr.RequestID); rec != nil && rec.FinalStatus != "" {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if rec == nil || rec.FinalStatus == "" {
+		t.Fatal("route record not found / not finalized")
+	}
+	if rec.FinalStatus != "success" {
+		t.Fatalf("final_status = %q, want success", rec.FinalStatus)
+	}
+	if rec.ActualTTFTMs <= 0 {
+		t.Fatalf("actual_ttft_ms must be populated and > 0 for a delivered completion, got %f (0/NULL = the FirstContentAt stamp-ordering bug)", rec.ActualTTFTMs)
+	}
+}

--- a/coordinator/api/ttft_shadow_metrics.go
+++ b/coordinator/api/ttft_shadow_metrics.go
@@ -1,0 +1,79 @@
+package api
+
+import "github.com/eigeninference/d-inference/coordinator/registry"
+
+// Phase-0 TTFT telemetry emission (DogStatsD + the in-process /v1/admin/metrics
+// registry). These are pure observability hooks — no routing behavior changes.
+
+// emitInvalidTTFT fires when applyPendingRouteTelemetry clamped a negative raw
+// time-to-first-token to 0. It is the loud guard against any regression of the
+// retried-request shared-Timing bug (FirstContentAt of an early attempt minus a
+// later attempt's overwritten DispatchedAt), which produced -ms rows down to
+// -378s. Emitted from the single store-submit funnel so it covers every path.
+func (s *Server) emitInvalidTTFT(model, reason string) {
+	if s == nil {
+		return
+	}
+	tags := []string{"reason:" + reason}
+	if model != "" {
+		tags = append(tags, "model:"+model)
+	}
+	s.ddIncr("routing.invalid_ttft", tags)
+	if s.metrics != nil {
+		labels := []MetricLabel{{Name: "reason", Value: reason}}
+		if model != "" {
+			labels = append(labels, MetricLabel{Name: "model", Value: model})
+		}
+		s.metrics.IncCounter("routing.invalid_ttft", labels...)
+	}
+}
+
+// emitTTFTShadowMetrics records the Phase-0 shadow admission/spread decision for
+// a selected provider. decision.ShadowEvaluated is true only when
+// EIGENINFERENCE_TTFT_ADMISSION_MODE != off and a provider was selected, so this
+// is a no-op in the default (off) configuration.
+//
+//   - routing.ttft_admission{decision:would_shed|would_serve} — would the
+//     occupancy-aware estimate at the ~10s base have shed the chosen provider.
+//   - routing.ttft_spread{would_redirect_to_idle:true|false} — was an
+//     instantly-usable loaded-idle peer for the same model available to spread to.
+func (s *Server) emitTTFTShadowMetrics(model string, decision registry.RoutingDecision) {
+	if s == nil || !decision.ShadowEvaluated {
+		return
+	}
+	shedTag := "would_serve"
+	if decision.ShadowWouldShed {
+		shedTag = "would_shed"
+	}
+	redirectTag := "false"
+	if decision.ShadowIdleAlternativeExists {
+		redirectTag = "true"
+	}
+
+	s.ddIncr("routing.ttft_admission", []string{"model:" + model, "decision:" + shedTag, "mode:" + decision.ShadowMode})
+	s.ddIncr("routing.ttft_spread", []string{"model:" + model, "would_redirect_to_idle:" + redirectTag, "mode:" + decision.ShadowMode})
+	if s.metrics != nil {
+		s.metrics.IncCounter("routing.ttft_admission",
+			MetricLabel{Name: "model", Value: model},
+			MetricLabel{Name: "decision", Value: shedTag},
+			MetricLabel{Name: "mode", Value: decision.ShadowMode},
+		)
+		s.metrics.IncCounter("routing.ttft_spread",
+			MetricLabel{Name: "model", Value: model},
+			MetricLabel{Name: "would_redirect_to_idle", Value: redirectTag},
+			MetricLabel{Name: "mode", Value: decision.ShadowMode},
+		)
+	}
+	if s.logger != nil {
+		s.logger.Debug("ttft shadow admission",
+			"model", model,
+			"mode", decision.ShadowMode,
+			"would_shed", decision.ShadowWouldShed,
+			"would_redirect_to_idle", decision.ShadowIdleAlternativeExists,
+			"estimate_ms", decision.ShadowEstimateMs,
+			"deadline_ms", decision.ShadowDeadlineMs,
+			"occupancy", decision.ShadowOccupancy,
+			"provider_id", decision.ProviderID,
+		)
+	}
+}

--- a/coordinator/api/ttft_shadow_metrics_test.go
+++ b/coordinator/api/ttft_shadow_metrics_test.go
@@ -1,0 +1,141 @@
+package api
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/registry"
+	"github.com/eigeninference/d-inference/coordinator/store"
+)
+
+func newTTFTTestServer(t *testing.T) *Server {
+	t.Helper()
+	return NewServer(registry.New(quietLogger()), store.NewMemory(store.Config{}), ServerConfig{}, quietLogger())
+}
+
+// counterMatches reports whether the in-process metrics registry holds a counter
+// whose key starts with name, contains every sub, and has a positive value.
+func counterMatches(counters map[string]int64, name string, subs ...string) bool {
+	for k, v := range counters {
+		if v < 1 || !strings.HasPrefix(k, name) {
+			continue
+		}
+		ok := true
+		for _, s := range subs {
+			if !strings.Contains(k, s) {
+				ok = false
+				break
+			}
+		}
+		if ok {
+			return true
+		}
+	}
+	return false
+}
+
+// TestEmitTTFTShadowMetrics asserts the shadow admission/spread counters are
+// emitted with the right tags for a would_shed + would_redirect decision.
+func TestEmitTTFTShadowMetrics(t *testing.T) {
+	srv := newTTFTTestServer(t)
+	srv.emitTTFTShadowMetrics("gpt-oss-20b", registry.RoutingDecision{
+		ProviderID:                  "p1",
+		ShadowEvaluated:             true,
+		ShadowMode:                  "shadow",
+		ShadowWouldShed:             true,
+		ShadowIdleAlternativeExists: true,
+		ShadowEstimateMs:            14000,
+		ShadowDeadlineMs:            11000,
+		ShadowOccupancy:             5,
+	})
+	counters := srv.metrics.Snapshot().Counters
+	if !counterMatches(counters, "routing.ttft_admission", "decision=would_shed", "model=gpt-oss-20b", "mode=shadow") {
+		t.Fatalf("missing routing.ttft_admission{would_shed}; counters=%v", counters)
+	}
+	if !counterMatches(counters, "routing.ttft_spread", "would_redirect_to_idle=true", "model=gpt-oss-20b") {
+		t.Fatalf("missing routing.ttft_spread{redirect=true}; counters=%v", counters)
+	}
+}
+
+// TestEmitTTFTShadowMetricsServeAndNoRedirect covers the negative tag values.
+func TestEmitTTFTShadowMetricsServeAndNoRedirect(t *testing.T) {
+	srv := newTTFTTestServer(t)
+	srv.emitTTFTShadowMetrics("gpt-oss-20b", registry.RoutingDecision{
+		ShadowEvaluated: true,
+		ShadowMode:      "shadow",
+	})
+	counters := srv.metrics.Snapshot().Counters
+	if !counterMatches(counters, "routing.ttft_admission", "decision=would_serve") {
+		t.Fatalf("missing routing.ttft_admission{would_serve}; counters=%v", counters)
+	}
+	if !counterMatches(counters, "routing.ttft_spread", "would_redirect_to_idle=false") {
+		t.Fatalf("missing routing.ttft_spread{redirect=false}; counters=%v", counters)
+	}
+}
+
+// TestEmitTTFTShadowMetricsNoopWhenNotEvaluated is the behavior-neutral default:
+// no shadow metrics when admission mode was off (ShadowEvaluated=false).
+func TestEmitTTFTShadowMetricsNoopWhenNotEvaluated(t *testing.T) {
+	srv := newTTFTTestServer(t)
+	srv.emitTTFTShadowMetrics("gpt-oss-20b", registry.RoutingDecision{ShadowEvaluated: false})
+	if got := len(srv.metrics.Snapshot().Counters); got != 0 {
+		t.Fatalf("no shadow metrics expected when not evaluated, got %d counters", got)
+	}
+}
+
+// TestActualTTFTUsesFirstContentNotPreamble pins the corrected semantics:
+// actual_ttft_ms comes from FirstContentAt (delivered content); the held
+// preamble (FirstChunkAt) only feeds dispatch_to_first_chunk_ms.
+func TestActualTTFTUsesFirstContentNotPreamble(t *testing.T) {
+	base := time.Now()
+	pr := &registry.PendingRequest{
+		RequestID: "req-content",
+		Timing: &registry.RequestTiming{
+			ReceivedAt:     base.Add(-50 * time.Millisecond),
+			DispatchedAt:   base,
+			FirstChunkAt:   base.Add(10 * time.Millisecond),  // held preamble
+			FirstContentAt: base.Add(500 * time.Millisecond), // real content
+		},
+	}
+	out := committedRouteOutcome(pr)
+	if out.InvalidTTFT {
+		t.Fatal("positive TTFT must not be flagged invalid")
+	}
+	if out.ActualTTFTMs != 500 {
+		t.Fatalf("actual_ttft_ms must reflect FirstContentAt (500ms), got %f", out.ActualTTFTMs)
+	}
+	if out.DispatchToFirstChunkMs != 10 {
+		t.Fatalf("dispatch_to_first_chunk_ms must reflect the preamble (10ms), got %f", out.DispatchToFirstChunkMs)
+	}
+}
+
+// TestRetriedRequestTTFTClampedAndMetered reproduces the retried-request
+// shared-Timing bug (the -378s rows): an early attempt's FirstContentAt minus a
+// later attempt's overwritten DispatchedAt is hugely negative. It must clamp to 0
+// and fire routing.invalid_ttft, never persist a negative.
+func TestRetriedRequestTTFTClampedAndMetered(t *testing.T) {
+	base := time.Now()
+	pr := &registry.PendingRequest{
+		RequestID: "req-retry-neg",
+		Timing: &registry.RequestTiming{
+			ReceivedAt:     base.Add(-time.Second),
+			DispatchedAt:   base.Add(378 * time.Second), // later attempt overwrote dispatch far ahead
+			FirstContentAt: base,                        // early attempt's content
+		},
+	}
+	out := committedRouteOutcome(pr)
+	if out.ActualTTFTMs != 0 {
+		t.Fatalf("negative TTFT must clamp to 0, got %f", out.ActualTTFTMs)
+	}
+	if !out.InvalidTTFT {
+		t.Fatal("negative TTFT must set InvalidTTFT for the loud guard")
+	}
+
+	srv := newTTFTTestServer(t)
+	srv.updateInferenceRouteOutcomeWithModel("req-retry-neg", 0, "gpt-oss-20b", out)
+	counters := srv.metrics.Snapshot().Counters
+	if !counterMatches(counters, "routing.invalid_ttft", "reason=negative", "model=gpt-oss-20b") {
+		t.Fatalf("routing.invalid_ttft{reason=negative,model=gpt-oss-20b} not emitted; counters=%v", counters)
+	}
+}

--- a/coordinator/cmd/coordinator/main.go
+++ b/coordinator/cmd/coordinator/main.go
@@ -27,6 +27,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"math"
 	"net/http"
 	"os"
 	"os/signal"
@@ -403,19 +404,21 @@ func main() {
 	//     reserved for a future step that would actually shed; it currently
 	//     behaves like shadow.
 	if v := os.Getenv("EIGENINFERENCE_TTFT_OCCUPANCY_ALPHA"); v != "" {
-		if alpha, err := strconv.ParseFloat(v, 64); err == nil && alpha >= 0 {
+		if alpha, ok := validateTTFTOccupancyAlpha(v); ok {
 			registry.SetTTFTOccupancyAlpha(alpha)
 			logger.Info("TTFT occupancy term configured via EIGENINFERENCE_TTFT_OCCUPANCY_ALPHA", "alpha", alpha, "behavior_neutral", alpha == 0)
 		} else {
-			logger.Warn("invalid EIGENINFERENCE_TTFT_OCCUPANCY_ALPHA; ignoring", "value", v)
+			logger.Warn("invalid or out-of-range EIGENINFERENCE_TTFT_OCCUPANCY_ALPHA; keeping default 0 (term off)",
+				"value", v, "max", maxTTFTOccupancyAlpha)
 		}
 	}
 	if v := os.Getenv("EIGENINFERENCE_TTFT_DEADLINE_BASE_MS"); v != "" {
-		if base, err := strconv.ParseFloat(v, 64); err == nil && base > 0 {
+		if base, ok := validateTTFTDeadlineBaseMs(v); ok {
 			registry.SetTTFTDeadlineBaseMs(base)
 			logger.Info("TTFT shadow deadline base configured via EIGENINFERENCE_TTFT_DEADLINE_BASE_MS", "base_ms", base)
 		} else {
-			logger.Warn("invalid EIGENINFERENCE_TTFT_DEADLINE_BASE_MS; ignoring", "value", v)
+			logger.Warn("invalid or out-of-range EIGENINFERENCE_TTFT_DEADLINE_BASE_MS; keeping default ~10s",
+				"value", v, "min_ms", minTTFTDeadlineBaseMs, "max_ms", maxTTFTDeadlineBaseMs)
 		}
 	}
 	if v := os.Getenv("EIGENINFERENCE_TTFT_ADMISSION_MODE"); v != "" {
@@ -890,6 +893,55 @@ func parseAPNsEnforceAfter() (time.Time, error) {
 		return time.Time{}, fmt.Errorf("APNS_ENFORCE_AFTER %q is not valid RFC3339: %w", raw, err)
 	}
 	return t, nil
+}
+
+const (
+	// maxTTFTOccupancyAlpha bounds EIGENINFERENCE_TTFT_OCCUPANCY_ALPHA. The term
+	// is alpha·occ·1000/decodeTPS ms, so an alpha above this would imply >1e6
+	// decode-token-times of head-of-line wait per peer — nonsensical and almost
+	// certainly a typo (e.g. a misplaced decimal), so it is rejected for the safe
+	// default (0 = term off) rather than silently distorting the shadow estimate.
+	maxTTFTOccupancyAlpha = 1e6
+	// minTTFTDeadlineBaseMs / maxTTFTDeadlineBaseMs bound
+	// EIGENINFERENCE_TTFT_DEADLINE_BASE_MS. Below ~1s no first-token SLA is
+	// realistic; above ~120s the shadow gate is meaningless. The verified
+	// OpenRouter base is ~10s (telemetry-db findings §2).
+	minTTFTDeadlineBaseMs = 1000.0
+	maxTTFTDeadlineBaseMs = 120000.0
+)
+
+// validateTTFTOccupancyAlpha parses and bounds EIGENINFERENCE_TTFT_OCCUPANCY_ALPHA.
+// It returns (alpha, ok): ok=false means the raw value was unparseable, non-finite,
+// or absurd (> maxTTFTOccupancyAlpha) and the caller should keep the default 0. A
+// negative value is clamped to 0 (occupancy term disabled) and accepted (ok=true).
+func validateTTFTOccupancyAlpha(raw string) (float64, bool) {
+	v, err := strconv.ParseFloat(strings.TrimSpace(raw), 64)
+	if err != nil || math.IsNaN(v) || math.IsInf(v, 0) {
+		return 0, false
+	}
+	if v < 0 {
+		return 0, true
+	}
+	if v > maxTTFTOccupancyAlpha {
+		return 0, false
+	}
+	return v, true
+}
+
+// validateTTFTDeadlineBaseMs parses and range-checks
+// EIGENINFERENCE_TTFT_DEADLINE_BASE_MS. It returns (baseMs, ok): ok=false means
+// the raw value was unparseable, non-finite, or outside
+// [minTTFTDeadlineBaseMs, maxTTFTDeadlineBaseMs], and the caller should keep the
+// verified ~10s default.
+func validateTTFTDeadlineBaseMs(raw string) (float64, bool) {
+	v, err := strconv.ParseFloat(strings.TrimSpace(raw), 64)
+	if err != nil || math.IsNaN(v) || math.IsInf(v, 0) {
+		return 0, false
+	}
+	if v < minTTFTDeadlineBaseMs || v > maxTTFTDeadlineBaseMs {
+		return 0, false
+	}
+	return v, true
 }
 
 // loadAPNsAttestor builds the production APNs code-identity attestor from the

--- a/coordinator/cmd/coordinator/main.go
+++ b/coordinator/cmd/coordinator/main.go
@@ -383,6 +383,52 @@ func main() {
 		}
 	}
 
+	// Routing (Phase-0 TTFT-contention, shadow + measurement slice). All three
+	// knobs are behavior-neutral at their defaults:
+	//
+	//   - EIGENINFERENCE_TTFT_OCCUPANCY_ALPHA (float, default 0): coefficient of
+	//     the occupancy term added to the TTFT estimate (ttftMsFromSnapshot). 0
+	//     leaves the estimate — and therefore the routing cost's TTFTMs, the
+	//     candidate-loop ceiling, and the preflight bestTTFT — byte-for-byte the
+	//     pre-Phase-0 value. Reuses the occupancy the snapshot already tracks
+	//     (max(pendingForModel, backend_running+backend_waiting)); herd-aware.
+	//   - EIGENINFERENCE_TTFT_DEADLINE_BASE_MS (float, default 10000): the SLA
+	//     base the shadow evaluator gates against. The verified OpenRouter SLA is
+	//     ~10s+1ms/token; the live consumer.go ttftDeadline (5s base) is left
+	//     untouched. Used ONLY by the shadow evaluator.
+	//   - EIGENINFERENCE_TTFT_ADMISSION_MODE (off|shadow|enforce, default off):
+	//     off => no evaluation; shadow/enforce => compute would_shed +
+	//     would_redirect_to_idle and emit routing.ttft_admission /
+	//     routing.ttft_spread WITHOUT changing the routing decision. enforce is
+	//     reserved for a future step that would actually shed; it currently
+	//     behaves like shadow.
+	if v := os.Getenv("EIGENINFERENCE_TTFT_OCCUPANCY_ALPHA"); v != "" {
+		if alpha, err := strconv.ParseFloat(v, 64); err == nil && alpha >= 0 {
+			registry.SetTTFTOccupancyAlpha(alpha)
+			logger.Info("TTFT occupancy term configured via EIGENINFERENCE_TTFT_OCCUPANCY_ALPHA", "alpha", alpha, "behavior_neutral", alpha == 0)
+		} else {
+			logger.Warn("invalid EIGENINFERENCE_TTFT_OCCUPANCY_ALPHA; ignoring", "value", v)
+		}
+	}
+	if v := os.Getenv("EIGENINFERENCE_TTFT_DEADLINE_BASE_MS"); v != "" {
+		if base, err := strconv.ParseFloat(v, 64); err == nil && base > 0 {
+			registry.SetTTFTDeadlineBaseMs(base)
+			logger.Info("TTFT shadow deadline base configured via EIGENINFERENCE_TTFT_DEADLINE_BASE_MS", "base_ms", base)
+		} else {
+			logger.Warn("invalid EIGENINFERENCE_TTFT_DEADLINE_BASE_MS; ignoring", "value", v)
+		}
+	}
+	if v := os.Getenv("EIGENINFERENCE_TTFT_ADMISSION_MODE"); v != "" {
+		mode := registry.ParseTTFTAdmissionMode(v)
+		registry.SetTTFTAdmissionMode(mode)
+		if mode == registry.TTFTAdmissionOff {
+			logger.Info("TTFT admission shadow evaluation OFF (EIGENINFERENCE_TTFT_ADMISSION_MODE)", "value", v)
+		} else {
+			logger.Warn("TTFT admission shadow evaluation ENABLED (measurement only — no decision change)",
+				"mode", mode.String(), "deadline_base_ms", registry.TTFTDeadlineBaseMs(), "occupancy_alpha", registry.TTFTOccupancyAlpha())
+		}
+	}
+
 	// Routing: long-prompt fastest-tier preference. Very long prompts
 	// have a long prefill window that drives pre-first-token client cancellations
 	// (client_gone). When EIGENINFERENCE_LONG_PROMPT_TOKENS is set, the scheduler

--- a/coordinator/cmd/coordinator/main_test.go
+++ b/coordinator/cmd/coordinator/main_test.go
@@ -1,6 +1,9 @@
 package main
 
-import "testing"
+import (
+	"math"
+	"testing"
+)
 
 // TestParseAPNsEnforceAfter verifies the security-relevant contract: unset is the
 // safe grace default, a valid RFC3339 value parses, and a NON-EMPTY malformed
@@ -20,5 +23,71 @@ func TestParseAPNsEnforceAfter(t *testing.T) {
 	t.Setenv("APNS_ENFORCE_AFTER", "tomorrow-ish")
 	if _, err := parseAPNsEnforceAfter(); err == nil {
 		t.Fatal("a malformed value must return an error, not silently fall back to grace")
+	}
+}
+
+// TestValidateTTFTOccupancyAlpha pins the env bounds: valid values apply,
+// negatives clamp to 0 (term off), and unparseable / non-finite / absurd values
+// are rejected so the caller keeps the safe default 0.
+func TestValidateTTFTOccupancyAlpha(t *testing.T) {
+	cases := []struct {
+		in       string
+		wantVal  float64
+		wantOK   bool
+		wantName string
+	}{
+		{"0", 0, true, "zero (behavior-neutral default)"},
+		{"45", 45, true, "typical configured value"},
+		{"1000000", 1_000_000, true, "exactly the max"},
+		{" 12.5 ", 12.5, true, "trimmed float"},
+		{"-1", 0, true, "negative clamps to 0"},
+		{"1000000.0001", 0, false, "above max → reject"},
+		{"1e9", 0, false, "absurd → reject"},
+		{"NaN", 0, false, "non-finite → reject"},
+		{"Inf", 0, false, "non-finite → reject"},
+		{"abc", 0, false, "unparseable → reject"},
+		{"", 0, false, "empty → reject"},
+	}
+	for _, c := range cases {
+		gotVal, gotOK := validateTTFTOccupancyAlpha(c.in)
+		if gotOK != c.wantOK || gotVal != c.wantVal {
+			t.Errorf("validateTTFTOccupancyAlpha(%q) [%s] = (%v, %v), want (%v, %v)",
+				c.in, c.wantName, gotVal, gotOK, c.wantVal, c.wantOK)
+		}
+	}
+}
+
+// TestValidateTTFTDeadlineBaseMs pins the env range [1000, 120000] ms; values
+// outside it (or unparseable/non-finite) are rejected so the caller keeps the
+// verified ~10s default.
+func TestValidateTTFTDeadlineBaseMs(t *testing.T) {
+	cases := []struct {
+		in      string
+		wantVal float64
+		wantOK  bool
+	}{
+		{"10000", 10000, true},
+		{"1000", 1000, true},       // lower bound inclusive
+		{"120000", 120000, true},   // upper bound inclusive
+		{"5000", 5000, true},       //
+		{"999", 0, false},          // below min
+		{"120000.5", 0, false},     // above max
+		{"0", 0, false},            // zero rejected
+		{"-1", 0, false},           // negative rejected
+		{"NaN", 0, false},          // non-finite
+		{"Inf", 0, false},          // non-finite
+		{"not-a-number", 0, false}, // unparseable
+		{"", 0, false},             // empty
+	}
+	for _, c := range cases {
+		gotVal, gotOK := validateTTFTDeadlineBaseMs(c.in)
+		if gotOK != c.wantOK || gotVal != c.wantVal {
+			t.Errorf("validateTTFTDeadlineBaseMs(%q) = (%v, %v), want (%v, %v)",
+				c.in, gotVal, gotOK, c.wantVal, c.wantOK)
+		}
+	}
+	// Sanity: the bounds constants are coherent.
+	if minTTFTDeadlineBaseMs >= maxTTFTDeadlineBaseMs || math.IsNaN(maxTTFTOccupancyAlpha) {
+		t.Fatal("TTFT bound constants are incoherent")
 	}
 }

--- a/coordinator/registry/config.go
+++ b/coordinator/registry/config.go
@@ -37,6 +37,13 @@ type QualityCapConfig struct {
 	// little per-request TPS for ~double pool capacity. The decode floor + load
 	// factor are shared with the warm-pool target math (WarmPool.DecodeFloorTPS,
 	// effectiveTPSLoadFactor) so admission and planning cannot drift.
+	//
+	// Settable via EIGENINFERENCE_QUALITY_CONCURRENCY_OVERCOMMIT (parsed below).
+	// The TTFT-contention plan stages this DOWN 2.0 -> 1.5 -> 1.0 (one step per
+	// observation window) once the occupancy estimate + shadow are validated:
+	// 2.0 lets a fast model's quality cap reach ~4 (the gpt-oss cancel knee), so
+	// tightening toward 1.0 is the existing occupancy SHEDDER for the high-b tail.
+	// Kept at 2.0 by default here — no behavior change until an operator stages it.
 	Overcommit float64
 }
 

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -195,11 +195,13 @@ type PendingRequest struct {
 	// Timing fields for latency decomposition. Written and read by the
 	// consumer/dispatch goroutine that owns the request. The reputation latency
 	// sample is recorded from that goroutine at commit (see
-	// dispatch.writeCommittedResponse). The ONE field the provider read-loop
-	// goroutine (handleComplete) also needs — FirstChunkAt, for the routing
-	// telemetry decode-throughput metric — must be accessed via
-	// MarkFirstChunkArrived / FirstChunkAtSafe, which guard it with timingMu so
-	// that cross-goroutine access is race-free. All other Timing fields remain
+	// dispatch.writeCommittedResponse). The TWO fields the provider read-loop
+	// goroutine (handleComplete) also needs — FirstChunkAt (X-Timing
+	// provider-first-byte diagnostic + decode-throughput metric) and
+	// FirstContentAt (the delivered-content actual_ttft_ms metric) — must be
+	// accessed via MarkFirstChunkArrived/FirstChunkAtSafe and
+	// MarkFirstContentArrived/FirstContentAtSafe, which guard them with timingMu
+	// so cross-goroutine access is race-free. All other Timing fields remain
 	// dispatch-goroutine-only.
 	Timing   *RequestTiming
 	timingMu sync.Mutex
@@ -230,6 +232,36 @@ func (pr *PendingRequest) FirstChunkAtSafe() time.Time {
 	pr.timingMu.Lock()
 	defer pr.timingMu.Unlock()
 	return pr.Timing.FirstChunkAt
+}
+
+// MarkFirstContentArrived stamps Timing.FirstContentAt to now exactly once,
+// under timingMu. The dispatch goroutine calls this when the first CONTENT-
+// bearing chunk is committed to the client, so the provider read-loop goroutine
+// (handleComplete, via the route-telemetry actual_ttft_ms metric) can read the
+// value via FirstContentAtSafe without a data race. Mirrors
+// MarkFirstChunkArrived.
+func (pr *PendingRequest) MarkFirstContentArrived() {
+	if pr == nil || pr.Timing == nil {
+		return
+	}
+	pr.timingMu.Lock()
+	if pr.Timing.FirstContentAt.IsZero() {
+		pr.Timing.FirstContentAt = time.Now()
+	}
+	pr.timingMu.Unlock()
+}
+
+// FirstContentAtSafe returns Timing.FirstContentAt under timingMu. It is the
+// only safe way for a goroutine other than the request owner (e.g. the provider
+// read-loop running handleComplete) to read FirstContentAt. Mirrors
+// FirstChunkAtSafe.
+func (pr *PendingRequest) FirstContentAtSafe() time.Time {
+	if pr == nil || pr.Timing == nil {
+		return time.Time{}
+	}
+	pr.timingMu.Lock()
+	defer pr.timingMu.Unlock()
+	return pr.Timing.FirstContentAt
 }
 
 type TokenAdmission struct {

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -205,6 +205,16 @@ type PendingRequest struct {
 	// dispatch-goroutine-only.
 	Timing   *RequestTiming
 	timingMu sync.Mutex
+	// contentCommitted marks THIS attempt as the one that delivered its first
+	// content chunk to the client (set by commitFirstContent / the generic
+	// first-content stamp, in the dispatch/handler goroutine). It distinguishes the
+	// committed attempt from abandoned/retried attempts that SHARE the same Timing
+	// pointer. handleComplete's fallback reads it (ContentCommittedSafe) so a
+	// late-completing abandoned attempt can never stamp FirstContentAt on the
+	// shared Timing and corrupt the committed attempt's actual_ttft_ms. Guarded by
+	// timingMu (written in the dispatch/handler goroutine, read in the provider
+	// read-loop goroutine).
+	contentCommitted bool
 }
 
 // MarkFirstChunkArrived stamps Timing.FirstChunkAt to now exactly once, under
@@ -262,6 +272,33 @@ func (pr *PendingRequest) FirstContentAtSafe() time.Time {
 	pr.timingMu.Lock()
 	defer pr.timingMu.Unlock()
 	return pr.Timing.FirstContentAt
+}
+
+// MarkContentCommitted records that THIS attempt committed its first content
+// chunk to the client. Set once, under timingMu, by the dispatch/handler
+// goroutine (commitFirstContent / the generic first-content stamp). See the
+// contentCommitted field for why it is per-attempt rather than on the shared
+// Timing.
+func (pr *PendingRequest) MarkContentCommitted() {
+	if pr == nil {
+		return
+	}
+	pr.timingMu.Lock()
+	pr.contentCommitted = true
+	pr.timingMu.Unlock()
+}
+
+// ContentCommittedSafe reports whether THIS attempt committed its first content,
+// read under timingMu. It is the safe way for the provider read-loop goroutine
+// (handleComplete) to verify the completing attempt is the committed one before
+// stamping shared-Timing fields.
+func (pr *PendingRequest) ContentCommittedSafe() bool {
+	if pr == nil {
+		return false
+	}
+	pr.timingMu.Lock()
+	defer pr.timingMu.Unlock()
+	return pr.contentCommitted
 }
 
 type TokenAdmission struct {

--- a/coordinator/registry/scheduler.go
+++ b/coordinator/registry/scheduler.go
@@ -282,7 +282,10 @@ func (r *Registry) ReserveProviderEx(model string, pr *PendingRequest, excludeID
 	// excludes the request we are about to admit. No-op (zero value) when the
 	// admission mode is off — keeping default behavior byte-for-byte. Attached to
 	// the success decision below; discarded if the admit re-check rejects.
-	shadowEval := r.evaluateTTFTShadowLocked(model, pr, selected)
+	// excludeIDs is threaded through so the idle-spread scan honors the SAME
+	// retry/speculative-backup exclusions the selector applied (an excluded
+	// provider is not a routable spread alternative).
+	shadowEval := r.evaluateTTFTShadowLocked(model, pr, selected, excludeIDs...)
 
 	p := selected.provider
 	p.mu.Lock()

--- a/coordinator/registry/scheduler.go
+++ b/coordinator/registry/scheduler.go
@@ -424,15 +424,34 @@ func shouldBypassBreakerFailOpen(winner *routingCandidate, breakerRejected, capa
 	return winner == nil && breakerRejected > 0 && capacityRejections == 0 && ttftRejections == 0
 }
 
-// selectBestCandidateScanLocked is one pass of candidate selection. When
-// ignoreProviderBreaker is true the node-health breaker gate is skipped
-// (every other structural/privacy/capacity/trait gate still applies). It
-// additionally returns breakerRejected: how many providers were dropped while
-// their node-health breaker was OPEN on this pass — the signal
-// selectBestCandidateLockedFull uses to decide whether a breaker-bypassed
-// fail-open re-scan could help. breakerRejected is always 0 when
-// ignoreProviderBreaker is true (the breaker is not consulted).
-func (r *Registry) selectBestCandidateScanLocked(model string, pr *PendingRequest, ignoreProviderBreaker bool, excludeIDs ...string) (*routingCandidate, int, int, int, int, int, float64, int) {
+// candidateScan is the result of building the eligible candidate pool for a
+// request: the cost-rankable pool (after every per-provider gate AND the
+// post-candidate pool narrowing) plus the rejection tallies and the affinity
+// hint selection needs. It is the SINGLE SOURCE of routing eligibility, shared by
+// the cost-ranking selector (selectBestCandidateScanLocked) and the Phase-0
+// idle-spread shadow scan (loadedIdleAlternativeExistsLocked) so the two can
+// never drift on which providers are routable.
+type candidateScan struct {
+	pool               []*routingCandidate
+	affinityProviderID string
+	candidateCount     int
+	capacityRejections int
+	tooLargeRejections int
+	visionRejections   int
+	ttftRejections     int
+	bestTTFTMs         float64
+	breakerRejected    int
+}
+
+// scanCandidatesLocked builds the eligible candidate pool for a request — every
+// per-provider gate (self-route, allowlist, exclude, structural/trait/trust via
+// snapshotProviderLockedEx, vision, capacity via buildCandidateWithReason, plus
+// the per-request TTFT ceiling) followed by the post-candidate pool narrowing
+// (prefer-owner / AvoidVersion / MinDecodeTPS) — i.e. exactly the set the
+// selector ranks by cost. When ignoreProviderBreaker is true the node-health
+// breaker gate is skipped (every other gate still applies); breakerRejected is
+// always 0 in that mode. Caller holds r.mu and no provider lock.
+func (r *Registry) scanCandidatesLocked(model string, pr *PendingRequest, ignoreProviderBreaker bool, excludeIDs ...string) candidateScan {
 	excludeSet := make(map[string]struct{}, len(excludeIDs))
 	for _, id := range excludeIDs {
 		excludeSet[id] = struct{}{}
@@ -579,10 +598,6 @@ func (r *Registry) selectBestCandidateScanLocked(model string, pr *PendingReques
 		candidateCount++
 	}
 
-	if len(candidates) == 0 {
-		return nil, candidateCount, capacityRejections, tooLargeRejections, visionRejections, ttftRejections, bestTTFTMs, breakerRejected
-	}
-
 	// Prefer-with-fallback: if the caller asked to prefer their own machine and
 	// at least one owned candidate can serve, choose among owned candidates
 	// only; otherwise fall back to the full pool (a public provider, charged
@@ -637,6 +652,35 @@ func (r *Registry) selectBestCandidateScanLocked(model string, pr *PendingReques
 		}
 	}
 
+	return candidateScan{
+		pool:               pool,
+		affinityProviderID: affinityProviderID,
+		candidateCount:     candidateCount,
+		capacityRejections: capacityRejections,
+		tooLargeRejections: tooLargeRejections,
+		visionRejections:   visionRejections,
+		ttftRejections:     ttftRejections,
+		bestTTFTMs:         bestTTFTMs,
+		breakerRejected:    breakerRejected,
+	}
+}
+
+// selectBestCandidateScanLocked is one pass of candidate selection: it builds the
+// eligible pool (scanCandidatesLocked — the single source of eligibility) and
+// ranks it by cost, returning the winner plus the rejection tallies. When
+// ignoreProviderBreaker is true the node-health breaker gate is skipped;
+// breakerRejected (providers dropped while their breaker was OPEN) is the signal
+// selectBestCandidateLockedFull uses to decide whether a breaker-bypassed
+// fail-open re-scan could help, and is always 0 in that mode.
+func (r *Registry) selectBestCandidateScanLocked(model string, pr *PendingRequest, ignoreProviderBreaker bool, excludeIDs ...string) (*routingCandidate, int, int, int, int, int, float64, int) {
+	scan := r.scanCandidatesLocked(model, pr, ignoreProviderBreaker, excludeIDs...)
+	if len(scan.pool) == 0 {
+		return nil, scan.candidateCount, scan.capacityRejections, scan.tooLargeRejections, scan.visionRejections, scan.ttftRejections, scan.bestTTFTMs, scan.breakerRejected
+	}
+	pool := scan.pool
+	affinityProviderID := scan.affinityProviderID
+	candidateCount := scan.candidateCount
+
 	var best *routingCandidate
 	for _, c := range pool {
 		if best == nil || c.costMs < best.costMs {
@@ -685,7 +729,7 @@ func (r *Registry) selectBestCandidateScanLocked(model string, pr *PendingReques
 		}
 	}
 	r.logRoutingDecision(model, pr, winner, candidateCount)
-	return winner, candidateCount, capacityRejections, tooLargeRejections, visionRejections, ttftRejections, bestTTFTMs, breakerRejected
+	return winner, candidateCount, scan.capacityRejections, scan.tooLargeRejections, scan.visionRejections, scan.ttftRejections, scan.bestTTFTMs, scan.breakerRejected
 }
 
 func providerMatchesAllowedSerial(p *Provider, allowed map[string]struct{}) bool {

--- a/coordinator/registry/scheduler.go
+++ b/coordinator/registry/scheduler.go
@@ -219,6 +219,20 @@ type RoutingDecision struct {
 	BestTTFTMs float64
 	// TTFTMs is the estimated time-to-first-token of the selected provider.
 	TTFTMs float64
+
+	// Phase-0 shadow TTFT admission/spread evaluation (see ttft_shadow.go).
+	// Populated ONLY when EIGENINFERENCE_TTFT_ADMISSION_MODE != off and a
+	// provider was selected. Purely observational — it never changes the
+	// selection; the API layer emits routing.ttft_admission / routing.ttft_spread
+	// from these fields so the spread-to-idle opportunity and the would-shed rate
+	// can be measured before any enforce flips them on.
+	ShadowEvaluated             bool
+	ShadowMode                  string
+	ShadowWouldShed             bool
+	ShadowIdleAlternativeExists bool
+	ShadowEstimateMs            float64
+	ShadowDeadlineMs            float64
+	ShadowOccupancy             int
 }
 
 // ReserveProvider selects a hardware-routable provider for the request and
@@ -261,6 +275,14 @@ func (r *Registry) ReserveProviderEx(model string, pr *PendingRequest, excludeID
 			BestTTFTMs:              bestTTFTMs,
 		}
 	}
+
+	// Phase-0 shadow TTFT evaluation: computed here (r.mu held, no provider lock
+	// taken yet, so it can snapshot peer providers one-at-a-time without holding
+	// two p.mu) against the winner's PRE-reserve snapshot, so its occupancy
+	// excludes the request we are about to admit. No-op (zero value) when the
+	// admission mode is off — keeping default behavior byte-for-byte. Attached to
+	// the success decision below; discarded if the admit re-check rejects.
+	shadowEval := r.evaluateTTFTShadowLocked(model, pr, selected)
 
 	p := selected.provider
 	p.mu.Lock()
@@ -341,6 +363,7 @@ func (r *Registry) ReserveProviderEx(model string, pr *PendingRequest, excludeID
 		EffectiveTPS:            selected.effectiveTPS,
 		StaticTPS:               selected.snapshot.decodeTPS,
 	}
+	shadowEval.applyTo(&decision)
 	return p, decision
 }
 
@@ -1142,11 +1165,7 @@ func (r *Registry) buildCandidateWithReason(snap routingSnapshot, pr *PendingReq
 		return nil, rejectCapacity, false
 	}
 
-	effectiveQueue := snap.pendingForModel
-	backendDepth := snap.backendRunning + snap.backendWaiting
-	if backendDepth > effectiveQueue {
-		effectiveQueue = backendDepth
-	}
+	effectiveQueue := snapshotOccupancy(snap)
 
 	waitingBacklogTokens := float64(snap.backendWaiting * reqMax)
 	unaccountedPendingTokens := float64(snap.pendingMaxTokens) - float64(snap.maxTokensPotential) - waitingBacklogTokens
@@ -1335,6 +1354,26 @@ func effectiveDecodeTPS(staticTPS float64, backendRunning int) float64 {
 	return tps
 }
 
+// snapshotOccupancy is the per-(provider,model) in-flight occupancy the
+// coordinator already tracks: max(pendingForModel, backend_running +
+// backend_waiting). pendingForModel is the coordinator's own dispatched-but-not-
+// yet-terminal count (incremented at reserve, held the whole dark-time), so this
+// is herd-aware even when the heartbeat gauge still reads backend_running=0 — no
+// parallel reservation counter is needed. It is the same quantity the routing
+// cost's effectiveQueue and the quality-concurrency cap consume; the Phase-0
+// occupancy-aware TTFT term and the shadow admission/spread evaluator reuse it so
+// every occupancy-keyed decision reads one signal.
+func snapshotOccupancy(snap routingSnapshot) int {
+	occ := snap.pendingForModel
+	if backendDepth := snap.backendRunning + snap.backendWaiting; backendDepth > occ {
+		occ = backendDepth
+	}
+	if occ < 0 {
+		occ = 0
+	}
+	return occ
+}
+
 func resolvedDecodeTPS(p *Provider) float64 {
 	if p.DecodeTPS > 0 {
 		return p.DecodeTPS
@@ -1401,6 +1440,31 @@ func SetPrefillToDecodeRatio(ratio float64) {
 // measured prefill rate). Exposed for the routing simulation harness.
 func PrefillToDecodeRatio() float64 {
 	return prefillToDecodeRatio
+}
+
+// ttftOccupancyAlpha scales the Phase-0 occupancy term in ttftMsFromSnapshot
+// (see ttftOccupancyMs). It is the decode-token-times of head-of-line wait
+// charged per occupying peer, divided by the per-request decode rate the new
+// request would see. 0 (the default) disables the term, so ttftMsFromSnapshot —
+// and therefore the routing cost's TTFTMs, the candidate-loop TTFT ceiling, and
+// the preflight bestTTFT — are all byte-for-byte the pre-Phase-0 estimate.
+// Configured once at startup via SetTTFTOccupancyAlpha
+// (EIGENINFERENCE_TTFT_OCCUPANCY_ALPHA), read-only on routing paths thereafter,
+// mirroring prefillToDecodeRatio.
+var ttftOccupancyAlpha = 0.0
+
+// SetTTFTOccupancyAlpha overrides the occupancy-term coefficient. Negative
+// values are clamped to 0 (term disabled). Must be called before serving starts.
+func SetTTFTOccupancyAlpha(alpha float64) {
+	if alpha < 0 {
+		alpha = 0
+	}
+	ttftOccupancyAlpha = alpha
+}
+
+// TTFTOccupancyAlpha returns the configured occupancy-term coefficient.
+func TTFTOccupancyAlpha() float64 {
+	return ttftOccupancyAlpha
 }
 
 // defaultLongPromptThresholdTokens gates the long-prompt fastest-tier routing
@@ -1834,7 +1898,43 @@ func ttftMsFromSnapshot(snap routingSnapshot, reqPromptTokens int) float64 {
 	queuedPrefillMs := queuedPrefillTokensAhead(snap, reqPromptTokens) / prefillTPS * 1000.0
 	thisPrefillMs := float64(reqPromptTokens) / prefillTPS * 1000.0
 	firstDecodeMs := 1000.0 / effectiveTPS
-	return statePenalty + queuedPrefillMs + thisPrefillMs + firstDecodeMs
+	return statePenalty + queuedPrefillMs + thisPrefillMs + firstDecodeMs + ttftOccupancyMs(snap)
+}
+
+// ttftOccupancyMs is the Phase-0 occupancy term added to the TTFT estimate: the
+// head-of-line wait while the box's already-occupying work (the herd) clears
+// enough for a newly admitted request to emit its first token. The old estimate
+// counted only WAITING prefill and a single decode step, so it was flat in
+// running occupancy — exactly where the ~11s of "dark time" lives.
+//
+// The term reuses the occupancy the snapshot ALREADY carries
+// (snapshotOccupancy = max(pendingForModel, backend_running+backend_waiting)),
+// not a new parallel counter, so it is herd-aware for free: a burst onto a box
+// still reporting backend_running=0 shows up through pendingForModel. Magnitude
+// per occupying peer is alpha decode-token-times divided by
+// projectedPerRequestDecodeTPS (the rate the new request sees at b+1), which
+// makes it super-linear in backend_running (the rate itself shrinks with b).
+//
+// Returns 0 when EIGENINFERENCE_TTFT_OCCUPANCY_ALPHA is 0 (the default →
+// byte-for-byte the pre-Phase-0 estimate) or occupancy is 0 (an idle box never
+// pays the term, so route-to-idle is preserved). The deadline this is gated
+// against in the shadow evaluator is the verified ~10s base, NOT the code's 5s
+// internal budget; gating an occupancy estimate fit to the 5s base over-sheds
+// ~2x (telemetry-db findings §2).
+func ttftOccupancyMs(snap routingSnapshot) float64 {
+	alpha := ttftOccupancyAlpha
+	if alpha <= 0 {
+		return 0
+	}
+	occ := snapshotOccupancy(snap)
+	if occ <= 0 {
+		return 0
+	}
+	perReqDecodeTPS := projectedPerRequestDecodeTPS(snap)
+	if perReqDecodeTPS <= 0 {
+		perReqDecodeTPS = 1.0
+	}
+	return alpha * float64(occ) * 1000.0 / perReqDecodeTPS
 }
 
 func queuedPrefillTokensAhead(snap routingSnapshot, reqPromptTokens int) float64 {

--- a/coordinator/registry/scheduler.go
+++ b/coordinator/registry/scheduler.go
@@ -1442,15 +1442,18 @@ func PrefillToDecodeRatio() float64 {
 	return prefillToDecodeRatio
 }
 
-// ttftOccupancyAlpha scales the Phase-0 occupancy term in ttftMsFromSnapshot
-// (see ttftOccupancyMs). It is the decode-token-times of head-of-line wait
-// charged per occupying peer, divided by the per-request decode rate the new
-// request would see. 0 (the default) disables the term, so ttftMsFromSnapshot —
-// and therefore the routing cost's TTFTMs, the candidate-loop TTFT ceiling, and
-// the preflight bestTTFT — are all byte-for-byte the pre-Phase-0 estimate.
-// Configured once at startup via SetTTFTOccupancyAlpha
-// (EIGENINFERENCE_TTFT_OCCUPANCY_ALPHA), read-only on routing paths thereafter,
-// mirroring prefillToDecodeRatio.
+// ttftOccupancyAlpha scales the Phase-0 occupancy term (see ttftOccupancyMs),
+// which is added ONLY inside occupancyAwareTTFTMsFromSnapshot — the shadow
+// evaluator's estimate — NEVER inside the live ttftMsFromSnapshot. It is the
+// decode-token-times of head-of-line wait charged per occupying peer, divided by
+// the per-request decode rate the new request would see. Because the term never
+// reaches ttftMsFromSnapshot, the routing cost's TTFTMs, the candidate-loop
+// MaxTTFTMs ceiling, and the preflight bestTTFT are occupancy-free at ANY alpha:
+// raising alpha changes only the shadow signal, not the live routing decision
+// (the HARD_REJECT safety invariant — see occupancyAwareTTFTMsFromSnapshot). 0
+// (the default) also makes ttftOccupancyMs itself a no-op. Configured once at
+// startup via SetTTFTOccupancyAlpha (EIGENINFERENCE_TTFT_OCCUPANCY_ALPHA),
+// read-only on routing paths thereafter, mirroring prefillToDecodeRatio.
 var ttftOccupancyAlpha = 0.0
 
 // SetTTFTOccupancyAlpha overrides the occupancy-term coefficient. Negative
@@ -1565,20 +1568,38 @@ func resolvedPrefillTPS(p *Provider) float64 {
 // reapplied at b+1; otherwise the static benchmark is the solo proxy. Used by the
 // decode-floor quality preference (PendingRequest.MinDecodeTPS).
 func projectedPerRequestDecodeTPS(snap routingSnapshot) float64 {
+	return projectedPerRequestDecodeTPSAtBatch(snap, snap.backendRunning)
+}
+
+// projectedPerRequestDecodeTPSAtBatch is projectedPerRequestDecodeTPS with an
+// EXPLICIT batch the new request would join, used when the heartbeat gauge
+// (backend_running) understates real contention. The observed-rate UNWIND always
+// uses the batch the observation was actually taken at (snap.backendRunning —
+// the heartbeat's observedDecodeTPS pairs with that gauge), while the REAPPLY
+// uses joinBatch. Passing joinBatch == snap.backendRunning reproduces the
+// original result exactly, so the decode-floor caller is byte-for-byte unchanged;
+// the occupancy term passes joinBatch == occ so a herd that has already reserved
+// peers the heartbeat has not yet reflected (occ > backend_running) is charged at
+// the contended rate it will actually see — not the idle/low-batch rate.
+func projectedPerRequestDecodeTPSAtBatch(snap routingSnapshot, joinBatch int) float64 {
 	k := effectiveTPSLoadFactor
 	if k < 0 {
 		k = 0
 	}
-	b := snap.backendRunning
-	if b < 0 {
-		b = 0
+	bObserved := snap.backendRunning
+	if bObserved < 0 {
+		bObserved = 0
+	}
+	if joinBatch < 0 {
+		joinBatch = 0
 	}
 	// Solo (b=0) decode-rate base, durable 3-tier chain:
 	solo := snap.decodeTPS // tier 3: static benchmark (last resort)
 	switch {
 	case snap.observedDecodeTPS > 0:
-		// tier 1: this box's own LIVE measured rate, unwound from batch b to solo.
-		solo = snap.observedDecodeTPS * (1 + k*float64(b))
+		// tier 1: this box's own LIVE measured rate, unwound from the batch it
+		// was measured at (bObserved) to solo.
+		solo = snap.observedDecodeTPS * (1 + k*float64(bObserved))
 	case decodeFloorUseFleetMedian() && snap.fleetMedianTPS > 0:
 		// tier 2: durable per-(model,chip) observed median from the tps registry.
 		// Exists even when this box is IDLE, so a historically-slow chip (e.g. the
@@ -1591,7 +1612,7 @@ func projectedPerRequestDecodeTPS(snap routingSnapshot) float64 {
 	if solo <= 0 {
 		return 0
 	}
-	return solo / (1 + k*float64(b+1))
+	return solo / (1 + k*float64(joinBatch+1))
 }
 
 // decodeFloorUseFleetMedian gates the tier-2 (fleet-median) solo-rate source in
@@ -1898,29 +1919,60 @@ func ttftMsFromSnapshot(snap routingSnapshot, reqPromptTokens int) float64 {
 	queuedPrefillMs := queuedPrefillTokensAhead(snap, reqPromptTokens) / prefillTPS * 1000.0
 	thisPrefillMs := float64(reqPromptTokens) / prefillTPS * 1000.0
 	firstDecodeMs := 1000.0 / effectiveTPS
-	return statePenalty + queuedPrefillMs + thisPrefillMs + firstDecodeMs + ttftOccupancyMs(snap)
+	// NOTE: the Phase-0 occupancy term (ttftOccupancyMs) is deliberately NOT added
+	// here. ttftMsFromSnapshot is the LIVE estimate consumed by the routing cost's
+	// TTFTMs, the candidate-loop MaxTTFTMs ceiling, and the preflight bestTTFT — so
+	// it must stay occupancy-FREE regardless of EIGENINFERENCE_TTFT_OCCUPANCY_ALPHA.
+	// The occupancy-aware estimate (base + occupancy term) lives in
+	// occupancyAwareTTFTMsFromSnapshot and is used ONLY by the shadow evaluator.
+	return statePenalty + queuedPrefillMs + thisPrefillMs + firstDecodeMs
 }
 
-// ttftOccupancyMs is the Phase-0 occupancy term added to the TTFT estimate: the
-// head-of-line wait while the box's already-occupying work (the herd) clears
-// enough for a newly admitted request to emit its first token. The old estimate
-// counted only WAITING prefill and a single decode step, so it was flat in
-// running occupancy — exactly where the ~11s of "dark time" lives.
+// occupancyAwareTTFTMsFromSnapshot is the occupancy-aware TTFT estimate: the base
+// estimate (ttftMsFromSnapshot — what the LIVE cost / MaxTTFTMs ceiling / bestTTFT
+// consume) PLUS the Phase-0 head-of-line occupancy term (ttftOccupancyMs, gated by
+// EIGENINFERENCE_TTFT_OCCUPANCY_ALPHA).
+//
+// It is used ONLY by the shadow evaluator today; a future enforce step will wire
+// it (against the verified ~10s base) into the live path. Keeping the occupancy
+// term OUT of ttftMsFromSnapshot is a SAFETY INVARIANT: prod runs HARD_REJECT
+// (pr.MaxTTFTMs set from the 5s ttftDeadline), so if the term leaked into
+// ttftMsFromSnapshot, raising alpha would tighten the live 5s ceiling and
+// over-shed ~2x (telemetry-db findings §2). The term may therefore only ever
+// reach the shadow estimate, never breakdown.TTFTMs.
+func occupancyAwareTTFTMsFromSnapshot(snap routingSnapshot, reqPromptTokens int) float64 {
+	base := ttftMsFromSnapshot(snap, reqPromptTokens)
+	if base <= 0 {
+		// No reliable base (provider without BackendCapacity) → no occupancy-aware
+		// estimate either, matching ttftMsFromSnapshot's contract.
+		return base
+	}
+	return base + ttftOccupancyMs(snap)
+}
+
+// ttftOccupancyMs is the Phase-0 occupancy term: the head-of-line wait while the
+// box's already-occupying work (the herd) clears enough for a newly admitted
+// request to emit its first token. The base estimate (ttftMsFromSnapshot) counts
+// only WAITING prefill and a single decode step, so it is flat in running
+// occupancy — exactly where the ~11s of "dark time" lives. It is added ONLY in
+// occupancyAwareTTFTMsFromSnapshot (the shadow estimate), never in the live
+// ttftMsFromSnapshot.
 //
 // The term reuses the occupancy the snapshot ALREADY carries
 // (snapshotOccupancy = max(pendingForModel, backend_running+backend_waiting)),
 // not a new parallel counter, so it is herd-aware for free: a burst onto a box
 // still reporting backend_running=0 shows up through pendingForModel. Magnitude
-// per occupying peer is alpha decode-token-times divided by
-// projectedPerRequestDecodeTPS (the rate the new request sees at b+1), which
-// makes it super-linear in backend_running (the rate itself shrinks with b).
+// per occupying peer is alpha decode-token-times divided by the per-request
+// decode rate the new request will actually see — projected at the SAME occupancy
+// (occ), not the stale backend_running gauge, so in the herd case (pendingForModel
+// > backend_running) it is charged the contended rate, not an idle-batch rate.
+// The rate itself shrinks with occ, making the term super-linear in occupancy.
 //
-// Returns 0 when EIGENINFERENCE_TTFT_OCCUPANCY_ALPHA is 0 (the default →
-// byte-for-byte the pre-Phase-0 estimate) or occupancy is 0 (an idle box never
-// pays the term, so route-to-idle is preserved). The deadline this is gated
-// against in the shadow evaluator is the verified ~10s base, NOT the code's 5s
-// internal budget; gating an occupancy estimate fit to the 5s base over-sheds
-// ~2x (telemetry-db findings §2).
+// Returns 0 when EIGENINFERENCE_TTFT_OCCUPANCY_ALPHA is 0 (the default) or
+// occupancy is 0 (an idle box never pays the term, so route-to-idle is
+// preserved). The deadline this is gated against in the shadow evaluator is the
+// verified ~10s base, NOT the code's 5s internal budget; gating an occupancy
+// estimate fit to the 5s base over-sheds ~2x (telemetry-db findings §2).
 func ttftOccupancyMs(snap routingSnapshot) float64 {
 	alpha := ttftOccupancyAlpha
 	if alpha <= 0 {
@@ -1930,7 +1982,11 @@ func ttftOccupancyMs(snap routingSnapshot) float64 {
 	if occ <= 0 {
 		return 0
 	}
-	perReqDecodeTPS := projectedPerRequestDecodeTPS(snap)
+	// Project the per-request rate at the batch the request ACTUALLY joins (occ),
+	// not the bare heartbeat backend_running: in the herd case the new request
+	// waits behind occ peers, so charging the idle/low-batch rate would under-
+	// state the term in exactly the case it exists to catch.
+	perReqDecodeTPS := projectedPerRequestDecodeTPSAtBatch(snap, occ)
 	if perReqDecodeTPS <= 0 {
 		perReqDecodeTPS = 1.0
 	}

--- a/coordinator/registry/ttft_shadow.go
+++ b/coordinator/registry/ttft_shadow.go
@@ -10,10 +10,13 @@ import "strings"
 // it computes two signals against the winning candidate and hands them to the
 // caller as fields on RoutingDecision, which the API layer emits as metrics.
 //
-//   - WouldShed: the occupancy-aware TTFT estimate (ttftMsFromSnapshot, which is
-//     occupancy-aware only when EIGENINFERENCE_TTFT_OCCUPANCY_ALPHA > 0) for the
-//     chosen provider exceeds the verified ~10s deadline base (NOT the code's 5s
-//     internal budget — gating at 5s over-sheds ~2x per telemetry-db findings §2).
+//   - WouldShed: the occupancy-aware TTFT estimate
+//     (occupancyAwareTTFTMsFromSnapshot = base + the occupancy term, which is
+//     non-zero only when EIGENINFERENCE_TTFT_OCCUPANCY_ALPHA > 0) for the chosen
+//     provider exceeds the verified ~10s deadline base (NOT the code's 5s internal
+//     budget — gating at 5s over-sheds ~2x per telemetry-db findings §2). The
+//     occupancy term is intentionally confined to this shadow estimate so it can
+//     never tighten the live HARD_REJECT ceiling fed by ttftMsFromSnapshot.
 //   - IdleAlternativeExists: the chosen provider already carries occupying peers
 //     while an instantly-usable (loaded, zero-occupancy) provider for the same
 //     model was routable — the load-SPREADING failure the data shows (idle loaded
@@ -159,7 +162,11 @@ func (r *Registry) evaluateTTFTShadowLocked(model string, pr *PendingRequest, wi
 		reqPrompt = 0
 	}
 	snap := winner.snapshot
-	estimate := ttftMsFromSnapshot(snap, reqPrompt)
+	// Occupancy-aware estimate (base + occupancy term). The occupancy term lives
+	// here, in the SHADOW path only — ttftMsFromSnapshot (the live cost / ceiling /
+	// bestTTFT input) stays occupancy-free so raising alpha cannot tighten the
+	// live 5s HARD_REJECT ceiling. See occupancyAwareTTFTMsFromSnapshot.
+	estimate := occupancyAwareTTFTMsFromSnapshot(snap, reqPrompt)
 	deadline := ttftDeadlineMsForPrompt(reqPrompt)
 	occ := snapshotOccupancy(snap)
 
@@ -186,10 +193,14 @@ func (r *Registry) evaluateTTFTShadowLocked(model string, pr *PendingRequest, wi
 
 // loadedIdleAlternativeExistsLocked reports whether some provider OTHER than the
 // winner is a routable, model-resident, zero-occupancy candidate for model — an
-// instantly-usable box the herded request could have been spread to. It mirrors
-// selection's owner/self-route filtering and reuses snapshotProviderLockedEx so
-// it counts only providers that pass the same routing gates. Caller holds r.mu
-// and no provider lock.
+// instantly-usable box the herded request could have been spread to. It applies
+// the SAME gates the scheduler's selection loop does so it cannot report a peer
+// the scheduler would have rejected (which would corrupt the Phase-0 spread
+// metric): structural gates + owner/self-route filtering (snapshotProviderLockedEx),
+// the vision-capability gate (providerServesVisionModelLocked, for media
+// requests), and the capacity / token-budget / hardware-fit feasibility predicate
+// (buildCandidateWithReason — the exact check the selection loop runs). Caller
+// holds r.mu and no provider lock.
 func (r *Registry) loadedIdleAlternativeExistsLocked(model string, pr *PendingRequest, winner *Provider) bool {
 	winnerID := ""
 	if winner != nil {
@@ -208,9 +219,31 @@ func (r *Registry) loadedIdleAlternativeExistsLocked(model string, pr *PendingRe
 		if !ok || !snap.modelLoaded {
 			continue
 		}
-		if snapshotOccupancy(snap) == 0 {
-			return true
+		// A spread target must be instantly usable — model resident AND
+		// unoccupied. Filter occupied peers before the costlier gates below.
+		if snapshotOccupancy(snap) != 0 {
+			continue
 		}
+		// Vision gate: a media request must only count a vision-capable peer, or
+		// the scheduler would have rejected it (visionRejections) and the spread
+		// signal would be a false positive. snapshotProviderLockedEx released p.mu,
+		// so re-take it for the p.Models read (mirrors the selection loop).
+		if pr.RequiresVision {
+			p.mu.Lock()
+			servesVision := r.providerServesVisionModelLocked(p, model)
+			p.mu.Unlock()
+			if !servesVision {
+				continue
+			}
+		}
+		// Capacity / token-budget / hardware-fit feasibility — the same predicate
+		// the selection loop applies via buildCandidateWithReason. Without it an
+		// oversized-token or memory-starved peer would be counted as a valid idle
+		// alternative the scheduler could never actually have selected.
+		if _, _, admissible := r.buildCandidateWithReason(snap, pr); !admissible {
+			continue
+		}
+		return true
 	}
 	return false
 }

--- a/coordinator/registry/ttft_shadow.go
+++ b/coordinator/registry/ttft_shadow.go
@@ -197,93 +197,34 @@ func (r *Registry) evaluateTTFTShadowLocked(model string, pr *PendingRequest, wi
 }
 
 // loadedIdleAlternativeExistsLocked reports whether some provider OTHER than the
-// winner is a routable, model-resident, zero-occupancy candidate for model — an
-// instantly-usable box the herded request could have been spread to.
+// winner is an instantly-usable (model-resident, zero-occupancy) spread target
+// the herded request could have been routed to instead.
 //
-// It applies the SAME per-provider eligibility the scheduler's selection scan
-// (selectBestCandidateScanLocked) applies, in the same order and using the same
-// helpers, so the Phase-0 spread metric can never count a peer the selector would
-// have rejected. The correspondence (keep in sync with the selection loop):
-//
-//   - winner / excludeIDs skip      → the selector's excludeSet (retry +
-//     speculative-backup exclusions) plus the already-reserved winner.
-//   - self-route owner gate         → `pr.SelfRouteOnly && !owned`.
-//   - provider allowlist            → `providerMatchesAllowedSerial`.
-//   - prefer-owner POOL restriction → when prefer-owner selected an OWNED winner,
-//     the selector's pool was owned-only, so a public peer is not a real
-//     alternative (mirrors the owned-pool block after candidate collection).
-//   - structural / trait / trust gates → `snapshotProviderLockedEx`.
-//   - instantly-usable              → model resident AND zero occupancy.
-//   - vision capability             → `providerServesVisionModelLocked`.
-//   - capacity / token-budget / fit → `buildCandidateWithReason`.
-//
-// Caller holds r.mu and no provider lock.
+// It derives eligibility from the SAME computation the selector uses
+// (scanCandidatesLocked — the single source of routing eligibility: every
+// per-provider gate AND the post-candidate pool narrowing, i.e.
+// exclude/self-route/allowlist/vision/capacity/TTFT-ceiling + prefer-owner +
+// AvoidVersion + MinDecodeTPS), then checks whether any resulting eligible
+// candidate other than the winner is loaded-idle. Because it reuses the
+// selector's pool rather than re-deriving the gates, the Phase-0 spread metric
+// can never count a peer the scheduler would have rejected. Caller holds r.mu and
+// no provider lock.
 func (r *Registry) loadedIdleAlternativeExistsLocked(model string, pr *PendingRequest, winner *Provider, excludeIDs ...string) bool {
 	winnerID := ""
 	if winner != nil {
 		winnerID = winner.ID
 	}
-	excludeSet := make(map[string]struct{}, len(excludeIDs))
-	for _, id := range excludeIDs {
-		excludeSet[id] = struct{}{}
-	}
-	allowedSerials := make(map[string]struct{}, len(pr.AllowedProviderSerials))
-	for _, serial := range pr.AllowedProviderSerials {
-		allowedSerials[serial] = struct{}{}
-	}
-	// Prefer-owner restricts the selector's pool to OWNED candidates whenever an
-	// owned candidate can serve — and the winner being owned is exactly that
-	// signal (prefer-owner picks from the owned pool when it is non-empty). So a
-	// public peer is only a real alternative when the winner itself is public.
-	winnerOwnedPool := pr.PreferOwner && providerOwnedBy(winner, pr.OwnerAccountID)
-
-	for _, p := range r.providers {
-		if p == nil || p.ID == winnerID {
+	scan := r.scanCandidatesLocked(model, pr, false, excludeIDs...)
+	for _, c := range scan.pool {
+		if c.provider == nil || c.provider.ID == winnerID {
 			continue
 		}
-		if _, excluded := excludeSet[p.ID]; excluded {
-			continue
+		// Instantly usable: the model is resident AND no work is occupying the box
+		// (a herded peer is not a spread target). The candidate already passed
+		// every selection gate via scanCandidatesLocked.
+		if c.snapshot.modelLoaded && snapshotOccupancy(c.snapshot) == 0 {
+			return true
 		}
-		owned := providerOwnedBy(p, pr.OwnerAccountID)
-		if pr.SelfRouteOnly && !owned {
-			continue
-		}
-		if len(allowedSerials) > 0 && !providerMatchesAllowedSerial(p, allowedSerials) {
-			continue
-		}
-		if winnerOwnedPool && !owned {
-			continue
-		}
-		relaxTrust := owned && (pr.SelfRouteOnly || pr.PreferOwner)
-		snap, ok := r.snapshotProviderLockedEx(p, model, pr.Traits, relaxTrust, false)
-		if !ok || !snap.modelLoaded {
-			continue
-		}
-		// A spread target must be instantly usable — model resident AND
-		// unoccupied. Filter occupied peers before the costlier gates below.
-		if snapshotOccupancy(snap) != 0 {
-			continue
-		}
-		// Vision gate: a media request must only count a vision-capable peer, or
-		// the scheduler would have rejected it (visionRejections) and the spread
-		// signal would be a false positive. snapshotProviderLockedEx released p.mu,
-		// so re-take it for the p.Models read (mirrors the selection loop).
-		if pr.RequiresVision {
-			p.mu.Lock()
-			servesVision := r.providerServesVisionModelLocked(p, model)
-			p.mu.Unlock()
-			if !servesVision {
-				continue
-			}
-		}
-		// Capacity / token-budget / hardware-fit feasibility — the same predicate
-		// the selection loop applies via buildCandidateWithReason. Without it an
-		// oversized-token or memory-starved peer would be counted as a valid idle
-		// alternative the scheduler could never actually have selected.
-		if _, _, admissible := r.buildCandidateWithReason(snap, pr); !admissible {
-			continue
-		}
-		return true
 	}
 	return false
 }

--- a/coordinator/registry/ttft_shadow.go
+++ b/coordinator/registry/ttft_shadow.go
@@ -152,7 +152,12 @@ func (e ttftShadowEval) applyTo(d *RoutingDecision) {
 // so taking a provider lock here would risk holding two at once. winner.snapshot
 // is the PRE-reserve snapshot, so the winner's occupancy excludes the request
 // about to be admitted (the b, not b+1, the new request actually waits behind).
-func (r *Registry) evaluateTTFTShadowLocked(model string, pr *PendingRequest, winner *routingCandidate) ttftShadowEval {
+//
+// excludeIDs are the same retry/speculative-backup exclusions ReserveProviderEx
+// passed to the real selector; they are threaded into the idle-spread scan so a
+// provider the selector would never have considered is never counted as a
+// routable idle alternative.
+func (r *Registry) evaluateTTFTShadowLocked(model string, pr *PendingRequest, winner *routingCandidate, excludeIDs ...string) ttftShadowEval {
 	mode := ttftAdmissionMode
 	if mode == TTFTAdmissionOff || winner == nil || pr == nil {
 		return ttftShadowEval{}
@@ -186,32 +191,67 @@ func (r *Registry) evaluateTTFTShadowLocked(model string, pr *PendingRequest, wi
 	// to. When herded, check whether an instantly-usable loaded-idle peer for the
 	// same model was routable.
 	if occ > 0 {
-		eval.IdleAlternativeExists = r.loadedIdleAlternativeExistsLocked(model, pr, winner.provider)
+		eval.IdleAlternativeExists = r.loadedIdleAlternativeExistsLocked(model, pr, winner.provider, excludeIDs...)
 	}
 	return eval
 }
 
 // loadedIdleAlternativeExistsLocked reports whether some provider OTHER than the
 // winner is a routable, model-resident, zero-occupancy candidate for model — an
-// instantly-usable box the herded request could have been spread to. It applies
-// the SAME gates the scheduler's selection loop does so it cannot report a peer
-// the scheduler would have rejected (which would corrupt the Phase-0 spread
-// metric): structural gates + owner/self-route filtering (snapshotProviderLockedEx),
-// the vision-capability gate (providerServesVisionModelLocked, for media
-// requests), and the capacity / token-budget / hardware-fit feasibility predicate
-// (buildCandidateWithReason — the exact check the selection loop runs). Caller
-// holds r.mu and no provider lock.
-func (r *Registry) loadedIdleAlternativeExistsLocked(model string, pr *PendingRequest, winner *Provider) bool {
+// instantly-usable box the herded request could have been spread to.
+//
+// It applies the SAME per-provider eligibility the scheduler's selection scan
+// (selectBestCandidateScanLocked) applies, in the same order and using the same
+// helpers, so the Phase-0 spread metric can never count a peer the selector would
+// have rejected. The correspondence (keep in sync with the selection loop):
+//
+//   - winner / excludeIDs skip      → the selector's excludeSet (retry +
+//     speculative-backup exclusions) plus the already-reserved winner.
+//   - self-route owner gate         → `pr.SelfRouteOnly && !owned`.
+//   - provider allowlist            → `providerMatchesAllowedSerial`.
+//   - prefer-owner POOL restriction → when prefer-owner selected an OWNED winner,
+//     the selector's pool was owned-only, so a public peer is not a real
+//     alternative (mirrors the owned-pool block after candidate collection).
+//   - structural / trait / trust gates → `snapshotProviderLockedEx`.
+//   - instantly-usable              → model resident AND zero occupancy.
+//   - vision capability             → `providerServesVisionModelLocked`.
+//   - capacity / token-budget / fit → `buildCandidateWithReason`.
+//
+// Caller holds r.mu and no provider lock.
+func (r *Registry) loadedIdleAlternativeExistsLocked(model string, pr *PendingRequest, winner *Provider, excludeIDs ...string) bool {
 	winnerID := ""
 	if winner != nil {
 		winnerID = winner.ID
 	}
+	excludeSet := make(map[string]struct{}, len(excludeIDs))
+	for _, id := range excludeIDs {
+		excludeSet[id] = struct{}{}
+	}
+	allowedSerials := make(map[string]struct{}, len(pr.AllowedProviderSerials))
+	for _, serial := range pr.AllowedProviderSerials {
+		allowedSerials[serial] = struct{}{}
+	}
+	// Prefer-owner restricts the selector's pool to OWNED candidates whenever an
+	// owned candidate can serve — and the winner being owned is exactly that
+	// signal (prefer-owner picks from the owned pool when it is non-empty). So a
+	// public peer is only a real alternative when the winner itself is public.
+	winnerOwnedPool := pr.PreferOwner && providerOwnedBy(winner, pr.OwnerAccountID)
+
 	for _, p := range r.providers {
 		if p == nil || p.ID == winnerID {
 			continue
 		}
+		if _, excluded := excludeSet[p.ID]; excluded {
+			continue
+		}
 		owned := providerOwnedBy(p, pr.OwnerAccountID)
 		if pr.SelfRouteOnly && !owned {
+			continue
+		}
+		if len(allowedSerials) > 0 && !providerMatchesAllowedSerial(p, allowedSerials) {
+			continue
+		}
+		if winnerOwnedPool && !owned {
 			continue
 		}
 		relaxTrust := owned && (pr.SelfRouteOnly || pr.PreferOwner)

--- a/coordinator/registry/ttft_shadow.go
+++ b/coordinator/registry/ttft_shadow.go
@@ -1,0 +1,216 @@
+package registry
+
+import "strings"
+
+// Phase-0 SLA-aware, occupancy-aware admission — SHADOW + MEASUREMENT slice.
+//
+// This file holds the configuration and the read-only evaluator for the TTFT
+// admission/spread shadow. It deliberately changes NO routing decision: in
+// `off` (default) the evaluator is a no-op; in `shadow` (and, for now, `enforce`)
+// it computes two signals against the winning candidate and hands them to the
+// caller as fields on RoutingDecision, which the API layer emits as metrics.
+//
+//   - WouldShed: the occupancy-aware TTFT estimate (ttftMsFromSnapshot, which is
+//     occupancy-aware only when EIGENINFERENCE_TTFT_OCCUPANCY_ALPHA > 0) for the
+//     chosen provider exceeds the verified ~10s deadline base (NOT the code's 5s
+//     internal budget — gating at 5s over-sheds ~2x per telemetry-db findings §2).
+//   - IdleAlternativeExists: the chosen provider already carries occupying peers
+//     while an instantly-usable (loaded, zero-occupancy) provider for the same
+//     model was routable — the load-SPREADING failure the data shows (idle loaded
+//     boxes coexisted with 100% of the gpt-oss cancels).
+//
+// The shadow reuses the occupancy the snapshot ALREADY tracks (snapshotOccupancy
+// = max(pendingForModel, backend_running+backend_waiting)); it does NOT introduce
+// a parallel reservation counter.
+
+// TTFTAdmissionMode selects the Phase-0 admission behavior.
+type TTFTAdmissionMode int
+
+const (
+	// TTFTAdmissionOff is the default: the evaluator is a no-op and behavior is
+	// byte-for-byte the pre-Phase-0 coordinator.
+	TTFTAdmissionOff TTFTAdmissionMode = iota
+	// TTFTAdmissionShadow computes the would-shed / would-redirect signals and
+	// emits metrics, but SERVES exactly as today (no decision change).
+	TTFTAdmissionShadow
+	// TTFTAdmissionEnforce is reserved for a future step that would actually shed
+	// on the signal. In this Phase-0 slice it behaves identically to shadow
+	// (evaluate + emit, no decision change) so it can be wired and validated
+	// without flipping live behavior.
+	TTFTAdmissionEnforce
+)
+
+func (m TTFTAdmissionMode) String() string {
+	switch m {
+	case TTFTAdmissionShadow:
+		return "shadow"
+	case TTFTAdmissionEnforce:
+		return "enforce"
+	default:
+		return "off"
+	}
+}
+
+// ParseTTFTAdmissionMode maps an env string to a mode. Anything unrecognized
+// (including empty) is OFF — the safe, behavior-neutral default.
+func ParseTTFTAdmissionMode(s string) TTFTAdmissionMode {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "shadow":
+		return TTFTAdmissionShadow
+	case "enforce":
+		return TTFTAdmissionEnforce
+	default:
+		return TTFTAdmissionOff
+	}
+}
+
+// defaultTTFTDeadlineBaseMs is the verified OpenRouter SLA base. Cancels fit
+// `10000 + 1ms·prompt_tokens` at a median ratio of 1.002 (telemetry-db findings
+// §2); the coordinator's internal `ttftDeadline` (consumer.go) still uses a 5s
+// base, which would over-shed ~2x if used as the gate — so the shadow evaluator
+// uses THIS base, decoupled from consumer.go.
+const defaultTTFTDeadlineBaseMs = 10000.0
+
+// Both are configured once at startup (from main.go env wiring) and read-only on
+// routing paths thereafter, mirroring prefillToDecodeRatio / ttftOccupancyAlpha.
+var (
+	ttftAdmissionMode  = TTFTAdmissionOff
+	ttftDeadlineBaseMs = defaultTTFTDeadlineBaseMs
+)
+
+// SetTTFTAdmissionMode sets the Phase-0 admission mode. Must be called before
+// serving starts.
+func SetTTFTAdmissionMode(mode TTFTAdmissionMode) {
+	ttftAdmissionMode = mode
+}
+
+// TTFTAdmissionModeValue returns the configured admission mode.
+func TTFTAdmissionModeValue() TTFTAdmissionMode {
+	return ttftAdmissionMode
+}
+
+// SetTTFTDeadlineBaseMs overrides the shadow-evaluation deadline base (ms).
+// Values <= 0 are ignored (keep the verified ~10s default). Must be called
+// before serving starts.
+func SetTTFTDeadlineBaseMs(ms float64) {
+	if ms > 0 {
+		ttftDeadlineBaseMs = ms
+	}
+}
+
+// TTFTDeadlineBaseMs returns the configured shadow-evaluation deadline base (ms).
+func TTFTDeadlineBaseMs() float64 {
+	return ttftDeadlineBaseMs
+}
+
+// ttftDeadlineMsForPrompt is the shadow gate's per-request SLA in ms:
+// base + 1ms·prompt_tokens, matching the per-token slope of consumer.ttftDeadline
+// but with the verified ~10s base instead of 5s. Used ONLY by the shadow
+// evaluator — the live consumer.go ttftDeadline path is untouched.
+func ttftDeadlineMsForPrompt(promptTokens int) float64 {
+	if promptTokens < 0 {
+		promptTokens = 0
+	}
+	return ttftDeadlineBaseMs + float64(promptTokens)
+}
+
+// ttftShadowEval is the result of the read-only Phase-0 evaluation. It is copied
+// onto RoutingDecision (applyTo) so the API layer can emit metrics without the
+// registry importing the telemetry package.
+type ttftShadowEval struct {
+	Evaluated             bool
+	Mode                  string
+	WouldShed             bool
+	IdleAlternativeExists bool
+	EstimateMs            float64
+	DeadlineMs            float64
+	Occupancy             int
+}
+
+func (e ttftShadowEval) applyTo(d *RoutingDecision) {
+	if d == nil || !e.Evaluated {
+		return
+	}
+	d.ShadowEvaluated = true
+	d.ShadowMode = e.Mode
+	d.ShadowWouldShed = e.WouldShed
+	d.ShadowIdleAlternativeExists = e.IdleAlternativeExists
+	d.ShadowEstimateMs = e.EstimateMs
+	d.ShadowDeadlineMs = e.DeadlineMs
+	d.ShadowOccupancy = e.Occupancy
+}
+
+// evaluateTTFTShadowLocked computes the Phase-0 shadow signals for the winning
+// candidate WITHOUT changing the routing decision. Returns the zero value (a
+// no-op for applyTo) when the admission mode is off.
+//
+// Caller holds r.mu and NO provider lock — the peer scan in
+// loadedIdleAlternativeExistsLocked snapshots each provider under its own p.mu,
+// so taking a provider lock here would risk holding two at once. winner.snapshot
+// is the PRE-reserve snapshot, so the winner's occupancy excludes the request
+// about to be admitted (the b, not b+1, the new request actually waits behind).
+func (r *Registry) evaluateTTFTShadowLocked(model string, pr *PendingRequest, winner *routingCandidate) ttftShadowEval {
+	mode := ttftAdmissionMode
+	if mode == TTFTAdmissionOff || winner == nil || pr == nil {
+		return ttftShadowEval{}
+	}
+	reqPrompt := pr.EstimatedPromptTokens
+	if reqPrompt < 0 {
+		reqPrompt = 0
+	}
+	snap := winner.snapshot
+	estimate := ttftMsFromSnapshot(snap, reqPrompt)
+	deadline := ttftDeadlineMsForPrompt(reqPrompt)
+	occ := snapshotOccupancy(snap)
+
+	eval := ttftShadowEval{
+		Evaluated: true,
+		Mode:      mode.String(),
+		// Providers without BackendCapacity have no reliable TTFT estimate
+		// (ttftMsFromSnapshot returns 0), so they never "would_shed" — matching
+		// the live ceiling's behavior.
+		WouldShed:  snap.hasBackendCapacity && estimate > deadline,
+		EstimateMs: estimate,
+		DeadlineMs: deadline,
+		Occupancy:  occ,
+	}
+	// The spread signal only makes sense when the winner is itself herded: if we
+	// already routed to an idle box (occ == 0) there was nothing better to spread
+	// to. When herded, check whether an instantly-usable loaded-idle peer for the
+	// same model was routable.
+	if occ > 0 {
+		eval.IdleAlternativeExists = r.loadedIdleAlternativeExistsLocked(model, pr, winner.provider)
+	}
+	return eval
+}
+
+// loadedIdleAlternativeExistsLocked reports whether some provider OTHER than the
+// winner is a routable, model-resident, zero-occupancy candidate for model — an
+// instantly-usable box the herded request could have been spread to. It mirrors
+// selection's owner/self-route filtering and reuses snapshotProviderLockedEx so
+// it counts only providers that pass the same routing gates. Caller holds r.mu
+// and no provider lock.
+func (r *Registry) loadedIdleAlternativeExistsLocked(model string, pr *PendingRequest, winner *Provider) bool {
+	winnerID := ""
+	if winner != nil {
+		winnerID = winner.ID
+	}
+	for _, p := range r.providers {
+		if p == nil || p.ID == winnerID {
+			continue
+		}
+		owned := providerOwnedBy(p, pr.OwnerAccountID)
+		if pr.SelfRouteOnly && !owned {
+			continue
+		}
+		relaxTrust := owned && (pr.SelfRouteOnly || pr.PreferOwner)
+		snap, ok := r.snapshotProviderLockedEx(p, model, pr.Traits, relaxTrust, false)
+		if !ok || !snap.modelLoaded {
+			continue
+		}
+		if snapshotOccupancy(snap) == 0 {
+			return true
+		}
+	}
+	return false
+}

--- a/coordinator/registry/ttft_shadow_test.go
+++ b/coordinator/registry/ttft_shadow_test.go
@@ -1,6 +1,11 @@
 package registry
 
-import "testing"
+import (
+	"math"
+	"testing"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+)
 
 // withTTFTConfig snapshots and restores the package-level Phase-0 TTFT knobs so
 // each test runs in isolation (Go runs package tests sequentially, so resetting
@@ -42,9 +47,12 @@ func TestTTFTOccupancyTermZeroWhenAlphaZero(t *testing.T) {
 	}
 }
 
-// TestTTFTEstimateOccupancyTermActiveAndMonotonic exercises the flag ON: the
-// occupancy term raises the estimate, the estimate is strictly increasing in
-// occupancy, and it crosses the verified ~10s deadline at a knee.
+// TestTTFTEstimateOccupancyTermActiveAndMonotonic exercises the flag ON via the
+// SHADOW estimate (occupancyAwareTTFTMsFromSnapshot — the only place the term is
+// added; ttftMsFromSnapshot stays occupancy-free, see Fix D): the occupancy term
+// raises the estimate, the estimate is strictly increasing in occupancy, and it
+// crosses the verified ~10s deadline at a knee. It also pins the safety invariant
+// at the unit level — ttftMsFromSnapshot (the live input) is unchanged by alpha.
 func TestTTFTEstimateOccupancyTermActiveAndMonotonic(t *testing.T) {
 	withTTFTConfig(t, 45, defaultTTFTDeadlineBaseMs, TTFTAdmissionOff)
 
@@ -59,13 +67,22 @@ func TestTTFTEstimateOccupancyTermActiveAndMonotonic(t *testing.T) {
 	}
 	const reqPrompt = 1000
 
-	// The occupancy term must add to the estimate at b>0 (compare alpha on vs off).
+	// The occupancy term must add to the SHADOW estimate at b>0 (compare alpha on
+	// vs off). The LIVE estimate (ttftMsFromSnapshot) must NOT move with alpha.
 	SetTTFTOccupancyAlpha(0)
-	base4 := ttftMsFromSnapshot(mk(4), reqPrompt)
+	liveOff := ttftMsFromSnapshot(mk(4), reqPrompt)
+	shadowOff := occupancyAwareTTFTMsFromSnapshot(mk(4), reqPrompt)
 	SetTTFTOccupancyAlpha(45)
-	withTerm4 := ttftMsFromSnapshot(mk(4), reqPrompt)
-	if withTerm4 <= base4 {
-		t.Fatalf("occupancy term must raise the estimate at b=4: with=%f base=%f", withTerm4, base4)
+	liveOn := ttftMsFromSnapshot(mk(4), reqPrompt)
+	shadowOn := occupancyAwareTTFTMsFromSnapshot(mk(4), reqPrompt)
+	if liveOn != liveOff {
+		t.Fatalf("ttftMsFromSnapshot must be occupancy-FREE (invariant): alpha=0 %f vs alpha=45 %f", liveOff, liveOn)
+	}
+	if shadowOff != liveOff {
+		t.Fatalf("at alpha=0 the shadow estimate must equal the base: shadow=%f base=%f", shadowOff, liveOff)
+	}
+	if shadowOn <= shadowOff {
+		t.Fatalf("occupancy term must raise the shadow estimate at b=4: with=%f base=%f", shadowOn, shadowOff)
 	}
 
 	// Strictly increasing in occupancy, crossing the deadline at a knee.
@@ -73,7 +90,7 @@ func TestTTFTEstimateOccupancyTermActiveAndMonotonic(t *testing.T) {
 	last := -1.0
 	knee := -1
 	for b := 0; b <= 8; b++ {
-		est := ttftMsFromSnapshot(mk(b), reqPrompt)
+		est := occupancyAwareTTFTMsFromSnapshot(mk(b), reqPrompt)
 		if est <= last {
 			t.Fatalf("estimate not strictly increasing at b=%d: %f <= %f", b, est, last)
 		}
@@ -86,8 +103,60 @@ func TestTTFTEstimateOccupancyTermActiveAndMonotonic(t *testing.T) {
 		t.Fatalf("estimate should cross the %.0fms deadline at a knee in b=1..8, got knee=%d", deadline, knee)
 	}
 	// b=0 (idle) must stay well under the deadline — route-to-idle is preserved.
-	if idle := ttftMsFromSnapshot(mk(0), reqPrompt); idle > deadline {
+	if idle := occupancyAwareTTFTMsFromSnapshot(mk(0), reqPrompt); idle > deadline {
 		t.Fatalf("idle box (b=0) must be under the deadline, got %f > %f", idle, deadline)
+	}
+}
+
+// TestTTFTOccupancyTermRateUsesOccupancyNotBackendRunning pins Fix C: in the herd
+// case (pendingForModel > backend_running) the occupancy term must project the
+// per-request decode rate at the batch the request ACTUALLY joins (occ), not the
+// stale heartbeat backend_running gauge. Charging the backend_running rate would
+// divide by an idle/low-batch rate and UNDER-state the term — the opposite of
+// intended — in exactly the case the term exists to measure.
+func TestTTFTOccupancyTermRateUsesOccupancyNotBackendRunning(t *testing.T) {
+	withTTFTConfig(t, 45, defaultTTFTDeadlineBaseMs, TTFTAdmissionOff)
+
+	// Heartbeat still reads backend_running=2, but the coordinator has already
+	// reserved 8 dispatched-not-terminal requests for this model (pendingForModel
+	// =8) → occ=8. The new request joins a batch of 8, not 2.
+	herd := routingSnapshot{
+		hasBackendCapacity: true,
+		slotState:          "running",
+		decodeTPS:          55,
+		prefillTPS:         660,
+		backendRunning:     2,
+		backendWaiting:     0,
+		pendingForModel:    8,
+	}
+	occ := snapshotOccupancy(herd)
+	if occ != 8 {
+		t.Fatalf("precondition: occ should be 8 (herd), got %d", occ)
+	}
+	got := ttftOccupancyMs(herd)
+
+	// Correct: rate projected at the batch the request joins (occ).
+	wantRate := projectedPerRequestDecodeTPSAtBatch(herd, occ)
+	want := 45 * float64(occ) * 1000.0 / wantRate
+	if math.Abs(got-want) > 1e-6 {
+		t.Fatalf("occupancy term must use occ for the rate: got %f want %f", got, want)
+	}
+
+	// The pre-fix rate (projected at the bare backend_running gauge) is FASTER, so
+	// the buggy term would be SMALLER. Assert the fix charges strictly more.
+	buggyRate := projectedPerRequestDecodeTPSAtBatch(herd, herd.backendRunning)
+	buggyTerm := 45 * float64(occ) * 1000.0 / buggyRate
+	if !(got > buggyTerm) {
+		t.Fatalf("herd term must exceed the backend_running-rate term: got %f buggy %f", got, buggyTerm)
+	}
+
+	// At an EQUAL heartbeat gauge, a larger pending burst (higher occ) must grow
+	// the term — both via the occ numerator AND the shrinking occ-projected rate.
+	lowBurst := herd
+	lowBurst.pendingForModel = 3 // occ = max(3, 2) = 3
+	if !(ttftOccupancyMs(herd) > ttftOccupancyMs(lowBurst)) {
+		t.Fatalf("term must grow with pending burst at equal backend_running: occ8=%f occ3=%f",
+			ttftOccupancyMs(herd), ttftOccupancyMs(lowBurst))
 	}
 }
 
@@ -206,5 +275,111 @@ func TestTTFTShadowEvalNoRedirectWhenWinnerIdle(t *testing.T) {
 	}
 	if decision.ShadowIdleAlternativeExists {
 		t.Fatalf("no redirect signal expected when the winner itself is idle: %+v", decision)
+	}
+}
+
+// TestTTFTOccupancyAlphaDoesNotMoveLiveCeiling pins the central HARD_REJECT safety
+// invariant (Fix D): with pr.MaxTTFTMs set (HARD_REJECT semantics) and the
+// occupancy term ON (alpha>0, mode=shadow), the LIVE candidate-loop ceiling is
+// identical to alpha=0 — the herded box is NOT hard-rejected by the occupancy term
+// and the winning decision's live TTFTMs is unchanged — while the shadow evaluator
+// STILL computes the occupancy-aware would_shed at the verified ~10s base.
+func TestTTFTOccupancyAlphaDoesNotMoveLiveCeiling(t *testing.T) {
+	const (
+		model     = "hardreject-invariant-model"
+		decodeTPS = 55.0
+		prompt    = 1000
+		// base estimate (~1.5s) passes this ceiling; the occupancy-aware estimate
+		// (~15s at occ=6) is well over the ~10s shadow deadline → would_shed.
+		maxTTFT = 5000.0
+	)
+	mkHerded := func(reg *Registry) *Provider {
+		p := makeSchedulerProvider(t, reg, "herded", model, decodeTPS)
+		p.mu.Lock()
+		p.BackendCapacity.Slots[0].NumRunning = 6 // occ=6
+		p.mu.Unlock()
+		return p
+	}
+	newReq := func() *PendingRequest {
+		return &PendingRequest{RequestID: "r1", Model: model, EstimatedPromptTokens: prompt, RequestedMaxTokens: 256, MaxTTFTMs: maxTTFT}
+	}
+
+	// Baseline: alpha=0, no shadow. The herded box passes the 5s live ceiling.
+	withTTFTConfig(t, 0, defaultTTFTDeadlineBaseMs, TTFTAdmissionOff)
+	regOff := New(testLogger())
+	pOff := mkHerded(regOff)
+	selOff, decOff := regOff.ReserveProviderEx(model, newReq())
+	if selOff == nil || decOff.ProviderID != pOff.ID {
+		t.Fatalf("alpha=0: herded box must pass the live ceiling and be selected: sel=%v dec=%+v", selOff, decOff)
+	}
+
+	// alpha>0 + shadow: the SAME live ceiling must hold (selection + live TTFTMs
+	// identical), proving the occupancy term never reached breakdown.TTFTMs; the
+	// shadow evaluator must still flag would_shed via the occupancy-aware estimate.
+	SetTTFTOccupancyAlpha(45)
+	SetTTFTAdmissionMode(TTFTAdmissionShadow)
+	regOn := New(testLogger())
+	pOn := mkHerded(regOn)
+	selOn, decOn := regOn.ReserveProviderEx(model, newReq())
+	if selOn == nil || decOn.ProviderID != pOn.ID {
+		t.Fatalf("alpha=45: occupancy term must NOT hard-reject the herded box (HARD_REJECT invariant): sel=%v dec=%+v", selOn, decOn)
+	}
+	if decOn.TTFTMs != decOff.TTFTMs {
+		t.Fatalf("live TTFTMs must be identical at alpha=0 and alpha=45 (occupancy-free): off=%f on=%f", decOff.TTFTMs, decOn.TTFTMs)
+	}
+	if !decOn.ShadowEvaluated || !decOn.ShadowWouldShed {
+		t.Fatalf("shadow must still compute occupancy-aware would_shed: %+v", decOn)
+	}
+	if decOn.ShadowEstimateMs <= decOn.TTFTMs {
+		t.Fatalf("shadow occupancy-aware estimate must exceed the occupancy-free live TTFTMs: shadow=%f live=%f", decOn.ShadowEstimateMs, decOn.TTFTMs)
+	}
+}
+
+// TestLoadedIdleAlternativeHonorsVisionGate pins Fix B: the idle shadow scan must
+// apply the SAME selection gates the scheduler does. A vision request whose only
+// idle peer is text-only must NOT count that peer as a spread alternative (the
+// scheduler would have vision-rejected it), and the same fleet must count it for a
+// text request and count a vision-capable peer for the vision request.
+func TestLoadedIdleAlternativeHonorsVisionGate(t *testing.T) {
+	withTTFTConfig(t, 0, defaultTTFTDeadlineBaseMs, TTFTAdmissionShadow)
+	reg := New(testLogger())
+	model := "shadow-vision-gate-model"
+
+	// Winner is excluded by ID inside the scan; its capability is irrelevant.
+	winner := makeSchedulerProvider(t, reg, "winner", model, 100)
+
+	// The only idle peer is TEXT-ONLY for this model.
+	idleText := makeSchedulerProvider(t, reg, "idle-text", model, 100)
+	idleText.mu.Lock()
+	idleText.Models = []protocol.ModelInfo{{ID: model, ModelType: "chat", Quantization: "4bit", IsVision: false}}
+	idleText.mu.Unlock()
+
+	visionReq := &PendingRequest{RequestID: "rv", Model: model, EstimatedPromptTokens: 100, RequestedMaxTokens: 128, RequiresVision: true}
+	textReq := &PendingRequest{RequestID: "rt", Model: model, EstimatedPromptTokens: 100, RequestedMaxTokens: 128}
+
+	// loadedIdleAlternativeExistsLocked requires r.mu; take it per call so the
+	// makeSchedulerProvider (Register → r.mu.Lock) calls between checks don't
+	// deadlock against a held lock.
+	idleAlt := func(pr *PendingRequest) bool {
+		reg.mu.Lock()
+		defer reg.mu.Unlock()
+		return reg.loadedIdleAlternativeExistsLocked(model, pr, winner)
+	}
+
+	if idleAlt(visionReq) {
+		t.Fatal("vision request must NOT count a text-only idle peer as a spread alternative")
+	}
+	// A TEXT request on the same fleet DOES have a valid idle alternative.
+	if !idleAlt(textReq) {
+		t.Fatal("text request must count the text-only idle peer as a spread alternative")
+	}
+
+	// Once a VISION-capable idle peer exists, the vision request counts it.
+	idleVision := makeSchedulerProvider(t, reg, "idle-vision", model, 100)
+	idleVision.mu.Lock()
+	idleVision.Models = []protocol.ModelInfo{{ID: model, ModelType: "chat", Quantization: "4bit", IsVision: true}}
+	idleVision.mu.Unlock()
+	if !idleAlt(visionReq) {
+		t.Fatal("vision request must count a vision-capable idle peer as a spread alternative")
 	}
 }

--- a/coordinator/registry/ttft_shadow_test.go
+++ b/coordinator/registry/ttft_shadow_test.go
@@ -1,0 +1,210 @@
+package registry
+
+import "testing"
+
+// withTTFTConfig snapshots and restores the package-level Phase-0 TTFT knobs so
+// each test runs in isolation (Go runs package tests sequentially, so resetting
+// in Cleanup is sufficient).
+func withTTFTConfig(t *testing.T, alpha, deadlineBaseMs float64, mode TTFTAdmissionMode) {
+	t.Helper()
+	prevAlpha := TTFTOccupancyAlpha()
+	prevBase := TTFTDeadlineBaseMs()
+	prevMode := TTFTAdmissionModeValue()
+	t.Cleanup(func() {
+		SetTTFTOccupancyAlpha(prevAlpha)
+		SetTTFTDeadlineBaseMs(prevBase)
+		SetTTFTAdmissionMode(prevMode)
+	})
+	SetTTFTOccupancyAlpha(alpha)
+	if deadlineBaseMs > 0 {
+		SetTTFTDeadlineBaseMs(deadlineBaseMs)
+	}
+	SetTTFTAdmissionMode(mode)
+}
+
+// TestTTFTOccupancyTermZeroWhenAlphaZero pins the behavior-neutral default: with
+// alpha=0 the occupancy term contributes nothing, so ttftMsFromSnapshot is
+// byte-for-byte the pre-Phase-0 estimate no matter how herded the box is.
+func TestTTFTOccupancyTermZeroWhenAlphaZero(t *testing.T) {
+	if TTFTOccupancyAlpha() != 0 {
+		t.Fatalf("default occupancy alpha must be 0, got %f", TTFTOccupancyAlpha())
+	}
+	snap := routingSnapshot{
+		hasBackendCapacity: true,
+		slotState:          "running",
+		decodeTPS:          55,
+		prefillTPS:         660,
+		backendRunning:     8,
+		pendingForModel:    8,
+	}
+	if got := ttftOccupancyMs(snap); got != 0 {
+		t.Fatalf("ttftOccupancyMs must be 0 when alpha=0, got %f", got)
+	}
+}
+
+// TestTTFTEstimateOccupancyTermActiveAndMonotonic exercises the flag ON: the
+// occupancy term raises the estimate, the estimate is strictly increasing in
+// occupancy, and it crosses the verified ~10s deadline at a knee.
+func TestTTFTEstimateOccupancyTermActiveAndMonotonic(t *testing.T) {
+	withTTFTConfig(t, 45, defaultTTFTDeadlineBaseMs, TTFTAdmissionOff)
+
+	mk := func(running int) routingSnapshot {
+		return routingSnapshot{
+			hasBackendCapacity: true,
+			slotState:          "running",
+			decodeTPS:          55, // gpt-oss solo ~55 tok/s
+			prefillTPS:         660,
+			backendRunning:     running,
+		}
+	}
+	const reqPrompt = 1000
+
+	// The occupancy term must add to the estimate at b>0 (compare alpha on vs off).
+	SetTTFTOccupancyAlpha(0)
+	base4 := ttftMsFromSnapshot(mk(4), reqPrompt)
+	SetTTFTOccupancyAlpha(45)
+	withTerm4 := ttftMsFromSnapshot(mk(4), reqPrompt)
+	if withTerm4 <= base4 {
+		t.Fatalf("occupancy term must raise the estimate at b=4: with=%f base=%f", withTerm4, base4)
+	}
+
+	// Strictly increasing in occupancy, crossing the deadline at a knee.
+	deadline := ttftDeadlineMsForPrompt(reqPrompt)
+	last := -1.0
+	knee := -1
+	for b := 0; b <= 8; b++ {
+		est := ttftMsFromSnapshot(mk(b), reqPrompt)
+		if est <= last {
+			t.Fatalf("estimate not strictly increasing at b=%d: %f <= %f", b, est, last)
+		}
+		last = est
+		if knee < 0 && est > deadline {
+			knee = b
+		}
+	}
+	if knee < 1 || knee > 8 {
+		t.Fatalf("estimate should cross the %.0fms deadline at a knee in b=1..8, got knee=%d", deadline, knee)
+	}
+	// b=0 (idle) must stay well under the deadline — route-to-idle is preserved.
+	if idle := ttftMsFromSnapshot(mk(0), reqPrompt); idle > deadline {
+		t.Fatalf("idle box (b=0) must be under the deadline, got %f > %f", idle, deadline)
+	}
+}
+
+func TestParseTTFTAdmissionMode(t *testing.T) {
+	cases := map[string]TTFTAdmissionMode{
+		"":        TTFTAdmissionOff,
+		"off":     TTFTAdmissionOff,
+		"garbage": TTFTAdmissionOff,
+		"shadow":  TTFTAdmissionShadow,
+		" SHADOW": TTFTAdmissionShadow,
+		"enforce": TTFTAdmissionEnforce,
+	}
+	for in, want := range cases {
+		if got := ParseTTFTAdmissionMode(in); got != want {
+			t.Errorf("ParseTTFTAdmissionMode(%q) = %v, want %v", in, got, want)
+		}
+	}
+}
+
+// TestTTFTAdmissionModeOffNoShadowEval confirms the default mode leaves the
+// RoutingDecision shadow fields untouched (behavior-neutral observability).
+func TestTTFTAdmissionModeOffNoShadowEval(t *testing.T) {
+	withTTFTConfig(t, 45, defaultTTFTDeadlineBaseMs, TTFTAdmissionOff)
+	reg := New(testLogger())
+	model := "shadow-off-model"
+	makeSchedulerProvider(t, reg, "p1", model, 100)
+
+	_, decision := reg.ReserveProviderEx(model, &PendingRequest{RequestID: "r1", Model: model, EstimatedPromptTokens: 100, RequestedMaxTokens: 128})
+	if decision.ShadowEvaluated {
+		t.Fatalf("admission mode off must not evaluate shadow: %+v", decision)
+	}
+	if decision.ShadowMode != "" || decision.ShadowWouldShed || decision.ShadowIdleAlternativeExists {
+		t.Fatalf("shadow fields must be zero when off: %+v", decision)
+	}
+}
+
+// TestTTFTShadowEvalWouldShedButStillServes is the core shadow assertion: a
+// herded provider whose occupancy-aware estimate exceeds the ~10s base is flagged
+// would_shed, yet the request is STILL served (the decision is unchanged). This
+// is the behavior-neutral guarantee of shadow mode.
+func TestTTFTShadowEvalWouldShedButStillServes(t *testing.T) {
+	withTTFTConfig(t, 45, defaultTTFTDeadlineBaseMs, TTFTAdmissionShadow)
+	reg := New(testLogger())
+	model := "shadow-shed-model"
+	p := makeSchedulerProvider(t, reg, "busy", model, 55)
+	p.mu.Lock()
+	p.BackendCapacity.Slots[0].NumRunning = 6 // herded → occupancy-aware estimate >> 10s
+	p.mu.Unlock()
+
+	selected, decision := reg.ReserveProviderEx(model, &PendingRequest{RequestID: "r1", Model: model, EstimatedPromptTokens: 1000, RequestedMaxTokens: 256})
+	if selected == nil || decision.ProviderID != p.ID {
+		t.Fatalf("shadow mode must NOT change the decision — provider should still be served: selected=%v decision=%+v", selected, decision)
+	}
+	if !decision.ShadowEvaluated || decision.ShadowMode != "shadow" {
+		t.Fatalf("shadow eval should be populated: %+v", decision)
+	}
+	if !decision.ShadowWouldShed {
+		t.Fatalf("a b=6 gpt-oss box at alpha=45 should be flagged would_shed (est=%f deadline=%f)", decision.ShadowEstimateMs, decision.ShadowDeadlineMs)
+	}
+	if decision.ShadowEstimateMs <= decision.ShadowDeadlineMs {
+		t.Fatalf("would_shed implies estimate>deadline: est=%f deadline=%f", decision.ShadowEstimateMs, decision.ShadowDeadlineMs)
+	}
+}
+
+// TestTTFTShadowEvalRedirectToIdle reproduces the load-spreading failure the data
+// shows: the cost lands a request on a fast-but-herded box while an
+// instantly-usable loaded-idle box for the same model was routable. Shadow flags
+// would_redirect_to_idle=true without changing the (herded) selection.
+func TestTTFTShadowEvalRedirectToIdle(t *testing.T) {
+	withTTFTConfig(t, 0, defaultTTFTDeadlineBaseMs, TTFTAdmissionShadow)
+	reg := New(testLogger())
+	model := "shadow-spread-model"
+
+	// Fast but herded winner: occupancy=1, but so cheap it still beats the slow
+	// idle box on cost.
+	fastBusy := makeSchedulerProvider(t, reg, "fast-busy", model, 300)
+	fastBusy.mu.Lock()
+	fastBusy.BackendCapacity.Slots[0].NumRunning = 1
+	fastBusy.mu.Unlock()
+
+	// Slow, idle, loaded alternative (occupancy=0).
+	makeSchedulerProvider(t, reg, "slow-idle", model, 20)
+
+	selected, decision := reg.ReserveProviderEx(model, &PendingRequest{RequestID: "r1", Model: model, EstimatedPromptTokens: 100, RequestedMaxTokens: 256})
+	if selected == nil {
+		t.Fatalf("expected a selection, got nil: %+v", decision)
+	}
+	if selected.ID != fastBusy.ID {
+		t.Skipf("cost model did not pick the herded box (picked %q); spread-signal precondition not met", selected.ID)
+	}
+	if !decision.ShadowEvaluated {
+		t.Fatalf("shadow eval should be populated: %+v", decision)
+	}
+	if decision.ShadowOccupancy == 0 {
+		t.Fatalf("winner should be herded (occupancy>0): %+v", decision)
+	}
+	if !decision.ShadowIdleAlternativeExists {
+		t.Fatalf("an idle loaded alternative existed; would_redirect_to_idle must be true: %+v", decision)
+	}
+}
+
+// TestTTFTShadowEvalNoRedirectWhenWinnerIdle confirms the spread signal is false
+// when the request already landed on an idle box (nothing better to spread to).
+func TestTTFTShadowEvalNoRedirectWhenWinnerIdle(t *testing.T) {
+	withTTFTConfig(t, 0, defaultTTFTDeadlineBaseMs, TTFTAdmissionShadow)
+	reg := New(testLogger())
+	model := "shadow-idle-winner-model"
+	makeSchedulerProvider(t, reg, "idle", model, 100)
+
+	_, decision := reg.ReserveProviderEx(model, &PendingRequest{RequestID: "r1", Model: model, EstimatedPromptTokens: 100, RequestedMaxTokens: 128})
+	if !decision.ShadowEvaluated {
+		t.Fatalf("shadow eval should be populated: %+v", decision)
+	}
+	if decision.ShadowOccupancy != 0 {
+		t.Fatalf("winner should be idle (occupancy 0): %+v", decision)
+	}
+	if decision.ShadowIdleAlternativeExists {
+		t.Fatalf("no redirect signal expected when the winner itself is idle: %+v", decision)
+	}
+}

--- a/coordinator/registry/ttft_shadow_test.go
+++ b/coordinator/registry/ttft_shadow_test.go
@@ -486,3 +486,74 @@ func TestLoadedIdleAlternativeHonorsExcludeIDs(t *testing.T) {
 		t.Fatal("an excluded (retry/backup) idle peer must not count as a spread alternative")
 	}
 }
+
+// TestLoadedIdleAlternativeHonorsAvoidVersionPool pins the post-candidate
+// diverse-version pool narrowing (Codex P2 round 3): a version-diverse retry must
+// not count an idle peer that runs the AVOIDED build (the selector drops it from
+// the pool). Reusing scanCandidatesLocked means the shadow scan honors this
+// automatically. The plain-request contrast proves the peer is otherwise eligible.
+func TestLoadedIdleAlternativeHonorsAvoidVersionPool(t *testing.T) {
+	withTTFTConfig(t, 0, defaultTTFTDeadlineBaseMs, TTFTAdmissionShadow)
+	reg := New(testLogger())
+	model := "shadow-avoidversion-model"
+
+	// Winner runs a build DIFFERENT from the one being avoided (so a diverse
+	// candidate exists and the pool narrows).
+	winner := makeSchedulerProvider(t, reg, "winner", model, 100)
+	winner.mu.Lock()
+	winner.Version = "0.6.30"
+	winner.mu.Unlock()
+
+	// The only idle peer runs the AVOIDED build.
+	idleAvoided := makeSchedulerProvider(t, reg, "idle-avoided", model, 100)
+	idleAvoided.mu.Lock()
+	idleAvoided.Version = "0.6.29"
+	idleAvoided.mu.Unlock()
+
+	idleAlt := func(pr *PendingRequest) bool {
+		reg.mu.Lock()
+		defer reg.mu.Unlock()
+		return reg.loadedIdleAlternativeExistsLocked(model, pr, winner)
+	}
+
+	avoid := &PendingRequest{RequestID: "rav", Model: model, EstimatedPromptTokens: 100, RequestedMaxTokens: 128, Traits: RequestTraits{AvoidVersion: "0.6.29"}}
+	if idleAlt(avoid) {
+		t.Fatal("AvoidVersion retry must NOT count an idle peer on the avoided build")
+	}
+
+	plain := &PendingRequest{RequestID: "rav2", Model: model, EstimatedPromptTokens: 100, RequestedMaxTokens: 128}
+	if !idleAlt(plain) {
+		t.Fatal("a plain retry must count the idle peer (proves it is otherwise eligible)")
+	}
+}
+
+// TestLoadedIdleAlternativeHonorsMinDecodeTPS pins the post-candidate decode-floor
+// pool narrowing (Codex P2 round 3): a quality-floored retry must not count an
+// idle peer below MinDecodeTPS (the selector drops it from the pool). The
+// plain-request contrast proves the peer is otherwise eligible.
+func TestLoadedIdleAlternativeHonorsMinDecodeTPS(t *testing.T) {
+	withTTFTConfig(t, 0, defaultTTFTDeadlineBaseMs, TTFTAdmissionShadow)
+	reg := New(testLogger())
+	model := "shadow-mindecode-model"
+
+	// Winner is fast (clears the floor → the quality pool narrows).
+	winner := makeSchedulerProvider(t, reg, "winner-fast", model, 200)
+	// The only idle peer is slow: projected ~20/(1+0.27) ≈ 15.7 tok/s at b=0.
+	makeSchedulerProvider(t, reg, "idle-slow", model, 20)
+
+	idleAlt := func(pr *PendingRequest) bool {
+		reg.mu.Lock()
+		defer reg.mu.Unlock()
+		return reg.loadedIdleAlternativeExistsLocked(model, pr, winner)
+	}
+
+	floor := &PendingRequest{RequestID: "rmd", Model: model, EstimatedPromptTokens: 100, RequestedMaxTokens: 128, MinDecodeTPS: 50}
+	if idleAlt(floor) {
+		t.Fatal("MinDecodeTPS retry must NOT count an idle peer below the decode floor")
+	}
+
+	plain := &PendingRequest{RequestID: "rmd2", Model: model, EstimatedPromptTokens: 100, RequestedMaxTokens: 128}
+	if !idleAlt(plain) {
+		t.Fatal("a plain retry must count the slow idle peer (proves it is otherwise eligible)")
+	}
+}

--- a/coordinator/registry/ttft_shadow_test.go
+++ b/coordinator/registry/ttft_shadow_test.go
@@ -383,3 +383,106 @@ func TestLoadedIdleAlternativeHonorsVisionGate(t *testing.T) {
 		t.Fatal("vision request must count a vision-capable idle peer as a spread alternative")
 	}
 }
+
+// TestLoadedIdleAlternativeHonorsPreferOwnerPool pins the prefer-owner owned-pool
+// restriction: when prefer-owner selected an OWNED winner, the selector's pool was
+// owned-only, so a PUBLIC idle peer is not a real alternative. A plain request (no
+// prefer-owner) still counts the public peer, and an OWNED idle peer counts for the
+// prefer-owner request.
+func TestLoadedIdleAlternativeHonorsPreferOwnerPool(t *testing.T) {
+	withTTFTConfig(t, 0, defaultTTFTDeadlineBaseMs, TTFTAdmissionShadow)
+	reg := New(testLogger())
+	model := "shadow-prefer-owner-model"
+	const owner = "owner-account-1"
+
+	// Owned winner (excluded by ID in the scan) — its ownership makes the
+	// selector's pool owned-only for a prefer-owner request.
+	winner := makeSchedulerProvider(t, reg, "owned-winner", model, 100)
+	winner.mu.Lock()
+	winner.AccountID = owner
+	winner.mu.Unlock()
+
+	// The only idle peer is PUBLIC (no owner).
+	makeSchedulerProvider(t, reg, "public-idle", model, 100)
+
+	idleAlt := func(pr *PendingRequest) bool {
+		reg.mu.Lock()
+		defer reg.mu.Unlock()
+		return reg.loadedIdleAlternativeExistsLocked(model, pr, winner)
+	}
+
+	preferOwner := &PendingRequest{RequestID: "rp", Model: model, EstimatedPromptTokens: 100, RequestedMaxTokens: 128, OwnerAccountID: owner, PreferOwner: true}
+	if idleAlt(preferOwner) {
+		t.Fatal("prefer-owner with an owned winner must NOT count a public idle peer (owned-pool restriction)")
+	}
+
+	// A plain request (no prefer-owner) does count the public idle peer.
+	plain := &PendingRequest{RequestID: "rpp", Model: model, EstimatedPromptTokens: 100, RequestedMaxTokens: 128}
+	if !idleAlt(plain) {
+		t.Fatal("a plain request must count the public idle peer")
+	}
+
+	// An OWNED idle peer IS a valid prefer-owner alternative.
+	ownedIdle := makeSchedulerProvider(t, reg, "owned-idle", model, 100)
+	ownedIdle.mu.Lock()
+	ownedIdle.AccountID = owner
+	ownedIdle.mu.Unlock()
+	if !idleAlt(preferOwner) {
+		t.Fatal("prefer-owner must count an OWNED idle peer as a spread alternative")
+	}
+}
+
+// TestLoadedIdleAlternativeHonorsAllowlist pins the provider-allowlist gate: a
+// request with AllowedProviderSerials must not count an idle peer whose serial is
+// not in the allowlist, but must count one whose serial is.
+func TestLoadedIdleAlternativeHonorsAllowlist(t *testing.T) {
+	withTTFTConfig(t, 0, defaultTTFTDeadlineBaseMs, TTFTAdmissionShadow)
+	reg := New(testLogger())
+	model := "shadow-allowlist-model"
+
+	winner := makeSchedulerProvider(t, reg, "winner", model, 100)
+	idlePeer := makeSchedulerProvider(t, reg, "idle-peer", model, 100)
+	setSchedulerProviderSerial(idlePeer, "SERIAL-IDLE")
+
+	idleAlt := func(pr *PendingRequest) bool {
+		reg.mu.Lock()
+		defer reg.mu.Unlock()
+		return reg.loadedIdleAlternativeExistsLocked(model, pr, winner)
+	}
+
+	disallowed := &PendingRequest{RequestID: "ra", Model: model, EstimatedPromptTokens: 100, RequestedMaxTokens: 128, AllowedProviderSerials: []string{"SERIAL-OTHER"}}
+	if idleAlt(disallowed) {
+		t.Fatal("allowlist request must NOT count a non-allowlisted idle peer")
+	}
+
+	allowed := &PendingRequest{RequestID: "raa", Model: model, EstimatedPromptTokens: 100, RequestedMaxTokens: 128, AllowedProviderSerials: []string{"SERIAL-IDLE"}}
+	if !idleAlt(allowed) {
+		t.Fatal("allowlist request must count an allowlisted idle peer")
+	}
+}
+
+// TestLoadedIdleAlternativeHonorsExcludeIDs pins the retry/speculative-backup
+// exclusion: an idle peer that the selector excluded (passed in excludeIDs) must
+// not be counted as a spread alternative.
+func TestLoadedIdleAlternativeHonorsExcludeIDs(t *testing.T) {
+	withTTFTConfig(t, 0, defaultTTFTDeadlineBaseMs, TTFTAdmissionShadow)
+	reg := New(testLogger())
+	model := "shadow-exclude-model"
+
+	winner := makeSchedulerProvider(t, reg, "winner", model, 100)
+	idlePeer := makeSchedulerProvider(t, reg, "idle-peer", model, 100)
+
+	idleAlt := func(pr *PendingRequest, exclude ...string) bool {
+		reg.mu.Lock()
+		defer reg.mu.Unlock()
+		return reg.loadedIdleAlternativeExistsLocked(model, pr, winner, exclude...)
+	}
+
+	req := &PendingRequest{RequestID: "re", Model: model, EstimatedPromptTokens: 100, RequestedMaxTokens: 128}
+	if !idleAlt(req) {
+		t.Fatal("idle peer should count when not excluded")
+	}
+	if idleAlt(req, idlePeer.ID) {
+		t.Fatal("an excluded (retry/backup) idle peer must not count as a spread alternative")
+	}
+}

--- a/coordinator/store/interface.go
+++ b/coordinator/store/interface.go
@@ -212,6 +212,23 @@ type InferenceRouteOutcome struct {
 	// Speculative/backup-race dispatch outcome.
 	UsedBackup bool `json:"used_backup"`
 	BackupWon  bool `json:"backup_won"`
+
+	// CompletionTokensSet forces the completion_tokens column to be written from
+	// CompletionTokens even when it is 0. Without it, a terminal cancel/error/
+	// timeout row (which delivers 0 tokens) leaves completion_tokens NULL, so the
+	// incident-majority 0-token cancels are invisible in telemetry. Success rows
+	// already write a real (usually non-zero) count, so this only needs to be set
+	// on the terminal cancel/error/timeout constructors (and success, harmlessly).
+	CompletionTokensSet bool `json:"completion_tokens_set,omitempty"`
+
+	// InvalidTTFT is a transient (never-persisted) signal that the raw
+	// time-to-first-token computed for this outcome was negative and was clamped
+	// to 0. The single store-submit funnel emits routing.invalid_ttft when it is
+	// set, so any regression of the retried-request shared-Timing bug
+	// (FirstContentAt of an early attempt minus a later attempt's DispatchedAt)
+	// is loud rather than silent. json:"-" keeps it out of every API payload and
+	// neither store impl persists it.
+	InvalidTTFT bool `json:"-"`
 }
 
 // RejectionRecord captures a single rejected inbound inference request (4xx/5xx)

--- a/coordinator/store/postgres.go
+++ b/coordinator/store/postgres.go
@@ -1767,7 +1767,11 @@ func (s *PostgresStore) UpdateInferenceRouteOutcome(requestID string, attempt in
 			error_class = COALESCE(NULLIF($5, ''), error_class),
 			error_reason = COALESCE(NULLIF($6, ''), error_reason),
 			prompt_tokens = CASE WHEN $7 <> 0 THEN $7 ELSE prompt_tokens END,
-			completion_tokens = CASE WHEN $8 <> 0 THEN $8 ELSE completion_tokens END,
+			-- $24 (CompletionTokensSet) force-writes the count even when 0 so a
+			-- terminal cancel/error/timeout row persists 0 instead of NULL; the
+			-- OR $8 <> 0 keeps the legacy non-zero write path (mirrors the memory
+			-- store's mergeInferenceRouteOutcome exactly).
+			completion_tokens = CASE WHEN $24 OR $8 <> 0 THEN $8 ELSE completion_tokens END,
 			reasoning_tokens = CASE WHEN $9 <> 0 THEN $9 ELSE reasoning_tokens END,
 			cost_micro_usd = CASE WHEN $10 <> 0 THEN $10 ELSE cost_micro_usd END,
 			actual_ttft_ms = CASE WHEN $11 <> 0 THEN $11 ELSE actual_ttft_ms END,
@@ -1790,6 +1794,7 @@ func (s *PostgresStore) UpdateInferenceRouteOutcome(requestID string, attempt in
 		outcome.CostMicroUSD, outcome.ActualTTFTMs, outcome.DispatchToFirstChunkMs, outcome.TotalDurationMs,
 		outcome.ParseMs, outcome.ReserveMs, outcome.RouteMs, outcome.EncryptMs, outcome.QueueWaitMs, outcome.DispatchMs, outcome.ActualDecodeTPS,
 		outcome.AdmittedButFailed, outcome.UsedBackup, outcome.BackupWon,
+		outcome.CompletionTokensSet,
 	)
 	if err != nil {
 		return fmt.Errorf("store: update inference route outcome: %w", err)

--- a/coordinator/store/route_telemetry.go
+++ b/coordinator/store/route_telemetry.go
@@ -23,7 +23,14 @@ func mergeInferenceRouteOutcome(dst *InferenceRouteOutcome, src *InferenceRouteO
 	if src.PromptTokens != 0 {
 		dst.PromptTokens = src.PromptTokens
 	}
-	if src.CompletionTokens != 0 {
+	// CompletionTokensSet force-writes the count even when 0 (terminal cancel/
+	// error/timeout rows deliver 0 tokens and must persist 0, not be skipped as a
+	// zero-value). The flag is sticky so a later commit/latency update with the
+	// default (unset) flag cannot un-set an explicitly recorded 0.
+	if src.CompletionTokensSet {
+		dst.CompletionTokens = src.CompletionTokens
+		dst.CompletionTokensSet = true
+	} else if src.CompletionTokens != 0 {
 		dst.CompletionTokens = src.CompletionTokens
 	}
 	if src.ReasoningTokens != 0 {

--- a/coordinator/store/ttft_completion_tokens_test.go
+++ b/coordinator/store/ttft_completion_tokens_test.go
@@ -1,0 +1,68 @@
+package store
+
+import (
+	"testing"
+	"time"
+)
+
+// assertCancelledRowPersistsZeroCompletionTokens drives the shared scenario
+// against any Store impl: a route row gets a stale non-zero completion count from
+// an earlier (non-terminal) update, then a terminal cancel with
+// CompletionTokensSet=true must FORCE-write 0 — proving the flag overrides the
+// "treat 0 as absent" merge so the 0-token cancel population is queryable (not
+// NULL / not the stale value).
+func assertCancelledRowPersistsZeroCompletionTokens(t *testing.T, s Store) {
+	t.Helper()
+	const reqID = "req-cancel-0tok"
+
+	if err := s.RecordInferenceRoute(&InferenceRouteRecord{
+		RequestID: reqID,
+		Attempt:   0,
+		Model:     "gpt-oss-20b",
+		Outcome:   "selected",
+		CreatedAt: time.Now(),
+	}); err != nil {
+		t.Fatalf("RecordInferenceRoute: %v", err)
+	}
+
+	// Stale non-zero count from a non-terminal update (no flag).
+	if err := s.UpdateInferenceRouteOutcome(reqID, 0, &InferenceRouteOutcome{CompletionTokens: 7}); err != nil {
+		t.Fatalf("stale update: %v", err)
+	}
+
+	// Terminal cancel: 0 tokens delivered, force-persisted via the flag.
+	if err := s.UpdateInferenceRouteOutcome(reqID, 0, &InferenceRouteOutcome{
+		FinalStatus:         "cancelled",
+		ErrorClass:          "client_gone",
+		CompletionTokens:    0,
+		CompletionTokensSet: true,
+	}); err != nil {
+		t.Fatalf("terminal cancel update: %v", err)
+	}
+
+	all := s.InferenceRouteRecordsSince(time.Time{})
+	var got *InferenceRouteRecord
+	for i := range all {
+		if all[i].RequestID == reqID {
+			got = &all[i]
+			break
+		}
+	}
+	if got == nil {
+		t.Fatalf("route row %q not found", reqID)
+	}
+	if got.FinalStatus != "cancelled" {
+		t.Fatalf("final_status = %q, want cancelled", got.FinalStatus)
+	}
+	if got.CompletionTokens != 0 {
+		t.Fatalf("completion_tokens = %d, want 0 (forced, not the stale 7)", got.CompletionTokens)
+	}
+}
+
+func TestMemoryCancelledRowPersistsZeroCompletionTokens(t *testing.T) {
+	assertCancelledRowPersistsZeroCompletionTokens(t, NewMemory(Config{}))
+}
+
+func TestPostgresCancelledRowPersistsZeroCompletionTokens(t *testing.T) {
+	assertCancelledRowPersistsZeroCompletionTokens(t, testPostgresStore(t))
+}


### PR DESCRIPTION
## Summary

Phase 0 (coordinator-only, **behavior-neutral by default**) of the TTFT-contention fix. Grounded in read-only prod telemetry analysis (see `docs/reports/2026-06-22-*`).

- **Fix the broken TTFT telemetry.** `actual_ttft_ms` now derives from `FirstContentAt` vs the *committed* attempt's `DispatchedAt` (retry-proof; the old `FirstChunkAt − DispatchedAt` went as low as −378s on retries). Negatives clamp to 0 and emit `routing.invalid_ttft`. `completion_tokens` is now persisted on cancelled/error/timeout rows (was NULL) in **both** stores.
- **Occupancy-aware TTFT estimate**, reusing the *existing* `max(pendingForModel, backend_running+backend_waiting)` occupancy (extracted into `snapshotOccupancy`; **no new reservation counter**). Gated behind `EIGENINFERENCE_TTFT_OCCUPANCY_ALPHA` (default `0` ⇒ estimate/cost/ceiling byte-for-byte unchanged).
- **Shadow admission + spread measurement** at the data-verified ~10s deadline: emits `routing.ttft_admission{would_shed|would_serve}` and `routing.ttft_spread{would_redirect_to_idle}` **without changing any routing decision**. Gated behind `EIGENINFERENCE_TTFT_ADMISSION_MODE` (default `off`); `EIGENINFERENCE_TTFT_DEADLINE_BASE_MS` (default `10000`) is consumed only by the shadow evaluator.

Why: prod data showed cancels fit a ~10s deadline (not the code's 5s), token budget was non-binding (0.4% util at cancel), and ~54%/65% of `backend_running=0` gpt-oss cancels had hidden in-flight peers while ~44 loaded-idle providers sat unused — a load-spreading failure the coordinator already has the state to fix.

## Before / After

```mermaid
flowchart TB
  subgraph Before
    A1[request] --> A2["admit onto provider reporting backend_running=0<br/>(stale gauge: hidden in-flight peers)"]
    A2 --> A3["~11s, 0 tokens delivered"]
    A3 --> A4["client_gone cancel"]
    A2 -.telemetry.-> A5["actual_ttft_ms = FirstChunkAt − DispatchedAt<br/>retry ⇒ negative (−378s); completion_tokens NULL on cancel"]
  end
  subgraph After["After (defaults alpha=0, mode=off ⇒ behavior-neutral)"]
    B1[request] --> B2["estimate reads EXISTING occupancy<br/>max(pendingForModel, backend_running+waiting) [alpha-gated]"]
    B2 --> B3{"TTFT_ADMISSION_MODE"}
    B3 -->|off default| B4["serve exactly as today"]
    B3 -->|shadow| B5["emit would_shed / would_redirect_to_idle<br/>(no decision change)"]
    B2 -.telemetry.-> B6["actual_ttft_ms = FirstContentAt − committed DispatchedAt<br/>clamp >= 0 + routing.invalid_ttft; completion_tokens persisted (0 on cancel)"]
  end
```

Code paths changed: `registry/scheduler.go` (`snapshotOccupancy`, `ttftOccupancyMs`, shadow wiring in `ReserveProviderEx`), new `registry/ttft_shadow.go`, `registry/registry.go` (`MarkFirstContentArrived`/`FirstContentAtSafe`), `api/route_outcome.go` + `api/provider.go` + `api/dispatch.go` (telemetry), new `api/ttft_shadow_metrics.go`, `store/{interface,postgres,route_telemetry}.go` (`CompletionTokensSet`), `cmd/coordinator/main.go` (env wiring).

## Test plan

- [x] `go test ./...` green; `go test -race ./registry/... ./api/...` green; `gofmt -l` empty; `go vet` clean (re-verified after rebase onto #445).
- [x] New tests: occupancy term == 0 at alpha=0; alpha>0 estimate monotonic in occupancy and crosses the 10s knee; shadow `would_shed` yet still serves; retried-request `actual_ttft_ms` clamped to 0 + metered; `completion_tokens`=0 persists on a cancelled row in memory **and** postgres impls.
- [x] Behavior-neutral by default: with `alpha=0` + `mode=off`, no routing or telemetry-decision change; prod `EIGENINFERENCE_TTFT_HARD_REJECT` path untouched.

## Rollout

Land (neutral) → set `TTFT_ADMISSION_MODE=shadow` in dev to collect `would_shed`/`would_redirect_to_idle` → **enforce step (separate PR):** wire the actual rejection/redirect, move the live `consumer.go` base 5s→10s, and stage `EIGENINFERENCE_QUALITY_CONCURRENCY_OVERCOMMIT` 2.0→1.0.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/447"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784739632&installation_id=133247490&pr_number=447&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F447&signature=e406ef8a7f764c72bb2972f6d4d8501c5fb8b9bd624728a96b729c999720720a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->