### PR TITLE
release(provider): v0.6.30 — roll back Gemma4 compiled decode (revert to 0.6.28 engine)

### DIFF
--- a/coordinator/api/server.go
+++ b/coordinator/api/server.go
@@ -145,7 +145,7 @@ func keyLimitResetFromContext(ctx context.Context) string {
 // 0.6.0 is the APNs code-identity / VLM-routing / graceful-update release.
 // Keep this fallback in sync with ProviderCore.version so dev/in-memory
 // coordinators advertise the same floor as the Swift binary they expect.
-var LatestProviderVersion = "0.6.29"
+var LatestProviderVersion = "0.6.30"
 
 // minProviderVersionForDesiredModels is the first provider version whose Swift
 // runtime understands the desired_models message. The coordinator must NOT send

--- a/provider-swift/Sources/ProviderCore/ProviderCore.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderCore.swift
@@ -75,5 +75,5 @@ public enum ProviderCore {
     // jinja_null_bridge / jinja_template / model_load), so durable telemetry can
     // tell the two indistinguishable gpt-oss 500 modes apart. Wire-compatible:
     // `error_reason` is an optional inference-error field, omitted when nil.
-    public static let version = "0.6.29"
+    public static let version = "0.6.30"
 }


### PR DESCRIPTION
## Incident rollback

v0.6.29's compiled-decode engine (`mlx-swift-lm 5d0a084`: `compile()` graph trace + bf16 weight conversion) has a heavy **cold start**. During the 00:00 UTC surge the fleet-wide v0.6.29 rollover **cold-started into peak load** — the ~26 GB Gemma model couldn't load + convert + compile within the TTFT deadline, so **Gemma dropped to ~2% success** (503 `provider_error` / 504 `first_chunk_timeout`), an effective outage. gpt-oss survived (smaller, warms fast).

## Change
- **Revert `libs/mlx-swift-lm` `5d0a084` → `e5d0a94`** (v0.6.28's known-good engine — no compiled decode, no bf16 conversion, no cold-start penalty).
- Bump `ProviderCore.version` + coordinator `LatestProviderVersion` `0.6.29 → 0.6.30` so the fleet auto-updates **forward** out of the broken 0.6.29.
- **Kept #483** (DH-key chunk-encryption precompute) — unrelated to the breakage, proven safe since 0.6.29.

v0.6.30 = **0.6.28 decode engine + version bump** (+ #483).

## Before / After
```mermaid
flowchart LR
  subgraph "v0.6.29 (broken)"
    A1[Gemma req] --> B1[cold box: load 26GB + bf16 + compile] --> C1[TTFT deadline blown -> 503/504] --> D1[~2% success]
  end
  subgraph "v0.6.30 (rollback)"
    A2[Gemma req] --> B2[0.6.28 engine: load 26GB, no compile] --> C2[first token in ~1.8s] --> D2[serves normally]
  end
```

## Follow-up
Compiled decode returns only after **DAR-378** (pre-warm / pre-compile at load, off the request critical path) so the cold-start cost is amortized during load, not paid on a live deadline-bound request.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/489"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785458918&installation_id=133247490&pr_number=489&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F489&signature=1f1992068ab7784183bc384ad4f0ae681223c390a6056b4885d556c7d057b87d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->