### PR TITLE
Add libs/mlx submodule (Layr-Labs/mlx @ darkbloom-base, MLX 0.32.0 + trim)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,7 @@
 [submodule "libs/mlx-swift-lm"]
 	path = libs/mlx-swift-lm
 	url = https://github.com/Layr-Labs/mlx-swift-lm.git
+[submodule "libs/mlx"]
+	path = libs/mlx
+	url = https://github.com/Layr-Labs/mlx.git
+	branch = darkbloom-base


### PR DESCRIPTION
## What
Adds the MLX C++ core fork as a top-level submodule **`libs/mlx`** → `Layr-Labs/mlx`, tracking the **`darkbloom-base`** branch (= ml-explore/mlx **0.32.0** + the "Bound Metal buffer COUNT" resource-count trim; this is the latest upstream, `ahead_by = 0`).

## Why
The MLX C++ core (where the resource-count trim and future M5 `_nax` work live) was only reachable as a nested submodule inside `libs/mlx-swift` (`Source/Cmlx/mlx`). Surfacing it at `libs/mlx` lets us develop/iterate on the core alongside `libs/mlx-swift` and `libs/mlx-swift-lm`. Same fork/commit as what `mlx-swift` vendors.

## Notes
- Tracks `darkbloom-base` (not `main`, which mirrors pure upstream). `git submodule update --remote libs/mlx` advances it.
- Two checkouts of the fork now exist (this one + `libs/mlx-swift/Source/Cmlx/mlx`); keep them on the same commit when bumping.
- Companion PRs that bring the engine to 0.32.0: `Layr-Labs/mlx#3` (merged), `Layr-Labs/mlx-c#2` (FFT), `Layr-Labs/mlx-swift#9` (packaging + regenerated JIT sources). Bumping `libs/mlx-swift`/`libs/mlx-swift-lm` here follows once #9 merges.

## Before / After
```mermaid
flowchart LR
  subgraph Before
    D1[d-inference] --> S1[libs/mlx-swift]
    D1 --> L1[libs/mlx-swift-lm]
    S1 --> M1[Source/Cmlx/mlx submodule -> Layr-Labs/mlx]
  end
  subgraph After
    D2[d-inference] --> S2[libs/mlx-swift]
    D2 --> L2[libs/mlx-swift-lm]
    D2 --> X2[libs/mlx -> Layr-Labs/mlx @ darkbloom-base]
    S2 --> M2[Source/Cmlx/mlx submodule -> Layr-Labs/mlx]
  end
```

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/469"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785024888&installation_id=133247490&pr_number=469&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F469&signature=451ac636a52af9ca873b011c1d869017fc25c9e589296b9232f876ddd649fbbc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->