### PR TITLE
fix(billing): payout fast-follow — deferred review polish from #498

### DIFF
--- a/console-ui/src/components/payouts/StripePayoutsCard.tsx
+++ b/console-ui/src/components/payouts/StripePayoutsCard.tsx
@@ -137,6 +137,16 @@ export function StripePayoutsCard({
               Minimum withdrawal is ${minWithdrawUsd.toFixed(2)} — your balance is ${balanceUsd.toFixed(2)}.
             </p>
           )}
+          {onUnlink && (
+            <button
+              onClick={onUnlink}
+              disabled={unlinkLoading}
+              className="mt-3 block text-xs text-text-tertiary underline underline-offset-2 hover:text-coral disabled:opacity-50 transition-colors"
+              title="Detach this Stripe account (e.g. to change your payout country). Your balance is unaffected; you can set up payouts again afterwards."
+            >
+              {unlinkLoading ? "Unlinking..." : "Unlink Stripe account"}
+            </button>
+          )}
         </>
       ) : (
         <>

--- a/console-ui/src/components/payouts/payout-copy.test.ts
+++ b/console-ui/src/components/payouts/payout-copy.test.ts
@@ -137,12 +137,12 @@ describe("classifyOnboardError", () => {
 describe("withdrawSuccessMessage", () => {
   it("standard: daily payout in local currency with ETA", () => {
     expect(withdrawSuccessMessage({ status: TRANSFERRED, method: STANDARD, eta: STANDARD_ETA_TEXT }))
-      .toBe("On its way - Stripe pays out daily to your bank in your local currency (ETA 1-3 business days).");
+      .toBe("On its way - Stripe pays out to your bank in your local currency (ETA 1-3 business days).");
   });
 
   it("standard without an ETA omits the parenthetical", () => {
     expect(withdrawSuccessMessage({ status: TRANSFERRED, method: STANDARD }))
-      .toBe("On its way - Stripe pays out daily to your bank in your local currency.");
+      .toBe("On its way - Stripe pays out to your bank in your local currency.");
   });
 
   it("instant submitted: debit card with ETA", () => {
@@ -225,5 +225,25 @@ describe("Japan weekly payout copy", () => {
     expect(methodExplainer("standard", 150, 0.5, "US")).toContain("daily payout");
     // Instant copy is country-independent.
     expect(methodExplainer("instant", 150, 0.5, "JP")).toContain("debit card");
+  });
+});
+
+describe("schedule-aware standard success toast", () => {
+  it("prefers the coordinator's schedule-aware message (weekly in Japan)", () => {
+    expect(withdrawSuccessMessage({
+      status: "transferred",
+      method: "standard",
+      eta: "up to 7-10 business days",
+      message: "funds are on the way - Stripe pays out to your bank on a weekly schedule in Japan",
+    })).toBe("Funds are on the way - Stripe pays out to your bank on a weekly schedule in Japan (ETA up to 7-10 business days).");
+  });
+
+  it("uses the daily message verbatim when the coordinator sends it", () => {
+    expect(withdrawSuccessMessage({
+      status: "transferred",
+      method: "standard",
+      eta: "1-3 business days",
+      message: "funds are on the way - Stripe pays out to your bank on a daily schedule",
+    })).toBe("Funds are on the way - Stripe pays out to your bank on a daily schedule (ETA 1-3 business days).");
   });
 });

--- a/console-ui/src/components/payouts/payout-copy.ts
+++ b/console-ui/src/components/payouts/payout-copy.ts
@@ -159,7 +159,13 @@ export function withdrawSuccessMessage(resp: {
     }
     return resp.message || `On its way - funds will arrive via Stripe's standard daily payout${eta}.`;
   }
-  return `On its way - Stripe pays out daily to your bank in your local currency${eta}.`;
+  // Standard: the coordinator's message is schedule-aware (daily in most
+  // countries, weekly in Japan) - prefer it over a hard-coded cadence.
+  if (resp.message) {
+    const msg = resp.message.charAt(0).toUpperCase() + resp.message.slice(1);
+    return `${msg}${eta}.`;
+  }
+  return `On its way - Stripe pays out to your bank in your local currency${eta}.`;
 }
 
 // --- Withdraw modal method copy ---

--- a/coordinator/api/stripe_payouts.go
+++ b/coordinator/api/stripe_payouts.go
@@ -269,9 +269,17 @@ func (s *Server) handleStripeStatus(w http.ResponseWriter, r *http.Request) {
 			if perr := s.billing.Store().SetUserStripeAccount(user.AccountID, "", "", "", "", "", false); perr != nil {
 				s.logger.Error("stripe connect: unlink gone account failed", "error", perr)
 			} else {
+				// Clear EVERY account-derived field the response was
+				// pre-populated with — the store no longer holds any of
+				// them, and stale country/destination values would leak
+				// into the fresh-onboarding UI for one page load.
 				resp["has_account"] = false
 				resp["stripe_account_id"] = ""
 				resp["status"] = ""
+				resp["stripe_account_country"] = ""
+				resp["destination_type"] = ""
+				resp["destination_last4"] = ""
+				resp["instant_eligible"] = false
 			}
 		case err != nil:
 			s.logger.Warn("stripe connect: status refresh failed", "error", err)

--- a/coordinator/api/stripe_payouts_fixes_test.go
+++ b/coordinator/api/stripe_payouts_fixes_test.go
@@ -6,6 +6,8 @@ package api
 // transient-store-error handling, schedule-heal abort, and unlink auth.
 
 import (
+	"bytes"
+	"encoding/json"
 	"errors"
 	"log/slog"
 	"net/http"
@@ -1116,5 +1118,159 @@ func TestConnectWebhookStaleSweepPaidForFailedPayoutNoClaim(t *testing.T) {
 	wd, _ := st.GetStripeWithdrawal("wd-stale-sweep")
 	if wd.Status != "transferred" {
 		t.Errorf("status = %q, want transferred (live payout status is failed — nothing claimed)", wd.Status)
+	}
+}
+
+// --- Post-merge fast-follow (deferred round-12 review items) ---
+
+// TestStripeWithdrawInstantRejectedOnRecipientAccount: recipient-agreement
+// transfers take +24h to become available, so an instant payout created
+// right after the transfer can never draw on the funds — it would always
+// fail and fall back to the sweep with fee churn. Reject up front, before
+// any debit.
+func TestStripeWithdrawInstantRejectedOnRecipientAccount(t *testing.T) {
+	fakeStripe := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/v1/accounts/") && r.Method == http.MethodGet {
+			id := strings.TrimPrefix(r.URL.Path, "/v1/accounts/")
+			_, _ = w.Write([]byte(healthyAccountJSON(id, "AU", "recipient", true)))
+			return
+		}
+		t.Errorf("unexpected Stripe call: %s %s", r.Method, r.URL.Path)
+	}))
+	defer fakeStripe.Close()
+
+	srv, st := stripePayoutsTestServer(t, false, fakeStripe)
+	user := readyUser(t, st, "acct-rec-instant", "alice@example.com", true)
+	st.CreditWithdrawable(user.AccountID, 10_000_000, store.LedgerDeposit, "seed")
+
+	body := `{"amount_usd":"5.00","method":"instant"}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/billing/withdraw/stripe", strings.NewReader(body))
+	req = withPrivyUser(req, user)
+	w := httptest.NewRecorder()
+	srv.handleStripeWithdraw(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("got %d, want 400: %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "instant_unavailable") {
+		t.Errorf("body = %s, want instant_unavailable", w.Body.String())
+	}
+	if bal := st.GetBalance(user.AccountID); bal != 10_000_000 {
+		t.Errorf("balance = %d, want untouched", bal)
+	}
+	if wds, _ := st.ListStripeWithdrawals(user.AccountID, 0); len(wds) != 0 {
+		t.Errorf("no withdrawal row should exist, got %d", len(wds))
+	}
+}
+
+// TestStripeStatusRefreshGoneAccountClearsResponseFields: when refresh=1
+// discovers the account is gone and auto-unlinks, the response must not
+// carry the pre-unlink country/destination snapshot for one page load.
+func TestStripeStatusRefreshGoneAccountClearsResponseFields(t *testing.T) {
+	fakeStripe := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/v1/accounts/") && r.Method == http.MethodGet {
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"error":{"message":"No such account","code":"account_invalid"}}`))
+			return
+		}
+	}))
+	defer fakeStripe.Close()
+
+	srv, st := stripePayoutsTestServer(t, false, fakeStripe)
+	user := seedUser(t, st, "acct-gone-fields", "alice@example.com")
+	if err := st.SetUserStripeAccount(user.AccountID, "acct_gone_fields", "ready", "DE", "bank", "6789", true); err != nil {
+		t.Fatal(err)
+	}
+	user, _ = st.GetUserByAccountID(user.AccountID)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/billing/stripe/status?refresh=1", nil)
+	req = withPrivyUser(req, user)
+	w := httptest.NewRecorder()
+	srv.handleStripeStatus(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("got %d: %s", w.Code, w.Body.String())
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp["has_account"] != false {
+		t.Errorf("has_account = %v, want false", resp["has_account"])
+	}
+	for field, want := range map[string]any{
+		"stripe_account_id": "", "status": "", "stripe_account_country": "",
+		"destination_type": "", "destination_last4": "",
+	} {
+		if resp[field] != want {
+			t.Errorf("%s = %v, want %q (stale pre-unlink value must not leak)", field, resp[field], want)
+		}
+	}
+	if resp["instant_eligible"] != false {
+		t.Errorf("instant_eligible = %v, want false", resp["instant_eligible"])
+	}
+	// And the store itself is unlinked with no stale country.
+	refreshed, _ := st.GetUserByAccountID(user.AccountID)
+	if refreshed.StripeAccountID != "" || refreshed.StripeAccountCountry != "" {
+		t.Errorf("store = id %q country %q, want both empty", refreshed.StripeAccountID, refreshed.StripeAccountCountry)
+	}
+}
+
+// TestStripeReconcilerWeeklyScheduleInTransitNotWarned: JP accounts sweep
+// weekly, so rows past the 48h base threshold but inside the 10-day weekly
+// bound are normal transit — the reconciler must log them at info, not fire
+// the stuck-account warning (and must never try to heal a weekly schedule).
+func TestStripeReconcilerWeeklyScheduleInTransitNotWarned(t *testing.T) {
+	fakeStripe := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasPrefix(r.URL.Path, "/v1/accounts/") && r.Method == http.MethodGet:
+			acct := strings.Replace(healthyAccountJSON("acct_jp_weekly", "JP", "recipient", false),
+				`"interval":"daily"`, `"interval":"weekly"`, 1)
+			_, _ = w.Write([]byte(acct))
+		default:
+			t.Errorf("unexpected Stripe call (weekly schedule must not be healed): %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer fakeStripe.Close()
+
+	var logBuf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	st := store.NewMemory(store.Config{AdminKey: "test-key"})
+	srv := NewServer(registry.New(logger), st, ServerConfig{}, logger)
+	t.Cleanup(setStripeAPIBase(fakeStripe.URL))
+	srv.SetBilling(billing.NewService(st, payments.NewLedger(st), logger, billing.Config{
+		StripeSecretKey:              "sk_test_fake",
+		StripeConnectWebhookSecret:   "whsec_test",
+		StripeConnectPlatformCountry: "US",
+	}))
+
+	user := readyUser(t, st, "acct-jp-user", "jp@example.com", false)
+	// 4 days old: past the 48h base threshold, inside the 10-day weekly bound.
+	_ = st.CreateStripeWithdrawal(&store.StripeWithdrawal{
+		ID: "wd-jp-transit", AccountID: user.AccountID, StripeAccountID: "acct_jp_weekly",
+		TransferID: "tr_jp_1", AmountMicroUSD: 5_000_000, NetMicroUSD: 5_000_000,
+		Method: "standard", Status: "transferred", CreatedAt: time.Now().Add(-4 * 24 * time.Hour),
+	})
+
+	srv.sweepStuckStripeWithdrawals()
+
+	logs := logBuf.String()
+	if strings.Contains(logs, "stuck withdrawals on auto-schedule account") {
+		t.Errorf("weekly in-transit rows fired the stuck warning:\n%s", logs)
+	}
+	if !strings.Contains(logs, "normal weekly-payout transit") {
+		t.Errorf("expected the weekly-transit info log, got:\n%s", logs)
+	}
+
+	// A row past the weekly bound DOES warn.
+	_ = st.CreateStripeWithdrawal(&store.StripeWithdrawal{
+		ID: "wd-jp-stuck", AccountID: user.AccountID, StripeAccountID: "acct_jp_weekly",
+		TransferID: "tr_jp_2", AmountMicroUSD: 5_000_000, NetMicroUSD: 5_000_000,
+		Method: "standard", Status: "transferred", CreatedAt: time.Now().Add(-12 * 24 * time.Hour),
+	})
+	logBuf.Reset()
+	srv.sweepStuckStripeWithdrawals()
+	if !strings.Contains(logBuf.String(), "stuck withdrawals on auto-schedule account") {
+		t.Errorf("row past the weekly bound must warn, got:\n%s", logBuf.String())
 	}
 }

--- a/coordinator/api/stripe_reconcile.go
+++ b/coordinator/api/stripe_reconcile.go
@@ -17,6 +17,13 @@ const (
 	// bank rail. 48h covers all of that with margin.
 	stripeStuckThreshold = 48 * time.Hour
 
+	// stripeStuckThresholdWeekly is the equivalent bound for accounts on a
+	// weekly automatic payout schedule (Japan — Stripe offers no daily
+	// there): up to 7 days to the sweep, +24h availability, plus the bank
+	// rail. Rows younger than this on a weekly account are in normal
+	// transit, not stuck.
+	stripeStuckThresholdWeekly = 10 * 24 * time.Hour
+
 	// stripeReconcileBatch bounds how many stuck rows one sweep inspects.
 	stripeReconcileBatch = 200
 )
@@ -88,39 +95,63 @@ func (s *Server) sweepStuckStripeWithdrawals() {
 	}
 
 	// Group by connected account — one Stripe lookup (and at most one
-	// schedule heal) per account, not per withdrawal.
-	byAcct := map[string]int{}
-	for _, wd := range stuck {
-		byAcct[wd.StripeAccountID]++
+	// schedule heal) per account, not per withdrawal. Track the oldest row
+	// per account so weekly-schedule accounts can be judged against their
+	// own (longer) threshold.
+	type acctStuck struct {
+		count  int
+		oldest time.Time
 	}
-	s.logger.Warn("stripe reconciler: withdrawals stuck in transferred",
+	byAcct := map[string]*acctStuck{}
+	for _, wd := range stuck {
+		st, ok := byAcct[wd.StripeAccountID]
+		if !ok {
+			st = &acctStuck{oldest: wd.CreatedAt}
+			byAcct[wd.StripeAccountID] = st
+		}
+		st.count++
+		if wd.CreatedAt.Before(st.oldest) {
+			st.oldest = wd.CreatedAt
+		}
+	}
+	s.logger.Info("stripe reconciler: withdrawals in transferred past base threshold",
 		"withdrawals", len(stuck), "accounts", len(byAcct), "stuck_threshold", stripeStuckThreshold.String())
 
-	for acctID, count := range byAcct {
+	for acctID, st := range byAcct {
 		if acctID == "" {
 			continue
 		}
 		acct, err := s.billing.StripeConnect().GetAccount(acctID)
 		if err != nil {
 			s.logger.Warn("stripe reconciler: account fetch failed",
-				"stripe_account_id", acctID, "stuck_withdrawals", count, "error", err)
+				"stripe_account_id", acctID, "stuck_withdrawals", st.count, "error", err)
 			continue
 		}
 		if acct.PayoutInterval == "manual" {
 			if err := s.billing.StripeConnect().UpdateAccountPayoutScheduleAuto(acctID, acct.Country); err != nil {
 				s.logger.Error("stripe reconciler: payout schedule heal failed",
-					"stripe_account_id", acctID, "stuck_withdrawals", count, "error", err)
+					"stripe_account_id", acctID, "stuck_withdrawals", st.count, "error", err)
 				continue
 			}
 			s.logger.Info("stripe reconciler: healed manual payout schedule to automatic",
-				"stripe_account_id", acctID, "stuck_withdrawals", count)
+				"stripe_account_id", acctID, "stuck_withdrawals", st.count)
+			continue
+		}
+		// Weekly-schedule accounts (JP) legitimately hold rows in
+		// "transferred" far longer than the base threshold — only alert
+		// once the oldest row exceeds the weekly bound.
+		if acct.PayoutInterval == "weekly" &&
+			time.Since(st.oldest) < stripeStuckThresholdWeekly {
+			s.logger.Info("stripe reconciler: withdrawals in normal weekly-payout transit",
+				"stripe_account_id", acctID, "withdrawals", st.count,
+				"oldest_created_at", st.oldest, "weekly_threshold", stripeStuckThresholdWeekly.String())
 			continue
 		}
 		// Schedule is already automatic — the sweep should be moving these.
 		// Loud log for ops: likely payouts_enabled=false (user needs to fix
 		// bank details) or a failed sweep that keeps retrying.
 		s.logger.Warn("stripe reconciler: stuck withdrawals on auto-schedule account",
-			"stripe_account_id", acctID, "stuck_withdrawals", count,
+			"stripe_account_id", acctID, "stuck_withdrawals", st.count,
 			"payouts_enabled", acct.PayoutsEnabled,
 			"disabled_reason", acct.DisabledReason,
 			"payout_interval", acct.PayoutInterval)

--- a/coordinator/api/stripe_withdraw.go
+++ b/coordinator/api/stripe_withdraw.go
@@ -145,6 +145,17 @@ func (s *Server) handleStripeWithdraw(w http.ResponseWriter, r *http.Request) {
 			"instant payouts require a debit card destination — link one in Stripe to enable"))
 		return
 	}
+	// Recipient-agreement transfers take +24h to become available in the
+	// connected balance, so an instant payout created right after the
+	// transfer can never draw on these funds — it would always fail and
+	// fall back to the sweep (with the fee refunded). Reject up front
+	// instead of charging a fee for a delivery speed we can't provide.
+	if method == "instant" &&
+		billing.NormalizeServiceAgreement(acct.ServiceAgreement) == billing.ServiceAgreementRecipient {
+		writeJSON(w, http.StatusBadRequest, errorResponse("instant_unavailable",
+			"instant payouts aren't available for accounts in your country — standard delivery arrives via the automatic payout"))
+		return
+	}
 
 	amountFloat, err := strconv.ParseFloat(req.AmountUSD, 64)
 	if err != nil || amountFloat <= 0 {


### PR DESCRIPTION
The five items deferred (on record, in-thread) from PR #498's final review round. None are money-correctness — each sits on behavior that already degraded gracefully — but together they remove fee churn, ops-alert noise, and stale/incorrect UI copy.

## Behavior: before → after

```mermaid
flowchart TB
  subgraph Before
    A1[JP user withdraws standard] --> B1["toast: 'pays out daily' (wrong)<br/>reconciler warns hourly while<br/>funds are in normal weekly transit"]
    C1[recipient acct + debit card, instant] --> D1[debit -> transfer -> payouts.create FAILS<br/>fee refunded, sweep delivers<br/>= guaranteed fee churn]
    E1["status?refresh=1 finds account gone"] --> F1[auto-unlink, but response keeps stale<br/>country/destination for one page load]
    G1[ready acct, wrong country] --> H1[no self-serve unlink - support ticket]
  end
```

```mermaid
flowchart TB
  subgraph After
    A2[JP user withdraws standard] --> B2["toast uses coordinator's schedule-aware<br/>message + weekly ETA; reconciler logs<br/>'normal weekly transit' until 10d bound"]
    C2[recipient acct + debit card, instant] --> D2["400 instant_unavailable up front<br/>(no debit, no fee, honest copy)"]
    E2["status?refresh=1 finds account gone"] --> F2[response clears ALL account-derived fields<br/>UI lands directly on fresh onboarding]
    G2[ready acct, wrong country] --> H2['Unlink Stripe account' action on the card]
  end
```

## Code: before → after

```mermaid
flowchart LR
  subgraph Before
    a1[stripe_withdraw.go<br/>instant gate: debit-card only] --> b1[stripe_reconcile.go<br/>single 48h threshold]
    c1[stripe_payouts.go refresh<br/>clears id/status only] --> d1[payout-copy.ts<br/>hard-coded 'daily' toast<br/>StripePayoutsCard: unlink only when non-ready]
  end
  subgraph After
    a2[stripe_withdraw.go<br/>+ recipient-agreement instant pre-gate] --> b2[stripe_reconcile.go<br/>+ stripeStuckThresholdWeekly 10d,<br/>oldest-row tracking per account]
    c2[stripe_payouts.go refresh<br/>clears country/destination/instant too] --> d2[payout-copy.ts<br/>prefers resp.message/eta<br/>StripePayoutsCard: unlink in ready branch]
  end
```

## Tests
- `TestStripeWithdrawInstantRejectedOnRecipientAccount` (400 before any debit)
- `TestStripeStatusRefreshGoneAccountClearsResponseFields` (response + store both clean)
- `TestStripeReconcilerWeeklyScheduleInTransitNotWarned` (info inside 10d, warn past it, weekly never "healed")
- JP/daily toast pins in payout-copy.test.ts
- Full coordinator suite + UI lint/vitest green.

Refs: deferred threads on #498 (comments 3525813193, 3525813196, 3525813199, 3525813204, 3525813209).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/519"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785886931&installation_id=133247490&pr_number=519&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F519&signature=44c54b037596a0834cc5a7127f33a149673e041c2ad5789308ed7785e7cd3c75"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->