### PR TITLE
coordinator: stamp build version/commit into /health via ldflags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,12 +15,24 @@ help:
 coordinator-test: ## Run Go unit tests for the coordinator
 	cd coordinator && go test ./...
 
+# Stamp build metadata into the binary so /health is traceable to a commit
+# (matches the ldflags the release Dockerfile injects). Falls back to dev/unknown
+# outside a git checkout.
+GIT_COMMIT ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)
+GIT_VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
+BUILD_DATE ?= $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
+COORDINATOR_LDFLAGS := \
+	-X github.com/eigeninference/d-inference/coordinator/api.BuildVersion=$(GIT_VERSION) \
+	-X github.com/eigeninference/d-inference/coordinator/api.BuildCommit=$(GIT_COMMIT) \
+	-X github.com/eigeninference/d-inference/coordinator/api.BuildDate=$(BUILD_DATE) \
+	-X github.com/eigeninference/d-inference/coordinator/telemetry.CoordinatorVersion=$(GIT_VERSION)
+
 coordinator-build: ## Build the coordinator binary for the host platform
-	cd coordinator && go build ./cmd/coordinator
+	cd coordinator && go build -ldflags="$(COORDINATOR_LDFLAGS)" ./cmd/coordinator
 
 coordinator-build-linux: ## Cross-compile coordinator for linux/amd64 (EigenCloud)
 	cd coordinator && GOOS=linux GOARCH=amd64 CGO_ENABLED=0 \
-	    go build -o coordinator-linux ./cmd/coordinator
+	    go build -ldflags="$(COORDINATOR_LDFLAGS)" -o coordinator-linux ./cmd/coordinator
 
 coordinator: coordinator-test coordinator-build ## Test + build coordinator
 

--- a/coordinator/Dockerfile
+++ b/coordinator/Dockerfile
@@ -3,7 +3,18 @@ WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o /app/coordinator-bin ./coordinator/cmd/coordinator
+
+# Build metadata stamped into the binary so /health is traceable to a commit.
+# Cloud Build passes GIT_COMMIT/GIT_VERSION=$SHORT_SHA (deploy/gcp/cloudbuild.yaml);
+# they default to dev/unknown for plain `docker build` so local images still work.
+ARG GIT_COMMIT=unknown
+ARG GIT_VERSION=dev
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a \
+    -ldflags="-X github.com/eigeninference/d-inference/coordinator/api.BuildVersion=${GIT_VERSION} \
+              -X github.com/eigeninference/d-inference/coordinator/api.BuildCommit=${GIT_COMMIT} \
+              -X github.com/eigeninference/d-inference/coordinator/api.BuildDate=$(date -u +%Y-%m-%dT%H:%M:%SZ) \
+              -X github.com/eigeninference/d-inference/coordinator/telemetry.CoordinatorVersion=${GIT_VERSION}" \
+    -o /app/coordinator-bin ./coordinator/cmd/coordinator
 
 # Pre-built base with MicroMDM v1.13.1, step-ca v0.28.3, step CLI v0.28.3.
 # Rebuild base only when tool versions change: docker build -f Dockerfile.base -t eigengajesh/d-inference-base:latest . && docker push

--- a/deploy/gcp/cloudbuild.yaml
+++ b/deploy/gcp/cloudbuild.yaml
@@ -29,6 +29,8 @@ steps:
     name: gcr.io/cloud-builders/docker
     args:
       - build
+      - --build-arg=GIT_COMMIT=$SHORT_SHA
+      - --build-arg=GIT_VERSION=$SHORT_SHA
       - --tag=${_IMAGE}:$SHORT_SHA
       - --tag=${_IMAGE}:latest
       - --file=coordinator/Dockerfile


### PR DESCRIPTION
## Problem

The live coordinator at `api.darkbloom.dev/health` reported `build=dev` / `commit=unknown` for 4 consecutive days (2026-06-26 → 06-29), so the running binary could not be traced to a git tag/SHA — a release-traceability and incident-triage gap. (DAR-371, closes #485)

Cloud Build (`deploy/gcp/cloudbuild.yaml`) already tags images with `$SHORT_SHA`, but that SHA was never threaded into the binary's version string, so the `api.Build*` vars kept their `dev`/`unknown` defaults.

## Fix

Inject the build metadata via `-ldflags -X` at build time:

- **`coordinator/Dockerfile`** — new `GIT_COMMIT` / `GIT_VERSION` build args (default `unknown`/`dev` so plain `docker build` still works) stamped into `go build`; `BuildDate` set to image build time. Stamps both `coordinator/api.{BuildVersion,BuildCommit,BuildDate}` and `coordinator/telemetry.CoordinatorVersion`.
- **`deploy/gcp/cloudbuild.yaml`** — pass `--build-arg GIT_COMMIT=$SHORT_SHA` and `--build-arg GIT_VERSION=$SHORT_SHA` to the docker build step.
- **`Makefile`** — stamp the same ldflags from `git` for local/manual `coordinator-build` and `coordinator-build-linux`.

The same `coordinator/Dockerfile` is the image EigenCloud prod uses, so both the GCP dev VM and EigenCloud prod `/health` become traceable.

## Verification

Compiled the coordinator with the ldflags (go 1.25) — build succeeds; `go tool nm` confirms all four symbols are stamped and the short SHA is embedded in the binary:

```
api.BuildVersion / api.BuildCommit / api.BuildDate / telemetry.CoordinatorVersion  → present
```

After this lands and redeploys, `GET /health` returns the real `version` / `build_commit` / `build_date` instead of `dev` / `unknown`.

> Triage note from the issue: it's still worth confirming whether `api.darkbloom.dev` is the dev or prod surface, and whether the EigenCloud prod coordinator likewise reported `dev/unknown`. This change fixes traceability for both since they share the Dockerfile.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/486"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785331258&installation_id=133247490&pr_number=486&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F486&signature=bccea6bca5251f2c6b6ccbd1dcb93698133ef790d808994494c1df43acc98660"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->