### PR TITLE
release(provider): v0.6.23 — MLX 0.32.0 (M5 NAX) + thread-stream crash fix + B1 (cache-deferred)

### DIFF
--- a/coordinator/api/server.go
+++ b/coordinator/api/server.go
@@ -145,7 +145,7 @@ func keyLimitResetFromContext(ctx context.Context) string {
 // 0.6.0 is the APNs code-identity / VLM-routing / graceful-update release.
 // Keep this fallback in sync with ProviderCore.version so dev/in-memory
 // coordinators advertise the same floor as the Swift binary they expect.
-var LatestProviderVersion = "0.6.11"
+var LatestProviderVersion = "0.6.23"
 
 // minProviderVersionForDesiredModels is the first provider version whose Swift
 // runtime understands the desired_models message. The coordinator must NOT send

--- a/provider-swift/Sources/ProviderCore/Inference/BatchScheduler+B1FastPath.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/BatchScheduler+B1FastPath.swift
@@ -97,6 +97,11 @@ extension BatchScheduler {
             maxTokens: maxTokens,
             maxContextLength: maxContextLength,
             cacheScope: cacheScope,
+            // Prefix/checkpoint cache active for this model (checkpoint tier for
+            // Gemma-4/GPT-OSS, engine tier for pure-attention models). When on, an
+            // unscoped request must stay on the engine so cache stores/hits keep
+            // working — the fast path bypasses planRestoredCheckpoint/capture.
+            prefixCacheEnabled: checkpointManager != nil || enginePrefixCacheActive,
             activeBridgeCount: activeBridges.count,
             pendingRequestCount: pendingRequestCount,
             fastPathActive: !fastPathTasks.isEmpty,
@@ -120,6 +125,7 @@ extension BatchScheduler {
         maxTokens: Int,
         maxContextLength: Int,
         cacheScope: String,
+        prefixCacheEnabled: Bool,
         activeBridgeCount: Int,
         pendingRequestCount: Int,
         fastPathActive: Bool,
@@ -168,6 +174,15 @@ extension BatchScheduler {
         // fresh cache and does not participate in the checkpoint / engine prefix
         // tiers, so a scoped request keeps the engine path to retain cache reuse.
         guard cacheScope.isEmpty else { return false }
+        // Prefix/checkpoint cache enabled: even an UNSCOPED greedy request would
+        // normally populate/hit the checkpoint (or engine-tier) prefix cache via
+        // `planRestoredCheckpoint` / `finalizeRestore` + the engine capture hooks.
+        // The fast path bypasses all of that (cold prefill on a fresh cache), so
+        // when a prefix cache is active (the provider default) we defer to the
+        // engine — otherwise default-on would silently stop populating/serving the
+        // cache for the common unscoped path (and break the HybridCheckpoint
+        // live tests that assert stores/hits).
+        guard !prefixCacheEnabled else { return false }
         // Exclusive: no other in-flight or queued work. Concurrent batched work
         // would defeat the single-row assumption (shared GPU + KV headroom).
         guard activeBridgeCount == 0 else { return false }
@@ -337,6 +352,9 @@ extension BatchScheduler {
     /// task self-removes; callers that also clear `fastPathTasks` (e.g.
     /// `stopCurrentEngine`) make late `clearFastPathTask` calls harmless no-ops.
     func cancelAllFastPathTasks() {
+        // Defensive: also drop any in-progress admission fence (a `submitTokenized`
+        // suspended at its KV-reserve await). Its own exit will also clear this.
+        fastPathAdmitting = false
         for task in fastPathTasks.values { task.cancel() }
     }
 
@@ -357,6 +375,11 @@ extension BatchScheduler {
     /// nil'd `engine` (every submit path short-circuits on a nil engine).
     /// Idempotent: a no-op when nothing is in flight.
     func waitForFastPathTasks() async {
+        // Clear the admission fence first (before the early-return guard) so a
+        // `submitTokenized` suspended mid-admission can't leave it stuck set after
+        // teardown. `stopCurrentEngine` has already nil'd `engine`, so no new fast
+        // path can begin.
+        fastPathAdmitting = false
         let inflight = Array(fastPathTasks.values)
         guard !inflight.isEmpty else { return }
         for task in inflight { task.cancel() }

--- a/provider-swift/Sources/ProviderCore/Inference/BatchScheduler+B1FastPath.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/BatchScheduler+B1FastPath.swift
@@ -19,7 +19,8 @@
 // `GenerationEvent` stream.
 //
 // Safety posture:
-//   * OFF by default; opt in with an env flag.
+//   * ON by default; opt OUT with an env flag (`DARKBLOOM_B1_GREEDY_FAST_PATH=0`
+//     or `DARKBLOOM_GEMMA_B1_FAST_PATH=0`).
 //   * Conservative gate — anything that isn't a single exclusive greedy text
 //     request falls back to the batched engine, so the engine path's behavior
 //     is never altered.
@@ -38,15 +39,27 @@ extension BatchScheduler {
 
     // MARK: - Env gate
 
-    /// True when the operator opted into the B=1 greedy fast path. Two flags are
-    /// accepted: `DARKBLOOM_B1_GREEDY_FAST_PATH` (generic) and
-    /// `DARKBLOOM_GEMMA_B1_FAST_PATH` (Gemma-targeted alias). Either set to `"1"`
-    /// enables it. Read per-call (cheap) so tests can toggle it via the
-    /// environment without restarting the scheduler.
+    /// Whether the B=1 greedy fast path is enabled. **Default ON.** Two flags are
+    /// accepted as an opt-OUT: `DARKBLOOM_B1_GREEDY_FAST_PATH` (generic) and
+    /// `DARKBLOOM_GEMMA_B1_FAST_PATH` (Gemma-targeted alias). Set EITHER to
+    /// `"0"`/`"false"`/`"no"`/`"off"` to disable; any other (or absent) value
+    /// keeps it on. Read per-call (cheap) so tests / operators can toggle it via
+    /// the environment without restarting the scheduler.
+    ///
+    /// (Still only ENGAGES for requests that pass every conservative eligibility
+    /// gate in `b1FastPathEligiblePure` — Gemma-family, greedy, no KV quant, no
+    /// tools, in-context, single exclusive in-flight request. Anything else
+    /// defers to the batched engine regardless of this flag.)
     static func b1GreedyFastPathEnabled() -> Bool {
         let env = ProcessInfo.processInfo.environment
-        return env["DARKBLOOM_B1_GREEDY_FAST_PATH"] == "1"
-            || env["DARKBLOOM_GEMMA_B1_FAST_PATH"] == "1"
+        let off: Set<String> = ["0", "false", "no", "off"]
+        if let v = env["DARKBLOOM_B1_GREEDY_FAST_PATH"], off.contains(v.lowercased()) {
+            return false
+        }
+        if let v = env["DARKBLOOM_GEMMA_B1_FAST_PATH"], off.contains(v.lowercased()) {
+            return false
+        }
+        return true
     }
 
     // MARK: - Eligibility

--- a/provider-swift/Sources/ProviderCore/Inference/BatchScheduler+Submit.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/BatchScheduler+Submit.swift
@@ -50,7 +50,7 @@ extension BatchScheduler {
         seed: UInt64? = nil,
         requestId: String? = nil,
         cacheScope: String = "",
-        allowFastPath: Bool = true
+        allowFastPath: Bool = false
     ) async -> AsyncStream<GenerationEvent> {
         let id = requestId ?? "req-\(UUID().uuidString.prefix(12))"
         let (stream, continuation) = AsyncStream<GenerationEvent>.makeStream()
@@ -104,14 +104,21 @@ extension BatchScheduler {
             cacheScope: cacheScope,
             allowFastPath: allowFastPath
         )
+        // Fence the fast-path admission window the instant we decide to take it
+        // (Codex P1): set BEFORE the bridge insert + KV-reserve await below, and
+        // before `runGreedyFastPath` populates `fastPathTasks`, so a concurrent
+        // request arriving during that await can't slip onto the engine path and
+        // run alongside the fast path. Cleared on every fast-path exit below.
+        if useFastPath { fastPathAdmitting = true }
         // Concurrency gate: never run the batched engine concurrently with an
-        // in-flight B=1 fast-path task. The fast path assumes it is the sole GPU /
-        // KV consumer (single-row), so a request that is NOT itself taking the
-        // fast path while one is active is rejected with a retryable signal
-        // (`token_budget_exhausted` ⇒ 503 upstream) so it reroutes / retries
-        // rather than overlapping. Inert when the fast path is OFF (the default):
-        // `fastPathTasks` is then always empty, so the engine path is unchanged.
-        if !useFastPath && !fastPathTasks.isEmpty {
+        // in-flight (or just-admitting) B=1 fast path. The fast path assumes it is
+        // the sole GPU / KV consumer (single-row), so a request that is NOT itself
+        // taking the fast path while one is active/admitting is rejected with a
+        // retryable signal (`token_budget_exhausted` ⇒ 503 upstream) so it
+        // reroutes / retries rather than overlapping. Inert when the fast path is
+        // OFF: `fastPathTasks` is empty and `fastPathAdmitting` stays false, so the
+        // engine path is unchanged.
+        if !useFastPath && (!fastPathTasks.isEmpty || fastPathAdmitting) {
             noteAdmissionReject()
             continuation.yield(.error(
                 "token_budget_exhausted: a single-request fast path is active; retry shortly"))
@@ -137,6 +144,8 @@ extension BatchScheduler {
                 restorePlanned: false
             )
             guard kvOutcome != .failed else {
+                // Fast-path exit: clear the admission fence (no task was launched).
+                fastPathAdmitting = false
                 await dropBridge(requestId: id)
                 noteAdmissionReject()
                 continuation.yield(.error(
@@ -149,6 +158,8 @@ extension BatchScheduler {
             // releaseRequestResources (not bare dropBridge) so the reservation
             // made above is not leaked if a cancel dropped the bridge meanwhile.
             guard engineStillCurrent(submitEpoch, engine), let container = self.modelContainer else {
+                // Fast-path exit: clear the admission fence (no task was launched).
+                fastPathAdmitting = false
                 await releaseRequestResources(id)
                 continuation.yield(.error("model reloaded during submit; please retry"))
                 continuation.finish()
@@ -161,6 +172,9 @@ extension BatchScheduler {
                 maxTokens: maxTokens,
                 continuation: continuation
             )
+            // The task is now tracked in `fastPathTasks`, which the concurrency
+            // gates check — hand the fence off to it and clear the admitting flag.
+            fastPathAdmitting = false
             let scheduler = self
             continuation.onTermination = { @Sendable termination in
                 if case .cancelled = termination {
@@ -296,11 +310,11 @@ extension BatchScheduler {
         let submitEpoch = generationEpoch
 
         // Concurrency gate (see submitTokenized): this ChatCompletionRequest path
-        // always uses the batched engine, which must not overlap an in-flight B=1
-        // fast-path task. Reject with a retryable signal while one is active.
-        // Inert when the fast path is OFF (`fastPathTasks` always empty), so the
-        // engine path is unchanged by default.
-        if !fastPathTasks.isEmpty {
+        // always uses the batched engine, which must not overlap an in-flight or
+        // just-admitting B=1 fast path. Reject with a retryable signal while one is
+        // active/admitting. Inert when the fast path is OFF (`fastPathTasks` empty
+        // and `fastPathAdmitting` false), so the engine path is unchanged.
+        if !fastPathTasks.isEmpty || fastPathAdmitting {
             noteAdmissionReject()
             continuation.yield(.error(
                 "token_budget_exhausted: a single-request fast path is active; retry shortly"))

--- a/provider-swift/Sources/ProviderCore/Inference/BatchScheduler.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/BatchScheduler.swift
@@ -270,6 +270,18 @@ public actor BatchScheduler {
     /// completion via `clearFastPathTask`.
     var fastPathTasks: [String: Task<Void, Never>] = [:]
 
+    /// Synchronous fence for the fast-path *admission* window. `submitTokenized`
+    /// sets this `true` the instant it decides to take the fast path — BEFORE its
+    /// first `await` (the KV reservation) and BEFORE `runGreedyFastPath` populates
+    /// `fastPathTasks`. Without it there is a reentrant hole: a concurrent request
+    /// arriving during that await sees `fastPathTasks.isEmpty`, takes the engine
+    /// path, and then runs alongside the fast path once it launches — violating the
+    /// single-exclusive assumption (OOM / mis-scheduling). Both engine concurrency
+    /// gates reject non-fast-path requests while this is set. It is cleared on
+    /// EVERY fast-path exit (KV-reserve failure, engine-superseded, or successful
+    /// launch where `fastPathTasks` takes over) and defensively on teardown.
+    var fastPathAdmitting: Bool = false
+
     /// Test-only override for the B=1 fast-path enablement gate. `nil` (the
     /// production default) defers to the env flags via `b1GreedyFastPathEnabled()`.
     /// Set via `_setForceB1FastPathForTest` so a benchmark can A/B the fast path

--- a/provider-swift/Sources/ProviderCore/ProviderCore.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderCore.swift
@@ -75,5 +75,5 @@ public enum ProviderCore {
     // jinja_null_bridge / jinja_template / model_load), so durable telemetry can
     // tell the two indistinguishable gpt-oss 500 modes apart. Wire-compatible:
     // `error_reason` is an optional inference-error field, omitted when nil.
-    public static let version = "0.6.17"
+    public static let version = "0.6.23"
 }

--- a/provider-swift/Tests/ProviderCoreTests/B1GreedyFastPathTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/B1GreedyFastPathTests.swift
@@ -38,6 +38,7 @@ struct B1GreedyFastPathEligibilityTests {
         maxTokens: Int = 128,
         maxContextLength: Int = 8192,
         cacheScope: String = "",
+        prefixCacheEnabled: Bool = false,
         activeBridgeCount: Int = 0,
         pendingRequestCount: Int = 0,
         fastPathActive: Bool = false,
@@ -56,6 +57,7 @@ struct B1GreedyFastPathEligibilityTests {
             maxTokens: maxTokens,
             maxContextLength: maxContextLength,
             cacheScope: cacheScope,
+            prefixCacheEnabled: prefixCacheEnabled,
             activeBridgeCount: activeBridgeCount,
             pendingRequestCount: pendingRequestCount,
             fastPathActive: fastPathActive,
@@ -129,6 +131,17 @@ struct B1GreedyFastPathEligibilityTests {
         #expect(!eligible(cacheScope: "tenant-abc"))
     }
 
+    @Test("an enabled prefix/checkpoint cache defers even unscoped requests")
+    func prefixCacheEnabledIsIneligible() {
+        // With the fast path default-on, an unscoped greedy request would
+        // otherwise take it and bypass the checkpoint prefix cache (cold prefill,
+        // no planRestoredCheckpoint/capture). Defer to the engine whenever a
+        // prefix cache is active so stores/hits keep working (Codex P2).
+        #expect(!eligible(prefixCacheEnabled: true))
+        // The canonical request stays eligible when no prefix cache is active.
+        #expect(eligible(prefixCacheEnabled: false))
+    }
+
     @Test("any concurrent or queued work disqualifies the exclusive fast path")
     func nonExclusiveIsIneligible() {
         #expect(!eligible(activeBridgeCount: 1))
@@ -186,7 +199,10 @@ struct B1GreedyFastPathBenchmark {
             promptTokens: promptTokens,
             maxTokens: maxTokens,
             temperature: 0.0,
-            requestId: "b1-bench-\(UUID().uuidString.prefix(8))"
+            requestId: "b1-bench-\(UUID().uuidString.prefix(8))",
+            // `submitTokenized` now defaults `allowFastPath: false` (Codex P2 — keep
+            // direct tokenized tool prompts on the engine); this A/B bench opts in.
+            allowFastPath: true
         )
         var run = FastPathRun()
         var chunks: [String] = []

--- a/provider-swift/Tests/ProviderCoreTests/B1GreedyFastPathTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/B1GreedyFastPathTests.swift
@@ -145,15 +145,18 @@ struct B1GreedyFastPathEligibilityTests {
         #expect(!eligible(hasContainer: false))
     }
 
-    @Test("env flags are off by default in this process")
-    func envFlagDefaultOff() {
-        // The CI runner does not set these, so the static gate is false. (If a
-        // developer exported them, this documents the expectation rather than
-        // asserting a hard false.)
+    @Test("fast path is ON by default; env flags opt OUT")
+    func envFlagDefaultOn() {
+        // Default ON: the gate is true unless EITHER flag is set to a falsey
+        // value (0/false/no/off). The CI runner does not set them, so the gate
+        // is true. (If a developer exported an opt-out, this documents the
+        // expectation rather than asserting a hard true.)
         let env = ProcessInfo.processInfo.environment
-        let expected = env["DARKBLOOM_B1_GREEDY_FAST_PATH"] == "1"
-            || env["DARKBLOOM_GEMMA_B1_FAST_PATH"] == "1"
-        #expect(BatchScheduler.b1GreedyFastPathEnabled() == expected)
+        let off: Set<String> = ["0", "false", "no", "off"]
+        let optedOut =
+            off.contains((env["DARKBLOOM_B1_GREEDY_FAST_PATH"] ?? "").lowercased())
+            || off.contains((env["DARKBLOOM_GEMMA_B1_FAST_PATH"] ?? "").lowercased())
+        #expect(BatchScheduler.b1GreedyFastPathEnabled() == !optedOut)
     }
 }
 


### PR DESCRIPTION
## Summary — provider v0.6.23

Three real wins + the correctness work to make them safe:

1. **MLX 0.32.0 (M5 Neural Accelerator).** Bumps `libs/mlx-swift` → `df1fdc5f` (MLX 0.32.0). NAX auto-activates on **M5 + macOS 26.2** — measured **prefill up to 3,796 tok/s** on an M5 Max (~3.2× compute-bound quantized matmul vs M4). Decode is memory-bound so unchanged (~79–95 tok/s).
2. **Critical 0.32 crash fix (thread-local streams).** MLX 0.32 made the default stream's Metal command encoder *thread-local*; Swift `async/await` + the actor engine hop threads, so **every** inference aborted with `There is no Stream(gpu, N) in current thread`. Fixed by using a single **process-global "thread-unsafe" default stream** (restores MLX 0.31 semantics): `Layr-Labs/mlx-c#3` + `Layr-Labs/mlx-swift#10` (both merged).
3. **B1 greedy fast path — default-on but cache-deferred.** Flipped to default-on, **but it defers to the prefix cache, which is ON by default** → so in the default config the prefix cache wins and B1 is dormant. B1 only engages with `DARKBLOOM_PREFIX_CACHE=0` (then ~+21% decode for single greedy Gemma requests). This is the intentional decision (no prefix-cache regression); a nuanced "B1 on cache-miss" policy is a follow-up.

### Codex review fixes (all addressed)
- **P1 — admission race:** added `fastPathAdmitting` actor flag set synchronously *before* the KV-reserve await; both concurrency gates reject on `!fastPathTasks.isEmpty || fastPathAdmitting`; cleared on every exit. Prevents engine+fast-path running concurrently.
- **P2 — prefix-cache bypass:** B1 now defers when the checkpoint/engine prefix cache is active (not only on non-empty scope).
- **P2 — tool prompts:** `submitTokenized(allowFastPath:)` now defaults `false` (production engine passes it explicitly).
- **P2 — coordinator fallback version:** `LatestProviderVersion 0.6.11 → 0.6.23`.

## Before / After
```mermaid
flowchart LR
  subgraph Before [v0.6.22 / MLX 0.31.1]
    A1[async inference] --> B1[OK on 0.31 single global stream]
    A2[Gemma B=1 greedy] --> B2[batched engine ~63 tok/s]
    A3[M5 prefill] --> B3[no NAX path]
  end
  subgraph After [v0.6.23 / MLX 0.32.0]
    A4[async inference] --> B4[global thread-unsafe stream: no crash]
    A5[Gemma B=1 greedy] --> B5{prefix cache on?}
    B5 -- yes default --> B6[engine + prefix cache]
    B5 -- DARKBLOOM_PREFIX_CACHE=0 --> B7[B1 fast path ~76 tok/s]
    A6[M5 prefill] --> B8[NAX ~3796 tok/s]
  end
```

## Validation
- **M5 Max (real `gemma-4-26b-8bit`, MLX 0.32):** clean — greedy (coherent Rayleigh-scattering answer), streaming (SSE), concurrent ×3 batched (no crash), 79–95 tok/s decode, 3,796 tok/s prefill.
- **CI:** Provider Tests ✅, Coordinator Tests ✅. E2E Integration ✅ on the pre-fix re-pin (`2908b669`); on the fix commit a single **flaky** `parse:mean<=1ms` latency assertion (1.6 ms) tripped under CI load — unrelated to these changes (re-running).

## Known gaps (tracked, not blocking the crash fix)
- VLM image/video not yet exercised on 0.32.
- macOS 14–26.1 metallib load not verified on a <26.2 device (the 0.31.x wheel is the existence proof).
