### PR TITLE
Add Third-Party Software Licenses disclaimer to Provider ToS

### DIFF
--- a/docs/legal/terms-of-service.md
+++ b/docs/legal/terms-of-service.md
@@ -78,6 +78,8 @@ If you install or operate Darkbloom provider software (a "provider"), you also a
 
 Provider participation does not create an employment, agency, partnership, franchise, fiduciary, or joint venture relationship between you and Eigen Labs.
 
+**Third-Party Software Licenses.** Your device and operating system may be subject to third-party software license agreements, including but not limited to ones from Apple and other applicable software licensors, that may restrict certain uses. You are solely responsible for ensuring your participation as a provider complies with all applicable third-party licenses. Eigen Labs makes no representation that provider participation is permitted under any such third-party licenses and is not responsible for third-party enforcement actions against you.
+
 ## 6. Fees, Credits, Deposits, and Payouts
 
 Some Services require payment. You authorize us and our payment service providers to charge the payment method, wallet, or blockchain account you choose for applicable fees, taxes, network fees, and other disclosed charges.

--- a/landing/terms.html
+++ b/landing/terms.html
@@ -251,6 +251,7 @@
       <li>you are enrolling a personally owned device and accept the risks associated with granting administrative control.</li>
     </ul>
     <p>Provider participation does not create an employment, agency, partnership, franchise, fiduciary, or joint venture relationship between you and Eigen Labs.</p>
+    <p><strong>Third-Party Software Licenses.</strong> Your device and operating system may be subject to third-party software license agreements, including but not limited to ones from Apple and other applicable software licensors, that may restrict certain uses. You are solely responsible for ensuring your participation as a provider complies with all applicable third-party licenses. Eigen Labs makes no representation that provider participation is permitted under any such third-party licenses and is not responsible for third-party enforcement actions against you.</p>
   </div>
 
   <div class="legal-section">


### PR DESCRIPTION
## What

Adds the **Third-Party Software Licenses** disclaimer to the Provider Responsibilities section of the Terms of Service, syncing the repo with the finalized [Darkbloom ToS (Google Doc 6.24.26)](https://docs.google.com/document/d/1d4J1qMg4uaXQwnmw4Hr8P6vfJ2IP4AdGO5GSUwkN0WM/edit).

Applied to both copies of the ToS:
- `docs/legal/terms-of-service.md`
- `landing/terms.html`

## New clause

> **Third-Party Software Licenses.** Your device and operating system may be subject to third-party software license agreements, including but not limited to ones from Apple and other applicable software licensors, that may restrict certain uses. You are solely responsible for ensuring your participation as a provider complies with all applicable third-party licenses. Eigen Labs makes no representation that provider participation is permitted under any such third-party licenses and is not responsible for third-party enforcement actions against you.

Inserted immediately after the "joint venture relationship between you and Eigen Labs" paragraph, matching the bold lead-in label convention used by sibling clauses (`Standalone Agreement.`, `Public Alpha Status.`).

## Source

This is the final, de-pointed wording from the Beatrice ⇄ Kydo negotiation thread ("We are good here now! I accepted all the changes"). Text verified verbatim against the current Google Doc.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/467"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784958278&installation_id=133247490&pr_number=467&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F467&signature=24c656bf8441cb7ffb02a6ddbd3d76dad3376cc919374948e6092e05e1daa252"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->