### PR TITLE
fix(provider): populate observed_prefill_tps (engine prefill-start marker + raised ceiling)

### DIFF
--- a/coordinator/registry/clamp_test.go
+++ b/coordinator/registry/clamp_test.go
@@ -164,3 +164,35 @@ func TestClampBackendCapacityPrefillOverflowIgnored(t *testing.T) {
 		t.Errorf("plausible ObservedPrefillTPS = %v, want 1600 (unchanged)", bc.Slots[3].ObservedPrefillTPS)
 	}
 }
+
+func TestClampBackendCapacityPrefillFastColdBandKept(t *testing.T) {
+	// The ceiling was raised to align with the provider's accepted prefill bound
+	// (maxPlausiblePrefillTps = 20000 tok/s) so a legitimately fast COLD prefill —
+	// measured p90 ~17,707 tok/s — is REPORTED and USED for TTFT instead of being
+	// zeroed at ingest (which forced the pessimistic decode×ratio fallback and
+	// defeated the whole point of the provider emitting the prefill-start marker).
+	// Values above the ceiling are still treated as no-measurement (0).
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	bc := &protocol.BackendCapacity{
+		Slots: []protocol.BackendSlotCapacity{
+			{Model: "cold-p90", ObservedPrefillTPS: 17707},           // fast cold p90 -> kept
+			{Model: "cold-mid", ObservedPrefillTPS: 6500},            // fast cold band -> kept
+			{Model: "at-ceiling", ObservedPrefillTPS: maxPrefillTPS}, // boundary -> kept
+			{Model: "over", ObservedPrefillTPS: maxPrefillTPS + 1},   // above ceiling -> zeroed
+		},
+	}
+	clampBackendCapacity(logger, "p1", bc)
+
+	if bc.Slots[0].ObservedPrefillTPS != 17707 {
+		t.Errorf("fast cold p90 ObservedPrefillTPS = %v, want 17707 (kept)", bc.Slots[0].ObservedPrefillTPS)
+	}
+	if bc.Slots[1].ObservedPrefillTPS != 6500 {
+		t.Errorf("fast cold ObservedPrefillTPS = %v, want 6500 (kept)", bc.Slots[1].ObservedPrefillTPS)
+	}
+	if bc.Slots[2].ObservedPrefillTPS != maxPrefillTPS {
+		t.Errorf("boundary ObservedPrefillTPS = %v, want %v (kept)", bc.Slots[2].ObservedPrefillTPS, maxPrefillTPS)
+	}
+	if bc.Slots[3].ObservedPrefillTPS != 0 {
+		t.Errorf("above-ceiling ObservedPrefillTPS = %v, want 0 (zeroed)", bc.Slots[3].ObservedPrefillTPS)
+	}
+}

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -2133,10 +2133,18 @@ func (r *Registry) SetQueue(q *RequestQueue) {
 // could otherwise report absurd values to monopolize routing. These caps are
 // ~3-4x current hardware ceilings (M2 Ultra is ~800 GB/s, MLX decode is ~120
 // tok/s, max Mac Studio RAM is 512 GB) so legitimate future hardware isn't
-// clamped unnecessarily.
+// clamped unnecessarily. maxPrefillTPS is instead pinned to the provider's
+// accepted prefill bound (see its inline note) so the two stay consistent.
 const (
-	maxDecodeTPS                    = 500.0
-	maxPrefillTPS                   = 5000.0
+	maxDecodeTPS = 500.0
+	// maxPrefillTPS matches the provider's maxPlausiblePrefillTps ceiling
+	// (provider-swift BatchScheduler+EngineBridge.swift). It admits the MEASURED
+	// cold-prefill p90 (~17,707 tok/s, docs/reports/2026-06-22-live-prefill-tps-check.md)
+	// so a legitimately fast cold prefill is USED for TTFT instead of zeroed at
+	// ingest (the old 5000 sat below p90 and discarded the fast-cold band, forcing
+	// the pessimistic decode×ratio fallback). Kept finite so a window-collapse
+	// artifact (billions of tok/s) is still treated as no-measurement.
+	maxPrefillTPS                   = 20000.0
 	maxMemoryBandwidthGBs           = 2000.0
 	maxMemoryGB                     = 1024
 	maxMemoryGBFloat                = 1024.0

--- a/provider-swift/Sources/ProviderBenchmark/SchedulerPrefillBenchmark.swift
+++ b/provider-swift/Sources/ProviderBenchmark/SchedulerPrefillBenchmark.swift
@@ -238,6 +238,14 @@ public enum SchedulerPrefillBenchmark {
         var firstOutput: Duration?
         var errorMessage: String?
         for await output in engine.core.streamOutputs(requestId: requestID) {
+            // Skip the token-less prefill-start admission marker (emitted at admit,
+            // BEFORE prefill). Timing TTFT to it would report ~admit latency, not the
+            // prefill+first-token time this benchmark measures. A terminal output or
+            // a real token is NOT skipped, so a maxTokens==1 request still measures
+            // to the finish (matches the bridge skip in BatchScheduler+EngineBridge).
+            let isPrefillStartMarker = output.newTokenIds.isEmpty
+                && !output.finished && output.error == nil
+            if isPrefillStartMarker { continue }
             if firstOutput == nil {
                 firstOutput = ContinuousClock.now - started
             }

--- a/provider-swift/Sources/ProviderBenchmark/ThroughputSweep.swift
+++ b/provider-swift/Sources/ProviderBenchmark/ThroughputSweep.swift
@@ -261,11 +261,18 @@ public enum ThroughputSweep {
                     var start = ContinuousClock.now
                     var produced = 0
                     for await output in engine.core.streamOutputs(requestId: id) {
-                        if !sawFirst {
-                            sawFirst = true
-                            start = ContinuousClock.now
-                        } else {
-                            produced += output.newTokenIds.count
+                        // The engine emits a token-less prefill-start marker as the
+                        // FIRST output (at admit, before prefill). Gate the decode
+                        // clock on a REAL token so throughput excludes prefill and
+                        // never starts on the marker (matches the bridge skip in
+                        // BatchScheduler+EngineBridge.swift).
+                        if !output.newTokenIds.isEmpty {
+                            if !sawFirst {
+                                sawFirst = true
+                                start = ContinuousClock.now
+                            } else {
+                                produced += output.newTokenIds.count
+                            }
                         }
                         if output.finished || output.error != nil { break }
                     }

--- a/provider-swift/Sources/ProviderCore/Inference/BatchScheduler+EngineBridge.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/BatchScheduler+EngineBridge.swift
@@ -36,11 +36,16 @@ extension BatchScheduler {
     /// rejects that near-zero-window artifact.
     static let minPrefillWindowSeconds = 0.001
 
-    /// Upper plausibility bound (tok/s) for a prefill sample. Set above the
-    /// coordinator's 5000 clamp so a legitimately fast cold prefill still
-    /// registers, while clearly impossible rates are dropped (defense in depth
-    /// behind the cold-only + window-floor guards).
-    static let maxPlausiblePrefillTps = 8000.0
+    /// Upper plausibility bound (tok/s) for a prefill sample. Raised above the
+    /// MEASURED real-prefill p90 (17,707 tok/s — see
+    /// docs/reports/2026-06-22-live-prefill-tps-check.md) so a legitimately fast
+    /// cold prefill still registers now that the engine emits a real prefill-start
+    /// marker (the old 8000 sat BELOW p90 and would drop the genuinely-fast tail).
+    /// Kept finite so a residual window-collapse artifact is still rejected
+    /// (defense in depth behind the cold-only + window-floor guards). Matches the
+    /// coordinator's maxPrefillTPS ceiling so a sample this side accepts is not
+    /// then zeroed at ingest.
+    static let maxPlausiblePrefillTps = 20000.0
 
     // MARK: - Bridge runner (called from `submit` in the main file)
 
@@ -65,23 +70,26 @@ extension BatchScheduler {
             var sawFirstToken = false
             var sawTerminal = false
             // Wedge instrumentation (measurement only): count the admit at bridge
-            // start, BEFORE awaiting the engine. This is REQUIRED — not a
-            // queued-stream miscount: in THIS engine a `RequestOutput` is emitted
-            // ONLY from the decode phase (`Scheduler.processGenResponses`); there
-            // is NO prefill/admission-stage output, so a wedged first `eval`
-            // produces NO `RequestOutput` at all. Tying the admit to a "real
-            // engine admission signal" (first `RequestOutput`) would make the
-            // exact wedge we exist to detect invisible. A merely-queued request on
-            // a HEALTHY engine does NOT false-trip: `wedgeSuspected` additionally
+            // start, BEFORE awaiting the engine, so it is recorded even for the
+            // window before the engine's `addRequest` runs (a request still
+            // mid-submit). The engine now emits a token-less prefill-start
+            // `RequestOutput` at admission (`Scheduler.step`), so a wedged first
+            // `eval` DOES surface as admittedAt!=nil && firstTokenAt==nil — but
+            // counting here too is the belt-and-suspenders that keeps the admit
+            // visible regardless of output timing. A merely-queued request on a
+            // HEALTHY engine does NOT false-trip: `wedgeSuspected` additionally
             // requires the engine step counter to be FROZEN (steps keep advancing
             // while the engine serves other work), so only a truly frozen engine
             // trips. (See docs/reports/2026-06-22-cancel-root-cause-and-fix.md §C4.)
             await scheduler.recordWedgeAdmit(epoch: bridgeEpoch)
             for await output in outputStream {
-                // First `RequestOutput` (even prefill-only with no tokens)
-                // marks engine admission. Required by `expirePlannerTimeouts`
-                // to distinguish "queued" from "running" — long prefills
-                // emit no decoded token for many seconds.
+                // First `RequestOutput` marks engine admission. The engine emits a
+                // token-less prefill-start marker at admit (`Scheduler.step`), so
+                // this stamps admittedAt at REAL prefill start — the basis of the
+                // cold-prefill window measured in `recordFinish`. Also required by
+                // `expirePlannerTimeouts` to distinguish "queued" from "running" so
+                // a long prefill (which emits no decoded token for many seconds) is
+                // not aborted as a queue timeout.
                 if !sawAdmission {
                     await scheduler.recordAdmission(requestId: id, at: .now)
                     sawAdmission = true

--- a/provider-swift/Sources/ProviderCore/Inference/BatchScheduler+PrefillSamplingHealth.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/BatchScheduler+PrefillSamplingHealth.swift
@@ -2,19 +2,20 @@
 //
 // Prefill-EWMA sampling health — MEASUREMENT ONLY.
 //
-// The cold-prefill EWMA (`observedPrefillTpsEwma`, fed by `recordFinish`) can sit
-// stuck at 0 because every cold sample is dropped: a prefix-cache HIT (or a
-// near-instant first token) collapses the admission→first-token window so
-// `prefillSeconds ≈ ε`, which either falls below the `minPrefillWindowSeconds`
-// floor or, after dividing, blows past the `maxPlausiblePrefillTps` ceiling. With
-// no accepted samples the EWMA never initializes and the coordinator's TTFT model
-// falls back to its (10–25× pessimistic) estimate.
+// This file holds only the OBSERVABILITY side of cold-prefill sampling: the
+// cumulative accept/drop counters (`PrefillSamplingHealth`, surfaced on the
+// `engine_health` telemetry path) and `classifyPrefillSample` — the pure,
+// unit-testable classifier that `recordFinish` routes each candidate sample
+// through. The classifier encodes the EXACT same floor/ceiling/finite/cold
+// conditions as `recordFinish` and the accept path (`updatePrefillTpsEwma` on
+// `.accepted`) is byte-for-byte unchanged, so extracting it changes no behavior;
+// the counters just turn a previously silent drop into a dashboard line.
 //
-// These counters turn that silent drop into a dashboard line. They do NOT change
-// the sampling logic or bounds — `classifyPrefillSample` encodes the EXACT same
-// floor/ceiling/finite/cold conditions `recordFinish` already used; the accept
-// path (`updatePrefillTpsEwma` on `.accepted`) is byte-for-byte unchanged. The
-// classifier is pulled out as a pure function only so it is unit-testable.
+// The prefill-measurement MECHANISM itself — why the engine emits a token-less
+// prefill-start marker at admit, how admittedAt/firstTokenAt bound the cold-prefill
+// window, and the `minPrefillWindowSeconds` / `maxPlausiblePrefillTps` bounds and
+// their rationale — is documented canonically in BatchScheduler+EngineBridge.swift
+// (the "Prefill-EWMA sampling bounds" section and `recordFinish`), not repeated here.
 
 import Foundation
 

--- a/provider-swift/Tests/ProviderCoreTests/BatchSchedulerBudgetTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/BatchSchedulerBudgetTests.swift
@@ -443,7 +443,7 @@ struct BatchSchedulerBudgetTests {
         await s._testSeedBridge(id: "engine", promptTokens: 1000, maxTokens: 16)
         let t0 = ContinuousClock.now
         // A perfectly representative-looking cold window (1000 tok over 1s, well
-        // above the 1ms floor and below the 8000 cap): the ONLY reason to skip is
+        // above the 1ms floor and below the 20000 cap): the ONLY reason to skip is
         // that an engine-tier hit is indistinguishable from a cold prefill.
         await s.recordAdmission(requestId: "engine", at: t0.advanced(by: .seconds(-2)))
         await s.recordFirstToken(requestId: "engine", at: t0.advanced(by: .seconds(-1)))
@@ -456,6 +456,64 @@ struct BatchSchedulerBudgetTests {
             "engine-tier prefix cache active ⇒ no prefill-EWMA sample (hit vs cold ambiguous)")
         #expect(tps == 0,
             "engine-tier sampling skipped; EWMA stays at its 0 default (got \(tps))")
+    }
+
+    // MARK: - Raised prefill ceiling (durable measurement fix)
+
+    /// The plausibility ceiling was raised from 8000 → 20000 tok/s, above the
+    /// MEASURED real-prefill p90 (17,707). The old 8000 sat BELOW p90, so once the
+    /// engine emits a real prefill-start marker (giving cold prefills a real
+    /// window), a genuinely-fast cold prefill in the 8k–17.7k band would have been
+    /// dropped as "implausible". The classifier must now accept it.
+    @Test("classifyPrefillSample accepts the fast-cold band up to the raised ceiling")
+    func prefillClassifierHonorsRaisedCeiling() {
+        #expect(BatchScheduler.maxPlausiblePrefillTps == 20000.0,
+            "ceiling must sit above the measured p90 (17,707)")
+
+        // p50 (6500) and a fast cold prefill (14000) — both ACCEPTED now; 14000
+        // would have been .aboveCeiling under the old 8000 bound.
+        for tps in [6500.0, 14000.0, 17700.0] {
+            let c = BatchScheduler.classifyPrefillSample(
+                prefilledTokens: Int(tps), prefillSeconds: 1.0)
+            #expect(c == .accepted(tps: tps),
+                "\(tps) tok/s is a plausible cold prefill (<= p90); got \(c)")
+        }
+        // Above the new ceiling is still rejected (residual overflow guard).
+        let over = BatchScheduler.classifyPrefillSample(
+            prefilledTokens: 25000, prefillSeconds: 1.0)
+        #expect(over == .aboveCeiling, "25000 tok/s must still be dropped; got \(over)")
+        // The sub-millisecond window floor is unchanged.
+        let collapsed = BatchScheduler.classifyPrefillSample(
+            prefilledTokens: 1000, prefillSeconds: 0.0005)
+        #expect(collapsed == .belowFloor, "sub-1ms window still below floor; got \(collapsed)")
+    }
+
+    /// End-to-end through `recordFinish`: a real cold prefill window that yields a
+    /// fast rate in the 8k–20k band (impossible to even reach before the engine
+    /// emitted a prefill-start marker) is now ACCEPTED and initializes the EWMA —
+    /// the same sample was `droppedCeiling` under the old 8000 bound.
+    @Test("recordFinish accepts a fast cold prefill under the raised ceiling")
+    func prefillEwmaAcceptsFastColdPrefill() async {
+        let s = BatchScheduler()
+        // 14000 prompt tokens prefilled over 1s → 14000 tok/s (above the old 8000
+        // ceiling, below the new 20000). Explicit instants make it deterministic.
+        await s._testSeedBridge(id: "fast", promptTokens: 14000, maxTokens: 16)
+        let t0 = ContinuousClock.now
+        await s.recordAdmission(requestId: "fast", at: t0.advanced(by: .seconds(-2)))
+        await s.recordFirstToken(requestId: "fast", at: t0.advanced(by: .seconds(-1)))
+        _ = await s.recordFinish(
+            requestId: "fast", promptTokens: 14000, completionTokens: 8, success: true)
+
+        let tps = await s.observedPrefillTpsEwma
+        let initialized = await s.prefillEwmaInitialized
+        let health = await s.prefillHealth
+
+        #expect(initialized, "a fast cold prefill must initialize the EWMA")
+        #expect(abs(tps - 14000) < 1.0,
+            "14000 tok over 1s ≈ 14000 tok/s (got \(tps))")
+        #expect(health.accepted == 1, "sample accepted (got accepted=\(health.accepted))")
+        #expect(health.droppedCeiling == 0,
+            "must NOT be dropped by the ceiling now that it is 20000 (got droppedCeiling=\(health.droppedCeiling))")
     }
 
     // MARK: - Billing-zero leak: terminal must not zero observed tokens

--- a/provider-swift/Tests/ProviderCoreTests/ContinuousBatchingLiveTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/ContinuousBatchingLiveTests.swift
@@ -653,11 +653,18 @@ struct ContinuousBatchingLiveTests {
                     var start = ContinuousClock.now
                     var produced = 0
                     for await output in engine.core.streamOutputs(requestId: id) {
-                        if !sawFirst {
-                            sawFirst = true
-                            start = .now
-                        } else {
-                            produced += output.newTokenIds.count
+                        // Gate on a REAL token: the engine emits a token-less
+                        // prefill-start marker as the FIRST output (at admit, before
+                        // prefill), so starting the decode clock on the first output
+                        // would include prefill and count the marker (matches the
+                        // bridge skip in BatchScheduler+EngineBridge.swift).
+                        if !output.newTokenIds.isEmpty {
+                            if !sawFirst {
+                                sawFirst = true
+                                start = .now
+                            } else {
+                                produced += output.newTokenIds.count
+                            }
                         }
                         if output.finished || output.error != nil { break }
                     }
@@ -1411,8 +1418,13 @@ struct ContinuousBatchingLiveTests {
                         samplingParams: SamplingParams(maxTokens: decodeTokens + 1, temperature: 0.0)))
                     var sawFirst = false; var start = ContinuousClock.now; var produced = 0
                     for await output in engine.core.streamOutputs(requestId: id) {
-                        if !sawFirst { sawFirst = true; start = .now }
-                        else { produced += output.newTokenIds.count }
+                        // Gate on a REAL token: the first output is now the token-less
+                        // prefill-start marker (emitted at admit), which would start
+                        // the decode clock before prefill (see BatchScheduler+EngineBridge).
+                        if !output.newTokenIds.isEmpty {
+                            if !sawFirst { sawFirst = true; start = .now }
+                            else { produced += output.newTokenIds.count }
+                        }
                         if output.finished || output.error != nil { break }
                     }
                     return (i, Self.tokensPerSecond(produced, .now - start))

--- a/provider-swift/Tests/ProviderCoreTests/PerformanceLiveTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/PerformanceLiveTests.swift
@@ -589,13 +589,20 @@ struct PerformanceLiveTests {
                     var start = ContinuousClock.now
                     var produced = 0
                     for await output in engine.core.streamOutputs(requestId: id) {
-                        if !sawFirst {
-                            // Start the clock after the first token to
-                            // discount prefill.
-                            sawFirst = true
-                            start = ContinuousClock.now
-                        } else {
-                            produced += output.newTokenIds.count
+                        // Gate on a REAL token: the engine now emits a token-less
+                        // prefill-start marker as the FIRST output (at admit), so
+                        // starting the clock on the first output would include
+                        // prefill. Skipping empty-token outputs discounts prefill as
+                        // intended (matches the bridge in BatchScheduler+EngineBridge).
+                        if !output.newTokenIds.isEmpty {
+                            if !sawFirst {
+                                // Start the clock after the first token to
+                                // discount prefill.
+                                sawFirst = true
+                                start = ContinuousClock.now
+                            } else {
+                                produced += output.newTokenIds.count
+                            }
                         }
                         if output.finished || output.error != nil { break }
                     }


### PR DESCRIPTION
## Summary

The durable fix for the broken cold-prefill measurement. `observed_prefill_tps` is **0 fleet-wide** (verified: 0 of 313 warm slots; `docs/reports/2026-06-22-live-prefill-tps-check.md`) because the MLX engine emits a `RequestOutput` **only** from the decode phase — so the provider stamps `admittedAt` at *first-decode* time, the admitted→first-token window collapses to ~ε, and every cold sample is dropped by the 1 ms floor. The EWMA never leaves 0 and the coordinator falls back to a ~23×-pessimistic prefill estimate (the live 41% long-prompt `ttft_429` over-shed — mitigated immediately by the coordinator-side PR, fixed at the root here).

This is the **provider-side root-cause fix** and needs a provider release. It pairs with the coordinator recalibration PR (which is independent and ships now).

### What changed
1. **Engine (`mlx-swift-lm` submodule → [Layr-Labs/mlx-swift-lm#49](https://github.com/Layr-Labs/mlx-swift-lm/pull/49)):** `Scheduler.step()` emits a **token-less prefill-start marker** (`promptTokens>0, newTokenIds=[], finished=false`) for each newly-admitted request at admit, *before* its first prefill `eval`. For a cold prompt the marker is consumed before the first decode token, so the bridge's `admittedAt`→`firstTokenAt` window spans the **real** prefill.
2. **Provider bridge:** no logic change needed — `runBridge` already stamps `admittedAt` on the first `RequestOutput` and `firstTokenAt` only when a token is present, and never forwards an empty-`newText` output as content. Only the now-accurate comments were updated (the old ones asserted "no prefill/admission output exists").
3. **Raised ceiling:** `maxPlausiblePrefillTps` **8000 → 20000**, above the measured real-prefill **p90 (17,707 tok/s)**. The old 8000 sat *below* p90 and would have dropped the genuinely-fast cold tail once the window became real. Matches the coordinator's `maxPrefillTPS` so a sample this side accepts is not zeroed at ingest.

**Bonus:** stamping `admittedAt` at real prefill start also fixes the wedge detector's blindness to prefill-stage stalls and stops the pending-timeout watchdog from treating a long prefill as a queue timeout.

## Before / After

### Behavior (provider measurement → coordinator)
```mermaid
flowchart LR
  subgraph Before
    A1[cold prefill] --> B1["admittedAt = firstTokenAt (no prefill output)"]
    B1 --> C1["window ~0 -> sample below 1ms floor -> dropped"]
    C1 --> D1["EWMA=0 -> field omitted -> coordinator uses decode x12 (~280)"]
  end
  subgraph After
    A2[cold prefill] --> B2["admittedAt = prefill-start marker; firstTokenAt = first token"]
    B2 --> C2["REAL window -> sample accepted (<= 20000 ceiling)"]
    C2 --> D2["EWMA>0 -> observed_prefill_tps reported -> coordinator routes on truth"]
  end
```

### Code
```mermaid
flowchart TB
  subgraph Before
    S1["Scheduler.step ADMIT"] -->|no output| O1[only processGenResponses emits]
    R1["recordFinish: prefillSeconds ~ eps"] --> X1["classifyPrefillSample -> belowFloor"]
  end
  subgraph After
    S2["Scheduler.step ADMIT"] --> M2["append RequestOutput(promptTokens, newTokenIds:[])"]
    M2 --> BR2["runBridge: recordAdmission (no recordFirstToken, no chunk)"]
    R2["recordFinish: real prefillSeconds"] --> X2["classifyPrefillSample -> accepted (ceiling 20000)"]
  end
```

## Files
- `libs/mlx-swift-lm` — submodule pin bump `2b4b0d8d → cb48d151` (engine prefill-start marker + the two Codex P2 fixes; PR #49).
- `provider-swift/Sources/ProviderCore/Inference/BatchScheduler+EngineBridge.swift` — `maxPlausiblePrefillTps` 8000→20000; comment accuracy (admission marker now exists).
- `provider-swift/Sources/ProviderCore/Inference/BatchScheduler+PrefillSamplingHealth.swift` — header reflects the engine fix.
- `provider-swift/Tests/ProviderCoreTests/BatchSchedulerBudgetTests.swift` — raised-ceiling tests.

## Test plan
- [x] Engine: `CBSchedulerTests.testSchedulerEmitsPrefillStartAdmissionMarker` + all 7 `CBSchedulerTests` pass (`swift test --filter CBSchedulerTests`).
- [x] Provider: `prefillClassifierHonorsRaisedCeiling` + `prefillEwmaAcceptsFastColdPrefill` (a 14k tok/s cold prefill — impossible to reach before — is now accepted, not `droppedCeiling`); all 64 `BatchScheduler` tests + 14 wedge tests + 5 prefill tests pass.
- [x] `swift build` green (provider links `darkbloom`).

## ⚠️ Submodule merge ordering
The submodule pin currently points at the **PR #49 head on the fork** (`cb48d151`, which includes the two Codex P2 fixes: the admission marker is now a discrete non-coalesceable output and carries `cachedTokens`). Merge [Layr-Labs/mlx-swift-lm#49](https://github.com/Layr-Labs/mlx-swift-lm/pull/49) **first**, then re-pin `libs/mlx-swift-lm` to the merged `main` SHA before merging this PR (otherwise `git submodule update` from upstream cannot resolve the gitlink). A provider release/version bump should accompany the merge.

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/454"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784838189&installation_id=133247490&pr_number=454&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F454&signature=57e04ecde097acdf3fbaddf5deb88bd88eaddbf525569a43b119888769d83cd9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
