### PR TITLE
provider: ContinuousBatchingV2 bridge behind DARKBLOOM_ENGINE_V2 (Gemma 4 + GPT-OSS 20B)

### DIFF
--- a/docs/engine-v2/CONTRACT-ISSUES-H-provider.md
+++ b/docs/engine-v2/CONTRACT-ISSUES-H-provider.md
@@ -1,0 +1,91 @@
+# CONTRACT ISSUES — WS-H (provider bridge)
+
+Places where the frozen `CBv2Contracts.swift` was insufficient for the
+provider bridge, and the closest conforming shape chosen. None block
+integration; all are resolvable with small additive contract changes on the
+integration branch.
+
+## 1. `CBv2Engine` is not `Sendable`
+
+The provider consumes the engine from an actor (`EngineV2Bridge`) and from
+`Task`s spawned per request; `submit`/`cancel`/`capacity`/`shutdown` are by
+design the engine's cross-actor entry points. The contract declares
+`CBv2Engine: AnyObject` without `Sendable`, so any capture across a
+concurrency boundary trips Swift 6 strict checking.
+
+**Chosen shape:** an `@unchecked Sendable` wrapper
+(`EngineV2EngineBox` in `EngineV2Bridge.swift`) documented against the
+engine's internal serialization. **Suggested contract fix:** declare
+`public protocol CBv2Engine: AnyObject, Sendable`.
+
+## 2. No representation for "chosen-token logprob only"
+
+OpenAI's `logprobs: true` with `top_logprobs` omitted/0 means "return the
+sampled token's logprob, no alternatives". `CBv2SamplingParams.topLogprobs`
+overloads 0 as "no logprobs at all", so that request shape is
+unrepresentable.
+
+**Chosen shape:** `EngineV2Translation.topLogprobs` maps
+`logprobs == true` to `min(20, max(1, top_logprobs ?? 0))` — the chosen
+token's logprob is still captured at the cost of one extra alternative.
+**Suggested contract fix:** split into `reportLogprobs: Bool` +
+`topLogprobs: Int`.
+
+## 3. No engine-loop progress / watchdog surface for `step_wedge`
+
+The spec asks for an `engine_v2.step_wedge` signal "from the v2 watchdog",
+but `CBv2Engine` exposes no step counter (legacy: `EngineCore.stepsExecuted`)
+and no watchdog callback; `CBv2CapacitySnapshot` carries only request/byte
+counts.
+
+**Chosen shape:** the bridge feeds the existing `WedgeMonitor` from
+bridge-observable signals — admits at submit, first tokens from the first
+non-empty `.delta`, and loop progress proxied by a monotonic count of
+received `CBv2Event`s (any event from any request proves the loop advanced).
+Wedge transitions emit `engine_health` telemetry with
+`operation=step_wedge`, `backend=engine_v2`. **Suggested contract fix:** add
+`stepsExecuted: Int` (or `lastStepAt`) to `CBv2CapacitySnapshot`.
+
+## 4. `CBv2CapacitySnapshot` lacks worst-case + queued token views
+
+The heartbeat protocol reports `max_tokens_potential`
+(Σ prompt+maxTokens across running requests) and `queued_token_budget`
+(token budget of the waiting queue). The snapshot only carries
+`waitingRequests` as a count.
+
+**Chosen shape:** the bridge computes `max_tokens_potential` from its own
+per-request bookkeeping and reports `queued_token_budget = 0`
+(`num_waiting` still carries the queue depth). Budget used/max are derived
+truthfully from `kvBytesInUse / kvBytesPerToken` per the spec.
+**Suggested contract fix:** add `waitingTokens` and `maxTokensPotential` to
+the snapshot.
+
+## 5. Logprobs have no path to the provider's stream surface
+
+`CBv2Event.delta` carries `[CBv2TokenLogprob]?`, but the provider's
+`GenerationEvent` (`.chunk`/`.info`/`.error`) — the shape all downstream
+SSE/billing/attestation plumbing consumes — has no logprobs channel, and
+extending it would break exhaustive switches across the legacy path
+(violating "flag off ⇒ byte-identical").
+
+**Chosen shape:** the request side is fully translated (so the engine
+computes and could stream logprobs); the event side drops them at the bridge
+for now. Surfacing logprobs end-to-end needs an additive upstream
+`MLXServerGenerationEvent`/SSE change at integration time — out of scope for
+this workstream.
+
+## 6. Admission error granularity
+
+Legacy admission distinguishes queue-full (429) from budget-exhausted (503)
+via distinct message strings. `CBv2KVError` has only
+`capacityExhausted(needed:available:)` (plus `backendIneligible`), and its
+units (tokens vs bytes) are unspecified.
+
+**Chosen shape:** `capacityExhausted` maps to the canonical
+`token_budget_exhausted: request requires N tokens but only M available`
+string (→ `.tokenBudgetExhausted` → 503, retryable), treating the values as
+token counts. `backendIneligible` maps to a non-capacity message
+(→ `.generationFailed`, non-retryable) since retrying a statically
+ineligible backend is futile. **Suggested contract fix:** add a
+`queueFull` case (or a reason enum) and document the units of
+`capacityExhausted`.

--- a/docs/engine-v2/CONTRACT-ISSUES-H-provider.md
+++ b/docs/engine-v2/CONTRACT-ISSUES-H-provider.md
@@ -5,18 +5,18 @@ provider bridge, and the closest conforming shape chosen. None block
 integration; all are resolvable with small additive contract changes on the
 integration branch.
 
-## 1. `CBv2Engine` is not `Sendable`
+## 1. `CBv2Engine` is not `Sendable` — RESOLVED
 
 The provider consumes the engine from an actor (`EngineV2Bridge`) and from
 `Task`s spawned per request; `submit`/`cancel`/`capacity`/`shutdown` are by
-design the engine's cross-actor entry points. The contract declares
-`CBv2Engine: AnyObject` without `Sendable`, so any capture across a
-concurrency boundary trips Swift 6 strict checking.
+design the engine's cross-actor entry points. The contract originally
+declared `CBv2Engine: AnyObject` without `Sendable`, so any capture across
+a concurrency boundary tripped Swift 6 strict checking.
 
-**Chosen shape:** an `@unchecked Sendable` wrapper
-(`EngineV2EngineBox` in `EngineV2Bridge.swift`) documented against the
-engine's internal serialization. **Suggested contract fix:** declare
-`public protocol CBv2Engine: AnyObject, Sendable`.
+**Resolution:** the contract now declares
+`public protocol CBv2Engine: AnyObject, Sendable` (engine tip `8662159`).
+The interim `@unchecked Sendable` wrapper (`EngineV2EngineBox`) has been
+removed; the bridge holds and calls the engine directly.
 
 ## 2. No representation for "chosen-token logprob only"
 
@@ -31,20 +31,22 @@ token's logprob is still captured at the cost of one extra alternative.
 **Suggested contract fix:** split into `reportLogprobs: Bool` +
 `topLogprobs: Int`.
 
-## 3. No engine-loop progress / watchdog surface for `step_wedge`
+## 3. No engine-loop progress / watchdog surface for `step_wedge` — RESOLVED
 
 The spec asks for an `engine_v2.step_wedge` signal "from the v2 watchdog",
-but `CBv2Engine` exposes no step counter (legacy: `EngineCore.stepsExecuted`)
-and no watchdog callback; `CBv2CapacitySnapshot` carries only request/byte
-counts.
+but `CBv2Engine` originally exposed no step counter (legacy:
+`EngineCore.stepsExecuted`) and no watchdog callback;
+`CBv2CapacitySnapshot` carried only request/byte counts.
 
-**Chosen shape:** the bridge feeds the existing `WedgeMonitor` from
-bridge-observable signals — admits at submit, first tokens from the first
-non-empty `.delta`, and loop progress proxied by a monotonic count of
-received `CBv2Event`s (any event from any request proves the loop advanced).
-Wedge transitions emit `engine_health` telemetry with
-`operation=step_wedge`, `backend=engine_v2`. **Suggested contract fix:** add
-`stepsExecuted: Int` (or `lastStepAt`) to `CBv2CapacitySnapshot`.
+**Resolution:** `CBv2CapacitySnapshot.stepsExecuted` (engine tip `8662159`)
+is a monotonic engine step count published every step. The bridge samples
+it into the existing `WedgeMonitor` on the heartbeat cadence
+(`EngineV2Bridge+Capacity.backendSlotCapacity`), replacing the interim
+event-count proxy — a stalled engine stops incrementing it, which is the
+exact flatline term `wedgeSuspected` requires. Admits and first tokens are
+still recorded from bridge-observable signals; wedge transitions emit
+`engine_health` telemetry with `operation=step_wedge`,
+`backend=engine_v2`, unchanged.
 
 ## 4. `CBv2CapacitySnapshot` lacks worst-case + queued token views
 
@@ -60,19 +62,26 @@ truthfully from `kvBytesInUse / kvBytesPerToken` per the spec.
 **Suggested contract fix:** add `waitingTokens` and `maxTokensPotential` to
 the snapshot.
 
-## 5. Logprobs have no path to the provider's stream surface
+## 5. Logprobs have no path to the provider's stream surface — RESOLVED
 
 `CBv2Event.delta` carries `[CBv2TokenLogprob]?`, but the provider's
 `GenerationEvent` (`.chunk`/`.info`/`.error`) — the shape all downstream
 SSE/billing/attestation plumbing consumes — has no logprobs channel, and
 extending it would break exhaustive switches across the legacy path
-(violating "flag off ⇒ byte-identical").
+(violating "flag off ⇒ byte-identical"). The upstream
+`MLXServerGenerationEvent`/`OpenAIChatCompletionChunk` types likewise have
+no logprobs field.
 
-**Chosen shape:** the request side is fully translated (so the engine
-computes and could stream logprobs); the event side drops them at the bridge
-for now. Surfacing logprobs end-to-end needs an additive upstream
-`MLXServerGenerationEvent`/SSE change at integration time — out of scope for
-this workstream.
+**Resolution:** logprobs travel out-of-band (`EngineV2Logprobs.swift`).
+The bridge pump converts each delta's entries to the OpenAI streaming
+shape (`EngineV2Translation.sseTokenLogprobs`) and appends them to a
+per-request `EngineV2LogprobsChannel`; the coordinator inference handler
+drains the channel per SSE frame and splices
+`choices[0].logprobs = {"content": [...]}` into the next content-bearing
+chunk (`ProviderLoop.injectLogprobs`) before encryption. NOTE: the legacy
+engine never emitted logprobs, so this is the OpenAI-standard shape, not a
+legacy match; the standalone `--local` path (frames served inside the
+upstream router, no provider seam) still does not emit logprobs.
 
 ## 6. Admission error granularity
 

--- a/e2e/testbed/suite.go
+++ b/e2e/testbed/suite.go
@@ -74,6 +74,13 @@ type Provider struct {
 	Logger        *slog.Logger
 	ProviderIndex int
 	AuthDir       string
+	// StateDir is a per-instance temp dir that holds the provider's
+	// persisted state files (daemon-state.json, loaded-models.json).
+	// Without it every testbed provider shares the real
+	// ~/.darkbloom/loaded-models.json, so provider N+1 startup-preloads
+	// (and self-tests) whatever provider N was serving — cross-test
+	// state leakage that does not represent a fresh provider boot.
+	StateDir string
 
 	cmd    *os.Process
 	cancel context.CancelFunc
@@ -432,12 +439,29 @@ func (p *Provider) Start(ctx context.Context, coordinatorURL string, cfg Provide
 		args = append(args, "--model", cfg.ModelID)
 	}
 
+	// Isolate the provider's persisted state per testbed instance. The
+	// provider defaults these files to ~/.darkbloom/, which is shared by
+	// every provider process on the machine (and across CI runs on a
+	// persistent runner): test 1's provider would persist its loaded-model
+	// set there, and test 2's freshly-booted provider would then
+	// startup-preload + self-test it — behavior a fresh boot must not have.
+	if p.StateDir == "" {
+		stateDir, err := os.MkdirTemp("",
+			"darkbloom-testbed-state-"+strconv.Itoa(p.ProviderIndex)+"-")
+		if err != nil {
+			return fmt.Errorf("create provider state dir: %w", err)
+		}
+		p.StateDir = stateDir
+	}
+
 	cmd := execCommandContext(ctx, p.BinaryPath, args...)
 	cmd.Stdout = &logWriter{logger: p.Logger, prefix: "provider:stdout"}
 	cmd.Stderr = &logWriter{logger: p.Logger, prefix: "provider:stderr"}
 	cmd.Env = append(os.Environ(),
 		"DARKBLOOM_PID_FILE=/tmp/darkbloom-testbed-"+strconv.Itoa(p.ProviderIndex)+".pid",
 		"DARKBLOOM_NO_UPDATE_CHECK=1",
+		"DARKBLOOM_STATE_FILE="+filepath.Join(p.StateDir, "daemon-state.json"),
+		"DARKBLOOM_LOADED_MODELS_FILE="+filepath.Join(p.StateDir, "loaded-models.json"),
 	)
 	if cfg.AuthTokenPath != "" {
 		cmd.Env = append(cmd.Env, "DARKBLOOM_AUTH_TOKEN_PATH="+cfg.AuthTokenPath)
@@ -481,6 +505,9 @@ func (p *Provider) Stop() {
 	}
 	if p.AuthDir != "" {
 		_ = os.RemoveAll(p.AuthDir)
+	}
+	if p.StateDir != "" {
+		_ = os.RemoveAll(p.StateDir)
 	}
 	p.Logger.Info("provider stopped")
 }

--- a/provider-swift/Sources/ProviderCore/Config/ProviderConfig.swift
+++ b/provider-swift/Sources/ProviderCore/Config/ProviderConfig.swift
@@ -74,6 +74,12 @@ public struct BackendSettings: Sendable, Equatable, Codable {
     /// fixed 512-token production path. Enable with `adaptive_prefill = true`
     /// under `[backend]` in provider.toml.
     public var adaptivePrefill: Bool
+    /// Opt-in ContinuousBatchingV2 engine for the allowlisted model families
+    /// (gemma-4*, gpt-oss* — see `EngineV2Config`). Default false keeps the
+    /// legacy `BatchedEngine` path byte-identical. Enable with
+    /// `engine_v2 = true` under `[backend]` in provider.toml, or override
+    /// either way via env `DARKBLOOM_ENGINE_V2`.
+    public var engineV2: Bool
 
     public init(
         port: UInt16 = 8100,
@@ -83,7 +89,8 @@ public struct BackendSettings: Sendable, Equatable, Codable {
         idleTimeoutMins: UInt64 = 60,
         maxModelSlots: UInt64 = 3,
         kvQuant: Bool = false,
-        adaptivePrefill: Bool = false
+        adaptivePrefill: Bool = false,
+        engineV2: Bool = false
     ) {
         self.port = port
         self.model = model
@@ -93,6 +100,7 @@ public struct BackendSettings: Sendable, Equatable, Codable {
         self.maxModelSlots = maxModelSlots
         self.kvQuant = kvQuant
         self.adaptivePrefill = adaptivePrefill
+        self.engineV2 = engineV2
     }
 
     enum CodingKeys: String, CodingKey {
@@ -104,6 +112,7 @@ public struct BackendSettings: Sendable, Equatable, Codable {
         case maxModelSlots = "max_model_slots"
         case kvQuant = "kv_quant"
         case adaptivePrefill = "adaptive_prefill"
+        case engineV2 = "engine_v2"
     }
 
     public init(from decoder: Decoder) throws {
@@ -116,6 +125,7 @@ public struct BackendSettings: Sendable, Equatable, Codable {
         self.maxModelSlots = try container.decodeIfPresent(UInt64.self, forKey: .maxModelSlots) ?? 3
         self.kvQuant = try container.decodeIfPresent(Bool.self, forKey: .kvQuant) ?? false
         self.adaptivePrefill = try container.decodeIfPresent(Bool.self, forKey: .adaptivePrefill) ?? false
+        self.engineV2 = try container.decodeIfPresent(Bool.self, forKey: .engineV2) ?? false
     }
 }
 

--- a/provider-swift/Sources/ProviderCore/Config/ProviderConfig.swift
+++ b/provider-swift/Sources/ProviderCore/Config/ProviderConfig.swift
@@ -26,12 +26,27 @@ public struct ProviderSettings: Sendable, Equatable, Codable {
     /// When true (default), the watchdog relaunches the provider ~5 min after a
     /// crash. `false` opts out while keeping the provider installed.
     public var autoRestart: Bool
+    /// Maximum random delay (seconds) inserted between staging a verified
+    /// background auto-update bundle and beginning the drain+restart. Staggers
+    /// fleet restarts after a release so every provider is not cold at once (the
+    /// first_chunk_timeout storm at rollover). The delay sits strictly AFTER the
+    /// download/verify security checks and the provider keeps serving while it
+    /// waits. 0 disables jitter. Manual (`darkbloom update`) and startup updates
+    /// are never jittered. Set `update_jitter_seconds` under `[provider]`.
+    public var updateJitterSeconds: UInt64
 
-    public init(name: String, memoryReserveGB: UInt64 = 4, autoUpdate: Bool = true, autoRestart: Bool = true) {
+    public init(
+        name: String,
+        memoryReserveGB: UInt64 = 4,
+        autoUpdate: Bool = true,
+        autoRestart: Bool = true,
+        updateJitterSeconds: UInt64 = 300
+    ) {
         self.name = name
         self.memoryReserveGB = memoryReserveGB
         self.autoUpdate = autoUpdate
         self.autoRestart = autoRestart
+        self.updateJitterSeconds = updateJitterSeconds
     }
 
     enum CodingKeys: String, CodingKey {
@@ -39,6 +54,7 @@ public struct ProviderSettings: Sendable, Equatable, Codable {
         case memoryReserveGB = "memory_reserve_gb"
         case autoUpdate = "auto_update"
         case autoRestart = "auto_restart"
+        case updateJitterSeconds = "update_jitter_seconds"
     }
 
     public init(from decoder: Decoder) throws {
@@ -47,6 +63,7 @@ public struct ProviderSettings: Sendable, Equatable, Codable {
         self.memoryReserveGB = try container.decodeIfPresent(UInt64.self, forKey: .memoryReserveGB) ?? 4
         self.autoUpdate = try container.decodeIfPresent(Bool.self, forKey: .autoUpdate) ?? true
         self.autoRestart = try container.decodeIfPresent(Bool.self, forKey: .autoRestart) ?? true
+        self.updateJitterSeconds = try container.decodeIfPresent(UInt64.self, forKey: .updateJitterSeconds) ?? 300
     }
 }
 
@@ -80,6 +97,37 @@ public struct BackendSettings: Sendable, Equatable, Codable {
     /// `engine_v2 = true` under `[backend]` in provider.toml, or override
     /// either way via env `DARKBLOOM_ENGINE_V2`.
     public var engineV2: Bool
+    /// Startup model preload (default true). On boot the provider loads the
+    /// `preload_models` set (or, when that is empty, the models it was serving
+    /// before the last restart — see `LoadedModelsStore`) BEFORE registering
+    /// with the coordinator, so a release restart never advertises models it
+    /// hasn't warmed. `startup_preload = false` restores the old
+    /// register-immediately behavior.
+    public var startupPreload: Bool
+    /// Models to preload at startup, in this order. Empty (default) means
+    /// "the models that were loaded before the last restart" (persisted set,
+    /// loaded biggest-first). Ids not in the advertised model set are skipped
+    /// with a warning. Set `preload_models = ["..."]` under `[backend]`.
+    public var preloadModels: [String]
+    /// Upper bound (seconds) the provider defers coordinator registration while
+    /// the startup preload runs. If the preload finishes sooner, it registers
+    /// warm immediately; on timeout it registers anyway (availability beats
+    /// perfection — a lone provider for a model must still serve it cold) and
+    /// the remaining loads finish in the background. Default 120s covers a
+    /// ~26 GB weight load + engine warmup with margin.
+    public var startupPreloadTimeoutSecs: UInt64
+    /// After each startup preload, run a 1-token greedy decode through the real
+    /// serving path (v2 bridge when flagged, else the legacy scheduler) so
+    /// Metal JIT, compiled buckets, and the chat-template render are warm
+    /// before the first routed request. Default true. Failure is fail-open
+    /// (WARN telemetry, model stays advertised) unless
+    /// `startup_selftest_fail_closed = true`.
+    public var startupSelftest: Bool
+    /// When true, a model whose startup self-test decode fails is unloaded and
+    /// dropped from the advertised set for this run (fail-closed). Default
+    /// false: availability beats perfection — a self-test failure may be
+    /// transient and the model can still serve via the lazy-load path.
+    public var startupSelftestFailClosed: Bool
 
     public init(
         port: UInt16 = 8100,
@@ -90,7 +138,12 @@ public struct BackendSettings: Sendable, Equatable, Codable {
         maxModelSlots: UInt64 = 3,
         kvQuant: Bool = false,
         adaptivePrefill: Bool = false,
-        engineV2: Bool = false
+        engineV2: Bool = false,
+        startupPreload: Bool = true,
+        preloadModels: [String] = [],
+        startupPreloadTimeoutSecs: UInt64 = 120,
+        startupSelftest: Bool = true,
+        startupSelftestFailClosed: Bool = false
     ) {
         self.port = port
         self.model = model
@@ -101,6 +154,11 @@ public struct BackendSettings: Sendable, Equatable, Codable {
         self.kvQuant = kvQuant
         self.adaptivePrefill = adaptivePrefill
         self.engineV2 = engineV2
+        self.startupPreload = startupPreload
+        self.preloadModels = preloadModels
+        self.startupPreloadTimeoutSecs = startupPreloadTimeoutSecs
+        self.startupSelftest = startupSelftest
+        self.startupSelftestFailClosed = startupSelftestFailClosed
     }
 
     enum CodingKeys: String, CodingKey {
@@ -113,6 +171,11 @@ public struct BackendSettings: Sendable, Equatable, Codable {
         case kvQuant = "kv_quant"
         case adaptivePrefill = "adaptive_prefill"
         case engineV2 = "engine_v2"
+        case startupPreload = "startup_preload"
+        case preloadModels = "preload_models"
+        case startupPreloadTimeoutSecs = "startup_preload_timeout_secs"
+        case startupSelftest = "startup_selftest"
+        case startupSelftestFailClosed = "startup_selftest_fail_closed"
     }
 
     public init(from decoder: Decoder) throws {
@@ -126,6 +189,13 @@ public struct BackendSettings: Sendable, Equatable, Codable {
         self.kvQuant = try container.decodeIfPresent(Bool.self, forKey: .kvQuant) ?? false
         self.adaptivePrefill = try container.decodeIfPresent(Bool.self, forKey: .adaptivePrefill) ?? false
         self.engineV2 = try container.decodeIfPresent(Bool.self, forKey: .engineV2) ?? false
+        self.startupPreload = try container.decodeIfPresent(Bool.self, forKey: .startupPreload) ?? true
+        self.preloadModels = try container.decodeIfPresent([String].self, forKey: .preloadModels) ?? []
+        self.startupPreloadTimeoutSecs =
+            try container.decodeIfPresent(UInt64.self, forKey: .startupPreloadTimeoutSecs) ?? 120
+        self.startupSelftest = try container.decodeIfPresent(Bool.self, forKey: .startupSelftest) ?? true
+        self.startupSelftestFailClosed =
+            try container.decodeIfPresent(Bool.self, forKey: .startupSelftestFailClosed) ?? false
     }
 }
 

--- a/provider-swift/Sources/ProviderCore/Config/ProviderConfig.swift
+++ b/provider-swift/Sources/ProviderCore/Config/ProviderConfig.swift
@@ -91,12 +91,25 @@ public struct BackendSettings: Sendable, Equatable, Codable {
     /// fixed 512-token production path. Enable with `adaptive_prefill = true`
     /// under `[backend]` in provider.toml.
     public var adaptivePrefill: Bool
-    /// Opt-in ContinuousBatchingV2 engine for the allowlisted model families
-    /// (gemma-4*, gpt-oss* — see `EngineV2Config`). Default false keeps the
-    /// legacy `BatchedEngine` path byte-identical. Enable with
-    /// `engine_v2 = true` under `[backend]` in provider.toml, or override
-    /// either way via env `DARKBLOOM_ENGINE_V2`.
+    /// ContinuousBatchingV2 engine for the allowlisted models (the exact
+    /// production checkpoints — see `EngineV2Config.defaultModelAllowlist`).
+    /// **Default true as of v0.7.0**: v2 ships on by default for the
+    /// allowlisted models; every other model keeps the legacy
+    /// `BatchedEngine` path byte-identical. Rollback is the env kill
+    /// switch `DARKBLOOM_ENGINE_V2=0` (absolute — beats config, per-box,
+    /// no release needed) or a release rollback. v2 init failure falls
+    /// back to legacy with WARN `engine_health` telemetry (model id +
+    /// error reason).
     public var engineV2: Bool
+    /// Opt-in compiled decode for the LEGACY engine (default false). The
+    /// mlx-swift-lm library defaults its `DARKBLOOM_COMPILED_DECODE` env
+    /// gate ON; the provider forces it OFF at startup unless this is true
+    /// or the operator set the env var explicitly (which always wins —
+    /// see `LegacyCompiledDecodeGate`). Off keeps release behavior
+    /// identical to prod v0.6.30 (the compiled-decode rollback):
+    /// no compile-on-first-dispatch cold start, no B=1 window-straddle
+    /// divergence. Single-stream speedups ship via the v2 engine instead.
+    public var legacyCompiledDecode: Bool
     /// Startup model preload (default true). On boot the provider loads the
     /// `preload_models` set (or, when that is empty, the models it was serving
     /// before the last restart — see `LoadedModelsStore`) BEFORE registering
@@ -138,7 +151,8 @@ public struct BackendSettings: Sendable, Equatable, Codable {
         maxModelSlots: UInt64 = 3,
         kvQuant: Bool = false,
         adaptivePrefill: Bool = false,
-        engineV2: Bool = false,
+        engineV2: Bool = true,
+        legacyCompiledDecode: Bool = false,
         startupPreload: Bool = true,
         preloadModels: [String] = [],
         startupPreloadTimeoutSecs: UInt64 = 120,
@@ -154,6 +168,7 @@ public struct BackendSettings: Sendable, Equatable, Codable {
         self.kvQuant = kvQuant
         self.adaptivePrefill = adaptivePrefill
         self.engineV2 = engineV2
+        self.legacyCompiledDecode = legacyCompiledDecode
         self.startupPreload = startupPreload
         self.preloadModels = preloadModels
         self.startupPreloadTimeoutSecs = startupPreloadTimeoutSecs
@@ -171,6 +186,7 @@ public struct BackendSettings: Sendable, Equatable, Codable {
         case kvQuant = "kv_quant"
         case adaptivePrefill = "adaptive_prefill"
         case engineV2 = "engine_v2"
+        case legacyCompiledDecode = "legacy_compiled_decode"
         case startupPreload = "startup_preload"
         case preloadModels = "preload_models"
         case startupPreloadTimeoutSecs = "startup_preload_timeout_secs"
@@ -188,7 +204,9 @@ public struct BackendSettings: Sendable, Equatable, Codable {
         self.maxModelSlots = try container.decodeIfPresent(UInt64.self, forKey: .maxModelSlots) ?? 3
         self.kvQuant = try container.decodeIfPresent(Bool.self, forKey: .kvQuant) ?? false
         self.adaptivePrefill = try container.decodeIfPresent(Bool.self, forKey: .adaptivePrefill) ?? false
-        self.engineV2 = try container.decodeIfPresent(Bool.self, forKey: .engineV2) ?? false
+        self.engineV2 = try container.decodeIfPresent(Bool.self, forKey: .engineV2) ?? true
+        self.legacyCompiledDecode =
+            try container.decodeIfPresent(Bool.self, forKey: .legacyCompiledDecode) ?? false
         self.startupPreload = try container.decodeIfPresent(Bool.self, forKey: .startupPreload) ?? true
         self.preloadModels = try container.decodeIfPresent([String].self, forKey: .preloadModels) ?? []
         self.startupPreloadTimeoutSecs =

--- a/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClient.swift
+++ b/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClient.swift
@@ -255,6 +255,19 @@ public actor CoordinatorClient {
         closeCurrentConnection()
     }
 
+    /// Tear down the current connection (clean close frame) WITHOUT setting
+    /// `shutdownRequested`, so the reconnect loop re-runs `sendRegistration`
+    /// with the CURRENT advertised set. Used when the advertised set SHRINKS
+    /// after registration (e.g. a startup self-test retirement under
+    /// `startup_selftest_fail_closed`): `models_update` is additive, so a
+    /// fresh `register` is the existing wire mechanism that communicates a
+    /// removal. Same reconnect path the coordinator handles on any network
+    /// blip; no-op when no connection is up (registration hasn't happened
+    /// yet — the register that follows will already carry the current set).
+    public func forceReconnect() {
+        closeCurrentConnection()
+    }
+
     /// Record refreshed per-model weight hashes for use in future
     /// (re)registrations. Called by the provider loop after a model (re)load
     /// recomputes the on-disk weight hash. See `modelWeightHashOverrides`.

--- a/provider-swift/Sources/ProviderCore/Inference/BatchScheduler+B1FastPath.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/BatchScheduler+B1FastPath.swift
@@ -310,7 +310,8 @@ extension BatchScheduler {
                 continuation.yield(.info(
                     promptTokens: usage.promptTokens,
                     completionTokens: usage.completionTokens,
-                    tokensPerSecond: usage.tps))
+                    tokensPerSecond: usage.tps,
+                    finishReason: nil))
             }
             if cancelled {
                 continuation.yield(.error("request cancelled"))
@@ -318,10 +319,14 @@ extension BatchScheduler {
                 continuation.yield(.error(
                     "fast path does not support tool calls; please retry"))
             } else {
+                // `container.generate` stops at maxTokens without surfacing a
+                // reason; a decode that used the full budget is a truncation
+                // (finish_reason "length"), matching the engine paths.
                 continuation.yield(.info(
                     promptTokens: usage.promptTokens,
                     completionTokens: usage.completionTokens,
-                    tokensPerSecond: usage.tps))
+                    tokensPerSecond: usage.tps,
+                    finishReason: usage.completionTokens >= maxTokens ? "length" : "stop"))
             }
             continuation.finish()
             await scheduler.clearFastPathTask(id)

--- a/provider-swift/Sources/ProviderCore/Inference/BatchScheduler+EngineBridge.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/BatchScheduler+EngineBridge.swift
@@ -141,7 +141,8 @@ extension BatchScheduler {
                                 continuation.yield(.info(
                                     promptTokens: usage.promptTokens,
                                     completionTokens: usage.completionTokens,
-                                    tokensPerSecond: usage.tps
+                                    tokensPerSecond: usage.tps,
+                                    finishReason: nil
                                 ))
                             }
                             // Distinct pending-timeout vs. client-cancel
@@ -165,10 +166,14 @@ extension BatchScheduler {
                         // Emit the authoritative (max of observed-vs-terminal)
                         // counts from recordFinish, not the raw terminal output
                         // — the terminal can under-report and zero out billing.
+                        // Thread the engine's finish reason ("stop"/"length")
+                        // so a max_tokens truncation reaches the client as
+                        // finish_reason "length" (abort was handled above).
                         continuation.yield(.info(
                             promptTokens: usage.promptTokens,
                             completionTokens: usage.completionTokens,
-                            tokensPerSecond: usage.tps
+                            tokensPerSecond: usage.tps,
+                            finishReason: output.finishReason
                         ))
                     }
                     // Wedge instrumentation: this request terminated. If it never

--- a/provider-swift/Sources/ProviderCore/Inference/BatchScheduler+Testing.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/BatchScheduler+Testing.swift
@@ -29,6 +29,15 @@ extension BatchScheduler {
         self.fp16KVBytesPerToken = fp16KVBytesPerToken
     }
 
+    /// TEST SEAM: pin the resident-weight figure without loading a model, so
+    /// the v2 slot factory's FLEET-WIDE KV-capacity derivation
+    /// (`EngineV2KVSizing.engineKVBytesCapacity`) can be exercised with
+    /// scripted hooks across multiple co-resident slots. Not used in
+    /// production.
+    func _setModelWeightBytesForTest(_ bytes: Int) {
+        self.modelWeightBytes = bytes
+    }
+
     /// TEST SEAM: install a checkpoint manager + capture hook onto the live
     /// engine, replicating exactly what `makeBatchedEngine` wires for a
     /// `.checkpoint` model. Production builds the manager with an SE-wrapped

--- a/provider-swift/Sources/ProviderCore/Inference/BatchScheduler+Testing.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/BatchScheduler+Testing.swift
@@ -18,6 +18,17 @@ extension BatchScheduler {
         _forceEnginePrefixCacheActiveForTest = active
     }
 
+    /// TEST SEAM: pin the live per-token KV rates without loading a model, so
+    /// the v2 slot factory's kv_quant → fp16 sizing decision
+    /// (`EngineV2KVSizing`) can be exercised end-to-end with scripted hooks.
+    /// `kvBytesPerToken` is the quantized (live) rate; `fp16KVBytesPerToken`
+    /// is the un-quantized cost the v2 caches actually consume. Not used in
+    /// production.
+    func _setKVRatesForTest(kvBytesPerToken: Int, fp16KVBytesPerToken: Int) {
+        self.kvBytesPerToken = kvBytesPerToken
+        self.fp16KVBytesPerToken = fp16KVBytesPerToken
+    }
+
     /// TEST SEAM: install a checkpoint manager + capture hook onto the live
     /// engine, replicating exactly what `makeBatchedEngine` wires for a
     /// `.checkpoint` model. Production builds the manager with an SE-wrapped

--- a/provider-swift/Sources/ProviderCore/Inference/BatchSchedulerTypes.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/BatchSchedulerTypes.swift
@@ -18,7 +18,15 @@ import MLXLMCommon
 /// Events emitted by the scheduler for a single inference request.
 public enum GenerationEvent: Sendable {
     case chunk(String)
-    case info(promptTokens: Int, completionTokens: Int, tokensPerSecond: Double)
+    /// Terminal usage. `finishReason` is the OpenAI wire value ("stop",
+    /// "length") when the engine reported one; nil maps to "stop"
+    /// downstream. Threaded end-to-end (legacy `RequestOutput.finishReason`,
+    /// v2 `CBv2FinishReason.length`) so a max_tokens truncation reaches
+    /// clients as `finish_reason: "length"` instead of being flattened
+    /// to "stop".
+    case info(
+        promptTokens: Int, completionTokens: Int, tokensPerSecond: Double,
+        finishReason: String?)
     case error(String)
 }
 

--- a/provider-swift/Sources/ProviderCore/Inference/ChatRequest.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/ChatRequest.swift
@@ -32,6 +32,15 @@ public struct ChatCompletionRequest: Codable, Sendable {
     /// checkpoint tier). Rides INSIDE the E2E-sealed body, so the coordinator
     /// never sees it; the provider reads it after decryption.
     public let prompt_cache_key: String?
+    /// OpenAI `logit_bias`: token-id (STRING keys on the wire) → additive
+    /// bias. Consumed by the v2 engine path (`EngineV2Translation`); the
+    /// legacy engine path ignores it (unchanged behavior).
+    public let logit_bias: [String: Float]?
+    /// OpenAI `logprobs` switch. v2 engine path only; ignored by legacy.
+    public let logprobs: Bool?
+    /// OpenAI `top_logprobs` (0–20, meaningful when `logprobs == true`).
+    /// v2 engine path only; ignored by legacy.
+    public let top_logprobs: Int?
 
     public init(
         model: String,
@@ -50,7 +59,10 @@ public struct ChatCompletionRequest: Codable, Sendable {
         tool_choice: ToolChoice? = nil,
         response_format: ResponseFormat? = nil,
         user: String? = nil,
-        prompt_cache_key: String? = nil
+        prompt_cache_key: String? = nil,
+        logit_bias: [String: Float]? = nil,
+        logprobs: Bool? = nil,
+        top_logprobs: Int? = nil
     ) {
         self.model = model
         self.messages = messages
@@ -69,6 +81,9 @@ public struct ChatCompletionRequest: Codable, Sendable {
         self.response_format = response_format
         self.user = user
         self.prompt_cache_key = prompt_cache_key
+        self.logit_bias = logit_bias
+        self.logprobs = logprobs
+        self.top_logprobs = top_logprobs
     }
 
     /// Per-tenant prefix-cache scope for this request. Policy (provider-only):

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge+Capacity.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge+Capacity.swift
@@ -125,6 +125,14 @@ extension EngineV2Bridge {
         active.count
     }
 
+    /// This engine's KV admission ceiling in bytes (construction-fixed).
+    /// Read by the slot factory when sizing a LATER v2 engine so that
+    /// Σ(engine ceilings) stays within the process-wide KV budget — see
+    /// `EngineV2KVSizing.engineKVBytesCapacity`.
+    public func engineKVBytesCapacity() -> Int {
+        engine.capacity().kvBytesCapacity
+    }
+
     // MARK: - engine_v2.step_wedge
 
     /// Emit an `engine_health` telemetry event on a wedge-suspected

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge+Capacity.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge+Capacity.swift
@@ -10,10 +10,13 @@
 //     (`kvBytesInUse / kvBytesPerToken`), not worst-case reservations.
 //
 //   * `engine_v2.step_wedge`: the same `WedgeMonitor` primitive the legacy
-//     engine uses (admits vs first tokens vs loop progress), fed from
-//     bridge-observable signals, emitted through the existing
-//     `engine_health` telemetry plumbing with `backend=engine_v2` on a
-//     wedge-suspected TRANSITION edge (both directions).
+//     engine uses (admits vs first tokens vs loop progress), with loop
+//     progress sampled from the engine's own monotonic
+//     `CBv2CapacitySnapshot.stepsExecuted` counter (published every step —
+//     the direct analogue of `EngineCore.stepsExecuted`), emitted through
+//     the existing `engine_health` telemetry plumbing with
+//     `backend=engine_v2` on a wedge-suspected TRANSITION edge (both
+//     directions).
 
 import Foundation
 import MLXLMCommon
@@ -26,12 +29,15 @@ extension EngineV2Bridge {
     public func backendSlotCapacity(
         now: ContinuousClock.Instant = .now
     ) -> BackendSlotCapacity {
-        let snapshot = engineBox.capacity()
+        let snapshot = engine.capacity()
 
         // Sample loop progress into the wedge monitor on the heartbeat
         // cadence (mirrors `sampleEngineSteps`), then emit the step_wedge
-        // transition signal if the verdict flipped.
-        wedgeMonitor.sampleSteps(eventsObserved, now: now)
+        // transition signal if the verdict flipped. `stepsExecuted` is the
+        // engine's own monotonic step counter — a stalled engine stops
+        // incrementing it, which is exactly the flatline term
+        // `wedgeSuspected` requires.
+        wedgeMonitor.sampleSteps(snapshot.stepsExecuted, now: now)
         emitStepWedgeTransitionIfNeeded(now: now)
 
         // Worst-case potential is bridge bookkeeping (the snapshot has no

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge+Capacity.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge+Capacity.swift
@@ -1,0 +1,134 @@
+// Copyright © 2026 Eigen Labs.
+//
+// Heartbeat capacity + engine-health signals for the v2 bridge:
+//
+//   * `backendSlotCapacity()` maps the engine's `CBv2CapacitySnapshot`
+//     into the EXISTING `BackendSlotCapacity` protocol fields — no wire
+//     changes, coordinator compatibility preserved. Numbers become
+//     truthful: `active_tokens` is the engine's real KV-resident token
+//     count and the budget fields are BYTES-derived
+//     (`kvBytesInUse / kvBytesPerToken`), not worst-case reservations.
+//
+//   * `engine_v2.step_wedge`: the same `WedgeMonitor` primitive the legacy
+//     engine uses (admits vs first tokens vs loop progress), fed from
+//     bridge-observable signals, emitted through the existing
+//     `engine_health` telemetry plumbing with `backend=engine_v2` on a
+//     wedge-suspected TRANSITION edge (both directions).
+
+import Foundation
+import MLXLMCommon
+
+extension EngineV2Bridge {
+
+    /// One heartbeat slot for this bridge's model, shaped exactly like the
+    /// legacy scheduler's slot (same protocol fields, same state strings)
+    /// so the coordinator's admission/routing math is engine-agnostic.
+    public func backendSlotCapacity(
+        now: ContinuousClock.Instant = .now
+    ) -> BackendSlotCapacity {
+        let snapshot = engineBox.capacity()
+
+        // Sample loop progress into the wedge monitor on the heartbeat
+        // cadence (mirrors `sampleEngineSteps`), then emit the step_wedge
+        // transition signal if the verdict flipped.
+        wedgeMonitor.sampleSteps(eventsObserved, now: now)
+        emitStepWedgeTransitionIfNeeded(now: now)
+
+        // Worst-case potential is bridge bookkeeping (the snapshot has no
+        // per-request max-token view); active tokens are engine truth.
+        var maxTokensPotential: Int64 = 0
+        for state in active.values {
+            maxTokensPotential += Int64(state.promptTokens + state.maxTokens)
+        }
+
+        // Truthful bytes-derived token budget. When the per-token KV cost
+        // is unknown (0), fall back to the engine's token counts rather
+        // than inventing a budget.
+        let budgetUsed: Int64
+        let budgetMax: Int64
+        if kvBytesPerToken > 0 {
+            budgetUsed = Int64(snapshot.kvBytesInUse / kvBytesPerToken)
+            budgetMax = Int64(snapshot.kvBytesCapacity / kvBytesPerToken)
+        } else {
+            budgetUsed = Int64(snapshot.activeTokens)
+            budgetMax = 0
+        }
+
+        let state: String
+        if wedgeMonitor.wedgeSuspected(now: now) {
+            // Same truthful-derouting contract as the legacy heartbeat: a
+            // wedged slot must not keep advertising healthy.
+            state = "crashed"
+        } else {
+            state = snapshot.activeRequests > 0 ? "running" : "idle"
+        }
+
+        return BackendSlotCapacity(
+            model: modelId,
+            state: state,
+            numRunning: UInt32(clamping: max(0, snapshot.activeRequests)),
+            numWaiting: UInt32(clamping: max(0, snapshot.waitingRequests)),
+            activeTokens: Int64(snapshot.activeTokens),
+            maxTokensPotential: maxTokensPotential,
+            maxConcurrency: UInt32(clamping: maxConcurrentRequests),
+            observedDecodeTps: observedDecodeTpsEwma,
+            observedPrefillTps: 0,
+            activeTokenBudgetUsed: budgetUsed,
+            activeTokenBudgetMax: budgetMax,
+            queuedTokenBudget: 0,
+            kvBytesPerToken: Int64(kvBytesPerToken),
+            modelLoadTimeMs: 0,
+            stepsExecuted: Int64(wedgeMonitor.lastStepsSample),
+            admits: Int64(wedgeMonitor.admits),
+            firstTokensEmitted: Int64(wedgeMonitor.firstTokens),
+            secondsSinceLastStep: wedgeMonitor.secondsSinceLastStep(now: now),
+            secondsSinceLastFirstToken: wedgeMonitor.secondsSinceLastFirstToken(now: now),
+            wedgeSuspected: wedgeMonitor.wedgeSuspected(now: now)
+        )
+    }
+
+    /// Number of requests currently active on this bridge (heartbeat
+    /// aggregate `inferenceActive` input).
+    public func activeRequestCount() -> Int {
+        active.count
+    }
+
+    // MARK: - engine_v2.step_wedge
+
+    /// Emit an `engine_health` telemetry event on a wedge-suspected
+    /// transition (both edges), tagged `backend=engine_v2` with
+    /// `operation=step_wedge` / `step_wedge_recovered`. Runs on the
+    /// heartbeat path — off the inference hot path — and only on edges so
+    /// it stays cheap fleet-wide.
+    func emitStepWedgeTransitionIfNeeded(now: ContinuousClock.Instant) {
+        let suspected = wedgeMonitor.wedgeSuspected(now: now)
+        guard suspected != lastWedgeSuspectedEmitted else { return }
+        lastWedgeSuspectedEmitted = suspected
+
+        let operation = suspected ? "step_wedge" : "step_wedge_recovered"
+        let event = TelemetryEvent(
+            source: .provider,
+            severity: suspected ? .warn : .info,
+            kind: .engineHealth,
+            message: suspected
+                ? "engine_v2: step wedge suspected"
+                : "engine_v2: step wedge recovered"
+        ).withFields([
+            "component": .string("engine"),
+            "operation": .string(operation),
+            "backend": .string("engine_v2"),
+            "model": .string(modelId),
+            "steps_executed": .int(wedgeMonitor.lastStepsSample),
+            "admits": .int(wedgeMonitor.admits),
+            "first_tokens_emitted": .int(wedgeMonitor.firstTokens),
+            "consecutive_admits_without_first_token":
+                .int(wedgeMonitor.consecutiveAdmitsWithoutFirstToken),
+            "seconds_since_last_step": .double(wedgeMonitor.secondsSinceLastStep(now: now)),
+            "seconds_since_last_first_token":
+                .double(wedgeMonitor.secondsSinceLastFirstToken(now: now)),
+            "num_running": .int(active.count),
+            "wedge_suspected": .bool(suspected),
+        ])
+        emit(event)
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge+Capacity.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge+Capacity.swift
@@ -28,8 +28,19 @@ extension EngineV2Bridge {
     /// One heartbeat slot for this bridge's model, shaped exactly like the
     /// legacy scheduler's slot (same protocol fields, same state strings)
     /// so the coordinator's admission/routing math is engine-agnostic.
+    ///
+    /// `kvBytesBudgetClamp` (round-3 PR#499 P2): the engine's admission
+    /// ceiling is construction-fixed, so when ANOTHER model loads later the
+    /// snapshot's `kvBytesCapacity` goes stale against fleet reality. The
+    /// heartbeat caller (`EngineV2Runtime.capacitySummary`) recomputes this
+    /// bridge's CURRENT byte budget from live fleet residency
+    /// (`EngineV2KVSizing.liveEngineKVBytesBudget`) and passes it here; the
+    /// REPORTED `activeTokenBudgetMax` is clamped to it so the coordinator
+    /// stops routing requests the shared KV gate would reject. nil ⇒ no
+    /// clamp (unit tests / callers without fleet context).
     public func backendSlotCapacity(
-        now: ContinuousClock.Instant = .now
+        now: ContinuousClock.Instant = .now,
+        kvBytesBudgetClamp: Int? = nil
     ) -> BackendSlotCapacity {
         let snapshot = engine.capacity()
 
@@ -74,17 +85,27 @@ extension EngineV2Bridge {
         //                           reservation the admission gate must see —
         //                           conservative for sliding-window models,
         //                           whose engine ledger plateaus per layer)
-        //   activeTokenBudgetMax  ← kvBytesCapacity / fp16 rate (the engine's
-        //                           admission ceiling in tokens; 0 when the
-        //                           rate is unknown ⇒ the coordinator's
-        //                           budget gate disengages rather than
-        //                           trusting an invented budget)
+        //   activeTokenBudgetMax  ← min(kvBytesCapacity, live fleet clamp) /
+        //                           fp16 rate (the engine's admission ceiling
+        //                           in tokens, clamped to the sizing
+        //                           function's CURRENT answer when the caller
+        //                           supplies fleet context — see the doc
+        //                           comment above; 0 when the rate is
+        //                           unknown ⇒ the coordinator's budget gate
+        //                           disengages rather than trusting an
+        //                           invented budget)
         //   queuedTokenBudget     ← 0 (engine-WAITING requests are already
         //                           inside the committed sum above — the
         //                           bridge does not split running/waiting)
         let budgetUsed = maxTokensPotential
+        let reportedKVBytesCapacity: Int
+        if let kvBytesBudgetClamp {
+            reportedKVBytesCapacity = min(snapshot.kvBytesCapacity, max(0, kvBytesBudgetClamp))
+        } else {
+            reportedKVBytesCapacity = snapshot.kvBytesCapacity
+        }
         let budgetMax: Int64 =
-            kvBytesPerToken > 0 ? Int64(snapshot.kvBytesCapacity / kvBytesPerToken) : 0
+            kvBytesPerToken > 0 ? Int64(reportedKVBytesCapacity / kvBytesPerToken) : 0
 
         let state: String
         if wedgeMonitor.wedgeSuspected(now: now) {
@@ -128,7 +149,9 @@ extension EngineV2Bridge {
     /// This engine's KV admission ceiling in bytes (construction-fixed).
     /// Read by the slot factory when sizing a LATER v2 engine so that
     /// Σ(engine ceilings) stays within the process-wide KV budget — see
-    /// `EngineV2KVSizing.engineKVBytesCapacity`.
+    /// `EngineV2KVSizing.engineKVBytesCapacity` — and by the heartbeat
+    /// (`EngineV2Runtime.capacitySummary`) as the grant input to the live
+    /// budget clamp (`EngineV2KVSizing.liveEngineKVBytesBudget`).
     public func engineKVBytesCapacity() -> Int {
         engine.capacity().kvBytesCapacity
     }

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge+Capacity.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge+Capacity.swift
@@ -4,10 +4,12 @@
 //
 //   * `backendSlotCapacity()` maps the engine's `CBv2CapacitySnapshot`
 //     into the EXISTING `BackendSlotCapacity` protocol fields — no wire
-//     changes, coordinator compatibility preserved. Numbers become
-//     truthful: `active_tokens` is the engine's real KV-resident token
-//     count and the budget fields are BYTES-derived
-//     (`kvBytesInUse / kvBytesPerToken`), not worst-case reservations.
+//     changes, coordinator compatibility preserved. `active_tokens` is the
+//     engine's real KV-resident token count (engine truth); the BUDGET
+//     fields carry the same committed/worst-case semantics the legacy
+//     scheduler reports, because that is the contract the coordinator's
+//     admission gate assumes — see the field-mapping table inside
+//     `backendSlotCapacity()`.
 //
 //   * `engine_v2.step_wedge`: the same `WedgeMonitor` primitive the legacy
 //     engine uses (admits vs first tokens vs loop progress), with loop
@@ -47,18 +49,42 @@ extension EngineV2Bridge {
             maxTokensPotential += Int64(state.promptTokens + state.maxTokens)
         }
 
-        // Truthful bytes-derived token budget. When the per-token KV cost
-        // is unknown (0), fall back to the engine's token counts rather
-        // than inventing a budget.
-        let budgetUsed: Int64
-        let budgetMax: Int64
-        if kvBytesPerToken > 0 {
-            budgetUsed = Int64(snapshot.kvBytesInUse / kvBytesPerToken)
-            budgetMax = Int64(snapshot.kvBytesCapacity / kvBytesPerToken)
-        } else {
-            budgetUsed = Int64(snapshot.activeTokens)
-            budgetMax = 0
-        }
+        // Budget fields — SEMANTICS ALIGNED WITH THE LEGACY SCHEDULER
+        // (round-2 PR#499 P2). The coordinator's token-budget admission gate
+        // is (coordinator/registry/scheduler.go):
+        //
+        //     activeTokenBudgetUsed + queuedTokenBudget + requestTokens
+        //         <= activeTokenBudgetMax        (only when budgetMax > 0)
+        //
+        // and it expects `used` to carry the COMMITTED worst-case reservation
+        // of every accepted request — the legacy scheduler reports
+        // Σ(promptTokens + maxTokens) over active bridges
+        // (`BatchScheduler.activeTokenBudgetUsed`). Reporting the engine's
+        // MATERIALIZED KV here instead (a long-max_tokens request that has
+        // only prefilled a small prefix) leaves the remaining growth of
+        // accepted requests unprotected: the gate does not consult
+        // `max_tokens_potential`, so the coordinator over-routes until the
+        // engine starts rejecting post-acceptance. Field mapping (existing
+        // wire fields only — no protocol change):
+        //
+        //   activeTokens          ← snapshot.activeTokens (ENGINE TRUTH: the
+        //                           real KV-resident token count)
+        //   maxTokensPotential    ← Σ(prompt + maxTokens)  (worst case)
+        //   activeTokenBudgetUsed ← Σ(prompt + maxTokens)  (the committed
+        //                           reservation the admission gate must see —
+        //                           conservative for sliding-window models,
+        //                           whose engine ledger plateaus per layer)
+        //   activeTokenBudgetMax  ← kvBytesCapacity / fp16 rate (the engine's
+        //                           admission ceiling in tokens; 0 when the
+        //                           rate is unknown ⇒ the coordinator's
+        //                           budget gate disengages rather than
+        //                           trusting an invented budget)
+        //   queuedTokenBudget     ← 0 (engine-WAITING requests are already
+        //                           inside the committed sum above — the
+        //                           bridge does not split running/waiting)
+        let budgetUsed = maxTokensPotential
+        let budgetMax: Int64 =
+            kvBytesPerToken > 0 ? Int64(snapshot.kvBytesCapacity / kvBytesPerToken) : 0
 
         let state: String
         if wedgeMonitor.wedgeSuspected(now: now) {

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge+Translation.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge+Translation.swift
@@ -1,0 +1,151 @@
+// Copyright © 2026 Eigen Labs.
+//
+// Pure translation between the provider's OpenAI-shaped
+// `ChatCompletionRequest` and the frozen v2 engine contract
+// (`CBv2Request` / `CBv2SamplingParams`), plus the admission-error →
+// canonical capacity-string mapping. Everything here is static and
+// side-effect-free so it can be unit-tested field-by-field without an
+// engine or tokenizer.
+
+import Foundation
+import MLXLMCommon
+
+enum EngineV2Translation {
+
+    // MARK: - Request translation
+
+    /// Build the `CBv2Request` for a tokenized prompt.
+    ///
+    /// * `maxTokens` defaulting matches the legacy path
+    ///   (`BatchScheduler.resolvedMaxTokens`: `request.max_tokens ??
+    ///   defaultMaxTokens`).
+    /// * `stopTokens` is the bridge-resolved EOS set (see
+    ///   ``stopTokenIds(eosTokenIds:tokenizerEOSTokenId:extraEOSTokens:convertTokenToId:)``)
+    ///   — resolved once at engine construction per the contract, so B=1
+    ///   and batched requests stop identically.
+    /// * `stopStrings` carries the request's `stop` sequences; the v2
+    ///   engine matches them against held-back detokenized text.
+    static func cbv2Request(
+        id: CBv2RequestID,
+        promptTokens: [Int],
+        request: ChatCompletionRequest,
+        defaultMaxTokens: Int,
+        stopTokenIds: Set<Int>
+    ) -> CBv2Request {
+        CBv2Request(
+            id: id,
+            promptTokens: promptTokens,
+            sampling: samplingParams(from: request),
+            maxTokens: request.max_tokens ?? defaultMaxTokens,
+            stopTokens: stopTokenIds,
+            stopStrings: request.stop?.asArray ?? [],
+            priority: 0
+        )
+    }
+
+    /// Per-request sampling translation. Defaults deliberately mirror the
+    /// legacy engine path (temperature `?? 0.0` — greedy — exactly as
+    /// `BatchScheduler.submit`; unset knobs collapse to the contract's
+    /// no-op values so the v2 sampler applies no transform the legacy
+    /// sampler would not have applied).
+    static func samplingParams(from request: ChatCompletionRequest) -> CBv2SamplingParams {
+        CBv2SamplingParams(
+            temperature: request.temperature ?? 0.0,
+            topP: request.top_p ?? 1.0,
+            topK: request.top_k ?? 0,
+            minP: 0,
+            repetitionPenalty: request.repetition_penalty ?? 1.0,
+            frequencyPenalty: request.frequency_penalty ?? 0,
+            presencePenalty: request.presence_penalty ?? 0,
+            seed: request.seed,
+            logitBias: parseLogitBias(request.logit_bias),
+            topLogprobs: topLogprobs(
+                logprobs: request.logprobs, topLogprobs: request.top_logprobs
+            )
+        )
+    }
+
+    /// OpenAI `logit_bias` arrives as a JSON object keyed by token-id
+    /// STRINGS (`{"50256": -100}`); the contract wants `[Int: Float]`.
+    /// Non-numeric keys are dropped (never guessed) — an invalid key can't
+    /// silently bias a random token id.
+    static func parseLogitBias(_ raw: [String: Float]?) -> [Int: Float] {
+        guard let raw, !raw.isEmpty else { return [:] }
+        var out: [Int: Float] = [:]
+        out.reserveCapacity(raw.count)
+        for (key, value) in raw {
+            guard let id = Int(key.trimmingCharacters(in: .whitespaces)), id >= 0 else {
+                continue
+            }
+            out[id] = value
+        }
+        return out
+    }
+
+    /// OpenAI `logprobs`/`top_logprobs` → contract `topLogprobs`.
+    ///
+    /// CONTRACT NOTE (see docs/engine-v2/CONTRACT-ISSUES-H-provider.md):
+    /// `CBv2SamplingParams.topLogprobs == 0` means "no logprobs at all", so
+    /// the OpenAI shape "logprobs=true, top_logprobs omitted/0" (chosen
+    /// token's logprob only, no alternatives) has no exact representation.
+    /// Closest conforming mapping: request 1 top alternative so the chosen
+    /// token's logprob is still captured. `top_logprobs` is clamped to the
+    /// OpenAI wire maximum of 20.
+    static func topLogprobs(logprobs: Bool?, topLogprobs: Int?) -> Int {
+        guard logprobs == true else { return 0 }
+        let requested = topLogprobs ?? 0
+        return min(20, max(1, requested))
+    }
+
+    // MARK: - Stop resolution (buildStopTokenIds semantics)
+
+    /// Reimplements `MLXLMCommon.buildStopTokenIds` (private upstream) so
+    /// the v2 stop set is resolved from the SAME three sources the B=1
+    /// generate loop uses: the model configuration's `eosTokenIds`, the
+    /// tokenizer's own EOS id, and the configuration's `extraEOSTokens`
+    /// (converted via the tokenizer). Resolution happens once at engine
+    /// construction — identical for B=1 and batched requests.
+    static func stopTokenIds(
+        eosTokenIds: Set<Int>,
+        tokenizerEOSTokenId: Int?,
+        extraEOSTokens: [String],
+        convertTokenToId: (String) -> Int?
+    ) -> Set<Int> {
+        var stopTokenIds = eosTokenIds
+        if let tokenizerEOS = tokenizerEOSTokenId {
+            stopTokenIds.insert(tokenizerEOS)
+        }
+        for token in extraEOSTokens {
+            if let id = convertTokenToId(token) {
+                stopTokenIds.insert(id)
+            }
+        }
+        return stopTokenIds
+    }
+
+    // MARK: - Admission-error mapping
+
+    /// Map a thrown `CBv2Engine.submit` error onto the provider's canonical
+    /// capacity-error strings. The `token_budget_exhausted:` prefix is the
+    /// stable contract that `MultiModelBatchSchedulerEngineError
+    /// .fromSchedulerMessage` (and the coordinator) string-match to produce
+    /// the retryable 429/503 classification — identical to the legacy
+    /// engine's admission rejections.
+    static func admissionErrorMessage(for error: Error) -> String {
+        if let kvError = error as? CBv2KVError {
+            switch kvError {
+            case .capacityExhausted(let needed, let available):
+                return "token_budget_exhausted: request requires \(needed) tokens "
+                    + "but only \(available) available"
+            case .backendIneligible(let reason):
+                // Deterministic (this model/backend pair can never serve) —
+                // NOT retryable capacity. Keep it off the capacity prefix so
+                // it maps to a non-retryable failure.
+                return "engine_v2 backend ineligible: \(reason)"
+            }
+        }
+        // Unknown throw: do NOT claim capacity exhaustion (which would be
+        // retried) — surface as a generic generation failure (500).
+        return "engine_v2 submit failed: \(error.localizedDescription)"
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge+Translation.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge+Translation.swift
@@ -9,8 +9,16 @@
 
 import Foundation
 import MLXLMCommon
+#if canImport(os)
+import os
+#endif
 
 enum EngineV2Translation {
+
+    #if canImport(os)
+    private static let logger = Logger(
+        subsystem: "com.darkbloom.provider", category: "engine_v2")
+    #endif
 
     // MARK: - Request translation
 
@@ -59,7 +67,17 @@ enum EngineV2Translation {
     /// no-op values so the v2 sampler applies no transform the legacy
     /// sampler would not have applied).
     static func samplingParams(from request: ChatCompletionRequest) -> CBv2SamplingParams {
-        CBv2SamplingParams(
+        let (logitBias, droppedBiasKeys) = parseLogitBiasCountingDropped(request.logit_bias)
+        if droppedBiasKeys > 0 {
+            // Count only — NEVER the keys/values (they are request content).
+            // Silent drops make a client's typo'd bias vanish with no signal;
+            // this one-line WARN surfaces it without touching the E2E body.
+            #if canImport(os)
+            Self.logger.warning(
+                "engine_v2: dropped \(droppedBiasKeys) invalid logit_bias key(s) (non-numeric or negative)")
+            #endif
+        }
+        return CBv2SamplingParams(
             temperature: request.temperature ?? 0.0,
             topP: request.top_p ?? 1.0,
             topK: request.top_k ?? 0,
@@ -68,7 +86,7 @@ enum EngineV2Translation {
             frequencyPenalty: request.frequency_penalty ?? 0,
             presencePenalty: request.presence_penalty ?? 0,
             seed: request.seed,
-            logitBias: parseLogitBias(request.logit_bias),
+            logitBias: logitBias,
             topLogprobs: topLogprobs(
                 logprobs: request.logprobs, topLogprobs: request.top_logprobs
             )
@@ -80,16 +98,28 @@ enum EngineV2Translation {
     /// Non-numeric keys are dropped (never guessed) — an invalid key can't
     /// silently bias a random token id.
     static func parseLogitBias(_ raw: [String: Float]?) -> [Int: Float] {
-        guard let raw, !raw.isEmpty else { return [:] }
+        parseLogitBiasCountingDropped(raw).bias
+    }
+
+    /// Same parse as `parseLogitBias`, but also returns how many keys were
+    /// dropped (non-numeric or negative) so the caller can surface a signal
+    /// for an otherwise-silent drop. Pure — no logging here so it stays
+    /// unit-testable field-by-field.
+    static func parseLogitBiasCountingDropped(
+        _ raw: [String: Float]?
+    ) -> (bias: [Int: Float], dropped: Int) {
+        guard let raw, !raw.isEmpty else { return ([:], 0) }
         var out: [Int: Float] = [:]
         out.reserveCapacity(raw.count)
+        var dropped = 0
         for (key, value) in raw {
             guard let id = Int(key.trimmingCharacters(in: .whitespaces)), id >= 0 else {
+                dropped += 1
                 continue
             }
             out[id] = value
         }
-        return out
+        return (out, dropped)
     }
 
     /// OpenAI `logprobs`/`top_logprobs` → contract `topLogprobs`.

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge+Translation.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge+Translation.swift
@@ -25,12 +25,21 @@ enum EngineV2Translation {
     ///   and batched requests stop identically.
     /// * `stopStrings` carries the request's `stop` sequences; the v2
     ///   engine matches them against held-back detokenized text.
+    /// * `cacheScope` is the provider's per-tenant prefix-cache scope
+    ///   (`SHA256(prompt_cache_key)`/`SHA256(user)`, "" ⇒ unscoped). It
+    ///   maps onto `CBv2Request.cacheSalt` (TB-007): a non-empty scope
+    ///   REPLACES the cache-level salt in the first block hash so tenants
+    ///   can never share cached KV; "" maps to nil (cache-level salt
+    ///   fallback — byte-identical hashes to the pre-salt behavior).
+    ///   Forward plumbing only today: the production v2 engine is built
+    ///   with `prefixCache: nil`.
     static func cbv2Request(
         id: CBv2RequestID,
         promptTokens: [Int],
         request: ChatCompletionRequest,
         defaultMaxTokens: Int,
-        stopTokenIds: Set<Int>
+        stopTokenIds: Set<Int>,
+        cacheScope: String = ""
     ) -> CBv2Request {
         CBv2Request(
             id: id,
@@ -39,7 +48,8 @@ enum EngineV2Translation {
             maxTokens: request.max_tokens ?? defaultMaxTokens,
             stopTokens: stopTokenIds,
             stopStrings: request.stop?.asArray ?? [],
-            priority: 0
+            priority: 0,
+            cacheSalt: cacheScope.isEmpty ? nil : cacheScope
         )
     }
 
@@ -95,6 +105,36 @@ enum EngineV2Translation {
         guard logprobs == true else { return 0 }
         let requested = topLogprobs ?? 0
         return min(20, max(1, requested))
+    }
+
+    // MARK: - Logprobs translation (CBv2TokenLogprob → OpenAI entry shape)
+
+    /// Convert engine-emitted logprobs into the OpenAI streaming entry
+    /// shape (`choices[].logprobs.content[]`): token text via the caller's
+    /// detokenizer, raw UTF-8 `bytes` (the OpenAI escape hatch for BPE
+    /// intermediates whose text is not valid standalone UTF-8), and the
+    /// `top_logprobs` alternatives. Pure — the decode closure is the only
+    /// dependency, so this is unit-testable without an engine.
+    static func sseTokenLogprobs(
+        _ logprobs: [CBv2TokenLogprob],
+        decodeToken: (Int) -> String
+    ) -> [SSETokenLogprob] {
+        logprobs.map { entry in
+            let token = decodeToken(entry.token)
+            return SSETokenLogprob(
+                token: token,
+                logprob: entry.logprob,
+                bytes: Array(token.utf8).map(Int.init),
+                topLogprobs: entry.topLogprobs.map { alt in
+                    let altToken = decodeToken(alt.token)
+                    return SSETokenLogprob.Top(
+                        token: altToken,
+                        logprob: alt.logprob,
+                        bytes: Array(altToken.utf8).map(Int.init)
+                    )
+                }
+            )
+        }
     }
 
     // MARK: - Stop resolution (buildStopTokenIds semantics)

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge+Translation.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge+Translation.swift
@@ -205,6 +205,34 @@ enum EngineV2Translation {
         if let kvError = error as? CBv2KVError {
             switch kvError {
             case .capacityExhausted(let needed, let available):
+                // Two engine rejection families share this case (round-3
+                // PR#499 P2 — `EngineV2.submit`):
+                //
+                //   * KV capacity ("could never fit"): thrown with the REAL
+                //     byte figures — `needed` = `AdmissionV2.estimatedBytes`
+                //     for prompt+max (a multiple of the per-token KV cost,
+                //     never 1) and `available` = `admissibleBytesCapacity`
+                //     (> 0 for any constructible engine, which requires
+                //     `kvBytesCapacity > 0`).
+                //   * Waiting-queue full / draining-for-shutdown guards:
+                //     thrown with the sentinel shape `(needed: 1,
+                //     available: 0)` — no byte estimate exists because the
+                //     rejection is about SLOTS, not bytes.
+                //
+                // The legacy path distinguishes these — queue-full carries
+                // the canonical "request queue full" marker that
+                // `MultiModelBatchSchedulerEngineError.fromSchedulerMessage`
+                // maps to `.queueFull` (429 + Retry-After), while budget
+                // exhaustion maps to `.tokenBudgetExhausted` (503) — so map
+                // the sentinel to the SAME legacy queue-full string
+                // (`BatchSchedulerTypes.RejectionReason.queueFull`). The
+                // shutdown-drain guard riding the same sentinel also lands
+                // on queue-full, exactly like the legacy handler's
+                // `.queueFull("provider shutting down")`. No new
+                // classification strings.
+                if needed == 1 && available <= 0 {
+                    return "token_budget_exhausted: request queue full"
+                }
                 return "token_budget_exhausted: request requires \(needed) tokens "
                     + "but only \(available) available"
             case .backendIneligible(let reason):

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge.swift
@@ -107,6 +107,19 @@ public actor EngineV2Bridge {
     /// outlive the engine drain (defense against a leaked stream). Keyed by
     /// the (normalized) provider request-id; each entry removes itself when
     /// its pump returns (`clearPumpTask`).
+    ///
+    /// BOUNDED WITHOUT A LOCAL LIMIT: a pump task exists only for an
+    /// engine-ACCEPTED request (created strictly after `engine.submit`
+    /// returned) and self-clears on its terminal, and the engine's own
+    /// admission bounds accepted-but-unfinished requests — `EngineV2.submit`
+    /// throws `capacityExhausted` once the waiting queue is full
+    /// (`gauges.beginSubmit(maxWaiting:)`, `CBv2SchedulerConfig.maxWaiting`,
+    /// default 64) on top of the running-row cap (`maxConcurrentRequests`,
+    /// production 4). So `pumpTasks.count ≤ maxConcurrent + maxWaiting`
+    /// (≈ 68 in production) by construction; the shared KV-budget gate in
+    /// `submitTokenized` bounds it further under memory pressure. A separate
+    /// bridge-side limit would just shadow the engine's admission with a
+    /// second constant to keep in sync.
     var pumpTasks: [String: Task<Void, Never>] = [:]
 
     /// Upper bound on a caller-supplied request-id we will use verbatim.

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge.swift
@@ -190,6 +190,17 @@ public actor EngineV2Bridge {
         let id = requestId ?? "req-\(UUID().uuidString.prefix(12))"
         let (stream, continuation) = AsyncStream<GenerationEvent>.makeStream()
 
+        // Duplicate request-id guard (legacy: the planner's
+        // `duplicateRequestID` rejection). Without it a second submit under
+        // the same id would overwrite the first request's bookkeeping and
+        // the two pumps would corrupt each other's teardown. Same canonical
+        // message → `.requestRejected` (a deterministic client fault).
+        guard active[id] == nil else {
+            continuation.yield(.error("token_budget_exhausted: duplicate request ID"))
+            continuation.finish()
+            return stream
+        }
+
         let cbv2Id = CBv2RequestID(nextRawId)
         nextRawId += 1
         let cbv2Request = EngineV2Translation.cbv2Request(

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge.swift
@@ -529,10 +529,14 @@ public actor EngineV2Bridge {
         switch reason {
         case .stop, .length:
             let final = recordFinish(id: id, usage: usage, success: true)
+            // Preserve the v2 engine's truncation signal: `.length` must
+            // reach the client as finish_reason "length", not be flattened
+            // to "stop" (max_tokens truncation was invisible on v2).
             continuation.yield(.info(
                 promptTokens: final.prompt,
                 completionTokens: final.completion,
-                tokensPerSecond: final.tps
+                tokensPerSecond: final.tps,
+                finishReason: reason == .length ? "length" : "stop"
             ))
         case .cancelled:
             let final = recordFinish(id: id, usage: usage, success: false)
@@ -543,7 +547,8 @@ public actor EngineV2Bridge {
                 continuation.yield(.info(
                     promptTokens: final.prompt,
                     completionTokens: final.completion,
-                    tokensPerSecond: final.tps
+                    tokensPerSecond: final.tps,
+                    finishReason: nil
                 ))
             }
             continuation.yield(.error("request cancelled"))

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge.swift
@@ -64,7 +64,18 @@ public actor EngineV2Bridge {
     let maxConcurrentRequests: Int
     /// Per-token KV byte cost for bytes→tokens capacity derivation
     /// (0 = unknown; capacity then falls back to the engine's token counts).
+    /// This is the UNQUANTIZED (fp16) rate: engine_v2 builds fp16 caches even
+    /// when the provider's `kv_quant` is on (KV-quant unsupported by v2), so
+    /// heartbeat token budgets AND the shared-budget reservation below are
+    /// sized to the caches actually built — see `EngineV2KVSizing`.
     let kvBytesPerToken: Int
+    /// Process-wide KV reservation ledger shared with the legacy schedulers.
+    /// When set (production), each in-flight v2 request records its worst-case
+    /// KV footprint here so the model-LOAD gate and the legacy live-KV gate
+    /// see v2 slots' committed KV (nil in unit tests ⇒ no shared accounting).
+    /// This is bookkeeping ONLY: it never gates v2 admission (the v2 engine's
+    /// own byte ledger does that) — see `GlobalKVCacheBudget.recordEngineKV`.
+    let kvBudget: GlobalKVCacheBudget?
     /// Injectable telemetry sink (tests); nil ⇒ `TelemetryClient.shared`.
     let emitTelemetry: (@Sendable (TelemetryEvent) -> Void)?
 
@@ -106,6 +117,7 @@ public actor EngineV2Bridge {
         defaultMaxTokens: Int = 4096,
         maxConcurrentRequests: Int = 4,
         kvBytesPerToken: Int = 0,
+        kvBudget: GlobalKVCacheBudget? = nil,
         emitTelemetry: (@Sendable (TelemetryEvent) -> Void)? = nil
     ) {
         self.engine = engine
@@ -120,6 +132,7 @@ public actor EngineV2Bridge {
         self.defaultMaxTokens = defaultMaxTokens
         self.maxConcurrentRequests = maxConcurrentRequests
         self.kvBytesPerToken = kvBytesPerToken
+        self.kvBudget = kvBudget
         self.emitTelemetry = emitTelemetry
     }
 
@@ -296,6 +309,16 @@ public actor EngineV2Bridge {
         continuation: AsyncStream<GenerationEvent>.Continuation,
         logprobsChannel: EngineV2LogprobsChannel? = nil
     ) async {
+        // Record this request's worst-case KV footprint in the shared budget
+        // so the model-LOAD gate and the legacy live-KV gate see the v2
+        // engine's committed KV (bookkeeping only — never gates v2 admission;
+        // released on every terminal path below). No-op when kvBudget is nil
+        // (unit tests) or kvBytesPerToken is unknown (0).
+        if let state = active[id] {
+            await kvBudget?.recordEngineKV(
+                requestID: id, kvBytesPerToken: kvBytesPerToken,
+                tokenCount: state.promptTokens + state.maxTokens)
+        }
         var sawFirstToken = false
         var sawTerminal = false
         for await event in events {
@@ -333,6 +356,9 @@ public actor EngineV2Bridge {
                     id: id, reason: reason, usage: usage,
                     sawFirstToken: sawFirstToken, continuation: continuation
                 )
+                // Release the shared-budget KV reservation on the terminal
+                // (idempotent; no-op when none was recorded).
+                await kvBudget?.release(requestID: id)
                 continuation.finish()
                 return
             }
@@ -346,6 +372,7 @@ public actor EngineV2Bridge {
                 wedgeMonitor.recordTerminalWithoutFirstToken()
             }
             dropRequest(id: id)
+            await kvBudget?.release(requestID: id)
             continuation.finish()
         }
     }

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge.swift
@@ -30,6 +30,9 @@
 import Foundation
 import MLXLMCommon
 import ProviderCoreFoundation
+#if canImport(os)
+import os
+#endif
 
 /// Bridges one `CBv2Engine` (one loaded model) to the provider's
 /// `GenerationEvent` streaming surface.
@@ -93,6 +96,22 @@ public actor EngineV2Bridge {
     /// Provider request-id → engine request-id, for `cancel`.
     var idMap: [String: CBv2RequestID] = [:]
     var nextRawId: UInt64 = 1
+    /// Live per-request pump tasks, so `shutdown()` can cancel any that
+    /// outlive the engine drain (defense against a leaked stream). Keyed by
+    /// the (normalized) provider request-id; each entry removes itself when
+    /// its pump returns (`clearPumpTask`).
+    var pumpTasks: [String: Task<Void, Never>] = [:]
+
+    /// Upper bound on a caller-supplied request-id we will use verbatim.
+    /// Coordinator/provider ids are short (`req-<uuid-prefix>` or a
+    /// coordinator UUID); anything longer is malformed and is replaced with a
+    /// fresh generated id rather than used as a dictionary key / cancel
+    /// correlation handle.
+    static let maxRequestIdLength = 256
+
+    #if canImport(os)
+    private static let logger = Logger(subsystem: "com.darkbloom.provider", category: "engine_v2")
+    #endif
 
     // MARK: - Health / telemetry state
 
@@ -201,7 +220,12 @@ public actor EngineV2Bridge {
         cacheScope: String = "",
         logprobsChannel: EngineV2LogprobsChannel? = nil
     ) -> AsyncStream<GenerationEvent> {
-        let id = requestId ?? "req-\(UUID().uuidString.prefix(12))"
+        // Validate the caller-supplied id before it becomes a dictionary key /
+        // cancel-correlation handle: a nil / empty / over-long / non-printable
+        // id is replaced with a fresh generated one (it could never correlate
+        // a cancel reliably anyway, and an unbounded/control-char key is a
+        // hardening risk). See `normalizedRequestId`.
+        let id = Self.normalizedRequestId(requestId)
         let (stream, continuation) = AsyncStream<GenerationEvent>.makeStream()
 
         // Duplicate request-id guard (legacy: the planner's
@@ -216,7 +240,12 @@ public actor EngineV2Bridge {
         }
 
         let cbv2Id = CBv2RequestID(nextRawId)
-        nextRawId += 1
+        // Wrapping increment: 2^64 request ids is unreachable in practice
+        // (billions of years at any real submit rate), but `&+` makes the
+        // theoretical overflow explicitly defined (wrap to 0) instead of a
+        // trap. Collisions after a wrap are still impossible in practice —
+        // the engine id space is far larger than the live-request window.
+        nextRawId &+= 1
         let cbv2Request = EngineV2Translation.cbv2Request(
             id: cbv2Id,
             promptTokens: promptTokens,
@@ -228,6 +257,14 @@ public actor EngineV2Bridge {
 
         let events: AsyncStream<CBv2Event>
         do {
+            // `engine.submit` is an O(1) non-blocking ENQUEUE by contract
+            // (`CBv2Engine.submit`: "Cancel promptly … row is dropped O(1)";
+            // `EngineV2.submit` does a lock-guarded admission check +
+            // `loop.register` + `loop.enqueue`, all constant-time, and NO
+            // forward pass — that runs on the engine's own step thread).
+            // Tokenization already happened off this actor (in `submit`, or in
+            // the caller for `submitTokenized`), so calling it synchronously
+            // on the bridge actor does not stall other actor work.
             events = try engine.submit(cbv2Request)
         } catch {
             // Admission failure. The message keeps the canonical
@@ -282,7 +319,19 @@ public actor EngineV2Bridge {
 
     /// Graceful drain (unload / process shutdown): running requests finish,
     /// new submissions are rejected by the engine.
+    ///
+    /// The per-request pump tasks are tracked (`pumpTasks`) and cancelled here
+    /// so none outlives the bridge. Cancellation makes each pump's
+    /// `for await event in events` resume with nil (AsyncStream is
+    /// cancellation-aware), so the pump hits its teardown path — yielding the
+    /// closed-stream sentinel and releasing per-request state — instead of
+    /// leaking. We cancel BEFORE draining the engine so a wedged engine stream
+    /// can't keep a pump (and its KV reservation) alive past shutdown, then
+    /// await the engine drain.
     public func shutdown() async {
+        let live = pumpTasks
+        pumpTasks.removeAll()
+        for task in live.values { task.cancel() }
         await engine.shutdown()
     }
 
@@ -295,12 +344,20 @@ public actor EngineV2Bridge {
         logprobsChannel: EngineV2LogprobsChannel? = nil
     ) {
         let bridge = self
-        Task {
+        let task = Task {
             await bridge.pump(
                 id: id, events: events, continuation: continuation,
                 logprobsChannel: logprobsChannel
             )
+            await bridge.clearPumpTask(id: id)
         }
+        pumpTasks[id] = task
+    }
+
+    /// Remove a completed pump's task handle (called from the pump task after
+    /// `pump` returns, on every exit path).
+    func clearPumpTask(id: String) {
+        pumpTasks.removeValue(forKey: id)
     }
 
     private func pump(
@@ -514,7 +571,29 @@ public actor EngineV2Bridge {
         }
     }
 
+    // MARK: - Request-id validation
+
+    /// Return a request-id safe to use as a dictionary key and cancel
+    /// correlation handle. A caller-supplied id is accepted verbatim only
+    /// when it is non-empty, at most `maxRequestIdLength`, and printable
+    /// (no ASCII control chars); otherwise — and when nil — a fresh
+    /// `req-<uuid-prefix>` is generated. Pure/static so it is unit-testable.
+    static func normalizedRequestId(_ requestId: String?) -> String {
+        if let requestId, isValidRequestId(requestId) { return requestId }
+        return "req-\(UUID().uuidString.prefix(12))"
+    }
+
+    /// A request-id is valid when non-empty, within the length cap, and free
+    /// of ASCII control characters (`< 0x20` or DEL `0x7f`).
+    static func isValidRequestId(_ id: String) -> Bool {
+        guard !id.isEmpty, id.count <= maxRequestIdLength else { return false }
+        return !id.unicodeScalars.contains { $0.value < 0x20 || $0.value == 0x7f }
+    }
+
     // MARK: - Test seams (internal; reachable via @testable only)
+
+    /// Number of live pump tasks (shutdown-tracking assertions).
+    func _testLivePumpCount() -> Int { pumpTasks.count }
 
     /// Snapshot of internal counters for unit assertions.
     func _testCounters() -> (active: Int, admits: Int, firstTokens: Int) {

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge.swift
@@ -31,32 +31,6 @@ import Foundation
 import MLXLMCommon
 import ProviderCoreFoundation
 
-/// `CBv2Engine` is not declared `Sendable` in the frozen contract, but its
-/// whole API surface (submit/cancel/capacity/shutdown) is the engine's
-/// cross-actor entry point (the engine serializes internally on its own
-/// step loop). Box it — and funnel ALL engine access through the box's
-/// wrappers — so the bridge actor can hold and use it under Swift 6 strict
-/// concurrency. Recorded in docs/engine-v2/CONTRACT-ISSUES-H-provider.md.
-struct EngineV2EngineBox: @unchecked Sendable {
-    let engine: any CBv2Engine
-
-    func submit(_ request: CBv2Request) throws -> AsyncStream<CBv2Event> {
-        try engine.submit(request)
-    }
-
-    func cancel(_ id: CBv2RequestID) {
-        engine.cancel(id)
-    }
-
-    func capacity() -> CBv2CapacitySnapshot {
-        engine.capacity()
-    }
-
-    func shutdown() async {
-        await engine.shutdown()
-    }
-}
-
 /// Bridges one `CBv2Engine` (one loaded model) to the provider's
 /// `GenerationEvent` streaming surface.
 ///
@@ -73,7 +47,13 @@ public actor EngineV2Bridge {
 
     // MARK: - Immutable configuration
 
-    let engineBox: EngineV2EngineBox
+    /// The v2 engine. `CBv2Engine` is declared `Sendable` in the contract
+    /// (the engine serializes all cross-actor entry points —
+    /// submit/cancel/capacity/shutdown — on its own step loop), so the
+    /// bridge actor holds and calls it directly. The former
+    /// `@unchecked Sendable` box workaround (CONTRACT-ISSUES-H-provider.md
+    /// §1) is resolved.
+    let engine: any CBv2Engine
     public let modelId: String
     let tokenizer: TokenizerHandle
     /// Resolved stop-token set (model EOS ∪ tokenizer EOS ∪ extra EOS
@@ -106,14 +86,12 @@ public actor EngineV2Bridge {
     // MARK: - Health / telemetry state
 
     /// Same monitor type + semantics as the legacy engine's first-token
-    /// wedge instrumentation (`WedgeMonitor`). The v2 contract exposes no
-    /// engine step counter, so loop progress is proxied by
-    /// `eventsObserved` — any event from any request proves the engine
-    /// loop advanced (see CONTRACT-ISSUES-H-provider.md).
+    /// wedge instrumentation (`WedgeMonitor`). Loop progress is sampled
+    /// from the engine's own monotonic `CBv2CapacitySnapshot.stepsExecuted`
+    /// counter on the heartbeat cadence — the direct analogue of the
+    /// legacy `EngineCore.stepsExecuted` signal (the event-count proxy
+    /// recorded in CONTRACT-ISSUES-H-provider.md §3 is resolved).
     var wedgeMonitor = WedgeMonitor()
-    /// Monotonic count of CBv2 events observed across all requests — the
-    /// v2 stand-in for `EngineCore.stepsExecuted`.
-    var eventsObserved: Int = 0
     var observedDecodeTpsEwma: Double = 0
     var ewmaInitialized = false
     /// Last wedge verdict emitted, for transition-edge telemetry.
@@ -130,7 +108,7 @@ public actor EngineV2Bridge {
         kvBytesPerToken: Int = 0,
         emitTelemetry: (@Sendable (TelemetryEvent) -> Void)? = nil
     ) {
-        self.engineBox = EngineV2EngineBox(engine: engine)
+        self.engine = engine
         self.modelId = modelId
         self.tokenizer = tokenizer
         self.stopTokenIds = EngineV2Translation.stopTokenIds(
@@ -150,9 +128,15 @@ public actor EngineV2Bridge {
     /// Tokenize + submit an OpenAI-shaped chat request. Mirrors the legacy
     /// `BatchScheduler.submit(request:)` tokenization path (role/content
     /// dict + Harmony channel-tag stripping for assistant turns).
+    ///
+    /// The per-tenant prefix-cache scope is derived from the request itself
+    /// (`prompt_cache_key`/`user` → `ChatCompletionRequest.cacheScope`);
+    /// callers that decode the scope out-of-band (the coordinator path)
+    /// use `submitTokenized(..., cacheScope:)` directly.
     public func submit(
         request: ChatCompletionRequest,
-        requestId: String? = nil
+        requestId: String? = nil,
+        logprobsChannel: EngineV2LogprobsChannel? = nil
     ) -> AsyncStream<GenerationEvent> {
         let messages: [[String: any Sendable]] = request.messages.map { msg in
             [
@@ -174,7 +158,8 @@ public actor EngineV2Bridge {
             return stream
         }
         return submitTokenized(
-            promptTokens: promptTokens, request: request, requestId: requestId
+            promptTokens: promptTokens, request: request, requestId: requestId,
+            cacheScope: request.cacheScope, logprobsChannel: logprobsChannel
         )
     }
 
@@ -182,10 +167,26 @@ public actor EngineV2Bridge {
     /// path, which tokenizes the full OpenAI request — tools included —
     /// itself). Sampling/stop/max-token translation still comes from the
     /// request so both entry points share one translation source.
+    ///
+    /// `cacheScope` is the per-tenant prefix-cache scope
+    /// (`SHA256(prompt_cache_key)`/`SHA256(user)`, "" ⇒ unscoped) — the
+    /// same value the legacy `BatchScheduler.submitTokenized(cacheScope:)`
+    /// receives. It maps onto `CBv2Request.cacheSalt` (TB-007): non-empty
+    /// scopes can never share cached KV across tenants; "" maps to nil
+    /// (cache-level salt fallback). Inert in production today — the v2
+    /// prefix cache is constructed OFF (`prefixCache: nil` in
+    /// `EngineV2Factory.makeProductionEngine`).
+    ///
+    /// `logprobsChannel`, when non-nil, receives OpenAI-shaped logprob
+    /// entries for every engine delta that carries them (requires
+    /// `request.logprobs == true` so the translated sampling params ask
+    /// the engine to capture them).
     public func submitTokenized(
         promptTokens: [Int],
         request: ChatCompletionRequest,
-        requestId: String? = nil
+        requestId: String? = nil,
+        cacheScope: String = "",
+        logprobsChannel: EngineV2LogprobsChannel? = nil
     ) -> AsyncStream<GenerationEvent> {
         let id = requestId ?? "req-\(UUID().uuidString.prefix(12))"
         let (stream, continuation) = AsyncStream<GenerationEvent>.makeStream()
@@ -208,12 +209,13 @@ public actor EngineV2Bridge {
             promptTokens: promptTokens,
             request: request,
             defaultMaxTokens: defaultMaxTokens,
-            stopTokenIds: stopTokenIds
+            stopTokenIds: stopTokenIds,
+            cacheScope: cacheScope
         )
 
         let events: AsyncStream<CBv2Event>
         do {
-            events = try engineBox.submit(cbv2Request)
+            events = try engine.submit(cbv2Request)
         } catch {
             // Admission failure. The message keeps the canonical
             // `token_budget_exhausted:` prefix contract so
@@ -233,7 +235,10 @@ public actor EngineV2Bridge {
         // Wedge instrumentation: the request is now in the engine's hands.
         wedgeMonitor.recordAdmit(now: .now)
 
-        runPump(id: id, events: events, continuation: continuation)
+        runPump(
+            id: id, events: events, continuation: continuation,
+            logprobsChannel: logprobsChannel
+        )
 
         let bridge = self
         continuation.onTermination = { @Sendable termination in
@@ -252,20 +257,20 @@ public actor EngineV2Bridge {
     /// which drives the normal bookkeeping/teardown in the pump.
     public func cancel(requestId: String) {
         guard let cbv2Id = idMap[requestId] else { return }
-        engineBox.cancel(cbv2Id)
+        engine.cancel(cbv2Id)
     }
 
     /// Runtime fan-out helper: cancel iff this bridge owns the request-id.
     func cancelIfOwned(requestId: String) -> Bool {
         guard let cbv2Id = idMap[requestId] else { return false }
-        engineBox.cancel(cbv2Id)
+        engine.cancel(cbv2Id)
         return true
     }
 
     /// Graceful drain (unload / process shutdown): running requests finish,
     /// new submissions are rejected by the engine.
     public func shutdown() async {
-        await engineBox.shutdown()
+        await engine.shutdown()
     }
 
     // MARK: - Event pump (CBv2Event → GenerationEvent)
@@ -273,25 +278,29 @@ public actor EngineV2Bridge {
     private func runPump(
         id: String,
         events: AsyncStream<CBv2Event>,
-        continuation: AsyncStream<GenerationEvent>.Continuation
+        continuation: AsyncStream<GenerationEvent>.Continuation,
+        logprobsChannel: EngineV2LogprobsChannel? = nil
     ) {
         let bridge = self
         Task {
-            await bridge.pump(id: id, events: events, continuation: continuation)
+            await bridge.pump(
+                id: id, events: events, continuation: continuation,
+                logprobsChannel: logprobsChannel
+            )
         }
     }
 
     private func pump(
         id: String,
         events: AsyncStream<CBv2Event>,
-        continuation: AsyncStream<GenerationEvent>.Continuation
+        continuation: AsyncStream<GenerationEvent>.Continuation,
+        logprobsChannel: EngineV2LogprobsChannel? = nil
     ) async {
         var sawFirstToken = false
         var sawTerminal = false
         for await event in events {
-            noteEngineProgress()
             switch event {
-            case .delta(let text, let tokens, _):
+            case .delta(let text, let tokens, let logprobs):
                 // Key first-token on TOKEN count, not text: some tokens
                 // (BPE intermediates, specials) detokenize to "" and would
                 // otherwise leave the first-token bookkeeping unset.
@@ -300,6 +309,21 @@ public actor EngineV2Bridge {
                     recordFirstToken(id: id)
                 }
                 recordProgress(id: id, newTokens: tokens.count)
+                // Logprobs passthrough: convert to the OpenAI streaming
+                // entry shape and publish to the per-request channel BEFORE
+                // yielding the chunk, so by the time the SSE frame carrying
+                // this delta's text reaches the frame decorator its entries
+                // are already drainable (happens-before via the yield).
+                if let logprobsChannel, let logprobs, !logprobs.isEmpty {
+                    logprobsChannel.append(
+                        EngineV2Translation.sseTokenLogprobs(
+                            logprobs,
+                            decodeToken: { [inner = tokenizer.inner] id in
+                                inner.decode(tokenIds: [id], skipSpecialTokens: false)
+                            }
+                        )
+                    )
+                }
                 if !text.isEmpty {
                     continuation.yield(.chunk(text))
                 }
@@ -381,12 +405,6 @@ public actor EngineV2Bridge {
         guard newTokens > 0, var state = active[id] else { return }
         state.completionTokens += newTokens
         active[id] = state
-    }
-
-    /// Progress proxy for the wedge monitor's step sampling: every event
-    /// received from the engine proves its loop advanced.
-    private func noteEngineProgress() {
-        eventsObserved += 1
     }
 
     /// Finish bookkeeping with the legacy billing-zero defense: the
@@ -472,8 +490,8 @@ public actor EngineV2Bridge {
     // MARK: - Test seams (internal; reachable via @testable only)
 
     /// Snapshot of internal counters for unit assertions.
-    func _testCounters() -> (active: Int, eventsObserved: Int, admits: Int, firstTokens: Int) {
-        (active.count, eventsObserved, wedgeMonitor.admits, wedgeMonitor.firstTokens)
+    func _testCounters() -> (active: Int, admits: Int, firstTokens: Int) {
+        (active.count, wedgeMonitor.admits, wedgeMonitor.firstTokens)
     }
 
     /// The engine request-id minted for a provider request-id, if active.

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge.swift
@@ -40,9 +40,10 @@ import os
 /// Event framing intentionally mirrors `BatchScheduler+EngineBridge`
 /// exactly (fixture-pinned in `EngineV2BridgeTests`):
 ///   * text deltas       → `.chunk(text)` (empty deltas suppressed)
-///   * finish stop/length→ `.info(prompt, completion, tps)` then finish
-///   * cancelled         → `.info(usage)` if any tokens were produced,
-///                         then `.error("request cancelled")`
+///   * finish stop/length→ `.info(prompt, completion, tps, reason)` then
+///                         finish (reason "stop"/"length" preserved)
+///   * cancelled         → `.info(usage, reason: nil)` if any tokens were
+///                         produced, then `.error("request cancelled")`
 ///   * engine error      → `.error(message)` (no `.info` — matches legacy)
 ///   * admission failure → single `.error("token_budget_exhausted: …")`
 ///   * stream torn down  → `.error("request stream closed by engine teardown")`

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge.swift
@@ -1,0 +1,472 @@
+// Copyright © 2026 Eigen Labs.
+//
+// EngineV2Bridge — adapts the ContinuousBatchingV2 engine (`CBv2Engine`,
+// frozen contract in libs/mlx-swift-lm `Libraries/MLXLMCommon/
+// ContinuousBatchingV2/CBv2Contracts.swift`) to the provider's existing
+// engine surface: the same `AsyncStream<GenerationEvent>` shape
+// (`.chunk` / `.info` / `.error`) that `BatchScheduler` produces and that
+// `MultiModelBatchSchedulerEngine` / `ProviderLoop` / `StandaloneServer`
+// consume. Downstream SSE framing, error→status mapping
+// (`MultiModelBatchSchedulerEngineError.fromSchedulerMessage` → 429/503),
+// billing extraction, and cancellation therefore work unchanged.
+//
+// Strictly additive: nothing constructs this type unless
+// `EngineV2Factory.makeBridgeIfSelected` picked the v2 engine (env
+// `DARKBLOOM_ENGINE_V2=1` / config `engine_v2` + per-model allowlist —
+// see `EngineV2Config.swift`). Flag off ⇒ this file is dead code and the
+// legacy path is byte-identical.
+//
+// Companion files:
+//   * `EngineV2Bridge+Translation.swift` — pure ChatRequest → CBv2Request
+//     translation (sampling params, logit_bias parsing, stop resolution
+//     with `buildStopTokenIds` semantics, error-message mapping).
+//   * `EngineV2Bridge+Capacity.swift`    — CBv2CapacitySnapshot → heartbeat
+//     `BackendSlotCapacity` mapping + the `engine_v2.step_wedge` signal.
+//   * `EngineV2Runtime.swift`            — process-wide bridge registry the
+//     ProviderLoop capacity/cancellation hooks fan out through.
+//   * `EngineV2Config.swift`             — flag/allowlist selection + the
+//     safe-fallback factory.
+
+import Foundation
+import MLXLMCommon
+import ProviderCoreFoundation
+
+/// `CBv2Engine` is not declared `Sendable` in the frozen contract, but its
+/// whole API surface (submit/cancel/capacity/shutdown) is the engine's
+/// cross-actor entry point (the engine serializes internally on its own
+/// step loop). Box it — and funnel ALL engine access through the box's
+/// wrappers — so the bridge actor can hold and use it under Swift 6 strict
+/// concurrency. Recorded in docs/engine-v2/CONTRACT-ISSUES-H-provider.md.
+struct EngineV2EngineBox: @unchecked Sendable {
+    let engine: any CBv2Engine
+
+    func submit(_ request: CBv2Request) throws -> AsyncStream<CBv2Event> {
+        try engine.submit(request)
+    }
+
+    func cancel(_ id: CBv2RequestID) {
+        engine.cancel(id)
+    }
+
+    func capacity() -> CBv2CapacitySnapshot {
+        engine.capacity()
+    }
+
+    func shutdown() async {
+        await engine.shutdown()
+    }
+}
+
+/// Bridges one `CBv2Engine` (one loaded model) to the provider's
+/// `GenerationEvent` streaming surface.
+///
+/// Event framing intentionally mirrors `BatchScheduler+EngineBridge`
+/// exactly (fixture-pinned in `EngineV2BridgeTests`):
+///   * text deltas       → `.chunk(text)` (empty deltas suppressed)
+///   * finish stop/length→ `.info(prompt, completion, tps)` then finish
+///   * cancelled         → `.info(usage)` if any tokens were produced,
+///                         then `.error("request cancelled")`
+///   * engine error      → `.error(message)` (no `.info` — matches legacy)
+///   * admission failure → single `.error("token_budget_exhausted: …")`
+///   * stream torn down  → `.error("request stream closed by engine teardown")`
+public actor EngineV2Bridge {
+
+    // MARK: - Immutable configuration
+
+    let engineBox: EngineV2EngineBox
+    public let modelId: String
+    let tokenizer: TokenizerHandle
+    /// Resolved stop-token set (model EOS ∪ tokenizer EOS ∪ extra EOS
+    /// tokens) — `buildStopTokenIds` semantics, computed ONCE at bridge
+    /// construction so B=1 and batched behavior stay identical.
+    let stopTokenIds: Set<Int>
+    let defaultMaxTokens: Int
+    let maxConcurrentRequests: Int
+    /// Per-token KV byte cost for bytes→tokens capacity derivation
+    /// (0 = unknown; capacity then falls back to the engine's token counts).
+    let kvBytesPerToken: Int
+    /// Injectable telemetry sink (tests); nil ⇒ `TelemetryClient.shared`.
+    let emitTelemetry: (@Sendable (TelemetryEvent) -> Void)?
+
+    // MARK: - Per-request bookkeeping
+
+    struct ActiveRequestState {
+        let promptTokens: Int
+        let maxTokens: Int
+        var completionTokens: Int = 0
+        let submittedAt: ContinuousClock.Instant
+        var firstTokenAt: ContinuousClock.Instant?
+    }
+
+    var active: [String: ActiveRequestState] = [:]
+    /// Provider request-id → engine request-id, for `cancel`.
+    var idMap: [String: CBv2RequestID] = [:]
+    var nextRawId: UInt64 = 1
+
+    // MARK: - Health / telemetry state
+
+    /// Same monitor type + semantics as the legacy engine's first-token
+    /// wedge instrumentation (`WedgeMonitor`). The v2 contract exposes no
+    /// engine step counter, so loop progress is proxied by
+    /// `eventsObserved` — any event from any request proves the engine
+    /// loop advanced (see CONTRACT-ISSUES-H-provider.md).
+    var wedgeMonitor = WedgeMonitor()
+    /// Monotonic count of CBv2 events observed across all requests — the
+    /// v2 stand-in for `EngineCore.stepsExecuted`.
+    var eventsObserved: Int = 0
+    var observedDecodeTpsEwma: Double = 0
+    var ewmaInitialized = false
+    /// Last wedge verdict emitted, for transition-edge telemetry.
+    var lastWedgeSuspectedEmitted = false
+
+    public init(
+        engine: any CBv2Engine,
+        modelId: String,
+        tokenizer: TokenizerHandle,
+        eosTokenIds: Set<Int>,
+        extraEOSTokens: [String] = [],
+        defaultMaxTokens: Int = 4096,
+        maxConcurrentRequests: Int = 4,
+        kvBytesPerToken: Int = 0,
+        emitTelemetry: (@Sendable (TelemetryEvent) -> Void)? = nil
+    ) {
+        self.engineBox = EngineV2EngineBox(engine: engine)
+        self.modelId = modelId
+        self.tokenizer = tokenizer
+        self.stopTokenIds = EngineV2Translation.stopTokenIds(
+            eosTokenIds: eosTokenIds,
+            tokenizerEOSTokenId: tokenizer.inner.eosTokenId,
+            extraEOSTokens: extraEOSTokens,
+            convertTokenToId: { [inner = tokenizer.inner] in inner.convertTokenToId($0) }
+        )
+        self.defaultMaxTokens = defaultMaxTokens
+        self.maxConcurrentRequests = maxConcurrentRequests
+        self.kvBytesPerToken = kvBytesPerToken
+        self.emitTelemetry = emitTelemetry
+    }
+
+    // MARK: - Submit
+
+    /// Tokenize + submit an OpenAI-shaped chat request. Mirrors the legacy
+    /// `BatchScheduler.submit(request:)` tokenization path (role/content
+    /// dict + Harmony channel-tag stripping for assistant turns).
+    public func submit(
+        request: ChatCompletionRequest,
+        requestId: String? = nil
+    ) -> AsyncStream<GenerationEvent> {
+        let messages: [[String: any Sendable]] = request.messages.map { msg in
+            [
+                "role": msg.role,
+                "content": msg.role == "assistant"
+                    ? stripHarmonyChannelFraming(fromAssistantContent: msg.content)
+                    : msg.content,
+            ]
+        }
+        let promptTokens: [Int]
+        do {
+            promptTokens = try tokenizer.inner.applyChatTemplate(
+                messages: messages, tools: nil, additionalContext: nil
+            )
+        } catch {
+            let (stream, continuation) = AsyncStream<GenerationEvent>.makeStream()
+            continuation.yield(.error("Failed to tokenize: \(error.localizedDescription)"))
+            continuation.finish()
+            return stream
+        }
+        return submitTokenized(
+            promptTokens: promptTokens, request: request, requestId: requestId
+        )
+    }
+
+    /// Submit a pre-tokenized prompt (the `MultiModelBatchSchedulerEngine`
+    /// path, which tokenizes the full OpenAI request — tools included —
+    /// itself). Sampling/stop/max-token translation still comes from the
+    /// request so both entry points share one translation source.
+    public func submitTokenized(
+        promptTokens: [Int],
+        request: ChatCompletionRequest,
+        requestId: String? = nil
+    ) -> AsyncStream<GenerationEvent> {
+        let id = requestId ?? "req-\(UUID().uuidString.prefix(12))"
+        let (stream, continuation) = AsyncStream<GenerationEvent>.makeStream()
+
+        let cbv2Id = CBv2RequestID(nextRawId)
+        nextRawId += 1
+        let cbv2Request = EngineV2Translation.cbv2Request(
+            id: cbv2Id,
+            promptTokens: promptTokens,
+            request: request,
+            defaultMaxTokens: defaultMaxTokens,
+            stopTokenIds: stopTokenIds
+        )
+
+        let events: AsyncStream<CBv2Event>
+        do {
+            events = try engineBox.submit(cbv2Request)
+        } catch {
+            // Admission failure. The message keeps the canonical
+            // `token_budget_exhausted:` prefix contract so
+            // `fromSchedulerMessage` classifies it as a retryable capacity
+            // error (429/503) exactly as the legacy engine's rejections.
+            continuation.yield(.error(EngineV2Translation.admissionErrorMessage(for: error)))
+            continuation.finish()
+            return stream
+        }
+
+        active[id] = ActiveRequestState(
+            promptTokens: promptTokens.count,
+            maxTokens: cbv2Request.maxTokens,
+            submittedAt: .now
+        )
+        idMap[id] = cbv2Id
+        // Wedge instrumentation: the request is now in the engine's hands.
+        wedgeMonitor.recordAdmit(now: .now)
+
+        runPump(id: id, events: events, continuation: continuation)
+
+        let bridge = self
+        continuation.onTermination = { @Sendable termination in
+            if case .cancelled = termination {
+                Task { await bridge.cancel(requestId: id) }
+            }
+        }
+        return stream
+    }
+
+    // MARK: - Cancel / shutdown
+
+    /// Cancel by provider request-id. Prompt per the v2 contract: the
+    /// in-flight step completes and the row is dropped O(1); the engine
+    /// then delivers `.finished(.cancelled)` on the request's stream,
+    /// which drives the normal bookkeeping/teardown in the pump.
+    public func cancel(requestId: String) {
+        guard let cbv2Id = idMap[requestId] else { return }
+        engineBox.cancel(cbv2Id)
+    }
+
+    /// Runtime fan-out helper: cancel iff this bridge owns the request-id.
+    func cancelIfOwned(requestId: String) -> Bool {
+        guard let cbv2Id = idMap[requestId] else { return false }
+        engineBox.cancel(cbv2Id)
+        return true
+    }
+
+    /// Graceful drain (unload / process shutdown): running requests finish,
+    /// new submissions are rejected by the engine.
+    public func shutdown() async {
+        await engineBox.shutdown()
+    }
+
+    // MARK: - Event pump (CBv2Event → GenerationEvent)
+
+    private func runPump(
+        id: String,
+        events: AsyncStream<CBv2Event>,
+        continuation: AsyncStream<GenerationEvent>.Continuation
+    ) {
+        let bridge = self
+        Task {
+            await bridge.pump(id: id, events: events, continuation: continuation)
+        }
+    }
+
+    private func pump(
+        id: String,
+        events: AsyncStream<CBv2Event>,
+        continuation: AsyncStream<GenerationEvent>.Continuation
+    ) async {
+        var sawFirstToken = false
+        var sawTerminal = false
+        for await event in events {
+            noteEngineProgress()
+            switch event {
+            case .delta(let text, let tokens, _):
+                // Key first-token on TOKEN count, not text: some tokens
+                // (BPE intermediates, specials) detokenize to "" and would
+                // otherwise leave the first-token bookkeeping unset.
+                if !sawFirstToken, !tokens.isEmpty {
+                    sawFirstToken = true
+                    recordFirstToken(id: id)
+                }
+                recordProgress(id: id, newTokens: tokens.count)
+                if !text.isEmpty {
+                    continuation.yield(.chunk(text))
+                }
+            case .finished(let reason, let usage):
+                sawTerminal = true
+                finishAndEmit(
+                    id: id, reason: reason, usage: usage,
+                    sawFirstToken: sawFirstToken, continuation: continuation
+                )
+                continuation.finish()
+                return
+            }
+        }
+        // Stream closed without a terminal event (engine torn down
+        // mid-request). Same distinct error string as the legacy bridge so
+        // callers never see a 200-OK with truncated content.
+        if !sawTerminal {
+            continuation.yield(.error("request stream closed by engine teardown"))
+            if !sawFirstToken {
+                wedgeMonitor.recordTerminalWithoutFirstToken()
+            }
+            dropRequest(id: id)
+            continuation.finish()
+        }
+    }
+
+    /// Terminal framing — mirrors `BatchScheduler+EngineBridge` exactly.
+    private func finishAndEmit(
+        id: String,
+        reason: CBv2FinishReason,
+        usage: CBv2Usage,
+        sawFirstToken: Bool,
+        continuation: AsyncStream<GenerationEvent>.Continuation
+    ) {
+        switch reason {
+        case .stop, .length:
+            let final = recordFinish(id: id, usage: usage, success: true)
+            continuation.yield(.info(
+                promptTokens: final.prompt,
+                completionTokens: final.completion,
+                tokensPerSecond: final.tps
+            ))
+        case .cancelled:
+            let final = recordFinish(id: id, usage: usage, success: false)
+            // A cancel that did real work emits its usage BEFORE the error
+            // so a listener can still bill delivered tokens (legacy abort
+            // framing).
+            if final.prompt > 0 || final.completion > 0 {
+                continuation.yield(.info(
+                    promptTokens: final.prompt,
+                    completionTokens: final.completion,
+                    tokensPerSecond: final.tps
+                ))
+            }
+            continuation.yield(.error("request cancelled"))
+        case .error(let message):
+            _ = recordFinish(id: id, usage: usage, success: false)
+            emitInferenceErrorTelemetry(requestId: id)
+            continuation.yield(.error(message))
+        }
+        if !sawFirstToken {
+            wedgeMonitor.recordTerminalWithoutFirstToken()
+        }
+    }
+
+    // MARK: - Bookkeeping
+
+    private func recordFirstToken(id: String) {
+        let now = ContinuousClock.Instant.now
+        wedgeMonitor.recordFirstToken(now: now)
+        guard var state = active[id] else { return }
+        if state.firstTokenAt == nil {
+            state.firstTokenAt = now
+            active[id] = state
+        }
+    }
+
+    private func recordProgress(id: String, newTokens: Int) {
+        guard newTokens > 0, var state = active[id] else { return }
+        state.completionTokens += newTokens
+        active[id] = state
+    }
+
+    /// Progress proxy for the wedge monitor's step sampling: every event
+    /// received from the engine proves its loop advanced.
+    private func noteEngineProgress() {
+        eventsObserved += 1
+    }
+
+    /// Finish bookkeeping with the legacy billing-zero defense: the
+    /// terminal usage can only ever RAISE observed counts, never zero them.
+    /// TPS methodology matches `BatchScheduler.recordFinish` (decode rate
+    /// measured first-token→finish over `completion - 1` tokens).
+    private func recordFinish(
+        id: String,
+        usage: CBv2Usage,
+        success: Bool
+    ) -> (prompt: Int, completion: Int, tps: Double) {
+        idMap.removeValue(forKey: id)
+        let now = ContinuousClock.Instant.now
+        guard var state = active.removeValue(forKey: id) else {
+            return (max(0, usage.promptTokens), max(0, usage.completionTokens), 0)
+        }
+        state.completionTokens = max(state.completionTokens, usage.completionTokens)
+        let prompt = max(state.promptTokens, usage.promptTokens)
+        let completion = state.completionTokens
+
+        let tps: Double
+        if let firstTokenAt = state.firstTokenAt, completion > 1 {
+            let seconds = WedgeMonitor.seconds(now - firstTokenAt)
+            tps = seconds > 0 ? Double(completion - 1) / seconds : 0
+        } else {
+            let seconds = WedgeMonitor.seconds(now - state.submittedAt)
+            tps = seconds > 0 ? Double(completion) / seconds : 0
+        }
+        if success, tps > 0 {
+            updateDecodeTpsEwma(tps)
+        }
+        return (prompt, completion, tps)
+    }
+
+    /// Stream torn down without a terminal event — drop local state.
+    private func dropRequest(id: String) {
+        active.removeValue(forKey: id)
+        idMap.removeValue(forKey: id)
+    }
+
+    /// Same EWMA (α = 0.3) as the legacy scheduler's decode-TPS heartbeat
+    /// signal so routing sees comparable numbers across engines.
+    private func updateDecodeTpsEwma(_ tps: Double) {
+        let alpha = 0.3
+        if ewmaInitialized {
+            observedDecodeTpsEwma = alpha * tps + (1 - alpha) * observedDecodeTpsEwma
+        } else {
+            observedDecodeTpsEwma = tps
+            ewmaInitialized = true
+        }
+    }
+
+    /// PRIVACY: engine-error telemetry carries only allowlisted operational
+    /// fields — never the error message (defense in depth against any
+    /// engine string that could embed request-adjacent detail).
+    private func emitInferenceErrorTelemetry(requestId: String) {
+        var event = TelemetryEvent(
+            source: .provider,
+            severity: .error,
+            kind: .inferenceError,
+            message: "engine_v2: generation failed"
+        ).withFields([
+            "component": .string("engine"),
+            "operation": .string("engine_v2_error"),
+            "backend": .string("engine_v2"),
+            "model": .string(modelId),
+            "error_class": .string("cbv2_engine_error"),
+        ])
+        event.requestId = requestId
+        emit(event)
+    }
+
+    /// Route telemetry through the injectable sink (tests) or the shared
+    /// client (production).
+    func emit(_ event: TelemetryEvent) {
+        if let emitTelemetry {
+            emitTelemetry(event)
+        } else {
+            TelemetryClient.shared.emit(event)
+        }
+    }
+
+    // MARK: - Test seams (internal; reachable via @testable only)
+
+    /// Snapshot of internal counters for unit assertions.
+    func _testCounters() -> (active: Int, eventsObserved: Int, admits: Int, firstTokens: Int) {
+        (active.count, eventsObserved, wedgeMonitor.admits, wedgeMonitor.firstTokens)
+    }
+
+    /// The engine request-id minted for a provider request-id, if active.
+    func _testEngineRequestId(for requestId: String) -> CBv2RequestID? {
+        idMap[requestId]
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge.swift
@@ -306,6 +306,19 @@ public actor EngineV2Bridge {
                 continuation.finish()
                 return stream
             }
+            // Re-check the duplicate guard: `reserve` suspended this actor,
+            // so a concurrent submit under the SAME id that skipped the gate
+            // (degenerate maxTokens / unknown rate ⇒ no suspension) could
+            // have been admitted in the gap. Reject THIS submission and roll
+            // back its reservation — never overwrite live bookkeeping. (A
+            // gate-taking duplicate can't get here: its own `reserve` fails
+            // on this id's existing entry.)
+            guard active[id] == nil else {
+                await kvBudget.release(requestID: id)
+                continuation.yield(.error("token_budget_exhausted: duplicate request ID"))
+                continuation.finish()
+                return stream
+            }
         }
 
         // Mint the engine request id: monotonic by default, STABLE
@@ -354,6 +367,7 @@ public actor EngineV2Bridge {
 
         runPump(
             id: id, events: events, continuation: continuation,
+            holdsSharedReservation: sharedKVReserved,
             logprobsChannel: logprobsChannel
         )
 
@@ -408,12 +422,14 @@ public actor EngineV2Bridge {
         id: String,
         events: AsyncStream<CBv2Event>,
         continuation: AsyncStream<GenerationEvent>.Continuation,
+        holdsSharedReservation: Bool,
         logprobsChannel: EngineV2LogprobsChannel? = nil
     ) {
         let bridge = self
         let task = Task {
             await bridge.pump(
                 id: id, events: events, continuation: continuation,
+                holdsSharedReservation: holdsSharedReservation,
                 logprobsChannel: logprobsChannel
             )
             await bridge.clearPumpTask(id: id)
@@ -431,11 +447,15 @@ public actor EngineV2Bridge {
         id: String,
         events: AsyncStream<CBv2Event>,
         continuation: AsyncStream<GenerationEvent>.Continuation,
+        holdsSharedReservation: Bool,
         logprobsChannel: EngineV2LogprobsChannel? = nil
     ) async {
-        // NOTE: the shared-budget KV reservation is recorded in
-        // `submitTokenized` (synchronously with admission), NOT here — the
-        // pump only RELEASES it on the terminal/teardown paths below.
+        // NOTE: the shared-budget KV reservation is taken in `submitTokenized`
+        // (the pre-engine admission gate), NOT here — the pump only RELEASES
+        // it on the terminal/teardown paths below, and ONLY when THIS request
+        // took one (`holdsSharedReservation`): an unconditional release could
+        // drop a same-keyed reservation owned by a different submission in
+        // the pathological duplicate-id corner.
         var sawFirstToken = false
         var sawTerminal = false
         for await event in events {
@@ -474,8 +494,10 @@ public actor EngineV2Bridge {
                     sawFirstToken: sawFirstToken, continuation: continuation
                 )
                 // Release the shared-budget KV reservation on the terminal
-                // (idempotent; no-op when none was recorded).
-                await kvBudget?.release(requestID: id)
+                // (only when this request took one; release is idempotent).
+                if holdsSharedReservation {
+                    await kvBudget?.release(requestID: id)
+                }
                 continuation.finish()
                 return
             }
@@ -489,7 +511,9 @@ public actor EngineV2Bridge {
                 wedgeMonitor.recordTerminalWithoutFirstToken()
             }
             dropRequest(id: id)
-            await kvBudget?.release(requestID: id)
+            if holdsSharedReservation {
+                await kvBudget?.release(requestID: id)
+            }
             continuation.finish()
         }
     }

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge.swift
@@ -73,11 +73,14 @@ public actor EngineV2Bridge {
     /// sized to the caches actually built — see `EngineV2KVSizing`.
     let kvBytesPerToken: Int
     /// Process-wide KV reservation ledger shared with the legacy schedulers.
-    /// When set (production), each in-flight v2 request records its worst-case
-    /// KV footprint here so the model-LOAD gate and the legacy live-KV gate
-    /// see v2 slots' committed KV (nil in unit tests ⇒ no shared accounting).
-    /// This is bookkeeping ONLY: it never gates v2 admission (the v2 engine's
-    /// own byte ledger does that) — see `GlobalKVCacheBudget.recordEngineKV`.
+    /// When set (production), each v2 submission must RESERVE its worst-case
+    /// KV footprint here BEFORE it is handed to the engine — the reservation
+    /// both GATES v2 admission against the process-wide unified-memory cap
+    /// (the engine's private byte ledger only knows its own slot; with
+    /// another slot's live KV already reserved, this shared pool is the only
+    /// gate that sees the whole process) and is the accounting entry the
+    /// model-LOAD gate and the legacy live-KV gate subtract. nil in unit
+    /// tests ⇒ no shared gating/accounting.
     let kvBudget: GlobalKVCacheBudget?
     /// Injectable telemetry sink (tests); nil ⇒ `TelemetryClient.shared`.
     let emitTelemetry: (@Sendable (TelemetryEvent) -> Void)?
@@ -255,6 +258,40 @@ public actor EngineV2Bridge {
             cacheScope: cacheScope
         )
 
+        // SHARED-BUDGET ADMISSION GATE: reserve this request's worst-case KV
+        // footprint (prompt + maxTokens at the fp16 rate — the caches v2
+        // actually builds) in the process-wide ledger BEFORE handing the
+        // request to the engine. The engine's private byte ledger
+        // (`AdmissionV2`, sized to its own `kvBytesCapacity`) only knows its
+        // own slot; when another slot (legacy or v2) already has live KV
+        // reserved, this shared pool is the only gate that sees the WHOLE
+        // process — without it, concurrent requests across co-resident models
+        // could overcommit unified memory (default `max_model_slots` allows
+        // several). `reserve` is atomic on the budget actor (check + record in
+        // one hop — no TOCTOU window between a probe and a later record), so
+        // once it returns true the reservation is already visible to the
+        // model-LOAD gate and the legacy live-KV gate; it is released on every
+        // terminal/teardown path in the pump, and below when the engine
+        // rejects the submission. A gate failure maps to the canonical
+        // retryable capacity error (429/503), exactly like the legacy
+        // scheduler's KV-reserve rejection. Skipped when kvBudget is nil
+        // (unit tests / standalone), the per-token rate is unknown (0), or
+        // maxTokens ≤ 0 (degenerate request — the engine finishes it
+        // immediately without allocating any KV).
+        let worstCaseTokens = promptTokens.count + cbv2Request.maxTokens
+        var sharedKVReserved = false
+        if let kvBudget, kvBytesPerToken > 0, cbv2Request.maxTokens > 0 {
+            sharedKVReserved = await kvBudget.reserve(
+                requestID: id, kvBytesPerToken: kvBytesPerToken, tokenCount: worstCaseTokens)
+            guard sharedKVReserved else {
+                continuation.yield(.error(
+                    "token_budget_exhausted: request requires \(worstCaseTokens) tokens "
+                        + "but the shared KV budget has no headroom"))
+                continuation.finish()
+                return stream
+            }
+        }
+
         let events: AsyncStream<CBv2Event>
         do {
             // `engine.submit` is an O(1) non-blocking ENQUEUE by contract
@@ -267,6 +304,9 @@ public actor EngineV2Bridge {
             // on the bridge actor does not stall other actor work.
             events = try engine.submit(cbv2Request)
         } catch {
+            // Engine rejected AFTER the shared reservation was taken — release
+            // it before surfacing the error (no pump will ever finish it).
+            if sharedKVReserved { await kvBudget?.release(requestID: id) }
             // Admission failure. The message keeps the canonical
             // `token_budget_exhausted:` prefix contract so
             // `fromSchedulerMessage` classifies it as a retryable capacity
@@ -284,17 +324,6 @@ public actor EngineV2Bridge {
         idMap[id] = cbv2Id
         // Wedge instrumentation: the request is now in the engine's hands.
         wedgeMonitor.recordAdmit(now: .now)
-
-        // Record the request's worst-case KV footprint in the shared budget
-        // SYNCHRONOUSLY with admission — before returning the stream and
-        // before the pump task is even scheduled — so a concurrent model-load
-        // gate can never observe zero v2 KV in the gap between engine
-        // admission and the pump starting. Bookkeeping only (never gates v2
-        // admission); released on every terminal/teardown path in the pump.
-        // No-op when kvBudget is nil (unit tests) or kvBytesPerToken is 0.
-        await kvBudget?.recordEngineKV(
-            requestID: id, kvBytesPerToken: kvBytesPerToken,
-            tokenCount: promptTokens.count + cbv2Request.maxTokens)
 
         runPump(
             id: id, events: events, continuation: continuation,

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge.swift
@@ -98,6 +98,10 @@ public actor EngineV2Bridge {
     var active: [String: ActiveRequestState] = [:]
     /// Provider request-id → engine request-id, for `cancel`.
     var idMap: [String: CBv2RequestID] = [:]
+    /// Monotonic engine-id counter for UNSEEDED requests. Lives in the low
+    /// half of the id space (seeded requests derive TAGGED ids with bit 63
+    /// set — see `stableSeededRawId`), so the two families cannot collide:
+    /// reaching 2^63 monotonic ids is unattainable at any real submit rate.
     var nextRawId: UInt64 = 1
     /// Live per-request pump tasks, so `shutdown()` can cancel any that
     /// outlive the engine drain (defense against a leaked stream). Keyed by
@@ -242,15 +246,14 @@ public actor EngineV2Bridge {
             return stream
         }
 
-        let cbv2Id = CBv2RequestID(nextRawId)
-        // Wrapping increment: 2^64 request ids is unreachable in practice
-        // (billions of years at any real submit rate), but `&+` makes the
-        // theoretical overflow explicitly defined (wrap to 0) instead of a
-        // trap. Collisions after a wrap are still impossible in practice —
-        // the engine id space is far larger than the live-request window.
-        nextRawId &+= 1
-        let cbv2Request = EngineV2Translation.cbv2Request(
-            id: cbv2Id,
+        // Translate with a PLACEHOLDER engine id — the real id is minted
+        // below, AFTER the shared-budget await, in the same synchronous
+        // stretch as `engine.submit` and the `idMap` registration. Minting
+        // before the suspension would let two concurrent IDENTICAL seeded
+        // submissions both pass the collision check and hand the engine
+        // duplicate live ids.
+        var cbv2Request = EngineV2Translation.cbv2Request(
+            id: CBv2RequestID(0),
             promptTokens: promptTokens,
             request: request,
             defaultMaxTokens: defaultMaxTokens,
@@ -291,6 +294,17 @@ public actor EngineV2Bridge {
                 return stream
             }
         }
+
+        // Mint the engine request id: monotonic by default, STABLE
+        // (seed, prompt)-derived when the caller supplied an explicit seed —
+        // the engine keys its sampler RNG on (seed, requestID, stepIndex)
+        // (`CBv2SamplingParams.seed`), so a fresh id on every submission
+        // would make identical seeded requests sample differently depending
+        // on prior traffic. See `mintEngineRequestId` for the collision
+        // guarantees and the documented reproducibility limits.
+        let cbv2Id = mintEngineRequestId(
+            seed: cbv2Request.sampling.seed, promptTokens: promptTokens)
+        cbv2Request.id = cbv2Id
 
         let events: AsyncStream<CBv2Event>
         do {
@@ -602,6 +616,72 @@ public actor EngineV2Bridge {
         } else {
             TelemetryClient.shared.emit(event)
         }
+    }
+
+    // MARK: - Engine request-id minting
+
+    /// Tag bit for (seed, prompt)-derived engine ids. Keeps the seeded id
+    /// family disjoint from the monotonic counter (which starts at 1 and can
+    /// never reach 2^63 at any real submit rate), so a derived id can only
+    /// ever collide with another SEEDED id — and then only for an identical
+    /// (seed, prompt) pair, which `mintEngineRequestId` guards against.
+    static let seededIdTagBit: UInt64 = 1 << 63
+
+    /// Deterministic engine-id for a seeded submission: a SplitMix64 chain
+    /// over (seed, promptTokens…), tagged into the seeded id family.
+    ///
+    /// WHY (round-2 PR#499 P2): the v2 sampler's RNG key is
+    /// (seed, requestID.raw, stepIndex) — `SamplerV2.mix` — so `seed` only
+    /// reproduces output if the request id is itself a pure function of the
+    /// request. Deriving it from (seed, prompt) makes same-seed + same-prompt
+    /// submissions sample identically at B=1 regardless of prior traffic,
+    /// while different prompts/seeds still get distinct RNG streams.
+    ///
+    /// Deterministic across processes (no `Hasher` seed), mirroring the
+    /// engine sampler's own SplitMix64 keying family.
+    static func stableSeededRawId(seed: UInt64, promptTokens: [Int]) -> UInt64 {
+        var hash = splitmix64(seed)
+        for token in promptTokens {
+            hash = splitmix64(hash ^ UInt64(bitPattern: Int64(token)))
+        }
+        return hash | seededIdTagBit
+    }
+
+    /// SplitMix64 finalizer (public-domain constants).
+    static func splitmix64(_ x: UInt64) -> UInt64 {
+        var z = x &+ 0x9E37_79B9_7F4A_7C15
+        z = (z ^ (z >> 30)) &* 0xBF58_476D_1CE4_E5B9
+        z = (z ^ (z >> 27)) &* 0x94D0_49BB_1331_11EB
+        return z ^ (z >> 31)
+    }
+
+    /// Mint the engine id for a submission. Seeded requests get the stable
+    /// (seed, prompt)-derived id; everything else gets the monotonic counter
+    /// (`&+` wrap: 2^63 ids is unreachable, but the overflow is defined).
+    ///
+    /// Collision guard: an IDENTICAL seeded request that is still LIVE would
+    /// collide inside the engine's per-request maps, so the derived id falls
+    /// back to a fresh monotonic id. DOCUMENTED LIMITS of seeded
+    /// reproducibility: (a) submissions that overlap their own duplicate
+    /// in-flight lose the stable id (this fallback); (b) under batching the
+    /// contract is best-effort — the RNG key itself is batch-invariant, but
+    /// non-deterministic kernel scheduling can still perturb floating-point
+    /// reductions across different batch compositions.
+    ///
+    /// MUST be called in the same synchronous (no-await) stretch as
+    /// `engine.submit` + the `idMap` registration, so the liveness check
+    /// cannot race a concurrent identical submission across a suspension.
+    private func mintEngineRequestId(seed: UInt64?, promptTokens: [Int]) -> CBv2RequestID {
+        if let seed {
+            let stable = CBv2RequestID(
+                Self.stableSeededRawId(seed: seed, promptTokens: promptTokens))
+            // O(live requests) scan (≤ engine concurrency + waiting cap);
+            // only taken on seeded submissions.
+            if !idMap.values.contains(stable) { return stable }
+        }
+        let fresh = CBv2RequestID(nextRawId)
+        nextRawId &+= 1
+        return fresh
     }
 
     // MARK: - Request-id validation

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge.swift
@@ -169,7 +169,7 @@ public actor EngineV2Bridge {
         request: ChatCompletionRequest,
         requestId: String? = nil,
         logprobsChannel: EngineV2LogprobsChannel? = nil
-    ) -> AsyncStream<GenerationEvent> {
+    ) async -> AsyncStream<GenerationEvent> {
         let messages: [[String: any Sendable]] = request.messages.map { msg in
             [
                 "role": msg.role,
@@ -189,7 +189,7 @@ public actor EngineV2Bridge {
             continuation.finish()
             return stream
         }
-        return submitTokenized(
+        return await submitTokenized(
             promptTokens: promptTokens, request: request, requestId: requestId,
             cacheScope: request.cacheScope, logprobsChannel: logprobsChannel
         )
@@ -219,7 +219,7 @@ public actor EngineV2Bridge {
         requestId: String? = nil,
         cacheScope: String = "",
         logprobsChannel: EngineV2LogprobsChannel? = nil
-    ) -> AsyncStream<GenerationEvent> {
+    ) async -> AsyncStream<GenerationEvent> {
         // Validate the caller-supplied id before it becomes a dictionary key /
         // cancel-correlation handle: a nil / empty / over-long / non-printable
         // id is replaced with a fresh generated one (it could never correlate
@@ -284,6 +284,17 @@ public actor EngineV2Bridge {
         idMap[id] = cbv2Id
         // Wedge instrumentation: the request is now in the engine's hands.
         wedgeMonitor.recordAdmit(now: .now)
+
+        // Record the request's worst-case KV footprint in the shared budget
+        // SYNCHRONOUSLY with admission — before returning the stream and
+        // before the pump task is even scheduled — so a concurrent model-load
+        // gate can never observe zero v2 KV in the gap between engine
+        // admission and the pump starting. Bookkeeping only (never gates v2
+        // admission); released on every terminal/teardown path in the pump.
+        // No-op when kvBudget is nil (unit tests) or kvBytesPerToken is 0.
+        await kvBudget?.recordEngineKV(
+            requestID: id, kvBytesPerToken: kvBytesPerToken,
+            tokenCount: promptTokens.count + cbv2Request.maxTokens)
 
         runPump(
             id: id, events: events, continuation: continuation,
@@ -366,16 +377,9 @@ public actor EngineV2Bridge {
         continuation: AsyncStream<GenerationEvent>.Continuation,
         logprobsChannel: EngineV2LogprobsChannel? = nil
     ) async {
-        // Record this request's worst-case KV footprint in the shared budget
-        // so the model-LOAD gate and the legacy live-KV gate see the v2
-        // engine's committed KV (bookkeeping only — never gates v2 admission;
-        // released on every terminal path below). No-op when kvBudget is nil
-        // (unit tests) or kvBytesPerToken is unknown (0).
-        if let state = active[id] {
-            await kvBudget?.recordEngineKV(
-                requestID: id, kvBytesPerToken: kvBytesPerToken,
-                tokenCount: state.promptTokens + state.maxTokens)
-        }
+        // NOTE: the shared-budget KV reservation is recorded in
+        // `submitTokenized` (synchronously with admission), NOT here — the
+        // pump only RELEASES it on the terminal/teardown paths below.
         var sawFirstToken = false
         var sawTerminal = false
         for await event in events {

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2Config.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2Config.swift
@@ -149,6 +149,7 @@ public enum EngineV2Factory {
         defaultMaxTokens: Int = 4096,
         maxConcurrentRequests: Int = 4,
         kvBytesPerToken: Int = 0,
+        kvBudget: GlobalKVCacheBudget? = nil,
         emitTelemetry: (@Sendable (TelemetryEvent) -> Void)? = nil,
         makeEngine: () throws -> any CBv2Engine
     ) -> EngineV2Bridge? {
@@ -170,6 +171,7 @@ public enum EngineV2Factory {
                 defaultMaxTokens: defaultMaxTokens,
                 maxConcurrentRequests: maxConcurrentRequests,
                 kvBytesPerToken: kvBytesPerToken,
+                kvBudget: kvBudget,
                 emitTelemetry: emitTelemetry
             )
         } catch {
@@ -205,6 +207,35 @@ public enum EngineV2Factory {
             "backend": .string("engine_v2"),
             "model": .string(modelId),
             "error_class": .string(String(reflecting: type(of: error))),
+        ])
+        if let emitTelemetry {
+            emitTelemetry(event)
+        } else {
+            TelemetryClient.shared.emit(event)
+        }
+    }
+
+    /// WARN `engine_health` event when a model configured for `kv_quant` is
+    /// served through engine_v2, which does NOT yet support KV-quant and
+    /// silently falls back to fp16 caches (`makeProductionEngine` builds
+    /// `CBv2LayerCache`, never a quantized cache). Surfacing this keeps the
+    /// operator from assuming the memory savings apply on the v2 path.
+    /// Allowlisted fields only.
+    static func emitKVQuantUnsupportedTelemetry(
+        modelId: String,
+        emitTelemetry: (@Sendable (TelemetryEvent) -> Void)?
+    ) {
+        var event = TelemetryEvent(
+            source: .provider,
+            severity: .warn,
+            kind: .engineHealth,
+            message: "engine_v2: kv_quant not supported — using fp16 caches"
+        )
+        event.fields = TelemetryFieldFilter.filter([
+            "component": .string("engine"),
+            "operation": .string("engine_v2_kv_quant_unsupported"),
+            "backend": .string("engine_v2"),
+            "model": .string(modelId),
         ])
         if let emitTelemetry {
             emitTelemetry(event)

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2Config.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2Config.swift
@@ -1,0 +1,215 @@
+// Copyright © 2026 Eigen Labs.
+//
+// ContinuousBatchingV2 (engine v2) selection + safe-fallback factory.
+//
+// The v2 engine (`MLXLMCommon.CBv2Engine`, see
+// libs/mlx-swift-lm/Libraries/MLXLMCommon/ContinuousBatchingV2/CBv2Contracts.swift)
+// is strictly OPT-IN and additive:
+//
+//   * Flag OFF (default)          → the legacy `BatchedEngine` path runs,
+//                                   byte-identical to today.
+//   * Flag ON + allowlisted model → `EngineV2Factory.makeBridgeIfSelected`
+//                                   builds an `EngineV2Bridge` over the v2
+//                                   engine.
+//   * Flag ON + other model       → legacy path (per-model allowlist).
+//   * v2 engine init throws       → legacy path + a WARN `engine_health`
+//                                   telemetry event (`engine_v2_fallback`)
+//                                   so a silent fleet-wide fallback is
+//                                   impossible.
+//
+// Selection sources, in precedence order:
+//   1. env `DARKBLOOM_ENGINE_V2` — explicit "1"/"true"/"yes"/"on" enables,
+//      explicit "0"/"false"/"no"/"off" force-disables (operator kill switch
+//      that beats the config file).
+//   2. provider config key `engine_v2` under `[backend]` in provider.toml.
+//
+// Per-model allowlist: default `gemma-4*` / `gpt-oss*` glob-prefix patterns
+// (the two families the v2 engine is correct-by-construction for first),
+// overridable via env `DARKBLOOM_ENGINE_V2_MODELS` (comma-separated
+// patterns) for staged rollout.
+
+import Foundation
+import MLXLMCommon
+
+// MARK: - Selection
+
+public enum EngineV2Config {
+    /// Master opt-in flag. "1"/"true"/"yes"/"on" enable; "0"/"false"/"no"/
+    /// "off" force-disable (overrides the config key); absent/other defers
+    /// to the `engine_v2` provider-config value.
+    public static let environmentFlag = "DARKBLOOM_ENGINE_V2"
+    /// Optional comma-separated allowlist pattern override
+    /// (e.g. `gemma-4*,gpt-oss*,qwen3*`). Empty/absent keeps the default.
+    public static let environmentAllowlist = "DARKBLOOM_ENGINE_V2_MODELS"
+
+    /// Model families the v2 engine serves by default when the flag is on.
+    /// Glob-prefix patterns (trailing `*`), matched case-insensitively
+    /// against the model id and its last path component (registry ids can be
+    /// `org/name` shaped, e.g. `mlx-community/gpt-oss-20b-4bit`).
+    public static let defaultModelAllowlist = ["gemma-4*", "gpt-oss*"]
+
+    public enum Selection: String, Sendable, Equatable {
+        case legacy
+        case v2
+    }
+
+    /// Resolve the master flag from env + provider config (`engine_v2`).
+    public static func flagEnabled(
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        configEnabled: Bool
+    ) -> Bool {
+        if let env = environment[environmentFlag]?
+            .trimmingCharacters(in: .whitespaces).lowercased(), !env.isEmpty
+        {
+            if ["1", "true", "yes", "on"].contains(env) { return true }
+            if ["0", "false", "no", "off"].contains(env) { return false }
+            // Unrecognized value: fail safe (legacy) rather than guessing.
+            return false
+        }
+        return configEnabled
+    }
+
+    /// Resolve the model allowlist patterns (env override or default).
+    public static func allowlistPatterns(
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> [String] {
+        guard let raw = environment[environmentAllowlist] else {
+            return defaultModelAllowlist
+        }
+        let patterns = raw.split(separator: ",")
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty }
+        return patterns.isEmpty ? defaultModelAllowlist : patterns
+    }
+
+    /// Does `modelId` match any allowlist pattern? Patterns are
+    /// case-insensitive; a trailing `*` makes them prefix globs, otherwise
+    /// they must match exactly. Both the full id and its last `/` component
+    /// are tried so `mlx-community/gemma-4-27b-it-4bit` matches `gemma-4*`.
+    public static func modelAllowlisted(
+        _ modelId: String,
+        patterns: [String] = defaultModelAllowlist
+    ) -> Bool {
+        let id = modelId.trimmingCharacters(in: .whitespaces).lowercased()
+        guard !id.isEmpty else { return false }
+        let lastComponent = id.split(separator: "/").last.map(String.init) ?? id
+        for pattern in patterns {
+            let p = pattern.lowercased()
+            guard !p.isEmpty else { continue }
+            if p.hasSuffix("*") {
+                let prefix = String(p.dropLast())
+                if id.hasPrefix(prefix) || lastComponent.hasPrefix(prefix) {
+                    return true
+                }
+            } else if id == p || lastComponent == p {
+                return true
+            }
+        }
+        return false
+    }
+
+    /// The single selection decision: which engine serves `modelId`.
+    public static func selection(
+        modelId: String,
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        configEnabled: Bool
+    ) -> Selection {
+        guard flagEnabled(environment: environment, configEnabled: configEnabled) else {
+            return .legacy
+        }
+        let patterns = allowlistPatterns(environment: environment)
+        return modelAllowlisted(modelId, patterns: patterns) ? .v2 : .legacy
+    }
+}
+
+// MARK: - Factory (selection + safe fallback)
+
+public enum EngineV2Factory {
+    /// Build an `EngineV2Bridge` for `modelId` iff the flag + allowlist
+    /// select the v2 engine. Returns nil (⇒ caller uses the legacy engine)
+    /// when:
+    ///   * the flag is off or the model is not allowlisted (silent — this is
+    ///     the normal steady state), or
+    ///   * `makeEngine` throws — the SAFE FALLBACK path, which additionally
+    ///     emits a WARN `engine_health` telemetry event
+    ///     (`operation=engine_v2_fallback`, `backend=engine_v2`) so the
+    ///     fleet dashboard can see v2 init failures instead of a silent
+    ///     downgrade.
+    ///
+    /// `makeEngine` is a closure (not a concrete type) because the v2 engine
+    /// implementation lands via the mlx-swift-lm integration branch; the
+    /// bridge codes against the frozen `CBv2Engine` contract only.
+    public static func makeBridgeIfSelected(
+        modelId: String,
+        configEnabled: Bool,
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        tokenizer: TokenizerHandle,
+        eosTokenIds: Set<Int>,
+        extraEOSTokens: [String] = [],
+        defaultMaxTokens: Int = 4096,
+        maxConcurrentRequests: Int = 4,
+        kvBytesPerToken: Int = 0,
+        emitTelemetry: (@Sendable (TelemetryEvent) -> Void)? = nil,
+        makeEngine: () throws -> any CBv2Engine
+    ) -> EngineV2Bridge? {
+        let selection = EngineV2Config.selection(
+            modelId: modelId,
+            environment: environment,
+            configEnabled: configEnabled
+        )
+        guard selection == .v2 else { return nil }
+
+        do {
+            let engine = try makeEngine()
+            return EngineV2Bridge(
+                engine: engine,
+                modelId: modelId,
+                tokenizer: tokenizer,
+                eosTokenIds: eosTokenIds,
+                extraEOSTokens: extraEOSTokens,
+                defaultMaxTokens: defaultMaxTokens,
+                maxConcurrentRequests: maxConcurrentRequests,
+                kvBytesPerToken: kvBytesPerToken,
+                emitTelemetry: emitTelemetry
+            )
+        } catch {
+            emitFallbackTelemetry(
+                modelId: modelId,
+                error: error,
+                emitTelemetry: emitTelemetry
+            )
+            return nil
+        }
+    }
+
+    /// WARN `engine_health` event for a v2-init failure → legacy fallback.
+    /// Fields are drawn from the existing telemetry allowlist (`component`,
+    /// `operation`, `backend`, `model`, `error_class`) — no new wire fields.
+    static func emitFallbackTelemetry(
+        modelId: String,
+        error: Error,
+        emitTelemetry: (@Sendable (TelemetryEvent) -> Void)?
+    ) {
+        var event = TelemetryEvent(
+            source: .provider,
+            severity: .warn,
+            kind: .engineHealth,
+            message: "engine_v2: init failed — falling back to legacy engine"
+        )
+        // Client-side allowlist filter (same as `TelemetryClient.emit`'s
+        // convenience path) — every key here is allowlisted already; the
+        // filter keeps that invariant enforced.
+        event.fields = TelemetryFieldFilter.filter([
+            "component": .string("engine"),
+            "operation": .string("engine_v2_fallback"),
+            "backend": .string("engine_v2"),
+            "model": .string(modelId),
+            "error_class": .string(String(reflecting: type(of: error))),
+        ])
+        if let emitTelemetry {
+            emitTelemetry(event)
+        } else {
+            TelemetryClient.shared.emit(event)
+        }
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2Config.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2Config.swift
@@ -4,29 +4,34 @@
 //
 // The v2 engine (`MLXLMCommon.CBv2Engine`, see
 // libs/mlx-swift-lm/Libraries/MLXLMCommon/ContinuousBatchingV2/CBv2Contracts.swift)
-// is strictly OPT-IN and additive:
+// ships DEFAULT-ON for the allowlisted models as of v0.7.0:
 //
-//   * Flag OFF (default)          → the legacy `BatchedEngine` path runs,
-//                                   byte-identical to today.
-//   * Flag ON + allowlisted model → `EngineV2Factory.makeBridgeIfSelected`
+//   * Allowlisted model (default) → `EngineV2Factory.makeBridgeIfSelected`
 //                                   builds an `EngineV2Bridge` over the v2
 //                                   engine.
-//   * Flag ON + other model       → legacy path (per-model allowlist).
+//   * Any other model             → legacy `BatchedEngine` path,
+//                                   byte-identical to today.
+//   * Kill switch / config off    → legacy path for everything.
 //   * v2 engine init throws       → legacy path + a WARN `engine_health`
-//                                   telemetry event (`engine_v2_fallback`)
-//                                   so a silent fleet-wide fallback is
-//                                   impossible.
+//                                   telemetry event (`engine_v2_fallback`,
+//                                   carrying the model id + error) so a
+//                                   silent fleet-wide fallback is
+//                                   impossible. This fallback is
+//                                   load-bearing for the fleet now that v2
+//                                   is the default.
 //
 // Selection sources, in precedence order:
-//   1. env `DARKBLOOM_ENGINE_V2` — explicit "1"/"true"/"yes"/"on" enables,
-//      explicit "0"/"false"/"no"/"off" force-disables (operator kill switch
-//      that beats the config file).
-//   2. provider config key `engine_v2` under `[backend]` in provider.toml.
+//   1. env `DARKBLOOM_ENGINE_V2` — explicit "0"/"false"/"no"/"off" is the
+//      ABSOLUTE per-box kill switch (beats config, no release needed);
+//      explicit "1"/"true"/"yes"/"on" force-enables.
+//   2. provider config key `engine_v2` under `[backend]` in provider.toml
+//      — **default true** (v0.7.0). Rollback = env kill switch or release
+//      rollback.
 //
-// Per-model allowlist: default `gemma-4*` / `gpt-oss*` glob-prefix patterns
-// (the two families the v2 engine is correct-by-construction for first),
-// overridable via env `DARKBLOOM_ENGINE_V2_MODELS` (comma-separated
-// patterns) for staged rollout.
+// Per-model allowlist: default is the EXACT production checkpoint ids —
+// default-on scope == real-model-validated scope. Operators can widen it
+// via env `DARKBLOOM_ENGINE_V2_MODELS` (comma-separated patterns, e.g. to
+// stage a QAT-4bit build later).
 
 import Foundation
 import MLXLMCommon
@@ -34,19 +39,28 @@ import MLXLMCommon
 // MARK: - Selection
 
 public enum EngineV2Config {
-    /// Master opt-in flag. "1"/"true"/"yes"/"on" enable; "0"/"false"/"no"/
-    /// "off" force-disable (overrides the config key); absent/other defers
-    /// to the `engine_v2` provider-config value.
+    /// Master flag. "0"/"false"/"no"/"off" is the absolute per-box KILL
+    /// SWITCH (beats the config key); "1"/"true"/"yes"/"on" force-enables;
+    /// absent/other defers to the `engine_v2` provider-config value
+    /// (default true as of v0.7.0).
     public static let environmentFlag = "DARKBLOOM_ENGINE_V2"
     /// Optional comma-separated allowlist pattern override
-    /// (e.g. `gemma-4*,gpt-oss*,qwen3*`). Empty/absent keeps the default.
+    /// (exact ids or trailing-`*` prefix globs). Empty/absent keeps the
+    /// default. Use to widen the default-on scope for staged rollout
+    /// (e.g. a QAT-4bit checkpoint later).
     public static let environmentAllowlist = "DARKBLOOM_ENGINE_V2_MODELS"
 
-    /// Model families the v2 engine serves by default when the flag is on.
-    /// Glob-prefix patterns (trailing `*`), matched case-insensitively
-    /// against the model id and its last path component (registry ids can be
-    /// `org/name` shaped, e.g. `mlx-community/gpt-oss-20b-4bit`).
-    public static let defaultModelAllowlist = ["gemma-4*", "gpt-oss*"]
+    /// The models the v2 engine serves by default: the EXACT checkpoint ids
+    /// production serves today — default-on scope == real-model-validated
+    /// scope (both were parity/soak-validated on real weights). Matched
+    /// case-insensitively against the model id and its last path component
+    /// (registry ids are `org/name` shaped). Every other model — including
+    /// other gemma-4 / gpt-oss quantizations — keeps the legacy engine
+    /// until an operator widens the list via `DARKBLOOM_ENGINE_V2_MODELS`.
+    public static let defaultModelAllowlist = [
+        "mlx-community/gpt-oss-20b-MXFP4-Q8",
+        "mlx-community/gemma-4-26b-a4b-it-8bit",
+    ]
 
     public enum Selection: String, Sendable, Equatable {
         case legacy
@@ -85,7 +99,9 @@ public enum EngineV2Config {
     /// Does `modelId` match any allowlist pattern? Patterns are
     /// case-insensitive; a trailing `*` makes them prefix globs, otherwise
     /// they must match exactly. Both the full id and its last `/` component
-    /// are tried so `mlx-community/gemma-4-27b-it-4bit` matches `gemma-4*`.
+    /// are tried on BOTH sides, so `mlx-community/gemma-4-26b-a4b-it-8bit`
+    /// matches the bare pattern `gemma-4-26b-a4b-it-8bit` AND the bare id
+    /// `gpt-oss-20b-MXFP4-Q8` matches the org-qualified default pattern.
     public static func modelAllowlisted(
         _ modelId: String,
         patterns: [String] = defaultModelAllowlist
@@ -101,8 +117,11 @@ public enum EngineV2Config {
                 if id.hasPrefix(prefix) || lastComponent.hasPrefix(prefix) {
                     return true
                 }
-            } else if id == p || lastComponent == p {
-                return true
+            } else {
+                let pLast = p.split(separator: "/").last.map(String.init) ?? p
+                if id == p || lastComponent == p || lastComponent == pLast {
+                    return true
+                }
             }
         }
         return false
@@ -207,6 +226,11 @@ public enum EngineV2Factory {
             "backend": .string("engine_v2"),
             "model": .string(modelId),
             "error_class": .string(String(reflecting: type(of: error))),
+            // Human-readable reason ("error" is allowlisted on both sides).
+            // v2 is default-on for the allowlisted models, so this fallback
+            // is load-bearing — the dashboard needs model + why, not just
+            // the error type.
+            "error": .string(String(describing: error)),
         ])
         if let emitTelemetry {
             emitTelemetry(event)

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2Factory+Production.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2Factory+Production.swift
@@ -52,6 +52,19 @@ enum EngineV2ProductionError: Error, CustomStringConvertible {
 
 extension EngineV2Factory {
 
+    /// Clamp a KV admission ceiling to physical unified memory. A ceiling
+    /// above physical RAM can only come from a mis-derivation upstream; the
+    /// engine would then admit requests that can never fit. Pure/static so it
+    /// is unit-testable without building an engine. `physicalBytes` defaults
+    /// to the machine's real memory; `Int.max`-safe.
+    static func clampKVBytesCapacity(
+        _ kvBytesCapacity: Int,
+        physicalBytes: UInt64 = ProcessInfo.processInfo.physicalMemory
+    ) -> Int {
+        let physicalCap = Int(min(physicalBytes, UInt64(Int.max)))
+        return min(max(0, kvBytesCapacity), physicalCap)
+    }
+
     /// Scheduler knobs for the production v2 engine. `maxConcurrentRequests`
     /// follows the CBv2 product target (4, max 8) rather than the legacy
     /// scheduler's 24-way ceiling — the v2 rollout is deliberately
@@ -76,6 +89,13 @@ extension EngineV2Factory {
         guard kvBytesCapacity > 0 else {
             throw EngineV2ProductionError.noKVHeadroom
         }
+        // Upper-bound sanity: a KV admission ceiling larger than physical
+        // unified memory is nonsensical (only reachable via a bad upstream
+        // computation) and would make the engine admit far past what can ever
+        // fit. Clamp to physical RAM as a cheap guard so a mis-derived budget
+        // degrades to "all of memory" instead of an absurd ceiling. Real
+        // budgets (cap − weights − activations) are always well under this.
+        let cappedCapacity = clampKVBytesCapacity(kvBytesCapacity)
 
         // Model adaptation: layer kinds + per-layer caches come from the
         // model's own CBv2 hooks so the derivation can never drift from the
@@ -105,7 +125,7 @@ extension EngineV2Factory {
         }
 
         let backend = CBv2ContiguousKVBackend(
-            config: CBv2ContiguousBackendConfig(bytesCapacity: kvBytesCapacity))
+            config: CBv2ContiguousBackendConfig(bytesCapacity: cappedCapacity))
         return EngineV2(
             model: CBv2SteppableLanguageModelAdapter(model),
             layerKinds: layerKinds,

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2Factory+Production.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2Factory+Production.swift
@@ -1,0 +1,123 @@
+// Copyright © 2026 Eigen Labs.
+//
+// Production CBv2 engine construction over an ALREADY-LOADED model.
+//
+// `EngineV2Factory.makeBridgeIfSelected` takes the engine as a closure so
+// selection/fallback logic stays engine-agnostic and unit-testable with a
+// scripted stub. This file supplies the closure's production body: assemble
+// the real `MLXLMCommon.EngineV2` from the model the provider just loaded
+// (no re-download, no second weight copy — the engine retains the same
+// module instance the legacy `BatchedEngine` serves) plus the v2 runtime
+// pieces:
+//
+//   * layer kinds + per-layer attending caches from the model's own
+//     `cbv2LayerKinds` / `newCacheV2` (Gemma 4 text, GPT-OSS — the two
+//     families the engine is correct-by-construction for; GPT-OSS's
+//     `newCacheV2` also primes its sinks-activation probe at build time),
+//   * `CBv2ContiguousKVBackend` sized from the unified-memory KV budget
+//     (admission ceiling only — nothing is preallocated),
+//   * `CBv2LayerCacheBank` over the model-built caches,
+//   * `CBv2DefaultSampler` + `CBv2TextDetokenizerFactory` (real incremental
+//     detokenization with stop-string holdback).
+//
+// Any throw here lands in `makeBridgeIfSelected`'s catch: WARN
+// `engine_health` telemetry (`operation=engine_v2_fallback`) + silent
+// legacy fallback — a provider can never lose serving capacity to a v2
+// construction failure.
+
+import Foundation
+import MLXLLM
+import MLXLMCommon
+
+/// Failure modes of production v2-engine construction. Each maps to the
+/// factory's safe-fallback path (WARN telemetry + legacy engine).
+enum EngineV2ProductionError: Error, CustomStringConvertible {
+    /// The loaded module is not a CBv2-adapted family (e.g. an allowlisted
+    /// model id resolved to a VLM wrapper or an unexpected architecture).
+    case unsupportedModel(String)
+    /// No KV byte budget is left under the unified-memory cap — an engine
+    /// admitted with a zero ceiling would reject every request, so fall
+    /// back to the legacy scheduler's shared-budget path instead.
+    case noKVHeadroom
+
+    var description: String {
+        switch self {
+        case .unsupportedModel(let type):
+            return "engine_v2: model type \(type) has no CBv2 adapter"
+        case .noKVHeadroom:
+            return "engine_v2: no KV byte headroom under the unified-memory cap"
+        }
+    }
+}
+
+extension EngineV2Factory {
+
+    /// Scheduler knobs for the production v2 engine. `maxConcurrentRequests`
+    /// follows the CBv2 product target (4, max 8) rather than the legacy
+    /// scheduler's 24-way ceiling — the v2 rollout is deliberately
+    /// conservative and the coordinator sees the true value in heartbeats.
+    static let productionMaxConcurrentRequests = 4
+
+    /// Build the real `EngineV2` over a loaded model.
+    ///
+    /// - Parameters:
+    ///   - model: the loaded language module (the SAME instance the legacy
+    ///     engine serves — weights are shared, never duplicated).
+    ///   - tokenizer: the model's tokenizer, for incremental detokenization.
+    ///   - kvBytesCapacity: admission ceiling for sequence KV, in bytes
+    ///     (derive from `UnifiedMemoryCap.kvBudgetBytes`).
+    ///   - maxConcurrentRequests: concurrent-decode row cap.
+    static func makeProductionEngine(
+        model: any LanguageModel,
+        tokenizer: any MLXLMCommon.Tokenizer,
+        kvBytesCapacity: Int,
+        maxConcurrentRequests: Int = EngineV2Factory.productionMaxConcurrentRequests
+    ) throws -> any CBv2Engine {
+        guard kvBytesCapacity > 0 else {
+            throw EngineV2ProductionError.noKVHeadroom
+        }
+
+        // Model adaptation: layer kinds + per-layer caches come from the
+        // model's own CBv2 hooks so the derivation can never drift from the
+        // constructors (see LayerKindDerivation.swift in mlx-swift-lm).
+        // Neither family uses attention softcapping (Gemma 4's final-logit
+        // softcap lives inside the model's logits path), so the caches take
+        // the default nil softcap.
+        let layerKinds: [CBv2LayerKind]
+        let caches: [any CBv2AttendingLayerCache]
+        switch model {
+        case let gemma as Gemma4TextModel:
+            layerKinds = gemma.cbv2LayerKinds
+            caches = gemma.newCacheV2 { index, kind in
+                CBv2LayerCache(layerIndex: index, kind: kind)
+            }
+        case let gptoss as GPTOSSModel:
+            layerKinds = gptoss.cbv2LayerKinds
+            // GPT-OSS primes its sinks-activation probe inside newCacheV2
+            // (one host readback per layer, HERE at build time — never on
+            // the step path).
+            caches = gptoss.newCacheV2 { index, kind in
+                CBv2LayerCache(layerIndex: index, kind: kind)
+            }
+        default:
+            throw EngineV2ProductionError.unsupportedModel(
+                String(describing: type(of: model)))
+        }
+
+        let backend = CBv2ContiguousKVBackend(
+            config: CBv2ContiguousBackendConfig(bytesCapacity: kvBytesCapacity))
+        return EngineV2(
+            model: CBv2SteppableLanguageModelAdapter(model),
+            layerKinds: layerKinds,
+            backend: backend,
+            cacheProvider: CBv2LayerCacheBank(caches: caches),
+            sampler: CBv2DefaultSampler(),
+            detokenizerFactory: CBv2TextDetokenizerFactory(tokenizer: tokenizer),
+            schedulerConfig: CBv2SchedulerConfig(
+                maxConcurrentRequests: max(1, maxConcurrentRequests)),
+            // TB-007: the v2 prefix cache stays OFF until it has its own
+            // threat-model review (cross-tenant prefix sharing channel).
+            prefixCache: nil
+        )
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2KVSizing.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2KVSizing.swift
@@ -1,0 +1,40 @@
+// Copyright © 2026 Eigen Labs.
+//
+// Per-token KV byte-cost resolution for the ContinuousBatchingV2 bridge.
+//
+// The v2 engine builds UNQUANTIZED (fp16) `CBv2LayerCache`s regardless of the
+// provider's `kv_quant` setting — KV-quant is not yet composed with engine_v2
+// (`EngineV2Factory.makeProductionEngine` always uses `CBv2LayerCache`, never a
+// quantized cache). But the loaded `BatchScheduler` reports its
+// `kvBytesPerToken` at the QUANTIZED rate when `kv_quant = true`, which is
+// 2–4× smaller than fp16. Feeding that quantized rate into the bridge would
+// make heartbeat token budgets (`kvBytesCapacity / kvBytesPerToken`) and
+// active-token counts (`kvBytesInUse / kvBytesPerToken`) OVERSTATE capacity by
+// the same 2–4×, and would under-size the shared-budget KV reservation.
+//
+// This helper picks the fp16 rate for v2 sizing and reports whether a
+// "kv_quant unsupported by engine_v2" WARN should fire (only when kv_quant
+// actually engaged for this model, i.e. the quantized rate is below fp16).
+
+import Foundation
+
+enum EngineV2KVSizing {
+    /// The per-token KV cost the v2 bridge must use, plus whether to WARN that
+    /// `kv_quant` is unsupported by engine_v2 (falls back to fp16 caches).
+    ///
+    /// - Parameters:
+    ///   - quantizedRate: the loaded scheduler's live `kvBytesPerToken`
+    ///     (quantized when `kv_quant` engaged, else already fp16).
+    ///   - fp16Rate: the scheduler's `fp16KVBytesPerToken` — the un-quantized
+    ///     cost, which is what the v2 caches actually consume.
+    /// - Returns: `rate` = fp16 cost to size the bridge with (falls back to
+    ///   the quantized rate only when fp16 is unknown/0); `warnKVQuantUnsupported`
+    ///   = true iff kv_quant engaged (quantized rate strictly below fp16).
+    static func resolve(
+        quantizedRate: Int, fp16Rate: Int
+    ) -> (rate: Int, warnKVQuantUnsupported: Bool) {
+        let rate = fp16Rate > 0 ? fp16Rate : quantizedRate
+        let warn = fp16Rate > 0 && quantizedRate > 0 && quantizedRate < fp16Rate
+        return (rate, warn)
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2KVSizing.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2KVSizing.swift
@@ -37,4 +37,52 @@ enum EngineV2KVSizing {
         let warn = fp16Rate > 0 && quantizedRate > 0 && quantizedRate < fp16Rate
         return (rate, warn)
     }
+
+    /// KV admission ceiling (bytes) for a NEW v2 engine, sized against the
+    /// WHOLE process — round-2 PR#499 P2.
+    ///
+    /// A v2 engine's `kvBytesCapacity` is fixed at construction and its
+    /// private admission ledger (`AdmissionV2`) admits up to it. Sizing each
+    /// slot's ceiling as if only ITS weights were resident lets Σ(ceilings)
+    /// on a default multi-slot provider exceed the unified-memory cap. This
+    /// helper derives the ceiling from the same `UnifiedMemoryCap` policy the
+    /// load gate uses, with the FULL fleet residency subtracted:
+    ///
+    ///     ceiling = kvBudgetBytes(Σ all resident weights, incl. the new
+    ///               model) − Σ(existing v2 engines' admission ceilings)
+    ///
+    /// so at all times Σ(v2 ceilings) ≤ cap − Σweights − activations. An
+    /// existing engine's ceiling cannot be shrunk after the fact (the
+    /// backend's byte capacity is construction-fixed), so later loads are
+    /// CAPPED by what earlier engines were granted; when nothing is left the
+    /// caller gets 0 and `makeProductionEngine` throws `noKVHeadroom` → the
+    /// slot serves via the legacy scheduler (whose shared live-KV gate needs
+    /// no static ceiling). Legacy co-resident slots contribute their weights
+    /// here and gate their KV per-request through `GlobalKVCacheBudget` — as
+    /// v2 requests now also do — so the runtime double-gate stays consistent
+    /// with these static ceilings.
+    ///
+    /// Pure policy (no MLX globals) so it is unit-testable; `physicalBytes`
+    /// defaults to the machine's real memory in production.
+    static func engineKVBytesCapacity(
+        newModelWeightBytes: Int,
+        coResidentWeightBytes: UInt64,
+        existingEngineKVCapacities: [Int],
+        physicalBytes: UInt64 = ProcessInfo.processInfo.physicalMemory
+    ) -> Int {
+        let totalWeights = saturatingAdd(
+            UInt64(max(0, newModelWeightBytes)), coResidentWeightBytes)
+        let fleetBudget = UnifiedMemoryCap.kvBudgetBytes(
+            physicalBytes: physicalBytes, residentWeightBytes: totalWeights)
+        let granted = existingEngineKVCapacities.reduce(UInt64(0)) {
+            saturatingAdd($0, UInt64(max(0, $1)))
+        }
+        let remaining = fleetBudget > granted ? fleetBudget - granted : 0
+        return Int(min(remaining, UInt64(Int.max)))
+    }
+
+    private static func saturatingAdd(_ a: UInt64, _ b: UInt64) -> UInt64 {
+        let (sum, overflow) = a.addingReportingOverflow(b)
+        return overflow ? .max : sum
+    }
 }

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2KVSizing.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2KVSizing.swift
@@ -62,23 +62,67 @@ enum EngineV2KVSizing {
     /// v2 requests now also do — so the runtime double-gate stays consistent
     /// with these static ceilings.
     ///
+    /// `configReserveBytes` is the operator's `memory_reserve_gb` (round-3
+    /// PR#499 P2): the shared `GlobalKVCacheBudget` and load/free-for-load
+    /// paths hold back `max(configReserve, physical − cap)`, so the static v2
+    /// ceiling must derive from the SAME effective cap — otherwise a bridge on
+    /// a 16/32 GiB box (where the default 4 GiB reserve exceeds the
+    /// cap-implied reserve) advertises and privately admits a budget the
+    /// shared gate then rejects post-acceptance.
+    ///
     /// Pure policy (no MLX globals) so it is unit-testable; `physicalBytes`
     /// defaults to the machine's real memory in production.
     static func engineKVBytesCapacity(
         newModelWeightBytes: Int,
         coResidentWeightBytes: UInt64,
         existingEngineKVCapacities: [Int],
+        configReserveBytes: UInt64 = 0,
         physicalBytes: UInt64 = ProcessInfo.processInfo.physicalMemory
     ) -> Int {
         let totalWeights = saturatingAdd(
             UInt64(max(0, newModelWeightBytes)), coResidentWeightBytes)
         let fleetBudget = UnifiedMemoryCap.kvBudgetBytes(
-            physicalBytes: physicalBytes, residentWeightBytes: totalWeights)
+            physicalBytes: physicalBytes, residentWeightBytes: totalWeights,
+            configReserveBytes: configReserveBytes)
         let granted = existingEngineKVCapacities.reduce(UInt64(0)) {
             saturatingAdd($0, UInt64(max(0, $1)))
         }
         let remaining = fleetBudget > granted ? fleetBudget - granted : 0
         return Int(min(remaining, UInt64(Int.max)))
+    }
+
+    /// CURRENT KV byte budget for an EXISTING v2 engine — the HEARTBEAT
+    /// figure, not an engine resize (round-3 PR#499 P2).
+    ///
+    /// A v2 engine's admission ceiling is construction-fixed (the backend's
+    /// byte capacity cannot shrink after the fact), so when ANOTHER model
+    /// loads later — especially a legacy/non-allowlisted slot, whose load
+    /// subtracts nothing from existing v2 ceilings — the engine's private cap
+    /// goes stale against fleet reality: the coordinator keeps routing
+    /// requests that fit the stale budget and the provider's shared KV gate
+    /// rejects them after `inference_accepted`. The fix is a CLAMP on the
+    /// REPORTED max: re-ask the same sizing function with the CURRENT
+    /// resident set (this engine's own weights are inside
+    /// `totalResidentWeightBytes`; co-resident v2 engines' construction
+    /// grants come off the top exactly as at sizing time) and report
+    /// `min(construction grant, current answer)`. The engine's private
+    /// ledger keeps its original grant — only the coordinator-visible budget
+    /// shrinks, so routing converges on what the shared gate will actually
+    /// admit. Σ(reported) never exceeds the current fleet budget.
+    static func liveEngineKVBytesBudget(
+        grantedKVBytesCapacity: Int,
+        totalResidentWeightBytes: UInt64,
+        otherEngineKVCapacities: [Int],
+        configReserveBytes: UInt64 = 0,
+        physicalBytes: UInt64 = ProcessInfo.processInfo.physicalMemory
+    ) -> Int {
+        let current = engineKVBytesCapacity(
+            newModelWeightBytes: 0,
+            coResidentWeightBytes: totalResidentWeightBytes,
+            existingEngineKVCapacities: otherEngineKVCapacities,
+            configReserveBytes: configReserveBytes,
+            physicalBytes: physicalBytes)
+        return min(max(0, grantedKVBytesCapacity), current)
     }
 
     private static func saturatingAdd(_ a: UInt64, _ b: UInt64) -> UInt64 {

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2Logprobs.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2Logprobs.swift
@@ -42,6 +42,9 @@
 // exactly like `delta.content`; nothing here flows into telemetry or logs.
 
 import Foundation
+#if canImport(os)
+import os
+#endif
 
 /// One OpenAI streaming logprobs entry (`choices[].logprobs.content[]`).
 public struct SSETokenLogprob: Codable, Sendable, Equatable {
@@ -123,16 +126,59 @@ public struct EngineV2LogprobsPlumbing: Sendable {
 /// only when the sealed request asked for logprobs AND the slot serves via
 /// the v2 engine). Appended by the bridge pump task, drained by the frames
 /// loop — a plain lock keeps it allocation-cheap on the hot path.
+///
+/// BOUNDED (hardening): the pump appends BEFORE yielding each text chunk and
+/// the frames loop drains per SSE frame, so in the steady state the buffer
+/// holds ~1 frame's worth of entries. But if the frames loop stalls or never
+/// drains (a slow/stuck consumer, a torn-down SSE stream), an unbounded
+/// buffer would grow with every decoded token for the life of the request.
+/// The buffer is therefore capped at `maxEntries` with drop-OLDEST eviction:
+/// under overflow the freshest entries — the ones a resuming consumer would
+/// splice into upcoming frames — are kept, and a dropped count is recorded
+/// (logged once). Dropping logprobs never affects `delta.content`, billing,
+/// or the response hash (they ride out-of-band), so a cap is safe.
 public final class EngineV2LogprobsChannel: @unchecked Sendable {
+    /// Max buffered entries before drop-oldest kicks in. ~4096 tokens of
+    /// undrained logprobs is already far past any real frame cadence.
+    public static let maxEntries = 4096
+
     private let lock = NSLock()
     private var entries: [SSETokenLogprob] = []
+    private var _droppedCount = 0
+    private var loggedDrop = false
+
+    #if canImport(os)
+    private static let logger = Logger(
+        subsystem: "com.darkbloom.provider", category: "engine_v2_logprobs")
+    #endif
 
     public init() {}
 
-    /// Append entries in emission order (pump side).
+    /// Append entries in emission order (pump side). Enforces the `maxEntries`
+    /// cap by dropping the OLDEST entries; the first time any are dropped it
+    /// logs a one-line warning (count only — never token text).
     public func append(_ new: [SSETokenLogprob]) {
         guard !new.isEmpty else { return }
-        lock.withLock { entries.append(contentsOf: new) }
+        let shouldLog: Int? = lock.withLock {
+            entries.append(contentsOf: new)
+            guard entries.count > Self.maxEntries else { return nil }
+            let overflow = entries.count - Self.maxEntries
+            entries.removeFirst(overflow)
+            _droppedCount += overflow
+            if !loggedDrop {
+                loggedDrop = true
+                return _droppedCount
+            }
+            return nil
+        }
+        #if canImport(os)
+        if let total = shouldLog {
+            Self.logger.warning(
+                "engine_v2 logprobs buffer hit \(Self.maxEntries) cap; dropping oldest (\(total) so far) — consumer not draining")
+        }
+        #else
+        _ = shouldLog
+        #endif
     }
 
     /// Remove and return everything appended so far (frames-loop side).
@@ -142,5 +188,10 @@ public final class EngineV2LogprobsChannel: @unchecked Sendable {
             entries = []
             return out
         }
+    }
+
+    /// Total entries evicted by the cap (drop-oldest). 0 in the steady state.
+    public var droppedCount: Int {
+        lock.withLock { _droppedCount }
     }
 }

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2Logprobs.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2Logprobs.swift
@@ -1,0 +1,146 @@
+// Copyright © 2026 Eigen Labs.
+//
+// Logprobs passthrough for the ContinuousBatchingV2 path.
+//
+// The v2 engine populates `CBv2Event.delta.logprobs` when the translated
+// sampling params request them (`request.logprobs == true` →
+// `CBv2SamplingParams.topLogprobs > 0`). The legacy engine NEVER emitted
+// logprobs — no SSE shape exists to match — so the v2 path emits the
+// OpenAI-standard streaming shape instead:
+//
+//     choices[0].logprobs = { "content": [ { token, logprob, bytes,
+//                                            top_logprobs: [...] } ] }
+//
+// The upstream SSE encoder (`MLXOpenAIService.streamChatCompletionFrames` /
+// `OpenAIChatCompletionChunk`) has no logprobs field, and the provider's
+// `GenerationEvent` deliberately stays `.chunk/.info/.error` (extending it
+// would break the "flag off ⇒ byte-identical" legacy invariant). So the
+// entries travel OUT-OF-BAND: the bridge pump converts each delta's
+// logprobs (`EngineV2Translation.sseTokenLogprobs`) and appends them to a
+// per-request `EngineV2LogprobsChannel`; the coordinator inference handler
+// drains the channel per SSE frame and splices the entries into the first
+// content-bearing chunk (`ProviderLoop.injectLogprobs(into:entries:)`)
+// before encryption. Ordering is safe because the pump appends BEFORE
+// yielding the text chunk that produced the entries.
+//
+// Scope: the coordinator serving path only. The standalone `--local` HTTP
+// path serves frames inside the upstream Hummingbird router (no provider
+// seam after SSE encoding), so it does not emit logprobs — same visible
+// behavior as the legacy engine there.
+//
+// KNOWN DEVIATIONS from OpenAI semantics (acceptable for the flag-gated
+// rollout): entries are emitted for EVERY sampled token, so when a
+// reasoning parser or tool handler diverts a token's text away from
+// `delta.content`, that token's entry still attaches to the next visible
+// content chunk (OpenAI omits reasoning/tool tokens from
+// `logprobs.content`). Conversely, trailing entries whose text never
+// renders as content (stop-token holdback, end-of-stream) are dropped
+// with the request.
+//
+// PRIVACY NOTE: entries carry token text — they are response content. They
+// ride only inside the E2E-encrypted SSE stream back to the consumer,
+// exactly like `delta.content`; nothing here flows into telemetry or logs.
+
+import Foundation
+
+/// One OpenAI streaming logprobs entry (`choices[].logprobs.content[]`).
+public struct SSETokenLogprob: Codable, Sendable, Equatable {
+    /// One `top_logprobs` alternative (same wire shape minus the nesting).
+    public struct Top: Codable, Sendable, Equatable {
+        public let token: String
+        public let logprob: Float
+        /// Raw UTF-8 bytes of `token` — the OpenAI escape hatch for BPE
+        /// intermediate tokens whose text is not valid standalone UTF-8.
+        public let bytes: [Int]?
+
+        public init(token: String, logprob: Float, bytes: [Int]?) {
+            self.token = token
+            self.logprob = logprob
+            self.bytes = bytes
+        }
+    }
+
+    public let token: String
+    public let logprob: Float
+    public let bytes: [Int]?
+    public let topLogprobs: [Top]
+
+    enum CodingKeys: String, CodingKey {
+        case token
+        case logprob
+        case bytes
+        case topLogprobs = "top_logprobs"
+    }
+
+    public init(token: String, logprob: Float, bytes: [Int]?, topLogprobs: [Top]) {
+        self.token = token
+        self.logprob = logprob
+        self.bytes = bytes
+        self.topLogprobs = topLogprobs
+    }
+
+    /// JSONSerialization-compatible dictionary in the exact OpenAI wire
+    /// shape. Used by the SSE frame injector, which edits frame JSON
+    /// generically (the upstream chunk type has no logprobs field to
+    /// re-encode through).
+    var jsonObject: [String: Any] {
+        [
+            "token": token,
+            "logprob": Double(logprob),
+            "bytes": bytes ?? [],
+            "top_logprobs": topLogprobs.map { top in
+                [
+                    "token": top.token,
+                    "logprob": Double(top.logprob),
+                    "bytes": top.bytes ?? [],
+                ] as [String: Any]
+            },
+        ]
+    }
+}
+
+/// Per-request logprobs plumbing handed to `MultiModelBatchSchedulerEngine`
+/// by the coordinator inference handler. `topLogprobs` mirrors the sealed
+/// request's OpenAI `top_logprobs` knob (the upstream
+/// `OpenAIChatCompletionRequest` does not model `logprobs`/`top_logprobs`,
+/// so — like `reasoning_effort` and the cache scope — the handler decodes
+/// them from the raw body and threads them in here); `channel` receives the
+/// engine-emitted entries. Present ⇒ the request asked for logprobs.
+public struct EngineV2LogprobsPlumbing: Sendable {
+    public let topLogprobs: Int?
+    public let channel: EngineV2LogprobsChannel
+
+    public init(topLogprobs: Int?, channel: EngineV2LogprobsChannel) {
+        self.topLogprobs = topLogprobs
+        self.channel = channel
+    }
+}
+
+/// Thread-safe per-request FIFO carrying logprob entries from the v2
+/// bridge's event pump to the coordinator path's SSE frame decorator.
+///
+/// One instance per inference request (created by the inference handler
+/// only when the sealed request asked for logprobs AND the slot serves via
+/// the v2 engine). Appended by the bridge pump task, drained by the frames
+/// loop — a plain lock keeps it allocation-cheap on the hot path.
+public final class EngineV2LogprobsChannel: @unchecked Sendable {
+    private let lock = NSLock()
+    private var entries: [SSETokenLogprob] = []
+
+    public init() {}
+
+    /// Append entries in emission order (pump side).
+    public func append(_ new: [SSETokenLogprob]) {
+        guard !new.isEmpty else { return }
+        lock.withLock { entries.append(contentsOf: new) }
+    }
+
+    /// Remove and return everything appended so far (frames-loop side).
+    public func drain() -> [SSETokenLogprob] {
+        lock.withLock {
+            let out = entries
+            entries = []
+            return out
+        }
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2Logprobs.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2Logprobs.swift
@@ -203,4 +203,24 @@ public final class EngineV2LogprobsChannel: @unchecked Sendable {
     public var droppedCount: Int {
         lock.withLock { _droppedCount }
     }
+
+    /// Enforce the channel's `maxEntries` cap on a CALLER-held pending buffer
+    /// (round-3 PR#499 P2). The frames loop drains this channel into a local
+    /// `pendingLogprobs` array and only clears it when a content-bearing
+    /// frame arrives — so a stream that emits many reasoning-only/tool-only
+    /// chunks before any visible `delta.content` (GPT-OSS reasoning) would
+    /// re-accumulate everything the channel cap just bounded. Same policy as
+    /// `append`: drop-OLDEST, keep the freshest window (the entries closest
+    /// to the content that will eventually render), report how many were
+    /// dropped so the caller can log it (count only — never token text).
+    /// Pure and synchronous so it is unit-testable.
+    public static func capPending(
+        _ pending: inout [SSETokenLogprob],
+        maxEntries: Int = EngineV2LogprobsChannel.maxEntries
+    ) -> Int {
+        guard pending.count > maxEntries else { return 0 }
+        let overflow = pending.count - maxEntries
+        pending.removeFirst(overflow)
+        return overflow
+    }
 }

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2Logprobs.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2Logprobs.swift
@@ -127,6 +127,15 @@ public struct EngineV2LogprobsPlumbing: Sendable {
 /// the v2 engine). Appended by the bridge pump task, drained by the frames
 /// loop — a plain lock keeps it allocation-cheap on the hot path.
 ///
+/// WHY A LOCK, NOT AN ACTOR (hardening review): the critical section is a
+/// bounded array append/swap — no I/O, no allocation beyond the append —
+/// contended by exactly TWO parties (one pump, one frames loop), and only
+/// on requests that opted into logprobs. An uncontended `NSLock`
+/// lock/unlock is tens of nanoseconds; converting to an actor would force
+/// the pump to `await` per delta (executor hop + suspension bookkeeping),
+/// which costs more than the lock it replaces and adds reordering risk
+/// before the chunk yield that the current synchronous append precludes.
+///
 /// BOUNDED (hardening): the pump appends BEFORE yielding each text chunk and
 /// the frames loop drains per SSE frame, so in the steady state the buffer
 /// holds ~1 frame's worth of entries. But if the frames loop stalls or never

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2Runtime.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2Runtime.swift
@@ -1,0 +1,85 @@
+// Copyright © 2026 Eigen Labs.
+//
+// Process-wide registry of active `EngineV2Bridge` instances (one per
+// v2-served model). This is the single seam the existing `ProviderLoop`
+// plumbing hooks into:
+//
+//   * `ProviderLoop+Capacity.updateAggregateCapacity` folds
+//     `capacitySummary()` slots into the SAME heartbeat payload as legacy
+//     scheduler slots (no protocol change).
+//   * `ProviderLoop+Cancellation.handleCancellation` fans the coordinator
+//     request-id out through `cancel(requestId:)` → `CBv2Engine.cancel`.
+//
+// Both hooks are no-ops (empty registry, zero allocations beyond the actor
+// hop) when the v2 engine is off, so flag-off behavior stays byte-identical.
+
+import Foundation
+
+public actor EngineV2Runtime {
+    public static let shared = EngineV2Runtime()
+
+    /// modelId → bridge. One bridge per v2-served model, mirroring the
+    /// one-scheduler-per-model shape of the legacy registry.
+    private var bridges: [String: EngineV2Bridge] = [:]
+
+    /// Public init so tests can build isolated instances; production code
+    /// uses `.shared`.
+    public init() {}
+
+    // MARK: - Registration (model lifecycle)
+
+    public func register(modelId: String, bridge: EngineV2Bridge) {
+        bridges[modelId] = bridge
+    }
+
+    /// Remove and return the bridge for `modelId` (caller drives
+    /// `bridge.shutdown()` — unregistering must not silently drop
+    /// in-flight requests).
+    @discardableResult
+    public func unregister(modelId: String) -> EngineV2Bridge? {
+        bridges.removeValue(forKey: modelId)
+    }
+
+    public func bridge(forModel modelId: String) -> EngineV2Bridge? {
+        bridges[modelId]
+    }
+
+    // MARK: - Heartbeat capacity
+
+    public struct CapacitySummary: Sendable {
+        public let slots: [BackendSlotCapacity]
+        public let activeRequests: Int
+
+        public static let empty = CapacitySummary(slots: [], activeRequests: 0)
+    }
+
+    /// Per-model heartbeat slots + aggregate active count for every
+    /// registered bridge. Sorted by model id so heartbeat payloads are
+    /// deterministic. Empty when v2 is off.
+    public func capacitySummary() async -> CapacitySummary {
+        guard !bridges.isEmpty else { return .empty }
+        var slots: [BackendSlotCapacity] = []
+        var activeRequests = 0
+        for modelId in bridges.keys.sorted() {
+            guard let bridge = bridges[modelId] else { continue }
+            slots.append(await bridge.backendSlotCapacity())
+            activeRequests += await bridge.activeRequestCount()
+        }
+        return CapacitySummary(slots: slots, activeRequests: activeRequests)
+    }
+
+    // MARK: - Cancellation fan-out
+
+    /// Forward a coordinator request-id cancellation to whichever bridge
+    /// owns it. Returns true when a bridge accepted the cancel; false when
+    /// no v2 bridge knows the id (the legacy path owns it).
+    @discardableResult
+    public func cancel(requestId: String) async -> Bool {
+        for bridge in bridges.values {
+            if await bridge.cancelIfOwned(requestId: requestId) {
+                return true
+            }
+        }
+        return false
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2Runtime.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2Runtime.swift
@@ -59,17 +59,71 @@ public actor EngineV2Runtime {
         public static let empty = CapacitySummary(slots: [], activeRequests: 0)
     }
 
+    /// Fleet-level inputs for the heartbeat budget CLAMP (round-3 PR#499
+    /// P2). v2 admission ceilings are construction-fixed, so a model loaded
+    /// LATER (especially a legacy/non-allowlisted slot) leaves existing
+    /// bridges advertising a stale `activeTokenBudgetMax`. The heartbeat
+    /// caller (`ProviderLoop.updateAggregateCapacity`) snapshots the CURRENT
+    /// fleet residency here so each bridge's reported max can be recomputed
+    /// from live inputs (`EngineV2KVSizing.liveEngineKVBytesBudget`).
+    public struct FleetKVContext: Sendable {
+        /// Σ resident model weights across ALL slots (v2 AND legacy),
+        /// including each bridge's own model.
+        public let totalResidentWeightBytes: UInt64
+        /// Operator `memory_reserve_gb`, in bytes (see `EngineV2KVSizing`).
+        public let configReserveBytes: UInt64
+        /// Injectable for tests; the machine's real memory in production.
+        public let physicalBytes: UInt64
+
+        public init(
+            totalResidentWeightBytes: UInt64,
+            configReserveBytes: UInt64 = 0,
+            physicalBytes: UInt64 = ProcessInfo.processInfo.physicalMemory
+        ) {
+            self.totalResidentWeightBytes = totalResidentWeightBytes
+            self.configReserveBytes = configReserveBytes
+            self.physicalBytes = physicalBytes
+        }
+    }
+
     /// Per-model heartbeat slots + aggregate active count for every
     /// registered bridge. Sorted by model id so heartbeat payloads are
     /// deterministic. Empty when v2 is off.
-    public func capacitySummary() async -> CapacitySummary {
+    ///
+    /// When `fleetKV` is supplied, each bridge's reported
+    /// `activeTokenBudgetMax` is clamped to the sizing function's CURRENT
+    /// answer for that engine — its construction grant capped by the live
+    /// fleet budget with the OTHER v2 engines' grants subtracted (the same
+    /// derivation `makeEngineV2BridgeForSlot` used at sizing time), so
+    /// Σ(reported budgets) tracks fleet reality as later models load. nil
+    /// preserves the raw construction-time figures.
+    public func capacitySummary(fleetKV: FleetKVContext? = nil) async -> CapacitySummary {
         consultCount += 1
         guard !bridges.isEmpty else { return .empty }
+        // Snapshot every bridge's construction grant first: bridge i's clamp
+        // subtracts the OTHER bridges' grants, so all grants must be read
+        // before any slot is built.
+        var grants: [String: Int] = [:]
+        if fleetKV != nil {
+            for (modelId, bridge) in bridges {
+                grants[modelId] = await bridge.engineKVBytesCapacity()
+            }
+        }
         var slots: [BackendSlotCapacity] = []
         var activeRequests = 0
         for modelId in bridges.keys.sorted() {
             guard let bridge = bridges[modelId] else { continue }
-            slots.append(await bridge.backendSlotCapacity())
+            var clamp: Int?
+            if let fleetKV, let grant = grants[modelId] {
+                let otherGrants = grants.filter { $0.key != modelId }.map(\.value)
+                clamp = EngineV2KVSizing.liveEngineKVBytesBudget(
+                    grantedKVBytesCapacity: grant,
+                    totalResidentWeightBytes: fleetKV.totalResidentWeightBytes,
+                    otherEngineKVCapacities: otherGrants,
+                    configReserveBytes: fleetKV.configReserveBytes,
+                    physicalBytes: fleetKV.physicalBytes)
+            }
+            slots.append(await bridge.backendSlotCapacity(kvBytesBudgetClamp: clamp))
             activeRequests += await bridge.activeRequestCount()
         }
         return CapacitySummary(slots: slots, activeRequests: activeRequests)

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2Runtime.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2Runtime.swift
@@ -80,6 +80,15 @@ public actor EngineV2Runtime {
     /// Forward a coordinator request-id cancellation to whichever bridge
     /// owns it. Returns true when a bridge accepted the cancel; false when
     /// no v2 bridge knows the id (the legacy path owns it).
+    ///
+    /// O(n) BY DESIGN (hardening review): n is the number of v2-SERVED
+    /// MODELS — bounded by the provider's `max_model_slots` (single digits;
+    /// production default ≤ 3) — not the number of requests, and each probe
+    /// is a dictionary hit inside the owning bridge. Cancellation is a rare,
+    /// non-hot event (client disconnects). A request-id → bridge index would
+    /// make this O(1) but adds per-request cross-actor register/unregister
+    /// traffic on the hot submit/finish paths of every bridge — strictly
+    /// more work overall than scanning ≤ 3 entries here.
     @discardableResult
     public func cancel(requestId: String) async -> Bool {
         consultCount += 1

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2Runtime.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2Runtime.swift
@@ -10,8 +10,9 @@
 //   * `ProviderLoop+Cancellation.handleCancellation` fans the coordinator
 //     request-id out through `cancel(requestId:)` → `CBv2Engine.cancel`.
 //
-// Both hooks are no-ops (empty registry, zero allocations beyond the actor
-// hop) when the v2 engine is off, so flag-off behavior stays byte-identical.
+// Both hooks guard on `ProviderLoop.hasEngineV2Slots` BEFORE hopping here,
+// so when the v2 engine is off they cost zero — no actor hop, no
+// allocations — and flag-off behavior stays byte-identical.
 
 import Foundation
 
@@ -21,6 +22,11 @@ public actor EngineV2Runtime {
     /// modelId → bridge. One bridge per v2-served model, mirroring the
     /// one-scheduler-per-model shape of the legacy registry.
     private var bridges: [String: EngineV2Bridge] = [:]
+
+    /// Test instrumentation: total `capacitySummary()` + `cancel(requestId:)`
+    /// invocations. Lets tests prove the flag-off production paths never
+    /// consult the runtime (the zero-overhead guard).
+    private(set) var consultCount = 0
 
     /// Public init so tests can build isolated instances; production code
     /// uses `.shared`.
@@ -57,6 +63,7 @@ public actor EngineV2Runtime {
     /// registered bridge. Sorted by model id so heartbeat payloads are
     /// deterministic. Empty when v2 is off.
     public func capacitySummary() async -> CapacitySummary {
+        consultCount += 1
         guard !bridges.isEmpty else { return .empty }
         var slots: [BackendSlotCapacity] = []
         var activeRequests = 0
@@ -75,6 +82,7 @@ public actor EngineV2Runtime {
     /// no v2 bridge knows the id (the legacy path owns it).
     @discardableResult
     public func cancel(requestId: String) async -> Bool {
+        consultCount += 1
         for bridge in bridges.values {
             if await bridge.cancelIfOwned(requestId: requestId) {
                 return true

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2SamplingOverrides.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2SamplingOverrides.swift
@@ -1,0 +1,39 @@
+// Copyright © 2026 Eigen Labs.
+//
+// Sampling fields that ride the E2E-sealed request body but are NOT modeled
+// by the upstream `OpenAIChatCompletionRequest` shape (see
+// `libs/mlx-swift-lm/Libraries/MLXLMServer/Protocol/OpenAIProtocol.swift`).
+//
+// The coordinator inference handler strict-decodes inbound requests into the
+// upstream shape, so anything absent from it must be decoded straight from
+// the raw body and threaded in out-of-band — the same pattern
+// `reasoning_effort`, the prefix-cache scope, and `logprobs`/`top_logprobs`
+// already use (`ProviderLoop+InboundDecode`). Without this, OpenAI
+// `logit_bias` and `seed` were silently dropped on the coordinator serving
+// path: `MultiModelBatchSchedulerEngine.translate` rebuilt the internal
+// `ChatCompletionRequest` from the upstream shape only, so
+// `EngineV2Translation.parseLogitBias(request.logit_bias)` always saw nil.
+//
+// Consumed by the v2 engine path only (`EngineV2Translation.samplingParams`);
+// the legacy engine never honored either knob, and its submit call is left
+// byte-identical (flag-off invariant).
+
+import Foundation
+
+/// OpenAI sampling knobs decoded out-of-band from the sealed request body
+/// and overlaid onto the v2 engine translation. Present ⇒ the request
+/// carried at least one of the fields.
+public struct EngineV2SamplingOverrides: Sendable, Equatable {
+    /// OpenAI `logit_bias`: token-id (STRING keys on the wire) → additive
+    /// bias. Parsed to `[Int: Float]` by `EngineV2Translation.parseLogitBias`
+    /// (invalid keys dropped, never guessed).
+    public let logitBias: [String: Float]?
+    /// OpenAI `seed` for best-effort reproducible sampling
+    /// (`CBv2SamplingParams.seed`; RNG key is (seed, requestID, stepIndex)).
+    public let seed: UInt64?
+
+    public init(logitBias: [String: Float]?, seed: UInt64?) {
+        self.logitBias = logitBias
+        self.seed = seed
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Inference/GlobalKVCacheBudget.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/GlobalKVCacheBudget.swift
@@ -97,29 +97,6 @@ public actor GlobalKVCacheBudget {
         reservations.removeValue(forKey: requestID)
     }
 
-    /// Record an ENGINE-managed KV reservation for one in-flight
-    /// ContinuousBatchingV2 request. Unlike `reserve`, this is UNCONDITIONAL
-    /// (never rejects) and does not gate admission: the v2 engine runs its
-    /// OWN optimistic + preemption admission against its private byte ledger
-    /// (`AdmissionV2`, sized to the engine's `kvBytesCapacity`), so it — not
-    /// this shared budget — stays authoritative for whether a v2 request is
-    /// accepted. This exists ONLY so `outstandingReservedBytes()` (which the
-    /// model-LOAD gate `availableMemoryGb` and the legacy live-KV gate both
-    /// subtract) truthfully includes v2 in-flight KV. Without it, a legacy
-    /// model loaded (or a legacy request admitted) alongside an active v2
-    /// slot computes headroom blind to the v2 engine's committed KV and could
-    /// over-commit unified memory. Sizes the worst-case footprint
-    /// (prompt + maxTokens) at the UNQUANTIZED rate — engine_v2 builds fp16
-    /// caches — exactly mirroring the legacy per-request `reserve` amount, so
-    /// the two engines contribute to the shared ledger on the same basis.
-    /// Idempotent on a duplicate id; released via `release(requestID:)`.
-    public func recordEngineKV(requestID: String, kvBytesPerToken: Int, tokenCount: Int) {
-        guard kvBytesPerToken > 0, tokenCount > 0, reservations[requestID] == nil else { return }
-        let (bytes, overflow) = UInt64(kvBytesPerToken)
-            .multipliedReportingOverflow(by: UInt64(tokenCount))
-        reservations[requestID] = overflow ? .max : bytes
-    }
-
     /// Reserve an arbitrary BYTE amount against the same live cap headroom KV
     /// uses. For non-KV unified-memory consumers that the cap would otherwise be
     /// blind to — notably VLM media decode (CIImage rasters + Swift Data pixel

--- a/provider-swift/Sources/ProviderCore/Inference/GlobalKVCacheBudget.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/GlobalKVCacheBudget.swift
@@ -97,6 +97,29 @@ public actor GlobalKVCacheBudget {
         reservations.removeValue(forKey: requestID)
     }
 
+    /// Record an ENGINE-managed KV reservation for one in-flight
+    /// ContinuousBatchingV2 request. Unlike `reserve`, this is UNCONDITIONAL
+    /// (never rejects) and does not gate admission: the v2 engine runs its
+    /// OWN optimistic + preemption admission against its private byte ledger
+    /// (`AdmissionV2`, sized to the engine's `kvBytesCapacity`), so it — not
+    /// this shared budget — stays authoritative for whether a v2 request is
+    /// accepted. This exists ONLY so `outstandingReservedBytes()` (which the
+    /// model-LOAD gate `availableMemoryGb` and the legacy live-KV gate both
+    /// subtract) truthfully includes v2 in-flight KV. Without it, a legacy
+    /// model loaded (or a legacy request admitted) alongside an active v2
+    /// slot computes headroom blind to the v2 engine's committed KV and could
+    /// over-commit unified memory. Sizes the worst-case footprint
+    /// (prompt + maxTokens) at the UNQUANTIZED rate — engine_v2 builds fp16
+    /// caches — exactly mirroring the legacy per-request `reserve` amount, so
+    /// the two engines contribute to the shared ledger on the same basis.
+    /// Idempotent on a duplicate id; released via `release(requestID:)`.
+    public func recordEngineKV(requestID: String, kvBytesPerToken: Int, tokenCount: Int) {
+        guard kvBytesPerToken > 0, tokenCount > 0, reservations[requestID] == nil else { return }
+        let (bytes, overflow) = UInt64(kvBytesPerToken)
+            .multipliedReportingOverflow(by: UInt64(tokenCount))
+        reservations[requestID] = overflow ? .max : bytes
+    }
+
     /// Reserve an arbitrary BYTE amount against the same live cap headroom KV
     /// uses. For non-KV unified-memory consumers that the cap would otherwise be
     /// blind to — notably VLM media decode (CIImage rasters + Swift Data pixel

--- a/provider-swift/Sources/ProviderCore/Inference/LegacyCompiledDecodeGate.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/LegacyCompiledDecodeGate.swift
@@ -1,0 +1,64 @@
+// Copyright © 2026 Eigen Labs.
+//
+// LegacyCompiledDecodeGate — makes the LEGACY engine's compiled decode
+// OPT-IN at the provider level.
+//
+// The mlx-swift-lm library ships `CompiledDecode.isEnabled` default-ON
+// (env `DARKBLOOM_COMPILED_DECODE`, absent ⇒ enabled). Shipping that
+// default would silently re-arm the exact code path v0.6.30 rolled back
+// for prod Gemma: compile-on-first-dispatch cold start plus the known
+// B=1 window-straddle divergence. Release behavior must stay identical
+// to current prod (v0.6.30); single-stream speed comes from the v2
+// engine canary instead.
+//
+// Resolution order (first match wins):
+//   1. env `DARKBLOOM_COMPILED_DECODE` explicitly set — the operator's
+//      per-box word is absolute; the gate never touches it.
+//   2. config `legacy_compiled_decode = true` under `[backend]` — leave
+//      the env unset so the library default (ON) applies.
+//   3. default — force `DARKBLOOM_COMPILED_DECODE=0` into the process
+//      environment so the library latches compiled decode OFF.
+//
+// MUST run before any engine/model code: `CompiledDecode.isEnabled` is a
+// `static let`, latched on first access. Both serve entry points
+// (`ProviderLoop.run()` and `StandaloneServer.start()`) apply the gate
+// as their first action. (`setenv` is reflected by
+// `ProcessInfo.processInfo.environment` on Darwin — verified in tests.)
+
+import Foundation
+
+public enum LegacyCompiledDecodeGate {
+    /// The env var the mlx-swift-lm `CompiledDecode` gate reads.
+    public static let envKey = "DARKBLOOM_COMPILED_DECODE"
+
+    /// Pure decision: the value to force into the environment, or nil to
+    /// leave it untouched. Unit-testable without process-env side effects.
+    ///
+    ///   * env set (non-empty) → nil (operator override wins, either way)
+    ///   * config enabled      → nil (library default ON applies)
+    ///   * otherwise           → "0" (disable legacy compiled decode)
+    static func resolvedOverride(
+        configEnabled: Bool,
+        environment: [String: String]
+    ) -> String? {
+        if let raw = environment[envKey], !raw.isEmpty {
+            return nil
+        }
+        return configEnabled ? nil : "0"
+    }
+
+    /// Apply the gate to the real process environment. Returns true when
+    /// the env var was written (i.e. compiled decode was forced off).
+    @discardableResult
+    public static func apply(
+        configEnabled: Bool,
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> Bool {
+        guard
+            let value = resolvedOverride(
+                configEnabled: configEnabled, environment: environment)
+        else { return false }
+        setenv(envKey, value, 1)
+        return true
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Inference/MultiModelBatchSchedulerEngine+Registry.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/MultiModelBatchSchedulerEngine+Registry.swift
@@ -32,16 +32,23 @@ public extension MultiModelBatchSchedulerEngine {
         /// `vision_config`). When true, requests that carry image/video
         /// content are routed to the container's vision path.
         public let isVLM: Bool
+        /// ContinuousBatchingV2 bridge for this model (flag-gated). When
+        /// non-nil, text generation routes through the v2 engine instead of
+        /// `scheduler` — see `streamChatCompletion`. nil (the default, and
+        /// every fallback path) keeps the legacy path byte-identical.
+        public let engineV2Bridge: EngineV2Bridge?
 
         public init(
             scheduler: BatchScheduler, tokenizer: TokenizerHandle, modelType: String? = nil,
-            container: ModelContainer? = nil, isVLM: Bool = false
+            container: ModelContainer? = nil, isVLM: Bool = false,
+            engineV2Bridge: EngineV2Bridge? = nil
         ) {
             self.scheduler = scheduler
             self.tokenizer = tokenizer
             self.modelType = modelType
             self.container = container
             self.isVLM = isVLM
+            self.engineV2Bridge = engineV2Bridge
         }
     }
 
@@ -66,6 +73,9 @@ public extension MultiModelBatchSchedulerEngine {
         public let container: ModelContainer?
         /// Whether this model is a vision-language model.
         public let isVLM: Bool
+        /// ContinuousBatchingV2 bridge for this model (flag-gated) — see
+        /// ``ModelRegistryEntry/engineV2Bridge``.
+        public let engineV2Bridge: EngineV2Bridge?
 
         public init(
             scheduler: BatchScheduler,
@@ -73,7 +83,8 @@ public extension MultiModelBatchSchedulerEngine {
             releaseToken: OneShotRelease,
             modelType: String? = nil,
             container: ModelContainer? = nil,
-            isVLM: Bool = false
+            isVLM: Bool = false,
+            engineV2Bridge: EngineV2Bridge? = nil
         ) {
             self.scheduler = scheduler
             self.tokenizer = tokenizer
@@ -81,6 +92,7 @@ public extension MultiModelBatchSchedulerEngine {
             self.modelType = modelType
             self.container = container
             self.isVLM = isVLM
+            self.engineV2Bridge = engineV2Bridge
         }
     }
 }

--- a/provider-swift/Sources/ProviderCore/Inference/MultiModelBatchSchedulerEngine+Translation.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/MultiModelBatchSchedulerEngine+Translation.swift
@@ -21,35 +21,35 @@ extension MultiModelBatchSchedulerEngine {
     /// Multimodal content parts are collapsed to text (image URLs are
     /// dropped) because the BatchScheduler is text-only.
     ///
-    /// KNOWN DEVIATION (P1 #3): `seed` is dropped on this path because
-    /// the upstream `OpenAIChatCompletionRequest` does not expose a
-    /// `seed` field today (see
-    /// `libs/mlx-swift-lm/Libraries/MLXLMServer/Protocol/OpenAIProtocol.swift`).
-    /// The internal `ChatCompletionRequest` shape does carry a `seed`
-    /// field, but inbound requests are decoded straight into the upstream
-    /// `OpenAIChatCompletionRequest` (which omits it), so the value never
-    /// reaches this translation step.
-    /// The wire-level result is that seeded reproducibility is not
-    /// available in OpenAI-compatible mode and the engine's default
-    /// sampler RNG is used. Tracking upstream:
-    /// https://github.com/Layr-Labs/mlx-swift-lm/issues — add `seed`
-    /// to `OpenAIChatCompletionRequest` and then plumb it through here.
+    /// KNOWN DEVIATION (P1 #3, narrowed): the upstream
+    /// `OpenAIChatCompletionRequest` does not expose `seed` or `logit_bias`
+    /// fields today (see
+    /// `libs/mlx-swift-lm/Libraries/MLXLMServer/Protocol/OpenAIProtocol.swift`),
+    /// so a translation from the upstream shape ALONE always yields
+    /// `seed == nil` / `logit_bias == nil`. On the coordinator serving path
+    /// they are recovered the same way `logprobs`/`top_logprobs` are: decoded
+    /// straight from the sealed body
+    /// (`ProviderLoop.extractSamplingOverrides`) and overlaid here via the
+    /// `logitBias`/`seed` parameters (v2 engine path only; the legacy engine
+    /// honors neither knob and its submit call is unchanged). The standalone
+    /// `--local` path still drops both — it decodes inside the upstream
+    /// Hummingbird router with no provider seam — pending the upstream shape
+    /// gaining the fields.
     /// We intentionally do NOT smuggle `seed` through the OpenAI `user`
     /// field (the other free-form caller field) because we may need to
     /// repurpose `user` for cancellation / request-id correlation in
     /// the future and double-booking that field would be a layering
     /// trap.
     /// `logprobs`/`topLogprobs` overlay the OpenAI knobs of the same names
-    /// onto the internal shape. Like `seed`, the upstream
-    /// `OpenAIChatCompletionRequest` does not model them, so on the
-    /// coordinator path they are decoded from the sealed body and threaded
-    /// in via `EngineV2LogprobsPlumbing` (v2 engine path only; the legacy
-    /// engine ignores the fields).
+    /// onto the internal shape; on the coordinator path they arrive via
+    /// `EngineV2LogprobsPlumbing`.
     static func translate(
         openAIRequest request: OpenAIChatCompletionRequest,
         defaultMaxTokens: Int,
         logprobs: Bool? = nil,
-        topLogprobs: Int? = nil
+        topLogprobs: Int? = nil,
+        logitBias: [String: Float]? = nil,
+        seed: UInt64? = nil
     ) -> ChatCompletionRequest {
         let stop: StopSequences? = {
             guard let stops = request.stop, !stops.isEmpty else { return nil }
@@ -69,11 +69,14 @@ extension MultiModelBatchSchedulerEngine {
             frequency_penalty: request.frequencyPenalty,
             stream: request.stream,
             stop: stop,
-            seed: nil, // P1 #3: see KNOWN DEVIATION on `translate(...)`.
+            // Sealed-body overlay (nil unless the coordinator handler decoded
+            // one) — see KNOWN DEVIATION on `translate(...)`.
+            seed: seed,
             tools: nil,
             tool_choice: nil,
             response_format: nil,
             user: nil,
+            logit_bias: logitBias,
             logprobs: logprobs,
             top_logprobs: topLogprobs
         )

--- a/provider-swift/Sources/ProviderCore/Inference/MultiModelBatchSchedulerEngine+Translation.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/MultiModelBatchSchedulerEngine+Translation.swift
@@ -39,9 +39,17 @@ extension MultiModelBatchSchedulerEngine {
     /// repurpose `user` for cancellation / request-id correlation in
     /// the future and double-booking that field would be a layering
     /// trap.
+    /// `logprobs`/`topLogprobs` overlay the OpenAI knobs of the same names
+    /// onto the internal shape. Like `seed`, the upstream
+    /// `OpenAIChatCompletionRequest` does not model them, so on the
+    /// coordinator path they are decoded from the sealed body and threaded
+    /// in via `EngineV2LogprobsPlumbing` (v2 engine path only; the legacy
+    /// engine ignores the fields).
     static func translate(
         openAIRequest request: OpenAIChatCompletionRequest,
-        defaultMaxTokens: Int
+        defaultMaxTokens: Int,
+        logprobs: Bool? = nil,
+        topLogprobs: Int? = nil
     ) -> ChatCompletionRequest {
         let stop: StopSequences? = {
             guard let stops = request.stop, !stops.isEmpty else { return nil }
@@ -65,7 +73,9 @@ extension MultiModelBatchSchedulerEngine {
             tools: nil,
             tool_choice: nil,
             response_format: nil,
-            user: nil
+            user: nil,
+            logprobs: logprobs,
+            top_logprobs: topLogprobs
         )
     }
 }

--- a/provider-swift/Sources/ProviderCore/Inference/MultiModelBatchSchedulerEngine.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/MultiModelBatchSchedulerEngine.swift
@@ -466,9 +466,15 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
                                 continuation.yield(.content(text))
                             }
                         }
-                    case .info(let p, let c, _):
+                    case .info(let p, let c, _, let reason):
                         promptTokenCount = p
                         completionTokens = c
+                        // Engine-reported finish reason ("stop"/"length");
+                        // nil (cancel-partials, older paths) keeps "stop".
+                        // Threaded into ServerGenerationInfo.stopReason below,
+                        // which MLXOpenAIService emits as finish_reason —
+                        // max_tokens truncations now reach clients as "length".
+                        if let reason { stopReason = reason }
                     case .error(let message):
                         failed = message
                     }

--- a/provider-swift/Sources/ProviderCore/Inference/MultiModelBatchSchedulerEngine.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/MultiModelBatchSchedulerEngine.swift
@@ -82,8 +82,17 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
     private let reasoningEffort: String?
     /// Per-tenant prefix-cache scope (`SHA256(prompt_cache_key)`/`user`, ""
     /// ⇒ unscoped). Threaded into `submitTokenized` so the checkpoint cache is
-    /// partitioned per consumer (closes the TB-007 cross-tenant channel).
+    /// partitioned per consumer (closes the TB-007 cross-tenant channel). On
+    /// the v2 path the same value maps onto `CBv2Request.cacheSalt` (inert
+    /// today — the production v2 engine is built with `prefixCache: nil`).
     private let cacheScope: String
+    /// Per-request logprobs plumbing (v2 engine path only; the legacy engine
+    /// never emitted logprobs). Non-nil ⇒ the sealed request asked for
+    /// logprobs: the v2 translation flips `logprobs`/`top_logprobs` on so
+    /// the engine captures them, and the bridge publishes OpenAI-shaped
+    /// entries to `engineV2Logprobs.channel` for the caller's SSE frame
+    /// decorator. Ignored (silently) when the model serves via legacy.
+    private let engineV2Logprobs: EngineV2LogprobsPlumbing?
 
     public init(
         registryProvider: @escaping @Sendable () async -> Registry,
@@ -92,7 +101,8 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
         releaseModel: @escaping @Sendable (String) async -> Void = { _ in },
         defaultMaxTokens: Int = 4096,
         reasoningEffort: String? = nil,
-        cacheScope: String = ""
+        cacheScope: String = "",
+        engineV2Logprobs: EngineV2LogprobsPlumbing? = nil
     ) {
         self.registryProvider = registryProvider
         self.ensureLoaded = ensureLoaded
@@ -101,6 +111,7 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
         self.defaultMaxTokens = defaultMaxTokens
         self.reasoningEffort = reasoningEffort
         self.cacheScope = cacheScope
+        self.engineV2Logprobs = engineV2Logprobs
         self.acquire = nil
         self.tokenizerProvider = nil
         self.availableModelsOverride = nil
@@ -139,6 +150,10 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
         // ⇒ unscoped (default). Set via DARKBLOOM_PREFIX_CACHE_SCOPE; used to
         // exercise/validate cross-tenant isolation on a single box.
         self.cacheScope = cacheScope
+        // The --local path serves SSE frames inside the upstream router, so
+        // there is no provider seam to decorate frames with logprobs on this
+        // init (same visible behavior as the legacy engine: none emitted).
+        self.engineV2Logprobs = nil
     }
 
     // MARK: - MLXServerEngine
@@ -366,10 +381,20 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
                 promptTokens: promptTokens,
                 // Sampling/stop/max-token translation reuses the OpenAI →
                 // internal request mapping (`EngineV2Translation` reads the
-                // internal shape).
+                // internal shape). `logprobs`/`top_logprobs` are not on the
+                // upstream request shape, so they arrive via the
+                // `engineV2Logprobs` plumbing and are overlaid here.
                 request: Self.translate(
-                    openAIRequest: request, defaultMaxTokens: defaultMaxTokens),
-                requestId: requestId
+                    openAIRequest: request, defaultMaxTokens: defaultMaxTokens,
+                    logprobs: engineV2Logprobs != nil ? true : nil,
+                    topLogprobs: engineV2Logprobs?.topLogprobs),
+                requestId: requestId,
+                // Same per-tenant scope the legacy submit threads into the
+                // checkpoint cache; the bridge maps it to CBv2Request.cacheSalt
+                // (TB-007; inert — production builds the engine with
+                // prefixCache: nil).
+                cacheScope: cacheScope,
+                logprobsChannel: engineV2Logprobs?.channel
             )
             cancelUpstream = { await bridge.cancel(requestId: requestId) }
         } else {

--- a/provider-swift/Sources/ProviderCore/Inference/MultiModelBatchSchedulerEngine.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/MultiModelBatchSchedulerEngine.swift
@@ -93,6 +93,14 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
     /// entries to `engineV2Logprobs.channel` for the caller's SSE frame
     /// decorator. Ignored (silently) when the model serves via legacy.
     private let engineV2Logprobs: EngineV2LogprobsPlumbing?
+    /// OpenAI `logit_bias`/`seed` decoded out-of-band from the sealed body
+    /// (the upstream `OpenAIChatCompletionRequest` models neither — same
+    /// pattern as `engineV2Logprobs`/`reasoningEffort`/`cacheScope`).
+    /// Overlaid onto the v2 translation so
+    /// `EngineV2Translation.samplingParams` sees the real values; ignored
+    /// (silently) when the model serves via legacy, which never honored
+    /// either knob.
+    private let engineV2Sampling: EngineV2SamplingOverrides?
 
     public init(
         registryProvider: @escaping @Sendable () async -> Registry,
@@ -102,7 +110,8 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
         defaultMaxTokens: Int = 4096,
         reasoningEffort: String? = nil,
         cacheScope: String = "",
-        engineV2Logprobs: EngineV2LogprobsPlumbing? = nil
+        engineV2Logprobs: EngineV2LogprobsPlumbing? = nil,
+        engineV2Sampling: EngineV2SamplingOverrides? = nil
     ) {
         self.registryProvider = registryProvider
         self.ensureLoaded = ensureLoaded
@@ -112,6 +121,7 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
         self.reasoningEffort = reasoningEffort
         self.cacheScope = cacheScope
         self.engineV2Logprobs = engineV2Logprobs
+        self.engineV2Sampling = engineV2Sampling
         self.acquire = nil
         self.tokenizerProvider = nil
         self.availableModelsOverride = nil
@@ -154,6 +164,11 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
         // there is no provider seam to decorate frames with logprobs on this
         // init (same visible behavior as the legacy engine: none emitted).
         self.engineV2Logprobs = nil
+        // Same reason: the --local path decodes the raw body inside the
+        // upstream router, so `logit_bias`/`seed` cannot be recovered here
+        // (the upstream request shape omits them — see the KNOWN DEVIATION on
+        // `translate(...)`).
+        self.engineV2Sampling = nil
     }
 
     // MARK: - MLXServerEngine
@@ -381,13 +396,17 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
                 promptTokens: promptTokens,
                 // Sampling/stop/max-token translation reuses the OpenAI →
                 // internal request mapping (`EngineV2Translation` reads the
-                // internal shape). `logprobs`/`top_logprobs` are not on the
-                // upstream request shape, so they arrive via the
-                // `engineV2Logprobs` plumbing and are overlaid here.
+                // internal shape). `logprobs`/`top_logprobs` and
+                // `logit_bias`/`seed` are not on the upstream request shape,
+                // so they arrive via the `engineV2Logprobs`/`engineV2Sampling`
+                // plumbing (decoded from the sealed body) and are overlaid
+                // here.
                 request: Self.translate(
                     openAIRequest: request, defaultMaxTokens: defaultMaxTokens,
                     logprobs: engineV2Logprobs != nil ? true : nil,
-                    topLogprobs: engineV2Logprobs?.topLogprobs),
+                    topLogprobs: engineV2Logprobs?.topLogprobs,
+                    logitBias: engineV2Sampling?.logitBias,
+                    seed: engineV2Sampling?.seed),
                 requestId: requestId,
                 // Same per-tenant scope the legacy submit threads into the
                 // checkpoint cache; the bridge maps it to CBv2Request.cacheSalt

--- a/provider-swift/Sources/ProviderCore/Inference/MultiModelBatchSchedulerEngine.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/MultiModelBatchSchedulerEngine.swift
@@ -165,6 +165,7 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
         let releaseBox: OneShotRelease
         let container: ModelContainer?
         let isVLM: Bool
+        let engineV2Bridge: EngineV2Bridge?
         let modelId = request.model
         if let acquire {
             let acquired = try await acquire(modelId)
@@ -174,6 +175,7 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
             releaseBox = acquired.releaseToken
             container = acquired.container
             isVLM = acquired.isVLM
+            engineV2Bridge = acquired.engineV2Bridge
         } else {
             try await ensureLoaded(modelId)
             let registry = await (registryProvider?() ?? [:])
@@ -187,6 +189,7 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
             releaseBox = OneShotRelease(release: releaseModel, modelId: modelId)
             container = entry.container
             isVLM = entry.isVLM
+            engineV2Bridge = entry.engineV2Bridge
         }
 
         // Multimodal (image/video) requests can't flow through the token-only
@@ -343,19 +346,48 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
         }
 
         let requestId = "req-\(UUID().uuidString.prefix(12))"
-        let upstream = await scheduler.submitTokenized(
-            promptTokens: promptTokens,
-            maxTokens: maxTokens,
-            temperature: temperature,
-            topP: request.topP,
-            topK: request.topK,
-            requestId: requestId,
-            cacheScope: cacheScope,
-            // Keep tool-bearing requests off the greedy text-only B=1 fast path:
-            // it cannot reproduce the engine's raw-text tool-call contract. No
-            // tools ⇒ fast path may apply (subject to the scheduler's gates).
-            allowFastPath: toolHandler == nil
-        )
+
+        // ContinuousBatchingV2 routing (flag-gated): when the resolved model
+        // carries a v2 bridge, submit the SAME tokenized prompt through it.
+        // The bridge yields the identical `AsyncStream<GenerationEvent>`
+        // shape the scheduler produces, so everything downstream — tool-call
+        // parsing, SSE framing, error→status mapping, billing extraction —
+        // is engine-agnostic. nil bridge ⇒ the legacy path, byte-identical.
+        //
+        // INTENTIONAL sampling delta on the v2 path: the legacy submit below
+        // forwards only temperature/topP/topK, silently dropping repetition/
+        // frequency/presence penalties and `stop` strings; the v2 translation
+        // honors them (more OpenAI-faithful). Identical wire requests using
+        // those knobs therefore sample differently across the two engines.
+        let upstream: AsyncStream<GenerationEvent>
+        let cancelUpstream: @Sendable () async -> Void
+        if let bridge = engineV2Bridge {
+            upstream = await bridge.submitTokenized(
+                promptTokens: promptTokens,
+                // Sampling/stop/max-token translation reuses the OpenAI →
+                // internal request mapping (`EngineV2Translation` reads the
+                // internal shape).
+                request: Self.translate(
+                    openAIRequest: request, defaultMaxTokens: defaultMaxTokens),
+                requestId: requestId
+            )
+            cancelUpstream = { await bridge.cancel(requestId: requestId) }
+        } else {
+            upstream = await scheduler.submitTokenized(
+                promptTokens: promptTokens,
+                maxTokens: maxTokens,
+                temperature: temperature,
+                topP: request.topP,
+                topK: request.topK,
+                requestId: requestId,
+                cacheScope: cacheScope,
+                // Keep tool-bearing requests off the greedy text-only B=1 fast path:
+                // it cannot reproduce the engine's raw-text tool-call contract. No
+                // tools ⇒ fast path may apply (subject to the scheduler's gates).
+                allowFastPath: toolHandler == nil
+            )
+            cancelUpstream = { await scheduler.cancel(requestId: requestId) }
+        }
 
         return AsyncThrowingStream { continuation in
             let task = Task {
@@ -370,7 +402,7 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
 
                 for await event in upstream {
                     if Task.isCancelled {
-                        await scheduler.cancel(requestId: requestId)
+                        await cancelUpstream()
                         await releaseBox.fire()
                         continuation.finish()
                         return
@@ -441,7 +473,7 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
             continuation.onTermination = { @Sendable _ in
                 task.cancel()
                 Task {
-                    await scheduler.cancel(requestId: requestId)
+                    await cancelUpstream()
                     await releaseBox.fire()
                 }
             }

--- a/provider-swift/Sources/ProviderCore/Inference/UnifiedMemoryCap.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/UnifiedMemoryCap.swift
@@ -99,17 +99,30 @@ public enum UnifiedMemoryCap {
     /// This is the core of the policy: `cap − Σweights − activations − ramPrefix`.
     /// It is recomputed whenever a model loads or unloads, so it rises as models
     /// leave and shrinks as they join, with no special-casing of model count.
+    ///
+    /// `configReserveBytes` is the operator's `memory_reserve_gb`. When it
+    /// exceeds the cap's own implied OS reserve (`physical − cap` — on 16/32 GiB
+    /// boxes the default 4 GiB reserve does), the effective cap drops to
+    /// `physical − configReserve`, the SAME `max(configReserve, capImplied)`
+    /// hold-back the model-LOAD gate (``loadReserveBytes``) and the runtime KV
+    /// gate (``liveKVHeadroomBytes``) apply — so a static budget derived here
+    /// can never promise memory the operator explicitly reserved. No-op when
+    /// `configReserve ≤ physical − cap` (the common case on big boxes).
     public static func kvBudgetBytes(
         physicalBytes: UInt64 = ProcessInfo.processInfo.physicalMemory,
         residentWeightBytes: UInt64,
         activationReserveBytes: UInt64? = nil,
         ramPrefixAllowanceBytes: UInt64 = 0,
+        configReserveBytes: UInt64 = 0,
         capFraction: Double? = nil
     ) -> UInt64 {
         let cap = hardCapBytes(physicalBytes: physicalBytes, capFraction: capFraction)
+        let reserveFloor =
+            physicalBytes > configReserveBytes ? physicalBytes - configReserveBytes : 0
+        let effectiveCap = min(cap, reserveFloor)
         let activations = activationReserveBytes ?? resolvedActivationReserveBytes()
         let claimed = saturatingAdd(residentWeightBytes, activations, ramPrefixAllowanceBytes)
-        return cap > claimed ? cap - claimed : 0
+        return effectiveCap > claimed ? effectiveCap - claimed : 0
     }
 
     /// Live KV headroom in bytes: how many more bytes may be committed to KV

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+AutoUpdate.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+AutoUpdate.swift
@@ -81,6 +81,7 @@ extension ProviderLoop {
         let updater = SelfUpdater(coordinatorBaseURL: coordinatorURL)
         let me = self
         let logger = self.logger
+        let jitterMaxSeconds = loopConfig.config.provider.updateJitterSeconds
 
         let deps = AutoUpdateController.Dependencies(
             claimStart: { await me.claimUpdateStart() },
@@ -88,6 +89,20 @@ extension ProviderLoop {
             check: { await updater.checkForUpdate() },
             downloadVerifyStage: { release in
                 await me.stageUpdateBundle(release: release, updater: updater)
+            },
+            // Rollover jitter: random 0..update_jitter_seconds sleep between
+            // stage and drain so a fleet never restarts (and goes cold) in
+            // unison. Background auto-update only — the manual `darkbloom
+            // update` command and the startup update check bypass this
+            // controller entirely and stay immediate.
+            waitBeforeInstall: {
+                let delay = UpdateJitter.delay(maxSeconds: jitterMaxSeconds)
+                guard delay > .zero else { return }
+                let secs = Double(delay.components.seconds)
+                    + Double(delay.components.attoseconds) / 1e18
+                logger.info(
+                    "Auto-update: bundle staged; waiting \(String(format: "%.0f", secs))s rollover jitter before draining (update_jitter_seconds=\(jitterMaxSeconds))")
+                try? await Task.sleep(for: delay)
             },
             beginDraining: { await me.beginUpdateDraining() },
             waitForDrain: { timeout in await me.waitForInflightDrain(timeout: timeout) },

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+AutoUpdate.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+AutoUpdate.swift
@@ -121,6 +121,8 @@ extension ProviderLoop {
         switch outcome {
         case .alreadyRunning:
             logger.info("Auto-update: cycle already in progress; skipping this tick")
+        case .cancelled:
+            logger.info("Auto-update: cycle cancelled during the pre-install wait; nothing installed")
         case .upToDate:
             logger.info("Auto-update: already running latest version")
         case .checkFailed(let reason):

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+Cancellation.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+Cancellation.swift
@@ -59,9 +59,15 @@ extension ProviderLoop {
         // coordinator request-id to any active v2 bridge so
         // `CBv2Engine.cancel` drops the row promptly (the in-flight step
         // completes, then the engine delivers `.finished(.cancelled)` and
-        // the bridge tears down). No-op when the v2 engine is off — the
-        // registry is empty and no bridge owns the id.
-        await EngineV2Runtime.shared.cancel(requestId: requestId)
+        // the bridge tears down). Guarded on the slot set so the flag-off
+        // steady state takes ZERO extra actor hops here. Defense in depth:
+        // the primary v2 teardown is the same Task-cancellation propagation
+        // documented above (the bridge stream's onTermination cancels the
+        // engine-minted id); this fan-out additionally catches any submit
+        // made directly under the coordinator id.
+        if hasEngineV2Slots {
+            await engineV2Runtime.cancel(requestId: requestId)
+        }
 
         if requestToModel.removeValue(forKey: requestId) != nil {
             if !hadInflightTask {

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+Cancellation.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+Cancellation.swift
@@ -55,6 +55,14 @@ extension ProviderLoop {
         // reach the same teardown).
         await cancellationRegistry.cancel(requestId: requestId)
 
+        // ContinuousBatchingV2 (flag-gated, additive): forward the
+        // coordinator request-id to any active v2 bridge so
+        // `CBv2Engine.cancel` drops the row promptly (the in-flight step
+        // completes, then the engine delivers `.finished(.cancelled)` and
+        // the bridge tears down). No-op when the v2 engine is off — the
+        // registry is empty and no bridge owns the id.
+        await EngineV2Runtime.shared.cancel(requestId: requestId)
+
         if requestToModel.removeValue(forKey: requestId) != nil {
             if !hadInflightTask {
                 stats.incrementCancelDuringModelLoad()

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+Capacity.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+Capacity.swift
@@ -60,7 +60,28 @@ extension ProviderLoop {
         // steady state pays ZERO extra cost here — no runtime actor hop, no
         // allocations; legacy behavior is byte-identical.
         if hasEngineV2Slots {
-            let engineV2 = await engineV2Runtime.capacitySummary()
+            // Fleet context for the v2 budget clamp (round-3 PR#499 P2): v2
+            // ceilings are construction-fixed, so a model loaded AFTER a
+            // bridge (legacy or v2) would otherwise leave that bridge's
+            // heartbeat advertising a stale `activeTokenBudgetMax` — the
+            // coordinator keeps routing what the shared KV gate then rejects
+            // post-acceptance. Snapshot the CURRENT resident set (ALL slots'
+            // weights — v2 and legacy, including slots mid-unload whose
+            // weights are still resident) + the operator reserve so the
+            // runtime can recompute each bridge's live budget and clamp the
+            // reported max. Heartbeat cadence only — never the submit path.
+            var totalResidentWeightBytes: UInt64 = 0
+            for (_, slot) in modelSlots {
+                let weights = await slot.scheduler.modelWeightBytes
+                let (sum, overflow) = totalResidentWeightBytes
+                    .addingReportingOverflow(UInt64(max(0, weights)))
+                totalResidentWeightBytes = overflow ? .max : sum
+            }
+            let engineV2 = await engineV2Runtime.capacitySummary(
+                fleetKV: EngineV2Runtime.FleetKVContext(
+                    totalResidentWeightBytes: totalResidentWeightBytes,
+                    configReserveBytes: Self.memoryReserveBytes(
+                        forGiB: loopConfig.config.provider.memoryReserveGB)))
             allSlots.append(contentsOf: engineV2.slots)
             totalActive += engineV2.activeRequests
         }

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+Capacity.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+Capacity.swift
@@ -42,6 +42,11 @@ extension ProviderLoop {
         var totalActive = 0
         let slots = modelSlots.filter { !modelsUnloading.contains($0.key) }
         for (_, slot) in slots {
+            // A v2-served slot reports through its bridge (folded in below via
+            // the runtime). Its legacy scheduler is a dormant fallback that
+            // serves no requests while the bridge exists — reporting BOTH
+            // would advertise the same model's capacity twice and over-admit.
+            if slot.engineV2 != nil { continue }
             let cap = await slot.scheduler.backendCapacity()
             allSlots.append(contentsOf: cap.slots)
             let schedCap = await slot.scheduler.capacity()
@@ -51,12 +56,14 @@ extension ProviderLoop {
         // ContinuousBatchingV2 (flag-gated, additive): fold any active v2
         // bridge slots into the SAME heartbeat payload — identical protocol
         // fields, truthful bytes-derived token numbers (see
-        // `EngineV2Bridge+Capacity`). The registry is empty when the v2
-        // engine is off (`DARKBLOOM_ENGINE_V2` unset / `engine_v2 = false`),
-        // so legacy behavior is unchanged.
-        let engineV2 = await EngineV2Runtime.shared.capacitySummary()
-        allSlots.append(contentsOf: engineV2.slots)
-        totalActive += engineV2.activeRequests
+        // `EngineV2Bridge+Capacity`). Guarded on the slot set so the flag-off
+        // steady state pays ZERO extra cost here — no runtime actor hop, no
+        // allocations; legacy behavior is byte-identical.
+        if hasEngineV2Slots {
+            let engineV2 = await engineV2Runtime.capacitySummary()
+            allSlots.append(contentsOf: engineV2.slots)
+            totalActive += engineV2.activeRequests
+        }
 
         let gbDivisor = 1024.0 * 1024.0 * 1024.0
         let totalMem = ProcessInfo.processInfo.physicalMemory

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+Capacity.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+Capacity.swift
@@ -48,6 +48,16 @@ extension ProviderLoop {
             totalActive += schedCap.activeRequests
         }
 
+        // ContinuousBatchingV2 (flag-gated, additive): fold any active v2
+        // bridge slots into the SAME heartbeat payload — identical protocol
+        // fields, truthful bytes-derived token numbers (see
+        // `EngineV2Bridge+Capacity`). The registry is empty when the v2
+        // engine is off (`DARKBLOOM_ENGINE_V2` unset / `engine_v2 = false`),
+        // so legacy behavior is unchanged.
+        let engineV2 = await EngineV2Runtime.shared.capacitySummary()
+        allSlots.append(contentsOf: engineV2.slots)
+        totalActive += engineV2.activeRequests
+
         let gbDivisor = 1024.0 * 1024.0 * 1024.0
         let totalMem = ProcessInfo.processInfo.physicalMemory
 

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+EngineV2.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+EngineV2.swift
@@ -168,14 +168,6 @@ extension ProviderLoop {
             }
         }
 
-        // WARN once (per load) that kv_quant is being ignored on the v2 path.
-        // Emitted after `emitTelemetry` is resolved so it routes through the
-        // test sink when hooks are installed.
-        if kvSizing.warnKVQuantUnsupported {
-            EngineV2Factory.emitKVQuantUnsupportedTelemetry(
-                modelId: modelId, emitTelemetry: emitTelemetry)
-        }
-
         guard
             let bridge = EngineV2Factory.makeBridgeIfSelected(
                 modelId: modelId,
@@ -199,6 +191,16 @@ extension ProviderLoop {
             logger.warning(
                 "engine_v2: init failed for \(modelId) — serving via the legacy engine")
             return nil
+        }
+
+        // WARN once (per load) that kv_quant is being ignored on the v2 path.
+        // Emitted ONLY after the v2 bridge actually built (below the guard):
+        // if v2 init failed and the model fell back to the legacy engine,
+        // legacy DOES honor kv_quant, so a "kv_quant unsupported" WARN there
+        // would be untruthful.
+        if kvSizing.warnKVQuantUnsupported {
+            EngineV2Factory.emitKVQuantUnsupportedTelemetry(
+                modelId: modelId, emitTelemetry: emitTelemetry)
         }
 
         // Register before the slot goes live so capacity heartbeats and

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+EngineV2.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+EngineV2.swift
@@ -1,0 +1,201 @@
+/// ProviderLoop -- ContinuousBatchingV2 (engine v2) slot wiring.
+///
+/// The single production call site that turns `DARKBLOOM_ENGINE_V2=1` /
+/// `engine_v2 = true` into a running CBv2 engine: at model-load time
+/// `ensureModelLoaded` calls `makeEngineV2BridgeForSlot`, which consults
+/// `EngineV2Config` and — only when the v2 engine is selected for this model
+/// — assembles the real engine over the just-loaded container, wraps it in
+/// an `EngineV2Bridge`, and registers it with the `EngineV2Runtime` so the
+/// capacity/cancellation hooks see it. The bridge is stored on `ModelSlot`
+/// ALONGSIDE the legacy `BatchScheduler` (never replacing it): a v2 init
+/// failure falls back to legacy with WARN telemetry (inside
+/// `EngineV2Factory.makeBridgeIfSelected`), and flag-off providers return
+/// before touching the container, the scheduler, or the runtime.
+
+import Foundation
+import MLXLMCommon
+#if canImport(os)
+import os
+#endif
+
+extension ProviderLoop {
+
+    /// Whether any live slot serves through the v2 engine. Synchronous and
+    /// actor-isolated — the zero-overhead guard the capacity/cancellation
+    /// hooks check BEFORE hopping to `engineV2Runtime`, so flag-off
+    /// providers never take the (pointless, empty-registry) actor hop.
+    internal var hasEngineV2Slots: Bool {
+        modelSlots.contains { $0.value.engineV2 != nil }
+    }
+
+    /// Test hooks for the slot factory (`ProviderLoop+Testing`): replace the
+    /// process environment, the container-derived EOS snapshot, and the
+    /// production engine builder so unit tests can drive the full wiring
+    /// path with a scripted `CBv2Engine` — no model weights, no network.
+    struct EngineV2SlotHooks: Sendable {
+        let environment: [String: String]
+        let eosTokenIds: Set<Int>
+        let extraEOSTokens: [String]
+        let emitTelemetry: (@Sendable (TelemetryEvent) -> Void)?
+        let makeEngine: @Sendable (String) throws -> any CBv2Engine
+
+        init(
+            environment: [String: String],
+            eosTokenIds: Set<Int> = [],
+            extraEOSTokens: [String] = [],
+            emitTelemetry: (@Sendable (TelemetryEvent) -> Void)? = nil,
+            makeEngine: @escaping @Sendable (String) throws -> any CBv2Engine
+        ) {
+            self.environment = environment
+            self.eosTokenIds = eosTokenIds
+            self.extraEOSTokens = extraEOSTokens
+            self.emitTelemetry = emitTelemetry
+            self.makeEngine = makeEngine
+        }
+    }
+
+    /// Build + register the v2 bridge for a freshly-loaded model slot, iff
+    /// `EngineV2Config` selects the v2 engine for `modelId`. Returns nil on
+    /// every legacy path:
+    ///
+    ///   * flag off / model not allowlisted — the ZERO-OVERHEAD steady
+    ///     state: no container access, no scheduler reads, no
+    ///     `EngineV2Runtime` hop, no allocations;
+    ///   * v2 engine construction throws — WARN `engine_health` telemetry
+    ///     (`engine_v2_fallback`) is emitted by the factory and the slot
+    ///     serves through the legacy scheduler exactly as before.
+    ///
+    /// On success the bridge is registered with `engineV2Runtime` BEFORE the
+    /// caller installs the slot, so a request routed the instant the slot
+    /// appears already has working capacity/cancel fan-out.
+    internal func makeEngineV2BridgeForSlot(
+        modelId: String,
+        modelType: String?,
+        isVLM: Bool = false,
+        container: ModelContainer,
+        tokenizer: TokenizerHandle,
+        scheduler: BatchScheduler
+    ) async -> EngineV2Bridge? {
+        // VLM slots are permanently unsupported by the v2 engine (the loaded
+        // module is a vision wrapper, not a CBv2-adapted text model), so gate
+        // them out BEFORE selection: an allowlist name match on a vision
+        // build (e.g. `gemma-4*`) would otherwise emit a WARN
+        // `engine_v2_fallback` on every load of a shape that can never serve
+        // v2. Silent legacy is the correct steady state here.
+        guard !isVLM else { return nil }
+        let configEnabled = loopConfig.config.backend.engineV2
+        let environment = engineV2SlotHooks?.environment
+            ?? ProcessInfo.processInfo.environment
+        // Zero-overhead gate: the common (flag-off / non-allowlisted) case
+        // returns here without touching anything else.
+        guard
+            EngineV2Config.selection(
+                modelId: modelId, environment: environment, configEnabled: configEnabled
+            ) == .v2
+        else {
+            return nil
+        }
+
+        // Legacy-comparable knobs, read from the already-loaded scheduler so
+        // v2 heartbeat numbers and max-token defaulting match what the
+        // legacy engine would have reported for the same model.
+        let kvBytesPerToken = await scheduler.kvBytesPerToken
+        let defaultMaxTokens = await scheduler.defaultMaxTokens
+        let weightBytes = await scheduler.modelWeightBytes
+        // KNOWN LIMIT (acceptable for the flag-gated rollout): this ceiling
+        // is computed ONCE at load from THIS model's weights only — it does
+        // not track co-resident models or live legacy KV afterwards, unlike
+        // the legacy scheduler's live headroom checks. The engine admission
+        // cap (no preallocation) plus the conservative v2 concurrency (4)
+        // bound the exposure; revisit before enabling v2 on multi-slot boxes.
+        let kvBytesCapacity = Int(
+            min(
+                UnifiedMemoryCap.kvBudgetBytes(
+                    residentWeightBytes: UInt64(max(0, weightBytes))),
+                UInt64(Int.max)))
+
+        // Resolve the EOS/stop inputs + engine builder: from the test hooks
+        // when installed, otherwise from the loaded container (production).
+        let eosTokenIds: Set<Int>
+        let extraEOSTokens: [String]
+        let emitTelemetry: (@Sendable (TelemetryEvent) -> Void)?
+        let makeEngine: () throws -> any CBv2Engine
+        if let hooks = engineV2SlotHooks {
+            eosTokenIds = hooks.eosTokenIds
+            extraEOSTokens = hooks.extraEOSTokens
+            emitTelemetry = hooks.emitTelemetry
+            let hookBuilder = hooks.makeEngine
+            makeEngine = { try hookBuilder(modelId) }
+        } else {
+            // Snapshot the model handle + EOS config out of the container.
+            // Handing the module reference to the v2 engine mirrors the
+            // legacy path exactly (`BatchScheduler.makeBatchedEngine` builds
+            // its engine over `ctx.model` the same way): the engine
+            // serializes all forward passes on its own step thread.
+            let snapshot = await container.perform { ctx in
+                EngineV2ModelSnapshot(
+                    model: ctx.model,
+                    eosTokenIds: ctx.configuration.eosTokenIds,
+                    extraEOSTokens: ctx.configuration.extraEOSTokens.sorted())
+            }
+            // Same model-specific EOS augmentation as the legacy scheduler
+            // (GPT-OSS/Harmony adds its generation-config action stops).
+            eosTokenIds = BatchScheduler.effectiveEOSTokenIds(
+                modelId: modelId,
+                modelType: modelType,
+                base: snapshot.eosTokenIds,
+                tokenToId: { tokenizer.inner.convertTokenToId($0) }
+            )
+            extraEOSTokens = snapshot.extraEOSTokens
+            emitTelemetry = nil  // production: TelemetryClient.shared
+            makeEngine = {
+                try EngineV2Factory.makeProductionEngine(
+                    model: snapshot.model,
+                    tokenizer: tokenizer.inner,
+                    kvBytesCapacity: kvBytesCapacity)
+            }
+        }
+
+        guard
+            let bridge = EngineV2Factory.makeBridgeIfSelected(
+                modelId: modelId,
+                configEnabled: configEnabled,
+                environment: environment,
+                tokenizer: tokenizer,
+                eosTokenIds: eosTokenIds,
+                extraEOSTokens: extraEOSTokens,
+                defaultMaxTokens: defaultMaxTokens,
+                maxConcurrentRequests: EngineV2Factory.productionMaxConcurrentRequests,
+                kvBytesPerToken: kvBytesPerToken,
+                emitTelemetry: emitTelemetry,
+                makeEngine: makeEngine)
+        else {
+            // Selection said v2, so a nil bridge here is the init-failure
+            // fallback (the factory already emitted the WARN event).
+            logger.warning(
+                "engine_v2: init failed for \(modelId) — serving via the legacy engine")
+            return nil
+        }
+
+        // Register before the slot goes live so capacity heartbeats and
+        // cancellation fan-out see the bridge from the first request.
+        await engineV2Runtime.register(modelId: modelId, bridge: bridge)
+        logger.info(
+            "engine_v2: serving \(modelId) via ContinuousBatchingV2 "
+                + "(legacy scheduler retained for fallback)")
+        return bridge
+    }
+}
+
+/// Model handle + EOS config snapshot pulled out of `ModelContainer.perform`.
+///
+/// `@unchecked Sendable` justification: the module reference crosses the
+/// container's isolation exactly once, at load time, to be handed to the v2
+/// engine — which serializes every use on its own engine thread. This is the
+/// same ownership handoff the legacy `BatchedEngine` performs with
+/// `ctx.model` in `BatchScheduler+EngineFactory`.
+struct EngineV2ModelSnapshot: @unchecked Sendable {
+    let model: any LanguageModel
+    let eosTokenIds: Set<Int>
+    let extraEOSTokens: [String]
+}

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+EngineV2.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+EngineV2.swift
@@ -143,10 +143,17 @@ extension ProviderLoop {
                     await existingBridge.engineKVBytesCapacity())
             }
         }
+        // `memory_reserve_gb` (round-3 PR#499 P2): the shared KV gate and the
+        // load gate hold back max(configReserve, cap-implied reserve); the
+        // static v2 ceiling must be derived under the same effective cap or a
+        // 16/32 GiB box (default 4 GiB reserve > implied reserve) advertises
+        // capacity the shared gate rejects post-acceptance.
         let kvBytesCapacity = EngineV2KVSizing.engineKVBytesCapacity(
             newModelWeightBytes: weightBytes,
             coResidentWeightBytes: coResidentWeightBytes,
-            existingEngineKVCapacities: existingEngineKVCapacities)
+            existingEngineKVCapacities: existingEngineKVCapacities,
+            configReserveBytes: Self.memoryReserveBytes(
+                forGiB: loopConfig.config.provider.memoryReserveGB))
 
         // Resolve the EOS/stop inputs + engine builder: from the test hooks
         // when installed, otherwise from the loaded container (production).

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+EngineV2.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+EngineV2.swift
@@ -99,7 +99,19 @@ extension ProviderLoop {
         // Legacy-comparable knobs, read from the already-loaded scheduler so
         // v2 heartbeat numbers and max-token defaulting match what the
         // legacy engine would have reported for the same model.
-        let kvBytesPerToken = await scheduler.kvBytesPerToken
+        //
+        // KV byte cost: engine_v2 builds UNQUANTIZED (fp16) caches even when
+        // the provider's `kv_quant` is on (KV-quant is not yet composed with
+        // v2). The scheduler's live `kvBytesPerToken` is the QUANTIZED rate in
+        // that case; sizing the bridge with it would overstate v2 token
+        // budgets 2–4× and under-size the shared KV reservation. Pick the fp16
+        // rate for v2 and WARN once that kv_quant is being ignored on this
+        // path — see `EngineV2KVSizing`.
+        let quantizedKVBytesPerToken = await scheduler.kvBytesPerToken
+        let fp16KVBytesPerToken = await scheduler.fp16KVBytesPerToken
+        let kvSizing = EngineV2KVSizing.resolve(
+            quantizedRate: quantizedKVBytesPerToken, fp16Rate: fp16KVBytesPerToken)
+        let kvBytesPerToken = kvSizing.rate
         let defaultMaxTokens = await scheduler.defaultMaxTokens
         let weightBytes = await scheduler.modelWeightBytes
         // KNOWN LIMIT (acceptable for the flag-gated rollout): this ceiling
@@ -156,6 +168,14 @@ extension ProviderLoop {
             }
         }
 
+        // WARN once (per load) that kv_quant is being ignored on the v2 path.
+        // Emitted after `emitTelemetry` is resolved so it routes through the
+        // test sink when hooks are installed.
+        if kvSizing.warnKVQuantUnsupported {
+            EngineV2Factory.emitKVQuantUnsupportedTelemetry(
+                modelId: modelId, emitTelemetry: emitTelemetry)
+        }
+
         guard
             let bridge = EngineV2Factory.makeBridgeIfSelected(
                 modelId: modelId,
@@ -167,6 +187,10 @@ extension ProviderLoop {
                 defaultMaxTokens: defaultMaxTokens,
                 maxConcurrentRequests: EngineV2Factory.productionMaxConcurrentRequests,
                 kvBytesPerToken: kvBytesPerToken,
+                // Shared KV ledger so v2 in-flight requests are visible to the
+                // model-LOAD gate + legacy live-KV gate (fix #2). nil ⇒ no
+                // shared accounting (unit tests / the standalone path).
+                kvBudget: kvBudget,
                 emitTelemetry: emitTelemetry,
                 makeEngine: makeEngine)
         else {

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+EngineV2.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+EngineV2.swift
@@ -37,14 +37,18 @@ extension ProviderLoop {
         let eosTokenIds: Set<Int>
         let extraEOSTokens: [String]
         let emitTelemetry: (@Sendable (TelemetryEvent) -> Void)?
-        let makeEngine: @Sendable (String) throws -> any CBv2Engine
+        /// Scripted engine builder: (modelId, kvBytesCapacity) — the second
+        /// argument is the FLEET-SIZED admission ceiling the production path
+        /// would hand `makeProductionEngine`, exposed so tests can assert the
+        /// multi-slot capacity derivation without building a real engine.
+        let makeEngine: @Sendable (String, Int) throws -> any CBv2Engine
 
         init(
             environment: [String: String],
             eosTokenIds: Set<Int> = [],
             extraEOSTokens: [String] = [],
             emitTelemetry: (@Sendable (TelemetryEvent) -> Void)? = nil,
-            makeEngine: @escaping @Sendable (String) throws -> any CBv2Engine
+            makeEngine: @escaping @Sendable (String, Int) throws -> any CBv2Engine
         ) {
             self.environment = environment
             self.eosTokenIds = eosTokenIds
@@ -114,17 +118,35 @@ extension ProviderLoop {
         let kvBytesPerToken = kvSizing.rate
         let defaultMaxTokens = await scheduler.defaultMaxTokens
         let weightBytes = await scheduler.modelWeightBytes
-        // KNOWN LIMIT (acceptable for the flag-gated rollout): this ceiling
-        // is computed ONCE at load from THIS model's weights only — it does
-        // not track co-resident models or live legacy KV afterwards, unlike
-        // the legacy scheduler's live headroom checks. The engine admission
-        // cap (no preallocation) plus the conservative v2 concurrency (4)
-        // bound the exposure; revisit before enabling v2 on multi-slot boxes.
-        let kvBytesCapacity = Int(
-            min(
-                UnifiedMemoryCap.kvBudgetBytes(
-                    residentWeightBytes: UInt64(max(0, weightBytes))),
-                UInt64(Int.max)))
+        // FLEET-WIDE ceiling (round-2 PR#499 P2): size this engine's KV
+        // admission cap against ALL resident models' weights plus the
+        // ceilings already granted to co-resident v2 engines — not just this
+        // slot's weights — so Σ(v2 ceilings) can never exceed the
+        // unified-memory KV budget on a multi-slot provider. Snapshot the
+        // slots once (each read awaits an actor hop; `modelSlots` could
+        // mutate across suspensions otherwise). The new model's own slot is
+        // not installed yet at this point; a same-id slot present during a
+        // reload is excluded so its weights are not double-counted against
+        // the fresh scheduler's figure. When nothing is left under the
+        // budget the capacity is 0 and `makeProductionEngine` throws
+        // `noKVHeadroom` → this slot serves via the legacy scheduler (whose
+        // per-request shared-budget gate needs no static ceiling).
+        var coResidentWeightBytes: UInt64 = 0
+        var existingEngineKVCapacities: [Int] = []
+        for (slotModelId, slot) in modelSlots where slotModelId != modelId {
+            let slotWeights = await slot.scheduler.modelWeightBytes
+            let (sum, overflow) = coResidentWeightBytes
+                .addingReportingOverflow(UInt64(max(0, slotWeights)))
+            coResidentWeightBytes = overflow ? .max : sum
+            if let existingBridge = slot.engineV2 {
+                existingEngineKVCapacities.append(
+                    await existingBridge.engineKVBytesCapacity())
+            }
+        }
+        let kvBytesCapacity = EngineV2KVSizing.engineKVBytesCapacity(
+            newModelWeightBytes: weightBytes,
+            coResidentWeightBytes: coResidentWeightBytes,
+            existingEngineKVCapacities: existingEngineKVCapacities)
 
         // Resolve the EOS/stop inputs + engine builder: from the test hooks
         // when installed, otherwise from the loaded container (production).
@@ -137,7 +159,7 @@ extension ProviderLoop {
             extraEOSTokens = hooks.extraEOSTokens
             emitTelemetry = hooks.emitTelemetry
             let hookBuilder = hooks.makeEngine
-            makeEngine = { try hookBuilder(modelId) }
+            makeEngine = { try hookBuilder(modelId, kvBytesCapacity) }
         } else {
             // Snapshot the model handle + EOS config out of the container.
             // Handing the module reference to the v2 engine mirrors the
@@ -179,9 +201,11 @@ extension ProviderLoop {
                 defaultMaxTokens: defaultMaxTokens,
                 maxConcurrentRequests: EngineV2Factory.productionMaxConcurrentRequests,
                 kvBytesPerToken: kvBytesPerToken,
-                // Shared KV ledger so v2 in-flight requests are visible to the
-                // model-LOAD gate + legacy live-KV gate (fix #2). nil ⇒ no
-                // shared accounting (unit tests / the standalone path).
+                // Shared KV ledger: v2 submissions RESERVE their worst-case
+                // KV here before engine admission (process-wide gate) and the
+                // reservation is what the model-LOAD gate + legacy live-KV
+                // gate subtract. nil ⇒ no shared gating/accounting (unit
+                // tests / the standalone path).
                 kvBudget: kvBudget,
                 emitTelemetry: emitTelemetry,
                 makeEngine: makeEngine)

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+InboundDecode.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+InboundDecode.swift
@@ -121,6 +121,28 @@ extension ProviderLoop {
         return (topLogprobs: probe.top_logprobs, requested: true)
     }
 
+    /// OpenAI `logit_bias` / `seed` for this request. Like `reasoning_effort`,
+    /// the cache scope, and the logprobs spec, neither field is on the upstream
+    /// `OpenAIChatCompletionRequest`, so decode them straight from the sealed
+    /// body. Returns nil when the request carries neither field (the common
+    /// case — zero allocation downstream). The two fields are probed
+    /// independently so a malformed value for one (e.g. a negative `seed`,
+    /// which cannot decode as UInt64) never discards the other. Consumed by
+    /// the v2 engine path only; legacy serving ignores both (unchanged
+    /// behavior).
+    internal static func extractSamplingOverrides(
+        from data: Data
+    ) -> EngineV2SamplingOverrides? {
+        struct BiasProbe: Decodable { let logit_bias: [String: Float]? }
+        struct SeedProbe: Decodable { let seed: UInt64? }
+        let decoder = JSONDecoder()
+        let rawBias = (try? decoder.decode(BiasProbe.self, from: data))?.logit_bias
+        let bias = (rawBias?.isEmpty == false) ? rawBias : nil
+        let seed = (try? decoder.decode(SeedProbe.self, from: data))?.seed
+        guard bias != nil || seed != nil else { return nil }
+        return EngineV2SamplingOverrides(logitBias: bias, seed: seed)
+    }
+
     /// Prompt-token floor for requests whose usage chunk never arrived (cancelled
     /// stream / upstream regression). Re-runs the engine's exact applyChatTemplate
     /// path so the count matches what was prefilled; VLM parts aren't in the text

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+InboundDecode.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+InboundDecode.swift
@@ -100,6 +100,27 @@ extension ProviderLoop {
         return ""
     }
 
+    /// OpenAI `logprobs` / `top_logprobs` for this request. Like
+    /// `reasoning_effort` and the cache scope, neither field is on the
+    /// upstream `OpenAIChatCompletionRequest`, so decode them straight from
+    /// the sealed body. Returns nil unless `logprobs == true` (per the
+    /// OpenAI contract `top_logprobs` is only meaningful alongside it);
+    /// `topLogprobs` passes through un-clamped — the engine translation
+    /// (`EngineV2Translation.topLogprobs`) owns the 1...20 clamp policy.
+    /// Consumed by the v2 engine path only; legacy serving ignores it.
+    internal static func extractLogprobsSpec(
+        from data: Data
+    ) -> (topLogprobs: Int?, requested: Bool)? {
+        struct Probe: Decodable {
+            let logprobs: Bool?
+            let top_logprobs: Int?
+        }
+        guard let probe = try? JSONDecoder().decode(Probe.self, from: data),
+              probe.logprobs == true
+        else { return nil }
+        return (topLogprobs: probe.top_logprobs, requested: true)
+    }
+
     /// Prompt-token floor for requests whose usage chunk never arrived (cancelled
     /// stream / upstream regression). Re-runs the engine's exact applyChatTemplate
     /// path so the count matches what was prefilled; VLM parts aren't in the text

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+InferenceHandler.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+InferenceHandler.swift
@@ -179,6 +179,10 @@ extension ProviderLoop {
         // honored on the v2 engine path (the legacy engine never emitted
         // logprobs — see EngineV2Logprobs.swift).
         let logprobsSpec = Self.extractLogprobsSpec(from: decryptedData)
+        // OpenAI `logit_bias` / `seed` (also absent from the upstream request
+        // shape). Overlaid onto the v2 engine translation; the legacy path
+        // never honored either knob and is untouched.
+        let samplingOverrides = Self.extractSamplingOverrides(from: decryptedData)
 
         // 3. Fast pre-accept admission check. The coordinator accepts fast and
         // then waits for the first chunk with the full inference timeout, so we
@@ -389,7 +393,8 @@ extension ProviderLoop {
                 engineV2Logprobs: logprobsChannel.map {
                     EngineV2LogprobsPlumbing(
                         topLogprobs: logprobsSpec?.topLogprobs, channel: $0)
-                }
+                },
+                engineV2Sampling: samplingOverrides
             )
 
             // Force-stream so we get SSE frames even if the original request

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+InferenceHandler.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+InferenceHandler.swift
@@ -501,7 +501,16 @@ extension ProviderLoop {
             // usage chunks are skipped); consumers accumulate
             // `logprobs.content` across chunks, so chunk-boundary
             // alignment is not load-bearing — order and exactly-once are.
+            //
+            // BOUNDED (round-3 PR#499 P2): a long reasoning-only/tool-only
+            // prefix (GPT-OSS) drains the capped channel here every frame
+            // without ever clearing, so this buffer is re-capped after each
+            // drain with the SAME drop-oldest policy as the channel
+            // (`EngineV2LogprobsChannel.capPending`); the freshest window —
+            // the entries nearest the content that eventually renders — is
+            // kept and the dropped count is logged (never token text).
             var pendingLogprobs: [SSETokenLogprob] = []
+            var pendingLogprobsDropped = 0
             do {
                 for try await frame in frames {
                     if token.isCancelled {
@@ -592,6 +601,20 @@ extension ProviderLoop {
                     // billing extraction are unaffected.
                     if let logprobsChannel {
                         pendingLogprobs += logprobsChannel.drain()
+                        // Re-cap after every drain: without a content-bearing
+                        // frame this buffer would grow unbounded past the
+                        // channel's own cap (see the declaration comment).
+                        let dropped = EngineV2LogprobsChannel.capPending(&pendingLogprobs)
+                        if dropped > 0 {
+                            if pendingLogprobsDropped == 0 {
+                                log.warning(
+                                    "[\(requestId)] pending logprobs hit the "
+                                    + "\(EngineV2LogprobsChannel.maxEntries)-entry cap before a "
+                                    + "content-bearing frame; dropping oldest entries (count only)"
+                                )
+                            }
+                            pendingLogprobsDropped += dropped
+                        }
                         if !pendingLogprobs.isEmpty,
                             let injected = Self.injectLogprobs(
                                 into: frameToEmit, entries: pendingLogprobs)
@@ -633,6 +656,15 @@ extension ProviderLoop {
                 }
             }
             if token.isCancelled { cancelledMidStream = true }
+
+            if pendingLogprobsDropped > 0 {
+                // Surface the request's TOTAL evicted-entry count once at
+                // stream end (the in-loop WARN fires only on the first drop).
+                log.warning(
+                    "[\(requestId)] dropped \(pendingLogprobsDropped) pending logprob "
+                    + "entries in total (buffer cap \(EngineV2LogprobsChannel.maxEntries))"
+                )
+            }
 
             if cancelledMidStream {
                 if reasoningTokens == 0 && !reasoningText.isEmpty {

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+InferenceHandler.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+InferenceHandler.swift
@@ -272,6 +272,10 @@ extension ProviderLoop {
         let modelType = slot.modelType
         let slotContainer = slot.container
         let slotIsVLM = slot.isVLM
+        // ContinuousBatchingV2 (flag-gated): non-nil only when the slot was
+        // loaded with a v2 bridge. The engine below routes text generation
+        // through it; nil keeps the legacy scheduler path byte-identical.
+        let slotEngineV2 = slot.engineV2
 
         // 8. Spawn inference task. The streaming pipeline now flows through
         // the upstream `MLXLMServer` library:
@@ -361,7 +365,8 @@ extension ProviderLoop {
                 registryProvider: { @Sendable in
                     [chatRequest.model: .init(
                         scheduler: sched, tokenizer: tokenizer, modelType: modelType,
-                        container: slotContainer, isVLM: slotIsVLM)]
+                        container: slotContainer, isVLM: slotIsVLM,
+                        engineV2Bridge: slotEngineV2)]
                 },
                 ensureLoaded: { _ in },
                 reserveModel: { _ in },

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+InferenceHandler.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+InferenceHandler.swift
@@ -174,6 +174,11 @@ extension ProviderLoop {
         // the sealed body like reasoning_effort; threaded into the engine so the
         // checkpoint cache is partitioned per consumer. "" ⇒ unscoped.
         let cacheScope = Self.extractCacheScope(from: decryptedData)
+        // OpenAI `logprobs` / `top_logprobs` (also absent from the upstream
+        // request shape). Non-nil only when the request asked for logprobs;
+        // honored on the v2 engine path (the legacy engine never emitted
+        // logprobs — see EngineV2Logprobs.swift).
+        let logprobsSpec = Self.extractLogprobsSpec(from: decryptedData)
 
         // 3. Fast pre-accept admission check. The coordinator accepts fast and
         // then waits for the first chunk with the full inference timeout, so we
@@ -276,6 +281,13 @@ extension ProviderLoop {
         // loaded with a v2 bridge. The engine below routes text generation
         // through it; nil keeps the legacy scheduler path byte-identical.
         let slotEngineV2 = slot.engineV2
+        // Logprobs passthrough (v2 only): a per-request channel the bridge
+        // pump fills with OpenAI-shaped entries and the frames loop below
+        // drains into content-bearing SSE chunks. nil (request didn't ask,
+        // or the slot serves via legacy) ⇒ frames pass through untouched.
+        let logprobsChannel: EngineV2LogprobsChannel? =
+            (logprobsSpec != nil && slotEngineV2 != nil)
+            ? EngineV2LogprobsChannel() : nil
 
         // 8. Spawn inference task. The streaming pipeline now flows through
         // the upstream `MLXLMServer` library:
@@ -373,7 +385,11 @@ extension ProviderLoop {
                 releaseModel: { _ in },
                 defaultMaxTokens: Self.schedulerDefaultMaxTokens,
                 reasoningEffort: reasoningEffort,
-                cacheScope: cacheScope
+                cacheScope: cacheScope,
+                engineV2Logprobs: logprobsChannel.map {
+                    EngineV2LogprobsPlumbing(
+                        topLogprobs: logprobsSpec?.topLogprobs, channel: $0)
+                }
             )
 
             // Force-stream so we get SSE frames even if the original request
@@ -474,6 +490,13 @@ extension ProviderLoop {
             // A cancelled request that already streamed output settles through
             // the completion path below with real usage, not a bare 499 ($0).
             var cancelledMidStream = false
+            // Logprobs entries drained from the v2 bridge but not yet
+            // attached to a frame. Entries attach to the NEXT content-
+            // bearing chunk (role preambles / reasoning-only deltas /
+            // usage chunks are skipped); consumers accumulate
+            // `logprobs.content` across chunks, so chunk-boundary
+            // alignment is not load-bearing — order and exactly-once are.
+            var pendingLogprobs: [SSETokenLogprob] = []
             do {
                 for try await frame in frames {
                     if token.isCancelled {
@@ -554,6 +577,22 @@ extension ProviderLoop {
                                     into: frame, reasoningTokens: reasoningTokens
                                 )
                             }
+                        }
+                    }
+                    // Logprobs passthrough (v2 only): splice pending entries
+                    // into this frame if it carries content; otherwise keep
+                    // them pending. Runs AFTER the hash/usage bookkeeping
+                    // above, which reads the original `frame` — logprobs
+                    // never alter `delta.content`, so the response hash and
+                    // billing extraction are unaffected.
+                    if let logprobsChannel {
+                        pendingLogprobs += logprobsChannel.drain()
+                        if !pendingLogprobs.isEmpty,
+                            let injected = Self.injectLogprobs(
+                                into: frameToEmit, entries: pendingLogprobs)
+                        {
+                            frameToEmit = injected
+                            pendingLogprobs = []
                         }
                     }
                     if !emitSSE(frameToEmit) { return }

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+LocalEndpoint.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+LocalEndpoint.swift
@@ -140,7 +140,10 @@ extension ProviderLoop {
             // hard-swap drop window (see ModelSlot.modelType).
             modelType: slot.modelType,
             container: slot.container,
-            isVLM: slot.isVLM
+            isVLM: slot.isVLM,
+            // ContinuousBatchingV2 (flag-gated): local requests route through
+            // the same v2 bridge as coordinator requests when the slot has one.
+            engineV2Bridge: slot.engineV2
         )
     }
 

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+ModelLoading.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+ModelLoading.swift
@@ -334,6 +334,9 @@ extension ProviderLoop {
             )
 
             syncWarmModelState()
+            // Remember the serving set across restarts: the persisted file is
+            // the default startup preload plan (ProviderLoop+StartupPreload).
+            persistLoadedModelSet()
             await updateAggregateCapacity()
             logger.info("Model loaded: \(modelId) (\(modelSlots.count) model(s) in memory)")
 
@@ -394,6 +397,13 @@ extension ProviderLoop {
         let waiters = unloadingWaiters.removeValue(forKey: modelId) ?? []
         for waiter in waiters { waiter.resume() }
         syncWarmModelState()
+        // A NON-shutdown unload (idle timeout, eviction, retirement) drops the
+        // model from the persisted serving set. Shutdown teardown skips this on
+        // purpose: a stop/update/restart must remember what was being served so
+        // the next boot's startup preload can re-warm it.
+        if !isShuttingDown {
+            persistLoadedModelSet()
+        }
         await updateAggregateCapacity()
         logger.info("Unloaded model: \(modelId) (\(modelSlots.count) model(s) remaining)")
     }
@@ -448,7 +458,11 @@ extension ProviderLoop {
     /// `doctor`'s model-fit check shares the SAME arithmetic via
     /// `ModelLoadAdmission`, so the operator-facing verdict can never drift from
     /// what this method enforces at load time.
-    private func availableMemoryGb() async -> Double {
+    ///
+    /// `internal` (not `private`): also the admission probe for the startup
+    /// preload (`ProviderLoop+StartupPreload`), which must skip — never evict
+    /// for — a preload candidate that doesn't fit.
+    internal func availableMemoryGb() async -> Double {
         let outstanding = await kvBudget.outstandingReservedBytes()
         // Hold back enough to honor the 90% unified cap: max(configured reserve,
         // physical − cap). Without this the free-memory gate would load models

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+ModelLoading.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+ModelLoading.swift
@@ -90,7 +90,17 @@ extension ProviderLoop {
         )
     }
 
-    internal func ensureModelLoaded(modelId: String) async throws {
+    /// Load `modelId` if it is not already resident.
+    ///
+    /// `allowEviction` (default true) gates BOTH eviction points — the
+    /// slot-cap LRU eviction and `evictUntilAvailable`'s memory reclamation.
+    /// The startup preload passes `false`: a later preload candidate must
+    /// never churn out an earlier one (it is skipped with a WARN and left to
+    /// the lazy-load path instead). Live traffic keeps the default. The
+    /// checks run INSIDE the `isLoadingAny` critical section, so an
+    /// interleaved local-endpoint load cannot make the no-evict verdict
+    /// stale.
+    internal func ensureModelLoaded(modelId: String, allowEviction: Bool = true) async throws {
         if isShuttingDown {
             throw CancellationError()
         }
@@ -115,7 +125,7 @@ extension ProviderLoop {
                 if isShuttingDown { throw CancellationError() }
             }
             if modelSlots[modelId] != nil { return }
-            try await ensureModelLoaded(modelId: modelId)
+            try await ensureModelLoaded(modelId: modelId, allowEviction: allowEviction)
             return
         }
 
@@ -154,11 +164,15 @@ extension ProviderLoop {
             let evictable = modelSlots.filter {
                 !modelsWithInflight.contains($0.key) && !hasLocalReservation($0.key) && !modelsUnloading.contains($0.key)
             }
-            if evictable.isEmpty {
+            if evictable.isEmpty || !allowEviction {
                 isLoadingAny = false
                 releaseLoadGateWaiters()
+                // Both messages contain "slot" so loadErrorStatusCode maps
+                // them to 503 (transient capacity, coordinator reroutes).
                 throw InferenceError.invalidModelDirectory(
-                    "All \(maxModelSlots) model slot(s) are active; cannot load '\(modelId)'"
+                    allowEviction
+                        ? "All \(maxModelSlots) model slot(s) are active; cannot load '\(modelId)'"
+                        : "All \(maxModelSlots) model slot(s) are occupied and eviction is disabled for this load; cannot load '\(modelId)'"
                 )
             }
             if let lru = evictable.min(by: { $0.value.lastInferenceAt < $1.value.lastInferenceAt }) {
@@ -190,7 +204,7 @@ extension ProviderLoop {
                 weightsGb: modelInfo.estimatedMemoryGb,
                 headroomGb: Self.loadHeadroomGb)
             do {
-                try await evictUntilAvailable(requiredGb: requiredGb)
+                try await evictUntilAvailable(requiredGb: requiredGb, allowEviction: allowEviction)
             } catch let InferenceError.modelLoadFailed(message) {
                 // Record for diagnostics so `doctor` shows the operator the exact
                 // "Insufficient memory …" reason, then rethrow unchanged.
@@ -500,12 +514,19 @@ extension ProviderLoop {
     /// no more idle models remain. Re-checks in-flight state before each
     /// eviction since `await unloadModel` is a suspension point.
     /// Throws if the memory target cannot be met after exhausting evictable models.
-    private func evictUntilAvailable(requiredGb: Double) async throws {
+    ///
+    /// `allowEviction: false` (startup preload) never considers a candidate:
+    /// it degrades to a pure availability check (with the clearCache
+    /// self-heal) that throws instead of reclaiming — a later preload must
+    /// not churn out an earlier one.
+    private func evictUntilAvailable(requiredGb: Double, allowEviction: Bool = true) async throws {
         while await availableMemoryGb() < requiredGb {
             let modelsWithInflight = Set(requestToModel.values)
-            let candidate = modelSlots
-                .filter { !modelsWithInflight.contains($0.key) && !hasLocalReservation($0.key) && !modelsUnloading.contains($0.key) }
-                .min(by: { $0.value.lastInferenceAt < $1.value.lastInferenceAt })
+            let candidate = allowEviction
+                ? modelSlots
+                    .filter { !modelsWithInflight.contains($0.key) && !hasLocalReservation($0.key) && !modelsUnloading.contains($0.key) }
+                    .min(by: { $0.value.lastInferenceAt < $1.value.lastInferenceAt })
+                : nil
 
             guard let (modelId, _) = candidate else {
                 // Nothing idle to evict — drop the reclaimable pool and resample
@@ -517,7 +538,9 @@ extension ProviderLoop {
                 let available = String(format: "%.1f", retried)
                 let required = String(format: "%.1f", requiredGb)
                 throw InferenceError.modelLoadFailed(
-                    "Insufficient memory (\(available) GB free, need \(required) GB) and all loaded models are actively serving"
+                    allowEviction
+                        ? "Insufficient memory (\(available) GB free, need \(required) GB) and all loaded models are actively serving"
+                        : "Insufficient memory (\(available) GB free, need \(required) GB) to load without evicting resident models"
                 )
             }
 

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+ModelLoading.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+ModelLoading.swift
@@ -304,11 +304,31 @@ extension ProviderLoop {
             let tokenizer: TokenizerHandle = await container.perform { ctx in
                 TokenizerHandle(ctx.tokenizer)
             }
-            modelSlots[modelId] = ModelSlot(
-                scheduler: scheduler,
+
+            // ContinuousBatchingV2 (flag-gated, additive): when EngineV2Config
+            // selects the v2 engine for this model, build the real CBv2 engine
+            // over the SAME loaded container, wrap it in an EngineV2Bridge, and
+            // register it with the runtime so capacity/cancel fan-out works
+            // from the first request. nil on every legacy path — flag off,
+            // non-allowlisted model, VLM slot, or v2 init failure (which emits
+            // WARN engine_health telemetry and falls back to the scheduler
+            // below).
+            let slotIsVLM = Self.modelIsVLM(at: modelPath)
+            let engineV2Bridge = await makeEngineV2BridgeForSlot(
+                modelId: modelId,
+                modelType: modelInfo.modelType,
+                isVLM: slotIsVLM,
                 container: container,
                 tokenizer: tokenizer,
-                isVLM: Self.modelIsVLM(at: modelPath),
+                scheduler: scheduler
+            )
+
+            modelSlots[modelId] = ModelSlot(
+                scheduler: scheduler,
+                engineV2: engineV2Bridge,
+                container: container,
+                tokenizer: tokenizer,
+                isVLM: slotIsVLM,
                 modelType: modelInfo.modelType,
                 lastInferenceAt: .now
             )
@@ -356,6 +376,14 @@ extension ProviderLoop {
     internal func unloadModel(_ modelId: String) async {
         guard let slot = modelSlots[modelId], !modelsUnloading.contains(modelId) else { return }
         modelsUnloading.insert(modelId)
+        // ContinuousBatchingV2: retire the slot's v2 bridge first — unregister
+        // so heartbeats/cancellation stop fanning out to it, then drain the
+        // engine gracefully (running requests finish, new submissions are
+        // rejected). No-op for legacy-only slots (engineV2 == nil).
+        if let bridge = slot.engineV2 {
+            await engineV2Runtime.unregister(modelId: modelId)
+            await bridge.shutdown()
+        }
         await slot.scheduler.unloadModel()
         modelSlots.removeValue(forKey: modelId)
         modelsUnloading.remove(modelId)

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+SSEParser.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+SSEParser.swift
@@ -198,6 +198,58 @@ extension ProviderLoop {
         return "data: \(json)\n\n"
     }
 
+    /// Splice OpenAI-standard streaming logprobs
+    /// (`choices[0].logprobs = {"content": [...]}`) into a content-bearing
+    /// SSE chunk. v2-engine path only — the legacy engine never emitted
+    /// logprobs, so this is the OpenAI-standard shape rather than a
+    /// legacy-match (see `EngineV2Logprobs.swift`).
+    ///
+    /// Returns the modified frame when `frame` is a chat-completion chunk
+    /// whose `choices[0].delta.content` is a non-empty string (the frames
+    /// logprobs semantically attach to). Returns nil — caller keeps the
+    /// entries pending for the next frame — for role preambles, reasoning-
+    /// only deltas, usage/terminal chunks, `[DONE]`, and anything that
+    /// fails to parse (never corrupt a frame we cannot faithfully edit).
+    ///
+    /// Like `injectReasoningTokens`, the edit is a generic JSON splice:
+    /// upstream's `OpenAIChatCompletionChunk` has no logprobs field, so we
+    /// decode the `data:` payload to a dictionary, attach the logprobs
+    /// object, and re-serialize with every other field untouched.
+    internal static func injectLogprobs(
+        into frame: String, entries: [SSETokenLogprob]
+    ) -> String? {
+        guard !entries.isEmpty,
+              let payload = joinedDataPayload(frame),
+              payload.trimmingCharacters(in: .whitespacesAndNewlines) != "[DONE]",
+              let bytes = payload.data(using: .utf8),
+              var obj = (try? JSONSerialization.jsonObject(with: bytes)) as? [String: Any],
+              var choices = obj["choices"] as? [[String: Any]],
+              var choice = choices.first,
+              let delta = choice["delta"] as? [String: Any],
+              let content = delta["content"] as? String,
+              !content.isEmpty
+        else {
+            return nil
+        }
+        // Merge with any existing content entries rather than clobbering
+        // (upstream never emits logprobs today; defensive for the future).
+        var logprobs = choice["logprobs"] as? [String: Any] ?? [:]
+        var contentEntries = logprobs["content"] as? [[String: Any]] ?? []
+        contentEntries.append(contentsOf: entries.map { $0.jsonObject })
+        logprobs["content"] = contentEntries
+        choice["logprobs"] = logprobs
+        choices[0] = choice
+        obj["choices"] = choices
+        guard let out = try? JSONSerialization.data(
+                withJSONObject: obj, options: [.sortedKeys, .withoutEscapingSlashes]
+              ),
+              let json = String(data: out, encoding: .utf8)
+        else {
+            return nil
+        }
+        return "data: \(json)\n\n"
+    }
+
     /// TB-007 P2 #2: deterministic serialization of a `tool_calls`
     /// delta for inclusion in the response-hash accumulator.
     ///

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+Serve.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+Serve.swift
@@ -66,6 +66,14 @@ extension ProviderLoop {
         // 1. Apply security hardening
         try await applySecurityHardening()
 
+        // 1.5 Startup preload + readiness gate (ProviderLoop+StartupPreload):
+        // load the previously-served / configured model set BEFORE the
+        // coordinator client exists, so a release restart never advertises
+        // models it hasn't warmed (the v0.6.30 first_chunk_timeout storm).
+        // Bounded by startup_preload_timeout_secs — on timeout we register
+        // anyway and the remaining loads continue in the background.
+        await runStartupPreloadGate()
+
         // 2. Build attestation blob for registration
         let attestation = buildRegistrationAttestation()
 
@@ -93,11 +101,15 @@ extension ProviderLoop {
         }
         #endif
 
-        // 4. Create coordinator client config
+        // 4. Create coordinator client config. The model list is filtered
+        // through the live advertised set: identical to loopConfig.models at
+        // defaults, minus any model the startup self-test retired when the
+        // operator opted into startup_selftest_fail_closed.
+        let registrationModels = loopConfig.models.filter { advertisedModels[$0.id] != nil }
         let coordinatorConfig = CoordinatorClientConfig(
             url: loopConfig.coordinatorURL,
             hardware: loopConfig.hardware,
-            models: loopConfig.models,
+            models: registrationModels,
             backendName: "mlx-swift",
             heartbeatInterval: TimeInterval(loopConfig.config.coordinator.heartbeatIntervalSecs),
             publicKey: keyPair.publicKeyBase64,
@@ -264,13 +276,20 @@ extension ProviderLoop {
         if let prefetchCoordinator {
             await prefetchCoordinator.shutdown(timeout: Self.preloadShutdownTimeout)
         }
-        let preloads = Array(preloadTasks.values)
+        // Cancel BOTH preload flavors: coordinator-driven load_model tasks and
+        // any still-running startup preload driver (it outlives the readiness
+        // gate when the timeout passed).
+        var preloads = Array(preloadTasks.values)
+        if let startupTask = startupPreloadTask {
+            preloads.append(startupTask)
+        }
         for task in preloads { task.cancel() }
         cancelLoadWaiters()
         let preloadsFinished = await waitForPreloads(preloads, timeout: Self.preloadShutdownTimeout)
         if !preloadsFinished {
             logger.warning("Timed out waiting for coordinator-driven preloads to cancel during shutdown")
         }
+        startupPreloadTask = nil
         preloadTasks.removeAll()
         preloadTaskIds.removeAll()
         preloadStatusSubscribers.removeAll()

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+Serve.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+Serve.swift
@@ -19,6 +19,18 @@ extension ProviderLoop {
     // MARK: - Main Run Loop
 
     public func run() async throws {
+        // FIRST, before any engine/model code can latch the library's
+        // `CompiledDecode.isEnabled` static: force the legacy engine's
+        // compiled decode OFF unless the operator opted in via config
+        // (`legacy_compiled_decode = true`) or set the env var explicitly
+        // (which always wins). Keeps release behavior identical to prod
+        // v0.6.30 — see `LegacyCompiledDecodeGate`.
+        if LegacyCompiledDecodeGate.apply(
+            configEnabled: loopConfig.config.backend.legacyCompiledDecode)
+        {
+            logger.info("Legacy compiled decode disabled (legacy_compiled_decode=false, env unset)")
+        }
+
         logger.info("darkbloom \(ProviderCore.version) starting")
         logger.info("Hardware: \(loopConfig.hardware.chipName), \(loopConfig.hardware.memoryGb) GB RAM, \(loopConfig.hardware.gpuCores) GPU cores")
         logger.info("Models: \(loopConfig.models.count) advertised")

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+Serve.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+Serve.swift
@@ -66,6 +66,11 @@ extension ProviderLoop {
         // 1. Apply security hardening
         try await applySecurityHardening()
 
+        // Arm the loaded-models persistence now that this loop is actually
+        // serving (test instances never flip this, so their unload paths
+        // cannot clobber the real ~/.darkbloom/loaded-models.json).
+        loadedModelsPersistenceEnabled = true
+
         // 1.5 Startup preload + readiness gate (ProviderLoop+StartupPreload):
         // load the previously-served / configured model set BEFORE the
         // coordinator client exists, so a release restart never advertises

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+StartupPreload.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+StartupPreload.swift
@@ -1,0 +1,314 @@
+/// ProviderLoop -- boot-time model preload + registration readiness gate.
+///
+/// Fixes the v0.6.30-class cold-restart failure mode: the provider used to
+/// register (and attract routing) immediately after a release restart with
+/// NOTHING loaded, so the first requests paid the full multi-GB weight load
+/// and engine build inside a live request — and at a fleet rollover every box
+/// was cold at once (first_chunk_timeout storm).
+///
+/// Now `run()` calls `runStartupPreloadGate()` BEFORE the coordinator client
+/// is created: the previously-served (or operator-configured) model set is
+/// loaded via the normal `ensureModelLoaded` path (weights + legacy scheduler
+/// + v2 bridge/warmup when flagged), optionally followed by a 1-token greedy
+/// decode through the real serving path so Metal JIT, compiled buckets, and
+/// the chat-template render are warm before the first routed request.
+///
+/// **Readiness vs availability tradeoff.** Registration is deferred only up
+/// to `startup_preload_timeout_secs` (default 120s). If a load exceeds it,
+/// the provider registers anyway — a lone provider for a model must still
+/// serve it cold, and the existing lazy-load path is unchanged as the
+/// fallback — while the remaining preloads continue in the background. The
+/// heartbeat's `warm_models` field (which the coordinator's warm-model bonus
+/// scores) stays truthful throughout: it is derived from live slots only, so
+/// a still-loading model is never advertised as warm.
+
+import CryptoKit
+import Foundation
+import MLX
+import MLXLLM
+import MLXLMCommon
+import MLXLMServer
+import MLXVLM
+#if canImport(os)
+import os
+#endif
+
+extension ProviderLoop {
+
+    /// How the startup preload gate resolved (logged; asserted in tests).
+    internal enum StartupPreloadGateOutcome: Sendable, Equatable {
+        /// `startup_preload = false`.
+        case disabled
+        /// Nothing to preload (no config list, no persisted set, or nothing
+        /// advertised) — legacy register-immediately timing.
+        case nothingToPreload
+        /// Preload finished within the timeout — registering fully warm.
+        case warm
+        /// Timeout hit — registering now; loads continue in the background.
+        case timedOut
+    }
+
+    /// Upper bound on one startup self-test decode so a wedged decode can
+    /// never stall the whole preload driver (and with it every later model's
+    /// warmup) indefinitely.
+    internal static let startupSelfTestTimeout: Duration = .seconds(180)
+
+    // MARK: - Loaded-model set persistence
+
+    internal func loadedModelsFileURL() -> URL {
+        loadedModelsFileOverride ?? LoadedModelsStore.path()
+    }
+
+    /// Persist the current loaded-model set. Called after every successful
+    /// load and every NON-shutdown unload (idle timeout, eviction,
+    /// retirement); the shutdown teardown skips it so a stop/update/restart
+    /// remembers what was being served — that persisted set is the default
+    /// startup preload plan.
+    internal func persistLoadedModelSet() {
+        let loaded = modelSlots.keys.filter { !modelsUnloading.contains($0) }.sorted()
+        LoadedModelsStore.write(loaded, to: loadedModelsFileURL())
+    }
+
+    // MARK: - Preload plan
+
+    /// Build the ordered startup preload plan:
+    ///   * `preload_models` non-empty → that list, in operator order;
+    ///   * otherwise → the persisted previously-served set, biggest first
+    ///     (the largest model loads while memory is emptiest).
+    /// Ids not in the advertised set are skipped with a WARN; the plan is
+    /// de-duplicated and capped at `maxModelSlots`.
+    internal func startupPreloadPlan() -> [StartupPreloader.Candidate] {
+        let backend = loopConfig.config.backend
+        let ids: [String]
+        if !backend.preloadModels.isEmpty {
+            ids = backend.preloadModels
+        } else {
+            ids = LoadedModelsStore.read(from: loadedModelsFileURL()).sorted {
+                (advertisedModels[$0]?.estimatedMemoryGb ?? 0)
+                    > (advertisedModels[$1]?.estimatedMemoryGb ?? 0)
+            }
+        }
+
+        var seen = Set<String>()
+        var plan: [StartupPreloader.Candidate] = []
+        for id in ids {
+            guard seen.insert(id).inserted else { continue }
+            guard let info = advertisedModels[id] else {
+                logger.warning("Startup preload: '\(id)' is not in the advertised model set — skipping")
+                continue
+            }
+            guard plan.count < maxModelSlots else {
+                logger.warning(
+                    "Startup preload: plan exceeds max_model_slots=\(self.maxModelSlots) — skipping '\(id)'")
+                continue
+            }
+            plan.append(
+                StartupPreloader.Candidate(
+                    modelId: id,
+                    requiredGb: ModelLoadAdmission.requiredToLoadGb(
+                        weightsGb: info.estimatedMemoryGb,
+                        headroomGb: Self.loadHeadroomGb)))
+        }
+        return plan
+    }
+
+    // MARK: - Readiness gate
+
+    /// Preload the startup plan, deferring the caller (registration) up to
+    /// `startup_preload_timeout_secs`. On timeout the driver keeps running in
+    /// the background (`startupPreloadTask`); shutdown cancels it.
+    @discardableResult
+    internal func runStartupPreloadGate() async -> StartupPreloadGateOutcome {
+        let backend = loopConfig.config.backend
+        guard backend.startupPreload else {
+            logger.info("Startup preload disabled (startup_preload=false)")
+            return .disabled
+        }
+        let plan = startupPreloadPlan()
+        guard !plan.isEmpty else {
+            logger.info("Startup preload: nothing to preload — registering immediately")
+            return .nothingToPreload
+        }
+
+        let timeout = Duration.seconds(Int64(max(1, backend.startupPreloadTimeoutSecs)))
+        logger.info(
+            "Startup preload: \(plan.count) model(s) [\(plan.map(\.modelId).joined(separator: ", "))] — "
+                + "deferring registration up to \(backend.startupPreloadTimeoutSecs)s")
+
+        let me = self
+        let log = logger
+        let failClosed = backend.startupSelftestFailClosed
+        var selfTestClosure: (@Sendable (String) async throws -> Duration)?
+        if backend.startupSelftest {
+            selfTestClosure = { modelId in try await me.startupPreloadSelfTest(modelId: modelId) }
+        }
+        let onSelfTestFailed: @Sendable (String, String) -> Void = { modelId, message in
+            TelemetryClient.shared.emit(
+                kind: .engineHealth,
+                severity: .warn,
+                message: "startup self-test decode failed",
+                fields: [
+                    "model": .string(modelId),
+                    "error": .string(message),
+                    "fail_closed": .bool(failClosed),
+                ]
+            )
+        }
+        let deps = StartupPreloader.Dependencies(
+            freeMemoryGb: { await me.startupPreloadFreeMemoryGb() },
+            load: { modelId in try await me.startupPreloadLoad(modelId: modelId) },
+            selfTest: selfTestClosure,
+            selfTestFailClosed: failClosed,
+            retire: { modelId in await me.retireModelAfterFailedSelfTest(modelId: modelId) },
+            onSelfTestFailed: onSelfTestFailed,
+            log: { line in log.info("\(line)") }
+        )
+
+        let preloader = StartupPreloader(deps: deps)
+        let clock = ContinuousClock()
+        let started = clock.now
+        let driver = Task {
+            let summary = await preloader.run(candidates: plan)
+            await me.finishStartupPreload(summary: summary, elapsed: clock.now - started)
+        }
+        startupPreloadTask = driver
+
+        let finishedInTime = await waitForPreloads([driver], timeout: timeout)
+        if finishedInTime {
+            logger.info(
+                "Startup preload gate: warm after \(StartupPreloader.secs(clock.now - started)) — registering")
+            return .warm
+        }
+        logger.warning(
+            "Startup preload gate: exceeded \(backend.startupPreloadTimeoutSecs)s — registering now; "
+                + "remaining loads continue in the background (cold requests use the lazy-load path)")
+        return .timedOut
+    }
+
+    /// Driver epilogue: log the summary and clear the task handle. Runs on the
+    /// actor whether the gate was still waiting or had already timed out.
+    private func finishStartupPreload(summary: StartupPreloader.Summary, elapsed: Duration) {
+        startupPreloadTask = nil
+        var parts = ["loaded=\(summary.loaded.count)"]
+        if !summary.skippedInsufficientMemory.isEmpty {
+            parts.append("skipped_memory=[\(summary.skippedInsufficientMemory.joined(separator: ", "))]")
+        }
+        if !summary.failed.isEmpty {
+            parts.append("failed=[\(summary.failed.joined(separator: ", "))]")
+        }
+        if !summary.selfTestFailed.isEmpty {
+            parts.append("selftest_failed=[\(summary.selfTestFailed.joined(separator: ", "))]")
+        }
+        if !summary.retired.isEmpty {
+            parts.append("retired=[\(summary.retired.joined(separator: ", "))]")
+        }
+        logger.info(
+            "Startup preload complete in \(StartupPreloader.secs(elapsed)): \(parts.joined(separator: " "))")
+        writeDaemonState()
+    }
+
+    // MARK: - Preload steps (production wiring, overridable in tests)
+
+    private func startupPreloadFreeMemoryGb() async -> Double {
+        if let override = startupPreloadFreeMemoryOverride {
+            return await override()
+        }
+        return await availableMemoryGb()
+    }
+
+    private func startupPreloadLoad(modelId: String) async throws {
+        if let override = startupPreloadLoadOverride {
+            try await override(modelId)
+            return
+        }
+        try await ensureModelLoaded(modelId: modelId)
+    }
+
+    private func startupPreloadSelfTest(modelId: String) async throws -> Duration {
+        if let override = startupSelfTestOverride {
+            return try await override(modelId)
+        }
+        // Bounded: a wedged decode fails the self-test instead of stalling the
+        // driver (and the remaining models' warmup) forever.
+        let me = self
+        return try await withThrowingTaskGroup(of: Duration.self) { group in
+            group.addTask { try await me.runStartupSelfTestDecode(modelId: modelId) }
+            group.addTask {
+                try await Task.sleep(for: Self.startupSelfTestTimeout)
+                throw InferenceError.generationFailed(
+                    "startup self-test timed out after \(Self.startupSelfTestTimeout.components.seconds)s")
+            }
+            guard let first = try await group.next() else { throw CancellationError() }
+            group.cancelAll()
+            return first
+        }
+    }
+
+    /// Fail-closed retirement: unload the model and drop it from the
+    /// advertised set for this run, so registration (which filters
+    /// `loopConfig.models` through `advertisedModels`) never announces it.
+    /// The persisted loaded-model set is updated by `unloadModel`.
+    private func retireModelAfterFailedSelfTest(modelId: String) async {
+        await unloadModel(modelId)
+        advertisedModels.removeValue(forKey: modelId)
+    }
+
+    // MARK: - Self-test decode (the serving path)
+
+    /// One-token greedy decode through the SAME path a routed request takes:
+    /// `MultiModelBatchSchedulerEngine` over the loaded slot (v2 bridge when
+    /// the slot carries one, else the legacy scheduler) via
+    /// `MLXOpenAIService.streamChatCompletionFrames`. Forces end-to-end
+    /// warmth — Metal JIT, compiled decode buckets, chat-template render —
+    /// with a tiny prompt. Holds a local reservation so eviction can't pull
+    /// the model out from under the decode.
+    internal func runStartupSelfTestDecode(modelId: String) async throws -> Duration {
+        guard let slot = modelSlots[modelId], !modelsUnloading.contains(modelId) else {
+            throw InferenceError.noModelLoaded
+        }
+        localReservations.reserve(modelId)
+        defer {
+            localReservations.release(modelId)
+            modelSlots[modelId]?.lastInferenceAt = .now
+        }
+
+        let sched = slot.scheduler
+        let tokenizer = slot.tokenizer
+        let modelType = slot.modelType
+        let slotContainer = slot.container
+        let slotIsVLM = slot.isVLM
+        let slotEngineV2 = slot.engineV2
+
+        let request = OpenAIChatCompletionRequest(
+            model: modelId,
+            messages: [OpenAIChatMessage(role: .user, content: .text("Hi"))],
+            reasoningParser: Self.inferReasoningParser(for: modelType),
+            stream: true,
+            temperature: 0,
+            maxTokens: 1
+        )
+
+        let engine = MultiModelBatchSchedulerEngine(
+            registryProvider: { @Sendable in
+                [modelId: .init(
+                    scheduler: sched, tokenizer: tokenizer, modelType: modelType,
+                    container: slotContainer, isVLM: slotIsVLM,
+                    engineV2Bridge: slotEngineV2)]
+            },
+            defaultMaxTokens: Self.schedulerDefaultMaxTokens
+        )
+        let service = MLXOpenAIService(engine: engine)
+
+        let clock = ContinuousClock()
+        let start = clock.now
+        let frames = try await service.streamChatCompletionFrames(request: request)
+        var frameCount = 0
+        for try await _ in frames {
+            frameCount += 1
+        }
+        guard frameCount > 0 else {
+            throw InferenceError.generationFailed("startup self-test produced no output frames")
+        }
+        return clock.now - start
+    }
+}

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+StartupPreload.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+StartupPreload.swift
@@ -65,6 +65,10 @@ extension ProviderLoop {
     /// remembers what was being served — that persisted set is the default
     /// startup preload plan.
     internal func persistLoadedModelSet() {
+        // Inert until run() (or the test seam) enables it: a ProviderLoop
+        // that never serves — every unit test exercising load/unload — must
+        // not write the operator's real loaded-models file.
+        guard loadedModelsPersistenceEnabled else { return }
         let loaded = modelSlots.keys.filter { !modelsUnloading.contains($0) }.sorted()
         LoadedModelsStore.write(loaded, to: loadedModelsFileURL())
     }
@@ -221,7 +225,14 @@ extension ProviderLoop {
             try await override(modelId)
             return
         }
-        try await ensureModelLoaded(modelId: modelId)
+        // allowEviction: false — the preloader's freeMemoryGb pre-check is a
+        // fast skip, but the authoritative no-evict enforcement lives INSIDE
+        // ensureModelLoaded's serialized critical section, so an interleaved
+        // local-endpoint load can't make it stale. A candidate that would
+        // require evicting an earlier preload (or any resident model) fails
+        // here and is WARN-logged by the preloader; the lazy-load path (which
+        // MAY evict, as always) remains the fallback for live traffic.
+        try await ensureModelLoaded(modelId: modelId, allowEviction: false)
     }
 
     private func startupPreloadSelfTest(modelId: String) async throws -> Duration {
@@ -248,9 +259,23 @@ extension ProviderLoop {
     /// advertised set for this run, so registration (which filters
     /// `loopConfig.models` through `advertisedModels`) never announces it.
     /// The persisted loaded-model set is updated by `unloadModel`.
+    ///
+    /// Post-registration retirement (the gate timed out, so the coordinator
+    /// client is already live and the initial `register` carried this model):
+    /// registration is the only wire mechanism that communicates a REMOVAL
+    /// from the advertised set (`models_update` is additive), so mirror the
+    /// hard-swap drop (`dropAdvertisedBuild`) — remove it from the client's
+    /// advertised store — and force a reconnect so a fresh `register`
+    /// announces the shrunken set. Pre-registration (the common case:
+    /// preload finished inside the gate) both are nil and the `run()` filter
+    /// handles it with no extra traffic.
     private func retireModelAfterFailedSelfTest(modelId: String) async {
         await unloadModel(modelId)
         advertisedModels.removeValue(forKey: modelId)
+        if let client = coordinatorClient {
+            await client.unadvertiseModel(modelId)
+            await client.forceReconnect()
+        }
     }
 
     // MARK: - Self-test decode (the serving path)

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+Testing.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+Testing.swift
@@ -63,4 +63,68 @@ extension ProviderLoop {
         if let send { self.outboundSend = send }
     }
 
+    // MARK: - ContinuousBatchingV2 seams
+
+    /// Test seam: swap the process-global v2 runtime for an isolated
+    /// instance so registration/consult assertions can't race other tests.
+    func setEngineV2RuntimeForTesting(_ runtime: EngineV2Runtime) {
+        engineV2Runtime = runtime
+    }
+
+    /// Test seam: install slot-factory hooks (environment + EOS snapshot +
+    /// engine builder) so `makeEngineV2BridgeForSlot` runs end-to-end with a
+    /// scripted `CBv2Engine` — no model weights, no container reads.
+    func setEngineV2SlotHooksForTesting(_ hooks: EngineV2SlotHooks?) {
+        engineV2SlotHooks = hooks
+    }
+
+    /// Test seam: drive the model-load slot factory directly (production
+    /// entry point is `ensureModelLoaded`, which needs real weights).
+    func makeEngineV2BridgeForSlotForTesting(
+        modelId: String,
+        modelType: String?,
+        isVLM: Bool = false,
+        container: MLXLMCommon.ModelContainer,
+        tokenizer: TokenizerHandle,
+        scheduler: BatchScheduler
+    ) async -> EngineV2Bridge? {
+        await makeEngineV2BridgeForSlot(
+            modelId: modelId,
+            modelType: modelType,
+            isVLM: isVLM,
+            container: container,
+            tokenizer: tokenizer,
+            scheduler: scheduler
+        )
+    }
+
+    /// Test seam: install a fully-formed model slot (optionally carrying a
+    /// v2 bridge) so capacity/cancellation guard tests can exercise the
+    /// slot-dependent paths without loading weights.
+    func installModelSlotForTesting(
+        modelId: String,
+        scheduler: BatchScheduler,
+        container: MLXLMCommon.ModelContainer,
+        tokenizer: TokenizerHandle,
+        engineV2: EngineV2Bridge? = nil,
+        modelType: String? = nil
+    ) {
+        modelSlots[modelId] = ModelSlot(
+            scheduler: scheduler,
+            engineV2: engineV2,
+            container: container,
+            tokenizer: tokenizer,
+            isVLM: false,
+            modelType: modelType,
+            lastInferenceAt: .now
+        )
+    }
+
+    /// Test seam: whether any live slot carries a v2 bridge (the capacity/
+    /// cancellation zero-overhead guard).
+    func hasEngineV2SlotsForTesting() -> Bool { hasEngineV2Slots }
+
+    /// Test seam: the current aggregate backend capacity snapshot.
+    func backendCapacityForTesting() -> BackendCapacity? { state.backendCapacity }
+
 }

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+Testing.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+Testing.swift
@@ -67,9 +67,17 @@ extension ProviderLoop {
 
     /// Test seam: redirect the loaded-models persistence file to a temp path
     /// so persistence tests never touch the operator's real
-    /// `~/.darkbloom/loaded-models.json`.
+    /// `~/.darkbloom/loaded-models.json`, and arm the persistence gate
+    /// (production arms it in `run()`).
     func setLoadedModelsFileForTesting(_ url: URL?) {
         loadedModelsFileOverride = url
+        loadedModelsPersistenceEnabled = url != nil
+    }
+
+    /// Test seam: toggle the persistence gate independently of the path
+    /// override (pins the "inert unless serving" guard).
+    func setLoadedModelsPersistenceEnabledForTesting(_ enabled: Bool) {
+        loadedModelsPersistenceEnabled = enabled
     }
 
     /// Test seam: replace `ensureModelLoaded` in the startup preload driver
@@ -123,6 +131,14 @@ extension ProviderLoop {
     /// Test seam: whether the startup preload driver is still running.
     func startupPreloadTaskRunningForTesting() -> Bool {
         startupPreloadTask != nil
+    }
+
+    /// Test seam: install a live coordinator client (without the prefetch
+    /// machinery `installPrefetchCoordinatorForTesting` requires) so the
+    /// post-registration fail-closed retirement path can be exercised
+    /// against a real client + mock coordinator.
+    func setCoordinatorClientForTesting(_ client: CoordinatorClient) {
+        coordinatorClient = client
     }
 
     // MARK: - ContinuousBatchingV2 seams

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+Testing.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+Testing.swift
@@ -63,6 +63,68 @@ extension ProviderLoop {
         if let send { self.outboundSend = send }
     }
 
+    // MARK: - Startup preload seams
+
+    /// Test seam: redirect the loaded-models persistence file to a temp path
+    /// so persistence tests never touch the operator's real
+    /// `~/.darkbloom/loaded-models.json`.
+    func setLoadedModelsFileForTesting(_ url: URL?) {
+        loadedModelsFileOverride = url
+    }
+
+    /// Test seam: replace `ensureModelLoaded` in the startup preload driver
+    /// with a scripted loader (no weights, no disk).
+    func setStartupPreloadLoadOverrideForTesting(
+        _ load: (@Sendable (String) async throws -> Void)?
+    ) {
+        startupPreloadLoadOverride = load
+    }
+
+    /// Test seam: replace the startup self-test decode with a scripted stub.
+    func setStartupSelfTestOverrideForTesting(
+        _ selfTest: (@Sendable (String) async throws -> Duration)?
+    ) {
+        startupSelfTestOverride = selfTest
+    }
+
+    /// Test seam: replace the preload admission's free-memory probe with a
+    /// scripted value (the real probe reads live machine memory).
+    func setStartupPreloadFreeMemoryOverrideForTesting(
+        _ freeMemoryGb: (@Sendable () async -> Double)?
+    ) {
+        startupPreloadFreeMemoryOverride = freeMemoryGb
+    }
+
+    /// Test seam: the ordered startup preload plan (config list vs persisted
+    /// set, dedup, advertised filter, slot cap).
+    func startupPreloadPlanForTesting() -> [StartupPreloader.Candidate] {
+        startupPreloadPlan()
+    }
+
+    /// Test seam: run the registration readiness gate (the production entry
+    /// point is `run()`, which needs a live coordinator).
+    func runStartupPreloadGateForTesting() async -> StartupPreloadGateOutcome {
+        await runStartupPreloadGate()
+    }
+
+    /// Test seam: write the current loaded-model set to the persistence file
+    /// (production write points are `ensureModelLoaded` / `unloadModel`).
+    func persistLoadedModelSetForTesting() {
+        persistLoadedModelSet()
+    }
+
+    /// Test seam: mark the loop as shutting down, so tests can assert the
+    /// shutdown-teardown guard (unloads during shutdown must NOT rewrite the
+    /// persisted serving set).
+    func beginShutdownForTesting() {
+        isShuttingDown = true
+    }
+
+    /// Test seam: whether the startup preload driver is still running.
+    func startupPreloadTaskRunningForTesting() -> Bool {
+        startupPreloadTask != nil
+    }
+
     // MARK: - ContinuousBatchingV2 seams
 
     /// Test seam: swap the process-global v2 runtime for an isolated

--- a/provider-swift/Sources/ProviderCore/ProviderLoop.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop.swift
@@ -335,6 +335,27 @@ public actor ProviderLoop {
     /// Tracks coordinator-driven preload tasks so they can be cancelled on shutdown.
     internal var preloadTasks: [String: Task<Void, Never>] = [:]
 
+    /// Startup preload driver (`ProviderLoop+StartupPreload`). Non-nil while
+    /// the boot-time preload of the configured/previously-served model set is
+    /// still running — it may outlive the registration gate when the
+    /// `startup_preload_timeout_secs` deadline passes (loads continue in the
+    /// background). Cancelled and awaited on shutdown alongside the
+    /// coordinator-driven preloads.
+    internal var startupPreloadTask: Task<Void, Never>?
+
+    /// Test seam: overrides the loaded-models persistence file
+    /// (default: `LoadedModelsStore.path()`).
+    internal var loadedModelsFileOverride: URL?
+
+    /// Test seams for the startup preload driver: replace the real
+    /// `ensureModelLoaded` / self-test decode / free-memory probe with
+    /// scripted stubs so the plan, gate timing, admission, and
+    /// fail-open/closed paths run without model weights or a live memory
+    /// reading. nil in production.
+    internal var startupPreloadLoadOverride: (@Sendable (String) async throws -> Void)?
+    internal var startupSelfTestOverride: (@Sendable (String) async throws -> Duration)?
+    internal var startupPreloadFreeMemoryOverride: (@Sendable () async -> Double)?
+
     /// Senders waiting for the terminal status of an in-flight preload.
     internal var preloadStatusSubscribers: [String: [SendHandle]] = [:]
 
@@ -557,6 +578,7 @@ public actor ProviderLoop {
     //   - ProviderLoop+Serve.swift               run() loop + registration setup
     //   - ProviderLoop+InferenceHandler.swift    handleInferenceRequest + draining gates
     //   - ProviderLoop+Preload.swift             load_model preload + preload/shutdown waits
+    //   - ProviderLoop+StartupPreload.swift      boot-time preload + registration readiness gate
     //   - ProviderLoop+Prefetch.swift            background prefetch + desired-models reconcile
     //   - ProviderLoop+Testing.swift             test-only seams (ProviderCoreTests)
     //   - ProviderLoop+Trust.swift               trust status + one-time auto-report

--- a/provider-swift/Sources/ProviderCore/ProviderLoop.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop.swift
@@ -347,6 +347,14 @@ public actor ProviderLoop {
     /// (default: `LoadedModelsStore.path()`).
     internal var loadedModelsFileOverride: URL?
 
+    /// Gate on the loaded-models persistence writes. `run()` flips it on at
+    /// startup; it stays FALSE for `ProviderLoop` instances that never serve
+    /// (unit tests exercising load/unload paths), so an unrelated test can
+    /// never clobber the operator's real `~/.darkbloom/loaded-models.json`
+    /// — that file is the next boot's preload plan. The test seam
+    /// `setLoadedModelsFileForTesting` enables it together with a temp path.
+    internal var loadedModelsPersistenceEnabled = false
+
     /// Test seams for the startup preload driver: replace the real
     /// `ensureModelLoaded` / self-test decode / free-memory probe with
     /// scripted stubs so the plan, gate timing, admission, and

--- a/provider-swift/Sources/ProviderCore/ProviderLoop.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop.swift
@@ -171,6 +171,18 @@ public actor ProviderLoop {
     /// BatchScheduler and worker task. Keyed by model ID.
     internal var modelSlots: [String: ModelSlot] = [:]
 
+    /// ContinuousBatchingV2 bridge registry consulted by the capacity and
+    /// cancellation hooks — but ONLY when at least one v2 slot exists (see
+    /// the `hasEngineV2Slots` guards in `ProviderLoop+Capacity` /
+    /// `+Cancellation`), so flag-off providers never pay the actor hop.
+    /// Defaults to the process-global instance; tests inject an isolated one.
+    internal var engineV2Runtime: EngineV2Runtime = .shared
+
+    /// Test seam (`ProviderLoop+Testing`): overrides the environment, the
+    /// container EOS snapshot, and the production CBv2 engine builder used
+    /// by `makeEngineV2BridgeForSlot`. nil in production.
+    internal var engineV2SlotHooks: EngineV2SlotHooks?
+
     /// Operator-configured hard cap on concurrent model slots
     /// (`backend.maxModelSlots`). This is the memory-safety ceiling: the
     /// effective cap never exceeds it. A provider configured with `1` has opted
@@ -489,6 +501,13 @@ public actor ProviderLoop {
 
     internal struct ModelSlot {
         let scheduler: BatchScheduler
+        /// ContinuousBatchingV2 bridge for this slot — non-nil ONLY when
+        /// `EngineV2Config` selected the v2 engine at load time AND its
+        /// construction succeeded. Stored ALONGSIDE (never replacing) the
+        /// legacy scheduler: requests route through the bridge when present,
+        /// and every fallback path (flag off, non-allowlisted model, v2 init
+        /// failure) leaves this nil and serves via `scheduler` unchanged.
+        let engineV2: EngineV2Bridge?
         let container: MLXLMCommon.ModelContainer
         let tokenizer: TokenizerHandle
         /// Vision-language model (config has `vision_config`). Multimodal
@@ -546,6 +565,7 @@ public actor ProviderLoop {
     //   - ProviderLoop+Capacity.swift            capacity refresh + updateAggregateCapacity
     //   - ProviderLoop+AutoUpdate.swift          background self-update + phase transitions
     //   - ProviderLoop+ModelLoading.swift        ensureModelLoaded/unload + memory admission
+    //   - ProviderLoop+EngineV2.swift            ContinuousBatchingV2 slot wiring (flag-gated)
     //   - ProviderLoop+Cancellation.swift        cancellation + in-flight drain
     //   - ProviderLoop+AttestationChallenge.swift attestation + APNs code challenge
     //   - ProviderLoop+LocalEndpoint.swift       unified local HTTP endpoint

--- a/provider-swift/Sources/ProviderCore/Server/StandaloneServer.swift
+++ b/provider-swift/Sources/ProviderCore/Server/StandaloneServer.swift
@@ -460,6 +460,11 @@ public actor StandaloneServer {
             release: releaseClosure,
             modelId: modelId
         )
+        // ContinuousBatchingV2 is deliberately NOT wired here: standalone
+        // (`--local`-only) mode builds its own slots outside ProviderLoop and
+        // always serves the legacy engine, regardless of DARKBLOOM_ENGINE_V2
+        // / engine_v2. The unified local endpoint (ProviderLoop+LocalEndpoint)
+        // does route through the v2 bridge when the slot carries one.
         return MultiModelBatchSchedulerEngine.AcquiredModel(
             scheduler: cached.scheduler,
             tokenizer: cached.tokenizer,

--- a/provider-swift/Sources/ProviderCore/Service/LoadedModelsStore.swift
+++ b/provider-swift/Sources/ProviderCore/Service/LoadedModelsStore.swift
@@ -1,0 +1,82 @@
+import Foundation
+
+/// Persists the set of models currently loaded by the serving daemon so the
+/// NEXT boot can preload them before registering with the coordinator.
+///
+/// This is the default input to the startup preload (`preload_models` empty):
+/// "warm what you were serving before the restart". The daemon rewrites the
+/// file on every model load and on every non-shutdown unload (idle timeout,
+/// eviction, retirement), so the file always describes the live serving set.
+/// Shutdown teardown deliberately does NOT clear it — a stop/update/restart
+/// must remember what was being served, which is the entire point.
+///
+/// The file lives in the provider's data dir (`~/.darkbloom/`, the same place
+/// as `daemon-state.json`) so it survives auto-updates, which replace the
+/// install layout but never touch the data dir. Best-effort like the daemon
+/// state file: read/write failures degrade to "no preload", never a crash.
+public enum LoadedModelsStore {
+    /// Schema version; bump on incompatible shape changes. A mismatched schema
+    /// reads as empty (safe: worst case the next boot preloads nothing).
+    public static let currentSchema = 1
+
+    /// Persisted shape: schema + loaded model ids + write timestamp.
+    public struct State: Codable, Sendable, Equatable {
+        public var schema: Int
+        public var models: [String]
+        public var updatedAt: Double
+
+        public init(schema: Int = LoadedModelsStore.currentSchema, models: [String], updatedAt: Double) {
+            self.schema = schema
+            self.models = models
+            self.updatedAt = updatedAt
+        }
+    }
+
+    /// `~/.darkbloom/loaded-models.json`, overridable with
+    /// `DARKBLOOM_LOADED_MODELS_FILE` (mirrors `DARKBLOOM_STATE_FILE`).
+    public static func path() -> URL {
+        if let override = ProcessInfo.processInfo.environment["DARKBLOOM_LOADED_MODELS_FILE"],
+            !override.isEmpty {
+            return URL(fileURLWithPath: override)
+        }
+        return FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".darkbloom/loaded-models.json")
+    }
+
+    private static func encoder() -> JSONEncoder {
+        let e = JSONEncoder()
+        e.keyEncodingStrategy = .convertToSnakeCase
+        e.outputFormatting = [.sortedKeys]
+        return e
+    }
+
+    private static func decoder() -> JSONDecoder {
+        let d = JSONDecoder()
+        d.keyDecodingStrategy = .convertFromSnakeCase
+        return d
+    }
+
+    /// Atomically writes the loaded-model set. Best-effort: failures are
+    /// swallowed (persistence is an optimization, never worth crashing the
+    /// serving daemon over).
+    public static func write(_ models: [String], to url: URL = LoadedModelsStore.path()) {
+        let state = State(models: models, updatedAt: Date().timeIntervalSince1970)
+        do {
+            let dir = url.deletingLastPathComponent()
+            try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+            let data = try encoder().encode(state)
+            try data.write(to: url, options: .atomic)
+        } catch {
+            // Intentionally ignored: worst case the next boot preloads nothing.
+        }
+    }
+
+    /// Reads the persisted loaded-model set. Missing / unreadable / corrupt /
+    /// wrong-schema files all read as empty.
+    public static func read(from url: URL = LoadedModelsStore.path()) -> [String] {
+        guard let data = try? Data(contentsOf: url) else { return [] }
+        guard let state = try? decoder().decode(State.self, from: data) else { return [] }
+        guard state.schema == currentSchema else { return [] }
+        return state.models
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Startup/StartupPreloader.swift
+++ b/provider-swift/Sources/ProviderCore/Startup/StartupPreloader.swift
@@ -1,0 +1,178 @@
+import Foundation
+
+/// StartupPreloader -- sequential boot-time model preload with memory
+/// admission and an optional per-model self-test decode.
+///
+/// Fixes the fleet-rollover cold-start failure mode: after a release restart
+/// the provider used to register (and attract routing) with NOTHING loaded, so
+/// first requests paid the full multi-GB weight load + engine build inside a
+/// live request — and at a fleet-wide rollover every box was cold at once
+/// (first_chunk_timeout storm). This component loads the configured /
+/// previously-served model set BEFORE the caller opens the coordinator
+/// connection.
+///
+/// Design rules:
+///   * **Sequential.** Loads are serialized (the `ProviderLoop` load gate
+///     serializes them anyway); one at a time keeps eviction decisions and
+///     memory admission deterministic.
+///   * **Preload never evicts.** Each candidate is admitted only if its
+///     weights + serve headroom fit what is free RIGHT NOW; otherwise it is
+///     skipped with a WARN. Loading a later candidate must never churn out an
+///     earlier preloaded model — the lazy-load path remains the fallback for
+///     skipped models.
+///   * **Failures degrade, never crash.** A failed load or self-test logs,
+///     optionally emits telemetry, and moves on. Fail-open is the default: a
+///     model whose self-test failed stays advertised (availability beats
+///     perfection); `selfTestFailClosed` opts into retiring it.
+///
+/// All side effects are injected so the sequencing is unit-testable with
+/// scripted loaders — no model weights, no network, no MLX.
+public struct StartupPreloader: Sendable {
+
+    /// One model to preload: id + the load-gate admission requirement
+    /// (weights + serve headroom, same arithmetic as `ModelLoadAdmission`).
+    public struct Candidate: Sendable, Equatable {
+        public let modelId: String
+        public let requiredGb: Double
+
+        public init(modelId: String, requiredGb: Double) {
+            self.modelId = modelId
+            self.requiredGb = requiredGb
+        }
+    }
+
+    /// Collaborators the preloader drives. Production wiring lives in
+    /// `ProviderLoop+StartupPreload`; tests substitute scripted closures.
+    public struct Dependencies: Sendable {
+        /// Memory (GB) currently free for a model load (the load-gate view).
+        public var freeMemoryGb: @Sendable () async -> Double
+        /// Full model load: weights + legacy scheduler + v2 bridge/warmup when
+        /// flagged (production: `ensureModelLoaded`).
+        public var load: @Sendable (String) async throws -> Void
+        /// Optional 1-token decode through the serving path after each load.
+        /// nil = self-test disabled. Returns the decode duration.
+        public var selfTest: (@Sendable (String) async throws -> Duration)?
+        /// When true, a failed self-test retires the model (see `retire`).
+        public var selfTestFailClosed: Bool
+        /// Retire a model whose self-test failed (fail-closed only):
+        /// production unloads it and drops it from the advertised set.
+        public var retire: @Sendable (String) async -> Void
+        /// Telemetry hook for self-test failures: (modelId, error message).
+        public var onSelfTestFailed: @Sendable (String, String) -> Void
+        /// Human-readable progress/warning lines.
+        public var log: @Sendable (String) -> Void
+
+        public init(
+            freeMemoryGb: @escaping @Sendable () async -> Double,
+            load: @escaping @Sendable (String) async throws -> Void,
+            selfTest: (@Sendable (String) async throws -> Duration)? = nil,
+            selfTestFailClosed: Bool = false,
+            retire: @escaping @Sendable (String) async -> Void = { _ in },
+            onSelfTestFailed: @escaping @Sendable (String, String) -> Void = { _, _ in },
+            log: @escaping @Sendable (String) -> Void = { _ in }
+        ) {
+            self.freeMemoryGb = freeMemoryGb
+            self.load = load
+            self.selfTest = selfTest
+            self.selfTestFailClosed = selfTestFailClosed
+            self.retire = retire
+            self.onSelfTestFailed = onSelfTestFailed
+            self.log = log
+        }
+    }
+
+    /// What happened, for logging and tests. `loaded` lists models resident
+    /// at the end of the run (a retired model is moved out of `loaded`).
+    public struct Summary: Sendable, Equatable {
+        public var loaded: [String] = []
+        public var skippedInsufficientMemory: [String] = []
+        public var failed: [String] = []
+        public var selfTestFailed: [String] = []
+        public var retired: [String] = []
+
+        public init() {}
+    }
+
+    private let deps: Dependencies
+
+    public init(deps: Dependencies) {
+        self.deps = deps
+    }
+
+    /// Run the preload sequentially over `candidates` (caller-defined order:
+    /// biggest-first for the persisted default, operator order for
+    /// `preload_models`). Honors task cancellation between and inside steps.
+    public func run(candidates: [Candidate]) async -> Summary {
+        var summary = Summary()
+        for candidate in candidates {
+            if Task.isCancelled { break }
+            let modelId = candidate.modelId
+
+            // Memory admission WITHOUT eviction (see the design rules above).
+            let freeGb = await deps.freeMemoryGb()
+            guard freeGb >= candidate.requiredGb else {
+                deps.log(
+                    "WARN: startup preload skipping '\(modelId)': needs "
+                        + "\(Self.gb(candidate.requiredGb)) GB, \(Self.gb(freeGb)) GB free — "
+                        + "will lazy-load on first request")
+                summary.skippedInsufficientMemory.append(modelId)
+                continue
+            }
+
+            let clock = ContinuousClock()
+            let loadStart = clock.now
+            do {
+                try await deps.load(modelId)
+                deps.log("startup preload: loaded '\(modelId)' in \(Self.secs(clock.now - loadStart))")
+                summary.loaded.append(modelId)
+            } catch is CancellationError {
+                break
+            } catch {
+                deps.log(
+                    "WARN: startup preload failed for '\(modelId)': "
+                        + "\(error.localizedDescription) — will lazy-load on first request")
+                summary.failed.append(modelId)
+                continue
+            }
+
+            guard let selfTest = deps.selfTest else { continue }
+            let selfTestStart = clock.now
+            do {
+                let decodeTook = try await selfTest(modelId)
+                deps.log(
+                    "startup self-test: '\(modelId)' decoded 1 token in \(Self.secs(decodeTook)) "
+                        + "(end-to-end \(Self.secs(clock.now - selfTestStart)))")
+            } catch is CancellationError {
+                break
+            } catch {
+                summary.selfTestFailed.append(modelId)
+                deps.onSelfTestFailed(modelId, error.localizedDescription)
+                if deps.selfTestFailClosed {
+                    await deps.retire(modelId)
+                    summary.retired.append(modelId)
+                    summary.loaded.removeAll { $0 == modelId }
+                    deps.log(
+                        "WARN: startup self-test failed for '\(modelId)': "
+                            + "\(error.localizedDescription) — retired "
+                            + "(startup_selftest_fail_closed=true)")
+                } else {
+                    deps.log(
+                        "WARN: startup self-test failed for '\(modelId)': "
+                            + "\(error.localizedDescription) — model stays advertised (fail-open)")
+                }
+            }
+        }
+        return summary
+    }
+
+    // MARK: - Formatting helpers
+
+    static func secs(_ d: Duration) -> String {
+        let seconds = Double(d.components.seconds) + Double(d.components.attoseconds) / 1e18
+        return String(format: "%.1fs", seconds)
+    }
+
+    static func gb(_ v: Double) -> String {
+        String(format: "%.1f", v)
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Update/AutoUpdateController.swift
+++ b/provider-swift/Sources/ProviderCore/Update/AutoUpdateController.swift
@@ -56,6 +56,14 @@ public struct AutoUpdateController: Sendable {
         /// live layout. `.completed` means a verified bundle is staged on
         /// disk; the process keeps serving the old binary.
         public var downloadVerifyStage: @Sendable (ReleaseInfo) async -> StepOutcome
+        /// Rollover jitter: awaited AFTER the bundle is verified + staged and
+        /// BEFORE the drain begins, so a fleet that discovers a release on
+        /// aligned update ticks does not drain + restart in unison (the
+        /// v0.6.30 cold-restart storm). The provider keeps serving normally
+        /// while it waits, and no security-critical check is deferred (verify
+        /// already ran). Defaults to a no-op; production wires a uniformly
+        /// random sleep of up to `update_jitter_seconds`.
+        public var waitBeforeInstall: @Sendable () async -> Void
         /// Stop accepting new requests (drain mode). In-flight requests continue.
         public var beginDraining: @Sendable () async -> Void
         /// Wait until in-flight work reaches zero or `timeout` elapses.
@@ -77,6 +85,7 @@ public struct AutoUpdateController: Sendable {
             resumeServing: @escaping @Sendable () async -> Void,
             check: @escaping @Sendable () async -> UpdateCheckResult,
             downloadVerifyStage: @escaping @Sendable (ReleaseInfo) async -> StepOutcome,
+            waitBeforeInstall: @escaping @Sendable () async -> Void = {},
             beginDraining: @escaping @Sendable () async -> Void,
             waitForDrain: @escaping @Sendable (Duration) async -> Bool,
             forceCancelInflight: @escaping @Sendable () async -> Void,
@@ -88,6 +97,7 @@ public struct AutoUpdateController: Sendable {
             self.resumeServing = resumeServing
             self.check = check
             self.downloadVerifyStage = downloadVerifyStage
+            self.waitBeforeInstall = waitBeforeInstall
             self.beginDraining = beginDraining
             self.waitForDrain = waitForDrain
             self.forceCancelInflight = forceCancelInflight
@@ -158,6 +168,10 @@ public struct AutoUpdateController: Sendable {
                 return .stageFailed(reason)
 
             case .completed:
+                // Rollover jitter (see Dependencies.waitBeforeInstall): the
+                // bundle is verified + staged and we are STILL serving; this
+                // staggers the drain+restart across the fleet.
+                await deps.waitBeforeInstall()
                 deps.log("auto-update: v\(release.version) staged; draining in-flight requests before install + restart")
                 await deps.beginDraining()
 

--- a/provider-swift/Sources/ProviderCore/Update/AutoUpdateController.swift
+++ b/provider-swift/Sources/ProviderCore/Update/AutoUpdateController.swift
@@ -111,6 +111,11 @@ public struct AutoUpdateController: Sendable {
     public enum Outcome: Sendable, Equatable {
         /// A cycle was already in progress; this call did nothing.
         case alreadyRunning
+        /// The cycle was cancelled (provider shutdown / monitor teardown)
+        /// during the pre-install rollover-jitter wait. Nothing was drained,
+        /// committed, or restarted; the staged bundle is discarded by
+        /// `resumeServing` and a later tick can retry.
+        case cancelled
         /// Already on the latest version.
         case upToDate
         /// The version check failed.
@@ -172,6 +177,17 @@ public struct AutoUpdateController: Sendable {
                 // bundle is verified + staged and we are STILL serving; this
                 // staggers the drain+restart across the fleet.
                 await deps.waitBeforeInstall()
+                // A cancelled cycle (provider shutdown / monitor teardown
+                // landing in the jitter window) must NOT proceed: the sleep
+                // returning early on cancellation is not permission to
+                // install. Abort before any drain/commit/restart side effect;
+                // resumeServing discards the staged bundle and a later tick
+                // retries.
+                if Task.isCancelled {
+                    deps.log("auto-update: cycle cancelled during the pre-install wait; aborting before drain")
+                    await deps.resumeServing()
+                    return .cancelled
+                }
                 deps.log("auto-update: v\(release.version) staged; draining in-flight requests before install + restart")
                 await deps.beginDraining()
 

--- a/provider-swift/Sources/ProviderCore/Update/UpdateJitter.swift
+++ b/provider-swift/Sources/ProviderCore/Update/UpdateJitter.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+/// Rollover jitter for background auto-updates.
+///
+/// A release used to restart the whole fleet in near-unison: every provider's
+/// 30-minute update tick discovered the release within the same window (ticks
+/// align after any previous synchronized restart), so every box drained and
+/// restarted together and the entire fleet was cold at once — the
+/// first_chunk_timeout storm. A uniformly-random delay before the
+/// drain+install step decorrelates the restarts.
+///
+/// Placement matters: the delay sits strictly AFTER the download + signature
+/// verification (the bundle is already verified and staged) and BEFORE the
+/// drain begins, so the provider keeps serving normally while it waits and no
+/// security-critical check is deferred. Forced/manual updates
+/// (`darkbloom update`, the startup update check) never call this — they stay
+/// immediate.
+public enum UpdateJitter {
+
+    /// Sanity ceiling: a misconfigured `update_jitter_seconds` can never delay
+    /// an update by more than an hour.
+    public static let maxJitterCapSeconds: UInt64 = 3600
+
+    /// Pick a uniformly-random delay in `[0, maxSeconds]` (millisecond
+    /// granularity). Returns `.zero` when jitter is disabled (`maxSeconds ==
+    /// 0`) or the update is forced (manual/startup paths).
+    public static func delay(maxSeconds: UInt64, forced: Bool = false) -> Duration {
+        var rng = SystemRandomNumberGenerator()
+        return delay(maxSeconds: maxSeconds, forced: forced, using: &rng)
+    }
+
+    /// RNG-injectable variant for deterministic tests.
+    public static func delay(
+        maxSeconds: UInt64,
+        forced: Bool = false,
+        using rng: inout some RandomNumberGenerator
+    ) -> Duration {
+        guard !forced, maxSeconds > 0 else { return .zero }
+        let capped = min(maxSeconds, maxJitterCapSeconds)
+        let millis = Int64.random(in: 0...(Int64(capped) * 1000), using: &rng)
+        return .milliseconds(millis)
+    }
+}

--- a/provider-swift/Sources/darkbloom/StartCommand+Modes.swift
+++ b/provider-swift/Sources/darkbloom/StartCommand+Modes.swift
@@ -59,6 +59,12 @@ extension Start {
         ProcessLifecycle.preventSystemSleep()
         defer { ProcessLifecycle.releaseSingleInstanceLock() }
 
+        // Before any engine/model code latches CompiledDecode.isEnabled:
+        // legacy compiled decode is opt-in (config legacy_compiled_decode /
+        // explicit env DARKBLOOM_COMPILED_DECODE — see LegacyCompiledDecodeGate).
+        LegacyCompiledDecodeGate.apply(
+            configEnabled: config.backend.legacyCompiledDecode)
+
         let server = StandaloneServer(
             config: StandaloneServerConfig(
                 port: port,

--- a/provider-swift/Tests/ProviderCoreTests/B1GreedyFastPathTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/B1GreedyFastPathTests.swift
@@ -210,7 +210,7 @@ struct B1GreedyFastPathBenchmark {
             switch event {
             case .chunk(let text):
                 chunks.append(text)
-            case .info(let prompt, let completion, let tps):
+            case .info(let prompt, let completion, let tps, _):
                 run.promptTokens = prompt
                 run.completionTokens = completion
                 run.tokensPerSecond = tps

--- a/provider-swift/Tests/ProviderCoreTests/BatchSchedulerEngineIntegrationTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/BatchSchedulerEngineIntegrationTests.swift
@@ -211,7 +211,7 @@ struct BatchSchedulerEngineIntegrationTests {
 
     /// Loads a real model and submits a request through `BatchScheduler`,
     /// verifying the event order: at least one `.chunk(...)`, then
-    /// exactly one `.info(promptTokens, completionTokens, _)` with
+    /// exactly one `.info(promptTokens, completionTokens, _, _)` with
     /// non-zero counts, then the stream finishes.
     @Test(
         "submit yields chunks followed by exactly one .info, then finishes",

--- a/provider-swift/Tests/ProviderCoreTests/BatchSchedulerEngineIntegrationTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/BatchSchedulerEngineIntegrationTests.swift
@@ -244,7 +244,7 @@ struct BatchSchedulerEngineIntegrationTests {
             case .chunk:
                 chunkCount += 1
                 lastEventWasInfo = false
-            case .info(let pt, let ct, _):
+            case .info(let pt, let ct, _, _):
                 infoCount += 1
                 promptTokens = pt
                 completionTokens = ct

--- a/provider-swift/Tests/ProviderCoreTests/ConfigTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/ConfigTests.swift
@@ -114,3 +114,68 @@ import Testing
     #expect(toml.contains("adaptive_prefill"))
     #expect(decoded.backend.adaptivePrefill == true)
 }
+
+// MARK: - Startup preload + rollover jitter keys
+
+@Test func configParsingDefaultsStartupPreloadKeys() throws {
+    let config = ConfigManager.parse("""
+    [provider]
+    name = "test-provider"
+
+    [backend]
+    port = 8100
+    """)
+
+    // Fleet-safe defaults: preload on (but a fresh install has no persisted
+    // set, so behavior is unchanged until a model has been served), 120s gate,
+    // self-test on + fail-open, 0-300s update jitter.
+    #expect(config.backend.startupPreload == true)
+    #expect(config.backend.preloadModels == [])
+    #expect(config.backend.startupPreloadTimeoutSecs == 120)
+    #expect(config.backend.startupSelftest == true)
+    #expect(config.backend.startupSelftestFailClosed == false)
+    #expect(config.provider.updateJitterSeconds == 300)
+}
+
+@Test func configParsingHonoursStartupPreloadKeys() throws {
+    let config = ConfigManager.parse("""
+    [provider]
+    name = "test-provider"
+    update_jitter_seconds = 0
+
+    [backend]
+    startup_preload = false
+    preload_models = ["gemma-4-26b-it", "qwen3-8b"]
+    startup_preload_timeout_secs = 45
+    startup_selftest = false
+    startup_selftest_fail_closed = true
+    """)
+
+    #expect(config.backend.startupPreload == false)
+    #expect(config.backend.preloadModels == ["gemma-4-26b-it", "qwen3-8b"])
+    #expect(config.backend.startupPreloadTimeoutSecs == 45)
+    #expect(config.backend.startupSelftest == false)
+    #expect(config.backend.startupSelftestFailClosed == true)
+    #expect(config.provider.updateJitterSeconds == 0)
+}
+
+@Test func configSerializationRoundTripsStartupPreloadKeys() throws {
+    let original = ProviderConfig(
+        provider: ProviderSettings(name: "test-provider", updateJitterSeconds: 60),
+        backend: BackendSettings(
+            preloadModels: ["gemma-4-26b-it"],
+            startupPreloadTimeoutSecs: 90,
+            startupSelftest: false),
+        coordinator: CoordinatorSettings()
+    )
+
+    let toml = ConfigManager.serialize(original)
+    let decoded = ConfigManager.parse(toml)
+
+    #expect(toml.contains("preload_models"))
+    #expect(toml.contains("update_jitter_seconds"))
+    #expect(decoded.backend.preloadModels == ["gemma-4-26b-it"])
+    #expect(decoded.backend.startupPreloadTimeoutSecs == 90)
+    #expect(decoded.backend.startupSelftest == false)
+    #expect(decoded.provider.updateJitterSeconds == 60)
+}

--- a/provider-swift/Tests/ProviderCoreTests/ContinuousBatchingLiveTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/ContinuousBatchingLiveTests.swift
@@ -198,7 +198,7 @@ struct ContinuousBatchingLiveTests {
             temperature: 0.0)
         var schedulerTPS = 0.0
         for await event in schedStream {
-            if case .info(_, let completion, let tps) = event, completion > 1 {
+            if case .info(_, let completion, let tps, _) = event, completion > 1 {
                 schedulerTPS = tps
             }
         }

--- a/provider-swift/Tests/ProviderCoreTests/EngineV2BridgeTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/EngineV2BridgeTests.swift
@@ -203,6 +203,7 @@ private func makeBridge(
     extraEOSTokens: [String] = [],
     defaultMaxTokens: Int = 4096,
     kvBytesPerToken: Int = 0,
+    kvBudget: GlobalKVCacheBudget? = nil,
     telemetry: TelemetrySink? = nil
 ) -> EngineV2Bridge {
     EngineV2Bridge(
@@ -214,6 +215,7 @@ private func makeBridge(
         defaultMaxTokens: defaultMaxTokens,
         maxConcurrentRequests: 4,
         kvBytesPerToken: kvBytesPerToken,
+        kvBudget: kvBudget,
         emitTelemetry: telemetry?.callback()
     )
 }
@@ -1082,5 +1084,93 @@ struct EngineV2ShutdownTests {
         let bridge = makeBridge(engine: engine)
         await bridge.shutdown()
         #expect(engine.shutdownCalls == 1)
+    }
+}
+
+// MARK: - Shared-budget KV accounting (fix #2)
+
+@Suite("EngineV2 shared-budget KV accounting")
+struct EngineV2SharedBudgetTests {
+
+    @Test("kv_quant → fp16 sizing decision (EngineV2KVSizing)")
+    func fp16SizingDecision() {
+        // kv_quant OFF (rates equal): use the rate, no WARN.
+        let off = EngineV2KVSizing.resolve(quantizedRate: 400_000, fp16Rate: 400_000)
+        #expect(off.rate == 400_000)
+        #expect(!off.warnKVQuantUnsupported)
+        // kv_quant ON (quantized below fp16): pick fp16, WARN.
+        let on = EngineV2KVSizing.resolve(quantizedRate: 100_000, fp16Rate: 400_000)
+        #expect(on.rate == 400_000)
+        #expect(on.warnKVQuantUnsupported)
+        // fp16 unknown: fall back to the quantized rate, never WARN.
+        let unknown = EngineV2KVSizing.resolve(quantizedRate: 100_000, fp16Rate: 0)
+        #expect(unknown.rate == 100_000)
+        #expect(!unknown.warnKVQuantUnsupported)
+    }
+
+    @Test("an in-flight v2 request records its worst-case KV in the shared budget, released on finish")
+    func recordsAndReleasesReservation() async {
+        // Manual script so the request stays in-flight until we drive the terminal.
+        let engine = ScriptedCBv2Engine(script: .manual)
+        let budget = GlobalKVCacheBudget()
+        // 4000 B/token × (5 prompt + 16 maxTokens) = 84_000 bytes.
+        let bridge = makeBridge(engine: engine, kvBytesPerToken: 4000, kvBudget: budget)
+        #expect(await budget.outstandingReservedBytes() == 0)
+
+        let stream = await bridge.submitTokenized(
+            promptTokens: [1, 2, 3, 4, 5],
+            request: makeRequest(maxTokens: 16),
+            requestId: "req-acct-1")
+        // Consume the stream on a separate task so the pump runs.
+        let consumer = Task { await record(stream) }
+        // The pump records the reservation shortly after submit.
+        for _ in 0..<200 where await budget.outstandingReservedBytes() == 0 {
+            try? await Task.sleep(for: .milliseconds(5))
+        }
+        #expect(await budget.outstandingReservedBytes() == 84_000)
+
+        // Terminal → the reservation is released.
+        engine.manualContinuation?.yield(
+            .finished(reason: .stop, usage: CBv2Usage(promptTokens: 5, completionTokens: 1)))
+        engine.manualContinuation?.finish()
+        _ = await consumer.value
+        #expect(await budget.outstandingReservedBytes() == 0)
+    }
+
+    @Test("teardown without a terminal still releases the reservation")
+    func teardownReleasesReservation() async {
+        // A stream that yields no terminal, then closes (engine torn down).
+        let engine = ScriptedCBv2Engine(script: .stream([
+            .delta(text: "partial", tokens: [10], logprobs: nil)
+        ]))
+        let budget = GlobalKVCacheBudget()
+        let bridge = makeBridge(engine: engine, kvBytesPerToken: 4000, kvBudget: budget)
+        _ = await record(await bridge.submitTokenized(
+            promptTokens: [1, 2, 3, 4, 5],
+            request: makeRequest(maxTokens: 16),
+            requestId: "req-acct-2"))
+        // The stream closed without a terminal — the pump's teardown path
+        // must still have released the reservation.
+        #expect(await budget.outstandingReservedBytes() == 0)
+        let counters = await bridge._testCounters()
+        #expect(counters.active == 0)
+    }
+
+    @Test("no reservation when kvBytesPerToken is unknown (0)")
+    func noReservationWhenRateUnknown() async {
+        let engine = ScriptedCBv2Engine(script: .manual)
+        let budget = GlobalKVCacheBudget()
+        let bridge = makeBridge(engine: engine, kvBytesPerToken: 0, kvBudget: budget)
+        let stream = await bridge.submitTokenized(
+            promptTokens: [1, 2, 3], request: makeRequest(maxTokens: 8),
+            requestId: "req-acct-3")
+        let consumer = Task { await record(stream) }
+        // Give the pump time to run; with an unknown rate nothing is recorded.
+        try? await Task.sleep(for: .milliseconds(30))
+        #expect(await budget.outstandingReservedBytes() == 0)
+        engine.manualContinuation?.yield(
+            .finished(reason: .stop, usage: CBv2Usage(promptTokens: 3, completionTokens: 0)))
+        engine.manualContinuation?.finish()
+        _ = await consumer.value
     }
 }

--- a/provider-swift/Tests/ProviderCoreTests/EngineV2BridgeTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/EngineV2BridgeTests.swift
@@ -552,6 +552,24 @@ struct EngineV2ErrorMappingTests {
         let classified = MultiModelBatchSchedulerEngineError.fromSchedulerMessage(message)
         #expect(classified == .generationFailed(message))
     }
+
+    @Test("duplicate request id is rejected with the legacy planner message")
+    func duplicateRequestId() async {
+        let engine = ScriptedCBv2Engine(script: .manual)
+        let bridge = makeBridge(engine: engine)
+        _ = await bridge.submit(request: makeRequest(), requestId: "req-dup")
+        let (events, _) = await record(
+            await bridge.submit(request: makeRequest(), requestId: "req-dup")
+        )
+        #expect(events == [.error("token_budget_exhausted: duplicate request ID")])
+        // Only the first submit reached the engine.
+        #expect(engine.submitted.count == 1)
+        // Deterministic client fault (400), not a retryable capacity error.
+        if case .error(let message)? = events.first {
+            let classified = MultiModelBatchSchedulerEngineError.fromSchedulerMessage(message)
+            #expect(classified == .requestRejected(message))
+        }
+    }
 }
 
 // MARK: - Cancellation
@@ -595,7 +613,10 @@ struct EngineV2CancellationTests {
         let runtime = EngineV2Runtime()
         await runtime.register(modelId: "gemma-4-27b-it", bridge: bridge)
 
-        _ = await bridge.submit(request: makeRequest(), requestId: "req-xyz")
+        // Hold the stream for the whole test: dropping it would fire
+        // `onTermination(.cancelled)` and race a second (idempotent)
+        // engine cancel into the count assertions below.
+        let stream = await bridge.submit(request: makeRequest(), requestId: "req-xyz")
         let owned = await runtime.cancel(requestId: "req-xyz")
         #expect(owned)
         #expect(engine.cancelled.count == 1)
@@ -604,6 +625,7 @@ struct EngineV2CancellationTests {
         let unowned = await runtime.cancel(requestId: "req-legacy")
         #expect(!unowned)
         #expect(engine.cancelled.count == 1)
+        withExtendedLifetime(stream) {}
     }
 }
 

--- a/provider-swift/Tests/ProviderCoreTests/EngineV2BridgeTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/EngineV2BridgeTests.swift
@@ -1136,13 +1136,14 @@ struct EngineV2SharedBudgetTests {
             promptTokens: [1, 2, 3, 4, 5],
             request: makeRequest(maxTokens: 16),
             requestId: "req-acct-1")
-        // Consume the stream on a separate task so the pump runs.
-        let consumer = Task { await record(stream) }
-        // The pump records the reservation shortly after submit.
-        for _ in 0..<200 where await budget.outstandingReservedBytes() == 0 {
-            try? await Task.sleep(for: .milliseconds(5))
-        }
+        // No-gap invariant: the reservation is recorded SYNCHRONOUSLY with
+        // admission, so it is already visible the instant submit returns —
+        // before the pump task runs and before the stream is consumed. No
+        // polling: a concurrent model-load gate can never observe zero in the
+        // window between engine admission and the pump starting.
         #expect(await budget.outstandingReservedBytes() == 84_000)
+        // Consume the stream on a separate task so the pump runs to terminal.
+        let consumer = Task { await record(stream) }
 
         // Terminal → the reservation is released.
         engine.manualContinuation?.yield(
@@ -1240,13 +1241,11 @@ struct EngineV2HardeningTests {
         let stream = await bridge.submitTokenized(
             promptTokens: [1, 2, 3, 4, 5], request: makeRequest(maxTokens: 16),
             requestId: "req-live-1")
-        let consumer = Task { await record(stream) }
-        // Wait for the pump to run + record its reservation.
-        for _ in 0..<200 where await budget.outstandingReservedBytes() == 0 {
-            try? await Task.sleep(for: .milliseconds(5))
-        }
-        #expect(await bridge._testLivePumpCount() == 1)
+        // Reservation is recorded synchronously with admission (no poll), and
+        // the pump task is tracked for shutdown.
         #expect(await budget.outstandingReservedBytes() == 84_000)
+        #expect(await bridge._testLivePumpCount() == 1)
+        let consumer = Task { await record(stream) }
 
         await bridge.shutdown()
         #expect(engine.shutdownCalls == 1)

--- a/provider-swift/Tests/ProviderCoreTests/EngineV2BridgeTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/EngineV2BridgeTests.swift
@@ -809,7 +809,7 @@ struct EngineV2CancellationTests {
 @Suite("EngineV2 capacity: CBv2CapacitySnapshot → BackendSlotCapacity")
 struct EngineV2CapacityTests {
 
-    @Test("bytes-derived truthful budget mapping onto the existing protocol fields")
+    @Test("budget fields follow the legacy committed/worst-case contract; activeTokens stays engine truth")
     func snapshotMapping() async {
         let engine = ScriptedCBv2Engine(
             script: .manual,
@@ -822,13 +822,28 @@ struct EngineV2CapacityTests {
                 stepsExecuted: 12345
             ))
         let bridge = makeBridge(engine: engine, kvBytesPerToken: 4000)
+        // Two accepted long-max_tokens requests whose KV has barely
+        // materialized: committed worst case = (5+100) + (3+200) = 308.
+        _ = await bridge.submitTokenized(
+            promptTokens: [1, 2, 3, 4, 5], request: makeRequest(maxTokens: 100),
+            requestId: "req-cap-a")
+        _ = await bridge.submitTokenized(
+            promptTokens: [1, 2, 3], request: makeRequest(maxTokens: 200),
+            requestId: "req-cap-b")
         let slot = await bridge.backendSlotCapacity()
         #expect(slot.model == "gemma-4-27b-it")
         #expect(slot.state == "running")
         #expect(slot.numRunning == 2)
         #expect(slot.numWaiting == 3)
+        // Engine truth: the real KV-resident token count, NOT the worst case.
         #expect(slot.activeTokens == 1000)
-        #expect(slot.activeTokenBudgetUsed == 1000)   // 4 MB / 4000 B-per-token
+        // Coordinator admission-gate fields: the COMMITTED worst-case
+        // reservation (legacy `activeTokenBudgetUsed` semantics) — a request
+        // that has only materialized a prefix still holds its full budget.
+        #expect(slot.maxTokensPotential == 308)
+        #expect(slot.activeTokenBudgetUsed == 308)
+        #expect(slot.queuedTokenBudget == 0)
+        // Budget ceiling: the engine's byte capacity in tokens.
         #expect(slot.activeTokenBudgetMax == 10000)   // 40 MB / 4000 B-per-token
         #expect(slot.kvBytesPerToken == 4000)
         #expect(slot.maxConcurrency == 4)
@@ -837,7 +852,7 @@ struct EngineV2CapacityTests {
         #expect(!slot.wedgeSuspected)
     }
 
-    @Test("idle when nothing runs; token fallback when kvBytesPerToken unknown")
+    @Test("idle when nothing runs; budget gate disengaged when kvBytesPerToken unknown")
     func idleAndFallback() async {
         let engine = ScriptedCBv2Engine(
             script: .manual,
@@ -851,8 +866,32 @@ struct EngineV2CapacityTests {
         let bridge = makeBridge(engine: engine, kvBytesPerToken: 0)
         let slot = await bridge.backendSlotCapacity()
         #expect(slot.state == "idle")
-        #expect(slot.activeTokenBudgetUsed == 17)
+        // Engine truth flows through; no committed requests ⇒ zero budget
+        // used, and an unknown rate reports budgetMax 0 so the coordinator's
+        // budget gate disengages instead of trusting an invented budget.
+        #expect(slot.activeTokens == 17)
+        #expect(slot.activeTokenBudgetUsed == 0)
         #expect(slot.activeTokenBudgetMax == 0)
+    }
+
+    @Test("finished requests release their committed budget from the heartbeat")
+    func budgetReleasedOnFinish() async {
+        let engine = ScriptedCBv2Engine(
+            script: .stream([
+                .delta(text: "x", tokens: [10], logprobs: nil),
+                .finished(reason: .stop, usage: CBv2Usage(promptTokens: 5, completionTokens: 1)),
+            ]),
+            capacity: CBv2CapacitySnapshot(
+                activeRequests: 0, waitingRequests: 0, kvBytesInUse: 0,
+                kvBytesCapacity: 40_000_000, activeTokens: 0
+            ))
+        let bridge = makeBridge(engine: engine, kvBytesPerToken: 4000)
+        _ = await record(await bridge.submitTokenized(
+            promptTokens: [1, 2, 3, 4, 5], request: makeRequest(maxTokens: 100),
+            requestId: "req-cap-done"))
+        let slot = await bridge.backendSlotCapacity()
+        #expect(slot.activeTokenBudgetUsed == 0)
+        #expect(slot.maxTokensPotential == 0)
     }
 
     @Test("wedge counters flow into the slot (admits / first tokens / engine steps)")

--- a/provider-swift/Tests/ProviderCoreTests/EngineV2BridgeTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/EngineV2BridgeTests.swift
@@ -1,0 +1,864 @@
+// Copyright © 2026 Eigen Labs.
+//
+// WS-H (provider bridge) unit tests — live-isolated style: a scripted
+// in-process `CBv2Engine` stub emitting canned streams; no network, no
+// models, no prod anything.
+//
+//   * Translation: OpenAI-style request → CBv2Request field-by-field
+//     (params, stops, maxTokens defaulting, logit_bias id parsing).
+//   * Event → stream framing: fixture-compare against the recorded legacy
+//     `BatchScheduler+EngineBridge` shape (chunks → single info → finish;
+//     abort usage-before-error; teardown sentinel).
+//   * Error mapping: capacityExhausted → the retryable capacity error
+//     class (`.tokenBudgetExhausted` → 429/503), backendIneligible →
+//     non-retryable.
+//   * Config gating: flag off → legacy; flag on + non-allowlisted model →
+//     legacy; init failure → fallback + telemetry event.
+//   * Cancellation: provider request-id → `CBv2Engine.cancel` with the
+//     minted engine id, incl. the `EngineV2Runtime` fan-out the
+//     ProviderLoop hook uses.
+//   * Capacity: CBv2CapacitySnapshot → BackendSlotCapacity field mapping
+//     (truthful bytes-derived budgets, wedge counters).
+
+import Foundation
+import MLXLMCommon
+import Testing
+
+@testable import ProviderCore
+
+// MARK: - Scripted CBv2Engine stub
+
+/// In-process scripted engine. Thread-safe via NSLock so the bridge actor
+/// and the test can both touch it.
+private final class ScriptedCBv2Engine: CBv2Engine, @unchecked Sendable {
+    enum Script {
+        /// Throw from `submit` (admission failure).
+        case throwOnSubmit(any Error)
+        /// Yield these events, then finish the stream. Include a
+        /// `.finished` event for a normal terminal; omit it to simulate an
+        /// engine teardown mid-request.
+        case stream([CBv2Event])
+        /// The test drives the event continuation by hand.
+        case manual
+    }
+
+    private let lock = NSLock()
+    private var script: Script
+    private var _submitted: [CBv2Request] = []
+    private var _cancelled: [CBv2RequestID] = []
+    private var _shutdownCalls = 0
+    private var _manualContinuation: AsyncStream<CBv2Event>.Continuation?
+    var capacitySnapshot: CBv2CapacitySnapshot
+
+    init(
+        script: Script,
+        capacity: CBv2CapacitySnapshot = CBv2CapacitySnapshot(
+            activeRequests: 0, waitingRequests: 0, kvBytesInUse: 0,
+            kvBytesCapacity: 0, activeTokens: 0
+        )
+    ) {
+        self.script = script
+        self.capacitySnapshot = capacity
+    }
+
+    var submitted: [CBv2Request] { lock.withLock { _submitted } }
+    var cancelled: [CBv2RequestID] { lock.withLock { _cancelled } }
+    var shutdownCalls: Int { lock.withLock { _shutdownCalls } }
+    var manualContinuation: AsyncStream<CBv2Event>.Continuation? {
+        lock.withLock { _manualContinuation }
+    }
+
+    func submit(_ request: CBv2Request) throws -> AsyncStream<CBv2Event> {
+        let script = lock.withLock { () -> Script in
+            _submitted.append(request)
+            return self.script
+        }
+        switch script {
+        case .throwOnSubmit(let error):
+            throw error
+        case .stream(let events):
+            let (stream, continuation) = AsyncStream<CBv2Event>.makeStream()
+            for event in events {
+                continuation.yield(event)
+            }
+            continuation.finish()
+            return stream
+        case .manual:
+            let (stream, continuation) = AsyncStream<CBv2Event>.makeStream()
+            lock.withLock { _manualContinuation = continuation }
+            return stream
+        }
+    }
+
+    func cancel(_ id: CBv2RequestID) {
+        lock.withLock { _cancelled.append(id) }
+    }
+
+    func capacity() -> CBv2CapacitySnapshot {
+        lock.withLock { capacitySnapshot }
+    }
+
+    func shutdown() async {
+        lock.withLock { _shutdownCalls += 1 }
+    }
+}
+
+// MARK: - Stub tokenizer
+
+/// Fixed-output tokenizer: `applyChatTemplate` always yields
+/// `templateTokens`; EOS resolves via the token table.
+private struct StubTokenizer: MLXLMCommon.Tokenizer {
+    var templateTokens: [Int] = [1, 2, 3, 4, 5]
+    var tokenTable: [String: Int] = ["</s>": 2, "<|eot|>": 7]
+    var eosTokenString: String? = "</s>"
+    var failTemplate = false
+
+    func encode(text: String, addSpecialTokens: Bool) -> [Int] {
+        Array(repeating: 0, count: text.count)
+    }
+    func decode(tokenIds: [Int], skipSpecialTokens: Bool) -> String { "" }
+    func convertTokenToId(_ token: String) -> Int? { tokenTable[token] }
+    func convertIdToToken(_ id: Int) -> String? { nil }
+    var bosToken: String? { nil }
+    var eosToken: String? { eosTokenString }
+    var unknownToken: String? { nil }
+
+    struct TemplateError: Error {}
+
+    func applyChatTemplate(
+        messages: [[String: any Sendable]],
+        tools: [[String: any Sendable]]?,
+        additionalContext: [String: any Sendable]?
+    ) throws -> [Int] {
+        if failTemplate { throw TemplateError() }
+        return templateTokens
+    }
+}
+
+// MARK: - Telemetry capture
+
+private final class TelemetrySink: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _events: [TelemetryEvent] = []
+    var events: [TelemetryEvent] { lock.withLock { _events } }
+    func callback() -> @Sendable (TelemetryEvent) -> Void {
+        { [weak self] event in
+            guard let self else { return }
+            self.lock.withLock { self._events.append(event) }
+        }
+    }
+}
+
+// MARK: - Stream recording (fixture comparison shape)
+
+/// Normalized event shape for fixture comparison. TPS is wall-clock
+/// dependent so it is recorded separately, not part of the fixture.
+private enum RecordedEvent: Equatable, CustomStringConvertible {
+    case chunk(String)
+    case info(prompt: Int, completion: Int)
+    case error(String)
+
+    var description: String {
+        switch self {
+        case .chunk(let s): return "chunk(\(s))"
+        case .info(let p, let c): return "info(\(p),\(c))"
+        case .error(let m): return "error(\(m))"
+        }
+    }
+}
+
+private func record(
+    _ stream: AsyncStream<GenerationEvent>
+) async -> (events: [RecordedEvent], tps: [Double]) {
+    var events: [RecordedEvent] = []
+    var tps: [Double] = []
+    for await event in stream {
+        switch event {
+        case .chunk(let text):
+            events.append(.chunk(text))
+        case .info(let prompt, let completion, let tokensPerSecond):
+            events.append(.info(prompt: prompt, completion: completion))
+            tps.append(tokensPerSecond)
+        case .error(let message):
+            events.append(.error(message))
+        }
+    }
+    return (events, tps)
+}
+
+// MARK: - Shared builders
+
+private func makeBridge(
+    engine: ScriptedCBv2Engine,
+    tokenizer: StubTokenizer = StubTokenizer(),
+    modelId: String = "gemma-4-27b-it",
+    eosTokenIds: Set<Int> = [2],
+    extraEOSTokens: [String] = [],
+    defaultMaxTokens: Int = 4096,
+    kvBytesPerToken: Int = 0,
+    telemetry: TelemetrySink? = nil
+) -> EngineV2Bridge {
+    EngineV2Bridge(
+        engine: engine,
+        modelId: modelId,
+        tokenizer: TokenizerHandle(tokenizer),
+        eosTokenIds: eosTokenIds,
+        extraEOSTokens: extraEOSTokens,
+        defaultMaxTokens: defaultMaxTokens,
+        maxConcurrentRequests: 4,
+        kvBytesPerToken: kvBytesPerToken,
+        emitTelemetry: telemetry?.callback()
+    )
+}
+
+private func makeRequest(
+    temperature: Float? = nil,
+    topP: Float? = nil,
+    topK: Int? = nil,
+    maxTokens: Int? = nil,
+    repetitionPenalty: Float? = nil,
+    presencePenalty: Float? = nil,
+    frequencyPenalty: Float? = nil,
+    stop: StopSequences? = nil,
+    seed: UInt64? = nil,
+    logitBias: [String: Float]? = nil,
+    logprobs: Bool? = nil,
+    topLogprobs: Int? = nil
+) -> ChatCompletionRequest {
+    ChatCompletionRequest(
+        model: "gemma-4-27b-it",
+        messages: [ChatMessage(role: "user", content: "hi")],
+        temperature: temperature,
+        top_p: topP,
+        top_k: topK,
+        max_tokens: maxTokens,
+        repetition_penalty: repetitionPenalty,
+        presence_penalty: presencePenalty,
+        frequency_penalty: frequencyPenalty,
+        stop: stop,
+        seed: seed,
+        logit_bias: logitBias,
+        logprobs: logprobs,
+        top_logprobs: topLogprobs
+    )
+}
+
+// MARK: - Translation
+
+@Suite("EngineV2 translation: ChatCompletionRequest → CBv2Request")
+struct EngineV2TranslationTests {
+
+    @Test("full request translates field-by-field")
+    func fullFieldTranslation() {
+        let request = makeRequest(
+            temperature: 0.7, topP: 0.9, topK: 40, maxTokens: 128,
+            repetitionPenalty: 1.1, presencePenalty: 0.5, frequencyPenalty: 0.25,
+            stop: .multiple(["a", "b"]), seed: 42,
+            logitBias: ["50256": -100], logprobs: true, topLogprobs: 5
+        )
+        let cbv2 = EngineV2Translation.cbv2Request(
+            id: CBv2RequestID(9),
+            promptTokens: [1, 2, 3],
+            request: request,
+            defaultMaxTokens: 4096,
+            stopTokenIds: [2, 7]
+        )
+        #expect(cbv2.id == CBv2RequestID(9))
+        #expect(cbv2.promptTokens == [1, 2, 3])
+        #expect(cbv2.maxTokens == 128)
+        #expect(cbv2.stopTokens == [2, 7])
+        #expect(cbv2.stopStrings == ["a", "b"])
+        #expect(cbv2.priority == 0)
+        #expect(cbv2.sampling.temperature == 0.7)
+        #expect(cbv2.sampling.topP == 0.9)
+        #expect(cbv2.sampling.topK == 40)
+        #expect(cbv2.sampling.repetitionPenalty == 1.1)
+        #expect(cbv2.sampling.presencePenalty == 0.5)
+        #expect(cbv2.sampling.frequencyPenalty == 0.25)
+        #expect(cbv2.sampling.seed == 42)
+        #expect(cbv2.sampling.logitBias == [50256: -100])
+        #expect(cbv2.sampling.topLogprobs == 5)
+    }
+
+    @Test("unset knobs collapse to legacy defaults (greedy temperature 0)")
+    func defaultTranslation() {
+        let cbv2 = EngineV2Translation.cbv2Request(
+            id: CBv2RequestID(1),
+            promptTokens: [1],
+            request: makeRequest(),
+            defaultMaxTokens: 2048,
+            stopTokenIds: []
+        )
+        // Legacy engine path uses `request.temperature ?? 0.0` — pinned here
+        // so v2 can't drift to the contract's 1.0 default.
+        #expect(cbv2.sampling.temperature == 0.0)
+        #expect(cbv2.sampling.topP == 1.0)
+        #expect(cbv2.sampling.topK == 0)
+        #expect(cbv2.sampling.repetitionPenalty == 1.0)
+        #expect(cbv2.sampling.frequencyPenalty == 0)
+        #expect(cbv2.sampling.presencePenalty == 0)
+        #expect(cbv2.sampling.seed == nil)
+        #expect(cbv2.sampling.logitBias.isEmpty)
+        #expect(cbv2.sampling.topLogprobs == 0)
+        // maxTokens defaulting matches BatchScheduler.resolvedMaxTokens.
+        #expect(cbv2.maxTokens == 2048)
+        #expect(cbv2.stopStrings.isEmpty)
+    }
+
+    @Test("logit_bias string keys parse to token ids; junk keys are dropped")
+    func logitBiasParsing() {
+        let parsed = EngineV2Translation.parseLogitBias([
+            "50256": -100,
+            " 42 ": 1.5,      // whitespace-tolerant
+            "abc": 5,         // non-numeric → dropped
+            "-7": 3,          // negative id → dropped
+        ])
+        #expect(parsed == [50256: -100, 42: 1.5])
+        #expect(EngineV2Translation.parseLogitBias(nil).isEmpty)
+        #expect(EngineV2Translation.parseLogitBias([:]).isEmpty)
+    }
+
+    @Test("logprobs/top_logprobs mapping (0 = none; chosen-token → 1; clamp 20)")
+    func topLogprobsMapping() {
+        #expect(EngineV2Translation.topLogprobs(logprobs: nil, topLogprobs: nil) == 0)
+        #expect(EngineV2Translation.topLogprobs(logprobs: false, topLogprobs: 3) == 0)
+        // Contract can't express "chosen token only" — maps to 1 (see
+        // CONTRACT-ISSUES-H-provider.md §2).
+        #expect(EngineV2Translation.topLogprobs(logprobs: true, topLogprobs: nil) == 1)
+        #expect(EngineV2Translation.topLogprobs(logprobs: true, topLogprobs: 0) == 1)
+        #expect(EngineV2Translation.topLogprobs(logprobs: true, topLogprobs: 5) == 5)
+        #expect(EngineV2Translation.topLogprobs(logprobs: true, topLogprobs: 50) == 20)
+    }
+
+    @Test("stop resolution follows buildStopTokenIds semantics")
+    func stopResolution() {
+        // model EOS ∪ tokenizer EOS ∪ resolvable extra EOS tokens.
+        let resolved = EngineV2Translation.stopTokenIds(
+            eosTokenIds: [1, 2],
+            tokenizerEOSTokenId: 2,
+            extraEOSTokens: ["<|eot|>", "<|unknown|>"],
+            convertTokenToId: { ["<|eot|>": 7][$0] }
+        )
+        #expect(resolved == [1, 2, 7])
+    }
+
+    @Test("bridge resolves the stop set once at construction and stamps every request")
+    func bridgeStampsStopTokens() async {
+        let engine = ScriptedCBv2Engine(script: .stream([
+            .finished(reason: .stop, usage: CBv2Usage(promptTokens: 5, completionTokens: 0))
+        ]))
+        let bridge = makeBridge(
+            engine: engine,
+            tokenizer: StubTokenizer(),   // eos "</s>" → 2
+            eosTokenIds: [1],
+            extraEOSTokens: ["<|eot|>"]   // → 7
+        )
+        let stream = await bridge.submit(request: makeRequest())
+        _ = await record(stream)
+        #expect(engine.submitted.count == 1)
+        #expect(engine.submitted[0].stopTokens == [1, 2, 7])
+        // Tokenization went through the tokenizer's chat-template path.
+        #expect(engine.submitted[0].promptTokens == [1, 2, 3, 4, 5])
+    }
+}
+
+// MARK: - Event framing (fixture-compare against the legacy stream shape)
+
+@Suite("EngineV2 event framing matches the legacy GenerationEvent shape")
+struct EngineV2EventFramingTests {
+
+    @Test("happy path: chunks then a single usage info, then finish")
+    func happyPath() async {
+        let engine = ScriptedCBv2Engine(script: .stream([
+            .delta(text: "Hello", tokens: [10], logprobs: nil),
+            .delta(text: " world", tokens: [11], logprobs: nil),
+            // Empty-text delta (BPE intermediate): counted, never yielded.
+            .delta(text: "", tokens: [12], logprobs: nil),
+            .finished(reason: .stop, usage: CBv2Usage(promptTokens: 5, completionTokens: 3)),
+        ]))
+        let bridge = makeBridge(engine: engine)
+        let (events, tps) = await record(
+            await bridge.submit(request: makeRequest())
+        )
+        // Recorded legacy shape (BatchScheduler+EngineBridge): every
+        // non-empty text delta is one `.chunk`, a successful terminal is
+        // exactly one `.info(prompt, completion, tps)`, then finish.
+        let legacyShape: [RecordedEvent] = [
+            .chunk("Hello"),
+            .chunk(" world"),
+            .info(prompt: 5, completion: 3),
+        ]
+        #expect(events == legacyShape)
+        #expect(tps.count == 1)
+        #expect(tps[0] >= 0)
+    }
+
+    @Test("length finish frames identically to stop")
+    func lengthFramesLikeStop() async {
+        let engine = ScriptedCBv2Engine(script: .stream([
+            .delta(text: "x", tokens: [10], logprobs: nil),
+            // Terminal under-reports the prompt (4 < the 5 tokens the bridge
+            // tokenized) — the bridge-known count wins (legacy max() rule).
+            .finished(reason: .length, usage: CBv2Usage(promptTokens: 4, completionTokens: 1)),
+        ]))
+        let bridge = makeBridge(engine: engine)
+        let (events, _) = await record(await bridge.submit(request: makeRequest()))
+        #expect(events == [.chunk("x"), .info(prompt: 5, completion: 1)])
+    }
+
+    @Test("terminal usage can only raise observed counts (billing-zero defense)")
+    func usageMaxDefense() async {
+        let engine = ScriptedCBv2Engine(script: .stream([
+            .delta(text: "a", tokens: [10], logprobs: nil),
+            .delta(text: "b", tokens: [11, 12], logprobs: nil),
+            // Terminal under-reports (0 completion) — must not zero billing.
+            .finished(reason: .stop, usage: CBv2Usage(promptTokens: 5, completionTokens: 0)),
+        ]))
+        let bridge = makeBridge(engine: engine)
+        let (events, _) = await record(await bridge.submit(request: makeRequest()))
+        #expect(events == [.chunk("a"), .chunk("b"), .info(prompt: 5, completion: 3)])
+    }
+
+    @Test("cancel that did work: usage info BEFORE the cancel error (legacy abort framing)")
+    func cancelledWithWork() async {
+        let engine = ScriptedCBv2Engine(script: .stream([
+            .delta(text: "Hi", tokens: [10], logprobs: nil),
+            .finished(reason: .cancelled, usage: CBv2Usage(promptTokens: 5, completionTokens: 1)),
+        ]))
+        let bridge = makeBridge(engine: engine)
+        let (events, _) = await record(await bridge.submit(request: makeRequest()))
+        #expect(events == [
+            .chunk("Hi"),
+            .info(prompt: 5, completion: 1),
+            .error("request cancelled"),
+        ])
+    }
+
+    @Test("cancel before any decode: prompt-only usage info, then cancel error")
+    func cancelledWithoutWork() async {
+        let engine = ScriptedCBv2Engine(script: .stream([
+            .finished(reason: .cancelled, usage: CBv2Usage(promptTokens: 0, completionTokens: 0)),
+        ]))
+        let bridge = makeBridge(engine: engine)
+        let (events, _) = await record(await bridge.submit(request: makeRequest()))
+        // The bridge tokenized a 5-token prompt, so even a did-nothing
+        // cancel reports prompt usage before the error — exactly the legacy
+        // abort framing (`recordFinish` max()es the bridge-known prompt).
+        #expect(events == [
+            .info(prompt: 5, completion: 0),
+            .error("request cancelled"),
+        ])
+    }
+
+    @Test("engine error: error only — no info (legacy failure framing)")
+    func engineError() async {
+        let telemetry = TelemetrySink()
+        let engine = ScriptedCBv2Engine(script: .stream([
+            .delta(text: "x", tokens: [10], logprobs: nil),
+            .finished(
+                reason: .error("metal command buffer failed"),
+                usage: CBv2Usage(promptTokens: 4, completionTokens: 1)
+            ),
+        ]))
+        let bridge = makeBridge(engine: engine, telemetry: telemetry)
+        let (events, _) = await record(await bridge.submit(request: makeRequest()))
+        #expect(events == [.chunk("x"), .error("metal command buffer failed")])
+        // engine_v2-tagged inference_error telemetry (allowlisted fields
+        // only — never the raw engine message).
+        let errorEvents = telemetry.events.filter { $0.kind == .inferenceError }
+        #expect(errorEvents.count == 1)
+        #expect(errorEvents.first?.fields?["backend"]?.description == "engine_v2")
+        #expect(errorEvents.first?.fields?["operation"]?.description == "engine_v2_error")
+    }
+
+    @Test("stream closed without terminal → teardown sentinel error")
+    func teardownSentinel() async {
+        let engine = ScriptedCBv2Engine(script: .stream([
+            .delta(text: "partial", tokens: [10], logprobs: nil)
+            // no .finished — engine torn down mid-request
+        ]))
+        let bridge = makeBridge(engine: engine)
+        let (events, _) = await record(await bridge.submit(request: makeRequest()))
+        #expect(events == [
+            .chunk("partial"),
+            .error("request stream closed by engine teardown"),
+        ])
+        // Local bookkeeping must be dropped.
+        let counters = await bridge._testCounters()
+        #expect(counters.active == 0)
+    }
+
+    @Test("tokenize failure surfaces as a tokenize error without touching the engine")
+    func tokenizeFailure() async {
+        let engine = ScriptedCBv2Engine(script: .stream([]))
+        var tokenizer = StubTokenizer()
+        tokenizer.failTemplate = true
+        let bridge = makeBridge(engine: engine, tokenizer: tokenizer)
+        let (events, _) = await record(await bridge.submit(request: makeRequest()))
+        #expect(events.count == 1)
+        if case .error(let message)? = events.first {
+            #expect(message.hasPrefix("Failed to tokenize:"))
+        }
+        #expect(engine.submitted.isEmpty)
+    }
+}
+
+// MARK: - Error mapping (capacity → retryable class)
+
+@Suite("EngineV2 admission-error mapping")
+struct EngineV2ErrorMappingTests {
+
+    @Test("capacityExhausted → canonical token_budget_exhausted string → retryable class")
+    func capacityExhaustedIsRetryable() async {
+        let engine = ScriptedCBv2Engine(
+            script: .throwOnSubmit(
+                CBv2KVError.capacityExhausted(needed: 5120, available: 1024)
+            ))
+        let bridge = makeBridge(engine: engine)
+        let (events, _) = await record(await bridge.submit(request: makeRequest()))
+        #expect(events.count == 1)
+        guard case .error(let message)? = events.first else {
+            Issue.record("expected a single .error event, got \(events)")
+            return
+        }
+        #expect(message == "token_budget_exhausted: request requires 5120 tokens but only 1024 available")
+        // The exact classification the legacy engine's rejections get:
+        // retryable capacity (→ 503 with backoff upstream).
+        let classified = MultiModelBatchSchedulerEngineError.fromSchedulerMessage(message)
+        #expect(classified == .tokenBudgetExhausted(message))
+    }
+
+    @Test("backendIneligible → non-retryable generation failure")
+    func backendIneligibleIsNotRetryable() async {
+        let engine = ScriptedCBv2Engine(
+            script: .throwOnSubmit(
+                CBv2KVError.backendIneligible(reason: "sinks unsupported")
+            ))
+        let bridge = makeBridge(engine: engine)
+        let (events, _) = await record(await bridge.submit(request: makeRequest()))
+        guard case .error(let message)? = events.first else {
+            Issue.record("expected a single .error event, got \(events)")
+            return
+        }
+        let classified = MultiModelBatchSchedulerEngineError.fromSchedulerMessage(message)
+        #expect(classified == .generationFailed(message))
+    }
+
+    @Test("unknown submit error → generic failure, never claims capacity")
+    func unknownErrorIsGeneric() {
+        struct Boom: Error {}
+        let message = EngineV2Translation.admissionErrorMessage(for: Boom())
+        #expect(!message.contains("token_budget_exhausted"))
+        let classified = MultiModelBatchSchedulerEngineError.fromSchedulerMessage(message)
+        #expect(classified == .generationFailed(message))
+    }
+}
+
+// MARK: - Cancellation
+
+@Suite("EngineV2 cancellation wiring")
+struct EngineV2CancellationTests {
+
+    @Test("bridge cancel maps the provider request-id to the minted engine id")
+    func bridgeCancelMapsId() async {
+        let engine = ScriptedCBv2Engine(script: .manual)
+        let bridge = makeBridge(engine: engine)
+        let stream = await bridge.submit(request: makeRequest(), requestId: "req-abc")
+        let engineId = await bridge._testEngineRequestId(for: "req-abc")
+        #expect(engineId != nil)
+
+        await bridge.cancel(requestId: "req-abc")
+        #expect(engine.cancelled == [engineId!])
+
+        // Engine delivers the cancelled terminal; the stream tears down
+        // with the legacy abort framing.
+        engine.manualContinuation?.yield(
+            .finished(reason: .cancelled, usage: CBv2Usage(promptTokens: 5, completionTokens: 0)))
+        engine.manualContinuation?.finish()
+        let (events, _) = await record(stream)
+        #expect(events.last == .error("request cancelled"))
+        #expect(await bridge._testEngineRequestId(for: "req-abc") == nil)
+    }
+
+    @Test("cancel for an unknown id is a no-op")
+    func cancelUnknownId() async {
+        let engine = ScriptedCBv2Engine(script: .manual)
+        let bridge = makeBridge(engine: engine)
+        await bridge.cancel(requestId: "req-never-submitted")
+        #expect(engine.cancelled.isEmpty)
+    }
+
+    @Test("runtime fan-out (the ProviderLoop handleCancellation hook path)")
+    func runtimeFanOut() async {
+        let engine = ScriptedCBv2Engine(script: .manual)
+        let bridge = makeBridge(engine: engine)
+        let runtime = EngineV2Runtime()
+        await runtime.register(modelId: "gemma-4-27b-it", bridge: bridge)
+
+        _ = await bridge.submit(request: makeRequest(), requestId: "req-xyz")
+        let owned = await runtime.cancel(requestId: "req-xyz")
+        #expect(owned)
+        #expect(engine.cancelled.count == 1)
+
+        // Unknown id: no bridge owns it (legacy path's request).
+        let unowned = await runtime.cancel(requestId: "req-legacy")
+        #expect(!unowned)
+        #expect(engine.cancelled.count == 1)
+    }
+}
+
+// MARK: - Capacity mapping
+
+@Suite("EngineV2 capacity: CBv2CapacitySnapshot → BackendSlotCapacity")
+struct EngineV2CapacityTests {
+
+    @Test("bytes-derived truthful budget mapping onto the existing protocol fields")
+    func snapshotMapping() async {
+        let engine = ScriptedCBv2Engine(
+            script: .manual,
+            capacity: CBv2CapacitySnapshot(
+                activeRequests: 2,
+                waitingRequests: 3,
+                kvBytesInUse: 4_000_000,
+                kvBytesCapacity: 40_000_000,
+                activeTokens: 1000
+            ))
+        let bridge = makeBridge(engine: engine, kvBytesPerToken: 4000)
+        let slot = await bridge.backendSlotCapacity()
+        #expect(slot.model == "gemma-4-27b-it")
+        #expect(slot.state == "running")
+        #expect(slot.numRunning == 2)
+        #expect(slot.numWaiting == 3)
+        #expect(slot.activeTokens == 1000)
+        #expect(slot.activeTokenBudgetUsed == 1000)   // 4 MB / 4000 B-per-token
+        #expect(slot.activeTokenBudgetMax == 10000)   // 40 MB / 4000 B-per-token
+        #expect(slot.kvBytesPerToken == 4000)
+        #expect(slot.maxConcurrency == 4)
+        #expect(!slot.wedgeSuspected)
+    }
+
+    @Test("idle when nothing runs; token fallback when kvBytesPerToken unknown")
+    func idleAndFallback() async {
+        let engine = ScriptedCBv2Engine(
+            script: .manual,
+            capacity: CBv2CapacitySnapshot(
+                activeRequests: 0,
+                waitingRequests: 0,
+                kvBytesInUse: 123,
+                kvBytesCapacity: 456,
+                activeTokens: 17
+            ))
+        let bridge = makeBridge(engine: engine, kvBytesPerToken: 0)
+        let slot = await bridge.backendSlotCapacity()
+        #expect(slot.state == "idle")
+        #expect(slot.activeTokenBudgetUsed == 17)
+        #expect(slot.activeTokenBudgetMax == 0)
+    }
+
+    @Test("wedge counters flow into the slot (admits / first tokens / steps)")
+    func wedgeCountersInSlot() async {
+        let engine = ScriptedCBv2Engine(script: .stream([
+            .delta(text: "hello", tokens: [10], logprobs: nil),
+            .finished(reason: .stop, usage: CBv2Usage(promptTokens: 5, completionTokens: 1)),
+        ]))
+        let bridge = makeBridge(engine: engine)
+        _ = await record(await bridge.submit(request: makeRequest()))
+        let slot = await bridge.backendSlotCapacity()
+        #expect(slot.admits == 1)
+        #expect(slot.firstTokensEmitted == 1)
+        // Loop-progress proxy: 2 events were observed.
+        #expect(slot.stepsExecuted == 2)
+    }
+
+    @Test("runtime capacity summary aggregates registered bridges")
+    func runtimeCapacitySummary() async {
+        let engine = ScriptedCBv2Engine(
+            script: .manual,
+            capacity: CBv2CapacitySnapshot(
+                activeRequests: 1, waitingRequests: 0, kvBytesInUse: 0,
+                kvBytesCapacity: 0, activeTokens: 10
+            ))
+        let bridge = makeBridge(engine: engine)
+        let runtime = EngineV2Runtime()
+
+        // Empty registry (v2 off) → empty summary, legacy heartbeat unchanged.
+        let empty = await runtime.capacitySummary()
+        #expect(empty.slots.isEmpty)
+        #expect(empty.activeRequests == 0)
+
+        await runtime.register(modelId: "gemma-4-27b-it", bridge: bridge)
+        _ = await bridge.submit(request: makeRequest(), requestId: "req-1")
+        let summary = await runtime.capacitySummary()
+        #expect(summary.slots.count == 1)
+        #expect(summary.slots.first?.model == "gemma-4-27b-it")
+        #expect(summary.activeRequests == 1)
+
+        await runtime.unregister(modelId: "gemma-4-27b-it")
+        let after = await runtime.capacitySummary()
+        #expect(after.slots.isEmpty)
+    }
+}
+
+// MARK: - Config gating
+
+@Suite("EngineV2 config gating (flag, allowlist, fallback)")
+struct EngineV2ConfigGatingTests {
+
+    @Test("flag resolution: env overrides config; garbage fails safe")
+    func flagResolution() {
+        #expect(EngineV2Config.flagEnabled(environment: ["DARKBLOOM_ENGINE_V2": "1"], configEnabled: false))
+        #expect(EngineV2Config.flagEnabled(environment: ["DARKBLOOM_ENGINE_V2": "true"], configEnabled: false))
+        // Env kill switch beats config.
+        #expect(!EngineV2Config.flagEnabled(environment: ["DARKBLOOM_ENGINE_V2": "0"], configEnabled: true))
+        #expect(!EngineV2Config.flagEnabled(environment: ["DARKBLOOM_ENGINE_V2": "off"], configEnabled: true))
+        // Absent env defers to the `engine_v2` provider-config key.
+        #expect(EngineV2Config.flagEnabled(environment: [:], configEnabled: true))
+        #expect(!EngineV2Config.flagEnabled(environment: [:], configEnabled: false))
+        // Unrecognized value fails safe (legacy).
+        #expect(!EngineV2Config.flagEnabled(environment: ["DARKBLOOM_ENGINE_V2": "maybe"], configEnabled: true))
+    }
+
+    @Test("default allowlist: gemma-4* and gpt-oss*, incl. org-prefixed ids")
+    func defaultAllowlist() {
+        #expect(EngineV2Config.modelAllowlisted("gemma-4-27b-it"))
+        #expect(EngineV2Config.modelAllowlisted("Gemma-4-9B"))
+        #expect(EngineV2Config.modelAllowlisted("gpt-oss-20b-4bit"))
+        #expect(EngineV2Config.modelAllowlisted("mlx-community/gpt-oss-20b-4bit"))
+        #expect(EngineV2Config.modelAllowlisted("mlx-community/gemma-4-27b-it-4bit"))
+        #expect(!EngineV2Config.modelAllowlisted("qwen3-8b"))
+        #expect(!EngineV2Config.modelAllowlisted("llama-3.3-70b"))
+        #expect(!EngineV2Config.modelAllowlisted(""))
+    }
+
+    @Test("allowlist env override")
+    func allowlistOverride() {
+        let env = ["DARKBLOOM_ENGINE_V2_MODELS": "qwen3*, exact-model"]
+        let patterns = EngineV2Config.allowlistPatterns(environment: env)
+        #expect(EngineV2Config.modelAllowlisted("qwen3-8b", patterns: patterns))
+        #expect(EngineV2Config.modelAllowlisted("exact-model", patterns: patterns))
+        #expect(!EngineV2Config.modelAllowlisted("exact-model-2", patterns: patterns))
+        #expect(!EngineV2Config.modelAllowlisted("gemma-4-27b-it", patterns: patterns))
+    }
+
+    @Test("selection matrix")
+    func selectionMatrix() {
+        // Flag off → legacy even for allowlisted models.
+        #expect(EngineV2Config.selection(
+            modelId: "gemma-4-27b-it", environment: [:], configEnabled: false
+        ) == .legacy)
+        // Flag on + allowlisted → v2.
+        #expect(EngineV2Config.selection(
+            modelId: "gemma-4-27b-it",
+            environment: ["DARKBLOOM_ENGINE_V2": "1"], configEnabled: false
+        ) == .v2)
+        // Flag on + non-allowlisted → legacy.
+        #expect(EngineV2Config.selection(
+            modelId: "qwen3-8b",
+            environment: ["DARKBLOOM_ENGINE_V2": "1"], configEnabled: false
+        ) == .legacy)
+    }
+
+    @Test("factory: flag off → legacy, builder never invoked")
+    func factoryFlagOff() {
+        let telemetry = TelemetrySink()
+        var builderCalls = 0
+        let bridge = EngineV2Factory.makeBridgeIfSelected(
+            modelId: "gemma-4-27b-it",
+            configEnabled: false,
+            environment: [:],
+            tokenizer: TokenizerHandle(StubTokenizer()),
+            eosTokenIds: [2],
+            emitTelemetry: telemetry.callback(),
+            makeEngine: {
+                builderCalls += 1
+                return ScriptedCBv2Engine(script: .manual)
+            }
+        )
+        #expect(bridge == nil)
+        #expect(builderCalls == 0)
+        #expect(telemetry.events.isEmpty)
+    }
+
+    @Test("factory: flag on + non-allowlisted model → legacy, builder never invoked")
+    func factoryNonAllowlisted() {
+        var builderCalls = 0
+        let bridge = EngineV2Factory.makeBridgeIfSelected(
+            modelId: "qwen3-8b",
+            configEnabled: true,
+            environment: [:],
+            tokenizer: TokenizerHandle(StubTokenizer()),
+            eosTokenIds: [2],
+            makeEngine: {
+                builderCalls += 1
+                return ScriptedCBv2Engine(script: .manual)
+            }
+        )
+        #expect(bridge == nil)
+        #expect(builderCalls == 0)
+    }
+
+    @Test("factory: init failure → legacy fallback + engine_v2_fallback telemetry")
+    func factoryInitFailureFallsBack() {
+        struct InitFailure: Error {}
+        let telemetry = TelemetrySink()
+        let bridge = EngineV2Factory.makeBridgeIfSelected(
+            modelId: "gpt-oss-20b",
+            configEnabled: true,
+            environment: [:],
+            tokenizer: TokenizerHandle(StubTokenizer()),
+            eosTokenIds: [2],
+            emitTelemetry: telemetry.callback(),
+            makeEngine: { throw InitFailure() }
+        )
+        #expect(bridge == nil)
+        let events = telemetry.events
+        #expect(events.count == 1)
+        #expect(events.first?.kind == .engineHealth)
+        #expect(events.first?.severity == .warn)
+        #expect(events.first?.fields?["operation"]?.description == "engine_v2_fallback")
+        #expect(events.first?.fields?["backend"]?.description == "engine_v2")
+        #expect(events.first?.fields?["model"]?.description == "gpt-oss-20b")
+        #expect(events.first?.fields?["error_class"]?.description.contains("InitFailure") == true)
+    }
+
+    @Test("factory: selected + healthy builder → v2 bridge")
+    func factorySelectedBuilds() {
+        let bridge = EngineV2Factory.makeBridgeIfSelected(
+            modelId: "gemma-4-27b-it",
+            configEnabled: true,
+            environment: [:],
+            tokenizer: TokenizerHandle(StubTokenizer()),
+            eosTokenIds: [2],
+            makeEngine: { ScriptedCBv2Engine(script: .manual) }
+        )
+        #expect(bridge != nil)
+    }
+
+    @Test("backend config decodes engine_v2 key (default false)")
+    func backendConfigKey() throws {
+        let decoder = JSONDecoder()
+        let on = try decoder.decode(
+            BackendSettings.self,
+            from: Data(#"{"engine_v2": true}"#.utf8)
+        )
+        #expect(on.engineV2)
+        let absent = try decoder.decode(
+            BackendSettings.self,
+            from: Data(#"{}"#.utf8)
+        )
+        #expect(!absent.engineV2)
+    }
+}
+
+// MARK: - Shutdown
+
+@Suite("EngineV2 bridge shutdown")
+struct EngineV2ShutdownTests {
+    @Test("shutdown drains through the engine")
+    func shutdownForwards() async {
+        let engine = ScriptedCBv2Engine(script: .manual)
+        let bridge = makeBridge(engine: engine)
+        await bridge.shutdown()
+        #expect(engine.shutdownCalls == 1)
+    }
+}

--- a/provider-swift/Tests/ProviderCoreTests/EngineV2BridgeTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/EngineV2BridgeTests.swift
@@ -1104,6 +1104,33 @@ struct EngineV2ShutdownTests {
 
 // MARK: - Shared-budget KV accounting (fix #2)
 
+/// Deterministic shared budgets driven by SCRIPTED memory snapshots (never
+/// the real machine's memory) — live-isolated per the testing rules.
+private enum TestBudgets {
+    /// A budget with plenty of headroom: 8 GiB box, nothing used.
+    /// Effective cap = min(0.9 × 8 GiB, 8 GiB − 2 GiB) = 6 GiB.
+    static func ample() -> GlobalKVCacheBudget {
+        let gib: UInt64 = 1024 * 1024 * 1024
+        return GlobalKVCacheBudget(
+            capFraction: 0.9,
+            activationReserveBytes: 0,
+            memorySnapshot: {
+                .init(total: 8 * gib, active: 0, cache: 0, systemAvailable: 8 * gib)
+            })
+    }
+
+    /// A budget with ZERO headroom: everything under the cap already used.
+    static func exhausted() -> GlobalKVCacheBudget {
+        let gib: UInt64 = 1024 * 1024 * 1024
+        return GlobalKVCacheBudget(
+            capFraction: 0.9,
+            activationReserveBytes: 0,
+            memorySnapshot: {
+                .init(total: 8 * gib, active: 8 * gib, cache: 0, systemAvailable: 0)
+            })
+    }
+}
+
 @Suite("EngineV2 shared-budget KV accounting")
 struct EngineV2SharedBudgetTests {
 
@@ -1123,11 +1150,11 @@ struct EngineV2SharedBudgetTests {
         #expect(!unknown.warnKVQuantUnsupported)
     }
 
-    @Test("an in-flight v2 request records its worst-case KV in the shared budget, released on finish")
+    @Test("an in-flight v2 request reserves its worst-case KV in the shared budget, released on finish")
     func recordsAndReleasesReservation() async {
         // Manual script so the request stays in-flight until we drive the terminal.
         let engine = ScriptedCBv2Engine(script: .manual)
-        let budget = GlobalKVCacheBudget()
+        let budget = TestBudgets.ample()
         // 4000 B/token × (5 prompt + 16 maxTokens) = 84_000 bytes.
         let bridge = makeBridge(engine: engine, kvBytesPerToken: 4000, kvBudget: budget)
         #expect(await budget.outstandingReservedBytes() == 0)
@@ -1136,11 +1163,12 @@ struct EngineV2SharedBudgetTests {
             promptTokens: [1, 2, 3, 4, 5],
             request: makeRequest(maxTokens: 16),
             requestId: "req-acct-1")
-        // No-gap invariant: the reservation is recorded SYNCHRONOUSLY with
-        // admission, so it is already visible the instant submit returns —
-        // before the pump task runs and before the stream is consumed. No
-        // polling: a concurrent model-load gate can never observe zero in the
-        // window between engine admission and the pump starting.
+        // No-gap invariant: the reservation is taken atomically WITH (in fact
+        // strictly before) engine admission, so it is already visible the
+        // instant submit returns — before the pump task runs and before the
+        // stream is consumed. No polling: a concurrent model-load gate can
+        // never observe zero in the window between engine admission and the
+        // pump starting.
         #expect(await budget.outstandingReservedBytes() == 84_000)
         // Consume the stream on a separate task so the pump runs to terminal.
         let consumer = Task { await record(stream) }
@@ -1159,7 +1187,7 @@ struct EngineV2SharedBudgetTests {
         let engine = ScriptedCBv2Engine(script: .stream([
             .delta(text: "partial", tokens: [10], logprobs: nil)
         ]))
-        let budget = GlobalKVCacheBudget()
+        let budget = TestBudgets.ample()
         let bridge = makeBridge(engine: engine, kvBytesPerToken: 4000, kvBudget: budget)
         _ = await record(await bridge.submitTokenized(
             promptTokens: [1, 2, 3, 4, 5],
@@ -1175,7 +1203,7 @@ struct EngineV2SharedBudgetTests {
     @Test("no reservation when kvBytesPerToken is unknown (0)")
     func noReservationWhenRateUnknown() async {
         let engine = ScriptedCBv2Engine(script: .manual)
-        let budget = GlobalKVCacheBudget()
+        let budget = TestBudgets.ample()
         let bridge = makeBridge(engine: engine, kvBytesPerToken: 0, kvBudget: budget)
         let stream = await bridge.submitTokenized(
             promptTokens: [1, 2, 3], request: makeRequest(maxTokens: 8),
@@ -1188,6 +1216,92 @@ struct EngineV2SharedBudgetTests {
             .finished(reason: .stop, usage: CBv2Usage(promptTokens: 3, completionTokens: 0)))
         engine.manualContinuation?.finish()
         _ = await consumer.value
+    }
+
+    @Test("shared-budget gate: exhausted pool rejects as capacity BEFORE the engine sees the request")
+    func sharedBudgetGateRejectsBeforeEngine() async {
+        let engine = ScriptedCBv2Engine(script: .manual)
+        let budget = TestBudgets.exhausted()
+        let bridge = makeBridge(engine: engine, kvBytesPerToken: 4000, kvBudget: budget)
+        let (events, _) = await record(await bridge.submitTokenized(
+            promptTokens: [1, 2, 3, 4, 5],
+            request: makeRequest(maxTokens: 16),
+            requestId: "req-gate-1"))
+        // Single canonical capacity error (5 prompt + 16 max = 21 tokens).
+        #expect(events == [.error(
+            "token_budget_exhausted: request requires 21 tokens "
+                + "but the shared KV budget has no headroom")])
+        // The gate fired BEFORE submission: the engine never saw the request,
+        // and no bookkeeping leaked.
+        #expect(engine.submitted.isEmpty)
+        #expect(await budget.outstandingReservedBytes() == 0)
+        let counters = await bridge._testCounters()
+        #expect(counters.active == 0)
+        // Classified exactly like the legacy KV-reserve rejection: retryable
+        // capacity (→ 429/503 upstream), so the coordinator reroutes.
+        if case .error(let message)? = events.first {
+            let classified = MultiModelBatchSchedulerEngineError.fromSchedulerMessage(message)
+            #expect(classified == .tokenBudgetExhausted(message))
+        }
+    }
+
+    @Test("shared-budget gate: another request's live reservation blocks a worst case that no longer fits")
+    func sharedBudgetGateSeesOtherLiveReservations() async {
+        // A pool with exactly 200_000 bytes of live headroom: 3 GiB box at
+        // capFraction 1.0 ⇒ effective cap = 3 GiB − 2 GiB OS floor = 1 GiB;
+        // MLX usage pinned 200_000 bytes below that cap.
+        let budget = GlobalKVCacheBudget(
+            capFraction: 1.0,
+            activationReserveBytes: 0,
+            memorySnapshot: {
+                let gib: UInt64 = 1024 * 1024 * 1024
+                return .init(
+                    total: 3 * gib, active: gib - 200_000, cache: 0,
+                    systemAvailable: 200_000)
+            })
+        let engine = ScriptedCBv2Engine(script: .manual)
+        let bridge = makeBridge(engine: engine, kvBytesPerToken: 4000, kvBudget: budget)
+        // First request: 21 tokens × 4000 = 84_000 bytes — fits.
+        let first = await bridge.submitTokenized(
+            promptTokens: [1, 2, 3, 4, 5], request: makeRequest(maxTokens: 16),
+            requestId: "req-gate-a")
+        #expect(engine.submitted.count == 1)
+        // Second identical worst case would need another 84_000 with only
+        // 116_000 left… fits. Third does not (232_000 > 200_000).
+        let second = await bridge.submitTokenized(
+            promptTokens: [1, 2, 3, 4, 5], request: makeRequest(maxTokens: 16),
+            requestId: "req-gate-b")
+        #expect(engine.submitted.count == 2)
+        let (events, _) = await record(await bridge.submitTokenized(
+            promptTokens: [1, 2, 3, 4, 5], request: makeRequest(maxTokens: 16),
+            requestId: "req-gate-c"))
+        #expect(engine.submitted.count == 2)  // third never reached the engine
+        if case .error(let message)? = events.first {
+            #expect(message.hasPrefix("token_budget_exhausted:"))
+        } else {
+            Issue.record("expected a capacity error, got \(events)")
+        }
+        withExtendedLifetime((first, second)) {}
+    }
+
+    @Test("engine rejection after the gate releases the shared reservation")
+    func engineRejectionReleasesSharedReservation() async {
+        let engine = ScriptedCBv2Engine(
+            script: .throwOnSubmit(
+                CBv2KVError.capacityExhausted(needed: 5120, available: 1024)))
+        let budget = TestBudgets.ample()
+        let bridge = makeBridge(engine: engine, kvBytesPerToken: 4000, kvBudget: budget)
+        let (events, _) = await record(await bridge.submitTokenized(
+            promptTokens: [1, 2, 3, 4, 5],
+            request: makeRequest(maxTokens: 16),
+            requestId: "req-gate-2"))
+        // The engine's own rejection surfaced (its private ledger stays
+        // authoritative for its slot)…
+        #expect(events == [.error(
+            "token_budget_exhausted: request requires 5120 tokens but only 1024 available")])
+        // …and the shared reservation taken by the gate was rolled back, so
+        // a rejected request can never pin shared headroom.
+        #expect(await budget.outstandingReservedBytes() == 0)
     }
 }
 
@@ -1236,7 +1350,7 @@ struct EngineV2HardeningTests {
         // A manual engine keeps the request in-flight (stream never finishes)
         // so the pump is parked on `for await`. Shutdown must cancel it.
         let engine = ScriptedCBv2Engine(script: .manual)
-        let budget = GlobalKVCacheBudget()
+        let budget = TestBudgets.ample()
         let bridge = makeBridge(engine: engine, kvBytesPerToken: 4000, kvBudget: budget)
         let stream = await bridge.submitTokenized(
             promptTokens: [1, 2, 3, 4, 5], request: makeRequest(maxTokens: 16),

--- a/provider-swift/Tests/ProviderCoreTests/EngineV2BridgeTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/EngineV2BridgeTests.swift
@@ -701,6 +701,51 @@ struct EngineV2ErrorMappingTests {
         // retryable capacity (→ 503 with backoff upstream).
         let classified = MultiModelBatchSchedulerEngineError.fromSchedulerMessage(message)
         #expect(classified == .tokenBudgetExhausted(message))
+        #expect(ProviderLoop.mapInferenceErrorToStatus(classified) == 503)
+    }
+
+    @Test("engine queue-full sentinel maps to the legacy queue-full class (429), not token-budget (503)")
+    func queueFullSentinelMapsToQueueFull() async {
+        // `EngineV2.submit` throws `capacityExhausted(needed: 1, available: 0)`
+        // when its waiting queue is full (`gauges.beginSubmit(maxWaiting:)`) or
+        // it is draining for shutdown — a SLOT rejection, not a byte figure.
+        // The legacy path classifies queue saturation as `.queueFull` (429 +
+        // Retry-After), so the v2 mapping must preserve that distinction
+        // (round-3 PR#499 P2).
+        let engine = ScriptedCBv2Engine(
+            script: .throwOnSubmit(
+                CBv2KVError.capacityExhausted(needed: 1, available: 0)
+            ))
+        let bridge = makeBridge(engine: engine)
+        let (events, _) = await record(await bridge.submit(request: makeRequest()))
+        #expect(events.count == 1)
+        guard case .error(let message)? = events.first else {
+            Issue.record("expected a single .error event, got \(events)")
+            return
+        }
+        // The exact canonical string the legacy planner emits for a full
+        // queue (`BatchSchedulerTypes.RejectionReason.queueFull`) — no new
+        // classification strings on the wire.
+        #expect(message == "token_budget_exhausted: request queue full")
+        let classified = MultiModelBatchSchedulerEngineError.fromSchedulerMessage(message)
+        #expect(classified == .queueFull(message))
+        #expect(ProviderLoop.mapInferenceErrorToStatus(classified) == 429)
+    }
+
+    @Test("real byte figures near the sentinel still classify as token-budget capacity")
+    func nearSentinelByteFiguresStayTokenBudget() {
+        // Only the exact slot-rejection sentinel (needed == 1, available ≤ 0)
+        // is queue-full; a genuine byte-ledger rejection always carries
+        // needed = a multiple of the per-token KV cost (≫ 1).
+        let byteReject = EngineV2Translation.admissionErrorMessage(
+            for: CBv2KVError.capacityExhausted(needed: 2, available: 0))
+        #expect(!byteReject.contains("queue full"))
+        #expect(MultiModelBatchSchedulerEngineError.fromSchedulerMessage(byteReject)
+            == .tokenBudgetExhausted(byteReject))
+        // needed == 1 with real headroom is not the sentinel either.
+        let withHeadroom = EngineV2Translation.admissionErrorMessage(
+            for: CBv2KVError.capacityExhausted(needed: 1, available: 512))
+        #expect(!withHeadroom.contains("queue full"))
     }
 
     @Test("backendIneligible → non-retryable generation failure")
@@ -974,6 +1019,69 @@ struct EngineV2CapacityTests {
         await runtime.unregister(modelId: "gemma-4-27b-it")
         let after = await runtime.capacitySummary()
         #expect(after.slots.isEmpty)
+    }
+
+    @Test("budget max clamps to the live fleet budget; nil clamp preserves the raw grant")
+    func budgetMaxClampsToLiveFleetBudget() async {
+        let engine = ScriptedCBv2Engine(
+            script: .manual,
+            capacity: CBv2CapacitySnapshot(
+                activeRequests: 0, waitingRequests: 0, kvBytesInUse: 0,
+                kvBytesCapacity: 40_000_000, activeTokens: 0
+            ))
+        let bridge = makeBridge(engine: engine, kvBytesPerToken: 4000)
+        // No clamp (unit callers / no fleet context): construction grant.
+        let raw = await bridge.backendSlotCapacity()
+        #expect(raw.activeTokenBudgetMax == 10000)
+        // Fleet shrank the live budget below the grant: report the clamp.
+        let clamped = await bridge.backendSlotCapacity(kvBytesBudgetClamp: 20_000_000)
+        #expect(clamped.activeTokenBudgetMax == 5000)
+        // A clamp ABOVE the grant never inflates the report.
+        let above = await bridge.backendSlotCapacity(kvBytesBudgetClamp: 80_000_000)
+        #expect(above.activeTokenBudgetMax == 10000)
+        // Degenerate negative clamp reports 0, never traps.
+        let negative = await bridge.backendSlotCapacity(kvBytesBudgetClamp: -1)
+        #expect(negative.activeTokenBudgetMax == 0)
+    }
+
+    @Test("runtime summary recomputes each bridge's budget from live fleet residency")
+    func runtimeSummaryAppliesFleetClamp() async {
+        let gib: UInt64 = 1024 * 1024 * 1024
+        let physical = 64 * gib
+        let weights = Int(8 * gib)
+        let rate = 4096
+        let grant = EngineV2KVSizing.engineKVBytesCapacity(
+            newModelWeightBytes: weights, coResidentWeightBytes: 0,
+            existingEngineKVCapacities: [], physicalBytes: physical)
+        let engine = ScriptedCBv2Engine(
+            script: .manual,
+            capacity: CBv2CapacitySnapshot(
+                activeRequests: 0, waitingRequests: 0, kvBytesInUse: 0,
+                kvBytesCapacity: grant, activeTokens: 0
+            ))
+        let bridge = makeBridge(engine: engine, kvBytesPerToken: rate)
+        let runtime = EngineV2Runtime()
+        await runtime.register(modelId: "gemma-4-27b-it", bridge: bridge)
+
+        // Fleet unchanged since construction: reported max == the grant.
+        let alone = await runtime.capacitySummary(
+            fleetKV: EngineV2Runtime.FleetKVContext(
+                totalResidentWeightBytes: UInt64(weights), physicalBytes: physical))
+        #expect(alone.slots.first?.activeTokenBudgetMax == Int64(grant / rate))
+
+        // A 12 GiB model loaded later (legacy — subtracts nothing from the
+        // grant): the reported max shrinks by exactly its weights in tokens.
+        let laterWeights = 12 * gib
+        let grown = await runtime.capacitySummary(
+            fleetKV: EngineV2Runtime.FleetKVContext(
+                totalResidentWeightBytes: UInt64(weights) + laterWeights,
+                physicalBytes: physical))
+        #expect(grown.slots.first?.activeTokenBudgetMax
+            == Int64((grant - Int(laterWeights)) / rate))
+
+        // No fleet context (legacy callers): raw construction figures.
+        let uncontexted = await runtime.capacitySummary()
+        #expect(uncontexted.slots.first?.activeTokenBudgetMax == Int64(grant / rate))
     }
 }
 

--- a/provider-swift/Tests/ProviderCoreTests/EngineV2BridgeTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/EngineV2BridgeTests.swift
@@ -1323,6 +1323,25 @@ struct EngineV2SharedBudgetTests {
         withExtendedLifetime((first, second)) {}
     }
 
+    @Test("degenerate maxTokens <= 0 skips the gate (engine finishes it without KV)")
+    func degenerateRequestSkipsGate() async {
+        // Even on an EXHAUSTED pool, a request that can allocate no KV must
+        // not be capacity-rejected by the gate — the engine's own degenerate
+        // path finishes it immediately (immediate .length terminal).
+        let engine = ScriptedCBv2Engine(script: .stream([
+            .finished(reason: .length, usage: CBv2Usage(promptTokens: 3, completionTokens: 0))
+        ]))
+        let budget = TestBudgets.exhausted()
+        let bridge = makeBridge(engine: engine, kvBytesPerToken: 4000, kvBudget: budget)
+        let (events, _) = await record(await bridge.submitTokenized(
+            promptTokens: [1, 2, 3], request: makeRequest(maxTokens: 0),
+            requestId: "req-degenerate"))
+        // Reached the engine (no gate rejection), reserved nothing.
+        #expect(engine.submitted.count == 1)
+        #expect(events == [.info(prompt: 3, completion: 0)])
+        #expect(await budget.outstandingReservedBytes() == 0)
+    }
+
     @Test("engine rejection after the gate releases the shared reservation")
     func engineRejectionReleasesSharedReservation() async {
         let engine = ScriptedCBv2Engine(

--- a/provider-swift/Tests/ProviderCoreTests/EngineV2BridgeTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/EngineV2BridgeTests.swift
@@ -47,7 +47,10 @@ private final class ScriptedCBv2Engine: CBv2Engine, @unchecked Sendable {
     private var _submitted: [CBv2Request] = []
     private var _cancelled: [CBv2RequestID] = []
     private var _shutdownCalls = 0
-    private var _manualContinuation: AsyncStream<CBv2Event>.Continuation?
+    /// ALL manual continuations, in submit order — retained so an earlier
+    /// request's event stream is not torn down (continuation deinit ⇒
+    /// stream finish) when a later manual submit arrives.
+    private var _manualContinuations: [AsyncStream<CBv2Event>.Continuation] = []
     var capacitySnapshot: CBv2CapacitySnapshot
 
     init(
@@ -65,7 +68,7 @@ private final class ScriptedCBv2Engine: CBv2Engine, @unchecked Sendable {
     var cancelled: [CBv2RequestID] { lock.withLock { _cancelled } }
     var shutdownCalls: Int { lock.withLock { _shutdownCalls } }
     var manualContinuation: AsyncStream<CBv2Event>.Continuation? {
-        lock.withLock { _manualContinuation }
+        lock.withLock { _manualContinuations.last }
     }
 
     func submit(_ request: CBv2Request) throws -> AsyncStream<CBv2Event> {
@@ -85,7 +88,7 @@ private final class ScriptedCBv2Engine: CBv2Engine, @unchecked Sendable {
             return stream
         case .manual:
             let (stream, continuation) = AsyncStream<CBv2Event>.makeStream()
-            lock.withLock { _manualContinuation = continuation }
+            lock.withLock { _manualContinuations.append(continuation) }
             return stream
         }
     }
@@ -116,7 +119,11 @@ private struct StubTokenizer: MLXLMCommon.Tokenizer {
     func encode(text: String, addSpecialTokens: Bool) -> [Int] {
         Array(repeating: 0, count: text.count)
     }
-    func decode(tokenIds: [Int], skipSpecialTokens: Bool) -> String { "" }
+    /// Deterministic per-id text ("t<id>") so logprob-entry conversion
+    /// (token string + UTF-8 bytes) is assertable.
+    func decode(tokenIds: [Int], skipSpecialTokens: Bool) -> String {
+        tokenIds.map { "t\($0)" }.joined()
+    }
     func convertTokenToId(_ token: String) -> Int? { tokenTable[token] }
     func convertIdToToken(_ id: Int) -> String? { nil }
     var bosToken: String? { nil }
@@ -221,6 +228,8 @@ private func makeRequest(
     frequencyPenalty: Float? = nil,
     stop: StopSequences? = nil,
     seed: UInt64? = nil,
+    user: String? = nil,
+    promptCacheKey: String? = nil,
     logitBias: [String: Float]? = nil,
     logprobs: Bool? = nil,
     topLogprobs: Int? = nil
@@ -237,6 +246,8 @@ private func makeRequest(
         frequency_penalty: frequencyPenalty,
         stop: stop,
         seed: seed,
+        user: user,
+        prompt_cache_key: promptCacheKey,
         logit_bias: logitBias,
         logprobs: logprobs,
         top_logprobs: topLogprobs
@@ -330,6 +341,47 @@ struct EngineV2TranslationTests {
         #expect(EngineV2Translation.topLogprobs(logprobs: true, topLogprobs: 50) == 20)
     }
 
+    @Test("cacheScope maps onto CBv2Request.cacheSalt; \"\" maps to nil")
+    func cacheSaltMapping() {
+        // TB-007 forward plumbing: a non-empty tenant scope becomes the
+        // per-request salt; unscoped ("") falls back to nil so the engine
+        // uses its cache-level salt (byte-identical pre-salt hashes).
+        let salted = EngineV2Translation.cbv2Request(
+            id: CBv2RequestID(1), promptTokens: [1], request: makeRequest(),
+            defaultMaxTokens: 16, stopTokenIds: [], cacheScope: "tenant-a")
+        #expect(salted.cacheSalt == "tenant-a")
+        let unsalted = EngineV2Translation.cbv2Request(
+            id: CBv2RequestID(2), promptTokens: [1], request: makeRequest(),
+            defaultMaxTokens: 16, stopTokenIds: [])
+        #expect(unsalted.cacheSalt == nil)
+    }
+
+    @Test("engine logprobs convert to the OpenAI streaming entry shape")
+    func sseTokenLogprobConversion() {
+        let names = [10: "Hi", 11: "Yo"]
+        let entries = EngineV2Translation.sseTokenLogprobs(
+            [
+                CBv2TokenLogprob(
+                    token: 10, logprob: -0.25,
+                    topLogprobs: [(token: 10, logprob: -0.25), (token: 11, logprob: -1.5)]
+                ),
+                CBv2TokenLogprob(token: 11, logprob: -0.5),
+            ],
+            decodeToken: { names[$0] ?? "?" }
+        )
+        #expect(entries.count == 2)
+        #expect(entries[0].token == "Hi")
+        #expect(entries[0].logprob == -0.25)
+        #expect(entries[0].bytes == [72, 105])  // UTF-8 of "Hi"
+        #expect(entries[0].topLogprobs.count == 2)
+        #expect(entries[0].topLogprobs[1].token == "Yo")
+        #expect(entries[0].topLogprobs[1].logprob == -1.5)
+        #expect(entries[0].topLogprobs[1].bytes == [89, 111])
+        // No alternatives requested → empty top_logprobs, entry still carried.
+        #expect(entries[1].token == "Yo")
+        #expect(entries[1].topLogprobs.isEmpty)
+    }
+
     @Test("stop resolution follows buildStopTokenIds semantics")
     func stopResolution() {
         // model EOS ∪ tokenizer EOS ∪ resolvable extra EOS tokens.
@@ -359,6 +411,34 @@ struct EngineV2TranslationTests {
         #expect(engine.submitted[0].stopTokens == [1, 2, 7])
         // Tokenization went through the tokenizer's chat-template path.
         #expect(engine.submitted[0].promptTokens == [1, 2, 3, 4, 5])
+    }
+
+    @Test("bridge stamps the tenant cache scope as CBv2Request.cacheSalt")
+    func bridgeStampsCacheSalt() async {
+        let engine = ScriptedCBv2Engine(script: .stream([
+            .finished(reason: .stop, usage: CBv2Usage(promptTokens: 5, completionTokens: 0))
+        ]))
+        let bridge = makeBridge(engine: engine)
+        // Coordinator path shape: scope decoded out-of-band, passed explicitly.
+        _ = await record(await bridge.submitTokenized(
+            promptTokens: [1, 2], request: makeRequest(), requestId: "req-salt-1",
+            cacheScope: "tenant-scope"))
+        // Internal-shape path: scope derived from the request's own
+        // prompt_cache_key via `ChatCompletionRequest.cacheScope`.
+        _ = await record(await bridge.submit(
+            request: makeRequest(promptCacheKey: "consumer-key"),
+            requestId: "req-salt-2"))
+        // `user` is the fallback identity when prompt_cache_key is absent.
+        _ = await record(await bridge.submit(
+            request: makeRequest(user: "user-77"), requestId: "req-salt-3"))
+        // No tenant identity at all → nil (engine cache-level salt fallback).
+        _ = await record(await bridge.submit(
+            request: makeRequest(), requestId: "req-salt-4"))
+        #expect(engine.submitted.count == 4)
+        #expect(engine.submitted[0].cacheSalt == "tenant-scope")
+        #expect(engine.submitted[1].cacheSalt == ChatCompletionRequest.scopeHash("consumer-key"))
+        #expect(engine.submitted[2].cacheSalt == ChatCompletionRequest.scopeHash("user-77"))
+        #expect(engine.submitted[3].cacheSalt == nil)
     }
 }
 
@@ -503,6 +583,84 @@ struct EngineV2EventFramingTests {
     }
 }
 
+// MARK: - Logprobs passthrough (delta logprobs → per-request channel)
+
+@Suite("EngineV2 logprobs passthrough")
+struct EngineV2LogprobsPassthroughTests {
+
+    @Test("delta logprobs publish to the channel in OpenAI entry shape, in order")
+    func logprobsFlowToChannel() async {
+        let engine = ScriptedCBv2Engine(script: .stream([
+            .delta(
+                text: "He", tokens: [10],
+                logprobs: [
+                    CBv2TokenLogprob(
+                        token: 10, logprob: -0.1,
+                        topLogprobs: [(token: 10, logprob: -0.1), (token: 12, logprob: -2.0)]
+                    )
+                ]),
+            .delta(
+                text: "llo", tokens: [11],
+                logprobs: [CBv2TokenLogprob(token: 11, logprob: -0.9)]),
+            .finished(reason: .stop, usage: CBv2Usage(promptTokens: 5, completionTokens: 2)),
+        ]))
+        let bridge = makeBridge(engine: engine)
+        let channel = EngineV2LogprobsChannel()
+        let (events, _) = await record(await bridge.submit(
+            request: makeRequest(logprobs: true, topLogprobs: 2),
+            requestId: "req-lp",
+            logprobsChannel: channel
+        ))
+        // The GenerationEvent stream is untouched — logprobs ride out-of-band.
+        #expect(events == [
+            .chunk("He"), .chunk("llo"), .info(prompt: 5, completion: 2),
+        ])
+        // Sampling translation asked the engine to capture logprobs.
+        #expect(engine.submitted[0].sampling.topLogprobs == 2)
+        // Entries arrive converted (StubTokenizer decodes id → "t<id>"),
+        // in emission order, with alternatives preserved.
+        let entries = channel.drain()
+        #expect(entries.count == 2)
+        #expect(entries[0].token == "t10")
+        #expect(entries[0].logprob == -0.1)
+        #expect(entries[0].bytes == Array("t10".utf8).map(Int.init))
+        #expect(entries[0].topLogprobs.count == 2)
+        #expect(entries[0].topLogprobs[1].token == "t12")
+        #expect(entries[1].token == "t11")
+        #expect(entries[1].topLogprobs.isEmpty)
+        // drain() empties the channel.
+        #expect(channel.drain().isEmpty)
+    }
+
+    @Test("nil/empty delta logprobs leave the channel empty")
+    func noLogprobsNoEntries() async {
+        let engine = ScriptedCBv2Engine(script: .stream([
+            .delta(text: "x", tokens: [10], logprobs: nil),
+            .delta(text: "y", tokens: [11], logprobs: []),
+            .finished(reason: .stop, usage: CBv2Usage(promptTokens: 5, completionTokens: 2)),
+        ]))
+        let bridge = makeBridge(engine: engine)
+        let channel = EngineV2LogprobsChannel()
+        _ = await record(await bridge.submit(
+            request: makeRequest(), requestId: "req-nolp", logprobsChannel: channel
+        ))
+        #expect(channel.drain().isEmpty)
+    }
+
+    @Test("no channel wired → logprob-bearing deltas stream normally (dropped)")
+    func logprobsWithoutChannelAreDropped() async {
+        let engine = ScriptedCBv2Engine(script: .stream([
+            .delta(
+                text: "x", tokens: [10],
+                logprobs: [CBv2TokenLogprob(token: 10, logprob: -0.5)]),
+            .finished(reason: .stop, usage: CBv2Usage(promptTokens: 5, completionTokens: 1)),
+        ]))
+        let bridge = makeBridge(engine: engine)
+        let (events, _) = await record(await bridge.submit(request: makeRequest()))
+        #expect(events == [.chunk("x"), .info(prompt: 5, completion: 1)])
+    }
+}
+
 // MARK: - Error mapping (capacity → retryable class)
 
 @Suite("EngineV2 admission-error mapping")
@@ -643,7 +801,8 @@ struct EngineV2CapacityTests {
                 waitingRequests: 3,
                 kvBytesInUse: 4_000_000,
                 kvBytesCapacity: 40_000_000,
-                activeTokens: 1000
+                activeTokens: 1000,
+                stepsExecuted: 12345
             ))
         let bridge = makeBridge(engine: engine, kvBytesPerToken: 4000)
         let slot = await bridge.backendSlotCapacity()
@@ -656,6 +815,8 @@ struct EngineV2CapacityTests {
         #expect(slot.activeTokenBudgetMax == 10000)   // 40 MB / 4000 B-per-token
         #expect(slot.kvBytesPerToken == 4000)
         #expect(slot.maxConcurrency == 4)
+        // The engine's own monotonic step counter flows straight through.
+        #expect(slot.stepsExecuted == 12345)
         #expect(!slot.wedgeSuspected)
     }
 
@@ -677,19 +838,58 @@ struct EngineV2CapacityTests {
         #expect(slot.activeTokenBudgetMax == 0)
     }
 
-    @Test("wedge counters flow into the slot (admits / first tokens / steps)")
+    @Test("wedge counters flow into the slot (admits / first tokens / engine steps)")
     func wedgeCountersInSlot() async {
-        let engine = ScriptedCBv2Engine(script: .stream([
-            .delta(text: "hello", tokens: [10], logprobs: nil),
-            .finished(reason: .stop, usage: CBv2Usage(promptTokens: 5, completionTokens: 1)),
-        ]))
+        let engine = ScriptedCBv2Engine(
+            script: .stream([
+                .delta(text: "hello", tokens: [10], logprobs: nil),
+                .finished(
+                    reason: .stop, usage: CBv2Usage(promptTokens: 5, completionTokens: 1)),
+            ]),
+            capacity: CBv2CapacitySnapshot(
+                activeRequests: 0, waitingRequests: 0, kvBytesInUse: 0,
+                kvBytesCapacity: 0, activeTokens: 0, stepsExecuted: 42
+            ))
         let bridge = makeBridge(engine: engine)
         _ = await record(await bridge.submit(request: makeRequest()))
         let slot = await bridge.backendSlotCapacity()
         #expect(slot.admits == 1)
         #expect(slot.firstTokensEmitted == 1)
-        // Loop-progress proxy: 2 events were observed.
-        #expect(slot.stepsExecuted == 2)
+        // Loop progress is the ENGINE's monotonic step counter (published in
+        // the capacity snapshot every step), not an event-count proxy.
+        #expect(slot.stepsExecuted == 42)
+    }
+
+    @Test("wedge trips only when the engine step counter flatlines under hanging admits")
+    func wedgeRequiresStepFlatline() async {
+        let engine = ScriptedCBv2Engine(
+            script: .manual,
+            capacity: CBv2CapacitySnapshot(
+                activeRequests: 3, waitingRequests: 0, kvBytesInUse: 0,
+                kvBytesCapacity: 0, activeTokens: 0, stepsExecuted: 100
+            ))
+        let bridge = makeBridge(engine: engine)
+        let t0 = ContinuousClock.Instant.now
+        // Three admits that never produce a first token.
+        for i in 0..<3 {
+            _ = await bridge.submit(request: makeRequest(), requestId: "req-hang-\(i)")
+        }
+        // Baseline heartbeat: step counter first observed at 100.
+        _ = await bridge.backendSlotCapacity(now: t0)
+        // 11s later, counter still 100 → frozen loop + 3 hanging admits over
+        // the stall threshold ⇒ wedge suspected; slot derates to "crashed".
+        let wedged = await bridge.backendSlotCapacity(now: t0.advanced(by: .seconds(11)))
+        #expect(wedged.wedgeSuspected)
+        #expect(wedged.state == "crashed")
+        // The counter advancing is proof of loop progress: same hanging
+        // admits, but a moving engine is a slow prefill — NOT a wedge.
+        engine.capacitySnapshot = CBv2CapacitySnapshot(
+            activeRequests: 3, waitingRequests: 0, kvBytesInUse: 0,
+            kvBytesCapacity: 0, activeTokens: 0, stepsExecuted: 101
+        )
+        let recovered = await bridge.backendSlotCapacity(now: t0.advanced(by: .seconds(22)))
+        #expect(!recovered.wedgeSuspected)
+        #expect(recovered.stepsExecuted == 101)
     }
 
     @Test("runtime capacity summary aggregates registered bridges")

--- a/provider-swift/Tests/ProviderCoreTests/EngineV2BridgeTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/EngineV2BridgeTests.swift
@@ -183,7 +183,7 @@ private func record(
         switch event {
         case .chunk(let text):
             events.append(.chunk(text))
-        case .info(let prompt, let completion, let tokensPerSecond):
+        case .info(let prompt, let completion, let tokensPerSecond, _):
             events.append(.info(prompt: prompt, completion: completion))
             tps.append(tokensPerSecond)
         case .error(let message):
@@ -490,7 +490,7 @@ struct EngineV2EventFramingTests {
         #expect(tps[0] >= 0)
     }
 
-    @Test("length finish frames identically to stop")
+    @Test("length finish frames usage like stop but preserves finish_reason 'length'")
     func lengthFramesLikeStop() async {
         let engine = ScriptedCBv2Engine(script: .stream([
             .delta(text: "x", tokens: [10], logprobs: nil),
@@ -501,6 +501,32 @@ struct EngineV2EventFramingTests {
         let bridge = makeBridge(engine: engine)
         let (events, _) = await record(await bridge.submit(request: makeRequest()))
         #expect(events == [.chunk("x"), .info(prompt: 5, completion: 1)])
+    }
+
+    /// Regression: the v2 bridge used to flatten `.length` into the same
+    /// `.info` shape as `.stop`, so clients saw finish_reason "stop" on a
+    /// max_tokens truncation. The reason now rides on GenerationEvent.info.
+    @Test("finish reason threads through: .length => 'length', .stop => 'stop', cancel partial => nil")
+    func finishReasonThreadsThroughInfoEvent() async {
+        func terminalReason(_ finish: CBv2FinishReason) async -> String?? {
+            let engine = ScriptedCBv2Engine(script: .stream([
+                .delta(text: "x", tokens: [10], logprobs: nil),
+                .finished(reason: finish, usage: CBv2Usage(promptTokens: 4, completionTokens: 1)),
+            ]))
+            let bridge = makeBridge(engine: engine)
+            var got: String?? = nil
+            for await event in await bridge.submit(request: makeRequest()) {
+                if case .info(_, _, _, let reason) = event {
+                    got = .some(reason)
+                }
+            }
+            return got
+        }
+        #expect(await terminalReason(.length) == .some("length"))
+        #expect(await terminalReason(.stop) == .some("stop"))
+        // Cancelled-with-work emits its usage info with a nil reason (the
+        // terminal signal is the trailing "request cancelled" error).
+        #expect(await terminalReason(.cancelled) == .some(String?.none))
     }
 
     @Test("terminal usage can only raise observed counts (billing-zero defense)")
@@ -1104,14 +1130,23 @@ struct EngineV2ConfigGatingTests {
         #expect(!EngineV2Config.flagEnabled(environment: ["DARKBLOOM_ENGINE_V2": "maybe"], configEnabled: true))
     }
 
-    @Test("default allowlist: gemma-4* and gpt-oss*, incl. org-prefixed ids")
+    @Test("default allowlist: EXACT production checkpoint ids only")
     func defaultAllowlist() {
-        #expect(EngineV2Config.modelAllowlisted("gemma-4-27b-it"))
-        #expect(EngineV2Config.modelAllowlisted("Gemma-4-9B"))
-        #expect(EngineV2Config.modelAllowlisted("gpt-oss-20b-4bit"))
-        #expect(EngineV2Config.modelAllowlisted("mlx-community/gpt-oss-20b-4bit"))
-        #expect(EngineV2Config.modelAllowlisted("mlx-community/gemma-4-27b-it-4bit"))
+        // The two checkpoints v2 was parity/soak-validated on — the default-on
+        // scope must equal the real-model-validated scope, nothing broader.
+        #expect(EngineV2Config.modelAllowlisted("mlx-community/gpt-oss-20b-MXFP4-Q8"))
+        #expect(EngineV2Config.modelAllowlisted("mlx-community/gemma-4-26b-a4b-it-8bit"))
+        // Case-insensitive + last-path-component matching still applies.
+        #expect(EngineV2Config.modelAllowlisted("MLX-Community/GPT-OSS-20B-MXFP4-Q8"))
+        #expect(EngineV2Config.modelAllowlisted("gpt-oss-20b-MXFP4-Q8"))
+        // Other quantizations of the SAME families are NOT default-enabled —
+        // they were not validated on real weights. Operators widen via
+        // DARKBLOOM_ENGINE_V2_MODELS.
+        #expect(!EngineV2Config.modelAllowlisted("mlx-community/gpt-oss-20b-4bit"))
+        #expect(!EngineV2Config.modelAllowlisted("mlx-community/gemma-4-27b-it-4bit"))
+        #expect(!EngineV2Config.modelAllowlisted("gemma-4-26B-A4B-it-qat-4bit"))
         #expect(!EngineV2Config.modelAllowlisted("qwen3-8b"))
+        #expect(!EngineV2Config.modelAllowlisted("mlx-community/Qwen3.5-0.8B-MLX-4bit"))
         #expect(!EngineV2Config.modelAllowlisted("llama-3.3-70b"))
         #expect(!EngineV2Config.modelAllowlisted(""))
     }
@@ -1128,13 +1163,34 @@ struct EngineV2ConfigGatingTests {
 
     @Test("selection matrix")
     func selectionMatrix() {
-        // Flag off → legacy even for allowlisted models.
+        let prodGemma = "mlx-community/gemma-4-26b-a4b-it-8bit"
+        // Config off (explicit opt-out) → legacy even for allowlisted models.
         #expect(EngineV2Config.selection(
-            modelId: "gemma-4-27b-it", environment: [:], configEnabled: false
+            modelId: prodGemma, environment: [:], configEnabled: false
+        ) == .legacy)
+        // DEFAULT-ON posture (v0.7.0): config default true + no env
+        // → v2 for the exact prod checkpoints, legacy for everything else.
+        #expect(EngineV2Config.selection(
+            modelId: prodGemma, environment: [:],
+            configEnabled: BackendSettings().engineV2
+        ) == .v2)
+        #expect(EngineV2Config.selection(
+            modelId: "mlx-community/gpt-oss-20b-MXFP4-Q8", environment: [:],
+            configEnabled: BackendSettings().engineV2
+        ) == .v2)
+        #expect(EngineV2Config.selection(
+            modelId: "mlx-community/Qwen3.5-0.8B-MLX-4bit", environment: [:],
+            configEnabled: BackendSettings().engineV2
+        ) == .legacy)
+        // Env kill switch is absolute — beats the default-on config.
+        #expect(EngineV2Config.selection(
+            modelId: prodGemma,
+            environment: ["DARKBLOOM_ENGINE_V2": "0"],
+            configEnabled: BackendSettings().engineV2
         ) == .legacy)
         // Flag on + allowlisted → v2.
         #expect(EngineV2Config.selection(
-            modelId: "gemma-4-27b-it",
+            modelId: prodGemma,
             environment: ["DARKBLOOM_ENGINE_V2": "1"], configEnabled: false
         ) == .v2)
         // Flag on + non-allowlisted → legacy.
@@ -1188,7 +1244,7 @@ struct EngineV2ConfigGatingTests {
         struct InitFailure: Error {}
         let telemetry = TelemetrySink()
         let bridge = EngineV2Factory.makeBridgeIfSelected(
-            modelId: "gpt-oss-20b",
+            modelId: "mlx-community/gpt-oss-20b-MXFP4-Q8",
             configEnabled: true,
             environment: [:],
             tokenizer: TokenizerHandle(StubTokenizer()),
@@ -1203,14 +1259,17 @@ struct EngineV2ConfigGatingTests {
         #expect(events.first?.severity == .warn)
         #expect(events.first?.fields?["operation"]?.description == "engine_v2_fallback")
         #expect(events.first?.fields?["backend"]?.description == "engine_v2")
-        #expect(events.first?.fields?["model"]?.description == "gpt-oss-20b")
+        #expect(events.first?.fields?["model"]?.description == "mlx-community/gpt-oss-20b-MXFP4-Q8")
         #expect(events.first?.fields?["error_class"]?.description.contains("InitFailure") == true)
+        // Default-on posture: the fallback is load-bearing, so the event must
+        // carry the human-readable reason too, not just the error type.
+        #expect(events.first?.fields?["error"]?.description.contains("InitFailure") == true)
     }
 
     @Test("factory: selected + healthy builder → v2 bridge")
     func factorySelectedBuilds() {
         let bridge = EngineV2Factory.makeBridgeIfSelected(
-            modelId: "gemma-4-27b-it",
+            modelId: "mlx-community/gemma-4-26b-a4b-it-8bit",
             configEnabled: true,
             environment: [:],
             tokenizer: TokenizerHandle(StubTokenizer()),
@@ -1220,19 +1279,22 @@ struct EngineV2ConfigGatingTests {
         #expect(bridge != nil)
     }
 
-    @Test("backend config decodes engine_v2 key (default false)")
+    @Test("backend config decodes engine_v2 key (default TRUE as of v0.7.0)")
     func backendConfigKey() throws {
         let decoder = JSONDecoder()
-        let on = try decoder.decode(
+        let off = try decoder.decode(
             BackendSettings.self,
-            from: Data(#"{"engine_v2": true}"#.utf8)
+            from: Data(#"{"engine_v2": false}"#.utf8)
         )
-        #expect(on.engineV2)
+        #expect(!off.engineV2)
+        // v0.7.0 ships v2 default-on for the exact-id allowlist; rollback is
+        // the DARKBLOOM_ENGINE_V2=0 kill switch or a release rollback.
         let absent = try decoder.decode(
             BackendSettings.self,
             from: Data(#"{}"#.utf8)
         )
-        #expect(!absent.engineV2)
+        #expect(absent.engineV2)
+        #expect(BackendSettings().engineV2)
     }
 }
 

--- a/provider-swift/Tests/ProviderCoreTests/EngineV2BridgeTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/EngineV2BridgeTests.swift
@@ -196,7 +196,7 @@ private func record(
 // MARK: - Shared builders
 
 private func makeBridge(
-    engine: ScriptedCBv2Engine,
+    engine: any CBv2Engine,
     tokenizer: StubTokenizer = StubTokenizer(),
     modelId: String = "gemma-4-27b-it",
     eosTokenIds: Set<Int> = [2],
@@ -1429,6 +1429,161 @@ struct EngineV2HardeningTests {
         #expect(engine.submitted.count == 2)
         #expect(engine.submitted[0].id == CBv2RequestID(1))
         #expect(engine.submitted[1].id == CBv2RequestID(2))
+    }
+}
+
+// MARK: - Seeded sampling reproducibility (stable engine ids)
+
+/// STOCHASTIC sampler stub: emitted tokens are a pure function of
+/// (sampling.seed, request.id.raw, stepIndex) — the exact key shape the real
+/// v2 sampler uses (`SamplerV2.mix`) — so these tests prove end-to-end that
+/// seeded outputs reproduce iff the bridge hands the engine a stable id.
+private final class StochasticScriptedEngine: CBv2Engine, @unchecked Sendable {
+    private let lock = NSLock()
+    private var _submitted: [CBv2Request] = []
+    var submitted: [CBv2Request] { lock.withLock { _submitted } }
+
+    func submit(_ request: CBv2Request) throws -> AsyncStream<CBv2Event> {
+        lock.withLock { _submitted.append(request) }
+        let (stream, continuation) = AsyncStream<CBv2Event>.makeStream()
+        for step in 0..<4 {
+            let key = Self.mix(
+                seed: request.sampling.seed ?? 0, id: request.id.raw, step: UInt64(step))
+            let token = Int(key % 50_000)
+            continuation.yield(.delta(text: "t\(token) ", tokens: [token], logprobs: nil))
+        }
+        continuation.yield(.finished(
+            reason: .stop,
+            usage: CBv2Usage(promptTokens: request.promptTokens.count, completionTokens: 4)))
+        continuation.finish()
+        return stream
+    }
+
+    func cancel(_ id: CBv2RequestID) {}
+    func capacity() -> CBv2CapacitySnapshot {
+        CBv2CapacitySnapshot(
+            activeRequests: 0, waitingRequests: 0, kvBytesInUse: 0,
+            kvBytesCapacity: 0, activeTokens: 0)
+    }
+    func shutdown() async {}
+
+    /// Same mixing family as the engine sampler's keyed RNG.
+    static func mix(seed: UInt64, id: UInt64, step: UInt64) -> UInt64 {
+        func splitmix(_ x: UInt64) -> UInt64 {
+            var z = x &+ 0x9E37_79B9_7F4A_7C15
+            z = (z ^ (z >> 30)) &* 0xBF58_476D_1CE4_E5B9
+            z = (z ^ (z >> 27)) &* 0x94D0_49BB_1331_11EB
+            return z ^ (z >> 31)
+        }
+        return splitmix(splitmix(splitmix(seed) ^ id) ^ step)
+    }
+}
+
+@Suite("EngineV2 seeded sampling reproducibility")
+struct EngineV2SeededSamplingTests {
+
+    private func chunks(_ events: [RecordedEvent]) -> [String] {
+        events.compactMap {
+            if case .chunk(let text) = $0 { return text }
+            return nil
+        }
+    }
+
+    @Test("same seed + same prompt reproduce identical output across submissions")
+    func seededOutputReproduces() async {
+        let engine = StochasticScriptedEngine()
+        let bridge = makeBridge(engine: engine)
+        let prompt = [11, 22, 33]
+
+        let (first, _) = await record(await bridge.submitTokenized(
+            promptTokens: prompt, request: makeRequest(maxTokens: 8, seed: 42),
+            requestId: "req-seed-1"))
+        // Interleave an UNRELATED request so the monotonic counter moves —
+        // the regression this fix targets: seeded output must not depend on
+        // prior traffic.
+        _ = await record(await bridge.submitTokenized(
+            promptTokens: [9, 9, 9], request: makeRequest(maxTokens: 8),
+            requestId: "req-noise"))
+        let (second, _) = await record(await bridge.submitTokenized(
+            promptTokens: prompt, request: makeRequest(maxTokens: 8, seed: 42),
+            requestId: "req-seed-2"))
+
+        #expect(!chunks(first).isEmpty)
+        #expect(chunks(first) == chunks(second))
+        // The engine saw the SAME stable id on both seeded submissions —
+        // that is what keys the RNG stream — and it carries the seeded tag.
+        #expect(engine.submitted.count == 3)
+        #expect(engine.submitted[0].id == engine.submitted[2].id)
+        #expect(engine.submitted[0].id.raw & EngineV2Bridge.seededIdTagBit != 0)
+    }
+
+    @Test("different seed or different prompt produce different ids (and RNG streams)")
+    func seededOutputDiverges() async {
+        let engine = StochasticScriptedEngine()
+        let bridge = makeBridge(engine: engine)
+        _ = await record(await bridge.submitTokenized(
+            promptTokens: [1, 2, 3], request: makeRequest(maxTokens: 8, seed: 42),
+            requestId: "req-a"))
+        _ = await record(await bridge.submitTokenized(
+            promptTokens: [1, 2, 3], request: makeRequest(maxTokens: 8, seed: 43),
+            requestId: "req-b"))
+        _ = await record(await bridge.submitTokenized(
+            promptTokens: [1, 2, 4], request: makeRequest(maxTokens: 8, seed: 42),
+            requestId: "req-c"))
+        let ids = engine.submitted.map(\.id.raw)
+        #expect(Set(ids).count == 3)
+    }
+
+    @Test("unseeded submissions keep fresh monotonic ids")
+    func unseededStaysMonotonic() async {
+        let engine = StochasticScriptedEngine()
+        let bridge = makeBridge(engine: engine)
+        _ = await record(await bridge.submitTokenized(
+            promptTokens: [1, 2, 3], request: makeRequest(maxTokens: 8),
+            requestId: "req-u1"))
+        _ = await record(await bridge.submitTokenized(
+            promptTokens: [1, 2, 3], request: makeRequest(maxTokens: 8),
+            requestId: "req-u2"))
+        #expect(engine.submitted[0].id == CBv2RequestID(1))
+        #expect(engine.submitted[1].id == CBv2RequestID(2))
+    }
+
+    @Test("a live identical seeded request falls back to a fresh id (collision guard)")
+    func liveCollisionFallsBackToFreshId() async {
+        // Manual engine keeps the first submission LIVE while the identical
+        // second one arrives.
+        let engine = ScriptedCBv2Engine(script: .manual)
+        let bridge = makeBridge(engine: engine)
+        let first = await bridge.submitTokenized(
+            promptTokens: [1, 2, 3], request: makeRequest(maxTokens: 8, seed: 42),
+            requestId: "req-live-a")
+        let second = await bridge.submitTokenized(
+            promptTokens: [1, 2, 3], request: makeRequest(maxTokens: 8, seed: 42),
+            requestId: "req-live-b")
+        #expect(engine.submitted.count == 2)
+        let firstId = engine.submitted[0].id
+        let secondId = engine.submitted[1].id
+        // First got the stable seeded id; the overlapping duplicate got a
+        // fresh monotonic id (documented reproducibility waiver) — never a
+        // duplicate live id inside the engine.
+        #expect(firstId.raw & EngineV2Bridge.seededIdTagBit != 0)
+        #expect(secondId.raw & EngineV2Bridge.seededIdTagBit == 0)
+        #expect(firstId != secondId)
+        withExtendedLifetime((first, second)) {}
+    }
+
+    @Test("stableSeededRawId is deterministic, tagged, and input-sensitive")
+    func stableSeededRawIdProperties() {
+        let a = EngineV2Bridge.stableSeededRawId(seed: 42, promptTokens: [1, 2, 3])
+        let b = EngineV2Bridge.stableSeededRawId(seed: 42, promptTokens: [1, 2, 3])
+        #expect(a == b)
+        #expect(a & EngineV2Bridge.seededIdTagBit != 0)
+        #expect(a != EngineV2Bridge.stableSeededRawId(seed: 43, promptTokens: [1, 2, 3]))
+        #expect(a != EngineV2Bridge.stableSeededRawId(seed: 42, promptTokens: [1, 2]))
+        #expect(a != EngineV2Bridge.stableSeededRawId(seed: 42, promptTokens: [1, 2, 4]))
+        // Empty prompt still derives a valid tagged id.
+        let empty = EngineV2Bridge.stableSeededRawId(seed: 42, promptTokens: [])
+        #expect(empty & EngineV2Bridge.seededIdTagBit != 0)
     }
 }
 

--- a/provider-swift/Tests/ProviderCoreTests/EngineV2BridgeTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/EngineV2BridgeTests.swift
@@ -331,6 +331,21 @@ struct EngineV2TranslationTests {
         #expect(EngineV2Translation.parseLogitBias([:]).isEmpty)
     }
 
+    @Test("parseLogitBias reports a dropped-key count for the silent-drop signal (fix #9)")
+    func logitBiasDroppedCount() {
+        let result = EngineV2Translation.parseLogitBiasCountingDropped([
+            "50256": -100,   // valid
+            "abc": 5,        // non-numeric → dropped
+            "-7": 3,         // negative → dropped
+            " 9 ": 1,        // valid (whitespace tolerant)
+        ])
+        #expect(result.bias == [50256: -100, 9: 1])
+        #expect(result.dropped == 2)
+        // All-valid → zero dropped; nil/empty → zero dropped.
+        #expect(EngineV2Translation.parseLogitBiasCountingDropped(["1": 2]).dropped == 0)
+        #expect(EngineV2Translation.parseLogitBiasCountingDropped(nil).dropped == 0)
+    }
+
     @Test("logprobs/top_logprobs mapping (0 = none; chosen-token → 1; clamp 20)")
     func topLogprobsMapping() {
         #expect(EngineV2Translation.topLogprobs(logprobs: nil, topLogprobs: nil) == 0)
@@ -1172,5 +1187,132 @@ struct EngineV2SharedBudgetTests {
             .finished(reason: .stop, usage: CBv2Usage(promptTokens: 3, completionTokens: 0)))
         engine.manualContinuation?.finish()
         _ = await consumer.value
+    }
+}
+
+// MARK: - Hardening (request-id validation, id overflow, pump lifecycle)
+
+@Suite("EngineV2 bridge hardening")
+struct EngineV2HardeningTests {
+
+    @Test("request-id validation: nil / empty / over-long / control chars → fresh id (fix #4)")
+    func requestIdValidation() {
+        // Valid ids pass through verbatim.
+        #expect(EngineV2Bridge.isValidRequestId("req-abc123"))
+        #expect(EngineV2Bridge.isValidRequestId(String(repeating: "a", count: 256)))
+        #expect(EngineV2Bridge.normalizedRequestId("req-coord-1") == "req-coord-1")
+        // Invalid ids are rejected and replaced with a generated one.
+        #expect(!EngineV2Bridge.isValidRequestId(""))
+        #expect(!EngineV2Bridge.isValidRequestId(String(repeating: "a", count: 257)))
+        #expect(!EngineV2Bridge.isValidRequestId("req\u{0}embedded-nul"))
+        #expect(!EngineV2Bridge.isValidRequestId("req\u{7f}del"))
+        #expect(!EngineV2Bridge.isValidRequestId("line\nbreak"))
+        // nil and each invalid form normalize to a fresh, valid `req-…` id.
+        for bad in [nil, "", "line\nbreak", String(repeating: "z", count: 300)] {
+            let normalized = EngineV2Bridge.normalizedRequestId(bad)
+            #expect(normalized.hasPrefix("req-"))
+            #expect(EngineV2Bridge.isValidRequestId(normalized))
+        }
+    }
+
+    @Test("a malformed request-id is normalized before it becomes a cancel handle")
+    func malformedIdNormalizedInSubmit() async {
+        let engine = ScriptedCBv2Engine(script: .manual)
+        let bridge = makeBridge(engine: engine)
+        // Submit with a control-char id: the bridge must NOT key its state on it.
+        let stream = await bridge.submitTokenized(
+            promptTokens: [1, 2, 3], request: makeRequest(), requestId: "bad\u{0}id")
+        // The raw malformed id maps to nothing (a fresh id was minted).
+        #expect(await bridge._testEngineRequestId(for: "bad\u{0}id") == nil)
+        // Exactly one request is live under the normalized id.
+        let counters = await bridge._testCounters()
+        #expect(counters.active == 1)
+        withExtendedLifetime(stream) {}
+    }
+
+    @Test("shutdown cancels live pump tasks and releases their reservations (fix #7)")
+    func shutdownCancelsLivePumps() async {
+        // A manual engine keeps the request in-flight (stream never finishes)
+        // so the pump is parked on `for await`. Shutdown must cancel it.
+        let engine = ScriptedCBv2Engine(script: .manual)
+        let budget = GlobalKVCacheBudget()
+        let bridge = makeBridge(engine: engine, kvBytesPerToken: 4000, kvBudget: budget)
+        let stream = await bridge.submitTokenized(
+            promptTokens: [1, 2, 3, 4, 5], request: makeRequest(maxTokens: 16),
+            requestId: "req-live-1")
+        let consumer = Task { await record(stream) }
+        // Wait for the pump to run + record its reservation.
+        for _ in 0..<200 where await budget.outstandingReservedBytes() == 0 {
+            try? await Task.sleep(for: .milliseconds(5))
+        }
+        #expect(await bridge._testLivePumpCount() == 1)
+        #expect(await budget.outstandingReservedBytes() == 84_000)
+
+        await bridge.shutdown()
+        #expect(engine.shutdownCalls == 1)
+        // The cancelled pump unwinds (AsyncStream.next() returns nil under
+        // cancellation → teardown path), releasing its reservation and
+        // clearing its task handle.
+        _ = await consumer.value
+        for _ in 0..<200 where await bridge._testLivePumpCount() != 0 {
+            try? await Task.sleep(for: .milliseconds(5))
+        }
+        #expect(await bridge._testLivePumpCount() == 0)
+        #expect(await budget.outstandingReservedBytes() == 0)
+    }
+
+    @Test("nextRawId uses wrapping increment (fix #5)")
+    func nextRawIdWraps() async {
+        // A stream engine so each submit runs to a terminal and self-clears,
+        // letting the same provider id be reused across submits.
+        let engine = ScriptedCBv2Engine(script: .stream([
+            .finished(reason: .stop, usage: CBv2Usage(promptTokens: 1, completionTokens: 0))
+        ]))
+        let bridge = makeBridge(engine: engine)
+        // Two sequential submits mint two distinct engine ids (raw 1, 2).
+        _ = await record(await bridge.submitTokenized(
+            promptTokens: [1], request: makeRequest(), requestId: "r1"))
+        _ = await record(await bridge.submitTokenized(
+            promptTokens: [1], request: makeRequest(), requestId: "r2"))
+        #expect(engine.submitted.count == 2)
+        #expect(engine.submitted[0].id == CBv2RequestID(1))
+        #expect(engine.submitted[1].id == CBv2RequestID(2))
+    }
+}
+
+// MARK: - Logprobs channel cap (fix #8)
+
+@Suite("EngineV2 logprobs channel bounding")
+struct EngineV2LogprobsChannelCapTests {
+
+    private func entry(_ token: String) -> SSETokenLogprob {
+        SSETokenLogprob(token: token, logprob: -0.1, bytes: nil, topLogprobs: [])
+    }
+
+    @Test("undrained channel is capped at maxEntries with drop-oldest")
+    func channelCapsWithDropOldest() {
+        let channel = EngineV2LogprobsChannel()
+        let cap = EngineV2LogprobsChannel.maxEntries
+        // Append cap + 10 entries, tagged by index, without ever draining.
+        for i in 0..<(cap + 10) {
+            channel.append([entry("t\(i)")])
+        }
+        let drained = channel.drain()
+        // Buffer never exceeds the cap; the 10 OLDEST were dropped.
+        #expect(drained.count == cap)
+        #expect(channel.droppedCount == 10)
+        // The freshest entries are retained (drop-oldest): first kept is t10,
+        // last is t<cap+9>.
+        #expect(drained.first?.token == "t10")
+        #expect(drained.last?.token == "t\(cap + 9)")
+    }
+
+    @Test("under the cap nothing is dropped; drain empties the buffer")
+    func channelUnderCapNoDrops() {
+        let channel = EngineV2LogprobsChannel()
+        for i in 0..<100 { channel.append([entry("t\(i)")]) }
+        #expect(channel.droppedCount == 0)
+        #expect(channel.drain().count == 100)
+        #expect(channel.drain().isEmpty)
     }
 }

--- a/provider-swift/Tests/ProviderCoreTests/EngineV2ProductionWiringTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/EngineV2ProductionWiringTests.swift
@@ -621,6 +621,81 @@ struct EngineV2MultiSlotCapacityTests {
         #expect(UInt64(capA + capB) == fleetBudget)
     }
 
+    @Test("pure sizing honors memory_reserve_gb in both regimes (round-3 PR#499 P2)")
+    func pureSizingHonorsMemoryReserve() {
+        // 32 GiB box: cap = 0.9 × 32 = 28.8 GiB ⇒ cap-implied reserve 3.2 GiB.
+        let physical = 32 * Self.gib
+        let weights = Int(8 * Self.gib)
+        let unreserved = EngineV2KVSizing.engineKVBytesCapacity(
+            newModelWeightBytes: weights, coResidentWeightBytes: 0,
+            existingEngineKVCapacities: [], physicalBytes: physical)
+        // Regime 1 — reserve BELOW the cap-implied reserve (2 GiB < 3.2 GiB):
+        // the cap already holds back more; the configured reserve is a no-op.
+        #expect(EngineV2KVSizing.engineKVBytesCapacity(
+            newModelWeightBytes: weights, coResidentWeightBytes: 0,
+            existingEngineKVCapacities: [], configReserveBytes: 2 * Self.gib,
+            physicalBytes: physical) == unreserved)
+        // Regime 2 — reserve ABOVE the cap-implied reserve (the DEFAULT
+        // memory_reserve_gb of 4 GiB on a 32 GiB box): the effective cap
+        // drops to physical − reserve = 28 GiB, the same hold-back the
+        // shared KV gate and the load gate apply, so the v2 ceiling can no
+        // longer advertise capacity the shared gate would reject.
+        let reserved = EngineV2KVSizing.engineKVBytesCapacity(
+            newModelWeightBytes: weights, coResidentWeightBytes: 0,
+            existingEngineKVCapacities: [], configReserveBytes: 4 * Self.gib,
+            physicalBytes: physical)
+        #expect(reserved < unreserved)
+        #expect(UInt64(reserved) == UnifiedMemoryCap.kvBudgetBytes(
+            physicalBytes: physical, residentWeightBytes: UInt64(weights),
+            configReserveBytes: 4 * Self.gib))
+        // Exact delta: the cap shrank by (configReserve − capImplied).
+        let cap = UnifiedMemoryCap.hardCapBytes(physicalBytes: physical)
+        let capImplied = physical - cap
+        #expect(UInt64(unreserved - reserved) == 4 * Self.gib - capImplied)
+    }
+
+    @Test("live budget clamp: a later load shrinks the REPORTED budget, never the grant")
+    func liveBudgetClampTracksFleetResidency() {
+        let physical = 64 * Self.gib
+        let wA = Int(8 * Self.gib)
+        let grantA = EngineV2KVSizing.engineKVBytesCapacity(
+            newModelWeightBytes: wA, coResidentWeightBytes: 0,
+            existingEngineKVCapacities: [], physicalBytes: physical)
+        // Nothing changed since construction ⇒ the current answer IS the
+        // grant (no spurious shrink, and never inflation past the grant).
+        #expect(EngineV2KVSizing.liveEngineKVBytesBudget(
+            grantedKVBytesCapacity: grantA,
+            totalResidentWeightBytes: UInt64(wA),
+            otherEngineKVCapacities: [], physicalBytes: physical) == grantA)
+        // A 12 GiB LEGACY model loads later (subtracts nothing from any v2
+        // grant): the reported budget shrinks by exactly its weights.
+        let wB = 12 * Self.gib
+        #expect(EngineV2KVSizing.liveEngineKVBytesBudget(
+            grantedKVBytesCapacity: grantA,
+            totalResidentWeightBytes: UInt64(wA) + wB,
+            otherEngineKVCapacities: [], physicalBytes: physical)
+            == grantA - Int(wB))
+        // A co-resident v2 engine's construction grant comes off the top the
+        // same way the sizing pass subtracted it.
+        let grantC = Int(4 * Self.gib)
+        #expect(EngineV2KVSizing.liveEngineKVBytesBudget(
+            grantedKVBytesCapacity: grantA,
+            totalResidentWeightBytes: UInt64(wA) + wB,
+            otherEngineKVCapacities: [grantC], physicalBytes: physical)
+            == grantA - Int(wB) - grantC)
+        // Fleet growth past the budget clamps to 0, never negative.
+        #expect(EngineV2KVSizing.liveEngineKVBytesBudget(
+            grantedKVBytesCapacity: grantA,
+            totalResidentWeightBytes: physical,
+            otherEngineKVCapacities: [], physicalBytes: physical) == 0)
+        // The clamp can only ever SHRINK the report: with fleet residency
+        // BELOW construction-time reality the grant still bounds the report.
+        #expect(EngineV2KVSizing.liveEngineKVBytesBudget(
+            grantedKVBytesCapacity: grantA,
+            totalResidentWeightBytes: 0,
+            otherEngineKVCapacities: [], physicalBytes: physical) == grantA)
+    }
+
     @Test("pure sizing: degenerate inputs clamp to zero, never trap")
     func pureSizingDegenerateInputs() {
         // Grants already exceed the budget → 0, not negative.
@@ -690,17 +765,97 @@ struct EngineV2MultiSlotCapacityTests {
         // A was sized alone; B's ceiling subtracts A's weights AND A's
         // construction-fixed grant — the exact fleet-aware derivation
         // (computed here with the same pure helper on this machine's
-        // physical memory, so the assertion is machine-independent).
+        // physical memory, so the assertion is machine-independent). The
+        // loop's configured memory_reserve_gb (1 GiB in makeWiringLoop)
+        // threads into the derivation too (round-3 PR#499 P2).
         #expect(granted[0] == EngineV2KVSizing.engineKVBytesCapacity(
             newModelWeightBytes: weightsA, coResidentWeightBytes: 0,
-            existingEngineKVCapacities: []))
+            existingEngineKVCapacities: [], configReserveBytes: 1 * Self.gib))
         #expect(granted[1] == EngineV2KVSizing.engineKVBytesCapacity(
             newModelWeightBytes: weightsB,
             coResidentWeightBytes: UInt64(weightsA),
-            existingEngineKVCapacities: [granted[0]]))
+            existingEngineKVCapacities: [granted[0]],
+            configReserveBytes: 1 * Self.gib))
         // And the fleet invariant: B's grant never lets the pair exceed the
         // budget A was granted under.
         #expect(granted[1] <= max(0, granted[0] - weightsB))
+    }
+
+    @Test("heartbeat budget max shrinks when a second slot's weights register later (round-3 PR#499 P2)")
+    func heartbeatBudgetShrinksWhenSecondSlotLoads() async throws {
+        let loop = try makeWiringLoop(engineV2Enabled: true)
+        let runtime = EngineV2Runtime()
+        await loop.setEngineV2RuntimeForTesting(runtime)
+        let recorder = CapacityRecorder()
+        await loop.setEngineV2SlotHooksForTesting(
+            ProviderLoop.EngineV2SlotHooks(
+                environment: ["DARKBLOOM_ENGINE_V2": "1"],
+                eosTokenIds: [2],
+                makeEngine: { _, kvBytesCapacity in
+                    recorder.record(kvBytesCapacity)
+                    // The engine reports its construction grant back in the
+                    // capacity snapshot, exactly like the production engine.
+                    return CapacityReportingEngine(kvBytesCapacity: kvBytesCapacity)
+                }))
+
+        // Slot A: v2-served, 1 GiB of weights, a known per-token KV rate so
+        // the heartbeat derives token budgets (bytes / rate).
+        let rate = 4096
+        let weightsA = Int(1 * Self.gib)
+        let schedulerA = BatchScheduler()
+        await schedulerA._setModelWeightBytesForTest(weightsA)
+        await schedulerA._setKVRatesForTest(kvBytesPerToken: rate, fp16KVBytesPerToken: rate)
+        let bridgeA = try #require(await loop.makeEngineV2BridgeForSlotForTesting(
+            modelId: "gemma-4-27b-it",
+            modelType: "gemma4_text",
+            container: makeStubContainer(),
+            tokenizer: TokenizerHandle(WiringStubTokenizer()),
+            scheduler: schedulerA))
+        await loop.installModelSlotForTesting(
+            modelId: "gemma-4-27b-it",
+            scheduler: schedulerA,
+            container: makeStubContainer(),
+            tokenizer: TokenizerHandle(WiringStubTokenizer()),
+            engineV2: bridgeA,
+            modelType: "gemma4_text")
+
+        func v2BudgetMax() async throws -> Int64 {
+            await loop.updateAggregateCapacity()
+            let capacity = try #require(await loop.backendCapacityForTesting())
+            let slot = try #require(
+                capacity.slots.first(where: { $0.model == "gemma-4-27b-it" }))
+            return slot.activeTokenBudgetMax
+        }
+
+        // Alone on the box the heartbeat reports the construction grant.
+        let grant = try #require(recorder.granted.first)
+        let before = try await v2BudgetMax()
+        #expect(before == Int64(grant / rate))
+
+        // A second slot's weights register LATER — a LEGACY (non-v2) slot,
+        // which subtracts nothing from A's construction-fixed ceiling. The
+        // heartbeat must nonetheless reflect fleet reality: the reported max
+        // shrinks by exactly the newcomer's weights (in tokens), while A's
+        // engine keeps its private grant.
+        let weightsB = Int(2 * Self.gib)
+        let schedulerB = BatchScheduler()
+        await schedulerB._setModelWeightBytesForTest(weightsB)
+        await loop.installModelSlotForTesting(
+            modelId: "gpt-oss-20b",
+            scheduler: schedulerB,
+            container: makeStubContainer(),
+            tokenizer: TokenizerHandle(WiringStubTokenizer()),
+            engineV2: nil,
+            modelType: "gpt_oss")
+
+        let after = try await v2BudgetMax()
+        // weightsB is a whole multiple of the rate, so the integer-division
+        // shrink is exact: wB / rate tokens.
+        #expect(before - after == Int64(weightsB / rate))
+        #expect(after < before)
+        // The clamp is heartbeat-side only: the engine's own snapshot still
+        // carries the construction grant.
+        #expect(await bridgeA.engineKVBytesCapacity() == grant)
     }
 }
 

--- a/provider-swift/Tests/ProviderCoreTests/EngineV2ProductionWiringTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/EngineV2ProductionWiringTests.swift
@@ -413,6 +413,19 @@ struct EngineV2SlotFactoryTests {
         }
     }
 
+    @Test("kvBytesCapacity clamp: a ceiling above physical RAM is capped (fix #10)")
+    func kvBytesCapacityClamp() {
+        let physical: UInt64 = 16 * 1024 * 1024 * 1024  // 16 GiB
+        // A sane budget passes through untouched.
+        #expect(EngineV2Factory.clampKVBytesCapacity(
+            4 * 1024 * 1024 * 1024, physicalBytes: physical) == 4 * 1024 * 1024 * 1024)
+        // A ceiling larger than physical is clamped to physical.
+        #expect(EngineV2Factory.clampKVBytesCapacity(
+            Int.max, physicalBytes: physical) == Int(physical))
+        // Negative degrades to 0 (the > 0 guard then rejects it upstream).
+        #expect(EngineV2Factory.clampKVBytesCapacity(-1, physicalBytes: physical) == 0)
+    }
+
     @Test("kv_quant off: bridge sized at the scheduler rate, no kv_quant WARN")
     func kvQuantOffNoWarn() async throws {
         let loop = try makeWiringLoop(engineV2Enabled: true)

--- a/provider-swift/Tests/ProviderCoreTests/EngineV2ProductionWiringTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/EngineV2ProductionWiringTests.swift
@@ -413,6 +413,80 @@ struct EngineV2SlotFactoryTests {
         }
     }
 
+    @Test("kv_quant off: bridge sized at the scheduler rate, no kv_quant WARN")
+    func kvQuantOffNoWarn() async throws {
+        let loop = try makeWiringLoop(engineV2Enabled: true)
+        let runtime = EngineV2Runtime()
+        let telemetry = WiringTelemetrySink()
+        let engine = WiringScriptedEngine(script: .manual)
+        await loop.setEngineV2RuntimeForTesting(runtime)
+        await loop.setEngineV2SlotHooksForTesting(
+            ProviderLoop.EngineV2SlotHooks(
+                environment: ["DARKBLOOM_ENGINE_V2": "1"],
+                eosTokenIds: [2],
+                emitTelemetry: telemetry.callback(),
+                makeEngine: { _ in engine }))
+
+        // Rates equal ⇒ kv_quant not engaged.
+        let scheduler = BatchScheduler()
+        await scheduler._setKVRatesForTest(
+            kvBytesPerToken: 400_000, fp16KVBytesPerToken: 400_000)
+        let bridge = await loop.makeEngineV2BridgeForSlotForTesting(
+            modelId: "gemma-4-27b-it",
+            modelType: "gemma4_text",
+            container: makeStubContainer(),
+            tokenizer: TokenizerHandle(WiringStubTokenizer()),
+            scheduler: scheduler
+        )
+        _ = try #require(bridge)
+        // No kv_quant WARN fired.
+        #expect(telemetry.events.allSatisfy {
+            $0.fields?["operation"]?.description != "engine_v2_kv_quant_unsupported"
+        })
+    }
+
+    @Test("kv_quant on: WARN engine_v2_kv_quant_unsupported + fp16 sizing")
+    func kvQuantOnWarnsAndSizesFP16() async throws {
+        let loop = try makeWiringLoop(engineV2Enabled: true)
+        let runtime = EngineV2Runtime()
+        let telemetry = WiringTelemetrySink()
+        // A stream so the bridge admits + heartbeats; the capacity math uses
+        // the fp16 rate the factory chose.
+        let engine = WiringScriptedEngine(script: .manual)
+        await loop.setEngineV2RuntimeForTesting(runtime)
+        await loop.setEngineV2SlotHooksForTesting(
+            ProviderLoop.EngineV2SlotHooks(
+                environment: ["DARKBLOOM_ENGINE_V2": "1"],
+                eosTokenIds: [2],
+                emitTelemetry: telemetry.callback(),
+                makeEngine: { _ in engine }))
+
+        // Quantized rate below fp16 ⇒ kv_quant engaged for this model.
+        let scheduler = BatchScheduler()
+        await scheduler._setKVRatesForTest(
+            kvBytesPerToken: 100_000, fp16KVBytesPerToken: 400_000)
+        let bridge = try #require(await loop.makeEngineV2BridgeForSlotForTesting(
+            modelId: "gemma-4-27b-it",
+            modelType: "gemma4_text",
+            container: makeStubContainer(),
+            tokenizer: TokenizerHandle(WiringStubTokenizer()),
+            scheduler: scheduler
+        ))
+        // WARN fired with allowlisted fields.
+        let warn = telemetry.events.first {
+            $0.fields?["operation"]?.description == "engine_v2_kv_quant_unsupported"
+        }
+        #expect(warn != nil)
+        #expect(warn?.severity == .warn)
+        #expect(warn?.kind == .engineHealth)
+        #expect(warn?.fields?["backend"]?.description == "engine_v2")
+        #expect(warn?.fields?["model"]?.description == "gemma-4-27b-it")
+        // The bridge was sized at the fp16 rate (400_000), not the quantized
+        // 100_000: the heartbeat slot reports kvBytesPerToken == fp16.
+        let slot = await bridge.backendSlotCapacity()
+        #expect(slot.kvBytesPerToken == 400_000)
+    }
+
     @Test("engine init failure: legacy fallback + WARN engine_v2_fallback telemetry")
     func initFailureFallsBackWithTelemetry() async throws {
         struct InitFailure: Error {}

--- a/provider-swift/Tests/ProviderCoreTests/EngineV2ProductionWiringTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/EngineV2ProductionWiringTests.swift
@@ -520,6 +520,36 @@ struct EngineV2RequestRoutingTests {
         #expect(entries[0].logprob == -0.25)
     }
 
+    @Test("coordinator path threads sealed-body logit_bias and seed into the engine")
+    func coordinatorPathThreadsSamplingOverrides() async throws {
+        let engine = WiringScriptedEngine(script: .stream([
+            .delta(text: "Hello", tokens: [10], logprobs: nil),
+            .finished(reason: .stop, usage: CBv2Usage(promptTokens: 5, completionTokens: 1)),
+        ]))
+        let bridge = makeBridge(engine: engine)
+        let providerEngine = MultiModelBatchSchedulerEngine(
+            registryProvider: { @Sendable in
+                [
+                    "gemma-4-27b-it": .init(
+                        scheduler: BatchScheduler(),
+                        tokenizer: TokenizerHandle(WiringStubTokenizer()),
+                        modelType: "gemma4_text",
+                        engineV2Bridge: bridge)
+                ]
+            },
+            // The shape `ProviderLoop.extractSamplingOverrides` produces from
+            // a sealed body carrying {"logit_bias":{"7":-100,"junk":1},"seed":42}.
+            engineV2Sampling: EngineV2SamplingOverrides(
+                logitBias: ["7": -100, "junk": 1], seed: 42)
+        )
+        let stream = try await providerEngine.streamChatCompletion(request: makeOpenAIRequest())
+        _ = try await recordServerStream(stream)
+        #expect(engine.submitted.count == 1)
+        // Parsed bias reached the engine ("junk" dropped, never guessed).
+        #expect(engine.submitted[0].sampling.logitBias == [7: -100])
+        #expect(engine.submitted[0].sampling.seed == 42)
+    }
+
     @Test("local-endpoint acquire path routes through the bridge and releases the token")
     func localAcquirePathRoutesThroughBridge() async throws {
         let engine = WiringScriptedEngine(script: .stream([

--- a/provider-swift/Tests/ProviderCoreTests/EngineV2ProductionWiringTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/EngineV2ProductionWiringTests.swift
@@ -311,7 +311,12 @@ struct EngineV2SlotFactoryTests {
         await loop.setEngineV2RuntimeForTesting(runtime)
         await loop.setEngineV2SlotHooksForTesting(
             ProviderLoop.EngineV2SlotHooks(
-                environment: ["DARKBLOOM_ENGINE_V2": "1"],
+                environment: [
+                    "DARKBLOOM_ENGINE_V2": "1",
+                    // The default allowlist is now the exact prod checkpoint ids;
+                    // these wiring fixtures use family-glob test ids, so widen it.
+                    "DARKBLOOM_ENGINE_V2_MODELS": "gemma-4*,gpt-oss*",
+                ],
                 eosTokenIds: [2],
                 makeEngine: { _, _ in engine }))
 
@@ -340,7 +345,7 @@ struct EngineV2SlotFactoryTests {
             case .chunk(let text):
                 #expect(text == "Hello")
                 sawChunk = true
-            case .info(let prompt, let completion, _):
+            case .info(let prompt, let completion, _, _):
                 #expect(prompt == 5)
                 #expect(completion == 1)
                 sawInfo = true
@@ -364,7 +369,12 @@ struct EngineV2SlotFactoryTests {
         await loop.setEngineV2RuntimeForTesting(runtime)
         await loop.setEngineV2SlotHooksForTesting(
             ProviderLoop.EngineV2SlotHooks(
-                environment: ["DARKBLOOM_ENGINE_V2": "1"],
+                environment: [
+                    "DARKBLOOM_ENGINE_V2": "1",
+                    // The default allowlist is now the exact prod checkpoint ids;
+                    // these wiring fixtures use family-glob test ids, so widen it.
+                    "DARKBLOOM_ENGINE_V2_MODELS": "gemma-4*,gpt-oss*",
+                ],
                 emitTelemetry: telemetry.callback(),
                 makeEngine: { _, _ in
                     counter.increment()
@@ -435,7 +445,12 @@ struct EngineV2SlotFactoryTests {
         await loop.setEngineV2RuntimeForTesting(runtime)
         await loop.setEngineV2SlotHooksForTesting(
             ProviderLoop.EngineV2SlotHooks(
-                environment: ["DARKBLOOM_ENGINE_V2": "1"],
+                environment: [
+                    "DARKBLOOM_ENGINE_V2": "1",
+                    // The default allowlist is now the exact prod checkpoint ids;
+                    // these wiring fixtures use family-glob test ids, so widen it.
+                    "DARKBLOOM_ENGINE_V2_MODELS": "gemma-4*,gpt-oss*",
+                ],
                 eosTokenIds: [2],
                 emitTelemetry: telemetry.callback(),
                 makeEngine: { _, _ in engine }))
@@ -469,7 +484,12 @@ struct EngineV2SlotFactoryTests {
         await loop.setEngineV2RuntimeForTesting(runtime)
         await loop.setEngineV2SlotHooksForTesting(
             ProviderLoop.EngineV2SlotHooks(
-                environment: ["DARKBLOOM_ENGINE_V2": "1"],
+                environment: [
+                    "DARKBLOOM_ENGINE_V2": "1",
+                    // The default allowlist is now the exact prod checkpoint ids;
+                    // these wiring fixtures use family-glob test ids, so widen it.
+                    "DARKBLOOM_ENGINE_V2_MODELS": "gemma-4*,gpt-oss*",
+                ],
                 eosTokenIds: [2],
                 emitTelemetry: telemetry.callback(),
                 makeEngine: { _, _ in engine }))
@@ -514,7 +534,7 @@ struct EngineV2SlotFactoryTests {
                 makeEngine: { _, _ in throw InitFailure() }))
 
         let bridge = await loop.makeEngineV2BridgeForSlotForTesting(
-            modelId: "gpt-oss-20b",
+            modelId: "mlx-community/gpt-oss-20b-MXFP4-Q8",
             modelType: "gpt_oss",
             container: makeStubContainer(),
             tokenizer: TokenizerHandle(WiringStubTokenizer()),
@@ -522,7 +542,7 @@ struct EngineV2SlotFactoryTests {
         )
         #expect(bridge == nil)
         // Nothing registered — the slot serves legacy.
-        #expect(await runtime.bridge(forModel: "gpt-oss-20b") == nil)
+        #expect(await runtime.bridge(forModel: "mlx-community/gpt-oss-20b-MXFP4-Q8") == nil)
         let events = telemetry.events
         #expect(events.count == 1)
         #expect(events.first?.kind == .engineHealth)
@@ -724,7 +744,12 @@ struct EngineV2MultiSlotCapacityTests {
         let recorder = CapacityRecorder()
         await loop.setEngineV2SlotHooksForTesting(
             ProviderLoop.EngineV2SlotHooks(
-                environment: ["DARKBLOOM_ENGINE_V2": "1"],
+                environment: [
+                    "DARKBLOOM_ENGINE_V2": "1",
+                    // The default allowlist is now the exact prod checkpoint ids;
+                    // these wiring fixtures use family-glob test ids, so widen it.
+                    "DARKBLOOM_ENGINE_V2_MODELS": "gemma-4*,gpt-oss*",
+                ],
                 eosTokenIds: [2],
                 makeEngine: { _, kvBytesCapacity in
                     recorder.record(kvBytesCapacity)
@@ -789,7 +814,12 @@ struct EngineV2MultiSlotCapacityTests {
         let recorder = CapacityRecorder()
         await loop.setEngineV2SlotHooksForTesting(
             ProviderLoop.EngineV2SlotHooks(
-                environment: ["DARKBLOOM_ENGINE_V2": "1"],
+                environment: [
+                    "DARKBLOOM_ENGINE_V2": "1",
+                    // The default allowlist is now the exact prod checkpoint ids;
+                    // these wiring fixtures use family-glob test ids, so widen it.
+                    "DARKBLOOM_ENGINE_V2_MODELS": "gemma-4*,gpt-oss*",
+                ],
                 eosTokenIds: [2],
                 makeEngine: { _, kvBytesCapacity in
                     recorder.record(kvBytesCapacity)

--- a/provider-swift/Tests/ProviderCoreTests/EngineV2ProductionWiringTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/EngineV2ProductionWiringTests.swift
@@ -1,0 +1,686 @@
+// Copyright © 2026 Eigen Labs.
+//
+// ContinuousBatchingV2 PRODUCTION-WIRING tests — live-isolated style:
+// scripted in-process `CBv2Engine` stubs, a fabricated `ModelContainer`
+// over a stub `LanguageModel`, isolated `EngineV2Runtime` instances.
+// No model weights, no network, no prod anything.
+//
+// Covers the P1 integration gap (bridge implemented but never
+// instantiated on production paths):
+//
+//   * Slot factory (`ProviderLoop.makeEngineV2BridgeForSlot`, the
+//     `ensureModelLoaded` call site): flag-on + allowlisted model builds
+//     a bridge via the factory seam AND registers it with the runtime;
+//     flag-off / non-allowlisted returns nil without invoking the builder
+//     or consulting the runtime; init failure falls back to legacy with
+//     the WARN `engine_v2_fallback` telemetry event.
+//   * Request routing (`MultiModelBatchSchedulerEngine`): both production
+//     inits — the registryProvider shape used by the coordinator
+//     inference handler and the atomic-acquire shape used by the local
+//     endpoint — route generation through the bridge when present and
+//     return the translated stream; the legacy scheduler path is
+//     untouched when no bridge exists.
+//   * Zero-overhead guards: `updateAggregateCapacity` and
+//     `handleCancellation` consult the `EngineV2Runtime` ONLY when at
+//     least one v2 slot exists (assert zero runtime consults flag-off);
+//     with a v2 slot, capacity folds the bridge slot into the heartbeat
+//     payload and cancellation fans out to the owning engine.
+
+import Foundation
+import MLX
+import MLXLMCommon
+import MLXLMServer
+import MLXNN
+import Testing
+
+@testable import ProviderCore
+
+// MARK: - Scripted CBv2Engine stub (same shape as EngineV2BridgeTests)
+
+private final class WiringScriptedEngine: CBv2Engine, @unchecked Sendable {
+    enum Script {
+        case throwOnSubmit(any Error)
+        case stream([CBv2Event])
+        case manual
+    }
+
+    private let lock = NSLock()
+    private let script: Script
+    private var _submitted: [CBv2Request] = []
+    private var _cancelled: [CBv2RequestID] = []
+    private var _shutdownCalls = 0
+    private var _manualContinuation: AsyncStream<CBv2Event>.Continuation?
+
+    init(script: Script) {
+        self.script = script
+    }
+
+    var submitted: [CBv2Request] { lock.withLock { _submitted } }
+    var cancelled: [CBv2RequestID] { lock.withLock { _cancelled } }
+    var shutdownCalls: Int { lock.withLock { _shutdownCalls } }
+    var manualContinuation: AsyncStream<CBv2Event>.Continuation? {
+        lock.withLock { _manualContinuation }
+    }
+
+    func submit(_ request: CBv2Request) throws -> AsyncStream<CBv2Event> {
+        let script = lock.withLock { () -> Script in
+            _submitted.append(request)
+            return self.script
+        }
+        switch script {
+        case .throwOnSubmit(let error):
+            throw error
+        case .stream(let events):
+            let (stream, continuation) = AsyncStream<CBv2Event>.makeStream()
+            for event in events { continuation.yield(event) }
+            continuation.finish()
+            return stream
+        case .manual:
+            let (stream, continuation) = AsyncStream<CBv2Event>.makeStream()
+            lock.withLock { _manualContinuation = continuation }
+            return stream
+        }
+    }
+
+    func cancel(_ id: CBv2RequestID) {
+        lock.withLock { _cancelled.append(id) }
+    }
+
+    func capacity() -> CBv2CapacitySnapshot {
+        let running = lock.withLock { _submitted.count - _cancelled.count }
+        return CBv2CapacitySnapshot(
+            activeRequests: max(0, running), waitingRequests: 0,
+            kvBytesInUse: 0, kvBytesCapacity: 0, activeTokens: 0)
+    }
+
+    func shutdown() async {
+        lock.withLock { _shutdownCalls += 1 }
+    }
+}
+
+// MARK: - Stub tokenizer / language model / container
+
+private struct WiringStubTokenizer: MLXLMCommon.Tokenizer {
+    var templateTokens: [Int] = [1, 2, 3, 4, 5]
+
+    func encode(text: String, addSpecialTokens: Bool) -> [Int] {
+        Array(repeating: 0, count: text.count)
+    }
+    func decode(tokenIds: [Int], skipSpecialTokens: Bool) -> String { "" }
+    func convertTokenToId(_ token: String) -> Int? { ["</s>": 2][token] }
+    func convertIdToToken(_ id: Int) -> String? { nil }
+    var bosToken: String? { nil }
+    var eosToken: String? { "</s>" }
+    var unknownToken: String? { nil }
+
+    func applyChatTemplate(
+        messages: [[String: any Sendable]],
+        tools: [[String: any Sendable]]?,
+        additionalContext: [String: any Sendable]?
+    ) throws -> [Int] {
+        templateTokens
+    }
+}
+
+/// Minimal `LanguageModel` so a real `ModelContainer` can exist in tests.
+/// Never forward-passed: the slot-factory tests run with hooks installed
+/// (container snapshot skipped) and the routing tests never touch it.
+private final class WiringStubLanguageModel: Module, LanguageModel {
+    func prepare(_ input: LMInput, cache: [KVCache], windowSize: Int?) throws -> PrepareResult {
+        .tokens(input.text)
+    }
+    func newCache(parameters: GenerateParameters?) -> [KVCache] { [] }
+}
+
+private struct WiringStubProcessorError: Error {}
+
+private struct WiringStubProcessor: UserInputProcessor {
+    func prepare(input: UserInput) async throws -> LMInput {
+        throw WiringStubProcessorError()
+    }
+}
+
+private func makeStubContainer() -> ModelContainer {
+    ModelContainer(
+        context: ModelContext(
+            configuration: ModelConfiguration(id: "test/stub-model"),
+            model: WiringStubLanguageModel(),
+            processor: WiringStubProcessor(),
+            tokenizer: WiringStubTokenizer()
+        ))
+}
+
+// MARK: - Telemetry capture
+
+private final class WiringTelemetrySink: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _events: [TelemetryEvent] = []
+    var events: [TelemetryEvent] { lock.withLock { _events } }
+    func callback() -> @Sendable (TelemetryEvent) -> Void {
+        { [weak self] event in
+            guard let self else { return }
+            self.lock.withLock { self._events.append(event) }
+        }
+    }
+}
+
+// MARK: - Builder-call counter
+
+private final class BuilderCallCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _calls = 0
+    var calls: Int { lock.withLock { _calls } }
+    func increment() { lock.withLock { _calls += 1 } }
+}
+
+// MARK: - Shared builders
+
+private func makeWiringLoop(engineV2Enabled: Bool = false) throws -> ProviderLoop {
+    let config = ProviderLoopConfig(
+        coordinatorURL: "ws://127.0.0.1:0/ignored",
+        hardware: HardwareInfo(
+            machineModel: "Mac16,5", chipName: "Apple M4 Max", chipFamily: .m4, chipTier: .max,
+            memoryGb: 128, memoryAvailableGb: 124,
+            cpuCores: CpuCores(total: 16, performance: 12, efficiency: 4),
+            gpuCores: 40, memoryBandwidthGbs: 546
+        ),
+        models: [],
+        config: ProviderConfig(
+            provider: ProviderSettings(name: "engine-v2-wiring-test", memoryReserveGB: 1),
+            backend: BackendSettings(
+                continuousBatching: true, idleTimeoutMins: 0, maxModelSlots: 2,
+                engineV2: engineV2Enabled),
+            coordinator: CoordinatorSettings(heartbeatIntervalSecs: 60)
+        )
+    )
+    return try ProviderLoop(config: config, purgeLegacyFiles: false, attestationSigner: nil)
+}
+
+private func makeBridge(
+    engine: WiringScriptedEngine,
+    modelId: String = "gemma-4-27b-it"
+) -> EngineV2Bridge {
+    EngineV2Bridge(
+        engine: engine,
+        modelId: modelId,
+        tokenizer: TokenizerHandle(WiringStubTokenizer()),
+        eosTokenIds: [2]
+    )
+}
+
+private func makeOpenAIRequest(model: String = "gemma-4-27b-it") -> OpenAIChatCompletionRequest {
+    OpenAIChatCompletionRequest(
+        model: model,
+        messages: [OpenAIChatMessage(role: .user, content: .text("hi"))]
+    )
+}
+
+/// Collect a server-engine event stream into a comparable shape.
+private enum RecordedServerEvent: Equatable {
+    case content(String)
+    case info(prompt: Int, completion: Int)
+}
+
+private func recordServerStream(
+    _ stream: AsyncThrowingStream<MLXServerGenerationEvent, Error>
+) async throws -> [RecordedServerEvent] {
+    var events: [RecordedServerEvent] = []
+    for try await event in stream {
+        switch event {
+        case .content(let text):
+            events.append(.content(text))
+        case .info(let info):
+            events.append(.info(prompt: info.promptTokens, completion: info.completionTokens))
+        case .toolCall:
+            continue
+        }
+    }
+    return events
+}
+
+// MARK: - Slot factory (the ensureModelLoaded call site)
+
+@Suite("EngineV2 production wiring: model-load slot factory")
+struct EngineV2SlotFactoryTests {
+
+    @Test("flag off: no bridge, builder never invoked, runtime never consulted")
+    func flagOffBuildsNothing() async throws {
+        let loop = try makeWiringLoop(engineV2Enabled: false)
+        let runtime = EngineV2Runtime()
+        let counter = BuilderCallCounter()
+        await loop.setEngineV2RuntimeForTesting(runtime)
+        await loop.setEngineV2SlotHooksForTesting(
+            ProviderLoop.EngineV2SlotHooks(
+                environment: [:],
+                makeEngine: { _ in
+                    counter.increment()
+                    return WiringScriptedEngine(script: .manual)
+                }))
+
+        let bridge = await loop.makeEngineV2BridgeForSlotForTesting(
+            modelId: "gemma-4-27b-it",
+            modelType: "gemma4_text",
+            container: makeStubContainer(),
+            tokenizer: TokenizerHandle(WiringStubTokenizer()),
+            scheduler: BatchScheduler()
+        )
+        #expect(bridge == nil)
+        #expect(counter.calls == 0)
+        #expect(await runtime.bridge(forModel: "gemma-4-27b-it") == nil)
+        #expect(await runtime.consultCount == 0)
+    }
+
+    @Test("flag on + non-allowlisted model: legacy, builder never invoked")
+    func flagOnNonAllowlistedStaysLegacy() async throws {
+        let loop = try makeWiringLoop(engineV2Enabled: true)
+        let runtime = EngineV2Runtime()
+        let counter = BuilderCallCounter()
+        await loop.setEngineV2RuntimeForTesting(runtime)
+        await loop.setEngineV2SlotHooksForTesting(
+            ProviderLoop.EngineV2SlotHooks(
+                environment: [:],
+                makeEngine: { _ in
+                    counter.increment()
+                    return WiringScriptedEngine(script: .manual)
+                }))
+
+        let bridge = await loop.makeEngineV2BridgeForSlotForTesting(
+            modelId: "qwen3-8b",
+            modelType: "qwen3",
+            container: makeStubContainer(),
+            tokenizer: TokenizerHandle(WiringStubTokenizer()),
+            scheduler: BatchScheduler()
+        )
+        #expect(bridge == nil)
+        #expect(counter.calls == 0)
+        #expect(await runtime.bridge(forModel: "qwen3-8b") == nil)
+    }
+
+    @Test("flag on + allowlisted model: builds, registers, and streams translated events")
+    func flagOnAllowlistedBuildsRegistersAndStreams() async throws {
+        let loop = try makeWiringLoop(engineV2Enabled: false)  // env flag wins
+        let runtime = EngineV2Runtime()
+        let engine = WiringScriptedEngine(script: .stream([
+            .delta(text: "Hello", tokens: [10], logprobs: nil),
+            .finished(reason: .stop, usage: CBv2Usage(promptTokens: 5, completionTokens: 1)),
+        ]))
+        await loop.setEngineV2RuntimeForTesting(runtime)
+        await loop.setEngineV2SlotHooksForTesting(
+            ProviderLoop.EngineV2SlotHooks(
+                environment: ["DARKBLOOM_ENGINE_V2": "1"],
+                eosTokenIds: [2],
+                makeEngine: { _ in engine }))
+
+        let bridge = await loop.makeEngineV2BridgeForSlotForTesting(
+            modelId: "gemma-4-27b-it",
+            modelType: "gemma4_text",
+            container: makeStubContainer(),
+            tokenizer: TokenizerHandle(WiringStubTokenizer()),
+            scheduler: BatchScheduler()
+        )
+        let unwrapped = try #require(bridge)
+
+        // Registered with the runtime BEFORE the slot goes live.
+        #expect(await runtime.bridge(forModel: "gemma-4-27b-it") === unwrapped)
+
+        // The bridge streams the translated events (legacy GenerationEvent
+        // framing) from the scripted engine.
+        var sawChunk = false
+        var sawInfo = false
+        let stream = await unwrapped.submit(
+            request: ChatCompletionRequest(
+                model: "gemma-4-27b-it",
+                messages: [ChatMessage(role: "user", content: "hi")]))
+        for await event in stream {
+            switch event {
+            case .chunk(let text):
+                #expect(text == "Hello")
+                sawChunk = true
+            case .info(let prompt, let completion, _):
+                #expect(prompt == 5)
+                #expect(completion == 1)
+                sawInfo = true
+            case .error(let message):
+                Issue.record("unexpected error event: \(message)")
+            }
+        }
+        #expect(sawChunk)
+        #expect(sawInfo)
+        #expect(engine.submitted.count == 1)
+        // Tokenization went through the tokenizer's chat-template path.
+        #expect(engine.submitted[0].promptTokens == [1, 2, 3, 4, 5])
+    }
+
+    @Test("VLM slot: silently legacy even when flag on + name allowlisted (no WARN noise)")
+    func vlmSlotStaysLegacySilently() async throws {
+        let loop = try makeWiringLoop(engineV2Enabled: true)
+        let runtime = EngineV2Runtime()
+        let counter = BuilderCallCounter()
+        let telemetry = WiringTelemetrySink()
+        await loop.setEngineV2RuntimeForTesting(runtime)
+        await loop.setEngineV2SlotHooksForTesting(
+            ProviderLoop.EngineV2SlotHooks(
+                environment: ["DARKBLOOM_ENGINE_V2": "1"],
+                emitTelemetry: telemetry.callback(),
+                makeEngine: { _ in
+                    counter.increment()
+                    return WiringScriptedEngine(script: .manual)
+                }))
+
+        // Name matches the gemma-4* allowlist, but the slot is a VLM — the
+        // loaded module is a vision wrapper the v2 engine can never serve,
+        // so this must be a SILENT legacy fallback (no per-load WARN).
+        let bridge = await loop.makeEngineV2BridgeForSlotForTesting(
+            modelId: "gemma-4-27b-it-vision",
+            modelType: "gemma4",
+            isVLM: true,
+            container: makeStubContainer(),
+            tokenizer: TokenizerHandle(WiringStubTokenizer()),
+            scheduler: BatchScheduler()
+        )
+        #expect(bridge == nil)
+        #expect(counter.calls == 0)
+        #expect(telemetry.events.isEmpty)
+        #expect(await runtime.bridge(forModel: "gemma-4-27b-it-vision") == nil)
+    }
+
+    @Test("production factory: unsupported model class throws (→ fallback)")
+    func productionFactoryRejectsUnsupportedModel() {
+        // A module that is neither Gemma4TextModel nor GPTOSSModel must throw
+        // BEFORE any engine machinery is built — the factory catch turns this
+        // into the WARN fallback.
+        #expect(throws: EngineV2ProductionError.self) {
+            _ = try EngineV2Factory.makeProductionEngine(
+                model: WiringStubLanguageModel(),
+                tokenizer: WiringStubTokenizer(),
+                kvBytesCapacity: 1 << 20
+            )
+        }
+    }
+
+    @Test("production factory: zero KV headroom throws (→ fallback)")
+    func productionFactoryRejectsZeroKVHeadroom() {
+        #expect(throws: EngineV2ProductionError.self) {
+            _ = try EngineV2Factory.makeProductionEngine(
+                model: WiringStubLanguageModel(),
+                tokenizer: WiringStubTokenizer(),
+                kvBytesCapacity: 0
+            )
+        }
+    }
+
+    @Test("engine init failure: legacy fallback + WARN engine_v2_fallback telemetry")
+    func initFailureFallsBackWithTelemetry() async throws {
+        struct InitFailure: Error {}
+        let loop = try makeWiringLoop(engineV2Enabled: true)
+        let runtime = EngineV2Runtime()
+        let telemetry = WiringTelemetrySink()
+        await loop.setEngineV2RuntimeForTesting(runtime)
+        await loop.setEngineV2SlotHooksForTesting(
+            ProviderLoop.EngineV2SlotHooks(
+                environment: [:],
+                emitTelemetry: telemetry.callback(),
+                makeEngine: { _ in throw InitFailure() }))
+
+        let bridge = await loop.makeEngineV2BridgeForSlotForTesting(
+            modelId: "gpt-oss-20b",
+            modelType: "gpt_oss",
+            container: makeStubContainer(),
+            tokenizer: TokenizerHandle(WiringStubTokenizer()),
+            scheduler: BatchScheduler()
+        )
+        #expect(bridge == nil)
+        // Nothing registered — the slot serves legacy.
+        #expect(await runtime.bridge(forModel: "gpt-oss-20b") == nil)
+        let events = telemetry.events
+        #expect(events.count == 1)
+        #expect(events.first?.kind == .engineHealth)
+        #expect(events.first?.severity == .warn)
+        #expect(events.first?.fields?["operation"]?.description == "engine_v2_fallback")
+        #expect(events.first?.fields?["backend"]?.description == "engine_v2")
+        #expect(events.first?.fields?["error_class"]?.description.contains("InitFailure") == true)
+    }
+}
+
+// MARK: - Request routing (inference handler + local endpoint shapes)
+
+@Suite("EngineV2 production wiring: request routing")
+struct EngineV2RequestRoutingTests {
+
+    @Test("coordinator registryProvider path routes through the bridge")
+    func coordinatorPathRoutesThroughBridge() async throws {
+        let engine = WiringScriptedEngine(script: .stream([
+            .delta(text: "Hello", tokens: [10], logprobs: nil),
+            .delta(text: " world", tokens: [11], logprobs: nil),
+            .finished(reason: .stop, usage: CBv2Usage(promptTokens: 5, completionTokens: 2)),
+        ]))
+        let bridge = makeBridge(engine: engine)
+        // The legacy scheduler here has NO model loaded: if routing fell
+        // through to it, the stream would throw "No model loaded" instead
+        // of producing the scripted content below.
+        let providerEngine = MultiModelBatchSchedulerEngine(
+            registryProvider: { @Sendable in
+                [
+                    "gemma-4-27b-it": .init(
+                        scheduler: BatchScheduler(),
+                        tokenizer: TokenizerHandle(WiringStubTokenizer()),
+                        modelType: "gemma4_text",
+                        engineV2Bridge: bridge)
+                ]
+            })
+
+        let stream = try await providerEngine.streamChatCompletion(request: makeOpenAIRequest())
+        let events = try await recordServerStream(stream)
+        #expect(events.dropLast() == [.content("Hello"), .content(" world")])
+        #expect(events.last == .info(prompt: 5, completion: 2))
+        #expect(engine.submitted.count == 1)
+        #expect(engine.submitted[0].promptTokens == [1, 2, 3, 4, 5])
+    }
+
+    @Test("local-endpoint acquire path routes through the bridge and releases the token")
+    func localAcquirePathRoutesThroughBridge() async throws {
+        let engine = WiringScriptedEngine(script: .stream([
+            .delta(text: "local", tokens: [10], logprobs: nil),
+            .finished(reason: .stop, usage: CBv2Usage(promptTokens: 5, completionTokens: 1)),
+        ]))
+        let bridge = makeBridge(engine: engine)
+        let released = BuilderCallCounter()
+        let providerEngine = MultiModelBatchSchedulerEngine(
+            acquire: { modelId in
+                MultiModelBatchSchedulerEngine.AcquiredModel(
+                    scheduler: BatchScheduler(),
+                    tokenizer: TokenizerHandle(WiringStubTokenizer()),
+                    releaseToken: OneShotRelease(
+                        release: { _ in released.increment() }, modelId: modelId),
+                    modelType: "gemma4_text",
+                    engineV2Bridge: bridge)
+            },
+            tokenizerProvider: { _ in TokenizerHandle(WiringStubTokenizer()) },
+            availableModels: { ["gemma-4-27b-it"] }
+        )
+
+        let stream = try await providerEngine.streamChatCompletion(request: makeOpenAIRequest())
+        let events = try await recordServerStream(stream)
+        #expect(events.first == .content("local"))
+        #expect(events.last == .info(prompt: 5, completion: 1))
+        #expect(engine.submitted.count == 1)
+        // The local reservation is dropped exactly once when the stream ends.
+        #expect(released.calls == 1)
+    }
+
+    @Test("no bridge: the legacy scheduler path is taken unchanged")
+    func legacyPathUntouchedWithoutBridge() async throws {
+        let providerEngine = MultiModelBatchSchedulerEngine(
+            registryProvider: { @Sendable in
+                [
+                    "gemma-4-27b-it": .init(
+                        scheduler: BatchScheduler(),
+                        tokenizer: TokenizerHandle(WiringStubTokenizer()),
+                        modelType: "gemma4_text")
+                ]
+            })
+
+        // The model-less scheduler proves the request went to the LEGACY
+        // engine: it fails with its "No model loaded" error, which the v2
+        // bridge could never produce.
+        let stream = try await providerEngine.streamChatCompletion(request: makeOpenAIRequest())
+        await #expect(throws: (any Error).self) {
+            _ = try await recordServerStream(stream)
+        }
+    }
+
+    @Test("cancelling the consumer cancels the engine-minted v2 request id")
+    func cancellationPropagatesToBridge() async throws {
+        let engine = WiringScriptedEngine(script: .manual)
+        let bridge = makeBridge(engine: engine)
+        let providerEngine = MultiModelBatchSchedulerEngine(
+            registryProvider: { @Sendable in
+                [
+                    "gemma-4-27b-it": .init(
+                        scheduler: BatchScheduler(),
+                        tokenizer: TokenizerHandle(WiringStubTokenizer()),
+                        modelType: "gemma4_text",
+                        engineV2Bridge: bridge)
+                ]
+            })
+
+        let stream = try await providerEngine.streamChatCompletion(request: makeOpenAIRequest())
+        let consumer = Task {
+            for try await _ in stream {}
+        }
+        // Wait until the request reaches the engine, then cancel the consumer.
+        for _ in 0..<200 where engine.submitted.isEmpty {
+            try await Task.sleep(for: .milliseconds(5))
+        }
+        #expect(engine.submitted.count == 1)
+        consumer.cancel()
+        _ = try? await consumer.value
+
+        // Task cancellation propagates: outer stream → engine wrapper
+        // (cancelUpstream → bridge.cancel) and/or the bridge stream's own
+        // onTermination — either way the ENGINE-minted id gets cancelled.
+        for _ in 0..<200 where engine.cancelled.isEmpty {
+            try await Task.sleep(for: .milliseconds(5))
+        }
+        #expect(engine.cancelled.first == engine.submitted.first?.id)
+    }
+}
+
+// MARK: - Zero-overhead runtime guards (capacity + cancellation)
+
+/// These tests drive the REAL `updateAggregateCapacity` / `unloadModel`
+/// paths, which read MLX GPU counters — so the mlx.metallib must be
+/// colocated with the test runner. CI places it under `.build` (see
+/// ci.yml "Extract mlx.metallib"); locally run `./scripts/fetch-metallib.sh
+/// debug` once. Mirrors the `LiveInferenceFixtures` pattern.
+@Suite("EngineV2 production wiring: runtime guards", .serialized)
+struct EngineV2RuntimeGuardTests {
+
+    init() {
+        _ = LiveInferenceFixtures.ensureMetallibColocated()
+    }
+
+    @Test("capacity + cancellation never consult the runtime without v2 slots")
+    func flagOffSkipsRuntime() async throws {
+        let loop = try makeWiringLoop()
+        let runtime = EngineV2Runtime()
+        await loop.setEngineV2RuntimeForTesting(runtime)
+        // A legacy-only slot (engineV2: nil) must not flip the guard.
+        await loop.installModelSlotForTesting(
+            modelId: "qwen3-8b",
+            scheduler: BatchScheduler(),
+            container: makeStubContainer(),
+            tokenizer: TokenizerHandle(WiringStubTokenizer())
+        )
+
+        #expect(await loop.hasEngineV2SlotsForTesting() == false)
+        await loop.updateAggregateCapacity()
+        await loop.handleCancellation(requestId: "req-legacy", receivedFromCoordinator: false)
+        #expect(await runtime.consultCount == 0)
+    }
+
+    @Test("capacity folds the v2 bridge slot into the heartbeat when a v2 slot exists")
+    func capacityIncludesV2Slot() async throws {
+        let loop = try makeWiringLoop()
+        let runtime = EngineV2Runtime()
+        let engine = WiringScriptedEngine(script: .manual)
+        let bridge = makeBridge(engine: engine)
+        await loop.setEngineV2RuntimeForTesting(runtime)
+        await runtime.register(modelId: "gemma-4-27b-it", bridge: bridge)
+        await loop.installModelSlotForTesting(
+            modelId: "gemma-4-27b-it",
+            scheduler: BatchScheduler(),
+            container: makeStubContainer(),
+            tokenizer: TokenizerHandle(WiringStubTokenizer()),
+            engineV2: bridge,
+            modelType: "gemma4_text"
+        )
+
+        #expect(await loop.hasEngineV2SlotsForTesting())
+        await loop.updateAggregateCapacity()
+        #expect(await runtime.consultCount == 1)
+        let capacity = await loop.backendCapacityForTesting()
+        let v2Slot = capacity?.slots.first { $0.model == "gemma-4-27b-it" }
+        #expect(v2Slot != nil)
+        // The bridge slot is AUTHORITATIVE for a v2-served model: the dormant
+        // legacy scheduler must not also report (its extra slot would
+        // advertise the same model's capacity twice and over-admit). Exactly
+        // one heartbeat slot exists — the bridge's.
+        #expect(capacity?.slots.count == 1)
+    }
+
+    @Test("cancellation fans out through the runtime to the owning bridge")
+    func cancellationFansOutToBridge() async throws {
+        let loop = try makeWiringLoop()
+        let runtime = EngineV2Runtime()
+        let engine = WiringScriptedEngine(script: .manual)
+        let bridge = makeBridge(engine: engine)
+        await loop.setEngineV2RuntimeForTesting(runtime)
+        await runtime.register(modelId: "gemma-4-27b-it", bridge: bridge)
+        await loop.installModelSlotForTesting(
+            modelId: "gemma-4-27b-it",
+            scheduler: BatchScheduler(),
+            container: makeStubContainer(),
+            tokenizer: TokenizerHandle(WiringStubTokenizer()),
+            engineV2: bridge,
+            modelType: "gemma4_text"
+        )
+
+        // Submit under the coordinator request-id (held open by the manual
+        // script) so the runtime fan-out has an owner to find.
+        let stream = await bridge.submit(
+            request: ChatCompletionRequest(
+                model: "gemma-4-27b-it",
+                messages: [ChatMessage(role: "user", content: "hi")]),
+            requestId: "req-coord-1")
+        let engineId = await bridge._testEngineRequestId(for: "req-coord-1")
+
+        await loop.handleCancellation(requestId: "req-coord-1", receivedFromCoordinator: false)
+        #expect(await runtime.consultCount >= 1)
+        #expect(engine.cancelled.first == engineId)
+        withExtendedLifetime(stream) {}
+    }
+
+    @Test("unloading a v2 slot unregisters the bridge and drains the engine")
+    func unloadRetiresBridge() async throws {
+        let loop = try makeWiringLoop()
+        let runtime = EngineV2Runtime()
+        let engine = WiringScriptedEngine(script: .manual)
+        let bridge = makeBridge(engine: engine)
+        await loop.setEngineV2RuntimeForTesting(runtime)
+        await runtime.register(modelId: "gemma-4-27b-it", bridge: bridge)
+        await loop.installModelSlotForTesting(
+            modelId: "gemma-4-27b-it",
+            scheduler: BatchScheduler(),
+            container: makeStubContainer(),
+            tokenizer: TokenizerHandle(WiringStubTokenizer()),
+            engineV2: bridge,
+            modelType: "gemma4_text"
+        )
+
+        await loop.unloadModel("gemma-4-27b-it")
+        #expect(await runtime.bridge(forModel: "gemma-4-27b-it") == nil)
+        #expect(engine.shutdownCalls == 1)
+        #expect(await loop.hasEngineV2SlotsForTesting() == false)
+    }
+}

--- a/provider-swift/Tests/ProviderCoreTests/EngineV2ProductionWiringTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/EngineV2ProductionWiringTests.swift
@@ -256,7 +256,7 @@ struct EngineV2SlotFactoryTests {
         await loop.setEngineV2SlotHooksForTesting(
             ProviderLoop.EngineV2SlotHooks(
                 environment: [:],
-                makeEngine: { _ in
+                makeEngine: { _, _ in
                     counter.increment()
                     return WiringScriptedEngine(script: .manual)
                 }))
@@ -283,7 +283,7 @@ struct EngineV2SlotFactoryTests {
         await loop.setEngineV2SlotHooksForTesting(
             ProviderLoop.EngineV2SlotHooks(
                 environment: [:],
-                makeEngine: { _ in
+                makeEngine: { _, _ in
                     counter.increment()
                     return WiringScriptedEngine(script: .manual)
                 }))
@@ -313,7 +313,7 @@ struct EngineV2SlotFactoryTests {
             ProviderLoop.EngineV2SlotHooks(
                 environment: ["DARKBLOOM_ENGINE_V2": "1"],
                 eosTokenIds: [2],
-                makeEngine: { _ in engine }))
+                makeEngine: { _, _ in engine }))
 
         let bridge = await loop.makeEngineV2BridgeForSlotForTesting(
             modelId: "gemma-4-27b-it",
@@ -366,7 +366,7 @@ struct EngineV2SlotFactoryTests {
             ProviderLoop.EngineV2SlotHooks(
                 environment: ["DARKBLOOM_ENGINE_V2": "1"],
                 emitTelemetry: telemetry.callback(),
-                makeEngine: { _ in
+                makeEngine: { _, _ in
                     counter.increment()
                     return WiringScriptedEngine(script: .manual)
                 }))
@@ -438,7 +438,7 @@ struct EngineV2SlotFactoryTests {
                 environment: ["DARKBLOOM_ENGINE_V2": "1"],
                 eosTokenIds: [2],
                 emitTelemetry: telemetry.callback(),
-                makeEngine: { _ in engine }))
+                makeEngine: { _, _ in engine }))
 
         // Rates equal ⇒ kv_quant not engaged.
         let scheduler = BatchScheduler()
@@ -472,7 +472,7 @@ struct EngineV2SlotFactoryTests {
                 environment: ["DARKBLOOM_ENGINE_V2": "1"],
                 eosTokenIds: [2],
                 emitTelemetry: telemetry.callback(),
-                makeEngine: { _ in engine }))
+                makeEngine: { _, _ in engine }))
 
         // Quantized rate below fp16 ⇒ kv_quant engaged for this model.
         let scheduler = BatchScheduler()
@@ -511,7 +511,7 @@ struct EngineV2SlotFactoryTests {
             ProviderLoop.EngineV2SlotHooks(
                 environment: [:],
                 emitTelemetry: telemetry.callback(),
-                makeEngine: { _ in throw InitFailure() }))
+                makeEngine: { _, _ in throw InitFailure() }))
 
         let bridge = await loop.makeEngineV2BridgeForSlotForTesting(
             modelId: "gpt-oss-20b",
@@ -530,6 +530,177 @@ struct EngineV2SlotFactoryTests {
         #expect(events.first?.fields?["operation"]?.description == "engine_v2_fallback")
         #expect(events.first?.fields?["backend"]?.description == "engine_v2")
         #expect(events.first?.fields?["error_class"]?.description.contains("InitFailure") == true)
+    }
+}
+
+// MARK: - Multi-slot KV capacity sizing (fleet-wide ceilings)
+
+/// Engine stub that reports a construction-granted KV admission ceiling —
+/// what the slot factory reads back (via
+/// `EngineV2Bridge.engineKVBytesCapacity`) when sizing a LATER engine.
+private final class CapacityReportingEngine: CBv2Engine, @unchecked Sendable {
+    let kvBytesCapacity: Int
+    init(kvBytesCapacity: Int) { self.kvBytesCapacity = kvBytesCapacity }
+
+    func submit(_ request: CBv2Request) throws -> AsyncStream<CBv2Event> {
+        let (stream, continuation) = AsyncStream<CBv2Event>.makeStream()
+        continuation.finish()
+        return stream
+    }
+    func cancel(_ id: CBv2RequestID) {}
+    func capacity() -> CBv2CapacitySnapshot {
+        CBv2CapacitySnapshot(
+            activeRequests: 0, waitingRequests: 0, kvBytesInUse: 0,
+            kvBytesCapacity: kvBytesCapacity, activeTokens: 0)
+    }
+    func shutdown() async {}
+}
+
+/// Thread-safe recorder for the kvBytesCapacity values handed to the hooks.
+private final class CapacityRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _granted: [Int] = []
+    var granted: [Int] { lock.withLock { _granted } }
+    func record(_ capacity: Int) { lock.withLock { _granted.append(capacity) } }
+}
+
+@Suite("EngineV2 production wiring: multi-slot KV capacity")
+struct EngineV2MultiSlotCapacityTests {
+
+    private static let gib: UInt64 = 1024 * 1024 * 1024
+
+    @Test("pure sizing: the second engine's ceiling subtracts co-resident weights AND the first ceiling")
+    func pureSizingSubtractsFleetResidency() {
+        let physical = 64 * Self.gib
+        let wA = Int(8 * Self.gib)
+        let wB = Int(12 * Self.gib)
+        // First engine, alone on the box: the whole budget under its weights.
+        let capA = EngineV2KVSizing.engineKVBytesCapacity(
+            newModelWeightBytes: wA, coResidentWeightBytes: 0,
+            existingEngineKVCapacities: [], physicalBytes: physical)
+        #expect(UInt64(capA) == UnifiedMemoryCap.kvBudgetBytes(
+            physicalBytes: physical, residentWeightBytes: UInt64(wA)))
+        // Second engine: fleet budget now counts BOTH models' weights, and
+        // the first engine's construction-fixed grant comes off the top.
+        // Here the first grant already consumed everything (kvBudget(wA+wB)
+        // = capA − wB < capA), so the second slot gets 0 → the factory
+        // throws noKVHeadroom and the slot serves via the legacy scheduler
+        // (v2 effectively single-slot when the first engine took the pie).
+        let capB = EngineV2KVSizing.engineKVBytesCapacity(
+            newModelWeightBytes: wB, coResidentWeightBytes: UInt64(wA),
+            existingEngineKVCapacities: [capA], physicalBytes: physical)
+        #expect(capB == 0)
+        // The pre-fix behavior — sizing B as if ONLY its weights were
+        // resident — would have granted far more than the fleet budget:
+        let naiveB = UnifiedMemoryCap.kvBudgetBytes(
+            physicalBytes: physical, residentWeightBytes: UInt64(wB))
+        let fleetBudget = UnifiedMemoryCap.kvBudgetBytes(
+            physicalBytes: physical, residentWeightBytes: UInt64(wA) + UInt64(wB))
+        #expect(UInt64(capA) + naiveB > fleetBudget)   // the bug this fixes
+        #expect(UInt64(capA + capB)
+            <= UnifiedMemoryCap.kvBudgetBytes(
+                physicalBytes: physical, residentWeightBytes: UInt64(wA)))
+    }
+
+    @Test("pure sizing: two-slot ceilings sum exactly to the fleet budget when headroom remains")
+    func pureSizingSumsWithinBudget() {
+        let physical = 64 * Self.gib
+        let wA = Int(8 * Self.gib)
+        let wB = Int(4 * Self.gib)
+        // First engine granted under a TIGHTER view (e.g. operator cap /
+        // memory pressure at its load): 10 GiB ceiling.
+        let capA = Int(10 * Self.gib)
+        let capB = EngineV2KVSizing.engineKVBytesCapacity(
+            newModelWeightBytes: wB, coResidentWeightBytes: UInt64(wA),
+            existingEngineKVCapacities: [capA], physicalBytes: physical)
+        let fleetBudget = UnifiedMemoryCap.kvBudgetBytes(
+            physicalBytes: physical, residentWeightBytes: UInt64(wA) + UInt64(wB))
+        #expect(capB > 0)
+        // Σ(ceilings) lands exactly ON the fleet-wide KV budget — the
+        // process-wide invariant the pre-fix per-slot sizing violated.
+        #expect(UInt64(capA + capB) == fleetBudget)
+    }
+
+    @Test("pure sizing: degenerate inputs clamp to zero, never trap")
+    func pureSizingDegenerateInputs() {
+        // Grants already exceed the budget → 0, not negative.
+        #expect(EngineV2KVSizing.engineKVBytesCapacity(
+            newModelWeightBytes: Int(4 * Self.gib), coResidentWeightBytes: 0,
+            existingEngineKVCapacities: [Int.max, Int.max],
+            physicalBytes: 16 * Self.gib) == 0)
+        // Negative weight/grant inputs are treated as 0.
+        #expect(EngineV2KVSizing.engineKVBytesCapacity(
+            newModelWeightBytes: -1, coResidentWeightBytes: 0,
+            existingEngineKVCapacities: [-5],
+            physicalBytes: 16 * Self.gib)
+            == Int(UnifiedMemoryCap.kvBudgetBytes(
+                physicalBytes: 16 * Self.gib, residentWeightBytes: 0)))
+        // Weights alone exceed the cap → 0 budget.
+        #expect(EngineV2KVSizing.engineKVBytesCapacity(
+            newModelWeightBytes: Int(20 * Self.gib), coResidentWeightBytes: 0,
+            existingEngineKVCapacities: [], physicalBytes: 16 * Self.gib) == 0)
+    }
+
+    @Test("slot factory sizes a second v2 engine against the first slot's weights and ceiling")
+    func slotFactoryUsesFleetResidency() async throws {
+        let loop = try makeWiringLoop(engineV2Enabled: true)
+        let runtime = EngineV2Runtime()
+        await loop.setEngineV2RuntimeForTesting(runtime)
+        let recorder = CapacityRecorder()
+        await loop.setEngineV2SlotHooksForTesting(
+            ProviderLoop.EngineV2SlotHooks(
+                environment: ["DARKBLOOM_ENGINE_V2": "1"],
+                eosTokenIds: [2],
+                makeEngine: { _, kvBytesCapacity in
+                    recorder.record(kvBytesCapacity)
+                    return CapacityReportingEngine(kvBytesCapacity: kvBytesCapacity)
+                }))
+
+        // Slot A: 1 GiB of resident weights, empty fleet.
+        let weightsA = Int(1 * Self.gib)
+        let schedulerA = BatchScheduler()
+        await schedulerA._setModelWeightBytesForTest(weightsA)
+        let bridgeA = try #require(await loop.makeEngineV2BridgeForSlotForTesting(
+            modelId: "gemma-4-27b-it",
+            modelType: "gemma4_text",
+            container: makeStubContainer(),
+            tokenizer: TokenizerHandle(WiringStubTokenizer()),
+            scheduler: schedulerA))
+        await loop.installModelSlotForTesting(
+            modelId: "gemma-4-27b-it",
+            scheduler: schedulerA,
+            container: makeStubContainer(),
+            tokenizer: TokenizerHandle(WiringStubTokenizer()),
+            engineV2: bridgeA,
+            modelType: "gemma4_text")
+
+        // Slot B: 2 GiB of weights, loaded WITH A resident.
+        let weightsB = Int(2 * Self.gib)
+        let schedulerB = BatchScheduler()
+        await schedulerB._setModelWeightBytesForTest(weightsB)
+        _ = await loop.makeEngineV2BridgeForSlotForTesting(
+            modelId: "gpt-oss-20b",
+            modelType: "gpt_oss",
+            container: makeStubContainer(),
+            tokenizer: TokenizerHandle(WiringStubTokenizer()),
+            scheduler: schedulerB)
+
+        let granted = recorder.granted
+        #expect(granted.count == 2)
+        // A was sized alone; B's ceiling subtracts A's weights AND A's
+        // construction-fixed grant — the exact fleet-aware derivation
+        // (computed here with the same pure helper on this machine's
+        // physical memory, so the assertion is machine-independent).
+        #expect(granted[0] == EngineV2KVSizing.engineKVBytesCapacity(
+            newModelWeightBytes: weightsA, coResidentWeightBytes: 0,
+            existingEngineKVCapacities: []))
+        #expect(granted[1] == EngineV2KVSizing.engineKVBytesCapacity(
+            newModelWeightBytes: weightsB,
+            coResidentWeightBytes: UInt64(weightsA),
+            existingEngineKVCapacities: [granted[0]]))
+        // And the fleet invariant: B's grant never lets the pair exceed the
+        // budget A was granted under.
+        #expect(granted[1] <= max(0, granted[0] - weightsB))
     }
 }
 

--- a/provider-swift/Tests/ProviderCoreTests/EngineV2ProductionWiringTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/EngineV2ProductionWiringTests.swift
@@ -106,7 +106,11 @@ private struct WiringStubTokenizer: MLXLMCommon.Tokenizer {
     func encode(text: String, addSpecialTokens: Bool) -> [Int] {
         Array(repeating: 0, count: text.count)
     }
-    func decode(tokenIds: [Int], skipSpecialTokens: Bool) -> String { "" }
+    /// Deterministic per-id text ("t<id>") so logprob-entry conversion is
+    /// assertable (mirrors the EngineV2BridgeTests stub).
+    func decode(tokenIds: [Int], skipSpecialTokens: Bool) -> String {
+        tokenIds.map { "t\($0)" }.joined()
+    }
     func convertTokenToId(_ token: String) -> Int? { ["</s>": 2][token] }
     func convertIdToToken(_ id: Int) -> String? { nil }
     var bosToken: String? { nil }
@@ -475,6 +479,45 @@ struct EngineV2RequestRoutingTests {
         #expect(events.last == .info(prompt: 5, completion: 2))
         #expect(engine.submitted.count == 1)
         #expect(engine.submitted[0].promptTokens == [1, 2, 3, 4, 5])
+    }
+
+    @Test("coordinator path threads cacheScope and logprobs plumbing into the bridge")
+    func coordinatorPathThreadsSaltAndLogprobs() async throws {
+        let engine = WiringScriptedEngine(script: .stream([
+            .delta(
+                text: "Hello", tokens: [10],
+                logprobs: [CBv2TokenLogprob(token: 10, logprob: -0.25)]),
+            .finished(reason: .stop, usage: CBv2Usage(promptTokens: 5, completionTokens: 1)),
+        ]))
+        let bridge = makeBridge(engine: engine)
+        let channel = EngineV2LogprobsChannel()
+        let providerEngine = MultiModelBatchSchedulerEngine(
+            registryProvider: { @Sendable in
+                [
+                    "gemma-4-27b-it": .init(
+                        scheduler: BatchScheduler(),
+                        tokenizer: TokenizerHandle(WiringStubTokenizer()),
+                        modelType: "gemma4_text",
+                        engineV2Bridge: bridge)
+                ]
+            },
+            cacheScope: "tenant-hash",
+            engineV2Logprobs: EngineV2LogprobsPlumbing(topLogprobs: 3, channel: channel)
+        )
+        let stream = try await providerEngine.streamChatCompletion(request: makeOpenAIRequest())
+        _ = try await recordServerStream(stream)
+        #expect(engine.submitted.count == 1)
+        // TB-007: the tenant scope rode through as the per-request cache
+        // salt (inert — production builds the v2 engine with the prefix
+        // cache off).
+        #expect(engine.submitted[0].cacheSalt == "tenant-hash")
+        // The logprobs plumbing flipped the sampling translation on.
+        #expect(engine.submitted[0].sampling.topLogprobs == 3)
+        // Entries reached the per-request channel in OpenAI shape.
+        let entries = channel.drain()
+        #expect(entries.count == 1)
+        #expect(entries[0].token == "t10")
+        #expect(entries[0].logprob == -0.25)
     }
 
     @Test("local-endpoint acquire path routes through the bridge and releases the token")

--- a/provider-swift/Tests/ProviderCoreTests/HybridCheckpointE2ELiveTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/HybridCheckpointE2ELiveTests.swift
@@ -38,7 +38,7 @@ struct HybridCheckpointE2ELiveTests {
             case .chunk(let c):
                 if first { ttft = Date().timeIntervalSince(start); first = false }
                 text += c
-            case .info(_, _, let t): tps = t
+            case .info(_, _, let t, _): tps = t
             case .error(let e): Issue.record("stream error: \(e)")
             }
         }

--- a/provider-swift/Tests/ProviderCoreTests/InboundDecodeTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/InboundDecodeTests.swift
@@ -255,4 +255,30 @@ struct InboundDecodeTests {
     func reasoningEffortNonString() {
         #expect(effort(#"{"model":"m","messages":[],"reasoning_effort":3}"#) == nil)
     }
+
+    // MARK: - logprobs / top_logprobs extraction
+
+    private func logprobsSpec(_ json: String) -> (topLogprobs: Int?, requested: Bool)? {
+        ProviderLoop.extractLogprobsSpec(from: Data(json.utf8))
+    }
+
+    @Test("logprobs:true is extracted, with and without top_logprobs")
+    func logprobsSpecExtracted() {
+        let bare = logprobsSpec(#"{"model":"m","messages":[],"logprobs":true}"#)
+        #expect(bare != nil)
+        #expect(bare?.topLogprobs == nil)
+        let withTop = logprobsSpec(
+            #"{"model":"m","messages":[],"logprobs":true,"top_logprobs":5}"#)
+        #expect(withTop?.topLogprobs == 5)
+    }
+
+    @Test("logprobs absent/false/non-bool yields nil (top_logprobs alone is not a request)")
+    func logprobsSpecAbsent() {
+        #expect(logprobsSpec(#"{"model":"m","messages":[]}"#) == nil)
+        #expect(logprobsSpec(#"{"model":"m","messages":[],"logprobs":false}"#) == nil)
+        #expect(logprobsSpec(#"{"model":"m","messages":[],"logprobs":"yes"}"#) == nil)
+        // Per the OpenAI contract, top_logprobs is only meaningful when
+        // logprobs is true.
+        #expect(logprobsSpec(#"{"model":"m","messages":[],"top_logprobs":5}"#) == nil)
+    }
 }

--- a/provider-swift/Tests/ProviderCoreTests/InboundDecodeTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/InboundDecodeTests.swift
@@ -281,4 +281,44 @@ struct InboundDecodeTests {
         // logprobs is true.
         #expect(logprobsSpec(#"{"model":"m","messages":[],"top_logprobs":5}"#) == nil)
     }
+
+    // MARK: - logit_bias / seed extraction (v2 sampling overrides)
+
+    private func sampling(_ json: String) -> EngineV2SamplingOverrides? {
+        ProviderLoop.extractSamplingOverrides(from: Data(json.utf8))
+    }
+
+    @Test("logit_bias and seed are extracted from the sealed body")
+    func samplingOverridesExtracted() {
+        let both = sampling(
+            #"{"model":"m","messages":[],"logit_bias":{"50256":-100,"42":1.5},"seed":7}"#)
+        #expect(both?.logitBias == ["50256": -100, "42": 1.5])
+        #expect(both?.seed == 7)
+        let biasOnly = sampling(#"{"model":"m","messages":[],"logit_bias":{"1":2}}"#)
+        #expect(biasOnly?.logitBias == ["1": 2])
+        #expect(biasOnly?.seed == nil)
+        let seedOnly = sampling(#"{"model":"m","messages":[],"seed":42}"#)
+        #expect(seedOnly?.logitBias == nil)
+        #expect(seedOnly?.seed == 42)
+    }
+
+    @Test("absent/empty logit_bias and absent seed yield nil (no allocation downstream)")
+    func samplingOverridesAbsent() {
+        #expect(sampling(#"{"model":"m","messages":[]}"#) == nil)
+        #expect(sampling(#"{"model":"m","messages":[],"logit_bias":{}}"#) == nil)
+    }
+
+    @Test("a malformed value for one field never discards the other")
+    func samplingOverridesFieldIndependence() {
+        // Negative seed can't decode as UInt64 — logit_bias must survive.
+        let badSeed = sampling(
+            #"{"model":"m","messages":[],"logit_bias":{"9":-5},"seed":-1}"#)
+        #expect(badSeed?.logitBias == ["9": -5])
+        #expect(badSeed?.seed == nil)
+        // Non-object logit_bias — seed must survive.
+        let badBias = sampling(
+            #"{"model":"m","messages":[],"logit_bias":"junk","seed":3}"#)
+        #expect(badBias?.logitBias == nil)
+        #expect(badBias?.seed == 3)
+    }
 }

--- a/provider-swift/Tests/ProviderCoreTests/InferenceLiveTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/InferenceLiveTests.swift
@@ -158,7 +158,7 @@ struct InferenceLiveTests {
                 switch event {
                 case .chunk(let text):
                     collected.chunks.append(text)
-                case .info(let prompt, let completion, let tps):
+                case .info(let prompt, let completion, let tps, _):
                     collected.info = (prompt, completion, tps)
                 case .error(let message):
                     collected.error = message

--- a/provider-swift/Tests/ProviderCoreTests/InferenceLiveTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/InferenceLiveTests.swift
@@ -481,6 +481,12 @@ struct InferenceLiveTests {
                 await loadGate.waitBeforeLoading(modelId)
             }
         )
+        // Keep the live loop's loaded-model persistence (and its startup
+        // preload plan) off the developer machine's real
+        // ~/.darkbloom/loaded-models.json.
+        await loop.setLoadedModelsFileForTesting(
+            FileManager.default.temporaryDirectory
+                .appendingPathComponent("darkbloom-live-loaded-models-\(UUID().uuidString).json"))
         let loopTask = Task { try await loop.run() }
 
         do {

--- a/provider-swift/Tests/ProviderCoreTests/LegacyCompiledDecodeGateTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/LegacyCompiledDecodeGateTests.swift
@@ -38,8 +38,10 @@ struct LegacyCompiledDecodeGateTests {
             LegacyCompiledDecodeGate.resolvedOverride(
                 configEnabled: true,
                 environment: ["DARKBLOOM_COMPILED_DECODE": "0"]) == nil)
-        // Empty string counts as unset (matches the library's read, which
-        // only sees set-and-nonempty as an operator decision).
+        // Empty string counts as unset by the GATE (an empty export is not
+        // an operator decision), so it forces "0". Note the library itself
+        // would treat a set-but-empty var as "not in the off-set" (ON) —
+        // stomping it to "0" here keeps the release posture deterministic.
         #expect(
             LegacyCompiledDecodeGate.resolvedOverride(
                 configEnabled: false,

--- a/provider-swift/Tests/ProviderCoreTests/LegacyCompiledDecodeGateTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/LegacyCompiledDecodeGateTests.swift
@@ -1,0 +1,94 @@
+// Copyright © 2026 Eigen Labs.
+//
+// LegacyCompiledDecodeGate — the provider-side opt-in gate over the
+// mlx-swift-lm `DARKBLOOM_COMPILED_DECODE` env flag (library default ON;
+// release posture OFF unless the operator opts in).
+
+import Foundation
+import Testing
+
+@testable import ProviderCore
+
+@Suite("legacy compiled decode gate")
+struct LegacyCompiledDecodeGateTests {
+
+    @Test("default posture: config false + env unset => force '0' (compiled decode OFF)")
+    func defaultForcesOff() {
+        #expect(
+            LegacyCompiledDecodeGate.resolvedOverride(
+                configEnabled: false, environment: [:]) == "0")
+    }
+
+    @Test("config opt-in: legacy_compiled_decode=true + env unset => untouched (library default ON)")
+    func configOptInLeavesEnvUnset() {
+        #expect(
+            LegacyCompiledDecodeGate.resolvedOverride(
+                configEnabled: true, environment: [:]) == nil)
+    }
+
+    @Test("explicit env always wins, both directions")
+    func explicitEnvWins() {
+        // Operator forced it ON; config default false must not clobber it.
+        #expect(
+            LegacyCompiledDecodeGate.resolvedOverride(
+                configEnabled: false,
+                environment: ["DARKBLOOM_COMPILED_DECODE": "1"]) == nil)
+        // Operator forced it OFF; config opt-in must not clobber it.
+        #expect(
+            LegacyCompiledDecodeGate.resolvedOverride(
+                configEnabled: true,
+                environment: ["DARKBLOOM_COMPILED_DECODE": "0"]) == nil)
+        // Empty string counts as unset (matches the library's read, which
+        // only sees set-and-nonempty as an operator decision).
+        #expect(
+            LegacyCompiledDecodeGate.resolvedOverride(
+                configEnabled: false,
+                environment: ["DARKBLOOM_COMPILED_DECODE": ""]) == "0")
+    }
+
+    @Test("apply() writes the real environment so the library gate latches OFF")
+    func applyWritesProcessEnvironment() {
+        // Snapshot + restore: the suite must not leak env state into other
+        // tests in this shared process.
+        let key = LegacyCompiledDecodeGate.envKey
+        let prior = ProcessInfo.processInfo.environment[key]
+        defer {
+            if let prior {
+                setenv(key, prior, 1)
+            } else {
+                unsetenv(key)
+            }
+        }
+
+        unsetenv(key)
+        let wrote = LegacyCompiledDecodeGate.apply(
+            configEnabled: false, environment: [:])
+        #expect(wrote)
+        // setenv must be visible through ProcessInfo (what the library's
+        // `CompiledDecode.isEnabled` static reads on first access).
+        #expect(ProcessInfo.processInfo.environment[key] == "0")
+
+        // Config opt-in: no write.
+        unsetenv(key)
+        let wroteOptIn = LegacyCompiledDecodeGate.apply(
+            configEnabled: true, environment: [:])
+        #expect(!wroteOptIn)
+        #expect(ProcessInfo.processInfo.environment[key] == nil)
+    }
+
+    @Test("backend config decodes legacy_compiled_decode (default false)")
+    func backendConfigKey() throws {
+        let decoder = JSONDecoder()
+        let on = try decoder.decode(
+            BackendSettings.self,
+            from: Data(#"{"legacy_compiled_decode": true}"#.utf8)
+        )
+        #expect(on.legacyCompiledDecode)
+        let absent = try decoder.decode(
+            BackendSettings.self,
+            from: Data(#"{}"#.utf8)
+        )
+        #expect(!absent.legacyCompiledDecode)
+        #expect(!BackendSettings().legacyCompiledDecode)
+    }
+}

--- a/provider-swift/Tests/ProviderCoreTests/LiveInferenceFixtures.swift
+++ b/provider-swift/Tests/ProviderCoreTests/LiveInferenceFixtures.swift
@@ -311,7 +311,7 @@ func collect(
         switch event {
         case .chunk(let text):
             collected.chunks.append(text)
-        case .info(let prompt, let completion, let tps):
+        case .info(let prompt, let completion, let tps, _):
             collected.info = (prompt, completion, tps)
         case .error(let message):
             collected.error = message

--- a/provider-swift/Tests/ProviderCoreTests/LoadedModelsStoreTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/LoadedModelsStoreTests.swift
@@ -191,6 +191,34 @@ struct LoadedModelsPersistenceWiringTests {
         #expect(LoadedModelsStore.read(from: url) == [])
     }
 
+    @Test("persistence is inert on a loop that never serves (unit tests can't clobber the real file)")
+    func persistenceInertUntilEnabled() async throws {
+        let url = tempFile()
+        defer { try? FileManager.default.removeItem(at: url) }
+        let loop = try makePersistLoop()
+        // Path override WITHOUT the serving gate: simulates any unrelated
+        // unit test that installs + unloads slots on a loop that never ran
+        // run() — the production write points must stay silent.
+        await loop.setLoadedModelsFileForTesting(url)
+        await loop.setLoadedModelsPersistenceEnabledForTesting(false)
+
+        await loop.installModelSlotForTesting(
+            modelId: "gemma-4-26b-it",
+            scheduler: BatchScheduler(maxConcurrentRequests: 2, defaultMaxTokens: 64),
+            container: makePersistStubContainer(),
+            tokenizer: TokenizerHandle(PersistStubTokenizer())
+        )
+        await loop.persistLoadedModelSetForTesting()
+        await loop.unloadModel("gemma-4-26b-it")
+        #expect(!FileManager.default.fileExists(atPath: url.path))
+
+        // Arming the gate (what run() does at startup) activates the same
+        // write points.
+        await loop.setLoadedModelsPersistenceEnabledForTesting(true)
+        await loop.persistLoadedModelSetForTesting()
+        #expect(LoadedModelsStore.read(from: url) == [])
+    }
+
     @Test("shutdown teardown preserves the persisted set for the next boot")
     func shutdownUnloadPreservesPersistedSet() async throws {
         let url = tempFile()

--- a/provider-swift/Tests/ProviderCoreTests/LoadedModelsStoreTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/LoadedModelsStoreTests.swift
@@ -1,0 +1,216 @@
+/// Tests for the persisted loaded-model set (`LoadedModelsStore`) and its
+/// `ProviderLoop` write points: every load/non-shutdown-unload rewrites the
+/// file, shutdown teardown preserves it. This file is the default startup
+/// preload plan, so the round-trip IS the restart-warmup contract.
+
+import Foundation
+import MLX
+import MLXLMCommon
+import MLXNN
+import Testing
+
+@testable import ProviderCore
+
+// MARK: - Store round-trip
+
+@Suite("LoadedModelsStore")
+struct LoadedModelsStoreTests {
+
+    private func tempFile() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("darkbloom-loaded-models-tests", isDirectory: true)
+            .appendingPathComponent("\(UUID().uuidString).json")
+    }
+
+    @Test("write then read round-trips the model set")
+    func roundTrip() {
+        let url = tempFile()
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        LoadedModelsStore.write(["gemma-4-26b-it", "qwen3-8b"], to: url)
+        #expect(LoadedModelsStore.read(from: url) == ["gemma-4-26b-it", "qwen3-8b"])
+    }
+
+    @Test("missing file reads as empty")
+    func missingFileReadsEmpty() {
+        let url = tempFile()
+        #expect(LoadedModelsStore.read(from: url) == [])
+    }
+
+    @Test("corrupt file reads as empty, not a crash")
+    func corruptFileReadsEmpty() throws {
+        let url = tempFile()
+        defer { try? FileManager.default.removeItem(at: url) }
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try Data("not json {{{".utf8).write(to: url)
+
+        #expect(LoadedModelsStore.read(from: url) == [])
+    }
+
+    @Test("schema mismatch reads as empty")
+    func schemaMismatchReadsEmpty() throws {
+        let url = tempFile()
+        defer { try? FileManager.default.removeItem(at: url) }
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        let future = LoadedModelsStore.State(schema: 99, models: ["m"], updatedAt: 0)
+        let encoder = JSONEncoder()
+        encoder.keyEncodingStrategy = .convertToSnakeCase
+        try encoder.encode(future).write(to: url)
+
+        #expect(LoadedModelsStore.read(from: url) == [])
+    }
+
+    @Test("a later write replaces the set")
+    func overwriteReplacesSet() {
+        let url = tempFile()
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        LoadedModelsStore.write(["a", "b"], to: url)
+        LoadedModelsStore.write(["c"], to: url)
+        #expect(LoadedModelsStore.read(from: url) == ["c"])
+    }
+
+    @Test("write failure is swallowed (unwritable path)")
+    func writeFailureIsSwallowed() {
+        // /dev/null/x can never be created; write must not crash.
+        let url = URL(fileURLWithPath: "/dev/null/nested/loaded-models.json")
+        LoadedModelsStore.write(["m"], to: url)
+        #expect(LoadedModelsStore.read(from: url) == [])
+    }
+}
+
+// MARK: - ProviderLoop write points
+
+/// Stub tokenizer/model/container so a real `ModelSlot` can exist without
+/// weights (same pattern as EngineV2ProductionWiringTests).
+private struct PersistStubTokenizer: MLXLMCommon.Tokenizer {
+    func encode(text: String, addSpecialTokens: Bool) -> [Int] { [0] }
+    func decode(tokenIds: [Int], skipSpecialTokens: Bool) -> String { "" }
+    func convertTokenToId(_ token: String) -> Int? { nil }
+    func convertIdToToken(_ id: Int) -> String? { nil }
+    var bosToken: String? { nil }
+    var eosToken: String? { nil }
+    var unknownToken: String? { nil }
+    func applyChatTemplate(
+        messages: [[String: any Sendable]],
+        tools: [[String: any Sendable]]?,
+        additionalContext: [String: any Sendable]?
+    ) throws -> [Int] { [0] }
+}
+
+private final class PersistStubLanguageModel: Module, LanguageModel {
+    func prepare(_ input: LMInput, cache: [KVCache], windowSize: Int?) throws -> PrepareResult {
+        .tokens(input.text)
+    }
+    func newCache(parameters: GenerateParameters?) -> [KVCache] { [] }
+}
+
+private struct PersistStubProcessorError: Error {}
+private struct PersistStubProcessor: UserInputProcessor {
+    func prepare(input: UserInput) async throws -> LMInput {
+        throw PersistStubProcessorError()
+    }
+}
+
+private func makePersistStubContainer() -> ModelContainer {
+    ModelContainer(
+        context: ModelContext(
+            configuration: ModelConfiguration(id: "test/stub-model"),
+            model: PersistStubLanguageModel(),
+            processor: PersistStubProcessor(),
+            tokenizer: PersistStubTokenizer()
+        ))
+}
+
+private func makePersistLoop() throws -> ProviderLoop {
+    let config = ProviderLoopConfig(
+        coordinatorURL: "ws://127.0.0.1:0/ignored",
+        hardware: HardwareInfo(
+            machineModel: "Mac16,5", chipName: "Apple M4 Max", chipFamily: .m4, chipTier: .max,
+            memoryGb: 128, memoryAvailableGb: 124,
+            cpuCores: CpuCores(total: 16, performance: 12, efficiency: 4),
+            gpuCores: 40, memoryBandwidthGbs: 546
+        ),
+        models: [],
+        config: ProviderConfig(
+            provider: ProviderSettings(name: "loaded-models-persist-test", memoryReserveGB: 1),
+            backend: BackendSettings(idleTimeoutMins: 0, maxModelSlots: 2),
+            coordinator: CoordinatorSettings(heartbeatIntervalSecs: 60)
+        )
+    )
+    return try ProviderLoop(config: config, purgeLegacyFiles: false, attestationSigner: nil)
+}
+
+@Suite("LoadedModelsStore: ProviderLoop write points")
+struct LoadedModelsPersistenceWiringTests {
+
+    private func tempFile() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("darkbloom-loaded-models-tests", isDirectory: true)
+            .appendingPathComponent("\(UUID().uuidString).json")
+    }
+
+    @Test("persisting after a slot install writes the loaded set")
+    func persistWritesLoadedSlots() async throws {
+        let url = tempFile()
+        defer { try? FileManager.default.removeItem(at: url) }
+        let loop = try makePersistLoop()
+        await loop.setLoadedModelsFileForTesting(url)
+
+        await loop.installModelSlotForTesting(
+            modelId: "gemma-4-26b-it",
+            scheduler: BatchScheduler(maxConcurrentRequests: 2, defaultMaxTokens: 64),
+            container: makePersistStubContainer(),
+            tokenizer: TokenizerHandle(PersistStubTokenizer())
+        )
+        await loop.persistLoadedModelSetForTesting()
+
+        #expect(LoadedModelsStore.read(from: url) == ["gemma-4-26b-it"])
+    }
+
+    @Test("a normal unload removes the model from the persisted set")
+    func unloadRemovesFromPersistedSet() async throws {
+        let url = tempFile()
+        defer { try? FileManager.default.removeItem(at: url) }
+        let loop = try makePersistLoop()
+        await loop.setLoadedModelsFileForTesting(url)
+
+        await loop.installModelSlotForTesting(
+            modelId: "gemma-4-26b-it",
+            scheduler: BatchScheduler(maxConcurrentRequests: 2, defaultMaxTokens: 64),
+            container: makePersistStubContainer(),
+            tokenizer: TokenizerHandle(PersistStubTokenizer())
+        )
+        await loop.persistLoadedModelSetForTesting()
+        #expect(LoadedModelsStore.read(from: url) == ["gemma-4-26b-it"])
+
+        await loop.unloadModel("gemma-4-26b-it")
+
+        #expect(LoadedModelsStore.read(from: url) == [])
+    }
+
+    @Test("shutdown teardown preserves the persisted set for the next boot")
+    func shutdownUnloadPreservesPersistedSet() async throws {
+        let url = tempFile()
+        defer { try? FileManager.default.removeItem(at: url) }
+        let loop = try makePersistLoop()
+        await loop.setLoadedModelsFileForTesting(url)
+
+        await loop.installModelSlotForTesting(
+            modelId: "gemma-4-26b-it",
+            scheduler: BatchScheduler(maxConcurrentRequests: 2, defaultMaxTokens: 64),
+            container: makePersistStubContainer(),
+            tokenizer: TokenizerHandle(PersistStubTokenizer())
+        )
+        await loop.persistLoadedModelSetForTesting()
+
+        // The run() epilogue unloads with isShuttingDown = true — the whole
+        // point of the file is remembering this set across the restart.
+        await loop.beginShutdownForTesting()
+        await loop.unloadModel("gemma-4-26b-it")
+
+        #expect(LoadedModelsStore.read(from: url) == ["gemma-4-26b-it"])
+    }
+}

--- a/provider-swift/Tests/ProviderCoreTests/MultiModelBatchSchedulerEngineTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/MultiModelBatchSchedulerEngineTests.swift
@@ -144,12 +144,13 @@ func multiModelEngineTranslateDropsEmptyStop() {
     #expect(translated.stop == nil)
 }
 
-// P1 #3 deviation guard: seed dropped on the OpenAI path because the
-// upstream request type does not carry one. If a future upstream PR
-// adds `OpenAIChatCompletionRequest.seed`, plumb it through `translate`
-// and update this test. Until then this fixture pins the current
-// behaviour so the deviation is visible.
-@Test("translate drops seed because OpenAIChatCompletionRequest has no seed field (P1 #3)")
+// P1 #3 deviation guard (narrowed): the upstream request type carries
+// neither `seed` nor `logit_bias`, so a translation WITHOUT the sealed-body
+// overlay yields nil for both. If a future upstream PR adds the fields,
+// plumb them through `translate` directly and retire the overlay. Until
+// then this fixture pins the bare-translation behaviour so the deviation
+// stays visible.
+@Test("translate without an overlay yields nil seed/logit_bias (upstream shape omits them)")
 func multiModelEngineTranslateDropsSeed() {
     let request = OpenAIChatCompletionRequest(
         model: "any",
@@ -160,7 +161,32 @@ func multiModelEngineTranslateDropsSeed() {
         defaultMaxTokens: 4096
     )
     #expect(translated.seed == nil,
-        "until OpenAIChatCompletionRequest exposes a seed field, the engine adapter must hard-code seed:nil")
+        "the upstream OpenAIChatCompletionRequest exposes no seed field; without the sealed-body overlay the adapter must yield nil")
+    #expect(translated.logit_bias == nil)
+}
+
+// Coordinator-path recovery for the same two fields: the inference handler
+// decodes them from the sealed body (`extractSamplingOverrides`) and
+// overlays them here, so the v2 engine sees the caller's real values.
+@Test("translate overlays sealed-body logit_bias and seed onto the internal shape")
+func multiModelEngineTranslateOverlaysSamplingFields() {
+    let request = OpenAIChatCompletionRequest(
+        model: "any",
+        messages: [.init(role: .user, content: .text("hi"))]
+    )
+    let translated = MultiModelBatchSchedulerEngine.translate(
+        openAIRequest: request,
+        defaultMaxTokens: 4096,
+        logitBias: ["50256": -100],
+        seed: 1234
+    )
+    #expect(translated.logit_bias == ["50256": -100])
+    #expect(translated.seed == 1234)
+    // The overlay feeds EngineV2Translation verbatim: the parsed bias and
+    // seed land in the CBv2 sampling params.
+    let sampling = EngineV2Translation.samplingParams(from: translated)
+    #expect(sampling.logitBias == [50256: -100])
+    #expect(sampling.seed == 1234)
 }
 
 // MARK: - Scheduler error mapping (P2 #6)

--- a/provider-swift/Tests/ProviderCoreTests/PerformanceLiveTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/PerformanceLiveTests.swift
@@ -500,7 +500,7 @@ struct PerformanceLiveTests {
             case .chunk:
                 if firstChunkAt == nil { firstChunkAt = .now }
                 lastChunkAt = .now
-            case .info(_, let completion, let tps):
+            case .info(_, let completion, let tps, _):
                 completionTokens = completion
                 schedulerTPS = tps
             case .error:
@@ -716,9 +716,9 @@ struct PerformanceLiveTests {
                                 ttft = ContinuousClock.now - start
                                 sawFirst = true
                             }
-                        case .info(_, let completion, _):
+                        case .info(_, let completion, _, _):
                             completionTokens = completion
-                            if case .info(_, _, let tps) = event {
+                            if case .info(_, _, let tps, _) = event {
                                 modelSideTPS = tps
                             }
                         case .error:

--- a/provider-swift/Tests/ProviderCoreTests/ProviderLoopStreamChunkTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/ProviderLoopStreamChunkTests.swift
@@ -422,6 +422,59 @@ func injectLogprobsContentFrame() throws {
     #expect((top[1]["bytes"] as? [Int]) == [72, 105])
 }
 
+// MARK: - Pending-logprobs bounding (round-3 PR#499 P2)
+
+private func logprobEntry(_ index: Int) -> SSETokenLogprob {
+    SSETokenLogprob(token: "t\(index)", logprob: -0.5, bytes: nil, topLogprobs: [])
+}
+
+@Test("capPending drops the OLDEST entries past the channel cap and reports the count")
+func capPendingDropsOldestPastCap() {
+    // A reasoning-only prefix accumulates far past the cap: the buffer must
+    // stay bounded at exactly `maxEntries`, evicting the oldest entries.
+    let cap = EngineV2LogprobsChannel.maxEntries
+    var pending = (0..<(cap + 25)).map(logprobEntry)
+    let dropped = EngineV2LogprobsChannel.capPending(&pending)
+    #expect(dropped == 25)
+    #expect(pending.count == cap)
+    // Freshest window kept: the first 25 (oldest) entries are gone.
+    #expect(pending.first?.token == "t25")
+    #expect(pending.last?.token == "t\(cap + 24)")
+    // At/under the cap the buffer is untouched and nothing is dropped.
+    #expect(EngineV2LogprobsChannel.capPending(&pending) == 0)
+    #expect(pending.count == cap)
+    var small = [logprobEntry(0)]
+    #expect(EngineV2LogprobsChannel.capPending(&small) == 0)
+    #expect(small.count == 1)
+}
+
+@Test("a content frame after a long reasoning-only prefix carries only the retained window")
+func cappedPendingWindowSplicesIntoContentFrame() throws {
+    // Simulate the frames loop: 6 entries accumulate across reasoning-only
+    // frames while the cap (3 here, for the test) evicts the oldest, then
+    // the first content-bearing chunk arrives and carries the survivors.
+    var pending = (0..<6).map(logprobEntry)
+    var droppedTotal = 0
+    droppedTotal += EngineV2LogprobsChannel.capPending(&pending, maxEntries: 3)
+    #expect(droppedTotal == 3)
+
+    // Reasoning-only frame: entries stay pending (and stay bounded).
+    #expect(ProviderLoop.injectLogprobs(
+        into: try encodeChunk(reasoningContent: "thinking"), entries: pending) == nil)
+
+    // First content frame: the retained window — and ONLY it — attaches.
+    let frame = try encodeChunk(content: "Hello")
+    let rewritten = try #require(ProviderLoop.injectLogprobs(into: frame, entries: pending))
+    let payload = try #require(ProviderLoop.joinedDataPayload(rewritten))
+    let obj = try #require(
+        try JSONSerialization.jsonObject(with: Data(payload.utf8)) as? [String: Any]
+    )
+    let choices = try #require(obj["choices"] as? [[String: Any]])
+    let logprobs = try #require(choices[0]["logprobs"] as? [String: Any])
+    let content = try #require(logprobs["content"] as? [[String: Any]])
+    #expect(content.map { $0["token"] as? String } == ["t3", "t4", "t5"])
+}
+
 @Test("injectLogprobs returns nil for non-content frames (entries stay pending)")
 func injectLogprobsSkipsNonContentFrames() throws {
     let entries = sampleLogprobEntries()

--- a/provider-swift/Tests/ProviderCoreTests/ProviderLoopStreamChunkTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/ProviderLoopStreamChunkTests.swift
@@ -378,3 +378,72 @@ func injectReasoningTokensMergesExistingDetails() throws {
     #expect((details["reasoning_tokens"] as? Int) == 4)
     #expect((details["audio_tokens"] as? Int) == 3)
 }
+
+// MARK: - injectLogprobs (engine-v2 logprobs passthrough)
+
+private func sampleLogprobEntries() -> [SSETokenLogprob] {
+    [
+        SSETokenLogprob(
+            token: "Hello", logprob: -0.25, bytes: [72, 101, 108, 108, 111],
+            topLogprobs: [
+                .init(token: "Hello", logprob: -0.25, bytes: [72, 101, 108, 108, 111]),
+                .init(token: "Hi", logprob: -1.5, bytes: [72, 105]),
+            ]
+        )
+    ]
+}
+
+@Test("injectLogprobs splices the OpenAI logprobs.content shape into a content frame")
+func injectLogprobsContentFrame() throws {
+    let frame = try encodeChunk(content: "Hello")
+    let rewritten = try #require(
+        ProviderLoop.injectLogprobs(into: frame, entries: sampleLogprobEntries())
+    )
+    // Content preserved; the rewritten frame still parses.
+    let parsed = try #require(ProviderLoop.parseStreamChunk(rewritten))
+    #expect(parsed.contentDelta == "Hello")
+    // OpenAI wire shape:
+    // choices[0].logprobs.content[].{token, logprob, bytes, top_logprobs}.
+    let payload = try #require(ProviderLoop.joinedDataPayload(rewritten))
+    let obj = try #require(
+        try JSONSerialization.jsonObject(with: Data(payload.utf8)) as? [String: Any]
+    )
+    let choices = try #require(obj["choices"] as? [[String: Any]])
+    let logprobs = try #require(choices[0]["logprobs"] as? [String: Any])
+    let content = try #require(logprobs["content"] as? [[String: Any]])
+    #expect(content.count == 1)
+    #expect((content[0]["token"] as? String) == "Hello")
+    let lp = try #require(content[0]["logprob"] as? Double)
+    #expect(abs(lp - (-0.25)) < 1e-6)
+    #expect((content[0]["bytes"] as? [Int]) == [72, 101, 108, 108, 111])
+    let top = try #require(content[0]["top_logprobs"] as? [[String: Any]])
+    #expect(top.count == 2)
+    #expect((top[1]["token"] as? String) == "Hi")
+    #expect((top[1]["bytes"] as? [Int]) == [72, 105])
+}
+
+@Test("injectLogprobs returns nil for non-content frames (entries stay pending)")
+func injectLogprobsSkipsNonContentFrames() throws {
+    let entries = sampleLogprobEntries()
+    // Role-only preamble.
+    #expect(ProviderLoop.injectLogprobs(
+        into: try encodeChunk(role: "assistant"), entries: entries) == nil)
+    // Reasoning-only delta (logprobs.content covers CONTENT tokens).
+    #expect(ProviderLoop.injectLogprobs(
+        into: try encodeChunk(reasoningContent: "thinking"), entries: entries) == nil)
+    // Terminal/usage chunk.
+    #expect(ProviderLoop.injectLogprobs(
+        into: try encodeChunk(
+            finishReason: "stop",
+            usage: OpenAIUsage(promptTokens: 1, completionTokens: 2)),
+        entries: entries) == nil)
+    // Empty content string is not content-bearing.
+    #expect(ProviderLoop.injectLogprobs(
+        into: try encodeChunk(content: ""), entries: entries) == nil)
+    // [DONE] sentinel and unparseable payloads are never touched.
+    #expect(ProviderLoop.injectLogprobs(into: "data: [DONE]\n\n", entries: entries) == nil)
+    #expect(ProviderLoop.injectLogprobs(into: "data: {not json}\n\n", entries: entries) == nil)
+    // No entries → nothing to splice, even into a content frame.
+    #expect(ProviderLoop.injectLogprobs(
+        into: try encodeChunk(content: "x"), entries: []) == nil)
+}

--- a/provider-swift/Tests/ProviderCoreTests/StartupPreloadTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/StartupPreloadTests.swift
@@ -1,0 +1,538 @@
+/// Startup preload + registration readiness gate tests — live-isolated style:
+/// scripted load/self-test/memory closures, temp persistence files, real
+/// `ProviderLoop` instances. No model weights, no network, no MLX forward
+/// passes.
+///
+/// Covers:
+///   * `StartupPreloader`: sequential order, no-eviction memory admission
+///     (largest skipped with WARN when the plan exceeds the budget — never a
+///     crash), load-failure continuation, self-test fail-open vs fail-closed,
+///     failure telemetry hook.
+///   * `ProviderLoop.startupPreloadPlan`: configured order vs persisted
+///     biggest-first default, unknown-id filtering, dedup, slot cap.
+///   * `ProviderLoop.runStartupPreloadGate`: registration deferred until warm
+///     within the timeout; proceeds at the timeout while loads continue in
+///     the background; fail-closed self-test retires the model from the
+///     advertised set.
+
+import Foundation
+import Testing
+
+@testable import ProviderCore
+
+// MARK: - Recording helpers
+
+/// Thread-safe event recorder shared by the scripted closures.
+private final class PreloadRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _loads: [String] = []
+    private var _selfTests: [String] = []
+    private var _retired: [String] = []
+    private var _telemetry: [(model: String, message: String)] = []
+    private var _logs: [String] = []
+
+    func recordLoad(_ id: String) { lock.withLock { _loads.append(id) } }
+    func recordSelfTest(_ id: String) { lock.withLock { _selfTests.append(id) } }
+    func recordRetire(_ id: String) { lock.withLock { _retired.append(id) } }
+    func recordTelemetry(_ model: String, _ message: String) {
+        lock.withLock { _telemetry.append((model, message)) }
+    }
+    func recordLog(_ line: String) { lock.withLock { _logs.append(line) } }
+
+    var loads: [String] { lock.withLock { _loads } }
+    var selfTests: [String] { lock.withLock { _selfTests } }
+    var retired: [String] { lock.withLock { _retired } }
+    var telemetry: [(model: String, message: String)] { lock.withLock { _telemetry } }
+    var logs: [String] { lock.withLock { _logs } }
+}
+
+/// Minimal async gate (same shape as the ModelPrefetchCoordinatorTests helper,
+/// which is file-private there).
+private final class PreloadGate: @unchecked Sendable {
+    private let lock = NSLock()
+    private var permits = 0
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func signal() {
+        let waiter: CheckedContinuation<Void, Never>? = lock.withLock {
+            if waiters.isEmpty {
+                permits += 1
+                return nil
+            }
+            return waiters.removeFirst()
+        }
+        waiter?.resume()
+    }
+
+    func wait() async {
+        await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
+            let resumeNow: Bool = lock.withLock {
+                if permits > 0 {
+                    permits -= 1
+                    return true
+                }
+                waiters.append(cont)
+                return false
+            }
+            if resumeNow { cont.resume() }
+        }
+    }
+}
+
+private enum PreloadStubError: Error, LocalizedError {
+    case loadExploded
+    case selfTestExploded
+    var errorDescription: String? {
+        switch self {
+        case .loadExploded: return "weights corrupted (stub)"
+        case .selfTestExploded: return "decode produced no frames (stub)"
+        }
+    }
+}
+
+private func candidate(_ id: String, requiredGb: Double = 1.0) -> StartupPreloader.Candidate {
+    StartupPreloader.Candidate(modelId: id, requiredGb: requiredGb)
+}
+
+// MARK: - StartupPreloader (component)
+
+@Suite("StartupPreloader")
+struct StartupPreloaderTests {
+
+    private func makeDeps(
+        recorder: PreloadRecorder,
+        freeMemoryGb: Double = 1_000,
+        loadError: @escaping @Sendable (String) -> (any Error)? = { _ in nil },
+        selfTest: Bool = false,
+        selfTestError: @escaping @Sendable (String) -> (any Error)? = { _ in nil },
+        selfTestFailClosed: Bool = false
+    ) -> StartupPreloader.Dependencies {
+        var selfTestClosure: (@Sendable (String) async throws -> Duration)?
+        if selfTest {
+            selfTestClosure = { id in
+                recorder.recordSelfTest(id)
+                if let error = selfTestError(id) { throw error }
+                return .milliseconds(5)
+            }
+        }
+        return StartupPreloader.Dependencies(
+            freeMemoryGb: { freeMemoryGb },
+            load: { id in
+                recorder.recordLoad(id)
+                if let error = loadError(id) { throw error }
+            },
+            selfTest: selfTestClosure,
+            selfTestFailClosed: selfTestFailClosed,
+            retire: { id in recorder.recordRetire(id) },
+            onSelfTestFailed: { id, message in recorder.recordTelemetry(id, message) },
+            log: { line in recorder.recordLog(line) }
+        )
+    }
+
+    @Test("loads run sequentially in the given order")
+    func loadsSequentiallyInGivenOrder() async {
+        let recorder = PreloadRecorder()
+        let preloader = StartupPreloader(deps: makeDeps(recorder: recorder))
+
+        let summary = await preloader.run(candidates: [
+            candidate("big-26b", requiredGb: 30),
+            candidate("mid-8b", requiredGb: 9),
+            candidate("small-1b", requiredGb: 2),
+        ])
+
+        #expect(recorder.loads == ["big-26b", "mid-8b", "small-1b"])
+        #expect(summary.loaded == ["big-26b", "mid-8b", "small-1b"])
+        #expect(summary.skippedInsufficientMemory.isEmpty)
+        #expect(summary.failed.isEmpty)
+    }
+
+    @Test("plan exceeding the memory budget: largest skipped with WARN, rest load, no crash")
+    func memoryAdmissionSkipsOversizedCandidate() async {
+        let recorder = PreloadRecorder()
+        // 8 GB free: the 30 GB model must be skipped WITHOUT evicting anything;
+        // the smaller ones still load.
+        let preloader = StartupPreloader(deps: makeDeps(recorder: recorder, freeMemoryGb: 8))
+
+        let summary = await preloader.run(candidates: [
+            candidate("big-26b", requiredGb: 30),
+            candidate("mid-8b", requiredGb: 7.5),
+            candidate("small-1b", requiredGb: 2),
+        ])
+
+        #expect(summary.skippedInsufficientMemory == ["big-26b"])
+        #expect(recorder.loads == ["mid-8b", "small-1b"])
+        #expect(summary.loaded == ["mid-8b", "small-1b"])
+        let warns = recorder.logs.filter { $0.contains("WARN") && $0.contains("big-26b") }
+        #expect(!warns.isEmpty)
+    }
+
+    @Test("a failed load logs, is recorded, and does not stop later candidates")
+    func loadFailureContinues() async {
+        let recorder = PreloadRecorder()
+        let preloader = StartupPreloader(
+            deps: makeDeps(
+                recorder: recorder,
+                loadError: { $0 == "broken" ? PreloadStubError.loadExploded : nil }))
+
+        let summary = await preloader.run(candidates: [
+            candidate("broken"),
+            candidate("healthy"),
+        ])
+
+        #expect(summary.failed == ["broken"])
+        #expect(summary.loaded == ["healthy"])
+        #expect(recorder.loads == ["broken", "healthy"])
+    }
+
+    @Test("self-test runs once per LOADED model, not for skipped/failed ones")
+    func selfTestRunsPerLoadedModel() async {
+        let recorder = PreloadRecorder()
+        let preloader = StartupPreloader(
+            deps: makeDeps(
+                recorder: recorder,
+                freeMemoryGb: 8,
+                loadError: { $0 == "broken" ? PreloadStubError.loadExploded : nil },
+                selfTest: true))
+
+        let summary = await preloader.run(candidates: [
+            candidate("too-big", requiredGb: 30),
+            candidate("broken", requiredGb: 1),
+            candidate("healthy", requiredGb: 1),
+        ])
+
+        #expect(recorder.selfTests == ["healthy"])
+        #expect(summary.loaded == ["healthy"])
+    }
+
+    @Test("self-test failure fail-open: telemetry fires, model stays loaded, no retire")
+    func selfTestFailureFailOpen() async {
+        let recorder = PreloadRecorder()
+        let preloader = StartupPreloader(
+            deps: makeDeps(
+                recorder: recorder,
+                selfTest: true,
+                selfTestError: { $0 == "flaky" ? PreloadStubError.selfTestExploded : nil }))
+
+        let summary = await preloader.run(candidates: [candidate("flaky"), candidate("healthy")])
+
+        #expect(summary.selfTestFailed == ["flaky"])
+        #expect(summary.loaded == ["flaky", "healthy"])  // fail-open: still advertised
+        #expect(summary.retired.isEmpty)
+        #expect(recorder.retired.isEmpty)
+        #expect(recorder.telemetry.count == 1)
+        #expect(recorder.telemetry.first?.model == "flaky")
+        #expect(recorder.telemetry.first?.message.contains("no frames") == true)
+    }
+
+    @Test("self-test failure fail-closed: model retired and dropped from loaded")
+    func selfTestFailureFailClosed() async {
+        let recorder = PreloadRecorder()
+        let preloader = StartupPreloader(
+            deps: makeDeps(
+                recorder: recorder,
+                selfTest: true,
+                selfTestError: { $0 == "flaky" ? PreloadStubError.selfTestExploded : nil },
+                selfTestFailClosed: true))
+
+        let summary = await preloader.run(candidates: [candidate("flaky"), candidate("healthy")])
+
+        #expect(summary.selfTestFailed == ["flaky"])
+        #expect(summary.retired == ["flaky"])
+        #expect(summary.loaded == ["healthy"])
+        #expect(recorder.retired == ["flaky"])
+        #expect(recorder.telemetry.count == 1)
+    }
+
+    @Test("cancellation stops the run between candidates")
+    func cancellationStopsRun() async {
+        let recorder = PreloadRecorder()
+        let gate = PreloadGate()
+        let deps = StartupPreloader.Dependencies(
+            freeMemoryGb: { 1_000 },
+            load: { id in
+                recorder.recordLoad(id)
+                gate.signal()
+                // Park until cancelled.
+                while true {
+                    try Task.checkCancellation()
+                    try await Task.sleep(for: .milliseconds(5))
+                }
+            },
+            log: { line in recorder.recordLog(line) }
+        )
+        let preloader = StartupPreloader(deps: deps)
+
+        let driver = Task { await preloader.run(candidates: [candidate("first"), candidate("second")]) }
+        await gate.wait()
+        driver.cancel()
+        let summary = await driver.value
+
+        #expect(recorder.loads == ["first"])
+        #expect(summary.loaded.isEmpty)
+    }
+}
+
+// MARK: - ProviderLoop plan + gate
+
+private func preloadModelInfo(_ id: String, memoryGb: Double) -> ModelInfo {
+    ModelInfo(
+        id: id,
+        modelType: "gemma",
+        parameters: nil,
+        quantization: "4bit",
+        sizeBytes: UInt64(memoryGb * 1_000_000_000),
+        estimatedMemoryGb: memoryGb
+    )
+}
+
+private func makePreloadLoop(
+    models: [ModelInfo],
+    backend: BackendSettings,
+    loadedModelsFile: URL? = nil
+) async throws -> ProviderLoop {
+    let config = ProviderLoopConfig(
+        coordinatorURL: "ws://127.0.0.1:0/ignored",
+        hardware: HardwareInfo(
+            machineModel: "Mac16,5", chipName: "Apple M4 Max", chipFamily: .m4, chipTier: .max,
+            memoryGb: 128, memoryAvailableGb: 124,
+            cpuCores: CpuCores(total: 16, performance: 12, efficiency: 4),
+            gpuCores: 40, memoryBandwidthGbs: 546
+        ),
+        models: models,
+        config: ProviderConfig(
+            provider: ProviderSettings(name: "startup-preload-test", memoryReserveGB: 1),
+            backend: backend,
+            coordinator: CoordinatorSettings(heartbeatIntervalSecs: 60)
+        )
+    )
+    let loop = try ProviderLoop(config: config, purgeLegacyFiles: false, attestationSigner: nil)
+    if let loadedModelsFile {
+        await loop.setLoadedModelsFileForTesting(loadedModelsFile)
+    } else {
+        // Point the default at a throwaway location so plan tests never read
+        // the developer machine's real ~/.darkbloom/loaded-models.json.
+        await loop.setLoadedModelsFileForTesting(
+            FileManager.default.temporaryDirectory
+                .appendingPathComponent("darkbloom-preload-tests", isDirectory: true)
+                .appendingPathComponent("\(UUID().uuidString).json"))
+    }
+    // Deterministic admission for gate tests (the real probe reads live memory).
+    await loop.setStartupPreloadFreeMemoryOverrideForTesting({ 1_000 })
+    return loop
+}
+
+@Suite("ProviderLoop startup preload plan")
+struct StartupPreloadPlanTests {
+
+    @Test("configured preload_models keeps operator order, filters unknown ids, dedups")
+    func planUsesConfiguredOrder() async throws {
+        let loop = try await makePreloadLoop(
+            models: [
+                preloadModelInfo("small-1b", memoryGb: 2),
+                preloadModelInfo("big-26b", memoryGb: 30),
+            ],
+            backend: BackendSettings(
+                maxModelSlots: 3,
+                preloadModels: ["small-1b", "not-installed", "big-26b", "small-1b"]))
+
+        let plan = await loop.startupPreloadPlanForTesting()
+
+        #expect(plan.map(\.modelId) == ["small-1b", "big-26b"])
+        // Admission requirement = weights + serve headroom (strictly more than
+        // the raw weights).
+        #expect(plan.allSatisfy { $0.requiredGb > 0 })
+        let small = try #require(plan.first)
+        #expect(small.requiredGb > 2)
+    }
+
+    @Test("empty preload_models defaults to the persisted set, biggest first")
+    func planDefaultsToPersistedBiggestFirst() async throws {
+        let file = FileManager.default.temporaryDirectory
+            .appendingPathComponent("darkbloom-preload-tests", isDirectory: true)
+            .appendingPathComponent("\(UUID().uuidString).json")
+        defer { try? FileManager.default.removeItem(at: file) }
+        LoadedModelsStore.write(["small-1b", "big-26b"], to: file)
+
+        let loop = try await makePreloadLoop(
+            models: [
+                preloadModelInfo("small-1b", memoryGb: 2),
+                preloadModelInfo("big-26b", memoryGb: 30),
+            ],
+            backend: BackendSettings(maxModelSlots: 3),
+            loadedModelsFile: file)
+
+        let plan = await loop.startupPreloadPlanForTesting()
+
+        #expect(plan.map(\.modelId) == ["big-26b", "small-1b"])
+    }
+
+    @Test("plan is capped at max_model_slots")
+    func planCapsAtMaxModelSlots() async throws {
+        let loop = try await makePreloadLoop(
+            models: [
+                preloadModelInfo("a", memoryGb: 2),
+                preloadModelInfo("b", memoryGb: 2),
+            ],
+            backend: BackendSettings(
+                maxModelSlots: 1,
+                preloadModels: ["a", "b"]))
+
+        let plan = await loop.startupPreloadPlanForTesting()
+
+        #expect(plan.map(\.modelId) == ["a"])
+    }
+
+    @Test("no persisted set and no configured list means nothing to preload")
+    func emptyPlanWhenNoHistory() async throws {
+        let loop = try await makePreloadLoop(
+            models: [preloadModelInfo("a", memoryGb: 2)],
+            backend: BackendSettings())
+
+        let plan = await loop.startupPreloadPlanForTesting()
+        #expect(plan.isEmpty)
+
+        let outcome = await loop.runStartupPreloadGateForTesting()
+        #expect(outcome == .nothingToPreload)
+    }
+}
+
+@Suite("ProviderLoop startup preload gate")
+struct StartupPreloadGateTests {
+
+    @Test("startup_preload = false disables the gate entirely")
+    func gateDisabledByConfig() async throws {
+        let loop = try await makePreloadLoop(
+            models: [preloadModelInfo("a", memoryGb: 2)],
+            backend: BackendSettings(startupPreload: false, preloadModels: ["a"]))
+
+        let outcome = await loop.runStartupPreloadGateForTesting()
+        #expect(outcome == .disabled)
+    }
+
+    @Test("registration is deferred until warm when the preload beats the timeout")
+    func gateWarmWithinTimeout() async throws {
+        let recorder = PreloadRecorder()
+        let loop = try await makePreloadLoop(
+            models: [
+                preloadModelInfo("a", memoryGb: 2),
+                preloadModelInfo("b", memoryGb: 2),
+            ],
+            backend: BackendSettings(
+                preloadModels: ["a", "b"],
+                startupPreloadTimeoutSecs: 30,
+                startupSelftest: false))
+        await loop.setStartupPreloadLoadOverrideForTesting({ id in
+            try await Task.sleep(for: .milliseconds(50))
+            recorder.recordLoad(id)
+        })
+
+        let outcome = await loop.runStartupPreloadGateForTesting()
+
+        // The gate resolving IS the registration readiness signal: run()
+        // creates the coordinator client (and therefore registers) strictly
+        // after this call returns.
+        #expect(outcome == .warm)
+        #expect(recorder.loads == ["a", "b"])
+    }
+
+    @Test("gate proceeds at the timeout; loads continue in the background")
+    func gateTimesOutAndContinuesInBackground() async throws {
+        let recorder = PreloadRecorder()
+        let loop = try await makePreloadLoop(
+            models: [preloadModelInfo("a", memoryGb: 2)],
+            backend: BackendSettings(
+                preloadModels: ["a"],
+                startupPreloadTimeoutSecs: 1,  // minimum configurable gate
+                startupSelftest: false))
+        // One 3s load vs a 1s gate: generous margins in both directions so a
+        // parallel-suite scheduling stall can't flip the outcome.
+        await loop.setStartupPreloadLoadOverrideForTesting({ id in
+            try await Task.sleep(for: .seconds(3))
+            recorder.recordLoad(id)
+        })
+
+        let clock = ContinuousClock()
+        let start = clock.now
+        let outcome = await loop.runStartupPreloadGateForTesting()
+        let gateElapsed = clock.now - start
+
+        // Availability beats perfection: the gate released at ~1s even though
+        // ~2s of loading remained.
+        #expect(outcome == .timedOut)
+        #expect(gateElapsed < .milliseconds(2800))
+        #expect(recorder.loads.isEmpty)
+
+        // The driver keeps warming in the background after the gate released.
+        var waited = 0
+        while recorder.loads.isEmpty, waited < 200 {
+            try await Task.sleep(for: .milliseconds(50))
+            waited += 1
+        }
+        #expect(recorder.loads == ["a"])
+
+        // And the driver handle clears once done.
+        waited = 0
+        while await loop.startupPreloadTaskRunningForTesting(), waited < 200 {
+            try await Task.sleep(for: .milliseconds(20))
+            waited += 1
+        }
+        #expect(await loop.startupPreloadTaskRunningForTesting() == false)
+    }
+
+    @Test("fail-closed self-test failure retires the model from the advertised set")
+    func gateFailClosedSelfTestRetires() async throws {
+        let loop = try await makePreloadLoop(
+            models: [
+                preloadModelInfo("flaky", memoryGb: 2),
+                preloadModelInfo("healthy", memoryGb: 2),
+            ],
+            backend: BackendSettings(
+                preloadModels: ["flaky", "healthy"],
+                startupPreloadTimeoutSecs: 30,
+                startupSelftest: true,
+                startupSelftestFailClosed: true))
+        await loop.setStartupPreloadLoadOverrideForTesting({ _ in })
+        await loop.setStartupSelfTestOverrideForTesting({ id in
+            if id == "flaky" { throw PreloadStubError.selfTestExploded }
+            return .milliseconds(1)
+        })
+
+        let outcome = await loop.runStartupPreloadGateForTesting()
+
+        #expect(outcome == .warm)
+        // Registration filters loopConfig.models through the advertised set,
+        // so the retired build is never announced to the coordinator.
+        #expect(await loop.isModelAdvertised("flaky") == false)
+        #expect(await loop.isModelAdvertised("healthy") == true)
+    }
+
+    @Test("fail-open (default) self-test failure keeps the model advertised")
+    func gateFailOpenSelfTestKeepsModel() async throws {
+        let loop = try await makePreloadLoop(
+            models: [preloadModelInfo("flaky", memoryGb: 2)],
+            backend: BackendSettings(
+                preloadModels: ["flaky"],
+                startupPreloadTimeoutSecs: 30,
+                startupSelftest: true))
+        await loop.setStartupPreloadLoadOverrideForTesting({ _ in })
+        await loop.setStartupSelfTestOverrideForTesting({ _ in
+            throw PreloadStubError.selfTestExploded
+        })
+
+        let outcome = await loop.runStartupPreloadGateForTesting()
+
+        #expect(outcome == .warm)
+        #expect(await loop.isModelAdvertised("flaky") == true)
+    }
+
+    @Test("self-test decode on a model without a live slot fails cleanly")
+    func selfTestWithoutSlotThrows() async throws {
+        let loop = try await makePreloadLoop(
+            models: [preloadModelInfo("a", memoryGb: 2)],
+            backend: BackendSettings())
+
+        await #expect(throws: InferenceError.self) {
+            _ = try await loop.runStartupSelfTestDecode(modelId: "a")
+        }
+    }
+}

--- a/provider-swift/Tests/ProviderCoreTests/StartupPreloadTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/StartupPreloadTests.swift
@@ -16,6 +16,9 @@
 ///     advertised set.
 
 import Foundation
+import MLX
+import MLXLMCommon
+import MLXNN
 import Testing
 
 @testable import ProviderCore
@@ -534,5 +537,223 @@ struct StartupPreloadGateTests {
         await #expect(throws: InferenceError.self) {
             _ = try await loop.runStartupSelfTestDecode(modelId: "a")
         }
+    }
+}
+
+// MARK: - No-evict enforcement (production ensureModelLoaded path)
+
+/// Stub tokenizer/model/container so real `ModelSlot`s can exist without
+/// weights (file-private copy of the LoadedModelsStoreTests pattern).
+private struct NoEvictStubTokenizer: MLXLMCommon.Tokenizer {
+    func encode(text: String, addSpecialTokens: Bool) -> [Int] { [0] }
+    func decode(tokenIds: [Int], skipSpecialTokens: Bool) -> String { "" }
+    func convertTokenToId(_ token: String) -> Int? { nil }
+    func convertIdToToken(_ id: Int) -> String? { nil }
+    var bosToken: String? { nil }
+    var eosToken: String? { nil }
+    var unknownToken: String? { nil }
+    func applyChatTemplate(
+        messages: [[String: any Sendable]],
+        tools: [[String: any Sendable]]?,
+        additionalContext: [String: any Sendable]?
+    ) throws -> [Int] { [0] }
+}
+
+private final class NoEvictStubLanguageModel: Module, LanguageModel {
+    func prepare(_ input: LMInput, cache: [KVCache], windowSize: Int?) throws -> PrepareResult {
+        .tokens(input.text)
+    }
+    func newCache(parameters: GenerateParameters?) -> [KVCache] { [] }
+}
+
+private struct NoEvictStubProcessorError: Error {}
+private struct NoEvictStubProcessor: UserInputProcessor {
+    func prepare(input: UserInput) async throws -> LMInput {
+        throw NoEvictStubProcessorError()
+    }
+}
+
+private func makeNoEvictStubContainer() -> ModelContainer {
+    ModelContainer(
+        context: ModelContext(
+            configuration: ModelConfiguration(id: "test/stub-model"),
+            model: NoEvictStubLanguageModel(),
+            processor: NoEvictStubProcessor(),
+            tokenizer: NoEvictStubTokenizer()
+        ))
+}
+
+/// Create a minimal fake HF-cache snapshot so `ModelScanner.resolveLocalPath`
+/// resolves `modelId` (ensureModelLoaded requires an on-disk snapshot BEFORE
+/// it reaches the admission gates under test). Returns the `models--...`
+/// directory for cleanup.
+private func makeFakeHFSnapshot(modelId: String) throws -> URL {
+    let cacheDir = FileManager.default.homeDirectoryForCurrentUser
+        .appendingPathComponent(".cache/huggingface/hub", isDirectory: true)
+    let modelDir = cacheDir.appendingPathComponent(
+        "models--\(modelId.replacingOccurrences(of: "/", with: "--"))", isDirectory: true)
+    let snapshot = modelDir
+        .appendingPathComponent("snapshots", isDirectory: true)
+        .appendingPathComponent("main", isDirectory: true)
+    try FileManager.default.createDirectory(at: snapshot, withIntermediateDirectories: true)
+    try Data("{}".utf8).write(to: snapshot.appendingPathComponent("config.json"))
+    return modelDir
+}
+
+@Suite("Startup preload no-evict enforcement (production load path)")
+struct StartupPreloadNoEvictTests {
+
+    private func installStubSlot(_ loop: ProviderLoop, _ id: String) async {
+        await loop.installModelSlotForTesting(
+            modelId: id,
+            scheduler: BatchScheduler(maxConcurrentRequests: 2, defaultMaxTokens: 64),
+            container: makeNoEvictStubContainer(),
+            tokenizer: TokenizerHandle(NoEvictStubTokenizer())
+        )
+    }
+
+    @Test("slot-cap: no-evict load refuses instead of evicting an idle resident model")
+    func slotCapNoEvictRefuses() async throws {
+        let fakeId = "darkbloom-tests/noevict-slot-\(UUID().uuidString.prefix(8))"
+        let fakeDir = try makeFakeHFSnapshot(modelId: fakeId)
+        defer { try? FileManager.default.removeItem(at: fakeDir) }
+
+        let loop = try await makePreloadLoop(
+            models: [
+                preloadModelInfo("stub-a", memoryGb: 0.01),
+                preloadModelInfo("stub-b", memoryGb: 0.01),
+                preloadModelInfo(fakeId, memoryGb: 0.01),
+            ],
+            backend: BackendSettings(maxModelSlots: 2))
+        await installStubSlot(loop, "stub-a")
+        await installStubSlot(loop, "stub-b")
+
+        // Both resident models are idle and WOULD be evictable — the no-evict
+        // load must refuse (503-shaped "slot" capacity error), not churn one.
+        do {
+            try await loop.ensureModelLoaded(modelId: fakeId, allowEviction: false)
+            Issue.record("expected the no-evict load to throw at the slot cap")
+        } catch let InferenceError.invalidModelDirectory(message) {
+            #expect(message.contains("slot"))
+            #expect(ProviderLoop.loadErrorStatusCode(for: InferenceError.invalidModelDirectory(message)) == 503)
+        }
+
+        let resident = await loop.modelSlots.keys.sorted()
+        #expect(resident == ["stub-a", "stub-b"])
+
+        // Contrast: the default (live-traffic) path evicts the idle LRU slot.
+        // The load then proceeds and fails on the fake weights — irrelevant
+        // here; the point is that eviction HAPPENED with the default policy
+        // and did NOT with allowEviction: false.
+        do {
+            try await loop.ensureModelLoaded(modelId: fakeId)
+            Issue.record("expected the fake-weights load to fail after eviction")
+        } catch {
+            // expected: fake snapshot has no loadable weights
+        }
+        let after = await loop.modelSlots.keys.sorted()
+        #expect(after.count == 1, "default policy should have evicted one idle model, got \(after)")
+    }
+
+    @Test("memory: no-evict load fails with a WARN-able error, resident model untouched")
+    func memoryNoEvictRefuses() async throws {
+        let fakeId = "darkbloom-tests/noevict-mem-\(UUID().uuidString.prefix(8))"
+        let fakeDir = try makeFakeHFSnapshot(modelId: fakeId)
+        defer { try? FileManager.default.removeItem(at: fakeDir) }
+
+        let loop = try await makePreloadLoop(
+            models: [
+                preloadModelInfo("stub-a", memoryGb: 0.01),
+                // Impossible footprint: the memory gate must refuse without
+                // touching the idle (evictable) resident model.
+                preloadModelInfo(fakeId, memoryGb: 100_000),
+            ],
+            backend: BackendSettings(maxModelSlots: 3))
+        await installStubSlot(loop, "stub-a")
+
+        do {
+            try await loop.ensureModelLoaded(modelId: fakeId, allowEviction: false)
+            Issue.record("expected the no-evict load to throw at the memory gate")
+        } catch let InferenceError.modelLoadFailed(message) {
+            #expect(message.contains("without evicting"))
+        }
+
+        let resident = await loop.modelSlots.keys.sorted()
+        #expect(resident == ["stub-a"])
+    }
+}
+
+// MARK: - Post-registration fail-closed retirement (end-to-end)
+
+@Suite("Startup preload post-registration retirement", .serialized)
+struct StartupPreloadPostRegistrationRetirementTests {
+
+    @Test("fail-closed retirement after registration re-registers without the retired model")
+    func postRegistrationRetirementReRegistersWithoutModel() async throws {
+        let mock = MockCoordinator()
+        let baseURL = try await mock.start()
+        defer { Task { await mock.shutdown() } }
+
+        // A REAL CoordinatorClient connected to the mock — the same
+        // registration path production uses. Its advertised store is what
+        // sendRegistration reads, so the retirement must shrink it AND force
+        // a reconnect for the coordinator to learn about the removal.
+        let keys = NodeKeyPair.generate()
+        let client = CoordinatorClient(
+            config: CoordinatorClientConfig(
+                url: baseURL.mockProviderWebSocketURL(),
+                hardware: HardwareInfo(
+                    machineModel: "Mac16,5", chipName: "Apple M4 Max", chipFamily: .m4, chipTier: .max,
+                    memoryGb: 128, memoryAvailableGb: 124,
+                    cpuCores: CpuCores(total: 16, performance: 12, efficiency: 4),
+                    gpuCores: 40, memoryBandwidthGbs: 546
+                ),
+                models: [
+                    preloadModelInfo("flaky", memoryGb: 2),
+                    preloadModelInfo("healthy", memoryGb: 2),
+                ],
+                backendName: "mlx-swift",
+                heartbeatInterval: 60,
+                publicKey: keys.publicKeyBase64
+            ),
+            stats: AtomicProviderStats(),
+            state: ProviderState()
+        )
+        let (_, _) = await client.start()
+        defer { Task { await client.shutdown() } }
+
+        let first = try await mock.awaitFirstRegister(timeout: .seconds(10))
+        let firstRegister = try #require(first)
+        #expect(firstRegister.models.map(\.id).sorted() == ["flaky", "healthy"])
+
+        // Simulate the timed-out-gate world: the client is live (registration
+        // already announced flaky) when the self-test retires it fail-closed.
+        let loop = try await makePreloadLoop(
+            models: [
+                preloadModelInfo("flaky", memoryGb: 2),
+                preloadModelInfo("healthy", memoryGb: 2),
+            ],
+            backend: BackendSettings(
+                preloadModels: ["flaky", "healthy"],
+                startupPreloadTimeoutSecs: 30,
+                startupSelftest: true,
+                startupSelftestFailClosed: true))
+        await loop.setCoordinatorClientForTesting(client)
+        await loop.setStartupPreloadLoadOverrideForTesting({ _ in })
+        await loop.setStartupSelfTestOverrideForTesting({ id in
+            if id == "flaky" { throw PreloadStubError.selfTestExploded }
+            return .milliseconds(1)
+        })
+
+        _ = await loop.runStartupPreloadGateForTesting()
+
+        // Retirement must have shrunk the client's advertised store and
+        // forced a reconnect whose fresh register no longer announces flaky.
+        let snap = try await mock.waitForSnapshot(timeout: .seconds(10)) { $0.registers.count >= 2 }
+        let registers = try #require(snap).registers
+        let second = try #require(registers.last)
+        #expect(!second.models.map(\.id).contains("flaky"))
+        #expect(second.models.map(\.id).contains("healthy"))
+        #expect(await client.currentAdvertisedModels().map(\.id) == ["healthy"])
     }
 }

--- a/provider-swift/Tests/ProviderCoreTests/StartupSelfTestDecodeLiveTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/StartupSelfTestDecodeLiveTests.swift
@@ -1,0 +1,176 @@
+// Copyright © 2026 Eigen Labs.
+//
+// Regression tests for the v0.6.31 CI failure: the startup preload
+// SELF-TEST decode (1-token greedy through MultiModelBatchSchedulerEngine)
+// left residual state in the legacy BatchScheduler for hybrid
+// (SSM + attention) models, and every subsequent real request crashed the
+// process with an MLX broadcast fatal:
+//
+//   [broadcast_shapes] Shapes (1,8,19,64) and (1,1,12,64) cannot be broadcast
+//
+// (second operand frozen at the self-test's ~12-token prompt length).
+//
+// These tests drive the EXACT serving path the self-test and a routed
+// request share — `MultiModelBatchSchedulerEngine` over one live
+// `BatchScheduler` via `MLXOpenAIService.streamChatCompletionFrames` —
+// first with the self-test-shaped request (tiny prompt, maxTokens=1,
+// greedy), then with a normal longer request, and assert the second one
+// streams content instead of dying.
+//
+// Weight-gated like the other live tests: enabled only when
+// DARKBLOOM_LIVE_MLX_TESTS is set and the model is in the local HF cache.
+
+import Foundation
+import MLX
+import MLXLLM
+import MLXLMCommon
+import MLXLMServer
+import MLXVLM
+import Testing
+
+@testable import ProviderCore
+
+@Suite("startup self-test decode leaves the engine reusable", .serialized)
+struct StartupSelfTestDecodeLiveTests {
+
+    /// The model the CI e2e suite serves. Its config.json declares a
+    /// `vision_config`, so the provider loads it via `VLMModelFactory`
+    /// (see `ProviderLoop.loadModelContainer`) — the bug only existed in
+    /// the MLXVLM `Qwen35` implementation (stale `precomputedPositionIds`
+    /// on the shared LanguageModel module), NOT in the MLXLLM one, so the
+    /// regression test MUST load through the same factory the provider
+    /// uses.
+    static let hybridModelID = "mlx-community/Qwen3.5-0.8B-MLX-4bit"
+
+    /// Load the model into a fresh `BatchScheduler` through the SAME
+    /// factory selection `ProviderLoop.loadModelContainer` uses (VLM
+    /// factory when config.json declares `vision_config`). The shared
+    /// `LiveInferenceFixtures.loadScheduler` always uses `LLMModelFactory`,
+    /// which does not reproduce this bug.
+    private func loadProviderStyle(
+        modelID: String
+    ) async throws -> (scheduler: BatchScheduler, container: ModelContainer) {
+        guard LiveInferenceFixtures.ensureMetallibColocated() != nil else {
+            throw LiveFixtureSkip.missingMetallib
+        }
+        guard case .found(let directory) = LiveInferenceFixtures.locate(modelID) else {
+            throw LiveFixtureSkip.modelNotInCache(modelID)
+        }
+        LiveInferenceFixtures.applyMemoryBudget(maxBytes: 8 * 1024 * 1024 * 1024)
+
+        let container: ModelContainer
+        if ProviderLoop.modelIsVLM(at: directory) {
+            container = try await VLMModelFactory.shared.loadContainer(
+                from: directory, using: LocalTokenizerLoader())
+        } else {
+            container = try await LLMModelFactory.shared.loadContainer(
+                from: directory, using: LocalTokenizerLoader())
+        }
+        let scheduler = BatchScheduler(
+            maxConcurrentRequests: 4,
+            pendingTimeout: .seconds(60),
+            defaultMaxTokens: 256
+        )
+        await scheduler.loadModel(container: container, modelId: modelID)
+        return (scheduler, container)
+    }
+
+    /// Drive one OpenAI-shaped chat request through the same
+    /// engine+service pipeline `ProviderLoop.runStartupSelfTestDecode` and
+    /// `ProviderLoop.handleInferenceRequest` use, and collect the frames.
+    private func streamRequest(
+        scheduler: BatchScheduler,
+        tokenizer: TokenizerHandle,
+        modelId: String,
+        userText: String,
+        maxTokens: Int
+    ) async throws -> (frames: Int, content: String) {
+        let engine = MultiModelBatchSchedulerEngine(
+            registryProvider: { @Sendable in
+                [modelId: .init(scheduler: scheduler, tokenizer: tokenizer)]
+            },
+            defaultMaxTokens: 256
+        )
+        let service = MLXOpenAIService(engine: engine)
+        let request = OpenAIChatCompletionRequest(
+            model: modelId,
+            messages: [.init(role: .user, content: .text(userText))],
+            stream: true,
+            temperature: 0,
+            maxTokens: maxTokens
+        )
+        let frames = try await service.streamChatCompletionFrames(request: request)
+        var frameCount = 0
+        var content = ""
+        for try await frame in frames {
+            frameCount += 1
+            if let parsed = ProviderLoop.parseStreamChunk(frame) {
+                if let delta = parsed.contentDelta { content += delta }
+                if let delta = parsed.reasoningDelta { content += delta }
+            }
+        }
+        return (frameCount, content)
+    }
+
+    @Test(
+        "hybrid model: self-test-shaped decode then a real request must not fault",
+        .enabled(if: LiveInferenceFixtures.liveTestsEnabled)
+    )
+    func selfTestThenRealRequest() async throws {
+        let loaded = try await loadProviderStyle(modelID: Self.hybridModelID)
+        let scheduler = loaded.scheduler
+        defer { Task { await scheduler.unloadModel() } }
+        let tokenizer: TokenizerHandle = await loaded.container.perform { ctx in
+            TokenizerHandle(ctx.tokenizer)
+        }
+
+        // 1. The startup self-test's exact shape: "Hi", greedy, one token.
+        let selfTest = try await streamRequest(
+            scheduler: scheduler, tokenizer: tokenizer,
+            modelId: Self.hybridModelID, userText: "Hi", maxTokens: 1
+        )
+        #expect(selfTest.frames > 0, "self-test decode produced no frames")
+
+        // 2. A routed-request shape: longer prompt, multi-token decode.
+        //    Before the fix this died in MLX with a broadcast_shapes fatal
+        //    against the self-test's 12-token residue.
+        let real = try await streamRequest(
+            scheduler: scheduler, tokenizer: tokenizer,
+            modelId: Self.hybridModelID,
+            userText: "What is 7 * 8? Reply with just the number.",
+            maxTokens: 8
+        )
+        #expect(real.frames > 0, "real request after self-test produced no frames")
+        #expect(!real.content.isEmpty, "real request after self-test produced no content")
+    }
+
+    @Test(
+        "hybrid model: two sequential normal requests must not fault",
+        .enabled(if: LiveInferenceFixtures.liveTestsEnabled)
+    )
+    func twoSequentialRealRequests() async throws {
+        let loaded = try await loadProviderStyle(modelID: Self.hybridModelID)
+        let scheduler = loaded.scheduler
+        defer { Task { await scheduler.unloadModel() } }
+        let tokenizer: TokenizerHandle = await loaded.container.perform { ctx in
+            TokenizerHandle(ctx.tokenizer)
+        }
+
+        let first = try await streamRequest(
+            scheduler: scheduler, tokenizer: tokenizer,
+            modelId: Self.hybridModelID,
+            userText: "Reply with the single word 'sky'.",
+            maxTokens: 6
+        )
+        #expect(first.frames > 0, "first request produced no frames")
+
+        let second = try await streamRequest(
+            scheduler: scheduler, tokenizer: tokenizer,
+            modelId: Self.hybridModelID,
+            userText: "What is 7 * 8? Reply with just the number.",
+            maxTokens: 8
+        )
+        #expect(second.frames > 0, "second request produced no frames")
+        #expect(!second.content.isEmpty, "second request produced no content")
+    }
+}

--- a/provider-swift/Tests/ProviderCoreTests/UnifiedMemoryCapTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/UnifiedMemoryCapTests.swift
@@ -74,6 +74,45 @@ private let gib: UInt64 = 1024 * 1024 * 1024
     #expect(kv == 0)
 }
 
+@Test func kvBudgetHonorsConfigReserveWhenItExceedsCapImpliedReserve() {
+    // 16 GiB box: hard cap = min(0.9×16 = 14.4, 16 − 2 = 14) = 14 GiB, so the
+    // cap-implied reserve is 2 GiB. The DEFAULT memory_reserve_gb (4 GiB)
+    // exceeds it → the effective cap drops to 16 − 4 = 12 GiB, exactly the
+    // hold-back the load gate and the runtime KV gate apply.
+    let phys = 16 * gib
+    let weights = 6 * gib
+    let noReserve = UnifiedMemoryCap.kvBudgetBytes(
+        physicalBytes: phys, residentWeightBytes: weights, activationReserveBytes: 1 * gib)
+    let withReserve = UnifiedMemoryCap.kvBudgetBytes(
+        physicalBytes: phys, residentWeightBytes: weights, activationReserveBytes: 1 * gib,
+        configReserveBytes: 4 * gib)
+    #expect(noReserve == 7 * gib)  // 14 − 6 − 1
+    #expect(withReserve == 5 * gib)  // 12 − 6 − 1
+}
+
+@Test func kvBudgetConfigReserveIsANoOpWhenCapImpliedReserveIsLarger() {
+    // 64 GiB box: cap 57.6 GiB ⇒ implied reserve 6.4 GiB > the default 4 GiB
+    // reserve, so the configured reserve must change nothing.
+    let phys = 64 * gib
+    let base = UnifiedMemoryCap.kvBudgetBytes(
+        physicalBytes: phys, residentWeightBytes: 10 * gib, activationReserveBytes: 3 * gib)
+    let withReserve = UnifiedMemoryCap.kvBudgetBytes(
+        physicalBytes: phys, residentWeightBytes: 10 * gib, activationReserveBytes: 3 * gib,
+        configReserveBytes: 4 * gib)
+    #expect(withReserve == base)
+}
+
+@Test func kvBudgetConfigReserveClampsToZeroNeverNegative() {
+    // A pathological reserve at/above physical memory zeroes the budget
+    // rather than underflowing.
+    #expect(UnifiedMemoryCap.kvBudgetBytes(
+        physicalBytes: 16 * gib, residentWeightBytes: 0,
+        activationReserveBytes: 0, configReserveBytes: 16 * gib) == 0)
+    #expect(UnifiedMemoryCap.kvBudgetBytes(
+        physicalBytes: 16 * gib, residentWeightBytes: 0,
+        activationReserveBytes: 0, configReserveBytes: 20 * gib) == 0)
+}
+
 @Test func activationReserveDefaultsToFloorAndReadsEnv() {
     #expect(UnifiedMemoryCap.resolvedActivationReserveBytes(explicit: nil, env: [:]) == 3 * gib)
     #expect(UnifiedMemoryCap.resolvedActivationReserveBytes(

--- a/provider-swift/Tests/ProviderCoreTests/UpdateJitterTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/UpdateJitterTests.swift
@@ -67,6 +67,39 @@ struct UpdateJitterTests {
 
 // MARK: - AutoUpdateController sequencing
 
+/// Minimal async gate for the cancellation test (file-private copy of the
+/// ModelPrefetchCoordinatorTests helper).
+private final class JitterGate: @unchecked Sendable {
+    private let lock = NSLock()
+    private var permits = 0
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func signal() {
+        let waiter: CheckedContinuation<Void, Never>? = lock.withLock {
+            if waiters.isEmpty {
+                permits += 1
+                return nil
+            }
+            return waiters.removeFirst()
+        }
+        waiter?.resume()
+    }
+
+    func wait() async {
+        await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
+            let resumeNow: Bool = lock.withLock {
+                if permits > 0 {
+                    permits -= 1
+                    return true
+                }
+                waiters.append(cont)
+                return false
+            }
+            if resumeNow { cont.resume() }
+        }
+    }
+}
+
 @Suite("AutoUpdateController rollover jitter")
 struct AutoUpdateJitterSequencingTests {
 
@@ -150,5 +183,49 @@ struct AutoUpdateJitterSequencingTests {
         #expect(outcome == .stageFailed("disk full"))
         #expect(!recorder.events.contains("jitter"))
         #expect(!recorder.events.contains("beginDraining"))
+    }
+
+    @Test("cancellation during the jitter window aborts the cycle before any install side effect")
+    func cancellationDuringJitterAborts() async {
+        let recorder = Recorder()
+        let jitterStarted = JitterGate()
+        // A jitter that parks like the production wiring does: `try? await
+        // Task.sleep` returns EARLY on cancellation — the regression this
+        // pins is that an early return must not be read as permission to
+        // drain + commit + restart a shutting-down provider.
+        let deps = AutoUpdateController.Dependencies(
+            claimStart: { recorder.record("claim"); return true },
+            resumeServing: { recorder.record("resume") },
+            check: {
+                recorder.record("check")
+                return .updateAvailable(current: "1.0.0", latest: Self.release)
+            },
+            downloadVerifyStage: { _ in recorder.record("stage"); return .completed },
+            waitBeforeInstall: {
+                recorder.record("jitter")
+                jitterStarted.signal()
+                try? await Task.sleep(for: .seconds(300))
+            },
+            beginDraining: { recorder.record("beginDraining") },
+            waitForDrain: { _ in recorder.record("waitForDrain"); return true },
+            forceCancelInflight: { recorder.record("forceCancel") },
+            commitInstall: { recorder.record("commit"); return .completed },
+            restart: { recorder.record("restart") },
+            log: { _ in }
+        )
+        let controller = AutoUpdateController(deps: deps, drainTimeout: .milliseconds(10))
+
+        let cycle = Task { await controller.run() }
+        await jitterStarted.wait()
+        cycle.cancel()
+        let outcome = await cycle.value
+
+        #expect(outcome == .cancelled)
+        // No install side effect after the cancelled jitter — and the cycle
+        // resumed serving so a later tick can retry.
+        #expect(recorder.events == ["claim", "check", "stage", "jitter", "resume"])
+        #expect(!recorder.events.contains("beginDraining"))
+        #expect(!recorder.events.contains("commit"))
+        #expect(!recorder.events.contains("restart"))
     }
 }

--- a/provider-swift/Tests/ProviderCoreTests/UpdateJitterTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/UpdateJitterTests.swift
@@ -1,0 +1,154 @@
+/// Rollover-jitter tests: delay bounds (seeded RNG), the disabled/forced
+/// bypasses, and the AutoUpdateController sequencing — the jitter must sit
+/// strictly AFTER download/verify/stage (security checks undeferred, still
+/// serving) and BEFORE the drain, and must never run on the no-update paths.
+
+import Foundation
+import Testing
+
+@testable import ProviderCore
+
+// MARK: - Deterministic RNG
+
+/// SplitMix64 — tiny deterministic RNG for bound assertions.
+private struct SeededRNG: RandomNumberGenerator {
+    private var state: UInt64
+    init(seed: UInt64) { self.state = seed }
+    mutating func next() -> UInt64 {
+        state &+= 0x9E37_79B9_7F4A_7C15
+        var z = state
+        z = (z ^ (z >> 30)) &* 0xBF58_476D_1CE4_E5B9
+        z = (z ^ (z >> 27)) &* 0x94D0_49BB_1331_11EB
+        return z ^ (z >> 31)
+    }
+}
+
+@Suite("UpdateJitter")
+struct UpdateJitterTests {
+
+    @Test("delays stay within [0, maxSeconds] and actually vary")
+    func delayBounds() {
+        var rng = SeededRNG(seed: 42)
+        var seen = Set<Duration>()
+        for _ in 0..<500 {
+            let delay = UpdateJitter.delay(maxSeconds: 300, using: &rng)
+            #expect(delay >= .zero)
+            #expect(delay <= .seconds(300))
+            seen.insert(delay)
+        }
+        // Uniform draws over 300_000 ms — a degenerate constant would defeat
+        // the whole point of de-correlating fleet restarts.
+        #expect(seen.count > 10)
+    }
+
+    @Test("update_jitter_seconds = 0 disables jitter")
+    func zeroMaxDisables() {
+        var rng = SeededRNG(seed: 7)
+        #expect(UpdateJitter.delay(maxSeconds: 0, using: &rng) == .zero)
+    }
+
+    @Test("forced updates bypass jitter entirely")
+    func forcedBypassesJitter() {
+        var rng = SeededRNG(seed: 7)
+        for _ in 0..<50 {
+            #expect(UpdateJitter.delay(maxSeconds: 300, forced: true, using: &rng) == .zero)
+        }
+    }
+
+    @Test("a misconfigured huge max is capped at one hour")
+    func hugeMaxIsCapped() {
+        var rng = SeededRNG(seed: 7)
+        for _ in 0..<200 {
+            let delay = UpdateJitter.delay(maxSeconds: .max, using: &rng)
+            #expect(delay <= .seconds(UpdateJitter.maxJitterCapSeconds))
+        }
+    }
+}
+
+// MARK: - AutoUpdateController sequencing
+
+@Suite("AutoUpdateController rollover jitter")
+struct AutoUpdateJitterSequencingTests {
+
+    private final class Recorder: @unchecked Sendable {
+        private let lock = NSLock()
+        private var _events: [String] = []
+        func record(_ event: String) {
+            lock.lock(); _events.append(event); lock.unlock()
+        }
+        var events: [String] {
+            lock.lock(); defer { lock.unlock() }; return _events
+        }
+    }
+
+    private static let release = ReleaseInfo(
+        version: "2.0.0",
+        platform: "macos-arm64",
+        url: "https://example.test/bundle.tar.gz",
+        bundleHash: String(repeating: "a", count: 64)
+    )
+
+    private func makeController(
+        checkResult: UpdateCheckResult,
+        stageResult: AutoUpdateController.StepOutcome = .completed,
+        recorder: Recorder
+    ) -> AutoUpdateController {
+        let deps = AutoUpdateController.Dependencies(
+            claimStart: { recorder.record("claim"); return true },
+            resumeServing: { recorder.record("resume") },
+            check: { recorder.record("check"); return checkResult },
+            downloadVerifyStage: { _ in recorder.record("stage"); return stageResult },
+            waitBeforeInstall: { recorder.record("jitter") },
+            beginDraining: { recorder.record("beginDraining") },
+            waitForDrain: { _ in recorder.record("waitForDrain"); return true },
+            forceCancelInflight: { recorder.record("forceCancel") },
+            commitInstall: { recorder.record("commit"); return .completed },
+            restart: { recorder.record("restart") },
+            log: { _ in }
+        )
+        return AutoUpdateController(deps: deps, drainTimeout: .milliseconds(10))
+    }
+
+    @Test("jitter runs after the verified stage and before the drain")
+    func jitterSitsBetweenStageAndDrain() async {
+        let recorder = Recorder()
+        let controller = makeController(
+            checkResult: .updateAvailable(current: "1.0.0", latest: Self.release),
+            recorder: recorder)
+
+        let outcome = await controller.run()
+
+        #expect(outcome == .restarted(from: "1.0.0", to: "2.0.0", drained: true))
+        #expect(recorder.events == [
+            "claim", "check", "stage", "jitter", "beginDraining",
+            "waitForDrain", "commit", "restart",
+        ])
+    }
+
+    @Test("no update available: jitter never runs")
+    func upToDateSkipsJitter() async {
+        let recorder = Recorder()
+        let controller = makeController(
+            checkResult: .upToDate(currentVersion: "1.0.0"),
+            recorder: recorder)
+
+        _ = await controller.run()
+
+        #expect(!recorder.events.contains("jitter"))
+    }
+
+    @Test("failed stage: jitter never runs (nothing verified to install)")
+    func stageFailureSkipsJitter() async {
+        let recorder = Recorder()
+        let controller = makeController(
+            checkResult: .updateAvailable(current: "1.0.0", latest: Self.release),
+            stageResult: .failed("disk full"),
+            recorder: recorder)
+
+        let outcome = await controller.run()
+
+        #expect(outcome == .stageFailed("disk full"))
+        #expect(!recorder.events.contains("jitter"))
+        #expect(!recorder.events.contains("beginDraining"))
+    }
+}


### PR DESCRIPTION
## Provider: ContinuousBatchingV2 bridge behind `DARKBLOOM_ENGINE_V2` (Gemma 4 + GPT-OSS 20B)

Wires the provider to the new per-request-KV continuous-batching engine (`libs/mlx-swift-lm` ContinuousBatchingV2, submodule bump) behind a feature flag with model allowlisting and legacy fallback. Flag off ⇒ byte-identical legacy behavior with zero added overhead.

### Before / after

```mermaid
flowchart TB
  subgraph Before [Before — legacy only]
    L1[ensureModelLoaded] --> L2[BatchScheduler per slot]
    L2 --> L3[InferenceHandler / LocalEndpoint<br/>→ MultiModelBatchSchedulerEngine]
    L3 --> L4["padded-batch engine<br/>(left-padding bug class,<br/>worst-case KV reservation)"]
  end
  subgraph After [After — flag-gated v2 alongside legacy]
    A1[ensureModelLoaded] --> A2{DARKBLOOM_ENGINE_V2<br/>+ model allowlist?}
    A2 -- no / init failure --> A3["legacy BatchScheduler<br/>(unchanged; WARN telemetry on fallback)"]
    A2 -- yes --> A4["EngineV2Factory.makeProductionEngine:<br/>Gemma4/GPTOSS newCacheV2 → EngineV2<br/>(contiguous KV backend, concurrency 4)"]
    A4 --> A5["ModelSlot.engineV2 alongside scheduler<br/>registered in EngineV2Runtime"]
    A5 --> A6["InferenceHandler / LocalEndpoint route<br/>bridge.submitTokenized (same SSE framing,<br/>same 429/503 error classes)"]
    A6 --> A7["heartbeat capacity: truthful bytes-derived<br/>budgets, no double-report; stepsExecuted<br/>feeds WedgeMonitor; cancel fan-out"]
  end
```

### Behavior

- **Request flow (flag on, allowlisted `gemma-4*` / `gpt-oss*`)**: tokenization and sampling translation reuse the legacy paths (identical stop resolution via `buildStopTokenIds` semantics, `temperature ?? 0.0` legacy default, logit_bias parsing, logprobs passthrough); event framing mirrors the legacy bridge exactly (chunks → single usage → finish; cancel emits usage before error; billing-zero defense); `CBv2KVError.capacityExhausted` maps to the canonical `token_budget_exhausted:` string so coordinator-facing 429/503 classification is unchanged. **No wire-protocol changes.**
- **Flag off**: legacy scheduler untouched; capacity/cancel paths guard the v2 runtime hop (zero consults, regression-tested).
- **Lifecycle**: v2 slots register at load and retire (unregister + drain) through `unloadModel` — covers idle-timeout, LRU eviction, hard swap, shutdown. Init failure ⇒ WARN `engine_v2_fallback` telemetry + legacy.
- **Wedge signal**: engine-published monotonic `stepsExecuted` feeds WedgeMonitor (replaces the event-count proxy).
- Forward plumbing (inert today): per-request `cacheSalt` mapping for the prefix cache (off in production config, TB-007).

### Validation

- 50+ EngineV2 tests / 10+ suites (translation, framing, error mapping, config gating, production wiring with scripted engine stubs, cancel propagation, capacity fold-in without double-report, unload retirement, fallback telemetry) — all live-isolated, no models/network/prod.
- Full provider suite green (1214+ tests); coordinator `go test ./...` green (21 packages).
- Engine-side gate: two independent full-diff reviews + two final-gate re-reviews (PASS, zero open findings); 229 CBv2 engine tests; real-model validation below.

**Real-model validation** (final composed matrix in the engine PR): both prod models pass all correctness gates token-exactly (batch invariance incl. mid-stream join, chunked prefill, compiled parity). Final numbers vs the current prod config (legacy compiled): **B=1 par-to-ahead (+2-4%), aggregate throughput +29-42% at B=4, TTFT 2-3x better at all concurrency** — v2 eager (contiguous) is the recommended production default for both models; compiled and paged variants are available behind engine config and validated token-exact.

### Rollout plan

1. Ships **dark** (flag off everywhere).
2. Canary: enable `DARKBLOOM_ENGINE_V2=1` on operator-controlled providers (M-Pro-class+, 16GB+), Gemma 4 + GPT-OSS only, watch `engine_v2` tagged TTFT/ITL/wedge/fallback telemetry vs legacy cohort.
3. Widen by chip class; kill switch = unset env (or `DARKBLOOM_ENGINE_V2=0` beats config).
4. Prefix cache stays off pending the windowed-upstream drift-bound follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
