### PR TITLE
fix(console-ui): fix hydration mismatch that broke client-side navigation (root cause)

### DIFF
--- a/console-ui/src/components/providers/verification-mode.test.tsx
+++ b/console-ui/src/components/providers/verification-mode.test.tsx
@@ -1,0 +1,69 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { VerificationModeProvider, useVerificationMode } from "./verification-mode";
+import { STORAGE_KEYS } from "@/lib/constants";
+
+// Records the mode on every render so a test can assert the FIRST render is
+// deterministic (server-safe) even when localStorage diverges. Reading
+// localStorage in the useState initializer was what diverged the first client
+// render from the server HTML and caused the hydration mismatch that broke
+// client-side navigation app-wide.
+let renders: string[] = [];
+
+function Probe() {
+  const { mode, toggle } = useVerificationMode();
+  renders.push(mode);
+  return (
+    <button data-testid="mode" onClick={toggle}>
+      {mode}
+    </button>
+  );
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  renders = [];
+});
+
+describe("VerificationModeProvider hydration determinism", () => {
+  it("first render is 'normal' even when localStorage says technical, then applies it after mount", () => {
+    localStorage.setItem(STORAGE_KEYS.verificationMode, "technical");
+
+    render(
+      <VerificationModeProvider>
+        <Probe />
+      </VerificationModeProvider>,
+    );
+
+    // The first client render must match the server (which has no localStorage):
+    // "normal". A divergent first render is the hydration mismatch we're fixing.
+    expect(renders[0]).toBe("normal");
+    // After the mount effect, the persisted preference is applied.
+    expect(screen.getByTestId("mode").textContent).toBe("technical");
+  });
+
+  it("stays 'normal' on first render and after mount when nothing is persisted", () => {
+    render(
+      <VerificationModeProvider>
+        <Probe />
+      </VerificationModeProvider>,
+    );
+
+    expect(renders[0]).toBe("normal");
+    expect(screen.getByTestId("mode").textContent).toBe("normal");
+  });
+
+  it("toggle flips the mode and persists it", () => {
+    render(
+      <VerificationModeProvider>
+        <Probe />
+      </VerificationModeProvider>,
+    );
+
+    expect(screen.getByTestId("mode").textContent).toBe("normal");
+    fireEvent.click(screen.getByTestId("mode"));
+    expect(screen.getByTestId("mode").textContent).toBe("technical");
+    expect(localStorage.getItem(STORAGE_KEYS.verificationMode)).toBe("technical");
+  });
+});

--- a/console-ui/src/components/providers/verification-mode.tsx
+++ b/console-ui/src/components/providers/verification-mode.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { createContext, useContext, useState, useCallback } from "react";
+import { createContext, useContext, useEffect, useState, useCallback } from "react";
 import { STORAGE_KEYS } from "@/lib/constants";
 
 type VerificationMode = "normal" | "technical";
@@ -17,15 +17,24 @@ const VerificationModeContext = createContext<VerificationModeContextValue>({
 
 const STORAGE_KEY = STORAGE_KEYS.verificationMode;
 
-function getInitialMode(): VerificationMode {
-  if (typeof window === "undefined") return "normal";
-  const stored = localStorage.getItem(STORAGE_KEY);
-  if (stored === "technical" || stored === "normal") return stored;
-  return "normal";
-}
-
 export function VerificationModeProvider({ children }: { children: React.ReactNode }) {
-  const [mode, setMode] = useState<VerificationMode>(getInitialMode);
+  // Start "normal" on the server AND the first client render, then load the
+  // persisted preference in an effect. Reading localStorage during render (in a
+  // useState initializer) diverged the first client render from the server HTML
+  // whenever the user had toggled "technical", causing a React hydration
+  // mismatch. On a mismatch React discards the server DOM and regenerates the
+  // tree on the client, which breaks App Router client navigation app-wide —
+  // links render but router.push silently no-ops (the symptom #458 band-aided
+  // with native <a>). Same hydration-determinism fix #457 applied to the store
+  // and InviteCodeBanner; this provider (added in #450) was missed.
+  const [mode, setMode] = useState<VerificationMode>("normal");
+
+  useEffect(() => {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored === "technical" || stored === "normal") {
+      setMode(stored);
+    }
+  }, []);
 
   const toggle = useCallback(() => {
     setMode((prev) => {


### PR DESCRIPTION
## Summary

This is the **root cause** behind the broken navigation that #457/#458/#462 have been chasing/band-aiding: client-side `next/link` navigation silently fails app-wide (links render but `router.push` no-ops), so only full-page-load `<a>` works.

`VerificationModeProvider` — added in **#450** and wrapping the **entire app** in `layout.tsx` — read `localStorage` inside its `useState` initializer:

```ts
const [mode, setMode] = useState<VerificationMode>(getInitialMode); // reads localStorage
```

So when a user had toggled **technical** mode, the first client render (`technical`) diverged from the server HTML (`normal`). On a React hydration mismatch the server DOM is discarded and the tree is regenerated on the client, which breaks App Router client navigation everywhere.

This is the **exact** bug class #457 fixed for the store and `InviteCodeBanner` — it just missed this provider (also from #450). #458 then worked around the symptom by switching the sidebar to native `<a>`.

## Fix

Make the first render deterministic (matches the server), then load the persisted preference in an effect — the same pattern as #457:

```ts
const [mode, setMode] = useState<VerificationMode>("normal");
useEffect(() => {
  const stored = localStorage.getItem(STORAGE_KEY);
  if (stored === "technical" || stored === "normal") setMode(stored);
}, []);
```

Adds `verification-mode.test.tsx` pinning the contract: first render is `normal` even when localStorage says `technical`, the persisted value applies after mount, and toggle persists.

## Scope / verification note

- I swept every `localStorage`/`window`/`Date`/`random` read in the global render path (`layout` → `AppShell` and the providers it mounts). After this change, `VerificationModeProvider` was the **only** remaining render-time `localStorage` read; `ThemeProvider`, the store (#457), and `InviteCodeBanner` (#457) are already effect-based. `ProviderSlackPopup` also reads localStorage in its initializers but is masked-safe (its `!isProvider` gate makes the first render `null` on both server and client) — a latent instance of the same pattern worth hardening separately.
- **Could not run a browser repro here**, so I kept the native-`<a>` band-aids in place. Please verify on the preview deploy with `localStorage['darkbloom-verification-mode'] = 'technical'` that `next/link` navigation works (no hydration error in console).

## Follow-up (separate PR)

Once verified, the native-`<a>` workarounds can be reverted to restore SPA navigation: the sidebar (#458) and the provider tabs (#462 — keep its "hide tabs until installed" change, revert only the `<a>` swap), plus the 2 remaining `<Link>`s in `stats`/`earn` stay correct either way.

## Test plan

- [x] `npx vitest run` — 3/3 in the new suite.
- [x] `npx eslint` — clean.
- [x] `npm run build` — succeeds.
- [ ] Manual on preview: with technical mode set, no React hydration error on load; clicking `next/link` elements navigates.

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/463"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784918435&installation_id=133247490&pr_number=463&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F463&signature=bd2ef18ffa98cf0b4be7332aacdaccbe15222312dde2270ed4a7c2813123e386"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->