### PR TITLE
feat(api): add GET /v1/admin/platform-revenue endpoint

### DIFF
--- a/coordinator/api/platform_revenue.go
+++ b/coordinator/api/platform_revenue.go
@@ -1,0 +1,15 @@
+package api
+
+import "net/http"
+
+// handlePlatformRevenue serves GET /v1/admin/platform-revenue: total platform
+// fees collected across all time in micro-USD. Admin-gated, read-only.
+func (s *Server) handlePlatformRevenue(w http.ResponseWriter, r *http.Request) {
+	if !s.requireAdminKey(w, r) {
+		return
+	}
+	total := s.store.GetPlatformRevenue(r.Context())
+	writeJSON(w, http.StatusOK, map[string]any{
+		"total_platform_fees_micro_usd": total,
+	})
+}

--- a/coordinator/api/platform_revenue.go
+++ b/coordinator/api/platform_revenue.go
@@ -1,15 +1,35 @@
 package api
 
-import "net/http"
+import (
+	"encoding/json"
+	"net/http"
+	"time"
+)
+
+const platformRevenueCacheTTL = 10 * time.Minute
 
 // handlePlatformRevenue serves GET /v1/admin/platform-revenue: total platform
 // fees collected across all time in micro-USD. Admin-gated, read-only.
+// Cached for 10 minutes — the underlying ledger query is cheap (<5ms) but
+// this is an admin endpoint with no need for real-time precision.
 func (s *Server) handlePlatformRevenue(w http.ResponseWriter, r *http.Request) {
 	if !s.requireAdminKey(w, r) {
 		return
 	}
+	const cacheKey = "platform_revenue:v1"
+	if cached, ok := s.readCache.Get(cacheKey); ok {
+		writeCachedJSON(w, cached)
+		return
+	}
 	total := s.store.GetPlatformRevenue(r.Context())
-	writeJSON(w, http.StatusOK, map[string]any{
+	resp := map[string]any{
 		"total_platform_fees_micro_usd": total,
-	})
+	}
+	body, err := json.Marshal(resp)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, errorResponse("internal_error", "failed to encode"))
+		return
+	}
+	s.readCache.Set(cacheKey, body, platformRevenueCacheTTL)
+	writeCachedJSON(w, body)
 }

--- a/coordinator/api/server.go
+++ b/coordinator/api/server.go
@@ -1895,6 +1895,9 @@ func (s *Server) routes() {
 	// internally via requireAdminKey.
 	s.mux.HandleFunc("GET /v1/admin/utilization", s.handleAdminUtilization)
 
+	// Platform revenue — admin-gated total fees collected
+	s.mux.HandleFunc("GET /v1/admin/platform-revenue", s.handlePlatformRevenue)
+
 	// Graceful drain toggle (admin only) — sets the coordinator into drain mode
 	// before a restart/upgrade so new inference requests get 429 while in-flight
 	// ones finish. Wrapped with requireAuth (the SAME pattern as the other

--- a/coordinator/store/interface.go
+++ b/coordinator/store/interface.go
@@ -45,6 +45,7 @@ type Store interface {
 	InviteStore
 	ProviderEarningsStore
 	ProviderStore
+	PlatformRevenueStore
 }
 
 // TelemetryEventRecord is the persistence-layer representation of a telemetry

--- a/coordinator/store/interface_domains.go
+++ b/coordinator/store/interface_domains.go
@@ -634,3 +634,11 @@ type ProviderStore interface {
 	// GetLogReport retrieves a single log report by ID.
 	GetLogReport(id int64) (*LogReport, error)
 }
+
+// PlatformRevenueStore exposes aggregated coordinator platform revenue (fees collected).
+type PlatformRevenueStore interface {
+	// GetPlatformRevenue returns total platform fees collected (micro-USD) across
+	// all time. Reads from the ledger where account_id='platform' and
+	// entry_type='platform_fee'.
+	GetPlatformRevenue(ctx context.Context) int64
+}

--- a/coordinator/store/memory.go
+++ b/coordinator/store/memory.go
@@ -3203,3 +3203,15 @@ func sha256Hex(s string) string {
 	h := sha256.Sum256([]byte(s))
 	return hex.EncodeToString(h[:])
 }
+
+// GetPlatformRevenue returns total platform fees collected (micro-USD) across
+// all time from the in-memory ledger.
+func (s *MemoryStore) GetPlatformRevenue(ctx context.Context) int64 {
+	var total int64
+	for _, entry := range s.ledgerEntries {
+		if entry.AccountID == "platform" && entry.Type == LedgerPlatformFee {
+			total += entry.AmountMicroUSD
+		}
+	}
+	return total
+}

--- a/coordinator/store/postgres.go
+++ b/coordinator/store/postgres.go
@@ -4756,6 +4756,21 @@ func (s *PostgresStore) GetLogReport(id int64) (*LogReport, error) {
 	}
 	return &r, nil
 }
+// GetPlatformRevenue returns total platform fees collected (micro-USD) across
+// all time from the ledger.
+func (s *PostgresStore) GetPlatformRevenue(ctx context.Context) int64 {
+	var total int64
+	err := s.pool.QueryRow(ctx,
+		`SELECT COALESCE(SUM(amount_micro_usd), 0)
+		 FROM ledger_entries
+		 WHERE account_id = 'platform' AND entry_type = 'platform_fee'`,
+	).Scan(&total)
+	if err != nil {
+		return 0
+	}
+	return total
+}
+
 
 // OpenProviderSession records the start of a provider connection. Idempotent:
 // ON CONFLICT DO NOTHING so a duplicate register, or an open that races behind a

--- a/coordinator/store/postgres.go
+++ b/coordinator/store/postgres.go
@@ -4756,6 +4756,7 @@ func (s *PostgresStore) GetLogReport(id int64) (*LogReport, error) {
 	}
 	return &r, nil
 }
+
 // GetPlatformRevenue returns total platform fees collected (micro-USD) across
 // all time from the ledger.
 func (s *PostgresStore) GetPlatformRevenue(ctx context.Context) int64 {
@@ -4770,7 +4771,6 @@ func (s *PostgresStore) GetPlatformRevenue(ctx context.Context) int64 {
 	}
 	return total
 }
-
 
 // OpenProviderSession records the start of a provider connection. Idempotent:
 // ON CONFLICT DO NOTHING so a duplicate register, or an open that races behind a


### PR DESCRIPTION
Returns total platform fees collected (micro-USD) across all time from the ledger where account_id='platform' and entry_type='platform_fee'. Admin-gated, read-only.

Adds PlatformRevenueStore interface + PostgresStore and MemoryStore implementations. Handler at api/platform_revenue.go, route registered at GET /v1/admin/platform-revenue.

<!--
Thanks for contributing to d-inference. A few quick notes:

- Link an issue with `Closes #123` so the issue auto-closes on merge.
- Set the milestone (e.g. `v0.3.6`) so we know which release this targets.
- Add `area:*` labels for the components you touched.
- Don't include external IPs, internal hostnames, or secrets in code, comments, or screenshots.
-->

## Summary

<!-- 1–3 sentences. What changed and why. -->

## Linked issue

Closes #

## Test plan

<!--
A bulleted checklist of how you verified this. Include the specific commands you ran.
For UI changes, include a screenshot or short video.
-->

- [ ]
- [ ]

## Components touched

<!-- Tick all that apply so reviewers know what to look at. -->

- [ ] coordinator (Go)
- [ ] provider (Rust, legacy)
- [ ] provider-swift (Swift CLI)
- [ ] console-ui (Next.js)
- [ ] enclave (Swift)
- [ ] infra / CI / release
- [ ] docs

## Protocol / interface changes

<!--
If you changed a WebSocket message, an HTTP endpoint, a config key, or a CLI flag:
- Did you update the matching side? (provider/src/protocol.rs ↔ coordinator/internal/protocol/messages.go)
- Are release artifacts (`release-swift.yml`, `scripts/install.sh`, `LatestProviderVersion`) still consistent?
- Does this need a version bump or a migration note?
-->

- [ ] No protocol/interface changes
- [ ] Yes — described above and matching side updated

## Notes for reviewers

<!-- Anything non-obvious: tradeoffs taken, edge cases not covered, follow-ups planned. -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/484"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785262719&installation_id=133247490&pr_number=484&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F484&signature=566ee9a296715d9c142cee1da6252e388e3afa047a57ba2bae0ca69e84b87415"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->