### PR TITLE
fix(console-ui): repair Network Stats surfaces and scroll containment

### DIFF
--- a/console-ui/src/app/stats/page.tsx
+++ b/console-ui/src/app/stats/page.tsx
@@ -475,7 +475,7 @@ function MiniStat({
   sub?: string;
 }) {
   return (
-    <div className="rounded-xl border border-border-dim bg-bg-primary px-4 py-3 shadow-sm">
+    <div className="rounded-xl border border-border-dim bg-bg-white px-4 py-3 shadow-sm">
       <p className="text-[10px] font-mono text-text-tertiary uppercase tracking-wider">
         {label}
       </p>
@@ -894,7 +894,7 @@ function ActiveModelsSection({
   const routableSlots = visibleInventory.reduce((sum, item) => sum + item.routable, 0);
 
   return (
-    <section className="rounded-xl border border-border-dim bg-bg-primary p-5 shadow-sm">
+    <section className="rounded-xl border border-border-dim bg-bg-white p-5 shadow-sm">
       <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
         <div className="flex items-start gap-3">
           <div className="flex h-9 w-9 items-center justify-center rounded-lg border border-accent-brand/20 bg-accent-brand/10 text-accent-brand">
@@ -1214,7 +1214,7 @@ function ProviderGeography({ stats }: { stats: PlatformStats }) {
     : "No resolved provider locations yet";
 
   return (
-    <section className="bg-bg-primary rounded-xl p-5 sm:p-6 shadow-sm space-y-5">
+    <section className="bg-bg-white rounded-xl p-5 sm:p-6 shadow-sm space-y-5">
       <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3">
         <div>
           <div className="flex items-center gap-2">
@@ -1618,7 +1618,7 @@ function RequestGeography({ stats }: { stats: PlatformStats }) {
   const topRegions = regionBuckets.slice(0, 6);
 
   return (
-    <section className="bg-bg-primary rounded-xl p-5 sm:p-6 shadow-sm space-y-5">
+    <section className="bg-bg-white rounded-xl p-5 sm:p-6 shadow-sm space-y-5">
       <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3">
         <div>
           <div className="flex items-center gap-2">
@@ -1893,7 +1893,7 @@ function ActivityChart({
   }
 
   return (
-    <div className="bg-bg-primary rounded-xl p-5 space-y-4 shadow-sm">
+    <div className="bg-bg-white rounded-xl p-5 space-y-4 shadow-sm">
       <div className="flex items-center justify-between">
         <div>
           <h3 className="text-xs font-mono text-text-tertiary uppercase tracking-wider">
@@ -2037,7 +2037,7 @@ function TokenChart({ data }: { data: TimeSeriesBucket[] }) {
   }
 
   return (
-    <div className="bg-bg-primary rounded-xl p-5 space-y-4 shadow-sm">
+    <div className="bg-bg-white rounded-xl p-5 space-y-4 shadow-sm">
       <div className="flex items-center justify-between">
         <div>
           <h3 className="text-xs font-mono text-text-tertiary uppercase tracking-wider">
@@ -2260,7 +2260,7 @@ function LeaderboardSection() {
 
   return (
     <section className="space-y-5">
-      <div className="rounded-xl border border-border-dim bg-bg-primary p-5 shadow-sm">
+      <div className="rounded-xl border border-border-dim bg-bg-white p-5 shadow-sm">
         <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
           <div>
             <div className="flex items-center gap-2">
@@ -2343,7 +2343,7 @@ function LeaderboardSection() {
         </div>
       </div>
 
-      <div className="rounded-xl border border-border-dim bg-bg-primary p-5 shadow-sm">
+      <div className="rounded-xl border border-border-dim bg-bg-white p-5 shadow-sm">
         <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
           <div>
             <h3 className="text-sm font-semibold text-text-primary">Rankings</h3>
@@ -2871,7 +2871,7 @@ function NetworkNodes({ providers }: { providers: ProviderStats[] }) {
   }
 
   return (
-    <section className="rounded-xl border border-border-dim bg-bg-primary p-5 shadow-sm">
+    <section className="rounded-xl border border-border-dim bg-bg-white p-5 shadow-sm">
       <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
         <div>
           <div className="flex items-center gap-2">
@@ -3053,7 +3053,7 @@ export default function StatsPage() {
 
   if (loading) {
     return (
-      <div className="flex-1 flex flex-col">
+      <div className="flex flex-col h-full">
         <TopBar title="Network Stats" />
         <div className="flex-1 flex items-center justify-center">
           <Loader2 size={24} className="animate-spin text-text-tertiary" />
@@ -3064,7 +3064,7 @@ export default function StatsPage() {
 
   if (error || !stats) {
     return (
-      <div className="flex-1 flex flex-col">
+      <div className="flex flex-col h-full">
         <TopBar title="Network Stats" />
         <div className="flex-1 flex items-center justify-center">
           <div className="text-center space-y-2">
@@ -3093,9 +3093,15 @@ export default function StatsPage() {
   ];
 
   return (
-    <div className="flex-1 flex flex-col overflow-y-auto">
+    <div className="flex flex-col h-full">
       <TopBar title="Network Stats" />
-      <div className="max-w-5xl mx-auto px-3 sm:px-6 py-6 sm:py-8 space-y-6">
+      {/* `relative` makes this the containing block for any absolutely-positioned
+          descendants (e.g. the sr-only toggle checkbox in ActiveModelsSection).
+          Without it, those abs elements escape this scroller's clip, anchor to
+          <body>, and stretch the document — making the whole page scroll when the
+          wheel is over the non-scrolling sidebar. */}
+      <div className="flex-1 overflow-y-auto relative">
+        <div className="max-w-5xl mx-auto px-3 sm:px-6 py-6 sm:py-8 space-y-6">
         {/* Header */}
         <div className="flex items-center justify-between">
           <div>
@@ -3120,7 +3126,7 @@ export default function StatsPage() {
           </div>
         </div>
 
-        <div className="flex flex-wrap gap-2 rounded-xl border border-border-dim bg-bg-primary p-1.5 shadow-sm">
+        <div className="flex flex-wrap gap-2 rounded-xl border border-border-dim bg-bg-white p-1.5 shadow-sm">
           {tabs.map((tab) => (
             <button
               key={tab.value}
@@ -3142,7 +3148,7 @@ export default function StatsPage() {
         ) : (
           <>
         {/* Hero section -- big numbers */}
-        <div className="bg-bg-primary rounded-2xl p-8 shadow-sm">
+        <div className="bg-bg-white rounded-2xl p-8 shadow-sm">
           <div className="grid grid-cols-2 md:grid-cols-4 gap-8">
             <HeroStat
               value={formatNumber(stats.total_tokens)}
@@ -3209,7 +3215,7 @@ export default function StatsPage() {
 
         {/* Token distribution bar (only if there are tokens) */}
         {stats.total_tokens > 0 && (
-          <div className="bg-bg-primary rounded-xl p-5 space-y-3 shadow-sm">
+          <div className="bg-bg-white rounded-xl p-5 space-y-3 shadow-sm">
             <h3 className="text-xs font-mono text-text-tertiary uppercase tracking-wider">
               Token Distribution
             </h3>
@@ -3261,6 +3267,7 @@ export default function StatsPage() {
           <p className="text-xs font-mono text-text-tertiary uppercase tracking-widest">
             Auto-refreshes every 10 seconds
           </p>
+        </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## What

Fixes three layout defects on the **Network Stats** page (`console-ui/src/app/stats/page.tsx`). Class/token-only change — no logic touched.

1. **Invisible card surfaces.** Every card/chart/panel used `bg-bg-primary` — the *same* token as the page background — so surfaces were near-invisible in light mode and fully invisible in dark mode. Switched the 12 top-level surfaces to `bg-bg-white`, matching billing/models and the rest of the console.
2. **Broken scroll container.** The page root carried `overflow-y-auto`, nesting a second scroller inside AppShell's `<main>` and letting the `TopBar` scroll away. Reworked to the canonical pattern every other page uses: non-scrolling root + pinned TopBar + a single `flex-1 overflow-y-auto` wrapper.
3. **Whole-document scroll.** An `sr-only`, absolutely-positioned toggle checkbox (the "Show deprecated models" switch in `ActiveModelsSection`) escaped the scroller's clip — its containing block fell through to `<body>` — stretching the document to ~3× the viewport (`html.scrollHeight` 3076 vs 1000px viewport). Scrolling while the pointer was over the non-scrolling sidebar dragged the entire app upward. Fixed by making the scroll wrapper `position: relative` so absolutely-positioned descendants are contained and clipped.

## Before / After

### Behavior

```mermaid
flowchart TB
  subgraph Before
    B1[wheel over sidebar] --> B2[document/&lt;html&gt; is 3076px, scrollable]
    B2 --> B3[whole app dragged up:<br/>TopBar + sidebar scroll away]
    B4[cards use bg-bg-primary<br/>= page background] --> B5[surfaces invisible<br/>invisible in dark mode]
  end
  subgraph After
    A1[wheel over sidebar] --> A2[document locked at viewport height<br/>window.scrollY stays 0]
    A3[wheel over content] --> A4[only inner wrapper scrolls;<br/>TopBar + sidebar pinned]
    A5[cards use bg-bg-white] --> A6[surfaces visible in light + dark]
  end
```

### Code / DOM structure

```mermaid
flowchart LR
  subgraph Before
    M1["main (overflow-y-auto)"] --> R1["root: flex-1 flex flex-col overflow-y-auto"]
    R1 --> T1[TopBar - inside scroller]
    R1 --> C1["content (no inner wrapper)"]
    C1 -. "sr-only abs checkbox escapes<br/>to &lt;body&gt; -> stretches doc" .-> X1[(&lt;body&gt;)]
  end
  subgraph After
    M2["main (overflow-y-auto)"] --> R2["root: flex flex-col h-full (no scroll)"]
    R2 --> T2[TopBar - pinned, shrink-0]
    R2 --> W2["wrapper: flex-1 overflow-y-auto relative"]
    W2 --> C2[content]
    C2 -. "abs descendants contained<br/>+ clipped by wrapper" .-> W2
  end
```

## Verification

- `tsc --noEmit`: error set **byte-for-byte identical** to `master` (0 new errors; pre-existing errors are unrelated fixture/type drift).
- `eslint stats/page.tsx`: **0 errors** (16 pre-existing warnings, unchanged).
- `next build`: **succeeds**, `/stats` prerenders.
- Ran the dev server against the **prod coordinator** and confirmed in-browser (Playwright): `html.scrollHeight` 3076 → 1000; wheel over sidebar keeps `window.scrollY === 0`; wheel over content scrolls the inner wrapper while TopBar/sidebar stay pinned. Scroll fix also confirmed manually by the reviewer.

## Scope

Only `stats/page.tsx`. `sr-only` is used nowhere else in the app, so no other page has the document-stretch trigger today (other pages share the scroll-wrapper pattern but lack an escaping element).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/448"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784751391&installation_id=133247490&pr_number=448&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F448&signature=4b6754708fa3dc7d153b2072b7a116cacb18cf2ce4bd4af7a9d1f1426899c879"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->