### PR TITLE
fix(coordinator): recalibrate prefill-TPS fallback — cut the 41% long-prompt ttft_429 over-shed

### DIFF
--- a/coordinator/api/inference_admission.go
+++ b/coordinator/api/inference_admission.go
@@ -380,6 +380,14 @@ func (s *Server) runInferenceAdmission(w http.ResponseWriter, r *http.Request, p
 		}
 	}
 	if ttftTooSlow(bestTTFT, hasTTFT, ttftThreshold) {
+		// Prefill-fallback shadow: live routing still runs on the legacy fallback
+		// here, but measure whether the recalibrated fallback would have cleared the
+		// SAME deadline — i.e. the projected ttft_429 recovery the enforce flip
+		// delivers. Extra scan paid only in shadow mode.
+		if registry.PrefillFallbackModeValue() == registry.PrefillFallbackShadow {
+			recalTTFT, recalHas := s.registry.QuickCapacityCheckRecalibratedTTFT(model, p.estimatedPromptTokens, p.requestedMaxTokens, registry.RequestTraits{HasTools: p.hasTools}, p.requiresVision, p.allowedProviderSerials...)
+			s.emitPrefillFallbackShadow(model, !ttftTooSlow(recalTTFT, recalHas, ttftThreshold))
+		}
 		if !s.ttftHardReject {
 			// Soft TTFT gate (default): a provider passed every routing and
 			// capacity gate, and pr.MaxTTFTMs is left 0 in soft mode, so the

--- a/coordinator/api/prefill_fallback_metrics.go
+++ b/coordinator/api/prefill_fallback_metrics.go
@@ -1,0 +1,41 @@
+package api
+
+// Prefill-fallback shadow telemetry (DogStatsD + the in-process /v1/admin/metrics
+// registry). Pure observability — emitted only when
+// EIGENINFERENCE_PREFILL_FALLBACK_MODE=shadow, where live routing is unchanged
+// (still on the legacy ~280 tok/s fallback) and we measure how many of today's
+// long-prompt ttft_429s the recalibrated fallback (~6500 tok/s) WOULD recover
+// before flipping enforce.
+//
+//   - routing.prefill_fallback{decision:would_admit} — the live (legacy) estimate
+//     sheds this request on TTFT, but the recalibrated estimate clears the same
+//     deadline: a 429 the enforce flip would convert to a served request.
+//   - routing.prefill_fallback{decision:would_shed} — even the recalibrated
+//     estimate is over the deadline (genuinely too slow; enforce would not help).
+//
+// The caller invokes this only for requests the live estimate already flagged
+// ttft_too_slow, so the would_admit / would_shed split is exactly the projected
+// recovery vs. residual.
+func (s *Server) emitPrefillFallbackShadow(model string, recalibratedAdmits bool) {
+	if s == nil {
+		return
+	}
+	decision := "would_shed"
+	if recalibratedAdmits {
+		decision = "would_admit"
+	}
+	s.ddIncr("routing.prefill_fallback", []string{"model:" + model, "decision:" + decision, "mode:shadow"})
+	if s.metrics != nil {
+		s.metrics.IncCounter("routing.prefill_fallback",
+			MetricLabel{Name: "model", Value: model},
+			MetricLabel{Name: "decision", Value: decision},
+			MetricLabel{Name: "mode", Value: "shadow"},
+		)
+	}
+	if s.logger != nil {
+		s.logger.Debug("prefill fallback shadow",
+			"model", model,
+			"decision", decision,
+		)
+	}
+}

--- a/coordinator/api/prefill_fallback_metrics_test.go
+++ b/coordinator/api/prefill_fallback_metrics_test.go
@@ -1,0 +1,26 @@
+package api
+
+import "testing"
+
+// TestEmitPrefillFallbackShadowWouldAdmit asserts the shadow counter is tagged
+// would_admit when the recalibrated fallback clears the TTFT deadline a live
+// (legacy) estimate sheds — the projected ttft_429 recovery the enforce flip buys.
+func TestEmitPrefillFallbackShadowWouldAdmit(t *testing.T) {
+	srv := newTTFTTestServer(t)
+	srv.emitPrefillFallbackShadow("gpt-oss-20b", true)
+	counters := srv.metrics.Snapshot().Counters
+	if !counterMatches(counters, "routing.prefill_fallback", "decision=would_admit", "model=gpt-oss-20b", "mode=shadow") {
+		t.Fatalf("missing routing.prefill_fallback{would_admit}; counters=%v", counters)
+	}
+}
+
+// TestEmitPrefillFallbackShadowWouldShed covers the residual: even recalibrated,
+// the request is over the deadline (enforce would not recover it).
+func TestEmitPrefillFallbackShadowWouldShed(t *testing.T) {
+	srv := newTTFTTestServer(t)
+	srv.emitPrefillFallbackShadow("gpt-oss-20b", false)
+	counters := srv.metrics.Snapshot().Counters
+	if !counterMatches(counters, "routing.prefill_fallback", "decision=would_shed", "model=gpt-oss-20b", "mode=shadow") {
+		t.Fatalf("missing routing.prefill_fallback{would_shed}; counters=%v", counters)
+	}
+}

--- a/coordinator/cmd/coordinator/main.go
+++ b/coordinator/cmd/coordinator/main.go
@@ -392,6 +392,52 @@ func main() {
 		}
 	}
 
+	// Routing: prefill-fallback recalibration (coordinator-side, ship-now fix for
+	// the live ~41% long-prompt ttft_429 over-shed). The mode is behavior-neutral
+	// at its default (off); the ceiling raise is also behavior-neutral on today's
+	// fleet (0 of 313 warm slots report observed_prefill_tps, so nothing is being
+	// zeroed/capped near the old 5000 ceiling).
+	//
+	//   - EIGENINFERENCE_PREFILL_FALLBACK_MODE (off|shadow|enforce, default off):
+	//     off => resolvePrefillTPS keeps the legacy sqrt(bandwidth)×ratio fallback
+	//     (~280 tok/s); shadow => routing unchanged but the preflight emits
+	//     routing.prefill_fallback{would_admit|would_shed} so the projected
+	//     ttft_429 recovery is measured BEFORE enforcing; enforce => routing uses
+	//     the data-derived fallback (~6500 tok/s, the measured prefill p50) when no
+	//     provider measurement exists.
+	//   - EIGENINFERENCE_PREFILL_FALLBACK_TPS (float, default 6500): the fallback
+	//     value, the measured empirical idle prefill p50.
+	//   - EIGENINFERENCE_MAX_PREFILL_TPS (float, default 20000): the prefill sanity
+	//     ceiling, raised above the measured p90 (17,707) so a correctly-measured
+	//     value from a fixed provider is neither zeroed at ingest nor capped in
+	//     routing. Tunable down for instant rollback.
+	if v := os.Getenv("EIGENINFERENCE_MAX_PREFILL_TPS"); v != "" {
+		if ceil, err := strconv.ParseFloat(v, 64); err == nil && ceil > 0 {
+			registry.SetMaxPrefillTPS(ceil)
+			logger.Info("max prefill TPS override via EIGENINFERENCE_MAX_PREFILL_TPS", "tps", ceil)
+		} else {
+			logger.Warn("invalid EIGENINFERENCE_MAX_PREFILL_TPS; keeping default", "value", v, "default", registry.MaxPrefillTPS())
+		}
+	}
+	if v := os.Getenv("EIGENINFERENCE_PREFILL_FALLBACK_TPS"); v != "" {
+		if tps, err := strconv.ParseFloat(v, 64); err == nil && tps > 0 {
+			registry.SetPrefillFallbackTPS(tps)
+			logger.Info("prefill fallback TPS override via EIGENINFERENCE_PREFILL_FALLBACK_TPS", "tps", tps)
+		} else {
+			logger.Warn("invalid EIGENINFERENCE_PREFILL_FALLBACK_TPS; keeping default", "value", v, "default", registry.PrefillFallbackTPS())
+		}
+	}
+	if v := os.Getenv("EIGENINFERENCE_PREFILL_FALLBACK_MODE"); v != "" {
+		mode := registry.ParsePrefillFallbackMode(v)
+		registry.SetPrefillFallbackMode(mode)
+		if mode == registry.PrefillFallbackOff {
+			logger.Info("prefill-fallback recalibration OFF (EIGENINFERENCE_PREFILL_FALLBACK_MODE)", "value", v)
+		} else {
+			logger.Warn("prefill-fallback recalibration ENABLED (EIGENINFERENCE_PREFILL_FALLBACK_MODE)",
+				"mode", mode.String(), "fallback_tps", registry.PrefillFallbackTPS(), "max_prefill_tps", registry.MaxPrefillTPS())
+		}
+	}
+
 	// Routing (Phase-0 TTFT-contention, shadow + measurement slice). All three
 	// knobs are behavior-neutral at their defaults:
 	//

--- a/coordinator/registry/prefill_fallback.go
+++ b/coordinator/registry/prefill_fallback.go
@@ -1,0 +1,176 @@
+package registry
+
+import (
+	"math"
+	"strings"
+	"time"
+)
+
+// Prefill-fallback recalibration — the coordinator-side, ship-now mitigation for
+// the live 41% long-prompt ttft_429 over-shed. No provider release required.
+//
+// Root cause (docs/reports/2026-06-22-live-prefill-tps-check.md): no provider in
+// the fleet reports a usable observed_prefill_tps (0 of 313 warm slots, 100% of
+// clean warm routing decisions resolved prefill to exactly the fallback). So
+// resolvePrefillTPS falls back to resolvedPrefillTPS(p) =
+// sqrt(MemoryBandwidthGBs) × prefillToDecodeRatio ≈ 280 tok/s p50 — ~23× below
+// the measured real prefill (empirical idle p50 6,523 tok/s, p90 17,707 tok/s,
+// recovered EXACTLY by inverting the stored ttft_ms). That pessimistic estimate
+// makes the TTFT gate reject every prompt above ~550 tokens.
+//
+// This file adds a data-derived fallback (defaultPrefillFallbackTPS ≈ the
+// measured p50) that REPLACES the sqrt(bandwidth)×ratio estimate when no
+// measurement exists, gated behind EIGENINFERENCE_PREFILL_FALLBACK_MODE so it can
+// be staged shadow→enforce. It is orthogonal to the durable provider-side
+// measurement fix (which makes observed_prefill_tps non-zero): once a provider
+// reports a real value, resolvePrefillTPS prefers that measured value and this
+// fallback is never consulted. It also raises maxPrefillTPS above the measured
+// p90 so a correctly-measured value is not discarded at ingest or capped at
+// routing time.
+
+// PrefillFallbackMode selects how the recalibrated prefill fallback is applied.
+type PrefillFallbackMode int
+
+const (
+	// PrefillFallbackOff is the default: resolvePrefillTPS returns the legacy
+	// sqrt(bandwidth)×ratio fallback, byte-for-byte the pre-recalibration value.
+	PrefillFallbackOff PrefillFallbackMode = iota
+	// PrefillFallbackShadow leaves live routing on the legacy fallback but lets
+	// the API layer emit routing.prefill_fallback{would_admit|would_shed} so the
+	// projected ttft_429 recovery can be measured before enforcing.
+	PrefillFallbackShadow
+	// PrefillFallbackEnforce applies the recalibrated fallback to live routing:
+	// resolvePrefillTPS uses max(static, prefillFallbackTPS) when no measured
+	// prefill exists, capped at maxPrefillTPS.
+	PrefillFallbackEnforce
+)
+
+func (m PrefillFallbackMode) String() string {
+	switch m {
+	case PrefillFallbackShadow:
+		return "shadow"
+	case PrefillFallbackEnforce:
+		return "enforce"
+	default:
+		return "off"
+	}
+}
+
+// ParsePrefillFallbackMode maps an env string to a mode. Anything unrecognized
+// (including empty) is OFF — the safe, behavior-neutral default.
+func ParsePrefillFallbackMode(s string) PrefillFallbackMode {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "shadow":
+		return PrefillFallbackShadow
+	case "enforce":
+		return PrefillFallbackEnforce
+	default:
+		return PrefillFallbackOff
+	}
+}
+
+// defaultPrefillFallbackTPS is the data-derived prefill fallback (tok/s): the
+// measured empirical idle prefill p50 = 6,523 tok/s (lower bound, recovered by
+// inverting the router's own stored ttft_ms on prompts ≥800 tok;
+// docs/reports/2026-06-22-live-prefill-tps-check.md). Rounded to 6500. It is
+// CONSERVATIVE on purpose: the regression slope implies a true asymptotic rate of
+// 7,500–10,500 tok/s, so anchoring on the p50 will not over-admit, while still
+// being ~23× the broken ~280 tok/s estimate that drives the 41% over-shed. Prefill
+// on Apple-Silicon MLX is a parallel/compute-bound pass, so a flat anchor (not the
+// bandwidth-scaled decode proxy) is the honest representation of the fleet-aggregate
+// data; tune per-deployment via EIGENINFERENCE_PREFILL_FALLBACK_TPS.
+const defaultPrefillFallbackTPS = 6500.0
+
+// defaultMaxPrefillTPS is the sanity ceiling (tok/s) on resolved/ingested prefill
+// rates. Raised from the legacy 5000 to sit comfortably above the measured p90
+// (17,707 tok/s) so (a) the recalibrated fallback (6500) is not capped back down
+// and (b) a correctly-measured cold-prefill value from a fixed provider is neither
+// zeroed at ingest (clampBackendCapacity) nor capped at routing time
+// (resolvePrefillTPS) — while still rejecting the "billions of tok/s" overflow a
+// collapsed admitted→first-token window produces. Tunable for rollback via
+// EIGENINFERENCE_MAX_PREFILL_TPS.
+const defaultMaxPrefillTPS = 20000.0
+
+// All three are configured once at startup (from main.go env wiring) and read-only
+// on routing/ingest paths thereafter, mirroring prefillToDecodeRatio /
+// ttftAdmissionMode.
+var (
+	prefillFallbackMode = PrefillFallbackOff
+	prefillFallbackTPS  = defaultPrefillFallbackTPS
+	// maxPrefillTPS is the prefill sanity ceiling shared by clampBackendCapacity
+	// (ingest zeroing of out-of-range observed_prefill_tps), the registration
+	// prefill_tps clamp, and resolvePrefillTPS (routing cap). Declared here rather
+	// than in registry.go's const block so the prefill ceiling lives next to the
+	// fallback it must clear.
+	maxPrefillTPS = defaultMaxPrefillTPS
+)
+
+// SetPrefillFallbackMode sets the recalibration mode. Must be called before
+// serving starts (read-only on routing paths thereafter).
+func SetPrefillFallbackMode(mode PrefillFallbackMode) { prefillFallbackMode = mode }
+
+// PrefillFallbackModeValue returns the configured recalibration mode.
+func PrefillFallbackModeValue() PrefillFallbackMode { return prefillFallbackMode }
+
+// SetPrefillFallbackTPS overrides the data-derived fallback (tok/s). Values <= 0
+// are ignored. Must be called before serving starts.
+func SetPrefillFallbackTPS(tps float64) {
+	if tps > 0 {
+		prefillFallbackTPS = tps
+	}
+}
+
+// PrefillFallbackTPS returns the configured prefill fallback (tok/s).
+func PrefillFallbackTPS() float64 { return prefillFallbackTPS }
+
+// SetMaxPrefillTPS overrides the prefill sanity ceiling (tok/s). Values <= 0 are
+// ignored. Must be called before serving starts.
+func SetMaxPrefillTPS(tps float64) {
+	if tps > 0 {
+		maxPrefillTPS = tps
+	}
+}
+
+// MaxPrefillTPS returns the configured prefill sanity ceiling (tok/s).
+func MaxPrefillTPS() float64 { return maxPrefillTPS }
+
+// prefillTPSForSnapshot resolves the prefill TPS for a snapshot. The measured
+// per-slot observed prefill EWMA always wins when present (>0). Otherwise, when
+// recalibrate is true and the provider reports BackendCapacity (so its TTFT
+// estimate is actually consulted by the gate), the data-derived fallback lifts the
+// pessimistic sqrt(bandwidth)×ratio static estimate — never lowering it, so a
+// (hypothetical) higher static prefill_tps is preserved. The result is always
+// capped at maxPrefillTPS.
+func prefillTPSForSnapshot(snap routingSnapshot, recalibrate bool) float64 {
+	tps := snap.prefillTPS
+	if snap.observedPrefillTPS > 0 {
+		tps = snap.observedPrefillTPS
+	} else if recalibrate && snap.hasBackendCapacity {
+		if prefillFallbackTPS > tps {
+			tps = prefillFallbackTPS
+		}
+	}
+	if tps > maxPrefillTPS {
+		tps = maxPrefillTPS
+	}
+	return tps
+}
+
+// recalibratedTTFTMsFromSnapshot is the TTFT estimate computed with the
+// recalibrated prefill fallback FORCED on, regardless of mode. Used only by the
+// shadow path to measure the projected admission recovery WITHOUT changing the
+// live decision (which, in shadow mode, still runs on the legacy fallback).
+func recalibratedTTFTMsFromSnapshot(snap routingSnapshot, reqPromptTokens int) float64 {
+	return ttftMsFromSnapshotWithPrefill(snap, reqPromptTokens, prefillTPSForSnapshot(snap, true))
+}
+
+// estimatedRecalibratedTTFTFromSnapshot mirrors estimatedTTFTFromSnapshot but with
+// the recalibrated prefill fallback forced on. Returns 0 for an invalid estimate
+// (no BackendCapacity, NaN/Inf), matching the live preflight contract.
+func estimatedRecalibratedTTFTFromSnapshot(snap routingSnapshot, reqPromptTokens int) time.Duration {
+	ttftMs := recalibratedTTFTMsFromSnapshot(snap, reqPromptTokens)
+	if ttftMs <= 0 || math.IsNaN(ttftMs) || math.IsInf(ttftMs, 0) {
+		return 0
+	}
+	return time.Duration(ttftMs * float64(time.Millisecond))
+}

--- a/coordinator/registry/prefill_fallback_test.go
+++ b/coordinator/registry/prefill_fallback_test.go
@@ -1,0 +1,280 @@
+package registry
+
+import (
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+)
+
+// withPrefillFallbackState snapshots and restores the package-level prefill
+// fallback knobs so a test that flips mode/value/ceiling cannot leak into the
+// rest of the (sequential) package suite.
+func withPrefillFallbackState(t *testing.T) {
+	t.Helper()
+	mode, fb, ceil := prefillFallbackMode, prefillFallbackTPS, maxPrefillTPS
+	t.Cleanup(func() {
+		prefillFallbackMode, prefillFallbackTPS, maxPrefillTPS = mode, fb, ceil
+	})
+}
+
+func TestParsePrefillFallbackMode(t *testing.T) {
+	cases := map[string]PrefillFallbackMode{
+		"":         PrefillFallbackOff,
+		"off":      PrefillFallbackOff,
+		"garbage":  PrefillFallbackOff,
+		"shadow":   PrefillFallbackShadow,
+		"  SHADOW": PrefillFallbackShadow,
+		"enforce":  PrefillFallbackEnforce,
+		"Enforce ": PrefillFallbackEnforce,
+	}
+	for in, want := range cases {
+		if got := ParsePrefillFallbackMode(in); got != want {
+			t.Errorf("ParsePrefillFallbackMode(%q) = %v, want %v", in, got, want)
+		}
+		if got := want.String(); ParsePrefillFallbackMode(got) != want {
+			t.Errorf("round-trip String()/Parse for %v gave %q", want, got)
+		}
+	}
+}
+
+func TestPrefillFallbackDefaultsAndSetters(t *testing.T) {
+	withPrefillFallbackState(t)
+
+	// Defaults are the data-derived values and the safe (off) mode.
+	if prefillFallbackMode != PrefillFallbackOff {
+		t.Fatalf("default mode = %v, want off (behavior-neutral)", prefillFallbackMode)
+	}
+	if defaultPrefillFallbackTPS != 6500.0 {
+		t.Fatalf("defaultPrefillFallbackTPS = %v, want 6500 (measured p50)", defaultPrefillFallbackTPS)
+	}
+	if defaultMaxPrefillTPS != 20000.0 {
+		t.Fatalf("defaultMaxPrefillTPS = %v, want 20000 (above measured p90 17,707)", defaultMaxPrefillTPS)
+	}
+
+	SetPrefillFallbackTPS(7200)
+	if PrefillFallbackTPS() != 7200 {
+		t.Fatalf("PrefillFallbackTPS = %v, want 7200", PrefillFallbackTPS())
+	}
+	SetPrefillFallbackTPS(0) // ignored
+	SetPrefillFallbackTPS(-1)
+	if PrefillFallbackTPS() != 7200 {
+		t.Fatalf("PrefillFallbackTPS = %v, want 7200 after ignored non-positive sets", PrefillFallbackTPS())
+	}
+
+	SetMaxPrefillTPS(18000)
+	if MaxPrefillTPS() != 18000 {
+		t.Fatalf("MaxPrefillTPS = %v, want 18000", MaxPrefillTPS())
+	}
+	SetMaxPrefillTPS(0) // ignored
+	if MaxPrefillTPS() != 18000 {
+		t.Fatalf("MaxPrefillTPS = %v, want 18000 after ignored zero set", MaxPrefillTPS())
+	}
+
+	SetPrefillFallbackMode(PrefillFallbackEnforce)
+	if PrefillFallbackModeValue() != PrefillFallbackEnforce {
+		t.Fatalf("mode = %v, want enforce", PrefillFallbackModeValue())
+	}
+}
+
+// TestPrefillTPSForSnapshotRecalibration pins the core resolution helper: measured
+// always wins; the recalibration only lifts (never lowers) the static estimate and
+// only when BackendCapacity is present; the ceiling always caps.
+func TestPrefillTPSForSnapshotRecalibration(t *testing.T) {
+	withPrefillFallbackState(t)
+	prefillFallbackTPS = 6500
+	maxPrefillTPS = 20000
+
+	// Measured observed prefill always wins, regardless of recalibrate.
+	obs := routingSnapshot{prefillTPS: 240, observedPrefillTPS: 1800, hasBackendCapacity: true}
+	if got := prefillTPSForSnapshot(obs, false); got != 1800 {
+		t.Fatalf("observed (off) = %v, want 1800", got)
+	}
+	if got := prefillTPSForSnapshot(obs, true); got != 1800 {
+		t.Fatalf("observed (recalibrate) = %v, want 1800 (measured wins)", got)
+	}
+
+	// No measurement, recalibrate OFF → legacy static estimate (the ~280 chain).
+	legacy := routingSnapshot{prefillTPS: 240, hasBackendCapacity: true}
+	if got := prefillTPSForSnapshot(legacy, false); got != 240 {
+		t.Fatalf("legacy (off) = %v, want 240", got)
+	}
+	// No measurement, recalibrate ON → lifted to the data-derived fallback.
+	if got := prefillTPSForSnapshot(legacy, true); got != 6500 {
+		t.Fatalf("recalibrated = %v, want 6500", got)
+	}
+
+	// Recalibration is gated on BackendCapacity (a legacy provider whose TTFT is
+	// never gated keeps its static estimate).
+	noBC := routingSnapshot{prefillTPS: 240, hasBackendCapacity: false}
+	if got := prefillTPSForSnapshot(noBC, true); got != 240 {
+		t.Fatalf("recalibrate without BackendCapacity = %v, want 240 (gated)", got)
+	}
+
+	// Never LOWER a higher static estimate to the fallback.
+	high := routingSnapshot{prefillTPS: 9000, hasBackendCapacity: true}
+	if got := prefillTPSForSnapshot(high, true); got != 9000 {
+		t.Fatalf("recalibrate with higher static = %v, want 9000 (max, never lowered)", got)
+	}
+
+	// The ceiling caps everything (e.g. an observed value above the ceiling).
+	over := routingSnapshot{observedPrefillTPS: 25000, hasBackendCapacity: true}
+	if got := prefillTPSForSnapshot(over, true); got != 20000 {
+		t.Fatalf("over-ceiling observed = %v, want capped to 20000", got)
+	}
+}
+
+// TestMaxPrefillCeilingRaiseKeepsHighObserved proves the ceiling raise: a
+// genuinely-fast cold-prefill measurement that sits BETWEEN the legacy 5000 and the
+// measured p90 (17,707) is now KEPT at ingest instead of being zeroed, while a true
+// overflow above the new ceiling is still dropped.
+func TestMaxPrefillCeilingRaiseKeepsHighObserved(t *testing.T) {
+	withPrefillFallbackState(t)
+	maxPrefillTPS = defaultMaxPrefillTPS // 20000
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	bc := &protocol.BackendCapacity{
+		Slots: []protocol.BackendSlotCapacity{
+			{Model: "p50", ObservedPrefillTPS: 6500},   // measured p50 — kept (was kept before too)
+			{Model: "p90", ObservedPrefillTPS: 15000},  // between old 5000 and new ceiling — NOW kept
+			{Model: "fast", ObservedPrefillTPS: 17700}, // ~p90 — NOW kept
+			{Model: "overflow", ObservedPrefillTPS: 25000},
+		},
+	}
+	clampBackendCapacity(logger, "p1", bc)
+
+	if bc.Slots[0].ObservedPrefillTPS != 6500 {
+		t.Errorf("p50 ObservedPrefillTPS = %v, want 6500 (kept)", bc.Slots[0].ObservedPrefillTPS)
+	}
+	if bc.Slots[1].ObservedPrefillTPS != 15000 {
+		t.Errorf("p90-ish ObservedPrefillTPS = %v, want 15000 (kept under raised ceiling; was zeroed at 5000)", bc.Slots[1].ObservedPrefillTPS)
+	}
+	if bc.Slots[2].ObservedPrefillTPS != 17700 {
+		t.Errorf("fast ObservedPrefillTPS = %v, want 17700 (kept)", bc.Slots[2].ObservedPrefillTPS)
+	}
+	if bc.Slots[3].ObservedPrefillTPS != 0 {
+		t.Errorf("overflow ObservedPrefillTPS = %v, want 0 (above new ceiling, dropped)", bc.Slots[3].ObservedPrefillTPS)
+	}
+}
+
+// makeBrokenPrefillProvider builds a healthy, model-resident provider whose static
+// prefill estimate is the broken ~fleet fallback (240 tok/s), so a long prompt's
+// TTFT estimate blows the gate under the legacy fallback but clears it once the
+// recalibrated fallback is applied. Decode is fast so the first-decode term is
+// negligible and the prefill term dominates (matching the live pathology).
+func makeBrokenPrefillProvider(t *testing.T, reg *Registry, id, model string) *Provider {
+	t.Helper()
+	p := makeSchedulerProvider(t, reg, id, model, 100) // decode 100 tok/s → 10ms first-decode
+	p.mu.Lock()
+	p.PrefillTPS = 240 // the broken sqrt(bandwidth)×12 ≈ fleet fallback
+	p.mu.Unlock()
+	return p
+}
+
+// TestLongPromptAdmittedUnderEnforceFallback is THE required regression: a
+// long-prompt request that the TTFT hard gate 429s under the legacy fallback is
+// ADMITTED once the recalibrated fallback is enforced — with cancels-flat safety,
+// because the recalibrated estimate (~615ms prefill for 4k tokens) is well within
+// the deadline rather than the legacy ~16.7s that over-shed it.
+func TestLongPromptAdmittedUnderEnforceFallback(t *testing.T) {
+	withPrefillFallbackState(t)
+	prefillFallbackTPS = defaultPrefillFallbackTPS // 6500
+	maxPrefillTPS = defaultMaxPrefillTPS           // 20000
+
+	const (
+		model     = "prefill-fallback-admit-model"
+		reqPrompt = 4_000 // ≈ the live 429'd long-prompt p50 (4,009 tok)
+		// Hard TTFT gate ≈ consumer ttftDeadline(4000) = 5000 + 1ms·4000.
+		maxTTFTMs = 9_000.0
+	)
+	newReq := func(id string) *PendingRequest {
+		return &PendingRequest{
+			RequestID:             id,
+			Model:                 model,
+			EstimatedPromptTokens: reqPrompt,
+			RequestedMaxTokens:    128,
+			MaxTTFTMs:             maxTTFTMs,
+		}
+	}
+
+	// OFF (legacy fallback ≈240 tok/s): 4000/240*1000 ≈ 16.7s ≫ 9s → 429.
+	prefillFallbackMode = PrefillFallbackOff
+	{
+		reg := New(testLogger())
+		makeBrokenPrefillProvider(t, reg, "p-off", model)
+		sel, dec := reg.ReserveProviderEx(model, newReq("off"))
+		if sel != nil {
+			t.Fatalf("OFF: expected TTFT 429 (nil provider), got %q; decision=%+v", sel.ID, dec)
+		}
+		if dec.TTFTRejections != 1 {
+			t.Fatalf("OFF: TTFTRejections = %d, want 1 (the only blocker is the prefill-driven TTFT gate); decision=%+v", dec.TTFTRejections, dec)
+		}
+		if dec.BestTTFTMs <= maxTTFTMs {
+			t.Fatalf("OFF: BestTTFTMs = %v, want > %v (legacy fallback over-estimates TTFT)", dec.BestTTFTMs, maxTTFTMs)
+		}
+	}
+
+	// ENFORCE (recalibrated fallback 6500 tok/s): 4000/6500*1000 ≈ 615ms ≪ 9s → admit.
+	prefillFallbackMode = PrefillFallbackEnforce
+	{
+		reg := New(testLogger())
+		p := makeBrokenPrefillProvider(t, reg, "p-enforce", model)
+		sel, dec := reg.ReserveProviderEx(model, newReq("enforce"))
+		if sel == nil {
+			t.Fatalf("ENFORCE: expected admission, got nil; decision=%+v", dec)
+		}
+		if sel.ID != p.ID {
+			t.Fatalf("ENFORCE: selected %q, want %q", sel.ID, p.ID)
+		}
+		if dec.TTFTRejections != 0 {
+			t.Fatalf("ENFORCE: TTFTRejections = %d, want 0 (recalibrated prefill clears the gate)", dec.TTFTRejections)
+		}
+		if dec.TTFTMs > maxTTFTMs {
+			t.Fatalf("ENFORCE: winning TTFTMs = %v, want <= %v", dec.TTFTMs, maxTTFTMs)
+		}
+	}
+}
+
+// TestPrefillFallbackShadowIsBehaviorNeutral proves shadow mode does NOT change the
+// live routing decision (the same long prompt is still 429'd, byte-for-byte with
+// OFF), while the recalibrated estimate the shadow measures WOULD have cleared the
+// gate — exactly the projected-recovery signal the API emits before enforcing.
+func TestPrefillFallbackShadowIsBehaviorNeutral(t *testing.T) {
+	withPrefillFallbackState(t)
+	prefillFallbackTPS = defaultPrefillFallbackTPS
+	maxPrefillTPS = defaultMaxPrefillTPS
+
+	const (
+		model     = "prefill-fallback-shadow-model"
+		reqPrompt = 4_000
+		maxTTFTMs = 9_000.0
+	)
+	req := func(id string) *PendingRequest {
+		return &PendingRequest{RequestID: id, Model: model, EstimatedPromptTokens: reqPrompt, RequestedMaxTokens: 128, MaxTTFTMs: maxTTFTMs}
+	}
+
+	prefillFallbackMode = PrefillFallbackShadow
+	reg := New(testLogger())
+	makeBrokenPrefillProvider(t, reg, "p-shadow", model)
+
+	// Live routing in shadow mode is unchanged → still 429 (behavior-neutral).
+	sel, dec := reg.ReserveProviderEx(model, req("shadow-live"))
+	if sel != nil {
+		t.Fatalf("SHADOW: live routing must stay 429 (behavior-neutral), got %q; decision=%+v", sel.ID, dec)
+	}
+	if dec.TTFTRejections != 1 {
+		t.Fatalf("SHADOW: TTFTRejections = %d, want 1 (live still on legacy fallback)", dec.TTFTRejections)
+	}
+
+	// The shadow measurement (recalibration forced on) would have ADMITTED it:
+	// the preflight's recalibrated best-TTFT clears the same deadline.
+	recalTTFT, hasTTFT := reg.QuickCapacityCheckRecalibratedTTFT(model, reqPrompt, 128, RequestTraits{}, false)
+	if !hasTTFT {
+		t.Fatalf("SHADOW: recalibrated preflight produced no TTFT estimate")
+	}
+	if float64(recalTTFT.Milliseconds()) > maxTTFTMs {
+		t.Fatalf("SHADOW: recalibrated best-TTFT = %v, want <= %v (would_admit)", recalTTFT, time.Duration(maxTTFTMs)*time.Millisecond)
+	}
+}

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -2134,9 +2134,13 @@ func (r *Registry) SetQueue(q *RequestQueue) {
 // ~3-4x current hardware ceilings (M2 Ultra is ~800 GB/s, MLX decode is ~120
 // tok/s, max Mac Studio RAM is 512 GB) so legitimate future hardware isn't
 // clamped unnecessarily.
+//
+// maxPrefillTPS (the prefill sanity ceiling) is declared as a var in
+// prefill_fallback.go (default defaultMaxPrefillTPS = 20000, above the measured
+// p90 17,707) so the ingest zeroing here, the registration clamp below, and the
+// routing cap in resolvePrefillTPS share one tunable ceiling.
 const (
 	maxDecodeTPS                    = 500.0
-	maxPrefillTPS                   = 5000.0
 	maxMemoryBandwidthGBs           = 2000.0
 	maxMemoryGB                     = 1024
 	maxMemoryGBFloat                = 1024.0
@@ -2233,7 +2237,9 @@ func clampBackendCapacity(logger *slog.Logger, providerID string, bc *protocol.B
 		// would make the TTFT estimate over-optimistic (prefill looks instant) and
 		// the hard gate over-accept; zeroing it makes resolvePrefillTPS fall back to
 		// the conservative decode×ratio estimate until the provider reports a sane
-		// value (provider fix: only sample cold prefills).
+		// value (provider fix: only sample cold prefills). The ceiling now sits
+		// above the measured p90 (17,707 tok/s; see defaultMaxPrefillTPS) so a
+		// genuinely-fast cold prefill from a fixed provider survives ingest.
 		if math.IsNaN(s.ObservedPrefillTPS) || s.ObservedPrefillTPS < 0 || s.ObservedPrefillTPS > maxPrefillTPS {
 			logger.Warn("provider slot observed_prefill_tps out of range; ignoring (fall back to estimate)",
 				"provider_id", providerID, "model", s.Model, "reported", s.ObservedPrefillTPS)

--- a/coordinator/registry/scheduler.go
+++ b/coordinator/registry/scheduler.go
@@ -1379,23 +1379,19 @@ func resolveEffectiveTPS(snap routingSnapshot) float64 {
 }
 
 // resolvePrefillTPS returns the best available prefill TPS estimate for TTFT.
-// Fallback chain: measured per-slot observed prefill EWMA → snap.prefillTPS (the
-// resolvedPrefillTPS chain: registration benchmark → decode×prefillToDecodeRatio
-// ×12 fallback). This mirrors how resolveEffectiveTPS prefers the measured
-// decode rate over the static estimate. The result is clamped to maxPrefillTPS
-// so a single outlier heartbeat cannot collapse the TTFT estimate.
+// Preference order: measured per-slot observed prefill EWMA → (in
+// PrefillFallbackEnforce mode) the data-derived fleet fallback → snap.prefillTPS
+// (the resolvedPrefillTPS chain: registration benchmark → decode×
+// prefillToDecodeRatio). This mirrors how resolveEffectiveTPS prefers the measured
+// decode rate over the static estimate. The result is clamped to maxPrefillTPS so
+// a single outlier heartbeat cannot collapse the TTFT estimate.
 //
-// observedPrefillTPS stays 0 until providers ship the W1 measurement, so on
-// today's fleet this is a no-op that returns the existing ×12-chain value.
+// observedPrefillTPS stays 0 until providers ship the durable measurement fix, so
+// on today's fleet the OFF default returns the legacy sqrt(bandwidth)×ratio value
+// (~280 tok/s) and ENFORCE returns the recalibrated fallback (~6500 tok/s, the
+// measured prefill p50) — see prefill_fallback.go (prefillTPSForSnapshot).
 func resolvePrefillTPS(snap routingSnapshot) float64 {
-	tps := snap.prefillTPS
-	if snap.observedPrefillTPS > 0 {
-		tps = snap.observedPrefillTPS
-	}
-	if tps > maxPrefillTPS {
-		tps = maxPrefillTPS
-	}
-	return tps
+	return prefillTPSForSnapshot(snap, prefillFallbackMode == PrefillFallbackEnforce)
 }
 
 // effectiveDecodeTPS scales the static decode TPS down by current
@@ -1488,7 +1484,11 @@ func resolvedModelTPSLocked(p *Provider, model string) (decodeTPS, prefillTPS fl
 // with the 5s+1ms/token TTFT deadline it estimated ~100 tok/s prefill (vs the
 // ~1000 tok/s the deadline implicitly assumes), so the TTFT gate wrongly
 // rejected warm, capable providers on any prompt above ~550 tokens. No provider
-// currently reports prefill_tps, so this fallback is the production path.
+// currently reports prefill_tps, so this fallback is the production path. Even 12×
+// is far too low against the MEASURED reality (real prefill p50 ≈ 6,500 tok/s vs
+// this chain's ~280 tok/s) — the data-derived replacement lives in
+// prefill_fallback.go (defaultPrefillFallbackTPS) and supersedes this chain when
+// PrefillFallbackEnforce is set.
 const defaultPrefillToDecodeRatio = 12.0
 
 // prefillToDecodeRatio is configured once at startup (via SetPrefillToDecodeRatio,
@@ -1773,20 +1773,32 @@ func (r *Registry) providerCanAdmitLockedEx(p *Provider, model string, traits Re
 //     a model that will never fit (the client would retry forever) — it should
 //     surface model_too_large / 503 instead.
 func (r *Registry) QuickCapacityCheck(model string, estimatedPromptTokens, requestedMaxTokens int, traits RequestTraits, allowedSerials ...string) (candidateCount, capacityRejections, modelTooLarge int) {
-	candidateCount, capacityRejections, modelTooLarge, _, _ = r.quickCapacityCheck(model, estimatedPromptTokens, requestedMaxTokens, traits, false, allowedSerials...)
+	candidateCount, capacityRejections, modelTooLarge, _, _ = r.quickCapacityCheck(model, estimatedPromptTokens, requestedMaxTokens, traits, false, false, allowedSerials...)
 	return candidateCount, capacityRejections, modelTooLarge
 }
 
 func (r *Registry) QuickCapacityCheckForRequest(model string, estimatedPromptTokens, requestedMaxTokens int, traits RequestTraits, requiresVision bool, allowedSerials ...string) (candidateCount, capacityRejections, modelTooLarge int) {
-	candidateCount, capacityRejections, modelTooLarge, _, _ = r.quickCapacityCheck(model, estimatedPromptTokens, requestedMaxTokens, traits, requiresVision, allowedSerials...)
+	candidateCount, capacityRejections, modelTooLarge, _, _ = r.quickCapacityCheck(model, estimatedPromptTokens, requestedMaxTokens, traits, requiresVision, false, allowedSerials...)
 	return candidateCount, capacityRejections, modelTooLarge
 }
 
 func (r *Registry) QuickCapacityCheckWithTTFTForRequest(model string, estimatedPromptTokens, requestedMaxTokens int, traits RequestTraits, requiresVision bool, allowedSerials ...string) (candidateCount, capacityRejections, modelTooLarge int, bestTTFT time.Duration, hasTTFT bool) {
-	return r.quickCapacityCheck(model, estimatedPromptTokens, requestedMaxTokens, traits, requiresVision, allowedSerials...)
+	return r.quickCapacityCheck(model, estimatedPromptTokens, requestedMaxTokens, traits, requiresVision, false, allowedSerials...)
 }
 
-func (r *Registry) quickCapacityCheck(model string, estimatedPromptTokens, requestedMaxTokens int, traits RequestTraits, requiresVision bool, allowedSerials ...string) (candidateCount, capacityRejections, modelTooLarge int, bestTTFT time.Duration, hasTTFT bool) {
+// QuickCapacityCheckRecalibratedTTFT runs the preflight TTFT scan with the
+// prefill-fallback recalibration FORCED on (regardless of mode), returning the
+// best estimated TTFT and whether any candidate produced a reliable estimate. Used
+// ONLY by the prefill-fallback shadow path to measure projected ttft_429 recovery
+// WITHOUT changing live routing; callers gate it on
+// PrefillFallbackModeValue() == PrefillFallbackShadow, so the extra scan is paid
+// only during a staging window.
+func (r *Registry) QuickCapacityCheckRecalibratedTTFT(model string, estimatedPromptTokens, requestedMaxTokens int, traits RequestTraits, requiresVision bool, allowedSerials ...string) (bestTTFT time.Duration, hasTTFT bool) {
+	_, _, _, bestTTFT, hasTTFT = r.quickCapacityCheck(model, estimatedPromptTokens, requestedMaxTokens, traits, requiresVision, true, allowedSerials...)
+	return bestTTFT, hasTTFT
+}
+
+func (r *Registry) quickCapacityCheck(model string, estimatedPromptTokens, requestedMaxTokens int, traits RequestTraits, requiresVision bool, recalibratePrefill bool, allowedSerials ...string) (candidateCount, capacityRejections, modelTooLarge int, bestTTFT time.Duration, hasTTFT bool) {
 	// Use a dummy PendingRequest with the caller's actual token estimates
 	// for the admission gate (freeMemoryAdmits).
 	if estimatedPromptTokens <= 0 {
@@ -1941,6 +1953,9 @@ func (r *Registry) quickCapacityCheck(model string, estimatedPromptTokens, reque
 		candidateCount++
 		if snap.hasBackendCapacity {
 			ttft := estimatedTTFTFromSnapshot(snap, estimatedPromptTokens)
+			if recalibratePrefill {
+				ttft = estimatedRecalibratedTTFTFromSnapshot(snap, estimatedPromptTokens)
+			}
 			if !hasTTFT || ttft < bestTTFT {
 				bestTTFT = ttft
 				hasTTFT = true
@@ -1977,6 +1992,14 @@ func estimatedTTFTFromSnapshot(snap routingSnapshot, reqPromptTokens int) time.D
 // and this request's own prefill instead of treating active_token_budget_used as
 // a serial decode backlog.
 func ttftMsFromSnapshot(snap routingSnapshot, reqPromptTokens int) float64 {
+	return ttftMsFromSnapshotWithPrefill(snap, reqPromptTokens, resolvePrefillTPS(snap))
+}
+
+// ttftMsFromSnapshotWithPrefill is ttftMsFromSnapshot parametrized by the prefill
+// TPS to use, so the prefill-fallback shadow path (recalibratedTTFTMsFromSnapshot)
+// can compute the recalibrated estimate without changing the live prefill
+// resolution. prefillTPS <= 0 is floored to 1 tok/s.
+func ttftMsFromSnapshotWithPrefill(snap routingSnapshot, reqPromptTokens int, prefillTPS float64) float64 {
 	if !snap.hasBackendCapacity {
 		return 0
 	}
@@ -1984,7 +2007,6 @@ func ttftMsFromSnapshot(snap routingSnapshot, reqPromptTokens int) float64 {
 	if reqPromptTokens < 0 {
 		reqPromptTokens = 0
 	}
-	prefillTPS := resolvePrefillTPS(snap)
 	if prefillTPS <= 0 {
 		prefillTPS = 1.0
 	}


### PR DESCRIPTION
## Summary

The coordinator over-sheds long prompts with `ttft_429` because its prefill estimate is **~23× too pessimistic**. Verified in prod (`docs/reports/2026-06-22-live-prefill-tps-check.md`): **0 of 313** warm `(provider, model)` slots report a usable `observed_prefill_tps`, so `resolvePrefillTPS` falls back to `resolvedPrefillTPS(p) = sqrt(MemoryBandwidthGBs) × 12 ≈ 280 tok/s` (p50, range 131–343). The **measured** real prefill (recovered *exactly* by inverting the router's own stored `ttft_ms`) is **p50 6,523 tok/s, p90 17,707**. The ~280 tok/s estimate makes the TTFT gate reject **every prompt above ~550 tokens** — the live **41% of routing rows that 429 as `ttft_429`** (100% of those had prompt ≥550 tok, p50 prompt 4,009).

This is the **ship-now coordinator-side mitigation** (no provider release). It is orthogonal to the durable provider-side measurement fix (separate PR): once a provider reports a real `observed_prefill_tps`, that measured value wins and this fallback is never consulted.

### What changed
- **Data-derived fallback**, env-gated & staged shadow→enforce. When no measurement exists, `resolvePrefillTPS` lifts the `sqrt(bandwidth)×ratio` estimate to `EIGENINFERENCE_PREFILL_FALLBACK_TPS` (**default 6500** = measured p50). New self-contained module `coordinator/registry/prefill_fallback.go`.
- **Ceiling raise** `maxPrefillTPS` **5000 → 20000** (`EIGENINFERENCE_MAX_PREFILL_TPS`), above the measured p90 (17,707), so a correctly-measured value from a fixed provider is neither **zeroed at ingest** (`clampBackendCapacity`) nor **capped at routing** (`resolvePrefillTPS`). Required: the 6500 fallback would otherwise be capped to the old 5000.
- **Shadow telemetry**: `routing.prefill_fallback{decision:would_admit|would_shed, mode:shadow}` emitted from the preflight, so the projected `ttft_429` recovery is measured **before** flipping enforce.

### Chosen values + justification (from the data)
| Knob | Old | New | Why |
|---|--:|--:|---|
| prefill fallback | `sqrt(bw)×12` ≈ **280** | **6500** | Measured empirical idle prefill **p50 = 6,523** tok/s. Conservative: the regression slope implies 7,500–10,500 tok/s, so anchoring on the p50 won't over-admit (keeps cancels flat) while killing the over-shed. Prefill on Apple-Silicon MLX is a parallel/compute-bound pass, so a flat anchor (not the bandwidth-scaled *decode* proxy) is the honest fit to the fleet-aggregate data. |
| `maxPrefillTPS` | **5000** | **20000** | Above measured **p90 = 17,707** (with ~13% headroom for the fast tail) while still dropping the "billions of tok/s" collapsed-window overflow. |

### Staging (behavior-neutral by default)
`EIGENINFERENCE_PREFILL_FALLBACK_MODE` = `off` (default) → `shadow` (measure `would_admit` volume) → `enforce` (apply). Success metric = the existing `routing.decisions{outcome:ttft_429}` falls on long prompts while cancels stay flat. The ceiling raise is behavior-neutral on today's fleet (0/313 report non-zero, so nothing is near the old 5000). Cost-based provider ranking is **untouched** — only the TTFT admission gate moves.

## Before / After

### Behavior
```mermaid
flowchart LR
  subgraph Before
    A1["4k-token prompt"] --> B1["prefill est = sqrt(bw)x12 ~280 tok/s"]
    B1 --> C1["TTFT ~16.7s > 9s deadline"]
    C1 --> D1["429 ttft_too_slow (41% of rows)"]
  end
  subgraph After_enforce
    A2["4k-token prompt"] --> B2["prefill fallback 6500 tok/s (measured p50)"]
    B2 --> C2["TTFT ~0.6s << 9s deadline"]
    C2 --> D2["admitted / served"]
  end
```

### Code
```mermaid
flowchart TB
  subgraph Before
    R1["resolvePrefillTPS(snap)"] --> S1["observed>0 ? observed : snap.prefillTPS"]
    S1 --> CAP1["cap at maxPrefillTPS=5000"]
  end
  subgraph After
    R2["resolvePrefillTPS(snap)"] --> P2["prefillTPSForSnapshot(snap, mode==enforce)"]
    P2 --> S2["observed>0 ? observed : (enforce ? max(static,6500) : static)"]
    S2 --> CAP2["cap at maxPrefillTPS=20000"]
    R3["preflight (shadow only)"] --> Q3["QuickCapacityCheckRecalibratedTTFT"] --> M3["emit routing.prefill_fallback{would_admit|would_shed}"]
  end
```

## Files
- `coordinator/registry/prefill_fallback.go` (new) — mode enum + parser, `defaultPrefillFallbackTPS=6500`, `defaultMaxPrefillTPS=20000`, setters/getters, `prefillTPSForSnapshot`, `recalibratedTTFTMsFromSnapshot`, `estimatedRecalibratedTTFTFromSnapshot`.
- `coordinator/registry/scheduler.go` — `resolvePrefillTPS` delegates to `prefillTPSForSnapshot`; `ttftMsFromSnapshot` split into a prefill-parametrized core; `quickCapacityCheck` gains a `recalibratePrefill` flag + exported `QuickCapacityCheckRecalibratedTTFT`.
- `coordinator/registry/registry.go` — `maxPrefillTPS` const→var (moved to `prefill_fallback.go`); ingest comment.
- `coordinator/api/prefill_fallback_metrics.go` (new) + `inference_admission.go` — shadow emission.
- `coordinator/cmd/coordinator/main.go` — env wiring for the 3 knobs.

## Test plan
- [x] `coordinator/registry/prefill_fallback_test.go`: **required regression** — a 4k-token prompt that 429s under the legacy fallback (`TTFTRejections=1`) is **admitted** under enforce (`TTFTMs ≤ deadline`); shadow mode stays behavior-neutral while the recalibrated preflight would admit; ceiling raise keeps a 15k/17.7k observed value (was zeroed at 5000) and drops 25k; mode parsing; setter clamps; `prefillTPSForSnapshot` (measured wins, lift-not-lower, BackendCapacity gate, cap).
- [x] `coordinator/api/prefill_fallback_metrics_test.go`: `routing.prefill_fallback{would_admit|would_shed}` tag emission.
- [x] `go test ./...` green (all coordinator packages); `gofmt`/`go vet` clean.

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/453"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784837217&installation_id=133247490&pr_number=453&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F453&signature=a7f18844199f3b02e644bfa1bb2b658dba35d02c650d41cc5992c8711501d05b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->