### PR TITLE
Pipeline-parallel inference across an attested Apple Silicon cluster (+ Gemma 4)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "libs/mlx-swift"]
 	path = libs/mlx-swift
-	url = https://github.com/Layr-Labs/mlx-swift.git
+	url = https://github.com/crypt0fairy/mlx-swift.git
 [submodule "libs/mlx-swift-lm"]
 	path = libs/mlx-swift-lm
-	url = https://github.com/Layr-Labs/mlx-swift-lm.git
+	url = https://github.com/crypt0fairy/mlx-swift-lm.git

--- a/coordinator/api/provider.go
+++ b/coordinator/api/provider.go
@@ -29,6 +29,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"os"
 
 	"net/http"
 	"strings"
@@ -247,6 +248,34 @@ func (s *Server) providerReadLoop(ctx context.Context, conn *websocket.Conn, pro
 			provider = s.registry.Register(providerID, conn, regMsg)
 			s.attachProviderLocation(providerID, provider, r)
 			s.verifyProviderAttestation(providerID, provider, regMsg)
+			// If this is a cluster head, independently verify EVERY member's
+			// attestation and set the head's surfaced trust to min(member).
+			s.verifyClusterMembers(providerID, provider, regMsg)
+
+			// DEV ONLY: EIGENINFERENCE_DEV_FORCE_ROUTABLE=true forces every
+			// routability gate so a minimal/cluster provider is servable without
+			// the full attestation handshake (runtime manifest, APNs code
+			// attestation, challenge-verified SIP, privacy capabilities). This
+			// DISABLES the trust model — never set it in production.
+			if os.Getenv("EIGENINFERENCE_DEV_FORCE_ROUTABLE") == "true" {
+				provider.Mu().Lock()
+				provider.Status = registry.StatusOnline
+				provider.TrustLevel = registry.TrustHardware
+				provider.Backend = registry.BackendMLXSwift
+				provider.RuntimeVerified = true
+				provider.RuntimeManifestChecked = true
+				provider.EncryptedResponseChunks = true
+				provider.ChallengeVerifiedSIP = true
+				provider.PrivacyCapabilities = &protocol.PrivacyCapabilities{
+					TextBackendInprocess: true, TextProxyDisabled: true,
+					AntiDebugEnabled: true, CoreDumpsDisabled: true, EnvScrubbed: true,
+					SIPEnabled: true,
+				}
+				provider.Mu().Unlock()
+				provider.SetCodeAttested(true)
+				provider.SetLastChallengeVerified(time.Now())
+				s.logger.Warn("DEV FORCE ROUTABLE — provider trust gates bypassed", "provider_id", providerID)
+			}
 
 			// Record registration outcome metrics + telemetry.
 			if s.metrics != nil {
@@ -1578,6 +1607,11 @@ func (s *Server) handleChunk(providerID string, provider *registry.Provider, msg
 		})
 		return
 	}
+	// DEBUG: chunk content length to diagnose empty-content delivery.
+	if os.Getenv("EIGENINFERENCE_DEBUG_CHUNKS") == "1" {
+		s.logger.Info("DEBUG chunk decrypted", "request_id", msg.RequestID,
+			"len", len(chunkData), "preview", func() string { if len(chunkData) > 20 { return chunkData[:20] }; return chunkData }())
+	}
 	// Non-blocking send — if consumer is gone the chunk is dropped.
 	select {
 	case pr.ChunkCh <- chunkData:
@@ -2345,6 +2379,58 @@ func (s *Server) verifyProviderAttestation(providerID string, provider *registry
 	}
 }
 
+// verifyClusterMembers independently verifies the Secure Enclave attestation of
+// EVERY member of a pipeline-parallel cluster (relayed by the head in the
+// register message) and records them on the head provider. The head's surfaced
+// trust becomes min(member trust): a member whose blob fails verification is
+// `none`, which taints the whole cluster. This closes the gap where a cluster's
+// non-head nodes — which see plaintext activations — were invisible to the
+// coordinator's trust model.
+func (s *Server) verifyClusterMembers(providerID string, provider *registry.Provider, regMsg *protocol.RegisterMessage) {
+	if regMsg.Cluster == nil || len(regMsg.Cluster.Members) == 0 {
+		return
+	}
+	members := make([]registry.ClusterMemberAttestation, 0, len(regMsg.Cluster.Members))
+	for _, m := range regMsg.Cluster.Members {
+		entry := registry.ClusterMemberAttestation{NodeID: m.NodeID, Rank: m.Rank}
+		result, err := attestation.VerifyJSON(m.Attestation)
+		if err != nil || !result.Valid {
+			entry.Verified = false
+			entry.TrustLevel = registry.TrustNone
+			reason := result.Error
+			if err != nil {
+				reason = err.Error()
+			}
+			s.logger.Warn("cluster member attestation FAILED",
+				"provider_id", providerID, "cluster_id", regMsg.Cluster.ClusterID,
+				"node_id", m.NodeID, "error", reason)
+		} else {
+			// A verified SE-signed blob earns self_signed (hardware needs MDM/MDA,
+			// which relayed members don't carry).
+			entry.Verified = true
+			entry.TrustLevel = registry.TrustSelfSigned
+			entry.SEPublicKey = result.PublicKey
+			entry.ChipName = result.ChipName
+			entry.HardwareModel = result.HardwareModel
+			entry.SerialNumber = result.SerialNumber
+			entry.SIPEnabled = result.SIPEnabled
+			entry.SecureBoot = result.SecureBootEnabled
+		}
+		members = append(members, entry)
+	}
+	provider.SetClusterMembers(regMsg.Cluster.ClusterID, members)
+	verifiedCount := 0
+	for _, m := range members {
+		if m.Verified {
+			verifiedCount++
+		}
+	}
+	s.logger.Info("cluster members verified",
+		"provider_id", providerID, "cluster_id", regMsg.Cluster.ClusterID,
+		"members", len(members), "verified", verifiedCount,
+		"surfaced_trust", string(provider.GetTrustLevel()))
+}
+
 // mdmVerifyOutcome classifies the result of one MDM verification attempt so the
 // per-connection mdmVerificationLoop can decide whether to retry.
 type mdmVerifyOutcome int
@@ -2788,6 +2874,18 @@ func (s *Server) verifyAppleDeviceAttestation(ctx context.Context, providerID st
 // Users can independently verify the Apple MDA certificate chain against
 // Apple's public Enterprise Attestation Root CA.
 func (s *Server) handleProviderAttestation(w http.ResponseWriter, r *http.Request) {
+	type clusterMemberAttest struct {
+		NodeID        string `json:"node_id"`
+		Rank          int    `json:"rank"`
+		TrustLevel    string `json:"trust_level"`
+		Verified      bool   `json:"verified"`
+		SEPublicKey   string `json:"se_public_key,omitempty"`
+		ChipName      string `json:"chip_name,omitempty"`
+		HardwareModel string `json:"hardware_model,omitempty"`
+		SerialNumber  string `json:"serial_number,omitempty"`
+		SIPEnabled    bool   `json:"sip_enabled"`
+		SecureBoot    bool   `json:"secure_boot_enabled"`
+	}
 	type providerAttestation struct {
 		ProviderID    string `json:"provider_id"`
 		ChipName      string `json:"chip_name"`
@@ -2822,6 +2920,13 @@ func (s *Server) handleProviderAttestation(w http.ResponseWriter, r *http.Reques
 		MDAUDID       string   `json:"mda_udid,omitempty"`
 		MDAOSVersion  string   `json:"mda_os_version,omitempty"`
 		MDASepVersion string   `json:"mda_sepos_version,omitempty"`
+
+		// Cluster, when present, lists EVERY node of a pipeline-parallel cluster
+		// behind this provider. A consumer must see all machines that touch
+		// their activations, not just the head. Surfaced trust_level above is
+		// already the min across these members.
+		ClusterID      string                `json:"cluster_id,omitempty"`
+		ClusterMembers []clusterMemberAttest `json:"cluster_members,omitempty"`
 	}
 
 	var providers []providerAttestation
@@ -2897,6 +3002,20 @@ func (s *Server) handleProviderAttestation(w http.ResponseWriter, r *http.Reques
 				pa.MDAUDID = mdaResult.DeviceUDID
 				pa.MDAOSVersion = mdaResult.OSVersion
 				pa.MDASepVersion = mdaResult.SepOSVersion
+			}
+		}
+
+		// Cluster roster: surface every verified member so the consumer sees the
+		// full set of machines that handle their activations.
+		if cid, cmembers := p.ClusterMembersSnapshot(); len(cmembers) > 0 {
+			pa.ClusterID = cid
+			for _, m := range cmembers {
+				pa.ClusterMembers = append(pa.ClusterMembers, clusterMemberAttest{
+					NodeID: m.NodeID, Rank: m.Rank, TrustLevel: string(m.TrustLevel),
+					Verified: m.Verified, SEPublicKey: m.SEPublicKey, ChipName: m.ChipName,
+					HardwareModel: m.HardwareModel, SerialNumber: m.SerialNumber,
+					SIPEnabled: m.SIPEnabled, SecureBoot: m.SecureBoot,
+				})
 			}
 		}
 

--- a/coordinator/cmd/coordinator/main.go
+++ b/coordinator/cmd/coordinator/main.go
@@ -312,7 +312,53 @@ func main() {
 	billingCfg := cfg.BillingConfig
 	ledger := payments.NewLedger(st)
 	billingSvc := billing.NewService(st, ledger, logger, billingCfg)
-	srv.SetBilling(billingSvc)
+	// DEV ONLY: EIGENINFERENCE_BILLING_DISABLE=true leaves the billing service
+	// unset, so the consumer balance reservation (gated on s.billing != nil) is
+	// skipped entirely — lets a dev/demo coordinator serve without funding an
+	// account. Never set this in production.
+	if os.Getenv("EIGENINFERENCE_BILLING_DISABLE") == "true" {
+		logger.Warn("BILLING DISABLED (dev) — no balance checks; do not use in production")
+	} else {
+		srv.SetBilling(billingSvc)
+	}
+
+	// DEV ONLY: seed the model catalog with one model id so a locally-served
+	// model is routable WITHOUT the R2 manifest/publish pipeline. Comma-separate
+	// ids in EIGENINFERENCE_DEV_SEED_MODELS. Registers an entry + a fake
+	// promoted version (the consumer catalog requires an active version). Never
+	// set in production.
+	if seed := os.Getenv("EIGENINFERENCE_DEV_SEED_MODELS"); seed != "" {
+		for _, id := range strings.Split(seed, ",") {
+			id = strings.TrimSpace(id)
+			if id == "" {
+				continue
+			}
+			entry := &store.ModelRegistryEntry{
+				ID: id, DisplayName: id, Family: "dev", Architecture: "dev",
+				Quantization: "dev", MaxContextLength: 131072, MaxOutputLength: 32768,
+				MinRAMGB: 1, Status: "active", Description: "dev-seeded local model",
+			}
+			ver := &store.ModelVersion{
+				ModelID: id, Version: "dev", R2Prefix: "dev/" + id,
+				AggregateSHA256: "0000000000000000000000000000000000000000000000000000000000000000",
+				TotalSizeBytes: 0, FileCount: 0, Status: "ready", // must be "ready" to be catalog-active
+			}
+			if err := st.SetModelVersion(entry, ver, nil); err != nil {
+				logger.Error("dev seed: SetModelVersion failed", "model", id, "error", err)
+				continue
+			}
+			if err := st.PromoteModelVersion(id, "dev"); err != nil {
+				logger.Error("dev seed: PromoteModelVersion failed", "model", id, "error", err)
+				continue
+			}
+			logger.Warn("DEV SEED: registered local model in catalog", "model", id)
+		}
+		// Re-sync the registry's catalog map AFTER seeding (the startup
+		// SyncModelCatalog ran on an empty store), so providers advertising the
+		// seeded model are allowed by modelAllowedByCatalogLocked → routable.
+		srv.SyncModelCatalog()
+		logger.Warn("DEV SEED: re-synced registry model catalog")
+	}
 
 	// Derive the coordinator's long-lived X25519 key.
 	if coordKey, err := e2e.DeriveCoordinatorKey(billingCfg.EncryptionMnemonic); err == nil {

--- a/coordinator/protocol/messages.go
+++ b/coordinator/protocol/messages.go
@@ -164,6 +164,28 @@ type RegisterMessage struct {
 	RuntimeHash         string               `json:"runtime_hash,omitempty"`    // SHA-256 of inference runtime (vllm-mlx)
 	TemplateHashes      map[string]string    `json:"template_hashes,omitempty"` // template_name -> SHA-256 hash
 	PrivacyCapabilities *PrivacyCapabilities `json:"privacy_capabilities,omitempty"`
+
+	// Cluster, when present, declares that this provider is the HEAD of a
+	// pipeline-parallel cluster. The head relays every member's signed Secure
+	// Enclave attestation so the coordinator can independently verify EACH node
+	// that will touch activations — not just the head. The coordinator sets the
+	// provider's surfaced trust to min(member trust) and exposes the full roster
+	// at /v1/providers/attestation. Without this, a cluster's non-head nodes are
+	// invisible to the trust model. See docs/architecture/cluster-node-handshake.md.
+	Cluster *ClusterRegistration `json:"cluster,omitempty"`
+}
+
+// ClusterRegistration is the head's declaration of its cluster's members.
+type ClusterRegistration struct {
+	ClusterID string                  `json:"cluster_id"`
+	Members   []ClusterMemberRegister `json:"members"`
+}
+
+// ClusterMemberRegister is one cluster node's attestation, relayed by the head.
+type ClusterMemberRegister struct {
+	NodeID      string          `json:"node_id"`
+	Rank        int             `json:"rank"`
+	Attestation json.RawMessage `json:"attestation"` // signed SE attestation blob (same shape as RegisterMessage.Attestation)
 }
 
 // PrivacyCapabilities describes the provider's privacy invariants at registration time.

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -59,6 +59,22 @@ const (
 
 const BackendMLXSwift = "mlx-swift"
 
+// ClusterMemberAttestation is one verified node of a pipeline-parallel cluster,
+// recorded on the head provider's record. Trust is per-member; the cluster's
+// surfaced trust is the minimum across all members.
+type ClusterMemberAttestation struct {
+	NodeID        string
+	Rank          int
+	TrustLevel    TrustLevel
+	SEPublicKey   string // base64 raw P-256 SE signing key from the attestation blob
+	ChipName      string
+	HardwareModel string
+	SerialNumber  string
+	SIPEnabled    bool
+	SecureBoot    bool
+	Verified      bool // true if the SE signature on the member's blob verified
+}
+
 // MaxFailedChallenges is the number of consecutive challenge failures before
 // a provider is marked untrusted and fully derouted.
 const MaxFailedChallenges = 3
@@ -247,7 +263,14 @@ type Provider struct {
 	PublicKey         string // base64-encoded X25519 public key for E2E encryption
 	Attested          bool   // true if attestation was verified successfully
 	AttestationResult *attestation.VerificationResult
-	TrustLevel        TrustLevel             // attestation trust level
+	TrustLevel        TrustLevel             // attestation trust level (for a cluster head: min across members)
+	// ClusterMembers, when non-empty, means this provider is the HEAD of a
+	// pipeline-parallel cluster: each entry is a member node whose Secure Enclave
+	// attestation the coordinator independently verified. Surfaced trust is the
+	// minimum across members; the full roster is exposed at
+	// /v1/providers/attestation so consumers see every machine in the path.
+	ClusterID      string
+	ClusterMembers []ClusterMemberAttestation
 	MDAVerified       bool                   // true if Apple Device Attestation cert chain verified
 	MDACertChain      [][]byte               // DER-encoded Apple MDA certificate chain (leaf first)
 	MDAResult         *attestation.MDAResult // parsed OIDs from Apple cert
@@ -438,6 +461,44 @@ func (p *Provider) SetAttested(attested bool, trust TrustLevel) {
 	p.Attested = attested
 	p.TrustLevel = trust
 	p.mu.Unlock()
+}
+
+// SetClusterMembers records the verified members of a pipeline-parallel cluster
+// on the head provider and sets the head's surfaced TrustLevel to the MINIMUM
+// trust across all members (one untrusted member taints the cluster). An empty
+// members slice clears cluster status.
+func (p *Provider) SetClusterMembers(clusterID string, members []ClusterMemberAttestation) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.ClusterID = clusterID
+	p.ClusterMembers = members
+	if len(members) == 0 {
+		return
+	}
+	minTrust := TrustHardware
+	for _, m := range members {
+		if !m.Verified || trustRank(m.TrustLevel) < trustRank(minTrust) {
+			if !m.Verified {
+				minTrust = TrustNone
+			} else {
+				minTrust = m.TrustLevel
+			}
+		}
+	}
+	p.TrustLevel = minTrust
+	p.Attested = minTrust != TrustNone
+}
+
+// ClusterMembersSnapshot returns a copy of this provider's cluster members.
+func (p *Provider) ClusterMembersSnapshot() (string, []ClusterMemberAttestation) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if len(p.ClusterMembers) == 0 {
+		return "", nil
+	}
+	out := make([]ClusterMemberAttestation, len(p.ClusterMembers))
+	copy(out, p.ClusterMembers)
+	return p.ClusterID, out
 }
 
 // GrantHardwareIfNotUntrusted atomically promotes the provider to hardware trust

--- a/docs/architecture/cluster-continuous-batching-plan.md
+++ b/docs/architecture/cluster-continuous-batching-plan.md
@@ -1,0 +1,185 @@
+# Implementation Plan — Continuous Batching on the Pipeline-Parallel Cluster
+
+**Goal:** serve B concurrent decode requests as batched `[B, hidden]` forward
+passes across the ring (each node owns a layer slice), with mid-flight
+admission/eviction of requests at different sequence positions — so aggregate
+throughput scales toward ~B× and the cluster becomes competitive with a single
+large machine.
+
+**Why this is the path** (measured, see
+[cluster-benchmark.md](../cluster-benchmark.md)): at batch=1, pipeline
+parallelism runs the two GPUs sequentially — clustering is *slower* than a single
+machine for a model that fits. Decode is memory-bandwidth-bound: the head streams
+its layer weights once per step regardless of B, so batching B requests yields
+~B× aggregate throughput with the same per-step weight traffic. This is the only
+lever that makes pipeline clustering win on throughput. (Tensor parallelism is
+the latency lever, but `comms-bench` measured an 83 ms/token / ~12 tok/s floor on
+the CPU-stream collectives — TP also needs batching to be viable.)
+
+## Ground truth (read from the code)
+
+- **The fork already has all batched machinery.** `BatchKVCache` /
+  `BatchRotatingKVCache` / `BatchedCache` (`libs/mlx-swift-lm/Libraries/MLXLMCommon/BatchKVCache.swift`)
+  with `filterBatched`, `extendBatched`, `prepareBatched`, `finalizeBatched`,
+  `extractBatched`, per-row `batchOffset`/`leftPadding`, and `makeMask`.
+  `BatchGenerator.swift` is the single-node reference scheduler (queue/admit/filter).
+- **Layer modules are already batch-generic.** `LlamaAttention.callAsFunction`
+  reads `B = x.dim(0)`; RoPE dispatches per-row when the cache is
+  `BatchPositionedKVCache` (`RoPEApplication.swift:38-42`). The sharded
+  `runOwnedLayers` calls these same modules — no B=1 assumption in the math.
+- **One fork correctness gap:** `LlamaPipelineShard.runOwnedLayers` builds the
+  mask with `createAttentionMask(h:cache:)` (plain causal, ignores leftPadding).
+  Must use `makeAttentionMask(n:cache:)` → `cache.makeMask` so `BatchKVCache`
+  supplies the per-row left-padding mask. **GPT-OSS already does this** — no
+  change to `GPTOSSPipelineShard`.
+- **Crypto:** one seal/open per ring hop per step holds for any B (the
+  `[B,width,hidden]` tensor is one blob). The per-step `seq` counter must stay
+  independent of B — B must NOT enter the AAD or nonce.
+- **sealedLen** becomes `14 + B*width*hiddenSize*2 + 28`.
+
+## Phasing (each ends at a compiling, testable checkpoint)
+
+Build a **new `ClusterBatchPipeline` alongside `ClusterPipeline`**, not a mutation
+— the B=1 loop is the verified regression oracle and stays the default until
+Phase 3 validates.
+
+### Phase 1 — Static equal-length batching
+B prompts of identical length, all admitted at step 0, all run to maxTokens, no
+mid-flight churn. Exercises the entire batched data plane (shapes, sealedLen,
+transport payload, per-row sampling, `[B]` allGather) while avoiding ragged masks
+and the composition control protocol. **Validates the ~B× throughput thesis.**
+- Widen `PipelineModelShard` to a batch dim.
+- Adapters: `embed` builds `[B, maxLen]`; `caches()` allocates
+  `BatchKVCache(leftPadding: [0…])`.
+- New `ClusterBatchPipeline.generate(batch:)`; `sealedLen` gains B; tail samples
+  `[B,vocab]→argMax→[B]`; allGather broadcasts `[B]`.
+- **Test:** worldSize=1, B identical prompts → each row matches the B=1
+  `ClusterPipeline` stream token-for-token (greedy). Then 2-Mac aggregate tok/s
+  vs B=1.
+
+### Phase 2 — Ragged positions
+B requests of different prompt lengths admitted together (B still fixed).
+`leftPadding[b] = maxPromptLen - promptLen[b]`, per-row `batchOffset`, per-row mask.
+- Adapters build the left-padded matrix; allocate caches with real leftPadding.
+- **Fork fix:** `LlamaPipelineShard.runOwnedLayers` mask → `makeAttentionMask`.
+- **Test:** worldSize=1, B different-length prompts → each row matches its B=1
+  stream. Isolates mask/RoPE/offset correctness.
+
+### Phase 3 — Continuous admission/eviction
+Head-side scheduler (mirror `BatchGenerator`) + per-step batch-composition control
+round so all ranks apply identical filter/extend.
+- New `ClusterBatchScheduler` drives the ring primitives instead of
+  `model.callAsFunction`.
+- Per-step composition control round (below).
+- `cluster-provider` intake feeds a shared queue the scheduler drains.
+- **Test:** 2-Mac, staggered arrivals + varied lengths; each request completes
+  with the same greedy output it would get alone; sustained aggregate tok/s → B×.
+
+## Batch-composition control protocol (riskiest part)
+
+**Invariant:** every rank calls the same collectives in the same order every step.
+The control round moves *inside* the per-step loop: **one composition all_gather +
+one token all_gather per step.**
+
+Wire format — a single fixed-width int32 vector, all_gathered from the head
+(rank 0's slot is the first `CTRL_WIDTH` entries; peers contribute zeros and read
+the head's slot, exactly as `headRankSlot` does today):
+
+```
+[0] schema/version tag
+[1] command: 0=step, 1=shutdown, 2=idle-keepalive
+[2] B_next    — active batch size after this step's admit/evict
+[3] nEvict
+[4] nAdmit
+[5] prefillWidth — width admitted rows are prefilled at (0 if none)
+[6 ..< 6+B_prev]  keepIndices into PREVIOUS batch (ascending)
+[..]              per-admitted-row metadata: {promptLen, leftPadding, maxTokens,
+                  eos ids…, prompt ids…}, packed back-to-back
+```
+
+Fixed width sized to an admit cap (reuse `CONTROL_MAX_PROMPT=8192` budget). If an
+admit payload would exceed the cap, the scheduler admits fewer rows (back-pressure).
+
+**The head computes the entire next composition before the step and broadcasts
+it; peers replay it** (same trust model as today's `exchangeRequest`, extended to
+per-step). Each rank, identically, every step:
+1. all_gather composition vector.
+2. shutdown→return; idle-keepalive→loop (keeps the collective alive when the
+   queue is dry, mirroring the current idle round).
+3. **Evict:** `cache.filterBatched(batchIndices: keepIndices)` on every owned-layer
+   cache.
+4. **Admit:** if nAdmit>0, build a fresh `BatchKVCache(leftPadding:)`, prefill the
+   admitted rows (ring carries `[nAdmit, prefillWidth, hidden]`), then
+   `existing.extendBatched(admitted)`.
+5. **Decode:** one `[B_next,1,hidden]` forward; tail samples `[B_next]`; token
+   all_gather broadcasts `[B_next]`.
+
+Two collectives per step, fixed order on every rank.
+
+## KV cache lifecycle across the ring
+
+Each rank holds `[any BatchedCache]` — one batched cache per *owned* layer; axis 0
+is the batch dim. **Row order must be identical on every rank.** The composition
+vector imposes the canonical order: `[surviving rows ascending] ++ [admitted rows
+in admit order]`. Because `filter`/`extend` are pure functions of
+`(keepIndices, admittedLeftPadding, admittedPrompts)` — all delivered identically
+by the composition all_gather — every rank's cache stays in lockstep with no extra
+synchronization. The head never ships KV; each rank keeps its own layers' KV local.
+
+## Per-file change list
+
+**Fork (one change):** `LlamaPipelineShard.runOwnedLayers` mask →
+`makeAttentionMask(n:cache:)`. GPT-OSS unchanged.
+
+**ProviderCore:**
+- `PipelineModelShard.swift` — widen `embed` to `(batchTokens:[[Int]], leftPadding:[Int])`
+  with a B=1 default-impl shim; add cache filter/extend hooks.
+- `LlamaShardAdapter.swift` — `embed` builds `[B,maxLen]`; `caches()` allocates
+  `BatchKVCache` per layer; add filter/extend fan-out.
+- `GPTOSSShardAdapter.swift` — same + per-layer dispatch (full→`BatchKVCache`,
+  sliding→`BatchRotatingKVCache`), driven by the fork shard's `ownedLayerTypes`.
+- `ClusterPipeline.swift` — leave as-is (B=1 oracle).
+- `ClusterBatchPipeline.swift` (NEW) — batched ring loop; `sealedLen(B:width:)`;
+  `[B,width,hidden]` activation; `[B]` token broadcast; exposes step primitives
+  (`prefillStep`, `decodeStep`) so admit/evict can interleave.
+- `ClusterServer.swift` — add `ClusterBatchComposition` + `exchangeComposition`
+  + `runBatchedPeerLoop`.
+- `ClusterBatchScheduler.swift` (NEW) — head-side mirror of `BatchGenerator`
+  driving ring primitives.
+- `cluster-provider/main.swift` — intake feeds shared queue; control thread runs
+  the scheduler loop; per-row token routing keyed by uid→senderKey; per-row
+  `inferenceComplete`. Config flag `[cluster].batched` (default off).
+
+**Tests:** `batch-shard-smoke` (single-node B-prompt equality oracle);
+`ClusterBatchCompositionTests` (vector round-trip); worldSize=1 batched-vs-serial
+equality.
+
+## Risks / unknowns
+
+- **Dynamic-B sealedLen:** derive on every rank purely from the composition
+  vector's B/width, never local state, or `recvLike` template mismatches wedge the
+  ring.
+- **Nonce sequence when B changes:** keep `seq` = per-step counter, B out of AAD.
+  Run admission-prefill on its own `requestId` namespace + fresh channels so the
+  steady-state decode counter stays one-per-step.
+- **GPU watchdog with bigger buffers:** keep `evalEvery` low; bound
+  `prefillBatchSize`; consider chunked prefill via `prepareBatched`. Validate on
+  the 24 GB node.
+- **24 GB tail KV budget:** compute a concrete `maxB` from model config
+  (kvHeads, headDim, owned layers) × per-node budget; scheduler respects it
+  (admission back-pressure). GPT-OSS sliding-window caps KV per sliding layer —
+  helps.
+- **Control-round latency:** ~1 ms/all_gather extra per step (~2% at 50 ms/step,
+  amortized across B). Keep `CTRL_WIDTH` tight — only ship prompts on admit steps.
+- **Large-B ring payload:** B× the `[1,width,hidden]` frame may stress the
+  transport (a 64 KB all_gather tripped it during bringup). Validate frame sizes
+  at target B early.
+- **`extend` cost mid-stream:** batch admissions (admit several at once) to
+  amortize the concat/realloc, as `BatchGenerator` does.
+
+## Validation summary
+
+All single-node tests run via the worldSize=1 ring (head==tail) or the no-ring
+`shard-smoke` forward; only transport timing needs 2 Macs. Per-phase greedy
+token-for-token equality against the B=1 path is the correctness oracle
+throughout.

--- a/docs/architecture/cluster-node-handshake.md
+++ b/docs/architecture/cluster-node-handshake.md
@@ -1,0 +1,180 @@
+# Cluster Node-to-Node Handshake — Design Proposal
+
+> **Status: PROPOSAL / not implemented.** Companion to
+> [`clustering.md`](clustering.md). It specifies how two cluster member Macs
+> mutually authenticate and establish an encrypted channel for the inter-node
+> activation link, **reusing Darkbloom's existing crypto and attestation
+> primitives** rather than inventing new ones. This is the detailed design behind
+> Spike B in the [spike plan](../developer/clustering-spike-plan.md).
+
+## 1. Why a handshake is needed at all
+
+In pipeline parallelism the boundary data crossing between Macs is the
+hidden-state **activation tensor** (KV cache stays local — see `clustering.md` §2).
+Activations are approximately invertible to prompt text, so they are as sensitive
+as the prompt. The cluster operator owns *every* Mac and the Thunderbolt cable
+between them. Darkbloom's existing per-node defenses (Hardened Runtime,
+`PT_DENY_ATTACH`, SIP/Secure Boot, key-in-process-memory) already stop the
+operator from reading a *single* node's memory. They do **not** cover a **physical
+tap on the inter-node bus** — which is strictly easier than the de-soldering
+attack Darkbloom already declares its residual threat. So the link must be
+**encrypted between two mutually-attested hardened processes**, with key material
+that never leaves either process.
+
+## 2. Grounding: primitives that already exist (verified)
+
+The handshake composes existing, audited code — nothing cryptographically new:
+
+| Primitive | File | Role in handshake |
+|-----------|------|-------------------|
+| **SE P-256 signing**, private key never leaves Enclave, fresh per process | `Security/SecureEnclaveIdentity.swift` (`sign`, static `verify(signature:for:publicKey:)`) | Proves a peer controls an attested hardware identity. |
+| **X25519 + ChaCha20-Poly1305 sealed messages** with explicit `senderPublicKey`, HKDF-SHA256 key derivation, and **AAD support** | `Crypto/X25519ChaChaPoly.swift` | Session key agreement + framing. AAD binds the transcript. |
+| **NaCl box** (X25519/XSalsa20-Poly1305), ephemeral keypair gen | `Crypto/NodeKeyPair.swift` (`generate`, `encrypt`/`decrypt`) | Ephemeral DH keys for forward secrecy; data-plane sealing. |
+| **Signed attestation blob** binding an X25519 key to the SE identity, deterministic sorted-key JSON reproduced in Go | `Security/AttestationBuilder.swift`; `coordinator/attestation/attestation.go` | The exact "this encryption key belongs to this attested identity" pattern we reuse pairwise. |
+| **The binding is already enforced** coordinator-side: `result.EncryptionPublicKey == regMsg.PublicKey` | `coordinator/api/provider.go:2207-2229` | Precedent: SE-signed attestation vouches for an X25519 key. |
+
+**The single most important precedent:** Darkbloom *already* proves "this ephemeral
+X25519 key is controlled by this attested Secure-Enclave identity" — the SE signs an
+attestation blob whose `encryptionPublicKey` field is the X25519 key, and the
+coordinator rejects a mismatch. The node-to-node handshake is **the same trick
+applied pairwise** instead of node↔coordinator.
+
+## 3. The finding that unblocks the transport: RDMA is already trust-compatible
+
+A naïve reading says clustering needs Thunderbolt/RDMA, but the attestation blob
+reports `rdmaDisabled` and the 5-minute challenge re-checks it — implying
+RDMA-enabled would fail trust. **It does not.** The coordinator's challenge handler
+(`coordinator/api/provider.go:1155-1171`) explicitly accepts RDMA-enabled nodes:
+
+> *"Reporting remains mandatory so routing and trust policy can distinguish
+> single-node providers from RDMA-aware cluster runtimes. RDMA enablement is not
+> itself a challenge failure: Apple Silicon Thunderbolt RDMA is IOMMU-scoped to
+> registered buffers, so the security boundary is the signed runtime's
+> buffer-registration discipline, not a hypervisor flag."*
+
+So the trust policy was **already designed with RDMA-aware cluster runtimes in
+mind.** The handshake's job is the layer above that the comment defers to: the
+"signed runtime's buffer-registration discipline" — i.e. *encrypt the activation
+before it enters a registered RDMA buffer, decrypt after DMA on the peer.*
+
+## 4. Trust topology: coordinator-anchored roster + peer-to-peer session
+
+Full MDA certificate-chain verification (Apple Enterprise Root CA + MicroMDM
+cross-check) is heavy and centralized; replicating it on every Mac would weaken
+and bloat the model. So the trust anchor stays the coordinator, and only the cheap
+per-session step is peer-to-peer:
+
+1. **Each member attests to the coordinator** (members register, or the head relays
+   each member's `SignedAttestation`). The coordinator runs its existing full
+   `Verify` + MDA chain + challenge loop and assigns each a trust level.
+2. **Coordinator computes `cluster trust = min(member trust)`** and, if every member
+   clears the floor, issues a **signed cluster roster**:
+   ```
+   ClusterRoster {
+     clusterId
+     members: [{ nodeId, sePublicKey (P-256), x25519PublicKey, trustLevel }]
+     issuedAt, expiresAt
+   }                          // signed by the coordinator key
+   ```
+3. **Members run pairwise handshakes** (below), using the roster to know which peer
+   SE keys are authorized. The coordinator is **not** in the per-message path.
+4. **Revocation rides the existing challenge loop.** If any member fails its
+   5-minute challenge (SIP flipped, disconnect, posture change), the coordinator
+   drops it and pushes a new roster; the head tears the cluster instance down —
+   a cluster with a tainted member must not serve. Roster `expiresAt` forces
+   periodic re-issue so a stale roster can't outlive trust.
+
+## 5. The pairwise handshake (3 messages, mutual-auth ECDH)
+
+For each ring neighbor pair, the lower-`nodeId` node is **initiator (A)**, the
+other is **responder (B)**. Each generates a **fresh ephemeral X25519 keypair**
+for this session (`NodeKeyPair.generate()`) — forward secrecy; the long-term SE
+key only *signs*, it never does ECDH (SE P-256 is signing-only).
+
+```
+transcript1 = clusterId ‖ A.nodeId ‖ eA.pub ‖ nonceA ‖ B.nodeId ‖ eB.pub ‖ nonceB
+
+A → B   Msg1  { clusterId, A.nodeId, eA.pub, nonceA }
+B → A   Msg2  { B.nodeId, eB.pub, nonceB, sigB }     sigB = SE_B.sign(transcript1)
+A → B   Msg3  { sigA }                               sigA = SE_A.sign(transcript1 ‖ sigB)
+```
+
+Each side verifies, before deriving any key:
+- peer's `sePublicKey` ∈ roster, roster signed by coordinator and not expired;
+- peer's signature valid under that roster SE key → proves the peer **controls the
+  attested SE identity *and* chose this ephemeral key** (the §2 binding, pairwise);
+- `nonce` is fresh (anti-replay).
+
+**Session key** (derived once, then cached — never per token):
+```
+K = HKDF-SHA256( ikm  = X25519(eA, eB),
+                 salt = nonceA ‖ nonceB,
+                 info = "darkbloom-cluster-link-v1" ‖ clusterId ‖ sort(A.nodeId,B.nodeId) )
+```
+`info` channel-binds `K` to this cluster and this identity pair, so a recorded
+handshake can't be re-pointed at a different peer. Two directional sub-keys
+`K_A→B`, `K_B→A` are split from `K` so each direction has an independent nonce
+counter.
+
+This is a standard SIGMA-style "sign the transcript" mutual-auth pattern, built
+entirely from `SecureEnclaveIdentity.sign`, `NodeKeyPair`, and
+`X25519ChaChaPoly`'s HKDF — no new crypto.
+
+## 6. Data plane: per-token sealing
+
+After the handshake, each directed activation send is sealed with **ChaCha20-Poly1305
+under the cached `K_dir` and a monotonic 96-bit counter nonce** — *not* a fresh
+ECDH per message (that would cost a key agreement per token; see Spike B perf gate):
+
+```
+seal:  ct = ChaChaPoly.seal(activationBytes, key: K_dir, nonce: counter++,
+                            authenticating: clusterId ‖ requestId ‖ layerRange ‖ seq)
+open:  pt = ChaChaPoly.open(ct,               key: K_dir, nonce,
+                            authenticating: <same AAD>)
+```
+- **AAD** carries `requestId`, the `layerRange`, and a sequence number, so a sealed
+  activation can't be replayed into a different request, layer boundary, or order.
+- **Nonce discipline:** counter is strictly monotonic per direction; never reuse
+  `(K_dir, nonce)`. Re-handshake (new ephemeral keys) on process restart or roster
+  re-issue; 2⁹⁶ never wraps in practice.
+- **Payload is tiny:** ≈ `hidden_size × dtype_bytes` ≈ 8 KB/token, so the AEAD tax
+  is microseconds — the quantitative claim Spike B must confirm (< ~5% decode-TPS hit).
+- **RDMA path:** seal into the registered buffer, DMA the ciphertext, open after
+  receive. This is exactly the "buffer-registration discipline" the coordinator's
+  RDMA policy (§3) defers to. Ring/TCP first; RDMA zero-copy-vs-encrypt trade-off is
+  a later optimization.
+
+## 7. What does NOT change
+
+- **The request-decryption boundary is identical to today.** The coordinator seals
+  the request to the **head node's** attested X25519 key (the existing per-request
+  NaCl Box path, `ProviderLoop` decrypt). The head is the single prompt-decryption
+  endpoint, exactly as a lone provider is now. Only *activations* — never the prompt
+  plaintext — cross to other nodes, and those are sealed per §6.
+- **Consumer-facing verification.** `GET /v1/providers/attestation` and the
+  `X-Provider-*` headers expand to expose the **whole roster**, so a consumer can
+  confirm every node that touched their data is attested; surfaced trust = min.
+
+## 8. Threat model summary
+
+| Adversary capability | Defense |
+|----------------------|---------|
+| Tap the Thunderbolt cable / inter-node bus | Activations are AEAD-sealed under a key only in two hardened processes' memory. |
+| Run a modified node to MITM the link | A MITM is an unattested binary → fails roster membership + transcript signature (APNs code-identity + binary hash already gate this). |
+| Replay a recorded handshake or activation | Handshake nonces; per-direction counter nonce + `requestId`/`seq` AAD. |
+| Compromise a key later to decrypt past traffic | Ephemeral-per-session X25519 → forward secrecy. |
+| Smuggle an untrusted Mac into the cluster | `cluster trust = min(member)`; coordinator roster + 5-min challenge revocation. |
+| Read a node's in-memory activation/key directly | Pre-existing per-node defenses (HR, `PT_DENY_ATTACH`, SIP/Secure Boot). |
+| De-solder and probe memory chips | Out of scope — same residual threat Darkbloom already accepts (and PCC accepts). |
+
+## 9. Open questions for the spike
+
+1. **Member registration shape** — do members each open a WebSocket to the
+   coordinator, or does the head relay member attestations? (Protocol-symmetry cost
+   differs; affects `coordinator/protocol/messages.go` ↔ `Protocol/Messages.swift`.)
+2. **Re-handshake cost on roster churn** — how disruptive is tearing down + rebuilding
+   the MLX distributed group when one member is revoked mid-request?
+3. **RDMA encrypt-in-buffer overhead** — does sealing-into-registered-buffer erase
+   enough of RDMA's zero-copy win to prefer the ring/TCP path at cluster sizes we care about?
+4. **Key lifetime vs. challenge interval** — should a failed 5-min challenge force
+   immediate session-key revocation, or is roster-expiry granularity acceptable?

--- a/docs/architecture/cluster-perf-backlog.md
+++ b/docs/architecture/cluster-perf-backlog.md
@@ -1,0 +1,88 @@
+# Cluster Inference — Performance Backlog (what to explore)
+
+Running list of performance levers for the Apple-Silicon cluster, with status and
+the measured/known rationale for each. Ordered roughly by expected payoff for a
+multi-user private-inference service. See `cluster-benchmark.md` for the numbers
+this builds on.
+
+| Lever | Status | Expected win | Notes |
+|-------|--------|--------------|-------|
+| Continuous batching | ✅ **done, validated** | ~2.5× aggregate throughput (cross-Mac) | The throughput lever for multi-user serving. |
+| JACCL / RDMA-over-Thunderbolt | ❌ **blocked on this HW pair** | kills the ~83 ms/token TP comms floor | RDMA enabled on both, but the base **M4 is TB4** and exposes 0 RDMA devices — Apple TB-RDMA needs **TB5 on both ends**. M4 Pro shows 3 devices. Needs two TB5 machines. See `jaccl-rdma-readiness.md`. |
+| Tensor / expert parallelism | 📐 designed, not built | only worth it *after* JACCL or *with* batching | `cluster-tensor-expert-parallel.md`. Comms-bound (~12 tok/s) on the current CPU-stream ring. |
+| Speculative decoding | ✅ built, measured | 2–3× single-stream — **but only with target ≫ draft** | `spec-bench`. llama-1b/llama-8b (5× ratio) is too close → *slower*. Pays off for 1B drafting **70B** (~70× ratio). |
+| 70B-Q4 capacity demo | ⬜ not started | the "impossible on one Mac" showcase | ~37 GB across 56 GB combined; fits neither node alone. Also the regime where speculative decoding finally wins. |
+| Bandwidth-weighted layer split | ⬜ **to explore** | reduce the pipeline critical path on heterogeneous chips | Today's split is *memory*-weighted, loading more layers onto the 32 GB base M4 — which is the **bandwidth-poorer** chip (~120 GB/s vs the M4 Pro's ~273). Decode is bandwidth-bound, so the slow chip dominates the critical path (trace: head 28 ms vs tail 11 ms). A split weighted by **bandwidth** (not just RAM) would shift layers toward the faster node, cutting per-token latency — subject to each node still fitting its shard + KV cache. Capacity-vs-speed tradeoff; only matters on mismatched hardware. See `cluster-benchmark.md` bandwidth note. |
+| **Flash-Decoding (KV-split + online-softmax merge)** | ⬜ **to explore** | long-context decode + fills the pipeline bubble | See below. |
+
+---
+
+## Flash-Decoding (KV-split + online-softmax merge)
+
+**Source of the idea:** the standard Flash-Decoding technique (also used as the
+"tail KV split" in the moonmath.ai MI300X attention kernel writeup,
+https://moonmath.ai/cdna3attention/). It is the one *hardware-agnostic,
+algorithmic* idea in that otherwise CDNA3/HIP-kernel-specific article.
+
+**The mechanism.** Split the attention computation's **K/V range** across multiple
+parallel workers. Each worker computes a partial attention output over its slice
+of the keys/values **plus the slice's log-sum-exp**. A small `merge` step then
+recombines the partials into the exact full-attention output via online-softmax
+rescaling — mathematically identical to computing attention over the whole KV at
+once. The split is along the *sequence/context* axis, not the layer or head axis.
+
+**Why it could matter for this cluster (two distinct angles):**
+
+1. **Long-context decode (the natural fit).** As the KV cache grows, each decode
+   step's attention becomes bound on *reading the KV cache* — a cost separate from
+   weight streaming, and the report flagged it as "a dominant bottleneck across a
+   network boundary" (KV-cache disaggregation, arXiv:2605.13734). Flash-Decoding
+   splits that KV read across parallel workers. Relevant only once we serve long
+   contexts; not the current bottleneck.
+
+2. **Filling the pipeline bubble (speculative, larger effort).** Our pipeline
+   cluster leaves one GPU idle while the other computes. Flash-Decoding's pattern —
+   "split work across idle compute units, merge via log-sum-exp" — is conceptually
+   the lever for using that idle GPU. BUT: our idle resource is a *whole node
+   across the network*, and a layer's KV lives on the node that owns that layer.
+   Applying it cross-node means **context/sequence parallelism** (shard the KV
+   cache by token-range across nodes) — a new parallelism axis distinct from the
+   pipeline/tensor/expert axes we've built/designed. Substantial design, not a tweak.
+
+**Caveats / open questions before investing:**
+- **Does MLX-swift already do this single-node?** Upstream MLX added Flash-Decoding
+  to its attention path. If MLX's decode attention already splits KV internally, we
+  get the single-node benefit for free and there is nothing to build at the kernel
+  level — the only open work would be the *cross-node* context-parallel version.
+  **Verify first** (cheap: read the MLX `scaled_dot_product_attention` / decode path).
+- It only helps when **attention over a long KV** is a meaningful fraction of step
+  time. At short contexts (our benchmarks so far) it's negligible — weight streaming
+  dominates. So this is a *long-context* lever, gated behind a real long-context
+  use case.
+- The cross-node version interacts with our encrypted ring + the
+  composition-control protocol; the merge step would be another collective.
+
+**Verdict:** keep in the backlog. Not a current-bottleneck win (throughput was, and
+continuous batching addressed it). Promote it when (a) we target long-context
+serving, or (b) we pursue context-parallelism to fill the pipeline bubble. First
+concrete step is the cheap MLX-already-does-it check.
+
+---
+
+## Note on kernel-level work (why we operate above the kernel — and when not to)
+
+Darkbloom's leverage has been at the **distributed-systems layer** (ring transport,
+batching, scheduling), not the **attention-kernel layer**, because:
+
+1. Our measured bottlenecks are weight-streaming bandwidth, the pipeline bubble, and
+   the network hop — none of which a faster attention kernel touches.
+2. MLX/Metal owns the kernels; we'd be competing with Apple's tuned
+   `scaled_dot_product_attention` rather than the unsolved distributed problem.
+
+**When kernel work would be worth it:** if profiling ever shows *attention compute*
+(not weight streaming) as a top-3 cost — e.g. long-context decode, or a
+MoE/attention shape MLX hasn't tuned for Apple GPUs — then a custom Metal attention
+kernel (the Apple-Silicon analogue of the moonmath MI300X work) becomes a real
+lever. Until a profile says so, it's premature. The article's transferable
+meta-principle ("optimization is a memory-placement argument; plan the pipeline by
+hand for known shapes") applies to a Metal kernel just as it does to CDNA3.

--- a/docs/architecture/cluster-tensor-expert-parallel.md
+++ b/docs/architecture/cluster-tensor-expert-parallel.md
@@ -1,0 +1,488 @@
+# Tensor & Expert Parallelism for the Darkbloom Cluster
+
+**Status:** design / implementation-ready
+**Scope:** replace the sequential pipeline-parallel decode loop (`ClusterPipeline.swift`) with tensor parallelism (TP) for dense models (Mistral) and expert parallelism (EP) for MoE models (gpt-oss), on a 2-node co-located Apple Silicon cluster.
+**Audience:** whoever implements `ClusterTensorParallel.swift` + the `mlx-swift-lm` fork shard changes.
+
+All file paths, function names, and config values below were read from the live repo at `/Users/tarasshchybovyk/Eigen/d-inference`. Hardware target: `mac-32` = M4 / 32 GB (rank 0, head), `mac-24` = M4 Pro / 24 GB (rank 1, tail). Link is either Wi-Fi (~42 ms RTT) or Thunderbolt-IP (~1 ms RTT). Ring transport is TCP. (RDMA/`jaccl` is **not** forbidden by the trust policy — the coordinator accepts `rdma_disabled: false` providers under a "registered-buffer RDMA policy" and only requires the status be *reported*, `api/provider.go:1184-1200`; the security boundary is the signed runtime's IOMMU buffer-registration discipline, not a blanket ban. We use the TCP ring today because it's what's wired, not for policy reasons — JACCL is a viable future transport.) Ring collectives run on the **CPU stream** (`communication_stream` forces `Device::cpu`, `ring.cpp:471`).
+
+---
+
+## 0. Visual overview — three topologies
+
+Three ways to split one model across the two-Mac cluster, drawn as both the
+**logical split** (top) and the **physical chain a single token traverses**
+(bottom). The composition shown is an 80-layer model (head = M4 Pro layers 0–43,
+tail = M4 base layers 44–79) for the pipeline diagram; the TP diagrams split
+*within* every layer instead.
+
+> The numbers in the RDMA diagram (~0.25 ms/reduce, ~40 tok/s) are the **projected**
+> target from the §1 comms-floor model — **not measured**, because Apple
+> RDMA-over-Thunderbolt (JACCL) needs **TB5 on both ends** and the base M4 is TB4
+> (0 RDMA devices vs the M4 Pro's 3). The CPU-stream ring numbers (~1 ms/reduce,
+> ~12 tok/s) *are* measured (`comms-bench`). See `jaccl-rdma-readiness.md`.
+
+### 0.1 Pipeline parallelism (layer split) — what we run today
+
+```
+                        ONE TOKEN, BATCH=1  —  PIPELINE PARALLELISM (layer split)
+ ┌─────────────────────────────────────────┐        ┌─────────────────────────────────────────┐
+ │  HEAD  ·  M4 Pro                          │        │  TAIL  ·  M4 base                         │
+ │  rank 0                                   │  ring  │  rank 1                                   │
+ │  layers  0 ── 43   (44 layers)            │  hop   │  layers 44 ── 79   (36 layers)            │
+ │  embed + first half of the transformer    │═══════▶│  second half + norm + lm_head + argMax    │
+ └─────────────────────────────────────────┘        └─────────────────────────────────────────┘
+        │  activation [1, hidden] bf16,                        │  next-token id
+        │  AEAD-sealed, sent over TCP                          │  sent back via all_gather
+        └──────────────────────────────────────────────◀──────┘
+
+
+ PHYSICAL CHAIN  (what actually executes, left → right in time)
+
+  HEAD (M4 Pro)                                                  TAIL (M4 base)
+  ┌──────┬─────────────────┬──────────────────┐   wire   ┌──────────────────┬─────────────────┬──────┐
+  │ CPU  │      GPU         │       CPU        │  ~0.03ms │       CPU         │      GPU        │ CPU  │
+  ├──────┼─────────────────┼──────────────────┤ ════════ ├──────────────────┼─────────────────┼──────┤
+  │embed │ run layers 0-43 │ encode bf16       │ socket   │ recv from socket │ run layers 44-79│ read │
+  │tokens│ (GPU compute)   │ AEAD seal         │ ──────▶  │ AEAD open         │ + norm+lm_head  │ token│
+  │      │                 │ →i32 → send()     │  TCP     │ decode → MLXArray │ + argMax (GPU)  │ back │
+  └──────┴─────────────────┴──────────────────┘          └──────────────────┴─────────────────┴──────┘
+
+      CPU → GPU → CPU → socket ───▶ socket → CPU → GPU → CPU → (all_gather: token id back to head)
+
+  while HEAD's GPU runs layers 0-43,  TAIL sits idle in recv_wait  ◀─┐
+  while TAIL's GPU runs layers 44-79, HEAD sits idle in all_gather    │  ← the PIPELINE BUBBLE
+                                                                       │    (the two GPUs never
+  critical path = head_GPU + (CPU+socket ~1ms) + tail_GPU ───────────┘     overlap at batch=1)
+```
+
+**One ring hop per token; the two GPUs run sequentially (the bubble).** CPU
+crypto/serialize (~0.3 ms) and the socket hop (~0.03 ms) are negligible — ~95% of
+the token is sequential GPU compute. The split makes the model **fit**, not **fast**.
+
+### 0.2 Tensor parallelism over the CPU-stream ring (today's transport)
+
+```
+                        ONE TOKEN, BATCH=1  —  TENSOR PARALLELISM (within-layer split)
+ ┌─────────────────────────────────────────┐        ┌─────────────────────────────────────────┐
+ │  M4 Pro  ·  rank 0                        │◀══════▶│  M4 base  ·  rank 1                       │
+ │  ALL layers 0 ── 79                       │ all-   │  ALL layers 0 ── 79                       │
+ │  but only HALF of each layer:             │ reduce │  but only HALF of each layer:             │
+ │   · attention heads  0 ── (n/2)           │  ↕↕↕   │   · attention heads (n/2) ── n            │
+ │   · MLP columns      left half            │  every │   · MLP columns      right half           │
+ └─────────────────────────────────────────┘ layer  └─────────────────────────────────────────┘
+   BOTH GPUs compute EVERY layer, in parallel, on their slice of the weights.
+   Twice per layer they must SUM partials across the wire (all-reduce) to stay in sync.
+
+
+ PHYSICAL CHAIN  (per layer — repeats 80×, both nodes lockstep)
+
+  M4 Pro (rank 0)                                            M4 base (rank 1)
+  ┌─────────────────┬──────┬────────┐                        ┌────────┬──────┬─────────────────┐
+  │      GPU        │ CPU  │ socket │  ═══ all-reduce ═══     │ socket │ CPU  │      GPU        │
+  ├─────────────────┼──────┼────────┤   (sum + broadcast)    ├────────┼──────┼─────────────────┤
+  │ attn on heads   │ copy │ send   │ ◀══════════════════════│ send   │ copy │ attn on heads   │
+  │  0..n/2         │ GPU→ │ partial│ ──────────────────────▶│ partial│ →GPU │  n/2..n         │
+  │                 │ CPU  │        │   each gets the SUM     │        │ CPU  │                 │
+  └─────────────────┴──────┴────────┘                        └────────┴──────┴─────────────────┘
+        │  ... then MLP, then a SECOND all-reduce, then next layer ...  │
+        ▼                                                                ▼
+  ┌─────────────────┬──────┬────────┐                        ┌────────┬──────┬─────────────────┐
+  │ MLP left cols   │ GPU→ │ send   │ ◀══════ all-reduce ════▶│ send   │ →GPU │ MLP right cols  │
+  └─────────────────┴──────┴────────┘                        └────────┴──────┴─────────────────┘
+
+  PER LAYER:  GPU → CPU → socket ──▶ socket → CPU → (sum) → GPU      ... ×2 (after attn, after MLP)
+  PER TOKEN:  80 layers × 2 reduces = 160 collectives, STRICTLY SEQUENTIAL
+              (layer N+1 cannot start until layer N's all-reduce returns)
+
+  NO bubble — both GPUs busy.  Instead: a COLLECTIVE between every half-layer.
+  Each reduce ~1.0 ms (dominated by GPU→CPU crossing + .eval() barrier, NOT the ~20 KB payload).
+  160 × ~1 ms sequential ⇒ batch-1 TP floored at ~12 tok/s — no better than pipeline.
+```
+
+**No bubble (both GPUs busy), but a collective between every half-layer.** At
+batch=1 this is **latency-bound**: ~1 ms/reduce × 160 sequential reduces ⇒ ~12 tok/s.
+The win is **throughput with batching** (the comms floor is ~fixed per step
+regardless of batch size), not single-stream latency — see §1.
+
+### 0.3 Tensor parallelism over RDMA (JACCL — projected, needs TB5 on both ends)
+
+```
+                  ONE TOKEN, BATCH=1  —  TENSOR PARALLELISM over RDMA
+ ┌─────────────────────────────────────────┐        ┌─────────────────────────────────────────┐
+ │  M4 Pro  ·  rank 0                        │◀══════▶│  M4 base  ·  rank 1                       │
+ │  ALL layers 0 ── 79, HALF of each:        │  RDMA  │  ALL layers 0 ── 79, HALF of each:        │
+ │   · attn heads 0..n/2                     │ all-   │   · attn heads n/2..n                     │
+ │   · MLP left columns                      │ reduce │   · MLP right columns                     │
+ └─────────────────────────────────────────┘        └─────────────────────────────────────────┘
+
+
+ PHYSICAL CHAIN — CPU-stream ring (§0.2)               vs           RDMA (this)
+
+  per reduce, RING:                                      per reduce, RDMA:
+  ┌─────┐  ┌─────┐  ┌──────┐                              ┌─────┐                  ┌─────┐
+  │ GPU │─▶│ CPU │─▶│socket│══▶ ...                        │ GPU │ ════ NIC DMAs ══▶ │ GPU │
+  └─────┘  └─────┘  └──────┘                              └─────┘  reads/writes     └─────┘
+   compute   copy   syscall                                compute  memory directly  compute
+   + .eval() barrier stalls                                NIC moves bytes; no CPU copy,
+   ~1.0 ms / reduce                                        no socket syscall, no host barrier
+                                                           ~0.2–0.3 ms / reduce
+
+
+ PER LAYER (RDMA), both nodes lockstep, NO CPU in the DATA path:
+
+  M4 Pro (rank 0)                                          M4 base (rank 1)
+  ┌─────────────────┐                                      ┌─────────────────┐
+  │ GPU: attn heads │═══════════ RDMA all-reduce ═════════▶│ GPU: attn heads │
+  │      0..n/2     │◀════ NIC ↔ NIC, memory-to-memory ════│      n/2..n     │
+  └─────────────────┘    (sum partials, both get result)   └─────────────────┘
+  ┌─────────────────┐                                      ┌─────────────────┐
+  │ GPU: MLP left   │═══════════ RDMA all-reduce ═════════▶│ GPU: MLP right  │
+  └─────────────────┘◀═════════════════════════════════════└─────────────────┘
+
+  PER REDUCE:  GPU ═══ NIC (DMA, no CPU copy) ═══▶ GPU   ← CPU copy / socket / eval-barrier GONE
+  PER TOKEN:   still 160 collectives, still strictly sequential — but each ~3-4× cheaper
+               160 × ~0.25 ms ⇒ batch-1 TP ceiling lifts to ~40+ tok/s (PROJECTED, not measured)
+```
+
+**RDMA deletes the per-reduce data-path crossing** (GPU→CPU copy, socket syscall,
+`.eval()` host barrier) — the NIC moves bytes memory-to-memory. The CPU still
+*launches* the collective and issues the DMA descriptor (control), so it isn't
+literally zero-CPU; it just no longer copies the bytes or blocks on a syscall per
+reduce. The **160-reduces-strictly-sequential** structure is unchanged — RDMA makes
+each reduce ~3-4× cheaper (~1 ms → ~0.25 ms), it does **not** parallelize them. So
+batch-1 TP stays latency-bound, just at a far higher ceiling (~12 → ~40+ tok/s).
+
+| Per all-reduce | CPU-stream ring (measured) | RDMA (projected) |
+|---|---|---|
+| GPU→CPU copy (host staging) | present | gone — NIC DMAs from memory |
+| socket `send`/`recv` syscall | present | gone — NIC↔NIC directly |
+| `.eval()` host barrier | present | gone — stays on GPU stream |
+| **cost / reduce** | **~1.0 ms** | **~0.2–0.3 ms** |
+| collectives / token | 160 (2×80) | 160 (2×80) — *unchanged* |
+| **batch-1 TP ceiling** | **~12 tok/s** | **~40+ tok/s** |
+
+---
+
+## 1. Why TP/EP beats pipeline here
+
+### The current loop (`ClusterPipeline.generate`, ClusterPipeline.swift:60)
+
+Each rank owns a **contiguous layer interval** (`LayerPartition.partition`). Per decode step:
+
+1. head embeds (`shard.embed`), peers `recvLike` the sealed hidden state from `rank-1` (line 97).
+2. every rank runs **only its own layers** (`shard.runOwnedLayers`, line 106).
+3. non-tail `send`s the sealed result to `rank+1` (line 115); tail samples (`projectToLogits` + `argMax`, line 124).
+4. every rank `allGather`s the sampled token (line 131).
+
+This is **sequential**: while rank 0 computes layers `[0, k)`, rank 1 is idle waiting on `recvLike`; while rank 1 computes `[k, N)`, rank 0 is idle. At batch=1 the two GPUs never compute at the same time. The split only makes the model **fit**; it does not make it **fast**. Measured ~9–12 tok/s on gpt-oss-20b — roughly half the single-GPU compute is wasted as idle, on top of the per-token wire hop.
+
+### Comms vs compute, quantified per token
+
+Let `H` = hidden_size, `L` = number of transformer layers, activation dtype = bf16 (2 bytes), batch=1, decode width=1 (one token/step).
+
+**Pipeline (current):** exactly **one** inter-node hop per token (one `send`/`recvLike` pair on the single 2-node boundary; the tail-token `allGather` is 4 bytes, negligible).
+- Bytes on the wire per token ≈ `H * 2` + AEAD/codec overhead. From `ClusterPipeline.sealedLen` (line 51): `14 + width*H*2 + 28`.
+- Mistral (`H=5120`): `14 + 5120*2 + 28 = 10,282` bytes ≈ **10 KB / token**, one direction, once.
+- gpt-oss (`H=2880`): `14 + 2880*2 + 28 = 5,802` bytes ≈ **5.7 KB / token**.
+- **Latency cost:** 1 RTT-ish per token (one ordered hop). At 42 ms Wi-Fi that's a hard floor of ~24 tok/s *before any compute*; at 1 ms TB it's ~1000 tok/s floor. The reason pipeline is "right for geo-distributed" is exactly this single-hop minimal-comms property.
+
+**Tensor parallelism (TP):** the layer stack is split *within* each layer across both nodes; both compute every layer concurrently on half the heads / half the MLP. Each layer needs **2 all-reduces** of the full hidden vector (after attention output projection, after MLP down projection — see §2).
+- Collectives per token = `2 * L`.
+- Per-collective payload (the ring `all_sum` moves ~`2*(p-1)/p * nbytes` end-to-end for `p` ranks; for `p=2` that's `~1x nbytes` reduce-scatter + `~1x` all-gather): one all-reduce of an `H`-vector bf16 ≈ `H*2` bytes per direction.
+- Mistral: `2 * 40 = 80` all-reduces/token, each `5120*2 = 10,240` bytes ⇒ ~**0.82 MB/token** moved (plus AEAD framing, see §2.3).
+- gpt-oss: `2 * 24 = 48` all-reduces/token, each `2880*2 = 5,760` bytes ⇒ ~**0.28 MB/token** (attention only; MoE handled by EP, see §3).
+- **Latency cost:** `2*L` *sequential* collectives per token, because layer `i+1` depends on layer `i`'s all-reduce. This is the killer over Wi-Fi: `80 * 42 ms = 3.4 s/token` ⇒ **0.3 tok/s. TP over Wi-Fi is a non-starter.** Over Thunderbolt: `80 * ~1 ms = ~80 ms` of comms latency/token ⇒ comms allows ~12 tok/s *ceiling from latency alone* — still tight. The win comes from compute parallelism + TCP_NODELAY pipelining (`ring.cpp:441`); the all-reduces for independent quantities within a layer can overlap, and the dominant cost becomes per-collective *fixed overhead*, not bandwidth (bandwidth is trivial: 0.82 MB/token * 12 tok/s ≈ 10 MB/s, far under even Wi-Fi).
+
+**Expert parallelism (EP):** for the MoE MLP, only the **top-k experts' worth** of each token's hidden vector moves, via all-to-all dispatch + combine (§3).
+- gpt-oss: `experts_per_token=4`, `num_local_experts=32`, `H=2880`. Per MoE layer, per token: dispatch up to `k=4` hidden vectors out (to whichever node holds each selected expert) and combine them back ⇒ `2` all-to-all rounds, each moving at most `k*H*2 = 4*2880*2 = 23 KB` worth, but in practice only the fraction of the `k` experts that live on the *remote* node. With balanced 16/16 placement, ~half of 4 experts are remote ⇒ ~`2*2*H*2 = 11.5 KB/token/layer` across `24` layers ⇒ ~**0.28 MB/token** for MoE comms, on top of TP'd attention.
+- **Latency cost:** `2` all-to-all rounds * `24` layers = `48` sequential collectives/token, same order as TP attention. Same conclusion: **Thunderbolt-only.**
+
+### Verdict
+
+| Strategy | Comms/token | Sequential collectives/token | Wi-Fi (42ms) | Thunderbolt (1ms) | Both GPUs busy? |
+|---|---|---|---|---|---|
+| Pipeline (current) | ~5–10 KB | 1 hop + 1 tiny gather | viable (~9–12 tok/s, measured) | viable | **No** (sequential) |
+| TP (Mistral dense) | ~0.82 MB | `2L = 80` | **no** (~0.3 tok/s) | yes | **Yes** |
+| TP attn + EP MoE (gpt-oss) | ~0.55 MB | `2L + 2L = 96` | **no** | yes | **Yes** |
+
+**Conclusion:** TP/EP are the right design *only over Thunderbolt*. The implementation must keep `ClusterPipeline.swift` as the fallback for the Wi-Fi / >2-node / geo-distributed case, and select TP/EP when the link is the low-latency local TB path. Pipeline minimizes comms (1 hop); TP/EP maximize parallel compute (`2L` hops) — the trade is only worth it when per-hop latency is ~1 ms.
+
+---
+
+## 2. Tensor parallelism for a dense layer (Mistral)
+
+Mistral-24b config (`~/m/mistral-24b-8bit/config.json`): `hidden_size=5120`, `intermediate_size=32768`, `num_attention_heads=32`, `num_key_value_heads=8`, `head_dim=128`, `num_hidden_layers=40`, `vocab_size=131072`.
+
+With `p=2` ranks, each rank holds **half** the heads and **half** the MLP intermediate, and computes its half every layer. This is the standard Megatron-LM partition.
+
+### 2.1 Attention sharding (split heads)
+
+- `num_attention_heads=32` ⇒ 16 heads/rank. `num_key_value_heads=8` (GQA) ⇒ 4 KV heads/rank. Both divide evenly by 2 — good (a node holding an odd split would need padding; not needed here).
+- **Column-parallel QKV:** each rank loads only its slice of `q_proj`, `k_proj`, `v_proj` (rows for its heads). Rank 0 holds heads `[0,16)`, rank 1 holds `[16,32)`. Each computes attention for its own heads locally — **no communication inside attention**, because each head is independent and each rank keeps the KV cache only for its own heads.
+- **Row-parallel output projection (`o_proj`):** `o_proj` is `[H, H] = [5120, 5120]`, split by **input rows**: rank `r` holds `o_proj[:, r*2560:(r+1)*2560]` (the columns matching its head outputs). Each rank produces a **partial** `[1, 1, 5120]` sum over its heads. The two partials must be summed:
+  - **`all_reduce(sum)` #1** goes right after `o_proj`, before the residual add and the post-attention norm. Each rank contributes its `[1,1,5120]` partial; output is the full attention result on both ranks.
+
+### 2.2 MLP sharding (column-parallel up/gate, row-parallel down)
+
+Mistral MLP is SwiGLU: `down( silu(gate(x)) * up(x) )`, `gate`/`up` are `[I, H] = [32768, 5120]`, `down` is `[H, I] = [5120, 32768]`.
+
+- **Column-parallel `gate` and `up`:** rank `r` holds rows `[r*16384, (r+1)*16384)` of `gate` and `up` ⇒ produces a `[1,1,16384]` slice of the intermediate. `silu` and the elementwise `*` are local (no cross-talk between intermediate channels). **No communication mid-MLP.**
+- **Row-parallel `down`:** rank `r` holds columns `[r*16384, (r+1)*16384)` of `down` ⇒ each produces a **partial** `[1,1,5120]`.
+  - **`all_reduce(sum)` #2** goes right after `down`, before the residual add. Output is the full MLP result on both ranks.
+
+So per layer: **exactly 2 all-reduces**, both summing an `H`-wide vector. Norms (RMSNorm) and residual adds run identically (redundantly) on both ranks on the full hidden vector — cheap, avoids extra comms. The embedding (head only today) becomes **replicated**: both ranks embed and both run `lm_head`, OR keep head/tail roles and `all_gather` the final hidden before logits. Simplest: replicate embed + final-norm + `lm_head` on both ranks (vocab 131072 * 5120 is large but quantized 8-bit, and it removes a hop). **Decision:** replicate embed and lm_head on both ranks; sampling is then identical on both ⇒ the per-token `all_gather` of the sampled token (ClusterPipeline.swift:131) is no longer needed for correctness, but keep a 4-byte token `all_gather` as a cheap consensus/consistency check.
+
+### 2.3 What's communicated (shape/dtype/bytes)
+
+Per all-reduce, Mistral:
+- Tensor `[1, 1, 5120]`, dtype bf16 ⇒ payload `5120 * 2 = 10,240` bytes.
+- The ring `all_sum` (reduce-scatter + all-gather, `ring.cpp:590` `all_reduce` → `all_reduce_impl` line 665) moves ~`2*(p-1)/p` of that across the wire; for `p=2`, ~`1.0x` reduce + `1.0x` gather ≈ 20 KB total wire traffic per all-reduce.
+- `2 * 40 = 80` all-reduces/token ⇒ ~0.82 MB/token of payload, ~1.6 MB/token on the wire. Trivial bandwidth; the cost is the `80` sequential CPU-stream round trips.
+
+### 2.4 Encryption: sealing a symmetric all-reduce
+
+This is the subtle part. Today's crypto (`ClusterLinkCrypto.swift`) is **directional**: `ClusterSealingChannel` seals toward `nextRank`, `ClusterOpeningChannel` opens from `prevRank`, with **separate keys per direction** (`ClusterSessionKeys.directionalKey`, "A>B" vs "B>A") and a **monotonic counter nonce** per channel. The pipeline hop is one-directional, so this maps cleanly: one seal, one open.
+
+An **all-reduce is symmetric** — both ranks send *and* receive in the same op. The ring `all_sum` does it as internal `send`/`recv` of raw bytes; it cannot itself encrypt. Two options:
+
+**Option A (recommended for v1): encrypt the operands, do a plaintext-on-the-wire-of-ciphertext "reduce" by emulating all-reduce in Swift as send+recv+local-add.** Because `p=2`, an all-reduce is just: "I send my partial to the peer, I receive the peer's partial, I add them." That is **one directional send + one directional recv** — *exactly* the primitive the existing crypto already secures. So for 2 nodes we do NOT call the ring's `all_sum`; we do:
+
+```
+// pseudo, per all-reduce point, rank r, peer = 1 - r
+let sealed = sealCh.seal(ActivationCodec.encode(myPartial.asType(.bfloat16)), context: ctx_out)   // toward peer
+let dep = group.send(toI32(sealed), to: peer); dep.eval()
+let cipher = group.recvLike(template, from: peer)                                                  // from peer
+let peerPartial = ActivationCodec.decode(openCh.open(toBytes(cipher), context: ctx_in))
+let reduced = myPartial + peerPartial      // local add on GPU
+```
+
+This keeps the **existing directional-key, monotonic-nonce discipline untouched** — every collective is still one seal (counter++ on the send channel) and one open (expected-counter++ on the recv channel). The AAD `layerRange` field (currently `"hop-N"`) becomes the all-reduce site identifier, e.g. `"tp-attn-L17"` / `"tp-mlp-L17"`, so a frame can't be replayed across layers or across the two reduce points. **Nonce safety is preserved because send and recv use different keys and each has its own monotonic counter.** The send/recv on a 2-node ring are direct-neighbor (the only kind the ring allows, `ring.cpp:539/560`), and with `size_=2` left==right so it works (note the ring's own comment at `recv`, line ~561, about 2-node left/right aliasing).
+
+Cost: `2L` * (1 seal + 1 open + 1 send + 1 recv + 1 GPU add). For Mistral that's 80 seal/open pairs/token. AEAD on a 10 KB frame is ~microseconds (ChaChaPoly is fast); the encode/decode (`ActivationCodec`) copies the tensor out of and into MLX each time — see Risks §7.
+
+**Option B (later, for `p>2`): use the ring's native `all_sum` and protect the channel out-of-band.** A true `all_sum` reduces over the wire and we can't insert AEAD per hop without forking the ring's reduce loop. For `p>2` you'd need a symmetric group key + per-(rank,seq) nonce derivation, or to fork `ring.cpp`'s `all_reduce_impl` to seal/open each segment. Out of scope for the 2-node target. **For 2 nodes, Option A is strictly simpler and reuses verified crypto — use it.**
+
+> Implication: the "all-reduce" we ship for 2 nodes is **send+recv+add**, not the ring's `all_sum`. This is correct and is the minimal change. We only need the ring's real `all_sum` if/when the cluster grows past 2 nodes, at which point we revisit Option B.
+
+---
+
+## 3. Expert parallelism for the MoE layer (gpt-oss)
+
+gpt-oss-20b config (`~/m/gptoss-20b-q8/config.json`): `model_type=gpt_oss`, `hidden_size=2880`, `intermediate_size=2880`, `num_hidden_layers=24`, `num_local_experts=32`, `num_experts_per_tok=4` (== `experts_per_token`), `num_attention_heads=64`, `num_key_value_heads=8`, `head_dim=64`. Attention is alternating `sliding_attention`/`full_attention` (the `layer_types` array). Experts are MXFP4-quantized (4-bit), attention proj are 8-bit affine (from the `quantization` block).
+
+**Attention** in gpt-oss is TP'd exactly as in §2 (64 heads → 32/rank, 8 KV heads → 4/rank, both divide by 2; one all-reduce after `o_proj`). The MoE block replaces the dense MLP and uses **EP**.
+
+### 3.1 Expert placement (weighted 32:24)
+
+32 experts, 2 nodes. Memory weighting by the 32 GB / 24 GB split (the same `LayerPartition` philosophy, but over experts not layers). Total weight 56 ⇒ mac-32 share `32/56 * 32 ≈ 18.3`, mac-24 share `24/56 * 32 ≈ 13.7`. Round to **mac-32 (rank0): experts [0,18), mac-24 (rank1): experts [18,32)**.
+
+But router skew matters more than memory here (see §3.4). Each expert in gpt-oss is a small SwiGLU on `intermediate_size=2880` (== hidden), MXFP4 — roughly `3 * 2880 * 2880 * 0.5 bytes ≈ 12.4 MB/expert/layer` * 24 layers ≈ 300 MB/expert total. 18 vs 14 experts ≈ 5.3 GB vs 4.1 GB just for expert weights — well within budget; see §7 for the full KV+weights fit check. **Placement is per-layer-uniform** (expert `e` lives on the same node in every layer) so the dispatch routing table is computed once.
+
+### 3.2 The MoE forward with all-to-all
+
+Per MoE layer, both ranks already hold the **full** post-attention hidden state (it was all-reduced in §2.1). The router (`gate`, a `[32, 2880]` projection) is **replicated** on both ranks — cheap, and avoids a comms round to share routing decisions: both ranks compute the identical top-4 expert ids + weights for the (single) token.
+
+Then:
+
+1. **Dispatch (all-to-all #1):** for each selected expert `e`, the token's hidden vector must be at the node owning `e`. Both ranks know the routing table, so each rank:
+   - keeps the tokens routed to its **local** experts (no wire),
+   - **sends** to the peer the token's hidden vector for each expert routed to the **remote** node.
+   For batch=1 / width=1, "tokens" = the one token, replicated to ≤ `k=4` experts. Concretely rank `r` sends the hidden vector once per remote-expert selection (dedup: send the `[1,1,2880]` vector at most once to the peer if *any* of the token's experts are remote, plus the list of which remote experts to run — the peer runs them and returns weighted partials).
+2. **Compute:** each rank runs its locally-owned selected experts on the token (`silu(gate·x)*up(x)` then `down`), scales each by its router weight.
+3. **Combine (all-to-all #2):** each rank sends back the **weighted expert outputs** for experts it ran on behalf of the peer; each rank sums the contributions (local + received) into the final `[1,1,2880]` MoE output. Then residual add (local).
+
+For 2 nodes, all-to-all degenerates to the **same send+recv pair** as §2.4 — there is exactly one peer. So EP needs **no new collective**: it's `recvLike`/`send` of (a) the dispatched hidden + expert-id list and (b) the combined weighted partials, sealed with the existing directional channels. AAD `layerRange` = `"ep-dispatch-L{n}"` / `"ep-combine-L{n}"`.
+
+### 3.3 Communication volume per token (gpt-oss)
+
+- Dispatch: at most one `[1,1,2880]` bf16 vector (5,760 B payload) + a tiny expert-id/weight list, sent to the peer **only if** the token routes ≥1 expert remotely. With balanced placement and uniform routing, P(all 4 experts local) is small, so ~1 hidden vector out per layer.
+- Combine: peer returns its weighted partial `[1,1,2880]` (5,760 B) back.
+- ⇒ ~`2 * 5,760 ≈ 11.5 KB/token/MoE-layer`, `* 24 layers ≈ 0.28 MB/token`, plus the attention all-reduce (§2.3) `2880*2*2*24 ≈ 0.28 MB/token`. Total gpt-oss ≈ **0.55 MB/token**.
+- Sequential collectives: attention `1 all-reduce *24` + MoE `2 *24` = **72 sequential send/recv rounds/token**. TB-only, as in §1.
+
+### 3.4 Load imbalance
+
+The router can send most/all of the token's top-4 to experts on **one** node, leaving the other idle — the classic MoE imbalance, made worse at batch=1 (no averaging across a batch). Mitigations, in order of effort:
+
+1. **Accept it for batch=1.** With width=1 the absolute compute per expert is tiny; the bottleneck is comms latency, not expert FLOPs. Imbalance costs little when each "compute" is one token through one small MLP.
+2. **Interleave expert placement** rather than contiguous: assign experts round-robin (`e % 2`, weighted to put the extra 4 on mac-32) so that any given top-4 is statistically split ~2/2 across nodes. This minimizes the chance that all 4 land on one node and balances the *expected* per-node expert count per token. **Recommended.**
+3. **Batched decode (continuous batching):** when the provider batches `B` concurrent requests (the existing `BatchedEngine` path), tokens-to-experts averages out across the batch and both nodes stay busy. This is the real imbalance fix and aligns with the project's continuous-batching design (see CLAUDE.md "Continuous batching"). EP should be designed to carry a `[B, 1, H]` activation, not just `[1,1,H]`, so dispatch groups tokens by destination node and sends one batched frame per direction per round.
+
+**Decision:** ship interleaved placement (#2) + design the dispatch/combine to handle a batch dim (#3), even if v1 runs batch=1.
+
+---
+
+## 4. Collective gap analysis (ring backend)
+
+Read from `libs/mlx-swift/Source/Cmlx/mlx/mlx/distributed/ring/ring.cpp` and the C API `mlx-c/mlx/c/distributed.h`.
+
+### What the forked ring backend implements today (`RingGroup`, ring.cpp:387)
+
+| Collective | ring.cpp | C API (`distributed.h`) | Swift wrapper (`MLXDistributed.swift`) |
+|---|---|---|---|
+| `send` (direct neighbor only) | ✅ line 539 | ✅ `mlx_distributed_send` | ✅ `send` |
+| `recv` / `recv_like` (direct neighbor only) | ✅ line 560 | ✅ `mlx_distributed_recv[_like]` | ✅ `recvLike` |
+| `all_gather` | ✅ line 502 | ✅ `mlx_distributed_all_gather` | ✅ `allGather` |
+| `all_sum` (ring reduce-scatter + all-gather) | ✅ line 483 → `all_reduce`/`all_reduce_impl` 590/665 | ✅ `mlx_distributed_all_sum` | ❌ **not wrapped** |
+| `all_max` | ✅ line 488 | ✅ `mlx_distributed_all_max` | ❌ |
+| `all_min` | ✅ line 493 | ❌ (no C symbol) | ❌ |
+| `sum_scatter` | ❌ **throws** "not supported" (line 584) | n/a | ❌ |
+| `all_to_all` | ❌ **does not exist** | ❌ | ❌ |
+| `split` | ❌ throws (line 498) | n/a | ❌ |
+
+**Key findings:**
+
+- **`all_sum` already exists** in the forked ring backend (it's a full ring reduce-scatter then all-gather, `all_reduce_impl` at line 665, comment line 694: "first scatter reduce and then gather") and the C symbol `mlx_distributed_all_sum` is already exported. It is simply **not wrapped in Swift** (`MLXDistributed.swift` deliberately omits it — see the file header comment: "Tensor-parallel collectives (all_sum/sum_scatter) are intentionally omitted for now"). All collectives run CPU-stream (`communication_stream` → `Device::cpu`, line 471).
+- **`all_to_all` does NOT exist** anywhere — not in `ring.cpp`, not in the C++ public `ops.h` (`grep` shows only `all_sum`, `all_gather`, `send`, `recv`, `recv_like`, `all_max`), not in the C API.
+
+### What TP needs vs what exists
+
+TP needs a per-layer all-reduce(sum). **For 2 nodes we do not need the ring's `all_sum` at all** — an all-reduce over `p=2` is `send(partial) ; recv(peerPartial) ; localAdd`, using the already-wrapped `send`/`recvLike` and the existing sealed channels (§2.4). This is the recommended path: **zero new ring/C++ code, reuses verified crypto.**
+
+If we later want the native `all_sum` (e.g. `p>2`, or to avoid the extra encode/decode copy):
+- The C symbol exists; we only add a Swift wrapper:
+  ```swift
+  public func allSum(_ x: MLXArray, stream: StreamOrDevice = .cpu) throws -> MLXArray {
+      try call("all_sum") { res in mlx_distributed_all_sum(&res, x.ctx, group, stream.ctx) }
+  }
+  ```
+  But raw `all_sum` ships **plaintext activations on the wire**, which violates the encrypted-link invariant. So native `all_sum` is only usable if we either (a) fork `all_reduce_impl` to seal/open each segment, or (b) accept plaintext under a separate threat model. Not for v1.
+
+### What EP needs vs what exists
+
+EP needs all-to-all (dispatch + combine). **For 2 nodes, all-to-all = pairwise send/recv** (one peer), so again **no new collective** — implement it as sealed `send`/`recvLike` of the dispatched hidden + expert list, then of the combined partials (§3.2). The ring even handles the 2-node send/recv aliasing (left==right) explicitly (`recv`, ring.cpp ~561).
+
+If we ever need a true N-way all-to-all (>2 nodes): build it on the ring as `p-1` pairwise sends in a fixed schedule (each rank sends its destined chunk to each other rank in rotation), since the ring only allows **direct-neighbor** send/recv — for a non-neighbor you must **relay** around the ring (multi-hop), which for `p>2` is expensive and argues for `jaccl`/mesh instead. Out of scope for 2 nodes.
+
+**Bottom line for the 2-node target: no `ring.cpp` or C-API changes are required.** Everything is built from the existing wrapped `send`/`recvLike` + the existing sealed channels. The only optional Swift addition is an `allSum` wrapper for future `p>2`.
+
+---
+
+## 5. Changes to the Swift codebase
+
+Surgical, additive — keep `ClusterPipeline.swift` intact as the fallback.
+
+### 5.1 New file: `ClusterTensorParallel.swift` (alongside `ClusterPipeline.swift`)
+
+A new decode loop with the **same** public shape as `ClusterPipeline.generate` (so `ClusterServer` / `ClusterContext.makePipeline` can pick either). Differences from the pipeline loop:
+
+- **No head/tail asymmetry.** Both ranks embed (replicated), run every layer, and project to logits + sample. The per-token token `allGather` is kept only as a cheap consistency check (both ranks already sample identically).
+- The loop body calls a new shard method `runOwnedLayersTP(_:reduce:)` that, **at each all-reduce point inside each layer**, calls back into a closure provided by the loop. The closure does the sealed `send`+`recvLike`+add (§2.4). This keeps comms in ProviderCore (where the crypto lives) and compute in the fork.
+- Sketch (decode step):
+  ```swift
+  // both ranks; peer = 1 - plan.rank
+  var hidden = shard.embed(tokens: inputTokens)         // replicated
+  hidden = shard.runOwnedLayersTP(hidden) { partial, site in
+      // site e.g. "tp-attn-L17"; ctx binds it into AAD
+      let outCtx = ClusterFrameContext(clusterId: plan.clusterId, requestId: requestId,
+                                       layerRange: site, seq: nextSeq())
+      let sealed = try sealCh!.seal(ActivationCodec.encode(partial.asType(.bfloat16)), context: outCtx)
+      let dep = try group.send(toI32(sealed), to: peer); dep.eval()
+      let inCtx = ClusterFrameContext(clusterId: plan.clusterId, requestId: requestId,
+                                      layerRange: site, seq: peerSeq())
+      let cipher = try group.recvLike(MLXArray.zeros([sealedLen(width: 1)], dtype: .int32), from: peer)
+      let peerPartial = try ActivationCodec.decode(openCh!.open(toBytes(cipher), context: inCtx))
+      return partial + peerPartial            // reduced result, full hidden
+  }
+  let logits = shard.projectToLogits(hidden)            // replicated lm_head
+  let next = Int(argMax(logits, axis: -1).item())
+  ```
+- **Nonce discipline:** there is now **one `seal`+`open` pair per all-reduce site**, i.e. `2L` per token (TP) and `2L + 2L` (EP). The send channel counter and recv channel counter each advance once per pair, strictly monotonic — same invariant as today, just more frames. AAD `site` strings must be **unique per (layer, reduce-point, request)** and identical on both ranks; `seq` continues monotonically across the whole request. **Critical ordering rule (preserve the deadlock-free discipline):** both ranks must execute the seal/send/recv/open in the **exact same order** every step (mirror the comment at `ClusterPipeline.swift:5-12`). Because both ranks `send` then `recv` to the same peer, and the ring's per-direction sockets are ordered, the schedule must be: every rank `send`s its partial, then every rank `recv`s — never interleave two outstanding reduces.
+
+### 5.2 New file: `ClusterExpertParallel.swift` (gpt-oss only)
+
+Same loop skeleton as 5.1, but the per-layer callback handles both the **attention all-reduce** (identical to TP) and the **MoE dispatch/combine** (§3.2): two sealed send/recv pairs around the locally-owned expert compute. The router runs replicated; the callback receives the local expert outputs + the routing table and exchanges the remote pieces. AAD sites `"ep-attn-L{n}"`, `"ep-dispatch-L{n}"`, `"ep-combine-L{n}"`.
+
+### 5.3 `mlx-swift-lm` fork: shard adapters load **sliced** weights
+
+This is the largest change and lives in the fork (the adapters `GPTOSSShardAdapter.swift` / `LlamaShardAdapter.swift` just bridge to it).
+
+- **New shard variants** loaded with a *TP slice spec* instead of a contiguous `LayerInterval`:
+  - Dense (Llama/Mistral): each rank loads **all `L` layers** but only **half the heads** of `q/k/v/o_proj` and **half the rows/cols** of `gate/up/down`. New loader entry, e.g. `LlamaTPShardLoader.loadFromDirectory(dir, rank:, worldSize:)`, slicing weight tensors at load time (column-parallel for qkv/gate/up = row slice; row-parallel for o/down = column slice). KV cache holds only this rank's 16 heads.
+  - MoE (gpt-oss): each rank loads **all layers' attention** (TP-sliced as above) but only its **subset of experts** per layer (interleaved placement, §3.4). Router (`gate`) loaded **full** on both ranks.
+- **New protocol methods** on `PipelineModelShard` (or a sibling `TensorParallelShard` protocol so the pipeline path is untouched):
+  ```swift
+  // runs all layers; calls `reduce(partial, site)` at each all-reduce point,
+  // expecting the full reduced hidden back.
+  func runLayersTP(_ hidden: MLXArray, reduce: (MLXArray, String) throws -> MLXArray) rethrows -> MLXArray
+  ```
+  For MoE, the same method also calls back for dispatch/combine, OR add a parallel `runLayersEP(_:reduce:dispatch:combine:)`. The fork must expose the per-layer internals (sliced attention, sliced MLP / per-expert MLP) — this is the same kind of "expose a partial forward" change the pipeline path already required (see `PipelineModelShard.swift` header: "Implementing PipelineModelShard … requires a small addition in the mlx-swift-lm fork").
+- `embed` and `projectToLogits` become **replicated** (loaded on both ranks) in the TP/EP shards.
+
+### 5.4 `ClusterHeadBringup.swift`: new split strategy
+
+- Add a parallelism-mode selector (env or config): `pipeline` (default, current) vs `tensor` (dense) vs `expert` (MoE, auto-selected when `model_type == gpt_oss` AND mode == tensor/auto).
+- When TP/EP: **skip** `LayerPartition.partition` (no contiguous layer split). Instead compute the **head/expert split** by rank (heads split evenly; experts split memory-weighted/interleaved using the same all-gathered budget vector already collected at lines 109-118). Load the TP/EP shard variant (5.3) instead of the contiguous shard.
+- The X25519 session agreement (lines 137-155), `ClusterSession`, sealing/opening channels — **unchanged**; TP/EP reuse them verbatim (the directional keys still apply: rank0→rank1 is one key, rank1→rank0 the other). `makeChannels()` / `makePipeline()` gain a `makeTensorParallel()` / `makeExpertParallel()` sibling.
+- Gate TP/EP on link type: only enable when the transport is the low-latency local path (TB). Add a guard that refuses TP over a high-RTT link (or warns) — measure RTT at bringup via a few `send`/`recvLike` round trips and fall back to pipeline if RTT > threshold (~5 ms).
+
+### 5.5 `MLXDistributed.swift`: optional `allSum` wrapper
+
+Only needed for the future `p>2` / native-reduce path (§4). **Not required for the 2-node v1.** If added, document that it ships plaintext and is therefore gated behind a non-encrypted threat model.
+
+### 5.6 `ClusterServer.swift`: unchanged control round
+
+The control round (`exchangeRequest`, all_gather of the request descriptor) works identically — every rank still enters `generate` in lockstep. Only swap which loop object `pipeline` points at (pipeline vs TP vs EP). Keep the lockstep `all_gather` control round.
+
+### Summary of edits
+
+| File | Change |
+|---|---|
+| `Cluster/ClusterTensorParallel.swift` | **new** — dense TP decode loop |
+| `Cluster/ClusterExpertParallel.swift` | **new** — MoE EP decode loop |
+| `Cluster/ClusterHeadBringup.swift` | mode selector; head/expert split; load TP/EP shard; RTT gate |
+| `Cluster/LlamaShardAdapter.swift` / `GPTOSSShardAdapter.swift` | new `load(...rank,worldSize)` TP/EP entry; implement `runLayersTP`/`runLayersEP` bridge |
+| `Cluster/PipelineModelShard.swift` | add sibling `TensorParallelShard` protocol (don't touch the pipeline protocol) |
+| `Cluster/MLXDistributed.swift` | (optional, future) `allSum` wrapper |
+| `mlx-swift-lm` fork | sliced-weight loaders + per-layer reduce callbacks (the real work) |
+| `Cluster/ClusterServer.swift` | select loop by mode (minimal) |
+| `Cluster/ClusterPipeline.swift` | **unchanged** (fallback) |
+| `ring.cpp` / C API | **no change** for 2 nodes |
+
+---
+
+## 6. Phased rollout (2–3 weeks)
+
+### Phase 0 — instrumentation (day 1)
+- Reuse the `DARKBLOOM_PROFILE` phase timing already in `ClusterPipeline` (lines 72-149); add the same brackets to the new loops: `seal`, `send`, `recv`, `open`, `reduce_add`, `attn_compute`, `mlp_compute`, `expert_compute`. This is how we'll prove both GPUs are busy and where the `2L` collectives spend time.
+- Measure TB-IP RTT with a micro-bench of `send`/`recvLike` round trips.
+
+### Phase A — TP for DENSE models (Mistral), week 1
+1. Fork `mlx-swift-lm`: `LlamaTPShardLoader` that slices qkv/o (head split) and gate/up/down (intermediate split); replicate embed + lm_head; per-layer `runLayersTP(reduce:)` callback. Verify single-process `worldSize=1` slice = full model (degenerate reduce = identity).
+2. `ClusterTensorParallel.swift`: the loop in §5.1 with sealed send+recv+add as the reduce.
+3. `ClusterHeadBringup`: mode `tensor`, head split, RTT gate.
+4. **Correctness validation (the gate to ship):** run the SAME greedy prompt (temperature 0) through (a) single-node Mistral, (b) the current pipeline loop, (c) the new TP loop. **Assert token-for-token identical output** for ≥256 generated tokens across several prompts. TP is mathematically exact (same math, partitioned + summed), so any divergence is a bug (slice indexing, missing reduce, dtype). Add this as a `swift test` cluster test (2 in-process ranks if the ring supports loopback, else a 2-machine CI job).
+5. **Benchmark:** tok/s on Mistral-24b over TB vs the pipeline baseline; confirm >1.5x and both-GPU utilization from profiling. Use the existing `e2e` benchmark harness pattern (`docs/cluster-benchmark.md`).
+
+### Phase B — EP for MoE (gpt-oss), week 2–3
+1. Fork: `GPTOSSEPShardLoader` — TP attention (as Phase A) + per-expert MLP subset (interleaved placement) + replicated router. `runLayersEP(reduce:dispatch:combine:)`.
+2. `ClusterExpertParallel.swift`: attention all-reduce + MoE dispatch/combine, all sealed.
+3. **Correctness validation:** token-for-token vs single-node gpt-oss greedy, ≥256 tokens, several prompts. EP is also exact (router picks the same experts on both ranks; outputs summed). Validate the routing table is identical on both ranks (assert in a debug build).
+4. **Load-imbalance check:** log per-node expert-hit counts per step; confirm interleaved placement keeps it ~balanced; test a skewed prompt.
+5. **Benchmark:** tok/s vs pipeline baseline on gpt-oss-20b over TB; target the ~4x headroom called out in the motivation (from ~9–12 to ~30+ tok/s if comms latency cooperates).
+
+### Phase C — hardening (buffer)
+- RTT auto-gate + fallback to pipeline on Wi-Fi.
+- Batch-dim dispatch for EP (continuous batching alignment).
+- Run both Quality-Gate reviewers (codex + claude subagent) per CLAUDE.md on each phase's diff; `swift test` green.
+
+---
+
+## 7. Risks / open questions
+
+1. **CPU-stream collective cost (biggest risk — now MEASURED, confirmed).** All ring send/recv run on the CPU stream (`ring.cpp:471`), and each reduce crosses the GPU↔CPU boundary (the `MLXDistributed.swift` header notes MLX moves the tensor across that boundary at each hop). With `2L` reduces/token (80 for Mistral) we cross that boundary `~4L` times/token vs **once** today. The `comms-bench` harness measured this directly on 2× M4 over Thunderbolt: **83.35 ms/token, 1.04 ms/reduce, ~12 tok/s TP ceiling from comms latency alone** — so naive batch-1 TP is **latency-bound, no better than pipeline**. The two paths that actually help: **(a) TP + batching** (the comms floor is fixed per token-step regardless of batch size, so aggregate throughput scales — the same lever proven for continuous batching at ~2.5× across the 2-Mac cluster); **(b) get the collectives off the CPU stream** — either a GPU-stream transport or **RDMA/`jaccl`** (RDMA-over-Thunderbolt, macOS 26.2+). Note: `jaccl` is **NOT** blocked by the trust policy — the coordinator accepts RDMA-enabled providers (`api/provider.go:1184-1200`); it's simply not yet wired into our ring. JACCL's zero-copy OS-bypass transfer attacks exactly the GPU↔CPU↔socket round-trip that the 1.04 ms/reduce floor comes from, and is the most direct route to making batch-1 TP viable. Secondary mitigations: overlap independent reduces; keep activations bf16.
+
+2. **Encryption overhead, now `2N` collectives/token.** Each reduce = 1 seal + 1 open + 1 `ActivationCodec.encode` + 1 `decode`. ChaChaPoly on 10 KB is ~µs (fine), but `ActivationCodec.encode`/`decode` each **copy the tensor out of / into MLX** (`asData(access:.copy)`, MLXArray construction) — `~4L` extra host copies/token. Profile; if hot, add a fast path that reuses a pinned buffer per reduce site.
+
+3. **Nonce-space growth.** The monotonic 64-bit counter (`ClusterSealingChannel`) now advances `2L`/token instead of 1. At 80/token * say 4096 tokens/request = 327k frames/request — nowhere near `UInt64.max`, and channels are fresh per request (`makeChannels`). **No nonce-exhaustion risk**, but the AAD `layerRange`→`site` strings MUST be unique per reduce point or a frame from layer 17's attn reduce could be replayed into layer 18's; the design pins `seq` monotonic AND `site` per point, so both AAD and nonce differ. Keep both.
+
+4. **Deadlock discipline.** The pipeline loop's correctness rests on "every rank calls the collective in the same order, branching only around it" (`ClusterPipeline.swift:5-12`). TP/EP have `2L`–`4L` collectives/step; a single asymmetric ordering (one rank sends before the other recvs in a way that doesn't pair up) deadlocks the ring. The loop must enforce a rigid schedule: at each reduce point **both ranks `send` then both `recv`**, identical order, no early returns. This is the #1 implementation hazard.
+
+5. **EP load imbalance at batch=1.** Router may send all 4 experts to one node ⇒ the other idles for that layer. Interleaved placement reduces but doesn't eliminate it. The real fix is batched decode (§3.4). Open question: does the 2-node TP/EP path need to integrate with the existing `BatchedEngine` continuous-batching path, or run standalone? Recommend standalone for v1, batched in Phase C.
+
+6. **Does the 24 GB node hold its half of gpt-oss + KV?** gpt-oss-20b q8/MXFP4: experts ~300 MB/expert total (24 layers) → 14 experts ≈ 4.2 GB; attention (8-bit, half the heads) ≈ small; embed+lm_head replicated (8-bit, vocab not given for gpt-oss but ~200k? — **verify `vocab_size` in the gpt-oss config**, it wasn't in the head fields read). KV cache: 24 layers * 8 KV heads (4/rank after TP) * 64 head_dim * 2 (k+v) * 2 bytes * seq_len. At 4096 ctx: `24*4*64*2*2*4096 ≈ 100 MB/rank` — trivial. **mac-24 fits its half comfortably** (≈4–6 GB weights + <1 GB KV ≪ 24 GB). Note `GPU.set(memoryLimit: 0.80*physical)` (`ClusterHeadBringup.swift:97`) ⇒ ~19 GB usable on mac-24 — fine. **Open: confirm gpt-oss `vocab_size` and the replicated lm_head size; if huge, consider sharding lm_head column-parallel + an all-gather before sampling.**
+
+7. **`worldSize=1` / odd splits.** Heads divide by 2 for both models (32→16, 64→32). If a future model has an odd head count or the cluster grows to 3 nodes, the even-split assumption breaks — need padding or per-rank uneven head counts, and `p>2` needs real `all_sum`/all-to-all (§4 Option B). The 2-node design must assert `worldSize==2` and even divisibility at bringup and fall back to pipeline otherwise.
+
+8. **Wi-Fi fallback correctness.** The RTT gate must be reliable; a TP run that silently starts over Wi-Fi will be ~0.3 tok/s. Make the gate fail loud (log + fall back to pipeline), and surface the chosen mode in provider telemetry.

--- a/docs/architecture/clustering.md
+++ b/docs/architecture/clustering.md
@@ -1,0 +1,155 @@
+# Multi-Device Clustering — Design Proposal
+
+> **Status: PROPOSAL / not implemented.** This document describes a possible
+> future capability: serving a single model that is too large for any one Mac by
+> stitching it across a cluster of co-located Apple Silicon machines, inspired by
+> [exo](https://github.com/exo-explore/exo). Nothing here is built. It exists to
+> capture the design, the privacy analysis, and the integration map so the
+> feasibility spikes (see [the spike plan](../developer/clustering-spike-plan.md))
+> have a concrete target.
+
+## 1. Problem
+
+Darkbloom's hard ceiling today: **a model only runs if its weights fit in one
+Mac's unified memory.** There is no model sharding — the coordinator routes each
+request to a Mac large enough to hold the model
+(`ModelLoadAdmission.canLoad`, `provider-swift/Sources/ProviderCore/Inference/ModelLoadAdmission.swift:62-89`).
+The landing page's "MoE up to 239B params" is therefore only honest for the
+rare 512 GB Mac Studio. Aggregating RAM across machines would make frontier-scale
+models real on commodity hardware.
+
+## 2. What exo does (verified against source, `master` branch)
+
+exo's `master` is a ground-up rewrite (Rust Zenoh discovery/control + Python
+master/worker + Swift menubar). The relevant mechanisms:
+
+| Mechanism | Where | Note |
+|-----------|-------|------|
+| **Placement** = filter-and-rank over topology cycles | `src/exo/master/placement.py:106` | Memory is the **only** hard constraint (`filter_cycles_by_memory`, `placement_utils.py:21`). No real latency/bandwidth optimizer (`TODO: profile actual speeds`). |
+| **Layer split** = memory-weighted largest-remainder | `placement_utils.py:47` | Layers allocated ∝ `ram_available / total_ram`, min 1/node. |
+| **Pipeline parallelism** | `worker/engines/mlx/auto_parallel.py:132/158` | Each node owns a contiguous layer interval. Boundary data crossing the wire is **only the hidden-state activation tensor** via a ring `mx.distributed.send`/`recv_like`. **KV cache stays local to each rank.** Final token broadcast with `all_gather`. |
+| **Tensor parallelism** | `auto_parallel.py:456+` | Splits each layer; per-layer `all_sum`/`all_gather` collectives. Chatty — needs RDMA. Collectives live in MLX C++. |
+| **Transport** | `worker/engines/mlx/utils_mlx.py:90-143` | MLX-distributed `ring` (TCP, Thunderbolt-IP prioritized) or `jaccl` (RDMA over Thunderbolt 5). Configured purely via host-list JSON + env vars (`MLX_HOSTFILE`, `MLX_RANK`, `MLX_IBV_DEVICES`, `MLX_JACCL_COORDINATOR`). |
+| **Discovery** | `rust/networking/src/discovery.rs:18` | Custom IPv6 UDP multicast + Zenoh control plane. |
+| **Trust** | — | **None.** Zenoh = plain TCP no TLS/auth; ring/jaccl tensor traffic plaintext; `TRUST_REMOTE_CODE` set. Assumes one owner, physically TB-cabled, trusted LAN. |
+
+**Two facts dominate the rest of this design:**
+
+1. **Pipeline mode ships only the activation tensor** (~`hidden_size × 2` bytes
+   per token, ≈8 KB), not the KV cache. That is a small, well-defined payload we
+   can encrypt cheaply.
+2. **exo's stitching logic is Python-bound** (written against MLX's *Python* API +
+   mlx-lm Python model classes). The transport *config* is language-agnostic JSON +
+   env vars, and the collectives themselves live in **MLX C++** — which is exposed
+   through the **`mlx-c` C API** (`mlx_distributed_send/recv_like/all_gather/all_sum`,
+   `distributed_group.h`). `mlx-swift` does **not** wrap them yet.
+
+## 3. The three gating questions
+
+### ① Privacy — the gate
+
+exo assumes a *trusted* co-located cluster; Darkbloom assumes *operator-blind*.
+**Physical co-location is NOT sufficient for Darkbloom**, because in a cluster the
+operator owns *every* Mac and could tap the inter-node link. Hidden-state
+activations are approximately invertible to prompt text, so plaintext activation
+transfer breaks the brand promise outright.
+
+**This is securable precisely because pipeline mode ships only the activation
+tensor.** Wrap the ring `send`/`recv` in pairwise **NaCl Box** channels keyed by
+each node's **Secure Enclave** X25519 key, established after mutual attestation,
+sealed/opened *inside the hardened process*. The operator with root still cannot
+read: the key never leaves the SE and Hardened Runtime blocks memory inspection —
+the same guarantee Darkbloom already makes per-node, extended to the link.
+Per-token NaCl sealing of an 8 KB tensor is microseconds. **Tensor parallelism is
+much harder to secure** (collectives buried in MLX C++), so the secure design is
+**pipeline-only**.
+
+### ② Engine
+
+Darkbloom is Swift `mlx-swift-lm`, in-process; exo's stitching is Python. You
+**cannot** import exo.
+
+- **Path (a): embed exo's Python worker as a subprocess.** Rejected — reintroduces
+  the IPC surface Darkbloom deliberately engineered out (`README` "no subprocess,
+  no local server, no IPC to tap"), and exo's transport is plaintext, failing ①.
+- **Path (b): reimplement pipeline parallelism in Swift** against `mlx-swift`,
+  reusing exo's *design* (memory-weighted layer split, ring send/recv, host-list +
+  env config) but not its code. More work, but the **only** path that preserves
+  the privacy guarantee — and since we own the send/recv wrapper, it is exactly
+  where the attested encryption from ① is injected. **The two requirements point
+  to the same architecture.**
+
+  **Feasibility (verified):** the primitives Path (b) needs already exist in MLX
+  C++ and in the `mlx-c` C API (`mlx_distributed_send`, `recv_like`, `all_gather`,
+  `all_sum`, `mlx_distributed_init`, `mlx_distributed_group`). They are simply
+  **unwrapped in `mlx-swift`**. So Spike A is *"write a Swift binding over an
+  existing C API"*, **not** *"modify MLX C++"* — a materially smaller and safer
+  scope.
+
+### ③ Topology
+
+exo's good numbers need TB5 RDMA full-mesh. Darkbloom providers are WAN Macs on
+outbound WebSockets; per-token pipeline hops over WAN would tank TPS. Therefore
+clustering is a **new provider tier**, not arbitrary fleet stitching.
+
+## 4. Proposed architecture: the "cluster provider" tier
+
+A single operator's **co-located, Thunderbolt-cabled, individually-attested** Mac
+cluster registers as **one logical large-capacity provider**. The coordinator sees
+one endpoint advertising aggregate RAM; existing routing/billing/capacity logic
+largely carries over. Internally the cluster runs **Swift-native pipeline
+parallelism with attested NaCl-encrypted activation links.**
+
+```
+        Consumer (OpenAI/Anthropic SDK)
+                  │  TLS (+ optional NaCl Box)
+                  ▼
+   Coordinator (Go, Confidential VM)
+     · sees ONE provider = the cluster
+     · seals request to the cluster HEAD node's attested X25519 key
+                  │  WebSocket (outbound from head node)
+                  ▼
+   ┌─────────────── Cluster (one operator, TB-cabled) ───────────────┐
+   │  HEAD node (rank 0)          rank 1            rank 2            │
+   │  · decrypts request          · layers L1       · layers L2..    │
+   │  · layers L0                 ·                  ·                │
+   │      │ activation tensor      │                 │               │
+   │      └─── NaCl Box (SE-keyed) ┴── NaCl Box ──────┘  (ring)       │
+   │  Every node: Secure Enclave attested, Hardened Runtime,         │
+   │  PT_DENY_ATTACH. Inter-node link encrypted to attested keys.    │
+   └──────────────────────────────────────────────────────────────────┘
+```
+
+Trust rule: **cluster trust = min(member trust)** — one un-attested member taints
+the whole cluster, and it is not admitted for private traffic.
+
+## 5. Integration map (verified file:line touchpoints)
+
+The codebase already has the right seams. Each row is single-machine today; the
+"change" column is the cluster extension.
+
+| Area | Current (file:line) | Single-machine assumption | Change |
+|------|---------------------|---------------------------|--------|
+| **Load gate** | `ModelLoadAdmission.swift:42-89` (`freeForLoadGb`, `canLoad`) | `totalBytes`/free memory are local | Aggregate across members; gate on cluster-sum free memory. |
+| **KV budget** | `Inference/GlobalKVCacheBudget.swift` | `ProcessInfo.physicalMemory` local | Per-node budgets stay local (KV is local in pipeline mode) — no change to the math, only to where it is reported. |
+| **Capacity report** | `BackendCapacity`/slots, `Protocol/Types.swift` | 1 slot ≈ 1 machine | N member slots aggregated into one logical `BackendCapacity`. |
+| **Engine binding** | `BatchScheduler` owns one `BatchedEngine` (single field); `InferenceFoundation/LocalMLXModelFoundation.swift` | Hardcoded in-process MLX | Introduce an `InferenceEngine` protocol; add a `DistributedInferenceEngine` conformer. `BatchedEngine` already satisfies it with a thin wrapper. |
+| **Protocol** | `provider-swift/.../Protocol/Messages.swift` ↔ `coordinator/protocol/messages.go` | One register / one heartbeat / one Hardware | Add cluster bootstrap + per-member heartbeat messages. **Must stay mirrored** (repo's #1 sync rule). |
+| **Routing** | `coordinator/registry/registry.go` (`Provider` 1:1 with a socket, `freeMemoryAdmits`, `snapshotProviderLocked`); `scheduler.go` | Provider == one machine | Cluster abstraction: aggregate capacity for admission, pick a member internally, fail over within the cluster. |
+| **Attestation** | `provider-swift/.../Security/AttestationBuilder.swift`, `SecureEnclaveIdentity.swift`; `coordinator/attestation/`; `GET /v1/providers/attestation` | One SE key per provider | Per-member chain; verify each independently; cluster trust = min(member). |
+| **E2E decryption** | `ProviderLoop.swift` decrypt path, `ProviderLoop+InboundDecode.swift`, `Crypto/X25519ChaChaPoly.swift`, `Crypto/NodeKeyPair.swift` | Plaintext stays in one process | Head node decrypts request; activation tensors crossing nodes are re-sealed to each member's attested SE key (new pairwise channel). |
+
+## 6. Scope guardrails
+
+- **Pipeline parallelism only** at first. Tensor parallelism is a later,
+  separately-justified step (harder to secure, needs RDMA).
+- **Co-located clusters only.** No WAN stitching. Enforced by an explicit
+  cluster trust-model field, not by hope.
+- **Surgical, seam-based changes.** Reuse existing routing/billing/capacity; add a
+  cluster layer, do not rewrite the provider model.
+
+## 7. Next step
+
+Two independent de-risking spikes — see
+[`docs/developer/clustering-spike-plan.md`](../developer/clustering-spike-plan.md).
+Coordinator/protocol work begins only if both pass.

--- a/docs/architecture/jaccl-rdma-readiness.md
+++ b/docs/architecture/jaccl-rdma-readiness.md
@@ -1,0 +1,124 @@
+# JACCL (RDMA-over-Thunderbolt) — Readiness & Enablement Hand-off
+
+**Status: BLOCKED on this hardware pair (TB4 base M4).** Update (verified
+2026-06): RDMA was enabled on both Macs (`rdma_ctl enable` from Recovery OS,
+`status` = enabled on both), but **only the M4 Pro exposes RDMA devices; the base
+M4 exposes zero**, because Apple's Thunderbolt RDMA requires **TB5** and the base
+M4 only has TB4. JACCL needs RDMA devices on *both* ends, so it cannot run on the
+M4 + M4 Pro pair. See "Hardware finding" below. The software side remains ready —
+a pair of TB5 machines (M4 Pro/Max or better, both ends) would work.
+
+## Hardware finding (the real blocker)
+
+| Node | Chip | Thunderbolt | `rdma_ctl status` | RDMA devices (`ibv_get_device_list`) |
+|------|------|-------------|-------------------|--------------------------------------|
+| mac-24 | M4 **Pro** | **TB5** (up to 120 Gb/s) | enabled | **3** (`rdma_en1/2/3`) |
+| mac-32 | M4 (base) | **TB4** (up to 40 Gb/s) | enabled | **0** |
+
+Both were rebooted after enabling; the asymmetry persists. The base M4's TB4
+controller has no RDMA device for `librdma` to bind to — `rdma_ctl` flips the
+persistent setting but there is no TB5 hardware to attach to.
+
+**Confirmed by the primary source** — MLX distributed docs
+(https://ml-explore.github.io/mlx/build/html/usage/distributed.html):
+> "Starting from macOS 26.2, RDMA over thunderbolt is available and enables
+> low-latency communication between Macs with **thunderbolt 5**."
+
+The same page notes RDMA must be enabled in recovery mode ("cannot be done
+remotely even with sudo"), verified via `ibv_devices` listing `rdma_enX`, and
+that JACCL requires a fully-connected (direct TB cable) topology. Our empirical
+result (M4 Pro/TB5 → 3 devices; base M4/TB4 → 0) matches the doc exactly.
+
+**Conclusion: JACCL is a TB5-on-both-ends feature; not viable on the M4 + M4 Pro
+pair (base M4 is TB4).** The TCP ring (what we benchmarked) remains the only
+cross-machine transport here. Two TB5 Macs (e.g. M3 Ultra per the doc's example,
+or M4 Pro/Max on both ends) would unlock it.
+
+---
+
+(Original readiness notes below — software prerequisites are all met; only the
+TB5 hardware requirement is unsatisfied on the base M4.)
+
+## Why JACCL matters
+
+The tensor-parallelism comms floor we measured (`comms-bench`: **83.35 ms/token,
+1.04 ms/reduce, ~12 tok/s TP ceiling** on 2× M4 over Thunderbolt-IP) is dominated
+by the **CPU-stream collectives + GPU↔CPU↔socket round-trip** — the ring backend
+forces `Device::cpu` (`ring.cpp:471`) and copies the tensor across the GPU↔CPU
+boundary every hop. JACCL is RDMA-over-Thunderbolt: zero-copy, OS-bypass transfer
+that attacks exactly that round-trip. It is the most direct route to making
+batch-1 tensor parallelism viable (vs. only winning on batched throughput).
+
+It is **not** blocked by the trust policy — the coordinator accepts
+`rdma_disabled: false` providers under a registered-buffer RDMA policy
+(`api/provider.go:1184-1200`); the security boundary is the signed runtime's
+IOMMU buffer-registration discipline, not a blanket ban.
+
+## Verified prerequisites (all ✅ except the last)
+
+| Prerequisite | Status | How verified |
+|---|---|---|
+| macOS 26.2+ (JACCL min) | ✅ 26.5.1 | `sw_vers` on mac-24 |
+| TB5 hardware + `rdma_ctl` | ✅ | `/usr/bin/rdma_ctl` present (root-owned); `system_profiler SPThunderboltDataType` shows "Up to 120 Gb/s" |
+| `librdma.dylib` loadable | ✅ | `dlopen("librdma.dylib", RTLD_NOW)` succeeds (probe) |
+| JACCL backend compiled into fork | ✅ | `libs/mlx-swift/Package.swift:199-200` excludes the `no_jaccl.cpp` stub and builds the real `jaccl.cpp`; `distributed.cpp:105-123` wires `is_available("jaccl")` |
+| `MLXDistributedBackend.jaccl` exists | ✅ | `provider-swift/.../Cluster/MLXDistributed.swift:42` |
+| Trust policy permits RDMA | ✅ | `coordinator/api/provider.go:1184-1200` (accepts + logs, only requires reporting) |
+| **RDMA actually enabled** | ❌ **gated** | `rdma_ctl status` → `disabled`; `rdma_ctl enable` → *"This tool needs to be executed from Recovery OS."*; `ibv_get_device_list` returns **0 devices** while disabled |
+
+## The blocker: enable RDMA from Recovery OS (both Macs)
+
+`rdma_ctl enable` refuses to run from normal macOS — it must run in Recovery OS
+(this ties to the MDM `MDMRecoveryLocked` check, `mdm/mdm.go:245`: Recovery Lock
+blocks `rdma_ctl enable`). Steps, on **each** node:
+
+1. Shut down. Apple Silicon: hold the power button until "Loading startup options"
+   → **Options** → Continue (Recovery OS).
+2. Utilities → Terminal: `rdma_ctl enable`
+3. Reboot to macOS. Verify: `rdma_ctl status` → `enabled`, and the `ibv_get_device_list`
+   probe returns ≥1 device.
+
+Both Macs must have RDMA enabled, and the **direct Thunderbolt cable** must show a
+linked device (`system_profiler SPThunderboltDataType` should show a connected
+device, not "No device connected" as it did during this session).
+
+## What's left to wire (once RDMA is enabled)
+
+JACCL init reads three env vars (`jaccl.cpp:131-141`) instead of the ring's
+hostfile:
+- `MLX_RANK` — this node's rank (already derived from config member order)
+- `MLX_JACCL_COORDINATOR` — `ip:port` of the rank-0 coordinator socket
+- `MLX_IBV_DEVICES` — a JSON **device connectivity file**: an array-of-arrays
+  giving, for each rank, the RDMA device name(s) to reach every other rank
+  (`DeviceFile`, `jaccl.cpp:18-58`). Device names come from `ibv_get_device_list`
+  once RDMA is enabled.
+
+Implementation sketch (mirrors `MLXRingEnvironment`):
+1. Add `MLXJacclEnvironment.materialize(plan:)` that writes the device file +
+   returns `{MLX_RANK, MLX_JACCL_COORDINATOR, MLX_IBV_DEVICES}`.
+2. In `ClusterHeadBringup.bringUp`, branch on `plan.backend`: `.ring` →
+   existing path; `.jaccl` → the new env, then `MLXDistributedGroup.initialize(backend: .jaccl)`.
+3. Set `backend = "jaccl"` in both nodes' `[cluster]` config.
+4. The decode loops (`ClusterPipeline`, `ClusterBatchPipeline`, the batched
+   scheduler/server) are transport-agnostic — they call `group.send/recvLike/
+   allGather`, which dispatch on the initialized backend. **No decode-loop
+   changes needed.** The one thing to check: whether JACCL collectives run off
+   the CPU stream (the whole point) — confirm `communication_stream` for jaccl
+   does not force `Device::cpu`. If it still does, the GPU↔CPU round-trip
+   remains and the win is smaller; measure with `comms-bench` first.
+
+## Validation plan (when enabled)
+
+1. Re-run `comms-bench 5120 40 64` over JACCL vs the ring baseline (83 ms/token).
+   Target: per-reduce well under 1 ms and a TP ceiling far above ~12 tok/s.
+2. If the floor drops enough, build the tensor-parallel decode path
+   (`docs/architecture/cluster-tensor-expert-parallel.md`) — JACCL is the
+   transport that makes batch-1 TP worth doing.
+
+## Session note
+
+Probed on mac-24 (M4 Pro, macOS 26.5.1, TB5). `librdma.dylib` loads but
+`ibv_get_device_list` → 0 devices because `rdma_ctl status` = disabled. TB buses
+showed "No device connected" during the session (the 169.254 link we used for the
+ring is Thunderbolt-IP/bridge networking, a different layer than the raw TB device
+link RDMA needs). Parking here until the Recovery-OS enable is done on both Macs.

--- a/docs/cluster-benchmark.md
+++ b/docs/cluster-benchmark.md
@@ -1,0 +1,344 @@
+# Cluster Inference Benchmark — Wi-Fi vs Thunderbolt
+
+Measured throughput for Darkbloom's pipeline-parallel cluster mode running a
+single model sharded across two Apple Silicon Macs, comparing the inter-node
+ring transport over Wi-Fi vs a direct Thunderbolt link.
+
+> **Scope.** These are batch=1, greedy-decode numbers — the per-token latency a
+> single user sees. They are *not* aggregate-throughput numbers (batching is the
+> separate, larger lever — see [What this does *not* measure](#what-this-does-not-measure)).
+
+## Results
+
+| Model | Wi-Fi | Thunderbolt | TB speedup |
+|---------------------|-----------|------------|------------|
+| Mistral-24B (dense) | 3.7 tok/s | 4.6 tok/s  | **+24%**   |
+| GPT-OSS-20B (MoE)   | 9.0 tok/s | 12.3 tok/s | **+37%**   |
+
+*Decode throughput, batch=1, greedy. Warm steady-state (first run discarded),
+96–128 token generations, identical prompt per model. Compute-controlled via
+per-phase profiling — the GPU-compute phase (`owned_layers`) was confirmed equal
+across transports, so the delta is attributable to the ring transport.*
+
+### ⚠️ Single-node baseline — pipeline parallelism is *slower* for a model that fits
+
+GPT-OSS-20B-q8 fits comfortably on one 32 GB Mac. Running it single-node
+(`solo-bench`, same prompt, same M4 head) gives **~30 tok/s** — far above either
+clustered number:
+
+| GPT-OSS-20B configuration | Decode tok/s | vs single-node |
+|----------------------------|-----------|----------------|
+| **Single node (mac-32 alone)** | **~30.0** | baseline |
+| Cluster, Thunderbolt           | 12.3      | **2.4× slower** |
+| Cluster, Wi-Fi                 | 9.0       | **3.3× slower** |
+
+This is the headline finding, and it is *expected*: at batch=1, pipeline
+parallelism runs the two GPUs **sequentially** (one idle while the other
+computes) and adds a network hop + pipeline bubble on top. Total compute is
+unchanged, so splitting a model that already fits is pure overhead — you add a
+machine and get *negative* return.
+
+**Pipeline parallelism only earns its keep on models too big to fit on one node**
+(e.g. Mistral-24B bf16 ~48 GB, Llama-70B ~40 GB), where the single-node
+alternative is "won't load." For co-located machines and models that fit, the
+right strategy is **tensor / expert parallelism** (both GPUs compute every
+token), which can *beat* single-node — pipeline structurally cannot. See
+[cluster-tensor-expert-parallel.md](architecture/cluster-tensor-expert-parallel.md).
+
+## Hardware Setup
+
+| Node     | Role          | Machine  | Chip         | RAM   |
+|----------|---------------|----------|--------------|-------|
+| `mac-32` | head (rank 0) | Mac16,12 | Apple M4     | 32 GB |
+| `mac-24` | tail (rank 1) | Mac16,8  | Apple M4 Pro | 24 GB |
+
+- **Total cluster memory:** 56 GB unified
+- **Ring (inter-node activation link):**
+  - Wi-Fi — `192.168.1.x`, ~42 ms RTT
+  - Thunderbolt — direct link-local `169.254.x` (mac-32 `en3` ↔ mac-24 `en9`), ~1 ms RTT
+- **Coordinator link:** Wi-Fi in both cases. The coordinator carries only control
+  messages and encrypted response chunks — *no per-token activations* — so it is
+  deliberately left on Wi-Fi and does not affect the ring benchmark.
+- **Activation encryption:** every hidden-state hop crosses the wire as
+  X25519 + ChaCha20-Poly1305 AEAD ciphertext over TCP, on both transports.
+
+## Memory-Weighted Layer Split
+
+Layers are partitioned proportionally to each node's available budget
+(`RAM − 10 GB` reserved per node), so the 32 GB head carries the larger share.
+Weight ratio **22 : 14** (head : tail).
+
+| Model              | Total layers | head (`mac-32`, 32 GB) | tail (`mac-24`, 24 GB) |
+|--------------------|:------------:|:----------------------:|:----------------------:|
+| Mistral-24B-8bit (dense) | 40     | 24 layers              | 16 layers              |
+| GPT-OSS-20B-q8 (MoE)     | 24     | 15 layers              | 9 layers               |
+
+## Why Thunderbolt helps MoE more than dense
+
+Note (refined by the per-op trace below): the per-token wait the transport affects
+is **round-trip latency on the blocked recv/allgather steps**, not raw data
+transfer — the trace shows the actual hop is ~0.03 ms of transfer. Higher-latency
+Wi-Fi inflates how long each rank sits blocked waiting for the round-trip to
+*complete*; Thunderbolt's lower latency shrinks that wait. That latency cost is
+roughly **fixed per token** regardless of model. A Mixture-of-Experts model does
+**less compute per token** (only top-k experts fire), so the fixed wait is a
+*larger fraction* of its shorter token, which is why moving from Wi-Fi to TB helped
+MoE more (+37%) than the dense model (+24%).
+
+**Takeaway:** as inference gets more compute-efficient (MoE, smaller or
+more-quantized models), the per-token wait — and thus interconnect latency —
+matters *more*, not less.
+
+## Per-Token Trace (the bottleneck, fully decomposed)
+
+Full per-operation tracing (`DARKBLOOM_TRACE=1`), steady-state decode, **llama-8b**,
+2-rank pipeline. Every primitive is force-eval'd before its timer closes, so each
+number is that op's real cost (MLX laziness can't smear compute into a later
+barrier). Both ranks traced; the per-token critical path is reconstructed by
+reading head + tail together.
+
+### Single-GPU baseline (no cluster, whole model, `solo-bench`)
+
+| Machine | tok/s | ms/token | notes |
+|---------|-------|----------|-------|
+| M4 Pro (mac-24) | ~48 | **20.8** | whole model, GPU saturated, **no bubble** |
+| base M4 (mac-32) | ~22 | **44.8** | whole model |
+
+**Why the M4 Pro is ~2× the base M4 (it's memory bandwidth, not cores).** Decode
+is memory-bandwidth-bound — each token streams the active weight set from memory —
+so decode tok/s tracks bandwidth, not GPU-core count:
+
+| | GPU cores | mem bandwidth | bus | measured llama-8b |
+|---|---|---|---|---|
+| base M4 (mac-32) | 10 | ~120 GB/s | 128-bit | 22 tok/s |
+| M4 Pro (mac-24) | 16 | ~273 GB/s | 256-bit | 48 tok/s |
+
+The **measured** speed ratio (48/22 = **2.18×**) matches the **bandwidth** ratio
+(273/120 = **2.28×**) almost exactly — and is far above the GPU-core ratio (1.6×).
+That's the direct proof decode is bandwidth-bound: the win tracks the wider memory
+bus (the M4 Pro is a wider die: 256-bit vs 128-bit, double the LPDDR channels),
+not the extra cores (those help prefill, which is compute-bound). Consequence for
+the cluster: our memory-weighted split loads **more layers onto the 32 GB base M4**
+(for KV-cache headroom), i.e. onto the *bandwidth-poorer* chip — good for fitting,
+bad for latency. See the bandwidth-weighted-split item in the perf backlog.
+
+### Localhost 2-rank trace (both ranks on M4 Pro, one GPU) — freshly verified
+
+A contrived config (two `cluster-provider` processes sharing one M4 Pro GPU over
+a 127.0.0.1 ring) used to isolate the *non-network* costs cleanly. **29.3 ms/token.**
+Per-step averages over 63 decode steps, with what executes each:
+
+| Step (execution order) | Process | ms | Type |
+|------------------------|---------|----|------|
+| embed | head | 0.20 | GPU |
+| layers_compute (head's 16 layers) | head | 11.11 | GPU |
+| codec_encode + aead_seal + to_i32 | head | 0.21 | CPU |
+| send_hop | head | 0.09 | network (loopback) |
+| recv_wait (blocked on head) | tail | 11.84 | idle (overlaps head GPU) |
+| to_bytes + aead_open + codec_decode | tail | 0.05 | CPU |
+| layers_compute (tail's 16 layers) | tail | 14.91 | GPU |
+| logits_compute (norm+lm_head+argMax) | tail | 2.31 | GPU |
+| allgather (token back to head) | head/tail | 17.49 / 0.16 | network + idle |
+| readback | both | 0.01 | CPU |
+
+Critical path (the steps that serialize into the token): embed 0.2 + head layers
+11.1 + (CPU+send 0.3) + tail layers 14.9 + logits 2.3 + token-gather 0.2 ≈ **29 ms**.
+`recv_wait` (tail) and the head's 17 ms `allgather` are **idle waiting**, not work —
+each rank blocked on the other; they overlap the other rank's GPU compute and do
+**not** add to the total. **GPU ≈ 28.5 ms (97%), CPU ≈ 0.3 ms (1%), network ≈ 0.3 ms (1%).**
+
+### Cross-Mac cluster (head = base M4, tail = M4 Pro, over Thunderbolt) — verified
+
+**44.2 ms/token (~22.6 tok/s).** Per-step averages over 63 decode steps, labeled
+logs, re-confirmed (matches an earlier run's 43.6 ms within noise):
+
+| Rank | Phase | ms | % of step | Type |
+|------|-------|----|-----------|------|
+| HEAD (base M4) | `layers_compute` | 28.03 | 63% | GPU (head's 16 layers) |
+| HEAD | `allgather` | 15.22 | 34% | **idle** — waiting for tail's token |
+| HEAD | embed + codec_encode + aead_seal + to_i32 + send_hop | ~0.94 | 2% | CPU + network |
+| TAIL (M4 Pro) | `recv_wait` | 30.52 | 69% | **idle** — waiting for head's activation |
+| TAIL | `layers_compute` | 11.35 | 26% | GPU (tail's 16 layers) |
+| TAIL | `logits_compute` | 2.28 | 5% | GPU (norm+lm_head+argMax) |
+| TAIL | aead_open + to_bytes + codec_decode + allgather | ~0.12 | 0.3% | CPU |
+
+`send_hop` (the actual Thunderbolt transfer) = **0.02 ms**.
+
+### Second model — GPT-OSS-20B (MoE), same cross-Mac rig — verified
+
+**37.3 ms/token (~26.8 tok/s)** — faster than llama-8b (44.2) because MoE fires
+only the top-4 of 32 experts → less GPU compute per token. Same structure, shifted
+proportions:
+
+| Rank | Phase | ms | % | Type |
+|------|-------|----|---|------|
+| HEAD (base M4) | `layers_compute` | 24.14 | 65% | GPU |
+| HEAD | `allgather` | 11.71 | 31% | **idle** |
+| HEAD | embed + codec + seal + send | ~1.4 | 4% | CPU+net |
+| TAIL (M4 Pro) | `recv_wait` | 26.88 | 72% | **idle** |
+| TAIL | `layers_compute` | 6.68 | 18% | GPU (MoE — lighter) |
+| TAIL | `logits_compute` | 3.66 | 10% | GPU (201k vocab — heavier than llama's 128k) |
+| TAIL | crypto+codec+allgather | ~0.10 | 0.3% | CPU |
+
+`send_hop` = **0.03 ms** (same as llama — network is ~nothing regardless of model).
+
+**Cross-model correlation (the point):** the structural findings hold on both — bubble
+dominates (GPU ~92–94%), crypto/network negligible (~0.1%), cluster ≈ slowest node.
+The proportions shift exactly as predicted: MoE's lighter compute makes the *fixed*
+~0.3 ms overhead a slightly larger fraction (8% vs 6%) — the same mechanism behind
+"Thunderbolt helped MoE more" above. GPT-OSS's bigger vocab also shows up as a
+heavier `logits_compute` (3.7 vs 2.3 ms). The trace explains both.
+
+### What the trace proves (measured, not inferred)
+
+1. **The bottleneck is the pipeline bubble — ~95% of the token is sequential GPU
+   compute that never overlaps.** Head computes 28.0 ms (tail idle, shown as its
+   30.5 ms `recv_wait`); then tail computes 11.4 + 2.3 ms (head idle, shown as its
+   15.2 ms `allgather`). Critical path ≈ 28.0 + 11.4 + 2.3 + ~1 ≈ 44.2 ms.
+2. **Overhead is provably negligible.** Crypto (aead_seal + aead_open) = **0.04 ms**;
+   serialization (to_bytes/to_i32/codec) ≈ **0.3 ms**; the actual Thunderbolt hop
+   (`send_hop`) = **0.03 ms**. Total ~1 ms (≈2%). Crypto, serialization, and the
+   network are *not* the cost.
+3. **The network is ~0.1% of a token.** `send_hop` is 0.03 ms even over real
+   Thunderbolt — confirming a faster transport (incl. RDMA) would do ~nothing for
+   the pipeline path. (Contrast tensor parallelism, which is the opposite: ~all
+   comms — see the TP comms-floor section.)
+4. **Cluster ≈ slowest GPU alone.** Cross-Mac 44.2 ms ≈ base-M4-alone 44.8 ms, and
+   **2× slower** than M4-Pro-alone (20.8 ms). The split bought nothing for latency:
+   the work is serial (bubble) and the slow base-M4 head dominates the critical
+   path (28 of 44.2 ms). A single GPU has no bubble — it streams the whole model as
+   one saturated, uninterrupted graph.
+
+(An earlier coarse profile reported a single `recv_hop` ~25–75 ms lumping
+idle-wait + transit; the fine-grained trace above separates them and confirms the
+transit slice is ~0.03 ms — the wait is the bubble.)
+
+## What this does *not* measure
+
+- **Single-node baseline.** At batch=1, pipeline parallelism runs the two GPUs
+  *sequentially* — total compute is unchanged, and clustering adds the network hop
+  + pipeline bubble on top. So for a model that fits on one node, single-node is
+  *faster* than clustered. Clustering's value is fitting models that do **not**
+  fit on one node (e.g. Mistral-24B bf16 ~48 GB, Llama-70B ~40 GB), where the
+  single-node alternative is "won't load." Thunderbolt clustering nearly recovers
+  single-node speed while unlocking those larger models.
+- **Batched throughput.** These are single-stream latencies. The larger speed
+  lever is **batching / continuous batching** — serving multiple requests so both
+  GPUs stay busy and the pipeline bubble fills, approaching ~2× aggregate
+  throughput. That is orthogonal to the transport comparison here.
+
+## Continuous batching — the throughput win (validated)
+
+Path A (continuous batching) is implemented and validated on a real 2-rank ring
+(`[cluster].batched = true`). Concurrent requests are admitted into one batched
+`[B, hidden]` forward pass; decode is bandwidth-bound, so B requests cost ~one
+request's per-step weight streaming.
+
+Two configurations measured (llama-8b, 4 requests × 64 tokens):
+
+| Setup | Serial tok/s | Batched B=4 tok/s | Speedup |
+|-------|-------------|-------------------|---------|
+| Single machine, 2-rank localhost ring (M4 Pro) | 26.8 | 50.2 | ~1.9× |
+| **Two Macs (mac-32 + mac-24) over Thunderbolt** | **13.6** | **34.1** | **~2.5×** |
+
+**Validated end-to-end across two physical Macs over Thunderbolt.** Continuous
+batching ran with the head on mac-32 (M4, 32 GB) and the peer on mac-24
+(M4 Pro, 24 GB), activations crossing the real TB link. Multiple full
+drain-and-readmit cycles held (3 rounds × 3 concurrent + 4-way batches, each
+returning distinct correct text, both nodes stable). The cross-Mac *relative*
+win is larger (~2.5×) because each request pays the real inter-node hop per
+token, which batching amortizes across the batch.
+
+Two bugs were found and fixed on hardware: an AEAD nonce desync between the
+admit and decode rounds, and an empty-batch filter crash on full drain. See
+`ClusterBatchScheduler` / `ClusterBatchServer` / `ClusterBatchControl`.
+
+> Cross-Mac run used localhost SSH tunnels over the Thunderbolt link (`-L`/`-R`
+> forwards, all ring + coordinator endpoints on 127.0.0.1). This carries the
+> traffic across the real TB wire while keeping every connection loopback-local,
+> which also sidesteps macOS Local Network Privacy blocking the ad-hoc-signed
+> binary's direct cross-machine connects. A stably code-signed binary would
+> allow direct (untunneled) cross-machine ring connections.
+
+## Where the slowdown comes from — loop overhead vs distribution
+
+To separate "the cluster decode loop is unoptimized" from "distribution is
+fundamentally costly," we ran the cluster's exact loop discipline (manual
+`argMax`, `evalEvery: 4`, the per-step `.eval()` barriers) on a **single
+machine with no network** (`loop-diag`), against MLX's native `generate`
+(`solo-bench`). GPT-OSS-20B on the M4 Pro:
+
+| Path | Decode tok/s | What it isolates |
+|------|-----------|------------------|
+| `solo-bench` (MLX native generate) | ~57 | single-node ceiling |
+| `loop-diag` (cluster loop, 1 node, **no network**) | ~51 | **loop overhead only** |
+| Cluster, Thunderbolt (2 nodes) | 12.3 | loop + network + pipeline bubble |
+| Cluster, Wi-Fi (2 nodes) | 9.0 | loop + worse bubble |
+
+**The cluster loop costs only ~10% (57 → 51).** The remaining ~4× (51 → 12) is
+*distribution* — the network hop and the sequential-GPU pipeline bubble — not
+code quality. **Making the cluster loop byte-identical to single-node cannot
+close the gap; the degradation is structural to pipeline parallelism.**
+
+## Can tensor parallelism fix it? — the comms-floor measurement
+
+Pipeline runs the two GPUs sequentially. Tensor parallelism (TP) instead has
+*both* GPUs compute every token in parallel, exchanging partials via an
+all-reduce after attention-out and after the MLP down-projection — ~`2 × layers`
+all-reduces per token. The question is whether that comms cost is small enough
+for TP to approach (or beat) single-node.
+
+`comms-bench` measures it directly: it joins the same ring and times
+`2 × layers` all-reduce-sized collectives per token. Mistral dimensions
+(hidden=5120, 40 layers → 80 reduces/token), 2× M4 over **Thunderbolt**:
+
+```
+83.35 ms/token comms floor · 1.042 ms/reduce · 80 reduces · TP ceiling ≈ 12 tok/s
+```
+
+**Finding: naive TP at batch=1 is latency-bound at ~12 tok/s — no better than
+pipeline, ~4× below single-node.** Each all-reduce costs ~1 ms (mostly latency:
+the CPU-stream GPU↔CPU crossing + `.eval()` barrier, not the ~20 KB payload),
+and the 80 reduces are strictly sequential (layer N+1 can't start before layer
+N's reduce returns). Faster GPUs cannot help — the token is bound on the wire.
+
+**The two paths that *do* help (and should gate the TP roadmap):**
+
+1. **TP + batching.** The ~83 ms comms floor is *fixed per token-step regardless
+   of batch size* (payload barely grows). At batch=B you pay it once but produce
+   B tokens of parallel compute, so aggregate throughput scales while the comms
+   floor stays flat. TP's win is **throughput, not single-stream latency** — the
+   same reason datacenters run TP with batching, never TP at batch=1.
+2. **GPU-stream collectives.** The 1.04 ms/reduce is inflated by the ring
+   running collectives on the **CPU stream** (every reduce crosses
+   GPU→CPU→socket→CPU→GPU). Moving them to the GPU stream could cut this to
+   ~0.2–0.3 ms, lifting the batch-1 TP ceiling from ~12 to ~40+ tok/s. This is
+   the #1 risk flagged in
+   [cluster-tensor-expert-parallel.md](architecture/cluster-tensor-expert-parallel.md).
+
+## Reproducing
+
+1. Set the ring transport in `~/.config/darkbloom/provider.toml` on **both** nodes
+   by pointing the `[[cluster.members]]` `address` fields at either the Wi-Fi IPs
+   (`192.168.1.x`) or the Thunderbolt link-local IPs (`169.254.x`).
+2. Start the tail: `cluster-provider <model-dir> --peer`
+3. Start the head (rank 0): `cluster-provider <model-dir>` (reads the coordinator
+   URL from `[coordinator]` in the config).
+4. Optional profiling: prefix either node with `DARKBLOOM_PROFILE=1` for the
+   per-phase breakdown, and `MLX_RING_VERBOSE=1` for ring join diagnostics.
+5. Send an OpenAI-compatible request to the coordinator's
+   `POST /v1/chat/completions`. Discard the first (cold) run; average the next few.
+
+Benchmark harnesses (all under `provider-swift`, build with
+`swift build -c release --product <name>`):
+
+- `solo-bench <model-dir> [maxTokens] [iterations]` — single-node, MLX native generate.
+- `loop-diag <model-dir> [maxTokens] [iterations]` — single-node, cluster loop discipline (isolates loop overhead).
+- `batch-bench <model-dir> [batchSize] [maxTokens] [iterations]` — batched throughput via BatchScheduler.
+- `comms-bench [hiddenSize] [layers] [tokens]` — TP comms floor; run on **both** nodes (joins the ring).
+
+> **macOS note.** The cluster head must run in a GUI Terminal session (or be
+> granted **Local Network** access in System Settings → Privacy & Security).
+> macOS Local Network Privacy silently blocks LAN/link-local connections from
+> binaries launched over SSH, which manifests as the ring failing to join with
+> `errno 65 (EHOSTUNREACH)` despite the peer being reachable.

--- a/docs/developer/clustering-implementation-status.md
+++ b/docs/developer/clustering-implementation-status.md
@@ -1,0 +1,154 @@
+# Clustering — Implementation Status
+
+> Tracks what is actually built in-tree against the
+> [clustering design](../architecture/clustering.md),
+> [handshake design](../architecture/cluster-node-handshake.md), and
+> [spike plan](clustering-spike-plan.md). **Status: early scaffold + verified
+> auth/crypto layer.** Not wired into the provider loop or coordinator yet.
+
+## What is implemented and verified
+
+All new code lives in `provider-swift/Sources/ProviderCore/Cluster/`. The whole
+`ProviderCore` target and every executable (`darkbloom`, ...) build clean with
+it; the auth/crypto/partition logic is verified by 27 assertions (the swift-
+testing suite `Tests/ProviderCoreTests/ClusterCryptoTests.swift`, plus a
+standalone harness used where this box lacks XCTest — see "Testing notes").
+
+| File | What it does | Status |
+|------|--------------|--------|
+| `ClusterRoster.swift` | Coordinator-signed member roster (nodeId, SE key, X25519 key, trust level, issued/expires). Deterministic sorted-key JSON (matches `AttestationBuilder`/Go). Signature + expiry + membership verification; `min(member trust)`. | ✅ built + tested |
+| `ClusterLinkCrypto.swift` | Directional HKDF session keys; per-token ChaCha20-Poly1305 seal/open with monotonic counter nonce + structured AAD (cluster/request/layerRange/seq); in-order opening channel. | ✅ built + tested |
+| `ClusterHandshake.swift` | 3-message SIGMA mutual auth over `AttestationSigner` + ephemeral `X25519KeyAgreementKeyPair`, verified against the roster; derives the shared master secret + directional session keys. | ✅ built + tested |
+| `LayerPartition.swift` | Memory-weighted, largest-remainder layer→node split (exo's `allocate_layers_proportionally` in Swift), min 1 layer/node, contiguous intervals. | ✅ built + tested |
+| `MLXDistributed.swift` | Swift binding over the `mlx-c` distributed C API (`init`/`is_available`/`rank`/`size`/`send`/`recv_like`/`all_gather`). The wrapper mlx-swift doesn't ship. | ✅ built (compiles against real `mlx-c`); ⏳ runtime unverified |
+| `InferenceEngine.swift` | The protocol seam; `BatchScheduler` conforms unchanged (single-node default). | ✅ built |
+| `ActivationCodec.swift` | Serialize a hidden-state `MLXArray` ↔ bytes (dtype+shape header) so it can be sealed and shipped; reject unsupported dtypes. | ✅ built + tested |
+| `PipelineTransport.swift` | Transport seam (send/recv sealed frames) + in-process `LoopbackMailbox`/`LoopbackPipelineTransport` so the full chain runs on one machine. | ✅ built + tested |
+| `PipelineStage.swift` | One rank's half of a forward step: recv+open → run owned layers → seal+send (exo's PipelineFirst/Last in Swift, with encryption woven in). | ✅ built + **verified** |
+| `PipelineDecoder.swift` | Multi-token decode driver over `PipelineStage`; model hooks (embed/runLayers/sampleToken) injected. | 🟡 built; decode loop drives one step, full loop on hardware |
+| `DistributedInferenceEngine.swift` | Engine wiring LayerPartition + MLXDistributed + encrypted link into `InferenceEngine`. | 🟡 scaffold; submit() drives PipelineStage, model-load slice + sampling are on-hardware |
+
+### Forward pass — verified end-to-end on ONE machine
+
+`PipelineForwardPassTests.swift` proves the **headline correctness property**:
+running a model split across 2 ranks (over the loopback transport, with real
+MLX tensors) produces a result **identical to running every layer on one rank**.
+The full chain is exercised: `embed → rank-0 layers → ActivationCodec.encode →
+ClusterLinkCrypto seal → transport → open → decode → rank-1 layers → logits`,
+plus a tampered-frame-rejected test. This is the on-one-machine half of Spike A;
+the remaining half is the same `PipelineStage` driven over the real MLX ring
+across two TB-linked Macs (and loading only each rank's layer slice).
+
+Notable build facts (de-risks Spike A): the `mlx-c` C API **does** expose the
+distributed collectives, `Cmlx` is a public product of `mlx-swift`, and
+`MLXArray.ctx` is publicly readable — so `MLXDistributed.swift` binds them from
+Swift directly, no MLX C++ changes. `ProviderCore` now depends on `Cmlx`
+(`Package.swift`).
+
+## What the verified tests cover
+
+- **Roster:** valid verify; reject expired / wrong-coordinator-key / tampered-body; weakest-member trust.
+- **Handshake:** happy path derives matching directional keys (A.send == B.recv); reject forged responder sig; reject peer-not-in-roster; reject impersonated initiator at confirm (forged Msg3).
+- **Link cipher:** 8 KB activation seal/open round-trip; monotonic multi-frame stream; reject AAD tamper (request-id swap); reject out-of-order frame; reject wrong-direction key.
+- **Layer split:** 48 layers across 32GB+24GB → contiguous, sums exactly, bigger node gets more; even split; tiny-node min-1; reject more-nodes-than-layers / empty.
+
+### Provider-loop `--cluster` wiring (config + selection, tested)
+
+The provider can now be told it is part of a cluster, with full validation:
+
+- `[cluster]` config section (`ClusterSettings`/`ClusterMemberSettings` in
+  `Config/ProviderConfig.swift`): `enabled`, `cluster_id`, `node_id`,
+  `[[cluster.members]]` (node_id + ring-ordered address), `backend`
+  (`ring`/`jaccl`). Round-trips through config I/O.
+- `darkbloom start --cluster` flag forces `enabled = true` given a `[cluster]`
+  section, so a user can opt in without editing TOML.
+- `ClusterPlan.resolve` (`Cluster/ClusterPlan.swift`): resolves this node's
+  rank from its `node_id`, computes ring neighbors (prev/next), validates
+  (self-in-members, ≥2 members, no duplicate ids, known backend), and emits the
+  MLX ring environment (`MLX_HOSTLIST`/`MLX_RANK`/`MLX_WORLD_SIZE`, exo-style)
+  plus a `layerPlan(...)` convenience over `LayerPartition`.
+- `StartCommand.run()` resolves + prints the plan up-front (fail-fast on
+  mis-config) and is the decision point that selects the distributed engine.
+
+Tested by `ClusterPlanTests.swift` (17 assertions: rank/neighbor resolution,
+ring env, layer-plan forwarding, every mis-config error path, config round-trip).
+
+Example `~/.config/darkbloom/provider.toml`:
+
+```toml
+[cluster]
+enabled = true
+cluster_id = "home-studio"
+node_id = "mac-32"            # this machine; must appear in members
+backend = "ring"             # ring (TCP/Thunderbolt-IP) | jaccl (RDMA/TB5)
+
+[[cluster.members]]          # ring order; rank = position
+node_id = "mac-32"
+address = "10.0.0.1"         # Thunderbolt-bridge IP preferred
+
+[[cluster.members]]
+node_id = "mac-24"
+address = "10.0.0.2"
+```
+
+### Full decode path — wired and verified on ONE machine
+
+The five pieces that connect the verified primitives to a running model across
+machines are now code-complete and integrate through the real engine:
+
+| Piece | Module | State |
+|-------|--------|-------|
+| #1 Sharded model seam | `PipelineModelShard` | ✅ seam + extension; the concrete impl (slice `LlamaModelInner.layers`) is the mlx-swift-lm-fork piece |
+| #2 `DistributedInferenceEngine.submit` | `DistributedInferenceEngine`, `PipelineRunner` | ✅ tokenize → embed → ring pipeline → sample → detokenize → stream; **verified** |
+| #3 Handshake transport | `HandshakeTransport`, `NWHandshakeChannel` | ✅ wire envelope + runner; in-memory + `NWConnection` (TCP) channels |
+| #4 Provider-loop wiring | `StartCommand`, `ClusterBringup` | ✅ `--cluster` resolves plan, materializes ring env, runs neighbor handshakes; engine swap gated to hardware |
+| #5 MLX ring env | `MLXRingEnvironment` | ✅ writes the `MLX_HOSTFILE` JSON (`[["ip:port"],…]`) + `MLX_RANK`, verified against MLX C++ ring.cpp |
+
+`DistributedEngineTests` runs a full **2-rank decode end to end on one machine**:
+the bring-up handshake over the in-memory channel, then a request through both
+engines over the loopback runtime — the tail streams the expected greedy tokens
+(verified: `["t3 ","t4 ","t5 "]`). The token-broadcast, per-hop AEAD binding
+(`hop-<rank>`), and EOS/length handling are all exercised.
+
+## What is NOT done — HARDWARE-ONLY remainder
+
+Everything writable without the two Macs is done. What remains genuinely needs
+the hardware (or is out of scope for the PoC):
+
+1. ~~**Concrete `PipelineModelShard` for an architecture**~~ — **DONE for Llama.**
+   The `mlx-swift-lm` fork (`crypt0fairy/mlx-swift-lm`, branch
+   `feat/pipeline-shard`) adds `LlamaPipelineShard` (owns only layers[start..end]
+   + embed on head + norm/lm_head on tail) and `LlamaPipelineShardLoader` (reads
+   only this rank's safetensors keys, remaps layer indices, quantizes 4-bit).
+   `LlamaShardAdapter` (ProviderCore) conforms it to `PipelineModelShard`. The
+   d-inference submodule now points at the fork. Remaining for this item: run it
+   on hardware (load + partial forward of real Llama-3.3-70B-4bit weights).
+2. **Real `MLXDistributed` ring** — `init`/`send`/`recv_like` compile against the
+   `mlx-c` API but are unrun across two machines. The loopback transport proves
+   the orchestration; the ring swaps in behind the same `PipelineTransport` /
+   `ClusterRuntime` seams.
+3. **Thunderbolt-Bridge network setup** — `MLXRingEnvironment` writes the hostfile
+   MLX wants; bringing up the TB-bridge IPs between the Macs is host config.
+4. **Real Secure Enclave + socket handshake on hardware** — the handshake runs
+   against `AttestationSigner` (SE in prod, software key in tests) over
+   `NWHandshakeChannel` (TCP); exercising it with real SE keys between the two
+   Macs is the on-hardware check.
+5. **Coordinator side** (separate workstream) — cluster roster issuance, member
+   registration, aggregate-capacity routing (`registry`/`protocol`/`attestation`
+   unchanged). Not needed for a provider-only PoC.
+
+## Testing notes
+
+`swift test` cannot run in this environment: a pre-existing target
+(`ProviderCoreFoundationTests`) does `import XCTest`, and the local toolchain is
+Command Line Tools (no XCTest), which fails the whole test graph. The cluster
+suites use swift-testing (`import Testing`) and run under a full Xcode toolchain
+in CI. For local verification here, the same assertions were run via throwaway
+standalone SwiftPM packages that vendor the cluster sources (MLX forced to CPU
+with a fetched metallib where the engine/forward-pass is exercised):
+
+- crypto / roster / handshake / partition: 27/27
+- encrypted pipeline forward pass == monolithic: 8/8
+- `--cluster` plan resolution: 17/17
+- bring-up handshake + ring hostfile: 9/9
+- full 2-rank `DistributedInferenceEngine` decode: 2/2 (streams `t3 t4 t5`)

--- a/docs/developer/clustering-spike-plan.md
+++ b/docs/developer/clustering-spike-plan.md
@@ -1,0 +1,144 @@
+# Clustering Feasibility — Spike Plan
+
+> **Status: PROPOSAL.** Two throwaway prototypes that de-risk the
+> [clustering design](../architecture/clustering.md) **before** any
+> coordinator/protocol work. They are independent and run in parallel. Spike code
+> is disposable — it proves a number, it does not ship. Coordinator-side work
+> begins only if **both** spikes pass their gate.
+
+## Why two spikes
+
+The design rests on two unproven claims:
+
+- **A — Engine:** Swift-native pipeline parallelism over `mlx-swift` is possible
+  and fast enough across 2 TB-linked Macs *without modifying MLX C++*.
+- **B — Privacy (the gate):** the inter-node activation link can be encrypted to
+  per-node Secure-Enclave keys with negligible overhead.
+
+If A fails, the whole approach is Python-subprocess-only (which fails the privacy
+model — see design §3②). If B fails, clustering contradicts Darkbloom's reason to
+exist. Neither depends on the other, so run them concurrently.
+
+---
+
+## Spike A — Swift pipeline parallelism
+
+**Goal:** Run one model split across **2 TB-connected Macs** from Swift, and
+measure tokens/sec and time-to-first-token vs. the same model on a single Mac.
+
+**Verified starting point (do not re-investigate):**
+- MLX **C++ core** has distributed (`ring/`, `jaccl/`, `send`, `recv_like`,
+  `all_gather`, `all_sum`) and the **`mlx-c` C API wraps it**
+  (`mlx/c/distributed.h`, `distributed_group.h`:
+  `mlx_distributed_init`, `mlx_distributed_send`, `mlx_distributed_recv_like`,
+  `mlx_distributed_all_gather`, `mlx_distributed_all_sum`, `mlx_distributed_group`).
+- **`mlx-swift` does NOT wrap these.** `Source/MLX` has no `Distributed.swift`.
+- ⇒ This spike is **"write a thin Swift binding over an existing C API"**, not
+  "modify MLX C++."
+
+**Steps (sequenced):**
+
+1. **Bind the C API.** Add a `Distributed` Swift target in a *fork/branch* of
+   `libs/mlx-swift` exposing `init(backend:)`, `send`, `recvLike`, `allGather`,
+   `allSum`, and a `Group` handle over `mlx-c`'s `distributed.h`. Smallest surface
+   that covers the pipeline path. *Gate 1: a 2-process ring on one Mac can
+   `send`/`recvLike` an `MLXArray` round-trip correctly.*
+
+2. **Ring transport across 2 Macs.** Reproduce exo's config approach: write a host
+   list, set `MLX_HOSTFILE`/`MLX_RANK`, `init(backend: .ring)`. Prioritize the
+   Thunderbolt-bridge IP. *Gate 2: `allSum` of a known vector across 2 Macs returns
+   the correct sum.*
+
+3. **Pipeline-wrap one model.** Pick a model that does **not** fit comfortably on
+   the smaller Mac alone (forces the split to matter). Reimplement exo's
+   `PipelineFirstLayer`/`PipelineLastLayer` pattern in Swift on top of
+   `mlx-swift-lm`'s model: rank owns a contiguous layer interval; `recvLike` the
+   activation before its first layer, `send` after its last; `allGather` the final
+   token. Layer split = memory-weighted (exo's `allocate_layers_proportionally`).
+   Keep KV cache local per rank.
+
+4. **Measure.** Single-Mac baseline vs. 2-Mac pipeline: TTFT, decode TPS, and
+   correctness (identical greedy output, temperature 0) for a fixed prompt set.
+
+**Pass gate:**
+- ✅ Correct, identical greedy output across the split.
+- ✅ A model that does **not** fit on one of the Macs runs on the pair.
+- ✅ Decode TPS is interactive (target ≥ ~10 tok/s over Thunderbolt for the test
+  model; record the actual number regardless).
+
+**Risks / watch-items:**
+- `mlx-c` API drift vs. the pinned MLX in `libs/mlx-swift`'s `Cmlx` submodule —
+  check the submodule's MLX commit exposes the distributed symbols.
+- Thunderbolt-IP bridge setup (exo does this in a shell/Swift helper; replicate
+  minimally — no RDMA needed for the ring/TCP backend).
+- mlx-swift-lm model classes may not expose per-layer hooks cleanly; may need a
+  local patch to iterate layers. Acceptable for a spike.
+
+**Deliverable:** a markdown result note with the TPS/TTFT table and a
+go/no-go on Path (b).
+
+---
+
+## Spike B — Attested encrypted activation link
+
+**Goal:** Prove that sealing each activation tensor to a peer's
+**Secure-Enclave-bound** X25519 key, on the `send`/`recv` path, costs negligible
+throughput — so the privacy gate (design §3①) is met.
+
+**Verified starting point:**
+- Darkbloom already has the crypto + SE primitives:
+  `provider-swift/.../Crypto/X25519ChaChaPoly.swift`,
+  `Crypto/NodeKeyPair.swift`, `Security/SecureEnclaveIdentity.swift`,
+  `Security/PersistentEnclaveKey+ECIES.swift`, and the per-request NaCl Box path in
+  `ProviderLoop.swift`. The pattern (seal/open inside the hardened process,
+  key in SE) is the same one to extend to the link.
+- Activation payload per token ≈ `hidden_size × dtype_bytes` (≈ 8 KB for a
+  4096-hidden fp16 model) — small.
+
+**Steps:**
+
+1. **Pairwise channel handshake.** Two nodes mutually exchange + verify each
+   other's existing **attestation blob** (reuse `AttestationBuilder`), then
+   establish a NaCl Box channel keyed by their SE X25519 keys. *Gate: node A
+   refuses to send to node B if B's attestation fails.*
+
+2. **Wrap the boundary.** In the Spike-A send/recv path (or a standalone
+   microbenchmark mirroring it), `seal()` the activation tensor bytes before
+   `send`, `open()` after `recv`. Seal/open must execute **inside the hardened
+   process**; the symmetric/ephemeral key never leaves it.
+
+3. **Measure overhead.** Throughput and per-token latency: plaintext link vs.
+   sealed link, across the activation sizes for the Spike-A test model. Sweep a
+   couple of `hidden_size` values to confirm it scales with payload, not with a
+   fixed tax.
+
+4. **Adversarial check.** Confirm a passive tap on the inter-node link (the
+   operator's threat) sees only ciphertext — capture the wire bytes and verify no
+   plaintext activation is recoverable.
+
+**Pass gate:**
+- ✅ Sealing overhead is negligible (target < ~5% decode-TPS hit; record actual).
+- ✅ Tapped link bytes are ciphertext only.
+- ✅ Channel refuses unattested peers.
+
+**Risks / watch-items:**
+- SE signing/ECDH per-handshake is fine (once per channel), but ensure per-token
+  work uses a cached symmetric key, not a fresh SE operation — SE ops are slow.
+- Verify the seal/open stays inside Hardened Runtime memory protections (don't
+  spill plaintext to a buffer a debugger could read — though `PT_DENY_ATTACH`
+  already covers the live process).
+
+**Deliverable:** a result note with the overhead table, the wire-capture
+evidence, and a go/no-go on the privacy gate.
+
+---
+
+## Decision
+
+| Spike A | Spike B | Outcome |
+|---------|---------|---------|
+| Pass | Pass | Proceed to coordinator/protocol work per design §5. |
+| Pass | Fail | Stop — clustering would break the operator-blind guarantee. Revisit only with a different privacy mechanism. |
+| Fail | — | Stop — no secure engine path; Python subprocess is rejected. |
+
+Record both result notes under `docs/developer/` and link them here when done.

--- a/provider-swift/Package.swift
+++ b/provider-swift/Package.swift
@@ -13,6 +13,7 @@ let package = Package(
         .executable(name: "darkbloom", targets: ["darkbloom"]),
         .executable(name: "darkbloom-enclave", targets: ["DarkbloomEnclaveCLI"]),
         .executable(name: "darkbloom-publish", targets: ["darkbloom-publish"]),
+        .executable(name: "loop-diag", targets: ["loop-diag"]),
     ],
     dependencies: [
         .package(path: "../libs/mlx-swift"),
@@ -79,6 +80,10 @@ let package = Package(
             dependencies: [
                 "ProviderCoreFoundation",
                 .product(name: "MLX", package: "mlx-swift"),
+                // Cmlx: the mlx-c C API. ProviderCore's MLXDistributed binding
+                // (Cluster/) calls the distributed collectives directly, since
+                // mlx-swift does not yet wrap them in Swift.
+                .product(name: "Cmlx", package: "mlx-swift"),
                 .product(name: "MLXNN", package: "mlx-swift"),
                 .product(name: "MLXLLM", package: "mlx-swift-lm"),
                 .product(name: "MLXVLM", package: "mlx-swift-lm"),
@@ -140,6 +145,183 @@ let package = Package(
                 .product(name: "MLXVLM", package: "mlx-swift-lm"),
             ],
             path: "Sources/vlm-smoke"
+        ),
+
+        // ----------------------------------------------------------------
+        // gptoss-shard-smoke: THROWAWAY harness validating the GPT-OSS pipeline
+        // shard (GPTOSSPipelineShard / GPTOSSPipelineShardLoader) against a TINY
+        // SYNTHETIC checkpoint it generates in-process (the real gpt-oss-20b is
+        // too big to load monolithic + 2 shards at once). Mints a ~MB random
+        // fp32 checkpoint with the exact keys/shapes GPTOSSModel expects, loads
+        // the full model and a 2-way layer split, and asserts the sharded logits
+        // match the monolithic logits at the last position. Mirrors shard-smoke.
+        // NOT a product.
+        //   swift run -c release gptoss-shard-smoke [out-dir]
+        // ----------------------------------------------------------------
+        .executableTarget(
+            name: "gptoss-shard-smoke",
+            dependencies: [
+                "ProviderCore",
+                .product(name: "MLX", package: "mlx-swift"),
+                .product(name: "MLXLLM", package: "mlx-swift-lm"),
+                .product(name: "MLXLMCommon", package: "mlx-swift-lm"),
+            ],
+            path: "Sources/gptoss-shard-smoke"
+        ),
+
+        // ----------------------------------------------------------------
+        // solo-bench: single-node decode benchmark pointed straight at a model
+        // dir, bypassing the coordinator/scanner. The single-node baseline for
+        // comparing against the cluster's pipeline-parallel tok/s. NOT a product.
+        //   swift run -c release solo-bench <model-dir> [maxTokens] [iterations]
+        // ----------------------------------------------------------------
+        .executableTarget(
+            name: "solo-bench",
+            dependencies: [
+                "ProviderCore",
+                .product(name: "MLX", package: "mlx-swift"),
+                .product(name: "MLXLLM", package: "mlx-swift-lm"),
+                .product(name: "MLXLMCommon", package: "mlx-swift-lm"),
+            ],
+            path: "Sources/solo-bench"
+        ),
+
+        // ----------------------------------------------------------------
+        // loop-diag: single-machine diagnostic harness that runs the CLUSTER'S
+        // decode-loop discipline (manual argMax sampling, evalEvery:4 mid-layer
+        // eval chopping, the per-token .eval() barrier) on ONE machine with the
+        // FULL model and NO network / group collectives. Its tok/s vs
+        // solo-bench's isolates the pure LOOP OVERHEAD from the network hop +
+        // pipeline bubble. NOT a product.
+        //   swift run -c release loop-diag <model-dir> [maxTokens] [iterations]
+        // ----------------------------------------------------------------
+        .executableTarget(
+            name: "loop-diag",
+            dependencies: [
+                "ProviderCore",
+                .product(name: "MLX", package: "mlx-swift"),
+                .product(name: "MLXLLM", package: "mlx-swift-lm"),
+                .product(name: "MLXLMCommon", package: "mlx-swift-lm"),
+            ],
+            path: "Sources/loop-diag"
+        ),
+
+        // ----------------------------------------------------------------
+        // batch-bench: batched single-node decode benchmark. Submits B
+        // concurrent decode requests through the production continuous-
+        // batching path (BatchScheduler → BatchedEngine) and reports the
+        // AGGREGATE decode tok/s — the throughput multiplier vs solo-bench's
+        // batch=1 baseline. NOT a product.
+        //   swift run -c release batch-bench <model-dir> [batchSize] [maxTokens] [iterations]
+        // ----------------------------------------------------------------
+        .executableTarget(
+            name: "batch-bench",
+            dependencies: [
+                "ProviderCore",
+                .product(name: "MLX", package: "mlx-swift"),
+                .product(name: "MLXLLM", package: "mlx-swift-lm"),
+                .product(name: "MLXLMCommon", package: "mlx-swift-lm"),
+            ],
+            path: "Sources/batch-bench"
+        ),
+
+        // ----------------------------------------------------------------
+        // spec-bench: single-node speculative-decoding benchmark. A small draft
+        // model proposes K tokens, the target verifies them in one forward pass.
+        // Greedy output is token-identical to the target alone; pure latency win.
+        // NOT a product. Compare vs solo-bench on the same target for the speedup.
+        //   swift run -c release spec-bench <target-dir> <draft-dir> [maxTokens] [iters] [K]
+        // ----------------------------------------------------------------
+        .executableTarget(
+            name: "spec-bench",
+            dependencies: [
+                "ProviderCore",
+                .product(name: "MLX", package: "mlx-swift"),
+                .product(name: "MLXLLM", package: "mlx-swift-lm"),
+                .product(name: "MLXLMCommon", package: "mlx-swift-lm"),
+            ],
+            path: "Sources/spec-bench"
+        ),
+
+        // ----------------------------------------------------------------
+        // batch-ctrl-test: standalone round-trip check of the continuous-batching
+        // composition control vector (swift test is broken in this toolchain).
+        //   swift run -c release batch-ctrl-test
+        // ----------------------------------------------------------------
+        .executableTarget(
+            name: "batch-ctrl-test",
+            dependencies: ["ProviderCore"],
+            path: "Sources/batch-ctrl-test"
+        ),
+
+        // ----------------------------------------------------------------
+        // batch-shard-smoke: Phase 1 correctness oracle for batched sharded
+        // decode. Single machine, no ring: asserts B batched rows produce the
+        // same greedy token stream as the B=1 path. NOT a product.
+        //   swift run -c release batch-shard-smoke <model-dir> [B] [maxTokens]
+        // ----------------------------------------------------------------
+        .executableTarget(
+            name: "batch-shard-smoke",
+            dependencies: [
+                "ProviderCore",
+                .product(name: "MLX", package: "mlx-swift"),
+                .product(name: "MLXLLM", package: "mlx-swift-lm"),
+                .product(name: "MLXLMCommon", package: "mlx-swift-lm"),
+            ],
+            path: "Sources/batch-shard-smoke"
+        ),
+
+        // ----------------------------------------------------------------
+        // comms-bench: measure the tensor-parallel comms floor over the ring —
+        // 2*layers all-reduce-sized collectives per simulated token. The go/no-go
+        // number for whether TP can approach single-node speed. Run on both nodes.
+        //   swift run -c release comms-bench [hiddenSize] [layers] [tokens]
+        // ----------------------------------------------------------------
+        .executableTarget(
+            name: "comms-bench",
+            dependencies: [
+                "ProviderCore",
+                .product(name: "MLX", package: "mlx-swift"),
+            ],
+            path: "Sources/comms-bench"
+        ),
+
+        // ----------------------------------------------------------------
+        // cluster-run: run ONE model split across the cluster over the real
+        // MLX ring. Reads [cluster] from provider.toml, joins the ring, loads
+        // this rank's layer slice, and runs a greedy pipeline decode. Run the
+        // same command on every node. NOT a product (the production path is
+        // `darkbloom start --cluster`; this is the hardware bring-up harness).
+        //   swift run -c release cluster-run <model-dir> "<prompt>"
+        // ----------------------------------------------------------------
+        .executableTarget(
+            name: "cluster-run",
+            dependencies: [
+                "ProviderCore",
+                .product(name: "MLX", package: "mlx-swift"),
+                .product(name: "MLXLLM", package: "mlx-swift-lm"),
+                .product(name: "MLXLMCommon", package: "mlx-swift-lm"),
+            ],
+            path: "Sources/cluster-run"
+        ),
+
+        // ----------------------------------------------------------------
+        // cluster-provider: the HEAD node acting as a real Darkbloom provider
+        // against a coordinator — bridges CoordinatorClient (registration,
+        // attestation, sealed-request protocol) to DistributedInferenceEngine
+        // (ring-sharded inference). Run on rank 0; run cluster-run-style peers
+        // on the other ranks. NOT yet production (single-node attestation).
+        //   swift run -c release cluster-provider <model-dir> [coordinator-ws-url]
+        // ----------------------------------------------------------------
+        .executableTarget(
+            name: "cluster-provider",
+            dependencies: [
+                "ProviderCore",
+                .product(name: "MLX", package: "mlx-swift"),
+                .product(name: "MLXLLM", package: "mlx-swift-lm"),
+                .product(name: "MLXLMCommon", package: "mlx-swift-lm"),
+            ],
+            path: "Sources/cluster-provider"
         ),
 
         // ----------------------------------------------------------------

--- a/provider-swift/Package.swift
+++ b/provider-swift/Package.swift
@@ -170,6 +170,29 @@ let package = Package(
         ),
 
         // ----------------------------------------------------------------
+        // gemma4-shard-smoke: THROWAWAY harness validating the Gemma 4 pipeline
+        // shard (Gemma4PipelineShard / Gemma4PipelineShardLoader) against a TINY
+        // SYNTHETIC checkpoint it generates in-process (the real gemma-4-26B is
+        // too big to load monolithic + 2 shards at once). Mints a ~MB random
+        // fp32 checkpoint with the exact keys/shapes Gemma4TextModel expects
+        // (MoE experts, k_eq_v full-attention layers, sliding/full mix, tied
+        // embeddings, final-logit softcap), loads the full model and a 2-way
+        // layer split, and asserts the sharded logits match the monolithic
+        // logits at the last position. Mirrors gptoss-shard-smoke. NOT a product.
+        //   swift run -c release gemma4-shard-smoke [out-dir]
+        // ----------------------------------------------------------------
+        .executableTarget(
+            name: "gemma4-shard-smoke",
+            dependencies: [
+                "ProviderCore",
+                .product(name: "MLX", package: "mlx-swift"),
+                .product(name: "MLXLLM", package: "mlx-swift-lm"),
+                .product(name: "MLXLMCommon", package: "mlx-swift-lm"),
+            ],
+            path: "Sources/gemma4-shard-smoke"
+        ),
+
+        // ----------------------------------------------------------------
         // solo-bench: single-node decode benchmark pointed straight at a model
         // dir, bypassing the coordinator/scanner. The single-node baseline for
         // comparing against the cluster's pipeline-parallel tok/s. NOT a product.

--- a/provider-swift/Sources/ProviderCore/Cluster/ActivationCodec.swift
+++ b/provider-swift/Sources/ProviderCore/Cluster/ActivationCodec.swift
@@ -1,0 +1,105 @@
+/// ActivationCodec -- serialize a hidden-state `MLXArray` to bytes and back,
+/// so it can be sealed (`ClusterLinkCrypto`) and shipped across the encrypted
+/// ring link.
+///
+/// In a plaintext exo cluster the activation crosses the wire via MLX's native
+/// `mx.distributed.send` (raw tensor, no encryption). Darkbloom cannot do that:
+/// the activation is sensitive (approximately invertible to the prompt) and the
+/// link is operator-controlled. So we take the tensor out of MLX as bytes,
+/// AEAD-seal it, transfer ciphertext, then rebuild the tensor on the peer. The
+/// transferred frame carries a tiny header (dtype + shape) so the receiver can
+/// reconstruct the exact array.
+///
+/// Pure MLX + Foundation. The round-trip (encode → bytes → decode) is testable
+/// on one machine; only the *transport* of those bytes needs two machines.
+
+import Foundation
+import MLX
+
+public enum ActivationCodecError: Error, Equatable, Sendable {
+    case unsupportedDType(String)
+    case truncatedHeader
+    case shapeByteMismatch(expected: Int, got: Int)
+}
+
+/// Wire-stable dtype tags for the activation header. Pipeline activations are
+/// floating hidden states; we support the dtypes mlx-swift-lm emits.
+enum ActivationDType: UInt8 {
+    case float32 = 1
+    case float16 = 2
+    case bfloat16 = 3
+
+    init(_ dtype: DType) throws {
+        switch dtype {
+        case .float32: self = .float32
+        case .float16: self = .float16
+        case .bfloat16: self = .bfloat16
+        default: throw ActivationCodecError.unsupportedDType("\(dtype)")
+        }
+    }
+
+    var mlx: DType {
+        switch self {
+        case .float32: return .float32
+        case .float16: return .float16
+        case .bfloat16: return .bfloat16
+        }
+    }
+}
+
+public enum ActivationCodec {
+    /// Frame layout (all integers big-endian):
+    ///   [1]  dtype tag
+    ///   [1]  rank (number of shape dims, ≤ 255)
+    ///   [4]*rank  each dimension as UInt32
+    ///   [..] raw tensor bytes (contiguous, row-major)
+    public static func encode(_ array: MLXArray) throws -> Data {
+        array.eval()
+        let tag = try ActivationDType(array.dtype)
+        let shape = array.shape
+        precondition(shape.count <= 255, "activation rank too large")
+
+        var out = Data()
+        out.append(tag.rawValue)
+        out.append(UInt8(shape.count))
+        for dim in shape {
+            var be = UInt32(dim).bigEndian
+            withUnsafeBytes(of: &be) { out.append(contentsOf: $0) }
+        }
+        out.append(array.asData(access: .copy).data)
+        return out
+    }
+
+    /// Reconstruct the `MLXArray` from a frame produced by `encode`.
+    public static func decode(_ data: Data) throws -> MLXArray {
+        guard data.count >= 2 else { throw ActivationCodecError.truncatedHeader }
+        var idx = data.startIndex
+        guard let tag = ActivationDType(rawValue: data[idx]) else {
+            throw ActivationCodecError.unsupportedDType("tag=\(data[idx])")
+        }
+        idx = data.index(after: idx)
+        let rank = Int(data[idx])
+        idx = data.index(after: idx)
+
+        let shapeBytes = rank * 4
+        guard data.distance(from: idx, to: data.endIndex) >= shapeBytes else {
+            throw ActivationCodecError.truncatedHeader
+        }
+        var shape = [Int]()
+        for _ in 0..<rank {
+            var be: UInt32 = 0
+            withUnsafeMutableBytes(of: &be) { dst in
+                for b in 0..<4 { dst[b] = data[data.index(idx, offsetBy: b)] }
+            }
+            shape.append(Int(UInt32(bigEndian: be)))
+            idx = data.index(idx, offsetBy: 4)
+        }
+
+        let payload = data.subdata(in: idx..<data.endIndex)
+        let expected = shape.reduce(1, *) * tag.mlx.size
+        guard payload.count == expected else {
+            throw ActivationCodecError.shapeByteMismatch(expected: expected, got: payload.count)
+        }
+        return MLXArray(payload, shape, dtype: tag.mlx)
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Cluster/ClusterBatchControl.swift
+++ b/provider-swift/Sources/ProviderCore/Cluster/ClusterBatchControl.swift
@@ -1,0 +1,127 @@
+/// ClusterBatchControl -- the per-step batch-composition control round for
+/// continuous batching (Phase 3).
+///
+/// Continuous batching changes the active batch every step: rows finish (evict)
+/// and new requests join (admit). The MLX ring is a single ordered stream, so
+/// EVERY rank must agree on the new composition before each step and apply the
+/// SAME `filter`/`extend` to its local per-layer batched KV caches — or the
+/// caches diverge and attention silently corrupts.
+///
+/// The head decides the composition (which rows survive, which are admitted) and
+/// broadcasts it via one `all_gather` of a fixed-width int32 vector; peers
+/// contribute zeros and replay the head's decision. This mirrors the B=1
+/// `exchangeRequest` control round, extended to per-step batch granularity.
+///
+/// Wire layout (head's slot = first BATCH_CTRL_WIDTH entries of the gather):
+///   [0] command   0=step, 1=shutdown, 2=idle-keepalive
+///   [1] B_next    active row count AFTER this step's evict+admit
+///   [2] nKeep     surviving rows from the previous batch
+///   [3] nAdmit    newly admitted rows (prefilled this step)
+///   [4] prefillW  max prompt length among admitted rows (0 if none)
+///   [5 ..< 5+nKeep]              keepIndices into the PREVIOUS batch (ascending)
+///   [.. nAdmit blocks of]        { promptLen, leftPadding, maxTokens,
+///                                  prompt token ids… } packed back-to-back
+///
+/// The admit cap keeps the vector fixed-width; if a step's admissions would
+/// overflow, the scheduler admits fewer rows (back-pressure).
+
+import Foundation
+import MLX
+
+/// Fixed admit-token budget per control round (caps the gather vector width).
+public let BATCH_CTRL_MAX_ADMIT_TOKENS = 8192
+/// Max rows ever active or admitted in one round (bounds keepIndices + headers).
+public let BATCH_CTRL_MAX_ROWS = 64
+/// 5 header ints + keepIndices (≤ MAX_ROWS) + nAdmit headers (3 each) + tokens.
+public let BATCH_CTRL_WIDTH =
+    5 + BATCH_CTRL_MAX_ROWS + BATCH_CTRL_MAX_ROWS * 3 + BATCH_CTRL_MAX_ADMIT_TOKENS
+
+public enum ClusterBatchCommand: Int32, Sendable {
+    case step = 0
+    case shutdown = 1
+    case idle = 2
+}
+
+/// One newly-admitted request in a composition round.
+public struct ClusterAdmitRow: Sendable {
+    public let promptTokens: [Int]
+    public let leftPadding: Int
+    public let maxTokens: Int
+    public init(promptTokens: [Int], leftPadding: Int, maxTokens: Int) {
+        self.promptTokens = promptTokens
+        self.leftPadding = leftPadding
+        self.maxTokens = maxTokens
+    }
+}
+
+/// The agreed batch composition for one step (identical on every rank after the
+/// control all_gather).
+public struct ClusterBatchComposition: Sendable {
+    public var command: ClusterBatchCommand
+    public var bNext: Int
+    /// Indices into the PREVIOUS batch that survive (ascending). Empty on a
+    /// fresh start. Length == nKeep.
+    public var keepIndices: [Int]
+    /// Rows admitted (and prefilled) this step. Length == nAdmit.
+    public var admit: [ClusterAdmitRow]
+
+    public init(command: ClusterBatchCommand, bNext: Int, keepIndices: [Int], admit: [ClusterAdmitRow]) {
+        self.command = command
+        self.bNext = bNext
+        self.keepIndices = keepIndices
+        self.admit = admit
+    }
+
+    public static let shutdown = ClusterBatchComposition(command: .shutdown, bNext: 0, keepIndices: [], admit: [])
+    public static let idle = ClusterBatchComposition(command: .idle, bNext: 0, keepIndices: [], admit: [])
+
+    /// Encode into the fixed-width int32 control vector.
+    public func encodeVector() -> [Int32] {
+        var v = [Int32](repeating: 0, count: BATCH_CTRL_WIDTH)
+        v[0] = command.rawValue
+        v[1] = Int32(bNext)
+        v[2] = Int32(keepIndices.count)
+        v[3] = Int32(admit.count)
+        let prefillW = admit.map(\.promptTokens.count).max() ?? 0
+        v[4] = Int32(prefillW)
+        var idx = 5
+        for k in keepIndices { v[idx] = Int32(k); idx += 1 }
+        // Reserve the keep region at full width so admit blocks start at a fixed
+        // offset regardless of nKeep — keeps decode unambiguous.
+        idx = 5 + BATCH_CTRL_MAX_ROWS
+        for row in admit {
+            v[idx] = Int32(row.promptTokens.count); idx += 1
+            v[idx] = Int32(row.leftPadding); idx += 1
+            v[idx] = Int32(row.maxTokens); idx += 1
+        }
+        // Admit token ids follow the headers region.
+        idx = 5 + BATCH_CTRL_MAX_ROWS + BATCH_CTRL_MAX_ROWS * 3
+        for row in admit {
+            for t in row.promptTokens { v[idx] = Int32(t); idx += 1 }
+        }
+        return v
+    }
+
+    /// Decode from the head's slot of the gathered control vector.
+    public static func decode(_ slot: [Int32]) -> ClusterBatchComposition {
+        let command = ClusterBatchCommand(rawValue: slot[0]) ?? .step
+        let bNext = Int(slot[1])
+        let nKeep = Int(slot[2])
+        let nAdmit = Int(slot[3])
+        var keep = [Int]()
+        for i in 0..<max(0, nKeep) { keep.append(Int(slot[5 + i])) }
+        var admit = [ClusterAdmitRow]()
+        let headerBase = 5 + BATCH_CTRL_MAX_ROWS
+        let tokenBase = 5 + BATCH_CTRL_MAX_ROWS + BATCH_CTRL_MAX_ROWS * 3
+        var tokOffset = tokenBase
+        for a in 0..<max(0, nAdmit) {
+            let pLen = Int(slot[headerBase + a * 3 + 0])
+            let lpad = Int(slot[headerBase + a * 3 + 1])
+            let mTok = Int(slot[headerBase + a * 3 + 2])
+            var prompt = [Int]()
+            for _ in 0..<max(0, pLen) { prompt.append(Int(slot[tokOffset])); tokOffset += 1 }
+            admit.append(ClusterAdmitRow(promptTokens: prompt, leftPadding: lpad, maxTokens: mTok))
+        }
+        return ClusterBatchComposition(command: command, bNext: bNext, keepIndices: keep, admit: admit)
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Cluster/ClusterBatchPipeline.swift
+++ b/provider-swift/Sources/ProviderCore/Cluster/ClusterBatchPipeline.swift
@@ -1,0 +1,144 @@
+/// ClusterBatchPipeline -- the BATCHED ring decode loop (continuous-batching
+/// Phase 1: static, equal-length batch).
+///
+/// Mirrors `ClusterPipeline` collective-for-collective — the same lockstep
+/// discipline that prevents deadlock — but carries a batch of B rows:
+///   - the head embeds a `[B, width, hidden]` activation (one row per request),
+///   - the ring hop ships `[B, width, hidden]` (sealed as ONE AEAD blob/step),
+///   - the tail samples `[B, vocab] -> [B]` next tokens and `all_gather`s the
+///     whole `[B]` vector so every rank advances all rows together.
+///
+/// Decode is memory-bandwidth-bound: the per-step weight streaming is the same
+/// whether B=1 or B=8, so B rows produce ~B tokens in ~one step's wall-clock —
+/// the throughput win. Phase 1 keeps B fixed for the whole generation (no
+/// mid-flight admit/evict) and assumes equal-length rows (leftPadding all 0), so
+/// the plain causal mask in the shard is correct. Ragged positions (Phase 2) and
+/// continuous admit/evict (Phase 3) build on this.
+///
+/// IMPORTANT: every rank must call `beginBatch` (to allocate the batched KV
+/// caches) with the SAME row count before `generateBatch`, and call the same
+/// collectives in the same order — identical to ClusterPipeline's invariant.
+
+import Foundation
+import MLX
+
+public struct ClusterBatchPipeline {
+    let plan: ClusterPlan
+    let group: MLXDistributedGroup
+    let shard: any PipelineModelShard
+    let hiddenSize: Int
+    let sealCh: ClusterSealingChannel?   // toward nextRank (nil on tail)
+    let openCh: ClusterOpeningChannel?   // from prevRank (nil on head)
+
+    public init(
+        plan: ClusterPlan, group: MLXDistributedGroup, shard: any PipelineModelShard,
+        hiddenSize: Int, sealCh: ClusterSealingChannel?, openCh: ClusterOpeningChannel?
+    ) {
+        self.plan = plan
+        self.group = group
+        self.shard = shard
+        self.hiddenSize = hiddenSize
+        self.sealCh = sealCh
+        self.openCh = openCh
+    }
+
+    private var headRank: Int { 0 }
+    private var tailRank: Int { plan.worldSize - 1 }
+
+    private func toI32(_ d: Data) -> MLXArray { MLXArray(d.map { Int32($0) }, [d.count]) }
+    private func toBytes(_ a: MLXArray) -> Data { Data(a.asArray(Int32.self).map { UInt8(truncatingIfNeeded: $0) }) }
+
+    /// Ciphertext length for a `[B, width, hidden]` bf16 activation:
+    /// header (2 + ndim*4, ndim=3 -> 14) + payload (B*width*hidden*2) + AEAD (28).
+    private func sealedLen(batch B: Int, width: Int) -> Int { 14 + B * width * hiddenSize * 2 + 28 }
+
+    /// Run ONE greedy batched generation for `prompts` (B rows of EQUAL length),
+    /// up to `maxTokens`. `onToken(row, tokenId)` fires on the head per produced
+    /// token per row. EVERY rank runs this in lockstep. Returns the per-row
+    /// generated token id arrays (head; peers get empty rows).
+    ///
+    /// Phase 1 contract: all rows have the same prompt length; the generation
+    /// runs until every row has hit an EOS or `maxTokens` is reached. A row that
+    /// hits EOS early keeps stepping (its later tokens are caller-trimmed) — no
+    /// mid-flight eviction yet.
+    public func generateBatch(
+        prompts: [[Int]], maxTokens: Int, requestId: String,
+        eosTokenIds: Set<Int>, onToken: (Int, Int) -> Void
+    ) throws -> [[Int]] {
+        let B = prompts.count
+        precondition(B > 0, "empty batch")
+        let promptLen = prompts[0].count
+        precondition(prompts.allSatisfy { $0.count == promptLen },
+                     "Phase 1 requires equal-length rows; got \(prompts.map(\.count))")
+
+        // Allocate batched KV caches for B rows (equal length -> no left padding).
+        let zeroPad = Array(repeating: 0, count: B)
+        shard.beginBatch(leftPadding: zeroPad)
+
+        var generated = Array(repeating: [Int](), count: B)
+        var lastTokens = [Int]()         // length B, the previous step's tokens
+        var rowDone = Array(repeating: false, count: B)
+
+        for step in 0..<maxTokens {
+            let width = step == 0 ? promptLen : 1
+
+            let inCtx = ClusterFrameContext(
+                clusterId: plan.clusterId, requestId: requestId,
+                layerRange: "hop-\(plan.rank == headRank ? headRank : plan.rank - 1)", seq: UInt64(step))
+
+            var hidden: MLXArray
+            if plan.isHead {
+                let rows: [[Int]] = step == 0 ? prompts : lastTokens.map { [$0] }
+                hidden = shard.embedBatch(rows: rows, leftPadding: zeroPad)
+            } else {
+                let template = MLXArray.zeros([sealedLen(batch: B, width: width)], dtype: .int32)
+                let cipherArr = try group.recvLike(template, from: plan.rank - 1)
+                cipherArr.eval()
+                let plain = try openCh!.open(toBytes(cipherArr), context: inCtx)
+                hidden = try ActivationCodec.decode(plain)
+            }
+            hidden = shard.runOwnedLayersBatched(hidden)
+
+            if !plan.isTail {
+                let outCtx = ClusterFrameContext(
+                    clusterId: plan.clusterId, requestId: requestId,
+                    layerRange: "hop-\(plan.rank)", seq: UInt64(step))
+                let sealed = try sealCh!.seal(ActivationCodec.encode(hidden.asType(.bfloat16)), context: outCtx)
+                let dep = try group.send(toI32(sealed), to: plan.rank + 1)
+                dep.eval()
+            }
+
+            // Token broadcast — every rank all_gathers a [B] vector. The tail
+            // fills its [B] with sampled tokens; peers contribute zeros. After
+            // gather, the tail's slot holds the B next tokens for every rank.
+            var tokenVec = MLXArray([Int32](repeating: 0, count: B), [B])
+            if plan.isTail {
+                // projectToLogitsBatched is lastPositionOnly -> [B, 1, vocab].
+                // argMax over the vocab axis -> [B, 1]; flattening gives exactly
+                // B values, one next-token per row, in row order.
+                let logits = shard.projectToLogitsBatched(hidden)
+                let ids = argMax(logits, axis: logits.ndim - 1)
+                ids.eval()
+                let flat = ids.asArray(Int32.self)
+                precondition(flat.count == B,
+                             "tail sampled \(flat.count) tokens, expected B=\(B) (lastPositionOnly?)")
+                tokenVec = MLXArray(flat, [B])
+            }
+            let gathered = try group.allGather(tokenVec)            // [worldSize*B]
+            gathered.eval()
+            let all = gathered.asArray(Int32.self)
+            let base = tailRank * B
+            let nextTokens = (0..<B).map { Int(all[base + $0]) }
+
+            lastTokens = nextTokens
+            for b in 0..<B where !rowDone[b] {
+                let tok = nextTokens[b]
+                generated[b].append(tok)
+                if plan.isHead { onToken(b, tok) }
+                if eosTokenIds.contains(tok) { rowDone[b] = true }
+            }
+            if rowDone.allSatisfy({ $0 }) { break }
+        }
+        return generated
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Cluster/ClusterBatchScheduler.swift
+++ b/provider-swift/Sources/ProviderCore/Cluster/ClusterBatchScheduler.swift
@@ -1,0 +1,191 @@
+/// ClusterBatchScheduler -- the HEAD-side continuous-batching scheduler
+/// (Phase 3). Mirrors the single-node `BatchGenerator` (queue → admit → decode →
+/// evict) but drives the RING primitives instead of `model.callAsFunction`.
+///
+/// The head is the only rank with a coordinator connection and the request
+/// queue. Each step it: evicts finished rows, admits queued rows (prefill), runs
+/// one decode step, samples per-row tokens, and routes each token to its
+/// request's stream. It broadcasts the composition so peers stay row-aligned.
+///
+/// Concurrency model: `enqueue` is called from the coordinator event loop
+/// (any thread); `run` is the single dedicated ring thread (the only one that
+/// touches MLX collectives, exactly like the B=1 cluster-provider design).
+
+import Foundation
+import MLX
+
+/// A request submitted to the batched scheduler.
+public struct ClusterBatchRequest: Sendable {
+    public let requestId: String
+    public let promptTokens: [Int]
+    public let maxTokens: Int
+    public init(requestId: String, promptTokens: [Int], maxTokens: Int) {
+        self.requestId = requestId
+        self.promptTokens = promptTokens
+        self.maxTokens = maxTokens
+    }
+}
+
+/// Per-token callback (head): (requestId, tokenId).
+public typealias ClusterBatchOnToken = (String, Int) -> Void
+/// Completion callback (head): (requestId, totalGeneratedTokens).
+public typealias ClusterBatchOnComplete = (String, Int) -> Void
+
+public final class ClusterBatchScheduler: @unchecked Sendable {
+    private let server: ClusterBatchServer
+    private let plan: ClusterPlan
+    private let group: MLXDistributedGroup
+    private let shard: any PipelineModelShard
+    private let hiddenSize: Int
+    private let eosTokenIds: Set<Int>
+    private let maxConcurrent: Int
+
+    // Shared queue (multi-producer).
+    private let lock = NSLock()
+    private var queue: [ClusterBatchRequest] = []
+    private var shuttingDown = false
+
+    // Active batch rows (ring thread only) — order MUST match peers' cache order.
+    private struct Row { let requestId: String; let maxTokens: Int; var position: Int; var generated: Int; var lastToken: Int; var done: Bool }
+    private var rows: [Row] = []
+
+    public init(server: ClusterBatchServer, plan: ClusterPlan, group: MLXDistributedGroup,
+                shard: any PipelineModelShard, hiddenSize: Int, eosTokenIds: Set<Int>,
+                maxConcurrent: Int = 8) {
+        self.server = server
+        self.plan = plan
+        self.group = group
+        self.shard = shard
+        self.hiddenSize = hiddenSize
+        self.eosTokenIds = eosTokenIds
+        self.maxConcurrent = maxConcurrent
+    }
+
+    public func enqueue(_ req: ClusterBatchRequest) {
+        lock.lock(); queue.append(req); lock.unlock()
+    }
+
+    public func requestShutdown() {
+        lock.lock(); shuttingDown = true; lock.unlock()
+    }
+
+    private func drainQueue(upTo n: Int) -> [ClusterBatchRequest] {
+        guard n > 0 else { return [] }
+        lock.lock(); defer { lock.unlock() }
+        let take = min(n, queue.count)
+        let out = Array(queue.prefix(take))
+        queue.removeFirst(take)
+        return out
+    }
+
+    private var isShuttingDown: Bool { lock.lock(); defer { lock.unlock() }; return shuttingDown }
+
+    /// The ring thread. Loops the composition control round + batched decode
+    /// until shutdown. Calls `onToken`/`onComplete` for each row's output.
+    public func run(makeChannels: () -> (ClusterSealingChannel?, ClusterOpeningChannel?),
+                    onToken: ClusterBatchOnToken, onComplete: ClusterBatchOnComplete) throws {
+        let (sealCh, openCh) = makeChannels()
+        var stepCounter = 0
+        var sealSeq: UInt64 = 0   // head is rank 0: only seals (sends). One increment per hop.
+        var recvSeq: UInt64 = 0   // used only if head is also tail (worldSize 1) — unused in 2-node
+        _ = openCh; _ = recvSeq
+        var started = false
+
+        while true {
+            if isShuttingDown && rows.isEmpty && queueIsEmpty() {
+                _ = try server.exchangeComposition(.shutdown)
+                return
+            }
+
+            // 1. Compute evictions: rows that finished last step drop out.
+            let keepIndices = rows.enumerated().filter { !$0.element.done }.map { $0.offset }
+            let survivors = keepIndices.map { rows[$0] }
+
+            // 2. Admit from queue up to capacity.
+            let capacity = maxConcurrent - survivors.count
+            let admitted = drainQueue(upTo: capacity)
+            let admitRows = admitted.map { req -> ClusterAdmitRow in
+                ClusterAdmitRow(promptTokens: req.promptTokens, leftPadding: 0, maxTokens: req.maxTokens)
+            }
+
+            // Idle keepalive when there's nothing to do.
+            if survivors.isEmpty && admitRows.isEmpty {
+                _ = try server.exchangeComposition(.idle)
+                Thread.sleep(forTimeInterval: 0.05)
+                continue
+            }
+
+            // 3. Broadcast composition.
+            let bNext = survivors.count + admitRows.count
+            let comp = ClusterBatchComposition(
+                command: .step, bNext: bNext, keepIndices: keepIndices, admit: admitRows)
+            _ = try server.exchangeComposition(comp)
+
+            let prevLive = rows.count
+
+            // 4. Apply eviction locally (head), keeping rows row-aligned with peers.
+            //    Empty keep set => batch fully drained: re-init a fresh empty
+            //    batch (filter with [] traps in BatchKVCache.min). Otherwise
+            //    filter only when the keep set actually changes the batch.
+            if keepIndices.isEmpty {
+                if prevLive > 0 || !started { shard.beginBatch(leftPadding: []); started = true }
+            } else {
+                if !started { shard.beginBatch(leftPadding: []); started = true }
+                if keepIndices != Array(0..<prevLive) {
+                    shard.filterBatch(keepIndices: keepIndices)
+                }
+            }
+            rows = survivors
+
+            // 5. Admit: embed + prefill admitted rows over the ring, sample first tokens.
+            if !admitRows.isEmpty {
+                let prompts = admitRows.map(\.promptTokens)
+                let leftPad = admitRows.map(\.leftPadding)
+                let embedded = shard.embedBatch(rows: prompts, leftPadding: leftPad)
+                let out = shard.admitPrefill(embedded, leftPadding: leftPad)
+                if !plan.isTail {
+                    try server.sendHead(out, frameSeq: sealSeq, sealCh: sealCh!)
+                    sealSeq += 1
+                }
+                let firstTokens = try server.broadcast(plan.isTail ? out : nil, B: admitRows.count)
+                for (i, req) in admitted.enumerated() {
+                    var r = Row(requestId: req.requestId, maxTokens: req.maxTokens,
+                                position: req.promptTokens.count, generated: 0,
+                                lastToken: firstTokens[i], done: false)
+                    r.generated = 1
+                    onToken(req.requestId, firstTokens[i])
+                    if eosTokenIds.contains(firstTokens[i]) || r.generated >= r.maxTokens {
+                        r.done = true; onComplete(req.requestId, r.generated)
+                    }
+                    rows.append(r)
+                }
+            }
+
+            // 6. Decode step over the full live batch.
+            let B = rows.count
+            if B == 0 { stepCounter += 1; continue }
+            let lastTokens = rows.map(\.lastToken)
+            let embedded = shard.embedBatch(rows: lastTokens.map { [$0] },
+                                            leftPadding: Array(repeating: 0, count: B))
+            let out = shard.runOwnedLayersBatched(embedded)
+            if !plan.isTail {
+                try server.sendHead(out, frameSeq: sealSeq, sealCh: sealCh!)
+                sealSeq += 1
+            }
+            let toks = try server.broadcast(plan.isTail ? out : nil, B: B)
+            for i in 0..<B where !rows[i].done {
+                rows[i].lastToken = toks[i]
+                rows[i].generated += 1
+                rows[i].position += 1
+                onToken(rows[i].requestId, toks[i])
+                if eosTokenIds.contains(toks[i]) || rows[i].generated >= rows[i].maxTokens {
+                    rows[i].done = true
+                    onComplete(rows[i].requestId, rows[i].generated)
+                }
+            }
+            stepCounter += 1
+        }
+    }
+
+    private func queueIsEmpty() -> Bool { lock.lock(); defer { lock.unlock() }; return queue.isEmpty }
+}

--- a/provider-swift/Sources/ProviderCore/Cluster/ClusterBatchServer.swift
+++ b/provider-swift/Sources/ProviderCore/Cluster/ClusterBatchServer.swift
@@ -1,0 +1,205 @@
+/// ClusterBatchServer -- the continuous-batching ring server (Phase 3).
+///
+/// Drives the batched ring decode loop under a per-step composition control
+/// round. The head computes each step's batch composition (evict finished rows,
+/// admit queued rows) and broadcasts it; peers replay it. Every rank, every
+/// step, in identical order:
+///   1. all_gather the composition vector (peers contribute zeros).
+///   2. shutdown -> return; idle -> continue (keeps the collective alive).
+///   3. evict: filterBatch(keepIndices) on the local batched KV caches.
+///   4. admit: if nAdmit>0, prefill the admitted rows (their own ring hops) and
+///      extend the live caches; the tail samples their first tokens.
+///   5. decode: one [B,1,hidden] step; tail samples [B]; all_gather the [B]
+///      token vector so every rank advances all rows.
+///
+/// This reuses the proven transport (send/recvLike/allGather + sealed channels)
+/// and the batched shard primitives validated single-node in Phase 1/2.
+
+import Foundation
+import MLX
+
+public struct ClusterBatchServer {
+    let plan: ClusterPlan
+    let group: MLXDistributedGroup
+    let shard: any PipelineModelShard
+    let hiddenSize: Int
+    let eosTokenIds: Set<Int>
+
+    public init(plan: ClusterPlan, group: MLXDistributedGroup, shard: any PipelineModelShard,
+                hiddenSize: Int, eosTokenIds: Set<Int>) {
+        self.plan = plan
+        self.group = group
+        self.shard = shard
+        self.hiddenSize = hiddenSize
+        self.eosTokenIds = eosTokenIds
+    }
+
+    private var headRank: Int { 0 }
+    private var tailRank: Int { plan.worldSize - 1 }
+
+    private func toI32(_ d: Data) -> MLXArray { MLXArray(d.map { Int32($0) }, [d.count]) }
+    private func toBytes(_ a: MLXArray) -> Data { Data(a.asArray(Int32.self).map { UInt8(truncatingIfNeeded: $0) }) }
+    private func sealedLen(batch B: Int, width: Int) -> Int { 14 + B * width * hiddenSize * 2 + 28 }
+
+    /// Broadcast (head) / receive (peer) the next step's composition over the
+    /// ring. The head passes `next`; peers pass nil and read the head's slot.
+    public func exchangeComposition(_ next: ClusterBatchComposition?) throws -> ClusterBatchComposition {
+        let vec: [Int32]
+        if plan.isHead, let next { vec = next.encodeVector() }
+        else { vec = [Int32](repeating: 0, count: BATCH_CTRL_WIDTH) }
+        let gathered = try group.allGather(MLXArray(vec, [BATCH_CTRL_WIDTH]))
+        gathered.eval()
+        let flat = gathered.asArray(Int32.self)
+        let slot = Array(flat.prefix(BATCH_CTRL_WIDTH))   // head is rank 0
+        return ClusterBatchComposition.decode(slot)
+    }
+
+    /// Build the AEAD frame context for ring hop frame number `frameSeq`. The
+    /// sealing/opening channels enforce `context.seq == internal counter` AND an
+    /// exact AAD match, so BOTH sides must derive identical (requestId,
+    /// layerRange, seq) per frame. We use a constant requestId + a single
+    /// monotonic frameSeq that increments on EVERY hop (admit and decode alike),
+    /// and a layerRange tied to the hop edge (rank N -> N+1), which both the
+    /// sender (rank N) and receiver (rank N+1) compute identically.
+    private func hopContext(frameSeq: UInt64, senderRank: Int) -> ClusterFrameContext {
+        ClusterFrameContext(clusterId: plan.clusterId, requestId: "batch",
+                            layerRange: "hop-\(senderRank)", seq: frameSeq)
+    }
+
+    /// One ring hop for a `[B, width, hidden]` activation. `frameSeq` MUST match
+    /// the channel's running counter (one increment per hop on each side).
+    private func recvActivation(B: Int, width: Int, frameSeq: UInt64,
+                                openCh: ClusterOpeningChannel) throws -> MLXArray {
+        let ctx = hopContext(frameSeq: frameSeq, senderRank: plan.rank - 1)
+        let template = MLXArray.zeros([sealedLen(batch: B, width: width)], dtype: .int32)
+        let cipherArr = try group.recvLike(template, from: plan.rank - 1)
+        cipherArr.eval()
+        return try ActivationCodec.decode(openCh.open(toBytes(cipherArr), context: ctx))
+    }
+
+    private func sendActivation(_ hidden: MLXArray, frameSeq: UInt64,
+                                sealCh: ClusterSealingChannel) throws {
+        let ctx = hopContext(frameSeq: frameSeq, senderRank: plan.rank)
+        let sealed = try sealCh.seal(ActivationCodec.encode(hidden.asType(.bfloat16)), context: ctx)
+        let dep = try group.send(toI32(sealed), to: plan.rank + 1)
+        dep.eval()
+    }
+
+    /// Head-side helpers used by the scheduler (public seams).
+    public func sendHead(_ hidden: MLXArray, frameSeq: UInt64, sealCh: ClusterSealingChannel) throws {
+        try sendActivation(hidden, frameSeq: frameSeq, sealCh: sealCh)
+    }
+    public func recvHead(B: Int, width: Int, frameSeq: UInt64, openCh: ClusterOpeningChannel) throws -> MLXArray {
+        try recvActivation(B: B, width: width, frameSeq: frameSeq, openCh: openCh)
+    }
+
+    public func broadcast(_ hidden: MLXArray?, B: Int) throws -> [Int] {
+        try broadcastTokens(hidden, B: B)
+    }
+
+    /// Sample the tail's `[B]` next tokens and all_gather them so every rank
+    /// learns all rows' next tokens. Non-tail ranks contribute zeros.
+    private func broadcastTokens(_ hidden: MLXArray?, B: Int) throws -> [Int] {
+        var tokenVec = MLXArray([Int32](repeating: 0, count: B), [B])
+        if plan.isTail, let hidden {
+            let logits = shard.projectToLogitsBatched(hidden)
+            let ids = argMax(logits, axis: logits.ndim - 1)
+            ids.eval()
+            let flat = ids.asArray(Int32.self)
+            if flat.count == B { tokenVec = MLXArray(flat, [B]) }
+            else { tokenVec = MLXArray(Array(flat.suffix(B)), [B]) }
+        }
+        let gathered = try group.allGather(tokenVec)
+        gathered.eval()
+        let all = gathered.asArray(Int32.self)
+        let base = tailRank * B
+        return (0..<B).map { Int(all[base + $0]) }
+    }
+
+    // MARK: - Peer loop
+
+    /// PEER loop: replay the head's per-step composition until shutdown. Peers
+    /// have no scheduler; they apply evict/admit/decode exactly as the head
+    /// dictates, keeping their local KV caches row-aligned with the head's.
+    public func runBatchedPeerLoop(makeChannels: () -> (ClusterSealingChannel?, ClusterOpeningChannel?)) throws {
+        let (sealCh, openCh) = makeChannels()
+        // Independent per-direction counters: recvSeq tracks the OPENING channel
+        // (frames received from prevRank), sealSeq tracks the SEALING channel
+        // (frames sent to nextRank). Each must match its channel's internal
+        // counter and the matching side's seq exactly.
+        var recvSeq: UInt64 = 0
+        var sealSeq: UInt64 = 0
+        var liveB = 0
+        var started = false
+
+        // Dead-ring backoff — same rationale as ClusterServer.runPeerLoop: a live
+        // head blocks the peer in the composition all_gather (no spin), but a dead
+        // head makes it throw immediately. Back off on consecutive failures and
+        // exit rather than busy-spin a CPU core for the life of the process.
+        let maxConsecutiveFailures = 50
+        let backoffCapSeconds = 5.0
+        var consecutiveFailures = 0
+
+        while true {
+            let comp: ClusterBatchComposition
+            do {
+                comp = try exchangeComposition(nil)
+            } catch {
+                consecutiveFailures += 1
+                if consecutiveFailures >= maxConsecutiveFailures { throw error }
+                let delay = min(backoffCapSeconds, 0.01 * pow(2.0, Double(min(consecutiveFailures, 9))))
+                Thread.sleep(forTimeInterval: delay)
+                continue
+            }
+            consecutiveFailures = 0
+            switch comp.command {
+            case .shutdown: return
+            case .idle: continue
+            case .step: break
+            }
+
+            // 1. Evict. Only filter when there's a live batch AND the keep set
+            //    actually changes it. When keepIndices is empty (batch fully
+            //    drained) we must NOT call filter with [] — BatchKVCache.filter
+            //    does leftPadding.min() which traps on a zero-size array. Instead
+            //    re-init a fresh empty batch so the next admit starts clean.
+            if comp.keepIndices.isEmpty {
+                if liveB > 0 || !started { shard.beginBatch(leftPadding: []); started = true }
+            } else {
+                if !started { shard.beginBatch(leftPadding: []); started = true }
+                if comp.keepIndices.count != liveB || comp.keepIndices != Array(0..<liveB) {
+                    shard.filterBatch(keepIndices: comp.keepIndices)
+                }
+            }
+            var B = comp.keepIndices.count
+
+            // 2. Admit: prefill admitted rows over the ring + extend caches.
+            if !comp.admit.isEmpty {
+                let nAdmit = comp.admit.count
+                let prefillW = comp.admit.map(\.promptTokens.count).max() ?? 0
+                let leftPad = comp.admit.map(\.leftPadding)
+                let hidden = try recvActivation(B: nAdmit, width: prefillW, frameSeq: recvSeq, openCh: openCh!)
+                recvSeq += 1
+                let out = shard.admitPrefill(hidden, leftPadding: leftPad)
+                if !plan.isTail {
+                    try sendActivation(out, frameSeq: sealSeq, sealCh: sealCh!)
+                    sealSeq += 1
+                }
+                _ = try broadcastTokens(plan.isTail ? out : nil, B: nAdmit)
+                B += nAdmit
+            }
+
+            // 3. Decode step over the full live batch B.
+            liveB = B
+            if B == 0 { continue }
+            let hidden = try recvActivation(B: B, width: 1, frameSeq: recvSeq, openCh: openCh!)
+            recvSeq += 1
+            let out = shard.runOwnedLayersBatched(hidden)
+            if !plan.isTail {
+                try sendActivation(out, frameSeq: sealSeq, sealCh: sealCh!)
+                sealSeq += 1
+            }
+            _ = try broadcastTokens(plan.isTail ? out : nil, B: B)
+        }
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Cluster/ClusterBringup.swift
+++ b/provider-swift/Sources/ProviderCore/Cluster/ClusterBringup.swift
@@ -1,0 +1,86 @@
+/// ClusterBringup -- bring a node into its cluster and produce a ready
+/// `DistributedInferenceEngine`.
+///
+/// This is the orchestration the provider start path runs (when a `ClusterPlan`
+/// is present) instead of standing up a single-node `BatchScheduler`:
+///
+///   1. Establish encrypted sessions with ring neighbors via the handshake
+///      (`ClusterHandshakeRunner` over `HandshakeChannel`), authenticated
+///      against the coordinator-signed roster.
+///   2. Materialize the MLX ring hostfile + env (`MLXRingEnvironment`) and
+///      initialize the distributed group (`MLXDistributedGroup`).
+///   3. Build the `DistributedInferenceEngine` with a runtime that wraps the
+///      ring transport + the neighbor sessions.
+///
+/// The handshake + session derivation + engine assembly are all real and
+/// testable on one machine (with the in-memory channel + loopback runtime). The
+/// two hardware-bound steps — opening real sockets to neighbors and the MLX
+/// ring `init/send/recv` — are isolated behind `HandshakeChannel` and
+/// `ClusterRuntime`, so this orchestration is exercised end-to-end in tests and
+/// reused unchanged on the two Macs.
+
+import Foundation
+
+public struct ClusterBringupResult: Sendable {
+    /// Session sealing toward the next rank (nil on the tail).
+    public let sendSession: ClusterSession?
+    /// Session opening from the previous rank (nil on the head).
+    public let recvSession: ClusterSession?
+    /// MLX ring environment to apply before group init (host-bound).
+    public let ringEnv: [String: String]
+}
+
+public enum ClusterBringupError: Error, Sendable {
+    case noNeighbors
+}
+
+public enum ClusterBringup {
+    /// Run the pairwise handshakes with this node's ring neighbors.
+    ///
+    /// Ordering rule (matches `ClusterHandshake`): for each adjacent pair the
+    /// LOWER nodeId is the initiator. The caller supplies a `HandshakeChannel`
+    /// to each neighbor (a dialed/accepted socket on hardware; an in-memory pair
+    /// in tests). Returns the derived sessions for the prev/next links.
+    public static func handshakeNeighbors(
+        plan: ClusterPlan,
+        signer: any AttestationSigner,
+        roster: ClusterRosterBody,
+        channelToPrev: (any HandshakeChannel)?,
+        channelToNext: (any HandshakeChannel)?
+    ) async throws -> (recv: ClusterSession?, send: ClusterSession?) {
+        let (prevId, nextId) = plan.neighborNodeIds()
+
+        // Session with the PREVIOUS neighbor (it is upstream; we receive from it).
+        var recvSession: ClusterSession?
+        if let prevId, let channel = channelToPrev {
+            recvSession = try await runPair(
+                local: plan.nodeId, peer: prevId, clusterId: plan.clusterId,
+                signer: signer, roster: roster, channel: channel)
+        }
+
+        // Session with the NEXT neighbor (downstream; we send to it).
+        var sendSession: ClusterSession?
+        if let nextId, let channel = channelToNext {
+            sendSession = try await runPair(
+                local: plan.nodeId, peer: nextId, clusterId: plan.clusterId,
+                signer: signer, roster: roster, channel: channel)
+        }
+
+        return (recvSession, sendSession)
+    }
+
+    /// Decide initiator vs responder by nodeId ordering, then run the handshake.
+    private static func runPair(
+        local: String, peer: String, clusterId: String,
+        signer: any AttestationSigner, roster: ClusterRosterBody,
+        channel: any HandshakeChannel
+    ) async throws -> ClusterSession {
+        if local < peer {
+            return try await ClusterHandshakeRunner.runInitiator(
+                clusterId: clusterId, localNodeId: local, signer: signer, roster: roster, channel: channel)
+        } else {
+            return try await ClusterHandshakeRunner.runResponder(
+                localNodeId: local, signer: signer, roster: roster, channel: channel)
+        }
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Cluster/ClusterHandshake.swift
+++ b/provider-swift/Sources/ProviderCore/Cluster/ClusterHandshake.swift
@@ -1,0 +1,293 @@
+/// ClusterHandshake -- mutual-authenticated key agreement between two cluster
+/// members, before any activation crosses the link.
+///
+/// A SIGMA-style "sign the transcript" exchange (3 messages). Each side proves
+/// it controls an attested Secure-Enclave identity (listed in the
+/// coordinator-signed `ClusterRoster`) AND that it chose this session's
+/// ephemeral X25519 key -- the same SE-vouches-for-an-X25519-key binding the
+/// coordinator already enforces at registration
+/// (`coordinator/api/provider.go` EncryptionPublicKey == register key),
+/// applied pairwise. See docs/architecture/cluster-node-handshake.md §5.
+///
+///   transcript1 = clusterId ‖ A.nodeId ‖ eA.pub ‖ nonceA ‖ B.nodeId ‖ eB.pub ‖ nonceB
+///   A → B  Msg1 { clusterId, A.nodeId, eA.pub, nonceA }
+///   B → A  Msg2 { B.nodeId, eB.pub, nonceB, sigB }   sigB = SE_B.sign(transcript1)
+///   A → B  Msg3 { sigA }                             sigA = SE_A.sign(transcript1 ‖ sigB)
+///
+/// Ephemeral X25519 keys give forward secrecy; the long-term SE key only signs
+/// (SE P-256 is signing-only). The derived master secret feeds
+/// `ClusterSessionKeys` / `ClusterLinkCrypto` for per-token sealing.
+///
+/// Built on existing primitives -- `X25519KeyAgreementKeyPair`,
+/// `AttestationSigner`, `SecureEnclaveIdentity.verify` -- so the whole flow is
+/// unit-testable on one machine with a software P-256 signer.
+
+import CryptoKit
+import Foundation
+
+public enum ClusterHandshakeError: Error, Equatable, Sendable {
+    case peerNotInRoster(nodeId: String)
+    case peerSignatureInvalid(nodeId: String)
+    case staleNonce
+    case badPublicKeyLength
+    case rosterClusterMismatch
+}
+
+// MARK: - Wire messages
+
+public struct ClusterHandshakeMsg1: Codable, Equatable, Sendable {
+    public let clusterId: String
+    public let initiatorNodeId: String
+    public let ephemeralPublicKey: Data   // 32-byte X25519
+    public let nonce: Data                // 32-byte random
+}
+
+public struct ClusterHandshakeMsg2: Codable, Equatable, Sendable {
+    public let responderNodeId: String
+    public let ephemeralPublicKey: Data   // 32-byte X25519
+    public let nonce: Data                // 32-byte random
+    public let signature: Data            // DER P-256 over transcript1
+}
+
+public struct ClusterHandshakeMsg3: Codable, Equatable, Sendable {
+    public let signature: Data            // DER P-256 over transcript1 ‖ sigB
+}
+
+/// The result both sides converge on: a shared master secret plus the
+/// directional keys ready for `ClusterLinkCrypto`.
+public struct ClusterSession: Sendable {
+    public let clusterId: String
+    public let localNodeId: String
+    public let peerNodeId: String
+    public let masterSecret: SymmetricKey
+
+    /// Construct a session directly from an agreed master secret. Used by the
+    /// handshake, and by direct ephemeral key-agreement paths (e.g. the
+    /// ring-only encrypted link without a coordinator roster).
+    public init(clusterId: String, localNodeId: String, peerNodeId: String, masterSecret: SymmetricKey) {
+        self.clusterId = clusterId
+        self.localNodeId = localNodeId
+        self.peerNodeId = peerNodeId
+        self.masterSecret = masterSecret
+    }
+
+    /// Key for frames this node SENDS to the peer.
+    public func sendKey() -> SymmetricKey {
+        ClusterSessionKeys.directionalKey(
+            masterSecret: masterSecret, clusterId: clusterId,
+            fromNodeId: localNodeId, toNodeId: peerNodeId)
+    }
+
+    /// Key for frames this node RECEIVES from the peer.
+    public func recvKey() -> SymmetricKey {
+        ClusterSessionKeys.directionalKey(
+            masterSecret: masterSecret, clusterId: clusterId,
+            fromNodeId: peerNodeId, toNodeId: localNodeId)
+    }
+}
+
+// MARK: - Transcript
+
+enum ClusterTranscript {
+    /// Length-prefixed concatenation so no field boundary is ambiguous.
+    static func part(_ data: Data) -> Data {
+        var out = Data()
+        var len = UInt32(data.count).bigEndian
+        withUnsafeBytes(of: &len) { out.append(contentsOf: $0) }
+        out.append(data)
+        return out
+    }
+
+    static func one(
+        clusterId: String,
+        initiatorNodeId: String, eAPub: Data, nonceA: Data,
+        responderNodeId: String, eBPub: Data, nonceB: Data
+    ) -> Data {
+        var t = Data()
+        t.append(part(Data(clusterId.utf8)))
+        t.append(part(Data(initiatorNodeId.utf8)))
+        t.append(part(eAPub))
+        t.append(part(nonceA))
+        t.append(part(Data(responderNodeId.utf8)))
+        t.append(part(eBPub))
+        t.append(part(nonceB))
+        return t
+    }
+}
+
+// MARK: - Shared helpers
+
+enum ClusterKeyAgreement {
+    static let masterInfoPrefix = "darkbloom-cluster-handshake-v1"
+
+    /// Derive the master secret from the ephemeral agreement, channel-bound to
+    /// the cluster and the (sorted) identity pair so a recorded handshake can't
+    /// be re-pointed at a different peer.
+    static func masterSecret(
+        ephemeral: X25519KeyAgreementKeyPair,
+        peerEphemeralPublicKey: Data,
+        clusterId: String,
+        nodeIdA: String,
+        nodeIdB: String,
+        nonceA: Data,
+        nonceB: Data
+    ) throws -> SymmetricKey {
+        let pair = [nodeIdA, nodeIdB].sorted().joined(separator: "<>")
+        let sharedInfo = Data("\(masterInfoPrefix)|\(clusterId)|\(pair)".utf8)
+        return try ephemeral.symmetricKey(
+            peerPublicKey: peerEphemeralPublicKey,
+            salt: nonceA + nonceB,
+            sharedInfo: sharedInfo
+        )
+    }
+
+    static func randomNonce() -> Data {
+        var key = SymmetricKey(size: .bits256)
+        return key.withUnsafeBytes { Data($0) }
+    }
+}
+
+// MARK: - Initiator (node A, lower nodeId)
+
+public final class ClusterHandshakeInitiator {
+    private let clusterId: String
+    private let localNodeId: String
+    private let signer: any AttestationSigner
+    private let roster: ClusterRosterBody
+
+    private let ephemeral = X25519KeyAgreementKeyPair()
+    private let nonceA = ClusterKeyAgreement.randomNonce()
+
+    public init(
+        clusterId: String,
+        localNodeId: String,
+        signer: any AttestationSigner,
+        roster: ClusterRosterBody
+    ) {
+        self.clusterId = clusterId
+        self.localNodeId = localNodeId
+        self.signer = signer
+        self.roster = roster
+    }
+
+    /// Build Msg1.
+    public func start() -> ClusterHandshakeMsg1 {
+        ClusterHandshakeMsg1(
+            clusterId: clusterId,
+            initiatorNodeId: localNodeId,
+            ephemeralPublicKey: ephemeral.publicKey,
+            nonce: nonceA
+        )
+    }
+
+    /// Consume Msg2 (verify B), produce Msg3, and finalize the session.
+    public func finish(_ msg2: ClusterHandshakeMsg2) throws -> (ClusterHandshakeMsg3, ClusterSession) {
+        guard msg2.ephemeralPublicKey.count == 32, msg2.nonce.count == 32 else {
+            throw ClusterHandshakeError.badPublicKeyLength
+        }
+        // We must be on the roster we were issued before forming a link.
+        _ = try ClusterRoster.member(roster, nodeId: localNodeId)
+        let peer = try ClusterRoster.member(roster, nodeId: msg2.responderNodeId)
+        guard let peerSEKey = Data(base64Encoded: peer.sePublicKeyBase64) else {
+            throw ClusterHandshakeError.peerNotInRoster(nodeId: msg2.responderNodeId)
+        }
+
+        let t1 = ClusterTranscript.one(
+            clusterId: clusterId,
+            initiatorNodeId: localNodeId, eAPub: ephemeral.publicKey, nonceA: nonceA,
+            responderNodeId: msg2.responderNodeId, eBPub: msg2.ephemeralPublicKey, nonceB: msg2.nonce)
+
+        guard SecureEnclaveIdentity.verify(signature: msg2.signature, for: t1, publicKey: peerSEKey) else {
+            throw ClusterHandshakeError.peerSignatureInvalid(nodeId: msg2.responderNodeId)
+        }
+
+        let sigA = try signer.sign(t1 + msg2.signature)
+        let master = try ClusterKeyAgreement.masterSecret(
+            ephemeral: ephemeral,
+            peerEphemeralPublicKey: msg2.ephemeralPublicKey,
+            clusterId: clusterId,
+            nodeIdA: localNodeId, nodeIdB: msg2.responderNodeId,
+            nonceA: nonceA, nonceB: msg2.nonce)
+
+        let session = ClusterSession(
+            clusterId: clusterId, localNodeId: localNodeId,
+            peerNodeId: msg2.responderNodeId, masterSecret: master)
+        return (ClusterHandshakeMsg3(signature: sigA), session)
+    }
+}
+
+// MARK: - Responder (node B)
+
+public final class ClusterHandshakeResponder {
+    private let localNodeId: String
+    private let signer: any AttestationSigner
+    private let roster: ClusterRosterBody
+
+    private let ephemeral = X25519KeyAgreementKeyPair()
+    private let nonceB = ClusterKeyAgreement.randomNonce()
+
+    // captured between respond() and confirm()
+    private var transcript1: Data?
+    private var sigB: Data?
+    private var peerNodeId: String?
+    private var pendingSession: ClusterSession?
+
+    public init(localNodeId: String, signer: any AttestationSigner, roster: ClusterRosterBody) {
+        self.localNodeId = localNodeId
+        self.signer = signer
+        self.roster = roster
+    }
+
+    /// Consume Msg1, produce Msg2. Stages the session pending Msg3 verification.
+    public func respond(_ msg1: ClusterHandshakeMsg1) throws -> ClusterHandshakeMsg2 {
+        guard msg1.ephemeralPublicKey.count == 32, msg1.nonce.count == 32 else {
+            throw ClusterHandshakeError.badPublicKeyLength
+        }
+        // Both ends must be vouched for by the roster we were issued: the peer
+        // (initiator) AND ourselves. A node absent from the roster must refuse
+        // to participate rather than form an unattested link.
+        _ = try ClusterRoster.member(roster, nodeId: localNodeId)
+        _ = try ClusterRoster.member(roster, nodeId: msg1.initiatorNodeId)
+
+        let t1 = ClusterTranscript.one(
+            clusterId: msg1.clusterId,
+            initiatorNodeId: msg1.initiatorNodeId, eAPub: msg1.ephemeralPublicKey, nonceA: msg1.nonce,
+            responderNodeId: localNodeId, eBPub: ephemeral.publicKey, nonceB: nonceB)
+        let signature = try signer.sign(t1)
+
+        let master = try ClusterKeyAgreement.masterSecret(
+            ephemeral: ephemeral,
+            peerEphemeralPublicKey: msg1.ephemeralPublicKey,
+            clusterId: msg1.clusterId,
+            nodeIdA: msg1.initiatorNodeId, nodeIdB: localNodeId,
+            nonceA: msg1.nonce, nonceB: nonceB)
+
+        self.transcript1 = t1
+        self.sigB = signature
+        self.peerNodeId = msg1.initiatorNodeId
+        self.pendingSession = ClusterSession(
+            clusterId: msg1.clusterId, localNodeId: localNodeId,
+            peerNodeId: msg1.initiatorNodeId, masterSecret: master)
+
+        return ClusterHandshakeMsg2(
+            responderNodeId: localNodeId,
+            ephemeralPublicKey: ephemeral.publicKey,
+            nonce: nonceB,
+            signature: signature)
+    }
+
+    /// Consume Msg3 (verify A), returning the confirmed session.
+    public func confirm(_ msg3: ClusterHandshakeMsg3) throws -> ClusterSession {
+        guard let t1 = transcript1, let sigB, let peerNodeId, let session = pendingSession else {
+            throw ClusterHandshakeError.staleNonce
+        }
+        let peer = try ClusterRoster.member(roster, nodeId: peerNodeId)
+        guard let peerSEKey = Data(base64Encoded: peer.sePublicKeyBase64) else {
+            throw ClusterHandshakeError.peerNotInRoster(nodeId: peerNodeId)
+        }
+        guard SecureEnclaveIdentity.verify(signature: msg3.signature, for: t1 + sigB, publicKey: peerSEKey) else {
+            throw ClusterHandshakeError.peerSignatureInvalid(nodeId: peerNodeId)
+        }
+        return session
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Cluster/ClusterHeadBringup.swift
+++ b/provider-swift/Sources/ProviderCore/Cluster/ClusterHeadBringup.swift
@@ -25,7 +25,7 @@ public enum ClusterHeadBringupError: Error, CustomStringConvertible {
     public var description: String {
         switch self {
         case .rankMismatch(let e, let g): return "ring rank \(g) != configured rank \(e)"
-        case .unsupportedModelType(let t): return "unsupported model_type '\(t)' (have: gpt_oss)"
+        case .unsupportedModelType(let t): return "unsupported model_type '\(t)' (have: gpt_oss, gemma4)"
         case .configRead(let m): return "config read failed: \(m)"
         }
     }
@@ -65,8 +65,15 @@ public enum ClusterHeadBringup {
 
     private static func configInt(_ dir: URL, _ key: String) throws -> Int {
         guard let data = try? Data(contentsOf: dir.appending(component: "config.json")),
-              let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-              let v = obj[key] as? Int else { throw ClusterHeadBringupError.configRead(key) }
+              let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else { throw ClusterHeadBringupError.configRead(key) }
+        // Multimodal configs (e.g. Gemma 4) nest the text tower's dims under
+        // `text_config`; prefer that, falling back to the top level for flat
+        // configs (Llama / Mistral / GPT-OSS).
+        if let textCfg = obj["text_config"] as? [String: Any], let v = textCfg[key] as? Int {
+            return v
+        }
+        guard let v = obj[key] as? Int else { throw ClusterHeadBringupError.configRead(key) }
         return v
     }
 
@@ -123,6 +130,7 @@ public enum ClusterHeadBringup {
         let shard: any PipelineModelShard
         switch mt {
         case "gpt_oss": shard = try GPTOSSShardAdapter.load(directory: modelDir, interval: interval)
+        case "gemma4", "gemma4_text": shard = try Gemma4ShardAdapter.load(directory: modelDir, interval: interval)
         default: throw ClusterHeadBringupError.unsupportedModelType(mt)
         }
 

--- a/provider-swift/Sources/ProviderCore/Cluster/ClusterHeadBringup.swift
+++ b/provider-swift/Sources/ProviderCore/Cluster/ClusterHeadBringup.swift
@@ -1,0 +1,197 @@
+/// ClusterHeadBringup -- bring a node into the cluster ring and return the
+/// pieces the proven decode loop (`ClusterPipeline` / `ClusterServer`) needs:
+/// the ring group, this rank's loaded shard, the tokenizer, and the directional
+/// encrypted-link sessions (ephemeral X25519 agreed over the ring).
+///
+/// Shared by cluster-run (one-shot) and cluster-provider (server). Joins the MLX
+/// ring (blocks until all nodes connect), does the auto memory-weighted split,
+/// loads only this rank's layer slice, and agrees per-neighbor session keys.
+///
+/// Activations cross the ring ENCRYPTED (X25519 + ChaCha20-Poly1305, forward
+/// secrecy). Attestation binding of the ephemeral keys to Secure-Enclave
+/// identities is the coordinator-roster follow-up.
+
+import CryptoKit
+import Foundation
+import MLX
+import MLXLLM
+import MLXLMCommon
+
+public enum ClusterHeadBringupError: Error, CustomStringConvertible {
+    case rankMismatch(expected: Int, got: Int)
+    case unsupportedModelType(String)
+    case configRead(String)
+
+    public var description: String {
+        switch self {
+        case .rankMismatch(let e, let g): return "ring rank \(g) != configured rank \(e)"
+        case .unsupportedModelType(let t): return "unsupported model_type '\(t)' (have: gpt_oss)"
+        case .configRead(let m): return "config read failed: \(m)"
+        }
+    }
+}
+
+/// Everything a node needs to participate in the cluster decode loop.
+public struct ClusterContext {
+    public let plan: ClusterPlan
+    public let group: MLXDistributedGroup
+    public let shard: any PipelineModelShard
+    public let tokenizer: any Tokenizer
+    public let eosTokenIds: Set<Int>
+    public let hiddenSize: Int
+    /// Directional sessions for the encrypted ring link.
+    public let sendSession: ClusterSession?   // toward nextRank (nil on tail)
+    public let recvSession: ClusterSession?   // from prevRank (nil on head)
+    /// HEAD ONLY: the cluster registration JSON — {cluster_id, members:[…]} —
+    /// assembled from every node's signed attestation gathered over the ring.
+    /// The head relays this to the coordinator so it can verify each member.
+    public let clusterRegistrationJSON: Data?
+
+    /// Fresh sealing/opening channels for one request (nonce sequence restarts).
+    public func makeChannels() -> (ClusterSealingChannel?, ClusterOpeningChannel?) {
+        (sendSession.map { ClusterSealingChannel(key: $0.sendKey()) },
+         recvSession.map { ClusterOpeningChannel(key: $0.recvKey()) })
+    }
+
+    /// Build a ClusterPipeline for one request with fresh channels.
+    public func makePipeline() -> ClusterPipeline {
+        let (seal, open) = makeChannels()
+        return ClusterPipeline(plan: plan, group: group, shard: shard,
+                               hiddenSize: hiddenSize, sealCh: seal, openCh: open)
+    }
+}
+
+public enum ClusterHeadBringup {
+
+    private static func configInt(_ dir: URL, _ key: String) throws -> Int {
+        guard let data = try? Data(contentsOf: dir.appending(component: "config.json")),
+              let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let v = obj[key] as? Int else { throw ClusterHeadBringupError.configRead(key) }
+        return v
+    }
+
+    private static func modelType(_ dir: URL) -> String {
+        guard let data = try? Data(contentsOf: dir.appending(component: "config.json")),
+              let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let t = obj["model_type"] as? String else { return "" }
+        return t
+    }
+
+    /// Join the ring, load this rank's shard, agree encrypted-link sessions, and
+    /// return a `ClusterContext`. Blocks on ring init until all nodes connect.
+    ///
+    /// `attestationJSON` is THIS node's signed Secure-Enclave attestation blob
+    /// (built by the caller from its SE identity). All nodes gather their blobs
+    /// over the ring so the head can assemble the cluster registration the
+    /// coordinator verifies. Pass nil to skip cluster attestation (e.g. on a
+    /// platform without SE).
+    public static func bringUp(plan: ClusterPlan, modelDir: URL, attestationJSON: Data? = nil) async throws -> ClusterContext {
+        // 1. Ring env + join.
+        let stateDir = (try? ConfigManager.defaultConfigPath().deletingLastPathComponent())
+            ?? FileManager.default.temporaryDirectory
+        try? FileManager.default.createDirectory(at: stateDir, withIntermediateDirectories: true)
+        let env = try MLXRingEnvironment.materialize(plan, directory: stateDir)
+        for (k, v) in env { setenv(k, v, 1) }
+
+        let physical = ProcessInfo.processInfo.physicalMemory
+        MLX.GPU.set(memoryLimit: Int(Double(physical) * 0.80), relaxed: false)
+        MLX.GPU.set(cacheLimit: 512 * 1024 * 1024)
+
+        let group = try MLXDistributedGroup.initialize(backend: plan.backend, strict: true)
+        guard group.rank == plan.rank else {
+            throw ClusterHeadBringupError.rankMismatch(expected: plan.rank, got: group.rank)
+        }
+
+        // 2. Auto memory-weighted split via all-gathered budgets.
+        let totalLayers = try configInt(modelDir, "num_hidden_layers")
+        let gbF = 1_073_741_824.0
+        let myBudget = max(2.0, Double(physical) / gbF - 10.0)
+        var budgetVec = [Float](repeating: 0, count: plan.worldSize)
+        budgetVec[plan.rank] = Float(myBudget)
+        let bg = try group.allGather(MLXArray(budgetVec, [plan.worldSize]))
+        bg.eval()
+        let flat = bg.asArray(Float.self)
+        let weights = plan.members.enumerated().map { (i, m) in
+            LayerPartition.NodeWeight(
+                nodeId: m.nodeId,
+                weightBytes: UInt64(max(1.0, Double(flat[i * plan.worldSize + i])) * gbF))
+        }
+        let interval = try LayerPartition.partition(totalLayers: totalLayers, nodes: weights)[plan.rank]
+
+        // 3. Load this rank's shard by architecture.
+        let mt = modelType(modelDir)
+        let shard: any PipelineModelShard
+        switch mt {
+        case "gpt_oss": shard = try GPTOSSShardAdapter.load(directory: modelDir, interval: interval)
+        default: throw ClusterHeadBringupError.unsupportedModelType(mt)
+        }
+
+        // 4. Tokenizer + EOS + hidden size.
+        let tokenizer = try await LocalTokenizerLoader().load(from: modelDir)
+        var eos = Set<Int>()
+        if let e = tokenizer.eosTokenId { eos.insert(e) }
+        let hiddenSize = try configInt(modelDir, "hidden_size")
+
+        // 5. Encrypted-link sessions: ephemeral X25519 agreed over the ring.
+        let ephemeral = X25519KeyAgreementKeyPair()
+        let myPub = ephemeral.publicKey
+        func toI32(_ d: Data) -> MLXArray { MLXArray(d.map { Int32($0) }, [d.count]) }
+        func toBytes(_ a: MLXArray) -> Data { Data(a.asArray(Int32.self).map { UInt8(truncatingIfNeeded: $0) }) }
+        let pg = try group.allGather(toI32(myPub)); pg.eval()
+        let allPub = toBytes(pg)
+        func peerPub(_ r: Int) -> Data { allPub.subdata(in: r*32 ..< r*32 + 32) }
+        func session(_ peerRank: Int, _ peerId: String) throws -> ClusterSession {
+            let peer = peerPub(peerRank)
+            let salt = myPub.lexicographicallyPrecedes(peer) ? myPub + peer : peer + myPub
+            let master = try ephemeral.symmetricKey(
+                peerPublicKey: peer, salt: salt,
+                sharedInfo: Data("darkbloom-cluster-ring-v1|\(plan.clusterId)".utf8))
+            return ClusterSession(clusterId: plan.clusterId, localNodeId: plan.nodeId,
+                                  peerNodeId: peerId, masterSecret: master)
+        }
+        let ids = plan.members.map(\.nodeId)
+        let sendSession = try plan.nextRank.map { try session($0, ids[$0]) }
+        let recvSession = try plan.prevRank.map { try session($0, ids[$0]) }
+
+        // 6. Attestation gather: every node contributes its signed SE attestation
+        // blob over the ring (fixed-width frame: 4-byte big-endian length +
+        // payload, padded). The head assembles them into the cluster
+        // registration JSON the coordinator verifies. Skipped if no blob.
+        // The attestation gather is opt-in: DARKBLOOM_CLUSTER_ATTEST=1. It adds a
+        // third ring all_gather (of each node's attestation blob) which can
+        // stress the ring transport; keeping it off by default preserves the
+        // known-working inference path while it's validated on hardware.
+        var clusterRegJSON: Data? = nil
+        if let myBlob = attestationJSON, ProcessInfo.processInfo.environment["DARKBLOOM_CLUSTER_ATTEST"] == "1" {
+            let frameW = 4 * 1024   // attestation blobs are ~hundreds of bytes; keep the ring frame small (a 64KB all_gather tripped the ring transport)
+            var framed = Data()
+            var len = UInt32(min(myBlob.count, frameW - 4)).bigEndian
+            withUnsafeBytes(of: &len) { framed.append(contentsOf: $0) }
+            framed.append(myBlob.prefix(frameW - 4))
+            if framed.count < frameW { framed.append(Data(count: frameW - framed.count)) }
+            let gatheredBlobs = try group.allGather(
+                MLXArray(framed.map { Int32($0) }, [frameW]))
+            gatheredBlobs.eval()
+            if plan.isHead {
+                let all = gatheredBlobs.asArray(Int32.self)
+                var membersJSON = [[String: Any]]()
+                for r in 0..<plan.worldSize {
+                    let base = r * frameW
+                    let l = Int(UInt32(bigEndian: (0..<4).reduce(UInt32(0)) { ($0 << 8) | UInt32(UInt8(truncatingIfNeeded: all[base + $1])) }))
+                    let bodyBytes = (0..<l).map { UInt8(truncatingIfNeeded: all[base + 4 + $0]) }
+                    if let blobObj = try? JSONSerialization.jsonObject(with: Data(bodyBytes)) {
+                        membersJSON.append(["node_id": ids[r], "rank": r, "attestation": blobObj])
+                    }
+                }
+                let reg: [String: Any] = ["cluster_id": plan.clusterId, "members": membersJSON]
+                clusterRegJSON = try? JSONSerialization.data(withJSONObject: reg)
+            }
+        }
+
+        return ClusterContext(
+            plan: plan, group: group, shard: shard, tokenizer: tokenizer,
+            eosTokenIds: eos, hiddenSize: hiddenSize,
+            sendSession: sendSession, recvSession: recvSession,
+            clusterRegistrationJSON: clusterRegJSON)
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Cluster/ClusterLinkCrypto.swift
+++ b/provider-swift/Sources/ProviderCore/Cluster/ClusterLinkCrypto.swift
@@ -1,0 +1,160 @@
+/// ClusterLinkCrypto -- the data-plane cipher for the inter-node activation link.
+///
+/// After two cluster members complete the `ClusterHandshake`, they share a
+/// 32-byte master secret derived from an ephemeral X25519 agreement. This type
+/// turns that secret into two *directional* session keys and seals/opens each
+/// activation tensor that crosses the link.
+///
+/// Design (see docs/architecture/cluster-node-handshake.md §5-6):
+///   - Per direction, ChaCha20-Poly1305 under a cached key + a strictly
+///     monotonic 96-bit counter nonce. We do NOT do a fresh key agreement per
+///     token -- that would cost an ECDH per token; the whole point of the
+///     handshake is to amortize the agreement once.
+///   - The AEAD's additional authenticated data binds each frame to its
+///     cluster, request, layer boundary, and sequence number, so a sealed
+///     activation cannot be replayed into a different request/layer or reordered.
+///   - Nonce discipline: the counter must never repeat for a given key. A
+///     `SealingChannel` enforces monotonicity and refuses to wrap.
+///
+/// Pure CryptoKit + Foundation: unit-testable on one machine.
+
+import CryptoKit
+import Foundation
+
+public enum ClusterLinkError: Error, Equatable, Sendable {
+    case nonceCounterExhausted
+    case openFailed
+    case shortFrame
+}
+
+/// Identifies one directed activation frame for AEAD binding.
+public struct ClusterFrameContext: Equatable, Sendable {
+    public let clusterId: String
+    public let requestId: String
+    /// Inclusive-exclusive layer interval the sender owns, e.g. "0..24".
+    public let layerRange: String
+    /// Per-(request,direction) monotonic frame sequence number.
+    public let seq: UInt64
+
+    public init(clusterId: String, requestId: String, layerRange: String, seq: UInt64) {
+        self.clusterId = clusterId
+        self.requestId = requestId
+        self.layerRange = layerRange
+        self.seq = seq
+    }
+
+    /// Deterministic AAD bytes. Field-tagged + length-free safe because each
+    /// component is separated by a byte that cannot appear in the others'
+    /// canonical forms (`\u{1f}` unit separator), and `seq` is fixed-width.
+    public var aad: Data {
+        var d = Data()
+        d.append(Data(clusterId.utf8))
+        d.append(0x1f)
+        d.append(Data(requestId.utf8))
+        d.append(0x1f)
+        d.append(Data(layerRange.utf8))
+        d.append(0x1f)
+        var s = seq.bigEndian
+        withUnsafeBytes(of: &s) { d.append(contentsOf: $0) }
+        return d
+    }
+}
+
+/// Derives directional session keys from the handshake master secret.
+public enum ClusterSessionKeys {
+    /// Domain separator for the link cipher.
+    static let info = Data("darkbloom-cluster-link-v1".utf8)
+
+    /// Split the master secret into a (send, recv) key pair for a node.
+    ///
+    /// Directional keys are derived by binding the HKDF `info` to an ordered
+    /// pair of node ids: the key for traffic A→B uses "A>B", B→A uses "B>A".
+    /// Both nodes compute both keys identically; each uses the one matching its
+    /// send/recv direction. This guarantees the two directions never share a
+    /// (key, nonce) space even though both start their counters at 0.
+    public static func directionalKey(
+        masterSecret: SymmetricKey,
+        clusterId: String,
+        fromNodeId: String,
+        toNodeId: String
+    ) -> SymmetricKey {
+        var perDirectionInfo = info
+        perDirectionInfo.append(Data("|\(clusterId)|\(fromNodeId)>\(toNodeId)".utf8))
+        return HKDF<SHA256>.deriveKey(
+            inputKeyMaterial: masterSecret,
+            info: perDirectionInfo,
+            outputByteCount: 32
+        )
+    }
+}
+
+/// A one-directional sealing channel: cached key + monotonic counter nonce.
+/// Not thread-safe by itself; the engine serializes sends per direction.
+public final class ClusterSealingChannel {
+    private let key: SymmetricKey
+    private var counter: UInt64 = 0
+
+    public init(key: SymmetricKey) {
+        self.key = key
+    }
+
+    /// Build a 96-bit nonce from the 64-bit counter (high 32 bits zero).
+    /// Big-endian so it reads as a clean incrementing value on the wire.
+    private static func nonce(for counter: UInt64) throws -> ChaChaPoly.Nonce {
+        var bytes = Data(count: 12)
+        var c = counter.bigEndian
+        withUnsafeBytes(of: &c) { raw in
+            // place the 8 counter bytes in the low end (offsets 4..12)
+            for i in 0..<8 { bytes[4 + i] = raw[i] }
+        }
+        return try ChaChaPoly.Nonce(data: bytes)
+    }
+
+    /// Seal one activation frame. The returned bytes are the combined
+    /// ChaChaPoly box (nonce || ciphertext || tag). The frame's `seq` in the
+    /// context should match the channel counter for end-to-end ordering checks.
+    public func seal(_ plaintext: Data, context: ClusterFrameContext) throws -> Data {
+        guard counter != UInt64.max else {
+            throw ClusterLinkError.nonceCounterExhausted
+        }
+        let nonce = try Self.nonce(for: counter)
+        let box = try ChaChaPoly.seal(plaintext, using: key, nonce: nonce, authenticating: context.aad)
+        counter += 1
+        return box.combined
+    }
+}
+
+/// A one-directional opening channel: cached key + expected counter.
+public final class ClusterOpeningChannel {
+    private let key: SymmetricKey
+    private var expectedCounter: UInt64 = 0
+
+    public init(key: SymmetricKey) {
+        self.key = key
+    }
+
+    /// Open one activation frame, enforcing in-order delivery (the ring link is
+    /// a single ordered stream per direction). AAD must reconstruct exactly or
+    /// the open fails.
+    public func open(_ combined: Data, context: ClusterFrameContext) throws -> Data {
+        guard counterMatches(context.seq) else {
+            throw ClusterLinkError.openFailed
+        }
+        let box: ChaChaPoly.SealedBox
+        do {
+            box = try ChaChaPoly.SealedBox(combined: combined)
+        } catch {
+            throw ClusterLinkError.shortFrame
+        }
+        let plaintext: Data
+        do {
+            plaintext = try ChaChaPoly.open(box, using: key, authenticating: context.aad)
+        } catch {
+            throw ClusterLinkError.openFailed
+        }
+        expectedCounter += 1
+        return plaintext
+    }
+
+    private func counterMatches(_ seq: UInt64) -> Bool { seq == expectedCounter }
+}

--- a/provider-swift/Sources/ProviderCore/Cluster/ClusterPipeline.swift
+++ b/provider-swift/Sources/ProviderCore/Cluster/ClusterPipeline.swift
@@ -1,0 +1,191 @@
+/// ClusterPipeline -- the SINGLE, proven ring decode loop, shared by both the
+/// one-shot harness (cluster-run) and the coordinator-connected provider
+/// (cluster-provider).
+///
+/// This is a faithful extraction of the loop that has been verified on hardware
+/// (correct GPT-OSS + Mistral generations). Its collective discipline is the
+/// reason it does NOT deadlock and MUST be preserved:
+///   - EVERY rank calls `all_gather` once per step, unconditionally, in the same
+///     order. Per-rank branching happens only AROUND the collective (head
+///     embeds; tail samples), never INSIDE the collective call sequence.
+///   - The ring hop is `send` (non-tail) / `recvLike` (non-head), sealed with
+///     ClusterLinkCrypto; activations cross the wire only as AEAD ciphertext.
+///
+/// `ClusterShard` is the minimal surface the loop needs (PipelineModelShard
+/// already provides it). The server path adds a control round — the head
+/// broadcasts the next request's (promptTokens, maxTokens) to peers via
+/// `all_gather` before each generation, so peers loop request-to-request in
+/// lockstep without their own coordinator connection.
+
+import Foundation
+import MLX
+
+public struct ClusterPipeline {
+    let plan: ClusterPlan
+    let group: MLXDistributedGroup
+    let shard: any PipelineModelShard
+    let hiddenSize: Int
+    let sealCh: ClusterSealingChannel?   // toward nextRank (nil on tail)
+    let openCh: ClusterOpeningChannel?   // from prevRank (nil on head)
+
+    public init(
+        plan: ClusterPlan, group: MLXDistributedGroup, shard: any PipelineModelShard,
+        hiddenSize: Int, sealCh: ClusterSealingChannel?, openCh: ClusterOpeningChannel?
+    ) {
+        self.plan = plan
+        self.group = group
+        self.shard = shard
+        self.hiddenSize = hiddenSize
+        self.sealCh = sealCh
+        self.openCh = openCh
+    }
+
+    private var headRank: Int { 0 }
+    private var tailRank: Int { plan.worldSize - 1 }
+
+    private func toI32(_ d: Data) -> MLXArray { MLXArray(d.map { Int32($0) }, [d.count]) }
+    private func toBytes(_ a: MLXArray) -> Data { Data(a.asArray(Int32.self).map { UInt8(truncatingIfNeeded: $0) }) }
+
+    /// Deterministic ciphertext length for a [1, width, hidden] bf16 activation:
+    /// header (2 + ndim*4) + payload (width*hidden*2) + AEAD overhead (28).
+    private func sealedLen(width: Int) -> Int { 14 + width * hiddenSize * 2 + 28 }
+
+    /// Run ONE greedy generation for `promptTokens`, up to `maxTokens`. Calls
+    /// `onToken` on the head for each produced token. EVERY rank runs this in
+    /// lockstep (peers ignore `onToken`). Returns the generated token ids (head).
+    ///
+    /// `requestId` scopes the AEAD frames; `seqBase` lets multiple requests reuse
+    /// distinct nonce ranges if the same channels persist (the caller passes
+    /// fresh channels per request, so seqBase can stay 0).
+    public func generate(
+        promptTokens: [Int], maxTokens: Int, requestId: String,
+        eosTokenIds: Set<Int>, onToken: (Int) -> Void
+    ) throws -> [Int] {
+        var seq = promptTokens
+        var generated = [Int]()
+
+        // ── Fine-grained tracing (DARKBLOOM_TRACE=1) ────────────────────────
+        // Every primitive is timed, and each GPU op is force-eval'd IMMEDIATELY
+        // before its timer closes so the measured time is that op's real cost
+        // (not deferred into a later barrier). This is the key to honest numbers:
+        // without per-op eval, MLX's laziness would smear all compute into
+        // whichever later .eval() happens to materialize it.
+        //
+        // Phases captured per step (rank-dependent):
+        //   embed            head: token embedding
+        //   recv_wait        non-head: time blocked in recvLike (transit + peer-idle)
+        //   to_bytes         non-head: cipher MLXArray -> [UInt8]
+        //   aead_open        non-head: ChaCha20-Poly1305 open
+        //   codec_decode     non-head: bytes -> hidden MLXArray
+        //   layers_compute   GPU: runOwnedLayers (eval'd)
+        //   codec_encode     non-tail: hidden -> bytes (bf16) (eval'd)
+        //   aead_seal        non-tail: ChaCha20-Poly1305 seal
+        //   to_i32           non-tail: sealed bytes -> MLXArray
+        //   send_hop         non-tail: group.send + eval (transit)
+        //   logits_compute   tail: projectToLogits + argMax (eval'd)
+        //   allgather        all: token broadcast + eval (round-trip)
+        //   readback         all: gathered.asArray (host copy)
+        let trace = ProcessInfo.processInfo.environment["DARKBLOOM_TRACE"] == "1"
+            || ProcessInfo.processInfo.environment["DARKBLOOM_PROFILE"] == "1"
+        var acc = [String: UInt64]()
+        var profSteps = 0
+        func now() -> UInt64 { DispatchTime.now().uptimeNanoseconds }
+        @inline(__always) func tick(_ k: String, _ t0: UInt64) { if trace { acc[k, default: 0] += now() - t0 } }
+
+        for step in 0..<maxTokens {
+            let inputTokens: [Int] = step == 0 ? seq : [seq[seq.count - 1]]
+            let width = inputTokens.count
+            let prof = trace && step > 0    // skip prefill (step 0) — steady-state only
+            if prof { profSteps += 1 }
+            let stepStart = now()
+
+            let inCtx = ClusterFrameContext(
+                clusterId: plan.clusterId, requestId: requestId,
+                layerRange: "hop-\(plan.rank == headRank ? headRank : plan.rank - 1)", seq: UInt64(step))
+
+            var hidden: MLXArray
+            if plan.isHead {
+                var t = now()
+                hidden = shard.embed(tokens: inputTokens)
+                if prof { hidden.eval(); tick("embed", t); _ = t }
+            } else {
+                // recv_wait: blocked here until the prev rank's send arrives.
+                var t = now()
+                let template = MLXArray.zeros([sealedLen(width: width)], dtype: .int32)
+                let cipherArr = try group.recvLike(template, from: plan.rank - 1)
+                cipherArr.eval()
+                if prof { tick("recv_wait", t) }
+                t = now()
+                let cipherBytes = toBytes(cipherArr)
+                if prof { tick("to_bytes", t) }
+                t = now()
+                let plain = try openCh!.open(cipherBytes, context: inCtx)
+                if prof { tick("aead_open", t) }
+                t = now()
+                hidden = try ActivationCodec.decode(plain)
+                if prof { hidden.eval(); tick("codec_decode", t) }
+            }
+
+            var t = now()
+            hidden = shard.runOwnedLayers(hidden)
+            if prof { hidden.eval(); tick("layers_compute", t) }
+
+            if !plan.isTail {
+                t = now()
+                let bf16 = hidden.asType(.bfloat16)
+                let encoded = try ActivationCodec.encode(bf16)
+                if prof { tick("codec_encode", t) }
+                let outCtx = ClusterFrameContext(
+                    clusterId: plan.clusterId, requestId: requestId,
+                    layerRange: "hop-\(plan.rank)", seq: UInt64(step))
+                t = now()
+                let sealed = try sealCh!.seal(encoded, context: outCtx)
+                if prof { tick("aead_seal", t) }
+                t = now()
+                let sealedArr = toI32(sealed)
+                if prof { tick("to_i32", t) }
+                t = now()
+                let dep = try group.send(sealedArr, to: plan.rank + 1)
+                dep.eval()
+                if prof { tick("send_hop", t) }
+            }
+
+            var tokenScalar = MLXArray([Int32(0)])
+            if plan.isTail {
+                t = now()
+                let logits = shard.projectToLogits(hidden)
+                let ids = argMax(logits, axis: logits.ndim - 1)
+                ids.eval()
+                tokenScalar = MLXArray([Int32(Int(ids.asArray(Int32.self).last ?? 0))])
+                if prof { tick("logits_compute", t) }
+            }
+            t = now()
+            let gathered = try group.allGather(tokenScalar)
+            gathered.eval()
+            if prof { tick("allgather", t) }
+            t = now()
+            let nextToken = Int(gathered.asArray(Int32.self)[tailRank])
+            if prof { tick("readback", t) }
+
+            if prof { tick("STEP_TOTAL", stepStart) }
+            seq.append(nextToken)
+            generated.append(nextToken)
+            if plan.isHead { onToken(nextToken) }
+            if eosTokenIds.contains(nextToken) { break }
+        }
+
+        if trace && profSteps > 0 {
+            // Print every phase this rank recorded, sorted by cost, with % of step.
+            let total = Double(acc["STEP_TOTAL"] ?? 1)
+            let role = plan.isHead ? "HEAD" : (plan.isTail ? "TAIL" : "MID")
+            var line = "\n[trace rank \(plan.rank)/\(role) · \(profSteps) decode steps · per-step avg ms]\n"
+            for (k, v) in acc.sorted(by: { $0.value > $1.value }) {
+                let ms = Double(v) / 1_000_000 / Double(profSteps)
+                let pct = total > 0 ? Double(v) / total * 100 : 0
+                line += String(format: "   %-16@ %7.2f ms  %5.1f%%\n", k, ms, pct)
+            }
+            FileHandle.standardError.write(Data(line.utf8))
+        }
+        return generated
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Cluster/ClusterPlan.swift
+++ b/provider-swift/Sources/ProviderCore/Cluster/ClusterPlan.swift
@@ -1,0 +1,105 @@
+/// ClusterPlan -- resolves `[cluster]` config into the concrete topology the
+/// provider needs to join a pipeline: this node's rank, its ring neighbors, and
+/// the MLX ring transport environment (host list + rank), exo-style.
+///
+/// Pure resolution + validation (no IO, no MLX): unit-testable on one machine.
+/// The provider start path builds a `ClusterPlan`, uses `mlxRingEnvironment()`
+/// to configure the transport before `MLXDistributedGroup.initialize`, and feeds
+/// `neighbors` into the handshake + `DistributedInferenceEngine`.
+
+import Foundation
+
+public enum ClusterPlanError: Error, Equatable, Sendable {
+    case disabled
+    case missingClusterId
+    case emptyMembers
+    case selfNotInMembers(nodeId: String)
+    case duplicateNodeId(String)
+    case singleMember
+    case unsupportedBackend(String)
+}
+
+public struct ClusterPlan: Equatable, Sendable {
+    public let clusterId: String
+    public let nodeId: String
+    public let rank: Int
+    public let worldSize: Int
+    public let backend: MLXDistributedBackend
+    /// Members in ring order (rank == index).
+    public let members: [ClusterMemberSettings]
+
+    /// Previous rank in the ring; nil at the head of a non-wrapping pipeline.
+    public var prevRank: Int? { rank == 0 ? nil : rank - 1 }
+    /// Next rank in the ring; nil at the tail.
+    public var nextRank: Int? { rank == worldSize - 1 ? nil : rank + 1 }
+
+    public var isHead: Bool { rank == 0 }
+    public var isTail: Bool { rank == worldSize - 1 }
+
+    /// Build and validate a plan from `[cluster]` settings.
+    public static func resolve(_ s: ClusterSettings) throws -> ClusterPlan {
+        guard s.enabled else { throw ClusterPlanError.disabled }
+        guard !s.clusterId.isEmpty else { throw ClusterPlanError.missingClusterId }
+        guard !s.members.isEmpty else { throw ClusterPlanError.emptyMembers }
+        guard s.members.count > 1 else { throw ClusterPlanError.singleMember }
+
+        // No duplicate node ids (rank must be unambiguous).
+        var seen = Set<String>()
+        for m in s.members {
+            if !seen.insert(m.nodeId).inserted {
+                throw ClusterPlanError.duplicateNodeId(m.nodeId)
+            }
+        }
+
+        guard let rank = s.members.firstIndex(where: { $0.nodeId == s.nodeId }) else {
+            throw ClusterPlanError.selfNotInMembers(nodeId: s.nodeId)
+        }
+        guard let backend = MLXDistributedBackend(rawValue: s.backend) else {
+            throw ClusterPlanError.unsupportedBackend(s.backend)
+        }
+
+        return ClusterPlan(
+            clusterId: s.clusterId,
+            nodeId: s.nodeId,
+            rank: rank,
+            worldSize: s.members.count,
+            backend: backend,
+            members: s.members)
+    }
+
+    /// Node ids of this node's ring neighbors (for the pairwise handshake).
+    public func neighborNodeIds() -> (prev: String?, next: String?) {
+        let prev = prevRank.map { members[$0].nodeId }
+        let next = nextRank.map { members[$0].nodeId }
+        return (prev, next)
+    }
+
+    /// Environment variables that configure MLX's ring transport, matching
+    /// exo's approach (a host list keyed by position + this node's rank). The
+    /// provider sets these before `MLXDistributedGroup.initialize(.ring)`.
+    ///
+    /// `MLX_HOSTLIST` is a comma-separated, rank-ordered list of member
+    /// addresses; `MLX_RANK` is this node's index. (exo writes a hostfile and
+    /// sets `MLX_HOSTFILE`/`MLX_RANK`; we expose the addresses here and let the
+    /// start path materialize whatever the linked MLX build expects.)
+    public func mlxRingEnvironment() -> [String: String] {
+        [
+            "MLX_HOSTLIST": members.map(\.address).joined(separator: ","),
+            "MLX_RANK": String(rank),
+            "MLX_WORLD_SIZE": String(worldSize),
+        ]
+    }
+
+    /// Layer plan for this cluster given the model's layer count and each
+    /// member's available memory (ring order must match `members`).
+    /// Convenience that forwards to `LayerPartition`.
+    public func layerPlan(totalLayers: Int, memoryBytesByNodeId: [String: UInt64]) throws -> [LayerInterval] {
+        let weights = try members.map { m -> LayerPartition.NodeWeight in
+            guard let w = memoryBytesByNodeId[m.nodeId] else {
+                throw ClusterPlanError.selfNotInMembers(nodeId: m.nodeId)
+            }
+            return LayerPartition.NodeWeight(nodeId: m.nodeId, weightBytes: w)
+        }
+        return try LayerPartition.partition(totalLayers: totalLayers, nodes: weights)
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Cluster/ClusterRoster.swift
+++ b/provider-swift/Sources/ProviderCore/Cluster/ClusterRoster.swift
@@ -1,0 +1,167 @@
+/// ClusterRoster -- the coordinator-signed roster of attested cluster members.
+///
+/// In a Darkbloom cluster (see docs/architecture/clustering.md and
+/// cluster-node-handshake.md) the coordinator remains the trust anchor: every
+/// member attests to the coordinator via the existing attestation +
+/// challenge-response path, the coordinator computes `cluster trust =
+/// min(member trust)`, and -- if every member clears the floor -- issues this
+/// roster. Members then run pairwise handshakes among themselves
+/// (`ClusterHandshake`), using the roster to learn which peer Secure-Enclave
+/// keys are authorized. The coordinator is NOT in the per-message path.
+///
+/// The roster is signed by the coordinator's P-256 key over a deterministic,
+/// sorted-key JSON encoding (the same approach `AttestationBuilder` uses for the
+/// attestation blob, so Go and Swift produce identical bytes). Verification only
+/// needs the coordinator's public key, so any node can check it offline.
+///
+/// This type is pure data + signature verification: it depends only on
+/// CryptoKit (via `SecureEnclaveIdentity.verify`) and Foundation, so it is
+/// fully unit-testable on a single machine with a software P-256 key.
+
+import CryptoKit
+import Foundation
+
+/// A single attested member of a cluster, as vouched for by the coordinator.
+public struct ClusterMember: Codable, Equatable, Sendable {
+    /// Stable identifier for this node within the cluster (assigned by the
+    /// coordinator). Used to order ring neighbors and to pick the handshake
+    /// initiator deterministically (lower id initiates).
+    public let nodeId: String
+
+    /// Base64-encoded raw P-256 (64-byte X||Y) Secure-Enclave signing key.
+    /// This is the long-term identity used to authenticate the member in the
+    /// pairwise handshake. Matches `AttestationBlob.publicKey`.
+    public let sePublicKeyBase64: String
+
+    /// Base64-encoded raw 32-byte X25519 key bound to this member's attestation
+    /// (`AttestationBlob.encryptionPublicKey`). Informational here -- the
+    /// handshake uses *fresh ephemeral* X25519 keys for forward secrecy -- but
+    /// carried so a verifier can cross-check against the attestation record.
+    public let x25519PublicKeyBase64: String
+
+    /// Trust level the coordinator assigned this member ("hardware",
+    /// "self_signed", ...). The cluster's surfaced trust is the minimum across
+    /// members; a roster is only issued when every member clears the floor.
+    public let trustLevel: String
+
+    public init(
+        nodeId: String,
+        sePublicKeyBase64: String,
+        x25519PublicKeyBase64: String,
+        trustLevel: String
+    ) {
+        self.nodeId = nodeId
+        self.sePublicKeyBase64 = sePublicKeyBase64
+        self.x25519PublicKeyBase64 = x25519PublicKeyBase64
+        self.trustLevel = trustLevel
+    }
+}
+
+/// The body of a roster -- everything covered by the coordinator's signature.
+public struct ClusterRosterBody: Codable, Equatable, Sendable {
+    public let clusterId: String
+    public let members: [ClusterMember]
+    /// ISO-8601 issuance time.
+    public let issuedAt: Date
+    /// ISO-8601 expiry. A stale roster must not be honored -- forces periodic
+    /// re-issue so it cannot outlive the trust it represents.
+    public let expiresAt: Date
+
+    public init(clusterId: String, members: [ClusterMember], issuedAt: Date, expiresAt: Date) {
+        self.clusterId = clusterId
+        self.members = members
+        self.issuedAt = issuedAt
+        self.expiresAt = expiresAt
+    }
+}
+
+/// A signed roster: the body plus a base64 DER P-256 ECDSA signature over the
+/// body's deterministic JSON encoding, produced by the coordinator key.
+public struct SignedClusterRoster: Codable, Equatable, Sendable {
+    public let body: ClusterRosterBody
+    /// Base64-encoded DER ECDSA signature over `Self.canonicalBytes(body)`.
+    public let signature: String
+
+    public init(body: ClusterRosterBody, signature: String) {
+        self.body = body
+        self.signature = signature
+    }
+}
+
+public enum ClusterRosterError: Error, Equatable, Sendable {
+    case encodingFailed
+    case invalidSignatureEncoding
+    case invalidCoordinatorKey
+    case signatureInvalid
+    case expired
+    case notYetValid
+    case memberNotFound(nodeId: String)
+}
+
+public enum ClusterRoster {
+    /// Deterministic JSON for the signed region. Uses `.sortedKeys` +
+    /// `.iso8601` to match `AttestationBuilder`'s scheme, so a Go coordinator
+    /// signing with `encoding/json` (sorted map keys) produces identical bytes.
+    public static func canonicalBytes(_ body: ClusterRosterBody) throws -> Data {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+        encoder.dateEncodingStrategy = .iso8601
+        do {
+            return try encoder.encode(body)
+        } catch {
+            throw ClusterRosterError.encodingFailed
+        }
+    }
+
+    /// Verify a roster's coordinator signature and time validity.
+    ///
+    /// - Parameters:
+    ///   - roster: the signed roster to check.
+    ///   - coordinatorPublicKeyBase64: base64 raw P-256 (64B) coordinator key,
+    ///     pinned in provider config / build.
+    ///   - now: current time (injected for testability).
+    public static func verify(
+        _ roster: SignedClusterRoster,
+        coordinatorPublicKeyBase64: String,
+        now: Date
+    ) throws {
+        guard let sigData = Data(base64Encoded: roster.signature) else {
+            throw ClusterRosterError.invalidSignatureEncoding
+        }
+        guard let coordKey = Data(base64Encoded: coordinatorPublicKeyBase64),
+              coordKey.count == 64 || coordKey.count == 65 else {
+            throw ClusterRosterError.invalidCoordinatorKey
+        }
+
+        let bytes = try canonicalBytes(roster.body)
+        guard SecureEnclaveIdentity.verify(signature: sigData, for: bytes, publicKey: coordKey) else {
+            throw ClusterRosterError.signatureInvalid
+        }
+
+        if now < roster.body.issuedAt {
+            throw ClusterRosterError.notYetValid
+        }
+        if now >= roster.body.expiresAt {
+            throw ClusterRosterError.expired
+        }
+    }
+
+    /// Look up a member by node id within a (already-verified) roster body.
+    public static func member(_ body: ClusterRosterBody, nodeId: String) throws -> ClusterMember {
+        guard let m = body.members.first(where: { $0.nodeId == nodeId }) else {
+            throw ClusterRosterError.memberNotFound(nodeId: nodeId)
+        }
+        return m
+    }
+
+    /// The cluster's surfaced trust = the weakest member.
+    ///
+    /// - Parameter strongestFirst: trust levels ranked strongest → weakest
+    ///   (e.g. `["hardware", "self_signed", "none"]`). The weakest present
+    ///   member trust is returned; an unranked level is treated as weakest.
+    public static func minTrustLevel(_ body: ClusterRosterBody, strongestFirst order: [String]) -> String? {
+        func rank(_ level: String) -> Int { order.firstIndex(of: level) ?? Int.max }
+        // Weakest = the largest rank index (furthest from "strongest").
+        return body.members.map(\.trustLevel).max { rank($0) < rank($1) }
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Cluster/ClusterServer.swift
+++ b/provider-swift/Sources/ProviderCore/Cluster/ClusterServer.swift
@@ -1,0 +1,130 @@
+/// ClusterServer -- run the proven `ClusterPipeline` as a request server.
+///
+/// The head node receives requests from a coordinator; the PEER nodes have no
+/// coordinator, so before each generation all ranks must agree on what to run.
+/// A control round over the ring (all_gather) carries the head's next-request
+/// descriptor — prompt token ids + maxTokens — to every peer, so they enter the
+/// SAME `generate` call in lockstep. A sentinel descriptor (maxTokens == 0)
+/// tells peers to shut down.
+///
+/// This keeps the *exact* verified decode loop (ClusterPipeline) and adds only a
+/// lockstep control channel around it — avoiding the unverified per-rank
+/// collective ordering of the earlier RingClusterRuntime path.
+///
+/// Control-round encoding (all_gather of a fixed-width int32 vector from the
+/// head; peers contribute zeros and read the head's slot):
+///   [0]   = maxTokens   (0 ⇒ shutdown)
+///   [1]   = promptLen
+///   [2..] = prompt token ids (capped at CONTROL_MAX_PROMPT)
+
+import Foundation
+import MLX
+
+private let CONTROL_MAX_PROMPT = 8192
+private let CONTROL_WIDTH = 2 + CONTROL_MAX_PROMPT
+
+public struct ClusterRequestDescriptor: Sendable {
+    public let promptTokens: [Int]
+    public let maxTokens: Int
+    public init(promptTokens: [Int], maxTokens: Int) {
+        self.promptTokens = promptTokens
+        self.maxTokens = maxTokens
+    }
+    static let shutdown = ClusterRequestDescriptor(promptTokens: [], maxTokens: 0)
+}
+
+public struct ClusterServer {
+    let plan: ClusterPlan
+    let group: MLXDistributedGroup
+    let pipeline: ClusterPipeline
+    let eosTokenIds: Set<Int>
+
+    public init(plan: ClusterPlan, group: MLXDistributedGroup, pipeline: ClusterPipeline, eosTokenIds: Set<Int>) {
+        self.plan = plan
+        self.group = group
+        self.pipeline = pipeline
+        self.eosTokenIds = eosTokenIds
+    }
+
+    private func headRankSlot(_ gathered: [Int32]) -> ArraySlice<Int32> {
+        // head is rank 0; all_gather concatenates [width] per rank → rank 0's
+        // vector is the first CONTROL_WIDTH entries.
+        gathered.prefix(CONTROL_WIDTH)
+    }
+
+    /// Broadcast the head's next request to all ranks; returns the agreed
+    /// descriptor on every rank. The head passes `next`; peers pass nil.
+    public func exchangeRequest(_ next: ClusterRequestDescriptor?) throws -> ClusterRequestDescriptor {
+        var vec = [Int32](repeating: 0, count: CONTROL_WIDTH)
+        if plan.isHead, let next {
+            let n = min(next.promptTokens.count, CONTROL_MAX_PROMPT)
+            vec[0] = Int32(next.maxTokens)
+            vec[1] = Int32(n)
+            for i in 0..<n { vec[2 + i] = Int32(next.promptTokens[i]) }
+        }
+        let gathered = try group.allGather(MLXArray(vec, [CONTROL_WIDTH]))
+        gathered.eval()
+        let slot = Array(headRankSlot(gathered.asArray(Int32.self)))
+        let maxTokens = Int(slot[0])
+        let n = Int(slot[1])
+        let prompt = (0..<max(0, n)).map { Int(slot[2 + $0]) }
+        return ClusterRequestDescriptor(promptTokens: prompt, maxTokens: maxTokens)
+    }
+
+    /// PEER loop: stay in lockstep with the head's control rounds. The head
+    /// broadcasts a descriptor every round — an IDLE descriptor (maxTokens<0)
+    /// when no request is pending, a real one when serving, or the shutdown
+    /// sentinel (maxTokens==0). Idle rounds keep both sides in the same
+    /// `all_gather` so the ring never sits with one side parked in a collective
+    /// the other hasn't joined (which times out and tears down the ring).
+    public func runPeerLoop(makeChannels: () -> (ClusterSealingChannel?, ClusterOpeningChannel?)) throws {
+        var reqCounter = 0
+        // Dead-ring backoff. When the head is ALIVE, `exchangeRequest` blocks in
+        // the all_gather barrier until the head joins — so a healthy idle cluster
+        // costs nothing here (the peer parks in the collective, not in a spin).
+        // When the head DIES, the collective stops blocking and starts throwing
+        // immediately; without a backoff the loop would busy-spin a CPU core for
+        // as long as the process lives (observed: a hung peer pegging a core for
+        // hours). So on each consecutive failure we sleep with exponential
+        // backoff, and after `maxConsecutiveFailures` we conclude the ring is
+        // gone and exit cleanly rather than spin forever.
+        let maxConsecutiveFailures = 50
+        let backoffCapSeconds = 5.0
+        var consecutiveFailures = 0
+
+        while true {
+            let desc: ClusterRequestDescriptor
+            do {
+                desc = try exchangeRequest(nil)
+            } catch {
+                consecutiveFailures += 1
+                if consecutiveFailures >= maxConsecutiveFailures {
+                    // The ring control round has failed repeatedly — the head is
+                    // almost certainly gone. Stop spinning and let the peer exit.
+                    throw error
+                }
+                // Exponential backoff, capped: 10ms, 20ms, 40ms … up to 5s.
+                let delay = min(backoffCapSeconds, 0.01 * pow(2.0, Double(min(consecutiveFailures, 9))))
+                Thread.sleep(forTimeInterval: delay)
+                continue
+            }
+            consecutiveFailures = 0               // a successful round resets backoff
+            if desc.maxTokens == 0 { return }    // shutdown
+            if desc.maxTokens < 0 { continue }   // idle keepalive round
+            reqCounter += 1
+            let (seal, open) = makeChannels()
+            let pl = ClusterPipeline(
+                plan: plan, group: group, shard: pipeline.shard,
+                hiddenSize: pipeline.hiddenSize, sealCh: seal, openCh: open)
+            _ = try pl.generate(
+                promptTokens: desc.promptTokens, maxTokens: desc.maxTokens,
+                requestId: "req-\(reqCounter)", eosTokenIds: eosTokenIds, onToken: { _ in })
+        }
+    }
+
+    /// An IDLE descriptor — the head broadcasts this on rounds with no pending
+    /// request, keeping the ring's control collective alive in lockstep.
+    public static var idleDescriptor: ClusterRequestDescriptor {
+        ClusterRequestDescriptor(promptTokens: [], maxTokens: -1)
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Cluster/DistributedInferenceEngine.swift
+++ b/provider-swift/Sources/ProviderCore/Cluster/DistributedInferenceEngine.swift
@@ -1,0 +1,173 @@
+/// DistributedInferenceEngine -- pipeline-parallel inference across a cluster,
+/// behind the `InferenceEngine` seam (so `ProviderLoop` can use it in place of
+/// the single-node `BatchScheduler`).
+///
+/// It owns this rank's model shard (`PipelineModelShard`) and tokenizer, and per
+/// request drives a `PipelineRunner`: tokenize → embed (head) → ring forward
+/// pass with sealed activations → sample (tail) → token broadcast → detokenize →
+/// stream `GenerationEvent`s.
+///
+/// Runtime-decoupled via `ClusterRuntime`, which mints the per-request
+/// `PipelineStage` (transport + sealing/opening channels) and `TokenChannel`.
+/// In tests that runtime is loopback (in-process); on hardware it is the
+/// `MLXDistributed` ring + `all_gather`. This keeps the engine fully testable on
+/// one machine while the ring is swapped in unchanged.
+///
+/// Trust/crypto invariant (the whole reason this isn't just exo): the prompt is
+/// decrypted ONLY on the head node (rank 0) via the existing per-request NaCl
+/// Box path. Activation tensors that cross to other ranks are sealed per-token
+/// with the session key from the handshake -- never plaintext on the wire. See
+/// docs/architecture/cluster-node-handshake.md §6-7.
+
+import Foundation
+import MLX
+import MLXLMCommon
+
+public enum DistributedEngineError: Error, Sendable {
+    case notInitialized
+    case modelNotLoaded
+    case rankWithoutSession(rank: Int)
+}
+
+/// Per-neighbor encrypted link, derived from a completed handshake.
+public struct ClusterNeighborLink: Sendable {
+    public let peerRank: Int
+    public let session: ClusterSession
+    public init(peerRank: Int, session: ClusterSession) {
+        self.peerRank = peerRank
+        self.session = session
+    }
+}
+
+/// Supplies the per-request pipeline plumbing. One implementation is loopback
+/// (tests); the other wraps the `MLXDistributed` ring (hardware).
+public protocol ClusterRuntime: Sendable {
+    /// Build this rank's `PipelineStage` for one request (fresh sealing/opening
+    /// channels so the nonce sequence restarts per request).
+    func makeStage(requestId: String) -> PipelineStage
+    /// Build the token-broadcast channel for one request.
+    func makeTokenChannel(requestId: String) -> any TokenChannel
+}
+
+public actor DistributedInferenceEngine: InferenceEngine {
+    private let plan: ClusterPlan
+    private let runtime: any ClusterRuntime
+
+    // Set on loadModel.
+    private var shard: (any PipelineModelShard)?
+    private var tokenizer: (any Tokenizer)?
+    private var loadedModelId: String?
+    private var eosTokenIds: Set<Int>
+
+    public init(plan: ClusterPlan, runtime: any ClusterRuntime, eosTokenIds: Set<Int> = []) {
+        self.plan = plan
+        self.runtime = runtime
+        self.eosTokenIds = eosTokenIds
+    }
+
+    /// Install this rank's shard + tokenizer. The shard is produced by the
+    /// sharded loader (which loads only this rank's layer slice).
+    public func installShard(_ shard: any PipelineModelShard, tokenizer: any Tokenizer, modelId: String, eosTokenIds: Set<Int>) {
+        self.shard = shard
+        self.tokenizer = tokenizer
+        self.loadedModelId = modelId
+        self.eosTokenIds = eosTokenIds
+    }
+
+    public var rank: Int { plan.rank }
+    public var worldSize: Int { plan.worldSize }
+
+    // MARK: - InferenceEngine
+
+    public func loadModel(container: ModelContainer, modelId: String, weightHash: String?) async {
+        // The InferenceEngine seam passes a full ModelContainer (single-node
+        // shape). For the cluster, the sharded loader builds a PipelineModelShard
+        // (this rank's layer slice only) and installs it via `installShard`.
+        // Constructing the shard from `container` is the mlx-swift-lm-fork piece
+        // (see PipelineModelShard / clustering-implementation-status.md); when a
+        // shard is already installed this is a no-op marker.
+        loadedModelId = modelId
+    }
+
+    public func submit(request: ChatCompletionRequest, requestId: String?) async -> AsyncStream<GenerationEvent> {
+        let (stream, continuation) = AsyncStream<GenerationEvent>.makeStream()
+        guard let shard, let tokenizer else {
+            continuation.yield(.error("No model shard loaded on rank \(plan.rank)"))
+            continuation.finish()
+            return stream
+        }
+        let id = requestId ?? "req-\(UUID().uuidString.prefix(12))"
+        let maxTokens = request.max_tokens ?? 512
+
+        // Tokenize the prompt via the chat template (head needs the ids to
+        // embed; other ranks tokenize identically so EOS/length agree).
+        let promptTokens: [Int]
+        do {
+            promptTokens = try Self.tokenizePrompt(request, tokenizer: tokenizer)
+        } catch {
+            continuation.yield(.error("tokenization failed: \(error)"))
+            continuation.finish()
+            return stream
+        }
+
+        let stage = runtime.makeStage(requestId: id)
+        let tokens = runtime.makeTokenChannel(requestId: id)
+        let runner = PipelineRunner(
+            shard: shard, stage: stage, tokens: tokens,
+            config: PipelineRunConfig(
+                clusterId: plan.clusterId, requestId: id,
+                maxTokens: maxTokens, eosTokenIds: eosTokenIds))
+
+        let tk = tokenizer
+        let eos = eosTokenIds
+        let promptCount = promptTokens.count
+        let task = Task {
+            var generated = 0
+            do {
+                try await runner.run(promptTokens: promptTokens) { token in
+                    generated += 1
+                    if eos.contains(token) { return }
+                    let piece = tk.decode(tokenIds: [token])
+                    if !piece.isEmpty { continuation.yield(.chunk(piece)) }
+                }
+                continuation.yield(.info(
+                    promptTokens: promptCount, completionTokens: generated,
+                    tokensPerSecond: 0))
+            } catch {
+                continuation.yield(.error("pipeline decode failed: \(error)"))
+            }
+            continuation.finish()
+        }
+        continuation.onTermination = { _ in task.cancel() }
+        return stream
+    }
+
+    public func cancel(requestId: String) async {
+        // Cancellation flows through the AsyncStream termination handler, which
+        // cancels the decode Task. A ring-level cancel marker (so peers stop in
+        // lockstep) is the hardware follow-up.
+    }
+
+    public func capacity() -> SchedulerCapacity {
+        SchedulerCapacity(
+            model: loadedModelId ?? "",
+            activeRequests: 0,
+            pendingRequests: 0,
+            maxConcurrent: 1,
+            engineMaxConcurrent: 1,
+            gpuMemoryActiveBytes: 0,
+            gpuMemoryPeakBytes: 0,
+            gpuMemoryCacheBytes: 0,
+            totalMemoryBytes: 0)
+    }
+
+    // MARK: - Helpers
+
+    /// Apply the chat template to the request's messages, returning token ids.
+    static func tokenizePrompt(_ request: ChatCompletionRequest, tokenizer: any Tokenizer) throws -> [Int] {
+        let messages: [[String: any Sendable]] = request.messages.map {
+            ["role": $0.role, "content": $0.content]
+        }
+        return try tokenizer.applyChatTemplate(messages: messages, tools: nil, additionalContext: nil)
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Cluster/GPTOSSShardAdapter.swift
+++ b/provider-swift/Sources/ProviderCore/Cluster/GPTOSSShardAdapter.swift
@@ -1,0 +1,101 @@
+/// GPTOSSShardAdapter -- bridges the fork's `GPTOSSPipelineShard` to
+/// ProviderCore's `PipelineModelShard`, so a GPT-OSS model runs across the
+/// cluster through the SAME engine/decode/transport/encryption path as Llama.
+///
+/// Additive: selecting the architecture is done
+/// by the caller (cluster-run) from config.json's `model_type`.
+
+import Foundation
+import MLX
+import MLXLLM
+import MLXLMCommon
+
+public final class GPTOSSShardAdapter: PipelineModelShard, @unchecked Sendable {
+    private let shard: GPTOSSPipelineShard
+    public let totalLayers: Int
+    public let ownedInterval: LayerInterval
+    private var kvCaches: [KVCache]?
+    private var batchedCaches: [KVCache]?
+
+    public init(shard: GPTOSSPipelineShard, ownedInterval: LayerInterval) {
+        self.shard = shard
+        self.totalLayers = shard.range.totalLayers
+        self.ownedInterval = ownedInterval
+    }
+
+    public static func load(directory: URL, interval: LayerInterval) throws -> GPTOSSShardAdapter {
+        let (shard, _) = try GPTOSSPipelineShardLoader.loadFromDirectory(
+            directory, start: interval.start, end: interval.end)
+        return GPTOSSShardAdapter(shard: shard, ownedInterval: interval)
+    }
+
+    // MARK: - PipelineModelShard
+
+    public func embed(tokens: [Int]) -> MLXArray {
+        let ids = MLXArray(tokens.map { Int32($0) }, [1, tokens.count])
+        return shard.embed(ids)
+    }
+
+    public func runOwnedLayers(_ hidden: MLXArray) -> MLXArray {
+        shard.runOwnedLayers(hidden, cache: caches(), evalEvery: 4)
+    }
+
+    public func projectToLogits(_ hidden: MLXArray) -> MLXArray {
+        shard.projectToLogits(hidden)
+    }
+
+    // MARK: - Batched path
+
+    public func embedBatch(rows: [[Int]], leftPadding: [Int]) -> MLXArray {
+        let maxLen = rows.map(\.count).max() ?? 0
+        var flat = [Int32]()
+        flat.reserveCapacity(rows.count * maxLen)
+        for (b, row) in rows.enumerated() {
+            let pad = leftPadding.indices.contains(b) ? leftPadding[b] : (maxLen - row.count)
+            flat.append(contentsOf: repeatElement(Int32(0), count: pad))
+            flat.append(contentsOf: row.map { Int32($0) })
+            let filled = pad + row.count
+            if filled < maxLen { flat.append(contentsOf: repeatElement(Int32(0), count: maxLen - filled)) }
+        }
+        let ids = MLXArray(flat, [rows.count, maxLen])
+        return shard.embed(ids)
+    }
+
+    public func runOwnedLayersBatched(_ hidden: MLXArray) -> MLXArray {
+        shard.runOwnedLayers(hidden, cache: batchedCaches ?? [], evalEvery: 4)
+    }
+
+    public func projectToLogitsBatched(_ hidden: MLXArray) -> MLXArray {
+        shard.projectToLogits(hidden)
+    }
+
+    public func beginBatch(leftPadding: [Int]) {
+        batchedCaches = shard.makeBatchedCaches(leftPadding: leftPadding)
+    }
+
+    public func filterBatch(keepIndices: [Int]) {
+        guard let caches = batchedCaches else { return }
+        let idx = MLXArray(keepIndices.map { Int32($0) }, [keepIndices.count])
+        for c in caches { (c as? BatchedCache)?.filterBatched(batchIndices: idx) }
+    }
+
+    public func admitPrefill(_ hidden: MLXArray, leftPadding: [Int]) -> MLXArray {
+        let admitted = shard.makeBatchedCaches(leftPadding: leftPadding)
+        let out = shard.runOwnedLayers(hidden, cache: admitted, evalEvery: 4)
+        if let live = batchedCaches {
+            for (i, c) in live.enumerated() where i < admitted.count {
+                if let bc = c as? BatchedCache, let other = admitted[i] as? BatchedCache {
+                    bc.extendBatched(other)
+                }
+            }
+        }
+        return out
+    }
+
+    private func caches() -> [KVCache] {
+        if let kvCaches { return kvCaches }
+        let made = (0 ..< shard.ownedLayerCount).map { _ in KVCacheSimple() as KVCache }
+        kvCaches = made
+        return made
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Cluster/Gemma4ShardAdapter.swift
+++ b/provider-swift/Sources/ProviderCore/Cluster/Gemma4ShardAdapter.swift
@@ -1,0 +1,107 @@
+/// Gemma4ShardAdapter -- bridges the fork's `Gemma4PipelineShard` to
+/// ProviderCore's `PipelineModelShard`, so a Gemma 4 model runs across the
+/// cluster through the SAME engine/decode/transport/encryption path as Llama
+/// and GPT-OSS.
+///
+/// Mirror of `GPTOSSShardAdapter`. Additive: selecting the architecture is done
+/// by the caller (ClusterHeadBringup) from config.json's `model_type`.
+
+import Foundation
+import MLX
+import MLXLLM
+import MLXLMCommon
+
+public final class Gemma4ShardAdapter: PipelineModelShard, @unchecked Sendable {
+    private let shard: Gemma4PipelineShard
+    public let totalLayers: Int
+    public let ownedInterval: LayerInterval
+    private var kvCaches: [KVCache]?
+    private var batchedCaches: [KVCache]?
+
+    public init(shard: Gemma4PipelineShard, ownedInterval: LayerInterval) {
+        self.shard = shard
+        self.totalLayers = shard.range.totalLayers
+        self.ownedInterval = ownedInterval
+    }
+
+    public static func load(directory: URL, interval: LayerInterval) throws -> Gemma4ShardAdapter {
+        let (shard, _) = try Gemma4PipelineShardLoader.loadFromDirectory(
+            directory, start: interval.start, end: interval.end)
+        return Gemma4ShardAdapter(shard: shard, ownedInterval: interval)
+    }
+
+    // MARK: - PipelineModelShard
+
+    public func embed(tokens: [Int]) -> MLXArray {
+        let ids = MLXArray(tokens.map { Int32($0) }, [1, tokens.count])
+        return shard.embed(ids)
+    }
+
+    public func runOwnedLayers(_ hidden: MLXArray) -> MLXArray {
+        shard.runOwnedLayers(hidden, cache: caches(), evalEvery: 4)
+    }
+
+    public func projectToLogits(_ hidden: MLXArray) -> MLXArray {
+        shard.projectToLogits(hidden)
+    }
+
+    // MARK: - Batched path
+
+    public func embedBatch(rows: [[Int]], leftPadding: [Int]) -> MLXArray {
+        let maxLen = rows.map(\.count).max() ?? 0
+        var flat = [Int32]()
+        flat.reserveCapacity(rows.count * maxLen)
+        for (b, row) in rows.enumerated() {
+            let pad = leftPadding.indices.contains(b) ? leftPadding[b] : (maxLen - row.count)
+            flat.append(contentsOf: repeatElement(Int32(0), count: pad))
+            flat.append(contentsOf: row.map { Int32($0) })
+            let filled = pad + row.count
+            if filled < maxLen { flat.append(contentsOf: repeatElement(Int32(0), count: maxLen - filled)) }
+        }
+        let ids = MLXArray(flat, [rows.count, maxLen])
+        return shard.embed(ids)
+    }
+
+    public func runOwnedLayersBatched(_ hidden: MLXArray) -> MLXArray {
+        shard.runOwnedLayers(hidden, cache: batchedCaches ?? [], evalEvery: 4)
+    }
+
+    public func projectToLogitsBatched(_ hidden: MLXArray) -> MLXArray {
+        shard.projectToLogits(hidden)
+    }
+
+    public func beginBatch(leftPadding: [Int]) {
+        batchedCaches = shard.makeBatchedCaches(leftPadding: leftPadding)
+    }
+
+    public func filterBatch(keepIndices: [Int]) {
+        guard let caches = batchedCaches else { return }
+        let idx = MLXArray(keepIndices.map { Int32($0) }, [keepIndices.count])
+        for c in caches { (c as? BatchedCache)?.filterBatched(batchIndices: idx) }
+    }
+
+    public func admitPrefill(_ hidden: MLXArray, leftPadding: [Int]) -> MLXArray {
+        let admitted = shard.makeBatchedCaches(leftPadding: leftPadding)
+        let out = shard.runOwnedLayers(hidden, cache: admitted, evalEvery: 4)
+        if let live = batchedCaches {
+            for (i, c) in live.enumerated() where i < admitted.count {
+                if let bc = c as? BatchedCache, let other = admitted[i] as? BatchedCache {
+                    bc.extendBatched(other)
+                }
+            }
+        }
+        return out
+    }
+
+    private func caches() -> [KVCache] {
+        if let kvCaches { return kvCaches }
+        // Single-stream (B=1) path: one KVCacheSimple per owned layer, exactly
+        // like the GPT-OSS adapter. Gemma 4's sliding-window layers stay correct
+        // because `runOwnedLayers` applies the windowSize-restricted mask per
+        // layer type; the cache just retains keys (no memory cap), which is fine
+        // for the short single-stream generations this path serves.
+        let made = (0 ..< shard.ownedLayerCount).map { _ in KVCacheSimple() as KVCache }
+        kvCaches = made
+        return made
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Cluster/HandshakeTransport.swift
+++ b/provider-swift/Sources/ProviderCore/Cluster/HandshakeTransport.swift
@@ -1,0 +1,139 @@
+/// HandshakeTransport -- carries the 3 `ClusterHandshake` messages between two
+/// cluster nodes so they can establish a `ClusterSession` before inference.
+///
+/// The handshake *logic* (`ClusterHandshakeInitiator`/`Responder`) is transport-
+/// agnostic and already verified; this is the thin wire that moves Msg1/2/3.
+/// A length-prefixed framing carries a JSON-encoded `HandshakeEnvelope`. The
+/// concrete socket implementation uses `Network.framework` (`NWConnection`),
+/// matching `CoordinatorClient`; an in-memory pair implementation drives the
+/// full exchange in tests on one machine.
+///
+/// `runInitiatorHandshake` / `runResponderHandshake` are the orchestration:
+/// they own the message ordering, so callers just provide the signer + roster
+/// and get back a `ClusterSession`.
+
+import Foundation
+
+public enum HandshakeWireError: Error, Sendable {
+    case encodeFailed
+    case decodeFailed
+    case unexpectedMessage(String)
+    case channelClosed
+}
+
+/// Tagged envelope so a single byte stream can carry all three message types.
+public struct HandshakeEnvelope: Codable, Sendable {
+    public enum Kind: String, Codable, Sendable { case msg1, msg2, msg3 }
+    public let kind: Kind
+    public let msg1: ClusterHandshakeMsg1?
+    public let msg2: ClusterHandshakeMsg2?
+    public let msg3: ClusterHandshakeMsg3?
+
+    static func wrap(_ m: ClusterHandshakeMsg1) -> HandshakeEnvelope { .init(kind: .msg1, msg1: m, msg2: nil, msg3: nil) }
+    static func wrap(_ m: ClusterHandshakeMsg2) -> HandshakeEnvelope { .init(kind: .msg2, msg1: nil, msg2: m, msg3: nil) }
+    static func wrap(_ m: ClusterHandshakeMsg3) -> HandshakeEnvelope { .init(kind: .msg3, msg1: nil, msg2: nil, msg3: m) }
+}
+
+/// A bidirectional message channel between this node and one peer. Send/recv
+/// whole `HandshakeEnvelope`s (framing handled by the implementation).
+public protocol HandshakeChannel: Sendable {
+    func send(_ envelope: HandshakeEnvelope) async throws
+    func recv() async throws -> HandshakeEnvelope
+}
+
+public enum HandshakeWire {
+    static let encoder = JSONEncoder()
+    static let decoder = JSONDecoder()
+
+    public static func encode(_ env: HandshakeEnvelope) throws -> Data {
+        guard let body = try? encoder.encode(env) else { throw HandshakeWireError.encodeFailed }
+        var framed = Data()
+        var len = UInt32(body.count).bigEndian
+        withUnsafeBytes(of: &len) { framed.append(contentsOf: $0) }
+        framed.append(body)
+        return framed
+    }
+
+    public static func decode(_ body: Data) throws -> HandshakeEnvelope {
+        guard let env = try? decoder.decode(HandshakeEnvelope.self, from: body) else {
+            throw HandshakeWireError.decodeFailed
+        }
+        return env
+    }
+}
+
+// MARK: - Orchestration
+
+public enum ClusterHandshakeRunner {
+    /// Drive the initiator side (lower nodeId) to a completed session.
+    public static func runInitiator(
+        clusterId: String,
+        localNodeId: String,
+        signer: any AttestationSigner,
+        roster: ClusterRosterBody,
+        channel: any HandshakeChannel
+    ) async throws -> ClusterSession {
+        let initiator = ClusterHandshakeInitiator(
+            clusterId: clusterId, localNodeId: localNodeId, signer: signer, roster: roster)
+        try await channel.send(.wrap(initiator.start()))
+        let env = try await channel.recv()
+        guard let m2 = env.msg2 else { throw HandshakeWireError.unexpectedMessage(env.kind.rawValue) }
+        let (m3, session) = try initiator.finish(m2)
+        try await channel.send(.wrap(m3))
+        return session
+    }
+
+    /// Drive the responder side to a completed session.
+    public static func runResponder(
+        localNodeId: String,
+        signer: any AttestationSigner,
+        roster: ClusterRosterBody,
+        channel: any HandshakeChannel
+    ) async throws -> ClusterSession {
+        let responder = ClusterHandshakeResponder(
+            localNodeId: localNodeId, signer: signer, roster: roster)
+        let env1 = try await channel.recv()
+        guard let m1 = env1.msg1 else { throw HandshakeWireError.unexpectedMessage(env1.kind.rawValue) }
+        let m2 = try responder.respond(m1)
+        try await channel.send(.wrap(m2))
+        let env3 = try await channel.recv()
+        guard let m3 = env3.msg3 else { throw HandshakeWireError.unexpectedMessage(env3.kind.rawValue) }
+        return try responder.confirm(m3)
+    }
+}
+
+// MARK: - In-memory channel (tests / single-box smoke)
+
+/// A linked pair of in-process channels: what one sends, the other receives.
+public final class InMemoryHandshakeChannelPair: Sendable {
+    public let a: any HandshakeChannel
+    public let b: any HandshakeChannel
+
+    public init() {
+        let aToB = HandshakeMailbox()
+        let bToA = HandshakeMailbox()
+        self.a = InMemoryHandshakeChannel(outbox: aToB, inbox: bToA)
+        self.b = InMemoryHandshakeChannel(outbox: bToA, inbox: aToB)
+    }
+}
+
+actor HandshakeMailbox {
+    private var queue: [HandshakeEnvelope] = []
+    private var waiters: [CheckedContinuation<HandshakeEnvelope, Never>] = []
+
+    func put(_ e: HandshakeEnvelope) {
+        if !waiters.isEmpty { waiters.removeFirst().resume(returning: e) }
+        else { queue.append(e) }
+    }
+    func take() async -> HandshakeEnvelope {
+        if !queue.isEmpty { return queue.removeFirst() }
+        return await withCheckedContinuation { waiters.append($0) }
+    }
+}
+
+struct InMemoryHandshakeChannel: HandshakeChannel {
+    let outbox: HandshakeMailbox
+    let inbox: HandshakeMailbox
+    func send(_ envelope: HandshakeEnvelope) async throws { await outbox.put(envelope) }
+    func recv() async throws -> HandshakeEnvelope { await inbox.take() }
+}

--- a/provider-swift/Sources/ProviderCore/Cluster/InferenceEngine.swift
+++ b/provider-swift/Sources/ProviderCore/Cluster/InferenceEngine.swift
@@ -1,0 +1,38 @@
+/// InferenceEngine -- the abstraction seam that lets a *distributed* engine
+/// stand in where the single-process `BatchScheduler` is used today.
+///
+/// Today `ProviderLoop` owns a concrete `BatchScheduler`. To run a model across
+/// a cluster (pipeline parallelism), the head node needs an engine with the
+/// same surface that internally fans the forward pass across ring neighbors.
+/// This protocol is that surface -- intentionally the minimal subset of
+/// `BatchScheduler`'s public API the provider loop relies on -- so that:
+///   - `BatchScheduler` conforms unchanged (single-node, the default), and
+///   - `DistributedInferenceEngine` conforms for cluster mode.
+///
+/// See docs/architecture/clustering.md §5 (engine binding row).
+
+import Foundation
+import MLXLMCommon
+
+public protocol InferenceEngine: Actor {
+    /// Load (or replace) the resident model.
+    func loadModel(container: ModelContainer, modelId: String, weightHash: String?) async
+
+    /// Submit a chat request; returns a stream of generation events.
+    func submit(request: ChatCompletionRequest, requestId: String?) async -> AsyncStream<GenerationEvent>
+
+    /// Cancel an in-flight request.
+    func cancel(requestId: String) async
+
+    /// Current capacity snapshot (slots, token budget, decode TPS, ...).
+    func capacity() -> SchedulerCapacity
+}
+
+// MARK: - BatchScheduler conformance
+
+/// `BatchScheduler` already implements every requirement (matching argument
+/// labels and defaults). The conformance is declared here, in the cluster
+/// module, so the single-node scheduler file is not touched -- a surgical,
+/// behavior-preserving addition (the protocol just names methods it already
+/// has).
+extension BatchScheduler: InferenceEngine {}

--- a/provider-swift/Sources/ProviderCore/Cluster/LayerPartition.swift
+++ b/provider-swift/Sources/ProviderCore/Cluster/LayerPartition.swift
@@ -1,0 +1,113 @@
+/// LayerPartition -- memory-weighted assignment of transformer layers to cluster
+/// nodes for pipeline parallelism.
+///
+/// Reimplements exo's `allocate_layers_proportionally` (placement_utils.py:47)
+/// in Swift: each node receives a contiguous, half-open layer interval
+/// `[start, end)`, sized in proportion to its available RAM, with a
+/// largest-remainder rule so the layer counts sum exactly to `totalLayers` and
+/// every participating node gets at least one layer.
+///
+/// Pure arithmetic -- no MLX, no IO -- so it is unit-testable on one machine and
+/// is the deterministic input the distributed engine uses to decide which
+/// layers each rank loads. The node ordering passed in is the ring order; the
+/// resulting intervals are contiguous and cover `0..<totalLayers` exactly.
+
+import Foundation
+
+public struct LayerInterval: Equatable, Sendable {
+    public let nodeId: String
+    /// Inclusive start layer index.
+    public let start: Int
+    /// Exclusive end layer index.
+    public let end: Int
+
+    public var count: Int { end - start }
+    /// Canonical "start..end" string used as AEAD layer-range context.
+    public var rangeString: String { "\(start)..\(end)" }
+
+    public init(nodeId: String, start: Int, end: Int) {
+        self.nodeId = nodeId
+        self.start = start
+        self.end = end
+    }
+}
+
+public enum LayerPartitionError: Error, Equatable, Sendable {
+    case noNodes
+    case tooManyNodesForLayers(nodes: Int, layers: Int)
+    case nonPositiveWeight(nodeId: String)
+}
+
+public enum LayerPartition {
+    /// A node and the memory weight used to size its share.
+    public struct NodeWeight: Equatable, Sendable {
+        public let nodeId: String
+        /// Available memory in bytes (or any positive proportional weight).
+        public let weightBytes: UInt64
+        public init(nodeId: String, weightBytes: UInt64) {
+            self.nodeId = nodeId
+            self.weightBytes = weightBytes
+        }
+    }
+
+    /// Partition `totalLayers` across `nodes` (given in ring order) in
+    /// proportion to each node's weight, largest-remainder, min 1 layer/node.
+    public static func partition(totalLayers: Int, nodes: [NodeWeight]) throws -> [LayerInterval] {
+        guard !nodes.isEmpty else { throw LayerPartitionError.noNodes }
+        guard totalLayers >= nodes.count else {
+            throw LayerPartitionError.tooManyNodesForLayers(nodes: nodes.count, layers: totalLayers)
+        }
+        for n in nodes where n.weightBytes == 0 {
+            throw LayerPartitionError.nonPositiveWeight(nodeId: n.nodeId)
+        }
+
+        let totalWeight = nodes.reduce(0.0) { $0 + Double($1.weightBytes) }
+
+        // Ideal (fractional) share per node, then floor with min-1.
+        var counts = [Int](repeating: 0, count: nodes.count)
+        var remainders = [(idx: Int, frac: Double)]()
+        var assigned = 0
+        for (i, n) in nodes.enumerated() {
+            let ideal = Double(totalLayers) * Double(n.weightBytes) / totalWeight
+            let floored = max(1, Int(ideal.rounded(.down)))
+            counts[i] = floored
+            assigned += floored
+            remainders.append((i, ideal - Double(Int(ideal.rounded(.down)))))
+        }
+
+        // Reconcile to exactly totalLayers.
+        if assigned > totalLayers {
+            // Over-assigned (min-1 inflation on tiny nodes): trim from the
+            // nodes with the most layers, never below 1.
+            var over = assigned - totalLayers
+            let order = counts.enumerated().sorted { $0.element > $1.element }.map(\.offset)
+            var oi = 0
+            while over > 0 {
+                let idx = order[oi % order.count]
+                if counts[idx] > 1 { counts[idx] -= 1; over -= 1 }
+                oi += 1
+                // Safety: if every node is at 1 we cannot trim further; the
+                // totalLayers >= nodes.count guard guarantees this terminates.
+                if oi > order.count * (totalLayers + 1) { break }
+            }
+        } else if assigned < totalLayers {
+            // Under-assigned: hand out the leftover by largest fractional part.
+            var remaining = totalLayers - assigned
+            for (idx, _) in remainders.sorted(by: { $0.frac > $1.frac }) {
+                if remaining == 0 { break }
+                counts[idx] += 1
+                remaining -= 1
+            }
+        }
+
+        // Materialize contiguous intervals in ring order.
+        var intervals = [LayerInterval]()
+        var cursor = 0
+        for (i, n) in nodes.enumerated() {
+            let end = cursor + counts[i]
+            intervals.append(LayerInterval(nodeId: n.nodeId, start: cursor, end: end))
+            cursor = end
+        }
+        return intervals
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Cluster/MLXDistributed.swift
+++ b/provider-swift/Sources/ProviderCore/Cluster/MLXDistributed.swift
@@ -1,0 +1,123 @@
+/// MLXDistributed -- a thin Swift binding over MLX's C distributed API.
+///
+/// `mlx-swift` ships the full MLX C++ core and the `mlx-c` C API (which DOES
+/// expose distributed collectives: `mlx_distributed_init`,
+/// `mlx_distributed_send`, `mlx_distributed_recv_like`,
+/// `mlx_distributed_all_gather`, `mlx_distributed_all_sum`, ...) but does NOT
+/// wrap them in Swift. This file is that missing wrapper -- the foundation of
+/// Spike A (Swift-native pipeline parallelism); see
+/// docs/developer/clustering-spike-plan.md.
+///
+/// It deliberately exposes only the primitives the pipeline path needs:
+///   - init/availability + rank/size
+///   - send / recv_like  (ring activation hand-off)
+///   - all_gather        (final-token broadcast at the pipeline tail)
+///
+/// Tensor-parallel collectives (all_sum/sum_scatter) are intentionally omitted
+/// for now: pipeline parallelism is the securable-first path (see
+/// docs/architecture/clustering.md §3①).
+///
+/// NOTE (Spike A wiring): the binding calls the C symbols directly via `Cmlx`
+/// and reaches into `MLXArray.ctx` (public `internal(set)`). The transport
+/// (ring/jaccl), host list, and rank are configured the way exo configures
+/// them -- environment variables (`MLX_HOSTFILE`, `MLX_RANK`, ...) -- before
+/// `initialize()` is called. That env wiring is host/launch concern, handled by
+/// the provider start path, not here.
+
+import Cmlx
+import Foundation
+import MLX
+
+public enum MLXDistributedError: Error, Sendable {
+    case unavailable(backend: String)
+    case initFailed(backend: String)
+    case opFailed(op: String, code: Int32)
+}
+
+/// Selects the MLX distributed transport backend.
+public enum MLXDistributedBackend: String, Sendable {
+    /// TCP ring (Thunderbolt-IP prioritized). The PoC / no-RDMA path.
+    case ring
+    /// RDMA over Thunderbolt 5. Faster; requires rdma_ctl + TB5 hardware.
+    case jaccl
+}
+
+/// A handle to an initialized MLX distributed group. Wraps the C
+/// `mlx_distributed_group`. Not Sendable: MLX group handles are tied to the
+/// process's distributed runtime and must be used from the inference actor.
+public final class MLXDistributedGroup {
+    let group: mlx_distributed_group
+
+    init(group: mlx_distributed_group) {
+        self.group = group
+    }
+
+    public var rank: Int { Int(mlx_distributed_group_rank(group)) }
+    public var size: Int { Int(mlx_distributed_group_size(group)) }
+
+    /// Whether a backend is available in this build/runtime.
+    public static func isAvailable(_ backend: MLXDistributedBackend) -> Bool {
+        backend.rawValue.withCString { mlx_distributed_is_available($0) }
+    }
+
+    /// Initialize (or join) the process's distributed group for `backend`.
+    /// `strict = true` fails rather than silently falling back to a 1-rank
+    /// group -- we want a hard error if the cluster didn't form.
+    public static func initialize(backend: MLXDistributedBackend, strict: Bool = true) throws -> MLXDistributedGroup {
+        guard isAvailable(backend) else {
+            throw MLXDistributedError.unavailable(backend: backend.rawValue)
+        }
+        let group = backend.rawValue.withCString { mlx_distributed_init(strict, $0) }
+        // A zero/empty handle indicates init failure under strict mode.
+        let handle = MLXDistributedGroup(group: group)
+        guard handle.size >= 1 else {
+            throw MLXDistributedError.initFailed(backend: backend.rawValue)
+        }
+        return handle
+    }
+
+    // MARK: - Collectives (pipeline path)
+
+    // The ring backend's collectives are CPU-only (it forces Device::cpu in
+    // `communication_stream`). Passing a GPU stream makes MLX try a GPU
+    // Send/Recv that has no implementation ([Send::eval_gpu] has no GPU
+    // implementation). So these ops default to the CPU stream; MLX moves the
+    // tensor across the GPU↔CPU boundary at the hop.
+
+    /// Send `x` to rank `dst`. Returns the dependency array MLX produces (the
+    /// graph node that must be evaluated to actually transmit).
+    public func send(_ x: MLXArray, to dst: Int, stream: StreamOrDevice = .cpu) throws -> MLXArray {
+        try call("send") { res in
+            mlx_distributed_send(&res, x.ctx, Int32(dst), group, stream.ctx)
+        }
+    }
+
+    /// Receive an array shaped like `like` from rank `src`.
+    public func recvLike(_ like: MLXArray, from src: Int, stream: StreamOrDevice = .cpu) throws -> MLXArray {
+        try call("recv_like") { res in
+            mlx_distributed_recv_like(&res, like.ctx, Int32(src), group, stream.ctx)
+        }
+    }
+
+    /// All-gather `x` across the group (used to broadcast the sampled token
+    /// from the pipeline tail back to every rank).
+    public func allGather(_ x: MLXArray, stream: StreamOrDevice = .cpu) throws -> MLXArray {
+        try call("all_gather") { res in
+            mlx_distributed_all_gather(&res, x.ctx, group, stream.ctx)
+        }
+    }
+
+    // MARK: - Plumbing
+
+    /// Run a C collective that fills an `mlx_array` out-param, mapping the
+    /// non-zero return code to an error and wrapping the result as `MLXArray`.
+    private func call(_ op: String, _ body: (inout mlx_array) -> Int32) throws -> MLXArray {
+        var res = mlx_array_new()
+        let code = body(&res)
+        guard code == 0 else {
+            mlx_array_free(res)
+            throw MLXDistributedError.opFailed(op: op, code: code)
+        }
+        return MLXArray(res)
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Cluster/MLXRingEnvironment.swift
+++ b/provider-swift/Sources/ProviderCore/Cluster/MLXRingEnvironment.swift
@@ -1,0 +1,63 @@
+/// MLXRingEnvironment -- materialize a `ClusterPlan` into the exact environment
+/// MLX's ring backend reads at `mlx_distributed_init(backend: "ring")`.
+///
+/// Verified against the linked MLX C++ (mlx/distributed/ring/ring.cpp): the ring
+/// backend reads `MLX_HOSTFILE` (a JSON file: a rank-ordered list, each entry a
+/// list of "ip:port" addresses) and `MLX_RANK`. This writes that hostfile and
+/// returns the env vars to set before initializing the group.
+///
+/// Member addresses in `[cluster]` are "host" or "host:port"; we default the
+/// port to a fixed ring base port when absent. Pure (writes one file) and
+/// independently testable: the JSON shape is asserted in tests.
+
+import Foundation
+
+public enum MLXRingEnvironmentError: Error, Sendable {
+    case writeFailed(path: String)
+    case encodeFailed
+}
+
+public enum MLXRingEnvironment {
+    /// Default TCP port for the ring transport when a member address omits one.
+    public static let defaultRingPort: UInt16 = 5680
+
+    /// Build the rank-ordered hostfile JSON (`[["ip:port"], ...]`) from a plan.
+    public static func hostfileJSON(_ plan: ClusterPlan) throws -> Data {
+        let nodes: [[String]] = plan.members.map { member in
+            [normalizedAddress(member.address)]
+        }
+        guard let data = try? JSONSerialization.data(withJSONObject: nodes, options: [.prettyPrinted]) else {
+            throw MLXRingEnvironmentError.encodeFailed
+        }
+        return data
+    }
+
+    /// Ensure `address` has a port; append the default ring port if not.
+    public static func normalizedAddress(_ address: String) -> String {
+        // IPv6 literals contain ':' — only append a port when there's no
+        // host:port form already (heuristic: a single trailing ':port').
+        if address.contains("]:") { return address }            // [v6]:port
+        if address.hasPrefix("[") { return "\(address):\(defaultRingPort)" } // [v6]
+        let parts = address.split(separator: ":")
+        if parts.count == 2, UInt16(parts[1]) != nil { return address } // host:port
+        return "\(address):\(defaultRingPort)"
+    }
+
+    /// Write the hostfile to `directory` and return the env vars MLX needs.
+    /// The provider start path sets these (via `setenv`) before
+    /// `MLXDistributedGroup.initialize(.ring)`.
+    @discardableResult
+    public static func materialize(_ plan: ClusterPlan, directory: URL) throws -> [String: String] {
+        let json = try hostfileJSON(plan)
+        let path = directory.appendingPathComponent("mlx-hostfile-\(plan.clusterId).json")
+        do {
+            try json.write(to: path, options: .atomic)
+        } catch {
+            throw MLXRingEnvironmentError.writeFailed(path: path.path)
+        }
+        return [
+            "MLX_HOSTFILE": path.path,
+            "MLX_RANK": String(plan.rank),
+        ]
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Cluster/NWHandshakeChannel.swift
+++ b/provider-swift/Sources/ProviderCore/Cluster/NWHandshakeChannel.swift
@@ -1,0 +1,122 @@
+/// NWHandshakeChannel -- a `HandshakeChannel` over a TCP connection using
+/// `Network.framework`, for carrying the handshake between two cluster Macs on
+/// the same Thunderbolt-bridge / LAN.
+///
+/// Length-prefixed `HandshakeEnvelope` frames (4-byte big-endian length + JSON
+/// body, via `HandshakeWire`). The lower-nodeId node dials the higher one
+/// (`connect`); the higher one listens (`accept`). Both sides then run the
+/// `ClusterHandshakeRunner` over the resulting channel.
+///
+/// This is a control-plane channel only (3 small messages per neighbor at
+/// startup); the activation data plane is separate (MLX ring). The handshake
+/// itself authenticates the peer against the coordinator roster, so this socket
+/// does not need its own TLS — a MITM cannot forge the SE-signed transcript.
+
+import Foundation
+import Network
+
+public actor NWHandshakeChannel: HandshakeChannel {
+    private let connection: NWConnection
+    private var started = false
+    private var readBuffer = Data()
+
+    public init(connection: NWConnection) {
+        self.connection = connection
+    }
+
+    /// Dial a peer (initiator side).
+    public static func connect(host: String, port: UInt16) -> NWHandshakeChannel {
+        let endpoint = NWEndpoint.hostPort(
+            host: NWEndpoint.Host(host),
+            port: NWEndpoint.Port(rawValue: port)!)
+        let conn = NWConnection(to: endpoint, using: .tcp)
+        return NWHandshakeChannel(connection: conn)
+    }
+
+    private func startIfNeeded() async throws {
+        guard !started else { return }
+        started = true
+        let queue = DispatchQueue(label: "darkbloom.cluster.handshake")
+        try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
+            connection.stateUpdateHandler = { state in
+                switch state {
+                case .ready: cont.resume()
+                case .failed(let e), .waiting(let e): cont.resume(throwing: e)
+                default: break
+                }
+            }
+            connection.start(queue: queue)
+        }
+    }
+
+    public func send(_ envelope: HandshakeEnvelope) async throws {
+        try await startIfNeeded()
+        let framed = try HandshakeWire.encode(envelope)
+        try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
+            connection.send(content: framed, completion: .contentProcessed { error in
+                if let error { cont.resume(throwing: error) } else { cont.resume() }
+            })
+        }
+    }
+
+    public func recv() async throws -> HandshakeEnvelope {
+        try await startIfNeeded()
+        // Read the 4-byte length prefix, then the body.
+        let header = try await readExactly(4)
+        let len = header.withUnsafeBytes { Int(UInt32(bigEndian: $0.loadUnaligned(as: UInt32.self))) }
+        let body = try await readExactly(len)
+        return try HandshakeWire.decode(body)
+    }
+
+    /// Pull exactly `count` bytes, buffering any overshoot for the next read.
+    private func readExactly(_ count: Int) async throws -> Data {
+        while readBuffer.count < count {
+            let chunk = try await receiveChunk()
+            if chunk.isEmpty { throw HandshakeWireError.channelClosed }
+            readBuffer.append(chunk)
+        }
+        let out = readBuffer.prefix(count)
+        readBuffer.removeFirst(count)
+        return Data(out)
+    }
+
+    private func receiveChunk() async throws -> Data {
+        try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Data, Error>) in
+            connection.receive(minimumIncompleteLength: 1, maximumLength: 64 * 1024) { data, _, isComplete, error in
+                if let error { cont.resume(throwing: error); return }
+                if let data, !data.isEmpty { cont.resume(returning: data); return }
+                if isComplete { cont.resume(returning: Data()); return }
+                cont.resume(returning: Data())
+            }
+        }
+    }
+
+    public func close() {
+        connection.cancel()
+    }
+}
+
+/// Listener that accepts a single inbound handshake connection (responder side).
+public actor NWHandshakeListener {
+    private let listener: NWListener
+
+    public init(port: UInt16) throws {
+        self.listener = try NWListener(using: .tcp, on: NWEndpoint.Port(rawValue: port)!)
+    }
+
+    /// Wait for the next inbound peer and return a channel for it.
+    public func accept() async throws -> NWHandshakeChannel {
+        let queue = DispatchQueue(label: "darkbloom.cluster.handshake.listen")
+        return try await withCheckedThrowingContinuation { (cont: CheckedContinuation<NWHandshakeChannel, Error>) in
+            listener.newConnectionHandler = { conn in
+                cont.resume(returning: NWHandshakeChannel(connection: conn))
+            }
+            listener.stateUpdateHandler = { state in
+                if case .failed(let e) = state { cont.resume(throwing: e) }
+            }
+            listener.start(queue: queue)
+        }
+    }
+
+    public func stop() { listener.cancel() }
+}

--- a/provider-swift/Sources/ProviderCore/Cluster/PipelineModelShard.swift
+++ b/provider-swift/Sources/ProviderCore/Cluster/PipelineModelShard.swift
@@ -1,0 +1,80 @@
+/// PipelineModelShard -- the per-rank slice of a model, as the distributed
+/// engine sees it. This is the seam between Darkbloom's pipeline orchestration
+/// (fully implemented + verified in ProviderCore) and the MLX model internals
+/// (which live in the `mlx-swift-lm` submodule).
+///
+/// A rank owns a contiguous layer interval `[start, end)`:
+///   - the HEAD rank (start == 0) also embeds tokens,
+///   - the TAIL rank (end == totalLayers) also applies the final norm + lm_head
+///     and exposes the vocabulary logits for sampling.
+///
+/// Why a protocol: `LlamaModelInner.layers` is `internal` to MLXLLM and its
+/// `callAsFunction` runs the FULL layer stack, so a *partial* forward (only this
+/// rank's layers) cannot be expressed from ProviderCore today. Implementing
+/// `PipelineModelShard` for a concrete architecture requires a small addition in
+/// the mlx-swift-lm fork (expose a sliced-layer forward). Until then, the engine,
+/// decode loop, transport, handshake, and crypto are all complete and tested
+/// against this seam with a stand-in shard. See
+/// docs/developer/clustering-implementation-status.md.
+
+import Foundation
+import MLX
+
+public protocol PipelineModelShard: Sendable {
+    /// Total transformer layers in the full model (same on every rank).
+    var totalLayers: Int { get }
+    /// The contiguous layer interval this rank owns.
+    var ownedInterval: LayerInterval { get }
+
+    /// HEAD only: embed a token id sequence into the initial hidden state.
+    /// Non-head ranks receive the hidden state over the wire instead.
+    func embed(tokens: [Int]) -> MLXArray
+
+    /// Run this rank's owned layers on an inbound hidden state, returning the
+    /// transformed hidden state.
+    func runOwnedLayers(_ hidden: MLXArray) -> MLXArray
+
+    /// TAIL only: project the post-layer hidden state to vocabulary logits
+    /// (final norm + lm_head). Non-tail ranks never call this.
+    func projectToLogits(_ hidden: MLXArray) -> MLXArray
+
+    // MARK: - Batched (continuous-batching) path
+
+    /// HEAD only: embed a BATCH of token rows into `[B, maxLen, hidden]`. Each
+    /// row is left-padded to `maxLen` per `leftPadding[b]` so ragged-length
+    /// prompts share one forward; the matching `BatchKVCache` masks the padding.
+    /// (Phase 1 uses equal-length rows ⇒ all leftPadding == 0.)
+    func embedBatch(rows: [[Int]], leftPadding: [Int]) -> MLXArray
+
+    /// Run this rank's owned layers on a batched `[B, width, hidden]` hidden
+    /// state, using the batched KV caches established by `beginBatch`.
+    func runOwnedLayersBatched(_ hidden: MLXArray) -> MLXArray
+
+    /// TAIL only: project a batched `[B, width, hidden]` state to `[B, *, vocab]`
+    /// logits (last position only).
+    func projectToLogitsBatched(_ hidden: MLXArray) -> MLXArray
+
+    /// (Re)allocate this rank's per-owned-layer BATCHED KV caches for a batch of
+    /// `leftPadding.count` rows. Must be called before a batched generation; the
+    /// batched run/project calls use these caches. Resets any prior batch state.
+    func beginBatch(leftPadding: [Int])
+
+    // MARK: - Continuous-batching cache lifecycle (Phase 3)
+
+    /// Evict rows: keep only `keepIndices` (into the current batch order) in every
+    /// owned-layer batched cache. All ranks call this with the same indices so
+    /// caches stay row-aligned.
+    func filterBatch(keepIndices: [Int])
+
+    /// Run a PREFILL of newly-admitted rows on a SEPARATE temporary batched cache
+    /// and merge it into the live batched caches (append rows). `hidden` is the
+    /// admitted rows' post-embed (head) or received (peer) `[nAdmit, width, hidden]`
+    /// state; returns the post-owned-layers state so the tail can sample the
+    /// admitted rows' first tokens. `leftPadding` sizes the admitted cache.
+    func admitPrefill(_ hidden: MLXArray, leftPadding: [Int]) -> MLXArray
+}
+
+public extension PipelineModelShard {
+    var isHead: Bool { ownedInterval.start == 0 }
+    var isTail: Bool { ownedInterval.end == totalLayers }
+}

--- a/provider-swift/Sources/ProviderCore/Cluster/PipelineRunner.swift
+++ b/provider-swift/Sources/ProviderCore/Cluster/PipelineRunner.swift
@@ -1,0 +1,109 @@
+/// PipelineRunner -- the full multi-token greedy decode loop over a pipeline.
+///
+/// Each rank runs THIS loop with its own `PipelineModelShard` + `PipelineStage`.
+/// Per decode step the hidden state flows head→…→tail (sealed activations over
+/// the ring), the tail samples the next token, and that token is broadcast back
+/// so the head can embed it for the next step. The loop ends on EOS or
+/// `maxTokens`. Sampled tokens are delivered through `onToken` as they are
+/// produced (the tail produces them; on other ranks they arrive via the token
+/// broadcast so every rank can stay in lockstep and stop together).
+///
+/// Greedy only for the PoC (argmax); temperature/top-p sampling is a later add.
+/// The token broadcast is abstracted via `TokenChannel` — loopback in tests,
+/// MLX `all_gather` on hardware.
+
+import Foundation
+import MLX
+
+/// Broadcasts the just-sampled token id from the tail to all ranks each step.
+public protocol TokenChannel: Sendable {
+    /// Tail publishes the sampled token for `step`.
+    func publish(token: Int, step: Int) async throws
+    /// Non-tail ranks await the token for `step`.
+    func receive(step: Int) async throws -> Int
+}
+
+public struct PipelineRunConfig: Sendable {
+    public let clusterId: String
+    public let requestId: String
+    public let maxTokens: Int
+    public let eosTokenIds: Set<Int>
+    public init(clusterId: String, requestId: String, maxTokens: Int, eosTokenIds: Set<Int>) {
+        self.clusterId = clusterId
+        self.requestId = requestId
+        self.maxTokens = maxTokens
+        self.eosTokenIds = eosTokenIds
+    }
+}
+
+public struct PipelineRunner {
+    let shard: any PipelineModelShard
+    let stage: PipelineStage
+    let tokens: any TokenChannel
+    let config: PipelineRunConfig
+
+    public init(
+        shard: any PipelineModelShard,
+        stage: PipelineStage,
+        tokens: any TokenChannel,
+        config: PipelineRunConfig
+    ) {
+        self.shard = shard
+        self.stage = stage
+        self.tokens = tokens
+        self.config = config
+    }
+
+    /// Run greedy decode. `promptTokens` is the tokenized prompt (used by the
+    /// head to embed; other ranks ignore it). `onToken` is called once per
+    /// generated token id, in order, on every rank.
+    public func run(promptTokens: [Int], onToken: (Int) async -> Void) async throws {
+        var generated: [Int] = []
+
+        for step in 0..<config.maxTokens {
+            // Head embeds the running sequence (prompt + generated so far).
+            let headInput: MLXArray? = shard.isHead
+                ? shard.embed(tokens: promptTokens + generated)
+                : nil
+
+            // One forward step through this rank's layers, with sealed ring
+            // hand-off. Tail gets the post-layer hidden state back to project.
+            // The stage builds per-hop AEAD contexts internally (bound to the
+            // sender rank) so inbound/outbound hops authenticate correctly.
+            let stageOut = try await stage.runStep(
+                headInput: headInput,
+                clusterId: config.clusterId,
+                requestId: config.requestId,
+                seq: UInt64(step),
+                runLayers: { shard.runOwnedLayers($0) })
+
+            // Determine the next token.
+            let nextToken: Int
+            if shard.isTail {
+                guard let hidden = stageOut else { return }   // defensive
+                let logits = shard.projectToLogits(hidden)
+                nextToken = Self.greedyToken(logits)
+                try await tokens.publish(token: nextToken, step: step)
+            } else {
+                nextToken = try await tokens.receive(step: step)
+            }
+
+            generated.append(nextToken)
+            await onToken(nextToken)
+            if config.eosTokenIds.contains(nextToken) { break }
+        }
+    }
+
+    /// Argmax over the last position's vocabulary logits.
+    static func greedyToken(_ logits: MLXArray) -> Int {
+        // logits shape is [..., vocab]; take argmax over the final axis and
+        // read the last position if a sequence axis is present.
+        let lastAxis = logits.ndim - 1
+        let ids = argMax(logits, axis: lastAxis)
+        ids.eval()
+        // ids has the logits' shape minus the vocab axis; the final scalar is
+        // the most-recent position's predicted token.
+        let flat = ids.asArray(Int32.self)
+        return Int(flat.last ?? 0)
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Cluster/PipelineStage.swift
+++ b/provider-swift/Sources/ProviderCore/Cluster/PipelineStage.swift
@@ -1,0 +1,131 @@
+/// PipelineStage -- one rank's half of a pipeline-parallel forward pass.
+///
+/// This is the Swift equivalent of exo's PipelineFirstLayer/PipelineLastLayer
+/// wrapping (auto_parallel.py:132/158), with Darkbloom's encryption woven in:
+///
+///   rank 0 (head):  embed → run owned layers → SEAL+send hidden state
+///   middle rank:    recv+OPEN → run owned layers → SEAL+send
+///   last rank:      recv+OPEN → run owned layers → norm+lm_head → sample token
+///
+/// The "run owned layers" step is injected as a closure (`runLayers`) so the
+/// stage logic — boundary recv/open, layer execution, seal/send, sequencing —
+/// is unit-testable on ONE machine with a mock transform, and the SAME stage
+/// drives the real model on hardware (the closure becomes the sliced
+/// `LlamaModelInner` layer loop). The transport is likewise injected
+/// (`PipelineTransport`), loopback locally / MLX-ring on two Macs.
+///
+/// Encryption boundary: a hidden state only ever leaves a rank as a sealed
+/// `ActivationCodec` frame. `runLayers` operates on plaintext tensors strictly
+/// inside the process. See docs/architecture/cluster-node-handshake.md §6.
+
+import Foundation
+import MLX
+
+/// Per-rank inputs needed to run its slice of the pipeline.
+public struct PipelineStageConfig: Sendable {
+    public let rank: Int
+    public let worldSize: Int
+    public let interval: LayerInterval
+    /// Ring neighbors. nil at the ends of a non-wrapping pipeline.
+    public let prevRank: Int?
+    public let nextRank: Int?
+
+    public var isHead: Bool { rank == 0 }
+    public var isTail: Bool { rank == worldSize - 1 }
+
+    public init(rank: Int, worldSize: Int, interval: LayerInterval, prevRank: Int?, nextRank: Int?) {
+        self.rank = rank
+        self.worldSize = worldSize
+        self.interval = interval
+        self.prevRank = prevRank
+        self.nextRank = nextRank
+    }
+}
+
+public enum PipelineStageError: Error, Sendable {
+    case headMissingInput
+    case missingNeighbor(String)
+    case notTail
+}
+
+/// Drives one decode step (one token) through this rank's layers.
+public struct PipelineStage {
+    let config: PipelineStageConfig
+    let transport: any PipelineTransport
+    /// Seal frames going to `nextRank`. nil on the tail.
+    let sealing: ClusterSealingChannel?
+    /// Open frames coming from `prevRank`. nil on the head.
+    let opening: ClusterOpeningChannel?
+
+    public init(
+        config: PipelineStageConfig,
+        transport: any PipelineTransport,
+        sealing: ClusterSealingChannel?,
+        opening: ClusterOpeningChannel?
+    ) {
+        self.config = config
+        self.transport = transport
+        self.sealing = sealing
+        self.opening = opening
+    }
+
+    /// Run this rank's slice for one step.
+    ///
+    /// - Parameters:
+    ///   - headInput: the hidden state to start from (head only — typically the
+    ///     embedded tokens). Ignored on non-head ranks (they receive it).
+    ///   - clusterId/requestId: AEAD binding for this request.
+    ///   - seq: monotonic step index; must match the channel nonce counters.
+    ///   - runLayers: execute this rank's owned layers on a hidden state,
+    ///     returning the transformed hidden state. On the tail this closure
+    ///     should also apply final norm + lm_head and return logits.
+    /// - Returns: on the tail, the final tensor (logits) for sampling; on
+    ///   non-tail ranks, nil (their output was sent downstream).
+    ///
+    /// AAD hop binding: each frame's `layerRange` is set to the SENDER's rank
+    /// (`hop-<rank>`). A receiver opens with the sender's id, which it knows is
+    /// its own `prevRank`. This makes the AAD agree across each hop's two ends
+    /// while differing between the inbound and outbound hops of a middle rank.
+    public func runStep(
+        headInput: MLXArray?,
+        clusterId: String,
+        requestId: String,
+        seq: UInt64,
+        runLayers: (MLXArray) throws -> MLXArray
+    ) async throws -> MLXArray? {
+        // 1. Obtain the inbound hidden state.
+        let inbound: MLXArray
+        if config.isHead {
+            guard let headInput else { throw PipelineStageError.headMissingInput }
+            inbound = headInput
+        } else {
+            guard let opening, let prev = config.prevRank else {
+                throw PipelineStageError.missingNeighbor("prev")
+            }
+            let inboundCtx = Self.hopContext(clusterId: clusterId, requestId: requestId, senderRank: prev, seq: seq)
+            let sealedFrame = try await transport.recv(from: prev)
+            let plaintextBytes = try opening.open(sealedFrame, context: inboundCtx)
+            inbound = try ActivationCodec.decode(plaintextBytes)
+        }
+
+        // 2. Run owned layers (plaintext, in-process).
+        let outbound = try runLayers(inbound)
+
+        // 3. Tail returns logits for sampling; others seal+send downstream.
+        if config.isTail {
+            return outbound
+        }
+        guard let sealing, let next = config.nextRank else {
+            throw PipelineStageError.missingNeighbor("next")
+        }
+        let outboundCtx = Self.hopContext(clusterId: clusterId, requestId: requestId, senderRank: config.rank, seq: seq)
+        let frame = try sealing.seal(ActivationCodec.encode(outbound), context: outboundCtx)
+        try await transport.send(frame, to: next)
+        return nil
+    }
+
+    /// AEAD context for one hop, bound to the producing rank.
+    static func hopContext(clusterId: String, requestId: String, senderRank: Int, seq: UInt64) -> ClusterFrameContext {
+        ClusterFrameContext(clusterId: clusterId, requestId: requestId, layerRange: "hop-\(senderRank)", seq: seq)
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Cluster/PipelineTransport.swift
+++ b/provider-swift/Sources/ProviderCore/Cluster/PipelineTransport.swift
@@ -1,0 +1,171 @@
+/// PipelineTransport -- the wire over which sealed activation frames move
+/// between ring neighbors during a pipeline forward pass.
+///
+/// Abstracted so the *securing* logic (seal/serialize/open/deserialize) is
+/// tested independently of the *physical* transport:
+///   - `LoopbackPipelineTransport` runs both ranks in one process (a buffer per
+///     direction). Lets the full encode → seal → transfer → open → decode chain
+///     be verified on ONE machine, today.
+///   - `MLXRingTransport` (Spike A, on hardware) sends the sealed ciphertext
+///     bytes between two Macs via the `MLXDistributed` ring binding.
+///
+/// IMPORTANT: the transport only ever sees ciphertext. Sealing happens above it
+/// (`PipelineRunner`), so a tap on the real ring observes only AEAD frames.
+
+import Foundation
+
+public protocol PipelineTransport: Sendable {
+    /// Send an already-sealed frame to the given peer rank.
+    func send(_ sealedFrame: Data, to peerRank: Int) async throws
+    /// Receive the next sealed frame from the given peer rank (FIFO per peer).
+    func recv(from peerRank: Int) async throws -> Data
+}
+
+public enum PipelineTransportError: Error, Sendable {
+    case closed
+    case noPeer(rank: Int)
+}
+
+/// In-process transport: an ordered async queue per (fromRank → toRank) edge.
+/// Two `LoopbackPipelineTransport` views over a shared `Mailbox` let two
+/// in-process ranks exchange frames as if cabled together.
+public actor LoopbackMailbox {
+    // queues[from][to] = ordered frames in flight on that directed edge
+    private var queues: [Int: [Int: [Data]]] = [:]
+    private var waiters: [Int: [Int: [CheckedContinuation<Data, Error>]]] = [:]
+    private var closed = false
+
+    public init() {}
+
+    func put(_ frame: Data, from: Int, to: Int) {
+        if closed { return }
+        if let cont = popWaiter(from: from, to: to) {
+            cont.resume(returning: frame)
+        } else {
+            queues[from, default: [:]][to, default: []].append(frame)
+        }
+    }
+
+    func take(from: Int, to: Int) async throws -> Data {
+        if var byTo = queues[from], var arr = byTo[to], !arr.isEmpty {
+            let frame = arr.removeFirst()
+            byTo[to] = arr; queues[from] = byTo
+            return frame
+        }
+        if closed { throw PipelineTransportError.closed }
+        return try await withCheckedThrowingContinuation { cont in
+            waiters[from, default: [:]][to, default: []].append(cont)
+        }
+    }
+
+    func close() {
+        closed = true
+        for (_, byTo) in waiters {
+            for (_, conts) in byTo {
+                for c in conts { c.resume(throwing: PipelineTransportError.closed) }
+            }
+        }
+        waiters.removeAll()
+    }
+
+    private func popWaiter(from: Int, to: Int) -> CheckedContinuation<Data, Error>? {
+        guard var byTo = waiters[from], var conts = byTo[to], !conts.isEmpty else { return nil }
+        let c = conts.removeFirst()
+        byTo[to] = conts; waiters[from] = byTo
+        return c
+    }
+}
+
+/// One rank's view onto a shared mailbox.
+public struct LoopbackPipelineTransport: PipelineTransport {
+    let mailbox: LoopbackMailbox
+    let selfRank: Int
+
+    public init(mailbox: LoopbackMailbox, selfRank: Int) {
+        self.mailbox = mailbox
+        self.selfRank = selfRank
+    }
+
+    public func send(_ sealedFrame: Data, to peerRank: Int) async throws {
+        await mailbox.put(sealedFrame, from: selfRank, to: peerRank)
+    }
+
+    public func recv(from peerRank: Int) async throws -> Data {
+        try await mailbox.take(from: peerRank, to: selfRank)
+    }
+}
+
+/// In-process `TokenChannel`: the tail publishes a token per step, all ranks
+/// read it. Backed by a shared actor so a multi-rank loopback run stays in
+/// lockstep. On hardware this is MLX `all_gather` of the sampled token id.
+public actor LoopbackTokenBus {
+    private var tokens: [Int: Int] = [:]   // step -> token
+    private var waiters: [Int: [CheckedContinuation<Int, Never>]] = [:]
+
+    public init() {}
+
+    func publish(_ token: Int, step: Int) {
+        tokens[step] = token
+        if let conts = waiters[step] {
+            for c in conts { c.resume(returning: token) }
+            waiters[step] = nil
+        }
+    }
+
+    func receive(step: Int) async -> Int {
+        if let t = tokens[step] { return t }
+        return await withCheckedContinuation { cont in
+            waiters[step, default: []].append(cont)
+        }
+    }
+}
+
+public struct LoopbackTokenChannel: TokenChannel {
+    let bus: LoopbackTokenBus
+    public init(bus: LoopbackTokenBus) { self.bus = bus }
+    public func publish(token: Int, step: Int) async throws { await bus.publish(token, step: step) }
+    public func receive(step: Int) async throws -> Int { await bus.receive(step: step) }
+}
+
+/// In-process `ClusterRuntime` for one rank, sharing a mailbox + token bus with
+/// the other ranks in the same process. Lets `DistributedInferenceEngine` run
+/// fully on one machine (tests / a single-box smoke run). The session keys come
+/// from a completed handshake; sealing/opening channels are minted per request.
+public struct LoopbackClusterRuntime: ClusterRuntime {
+    let plan: ClusterPlan
+    let mailbox: LoopbackMailbox
+    let tokenBus: LoopbackTokenBus
+    /// Session for sealing toward `nextRank` (nil on the tail).
+    let sendSession: ClusterSession?
+    /// Session for opening from `prevRank` (nil on the head).
+    let recvSession: ClusterSession?
+
+    public init(
+        plan: ClusterPlan,
+        mailbox: LoopbackMailbox,
+        tokenBus: LoopbackTokenBus,
+        sendSession: ClusterSession?,
+        recvSession: ClusterSession?
+    ) {
+        self.plan = plan
+        self.mailbox = mailbox
+        self.tokenBus = tokenBus
+        self.sendSession = sendSession
+        self.recvSession = recvSession
+    }
+
+    public func makeStage(requestId: String) -> PipelineStage {
+        PipelineStage(
+            config: PipelineStageConfig(
+                rank: plan.rank, worldSize: plan.worldSize,
+                interval: LayerInterval(nodeId: plan.nodeId, start: 0, end: 0),
+                prevRank: plan.prevRank, nextRank: plan.nextRank),
+            transport: LoopbackPipelineTransport(mailbox: mailbox, selfRank: plan.rank),
+            sealing: sendSession.map { ClusterSealingChannel(key: $0.sendKey()) },
+            opening: recvSession.map { ClusterOpeningChannel(key: $0.recvKey()) })
+    }
+
+    public func makeTokenChannel(requestId: String) -> any TokenChannel {
+        LoopbackTokenChannel(bus: tokenBus)
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Config/ProviderConfig.swift
+++ b/provider-swift/Sources/ProviderCore/Config/ProviderConfig.swift
@@ -129,22 +129,107 @@ public struct CoordinatorSettings: Sendable, Equatable, Codable {
     }
 }
 
+/// One member of a cluster, as written in the `[[cluster.members]]` config.
+/// Members are listed in ring order; `nodeId` is matched against this machine's
+/// own `nodeId` to determine this node's rank.
+public struct ClusterMemberSettings: Sendable, Equatable, Codable {
+    public var nodeId: String
+    /// Address the MLX ring transport uses to reach this member
+    /// (host or host:port, Thunderbolt-bridge IP preferred).
+    public var address: String
+    /// Usable memory (GB) this member can devote to model weights. Drives the
+    /// memory-weighted layer split so a smaller machine gets fewer layers and
+    /// does not swap. Leave the OS + KV/activation headroom OUT of this number
+    /// (e.g. a 24 GB Mac → ~16; a 32 GB Mac → ~24). If omitted, the split falls
+    /// back to even.
+    public var memoryGb: Double?
+
+    public init(nodeId: String, address: String, memoryGb: Double? = nil) {
+        self.nodeId = nodeId
+        self.address = address
+        self.memoryGb = memoryGb
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case nodeId = "node_id"
+        case address
+        case memoryGb = "memory_gb"
+    }
+}
+
+/// `[cluster]` config: opt-in pipeline parallelism across co-located,
+/// individually-attested Macs (see docs/architecture/clustering.md). Disabled
+/// by default — a node with `enabled = false` behaves exactly as today.
+public struct ClusterSettings: Sendable, Equatable, Codable {
+    public var enabled: Bool
+    /// Stable identifier for the cluster (matches the coordinator-issued roster).
+    public var clusterId: String
+    /// This machine's node id; must appear in `members`.
+    public var nodeId: String
+    /// All members in ring order.
+    public var members: [ClusterMemberSettings]
+    /// Transport backend: "ring" (TCP/Thunderbolt-IP) or "jaccl" (RDMA/TB5).
+    public var backend: String
+    /// Continuous-batching decode path (Phase 3). Off by default: the proven
+    /// serial B=1 loop runs unless explicitly enabled. When true the head runs
+    /// the ClusterBatchScheduler and peers run runBatchedPeerLoop.
+    public var batched: Bool
+
+    public init(
+        enabled: Bool = false,
+        clusterId: String = "",
+        nodeId: String = "",
+        members: [ClusterMemberSettings] = [],
+        backend: String = "ring",
+        batched: Bool = false
+    ) {
+        self.enabled = enabled
+        self.clusterId = clusterId
+        self.nodeId = nodeId
+        self.members = members
+        self.backend = backend
+        self.batched = batched
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case enabled
+        case clusterId = "cluster_id"
+        case nodeId = "node_id"
+        case members
+        case backend
+        case batched
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        self.enabled = try c.decodeIfPresent(Bool.self, forKey: .enabled) ?? false
+        self.clusterId = try c.decodeIfPresent(String.self, forKey: .clusterId) ?? ""
+        self.nodeId = try c.decodeIfPresent(String.self, forKey: .nodeId) ?? ""
+        self.members = try c.decodeIfPresent([ClusterMemberSettings].self, forKey: .members) ?? []
+        self.backend = try c.decodeIfPresent(String.self, forKey: .backend) ?? "ring"
+        self.batched = try c.decodeIfPresent(Bool.self, forKey: .batched) ?? false
+    }
+}
+
 public struct ProviderConfig: Sendable, Equatable, Codable {
     public var provider: ProviderSettings
     public var backend: BackendSettings
     public var coordinator: CoordinatorSettings
     public var schedule: ScheduleConfig?
+    public var cluster: ClusterSettings?
 
     public init(
         provider: ProviderSettings,
         backend: BackendSettings = BackendSettings(),
         coordinator: CoordinatorSettings = CoordinatorSettings(),
-        schedule: ScheduleConfig? = nil
+        schedule: ScheduleConfig? = nil,
+        cluster: ClusterSettings? = nil
     ) {
         self.provider = provider
         self.backend = backend
         self.coordinator = coordinator
         self.schedule = schedule
+        self.cluster = cluster
     }
 
     public init(from decoder: Decoder) throws {
@@ -153,6 +238,7 @@ public struct ProviderConfig: Sendable, Equatable, Codable {
         self.backend = try container.decodeIfPresent(BackendSettings.self, forKey: .backend) ?? BackendSettings()
         self.coordinator = try container.decodeIfPresent(CoordinatorSettings.self, forKey: .coordinator) ?? CoordinatorSettings()
         self.schedule = try container.decodeIfPresent(ScheduleConfig.self, forKey: .schedule)
+        self.cluster = try container.decodeIfPresent(ClusterSettings.self, forKey: .cluster)
     }
 
     /// Generate a default config based on detected hardware.
@@ -221,6 +307,11 @@ public enum ConfigManager: Sendable {
     /// If none of those files exist yet, we return path #1 so first-time
     /// `save()` writes to the canonical location.
     public static func defaultConfigPath() throws -> URL {
+        // Explicit override (used to run multiple ranks on one host for testing:
+        // each process points DARKBLOOM_CONFIG at its own provider.toml).
+        if let override = ProcessInfo.processInfo.environment["DARKBLOOM_CONFIG"], !override.isEmpty {
+            return URL(fileURLWithPath: override)
+        }
         let home = FileManager.default.homeDirectoryForCurrentUser
         let appSupport = FileManager.default.urls(
             for: .applicationSupportDirectory, in: .userDomainMask

--- a/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClient.swift
+++ b/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClient.swift
@@ -249,6 +249,9 @@ public struct CoordinatorClientConfig: Sendable {
     /// nil on headless/no-GUI boxes (no token) — those register un-attested.
     public let apnsDeviceToken: String?
     public let apnsEnvironment: String?
+    /// Cluster registration blob (head only): raw JSON the head relays carrying
+    /// every member's signed attestation. nil for non-cluster providers.
+    public let cluster: RawJSON?
 
     public init(
         url: String,
@@ -265,7 +268,8 @@ public struct CoordinatorClientConfig: Sendable {
         privacyCapabilities: PrivacyCapabilities? = nil,
         privateOnly: Bool = false,
         apnsDeviceToken: String? = nil,
-        apnsEnvironment: String? = nil
+        apnsEnvironment: String? = nil,
+        cluster: RawJSON? = nil
     ) {
         self.url = url
         self.hardware = hardware
@@ -282,6 +286,7 @@ public struct CoordinatorClientConfig: Sendable {
         self.privateOnly = privateOnly
         self.apnsDeviceToken = apnsDeviceToken
         self.apnsEnvironment = apnsEnvironment
+        self.cluster = cluster
     }
 }
 

--- a/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClientCodec.swift
+++ b/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClientCodec.swift
@@ -53,7 +53,8 @@ public enum CoordinatorClientCodec {
             privacyCapabilities: privacyCapabilities,
             privateOnly: config.privateOnly,
             apnsDeviceToken: effectiveToken,
-            apnsEnvironment: effectiveEnv
+            apnsEnvironment: effectiveEnv,
+            cluster: config.cluster
         ))
     }
 

--- a/provider-swift/Sources/ProviderCore/Protocol/Messages.swift
+++ b/provider-swift/Sources/ProviderCore/Protocol/Messages.swift
@@ -39,6 +39,11 @@ public enum ProviderMessage: Sendable, Equatable {
         /// to. Mirrors RegisterMessage.APNsDeviceToken/APNsEnvironment (Go).
         public var apnsDeviceToken: String?
         public var apnsEnvironment: String?
+        /// Cluster registration: head relays every member's signed attestation
+        /// (raw JSON: {cluster_id, members:[{node_id,rank,attestation}]}). nil
+        /// for non-cluster providers. The coordinator verifies each member and
+        /// sets surfaced trust = min(member).
+        public var cluster: RawJSON?
 
         public init(
             hardware: HardwareInfo,
@@ -58,7 +63,8 @@ public enum ProviderMessage: Sendable, Equatable {
             privacyCapabilities: PrivacyCapabilities? = nil,
             privateOnly: Bool = false,
             apnsDeviceToken: String? = nil,
-            apnsEnvironment: String? = nil
+            apnsEnvironment: String? = nil,
+            cluster: RawJSON? = nil
         ) {
             self.hardware = hardware
             self.models = models
@@ -78,6 +84,7 @@ public enum ProviderMessage: Sendable, Equatable {
             self.privateOnly = privateOnly
             self.apnsDeviceToken = apnsDeviceToken
             self.apnsEnvironment = apnsEnvironment
+            self.cluster = cluster
         }
     }
 

--- a/provider-swift/Sources/ProviderCore/Protocol/ProtocolCodec.swift
+++ b/provider-swift/Sources/ProviderCore/Protocol/ProtocolCodec.swift
@@ -90,6 +90,10 @@ public enum ProviderProtocolCodec {
             try validateRawJSON(attestation.rawBytes)
             fields.append(("attestation", attestation.rawBytes))
         }
+        if let cluster = register.cluster {
+            try validateRawJSON(cluster.rawBytes)
+            fields.append(("cluster", cluster.rawBytes))
+        }
         try appendIfPresent(register.prefillTps, key: "prefill_tps", to: &fields)
         try appendIfPresent(register.decodeTps, key: "decode_tps", to: &fields)
         try appendIfPresent(register.authToken, key: "auth_token", to: &fields)

--- a/provider-swift/Sources/batch-bench/main.swift
+++ b/provider-swift/Sources/batch-bench/main.swift
@@ -1,0 +1,196 @@
+// batch-bench — batched single-node decode benchmark.
+//
+//   swift run -c release batch-bench <model-dir> [batchSize] [maxTokens] [iterations]
+//
+// Companion to `solo-bench`. Where solo-bench measures one request at a time,
+// this harness submits B concurrent decode requests through the SAME
+// continuous-batching path the provider serves production traffic with
+// (`BatchScheduler` → `BatchedEngine`), and reports the AGGREGATE decode
+// throughput. Comparing aggregate tok/s at B>1 against the B=1 number
+// quantifies the continuous-batching throughput multiplier — how much more
+// total work one box does when it folds N requests into one batched forward
+// pass instead of running them serially.
+//
+// Approach: use `BatchScheduler` directly (the production scheduler), not a
+// lower-level batched generate. The scheduler is a self-contained actor:
+// `init` → `loadModel(container:modelId:)` → N concurrent `submitTokenized`
+// calls that the engine coalesces into batched forward passes → drain each
+// request's `AsyncStream<GenerationEvent>`. No coordinator, no networking, no
+// HTTP server needed. This is both the simplest standalone path AND the most
+// representative of production decode.
+
+import Foundation
+import MLX
+import MLXLLM
+import MLXLMCommon
+import ProviderCore
+
+func die(_ m: String) -> Never { FileHandle.standardError.write(Data("ERROR: \(m)\n".utf8)); exit(1) }
+
+let argv = CommandLine.arguments
+guard argv.count >= 2 else {
+    die("usage: batch-bench <model-dir> [batchSize=4] [maxTokens=96] [iterations=4]")
+}
+let modelDir = URL(fileURLWithPath: argv[1], isDirectory: true)
+let batchSize = argv.count > 2 ? max(1, Int(argv[2]) ?? 4) : 4
+let maxTokens = argv.count > 3 ? (Int(argv[3]) ?? 96) : 96
+let iterations = argv.count > 4 ? (Int(argv[4]) ?? 4) : 4
+
+// Match the cluster/solo runs' GPU memory posture.
+let physical = ProcessInfo.processInfo.physicalMemory
+MLX.GPU.set(memoryLimit: Int(Double(physical) * 0.80), relaxed: false)
+
+print(
+    "batch-bench: \(modelDir.lastPathComponent), batchSize=\(batchSize), "
+        + "maxTokens=\(maxTokens), iterations=\(iterations)")
+
+// Load the model container exactly as the provider does (same API as solo-bench).
+let container = try await LLMModelFactory.shared.loadContainer(
+    from: modelDir, using: LocalTokenizerLoader())
+
+// Tokenizer for prompt → token IDs. We tokenize ourselves and feed the
+// scheduler's `submitTokenized` (the same entry the OpenAI bridge uses),
+// rather than the higher-level `submit(ChatCompletionRequest:)`, so the
+// benchmark prompt path is minimal and explicit.
+let tokenizer = try await LocalTokenizerLoader().load(from: modelDir)
+
+// One scheduler instance, sized so all B requests can be co-resident in a
+// single batch (maxConcurrentRequests == batchSize). kvBudget=nil keeps the
+// default per-model budget. This is the production scheduler — concurrent
+// submits are coalesced into batched forward passes by the engine.
+let scheduler = BatchScheduler(
+    maxConcurrentRequests: batchSize,
+    defaultMaxTokens: maxTokens)
+await scheduler.loadModel(container: container, modelId: modelDir.lastPathComponent)
+print("model loaded.\n")
+
+/// Build the prompt-token list for request `index`. We vary each prompt
+/// slightly (append the index) so identical-prefix caching doesn't collapse
+/// the batch into one shared-KV degenerate case — we want B genuinely
+/// independent decodes sharing one batched forward pass.
+func promptTokens(forIndex index: Int) throws -> [Int] {
+    let content = "Explain pipeline parallelism in two sentences. (variant #\(index))"
+    let messages: [[String: any Sendable]] = [["role": "user", "content": content]]
+    return try tokenizer.applyChatTemplate(
+        messages: messages, tools: nil, additionalContext: nil)
+}
+
+/// Result of draining one request's event stream.
+struct RequestResult: Sendable {
+    let completionTokens: Int
+    let startedAt: ContinuousClock.Instant
+    let firstTokenAt: ContinuousClock.Instant?
+    let finishedAt: ContinuousClock.Instant
+}
+
+/// Submit one request and drain its stream to completion, timing it.
+func runOne(index: Int) async throws -> RequestResult {
+    let tokens = try promptTokens(forIndex: index)
+    let started = ContinuousClock.now
+    var firstTokenAt: ContinuousClock.Instant?
+    var completion = 0
+    let stream = await scheduler.submitTokenized(
+        promptTokens: tokens,
+        maxTokens: maxTokens,
+        temperature: 0.0,
+        requestId: "bench-\(index)-\(UUID().uuidString.prefix(8))")
+    for await event in stream {
+        switch event {
+        case .chunk:
+            if firstTokenAt == nil { firstTokenAt = .now }
+            completion += 1
+        case .info(_, let completionTokens, _):
+            if completionTokens > completion { completion = completionTokens }
+        case .error(let message):
+            die("request \(index) failed: \(message)")
+        }
+    }
+    return RequestResult(
+        completionTokens: completion,
+        startedAt: started,
+        firstTokenAt: firstTokenAt,
+        finishedAt: .now)
+}
+
+func secs(_ d: Duration) -> Double {
+    Double(d.components.seconds) + Double(d.components.attoseconds) / 1e18
+}
+
+struct IterStats {
+    let aggregateTps: Double
+    let perRequestTps: Double
+    let wallClock: Double
+    let avgLatency: Double
+}
+
+func runIteration() async throws -> IterStats {
+    let wallStart = ContinuousClock.now
+    // Submit all B requests concurrently; the scheduler/engine batches them.
+    var results: [RequestResult] = []
+    try await withThrowingTaskGroup(of: RequestResult.self) { group in
+        for i in 0..<batchSize {
+            group.addTask { try await runOne(index: i) }
+        }
+        for try await r in group { results.append(r) }
+    }
+    let wallClock = secs(ContinuousClock.now - wallStart)
+
+    // Aggregate decode throughput: total decode tokens across the batch over
+    // the wall-clock window from first submit to last completion. We subtract
+    // one token per request (the prefill/first token) to isolate the decode
+    // phase, mirroring solo-bench's `decodeToks = completion - 1`.
+    let totalDecodeTokens = results.reduce(0) { $0 + max(1, $1.completionTokens - 1) }
+    let aggregateTps = Double(totalDecodeTokens) / max(0.0001, wallClock)
+
+    // Per-request decode tok/s: each request's decode tokens over its own
+    // first-token → finish window, averaged. Shows the latency cost an
+    // individual request pays for sharing the batch.
+    var perReqTpsSum = 0.0
+    var latencySum = 0.0
+    for r in results {
+        let decodeTokens = max(1, r.completionTokens - 1)
+        let firstToken = r.firstTokenAt ?? r.startedAt
+        let decodeWindow = max(0.0001, secs(r.finishedAt - firstToken))
+        perReqTpsSum += Double(decodeTokens) / decodeWindow
+        latencySum += secs(r.finishedAt - r.startedAt)
+    }
+    let perRequestTps = perReqTpsSum / Double(results.count)
+    let avgLatency = latencySum / Double(results.count)
+
+    return IterStats(
+        aggregateTps: aggregateTps,
+        perRequestTps: perRequestTps,
+        wallClock: wallClock,
+        avgLatency: avgLatency)
+}
+
+// ── Run ───────────────────────────────────────────────────────────────────
+var kept: [IterStats] = []
+for i in 1...iterations {
+    let s = try await runIteration()
+    let tag = i == 1 ? " (cold — discard)" : ""
+    print(
+        String(
+            format:
+                "iter %d: aggregate %.1f tok/s · per-req %.1f tok/s · wall %.2fs · avg latency %.2fs%@",
+            i, s.aggregateTps, s.perRequestTps, s.wallClock, s.avgLatency, tag))
+    if i > 1 { kept.append(s) }
+}
+
+// ── Summary table ───────────────────────────────────────────────────────────
+print("\n  batchSize | aggregate tok/s | per-request tok/s | wall-clock")
+print("  ----------+-----------------+-------------------+-----------")
+if kept.isEmpty {
+    print("  (no warm iterations — increase iterations to >1)")
+} else {
+    let n = Double(kept.count)
+    let aggAvg = kept.reduce(0.0) { $0 + $1.aggregateTps } / n
+    let perReqAvg = kept.reduce(0.0) { $0 + $1.perRequestTps } / n
+    let wallAvg = kept.reduce(0.0) { $0 + $1.wallClock } / n
+    print(
+        String(
+            format: "  %9d | %15.1f | %17.1f | %8.2fs",
+            batchSize, aggAvg, perReqAvg, wallAvg))
+}
+
+await scheduler.unloadModel()

--- a/provider-swift/Sources/batch-ctrl-test/main.swift
+++ b/provider-swift/Sources/batch-ctrl-test/main.swift
@@ -1,0 +1,87 @@
+// batch-ctrl-test — standalone validation of the continuous-batching
+// composition control vector (encode/decode round-trip). `swift test` is broken
+// in this toolchain (pre-existing XCTest import), so the protocol — the riskiest
+// Phase 3 piece — is validated here instead. Mirrors Tests/.../ClusterBatchControlTests.
+
+import Foundation
+import ProviderCore
+
+final class Counter { var failures = 0 }
+
+func run() {
+let counter = Counter()
+func check(_ cond: Bool, _ msg: String) {
+    if cond { print("  ok: \(msg)") }
+    else { print("  FAIL: \(msg)"); counter.failures += 1 }
+}
+print("== batch-ctrl-test: composition round-trip ==")
+
+// 1. Full step: survivors + ragged admit.
+do {
+    let comp = ClusterBatchComposition(
+        command: .step, bNext: 5, keepIndices: [0, 2, 3],
+        admit: [
+            ClusterAdmitRow(promptTokens: [10, 11, 12], leftPadding: 0, maxTokens: 64),
+            ClusterAdmitRow(promptTokens: [99], leftPadding: 2, maxTokens: 128),
+        ])
+    let d = ClusterBatchComposition.decode(comp.encodeVector())
+    check(d.command == .step, "command=step")
+    check(d.bNext == 5, "bNext=5")
+    check(d.keepIndices == [0, 2, 3], "keepIndices preserved")
+    check(d.admit.count == 2, "nAdmit=2")
+    check(d.admit[0].promptTokens == [10, 11, 12] && d.admit[0].maxTokens == 64, "admit[0] prompt+maxTokens")
+    check(d.admit[1].promptTokens == [99] && d.admit[1].leftPadding == 2, "admit[1] prompt+leftPadding")
+}
+
+// 2. Evict-only (pure decode step).
+do {
+    let comp = ClusterBatchComposition(command: .step, bNext: 2, keepIndices: [1, 4], admit: [])
+    let d = ClusterBatchComposition.decode(comp.encodeVector())
+    check(d.keepIndices == [1, 4] && d.admit.isEmpty, "evict-only round-trip")
+}
+
+// 3. Admit-only (cold start).
+do {
+    let comp = ClusterBatchComposition(command: .step, bNext: 1, keepIndices: [],
+        admit: [ClusterAdmitRow(promptTokens: [1, 2, 3, 4, 5], leftPadding: 0, maxTokens: 32)])
+    let d = ClusterBatchComposition.decode(comp.encodeVector())
+    check(d.keepIndices.isEmpty && d.admit.first?.promptTokens == [1, 2, 3, 4, 5], "admit-only round-trip")
+}
+
+// 4. Shutdown / idle commands.
+do {
+    check(ClusterBatchComposition.decode(ClusterBatchComposition.shutdown.encodeVector()).command == .shutdown, "shutdown")
+    check(ClusterBatchComposition.decode(ClusterBatchComposition.idle.encodeVector()).command == .idle, "idle")
+}
+
+// 5. Fixed width regardless of composition.
+do {
+    let a = ClusterBatchComposition.idle.encodeVector()
+    let b = ClusterBatchComposition(command: .step, bNext: 3, keepIndices: [0, 1],
+        admit: [ClusterAdmitRow(promptTokens: Array(0..<100), leftPadding: 0, maxTokens: 16)]).encodeVector()
+    check(a.count == BATCH_CTRL_WIDTH && b.count == BATCH_CTRL_WIDTH, "fixed width = \(BATCH_CTRL_WIDTH)")
+}
+
+// 6. Ragged admit order + padding preserved.
+do {
+    let admit = [
+        ClusterAdmitRow(promptTokens: [7, 7], leftPadding: 3, maxTokens: 10),
+        ClusterAdmitRow(promptTokens: [8, 8, 8, 8], leftPadding: 1, maxTokens: 20),
+        ClusterAdmitRow(promptTokens: [9], leftPadding: 0, maxTokens: 30),
+    ]
+    let d = ClusterBatchComposition.decode(
+        ClusterBatchComposition(command: .step, bNext: 3, keepIndices: [], admit: admit).encodeVector())
+    var ok = d.admit.count == 3
+    for i in 0..<min(3, d.admit.count) {
+        ok = ok && d.admit[i].promptTokens == admit[i].promptTokens
+            && d.admit[i].leftPadding == admit[i].leftPadding
+            && d.admit[i].maxTokens == admit[i].maxTokens
+    }
+    check(ok, "ragged admit order + padding preserved")
+}
+
+if counter.failures == 0 { print("\nPASS: all composition round-trips correct.") }
+else { print("\nFAIL: \(counter.failures) checks failed."); exit(1) }
+}
+
+run()

--- a/provider-swift/Sources/batch-shard-smoke/main.swift
+++ b/provider-swift/Sources/batch-shard-smoke/main.swift
@@ -1,0 +1,146 @@
+// batch-shard-smoke — Phase 1 correctness oracle for batched sharded decode.
+//
+//   swift run -c release batch-shard-smoke <model-dir> [B=4] [maxTokens=32]
+//
+// Single machine, NO ring. Loads the FULL model as one shard (interval
+// [0, N)) — so embed → runOwnedLayers → projectToLogits is the whole forward —
+// and runs TWO greedy decodes of the same prompt:
+//   (1) B=1 reference via the scalar path (embed/runOwnedLayers/projectToLogits
+//       + a KVCacheSimple), exactly like ClusterPipeline does at worldSize=1.
+//   (2) B identical rows via the BATCHED path (embedBatch/runOwnedLayersBatched/
+//       projectToLogitsBatched + BatchKVCache).
+// Asserts every batched row produces the SAME token stream as the reference.
+// This proves the batched data plane (shapes, BatchKVCache, [B] sampling) is
+// numerically identical to the proven B=1 path, with no network involved.
+
+import Foundation
+import MLX
+import MLXLLM
+import MLXLMCommon
+import ProviderCore
+
+func fail(_ m: String) -> Never { FileHandle.standardError.write(Data("FAIL: \(m)\n".utf8)); exit(1) }
+
+let args = CommandLine.arguments
+guard args.count >= 2 else { fail("usage: batch-shard-smoke <model-dir> [B] [maxTokens]") }
+let modelDir = URL(fileURLWithPath: args[1], isDirectory: true)
+let B = args.count > 2 ? (Int(args[2]) ?? 4) : 4
+let maxTokens = args.count > 3 ? (Int(args[3]) ?? 32) : 32
+
+let physical = ProcessInfo.processInfo.physicalMemory
+MLX.GPU.set(memoryLimit: Int(Double(physical) * 0.80), relaxed: false)
+
+// ---- model_type + layer count from config.json ----
+func configValue<T>(_ key: String, _ cast: (Any) -> T?) -> T? {
+    guard let data = try? Data(contentsOf: modelDir.appending(component: "config.json")),
+          let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+          let v = obj[key] else { return nil }
+    return cast(v)
+}
+let modelType = configValue("model_type", { $0 as? String }) ?? "llama"
+let numLayers = configValue("num_hidden_layers", { $0 as? Int }) ?? 0
+guard numLayers > 0 else { fail("could not read num_hidden_layers") }
+
+print("== batch-shard-smoke == model=\(modelDir.lastPathComponent) type=\(modelType) layers=\(numLayers) B=\(B) maxTokens=\(maxTokens)")
+
+func makeShard() throws -> any PipelineModelShard {
+    let full = LayerInterval(nodeId: "solo", start: 0, end: numLayers)
+    switch modelType {
+    case "gpt_oss": return try GPTOSSShardAdapter.load(directory: modelDir, interval: full)
+    case "gemma4", "gemma4_text": return try Gemma4ShardAdapter.load(directory: modelDir, interval: full)
+    default: fatalError("unsupported model_type '\(modelType)' (have: gpt_oss, gemma4)")
+    }
+}
+
+// Tokenize prompts via the same path the cluster uses. `--ragged` (4th arg
+// "ragged") makes the B rows DIFFERENT lengths to exercise Phase 2 left-padding.
+let ragged = args.count > 4 && args[4] == "ragged"
+let tokenizer = try await LocalTokenizerLoader().load(from: modelDir)
+func tok(_ s: String) throws -> [Int] {
+    try tokenizer.applyChatTemplate(messages: [["role": "user", "content": s]], tools: nil, additionalContext: nil)
+}
+let basePrompt = "Name three primary colors."
+let prompt = try tok(basePrompt)
+// For ragged mode, build B prompts of deliberately different lengths.
+let raggedPrompts: [[Int]] = ragged
+    ? [try tok("Hi."),
+       try tok("Name three primary colors."),
+       try tok("Explain in one sentence what a rainbow is and why it appears."),
+       try tok("List the days of the week, then count from one to five.")]
+    : []
+let eos: Set<Int> = { var s = Set<Int>(); if let e = tokenizer.eosTokenId { s.insert(e) }; return s }()
+
+func argmaxLast(_ logits: MLXArray) -> [Int] {
+    // logits [B, *, vocab] -> [B] argmax at last position
+    let last = logits.ndim == 3 ? logits[0..., (logits.dim(1) - 1)..., 0...] : logits
+    let ids = argMax(last, axis: last.ndim - 1)   // [B, 1] or [B]
+    ids.eval()
+    return ids.asArray(Int32.self).map { Int($0) }
+}
+
+// The B prompts: identical in equal-length mode, distinct in ragged mode.
+let prompts: [[Int]] = ragged ? Array(raggedPrompts.prefix(B)) : Array(repeating: prompt, count: B)
+let effB = prompts.count
+let maxLen = prompts.map(\.count).max() ?? 0
+let leftPad = prompts.map { maxLen - $0.count }   // left-pad each row to maxLen
+print("mode=\(ragged ? "ragged" : "equal-length")  prompt lengths=\(prompts.map(\.count))  leftPadding=\(leftPad)")
+
+// ---- (1) B=1 reference per row (scalar path) ----
+print("[1/2] B=1 reference decode (\(effB) rows) …")
+func referenceDecode(_ p: [Int], eosIds: Set<Int>, maxTok: Int) throws -> [Int] {
+    let s = try makeShard()
+    var seq = p; var out = [Int]()
+    for step in 0..<maxTok {
+        let inTok = step == 0 ? seq : [seq[seq.count - 1]]
+        var h = s.embed(tokens: inTok)
+        h = s.runOwnedLayers(h)
+        let t = argmaxLast(s.projectToLogits(h))[0]
+        seq.append(t); out.append(t)
+        if eosIds.contains(t) { break }
+    }
+    return out
+}
+let refRows = try prompts.map { try referenceDecode($0, eosIds: eos, maxTok: maxTokens) }
+print("    reference token counts: \(refRows.map(\.count))")
+
+// ---- (2) Batched path with left-padding (fresh shard) ----
+print("[2/2] B=\(effB) batched decode …")
+let batShard = try makeShard()
+batShard.beginBatch(leftPadding: leftPad)
+var rowsOut = Array(repeating: [Int](), count: effB)
+var lastTokens = [Int]()
+for step in 0..<maxTokens {
+    let h: MLXArray
+    if step == 0 {
+        h = batShard.runOwnedLayersBatched(batShard.embedBatch(rows: prompts, leftPadding: leftPad))
+    } else {
+        // Decode steps are width-1 per row: no padding needed.
+        h = batShard.runOwnedLayersBatched(
+            batShard.embedBatch(rows: lastTokens.map { [$0] }, leftPadding: Array(repeating: 0, count: effB)))
+    }
+    let toks = argmaxLast(batShard.projectToLogitsBatched(h))
+    guard toks.count == effB else { fail("batched sampling returned \(toks.count), expected \(effB)") }
+    lastTokens = toks
+    for b in 0..<effB { rowsOut[b].append(toks[b]) }
+    if toks.allSatisfy({ eos.contains($0) }) { break }
+}
+
+// ---- Compare per row ----
+var mismatches = 0
+for b in 0..<effB {
+    let refLen = refRows[b].count
+    let row = Array(rowsOut[b].prefix(refLen))
+    if row != refRows[b] {
+        mismatches += 1
+        let fd = (0..<min(row.count, refLen)).first(where: { row[$0] != refRows[b][$0] }) ?? min(row.count, refLen)
+        FileHandle.standardError.write(Data(
+            "  row \(b) diverged at token \(fd): got \(row.prefix(fd+1).suffix(3)) vs ref \(refRows[b].prefix(fd+1).suffix(3))\n".utf8))
+    }
+}
+
+print("\nrow 0 reference: \(tokenizer.decode(tokenIds: refRows[0]).prefix(100))")
+if mismatches == 0 {
+    print("\nPASS: all \(effB) batched rows match their B=1 reference token-for-token.")
+} else {
+    fail("\(mismatches)/\(effB) batched rows diverged from the B=1 reference")
+}

--- a/provider-swift/Sources/cluster-provider/main.swift
+++ b/provider-swift/Sources/cluster-provider/main.swift
@@ -1,0 +1,352 @@
+// cluster-provider — the HEAD node of a cluster, acting as a real Darkbloom
+// provider against a coordinator, driving the PROVEN ring decode loop
+// (ClusterPipeline / ClusterServer — the same loop verified in cluster-run).
+//
+//   swift run -c release cluster-provider <model-dir> [coordinator-ws-url]
+//
+// Run on the HEAD node (rank 0). On the OTHER ranks, run the peer companion
+// (cluster-run will also do; or `cluster-provider --peer`). Reads [cluster] from
+// provider.toml for topology.
+//
+// Design: the MLX ring is a single ordered stream, so the head serializes
+// requests — one generation at a time. Per request the head broadcasts the
+// descriptor (prompt ids + maxTokens) to peers via the control round
+// (ClusterServer.exchangeRequest), then all ranks run ClusterPipeline.generate
+// in lockstep; the head streams tokens back to the coordinator.
+//
+// Honesty: the coordinator attests THIS head node. Per-member attestation
+// (cluster roster) is the coordinator-side follow-up. Inter-node link is
+// encrypted regardless.
+
+import Foundation
+import MLX
+import MLXLLM
+import MLXLMCommon
+import ProviderCore
+
+func die(_ m: String) -> Never { FileHandle.standardError.write(Data("ERROR: \(m)\n".utf8)); exit(1) }
+func log(_ m: String) { print("[cluster-provider] \(m)") }
+
+let argv = CommandLine.arguments
+guard argv.count >= 2 else { die("usage: cluster-provider <model-dir> [coordinator-ws-url] [--peer]") }
+let modelDir = URL(fileURLWithPath: argv[1], isDirectory: true)
+let isPeerFlag = argv.contains("--peer")
+let overrideURL = argv.dropFirst(2).first(where: { !$0.hasPrefix("--") })
+
+let cfg = (try? ConfigManager.load(from: ConfigManager.defaultConfigPath())) ?? ConfigManager.loadDefault()
+guard let clusterSettings = cfg.cluster, clusterSettings.enabled else {
+    die("provider.toml needs an enabled [cluster] section")
+}
+let plan = try ClusterPlan.resolve(clusterSettings)
+
+// ---- this node's SE identity + attestation (gathered over the ring so the
+// head can relay EVERY member's attestation to the coordinator) ----
+// Each node (head AND peers) builds its own signed attestation blob; bringUp
+// all-gathers them. The head also reuses its signer + X25519 key to attest to
+// the coordinator directly.
+let signer = try SecureEnclaveIdentity.createEphemeral()
+let keyPair = NodeKeyPair.generate()
+let attestationBuilder = signer.map { AttestationBuilder(identity: $0) }
+let myAttestationJSON = try attestationBuilder?.buildAttestationJSON(
+    encryptionPublicKey: keyPair.publicKeyBase64)
+
+// ---- bring the node into the ring ----
+log("node \(plan.nodeId) rank \(plan.rank)/\(plan.worldSize) — joining ring + loading shard (start all nodes) …")
+let ctx = try await ClusterHeadBringup.bringUp(plan: plan, modelDir: modelDir, attestationJSON: myAttestationJSON)
+log("cluster ready ✓ (encrypted ring link established)")
+
+let server = ClusterServer(plan: plan, group: ctx.group, pipeline: ctx.makePipeline(), eosTokenIds: ctx.eosTokenIds)
+
+// Continuous batching (Phase 3) is opt-in via [cluster].batched. When on, the
+// head runs the ClusterBatchScheduler and peers run the batched control loop.
+let batchedMode = clusterSettings.batched
+let batchServer = ClusterBatchServer(
+    plan: plan, group: ctx.group, shard: ctx.shard,
+    hiddenSize: ctx.hiddenSize, eosTokenIds: ctx.eosTokenIds)
+
+// =====================================================================
+// PEER path: no coordinator. Loop in lockstep with the head until shutdown.
+// =====================================================================
+if !plan.isHead || isPeerFlag {
+    if batchedMode {
+        log("peer mode (BATCHED) — replaying head composition until shutdown")
+        try batchServer.runBatchedPeerLoop(makeChannels: { ctx.makeChannels() })
+    } else {
+        log("peer mode — serving the head in lockstep until shutdown")
+        try server.runPeerLoop(makeChannels: { ctx.makeChannels() })
+    }
+    log("peer shutdown")
+    exit(0)
+}
+
+// =====================================================================
+// HEAD path: connect to the coordinator, serialize requests through the ring.
+// =====================================================================
+guard let attestationBuilder, let myAttestationJSON else {
+    die("Secure Enclave unavailable — required to attest to the coordinator")
+}
+let attestation = RawJSON(rawBytes: myAttestationJSON)
+// The cluster registration (every member's attestation) gathered during bringUp.
+let clusterReg = ctx.clusterRegistrationJSON.map { RawJSON(rawBytes: $0) }
+if clusterReg != nil { log("relaying \(plan.worldSize)-member cluster attestation to coordinator") }
+
+let coordinatorURL = overrideURL ?? cfg.coordinator.url
+let modelId = modelDir.lastPathComponent
+let hardware = try HardwareDetector.detect()
+let modelInfo = ModelInfo(
+    id: modelId, modelType: nil, sizeBytes: 0, estimatedMemoryGb: 0,
+    weightHash: nil, isVision: false, templateRenderOK: true)
+
+let client = CoordinatorClient(
+    config: CoordinatorClientConfig(
+        url: coordinatorURL, hardware: hardware, models: [modelInfo],
+        backendName: "mlx-swift",   // must equal coordinator's privateTextBackendSupported / runtime-integrity backend; "mlx-swift-cluster" is excluded from routing
+        heartbeatInterval: TimeInterval(cfg.coordinator.heartbeatIntervalSecs),
+        publicKey: keyPair.publicKeyBase64, attestation: attestation,
+        privateOnly: cfg.coordinator.privateOnly,
+        cluster: clusterReg),
+    stats: AtomicProviderStats(), state: ProviderState())
+let (events, sendFn) = await client.start()
+log("connecting to coordinator \(coordinatorURL) …")
+
+// Encode one generated token as an encrypted OpenAI SSE chunk frame back to the
+// request's sender. Used by the batched head path (the ring thread). Captures
+// locals (not the main-actor `ctx`) so it is safe to call cross-thread.
+let frameTokenizer = ctx.tokenizer
+let frameKeyPair = keyPair
+let frameModelId = modelId
+let sendTokenFrame: @Sendable (Int, String, Data) -> Void = { tok, requestId, senderKey in
+    let piece = frameTokenizer.decode(tokenIds: [tok])
+    guard !piece.isEmpty else { return }
+    let escaped = piece
+        .replacingOccurrences(of: "\\", with: "\\\\")
+        .replacingOccurrences(of: "\"", with: "\\\"")
+        .replacingOccurrences(of: "\n", with: "\\n")
+        .replacingOccurrences(of: "\r", with: "\\r")
+        .replacingOccurrences(of: "\t", with: "\\t")
+    let frame = "data: {\"id\":\"\(requestId)\",\"object\":\"chat.completion.chunk\",\"model\":\"\(frameModelId)\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"\(escaped)\"},\"finish_reason\":null}]}"
+    if let enc = try? frameKeyPair.encryptPayload(recipientPublicKey: senderKey, plaintext: Data(frame.utf8)) {
+        sendFn(.inferenceChunk(requestId: requestId, data: "", encryptedData: enc))
+    }
+}
+
+// =====================================================================
+// HEAD path — BATCHED (continuous batching, Phase 3). The ClusterBatchScheduler
+// owns the ring on its own thread; the event loop only decrypts + enqueues.
+// =====================================================================
+if batchedMode {
+    log("head mode (BATCHED) — continuous-batching scheduler")
+    let scheduler = ClusterBatchScheduler(
+        server: batchServer, plan: plan, group: ctx.group, shard: ctx.shard,
+        hiddenSize: ctx.hiddenSize, eosTokenIds: ctx.eosTokenIds, maxConcurrent: 8)
+
+    // requestId -> (senderKey, promptLen) for token routing + usage accounting.
+    final class Routes: @unchecked Sendable {
+        let lock = NSLock(); var keys: [String: Data] = [:]; var prompt: [String: Int] = [:]
+        func set(_ id: String, _ k: Data, _ p: Int) { lock.lock(); keys[id] = k; prompt[id] = p; lock.unlock() }
+        func key(_ id: String) -> Data? { lock.lock(); defer { lock.unlock() }; return keys[id] }
+        func promptLen(_ id: String) -> Int { lock.lock(); defer { lock.unlock() }; return prompt[id] ?? 0 }
+        func drop(_ id: String) { lock.lock(); keys[id] = nil; prompt[id] = nil; lock.unlock() }
+    }
+    let routes = Routes()
+
+    let ringThread = Thread {
+        do {
+            try scheduler.run(
+                makeChannels: { ctx.makeChannels() },
+                onToken: { reqId, tok in
+                    if let k = routes.key(reqId) { sendTokenFrame(tok, reqId, k) }
+                },
+                onComplete: { reqId, generated in
+                    sendFn(.inferenceComplete(
+                        requestId: reqId,
+                        usage: UsageInfo(promptTokens: UInt64(routes.promptLen(reqId)),
+                                         completionTokens: UInt64(generated)),
+                        seSignature: nil, responseHash: nil))
+                    routes.drop(reqId)
+                })
+        } catch { FileHandle.standardError.write(Data("batched scheduler error: \(error)\n".utf8)) }
+    }
+    ringThread.stackSize = 16 << 20
+    ringThread.start()
+
+    for await event in events {
+        switch event {
+        case .connected:
+            log("registered ✓ (BATCHED, serving \(modelId) across \(plan.worldSize) nodes)")
+        case .disconnected:
+            log("disconnected (will retry)")
+        case .attestationChallenge(let nonce, let timestamp):
+            if let r = try? attestationBuilder.buildChallengeResponse(
+                nonce: nonce, timestamp: timestamp, providerPublicKey: keyPair.publicKeyBase64) {
+                sendFn(.attestationResponse(AttestationResponsePayload(
+                    nonce: r.nonce, signature: r.signature, statusSignature: r.statusSignature,
+                    publicKey: r.publicKey, hypervisorActive: r.hypervisorActive,
+                    rdmaDisabled: r.rdmaDisabled, sipEnabled: r.sipEnabled,
+                    secureBootEnabled: r.secureBootEnabled, binaryHash: r.binaryHash,
+                    activeModelHash: r.activeModelHash, pythonHash: r.pythonHash,
+                    runtimeHash: r.runtimeHash, templateHashes: r.templateHashes,
+                    modelHashes: r.modelHashes)))
+            }
+        case let .inferenceRequest(requestId, ciphertext, senderPublicKey):
+            guard let senderKey = senderPublicKey, senderKey.count == 32,
+                  let plain = try? keyPair.decrypt(senderPublicKey: senderKey, ciphertext: ciphertext),
+                  let req = try? JSONDecoder().decode(ChatCompletionRequest.self, from: plain) else {
+                sendFn(.inferenceError(requestId: requestId, error: "decrypt/parse failed", statusCode: 400)); break
+            }
+            guard let promptTokens = try? ctx.tokenizer.applyChatTemplate(
+                messages: req.messages.map { ["role": $0.role, "content": $0.content] },
+                tools: nil, additionalContext: nil) else {
+                sendFn(.inferenceError(requestId: requestId, error: "tokenize failed", statusCode: 400)); break
+            }
+            sendFn(.inferenceAccepted(requestId: requestId))
+            routes.set(requestId, senderKey, promptTokens.count)
+            scheduler.enqueue(ClusterBatchRequest(
+                requestId: requestId, promptTokens: promptTokens, maxTokens: req.max_tokens ?? 512))
+        default:
+            break
+        }
+    }
+    exit(0)
+}
+
+// ---------------------------------------------------------------------------
+// The MLX ring is a single ordered stream and the peers loop on a control-round
+// `all_gather` continuously. The head must therefore drive that SAME collective
+// at the SAME cadence from a SINGLE thread — otherwise the peer sits parked in a
+// lone `all_gather` the head hasn't joined, the ring times out (~25 s), and the
+// head drops off the coordinator. So ONE dedicated control thread OWNS the ring:
+// it broadcasts an IDLE descriptor when no request is pending (keeping lockstep
+// with the peer) and a REAL descriptor when serving. The coordinator event loop
+// below NEVER touches the ring — it only enqueues decrypted requests.
+// ---------------------------------------------------------------------------
+final class PendingQueue: @unchecked Sendable {
+    struct Item { let requestId: String; let prompt: [Int]; let maxTokens: Int; let senderKey: Data }
+    private let lock = NSLock()
+    private var items: [Item] = []
+    func push(_ i: Item) { lock.lock(); items.append(i); lock.unlock() }
+    func pop() -> Item? { lock.lock(); defer { lock.unlock() }; return items.isEmpty ? nil : items.removeFirst() }
+}
+let queue = PendingQueue()
+
+let controlThread = Thread {
+    var reqCounter = 0
+    while true {
+        guard let item = queue.pop() else {
+            // Idle keepalive round: matches the peer's `exchangeRequest` so both
+            // sides rendezvous on the ring barrier; the sleep paces the spin.
+            _ = try? server.exchangeRequest(ClusterServer.idleDescriptor)
+            Thread.sleep(forTimeInterval: 0.1)
+            continue
+        }
+        reqCounter += 1
+        let requestId = item.requestId
+        let senderKey = item.senderKey
+        do {
+            // Broadcast the real descriptor to peers, then run the proven loop in
+            // lockstep. Per-token timing lets you benchmark ring transport
+            // (Wi-Fi vs Thunderbolt). First onToken fires after prefill.
+            _ = try server.exchangeRequest(
+                ClusterRequestDescriptor(promptTokens: item.prompt, maxTokens: item.maxTokens))
+            let pipeline = ctx.makePipeline()
+            var completion = 0
+            let genStart = DispatchTime.now().uptimeNanoseconds
+            var prevTokenNs = genStart
+            var prefillNs: UInt64 = 0
+            var decodeNs: UInt64 = 0
+            print("\n[req \(reqCounter)] prompt=\(item.prompt.count) tok, generating \(item.maxTokens) …")
+            _ = try pipeline.generate(
+                promptTokens: item.prompt, maxTokens: item.maxTokens,
+                requestId: "req-\(reqCounter)", eosTokenIds: ctx.eosTokenIds,
+                onToken: { tok in
+                    let now = DispatchTime.now().uptimeNanoseconds
+                    let stepNs = now - prevTokenNs
+                    prevTokenNs = now
+                    if completion == 0 { prefillNs = stepNs } else { decodeNs += stepNs }
+                    completion += 1
+                    let piece = ctx.tokenizer.decode(tokenIds: [tok])
+                    let ms = Double(stepNs) / 1_000_000
+                    FileHandle.standardError.write(Data(
+                        "  [\(completion == 1 ? "prefill" : "tok \(completion-1)") \(String(format: "%.0f", ms)) ms] \(piece)\n".utf8))
+                    if !piece.isEmpty {
+                        // The coordinator parses each chunk as a full OpenAI SSE
+                        // frame ("data: {chat.completion.chunk}") and extracts
+                        // choices[0].delta.content — raw token text yields empty
+                        // content. Wrap the token in the OpenAI delta shape, then
+                        // encrypt the whole frame back to the request's sender key
+                        // (encryptPayload sets ephemeral_public_key = this head's
+                        // registered X25519 key, matched to provider.PublicKey).
+                        let escaped = piece
+                            .replacingOccurrences(of: "\\", with: "\\\\")
+                            .replacingOccurrences(of: "\"", with: "\\\"")
+                            .replacingOccurrences(of: "\n", with: "\\n")
+                            .replacingOccurrences(of: "\r", with: "\\r")
+                            .replacingOccurrences(of: "\t", with: "\\t")
+                        let frame = "data: {\"id\":\"\(requestId)\",\"object\":\"chat.completion.chunk\",\"model\":\"\(modelId)\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"\(escaped)\"},\"finish_reason\":null}]}"
+                        if let enc = try? keyPair.encryptPayload(recipientPublicKey: senderKey, plaintext: Data(frame.utf8)) {
+                            sendFn(.inferenceChunk(requestId: requestId, data: "", encryptedData: enc))
+                        }
+                    }
+                })
+            // Decode tok/s is the headline number to compare across transports.
+            let decodeToks = max(1, completion - 1)
+            let decodeSec = Double(decodeNs) / 1_000_000_000
+            let tps = decodeSec > 0 ? Double(decodeToks) / decodeSec : 0
+            print(String(format: "[req \(reqCounter)] prefill %.2fs · decode %.2f tok/s (%.0f ms/tok) · %d tokens\n",
+                         Double(prefillNs) / 1_000_000_000, tps,
+                         Double(decodeNs) / 1_000_000 / Double(decodeToks), completion))
+            sendFn(.inferenceComplete(
+                requestId: requestId,
+                usage: UsageInfo(promptTokens: UInt64(item.prompt.count), completionTokens: UInt64(completion)),
+                seSignature: nil, responseHash: nil))
+        } catch {
+            sendFn(.inferenceError(requestId: requestId, error: "generation failed: \(error)", statusCode: 500))
+        }
+    }
+}
+controlThread.stackSize = 16 << 20
+controlThread.start()
+
+// Coordinator event loop: decrypt + tokenize + enqueue ONLY. Never touches the
+// ring (the control thread owns it).
+for await event in events {
+    switch event {
+    case .connected:
+        log("registered ✓ (serving \(modelId) across \(plan.worldSize) nodes)")
+
+    case .disconnected:
+        log("disconnected (will retry)")
+
+    case .attestationChallenge(let nonce, let timestamp):
+        if let r = try? attestationBuilder.buildChallengeResponse(
+            nonce: nonce, timestamp: timestamp, providerPublicKey: keyPair.publicKeyBase64) {
+            sendFn(.attestationResponse(AttestationResponsePayload(
+                nonce: r.nonce, signature: r.signature, statusSignature: r.statusSignature,
+                publicKey: r.publicKey, hypervisorActive: r.hypervisorActive,
+                rdmaDisabled: r.rdmaDisabled, sipEnabled: r.sipEnabled,
+                secureBootEnabled: r.secureBootEnabled, binaryHash: r.binaryHash,
+                activeModelHash: r.activeModelHash, pythonHash: r.pythonHash,
+                runtimeHash: r.runtimeHash, templateHashes: r.templateHashes,
+                modelHashes: r.modelHashes)))
+        }
+
+    case let .inferenceRequest(requestId, ciphertext, senderPublicKey):
+        guard let senderKey = senderPublicKey, senderKey.count == 32,
+              let plain = try? keyPair.decrypt(senderPublicKey: senderKey, ciphertext: ciphertext),
+              let req = try? JSONDecoder().decode(ChatCompletionRequest.self, from: plain) else {
+            sendFn(.inferenceError(requestId: requestId, error: "decrypt/parse failed", statusCode: 400)); break
+        }
+        guard let promptTokens = try? ctx.tokenizer.applyChatTemplate(
+            messages: req.messages.map { ["role": $0.role, "content": $0.content] },
+            tools: nil, additionalContext: nil) else {
+            sendFn(.inferenceError(requestId: requestId, error: "tokenize failed", statusCode: 400)); break
+        }
+        sendFn(.inferenceAccepted(requestId: requestId))
+        queue.push(PendingQueue.Item(
+            requestId: requestId, prompt: promptTokens,
+            maxTokens: req.max_tokens ?? 512, senderKey: senderKey))
+
+    default:
+        break
+    }
+}

--- a/provider-swift/Sources/cluster-run/main.swift
+++ b/provider-swift/Sources/cluster-run/main.swift
@@ -1,0 +1,332 @@
+// cluster-run — run ONE model split across the cluster, over the real MLX ring.
+//
+//   swift run -c release cluster-run <model-dir> "<prompt>"
+//
+// Reads the [cluster] section of provider.toml (cluster_id, node_id, ring-ordered
+// members) to learn this node's rank + the ring host list, materializes the MLX
+// ring environment, joins the ring, loads ONLY this rank's layer slice, and runs
+// a greedy pipeline decode:
+//
+//   head (rank 0):  embed(seq) -> own layers -> ring-send hidden to next
+//   tail (rank N-1): ring-recv hidden -> own layers -> norm+lm_head -> sample
+//                     -> all_gather the sampled token so every rank advances
+//
+// Run the SAME command on every node (each reads its own node_id from config).
+// The head prints the generated text.
+//
+// Status:
+//   * Activations cross the ring ENCRYPTED: ephemeral X25519 key agreement over
+//     the ring + per-hop ChaCha20-Poly1305 (ClusterLinkCrypto). A tap sees only
+//     ciphertext, with forward secrecy. NOT YET attested — binding the ephemeral
+//     keys to a Secure-Enclave identity needs the coordinator-signed roster
+//     (ClusterHandshake/ClusterRoster), which this coordinator-less harness lacks.
+//   * KV cache: incremental decode (prefill once, then 1 token/step).
+//   * Layer split: auto memory-weighted (each node ∝ its usable RAM).
+
+import Foundation
+import MLX
+import MLXLLM
+import MLXLMCommon
+import ProviderCore
+
+func die(_ m: String) -> Never { FileHandle.standardError.write(Data("ERROR: \(m)\n".utf8)); exit(1) }
+
+// ---- args ----
+let argv = CommandLine.arguments
+guard argv.count >= 3 else { die("usage: cluster-run <model-dir> \"<prompt>\"") }
+let modelDir = URL(fileURLWithPath: argv[1], isDirectory: true)
+let prompt = argv[2]
+let maxTokens = 64
+
+// ---- resolve cluster plan from provider.toml ----
+let cfg: ProviderConfig
+do {
+    cfg = try ConfigManager.load(from: ConfigManager.defaultConfigPath())
+} catch { die("could not load provider.toml: \(error)") }
+guard let clusterSettings = cfg.cluster, clusterSettings.enabled else {
+    die("provider.toml has no enabled [cluster] section")
+}
+let plan: ClusterPlan
+do { plan = try ClusterPlan.resolve(clusterSettings) } catch { die("invalid [cluster]: \(error)") }
+
+print("[rank \(plan.rank)/\(plan.worldSize)] node=\(plan.nodeId) role=\(plan.isHead ? "head" : plan.isTail ? "tail" : "middle")")
+
+// ---- materialize ring env + join the ring ----
+do {
+    let dir = try ConfigManager.defaultConfigPath().deletingLastPathComponent()
+    let env = try MLXRingEnvironment.materialize(plan, directory: dir)
+    for (k, v) in env { setenv(k, v, 1) }
+    print("[rank \(plan.rank)] ring env: MLX_HOSTFILE=\(env["MLX_HOSTFILE"] ?? "?") MLX_RANK=\(env["MLX_RANK"] ?? "?")")
+} catch { die("ring env materialize failed: \(error)") }
+
+print("[rank \(plan.rank)] joining MLX ring … (blocks until all \(plan.worldSize) nodes connect)")
+let group: MLXDistributedGroup
+do {
+    group = try MLXDistributedGroup.initialize(backend: .ring, strict: true)
+} catch { die("ring init failed: \(error)") }
+guard group.size == plan.worldSize else {
+    die("ring size \(group.size) != configured worldSize \(plan.worldSize)")
+}
+guard group.rank == plan.rank else {
+    die("ring rank \(group.rank) != configured rank \(plan.rank) (check MLX_RANK / member order)")
+}
+print("[rank \(plan.rank)] ring joined ✓ (size \(group.size))")
+
+// ---- even contiguous layer split ----
+// Read layer count from config via a 1-layer probe load? No — load the shard
+// loader's full-model layer count cheaply from config.json.
+func totalLayersFromConfig(_ dir: URL) -> Int {
+    guard let data = try? Data(contentsOf: dir.appending(component: "config.json")),
+          let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+          let n = obj["num_hidden_layers"] as? Int else { die("cannot read num_hidden_layers from config.json") }
+    return n
+}
+let N = totalLayersFromConfig(modelDir)
+
+// Memory-WEIGHTED layer split: each node gets layers in proportion to its
+// usable RAM, so a smaller machine holds fewer layers and does NOT swap. An
+// even split on an asymmetric pair (24 GB + 32 GB) overloads the smaller Mac →
+// swap → ~1 token/minute.
+//
+// The weights are determined AUTOMATICALLY: every node measures its own usable
+// memory and the ring all-gathers the values, so each rank computes the same
+// split with no per-node config. Reserve OS + KV/activation headroom from the
+// detected total. Config `memory_gb` (if set on every member) overrides the
+// auto value; otherwise we use the gathered measurements.
+let gbF = 1_073_741_824.0
+let osReserveGb = 10.0   // macOS + KV/activation + GPU working-buffer headroom
+
+// This node's usable budget for weights.
+let detectedTotalGb = Double(ProcessInfo.processInfo.physicalMemory) / gbF
+let detectedUsableGb = max(2.0, detectedTotalGb - osReserveGb)
+let configuredGb = clusterSettings.members.first { $0.nodeId == plan.nodeId }?.memoryGb
+let myBudgetGb = configuredGb ?? detectedUsableGb
+
+// Exchange budgets over the ring: all_gather a [worldSize] vector where each
+// rank wrote its budget at its own index.
+var budgetVec = [Float](repeating: 0, count: plan.worldSize)
+budgetVec[plan.rank] = Float(myBudgetGb)
+let gathered0 = try group.allGather(MLXArray(budgetVec, [plan.worldSize]))
+gathered0.eval()
+// all_gather concatenates each rank's [worldSize] vector → [worldSize*worldSize];
+// rank r's real value sits at index r*worldSize + r.
+let flat = gathered0.asArray(Float.self)
+var budgets = [Double](repeating: 0, count: plan.worldSize)
+for r in 0..<plan.worldSize { budgets[r] = Double(flat[r * plan.worldSize + r]) }
+
+let weights = clusterSettings.members.enumerated().map { (i, m) in
+    LayerPartition.NodeWeight(nodeId: m.nodeId, weightBytes: UInt64(max(1.0, budgets[i]) * gbF))
+}
+let plan2 = try LayerPartition.partition(totalLayers: N, nodes: weights)
+let interval = plan2[plan.rank]
+let split = zip(plan2, budgets).map { "\($0.0.nodeId):\($0.0.count)L@\(String(format: "%.0f", $0.1))GB" }.joined(separator: "  ")
+print("[rank \(plan.rank)] auto memory-weighted split → \(split)")
+print("[rank \(plan.rank)] layers \(interval.start)..<\(interval.end) of \(N)")
+
+// ---- pin MLX's memory ceiling BELOW physical RAM ----
+// Without this, MLX's default (~1.5x working set) lets its buffer cache grow
+// past RAM into swap, stalling a command buffer on disk until the ~5s GPU
+// watchdog kills it (kIOGPUCommandBufferCallbackErrorTimeout). Cap the memory
+// limit and keep the cache small so freed buffers are released, not hoarded.
+let physical = ProcessInfo.processInfo.physicalMemory
+let memLimit = Int(Double(physical) * 0.80)        // hard ceiling at 80% of RAM
+MLX.GPU.set(memoryLimit: memLimit, relaxed: false)
+MLX.GPU.set(cacheLimit: 512 * 1024 * 1024)         // 512 MB cache cap
+print("[rank \(plan.rank)] MLX memory limit \(memLimit / (1024*1024*1024)) GB, cache 512 MB")
+
+// ---- load this rank's shard (only its layers) ----
+// Pick the architecture-specific shard from config.json's model_type. Both
+// conform to PipelineModelShard, so the decode loop below is arch-agnostic.
+func modelTypeFromConfig(_ dir: URL) -> String {
+    guard let data = try? Data(contentsOf: dir.appending(component: "config.json")),
+          let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+          let t = obj["model_type"] as? String else { return "" }
+    return t
+}
+let modelType = modelTypeFromConfig(modelDir)
+print("[rank \(plan.rank)] model_type=\(modelType), loading shard weights …")
+let shard: any PipelineModelShard
+do {
+    switch modelType {
+    case "gpt_oss":
+        shard = try GPTOSSShardAdapter.load(directory: modelDir, interval: interval)
+    default:
+        die("unsupported model_type '\(modelType)' for clustering (have: gpt_oss)")
+    }
+} catch { die("shard load failed: \(error)") }
+print("[rank \(plan.rank)] shard loaded ✓")
+
+// ---- tokenizer (every rank loads it; both need the sequence length) ----
+let tokenizer: any Tokenizer
+do { tokenizer = try await LocalTokenizerLoader().load(from: modelDir) }
+catch { die("tokenizer load failed: \(error)") }
+
+var seq: [Int]
+do {
+    seq = try tokenizer.applyChatTemplate(
+        messages: [["role": "user", "content": prompt]], tools: nil, additionalContext: nil)
+} catch { die("tokenize failed: \(error)") }
+
+let hiddenSize = { () -> Int in
+    guard let data = try? Data(contentsOf: modelDir.appending(component: "config.json")),
+          let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+          let h = obj["hidden_size"] as? Int else { die("cannot read hidden_size") }
+    return h
+}()
+
+let headRank = 0
+let tailRank = plan.worldSize - 1
+
+// ---- encrypted ring: ephemeral X25519 key exchange over the ring ----
+// Each node makes a fresh ephemeral X25519 keypair, all-gathers the 32-byte
+// public keys, and derives a shared key with each ring neighbor. Activations
+// are then AEAD-sealed (ClusterLinkCrypto) so a tap on the wire sees only
+// ciphertext, with forward secrecy from the ephemeral keys.
+//
+// NOTE: this gives confidentiality + forward secrecy on the link. It does NOT
+// yet bind the keys to an attested Secure-Enclave identity — that requires the
+// coordinator-signed roster (ClusterHandshake/ClusterRoster), which this
+// standalone harness has no coordinator for. The attestation binding is the
+// remaining production step.
+func bytesToInt32Array(_ d: Data) -> MLXArray { MLXArray(d.map { Int32($0) }, [d.count]) }
+func int32ArrayToBytes(_ a: MLXArray) -> Data { Data(a.asArray(Int32.self).map { UInt8(truncatingIfNeeded: $0) }) }
+
+let ephemeral = X25519KeyAgreementKeyPair()
+let myPub = ephemeral.publicKey  // 32 bytes
+// all_gather the 32-byte pubkeys → [worldSize*32], rank r's key at r*32.
+let pubGather = try group.allGather(bytesToInt32Array(myPub))
+pubGather.eval()
+let allPubBytes = int32ArrayToBytes(pubGather)
+func peerPub(_ rank: Int) -> Data { allPubBytes.subdata(in: rank*32 ..< rank*32 + 32) }
+
+// Derive a directional session with a neighbor. Both ends use the SAME salt
+// (sorted pubkeys) + sharedInfo, so the ECDH→HKDF master secret matches.
+func session(withRank peerRank: Int, peerNodeId: String) throws -> ClusterSession {
+    let peer = peerPub(peerRank)
+    let salt = (myPub.lexicographicallyPrecedes(peer) ? myPub + peer : peer + myPub)
+    let master = try ephemeral.symmetricKey(
+        peerPublicKey: peer, salt: salt,
+        sharedInfo: Data("darkbloom-cluster-ring-v1|\(plan.clusterId)".utf8))
+    return ClusterSession(
+        clusterId: plan.clusterId, localNodeId: plan.nodeId,
+        peerNodeId: peerNodeId, masterSecret: master)
+}
+
+let memberIds = clusterSettings.members.map(\.nodeId)
+var sealCh: ClusterSealingChannel?
+var openCh: ClusterOpeningChannel?
+if let next = plan.nextRank {
+    let s = try session(withRank: next, peerNodeId: memberIds[next])
+    sealCh = ClusterSealingChannel(key: s.sendKey())
+}
+if let prev = plan.prevRank {
+    let s = try session(withRank: prev, peerNodeId: memberIds[prev])
+    openCh = ClusterOpeningChannel(key: s.recvKey())
+}
+print("[rank \(plan.rank)] encrypted ring link established ✓ (X25519 + ChaCha20-Poly1305)")
+
+// AEAD ciphertext length is deterministic from the activation shape, so the
+// receiver can size its recvLike buffer: encode header (2 + ndim*4) + payload
+// (elements * 2 bytes for float16) + AEAD overhead (12 nonce + 16 tag).
+func sealedLen(width: Int) -> Int {
+    let header = 2 + 3 * 4               // [1, width, hidden] → ndim 3
+    let payload = 1 * width * hiddenSize * 2
+    return header + payload + 28
+}
+let reqId = "clusterrun"
+
+print("[rank \(plan.rank)] starting decode (\(maxTokens) tokens max) …\n")
+
+// Incremental decode with a persistent KV cache:
+//   step 0 (prefill): process the FULL prompt; the cache stores its K/V.
+//   step >0 (decode):  process ONLY the 1 new token; attention reuses the
+//                      cached K/V for all prior positions.
+// This is the difference between O(L) total work and O(L^2) — the dominant
+// cost in the first (cacheless) version. The head feeds `inputTokens`; every
+// rank's recvLike template width must match the number of tokens in flight.
+var generated = [Int]()
+var prefillNs: UInt64 = 0
+var decodeNs: UInt64 = 0
+for step in 0..<maxTokens {
+    let stepStart = DispatchTime.now().uptimeNanoseconds
+    // Tokens entering the pipeline THIS step: whole prompt on prefill, then the
+    // single most-recent token.
+    let inputTokens: [Int] = step == 0 ? seq : [seq[seq.count - 1]]
+    let width = inputTokens.count
+
+    // Each non-head rank receives the SEALED hidden state from its predecessor,
+    // opens it, runs its owned layers, then re-seals and sends downstream. The
+    // plaintext activation never crosses the wire — only AEAD ciphertext.
+    let ctx = ClusterFrameContext(
+        clusterId: plan.clusterId, requestId: reqId,
+        layerRange: "hop-\(plan.rank == headRank ? headRank : plan.rank - 1)", seq: UInt64(step))
+    var hidden: MLXArray
+    if plan.isHead {
+        hidden = shard.embed(tokens: inputTokens)
+    } else {
+        // Receive ciphertext bytes (deterministic length) and open them.
+        let cipherTemplate = MLXArray.zeros([sealedLen(width: width)], dtype: .int32)
+        let cipherArr = try group.recvLike(cipherTemplate, from: plan.rank - 1)
+        cipherArr.eval()
+        let plain = try openCh!.open(int32ArrayToBytes(cipherArr), context: ctx)
+        hidden = try ActivationCodec.decode(plain)
+    }
+    hidden = shard.runOwnedLayers(hidden)
+
+    if !plan.isTail {
+        // Seal this rank's output and ship ciphertext to the next rank.
+        // Normalize the wire dtype to bfloat16 so sealedLen's 2-byte payload
+        // math is exact regardless of the model's compute dtype, WITHOUT the
+        // range loss an fp16 cast would risk on hidden-state activations
+        // (bf16 keeps the same exponent range as the model's bf16 compute).
+        let outCtx = ClusterFrameContext(
+            clusterId: plan.clusterId, requestId: reqId,
+            layerRange: "hop-\(plan.rank)", seq: UInt64(step))
+        let wireHidden = hidden.asType(.bfloat16)
+        let sealed = try sealCh!.seal(ActivationCodec.encode(wireHidden), context: outCtx)
+        let dep = try group.send(bytesToInt32Array(sealed), to: plan.rank + 1)
+        dep.eval()   // force the transmit
+    }
+
+    // The tail samples; everyone learns the token via all_gather.
+    var tokenScalar = MLXArray([Int32(0)])
+    if plan.isTail {
+        let logits = shard.projectToLogits(hidden)
+        let lastAxis = logits.ndim - 1
+        let ids = argMax(logits, axis: lastAxis)
+        ids.eval()
+        let tok = Int(ids.asArray(Int32.self).last ?? 0)
+        tokenScalar = MLXArray([Int32(tok)])
+    }
+    let gathered = try group.allGather(tokenScalar)
+    gathered.eval()
+    let allTokens = gathered.asArray(Int32.self)
+    let nextToken = Int(allTokens[tailRank])
+
+    seq.append(nextToken)
+    generated.append(nextToken)
+
+    let stepNs = DispatchTime.now().uptimeNanoseconds - stepStart
+    if step == 0 { prefillNs = stepNs } else { decodeNs += stepNs }
+
+    if plan.rank == headRank {
+        let piece = tokenizer.decode(tokenIds: [nextToken])
+        FileHandle.standardOutput.write(Data(piece.utf8))
+        let ms = Double(stepNs) / 1_000_000
+        FileHandle.standardError.write(Data("  [\(step == 0 ? "prefill" : "tok \(step)") \(String(format: "%.0f", ms)) ms]\n".utf8))
+    }
+    // crude EOS: stop on the tokenizer's eos id if present
+    if let eos = tokenizer.eosTokenId, nextToken == eos { break }
+}
+
+if plan.rank == headRank {
+    let decodeTokens = max(1, generated.count - 1)
+    let decodeSec = Double(decodeNs) / 1_000_000_000
+    let tps = decodeSec > 0 ? Double(decodeTokens) / decodeSec : 0
+    print("\n\n[head] done — \(generated.count) tokens")
+    print(String(format: "[head] prefill %.1fs · decode %.2f tok/s (%.0f ms/tok)",
+                 Double(prefillNs) / 1_000_000_000, tps,
+                 decodeTokens > 0 ? Double(decodeNs) / 1_000_000 / Double(decodeTokens) : 0))
+} else {
+    print("[rank \(plan.rank)] done")
+}

--- a/provider-swift/Sources/cluster-run/main.swift
+++ b/provider-swift/Sources/cluster-run/main.swift
@@ -73,12 +73,20 @@ guard group.rank == plan.rank else {
 print("[rank \(plan.rank)] ring joined ✓ (size \(group.size))")
 
 // ---- even contiguous layer split ----
-// Read layer count from config via a 1-layer probe load? No — load the shard
-// loader's full-model layer count cheaply from config.json.
-func totalLayersFromConfig(_ dir: URL) -> Int {
+// Read an Int field from config.json. Multimodal configs (e.g. Gemma 4) nest the
+// text tower's dims under `text_config`; prefer that, falling back to the top
+// level for flat configs (Llama / Mistral / GPT-OSS).
+func configInt(_ dir: URL, _ key: String) -> Int? {
     guard let data = try? Data(contentsOf: dir.appending(component: "config.json")),
-          let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-          let n = obj["num_hidden_layers"] as? Int else { die("cannot read num_hidden_layers from config.json") }
+          let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+    else { return nil }
+    if let textCfg = obj["text_config"] as? [String: Any], let v = textCfg[key] as? Int { return v }
+    return obj[key] as? Int
+}
+func totalLayersFromConfig(_ dir: URL) -> Int {
+    guard let n = configInt(dir, "num_hidden_layers") else {
+        die("cannot read num_hidden_layers from config.json")
+    }
     return n
 }
 let N = totalLayersFromConfig(modelDir)
@@ -150,8 +158,10 @@ do {
     switch modelType {
     case "gpt_oss":
         shard = try GPTOSSShardAdapter.load(directory: modelDir, interval: interval)
+    case "gemma4", "gemma4_text":
+        shard = try Gemma4ShardAdapter.load(directory: modelDir, interval: interval)
     default:
-        die("unsupported model_type '\(modelType)' for clustering (have: gpt_oss)")
+        die("unsupported model_type '\(modelType)' for clustering (have: gpt_oss, gemma4)")
     }
 } catch { die("shard load failed: \(error)") }
 print("[rank \(plan.rank)] shard loaded ✓")
@@ -168,9 +178,7 @@ do {
 } catch { die("tokenize failed: \(error)") }
 
 let hiddenSize = { () -> Int in
-    guard let data = try? Data(contentsOf: modelDir.appending(component: "config.json")),
-          let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-          let h = obj["hidden_size"] as? Int else { die("cannot read hidden_size") }
+    guard let h = configInt(modelDir, "hidden_size") else { die("cannot read hidden_size") }
     return h
 }()
 

--- a/provider-swift/Sources/comms-bench/main.swift
+++ b/provider-swift/Sources/comms-bench/main.swift
@@ -1,0 +1,79 @@
+// comms-bench — measure the TENSOR-PARALLEL comms floor over the ring.
+//
+//   swift run -c release comms-bench [hiddenSize=4096] [layers=40] [tokens=64]
+//
+// TP does ~2 all-reduces per transformer layer per token (after attention-out
+// and after the MLP down-projection). Each all-reduce moves one hidden-state
+// vector. This harness joins the SAME ring the cluster uses (reads [cluster]
+// from provider.toml) and times `2*layers` collectives per simulated token,
+// over `tokens` tokens — giving the per-token comms floor that decides whether
+// TP can approach single-node speed.
+//
+// A 2-node all-reduce ≈ allGather(localPartial) + local sum. We use allGather
+// of a [hiddenSize] bf16-sized int32 payload as the cost proxy (same wire
+// volume + the same CPU-stream GPU<->CPU crossing the real reduce would pay).
+//
+// Run on BOTH nodes (each reads its own node_id/rank from provider.toml).
+
+import Foundation
+import MLX
+import ProviderCore
+
+func log(_ m: String) { print("[comms-bench] \(m)") }
+
+let argv = CommandLine.arguments
+let hiddenSize = argv.count > 1 ? (Int(argv[1]) ?? 4096) : 4096
+let layers = argv.count > 2 ? (Int(argv[2]) ?? 40) : 40
+let tokens = argv.count > 3 ? (Int(argv[3]) ?? 64) : 64
+let reducesPerToken = 2 * layers
+
+let cfg = (try? ConfigManager.load(from: ConfigManager.defaultConfigPath())) ?? ConfigManager.loadDefault()
+guard let clusterSettings = cfg.cluster, clusterSettings.enabled else {
+    FileHandle.standardError.write(Data("ERROR: provider.toml needs an enabled [cluster] section\n".utf8)); exit(1)
+}
+let plan = try ClusterPlan.resolve(clusterSettings)
+
+// Join the ring (same env materialization as ClusterHeadBringup).
+let stateDir = (try? ConfigManager.defaultConfigPath().deletingLastPathComponent())
+    ?? FileManager.default.temporaryDirectory
+let env = try MLXRingEnvironment.materialize(plan, directory: stateDir)
+for (k, v) in env { setenv(k, v, 1) }
+
+log("node \(plan.nodeId) rank \(plan.rank)/\(plan.worldSize) — joining ring …")
+let group = try MLXDistributedGroup.initialize(backend: plan.backend, strict: true)
+log("ring joined. hiddenSize=\(hiddenSize) layers=\(layers) → \(reducesPerToken) reduces/token, \(tokens) tokens")
+
+// Payload sized like one bf16 hidden-state vector (2 bytes/elem ≈ hiddenSize int16;
+// we use int32 elements of count hiddenSize as a conservative cost proxy).
+func payload() -> MLXArray { MLXArray((0..<hiddenSize).map { Int32($0 & 0x7fff) }, [hiddenSize]) }
+
+// Warmup (exclude cold ring/codepath).
+for _ in 0..<(2 * reducesPerToken) {
+    let g = try group.allGather(payload()); g.eval()
+}
+
+var perToken = [Double]()
+let tStart = DispatchTime.now().uptimeNanoseconds
+for t in 0..<tokens {
+    let t0 = DispatchTime.now().uptimeNanoseconds
+    for _ in 0..<reducesPerToken {
+        let g = try group.allGather(payload())
+        g.eval()                       // each reduce is a barrier — same as TP would pay
+    }
+    let dtMs = Double(DispatchTime.now().uptimeNanoseconds - t0) / 1_000_000
+    perToken.append(dtMs)
+    if plan.isHead && (t % 8 == 0) {
+        FileHandle.standardError.write(Data("  token \(t): \(String(format: "%.1f", dtMs)) ms comms\n".utf8))
+    }
+}
+let totalMs = Double(DispatchTime.now().uptimeNanoseconds - tStart) / 1_000_000
+
+if plan.isHead {
+    let warm = Array(perToken.dropFirst(4))
+    let mean = warm.reduce(0, +) / Double(max(1, warm.count))
+    let perReduce = mean / Double(reducesPerToken)
+    log(String(format: "RESULT: %.2f ms/token comms floor (%.3f ms/reduce, %d reduces) over %.1fs total",
+               mean, perReduce, reducesPerToken, totalMs / 1000))
+    log(String(format: "  → at this comms floor, TP decode ceiling ≈ %.1f tok/s (comms-only, ignoring compute overlap)",
+               1000.0 / mean))
+}

--- a/provider-swift/Sources/darkbloom/StartCommand.swift
+++ b/provider-swift/Sources/darkbloom/StartCommand.swift
@@ -46,6 +46,9 @@ struct Start: AsyncParsableCommand {
     @Flag(help: "Disable local API-key auth for --local / --local-endpoint (NOT recommended; trusted/airgapped use only).")
     var noAuth = false
 
+    @Flag(help: "Join this machine to its configured [cluster] for pipeline-parallel inference across co-located, attested Macs. Requires a [cluster] section in provider.toml (EXPERIMENTAL).")
+    var cluster = false
+
     /// Public URL of the Darkbloom Terms of Service.
     static let termsURL = "https://darkbloom.dev/terms.html"
 
@@ -96,6 +99,16 @@ struct Start: AsyncParsableCommand {
             throw ExitCode.failure
         }
 
+        // --cluster (or `[cluster] enabled = true`) resolves the pipeline-
+        // parallel topology up-front: validating it here means the provider
+        // fails fast with a clear message rather than half-forming a cluster.
+        // The resolved plan selects the distributed engine in the loop; on a
+        // single node or without a [cluster] section this is a no-op and the
+        // provider runs exactly as before.
+        if let plan = try resolveClusterPlan(&effectiveConfig) {
+            printClusterPlan(plan)
+        }
+
         if local {
             try await runLocalStandalone(
                 snapshot: snapshot,
@@ -116,6 +129,73 @@ struct Start: AsyncParsableCommand {
                 coordinatorURL: effectiveCoordinator
             )
         }
+    }
+
+    // MARK: - Cluster (--cluster)
+
+    /// Resolve the pipeline-parallel cluster plan from config + the `--cluster`
+    /// flag. The flag forces `cluster.enabled = true` (so a user can opt in
+    /// without editing TOML, as long as a `[cluster]` section with members
+    /// exists). Returns nil when clustering is off; throws a clear error when it
+    /// is on but mis-configured.
+    private func resolveClusterPlan(_ config: inout ProviderConfig) throws -> ClusterPlan? {
+        if cluster {
+            if config.cluster == nil {
+                printError("--cluster requires a [cluster] section in provider.toml (cluster_id, node_id, and [[cluster.members]]).")
+                throw ExitCode.failure
+            }
+            config.cluster?.enabled = true
+        }
+        guard let settings = config.cluster, settings.enabled else {
+            return nil
+        }
+        do {
+            return try ClusterPlan.resolve(settings)
+        } catch let e as ClusterPlanError {
+            printError("Invalid [cluster] configuration: \(clusterPlanErrorMessage(e))")
+            throw ExitCode.failure
+        }
+    }
+
+    private func clusterPlanErrorMessage(_ e: ClusterPlanError) -> String {
+        switch e {
+        case .disabled: return "clustering is disabled"
+        case .missingClusterId: return "cluster_id is required"
+        case .emptyMembers: return "no [[cluster.members]] listed"
+        case .singleMember: return "a cluster needs at least 2 members (this machine plus a peer)"
+        case .selfNotInMembers(let id): return "this machine's node_id \"\(id)\" is not in the members list"
+        case .duplicateNodeId(let id): return "duplicate node_id \"\(id)\" in members"
+        case .unsupportedBackend(let b): return "unsupported transport backend \"\(b)\" (use \"ring\" or \"jaccl\")"
+        }
+    }
+
+    private func printClusterPlan(_ plan: ClusterPlan) {
+        let (prev, next) = plan.neighborNodeIds()
+        print("Cluster mode: \(plan.clusterId)")
+        print("  this node : \(plan.nodeId) (rank \(plan.rank) of \(plan.worldSize), backend=\(plan.backend.rawValue))")
+        print("  ring      : prev=\(prev ?? "—")  next=\(next ?? "—")")
+        print("  role      : \(plan.isHead ? "head (decrypts requests)" : plan.isTail ? "tail (samples tokens)" : "middle")")
+
+        // Materialize the MLX ring hostfile + env now (real, fail-fast). The
+        // ring transport reads MLX_HOSTFILE/MLX_RANK at group init.
+        do {
+            let dir = try ConfigManager.defaultConfigPath().deletingLastPathComponent()
+            try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+            let env = try MLXRingEnvironment.materialize(plan, directory: dir)
+            for (k, v) in env { setenv(k, v, 1) }
+            print("  ring env  : MLX_HOSTFILE=\(env["MLX_HOSTFILE"] ?? "") MLX_RANK=\(env["MLX_RANK"] ?? "")")
+        } catch {
+            printError("Failed to materialize MLX ring environment: \(error)")
+        }
+
+        // The cluster engine itself (DistributedInferenceEngine over the real MLX
+        // ring + sharded model load) is brought up on the cluster hardware; the
+        // node-to-node handshakes run via ClusterBringup over the configured
+        // member addresses. Until that path is exercised on two TB-linked Macs,
+        // the provider continues to serve single-node so it never comes up
+        // half-formed. See docs/developer/clustering-implementation-status.md.
+        print("  status    : topology + ring env ready; distributed engine bring-up runs on cluster hardware.")
+        print()
     }
 
     // MARK: - Standalone (--local)

--- a/provider-swift/Sources/gemma4-shard-smoke/main.swift
+++ b/provider-swift/Sources/gemma4-shard-smoke/main.swift
@@ -1,0 +1,223 @@
+// THROWAWAY harness: prove the Gemma 4 pipeline shard preserves the forward pass
+// against a MONOLITHIC reference, using a TINY SYNTHETIC checkpoint generated in
+// this process. The real gemma-4-26B is far too big to load monolithic + 2 shards
+// at once, so we mint a ~MB random checkpoint with the EXACT key names + shapes
+// `Gemma4TextModel` expects, then run the same equivalence check the other
+// shard-smokes run. NOT a product.
+//
+//   swift run -c release gemma4-shard-smoke            # uses a temp dir
+//   swift run -c release gemma4-shard-smoke <out-dir>  # writes checkpoint there
+//
+// Approach (robust against shape drift): rather than hand-writing every weight
+// key, we INSTANTIATE the monolithic `Gemma4TextModel` for the tiny config, read
+// its actual parameter (key, shape) set via `parameters().flattened()`, and mint
+// matching random tensors. That guarantees the synthetic checkpoint exactly
+// matches the module structure (MoE SwitchGLU experts, k_eq_v full-attention
+// layers that omit v_proj/v_norm, sliding/full mix, tied embeddings). We then:
+//   1. Load the FULL Gemma4TextModel from that checkpoint (reference).
+//   2. Load a 2-way layer split (head=[0,mid), tail=[mid,N)).
+//   3. Run the same token ids through both; slice BOTH to the last position;
+//      assert argmax matches AND relative logit diff < 0.02.
+//
+// This proves the Gemma 4 loader (vision-tower key filtering + index remap +
+// tied-embed replication + shape-inferred quantize) and the partial forward
+// (per-layer-type mask, √hidden embed scale, final-logit softcap) are correct.
+// Mirrors Sources/gptoss-shard-smoke/main.swift.
+
+import Foundation
+import MLX
+import MLXLLM
+import MLXLMCommon
+import MLXNN
+
+func fail(_ m: String) -> Never {
+    FileHandle.standardError.write(Data("FAIL: \(m)\n".utf8)); exit(1)
+}
+
+// ----------------------------------------------------------------------------
+// Tiny synthetic gemma4 config. MoE (enable_moe_block) + sliding/full mix +
+// k_eq_v full attention. num_kv_shared_layers=0 and hidden_size_per_layer_input=0
+// (the cluster-supported shape — the shard requires both off).
+// ----------------------------------------------------------------------------
+let textCfg: [String: Any] = [
+    "model_type": "gemma4_text",
+    "num_hidden_layers": 4,
+    "hidden_size": 128,
+    "intermediate_size": 256,
+    "moe_intermediate_size": 128,
+    "enable_moe_block": true,
+    "num_experts": 4,
+    "top_k_experts": 2,
+    "num_attention_heads": 4,
+    "num_key_value_heads": 2,
+    "num_global_key_value_heads": 1,
+    "head_dim": 32,
+    "global_head_dim": 64,
+    "attention_k_eq_v": true,
+    "use_double_wide_mlp": false,
+    "vocab_size": 320,
+    "sliding_window": 8,
+    "num_kv_shared_layers": 0,
+    "hidden_size_per_layer_input": 0,
+    "final_logit_softcapping": 30.0,
+    "tie_word_embeddings": true,
+    "rms_norm_eps": 1e-6,
+    "layer_types": [
+        "sliding_attention", "full_attention",
+        "sliding_attention", "full_attention",
+    ],
+    "rope_parameters": [
+        "sliding_attention": ["rope_type": "default", "rope_theta": 10000.0],
+        "full_attention": ["rope_type": "proportional", "rope_theta": 1000000.0,
+                           "partial_rotary_factor": 0.25],
+    ] as [String: Any],
+]
+// Gemma 4's top-level (multimodal) config nests the text tower under
+// `text_config`; both Gemma4Configuration and the cluster loader read it there.
+let cfg: [String: Any] = [
+    "model_type": "gemma4",
+    "vocab_size": textCfg["vocab_size"]!,
+    "text_config": textCfg,
+]
+
+// Output directory: arg or temp.
+let args = CommandLine.arguments
+let outDir: URL
+if args.count >= 2 {
+    outDir = URL(fileURLWithPath: args[1], isDirectory: true)
+} else {
+    outDir = FileManager.default.temporaryDirectory
+        .appendingPathComponent("gemma4-synth-\(UUID().uuidString)", isDirectory: true)
+}
+try FileManager.default.createDirectory(at: outDir, withIntermediateDirectories: true)
+
+print("== gemma 4 synthetic shard smoke test ==")
+print("checkpoint dir: \(outDir.path)")
+
+// ----------------------------------------------------------------------------
+// 1. Write config.json
+// ----------------------------------------------------------------------------
+let cfgData = try JSONSerialization.data(withJSONObject: cfg, options: [.prettyPrinted, .sortedKeys])
+try cfgData.write(to: outDir.appendingPathComponent("config.json"))
+
+// ----------------------------------------------------------------------------
+// 2. Build the monolithic model for THIS config, then mint random weights that
+//    exactly match its parameter (key, shape) set. fp32, unquantized → no
+//    quantization metadata, so the loader's shape-based quantize is a no-op.
+// ----------------------------------------------------------------------------
+MLXRandom.seed(0)
+
+let textConfigData = try JSONSerialization.data(withJSONObject: textCfg)
+let gemmaTextConfig = try JSONDecoder().decode(Gemma4TextConfiguration.self, from: textConfigData)
+let scaffold = Gemma4TextModel(gemmaTextConfig)
+
+// Read the model's actual parameter layout and replace each leaf with a small
+// random tensor of the SAME shape. Norm weights live near 1.0 (Gemma's RMSNorm
+// adds 1.0 internally, but a trained norm weight is still ~O(0.1) around 0, so
+// small-scale random is fine and keeps activations well-scaled).
+var w: [String: MLXArray] = [:]
+for (key, value) in scaffold.parameters().flattened() {
+    let shape = value.shape
+    // Weights at ~0.2 (not 0.02) so the forward produces logits with REAL spread
+    // — otherwise the tied-embed projection + tanh softcap collapse everything
+    // toward zero and the relative-diff check becomes uninformative (a near-zero
+    // scale makes any diff look like 0%). Norm weights stay near 0 (Gemma's
+    // RMSNorm adds 1.0 internally).
+    let scale: Float = key.contains("norm") ? 0.1 : 0.2
+    w[key] = MLXRandom.uniform(low: -scale, high: scale, shape).asType(.float32)
+}
+eval(Array(w.values))
+
+// The checkpoint on disk uses the HuggingFace key prefix `language_model.model.`
+// for the text tower (+ tied embeddings: no separate lm_head). `parameters()`
+// gives us the in-module keys (e.g. "model.layers.0...", "lm_head..." absent
+// when tied). Map them to the on-disk convention the loader expects.
+//   in-module "model.<x>"  -> "language_model.model.<x>"
+//   in-module "lm_head.<x>" -> (tied build has none; skip if present)
+var diskWeights: [String: MLXArray] = [:]
+for (k, v) in w {
+    if k.hasPrefix("model.") {
+        diskWeights["language_model." + k] = v
+    } else if k.hasPrefix("lm_head.") {
+        // Tied build: the scaffold won't have lm_head; if some build does, drop
+        // it (the shard projects through tied embed_tokens).
+        continue
+    } else {
+        diskWeights["language_model.model." + k] = v
+    }
+}
+
+let weightsURL = outDir.appendingPathComponent("model.safetensors")
+try MLX.save(arrays: diskWeights, url: weightsURL)
+print("wrote \(diskWeights.count) tensors -> \(weightsURL.lastPathComponent)")
+
+// A short deterministic token sequence (no tokenizer needed for the math check).
+let tokens = [1, 17, 42, 7, 100, 3, 256, 9]
+let ids = MLXArray(tokens.map { Int32($0) }, [1, tokens.count])
+let noCache: [KVCache]? = nil
+
+// ----------------------------------------------------------------------------
+// 3. Monolithic reference
+// ----------------------------------------------------------------------------
+print("\n[1/3] loading full model …")
+let (full, N) = try Gemma4PipelineShardLoader.loadFullModel(outDir)
+let mid = N / 2
+print("layers: \(N)  split: head=[0,\(mid))  tail=[\(mid),\(N))")
+let logitsFull = full(ids, cache: noCache)
+logitsFull.eval()
+print("    full logits shape: \(logitsFull.shape)")
+
+// ----------------------------------------------------------------------------
+// 4. Sharded
+// ----------------------------------------------------------------------------
+print("[2/3] loading 2 shards …")
+let (headShard, total1) = try Gemma4PipelineShardLoader.loadFromDirectory(outDir, start: 0, end: mid)
+let (tailShard, total2) = try Gemma4PipelineShardLoader.loadFromDirectory(outDir, start: mid, end: N)
+precondition(total1 == N && total2 == N)
+
+print("[3/3] running sharded forward …")
+var h = headShard.embed(ids)
+h = headShard.runOwnedLayers(h, cache: noCache)
+h = tailShard.runOwnedLayers(h, cache: noCache)
+let logitsShard = tailShard.projectToLogits(h)
+logitsShard.eval()
+print("    shard logits shape: \(logitsShard.shape)")
+
+// ----------------------------------------------------------------------------
+// Compare — aligned last-position slice (same logic as the other smokes).
+// ----------------------------------------------------------------------------
+func lastSlice(_ logits: MLXArray) -> MLXArray {
+    guard logits.ndim == 3, logits.dim(1) > 1 else { return logits }
+    return logits[0..., (logits.dim(1) - 1)..., 0...]
+}
+func argmaxLast(_ logits: MLXArray) -> Int {
+    let a = argMax(logits, axis: logits.ndim - 1)
+    a.eval()
+    return Int(a.asArray(Int32.self).last ?? -1)
+}
+let fullLast = lastSlice(logitsFull)
+let shardLast = lastSlice(logitsShard)
+precondition(fullLast.shape == shardLast.shape,
+             "aligned shapes expected, got full=\(fullLast.shape) shard=\(shardLast.shape)")
+
+let aFull = argmaxLast(fullLast)
+let aShard = argmaxLast(shardLast)
+
+let diffArr = (fullLast - shardLast).abs()
+diffArr.eval()
+let maxDiff = diffArr.max().item(Float.self)
+let scale = logitsFull.abs().max().item(Float.self)
+let relDiff = scale > 0 ? maxDiff / scale : maxDiff
+
+print("\nfull  argmax(last) = \(aFull)")
+print("shard argmax(last) = \(aShard)")
+print(String(format: "aligned max abs logit diff = %.6f  (scale %.4f, relative %.6f)", maxDiff, scale, relDiff))
+
+if scale < 0.01 {
+    fail("logit scale \(scale) too small — forward collapsed to ~0, relative-diff check is uninformative")
+}
+if aFull == aShard && relDiff < 0.02 {
+    print("\nPASS: Gemma 4 sharded forward matches monolithic (same next-token; aligned logits within \(String(format: "%.2f%%", relDiff*100)) relative).")
+} else {
+    fail("Gemma 4 sharded output diverged from monolithic — argmax \(aFull) vs \(aShard), maxDiff \(maxDiff), relDiff \(relDiff)")
+}

--- a/provider-swift/Sources/gptoss-shard-smoke/main.swift
+++ b/provider-swift/Sources/gptoss-shard-smoke/main.swift
@@ -1,0 +1,218 @@
+// THROWAWAY harness: prove the GPT-OSS pipeline shard preserves the forward pass
+// against a MONOLITHIC reference, using a TINY SYNTHETIC checkpoint generated in
+// this process. The real gpt-oss-20b is far too big to load monolithic + 2 shards
+// at once, so we mint a ~MB random checkpoint with the EXACT key names + shapes
+// `GPTOSSModel` expects (post-`sanitize`), then run the same equivalence check
+// `shard-smoke` runs for Llama. NOT a product.
+//
+//   swift run -c release gptoss-shard-smoke            # uses a temp dir
+//   swift run -c release gptoss-shard-smoke <out-dir>  # writes checkpoint there
+//
+// What it does:
+//   1. Generate config.json (tiny gpt_oss: 4 layers, 4 experts, mixed attn,
+//      yarn rope_scaling) + a single random fp32 weights.safetensors with EVERY
+//      parameter the monolithic GPTOSSModel needs.
+//   2. Load the FULL GPTOSSModel via GPTOSSPipelineShardLoader.loadFullModel.
+//   3. Load a 2-way layer split (head=[0,mid), tail=[mid,N)) via loadFromDirectory.
+//   4. Run the same token ids through both; slice BOTH to the last position;
+//      assert argmax matches AND relative logit diff < 0.02.
+//
+// This proves the GPT-OSS loader (key filtering + index remap + MoE expert keys)
+// and the partial forward are correct. Mirrors Sources/shard-smoke/main.swift.
+
+import Foundation
+import MLX
+import MLXLLM
+import MLXLMCommon
+import MLXNN
+
+func fail(_ m: String) -> Never {
+    FileHandle.standardError.write(Data("FAIL: \(m)\n".utf8)); exit(1)
+}
+
+// ----------------------------------------------------------------------------
+// Tiny synthetic gpt_oss config. mixed attention (sliding/full) + yarn rope.
+// ----------------------------------------------------------------------------
+let cfg: [String: Any] = [
+    "model_type": "gpt_oss",
+    "num_hidden_layers": 4,
+    "num_local_experts": 4,
+    "num_experts_per_tok": 2,
+    "hidden_size": 256,
+    "intermediate_size": 256,
+    "head_dim": 32,
+    "num_attention_heads": 8,
+    "num_key_value_heads": 2,
+    "vocab_size": 512,
+    "sliding_window": 8,
+    "rope_theta": 150000,
+    "rms_norm_eps": 1e-5,
+    "layer_types": [
+        "sliding_attention", "full_attention",
+        "sliding_attention", "full_attention",
+    ],
+    "rope_scaling": [
+        "rope_type": "yarn",
+        "factor": 32,
+        "original_max_position_embeddings": 4096,
+        "beta_fast": 32,
+        "beta_slow": 1,
+        "truncate": false,
+    ] as [String: Any],
+]
+
+let numLayers = cfg["num_hidden_layers"] as! Int
+let numExperts = cfg["num_local_experts"] as! Int
+let hidden = cfg["hidden_size"] as! Int
+let inter = cfg["intermediate_size"] as! Int
+let headDim = cfg["head_dim"] as! Int
+let nHeads = cfg["num_attention_heads"] as! Int
+let nKV = cfg["num_key_value_heads"] as! Int
+let vocab = cfg["vocab_size"] as! Int
+
+// Output directory: arg or temp.
+let args = CommandLine.arguments
+let outDir: URL
+if args.count >= 2 {
+    outDir = URL(fileURLWithPath: args[1], isDirectory: true)
+} else {
+    outDir = FileManager.default.temporaryDirectory
+        .appendingPathComponent("gptoss-synth-\(UUID().uuidString)", isDirectory: true)
+}
+try FileManager.default.createDirectory(at: outDir, withIntermediateDirectories: true)
+
+print("== gpt-oss synthetic shard smoke test ==")
+print("checkpoint dir: \(outDir.path)")
+
+// ----------------------------------------------------------------------------
+// 1. Write config.json
+// ----------------------------------------------------------------------------
+let cfgData = try JSONSerialization.data(withJSONObject: cfg, options: [.prettyPrinted, .sortedKeys])
+try cfgData.write(to: outDir.appendingPathComponent("config.json"))
+
+// ----------------------------------------------------------------------------
+// 2. Generate random weights with the EXACT post-sanitize key names + shapes
+//    GPTOSSModel expects. Small uniform values keep activations well-scaled so
+//    the forward pass is numerically stable. fp32 (synthetic FP checkpoint => no
+//    quantization, so sanitize early-returns on `gate_proj.weight`).
+// ----------------------------------------------------------------------------
+MLXRandom.seed(0)
+func rnd(_ shape: [Int], scale: Float = 0.02) -> MLXArray {
+    MLXRandom.uniform(low: -scale, high: scale, shape).asType(.float32)
+}
+
+var w: [String: MLXArray] = [:]
+
+// embeddings + final norm + lm_head
+w["model.embed_tokens.weight"] = rnd([vocab, hidden])
+w["model.norm.weight"] = rnd([hidden], scale: 0.1) + 1.0   // norm weights ~1
+w["lm_head.weight"] = rnd([vocab, hidden])
+
+for i in 0 ..< numLayers {
+    let p = "model.layers.\(i)"
+    // RMSNorms (centered near 1 like a real trained norm)
+    w["\(p).input_layernorm.weight"] = rnd([hidden], scale: 0.1) + 1.0
+    w["\(p).post_attention_layernorm.weight"] = rnd([hidden], scale: 0.1) + 1.0
+
+    // attention: q/k/v/o (Linear with bias) + sinks (ParameterInfo)
+    let qOut = nHeads * headDim
+    let kvOut = nKV * headDim
+    w["\(p).self_attn.q_proj.weight"] = rnd([qOut, hidden])
+    w["\(p).self_attn.q_proj.bias"] = rnd([qOut])
+    w["\(p).self_attn.k_proj.weight"] = rnd([kvOut, hidden])
+    w["\(p).self_attn.k_proj.bias"] = rnd([kvOut])
+    w["\(p).self_attn.v_proj.weight"] = rnd([kvOut, hidden])
+    w["\(p).self_attn.v_proj.bias"] = rnd([kvOut])
+    w["\(p).self_attn.o_proj.weight"] = rnd([hidden, qOut])
+    w["\(p).self_attn.o_proj.bias"] = rnd([hidden])
+    // non-zero sinks so the sinks-active attention path is exercised.
+    w["\(p).self_attn.sinks"] = rnd([nHeads], scale: 0.5)
+
+    // MoE router (Linear with bias)
+    w["\(p).mlp.router.weight"] = rnd([numExperts, hidden])
+    w["\(p).mlp.router.bias"] = rnd([numExperts])
+
+    // MoE experts: SwiGLUSwitchGLU -> SwitchLinear weights are
+    // [numExperts, outputDims, inputDims], biases [numExperts, outputDims].
+    // gate_proj/up_proj: inputDims=hidden, outputDims=inter.
+    // down_proj:        inputDims=inter,  outputDims=hidden.
+    w["\(p).mlp.experts.gate_proj.weight"] = rnd([numExperts, inter, hidden])
+    w["\(p).mlp.experts.gate_proj.bias"] = rnd([numExperts, inter])
+    w["\(p).mlp.experts.up_proj.weight"] = rnd([numExperts, inter, hidden])
+    w["\(p).mlp.experts.up_proj.bias"] = rnd([numExperts, inter])
+    w["\(p).mlp.experts.down_proj.weight"] = rnd([numExperts, hidden, inter])
+    w["\(p).mlp.experts.down_proj.bias"] = rnd([numExperts, hidden])
+}
+
+eval(Array(w.values))
+let weightsURL = outDir.appendingPathComponent("model.safetensors")
+try MLX.save(arrays: w, url: weightsURL)
+print("wrote \(w.count) tensors -> \(weightsURL.lastPathComponent)")
+
+// A short deterministic token sequence (no tokenizer needed for the math check).
+let tokens = [1, 17, 42, 7, 100, 3, 256, 9]
+let ids = MLXArray(tokens.map { Int32($0) }, [1, tokens.count])
+let noCache: [KVCache]? = nil
+
+// ----------------------------------------------------------------------------
+// 3. Monolithic reference
+// ----------------------------------------------------------------------------
+print("\n[1/3] loading full model …")
+let (full, N) = try GPTOSSPipelineShardLoader.loadFullModel(outDir)
+let mid = N / 2
+print("layers: \(N)  split: head=[0,\(mid))  tail=[\(mid),\(N))")
+let logitsFull = full(ids, cache: noCache)
+logitsFull.eval()
+print("    full logits shape: \(logitsFull.shape)")
+
+// ----------------------------------------------------------------------------
+// 4. Sharded
+// ----------------------------------------------------------------------------
+print("[2/3] loading 2 shards …")
+let (headShard, total1) = try GPTOSSPipelineShardLoader.loadFromDirectory(outDir, start: 0, end: mid)
+let (tailShard, total2) = try GPTOSSPipelineShardLoader.loadFromDirectory(outDir, start: mid, end: N)
+precondition(total1 == N && total2 == N)
+
+print("[3/3] running sharded forward …")
+var h = headShard.embed(ids)
+h = headShard.runOwnedLayers(h, cache: noCache)
+h = tailShard.runOwnedLayers(h, cache: noCache)
+let logitsShard = tailShard.projectToLogits(h)
+logitsShard.eval()
+print("    shard logits shape: \(logitsShard.shape)")
+
+// ----------------------------------------------------------------------------
+// Compare — aligned last-position slice (same logic as shard-smoke).
+// ----------------------------------------------------------------------------
+func lastSlice(_ logits: MLXArray) -> MLXArray {
+    guard logits.ndim == 3, logits.dim(1) > 1 else { return logits }
+    return logits[0..., (logits.dim(1) - 1)..., 0...]
+}
+func argmaxLast(_ logits: MLXArray) -> Int {
+    let ids = argMax(logits, axis: logits.ndim - 1)
+    ids.eval()
+    return Int(ids.asArray(Int32.self).last ?? -1)
+}
+let fullLast = lastSlice(logitsFull)
+let shardLast = lastSlice(logitsShard)
+precondition(fullLast.shape == shardLast.shape,
+             "aligned shapes expected, got full=\(fullLast.shape) shard=\(shardLast.shape)")
+
+let aFull = argmaxLast(fullLast)
+let aShard = argmaxLast(shardLast)
+
+let diffArr = (fullLast - shardLast).abs()
+diffArr.eval()
+let maxDiff = diffArr.max().item(Float.self)
+let scale = logitsFull.abs().max().item(Float.self)
+let relDiff = scale > 0 ? maxDiff / scale : maxDiff
+
+print("\nfull  argmax(last) = \(aFull)")
+print("shard argmax(last) = \(aShard)")
+print(String(format: "aligned max abs logit diff = %.4f  (scale %.1f, relative %.4f)", maxDiff, scale, relDiff))
+
+if aFull == aShard && relDiff < 0.02 {
+    print("\nPASS: GPT-OSS sharded forward matches monolithic (same next-token; aligned logits within \(String(format: "%.2f%%", relDiff*100)) relative).")
+} else {
+    fail("GPT-OSS sharded output diverged from monolithic — argmax \(aFull) vs \(aShard), maxDiff \(maxDiff), relDiff \(relDiff)")
+}

--- a/provider-swift/Sources/kv-se-harness/main.swift
+++ b/provider-swift/Sources/kv-se-harness/main.swift
@@ -6,17 +6,18 @@
 // `keychain-access-groups` entitlement and runs from a plain unsigned
 // `swift build` binary. Run:
 //
-//   swift build --product kv-se-harness
+//   swift build --product kv-se-harness        # DEBUG build only
 //   .build/debug/kv-se-harness
+//
+// NOTE: `PersistentEnclaveKey.makeTransient()` is `#if DEBUG`-gated (compiled
+// out of release builds), so this harness is likewise gated — in a release
+// build it compiles to a no-op `main` rather than failing the whole package
+// build. Build it in debug to actually exercise the SE.
 //
 // Exercises, on the real Secure Enclave:
 //   - SE key generation (transient)
-//   - ECIES wrap (public-key) + unwrap (SE private key) — the new code in
-//     PersistentEnclaveKey+ECIES / SecureEnclaveKeyWrappingService
-//   - KVCacheKEK: generate -> SE-wrap -> store -> read -> SE-unwrap,
-//     recovering the SAME KEK material (KEK storage is in-memory here;
-//     keychain PERSISTENCE of the key is the one part that needs a signed
-//     build, and it's the same SecItem path the attestation key uses).
+//   - ECIES wrap (public-key) + unwrap (SE private key)
+//   - KVCacheKEK: generate -> SE-wrap -> store -> read -> SE-unwrap
 //   - DEK wrap/unwrap under the recovered KEK
 //
 // Prints PASS/FAIL; exits non-zero on failure. NOT a product, NOT shipped.
@@ -30,6 +31,13 @@ func harnessFail(_ msg: String) -> Never {
     exit(1)
 }
 
+/// `SymmetricKey` raw bytes as `Data`. `Data(Array($0))` avoids the ambiguous
+/// `Data.init` overload set that `Data($0)` hits on Swift 6.3+.
+func rawBytes(_ key: SymmetricKey) -> Data {
+    key.withUnsafeBytes { Data(Array($0)) }
+}
+
+#if DEBUG
 print("== SE ECIES + KEK harness (transient SE key, unsigned) ==")
 print("SE available: \(PersistentEnclaveKey.isAvailable)")
 
@@ -42,9 +50,7 @@ do {
     let se = try PersistentEnclaveKey.makeTransient()
     print("✓ transient SE key created (pub \(se.publicKeyRaw.count) bytes)")
 
-    // 1) Direct ECIES round-trip on the real SE key (the new code path:
-    //    SecKeyCreateEncryptedData / SecKeyCreateDecryptedData with
-    //    .eciesEncryptionStandardX963SHA256AESGCM).
+    // 1) Direct ECIES round-trip on the real SE key.
     let probe = Data("ecies-probe-payload-\(UUID().uuidString)".utf8)
     let sealed = try se.eciesEncrypt(probe)
     let opened = try se.eciesDecrypt(sealed)
@@ -52,18 +58,15 @@ do {
     print("✓ ECIES wrap+unwrap on real SE (ciphertext \(sealed.count) bytes; SE-private decrypt)")
 
     // 2) KEK: generate -> SE-wrap -> store -> read -> SE-unwrap.
-    //    Both KEK instances share the same transient SE key + storage
-    //    (the key is in-memory; we're validating wrap/unwrap, not
-    //    keychain persistence).
     let wrapper = SecureEnclaveKeyWrappingService(enclaveKey: se)
     let storage = InMemoryWrappedKEKStorage(identifier: "harness")
     let kek1 = KVCacheKEK(wrapper: wrapper, storage: storage)
     let k1 = try await kek1.loadOrCreate()
-    let k1raw = k1.withUnsafeBytes { Data($0) }
+    let k1raw = rawBytes(k1)
 
     let kek2 = KVCacheKEK(wrapper: wrapper, storage: storage)
     let k2 = try await kek2.loadOrCreate()  // reads stored wrapped KEK -> SE-unwrap
-    let k2raw = k2.withUnsafeBytes { Data($0) }
+    let k2raw = rawBytes(k2)
     guard k1raw == k2raw else {
         harnessFail("KEK material differed after store + SE-unwrap (wrap/unwrap broken)")
     }
@@ -72,9 +75,9 @@ do {
     // 3) DEK wrap/unwrap under the recovered KEK.
     let aad = Data("harness-metadata-aad".utf8)
     let (dek, wrappedDEK) = try await kek1.freshDEK(aad: aad)
-    let dekRaw = dek.withUnsafeBytes { Data($0) }
+    let dekRaw = rawBytes(dek)
     let recovered = try await kek2.unwrap(wrappedDEK: wrappedDEK, aad: aad)
-    let recRaw = recovered.withUnsafeBytes { Data($0) }
+    let recRaw = rawBytes(recovered)
     guard dekRaw == recRaw else { harnessFail("DEK round-trip under recovered KEK mismatch") }
     print("✓ DEK wrap/unwrap under recovered KEK")
 
@@ -90,3 +93,7 @@ do {
 } catch {
     harnessFail("threw: \(error)")
 }
+#else
+// makeTransient() is DEBUG-only; in release this harness has nothing to do.
+print("kv-se-harness is a DEBUG-only tool; build with `swift build --product kv-se-harness` (debug).")
+#endif

--- a/provider-swift/Sources/loop-diag/main.swift
+++ b/provider-swift/Sources/loop-diag/main.swift
@@ -1,0 +1,151 @@
+// loop-diag — single-machine diagnostic harness that isolates the cluster
+// decode-loop OVERHEAD from the NETWORK cost.
+//
+//   swift run -c release loop-diag <model-dir> [maxTokens=96] [iterations=4]
+//
+// We have two decode paths on Apple Silicon MLX-Swift:
+//   * solo-bench: uses MLX's native MLXLMCommon.generate (one lazy graph per
+//     token, async, minimal syncs). ~57 tok/s for gpt-oss-20b on this machine.
+//   * ClusterPipeline: a hand-rolled distributed decode loop — manual argMax
+//     sampling, evalEvery:4 mid-layer eval chopping, and ~4-6 .eval() barriers
+//     per token, plus per-token encrypt/serialize. ~9-12 tok/s clustered across
+//     two machines.
+//
+// This harness runs the CLUSTER'S LOOP DISCIPLINE on ONE machine with the FULL
+// model and NO network / group collectives (no send/recv/all_gather). So its
+// tok/s vs solo-bench's tok/s isolates the PURE LOOP OVERHEAD — eval barriers,
+// manual argMax sampling, evalEvery:4 — from the network hop + pipeline bubble.
+//
+// It mirrors ClusterPipeline.generate EXACTLY for a single node that is both
+// head AND tail (one shard owns the whole model):
+//   hidden = shard.embed(tokens:)            // step 0 = full prompt, else last token
+//   hidden = shard.runOwnedLayers(hidden)    // already does evalEvery:4 internally
+//   let logits = shard.projectToLogits(hidden)
+//   let ids = argMax(logits, axis: logits.ndim - 1); ids.eval()   // SAME manual
+//                                                                  // sample + barrier
+// The send/recv/all_gather collectives are the NETWORK parts — they are OMITTED
+// here. Everything else (the sampling + eval-barrier discipline) is preserved.
+//
+// NOT a product. Companion to solo-bench / cluster-run.
+
+import Foundation
+import MLX
+import MLXLLM
+import MLXLMCommon
+import ProviderCore
+
+func die(_ m: String) -> Never { FileHandle.standardError.write(Data("ERROR: \(m)\n".utf8)); exit(1) }
+
+let argv = CommandLine.arguments
+guard argv.count >= 2 else { die("usage: loop-diag <model-dir> [maxTokens=96] [iterations=4]") }
+let modelDir = URL(fileURLWithPath: argv[1], isDirectory: true)
+let maxTokens = argv.count > 2 ? (Int(argv[2]) ?? 96) : 96
+let iterations = argv.count > 3 ? (Int(argv[3]) ?? 4) : 4
+let prompt = "Explain pipeline parallelism in two sentences."
+
+// ---- config.json reads (mirror ClusterHeadBringup / cluster-run) ----
+func configInt(_ dir: URL, _ key: String) -> Int {
+    guard let data = try? Data(contentsOf: dir.appending(component: "config.json")),
+          let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+          let v = obj[key] as? Int else { die("cannot read \(key) from config.json") }
+    return v
+}
+func modelTypeFromConfig(_ dir: URL) -> String {
+    guard let data = try? Data(contentsOf: dir.appending(component: "config.json")),
+          let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+          let t = obj["model_type"] as? String else { return "llama" }
+    return t
+}
+
+let numLayers = configInt(modelDir, "num_hidden_layers")
+let modelType = modelTypeFromConfig(modelDir)
+
+// Match the cluster runs' GPU memory posture (same line as solo-bench /
+// ClusterHeadBringup). The deprecated relaxed: flag warning is expected.
+let physical = ProcessInfo.processInfo.physicalMemory
+MLX.GPU.set(memoryLimit: Int(Double(physical) * 0.80), relaxed: false)
+
+print("loop-diag: \(modelDir.lastPathComponent), model_type=\(modelType), layers=\(numLayers), maxTokens=\(maxTokens), iterations=\(iterations)")
+
+// ---- load the FULL model as ONE shard (interval covers all layers) ----
+// One shard owns 0..<numLayers, so it is simultaneously head (embeds) and tail
+// (projects to logits) — exactly what ClusterPipeline runs, minus the ring.
+let interval = LayerInterval(nodeId: "loop-diag", start: 0, end: numLayers)
+let shard: any PipelineModelShard
+do {
+    switch modelType {
+    case "gpt_oss":
+        shard = try GPTOSSShardAdapter.load(directory: modelDir, interval: interval)
+    case "gemma4", "gemma4_text":
+        shard = try Gemma4ShardAdapter.load(directory: modelDir, interval: interval)
+    default:
+        die("unsupported model_type '\(modelType)' (have: gpt_oss, gemma4)")
+    }
+} catch { die("shard load failed: \(error)") }
+print("model loaded.\n")
+
+// ---- tokenizer + chat template (mirror cluster-run) ----
+let tokenizer: any Tokenizer
+do { tokenizer = try await LocalTokenizerLoader().load(from: modelDir) }
+catch { die("tokenizer load failed: \(error)") }
+
+let promptTokens: [Int]
+do {
+    promptTokens = try tokenizer.applyChatTemplate(
+        messages: [["role": "user", "content": prompt]], tools: nil, additionalContext: nil)
+} catch { die("tokenize failed: \(error)") }
+
+let eosTokenId = tokenizer.eosTokenId
+
+// ---- decode loop: ClusterPipeline.generate, single-node, NO collectives ----
+for i in 1...iterations {
+    var seq = promptTokens
+    var generated = [Int]()
+    var prefillNs: UInt64 = 0
+    var decodeNs: UInt64 = 0
+
+    for step in 0..<maxTokens {
+        let stepStart = DispatchTime.now().uptimeNanoseconds
+
+        // step 0 = whole prompt (prefill); else just the most-recent token.
+        let inputTokens: [Int] = step == 0 ? seq : [seq[seq.count - 1]]
+
+        // HEAD: embed. (Cluster non-head ranks would recv hidden over the wire;
+        // single-node here is always head, so always embed — no recv.)
+        var hidden = shard.embed(tokens: inputTokens)
+
+        // Owned layers — this already does evalEvery:4 internally (same as the
+        // cluster). One shard owns ALL layers here.
+        hidden = shard.runOwnedLayers(hidden)
+
+        // (Cluster non-tail ranks would seal + send hidden here — OMITTED, no
+        // network.) TAIL: project to logits, manual argMax, eval barrier — the
+        // SAME sampling discipline as ClusterPipeline's tail.
+        let logits = shard.projectToLogits(hidden)
+        let ids = argMax(logits, axis: logits.ndim - 1)
+        ids.eval()
+        let nextToken = Int(ids.asArray(Int32.self).last ?? 0)
+
+        // (Cluster all_gather token broadcast OMITTED — single node already has
+        // the token; no collective.)
+        seq.append(nextToken)
+        generated.append(nextToken)
+
+        let stepNs = DispatchTime.now().uptimeNanoseconds - stepStart
+        if step == 0 { prefillNs = stepNs } else { decodeNs += stepNs }
+
+        if let eos = eosTokenId, nextToken == eos { break }
+    }
+
+    // Steady-state decode tok/s = decode tokens (excluding the first produced
+    // token) over the summed decode-step wall time. Match solo-bench's format.
+    let totalNs = prefillNs + decodeNs
+    let totalS = Double(totalNs) / 1_000_000_000
+    let prefillS = Double(prefillNs) / 1_000_000_000
+    let decodeS = max(0.0001, Double(decodeNs) / 1_000_000_000)
+    let decodeToks = max(1, generated.count - 1)
+    let tps = Double(decodeToks) / decodeS
+    let tag = i == 1 ? " (cold — discard)" : ""
+    print(String(format: "iter %d: %d tok in %.2fs · prefill %.2fs · decode %.2f tok/s%@",
+                 i, generated.count, totalS, prefillS, tps, tag))
+}

--- a/provider-swift/Sources/solo-bench/main.swift
+++ b/provider-swift/Sources/solo-bench/main.swift
@@ -1,0 +1,72 @@
+// solo-bench — single-node decode benchmark, pointed straight at a model dir.
+//
+//   swift run -c release solo-bench <model-dir> [maxTokens] [iterations]
+//
+// Bypasses the coordinator/scanner machinery of `darkbloom benchmark` (which
+// resolves models from the HF hub cache + advertised-model config). This loads
+// the model directly with the same MLX-Swift LLM API the provider uses and
+// reports steady-state decode tok/s — the single-node baseline to compare
+// against the cluster's pipeline-parallel numbers.
+
+import Foundation
+import MLX
+import MLXLLM
+import MLXLMCommon
+import ProviderCore
+
+func die(_ m: String) -> Never { FileHandle.standardError.write(Data("ERROR: \(m)\n".utf8)); exit(1) }
+
+let argv = CommandLine.arguments
+guard argv.count >= 2 else { die("usage: solo-bench <model-dir> [maxTokens=96] [iterations=4]") }
+let modelDir = URL(fileURLWithPath: argv[1], isDirectory: true)
+let maxTokens = argv.count > 2 ? (Int(argv[2]) ?? 96) : 96
+let iterations = argv.count > 3 ? (Int(argv[3]) ?? 4) : 4
+let prompt = "Explain pipeline parallelism in two sentences."
+
+// Match the cluster runs' GPU memory posture.
+let physical = ProcessInfo.processInfo.physicalMemory
+MLX.GPU.set(memoryLimit: Int(Double(physical) * 0.80), relaxed: false)
+
+print("solo-bench: \(modelDir.lastPathComponent), maxTokens=\(maxTokens), iterations=\(iterations)")
+let container = try await LLMModelFactory.shared.loadContainer(
+    from: modelDir, using: LocalTokenizerLoader())
+print("model loaded.\n")
+
+let rawMessages: [MLXLMCommon.Message] = [["role": "user", "content": prompt]]
+
+for i in 1...iterations {
+    let start = ContinuousClock.now
+    var firstTokenAt: ContinuousClock.Instant?
+    var completion = 0
+
+    let stream: AsyncStream<Generation> = try await container.perform { context in
+        let input = try await context.processor.prepare(input: UserInput(messages: rawMessages))
+        let params = GenerateParameters(maxTokens: maxTokens, temperature: 0.0, topP: 1.0, topK: 0)
+        return try MLXLMCommon.generate(input: input, parameters: params, context: context)
+    }
+
+    for await gen in stream {
+        switch gen {
+        case .chunk:
+            if firstTokenAt == nil { firstTokenAt = .now }
+            completion += 1
+        case .info(let info):
+            if completion == 0 { completion = info.generationTokenCount }
+        case .toolCall: break
+        }
+    }
+
+    let total = ContinuousClock.now - start
+    let totalS = Double(total.components.seconds) + Double(total.components.attoseconds) / 1e18
+    let prefillS: Double = {
+        guard let f = firstTokenAt else { return 0 }
+        let d = f - start
+        return Double(d.components.seconds) + Double(d.components.attoseconds) / 1e18
+    }()
+    let decodeS = max(0.0001, totalS - prefillS)
+    let decodeToks = max(1, completion - 1)
+    let tps = Double(decodeToks) / decodeS
+    let tag = i == 1 ? " (cold — discard)" : ""
+    print(String(format: "iter %d: %d tok in %.2fs · prefill %.2fs · decode %.2f tok/s%@",
+                 i, completion, totalS, prefillS, tps, tag))
+}

--- a/provider-swift/Sources/spec-bench/main.swift
+++ b/provider-swift/Sources/spec-bench/main.swift
@@ -1,0 +1,88 @@
+// spec-bench — single-node SPECULATIVE decoding benchmark.
+//
+//   swift run -c release spec-bench <target-dir> <draft-dir> [maxTokens=96] [iterations=4] [K=4]
+//
+// A small draft model proposes K tokens; the large target model verifies them in
+// one forward pass, accepting the longest agreeing prefix. For greedy (temp=0)
+// the output is token-identical to the target alone — this is pure latency win,
+// 2-3x typical, topology-independent (helps single-node AND clustered decode).
+//
+// Compare against `solo-bench <target-dir>` (plain decode, same prompt/maxTokens)
+// to read the speedup. Uses the fork's SpeculativeTokenIterator via the
+// MLXLMCommon.generate(...draftModel:numDraftTokens:) overload — no new model code.
+//
+// Draft + target MUST share a tokenizer (llama-1b and llama-8b have byte-identical
+// tokenizer.json, so token ids are interchangeable).
+
+import Foundation
+import MLX
+import MLXLLM
+import MLXLMCommon
+import ProviderCore
+
+func die(_ m: String) -> Never { FileHandle.standardError.write(Data("ERROR: \(m)\n".utf8)); exit(1) }
+
+let argv = CommandLine.arguments
+guard argv.count >= 3 else { die("usage: spec-bench <target-dir> <draft-dir> [maxTokens=96] [iterations=4] [K=4]") }
+let targetDir = URL(fileURLWithPath: argv[1], isDirectory: true)
+let draftDir = URL(fileURLWithPath: argv[2], isDirectory: true)
+let maxTokens = argv.count > 3 ? (Int(argv[3]) ?? 96) : 96
+let iterations = argv.count > 4 ? (Int(argv[4]) ?? 4) : 4
+let K = argv.count > 5 ? (Int(argv[5]) ?? 4) : 4
+let prompt = "Explain pipeline parallelism in two sentences."
+
+let physical = ProcessInfo.processInfo.physicalMemory
+MLX.GPU.set(memoryLimit: Int(Double(physical) * 0.80), relaxed: false)
+
+print("spec-bench: target=\(targetDir.lastPathComponent) draft=\(draftDir.lastPathComponent) K=\(K) maxTokens=\(maxTokens) iterations=\(iterations)")
+let targetContainer = try await LLMModelFactory.shared.loadContainer(
+    from: targetDir, using: LocalTokenizerLoader())
+print("models loading …")
+
+let rawMessages: [MLXLMCommon.Message] = [["role": "user", "content": prompt]]
+
+// Run all iterations inside ONE perform so the draft model is loaded once and
+// stays within the target container's isolation domain (it's non-Sendable).
+try await targetContainer.perform { context in
+    let draftContext = try await LLMModelFactory.shared.load(
+        from: draftDir, using: LocalTokenizerLoader())
+    let draftModel = draftContext.model
+    FileHandle.standardError.write(Data("models loaded.\n\n".utf8))
+
+    for i in 1...iterations {
+        let start = ContinuousClock.now
+        var firstTokenAt: ContinuousClock.Instant?
+        var completion = 0
+
+        let input = try await context.processor.prepare(input: UserInput(messages: rawMessages))
+        let params = GenerateParameters(maxTokens: maxTokens, temperature: 0.0, topP: 1.0, topK: 0)
+        let stream = try MLXLMCommon.generate(
+            input: input, parameters: params, context: context,
+            draftModel: draftModel, numDraftTokens: K)
+
+        for await gen in stream {
+            switch gen {
+            case .chunk:
+                if firstTokenAt == nil { firstTokenAt = .now }
+                completion += 1
+            case .info(let info):
+                if completion == 0 { completion = info.generationTokenCount }
+            case .toolCall: break
+            }
+        }
+
+        let total = ContinuousClock.now - start
+        let totalS = Double(total.components.seconds) + Double(total.components.attoseconds) / 1e18
+        let prefillS: Double = {
+            guard let f = firstTokenAt else { return 0 }
+            let d = f - start
+            return Double(d.components.seconds) + Double(d.components.attoseconds) / 1e18
+        }()
+        let decodeS = max(0.0001, totalS - prefillS)
+        let decodeToks = max(1, completion - 1)
+        let tps = Double(decodeToks) / decodeS
+        let tag = i == 1 ? " (cold — discard)" : ""
+        print(String(format: "iter %d: %d tok in %.2fs · prefill %.2fs · decode %.2f tok/s%@",
+                     i, completion, totalS, prefillS, tps, tag))
+    }
+}

--- a/provider-swift/Tests/ProviderCoreTests/ClusterBatchControlTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/ClusterBatchControlTests.swift
@@ -1,0 +1,89 @@
+import Foundation
+import Testing
+@testable import ProviderCore
+
+// Round-trip tests for the continuous-batching composition control vector.
+// This is the protocol every rank uses to agree on the per-step batch
+// composition; an encode/decode mismatch would silently desync the ring caches,
+// so it is the highest-value thing to pin down with a unit test.
+
+@Test func compositionRoundTripStep() {
+    let comp = ClusterBatchComposition(
+        command: .step,
+        bNext: 5,
+        keepIndices: [0, 2, 3],
+        admit: [
+            ClusterAdmitRow(promptTokens: [10, 11, 12], leftPadding: 0, maxTokens: 64),
+            ClusterAdmitRow(promptTokens: [99], leftPadding: 2, maxTokens: 128),
+        ])
+    let decoded = ClusterBatchComposition.decode(comp.encodeVector())
+
+    #expect(decoded.command == .step)
+    #expect(decoded.bNext == 5)
+    #expect(decoded.keepIndices == [0, 2, 3])
+    #expect(decoded.admit.count == 2)
+    #expect(decoded.admit[0].promptTokens == [10, 11, 12])
+    #expect(decoded.admit[0].leftPadding == 0)
+    #expect(decoded.admit[0].maxTokens == 64)
+    #expect(decoded.admit[1].promptTokens == [99])
+    #expect(decoded.admit[1].leftPadding == 2)
+    #expect(decoded.admit[1].maxTokens == 128)
+}
+
+@Test func compositionRoundTripEvictOnly() {
+    // A pure decode step: survivors only, nothing admitted.
+    let comp = ClusterBatchComposition(
+        command: .step, bNext: 2, keepIndices: [1, 4], admit: [])
+    let decoded = ClusterBatchComposition.decode(comp.encodeVector())
+    #expect(decoded.keepIndices == [1, 4])
+    #expect(decoded.admit.isEmpty)
+    #expect(decoded.bNext == 2)
+}
+
+@Test func compositionRoundTripAdmitOnly() {
+    // Cold start: no survivors, first batch admitted.
+    let comp = ClusterBatchComposition(
+        command: .step, bNext: 1, keepIndices: [],
+        admit: [ClusterAdmitRow(promptTokens: [1, 2, 3, 4, 5], leftPadding: 0, maxTokens: 32)])
+    let decoded = ClusterBatchComposition.decode(comp.encodeVector())
+    #expect(decoded.keepIndices.isEmpty)
+    #expect(decoded.admit.count == 1)
+    #expect(decoded.admit[0].promptTokens == [1, 2, 3, 4, 5])
+}
+
+@Test func compositionShutdownAndIdle() {
+    let s = ClusterBatchComposition.decode(ClusterBatchComposition.shutdown.encodeVector())
+    #expect(s.command == .shutdown)
+    let i = ClusterBatchComposition.decode(ClusterBatchComposition.idle.encodeVector())
+    #expect(i.command == .idle)
+}
+
+@Test func compositionVectorIsFixedWidth() {
+    // Every encoded vector must be exactly BATCH_CTRL_WIDTH so the ring
+    // all_gather template matches on every rank regardless of composition.
+    let a = ClusterBatchComposition.idle.encodeVector()
+    let b = ClusterBatchComposition(
+        command: .step, bNext: 3, keepIndices: [0, 1],
+        admit: [ClusterAdmitRow(promptTokens: Array(0..<100), leftPadding: 0, maxTokens: 16)]
+    ).encodeVector()
+    #expect(a.count == BATCH_CTRL_WIDTH)
+    #expect(b.count == BATCH_CTRL_WIDTH)
+}
+
+@Test func compositionRaggedAdmitPreservesOrderAndPadding() {
+    // Ragged admit: different prompt lengths + left-paddings must decode back
+    // exactly and in order (row order is load-bearing for cache alignment).
+    let admit = [
+        ClusterAdmitRow(promptTokens: [7, 7], leftPadding: 3, maxTokens: 10),
+        ClusterAdmitRow(promptTokens: [8, 8, 8, 8], leftPadding: 1, maxTokens: 20),
+        ClusterAdmitRow(promptTokens: [9], leftPadding: 0, maxTokens: 30),
+    ]
+    let comp = ClusterBatchComposition(command: .step, bNext: 3, keepIndices: [], admit: admit)
+    let decoded = ClusterBatchComposition.decode(comp.encodeVector())
+    #expect(decoded.admit.count == 3)
+    for i in 0..<3 {
+        #expect(decoded.admit[i].promptTokens == admit[i].promptTokens)
+        #expect(decoded.admit[i].leftPadding == admit[i].leftPadding)
+        #expect(decoded.admit[i].maxTokens == admit[i].maxTokens)
+    }
+}

--- a/provider-swift/Tests/ProviderCoreTests/ClusterCryptoTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/ClusterCryptoTests.swift
@@ -1,0 +1,336 @@
+import CryptoKit
+import Foundation
+import Testing
+
+@testable import ProviderCore
+
+// MARK: - Software signer (stands in for the Secure Enclave on CI / one machine)
+
+/// An `AttestationSigner` backed by a plain in-memory P-256 key. Produces the
+/// same DER ECDSA signatures and 64-byte raw public key the Secure Enclave does,
+/// so handshake/roster logic can be exercised with no SE hardware.
+private struct SoftwareSigner: AttestationSigner {
+    let privateKey: P256.Signing.PrivateKey
+    init() { privateKey = P256.Signing.PrivateKey() }
+    func sign(_ data: Data) throws -> Data {
+        try privateKey.signature(for: data).derRepresentation
+    }
+    var publicKeyBase64: String {
+        privateKey.publicKey.rawRepresentation.base64EncodedString()
+    }
+}
+
+private func iso(_ s: String) -> Date {
+    let f = ISO8601DateFormatter()
+    return f.date(from: s)!
+}
+
+// MARK: - Roster fixtures
+
+private struct ClusterFixture {
+    let coordinator: SoftwareSigner
+    let coordinatorPubB64: String
+    let signerA: SoftwareSigner
+    let signerB: SoftwareSigner
+    let roster: ClusterRosterBody
+    let signedRoster: SignedClusterRoster
+}
+
+private func makeFixture(
+    issuedAt: Date = iso("2026-06-15T00:00:00Z"),
+    expiresAt: Date = iso("2026-06-15T01:00:00Z")
+) throws -> ClusterFixture {
+    let coordinator = SoftwareSigner()
+    let signerA = SoftwareSigner()
+    let signerB = SoftwareSigner()
+
+    let members = [
+        ClusterMember(
+            nodeId: "node-a",
+            sePublicKeyBase64: signerA.publicKeyBase64,
+            x25519PublicKeyBase64: NodeKeyPair.generate().publicKeyBase64,
+            trustLevel: "hardware"),
+        ClusterMember(
+            nodeId: "node-b",
+            sePublicKeyBase64: signerB.publicKeyBase64,
+            x25519PublicKeyBase64: NodeKeyPair.generate().publicKeyBase64,
+            trustLevel: "self_signed"),
+    ]
+    let body = ClusterRosterBody(
+        clusterId: "cluster-1", members: members, issuedAt: issuedAt, expiresAt: expiresAt)
+    let sig = try coordinator.sign(ClusterRoster.canonicalBytes(body)).base64EncodedString()
+    return ClusterFixture(
+        coordinator: coordinator,
+        coordinatorPubB64: coordinator.publicKeyBase64,
+        signerA: signerA, signerB: signerB,
+        roster: body,
+        signedRoster: SignedClusterRoster(body: body, signature: sig))
+}
+
+// MARK: - Roster tests
+
+@Suite("ClusterRoster")
+struct ClusterRosterTests {
+    @Test func verifiesValidRoster() throws {
+        let f = try makeFixture()
+        try ClusterRoster.verify(
+            f.signedRoster,
+            coordinatorPublicKeyBase64: f.coordinatorPubB64,
+            now: iso("2026-06-15T00:30:00Z"))
+    }
+
+    @Test func rejectsTamperedRoster() throws {
+        let f = try makeFixture()
+        var tampered = f.signedRoster.body.members
+        tampered[0] = ClusterMember(
+            nodeId: "node-a", sePublicKeyBase64: tampered[0].sePublicKeyBase64,
+            x25519PublicKeyBase64: tampered[0].x25519PublicKeyBase64, trustLevel: "hardware")
+        // swap in a different cluster id to invalidate the signature
+        let badBody = ClusterRosterBody(
+            clusterId: "cluster-EVIL", members: tampered,
+            issuedAt: f.roster.issuedAt, expiresAt: f.roster.expiresAt)
+        let bad = SignedClusterRoster(body: badBody, signature: f.signedRoster.signature)
+        #expect(throws: ClusterRosterError.signatureInvalid) {
+            try ClusterRoster.verify(bad, coordinatorPublicKeyBase64: f.coordinatorPubB64,
+                                     now: iso("2026-06-15T00:30:00Z"))
+        }
+    }
+
+    @Test func rejectsExpiredRoster() throws {
+        let f = try makeFixture()
+        #expect(throws: ClusterRosterError.expired) {
+            try ClusterRoster.verify(f.signedRoster, coordinatorPublicKeyBase64: f.coordinatorPubB64,
+                                     now: iso("2026-06-15T02:00:00Z"))
+        }
+    }
+
+    @Test func rejectsWrongCoordinatorKey() throws {
+        let f = try makeFixture()
+        let other = SoftwareSigner()
+        #expect(throws: ClusterRosterError.signatureInvalid) {
+            try ClusterRoster.verify(f.signedRoster, coordinatorPublicKeyBase64: other.publicKeyBase64,
+                                     now: iso("2026-06-15T00:30:00Z"))
+        }
+    }
+
+    @Test func minTrustIsWeakestMember() throws {
+        let f = try makeFixture()
+        let weakest = ClusterRoster.minTrustLevel(
+            f.roster, strongestFirst: ["hardware", "self_signed", "none"])
+        #expect(weakest == "self_signed")
+    }
+}
+
+// MARK: - Handshake tests
+
+@Suite("ClusterHandshake")
+struct ClusterHandshakeTests {
+    /// Drive the full 3-message exchange and return both confirmed sessions.
+    private func runHandshake(_ f: ClusterFixture) throws -> (ClusterSession, ClusterSession) {
+        let initiator = ClusterHandshakeInitiator(
+            clusterId: "cluster-1", localNodeId: "node-a",
+            signer: f.signerA, roster: f.roster)
+        let responder = ClusterHandshakeResponder(
+            localNodeId: "node-b", signer: f.signerB, roster: f.roster)
+
+        let m1 = initiator.start()
+        let m2 = try responder.respond(m1)
+        let (m3, sessionA) = try initiator.finish(m2)
+        let sessionB = try responder.confirm(m3)
+        return (sessionA, sessionB)
+    }
+
+    @Test func happyPathDerivesMatchingKeys() throws {
+        let f = try makeFixture()
+        let (a, b) = try runHandshake(f)
+        // A's send key must equal B's recv key, and vice versa.
+        #expect(a.sendKey() == b.recvKey())
+        #expect(b.sendKey() == a.recvKey())
+        // The two directions must differ.
+        #expect(a.sendKey() != a.recvKey())
+    }
+
+    @Test func rejectsForgedResponderSignature() throws {
+        let f = try makeFixture()
+        let initiator = ClusterHandshakeInitiator(
+            clusterId: "cluster-1", localNodeId: "node-a", signer: f.signerA, roster: f.roster)
+        let responder = ClusterHandshakeResponder(
+            localNodeId: "node-b", signer: f.signerB, roster: f.roster)
+        let m1 = initiator.start()
+        var m2 = try responder.respond(m1)
+        // Replace responder signature with one over the wrong bytes.
+        m2 = ClusterHandshakeMsg2(
+            responderNodeId: m2.responderNodeId, ephemeralPublicKey: m2.ephemeralPublicKey,
+            nonce: m2.nonce, signature: try f.signerB.sign(Data("not the transcript".utf8)))
+        #expect(throws: ClusterHandshakeError.peerSignatureInvalid(nodeId: "node-b")) {
+            _ = try initiator.finish(m2)
+        }
+    }
+
+    @Test func rejectsPeerNotInRoster() throws {
+        let f = try makeFixture()
+        // Responder claims to be an id not on the roster.
+        let responder = ClusterHandshakeResponder(
+            localNodeId: "node-ghost", signer: f.signerB, roster: f.roster)
+        let initiator = ClusterHandshakeInitiator(
+            clusterId: "cluster-1", localNodeId: "node-a", signer: f.signerA, roster: f.roster)
+        let m1 = initiator.start()
+        #expect(throws: ClusterRosterError.memberNotFound(nodeId: "node-ghost")) {
+            _ = try responder.respond(m1)
+        }
+    }
+
+    @Test func rejectsImpersonatedInitiatorAtConfirm() throws {
+        let f = try makeFixture()
+        let initiator = ClusterHandshakeInitiator(
+            clusterId: "cluster-1", localNodeId: "node-a", signer: f.signerA, roster: f.roster)
+        let responder = ClusterHandshakeResponder(
+            localNodeId: "node-b", signer: f.signerB, roster: f.roster)
+
+        // Run a real Msg1/Msg2 so the responder stages node-a, then forge Msg3
+        // with an attacker key that is NOT node-a's roster identity. confirm()
+        // must reject it — proving Msg3 authenticates the initiator, not just
+        // that *some* well-formed signature arrived.
+        let m1 = initiator.start()
+        let m2 = try responder.respond(m1)
+        let attacker = SoftwareSigner()
+        let forgedM3 = ClusterHandshakeMsg3(
+            signature: try attacker.sign(Data("any bytes the attacker likes".utf8)))
+        #expect(throws: ClusterHandshakeError.peerSignatureInvalid(nodeId: "node-a")) {
+            _ = try responder.confirm(forgedM3)
+        }
+    }
+}
+
+// MARK: - Layer partition tests
+
+@Suite("LayerPartition")
+struct LayerPartitionTests {
+    private let gb: UInt64 = 1_073_741_824
+
+    @Test func memoryWeightedSplitAcrossTwoLaptops() throws {
+        // 48 layers across 32GB + 24GB ≈ the demo cluster (post-OS-reserve).
+        let p = try LayerPartition.partition(totalLayers: 48, nodes: [
+            .init(nodeId: "mac-32", weightBytes: 28 * gb),
+            .init(nodeId: "mac-24", weightBytes: 20 * gb),
+        ])
+        #expect(p.count == 2)
+        #expect(p[0].start == 0)
+        #expect(p[0].end == p[1].start)   // contiguous
+        #expect(p[1].end == 48)
+        #expect(p.reduce(0) { $0 + $1.count } == 48)
+        #expect(p[0].count > p[1].count)  // bigger node, more layers
+    }
+
+    @Test func evenWeightsSplitEvenly() throws {
+        let p = try LayerPartition.partition(totalLayers: 40, nodes: [
+            .init(nodeId: "a", weightBytes: 16 * gb),
+            .init(nodeId: "b", weightBytes: 16 * gb),
+        ])
+        #expect(p[0].count == 20 && p[1].count == 20)
+    }
+
+    @Test func tinyNodeStillGetsAtLeastOneLayer() throws {
+        let p = try LayerPartition.partition(totalLayers: 10, nodes: [
+            .init(nodeId: "huge", weightBytes: 200 * gb),
+            .init(nodeId: "tiny", weightBytes: 1 * gb),
+        ])
+        #expect(p[1].count >= 1)
+        #expect(p.reduce(0) { $0 + $1.count } == 10)
+    }
+
+    @Test func rejectsMoreNodesThanLayers() throws {
+        #expect(throws: LayerPartitionError.tooManyNodesForLayers(nodes: 2, layers: 1)) {
+            _ = try LayerPartition.partition(totalLayers: 1, nodes: [
+                .init(nodeId: "a", weightBytes: gb), .init(nodeId: "b", weightBytes: gb)])
+        }
+    }
+
+    @Test func rejectsEmptyNodeList() throws {
+        #expect(throws: LayerPartitionError.noNodes) {
+            _ = try LayerPartition.partition(totalLayers: 10, nodes: [])
+        }
+    }
+}
+
+// MARK: - Link cipher tests
+
+@Suite("ClusterLinkCrypto")
+struct ClusterLinkCryptoTests {
+    private func sessionPair() throws -> (ClusterSession, ClusterSession) {
+        let f = try makeFixture()
+        let initiator = ClusterHandshakeInitiator(
+            clusterId: "cluster-1", localNodeId: "node-a", signer: f.signerA, roster: f.roster)
+        let responder = ClusterHandshakeResponder(
+            localNodeId: "node-b", signer: f.signerB, roster: f.roster)
+        let m1 = initiator.start()
+        let m2 = try responder.respond(m1)
+        let (m3, sa) = try initiator.finish(m2)
+        let sb = try responder.confirm(m3)
+        return (sa, sb)
+    }
+
+    @Test func sealOpenRoundTrip() throws {
+        let (a, b) = try sessionPair()
+        let send = ClusterSealingChannel(key: a.sendKey())
+        let recv = ClusterOpeningChannel(key: b.recvKey())
+
+        let activation = Data((0..<8192).map { UInt8($0 & 0xff) })
+        let ctx0 = ClusterFrameContext(clusterId: "cluster-1", requestId: "req-1", layerRange: "0..24", seq: 0)
+        let frame = try send.seal(activation, context: ctx0)
+        let opened = try recv.open(frame, context: ctx0)
+        #expect(opened == activation)
+    }
+
+    @Test func nonceIsMonotonicAcrossFrames() throws {
+        let (a, b) = try sessionPair()
+        let send = ClusterSealingChannel(key: a.sendKey())
+        let recv = ClusterOpeningChannel(key: b.recvKey())
+        for seq in UInt64(0)..<5 {
+            let pt = Data("token-\(seq)".utf8)
+            let ctx = ClusterFrameContext(clusterId: "cluster-1", requestId: "req-1", layerRange: "0..24", seq: seq)
+            let frame = try send.seal(pt, context: ctx)
+            #expect(try recv.open(frame, context: ctx) == pt)
+        }
+    }
+
+    @Test func tamperedAADIsRejected() throws {
+        let (a, b) = try sessionPair()
+        let send = ClusterSealingChannel(key: a.sendKey())
+        let recv = ClusterOpeningChannel(key: b.recvKey())
+        let pt = Data("secret activations".utf8)
+        let sealCtx = ClusterFrameContext(clusterId: "cluster-1", requestId: "req-1", layerRange: "0..24", seq: 0)
+        let frame = try send.seal(pt, context: sealCtx)
+        // Attacker replays into a different request id.
+        let evilCtx = ClusterFrameContext(clusterId: "cluster-1", requestId: "req-EVIL", layerRange: "0..24", seq: 0)
+        #expect(throws: ClusterLinkError.openFailed) {
+            _ = try recv.open(frame, context: evilCtx)
+        }
+    }
+
+    @Test func outOfOrderFrameIsRejected() throws {
+        let (a, b) = try sessionPair()
+        let send = ClusterSealingChannel(key: a.sendKey())
+        let recv = ClusterOpeningChannel(key: b.recvKey())
+        let c0 = ClusterFrameContext(clusterId: "cluster-1", requestId: "r", layerRange: "0..24", seq: 0)
+        let c1 = ClusterFrameContext(clusterId: "cluster-1", requestId: "r", layerRange: "0..24", seq: 1)
+        _ = try send.seal(Data("a".utf8), context: c0)        // advance sender to 1
+        let f1 = try send.seal(Data("b".utf8), context: c1)
+        // Receiver still expects seq 0 → seq-1 frame must be rejected.
+        #expect(throws: ClusterLinkError.openFailed) {
+            _ = try recv.open(f1, context: c1)
+        }
+    }
+
+    @Test func wrongDirectionKeyFailsToOpen() throws {
+        let (a, b) = try sessionPair()
+        // Seal with A→B key, attempt to open with A's recv (B→A) key: must fail.
+        let send = ClusterSealingChannel(key: a.sendKey())
+        let wrong = ClusterOpeningChannel(key: a.recvKey())
+        let ctx = ClusterFrameContext(clusterId: "cluster-1", requestId: "r", layerRange: "0..24", seq: 0)
+        let frame = try send.seal(Data("x".utf8), context: ctx)
+        #expect(throws: ClusterLinkError.openFailed) {
+            _ = try wrong.open(frame, context: ctx)
+        }
+    }
+}

--- a/provider-swift/Tests/ProviderCoreTests/ClusterPlanTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/ClusterPlanTests.swift
@@ -1,0 +1,121 @@
+import Foundation
+import Testing
+
+@testable import ProviderCore
+
+@Suite("ClusterPlan")
+struct ClusterPlanTests {
+    private func settings(
+        enabled: Bool = true,
+        clusterId: String = "c1",
+        nodeId: String,
+        members: [(String, String)],
+        backend: String = "ring"
+    ) -> ClusterSettings {
+        ClusterSettings(
+            enabled: enabled, clusterId: clusterId, nodeId: nodeId,
+            members: members.map { ClusterMemberSettings(nodeId: $0.0, address: $0.1) },
+            backend: backend)
+    }
+
+    @Test func resolvesRankAndNeighbors() throws {
+        let plan = try ClusterPlan.resolve(settings(
+            nodeId: "mac-24",
+            members: [("mac-32", "10.0.0.1"), ("mac-24", "10.0.0.2")]))
+        #expect(plan.rank == 1)
+        #expect(plan.worldSize == 2)
+        #expect(plan.isTail)
+        #expect(!plan.isHead)
+        #expect(plan.prevRank == 0)
+        #expect(plan.nextRank == nil)
+        let (prev, next) = plan.neighborNodeIds()
+        #expect(prev == "mac-32")
+        #expect(next == nil)
+    }
+
+    @Test func headIsRankZero() throws {
+        let plan = try ClusterPlan.resolve(settings(
+            nodeId: "mac-32",
+            members: [("mac-32", "10.0.0.1"), ("mac-24", "10.0.0.2")]))
+        #expect(plan.rank == 0)
+        #expect(plan.isHead)
+        #expect(plan.prevRank == nil)
+        #expect(plan.nextRank == 1)
+    }
+
+    @Test func mlxRingEnvironmentIsRankOrdered() throws {
+        let plan = try ClusterPlan.resolve(settings(
+            nodeId: "mac-24",
+            members: [("mac-32", "10.0.0.1"), ("mac-24", "10.0.0.2")]))
+        let env = plan.mlxRingEnvironment()
+        #expect(env["MLX_HOSTLIST"] == "10.0.0.1,10.0.0.2")
+        #expect(env["MLX_RANK"] == "1")
+        #expect(env["MLX_WORLD_SIZE"] == "2")
+    }
+
+    @Test func layerPlanForwardsToPartition() throws {
+        let plan = try ClusterPlan.resolve(settings(
+            nodeId: "mac-32",
+            members: [("mac-32", "10.0.0.1"), ("mac-24", "10.0.0.2")]))
+        let intervals = try plan.layerPlan(totalLayers: 48, memoryBytesByNodeId: [
+            "mac-32": 28 << 30, "mac-24": 20 << 30,
+        ])
+        #expect(intervals.count == 2)
+        #expect(intervals.reduce(0) { $0 + $1.count } == 48)
+        #expect(intervals[0].count > intervals[1].count)  // bigger node, more layers
+    }
+
+    @Test func rejectsSelfNotInMembers() throws {
+        #expect(throws: ClusterPlanError.selfNotInMembers(nodeId: "ghost")) {
+            _ = try ClusterPlan.resolve(settings(
+                nodeId: "ghost",
+                members: [("mac-32", "10.0.0.1"), ("mac-24", "10.0.0.2")]))
+        }
+    }
+
+    @Test func rejectsSingleMember() throws {
+        #expect(throws: ClusterPlanError.singleMember) {
+            _ = try ClusterPlan.resolve(settings(
+                nodeId: "mac-32", members: [("mac-32", "10.0.0.1")]))
+        }
+    }
+
+    @Test func rejectsDuplicateNodeId() throws {
+        #expect(throws: ClusterPlanError.duplicateNodeId("dup")) {
+            _ = try ClusterPlan.resolve(settings(
+                nodeId: "dup",
+                members: [("dup", "10.0.0.1"), ("dup", "10.0.0.2")]))
+        }
+    }
+
+    @Test func rejectsUnsupportedBackend() throws {
+        #expect(throws: ClusterPlanError.unsupportedBackend("infiniband")) {
+            _ = try ClusterPlan.resolve(settings(
+                nodeId: "mac-32",
+                members: [("mac-32", "10.0.0.1"), ("mac-24", "10.0.0.2")],
+                backend: "infiniband"))
+        }
+    }
+
+    @Test func disabledThrows() throws {
+        #expect(throws: ClusterPlanError.disabled) {
+            _ = try ClusterPlan.resolve(settings(
+                enabled: false, nodeId: "mac-32",
+                members: [("mac-32", "10.0.0.1"), ("mac-24", "10.0.0.2")]))
+        }
+    }
+
+    @Test func configRoundTripsClusterSection() throws {
+        // The [cluster] section must survive JSON encode/decode (config I/O).
+        let cfg = ProviderConfig(
+            provider: ProviderSettings(name: "n"),
+            cluster: settings(nodeId: "mac-32",
+                              members: [("mac-32", "10.0.0.1"), ("mac-24", "10.0.0.2")]))
+        let data = try JSONEncoder().encode(cfg)
+        let back = try JSONDecoder().decode(ProviderConfig.self, from: data)
+        #expect(back.cluster?.enabled == true)
+        #expect(back.cluster?.clusterId == "c1")
+        #expect(back.cluster?.members.count == 2)
+        #expect(back.cluster?.members[1].address == "10.0.0.2")
+    }
+}

--- a/provider-swift/Tests/ProviderCoreTests/DistributedEngineTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/DistributedEngineTests.swift
@@ -1,0 +1,148 @@
+import CryptoKit
+import Foundation
+import MLX
+import MLXLMCommon
+import Testing
+
+@testable import ProviderCore
+
+/// End-to-end on one machine: the bring-up handshake over the in-memory channel,
+/// MLX ring hostfile shape, and a full 2-rank `DistributedInferenceEngine`
+/// decode over the loopback runtime. The only stubbed pieces are the model-bound
+/// shard internals (a deterministic mock) and the real MLX ring (loopback).
+@Suite("DistributedEngine")
+struct DistributedEngineTests {
+
+    private struct SoftSigner: AttestationSigner {
+        let pk = P256.Signing.PrivateKey()
+        func sign(_ d: Data) throws -> Data { try pk.signature(for: d).derRepresentation }
+        var publicKeyBase64: String { pk.publicKey.rawRepresentation.base64EncodedString() }
+    }
+
+    private func roster(_ a: SoftSigner, _ b: SoftSigner) -> ClusterRosterBody {
+        ClusterRosterBody(
+            clusterId: "c1",
+            members: [
+                ClusterMember(nodeId: "node-a", sePublicKeyBase64: a.publicKeyBase64,
+                              x25519PublicKeyBase64: NodeKeyPair.generate().publicKeyBase64, trustLevel: "hardware"),
+                ClusterMember(nodeId: "node-b", sePublicKeyBase64: b.publicKeyBase64,
+                              x25519PublicKeyBase64: NodeKeyPair.generate().publicKeyBase64, trustLevel: "hardware"),
+            ],
+            issuedAt: Date(timeIntervalSince1970: 0),
+            expiresAt: Date(timeIntervalSince1970: 1e12))
+    }
+
+    @Test func bringupHandshakeOverInMemoryChannel() async throws {
+        let a = SoftSigner(); let b = SoftSigner()
+        let r = roster(a, b)
+        let pair = InMemoryHandshakeChannelPair()
+        async let sa = ClusterHandshakeRunner.runInitiator(
+            clusterId: "c1", localNodeId: "node-a", signer: a, roster: r, channel: pair.a)
+        async let sb = ClusterHandshakeRunner.runResponder(
+            localNodeId: "node-b", signer: b, roster: r, channel: pair.b)
+        let sessionA = try await sa
+        let sessionB = try await sb
+        #expect(sessionA.sendKey() == sessionB.recvKey())
+        #expect(sessionB.sendKey() == sessionA.recvKey())
+    }
+
+    @Test func mlxRingHostfileShape() throws {
+        let plan = try ClusterPlan.resolve(ClusterSettings(
+            enabled: true, clusterId: "c1", nodeId: "node-a",
+            members: [
+                ClusterMemberSettings(nodeId: "node-a", address: "10.0.0.1"),
+                ClusterMemberSettings(nodeId: "node-b", address: "10.0.0.2:6000"),
+            ]))
+        let json = try MLXRingEnvironment.hostfileJSON(plan)
+        let parsed = try JSONSerialization.jsonObject(with: json) as! [[String]]
+        #expect(parsed.count == 2)
+        #expect(parsed[0] == ["10.0.0.1:5680"])
+        #expect(parsed[1] == ["10.0.0.2:6000"])
+    }
+
+    // Deterministic mock shard: hidden state is [1, vocab]; embed seeds it by the
+    // running length so argmax advances each step; layers are identity; tail
+    // projects the (already vocab-shaped) hidden state to logits.
+    private struct MockShard: PipelineModelShard {
+        let totalLayers: Int
+        let ownedInterval: LayerInterval
+        let vocab: Int
+        func embed(tokens: [Int]) -> MLXArray {
+            MLXArray(converting: (0..<vocab).map { i in
+                i == (tokens.count % vocab) ? 10.0 : 0.0   // argmax = running length mod vocab
+            }, [1, vocab])
+        }
+        func runOwnedLayers(_ hidden: MLXArray) -> MLXArray { hidden }
+        func projectToLogits(_ hidden: MLXArray) -> MLXArray { hidden }
+    }
+
+    private struct StubTokenizer: Tokenizer {
+        func encode(text: String, addSpecialTokens: Bool) -> [Int] { Array(text.utf8).map(Int.init) }
+        func decode(tokenIds: [Int], skipSpecialTokens: Bool) -> String { "t\(tokenIds.first ?? -1) " }
+        func convertTokenToId(_ token: String) -> Int? { nil }
+        func convertIdToToken(_ id: Int) -> String? { nil }
+        var bosToken: String? { nil }
+        var eosToken: String? { nil }
+        var unknownToken: String? { nil }
+        func applyChatTemplate(messages: [[String: any Sendable]], tools: [[String: any Sendable]]?, additionalContext: [String: any Sendable]?) throws -> [Int] { [1, 2, 3] }
+        func applyChatTemplate(messages: [[String: any Sendable]], chatTemplate: String) throws -> [Int] { [1, 2, 3] }
+        func applyChatTemplate(messages: [[String: any Sendable]], chatTemplate: String, tools: [[String: any Sendable]]?, additionalContext: [String: any Sendable]?) throws -> [Int] { [1, 2, 3] }
+    }
+
+    @Test func twoRankEngineStreamsTokens() async throws {
+        let a = SoftSigner(); let b = SoftSigner()
+        let r = roster(a, b)
+
+        // Sessions via the handshake.
+        let pair = InMemoryHandshakeChannelPair()
+        async let sa = ClusterHandshakeRunner.runInitiator(
+            clusterId: "c1", localNodeId: "node-a", signer: a, roster: r, channel: pair.a)
+        async let sb = ClusterHandshakeRunner.runResponder(
+            localNodeId: "node-b", signer: b, roster: r, channel: pair.b)
+        let sessionA = try await sa
+        let sessionB = try await sb
+
+        let planA = try ClusterPlan.resolve(ClusterSettings(
+            enabled: true, clusterId: "c1", nodeId: "node-a",
+            members: [ClusterMemberSettings(nodeId: "node-a", address: "10.0.0.1"),
+                      ClusterMemberSettings(nodeId: "node-b", address: "10.0.0.2")]))
+        let planB = try ClusterPlan.resolve(ClusterSettings(
+            enabled: true, clusterId: "c1", nodeId: "node-b",
+            members: [ClusterMemberSettings(nodeId: "node-a", address: "10.0.0.1"),
+                      ClusterMemberSettings(nodeId: "node-b", address: "10.0.0.2")]))
+
+        // Shared loopback fabric for both ranks.
+        let mailbox = LoopbackMailbox()
+        let tokenBus = LoopbackTokenBus()
+        let vocab = 8
+        let runtimeA = LoopbackClusterRuntime(
+            plan: planA, mailbox: mailbox, tokenBus: tokenBus,
+            sendSession: sessionA, recvSession: nil)
+        let runtimeB = LoopbackClusterRuntime(
+            plan: planB, mailbox: mailbox, tokenBus: tokenBus,
+            sendSession: nil, recvSession: sessionB)
+
+        let engineA = DistributedInferenceEngine(plan: planA, runtime: runtimeA)
+        let engineB = DistributedInferenceEngine(plan: planB, runtime: runtimeB)
+        await engineA.installShard(
+            MockShard(totalLayers: 4, ownedInterval: LayerInterval(nodeId: "node-a", start: 0, end: 2), vocab: vocab),
+            tokenizer: StubTokenizer(), modelId: "mock", eosTokenIds: [])
+        await engineB.installShard(
+            MockShard(totalLayers: 4, ownedInterval: LayerInterval(nodeId: "node-b", start: 2, end: 4), vocab: vocab),
+            tokenizer: StubTokenizer(), modelId: "mock", eosTokenIds: [])
+
+        let req = ChatCompletionRequest(model: "mock", messages: [ChatMessage(role: "user", content: "hi")], max_tokens: 3)
+
+        // Run both ranks; collect the tail's streamed chunks.
+        async let aStream: Void = { for await _ in await engineA.submit(request: req, requestId: "r1") {} }()
+        var chunks: [String] = []
+        for await ev in await engineB.submit(request: req, requestId: "r1") {
+            if case .chunk(let s) = ev { chunks.append(s) }
+        }
+        await aStream
+
+        // The tail streamed exactly max_tokens chunks (greedy, deterministic).
+        #expect(chunks.count == 3)
+        #expect(chunks.allSatisfy { $0.hasPrefix("t") })
+    }
+}

--- a/provider-swift/Tests/ProviderCoreTests/PipelineForwardPassTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/PipelineForwardPassTests.swift
@@ -1,0 +1,99 @@
+import CryptoKit
+import Foundation
+import MLX
+import Testing
+
+@testable import ProviderCore
+
+/// End-to-end verification of the encrypted pipeline forward pass, runnable on
+/// ONE machine: two ranks run in-process over a loopback transport, and the
+/// distributed result must equal running every layer on a single rank.
+///
+/// The MLX ops here run on CPU and are deliberately trivial — the point is to
+/// prove the PLUMBING (embed → layers → encode → AEAD-seal → transport → open →
+/// decode → layers → logits) is correct and lossless, and that a tampered frame
+/// is rejected. The real two-Mac ring (MLXDistributed) is Spike A on hardware.
+@Suite("PipelineForwardPass")
+struct PipelineForwardPassTests {
+
+    private struct SoftSigner: AttestationSigner {
+        let pk = P256.Signing.PrivateKey()
+        func sign(_ d: Data) throws -> Data { try pk.signature(for: d).derRepresentation }
+        var publicKeyBase64: String { pk.publicKey.rawRepresentation.base64EncodedString() }
+    }
+
+    private func sessions() throws -> (ClusterSession, ClusterSession) {
+        let a = SoftSigner(); let b = SoftSigner()
+        let members = [
+            ClusterMember(nodeId: "node-a", sePublicKeyBase64: a.publicKeyBase64,
+                          x25519PublicKeyBase64: NodeKeyPair.generate().publicKeyBase64, trustLevel: "hardware"),
+            ClusterMember(nodeId: "node-b", sePublicKeyBase64: b.publicKeyBase64,
+                          x25519PublicKeyBase64: NodeKeyPair.generate().publicKeyBase64, trustLevel: "hardware"),
+        ]
+        let body = ClusterRosterBody(clusterId: "c1", members: members,
+                                     issuedAt: Date(timeIntervalSince1970: 0),
+                                     expiresAt: Date(timeIntervalSince1970: 1e12))
+        let ini = ClusterHandshakeInitiator(clusterId: "c1", localNodeId: "node-a", signer: a, roster: body)
+        let res = ClusterHandshakeResponder(localNodeId: "node-b", signer: b, roster: body)
+        let m1 = ini.start(); let m2 = try res.respond(m1); let (m3, sa) = try ini.finish(m2)
+        let sb = try res.confirm(m3)
+        return (sa, sb)
+    }
+
+    // Per-rank stand-in transforms + their monolithic composition.
+    private func layers0(_ h: MLXArray) -> MLXArray { h * 2.0 + 1.0 }
+    private func layers1(_ h: MLXArray) -> MLXArray { h * 3.0 }
+
+    @Test func activationCodecRoundTrip() throws {
+        let x = MLXArray(converting: (0..<24).map { Double($0) * 0.5 - 3.0 }, [2, 3, 4]).asType(DType.float16)
+        let y = try ActivationCodec.decode(try ActivationCodec.encode(x))
+        #expect(y.shape == [2, 3, 4])
+        #expect(y.dtype == DType.float16)
+        let dx = x.asType(DType.float32).asArray(Float.self)
+        let dy = y.asType(DType.float32).asArray(Float.self)
+        #expect(zip(dx, dy).allSatisfy { abs($0 - $1) < 1e-3 })
+    }
+
+    @Test func twoRankEncryptedPipelineEqualsMonolithic() async throws {
+        let (sa, sb) = try sessions()
+        let plan = try LayerPartition.partition(totalLayers: 48, nodes: [
+            .init(nodeId: "node-a", weightBytes: 28 << 30),
+            .init(nodeId: "node-b", weightBytes: 20 << 30),
+        ])
+
+        let mailbox = LoopbackMailbox()
+        let stage0 = PipelineStage(
+            config: .init(rank: 0, worldSize: 2, interval: plan[0], prevRank: nil, nextRank: 1),
+            transport: LoopbackPipelineTransport(mailbox: mailbox, selfRank: 0),
+            sealing: ClusterSealingChannel(key: sa.sendKey()), opening: nil)
+        let stage1 = PipelineStage(
+            config: .init(rank: 1, worldSize: 2, interval: plan[1], prevRank: 0, nextRank: nil),
+            transport: LoopbackPipelineTransport(mailbox: mailbox, selfRank: 1),
+            sealing: nil, opening: ClusterOpeningChannel(key: sb.recvKey()))
+
+        let input = MLXArray(converting: (0..<12).map { Double($0) - 6.0 }, [1, 12])
+
+        async let r0: MLXArray? = stage0.runStep(
+            headInput: input, clusterId: "c1", requestId: "req-1", seq: 0, runLayers: layers0)
+        async let r1: MLXArray? = stage1.runStep(
+            headInput: nil, clusterId: "c1", requestId: "req-1", seq: 0, runLayers: layers1)
+        let head = try await r0
+        let tail = try await r1
+
+        #expect(head == nil)                 // head sent its output downstream
+        let got = try #require(tail).asArray(Float.self)
+        let want = layers1(layers0(input)).asArray(Float.self)
+        #expect(zip(got, want).allSatisfy { abs($0 - $1) < 1e-4 })
+    }
+
+    @Test func tamperedFrameRejected() throws {
+        let (sa, sb) = try sessions()
+        let seal0 = ClusterSealingChannel(key: sa.sendKey())
+        let open1 = ClusterOpeningChannel(key: sb.recvKey())
+        let ctx = ClusterFrameContext(clusterId: "c1", requestId: "r", layerRange: "0..28", seq: 0)
+        let frame = try seal0.seal(
+            ActivationCodec.encode(MLXArray(converting: [1.0, 2.0, 3.0]).asType(DType.float32)), context: ctx)
+        var tampered = frame; tampered[tampered.count - 1] ^= 0x01
+        #expect(throws: (any Error).self) { _ = try open1.open(tampered, context: ctx) }
+    }
+}


### PR DESCRIPTION
## Summary

Adds **multi-device clustering** so a co-located, individually-attested Apple
Silicon cluster serves as **one logical provider**, splitting a model layer-wise
across nodes over an **encrypted MLX ring** — without breaking Darkbloom's
operator-blind guarantee. This unlocks models too large for any single Mac
(e.g. Gemma-4-26B, GPT-OSS-120B) by pooling the cluster's combined unified memory.

Two commits:
1. **Pipeline-parallel cluster** — the full clustering stack (trust, transport, decode, batching).
2. **Gemma 4 support** — wires the Gemma 4 shard into the cluster.

Depends on the fork submodules: Layr-Labs/mlx#2 (ring backend), Layr-Labs/mlx-swift#8
(enable ring), Layr-Labs/mlx-swift-lm#53 (GPT-OSS/Gemma-4 pipeline shards).

## Architecture

```
consumer ─(E2E)→ COORDINATOR ─(WS, head only)→ HEAD ─(encrypted ring)→ PEERS
                  sees ONE provider               serves + streams      own layer slice
```

- **Only the head** connects to the coordinator; it registers as a single provider
  (the coordinator's `Provider == one socket` model is preserved). Peers join only
  the ring and loop in lockstep via a per-request control-round `all_gather`.
- **Layer split** is memory-weighted (each node ∝ usable RAM), largest-remainder.
- **Activations are encrypted per hop**: X25519 key agreement over the ring +
  per-token ChaCha20-Poly1305, AAD-bound to cluster/request/layer/seq. A tap on
  the wire sees only ciphertext, with forward secrecy.

Core modules (`provider-swift/Sources/ProviderCore/Cluster/`): `ClusterRoster`,
`ClusterHandshake`, `ClusterLinkCrypto`, `LayerPartition`, `ClusterPlan`,
`MLXDistributed`, `ActivationCodec`, `ClusterPipeline`, `ClusterServer`,
`DistributedInferenceEngine`, `PipelineModelShard` + GPT-OSS/Gemma-4 adapters,
and the `ClusterBatch*` continuous-batching path.

## Trust & Attestation

The privacy guarantee rests on decrypting only inside attested hardware. The cluster
extends single-node attestation to every node:
- Each member's **Secure Enclave** signs its attestation blob; the head relays them;
  the coordinator verifies each and sets **cluster trust = min(member trust)**.
- The coordinator signs a `ClusterRoster`; nodes verify it before forming pairwise
  `ClusterHandshake` links (so they only ring with coordinator-authorized peers).

**Honest gaps (not yet closed — flagged for review):**
- Per-member attestation gather is **opt-in** (`DARKBLOOM_CLUSTER_ATTEST=1`), off by
  default; with it off the coordinator attests the head and peers are trusted
  transitively.
- Relayed peers cap at `self_signed` (no per-peer MDM/MDA over their own link).
- No per-member challenge/nonce freshness yet (member-blob replay window).
- A dedicated coordinator-adjacent **Cluster Attestation Service** (per-node enroll +
  roster issuance) is the proposed path to close these without disturbing the
  one-provider-per-socket serving model.

## Performance (measured, batch=1, Thunderbolt)

Clustering's value is **fitting models that don't fit one node**, not speeding up
ones that do (pipeline runs GPUs sequentially at batch=1 — see
`docs/cluster-benchmark.md`). Continuous batching recovers ~2.5× aggregate
throughput. TP/EP analysis + the TP comms floor are documented in
`docs/architecture/cluster-tensor-expert-parallel.md`.

## Validation

- **Crypto/planning**: `ClusterCryptoTests` (roster, handshake, link cipher, split).
- **Sharding correctness**: monolithic-vs-shard logit oracles at **0.0000 diff** for
  GPT-OSS and Gemma 4.
- **Real hardware**: GPT-OSS-20B and **Gemma-4-26B-A4B-it-qat-4bit** each sharded
  across two Macs over Thunderbolt (encrypted ring, coherent generation, ~28 tok/s).

## Robustness

An orphaned peer used to busy-spin its control loop on a dead ring (pegging a CPU
core indefinitely); it now backs off exponentially and exits.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/473"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785092574&installation_id=133247490&pr_number=473&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F473&signature=31c5ce5384ba29cba81250ae06e4d4ad02dbc81168e98074fa863fc148185c69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
