### PR TITLE
fix(console-ui): stop /api/auth/keys provisioning request storm

### DIFF
--- a/console-ui/src/components/providers/PrivyRealProvider.test.tsx
+++ b/console-ui/src/components/providers/PrivyRealProvider.test.tsx
@@ -1,0 +1,66 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render } from "@testing-library/react";
+import type { AuthState } from "./PrivyClientProvider";
+
+// Mutable holder for the value usePrivy() returns, so a test can simulate a
+// Privy "tick" by swapping in a brand-new object with new function identities.
+const h = vi.hoisted(() => ({ privy: null as unknown as Record<string, unknown> }));
+
+vi.mock("@privy-io/react-auth", () => ({
+  PrivyProvider: (props: { children?: unknown }) => props.children,
+  usePrivy: () => h.privy,
+}));
+
+import PrivyRealProvider from "./PrivyRealProvider";
+
+function privyValue(over: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    ready: true,
+    authenticated: true,
+    user: { id: "u1" },
+    login: vi.fn(),
+    logout: vi.fn(async () => {}),
+    getAccessToken: vi.fn(async () => "tok"),
+    ...over,
+  };
+}
+
+beforeEach(() => {
+  h.privy = privyValue();
+});
+
+describe("PrivyRealProvider auth identity stability", () => {
+  it("does not republish AuthState when only Privy's object identity changes", () => {
+    const onAuthChange = vi.fn();
+    const { rerender } = render(
+      <PrivyRealProvider appId="x" onAuthChange={onAuthChange} />,
+    );
+
+    const callsAfterMount = onAuthChange.mock.calls.length;
+    expect(callsAfterMount).toBeGreaterThan(0);
+
+    // Simulate a token-refresh tick: new object + new function refs, but the
+    // SAME ready/authenticated/user.id.
+    h.privy = privyValue();
+    rerender(<PrivyRealProvider appId="x" onAuthChange={onAuthChange} />);
+
+    expect(onAuthChange).toHaveBeenCalledTimes(callsAfterMount);
+  });
+
+  it("publishes a stable getAccessToken across renders", () => {
+    const states: AuthState[] = [];
+    const onAuthChange = (s: AuthState) => states.push(s);
+    const { rerender } = render(
+      <PrivyRealProvider appId="x" onAuthChange={onAuthChange} />,
+    );
+
+    // A real auth change DOES republish — but the action callback identity
+    // must remain stable so consumer effects don't churn.
+    h.privy = privyValue({ authenticated: false, user: null });
+    rerender(<PrivyRealProvider appId="x" onAuthChange={onAuthChange} />);
+
+    expect(states.length).toBeGreaterThanOrEqual(2);
+    expect(states[0].getAccessToken).toBe(states[states.length - 1].getAccessToken);
+  });
+});

--- a/console-ui/src/components/providers/PrivyRealProvider.tsx
+++ b/console-ui/src/components/providers/PrivyRealProvider.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import { PrivyProvider, usePrivy } from "@privy-io/react-auth";
 import type { AuthState } from "./PrivyClientProvider";
 
@@ -12,13 +12,30 @@ import type { AuthState } from "./PrivyClientProvider";
 
 function PrivyAuthBridge({ onAuthChange }: { onAuthChange: (s: AuthState) => void }) {
   const privy = usePrivy();
-  const { ready, authenticated, user, login, logout } = privy;
+  const { ready, authenticated, user } = privy;
 
-  const getAccessToken = useCallback(() => privy.getAccessToken(), [privy]);
+  // usePrivy() returns a NEW object on every internal tick (token refresh,
+  // etc.). Closing over it directly gave getAccessToken/login/logout a fresh
+  // identity each tick, which pushed a new AuthState into context and
+  // invalidated every consumer effect — most visibly the key auto-provision,
+  // which then stormed POST /api/auth/keys. Hold the live instance in a ref so
+  // the action callbacks stay STABLE while still calling the latest Privy.
+  const privyRef = useRef(privy);
+  privyRef.current = privy;
 
+  const getAccessToken = useCallback(() => privyRef.current.getAccessToken(), []);
+  const login = useCallback(() => privyRef.current.login(), []);
+  const logout = useCallback(() => privyRef.current.logout(), []);
+
+  // Only publish a new AuthState when the MEANINGFUL auth state changes
+  // (readiness, authentication, or which user). A token refresh that leaves
+  // those untouched must not churn the context. The action callbacks above are
+  // stable refs, so they are intentionally excluded from the deps.
+  const userId = (user as { id?: string } | null)?.id ?? null;
   useEffect(() => {
     onAuthChange({ ready, authenticated, user, login, logout, getAccessToken });
-  }, [ready, authenticated, user, login, logout, getAccessToken, onAuthChange]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [ready, authenticated, userId, onAuthChange]);
 
   return null;
 }

--- a/console-ui/src/hooks/useAuth.test.tsx
+++ b/console-ui/src/hooks/useAuth.test.tsx
@@ -1,0 +1,95 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { AuthState } from "@/components/providers/PrivyClientProvider";
+import { useAuth, resetConsoleKeyProvisionBackoff } from "./useAuth";
+import { STORAGE_KEYS } from "@/lib/constants";
+
+// Mutable holder so each test can drive what useAuthContext returns.
+const h = vi.hoisted(() => ({ auth: null as unknown as AuthState }));
+
+vi.mock("@/components/providers/PrivyClientProvider", () => ({
+  useAuthContext: () => h.auth,
+}));
+vi.mock("@/lib/google-analytics", () => ({ trackEvent: vi.fn() }));
+
+function authState(over: Partial<AuthState> = {}): AuthState {
+  return {
+    ready: true,
+    authenticated: true,
+    user: { id: "u1" },
+    login: vi.fn(),
+    logout: vi.fn(async () => {}),
+    getAccessToken: vi.fn(async () => "privy-token"),
+    ...over,
+  };
+}
+
+// Let pending provision microtasks settle (fetch + json + finally/cooldown).
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+beforeEach(() => {
+  localStorage.clear();
+  resetConsoleKeyProvisionBackoff();
+  h.auth = authState();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  resetConsoleKeyProvisionBackoff();
+});
+
+describe("useAuth console-key provisioning", () => {
+  it("coalesces many concurrent mounts into a single POST /api/auth/keys", async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ api_key: "sk-db-new" }),
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    // The provider dashboard mounts useAuth many times at once.
+    for (let i = 0; i < 6; i++) renderHook(() => useAuth());
+
+    await waitFor(() =>
+      expect(localStorage.getItem(STORAGE_KEYS.apiKey)).toBe("sk-db-new"),
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/auth/keys",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+
+  it("does not call the endpoint when a key already exists", async () => {
+    localStorage.setItem(STORAGE_KEYS.apiKey, "sk-db-existing");
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    for (let i = 0; i < 4; i++) renderHook(() => useAuth());
+    await flush();
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("backs off after a rate-limited response instead of storming", async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: false,
+      status: 429,
+      json: async () => ({ error: "rate limit exceeded" }),
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    // First mount makes exactly one attempt, which fails and arms the cooldown.
+    renderHook(() => useAuth());
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    await flush();
+
+    // Further mounts within the cooldown must NOT re-hit the endpoint.
+    fetchMock.mockClear();
+    for (let i = 0; i < 5; i++) renderHook(() => useAuth());
+    await flush();
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(localStorage.getItem(STORAGE_KEYS.apiKey)).toBeNull();
+  });
+});

--- a/console-ui/src/hooks/useAuth.ts
+++ b/console-ui/src/hooks/useAuth.ts
@@ -9,6 +9,79 @@ const API_KEY_STORAGE = STORAGE_KEYS.apiKey;
 const OLD_API_KEY_STORAGE = STORAGE_KEYS.legacyApiKey;
 const COORD_URL_STORAGE = STORAGE_KEYS.coordinatorUrl;
 
+// How long to stop re-attempting auto-provision after a failed/rate-limited
+// response, so a page that mounts useAuth many times cannot turn one failure
+// into a sustained request storm.
+const PROVISION_FAILURE_COOLDOWN_MS = 30_000;
+
+// Module-level (one per browser tab) so EVERY useAuth instance shares a single
+// in-flight provision. The provider dashboard mounts useAuth many times at once
+// (the fleet hook, one per machine's RemoveMachineButton, the sidebar, RUM),
+// and a provider account often has no inference key yet — so without coalescing
+// each instance fires POST /api/auth/keys simultaneously. That burst trips the
+// coordinator's financial rate limit, every response then comes back without an
+// api_key, the localStorage guard never engages, and the burst repeats: a
+// browser-side self-DoS. One shared promise + a post-failure cooldown bounds it
+// to a single request that, on success, persists the key for all callers.
+let provisionInFlight: Promise<string | null> | null = null;
+let provisionBlockedUntil = 0;
+
+// Clear the provision backoff/in-flight state. Called on logout so a fast
+// re-login isn't blocked by a stale cooldown from the previous session.
+export function resetConsoleKeyProvisionBackoff(): void {
+  provisionInFlight = null;
+  provisionBlockedUntil = 0;
+}
+
+// Provision (or reuse) the console's inference API key, deduped across all
+// concurrent callers in the tab. Resolves to the key, or null when none could
+// be obtained (no token, rate-limited, or error) — callers treat null as
+// "not ready".
+async function provisionConsoleKey(
+  getToken: () => Promise<string | null>,
+): Promise<string | null> {
+  if (typeof window === "undefined") return null;
+
+  const existing = localStorage.getItem(API_KEY_STORAGE);
+  if (existing) return existing;
+
+  // Coalesce: hand every concurrent caller the same in-flight request.
+  if (provisionInFlight) return provisionInFlight;
+  // Back off after a recent failure instead of hammering the endpoint.
+  if (Date.now() < provisionBlockedUntil) return null;
+
+  provisionInFlight = (async () => {
+    try {
+      const token = await getToken().catch(() => null);
+      if (!token) return null;
+      const res = await fetch("/api/auth/keys", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+      });
+      const data = (await res.json().catch(() => ({}))) as { api_key?: string };
+      if (res.ok && data.api_key) {
+        localStorage.setItem(API_KEY_STORAGE, data.api_key);
+        return data.api_key;
+      }
+      // Rate-limited / error / keyless response: arm the cooldown so a
+      // multi-mount page can't spin on it.
+      provisionBlockedUntil = Date.now() + PROVISION_FAILURE_COOLDOWN_MS;
+      return null;
+    } catch (err) {
+      console.warn("[useAuth] Key provisioning failed:", err);
+      provisionBlockedUntil = Date.now() + PROVISION_FAILURE_COOLDOWN_MS;
+      return null;
+    } finally {
+      provisionInFlight = null;
+    }
+  })();
+
+  return provisionInFlight;
+}
+
 export function useAuth() {
   const { ready, authenticated, user, login, logout: privyLogout, getAccessToken } = useAuthContext();
   const [apiKeyReady, setApiKeyReady] = useState(false);
@@ -22,27 +95,8 @@ export function useAuth() {
   // and store it. Used by both the mount effect and the key-expired handler so
   // the sequence lives in one place (proposal F8).
   const provisionApiKey = useCallback(async () => {
-    const token = await getAccessToken().catch(() => null);
-    if (!token) return;
-    try {
-      const res = await fetch("/api/auth/keys", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${token}`,
-        },
-      });
-      const data = await res.json();
-      if (data.api_key) {
-        localStorage.setItem(API_KEY_STORAGE, data.api_key);
-        setApiKeyReady(true);
-      } else {
-        setApiKeyReady(false);
-      }
-    } catch (err) {
-      console.warn("[useAuth] Key provisioning failed:", err);
-      setApiKeyReady(false);
-    }
+    const key = await provisionConsoleKey(getAccessToken);
+    setApiKeyReady(!!key);
   }, [getAccessToken]);
 
   // Migrate old API key and auto-provision on auth.
@@ -104,6 +158,8 @@ export function useAuth() {
       localStorage.removeItem(OLD_API_KEY_STORAGE);
       localStorage.removeItem(COORD_URL_STORAGE);
     }
+    // Drop any provision cooldown/in-flight so a re-login provisions promptly.
+    resetConsoleKeyProvisionBackoff();
     await privyLogout();
   }, [privyLogout]);
 


### PR DESCRIPTION
## Summary

A frontend bug DoS'd the coordinator's key auto-provision endpoint: the browser hammered `POST /api/auth/keys`, most visibly on the **provider dashboard**.

Root cause is a combination of factors that all peak on the dashboard:

- `useAuth` is mounted **many times at once** there — the fleet hook, one per offline machine's `RemoveMachineButton`, the sidebar, and RUM — and each instance independently runs the auto-provision effect.
- Provider accounts often have **no inference key yet**, so the `localStorage` guard doesn't short-circuit.
- There was **no dedup/in-flight guard**, so all instances fired `POST /api/auth/keys` concurrently. Each call **mints a new key** server-side, and the burst trips the coordinator's financial rate limit. The rate-limited responses come back **without** an `api_key`, so the `localStorage` guard never engages.
- `PrivyRealProvider` rebuilt `getAccessToken`/the whole `AuthState` on **every Privy tick** (token refresh, etc.), and the dashboard's 15s fleet poll + 1s header re-render maximize that churn — which kept re-firing the provisioning effect.

Net: many mounts × no dedup × create-every-call × unstable identity = a self-inflicted request storm.

## Changes

- **`useAuth`** — provisioning is now a single, tab-wide, in-flight-deduped call (`provisionConsoleKey`) with a 30s post-failure cooldown, so a rate-limited/error response can't be retried into a storm. On success it persists the key for all callers; the backoff resets on logout.
- **`PrivyRealProvider`** — hold the live Privy instance in a ref so `getAccessToken`/`login`/`logout` keep a **stable identity**, and only republish `AuthState` when `ready`/`authenticated`/`user.id` actually change. Token-refresh ticks no longer churn every consumer effect.

## Follow-up (not in this PR)

The endpoint itself is still create-every-call. Recommend making `POST /v1/auth/keys` (`handleCreateKey` -> `store.CreateKeyForAccount`) **get-or-create** the account's auto-provisioned key, as a server-side backstop against any client. That spans the handler + both store impls + tests, so it's tracked separately.

## Test plan

- [x] `npx vitest run` for the new suites — many concurrent `useAuth` mounts produce **exactly one** `POST /api/auth/keys`; a 429 arms the cooldown so subsequent mounts make zero further calls; a Privy identity-only tick does not republish `AuthState` and `getAccessToken` stays stable.
- [x] `npx eslint` clean on changed files.
- [x] `npm run build` succeeds.
- [ ] Manual: open the provider dashboard with DevTools Network filtered to `keys`; confirm a single `POST /api/auth/keys` on first load and none while idle; walk a 401 (expire the key) and confirm a single re-provision, not a burst.

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/461"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784915875&installation_id=133247490&pr_number=461&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F461&signature=674d577a2dabc702683ede393e121b1e9ef4f35d746a956433579ba0469354df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->