### PR TITLE
fix(console-ui): sidebar nav unclickable — fix React #418 hydration mismatch

### DIFF
--- a/console-ui/__tests__/store-hydration.test.ts
+++ b/console-ui/__tests__/store-hydration.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// Regression coverage for the "nav buttons unclickable after login" bug.
+//
+// Root cause: the store computed its initial `sidebarOpen` from
+// `window.innerWidth` and let zustand's `persist` middleware rehydrate
+// synchronously on load. Both make the FIRST client render diverge from the
+// server HTML, which triggers a React hydration mismatch (#418). React then
+// regenerates the whole tree, re-mounting the freshly-SSR'd sidebar and
+// stranding it (via its slide-in transform) so its nav links can't be clicked.
+//
+// The fix: a deterministic SSR-safe default (`sidebarOpen: true`) plus
+// `skipHydration: true`, with AppShell calling `persist.rehydrate()` after mount.
+
+const STORE_KEY = "darkbloom-store";
+
+describe("store SSR-safe hydration (regression: nav unclickable / #418)", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.resetModules();
+  });
+
+  it("initializes sidebarOpen to a deterministic true, independent of window.innerWidth", async () => {
+    // The old code returned `window.innerWidth >= 640`. Force a small viewport to
+    // prove the initial value no longer depends on it (otherwise the server,
+    // which has no window, would render a different sidebar than the client).
+    Object.defineProperty(window, "innerWidth", {
+      value: 320,
+      configurable: true,
+      writable: true,
+    });
+
+    const { useStore } = await import("@/lib/store");
+    expect(useStore.getState().sidebarOpen).toBe(true);
+  });
+
+  it("does not apply persisted state until rehydrate() runs (skipHydration)", async () => {
+    // Persist values that differ from the SSR defaults. With synchronous
+    // rehydration (the bug), these would be applied during module init so the
+    // first client render diverges from the server HTML.
+    localStorage.setItem(
+      STORE_KEY,
+      JSON.stringify({
+        state: {
+          sidebarOpen: false,
+          chats: [{ id: "c1", title: "Saved chat", messages: [], createdAt: 0 }],
+          activeChatId: "c1",
+          selectedModel: "saved-model",
+          useMyMachine: true,
+        },
+        version: 0,
+      })
+    );
+
+    const { useStore } = await import("@/lib/store");
+
+    // First-render state MUST equal the in-code defaults so it matches the
+    // server render. (Pre-fix this fails: persist applies the stored values now.)
+    expect(useStore.getState().sidebarOpen).toBe(true);
+    expect(useStore.getState().chats).toEqual([]);
+    expect(useStore.getState().selectedModel).toBe("");
+
+    // AppShell triggers this on mount — only then is persisted state applied.
+    await useStore.persist.rehydrate();
+    expect(useStore.getState().sidebarOpen).toBe(false);
+    expect(useStore.getState().chats).toHaveLength(1);
+    expect(useStore.getState().selectedModel).toBe("saved-model");
+  });
+
+  it("still writes state changes back to localStorage after the fix", async () => {
+    const { useStore } = await import("@/lib/store");
+    useStore.getState().setSidebarOpen(false);
+
+    const raw = localStorage.getItem(STORE_KEY);
+    expect(raw).toBeTruthy();
+    expect(JSON.parse(raw as string).state.sidebarOpen).toBe(false);
+  });
+});

--- a/console-ui/src/components/AppShell.tsx
+++ b/console-ui/src/components/AppShell.tsx
@@ -1,12 +1,28 @@
 "use client";
 
+import { useEffect } from "react";
 import { usePathname } from "next/navigation";
 import { Sidebar } from "./Sidebar";
 import { Toasts } from "./Toasts";
 import { ProviderSlackPopup } from "./community/ProviderSlackPopup";
+import { useStore, STORE_NAME } from "@/lib/store";
 
 export function AppShell({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
+
+  // The store uses `skipHydration` so the first client render matches the server
+  // (no React #418 hydration mismatch). Now that we're mounted, restore the
+  // persisted state, then apply the responsive sidebar default for first-time
+  // visitors on small screens (where the sidebar is a full-screen overlay).
+  useEffect(() => {
+    const firstVisit =
+      typeof window !== "undefined" &&
+      window.localStorage.getItem(STORE_NAME) === null;
+    useStore.persist.rehydrate();
+    if (firstVisit && typeof window !== "undefined" && window.innerWidth < 640) {
+      useStore.getState().setSidebarOpen(false);
+    }
+  }, []);
 
   // Device-linking page — no shell
   if (pathname === "/link") {

--- a/console-ui/src/components/InviteCodeBanner.tsx
+++ b/console-ui/src/components/InviteCodeBanner.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect } from "react";
 import { Ticket, X, Check, Loader2 } from "lucide-react";
 import { redeemInviteCode } from "@/lib/api";
 import { trackEvent } from "@/lib/google-analytics";
@@ -11,10 +11,14 @@ export const INVITE_DISMISSED_EVENT = "darkbloom-invite-dismissed";
 const DISMISSED_KEY = INVITE_DISMISSED_KEY;
 
 export function InviteCodeBanner() {
-  const [dismissed, setDismissed] = useState(() => {
-    if (typeof window === "undefined") return true;
-    return localStorage.getItem(DISMISSED_KEY) === "1";
-  });
+  // SSR-safe: render nothing on the first client paint (matching the server,
+  // which has no localStorage) to avoid a React #418 hydration mismatch that
+  // would regenerate the page tree and break the sidebar nav. The real dismissed
+  // state is read after mount.
+  const [dismissed, setDismissed] = useState(true);
+  useEffect(() => {
+    setDismissed(localStorage.getItem(DISMISSED_KEY) === "1");
+  }, []);
   const [expanded, setExpanded] = useState(false);
   const [code, setCode] = useState("");
   const [loading, setLoading] = useState(false);

--- a/console-ui/src/lib/store.ts
+++ b/console-ui/src/lib/store.ts
@@ -2,6 +2,10 @@ import { create } from "zustand";
 import { persist } from "zustand/middleware";
 import type { TrustMetadata, Model } from "./api";
 
+// localStorage key for the persisted store. Exported so the app shell can detect
+// a first-time visitor (no persisted state yet) when applying responsive defaults.
+export const STORE_NAME = "darkbloom-store";
+
 export interface Chat {
   id: string;
   title: string;
@@ -65,7 +69,13 @@ export const useStore = create<AppState>()(
       activeChatId: null,
       selectedModel: "",
       models: [],
-      sidebarOpen: typeof window !== "undefined" ? window.innerWidth >= 640 : true,
+      // Deterministic SSR-safe default: the server always renders the sidebar
+      // open, so the first client render must match (reading window.innerWidth
+      // here diverges on mobile → React #418 hydration mismatch, which
+      // regenerates the tree and breaks the sidebar's event handlers). The
+      // responsive default + any persisted value are applied after mount (see
+      // AppShell's rehydrate effect and `skipHydration` below).
+      sidebarOpen: true,
       useMyMachine: false,
 
       createChat: () => {
@@ -166,7 +176,14 @@ export const useStore = create<AppState>()(
         })),
     }),
     {
-      name: "darkbloom-store",
+      name: STORE_NAME,
+      // Defer reading persisted state until after mount. With the default
+      // (synchronous) rehydration, persisted values (chats, sidebarOpen,
+      // selectedModel, …) are applied during the first client render and diverge
+      // from the server HTML → React hydration mismatch (#418) → the whole tree
+      // (including the freshly-SSR'd sidebar) is regenerated and loses its click
+      // handlers. AppShell calls `useStore.persist.rehydrate()` once mounted.
+      skipHydration: true,
       partialize: (state) => ({
         chats: state.chats.map((c) => ({
           ...c,


### PR DESCRIPTION
## Summary

The left-nav sidebar (Chat / Stats / Provider Dashboard / Earn / API / Models / Billing / Settings) **rendered but was completely unclickable** — clicking a nav item did nothing and the URL never changed. Login (Privy modal) worked fine.

This was **not** an overlay or a z-index / stacking bug. The true cause is a **React hydration mismatch (#418)**: client-only state was read during the first (hydration) render, so the first client render diverged from the server HTML. React then threw away the server DOM and regenerated the tree, which re-mounted the freshly-SSR'd `<aside>` and replayed its `slide-in` transform — leaving the sidebar stranded at `translateX(-100%)`, present in the DOM but off-screen, so its links couldn't be hit.

Confirmed in-browser:
- `document.elementFromPoint(centerOfStatsLink)` returned **nothing** while the `<aside>` sat at `transform: matrix(1,0,0,1,-260,0)` / `opacity:0`.
- The dev server relayed `Uncaught Error: Hydration failed …` pointing at `InviteCodeBanner` reading `localStorage` in a `useState` initializer.

## Root cause

Two client-only reads diverged the first client render from the server HTML:

1. **`console-ui/src/lib/store.ts`** — `sidebarOpen` was seeded from `window.innerWidth >= 640`, and zustand's `persist` middleware rehydrated **synchronously** on load. So any persisted value (`sidebarOpen`, `chats`, `selectedModel`) — or a sub-640px viewport — made the first client render differ from the server (which always renders the sidebar open with empty chats). This is environment-independent and hits returning users in prod.
2. **`console-ui/src/components/InviteCodeBanner.tsx`** — read `localStorage` in its `useState` initializer, so the server rendered `null` while the client rendered the banner (the confirmed dev-console error).

## Fix

Make the first client render deterministic so it matches the server; apply client-only values **after** mount.

- **`store.ts`**: default `sidebarOpen: true` (no `window` read) + `skipHydration: true` (persist no longer rehydrates synchronously; writes still persist).
- **`AppShell.tsx`**: call `useStore.persist.rehydrate()` on mount, then reapply the responsive (mobile-collapsed) default for first-time visitors — so persisted state and viewport logic run after hydration instead of during it.
- **`InviteCodeBanner.tsx`**: initialize `dismissed: true`; read `localStorage` in a mount effect.
- **`__tests__/store-hydration.test.ts`**: regression test that fails without the fix (asserts deterministic initial state and that persisted values only apply after `rehydrate()`).

Behavior is preserved: persisted sidebar/chat state still restores, the mobile sidebar overlay still starts collapsed for new visitors, theme toggle / toasts / popups are untouched — they just reconcile one frame after mount (the correct SSR-safe pattern).

## Before / After

```mermaid
flowchart TB
  subgraph BEFORE["Before — hydration mismatch breaks the nav"]
    direction TB
    B1["SSR renders sidebar OPEN (aside present)<br/>InviteCodeBanner = null"]
    B2["Client FIRST render DIVERGES from server:<br/>store reads window.innerWidth + persist<br/>rehydrates synchronously;<br/>InviteCodeBanner reads localStorage"]
    B3["React #418 hydration mismatch:<br/>discard server DOM, regenerate tree on client"]
    B4["aside re-mounts -> slide-in replays<br/>-> stuck at translateX(-100%), opacity 0 (off-screen)"]
    B5["Click Stats -> nothing happens<br/>(elementFromPoint = null)"]
    B1 --> B2 --> B3 --> B4 --> B5
  end
  subgraph AFTER["After — deterministic first render"]
    direction TB
    A1["SSR renders sidebar OPEN<br/>InviteCodeBanner = null"]
    A2["Client FIRST render MATCHES server:<br/>sidebarOpen=true (no window read),<br/>skipHydration defers persist,<br/>InviteCodeBanner dismissed=true -> null"]
    A3["Hydration succeeds (no #418):<br/>adopt server DOM in place, bind handlers"]
    A4["AppShell useEffect:<br/>persist.rehydrate() + mobile default (after mount)"]
    A5["slide-in completes -> translateX(0) (on-screen)"]
    A6["Click Stats -> navigates to /stats<br/>(elementFromPoint = a[href=/stats])"]
    A1 --> A2 --> A3 --> A4 --> A5 --> A6
  end
```

## Verification

- **Browser (dev, localhost:3000):** no hydration error in the console on `/` and `/stats`; `elementFromPoint` over the Stats link returns the `<a href="/stats">`; clicking **Stats** navigates to `/stats` (`location.pathname === "/stats"`, heading "Network Stats").
- `cd console-ui && npm run build` — passes (39 routes, no errors).
- `cd console-ui && npx eslint src/` — passes (0 errors).
- `cd console-ui && npx vitest run` — passes, including the new regression test.

## Test plan

- [ ] Returning user with persisted `chats` / `sidebarOpen=false`: sidebar renders and every nav item is clickable; no `#418` in console.
- [ ] First-time visitor on mobile (<640px): sidebar starts collapsed (full-screen overlay), opens via the hamburger.
- [ ] Desktop: sidebar slide-in plays once and lands on-screen; Chat/Stats/Providers/Earn/API/Models/Billing/Settings all navigate.
- [ ] Theme toggle, toasts, invite-code banner, and provider Slack popup still work.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/457"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784848650&installation_id=133247490&pr_number=457&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F457&signature=72d534eeb9ee40971abb114ce0a527f6817083dec8cb082e44ae1dbec30cf24c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->