### PR TITLE
fix(console-ui): repair provider dashboard tab navigation + gate post-install tabs

### DIFF
--- a/console-ui/src/app/providers/dashboard/FixAffordance.tsx
+++ b/console-ui/src/app/providers/dashboard/FixAffordance.tsx
@@ -2,7 +2,9 @@
 // card hero and the attention feed: a copy-command pill, a link button, or a
 // line of guidance. Shared so the action always looks and behaves the same.
 
-import Link from "next/link";
+// Native <a> for internal links too: the App Router client-router path is
+// currently broken for shell navigation (see #457/#458) — next/link renders but
+// does not navigate. Browser-native route loads always work. Mirrors #458.
 import { ArrowRight, ExternalLink } from "lucide-react";
 import { CopyCommand } from "./gauges/CopyCommand";
 import type { FixAction } from "./fixes";
@@ -41,9 +43,9 @@ export function FixAffordance({
             {fix.label} <ExternalLink size={11} />
           </a>
         ) : (
-          <Link href={fix.href} className={cls}>
+          <a href={fix.href} className={cls}>
             {fix.label} <ArrowRight size={11} />
-          </Link>
+          </a>
         )}
         {note}
       </div>

--- a/console-ui/src/app/providers/dashboard/OnboardingState.tsx
+++ b/console-ui/src/app/providers/dashboard/OnboardingState.tsx
@@ -2,7 +2,9 @@
 // gives the three concrete steps with a copyable install command, and explains
 // in one line why the network is trustworthy.
 
-import Link from "next/link";
+// Native <a> navigation (not next/link): the App Router client-router path is
+// currently broken for shell navigation (see #457/#458) — Link renders but does
+// not navigate. Browser-native route loads always work. Mirrors #458.
 import { ArrowRight, Cpu, ShieldCheck, TrendingUp, Zap } from "lucide-react";
 import { CopyCommand } from "./gauges/CopyCommand";
 import { INSTALL_COMMAND } from "./fixes";
@@ -51,18 +53,18 @@ export function OnboardingState() {
             </div>
 
             <div className="flex flex-wrap gap-3 mt-6">
-              <Link
+              <a
                 href="/providers/setup"
                 className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-accent-brand text-white text-sm font-medium hover:bg-accent-brand-hover transition-colors"
               >
                 Set up a provider <ArrowRight size={14} />
-              </Link>
-              <Link
+              </a>
+              <a
                 href="/earn"
                 className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-bg-tertiary text-text-primary text-sm font-medium hover:bg-bg-hover transition-colors"
               >
                 Open calculator <ArrowRight size={14} />
-              </Link>
+              </a>
             </div>
           </div>
 

--- a/console-ui/src/app/providers/layout.tsx
+++ b/console-ui/src/app/providers/layout.tsx
@@ -1,11 +1,18 @@
 "use client";
 
+// Native <a> navigation (not next/link): the App Router client-router path is
+// currently broken for shell/tab navigation (see #457/#458) — Link renders but
+// router.push silently no-ops, so the tabs don't switch pages. Browser-native
+// route loads always work. Mirrors the sidebar workaround in #458.
 import { TopBar } from "@/components/TopBar";
-import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { useHasLinkedProviders } from "./useHasLinkedProviders";
 
-const TABS = [
-  { href: "/providers", label: "Dashboard" },
+const DASHBOARD_TAB = { href: "/providers", label: "Dashboard" };
+// Setup and Earnings are post-install surfaces — shown only once the account has
+// at least one linked machine. Before that, the Dashboard's onboarding state
+// owns the "set up a provider" flow.
+const POST_INSTALL_TABS = [
   { href: "/providers/setup", label: "Setup" },
   { href: "/providers/earnings", label: "Earnings" },
 ];
@@ -16,6 +23,8 @@ export default function ProvidersLayout({
   children: React.ReactNode;
 }) {
   const pathname = usePathname();
+  const hasProviders = useHasLinkedProviders();
+  const tabs = hasProviders ? [DASHBOARD_TAB, ...POST_INSTALL_TABS] : [DASHBOARD_TAB];
 
   return (
     <div className="flex flex-col h-full">
@@ -23,10 +32,10 @@ export default function ProvidersLayout({
       <div className="border-b border-border-dim bg-bg-primary">
         <div className="max-w-5xl mx-auto px-6">
           <nav className="flex gap-1">
-            {TABS.map(({ href, label }) => {
+            {tabs.map(({ href, label }) => {
               const isActive = pathname === href;
               return (
-                <Link
+                <a
                   key={href}
                   href={href}
                   className={`px-4 py-3 text-sm font-medium border-b-2 transition-colors ${
@@ -36,7 +45,7 @@ export default function ProvidersLayout({
                   }`}
                 >
                   {label}
-                </Link>
+                </a>
               );
             })}
           </nav>

--- a/console-ui/src/app/providers/useHasLinkedProviders.ts
+++ b/console-ui/src/app/providers/useHasLinkedProviders.ts
@@ -1,0 +1,48 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useAuth } from "@/hooks/useAuth";
+
+// One-shot check for whether the signed-in account has at least one linked
+// provider machine. Drives progressive disclosure of the Setup/Earnings tabs in
+// the providers layout, which are only meaningful post-install.
+//
+// Deliberately starts `false` and only reads state inside an effect (never
+// during render) so the first client render matches the server (Dashboard-only)
+// — the same hydration-determinism discipline as the store/InviteCodeBanner fix
+// in #457. Non-polling and best-effort: an unauthenticated session or a failed
+// fetch leaves the tabs hidden, which self-heals on the next load.
+export function useHasLinkedProviders(): boolean {
+  const { authenticated, getAccessToken } = useAuth();
+  const [hasProviders, setHasProviders] = useState(false);
+
+  useEffect(() => {
+    if (!authenticated) {
+      setHasProviders(false);
+      return;
+    }
+    let cancelled = false;
+    void (async () => {
+      const token = await getAccessToken().catch(() => null);
+      if (!token || cancelled) return;
+      try {
+        const res = await fetch("/api/me/providers", {
+          headers: { Authorization: `Bearer ${token}` },
+          cache: "no-store",
+        });
+        if (!res.ok || cancelled) return;
+        const data = (await res.json()) as { providers?: unknown[] };
+        if (!cancelled) {
+          setHasProviders(Array.isArray(data.providers) && data.providers.length > 0);
+        }
+      } catch {
+        // Best-effort: leave the tabs hidden on failure.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [authenticated, getAccessToken]);
+
+  return hasProviders;
+}


### PR DESCRIPTION
## Summary

On the Provider Dashboard the top tabs (**Dashboard / Setup / Earnings**) and the onboarding **Set up a provider** / **Open calculator** buttons rendered but did nothing — clicking them never switched pages.

**Root cause:** they use `next/link`, whose App Router **client-router path is currently broken app-wide** (the #457/#458 regression) — the link renders but `router.push` silently no-ops, so only full-page-load `<a>` navigation works. #458 worked around this for the **sidebar** by switching to native `<a>` and explicitly left "the broken Next Link client-router path" in place; these dashboard surfaces were never converted, which is the regression.

Two asks were folded in:
1. **Navigation must work** — fixed.
2. **Setup/Earnings should only appear after installation** — the tabs previously always rendered (not a recent change); now gated on having ≥1 linked machine.

## Changes

- Switch to native `<a>` navigation (mirroring #458) in:
  - `providers/layout.tsx` — the Dashboard/Setup/Earnings tabs
  - `dashboard/OnboardingState.tsx` — "Set up a provider" + "Open calculator"
  - `dashboard/FixAffordance.tsx` — internal "fix" CTA links (external ones already used `<a>`)
- Add `useHasLinkedProviders` (one-shot, non-polling `/api/me/providers` check) and gate the **Setup/Earnings** tabs behind it. Pre-install shows only **Dashboard** (whose onboarding state owns the setup flow); the tabs appear once a machine is linked. The hook starts `false` and reads state only inside an effect, so the first render is deterministic — no hydration mismatch (the same discipline as the #457 fix).
- Dropped the `eslint-disable @next/next/no-html-link-for-pages` lines #458 introduced; the rule doesn't fire in this App Router config (it was flagged as an unused directive).

## Not in this PR (follow-ups)

- **Deeper root cause:** Next's `<Link>` client router is broken app-wide. The durable fix is to find/repair that (then revert all the native-`<a>` band-aids). Two `<Link>` usages remain on the broken path outside this scope: `app/stats/page.tsx` and `app/earn/SetupProviderCTA.tsx`.

## Test plan

- [x] `npx eslint src/` — 0 errors (pre-existing warnings only).
- [x] `npm run build` — succeeds.
- [ ] Manual: on the Provider Dashboard with **no machines**, only the Dashboard tab shows; **Set up a provider** / **Open calculator** navigate. With **≥1 linked machine**, Setup/Earnings tabs appear and the tabs switch pages.

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/462"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784917648&installation_id=133247490&pr_number=462&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F462&signature=a3d518dd8e3d2a4f716a8ae7069fbc6346edc7acf381e3fd343a96dc0bf0513c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->