### PR TITLE
fix(terminal-paths): refund observability, chunk-key lifecycle, 499 classification, writer deadline races

### DIFF
--- a/coordinator/api/chunk_key_cache.go
+++ b/coordinator/api/chunk_key_cache.go
@@ -1,8 +1,8 @@
 package api
 
 import (
+	"reflect"
 	"sync"
-	"unsafe"
 
 	"github.com/eigeninference/d-inference/coordinator/internal/e2e"
 )
@@ -110,7 +110,7 @@ func (c *chunkKeyCache) sharedKey(priv *[32]byte, peerPub string) (*[32]byte, er
 	shared := e2e.PrecomputeSharedKey(&pub, priv)
 
 	c.mu.Lock()
-	if _, gone := c.dead[uintptr(unsafe.Pointer(priv))]; gone {
+	if _, gone := c.dead[tombstoneKey(priv)]; gone {
 		// The request hit a terminal path while the lock was dropped for the
 		// compute (or this is a late chunk of an already-forgotten request):
 		// hand the key back for this one decrypt but do NOT cache it — no
@@ -139,7 +139,7 @@ func (c *chunkKeyCache) markDeadLocked(priv *[32]byte) {
 	if c.dead == nil || len(c.dead) >= chunkKeyDeadMax {
 		c.dead = make(map[uintptr]struct{})
 	}
-	c.dead[uintptr(unsafe.Pointer(priv))] = struct{}{}
+	c.dead[tombstoneKey(priv)] = struct{}{}
 }
 
 // forget drops the cached shared key for a finished request WITHOUT zeroing
@@ -210,4 +210,12 @@ func (c *chunkKeyCache) forgetPeer(peerPub string) {
 		}
 	}
 	c.mu.Unlock()
+}
+
+// tombstoneKey converts a priv pointer to its non-pinning map identity. Uses
+// reflect rather than unsafe purely to avoid the unsafe import; the semantics
+// (address as identity, no GC pinning, benign ABA on address reuse — see the
+// dead field comment) are identical.
+func tombstoneKey(priv *[32]byte) uintptr {
+	return reflect.ValueOf(priv).Pointer()
 }

--- a/coordinator/api/chunk_key_cache.go
+++ b/coordinator/api/chunk_key_cache.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"sync"
+	"unsafe"
 
 	"github.com/eigeninference/d-inference/coordinator/internal/e2e"
 )
@@ -66,11 +67,24 @@ type chunkKeyCache struct {
 	m  map[*[32]byte]chunkKeyEntry
 	// dead tombstones privs whose request hit a terminal path (forget /
 	// forgetAndZero). sharedKey refuses to (re-)cache a tombstoned priv.
-	// Bounded by chunkKeyDeadMax with a wholesale drop, like m. Note the
-	// entries pin their 32-byte priv arrays from the GC until that drop —
-	// bounded and secret-free (the SHARED key is what the cache zeroes; the
-	// priv array lives on in its PendingRequest anyway).
-	dead map[*[32]byte]struct{}
+	// Bounded by chunkKeyDeadMax with a wholesale drop, like m.
+	//
+	// Keyed by the priv's ADDRESS (uintptr), not the pointer, so a tombstone
+	// never pins the 32-byte private-key array in the heap after its
+	// PendingRequest is gone — retaining dead key material would undermine
+	// the forget-on-terminal hygiene this cache exists for. The trade is a
+	// benign ABA: after the GC reclaims a tombstoned array, a future
+	// SessionPrivKey allocated at the same address is falsely treated as
+	// dead — its stream still decrypts correctly (sharedKey always returns a
+	// freshly computed key), it just recomputes per chunk until the wholesale
+	// drop clears the stale tombstone. Perf-only, rare, self-healing.
+	//
+	// Why a tombstone rather than refcounting or an owner-managed lifecycle:
+	// the racing readers (late chunks on the provider read loop) are
+	// fire-and-forget with no owner to release against, and the race window
+	// is milliseconds; a lock-only O(1) set that self-expires via the
+	// wholesale drop is the smallest mechanism that closes it.
+	dead map[uintptr]struct{}
 }
 
 type chunkKeyEntry struct {
@@ -96,7 +110,7 @@ func (c *chunkKeyCache) sharedKey(priv *[32]byte, peerPub string) (*[32]byte, er
 	shared := e2e.PrecomputeSharedKey(&pub, priv)
 
 	c.mu.Lock()
-	if _, gone := c.dead[priv]; gone {
+	if _, gone := c.dead[uintptr(unsafe.Pointer(priv))]; gone {
 		// The request hit a terminal path while the lock was dropped for the
 		// compute (or this is a late chunk of an already-forgotten request):
 		// hand the key back for this one decrypt but do NOT cache it — no
@@ -123,9 +137,9 @@ func (c *chunkKeyCache) sharedKey(priv *[32]byte, peerPub string) (*[32]byte, er
 // path can race a late decrypt (see the field comment).
 func (c *chunkKeyCache) markDeadLocked(priv *[32]byte) {
 	if c.dead == nil || len(c.dead) >= chunkKeyDeadMax {
-		c.dead = make(map[*[32]byte]struct{})
+		c.dead = make(map[uintptr]struct{})
 	}
-	c.dead[priv] = struct{}{}
+	c.dead[uintptr(unsafe.Pointer(priv))] = struct{}{}
 }
 
 // forget drops the cached shared key for a finished request WITHOUT zeroing

--- a/coordinator/api/chunk_key_cache.go
+++ b/coordinator/api/chunk_key_cache.go
@@ -23,6 +23,27 @@ const chunkKeyCacheMax = 8192
 // key change (paranoia: reconnect races) invalidates the entry instead of
 // decrypting with a stale shared key.
 //
+// Lifecycle / zeroing policy. Every request-terminal path must drop its entry
+// (orphans are otherwise pinned until the chunkKeyCacheMax wholesale reset),
+// but only SOME of those paths may zero the key material:
+//
+//   - forgetAndZero (delete + zero): ONLY from the provider read-loop
+//     goroutine that performs this request's chunk decryption —
+//     handleComplete, handleInferenceError, and providerReadLoop's disconnect
+//     cleanup. On that goroutine no decrypt with the key can be concurrently
+//     in flight, so zeroing is safe and scrubs the shared secret from the
+//     heap promptly.
+//   - forget (delete only, NO zeroing): every CROSS-GOROUTINE terminal —
+//     dispatch retry key reassignment, the settlement-grace expiry timer,
+//     dispatch-loop cancel/abandon sites. Zeroing there would race a
+//     possibly-in-flight box.OpenAfterPrecomputation on the read loop; a
+//     corrupted decrypt is reported as an invalid encrypted chunk and
+//     triggers MarkUntrusted against an innocent provider. The deleted
+//     array is left intact for the GC.
+//   - The wholesale cap-reset in sharedKey must NOT zero either: the dropped
+//     entries may belong to live streams that will recompute and keep
+//     decrypting with the same private key.
+//
 // The zero value is ready to use.
 type chunkKeyCache struct {
 	mu sync.Mutex
@@ -53,6 +74,10 @@ func (c *chunkKeyCache) sharedKey(priv *[32]byte, peerPub string) (*[32]byte, er
 
 	c.mu.Lock()
 	if c.m == nil || len(c.m) >= chunkKeyCacheMax {
+		// Wholesale reset (abandoned-entry safety net). Deliberately does NOT
+		// zero the dropped keys: entries may belong to live streams whose read
+		// loops are decrypting with them right now (see the zeroing policy on
+		// the type comment).
 		c.m = make(map[*[32]byte]chunkKeyEntry)
 	}
 	c.m[priv] = chunkKeyEntry{peerPub: peerPub, shared: shared}
@@ -60,12 +85,39 @@ func (c *chunkKeyCache) sharedKey(priv *[32]byte, peerPub string) (*[32]byte, er
 	return shared, nil
 }
 
-// forget drops the cached shared key for a finished request.
+// forget drops the cached shared key for a finished request WITHOUT zeroing
+// it. Safe to call from ANY goroutine — this is the variant every
+// cross-goroutine terminal path must use (dispatch retry reassignment,
+// settlement-grace timer, dispatch cancel/abandon): zeroing here could race an
+// in-flight decrypt on the provider read loop (see the type comment).
 func (c *chunkKeyCache) forget(priv *[32]byte) {
 	if priv == nil {
 		return
 	}
 	c.mu.Lock()
 	delete(c.m, priv)
+	c.mu.Unlock()
+}
+
+// forgetAndZero drops the cached shared key for a terminal request AND zeroes
+// the 32-byte array so the shared secret does not linger on the heap.
+//
+// MUST only be called from the goroutine that performs this request's chunk
+// decryption — the owning provider's read loop (handleComplete,
+// handleInferenceError, providerReadLoop's disconnect cleanup). On any other
+// goroutine the zeroing races a possibly-in-flight
+// box.OpenAfterPrecomputation and can corrupt a decrypt (which would
+// MarkUntrusted an innocent provider); use forget there instead.
+func (c *chunkKeyCache) forgetAndZero(priv *[32]byte) {
+	if priv == nil {
+		return
+	}
+	c.mu.Lock()
+	if e, ok := c.m[priv]; ok {
+		if e.shared != nil {
+			*e.shared = [32]byte{}
+		}
+		delete(c.m, priv)
+	}
 	c.mu.Unlock()
 }

--- a/coordinator/api/chunk_key_cache.go
+++ b/coordinator/api/chunk_key_cache.go
@@ -13,6 +13,13 @@ import (
 // X25519 recompute per live stream.
 const chunkKeyCacheMax = 8192
 
+// chunkKeyDeadMax bounds the tombstone set (chunkKeyCache.dead). One tombstone
+// is added per terminated request; when full the set is dropped wholesale. A
+// tombstone only needs to outlive the terminal path's race with a late
+// in-flight decrypt on the provider read loop (milliseconds), so losing old
+// tombstones to the reset is harmless in practice.
+const chunkKeyDeadMax = 8192
+
 // chunkKeyCache memoizes the NaCl box shared key per inference request so the
 // per-token chunk decrypt path performs only the symmetric open, not a fresh
 // X25519 scalar multiplication per chunk (~40-60µs each, serialized on the
@@ -44,10 +51,26 @@ const chunkKeyCacheMax = 8192
 //     entries may belong to live streams that will recompute and keep
 //     decrypting with the same private key.
 //
+// Both forget variants also TOMBSTONE the priv (see dead below): sharedKey
+// drops the lock during the X25519 compute, so without a tombstone a forget
+// racing that window (or a late chunk decrypted just after a cross-goroutine
+// forget) would re-insert an entry for a request no terminal path remains to
+// clean up, pinning the session key until the cap reset. A tombstoned priv is
+// never legitimately re-cached: every dispatch attempt generates fresh session
+// keys, so post-forget decrypts are only late stragglers of an abandoned
+// attempt — they still get a working key, they just recompute per chunk.
+//
 // The zero value is ready to use.
 type chunkKeyCache struct {
 	mu sync.Mutex
 	m  map[*[32]byte]chunkKeyEntry
+	// dead tombstones privs whose request hit a terminal path (forget /
+	// forgetAndZero). sharedKey refuses to (re-)cache a tombstoned priv.
+	// Bounded by chunkKeyDeadMax with a wholesale drop, like m. Note the
+	// entries pin their 32-byte priv arrays from the GC until that drop —
+	// bounded and secret-free (the SHARED key is what the cache zeroes; the
+	// priv array lives on in its PendingRequest anyway).
+	dead map[*[32]byte]struct{}
 }
 
 type chunkKeyEntry struct {
@@ -73,6 +96,15 @@ func (c *chunkKeyCache) sharedKey(priv *[32]byte, peerPub string) (*[32]byte, er
 	shared := e2e.PrecomputeSharedKey(&pub, priv)
 
 	c.mu.Lock()
+	if _, gone := c.dead[priv]; gone {
+		// The request hit a terminal path while the lock was dropped for the
+		// compute (or this is a late chunk of an already-forgotten request):
+		// hand the key back for this one decrypt but do NOT cache it — no
+		// terminal path remains to forget the entry, so it would pin the
+		// session key until the cap reset.
+		c.mu.Unlock()
+		return shared, nil
+	}
 	if c.m == nil || len(c.m) >= chunkKeyCacheMax {
 		// Wholesale reset (abandoned-entry safety net). Deliberately does NOT
 		// zero the dropped keys: entries may belong to live streams whose read
@@ -85,22 +117,37 @@ func (c *chunkKeyCache) sharedKey(priv *[32]byte, peerPub string) (*[32]byte, er
 	return shared, nil
 }
 
+// markDeadLocked tombstones priv so sharedKey never re-caches it. Caller must
+// hold c.mu. The set is dropped wholesale at chunkKeyDeadMax — a tombstone
+// only needs to outlive the milliseconds-scale window in which a terminal
+// path can race a late decrypt (see the field comment).
+func (c *chunkKeyCache) markDeadLocked(priv *[32]byte) {
+	if c.dead == nil || len(c.dead) >= chunkKeyDeadMax {
+		c.dead = make(map[*[32]byte]struct{})
+	}
+	c.dead[priv] = struct{}{}
+}
+
 // forget drops the cached shared key for a finished request WITHOUT zeroing
-// it. Safe to call from ANY goroutine — this is the variant every
-// cross-goroutine terminal path must use (dispatch retry reassignment,
-// settlement-grace timer, dispatch cancel/abandon): zeroing here could race an
-// in-flight decrypt on the provider read loop (see the type comment).
+// it, and tombstones the priv so a racing/late decrypt cannot re-cache it
+// (see the type comment). Safe to call from ANY goroutine — this is the
+// variant every cross-goroutine terminal path must use (dispatch retry
+// reassignment, settlement-grace timer, dispatch cancel/abandon): zeroing
+// here could race an in-flight decrypt on the provider read loop.
 func (c *chunkKeyCache) forget(priv *[32]byte) {
 	if priv == nil {
 		return
 	}
 	c.mu.Lock()
 	delete(c.m, priv)
+	c.markDeadLocked(priv)
 	c.mu.Unlock()
 }
 
 // forgetAndZero drops the cached shared key for a terminal request AND zeroes
-// the 32-byte array so the shared secret does not linger on the heap.
+// the 32-byte array so the shared secret does not linger on the heap. Like
+// forget, it tombstones the priv so a late decrypt cannot re-cache it (see
+// the type comment).
 //
 // MUST only be called from the goroutine that performs this request's chunk
 // decryption — the owning provider's read loop (handleComplete,
@@ -118,6 +165,35 @@ func (c *chunkKeyCache) forgetAndZero(priv *[32]byte) {
 			*e.shared = [32]byte{}
 		}
 		delete(c.m, priv)
+	}
+	c.markDeadLocked(priv)
+	c.mu.Unlock()
+}
+
+// forgetPeer drops every cache entry whose peer public key matches peerPub,
+// WITHOUT zeroing and WITHOUT tombstoning. It is the provider-disconnect
+// catch-all: registry-initiated disconnects (stale eviction, duplicate-serial
+// eviction, forced removal) call Registry.Disconnect directly, which wipes
+// the provider's pending map BEFORE the read-loop cleanup defer can snapshot
+// the session keys — leaving those requests' entries unreachable by any
+// per-request terminal. Sweeping by the provider's public key needs no
+// request state at all.
+//
+// No zeroing and no tombstones because the same peerPub can serve a NEWER
+// session of the same machine (duplicate-serial eviction: the replacement
+// connection reuses the keypair): zeroing could corrupt a live decrypt on the
+// new session's read loop, and a tombstone would permanently disable caching
+// for its live streams. A swept live entry simply recomputes on its next
+// chunk. O(len(m)) ≤ chunkKeyCacheMax under the lock, on rare disconnects.
+func (c *chunkKeyCache) forgetPeer(peerPub string) {
+	if peerPub == "" {
+		return
+	}
+	c.mu.Lock()
+	for priv, e := range c.m {
+		if e.peerPub == peerPub {
+			delete(c.m, priv)
+		}
 	}
 	c.mu.Unlock()
 }

--- a/coordinator/api/chunk_key_cache_test.go
+++ b/coordinator/api/chunk_key_cache_test.go
@@ -217,6 +217,160 @@ func TestChunkKeyCacheForgetDoesNotZero(t *testing.T) {
 	}
 }
 
+// A forgotten priv must never be re-cached: forget tombstones it, so a late
+// straggler decrypt — or one whose unlocked X25519 compute window in sharedKey
+// raced the forget — hands back a working key WITHOUT re-inserting an entry
+// that no terminal path remains to clean up.
+func TestChunkKeyCacheForgetPreventsRecache(t *testing.T) {
+	var c chunkKeyCache
+	peerPub, _, _ := testPeerKeyB64(t)
+	priv := new([32]byte)
+	if _, err := rand.Read(priv[:]); err != nil {
+		t.Fatalf("rand: %v", err)
+	}
+
+	first, err := c.sharedKey(priv, peerPub)
+	if err != nil {
+		t.Fatalf("sharedKey: %v", err)
+	}
+	c.forget(priv)
+
+	late, err := c.sharedKey(priv, peerPub) // late straggler decrypt
+	if err != nil {
+		t.Fatalf("sharedKey after forget: %v", err)
+	}
+	if *late != *first {
+		t.Error("straggler decrypt must still get the correct key value")
+	}
+	c.mu.Lock()
+	_, cached := c.m[priv]
+	c.mu.Unlock()
+	if cached {
+		t.Error("a forgotten priv must not be re-cached by a late sharedKey call")
+	}
+}
+
+// The tombstone also protects the cancel-before-first-chunk case: a forget on
+// a priv that never entered the cache must still block a later first-chunk
+// decrypt from caching. Same guarantee for the zeroing variant.
+func TestChunkKeyCacheForgetBeforeFirstUsePreventsCache(t *testing.T) {
+	for name, forget := range map[string]func(*chunkKeyCache, *[32]byte){
+		"forget":        (*chunkKeyCache).forget,
+		"forgetAndZero": (*chunkKeyCache).forgetAndZero,
+	} {
+		var c chunkKeyCache
+		peerPub, _, _ := testPeerKeyB64(t)
+		priv := new([32]byte)
+		if _, err := rand.Read(priv[:]); err != nil {
+			t.Fatalf("rand: %v", err)
+		}
+
+		forget(&c, priv) // request cancelled before any chunk arrived
+
+		if _, err := c.sharedKey(priv, peerPub); err != nil {
+			t.Fatalf("%s: sharedKey after early forget: %v", name, err)
+		}
+		c.mu.Lock()
+		_, cached := c.m[priv]
+		c.mu.Unlock()
+		if cached {
+			t.Errorf("%s: a late first chunk must not cache a tombstoned priv", name)
+		}
+	}
+}
+
+// The tombstone set is bounded: once it hits chunkKeyDeadMax it is dropped
+// wholesale, after which an old tombstoned priv may cache again (the race
+// window a tombstone protects is milliseconds; this is the documented
+// safety-net trade-off).
+func TestChunkKeyCacheDeadTombstoneCapResets(t *testing.T) {
+	var c chunkKeyCache
+	peerPub, _, _ := testPeerKeyB64(t)
+
+	first := new([32]byte)
+	first[0] = 0xF1
+	c.forget(first)
+	// chunkKeyDeadMax more tombstones guarantee at least one wholesale reset
+	// after first's tombstone landed.
+	for i := 0; i < chunkKeyDeadMax; i++ {
+		c.forget(new([32]byte))
+	}
+	c.mu.Lock()
+	deadLen := len(c.dead)
+	c.mu.Unlock()
+	if deadLen > chunkKeyDeadMax {
+		t.Fatalf("tombstone set grew past the cap: %d > %d", deadLen, chunkKeyDeadMax)
+	}
+
+	if _, err := c.sharedKey(first, peerPub); err != nil {
+		t.Fatalf("sharedKey after tombstone reset: %v", err)
+	}
+	c.mu.Lock()
+	_, cached := c.m[first]
+	c.mu.Unlock()
+	if !cached {
+		t.Error("after the tombstone wholesale reset the priv should cache again")
+	}
+}
+
+// forgetPeer sweeps every entry cached under one peer public key — the
+// provider-disconnect catch-all — without zeroing and without tombstoning
+// (same-keypair replacement sessions must be able to keep caching).
+func TestChunkKeyCacheForgetPeerSweepsWithoutZeroingOrTombstoning(t *testing.T) {
+	var c chunkKeyCache
+	peerA, _, _ := testPeerKeyB64(t)
+	peerB, _, _ := testPeerKeyB64(t)
+
+	privA1, privA2, privB := &[32]byte{1}, &[32]byte{2}, &[32]byte{3}
+	sharedA1, err := c.sharedKey(privA1, peerA)
+	if err != nil {
+		t.Fatalf("sharedKey A1: %v", err)
+	}
+	wantA1 := *sharedA1
+	if _, err := c.sharedKey(privA2, peerA); err != nil {
+		t.Fatalf("sharedKey A2: %v", err)
+	}
+	sharedB, err := c.sharedKey(privB, peerB)
+	if err != nil {
+		t.Fatalf("sharedKey B: %v", err)
+	}
+
+	c.forgetPeer(peerA)
+
+	c.mu.Lock()
+	_, a1 := c.m[privA1]
+	_, a2 := c.m[privA2]
+	_, b := c.m[privB]
+	c.mu.Unlock()
+	if a1 || a2 {
+		t.Error("forgetPeer should sweep every entry for the matching peer")
+	}
+	if !b {
+		t.Error("forgetPeer must not touch entries for other peers")
+	}
+	if *sharedA1 != wantA1 {
+		t.Error("forgetPeer must NOT zero swept keys (replacement session may be decrypting)")
+	}
+	if again, _ := c.sharedKey(privB, peerB); again != sharedB {
+		t.Error("unswept entry should still hit the cache")
+	}
+
+	// NOT tombstoned: a replacement session reusing the keypair re-caches.
+	if _, err := c.sharedKey(privA1, peerA); err != nil {
+		t.Fatalf("sharedKey re-cache after forgetPeer: %v", err)
+	}
+	c.mu.Lock()
+	_, recached := c.m[privA1]
+	c.mu.Unlock()
+	if !recached {
+		t.Error("forgetPeer must not tombstone: a live replacement session must re-cache")
+	}
+
+	c.forgetPeer("") // empty peer is a documented no-op
+	var empty chunkKeyCache
+	empty.forgetPeer(peerA) // nil map must not panic
+}
+
 func TestChunkKeyCacheInvalidPeerKeyNotCached(t *testing.T) {
 	var c chunkKeyCache
 	priv := new([32]byte)

--- a/coordinator/api/chunk_key_cache_test.go
+++ b/coordinator/api/chunk_key_cache_test.go
@@ -145,8 +145,76 @@ func TestChunkKeyCacheForgetRemoves(t *testing.T) {
 
 func TestChunkKeyCacheForgetNilAndEmptyAreSafe(t *testing.T) {
 	var c chunkKeyCache
-	c.forget(nil)           // nil priv is a documented no-op
-	c.forget(new([32]byte)) // forget on a zero-value cache (nil map) must not panic
+	c.forget(nil)                  // nil priv is a documented no-op
+	c.forget(new([32]byte))        // forget on a zero-value cache (nil map) must not panic
+	c.forgetAndZero(nil)           // same no-op guarantees for the zeroing variant
+	c.forgetAndZero(new([32]byte)) // absent entry on a nil map must not panic
+}
+
+// forgetAndZero removes the entry AND scrubs the 32-byte shared key so the
+// secret does not linger on the heap (read-loop terminal paths only — see the
+// zeroing policy on chunkKeyCache).
+func TestChunkKeyCacheForgetAndZeroRemovesAndZeroes(t *testing.T) {
+	var c chunkKeyCache
+	peerPub, _, _ := testPeerKeyB64(t)
+	priv := new([32]byte)
+	if _, err := rand.Read(priv[:]); err != nil {
+		t.Fatalf("rand: %v", err)
+	}
+
+	shared, err := c.sharedKey(priv, peerPub)
+	if err != nil {
+		t.Fatalf("sharedKey: %v", err)
+	}
+	if *shared == ([32]byte{}) {
+		t.Fatal("sanity: freshly computed shared key should not be all-zero")
+	}
+
+	c.forgetAndZero(priv)
+
+	c.mu.Lock()
+	_, stillThere := c.m[priv]
+	c.mu.Unlock()
+	if stillThere {
+		t.Fatal("forgetAndZero should remove the entry")
+	}
+	if *shared != ([32]byte{}) {
+		t.Error("forgetAndZero should zero the shared key array")
+	}
+
+	// Cache still functions: the same inputs recompute the same value under a
+	// fresh array (the zeroed one is never reused).
+	recomputed, err := c.sharedKey(priv, peerPub)
+	if err != nil {
+		t.Fatalf("sharedKey after forgetAndZero: %v", err)
+	}
+	if recomputed == shared {
+		t.Error("recompute after forgetAndZero must allocate a new array, not reuse the zeroed one")
+	}
+	if *recomputed == ([32]byte{}) {
+		t.Error("recomputed shared key should be the real value, not zeroes")
+	}
+}
+
+// The plain forget must NOT zero — cross-goroutine callers rely on the array
+// staying intact for a possibly-in-flight decrypt on the provider read loop.
+func TestChunkKeyCacheForgetDoesNotZero(t *testing.T) {
+	var c chunkKeyCache
+	peerPub, _, _ := testPeerKeyB64(t)
+	priv := new([32]byte)
+	if _, err := rand.Read(priv[:]); err != nil {
+		t.Fatalf("rand: %v", err)
+	}
+
+	shared, err := c.sharedKey(priv, peerPub)
+	if err != nil {
+		t.Fatalf("sharedKey: %v", err)
+	}
+	want := *shared
+	c.forget(priv)
+	if *shared != want {
+		t.Error("forget must leave the shared key array intact (no zeroing cross-goroutine)")
+	}
 }
 
 func TestChunkKeyCacheInvalidPeerKeyNotCached(t *testing.T) {

--- a/coordinator/api/chunk_key_cache_test.go
+++ b/coordinator/api/chunk_key_cache_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"crypto/rand"
 	"encoding/base64"
+	"runtime"
 	"sync"
 	"testing"
 
@@ -291,10 +292,17 @@ func TestChunkKeyCacheDeadTombstoneCapResets(t *testing.T) {
 	first[0] = 0xF1
 	c.forget(first)
 	// chunkKeyDeadMax more tombstones guarantee at least one wholesale reset
-	// after first's tombstone landed.
+	// after first's tombstone landed. The fillers must be KEPT ALIVE for the
+	// duration of the loop: tombstones are keyed by address (uintptr, no GC
+	// pinning — that's the point of the design), so letting the GC reclaim
+	// fillers mid-loop would reuse addresses and the set would never reach
+	// the cap.
+	fillers := make([]*[32]byte, chunkKeyDeadMax)
 	for i := 0; i < chunkKeyDeadMax; i++ {
-		c.forget(new([32]byte))
+		fillers[i] = new([32]byte)
+		c.forget(fillers[i])
 	}
+	runtime.KeepAlive(fillers)
 	c.mu.Lock()
 	deadLen := len(c.dead)
 	c.mu.Unlock()

--- a/coordinator/api/chunk_key_lifecycle_test.go
+++ b/coordinator/api/chunk_key_lifecycle_test.go
@@ -1,0 +1,276 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+	"github.com/eigeninference/d-inference/coordinator/registry"
+	"github.com/eigeninference/d-inference/coordinator/store"
+	"nhooyr.io/websocket"
+)
+
+// Lifecycle tests for the chunk-key cache terminal paths: every way a request
+// can end must drop its memoized X25519 shared key (and only read-loop
+// terminals may zero it — see chunkKeyCache's zeroing policy).
+
+// chunkKeyCached reports whether the cache currently holds an entry for priv.
+func chunkKeyCached(c *chunkKeyCache, priv *[32]byte) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	_, ok := c.m[priv]
+	return ok
+}
+
+// seedChunkKey populates srv.chunkKeys for pr's session key against a fresh
+// peer public key, returning the cached shared-key pointer.
+func seedChunkKey(t *testing.T, srv *Server, priv *[32]byte) *[32]byte {
+	t.Helper()
+	peerPub, _, _ := testPeerKeyB64(t)
+	shared, err := srv.chunkKeys.sharedKey(priv, peerPub)
+	if err != nil {
+		t.Fatalf("seed sharedKey: %v", err)
+	}
+	return shared
+}
+
+// handleInferenceError is a read-loop terminal: the key is removed AND zeroed.
+func TestHandleInferenceErrorForgetsAndZeroesChunkKey(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	reg := registry.New(logger)
+	srv := &Server{registry: reg, logger: logger}
+
+	p := reg.Register("prov-err-key", nil, &protocol.RegisterMessage{
+		Type:     protocol.TypeRegister,
+		Hardware: protocol.Hardware{ChipName: "M3 Max", MemoryGB: 64},
+		Models:   []protocol.ModelInfo{{ID: "key-model", ModelType: "chat", Quantization: "4bit"}},
+		Backend:  "mlx-swift",
+	})
+
+	priv := &[32]byte{7}
+	pr := &registry.PendingRequest{
+		RequestID:      "req-err-key",
+		ProviderID:     p.ID,
+		Model:          "key-model",
+		SessionPrivKey: priv,
+		ChunkCh:        make(chan string, 1),
+		CompleteCh:     make(chan protocol.UsageInfo, 1),
+		ErrorCh:        make(chan protocol.InferenceErrorMessage, 1),
+	}
+	p.AddPending(pr)
+	shared := seedChunkKey(t, srv, priv)
+
+	srv.handleInferenceError(p.ID, p, &protocol.InferenceErrorMessage{
+		Type:       protocol.TypeInferenceError,
+		RequestID:  pr.RequestID,
+		Error:      "model crashed during generation",
+		StatusCode: 500,
+	})
+
+	if chunkKeyCached(&srv.chunkKeys, priv) {
+		t.Fatal("handleInferenceError should forget the chunk key")
+	}
+	if *shared != ([32]byte{}) {
+		t.Error("read-loop terminal should zero the shared key (forgetAndZero)")
+	}
+}
+
+// cancelDispatchAndForget (the dispatch-loop abandon seam: speculative losers,
+// failover retries) drops the key WITHOUT zeroing — it runs cross-goroutine
+// from the provider read loop.
+func TestCancelDispatchAndForgetDropsKeyWithoutZeroing(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	reg := registry.New(logger)
+	st := store.NewMemory(store.Config{AdminKey: "test-key"})
+	srv := NewServer(reg, st, ServerConfig{}, logger)
+
+	p := reg.Register("prov-cancel-key", nil, &protocol.RegisterMessage{
+		Type:     protocol.TypeRegister,
+		Hardware: protocol.Hardware{ChipName: "M3 Max", MemoryGB: 64},
+		Models:   []protocol.ModelInfo{{ID: "key-model", ModelType: "chat", Quantization: "4bit"}},
+		Backend:  "mlx-swift",
+	})
+
+	priv := &[32]byte{9}
+	pr := &registry.PendingRequest{
+		RequestID:      "req-cancel-key",
+		ProviderID:     p.ID,
+		Model:          "key-model",
+		SessionPrivKey: priv,
+	}
+	p.AddPending(pr)
+	shared := seedChunkKey(t, srv, priv)
+	want := *shared
+
+	srv.cancelDispatchAndForget(p, pr)
+
+	if p.GetPending(pr.RequestID) != nil {
+		t.Fatal("cancelDispatchAndForget should remove the pending request")
+	}
+	if chunkKeyCached(&srv.chunkKeys, priv) {
+		t.Fatal("cancelDispatchAndForget should forget the chunk key")
+	}
+	if *shared != want {
+		t.Error("cross-goroutine forget must NOT zero the shared key")
+	}
+	// nil pr must be a no-op, not a panic.
+	srv.cancelDispatchAndForget(p, nil)
+}
+
+// The queued-retry reassignment contract (dispatchPrimary ~line 905): the OLD
+// SessionPrivKey must be forgotten BEFORE the pointer is overwritten, or its
+// cache entry is orphaned forever (the cache is keyed by pointer identity).
+// This exercises the exact forget-then-reassign sequence the dispatch path
+// performs, on a shared PendingRequest object.
+func TestRetryReassignmentForgetsOldChunkKey(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	srv := &Server{logger: logger}
+
+	oldKey := &[32]byte{1}
+	pr := &registry.PendingRequest{RequestID: "req-retry", SessionPrivKey: oldKey}
+	oldShared := seedChunkKey(t, srv, pr.SessionPrivKey)
+	want := *oldShared
+
+	// The dispatch retry seam: forget the old key, then overwrite the pointer.
+	srv.chunkKeys.forget(pr.SessionPrivKey)
+	newKey := &[32]byte{2}
+	pr.SessionPrivKey = newKey
+
+	if chunkKeyCached(&srv.chunkKeys, oldKey) {
+		t.Fatal("old session key must be forgotten before reassignment")
+	}
+	if *oldShared != want {
+		t.Error("retry reassignment is cross-goroutine: the old shared key must not be zeroed")
+	}
+	// The new key works independently.
+	if seedChunkKey(t, srv, pr.SessionPrivKey) == nil {
+		t.Fatal("new session key should be cacheable")
+	}
+	if !chunkKeyCached(&srv.chunkKeys, newKey) {
+		t.Fatal("new session key entry missing")
+	}
+}
+
+// forgetProviderPendingKeys (the providerReadLoop cleanup helper) drops and
+// zeroes every pending request's key, and tolerates nil providers and requests
+// without keys.
+func TestForgetProviderPendingKeysDirect(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	reg := registry.New(logger)
+	srv := &Server{registry: reg, logger: logger}
+
+	srv.forgetProviderPendingKeys(nil) // never-registered provider: no-op
+
+	p := reg.Register("prov-disc-key", nil, &protocol.RegisterMessage{
+		Type:     protocol.TypeRegister,
+		Hardware: protocol.Hardware{ChipName: "M3 Max", MemoryGB: 64},
+		Models:   []protocol.ModelInfo{{ID: "key-model", ModelType: "chat", Quantization: "4bit"}},
+		Backend:  "mlx-swift",
+	})
+
+	privA := &[32]byte{3}
+	privB := &[32]byte{4}
+	p.AddPending(&registry.PendingRequest{RequestID: "req-a", SessionPrivKey: privA})
+	p.AddPending(&registry.PendingRequest{RequestID: "req-b", SessionPrivKey: privB})
+	p.AddPending(&registry.PendingRequest{RequestID: "req-nokey"})
+
+	sharedA := seedChunkKey(t, srv, privA)
+	sharedB := seedChunkKey(t, srv, privB)
+
+	srv.forgetProviderPendingKeys(p)
+
+	if chunkKeyCached(&srv.chunkKeys, privA) || chunkKeyCached(&srv.chunkKeys, privB) {
+		t.Fatal("disconnect cleanup should forget every pending session key")
+	}
+	if *sharedA != ([32]byte{}) || *sharedB != ([32]byte{}) {
+		t.Error("disconnect cleanup runs on the read-loop goroutine: keys must be zeroed")
+	}
+}
+
+// End-to-end: a provider WebSocket disconnect runs providerReadLoop's cleanup
+// defer, which must forget (and zero) the chunk keys of every request still
+// in-flight on that provider — BEFORE registry.Disconnect wipes the pending map.
+func TestProviderDisconnectForgetsPendingChunkKeys(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	st := store.NewMemory(store.Config{AdminKey: "test-key"})
+	reg := registry.New(logger)
+	srv := NewServer(reg, st, ServerConfig{}, logger)
+
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http") + "/ws/provider"
+	conn, _, err := websocket.Dial(ctx, wsURL, nil)
+	if err != nil {
+		t.Fatalf("websocket dial: %v", err)
+	}
+
+	regMsg := protocol.RegisterMessage{
+		Type:     protocol.TypeRegister,
+		Hardware: protocol.Hardware{ChipName: "M3 Max", MemoryGB: 64},
+		Models:   []protocol.ModelInfo{{ID: "disc-model", ModelType: "chat", Quantization: "4bit"}},
+		Backend:  "mlx-swift",
+	}
+	regData, _ := json.Marshal(regMsg)
+	if err := conn.Write(ctx, websocket.MessageText, regData); err != nil {
+		t.Fatalf("write register: %v", err)
+	}
+
+	deadline := time.Now().Add(5 * time.Second)
+	var p *registry.Provider
+	for time.Now().Before(deadline) {
+		if p = findProviderByModel(reg, "disc-model"); p != nil {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if p == nil {
+		t.Fatal("provider never registered")
+	}
+
+	priv := &[32]byte{5}
+	p.AddPending(&registry.PendingRequest{
+		RequestID:      "req-inflight",
+		ProviderID:     p.ID,
+		Model:          "disc-model",
+		SessionPrivKey: priv,
+		ChunkCh:        make(chan string, 1),
+		CompleteCh:     make(chan protocol.UsageInfo, 1),
+		ErrorCh:        make(chan protocol.InferenceErrorMessage, 1),
+	})
+	shared := seedChunkKey(t, srv, priv)
+
+	// Client-side close: the read loop exits and its cleanup defer runs.
+	conn.Close(websocket.StatusNormalClosure, "bye")
+
+	for time.Now().Before(deadline) {
+		if !chunkKeyCached(&srv.chunkKeys, priv) {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if chunkKeyCached(&srv.chunkKeys, priv) {
+		t.Fatal("disconnect cleanup never forgot the in-flight request's chunk key")
+	}
+	// forgetAndZero zeroes under the same lock that deletes: once the entry is
+	// gone, the array must already be scrubbed.
+	if *shared != ([32]byte{}) {
+		t.Error("disconnect cleanup should zero the shared key (read-loop goroutine)")
+	}
+	if got := reg.ProviderCount(); got != 0 {
+		// Disconnect runs after the forget in the same defer; give it a beat.
+		time.Sleep(100 * time.Millisecond)
+		if got = reg.ProviderCount(); got != 0 {
+			t.Fatalf("provider count after disconnect = %d, want 0", got)
+		}
+	}
+}

--- a/coordinator/api/chunk_key_lifecycle_test.go
+++ b/coordinator/api/chunk_key_lifecycle_test.go
@@ -81,7 +81,7 @@ func TestHandleInferenceErrorForgetsAndZeroesChunkKey(t *testing.T) {
 	}
 }
 
-// cancelDispatchAndForget (the dispatch-loop abandon seam: speculative losers,
+// cancelDispatch (the dispatch-loop abandon seam: speculative losers,
 // failover retries) drops the key WITHOUT zeroing — it runs cross-goroutine
 // from the provider read loop.
 func TestCancelDispatchAndForgetDropsKeyWithoutZeroing(t *testing.T) {
@@ -108,19 +108,19 @@ func TestCancelDispatchAndForgetDropsKeyWithoutZeroing(t *testing.T) {
 	shared := seedChunkKey(t, srv, priv)
 	want := *shared
 
-	srv.cancelDispatchAndForget(p, pr)
+	srv.cancelDispatch(p, pr)
 
 	if p.GetPending(pr.RequestID) != nil {
-		t.Fatal("cancelDispatchAndForget should remove the pending request")
+		t.Fatal("cancelDispatch should remove the pending request")
 	}
 	if chunkKeyCached(&srv.chunkKeys, priv) {
-		t.Fatal("cancelDispatchAndForget should forget the chunk key")
+		t.Fatal("cancelDispatch should forget the chunk key")
 	}
 	if *shared != want {
 		t.Error("cross-goroutine forget must NOT zero the shared key")
 	}
 	// nil pr must be a no-op, not a panic.
-	srv.cancelDispatchAndForget(p, nil)
+	srv.cancelDispatch(p, nil)
 }
 
 // The queued-retry reassignment contract (dispatchPrimary ~line 905): the OLD

--- a/coordinator/api/chunk_key_lifecycle_test.go
+++ b/coordinator/api/chunk_key_lifecycle_test.go
@@ -193,6 +193,92 @@ func TestForgetProviderPendingKeysDirect(t *testing.T) {
 	}
 }
 
+// End-to-end: a REGISTRY-INITIATED disconnect (stale eviction, duplicate-
+// serial eviction, forced removal — anything that calls Registry.Disconnect
+// directly) wipes the provider's pending map BEFORE its CloseNow unblocks the
+// read loop, so the defer's per-request key snapshot is empty. The peer-key
+// sweep (chunkKeys.forgetPeer) must still drop every entry cached under the
+// provider's public key — WITHOUT zeroing, since a same-keypair replacement
+// session could be decrypting with a matching entry.
+func TestRegistryInitiatedDisconnectSweepsChunkKeys(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	st := store.NewMemory(store.Config{AdminKey: "test-key"})
+	reg := registry.New(logger)
+	srv := NewServer(reg, st, ServerConfig{}, logger)
+
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http") + "/ws/provider"
+	conn, _, err := websocket.Dial(ctx, wsURL, nil)
+	if err != nil {
+		t.Fatalf("websocket dial: %v", err)
+	}
+	defer conn.Close(websocket.StatusNormalClosure, "test done")
+
+	peerPubB64, _, _ := testPeerKeyB64(t)
+	regMsg := protocol.RegisterMessage{
+		Type:      protocol.TypeRegister,
+		Hardware:  protocol.Hardware{ChipName: "M3 Max", MemoryGB: 64},
+		Models:    []protocol.ModelInfo{{ID: "evict-model", ModelType: "chat", Quantization: "4bit"}},
+		Backend:   "mlx-swift",
+		PublicKey: peerPubB64,
+	}
+	regData, _ := json.Marshal(regMsg)
+	if err := conn.Write(ctx, websocket.MessageText, regData); err != nil {
+		t.Fatalf("write register: %v", err)
+	}
+
+	deadline := time.Now().Add(5 * time.Second)
+	var p *registry.Provider
+	for time.Now().Before(deadline) {
+		if p = findProviderByModel(reg, "evict-model"); p != nil {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if p == nil {
+		t.Fatal("provider never registered")
+	}
+
+	priv := &[32]byte{6}
+	p.AddPending(&registry.PendingRequest{
+		RequestID:      "req-evicted",
+		ProviderID:     p.ID,
+		Model:          "evict-model",
+		SessionPrivKey: priv,
+		ChunkCh:        make(chan string, 1),
+		CompleteCh:     make(chan protocol.UsageInfo, 1),
+		ErrorCh:        make(chan protocol.InferenceErrorMessage, 1),
+	})
+	// The real decrypt path caches under the provider's registered public key.
+	shared, err := srv.chunkKeys.sharedKey(priv, p.PublicKey)
+	if err != nil {
+		t.Fatalf("seed sharedKey under provider key: %v", err)
+	}
+	want := *shared
+
+	// Registry-initiated: wipes the pending map, THEN CloseNow unblocks the
+	// server read loop, whose defer must sweep by peer key.
+	reg.Disconnect(p.ID)
+
+	for time.Now().Before(deadline) {
+		if !chunkKeyCached(&srv.chunkKeys, priv) {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if chunkKeyCached(&srv.chunkKeys, priv) {
+		t.Fatal("registry-initiated disconnect never swept the orphaned chunk key")
+	}
+	if *shared != want {
+		t.Error("the peer-key sweep must NOT zero (possible same-keypair replacement session)")
+	}
+}
+
 // End-to-end: a provider WebSocket disconnect runs providerReadLoop's cleanup
 // defer, which must forget (and zero) the chunk keys of every request still
 // in-flight on that provider — BEFORE registry.Disconnect wipes the pending map.

--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -220,6 +220,12 @@ func (s *Server) cancelDispatch(provider *registry.Provider, pr *registry.Pendin
 		return
 	}
 	removed := provider.RemovePending(pr.RequestID)
+	// Drop the attempt's memoized chunk-decryption key: after RemovePending no
+	// provider terminal can find the request to clean it up. Plain forget, NO
+	// zeroing — this runs on the consumer/dispatch goroutine while the provider
+	// read loop may still be decrypting a late in-flight chunk with this key
+	// (see chunkKeyCache's zeroing policy).
+	s.chunkKeys.forget(pr.SessionPrivKey)
 	s.registry.SetProviderIdle(provider.ID)
 	s.sendProviderCancel(provider, pr.RequestID)
 	if removed != nil {
@@ -241,7 +247,19 @@ func (s *Server) refundProviderExtra(pr *registry.PendingRequest) {
 	if extra <= 0 {
 		return
 	}
-	_ = s.store.Credit(pr.ConsumerKey, extra, store.LedgerRefund, "reservation_extra_refund:"+pr.RequestID)
+	if err := s.store.Credit(pr.ConsumerKey, extra, store.LedgerRefund, "reservation_extra_refund:"+pr.RequestID); err != nil {
+		// Never swallow a failed refund: the consumer stays debited. The
+		// alert hook is the metric; ops resolves via the logged account.
+		s.logger.Error("reservation extra refund failed — consumer remains debited",
+			"account_id", pr.ConsumerKey,
+			"request_id", pr.RequestID,
+			"model", pr.Model,
+			"refund_micro_usd", extra,
+			"error", err,
+		)
+		s.ddIncr("billing.refund_failures", []string{"model:" + pr.Model, "op:reservation_extra_refund"})
+		return
+	}
 	pr.ReservedMicroUSD = pr.BaseReservedMicroUSD
 	s.ddIncr("billing.reservation_extra_refunds", []string{"model:" + pr.Model})
 }
@@ -712,7 +730,9 @@ func (s *Server) dispatchOneProvider(
 	pendingCleanup := true
 	cleanupPending := func() {
 		if pendingCleanup {
-			provider.RemovePending(requestID)
+			if removed := provider.RemovePending(requestID); removed != nil {
+				s.chunkKeys.forget(removed.SessionPrivKey)
+			}
 			s.registry.SetProviderIdle(provider.ID)
 			pendingCleanup = false
 		}
@@ -764,7 +784,20 @@ func (s *Server) dispatchOneProvider(
 		extra := pr.ReservedMicroUSD - reservedMicroUSD
 		if extra > 0 {
 			start := time.Now()
-			_ = s.store.Credit(consumerKey, extra, store.LedgerRefund, "reservation_extra_refund:"+requestID)
+			if err := s.store.Credit(consumerKey, extra, store.LedgerRefund, "reservation_extra_refund:"+requestID); err != nil {
+				// Never swallow a failed refund: the consumer stays debited.
+				// Keep ReservedMicroUSD unchanged so a later settlement path
+				// can still retry the refund.
+				s.logger.Error("reservation extra refund failed — consumer remains debited",
+					"account_id", consumerKey,
+					"request_id", requestID,
+					"model", model,
+					"refund_micro_usd", extra,
+					"error", err,
+				)
+				s.ddIncr("billing.refund_failures", []string{"model:" + model, "op:reservation_extra_refund"})
+				return
+			}
 			s.ddIncr("billing.reservation_extra_refunds", []string{"model:" + model})
 			s.ddHistogram("store.credit.latency_ms", float64(time.Since(start).Milliseconds()), []string{"op:reservation_extra_refund"})
 			pr.ReservedMicroUSD = reservedMicroUSD
@@ -3352,7 +3385,20 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 		extra := pr.ReservedMicroUSD - reservedMicroUSD
 		if extra > 0 {
 			start := time.Now()
-			_ = s.store.Credit(consumerKey, extra, store.LedgerRefund, "reservation_extra_refund:"+requestID)
+			if err := s.store.Credit(consumerKey, extra, store.LedgerRefund, "reservation_extra_refund:"+requestID); err != nil {
+				// Never swallow a failed refund: the consumer stays debited.
+				// Keep ReservedMicroUSD unchanged so a later settlement path
+				// can still retry the refund.
+				s.logger.Error("reservation extra refund failed — consumer remains debited",
+					"account_id", consumerKey,
+					"request_id", requestID,
+					"model", model,
+					"refund_micro_usd", extra,
+					"error", err,
+				)
+				s.ddIncr("billing.refund_failures", []string{"model:" + model, "op:reservation_extra_refund"})
+				return
+			}
 			s.ddIncr("billing.reservation_extra_refunds", []string{"model:" + model})
 			s.ddHistogram("store.credit.latency_ms", float64(time.Since(start).Milliseconds()), []string{"op:reservation_extra_refund"})
 			pr.ReservedMicroUSD = reservedMicroUSD
@@ -3388,7 +3434,9 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 		// rate. Skipped for free (owned) requests, which settle at zero cost.
 		if s.billing != nil && !settlesFree {
 			if _, err := s.reserveAdditionalForProvider(pr, provider); err != nil {
-				provider.RemovePending(requestID)
+				if removed := provider.RemovePending(requestID); removed != nil {
+					s.chunkKeys.forget(removed.SessionPrivKey)
+				}
 				s.registry.SetProviderIdle(provider.ID)
 				excludeProviders = append(excludeProviders, provider.ID)
 				if !errors.Is(err, store.ErrInsufficientBalance) {
@@ -3546,7 +3594,9 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 	pendingCleanup := true
 	cleanupPending := func() {
 		if pendingCleanup {
-			provider.RemovePending(requestID)
+			if removed := provider.RemovePending(requestID); removed != nil {
+				s.chunkKeys.forget(removed.SessionPrivKey)
+			}
 			s.registry.SetProviderIdle(provider.ID)
 			pendingCleanup = false
 		}
@@ -3752,7 +3802,9 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 		} else {
 			select {
 			case errMsg := <-pr.ErrorCh:
-				provider.RemovePending(requestID)
+				if removed := provider.RemovePending(requestID); removed != nil {
+					s.chunkKeys.forget(removed.SessionPrivKey)
+				}
 				s.registry.SetProviderIdle(provider.ID)
 				s.sendProviderCancel(provider, requestID)
 				refundExtra()
@@ -3771,7 +3823,9 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 		}
 	case errMsg := <-pr.ErrorCh:
 		ttftTimer.Stop()
-		provider.RemovePending(requestID)
+		if removed := provider.RemovePending(requestID); removed != nil {
+			s.chunkKeys.forget(removed.SessionPrivKey)
+		}
 		s.registry.SetProviderIdle(provider.ID)
 		s.sendProviderCancel(provider, requestID)
 		refundExtra()
@@ -3785,7 +3839,9 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 		writeJSON(w, statusCode, errorResponse("provider_error", errMsg.Error))
 		return
 	case <-ttftTimer.C:
-		provider.RemovePending(requestID)
+		if removed := provider.RemovePending(requestID); removed != nil {
+			s.chunkKeys.forget(removed.SessionPrivKey)
+		}
 		s.registry.SetProviderIdle(provider.ID)
 		s.sendProviderCancel(provider, requestID)
 		refundExtra()
@@ -3796,7 +3852,9 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 		return
 	case <-r.Context().Done():
 		ttftTimer.Stop()
-		provider.RemovePending(requestID)
+		if removed := provider.RemovePending(requestID); removed != nil {
+			s.chunkKeys.forget(removed.SessionPrivKey)
+		}
 		s.registry.SetProviderIdle(provider.ID)
 		s.sendProviderCancel(provider, requestID)
 		refundExtra()
@@ -3825,7 +3883,9 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 			} else {
 				select {
 				case errMsg := <-pr.ErrorCh:
-					provider.RemovePending(requestID)
+					if removed := provider.RemovePending(requestID); removed != nil {
+						s.chunkKeys.forget(removed.SessionPrivKey)
+					}
 					s.registry.SetProviderIdle(provider.ID)
 					s.sendProviderCancel(provider, requestID)
 					refundExtra()
@@ -3844,7 +3904,9 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 			}
 		case errMsg := <-pr.ErrorCh:
 			chunkTimer.Stop()
-			provider.RemovePending(requestID)
+			if removed := provider.RemovePending(requestID); removed != nil {
+				s.chunkKeys.forget(removed.SessionPrivKey)
+			}
 			s.registry.SetProviderIdle(provider.ID)
 			s.sendProviderCancel(provider, requestID)
 			refundExtra()
@@ -3858,7 +3920,9 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 			writeJSON(w, statusCode, errorResponse("provider_error", errMsg.Error))
 			return
 		case <-chunkTimer.C:
-			provider.RemovePending(requestID)
+			if removed := provider.RemovePending(requestID); removed != nil {
+				s.chunkKeys.forget(removed.SessionPrivKey)
+			}
 			s.registry.SetProviderIdle(provider.ID)
 			s.sendProviderCancel(provider, requestID)
 			refundExtra()
@@ -3874,7 +3938,9 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 			return
 		case <-r.Context().Done():
 			chunkTimer.Stop()
-			provider.RemovePending(requestID)
+			if removed := provider.RemovePending(requestID); removed != nil {
+				s.chunkKeys.forget(removed.SessionPrivKey)
+			}
 			s.registry.SetProviderIdle(provider.ID)
 			s.sendProviderCancel(provider, requestID)
 			refundExtra()
@@ -3886,7 +3952,9 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 	}
 
 	if !committed {
-		provider.RemovePending(requestID)
+		if removed := provider.RemovePending(requestID); removed != nil {
+			s.chunkKeys.forget(removed.SessionPrivKey)
+		}
 		s.registry.SetProviderIdle(provider.ID)
 		s.sendProviderCancel(provider, requestID)
 		refundExtra()
@@ -3909,7 +3977,9 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 				s.refundReservedBalance(refundPr, "post_terminal_sweep:"+requestID)
 			})
 		}
-		provider.RemovePending(requestID)
+		if removed := provider.RemovePending(requestID); removed != nil {
+			s.chunkKeys.forget(removed.SessionPrivKey)
+		}
 		s.registry.SetProviderIdle(provider.ID)
 		s.sendProviderCancel(provider, requestID)
 	}()

--- a/coordinator/api/dispatch.go
+++ b/coordinator/api/dispatch.go
@@ -990,23 +990,6 @@ func (d *dispatchState) dispatchPrimary() dispatchOutcome {
 	return outcomeProceed
 }
 
-// cancelDispatchAndForget abandons a dispatched attempt (cancelDispatch:
-// remove pending, idle the provider, WS-cancel, refund the attempt's top-up)
-// and drops the attempt's memoized chunk-decryption key. Every dispatch-loop
-// abandon site (speculative losers, failover retries, deadline/client-gone
-// exits) funnels through here so an abandoned attempt cannot pin its session
-// key in the cache until the cap-reset. Plain forget, NO zeroing: these sites
-// run on the consumer/dispatch goroutine, not the provider read loop — the
-// read loop may still be decrypting a late in-flight chunk with this key, and
-// zeroing under it would corrupt that decrypt (and MarkUntrusted an innocent
-// provider). See chunkKeyCache's zeroing policy.
-func (s *Server) cancelDispatchAndForget(provider *registry.Provider, pr *registry.PendingRequest) {
-	s.cancelDispatch(provider, pr)
-	if pr != nil {
-		s.chunkKeys.forget(pr.SessionPrivKey)
-	}
-}
-
 // noteDispatchRetry feeds the inference-error breaker + refund for a pre-commit
 // provider error and, unless held boilerplate was discarded (which emits its own
 // pre-content failover counter), emits the generic retry counter. This is the
@@ -1175,7 +1158,7 @@ func (d *dispatchState) waitFirstChunk() (outcome dispatchOutcome) {
 				select {
 				case errMsg := <-pr.ErrorCh:
 					d.excludeProviders[provider.ID] = struct{}{}
-					s.cancelDispatchAndForget(provider, pr)
+					s.cancelDispatch(provider, pr)
 					d.setLastInferenceError(provider, errMsg)
 					d.lastFailedVersion = failedProviderVersion(provider)
 					d.noteDispatchRetry(provider, pr, errMsg.StatusCode, errMsg.Error, &d.heldChunks)
@@ -1200,7 +1183,7 @@ func (d *dispatchState) waitFirstChunk() (outcome dispatchOutcome) {
 			speculativeTimer.Stop()
 			deadlineTimer.Stop()
 			d.excludeProviders[provider.ID] = struct{}{}
-			s.cancelDispatchAndForget(provider, pr)
+			s.cancelDispatch(provider, pr)
 			d.setLastInferenceError(provider, errMsg)
 			d.lastFailedVersion = failedProviderVersion(provider)
 			s.logger.Warn("provider failed, retrying",
@@ -1241,7 +1224,7 @@ func (d *dispatchState) waitFirstChunk() (outcome dispatchOutcome) {
 			}
 			d.excludeProviders[provider.ID] = struct{}{}
 			s.registry.RecordWarmPoolTTFTMiss(d.model, d.deadline)
-			s.cancelDispatchAndForget(provider, pr)
+			s.cancelDispatch(provider, pr)
 			d.setLastError("timeout waiting for first response", http.StatusGatewayTimeout)
 			s.logger.Warn("provider timeout (full deadline), retrying",
 				"request_id", d.requestID,
@@ -1266,7 +1249,7 @@ func (d *dispatchState) waitFirstChunk() (outcome dispatchOutcome) {
 		case <-r.Context().Done():
 			speculativeTimer.Stop()
 			deadlineTimer.Stop()
-			s.cancelDispatchAndForget(provider, pr)
+			s.cancelDispatch(provider, pr)
 			d.refundReservation()
 			return outcomeClientGone
 		}
@@ -1390,7 +1373,7 @@ func (d *dispatchState) waitNoBackup() dispatchOutcome {
 				select {
 				case errMsg := <-pr.ErrorCh:
 					d.excludeProviders[provider.ID] = struct{}{}
-					s.cancelDispatchAndForget(provider, pr)
+					s.cancelDispatch(provider, pr)
 					d.setLastInferenceError(provider, errMsg)
 					d.lastFailedVersion = failedProviderVersion(provider)
 					d.noteDispatchRetry(provider, pr, errMsg.StatusCode, errMsg.Error, &d.heldChunks)
@@ -1409,7 +1392,7 @@ func (d *dispatchState) waitNoBackup() dispatchOutcome {
 		case errMsg := <-pr.ErrorCh:
 			remainingDeadline.Stop()
 			d.excludeProviders[provider.ID] = struct{}{}
-			s.cancelDispatchAndForget(provider, pr)
+			s.cancelDispatch(provider, pr)
 			d.setLastInferenceError(provider, errMsg)
 			d.lastFailedVersion = failedProviderVersion(provider)
 			if s.metrics != nil {
@@ -1432,7 +1415,7 @@ func (d *dispatchState) waitNoBackup() dispatchOutcome {
 			}
 			d.excludeProviders[provider.ID] = struct{}{}
 			s.registry.RecordWarmPoolTTFTMiss(d.model, d.deadline)
-			s.cancelDispatchAndForget(provider, pr)
+			s.cancelDispatch(provider, pr)
 			d.setLastError("timeout waiting for first response", http.StatusGatewayTimeout)
 			s.logger.Warn("provider timeout (no backup), retrying",
 				"request_id", d.requestID,
@@ -1455,7 +1438,7 @@ func (d *dispatchState) waitNoBackup() dispatchOutcome {
 			return outcomeRetry
 		case <-r.Context().Done():
 			remainingDeadline.Stop()
-			s.cancelDispatchAndForget(provider, pr)
+			s.cancelDispatch(provider, pr)
 			d.refundReservation()
 			return outcomeClientGone
 		}
@@ -1493,7 +1476,7 @@ func (d *dispatchState) runRace(backupProvider *registry.Provider, backupPR *reg
 			}
 			// Primary wins!
 			raceDeadline.Stop()
-			s.cancelDispatchAndForget(backupProvider, backupPR)
+			s.cancelDispatch(backupProvider, backupPR)
 			if ok {
 				d.markSpeculativeLoser(backupPR)
 				d.commitFirstContent(pr, chunk)
@@ -1504,7 +1487,7 @@ func (d *dispatchState) runRace(backupProvider *registry.Provider, backupPR *reg
 					// Primary failed but we already cancelled backup.
 					d.markSpeculativeLoser(backupPR)
 					d.excludeProviders[provider.ID] = struct{}{}
-					s.cancelDispatchAndForget(provider, pr)
+					s.cancelDispatch(provider, pr)
 					d.setLastInferenceError(provider, errMsg)
 					d.lastFailedVersion = failedProviderVersion(provider)
 					d.noteDispatchRetry(provider, pr, errMsg.StatusCode, errMsg.Error, &d.heldChunks)
@@ -1527,7 +1510,7 @@ func (d *dispatchState) runRace(backupProvider *registry.Provider, backupPR *reg
 			}
 			// Backup wins!
 			raceDeadline.Stop()
-			s.cancelDispatchAndForget(provider, pr)
+			s.cancelDispatch(provider, pr)
 			s.ddIncr("inference.speculative_win", []string{"model:" + d.model})
 			s.registry.RecordWarmPoolSpeculativeWon(d.model)
 			if ok {
@@ -1554,7 +1537,7 @@ func (d *dispatchState) runRace(backupProvider *registry.Provider, backupPR *reg
 					return d.raceBackupChunkClosedWaitPrimary(provider, pr)
 				default:
 					// Backup channel closed with no error — treat as committed.
-					s.cancelDispatchAndForget(provider, pr)
+					s.cancelDispatch(provider, pr)
 					d.markSpeculativeLoser(pr)
 					backupPR.BackupWon = true
 					d.provider = backupProvider
@@ -1569,7 +1552,7 @@ func (d *dispatchState) runRace(backupProvider *registry.Provider, backupPR *reg
 		case <-pr.AcceptedCh:
 			// Primary accepted (model reload). Cancel backup, extend deadline.
 			raceDeadline.Stop()
-			s.cancelDispatchAndForget(backupProvider, backupPR)
+			s.cancelDispatch(backupProvider, backupPR)
 			d.markSpeculativeLoser(backupPR)
 			d.accepted = true
 			return outcomeAccepted
@@ -1577,7 +1560,7 @@ func (d *dispatchState) runRace(backupProvider *registry.Provider, backupPR *reg
 		case <-backupPR.AcceptedCh:
 			// Backup accepted (model reload). Cancel primary, extend deadline.
 			raceDeadline.Stop()
-			s.cancelDispatchAndForget(provider, pr)
+			s.cancelDispatch(provider, pr)
 			d.markSpeculativeLoser(pr)
 			backupPR.BackupWon = true
 			d.provider = backupProvider
@@ -1591,7 +1574,7 @@ func (d *dispatchState) runRace(backupProvider *registry.Provider, backupPR *reg
 			// Primary failed. Keep waiting for backup.
 			raceDeadline.Stop()
 			d.excludeProviders[provider.ID] = struct{}{}
-			s.cancelDispatchAndForget(provider, pr)
+			s.cancelDispatch(provider, pr)
 			d.lastFailedVersion = failedProviderVersion(provider)
 			d.updateSpeculativeFailure(pr, errMsg)
 			s.noteDispatchProviderError(provider, pr, errMsg.StatusCode, errMsg.Error, &d.heldChunks)
@@ -1607,7 +1590,7 @@ func (d *dispatchState) runRace(backupProvider *registry.Provider, backupPR *reg
 			// Backup failed. Keep waiting for primary.
 			raceDeadline.Stop()
 			d.excludeProviders[backupProvider.ID] = struct{}{}
-			s.cancelDispatchAndForget(backupProvider, backupPR)
+			s.cancelDispatch(backupProvider, backupPR)
 			d.lastFailedVersion = failedProviderVersion(backupProvider)
 			d.updateSpeculativeFailure(backupPR, errMsg)
 			s.noteDispatchProviderError(backupProvider, backupPR, errMsg.StatusCode, errMsg.Error, &backupHeld)
@@ -1639,9 +1622,9 @@ func (d *dispatchState) runRace(backupProvider *registry.Provider, backupPR *reg
 			if len(backupHeld) > 0 {
 				s.noteInferenceError(backupProvider.ID, backupPR, http.StatusGatewayTimeout, "")
 			}
-			s.cancelDispatchAndForget(provider, pr)
+			s.cancelDispatch(provider, pr)
 			s.registry.RecordWarmPoolTTFTMiss(d.model, d.deadline)
-			s.cancelDispatchAndForget(backupProvider, backupPR)
+			s.cancelDispatch(backupProvider, backupPR)
 			d.updateSpeculativeTimeout(backupPR, "first_chunk_timeout")
 			d.excludeProviders[provider.ID] = struct{}{}
 			d.excludeProviders[backupProvider.ID] = struct{}{}
@@ -1657,8 +1640,8 @@ func (d *dispatchState) runRace(backupProvider *registry.Provider, backupPR *reg
 		case <-r.Context().Done():
 			raceDeadline.Stop()
 			d.updateSpeculativeClientGone(backupPR)
-			s.cancelDispatchAndForget(provider, pr)
-			s.cancelDispatchAndForget(backupProvider, backupPR)
+			s.cancelDispatch(provider, pr)
+			s.cancelDispatch(backupProvider, backupPR)
 			d.refundReservation()
 			return outcomeClientGone
 		}
@@ -1689,7 +1672,7 @@ func (d *dispatchState) raceBackupChunkClosedWaitPrimary(provider *registry.Prov
 				select {
 				case errMsg2 := <-pr.ErrorCh:
 					d.excludeProviders[provider.ID] = struct{}{}
-					s.cancelDispatchAndForget(provider, pr)
+					s.cancelDispatch(provider, pr)
 					d.setLastInferenceError(provider, errMsg2)
 					d.lastFailedVersion = failedProviderVersion(provider)
 					d.updateSpeculativeFailure(pr, errMsg2)
@@ -1714,7 +1697,7 @@ func (d *dispatchState) raceBackupChunkClosedWaitPrimary(provider *registry.Prov
 			// ordering ever changes — mirroring its sibling wait loops.
 			remainingPrimary.Stop()
 			d.excludeProviders[provider.ID] = struct{}{}
-			s.cancelDispatchAndForget(provider, pr)
+			s.cancelDispatch(provider, pr)
 			d.setLastInferenceError(provider, errMsg2)
 			d.lastFailedVersion = failedProviderVersion(provider)
 			d.updateSpeculativeFailure(pr, errMsg2)
@@ -1736,7 +1719,7 @@ func (d *dispatchState) raceBackupChunkClosedWaitPrimary(provider *registry.Prov
 			// backup's stale error text.
 			d.excludeProviders[provider.ID] = struct{}{}
 			s.registry.RecordWarmPoolTTFTMiss(d.model, d.deadline)
-			s.cancelDispatchAndForget(provider, pr)
+			s.cancelDispatch(provider, pr)
 			d.updateSpeculativeTimeout(pr, "first_chunk_timeout")
 			d.setLastError("timeout waiting for first response", http.StatusGatewayTimeout)
 			if s.metrics != nil {
@@ -1750,7 +1733,7 @@ func (d *dispatchState) raceBackupChunkClosedWaitPrimary(provider *registry.Prov
 		case <-r.Context().Done():
 			remainingPrimary.Stop()
 			d.updateSpeculativeClientGone(pr)
-			s.cancelDispatchAndForget(provider, pr)
+			s.cancelDispatch(provider, pr)
 			d.refundReservation()
 			return outcomeClientGone
 		}
@@ -1786,7 +1769,7 @@ func (d *dispatchState) racePrimaryFailedWaitBackup(backupProvider *registry.Pro
 				select {
 				case errMsg2 := <-backupPR.ErrorCh:
 					d.excludeProviders[backupProvider.ID] = struct{}{}
-					s.cancelDispatchAndForget(backupProvider, backupPR)
+					s.cancelDispatch(backupProvider, backupPR)
 					d.setLastInferenceError(backupProvider, errMsg2)
 					d.lastFailedVersion = failedProviderVersion(backupProvider)
 					d.updateSpeculativeFailure(backupPR, errMsg2)
@@ -1816,7 +1799,7 @@ func (d *dispatchState) racePrimaryFailedWaitBackup(backupProvider *registry.Pro
 		case errMsg2 := <-backupPR.ErrorCh:
 			backupDeadline.Stop()
 			d.excludeProviders[backupProvider.ID] = struct{}{}
-			s.cancelDispatchAndForget(backupProvider, backupPR)
+			s.cancelDispatch(backupProvider, backupPR)
 			d.setLastInferenceError(backupProvider, errMsg2)
 			d.lastFailedVersion = failedProviderVersion(backupProvider)
 			d.updateSpeculativeFailure(backupPR, errMsg2)
@@ -1839,7 +1822,7 @@ func (d *dispatchState) racePrimaryFailedWaitBackup(backupProvider *registry.Pro
 			}
 			d.excludeProviders[backupProvider.ID] = struct{}{}
 			s.registry.RecordWarmPoolTTFTMiss(d.model, d.deadline)
-			s.cancelDispatchAndForget(backupProvider, backupPR)
+			s.cancelDispatch(backupProvider, backupPR)
 			d.updateSpeculativeTimeout(backupPR, "first_chunk_timeout")
 			d.setLastError("timeout waiting for first response (backup)", http.StatusGatewayTimeout)
 			if s.metrics != nil {
@@ -1852,7 +1835,7 @@ func (d *dispatchState) racePrimaryFailedWaitBackup(backupProvider *registry.Pro
 		case <-r.Context().Done():
 			backupDeadline.Stop()
 			d.updateSpeculativeClientGone(backupPR)
-			s.cancelDispatchAndForget(backupProvider, backupPR)
+			s.cancelDispatch(backupProvider, backupPR)
 			d.refundReservation()
 			return outcomeClientGone
 		}
@@ -1882,7 +1865,7 @@ func (d *dispatchState) raceBackupErrWaitPrimary(provider *registry.Provider, pr
 				select {
 				case errMsg2 := <-pr.ErrorCh:
 					d.excludeProviders[provider.ID] = struct{}{}
-					s.cancelDispatchAndForget(provider, pr)
+					s.cancelDispatch(provider, pr)
 					d.setLastInferenceError(provider, errMsg2)
 					d.lastFailedVersion = failedProviderVersion(provider)
 					d.noteDispatchRetry(provider, pr, errMsg2.StatusCode, errMsg2.Error, &d.heldChunks)
@@ -1901,7 +1884,7 @@ func (d *dispatchState) raceBackupErrWaitPrimary(provider *registry.Provider, pr
 		case errMsg2 := <-pr.ErrorCh:
 			primaryDeadline.Stop()
 			d.excludeProviders[provider.ID] = struct{}{}
-			s.cancelDispatchAndForget(provider, pr)
+			s.cancelDispatch(provider, pr)
 			d.setLastInferenceError(provider, errMsg2)
 			d.lastFailedVersion = failedProviderVersion(provider)
 			d.updateSpeculativeFailure(pr, errMsg2)
@@ -1920,7 +1903,7 @@ func (d *dispatchState) raceBackupErrWaitPrimary(provider *registry.Provider, pr
 			}
 			d.excludeProviders[provider.ID] = struct{}{}
 			s.registry.RecordWarmPoolTTFTMiss(d.model, d.deadline)
-			s.cancelDispatchAndForget(provider, pr)
+			s.cancelDispatch(provider, pr)
 			d.updateSpeculativeTimeout(pr, "first_chunk_timeout")
 			d.setLastError("timeout waiting for first response", http.StatusGatewayTimeout)
 			if s.metrics != nil {
@@ -1934,7 +1917,7 @@ func (d *dispatchState) raceBackupErrWaitPrimary(provider *registry.Provider, pr
 		case <-r.Context().Done():
 			primaryDeadline.Stop()
 			d.updateSpeculativeClientGone(pr)
-			s.cancelDispatchAndForget(provider, pr)
+			s.cancelDispatch(provider, pr)
 			d.refundReservation()
 			return outcomeClientGone
 		}
@@ -2000,7 +1983,7 @@ func (d *dispatchState) waitAccepted() (outcome dispatchOutcome) {
 				select {
 				case errMsg := <-pr.ErrorCh:
 					d.excludeProviders[provider.ID] = struct{}{}
-					s.cancelDispatchAndForget(provider, pr)
+					s.cancelDispatch(provider, pr)
 					d.setLastInferenceError(provider, errMsg)
 					d.lastFailedVersion = failedProviderVersion(provider)
 					s.logger.Warn("provider failed after accepting request, retrying",
@@ -2032,7 +2015,7 @@ func (d *dispatchState) waitAccepted() (outcome dispatchOutcome) {
 		case errMsg := <-pr.ErrorCh:
 			chunkTimer.Stop()
 			d.excludeProviders[provider.ID] = struct{}{}
-			s.cancelDispatchAndForget(provider, pr)
+			s.cancelDispatch(provider, pr)
 			d.setLastInferenceError(provider, errMsg)
 			d.lastFailedVersion = failedProviderVersion(provider)
 			s.logger.Warn("provider failed after accepting request, retrying",
@@ -2059,7 +2042,7 @@ func (d *dispatchState) waitAccepted() (outcome dispatchOutcome) {
 		case <-chunkTimer.C:
 			d.excludeProviders[provider.ID] = struct{}{}
 			s.registry.RecordWarmPoolTTFTMiss(d.model, firstContentBudget)
-			s.cancelDispatchAndForget(provider, pr)
+			s.cancelDispatch(provider, pr)
 			// Accepted-then-silent (or preamble-then-stall) is a
 			// provider-at-fault 504 — feed the breaker so a provider
 			// that repeatedly acks and stalls enters cooldown instead
@@ -2091,7 +2074,7 @@ func (d *dispatchState) waitAccepted() (outcome dispatchOutcome) {
 			d.pr = nil
 			return outcomeRetry
 		case <-r.Context().Done():
-			s.cancelDispatchAndForget(provider, pr)
+			s.cancelDispatch(provider, pr)
 			d.refundReservation()
 			return outcomeClientGone
 		}

--- a/coordinator/api/dispatch.go
+++ b/coordinator/api/dispatch.go
@@ -965,6 +965,13 @@ func (d *dispatchState) dispatchPrimary() dispatchOutcome {
 				"ciphertext":           encrypted.Ciphertext,
 			},
 		}
+		// A retry reuses the queue PR object: overwriting SessionPrivKey below
+		// would permanently orphan the previous attempt's memoized chunk key
+		// (the cache is keyed by pointer identity). Forget the OLD key first.
+		// Plain forget, NO zeroing — this is the dispatch goroutine, and the
+		// abandoned attempt's provider read loop may still be decrypting a
+		// late chunk with it (see chunkKeyCache's zeroing policy).
+		s.chunkKeys.forget(d.pr.SessionPrivKey)
 		d.pr.SessionPrivKey = &sessionKeys.PrivateKey
 		// pr.ReservedMicroUSD was already set in the struct literal and may
 		// have been increased by reserveAdditionalForProvider. Don't overwrite.
@@ -981,6 +988,23 @@ func (d *dispatchState) dispatchPrimary() dispatchOutcome {
 		}
 	}
 	return outcomeProceed
+}
+
+// cancelDispatchAndForget abandons a dispatched attempt (cancelDispatch:
+// remove pending, idle the provider, WS-cancel, refund the attempt's top-up)
+// and drops the attempt's memoized chunk-decryption key. Every dispatch-loop
+// abandon site (speculative losers, failover retries, deadline/client-gone
+// exits) funnels through here so an abandoned attempt cannot pin its session
+// key in the cache until the cap-reset. Plain forget, NO zeroing: these sites
+// run on the consumer/dispatch goroutine, not the provider read loop — the
+// read loop may still be decrypting a late in-flight chunk with this key, and
+// zeroing under it would corrupt that decrypt (and MarkUntrusted an innocent
+// provider). See chunkKeyCache's zeroing policy.
+func (s *Server) cancelDispatchAndForget(provider *registry.Provider, pr *registry.PendingRequest) {
+	s.cancelDispatch(provider, pr)
+	if pr != nil {
+		s.chunkKeys.forget(pr.SessionPrivKey)
+	}
 }
 
 // noteDispatchRetry feeds the inference-error breaker + refund for a pre-commit
@@ -1151,7 +1175,7 @@ func (d *dispatchState) waitFirstChunk() (outcome dispatchOutcome) {
 				select {
 				case errMsg := <-pr.ErrorCh:
 					d.excludeProviders[provider.ID] = struct{}{}
-					s.cancelDispatch(provider, pr)
+					s.cancelDispatchAndForget(provider, pr)
 					d.setLastInferenceError(provider, errMsg)
 					d.lastFailedVersion = failedProviderVersion(provider)
 					d.noteDispatchRetry(provider, pr, errMsg.StatusCode, errMsg.Error, &d.heldChunks)
@@ -1176,7 +1200,7 @@ func (d *dispatchState) waitFirstChunk() (outcome dispatchOutcome) {
 			speculativeTimer.Stop()
 			deadlineTimer.Stop()
 			d.excludeProviders[provider.ID] = struct{}{}
-			s.cancelDispatch(provider, pr)
+			s.cancelDispatchAndForget(provider, pr)
 			d.setLastInferenceError(provider, errMsg)
 			d.lastFailedVersion = failedProviderVersion(provider)
 			s.logger.Warn("provider failed, retrying",
@@ -1217,7 +1241,7 @@ func (d *dispatchState) waitFirstChunk() (outcome dispatchOutcome) {
 			}
 			d.excludeProviders[provider.ID] = struct{}{}
 			s.registry.RecordWarmPoolTTFTMiss(d.model, d.deadline)
-			s.cancelDispatch(provider, pr)
+			s.cancelDispatchAndForget(provider, pr)
 			d.setLastError("timeout waiting for first response", http.StatusGatewayTimeout)
 			s.logger.Warn("provider timeout (full deadline), retrying",
 				"request_id", d.requestID,
@@ -1242,7 +1266,7 @@ func (d *dispatchState) waitFirstChunk() (outcome dispatchOutcome) {
 		case <-r.Context().Done():
 			speculativeTimer.Stop()
 			deadlineTimer.Stop()
-			s.cancelDispatch(provider, pr)
+			s.cancelDispatchAndForget(provider, pr)
 			d.refundReservation()
 			return outcomeClientGone
 		}
@@ -1366,7 +1390,7 @@ func (d *dispatchState) waitNoBackup() dispatchOutcome {
 				select {
 				case errMsg := <-pr.ErrorCh:
 					d.excludeProviders[provider.ID] = struct{}{}
-					s.cancelDispatch(provider, pr)
+					s.cancelDispatchAndForget(provider, pr)
 					d.setLastInferenceError(provider, errMsg)
 					d.lastFailedVersion = failedProviderVersion(provider)
 					d.noteDispatchRetry(provider, pr, errMsg.StatusCode, errMsg.Error, &d.heldChunks)
@@ -1385,7 +1409,7 @@ func (d *dispatchState) waitNoBackup() dispatchOutcome {
 		case errMsg := <-pr.ErrorCh:
 			remainingDeadline.Stop()
 			d.excludeProviders[provider.ID] = struct{}{}
-			s.cancelDispatch(provider, pr)
+			s.cancelDispatchAndForget(provider, pr)
 			d.setLastInferenceError(provider, errMsg)
 			d.lastFailedVersion = failedProviderVersion(provider)
 			if s.metrics != nil {
@@ -1408,7 +1432,7 @@ func (d *dispatchState) waitNoBackup() dispatchOutcome {
 			}
 			d.excludeProviders[provider.ID] = struct{}{}
 			s.registry.RecordWarmPoolTTFTMiss(d.model, d.deadline)
-			s.cancelDispatch(provider, pr)
+			s.cancelDispatchAndForget(provider, pr)
 			d.setLastError("timeout waiting for first response", http.StatusGatewayTimeout)
 			s.logger.Warn("provider timeout (no backup), retrying",
 				"request_id", d.requestID,
@@ -1431,7 +1455,7 @@ func (d *dispatchState) waitNoBackup() dispatchOutcome {
 			return outcomeRetry
 		case <-r.Context().Done():
 			remainingDeadline.Stop()
-			s.cancelDispatch(provider, pr)
+			s.cancelDispatchAndForget(provider, pr)
 			d.refundReservation()
 			return outcomeClientGone
 		}
@@ -1469,7 +1493,7 @@ func (d *dispatchState) runRace(backupProvider *registry.Provider, backupPR *reg
 			}
 			// Primary wins!
 			raceDeadline.Stop()
-			s.cancelDispatch(backupProvider, backupPR)
+			s.cancelDispatchAndForget(backupProvider, backupPR)
 			if ok {
 				d.markSpeculativeLoser(backupPR)
 				d.commitFirstContent(pr, chunk)
@@ -1480,7 +1504,7 @@ func (d *dispatchState) runRace(backupProvider *registry.Provider, backupPR *reg
 					// Primary failed but we already cancelled backup.
 					d.markSpeculativeLoser(backupPR)
 					d.excludeProviders[provider.ID] = struct{}{}
-					s.cancelDispatch(provider, pr)
+					s.cancelDispatchAndForget(provider, pr)
 					d.setLastInferenceError(provider, errMsg)
 					d.lastFailedVersion = failedProviderVersion(provider)
 					d.noteDispatchRetry(provider, pr, errMsg.StatusCode, errMsg.Error, &d.heldChunks)
@@ -1503,7 +1527,7 @@ func (d *dispatchState) runRace(backupProvider *registry.Provider, backupPR *reg
 			}
 			// Backup wins!
 			raceDeadline.Stop()
-			s.cancelDispatch(provider, pr)
+			s.cancelDispatchAndForget(provider, pr)
 			s.ddIncr("inference.speculative_win", []string{"model:" + d.model})
 			s.registry.RecordWarmPoolSpeculativeWon(d.model)
 			if ok {
@@ -1530,7 +1554,7 @@ func (d *dispatchState) runRace(backupProvider *registry.Provider, backupPR *reg
 					return d.raceBackupChunkClosedWaitPrimary(provider, pr)
 				default:
 					// Backup channel closed with no error — treat as committed.
-					s.cancelDispatch(provider, pr)
+					s.cancelDispatchAndForget(provider, pr)
 					d.markSpeculativeLoser(pr)
 					backupPR.BackupWon = true
 					d.provider = backupProvider
@@ -1545,7 +1569,7 @@ func (d *dispatchState) runRace(backupProvider *registry.Provider, backupPR *reg
 		case <-pr.AcceptedCh:
 			// Primary accepted (model reload). Cancel backup, extend deadline.
 			raceDeadline.Stop()
-			s.cancelDispatch(backupProvider, backupPR)
+			s.cancelDispatchAndForget(backupProvider, backupPR)
 			d.markSpeculativeLoser(backupPR)
 			d.accepted = true
 			return outcomeAccepted
@@ -1553,7 +1577,7 @@ func (d *dispatchState) runRace(backupProvider *registry.Provider, backupPR *reg
 		case <-backupPR.AcceptedCh:
 			// Backup accepted (model reload). Cancel primary, extend deadline.
 			raceDeadline.Stop()
-			s.cancelDispatch(provider, pr)
+			s.cancelDispatchAndForget(provider, pr)
 			d.markSpeculativeLoser(pr)
 			backupPR.BackupWon = true
 			d.provider = backupProvider
@@ -1567,7 +1591,7 @@ func (d *dispatchState) runRace(backupProvider *registry.Provider, backupPR *reg
 			// Primary failed. Keep waiting for backup.
 			raceDeadline.Stop()
 			d.excludeProviders[provider.ID] = struct{}{}
-			s.cancelDispatch(provider, pr)
+			s.cancelDispatchAndForget(provider, pr)
 			d.lastFailedVersion = failedProviderVersion(provider)
 			d.updateSpeculativeFailure(pr, errMsg)
 			s.noteDispatchProviderError(provider, pr, errMsg.StatusCode, errMsg.Error, &d.heldChunks)
@@ -1583,7 +1607,7 @@ func (d *dispatchState) runRace(backupProvider *registry.Provider, backupPR *reg
 			// Backup failed. Keep waiting for primary.
 			raceDeadline.Stop()
 			d.excludeProviders[backupProvider.ID] = struct{}{}
-			s.cancelDispatch(backupProvider, backupPR)
+			s.cancelDispatchAndForget(backupProvider, backupPR)
 			d.lastFailedVersion = failedProviderVersion(backupProvider)
 			d.updateSpeculativeFailure(backupPR, errMsg)
 			s.noteDispatchProviderError(backupProvider, backupPR, errMsg.StatusCode, errMsg.Error, &backupHeld)
@@ -1615,9 +1639,9 @@ func (d *dispatchState) runRace(backupProvider *registry.Provider, backupPR *reg
 			if len(backupHeld) > 0 {
 				s.noteInferenceError(backupProvider.ID, backupPR, http.StatusGatewayTimeout, "")
 			}
-			s.cancelDispatch(provider, pr)
+			s.cancelDispatchAndForget(provider, pr)
 			s.registry.RecordWarmPoolTTFTMiss(d.model, d.deadline)
-			s.cancelDispatch(backupProvider, backupPR)
+			s.cancelDispatchAndForget(backupProvider, backupPR)
 			d.updateSpeculativeTimeout(backupPR, "first_chunk_timeout")
 			d.excludeProviders[provider.ID] = struct{}{}
 			d.excludeProviders[backupProvider.ID] = struct{}{}
@@ -1633,8 +1657,8 @@ func (d *dispatchState) runRace(backupProvider *registry.Provider, backupPR *reg
 		case <-r.Context().Done():
 			raceDeadline.Stop()
 			d.updateSpeculativeClientGone(backupPR)
-			s.cancelDispatch(provider, pr)
-			s.cancelDispatch(backupProvider, backupPR)
+			s.cancelDispatchAndForget(provider, pr)
+			s.cancelDispatchAndForget(backupProvider, backupPR)
 			d.refundReservation()
 			return outcomeClientGone
 		}
@@ -1665,7 +1689,7 @@ func (d *dispatchState) raceBackupChunkClosedWaitPrimary(provider *registry.Prov
 				select {
 				case errMsg2 := <-pr.ErrorCh:
 					d.excludeProviders[provider.ID] = struct{}{}
-					s.cancelDispatch(provider, pr)
+					s.cancelDispatchAndForget(provider, pr)
 					d.setLastInferenceError(provider, errMsg2)
 					d.lastFailedVersion = failedProviderVersion(provider)
 					d.updateSpeculativeFailure(pr, errMsg2)
@@ -1690,7 +1714,7 @@ func (d *dispatchState) raceBackupChunkClosedWaitPrimary(provider *registry.Prov
 			// ordering ever changes — mirroring its sibling wait loops.
 			remainingPrimary.Stop()
 			d.excludeProviders[provider.ID] = struct{}{}
-			s.cancelDispatch(provider, pr)
+			s.cancelDispatchAndForget(provider, pr)
 			d.setLastInferenceError(provider, errMsg2)
 			d.lastFailedVersion = failedProviderVersion(provider)
 			d.updateSpeculativeFailure(pr, errMsg2)
@@ -1712,7 +1736,7 @@ func (d *dispatchState) raceBackupChunkClosedWaitPrimary(provider *registry.Prov
 			// backup's stale error text.
 			d.excludeProviders[provider.ID] = struct{}{}
 			s.registry.RecordWarmPoolTTFTMiss(d.model, d.deadline)
-			s.cancelDispatch(provider, pr)
+			s.cancelDispatchAndForget(provider, pr)
 			d.updateSpeculativeTimeout(pr, "first_chunk_timeout")
 			d.setLastError("timeout waiting for first response", http.StatusGatewayTimeout)
 			if s.metrics != nil {
@@ -1726,7 +1750,7 @@ func (d *dispatchState) raceBackupChunkClosedWaitPrimary(provider *registry.Prov
 		case <-r.Context().Done():
 			remainingPrimary.Stop()
 			d.updateSpeculativeClientGone(pr)
-			s.cancelDispatch(provider, pr)
+			s.cancelDispatchAndForget(provider, pr)
 			d.refundReservation()
 			return outcomeClientGone
 		}
@@ -1762,7 +1786,7 @@ func (d *dispatchState) racePrimaryFailedWaitBackup(backupProvider *registry.Pro
 				select {
 				case errMsg2 := <-backupPR.ErrorCh:
 					d.excludeProviders[backupProvider.ID] = struct{}{}
-					s.cancelDispatch(backupProvider, backupPR)
+					s.cancelDispatchAndForget(backupProvider, backupPR)
 					d.setLastInferenceError(backupProvider, errMsg2)
 					d.lastFailedVersion = failedProviderVersion(backupProvider)
 					d.updateSpeculativeFailure(backupPR, errMsg2)
@@ -1792,7 +1816,7 @@ func (d *dispatchState) racePrimaryFailedWaitBackup(backupProvider *registry.Pro
 		case errMsg2 := <-backupPR.ErrorCh:
 			backupDeadline.Stop()
 			d.excludeProviders[backupProvider.ID] = struct{}{}
-			s.cancelDispatch(backupProvider, backupPR)
+			s.cancelDispatchAndForget(backupProvider, backupPR)
 			d.setLastInferenceError(backupProvider, errMsg2)
 			d.lastFailedVersion = failedProviderVersion(backupProvider)
 			d.updateSpeculativeFailure(backupPR, errMsg2)
@@ -1815,7 +1839,7 @@ func (d *dispatchState) racePrimaryFailedWaitBackup(backupProvider *registry.Pro
 			}
 			d.excludeProviders[backupProvider.ID] = struct{}{}
 			s.registry.RecordWarmPoolTTFTMiss(d.model, d.deadline)
-			s.cancelDispatch(backupProvider, backupPR)
+			s.cancelDispatchAndForget(backupProvider, backupPR)
 			d.updateSpeculativeTimeout(backupPR, "first_chunk_timeout")
 			d.setLastError("timeout waiting for first response (backup)", http.StatusGatewayTimeout)
 			if s.metrics != nil {
@@ -1828,7 +1852,7 @@ func (d *dispatchState) racePrimaryFailedWaitBackup(backupProvider *registry.Pro
 		case <-r.Context().Done():
 			backupDeadline.Stop()
 			d.updateSpeculativeClientGone(backupPR)
-			s.cancelDispatch(backupProvider, backupPR)
+			s.cancelDispatchAndForget(backupProvider, backupPR)
 			d.refundReservation()
 			return outcomeClientGone
 		}
@@ -1858,7 +1882,7 @@ func (d *dispatchState) raceBackupErrWaitPrimary(provider *registry.Provider, pr
 				select {
 				case errMsg2 := <-pr.ErrorCh:
 					d.excludeProviders[provider.ID] = struct{}{}
-					s.cancelDispatch(provider, pr)
+					s.cancelDispatchAndForget(provider, pr)
 					d.setLastInferenceError(provider, errMsg2)
 					d.lastFailedVersion = failedProviderVersion(provider)
 					d.noteDispatchRetry(provider, pr, errMsg2.StatusCode, errMsg2.Error, &d.heldChunks)
@@ -1877,7 +1901,7 @@ func (d *dispatchState) raceBackupErrWaitPrimary(provider *registry.Provider, pr
 		case errMsg2 := <-pr.ErrorCh:
 			primaryDeadline.Stop()
 			d.excludeProviders[provider.ID] = struct{}{}
-			s.cancelDispatch(provider, pr)
+			s.cancelDispatchAndForget(provider, pr)
 			d.setLastInferenceError(provider, errMsg2)
 			d.lastFailedVersion = failedProviderVersion(provider)
 			d.updateSpeculativeFailure(pr, errMsg2)
@@ -1896,7 +1920,7 @@ func (d *dispatchState) raceBackupErrWaitPrimary(provider *registry.Provider, pr
 			}
 			d.excludeProviders[provider.ID] = struct{}{}
 			s.registry.RecordWarmPoolTTFTMiss(d.model, d.deadline)
-			s.cancelDispatch(provider, pr)
+			s.cancelDispatchAndForget(provider, pr)
 			d.updateSpeculativeTimeout(pr, "first_chunk_timeout")
 			d.setLastError("timeout waiting for first response", http.StatusGatewayTimeout)
 			if s.metrics != nil {
@@ -1910,7 +1934,7 @@ func (d *dispatchState) raceBackupErrWaitPrimary(provider *registry.Provider, pr
 		case <-r.Context().Done():
 			primaryDeadline.Stop()
 			d.updateSpeculativeClientGone(pr)
-			s.cancelDispatch(provider, pr)
+			s.cancelDispatchAndForget(provider, pr)
 			d.refundReservation()
 			return outcomeClientGone
 		}
@@ -1976,7 +2000,7 @@ func (d *dispatchState) waitAccepted() (outcome dispatchOutcome) {
 				select {
 				case errMsg := <-pr.ErrorCh:
 					d.excludeProviders[provider.ID] = struct{}{}
-					s.cancelDispatch(provider, pr)
+					s.cancelDispatchAndForget(provider, pr)
 					d.setLastInferenceError(provider, errMsg)
 					d.lastFailedVersion = failedProviderVersion(provider)
 					s.logger.Warn("provider failed after accepting request, retrying",
@@ -2008,7 +2032,7 @@ func (d *dispatchState) waitAccepted() (outcome dispatchOutcome) {
 		case errMsg := <-pr.ErrorCh:
 			chunkTimer.Stop()
 			d.excludeProviders[provider.ID] = struct{}{}
-			s.cancelDispatch(provider, pr)
+			s.cancelDispatchAndForget(provider, pr)
 			d.setLastInferenceError(provider, errMsg)
 			d.lastFailedVersion = failedProviderVersion(provider)
 			s.logger.Warn("provider failed after accepting request, retrying",
@@ -2035,7 +2059,7 @@ func (d *dispatchState) waitAccepted() (outcome dispatchOutcome) {
 		case <-chunkTimer.C:
 			d.excludeProviders[provider.ID] = struct{}{}
 			s.registry.RecordWarmPoolTTFTMiss(d.model, firstContentBudget)
-			s.cancelDispatch(provider, pr)
+			s.cancelDispatchAndForget(provider, pr)
 			// Accepted-then-silent (or preamble-then-stall) is a
 			// provider-at-fault 504 — feed the breaker so a provider
 			// that repeatedly acks and stalls enters cooldown instead
@@ -2067,7 +2091,7 @@ func (d *dispatchState) waitAccepted() (outcome dispatchOutcome) {
 			d.pr = nil
 			return outcomeRetry
 		case <-r.Context().Done():
-			s.cancelDispatch(provider, pr)
+			s.cancelDispatchAndForget(provider, pr)
 			d.refundReservation()
 			return outcomeClientGone
 		}

--- a/coordinator/api/provider.go
+++ b/coordinator/api/provider.go
@@ -173,6 +173,23 @@ func (s *Server) closeSessionWithReason(providerID, reason string) {
 	}
 }
 
+// forgetProviderPendingKeys drops (and zeroes) the memoized chunk-decryption
+// key of every request still pending on the given provider. Called from
+// providerReadLoop's cleanup defer, BEFORE registry.Disconnect clears the
+// pending map — Disconnect orphans the keys otherwise. It must only run on the
+// provider's read-loop goroutine after the read loop has exited: that is the
+// only goroutine that decrypts with these keys, so zeroing cannot race an
+// in-flight decrypt (see chunkKeyCache's zeroing policy). nil provider (never
+// registered) is a no-op.
+func (s *Server) forgetProviderPendingKeys(provider *registry.Provider) {
+	if provider == nil {
+		return
+	}
+	for _, key := range provider.PendingSessionKeys() {
+		s.chunkKeys.forgetAndZero(key)
+	}
+}
+
 // providerReadLoop reads messages from the provider WebSocket and dispatches
 // them. It runs until the connection closes or the context is cancelled.
 func (s *Server) providerReadLoop(ctx context.Context, conn *websocket.Conn, providerID string, r *http.Request) {
@@ -183,6 +200,13 @@ func (s *Server) providerReadLoop(ctx context.Context, conn *websocket.Conn, pro
 	loopCtx, loopCancel := context.WithCancel(ctx)
 	defer func() {
 		loopCancel()
+		// Drop the memoized chunk-decryption keys of every request still
+		// in-flight on this provider BEFORE Disconnect wipes the pending map
+		// (after the wipe the keys are unreachable and would pin their cache
+		// entries until the cap-reset). Zeroing is safe here: this defer runs
+		// on the provider's read-loop goroutine — the only goroutine that ever
+		// decrypts with these keys — after conn.Read has returned for good.
+		s.forgetProviderPendingKeys(provider)
 		s.registry.Disconnect(providerID)
 		conn.Close(websocket.StatusNormalClosure, "goodbye")
 	}()
@@ -1448,13 +1472,14 @@ func (s *Server) handleChunk(providerID string, provider *registry.Provider, msg
 		)
 		s.ddIncr("inference.chunk_overflow_abort", []string{})
 		s.sendProviderCancel(provider, msg.RequestID)
-		// 499 + "request cancelled" classifies as a consumer-side terminal in
-		// handleInferenceError: no provider reputation hit for our backpressure.
+		// 499 + "request cancelled" classifies as a consumer-side terminal
+		// (isConsumerCancelTerminal) in handleInferenceError and the route
+		// outcome: no provider reputation hit for our backpressure.
 		s.handleInferenceError(providerID, provider, &protocol.InferenceErrorMessage{
 			Type:       protocol.TypeInferenceError,
 			RequestID:  msg.RequestID,
 			Error:      "request cancelled: consumer stream stalled (chunk buffer overflow)",
-			StatusCode: 499,
+			StatusCode: statusClientClosedRequest,
 		})
 	}
 }
@@ -1576,8 +1601,11 @@ func (s *Server) handleComplete(providerID string, provider *registry.Provider, 
 		s.logger.Warn("complete for unknown request", "provider_id", providerID, "request_id", msg.RequestID)
 		return
 	}
-	// The request is terminal — drop its memoized chunk-decryption key.
-	s.chunkKeys.forget(pr.SessionPrivKey)
+	// The request is terminal — drop its memoized chunk-decryption key and
+	// scrub it. Zeroing is safe: the WS delivers every chunk before the
+	// complete frame, so all decrypts for this request finished on the read
+	// loop before this handler was spawned (see chunkKeyCache zeroing policy).
+	s.chunkKeys.forgetAndZero(pr.SessionPrivKey)
 	// A parked record means the consumer handler already returned: there is no
 	// channel reader, and registry.Disconnect may have already CLOSED the
 	// channels (park-before-remove leaves a window where the record is in both
@@ -2072,8 +2100,11 @@ func (s *Server) handleInferenceError(providerID string, provider *registry.Prov
 		s.logger.Warn("error for unknown request", "provider_id", providerID, "request_id", msg.RequestID)
 		return
 	}
-	// The request is terminal — drop its memoized chunk-decryption key.
-	s.chunkKeys.forget(pr.SessionPrivKey)
+	// The request is terminal — drop its memoized chunk-decryption key and
+	// scrub it. Zeroing is safe: this handler runs on the provider read-loop
+	// goroutine, the only goroutine that decrypts with this key (see
+	// chunkKeyCache zeroing policy).
+	s.chunkKeys.forgetAndZero(pr.SessionPrivKey)
 	consumerGone := parked != nil
 
 	// Record a job failure, but not for capacity rejections or consumer
@@ -2088,8 +2119,7 @@ func (s *Server) handleInferenceError(providerID string, provider *registry.Prov
 		msg.StatusCode == http.StatusTooManyRequests ||
 		strings.Contains(loweredErr, "token_budget_exhausted") ||
 		strings.Contains(loweredErr, "insufficient memory")
-	cancelTerminal := msg.StatusCode == 499 ||
-		strings.Contains(loweredErr, "request cancelled")
+	cancelTerminal := isConsumerCancelTerminal(msg.StatusCode, msg.Error)
 	if !capacityRejection && !cancelTerminal {
 		s.registry.RecordJobFailure(providerID)
 	}

--- a/coordinator/api/provider.go
+++ b/coordinator/api/provider.go
@@ -188,6 +188,17 @@ func (s *Server) forgetProviderPendingKeys(provider *registry.Provider) {
 	for _, key := range provider.PendingSessionKeys() {
 		s.chunkKeys.forgetAndZero(key)
 	}
+	// Catch-all for REGISTRY-INITIATED disconnects (stale eviction,
+	// duplicate-serial eviction, forced removal): those call
+	// Registry.Disconnect directly, which wipes the pending map BEFORE its
+	// CloseNow unblocks this read loop — the snapshot above is then empty and
+	// the wiped requests' cache entries are unreachable per-request. Sweep
+	// everything cached under this provider's public key instead (the cache
+	// stores it per entry; no pending-map state needed). Plain delete, NO
+	// zeroing and NO tombstoning: a same-keypair replacement session
+	// (duplicate-serial eviction) may be decrypting with a matching entry
+	// right now on its own read loop — it just recomputes on its next chunk.
+	s.chunkKeys.forgetPeer(provider.PublicKey)
 }
 
 // providerReadLoop reads messages from the provider WebSocket and dispatches

--- a/coordinator/api/reservations.go
+++ b/coordinator/api/reservations.go
@@ -108,6 +108,10 @@ func (s *Server) releaseInitialReservation(accountID, model string, amount int64
 			"error", err,
 		)
 		s.ddIncr("billing.refund_failures", tags)
+		// Return WITHOUT the refund/release success counters: a failure
+		// counted as a success would make refund dashboards undercount
+		// exactly the incidents this alert exists to surface.
+		return
 	}
 	s.ddIncr("billing.reservation_refunds", tags)
 	s.ddIncr("billing.reservation_releases", append(tags, "reason:early"))

--- a/coordinator/api/reservations.go
+++ b/coordinator/api/reservations.go
@@ -97,7 +97,18 @@ func (s *Server) releaseInitialReservation(accountID, model string, amount int64
 		return
 	}
 	start := time.Now()
-	_ = s.store.Credit(accountID, amount, store.LedgerRefund, "reservation_refund")
+	// Financial: a failed refund over-charges the consumer. Never swallow it.
+	// No inline retry — this path can run on latency-sensitive request paths;
+	// the ERROR log + billing.refund_failures metric is the alerting hook.
+	if err := s.store.Credit(accountID, amount, store.LedgerRefund, "reservation_refund"); err != nil {
+		s.logger.Error("failed to credit reservation refund to consumer",
+			"account_id", accountID,
+			"model", model,
+			"refund_micro_usd", amount,
+			"error", err,
+		)
+		s.ddIncr("billing.refund_failures", tags)
+	}
 	s.ddIncr("billing.reservation_refunds", tags)
 	s.ddIncr("billing.reservation_releases", append(tags, "reason:early"))
 	s.ddHistogram("store.credit.latency_ms", float64(time.Since(start).Milliseconds()), []string{"op:reservation_refund"})

--- a/coordinator/api/reservations_test.go
+++ b/coordinator/api/reservations_test.go
@@ -134,6 +134,95 @@ func TestNormalConsumerStillUsesSynchronousDebit(t *testing.T) {
 	}
 }
 
+// countingCreditFailStore fails every Credit write (simulating DB pressure on
+// the refund path) while counting the attempts. The always-failing sibling
+// without a counter is billing_integration_test.go's failingCreditStore.
+type countingCreditFailStore struct {
+	store.Store
+
+	mu        sync.Mutex
+	credits   int
+	creditErr error
+}
+
+func (s *countingCreditFailStore) Credit(accountID string, amountMicroUSD int64, entryType store.LedgerEntryType, reference string) error {
+	s.mu.Lock()
+	s.credits++
+	err := s.creditErr
+	s.mu.Unlock()
+	if err != nil {
+		return err
+	}
+	return s.Store.Credit(accountID, amountMicroUSD, entryType, reference)
+}
+
+func (s *countingCreditFailStore) CreditCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.credits
+}
+
+// A reservation refund whose store Credit fails must not be swallowed: the
+// failure is surfaced on billing.refund_failures (the alerting hook) and the
+// release path must not panic. No inline retry — the metric/log is the fix.
+func TestReleaseInitialReservationCreditFailureEmitsMetric(t *testing.T) {
+	collector := newUDPCollector(t)
+	defer collector.Close()
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	mem := store.NewMemory(store.Config{AdminKey: "test-key"})
+	st := &countingCreditFailStore{Store: mem, creditErr: errors.New("db write failed")}
+	srv := NewServer(registry.New(logger), st, ServerConfig{}, logger)
+	ddClient := newTestDD(t, collector)
+	defer ddClient.Close()
+	srv.SetDatadog(ddClient)
+
+	srv.releaseInitialReservation("acct-refund-fail", "test-model", 250_000, false)
+
+	if got := st.CreditCount(); got != 1 {
+		t.Fatalf("Credit calls = %d, want 1 (refund attempted exactly once, no inline retry)", got)
+	}
+	_ = ddClient.Statsd.Flush()
+	packets := collector.drain()
+	failures := findMetrics(packets, "billing.refund_failures")
+	if len(failures) == 0 {
+		t.Fatalf("missing billing.refund_failures metric; packets=%v", packets)
+	}
+	if !hasMetric(failures, "model:test-model") {
+		t.Fatalf("refund_failures missing model tag; metrics=%v", failures)
+	}
+	if !hasMetric(failures, "mode:ledger") {
+		t.Fatalf("refund_failures missing mode tag; metrics=%v", failures)
+	}
+}
+
+// A successful refund must NOT emit the failure metric.
+func TestReleaseInitialReservationCreditSuccessNoFailureMetric(t *testing.T) {
+	collector := newUDPCollector(t)
+	defer collector.Close()
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	st := store.NewMemory(store.Config{AdminKey: "test-key"})
+	srv := NewServer(registry.New(logger), st, ServerConfig{}, logger)
+	ddClient := newTestDD(t, collector)
+	defer ddClient.Close()
+	srv.SetDatadog(ddClient)
+
+	srv.releaseInitialReservation("acct-refund-ok", "test-model", 250_000, false)
+
+	if got := st.GetBalance("acct-refund-ok"); got != 250_000 {
+		t.Fatalf("balance = %d, want 250000 (refund credited)", got)
+	}
+	_ = ddClient.Statsd.Flush()
+	packets := collector.drain()
+	if hasMetric(packets, "billing.refund_failures") {
+		t.Fatalf("billing.refund_failures emitted on a successful refund; packets=%v", packets)
+	}
+	if !hasMetric(packets, "billing.reservation_refunds") {
+		t.Fatalf("missing billing.reservation_refunds metric; packets=%v", packets)
+	}
+}
+
 func TestServiceReservationRefundReleasesHoldWithoutCredit(t *testing.T) {
 	srv, st := newReservationTestServer(t, ServerConfig{ServiceReservations: true}, nil)
 	createServiceUser(t, st, "svc-refund")

--- a/coordinator/api/route_outcome.go
+++ b/coordinator/api/route_outcome.go
@@ -176,6 +176,14 @@ func providerDisconnectedError(errorText string, statusCode int) bool {
 }
 
 func postCommitProviderErrorOutcome(pr *registry.PendingRequest, msg protocol.InferenceErrorMessage) *store.InferenceRouteOutcome {
+	if isConsumerCancelTerminal(msg.StatusCode, msg.Error) {
+		// Consumer-side cancel terminal (client cancel or the coordinator's
+		// overflow-499 abort of a stalled consumer stream). Mirrors
+		// handleInferenceError's cancelTerminal branch: partial_success with a
+		// cancel error-class and NO AdmittedButFailed — it is not a provider
+		// fault and must never pollute provider_error calibration signals.
+		return pendingRouteOutcomeWithReason(pr, finalStatusPartialSuccess, errorClassConsumerCancelAfterCommit, msg.StatusCode, msg.ErrorReason, msg.Error)
+	}
 	class := "provider_error_after_commit"
 	if providerDisconnectedError(msg.Error, msg.StatusCode) {
 		class = "provider_disconnect_after_commit"
@@ -285,7 +293,7 @@ func inferenceErrorReason(providerReason, status, class string, code int, messag
 		return errorReasonQueueFull
 	case lowerClass == "queue_timeout" || lowerClass == errorReasonCapacityTimeout || strings.Contains(lowerMessage, "queue timeout") || strings.Contains(lowerMessage, "timed out waiting for a free slot"):
 		return errorReasonCapacityTimeout
-	case lowerStatus == errorReasonCancelled || code == 499 || strings.Contains(lowerClass, "client_gone") || strings.Contains(lowerClass, "cancel") || strings.Contains(lowerMessage, "request cancelled"):
+	case lowerStatus == errorReasonCancelled || code == statusClientClosedRequest || strings.Contains(lowerClass, "client_gone") || strings.Contains(lowerClass, "cancel") || strings.Contains(lowerMessage, "request cancelled"):
 		return errorReasonCancelled
 	case lowerClass == errorReasonClientError || strings.HasPrefix(lowerClass, errorReasonClientError):
 		return errorReasonClientError

--- a/coordinator/api/route_outcome_test.go
+++ b/coordinator/api/route_outcome_test.go
@@ -53,6 +53,61 @@ func TestPostCommitProviderDisconnectOutcome(t *testing.T) {
 	}
 }
 
+// A consumer-cancel terminal after commit (the coordinator's overflow-499
+// abort, or a client cancel the provider acknowledged) is NOT a provider
+// fault: partial_success with the cancel class, AdmittedButFailed false, and
+// the "cancelled" reason — it must never pollute provider_error calibration.
+func TestPostCommitConsumerCancelOutcome(t *testing.T) {
+	pr := &registry.PendingRequest{RequestID: "req-overflow-cancel"}
+	out := postCommitProviderErrorOutcome(pr, protocol.InferenceErrorMessage{
+		Error:      "request cancelled: consumer stream stalled (chunk buffer overflow)",
+		StatusCode: statusClientClosedRequest,
+	})
+	if out.FinalStatus != finalStatusPartialSuccess {
+		t.Fatalf("FinalStatus = %q, want partial_success", out.FinalStatus)
+	}
+	if out.ErrorClass != errorClassConsumerCancelAfterCommit {
+		t.Fatalf("ErrorClass = %q, want %q", out.ErrorClass, errorClassConsumerCancelAfterCommit)
+	}
+	if out.AdmittedButFailed {
+		t.Fatal("consumer cancel must not be recorded as admitted_but_failed (provider fault)")
+	}
+	if out.ErrorReason != errorReasonCancelled {
+		t.Fatalf("ErrorReason = %q, want %q", out.ErrorReason, errorReasonCancelled)
+	}
+	if out.ErrorCode != statusClientClosedRequest {
+		t.Fatalf("ErrorCode = %d, want %d", out.ErrorCode, statusClientClosedRequest)
+	}
+
+	// A bare 499 with no message classifies the same way.
+	bare := postCommitProviderErrorOutcome(pr, protocol.InferenceErrorMessage{StatusCode: statusClientClosedRequest})
+	if bare.ErrorClass != errorClassConsumerCancelAfterCommit || bare.AdmittedButFailed {
+		t.Fatalf("bare 499 outcome = %+v, want consumer-cancel classification", bare)
+	}
+}
+
+// A genuine post-commit provider error (non-disconnect 502) keeps the provider
+// fault classification — the cancel carve-out must not over-match.
+func TestPostCommitProviderErrorStillProviderFault(t *testing.T) {
+	pr := &registry.PendingRequest{RequestID: "req-real-502"}
+	out := postCommitProviderErrorOutcome(pr, protocol.InferenceErrorMessage{
+		Error:      "upstream engine returned garbage",
+		StatusCode: 502,
+	})
+	if out.FinalStatus != finalStatusPartialSuccess {
+		t.Fatalf("FinalStatus = %q, want partial_success", out.FinalStatus)
+	}
+	if out.ErrorClass != "provider_error_after_commit" {
+		t.Fatalf("ErrorClass = %q, want provider_error_after_commit", out.ErrorClass)
+	}
+	if !out.AdmittedButFailed {
+		t.Fatal("a real provider error after commit must stay admitted_but_failed")
+	}
+	if out.ErrorReason != errorReasonProviderError {
+		t.Fatalf("ErrorReason = %q, want %q", out.ErrorReason, errorReasonProviderError)
+	}
+}
+
 func TestPreCommitProviderDisconnectOutcome(t *testing.T) {
 	pr := &registry.PendingRequest{RequestID: "req-disconnect-pre"}
 	out := preCommitProviderErrorOutcome(pr, protocol.InferenceErrorMessage{

--- a/coordinator/api/settlement.go
+++ b/coordinator/api/settlement.go
@@ -81,6 +81,17 @@ func (s *Server) holdForSettlement(pr *registry.PendingRequest) {
 	// cancellation. A genuine after-commit client disconnect returns WITHOUT
 	// refunding, so it is not yet finalized and is still parked + counted.
 	if pr.IsReservationFinalized() {
+		// Finalized-and-never-parked is still a request TERMINAL: the
+		// consumer handler has returned and this record will never be held,
+		// so no late provider terminal can claim it to drop its memoized
+		// chunk key — without this it pins the session key until the cap
+		// reset. Usually a no-op (handleComplete/handleInferenceError already
+		// forgetAndZero'd before finalizing), but the relay's stream-timeout/
+		// provider-incomplete refund paths finalize WITHOUT a read-loop
+		// terminal ever running. Plain forget, NO zeroing: consumer
+		// goroutine — a late chunk decrypt may be in flight on the provider
+		// read loop (see chunkKeyCache's zeroing policy).
+		s.chunkKeys.forget(pr.SessionPrivKey)
 		return
 	}
 	// Single chokepoint for post-commit consumer disconnects: the request

--- a/coordinator/api/settlement.go
+++ b/coordinator/api/settlement.go
@@ -92,7 +92,10 @@ func (s *Server) holdForSettlement(pr *registry.PendingRequest) {
 	// dimensions — so it is not duplicated here.
 	if s.settlements == nil {
 		// Defensive: a Server built without newSettlementHolder still refunds
-		// rather than leaking the reservation.
+		// rather than leaking the reservation. The request is terminal here —
+		// drop its memoized chunk key too (plain forget, no zeroing: this runs
+		// on the consumer goroutine, not the provider read loop).
+		s.chunkKeys.forget(pr.SessionPrivKey)
 		if s.refundReservedBalance(pr, "no_terminal_after_cancel:"+pr.RequestID) {
 			s.updateInferenceRouteOutcomeForPending(pr, noTerminalAfterCancelOutcome(pr))
 			s.recordNoTerminalAfterCancel(pr.Model)
@@ -101,6 +104,14 @@ func (s *Server) holdForSettlement(pr *registry.PendingRequest) {
 		return
 	}
 	s.settlements.hold(pr, s.terminalSettleGrace(), func(expired *registry.PendingRequest) {
+		// Grace expired with no provider terminal: the request is abandoned
+		// for good, so drop its memoized chunk-decryption key. This runs on
+		// the AfterFunc timer goroutine — plain forget, NO zeroing, which
+		// would race a late chunk decrypt on the provider read loop (see
+		// chunkKeyCache's zeroing policy). Unconditional: even when the
+		// refund below no-ops (already-finalized dup park), no terminal
+		// handler ever claimed this record to forget the key.
+		s.chunkKeys.forget(expired.SessionPrivKey)
 		// Log only if this actually refunded — a request already settled by
 		// handleComplete leaves a dup here whose refund no-ops (FinalizeReservation).
 		if s.refundReservedBalance(expired, "no_terminal_after_cancel:"+expired.RequestID) {

--- a/coordinator/api/settlement_test.go
+++ b/coordinator/api/settlement_test.go
@@ -126,3 +126,67 @@ func TestHoldForSettlementNilHolderRefunds(t *testing.T) {
 		t.Fatalf("balance = %d, want %d (nil holder must refund immediately)", got, base+reserved)
 	}
 }
+
+// Settlement-grace expiry is a request terminal: the abandoned request's
+// memoized chunk key must be forgotten — but NOT zeroed, because the AfterFunc
+// timer goroutine can race a late chunk decrypt on the provider read loop.
+func TestHoldForSettlementExpiryForgetsChunkKey(t *testing.T) {
+	srv, _, _ := billingTestServer(t)
+	srv.settleGrace = 30 * time.Millisecond
+
+	priv := &[32]byte{11}
+	pr := &registry.PendingRequest{
+		RequestID:            "settle-forget-key",
+		Model:                "m",
+		ConsumerKey:          testConsumerID,
+		BaseReservedMicroUSD: 100_000,
+		ReservedMicroUSD:     100_000,
+		SessionPrivKey:       priv,
+	}
+	shared := seedChunkKey(t, srv, priv)
+	want := *shared
+
+	srv.holdForSettlement(pr)
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if !chunkKeyCached(&srv.chunkKeys, priv) {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if chunkKeyCached(&srv.chunkKeys, priv) {
+		t.Fatal("grace expiry never forgot the chunk key")
+	}
+	if *shared != want {
+		t.Error("grace-expiry forget is cross-goroutine: it must NOT zero the shared key")
+	}
+}
+
+// The defensive nil-holder branch is also a terminal: it must forget the key
+// immediately (plain forget — consumer goroutine).
+func TestHoldForSettlementNilHolderForgetsChunkKey(t *testing.T) {
+	srv, _, _ := billingTestServer(t)
+	srv.settlements = nil
+
+	priv := &[32]byte{12}
+	pr := &registry.PendingRequest{
+		RequestID:            "nil-holder-key",
+		Model:                "m",
+		ConsumerKey:          testConsumerID,
+		BaseReservedMicroUSD: 100_000,
+		ReservedMicroUSD:     100_000,
+		SessionPrivKey:       priv,
+	}
+	shared := seedChunkKey(t, srv, priv)
+	want := *shared
+
+	srv.holdForSettlement(pr)
+
+	if chunkKeyCached(&srv.chunkKeys, priv) {
+		t.Fatal("nil-holder terminal should forget the chunk key")
+	}
+	if *shared != want {
+		t.Error("nil-holder forget must NOT zero the shared key")
+	}
+}

--- a/coordinator/api/settlement_test.go
+++ b/coordinator/api/settlement_test.go
@@ -163,6 +163,46 @@ func TestHoldForSettlementExpiryForgetsChunkKey(t *testing.T) {
 	}
 }
 
+// The already-finalized early return (relay stream-timeout / provider-
+// incomplete refunds finalize without a read-loop terminal, then the cleanup
+// defer still reaches holdForSettlement) is a request terminal too: the record
+// is never parked, so no late provider terminal can claim it — the key must be
+// forgotten right here, and NOT zeroed (consumer goroutine).
+func TestHoldForSettlementFinalizedForgetsChunkKey(t *testing.T) {
+	srv, _, ledger := billingTestServer(t)
+	srv.settleGrace = 20 * time.Millisecond
+
+	priv := &[32]byte{13}
+	pr := &registry.PendingRequest{
+		RequestID:            "finalized-key",
+		Model:                "m",
+		ConsumerKey:          testConsumerID,
+		BaseReservedMicroUSD: 100_000,
+		ReservedMicroUSD:     100_000,
+		SessionPrivKey:       priv,
+	}
+	if !pr.MarkReservationFinalized() {
+		t.Fatal("sanity: first finalize should win")
+	}
+	shared := seedChunkKey(t, srv, priv)
+	want := *shared
+	balBefore := ledger.Balance(testConsumerID)
+
+	srv.holdForSettlement(pr)
+
+	if chunkKeyCached(&srv.chunkKeys, priv) {
+		t.Fatal("finalized early return must forget the chunk key (nothing else ever will)")
+	}
+	if *shared != want {
+		t.Error("finalized-path forget is on the consumer goroutine: it must NOT zero the key")
+	}
+	// Still skips the park: no grace-expiry refund may fire for a finalized record.
+	time.Sleep(3 * srv.settleGrace)
+	if got := ledger.Balance(testConsumerID); got != balBefore {
+		t.Errorf("finalized record must not be parked/refunded: balance %d -> %d", balBefore, got)
+	}
+}
+
 // The defensive nil-holder branch is also a terminal: it must forget the key
 // immediately (plain forget — consumer goroutine).
 func TestHoldForSettlementNilHolderForgetsChunkKey(t *testing.T) {

--- a/coordinator/api/terminal_class.go
+++ b/coordinator/api/terminal_class.go
@@ -1,0 +1,29 @@
+package api
+
+import "strings"
+
+// statusClientClosedRequest is the de-facto standard (nginx-originated) HTTP
+// status for "client closed request". The coordinator uses it both for genuine
+// consumer disconnects and for coordinator-initiated aborts on the consumer's
+// behalf (e.g. the chunk-buffer-overflow abort in handleChunk), so terminal
+// classification treats it as a consumer-side outcome, never a provider fault.
+const statusClientClosedRequest = 499
+
+// errorClassConsumerCancelAfterCommit is the route-outcome error_class for a
+// provider terminal that reports a consumer-side cancellation AFTER content
+// was committed (client cancel, or the coordinator's overflow-499 abort of a
+// stalled consumer stream). Mirrors handleInferenceError's cancelTerminal
+// semantics: partial_success, NOT AdmittedButFailed — it must never pollute
+// provider_error calibration signals.
+const errorClassConsumerCancelAfterCommit = "consumer_cancel_after_commit"
+
+// isConsumerCancelTerminal reports whether a provider terminal was caused by
+// the CONSUMER (or by the coordinator acting on the consumer's behalf) rather
+// than by the provider: a 499 status, or a "request cancelled" error message
+// (the provider's response to a Cancel we sent). This is the single matcher
+// shared by handleInferenceError's reputation carve-out and the route-outcome
+// classification, so the two can never drift.
+func isConsumerCancelTerminal(statusCode int, errMsg string) bool {
+	return statusCode == statusClientClosedRequest ||
+		strings.Contains(strings.ToLower(errMsg), "request cancelled")
+}

--- a/coordinator/api/terminal_class_test.go
+++ b/coordinator/api/terminal_class_test.go
@@ -1,0 +1,37 @@
+package api
+
+import "testing"
+
+func TestIsConsumerCancelTerminal(t *testing.T) {
+	cases := []struct {
+		name   string
+		status int
+		errMsg string
+		want   bool
+	}{
+		{"bare 499", statusClientClosedRequest, "", true},
+		{"499 with unrelated text", statusClientClosedRequest, "anything at all", true},
+		{"overflow abort message, no status", 0, "request cancelled: consumer stream stalled (chunk buffer overflow)", true},
+		{"provider cancel ack, 200", 200, "request cancelled", true},
+		{"case-insensitive match", 500, "Request Cancelled by peer", true},
+		{"provider disconnect 502", 502, "provider disconnected", false},
+		{"genuine fault 500", 500, "model crashed during generation", false},
+		{"capacity 503", 503, "token_budget_exhausted", false},
+		{"empty", 0, "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isConsumerCancelTerminal(tc.status, tc.errMsg); got != tc.want {
+				t.Errorf("isConsumerCancelTerminal(%d, %q) = %v, want %v", tc.status, tc.errMsg, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestStatusClientClosedRequestValue(t *testing.T) {
+	// The wire value is load-bearing (providers and consumers key off 499);
+	// pin it so a refactor cannot silently change it.
+	if statusClientClosedRequest != 499 {
+		t.Fatalf("statusClientClosedRequest = %d, want 499", statusClientClosedRequest)
+	}
+}

--- a/coordinator/registry/pending_iter.go
+++ b/coordinator/registry/pending_iter.go
@@ -1,0 +1,24 @@
+package registry
+
+// PendingSessionKeys returns the E2E session private keys of every request
+// currently pending on this provider (nil entries and requests without a
+// session key are skipped). The returned slice is a snapshot: it stays valid
+// after the pending map is mutated or cleared.
+//
+// It exists for the API layer's provider read-loop cleanup: when a provider
+// disconnects, Registry.Disconnect wipes the pending map, which would orphan
+// every in-flight request's memoized chunk-decryption cache entry. The caller
+// collects the keys with this method BEFORE calling Disconnect and forgets
+// each one from the cache.
+func (p *Provider) PendingSessionKeys() []*[32]byte {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	keys := make([]*[32]byte, 0, len(p.pendingReqs))
+	for _, pr := range p.pendingReqs {
+		if pr == nil || pr.SessionPrivKey == nil {
+			continue
+		}
+		keys = append(keys, pr.SessionPrivKey)
+	}
+	return keys
+}

--- a/coordinator/registry/pending_iter_test.go
+++ b/coordinator/registry/pending_iter_test.go
@@ -1,0 +1,49 @@
+package registry
+
+import (
+	"testing"
+)
+
+// PendingSessionKeys returns exactly the non-nil session keys of pending
+// requests, skipping nil entries, and the snapshot survives the pending map
+// being cleared (the whole point: it is collected BEFORE Disconnect wipes it).
+func TestPendingSessionKeys(t *testing.T) {
+	reg := New(testLogger())
+	p := reg.Register("prov-pending-keys", nil, testRegisterMessage())
+
+	keyA := &[32]byte{1}
+	keyB := &[32]byte{2}
+	p.AddPending(&PendingRequest{RequestID: "req-a", SessionPrivKey: keyA})
+	p.AddPending(&PendingRequest{RequestID: "req-b", SessionPrivKey: keyB})
+	p.AddPending(&PendingRequest{RequestID: "req-nil-key"}) // no session key: skipped
+
+	keys := p.PendingSessionKeys()
+	if len(keys) != 2 {
+		t.Fatalf("PendingSessionKeys returned %d keys, want 2", len(keys))
+	}
+	seen := map[*[32]byte]bool{}
+	for _, k := range keys {
+		seen[k] = true
+	}
+	if !seen[keyA] || !seen[keyB] {
+		t.Fatalf("PendingSessionKeys missing expected pointers: got %v", keys)
+	}
+
+	// Snapshot semantics: wiping the pending map (as Disconnect does) must not
+	// invalidate the already-collected slice.
+	reg.Disconnect("prov-pending-keys")
+	if len(keys) != 2 || !seen[keyA] || !seen[keyB] {
+		t.Fatal("collected snapshot must remain valid after Disconnect")
+	}
+	if got := p.PendingSessionKeys(); len(got) != 0 {
+		t.Fatalf("after Disconnect, PendingSessionKeys = %d keys, want 0", len(got))
+	}
+}
+
+func TestPendingSessionKeysEmpty(t *testing.T) {
+	reg := New(testLogger())
+	p := reg.Register("prov-no-pending", nil, testRegisterMessage())
+	if got := p.PendingSessionKeys(); len(got) != 0 {
+		t.Fatalf("PendingSessionKeys on empty provider = %d keys, want 0", len(got))
+	}
+}

--- a/coordinator/registry/provider_writer.go
+++ b/coordinator/registry/provider_writer.go
@@ -67,12 +67,11 @@ type providerWriter struct {
 
 	// writeDeadline is the UnixNano deadline of the in-flight conn.Write
 	// (0 = no write in progress). Published by writeFrame, enforced by
-	// watchWrites.
+	// watchWrites. The deadline value doubles as a CAS token: exactly one
+	// of writeFrame (releaseWriteDeadline) and the watchdog
+	// (claimExpiredWriteDeadline) swaps it to 0 and thereby owns the
+	// frame's outcome. See those methods for the protocol.
 	writeDeadline atomic.Int64
-	// writeTimedOut records that the watchdog closed the socket due to a
-	// write deadline, so writeFrame can surface a timeout error instead of
-	// the generic connection-closed error.
-	writeTimedOut atomic.Bool
 
 	// timeoutFor overrides the per-frame write timeout in tests. Nil means
 	// the default providerWriteTimeout schedule.
@@ -161,6 +160,20 @@ func (w *providerWriter) writeLane(ctx context.Context, data []byte, control boo
 	if err := w.submit(lane, req); err != nil {
 		return err
 	}
+	return w.awaitWriteResult(ctx, req)
+}
+
+// awaitWriteResult blocks until the frame's outcome is known: the serve loop
+// delivered a result, the caller's ctx expired before the write started, or
+// the writer stopped.
+//
+// When <-w.done and req.done are ready simultaneously (writer stopped right
+// after serving this frame), select picks randomly — so the w.done branches
+// must NOT unconditionally report errProviderWriterStopped: the frame may
+// already have been written successfully, and reporting "stopped" would make
+// the caller re-dispatch a request that is already running on this provider.
+// stoppedResult drains req.done first and prefers the real outcome.
+func (w *providerWriter) awaitWriteResult(ctx context.Context, req *providerWriteRequest) error {
 	select {
 	case err := <-req.done:
 		return err
@@ -168,13 +181,30 @@ func (w *providerWriter) writeLane(ctx context.Context, data []byte, control boo
 		if req.state.CompareAndSwap(0, 1) {
 			return ctx.Err()
 		}
+		// The write already started; its result is authoritative.
 		select {
 		case err := <-req.done:
 			return err
 		case <-w.done:
-			return errProviderWriterStopped
+			return w.stoppedResult(req)
 		}
 	case <-w.done:
+		return w.stoppedResult(req)
+	}
+}
+
+// stoppedResult resolves a frame's outcome after the writer stopped. Every
+// accepted frame receives a result on req.done before w.done closes (serve
+// delivers in-flight results; drainAll covers queued frames; submit's
+// acceptMu/dead handshake orders enqueue before drain), so a final
+// non-blocking drain returns the frame's true result — including a nil for a
+// frame that hit the wire just before shutdown. The errProviderWriterStopped
+// fallback is defensive.
+func (w *providerWriter) stoppedResult(req *providerWriteRequest) error {
+	select {
+	case err := <-req.done:
+		return err
+	default:
 		return errProviderWriterStopped
 	}
 }
@@ -289,10 +319,13 @@ func (w *providerWriter) drainLane(lane chan *providerWriteRequest, err error) {
 
 // watchWrites enforces per-frame write deadlines with one goroutine per
 // connection instead of a goroutine+timer per frame. writeFrame publishes its
-// deadline before the blocking conn.Write and clears it after; when a deadline
-// is exceeded the watchdog closes the socket, which unblocks Write with an
-// error. Granularity is providerWriteWatchdogInterval, acceptable slack on a
-// >=5s timeout floor.
+// deadline before the blocking conn.Write and releases it after; when a
+// deadline is exceeded the watchdog claims the frame via CAS and closes the
+// socket, which unblocks Write with an error. The CAS guarantees exactly one
+// side owns an expired frame's outcome — the watchdog never tears down the
+// socket for a write that already completed, and writeFrame never reports
+// success for a frame whose socket the watchdog is killing. Granularity is
+// providerWriteWatchdogInterval, acceptable slack on a >=5s timeout floor.
 func (w *providerWriter) watchWrites(stop <-chan struct{}) {
 	ticker := time.NewTicker(providerWriteWatchdogInterval)
 	defer ticker.Stop()
@@ -303,16 +336,47 @@ func (w *providerWriter) watchWrites(stop <-chan struct{}) {
 		case <-w.stop:
 			return
 		case <-ticker.C:
-			d := w.writeDeadline.Load()
-			if d != 0 && time.Now().UnixNano() > d {
-				w.writeTimedOut.Store(true)
-				if w.conn != nil {
-					_ = w.conn.CloseNow()
-				}
-				return
+			if !w.claimExpiredWriteDeadline(time.Now().UnixNano()) {
+				continue
 			}
+			if w.conn != nil {
+				_ = w.conn.CloseNow()
+			}
+			return
 		}
 	}
+}
+
+// claimExpiredWriteDeadline is the watchdog's side of the deadline CAS
+// protocol. It returns true when an in-flight write's deadline has expired
+// AND the watchdog won the race to claim it (CAS deadline -> 0); only then
+// may the watchdog close the socket. A false return means either no write is
+// in flight, the write is not yet expired, or writeFrame released the
+// deadline between our Load and CAS — the write completed in time and must
+// not be treated as a timeout.
+//
+// ABA safety: a lost CAS can only be caused by writeFrame releasing to 0;
+// a subsequent frame's freshly published deadline is strictly in the future
+// while the loaded expired value is in the past, so the CAS can never
+// mistakenly claim the next frame.
+func (w *providerWriter) claimExpiredWriteDeadline(nowNano int64) bool {
+	d := w.writeDeadline.Load()
+	if d == 0 || nowNano <= d {
+		return false
+	}
+	return w.writeDeadline.CompareAndSwap(d, 0)
+}
+
+// releaseWriteDeadline is writeFrame's side of the deadline CAS protocol.
+// It returns true when the frame still owned its published deadline (the
+// normal case: conn.Write returned before expiry, or after a non-timeout
+// failure). A false return means the watchdog claimed the deadline and is
+// closing (or has closed) the socket: the frame must be reported as
+// errProviderWriteTimeout even if conn.Write returned nil, because the
+// socket is dead and the caller has to fail over now — not on the next
+// frame.
+func (w *providerWriter) releaseWriteDeadline(deadline int64) bool {
+	return w.writeDeadline.CompareAndSwap(deadline, 0)
 }
 
 func (w *providerWriter) writeFrame(data []byte) error {
@@ -324,10 +388,15 @@ func (w *providerWriter) writeFrame(data []byte) error {
 	if w.timeoutFor != nil {
 		timeout = w.timeoutFor(len(data))
 	}
-	w.writeDeadline.Store(time.Now().Add(timeout).UnixNano())
+	deadline := time.Now().Add(timeout).UnixNano()
+	w.writeDeadline.Store(deadline)
 	err := w.conn.Write(context.Background(), websocket.MessageText, data)
-	w.writeDeadline.Store(0)
-	if err != nil && w.writeTimedOut.Load() {
+	if !w.releaseWriteDeadline(deadline) {
+		// The watchdog claimed this frame: the socket is being torn down.
+		// Even a nil err from Write means nothing reached a live peer —
+		// surface the timeout so serve() closes the writer and the caller
+		// fails over immediately. Timeout attribution is per frame: only
+		// the frame that lost its own CAS reports errProviderWriteTimeout.
 		return errProviderWriteTimeout
 	}
 	return err

--- a/coordinator/registry/provider_writer_test.go
+++ b/coordinator/registry/provider_writer_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -328,21 +329,25 @@ func TestProviderWriterWatchdogClosesStalledWrite(t *testing.T) {
 	case <-time.After(15 * time.Second):
 		t.Fatal("timed out waiting for watchdog to abort the stalled write")
 	}
-	if !w.writeTimedOut.Load() {
-		t.Fatal("writeTimedOut not set by watchdog")
-	}
 	select {
 	case <-w.done:
 	case <-time.After(5 * time.Second):
 		t.Fatal("writer did not shut down after watchdog closed the socket")
 	}
+	// Timeout attribution is per frame: only the frame that lost its own
+	// deadline CAS reports errProviderWriteTimeout. Later write attempts on
+	// the dead writer must report errProviderWriterStopped, never a stale
+	// timeout.
 	if err := w.write(context.Background(), []byte(`{"after":"close"}`)); err != errProviderWriterStopped {
 		t.Fatalf("write after watchdog close = %v, want errProviderWriterStopped", err)
+	}
+	if err := w.writeControl(context.Background(), []byte(`{"after":"close"}`)); err != errProviderWriterStopped {
+		t.Fatalf("writeControl after watchdog close = %v, want errProviderWriterStopped", err)
 	}
 }
 
 // TestProviderWriterWatchdogFiresOnPastDeadline unit-tests watchWrites: a
-// published deadline in the past makes the watchdog set writeTimedOut and
+// published deadline in the past makes the watchdog claim it (CAS to 0) and
 // close the socket within one tick.
 func TestProviderWriterWatchdogFiresOnPastDeadline(t *testing.T) {
 	serverConn, _ := testWebSocketPair(t)
@@ -357,16 +362,217 @@ func TestProviderWriterWatchdogFiresOnPastDeadline(t *testing.T) {
 	go w.watchWrites(watchdogStop)
 
 	deadline := time.Now().Add(5 * time.Second)
-	for !w.writeTimedOut.Load() {
+	for w.writeDeadline.Load() != 0 {
 		if time.Now().After(deadline) {
-			t.Fatal("watchdog did not fire on a past write deadline")
+			t.Fatal("watchdog did not claim a past write deadline")
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
-	writeCtx, cancelWrite := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancelWrite()
-	if err := serverConn.Write(writeCtx, websocket.MessageText, []byte(`{"x":1}`)); err == nil {
-		t.Fatal("expected write on watchdog-closed socket to fail")
+	// The socket close happens just after the claim; poll until a write on
+	// the watchdog-closed socket fails.
+	for {
+		writeCtx, cancelWrite := context.WithTimeout(context.Background(), time.Second)
+		err := serverConn.Write(writeCtx, websocket.MessageText, []byte(`{"x":1}`))
+		cancelWrite()
+		if err != nil {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("watchdog claimed the deadline but never closed the socket")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// TestProviderWriterDeadlineCASExactlyOneWinner pins the deadline CAS
+// protocol: when a frame's deadline has expired, writeFrame's release and the
+// watchdog's claim race — exactly one side must win. If the writer wins, the
+// frame completed in time and the watchdog must not tear down the socket; if
+// the watchdog wins, the frame must be reported as timed out even when
+// conn.Write returned nil. Run under -race with many iterations to flush the
+// TOCTOU window.
+func TestProviderWriterDeadlineCASExactlyOneWinner(t *testing.T) {
+	w := &providerWriter{}
+	for i := 0; i < 10000; i++ {
+		deadline := time.Now().Add(-time.Millisecond).UnixNano()
+		w.writeDeadline.Store(deadline)
+		var writerWon, watchdogWon bool
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			writerWon = w.releaseWriteDeadline(deadline)
+		}()
+		go func() {
+			defer wg.Done()
+			watchdogWon = w.claimExpiredWriteDeadline(time.Now().UnixNano())
+		}()
+		wg.Wait()
+		if writerWon == watchdogWon {
+			t.Fatalf("iteration %d: writerWon=%v watchdogWon=%v, want exactly one winner", i, writerWon, watchdogWon)
+		}
+		if got := w.writeDeadline.Load(); got != 0 {
+			t.Fatalf("iteration %d: writeDeadline = %d after race, want 0", i, got)
+		}
+	}
+}
+
+// TestProviderWriterDeadlineClaimSemantics unit-tests the watchdog's claim
+// path: no in-flight write and unexpired deadlines are never claimed, an
+// expired deadline is claimed at most once, and a release after a successful
+// claim loses.
+func TestProviderWriterDeadlineClaimSemantics(t *testing.T) {
+	w := &providerWriter{}
+	now := time.Now().UnixNano()
+
+	if w.claimExpiredWriteDeadline(now) {
+		t.Fatal("claim with no write in flight must fail")
+	}
+
+	future := now + int64(time.Hour)
+	w.writeDeadline.Store(future)
+	if w.claimExpiredWriteDeadline(now) {
+		t.Fatal("claim of an unexpired deadline must fail")
+	}
+	if got := w.writeDeadline.Load(); got != future {
+		t.Fatalf("unexpired deadline mutated by failed claim: %d, want %d", got, future)
+	}
+	if !w.releaseWriteDeadline(future) {
+		t.Fatal("release of an unclaimed deadline must win")
+	}
+
+	expired := now - 1
+	w.writeDeadline.Store(expired)
+	if !w.claimExpiredWriteDeadline(now) {
+		t.Fatal("claim of an expired deadline must win")
+	}
+	if w.claimExpiredWriteDeadline(now) {
+		t.Fatal("second claim after the deadline was cleared must fail")
+	}
+	if w.releaseWriteDeadline(expired) {
+		t.Fatal("release after the watchdog claimed the deadline must lose")
+	}
+}
+
+// TestProviderWriterExpiredButCompletedWritesNeverReportSuccessOnDeadSocket
+// drives the caller-visible contract at the deadline boundary: with an
+// immediately-expired per-frame deadline (timeoutFor = 1ns), every frame is
+// past its deadline while in flight, so writeFrame's release races the
+// watchdog's claim on every tick. The caller must only ever observe (a) nil
+// with a still-usable writer, or (b) errProviderWriteTimeout followed by
+// errProviderWriterStopped. A connection-closed error after a nil result —
+// the success-then-dead-socket signature of the TOCTOU bug — fails the test.
+func TestProviderWriterExpiredButCompletedWritesNeverReportSuccessOnDeadSocket(t *testing.T) {
+	serverConn, clientConn := testWebSocketPair(t)
+	w := &providerWriter{
+		conn:       serverConn,
+		queue:      make(chan *providerWriteRequest, providerWriteQueueSize),
+		control:    make(chan *providerWriteRequest, providerControlQueueSize),
+		stop:       make(chan struct{}),
+		done:       make(chan struct{}),
+		timeoutFor: func(int) time.Duration { return time.Nanosecond },
+	}
+	go w.run()
+	t.Cleanup(w.closeNow)
+
+	// Drain the client side so writes complete quickly.
+	readerDone := make(chan struct{})
+	go func() {
+		defer close(readerDone)
+		for {
+			if _, _, err := clientConn.Read(context.Background()); err != nil {
+				return
+			}
+		}
+	}()
+	t.Cleanup(func() {
+		_ = clientConn.CloseNow()
+		<-readerDone
+	})
+
+	// Span several watchdog ticks (250ms interval).
+	stopAt := time.Now().Add(3 * providerWriteWatchdogInterval)
+	for time.Now().Before(stopAt) {
+		err := w.write(context.Background(), []byte(`{"boundary":"frame"}`))
+		if err == nil {
+			continue // writer won the CAS; writer must still be live for the next iteration
+		}
+		if err == errProviderWriteTimeout {
+			// Watchdog won the CAS on an expired in-flight frame; the writer
+			// must now be dead and later frames attributed as stopped.
+			if err2 := w.write(context.Background(), []byte(`{"after":"timeout"}`)); err2 != errProviderWriterStopped {
+				t.Fatalf("write after timeout teardown = %v, want errProviderWriterStopped", err2)
+			}
+			return
+		}
+		t.Fatalf("boundary write = %v, want nil or errProviderWriteTimeout (connection error after reported success indicates the watchdog TOCTOU)", err)
+	}
+}
+
+// TestProviderWriterAwaitResultPrefersSuccessOverStopped deterministically
+// pins the stopped-vs-success select race: both req.done (carrying nil from a
+// successful write) and w.done (writer stopped) are ready before the waiter
+// runs, and the waiter must still report success — otherwise the caller
+// re-dispatches a request that is already running on this provider.
+func TestProviderWriterAwaitResultPrefersSuccessOverStopped(t *testing.T) {
+	serverConn, clientConn := testWebSocketPair(t)
+	w := &providerWriter{
+		conn:    serverConn,
+		queue:   make(chan *providerWriteRequest, providerWriteQueueSize),
+		control: make(chan *providerWriteRequest, providerControlQueueSize),
+		stop:    make(chan struct{}),
+		done:    make(chan struct{}),
+	}
+	req := laneRequest(`{"type":"request"}`)
+	w.queue <- req
+	go w.run()
+	t.Cleanup(w.closeNow)
+
+	readFrames(t, clientConn, 1) // the frame reached the wire
+	// Wait until serve() has delivered the frame's result, then stop the
+	// writer, so req.done and w.done are BOTH ready before the waiter runs.
+	settle := time.Now().Add(5 * time.Second)
+	for len(req.done) == 0 {
+		if time.Now().After(settle) {
+			t.Fatal("serve() never delivered the write result")
+		}
+		time.Sleep(time.Millisecond)
+	}
+	w.closeNow()
+	select {
+	case <-w.done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("writer did not stop after closeNow")
+	}
+
+	if err := w.awaitWriteResult(context.Background(), req); err != nil {
+		t.Fatalf("awaitWriteResult with success and stop both ready = %v, want nil (success)", err)
+	}
+}
+
+// TestProviderWriterCloseAfterSuccessfulWriteReportsSuccess is the end-to-end
+// variant of the stopped-vs-success race through the public write path: a
+// frame is written to the wire, the writer is torn down immediately, and the
+// caller blocked in write() must observe nil, never errProviderWriterStopped.
+// Run with -count=50 -race: before the awaitWriteResult drain fix this flaked
+// ~50% of runs (select picked <-w.done over the ready req.done).
+func TestProviderWriterCloseAfterSuccessfulWriteReportsSuccess(t *testing.T) {
+	serverConn, clientConn := testWebSocketPair(t)
+	w := newProviderWriter(serverConn)
+	t.Cleanup(w.closeNow)
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- w.write(context.Background(), []byte(`{"type":"request"}`)) }()
+	readFrames(t, clientConn, 1) // success on the wire
+	w.closeNow()
+
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("write result after wire delivery + immediate close = %v, want nil", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for write result")
 	}
 }
 


### PR DESCRIPTION
## Summary

Terminal-path correctness fixes — the top follow-ups from the #491 review plus the P0 swallowed-refund bug. Four fixes, all about what happens when a request or connection *ends*: money that silently vanished, session keys that outlived their requests, backpressure aborts booked as provider faults, and two writer races at the deadline/shutdown boundary.

Coordinator-only; no wire-format changes; `consumer.go`/`registry.go`/`scheduler.go` untouched (in-flight v0.6.31 work) — deferred sites listed below.

## Before / After

### Behavior — request/connection terminals

```mermaid
flowchart LR
  subgraph Before
    A1[refund credit fails] --> B1["silently dropped<br/>(_ = store.Credit)"]
    C1[request abandoned:<br/>retry / cancel / disconnect / grace-expiry] --> D1["session key stays cached<br/>until 8192 cap-reset (maybe never)"]
    E1[overflow-499 / client cancel<br/>after commit] --> F1["route outcome: provider_error_after_commit<br/>AdmittedButFailed=true — pollutes calibration"]
    G1["write completes just as<br/>deadline expires"] --> H1["reported SUCCESS on a socket the<br/>watchdog killed -> TTFT burned + fake fault;<br/>writeTimedOut latch misattributes next frame;<br/>~50% 'stopped' for successfully-written frames"]
  end
  subgraph After
    A2[refund credit fails] --> B2["ERROR log + billing.refund_failures metric<br/>(alerting hook)"]
    C2[ALL terminal paths] --> D2["key forgotten immediately;<br/>zeroed when on the read-loop goroutine"]
    E2[consumer-cancel terminal] --> F2["partial_success / consumer_cancel_after_commit<br/>AdmittedButFailed=false"]
    G2[deadline boundary] --> H2["CAS handoff: exactly one winner;<br/>lost write returns errProviderWriteTimeout even on nil err;<br/>per-frame attribution; final done-drain before 'stopped'"]
  end
```

### Code — control flow

```mermaid
flowchart LR
  subgraph Before
    a1["cancelDispatch x38 (dispatch.go)<br/>grace expiry, disconnect, retry-reassign"] --> b1["no chunkKeys cleanup"]
    c1["magic literals: 499,<br/>'request cancelled' (2 sites)"] --> d1["postCommitProviderErrorOutcome:<br/>always provider fault"]
    e1["writeFrame: bare Load + sticky<br/>writeTimedOut bool"] --> f1["writeLane: random select between<br/>req.done and w.done"]
  end
  subgraph After
    a2["cancelDispatchAndForget wrapper;<br/>settlement onExpiry forget;<br/>forgetProviderPendingKeys (new<br/>registry/pending_iter.go accessor);<br/>forget-before-reassign"] --> b2["chunkKeyCache: forget (cross-goroutine)<br/>vs forgetAndZero (read-loop only,<br/>zeroing policy documented)"]
    c2["terminal_class.go:<br/>statusClientClosedRequest,<br/>isConsumerCancelTerminal()"] --> d2["postCommitProviderErrorOutcome<br/>short-circuits consumer-cancels"]
    e2["writeDeadline value IS the CAS token<br/>(nonzero->0); watchdog and writeFrame<br/>race to claim; writeTimedOut deleted"] --> f2["awaitWriteResult: non-blocking<br/>req.done drain before stoppedResult"]
  end
```

## The fixes

### 1. Swallowed refund credit (money)
`releaseInitialReservation` dropped consumer refunds on store failure with `_ =`. Now: ERROR log (account/model/amount) + `billing.refund_failures` metric, matching the platform-fee path's documented "never swallow it" policy. No inline retry — this runs on latency-sensitive paths; the metric is the alerting hook.

### 2. `chunkKeys` lifecycle (crypto hygiene — highest-agreement #491 review finding)
Only `handleComplete`/`handleInferenceError` forgot the memoized X25519 shared key; every consumer-side terminal orphaned entries, pinning session keys until a cap-reset that may never fire. Now covered: **retry reassignment** (forget before the `SessionPrivKey` pointer overwrite), **settlement grace expiry**, **provider disconnect** (new `Provider.PendingSessionKeys()` snapshot taken *before* `Disconnect` wipes the map), and **all 38 `cancelDispatch` sites in dispatch.go** via a `cancelDispatchAndForget` wrapper.

**Zeroing policy** (deliberate, documented on the type): keys are zeroed only on read-loop-goroutine forgets (`handleComplete`, `handleInferenceError`, disconnect cleanup — same goroutine as chunk decryption, no concurrent use possible). Cross-goroutine forgets (retry, grace timer) delete without zeroing: zeroing there races an in-flight `box.OpenAfterPrecomputation`, and a corrupted decrypt would `MarkUntrusted` an innocent provider.

### 3. Overflow-499 telemetry classification
The #491 overflow abort was correctly classified for reputation but `postCommitProviderErrorOutcome` still booked it as `provider_error_after_commit` + `AdmittedButFailed=true` — polluting exactly the calibration signals the 499 was meant to protect. Now: shared `terminal_class.go` constants/helper (`statusClientClosedRequest`, `isConsumerCancelTerminal`) replace the magic literals in both `provider.go` and `route_outcome.go`, and consumer-cancel terminals short-circuit to `partial_success`/`consumer_cancel_after_commit`/`AdmittedButFailed=false`. Real 502s still book as provider faults (pinned by test).

### 4. Writer deadline/shutdown races
- **Watchdog TOCTOU**: `writeDeadline`'s value is now the CAS token (nonzero UnixNano → 0). `writeFrame` and the watchdog race to claim it; exactly one wins. A write that lost the claim returns `errProviderWriteTimeout` **even on nil err** (the socket is dead — fail over now, not after the TTFT budget). The sticky `writeTimedOut` latch is deleted; attribution is per-frame.
- **Stopped-vs-success**: when `req.done` and `w.done` were both ready, Go's select returned `errProviderWriterStopped` ~50% of the time for a frame that was on the wire — duplicate dispatch to a second provider. Now a final non-blocking `req.done` drain runs before the stopped fallback. Regression test proven to have teeth: reverting the fix fails 6/10 runs.

## Deferred (blocked on in-flight v0.6.31 files)

- `consumer.go:244/:717/:3305` — same refund-swallow fix
- `consumer.go` cancel/cleanup sites (`cancelDispatch` itself could absorb the forget once unfrozen; `cleanupPending` closures; generic-handler exits — full list in review notes)
- `registry.go` — routing `SendLoadModel`/`SendPrefetchModel`/`SendDesiredModels` through the control lane

## Verification

- `gofmt` clean, `go vet ./...` clean, **full `go test ./...` green** (api 104s)
- `go test ./registry/ -race -count=3` green; race-sensitive writer tests at `-race -count=50`
- New tests: refund-failure metric (counting fail-store), forgetAndZero/forget semantics, per-terminal-path lifecycle (incl. full WS-disconnect end-to-end and settlement expiry), 499 classification (overflow + bare 499 vs real 502), CAS exactly-one-winner (10k concurrent iterations), deadline-boundary never-reports-success-on-dead-socket, stopped-vs-success determinism

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/494"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785559209&installation_id=133247490&pr_number=494&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F494&signature=d1658ce987e35d3d6f84c276efbda157abcae78bc95aed05edf1fb057a20a74e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->