### PR TITLE
fix(provider): v0.7.2 — engine_v2 text routing on VLM-loaded Gemma 4 slots (weight-shared extraction, per-request routing)

### DIFF
--- a/coordinator/api/server.go
+++ b/coordinator/api/server.go
@@ -145,7 +145,7 @@ func keyLimitResetFromContext(ctx context.Context) string {
 // 0.6.0 is the APNs code-identity / VLM-routing / graceful-update release.
 // Keep this fallback in sync with ProviderCore.version so dev/in-memory
 // coordinators advertise the same floor as the Swift binary they expect.
-var LatestProviderVersion = "0.7.1"
+var LatestProviderVersion = "0.7.2"
 
 // minProviderVersionForDesiredModels is the first provider version whose Swift
 // runtime understands the desired_models message. The coordinator must NOT send

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2Factory+Production.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2Factory+Production.swift
@@ -32,8 +32,10 @@ import MLXLMCommon
 /// Failure modes of production v2-engine construction. Each maps to the
 /// factory's safe-fallback path (WARN telemetry + legacy engine).
 enum EngineV2ProductionError: Error, CustomStringConvertible {
-    /// The loaded module is not a CBv2-adapted family (e.g. an allowlisted
-    /// model id resolved to a VLM wrapper or an unexpected architecture).
+    /// The loaded module is not a CBv2-adapted family (an unexpected
+    /// architecture). Allowlisted Gemma 4 VLM wrappers do NOT land here —
+    /// the slot factory extracts their CBv2-adapted text model first
+    /// (`EngineV2VLMTextExtraction`) and hands THAT to this factory.
     case unsupportedModel(String)
     /// No KV byte budget is left under the unified-memory cap — an engine
     /// admitted with a zero ceiling would reject every request, so fall

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2VLMTextExtraction.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2VLMTextExtraction.swift
@@ -1,0 +1,344 @@
+// Copyright © 2026 Eigen Labs.
+//
+// ContinuousBatchingV2 — weight-sharing text-model extraction for VLM slots.
+//
+// Every production Gemma 4 checkpoint ships a vision tower, so the provider
+// loads it through `VLMModelFactory` and the resident module is MLXVLM's
+// `Gemma4` wrapper — whose language model is a PRIVATE inline duplicate of
+// the text architecture ("MLXVLM can't import MLXLLM") with none of the
+// CBv2 hooks (`cbv2LayerKinds` / `newCacheV2`). The v2 engine therefore
+// could never serve a VLM slot directly, and before v0.7.2 the per-slot
+// `isVLM` gate excluded 100% of prod Gemma traffic from engine v2.
+//
+// This file builds the CBv2-adapted MLXLLM `Gemma4TextModel` OVER THE SAME
+// WEIGHT ARRAYS the wrapper already holds:
+//
+//   1. decode the checkpoint's `config.json` `text_config` with MLXLLM's
+//      `Gemma4TextConfiguration` decoder and construct a lazy skeleton
+//      (nothing is materialized — MLXArray init is lazy until eval);
+//   2. re-apply the checkpoint's quantization STRUCTURE to the skeleton the
+//      exact way `loadWeights` did for the wrapper (scales-presence gate +
+//      the same per-layer table from `BaseConfiguration`, whose keys live in
+//      the checkpoint's `language_model.`-prefixed key space);
+//   3. re-key the wrapper's live parameter tree (`language_model.model.X` →
+//      `model.X`, `language_model.lm_head.X` → `lm_head.X`), run it through
+//      `Gemma4TextModel.sanitize` (drops shared-KV k/v duplicates the
+//      wrapper allocates but the MLXLLM model does not), and
+//      `update(parameters:verify:[.all])` — missing/extra/mis-shaped keys
+//      all THROW, which the engine factory catches as the standard
+//      `engine_v2_fallback` WARN + legacy path (never silent wrongness);
+//   4. run a tiny forward through BOTH the wrapper's text path and the
+//      extracted model and require cross-containment of each side's greedy
+//      argmax in the other side's top-5, plus a bounded max |Δlogit| — a
+//      load-time backstop against catastrophic extraction bugs (see
+//      `assertForwardParity` for why bit-parity is structurally
+//      unattainable; env `DARKBLOOM_ENGINE_V2_VLM_PARITY_CHECK=0` skips).
+//
+// The result is a SEPARATE module instance (own norms/rope/layer objects)
+// sharing only the immutable parameter arrays — zero extra weight memory,
+// and no module-level mutable state shared with the wrapper, which is what
+// makes the Qwen3.5-mrope class of cross-path state corruption structurally
+// impossible here. Concurrency: the legacy vision forward (wrapper) and v2
+// text forward (extracted model) may interleave on the same arrays; both
+// are read-only over the parameters (forward passes never mutate weights)
+// and each path owns its private KV caches.
+
+import Foundation
+import MLX
+import MLXLLM
+import MLXLMCommon
+import MLXNN
+import MLXVLM
+
+/// Failure modes of VLM text-model extraction. Every case lands in
+/// `EngineV2Factory.makeBridgeIfSelected`'s catch → WARN `engine_v2_fallback`
+/// telemetry + legacy serving. The messages are operator-facing (they ride
+/// the telemetry `error` field), so they say exactly what to look at.
+enum EngineV2VLMTextExtractionError: Error, CustomStringConvertible {
+    /// The loaded module is not a VLM wrapper this extraction understands.
+    case unsupportedWrapper(String)
+    /// The slot factory could not hand us the model directory (needed for
+    /// `config.json`).
+    case missingModelDirectory
+    /// `config.json` was unreadable or had no decodable `text_config`.
+    case invalidConfig(String)
+    /// The checkpoint has quantized weights but no `quantization` block in
+    /// `config.json` to derive the skeleton's quantization structure from.
+    case missingQuantizationConfig
+    /// The load-time forward parity gate failed: the extracted text model
+    /// disagrees with the wrapper's own text path on the same weights.
+    case parityMismatch(String)
+
+    var description: String {
+        switch self {
+        case .unsupportedWrapper(let type):
+            return "engine_v2 vlm extraction: unsupported VLM wrapper \(type)"
+        case .missingModelDirectory:
+            return "engine_v2 vlm extraction: model directory unavailable for config.json"
+        case .invalidConfig(let detail):
+            return "engine_v2 vlm extraction: config.json unusable (\(detail))"
+        case .missingQuantizationConfig:
+            return "engine_v2 vlm extraction: quantized weights but no quantization block in config.json"
+        case .parityMismatch(let detail):
+            return "engine_v2 vlm extraction: wrapper/extracted forward parity failed (\(detail))"
+        }
+    }
+}
+
+/// Weight-sharing extraction of the CBv2-adapted MLXLLM text model from a
+/// loaded MLXVLM wrapper. Pure functions; no state.
+enum EngineV2VLMTextExtraction {
+
+    /// Env kill switch for the load-time forward parity gate ("0"/"false"/
+    /// "no"/"off" disables). Default ON — the check is one tiny prefill at
+    /// model-load time and is the backstop against silent architecture
+    /// drift between MLXVLM's inline text model and MLXLLM's.
+    static let parityCheckFlag = "DARKBLOOM_ENGINE_V2_VLM_PARITY_CHECK"
+
+    /// Checkpoint key-space prefix of the wrapper's language model. Both the
+    /// parameter tree and the per-layer quantization table use it.
+    private static let languageModelPrefix = "language_model."
+
+    /// Result of one extraction: the CBv2-adapted text model (sharing the
+    /// wrapper's weight arrays) plus the parity probe's max |Δlogit| for the
+    /// slot factory's log line (nil when the parity gate was disabled).
+    struct Extraction {
+        let model: Gemma4TextModel
+        let parityMaxAbsLogitDiff: Float?
+    }
+
+    /// Build an MLXLLM `Gemma4TextModel` over the weight arrays of a loaded
+    /// MLXVLM `Gemma4` wrapper. See the file header for the full mechanism.
+    ///
+    /// - Parameters:
+    ///   - model: the slot's loaded module (must be `MLXVLM.Gemma4`).
+    ///   - modelDirectory: the checkpoint directory (for `config.json`).
+    ///   - environment: env snapshot (parity-gate kill switch).
+    static func extractTextModel(
+        from model: any LanguageModel,
+        modelDirectory: URL,
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) throws -> Extraction {
+        guard let wrapper = model as? MLXVLM.Gemma4 else {
+            throw EngineV2VLMTextExtractionError.unsupportedWrapper(
+                String(describing: type(of: model)))
+        }
+
+        // 1. Text config: decode the checkpoint's `text_config` with the SAME
+        //    decoder `LLMModelFactory` would use for a text-only checkpoint.
+        let configURL = modelDirectory.appendingPathComponent("config.json")
+        let configData: Data
+        do {
+            configData = try Data(contentsOf: configURL)
+        } catch {
+            throw EngineV2VLMTextExtractionError.invalidConfig(
+                "read \(configURL.path): \(error)")
+        }
+        let textConfig = try decodeTextConfiguration(configData: configData)
+
+        // Quantization table: `BaseConfiguration` holds the checkpoint-wide
+        // default plus the per-layer overrides, keyed in the checkpoint's
+        // `language_model.`-prefixed key space.
+        let baseConfig = try? JSONDecoder.json5().decode(BaseConfiguration.self, from: configData)
+
+        // 2-3. Lazy skeleton → quantization structure → weight-sharing update.
+        let skeleton = Gemma4TextModel(textConfig)
+        let textWeights = reKeyedTextWeights(wrapper: wrapper, sanitizer: skeleton)
+        try applyQuantizationStructure(
+            skeleton: skeleton, weights: textWeights,
+            perLayerQuantization: baseConfig?.perLayerQuantization)
+        // verify: [.all] — a missing model key, an unused weight key, or a
+        // shape mismatch all throw here. That is the design: any drift
+        // between the wrapper's parameter tree and the MLXLLM architecture
+        // must fail LOUDLY at load (→ engine_v2_fallback WARN + legacy),
+        // never produce a silently wrong serving model.
+        try skeleton.update(
+            parameters: ModuleParameters.unflattened(textWeights), verify: [.all])
+
+        // 4. Load-time forward parity gate (env-gated, default on).
+        var parityDiff: Float? = nil
+        if parityCheckEnabled(environment: environment) {
+            parityDiff = try assertForwardParity(
+                wrapper: wrapper, extracted: skeleton, vocabSize: textConfig.vocabSize)
+        }
+
+        return Extraction(model: skeleton, parityMaxAbsLogitDiff: parityDiff)
+    }
+
+    // MARK: - Steps
+
+    /// Decode MLXLLM's `Gemma4TextConfiguration` from the VLM checkpoint's
+    /// `text_config` block. The top-level `quantization` block is merged in
+    /// so the configuration's informational `quantizationBits`/`GroupSize`
+    /// fields reflect the checkpoint (they do not drive the skeleton's
+    /// quantization — `applyQuantizationStructure` does).
+    static func decodeTextConfiguration(configData: Data) throws -> Gemma4TextConfiguration {
+        let root: [String: Any]
+        do {
+            guard
+                let parsed = try JSONSerialization.jsonObject(with: configData)
+                    as? [String: Any]
+            else {
+                throw EngineV2VLMTextExtractionError.invalidConfig("config.json is not an object")
+            }
+            root = parsed
+        } catch let error as EngineV2VLMTextExtractionError {
+            throw error
+        } catch {
+            throw EngineV2VLMTextExtractionError.invalidConfig("parse config.json: \(error)")
+        }
+        guard var textConfigJSON = root["text_config"] as? [String: Any] else {
+            throw EngineV2VLMTextExtractionError.invalidConfig("no text_config object")
+        }
+        if textConfigJSON["quantization"] == nil, let quantization = root["quantization"] {
+            textConfigJSON["quantization"] = quantization
+        }
+        do {
+            let textConfigData = try JSONSerialization.data(withJSONObject: textConfigJSON)
+            return try JSONDecoder.json5().decode(Gemma4TextConfiguration.self, from: textConfigData)
+        } catch {
+            throw EngineV2VLMTextExtractionError.invalidConfig("decode text_config: \(error)")
+        }
+    }
+
+    /// Re-key the wrapper's live parameter tree into the text model's key
+    /// space and drop everything outside the language model (vision tower,
+    /// multimodal embedder). The result then passes through the text
+    /// model's own `sanitize`, which drops the k/v-projection duplicates
+    /// the wrapper allocates for KV-shared layers (MLXLLM does not allocate
+    /// those modules) and leaves everything else untouched.
+    private static func reKeyedTextWeights(
+        wrapper: MLXVLM.Gemma4, sanitizer: Gemma4TextModel
+    ) -> [String: MLXArray] {
+        var textWeights: [String: MLXArray] = [:]
+        for (key, value) in wrapper.parameters().flattened() {
+            guard key.hasPrefix(languageModelPrefix) else { continue }
+            textWeights[String(key.dropFirst(languageModelPrefix.count))] = value
+        }
+        return sanitizer.sanitize(weights: textWeights)
+    }
+
+    /// Mirror `loadWeights`' quantization pass onto the skeleton: a module is
+    /// quantized iff the (re-keyed, live) weights carry `<path>.scales`, with
+    /// (groupSize, bits, mode) resolved from the checkpoint's per-layer table
+    /// under the module's `language_model.`-prefixed checkpoint key — the
+    /// exact lookup the wrapper's own load performed, so the two module trees
+    /// can never disagree on quantization structure. All arrays involved stay
+    /// lazy; `update(parameters:)` replaces them before anything evaluates.
+    private static func applyQuantizationStructure(
+        skeleton: Gemma4TextModel,
+        weights: [String: MLXArray],
+        perLayerQuantization: BaseConfiguration.PerLayerQuantization?
+    ) throws {
+        let hasQuantizedWeights = weights.keys.contains { $0.hasSuffix(".scales") }
+        guard hasQuantizedWeights else { return }
+        guard let perLayerQuantization else {
+            throw EngineV2VLMTextExtractionError.missingQuantizationConfig
+        }
+        quantize(model: skeleton) { path, _ in
+            guard weights["\(path).scales"] != nil else { return nil }
+            return perLayerQuantization
+                .quantization(layer: languageModelPrefix + path)?.asTuple
+        }
+    }
+
+    // MARK: - Parity gate
+
+    static func parityCheckEnabled(environment: [String: String]) -> Bool {
+        guard
+            let raw = environment[parityCheckFlag]?
+                .trimmingCharacters(in: .whitespaces).lowercased(), !raw.isEmpty
+        else { return true }
+        return !["0", "false", "no", "off"].contains(raw)
+    }
+
+    /// Top-k window for the bidirectional argmax-containment check.
+    static let parityTopK = 5
+    /// Ceiling on max |Δlogit| across the probe. Final logits are
+    /// softcapped to ±`final_logit_softcapping` (30 on every Gemma 4
+    /// checkpoint), so unrelated distributions differ by up to ~60;
+    /// same-weights implementation noise measured ≤ ~8 (see below).
+    static let parityMaxAbsLogitDiff: Float = 20
+
+    /// One tiny forward through the wrapper's text path and the extracted
+    /// model on identical tokens — a CATASTROPHIC-EXTRACTION detector, not
+    /// a bit-parity check.
+    ///
+    /// Token-exact parity between the two is structurally unattainable
+    /// (measured on gemma-4-26B-A4B qat-4bit, 2026-07):
+    ///
+    ///   * the two implementations have different bf16 kernel/fusion
+    ///     orderings, giving ~0.5 max |Δlogit| even at position 0 (where
+    ///     RoPE is the identity), which flips near-tie top-8-of-128 MoE
+    ///     expert selections at later positions (~8 max |Δlogit|);
+    ///   * MLXVLM's wrapper mis-implements the checkpoint's declared
+    ///     `rope_type: "proportional"` for full-attention layers as an
+    ///     HF-style truncated-dims partial RoPE (freqs /128, partner +64),
+    ///     while MLXLLM's `ProportionalRoPE` implements the declared type
+    ///     (freqs /512 over the full head, partner +256 — verified against
+    ///     the mlx_lm Python reference). The extracted model keeps the
+    ///     CORRECT scheme; the wrapper discrepancy is flagged upstream.
+    ///
+    /// What a correct extraction guarantees — and what this gate enforces —
+    /// is that both models compute the same function up to implementation
+    /// noise: each side's greedy argmax must sit inside the other side's
+    /// top-`parityTopK` at EVERY position, and max |Δlogit| must stay under
+    /// `parityMaxAbsLogitDiff`. A mis-extracted model (wrong keys, wrong
+    /// quantization structure, wrong config) produces unrelated
+    /// distributions and fails both with overwhelming probability. The
+    /// probe is fixed and both models are deterministic, so for a given
+    /// (checkpoint, binary) the gate either always passes or always fails —
+    /// no per-load flakiness.
+    private static func assertForwardParity(
+        wrapper: MLXVLM.Gemma4, extracted: Gemma4TextModel, vocabSize: Int
+    ) throws -> Float {
+        // Fixed probe: small ids well inside every Gemma vocab; length stays
+        // far under the sliding window so the check exercises both layer
+        // types without materializing meaningful KV.
+        let probeTokens = [2, 651, 6134, 1024, 578, 108, 2364].map {
+            min($0, max(0, vocabSize - 1))
+        }
+        let inputs = MLXArray(probeTokens.map(Int32.init)).expandedDimensions(axis: 0)
+
+        let wrapperLogits = wrapper(inputs, cache: nil).asType(.float32)
+        let extractedLogits = extracted(inputs, cache: nil).asType(.float32)
+
+        let k = parityTopK
+        // Top-k token ids per position, [1, L, k] (unordered within k).
+        let wrapperTopK = argPartition(-wrapperLogits, kth: k - 1, axis: -1)[.ellipsis, ..<k]
+        let extractedTopK = argPartition(-extractedLogits, kth: k - 1, axis: -1)[.ellipsis, ..<k]
+        let wrapperArgmax = argMax(wrapperLogits, axis: -1)
+        let extractedArgmax = argMax(extractedLogits, axis: -1)
+        let maxAbsDiff = MLX.abs(wrapperLogits - extractedLogits).max()
+        eval(wrapperTopK, extractedTopK, wrapperArgmax, extractedArgmax, maxAbsDiff)
+
+        let positions = probeTokens.count
+        let wrapperIds = wrapperArgmax.asArray(Int32.self)
+        let extractedIds = extractedArgmax.asArray(Int32.self)
+        let wrapperTop = wrapperTopK.asArray(Int32.self)  // row-major [L × k]
+        let extractedTop = extractedTopK.asArray(Int32.self)
+        let diff = maxAbsDiff.item(Float.self)
+
+        for position in 0 ..< positions {
+            let window = position * k ..< (position + 1) * k
+            let wrapperWindow = Set(wrapperTop[window])
+            let extractedWindow = Set(extractedTop[window])
+            guard extractedWindow.contains(wrapperIds[position]),
+                wrapperWindow.contains(extractedIds[position])
+            else {
+                throw EngineV2VLMTextExtractionError.parityMismatch(
+                    "top-\(k) containment failed at position \(position): "
+                        + "wrapper argmax \(wrapperIds[position]) vs extracted top-\(k) "
+                        + "\(extractedWindow.sorted()); extracted argmax "
+                        + "\(extractedIds[position]) vs wrapper top-\(k) "
+                        + "\(wrapperWindow.sorted()); maxAbsLogitDiff=\(diff)")
+            }
+        }
+        guard diff <= parityMaxAbsLogitDiff else {
+            throw EngineV2VLMTextExtractionError.parityMismatch(
+                "max |Δlogit| \(diff) exceeds \(parityMaxAbsLogitDiff) "
+                    + "(argmax containment held — distributions drifted)")
+        }
+        return diff
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Inference/MultiModelBatchSchedulerEngine.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/MultiModelBatchSchedulerEngine.swift
@@ -225,6 +225,12 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
         // Multimodal (image/video) requests can't flow through the token-only
         // batched engine. For VLM models, serve them via the container's
         // non-batched prepare/generate vision path.
+        //
+        // ORDERING CONTRACT (v0.7.2 VLM text routing): this media check MUST
+        // stay ABOVE the engineV2Bridge branch below. A VLM slot may carry a
+        // v2 bridge built over its extracted text model — text-only requests
+        // route through that bridge, but image/video requests must keep this
+        // legacy vision path (the extracted text model cannot embed pixels).
         if isVLM, let container, VLMRequestInference.hasMedia(request) {
             // Decode + validate inline media SYNCHRONOUSLY, before returning the
             // stream. A MediaError (oversized/malformed/non-`data:` payload) thrown

--- a/provider-swift/Sources/ProviderCore/ProviderCore.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderCore.swift
@@ -75,5 +75,14 @@ public enum ProviderCore {
     // jinja_null_bridge / jinja_template / model_load), so durable telemetry can
     // tell the two indistinguishable gpt-oss 500 modes apart. Wire-compatible:
     // `error_reason` is an optional inference-error field, omitted when nil.
-    public static let version = "0.7.1"
+    // 0.7.2 lets engine_v2 (continuous batching) serve TEXT requests on
+    // allowlisted VLM-loaded Gemma 4 slots. Every prod Gemma 4 checkpoint
+    // ships a vision tower, so it loads via VLMModelFactory and the per-slot
+    // isVLM gate previously kept 100% of Gemma traffic on the legacy engine.
+    // The slot factory now extracts the CBv2-adapted MLXLLM text model over
+    // the SAME weight arrays (zero extra weight memory) and serves text
+    // through v2; image/video requests keep the legacy VLM path. No protocol
+    // change — capability is behavioral, gated by the existing engine_v2
+    // allowlist + flag.
+    public static let version = "0.7.2"
 }

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+EngineV2.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+EngineV2.swift
@@ -64,10 +64,23 @@ extension ProviderLoop {
     ///
     ///   * flag off / model not allowlisted — the ZERO-OVERHEAD steady
     ///     state: no container access, no scheduler reads, no
-    ///     `EngineV2Runtime` hop, no allocations;
+    ///     `EngineV2Runtime` hop, no allocations. This also covers
+    ///     NON-allowlisted VLM builds (silent legacy — no WARN spam);
     ///   * v2 engine construction throws — WARN `engine_health` telemetry
     ///     (`engine_v2_fallback`) is emitted by the factory and the slot
-    ///     serves through the legacy scheduler exactly as before.
+    ///     serves through the legacy scheduler exactly as before. For an
+    ///     ALLOWLISTED VLM slot this covers text-model extraction failures
+    ///     (see below) — loud, never silently wrong.
+    ///
+    /// VLM slots (v0.7.2): every production Gemma 4 checkpoint ships a
+    /// vision tower, so its slot loads MLXVLM's wrapper — which has no CBv2
+    /// hooks. Instead of gating the whole slot out (which kept 100% of prod
+    /// Gemma traffic on legacy), an allowlisted VLM slot builds the engine
+    /// over `EngineV2VLMTextExtraction`'s weight-sharing MLXLLM text model:
+    /// TEXT requests then serve through v2 while image/video requests keep
+    /// the legacy VLM path (per-request routing in
+    /// `MultiModelBatchSchedulerEngine.streamChatCompletion`, which peels
+    /// media off to the vision path BEFORE the bridge branch).
     ///
     /// On success the bridge is registered with `engineV2Runtime` BEFORE the
     /// caller installs the slot, so a request routed the instant the slot
@@ -76,17 +89,11 @@ extension ProviderLoop {
         modelId: String,
         modelType: String?,
         isVLM: Bool = false,
+        modelDirectory: URL? = nil,
         container: ModelContainer,
         tokenizer: TokenizerHandle,
         scheduler: BatchScheduler
     ) async -> EngineV2Bridge? {
-        // VLM slots are permanently unsupported by the v2 engine (the loaded
-        // module is a vision wrapper, not a CBv2-adapted text model), so gate
-        // them out BEFORE selection: an allowlist name match on a vision
-        // build (e.g. `gemma-4*`) would otherwise emit a WARN
-        // `engine_v2_fallback` on every load of a shape that can never serve
-        // v2. Silent legacy is the correct steady state here.
-        guard !isVLM else { return nil }
         let configEnabled = loopConfig.config.backend.engineV2
         let environment = engineV2SlotHooks?.environment
             ?? ProcessInfo.processInfo.environment
@@ -189,9 +196,32 @@ extension ProviderLoop {
             )
             extraEOSTokens = snapshot.extraEOSTokens
             emitTelemetry = nil  // production: TelemetryClient.shared
+            let loadedModelDirectory = modelDirectory
+            let slotLogger = logger
             makeEngine = {
-                try EngineV2Factory.makeProductionEngine(
-                    model: snapshot.model,
+                // VLM slot: the loaded module is a vision wrapper with no
+                // CBv2 hooks. Extract the CBv2-adapted MLXLLM text model
+                // over the SAME weight arrays (zero extra weight memory) and
+                // build the engine on that; any extraction/verify/parity
+                // failure throws into the factory's engine_v2_fallback WARN.
+                let servingModel: any LanguageModel
+                if isVLM {
+                    guard let loadedModelDirectory else {
+                        throw EngineV2VLMTextExtractionError.missingModelDirectory
+                    }
+                    let extraction = try EngineV2VLMTextExtraction.extractTextModel(
+                        from: snapshot.model, modelDirectory: loadedModelDirectory)
+                    if let parityDiff = extraction.parityMaxAbsLogitDiff {
+                        slotLogger.info(
+                            "engine_v2: \(modelId) VLM text-model extraction passed the "
+                                + "load-time forward parity gate (max |Δlogit| \(parityDiff))")
+                    }
+                    servingModel = extraction.model
+                } else {
+                    servingModel = snapshot.model
+                }
+                return try EngineV2Factory.makeProductionEngine(
+                    model: servingModel,
                     tokenizer: tokenizer.inner,
                     kvBytesCapacity: kvBytesCapacity)
             }
@@ -237,9 +267,19 @@ extension ProviderLoop {
         // Register before the slot goes live so capacity heartbeats and
         // cancellation fan-out see the bridge from the first request.
         await engineV2Runtime.register(modelId: modelId, bridge: bridge)
-        logger.info(
-            "engine_v2: serving \(modelId) via ContinuousBatchingV2 "
-                + "(legacy scheduler retained for fallback)")
+        if isVLM {
+            // Distinguish the VLM text-routing mode in prod logs: text
+            // requests serve via v2 over the extracted text model, image/
+            // video requests keep the legacy VLM path.
+            logger.info(
+                "engine_v2: serving \(modelId) via ContinuousBatchingV2 "
+                    + "(vlm_text_routing=true: text→v2, image/video→legacy VLM path; "
+                    + "legacy scheduler retained for fallback)")
+        } else {
+            logger.info(
+                "engine_v2: serving \(modelId) via ContinuousBatchingV2 "
+                    + "(legacy scheduler retained for fallback)")
+        }
         return bridge
     }
 }

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+ModelLoading.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+ModelLoading.swift
@@ -323,15 +323,19 @@ extension ProviderLoop {
             // selects the v2 engine for this model, build the real CBv2 engine
             // over the SAME loaded container, wrap it in an EngineV2Bridge, and
             // register it with the runtime so capacity/cancel fan-out works
-            // from the first request. nil on every legacy path — flag off,
-            // non-allowlisted model, VLM slot, or v2 init failure (which emits
-            // WARN engine_health telemetry and falls back to the scheduler
-            // below).
+            // from the first request. Allowlisted VLM slots (all prod Gemma 4
+            // checkpoints ship a vision tower) serve TEXT through v2 via the
+            // weight-sharing text-model extraction; the model directory is
+            // threaded through for its config.json. nil on every legacy path —
+            // flag off, non-allowlisted model, or v2 init/extraction failure
+            // (which emits WARN engine_health telemetry and falls back to the
+            // scheduler below).
             let slotIsVLM = Self.modelIsVLM(at: modelPath)
             let engineV2Bridge = await makeEngineV2BridgeForSlot(
                 modelId: modelId,
                 modelType: modelInfo.modelType,
                 isVLM: slotIsVLM,
+                modelDirectory: modelPath,
                 container: container,
                 tokenizer: tokenizer,
                 scheduler: scheduler

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+Testing.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+Testing.swift
@@ -162,6 +162,7 @@ extension ProviderLoop {
         modelId: String,
         modelType: String?,
         isVLM: Bool = false,
+        modelDirectory: URL? = nil,
         container: MLXLMCommon.ModelContainer,
         tokenizer: TokenizerHandle,
         scheduler: BatchScheduler
@@ -170,6 +171,7 @@ extension ProviderLoop {
             modelId: modelId,
             modelType: modelType,
             isVLM: isVLM,
+            modelDirectory: modelDirectory,
             container: container,
             tokenizer: tokenizer,
             scheduler: scheduler

--- a/provider-swift/Tests/ProviderCoreTests/EngineV2ProductionWiringTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/EngineV2ProductionWiringTests.swift
@@ -360,8 +360,8 @@ struct EngineV2SlotFactoryTests {
         #expect(engine.submitted[0].promptTokens == [1, 2, 3, 4, 5])
     }
 
-    @Test("VLM slot: silently legacy even when flag on + name allowlisted (no WARN noise)")
-    func vlmSlotStaysLegacySilently() async throws {
+    @Test("non-allowlisted VLM slot: silently legacy (no WARN noise, builder never invoked)")
+    func nonAllowlistedVLMSlotStaysLegacySilently() async throws {
         let loop = try makeWiringLoop(engineV2Enabled: true)
         let runtime = EngineV2Runtime()
         let counter = BuilderCallCounter()
@@ -370,10 +370,9 @@ struct EngineV2SlotFactoryTests {
         await loop.setEngineV2SlotHooksForTesting(
             ProviderLoop.EngineV2SlotHooks(
                 environment: [
-                    "DARKBLOOM_ENGINE_V2": "1",
-                    // The default allowlist is now the exact prod checkpoint ids;
-                    // these wiring fixtures use family-glob test ids, so widen it.
-                    "DARKBLOOM_ENGINE_V2_MODELS": "gemma-4*,gpt-oss*",
+                    "DARKBLOOM_ENGINE_V2": "1"
+                    // DEFAULT allowlist (exact prod checkpoint ids) — the
+                    // fixture id below is NOT on it.
                 ],
                 emitTelemetry: telemetry.callback(),
                 makeEngine: { _, _ in
@@ -381,11 +380,11 @@ struct EngineV2SlotFactoryTests {
                     return WiringScriptedEngine(script: .manual)
                 }))
 
-        // Name matches the gemma-4* allowlist, but the slot is a VLM — the
-        // loaded module is a vision wrapper the v2 engine can never serve,
-        // so this must be a SILENT legacy fallback (no per-load WARN).
+        // A VLM build that is NOT allowlisted (e.g. a bare vision conversion
+        // an operator never staged) must be a SILENT legacy skip — no
+        // extraction attempt, no per-load WARN spam.
         let bridge = await loop.makeEngineV2BridgeForSlotForTesting(
-            modelId: "gemma-4-27b-it-vision",
+            modelId: "gemma-4-27b-it-vision-experimental",
             modelType: "gemma4",
             isVLM: true,
             container: makeStubContainer(),
@@ -395,7 +394,78 @@ struct EngineV2SlotFactoryTests {
         #expect(bridge == nil)
         #expect(counter.calls == 0)
         #expect(telemetry.events.isEmpty)
-        #expect(await runtime.bridge(forModel: "gemma-4-27b-it-vision") == nil)
+        #expect(await runtime.bridge(forModel: "gemma-4-27b-it-vision-experimental") == nil)
+    }
+
+    @Test("allowlisted VLM slot: builds + registers a bridge (extraction seam via hooks)")
+    func allowlistedVLMSlotBuildsBridge() async throws {
+        // v0.7.2: allowlisted VLM slots are no longer gated out per-slot —
+        // the factory attempts the weight-sharing text-model extraction and
+        // serves TEXT through v2. The hooks' engine builder stands in for
+        // the extraction+engine step.
+        let loop = try makeWiringLoop(engineV2Enabled: true)
+        let runtime = EngineV2Runtime()
+        let engine = WiringScriptedEngine(script: .manual)
+        await loop.setEngineV2RuntimeForTesting(runtime)
+        await loop.setEngineV2SlotHooksForTesting(
+            ProviderLoop.EngineV2SlotHooks(
+                environment: [
+                    "DARKBLOOM_ENGINE_V2": "1",
+                    "DARKBLOOM_ENGINE_V2_MODELS": "gemma-4*",
+                ],
+                eosTokenIds: [2],
+                makeEngine: { _, _ in engine }))
+
+        let bridge = await loop.makeEngineV2BridgeForSlotForTesting(
+            modelId: "gemma-4-26b-8bit",
+            modelType: "gemma4",
+            isVLM: true,
+            container: makeStubContainer(),
+            tokenizer: TokenizerHandle(WiringStubTokenizer()),
+            scheduler: BatchScheduler()
+        )
+        let unwrapped = try #require(bridge)
+        #expect(await runtime.bridge(forModel: "gemma-4-26b-8bit") === unwrapped)
+    }
+
+    @Test("allowlisted VLM slot: extraction failure → legacy + WARN engine_v2_fallback")
+    func allowlistedVLMExtractionFailureFallsBackWithWarn() async throws {
+        let loop = try makeWiringLoop(engineV2Enabled: true)
+        let runtime = EngineV2Runtime()
+        let telemetry = WiringTelemetrySink()
+        await loop.setEngineV2RuntimeForTesting(runtime)
+        await loop.setEngineV2SlotHooksForTesting(
+            ProviderLoop.EngineV2SlotHooks(
+                environment: [
+                    "DARKBLOOM_ENGINE_V2": "1",
+                    "DARKBLOOM_ENGINE_V2_MODELS": "gemma-4*",
+                ],
+                emitTelemetry: telemetry.callback(),
+                makeEngine: { _, _ in
+                    // Stands in for any extraction failure (config decode,
+                    // verify [.all] mismatch, forward-parity gate).
+                    throw EngineV2VLMTextExtractionError.parityMismatch("scripted")
+                }))
+
+        let bridge = await loop.makeEngineV2BridgeForSlotForTesting(
+            modelId: "gemma-4-26b-8bit",
+            modelType: "gemma4",
+            isVLM: true,
+            container: makeStubContainer(),
+            tokenizer: TokenizerHandle(WiringStubTokenizer()),
+            scheduler: BatchScheduler()
+        )
+        #expect(bridge == nil)
+        #expect(await runtime.bridge(forModel: "gemma-4-26b-8bit") == nil)
+        let events = telemetry.events
+        #expect(events.count == 1)
+        #expect(events.first?.kind == .engineHealth)
+        #expect(events.first?.severity == .warn)
+        #expect(events.first?.fields?["operation"]?.description == "engine_v2_fallback")
+        #expect(events.first?.fields?["model"]?.description == "gemma-4-26b-8bit")
+        #expect(
+            events.first?.fields?["error_class"]?.description
+                .contains("EngineV2VLMTextExtractionError") == true)
     }
 
     @Test("production factory: unsupported model class throws (→ fallback)")
@@ -1022,6 +1092,97 @@ struct EngineV2RequestRoutingTests {
         #expect(engine.submitted.count == 1)
         // The local reservation is dropped exactly once when the stream ends.
         #expect(released.calls == 1)
+    }
+
+    @Test("VLM slot with a bridge: text-only request routes through the bridge")
+    func vlmSlotTextRequestRoutesThroughBridge() async throws {
+        // v0.7.2 per-request routing: a VLM slot may carry a v2 bridge built
+        // over its extracted text model. TEXT requests must serve through
+        // the bridge exactly like a text-slot bridge would.
+        let engine = WiringScriptedEngine(script: .stream([
+            .delta(text: "Hello", tokens: [10], logprobs: nil),
+            .finished(reason: .stop, usage: CBv2Usage(promptTokens: 5, completionTokens: 1)),
+        ]))
+        let bridge = makeBridge(engine: engine, modelId: "gemma-4-26b-8bit")
+        let providerEngine = MultiModelBatchSchedulerEngine(
+            registryProvider: { @Sendable in
+                [
+                    "gemma-4-26b-8bit": .init(
+                        scheduler: BatchScheduler(),
+                        tokenizer: TokenizerHandle(WiringStubTokenizer()),
+                        modelType: "gemma4",
+                        container: makeStubContainer(),
+                        isVLM: true,
+                        engineV2Bridge: bridge)
+                ]
+            })
+
+        let stream = try await providerEngine.streamChatCompletion(
+            request: makeOpenAIRequest(model: "gemma-4-26b-8bit"))
+        let events = try await recordServerStream(stream)
+        #expect(events.first == .content("Hello"))
+        #expect(events.last == .info(prompt: 5, completion: 1))
+        #expect(engine.submitted.count == 1)
+        #expect(engine.submitted[0].promptTokens == [1, 2, 3, 4, 5])
+    }
+
+    @Test("VLM slot with a bridge: image-bearing request never reaches the bridge")
+    func vlmSlotMediaRequestBypassesBridge() async throws {
+        // The media check sits ABOVE the bridge branch (ordering contract in
+        // MultiModelBatchSchedulerEngine.streamChatCompletion): an
+        // image-bearing request on a bridge-carrying VLM slot must take the
+        // legacy vision path — here it fails inside that path (stub
+        // container / model-less scheduler), which is exactly the proof:
+        // the scripted v2 engine must never see a submission.
+        let engine = WiringScriptedEngine(script: .stream([
+            .delta(text: "must-not-appear", tokens: [10], logprobs: nil),
+            .finished(reason: .stop, usage: CBv2Usage(promptTokens: 5, completionTokens: 1)),
+        ]))
+        let bridge = makeBridge(engine: engine, modelId: "gemma-4-26b-8bit")
+        let providerEngine = MultiModelBatchSchedulerEngine(
+            registryProvider: { @Sendable in
+                [
+                    "gemma-4-26b-8bit": .init(
+                        scheduler: BatchScheduler(),
+                        tokenizer: TokenizerHandle(WiringStubTokenizer()),
+                        modelType: "gemma4",
+                        container: makeStubContainer(),
+                        isVLM: true,
+                        engineV2Bridge: bridge)
+                ]
+            })
+
+        // A real, round-trip-verified 1x1 PNG so hasMedia + media validation
+        // both engage (same fixture as VLMRequestInferenceTests).
+        let tinyPNG =
+            "data:image/png;base64,"
+            + "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAAAXNSR0IArs4c6QAAAERl"
+            + "WElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAAB"
+            + "AAAAAaADAAQAAAABAAAAAQAAAAD5Ip3+AAAADElEQVQIHWP4z8AAAAMBAQBb2/lEAAAA"
+            + "AElFTkSuQmCC"
+        let mediaRequest = OpenAIChatCompletionRequest(
+            model: "gemma-4-26b-8bit",
+            messages: [
+                OpenAIChatMessage(
+                    role: .user,
+                    content: .parts([
+                        .text("what is this?"),
+                        .imageURL(tinyPNG),
+                    ]))
+            ]
+        )
+
+        // The vision path errors on the stub fixtures (model-less scheduler /
+        // throwing processor) — either shape proves the routing; what must
+        // NOT happen is a silent success through the bridge.
+        do {
+            let stream = try await providerEngine.streamChatCompletion(request: mediaRequest)
+            _ = try await recordServerStream(stream)
+            Issue.record("media request unexpectedly succeeded on stub fixtures")
+        } catch {
+            // expected: legacy vision path surfaced its failure
+        }
+        #expect(engine.submitted.isEmpty)
     }
 
     @Test("no bridge: the legacy scheduler path is taken unchanged")

--- a/provider-swift/Tests/ProviderCoreTests/GemmaVLMEngineV2LiveTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/GemmaVLMEngineV2LiveTests.swift
@@ -1,0 +1,408 @@
+// Copyright © 2026 Eigen Labs.
+//
+// Live (weight-gated) validation of the v0.7.2 Gemma 4 VLM → engine_v2
+// text-model extraction, on the EXACT checkpoints production serves
+// (gemma-4-26b-qat-4bit / gemma-4-26b-8bit — both ship a vision tower, so
+// the provider loads them through VLMModelFactory exactly like
+// `ProviderLoop.loadModelContainer`). Three stages, mirroring the prod
+// serving paths:
+//
+//   (a) EXTRACTION + PARITY — extract the CBv2-adapted MLXLLM
+//       `Gemma4TextModel` over the wrapper's weight arrays; the extraction
+//       must not duplicate weights (MLX active memory grows by ~nothing),
+//       and the built-in load-time parity gate must pass (each side's greedy
+//       argmax sits in the other's top-5 at every probe position, max
+//       |Δlogit| bounded — see EngineV2VLMTextExtraction for why token-exact
+//       WRAPPER parity is structurally unattainable).
+//
+//   (b) V2 == LEGACY GREEDY — the SAME tokenized prompt through the REAL
+//       `EngineV2` over the extracted model (via `EngineV2Bridge` +
+//       `MultiModelBatchSchedulerEngine`, the production seam) must produce
+//       the same greedy completion as the legacy `BatchScheduler` over the
+//       SAME extracted module instance (the engine-repo v2==legacy invariant,
+//       here on prod weights); the wrapper's own legacy output is logged for
+//       reference.
+//
+//   (c) INTERLEAVE HYGIENE — a legacy VISION request (real image through the
+//       wrapper's prepare/generate path) sandwiched between two identical v2
+//       text decodes must not perturb the v2 output (the Qwen3.5-mrope
+//       regression pattern from StartupSelfTestDecodeLiveTests: shared
+//       module state corrupting the "other" path). The extracted model is a
+//       separate module instance sharing only immutable weight arrays, so
+//       this must hold structurally.
+//
+// Gated like the other multi-GB Gemma tests: DARKBLOOM_LIVE_MLX_TESTS +
+// DARKBLOOM_LIVE_MLX_GEMMA, and each checkpoint is skipped cleanly when not
+// in the local HF cache.
+
+import Foundation
+import MLX
+import MLXLLM
+import MLXLMCommon
+import MLXLMServer
+import MLXVLM
+import Testing
+
+@testable import ProviderCore
+
+// A real, round-trip-verified 1x1 PNG (red pixel) — same fixture as
+// VLMRequestInferenceTests. The Gemma4 processor upsizes it to the minimum
+// patch grid, so it exercises the full vision tower cheaply.
+private let interleaveTinyPNGDataURI =
+    "data:image/png;base64,"
+    + "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAAAXNSR0IArs4c6QAAAERl"
+    + "WElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAAB"
+    + "AAAAAaADAAQAAAABAAAAAQAAAAD5Ip3+AAAADElEQVQIHWP4z8AAAAMBAQBb2/lEAAAA"
+    + "AElFTkSuQmCC"
+
+@Suite("Gemma 4 VLM engine_v2 extraction (live)", .serialized)
+struct GemmaVLMEngineV2LiveTests {
+
+    /// The two production Gemma 4 checkpoints (coordinator catalog ids
+    /// `gemma-4-26b-qat-4bit` / `gemma-4-26b-8bit`).
+    static let qat4bitModelID = "mlx-community/gemma-4-26B-A4B-it-qat-4bit"
+    static let eightBitModelID = LiveInferenceFixtures.gemmaModelID  // ...-8bit
+
+    // MARK: - Shared harness
+
+    private struct LoadedVLMSlot {
+        let modelID: String
+        let directory: URL
+        let container: ModelContainer
+        let scheduler: BatchScheduler
+        let tokenizer: TokenizerHandle
+        let model: any LanguageModel
+        let eosTokenIds: Set<Int>
+    }
+
+    /// Load a checkpoint EXACTLY the way the provider does for a VLM slot:
+    /// `VLMModelFactory` + `BatchScheduler.loadModel` (the legacy engine the
+    /// slot retains for fallback + vision requests).
+    private func loadVLMSlot(modelID: String, budgetBytes: Int) async throws -> LoadedVLMSlot {
+        guard LiveInferenceFixtures.ensureMetallibColocated() != nil else {
+            throw LiveFixtureSkip.missingMetallib
+        }
+        guard case .found(let directory) = LiveInferenceFixtures.locate(modelID) else {
+            throw LiveFixtureSkip.modelNotInCache(modelID)
+        }
+        #expect(
+            ProviderLoop.modelIsVLM(at: directory),
+            "prod Gemma 4 checkpoints are VLM builds — if this fails the whole premise changed")
+        LiveInferenceFixtures.applyMemoryBudget(maxBytes: budgetBytes)
+
+        let container = try await VLMModelFactory.shared.loadContainer(
+            from: directory, using: LocalTokenizerLoader())
+        let scheduler = BatchScheduler(
+            maxConcurrentRequests: 4,
+            pendingTimeout: .seconds(300),
+            defaultMaxTokens: 256
+        )
+        await scheduler.loadModel(container: container, modelId: modelID)
+
+        let snapshot = await container.perform { ctx in
+            EngineV2ModelSnapshot(
+                model: ctx.model,
+                eosTokenIds: ctx.configuration.eosTokenIds,
+                extraEOSTokens: ctx.configuration.extraEOSTokens.sorted())
+        }
+        let tokenizer: TokenizerHandle = await container.perform { ctx in
+            TokenizerHandle(ctx.tokenizer)
+        }
+        return LoadedVLMSlot(
+            modelID: modelID,
+            directory: directory,
+            container: container,
+            scheduler: scheduler,
+            tokenizer: tokenizer,
+            model: snapshot.model,
+            eosTokenIds: snapshot.eosTokenIds
+        )
+    }
+
+    /// Stage (a): weight-sharing extraction + the load-time parity gate.
+    ///
+    /// Two concerns, measured separately:
+    ///   * WEIGHT-SHARING — extract with the parity gate OFF and require MLX
+    ///     active memory to grow by ~nothing (skeleton construction is lazy;
+    ///     `update(parameters:)` re-points at the wrapper's arrays). A second
+    ///     weight COPY would show up as ≥ the model size (~14 GiB qat-4bit).
+    ///     The parity gate is excluded here because its two forward passes
+    ///     materialize several GiB of transient activation buffers that MLX
+    ///     retains until `clearCache` — real, but not a weight copy.
+    ///   * PARITY GATE — extract again with the gate ON (production default)
+    ///     and require it to pass and report a bounded max |Δlogit|. Both
+    ///     extractions share the same wrapper arrays, so this is not a second
+    ///     copy either; the returned model is the one stages (b)/(c) use.
+    private func runExtractionStage(
+        _ slot: LoadedVLMSlot
+    ) throws -> EngineV2VLMTextExtraction.Extraction {
+        // Weight-sharing invariant (parity gate off).
+        MLX.Memory.clearCache()
+        let activeBefore = MLX.GPU.activeMemory
+        let noParity = try EngineV2VLMTextExtraction.extractTextModel(
+            from: slot.model, modelDirectory: slot.directory,
+            environment: ["DARKBLOOM_ENGINE_V2_VLM_PARITY_CHECK": "0"])
+        #expect(noParity.parityMaxAbsLogitDiff == nil)
+        let growth = max(0, MLX.GPU.activeMemory - activeBefore)
+        #expect(
+            growth < 1_536 * 1024 * 1024,
+            Comment(
+                rawValue: "extraction grew MLX active memory by \(growth) bytes "
+                    + "(> 1.5 GiB) — weights were copied instead of shared"))
+
+        // Parity gate (production default env). Returns the model stages
+        // (b)/(c) run on.
+        let extraction = try EngineV2VLMTextExtraction.extractTextModel(
+            from: slot.model, modelDirectory: slot.directory)
+        let diff = try #require(
+            extraction.parityMaxAbsLogitDiff, "parity gate did not run under the default env")
+        print("[gemma-vlm-v2] \(slot.modelID) parity max |Δlogit| = \(diff), weight-share growth = \(growth) bytes")
+        return extraction
+    }
+
+    /// Drive one OpenAI-shaped request through the production routing seam
+    /// (`MultiModelBatchSchedulerEngine.streamChatCompletion`) over an
+    /// arbitrary registry entry and join the streamed content.
+    private func streamText(
+        modelID: String,
+        scheduler: BatchScheduler,
+        tokenizer: TokenizerHandle,
+        container: ModelContainer?,
+        isVLM: Bool,
+        modelType: String,
+        bridge: EngineV2Bridge?,
+        userContent: OpenAIMessageContent,
+        maxTokens: Int
+    ) async throws -> String {
+        let engine = MultiModelBatchSchedulerEngine(
+            registryProvider: { @Sendable in
+                [
+                    modelID: .init(
+                        scheduler: scheduler,
+                        tokenizer: tokenizer,
+                        modelType: modelType,
+                        container: container,
+                        isVLM: isVLM,
+                        engineV2Bridge: bridge)
+                ]
+            },
+            defaultMaxTokens: 256
+        )
+        let request = OpenAIChatCompletionRequest(
+            model: modelID,
+            messages: [OpenAIChatMessage(role: .user, content: userContent)],
+            temperature: 0,
+            maxTokens: maxTokens
+        )
+        var content = ""
+        for try await event in try await engine.streamChatCompletion(request: request) {
+            if case .content(let text) = event {
+                content += text
+            }
+        }
+        return content
+    }
+
+    /// Convenience: stream over the loaded VLM slot's own entry (the shape
+    /// the provider registers for a Gemma 4 slot).
+    private func streamText(
+        slot: LoadedVLMSlot,
+        bridge: EngineV2Bridge?,
+        userContent: OpenAIMessageContent,
+        maxTokens: Int
+    ) async throws -> String {
+        try await streamText(
+            modelID: slot.modelID,
+            scheduler: slot.scheduler,
+            tokenizer: slot.tokenizer,
+            container: slot.container,
+            isVLM: true,
+            modelType: "gemma4",
+            bridge: bridge,
+            userContent: userContent,
+            maxTokens: maxTokens)
+    }
+
+    /// Build a LEGACY `BatchScheduler` over the EXTRACTED text model via a
+    /// synthetic text-only container — the reference for the token-exact
+    /// engine-equivalence check in stage (b): the real EngineV2 and the
+    /// legacy BatchedEngine, run over the SAME module instance, must agree
+    /// exactly on greedy decode (the engine-repo v2-vs-legacy invariant,
+    /// verified here on prod weights through the provider's own seams).
+    private func makeExtractedTextScheduler(
+        slot: LoadedVLMSlot, extracted: Gemma4TextModel
+    ) async -> BatchScheduler {
+        struct NeverCalledProcessor: UserInputProcessor {
+            struct NotSupported: Error {}
+            func prepare(input: UserInput) async throws -> LMInput { throw NotSupported() }
+        }
+        // Thread the slot's EOS set into the config so the legacy scheduler
+        // stops at the SAME turn-end token the v2 bridge does — otherwise the
+        // token-exact comparison trips on stop config, not on decode.
+        let context = ModelContext(
+            configuration: ModelConfiguration(
+                directory: slot.directory, eosTokenIds: slot.eosTokenIds),
+            model: extracted,
+            processor: NeverCalledProcessor(),
+            tokenizer: slot.tokenizer.inner
+        )
+        let container = ModelContainer(context: context)
+        let scheduler = BatchScheduler(
+            maxConcurrentRequests: 4,
+            pendingTimeout: .seconds(300),
+            defaultMaxTokens: 256
+        )
+        await scheduler.loadModel(container: container, modelId: slot.modelID + "#extracted-text")
+        return scheduler
+    }
+
+    /// Build the REAL production v2 engine + bridge over the extracted text
+    /// model (same constructor path as `EngineV2Factory.makeProductionEngine`
+    /// from the slot factory).
+    private func makeBridge(
+        slot: LoadedVLMSlot, extracted: Gemma4TextModel
+    ) throws -> EngineV2Bridge {
+        let engine = try EngineV2Factory.makeProductionEngine(
+            model: extracted,
+            tokenizer: slot.tokenizer.inner,
+            kvBytesCapacity: 4 * 1024 * 1024 * 1024
+        )
+        return EngineV2Bridge(
+            engine: engine,
+            modelId: slot.modelID,
+            tokenizer: slot.tokenizer,
+            eosTokenIds: slot.eosTokenIds
+        )
+    }
+
+    // MARK: - qat-4bit: full pipeline (extraction, v2==legacy, interleave)
+
+    @Test(
+        "qat-4bit: extraction parity, v2==legacy greedy, vision interleave hygiene",
+        .enabled(if: LiveInferenceFixtures.gemmaTestsEnabled)
+    )
+    func qat4bitFullPipeline() async throws {
+        let slot = try await loadVLMSlot(
+            modelID: Self.qat4bitModelID, budgetBytes: 48 * 1024 * 1024 * 1024)
+        let scheduler = slot.scheduler
+        defer { Task { await scheduler.unloadModel() } }
+
+        // (a) extraction + load-time parity gate + weight-sharing invariant.
+        let extraction = try runExtractionStage(slot)
+
+        // (b) engine equivalence, token-exact: the REAL EngineV2 over the
+        //     extracted model must reproduce the legacy BatchedEngine over
+        //     the SAME extracted module instance exactly on greedy decode.
+        //     The wrapper's legacy path is compared qualitatively only —
+        //     token-exact wrapper parity is structurally unattainable (bf16
+        //     kernel-order noise flips near-tie MoE expert picks, and the
+        //     wrapper mis-implements the checkpoint's `rope_type:
+        //     "proportional"`; see EngineV2VLMTextExtraction).
+        let prompt = OpenAIMessageContent.text(
+            "Count from one to five as digits separated by commas.")
+        let wrapperLegacyText = try await streamText(
+            slot: slot, bridge: nil, userContent: prompt, maxTokens: 32)
+        #expect(!wrapperLegacyText.isEmpty, "wrapper legacy text path produced no content")
+
+        let textRefScheduler = await makeExtractedTextScheduler(
+            slot: slot, extracted: extraction.model)
+        let legacyExtractedText = try await streamText(
+            modelID: slot.modelID,
+            scheduler: textRefScheduler,
+            tokenizer: slot.tokenizer,
+            container: nil,
+            isVLM: false,
+            modelType: "gemma4_text",
+            bridge: nil,
+            userContent: prompt,
+            maxTokens: 32)
+        #expect(!legacyExtractedText.isEmpty, "extracted-model legacy path produced no content")
+
+        let bridge = try makeBridge(slot: slot, extracted: extraction.model)
+        let v2Text = try await streamText(
+            slot: slot, bridge: bridge, userContent: prompt, maxTokens: 32)
+        print("[gemma-vlm-v2] wrapperLegacy=\(wrapperLegacyText.debugDescription)")
+        print("[gemma-vlm-v2] legacyExtracted=\(legacyExtractedText.debugDescription)")
+        print("[gemma-vlm-v2] v2=\(v2Text.debugDescription)")
+        #expect(
+            v2Text == legacyExtractedText,
+            Comment(
+                rawValue: "v2 greedy diverged from legacy greedy on the SAME extracted model: "
+                    + "v2=\(v2Text.debugDescription) "
+                    + "legacy=\(legacyExtractedText.debugDescription)"))
+        await textRefScheduler.unloadModel()
+
+        // (c) interleave hygiene: legacy VISION request between two identical
+        //     v2 text decodes; the v2 output must be unchanged and the vision
+        //     request must stream real content through the wrapper.
+        let visionContent = try await streamText(
+            slot: slot, bridge: bridge,
+            userContent: .parts([
+                .text("What color is this image? Answer with one word."),
+                .imageURL(interleaveTinyPNGDataURI),
+            ]),
+            maxTokens: 16)
+        #expect(!visionContent.isEmpty, "vision request through the legacy path produced no content")
+
+        let v2TextAfterVision = try await streamText(
+            slot: slot, bridge: bridge, userContent: prompt, maxTokens: 32)
+        #expect(
+            v2TextAfterVision == v2Text,
+            Comment(
+                rawValue: "v2 text decode changed after an interleaved vision request: "
+                    + "before=\(v2Text.debugDescription) after=\(v2TextAfterVision.debugDescription)"))
+
+        await bridge.shutdown()
+    }
+
+    // MARK: - 8bit: extraction parity + v2==legacy greedy
+
+    @Test(
+        "8bit: extraction parity and v2==legacy greedy",
+        .enabled(if: LiveInferenceFixtures.gemmaTestsEnabled)
+    )
+    func eightBitExtractionAndGreedyParity() async throws {
+        let slot = try await loadVLMSlot(
+            modelID: Self.eightBitModelID, budgetBytes: 64 * 1024 * 1024 * 1024)
+        let scheduler = slot.scheduler
+        defer { Task { await scheduler.unloadModel() } }
+
+        let extraction = try runExtractionStage(slot)
+
+        let prompt = OpenAIMessageContent.text(
+            "Count from one to five as digits separated by commas.")
+        let wrapperLegacyText = try await streamText(
+            slot: slot, bridge: nil, userContent: prompt, maxTokens: 32)
+        #expect(!wrapperLegacyText.isEmpty, "wrapper legacy text path produced no content")
+
+        let textRefScheduler = await makeExtractedTextScheduler(
+            slot: slot, extracted: extraction.model)
+        let legacyExtractedText = try await streamText(
+            modelID: slot.modelID,
+            scheduler: textRefScheduler,
+            tokenizer: slot.tokenizer,
+            container: nil,
+            isVLM: false,
+            modelType: "gemma4_text",
+            bridge: nil,
+            userContent: prompt,
+            maxTokens: 32)
+        #expect(!legacyExtractedText.isEmpty, "extracted-model legacy path produced no content")
+
+        let bridge = try makeBridge(slot: slot, extracted: extraction.model)
+        let v2Text = try await streamText(
+            slot: slot, bridge: bridge, userContent: prompt, maxTokens: 32)
+        print("[gemma-vlm-v2] wrapperLegacy=\(wrapperLegacyText.debugDescription)")
+        print("[gemma-vlm-v2] legacyExtracted=\(legacyExtractedText.debugDescription)")
+        print("[gemma-vlm-v2] v2=\(v2Text.debugDescription)")
+        #expect(
+            v2Text == legacyExtractedText,
+            Comment(
+                rawValue: "v2 greedy diverged from legacy greedy on the SAME extracted model: "
+                    + "v2=\(v2Text.debugDescription) "
+                    + "legacy=\(legacyExtractedText.debugDescription)"))
+        await textRefScheduler.unloadModel()
+
+        await bridge.shutdown()
+    }
+}


### PR DESCRIPTION
# v0.7.2 — Engine V2 (continuous batching) for text on VLM-loaded Gemma 4 slots

## Root cause

Engine V2 (ContinuousBatchingV2) never engaged for **any** production Gemma 4
model, so **100% of Gemma traffic — overwhelmingly text — ran on the legacy
engine**, while GPT-OSS on v2 shows **+78% p50 TPS** in prod.

Why: every production Gemma 4 checkpoint ships a vision tower
(`gemma-4-26b-8bit`, `gemma-4-26b-qat-4bit` both have `vision_config` in
`config.json`, so `ProviderLoop.modelIsVLM` → true). The provider loads them
via `VLMModelFactory`, and the loaded module is MLXVLM's `Gemma4` wrapper.
`ProviderLoop+EngineV2.swift` then gated v2 out **per slot**:

```swift
guard !isVLM else { return nil }   // excluded every prod Gemma checkpoint
```

The wrapper's language model is a **private inline duplicate** of the text
architecture ("MLXVLM can't import MLXLLM") with **no CBv2 hooks**
(`cbv2LayerKinds` / `newCacheV2`), so the v2 engine genuinely could not serve
it directly — and the blanket per-slot gate meant text requests (the vast
majority of Gemma load) silently missed the +78% win GPT-OSS already gets.

## Fix — weight-sharing text-model extraction + per-request routing

For an **allowlisted VLM slot**, the slot factory now extracts the
CBv2-adapted **MLXLLM `Gemma4TextModel`** over the **same weight arrays** the
wrapper already holds (zero extra weight memory), and serves **text** through
v2. **Image/video** requests keep the legacy VLM prepare/generate path.

Extraction (`EngineV2VLMTextExtraction.swift`):
1. Decode the checkpoint's `text_config` with MLXLLM's `Gemma4TextConfiguration`
   decoder; construct a lazy `Gemma4TextModel` skeleton.
2. Re-apply the checkpoint's quantization **structure** the same way
   `loadWeights` does — `<path>.scales`-presence gate + the per-layer
   `(groupSize, bits, mode)` table from `BaseConfiguration`, keyed in the
   checkpoint's `language_model.`-prefixed key space. Handles **4bit (QAT) and
   8bit** identically (quantization-agnostic).
3. Re-key the wrapper's **live** parameter tree (`language_model.model.X → model.X`,
   `language_model.lm_head.X → lm_head.X`), run it through `Gemma4TextModel.sanitize`
   (drops the shared-KV k/v duplicates the wrapper allocates but MLXLLM does not),
   then `update(parameters:verify:[.all])` — a missing/extra/mis-shaped key
   **throws** → the existing `engine_v2_fallback` WARN + legacy (never silent
   wrongness).
4. Load-time forward parity gate: one tiny forward through both the wrapper's
   text path and the extracted model; each side's greedy argmax must sit in the
   other's **top-5** at every probe position, with bounded max |Δlogit|
   (`DARKBLOOM_ENGINE_V2_VLM_PARITY_CHECK=0` to skip).

The extracted model is a **separate module instance** sharing only immutable
weight arrays — no module-level mutable state is shared with the wrapper, which
makes the Qwen3.5-mrope class of cross-path state corruption structurally
impossible. Legacy vision forward and v2 text forward may interleave on the
same arrays; both are read-only over the parameters and each owns its private
KV caches.

Per-request routing (`MultiModelBatchSchedulerEngine.streamChatCompletion`):
the media check (`VLMRequestInference.hasMedia`) already peels image/video
requests off to the legacy vision path **before** the `engineV2Bridge` branch —
so text-only requests on a bridge-carrying VLM slot route to v2, and
image-bearing requests stay legacy. Made the ordering an explicit contract.

Telemetry: the slot-build log line reports `vlm_text_routing=true` so the mode
is visible in prod logs.

## Before / After

```mermaid
flowchart TB
  subgraph Before
    A1[Gemma 4 request<br/>text or image] --> B1[VLM slot<br/>isVLM=true]
    B1 --> C1{makeEngineV2BridgeForSlot}
    C1 -->|guard !isVLM else return nil| D1[legacy BatchScheduler<br/>ALL Gemma traffic]
    D1 --> E1[legacy engine<br/>no +78% TPS]
  end

  subgraph After
    A2[Gemma 4 request] --> B2[allowlisted VLM slot]
    B2 --> C2{makeEngineV2BridgeForSlot<br/>isVLM + selection==v2}
    C2 --> X2[extract MLXLLM Gemma4TextModel<br/>over SAME weight arrays<br/>verify .all + parity gate]
    X2 -->|extraction fails| D2[engine_v2_fallback WARN → legacy]
    X2 -->|ok| F2[EngineV2 bridge<br/>vlm_text_routing=true]
    F2 --> G2{streamChatCompletion<br/>hasMedia?}
    G2 -->|text| H2[Engine V2<br/>+78% p50 TPS class]
    G2 -->|image/video| I2[legacy VLM prepare/generate]
  end
```

## Prod evidence

- `is_vision=true` on both prod Gemma builds (`config.json` carries
  `vision_config`) → every one loads via `VLMModelFactory` → old per-slot gate
  excluded them all.
- GPT-OSS 20B on v2: **+78% p50 TPS** in prod — the proof of what Gemma text
  was missing.

## Engine-repo changes

**None.** `libs/mlx-swift-lm` is untouched. The extraction codes purely against
existing public API (`Gemma4TextModel`, `Gemma4TextConfiguration`,
`BaseConfiguration`, `Module.parameters()`/`update()`, `quantize()`,
`MLXVLM.Gemma4`). One upstream **discrepancy** was found and documented (not
fixed here): MLXVLM's inline Gemma4 text model implements the checkpoint's
declared full-attention `rope_type: "proportional"` as an HF-style
truncated-dims partial RoPE (freqs /128, partner +64), while MLXLLM's
`ProportionalRoPE` implements the declared type (freqs /512 over the full head,
partner +256 — matches the mlx_lm Python reference). The extracted model keeps
the **correct** MLXLLM scheme; this (plus bf16 kernel-order noise flipping
near-tie top-8-of-128 MoE expert picks) is why token-exact **wrapper** parity is
structurally unattainable and the gate uses top-k containment instead. Flagged
for upstream resolution.

## Tests

Unit (`EngineV2ProductionWiringTests`, live-isolated, scripted CBv2 stub):
- allowlisted VLM slot builds + registers a bridge (extraction seam via hooks);
- allowlisted VLM slot extraction failure → legacy + WARN `engine_v2_fallback`;
- non-allowlisted VLM slot → **silent** legacy (no WARN, builder never invoked);
- VLM slot + bridge: text-only request routes **through** the bridge;
- VLM slot + bridge: image-bearing request **never reaches** the bridge (legacy
  vision path), scripted engine sees zero submissions.

Weight-gated live (`GemmaVLMEngineV2LiveTests`, `DARKBLOOM_LIVE_MLX_TESTS` +
`DARKBLOOM_LIVE_MLX_GEMMA`), on the exact prod checkpoints — **both 4bit and 8bit**:
- **qat-4bit**: weight-share growth **10 KB** (zero copy), parity |Δlogit| 8.59,
  v2 == legacy-extracted == wrapper-legacy token-exact ("1, 2, 3, 4, 5"),
  vision interleave hygiene holds (v2 output unchanged after an interleaved real
  vision request);
- **8bit**: weight-share growth **10 KB**, parity |Δlogit| 8.72, v2 == legacy
  token-exact.

Full suite: `swift build -j 8 && swift test -j 6` → **1333 tests / 114 suites
pass** (0 failures). Coordinator `go build ./...` OK, `gofmt` clean.

## Version bumps

- `ProviderCore.version` → `0.7.2`
- `coordinator/api/server.go` `LatestProviderVersion` → `0.7.2`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/505"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785690622&installation_id=133247490&pr_number=505&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F505&signature=a22ea70b65c053f05a74966689ede8e786f2303970e60f153434f36401039a1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->