### PR TITLE
fix(provider): darkbloom stop no longer auto-starts again after reboot

### DIFF
--- a/provider-swift/Sources/ProviderCore/Service/LaunchAgent.swift
+++ b/provider-swift/Sources/ProviderCore/Service/LaunchAgent.swift
@@ -3,7 +3,9 @@
 /// The provider runs only after the user explicitly starts it (`darkbloom start`
 /// or the app's "Go Online"). It auto-starts at login (RunAtLoad) so a rebooted
 /// box re-attests without a manual start; crash recovery is delegated to the
-/// separate `WatchdogAgent`. `darkbloom stop` unloads it and keeps it stopped.
+/// separate `WatchdogAgent`. `darkbloom stop` unloads it AND persistently
+/// disables it (`launchctl disable`), so a reboot/re-login does not resurrect a
+/// provider the user explicitly stopped; `start` re-enables it.
 
 import Foundation
 
@@ -131,15 +133,32 @@ public enum LaunchAgent: Sendable {
 
     // MARK: - Stop
 
-    /// Stop the provider by unloading the launchd agent.
+    /// Stop the provider: unload the launchd agent AND persistently disable it.
     ///
-    /// If the service is not loaded this is a no-op.
+    /// `bootout` alone only deregisters the job from the current login session.
+    /// The plist stays in ~/Library/LaunchAgents (it holds the model selection
+    /// for `restart`), and launchd re-bootstraps everything in that directory at
+    /// the next login/reboot — so with RunAtLoad=true the provider would come
+    /// back even though the user explicitly stopped it. `launchctl disable`
+    /// writes a per-user override that survives reboots; `loadService()`
+    /// re-enables on the next `start`/`restart`.
+    ///
+    /// If the service is not loaded, the unload is a no-op but the disable
+    /// still applies (covers a stop issued after a crash or partial install).
     public static func stop() throws {
         if isLoaded() {
             try unloadService()
         }
         for legacyLabel in legacyLabels where isLoaded(label: legacyLabel) {
             try unloadService(label: legacyLabel)
+        }
+        // Disable every supported label: a not-yet-migrated legacy plist on
+        // disk would otherwise RunAtLoad under its old label at next login.
+        for serviceLabel in supportedLabels {
+            let result = LaunchctlControl.setEnabled(false, label: serviceLabel)
+            if !result.succeeded {
+                throw LaunchAgentError.disableFailed(result.stderr.trimmingCharacters(in: .whitespacesAndNewlines))
+            }
         }
     }
 
@@ -363,6 +382,12 @@ public enum LaunchAgent: Sendable {
         let path = plistPath()
         let domain = "gui/\(getuid())"
 
+        // Clear any persistent disable left by `stop()` (launchctl disable
+        // survives reboots). Without this, bootstrap fails and RunAtLoad stays
+        // suppressed. Best-effort: if it fails while the service is actually
+        // disabled, the bootstrap below surfaces the error.
+        LaunchctlControl.setEnabled(true, label: label)
+
         // Bootstrap registers the service with launchd.
         let bootstrap = Process()
         bootstrap.executableURL = URL(fileURLWithPath: "/bin/launchctl")
@@ -454,6 +479,7 @@ public enum LaunchAgentError: Error, CustomStringConvertible, Sendable {
     case bootstrapFailed(String)
     case bootoutFailed(String)
     case kickstartFailed(String)
+    case disableFailed(String)
     case notInstalled
 
     public var description: String {
@@ -464,6 +490,8 @@ public enum LaunchAgentError: Error, CustomStringConvertible, Sendable {
             return "launchctl bootout failed: \(detail)"
         case .kickstartFailed(let detail):
             return "launchctl kickstart failed: \(detail)"
+        case .disableFailed(let detail):
+            return "launchctl disable failed (the provider may auto-start again at next login): \(detail)"
         case .notInstalled:
             return "provider service is not installed; run `darkbloom start` first"
         }

--- a/provider-swift/Sources/ProviderCore/Service/LaunchctlControl.swift
+++ b/provider-swift/Sources/ProviderCore/Service/LaunchctlControl.swift
@@ -48,6 +48,18 @@ enum LaunchctlControl {
         )
     }
 
+    /// `launchctl enable|disable gui/$UID/<label>`.
+    ///
+    /// Unlike `bootout` — which only deregisters the job from the CURRENT login
+    /// session — the enabled/disabled state lives in launchd's per-user override
+    /// database and PERSISTS across logins and reboots. This is what keeps a
+    /// stopped agent stopped after a reboot even though its plist
+    /// (RunAtLoad=true) stays in ~/Library/LaunchAgents.
+    @discardableResult
+    static func setEnabled(_ enabled: Bool, label: String, uid: uid_t = getuid()) -> Output {
+        run([enabled ? "enable" : "disable", target(label: label, uid: uid)], captureStderr: true)
+    }
+
     /// `launchctl print` exit-0 check — i.e. the job is loaded.
     static func printSucceeds(label: String, uid: uid_t = getuid()) -> Bool {
         run(["print", target(label: label, uid: uid)]).succeeded

--- a/provider-swift/Sources/ProviderCore/Service/WatchdogAgent.swift
+++ b/provider-swift/Sources/ProviderCore/Service/WatchdogAgent.swift
@@ -1,8 +1,10 @@
 /// The crash-recovery watchdog's launchd agent (`io.darkbloom.watchdog`),
 /// separate from the provider service. Runs `darkbloom watchdog` once a minute
 /// (`StartInterval`) as a check-and-exit one-shot, so a wedged tick can't stall
-/// recovery. Lifecycle mirrors the provider agent: `start` installs+loads it,
-/// `stop` bootouts it (plist stays for reboot), `stop --uninstall` deletes it.
+/// recovery. Lifecycle mirrors the provider agent: `start` installs+loads it
+/// (re-enabling any persistent disable), `stop` bootouts it AND persistently
+/// disables it so RunAtLoad/StartInterval can't resurrect it at the next
+/// login/reboot (plist stays on disk), `stop --uninstall` deletes it.
 
 import Foundation
 
@@ -41,9 +43,15 @@ public enum WatchdogAgent: Sendable {
         try loadService()
     }
 
-    /// Unload (no-op if not loaded); leaves the plist on disk.
+    /// Unload (no-op if not loaded) and persistently disable, so the plist left
+    /// on disk (RunAtLoad=true) cannot resurrect the watchdog at the next
+    /// login/reboot. `installAndStart()` re-enables.
     public static func stop() throws {
         if isLoaded() { try bootout() }
+        let result = LaunchctlControl.setEnabled(false, label: label)
+        if !result.succeeded {
+            throw WatchdogAgentError.disableFailed(result.stderr.trimmingCharacters(in: .whitespacesAndNewlines))
+        }
     }
 
     /// Unload and delete the plist.
@@ -84,6 +92,9 @@ public enum WatchdogAgent: Sendable {
     }
 
     private static func loadService() throws {
+        // Clear any persistent disable left by `stop()`; best-effort — a real
+        // failure surfaces via the bootstrap below.
+        LaunchctlControl.setEnabled(true, label: label)
         let bootstrap = LaunchctlControl.run(["bootstrap", LaunchctlControl.guiDomain(), plistPath().path], captureStderr: true)
         // Error 37 = "already loaded" — benign.
         if !bootstrap.succeeded, !bootstrap.stderr.contains("37:"), !bootstrap.stderr.contains("already loaded") {
@@ -109,12 +120,14 @@ public enum WatchdogAgentError: Error, CustomStringConvertible, Sendable {
     case bootstrapFailed(String)
     case bootoutFailed(String)
     case kickstartFailed(String)
+    case disableFailed(String)
 
     public var description: String {
         switch self {
         case .bootstrapFailed(let d): return "watchdog launchctl bootstrap failed: \(d)"
         case .bootoutFailed(let d): return "watchdog launchctl bootout failed: \(d)"
         case .kickstartFailed(let d): return "watchdog launchctl kickstart failed: \(d)"
+        case .disableFailed(let d): return "watchdog launchctl disable failed (it may auto-start again at next login): \(d)"
         }
     }
 }

--- a/provider-swift/Sources/ProviderCore/Service/WatchdogDecision.swift
+++ b/provider-swift/Sources/ProviderCore/Service/WatchdogDecision.swift
@@ -1,8 +1,9 @@
 /// The crash-recovery policy (pure, no I/O).
 ///
 /// A crash = the provider's launchd job is loaded but not running (`KeepAlive=false`
-/// leaves a crashed job loaded). `darkbloom stop` unloads it (`bootout`), so
-/// `providerLoaded == false` means the user disabled it — never restarted.
+/// leaves a crashed job loaded). `darkbloom stop` unloads it (`bootout` +
+/// persistent `launchctl disable`), so `providerLoaded == false` means the user
+/// disabled it — never restarted.
 /// `auto_restart = false` opts out. A crashed provider is restarted only after it
 /// stays down `graceSeconds` (default 5 min): long enough to clear the
 /// self-updater's kill+relaunch and to avoid tight crash-loops.

--- a/provider-swift/Sources/darkbloom/StopCommand.swift
+++ b/provider-swift/Sources/darkbloom/StopCommand.swift
@@ -29,9 +29,9 @@ struct Stop: AsyncParsableCommand {
         } else {
             try LaunchAgent.stop()
             if wasLoaded {
-                print("Provider service stopped. (Auto-restart disabled until you start again.)")
+                print("Provider service stopped. (Won't auto-start at login/reboot until you run `darkbloom start` again.)")
             } else {
-                print("Provider service is not running.")
+                print("Provider service is not running. (Auto-start at login/reboot is now disabled.)")
             }
         }
     }

--- a/provider-swift/Tests/ProviderCoreTests/LaunchAgentRestartTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/LaunchAgentRestartTests.swift
@@ -21,6 +21,27 @@ struct LaunchAgentRestartTests {
         #expect(message.contains("kickstart"))
         #expect(message.contains("boom"))
     }
+
+    // `darkbloom stop` must persistently disable the agent (launchctl disable)
+    // in addition to bootout: bootout only affects the current login session,
+    // and the plist left on disk (RunAtLoad=true) would otherwise restart the
+    // provider at the next reboot/login. If the disable fails, the error must
+    // warn the user about exactly that.
+    @Test("disableFailed warns the provider may auto-start at next login")
+    func disableFailedDescription() {
+        let message = LaunchAgentError.disableFailed("boom").description
+        #expect(message.contains("disable"))
+        #expect(message.contains("auto-start"))
+        #expect(message.contains("boom"))
+    }
+
+    @Test("watchdog disableFailed warns it may auto-start at next login")
+    func watchdogDisableFailedDescription() {
+        let message = WatchdogAgentError.disableFailed("boom").description
+        #expect(message.contains("disable"))
+        #expect(message.contains("auto-start"))
+        #expect(message.contains("boom"))
+    }
 }
 
 @Suite("LaunchAgent environment passthrough")


### PR DESCRIPTION
## Problem

`darkbloom stop` only ran `launchctl bootout`, which deregisters the job from the **current login session**. The provider and watchdog plists stayed in `~/Library/LaunchAgents/` with `RunAtLoad=true`, so at the next reboot/login launchd re-scanned the directory, re-bootstrapped both jobs, and started the provider again — overriding the user's explicit stop.

## Fix

`stop` now also runs `launchctl disable gui/$UID/<label>` (provider canonical + legacy labels, and the watchdog), which persists in launchd's per-user override database across reboots. `start`/`restart` re-enable via `launchctl enable` before bootstrap. The plist intentionally stays on disk so `darkbloom restart` keeps the model selection.

## Before / After

### Behavior

```mermaid
flowchart LR
  subgraph Before
    A1[darkbloom stop] --> B1[launchctl bootout only]
    B1 --> C1[plists stay, RunAtLoad=true]
    C1 --> D1[reboot / re-login]
    D1 --> E1[launchd re-bootstraps LaunchAgents]
    E1 --> F1[provider + watchdog START AGAIN — bug]
  end
  subgraph After
    A2[darkbloom stop] --> B2[bootout + launchctl disable]
    B2 --> C2[disable persists in per-user override DB]
    C2 --> D2[reboot / re-login]
    D2 --> E2[launchd skips disabled agents]
    E2 --> F2[provider stays stopped]
    F2 --> G2[darkbloom start / restart] --> H2[launchctl enable + bootstrap + kickstart]
  end
```

### Code

```mermaid
flowchart LR
  subgraph Before
    S1[Stop.run] --> W1[WatchdogAgent.stop = bootout]
    S1 --> L1[LaunchAgent.stop = bootout canonical+legacy]
    T1[LaunchAgent.loadService] --> BS1[bootstrap + kickstart]
  end
  subgraph After
    S2[Stop.run] --> W2[WatchdogAgent.stop = bootout + setEnabled false]
    S2 --> L2[LaunchAgent.stop = bootout + setEnabled false for all supportedLabels]
    T2[LaunchAgent.loadService] --> EN2[LaunchctlControl.setEnabled true] --> BS2[bootstrap + kickstart]
    T3[WatchdogAgent.loadService] --> EN3[setEnabled true] --> BS3[bootstrap + kickstart]
  end
```

## Changes

- `LaunchctlControl.setEnabled(_:label:)` — new shared `launchctl enable|disable` helper with a doc note on bootout-vs-disable persistence semantics.
- `LaunchAgent.stop()` — disables all supported labels after bootout (a not-yet-migrated legacy plist would otherwise RunAtLoad under its old label); new `LaunchAgentError.disableFailed` warns the user if the persistent disable fails.
- `LaunchAgent.loadService()` — re-enables before bootstrap (covers `start` and `restart`-after-stop paths).
- `WatchdogAgent.stop()` / `loadService()` — same treatment (its plist also had `RunAtLoad=true` + `StartInterval=60`); new `WatchdogAgentError.disableFailed`.
- `StopCommand` — user message now states auto-start at login/reboot is disabled.
- Doc comments updated (`LaunchAgent`, `WatchdogAgent`, `WatchdogDecision`).

Unaffected paths verified: the self-updater (`ProcessLifecycle`) uses `kickstart -k` on a loaded job and the watchdog's `kickstartIfLoaded` never loads an unloaded job — neither interacts with enable/disable state.

## Testing

- `swift build` passes.
- `swift test --filter LaunchAgent` / `--filter Watchdog`: 41 tests pass, including new tests pinning the `disableFailed` error surface for both agents. (launchctl side effects remain manual-verification per the existing test-suite convention; full-suite MLX metallib crash is a pre-existing local env issue.)
- Suggested manual check on a real box: `start` → `stop` → reboot → `launchctl print gui/$(id -u)/io.darkbloom.provider` reports nothing, no provider process → `start` works and survives a second reboot.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/496"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785562900&installation_id=133247490&pr_number=496&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F496&signature=7f003df787a7e6733f21d386f310c5d8164394aa030de37d9abc46d1d3eea6c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->