### PR TITLE
fix(provider): v0.7.1 — engine_v2 allowlist uses fleet catalog ids (drop HF repo ids)

### DIFF
--- a/coordinator/api/server.go
+++ b/coordinator/api/server.go
@@ -145,7 +145,7 @@ func keyLimitResetFromContext(ctx context.Context) string {
 // 0.6.0 is the APNs code-identity / VLM-routing / graceful-update release.
 // Keep this fallback in sync with ProviderCore.version so dev/in-memory
 // coordinators advertise the same floor as the Swift binary they expect.
-var LatestProviderVersion = "0.7.0"
+var LatestProviderVersion = "0.7.1"
 
 // minProviderVersionForDesiredModels is the first provider version whose Swift
 // runtime understands the desired_models message. The coordinator must NOT send

--- a/provider-swift/Sources/ProviderCore/Config/ProviderConfig.swift
+++ b/provider-swift/Sources/ProviderCore/Config/ProviderConfig.swift
@@ -91,8 +91,9 @@ public struct BackendSettings: Sendable, Equatable, Codable {
     /// fixed 512-token production path. Enable with `adaptive_prefill = true`
     /// under `[backend]` in provider.toml.
     public var adaptivePrefill: Bool
-    /// ContinuousBatchingV2 engine for the allowlisted models (the exact
-    /// production checkpoints — see `EngineV2Config.defaultModelAllowlist`).
+    /// ContinuousBatchingV2 engine for the allowlisted models (the
+    /// coordinator-catalog fleet model ids — see
+    /// `EngineV2Config.defaultModelAllowlist`).
     /// **Default true as of v0.7.0**: v2 ships on by default for the
     /// allowlisted models; every other model keeps the legacy
     /// `BatchedEngine` path byte-identical. Rollback is the env kill

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2Config.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2Config.swift
@@ -28,10 +28,11 @@
 //      — **default true** (v0.7.0). Rollback = env kill switch or release
 //      rollback.
 //
-// Per-model allowlist: default is the EXACT production checkpoint ids —
-// default-on scope == real-model-validated scope. Operators can widen it
-// via env `DARKBLOOM_ENGINE_V2_MODELS` (comma-separated patterns, e.g. to
-// stage a QAT-4bit build later).
+// Per-model allowlist: default is the set of coordinator-catalog model ids
+// the production fleet actually advertises (these are the registry/heartbeat
+// ids, NOT HuggingFace repo ids) — all three were parity/soak-validated on
+// real weights. Operators can widen it via env `DARKBLOOM_ENGINE_V2_MODELS`
+// (comma-separated patterns, e.g. to stage another checkpoint quantization).
 
 import Foundation
 import MLXLMCommon
@@ -47,19 +48,24 @@ public enum EngineV2Config {
     /// Optional comma-separated allowlist pattern override
     /// (exact ids or trailing-`*` prefix globs). Empty/absent keeps the
     /// default. Use to widen the default-on scope for staged rollout
-    /// (e.g. a QAT-4bit checkpoint later).
+    /// (e.g. another checkpoint quantization).
     public static let environmentAllowlist = "DARKBLOOM_ENGINE_V2_MODELS"
 
-    /// The models the v2 engine serves by default: the EXACT checkpoint ids
-    /// production serves today — default-on scope == real-model-validated
-    /// scope (both were parity/soak-validated on real weights). Matched
-    /// case-insensitively against the model id and its last path component
-    /// (registry ids are `org/name` shaped). Every other model — including
-    /// other gemma-4 / gpt-oss quantizations — keeps the legacy engine
-    /// until an operator widens the list via `DARKBLOOM_ENGINE_V2_MODELS`.
+    /// The models the v2 engine serves by default: the coordinator-catalog
+    /// model ids the production fleet actually advertises (these are the
+    /// registry/heartbeat ids, NOT HuggingFace repo ids). All three were
+    /// parity/soak-validated on real weights — `gpt-oss-20b` and
+    /// `gemma-4-26b-8bit` are the two 8-bit / GPT-OSS production models, and
+    /// `gemma-4-26b-qat-4bit` passed strict batch-invariance and benchmarked
+    /// faster. Matched case-insensitively against the model id and its last
+    /// path component (some ids may be `org/name` shaped). Every other model
+    /// — including other gemma-4 / gpt-oss quantizations — keeps the legacy
+    /// engine until an operator widens the list via
+    /// `DARKBLOOM_ENGINE_V2_MODELS`.
     public static let defaultModelAllowlist = [
-        "mlx-community/gpt-oss-20b-MXFP4-Q8",
-        "mlx-community/gemma-4-26b-a4b-it-8bit",
+        "gpt-oss-20b",
+        "gemma-4-26b-8bit",
+        "gemma-4-26b-qat-4bit",
     ]
 
     public enum Selection: String, Sendable, Equatable {
@@ -99,9 +105,9 @@ public enum EngineV2Config {
     /// Does `modelId` match any allowlist pattern? Patterns are
     /// case-insensitive; a trailing `*` makes them prefix globs, otherwise
     /// they must match exactly. Both the full id and its last `/` component
-    /// are tried on BOTH sides, so `mlx-community/gemma-4-26b-a4b-it-8bit`
-    /// matches the bare pattern `gemma-4-26b-a4b-it-8bit` AND the bare id
-    /// `gpt-oss-20b-MXFP4-Q8` matches the org-qualified default pattern.
+    /// are tried on BOTH sides, so an org-qualified id like
+    /// `some-org/gpt-oss-20b` still matches the bare pattern `gpt-oss-20b`,
+    /// and a bare id matches an org-qualified pattern by last component.
     public static func modelAllowlisted(
         _ modelId: String,
         patterns: [String] = defaultModelAllowlist

--- a/provider-swift/Sources/ProviderCore/ProviderCore.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderCore.swift
@@ -75,5 +75,5 @@ public enum ProviderCore {
     // jinja_null_bridge / jinja_template / model_load), so durable telemetry can
     // tell the two indistinguishable gpt-oss 500 modes apart. Wire-compatible:
     // `error_reason` is an optional inference-error field, omitted when nil.
-    public static let version = "0.7.0"
+    public static let version = "0.7.1"
 }

--- a/provider-swift/Tests/ProviderCoreTests/EngineV2BridgeTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/EngineV2BridgeTests.swift
@@ -1130,23 +1130,28 @@ struct EngineV2ConfigGatingTests {
         #expect(!EngineV2Config.flagEnabled(environment: ["DARKBLOOM_ENGINE_V2": "maybe"], configEnabled: true))
     }
 
-    @Test("default allowlist: EXACT production checkpoint ids only")
+    @Test("default allowlist: fleet catalog model ids only")
     func defaultAllowlist() {
-        // The two checkpoints v2 was parity/soak-validated on — the default-on
-        // scope must equal the real-model-validated scope, nothing broader.
-        #expect(EngineV2Config.modelAllowlisted("mlx-community/gpt-oss-20b-MXFP4-Q8"))
-        #expect(EngineV2Config.modelAllowlisted("mlx-community/gemma-4-26b-a4b-it-8bit"))
-        // Case-insensitive + last-path-component matching still applies.
-        #expect(EngineV2Config.modelAllowlisted("MLX-Community/GPT-OSS-20B-MXFP4-Q8"))
-        #expect(EngineV2Config.modelAllowlisted("gpt-oss-20b-MXFP4-Q8"))
-        // Other quantizations of the SAME families are NOT default-enabled —
-        // they were not validated on real weights. Operators widen via
+        // The three coordinator-catalog ids the production fleet advertises —
+        // the default-on scope must equal the parity/soak-validated scope,
+        // nothing broader. These are NOT HuggingFace repo ids.
+        #expect(EngineV2Config.modelAllowlisted("gpt-oss-20b"))
+        #expect(EngineV2Config.modelAllowlisted("gemma-4-26b-8bit"))
+        #expect(EngineV2Config.modelAllowlisted("gemma-4-26b-qat-4bit"))
+        // Case-insensitive matching still applies.
+        #expect(EngineV2Config.modelAllowlisted("GPT-OSS-20B"))
+        #expect(EngineV2Config.modelAllowlisted("Gemma-4-26B-QAT-4bit"))
+        // The old HuggingFace repo ids are now REJECTED: their last path
+        // component (`gpt-oss-20b-mxfp4-q8`, `gemma-4-26b-a4b-it-8bit`) differs
+        // from the fleet catalog id, so v2 must NOT engage on them. This is the
+        // exact mismatch that made v0.7.0 inert fleet-wide.
+        #expect(!EngineV2Config.modelAllowlisted("mlx-community/gpt-oss-20b-MXFP4-Q8"))
+        #expect(!EngineV2Config.modelAllowlisted("mlx-community/gemma-4-26b-a4b-it-8bit"))
+        // Other quantizations / families are NOT default-enabled — they were
+        // not validated on real weights. Operators widen via
         // DARKBLOOM_ENGINE_V2_MODELS.
-        #expect(!EngineV2Config.modelAllowlisted("mlx-community/gpt-oss-20b-4bit"))
-        #expect(!EngineV2Config.modelAllowlisted("mlx-community/gemma-4-27b-it-4bit"))
-        #expect(!EngineV2Config.modelAllowlisted("gemma-4-26B-A4B-it-qat-4bit"))
+        #expect(!EngineV2Config.modelAllowlisted("gemma-4-27b-it-4bit"))
         #expect(!EngineV2Config.modelAllowlisted("qwen3-8b"))
-        #expect(!EngineV2Config.modelAllowlisted("mlx-community/Qwen3.5-0.8B-MLX-4bit"))
         #expect(!EngineV2Config.modelAllowlisted("llama-3.3-70b"))
         #expect(!EngineV2Config.modelAllowlisted(""))
     }
@@ -1163,7 +1168,7 @@ struct EngineV2ConfigGatingTests {
 
     @Test("selection matrix")
     func selectionMatrix() {
-        let prodGemma = "mlx-community/gemma-4-26b-a4b-it-8bit"
+        let prodGemma = "gemma-4-26b-8bit"
         // Config off (explicit opt-out) → legacy even for allowlisted models.
         #expect(EngineV2Config.selection(
             modelId: prodGemma, environment: [:], configEnabled: false
@@ -1175,7 +1180,7 @@ struct EngineV2ConfigGatingTests {
             configEnabled: BackendSettings().engineV2
         ) == .v2)
         #expect(EngineV2Config.selection(
-            modelId: "mlx-community/gpt-oss-20b-MXFP4-Q8", environment: [:],
+            modelId: "gpt-oss-20b", environment: [:],
             configEnabled: BackendSettings().engineV2
         ) == .v2)
         #expect(EngineV2Config.selection(
@@ -1244,7 +1249,7 @@ struct EngineV2ConfigGatingTests {
         struct InitFailure: Error {}
         let telemetry = TelemetrySink()
         let bridge = EngineV2Factory.makeBridgeIfSelected(
-            modelId: "mlx-community/gpt-oss-20b-MXFP4-Q8",
+            modelId: "gpt-oss-20b",
             configEnabled: true,
             environment: [:],
             tokenizer: TokenizerHandle(StubTokenizer()),
@@ -1259,7 +1264,7 @@ struct EngineV2ConfigGatingTests {
         #expect(events.first?.severity == .warn)
         #expect(events.first?.fields?["operation"]?.description == "engine_v2_fallback")
         #expect(events.first?.fields?["backend"]?.description == "engine_v2")
-        #expect(events.first?.fields?["model"]?.description == "mlx-community/gpt-oss-20b-MXFP4-Q8")
+        #expect(events.first?.fields?["model"]?.description == "gpt-oss-20b")
         #expect(events.first?.fields?["error_class"]?.description.contains("InitFailure") == true)
         // Default-on posture: the fallback is load-bearing, so the event must
         // carry the human-readable reason too, not just the error type.
@@ -1269,7 +1274,7 @@ struct EngineV2ConfigGatingTests {
     @Test("factory: selected + healthy builder → v2 bridge")
     func factorySelectedBuilds() {
         let bridge = EngineV2Factory.makeBridgeIfSelected(
-            modelId: "mlx-community/gemma-4-26b-a4b-it-8bit",
+            modelId: "gemma-4-26b-8bit",
             configEnabled: true,
             environment: [:],
             tokenizer: TokenizerHandle(StubTokenizer()),

--- a/provider-swift/Tests/ProviderCoreTests/EngineV2ProductionWiringTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/EngineV2ProductionWiringTests.swift
@@ -534,7 +534,7 @@ struct EngineV2SlotFactoryTests {
                 makeEngine: { _, _ in throw InitFailure() }))
 
         let bridge = await loop.makeEngineV2BridgeForSlotForTesting(
-            modelId: "mlx-community/gpt-oss-20b-MXFP4-Q8",
+            modelId: "gpt-oss-20b",
             modelType: "gpt_oss",
             container: makeStubContainer(),
             tokenizer: TokenizerHandle(WiringStubTokenizer()),
@@ -542,7 +542,7 @@ struct EngineV2SlotFactoryTests {
         )
         #expect(bridge == nil)
         // Nothing registered — the slot serves legacy.
-        #expect(await runtime.bridge(forModel: "mlx-community/gpt-oss-20b-MXFP4-Q8") == nil)
+        #expect(await runtime.bridge(forModel: "gpt-oss-20b") == nil)
         let events = telemetry.events
         #expect(events.count == 1)
         #expect(events.first?.kind == .engineHealth)


### PR DESCRIPTION
# fix(provider): v0.7.1 — engine_v2 allowlist uses fleet catalog ids

## Root cause

v0.7.0 shipped Engine V2 (ContinuousBatchingV2) **default-on**, but gated
behind a per-model allowlist whose entries were **HuggingFace repo ids**:

```
mlx-community/gpt-oss-20b-MXFP4-Q8
mlx-community/gemma-4-26b-a4b-it-8bit
```

The production fleet does not advertise those ids. Verified against the prod
DB, online providers advertise the **coordinator-catalog** model ids:

| Fleet catalog id        | Online providers |
|-------------------------|------------------|
| `gpt-oss-20b`           | 255              |
| `gemma-4-26b-8bit`      | 179              |
| `gemma-4-26b-qat-4bit`  | 66               |

`EngineV2Config.modelAllowlisted` matches case-insensitively on the full id
and the last `/` path component, on both sides. The catalog ids and the HF
repo ids share **no** matching component (e.g. last component
`gpt-oss-20b-mxfp4-q8` ≠ `gpt-oss-20b`), so **`selection()` returned `.legacy`
for every real model** — Engine V2 never engaged anywhere. The whole fleet
silently ran the legacy `BatchedEngine`, exactly as if v2 had never shipped.

## Fix

Replace the allowlist with the three coordinator-catalog ids the fleet
actually advertises, and drop the HF repo ids entirely:

```swift
public static let defaultModelAllowlist = [
    "gpt-oss-20b",
    "gemma-4-26b-8bit",
    "gemma-4-26b-qat-4bit",
]
```

All three were parity/soak-validated on real weights: `gpt-oss-20b` and
`gemma-4-26b-8bit` are the two 8-bit / GPT-OSS production models;
`gemma-4-26b-qat-4bit` passed strict batch-invariance and benchmarked faster.
Doc comments in `EngineV2Config.swift` (and the `engine_v2` config-key doc in
`ProviderConfig.swift`) are re-framed: these are coordinator-catalog / fleet
model ids, **not** HuggingFace repo ids. Matching semantics are unchanged
(case-insensitive; exact or trailing-`*` prefix glob; full id and last path
component tried on both sides).

Version bumped to **0.7.1** (`ProviderCore.version`, coordinator
`LatestProviderVersion`).

## Kill switch / rollback

Unchanged and still absolute:

- **Per-box kill switch:** `DARKBLOOM_ENGINE_V2=0` (or `false`/`no`/`off`)
  forces legacy for that provider, beats config, no release needed.
- **Widen scope:** `DARKBLOOM_ENGINE_V2_MODELS="gpt-oss*,gemma-4*"`
  (comma-separated exact ids or trailing-`*` globs) overrides the default.
- **Release rollback:** re-deploy the prior provider bundle; a v2 init failure
  already falls back to legacy with a WARN `engine_v2_fallback` telemetry event
  (model id + reason), so a bad engine can never take a box down silently.

## Before / After

```mermaid
flowchart TB
  subgraph Before["Before (v0.7.0) — v2 inert fleet-wide"]
    A1[request: model gpt-oss-20b] --> B1[provider: EngineV2Config.selection]
    B1 --> C1{"allowlist =\nmlx-community/gpt-oss-20b-MXFP4-Q8,\nmlx-community/gemma-4-26b-a4b-it-8bit"}
    C1 -->|"no id/last-component match"| D1[selection = .legacy]
    D1 --> E1[legacy BatchedEngine]
  end
  subgraph After["After (v0.7.1) — v2 engages on prod models"]
    A2[request: model gpt-oss-20b] --> B2[provider: EngineV2Config.selection]
    B2 --> C2{"allowlist =\ngpt-oss-20b,\ngemma-4-26b-8bit,\ngemma-4-26b-qat-4bit"}
    C2 -->|"exact match"| D2[selection = .v2]
    D2 --> F2[EngineV2Factory.makeBridgeIfSelected]
    F2 -->|builds| G2[EngineV2Bridge / CBv2 engine]
    F2 -->|init throws| H2[legacy fallback + WARN engine_v2_fallback]
    C2 -->|"non-allowlisted (e.g. qwen3-8b)"| D2b[selection = .legacy]
    D2b --> E2[legacy BatchedEngine]
  end
```

## Tests

`EngineV2BridgeTests.swift`:

- `defaultAllowlist()` rewritten: positives now `gpt-oss-20b`,
  `gemma-4-26b-8bit`, `gemma-4-26b-qat-4bit` + a case-insensitive variant; the
  old HF repo ids are asserted **rejected** (the exact v0.7.0 miss), plus
  `qwen3-8b`, `llama-3.3-70b`, `""`, and a different gemma quant
  (`gemma-4-27b-it-4bit`).
- `selectionMatrix()`, `factoryInitFailureFallsBack()`, `factorySelectedBuilds()`
  updated to use the real fleet ids as their allowlisted examples so they still
  exercise the `.v2` path.

`EngineV2ProductionWiringTests.swift`:

- `initFailureFallsBackWithTelemetry()` used the old HF id under the **default**
  allowlist to reach the makeEngine throw. Under the new allowlist that id
  gates out to legacy before makeEngine, so it was switched to `gpt-oss-20b` —
  otherwise the fallback-telemetry assertion would silently stop being
  exercised.

`swift test --filter EngineV2` is green; `go build ./...` compiles.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/504"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785650837&installation_id=133247490&pr_number=504&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F504&signature=df3c8a737a71b9829a6ff95366a147eaa88eb9ef8630a2f06c6b13311c896df4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->