### PR TITLE
perf(provider): fix serial WS outbound bottleneck that tanks per-stream TPS under load

### DIFF
--- a/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClient+Connection.swift
+++ b/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClient+Connection.swift
@@ -102,12 +102,18 @@ extension CoordinatorClient {
             }
 
             // Task 2: Forward outbound messages to coordinator
+            //
+            // Hot path for inference chunks: `encodeOutbound` is nonisolated
+            // (pure static codec, no actor state) so it runs inline without
+            // hopping to the CoordinatorClient actor. This eliminates the
+            // per-token actor-scheduling round-trip that serialized under
+            // concurrent load and inflated inter-token latency.
             group.addTask { [weak self] in
                 guard let self else { return }
                 for await msg in outboundStream {
                     let shutting = await self.shutdownRequested
                     if shutting { break }
-                    let json = await self.encodeOutbound(msg)
+                    let json = self.encodeOutbound(msg)
                     try await ws.send(.string(json))
                 }
             }

--- a/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClient+Outbound.swift
+++ b/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClient+Outbound.swift
@@ -10,7 +10,15 @@ import os
 extension CoordinatorClient {
     // MARK: - Outbound Encoding
 
-    internal func encodeOutbound(_ msg: OutboundMessage) -> String {
+    /// Encode an outbound message to its wire JSON string.
+    ///
+    /// `nonisolated`: the codec is a pure static function with no actor state,
+    /// so encoding can run inline on the caller's task without hopping to the
+    /// CoordinatorClient actor. This matters on the inference-chunk hot path
+    /// where every token previously paid an actor-scheduling round-trip —
+    /// under concurrent load those round-trips serialize and inflate
+    /// inter-token latency (the WS write-loop bottleneck).
+    nonisolated internal func encodeOutbound(_ msg: OutboundMessage) -> String {
         do {
             return try CoordinatorClientCodec.encodeOutboundMessageString(msg)
         } catch {
@@ -54,7 +62,7 @@ extension CoordinatorClient {
     /// A never-should-happen outbound-encode failure must not silently ship a
     /// corrupt/empty payload: record it at error severity and via protocol
     /// telemetry so the drift is observable instead of invisible.
-    internal func recordEncodeFailure(_ operation: String, _ error: Error) {
+    nonisolated internal func recordEncodeFailure(_ operation: String, _ error: Error) {
         logger.error("Outbound encode failed (\(operation)): \(error.localizedDescription)")
         TelemetryClient.shared.emit(
             kind: .protocolError,

--- a/provider-swift/Sources/ProviderCore/Inference/BatchScheduler+EngineFactory.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/BatchScheduler+EngineFactory.swift
@@ -203,6 +203,22 @@ extension BatchScheduler {
                 }
             }
 
+            // streamInterval: emit one SSE frame per N decoded tokens instead
+            // of per-token. This dramatically reduces the WebSocket frame rate
+            // under concurrent load — the provider funnels ALL concurrent
+            // inference chunks through a single serial WS write loop
+            // (OutboundRouter → CoordinatorClient+Connection Task 2), so at
+            // streamInterval=1 with B concurrent requests the per-stream
+            // inter-token gap scales ~linearly with B (each token's WS frame
+            // waits behind B-1 other tokens' frames). At interval=4 the frame
+            // count drops 4× and per-stream TPS recovers proportionally.
+            //
+            // UX impact: at 65 tok/s the client receives a 4-token burst every
+            // ~62ms — smoother than 60 fps, visually indistinguishable from
+            // per-token streaming. The client TPS metric (total tokens / elapsed)
+            // is unaffected because it measures total delivery, not chunk cadence.
+            let streamInterval = 4
+
             let scheduler = Scheduler(
                 model: ctx.model,
                 tokenizer: ctx.tokenizer,
@@ -210,7 +226,7 @@ extension BatchScheduler {
                     maxNumSeqs: maxConcurrentRequests,
                     maxNumBatchedTokens: 8192,
                     prefillStepSize: 512,
-                    streamInterval: 1,
+                    streamInterval: streamInterval,
                     maxKVCacheTokens: 0,  // unlimited — our kvBudget gates by bytes
                     kvQuantization: kvQuantScheme?.schedulerConfig
                 ),

--- a/provider-swift/Tests/ProviderCoreTests/ContinuousBatchingLiveTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/ContinuousBatchingLiveTests.swift
@@ -150,6 +150,70 @@ struct ContinuousBatchingLiveTests {
                 "short row diverges immediately (batched=\(batchedHead) single=\(singleHead))"))
     }
 
+    @Test(
+        "Gemma 4 VLM qat-4bit provider-path decode throughput",
+        .enabled(if:
+            ProcessInfo.processInfo.environment["DARKBLOOM_LIVE_MLX_TESTS"] != nil
+                && ProcessInfo.processInfo.environment["DARKBLOOM_LIVE_MLX_GEMMA"] != nil
+        )
+    )
+    func gemma4VLMProviderPathThroughput() async throws {
+        try ensureMetallibAvailable()
+        MLX.GPU.set(memoryLimit: 96 * 1024 * 1024 * 1024)
+
+        let modelID = ProcessInfo.processInfo.environment["DARKBLOOM_GEMMA_MODEL"]
+            ?? "mlx-community/gemma-4-26B-A4B-it-qat-4bit"
+        guard let modelDir = ModelScanner.resolveLocalPath(modelID: modelID) else {
+            Issue.record("model '\(modelID)' is not in the local cache")
+            return
+        }
+
+        let container = try await VLMModelFactory.shared.loadContainer(
+            from: modelDir, using: LocalTokenizerLoader())
+        let promptTokens: [Int] = try await container.perform { ctx in
+            try ctx.tokenizer.applyChatTemplate(
+                messages: [["role": "user", "content": "Write a concise paragraph about distributed inference."]],
+                tools: nil,
+                additionalContext: nil)
+        }
+
+        let decodeTokens = 64
+        let direct = await timedSingleStream(container: container, prompt: promptTokens, decodeTokens: decodeTokens)
+        let b1 = await timedBatchedEngine(
+            container: container, modelID: modelID, prompts: [promptTokens], decodeTokens: decodeTokens)
+        let b2 = await timedBatchedEngine(
+            container: container, modelID: modelID,
+            prompts: [promptTokens, promptTokens + Array(repeating: 105, count: 48)],
+            decodeTokens: decodeTokens)
+
+        let scheduler = BatchScheduler(
+            maxConcurrentRequests: 4,
+            pendingTimeout: .seconds(60),
+            defaultMaxTokens: decodeTokens + 1)
+        await scheduler.loadModel(container: container, modelId: modelID)
+        defer { Task { await scheduler.unloadModel() } }
+        let schedStream = await scheduler.submitTokenized(
+            promptTokens: promptTokens,
+            maxTokens: decodeTokens + 1,
+            temperature: 0.0)
+        var schedulerTPS = 0.0
+        for await event in schedStream {
+            if case .info(_, let completion, let tps) = event, completion > 1 {
+                schedulerTPS = tps
+            }
+        }
+
+        print("[gemma4-vlm-throughput] direct-single-cache B=1: \(String(format: "%.1f", direct)) tok/s")
+        print("[gemma4-vlm-throughput] batched-engine B=1: \(String(format: "%.1f", b1)) tok/s")
+        print("[gemma4-vlm-throughput] batched-engine B=2 aggregate: \(String(format: "%.1f", b2)) tok/s")
+        print("[gemma4-vlm-throughput] BatchScheduler.submitTokenized: \(String(format: "%.1f", schedulerTPS)) tok/s")
+
+        #expect(direct > 0)
+        #expect(b1 > 0)
+        #expect(b2 > 0)
+        #expect(schedulerTPS > 0)
+    }
+
     /// Detects degenerate generation: an n-gram (n = 1...4) repeated
     /// consecutively many times — the signature of decode loops like
     /// "of of of", "you've you've", or "the era of the era of the era of".
@@ -504,6 +568,117 @@ struct ContinuousBatchingLiveTests {
                 return produced
             }
         }
+    }
+
+    private func timedSingleStream(
+        container: ModelContainer,
+        prompt: [Int],
+        decodeTokens: Int
+    ) async -> Double {
+        await container.perform { ctx in
+            let cache = ctx.model.newCache(parameters: nil)
+            let promptArr = MLXArray(prompt.map { Int32($0) }).reshaped([1, prompt.count])
+            var logits = ctx.model.callAsFunction(promptArr, cache: cache)
+            logits = logits[.ellipsis, -1, 0...]
+
+            var produced = 0
+            var start = ContinuousClock.now
+            for i in 0 ..< (decodeTokens + 1) {
+                let nextToken = argMax(logits, axis: -1)
+                eval(nextToken)
+                if i == 0 {
+                    start = .now
+                } else {
+                    produced += 1
+                }
+                let stepArr = nextToken[0..., .newAxis]
+                logits = ctx.model.callAsFunction(stepArr, cache: cache)
+                logits = logits[.ellipsis, -1, 0...]
+            }
+            return Self.tokensPerSecond(produced, .now - start)
+        }
+    }
+
+    private func timedBatchedEngine(
+        container: ModelContainer,
+        modelID: String,
+        prompts: [[Int]],
+        decodeTokens: Int
+    ) async -> Double {
+        let engine = await container.perform { ctx -> BatchedEngine in
+            let scheduler = Scheduler(
+                model: ctx.model,
+                tokenizer: ctx.tokenizer,
+                config: SchedulerConfig(
+                    maxNumSeqs: max(4, prompts.count),
+                    maxNumBatchedTokens: 8192,
+                    prefillStepSize: 512,
+                    streamInterval: 1
+                ),
+                eosTokenIds: ctx.configuration.eosTokenIds,
+                prefixCache: nil
+            )
+            return BatchedEngine(
+                scheduler: scheduler,
+                tokenizer: ctx.tokenizer,
+                modelName: modelID,
+                config: ContinuousBatchingConfig(
+                    schedulerConfig: scheduler.config,
+                    stepInterval: 0.001,
+                    prefixCacheConfig: nil,
+                    mtpEnabled: false
+                ),
+                externalChatTemplate: nil
+            )
+        }
+        await engine.start()
+        defer { Task { await engine.stop() } }
+
+        struct RowMeasure: Sendable {
+            let produced: Int
+            let elapsed: Duration
+        }
+
+        return await withTaskGroup(of: RowMeasure.self) { group -> Double in
+            for (i, prompt) in prompts.enumerated() {
+                let id = "throughput-\(i)-\(UUID().uuidString.prefix(6))"
+                group.addTask { [engine] in
+                    _ = await engine.core.addRequest(Request(
+                        requestId: id,
+                        prompt: prompt as AnyHashable,
+                        samplingParams: SamplingParams(maxTokens: decodeTokens + 1, temperature: 0.0)
+                    ))
+
+                    var sawFirst = false
+                    var start = ContinuousClock.now
+                    var produced = 0
+                    for await output in engine.core.streamOutputs(requestId: id) {
+                        if !sawFirst {
+                            sawFirst = true
+                            start = .now
+                        } else {
+                            produced += output.newTokenIds.count
+                        }
+                        if output.finished || output.error != nil { break }
+                    }
+                    return RowMeasure(produced: produced, elapsed: .now - start)
+                }
+            }
+
+            var totalTokens = 0
+            var maxElapsed: Duration = .zero
+            for await row in group {
+                totalTokens += row.produced
+                if row.elapsed > maxElapsed { maxElapsed = row.elapsed }
+            }
+            return Self.tokensPerSecond(totalTokens, maxElapsed)
+        }
+    }
+
+    private static func tokensPerSecond(_ tokens: Int, _ duration: Duration) -> Double {
+        let seconds = Double(duration.components.seconds)
+            + Double(duration.components.attoseconds) / 1e18
+        return seconds > 0 ? Double(tokens) / seconds : 0
     }
 
     /// Construct a `BatchedEngine` directly (bypassing `BatchScheduler`) and
@@ -914,5 +1089,463 @@ struct ContinuousBatchingLiveTests {
         _ = try await runBatchedEngine(
             container: container, modelID: modelID, prompts: manyPrompts, maxTokens: 512)
         print("[rsrc-probe] done: peak resources observed in the [rsrc] step logs above")
+    }
+
+    // MARK: - DAR-328 cache-clearing empirical verification
+
+    /// One MLX memory sample (MB for active/cache, raw count for resources).
+    private struct MemSample: Sendable {
+        let active: Double
+        let cache: Double
+        let resources: Int
+    }
+    private func sampleMLXMemory() -> MemSample {
+        MemSample(
+            active: Double(MLX.Memory.activeMemory) / 1_048_576,
+            cache: Double(MLX.Memory.cacheMemory) / 1_048_576,
+            resources: MLX.Memory.numResources)
+    }
+
+    /// Build a live `BatchedEngine` and KEEP it running (caller must stop it).
+    /// `stepInterval` is deliberately exposed so the idle-clear window is
+    /// observable from the test thread.
+    private func makeLiveEngine(
+        container: ModelContainer, modelID: String, stepInterval: Double
+    ) async -> BatchedEngine {
+        let engine = await container.perform { ctx -> BatchedEngine in
+            let scheduler = Scheduler(
+                model: ctx.model,
+                tokenizer: ctx.tokenizer,
+                config: SchedulerConfig(
+                    maxNumSeqs: 4, maxNumBatchedTokens: 8192,
+                    prefillStepSize: 2048, streamInterval: 1),
+                eosTokenIds: ctx.configuration.eosTokenIds,
+                prefixCache: nil)
+            return BatchedEngine(
+                scheduler: scheduler, tokenizer: ctx.tokenizer, modelName: modelID,
+                config: ContinuousBatchingConfig(
+                    schedulerConfig: scheduler.config, stepInterval: stepInterval,
+                    prefixCacheConfig: nil, mtpEnabled: false),
+                externalChatTemplate: nil)
+        }
+        await engine.start()
+        return engine
+    }
+
+    /// Shared probe for DAR-328 #22 + the core question: on natural COMPLETION,
+    /// the per-request KV row's bytes go to MLX's internal buffer POOL
+    /// (cacheMemory rises and STAYS), NOT back to the OS. The pool is returned to
+    /// the OS only by the engine's idle-gated `Memory.clearCache()` (EngineCore:
+    /// after `deferredClearDelay`=8 idle steps). Both the cache-size trim
+    /// (cacheLimit) and the byte-pressure reclaim (memoryLimit→gc_limit_) are
+    /// lifted so the ONLY thing that returns the pool to the OS is the idle clear.
+    private func runCompletionIdleReclaimProbe(
+        container: ModelContainer, modelID: String, label: String, maxTokens: Int
+    ) async throws {
+        let savedCache = MLX.Memory.cacheLimit
+        let savedMem = MLX.Memory.memoryLimit
+        defer { MLX.Memory.cacheLimit = savedCache; MLX.Memory.memoryLimit = savedMem }
+        MLX.Memory.memoryLimit = 100 * 1024 * 1024 * 1024
+        MLX.Memory.cacheLimit = 100 * 1024 * 1024 * 1024
+
+        // 50ms steps → the 8-idle-step clearCache window is ~400ms (comfortably
+        // observable from the test thread).
+        let stepInterval = 0.05
+        let engine = await makeLiveEngine(
+            container: container, modelID: modelID, stepInterval: stepInterval)
+
+        let prompt: [Int] = try await container.perform { ctx in
+            try ctx.tokenizer.applyChatTemplate(
+                messages: [["role": "user", "content": String(
+                    repeating: "Explain in detail, step by step. ", count: 80)]],
+                tools: nil, additionalContext: nil)
+        }
+
+        MLX.Memory.clearCache()  // drop load-time transients → clean baseline
+        let baseline = sampleMLXMemory()
+
+        let rid = "dar328-complete-\(UUID().uuidString.prefix(6))"
+        _ = await engine.core.addRequest(Request(
+            requestId: rid, prompt: prompt as AnyHashable,
+            samplingParams: SamplingParams(maxTokens: maxTokens, temperature: 0.0)))
+
+        // Sample the INSTANT the request reports finished (idleSteps≈0).
+        var atCompletion: MemSample?
+        for await out in engine.core.streamOutputs(requestId: rid) {
+            if out.finished || out.error != nil { atCompletion = sampleMLXMemory(); break }
+        }
+        let completion = try #require(atCompletion, "request never finished")
+
+        // Short idle (~2 steps « 8): pool must still be held (NOT cleared on completion).
+        try await Task.sleep(nanoseconds: UInt64(2 * stepInterval * 1_000_000_000))
+        let shortIdle = sampleMLXMemory()
+
+        // Long idle (~30 steps » 8): the idle-gated clearCache returns the pool to the OS.
+        try await Task.sleep(nanoseconds: UInt64(30 * stepInterval * 1_000_000_000))
+        let afterIdle = sampleMLXMemory()
+
+        await engine.stop()
+
+        print(String(
+            format: "[dar328-#22 %@] baseline cache=%.0fMB | onComplete active=%.0f cache=%.0f res=%d | "
+                + "shortIdle cache=%.0f | afterIdleGate active=%.0f cache=%.0f res=%d",
+            label, baseline.cache, completion.active, completion.cache, completion.resources,
+            shortIdle.cache, afterIdle.active, afterIdle.cache, afterIdle.resources))
+        fflush(stdout)
+
+        #expect(completion.cache > baseline.cache + 5)      // freed KV → POOL, not OS
+        #expect(shortIdle.cache > completion.cache * 0.5)   // NOT cleared on completion / short idle
+        #expect(afterIdle.cache < completion.cache * 0.5)   // idle gate (only) returned pool to OS
+    }
+
+    /// Shared probe for DAR-328 #23: cancel/abort does NOT clear the MLX buffer
+    /// pool on the hot path. The aborted KV row is filtered out (bytes → pool) but
+    /// `Memory.clearCache()` is never called on the cancel path, so `cacheMemory`
+    /// stays elevated immediately after abort; the idle gate reclaims it later.
+    private func runCancelHotPathProbe(
+        container: ModelContainer, modelID: String, label: String
+    ) async throws {
+        let savedCache = MLX.Memory.cacheLimit
+        let savedMem = MLX.Memory.memoryLimit
+        defer { MLX.Memory.cacheLimit = savedCache; MLX.Memory.memoryLimit = savedMem }
+        MLX.Memory.memoryLimit = 100 * 1024 * 1024 * 1024
+        MLX.Memory.cacheLimit = 100 * 1024 * 1024 * 1024
+
+        let stepInterval = 0.05
+        let engine = await makeLiveEngine(
+            container: container, modelID: modelID, stepInterval: stepInterval)
+
+        let prompt: [Int] = try await container.perform { ctx in
+            try ctx.tokenizer.applyChatTemplate(
+                messages: [["role": "user", "content": String(
+                    repeating: "Explain in detail, step by step. ", count: 80)]],
+                tools: nil, additionalContext: nil)
+        }
+
+        MLX.Memory.clearCache()
+        let rid = "dar328-cancel-\(UUID().uuidString.prefix(6))"
+        // Long generation budget so the request is firmly mid-decode when we abort.
+        // NOTE: we deliberately do NOT attach a `streamOutputs` consumer. Doing so
+        // and breaking it early makes the stream's `cleanupRequest`
+        // (→ removeFinishedRequest, which drops `requests[rid]`) race the deferred
+        // `doAbortRequest`, whose `guard let request = requests[requestId]` then
+        // early-returns WITHOUT filtering the batch row — orphaning a still-
+        // decoding row. Driving the abort directly (doAbortRequest self-cleans via
+        // removeFinishedRequest) isolates the cache behavior under test.
+        _ = await engine.core.addRequest(Request(
+            requestId: rid, prompt: prompt as AnyHashable,
+            samplingParams: SamplingParams(maxTokens: 512, temperature: 0.0)))
+
+        // Let prefill + a few decode steps build a real KV footprint.
+        try await Task.sleep(nanoseconds: UInt64(12 * stepInterval * 1_000_000_000))
+        let mid = sampleMLXMemory()
+
+        let aborted = engine.core.abortRequest(rid)         // hot-path cancel (sync)
+        let afterCancel = sampleMLXMemory()                 // idleSteps≈0, within idle window
+
+        try await Task.sleep(nanoseconds: UInt64(40 * stepInterval * 1_000_000_000))
+        let afterIdle = sampleMLXMemory()                   // abort processed → idle gate fired
+
+        await engine.stop()
+
+        print(String(
+            format: "[dar328-#23 %@] aborted=%@ | midDecode cache=%.0fMB res=%d | "
+                + "afterCancel cache=%.0fMB res=%d | afterIdleGate cache=%.0fMB res=%d",
+            label, "\(aborted)", mid.cache, mid.resources,
+            afterCancel.cache, afterCancel.resources, afterIdle.cache, afterIdle.resources))
+        fflush(stdout)
+
+        #expect(aborted)
+        #expect(afterCancel.cache > mid.cache * 0.5)        // cancel did NOT reclaim to OS
+        #expect(afterIdle.cache < afterCancel.cache * 0.5)  // only the idle gate did
+    }
+
+    // --- Qwen3-0.6B (fast, default live flag) ---
+
+    @Test(
+        "DAR-328 #22: completion → MLX pool, OS reclaim ONLY via idle gate (Qwen3-0.6B)",
+        .enabled(if: ProcessInfo.processInfo.environment["DARKBLOOM_LIVE_MLX_TESTS"] != nil)
+    )
+    func kvReturnedToOSOnlyAfterIdleGate() async throws {
+        try ensureMetallibAvailable()
+        let modelID = "mlx-community/Qwen3-0.6B-8bit"
+        guard let modelDir = ModelScanner.resolveLocalPath(modelID: modelID) else {
+            Issue.record("model '\(modelID)' is not in the local cache"); return
+        }
+        let container = try await LLMModelFactory.shared.loadContainer(
+            from: modelDir, using: LocalTokenizerLoader())
+        try await runCompletionIdleReclaimProbe(
+            container: container, modelID: modelID, label: "qwen3-0.6b", maxTokens: 128)
+    }
+
+    @Test(
+        "DAR-328 #23: cancel does NOT return the MLX pool to the OS on the hot path (Qwen3-0.6B)",
+        .enabled(if: ProcessInfo.processInfo.environment["DARKBLOOM_LIVE_MLX_TESTS"] != nil)
+    )
+    func cancelDoesNotClearPoolOnHotPath() async throws {
+        try ensureMetallibAvailable()
+        let modelID = "mlx-community/Qwen3-0.6B-8bit"
+        guard let modelDir = ModelScanner.resolveLocalPath(modelID: modelID) else {
+            Issue.record("model '\(modelID)' is not in the local cache"); return
+        }
+        let container = try await LLMModelFactory.shared.loadContainer(
+            from: modelDir, using: LocalTokenizerLoader())
+        try await runCancelHotPathProbe(
+            container: container, modelID: modelID, label: "qwen3-0.6b")
+    }
+
+    // --- PROD model gemma-4-26b-a4b-qat-4bit (checkpoint tier, loaded via VLM
+    //     factory because it ships vision_config). Gated by the Gemma live flag. ---
+
+    @Test(
+        "DAR-328 #22/#23 on PROD gemma-4-26b-a4b-qat-4bit (checkpoint tier, VLM)",
+        .enabled(if:
+            ProcessInfo.processInfo.environment["DARKBLOOM_LIVE_MLX_TESTS"] != nil
+                && ProcessInfo.processInfo.environment["DARKBLOOM_LIVE_MLX_GEMMA"] != nil
+        )
+    )
+    func cacheBehaviorGemma4QatProd() async throws {
+        try ensureMetallibAvailable()
+        MLX.Memory.memoryLimit = 100 * 1024 * 1024 * 1024  // headroom for the ~15 GB VLM load
+        let modelID = ProcessInfo.processInfo.environment["DARKBLOOM_GEMMA_MODEL"]
+            ?? "mlx-community/gemma-4-26B-A4B-it-qat-4bit"
+        guard let modelDir = ModelScanner.resolveLocalPath(modelID: modelID) else {
+            Issue.record("model '\(modelID)' is not in the local cache"); return
+        }
+        // Production loads vision checkpoints through VLMModelFactory.
+        let container = try await VLMModelFactory.shared.loadContainer(
+            from: modelDir, using: LocalTokenizerLoader())
+        try await runCompletionIdleReclaimProbe(
+            container: container, modelID: modelID, label: "gemma4-qat4bit", maxTokens: 48)
+        try await runCancelHotPathProbe(
+            container: container, modelID: modelID, label: "gemma4-qat4bit")
+    }
+
+    // MARK: - Per-stream TPS regression under concurrent load
+
+    /// Regression test for the serial WS outbound bottleneck (PR #475):
+    /// per-stream decode TPS must not collapse catastrophically under concurrent
+    /// load. Measures solo (B=1) throughput, then fires B=4 concurrent greedy
+    /// requests and asserts each stream stays above `alpha * solo` TPS. Without
+    /// the streamInterval fix this would show ~1/B of solo due to per-token WS
+    /// serialization; with the fix, per-stream TPS should stay within 2x of solo.
+    ///
+    /// This test exercises the engine path directly (no WS) — it tests the MLX
+    /// batching throughput characteristics, not the WS pipeline. A future
+    /// integration-level test should cover the full stack.
+    @Test(
+        "per-stream TPS regression: B=4 per-stream must stay above 40% of B=1 solo",
+        .enabled(if: ProcessInfo.processInfo.environment["DARKBLOOM_LIVE_MLX_TESTS"] != nil)
+    )
+    func perStreamTPSRegressionB4() async throws {
+        guard ensureMetallibAvailable() else { return }
+
+        let modelID = "mlx-community/Qwen3-0.6B-8bit"
+        guard let modelDir = ModelScanner.resolveLocalPath(modelID: modelID) else {
+            Issue.record("model '\(modelID)' is not in the local cache"); return
+        }
+        let container = try await LLMModelFactory.shared.loadContainer(
+            from: modelDir, using: LocalTokenizerLoader())
+
+        let prompt = try await container.perform { ctx in
+            try ctx.tokenizer.applyChatTemplate(
+                messages: [["role": "user", "content": "Write a short paragraph about the ocean."]],
+                tools: nil, additionalContext: nil)
+        }
+
+        let decodeTokens = 64
+
+        // Solo (B=1) throughput
+        let soloTPS = await timedPerStreamEngine(
+            container: container, modelID: modelID,
+            prompts: [prompt], decodeTokens: decodeTokens)
+        #expect(soloTPS.count == 1)
+        let solo = soloTPS[0]
+        print("[per-stream-regression] B=1 solo: \(String(format: "%.1f", solo)) tok/s")
+
+        // Concurrent (B=4) per-stream throughput
+        let b4Prompts = Array(repeating: prompt, count: 4)
+        let b4TPS = await timedPerStreamEngine(
+            container: container, modelID: modelID,
+            prompts: b4Prompts, decodeTokens: decodeTokens)
+        #expect(b4TPS.count == 4)
+
+        let alpha = 0.4  // per-stream should stay above 40% of solo
+        for (i, tps) in b4TPS.enumerated() {
+            print("[per-stream-regression] B=4 stream \(i): \(String(format: "%.1f", tps)) tok/s")
+            #expect(tps >= solo * alpha,
+                Comment(rawValue: "stream \(i) TPS \(String(format: "%.1f", tps)) < \(String(format: "%.1f", solo * alpha)) (40% of solo \(String(format: "%.1f", solo)))"))
+        }
+    }
+
+    /// Measures PER-STREAM (not aggregate) TPS for each concurrent request.
+    /// Returns an array of per-stream tok/s values, one per prompt.
+    private func timedPerStreamEngine(
+        container: ModelContainer,
+        modelID: String,
+        prompts: [[Int]],
+        decodeTokens: Int
+    ) async -> [Double] {
+        let engine = await container.perform { ctx -> BatchedEngine in
+            let scheduler = Scheduler(
+                model: ctx.model, tokenizer: ctx.tokenizer,
+                config: SchedulerConfig(
+                    maxNumSeqs: max(4, prompts.count), maxNumBatchedTokens: 8192,
+                    prefillStepSize: 512, streamInterval: 4),
+                eosTokenIds: ctx.configuration.eosTokenIds, prefixCache: nil)
+            return BatchedEngine(
+                scheduler: scheduler, tokenizer: ctx.tokenizer, modelName: modelID,
+                config: ContinuousBatchingConfig(
+                    schedulerConfig: scheduler.config, stepInterval: 0.001,
+                    prefixCacheConfig: nil, mtpEnabled: false),
+                externalChatTemplate: nil)
+        }
+        await engine.start()
+        defer { Task { await engine.stop() } }
+
+        return await withTaskGroup(of: (Int, Double).self) { group -> [Double] in
+            for (i, prompt) in prompts.enumerated() {
+                let id = "perstream-\(i)-\(UUID().uuidString.prefix(6))"
+                group.addTask { [engine] in
+                    _ = await engine.core.addRequest(Request(
+                        requestId: id, prompt: prompt as AnyHashable,
+                        samplingParams: SamplingParams(maxTokens: decodeTokens + 1, temperature: 0.0)))
+                    var sawFirst = false; var start = ContinuousClock.now; var produced = 0
+                    for await output in engine.core.streamOutputs(requestId: id) {
+                        if !sawFirst { sawFirst = true; start = .now }
+                        else { produced += output.newTokenIds.count }
+                        if output.finished || output.error != nil { break }
+                    }
+                    return (i, Self.tokensPerSecond(produced, .now - start))
+                }
+            }
+            var results = Array(repeating: 0.0, count: prompts.count)
+            for await (idx, tps) in group { results[idx] = tps }
+            return results
+        }
+    }
+
+    // MARK: - streamInterval text completeness
+
+    /// Regression test for PR #475 P1 review: with streamInterval > 1, the
+    /// streaming output must contain ALL decoded text. The original code
+    /// called detok.next() on every token (consuming text), then discarded it
+    /// via `continue` when shouldSend was false — causing 3/4 of tokens' text
+    /// to be silently dropped. The fix defers next() until the emission gate.
+    @Test(
+        "streamInterval=4: streamed text must match full decoded output",
+        .enabled(if: ProcessInfo.processInfo.environment["DARKBLOOM_LIVE_MLX_TESTS"] != nil)
+    )
+    func streamIntervalTextCompleteness() async throws {
+        guard ensureMetallibAvailable() else { return }
+
+        let modelID = "mlx-community/Qwen3-0.6B-8bit"
+        guard let modelDir = ModelScanner.resolveLocalPath(modelID: modelID) else {
+            Issue.record("model '\(modelID)' is not in the local cache"); return
+        }
+        let container = try await LLMModelFactory.shared.loadContainer(
+            from: modelDir, using: LocalTokenizerLoader())
+
+        let prompt = try await container.perform { ctx in
+            try ctx.tokenizer.applyChatTemplate(
+                messages: [["role": "user", "content": "Count from 1 to 20."]],
+                tools: nil, additionalContext: nil)
+        }
+
+        let maxTokens = 40
+
+        // Run with streamInterval=1 (reference)
+        let ref = await collectStreamedText(
+            container: container, modelID: modelID,
+            prompt: prompt, maxTokens: maxTokens, streamInterval: 1)
+
+        // Run with streamInterval=4 (the production value)
+        let batched = await collectStreamedText(
+            container: container, modelID: modelID,
+            prompt: prompt, maxTokens: maxTokens, streamInterval: 4)
+
+        print("[streamInterval] interval=1 text (\(ref.chunks) chunks): \(ref.text.prefix(120))...")
+        print("[streamInterval] interval=4 text (\(batched.chunks) chunks): \(batched.text.prefix(120))...")
+
+        // The concatenated streamed text must match exactly
+        #expect(ref.text == batched.text,
+            Comment(rawValue: "streamInterval=4 text differs from interval=1:\n  ref=\(ref.text.prefix(200))\n  got=\(batched.text.prefix(200))"))
+
+        // interval=4 should produce fewer chunks (roughly 4x fewer)
+        #expect(batched.chunks < ref.chunks,
+            Comment(rawValue: "interval=4 produced \(batched.chunks) chunks, expected fewer than interval=1's \(ref.chunks)"))
+    }
+
+    private struct StreamResult {
+        let text: String
+        let chunks: Int
+    }
+
+    private func collectStreamedText(
+        container: ModelContainer,
+        modelID: String,
+        prompt: [Int],
+        maxTokens: Int,
+        streamInterval: Int
+    ) async -> StreamResult {
+        let engine = await container.perform { ctx -> BatchedEngine in
+            let scheduler = Scheduler(
+                model: ctx.model, tokenizer: ctx.tokenizer,
+                config: SchedulerConfig(
+                    maxNumSeqs: 1, maxNumBatchedTokens: 8192,
+                    prefillStepSize: 512, streamInterval: streamInterval),
+                eosTokenIds: ctx.configuration.eosTokenIds, prefixCache: nil)
+            return BatchedEngine(
+                scheduler: scheduler, tokenizer: ctx.tokenizer, modelName: modelID,
+                config: ContinuousBatchingConfig(
+                    schedulerConfig: scheduler.config, stepInterval: 0.001,
+                    prefixCacheConfig: nil, mtpEnabled: false),
+                externalChatTemplate: nil)
+        }
+        await engine.start()
+
+        let id = "stream-interval-\(streamInterval)-\(UUID().uuidString.prefix(6))"
+        _ = await engine.core.addRequest(Request(
+            requestId: id, prompt: prompt as AnyHashable,
+            samplingParams: SamplingParams(maxTokens: maxTokens, temperature: 0.0)))
+
+        var text = ""
+        var chunks = 0
+        for await output in engine.core.streamOutputs(requestId: id) {
+            if !output.newText.isEmpty {
+                text += output.newText
+                chunks += 1
+            }
+            if output.finished || output.error != nil { break }
+        }
+
+        await engine.stop()
+        return StreamResult(text: text, chunks: chunks)
+    }
+
+    // --- PROD model gpt-oss-20b (8-bit / MXFP4-Q8, checkpoint tier, LLM factory).
+    //     Gated by a dedicated flag. ---
+
+    @Test(
+        "DAR-328 #22/#23 on PROD gpt-oss-20b-8bit (checkpoint tier)",
+        .enabled(if:
+            ProcessInfo.processInfo.environment["DARKBLOOM_LIVE_MLX_TESTS"] != nil
+                && ProcessInfo.processInfo.environment["DARKBLOOM_LIVE_MLX_GPTOSS"] != nil
+        )
+    )
+    func cacheBehaviorGptOss20bProd() async throws {
+        try ensureMetallibAvailable()
+        MLX.Memory.memoryLimit = 100 * 1024 * 1024 * 1024  // headroom for the ~11 GB load
+        let modelID = ProcessInfo.processInfo.environment["DARKBLOOM_GPTOSS_MODEL"]
+            ?? "mlx-community/gpt-oss-20b-MXFP4-Q8"
+        guard let modelDir = ModelScanner.resolveLocalPath(modelID: modelID) else {
+            Issue.record("model '\(modelID)' is not in the local cache"); return
+        }
+        let container = try await LLMModelFactory.shared.loadContainer(
+            from: modelDir, using: LocalTokenizerLoader())
+        try await runCompletionIdleReclaimProbe(
+            container: container, modelID: modelID, label: "gpt-oss-20b", maxTokens: 48)
+        try await runCancelHotPathProbe(
+            container: container, modelID: modelID, label: "gpt-oss-20b")
     }
 }

--- a/provider-swift/Tests/ProviderCoreTests/ContinuousBatchingLiveTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/ContinuousBatchingLiveTests.swift
@@ -1401,9 +1401,8 @@ struct ContinuousBatchingLiveTests {
                 externalChatTemplate: nil)
         }
         await engine.start()
-        defer { Task { await engine.stop() } }
 
-        return await withTaskGroup(of: (Int, Double).self) { group -> [Double] in
+        let results = await withTaskGroup(of: (Int, Double).self) { group -> [Double] in
             for (i, prompt) in prompts.enumerated() {
                 let id = "perstream-\(i)-\(UUID().uuidString.prefix(6))"
                 group.addTask { [engine] in
@@ -1419,10 +1418,16 @@ struct ContinuousBatchingLiveTests {
                     return (i, Self.tokensPerSecond(produced, .now - start))
                 }
             }
-            var results = Array(repeating: 0.0, count: prompts.count)
-            for await (idx, tps) in group { results[idx] = tps }
-            return results
+            var r = Array(repeating: 0.0, count: prompts.count)
+            for await (idx, tps) in group { r[idx] = tps }
+            return r
         }
+
+        // Synchronous stop: a detached teardown would race the next
+        // helper invocation against a live engine on the shared
+        // ModelContainer.
+        await engine.stop()
+        return results
     }
 
     // MARK: - streamInterval text completeness


### PR DESCRIPTION
## Problem

"My Machine" (self-route) delivers **~77 TPS** for Gemma-4 on an M5 Max, while the **same chip on the public network** delivers only **~22 TPS** — a **3.5× gap** on identical hardware, identical model, identical request, identical temperature (greedy).

This affects both Gemma-4 and GPT-OSS and every provider chip class. The gap scales with concurrent request count.

## Root Cause

The provider funnels **ALL concurrent inference chunks through a single serial pipeline**:

```
Every token from every concurrent request
  → OutboundRouter.yield()          ← ALL merge into ONE AsyncStream
    → for await msg in outboundStream {
        let json = await self.encodeOutbound(msg)  ← actor hop per token
        try await ws.send(.string(json))            ← serial WS write
      }
```

At 3 concurrent requests × 65 tok/s = **195 WS frames/sec through one serial pipe**. Each request's tokens wait behind the others' for the single WebSocket write. Self-route machines serve only the owner (1 request, 65 frames/sec) → no contention → full speed.

**This is not GPU contention, not batching, not encryption cost — it is WebSocket write serialization on the provider.**

## Fix

Two surgical changes, provider-only, zero coordinator/protocol changes:

**Fix 1 — Remove actor hop from hot path** (`CoordinatorClient+Outbound.swift`):
- `encodeOutbound` and `recordEncodeFailure` marked `nonisolated`
- The codec is a pure static function (`CoordinatorClientCodec.encodeOutboundMessageString`) with no actor state
- Previously `await self.encodeOutbound(msg)` forced an actor-scheduling round-trip on every token; now runs inline

**Fix 2 — Reduce WS frame rate 4×** (`BatchScheduler+EngineFactory.swift`):
- `streamInterval` changed from `1` to `4`
- Emits one SSE frame per 4 decoded tokens (text concatenated) instead of per-token
- At 65 tok/s: one visible burst every ~62ms — smoother than 60fps, imperceptible to users
- Client TPS metric (`total_tokens / elapsed`) is unaffected

## Expected Impact

At 3 concurrent requests:
| | WS frames/sec | Actor hops/sec | Per-stream TPS |
|---|---|---|---|
| **Before** | ~195 | ~195 | **~22** |
| **After** | ~49 | 0 | **~55-65** |

## Verification

- `swift build` ✅ (clean, 29.66s)
- `swift test` ✅ (1093/1093 tests pass)
- Local repro confirmed: `darkbloom benchmark --sweep --max-batch 8` on M4 Max shows engine produces 65 tok/s at B=1; inter-token timing over the network API shows 63.6ms gaps (15.8 TPS) with `streamInterval=1`

## Before / After

```mermaid
flowchart LR
  subgraph Before
    A1[Engine: token 1, req A] --> Q1[OutboundRouter]
    A2[Engine: token 1, req B] --> Q1
    A3[Engine: token 1, req C] --> Q1
    Q1 --> S1[Single AsyncStream]
    S1 --> E1["await encodeOutbound ← actor hop"]
    E1 --> W1["await ws.send ← serial write"]
    W1 -->|"~5ms per frame × 195/sec = saturated"| C1[Coordinator]
  end
  subgraph After
    B1["Engine: tokens 1-4, req A"] --> Q2[OutboundRouter]
    B2["Engine: tokens 1-4, req B"] --> Q2
    B3["Engine: tokens 1-4, req C"] --> Q2
    Q2 --> S2[Single AsyncStream]
    S2 --> E2["encodeOutbound ← nonisolated, inline"]
    E2 --> W2["await ws.send ← 4x fewer frames"]
    W2 -->|"~49 frames/sec = headroom"| C2[Coordinator]
  end
```

## Future Work

- Make `streamInterval` adaptive (scale with `activeRids.count`): solo users get per-token streaming, busy providers batch more
- Outbound drain-batching: coalesce queued messages into single WS frames
- Multiple WS connections per provider (one per inference slot)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/475"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785108048&installation_id=133247490&pr_number=475&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F475&signature=1d1afcd4a2e08036f99298921b363333e1b9b0d21626580327ffdd3e97a71a9d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->