### PR TITLE
release(provider): v0.6.29 — Gemma4 MoE compiled decode + DH-key chunk encryption

### DIFF
--- a/coordinator/api/server.go
+++ b/coordinator/api/server.go
@@ -145,7 +145,7 @@ func keyLimitResetFromContext(ctx context.Context) string {
 // 0.6.0 is the APNs code-identity / VLM-routing / graceful-update release.
 // Keep this fallback in sync with ProviderCore.version so dev/in-memory
 // coordinators advertise the same floor as the Swift binary they expect.
-var LatestProviderVersion = "0.6.28"
+var LatestProviderVersion = "0.6.29"
 
 // minProviderVersionForDesiredModels is the first provider version whose Swift
 // runtime understands the desired_models message. The coordinator must NOT send

--- a/provider-swift/Sources/ProviderCore/ProviderCore.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderCore.swift
@@ -75,5 +75,5 @@ public enum ProviderCore {
     // jinja_null_bridge / jinja_template / model_load), so durable telemetry can
     // tell the two indistinguishable gpt-oss 500 modes apart. Wire-compatible:
     // `error_reason` is an optional inference-error field, omitted when nil.
-    public static let version = "0.6.28"
+    public static let version = "0.6.29"
 }


### PR DESCRIPTION
## Summary
Version bump **0.6.28 → 0.6.29** (`ProviderCore.version` + coordinator `LatestProviderVersion`). All functional changes are already merged to master since v0.6.28.

## Release contents
- **#482** — Gemma4 MoE compiled decode + fused gate+up + bf16 (pin `mlx-swift-lm` `5d0a084`), including the P1/P2 compiled-decode correctness fixes (Codex-clean). Gemma decode 64→78 TPS @ B=1 on M4 Max.
- **#483** — precompute DH shared key for chunk encryption (~150µs → ~2µs per chunk).

## Before / After
```mermaid
flowchart LR
  A[fleet on v0.6.28<br/>Gemma ~9 tok/s prod, ~150µs/chunk crypto] --> B[v0.6.29<br/>compiled MoE decode + ~2µs/chunk crypto]
```

## Rollout note
After this merges + the `v0.6.29` tag builds/signs/notarizes and uploads the bundle, the coordinator must be redeployed to advertise `LatestProviderVersion=0.6.29` to the fleet. `scripts/install.sh` reads the version from the release JSON (no change needed).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/487"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785456198&installation_id=133247490&pr_number=487&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F487&signature=3a8b4ccbbcd77bbeecb85a1669682168c90cf1ecc47b2356ccc22e45a052691e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->