### PR TITLE
hotfix(provider): v0.6.24 — re-pin mlx-swift-lm to main (restore fast decode ring)

### DIFF
--- a/coordinator/api/server.go
+++ b/coordinator/api/server.go
@@ -145,7 +145,7 @@ func keyLimitResetFromContext(ctx context.Context) string {
 // 0.6.0 is the APNs code-identity / VLM-routing / graceful-update release.
 // Keep this fallback in sync with ProviderCore.version so dev/in-memory
 // coordinators advertise the same floor as the Swift binary they expect.
-var LatestProviderVersion = "0.6.23"
+var LatestProviderVersion = "0.6.24"
 
 // minProviderVersionForDesiredModels is the first provider version whose Swift
 // runtime understands the desired_models message. The coordinator must NOT send

--- a/provider-swift/Sources/ProviderCore/ProviderCore.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderCore.swift
@@ -75,5 +75,5 @@ public enum ProviderCore {
     // jinja_null_bridge / jinja_template / model_load), so durable telemetry can
     // tell the two indistinguishable gpt-oss 500 modes apart. Wire-compatible:
     // `error_reason` is an optional inference-error field, omitted when nil.
-    public static let version = "0.6.23"
+    public static let version = "0.6.24"
 }


### PR DESCRIPTION
## Summary

**HOTFIX** — v0.6.23 shipped with `libs/mlx-swift-lm` pinned to a diverged branch (`fix/stream-interval-detokenizer`) that forked from `main` **before** PR #58 (`perf/batch-rotating-kv-ring`) and PR #59 (`fix/gemma4-remaining-comments`) were merged. This silently dropped the fast decode ring buffer and other fixes.

## Production Impact (DB-verified, 1h window)

| Metric | 0.6.22 | 0.6.23 | Delta |
|--------|--------|--------|-------|
| gpt-oss-20b TPS (concurrency 0-1) | **33.2** | **11.6** | **-65%** |
| gpt-oss-20b error rate | **0.7%** | **5.7%** | **8x worse** |
| Provider errors (gpt-oss-20b) | 96 | 212 | +121% |

TPS regression confirmed across **every chip type** (M1 Max through M5 Max) at matching concurrency levels — not a load artifact.

### Chip-by-chip TPS at low concurrency (backend_running <= 3)

| Chip | 0.6.22 TPS | 0.6.23 TPS | Delta |
|------|-----------|-----------|-------|
| M5 Max | 39.3 | 14.9 | -62% |
| M5 Pro | 32.0 | 12.3 | -62% |
| M4 Max | 26.8 | 12.8 | -52% |
| M3 Ultra | 37.1 | 13.7 | -63% |
| M3 Max | 28.5 | 6.4 | -78% |
| M2 Ultra | 19.7 | 11.4 | -42% |

## Root Cause

```
0.6.22 pin: 791c17f8 (main)     — has PR #58 fast decode ring + PR #59
0.6.23 pin: 7b81b03c (fix/...)  — branched BEFORE #58/#59 merged
                                  git merge-base --is-ancestor → NO (diverged)
```

### What was lost

1. **Fast decode ring** (`BatchRotatingKVCache`, PR #58) — every decode step fell from O(1) in-place pointer-advance to O(n) concat+trim (2x full KV window copies per layer per step). gpt-oss-20b has 36 layers with sliding window → ~72 unnecessary copies per token.

2. **`isCompiledDecodeSupported` gate** (`SwitchLayers.swift`) — compiled SiLU always enabled without hardware check, risking crashes on M1/M2 + Tahoe (MLX #3329).

3. **Gemma4 VLM fixes** (PR #59 `fix/gemma4-remaining-comments`).

## Fix

1. Cherry-picked the detokenizer fix (`7b81b03`) onto `mlx-swift-lm` `main` → `c945bfe`
2. Re-pinned `libs/mlx-swift-lm` to `main` HEAD (`c945bfe`)
3. Bumped provider to `0.6.24`, coordinator `LatestProviderVersion` to `0.6.24`

New pin has all of: fast decode ring (#58) + Gemma4 fixes (#59) + detokenizer streamInterval fix (cherry-picked).

## Before / After

```mermaid
flowchart LR
  subgraph "Before (v0.6.23)"
    A1[decode step] --> B1["concat(keys, new) → full copy #1"]
    B1 --> C1["trim front → full copy #2"]
    C1 --> D1["~72 copies/token across 36 layers"]
    D1 --> E1["11.6 TPS at solo, 5.7% error rate"]
  end
  subgraph "After (v0.6.24)"
    A2[decode step] --> B2["in-place ring write + pointer advance"]
    B2 --> C2["O(1) per layer, compact every N steps"]
    C2 --> D2["~0 copies/token (amortized)"]
    D2 --> E2["~33+ TPS at solo, ~0.7% error rate (expected)"]
  end
```

## Changes

- `libs/mlx-swift-lm`: `7b81b03` → `c945bfe` (diverged branch → main)
- `provider-swift/.../ProviderCore.swift`: version `0.6.23` → `0.6.24`
- `coordinator/api/server.go`: `LatestProviderVersion` `0.6.23` → `0.6.24`

## Testing

- `swift build` — clean (20.8s)
- `go build ./cmd/coordinator` — clean
- Verified new pin contains: fast decode ring (21 refs to `_base`), `isCompiledDecodeSupported` (6 refs), detokenizer deferred next() (4 refs), Gemma4 fixes (PR #59 in log)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/477"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785114194&installation_id=133247490&pr_number=477&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F477&signature=2c88cf542b843841341c56ad4007b4cc03f9a2e284e8c796f2ceb30304143e81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->