### PR TITLE
hotfix(provider): v0.7.3 — Gemma black-hole cure: share the MoE fused gate+up cache; budget self-heal

### DIFF
--- a/console-ui/src/lib/telemetry-types.ts
+++ b/console-ui/src/lib/telemetry-types.ts
@@ -115,4 +115,14 @@ export const TELEMETRY_ALLOWED_FIELDS = new Set<string>([
   "prefill_samples_dropped_ceiling",
   "last_prefill_sample_tps",
   "observed_prefill_tps_ewma",
+  // KV-budget sustained-rejection audit (v0.7.3 black-hole hardening,
+  // mirror of Go + Swift allowlists).
+  "streak_seconds",
+  "reservation_count",
+  "reserved_bytes",
+  "mlx_cache_bytes",
+  "system_available_bytes",
+  "reservations",
+  "request_id",
+  "age_seconds",
 ]);

--- a/coordinator/api/server.go
+++ b/coordinator/api/server.go
@@ -145,7 +145,7 @@ func keyLimitResetFromContext(ctx context.Context) string {
 // 0.6.0 is the APNs code-identity / VLM-routing / graceful-update release.
 // Keep this fallback in sync with ProviderCore.version so dev/in-memory
 // coordinators advertise the same floor as the Swift binary they expect.
-var LatestProviderVersion = "0.7.2"
+var LatestProviderVersion = "0.7.3"
 
 // minProviderVersionForDesiredModels is the first provider version whose Swift
 // runtime understands the desired_models message. The coordinator must NOT send

--- a/coordinator/api/telemetry_handlers.go
+++ b/coordinator/api/telemetry_handlers.go
@@ -110,6 +110,17 @@ var telemetryFieldAllowlist = map[string]struct{}{
 	"prefill_samples_dropped_ceiling": {},
 	"last_prefill_sample_tps":         {},
 	"observed_prefill_tps_ewma":       {},
+	// KV-budget sustained-rejection audit (v0.7.3 black-hole hardening):
+	// reservation ids/byte counts/ages + memory snapshot terms — operational
+	// bookkeeping only. Mirror of the Swift + TS allowlists.
+	"streak_seconds":         {},
+	"reservation_count":      {},
+	"reserved_bytes":         {},
+	"mlx_cache_bytes":        {},
+	"system_available_bytes": {},
+	"reservations":           {},
+	"request_id":             {},
+	"age_seconds":            {},
 	// Console UI context
 	"url":        {},
 	"user_agent": {},

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2KVSizing.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2KVSizing.swift
@@ -91,6 +91,35 @@ enum EngineV2KVSizing {
         return Int(min(remaining, UInt64(Int.max)))
     }
 
+    /// Net a v2 engine's admission ceiling of the slot's MEASURED
+    /// engine-retained residency overhead — the shared MoE fused gate+up
+    /// cache the VLM text extraction eagerly builds (v0.7.3, PR#508
+    /// finding 2).
+    ///
+    /// `engineKVBytesCapacity` derives the ceiling from WEIGHTS + reserves
+    /// BEFORE the engine build runs, but on a VLM-extracted Gemma slot the
+    /// build then materializes ~8–15 GiB of fused expert cache —
+    /// module-retained ACTIVE memory that behaves exactly like weights (the
+    /// pool reclaimer cannot touch it) yet appears in neither
+    /// `scheduler.modelWeightBytes` nor any parameter sum. An unadjusted
+    /// ceiling — and the heartbeat `active_token_budget_max` derived from
+    /// it — therefore over-advertises by exactly the cache size (~1.7× on
+    /// the incident's 64 GB/8-bit profile): the coordinator over-routes and
+    /// the shared KV gate (which sees the cache in live MLX `active`)
+    /// rejects the excess post-acceptance — a mild replay of the v0.7.2
+    /// black hole, mitigated only by coordinator-side cooldowns. Subtracting
+    /// the measured cache here keeps the engine's private ledger, the
+    /// heartbeat max, and the shared gate consistent. Clamps to 0 — a slot
+    /// whose cache consumed the whole KV budget falls back to legacy via
+    /// `makeProductionEngine`'s `noKVHeadroom` throw.
+    static func netOfEngineResidentOverhead(
+        _ baseCapacity: Int, overheadBytes: Int
+    ) -> Int {
+        let base = max(0, baseCapacity)
+        let overhead = max(0, overheadBytes)
+        return base > overhead ? base - overhead : 0
+    }
+
     /// CURRENT KV byte budget for an EXISTING v2 engine — the HEARTBEAT
     /// figure, not an engine resize (round-3 PR#499 P2).
     ///

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2Runtime.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2Runtime.swift
@@ -68,7 +68,10 @@ public actor EngineV2Runtime {
     /// from live inputs (`EngineV2KVSizing.liveEngineKVBytesBudget`).
     public struct FleetKVContext: Sendable {
         /// Σ resident model weights across ALL slots (v2 AND legacy),
-        /// including each bridge's own model.
+        /// including each bridge's own model — PLUS each slot's measured
+        /// engine-retained residency overhead (the shared MoE fused gate+up
+        /// cache a VLM extraction eagerly builds), which behaves like
+        /// weights for budget purposes but appears in no parameters() sum.
         public let totalResidentWeightBytes: UInt64
         /// Operator `memory_reserve_gb`, in bytes (see `EngineV2KVSizing`).
         public let configReserveBytes: UInt64

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2VLMTextExtraction.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2VLMTextExtraction.swift
@@ -101,10 +101,13 @@ enum EngineV2VLMTextExtraction {
 
     /// Result of one extraction: the CBv2-adapted text model (sharing the
     /// wrapper's weight arrays) plus the parity probe's max |Δlogit| for the
-    /// slot factory's log line (nil when the parity gate was disabled).
+    /// slot factory's log line (nil when the parity gate was disabled), and
+    /// the number of MoE layers whose fused gate+up cache is shared between
+    /// the wrapper and the extracted model (the v0.7.3 black-hole fix).
     struct Extraction {
         let model: Gemma4TextModel
         let parityMaxAbsLogitDiff: Float?
+        let sharedFusedMoELayerCount: Int
     }
 
     /// Build an MLXLLM `Gemma4TextModel` over the weight arrays of a loaded
@@ -155,14 +158,75 @@ enum EngineV2VLMTextExtraction {
         try skeleton.update(
             parameters: ModuleParameters.unflattened(textWeights), verify: [.all])
 
-        // 4. Load-time forward parity gate (env-gated, default on).
+        // 4. Share the MoE fused gate+up caches (v0.7.3 — the 64 GB
+        //    black-hole fix). `MLXLMCommon.SwitchGLU` lazily concatenates a
+        //    fused copy of its gate+up expert weights on FIRST FORWARD and
+        //    retains it on the module (~540 MB/layer, ~15 GiB model-wide on
+        //    gemma-4-26b-8bit). The wrapper's tree and this extracted tree
+        //    each hold their own SwitchGLU instances, so without sharing the
+        //    load-time parity probe below (or, with the gate disabled, the
+        //    first live request on each path) builds TWO identical multi-GiB
+        //    copies — pushing weights+caches past the 90% unified-memory cap
+        //    on 64 GB (8-bit) and 36 GB (qat-4bit) boxes, after which the
+        //    shared KV gate rejected every request (the v0.7.2 incident).
+        //    Pairing wrapper↔extracted instances keeps the total at ONE
+        //    fused copy, built eagerly here where the load path's admission
+        //    guards can see it. Runs before the probe so neither probe
+        //    forward can trigger a private build.
+        let sharedFusedLayers = shareMoEFusedCaches(wrapper: wrapper, extracted: skeleton)
+
+        // 5. Load-time forward parity gate (env-gated, default on).
         var parityDiff: Float? = nil
         if parityCheckEnabled(environment: environment) {
+            // Return the probe's transient buffers to the OS before the load
+            // path's post-build admission/headroom reads. The probe's two
+            // forwards leave ~GiBs of intermediates in the MLX pool; fence
+            // async GPU completion first (M4 IOKit guard), and clean up on
+            // the parity-failure throw path too.
+            defer {
+                MLX.Stream().synchronize()
+                MLX.Memory.clearCache()
+            }
             parityDiff = try assertForwardParity(
                 wrapper: wrapper, extracted: skeleton, vocabSize: textConfig.vocabSize)
         }
 
-        return Extraction(model: skeleton, parityMaxAbsLogitDiff: parityDiff)
+        return Extraction(
+            model: skeleton,
+            parityMaxAbsLogitDiff: parityDiff,
+            sharedFusedMoELayerCount: sharedFusedLayers)
+    }
+
+    /// Pair every MoE `SwitchGLU` in the wrapper's language model with its
+    /// counterpart in the extracted text model (same dotted module path minus
+    /// the `language_model.` prefix — the exact re-keying the parameter
+    /// update used) and share ONE fused gate+up cache between each pair.
+    /// Returns the number of pairs shared. Zero for dense checkpoints (no
+    /// SwitchGLU anywhere) — and, defensively, when the two trees' module
+    /// paths ever diverge, in which case each side keeps its lazy build (the
+    /// pre-v0.7.2 behavior) rather than failing the extraction.
+    private static func shareMoEFusedCaches(
+        wrapper: MLXVLM.Gemma4, extracted: Gemma4TextModel
+    ) -> Int {
+        var extractedSwitchGLUs: [String: SwitchGLU] = [:]
+        for (path, module) in extracted.namedModules() {
+            if let glu = module as? SwitchGLU {
+                extractedSwitchGLUs[path] = glu
+            }
+        }
+        guard !extractedSwitchGLUs.isEmpty else { return 0 }
+
+        var shared = 0
+        for (path, module) in wrapper.namedModules() {
+            guard let wrapperGLU = module as? SwitchGLU,
+                path.hasPrefix(languageModelPrefix),
+                let extractedGLU =
+                    extractedSwitchGLUs[String(path.dropFirst(languageModelPrefix.count))]
+            else { continue }
+            wrapperGLU.shareFusedGateUpCache(with: extractedGLU)
+            shared += 1
+        }
+        return shared
     }
 
     // MARK: - Steps

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2VLMTextExtraction.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2VLMTextExtraction.swift
@@ -223,8 +223,12 @@ enum EngineV2VLMTextExtraction {
                 let extractedGLU =
                     extractedSwitchGLUs[String(path.dropFirst(languageModelPrefix.count))]
             else { continue }
-            wrapperGLU.shareFusedGateUpCache(with: extractedGLU)
-            shared += 1
+            // Counts only pairs where a cache actually exists and is shared —
+            // an ineligible layer (opt-out env, cache limit, non-quantized)
+            // propagates its no-fusion verdict but is not "shared".
+            if wrapperGLU.shareFusedGateUpCache(with: extractedGLU) {
+                shared += 1
+            }
         }
         return shared
     }

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2VLMTextExtraction.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2VLMTextExtraction.swift
@@ -101,13 +101,17 @@ enum EngineV2VLMTextExtraction {
 
     /// Result of one extraction: the CBv2-adapted text model (sharing the
     /// wrapper's weight arrays) plus the parity probe's max |Δlogit| for the
-    /// slot factory's log line (nil when the parity gate was disabled), and
-    /// the number of MoE layers whose fused gate+up cache is shared between
-    /// the wrapper and the extracted model (the v0.7.3 black-hole fix).
+    /// slot factory's log line (nil when the parity gate was disabled), the
+    /// number of MoE layers whose fused gate+up cache is shared between
+    /// the wrapper and the extracted model (the v0.7.3 black-hole fix), and
+    /// the MEASURED total bytes of that fused cache — module-retained
+    /// active memory the slot factory must net out of the v2 engine's
+    /// weights-derived KV admission ceiling (PR#508 finding 2).
     struct Extraction {
         let model: Gemma4TextModel
         let parityMaxAbsLogitDiff: Float?
         let sharedFusedMoELayerCount: Int
+        let fusedMoECacheBytes: Int
     }
 
     /// Build an MLXLLM `Gemma4TextModel` over the weight arrays of a loaded
@@ -191,10 +195,42 @@ enum EngineV2VLMTextExtraction {
                 wrapper: wrapper, extracted: skeleton, vocabSize: textConfig.vocabSize)
         }
 
+        // Measure AFTER the probe: on the (defensive) path where some layer
+        // pair was NOT shared, the probe's forwards are what lazily built
+        // each tree's private cache, and the capacity derivation must see
+        // the full retained footprint either way.
+        let fusedBytes = fusedMoECacheBytes(of: [wrapper, skeleton])
+
         return Extraction(
             model: skeleton,
             parityMaxAbsLogitDiff: parityDiff,
-            sharedFusedMoELayerCount: sharedFusedLayers)
+            sharedFusedMoELayerCount: sharedFusedLayers,
+            fusedMoECacheBytes: fusedBytes)
+    }
+
+    /// Total bytes of MoE fused gate+up caches retained across `roots`,
+    /// counting each cache ONCE even when it is shared between trees
+    /// (`shareFusedGateUpCache` hands the SAME `MLXArray` instances to both
+    /// SwitchGLUs, so dedup is by weight-buffer identity). This is the
+    /// engine-retained residency overhead the v2 capacity derivation nets
+    /// out (`EngineV2KVSizing.netOfEngineResidentOverhead`) and the load
+    /// path records on the model slot — the fused arrays are plain module
+    /// properties, so they appear in neither `parameters()` sums nor
+    /// `scheduler.modelWeightBytes`. Zero for dense checkpoints and before
+    /// any cache is built.
+    static func fusedMoECacheBytes(of roots: [Module]) -> Int {
+        var seen = Set<ObjectIdentifier>()
+        var total = 0
+        for root in roots {
+            for (_, module) in root.namedModules() {
+                guard let glu = module as? SwitchGLU,
+                    let weight = glu.fusedGateUpWeightForVerification
+                else { continue }
+                guard seen.insert(ObjectIdentifier(weight)).inserted else { continue }
+                total += glu.fusedGateUpCacheBytes
+            }
+        }
+        return total
     }
 
     /// Pair every MoE `SwitchGLU` in the wrapper's language model with its

--- a/provider-swift/Sources/ProviderCore/Inference/GlobalKVCacheBudget.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/GlobalKVCacheBudget.swift
@@ -25,7 +25,50 @@ public actor GlobalKVCacheBudget {
     /// grow into memory the operator reserved. 0 = no extra reserve (cap only).
     private let configReserveBytes: UInt64
     private let memorySnapshot: @Sendable () -> MemorySnapshot
-    private var reservations: [String: UInt64] = [:]
+
+    /// One ledger entry: the promised bytes plus when the promise was made.
+    /// The creation instant exists solely for the stale-reservation audit —
+    /// a reservation that outlives any plausible request/load lifetime while
+    /// the budget rejects everything is, by definition, leaked bookkeeping.
+    struct Reservation: Sendable {
+        var bytes: UInt64
+        let createdAt: ContinuousClock.Instant
+    }
+
+    private var reservations: [String: Reservation] = [:]
+
+    // MARK: - Sustained-rejection audit state (v0.7.3 black-hole hardening)
+    //
+    // The 0.7.2 incident class: the budget's headroom terms wedge (leaked
+    // reservation / retained active memory) and EVERY commit fails forever,
+    // while the cache-pool reclaimer — the only self-heal that existed —
+    // can't help because the binding term isn't the reclaimable pool. These
+    // fields turn that permanent black hole into a bounded blip: when every
+    // commit has failed for `sustainedRejectionAuditThreshold` straight, the
+    // budget logs the FULL reservation table at CRITICAL severity and drops
+    // any reservation older than `staleReservationTTL` with a WARN. Live
+    // requests/loads hold their reservations for seconds-to-minutes, so a
+    // multi-minute-old reservation during a full-rejection streak is leaked
+    // bookkeeping, not live work.
+    private var rejectionStreakStart: ContinuousClock.Instant?
+    private var lastAuditAt: ContinuousClock.Instant?
+    private let sustainedRejectionAuditThreshold: Duration
+    private let staleReservationTTL: Duration
+    private let auditMinInterval: Duration
+    private let emitAuditEvent: @Sendable (TelemetrySeverity, String, [String: AnyCodableValue]) -> Void
+
+    /// Every commit must have failed for this long before the audit runs.
+    /// Well above any transient rejection burst (the coordinator reroutes in
+    /// seconds), far below the incident's 40+ minutes of black hole.
+    static let defaultSustainedRejectionAuditThreshold: Duration = .seconds(120)
+    /// A reservation older than this is considered leaked *during a
+    /// sustained full-rejection streak*. Requests hold reservations for the
+    /// request duration (worst realistic long decode: minutes); pending-load
+    /// reservations for the container-allocation window (also minutes).
+    static let defaultStaleReservationTTL: Duration = .seconds(600)
+    /// Rate limit between audits so a wedged box logs one CRITICAL per
+    /// interval, not one per rejected request.
+    static let defaultAuditMinInterval: Duration = .seconds(60)
 
     /// The reclaimable-pool flush runs in this reclaimer, off the budget actor.
     /// The admission paths only ever signal it (non-blocking); the blocking GPU
@@ -43,6 +86,13 @@ public actor GlobalKVCacheBudget {
         self.capFraction = capFraction
         self.activationReserveBytes = activationReserveBytes
         self.configReserveBytes = configReserveBytes
+        self.sustainedRejectionAuditThreshold = Self.defaultSustainedRejectionAuditThreshold
+        self.staleReservationTTL = Self.defaultStaleReservationTTL
+        self.auditMinInterval = Self.defaultAuditMinInterval
+        self.emitAuditEvent = { severity, message, fields in
+            TelemetryClient.shared.emit(
+                kind: .engineHealth, severity: severity, message: message, fields: fields)
+        }
         // Fence async GPU completion before freeing buffers, matching the engine's
         // own reclaim paths (avoids the IOKit completeMemory race seen on M4).
         let clearCache: @Sendable () -> Void = {
@@ -70,12 +120,20 @@ public actor GlobalKVCacheBudget {
         memorySnapshot: @escaping @Sendable () -> MemorySnapshot,
         clearCache: @escaping @Sendable () -> Void = {},
         selfHealMinInterval: Duration = GlobalKVCacheBudget.defaultSelfHealMinInterval,
-        reclaimer: KVPoolReclaimer? = nil
+        reclaimer: KVPoolReclaimer? = nil,
+        sustainedRejectionAuditThreshold: Duration = GlobalKVCacheBudget.defaultSustainedRejectionAuditThreshold,
+        staleReservationTTL: Duration = GlobalKVCacheBudget.defaultStaleReservationTTL,
+        auditMinInterval: Duration = GlobalKVCacheBudget.defaultAuditMinInterval,
+        emitAuditEvent: @escaping @Sendable (TelemetrySeverity, String, [String: AnyCodableValue]) -> Void = { _, _, _ in }
     ) {
         self.capFraction = capFraction
         self.activationReserveBytes = activationReserveBytes
         self.configReserveBytes = configReserveBytes
         self.memorySnapshot = memorySnapshot
+        self.sustainedRejectionAuditThreshold = sustainedRejectionAuditThreshold
+        self.staleReservationTTL = staleReservationTTL
+        self.auditMinInterval = auditMinInterval
+        self.emitAuditEvent = emitAuditEvent
         self.reclaimer = reclaimer ?? KVPoolReclaimer(
             clearCache: clearCache,
             reclaimableBytes: { memorySnapshot().cache },
@@ -128,7 +186,7 @@ public actor GlobalKVCacheBudget {
     /// resident (and thus reflected in `mlxUsed`). Pair with `release`.
     public func reservePendingLoad(requestID: String, bytes: UInt64) {
         guard bytes > 0 else { return }
-        reservations[requestID] = bytes
+        reservations[requestID] = Reservation(bytes: bytes, createdAt: .now)
     }
 
     /// Atomically shrink an existing reservation to a smaller byte count,
@@ -144,7 +202,11 @@ public actor GlobalKVCacheBudget {
         guard let current = reservations[requestID], kvBytesPerToken > 0, tokenCount > 0 else { return }
         let (bytes, overflow) = UInt64(kvBytesPerToken).multipliedReportingOverflow(by: UInt64(tokenCount))
         let newBytes = overflow ? UInt64.max : bytes
-        if newBytes < current { reservations[requestID] = newBytes }   // only ever shrink; frees the difference; never fails
+        if newBytes < current.bytes {
+            // Only ever shrink; frees the difference; never fails. Keeps the
+            // original creation instant — a shrink is not a new promise.
+            reservations[requestID]?.bytes = newBytes
+        }
     }
 
     /// Total KV bytes currently promised to in-flight requests. The model-load
@@ -154,7 +216,7 @@ public actor GlobalKVCacheBudget {
     /// promised memory as free and risk an OOM).
     public func outstandingReservedBytes() -> UInt64 {
         reservations.values.reduce(UInt64(0)) { partial, value in
-            let (sum, overflow) = partial.addingReportingOverflow(value)
+            let (sum, overflow) = partial.addingReportingOverflow(value.bytes)
             return overflow ? UInt64.max : sum
         }
     }
@@ -172,10 +234,78 @@ public actor GlobalKVCacheBudget {
         let available = availableReservationBytes()
         guard bytes <= available else {
             reclaimer.scheduleReclaim(shortfall: bytes - available)   // non-blocking; flush runs off-actor
+            recordCommitRejection()
             return false
         }
-        reservations[requestID] = bytes
+        reservations[requestID] = Reservation(bytes: bytes, createdAt: .now)
+        rejectionStreakStart = nil
         return true
+    }
+
+    // MARK: - Sustained-rejection reservation audit (v0.7.3)
+
+    /// Called on every failed commit. When EVERY commit has failed for
+    /// `sustainedRejectionAuditThreshold` straight — the black-hole signature:
+    /// the coordinator keeps routing, the provider keeps rejecting, and the
+    /// cache-pool reclaimer isn't helping — log the full reservation table at
+    /// ERROR severity and drop any reservation older than
+    /// `staleReservationTTL` with a WARN. Live requests hold reservations for
+    /// seconds-to-minutes and release them on every terminal path; pending
+    /// loads release once weights are resident. A reservation that has
+    /// out-lived the TTL *while nothing at all is being admitted* is leaked
+    /// bookkeeping, and dropping it converts a permanent reject-everything
+    /// wedge into a self-healed blip. Rate-limited to one audit per
+    /// `auditMinInterval`.
+    private func recordCommitRejection() {
+        let now = ContinuousClock.now
+        if rejectionStreakStart == nil {
+            rejectionStreakStart = now
+            return
+        }
+        guard let streakStart = rejectionStreakStart,
+            now - streakStart >= sustainedRejectionAuditThreshold
+        else { return }
+        if let last = lastAuditAt, now - last < auditMinInterval { return }
+        lastAuditAt = now
+
+        let snap = memorySnapshot()
+        let table = reservations
+            .map { id, r in
+                "\(id)=\(r.bytes)B age=\(Int((now - r.createdAt).components.seconds))s"
+            }
+            .sorted()
+            .joined(separator: ", ")
+        let streakSeconds = Int((now - streakStart).components.seconds)
+        emitAuditEvent(
+            .error,
+            "kv budget: every reservation rejected for \(streakSeconds)s — auditing reservation table",
+            [
+                "operation": .string("kv_budget_sustained_rejection"),
+                "streak_seconds": .int(streakSeconds),
+                "reservation_count": .int(reservations.count),
+                "reserved_bytes": .string(String(outstandingReservedBytes())),
+                "mlx_active_bytes": .string(String(snap.active)),
+                "mlx_cache_bytes": .string(String(snap.cache)),
+                "system_available_bytes": .string(String(snap.systemAvailable)),
+                "reservations": .string(table),
+            ])
+
+        let staleIDs = reservations.filter { now - $0.value.createdAt >= staleReservationTTL }
+        guard !staleIDs.isEmpty else { return }
+        for (id, r) in staleIDs {
+            reservations.removeValue(forKey: id)
+            emitAuditEvent(
+                .warn,
+                "kv budget: dropped stale reservation during sustained full-rejection",
+                [
+                    "operation": .string("kv_budget_stale_reservation_dropped"),
+                    "request_id": .string(id),
+                    "reserved_bytes": .string(String(r.bytes)),
+                    "age_seconds": .int(Int((now - r.createdAt).components.seconds)),
+                ])
+        }
+        // Freed headroom — let the next commit start a fresh verdict.
+        rejectionStreakStart = nil
     }
 
     /// Signal the off-actor reclaimer to flush the reclaimable MLX pool for a
@@ -217,7 +347,7 @@ public actor GlobalKVCacheBudget {
             configReserveBytes: configReserveBytes,
             capFraction: capFraction)
         let reserved = reservations.values.reduce(UInt64(0)) { partial, value in
-            let (sum, overflow) = partial.addingReportingOverflow(value)
+            let (sum, overflow) = partial.addingReportingOverflow(value.bytes)
             return overflow ? UInt64.max : sum
         }
         return reservationCap > reserved ? reservationCap - reserved : 0
@@ -239,4 +369,8 @@ public actor GlobalKVCacheBudget {
     /// deterministically (they run the injected `clearCache` synchronously on the
     /// reclaimer actor) instead of racing the fire-and-forget signal tasks.
     var reclaimerForTesting: KVPoolReclaimer { reclaimer }
+
+    /// Current reservation ids, so tests can assert the ledger is empty (or
+    /// holds exactly the expected live entries) after a load/audit sequence.
+    func reservationIDsForTesting() -> [String] { Array(reservations.keys) }
 }

--- a/provider-swift/Sources/ProviderCore/Inference/GlobalKVCacheBudget.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/GlobalKVCacheBudget.swift
@@ -45,7 +45,7 @@ public actor GlobalKVCacheBudget {
     // can't help because the binding term isn't the reclaimable pool. These
     // fields turn that permanent black hole into a bounded blip: when every
     // commit has failed for `sustainedRejectionAuditThreshold` straight, the
-    // budget logs the FULL reservation table at CRITICAL severity and drops
+    // budget logs the FULL reservation table at ERROR severity and drops
     // any reservation older than `staleReservationTTL` with a WARN. Live
     // requests/loads hold their reservations for seconds-to-minutes, so a
     // multi-minute-old reservation during a full-rejection streak is leaked

--- a/provider-swift/Sources/ProviderCore/Inference/GlobalKVCacheBudget.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/GlobalKVCacheBudget.swift
@@ -44,15 +44,22 @@ public actor GlobalKVCacheBudget {
     // while the cache-pool reclaimer — the only self-heal that existed —
     // can't help because the binding term isn't the reclaimable pool. These
     // fields turn that permanent black hole into a bounded blip: when every
-    // commit has failed for `sustainedRejectionAuditThreshold` straight, the
-    // budget logs the FULL reservation table at ERROR severity and drops
-    // any reservation older than `staleReservationTTL` with a WARN. Live
-    // requests/loads hold their reservations for seconds-to-minutes, so a
-    // multi-minute-old reservation during a full-rejection streak is leaked
-    // bookkeeping, not live work.
+    // commit has failed for `sustainedRejectionAuditThreshold` straight —
+    // as one CONTINUOUS streak (gaps between rejections no longer than
+    // `rejectionStreakContinuityWindow`; a wedged box under coordinator
+    // routing rejects far more often than that) — the budget logs the FULL
+    // reservation table at ERROR severity and drops any reservation older
+    // than `staleReservationTTL` with a WARN. Live requests/loads hold
+    // their reservations for seconds-to-minutes, so a multi-minute-old
+    // reservation during a full-rejection streak is leaked bookkeeping,
+    // not live work. The streak resets on any successful commit AND on any
+    // release of a real reservation (either proves the system is making
+    // progress, so live work must never age into the stale-drop).
     private var rejectionStreakStart: ContinuousClock.Instant?
+    private var lastRejectionAt: ContinuousClock.Instant?
     private var lastAuditAt: ContinuousClock.Instant?
     private let sustainedRejectionAuditThreshold: Duration
+    private let rejectionStreakContinuityWindow: Duration
     private let staleReservationTTL: Duration
     private let auditMinInterval: Duration
     private let emitAuditEvent: @Sendable (TelemetrySeverity, String, [String: AnyCodableValue]) -> Void
@@ -61,6 +68,19 @@ public actor GlobalKVCacheBudget {
     /// Well above any transient rejection burst (the coordinator reroutes in
     /// seconds), far below the incident's 40+ minutes of black hole.
     static let defaultSustainedRejectionAuditThreshold: Duration = .seconds(120)
+    /// Maximum gap between two consecutive rejections for them to count as
+    /// ONE sustained streak; a longer gap RESTARTS the streak at the newer
+    /// rejection. Without this, sparse organic traffic (requests minutes
+    /// apart, each rejected) would satisfy the 120 s threshold by wall
+    /// clock alone and the audit could drop reservations backing LIVE
+    /// long-running work — a 32k-token decode at 10 tps holds its
+    /// reservation ~50 min, a slow pending model load can exceed 10 min.
+    /// 30 s: a genuinely black-holed box under coordinator routing sees
+    /// rejections many times per window (routing retries + heartbeat-driven
+    /// traffic are seconds apart), so the real incident shape always
+    /// sustains the streak, while anything sparser is idle-gapped traffic
+    /// the audit must ignore.
+    static let defaultRejectionStreakContinuityWindow: Duration = .seconds(30)
     /// A reservation older than this is considered leaked *during a
     /// sustained full-rejection streak*. Requests hold reservations for the
     /// request duration (worst realistic long decode: minutes); pending-load
@@ -87,6 +107,7 @@ public actor GlobalKVCacheBudget {
         self.activationReserveBytes = activationReserveBytes
         self.configReserveBytes = configReserveBytes
         self.sustainedRejectionAuditThreshold = Self.defaultSustainedRejectionAuditThreshold
+        self.rejectionStreakContinuityWindow = Self.defaultRejectionStreakContinuityWindow
         self.staleReservationTTL = Self.defaultStaleReservationTTL
         self.auditMinInterval = Self.defaultAuditMinInterval
         self.emitAuditEvent = { severity, message, fields in
@@ -122,6 +143,7 @@ public actor GlobalKVCacheBudget {
         selfHealMinInterval: Duration = GlobalKVCacheBudget.defaultSelfHealMinInterval,
         reclaimer: KVPoolReclaimer? = nil,
         sustainedRejectionAuditThreshold: Duration = GlobalKVCacheBudget.defaultSustainedRejectionAuditThreshold,
+        rejectionStreakContinuityWindow: Duration = GlobalKVCacheBudget.defaultRejectionStreakContinuityWindow,
         staleReservationTTL: Duration = GlobalKVCacheBudget.defaultStaleReservationTTL,
         auditMinInterval: Duration = GlobalKVCacheBudget.defaultAuditMinInterval,
         emitAuditEvent: @escaping @Sendable (TelemetrySeverity, String, [String: AnyCodableValue]) -> Void = { _, _, _ in }
@@ -131,6 +153,7 @@ public actor GlobalKVCacheBudget {
         self.configReserveBytes = configReserveBytes
         self.memorySnapshot = memorySnapshot
         self.sustainedRejectionAuditThreshold = sustainedRejectionAuditThreshold
+        self.rejectionStreakContinuityWindow = rejectionStreakContinuityWindow
         self.staleReservationTTL = staleReservationTTL
         self.auditMinInterval = auditMinInterval
         self.emitAuditEvent = emitAuditEvent
@@ -152,7 +175,15 @@ public actor GlobalKVCacheBudget {
     }
 
     public func release(requestID: String) {
-        reservations.removeValue(forKey: requestID)
+        guard reservations.removeValue(forKey: requestID) != nil else { return }
+        // A real reservation just drained — in-flight work is terminating
+        // normally, so this is not the reject-everything black hole the
+        // audit exists for. Reset the streak so a long-lived LIVE
+        // reservation (multi-10-minute decode, slow pending load) can never
+        // age into the audit's stale-drop while the table is demonstrably
+        // making progress. Unknown ids don't count: they prove nothing.
+        rejectionStreakStart = nil
+        lastRejectionAt = nil
     }
 
     /// Reserve an arbitrary BYTE amount against the same live cap headroom KV
@@ -239,6 +270,7 @@ public actor GlobalKVCacheBudget {
         }
         reservations[requestID] = Reservation(bytes: bytes, createdAt: .now)
         rejectionStreakStart = nil
+        lastRejectionAt = nil
         return true
     }
 
@@ -256,8 +288,22 @@ public actor GlobalKVCacheBudget {
     /// bookkeeping, and dropping it converts a permanent reject-everything
     /// wedge into a self-healed blip. Rate-limited to one audit per
     /// `auditMinInterval`.
+    ///
+    /// "Straight" is enforced two ways (both required, or sparse traffic
+    /// could satisfy the threshold by wall clock alone and drop LIVE work):
+    ///   * continuity — a gap since the PREVIOUS rejection longer than
+    ///     `rejectionStreakContinuityWindow` restarts the streak here;
+    ///   * progress — a successful commit (in `commit`) or a real release
+    ///     (in `release`) resets the streak entirely.
     private func recordCommitRejection() {
         let now = ContinuousClock.now
+        if let previous = lastRejectionAt, now - previous > rejectionStreakContinuityWindow {
+            // Idle gap: two rejections minutes apart are sparse traffic, not
+            // a black hole — a genuinely wedged box under coordinator
+            // routing rejects many times per continuity window.
+            rejectionStreakStart = nil
+        }
+        lastRejectionAt = now
         if rejectionStreakStart == nil {
             rejectionStreakStart = now
             return

--- a/provider-swift/Sources/ProviderCore/ProviderCore.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderCore.swift
@@ -84,5 +84,16 @@ public enum ProviderCore {
     // through v2; image/video requests keep the legacy VLM path. No protocol
     // change — capability is behavioral, gated by the existing engine_v2
     // allowlist + flag.
-    public static let version = "0.7.2"
+    // 0.7.3 fixes the v0.7.2 black-hole incident: the VLM text extraction's
+    // two module trees each lazily built their own multi-GiB SwitchGLU fused
+    // gate+up expert cache at the load-time parity probe (~15 GiB × 2 on
+    // gemma-4-26b-8bit), pushing 64 GB (8-bit) and 36 GB (qat-4bit) boxes
+    // past the 90% unified-memory cap so the shared KV gate rejected every
+    // request forever. The trees now share ONE fused cache
+    // (SwitchGLU.shareFusedGateUpCache); the load path re-checks serveable
+    // KV headroom AFTER the engine build and unloads instead of advertising
+    // a dead model; and GlobalKVCacheBudget audits + drops stale
+    // reservations under sustained full-rejection (defense in depth). No
+    // protocol changes.
+    public static let version = "0.7.3"
 }

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+Capacity.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+Capacity.swift
@@ -73,8 +73,18 @@ extension ProviderLoop {
             var totalResidentWeightBytes: UInt64 = 0
             for (_, slot) in modelSlots {
                 let weights = await slot.scheduler.modelWeightBytes
+                // Engine-retained residency overhead (the shared MoE fused
+                // gate+up cache a VLM extraction built) counts like weights:
+                // module-retained active memory that `modelWeightBytes`
+                // cannot see. Omitting it would let the live budget clamp
+                // recompute OTHER bridges' budgets against a rosier resident
+                // set than the shared KV gate actually observes.
+                var slotResident = UInt64(max(0, weights))
+                let (withOverhead, overheadOverflow) = slotResident
+                    .addingReportingOverflow(slot.engineResidentOverheadBytes)
+                slotResident = overheadOverflow ? .max : withOverhead
                 let (sum, overflow) = totalResidentWeightBytes
-                    .addingReportingOverflow(UInt64(max(0, weights)))
+                    .addingReportingOverflow(slotResident)
                 totalResidentWeightBytes = overflow ? .max : sum
             }
             let engineV2 = await engineV2Runtime.capacitySummary(

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+EngineV2.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+EngineV2.swift
@@ -142,8 +142,18 @@ extension ProviderLoop {
         var existingEngineKVCapacities: [Int] = []
         for (slotModelId, slot) in modelSlots where slotModelId != modelId {
             let slotWeights = await slot.scheduler.modelWeightBytes
+            // Count the slot's engine-retained residency overhead (the
+            // shared MoE fused gate+up cache a VLM extraction eagerly
+            // built) like weights: it is module-retained ACTIVE memory that
+            // `modelWeightBytes` (a parameters() sum) does not see, so
+            // omitting it would size THIS engine's ceiling against memory
+            // that co-resident slot is already holding.
+            var slotResident = UInt64(max(0, slotWeights))
+            let (withOverhead, overheadOverflow) = slotResident
+                .addingReportingOverflow(slot.engineResidentOverheadBytes)
+            slotResident = overheadOverflow ? .max : withOverhead
             let (sum, overflow) = coResidentWeightBytes
-                .addingReportingOverflow(UInt64(max(0, slotWeights)))
+                .addingReportingOverflow(slotResident)
             coResidentWeightBytes = overflow ? .max : sum
             if let existingBridge = slot.engineV2 {
                 existingEngineKVCapacities.append(
@@ -205,18 +215,41 @@ extension ProviderLoop {
                 // build the engine on that; any extraction/verify/parity
                 // failure throws into the factory's engine_v2_fallback WARN.
                 let servingModel: any LanguageModel
+                var grantedKVBytesCapacity = kvBytesCapacity
                 if isVLM {
                     guard let loadedModelDirectory else {
                         throw EngineV2VLMTextExtractionError.missingModelDirectory
                     }
                     let extraction = try EngineV2VLMTextExtraction.extractTextModel(
                         from: snapshot.model, modelDirectory: loadedModelDirectory)
+                    // PR#508 finding 2: `kvBytesCapacity` was derived from
+                    // WEIGHTS before this extraction materialized the shared
+                    // MoE fused gate+up cache (~8–15 GiB on Gemma 4) —
+                    // module-retained active memory the shared KV gate sees
+                    // in live MLX usage but the static derivation did not.
+                    // Net the MEASURED cache out of the engine's admission
+                    // ceiling so the heartbeat max (derived from the
+                    // engine's grant), the engine's private ledger, and the
+                    // shared gate agree; an unadjusted ceiling over-routes
+                    // by exactly the cache size (~1.7× on the incident's
+                    // 64 GB profile) and replays a mild v0.7.2. A 0 result
+                    // throws noKVHeadroom below → legacy fallback.
+                    grantedKVBytesCapacity = EngineV2KVSizing.netOfEngineResidentOverhead(
+                        kvBytesCapacity, overheadBytes: extraction.fusedMoECacheBytes)
                     if let parityDiff = extraction.parityMaxAbsLogitDiff {
+                        let fusedGiB = String(
+                            format: "%.2f",
+                            Double(extraction.fusedMoECacheBytes) / (1024 * 1024 * 1024))
+                        let grantedGiB = String(
+                            format: "%.2f",
+                            Double(grantedKVBytesCapacity) / (1024 * 1024 * 1024))
                         slotLogger.info(
                             "engine_v2: \(modelId) VLM text-model extraction passed the "
                                 + "load-time forward parity gate (max |Δlogit| \(parityDiff), "
                                 + "fused MoE gate+up cache shared across "
-                                + "\(extraction.sharedFusedMoELayerCount) layer(s))")
+                                + "\(extraction.sharedFusedMoELayerCount) layer(s), "
+                                + "\(fusedGiB) GiB netted out of the KV ceiling → "
+                                + "\(grantedGiB) GiB)")
                     }
                     servingModel = extraction.model
                 } else {
@@ -225,7 +258,7 @@ extension ProviderLoop {
                 return try EngineV2Factory.makeProductionEngine(
                     model: servingModel,
                     tokenizer: tokenizer.inner,
-                    kvBytesCapacity: kvBytesCapacity)
+                    kvBytesCapacity: grantedKVBytesCapacity)
             }
         }
 

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+EngineV2.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+EngineV2.swift
@@ -214,7 +214,9 @@ extension ProviderLoop {
                     if let parityDiff = extraction.parityMaxAbsLogitDiff {
                         slotLogger.info(
                             "engine_v2: \(modelId) VLM text-model extraction passed the "
-                                + "load-time forward parity gate (max |Δlogit| \(parityDiff))")
+                                + "load-time forward parity gate (max |Δlogit| \(parityDiff), "
+                                + "fused MoE gate+up cache shared across "
+                                + "\(extraction.sharedFusedMoELayerCount) layer(s))")
                     }
                     servingModel = extraction.model
                 } else {

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+ModelLoading.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+ModelLoading.swift
@@ -355,7 +355,20 @@ extension ProviderLoop {
             // legacy (nil bridge) has still grown resident memory. Trim the
             // pool first, mirroring the post-load check. (unregister/shutdown
             // are safe no-ops on the nil-bridge path.)
+            var engineResidentOverheadBytes: UInt64 = 0
             if engineV2Bridge != nil || slotIsVLM {
+                // Measure the engine build's retained residency overhead —
+                // the shared MoE fused gate+up cache the VLM extraction
+                // eagerly builds (resident even when the bridge then FAILED,
+                // e.g. a parity mismatch after the cache build). Recorded on
+                // the slot so later v2 engine ceilings and the heartbeat
+                // fleet-budget clamp count it like resident weights
+                // (`modelWeightBytes` is a parameters() sum and cannot see
+                // it). The wrapper tree carries the shared arrays on every
+                // path, so scanning the loaded model is sufficient.
+                engineResidentOverheadBytes = await container.perform { ctx in
+                    UInt64(max(0, EngineV2VLMTextExtraction.fusedMoECacheBytes(of: [ctx.model])))
+                }
                 MLX.Memory.clearCache()
                 if !(await scheduler.hasServeableKVHeadroom()) {
                     let headroomGb = String(
@@ -379,6 +392,7 @@ extension ProviderLoop {
                 tokenizer: tokenizer,
                 isVLM: slotIsVLM,
                 modelType: modelInfo.modelType,
+                engineResidentOverheadBytes: engineResidentOverheadBytes,
                 lastInferenceAt: .now
             )
 

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+ModelLoading.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+ModelLoading.swift
@@ -343,15 +343,19 @@ extension ProviderLoop {
 
             // Post-BRIDGE measured-headroom guard (v0.7.3): the engine build
             // can retain additional load-time memory beyond the weights the
-            // check above measured — the VLM extraction's parity probe
-            // materializes the (shared) MoE fused gate+up cache, ~15 GiB on
-            // gemma-4-26b-8bit. Re-measure AFTER the bridge so a box whose
-            // full load-time footprint leaves no serveable KV unloads and
-            // 503s (coordinator reroutes, telemetry fires) instead of
-            // advertising a model whose every request the shared KV gate
-            // rejects — the v0.7.2 black-hole failure shape. Trim the pool
-            // first, mirroring the post-load check.
-            if engineV2Bridge != nil {
+            // check above measured — the VLM extraction eagerly builds the
+            // (shared) MoE fused gate+up cache, ~15 GiB on gemma-4-26b-8bit.
+            // Re-measure AFTER the bridge so a box whose full load-time
+            // footprint leaves no serveable KV unloads and 503s (coordinator
+            // reroutes, telemetry fires) instead of advertising a model whose
+            // every request the shared KV gate rejects — the v0.7.2
+            // black-hole failure shape. Runs for ANY VLM slot, not just when
+            // the bridge built: the extraction builds the fused cache BEFORE
+            // its parity gate, so a parity/init failure that fell back to
+            // legacy (nil bridge) has still grown resident memory. Trim the
+            // pool first, mirroring the post-load check. (unregister/shutdown
+            // are safe no-ops on the nil-bridge path.)
+            if engineV2Bridge != nil || slotIsVLM {
                 MLX.Memory.clearCache()
                 if !(await scheduler.hasServeableKVHeadroom()) {
                     let headroomGb = String(

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+ModelLoading.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+ModelLoading.swift
@@ -341,6 +341,33 @@ extension ProviderLoop {
                 scheduler: scheduler
             )
 
+            // Post-BRIDGE measured-headroom guard (v0.7.3): the engine build
+            // can retain additional load-time memory beyond the weights the
+            // check above measured — the VLM extraction's parity probe
+            // materializes the (shared) MoE fused gate+up cache, ~15 GiB on
+            // gemma-4-26b-8bit. Re-measure AFTER the bridge so a box whose
+            // full load-time footprint leaves no serveable KV unloads and
+            // 503s (coordinator reroutes, telemetry fires) instead of
+            // advertising a model whose every request the shared KV gate
+            // rejects — the v0.7.2 black-hole failure shape. Trim the pool
+            // first, mirroring the post-load check.
+            if engineV2Bridge != nil {
+                MLX.Memory.clearCache()
+                if !(await scheduler.hasServeableKVHeadroom()) {
+                    let headroomGb = String(
+                        format: "%.1f",
+                        Double(await scheduler.measuredLiveKVHeadroomBytes) / (1024.0 * 1024.0 * 1024.0))
+                    await engineV2Runtime.unregister(modelId: modelId)
+                    await engineV2Bridge?.shutdown()
+                    await scheduler.unloadModel()
+                    MLX.Memory.clearCache()
+                    let message = "Model '\(modelId)' loaded but its engine build left insufficient "
+                        + "KV headroom under the memory cap (\(headroomGb) GB free) — unloaded"
+                    recordModelLoadError(model: modelId, message: message)
+                    throw InferenceError.modelLoadFailed(message)
+                }
+            }
+
             modelSlots[modelId] = ModelSlot(
                 scheduler: scheduler,
                 engineV2: engineV2Bridge,

--- a/provider-swift/Sources/ProviderCore/ProviderLoop.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop.swift
@@ -548,6 +548,16 @@ public actor ProviderLoop {
         /// drop window while the slot is still resident (a Gemma build would
         /// otherwise fall back to the qwen3 parser and leak <think> tokens).
         let modelType: String?
+        /// MEASURED engine-retained residency overhead beyond the weights —
+        /// the shared MoE fused gate+up cache the VLM text extraction
+        /// eagerly builds (~8–15 GiB on Gemma 4; PR#508 finding 2). Plain
+        /// module properties, so it appears in neither
+        /// `scheduler.modelWeightBytes` (a parameters() sum) nor any
+        /// pending-load estimate; the sizing paths that treat weights as
+        /// resident memory (later v2 engine ceilings, the heartbeat fleet
+        /// budget clamp) must add this alongside them. 0 for non-VLM slots
+        /// and dense checkpoints.
+        var engineResidentOverheadBytes: UInt64 = 0
         var lastInferenceAt: ContinuousClock.Instant
     }
 

--- a/provider-swift/Sources/ProviderCore/Telemetry/TelemetryEvent.swift
+++ b/provider-swift/Sources/ProviderCore/Telemetry/TelemetryEvent.swift
@@ -256,6 +256,12 @@ public enum TelemetryFieldFilter {
         "prefill_samples_accepted", "prefill_samples_dropped_floor",
         "prefill_samples_dropped_ceiling", "last_prefill_sample_tps",
         "observed_prefill_tps_ewma",
+        // KV-budget sustained-rejection audit (v0.7.3 black-hole hardening):
+        // reservation ids/byte counts/ages + memory snapshot terms — pure
+        // operational bookkeeping, no prompt/response data. Mirror in Go + TS.
+        "streak_seconds", "reservation_count", "reserved_bytes",
+        "mlx_cache_bytes", "system_available_bytes", "reservations",
+        "request_id", "age_seconds",
     ]
 
     /// Filter a dictionary to only the keys the coordinator accepts.

--- a/provider-swift/Tests/ProviderCoreTests/EngineV2FusedCacheCapacityTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/EngineV2FusedCacheCapacityTests.swift
@@ -1,0 +1,234 @@
+// Copyright © 2026 Eigen Labs.
+//
+// PR#508 finding 2 — the v2 engine's static KV admission ceiling (which
+// becomes heartbeat `active_token_budget_max`, the coordinator's admission
+// input) is derived from WEIGHTS before the VLM text extraction materializes
+// the shared MoE fused gate+up cache (~8–15 GiB on Gemma 4). Post-fix the
+// slot factory nets the MEASURED cache out of the ceiling
+// (`EngineV2KVSizing.netOfEngineResidentOverhead`) and the residency sums
+// (later engine sizings, heartbeat fleet clamp) count it like weights, so
+// heartbeat max, engine admission, and the shared KV gate agree.
+//
+// These tests pin that consistency on the incident's simulated 64 GB
+// profile (26 GiB weights + 15 GiB fused cache — the gemma-4-26b-8bit
+// shape) at scripted-stub level: no model weights, no network. The live
+// counterpart (real checkpoint, real extraction) is
+// `GemmaVLMParityProbeMemoryLiveTests`.
+
+import Foundation
+import MLXLMCommon
+import MLXNN
+import Testing
+
+@testable import ProviderCore
+
+private let gib: UInt64 = 1024 * 1024 * 1024
+
+// MARK: - Stubs
+
+/// Engine stub reporting a fixed construction grant — what the bridge's
+/// heartbeat path reads back through `capacity().kvBytesCapacity`.
+private final class FixedCapacityEngine: CBv2Engine, @unchecked Sendable {
+    let kvBytesCapacity: Int
+    init(kvBytesCapacity: Int) { self.kvBytesCapacity = kvBytesCapacity }
+
+    func submit(_ request: CBv2Request) throws -> AsyncStream<CBv2Event> {
+        let (stream, continuation) = AsyncStream<CBv2Event>.makeStream()
+        continuation.finish()
+        return stream
+    }
+    func cancel(_ id: CBv2RequestID) {}
+    func capacity() -> CBv2CapacitySnapshot {
+        CBv2CapacitySnapshot(
+            activeRequests: 0, waitingRequests: 0, kvBytesInUse: 0,
+            kvBytesCapacity: kvBytesCapacity, activeTokens: 0)
+    }
+    func shutdown() async {}
+}
+
+private struct NoopTokenizer: MLXLMCommon.Tokenizer {
+    func encode(text: String, addSpecialTokens: Bool) -> [Int] { [] }
+    func decode(tokenIds: [Int], skipSpecialTokens: Bool) -> String { "" }
+    func convertTokenToId(_ token: String) -> Int? { nil }
+    func convertIdToToken(_ id: Int) -> String? { nil }
+    var bosToken: String? { nil }
+    var eosToken: String? { nil }
+    var unknownToken: String? { nil }
+    func applyChatTemplate(
+        messages: [[String: any Sendable]],
+        tools: [[String: any Sendable]]?,
+        additionalContext: [String: any Sendable]?
+    ) throws -> [Int] { [] }
+}
+
+@Suite("EngineV2 fused-cache capacity accounting (PR#508 finding 2)")
+struct EngineV2FusedCacheCapacityTests {
+
+    // The incident profile: 64 GB box, gemma-4-26b-8bit (26 GiB weights,
+    // 15 GiB measured fused cache), fp16 KV rate 20 480 B/token.
+    private static let physical = 64 * gib
+    private static let weights = Int(26 * gib)
+    private static let fused = Int(15 * gib)
+    private static let kvBytesPerToken = 20_480
+
+    @Test("netOfEngineResidentOverhead: identity at 0, subtraction, clamps")
+    func netOfOverheadArithmetic() {
+        #expect(EngineV2KVSizing.netOfEngineResidentOverhead(100, overheadBytes: 0) == 100)
+        #expect(EngineV2KVSizing.netOfEngineResidentOverhead(100, overheadBytes: 40) == 60)
+        // The cache consumed the whole budget → 0 → makeProductionEngine
+        // throws noKVHeadroom → legacy fallback (never a negative ceiling).
+        #expect(EngineV2KVSizing.netOfEngineResidentOverhead(100, overheadBytes: 100) == 0)
+        #expect(EngineV2KVSizing.netOfEngineResidentOverhead(100, overheadBytes: 250) == 0)
+        // Defensive inputs.
+        #expect(EngineV2KVSizing.netOfEngineResidentOverhead(-5, overheadBytes: 10) == 0)
+        #expect(EngineV2KVSizing.netOfEngineResidentOverhead(100, overheadBytes: -10) == 100)
+    }
+
+    @Test("advertised token max reflects post-cache headroom on the 64 GB profile")
+    func advertisedTokenMaxReflectsPostCacheHeadroom() async {
+        let base = EngineV2KVSizing.engineKVBytesCapacity(
+            newModelWeightBytes: Self.weights, coResidentWeightBytes: 0,
+            existingEngineKVCapacities: [], physicalBytes: Self.physical)
+        let granted = EngineV2KVSizing.netOfEngineResidentOverhead(
+            base, overheadBytes: Self.fused)
+
+        // The grant is the weights-derived budget minus EXACTLY the cache —
+        // the pre-fix over-advertise was the cache size, byte for byte.
+        #expect(
+            UInt64(granted)
+                == UnifiedMemoryCap.kvBudgetBytes(
+                    physicalBytes: Self.physical, residentWeightBytes: UInt64(Self.weights))
+                    - UInt64(Self.fused))
+        #expect(base - granted == Self.fused)
+
+        // Heartbeat: the fleet clamp recomputed from OVERHEAD-INCLUSIVE
+        // residency (weights + fused — what ProviderLoop+Capacity now sums)
+        // equals the adjusted grant, so the reported budget is neither
+        // inflated back to the stale weights-only figure nor double-shrunk.
+        let clamp = EngineV2KVSizing.liveEngineKVBytesBudget(
+            grantedKVBytesCapacity: granted,
+            totalResidentWeightBytes: UInt64(Self.weights + Self.fused),
+            otherEngineKVCapacities: [],
+            physicalBytes: Self.physical)
+        #expect(clamp == granted)
+
+        // …and the wire figure a coordinator admission gate consumes.
+        let bridge = EngineV2Bridge(
+            engine: FixedCapacityEngine(kvBytesCapacity: granted),
+            modelId: "gemma-4-26b-8bit",
+            tokenizer: TokenizerHandle(NoopTokenizer()),
+            eosTokenIds: [2],
+            extraEOSTokens: [],
+            defaultMaxTokens: 4096,
+            maxConcurrentRequests: 4,
+            kvBytesPerToken: Self.kvBytesPerToken,
+            kvBudget: nil,
+            emitTelemetry: { _ in })
+        let slot = await bridge.backendSlotCapacity(kvBytesBudgetClamp: clamp)
+        #expect(slot.activeTokenBudgetMax == Int64(granted / Self.kvBytesPerToken))
+        // Regression: the pre-fix advertised max (weights-only ceiling).
+        #expect(slot.activeTokenBudgetMax < Int64(base / Self.kvBytesPerToken))
+    }
+
+    @Test("a request stream sized to the advertised max is admitted by the shared gate")
+    func sharedGateAdmitsStreamSizedToAdvertisedMax() async {
+        let base = EngineV2KVSizing.engineKVBytesCapacity(
+            newModelWeightBytes: Self.weights, coResidentWeightBytes: 0,
+            existingEngineKVCapacities: [], physicalBytes: Self.physical)
+        let granted = EngineV2KVSizing.netOfEngineResidentOverhead(
+            base, overheadBytes: Self.fused)
+        let advertisedTokens = granted / Self.kvBytesPerToken
+
+        // The shared gate views the REAL post-load memory state: weights +
+        // ONE fused cache resident in MLX active. capFraction/activation
+        // reserve stay nil so the gate resolves the SAME defaults the static
+        // sizing above used — the consistency under test.
+        let budget = GlobalKVCacheBudget(
+            memorySnapshot: {
+                GlobalKVCacheBudget.MemorySnapshot(
+                    total: Self.physical,
+                    active: UInt64(Self.weights + Self.fused),
+                    cache: 0,
+                    systemAvailable: .max)
+            })
+
+        // Four concurrent requests summing to the advertised max: every one
+        // admitted, no rejects — the coordinator routing to the advertised
+        // budget never trips the gate.
+        for i in 0 ..< 4 {
+            #expect(
+                await budget.reserve(
+                    requestID: "advertised-\(i)",
+                    kvBytesPerToken: Self.kvBytesPerToken,
+                    tokenCount: advertisedTokens / 4),
+                "request \(i) of an advertised-max stream was rejected by the shared gate")
+        }
+
+        // Regression: the PRE-FIX advertised budget (weights-only) exceeds
+        // the gate's headroom by the cache size — the excess the coordinator
+        // used to over-route is exactly what the gate rejects.
+        #expect(
+            !(await budget.reserveBytes(
+                requestID: "prefix-excess", bytes: UInt64(base - granted))))
+    }
+
+    @Test("a later engine's ceiling counts the first slot's fused cache like weights")
+    func laterEngineSizingCountsFusedOverhead() {
+        let physical = 64 * gib
+        let wA = Int(8 * gib)
+        let fA = Int(4 * gib)
+        let wB = Int(8 * gib)
+        // First engine granted under a tighter construction view (mirrors
+        // `pureSizingSumsWithinBudget`), then netted of its fused cache.
+        let grantA = EngineV2KVSizing.netOfEngineResidentOverhead(
+            Int(10 * gib), overheadBytes: fA)  // 6 GiB
+        // Second engine: co-resident residency now includes slot A's fused
+        // cache (what the slot factory sums post-fix).
+        let capB = EngineV2KVSizing.engineKVBytesCapacity(
+            newModelWeightBytes: wB,
+            coResidentWeightBytes: UInt64(wA + fA),
+            existingEngineKVCapacities: [grantA],
+            physicalBytes: physical)
+        #expect(capB > 0)
+        // Σ(grants) lands exactly ON the fleet budget over the TRUE resident
+        // set (weights + cache) — the process-wide invariant.
+        #expect(
+            UInt64(grantA + capB)
+                == UnifiedMemoryCap.kvBudgetBytes(
+                    physicalBytes: physical,
+                    residentWeightBytes: UInt64(wA + fA + wB)))
+        // Regression: ignoring the overhead (pre-fix residency sum) would
+        // over-grant the second engine by exactly the cache size.
+        let naiveB = EngineV2KVSizing.engineKVBytesCapacity(
+            newModelWeightBytes: wB,
+            coResidentWeightBytes: UInt64(wA),
+            existingEngineKVCapacities: [grantA],
+            physicalBytes: physical)
+        #expect(naiveB - capB == fA)
+    }
+
+    @Test("fusedMoECacheBytes counts a shared cache once and unbuilt caches as zero")
+    func fusedCacheMeasurementDedupesSharedArrays() {
+        // Two tiny REAL quantized SwitchGLUs over independent weights —
+        // the same module type the Gemma 4 MoE layers use — then share one
+        // fused cache exactly as the extraction does.
+        let a = SwitchGLU(inputDims: 64, hiddenDims: 64, numExperts: 2)
+        let b = SwitchGLU(inputDims: 64, hiddenDims: 64, numExperts: 2)
+        quantize(model: a, groupSize: 32, bits: 4)
+        quantize(model: b, groupSize: 32, bits: 4)
+
+        // Nothing built yet → zero overhead (a non-VLM slot at load time).
+        #expect(EngineV2VLMTextExtraction.fusedMoECacheBytes(of: [a, b]) == 0)
+
+        #expect(a.shareFusedGateUpCache(with: b))
+        let cacheBytes = a.fusedGateUpCacheBytes
+        #expect(cacheBytes > 0)
+        #expect(b.fusedGateUpCacheBytes == cacheBytes)
+
+        // Each tree alone reports the cache; BOTH trees together still count
+        // it ONCE — dedup by array identity, the sharing contract.
+        #expect(EngineV2VLMTextExtraction.fusedMoECacheBytes(of: [a]) == cacheBytes)
+        #expect(EngineV2VLMTextExtraction.fusedMoECacheBytes(of: [b]) == cacheBytes)
+        #expect(EngineV2VLMTextExtraction.fusedMoECacheBytes(of: [a, b]) == cacheBytes)
+    }
+}

--- a/provider-swift/Tests/ProviderCoreTests/GemmaVLMEngineV2LiveTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/GemmaVLMEngineV2LiveTests.swift
@@ -119,16 +119,38 @@ struct GemmaVLMEngineV2LiveTests {
         )
     }
 
+    /// Load a VLM slot, run `body`, and AWAIT the scheduler unload on every
+    /// exit path (success or throw). A `defer { Task { … } }` teardown is
+    /// unstructured — the test returns while the multi-GB unload (and its
+    /// `clearCache`) races the NEXT test's load, which can double-resident
+    /// two checkpoints and OOM the suite. Structured teardown serializes it.
+    private func withLoadedVLMSlot(
+        modelID: String, budgetBytes: Int,
+        _ body: (LoadedVLMSlot) async throws -> Void
+    ) async throws {
+        let slot = try await loadVLMSlot(modelID: modelID, budgetBytes: budgetBytes)
+        do {
+            try await body(slot)
+        } catch {
+            await slot.scheduler.unloadModel()
+            throw error
+        }
+        await slot.scheduler.unloadModel()
+    }
+
     /// Stage (a): weight-sharing extraction + the load-time parity gate.
     ///
-    /// Two concerns, measured separately:
+    /// Three concerns, measured separately:
     ///   * WEIGHT-SHARING — extract with the parity gate OFF and require MLX
-    ///     active memory to grow by ~nothing (skeleton construction is lazy;
-    ///     `update(parameters:)` re-points at the wrapper's arrays). A second
-    ///     weight COPY would show up as ≥ the model size (~14 GiB qat-4bit).
-    ///     The parity gate is excluded here because its two forward passes
-    ///     materialize several GiB of transient activation buffers that MLX
-    ///     retains until `clearCache` — real, but not a weight copy.
+    ///     active memory to grow by no more than the (single, shared) MoE
+    ///     fused gate+up cache plus tolerance. Skeleton construction is lazy;
+    ///     `update(parameters:)` re-points at the wrapper's arrays; the only
+    ///     legitimate load-time materialization is the ONE fused cache the
+    ///     extraction eagerly builds and shares wrapper↔extracted (v0.7.3).
+    ///     A second weight copy would show up as ≥ the model size.
+    ///   * FUSED-CACHE SHARING (the v0.7.2 64 GB black-hole regression) —
+    ///     every extracted SwitchGLU must hold the SAME fused arrays as its
+    ///     wrapper counterpart, not a private second concatenation.
     ///   * PARITY GATE — extract again with the gate ON (production default)
     ///     and require it to pass and report a bounded max |Δlogit|. Both
     ///     extractions share the same wrapper arrays, so this is not a second
@@ -143,12 +165,44 @@ struct GemmaVLMEngineV2LiveTests {
             from: slot.model, modelDirectory: slot.directory,
             environment: ["DARKBLOOM_ENGINE_V2_VLM_PARITY_CHECK": "0"])
         #expect(noParity.parityMaxAbsLogitDiff == nil)
+        // The one legitimate materialization: the shared fused MoE cache.
+        let fusedBytes = slot.model.namedModules()
+            .compactMap { ($0.1 as? SwitchGLU)?.fusedGateUpCacheBytes }
+            .reduce(0, +)
         let growth = max(0, MLX.GPU.activeMemory - activeBefore)
+        let allowance = fusedBytes + 1_536 * 1024 * 1024
         #expect(
-            growth < 1_536 * 1024 * 1024,
+            growth < allowance,
             Comment(
                 rawValue: "extraction grew MLX active memory by \(growth) bytes "
-                    + "(> 1.5 GiB) — weights were copied instead of shared"))
+                    + "(> shared fused cache \(fusedBytes) + 1.5 GiB) — weights or the "
+                    + "fused MoE cache were duplicated instead of shared"))
+
+        // v0.7.2 black-hole regression: the extracted tree must ADOPT the
+        // wrapper's fused gate+up cache, never build its own copy.
+        #expect(
+            noParity.sharedFusedMoELayerCount > 0,
+            "MoE checkpoint extracted with zero shared fused-cache layers")
+        var extractedGLUs: [String: SwitchGLU] = [:]
+        for (path, module) in noParity.model.namedModules() {
+            if let glu = module as? SwitchGLU { extractedGLUs[path] = glu }
+        }
+        var verifiedPairs = 0
+        for (path, module) in slot.model.namedModules() {
+            guard let wrapperGLU = module as? SwitchGLU,
+                path.hasPrefix("language_model."),
+                let extractedGLU = extractedGLUs[String(path.dropFirst("language_model.".count))]
+            else { continue }
+            #expect(
+                wrapperGLU.fusedGateUpWeightForVerification != nil
+                    && wrapperGLU.fusedGateUpWeightForVerification
+                        === extractedGLU.fusedGateUpWeightForVerification,
+                Comment(
+                    rawValue: "fused gate+up cache not shared at \(path) — the extracted "
+                        + "tree built (or will lazily build) its own multi-GiB copy"))
+            verifiedPairs += 1
+        }
+        #expect(verifiedPairs == noParity.sharedFusedMoELayerCount)
 
         // Parity gate (production default env). Returns the model stages
         // (b)/(c) run on.
@@ -156,7 +210,10 @@ struct GemmaVLMEngineV2LiveTests {
             from: slot.model, modelDirectory: slot.directory)
         let diff = try #require(
             extraction.parityMaxAbsLogitDiff, "parity gate did not run under the default env")
-        print("[gemma-vlm-v2] \(slot.modelID) parity max |Δlogit| = \(diff), weight-share growth = \(growth) bytes")
+        print(
+            "[gemma-vlm-v2] \(slot.modelID) parity max |Δlogit| = \(diff), "
+                + "weight-share growth = \(growth) bytes, shared fused cache = \(fusedBytes) bytes "
+                + "across \(extraction.sharedFusedMoELayerCount) layer(s)")
         return extraction
     }
 
@@ -282,11 +339,14 @@ struct GemmaVLMEngineV2LiveTests {
         .enabled(if: LiveInferenceFixtures.gemmaTestsEnabled)
     )
     func qat4bitFullPipeline() async throws {
-        let slot = try await loadVLMSlot(
-            modelID: Self.qat4bitModelID, budgetBytes: 48 * 1024 * 1024 * 1024)
-        let scheduler = slot.scheduler
-        defer { Task { await scheduler.unloadModel() } }
+        try await withLoadedVLMSlot(
+            modelID: Self.qat4bitModelID, budgetBytes: 48 * 1024 * 1024 * 1024
+        ) { slot in
+            try await runQat4bitFullPipeline(slot)
+        }
+    }
 
+    private func runQat4bitFullPipeline(_ slot: LoadedVLMSlot) async throws {
         // (a) extraction + load-time parity gate + weight-sharing invariant.
         let extraction = try runExtractionStage(slot)
 
@@ -362,11 +422,14 @@ struct GemmaVLMEngineV2LiveTests {
         .enabled(if: LiveInferenceFixtures.gemmaTestsEnabled)
     )
     func eightBitExtractionAndGreedyParity() async throws {
-        let slot = try await loadVLMSlot(
-            modelID: Self.eightBitModelID, budgetBytes: 64 * 1024 * 1024 * 1024)
-        let scheduler = slot.scheduler
-        defer { Task { await scheduler.unloadModel() } }
+        try await withLoadedVLMSlot(
+            modelID: Self.eightBitModelID, budgetBytes: 64 * 1024 * 1024 * 1024
+        ) { slot in
+            try await runEightBitExtractionAndGreedyParity(slot)
+        }
+    }
 
+    private func runEightBitExtractionAndGreedyParity(_ slot: LoadedVLMSlot) async throws {
         let extraction = try runExtractionStage(slot)
 
         let prompt = OpenAIMessageContent.text(

--- a/provider-swift/Tests/ProviderCoreTests/GemmaVLMParityProbeMemoryLiveTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/GemmaVLMParityProbeMemoryLiveTests.swift
@@ -1,0 +1,238 @@
+// Copyright © 2026 Eigen Labs.
+//
+// Live (weight-gated) regression for the v0.7.2 black-hole incident
+// (7×64 GB gemma-4-26b-8bit + 1×36 GB qat-4bit boxes rejecting 100% of
+// requests with the shared-KV capacity string from their first request,
+// permanently).
+//
+// ROOT CAUSE (measured on the real 8-bit checkpoint, 2026-07-03):
+// `MLXLMCommon.SwitchGLU` lazily concatenates a fused gate+up copy of its
+// quantized expert weights on FIRST FORWARD and retains it on the module
+// (~540 MB per MoE layer, ~15 GiB model-wide on gemma-4-26b-8bit). The
+// v0.7.2 VLM text extraction created a SECOND SwitchGLU tree over the same
+// weights, and the load-time parity probe ran one forward through EACH tree
+// — materializing TWO ~15 GiB fused copies before the first request:
+//
+//     26.04 GiB (weights) + 15.06 (wrapper fused) + 15.07 (extracted fused)
+//     = 56.17 GiB active  vs  57.6 GiB cap (0.9 × 64 GB)
+//
+// → `UnifiedMemoryCap.liveKVHeadroomBytes` ≈ 0 forever. MLX `clearCache`
+// cannot reclaim module-retained ACTIVE memory, so the KVPoolReclaimer
+// self-heal never helped, while the engine's own ledger stayed idle — the
+// two-ledgers-disagree signature. Deterministic on any box where
+// weights + 2×fusedCache crosses the cap (64 GB/8-bit, 36 GB/qat-4bit).
+//
+// THE FIX (v0.7.3): the extraction eagerly builds ONE fused cache and
+// shares it wrapper↔extracted (`SwitchGLU.shareFusedGateUpCache`), so the
+// load-time footprint returns to the pre-v0.7.2 steady state
+// (weights + ONE fused cache — what a 0.7.1 box reached after its first
+// request). This test asserts, on the real checkpoint:
+//
+//   1. GROWTH BOUND — extraction WITH the parity probe (production default)
+//      grows MLX active memory by at most ONE fused cache (+ tolerance),
+//      not two.
+//   2. STEADY STATE AT LOAD — re-running both probe forwards afterwards
+//      grows active memory by ~nothing: no lazy build is waiting to fire
+//      mid-serving.
+//   3. ADMISSION — a `GlobalKVCacheBudget` viewing the post-extraction MLX
+//      state through a simulated 64 GB profile admits a typical worst-case
+//      request reservation (the incident's first-request rejection,
+//      inverted).
+//
+// Gated like the other multi-GB Gemma tests: DARKBLOOM_LIVE_MLX_TESTS +
+// DARKBLOOM_LIVE_MLX_GEMMA; skipped cleanly when no checkpoint is cached.
+
+import Foundation
+import MLX
+import MLXLMCommon
+import MLXNN
+import MLXVLM
+import Testing
+
+@testable import ProviderCore
+
+@Suite("Gemma 4 VLM parity-probe memory hygiene (live)", .serialized)
+struct GemmaVLMParityProbeMemoryLiveTests {
+
+    /// The incident checkpoint (catalog id `gemma-4-26b-8bit`); falls back to
+    /// the qat-4bit build when only that one is cached — the fused-cache
+    /// sharing invariant is checkpoint-independent.
+    private static let preferredModelIDs = [
+        LiveInferenceFixtures.gemmaModelID,
+        "mlx-community/gemma-4-26B-A4B-it-qat-4bit",
+    ]
+
+    private struct LoadedVLMSlot {
+        let modelID: String
+        let directory: URL
+        let container: ModelContainer
+        let scheduler: BatchScheduler
+        let model: any LanguageModel
+    }
+
+    private func loadFirstCachedVLMSlot() async throws -> LoadedVLMSlot {
+        guard LiveInferenceFixtures.ensureMetallibColocated() != nil else {
+            throw LiveFixtureSkip.missingMetallib
+        }
+        var located: (String, URL)? = nil
+        for modelID in Self.preferredModelIDs {
+            if case .found(let directory) = LiveInferenceFixtures.locate(modelID) {
+                located = (modelID, directory)
+                break
+            }
+        }
+        guard let (modelID, directory) = located else {
+            throw LiveFixtureSkip.modelNotInCache(Self.preferredModelIDs[0])
+        }
+        #expect(ProviderLoop.modelIsVLM(at: directory))
+        LiveInferenceFixtures.applyMemoryBudget(maxBytes: 64 * 1024 * 1024 * 1024)
+
+        let container = try await VLMModelFactory.shared.loadContainer(
+            from: directory, using: LocalTokenizerLoader())
+        let scheduler = BatchScheduler(
+            maxConcurrentRequests: 4,
+            pendingTimeout: .seconds(300),
+            defaultMaxTokens: 256
+        )
+        await scheduler.loadModel(container: container, modelId: modelID)
+        let snapshot = await container.perform { ctx in
+            EngineV2ModelSnapshot(
+                model: ctx.model,
+                eosTokenIds: ctx.configuration.eosTokenIds,
+                extraEOSTokens: [])
+        }
+        return LoadedVLMSlot(
+            modelID: modelID,
+            directory: directory,
+            container: container,
+            scheduler: scheduler,
+            model: snapshot.model
+        )
+    }
+
+    private static func gib(_ bytes: Int) -> String {
+        String(format: "%.2f GiB", Double(bytes) / (1024 * 1024 * 1024))
+    }
+
+    @Test(
+        "extraction + parity probe leave the shared KV budget serveable (64 GB profile)",
+        .enabled(if: LiveInferenceFixtures.gemmaTestsEnabled)
+    )
+    func parityProbeMemoryHygieneAndBudgetAdmission() async throws {
+        let slot = try await loadFirstCachedVLMSlot()
+        do {
+            try await runBody(slot)
+        } catch {
+            await slot.scheduler.unloadModel()
+            throw error
+        }
+        await slot.scheduler.unloadModel()
+    }
+
+    private func runBody(_ slot: LoadedVLMSlot) async throws {
+        // Mirror the production sequence: the load path's post-load headroom
+        // check trims the cold-load pool BEFORE the bridge build, so the
+        // pre-extraction baseline starts from a clean pool exactly like prod.
+        MLX.Stream().synchronize()
+        MLX.Memory.clearCache()
+        let activeBefore = MLX.GPU.activeMemory
+        let sysBefore = SystemMemory.availableBytes() ?? 0
+        print(
+            "[parity-mem] pre-extraction: active=\(Self.gib(activeBefore)) "
+                + "cache=\(Self.gib(MLX.GPU.cacheMemory)) sysAvail=\(Self.gib(Int(sysBefore)))")
+
+        // REAL extraction with the parity gate ON (production default env).
+        let extraction = try EngineV2VLMTextExtraction.extractTextModel(
+            from: slot.model, modelDirectory: slot.directory)
+        #expect(extraction.parityMaxAbsLogitDiff != nil)
+        #expect(extraction.sharedFusedMoELayerCount > 0)
+
+        let activeAfter = MLX.GPU.activeMemory
+        let cacheAfter = MLX.GPU.cacheMemory
+        let activeGrowth = max(0, activeAfter - activeBefore)
+        // ONE shared fused MoE cache is the only legitimate retained growth.
+        let fusedBytes = slot.model.namedModules()
+            .compactMap { ($0.1 as? SwitchGLU)?.fusedGateUpCacheBytes }
+            .reduce(0, +)
+        print(
+            "[parity-mem] post-extraction: active=\(Self.gib(activeAfter)) "
+                + "cache=\(Self.gib(cacheAfter)) activeGrowth=\(Self.gib(activeGrowth)) "
+                + "sharedFusedCache=\(Self.gib(fusedBytes)) "
+                + "layers=\(extraction.sharedFusedMoELayerCount)")
+
+        // 1. GROWTH BOUND: at most ONE fused cache (+ 2 GiB tolerance for
+        //    rope tables / compiled-graph constants / probe stragglers).
+        //    Pre-fix, this measured fusedBytes × 2 (30.13 GiB on 8-bit).
+        let tolerance = 2 * 1024 * 1024 * 1024
+        #expect(
+            activeGrowth < fusedBytes + tolerance,
+            Comment(
+                rawValue: "extraction + parity probe retained \(Self.gib(activeGrowth)) "
+                    + "(> one shared fused cache \(Self.gib(fusedBytes)) + 2 GiB) — a second "
+                    + "fused/weight copy is being built (the v0.7.2 black hole)"))
+        //    The pool must also come back trimmed (post-probe clearCache).
+        #expect(
+            cacheAfter < 1 * 1024 * 1024 * 1024,
+            Comment(
+                rawValue: "probe left \(Self.gib(cacheAfter)) in the MLX pool — "
+                    + "the post-probe clearCache is missing"))
+
+        // 2. STEADY STATE AT LOAD: re-running both probe forwards must not
+        //    materialize anything new — no lazy multi-GiB build can be
+        //    waiting to fire on the first real request.
+        guard let wrapper = slot.model as? MLXVLM.Gemma4 else {
+            Issue.record("prod Gemma 4 slot did not load the MLXVLM.Gemma4 wrapper")
+            return
+        }
+        let probeTokens = MLXArray([2, 651, 6134, 1024, 578, 108, 2364].map(Int32.init))
+            .expandedDimensions(axis: 0)
+        eval(wrapper(probeTokens, cache: nil))
+        eval(extraction.model(probeTokens, cache: nil))
+        MLX.Stream().synchronize()
+        MLX.Memory.clearCache()
+        let activeSteady = MLX.GPU.activeMemory
+        let steadyGrowth = max(0, activeSteady - activeAfter)
+        print("[parity-mem] steady-state re-forward growth=\(Self.gib(steadyGrowth))")
+        #expect(
+            steadyGrowth < 512 * 1024 * 1024,
+            Comment(
+                rawValue: "serving forwards after load grew active memory by "
+                    + "\(Self.gib(steadyGrowth)) — a lazy per-tree cache still fires at "
+                    + "request time"))
+
+        // 3. ADMISSION on the incident profile: view the REAL post-extraction
+        //    MLX counters through a synthetic 64 GB box (the incident
+        //    hardware). The budget must admit one typical worst-case request
+        //    (2 KiB prompt + 4096 max tokens at the slot's fp16 KV rate) —
+        //    pre-fix this is exactly the reservation that failed 100% of the
+        //    time from the first request.
+        let fp16Rate = await slot.scheduler.fp16KVBytesPerToken
+        let totalBytes: UInt64 = 64 * 1024 * 1024 * 1024
+        let budget = GlobalKVCacheBudget(
+            memorySnapshot: {
+                let active = UInt64(max(0, MLX.GPU.activeMemory))
+                let cache = UInt64(max(0, MLX.GPU.cacheMemory))
+                let used = active + cache
+                // Simulated OS view of the 64 GB box: whatever the provider
+                // isn't holding, minus a 4 GiB OS/wired allowance.
+                let osAllowance: UInt64 = 4 * 1024 * 1024 * 1024
+                let free = totalBytes > used + osAllowance ? totalBytes - used - osAllowance : 0
+                return .init(
+                    total: totalBytes, active: active, cache: cache, systemAvailable: free)
+            }
+        )
+        let worstCaseTokens = 2048 + 4096
+        let admitted = await budget.reserve(
+            requestID: "incident-probe", kvBytesPerToken: fp16Rate, tokenCount: worstCaseTokens)
+        print(
+            "[parity-mem] 64GB-profile admission: fp16KVBytesPerToken=\(fp16Rate) "
+                + "worstCaseTokens=\(worstCaseTokens) admitted=\(admitted)")
+        #expect(
+            admitted,
+            Comment(
+                rawValue: "the shared KV budget rejected a typical request on the simulated "
+                    + "64 GB profile after the parity probe — the v0.7.2 black-hole signature"))
+        await budget.release(requestID: "incident-probe")
+        #expect(await budget.reservationIDsForTesting().isEmpty)
+    }
+}

--- a/provider-swift/Tests/ProviderCoreTests/GemmaVLMParityProbeMemoryLiveTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/GemmaVLMParityProbeMemoryLiveTests.swift
@@ -154,6 +154,11 @@ struct GemmaVLMParityProbeMemoryLiveTests {
         let fusedBytes = slot.model.namedModules()
             .compactMap { ($0.1 as? SwitchGLU)?.fusedGateUpCacheBytes }
             .reduce(0, +)
+        // The extraction's own measurement — what the slot factory nets out
+        // of the v2 KV ceiling (PR#508 finding 2) — must agree with the
+        // wrapper-side sum (shared arrays, counted once).
+        #expect(extraction.fusedMoECacheBytes == fusedBytes)
+        #expect(extraction.fusedMoECacheBytes > 0)
         print(
             "[parity-mem] post-extraction: active=\(Self.gib(activeAfter)) "
                 + "cache=\(Self.gib(cacheAfter)) activeGrowth=\(Self.gib(activeGrowth)) "
@@ -234,5 +239,47 @@ struct GemmaVLMParityProbeMemoryLiveTests {
                     + "64 GB profile after the parity probe — the v0.7.2 black-hole signature"))
         await budget.release(requestID: "incident-probe")
         #expect(await budget.reservationIDsForTesting().isEmpty)
+
+        // 4. CAPACITY CONSISTENCY (PR#508 finding 2): the v2 static ceiling —
+        //    the weights-derived grant netted of the MEASURED fused cache,
+        //    exactly what the slot factory now hands `makeProductionEngine`
+        //    and the heartbeat advertises — must equal the shared gate's
+        //    live headroom on the same simulated 64 GB profile. Pre-fix the
+        //    unadjusted grant exceeded that headroom by the cache size
+        //    (~1.7×), so the coordinator over-routed into gate rejects.
+        MLX.Stream().synchronize()
+        MLX.Memory.clearCache()
+        let mlxUsedNow =
+            UInt64(max(0, MLX.GPU.activeMemory)) + UInt64(max(0, MLX.GPU.cacheMemory))
+        // Resident weights as the static derivation would see them: live MLX
+        // usage minus the (measured) engine-retained cache.
+        let residentWeights =
+            mlxUsedNow > UInt64(extraction.fusedMoECacheBytes)
+            ? mlxUsedNow - UInt64(extraction.fusedMoECacheBytes) : 0
+        let baseCeiling = EngineV2KVSizing.engineKVBytesCapacity(
+            newModelWeightBytes: Int(min(residentWeights, UInt64(Int.max))),
+            coResidentWeightBytes: 0,
+            existingEngineKVCapacities: [],
+            physicalBytes: totalBytes)
+        let grantedCeiling = EngineV2KVSizing.netOfEngineResidentOverhead(
+            baseCeiling, overheadBytes: extraction.fusedMoECacheBytes)
+        let gateHeadroom = UnifiedMemoryCap.liveKVHeadroomBytes(
+            physicalBytes: totalBytes,
+            mlxUsedBytes: mlxUsedNow,
+            systemAvailableBytes: .max)
+        print(
+            "[parity-mem] 64GB-profile capacity: base=\(Self.gib(baseCeiling)) "
+                + "granted=\(Self.gib(grantedCeiling)) gateHeadroom=\(Self.gib(Int(gateHeadroom)))")
+        #expect(
+            UInt64(grantedCeiling) == gateHeadroom,
+            Comment(
+                rawValue: "advertised v2 ceiling \(Self.gib(grantedCeiling)) != shared-gate "
+                    + "headroom \(Self.gib(Int(gateHeadroom))) — heartbeat max and the gate "
+                    + "would disagree (the finding-2 over-routing shape)"))
+        #expect(
+            UInt64(baseCeiling) > gateHeadroom,
+            Comment(
+                rawValue: "pre-fix (weights-only) ceiling no longer exceeds the gate headroom "
+                    + "— the regression premise vanished; re-derive this stage"))
     }
 }

--- a/provider-swift/Tests/ProviderCoreTests/GlobalKVCacheBudgetTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/GlobalKVCacheBudgetTests.swift
@@ -169,9 +169,13 @@ private final class AuditEventLog: @unchecked Sendable {
 
 /// Build a budget with tiny audit thresholds: 6 GiB cap headroom, so a leaked
 /// 6 GiB reservation makes EVERY later commit fail — the black-hole shape.
+/// The continuity window defaults to the production 30 s so the storm-style
+/// tests (rejections ~10 ms apart) exercise the same "gaps far under the
+/// window sustain the streak" regime production sees.
 private func makeAuditBudget(
     log: AuditEventLog,
-    staleTTL: Duration = .milliseconds(50)
+    staleTTL: Duration = .milliseconds(50),
+    continuityWindow: Duration = GlobalKVCacheBudget.defaultRejectionStreakContinuityWindow
 ) -> GlobalKVCacheBudget {
     GlobalKVCacheBudget(
         capFraction: 1.0,
@@ -181,6 +185,7 @@ private func makeAuditBudget(
                 total: 8 * gib, active: 0, cache: 0, systemAvailable: .max)
         },
         sustainedRejectionAuditThreshold: .milliseconds(40),
+        rejectionStreakContinuityWindow: continuityWindow,
         staleReservationTTL: staleTTL,
         auditMinInterval: .milliseconds(10),
         emitAuditEvent: { severity, message, fields in
@@ -242,6 +247,84 @@ private func makeAuditBudget(
     #expect(!log.operations().contains("kv_budget_stale_reservation_dropped"))
     let ids = await budget.reservationIDsForTesting()
     #expect(ids.contains("pending-load:live"))
+}
+
+/// Sparse traffic must never age into an audit: two rejections separated by
+/// an idle gap longer than the continuity window are NOT a sustained streak,
+/// even when their wall-clock span exceeds the audit threshold. Without
+/// continuity, the audit would fire on the second rejection and drop the
+/// >TTL-old reservation — which here models LIVE work (a multi-10-minute
+/// decode or a slow pending load legitimately outlives the 10-min TTL).
+@Test func idleGapsBetweenRejectionsNeverAgeIntoAnAudit() async throws {
+    let log = AuditEventLog()
+    // Continuity window 30 ms, audit threshold 40 ms, stale TTL 30 ms.
+    let budget = makeAuditBudget(
+        log: log, staleTTL: .milliseconds(30), continuityWindow: .milliseconds(30))
+
+    // A long-running piece of LIVE work whose reservation outlives the TTL.
+    await budget.reservePendingLoad(requestID: "pending-load:live-decode", bytes: 6 * gib)
+    try await Task.sleep(for: .milliseconds(50))  // now older than the stale TTL
+
+    // Rejection 1 arms the streak; a >window idle gap follows.
+    #expect(!(await budget.reserve(requestID: "sparse-1", kvBytesPerToken: 1, tokenCount: Int(gib))))
+    try await Task.sleep(for: .milliseconds(100))
+    // Rejection 2: wall clock since rejection 1 exceeds the 40 ms threshold,
+    // but the gap broke the streak — pre-fix this fired the audit and
+    // dropped the live reservation. Rejection 3 lands inside the window but
+    // the re-armed streak is only milliseconds old.
+    #expect(!(await budget.reserve(requestID: "sparse-2", kvBytesPerToken: 1, tokenCount: Int(gib))))
+    #expect(!(await budget.reserve(requestID: "sparse-3", kvBytesPerToken: 1, tokenCount: Int(gib))))
+
+    #expect(log.operations().isEmpty, "audit fired across an idle traffic gap")
+    let ids = await budget.reservationIDsForTesting()
+    #expect(ids.contains("pending-load:live-decode"), "live work was dropped as stale")
+}
+
+/// A release of a REAL reservation proves the table drains (work is
+/// terminating normally), so it must reset the rejection streak: a
+/// continuous rejection storm interleaved with releases never audits.
+@Test func releasesOfRealReservationsResetTheRejectionStreak() async throws {
+    let log = AuditEventLog()
+    let budget = makeAuditBudget(log: log)
+
+    // The wedge: consumes the whole 6 GiB effective cap.
+    await budget.reservePendingLoad(requestID: "pending-load:wedge", bytes: 6 * gib)
+
+    // 12 × 10 ms of continuous rejections (well past the 40 ms threshold),
+    // but unrelated in-flight work keeps completing — each release resets
+    // the streak, so the audit must never fire.
+    for i in 0 ..< 12 {
+        _ = await budget.reserve(requestID: "storm-\(i)", kvBytesPerToken: 1, tokenCount: Int(gib))
+        await budget.reservePendingLoad(requestID: "tick-\(i)", bytes: 1)
+        await budget.release(requestID: "tick-\(i)")
+        try await Task.sleep(for: .milliseconds(10))
+    }
+
+    #expect(log.operations().isEmpty, "audit fired despite reservations draining via release()")
+    #expect(await budget.reservationIDsForTesting().contains("pending-load:wedge"))
+}
+
+/// The complement: releasing an id that holds NO reservation proves nothing
+/// and must NOT reset the streak — otherwise a caller releasing a stale/
+/// unknown id on every request would mask a real black hole forever.
+@Test func releaseOfUnknownIDDoesNotResetTheStreak() async throws {
+    let log = AuditEventLog()
+    let budget = makeAuditBudget(log: log)
+
+    await budget.reservePendingLoad(requestID: "pending-load:leaked", bytes: 6 * gib)
+
+    var audited = false
+    for i in 0 ..< 30 {
+        _ = await budget.reserve(requestID: "storm-\(i)", kvBytesPerToken: 1, tokenCount: Int(gib))
+        await budget.release(requestID: "ghost-\(i)")  // never reserved — a no-op
+        if log.operations().contains("kv_budget_sustained_rejection") {
+            audited = true
+            break
+        }
+        try await Task.sleep(for: .milliseconds(10))
+    }
+
+    #expect(audited, "no-op releases suppressed the sustained-rejection audit")
 }
 
 /// A successful commit resets the rejection streak: intermittent capacity

--- a/provider-swift/Tests/ProviderCoreTests/GlobalKVCacheBudgetTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/GlobalKVCacheBudgetTests.swift
@@ -1,4 +1,6 @@
+import Foundation
 import Testing
+
 @testable import ProviderCore
 
 // These exercise GlobalKVCacheBudget against the unified-cap headroom formula
@@ -143,4 +145,121 @@ private let gib: UInt64 = 1024 * 1024 * 1024
 @Test func providerLoopMemoryReserveBytesSaturatesOnOverflow() {
     #expect(ProviderLoop.memoryReserveBytes(forGiB: 4) == 4 * 1024 * 1024 * 1024)
     #expect(ProviderLoop.memoryReserveBytes(forGiB: UInt64.max) == UInt64.max)
+}
+
+// MARK: - Sustained-rejection reservation audit (v0.7.3 black-hole hardening)
+
+/// Thread-safe capture sink for the budget's audit telemetry closure.
+private final class AuditEventLog: @unchecked Sendable {
+    private let lock = NSLock()
+    private var events: [(severity: TelemetrySeverity, message: String, fields: [String: AnyCodableValue])] = []
+
+    func append(_ severity: TelemetrySeverity, _ message: String, _ fields: [String: AnyCodableValue]) {
+        lock.lock()
+        defer { lock.unlock() }
+        events.append((severity, message, fields))
+    }
+
+    func operations() -> [String] {
+        lock.lock()
+        defer { lock.unlock() }
+        return events.compactMap { $0.fields["operation"]?.description }
+    }
+}
+
+/// Build a budget with tiny audit thresholds: 6 GiB cap headroom, so a leaked
+/// 6 GiB reservation makes EVERY later commit fail — the black-hole shape.
+private func makeAuditBudget(
+    log: AuditEventLog,
+    staleTTL: Duration = .milliseconds(50)
+) -> GlobalKVCacheBudget {
+    GlobalKVCacheBudget(
+        capFraction: 1.0,
+        activationReserveBytes: 0,
+        memorySnapshot: {
+            GlobalKVCacheBudget.MemorySnapshot(
+                total: 8 * gib, active: 0, cache: 0, systemAvailable: .max)
+        },
+        sustainedRejectionAuditThreshold: .milliseconds(40),
+        staleReservationTTL: staleTTL,
+        auditMinInterval: .milliseconds(10),
+        emitAuditEvent: { severity, message, fields in
+            log.append(severity, message, fields)
+        }
+    )
+}
+
+/// The incident shape, generalized: a reservation that never gets released
+/// wedges the budget into 100% rejection. After the sustained-rejection
+/// threshold, the audit must log the table, drop the stale entry, and the
+/// next commit must succeed — permanent black hole → self-healed blip.
+@Test func sustainedRejectionAuditDropsStaleReservationAndHeals() async throws {
+    let log = AuditEventLog()
+    let budget = makeAuditBudget(log: log)
+
+    // The leak: consumes the whole 6 GiB effective cap (8 GiB − 2 GiB floor).
+    await budget.reservePendingLoad(requestID: "pending-load:leaked", bytes: 6 * gib)
+
+    // Rejections must persist past BOTH the stale TTL and the audit
+    // threshold. Loop instead of one long sleep so the streak has failures
+    // on both ends of the threshold window.
+    var healed = false
+    for _ in 0 ..< 30 {
+        if await budget.reserve(requestID: "req-\(UUID().uuidString)", kvBytesPerToken: 1, tokenCount: Int(gib)) {
+            healed = true
+            break
+        }
+        try await Task.sleep(for: .milliseconds(10))
+    }
+
+    #expect(healed, "budget never healed — the stale reservation was not dropped")
+    let ids = await budget.reservationIDsForTesting()
+    #expect(!ids.contains("pending-load:leaked"))
+    let operations = log.operations()
+    #expect(operations.contains("kv_budget_sustained_rejection"))
+    #expect(operations.contains("kv_budget_stale_reservation_dropped"))
+}
+
+/// Fresh (younger than the TTL) reservations are live work and must survive
+/// the audit even during a full-rejection streak — the audit only ever drops
+/// entries no plausible request/load lifetime can explain.
+@Test func sustainedRejectionAuditKeepsFreshReservations() async throws {
+    let log = AuditEventLog()
+    // TTL far above the test duration: everything stays "fresh".
+    let budget = makeAuditBudget(log: log, staleTTL: .seconds(60))
+
+    await budget.reservePendingLoad(requestID: "pending-load:live", bytes: 6 * gib)
+
+    for _ in 0 ..< 12 {
+        _ = await budget.reserve(
+            requestID: "req-\(UUID().uuidString)", kvBytesPerToken: 1, tokenCount: Int(gib))
+        try await Task.sleep(for: .milliseconds(10))
+    }
+
+    // The audit fired (CRITICAL visibility)…
+    #expect(log.operations().contains("kv_budget_sustained_rejection"))
+    // …but dropped nothing.
+    #expect(!log.operations().contains("kv_budget_stale_reservation_dropped"))
+    let ids = await budget.reservationIDsForTesting()
+    #expect(ids.contains("pending-load:live"))
+}
+
+/// A successful commit resets the rejection streak: intermittent capacity
+/// pressure (rejections interleaved with successes) must never trigger the
+/// audit — it is reserved for the every-commit-fails black hole.
+@Test func successfulCommitsResetTheRejectionStreak() async throws {
+    let log = AuditEventLog()
+    let budget = makeAuditBudget(log: log)
+
+    for i in 0 ..< 8 {
+        // Too big — rejected (5 GiB headroom left under the 6 GiB cap after
+        // the small success below on later iterations).
+        _ = await budget.reserve(requestID: "big-\(i)", kvBytesPerToken: 1, tokenCount: Int(7 * gib))
+        // Small — succeeds, resetting the streak.
+        #expect(await budget.reserve(requestID: "small-\(i)", kvBytesPerToken: 1, tokenCount: 1024))
+        await budget.release(requestID: "small-\(i)")
+        try await Task.sleep(for: .milliseconds(10))
+    }
+
+    #expect(log.operations().isEmpty, "audit fired despite interleaved successful commits")
 }


### PR DESCRIPTION
# v0.7.3 hotfix — Gemma VLM black hole: duplicated MoE fused gate+up cache pushed 64 GB boxes past the memory cap

## Incident

After the 0.7.2 fleet rollout (~18:20Z mass-update wave), **8 boxes — 7×64 GB serving `gemma-4-26b-8bit` + 1×36 GB serving `gemma-4-26b-qat-4bit` — rejected 100 % of requests from their very first request, permanently** (40+ min, zero successes, no decay), all with the shared-KV gate's capacity string:

```
token_budget_exhausted: request requires N tokens but the shared KV budget has no headroom
```

Signature: heartbeat **engine ledgers idle** (nothing was ever admitted) while the **process-wide `GlobalKVCacheBudget` rejected everything** — the two ledgers disagreed. The budget's async reclaimer (`KVPoolReclaimer` → `clearCache`) never healed it. Fresh restarts did not heal it (box `f21d71d7` re-registered via the new startup-preload path and was wedged from request one). The sink population never spread to other memory profiles — deterministic, not a race.

## Root cause (confirmed by local reproduction on the real checkpoint)

`MLXLMCommon.SwitchGLU` carries a **lazy "fused gate+up" decode optimization**: on **first forward** it concatenates its quantized gate+up expert weights/scales/biases into one wider tensor and **retains it on the module forever** (~540 MB per MoE layer; the fork deliberately raised the per-layer cache limit to 1024 MiB so Gemma-8-bit qualifies). For `gemma-4-26b-8bit` that is **15.07 GiB model-wide across 30 MoE layers** (measured).

v0.7.2's VLM text extraction (`EngineV2VLMTextExtraction`) builds a **second** module tree (`Gemma4TextModel`) over the same weight arrays. The weight arrays themselves are perfectly shared (measured: extraction + `eval(parameters)` = **0 bytes** growth). But each tree owns its **own SwitchGLU instances** — and the load-time forward-parity probe runs one forward through **each** tree, so **each builds its own 15 GiB fused copy**, at load time, before the first request:

**Measured phase decomposition** (this box, real `mlx-community/gemma-4-26b-a4b-it-8bit`):

| Phase | MLX active | Δ |
|---|---|---|
| Weights loaded (baseline, pool trimmed) | 26.04 GiB | — |
| Extraction (skeleton + quantize + update), parity off | 26.04 GiB | +0 |
| `eval(extracted parameters)` — sharing check | 26.04 GiB | +0 |
| **Wrapper probe forward** | **41.10 GiB** | **+15.06** (survives `clearCache`) |
| **Extracted probe forward** | **56.17 GiB** | **+15.07** (survives `clearCache`) |

On a 64 GB box: cap = 0.9 × 64 = **57.6 GiB**; `mlxUsed` = **56.17 GiB** → `UnifiedMemoryCap.liveKVHeadroomBytes` ≈ 0 → **every reservation rejected forever**. Reproduced end-to-end: a `GlobalKVCacheBudget` viewing the post-extraction MLX state through a simulated 64 GB profile **rejected** a typical worst-case request (2 K prompt + 4 K max tokens @ 20 480 B/token) — the exact incident behavior.

Why every piece of the signature follows:

- **Permanent / reclaimer can't heal**: the copies are module-**retained active** memory, not the reclaimable pool — `clearCache` is a no-op on them (cache measured 0.12 GiB while active sat at 56 GiB).
- **Engine ledger idle**: the v2 engine's `AdmissionV2` ceiling was sized before the probe and its usage ledger stayed empty — only the live shared gate saw the real memory.
- **From the first request**: the probe runs during `ensureModelLoaded` (startup preload) — the wedge exists before registration completes. The existing post-load headroom check runs **before** the bridge build, so it passed.
- **Exactly these profiles**: black hole iff `weights + 2×fusedCache` crosses the cap. 8-bit: 26.0 + 2×15.07 ≈ 56.2 vs 57.6 (64 GB dies; 96/128 GB fine). qat-4bit (measured fused cache 8.56 GiB): ~14.9 + 2×8.56 ≈ 32.0 vs 32.4 cap on 36 GB (dies) but 43.2 on 48 GB (fine). Matches the sink population exactly — 7×64 GB/8-bit + 1×36 GB/qat-4bit, never spreading.
- **Why 0.7.2 triggered it**: pre-0.7.2 there was only ONE tree (the wrapper), whose single fused cache (26+15 = 41 GiB) was the accepted steady state after the first request. 0.7.2 added the second tree **and** moved the materialization to load time via the parity probe.

Suspects ruled out: **`reservePendingLoad` leak** — disproven by code audit (release at `ProviderLoop+ModelLoading.swift:281` runs *before* the bridge build at :334; every throw between reserve and release lands in the catch which releases at :372) and by the live run (reservation table empty after load). **MLX cache retention** — disproven by measurement (cache ≈ 0; the binding term is active memory).

## Fixes

1. **Cure — share ONE fused cache across the trees** (`libs/mlx-swift-lm` `SwitchGLU.shareFusedGateUpCache(with:)` + `EngineV2VLMTextExtraction.shareMoEFusedCaches`): the extraction pairs every wrapper SwitchGLU with its extracted counterpart (same dotted module path minus the `language_model.` prefix — the same re-keying the parameter update uses) and eagerly builds a single shared fused cache. Eligibility verdicts (non-quantized, cache limit, `BENCH_NO_FUSED_GATE_UP`) propagate, so the two trees can never diverge. Load-time footprint returns to the pre-0.7.2 steady state.
2. **Probe hygiene**: the parity probe now fences the GPU stream and clears the MLX pool on exit (success and throw), returning probe transients before the load path's admission reads.
3. **Fail-closed load guard**: `ensureModelLoaded` re-checks serveable KV headroom **after** the engine-bridge build (where the extraction's eager cache build happens). Runs for **any VLM slot, bridge or not** — a parity/init failure that fell back to legacy has still grown resident memory (the cache builds before the parity gate). On failure: unregister bridge, unload, record error, 503 (coordinator reroutes) instead of advertising a dead model.
4. **Budget self-heal hardening** (defense in depth for any future variant): `GlobalKVCacheBudget` reservations now carry creation timestamps; when **every commit has failed for 120 s straight**, the budget logs the full reservation table + memory snapshot at ERROR severity (`kv_budget_sustained_rejection`) and **drops reservations older than 10 min** with a WARN (`kv_budget_stale_reservation_dropped`), converting any stuck-reservation black hole into a self-healing blip. Rate-limited; one successful commit resets the streak. The audit fields (`streak_seconds`, `reservations`, `reserved_bytes`, …) are added to **all three telemetry field allowlists** (Swift `TelemetryEvent.swift`, Go `coordinator/api/telemetry_handlers.go`, TS `console-ui/src/lib/telemetry-types.ts`) so the table actually reaches Datadog — operational counters/ids only, no prompt data.
5. **Test teardown correctness** (queued Codex P2): `GemmaVLMEngineV2LiveTests` awaits its scheduler unloads structurally (`withLoadedVLMSlot`) instead of `defer { Task { … } }`, which raced the next test's multi-GB load.
6. **Version**: `ProviderCore.version` → **0.7.3**; `coordinator/api/server.go` `LatestProviderVersion` → **0.7.3**.

## Post-fix validation (same box, same checkpoint)

```
pre-extraction:  active=26.04 GiB
post-extraction: active=41.10 GiB  activeGrowth=15.07 GiB  sharedFusedCache=15.07 GiB  layers=30
steady-state re-forward growth = 0.00 GiB
64GB-profile admission: admitted=true          (pre-fix: false)
```

Exactly one fused copy; nothing lazily fires at request time; the incident profile admits requests again (headroom ≈ 16.5 GiB minus reserves).

## Before / after

### Behavior

```mermaid
flowchart LR
  subgraph Before["Before (v0.7.2)"
]
    A1[restart → startup preload<br/>gemma-4-26b-8bit, 64 GB] --> B1[load weights 26 GiB<br/>post-load headroom check ✓]
    B1 --> C1[v2 bridge build:<br/>extraction + parity probe]
    C1 --> D1["wrapper forward → +15 GiB fused copy #1<br/>extracted forward → +15 GiB fused copy #2<br/>active = 56.2 GiB vs 57.6 GiB cap"]
    D1 --> E1[register, advertise model]
    E1 --> F1[every request →<br/>kvBudget.reserve fails →<br/>token_budget_exhausted]
    F1 --> G1[reclaimer clearCache: no-op<br/>(active, not pool)<br/>PERMANENT BLACK HOLE]
  end
  subgraph After["After (v0.7.3)"]
    A2[restart → startup preload] --> B2[load weights 26 GiB<br/>post-load headroom check ✓]
    B2 --> C2["v2 bridge build:<br/>extraction shares ONE fused cache<br/>(+15 GiB, wrapper ↔ extracted)<br/>probe runs, pool cleared"]
    C2 --> D2[post-bridge headroom re-check ✓<br/>active = 41.1 GiB]
    D2 --> E2[register, advertise model]
    E2 --> F2[requests admitted and served<br/>(16.5 GiB KV headroom)]
    D2 -.headroom < 1 GiB.-> X2[unload + 503<br/>coordinator reroutes]
    F2 -.any future wedge: all commits fail 120 s.-> Y2[budget audits table at ERROR,<br/>drops stale reservations → self-heals]
  end
```

### Code

```mermaid
flowchart TD
  subgraph BeforeC["Before (v0.7.2)"]
    a1["EngineV2VLMTextExtraction.extractTextModel<br/>skeleton → quantize → update → assertForwardParity"] --> b1["SwitchGLU.ensureFusedGateUp (lazy, per instance)<br/>wrapper tree builds copy #1<br/>extracted tree builds copy #2"]
    c1[ensureModelLoaded:<br/>headroom check BEFORE bridge build only] --> a1
    d1[GlobalKVCacheBudget.commit fail →<br/>scheduleReclaim only]
  end
  subgraph AfterC["After (v0.7.3)"]
    a2["extractTextModel<br/>skeleton → quantize → update →<br/><b>shareMoEFusedCaches</b> (pairs SwitchGLUs,<br/>SwitchGLU.shareFusedGateUpCache builds ONE) →<br/>assertForwardParity (defer: sync + clearCache)"]
    c2[ensureModelLoaded:<br/>headroom check before bridge<br/><b>+ re-check AFTER bridge build</b><br/>fail → unregister + unload + 503] --> a2
    d2["GlobalKVCacheBudget.commit fail →<br/>scheduleReclaim + <b>recordCommitRejection</b><br/>→ sustained-rejection audit:<br/>ERROR table log + stale-reservation drop"]
  end
```

## Tests

- **New live regression** `GemmaVLMParityProbeMemoryLiveTests` (weight-gated: `DARKBLOOM_LIVE_MLX_TESTS` + `DARKBLOOM_LIVE_MLX_GEMMA`): one-shared-cache growth bound, zero steady-state re-forward growth, pool hygiene, and the inverted incident (64 GB-profile budget admission). Fails without the fix (measured 30.13 GiB growth, admission=false); passes with it.
- **Updated live** `GemmaVLMEngineV2LiveTests` stage (a): asserts per-layer fused-cache **array identity** wrapper↔extracted + `sharedFusedMoELayerCount`; structured (awaited) unload teardown. Both checkpoints re-run green post-fix: qat-4bit full pipeline (parity 8.59, shared cache 8.56 GiB/30 layers, v2==legacy greedy exact, vision interleave clean) and 8-bit (parity 8.72, shared cache 15.07 GiB/30 layers, v2==legacy greedy exact).
- **New unit** ×3 in `GlobalKVCacheBudgetTests`: sustained-rejection audit drops stale reservation and heals; fresh reservations survive the audit; successful commits reset the streak.
- **Full suites green**: `swift build` + `swift test` — 1337 tests / 115 suites passed (ChunkSender coalesce flake did not trip); coordinator `go build ./...` + `go test ./api` ok (103 s).

## Review gate

Dual review per repo policy. Codex rescue: PASS (no blocking issues). Independent reviewer: initial FAIL with two blocking findings, both fixed and re-verified: (1) audit telemetry fields were being stripped by the three-way field allowlist → fields added to Swift/Go/TS mirrors; (2) the post-bridge headroom guard was skipped on the extraction-failure fallback path (nil bridge) even though the fused cache was already resident → guard now runs for any VLM slot. Also folded in: `shareFusedGateUpCache` returns whether a cache was actually shared (truthful log counts under `BENCH_NO_FUSED_GATE_UP`), comment severity fix. Known accepted residual (reviewer non-blocking): a >10-min decode coinciding with a 2-min full-rejection streak could have its reservation dropped — consequence bounded (materialized KV already counted in `active`; only future growth over-granted) and loudly WARN'd.

## Deployment notes

- **`libs/mlx-swift-lm` submodule** carries the `SwitchGLU.shareFusedGateUpCache` change: branch `hotfix/moe-fused-cache-share`, HEAD `a71c8018c02c5da6097bfd28c35c2b162c6fe5c6` (2 commits off the current pin `d3b1ae9`: `7041eca` sharing API + `a71c801` truthful share-count return). **It must be pushed to the layr-labs remote before this PR's CI / release tag can build** (human action — agent does not push). The super-repo pin records `a71c801`.
- No protocol changes; wire-compatible. The multimodal work in flight becomes 0.7.4 and should rebase onto this.
- Rollout note for the 8 wedged boxes: the 0.7.3 auto-update restarts the provider; the fixed load path comes up at 41 GiB and serves. No manual intervention expected beyond the release.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/508"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785700119&installation_id=133247490&pr_number=508&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F508&signature=93847b0ed6b36a6431464693925002813b4c210480a1e2860b2ec84dee06069c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->