### PR TITLE
perf(provider): remove shutdown actor hop from WS hot path

### DIFF
--- a/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClient+Connection.swift
+++ b/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClient+Connection.swift
@@ -111,8 +111,7 @@ extension CoordinatorClient {
             group.addTask { [weak self] in
                 guard let self else { return }
                 for await msg in outboundStream {
-                    let shutting = await self.shutdownRequested
-                    if shutting { break }
+                    if self.shutdownRequested { break }
                     let json = self.encodeOutbound(msg)
                     try await ws.send(.string(json))
                 }
@@ -121,13 +120,12 @@ extension CoordinatorClient {
             // Task 3: Heartbeat timer
             group.addTask { [weak self] in
                 guard let self else { return }
-                let interval = await self.config.heartbeatInterval
+                let interval = self.config.heartbeatInterval
 
                 try await Task.sleep(for: .seconds(interval))
 
                 while true {
-                    let shutting = await self.shutdownRequested
-                    if shutting { break }
+                    if self.shutdownRequested { break }
                     let json = await self.buildHeartbeatJSON()
                     try await ws.send(.string(json))
                     try await Task.sleep(for: .seconds(interval))

--- a/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClient.swift
+++ b/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClient.swift
@@ -71,7 +71,16 @@ public actor CoordinatorClient {
     /// registrations consistent.
     internal var modelWeightHashOverrides: [String: String] = [:]
 
-    internal var shutdownRequested = false
+    private let shutdownFlag = ShutdownFlag()
+
+    /// Fast, thread-safe shutdown visibility for connection tasks.
+    ///
+    /// The outbound WebSocket writer checks this once per inference chunk. Keep
+    /// the read nonisolated so the hot path does not hop back to the
+    /// CoordinatorClient actor just to read a Bool.
+    nonisolated internal var shutdownRequested: Bool {
+        shutdownFlag.isRequested
+    }
 
     /// Mutable advertised-model list. Seeded from `config.models`; background
     /// prefetch (Layer 3) appends newly-verified builds so re-registration and
@@ -155,7 +164,7 @@ public actor CoordinatorClient {
     }
 
     public func shutdown() {
-        shutdownRequested = true
+        shutdownFlag.request()
         webSocketTask?.cancel(with: .goingAway, reason: nil)
         eventContinuation?.finish()
         outboundRouter.finish()

--- a/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClientState.swift
+++ b/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClientState.swift
@@ -209,6 +209,24 @@ internal final class PongTracker: @unchecked Sendable {
     }
 }
 
+// MARK: - ShutdownFlag
+
+/// Thread-safe shutdown state shared between the CoordinatorClient actor and
+/// its connection child tasks. A lock-backed Bool is enough here and avoids a
+/// per-frame actor hop in the outbound WebSocket writer.
+internal final class ShutdownFlag: @unchecked Sendable {
+    private let lock = OSAllocatedUnfairLock()
+    private var requested = false
+
+    var isRequested: Bool {
+        lock.withLock { requested }
+    }
+
+    func request() {
+        lock.withLock { requested = true }
+    }
+}
+
 // MARK: - ManagedAtomic
 
 private final class ManagedAtomic<Value: FixedWidthInteger>: @unchecked Sendable {
@@ -231,4 +249,3 @@ private final class ManagedAtomic<Value: FixedWidthInteger>: @unchecked Sendable
         lock.withLock { value &+= delta }
     }
 }
-

--- a/provider-swift/Tests/ProviderCoreTests/CoordinatorClientTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/CoordinatorClientTests.swift
@@ -298,6 +298,54 @@ import Testing
     #expect(!json.contains("apns_environment"))
 }
 
+@Test func shutdownRequestedIsNonisolatedAndIdempotent() async {
+    let config = CoordinatorClientConfig(
+        url: "wss://api.dev.darkbloom.xyz/v1/providers/ws",
+        hardware: clientSampleHardware(),
+        models: [clientSampleModel()],
+        backendName: "mlx_swift_lm",
+        publicKey: "cHVibGlj"
+    )
+    let client = CoordinatorClient(
+        config: config,
+        stats: AtomicProviderStats(),
+        state: ProviderState()
+    )
+
+    // This read intentionally has no `await`: the outbound WebSocket writer
+    // checks the same property once per frame on the inference hot path.
+    #expect(client.shutdownRequested == false)
+
+    await client.shutdown()
+    #expect(client.shutdownRequested == true)
+
+    await client.shutdown()
+    #expect(client.shutdownRequested == true)
+}
+
+@Test func shutdownFlagHandlesConcurrentReadersAndRequests() async {
+    let flag = ShutdownFlag()
+
+    await withTaskGroup(of: Void.self) { group in
+        for _ in 0..<16 {
+            group.addTask {
+                for _ in 0..<1_000 {
+                    _ = flag.isRequested
+                }
+            }
+        }
+        for _ in 0..<4 {
+            group.addTask {
+                for _ in 0..<100 {
+                    flag.request()
+                }
+            }
+        }
+    }
+
+    #expect(flag.isRequested == true)
+}
+
 @Test func atomicProviderStatsSnapshotIncludesOutcomeCounters() {
     let stats = AtomicProviderStats()
     stats.incrementRequestsServed()


### PR DESCRIPTION
## Summary
- Moves `CoordinatorClient.shutdownRequested` behind a lock-backed `ShutdownFlag`.
- Keeps shutdown visibility reliable for connection child tasks without crossing the `CoordinatorClient` actor.
- Removes the per-frame `await self.shutdownRequested` actor hop from the outbound WebSocket writer.
- Adds focused tests for nonisolated/idempotent shutdown reads and concurrent shutdown flag access.

## Before
```mermaid
flowchart LR
  subgraph Behavior_Before[Behavior Before]
    R1[Provider streaming chunks] --> W1[Outbound WS writer]
    W1 --> S1[Check shutdownRequested]
    S1 --> A1[Hop to CoordinatorClient actor]
    A1 --> E1[Encode outbound JSON]
    E1 --> WS1[ws.send frame]
    C1[shutdown called] --> AC1[Actor bool set]
    AC1 --> X1[Socket cancel + streams finish]
  end

  subgraph Code_Before[Code Before]
    L1[CoordinatorClient.shutdownRequested var Bool] --> L2[await self.shutdownRequested]
    L2 --> L3[Actor executor scheduling per frame]
  end
```

## After
```mermaid
flowchart LR
  subgraph Behavior_After[Behavior After]
    R2[Provider streaming chunks] --> W2[Outbound WS writer]
    W2 --> S2[Check shutdownRequested]
    S2 --> F2[Lock-backed ShutdownFlag read]
    F2 --> E2[Encode outbound JSON]
    E2 --> WS2[ws.send frame]
    C2[shutdown called] --> SF2[ShutdownFlag.request]
    SF2 --> X2[Socket cancel + streams finish]
  end

  subgraph Code_After[Code After]
    L4[CoordinatorClient.shutdownFlag private let] --> L5[nonisolated shutdownRequested computed property]
    L5 --> L6[No actor hop in outbound loop]
  end
```

## Verification
- `swift test --filter CoordinatorClientTests`
- `./scripts/fetch-metallib.sh debug`
- `./scripts/fetch-metallib.sh provider-swift/.build/arm64-apple-macosx/debug/DarkbloomProviderPackageTests.xctest/Contents/MacOS`
- `swift test` passed: 1156 Swift Testing tests in 85 suites, plus XCTest suite.
- Real Gemma 4 provider-path validation:

```text
DARKBLOOM_LIVE_MLX_TESTS=1 DARKBLOOM_LIVE_MLX_GEMMA=1 \
DARKBLOOM_GEMMA_MODEL=mlx-community/gemma-4-26B-A4B-it-qat-4bit \
MLX_METALLIB_SOURCE=provider-swift/.build/arm64-apple-macosx/debug/mlx.metallib \
swift test --filter gemma4VLMProviderPathThroughput

[gemma4-vlm-throughput] direct-single-cache B=1: 33.8 tok/s
[gemma4-vlm-throughput] batched-engine B=1: 30.0 tok/s
[gemma4-vlm-throughput] batched-engine B=2 aggregate: 60.5 tok/s
[gemma4-vlm-throughput] BatchScheduler.submitTokenized: 32.1 tok/s
```

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/476"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785113678&installation_id=133247490&pr_number=476&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F476&signature=0424beadffe0d780e4b158560d365f62f77913c262187e094b4f1bc790446943"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->