### PR TITLE
ci: build mlx.metallib from source (drop PyPI wheel) + macos-latest runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
 
   test-provider:
     name: Provider Tests
-    runs-on: blacksmith-12vcpu-macos-26
+    runs-on: blacksmith-12vcpu-macos-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -105,7 +105,7 @@ jobs:
 
   cache-swift:
     name: Swift Build + Cache
-    runs-on: blacksmith-12vcpu-macos-26
+    runs-on: blacksmith-12vcpu-macos-latest
     if: github.event_name == 'push'
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   integration-tests:
     name: E2E Integration Tests
-    runs-on: blacksmith-12vcpu-macos-26
+    runs-on: blacksmith-12vcpu-macos-latest
     timeout-minutes: 30
     env:
       DARKBLOOM_REPO_ROOT: ${{ github.workspace }}
@@ -51,7 +51,7 @@ jobs:
 
   benchmark:
     name: E2E Benchmarks
-    runs-on: blacksmith-12vcpu-macos-26
+    runs-on: blacksmith-12vcpu-macos-latest
     timeout-minutes: 30
     if: github.event_name == 'pull_request'
     environment: benchmarks

--- a/.github/workflows/release-swift.yml
+++ b/.github/workflows/release-swift.yml
@@ -60,11 +60,15 @@ env:
   CLI_NAME: 'darkbloom'
   ENCLAVE_NAME: 'darkbloom-enclave'
   MIN_MACOS: '14.0'
-  # mlx-swift currently pins MLX 0.31.x. The .metallib must come from a wheel
-  # matching that ABI EXACTLY (patch-level skew can break Metal kernel
-  # loading at runtime). Source of truth: libs/mlx-swift/Source/Cmlx/mlx/mlx/version.h
-  # — bump both together.
-  MLX_PYTHON_PIN: 'mlx==0.31.1'
+  # The mlx.metallib (compiled Metal GPU kernels) is BUILT FROM SOURCE from the
+  # MLX fork pinned at libs/mlx-swift/Source/Cmlx/mlx — NOT fetched from a PyPI
+  # wheel. Building from source guarantees the GPU kernels match the exact fork
+  # commit the host C++ links against (incl. the resource-count trim and the M5
+  # _nax kernels) and removes the dependency on a published wheel (there is no
+  # mlx==0.32.0 on PyPI). The _nax kernels are only compiled when SDK >= 26.2
+  # AND deployment target >= 26.2 AND Metal >= 4.0 (see
+  # mlx/backend/metal/kernels/CMakeLists.txt), so we pin the deployment target.
+  MLX_METALLIB_DEPLOYMENT_TARGET: '26.2'
 
 jobs:
   resolve-env:
@@ -97,7 +101,7 @@ jobs:
   build-and-release:
     name: Build, sign, notarize, upload, register
     needs: [resolve-env]
-    runs-on: blacksmith-12vcpu-macos-26
+    runs-on: blacksmith-12vcpu-macos-latest
 
     env:
       VERSION: ${{ needs.resolve-env.outputs.version }}
@@ -207,32 +211,88 @@ jobs:
             spm-v1-${{ runner.os }}-
 
       # ----------------------------------------------------------------------
-      # Fetch the mlx.metallib for the matching MLX version.
+      # Build mlx.metallib (compiled Metal GPU kernels) FROM SOURCE.
       #
-      # mlx-swift's Cmlx target does not auto-build .metal kernels via SwiftPM
-      # (see swift-migration-plan.md Phase 0). We ship the .metallib from the
-      # MLX Python wheel that matches the MLX C++ version pinned in the fork.
+      # mlx-swift's Cmlx target does not compile .metal kernels via SwiftPM, so
+      # we build them here with cmake from the exact fork commit at
+      # libs/mlx-swift/Source/Cmlx/mlx (the same source the host C++ links
+      # against). This guarantees the kernels match — including the _nax kernels
+      # — and needs no published mlx wheel. The result is cached on the mlx
+      # commit + toolchain, so it only rebuilds when the submodule or Xcode
+      # changes (~1 min on a cold build, instant on a cache hit).
       # ----------------------------------------------------------------------
 
-      - name: Fetch matching mlx.metallib
+      - name: Resolve metallib cache key
+        id: mlxkey
+        run: |
+          set -euo pipefail
+          MLX_SRC="libs/mlx-swift/Source/Cmlx/mlx"
+          test -f "$MLX_SRC/mlx/version.h" || { echo "::error::mlx submodule not checked out at $MLX_SRC"; exit 1; }
+          MLX_SHA=$(git -C "$MLX_SRC" rev-parse HEAD)
+          SDK=$(xcrun --sdk macosx --show-sdk-version)
+          XCODE=$(xcodebuild -version | head -1 | tr -d ' ')
+          KEY="metallib-v1-${MLX_SHA}-${XCODE}-sdk${SDK}-dt${MLX_METALLIB_DEPLOYMENT_TARGET}-jitoff"
+          echo "mlx_src=$MLX_SRC" >> "$GITHUB_OUTPUT"
+          echo "mlx_sha=$MLX_SHA" >> "$GITHUB_OUTPUT"
+          echo "mlx_sha_short=${MLX_SHA:0:12}" >> "$GITHUB_OUTPUT"
+          echo "key=$KEY" >> "$GITHUB_OUTPUT"
+          echo "Metallib cache key: $KEY"
+
+      - name: Restore metallib cache
+        id: metallib-cache
+        uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
+        with:
+          path: ${{ runner.temp }}/metallib/mlx.metallib
+          key: ${{ steps.mlxkey.outputs.key }}
+
+      - name: Build mlx.metallib from source
+        if: steps.metallib-cache.outputs.cache-hit != 'true'
+        run: |
+          set -euo pipefail
+          command -v cmake >/dev/null 2>&1 || brew install cmake
+          SRC="${{ steps.mlxkey.outputs.mlx_src }}"
+          BUILD="$RUNNER_TEMP/metallib-build"
+          OUT="$RUNNER_TEMP/metallib"
+          rm -rf "$BUILD"; mkdir -p "$OUT"
+          # JIT=OFF compiles the full kernel set into the metallib. Deployment
+          # target >= 26.2 + SDK >= 26.2 + Metal >= 4.0 is what gates the _nax
+          # kernels (mlx/backend/metal/kernels/CMakeLists.txt).
+          cmake -S "$SRC" -B "$BUILD" \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_OSX_DEPLOYMENT_TARGET="$MLX_METALLIB_DEPLOYMENT_TARGET" \
+            -DMLX_METAL_JIT=OFF \
+            -DMLX_BUILD_TESTS=OFF -DMLX_BUILD_EXAMPLES=OFF \
+            -DMLX_BUILD_BENCHMARKS=OFF -DMLX_BUILD_PYTHON_BINDINGS=OFF
+          cmake --build "$BUILD" --target mlx-metallib -j"$(sysctl -n hw.ncpu)"
+          cp "$BUILD/mlx/backend/metal/kernels/mlx.metallib" "$OUT/mlx.metallib"
+          ls -lh "$OUT/mlx.metallib"
+
+      - name: Save metallib cache
+        if: steps.metallib-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
+        with:
+          path: ${{ runner.temp }}/metallib/mlx.metallib
+          key: ${{ steps.mlxkey.outputs.key }}
+
+      - name: Verify metallib completeness (nax + gemv)
         id: metallib
         run: |
           set -euo pipefail
-          python3 -m venv /tmp/mlxvenv
-          /tmp/mlxvenv/bin/pip install --quiet --no-cache-dir "$MLX_PYTHON_PIN"
-          # mlx 0.31+ became a namespace package, so `mlx.__file__` is None;
-          # find the metallib by walking site-packages instead.
-          METALLIB=$(/tmp/mlxvenv/bin/python - <<'PY'
-          import os, sys, glob
-          for sp in sys.path:
-              for cand in glob.glob(os.path.join(sp, "mlx", "lib", "mlx.metallib")):
-                  print(cand); raise SystemExit(0)
-          raise SystemExit("mlx.metallib not found in venv site-packages")
-          PY
-          )
-          test -s "$METALLIB" || { echo "metallib not found at $METALLIB"; exit 1; }
-          echo "metallib=$METALLIB" >> "$GITHUB_OUTPUT"
-          ls -lh "$METALLIB"
+          MLIB="$RUNNER_TEMP/metallib/mlx.metallib"
+          test -s "$MLIB" || { echo "::error::metallib missing at $MLIB"; exit 1; }
+          # Count with `grep -c` (not `grep -q`): grep -q closes the pipe on the
+          # first match, which makes `strings` on this 150 MB+ file exit via
+          # SIGPIPE and trip `set -o pipefail` — a false negative.
+          NAX=$(strings "$MLIB" | grep -c "_nax" || true)
+          GEMV=$(strings "$MLIB" | grep -c "gemv" || true)
+          # _nax kernels are required for the M5 Neural Accelerator path. Their
+          # absence means the build used the wrong SDK/deployment target (see the
+          # gate in kernels/CMakeLists.txt). gemv guards against an incomplete
+          # (JIT) build. Fail loudly rather than ship a broken bundle.
+          [ "$NAX" -gt 0 ] || { echo "::error::metallib has no _nax kernels (SDK/deployment target < 26.2?)"; exit 1; }
+          [ "$GEMV" -gt 0 ] || { echo "::error::metallib missing gemv kernels (incomplete build?)"; exit 1; }
+          echo "metallib=$MLIB" >> "$GITHUB_OUTPUT"
+          echo "Metallib OK: size=$(ls -lh "$MLIB" | awk '{print $5}') nax_refs=$NAX gemv_refs=$GEMV"
 
       # ----------------------------------------------------------------------
       # Build (tests run by CI, not the release workflow).
@@ -633,7 +693,7 @@ jobs:
 
           **Binary hash:**   \`${BINARY_HASH}\`
           **Bundle hash:**   \`${BUNDLE_HASH}\`
-          **Metallib hash:** \`${METALLIB_HASH}\` (\`${MLX_PYTHON_PIN}\`)
+          **Metallib hash:** \`${METALLIB_HASH}\` (built from mlx \`${{ steps.mlxkey.outputs.mlx_sha_short }}\`)
           **Signed by:**     \`${DEVELOPER_ID}\`
           **Notarized:**     yes
           **Min macOS:**     ${MIN_MACOS}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,7 +73,7 @@ scripts/              build, signing, install, and deploy helpers
 ├── admin.sh          admin CLI (Privy auth, release mgmt, API calls)
 ├── publish-model.sh  model registry publish workflow
 ├── deploy-acme.sh    nginx/step-ca helper
-├── fetch-metallib.sh MLX metallib fetcher
+├── fetch-metallib.sh MLX metallib builder (cmake from libs/mlx-swift source)
 └── entitlements.plist hardened runtime entitlements (hypervisor, network)
 
 docs/                 architecture, deploy runbooks, MDM/ACME notes, threat model

--- a/scripts/fetch-metallib.sh
+++ b/scripts/fetch-metallib.sh
@@ -1,65 +1,82 @@
 #!/bin/bash
-# fetch-metallib.sh -- pull the matching mlx.metallib for local Swift builds.
+# fetch-metallib.sh -- build the matching mlx.metallib for local Swift builds.
 #
-# mlx-swift's Cmlx target does NOT auto-compile its Metal kernels through
-# SwiftPM today. Until we land a SwiftPM build-tool plugin, the local dev
-# workflow is to copy the .metallib from a matching `mlx==0.31.x` Python
-# wheel.
+# NOTE: despite the name, this now BUILDS the .metallib from source rather than
+# fetching it from a PyPI wheel. Building from our own fork guarantees the GPU
+# kernels match the exact MLX commit the host C++ links against — including the
+# resource-count trim and the M5 `_nax` kernels — and needs no published wheel
+# (there is no mlx==0.32.0 on PyPI). This mirrors the release-swift.yml
+# "Build mlx.metallib from source" step.
 #
-# The release CI does the same trick automatically (release-swift.yml step
-# "Fetch matching mlx.metallib").
+# mlx-swift's Cmlx target does NOT compile its Metal kernels through SwiftPM, so
+# we compile them here with cmake from libs/mlx-swift/Source/Cmlx/mlx (the same
+# source SwiftPM compiles for the host side) and copy the result next to the
+# build output.
 #
 # Usage:
-#   ./scripts/fetch-metallib.sh                # places mlx.metallib next to the latest debug build
-#   ./scripts/fetch-metallib.sh release        # places it next to the release build
-#   ./scripts/fetch-metallib.sh /custom/path   # places it at /custom/path/mlx.metallib
+#   ./scripts/fetch-metallib.sh                # next to the latest debug build
+#   ./scripts/fetch-metallib.sh release        # next to the release build
+#   ./scripts/fetch-metallib.sh /custom/path   # at /custom/path/mlx.metallib
 set -euo pipefail
 
-# Must match MLX_PYTHON_PIN in .github/workflows/release-swift.yml and the
-# MLX C++ version pinned in libs/mlx-swift/Source/Cmlx/mlx/mlx/version.h —
-# patch-level skew can break Metal kernel loading at runtime.
-MLX_VERSION="${MLX_VERSION:-0.31.1}"
-SWIFT_PROVIDER_DIR="${SWIFT_PROVIDER_DIR:-$(cd "$(dirname "$0")/.." && pwd)/provider-swift}"
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SWIFT_PROVIDER_DIR="${SWIFT_PROVIDER_DIR:-$REPO_ROOT/provider-swift}"
+# Source of truth: the mlx submodule the Cmlx target actually compiles against.
+MLX_SRC="${MLX_SRC:-$REPO_ROOT/libs/mlx-swift/Source/Cmlx/mlx}"
+# The _nax kernels are only compiled when SDK >= 26.2 AND deployment target
+# >= 26.2 AND Metal >= 4.0 (mlx/backend/metal/kernels/CMakeLists.txt).
+DEPLOYMENT_TARGET="${MLX_METALLIB_DEPLOYMENT_TARGET:-26.2}"
 TARGET_ARG="${1:-debug}"
 
 case "$TARGET_ARG" in
-  debug)
-    DEST_DIR="$SWIFT_PROVIDER_DIR/.build/debug"
-    ;;
-  release)
-    DEST_DIR="$SWIFT_PROVIDER_DIR/.build/release"
-    ;;
-  /*)
-    DEST_DIR="$TARGET_ARG"
-    ;;
-  *)
-    DEST_DIR="$(pwd)/$TARGET_ARG"
-    ;;
+  debug)   DEST_DIR="$SWIFT_PROVIDER_DIR/.build/debug" ;;
+  release) DEST_DIR="$SWIFT_PROVIDER_DIR/.build/release" ;;
+  /*)      DEST_DIR="$TARGET_ARG" ;;
+  *)       DEST_DIR="$(pwd)/$TARGET_ARG" ;;
 esac
-
 mkdir -p "$DEST_DIR"
 
-VENV_DIR="${VENV_DIR:-/tmp/mlxvenv-${MLX_VERSION}}"
-if [ ! -x "$VENV_DIR/bin/python" ]; then
-    echo "→ Creating venv at $VENV_DIR"
-    python3 -m venv "$VENV_DIR"
+command -v cmake >/dev/null 2>&1 || { echo "✗ cmake not found (brew install cmake)"; exit 1; }
+test -f "$MLX_SRC/mlx/version.h" || {
+  echo "✗ mlx submodule missing at $MLX_SRC"
+  echo "  run: git submodule update --init --recursive"
+  exit 1
+}
+
+MLX_SHA="$(git -C "$MLX_SRC" rev-parse HEAD 2>/dev/null || echo nogit)"
+
+# Cache the built metallib by mlx commit + deployment target so repeat runs are
+# instant (the build is ~1 min). Override with METALLIB_CACHE_DIR.
+CACHE_DIR="${METALLIB_CACHE_DIR:-/tmp/mlx-metallib-cache}"
+CACHED="$CACHE_DIR/mlx-${MLX_SHA}-dt${DEPLOYMENT_TARGET}.metallib"
+
+if [ ! -s "$CACHED" ]; then
+    echo "→ Building mlx.metallib from $MLX_SRC @ ${MLX_SHA:0:12} (deployment target $DEPLOYMENT_TARGET)"
+    BUILD_DIR="$(mktemp -d)"
+    cmake -S "$MLX_SRC" -B "$BUILD_DIR" \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_OSX_DEPLOYMENT_TARGET="$DEPLOYMENT_TARGET" \
+        -DMLX_METAL_JIT=OFF \
+        -DMLX_BUILD_TESTS=OFF -DMLX_BUILD_EXAMPLES=OFF \
+        -DMLX_BUILD_BENCHMARKS=OFF -DMLX_BUILD_PYTHON_BINDINGS=OFF >/dev/null
+    cmake --build "$BUILD_DIR" --target mlx-metallib -j"$(sysctl -n hw.ncpu 2>/dev/null || echo 4)"
+    mkdir -p "$CACHE_DIR"
+    cp "$BUILD_DIR/mlx/backend/metal/kernels/mlx.metallib" "$CACHED"
+    rm -rf "$BUILD_DIR"
+else
+    echo "→ Using cached metallib for ${MLX_SHA:0:12}"
 fi
 
-echo "→ Installing mlx==$MLX_VERSION (silenced)"
-"$VENV_DIR/bin/pip" install --quiet --no-cache-dir "mlx==$MLX_VERSION"
+# Sanity: the _nax kernels must be present, otherwise the build silently used an
+# SDK/deployment target < 26.2 and we'd ship a nax-less metallib. Use `grep -c`
+# (not `grep -q`): grep -q closes the pipe on first match, which makes `strings`
+# on this 150 MB+ file exit via SIGPIPE and trips `set -o pipefail` — a false
+# negative.
+NAX_KERNELS="$(strings "$CACHED" | grep -c "_nax" || true)"
+if [ "$NAX_KERNELS" -eq 0 ]; then
+    echo "✗ built metallib has no _nax kernels — is your Xcode SDK / deployment target >= 26.2?"
+    exit 1
+fi
 
-# `mlx` 0.31+ ships as a namespace package (`mlx.__file__ is None`), so we
-# can't go through `os.path.dirname(mlx.__file__)`. Walk site-packages
-# instead -- works with both the legacy and namespace layouts.
-METALLIB="$("$VENV_DIR/bin/python" - <<'PY'
-import os, sys, glob
-for sp in sys.path:
-    for cand in glob.glob(os.path.join(sp, "mlx", "lib", "mlx.metallib")):
-        print(cand); raise SystemExit(0)
-raise SystemExit("mlx.metallib not found in venv site-packages")
-PY
-)"
-test -s "$METALLIB" || { echo "✗ metallib not found at $METALLIB"; exit 1; }
-
-cp "$METALLIB" "$DEST_DIR/mlx.metallib"
+cp "$CACHED" "$DEST_DIR/mlx.metallib"
 echo "✓ wrote $DEST_DIR/mlx.metallib  ($(shasum -a 256 "$DEST_DIR/mlx.metallib" | cut -d' ' -f1))"


### PR DESCRIPTION
## What

Build `mlx.metallib` (the compiled Metal GPU kernels) **from our own MLX fork source** instead of copying it from a PyPI `mlx` wheel — in both the release workflow and the local-dev script — and move the macOS runners to `-macos-latest`.

## Why

`mlx-swift`'s `Cmlx` target compiles the MLX **host C++** from our fork, but the **GPU kernels** (`mlx.metallib`) were fetched from the PyPI `mlx==0.31.1` wheel. The host C++ asks the metallib for kernels **by name**, so the two halves must come from the same MLX version. That coupling breaks for the 0.32.0 bump:

- **There is no `mlx==0.32.0` on PyPI** (latest is `0.31.2`) — `pip install mlx==0.32.0`, and the release step, would fail.
- A version-mismatched metallib can fail Metal kernel loading at runtime (`Unable to load kernel …`).

Building from `libs/mlx-swift/Source/Cmlx/mlx` (the exact source the host links against) guarantees the kernels match — including the resource-count trim and the M5 `_nax` kernels — and removes the published-wheel dependency entirely.

## Before / After

**Behavior** — what determines the shipped `mlx.metallib`:

```mermaid
flowchart LR
  subgraph Before
    A1[release tag] --> B1[pip install mlx==0.31.1]
    B1 --> C1[copy mlx.metallib out of wheel]
    C1 --> D1[sign + bundle + ship]
    B1 -. "mlx==0.32.0 not on PyPI" .-> X1[(fetch fails / version skew)]
  end
  subgraph After
    A2[release tag] --> B2[cmake build mlx-metallib from libs/mlx-swift source]
    B2 --> V2{nax + gemv present?}
    V2 -- yes --> D2[sign + bundle + ship]
    V2 -- no --> X2[(fail loudly)]
  end
```

**Code** — the workflow steps:

```mermaid
flowchart TB
  subgraph Before [release-swift.yml: Fetch matching mlx.metallib]
    F1[python venv] --> F2["pip install $MLX_PYTHON_PIN"] --> F3[glob site-packages for mlx.metallib] --> F4[steps.metallib.outputs.metallib]
  end
  subgraph After [release-swift.yml: build from source + cache]
    G1[Resolve cache key: mlx SHA + Xcode + SDK] --> G2[Restore metallib cache]
    G2 --> G3{cache hit?}
    G3 -- no --> G4["cmake -DMLX_METAL_JIT=OFF -DCMAKE_OSX_DEPLOYMENT_TARGET=26.2"] --> G5[Save cache]
    G3 -- yes --> G6
    G5 --> G6[Verify nax + gemv] --> G7[steps.metallib.outputs.metallib]
  end
```

## Notes

- **`_nax` gate:** `mlx/backend/metal/kernels/CMakeLists.txt` only compiles the `_nax` kernels when `SDK >= 26.2 AND deployment target >= 26.2 AND Metal >= 4.0`. The deployment target defaults to the host OS, so the build pins `-DCMAKE_OSX_DEPLOYMENT_TARGET=26.2` and the verify step fails loudly if `_nax` is missing (turns a silent capability loss into a hard failure).
- **Runners:** `blacksmith-12vcpu-macos-26` → `blacksmith-12vcpu-macos-latest` across release/ci/integration so the metallib is built, tested, and shipped on the same image (currently macOS 26, SDK 26.5 — satisfies the gate).
- **Cache:** keyed on the mlx commit + Xcode/SDK, so it only rebuilds when those change (~1 min cold, instant hit). Cross-tag cache hits on the release workflow are limited by GH cache scoping; the build is cheap enough that this is acceptable.
- **`grep -c` not `grep -q`:** under `set -o pipefail`, `grep -q` closes the pipe on first match → `strings` on the 150 MB+ metallib exits via SIGPIPE → false negative. The verify counts with `grep -c`.
- **Validated locally:** cold build ~57s → 157 MB metallib with 3798 `_nax` refs + `gemv`; `fetch-metallib.sh` cache hit is instant.

## Not in this PR

This wires up *how* the metallib is built; it does **not** bump the MLX version. The `libs/mlx-swift` submodule is still 0.31.1, so a release today builds a 0.31.1 metallib (which already contains `_nax`, so it passes the gate). Bumping to 0.32.0 (the `Layr-Labs/mlx-swift#9` work) is a separate submodule-pin change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/472"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785085000&installation_id=133247490&pr_number=472&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F472&signature=b6208cb36bde8dd5ed3f6cb88c032ee8db66164bda9b3c4285669760277f8f26"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->