### PR TITLE
feat(provider): default-on n-gram loop detection for Gemma-4 requests

### DIFF
--- a/provider-swift/Sources/ProviderCore/Inference/BatchScheduler+LoopDetectionDefaults.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/BatchScheduler+LoopDetectionDefaults.swift
@@ -1,0 +1,55 @@
+// Copyright © 2026 Eigen Labs.
+//
+// Default-on n-gram tail-loop detection for Gemma-4 requests.
+//
+// mlx-swift-lm's `TailLoopDetector` / `SamplingParams.loopDetectionMaxPatternSize`
+// is a generic, opt-in library primitive -- disabled by default there, since
+// the library has no way to know which model families it's safe to force on
+// for. Gemma 4 specifically is known to hit a degenerate repetition-collapse
+// bug (a reference MLX runtime, mlxcel, defaults its own n-gram loop breaker
+// on for exactly this model family after validating it there). This file
+// makes the analogous provider-side decision -- default loop detection ON
+// for Gemma-4 requests -- mirroring the model-family gate already used by
+// `BatchScheduler+B1FastPath.swift`.
+
+import Foundation
+
+extension BatchScheduler {
+
+    // MARK: - Env gate
+
+    /// Whether Gemma-4 default loop detection is enabled. **Default ON.** Opt
+    /// OUT with `DARKBLOOM_GEMMA_LOOP_DETECTION` set to `"0"`/`"false"`/`"no"`/
+    /// `"off"`, e.g. to disable it without a code deploy if it ever needs
+    /// disabling. Read per-call (cheap), same pattern as
+    /// `b1GreedyFastPathEnabled()`.
+    static func gemmaLoopDetectionEnabled() -> Bool {
+        let env = ProcessInfo.processInfo.environment
+        let off: Set<String> = ["0", "false", "no", "off"]
+        if let v = env["DARKBLOOM_GEMMA_LOOP_DETECTION"], off.contains(v.lowercased()) {
+            return false
+        }
+        return true
+    }
+
+    // MARK: - Defaults
+
+    /// Loop-detection parameters to apply for `modelId`, or `nil` if this
+    /// model family shouldn't get a default. Pure function -- no actor state
+    /// -- so it's fully unit-testable without a loaded model, mirroring
+    /// `b1FastPathEligiblePure`.
+    ///
+    /// Only Gemma-4 is covered today: it's the one family with a known,
+    /// specific repetition-collapse issue (see mlxcel's own default-on scope
+    /// for the same bug). Every other model family is unaffected until it has
+    /// its own validated case for a default -- this is intentionally narrow,
+    /// not a blanket "enable for everything" switch.
+    static func loopDetectionDefaults(
+        modelId: String,
+        enabled: Bool
+    ) -> (maxPatternSize: Int, minCount: Int)? {
+        guard enabled else { return nil }
+        guard modelId.lowercased().contains("gemma") else { return nil }
+        return (maxPatternSize: 64, minCount: 3)
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Inference/BatchScheduler+Submit.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/BatchScheduler+Submit.swift
@@ -204,6 +204,12 @@ extension BatchScheduler {
         if let topP { sp.topP = topP }
         if let topK { sp.topK = topK }
         if let seed { sp.seed = seed }
+        if let loopDefaults = Self.loopDetectionDefaults(
+            modelId: modelId, enabled: Self.gemmaLoopDetectionEnabled())
+        {
+            sp.loopDetectionMaxPatternSize = loopDefaults.maxPatternSize
+            sp.loopDetectionMinCount = loopDefaults.minCount
+        }
 
         let req = Request(
             requestId: id,
@@ -415,6 +421,12 @@ extension BatchScheduler {
         if let topP = request.top_p { sp.topP = topP }
         if let topK = request.top_k { sp.topK = topK }
         if let seed = request.seed { sp.seed = seed }
+        if let loopDefaults = Self.loopDetectionDefaults(
+            modelId: modelId, enabled: Self.gemmaLoopDetectionEnabled())
+        {
+            sp.loopDetectionMaxPatternSize = loopDefaults.maxPatternSize
+            sp.loopDetectionMinCount = loopDefaults.minCount
+        }
 
         let req = Request(
             requestId: id,

--- a/provider-swift/Tests/ProviderCoreTests/GemmaLoopDetectionDefaultsTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/GemmaLoopDetectionDefaultsTests.swift
@@ -1,0 +1,79 @@
+// GemmaLoopDetectionDefaultsTests -- unit coverage for the default-on n-gram
+// tail-loop detection gate applied to Gemma-4 requests
+// (BatchScheduler+LoopDetectionDefaults.swift).
+//
+// Pure function, no model/GPU required -- mirrors the style of
+// B1GreedyFastPathTests's eligibility-policy tests.
+
+import Foundation
+import Testing
+
+@testable import ProviderCore
+
+@Suite("Gemma-4 default loop detection")
+struct GemmaLoopDetectionDefaultsTests {
+
+    @Test("Gemma-4 model ids get the default when enabled")
+    func gemmaModelGetsDefault() {
+        let defaults = BatchScheduler.loopDetectionDefaults(
+            modelId: "mlx-community/gemma-4-26b-a4b-it-8bit", enabled: true)
+        #expect(defaults?.maxPatternSize == 64)
+        #expect(defaults?.minCount == 3)
+    }
+
+    @Test("model id matching is case-insensitive")
+    func caseInsensitiveMatch() {
+        let defaults = BatchScheduler.loopDetectionDefaults(
+            modelId: "MLX-Community/Gemma-4-12B-IT-4bit", enabled: true)
+        #expect(defaults != nil)
+    }
+
+    @Test("non-Gemma model families get no default")
+    func nonGemmaModelGetsNoDefault() {
+        for modelId in [
+            "mlx-community/Qwen3.5-4B-4bit",
+            "mlx-community/gpt-oss-20b-mxfp4",
+            "mlx-community/Llama-3.2-3B-Instruct-4bit",
+        ] {
+            #expect(BatchScheduler.loopDetectionDefaults(modelId: modelId, enabled: true) == nil)
+        }
+    }
+
+    /// The `.contains("gemma")` match is a substring match, not "exactly
+    /// Gemma-4" -- it also catches Gemma-2/Gemma-3 ids, mirroring the
+    /// identical imprecision already in `BatchScheduler+B1FastPath.swift`'s
+    /// own Gemma-family gate. Pinning that here so it's an explicit, known
+    /// scope decision rather than an implicit side effect discovered later.
+    /// If this repo ever validates loop detection specifically against
+    /// Gemma-2/Gemma-3 (or decides it should NOT apply there), update this
+    /// test alongside `loopDetectionDefaults` and `b1FastPathEligiblePure`
+    /// together -- they should not drift apart on model-family scoping.
+    @Test("the match is broader than Gemma-4 alone -- also matches Gemma-2/Gemma-3, by design parity with B1FastPath")
+    func matchIsBroaderThanGemma4Alone() {
+        #expect(BatchScheduler.loopDetectionDefaults(modelId: "mlx-community/gemma-2-9b-it-4bit", enabled: true) != nil)
+        #expect(BatchScheduler.loopDetectionDefaults(modelId: "mlx-community/gemma-3-27b-it-4bit", enabled: true) != nil)
+    }
+
+    @Test("the env kill switch disables the default even for Gemma-4")
+    func disabledGateShortCircuits() {
+        #expect(
+            BatchScheduler.loopDetectionDefaults(
+                modelId: "mlx-community/gemma-4-26b-a4b-it-8bit", enabled: false) == nil)
+    }
+
+    @Test("empty model id gets no default")
+    func emptyModelIdGetsNoDefault() {
+        #expect(BatchScheduler.loopDetectionDefaults(modelId: "", enabled: true) == nil)
+    }
+
+    @Test("loop detection is ON by default; the env flag opts OUT")
+    func envFlagDefaultOn() {
+        // Same shape as B1GreedyFastPathTests.envFlagDefaultOn: documents the
+        // expectation rather than asserting a hard true, since a developer's
+        // shell may have exported the opt-out.
+        let env = ProcessInfo.processInfo.environment
+        let off: Set<String> = ["0", "false", "no", "off"]
+        let optedOut = off.contains((env["DARKBLOOM_GEMMA_LOOP_DETECTION"] ?? "").lowercased())
+        #expect(BatchScheduler.gemmaLoopDetectionEnabled() == !optedOut)
+    }
+}


### PR DESCRIPTION
## ⚠️ Blocked on Layr-Labs/mlx-swift-lm#61

This PR references `SamplingParams.loopDetectionMaxPatternSize` / `loopDetectionMinCount`, which only exist on the **open, unmerged** `mlx-swift-lm` PR [#61](https://github.com/Layr-Labs/mlx-swift-lm/pull/61). It was built and tested locally against a temporary submodule pin to that PR's branch tip (not committed — the pin isn't a real merged commit). **Opened as a draft** for review now; once #61 merges, this needs one follow-up commit bumping `libs/mlx-swift-lm` to the real merged SHA before it can build/pass CI or be marked ready.

## Summary

- mlx-swift-lm#61 added a generic, opt-in n-gram tail-loop detector to break degenerate repeating-cycle generation (e.g. the model getting stuck emitting `"a b c a b c ..."` forever). It defaults to **disabled** there — the shared library has no way to know which model families it's safe to force on for.
- Gemma 4 specifically has a known repetition-collapse bug (the reference MLX runtime, mlxcel, defaults its own equivalent loop breaker on for exactly this model family, after validating it there). This PR makes that provider-side call: default the detector **ON** for Gemma-4 requests.
- New `BatchScheduler+LoopDetectionDefaults.swift`: `gemmaLoopDetectionEnabled()` (env-gated, default ON, opt out with `DARKBLOOM_GEMMA_LOOP_DETECTION=0/false/no/off`) + `loopDetectionDefaults(modelId:enabled:)` (pure function returning `(maxPatternSize: 64, minCount: 3)` for Gemma model ids, else `nil`) — deliberately mirrors the existing `BatchScheduler+B1FastPath.swift` model-family gate (`modelId.lowercased().contains("gemma")`), including that gate's same Gemma-2/Gemma-3-also-matches breadth (pinned down explicitly in a new test rather than left implicit).
- Wired into both `SamplingParams` construction sites in `BatchScheduler+Submit.swift` (`submitTokenized` and `submit(request: ChatCompletionRequest, ...)`) — confirmed via grep these are the only two production call sites; the other four `SamplingParams(...)` constructions in the repo are benchmark/test scaffolding.
- 7 new tests in `GemmaLoopDetectionDefaultsTests.swift`.

## Review notes

Reviewed independently by a Claude agent and Codex; both passed. Codex traced the actual request-routing path (`MultiModelBatchSchedulerEngine.swift`) to confirm reading `modelId` from `BatchScheduler`'s own actor state (rather than per-request) is safe — one scheduler instance always serves exactly one loaded model, and the scheduler is looked up per-model before submission. The independent reviewer flagged that the substring match also covers Gemma-2/Gemma-3, not just Gemma-4; confirmed this exactly mirrors the identical pre-existing imprecision already in `B1FastPath.swift`, not a new scope decision — added `matchIsBroaderThanGemma4Alone` to make it an explicit, tracked decision.

## Behavior: before vs. after

```mermaid
flowchart LR
  subgraph Before
    A1[Gemma-4 request submitted] --> B1[SamplingParams built:<br/>maxTokens/temperature/topP/topK/seed]
    B1 --> C1[No loop-cycle protection<br/>-- dormant capability, opt-in default OFF]
  end
  subgraph After
    A2[Gemma-4 request submitted] --> B2[SamplingParams built] --> C2{modelId contains 'gemma'<br/>AND env gate on?}
    C2 -->|yes| D2[loopDetectionMaxPatternSize=64<br/>loopDetectionMinCount=3]
    C2 -->|no, other model family| E2[unchanged -- no default applied]
  end
```

## Code: before vs. after

```mermaid
flowchart TB
  subgraph Before["Before"]
    B1[submitTokenized / submit] --> B2["var sp = SamplingParams(...)"]
    B2 --> B3["sp.topP / sp.topK / sp.seed<br/>(if present)"]
  end
  subgraph After["After"]
    A1[submitTokenized / submit] --> A2["var sp = SamplingParams(...)"]
    A2 --> A3["sp.topP / sp.topK / sp.seed<br/>(if present)"]
    A3 --> A4["Self.loopDetectionDefaults(<br/>modelId: modelId,<br/>enabled: Self.gemmaLoopDetectionEnabled())"]
    A4 -->|non-nil| A5["sp.loopDetectionMaxPatternSize<br/>sp.loopDetectionMinCount"]
    A4 -->|nil| A6[unchanged]
  end
```

## Test plan

- [x] `swift build --target ProviderCore` — clean
- [x] `swift test --filter "GemmaLoopDetectionDefaultsTests|B1GreedyFastPathEligibilityTests"` — 22/22 pass, no regressions in the B1FastPath gate this mirrors
- [x] Dual review (Claude + Codex) — both pass
- [ ] Blocked: full CI / merge, pending mlx-swift-lm#61

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/488"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785457777&installation_id=133247490&pr_number=488&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F488&signature=9a711776eeeb420076799294e932f10fcfa41fd4990f4ada5067ca0e38daba15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->