### PR TITLE
fix(coordinator): capacity-cooldown follow-ups — half-open probe, generic-path accept, 404 strikes, all-cooled 429

### DIFF
--- a/coordinator/api/capacity_cooldown_followups_test.go
+++ b/coordinator/api/capacity_cooldown_followups_test.go
@@ -1,0 +1,285 @@
+package api
+
+// Follow-up coverage for the capacity-reject cooldown (PR #507 P2s):
+//   1. the generic (/v1/completions, /v1/messages) path records the ACCEPT at
+//      first content, so a long generic stream on a busy box keeps vouching
+//      for the pair while it sheds concurrent dispatches;
+//   2. cold 404 "model not loaded" misses strike (a box that 404s forever is
+//      a black hole) while the normal 404-then-load-then-serve lifecycle
+//      never trips (the accept resets the streak);
+//   3. an ALL-COOLED model surfaces as TRANSIENT capacity — a preflight 429
+//      with Retry-After and zero provider dispatches — not a structural
+//      "no providers" 503.
+// The half-open single-probe semantics are covered in
+// registry/capacity_cooldown_test.go (claim lifecycle + concurrency).
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+	"github.com/eigeninference/d-inference/coordinator/registry"
+	"github.com/eigeninference/d-inference/coordinator/store"
+)
+
+// A box that cold-404s ("model not loaded") FOREVER with zero accepts is a
+// black hole and must trip; a box that 404s while lazily loading and then
+// SERVES (the normal lifecycle) must never trip — the accept is the safety.
+func TestCapacityCooldown404NotLoadedStrikes(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	st := store.NewMemory(store.Config{AdminKey: "test-key"})
+	reg := registry.New(logger)
+	srv := NewServer(reg, st, ServerConfig{}, logger)
+
+	const model = "gemma-4-26b-8bit"
+	const notLoaded = "model 'gemma-4-26b-8bit' is not loaded on this provider"
+
+	// Normal lazy-load lifecycle: a few cold 404s, then the load completes and
+	// the box serves. The accept resets the streak every round — never trips.
+	lazy := makeRoutableProvider(t, reg, "p-lazy-load", model)
+	for round := 0; round < 4; round++ {
+		for i := 0; i < 3; i++ {
+			srv.noteInferenceError(lazy.ID, capacityTestPending(model, lazy.ID, round*10+i), http.StatusNotFound, notLoaded)
+		}
+		srv.noteInferenceSuccess(capacityTestPending(model, lazy.ID, round))
+	}
+	if reg.CapacityCooldownActive(lazy.ID, model) {
+		t.Fatal("404-then-load-then-serve lifecycle tripped the capacity cooldown")
+	}
+
+	// Black hole flavor: 404s forever, zero accepts — trips at the threshold.
+	stuck := makeRoutableProvider(t, reg, "p-never-loads", model)
+	for i := 0; i < 5; i++ {
+		srv.noteInferenceError(stuck.ID, capacityTestPending(model, stuck.ID, i), http.StatusNotFound, notLoaded)
+	}
+	if !reg.CapacityCooldownActive(stuck.ID, model) {
+		t.Fatal("a box that 404s 'not loaded' forever with zero accepts did not trip")
+	}
+
+	// A 404 whose message is NOT the capacity vocabulary (unknown model id — a
+	// request-shape error) never strikes, no matter how many arrive.
+	notFound := makeRoutableProvider(t, reg, "p-model-not-found", model)
+	for i := 0; i < 10; i++ {
+		srv.noteInferenceError(notFound.ID, capacityTestPending(model, notFound.ID, i), http.StatusNotFound, "model not found")
+	}
+	if reg.CapacityCooldownActive(notFound.ID, model) {
+		t.Fatal("request-shape 404 'model not found' tripped the capacity cooldown")
+	}
+}
+
+// The generic-path accept regression (P2 #1): a busy box serving a LONG
+// /v1/completions stream sheds 5 capacity rejects inside the window. The
+// stream's first content is an ACCEPT interleaved with the rejects, so the
+// pair must NEVER trip — before the fix the generic path recorded accepts
+// only at clean completion, so the in-flight stream could not vouch for the
+// box and the shed storm read as the zero-accepts black-hole signature.
+func TestCapacityCooldownGenericStreamAcceptPreventsFalseTrip(t *testing.T) {
+	// Crisp failure mode if the pair DOES trip: fast-shed 429 instead of a
+	// 120s queue hang. Both flags are read live per request.
+	t.Setenv("EIGENINFERENCE_QUEUE_BEFORE_SHED", "false")
+	t.Setenv("EIGENINFERENCE_COLD_DISPATCH", "false")
+
+	reg, _, ts := setupFailoverServer(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	model := "generic-accept-model"
+	const holdMarker = "GENERIC-HOLD"
+	const endMarker = "GENERIC-END"
+	release := make(chan struct{})
+	var chatServe atomic.Bool
+
+	script := func(ctx context.Context, fp *failoverProvider, req protocol.InferenceRequestMessage, body []byte) {
+		if bytes.Contains(body, []byte(`"prompt"`)) {
+			// The long generic stream: first content immediately (the ACCEPT),
+			// then hold the stream open while the shed storm runs. In a
+			// goroutine — the script runs on the provider read loop, which must
+			// stay free to reject the concurrent chat dispatches.
+			go func() {
+				fp.sendContentChunk(ctx, req, model, holdMarker+" ")
+				select {
+				case <-release:
+				case <-ctx.Done():
+					return
+				}
+				fp.sendContentChunk(ctx, req, model, endMarker)
+				fp.sendComplete(ctx, req, protocol.UsageInfo{PromptTokens: 5, CompletionTokens: 2})
+			}()
+			return
+		}
+		if chatServe.Load() {
+			fp.serveFull(ctx, req, model, markerFor(fp.name))
+			return
+		}
+		fp.sendInferenceError(ctx, req, "token_budget_exhausted: request exceeds active token budget", http.StatusServiceUnavailable)
+	}
+	fp := startFailoverProvider(t, ctx, ts, reg, failoverProviderConfig{
+		Name: "provider-busy", Version: "0.7.2", DecodeTPS: 100,
+		Models: []failoverModelSpec{{ID: model}}, Script: script,
+	})
+
+	rejectOnce := func(n int) {
+		t.Helper()
+		status, body, err := postChat(ctx, ts.URL, "test-key", buildChatBody(t, model, false, nil))
+		if err != nil {
+			t.Fatalf("shed request %d: %v", n, err)
+		}
+		if status == http.StatusOK {
+			t.Fatalf("shed request %d unexpectedly served; body=%s", n, body)
+		}
+	}
+
+	// Rejects 1-2: the box is saturated and sheds.
+	rejectOnce(1)
+	rejectOnce(2)
+
+	// Start the LONG generic stream and read up to its first content — the
+	// coordinator records the ACCEPT at the commit, before relaying the chunk,
+	// so seeing the marker guarantees the accept has landed.
+	genBody := fmt.Sprintf(`{"model":%q,"prompt":"long generic stream","stream":true,"max_tokens":64}`, model)
+	genReq, err := http.NewRequestWithContext(ctx, http.MethodPost, ts.URL+"/v1/completions", strings.NewReader(genBody))
+	if err != nil {
+		t.Fatalf("generic request: %v", err)
+	}
+	genReq.Header.Set("Authorization", "Bearer test-key")
+	genReq.Header.Set("Content-Type", "application/json")
+	genResp, err := http.DefaultClient.Do(genReq)
+	if err != nil {
+		t.Fatalf("generic request: %v", err)
+	}
+	defer genResp.Body.Close()
+	if genResp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(genResp.Body)
+		t.Fatalf("generic stream status = %d, want 200; body=%s", genResp.StatusCode, b)
+	}
+	genReader := bufio.NewReader(genResp.Body)
+	for {
+		line, err := genReader.ReadString('\n')
+		if err != nil {
+			t.Fatalf("generic stream ended before first content: %v", err)
+		}
+		if strings.Contains(line, holdMarker) {
+			break
+		}
+	}
+
+	// Rejects 3-5 while the stream is STILL in flight: 5 total rejects inside
+	// the window — but the stream's first-content accept interleaved, so the
+	// post-accept streak is only 3 and the pair must not be cooled.
+	rejectOnce(3)
+	rejectOnce(4)
+	rejectOnce(5)
+
+	// The box frees up: the next chat request must route to it and serve. A
+	// falsely-tripped cooldown would fast-shed this with a 429 instead.
+	chatServe.Store(true)
+	status, body, err := postChat(ctx, ts.URL, "test-key", buildChatBody(t, model, true, nil))
+	if err != nil {
+		t.Fatalf("post-storm request: %v", err)
+	}
+	if status != http.StatusOK || !strings.Contains(body, markerFor("provider-busy")) {
+		t.Fatalf("busy-but-serving box was cooled by sheds during its long generic stream: status=%d body=%s", status, body)
+	}
+
+	// Sanity: every request above actually reached the provider (strikes and
+	// the accept were real, not admission-filtered away).
+	if got := fp.dispatchCount(); got != 7 {
+		t.Errorf("provider dispatches = %d, want 7 (2 rejects + generic + 3 rejects + serve)", got)
+	}
+
+	// Let the held stream finish cleanly.
+	close(release)
+	rest, _ := io.ReadAll(genResp.Body)
+	if !strings.Contains(string(rest), endMarker) {
+		t.Errorf("generic stream missing tail content after release; got: %s", string(rest))
+	}
+}
+
+// The all-cooled surfacing regression (P2 #4): when EVERY provider for a model
+// is capacity-cooled, the preflight must classify them as TRANSIENT capacity
+// rejections — a 429 with Retry-After and ZERO provider dispatches — not as
+// structural absence (a "no providers" 503). Replays the incident shape end to
+// end: black-hole boxes trip, then the next request is shed cleanly upstream.
+func TestCapacityCooldownAllCooledSurfaces429NotNoProvider(t *testing.T) {
+	// Threshold 2 so both pairs trip within two requests (read at registry
+	// construction inside setupFailoverServer); fast-shed + no cold-dispatch so
+	// the all-cooled preflight verdict surfaces as an immediate 429 rather
+	// than a queue spill (both read live per request).
+	t.Setenv("EIGENINFERENCE_CAPACITY_COOLDOWN_THRESHOLD", "2")
+	t.Setenv("EIGENINFERENCE_QUEUE_BEFORE_SHED", "false")
+	t.Setenv("EIGENINFERENCE_COLD_DISPATCH", "false")
+
+	reg, _, ts := setupFailoverServer(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	model := "all-cooled-model"
+	script := rejectScript("token_budget_exhausted: request exceeds active token budget", http.StatusServiceUnavailable)
+	pA := startFailoverProvider(t, ctx, ts, reg, failoverProviderConfig{
+		Name: "provider-a", Version: "0.7.2", DecodeTPS: 200,
+		Models: []failoverModelSpec{{ID: model}}, Script: script,
+	})
+	pB := startFailoverProvider(t, ctx, ts, reg, failoverProviderConfig{
+		Name: "provider-b", Version: "0.7.2", DecodeTPS: 100,
+		Models: []failoverModelSpec{{ID: model}}, Script: script,
+	})
+
+	// Drive the incident loop until the preflight sheds WITHOUT touching a
+	// provider: that is the all-cooled verdict. Each earlier warmup request
+	// burns dispatches on the rejecting pairs and accumulates their strikes.
+	var shedResp *http.Response
+	var shedBody string
+	for i := 0; i < 8; i++ {
+		before := pA.dispatchCount() + pB.dispatchCount()
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, ts.URL+"/v1/chat/completions",
+			strings.NewReader(buildChatBody(t, model, false, nil)))
+		if err != nil {
+			t.Fatalf("request %d: %v", i, err)
+		}
+		req.Header.Set("Authorization", "Bearer test-key")
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("request %d: %v", i, err)
+		}
+		b, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if resp.StatusCode == http.StatusOK {
+			t.Fatalf("request %d unexpectedly served; body=%s", i, b)
+		}
+		if after := pA.dispatchCount() + pB.dispatchCount(); after == before {
+			// No provider was dispatched: the preflight itself shed this one.
+			shedResp, shedBody = resp, string(b)
+			break
+		}
+	}
+	if shedResp == nil {
+		t.Fatal("preflight never shed without dispatching — cooled pairs are not being counted as capacity rejections")
+	}
+
+	// The all-cooled verdict must read as TRANSIENT capacity: 429 +
+	// Retry-After + the rate-limit error shape — never a structural
+	// no-provider / model-unavailable 503.
+	if shedResp.StatusCode != http.StatusTooManyRequests {
+		t.Fatalf("all-cooled preflight status = %d, want 429; body=%s", shedResp.StatusCode, shedBody)
+	}
+	if shedResp.Header.Get("Retry-After") == "" {
+		t.Errorf("all-cooled 429 missing Retry-After header")
+	}
+	if !strings.Contains(shedBody, "rate_limit_exceeded") || !strings.Contains(shedBody, "at capacity") {
+		t.Errorf("all-cooled shed body is not the capacity shape; body=%s", shedBody)
+	}
+	if strings.Contains(shedBody, "no_provider") || strings.Contains(shedBody, "model_unavailable") {
+		t.Errorf("all-cooled shed misclassified as structural absence; body=%s", shedBody)
+	}
+}

--- a/coordinator/api/capacity_cooldown_test.go
+++ b/coordinator/api/capacity_cooldown_test.go
@@ -48,6 +48,10 @@ func TestIsCapacityRejectStrike(t *testing.T) {
 		{"opaque foundation error", "The operation couldn’t be completed. (ProviderCore.InferenceError error 1.)", false},
 		{"cancel", "request cancelled", false},
 		{"empty", "", false},
+		// A 404-shaped "model not found" (unknown model id) is a request-shape
+		// error, NOT the cold "not loaded" capacity miss — never a strike.
+		{"unknown model not found", "model not found", false},
+		{"unknown model in registry", "model \"nope\" not found in registry", false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -289,11 +289,22 @@ func (s *Server) noteInferenceError(providerID string, pr *registry.PendingReque
 	// (2026-07 incident: 7 boxes, ~9k "token_budget_exhausted" rejections in
 	// 30 min, zero successes). Strikes accumulate per (provider, model); any
 	// accept (first content chunk or clean completion) resets the streak, so
-	// transient fullness on a serving box can never trip. Gated to 429/5xx so
-	// a client-shape 4xx that happens to carry a capacity-looking string never
-	// strikes; explicit context-overflow rejections are excluded by
+	// transient fullness on a serving box can never trip. Gated to 429/404/5xx
+	// so a client-shape 4xx that happens to carry a capacity-looking string
+	// never strikes; explicit context-overflow rejections are excluded by
 	// isCapacityRejectStrike (they indict the request, not the provider).
-	if (statusCode == http.StatusTooManyRequests || statusCode >= http.StatusInternalServerError) &&
+	//
+	// 404 is included WITH CARE for the cold "model not loaded" miss: a lazy
+	// load on first touch makes a 404-then-load-then-serve sequence NORMAL
+	// lifecycle, so the zero-interleaved-accepts discriminator remains the
+	// safety — the first accept after the load clears the streak, and only a
+	// box that 404s FOREVER (never loads, zero accepts) trips. A 404 whose
+	// message is not capacity-class (e.g. "model not found" for an unknown
+	// model id — a request-shape error) never strikes, because
+	// isCapacityRejectStrike only matches the capacity vocabulary
+	// ("not loaded" / "no model loaded").
+	if (statusCode == http.StatusTooManyRequests || statusCode == http.StatusNotFound ||
+		statusCode >= http.StatusInternalServerError) &&
 		isCapacityRejectStrike(errStr) {
 		if s.registry.RecordCapacityReject(providerID, pr.Model) {
 			s.ddIncr(metricCapacityCooldownTripped, []string{"provider_id:" + providerID, "model:" + pr.Model})
@@ -3710,6 +3721,18 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 			// this attempt committed so handleComplete's fallback is scoped to it.
 			pr.MarkFirstContentArrived()
 			pr.MarkContentCommitted()
+			// First chunk == the provider ACCEPTED and is serving: clear the
+			// pair's capacity-reject streak NOW, not at completion — a long
+			// generic (/v1/completions, /v1/messages) stream on a busy box must
+			// keep vouching for the pair while the box legitimately sheds
+			// concurrent dispatches, exactly like the chat path's
+			// commitFirstContent. Without this, generic-only traffic recorded
+			// accepts only at clean completion, so sheds during a long stream
+			// could masquerade as the zero-accepts black-hole signature. (The
+			// generic path has no preamble filter, so this is the first chunk of
+			// ANY kind rather than strictly first content — fine as an accept
+			// signal: a black hole capacity-rejects, it never emits a chunk.)
+			s.registry.RecordCapacityAccept(provider.ID, pr.Model)
 			committed = true
 		} else {
 			select {
@@ -3778,9 +3801,11 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 				firstChunk = chunk
 				pr.MarkFirstChunkArrived()
 				// Stamp the actual_ttft_ms anchor + mark this attempt committed at
-				// first CONTENT (see the pre-accept branch above).
+				// first CONTENT (see the pre-accept branch above), and record the
+				// capacity-cooldown ACCEPT at first content for the same reason.
 				pr.MarkFirstContentArrived()
 				pr.MarkContentCommitted()
+				s.registry.RecordCapacityAccept(provider.ID, pr.Model)
 				committed = true
 			} else {
 				select {

--- a/coordinator/registry/capacity_cooldown.go
+++ b/coordinator/registry/capacity_cooldown.go
@@ -176,7 +176,14 @@ func (r *Registry) RecordCapacityReject(providerID, modelID string) (tripped boo
 	// expired/idle entries once they grow.
 	if len(r.capacityCooldowns) > 1024 {
 		for key, e := range r.capacityCooldowns {
-			if !now.Before(e.expiry) {
+			// Half-open entries live PAST their expiry by design: the fresh
+			// probe claim (probeAt) is the only thing keeping the gate closed
+			// while the single probe's outcome is pending. Sweeping such an
+			// entry would reopen the gate mid-probe and leak a thundering herd
+			// through the post-expiry window — keep entries whose claim is
+			// still fresh; they self-resolve within capacityProbeOutcomeWindow.
+			if !now.Before(e.expiry) &&
+				(e.probeAt.IsZero() || !now.Before(e.probeAt.Add(capacityProbeOutcomeWindow))) {
 				delete(r.capacityCooldowns, key)
 				delete(r.capacityCooldownTrips, key)
 			}

--- a/coordinator/registry/capacity_cooldown.go
+++ b/coordinator/registry/capacity_cooldown.go
@@ -31,13 +31,20 @@ import (
 // trip the cooldown. Keyed per (provider, model) with a struct key (no
 // delimiter aliasing), mirroring error_cooldown.go.
 //
-// RE-PROBE + BACKOFF. A trip quarantines the pair for BaseTTL (default 120s).
-// After expiry routing re-probes it: a genuinely-full box that recovered gets
-// traffic back and its first accept clears ALL state (streak, cooldown, trip
-// count). A still-pathological pair re-arms on its FIRST post-expiry reject
-// (half-open, like provider_breaker.go) with an exponentially doubled TTL,
-// capped at MaxTTL (default 10 min) — so a persistent black hole costs one
-// bounced probe per cycle instead of Threshold-many.
+// RE-PROBE + BACKOFF — TRUE HALF-OPEN. A trip quarantines the pair for
+// BaseTTL (default 120s). After expiry EXACTLY ONE request passes as the
+// probe: the routing gate opens only while no probe claim is fresh, and
+// ReserveProviderEx claims the probe (claimCapacityProbeLocked, under the
+// r.mu write lock held for the whole reservation, so concurrent reservations
+// serialize) the moment it reserves the pair — every other request keeps
+// seeing the cooldown until the probe's outcome lands. Accept → all state
+// cleared, the pair is fully re-admitted (a genuinely-full box that recovered
+// gets traffic back). Reject → immediate re-arm with an exponentially doubled
+// TTL, capped at MaxTTL (default 10 min) — a persistent black hole costs ONE
+// bounced probe per cycle, with no thundering-herd leak in the post-expiry
+// window. If the probe's outcome never lands (the request died before any
+// terminal reached the breaker hooks), the claim goes stale after
+// capacityProbeOutcomeWindow and the next reservation may probe again.
 //
 // NOT bypassed by the selectBestCandidateLockedFull fail-open rescan
 // (consistent with the other pair-scoped cooldowns): if every pair for a model
@@ -66,6 +73,32 @@ const (
 	defaultCapacityCooldownTTL       = 120 * time.Second
 	defaultCapacityCooldownMaxTTL    = 10 * time.Minute
 )
+
+// capacityProbeOutcomeWindow is how long a claimed post-expiry probe keeps the
+// gate closed to everyone else while its outcome is pending. A reject outcome
+// lands within seconds (capacity rejects are immediate); an accept usually
+// does too, but on the accept-then-reload path first content can take much
+// longer, so this window is deliberately short — it is a LIVENESS bound, not
+// the accept deadline: if it lapses before the outcome lands, the next
+// reservation may claim a fresh probe (one extra probe per window during a
+// genuinely slow load — the box is accepting, so that is acceptable). Its real
+// job is that a probe request which DIED before any terminal reached the
+// breaker hooks can never wedge the pair closed forever.
+const capacityProbeOutcomeWindow = 30 * time.Second
+
+// capacityCooldownEntry is one pair's active (or expired-awaiting-probe)
+// cooldown. Fields are written ONLY under the r.mu write lock (arm/re-arm in
+// RecordCapacityReject, probe claim in claimCapacityProbeLocked); the routing
+// gate reads them under either lock mode.
+type capacityCooldownEntry struct {
+	// expiry is when the quarantine TTL lapses and the pair becomes eligible
+	// for a single half-open probe.
+	expiry time.Time
+	// probeAt is when a post-expiry probe was claimed (zero = unclaimed).
+	// While the claim is fresh (now < probeAt+capacityProbeOutcomeWindow) the
+	// gate stays closed to everyone but the claimed probe.
+	probeAt time.Time
+}
 
 // capacityCooldownConfig carries the env-tunable cooldown parameters.
 type capacityCooldownConfig struct {
@@ -142,8 +175,8 @@ func (r *Registry) RecordCapacityReject(providerID, modelID string) (tripped boo
 	// per-connection UUIDs that never get re-keyed — bound the maps by dropping
 	// expired/idle entries once they grow.
 	if len(r.capacityCooldowns) > 1024 {
-		for key, expiry := range r.capacityCooldowns {
-			if !now.Before(expiry) {
+		for key, e := range r.capacityCooldowns {
+			if !now.Before(e.expiry) {
 				delete(r.capacityCooldowns, key)
 				delete(r.capacityCooldownTrips, key)
 			}
@@ -171,7 +204,7 @@ func (r *Registry) RecordCapacityReject(providerID, modelID string) (tripped boo
 	r.capacityRejectStrikes[key] = kept
 
 	// Active cooldown: record only — never extend or re-arm (see doc above).
-	if expiry, ok := r.capacityCooldowns[key]; ok && now.Before(expiry) {
+	if e, ok := r.capacityCooldowns[key]; ok && now.Before(e.expiry) {
 		return false
 	}
 
@@ -183,9 +216,29 @@ func (r *Registry) RecordCapacityReject(providerID, modelID string) (tripped boo
 		return false
 	}
 
-	r.capacityCooldowns[key] = now.Add(capacityCooldownBackoff(cfg, trips))
+	// Arm/re-arm: fresh entry with an unclaimed probe slot for the NEXT expiry.
+	r.capacityCooldowns[key] = &capacityCooldownEntry{expiry: now.Add(capacityCooldownBackoff(cfg, trips))}
 	r.capacityCooldownTrips[key] = trips + 1
 	return true
+}
+
+// claimCapacityProbeLocked claims the single half-open probe for an EXPIRED
+// cooldown entry, called by ReserveProviderEx at reservation commit — the
+// moment a request is actually bound to the pair. Caller MUST hold the r.mu
+// WRITE lock (ReserveProviderEx does, for the whole selection+reservation), so
+// concurrent reservations serialize: the first to reserve the pair claims the
+// probe, and the gate (capacityCooldownActiveLocked) closes for everyone else
+// until the probe's outcome lands or the claim goes stale. A no-op for pairs
+// with no cooldown entry (the overwhelmingly common case — one map lookup) or
+// one still inside its TTL (unreachable via routing, but harmless).
+func (r *Registry) claimCapacityProbeLocked(providerID, modelID string, now time.Time) {
+	e, ok := r.capacityCooldowns[capacityRejectKey{ProviderID: providerID, ModelID: modelID}]
+	if !ok || now.Before(e.expiry) {
+		return
+	}
+	if e.probeAt.IsZero() || !now.Before(e.probeAt.Add(capacityProbeOutcomeWindow)) {
+		e.probeAt = now
+	}
 }
 
 // RecordCapacityAccept records that the (provider, model) pair ACCEPTED work —
@@ -228,13 +281,26 @@ func (r *Registry) CapacityCooldownActive(providerID, modelID string) bool {
 }
 
 // capacityCooldownActiveLocked reports whether routing should skip the pair.
-// READ-ONLY (no lazy delete) — some callers hold only r.mu.RLock. Caller holds
-// r.mu in either mode (mirrors inferenceErrorCooldownActiveLocked). Once now
-// reaches the expiry it returns false, letting the next request through as the
-// half-open re-probe.
+// READ-ONLY (no lazy delete, no claim) — some callers hold only r.mu.RLock.
+// Caller holds r.mu in either mode (mirrors inferenceErrorCooldownActiveLocked).
+//
+// Half-open semantics: inside the TTL the gate is closed. Once now reaches the
+// expiry it opens ONLY while no probe claim is fresh — the first reservation
+// through claims the probe (claimCapacityProbeLocked, write lock), which
+// closes the gate again for everyone else until the probe's outcome lands
+// (accept deletes the entry; reject re-arms it) or the claim goes stale after
+// capacityProbeOutcomeWindow (a lost probe must not wedge the pair).
 func (r *Registry) capacityCooldownActiveLocked(providerID, modelID string, now time.Time) bool {
-	expiry, ok := r.capacityCooldowns[capacityRejectKey{ProviderID: providerID, ModelID: modelID}]
-	return ok && now.Before(expiry)
+	e, ok := r.capacityCooldowns[capacityRejectKey{ProviderID: providerID, ModelID: modelID}]
+	if !ok {
+		return false
+	}
+	if now.Before(e.expiry) {
+		return true
+	}
+	// Expired: closed to everyone but the single claimed probe while its
+	// outcome is pending; open when unclaimed or the claim went stale.
+	return !e.probeAt.IsZero() && now.Before(e.probeAt.Add(capacityProbeOutcomeWindow))
 }
 
 // capacityCooldownBackoff returns the cooldown TTL for a pair that has already

--- a/coordinator/registry/capacity_cooldown_test.go
+++ b/coordinator/registry/capacity_cooldown_test.go
@@ -580,3 +580,44 @@ func TestCapacityCooldownPreflightVisionExcludesTextOnlyCooledPairs(t *testing.T
 		t.Fatalf("vision preflight capacityRejections = %d, want 0 (text-only cooled pair must not read as vision capacity)", capRejVis)
 	}
 }
+
+// Regression (PR #510 Codex round-2): the cooldown-only preflight recheck must
+// apply the SAME structural exclusions as the main path below it. A cooled
+// pair that is ALSO thermally critical is excluded outright; a cooled pair
+// whose model can never fit the hardware counts as modelTooLarge, never as
+// transient capacity (or undersized cooled boxes read as "busy, retry" for a
+// model that will never fit).
+func TestCapacityCooldownPreflightAppliesThermalAndFitFilters(t *testing.T) {
+	const model = "gemma-4-26b-8bit"
+
+	// Thermal-critical cooled pair: excluded from both counts.
+	r := New(testLogger())
+	p := makeSchedulerProvider(t, r, "hot-box", model, 200)
+	for i := 0; i < r.capacityCooldownCfg.Threshold; i++ {
+		r.RecordCapacityReject(p.ID, model)
+	}
+	p.mu.Lock()
+	p.SystemMetrics.ThermalState = "critical"
+	p.mu.Unlock()
+	cc, capRej, tooLarge := r.QuickCapacityCheck(model, 10, 128, RequestTraits{})
+	if cc != 0 || capRej != 0 || tooLarge != 0 {
+		t.Fatalf("thermal-critical cooled pair = (cand=%d, rej=%d, tooLarge=%d), want 0/0/0", cc, capRej, tooLarge)
+	}
+
+	// Undersized cooled pair (cold model, catalog says it can never fit):
+	// counts as modelTooLarge, not capacityRejections.
+	r2 := New(testLogger())
+	r2.SetModelCatalog([]CatalogEntry{{ID: model, SizeGB: 128}}) // needs far more than 24GB
+	small := makeSchedulerProvider(t, r2, "small-box", model, 200)
+	small.mu.Lock()
+	small.BackendCapacity.TotalMemoryGB = 24
+	small.BackendCapacity.Slots[0].State = "idle_shutdown" // cold: fit gate applies
+	small.mu.Unlock()
+	for i := 0; i < r2.capacityCooldownCfg.Threshold; i++ {
+		r2.RecordCapacityReject(small.ID, model)
+	}
+	cc2, capRej2, tooLarge2 := r2.QuickCapacityCheck(model, 10, 128, RequestTraits{})
+	if cc2 != 0 || capRej2 != 0 || tooLarge2 != 1 {
+		t.Fatalf("undersized cooled pair = (cand=%d, rej=%d, tooLarge=%d), want 0/0/1", cc2, capRej2, tooLarge2)
+	}
+}

--- a/coordinator/registry/capacity_cooldown_test.go
+++ b/coordinator/registry/capacity_cooldown_test.go
@@ -2,6 +2,7 @@ package registry
 
 import (
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 )
@@ -18,8 +19,29 @@ func capacityCooldownActiveAt(r *Registry, providerID, modelID string, now time.
 func capacityCooldownExpiryOf(r *Registry, providerID, modelID string) (time.Time, bool) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	expiry, ok := r.capacityCooldowns[capacityRejectKey{ProviderID: providerID, ModelID: modelID}]
-	return expiry, ok
+	e, ok := r.capacityCooldowns[capacityRejectKey{ProviderID: providerID, ModelID: modelID}]
+	if !ok {
+		return time.Time{}, false
+	}
+	return e.expiry, true
+}
+
+// claimCapacityProbe claims the pair's half-open probe as ReserveProviderEx
+// would at reservation commit (under the r.mu write lock).
+func claimCapacityProbe(r *Registry, providerID, modelID string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.claimCapacityProbeLocked(providerID, modelID, time.Now())
+}
+
+// ageCapacityProbeClaim rewinds the pair's probe claim by d, simulating a
+// probe whose outcome never landed (stale claim) without sleeping.
+func ageCapacityProbeClaim(r *Registry, providerID, modelID string, d time.Duration) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if e, ok := r.capacityCooldowns[capacityRejectKey{ProviderID: providerID, ModelID: modelID}]; ok && !e.probeAt.IsZero() {
+		e.probeAt = e.probeAt.Add(-d)
+	}
 }
 
 func capacityCooldownTripsOf(r *Registry, providerID, modelID string) int {
@@ -28,12 +50,16 @@ func capacityCooldownTripsOf(r *Registry, providerID, modelID string) int {
 	return r.capacityCooldownTrips[capacityRejectKey{ProviderID: providerID, ModelID: modelID}]
 }
 
-// expireCapacityCooldown rewinds the pair's cooldown expiry into the past,
-// simulating the TTL elapsing (active -> half-open re-probe) without sleeping.
+// expireCapacityCooldown rewinds the pair's cooldown expiry into the past
+// (and clears any probe claim), simulating the TTL elapsing (active ->
+// half-open, probe unclaimed) without sleeping.
 func expireCapacityCooldown(r *Registry, providerID, modelID string) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	r.capacityCooldowns[capacityRejectKey{ProviderID: providerID, ModelID: modelID}] = time.Now().Add(-time.Second)
+	if e, ok := r.capacityCooldowns[capacityRejectKey{ProviderID: providerID, ModelID: modelID}]; ok {
+		e.expiry = time.Now().Add(-time.Second)
+		e.probeAt = time.Time{}
+	}
 }
 
 // ageCapacityStrikes rewinds every recorded reject strike for the pair by d,
@@ -306,6 +332,124 @@ func TestCapacityCooldownConfigClamps(t *testing.T) {
 	}
 }
 
+// TRUE HALF-OPEN, claim lifecycle: after expiry the gate is open only while no
+// probe claim is fresh. A claim (as ReserveProviderEx makes at reservation
+// commit) closes it for everyone else; a stale claim (probe outcome never
+// landed) reopens it; a rejected probe re-arms with doubled TTL; an accepted
+// probe clears the pair entirely.
+func TestCapacityCooldownProbeClaimLifecycle(t *testing.T) {
+	r := New(nil)
+	const provider, model = "prov-probe", "gemma-4-26b-8bit"
+	cfg := r.capacityCooldownCfg
+
+	for i := 0; i < cfg.Threshold; i++ {
+		r.RecordCapacityReject(provider, model)
+	}
+	if !capacityCooldownActiveAt(r, provider, model, time.Now()) {
+		t.Fatal("setup: cooldown should be active")
+	}
+
+	// Expiry, unclaimed: gate open (a probe may be reserved).
+	expireCapacityCooldown(r, provider, model)
+	if capacityCooldownActiveAt(r, provider, model, time.Now()) {
+		t.Fatal("expired unclaimed cooldown still reads active")
+	}
+	// Claim the probe: gate closes for everyone else while the outcome pends.
+	claimCapacityProbe(r, provider, model)
+	if !capacityCooldownActiveAt(r, provider, model, time.Now()) {
+		t.Fatal("gate open to the herd while the probe outcome is pending")
+	}
+	// Probe outcome never lands: the claim goes stale after
+	// capacityProbeOutcomeWindow and the gate reopens for a fresh probe.
+	ageCapacityProbeClaim(r, provider, model, capacityProbeOutcomeWindow+time.Second)
+	if capacityCooldownActiveAt(r, provider, model, time.Now()) {
+		t.Fatal("stale probe claim wedged the pair closed")
+	}
+	// Fresh claim, probe REJECTED: immediate re-arm with doubled TTL, and the
+	// new entry's probe slot is unclaimed again.
+	claimCapacityProbe(r, provider, model)
+	if !r.RecordCapacityReject(provider, model) {
+		t.Fatal("rejected probe did not re-arm the cooldown")
+	}
+	expiry, _ := capacityCooldownExpiryOf(r, provider, model)
+	if got, want := time.Until(expiry), 2*cfg.BaseTTL; got > want || got < want-5*time.Second {
+		t.Fatalf("re-arm TTL ≈ %v, want doubled ≈ %v", got, want)
+	}
+	if !capacityCooldownActiveAt(r, provider, model, time.Now()) {
+		t.Fatal("re-armed cooldown not active")
+	}
+	// Next cycle: expire, claim, probe ACCEPTED: everything clears.
+	expireCapacityCooldown(r, provider, model)
+	claimCapacityProbe(r, provider, model)
+	r.RecordCapacityAccept(provider, model)
+	if capacityCooldownActiveAt(r, provider, model, time.Now()) {
+		t.Fatal("accepted probe did not clear the cooldown")
+	}
+	if trips := capacityCooldownTripsOf(r, provider, model); trips != 0 {
+		t.Fatalf("accepted probe did not reset the trip count: %d", trips)
+	}
+}
+
+// TRUE HALF-OPEN, concurrency: when a cooldown expires, EXACTLY ONE of N
+// concurrent reservations passes as the probe — the rest keep seeing the
+// cooldown (no thundering herd into a possibly-still-black-holed pair). The
+// claim rides ReserveProviderEx's r.mu write lock, so this drives the REAL
+// reservation path, not the gate helper in isolation.
+func TestCapacityCooldownHalfOpenExactlyOneProbe(t *testing.T) {
+	r := New(testLogger())
+	const model = "gemma-4-26b-8bit"
+	p := makeSchedulerProvider(t, r, "prov-halfopen", model, 100)
+
+	for i := 0; i < r.capacityCooldownCfg.Threshold; i++ {
+		r.RecordCapacityReject(p.ID, model)
+	}
+	expireCapacityCooldown(r, p.ID, model)
+
+	const n = 32
+	var wg sync.WaitGroup
+	got := make([]*Provider, n)
+	start := make(chan struct{})
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			prov, _ := r.ReserveProviderEx(model, &PendingRequest{
+				RequestID:             fmt.Sprintf("probe-%d", i),
+				Model:                 model,
+				EstimatedPromptTokens: 50,
+				RequestedMaxTokens:    32,
+			})
+			got[i] = prov
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	probes := 0
+	for _, prov := range got {
+		if prov != nil {
+			probes++
+		}
+	}
+	if probes != 1 {
+		t.Fatalf("%d of %d concurrent reservations passed the expired cooldown, want exactly 1 probe", probes, n)
+	}
+	// The claimed-probe window keeps the gate closed for any late arrival too.
+	if prov, _ := r.ReserveProviderEx(model, &PendingRequest{
+		RequestID: "late", Model: model, EstimatedPromptTokens: 50, RequestedMaxTokens: 32,
+	}); prov != nil {
+		t.Fatal("late reservation passed while the probe outcome was still pending")
+	}
+	// Probe REJECTED: re-arm; everyone (including a next fresh request) is out.
+	if !r.RecordCapacityReject(p.ID, model) {
+		t.Fatal("failed probe did not re-arm")
+	}
+	if !r.CapacityCooldownActive(p.ID, model) {
+		t.Fatal("cooldown not active after the failed probe")
+	}
+}
+
 // Map-bound sweep: expired cooldowns and idle strike lists are dropped once the
 // maps grow past the bound, so per-session UUID keys cannot leak forever.
 func TestCapacityCooldownMapsBounded(t *testing.T) {
@@ -318,7 +462,7 @@ func TestCapacityCooldownMapsBounded(t *testing.T) {
 	past := time.Now().Add(-time.Hour)
 	for i := 0; i < 1100; i++ {
 		key := capacityRejectKey{ProviderID: fmt.Sprintf("dead-%d", i), ModelID: model}
-		r.capacityCooldowns[key] = past
+		r.capacityCooldowns[key] = &capacityCooldownEntry{expiry: past}
 		r.capacityCooldownTrips[key] = 1
 		r.capacityRejectStrikes[key] = []time.Time{past.Add(-cfg.Window)}
 	}

--- a/coordinator/registry/capacity_cooldown_test.go
+++ b/coordinator/registry/capacity_cooldown_test.go
@@ -480,3 +480,103 @@ func TestCapacityCooldownMapsBounded(t *testing.T) {
 		t.Fatalf("stale strike lists not swept: %d entries remain", strikes)
 	}
 }
+
+// Regression (PR #510 Codex P2): the >1024 bound sweep must NOT delete a
+// half-open entry whose probe claim is still fresh. In that state expiry is
+// deliberately in the past and probeAt is the only thing holding the gate
+// closed while the single probe's outcome pends — sweeping it (triggered by a
+// reject on ANY other pair) reopened the gate to a thundering herd mid-probe
+// and dropped the pair's exponential-backoff state.
+func TestCapacityCooldownSweepPreservesFreshProbeClaims(t *testing.T) {
+	r := New(nil)
+	const provider, model = "prov-probed", "gemma-4-26b-8bit"
+	cfg := r.capacityCooldownCfg
+
+	// Trip the pair, expire the TTL, claim the half-open probe.
+	for i := 0; i < cfg.Threshold; i++ {
+		r.RecordCapacityReject(provider, model)
+	}
+	expireCapacityCooldown(r, provider, model)
+	claimCapacityProbe(r, provider, model)
+	if !capacityCooldownActiveAt(r, provider, model, time.Now()) {
+		t.Fatal("setup: pending probe should hold the gate closed")
+	}
+
+	// Grow the map past the sweep bound with long-expired junk entries.
+	r.mu.Lock()
+	for i := 0; i < 1100; i++ {
+		key := capacityRejectKey{ProviderID: fmt.Sprintf("junk-%d", i), ModelID: model}
+		r.capacityCooldowns[key] = &capacityCooldownEntry{expiry: time.Now().Add(-time.Hour)}
+		r.capacityCooldownTrips[key] = 1
+	}
+	r.mu.Unlock()
+
+	// A reject on an unrelated pair triggers the opportunistic sweep.
+	r.RecordCapacityReject("prov-other", model)
+
+	key := capacityRejectKey{ProviderID: provider, ModelID: model}
+	r.mu.RLock()
+	_, probedAlive := r.capacityCooldowns[key]
+	trips := r.capacityCooldownTrips[key]
+	size := len(r.capacityCooldowns)
+	r.mu.RUnlock()
+	if !probedAlive {
+		t.Fatal("sweep deleted the half-open entry with a fresh probe claim")
+	}
+	if trips == 0 {
+		t.Fatal("sweep dropped the pair's backoff state mid-probe")
+	}
+	if size > 8 {
+		t.Fatalf("junk entries not bounded by the sweep: %d remain", size)
+	}
+	if !capacityCooldownActiveAt(r, provider, model, time.Now()) {
+		t.Fatal("gate reopened to the herd mid-probe after the sweep")
+	}
+
+	// A STALE claim (outcome never landed) must still be sweepable — the
+	// liveness bound, not the claim itself, decides retention.
+	ageCapacityProbeClaim(r, provider, model, capacityProbeOutcomeWindow+time.Second)
+	r.mu.Lock()
+	for i := 0; i < 1100; i++ {
+		key := capacityRejectKey{ProviderID: fmt.Sprintf("junk2-%d", i), ModelID: model}
+		r.capacityCooldowns[key] = &capacityCooldownEntry{expiry: time.Now().Add(-time.Hour)}
+	}
+	r.mu.Unlock()
+	r.RecordCapacityReject("prov-other-2", model)
+	r.mu.RLock()
+	_, staleAlive := r.capacityCooldowns[key]
+	r.mu.RUnlock()
+	if staleAlive {
+		t.Fatal("sweep retained an entry whose probe claim went stale")
+	}
+}
+
+// Regression (PR #510 Codex P2): the preflight's cooldown-only recheck must
+// apply the same structural filters as the main candidate path — vision in
+// particular. A capacity-cooled TEXT-ONLY pair can never serve a vision
+// request; counting it as a capacityRejection surfaced a false "at capacity"
+// 429 (retry forever) where the vision/model-unavailable path is the truth.
+func TestCapacityCooldownPreflightVisionExcludesTextOnlyCooledPairs(t *testing.T) {
+	r := New(testLogger())
+	const model = "gemma-4-26b-8bit"
+	p := makeSchedulerProvider(t, r, "text-only", model, 200) // IsVision unset → text build
+
+	for i := 0; i < r.capacityCooldownCfg.Threshold; i++ {
+		r.RecordCapacityReject(p.ID, model)
+	}
+
+	// Text request: the cooled pair IS transient capacity (429 + Retry-After).
+	_, capRejText, _, _, _ := r.QuickCapacityCheckWithTTFTForRequest(model, 10, 128, RequestTraits{}, false)
+	if capRejText != 1 {
+		t.Fatalf("text preflight capacityRejections = %d, want 1 (cooled pair is transient capacity)", capRejText)
+	}
+
+	// Vision request: same cooled pair is structurally unservable → not counted.
+	cc, capRejVis, _, _, _ := r.QuickCapacityCheckWithTTFTForRequest(model, 10, 128, RequestTraits{}, true)
+	if cc != 0 {
+		t.Fatalf("vision preflight candidates = %d, want 0", cc)
+	}
+	if capRejVis != 0 {
+		t.Fatalf("vision preflight capacityRejections = %d, want 0 (text-only cooled pair must not read as vision capacity)", capRejVis)
+	}
+}

--- a/coordinator/registry/provider_breaker_test.go
+++ b/coordinator/registry/provider_breaker_test.go
@@ -154,8 +154,8 @@ func TestProviderPassesRoutingGatesBreakerBypass(t *testing.T) {
 	now := time.Now()
 	reg.mu.Lock()
 	p.mu.Lock()
-	honored := reg.providerPassesRoutingGatesLockedEx(p, model, RequestTraits{}, false, now, false)
-	bypassed := reg.providerPassesRoutingGatesLockedEx(p, model, RequestTraits{}, false, now, true)
+	honored := reg.providerPassesRoutingGatesLockedEx(p, model, RequestTraits{}, false, now, false, false)
+	bypassed := reg.providerPassesRoutingGatesLockedEx(p, model, RequestTraits{}, false, now, true, false)
 	p.mu.Unlock()
 	reg.mu.Unlock()
 	if honored {

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -1294,9 +1294,9 @@ type Registry struct {
 	// env-tunable (EIGENINFERENCE_CAPACITY_COOLDOWN_*), loaded at
 	// construction. Guarded by r.mu like the maps above.
 	capacityCooldownCfg   capacityCooldownConfig
-	capacityRejectStrikes map[capacityRejectKey][]time.Time // recent capacity-reject strikes per (provider, model)
-	capacityCooldowns     map[capacityRejectKey]time.Time   // cooldown expiry per (provider, model)
-	capacityCooldownTrips map[capacityRejectKey]int         // trip count per (provider, model) (exponential backoff)
+	capacityRejectStrikes map[capacityRejectKey][]time.Time            // recent capacity-reject strikes per (provider, model)
+	capacityCooldowns     map[capacityRejectKey]*capacityCooldownEntry // cooldown expiry + half-open probe claim per (provider, model)
+	capacityCooldownTrips map[capacityRejectKey]int                    // trip count per (provider, model) (exponential backoff)
 
 	// Stable-identity health ejection (health_ejection.go). Keyed by a STABLE
 	// identity (serial/SE-key/account), NOT the session UUID, and DELIBERATELY
@@ -1387,7 +1387,7 @@ func New(logger *slog.Logger) *Registry {
 		providerBreakerTrips:     make(map[string]int),
 		capacityCooldownCfg:      loadCapacityCooldownConfig(),
 		capacityRejectStrikes:    make(map[capacityRejectKey][]time.Time),
-		capacityCooldowns:        make(map[capacityRejectKey]time.Time),
+		capacityCooldowns:        make(map[capacityRejectKey]*capacityCooldownEntry),
 		capacityCooldownTrips:    make(map[capacityRejectKey]int),
 		healthEjectionWindows:    make(map[string]*providerHealthWindow),
 		healthEjectionUntil:      make(map[string]time.Time),

--- a/coordinator/registry/routing_gates_characterization_test.go
+++ b/coordinator/registry/routing_gates_characterization_test.go
@@ -49,9 +49,9 @@ func collectGateOutcomes(reg *Registry, p *Provider, model string, now time.Time
 
 	var out gateOutcomes
 	p.mu.Lock()
-	out.routingGates = reg.providerPassesRoutingGatesLockedEx(p, model, RequestTraits{}, false, now, false)
-	out.routingGatesSelf = reg.providerPassesRoutingGatesLockedEx(p, model, RequestTraits{}, true, now, false)
-	out.routingGatesBypass = reg.providerPassesRoutingGatesLockedEx(p, model, RequestTraits{}, false, now, true)
+	out.routingGates = reg.providerPassesRoutingGatesLockedEx(p, model, RequestTraits{}, false, now, false, false)
+	out.routingGatesSelf = reg.providerPassesRoutingGatesLockedEx(p, model, RequestTraits{}, true, now, false, false)
+	out.routingGatesBypass = reg.providerPassesRoutingGatesLockedEx(p, model, RequestTraits{}, false, now, true, false)
 	out.canRoutePublic = reg.providerCanRouteBuildLocked(p, model, reg.MinTrustLevel, now, false)
 	out.canRouteRelaxed = reg.providerCanRouteBuildLocked(p, model, TrustNone, now, true)
 	out.hasWarm = reg.providerHasWarmModelLocked(p, model, now)
@@ -332,7 +332,7 @@ func TestRoutingGateInferenceErrorCooldown(t *testing.T) {
 
 	reg.mu.RLock()
 	p.mu.Lock()
-	dispatch := reg.providerPassesRoutingGatesLockedEx(p, gateCharModel, traits, false, now, false)
+	dispatch := reg.providerPassesRoutingGatesLockedEx(p, gateCharModel, traits, false, now, false, false)
 	canRoute := reg.providerCanRouteBuildLocked(p, gateCharModel, reg.MinTrustLevel, now, false)
 	hasWarm := reg.providerHasWarmModelLocked(p, gateCharModel, now)
 	p.mu.Unlock()

--- a/coordinator/registry/scheduler.go
+++ b/coordinator/registry/scheduler.go
@@ -1884,14 +1884,37 @@ func (r *Registry) quickCapacityCheck(model string, estimatedPromptTokens, reque
 			// as "the model vanished". The ignoreCapacityCooldown re-check keeps
 			// a pair that ALSO fails a structural gate (offline, untrusted,
 			// render-broken, …) out of the count. Structural filters applied
-			// AFTER the gates on the main path must apply here too — vision in
-			// particular: a capacity-cooled text-only pair could never serve a
-			// vision request, so counting it would surface a false
-			// "at capacity" 429 where vision/model-unavailable is the truth.
+			// AFTER the gates on the main path must apply here too:
+			// thermal-critical and vision-blind pairs are excluded outright
+			// (same as the main path just below), and a pair whose model can
+			// never fit the hardware counts as modelTooLarge — never as
+			// transient capacity, or a fleet of undersized cooled boxes would
+			// read as "busy, retry" for a model that will never fit.
 			if r.capacityCooldownActiveLocked(p.ID, model, now) &&
 				r.providerPassesRoutingGatesLockedEx(p, model, traits, false, now, true, true) &&
+				p.SystemMetrics.ThermalState != "critical" &&
 				(!requiresVision || r.providerServesVisionModelLocked(p, model)) {
-				capacityRejections++
+				// Mirror the absolute hardware-fit gate (skipped for a
+				// resident model, which has demonstrably fit).
+				slotState := "unknown"
+				totalMemGB := float64(p.Hardware.MemoryGB)
+				if p.BackendCapacity != nil {
+					if p.BackendCapacity.TotalMemoryGB > 0 {
+						totalMemGB = p.BackendCapacity.TotalMemoryGB
+					}
+					for _, slot := range p.BackendCapacity.Slots {
+						if slot.Model == model {
+							slotState = slot.State
+							break
+						}
+					}
+				}
+				if !slotStateModelLoaded(slotState) &&
+					!modelFitsHardware(r.catalogMinRAMGbLocked(model), r.catalogSizeGBLocked(model), totalMemGB) {
+					modelTooLarge++
+				} else {
+					capacityRejections++
+				}
 			}
 			p.mu.Unlock()
 			continue

--- a/coordinator/registry/scheduler.go
+++ b/coordinator/registry/scheduler.go
@@ -1883,9 +1883,14 @@ func (r *Registry) quickCapacityCheck(model string, estimatedPromptTokens, reque
 			// "no providers" 503 — the cooldown must read as "busy fleet", never
 			// as "the model vanished". The ignoreCapacityCooldown re-check keeps
 			// a pair that ALSO fails a structural gate (offline, untrusted,
-			// render-broken, …) out of the count.
+			// render-broken, …) out of the count. Structural filters applied
+			// AFTER the gates on the main path must apply here too — vision in
+			// particular: a capacity-cooled text-only pair could never serve a
+			// vision request, so counting it would surface a false
+			// "at capacity" 429 where vision/model-unavailable is the truth.
 			if r.capacityCooldownActiveLocked(p.ID, model, now) &&
-				r.providerPassesRoutingGatesLockedEx(p, model, traits, false, now, true, true) {
+				r.providerPassesRoutingGatesLockedEx(p, model, traits, false, now, true, true) &&
+				(!requiresVision || r.providerServesVisionModelLocked(p, model)) {
 				capacityRejections++
 			}
 			p.mu.Unlock()

--- a/coordinator/registry/scheduler.go
+++ b/coordinator/registry/scheduler.go
@@ -351,6 +351,13 @@ func (r *Registry) ReserveProviderEx(model string, pr *PendingRequest, excludeID
 
 	pr.ProviderID = p.ID
 	p.addPendingLocked(pr)
+	// If this pair's capacity-reject cooldown just EXPIRED, this reservation is
+	// its single half-open probe: claim it here (r.mu write lock is held for the
+	// whole selection+reservation, so concurrent reservations serialize) so the
+	// routing gate closes for everyone else until the probe's outcome lands —
+	// no thundering herd into a possibly-still-black-holed pair. A no-op (one
+	// map lookup) for the overwhelmingly common no-cooldown case.
+	r.claimCapacityProbeLocked(p.ID, model, time.Now())
 	if p.Status != StatusUntrusted && p.Status != StatusOffline {
 		p.Status = StatusServing
 	}
@@ -548,6 +555,21 @@ func (r *Registry) scanCandidatesLocked(model string, pr *PendingRequest, ignore
 					if sid != "" && r.healthEjectionOpenLocked(sid, now) {
 						breakerRejected++
 					}
+				}
+			}
+			// A pair dropped ONLY by the capacity-reject cooldown is TRANSIENT
+			// capacity, not structural absence — count it as a capacityRejection
+			// (mirroring quickCapacityCheck) so an all-cooled model classifies as
+			// over_capacity (429/queue material) rather than no_provider. The
+			// ignoreCapacityCooldown re-run of the shared gate keeps a pair that
+			// ALSO fails a structural gate out of the count; both checks are
+			// cheap and only run on the already-rare drop path.
+			if r.capacityCooldownActiveLocked(p.ID, model, now) {
+				p.mu.Lock()
+				otherwiseRoutable := r.providerPassesRoutingGatesLockedEx(p, model, pr.Traits, relaxTrust, now, ignoreProviderBreaker, true)
+				p.mu.Unlock()
+				if otherwiseRoutable {
+					capacityRejections++
 				}
 			}
 			continue
@@ -883,18 +905,22 @@ func (r *Registry) logRoutingDecision(model string, pr *PendingRequest, winner *
 // caller's own (possibly un-enrolled) machine; every privacy-critical gate
 // still applies. Caller holds r.mu and p.mu.
 func (r *Registry) providerPassesRoutingGatesLocked(p *Provider, model string, traits RequestTraits, selfRouteOwner bool, now time.Time) bool {
-	return r.providerPassesRoutingGatesLockedEx(p, model, traits, selfRouteOwner, now, false)
+	return r.providerPassesRoutingGatesLockedEx(p, model, traits, selfRouteOwner, now, false, false)
 }
 
-// providerPassesRoutingGatesLockedEx is providerPassesRoutingGatesLocked with an
-// explicit ignoreProviderBreaker switch. When ignoreProviderBreaker is true it
-// skips ONLY the per-provider node-health breaker; every other gate
-// still applies. It exists solely for the selectBestCandidateLockedFull
-// fail-open fallback pass, so a fleet-wide fault rollout that trips the breaker
-// on every provider can never deroute the entire fleet. Every other caller goes
-// through the default wrapper above (breaker always honored). Caller holds r.mu
-// and p.mu.
-func (r *Registry) providerPassesRoutingGatesLockedEx(p *Provider, model string, traits RequestTraits, selfRouteOwner bool, now time.Time, ignoreProviderBreaker bool) bool {
+// providerPassesRoutingGatesLockedEx is providerPassesRoutingGatesLocked with
+// two explicit switches. ignoreProviderBreaker skips ONLY the per-provider
+// node-health breaker (and health ejection); it exists solely for the
+// selectBestCandidateLockedFull fail-open fallback pass, so a fleet-wide fault
+// rollout that trips the breaker on every provider can never deroute the
+// entire fleet. ignoreCapacityCooldown skips ONLY the capacity-reject cooldown;
+// it exists solely for the "would this pair otherwise pass?" re-check that
+// lets the candidate scan and the QuickCapacityCheck preflight count a
+// capacity-cooled pair as a TRANSIENT capacityRejection (429/queue material)
+// instead of structural absence (a "no providers" 503) — it must never be set
+// on an actual routing/admission decision. Every other caller goes through the
+// default wrapper above (both always honored). Caller holds r.mu and p.mu.
+func (r *Registry) providerPassesRoutingGatesLockedEx(p *Provider, model string, traits RequestTraits, selfRouteOwner bool, now time.Time, ignoreProviderBreaker, ignoreCapacityCooldown bool) bool {
 	// Catalog membership + dedicated-box isolation: a request for a dedicated
 	// model family (e.g. Gemma 4) may ONLY route to a provider whose ENTIRE
 	// advertised catalog is that family. This single gate is shared by the
@@ -927,7 +953,7 @@ func (r *Registry) providerPassesRoutingGatesLockedEx(p *Provider, model string,
 	// keep winning the cost scheduler. A busy box that is also SERVING never
 	// trips this (any accept resets the streak), and the pair is re-probed once
 	// its TTL expires. See capacity_cooldown.go.
-	if r.capacityCooldownActiveLocked(p.ID, model, now) {
+	if !ignoreCapacityCooldown && r.capacityCooldownActiveLocked(p.ID, model, now) {
 		return false
 	}
 	// Skip a provider quarantined by the per-provider node-health breaker: a
@@ -997,7 +1023,7 @@ func (r *Registry) snapshotProviderLockedEx(p *Provider, model string, traits Re
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
-	if !r.providerPassesRoutingGatesLockedEx(p, model, traits, selfRouteOwner, now, ignoreProviderBreaker) {
+	if !r.providerPassesRoutingGatesLockedEx(p, model, traits, selfRouteOwner, now, ignoreProviderBreaker, false) {
 		return routingSnapshot{}, false
 	}
 
@@ -1732,7 +1758,7 @@ func providerModelIDs(p *Provider) []string {
 // Caller holds r.mu and p.mu.
 func (r *Registry) providerCanAdmitLockedEx(p *Provider, model string, traits RequestTraits, selfRouteOwner bool, ignoreProviderBreaker bool) bool {
 	now := time.Now()
-	if !r.providerPassesRoutingGatesLockedEx(p, model, traits, selfRouteOwner, now, ignoreProviderBreaker) {
+	if !r.providerPassesRoutingGatesLockedEx(p, model, traits, selfRouteOwner, now, ignoreProviderBreaker, false) {
 		return false
 	}
 	// Apply the SAME quality-concurrency cap as the selection snapshot and the
@@ -1848,7 +1874,20 @@ func (r *Registry) quickCapacityCheck(model string, estimatedPromptTokens, reque
 		// re-introducing the very model-wide outage the valve exists to prevent.
 		// Every other gate (incl. the shape-keyed inference-error cooldown) is
 		// still honored; the breaker still steers SELECTION away from bad nodes.
-		if !r.providerPassesRoutingGatesLockedEx(p, model, traits, false, now, true) {
+		if !r.providerPassesRoutingGatesLockedEx(p, model, traits, false, now, true, false) {
+			// A pair blocked ONLY by the capacity-reject cooldown is TRANSIENT
+			// capacity, not structural absence: the box exists, serves the model,
+			// and will be re-probed when its TTL lapses. Count it as a
+			// capacityRejection so an all-cooled model surfaces to the consumer
+			// as capacity (429 + Retry-After / queue-before-shed) instead of a
+			// "no providers" 503 — the cooldown must read as "busy fleet", never
+			// as "the model vanished". The ignoreCapacityCooldown re-check keeps
+			// a pair that ALSO fails a structural gate (offline, untrusted,
+			// render-broken, …) out of the count.
+			if r.capacityCooldownActiveLocked(p.ID, model, now) &&
+				r.providerPassesRoutingGatesLockedEx(p, model, traits, false, now, true, true) {
+				capacityRejections++
+			}
 			p.mu.Unlock()
 			continue
 		}


### PR DESCRIPTION
Fast-follow for the four P2 review findings on #507 (capacity-reject cooldown). Coordinator-only; no protocol changes.

1. **Generic-path accept** (`api/consumer.go`): `/v1/completions` and `/v1/messages` now record the capacity-cooldown ACCEPT at first content (both pre-accept and post-accept commit branches), matching the chat path. A long generic stream on a busy box keeps vouching for the (provider, model) pair while it sheds concurrent dispatches — the shed storm can no longer read as the zero-accepts black-hole signature.
2. **True half-open re-probe** (`registry/capacity_cooldown.go`, `registry/scheduler.go`): cooldown entries are now `{expiry, probeAt}` structs. After expiry, exactly ONE reservation claims the probe (under the registry write lock); the gate stays closed for everyone else until the probe's outcome lands — accept clears, reject re-arms with doubled TTL. Stale claims expire after 30s so a lost probe can't wedge the pair. No thundering herd through the post-expiry window.
3. **Cold 404 "model not loaded" strikes** (`api/consumer.go`): 404 joins 429/5xx as strike-eligible, guarded by the zero-interleaved-accepts discriminator — the normal 404→load→serve lifecycle never trips (the accept resets); only a box that 404s forever with zero accepts does. Request-shape 404s ("model not found") never strike.
4. **All-cooled surfaces as capacity** (`registry/scheduler.go`): the candidate scan and `QuickCapacityCheck` preflight count a pair blocked only by the capacity cooldown as a TRANSIENT capacityRejection (via an `ignoreCapacityCooldown` re-check), so an all-cooled model returns **429 + Retry-After** (or queues) instead of a structural "no providers" **503**.

Tests: probe-claim lifecycle, 32-way concurrent single-probe reservation race, generic-path accept commit on both branches, 404 strike discriminator, all-cooled 429 surfacing. `go build ./... && go test ./registry/... ./api/...` green on top of v0.7.3 master.

## Before / After

```mermaid
flowchart TB
  subgraph Before
    A1[cooldown expires] --> B1[gate fully opens]
    B1 --> C1[ALL waiting dispatches rush the box]
    C1 --> D1[box still sick: mass rejects, cooldown re-arms after damage]
    E1[long stream on /v1/completions] --> F1[no ACCEPT recorded] --> G1[pair looks like zero-accepts black hole → false cooldown]
    H1[box 404s 'model not loaded' forever] --> I1[no strike → router keeps selecting it]
    J1[every provider for model cooled] --> K1[503 'no providers' → reads as downtime]
  end
  subgraph After
    A2[cooldown expires] --> B2[ONE reservation claims half-open probe under write lock]
    B2 --> C2{probe outcome}
    C2 -->|accept| D2[cooldown cleared, gate opens]
    C2 -->|reject| E2[re-arm with doubled TTL]
    C2 -->|lost >30s| F2[stale claim expires, next probe allowed]
    G2[long stream on generic paths] --> H2[ACCEPT at first content → pair keeps vouching]
    I2[404 not-loaded + zero interleaved accepts] --> J2[strike-eligible → cooldown]
    K2[every provider for model cooled] --> L2[transient capacityRejection → 429 + Retry-After / queue]
  end
```

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/510"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785708319&installation_id=133247490&pr_number=510&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F510&signature=62c5b58bf7e7b834b9855dba73ea73a9c1a135e5fdf7d9b9645dff6fc5c25162"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->