### PR TITLE
fix(console-ui): restore sidebar nav — stop Privy bridge starving App Router transitions

### DIFF
--- a/console-ui/__tests__/privy-auth-bridge.test.tsx
+++ b/console-ui/__tests__/privy-auth-bridge.test.tsx
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render } from "@testing-library/react";
+
+// Regression coverage for the "sidebar nav unclickable in production" bug.
+//
+// Root cause: `PrivyAuthBridge` consumed `usePrivy()` and pushed the auth state
+// up to the app via `onAuthChange` from an effect whose dependencies included
+// `login`/`logout`/`getAccessToken`. The Privy SDK hands back FRESH identities
+// for those methods on most renders, so the effect re-fired and called
+// `onAuthChange` (a `setState` in the parent provider) on essentially every
+// render. The rendered output never changed, so it produced no DOM mutations and
+// was invisible — but it perpetually re-scheduled default-priority work and
+// starved React's lower-priority navigation transitions. The result: `<Link>` /
+// `router.push()` silently no-opped under the Next 16 App Router, i.e. the
+// sidebar nav looked fine but clicking did nothing.
+//
+// The fix stabilizes the exposed callbacks (refs + `useCallback([])`) and keys
+// the effect on a stable `userId`, so `onAuthChange` fires only on real auth
+// changes.
+
+const { usePrivyCalls } = vi.hoisted(() => ({ usePrivyCalls: { n: 0 } }));
+
+vi.mock("@privy-io/react-auth", () => ({
+  // Passthrough provider so we can mount the bridge without the real SDK.
+  PrivyProvider: ({ children }: { children: React.ReactNode }) => children,
+  // Mimic the real SDK: stable auth fields, but NEW method identities each call.
+  usePrivy: () => {
+    usePrivyCalls.n++;
+    return {
+      ready: true,
+      authenticated: false,
+      user: null,
+      login: () => {},
+      logout: async () => {},
+      getAccessToken: async () => "token",
+    };
+  },
+}));
+
+import PrivyRealProvider from "@/components/providers/PrivyRealProvider";
+
+describe("PrivyAuthBridge stability (regression: router.push no-op / nav unclickable)", () => {
+  beforeEach(() => {
+    usePrivyCalls.n = 0;
+  });
+
+  it("reports auth state once despite re-renders + unstable Privy callbacks", () => {
+    const onAuthChange = vi.fn();
+    const { rerender } = render(
+      <PrivyRealProvider appId="test-app" onAuthChange={onAuthChange} />
+    );
+    // Force several re-renders; the mocked SDK returns fresh login/logout/
+    // getAccessToken each time, exactly like the real SDK does in production.
+    for (let i = 0; i < 6; i++) {
+      rerender(
+        <PrivyRealProvider appId="test-app" onAuthChange={onAuthChange} />
+      );
+    }
+
+    // The bridge really did re-render multiple times...
+    expect(usePrivyCalls.n).toBeGreaterThan(1);
+    // ...but auth state is reported ONCE, not once per render. Pre-fix this was
+    // 7 (1 mount + 6 rerenders), which is what starved navigation transitions.
+    expect(onAuthChange).toHaveBeenCalledTimes(1);
+
+    const state = onAuthChange.mock.calls[0][0];
+    expect(state.ready).toBe(true);
+    expect(state.authenticated).toBe(false);
+    expect(typeof state.getAccessToken).toBe("function");
+    expect(typeof state.login).toBe("function");
+    expect(typeof state.logout).toBe("function");
+  });
+});

--- a/console-ui/src/components/providers/PrivyRealProvider.tsx
+++ b/console-ui/src/components/providers/PrivyRealProvider.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import { PrivyProvider, usePrivy } from "@privy-io/react-auth";
 import type { AuthState } from "./PrivyClientProvider";
 
@@ -12,13 +12,40 @@ import type { AuthState } from "./PrivyClientProvider";
 
 function PrivyAuthBridge({ onAuthChange }: { onAuthChange: (s: AuthState) => void }) {
   const privy = usePrivy();
-  const { ready, authenticated, user, login, logout } = privy;
+  const { ready, authenticated, user } = privy;
 
-  const getAccessToken = useCallback(() => privy.getAccessToken(), [privy]);
+  // Keep a live ref to the Privy handle so the methods we expose are STABLE
+  // identities. Without this, `usePrivy()` hands back fresh `login`/`logout`/
+  // `getAccessToken` references on most renders, which made the effect below
+  // re-fire and call `onAuthChange` on every render — a setState-in-the-parent
+  // loop. It produced no DOM changes (the rendered output was identical), so it
+  // was invisible, but it perpetually re-scheduled default-priority work and
+  // starved React's lower-priority navigation transitions, so `<Link>` /
+  // `router.push` silently no-opped (the App Router sidebar became unclickable).
+  const privyRef = useRef(privy);
+  privyRef.current = privy;
+
+  const getAccessToken = useCallback(() => privyRef.current.getAccessToken(), []);
+  const login = useCallback(() => privyRef.current.login(), []);
+  const logout = useCallback(() => privyRef.current.logout(), []);
+
+  // Identify the user by a stable primitive so an unstable `user` object
+  // identity from Privy doesn't re-fire this effect every render.
+  const userId = (user as { id?: string } | null)?.id ?? null;
 
   useEffect(() => {
-    onAuthChange({ ready, authenticated, user, login, logout, getAccessToken });
-  }, [ready, authenticated, user, login, logout, getAccessToken, onAuthChange]);
+    onAuthChange({
+      ready,
+      authenticated,
+      user: privyRef.current.user,
+      login,
+      logout,
+      getAccessToken,
+    });
+    // Depend only on the values that meaningfully change auth state; the
+    // callbacks are stable (refs) so this fires once per real auth change.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [ready, authenticated, userId, login, logout, getAccessToken, onAuthChange]);
 
   return null;
 }


### PR DESCRIPTION
## Summary

The console-ui sidebar links (Stats, Providers, Earn, Models, Billing, Settings, …) are **visible but unclickable in production**: clicking does nothing, the URL never changes. This is **not** the issue #457 tried to fix (that hydration fix is correct, but orthogonal — the sidebar is rendered, on‑screen, and hit‑testable; no overlay, no `#418`).

**Root cause:** the Privy auth bridge (`PrivyRealProvider` → `PrivyAuthBridge`) reports auth state up to the app through an effect keyed on `usePrivy()`'s `login` / `logout` / `getAccessToken`. The Privy SDK hands back **fresh identities** for those methods on most renders, so the effect re-fired and called `onAuthChange` (a `setState` in `PrivyClientProvider`) on essentially **every render**. The rendered output never changed, so it produced **no DOM mutations and was invisible**, but it perpetually re‑scheduled default‑priority work and **starved React's lower‑priority navigation transitions**. Under the Next 16 App Router, `<Link>` / `router.push()` then **silently no‑op** (no `pushState`, no RSC fetch, no error).

It only reproduces in production because Privy is gated on `NEXT_PUBLIC_PRIVY_APP_ID` (absent in local dev), which is exactly why #457's dev‑only verification couldn't surface it.

**Fix:** keep a live ref to the Privy handle and expose **stable** `login` / `logout` / `getAccessToken` (`useCallback([])`), and key the bridge effect on a stable `userId`, so `onAuthChange` fires only on real auth changes. Navigation transitions are no longer starved and SPA navigation works again.

## Evidence (production build, headed Chromium, returning‑user localStorage)

| Build | Click "Stats" | `history.pushState` | URL | Verdict |
|---|---|---|---|---|
| master (Privy active) | `preventDefault` runs | **0** | stays `/` | **NO‑OP (broken)** |
| this PR | `preventDefault` runs | **1** | `/stats` | **SPA nav OK** |

Bisect that pinned it down: a bare `<PrivyProvider>` (no `PrivyAuthBridge`) navigates fine (`SPA_OK`); re‑adding the original bridge reproduces the no‑op. Disabling GA, Datadog, the client route cache (`staleTimes`), `prefetch`, a Suspense boundary, and upgrading Next (incl. `16.3.0-canary` with the #94144 cache fix) all did **not** fix it — only stabilizing the bridge does.

## Before / After — behavior

```mermaid
flowchart LR
  subgraph Before [Before: nav unclickable]
    A1[Click sidebar Stats] --> B1[next/link onClick<br/>preventDefault]
    B1 --> C1[startTransition router.push]
    C1 --> D1{transition starved by<br/>per-render setState loop}
    D1 --> E1[no pushState / no RSC fetch]
    E1 --> F1[URL stays / — nothing happens]
  end
  subgraph After [After: SPA nav]
    A2[Click sidebar Stats] --> B2[next/link onClick<br/>preventDefault]
    B2 --> C2[startTransition router.push]
    C2 --> D2[transition commits]
    D2 --> E2[pushState + RSC fetch]
    E2 --> F2[URL becomes /stats]
  end
```

## Before / After — code

```mermaid
flowchart TB
  subgraph Before [Before: PrivyAuthBridge]
    a1[usePrivy returns fresh<br/>login/logout/getAccessToken each render]
    a1 --> a2[effect deps include those identities]
    a2 --> a3[effect re-fires every render]
    a3 --> a4[onAuthChange -> setState in parent]
    a4 --> a5[re-render -> usePrivy -> new identities]
    a5 --> a2
    a5 -.default-priority churn.-> a6[React navigation transition never commits]
  end
  subgraph After [After: PrivyAuthBridge]
    b1[privyRef holds live handle]
    b1 --> b2[login/logout/getAccessToken = useCallback&#40;[]&#41; stable]
    b2 --> b3[effect keyed on ready/authenticated/userId + stable cbs]
    b3 --> b4[onAuthChange fires once per real auth change]
    b4 --> b5[no churn -> transitions commit]
  end
```

## Test plan

- [x] `cd console-ui && npm run build` — passes
- [x] `npx eslint src/` — 0 errors
- [x] `npx vitest run` — only the 3 pre-existing `provider-dashboard-*` failures remain (present on master `e8ba9c0f`, unrelated to this change); all others pass
- [x] New regression test `__tests__/privy-auth-bridge.test.tsx` — **fails** on the old bridge (`onAuthChange` called per render), **passes** on the fix
- [x] Browser re-check (headed Chromium, production build, Privy enabled): clicking Stats navigates to `/stats` via SPA (3/3); cross-page nav `/stats → /models` works; mobile (390px) overlay nav works and auto-closes; theme toggle + toasts unaffected
- [ ] Post-merge: confirm Vercel promotes the merge commit to `console.darkbloom.dev` and re-verify sidebar nav in the live deploy

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/460"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784855065&installation_id=133247490&pr_number=460&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F460&signature=5acb484a646d4a4fe992f69810ebb8f7a3316be4f397dafce741f3d2db046edb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->