### PR TITLE
chore(attestation): retire the hypervisor_active stub — field, entitlement, and false UI claims

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,7 +74,7 @@ scripts/              build, signing, install, and deploy helpers
 ├── publish-model.sh  model registry publish workflow
 ├── deploy-acme.sh    nginx/step-ca helper
 ├── fetch-metallib.sh MLX metallib builder (cmake from libs/mlx-swift source)
-└── entitlements.plist hardened runtime entitlements (hypervisor, network)
+└── entitlements.plist hardened runtime entitlements (network, keychain)
 
 docs/                 architecture, deploy runbooks, MDM/ACME notes, threat model
 .github/workflows/    CI (ci.yml), integration tests (integration.yml), Swift release (release-swift.yml),

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,7 @@ scripts/
 ├── deploy-acme.sh    nginx/step-ca helper
 ├── fetch-metallib.sh MLX metallib fetcher
 ├── smoke-dev.sh      Dev-coordinator smoke test
-└── entitlements.plist Hardened Runtime entitlements (hypervisor, network)
+└── entitlements.plist Hardened Runtime entitlements (network, keychain)
 
 docs/                 Architecture docs, deploy runbook, MDM/ACME notes, threat model
 .github/workflows/    CI (ci.yml), integration tests (integration.yml), Swift release (release-swift.yml),
@@ -188,7 +188,6 @@ CI (`.github/workflows/release-swift.yml`) builds, signs, notarizes, and uploads
 - **Challenge timing**: Initial attestation challenge sent immediately on provider registration, then every 5 minutes via ticker.
 - **Model scan performance**: `scan_models()` does fast discovery without hashing. Weight hash computed on-demand only for the model being served via `compute_weight_hash()`.
 - **Chat template injection**: Provider auto-injects ChatML template for models missing `chat_template` field (e.g., Qwen3.5 base models).
-- **Hypervisor memory isolation**: Apple Hypervisor.framework creates Stage 2 page tables to protect inference memory from RDMA/DMA attacks. Requires `com.apple.security.hypervisor` entitlement.
 - **Device auth**: RFC 8628 device code flow for linking provider machines to user accounts. Provider runs `login`, gets a code, user enters it on the web.
 - **CI code signing**: GitHub Actions release workflow signs provider binary with Developer ID Application cert, notarizes with Apple, computes SHA-256 hashes after signing. Provisioning profile embedded in .app bundle for persistent SE key.
 - **Observability**: Datadog DogStatsD metrics for attestation, routing, billing, fleet version, provider capacity. X-Timing JSON header decomposes per-request latency (parse, reserve, route, queue, encrypt, dispatch, provider).

--- a/README.md
+++ b/README.md
@@ -92,7 +92,6 @@ sequenceDiagram
 | In-process inference | MLX runs inside the provider process — no subprocess, local server, or IPC to observe |
 | Hardened Runtime + SIP | Blocks debugger attachment, memory reads, and code injection; immutable for the process lifetime |
 | `PT_DENY_ATTACH` | Kernel-level denial of debugger attach |
-| Hypervisor memory isolation | `Hypervisor.framework` Stage-2 page tables protect inference memory from RDMA/DMA attacks |
 
 ### Attestation & trust
 

--- a/console-ui/src/components/TrustExplainerModal.tsx
+++ b/console-ui/src/components/TrustExplainerModal.tsx
@@ -91,8 +91,8 @@ const STEPS: StepData[] = [
       "The coordinator sends attestation challenges (32-byte random nonce + timestamp) " +
       "every 5 minutes. The provider must sign the challenge with its SE key and report " +
       "fresh security posture: SIP status, Secure Boot, binary hash (self-hash of provider binary), " +
-      "RDMA status, hypervisor isolation status, and runtime integrity hashes " +
-      "(Python, vllm-mlx, Jinja templates). Any mismatch triggers demotion.",
+      "RDMA status, and runtime integrity hashes (MLX-Swift runtime, chat templates, " +
+      "and active model weights). Any mismatch triggers demotion.",
   },
 ];
 

--- a/console-ui/src/hooks/useChatStream.ts
+++ b/console-ui/src/hooks/useChatStream.ts
@@ -14,7 +14,7 @@ When users ask "what is Darkbloom" or about the platform, use ONLY these facts:
 - Every provider machine is verified through Apple's Secure Enclave, MDM, and Managed Device Attestation (MDA)
 - All prompts are end-to-end encrypted using X25519 NaCl box encryption — the node operator never sees your data
 - The coordinator routes traffic but cannot read plaintext prompts
-- Runtime integrity is enforced on every node: SIP, Hardened Runtime, binary self-hash, Hypervisor.framework memory isolation
+- Runtime integrity is enforced on every node: SIP, Hardened Runtime, and binary self-hash
 - The full attestation chain is public and independently verifiable at /v1/providers/attestation
 - Darkbloom is an Eigen Labs project, currently in public alpha (https://darkbloom.dev)
 

--- a/coordinator/api/provider.go
+++ b/coordinator/api/provider.go
@@ -927,8 +927,12 @@ func (s *Server) verifyChallengeResponse(providerID string, provider *registry.P
 		// tampering or the provider is signing a different canonical
 		// payload than this code expects.
 		statusInput := attestation.StatusCanonicalInput{
-			Nonce:             pc.nonce,
-			Timestamp:         pc.timestamp,
+			Nonce:     pc.nonce,
+			Timestamp: pc.timestamp,
+			// Legacy fleet compat only: old providers (< v0.6.31) sign
+			// hypervisor_active into the canonical status, so it must be
+			// carried into the reconstruction when reported. New providers
+			// omit it (nil). See attestation.StatusCanonicalInput.
 			HypervisorActive:  resp.HypervisorActive,
 			RDMADisabled:      resp.RDMADisabled,
 			SIPEnabled:        resp.SIPEnabled,
@@ -1049,7 +1053,7 @@ func (s *Server) verifyChallengeResponse(providerID string, provider *registry.P
 	// cluster runtimes. RDMA enablement is not itself a challenge failure:
 	// Apple Silicon Thunderbolt RDMA is IOMMU-scoped to registered buffers,
 	// so the security boundary is the signed runtime's buffer-registration
-	// discipline, not a hypervisor flag.
+	// discipline.
 	if resp.RDMADisabled == nil {
 		s.handleChallengeFailure(providerID, "RDMA status not reported — provider must update to v0.2.0+")
 		return
@@ -1058,7 +1062,6 @@ func (s *Server) verifyChallengeResponse(providerID string, provider *registry.P
 		s.logger.Info("provider RDMA enabled — accepting under registered-buffer RDMA policy",
 			"provider_id", providerID,
 			"backend", provider.Backend,
-			"hypervisor_active", resp.HypervisorActive,
 		)
 	}
 
@@ -1287,17 +1290,13 @@ func (s *Server) verifyChallengeResponse(providerID string, provider *registry.P
 		return
 	}
 
-	// Override self-reported privacy capabilities with coordinator-verified
-	// values from the challenge response. The coordinator independently checks
-	// SIP during each attestation challenge. Hypervisor status is preserved as
-	// a reported capability only; it is not the RDMA safety proof.
+	// Override the self-reported SIP capability with the coordinator-verified
+	// value from the challenge response. The coordinator independently checks
+	// SIP during each attestation challenge.
 	provider.Mu().Lock()
 	if provider.PrivacyCapabilities != nil {
 		if resp.SIPEnabled != nil {
 			provider.PrivacyCapabilities.SIPEnabled = *resp.SIPEnabled
-		}
-		if resp.HypervisorActive != nil {
-			provider.PrivacyCapabilities.HypervisorActive = *resp.HypervisorActive
 		}
 	}
 	provider.ChallengeVerifiedSIP = resp.SIPEnabled != nil && *resp.SIPEnabled
@@ -1330,7 +1329,6 @@ func (s *Server) verifyChallengeResponse(providerID string, provider *registry.P
 		"sip_enabled", resp.SIPEnabled,
 		"secure_boot_enabled", resp.SecureBootEnabled,
 		"rdma_disabled", resp.RDMADisabled,
-		"hypervisor_active", resp.HypervisorActive,
 		"binary_hash", resp.BinaryHash,
 		"active_model_hash", resp.ActiveModelHash,
 		"model_hashes_count", len(resp.ModelHashes),

--- a/coordinator/api/provider_test.go
+++ b/coordinator/api/provider_test.go
@@ -1235,7 +1235,11 @@ func TestChallengeResponseSuccess(t *testing.T) {
 	}
 }
 
-func TestChallengeResponseAllowsRDMAEnabledWithoutHypervisor(t *testing.T) {
+// TestChallengeResponseAllowsRDMAEnabled verifies RDMA-enabled providers pass
+// the challenge under the registered-buffer RDMA policy. The response also
+// carries the retired hypervisor_active field the way a legacy (< v0.6.31)
+// provider still sends it — the coordinator must tolerate it on the wire.
+func TestChallengeResponseAllowsRDMAEnabled(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	st := store.NewMemory(store.Config{AdminKey: "test-key"})
 	reg := registry.New(logger)
@@ -1290,7 +1294,7 @@ func TestChallengeResponseAllowsRDMAEnabledWithoutHypervisor(t *testing.T) {
 		var challenge protocol.AttestationChallengeMessage
 		json.Unmarshal(data, &challenge)
 		rdmaDisabled := false
-		hypervisorActive := false
+		hypervisorActive := false // legacy (< v0.6.31) providers still send this retired field
 		sipEnabled := true
 		secureBootEnabled := true
 		response := protocol.AttestationResponseMessage{

--- a/coordinator/attestation/attestation.go
+++ b/coordinator/attestation/attestation.go
@@ -50,16 +50,21 @@ type AttestationBlob struct {
 	ChipName                 string `json:"chipName"`
 	EncryptionPublicKey      string `json:"encryptionPublicKey,omitempty"`
 	HardwareModel            string `json:"hardwareModel"`
-	HypervisorActive         bool   `json:"hypervisorActive"`
-	OSVersion                string `json:"osVersion"`
-	PublicKey                string `json:"publicKey"`
-	RDMADisabled             bool   `json:"rdmaDisabled"`
-	SecureBootEnabled        bool   `json:"secureBootEnabled"`
-	SecureEnclaveAvailable   bool   `json:"secureEnclaveAvailable"`
-	SerialNumber             string `json:"serialNumber,omitempty"`
-	SIPEnabled               bool   `json:"sipEnabled"`
-	SystemVolumeHash         string `json:"systemVolumeHash,omitempty"`
-	Timestamp                string `json:"timestamp"`
+	// HypervisorActive — legacy fleet compat only: old providers (< v0.6.31)
+	// include this hardcoded-false field in their SIGNED blob JSON, so it must
+	// keep decoding (non-nil) for marshalSortedJSON to reconstruct the exact
+	// signed bytes. New providers omit it (nil). Remove once the fleet floor
+	// passes v0.6.31.
+	HypervisorActive       *bool  `json:"hypervisorActive,omitempty"`
+	OSVersion              string `json:"osVersion"`
+	PublicKey              string `json:"publicKey"`
+	RDMADisabled           bool   `json:"rdmaDisabled"`
+	SecureBootEnabled      bool   `json:"secureBootEnabled"`
+	SecureEnclaveAvailable bool   `json:"secureEnclaveAvailable"`
+	SerialNumber           string `json:"serialNumber,omitempty"`
+	SIPEnabled             bool   `json:"sipEnabled"`
+	SystemVolumeHash       string `json:"systemVolumeHash,omitempty"`
+	Timestamp              string `json:"timestamp"`
 }
 
 // SignedAttestation is a signed attestation blob with a base64-encoded
@@ -103,7 +108,6 @@ type VerificationResult struct {
 	SecureEnclaveAvailable   bool
 	SIPEnabled               bool
 	SecureBootEnabled        bool
-	HypervisorActive         bool
 	RDMADisabled             bool
 	AuthenticatedRootEnabled bool
 	SystemVolumeHash         string
@@ -136,7 +140,6 @@ func Verify(signed SignedAttestation) VerificationResult {
 		SecureEnclaveAvailable:   signed.Attestation.SecureEnclaveAvailable,
 		SIPEnabled:               signed.Attestation.SIPEnabled,
 		SecureBootEnabled:        signed.Attestation.SecureBootEnabled,
-		HypervisorActive:         signed.Attestation.HypervisorActive,
 		RDMADisabled:             signed.Attestation.RDMADisabled,
 		AuthenticatedRootEnabled: signed.Attestation.AuthenticatedRootEnabled,
 		SystemVolumeHash:         signed.Attestation.SystemVolumeHash,
@@ -299,7 +302,6 @@ func marshalSortedJSON(blob AttestationBlob) ([]byte, error) {
 		"authenticatedRootEnabled": blob.AuthenticatedRootEnabled,
 		"chipName":                 blob.ChipName,
 		"hardwareModel":            blob.HardwareModel,
-		"hypervisorActive":         blob.HypervisorActive,
 		"osVersion":                blob.OSVersion,
 		"publicKey":                blob.PublicKey,
 		"rdmaDisabled":             blob.RDMADisabled,
@@ -316,6 +318,12 @@ func marshalSortedJSON(blob AttestationBlob) ([]byte, error) {
 	}
 	if blob.EncryptionPublicKey != "" {
 		m["encryptionPublicKey"] = blob.EncryptionPublicKey
+	}
+	// Legacy fleet compat (< v0.6.31): old providers include the retired
+	// hypervisorActive field in the signed blob — reproduce it EXACTLY when
+	// present so their signatures keep verifying; new providers omit it.
+	if blob.HypervisorActive != nil {
+		m["hypervisorActive"] = *blob.HypervisorActive
 	}
 	if blob.SerialNumber != "" {
 		m["serialNumber"] = blob.SerialNumber
@@ -335,15 +343,18 @@ func marshalSortedJSON(blob AttestationBlob) ([]byte, error) {
 // Go's encoding/json map ordering and the Swift provider's canonical
 // encoder, which produce identical bytes for equivalent content).
 //
-// Fields that are absent on the provider side (e.g. hypervisor not
-// active, no model loaded yet) are omitted from the canonical payload —
-// "unknown" must serialize differently than "false" so a downgrade
-// attacker can't strip a sip_enabled=true claim and have it look like
-// the provider just didn't report it. Both sides must follow the same
-// convention.
+// Fields that are absent on the provider side (e.g. no model loaded
+// yet) are omitted from the canonical payload — "unknown" must
+// serialize differently than "false" so a downgrade attacker can't
+// strip a sip_enabled=true claim and have it look like the provider
+// just didn't report it. Both sides must follow the same convention.
 type StatusCanonicalInput struct {
-	Nonce             string
-	Timestamp         string
+	Nonce     string
+	Timestamp string
+	// HypervisorActive — legacy fleet compat only: old providers (< v0.6.31)
+	// sign hypervisor_active into the canonical status. The concept is
+	// retired — new providers omit it. Remove once the fleet floor passes
+	// v0.6.31.
 	HypervisorActive  *bool
 	RDMADisabled      *bool
 	SIPEnabled        *bool
@@ -381,6 +392,9 @@ func BuildStatusCanonical(in StatusCanonicalInput) ([]byte, error) {
 		"nonce":     in.Nonce,
 		"timestamp": in.Timestamp,
 	}
+	// Legacy fleet compat only: old providers (< v0.6.31) sign
+	// hypervisor_active into the canonical status. The concept is retired —
+	// new providers omit it. Remove once the fleet floor passes v0.6.31.
 	if in.HypervisorActive != nil {
 		m["hypervisor_active"] = *in.HypervisorActive
 	}

--- a/coordinator/attestation/attestation_test.go
+++ b/coordinator/attestation/attestation_test.go
@@ -467,6 +467,91 @@ func TestMarshalSortedJSONWithEncryptionKey(t *testing.T) {
 	}
 }
 
+// TestMarshalSortedJSONLegacyHypervisorRoundTrip is the legacy-fleet
+// signature-compat guard for the SIGNED registration blob. Old providers
+// (< v0.6.31) include the retired, hardcoded-false "hypervisorActive"
+// key in the JSON they sign with the Secure Enclave. The coordinator
+// re-serializes the parsed blob via marshalSortedJSON on the fallback
+// verification path, so decode→re-encode MUST reproduce the exact
+// signed bytes — key present when the provider sent it, absent when it
+// didn't. Remove together with AttestationBlob.HypervisorActive once
+// the fleet floor passes v0.6.31.
+func TestMarshalSortedJSONLegacyHypervisorRoundTrip(t *testing.T) {
+	privKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pubB64 := base64.StdEncoding.EncodeToString(marshalUncompressedP256(privKey))
+
+	// Exactly what an old provider signs: alphabetically sorted keys,
+	// hypervisorActive present (always false — it was a stub).
+	legacyJSON := []byte(`{"authenticatedRootEnabled":true,"chipName":"Apple M3 Max","hardwareModel":"Mac15,8","hypervisorActive":false,"osVersion":"15.3.0","publicKey":"` + pubB64 + `","rdmaDisabled":true,"secureBootEnabled":true,"secureEnclaveAvailable":true,"sipEnabled":true,"timestamp":"2026-06-30T12:00:00Z"}`)
+
+	var blob AttestationBlob
+	if err := json.Unmarshal(legacyJSON, &blob); err != nil {
+		t.Fatalf("unmarshal legacy blob: %v", err)
+	}
+	if blob.HypervisorActive == nil || *blob.HypervisorActive {
+		t.Fatal("expected HypervisorActive to decode as non-nil false for a legacy blob")
+	}
+
+	reencoded, err := marshalSortedJSON(blob)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(reencoded) != string(legacyJSON) {
+		t.Fatalf("legacy blob does not round-trip — old-fleet signatures would break\nwant: %s\ngot:  %s", legacyJSON, reencoded)
+	}
+
+	// Full signature verification through the marshalSortedJSON fallback
+	// path (AttestationRaw deliberately nil): sign the original bytes and
+	// verify the re-encoded reconstruction matches.
+	signed := signOverRawJSON(t, blob, legacyJSON, privKey)
+	result := Verify(signed)
+	if !result.Valid {
+		t.Fatalf("legacy blob with hypervisorActive failed verification: %s", result.Error)
+	}
+}
+
+// TestMarshalSortedJSONNewProviderOmitsHypervisor is the counterpart for
+// new (v0.6.31+) providers: the signed blob has NO hypervisorActive key,
+// the field decodes to nil, and re-encoding omits it — reproducing the
+// signed bytes exactly.
+func TestMarshalSortedJSONNewProviderOmitsHypervisor(t *testing.T) {
+	privKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pubB64 := base64.StdEncoding.EncodeToString(marshalUncompressedP256(privKey))
+
+	newJSON := []byte(`{"authenticatedRootEnabled":true,"chipName":"Apple M3 Max","hardwareModel":"Mac15,8","osVersion":"15.3.0","publicKey":"` + pubB64 + `","rdmaDisabled":true,"secureBootEnabled":true,"secureEnclaveAvailable":true,"sipEnabled":true,"timestamp":"2026-06-30T12:00:00Z"}`)
+
+	var blob AttestationBlob
+	if err := json.Unmarshal(newJSON, &blob); err != nil {
+		t.Fatalf("unmarshal new blob: %v", err)
+	}
+	if blob.HypervisorActive != nil {
+		t.Fatal("expected HypervisorActive to decode as nil when the key is absent")
+	}
+
+	reencoded, err := marshalSortedJSON(blob)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(reencoded) != string(newJSON) {
+		t.Fatalf("new-provider blob does not round-trip\nwant: %s\ngot:  %s", newJSON, reencoded)
+	}
+	if findStringIndex(string(reencoded), "hypervisorActive") >= 0 {
+		t.Error("hypervisorActive must be omitted when the provider did not send it")
+	}
+
+	signed := signOverRawJSON(t, blob, newJSON, privKey)
+	result := Verify(signed)
+	if !result.Valid {
+		t.Fatalf("new-provider blob failed verification: %s", result.Error)
+	}
+}
+
 // --- helpers ---
 
 func createTestAttestation(t *testing.T) SignedAttestation {
@@ -517,6 +602,28 @@ func signBlob(t *testing.T, blob AttestationBlob, privKey *ecdsa.PrivateKey) Sig
 	return SignedAttestation{
 		Attestation:    blob,
 		AttestationRaw: blobJSON,
+		Signature:      base64.StdEncoding.EncodeToString(sigDER),
+	}
+}
+
+// signOverRawJSON signs the exact raw blob JSON (what a provider's Secure
+// Enclave signs) but returns a SignedAttestation WITHOUT AttestationRaw,
+// forcing Verify down the marshalSortedJSON reconstruction path.
+func signOverRawJSON(t *testing.T, blob AttestationBlob, rawJSON []byte, privKey *ecdsa.PrivateKey) SignedAttestation {
+	t.Helper()
+
+	hash := sha256.Sum256(rawJSON)
+	r, s, err := ecdsa.Sign(rand.Reader, privKey, hash[:])
+	if err != nil {
+		t.Fatal(err)
+	}
+	sigDER, err := asn1.Marshal(ecdsaSig{R: r, S: s})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return SignedAttestation{
+		Attestation:    blob,
+		AttestationRaw: nil, // force the marshalSortedJSON fallback
 		Signature:      base64.StdEncoding.EncodeToString(sigDER),
 	}
 }

--- a/coordinator/attestation/status_canonical_test.go
+++ b/coordinator/attestation/status_canonical_test.go
@@ -14,13 +14,60 @@ import (
 )
 
 // TestBuildStatusCanonicalGoldenBytes is the cross-language wire-format
-// guard. The bytes asserted here MUST be identical to the bytes produced
-// by the Swift provider's StatusCanonical.build for the same input. The
-// matching Swift test lives in
-// provider-swift/Tests/ProviderCoreTests/SecurityTests.swift
+// guard for the CURRENT (v0.6.31+) provider shape, which no longer
+// reports the retired hypervisor_active field. The bytes asserted here
+// MUST be identical to the bytes produced by the Swift provider's
+// StatusCanonical.build for the same input. The matching Swift test
+// lives in provider-swift/Tests/ProviderCoreTests/SecurityTests.swift
 // (statusCanonicalMatchesCoordinatorGoldenBytes). If either side drifts,
 // both tests fail and you catch the protocol drift before it ships.
 func TestBuildStatusCanonicalGoldenBytes(t *testing.T) {
+	True := true
+	in := StatusCanonicalInput{
+		Nonce:             "test-nonce",
+		Timestamp:         "2026-04-16T12:00:00Z",
+		RDMADisabled:      &True,
+		SIPEnabled:        &True,
+		SecureBootEnabled: &True,
+		BinaryHash:        "binhash",
+		ActiveModelHash:   "activemodel",
+		PythonHash:        "pyhash",
+		RuntimeHash:       "rthash",
+		TemplateHashes: map[string]string{
+			"chatml": "tmplhash1",
+			"gemma":  "tmplhash2",
+		},
+		GrpcBinaryHash: "",
+		ModelHashes: map[string]string{
+			"qwen":    "modelhash1",
+			"trinity": "modelhash2",
+		},
+	}
+
+	got, err := BuildStatusCanonical(in)
+	if err != nil {
+		t.Fatalf("BuildStatusCanonical: %v", err)
+	}
+
+	expected := []byte(`{"active_model_hash":"activemodel","binary_hash":"binhash","model_hashes":{"qwen":"modelhash1","trinity":"modelhash2"},"nonce":"test-nonce","python_hash":"pyhash","rdma_disabled":true,"runtime_hash":"rthash","secure_boot_enabled":true,"sip_enabled":true,"template_hashes":{"chatml":"tmplhash1","gemma":"tmplhash2"},"timestamp":"2026-04-16T12:00:00Z"}`)
+
+	if !bytes.Equal(got, expected) {
+		t.Fatalf("canonical bytes drifted from Swift golden — protocol break\nwant: %s\ngot:  %s", expected, got)
+	}
+	if bytes.Contains(got, []byte("hypervisor_active")) {
+		t.Fatalf("hypervisor_active must be absent when not reported (new provider): %s", got)
+	}
+}
+
+// TestBuildStatusCanonicalGoldenBytesLegacyHypervisor pins the OLD-fleet
+// canonical bytes. Legacy fleet compat only: providers < v0.6.31 sign
+// hypervisor_active into the canonical status, so when a challenge
+// response carries the field the coordinator MUST reconstruct it
+// byte-for-byte as before — including the retired "hypervisor_active"
+// key — or every old provider's StatusSignature verification breaks.
+// Remove this test together with StatusCanonicalInput.HypervisorActive
+// once the fleet floor passes v0.6.31.
+func TestBuildStatusCanonicalGoldenBytesLegacyHypervisor(t *testing.T) {
 	True := true
 	in := StatusCanonicalInput{
 		Nonce:             "test-nonce",
@@ -52,7 +99,18 @@ func TestBuildStatusCanonicalGoldenBytes(t *testing.T) {
 	expected := []byte(`{"active_model_hash":"activemodel","binary_hash":"binhash","hypervisor_active":true,"model_hashes":{"qwen":"modelhash1","trinity":"modelhash2"},"nonce":"test-nonce","python_hash":"pyhash","rdma_disabled":true,"runtime_hash":"rthash","secure_boot_enabled":true,"sip_enabled":true,"template_hashes":{"chatml":"tmplhash1","gemma":"tmplhash2"},"timestamp":"2026-04-16T12:00:00Z"}`)
 
 	if !bytes.Equal(got, expected) {
-		t.Fatalf("canonical bytes drifted from Swift golden — protocol break\nwant: %s\ngot:  %s", expected, got)
+		t.Fatalf("legacy canonical bytes drifted — old-fleet StatusSignature verification would break\nwant: %s\ngot:  %s", expected, got)
+	}
+
+	// Old providers hardcode hypervisor_active=false; pin that shape too.
+	False := false
+	in.HypervisorActive = &False
+	got, err = BuildStatusCanonical(in)
+	if err != nil {
+		t.Fatalf("BuildStatusCanonical: %v", err)
+	}
+	if !bytes.Contains(got, []byte(`"hypervisor_active":false`)) {
+		t.Fatalf(`expected "hypervisor_active":false in legacy canonical, got: %s`, got)
 	}
 }
 

--- a/coordinator/protocol/messages.go
+++ b/coordinator/protocol/messages.go
@@ -167,6 +167,11 @@ type RegisterMessage struct {
 }
 
 // PrivacyCapabilities describes the provider's privacy invariants at registration time.
+//
+// Note: legacy providers (< v0.6.31) also send a `hypervisor_active` key here.
+// The concept is retired (Darkbloom never uses hypervisors — it was a
+// hardcoded-false stub) and is intentionally not modeled; encoding/json drops
+// unknown fields, so old providers remain wire-compatible.
 type PrivacyCapabilities struct {
 	TextBackendInprocess    bool `json:"text_backend_inprocess"`
 	TextProxyDisabled       bool `json:"text_proxy_disabled"`
@@ -176,7 +181,6 @@ type PrivacyCapabilities struct {
 	AntiDebugEnabled        bool `json:"anti_debug_enabled"`
 	CoreDumpsDisabled       bool `json:"core_dumps_disabled"`
 	EnvScrubbed             bool `json:"env_scrubbed"`
-	HypervisorActive        bool `json:"hypervisor_active"`
 }
 
 // HeartbeatMessage is sent periodically by connected providers.
@@ -488,12 +492,17 @@ type AttestationChallengeMessage struct {
 // which case the status fields are treated as advisory (not a basis for
 // trust upgrades).
 type AttestationResponseMessage struct {
-	Type              string `json:"type"`
-	Nonce             string `json:"nonce"`                         // echoed back from the challenge
-	Signature         string `json:"signature"`                     // base64-encoded signature of nonce+timestamp
-	StatusSignature   string `json:"status_signature,omitempty"`    // base64-encoded signature of canonical status JSON (see attestation.BuildStatusCanonical)
-	PublicKey         string `json:"public_key"`                    // base64-encoded public key
-	HypervisorActive  *bool  `json:"hypervisor_active,omitempty"`   // reported hypervisor containment status, if any
+	Type            string `json:"type"`
+	Nonce           string `json:"nonce"`                      // echoed back from the challenge
+	Signature       string `json:"signature"`                  // base64-encoded signature of nonce+timestamp
+	StatusSignature string `json:"status_signature,omitempty"` // base64-encoded signature of canonical status JSON (see attestation.BuildStatusCanonical)
+	PublicKey       string `json:"public_key"`                 // base64-encoded public key
+	// HypervisorActive — legacy fleet compat only: old providers (< v0.6.31)
+	// sign hypervisor_active into the canonical status (see
+	// attestation.BuildStatusCanonical), so this field must keep decoding for
+	// their StatusSignature to verify. The concept is retired — new providers
+	// omit it. Remove once the fleet floor passes v0.6.31.
+	HypervisorActive  *bool  `json:"hypervisor_active,omitempty"`
 	RDMADisabled      *bool  `json:"rdma_disabled,omitempty"`       // fresh RDMA status (true = disabled, false = enabled)
 	SIPEnabled        *bool  `json:"sip_enabled,omitempty"`         // fresh SIP status at challenge time
 	SecureBootEnabled *bool  `json:"secure_boot_enabled,omitempty"` // fresh Secure Boot status

--- a/coordinator/protocol/messages_test.go
+++ b/coordinator/protocol/messages_test.go
@@ -822,6 +822,33 @@ func TestProviderMessageUnmarshalRegister(t *testing.T) {
 	}
 }
 
+// TestProviderMessageUnmarshalRegisterLegacyHypervisorCapability is the
+// legacy-fleet wire guard for the retired hypervisor_active capability.
+// Old providers (< v0.6.31) still send it inside privacy_capabilities;
+// the Go field was removed, so it must decode as a harmless unknown
+// field — no error, all remaining capabilities intact.
+func TestProviderMessageUnmarshalRegisterLegacyHypervisorCapability(t *testing.T) {
+	raw := `{"type":"register","hardware":{"chip_name":"Apple M3 Max","memory_gb":64},"models":[{"id":"m1","model_type":"chat","quantization":"4bit"}],"backend":"mlx_swift","privacy_capabilities":{"text_backend_inprocess":true,"text_proxy_disabled":true,"python_runtime_locked":true,"dangerous_modules_blocked":true,"sip_enabled":true,"anti_debug_enabled":true,"core_dumps_disabled":true,"env_scrubbed":true,"hypervisor_active":false}}`
+
+	var pm ProviderMessage
+	if err := json.Unmarshal([]byte(raw), &pm); err != nil {
+		t.Fatalf("legacy register frame with hypervisor_active must decode: %v", err)
+	}
+
+	reg, ok := pm.Payload.(*RegisterMessage)
+	if !ok {
+		t.Fatalf("payload type = %T, want *RegisterMessage", pm.Payload)
+	}
+	caps := reg.PrivacyCapabilities
+	if caps == nil {
+		t.Fatal("privacy_capabilities missing after decode")
+	}
+	if !caps.TextBackendInprocess || !caps.TextProxyDisabled || !caps.SIPEnabled ||
+		!caps.AntiDebugEnabled || !caps.CoreDumpsDisabled || !caps.EnvScrubbed {
+		t.Fatalf("privacy capabilities lost around the ignored hypervisor_active field: %+v", caps)
+	}
+}
+
 func TestProviderMessageUnmarshalHeartbeat(t *testing.T) {
 	raw := `{"type":"heartbeat","status":"idle","active_model":null,"stats":{"requests_served":0,"tokens_generated":0}}`
 

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -467,7 +467,7 @@ type Provider struct {
 	// Phase 7: Privacy invariant attestation.
 	// Self-reported by the provider at registration. SIPEnabled is overridden
 	// by the coordinator after each attestation challenge response with a
-	// coordinator-verified value. HypervisorActive is informational.
+	// coordinator-verified value.
 	PrivacyCapabilities *protocol.PrivacyCapabilities `json:"privacy_capabilities,omitempty"`
 
 	// Coordinator-verified SIP status from the most recent attestation challenge.

--- a/docs/architecture/security/attestation.md
+++ b/docs/architecture/security/attestation.md
@@ -54,9 +54,9 @@ Code:
 
 ### Layer 4: Challenge-response — fresh security posture every ~5 minutes
 
-The coordinator sends an `attestation_challenge` over the WebSocket immediately on registration and then every ~5 minutes. The provider signs a canonical status payload and returns fresh runtime state (SIP, Secure Boot, RDMA, hypervisor, runtime hashes, model hashes). The coordinator verifies the nonce, the SE signature over the canonical payload, and that SIP and Secure Boot are still enabled. SIP/SecureBoot failure is immediate untrust; three consecutive failures also mark the provider untrusted.
+The coordinator sends an `attestation_challenge` over the WebSocket immediately on registration and then every ~5 minutes. The provider signs a canonical status payload and returns fresh runtime state (SIP, Secure Boot, RDMA, runtime hashes, model hashes). The coordinator verifies the nonce, the SE signature over the canonical payload, and that SIP and Secure Boot are still enabled. SIP/SecureBoot failure is immediate untrust; three consecutive failures also mark the provider untrusted.
 
-The status canonical omits absent bool/string/map fields entirely so a downgrade attacker cannot make a stripped claim look like a missing field. Code:
+The status canonical omits absent bool/string/map fields entirely so a downgrade attacker cannot make a stripped claim look like a missing field. `hypervisor_active` is a legacy field in this canonical: it was only ever a hardcoded-`false` stub (no hypervisor isolation was ever implemented), current providers no longer report it, and the canonical builder retains it solely so signatures from older providers that still include it keep verifying. Code:
 
 - Challenge sender: `coordinator/api/provider.go:830-899`
 - Response verification: `coordinator/api/provider.go:942-1040`

--- a/docs/provider/attestation.md
+++ b/docs/provider/attestation.md
@@ -62,7 +62,6 @@ The blob contains:
 | `secureBootEnabled` | Secure Boot state |
 | `authenticatedRootEnabled` | Authenticated root volume state |
 | `rdmaDisabled` | RDMA safety signal |
-| `hypervisorActive` | Hypervisor state (reported only) |
 | `secureEnclaveAvailable` | Confirms SE presence |
 | `binaryHash` | SHA-256 of the provider binary |
 | `systemVolumeHash` | Signed system-volume snapshot hash |
@@ -73,6 +72,13 @@ The coordinator verifies the ECDSA signature over the exact attestation JSON
 bytes in `coordinator/attestation/attestation.go:128` and checks that the
 encryption public key in the blob matches the key supplied in the `register`
 message (`coordinator/api/provider.go:2130-2156`).
+
+> **Legacy field:** older provider builds also included a `hypervisorActive`
+> field in this blob and in the challenge-response canonical payload. It was a
+> hardcoded-`false` stub — hypervisor isolation was never implemented — and
+> current providers no longer report it. The coordinator still accepts it in
+> signed payloads from older providers so their signatures keep verifying, but
+> it carries no meaning and is not used in any routing or trust decision.
 
 ## Periodic challenge-response
 

--- a/docs/reference/protocol-messages.md
+++ b/docs/reference/protocol-messages.md
@@ -103,7 +103,7 @@ Go: [`AttestationResponseMessage`](../../coordinator/protocol/messages.go); Swif
 | `signature` | string | Base64 signature of `nonce+timestamp` |
 | `status_signature` | string | Base64 signature of canonical status JSON (v0.3.11+) |
 | `public_key` | string | Base64 X25519 public key |
-| `hypervisor_active` | bool / null | |
+| `hypervisor_active` | bool / null | Legacy: hardcoded-`false` stub, no longer sent by current providers; accepted in older providers' signed payloads for verification compat only |
 | `rdma_disabled` | bool / null | |
 | `sip_enabled` | bool / null | |
 | `secure_boot_enabled` | bool / null | |
@@ -359,4 +359,3 @@ Go: [`PrivacyCapabilities`](../../coordinator/protocol/messages.go); Swift: `Pri
 | `anti_debug_enabled` | bool |
 | `core_dumps_disabled` | bool |
 | `env_scrubbed` | bool |
-| `hypervisor_active` | bool |

--- a/docs/threat-model.yaml
+++ b/docs/threat-model.yaml
@@ -1449,7 +1449,11 @@ threats:
         status: implemented
       - description: GPU-side MLX buffers (Metal) are not explicitly zeroed between requests.
         status: open
-      - description: Hypervisor memory isolation (Stage 2 page tables) not implemented in Swift provider.
+      - description: >
+          No hardware memory isolation exists for inference memory. Hypervisor
+          Stage 2 page-table isolation was never implemented; the
+          hypervisor_active attestation field was a hardcoded-false stub and
+          has been removed from provider and coordinator.
         status: open
     open_findings: []
     severity: medium

--- a/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClient+Registration.swift
+++ b/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClient+Registration.swift
@@ -19,8 +19,7 @@ extension CoordinatorClient {
             sipEnabled: SecurityChecks.isSIPEnabled(),
             antiDebugEnabled: true,
             coreDumpsDisabled: true,
-            envScrubbed: true,
-            hypervisorActive: SecurityChecks.isHypervisorActive()
+            envScrubbed: true
         )
         // Read the live advertised list (startup ∪ prefetched builds) rather
         // than the immutable `config.models`, so a re-registration after a

--- a/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClient.swift
+++ b/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClient.swift
@@ -273,10 +273,6 @@ enum SecurityChecks {
     static func isSIPEnabled() -> Bool {
         SIPStatusChecker().isFullyEnabled()
     }
-
-    static func isHypervisorActive() -> Bool {
-        false
-    }
 }
 
 

--- a/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClientCodec.swift
+++ b/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClientCodec.swift
@@ -133,7 +133,6 @@ public enum CoordinatorClientCodec {
                 signature: payload.signature,
                 statusSignature: payload.statusSignature,
                 publicKey: payload.publicKey,
-                hypervisorActive: payload.hypervisorActive,
                 rdmaDisabled: payload.rdmaDisabled,
                 sipEnabled: payload.sipEnabled,
                 secureBootEnabled: payload.secureBootEnabled,

--- a/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClientTypes.swift
+++ b/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClientTypes.swift
@@ -145,7 +145,6 @@ public struct AttestationResponsePayload: Sendable {
     public let signature: String
     public let statusSignature: String?
     public let publicKey: String
-    public let hypervisorActive: Bool?
     public let rdmaDisabled: Bool?
     public let sipEnabled: Bool?
     public let secureBootEnabled: Bool?
@@ -161,7 +160,6 @@ public struct AttestationResponsePayload: Sendable {
         signature: String,
         statusSignature: String? = nil,
         publicKey: String,
-        hypervisorActive: Bool? = nil,
         rdmaDisabled: Bool? = nil,
         sipEnabled: Bool? = nil,
         secureBootEnabled: Bool? = nil,
@@ -176,7 +174,6 @@ public struct AttestationResponsePayload: Sendable {
         self.signature = signature
         self.statusSignature = statusSignature
         self.publicKey = publicKey
-        self.hypervisorActive = hypervisorActive
         self.rdmaDisabled = rdmaDisabled
         self.sipEnabled = sipEnabled
         self.secureBootEnabled = secureBootEnabled

--- a/provider-swift/Sources/ProviderCore/Protocol/Messages.swift
+++ b/provider-swift/Sources/ProviderCore/Protocol/Messages.swift
@@ -246,7 +246,6 @@ public enum ProviderMessage: Sendable, Equatable {
         public var signature: String
         public var statusSignature: String?
         public var publicKey: String
-        public var hypervisorActive: Bool?
         public var rdmaDisabled: Bool?
         public var sipEnabled: Bool?
         public var secureBootEnabled: Bool?
@@ -262,7 +261,6 @@ public enum ProviderMessage: Sendable, Equatable {
             signature: String,
             statusSignature: String? = nil,
             publicKey: String,
-            hypervisorActive: Bool? = nil,
             rdmaDisabled: Bool? = nil,
             sipEnabled: Bool? = nil,
             secureBootEnabled: Bool? = nil,
@@ -277,7 +275,6 @@ public enum ProviderMessage: Sendable, Equatable {
             self.signature = signature
             self.statusSignature = statusSignature
             self.publicKey = publicKey
-            self.hypervisorActive = hypervisorActive
             self.rdmaDisabled = rdmaDisabled
             self.sipEnabled = sipEnabled
             self.secureBootEnabled = secureBootEnabled
@@ -364,7 +361,6 @@ extension ProviderMessage: Codable {
         // AttestationResponse
         case nonce, signature
         case statusSignature = "status_signature"
-        case hypervisorActive = "hypervisor_active"
         case rdmaDisabled = "rdma_disabled"
         case sipEnabled = "sip_enabled"
         case secureBootEnabled = "secure_boot_enabled"
@@ -455,7 +451,6 @@ extension ProviderMessage: Codable {
             try container.encode(a.signature, forKey: .signature)
             try container.encodeIfPresent(a.statusSignature, forKey: .statusSignature)
             try container.encode(a.publicKey, forKey: .publicKey)
-            try container.encodeIfPresent(a.hypervisorActive, forKey: .hypervisorActive)
             try container.encodeIfPresent(a.rdmaDisabled, forKey: .rdmaDisabled)
             try container.encodeIfPresent(a.sipEnabled, forKey: .sipEnabled)
             try container.encodeIfPresent(a.secureBootEnabled, forKey: .secureBootEnabled)
@@ -574,7 +569,6 @@ extension ProviderMessage: Codable {
                 signature: try container.decode(String.self, forKey: .signature),
                 statusSignature: try container.decodeIfPresent(String.self, forKey: .statusSignature),
                 publicKey: try container.decode(String.self, forKey: .publicKey),
-                hypervisorActive: try container.decodeIfPresent(Bool.self, forKey: .hypervisorActive),
                 rdmaDisabled: try container.decodeIfPresent(Bool.self, forKey: .rdmaDisabled),
                 sipEnabled: try container.decodeIfPresent(Bool.self, forKey: .sipEnabled),
                 secureBootEnabled: try container.decodeIfPresent(Bool.self, forKey: .secureBootEnabled),

--- a/provider-swift/Sources/ProviderCore/Protocol/Types.swift
+++ b/provider-swift/Sources/ProviderCore/Protocol/Types.swift
@@ -303,7 +303,6 @@ public struct PrivacyCapabilities: Codable, Sendable, Equatable {
     public var antiDebugEnabled: Bool
     public var coreDumpsDisabled: Bool
     public var envScrubbed: Bool
-    public var hypervisorActive: Bool
 
     enum CodingKeys: String, CodingKey {
         case textBackendInprocess = "text_backend_inprocess"
@@ -314,7 +313,6 @@ public struct PrivacyCapabilities: Codable, Sendable, Equatable {
         case antiDebugEnabled = "anti_debug_enabled"
         case coreDumpsDisabled = "core_dumps_disabled"
         case envScrubbed = "env_scrubbed"
-        case hypervisorActive = "hypervisor_active"
     }
 
     public init(
@@ -325,8 +323,7 @@ public struct PrivacyCapabilities: Codable, Sendable, Equatable {
         sipEnabled: Bool,
         antiDebugEnabled: Bool,
         coreDumpsDisabled: Bool,
-        envScrubbed: Bool,
-        hypervisorActive: Bool = false
+        envScrubbed: Bool
     ) {
         self.textBackendInprocess = textBackendInprocess
         self.textProxyDisabled = textProxyDisabled
@@ -336,20 +333,6 @@ public struct PrivacyCapabilities: Codable, Sendable, Equatable {
         self.antiDebugEnabled = antiDebugEnabled
         self.coreDumpsDisabled = coreDumpsDisabled
         self.envScrubbed = envScrubbed
-        self.hypervisorActive = hypervisorActive
-    }
-
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        textBackendInprocess = try container.decode(Bool.self, forKey: .textBackendInprocess)
-        textProxyDisabled = try container.decode(Bool.self, forKey: .textProxyDisabled)
-        pythonRuntimeLocked = try container.decode(Bool.self, forKey: .pythonRuntimeLocked)
-        dangerousModulesBlocked = try container.decode(Bool.self, forKey: .dangerousModulesBlocked)
-        sipEnabled = try container.decode(Bool.self, forKey: .sipEnabled)
-        antiDebugEnabled = try container.decode(Bool.self, forKey: .antiDebugEnabled)
-        coreDumpsDisabled = try container.decode(Bool.self, forKey: .coreDumpsDisabled)
-        envScrubbed = try container.decode(Bool.self, forKey: .envScrubbed)
-        hypervisorActive = try container.decodeIfPresent(Bool.self, forKey: .hypervisorActive) ?? false
     }
 }
 

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+AttestationChallenge.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+AttestationChallenge.swift
@@ -65,7 +65,6 @@ extension ProviderLoop {
                 signature: response.signature,
                 statusSignature: response.statusSignature,
                 publicKey: response.publicKey,
-                hypervisorActive: response.hypervisorActive,
                 rdmaDisabled: response.rdmaDisabled,
                 sipEnabled: response.sipEnabled,
                 secureBootEnabled: response.secureBootEnabled,

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+Serve.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+Serve.swift
@@ -320,9 +320,6 @@ extension ProviderLoop {
         // pythonRuntimeLocked + dangerousModulesBlocked: report false. There
         //   is no Python runtime to lock anymore. Coordinator's Swift-runtime
         //   trust path (registry.BackendUsesSwiftRuntime) doesn't read these.
-        // hypervisorActive: false -- Hypervisor.framework Stage 2 page tables
-        //   were dropped at the migration; trust is RDMA discipline + SE
-        //   attestation.
         if let posture = securityPosture {
             return PrivacyCapabilities(
                 textBackendInprocess: true,
@@ -332,8 +329,7 @@ extension ProviderLoop {
                 sipEnabled: posture.sipEnabled,
                 antiDebugEnabled: posture.antiDebugEnabled,
                 coreDumpsDisabled: posture.coreDumpsDisabled,
-                envScrubbed: posture.envScrubbed,
-                hypervisorActive: false
+                envScrubbed: posture.envScrubbed
             )
         }
 
@@ -346,8 +342,7 @@ extension ProviderLoop {
             sipEnabled: SecurityChecks.isSIPEnabled(),
             antiDebugEnabled: false,
             coreDumpsDisabled: false,
-            envScrubbed: false,
-            hypervisorActive: false
+            envScrubbed: false
         )
     }
 

--- a/provider-swift/Sources/ProviderCore/Security/AttestationBuilder.swift
+++ b/provider-swift/Sources/ProviderCore/Security/AttestationBuilder.swift
@@ -73,7 +73,6 @@ public struct SignedAttestation: Codable, Sendable {
 public struct StatusCanonicalInput: Sendable, Equatable {
     public var nonce: String
     public var timestamp: String
-    public var hypervisorActive: Bool?
     public var rdmaDisabled: Bool?
     public var sipEnabled: Bool?
     public var secureBootEnabled: Bool?
@@ -87,7 +86,6 @@ public struct StatusCanonicalInput: Sendable, Equatable {
     public init(
         nonce: String,
         timestamp: String,
-        hypervisorActive: Bool? = nil,
         rdmaDisabled: Bool? = nil,
         sipEnabled: Bool? = nil,
         secureBootEnabled: Bool? = nil,
@@ -100,7 +98,6 @@ public struct StatusCanonicalInput: Sendable, Equatable {
     ) {
         self.nonce = nonce
         self.timestamp = timestamp
-        self.hypervisorActive = hypervisorActive
         self.rdmaDisabled = rdmaDisabled
         self.sipEnabled = sipEnabled
         self.secureBootEnabled = secureBootEnabled
@@ -119,7 +116,6 @@ public enum StatusCanonical {
             "nonce": input.nonce,
             "timestamp": input.timestamp,
         ]
-        if let value = input.hypervisorActive { object["hypervisor_active"] = value }
         if let value = input.rdmaDisabled { object["rdma_disabled"] = value }
         if let value = input.sipEnabled { object["sip_enabled"] = value }
         if let value = input.secureBootEnabled { object["secure_boot_enabled"] = value }
@@ -284,7 +280,6 @@ extension AttestationBuilder {
         binaryHash: String? = nil,
         activeModelHash: String? = nil,
         runtimeHashes: RuntimeHashes? = nil,
-        hypervisorActive: Bool? = nil,
         modelHashes: [String: String] = [:]
     ) throws -> ProviderMessage.AttestationResponse {
         let signature = try signChallenge(nonce: nonce, timestamp: timestamp)
@@ -295,7 +290,6 @@ extension AttestationBuilder {
         let statusData = try StatusCanonical.build(StatusCanonicalInput(
             nonce: nonce,
             timestamp: timestamp,
-            hypervisorActive: hypervisorActive,
             rdmaDisabled: rdmaDisabled,
             sipEnabled: sipEnabled,
             secureBootEnabled: secureBootEnabled,
@@ -313,7 +307,6 @@ extension AttestationBuilder {
             signature: signature,
             statusSignature: statusSignature,
             publicKey: providerPublicKey,
-            hypervisorActive: hypervisorActive,
             rdmaDisabled: rdmaDisabled,
             sipEnabled: sipEnabled,
             secureBootEnabled: secureBootEnabled,

--- a/provider-swift/Sources/ProviderCore/Security/SecurityHardening.swift
+++ b/provider-swift/Sources/ProviderCore/Security/SecurityHardening.swift
@@ -368,7 +368,7 @@ public struct SecurityPosture: Sendable {
 ///
 /// Throws `SecurityError.sipDisabled` if SIP is off. RDMA is no longer a
 /// startup-fatal condition; it is included in the signed posture report.
-public func verifySecurityPosture(hypervisorActive _: Bool = false) throws -> SecurityPosture {
+public func verifySecurityPosture() throws -> SecurityPosture {
     let sipEnabled = checkSIPEnabled()
     if !sipEnabled {
         throw SecurityError.sipDisabled

--- a/provider-swift/Tests/ProviderCoreTests/CoordinatorClientTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/CoordinatorClientTests.swift
@@ -37,6 +37,13 @@ import Testing
     #expect(object["encrypted_response_chunks"] as? Bool == true)
     #expect(json.contains(#""attestation":\#(rawAttestation)"#))
 
+    // The hypervisor concept was removed: the registration frame's
+    // privacy_capabilities must carry NO hypervisor key on the wire.
+    let caps = object["privacy_capabilities"] as? [String: Any]
+    #expect(caps != nil)
+    #expect(caps?["hypervisor_active"] == nil)
+    #expect(caps?["hypervisorActive"] == nil)
+
     let decoded = try ProviderProtocolCodec.decodeProviderMessage(from: data)
     guard case .register(let register) = decoded else {
         throw ClientTestFailure.unexpectedMessage
@@ -458,8 +465,7 @@ private func clientPrivacyCapabilities() -> PrivacyCapabilities {
         sipEnabled: true,
         antiDebugEnabled: true,
         coreDumpsDisabled: true,
-        envScrubbed: true,
-        hypervisorActive: false
+        envScrubbed: true
     )
 }
 

--- a/provider-swift/Tests/ProviderCoreTests/CoordinatorIntegrationTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/CoordinatorIntegrationTests.swift
@@ -627,8 +627,7 @@ private func makeClient(
             sipEnabled: true,
             antiDebugEnabled: false,
             coreDumpsDisabled: false,
-            envScrubbed: false,
-            hypervisorActive: false
+            envScrubbed: false
         )
     )
     return CoordinatorClient(

--- a/provider-swift/Tests/ProviderCoreTests/IntegrationPlanTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/IntegrationPlanTests.swift
@@ -113,8 +113,7 @@ private func phase6PrivacyCapabilities() -> PrivacyCapabilities {
         sipEnabled: true,
         antiDebugEnabled: true,
         coreDumpsDisabled: true,
-        envScrubbed: true,
-        hypervisorActive: false
+        envScrubbed: true
     )
 }
 

--- a/provider-swift/Tests/ProviderCoreTests/ProtocolTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/ProtocolTests.swift
@@ -205,7 +205,6 @@ import Testing
             signature: "c2ln",
             statusSignature: "c3RhdHVz",
             publicKey: "cGs=",
-            hypervisorActive: true,
             rdmaDisabled: true,
             sipEnabled: true,
             secureBootEnabled: true,
@@ -746,11 +745,47 @@ import Testing
     #expect(decoded == slot)
 }
 
-@Test func privacyCapabilitiesDecodesMissingHypervisorActiveAsFalse() throws {
-    let raw = #"{"text_backend_inprocess":true,"text_proxy_disabled":true,"python_runtime_locked":true,"dangerous_modules_blocked":true,"sip_enabled":true,"anti_debug_enabled":true,"core_dumps_disabled":true,"env_scrubbed":true}"#
-    let decoded = try JSONDecoder().decode(PrivacyCapabilities.self, from: Data(raw.utf8))
+@Test func privacyCapabilitiesJSONOmitsHypervisorKeys() throws {
+    // The hypervisor concept was removed from the provider (it never uses
+    // hypervisors; the old field was a hardcoded-false trust signal). Pin
+    // that registration privacy_capabilities JSON carries NO hypervisor key.
+    let data = try JSONEncoder().encode(samplePrivacyCapabilities())
+    let object = try jsonObject(data)
 
-    #expect(decoded.hypervisorActive == false)
+    #expect(object["hypervisor_active"] == nil)
+    #expect(object["hypervisorActive"] == nil)
+    // Sanity: the remaining capabilities still encode under snake_case keys.
+    #expect(object["text_backend_inprocess"] as? Bool == true)
+    #expect(object["env_scrubbed"] as? Bool == true)
+    #expect(object.count == 8)
+}
+
+@Test func attestationResponseJSONOmitsHypervisorKeys() throws {
+    // Challenge-response wire shape: no hypervisor_active key, ever -- the
+    // canonical status bytes (StatusCanonical) omit it too, so the coordinator
+    // and provider sign/verify the same bytes.
+    let message = ProviderMessage.attestationResponse(ProviderMessage.AttestationResponse(
+        nonce: "bm9uY2U=",
+        signature: "c2ln",
+        statusSignature: "c3RhdHVz",
+        publicKey: "cGs=",
+        rdmaDisabled: true,
+        sipEnabled: true,
+        secureBootEnabled: true,
+        binaryHash: "binaryhash",
+        activeModelHash: "modelhash",
+        runtimeHash: "runtimehash",
+        templateHashes: ["chatml": "templatehash"],
+        modelHashes: ["model": "weighthash"]
+    ))
+    let data = try ProviderProtocolCodec.encodeProviderMessage(message)
+    let object = try jsonObject(data)
+
+    #expect(object["hypervisor_active"] == nil)
+    #expect(object["hypervisorActive"] == nil)
+    // Sanity: the posture fields that remain still ride the response.
+    #expect(object["rdma_disabled"] as? Bool == true)
+    #expect(object["sip_enabled"] as? Bool == true)
 }
 
 @Test func heartbeatBackendCapacityEncodesSnakeCaseFields() throws {
@@ -870,8 +905,7 @@ private func samplePrivacyCapabilities() -> PrivacyCapabilities {
         sipEnabled: true,
         antiDebugEnabled: true,
         coreDumpsDisabled: true,
-        envScrubbed: true,
-        hypervisorActive: false
+        envScrubbed: true
     )
 }
 

--- a/provider-swift/Tests/ProviderCoreTests/SecurityTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/SecurityTests.swift
@@ -124,7 +124,6 @@ import Testing
     let data = try StatusCanonical.build(StatusCanonicalInput(
         nonce: "test-nonce",
         timestamp: "2026-04-16T12:00:00Z",
-        hypervisorActive: true,
         rdmaDisabled: true,
         sipEnabled: true,
         secureBootEnabled: true,
@@ -141,8 +140,43 @@ import Testing
             "trinity": "modelhash2",
         ]
     ))
-    let expected = #"{"active_model_hash":"activemodel","binary_hash":"binhash","hypervisor_active":true,"model_hashes":{"qwen":"modelhash1","trinity":"modelhash2"},"nonce":"test-nonce","python_hash":"pyhash","rdma_disabled":true,"runtime_hash":"rthash","secure_boot_enabled":true,"sip_enabled":true,"template_hashes":{"chatml":"tmplhash1","gemma":"tmplhash2"},"timestamp":"2026-04-16T12:00:00Z"}"#
+    let expected = #"{"active_model_hash":"activemodel","binary_hash":"binhash","model_hashes":{"qwen":"modelhash1","trinity":"modelhash2"},"nonce":"test-nonce","python_hash":"pyhash","rdma_disabled":true,"runtime_hash":"rthash","secure_boot_enabled":true,"sip_enabled":true,"template_hashes":{"chatml":"tmplhash1","gemma":"tmplhash2"},"timestamp":"2026-04-16T12:00:00Z"}"#
     #expect(String(data: data, encoding: .utf8) == expected)
+}
+
+@Test func registrationAttestationBlobJSONOmitsHypervisorKeys() throws {
+    // The registration attestation blob is signed over its exact serialized
+    // bytes (sorted keys, ISO-8601 dates -- the same encoder settings
+    // AttestationBuilder.buildAttestation uses). The hypervisor concept was
+    // removed from the provider: pin that NO hypervisor key appears in the
+    // signed blob JSON.
+    let blob = AttestationBlob(
+        authenticatedRootEnabled: true,
+        binaryHash: "binhash",
+        chipName: "Apple M4 Max",
+        encryptionPublicKey: "ZW5jcnlwdGlvbi1rZXk=",
+        hardwareModel: "Mac16,5",
+        osVersion: "15.3.0",
+        publicKey: "cHVibGljLWtleQ==",
+        rdmaDisabled: true,
+        secureBootEnabled: true,
+        secureEnclaveAvailable: true,
+        serialNumber: "C02TESTSERIAL",
+        sipEnabled: true,
+        systemVolumeHash: "svhash",
+        timestamp: Date(timeIntervalSince1970: 1_766_000_000)
+    )
+    let encoder = JSONEncoder()
+    encoder.dateEncodingStrategy = .iso8601
+    encoder.outputFormatting = .sortedKeys
+    let data = try encoder.encode(blob)
+
+    let object = try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+    #expect(object["hypervisorActive"] == nil)
+    #expect(object["hypervisor_active"] == nil)
+    // Sanity: the blob still carries its real posture fields.
+    #expect(object["sipEnabled"] as? Bool == true)
+    #expect(object["rdmaDisabled"] as? Bool == true)
 }
 
 @Test func statusCanonicalOmitsEmptyFieldsAndSerializesFalse() throws {

--- a/provider-swift/entitlements.plist
+++ b/provider-swift/entitlements.plist
@@ -10,8 +10,6 @@
          signed-binary value so the entitlement never ships without a push profile. -->
     <key>com.apple.developer.aps-environment</key>
     <string>production</string>
-    <key>com.apple.security.hypervisor</key>
-    <true/>
     <key>com.apple.security.network.client</key>
     <true/>
     <key>com.apple.security.network.server</key>

--- a/scripts/entitlements.plist
+++ b/scripts/entitlements.plist
@@ -3,8 +3,6 @@
 <plist version="1.0">
 <dict>
     <!-- NO get-task-allow → blocks debugger attachment under Hardened Runtime -->
-    <key>com.apple.security.hypervisor</key>
-    <true/>
     <key>com.apple.security.network.client</key>
     <true/>
     <key>com.apple.security.network.server</key>


### PR DESCRIPTION
## Summary

Darkbloom never uses Hypervisor.framework. `SecurityChecks.isHypervisorActive()` was a hardcoded-`return false` stub whose value flowed into four surfaces as a memory-isolation claim that never existed: the signed attestation payloads, registration privacy capabilities, the trust UI shown to users, and the hardened-runtime entitlements. This PR retires the concept end-to-end while keeping **wire + signature tolerance for the old fleet** (coordinator deploys first; providers update lazily over weeks).

## Before / After

### Behavior — what gets attested and claimed

```mermaid
flowchart LR
  subgraph Before
    A1["provider stub<br/>isHypervisorActive() -> false (hardcoded)"] --> B1["registration privacy_capabilities<br/>hypervisor_active:false"]
    A1 --> C1["challenge response + SIGNED canonical status<br/>hypervisor_active:false"]
    C1 --> D1["coordinator: stores/logs value<br/>(informational only)"]
    D1 --> E1["UI: 'Hypervisor.framework memory isolation'<br/>trust claim shown to users"]
    F1["entitlements: com.apple.security.hypervisor<br/>granted, framework never imported"]
  end
  subgraph After
    A2["stub deleted"] --> B2["privacy_capabilities: field gone<br/>(old senders tolerated, key ignored)"]
    A2 --> C2["challenge response omits field;<br/>canonical status omits it (omit-if-nil)"]
    C2 --> D2["coordinator: still VERIFIES old providers'<br/>signed payloads containing the field<br/>(deprecated, remove after fleet > v0.6.31)"]
    D2 --> E2["UI: honest copy — SIP, Hardened Runtime,<br/>binary self-hash only"]
    F2["entitlement removed<br/>(capability reduction)"]
  end
```

### Code — signature-compat plumbing

```mermaid
flowchart LR
  subgraph Before
    a1["Swift: SecurityChecks.isHypervisorActive stub<br/>+ PrivacyCapabilities.hypervisorActive<br/>+ AttestationResponse.hypervisorActive<br/>+ StatusCanonical emit"] --> b1["Go: marshalSortedJSON includes<br/>'hypervisorActive' UNCONDITIONALLY<br/>AttestationBlob.HypervisorActive bool"]
    b1 --> c1["Go: BuildStatusCanonical includes if non-nil<br/>VerificationResult.HypervisorActive (write-only)<br/>provider.go copies into PrivacyCapabilities"]
  end
  subgraph After
    a2["Swift: all hypervisor code deleted;<br/>absence pinned by tests using the exact<br/>signing encoder (.sortedKeys/.iso8601)"] --> b2["Go: AttestationBlob.HypervisorActive *bool,<br/>emitted only when present -> old signed blobs<br/>verify AND new omitting blobs verify"]
    b2 --> c2["Go: AttestationResponseMessage.HypervisorActive *bool<br/>+ BuildStatusCanonical inclusion KEPT (deprecated)<br/>write-only plumbing/logs/copies removed"]
  end
```

## Mixed-fleet compatibility (the design constraint)

| Surface | Old provider (still sends/signs it) | New provider (omits it) |
|---|---|---|
| Registration `privacy_capabilities` | key ignored by encoding/json | field gone from both sides |
| Registration SE blob (`hypervisorActive`, signed) | parsed as non-nil → canonical re-serialization includes it → **signature verifies** | nil → omitted → **signature verifies** (Swift blob already omitted it; now pinned by test) |
| Challenge canonical status (`hypervisor_active`, signed) | `*bool` kept + canonical inclusion kept → **StatusSignature verifies** | nil → omitted (matches Swift golden bytes byte-for-byte) |

Legacy shapes are pinned by tests: canonical bytes with `hypervisor_active` true/false, blob JSON with/without `hypervisorActive` round-tripping through full ECDSA `Verify`, and a raw register frame carrying the legacy capability key. The Go and Swift cross-language golden-bytes tests were updated in lockstep and match byte-identically.

**Removal debt**: `AttestationResponseMessage.HypervisorActive` + its `BuildStatusCanonical` inclusion carry deprecation comments — delete once the fleet floor passes v0.6.31.

## Also in this PR

- **Entitlement removed** from both `provider-swift/entitlements.plist` and `scripts/entitlements.plist` — `Hypervisor.framework` is never imported anywhere in Sources; this is a pure reduction of the signed binary's declared capabilities (release flow computes hashes after signing, so no process impact).
- **False UI claims removed**: chat system context no longer says "Hypervisor.framework memory isolation"; the trust explainer drops "hypervisor isolation status" and also fixes its stale retired-backend claim (Python/vllm-mlx/Jinja → MLX-Swift runtime, chat templates, model weights).
- **Docs made honest**: attestation docs describe `hypervisor_active` as a retired legacy field kept only for signature compat; threat-model T-028 now states plainly that hypervisor Stage-2 isolation was never implemented; README hardening table row removed; AGENTS/CLAUDE entitlement notes corrected.

## Deliberately left alone

- `papers/dginf-private-inference.tex` — historical document.
- `landing/index.html:1313` — one SVG diagram label ("Hypervisor.framework · Stage 2 page tables"); the file has in-flight edits on another branch. **Follow-up: remove that label when landing changes land.**

## Verification

- Coordinator: `gofmt` clean, `go vet` clean, **full `go test ./...` green** (incl. new legacy-compat and cross-language golden tests)
- Provider: `swift build` green; ProtocolTests/CoordinatorClientTests/SecurityTests/IntegrationPlanTests/CoordinatorIntegrationTests — 68 tests pass; `plutil -lint` on both plists OK
- Console UI: eslint 0 errors, build green, tests green except the 4 pre-existing provider-dashboard failures
- `docs/threat-model.yaml` parses (feeds the automated threat-model workflow)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/492"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785545027&installation_id=133247490&pr_number=492&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F492&signature=53f243ee5b1951fbfe478f4471955b1dcaf4669a9bbf85c9736d0a9210a21e10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->