### PR TITLE
fix(coordinator): capacity-reject routing cooldown — stop black-hole providers absorbing dispatch

### DIFF
--- a/coordinator/api/capacity_cooldown_test.go
+++ b/coordinator/api/capacity_cooldown_test.go
@@ -1,0 +1,236 @@
+package api
+
+import (
+	"bytes"
+	"fmt"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+	"github.com/eigeninference/d-inference/coordinator/registry"
+	"github.com/eigeninference/d-inference/coordinator/store"
+)
+
+// isCapacityRejectStrike must count node-scoped capacity rejections (the
+// black-hole vocabulary) and NEVER count request-shape context overflows
+// (deterministic for the model — they indict the request, not the provider)
+// or genuine faults (owned by the 5xx breakers).
+func TestIsCapacityRejectStrike(t *testing.T) {
+	cases := []struct {
+		name   string
+		errStr string
+		want   bool
+	}{
+		// Node-scoped capacity rejects: COUNT. These are the incident strings —
+		// a pair emitting them repeatedly with zero accepts is a black hole.
+		{"active token budget", "token_budget_exhausted: request exceeds active token budget", true},
+		{"requires-but-available", "token_budget_exhausted: request requires 115635 tokens but only 90000 available", true},
+		{"kv headroom", "token_budget_exhausted: insufficient global KV cache headroom", true},
+		{"queue full", "token_budget_exhausted: request queue full", true},
+		{"server busy", "server busy", true},
+		{"draining", "provider draining for update", true},
+		{"cold not-loaded miss", "model 'gemma-4-26b-8bit' is not loaded on this provider", true},
+		// "batch token budget" is deliberately INCLUDED (misreported-budget
+		// pathology rejects normal prompts with exactly this string).
+		{"batch token budget", "token_budget_exhausted: request exceeds batch token budget", true},
+
+		// Request-shape context overflows: NEVER count (identical fleet-wide;
+		// striking them would cool healthy providers on oversized-prompt bursts).
+		{"exceeds model context window", "token_budget_exhausted: request exceeds model context window (200000 prompt tokens > 131072 context)", false},
+		{"context length exceeded", "context length exceeded", false},
+		{"context window bare marker", "prompt too long for context window", false},
+
+		// Genuine faults / non-capacity: NEVER count (the 5xx breakers own them).
+		{"panic", "panic: index out of range", false},
+		{"internal error", "internal error", false},
+		{"bad-weights load fault", "model load failed: corrupt weights", false},
+		{"opaque foundation error", "The operation couldn’t be completed. (ProviderCore.InferenceError error 1.)", false},
+		{"cancel", "request cancelled", false},
+		{"empty", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isCapacityRejectStrike(tc.errStr); got != tc.want {
+				t.Fatalf("isCapacityRejectStrike(%q) = %v, want %v", tc.errStr, got, tc.want)
+			}
+		})
+	}
+}
+
+func capacityTestPending(model, providerID string, n int) *registry.PendingRequest {
+	return &registry.PendingRequest{
+		RequestID:             fmt.Sprintf("req-cap-%s-%d", providerID, n),
+		Model:                 model,
+		ProviderID:            providerID,
+		EstimatedPromptTokens: 100,
+		RequestedMaxTokens:    128,
+		ChunkCh:               make(chan string, 1),
+		CompleteCh:            make(chan protocol.UsageInfo, 1),
+		ErrorCh:               make(chan protocol.InferenceErrorMessage, 1),
+	}
+}
+
+// End-to-end incident regression: a black-hole provider (100% capacity rejects,
+// zero accepts) must trip the capacity-reject cooldown through the REAL
+// noteInferenceError glue, emit the routing.capacity_cooldown_tripped metric
+// (tagged provider_id + model) and the distinct log line exactly once, and be
+// skipped by routing so dispatch diverts to the healthy provider — while a
+// busy-but-serving provider with interleaved accepts is never cooled, and a
+// client-shape 4xx carrying a capacity-looking string never strikes.
+func TestCapacityCooldownTripsMetricLogAndRoutingDiverts(t *testing.T) {
+	collector := newUDPCollector(t)
+	defer collector.Close()
+
+	var logBuf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	st := store.NewMemory(store.Config{AdminKey: "test-key"})
+	reg := registry.New(logger)
+
+	const model = "gemma-4-26b-8bit"
+	blackHole := makeRoutableProvider(t, reg, "p-blackhole", model)
+	healthy := makeRoutableProvider(t, reg, "p-healthy", model)
+
+	srv := NewServer(reg, st, ServerConfig{}, logger)
+	ddClient := newTestDD(t, collector)
+	defer ddClient.Close()
+	srv.SetDatadog(ddClient)
+
+	const rejectStr = "token_budget_exhausted: request exceeds active token budget"
+
+	// The incident pattern: every dispatch to the black hole bounces with the
+	// capacity string (classified 503) and it never serves anything.
+	for i := 0; i < 8; i++ {
+		srv.noteInferenceError(blackHole.ID, capacityTestPending(model, blackHole.ID, i), 503, rejectStr)
+	}
+	if !reg.CapacityCooldownActive(blackHole.ID, model) {
+		t.Fatal("black-hole provider not in capacity cooldown after 8 zero-accept rejects")
+	}
+
+	// Distinct metric, tagged provider_id + model, emitted exactly once (on the
+	// transition — not per straggler reject).
+	_ = ddClient.Statsd.Flush()
+	packets := collector.drain()
+	tripped := findMetrics(packets, "routing.capacity_cooldown_tripped")
+	if len(tripped) != 1 {
+		t.Fatalf("want exactly 1 capacity_cooldown_tripped metric, got %d: %v", len(tripped), tripped)
+	}
+	if !strings.Contains(tripped[0], "provider_id:"+blackHole.ID) || !strings.Contains(tripped[0], "model:"+model) {
+		t.Fatalf("metric missing provider_id/model tags: %s", tripped[0])
+	}
+	if got := strings.Count(logBuf.String(), "capacity-reject cooldown tripped"); got != 1 {
+		t.Fatalf("want exactly 1 trip log line, got %d; logs: %s", got, logBuf.String())
+	}
+
+	// Routing now diverts every dispatch to the healthy box.
+	for i := 0; i < 5; i++ {
+		provider, _ := reg.ReserveProviderEx(model, capacityTestPending(model, "", 100+i))
+		if provider == nil {
+			t.Fatal("no provider reserved — healthy box should still be routable")
+		}
+		if provider.ID != healthy.ID {
+			t.Fatalf("reserve %d picked %s, want the healthy provider %s", i, provider.ID, healthy.ID)
+		}
+		reg.SetProviderIdle(provider.ID)
+	}
+
+	// Balance: the healthy box now saturates and legitimately sheds — but it
+	// keeps SERVING (accepts interleaved), so it must NEVER trip.
+	for round := 0; round < 5; round++ {
+		for i := 0; i < 4; i++ {
+			srv.noteInferenceError(healthy.ID, capacityTestPending(model, healthy.ID, round*10+i), 503, rejectStr)
+		}
+		srv.noteInferenceSuccess(capacityTestPending(model, healthy.ID, round))
+	}
+	if reg.CapacityCooldownActive(healthy.ID, model) {
+		t.Fatal("busy-but-serving provider was cooled despite interleaved accepts")
+	}
+
+	// Client-shape 4xx carrying a capacity-looking string never strikes.
+	other := makeRoutableProvider(t, reg, "p-4xx", model)
+	for i := 0; i < 10; i++ {
+		srv.noteInferenceError(other.ID, capacityTestPending(model, other.ID, i), 400, rejectStr)
+	}
+	if reg.CapacityCooldownActive(other.ID, model) {
+		t.Fatal("client-shape 4xx with a capacity string tripped the capacity cooldown")
+	}
+
+	// Deterministic context overflows never strike either — they indict the
+	// request, not the provider.
+	ctxProvider := makeRoutableProvider(t, reg, "p-ctx", model)
+	for i := 0; i < 10; i++ {
+		srv.noteInferenceError(ctxProvider.ID, capacityTestPending(model, ctxProvider.ID, i), 503,
+			"token_budget_exhausted: request exceeds model context window (200000 prompt tokens > 131072 context)")
+	}
+	if reg.CapacityCooldownActive(ctxProvider.ID, model) {
+		t.Fatal("deterministic context-overflow rejections tripped the capacity cooldown")
+	}
+}
+
+// The retry-amplification loop from the live incident: a sink box looks IDLE
+// (near-zero active tokens), so it wins the cost score; its rejects are fast,
+// so the retry path re-selects it immediately — dispatch walks straight back
+// into the sink (~950 rejects/min fleet-wide) while loaded-but-healthy boxes
+// get nothing. Retry re-selection funnels through ReserveProviderEx →
+// providerPassesRoutingGatesLockedEx (the same gate on BOTH scan passes — the
+// fail-open rescan only bypasses the node-health breaker), so after the trip
+// every re-selection must divert to the healthy box within the threshold.
+func TestCapacityCooldownRetryReselectionEscapesSink(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(&bytes.Buffer{}, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	st := store.NewMemory(store.Config{AdminKey: "test-key"})
+	reg := registry.New(logger)
+
+	const model = "gemma-4-26b-8bit"
+	sink := makeRoutableProvider(t, reg, "p-sink", model)
+	healthy := makeRoutableProvider(t, reg, "p-loaded-healthy", model)
+	// Incident shape: the sink looks idle and fast; the healthy box carries
+	// real load and a slower decode rate, so the cost scheduler deterministically
+	// prefers the sink until the cooldown gates it out.
+	healthy.Mu().Lock()
+	healthy.DecodeTPS = 20.0
+	healthy.BackendCapacity.Slots[0].NumRunning = 3
+	healthy.BackendCapacity.Slots[0].NumWaiting = 2
+	healthy.Mu().Unlock()
+
+	srv := NewServer(reg, st, ServerConfig{}, logger)
+
+	const rejectStr = "token_budget_exhausted: request exceeds active token budget"
+	sinkPicks := 0
+	var servedBy string
+	for attempt := 0; attempt < 12; attempt++ {
+		pr := capacityTestPending(model, "", 200+attempt)
+		provider, _ := reg.ReserveProviderEx(model, pr)
+		if provider == nil {
+			t.Fatalf("attempt %d: no provider reserved", attempt)
+		}
+		if provider.ID == sink.ID {
+			// The sink instantly capacity-rejects; the retry loop records the
+			// failure and re-selects.
+			sinkPicks++
+			srv.noteInferenceError(sink.ID, pr, 503, rejectStr)
+			reg.SetProviderIdle(sink.ID)
+			continue
+		}
+		servedBy = provider.ID
+		reg.SetProviderIdle(provider.ID)
+		break
+	}
+	if servedBy != healthy.ID {
+		t.Fatalf("retry re-selection never escaped the sink (served by %q after %d sink picks)", servedBy, sinkPicks)
+	}
+	if sinkPicks > 5 {
+		t.Fatalf("took %d sink picks to escape, want <= default threshold 5", sinkPicks)
+	}
+	if !reg.CapacityCooldownActive(sink.ID, model) {
+		t.Fatal("sink not in capacity cooldown after the escape")
+	}
+	// Every subsequent selection — fresh requests AND retries — stays off the
+	// sink for the cooldown's lifetime.
+	for i := 0; i < 5; i++ {
+		provider, _ := reg.ReserveProviderEx(model, capacityTestPending(model, "", 300+i))
+		if provider == nil || provider.ID != healthy.ID {
+			t.Fatalf("post-trip selection %d did not stay on the healthy box", i)
+		}
+		reg.SetProviderIdle(provider.ID)
+	}
+}

--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -246,12 +246,15 @@ func (s *Server) refundProviderExtra(pr *registry.PendingRequest) {
 	s.ddIncr("billing.reservation_extra_refunds", []string{"model:" + pr.Model})
 }
 
-// noteInferenceError feeds BOTH circuit breakers for a provider-side error
+// noteInferenceError feeds the circuit breakers for a provider-side error
 // received on a pending request's ErrorCh (any phase, pre- or post-commit):
 //   - the shape-keyed inference-error breaker (counts only sickness-shaped
-//     500/502/504 for the (provider, model, shape) triple), and
+//     500/502/504 for the (provider, model, shape) triple),
 //   - the per-provider node-health breaker, which also counts fault-shaped
-//     503s (errStr classifies capacity-503 vs fault-503).
+//     503s (errStr classifies capacity-503 vs fault-503),
+//   - the stable-identity ejection breaker (survives reconnect churn), and
+//   - the capacity-reject cooldown (the ONLY consumer of capacity-class
+//     rejections, which every breaker above deliberately ignores).
 //
 // It emits the cool-down metric on the inference-error transition and the
 // provider_breaker_open metric on the node-health transition into quarantine.
@@ -278,7 +281,38 @@ func (s *Server) noteInferenceError(providerID string, pr *registry.PendingReque
 			s.ddIncr("routing.provider_ejected", []string{"model:" + pr.Model})
 		}
 	}
+	// Feed the capacity-reject cooldown. Capacity-class rejections are
+	// DELIBERATELY invisible to reputation and to ALL the breakers above (a
+	// busy box must never be punished for shedding) — which turns a box that
+	// capacity-rejects EVERYTHING into a routing black hole: its idle-looking
+	// heartbeats keep winning the cost scheduler while every dispatch bounces
+	// (2026-07 incident: 7 boxes, ~9k "token_budget_exhausted" rejections in
+	// 30 min, zero successes). Strikes accumulate per (provider, model); any
+	// accept (first content chunk or clean completion) resets the streak, so
+	// transient fullness on a serving box can never trip. Gated to 429/5xx so
+	// a client-shape 4xx that happens to carry a capacity-looking string never
+	// strikes; explicit context-overflow rejections are excluded by
+	// isCapacityRejectStrike (they indict the request, not the provider).
+	if (statusCode == http.StatusTooManyRequests || statusCode >= http.StatusInternalServerError) &&
+		isCapacityRejectStrike(errStr) {
+		if s.registry.RecordCapacityReject(providerID, pr.Model) {
+			s.ddIncr(metricCapacityCooldownTripped, []string{"provider_id:" + providerID, "model:" + pr.Model})
+			s.logger.Warn("capacity-reject cooldown tripped: provider+model capacity-rejecting with zero interleaved accepts — routing will skip the pair until the cooldown expires",
+				"provider_id", providerID,
+				"model", pr.Model,
+				"status_code", statusCode,
+				"error", errStr,
+			)
+		}
+	}
 }
+
+// metricCapacityCooldownTripped counts transitions of a (provider, model) pair
+// into the capacity-reject routing cooldown (registry/capacity_cooldown.go),
+// tagged provider_id + model. Distinct from routing.cooldown_entered (the 5xx
+// inference-error breaker) and routing.provider_breaker_open (node health) so
+// black-hole trips are independently alertable.
+const metricCapacityCooldownTripped = "routing.capacity_cooldown_tripped"
 
 // noteInferenceSuccess clears the inference-error strike state for the serving
 // provider-model pair on a clean completion (streaming relay ended without a
@@ -288,6 +322,11 @@ func (s *Server) noteInferenceSuccess(pr *registry.PendingRequest) {
 		return
 	}
 	s.registry.RecordInferenceSuccess(pr.ProviderID, pr.Model, pr.Traits.CooldownShape())
+	// A clean completion is an ACCEPT for the capacity-reject cooldown: clear
+	// the pair's reject streak, any active capacity cooldown, and the re-trip
+	// backoff. Belt-and-braces with the commit-time accept (commitFirstContent)
+	// and the only accept signal on paths that never stream content.
+	s.registry.RecordCapacityAccept(pr.ProviderID, pr.Model)
 	// A clean completion proves the node is healthy — close its node-health
 	// breaker (and reset the exponential backoff) if it had tripped.
 	if _, closed := s.registry.RecordProviderOutcome(pr.ProviderID, true, 200, ""); closed {

--- a/coordinator/api/dispatch.go
+++ b/coordinator/api/dispatch.go
@@ -392,6 +392,13 @@ func (d *dispatchState) commitFirstContent(pr *registry.PendingRequest, chunk st
 	// ever stamps FirstContentAt for the attempt that actually delivered content —
 	// never a late-completing abandoned/retried attempt sharing the same Timing.
 	pr.MarkContentCommitted()
+	// First CONTENT chunk == the provider ACCEPTED and is serving: clear the
+	// pair's capacity-reject streak NOW rather than at completion. A long
+	// generation on a busy box must keep vouching for the pair while the box
+	// legitimately sheds concurrent dispatches — waiting for the completion
+	// accept (noteInferenceSuccess) would let transient fullness masquerade as
+	// the zero-accepts black-hole signature. See registry/capacity_cooldown.go.
+	d.s.registry.RecordCapacityAccept(pr.ProviderID, pr.Model)
 }
 
 // successRoutingOutcome builds a success outcome for the committed attempt.

--- a/coordinator/api/inference_failure_class.go
+++ b/coordinator/api/inference_failure_class.go
@@ -212,6 +212,51 @@ func classifyRejection(reason, errStr string, providerBudget int64, modelContext
 	return rejectionTransientCapacity
 }
 
+// isCapacityRejectStrike reports whether a provider rejection should count
+// toward the capacity-reject routing cooldown (registry.RecordCapacityReject —
+// the black-hole breaker). It is BUCKET A (capacity-class) MINUS the
+// request-shape rejections that indict the REQUEST rather than the provider:
+// an explicit context-window/length overflow is deterministic for the MODEL
+// (every provider rejects that prompt identically), so counting it would cool
+// down healthy providers on a burst of oversized requests.
+//
+// Node-scoped capacity flavors all count — "exceeds active token budget",
+// "requires N tokens but only M available", "insufficient KV headroom",
+// "request exceeds batch token budget", "queue full", "draining", cold "not
+// loaded" misses, … For the SAME (provider, model) pair, threshold-many of
+// those inside the window with ZERO interleaved accepts is the black-hole
+// signature this cooldown exists for (2026-07 incident: 7 boxes rejecting
+// 100% of dispatches with "token_budget_exhausted" from their first request,
+// ~9k rejections/30min, zero successes — invisible to reputation and to both
+// fault breakers, which deliberately skip capacity-class errors). "batch token
+// budget" is deliberately INCLUDED even though classifyRejection may treat it
+// as deterministic for FAILOVER purposes: a pair emitting it repeatedly for
+// differently-sized prompts with zero accepts is exactly the misreported-
+// budget pathology; a rare false trip costs one pair a bounded, re-probed TTL.
+//
+// Matching mirrors isCapacityClassProviderError (substring, case-insensitive,
+// curly-apostrophe-normalised). The registry enforces the zero-interleaved-
+// accepts discriminator; this function only answers "is this reject about the
+// provider's capacity?".
+func isCapacityRejectStrike(errStr string) bool {
+	if !isCapacityClassProviderError(errStr) {
+		return false
+	}
+	s := strings.ToLower(strings.TrimSpace(errStr))
+	s = strings.ReplaceAll(s, "’", "'")
+	// Request-shape deterministic: the prompt is too big for the MODEL itself
+	// (both tenses + the bare context markers, mirroring classifyRejection).
+	// These reject identically fleet-wide and say nothing about this provider.
+	if strings.Contains(s, "context") &&
+		(strings.Contains(s, "exceeds") || strings.Contains(s, "exceeded")) {
+		return false
+	}
+	if strings.Contains(s, "context length") || strings.Contains(s, "context window") {
+		return false
+	}
+	return true
+}
+
 // capacityClassMarkers are BUCKET A substrings: ADMITTED-but-unservable or
 // lifecycle rejections that should reclassify a provider 5xx to an uptime-neutral
 // 429. Drop a newly-observed capacity string here (predicates that need more than

--- a/coordinator/registry/capacity_cooldown.go
+++ b/coordinator/registry/capacity_cooldown.go
@@ -1,0 +1,253 @@
+package registry
+
+import (
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/env"
+)
+
+// Capacity-reject routing cooldown.
+//
+// Prod incident (2026-07): 7 provider boxes (64GB, gemma-4-26b-8bit, v0.7.2)
+// rejected 100% of dispatched requests with the capacity string
+// ("token_budget_exhausted", classified 503) from their FIRST request after
+// registration — ~9,000 rejections in 30 minutes, zero successes — while ~170
+// healthy boxes for the same model sat underutilized. The router kept picking
+// them because (a) their heartbeats reported near-zero active tokens, so the
+// cost-based scheduler scored them best, and (b) capacity-class failures are
+// DELIBERATELY invisible to reputation, the shape-keyed inference-error
+// breaker (error_cooldown.go skips 503), and the node-health breaker
+// (provider_breaker.go ignores capacity sheds). That invisibility is sound
+// policy for OCCASIONAL capacity rejects — a busy box must never be punished
+// for shedding load — but catastrophic for a box that rejects EVERYTHING: it
+// becomes a dispatch black hole.
+//
+// DISCRIMINATOR — zero interleaved accepts. Transient fullness is NORMAL: a
+// saturated box legitimately capacity-rejects while it is ALSO serving. What
+// separates pathology from fullness is that a serving box keeps producing
+// accepts (first content chunk / clean completion), and any accept resets the
+// pair's strike streak (RecordCapacityAccept). Only Threshold-many capacity
+// rejects inside Window with NO accept in between — the black-hole signature —
+// trip the cooldown. Keyed per (provider, model) with a struct key (no
+// delimiter aliasing), mirroring error_cooldown.go.
+//
+// RE-PROBE + BACKOFF. A trip quarantines the pair for BaseTTL (default 120s).
+// After expiry routing re-probes it: a genuinely-full box that recovered gets
+// traffic back and its first accept clears ALL state (streak, cooldown, trip
+// count). A still-pathological pair re-arms on its FIRST post-expiry reject
+// (half-open, like provider_breaker.go) with an exponentially doubled TTL,
+// capped at MaxTTL (default 10 min) — so a persistent black hole costs one
+// bounced probe per cycle instead of Threshold-many.
+//
+// NOT bypassed by the selectBestCandidateLockedFull fail-open rescan
+// (consistent with the other pair-scoped cooldowns): if every pair for a model
+// is capacity-cooled, the fleet genuinely has zero accepting capacity and the
+// truthful outcome is the queue/429 path, not a guaranteed-reject dispatch.
+// TTLs stagger, so re-probes trickle back on their own.
+//
+// State is keyed by the per-session provider UUID: a reconnect starts clean
+// (same limitation as error_cooldown.go), and the maps are bounded by the
+// same opportunistic >1024 sweep. r.mu discipline and the transition-bool
+// return also mirror error_cooldown.go.
+
+// Env tunables — read ONCE at Registry construction (coordinator restart
+// applies changes). All values have safe defaults; setting the threshold to 0
+// disables the cooldown entirely (kill switch).
+const (
+	envCapacityCooldownThreshold  = "EIGENINFERENCE_CAPACITY_COOLDOWN_THRESHOLD"
+	envCapacityCooldownWindowSecs = "EIGENINFERENCE_CAPACITY_COOLDOWN_WINDOW_SECONDS"
+	envCapacityCooldownTTLSecs    = "EIGENINFERENCE_CAPACITY_COOLDOWN_TTL_SECONDS"
+	envCapacityCooldownMaxTTLSecs = "EIGENINFERENCE_CAPACITY_COOLDOWN_MAX_TTL_SECONDS"
+)
+
+const (
+	defaultCapacityCooldownThreshold = 5
+	defaultCapacityCooldownWindow    = 60 * time.Second
+	defaultCapacityCooldownTTL       = 120 * time.Second
+	defaultCapacityCooldownMaxTTL    = 10 * time.Minute
+)
+
+// capacityCooldownConfig carries the env-tunable cooldown parameters.
+type capacityCooldownConfig struct {
+	// Threshold is how many capacity rejects inside Window — with ZERO accepts
+	// interleaved — trip the cooldown. <= 0 disables the breaker (kill switch).
+	Threshold int
+	// Window is the sliding window over which reject strikes count.
+	Window time.Duration
+	// BaseTTL is the first cooldown duration. Each re-trip without an
+	// intervening accept doubles it (half-open re-arm), capped at MaxTTL.
+	BaseTTL time.Duration
+	// MaxTTL caps the exponential backoff.
+	MaxTTL time.Duration
+}
+
+// loadCapacityCooldownConfig reads the EIGENINFERENCE_CAPACITY_COOLDOWN_* env
+// tunables, falling back to the defaults and clamping nonsensical values
+// (non-positive durations revert to defaults; MaxTTL is raised to BaseTTL).
+func loadCapacityCooldownConfig() capacityCooldownConfig {
+	cfg := capacityCooldownConfig{
+		Threshold: env.EnvInt(envCapacityCooldownThreshold, defaultCapacityCooldownThreshold),
+		Window:    time.Duration(env.EnvInt(envCapacityCooldownWindowSecs, int(defaultCapacityCooldownWindow/time.Second))) * time.Second,
+		BaseTTL:   time.Duration(env.EnvInt(envCapacityCooldownTTLSecs, int(defaultCapacityCooldownTTL/time.Second))) * time.Second,
+		MaxTTL:    time.Duration(env.EnvInt(envCapacityCooldownMaxTTLSecs, int(defaultCapacityCooldownMaxTTL/time.Second))) * time.Second,
+	}
+	if cfg.Window <= 0 {
+		cfg.Window = defaultCapacityCooldownWindow
+	}
+	if cfg.BaseTTL <= 0 {
+		cfg.BaseTTL = defaultCapacityCooldownTTL
+	}
+	if cfg.MaxTTL < cfg.BaseTTL {
+		cfg.MaxTTL = cfg.BaseTTL
+	}
+	return cfg
+}
+
+// capacityRejectKey identifies a capacity-cooldown bucket. A struct key (vs a
+// delimiter-joined string) cannot alias across ids containing the delimiter.
+type capacityRejectKey struct {
+	ProviderID string
+	ModelID    string
+}
+
+// RecordCapacityReject records one capacity-class rejection (token budget /
+// KV headroom / queue full / draining / …) for the (provider, model) pair.
+// The api layer classifies which provider errors qualify
+// (isCapacityRejectStrike) — request-shape context overflows never reach here.
+//
+// Returns true ONLY on the transition into cooldown so callers can emit the
+// capacity_cooldown_tripped metric/log without double-counting. Trip
+// conditions:
+//   - fresh pair (never tripped, or accept-cleared): Threshold strikes inside
+//     Window with zero interleaved accepts;
+//   - half-open pair (tripped before, cooldown expired, still no accept): the
+//     FIRST post-expiry reject re-arms immediately with doubled backoff.
+//
+// While a cooldown is ACTIVE, strikes are still recorded (in-flight stragglers
+// dispatched before the trip land here) but never extend or re-arm it —
+// otherwise stragglers could push recovery out indefinitely.
+func (r *Registry) RecordCapacityReject(providerID, modelID string) (tripped bool) {
+	if providerID == "" || modelID == "" {
+		return false
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	cfg := r.capacityCooldownCfg
+	if cfg.Threshold <= 0 {
+		return false // disabled via EIGENINFERENCE_CAPACITY_COOLDOWN_THRESHOLD=0
+	}
+	now := time.Now()
+
+	// Opportunistic sweep (mirrors error_cooldown.go): session provider ids are
+	// per-connection UUIDs that never get re-keyed — bound the maps by dropping
+	// expired/idle entries once they grow.
+	if len(r.capacityCooldowns) > 1024 {
+		for key, expiry := range r.capacityCooldowns {
+			if !now.Before(expiry) {
+				delete(r.capacityCooldowns, key)
+				delete(r.capacityCooldownTrips, key)
+			}
+		}
+	}
+	if len(r.capacityRejectStrikes) > 1024 {
+		for key, strikes := range r.capacityRejectStrikes {
+			if len(strikes) == 0 || !strikes[len(strikes)-1].Add(cfg.Window).After(now) {
+				delete(r.capacityRejectStrikes, key)
+			}
+		}
+	}
+
+	key := capacityRejectKey{ProviderID: providerID, ModelID: modelID}
+
+	// Slide the window: keep only strikes still inside it, then add this one.
+	strikes := r.capacityRejectStrikes[key]
+	kept := strikes[:0]
+	for _, ts := range strikes {
+		if now.Sub(ts) < cfg.Window {
+			kept = append(kept, ts)
+		}
+	}
+	kept = append(kept, now)
+	r.capacityRejectStrikes[key] = kept
+
+	// Active cooldown: record only — never extend or re-arm (see doc above).
+	if expiry, ok := r.capacityCooldowns[key]; ok && now.Before(expiry) {
+		return false
+	}
+
+	trips := r.capacityCooldownTrips[key]
+	// A fresh pair (trips == 0) needs the full threshold inside the window. A
+	// half-open pair (trips > 0: tripped before, no accept since, cooldown
+	// expired → this reject IS the failed re-probe) re-arms immediately.
+	if trips == 0 && len(kept) < cfg.Threshold {
+		return false
+	}
+
+	r.capacityCooldowns[key] = now.Add(capacityCooldownBackoff(cfg, trips))
+	r.capacityCooldownTrips[key] = trips + 1
+	return true
+}
+
+// RecordCapacityAccept records that the (provider, model) pair ACCEPTED work —
+// the api layer calls it on the first content-bearing chunk (commit) and on
+// clean completion. It clears the pair's reject streak, any active cooldown,
+// and the exponential-backoff trip count: an accept proves the pair admits
+// work, which is exactly the discriminator that separates a busy-but-serving
+// box (must NEVER trip) from a black hole (zero accepts).
+func (r *Registry) RecordCapacityAccept(providerID, modelID string) {
+	if providerID == "" || modelID == "" {
+		return
+	}
+	key := capacityRejectKey{ProviderID: providerID, ModelID: modelID}
+	// Fast path: this runs once per served request, and for a healthy pair all
+	// three maps are empty — check under the read lock so the serving hot path
+	// does not serialize on r.mu write acquisition.
+	r.mu.RLock()
+	_, hasStrikes := r.capacityRejectStrikes[key]
+	_, hasCooldown := r.capacityCooldowns[key]
+	_, hasTrips := r.capacityCooldownTrips[key]
+	r.mu.RUnlock()
+	if !hasStrikes && !hasCooldown && !hasTrips {
+		return
+	}
+	r.mu.Lock()
+	delete(r.capacityRejectStrikes, key)
+	delete(r.capacityCooldowns, key)
+	delete(r.capacityCooldownTrips, key)
+	r.mu.Unlock()
+}
+
+// CapacityCooldownActive reports whether the (provider, model) pair is
+// currently quarantined by the capacity-reject cooldown. Exposed for tests and
+// observability; the routing hot path uses capacityCooldownActiveLocked under
+// the already-held r.mu.
+func (r *Registry) CapacityCooldownActive(providerID, modelID string) bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.capacityCooldownActiveLocked(providerID, modelID, time.Now())
+}
+
+// capacityCooldownActiveLocked reports whether routing should skip the pair.
+// READ-ONLY (no lazy delete) — some callers hold only r.mu.RLock. Caller holds
+// r.mu in either mode (mirrors inferenceErrorCooldownActiveLocked). Once now
+// reaches the expiry it returns false, letting the next request through as the
+// half-open re-probe.
+func (r *Registry) capacityCooldownActiveLocked(providerID, modelID string, now time.Time) bool {
+	expiry, ok := r.capacityCooldowns[capacityRejectKey{ProviderID: providerID, ModelID: modelID}]
+	return ok && now.Before(expiry)
+}
+
+// capacityCooldownBackoff returns the cooldown TTL for a pair that has already
+// tripped `trips` times (0 = first trip): BaseTTL * 2^trips, capped at MaxTTL.
+// The loop avoids overflowing the shift for large trip counts (mirrors
+// providerBreakerBackoff).
+func capacityCooldownBackoff(cfg capacityCooldownConfig, trips int) time.Duration {
+	ttl := cfg.BaseTTL
+	for i := 0; i < trips && ttl < cfg.MaxTTL; i++ {
+		ttl *= 2
+	}
+	if ttl > cfg.MaxTTL {
+		ttl = cfg.MaxTTL
+	}
+	return ttl
+}

--- a/coordinator/registry/capacity_cooldown_test.go
+++ b/coordinator/registry/capacity_cooldown_test.go
@@ -1,0 +1,338 @@
+package registry
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+// --- test helpers (poke internal maps / call *Locked helpers, mirroring
+// error_cooldown_test.go and provider_breaker_test.go) ---
+
+func capacityCooldownActiveAt(r *Registry, providerID, modelID string, now time.Time) bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.capacityCooldownActiveLocked(providerID, modelID, now)
+}
+
+func capacityCooldownExpiryOf(r *Registry, providerID, modelID string) (time.Time, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	expiry, ok := r.capacityCooldowns[capacityRejectKey{ProviderID: providerID, ModelID: modelID}]
+	return expiry, ok
+}
+
+func capacityCooldownTripsOf(r *Registry, providerID, modelID string) int {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.capacityCooldownTrips[capacityRejectKey{ProviderID: providerID, ModelID: modelID}]
+}
+
+// expireCapacityCooldown rewinds the pair's cooldown expiry into the past,
+// simulating the TTL elapsing (active -> half-open re-probe) without sleeping.
+func expireCapacityCooldown(r *Registry, providerID, modelID string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.capacityCooldowns[capacityRejectKey{ProviderID: providerID, ModelID: modelID}] = time.Now().Add(-time.Second)
+}
+
+// ageCapacityStrikes rewinds every recorded reject strike for the pair by d,
+// simulating the passage of time without sleeping.
+func ageCapacityStrikes(r *Registry, providerID, modelID string, d time.Duration) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	key := capacityRejectKey{ProviderID: providerID, ModelID: modelID}
+	strikes := r.capacityRejectStrikes[key]
+	aged := make([]time.Time, len(strikes))
+	for i, ts := range strikes {
+		aged[i] = ts.Add(-d)
+	}
+	r.capacityRejectStrikes[key] = aged
+}
+
+// Regression for the 2026-07 black-hole incident: 7 providers capacity-rejected
+// 100% of dispatches ("token_budget_exhausted") from their first request while
+// idle-looking heartbeats kept them at the top of the scheduler — ~9k rejects
+// in 30 min, zero successes. Threshold-many rejects with ZERO interleaved
+// accepts must trip the cooldown, exactly once per transition.
+func TestCapacityRejectBlackHoleTrips(t *testing.T) {
+	r := New(nil)
+	const provider, model = "prov-blackhole", "gemma-4-26b-8bit"
+
+	threshold := r.capacityCooldownCfg.Threshold
+	if threshold != defaultCapacityCooldownThreshold {
+		t.Fatalf("default threshold = %d, want %d", threshold, defaultCapacityCooldownThreshold)
+	}
+
+	for i := 1; i < threshold; i++ {
+		if tripped := r.RecordCapacityReject(provider, model); tripped {
+			t.Fatalf("reject %d/%d tripped early", i, threshold)
+		}
+		if capacityCooldownActiveAt(r, provider, model, time.Now()) {
+			t.Fatalf("cooldown active after only %d rejects", i)
+		}
+	}
+	if tripped := r.RecordCapacityReject(provider, model); !tripped {
+		t.Fatalf("reject %d did not trip the cooldown", threshold)
+	}
+	if !capacityCooldownActiveAt(r, provider, model, time.Now()) {
+		t.Fatal("cooldown not active after trip")
+	}
+	// In-flight stragglers while cooling: recorded, but never a second
+	// transition and never an extension of the expiry.
+	expiry, _ := capacityCooldownExpiryOf(r, provider, model)
+	for i := 0; i < 3; i++ {
+		if tripped := r.RecordCapacityReject(provider, model); tripped {
+			t.Fatal("straggler reject reported a second transition while cooling")
+		}
+	}
+	if after, _ := capacityCooldownExpiryOf(r, provider, model); !after.Equal(expiry) {
+		t.Fatalf("straggler rejects extended the cooldown: %v -> %v", expiry, after)
+	}
+	// The first trip uses the base TTL.
+	if got, want := time.Until(expiry), defaultCapacityCooldownTTL; got > want || got < want-5*time.Second {
+		t.Fatalf("first-trip TTL ≈ %v, want ≈ %v", got, want)
+	}
+	// A different model on the SAME provider is unaffected (pair-keyed).
+	if capacityCooldownActiveAt(r, provider, "other-model", time.Now()) {
+		t.Fatal("cooldown leaked to a different model on the same provider")
+	}
+}
+
+// The balance side of the incident fix: transient fullness is NORMAL. A busy
+// box that keeps SERVING while it sheds (accepts interleaved with capacity
+// rejects) must never trip, no matter how many rejects accumulate in total.
+func TestCapacityRejectBusyButServingNeverTrips(t *testing.T) {
+	r := New(nil)
+	const provider, model = "prov-busy", "gemma-4-26b-8bit"
+	threshold := r.capacityCooldownCfg.Threshold
+
+	// 25 rounds of (threshold-1 rejects, then one accept): 100 rejects total,
+	// but never threshold-many without an accept in between.
+	for round := 0; round < 25; round++ {
+		for i := 0; i < threshold-1; i++ {
+			if tripped := r.RecordCapacityReject(provider, model); tripped {
+				t.Fatalf("round %d: busy-but-serving provider tripped after %d rejects", round, i+1)
+			}
+		}
+		r.RecordCapacityAccept(provider, model)
+	}
+	if capacityCooldownActiveAt(r, provider, model, time.Now()) {
+		t.Fatal("busy-but-serving provider ended up in cooldown")
+	}
+	// The accept also cleared the streak: threshold-1 MORE rejects still don't trip.
+	for i := 0; i < threshold-1; i++ {
+		if tripped := r.RecordCapacityReject(provider, model); tripped {
+			t.Fatal("accept did not reset the reject streak")
+		}
+	}
+}
+
+// An accept mid-cooldown (e.g. the completion of a request dispatched before
+// the trip) immediately clears the cooldown AND the backoff state — the pair
+// has proven it can serve.
+func TestCapacityAcceptClearsActiveCooldownAndBackoff(t *testing.T) {
+	r := New(nil)
+	const provider, model = "prov-recover", "gemma-4-26b-8bit"
+	threshold := r.capacityCooldownCfg.Threshold
+
+	for i := 0; i < threshold; i++ {
+		r.RecordCapacityReject(provider, model)
+	}
+	if !capacityCooldownActiveAt(r, provider, model, time.Now()) {
+		t.Fatal("setup: cooldown should be active")
+	}
+	r.RecordCapacityAccept(provider, model)
+	if capacityCooldownActiveAt(r, provider, model, time.Now()) {
+		t.Fatal("accept did not clear the active cooldown")
+	}
+	if trips := capacityCooldownTripsOf(r, provider, model); trips != 0 {
+		t.Fatalf("accept did not reset the trip count: %d", trips)
+	}
+	// After the accept the pair is FRESH: it needs the full threshold again
+	// (not the half-open single-reject re-arm) and the next trip uses the BASE
+	// TTL (backoff reset).
+	for i := 1; i < threshold; i++ {
+		if tripped := r.RecordCapacityReject(provider, model); tripped {
+			t.Fatalf("post-accept reject %d re-tripped before the full threshold", i)
+		}
+	}
+	if tripped := r.RecordCapacityReject(provider, model); !tripped {
+		t.Fatal("full threshold after accept did not trip")
+	}
+	expiry, _ := capacityCooldownExpiryOf(r, provider, model)
+	if got, want := time.Until(expiry), defaultCapacityCooldownTTL; got > want || got < want-5*time.Second {
+		t.Fatalf("post-accept trip TTL ≈ %v, want base ≈ %v (backoff must have reset)", got, want)
+	}
+}
+
+// Cooldown expiry re-probes the pair (gate reads false), and a still-rejecting
+// pair re-arms on its FIRST post-expiry reject with exponentially doubled TTL,
+// capped at MaxTTL.
+func TestCapacityCooldownExpiryReprobeAndExponentialBackoff(t *testing.T) {
+	r := New(nil)
+	const provider, model = "prov-repeat", "gemma-4-26b-8bit"
+	cfg := r.capacityCooldownCfg
+
+	for i := 0; i < cfg.Threshold; i++ {
+		r.RecordCapacityReject(provider, model)
+	}
+	if !capacityCooldownActiveAt(r, provider, model, time.Now()) {
+		t.Fatal("setup: first trip should be active")
+	}
+
+	wantTTL := cfg.BaseTTL
+	for round := 0; round < 5; round++ {
+		expireCapacityCooldown(r, provider, model)
+		if capacityCooldownActiveAt(r, provider, model, time.Now()) {
+			t.Fatalf("round %d: expired cooldown still reads active — re-probe blocked", round)
+		}
+		// The re-probe was dispatched and REJECTED again: one reject re-arms.
+		if tripped := r.RecordCapacityReject(provider, model); !tripped {
+			t.Fatalf("round %d: failed re-probe did not re-arm the cooldown", round)
+		}
+		wantTTL *= 2
+		if wantTTL > cfg.MaxTTL {
+			wantTTL = cfg.MaxTTL
+		}
+		expiry, ok := capacityCooldownExpiryOf(r, provider, model)
+		if !ok {
+			t.Fatalf("round %d: no cooldown expiry after re-arm", round)
+		}
+		if got := time.Until(expiry); got > wantTTL || got < wantTTL-5*time.Second {
+			t.Fatalf("round %d: backoff TTL ≈ %v, want ≈ %v", round, got, wantTTL)
+		}
+	}
+	// 120s -> 240s -> 480s -> 600s (cap) -> 600s: the final rounds must sit at MaxTTL.
+	if wantTTL != cfg.MaxTTL {
+		t.Fatalf("test walked %v but never reached the %v cap", wantTTL, cfg.MaxTTL)
+	}
+}
+
+// Strikes older than the window never combine with fresh ones: 4 stale rejects
+// plus 1 fresh one is a streak of 1, not 5.
+func TestCapacityRejectWindowSlides(t *testing.T) {
+	r := New(nil)
+	const provider, model = "prov-window", "gemma-4-26b-8bit"
+	cfg := r.capacityCooldownCfg
+
+	for i := 0; i < cfg.Threshold-1; i++ {
+		if tripped := r.RecordCapacityReject(provider, model); tripped {
+			t.Fatal("tripped below threshold")
+		}
+	}
+	// Age everything past the window; the next reject starts a fresh streak.
+	ageCapacityStrikes(r, provider, model, cfg.Window+time.Second)
+	if tripped := r.RecordCapacityReject(provider, model); tripped {
+		t.Fatal("stale strikes outside the window combined with a fresh one to trip")
+	}
+	if capacityCooldownActiveAt(r, provider, model, time.Now()) {
+		t.Fatal("cooldown active after windowed strikes expired")
+	}
+}
+
+// The EIGENINFERENCE_CAPACITY_COOLDOWN_* env tunables are honored at Registry
+// construction: threshold, window, base TTL, and the backoff cap.
+func TestCapacityCooldownEnvTunables(t *testing.T) {
+	t.Setenv(envCapacityCooldownThreshold, "2")
+	t.Setenv(envCapacityCooldownWindowSecs, "30")
+	t.Setenv(envCapacityCooldownTTLSecs, "45")
+	t.Setenv(envCapacityCooldownMaxTTLSecs, "90")
+	r := New(nil)
+
+	want := capacityCooldownConfig{Threshold: 2, Window: 30 * time.Second, BaseTTL: 45 * time.Second, MaxTTL: 90 * time.Second}
+	if r.capacityCooldownCfg != want {
+		t.Fatalf("config = %+v, want %+v", r.capacityCooldownCfg, want)
+	}
+
+	const provider, model = "prov-env", "gemma-4-26b-8bit"
+	if tripped := r.RecordCapacityReject(provider, model); tripped {
+		t.Fatal("tripped on the first reject with threshold 2")
+	}
+	if tripped := r.RecordCapacityReject(provider, model); !tripped {
+		t.Fatal("did not trip on the second reject with threshold 2")
+	}
+	expiry, _ := capacityCooldownExpiryOf(r, provider, model)
+	if got := time.Until(expiry); got > 45*time.Second || got < 40*time.Second {
+		t.Fatalf("first-trip TTL ≈ %v, want ≈ 45s", got)
+	}
+	// Backoff: 45s -> 90s (cap) -> stays 90s.
+	for round, wantTTL := range []time.Duration{90 * time.Second, 90 * time.Second} {
+		expireCapacityCooldown(r, provider, model)
+		if tripped := r.RecordCapacityReject(provider, model); !tripped {
+			t.Fatalf("round %d: failed re-probe did not re-arm", round)
+		}
+		expiry, _ := capacityCooldownExpiryOf(r, provider, model)
+		if got := time.Until(expiry); got > wantTTL || got < wantTTL-5*time.Second {
+			t.Fatalf("round %d: TTL ≈ %v, want cap ≈ %v", round, got, wantTTL)
+		}
+	}
+}
+
+// Threshold 0 is the kill switch: nothing is recorded, nothing ever trips.
+func TestCapacityCooldownDisabledViaThresholdZero(t *testing.T) {
+	t.Setenv(envCapacityCooldownThreshold, "0")
+	r := New(nil)
+	const provider, model = "prov-disabled", "gemma-4-26b-8bit"
+	for i := 0; i < 50; i++ {
+		if tripped := r.RecordCapacityReject(provider, model); tripped {
+			t.Fatal("disabled cooldown tripped")
+		}
+	}
+	if capacityCooldownActiveAt(r, provider, model, time.Now()) {
+		t.Fatal("disabled cooldown reads active")
+	}
+}
+
+// Nonsensical env values (unparseable / non-positive durations / cap below
+// base) fall back to safe defaults instead of a zero-window or zero-TTL config.
+func TestCapacityCooldownConfigClamps(t *testing.T) {
+	t.Setenv(envCapacityCooldownThreshold, "banana")
+	t.Setenv(envCapacityCooldownWindowSecs, "-5")
+	t.Setenv(envCapacityCooldownTTLSecs, "0")
+	t.Setenv(envCapacityCooldownMaxTTLSecs, "1") // below base -> raised to base
+	cfg := loadCapacityCooldownConfig()
+	if cfg.Threshold != defaultCapacityCooldownThreshold {
+		t.Fatalf("Threshold = %d, want default %d", cfg.Threshold, defaultCapacityCooldownThreshold)
+	}
+	if cfg.Window != defaultCapacityCooldownWindow {
+		t.Fatalf("Window = %v, want default %v", cfg.Window, defaultCapacityCooldownWindow)
+	}
+	if cfg.BaseTTL != defaultCapacityCooldownTTL {
+		t.Fatalf("BaseTTL = %v, want default %v", cfg.BaseTTL, defaultCapacityCooldownTTL)
+	}
+	if cfg.MaxTTL != cfg.BaseTTL {
+		t.Fatalf("MaxTTL = %v, want raised to BaseTTL %v", cfg.MaxTTL, cfg.BaseTTL)
+	}
+}
+
+// Map-bound sweep: expired cooldowns and idle strike lists are dropped once the
+// maps grow past the bound, so per-session UUID keys cannot leak forever.
+func TestCapacityCooldownMapsBounded(t *testing.T) {
+	r := New(nil)
+	const model = "gemma-4-26b-8bit"
+	cfg := r.capacityCooldownCfg
+
+	// Seed >1024 expired cooldowns and stale strike lists directly.
+	r.mu.Lock()
+	past := time.Now().Add(-time.Hour)
+	for i := 0; i < 1100; i++ {
+		key := capacityRejectKey{ProviderID: fmt.Sprintf("dead-%d", i), ModelID: model}
+		r.capacityCooldowns[key] = past
+		r.capacityCooldownTrips[key] = 1
+		r.capacityRejectStrikes[key] = []time.Time{past.Add(-cfg.Window)}
+	}
+	r.mu.Unlock()
+
+	r.RecordCapacityReject("prov-live", model)
+
+	r.mu.RLock()
+	cooldowns, strikes := len(r.capacityCooldowns), len(r.capacityRejectStrikes)
+	r.mu.RUnlock()
+	if cooldowns > 8 {
+		t.Fatalf("expired cooldowns not swept: %d entries remain", cooldowns)
+	}
+	if strikes > 8 {
+		t.Fatalf("stale strike lists not swept: %d entries remain", strikes)
+	}
+}

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -1280,6 +1280,24 @@ type Registry struct {
 	providerBreakerOpenUntil map[string]time.Time             // breaker-open expiry per provider
 	providerBreakerTrips     map[string]int                   // trip count per provider (exponential backoff)
 
+	// capacityRejectStrikes / capacityCooldowns / capacityCooldownTrips
+	// implement the capacity-reject routing cooldown (capacity_cooldown.go),
+	// SEPARATE from every breaker above — all of which deliberately IGNORE
+	// capacity-class rejections (sound for occasional sheds from a busy box,
+	// catastrophic for a box that capacity-rejects EVERYTHING while its
+	// idle-looking heartbeats keep winning the cost scheduler: the 2026-07
+	// black-hole incident, 7 boxes, ~9k rejects/30min, zero successes). A
+	// (provider, model) pair that accumulates threshold-many capacity rejects
+	// inside the window with ZERO interleaved accepts enters a routing
+	// cooldown with exponential re-trip backoff; any accept (first content
+	// chunk or clean completion) clears all three entries. Config is
+	// env-tunable (EIGENINFERENCE_CAPACITY_COOLDOWN_*), loaded at
+	// construction. Guarded by r.mu like the maps above.
+	capacityCooldownCfg   capacityCooldownConfig
+	capacityRejectStrikes map[capacityRejectKey][]time.Time // recent capacity-reject strikes per (provider, model)
+	capacityCooldowns     map[capacityRejectKey]time.Time   // cooldown expiry per (provider, model)
+	capacityCooldownTrips map[capacityRejectKey]int         // trip count per (provider, model) (exponential backoff)
+
 	// Stable-identity health ejection (health_ejection.go). Keyed by a STABLE
 	// identity (serial/SE-key/account), NOT the session UUID, and DELIBERATELY
 	// NOT deleted on Disconnect — so a zombie that fails ~every request while
@@ -1367,6 +1385,10 @@ func New(logger *slog.Logger) *Registry {
 		providerOutcomes:         make(map[string]*providerHealthWindow),
 		providerBreakerOpenUntil: make(map[string]time.Time),
 		providerBreakerTrips:     make(map[string]int),
+		capacityCooldownCfg:      loadCapacityCooldownConfig(),
+		capacityRejectStrikes:    make(map[capacityRejectKey][]time.Time),
+		capacityCooldowns:        make(map[capacityRejectKey]time.Time),
+		capacityCooldownTrips:    make(map[capacityRejectKey]int),
 		healthEjectionWindows:    make(map[string]*providerHealthWindow),
 		healthEjectionUntil:      make(map[string]time.Time),
 		healthEjectionTrips:      make(map[string]int),

--- a/coordinator/registry/scheduler.go
+++ b/coordinator/registry/scheduler.go
@@ -868,6 +868,8 @@ func (r *Registry) logRoutingDecision(model string, pr *PendingRequest, winner *
 //   - dispatch-load cooldown (pair instant-503'd on "insufficient memory")
 //   - inference-error cooldown, SHAPE-KEYED to traits.CooldownShape() (pair
 //     returning repeated provider-side 5xx for THIS request shape)
+//   - capacity-reject cooldown (pair capacity-rejecting everything with ZERO
+//     interleaved accepts — the black-hole signature)
 //   - status not offline/untrusted
 //   - private-only admission (only the owner's self-route may use it)
 //   - hardware-trust floor (relaxed to TrustNone for the owner's own machine)
@@ -916,6 +918,16 @@ func (r *Registry) providerPassesRoutingGatesLockedEx(p *Provider, model string,
 	// tool failure does not deroute clean text traffic. Cleared by
 	// RecordInferenceSuccess (same shape) or by TTL expiry.
 	if r.inferenceErrorCooldownActiveLocked(p.ID, model, traits.CooldownShape(), now) {
+		return false
+	}
+	// Skip a (provider, model) pair quarantined by the capacity-reject cooldown:
+	// it kept capacity-rejecting with ZERO interleaved accepts (the black-hole
+	// signature — e.g. a box whose engine misreports its token budget), so a
+	// dispatch here is a guaranteed bounce while its idle-looking heartbeats
+	// keep winning the cost scheduler. A busy box that is also SERVING never
+	// trips this (any accept resets the streak), and the pair is re-probed once
+	// its TTL expires. See capacity_cooldown.go.
+	if r.capacityCooldownActiveLocked(p.ID, model, now) {
 		return false
 	}
 	// Skip a provider quarantined by the per-provider node-health breaker: a


### PR DESCRIPTION
# fix(coordinator): capacity-reject routing cooldown — stop black-hole providers absorbing dispatch

## Incident (live)

7 provider boxes (64GB, `gemma-4-26b-8bit`, v0.7.2) reject **100% of dispatched requests** with the capacity string (`token_budget_exhausted`, classified 503) from their **first request after registration** — **~9,000 rejections in 30 minutes, zero successes** — while **~170 healthy boxes** for the same model sit underutilized.

The router keeps selecting them because:

1. Their heartbeats report near-zero active tokens, so the cost-based scheduler (`registry/scheduler.go`) scores them best — they look like ideal instant-TTFT targets.
2. Capacity-class failures are **deliberately** excluded from reputation penalties, the shape-keyed 5xx breaker (`registry/error_cooldown.go` skips 503), and the node-health breaker (`registry/provider_breaker.go` ignores capacity sheds). Sound policy for occasional capacity rejects from a busy box; catastrophic for a box that rejects *everything*. Nothing in the system could ever deroute them.

## Fix

A **capacity-reject routing cooldown** (`registry/capacity_cooldown.go`), distinct from the 5xx error cooldown, keyed per `(provider, model)`:

- **Discriminator — zero interleaved accepts.** Trips on **>= N capacity rejects within window W with NO accept in between** (defaults N=5, W=60s). Any accept — the **first content-bearing chunk** (`commitFirstContent`, so a long generation vouches for a busy box *while* it sheds concurrent dispatches) or a **clean completion** (`noteInferenceSuccess`) — resets the streak, any active cooldown, and the backoff. A busy-but-serving box **can never trip**; a black hole (zero accepts by definition) trips within seconds.
- **Cooldown + re-probe.** Trip quarantines the pair for 120s (env-tunable) via the shared routing gate `providerPassesRoutingGatesLockedEx` — honored by both the dispatch hot path and the `QuickCapacityCheck` preflight, so they cannot drift. After expiry the pair is re-probed; a genuinely-full box that recovered gets traffic back and its first accept clears all state. A still-rejecting pair re-arms on its **first** post-expiry reject (half-open) with exponential backoff: 120s → 240s → 480s → capped at 10 min.
- **Strike classification** (`api/inference_failure_class.go: isCapacityRejectStrike`): capacity-class strings count (`token_budget_exhausted`, KV headroom, queue full, draining, cold not-loaded, batch token budget); explicit **context-window overflows never strike** (they indict the request, not the provider — a burst of oversized prompts cannot cool healthy boxes), and 4xx client-shape errors never strike.
- **Observability**: distinct Datadog counter **`routing.capacity_cooldown_tripped`** tagged `provider_id` + `model`, emitted exactly once per trip transition, plus a `Warn` log line.
- **Env tunables** (read at coordinator start): `EIGENINFERENCE_CAPACITY_COOLDOWN_THRESHOLD` (5; `0` = kill switch), `EIGENINFERENCE_CAPACITY_COOLDOWN_WINDOW_SECONDS` (60), `EIGENINFERENCE_CAPACITY_COOLDOWN_TTL_SECONDS` (120), `EIGENINFERENCE_CAPACITY_COOLDOWN_MAX_TTL_SECONDS` (600).

## Before / After — behavior

```mermaid
flowchart LR
  subgraph Before["Before — black hole absorbs dispatch"
]
    A1[request] --> S1[cost scheduler]
    S1 -- "near-zero active tokens =\nbest score" --> B1[black-hole box]
    B1 -- "503 token_budget_exhausted\n(invisible to reputation +\nall 3 breakers)" --> R1[retry]
    R1 --> S1
    R1 -- "maxCapacityClassRetries\nexhausted" --> E1[429/503 to client]
    H1[~170 healthy boxes] -.->|underutilized| S1
  end
  subgraph After["After — cooldown diverts to healthy boxes"]
    A2[request] --> S2[cost scheduler]
    S2 -- first N=5 rejects/60s\nzero accepts --> B2[black-hole box]
    B2 -- "trip: capacity_cooldown_tripped\n(provider_id, model)" --> C2[routing cooldown 120s\nbackoff x2 -> 10min cap]
    C2 -- gate skips pair --> S2
    S2 -- all later dispatch --> H2[healthy boxes]
    H2 -- first content chunk /\ncompletion = accept --> OK2[200 to client]
    C2 -- TTL expiry --> P2[re-probe]
    P2 -- accept --> S2
    P2 -- reject --> C2
  end
```

- **Busy-but-serving box (must not regress):** a saturated box that rejects while also serving keeps producing accepts, which reset the streak — it never trips, before or after this PR.
- **Failover, reputation, uptime classification unchanged:** capacity rejects still reclassify to uptime-neutral 429s, still skip reputation and the fault breakers; this PR only adds the missing routing consequence for the pathological zero-accept pattern.

## Before / After — code

```mermaid
flowchart LR
  subgraph BeforeC["Before"]
    N1["noteInferenceError(503, capacity)"] --> X1["RecordInferenceError: skips 503"]
    N1 --> X2["RecordProviderOutcome: capacity shed ignored"]
    N1 --> X3["RecordProviderServeOutcome: capacity shed ignored"]
    G1[providerPassesRoutingGatesLockedEx] --> G1a[load cooldown]
    G1 --> G1b[5xx shape cooldown]
    G1 --> G1c[node-health breaker]
  end
  subgraph AfterC["After"]
    N2["noteInferenceError(429/5xx, capacity)"] --> Y0["isCapacityRejectStrike\n(api/inference_failure_class.go)"]
    Y0 --> Y1["Registry.RecordCapacityReject\n(registry/capacity_cooldown.go)\nN in W, zero accepts -> trip\nhalf-open re-arm + backoff"]
    Y1 -- trip --> Y2["ddIncr routing.capacity_cooldown_tripped\n+ Warn log"]
    K1["commitFirstContent (dispatch.go)\nfirst content chunk"] --> Y3[Registry.RecordCapacityAccept]
    K2["noteInferenceSuccess (consumer.go)\nclean completion"] --> Y3
    Y3 -- clears streak+cooldown+backoff --> Y1
    G2[providerPassesRoutingGatesLockedEx] --> G2a[load cooldown]
    G2 --> G2b[5xx shape cooldown]
    G2 --> G2n["capacityCooldownActiveLocked (NEW)"]
    G2 --> G2c[node-health breaker]
  end
```

## Files changed

| File | Change |
|---|---|
| `coordinator/registry/capacity_cooldown.go` | **new** — config (env), strike/accept/active/backoff logic |
| `coordinator/registry/registry.go` | struct fields + init for the three cooldown maps + config |
| `coordinator/registry/scheduler.go` | routing gate: skip capacity-cooled `(provider, model)` pairs |
| `coordinator/api/inference_failure_class.go` | `isCapacityRejectStrike` classifier |
| `coordinator/api/consumer.go` | feed rejects in `noteInferenceError` (metric + log on trip); accept on clean completion |
| `coordinator/api/dispatch.go` | accept on first content chunk (`commitFirstContent`) |
| `coordinator/registry/capacity_cooldown_test.go` | **new** — 9 registry tests |
| `coordinator/api/capacity_cooldown_test.go` | **new** — classifier table + end-to-end trip/metric/log/routing test |

## Tests

- **Black hole trips + routing skips**: 5 zero-accept rejects trip exactly once; stragglers never re-transition or extend; `ReserveProviderEx` diverts every dispatch to the healthy box (`TestCapacityRejectBlackHoleTrips`, `TestCapacityCooldownTripsMetricLogAndRoutingDiverts`).
- **Retry re-selection escapes the sink** (`TestCapacityCooldownRetryReselectionEscapesSink`): reproduces the live amplification loop — an idle-looking sink deterministically wins the cost score over a loaded healthy box, instant-rejects, and the retry loop re-selects it. The loop escapes to the healthy box within <= threshold (5) picks and every subsequent selection stays off the sink. (Retry re-selection funnels through `ReserveProviderEx` → the shared gate, which runs on BOTH scan passes — the fail-open rescan bypasses only the node-health breaker, never this cooldown.)
- **Busy-but-serving never trips**: 100 rejects with interleaved accepts — never cooled, at registry and api level.
- **Expiry re-probes; backoff on repeat**: expired cooldown reads inactive (probe allowed); failed probe re-arms 240s → 480s → 600s cap; accept resets backoff to base (`TestCapacityCooldownExpiryReprobeAndExponentialBackoff`, `TestCapacityAcceptClearsActiveCooldownAndBackoff`).
- **Window slides**: stale strikes never combine with fresh ones.
- **Env tunables respected** (threshold/window/TTL/cap via `t.Setenv` + fresh registry), **kill switch** (`THRESHOLD=0`), **config clamps**, **map bounding sweep**.
- **Metric/log emitted**: exactly one `routing.capacity_cooldown_tripped` DogStatsD packet (live UDP collector) with `provider_id` + `model` tags, exactly one Warn log line.
- **Never-strike cases**: 4xx with capacity string, deterministic context overflow.

`go test ./...` green across the coordinator; `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/507"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785698238&installation_id=133247490&pr_number=507&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F507&signature=d5f674ba113f97e32ccc0b41119b5eec509925ac6121f4a260a086f8b324e9c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->