### PR TITLE
geo: ip-api.com PRO endpoint via EIGENINFERENCE_IPAPI_KEY (free fallback)

### DIFF
--- a/coordinator/api/provider_geo.go
+++ b/coordinator/api/provider_geo.go
@@ -19,6 +19,21 @@ import (
 
 const (
 	envTrustGeoHeaders = "EIGENINFERENCE_TRUST_GEO_HEADERS"
+	// envIPAPIKey holds the ip-api.com PRO API key. It is a SECRET — injected via
+	// the deployment env (EigenCloud KMS / GCP Secret Manager), never committed.
+	// When set, geo lookups use the unmetered https://pro.ip-api.com endpoint;
+	// when empty the resolver falls back to the free http://ip-api.com tier.
+	envIPAPIKey = "EIGENINFERENCE_IPAPI_KEY"
+
+	// ipAPIFreeBaseURL is the free, HTTP-only ip-api.com endpoint (45 req/min by
+	// source IP, no key). ipAPIProBaseURL is the keyed, HTTPS, unmetered PRO
+	// endpoint. Both share the same /json/<ip> path and field set.
+	ipAPIFreeBaseURL = "http://ip-api.com"
+	ipAPIProBaseURL  = "https://pro.ip-api.com"
+
+	// ipAPIFields is the comma-separated ip-api.com field selector. Kept minimal:
+	// only the geo fields ProviderLocation needs, plus status for success checks.
+	ipAPIFields = "status,country,countryCode,regionName,region,city,lat,lon,timezone"
 )
 
 type providerGeoResolver interface {
@@ -27,13 +42,32 @@ type providerGeoResolver interface {
 
 type ipAPIGeoResolver struct {
 	trustHeaders bool
-	logger       *slog.Logger
+	// apiKey is the ip-api.com PRO key (empty => free tier). When non-empty the
+	// resolver targets baseURL=ipAPIProBaseURL and appends &key=<apiKey>.
+	apiKey string
+	// baseURL is the ip-api.com origin (scheme+host, no trailing slash). Defaults
+	// to the free or PRO endpoint based on apiKey; overridable in tests so URL
+	// construction and response parsing can be exercised against httptest without
+	// hitting the live service.
+	baseURL string
+	// httpClient performs the lookup. Defaults to http.DefaultClient; overridable
+	// in tests. A nil client falls back to http.DefaultClient at call time.
+	httpClient *http.Client
+	logger     *slog.Logger
 }
 
 func newProviderGeoResolverFromEnv(logger *slog.Logger) providerGeoResolver {
 	trustHeaders := os.Getenv(envTrustGeoHeaders) == "1"
+	apiKey := strings.TrimSpace(os.Getenv(envIPAPIKey))
+	baseURL := ipAPIFreeBaseURL
+	if apiKey != "" {
+		baseURL = ipAPIProBaseURL
+	}
 	return &ipAPIGeoResolver{
 		trustHeaders: trustHeaders,
+		apiKey:       apiKey,
+		baseURL:      baseURL,
+		httpClient:   http.DefaultClient,
 		logger:       logger,
 	}
 }
@@ -61,22 +95,30 @@ func (g *ipAPIGeoResolver) Lookup(r *http.Request) *store.ProviderLocation {
 	return g.lookupIPAPI(ip)
 }
 
-// lookupIPAPI resolves geolocation via the free ip-api.com service.
-// No API key required. Rate limit: 45 req/min — called once per provider
-// WebSocket connection, so even 250 concurrent providers is fine.
+// lookupIPAPI resolves geolocation via ip-api.com.
+//
+// With a PRO key (EIGENINFERENCE_IPAPI_KEY) it uses the unmetered
+// https://pro.ip-api.com endpoint; without one it falls back to the free
+// http://ip-api.com endpoint (45 req/min by source IP — called once per provider
+// WebSocket connection, so even 250 concurrent providers is fine on the free
+// tier). The Source field records which tier answered ("ip-api-pro" vs "ip-api").
 func (g *ipAPIGeoResolver) lookupIPAPI(ip net.IP) *store.ProviderLocation {
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
 
-	apiURL := fmt.Sprintf("http://ip-api.com/json/%s?fields=status,country,countryCode,regionName,region,city,lat,lon,timezone", ip.String())
+	apiURL := g.buildLookupURL(ip)
 	req, err := http.NewRequestWithContext(ctx, "GET", apiURL, nil)
 	if err != nil {
 		return nil
 	}
-	resp, err := http.DefaultClient.Do(req)
+	client := g.httpClient
+	if client == nil {
+		client = http.DefaultClient
+	}
+	resp, err := client.Do(req)
 	if err != nil {
 		if g.logger != nil {
-			g.logger.Debug("ip-api lookup failed", "ip", ip.String(), "error", err)
+			g.logger.Debug("ip-api lookup failed", "ip", ip.String(), "pro", g.apiKey != "", "error", err)
 		}
 		return nil
 	}
@@ -95,7 +137,7 @@ func (g *ipAPIGeoResolver) lookupIPAPI(ip net.IP) *store.ProviderLocation {
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil || result.Status != "success" {
 		if g.logger != nil {
-			g.logger.Debug("ip-api lookup unsuccessful", "ip", ip.String(), "status", result.Status)
+			g.logger.Debug("ip-api lookup unsuccessful", "ip", ip.String(), "pro", g.apiKey != "", "status", result.Status)
 		}
 		return nil
 	}
@@ -109,9 +151,35 @@ func (g *ipAPIGeoResolver) lookupIPAPI(ip net.IP) *store.ProviderLocation {
 		Latitude:    result.Lat,
 		Longitude:   result.Lon,
 		Timezone:    result.Timezone,
-		Source:      "ip-api",
+		Source:      g.sourceLabel(),
 		UpdatedAt:   time.Now().UTC(),
 	}
+}
+
+// buildLookupURL constructs the ip-api.com request URL for ip. When a PRO key is
+// configured it targets baseURL (https://pro.ip-api.com by default) and appends
+// &key=<key>; otherwise it uses the free endpoint with no key. The /json/<ip>
+// path and field set are identical across tiers, so the only wire difference is
+// the origin and the trailing key parameter.
+func (g *ipAPIGeoResolver) buildLookupURL(ip net.IP) string {
+	base := strings.TrimRight(g.baseURL, "/")
+	if base == "" {
+		base = ipAPIFreeBaseURL
+	}
+	apiURL := fmt.Sprintf("%s/json/%s?fields=%s", base, ip.String(), ipAPIFields)
+	if g.apiKey != "" {
+		apiURL += "&key=" + url.QueryEscape(g.apiKey)
+	}
+	return apiURL
+}
+
+// sourceLabel reports the ProviderLocation.Source tag for the active tier so
+// telemetry can distinguish PRO from free lookups.
+func (g *ipAPIGeoResolver) sourceLabel() string {
+	if g.apiKey != "" {
+		return "ip-api-pro"
+	}
+	return "ip-api"
 }
 
 func (s *Server) requestLocation(r *http.Request) *store.ProviderLocation {

--- a/coordinator/api/provider_geo_test.go
+++ b/coordinator/api/provider_geo_test.go
@@ -1,7 +1,11 @@
 package api
 
 import (
+	"io"
+	"net"
 	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"testing"
 )
 
@@ -44,5 +48,157 @@ func TestLocationFromTrustedGeoHeaders(t *testing.T) {
 	}
 	if loc.Latitude != 37.7749 || loc.Longitude != -122.4194 {
 		t.Fatalf("unexpected coordinates: %#v", loc)
+	}
+}
+
+// ipAPIResolverFromEnv constructs the concrete resolver and asserts the env
+// wiring produced an *ipAPIGeoResolver (the only implementation).
+func ipAPIResolverFromEnv(t *testing.T) *ipAPIGeoResolver {
+	t.Helper()
+	r, ok := newProviderGeoResolverFromEnv(nil).(*ipAPIGeoResolver)
+	if !ok {
+		t.Fatalf("newProviderGeoResolverFromEnv returned %T, want *ipAPIGeoResolver", r)
+	}
+	return r
+}
+
+func TestNewProviderGeoResolverUsesProEndpointWithKey(t *testing.T) {
+	t.Setenv(envIPAPIKey, "fake-pro-key")
+
+	g := ipAPIResolverFromEnv(t)
+	if g.apiKey != "fake-pro-key" {
+		t.Fatalf("apiKey = %q, want fake-pro-key", g.apiKey)
+	}
+	if g.baseURL != ipAPIProBaseURL {
+		t.Fatalf("baseURL = %q, want %q", g.baseURL, ipAPIProBaseURL)
+	}
+	if got := g.sourceLabel(); got != "ip-api-pro" {
+		t.Fatalf("sourceLabel = %q, want ip-api-pro", got)
+	}
+}
+
+func TestNewProviderGeoResolverFreeEndpointWithoutKey(t *testing.T) {
+	// Empty value behaves exactly like unset (graceful free-tier fallback).
+	t.Setenv(envIPAPIKey, "  ")
+
+	g := ipAPIResolverFromEnv(t)
+	if g.apiKey != "" {
+		t.Fatalf("apiKey = %q, want empty", g.apiKey)
+	}
+	if g.baseURL != ipAPIFreeBaseURL {
+		t.Fatalf("baseURL = %q, want %q", g.baseURL, ipAPIFreeBaseURL)
+	}
+	if got := g.sourceLabel(); got != "ip-api" {
+		t.Fatalf("sourceLabel = %q, want ip-api", got)
+	}
+}
+
+func TestBuildLookupURL(t *testing.T) {
+	ip := net.ParseIP("8.8.8.8")
+	const fields = "fields=status,country,countryCode,regionName,region,city,lat,lon,timezone"
+
+	tests := []struct {
+		name   string
+		apiKey string
+		base   string
+		want   string
+	}{
+		{
+			name: "free tier omits key",
+			base: ipAPIFreeBaseURL,
+			want: "http://ip-api.com/json/8.8.8.8?" + fields,
+		},
+		{
+			name:   "pro tier appends key over https",
+			apiKey: "fake-pro-key",
+			base:   ipAPIProBaseURL,
+			want:   "https://pro.ip-api.com/json/8.8.8.8?" + fields + "&key=fake-pro-key",
+		},
+		{
+			name:   "key with reserved chars is escaped",
+			apiKey: "a b&c",
+			base:   ipAPIProBaseURL,
+			want:   "https://pro.ip-api.com/json/8.8.8.8?" + fields + "&key=a+b%26c",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g := &ipAPIGeoResolver{apiKey: tc.apiKey, baseURL: tc.base}
+			if got := g.buildLookupURL(ip); got != tc.want {
+				t.Fatalf("buildLookupURL = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+const ipAPISuccessBody = `{"status":"success","country":"United States","countryCode":"US",` +
+	`"regionName":"California","region":"CA","city":"Mountain View",` +
+	`"lat":37.4056,"lon":-122.0775,"timezone":"America/Los_Angeles"}`
+
+func TestLookupIPAPIProUsesKeyAndParsesResponse(t *testing.T) {
+	var gotURL *url.URL
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotURL = r.URL
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, ipAPISuccessBody)
+	}))
+	defer ts.Close()
+
+	g := &ipAPIGeoResolver{apiKey: "fake-pro-key", baseURL: ts.URL, httpClient: ts.Client()}
+	loc := g.lookupIPAPI(net.ParseIP("8.8.8.8"))
+
+	if gotURL == nil {
+		t.Fatal("server received no request")
+	}
+	if gotURL.Path != "/json/8.8.8.8" {
+		t.Fatalf("request path = %q, want /json/8.8.8.8", gotURL.Path)
+	}
+	if got := gotURL.Query().Get("key"); got != "fake-pro-key" {
+		t.Fatalf("key query = %q, want fake-pro-key", got)
+	}
+	if got := gotURL.Query().Get("fields"); got != ipAPIFields {
+		t.Fatalf("fields query = %q, want %q", got, ipAPIFields)
+	}
+
+	if loc == nil {
+		t.Fatal("expected location")
+	}
+	if loc.City != "Mountain View" || loc.Region != "California" || loc.RegionCode != "CA" {
+		t.Fatalf("unexpected location: %#v", loc)
+	}
+	if loc.Country != "United States" || loc.CountryCode != "US" {
+		t.Fatalf("unexpected country: %#v", loc)
+	}
+	if loc.Latitude != 37.4056 || loc.Longitude != -122.0775 {
+		t.Fatalf("unexpected coordinates: %#v", loc)
+	}
+	if loc.Timezone != "America/Los_Angeles" {
+		t.Fatalf("unexpected timezone: %q", loc.Timezone)
+	}
+	if loc.Source != "ip-api-pro" {
+		t.Fatalf("Source = %q, want ip-api-pro", loc.Source)
+	}
+}
+
+func TestLookupIPAPIFreeOmitsKey(t *testing.T) {
+	var gotURL *url.URL
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotURL = r.URL
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, ipAPISuccessBody)
+	}))
+	defer ts.Close()
+
+	g := &ipAPIGeoResolver{apiKey: "", baseURL: ts.URL, httpClient: ts.Client()}
+	loc := g.lookupIPAPI(net.ParseIP("8.8.8.8"))
+
+	if gotURL == nil {
+		t.Fatal("server received no request")
+	}
+	if gotURL.Query().Has("key") {
+		t.Fatalf("free tier must not send a key, got query %q", gotURL.RawQuery)
+	}
+	if loc == nil || loc.Source != "ip-api" {
+		t.Fatalf("Source = %v, want ip-api", loc)
 	}
 }

--- a/coordinator/cmd/coordinator/main.go
+++ b/coordinator/cmd/coordinator/main.go
@@ -212,6 +212,14 @@ func main() {
 		logger.Info("warm-pool controller enabled", "observe_only", cfg.RegistryCfg.WarmPool.ObserveOnly, "interval", cfg.RegistryCfg.WarmPool.Interval.String())
 	}
 
+	// Provider/consumer IP geolocation (api.newProviderGeoResolverFromEnv, invoked
+	// from NewServer) reads two optional env vars:
+	//   - EIGENINFERENCE_TRUST_GEO_HEADERS=1 — trust CF/Vercel geo headers from a
+	//     trusted reverse proxy instead of calling ip-api.com.
+	//   - EIGENINFERENCE_IPAPI_KEY — ip-api.com PRO key (SECRET; inject via KMS /
+	//     Secret Manager, never commit). When set, geo lookups use the unmetered
+	//     https://pro.ip-api.com endpoint; unset falls back to the free, 45 req/min
+	//     http://ip-api.com endpoint (graceful, so dev without a key still works).
 	srv := api.NewServer(reg, st, cfg.ServerConfig, logger)
 	// Stop the routing-telemetry sink's worker pool on shutdown. Deferred so it
 	// runs after the HTTP server has drained (no in-flight request can still be

--- a/deploy/gcp/refresh-env.sh
+++ b/deploy/gcp/refresh-env.sh
@@ -55,6 +55,11 @@ EIGENINFERENCE_STRIPE_CANCEL_URL=$(fetch eigeninference-stripe-cancel-url)
 EIGENINFERENCE_STRIPE_CONNECT_WEBHOOK_SECRET=$(fetch eigeninference-stripe-connect-webhook-secret)
 EIGENINFERENCE_STRIPE_CONNECT_RETURN_URL=$(fetch eigeninference-stripe-connect-return-url)
 EIGENINFERENCE_STRIPE_CONNECT_REFRESH_URL=$(fetch eigeninference-stripe-connect-refresh-url)
+# ip-api.com PRO key (optional, not in CRITICAL_VARS). When present, provider/
+# consumer geo lookups use the unmetered https://pro.ip-api.com endpoint; absent
+# (secret missing => empty) the coordinator gracefully falls back to the free
+# 45 req/min http://ip-api.com tier, so a missing secret never breaks deploy.
+EIGENINFERENCE_IPAPI_KEY=$(fetch eigeninference-ipapi-key)
 DD_API_KEY=$(fetch eigeninference-dd-api-key)
 DD_SITE=$(fetch eigeninference-dd-site)
 DD_ENV=development

--- a/docs/operations/coordinator-deploy.md
+++ b/docs/operations/coordinator-deploy.md
@@ -185,6 +185,7 @@ Managed via EigenCloud KMS (prod) or GCP Secret Manager (dev). Core coordinator 
 | `EIGENINFERENCE_STEP_CA_ROOT`, `EIGENINFERENCE_STEP_CA_INTERMEDIATE` | CA cert paths |
 | `MNEMONIC` | 12-word BIP39 Solana wallet for coordinator |
 | `EIGENINFERENCE_SOLANA_RPC_URL` | Solana RPC endpoint |
+| `EIGENINFERENCE_IPAPI_KEY` | ip-api.com **PRO** key (secret, optional). When set, provider/consumer geo lookups use the unmetered `https://pro.ip-api.com` endpoint; unset falls back to the free 45 req/min `http://ip-api.com` tier. Dev: `gcloud secrets create eigeninference-ipapi-key`. Never commit the value. |
 | `DOMAIN` | Public domain, used by Caddyfile and `start.sh` |
 | `APP_PORT` | Port Caddy reverse-proxies to (default 8080) |
 


### PR DESCRIPTION
## Summary

The coordinator's provider/consumer IP geo resolver (`coordinator/api/provider_geo.go`) was hardwired to the **free** `http://ip-api.com/json/...` endpoint, capped at **45 req/min** by source IP. This PR adds **ip-api.com PRO** support behind the `EIGENINFERENCE_IPAPI_KEY` env var (a secret):

- **Pro with graceful free fallback.** When `EIGENINFERENCE_IPAPI_KEY` is set, lookups use the unmetered `https://pro.ip-api.com/json/<ip>?fields=...&key=<key>` endpoint and tag `ProviderLocation.Source = "ip-api-pro"`. When unset/empty, behavior is **byte-for-byte identical** to today (free endpoint, `Source = "ip-api"`), so dev without a key keeps working.
- **Testable.** The ip-api base URL and HTTP client are now injectable fields on the resolver (defaulting to the real values), so URL construction + response parsing are unit-tested against `httptest.NewServer` without hitting the live service.
- **Secret hygiene.** The key is read from env only — never hardcoded, logged (debug logs record only a `pro` bool), or committed. Operator sets it via EigenCloud KMS (prod) / GCP Secret Manager (dev); tests use a fake key.
- **Docs/wiring.** `EIGENINFERENCE_IPAPI_KEY` is documented in `cmd/coordinator/main.go`, the deploy env-var table (`docs/operations/coordinator-deploy.md`), and wired (optional, graceful, **not** in `CRITICAL_VARS`) into `deploy/gcp/refresh-env.sh` as `$(fetch eigeninference-ipapi-key)`.

### UI
**No UI changes needed.** Neither `console-ui/next.config.ts` nor `admin-ui/next.config.ts` — nor any UI code — makes client-side ip-api calls; a repo-wide search for `ip-api` matches only `provider_geo.go`. Geo resolution is entirely server-side in the coordinator, and the key stays server-side (never exposed to the browser).

### Follow-up (not in this PR)
Now that PRO removes the rate limit, a one-time backfill of providers currently missing a `Location` would be cheap, but is intentionally out of scope: the per-connection lookup already re-resolves on every reconnect, so the fleet self-heals without it.

## Before / After

### Behavior
```mermaid
flowchart LR
  subgraph Before["Before — free only"]
    A1["provider / consumer connects"] --> B1["resolver.Lookup"]
    B1 --> C1["GET ip-api.com over HTTP, no key"]
    C1 --> D1["45 req per min cap"]
    D1 --> E1["Source = ip-api"]
  end
  subgraph After["After — PRO with free fallback"]
    A2["provider / consumer connects"] --> B2["resolver.Lookup"]
    B2 --> K{"EIGENINFERENCE_IPAPI_KEY set"}
    K -- yes --> P["GET pro.ip-api.com over HTTPS, key appended, unmetered"]
    K -- no --> F["GET ip-api.com over HTTP, no key, 45 req per min"]
    P --> SP["Source = ip-api-pro"]
    F --> SF["Source = ip-api"]
  end
```

### Code
```mermaid
flowchart TB
  subgraph CodeBefore["Before"]
    cb1["newProviderGeoResolverFromEnv"] --> cb2["ipAPIGeoResolver: trustHeaders, logger"]
    cb2 --> cb3["lookupIPAPI: hardcoded http://ip-api.com plus http.DefaultClient"]
    cb3 --> cb4["Source constant ip-api"]
  end
  subgraph CodeAfter["After"]
    ca1["newProviderGeoResolverFromEnv reads EIGENINFERENCE_IPAPI_KEY"] --> ca2["ipAPIGeoResolver: trustHeaders, apiKey, baseURL, httpClient, logger"]
    ca2 --> ca3["lookupIPAPI calls buildLookupURL plus injectable httpClient"]
    ca3 --> ca4["sourceLabel returns ip-api-pro when keyed else ip-api"]
  end
```

## Test plan

New unit tests in `coordinator/api/provider_geo_test.go` (each fails to compile/pass without this change — they reference the new fields/helpers and assert PRO wiring):

- `TestNewProviderGeoResolverUsesProEndpointWithKey` — key set ⇒ `baseURL == https://pro.ip-api.com`, `apiKey` populated, `sourceLabel == ip-api-pro`.
- `TestNewProviderGeoResolverFreeEndpointWithoutKey` — empty/whitespace key ⇒ free base, no key, `sourceLabel == ip-api`.
- `TestBuildLookupURL` — table: free omits `key`; pro appends `&key=`; reserved chars in the key are URL-escaped.
- `TestLookupIPAPIProUsesKeyAndParsesResponse` — via `httptest`: asserts the server receives `/json/<ip>`, `key=<fake>`, and the full `fields` set, parses the success body, and returns `Source == ip-api-pro` (no live call).
- `TestLookupIPAPIFreeOmitsKey` — via `httptest`: free tier sends **no** `key` param, returns `Source == ip-api`.

Verification (in `coordinator/`):

- [x] `gofmt -l` clean on changed files
- [x] `go build ./...`
- [x] `go vet ./api/... ./cmd/...`
- [x] `go test ./...` — all packages green
- [n/a] UI lint/build — no UI files touched

**Not deployed.** No `.env` or key value is committed anywhere (verified by scan).

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/449"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784753324&installation_id=133247490&pr_number=449&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F449&signature=3e497c74f1f52077fe0c3fad7c7ed345c6872e4005bc5994fc87cc55aad127c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->